### PR TITLE
Add Replicate delegated-run provider

### DIFF
--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -61,7 +61,7 @@ selection metadata. Regenerate it with `node scripts/generate-provider-matrix.mj
 `scripts/check-docs.sh` fails when provider registration, metadata, docs paths, or
 this generated table drift.
 
-Current built-in surface: 67 providers (39 SSH lease, 26 delegated run, 2 service control).
+Current built-in surface: 68 providers (39 SSH lease, 27 delegated run, 2 service control).
 
 Access terms:
 
@@ -122,6 +122,7 @@ Access terms:
 | [phala](phala.md) (`phala-cloud`, `dstack`) | built-in; `ssh-lease` · direct-cloud | Crabbox-managed SSH; `crabbox-sync` · direct only; features: `ssh`, `crabbox-sync`, `cleanup` | `linux`; Phala Cloud confidential Intel TDX CVM | `provider-managed`; GPU: no | Phala phala CLI; CVM delete | Short-lived confidential Linux compute over SSH | Requires the phala CLI and its stored auth; verifies Intel TDX attestation by default (needs outbound Intel PCS network; --phala-skip-attestation to opt out) |
 | [proxmox](proxmox.md) | built-in; `ssh-lease` · self-hosted-virtualization | Crabbox-managed SSH; `crabbox-sync` · direct only; features: `ssh`, `crabbox-sync`, `cleanup` | `linux`; Proxmox VE QEMU clone | `self-hosted`; GPU: optional | Crabbox; VM delete | Self-hosted Linux VM fleet | Needs a prepared template, guest agent, and network |
 | [railway](railway.md) (`rail`, `railwayapp`) | specialized; `service-control` · service-control | SSH not applicable; `none` · direct only; features: `url-bridge` | `linux`; Railway service | `cloud`; GPU: unknown | Railway; service stop only | Inspecting or stopping an existing Railway service | Cannot execute arbitrary Crabbox run commands |
+| [replicate](replicate.md) | built-in; `delegated-run` · delegated-sandbox | No SSH; `archive-sync` · direct only; features: `archive-sync`, `run-session` | `linux`; Replicate prediction runner | `cloud`; GPU: optional | Replicate prediction; prediction cancellation | Small archived command runs on a compatible Replicate runner | Backend lifecycle is deferred in this branch; no SSH or coordinator path |
 | [runpod](runpod.md) (`run-pod`, `runpodio`) | built-in; `ssh-lease` · gpu-cloud | Crabbox-managed SSH; `crabbox-sync` · direct only; features: `ssh`, `crabbox-sync` | `linux`; RunPod GPU pod | `cloud`; GPU: yes | RunPod; pod release | GPU-backed Linux workload over public SSH | Capacity, GPU pricing, and public SSH vary |
 | [scaleway](scaleway.md) | built-in; `ssh-lease` · direct-cloud | Crabbox-managed SSH; `crabbox-sync` · direct only; features: `ssh`, `crabbox-sync`, `cleanup`, `tailscale` | `linux`; Scaleway Instance | `cloud`; GPU: optional | Crabbox; instance and managed key delete | Direct Linux VM on Scaleway Instances | Direct-only; security groups must already allow SSH |
 | [semaphore](semaphore.md) (`sem`) | built-in; `ssh-lease` · ci-proof-runner | Crabbox-managed SSH; `crabbox-sync` · direct only; features: `ssh`, `crabbox-sync` | `linux`; Semaphore CI job | `provider-managed`; GPU: optional | Semaphore; job stop | Debugging in the same image and secret plane as CI | Depends on debug SSH metadata from the job |

--- a/docs/providers/provider-metadata.json
+++ b/docs/providers/provider-metadata.json
@@ -657,6 +657,20 @@
     "caveat": "REST execution contract, not an SSH lease",
     "docs": "opencomputer.md"
   },
+  "replicate": {
+    "status": "built-in",
+    "category": "delegated-sandbox",
+    "substrate": "Replicate prediction runner",
+    "location": "cloud",
+    "ssh": "no",
+    "sync": "archive-sync",
+    "gpu": "optional",
+    "lifecycle": "Replicate prediction",
+    "cleanup": "prediction cancellation",
+    "bestFit": "Small archived command runs on a compatible Replicate runner",
+    "caveat": "Backend lifecycle is deferred in this branch; no SSH or coordinator path",
+    "docs": "replicate.md"
+  },
   "opensandbox": {
     "status": "built-in",
     "category": "delegated-sandbox",

--- a/docs/providers/replicate.md
+++ b/docs/providers/replicate.md
@@ -64,9 +64,11 @@ screenshots.
 
 ## Config
 
-Choose exactly one runner target: `replicate.deployment` or
-`replicate.version`. Setting both is rejected; setting neither is rejected when
-`provider: replicate` is selected.
+Choose exactly one runner target for `run`, `warmup`, and `doctor`:
+`replicate.deployment` or `replicate.version`. Setting both is rejected;
+setting neither is rejected for commands that create or validate a runner
+target. Existing-prediction commands such as `status`, `list`, and `stop` only
+require the API URL, API token, and prediction or claim identifier.
 
 ```yaml
 provider: replicate

--- a/docs/providers/replicate.md
+++ b/docs/providers/replicate.md
@@ -1,0 +1,210 @@
+# Replicate Provider
+
+Read this when:
+
+- choosing `provider: replicate`;
+- configuring the Replicate deployment or model version, workdir, polling, or
+  archive limit;
+- changing `internal/providers/replicate`.
+
+Replicate is a delegated-run provider for Linux command execution on a
+compatible Replicate runner deployment or model version. Crabbox does not
+provision an SSH machine, does not use the coordinator broker, and does not
+run rsync. Instead, Crabbox prepares a small workspace archive, sends it to the
+Replicate prediction as an input, and expects the runner to execute the
+requested command inside the configured workdir.
+
+Current implementation status: this branch registers the provider, config,
+flags, provider metadata, and runner input/output contract. The runtime
+lifecycle backend is still deferred to the Replicate delegated-backend plan.
+Until that backend lands, `run`, `warmup`, `list`, `status`, and `stop` return
+`provider=replicate backend lifecycle is not implemented in this build`.
+`doctor` reports the same not-implemented state without making a live API call.
+
+## When To Use
+
+Use Replicate when you have built or selected a Replicate runner that accepts
+Crabbox's runner input schema and can run Linux commands in its prediction
+environment. It fits small proof runs where the provider owns command
+execution and the workspace can be represented as a bounded data URL archive.
+
+Use an SSH-lease provider such as AWS, Hetzner, Azure, Google Cloud, Static
+SSH, or Local Container when you need `crabbox ssh`, VNC, code-server, normal
+rsync, long-running warm boxes, Actions hydration, or desktop/browser/code
+capability flags.
+
+Replicate is Linux-only in Crabbox. SSH, desktop, browser, code-server,
+Tailscale, coordinator routing, and Crabbox-managed VM lifecycle are not part
+of the provider contract.
+
+## Auth
+
+Keep the Replicate API token in the environment. Crabbox intentionally has no
+`--replicate-api-token` flag and no YAML token field.
+
+```sh
+export CRABBOX_REPLICATE_API_TOKEN="$(python3 -c 'import getpass; print(getpass.getpass("Replicate API token: "))')"
+```
+
+Token precedence:
+
+1. `CRABBOX_REPLICATE_API_TOKEN`
+2. `REPLICATE_API_TOKEN`
+
+The token is sent only as Replicate API authentication by the provider client
+once lifecycle support lands. Do not place it in `crabbox.yaml`, shell
+history, issue bodies, PR descriptions, logs, or screenshots.
+
+## Config
+
+Choose exactly one runner target: `replicate.deployment` or
+`replicate.version`. Setting both is rejected; setting neither is rejected when
+`provider: replicate` is selected.
+
+```yaml
+provider: replicate
+target: linux
+replicate:
+  deployment: example-org/crabbox-runner
+  # version: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+  workdir: /workspace/crabbox
+  waitSecs: 0
+  pollIntervalSecs: 2
+  execTimeoutSecs: 3600
+  cancelAfterSecs: 0
+  maxArchiveBytes: 10485760
+```
+
+Defaults:
+
+- `apiURL`: `https://api.replicate.com/v1`
+- `workdir`: `/workspace/crabbox`
+- `waitSecs`: `0` (provider default wait behavior)
+- `pollIntervalSecs`: `2`
+- `execTimeoutSecs`: `3600`
+- `cancelAfterSecs`: `0` (disabled)
+- `maxArchiveBytes`: `10485760` (10 MiB)
+
+Provider flags, each overriding the matching config key:
+
+```text
+--replicate-api-url
+--replicate-deployment
+--replicate-version
+--replicate-workdir
+--replicate-wait-secs
+--replicate-poll-interval-secs
+--replicate-exec-timeout-secs
+--replicate-cancel-after-secs
+--replicate-max-archive-bytes
+```
+
+Environment overrides:
+
+```text
+CRABBOX_REPLICATE_API_URL
+REPLICATE_API_URL
+CRABBOX_REPLICATE_DEPLOYMENT
+CRABBOX_REPLICATE_VERSION
+CRABBOX_REPLICATE_WORKDIR
+CRABBOX_REPLICATE_WAIT_SECS
+CRABBOX_REPLICATE_POLL_INTERVAL_SECS
+CRABBOX_REPLICATE_EXEC_TIMEOUT_SECS
+CRABBOX_REPLICATE_CANCEL_AFTER_SECS
+CRABBOX_REPLICATE_MAX_ARCHIVE_BYTES
+```
+
+`--class` and `--type` are rejected for `provider=replicate`; Replicate
+capacity and hardware selection belong to the selected deployment or model
+version rather than Crabbox's VM class map.
+
+## Runner Contract
+
+The runner input is JSON-shaped and includes the command, working directory,
+optional archive data URL, forwarded environment, timeout settings, metadata,
+and output schema hint. The runner must extract the archive into the configured
+workdir when one is present, run the command there, and return JSON output.
+
+Command success is based on the runner output's command exit code, not merely
+on Replicate reporting the prediction as `succeeded`. The output must include
+an integer `exit_code` field. `exitCode` is accepted as a compatibility alias.
+
+Expected output shape:
+
+```json
+{
+  "exit_code": 0,
+  "stdout": "test output\n",
+  "stderr": ""
+}
+```
+
+If the prediction succeeds but the runner omits `exit_code`, or returns it as a
+string or float, Crabbox treats that as a runner contract failure.
+
+## Commands
+
+The CLI discovery surface is available as soon as the provider is registered:
+
+```sh
+crabbox providers --json
+crabbox doctor --provider replicate --json
+```
+
+Lifecycle commands below are the intended provider contract, but remain
+deferred until the backend implementation lands:
+
+```sh
+crabbox run --provider replicate -- pnpm test
+crabbox run --provider replicate --id prediction-id -- pnpm test:changed
+crabbox status --provider replicate --id prediction-id --json
+crabbox list --provider replicate --json
+crabbox stop --provider replicate prediction-id
+```
+
+Use the Replicate prediction ID or a local Crabbox claim/slug that resolves to
+one when targeting an existing run.
+
+## Capabilities
+
+- SSH: no.
+- Crabbox sync: delegated archive sync through a small data URL archive.
+- Provider sync: no separate provider-native source checkout is assumed.
+- Desktop / browser / code / VNC: no.
+- Actions hydration: no.
+- Coordinator broker: no, Replicate runs direct from the CLI.
+- Run sessions: advertised by the provider spec; runtime lifecycle is deferred
+  in the current branch until the backend plan lands.
+
+## Archive Limits
+
+Replicate v1 support is intentionally bounded to small data URL archives. The
+default `replicate.maxArchiveBytes` is 10 MiB. Oversized workspaces should fail
+before a prediction is created, so a local size mistake does not unexpectedly
+consume provider billing.
+
+Large-workspace upload through object storage or another staged data plane is a
+future extension and is not documented as available here.
+
+## Live Smoke
+
+Normal verification must not create live Replicate predictions or consume
+billing. A live smoke should only run when all of these are true:
+
+- a Replicate token is exported through `CRABBOX_REPLICATE_API_TOKEN` or
+  `REPLICATE_API_TOKEN`;
+- exactly one deployment or version is configured;
+- the runner is known to implement Crabbox's JSON input/output contract;
+- an explicit arming variable such as `CRABBOX_REPLICATE_LIVE_SMOKE=1` is set.
+
+Until a guarded `scripts/live-replicate-smoke.sh` exists, classify live proof as
+deferred rather than substituting docs checks for real provider behavior. Any
+future smoke must report one of: success, `skipped`, `environment_blocked`,
+`quota_blocked`, `validation_failed`, `cleanup_failed`, or `diagnostic_only`.
+If it creates a prediction, it must preserve the prediction ID long enough to
+attempt `crabbox stop --provider replicate` cleanup and report the result.
+
+Related docs:
+
+- [Provider backends](../provider-backends.md)
+- [Provider live smoke](../features/provider-live-smoke.md)

--- a/docs/providers/replicate.md
+++ b/docs/providers/replicate.md
@@ -14,12 +14,15 @@ run rsync. Instead, Crabbox prepares a small workspace archive, sends it to the
 Replicate prediction as an input, and expects the runner to execute the
 requested command inside the configured workdir.
 
-Current implementation status: this branch registers the provider, config,
-flags, provider metadata, and runner input/output contract. The runtime
-lifecycle backend is still deferred to the Replicate delegated-backend plan.
-Until that backend lands, `run`, `warmup`, `list`, `status`, and `stop` return
-`provider=replicate backend lifecycle is not implemented in this build`.
-`doctor` reports the same not-implemented state without making a live API call.
+Current implementation status: the provider has a delegated-run lifecycle
+backend. `warmup` and `doctor` validate local configuration and API token
+presence without creating a prediction or consuming billing. `run` creates a
+new prediction, sends the archive-backed runner input, polls until the
+prediction reaches a terminal state, maps the runner's command exit code, and
+stores a local claim for later lookup. `status` and `stop` operate on a
+prediction ID, local Crabbox claim, or local claim slug. `list` shows local
+Replicate claims for the configured API endpoint; it is not an account-wide
+Replicate prediction inventory.
 
 ## When To Use
 
@@ -51,9 +54,13 @@ Token precedence:
 1. `CRABBOX_REPLICATE_API_TOKEN`
 2. `REPLICATE_API_TOKEN`
 
-The token is sent only as Replicate API authentication by the provider client
-once lifecycle support lands. Do not place it in `crabbox.yaml`, shell
-history, issue bodies, PR descriptions, logs, or screenshots.
+The token is sent only as Replicate API authentication by the provider client.
+Crabbox strips `CRABBOX_REPLICATE_API_TOKEN` and `REPLICATE_API_TOKEN` from the
+runner environment even if they are selected by `CRABBOX_ENV_ALLOW`,
+`--allow-env`, or a forwarding profile. If the runner command needs secrets,
+use separate non-provider-auth variable names. Do not place the Replicate token
+in `crabbox.yaml`, shell history, issue bodies, PR descriptions, logs, or
+screenshots.
 
 ## Config
 
@@ -144,26 +151,26 @@ string or float, Crabbox treats that as a runner contract failure.
 
 ## Commands
 
-The CLI discovery surface is available as soon as the provider is registered:
+Discovery and non-billing readiness checks:
 
 ```sh
 crabbox providers --json
+crabbox warmup --provider replicate
 crabbox doctor --provider replicate --json
 ```
 
-Lifecycle commands below are the intended provider contract, but remain
-deferred until the backend implementation lands:
+Run lifecycle:
 
 ```sh
 crabbox run --provider replicate -- pnpm test
-crabbox run --provider replicate --id prediction-id -- pnpm test:changed
-crabbox status --provider replicate --id prediction-id --json
+crabbox status --provider replicate --id pred_abc123 --json
 crabbox list --provider replicate --json
-crabbox stop --provider replicate prediction-id
+crabbox stop --provider replicate rbx_pred_abc123
 ```
 
-Use the Replicate prediction ID or a local Crabbox claim/slug that resolves to
-one when targeting an existing run.
+Each `run` creates a new one-shot prediction. `crabbox run --provider replicate
+--id ...` is rejected; use `status` or `stop` with an existing prediction ID,
+local Crabbox claim ID, or local claim slug instead.
 
 ## Capabilities
 
@@ -173,8 +180,9 @@ one when targeting an existing run.
 - Desktop / browser / code / VNC: no.
 - Actions hydration: no.
 - Coordinator broker: no, Replicate runs direct from the CLI.
-- Run sessions: advertised by the provider spec; runtime lifecycle is deferred
-  in the current branch until the backend plan lands.
+- Run sessions: yes, backed by local Crabbox claims for the created prediction.
+  Claims support `status`, `list`, and `stop`; there is no Crabbox-managed VM
+  cleanup resource beyond canceling the Replicate prediction.
 
 ## Archive Limits
 
@@ -197,12 +205,15 @@ billing. A live smoke should only run when all of these are true:
 - the runner is known to implement Crabbox's JSON input/output contract;
 - an explicit arming variable such as `CRABBOX_REPLICATE_LIVE_SMOKE=1` is set.
 
-Until a guarded `scripts/live-replicate-smoke.sh` exists, classify live proof as
-deferred rather than substituting docs checks for real provider behavior. Any
-future smoke must report one of: success, `skipped`, `environment_blocked`,
-`quota_blocked`, `validation_failed`, `cleanup_failed`, or `diagnostic_only`.
-If it creates a prediction, it must preserve the prediction ID long enough to
-attempt `crabbox stop --provider replicate` cleanup and report the result.
+Until a guarded `scripts/live-replicate-smoke.sh` exists, classify live smoke
+script proof as deferred rather than substituting docs checks for real provider
+behavior. Non-mutating local proof can still cover `providers --json`,
+configuration validation, missing-auth `doctor`, and token-redaction behavior.
+Any future smoke must report one of: success, `skipped`,
+`environment_blocked`, `quota_blocked`, `validation_failed`, `cleanup_failed`,
+or `diagnostic_only`. If it creates a prediction, it must preserve the
+prediction ID long enough to attempt `crabbox stop --provider replicate`
+cleanup and report the result.
 
 Related docs:
 

--- a/docs/source-map.md
+++ b/docs/source-map.md
@@ -109,6 +109,8 @@ Delegated-run providers (no SSH lease):
   `internal/providers/blacksmith`, `internal/providers/wandb`
 - Superserve delegated lifecycle, archive sync, data-plane file upload, exec,
   and live smoke: `internal/providers/superserve`, `scripts/live-superserve-smoke.sh`
+- Replicate delegated registration, config, runner schema, and currently
+  deferred lifecycle backend: `internal/providers/replicate`
 - Anthropic Sandbox Runtime live local enforcement smoke: `scripts/live-anthropic-sandbox-runtime-smoke.sh`
 - Azure Container Apps dynamic sessions (shares the `azure` family, but
   delegated-run): `internal/providers/azuredynamicsessions`, runner image `worker/azure-dynamic-sessions.Dockerfile`
@@ -148,7 +150,7 @@ Actions hydration or repo scripts.
 Provider docs:
 
 - Per-provider feature notes: `docs/features/aws.md`, `docs/features/azure.md`, `docs/features/hetzner.md`, `docs/features/blacksmith-testbox.md`, `docs/features/namespace-devbox.md`, `docs/features/namespace-devbox-setup.md`, `docs/features/semaphore.md`, `docs/features/sprites.md`, `docs/features/daytona.md`, `docs/features/islo.md`, `docs/features/e2b.md`
-- Per-provider reference: `docs/providers/README.md` plus one file per provider under `docs/providers/`, including `docs/providers/aws-lambda-microvm.md` for Lambda MicroVM delegated execution and its runner image, `docs/providers/lambda.md` for the direct Lambda GPU SSH lease provider, `docs/providers/blaxel.md` for delegated Blaxel sandbox execution, `docs/providers/apple-vz.md` for the local Apple Silicon `Virtualization.framework` path, `docs/providers/digitalocean.md` for the direct Droplet provider, `docs/providers/vultr.md` for the direct Vultr provider, `docs/providers/ovh.md` for the direct OVHcloud provider, `docs/providers/incus.md` for the separate local live validation contract, `docs/providers/superserve.md` for delegated Superserve execution and live proof, and `docs/providers/cloudflare-sandbox.md` for Cloudflare Sandbox bridge-backed delegated Linux execution
+- Per-provider reference: `docs/providers/README.md` plus one file per provider under `docs/providers/`, including `docs/providers/aws-lambda-microvm.md` for Lambda MicroVM delegated execution and its runner image, `docs/providers/lambda.md` for the direct Lambda GPU SSH lease provider, `docs/providers/blaxel.md` for delegated Blaxel sandbox execution, `docs/providers/apple-vz.md` for the local Apple Silicon `Virtualization.framework` path, `docs/providers/digitalocean.md` for the direct Droplet provider, `docs/providers/vultr.md` for the direct Vultr provider, `docs/providers/ovh.md` for the direct OVHcloud provider, `docs/providers/incus.md` for the separate local live validation contract, `docs/providers/superserve.md` for delegated Superserve execution and live proof, `docs/providers/replicate.md` for the Replicate runner contract and deferred lifecycle surface, and `docs/providers/cloudflare-sandbox.md` for Cloudflare Sandbox bridge-backed delegated Linux execution
 - Provider selection, landscape, live-smoke, and backend authoring guide: `docs/features/provider-selection.md`, `docs/features/provider-landscape.md`, `docs/features/provider-live-smoke.md`, `docs/provider-backends.md`, `docs/features/provider-authoring.md`
 - Tailscale contract: `docs/features/tailscale.md`
 

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -178,6 +178,7 @@ type Config struct {
 	Tenki                         TenkiConfig
 	Tensorlake                    TensorlakeConfig
 	OpenComputer                  OpenComputerConfig
+	Replicate                     ReplicateConfig
 	CodeSandbox                   CodeSandboxConfig
 	OpenSandbox                   OpenSandboxConfig
 	Blaxel                        BlaxelConfig
@@ -711,6 +712,22 @@ type OpenComputerConfig struct {
 	ExecTimeoutSecs int
 	Burst           bool
 	ForgetMissing   bool
+}
+
+// ReplicateConfig configures the delegated Replicate provider. The API token
+// is intentionally absent: provider clients read CRABBOX_REPLICATE_API_TOKEN
+// before REPLICATE_API_TOKEN at runtime and never persist it in Crabbox config
+// or place it on argv.
+type ReplicateConfig struct {
+	APIURL           string
+	Deployment       string
+	Version          string
+	Workdir          string
+	WaitSecs         int
+	PollIntervalSecs int
+	ExecTimeoutSecs  int
+	CancelAfterSecs  int
+	MaxArchiveBytes  int64
 }
 
 // CodeSandboxConfig configures the delegated CodeSandbox provider. The API key
@@ -2598,6 +2615,13 @@ func baseConfig() Config {
 			Workdir:         "/workspace/crabbox",
 			ExecTimeoutSecs: 3600,
 		},
+		Replicate: ReplicateConfig{
+			APIURL:           "https://api.replicate.com/v1",
+			Workdir:          "/workspace/crabbox",
+			PollIntervalSecs: 2,
+			ExecTimeoutSecs:  3600,
+			MaxArchiveBytes:  10 * 1024 * 1024,
+		},
 		CodeSandbox: CodeSandboxConfig{
 			Workdir:                  "/project/workspace",
 			Privacy:                  "private",
@@ -2860,6 +2884,7 @@ type fileConfig struct {
 	Tenki                    *fileTenkiConfig                    `yaml:"tenki,omitempty"`
 	Tensorlake               *fileTensorlakeConfig               `yaml:"tensorlake,omitempty"`
 	OpenComputer             *fileOpenComputerConfig             `yaml:"openComputer,omitempty"`
+	Replicate                *fileReplicateConfig                `yaml:"replicate,omitempty"`
 	CodeSandbox              *fileCodeSandboxConfig              `yaml:"codeSandbox,omitempty"`
 	OpenSandbox              *fileOpenSandboxConfig              `yaml:"openSandbox,omitempty"`
 	Blaxel                   *fileBlaxelConfig                   `yaml:"blaxel,omitempty"`
@@ -3498,6 +3523,18 @@ type fileOpenComputerConfig struct {
 	TimeoutSecs     *int   `yaml:"timeoutSecs,omitempty"`
 	ExecTimeoutSecs *int   `yaml:"execTimeoutSecs,omitempty"`
 	Burst           *bool  `yaml:"burst,omitempty"`
+}
+
+type fileReplicateConfig struct {
+	APIURL           *string `yaml:"apiUrl,omitempty"`
+	Deployment       *string `yaml:"deployment,omitempty"`
+	Version          *string `yaml:"version,omitempty"`
+	Workdir          *string `yaml:"workdir,omitempty"`
+	WaitSecs         *int    `yaml:"waitSecs,omitempty"`
+	PollIntervalSecs *int    `yaml:"pollIntervalSecs,omitempty"`
+	ExecTimeoutSecs  *int    `yaml:"execTimeoutSecs,omitempty"`
+	CancelAfterSecs  *int    `yaml:"cancelAfterSecs,omitempty"`
+	MaxArchiveBytes  *int64  `yaml:"maxArchiveBytes,omitempty"`
 }
 
 type fileCodeSandboxConfig struct {
@@ -5703,6 +5740,50 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 			cfg.OpenComputer.Burst = *file.OpenComputer.Burst
 		}
 	}
+	if file.Replicate != nil {
+		if file.Replicate.APIURL != nil {
+			cfg.Replicate.APIURL = *file.Replicate.APIURL
+		}
+		if file.Replicate.Deployment != nil {
+			cfg.Replicate.Deployment = *file.Replicate.Deployment
+		}
+		if file.Replicate.Version != nil {
+			cfg.Replicate.Version = *file.Replicate.Version
+		}
+		if file.Replicate.Workdir != nil {
+			cfg.Replicate.Workdir = *file.Replicate.Workdir
+		}
+		if file.Replicate.WaitSecs != nil {
+			if *file.Replicate.WaitSecs < 0 {
+				return exit(2, "replicate waitSecs must be non-negative")
+			}
+			cfg.Replicate.WaitSecs = *file.Replicate.WaitSecs
+		}
+		if file.Replicate.PollIntervalSecs != nil {
+			if *file.Replicate.PollIntervalSecs < 0 {
+				return exit(2, "replicate pollIntervalSecs must be non-negative")
+			}
+			cfg.Replicate.PollIntervalSecs = *file.Replicate.PollIntervalSecs
+		}
+		if file.Replicate.ExecTimeoutSecs != nil {
+			if *file.Replicate.ExecTimeoutSecs < 0 {
+				return exit(2, "replicate execTimeoutSecs must be non-negative")
+			}
+			cfg.Replicate.ExecTimeoutSecs = *file.Replicate.ExecTimeoutSecs
+		}
+		if file.Replicate.CancelAfterSecs != nil {
+			if *file.Replicate.CancelAfterSecs < 0 {
+				return exit(2, "replicate cancelAfterSecs must be non-negative")
+			}
+			cfg.Replicate.CancelAfterSecs = *file.Replicate.CancelAfterSecs
+		}
+		if file.Replicate.MaxArchiveBytes != nil {
+			if *file.Replicate.MaxArchiveBytes < 0 {
+				return exit(2, "replicate maxArchiveBytes must be non-negative")
+			}
+			cfg.Replicate.MaxArchiveBytes = *file.Replicate.MaxArchiveBytes
+		}
+	}
 	if file.CodeSandbox != nil {
 		if file.CodeSandbox.TemplateID != nil {
 			cfg.CodeSandbox.TemplateID = *file.CodeSandbox.TemplateID
@@ -7508,6 +7589,30 @@ func applyEnv(cfg *Config) error {
 		cfg.OpenComputer.Burst = v
 	}
 	var err error
+	cfg.Replicate.APIURL = getenv("CRABBOX_REPLICATE_API_URL", getenv("REPLICATE_API_URL", cfg.Replicate.APIURL))
+	cfg.Replicate.Deployment = getenv("CRABBOX_REPLICATE_DEPLOYMENT", cfg.Replicate.Deployment)
+	cfg.Replicate.Version = getenv("CRABBOX_REPLICATE_VERSION", cfg.Replicate.Version)
+	cfg.Replicate.Workdir = getenv("CRABBOX_REPLICATE_WORKDIR", cfg.Replicate.Workdir)
+	cfg.Replicate.WaitSecs, err = getenvNonNegativeInt("CRABBOX_REPLICATE_WAIT_SECS", cfg.Replicate.WaitSecs)
+	if err != nil {
+		return err
+	}
+	cfg.Replicate.PollIntervalSecs, err = getenvNonNegativeInt("CRABBOX_REPLICATE_POLL_INTERVAL_SECS", cfg.Replicate.PollIntervalSecs)
+	if err != nil {
+		return err
+	}
+	cfg.Replicate.ExecTimeoutSecs, err = getenvNonNegativeInt("CRABBOX_REPLICATE_EXEC_TIMEOUT_SECS", cfg.Replicate.ExecTimeoutSecs)
+	if err != nil {
+		return err
+	}
+	cfg.Replicate.CancelAfterSecs, err = getenvNonNegativeInt("CRABBOX_REPLICATE_CANCEL_AFTER_SECS", cfg.Replicate.CancelAfterSecs)
+	if err != nil {
+		return err
+	}
+	cfg.Replicate.MaxArchiveBytes, err = getenvNonNegativeInt64("CRABBOX_REPLICATE_MAX_ARCHIVE_BYTES", cfg.Replicate.MaxArchiveBytes)
+	if err != nil {
+		return err
+	}
 	cfg.CodeSandbox.TemplateID = getenv("CRABBOX_CODESANDBOX_TEMPLATE_ID", cfg.CodeSandbox.TemplateID)
 	cfg.CodeSandbox.Workdir = getenv("CRABBOX_CODESANDBOX_WORKDIR", cfg.CodeSandbox.Workdir)
 	cfg.CodeSandbox.VMTier = getenv("CRABBOX_CODESANDBOX_VM_TIER", cfg.CodeSandbox.VMTier)
@@ -8523,6 +8628,21 @@ func getenvNonNegativeInt(name string, fallback int) (int, error) {
 		return fallback, nil
 	}
 	parsed, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, exit(2, "%s must be an integer", name)
+	}
+	if parsed < 0 {
+		return 0, exit(2, "%s must be non-negative", name)
+	}
+	return parsed, nil
+}
+
+func getenvNonNegativeInt64(name string, fallback int64) (int64, error) {
+	value := os.Getenv(name)
+	if value == "" {
+		return fallback, nil
+	}
+	parsed, err := strconv.ParseInt(value, 10, 64)
 	if err != nil {
 		return 0, exit(2, "%s must be an integer", name)
 	}

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -5743,6 +5743,7 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 	if file.Replicate != nil {
 		if file.Replicate.APIURL != nil {
 			cfg.Replicate.APIURL = *file.Replicate.APIURL
+			cfg.credentialProvenance.replicateAPIURL = credentialSource
 		}
 		if file.Replicate.Deployment != nil {
 			cfg.Replicate.Deployment = *file.Replicate.Deployment
@@ -7589,7 +7590,10 @@ func applyEnv(cfg *Config) error {
 		cfg.OpenComputer.Burst = v
 	}
 	var err error
-	cfg.Replicate.APIURL = getenv("CRABBOX_REPLICATE_API_URL", getenv("REPLICATE_API_URL", cfg.Replicate.APIURL))
+	if value, ok := firstNonEmptyEnv("CRABBOX_REPLICATE_API_URL", "REPLICATE_API_URL"); ok {
+		cfg.Replicate.APIURL = value
+		cfg.credentialProvenance.replicateAPIURL = credentialSourceEnvironment
+	}
 	cfg.Replicate.Deployment = getenv("CRABBOX_REPLICATE_DEPLOYMENT", cfg.Replicate.Deployment)
 	cfg.Replicate.Version = getenv("CRABBOX_REPLICATE_VERSION", cfg.Replicate.Version)
 	cfg.Replicate.Workdir = getenv("CRABBOX_REPLICATE_WORKDIR", cfg.Replicate.Workdir)

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -166,6 +166,18 @@ func clearConfigEnv(t *testing.T) {
 		"CRABBOX_CODESANDBOX_SDK_PACKAGE",
 		"CRABBOX_CODESANDBOX_DOCTOR_LIST_LIMIT",
 		"CRABBOX_CODESANDBOX_OPERATION_TIMEOUT_SECS",
+		"CRABBOX_REPLICATE_API_URL",
+		"REPLICATE_API_URL",
+		"CRABBOX_REPLICATE_API_TOKEN",
+		"REPLICATE_API_TOKEN",
+		"CRABBOX_REPLICATE_DEPLOYMENT",
+		"CRABBOX_REPLICATE_VERSION",
+		"CRABBOX_REPLICATE_WORKDIR",
+		"CRABBOX_REPLICATE_WAIT_SECS",
+		"CRABBOX_REPLICATE_POLL_INTERVAL_SECS",
+		"CRABBOX_REPLICATE_EXEC_TIMEOUT_SECS",
+		"CRABBOX_REPLICATE_CANCEL_AFTER_SECS",
+		"CRABBOX_REPLICATE_MAX_ARCHIVE_BYTES",
 		"CRABBOX_OPENSANDBOX_API_URL",
 		"OPEN_SANDBOX_API_URL",
 		"CRABBOX_OPENSANDBOX_API_KEY",
@@ -3287,6 +3299,114 @@ func TestOpenComputerConfigYAMLCannotSetAPIURL(t *testing.T) {
 	}
 	if cfg.OpenComputer.APIURL != "" {
 		t.Fatalf("repository config set OpenComputer API URL to %q", cfg.OpenComputer.APIURL)
+	}
+}
+
+func TestReplicateConfigDefaultsFileEnvAndNoPersistentSecretSurface(t *testing.T) {
+	clearConfigEnv(t)
+	cfg := baseConfig()
+	if cfg.Replicate.APIURL != "https://api.replicate.com/v1" || cfg.Replicate.Workdir != "/workspace/crabbox" || cfg.Replicate.PollIntervalSecs != 2 || cfg.Replicate.ExecTimeoutSecs != 3600 || cfg.Replicate.MaxArchiveBytes != 10*1024*1024 {
+		t.Fatalf("unexpected replicate defaults: %#v", cfg.Replicate)
+	}
+	file := fileConfig{Replicate: &fileReplicateConfig{
+		APIURL:           stringPtr("https://replicate-file.example/v1"),
+		Deployment:       stringPtr("owner/deployment"),
+		Workdir:          stringPtr("/workspace/file"),
+		WaitSecs:         intPtr(3),
+		PollIntervalSecs: intPtr(4),
+		ExecTimeoutSecs:  intPtr(5),
+		CancelAfterSecs:  intPtr(6),
+		MaxArchiveBytes:  int64Ptr(7),
+	}}
+	if err := applyFileConfig(&cfg, file); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Replicate.APIURL != "https://replicate-file.example/v1" || cfg.Replicate.Deployment != "owner/deployment" || cfg.Replicate.Workdir != "/workspace/file" || cfg.Replicate.WaitSecs != 3 || cfg.Replicate.PollIntervalSecs != 4 || cfg.Replicate.ExecTimeoutSecs != 5 || cfg.Replicate.CancelAfterSecs != 6 || cfg.Replicate.MaxArchiveBytes != 7 {
+		t.Fatalf("replicate file config not applied: %#v", cfg.Replicate)
+	}
+
+	t.Setenv("REPLICATE_API_URL", "https://replicate-vendor.example/v1")
+	t.Setenv("CRABBOX_REPLICATE_API_URL", "https://replicate-env.example/v1")
+	t.Setenv("CRABBOX_REPLICATE_DEPLOYMENT", "")
+	t.Setenv("CRABBOX_REPLICATE_VERSION", "version-env")
+	t.Setenv("CRABBOX_REPLICATE_WORKDIR", "/workspace/env")
+	t.Setenv("CRABBOX_REPLICATE_WAIT_SECS", "8")
+	t.Setenv("CRABBOX_REPLICATE_POLL_INTERVAL_SECS", "9")
+	t.Setenv("CRABBOX_REPLICATE_EXEC_TIMEOUT_SECS", "10")
+	t.Setenv("CRABBOX_REPLICATE_CANCEL_AFTER_SECS", "11")
+	t.Setenv("CRABBOX_REPLICATE_MAX_ARCHIVE_BYTES", "12")
+	t.Setenv("CRABBOX_REPLICATE_API_TOKEN", "token-must-not-enter-config")
+	t.Setenv("REPLICATE_API_TOKEN", "vendor-token-must-not-enter-config")
+	if err := applyEnv(&cfg); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Replicate.APIURL != "https://replicate-env.example/v1" || cfg.Replicate.Deployment != "owner/deployment" || cfg.Replicate.Version != "version-env" || cfg.Replicate.Workdir != "/workspace/env" || cfg.Replicate.WaitSecs != 8 || cfg.Replicate.PollIntervalSecs != 9 || cfg.Replicate.ExecTimeoutSecs != 10 || cfg.Replicate.CancelAfterSecs != 11 || cfg.Replicate.MaxArchiveBytes != 12 {
+		t.Fatalf("replicate env config not applied: %#v", cfg.Replicate)
+	}
+	if _, ok := reflect.TypeOf(ReplicateConfig{}).FieldByName("APIToken"); ok {
+		t.Fatal("ReplicateConfig unexpectedly exposes APIToken")
+	}
+	if _, ok := reflect.TypeOf(ReplicateConfig{}).FieldByName("Token"); ok {
+		t.Fatal("ReplicateConfig unexpectedly exposes Token")
+	}
+}
+
+func stringPtr(value string) *string { return &value }
+
+func intPtr(value int) *int { return &value }
+
+func int64Ptr(value int64) *int64 { return &value }
+
+func TestReplicateConfigYAMLExplicitZeroPreserved(t *testing.T) {
+	cfg := baseConfig()
+	cfg.Replicate.WaitSecs = 10
+	cfg.Replicate.PollIntervalSecs = 11
+	cfg.Replicate.ExecTimeoutSecs = 12
+	cfg.Replicate.CancelAfterSecs = 13
+	cfg.Replicate.MaxArchiveBytes = 14
+	zero := 0
+	zero64 := int64(0)
+	file := fileConfig{Replicate: &fileReplicateConfig{
+		WaitSecs:         &zero,
+		PollIntervalSecs: &zero,
+		ExecTimeoutSecs:  &zero,
+		CancelAfterSecs:  &zero,
+		MaxArchiveBytes:  &zero64,
+	}}
+	if err := applyFileConfig(&cfg, file); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Replicate.WaitSecs != 0 || cfg.Replicate.PollIntervalSecs != 0 || cfg.Replicate.ExecTimeoutSecs != 0 || cfg.Replicate.CancelAfterSecs != 0 || cfg.Replicate.MaxArchiveBytes != 0 {
+		t.Fatalf("explicit zero values not preserved: %#v", cfg.Replicate)
+	}
+}
+
+func TestReplicateConfigRejectsNegativeYAMLAndEnv(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		file fileConfig
+		env  map[string]string
+		want string
+	}{
+		{name: "file wait", file: fileConfig{Replicate: &fileReplicateConfig{WaitSecs: intPtr(-1)}}, want: "replicate waitSecs must be non-negative"},
+		{name: "env archive", env: map[string]string{"CRABBOX_REPLICATE_MAX_ARCHIVE_BYTES": "-1"}, want: "CRABBOX_REPLICATE_MAX_ARCHIVE_BYTES must be non-negative"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clearConfigEnv(t)
+			cfg := baseConfig()
+			for key, value := range tc.env {
+				t.Setenv(key, value)
+			}
+			var err error
+			if tc.file.Replicate != nil {
+				err = applyFileConfig(&cfg, tc.file)
+			} else {
+				err = applyEnv(&cfg)
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error=%v want %q", err, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/cli/credential_provenance.go
+++ b/internal/cli/credential_provenance.go
@@ -51,6 +51,7 @@ type credentialDestinationProvenance struct {
 	tenkiGateway        credentialValueSource
 	tensorlakeAPIURL    credentialValueSource
 	tensorlakeAPIKey    credentialValueSource
+	replicateAPIURL     credentialValueSource
 	upstashBoxBaseURL   credentialValueSource
 	upstashBoxAPIKey    credentialValueSource
 	smolvmBaseURL       credentialValueSource
@@ -139,6 +140,9 @@ func markCredentialDestinationFlagSources(cfg *Config, fs *flag.FlagSet) {
 	}
 	if flagWasSet(fs, "tensorlake-api-url") {
 		provenance.tensorlakeAPIURL = credentialSourceFlag
+	}
+	if flagWasSet(fs, "replicate-api-url") {
+		provenance.replicateAPIURL = credentialSourceFlag
 	}
 	if flagWasSet(fs, "upstash-box-base-url") {
 		provenance.upstashBoxBaseURL = credentialSourceFlag
@@ -257,6 +261,10 @@ func validateProviderCredentialDestination(cfg Config) error {
 			inheritedCredential(sourcedCredential{cfg.Tensorlake.APIKey, provenance.tensorlakeAPIKey}) {
 			return repositoryCredentialDestinationError("tensorlake", "tensorlake.apiUrl", "CRABBOX_TENSORLAKE_API_URL or --tensorlake-api-url")
 		}
+	case "replicate":
+		if provenance.replicateAPIURL == credentialSourceRepository && inheritedReplicateToken() {
+			return repositoryCredentialDestinationError("replicate", "replicate.apiUrl", "CRABBOX_REPLICATE_API_URL or --replicate-api-url")
+		}
 	case "upstash-box":
 		if provenance.upstashBoxBaseURL == credentialSourceRepository &&
 			inheritedCredential(sourcedCredential{cfg.UpstashBox.APIKey, provenance.upstashBoxAPIKey}) {
@@ -316,6 +324,15 @@ func ValidateNativeCredentialDestination(cfg Config, provider string) error {
 		}
 	}
 	return nil
+}
+
+func inheritedReplicateToken() bool {
+	for _, name := range []string{"CRABBOX_REPLICATE_API_TOKEN", "REPLICATE_API_TOKEN"} {
+		if strings.TrimSpace(os.Getenv(name)) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func inheritedCredential(credentials ...sourcedCredential) bool {

--- a/internal/cli/credential_provenance_test.go
+++ b/internal/cli/credential_provenance_test.go
@@ -593,6 +593,13 @@ func TestConfigMergeSourceBindsDirectProviderCredentials(t *testing.T) {
 			approveEnv:    "CRABBOX_TENSORLAKE_API_URL",
 		},
 		{
+			name:          "replicate",
+			provider:      "replicate",
+			file:          fileConfig{Replicate: &fileReplicateConfig{APIURL: stringPtr("https://repo.example.test/v1")}},
+			credentialEnv: "CRABBOX_REPLICATE_API_TOKEN",
+			approveEnv:    "CRABBOX_REPLICATE_API_URL",
+		},
+		{
 			name:          "upstash box",
 			provider:      "upstash-box",
 			file:          fileConfig{UpstashBox: &fileUpstashBoxConfig{BaseURL: "https://repo.example.test"}},

--- a/internal/cli/provider_categories_generated.go
+++ b/internal/cli/provider_categories_generated.go
@@ -54,6 +54,7 @@ var benchmarkProviderCategories = map[string]string{
 	"phala":                      "direct-cloud",
 	"proxmox":                    "self-hosted-virtualization",
 	"railway":                    "service-control",
+	"replicate":                  "delegated-sandbox",
 	"runpod":                     "gpu-cloud",
 	"scaleway":                   "direct-cloud",
 	"semaphore":                  "ci-proof-runner",

--- a/internal/providers/all/all.go
+++ b/internal/providers/all/all.go
@@ -52,6 +52,7 @@ import (
 	_ "github.com/openclaw/crabbox/internal/providers/phala"
 	_ "github.com/openclaw/crabbox/internal/providers/proxmox"
 	_ "github.com/openclaw/crabbox/internal/providers/railway"
+	_ "github.com/openclaw/crabbox/internal/providers/replicate"
 	_ "github.com/openclaw/crabbox/internal/providers/runpod"
 	_ "github.com/openclaw/crabbox/internal/providers/scaleway"
 	_ "github.com/openclaw/crabbox/internal/providers/semaphore"

--- a/internal/providers/all/all_test.go
+++ b/internal/providers/all/all_test.go
@@ -62,6 +62,34 @@ func TestOpenSandboxRegistersWithoutAliasCollision(t *testing.T) {
 	}
 }
 
+func TestReplicateRegistersWithoutAliases(t *testing.T) {
+	provider, err := core.ProviderFor("replicate")
+	if err != nil {
+		t.Fatalf("ProviderFor(replicate): %v", err)
+	}
+	if provider.Name() != "replicate" {
+		t.Fatalf("ProviderFor(replicate).Name=%q", provider.Name())
+	}
+	if provider.Aliases() != nil {
+		t.Fatalf("replicate aliases=%v, want none", provider.Aliases())
+	}
+	spec := provider.Spec()
+	if spec.Family != "replicate" || spec.Kind != core.ProviderKindDelegatedRun || spec.Coordinator != core.CoordinatorNever {
+		t.Fatalf("replicate spec=%#v", spec)
+	}
+	if len(spec.Targets) != 1 || spec.Targets[0].OS != core.TargetLinux {
+		t.Fatalf("replicate targets=%#v", spec.Targets)
+	}
+	if !spec.Features.Has(core.FeatureArchiveSync) || !spec.Features.Has(core.FeatureRunSession) {
+		t.Fatalf("replicate features=%v", spec.Features)
+	}
+	for _, alias := range []string{"rep", "r8", "replicate-ai"} {
+		if got, err := core.ProviderFor(alias); err == nil && got.Name() == "replicate" {
+			t.Fatalf("%q alias unexpectedly resolves to replicate", alias)
+		}
+	}
+}
+
 func TestNvidiaBrevRegistersCanonicalAndAliases(t *testing.T) {
 	for _, name := range []string{"nvidia-brev", "brev", "nvidia"} {
 		provider, err := core.ProviderFor(name)
@@ -1174,6 +1202,7 @@ func allBuiltInProviderNames() []string {
 		"phala",
 		"proxmox",
 		"railway",
+		"replicate",
 		"runpod",
 		"scaleway",
 		"anthropic-sandbox-runtime",

--- a/internal/providers/replicate/backend.go
+++ b/internal/providers/replicate/backend.go
@@ -314,6 +314,9 @@ func (b replicateBackend) validateReadyConfig() (string, string, error) {
 	if err := ValidateConfig(cfg); err != nil {
 		return "", "", err
 	}
+	if err := validateRunnerTargetConfig(cfg); err != nil {
+		return "", "", err
+	}
 	baseURL, source, err := b.validateAPIConfig()
 	if err != nil {
 		return "", "", err

--- a/internal/providers/replicate/backend.go
+++ b/internal/providers/replicate/backend.go
@@ -124,7 +124,7 @@ func (b replicateBackend) Run(ctx context.Context, req RunRequest) (RunResult, e
 	leaseID := leaseIDForPrediction(pred.ID)
 	slug, err := allocateClaimLeaseSlug(leaseID, req.RequestedSlug)
 	if err != nil {
-		return RunResult{Provider: providerName, LeaseID: leaseID, Total: b.now().Sub(started), SyncDelegated: true}, err
+		return RunResult{Provider: providerName, LeaseID: leaseID, Total: b.now().Sub(started), SyncDelegated: true}, b.cleanupCreateFailure(ctx, api, pred.ID, err)
 	}
 	if err := claimLeaseForRepoProviderScopePond(leaseID, slug, providerName, replicateEndpointScope(baseURL), b.cfg.Pond, req.Repo.Root, b.cfg.IdleTimeout, req.Reclaim); err != nil {
 		return RunResult{Provider: providerName, LeaseID: leaseID, Slug: slug, Total: b.now().Sub(started), SyncDelegated: true}, b.cleanupCreateFailure(ctx, api, pred.ID, err)

--- a/internal/providers/replicate/backend.go
+++ b/internal/providers/replicate/backend.go
@@ -1,0 +1,668 @@
+package replicate
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"strings"
+	"time"
+)
+
+const replicateCleanupTimeout = 15 * time.Second
+
+func NewReplicateBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+	cfg.Provider = providerName
+	applyReplicateDefaults(&cfg)
+	return &replicateBackend{spec: spec, cfg: cfg, rt: rt}
+}
+
+type replicateBackend struct {
+	spec   ProviderSpec
+	cfg    Config
+	rt     Runtime
+	client replicateAPI
+}
+
+func (b replicateBackend) Spec() ProviderSpec { return b.spec }
+
+func (b replicateBackend) Warmup(ctx context.Context, req WarmupRequest) error {
+	_ = ctx
+	if req.ActionsRunner {
+		return exit(2, "--actions-runner is not supported for provider=%s", providerName)
+	}
+	started := b.now()
+	if _, _, err := b.validateReadyConfig(); err != nil {
+		return err
+	}
+	fmt.Fprintf(b.stdout(), "provider=%s ready deployment=%t version=%t mutation=false\n",
+		providerName,
+		strings.TrimSpace(b.cfg.Replicate.Deployment) != "",
+		strings.TrimSpace(b.cfg.Replicate.Version) != "")
+	if req.TimingJSON {
+		return writeTimingJSON(b.stderr(), timingReport{
+			Provider: providerName,
+			TotalMs:  b.now().Sub(started).Milliseconds(),
+			ExitCode: 0,
+		})
+	}
+	return nil
+}
+
+func (b replicateBackend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
+	_ = ctx
+	if _, _, err := b.validateReadyConfig(); err != nil {
+		return DoctorResult{}, err
+	}
+	claims, err := listReplicateLeaseClaims()
+	if err != nil {
+		return DoctorResult{}, err
+	}
+	result := inventoryDoctorResult(providerName, countReplicateClaimsForScope(claims, b.claimScope()))
+	result.Message = strings.TrimSpace(result.Message + " mutation=false billing=none")
+	return result, nil
+}
+
+func (b replicateBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+	if err := b.rejectRunOptions(req); err != nil {
+		return RunResult{}, err
+	}
+	command, err := buildCommand(req.Command, req.ShellMode)
+	if err != nil {
+		return RunResult{}, err
+	}
+	workdir, err := replicateWorkdir(b.cfg)
+	if err != nil {
+		return RunResult{}, err
+	}
+	api, baseURL, err := b.api()
+	if err != nil {
+		return RunResult{}, err
+	}
+
+	started := b.now()
+	syncDuration := time.Duration(0)
+	syncPhases := []timingPhase{{Name: "sync", Skipped: true, Reason: "--no-sync"}}
+	archiveURL := ""
+	if !req.NoSync {
+		archive, err := buildReplicateArchiveDataURL(ctx, b.cfg, b.rt, req.Repo, req.ForceSyncLarge)
+		if err != nil {
+			return RunResult{Provider: providerName, Total: b.now().Sub(started), SyncDelegated: true}, err
+		}
+		archiveURL = archive.DataURL
+		syncDuration = archive.Duration
+		syncPhases = archive.Phases
+		fmt.Fprintf(b.stderr(), "sync archive complete size=%d duration=%s\n", archive.Size, syncDuration.Round(time.Millisecond))
+	}
+	if req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != "" {
+		printEnvForwardingSummary(b.stderr(), providerName, "forwarded", req.Options.EnvAllow, req.Env)
+	}
+
+	input := b.runnerInput(req, command, workdir, archiveURL)
+	createReq := replicateCreatePredictionRequest{
+		Deployment:      strings.TrimSpace(b.cfg.Replicate.Deployment),
+		Version:         strings.TrimSpace(b.cfg.Replicate.Version),
+		Input:           runnerInputMap(input),
+		WaitSecs:        b.cfg.Replicate.WaitSecs,
+		CancelAfterSecs: b.cfg.Replicate.CancelAfterSecs,
+	}
+	pred, err := api.CreatePrediction(ctx, createReq)
+	if err != nil {
+		return RunResult{Provider: providerName, Total: b.now().Sub(started), SyncDelegated: true}, err
+	}
+	if strings.TrimSpace(pred.ID) == "" {
+		return RunResult{Provider: providerName, Total: b.now().Sub(started), SyncDelegated: true}, exit(5, "replicate prediction create returned empty id")
+	}
+	leaseID := leaseIDForPrediction(pred.ID)
+	slug, err := allocateClaimLeaseSlug(leaseID, req.RequestedSlug)
+	if err != nil {
+		return RunResult{Provider: providerName, LeaseID: leaseID, Total: b.now().Sub(started), SyncDelegated: true}, err
+	}
+	if err := claimLeaseForRepoProviderScopePond(leaseID, slug, providerName, replicateEndpointScope(baseURL), b.cfg.Pond, req.Repo.Root, b.cfg.IdleTimeout, req.Reclaim); err != nil {
+		return RunResult{Provider: providerName, LeaseID: leaseID, Slug: slug, Total: b.now().Sub(started), SyncDelegated: true}, b.cleanupCreateFailure(ctx, api, pred.ID, err)
+	}
+	fmt.Fprintf(b.stderr(), "provider=%s prediction=%s lease=%s slug=%s workdir=%s\n", providerName, pred.ID, leaseID, slug, workdir)
+
+	session := &RunSessionHandle{
+		Provider:       providerName,
+		LeaseID:        leaseID,
+		Slug:           slug,
+		Kept:           true,
+		RunID:          pred.ID,
+		CleanupCommand: replicateCleanupCommand(leaseID),
+	}
+	logOffset := 0
+	b.writeNewLogs(pred, &logOffset)
+	commandStarted := b.now()
+	pred, err = b.pollPrediction(ctx, api, pred, &logOffset)
+	commandDuration := b.now().Sub(commandStarted)
+	result, runErr := b.resultFromPrediction(pred, started, commandDuration, syncDuration, session, req.Command)
+	result.SyncDelegated = true
+	if req.TimingJSON {
+		report := timingReportWithRunResult(timingReport{
+			Provider:      providerName,
+			LeaseID:       leaseID,
+			Slug:          slug,
+			SyncDelegated: true,
+			SyncMs:        syncDuration.Milliseconds(),
+			SyncPhases:    syncPhases,
+			SyncSkipped:   req.NoSync,
+			CommandMs:     commandDuration.Milliseconds(),
+			TotalMs:       result.Total.Milliseconds(),
+			ExitCode:      result.ExitCode,
+			Label:         strings.TrimSpace(req.Label),
+		}, result, errors.Join(runErr, err))
+		if timingErr := writeTimingJSON(b.stderr(), report); timingErr != nil {
+			return result, timingErr
+		}
+	}
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			cancelCtx, cancel := b.cleanupContext(ctx)
+			defer cancel()
+			if _, cancelErr := api.CancelPrediction(cancelCtx, pred.ID); cancelErr != nil {
+				fmt.Fprintf(b.stderr(), "warning: replicate cancel failed for prediction=%s: %v\n", pred.ID, cancelErr)
+			}
+		}
+		shouldStop := false
+		handleDelegatedRunFailure(b.stderr(), req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, true, &shouldStop)
+		return result, err
+	}
+	if runErr != nil {
+		shouldStop := false
+		handleDelegatedRunFailure(b.stderr(), req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, true, &shouldStop)
+		return result, runErr
+	}
+	return result, nil
+}
+
+func (b replicateBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+	_ = ctx
+	_ = req
+	if _, _, err := b.validateReadyConfig(); err != nil {
+		return nil, err
+	}
+	claims, err := listReplicateLeaseClaims()
+	if err != nil {
+		return nil, err
+	}
+	scope := b.claimScope()
+	views := make([]LeaseView, 0, len(claims))
+	for _, claim := range claims {
+		if claim.Provider != providerName || !strings.HasPrefix(claim.LeaseID, leasePrefix) || claim.ProviderScope != scope {
+			continue
+		}
+		predictionID := predictionIDFromLeaseID(claim.LeaseID)
+		if predictionID == "" {
+			continue
+		}
+		slug := claim.Slug
+		if strings.TrimSpace(slug) == "" {
+			slug = newLeaseSlug(claim.LeaseID)
+		}
+		views = append(views, Server{
+			Provider: providerName,
+			CloudID:  predictionID,
+			Name:     predictionID,
+			Status:   "claimed",
+			Labels: map[string]string{
+				"provider": providerName,
+				"lease":    claim.LeaseID,
+				"slug":     slug,
+				"pond":     claim.Pond,
+				"target":   targetLinux,
+				"state":    "claimed",
+			},
+		})
+	}
+	return views, nil
+}
+
+func (b replicateBackend) Status(ctx context.Context, req StatusRequest) (StatusView, error) {
+	api, baseURL, err := b.api()
+	if err != nil {
+		return StatusView{}, err
+	}
+	leaseID, predictionID, slug, _, err := b.resolvePredictionIdentifier(req.ID, baseURL, false, "", false)
+	if err != nil {
+		return StatusView{}, err
+	}
+	waitTimeout := req.WaitTimeout
+	if waitTimeout <= 0 {
+		waitTimeout = 5 * time.Minute
+	}
+	pollCtx := ctx
+	cancel := func() {}
+	if req.Wait {
+		pollCtx, cancel = context.WithTimeout(ctx, waitTimeout)
+	}
+	defer cancel()
+	for {
+		pred, err := api.GetPrediction(pollCtx, predictionID)
+		if err != nil {
+			if req.Wait && errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
+				return StatusView{}, exit(5, "timed out waiting for replicate prediction %s to finish", predictionID)
+			}
+			return StatusView{}, err
+		}
+		view := replicateStatusView(leaseID, predictionID, slug, pred, b.claimPond(leaseID))
+		if !req.Wait || predictionTerminal(pred.Status) {
+			return view, nil
+		}
+		select {
+		case <-pollCtx.Done():
+			if errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
+				return StatusView{}, exit(5, "timed out waiting for replicate prediction %s to finish", predictionID)
+			}
+			return StatusView{}, pollCtx.Err()
+		case <-time.After(b.pollInterval()):
+		}
+	}
+}
+
+func (b replicateBackend) Stop(ctx context.Context, req StopRequest) error {
+	api, baseURL, err := b.api()
+	if err != nil {
+		return err
+	}
+	leaseID, predictionID, _, claimed, err := b.resolvePredictionIdentifier(req.ID, baseURL, false, "", false)
+	if err != nil {
+		return err
+	}
+	pred, err := api.CancelPrediction(ctx, predictionID)
+	if err != nil {
+		return err
+	}
+	if claimed || predictionTerminal(pred.Status) {
+		removeLeaseClaim(leaseID)
+	}
+	fmt.Fprintf(b.stderr(), "canceled provider=%s prediction=%s lease=%s status=%s\n", providerName, predictionID, leaseID, strings.TrimSpace(pred.Status))
+	return nil
+}
+
+func (b replicateBackend) rejectRunOptions(req RunRequest) error {
+	if err := rejectDelegatedSyncOptionsForSpec(b.spec, req); err != nil {
+		return err
+	}
+	if strings.TrimSpace(req.ID) != "" {
+		return exit(2, "provider=replicate creates a new prediction for each run; use status/stop with --id for existing predictions")
+	}
+	if req.SyncOnly {
+		return exit(2, "provider=replicate cannot --sync-only because predictions are one-shot runs")
+	}
+	if req.Preflight {
+		return exit(2, "provider=replicate does not support --preflight without creating a prediction")
+	}
+	return nil
+}
+
+func (b replicateBackend) validateReadyConfig() (string, string, error) {
+	cfg := b.cfg
+	cfg.Provider = providerName
+	if err := ValidateConfig(cfg); err != nil {
+		return "", "", err
+	}
+	baseURL, err := validateReplicateAPIURL(blank(strings.TrimSpace(cfg.Replicate.APIURL), defaultAPIURL))
+	if err != nil {
+		return "", "", err
+	}
+	_, source, ok := ResolveAPIToken()
+	if !ok {
+		return "", "", exit(2, "provider=replicate needs an API token; load CRABBOX_REPLICATE_API_TOKEN from a secret manager or set REPLICATE_API_TOKEN")
+	}
+	if _, err := replicateWorkdir(cfg); err != nil {
+		return "", "", err
+	}
+	return baseURL, source, nil
+}
+
+func (b replicateBackend) api() (replicateAPI, string, error) {
+	baseURL, _, err := b.validateReadyConfig()
+	if err != nil {
+		return nil, "", err
+	}
+	if b.client != nil {
+		return b.client, baseURL, nil
+	}
+	client, err := newReplicateClient(b.cfg, b.rt)
+	if err != nil {
+		return nil, "", err
+	}
+	return client, baseURL, nil
+}
+
+func (b replicateBackend) runnerInput(req RunRequest, command []string, workdir, archiveURL string) RunnerInput {
+	return RunnerInput{
+		Command:      append([]string(nil), command...),
+		Workdir:      workdir,
+		ArchiveURL:   archiveURL,
+		Env:          cloneStringMap(req.Env),
+		TimeoutSecs:  b.cfg.Replicate.ExecTimeoutSecs,
+		CancelAfter:  b.cfg.Replicate.CancelAfterSecs,
+		Metadata:     b.runnerMetadata(req),
+		OutputSchema: "crabbox.runner.v1",
+	}
+}
+
+func (b replicateBackend) runnerMetadata(req RunRequest) map[string]string {
+	metadata := map[string]string{
+		"provider": "crabbox",
+	}
+	if strings.TrimSpace(req.Repo.Name) != "" {
+		metadata["repo"] = strings.TrimSpace(req.Repo.Name)
+	}
+	if strings.TrimSpace(req.Label) != "" {
+		metadata["label"] = strings.TrimSpace(req.Label)
+	}
+	return metadata
+}
+
+func runnerInputMap(input RunnerInput) map[string]any {
+	payload, _ := json.Marshal(input)
+	var out map[string]any
+	_ = json.Unmarshal(payload, &out)
+	return out
+}
+
+func (b replicateBackend) pollPrediction(ctx context.Context, api replicateAPI, pred replicatePrediction, logOffset *int) (replicatePrediction, error) {
+	for !predictionTerminal(pred.Status) {
+		select {
+		case <-ctx.Done():
+			return pred, ctx.Err()
+		case <-time.After(b.pollInterval()):
+		}
+		next, err := api.GetPrediction(ctx, pred.ID)
+		if err != nil {
+			return pred, err
+		}
+		pred = next
+		b.writeNewLogs(pred, logOffset)
+	}
+	return pred, nil
+}
+
+func (b replicateBackend) resultFromPrediction(pred replicatePrediction, started time.Time, commandDuration, syncDuration time.Duration, session *RunSessionHandle, command []string) (RunResult, error) {
+	result := RunResult{
+		Command:       commandDuration,
+		Total:         b.now().Sub(started),
+		SyncDelegated: true,
+		Provider:      providerName,
+		LeaseID:       session.LeaseID,
+		Slug:          session.Slug,
+		CommandText:   strings.Join(command, " "),
+		Session:       session,
+	}
+	status := strings.ToLower(strings.TrimSpace(pred.Status))
+	switch status {
+	case "succeeded":
+		output, err := parsePredictionOutput(pred)
+		if err != nil {
+			result.ExitCode = 1
+			return result, exit(5, "%v", err)
+		}
+		if output.Stdout != "" {
+			_, _ = io.WriteString(b.stdout(), output.Stdout)
+		}
+		if output.Stderr != "" {
+			_, _ = io.WriteString(b.stderr(), output.Stderr)
+		}
+		result.ExitCode = output.ExitCode
+		if output.ExitCode != 0 {
+			return result, ExitError{Code: output.ExitCode, Message: fmt.Sprintf("replicate run exited %d", output.ExitCode)}
+		}
+		return result, nil
+	case "failed":
+		result.ExitCode = 1
+		return result, exit(5, "replicate prediction %s failed: %s", pred.ID, predictionErrorText(pred))
+	case "canceled":
+		result.ExitCode = 1
+		return result, ExitError{Code: 1, Message: fmt.Sprintf("replicate prediction %s canceled", pred.ID)}
+	default:
+		result.ExitCode = 1
+		return result, exit(5, "replicate prediction %s ended with unknown status %q after sync=%s", pred.ID, pred.Status, syncDuration.Round(time.Millisecond))
+	}
+}
+
+func predictionErrorText(pred replicatePrediction) string {
+	if len(pred.Error) == 0 || string(pred.Error) == "null" {
+		return "no error detail"
+	}
+	var text string
+	if err := json.Unmarshal(pred.Error, &text); err == nil && strings.TrimSpace(text) != "" {
+		return strings.TrimSpace(text)
+	}
+	return strings.TrimSpace(string(pred.Error))
+}
+
+func (b replicateBackend) writeNewLogs(pred replicatePrediction, offset *int) {
+	if offset == nil {
+		return
+	}
+	logs := pred.Logs
+	if logs == "" {
+		return
+	}
+	if *offset > len(logs) {
+		*offset = 0
+	}
+	if *offset < len(logs) {
+		_, _ = io.WriteString(b.stderr(), logs[*offset:])
+		*offset = len(logs)
+	}
+}
+
+func (b replicateBackend) resolvePredictionIdentifier(identifier, baseURL string, reclaim bool, repoRoot string, updateClaim bool) (string, string, string, bool, error) {
+	id := strings.TrimSpace(identifier)
+	if id == "" {
+		return "", "", "", false, exit(2, "provider=replicate requires a prediction id or Crabbox claim slug")
+	}
+	scope := replicateEndpointScope(baseURL)
+	exactLeaseID := id
+	if !strings.HasPrefix(exactLeaseID, leasePrefix) {
+		exactLeaseID = leaseIDForPrediction(id)
+	}
+	if claim, err := readLeaseClaim(exactLeaseID); err != nil {
+		return "", "", "", false, err
+	} else if claim.LeaseID == exactLeaseID && claim.Provider == providerName {
+		leaseID, predictionID, slug, err := b.finishResolvedClaim(claim, scope, reclaim, repoRoot, updateClaim)
+		return leaseID, predictionID, slug, true, err
+	}
+	claims, err := listReplicateLeaseClaims()
+	if err != nil {
+		return "", "", "", false, err
+	}
+	slugKey := normalizeLeaseSlug(id)
+	for _, claim := range claims {
+		if claim.Provider != providerName || claim.ProviderScope != scope {
+			continue
+		}
+		if claim.LeaseID == id || (slugKey != "" && normalizeLeaseSlug(claim.Slug) == slugKey) {
+			leaseID, predictionID, slug, err := b.finishResolvedClaim(claim, scope, reclaim, repoRoot, updateClaim)
+			return leaseID, predictionID, slug, true, err
+		}
+	}
+	if strings.HasPrefix(id, leasePrefix) {
+		return "", "", "", false, exit(4, "replicate prediction %q is not claimed by Crabbox for this API endpoint", id)
+	}
+	return leaseIDForPrediction(id), id, newLeaseSlug(leaseIDForPrediction(id)), false, nil
+}
+
+func (b replicateBackend) finishResolvedClaim(claim LeaseClaim, scope string, reclaim bool, repoRoot string, updateClaim bool) (string, string, string, error) {
+	if claim.ProviderScope != scope {
+		return "", "", "", exit(4, "replicate lease %q belongs to a different API endpoint; restore the endpoint used to create it", claim.LeaseID)
+	}
+	if updateClaim && repoRoot != "" {
+		if err := claimLeaseForRepoProviderScopePond(claim.LeaseID, claim.Slug, providerName, claim.ProviderScope, claim.Pond, repoRoot, b.cfg.IdleTimeout, reclaim); err != nil {
+			return "", "", "", err
+		}
+	}
+	slug := claim.Slug
+	if strings.TrimSpace(slug) == "" {
+		slug = newLeaseSlug(claim.LeaseID)
+	}
+	return claim.LeaseID, predictionIDFromLeaseID(claim.LeaseID), slug, nil
+}
+
+func (b replicateBackend) claimPond(leaseID string) string {
+	claim, err := readLeaseClaim(leaseID)
+	if err != nil {
+		return ""
+	}
+	return claim.Pond
+}
+
+func (b replicateBackend) claimScope() string {
+	baseURL, err := validateReplicateAPIURL(blank(strings.TrimSpace(b.cfg.Replicate.APIURL), defaultAPIURL))
+	if err != nil {
+		return ""
+	}
+	return replicateEndpointScope(baseURL)
+}
+
+func countReplicateClaimsForScope(claims []LeaseClaim, scope string) int {
+	count := 0
+	for _, claim := range claims {
+		if claim.Provider == providerName && strings.HasPrefix(claim.LeaseID, leasePrefix) && claim.ProviderScope == scope {
+			count++
+		}
+	}
+	return count
+}
+
+func replicateStatusView(leaseID, predictionID, slug string, pred replicatePrediction, pond string) StatusView {
+	state := strings.ToLower(strings.TrimSpace(pred.Status))
+	return StatusView{
+		ID:       leaseID,
+		Slug:     slug,
+		Provider: providerName,
+		TargetOS: targetLinux,
+		State:    state,
+		ServerID: predictionID,
+		Pond:     pond,
+		Network:  networkPublic,
+		Ready:    state == statusViewReady,
+		Labels: map[string]string{
+			"provider":   providerName,
+			"lease":      leaseID,
+			"prediction": predictionID,
+			"state":      state,
+		},
+	}
+}
+
+func applyReplicateDefaults(cfg *Config) {
+	defaults := DefaultConfig()
+	if strings.TrimSpace(cfg.Replicate.APIURL) == "" {
+		cfg.Replicate.APIURL = defaults.APIURL
+	}
+	if strings.TrimSpace(cfg.Replicate.Workdir) == "" {
+		cfg.Replicate.Workdir = defaults.Workdir
+	}
+}
+
+func replicateWorkdir(cfg Config) (string, error) {
+	workdir := strings.TrimSpace(cfg.Replicate.Workdir)
+	if workdir == "" {
+		workdir = defaultWorkdir
+	}
+	clean := path.Clean(workdir)
+	if !strings.HasPrefix(clean, "/") {
+		return "", exit(2, "replicate workdir %q must be an absolute path", workdir)
+	}
+	switch clean {
+	case "/", "/bin", "/dev", "/etc", "/home", "/lib", "/lib64", "/opt", "/proc", "/root", "/sbin", "/sys", "/tmp", "/usr", "/var", "/workspace":
+		return "", exit(2, "replicate workdir %q is too broad; choose a dedicated subdirectory", clean)
+	}
+	return clean, nil
+}
+
+func leaseIDForPrediction(predictionID string) string {
+	id := strings.TrimSpace(predictionID)
+	if strings.HasPrefix(id, leasePrefix) {
+		return id
+	}
+	return leasePrefix + id
+}
+
+func predictionIDFromLeaseID(leaseID string) string {
+	return strings.TrimPrefix(strings.TrimSpace(leaseID), leasePrefix)
+}
+
+func replicateCleanupCommand(leaseID string) string {
+	return "crabbox stop --provider " + providerName + " --id " + shellQuote(leaseID)
+}
+
+func buildCommand(command []string, shellMode bool) ([]string, error) {
+	if len(command) == 0 {
+		return nil, errors.New("missing command")
+	}
+	if shellMode {
+		return []string{"bash", "-lc", strings.Join(command, " ")}, nil
+	}
+	if shouldUseShell(command) || leadingEnvAssignment(command) {
+		if len(command) == 1 {
+			return []string{"bash", "-lc", command[0]}, nil
+		}
+		return []string{"bash", "-lc", shellScriptFromArgv(command)}, nil
+	}
+	return command, nil
+}
+
+func leadingEnvAssignment(command []string) bool {
+	return len(command) > 1 && strings.Contains(command[0], "=") && !strings.HasPrefix(command[0], "-")
+}
+
+func cloneStringMap(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}
+
+func (b replicateBackend) pollInterval() time.Duration {
+	if b.cfg.Replicate.PollIntervalSecs <= 0 {
+		return time.Second
+	}
+	return time.Duration(b.cfg.Replicate.PollIntervalSecs) * time.Second
+}
+
+func (b replicateBackend) now() time.Time {
+	if b.rt.Clock != nil {
+		return b.rt.Clock.Now()
+	}
+	return time.Now()
+}
+
+func (b replicateBackend) stdout() io.Writer {
+	if b.rt.Stdout != nil {
+		return b.rt.Stdout
+	}
+	return io.Discard
+}
+
+func (b replicateBackend) stderr() io.Writer {
+	if b.rt.Stderr != nil {
+		return b.rt.Stderr
+	}
+	return io.Discard
+}
+
+func (b replicateBackend) cleanupContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(ctx), replicateCleanupTimeout)
+}
+
+func (b replicateBackend) cleanupCreateFailure(ctx context.Context, api replicateAPI, predictionID string, cause error) error {
+	cleanupCtx, cancel := b.cleanupContext(ctx)
+	defer cancel()
+	if _, err := api.CancelPrediction(cleanupCtx, predictionID); err != nil {
+		return errors.Join(cause, fmt.Errorf("replicate cleanup failed for prediction %s; cancel it in Replicate: %w", predictionID, err))
+	}
+	return cause
+}

--- a/internal/providers/replicate/backend.go
+++ b/internal/providers/replicate/backend.go
@@ -75,11 +75,15 @@ func (b replicateBackend) Run(ctx context.Context, req RunRequest) (RunResult, e
 	if err != nil {
 		return RunResult{}, err
 	}
+	baseURL, _, err := b.validateReadyConfig()
+	if err != nil {
+		return RunResult{}, err
+	}
 	workdir, err := replicateWorkdir(b.cfg)
 	if err != nil {
 		return RunResult{}, err
 	}
-	api, baseURL, err := b.api()
+	api, _, err := b.api()
 	if err != nil {
 		return RunResult{}, err
 	}
@@ -187,7 +191,7 @@ func (b replicateBackend) Run(ctx context.Context, req RunRequest) (RunResult, e
 func (b replicateBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
 	_ = ctx
 	_ = req
-	if _, _, err := b.validateReadyConfig(); err != nil {
+	if _, _, err := b.validateAPIConfig(); err != nil {
 		return nil, err
 	}
 	claims, err := listReplicateLeaseClaims()
@@ -310,6 +314,18 @@ func (b replicateBackend) validateReadyConfig() (string, string, error) {
 	if err := ValidateConfig(cfg); err != nil {
 		return "", "", err
 	}
+	baseURL, source, err := b.validateAPIConfig()
+	if err != nil {
+		return "", "", err
+	}
+	if _, err := replicateWorkdir(cfg); err != nil {
+		return "", "", err
+	}
+	return baseURL, source, nil
+}
+
+func (b replicateBackend) validateAPIConfig() (string, string, error) {
+	cfg := b.cfg
 	baseURL, err := validateReplicateAPIURL(blank(strings.TrimSpace(cfg.Replicate.APIURL), defaultAPIURL))
 	if err != nil {
 		return "", "", err
@@ -318,14 +334,11 @@ func (b replicateBackend) validateReadyConfig() (string, string, error) {
 	if !ok {
 		return "", "", exit(2, "provider=replicate needs an API token; load CRABBOX_REPLICATE_API_TOKEN from a secret manager or set REPLICATE_API_TOKEN")
 	}
-	if _, err := replicateWorkdir(cfg); err != nil {
-		return "", "", err
-	}
 	return baseURL, source, nil
 }
 
 func (b replicateBackend) api() (replicateAPI, string, error) {
-	baseURL, _, err := b.validateReadyConfig()
+	baseURL, _, err := b.validateAPIConfig()
 	if err != nil {
 		return nil, "", err
 	}

--- a/internal/providers/replicate/backend.go
+++ b/internal/providers/replicate/backend.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"slices"
 	"strings"
 	"time"
 )
@@ -97,11 +98,15 @@ func (b replicateBackend) Run(ctx context.Context, req RunRequest) (RunResult, e
 		syncPhases = archive.Phases
 		fmt.Fprintf(b.stderr(), "sync archive complete size=%d duration=%s\n", archive.Size, syncDuration.Round(time.Millisecond))
 	}
+	runnerEnv, strippedAuthEnv := replicateRunnerEnv(req.Env)
+	if len(strippedAuthEnv) > 0 {
+		fmt.Fprintf(b.stderr(), "warning: provider=%s did not forward provider authentication variables: %s\n", providerName, strings.Join(strippedAuthEnv, ","))
+	}
 	if req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != "" {
-		printEnvForwardingSummary(b.stderr(), providerName, "forwarded", req.Options.EnvAllow, req.Env)
+		printEnvForwardingSummary(b.stderr(), providerName, "forwarded", req.Options.EnvAllow, runnerEnv)
 	}
 
-	input := b.runnerInput(req, command, workdir, archiveURL)
+	input := b.runnerInput(req, command, workdir, archiveURL, runnerEnv)
 	createReq := replicateCreatePredictionRequest{
 		Deployment:      strings.TrimSpace(b.cfg.Replicate.Deployment),
 		Version:         strings.TrimSpace(b.cfg.Replicate.Version),
@@ -334,17 +339,35 @@ func (b replicateBackend) api() (replicateAPI, string, error) {
 	return client, baseURL, nil
 }
 
-func (b replicateBackend) runnerInput(req RunRequest, command []string, workdir, archiveURL string) RunnerInput {
+func (b replicateBackend) runnerInput(req RunRequest, command []string, workdir, archiveURL string, env map[string]string) RunnerInput {
 	return RunnerInput{
 		Command:      append([]string(nil), command...),
 		Workdir:      workdir,
 		ArchiveURL:   archiveURL,
-		Env:          cloneStringMap(req.Env),
+		Env:          cloneStringMap(env),
 		TimeoutSecs:  b.cfg.Replicate.ExecTimeoutSecs,
 		CancelAfter:  b.cfg.Replicate.CancelAfterSecs,
 		Metadata:     b.runnerMetadata(req),
 		OutputSchema: "crabbox.runner.v1",
 	}
+}
+
+func replicateRunnerEnv(env map[string]string) (map[string]string, []string) {
+	if len(env) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]string, len(env))
+	var stripped []string
+	for name, value := range env {
+		switch name {
+		case envCrabboxReplicateToken, envReplicateToken:
+			stripped = append(stripped, name)
+		default:
+			out[name] = value
+		}
+	}
+	slices.Sort(stripped)
+	return out, stripped
 }
 
 func (b replicateBackend) runnerMetadata(req RunRequest) map[string]string {

--- a/internal/providers/replicate/backend_test.go
+++ b/internal/providers/replicate/backend_test.go
@@ -1,0 +1,375 @@
+package replicate
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type fakeReplicateAPI struct {
+	mu        sync.Mutex
+	creates   []replicateCreatePredictionRequest
+	gets      []string
+	cancels   []string
+	listed    int
+	create    replicatePrediction
+	createErr error
+	getSeq    []replicatePrediction
+	getErr    error
+	cancel    replicatePrediction
+	cancelErr error
+}
+
+func (f *fakeReplicateAPI) CreatePrediction(_ context.Context, req replicateCreatePredictionRequest) (replicatePrediction, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.creates = append(f.creates, req)
+	if f.createErr != nil {
+		return replicatePrediction{}, f.createErr
+	}
+	return f.create, nil
+}
+
+func (f *fakeReplicateAPI) GetPrediction(_ context.Context, id string) (replicatePrediction, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.gets = append(f.gets, id)
+	if f.getErr != nil {
+		return replicatePrediction{}, f.getErr
+	}
+	if len(f.getSeq) == 0 {
+		return replicatePrediction{ID: id, Status: "succeeded", Output: rawJSON(`{"exit_code":0}`)}, nil
+	}
+	out := f.getSeq[0]
+	if len(f.getSeq) > 1 {
+		f.getSeq = f.getSeq[1:]
+	}
+	return out, nil
+}
+
+func (f *fakeReplicateAPI) ListPredictions(context.Context) (replicatePredictionList, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.listed++
+	return replicatePredictionList{Results: []replicatePrediction{{ID: "unrelated", Status: "processing"}}}, nil
+}
+
+func (f *fakeReplicateAPI) CancelPrediction(_ context.Context, id string) (replicatePrediction, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.cancels = append(f.cancels, id)
+	if f.cancelErr != nil {
+		return replicatePrediction{}, f.cancelErr
+	}
+	if f.cancel.ID == "" {
+		return replicatePrediction{ID: id, Status: "canceled"}, nil
+	}
+	return f.cancel, nil
+}
+
+func TestWarmupDoctorValidateConfigWithoutPredictionCreate(t *testing.T) {
+	t.Setenv(envCrabboxReplicateToken, "test-token")
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	fake := &fakeReplicateAPI{}
+	var stdout bytes.Buffer
+	backend := newTestBackend(fake, &stdout, io.Discard)
+
+	if err := backend.Warmup(context.Background(), WarmupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := backend.Doctor(context.Background(), DoctorRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.creates) != 0 || fake.listed != 0 || len(fake.gets) != 0 || len(fake.cancels) != 0 {
+		t.Fatalf("warmup/doctor made API calls: creates=%d list=%d gets=%d cancels=%d", len(fake.creates), fake.listed, len(fake.gets), len(fake.cancels))
+	}
+	if !strings.Contains(stdout.String(), "mutation=false") {
+		t.Fatalf("warmup output=%q", stdout.String())
+	}
+}
+
+func TestWarmupRequiresTokenAndRunnerTarget(t *testing.T) {
+	t.Setenv(envCrabboxReplicateToken, "")
+	t.Setenv(envReplicateToken, "")
+	backend := newTestBackend(&fakeReplicateAPI{}, io.Discard, io.Discard)
+	if err := backend.Warmup(context.Background(), WarmupRequest{}); err == nil || !strings.Contains(err.Error(), "needs an API token") {
+		t.Fatalf("Warmup err=%v, want missing token", err)
+	}
+
+	t.Setenv(envCrabboxReplicateToken, "test-token")
+	backend.cfg.Replicate.Deployment = ""
+	backend.cfg.Replicate.Version = ""
+	if err := backend.Warmup(context.Background(), WarmupRequest{}); err == nil || !strings.Contains(err.Error(), "requires exactly one") {
+		t.Fatalf("Warmup err=%v, want target validation", err)
+	}
+}
+
+func TestReplicateWorkdirRejectsRelativeAndBroad(t *testing.T) {
+	for _, workdir := range []string{"relative", "/", "/workspace", "/tmp"} {
+		cfg := testReplicateConfig()
+		cfg.Replicate.Workdir = workdir
+		if _, err := replicateWorkdir(cfg); err == nil {
+			t.Fatalf("replicateWorkdir(%q) unexpectedly passed", workdir)
+		}
+	}
+	cfg := testReplicateConfig()
+	cfg.Replicate.Workdir = "/workspace/crabbox/../app"
+	if got, err := replicateWorkdir(cfg); err != nil || got != "/workspace/app" {
+		t.Fatalf("replicateWorkdir=%q err=%v", got, err)
+	}
+}
+
+func TestRunCreatesPredictionWithArchiveInputAndMapsExitZero(t *testing.T) {
+	t.Setenv(envCrabboxReplicateToken, "test-token")
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	repoRoot := newReplicateTestRepo(t, map[string]string{"main.go": "package main\n"})
+	fake := &fakeReplicateAPI{
+		create: replicatePrediction{
+			ID:     "pred_success",
+			Status: "succeeded",
+			Logs:   "runner boot\n",
+			Output: rawJSON(`{"exit_code":0,"stdout":"ok\n","stderr":"warn\n"}`),
+		},
+	}
+	var stdout, stderr bytes.Buffer
+	backend := newTestBackend(fake, &stdout, &stderr)
+
+	result, err := backend.Run(context.Background(), RunRequest{
+		Repo:       core.Repo{Name: "my-app", Root: repoRoot},
+		Command:    []string{"go", "test", "./..."},
+		Env:        map[string]string{"CI": "1"},
+		Label:      "unit",
+		TimingJSON: true,
+		NoSync:     false,
+		Reclaim:    true,
+		ShellMode:  false,
+		EnvSummary: true,
+		Options:    core.LeaseOptions{EnvAllow: []string{"CI"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.ExitCode != 0 || result.LeaseID != "rbx_pred_success" || result.Session == nil || result.Session.RunID != "pred_success" {
+		t.Fatalf("result=%#v", result)
+	}
+	if len(fake.creates) != 1 {
+		t.Fatalf("creates=%d", len(fake.creates))
+	}
+	req := fake.creates[0]
+	if req.Deployment != "owner/runner" || req.Version != "" || req.WaitSecs != 3 || req.CancelAfterSecs != 9 {
+		t.Fatalf("create request=%#v", req)
+	}
+	command, _ := req.Input["command"].([]any)
+	if !reflect.DeepEqual(command, []any{"go", "test", "./..."}) {
+		t.Fatalf("command input=%#v", req.Input["command"])
+	}
+	if req.Input["workdir"] != "/workspace/crabbox" || req.Input["timeout_secs"] != float64(17) || req.Input["cancel_after_secs"] != float64(9) {
+		t.Fatalf("runner input=%#v", req.Input)
+	}
+	if env, ok := req.Input["env"].(map[string]any); !ok || env["CI"] != "1" {
+		t.Fatalf("env input=%#v", req.Input["env"])
+	}
+	archive, _ := req.Input["archive_url"].(string)
+	if !strings.HasPrefix(archive, replicateArchiveDataURLPrefix) {
+		t.Fatalf("archive_url=%q", archive)
+	}
+	if stdout.String() != "ok\n" {
+		t.Fatalf("stdout=%q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "runner boot\nwarn\n") {
+		t.Fatalf("stderr=%q", stderr.String())
+	}
+	if _, ok, err := core.ResolveLeaseClaim("rbx_pred_success"); err != nil || !ok {
+		t.Fatalf("claim ok=%t err=%v", ok, err)
+	}
+}
+
+func TestRunMapsNonzeroRunnerExit(t *testing.T) {
+	t.Setenv(envCrabboxReplicateToken, "test-token")
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	fake := &fakeReplicateAPI{create: replicatePrediction{ID: "pred_exit", Status: "succeeded", Output: rawJSON(`{"exit_code":7,"stderr":"bad\n"}`)}}
+	backend := newTestBackend(fake, io.Discard, io.Discard)
+	result, err := backend.Run(context.Background(), RunRequest{Repo: testRepo(t), Command: []string{"false"}, Reclaim: true})
+	if err == nil || result.ExitCode != 7 {
+		t.Fatalf("result=%#v err=%v, want exit 7", result, err)
+	}
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 7 {
+		t.Fatalf("err=%T %[1]v, want ExitError code 7", err)
+	}
+}
+
+func TestRunRejectsMalformedRunnerOutput(t *testing.T) {
+	t.Setenv(envCrabboxReplicateToken, "test-token")
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	fake := &fakeReplicateAPI{create: replicatePrediction{ID: "pred_bad", Status: "succeeded", Output: rawJSON(`{"stdout":"missing exit"}`)}}
+	backend := newTestBackend(fake, io.Discard, io.Discard)
+	result, err := backend.Run(context.Background(), RunRequest{Repo: testRepo(t), Command: []string{"true"}, Reclaim: true})
+	if err == nil || result.ExitCode != 1 || !strings.Contains(err.Error(), "missing required exit_code") {
+		t.Fatalf("result=%#v err=%v", result, err)
+	}
+}
+
+func TestRunCancelOnContextCancellation(t *testing.T) {
+	t.Setenv(envCrabboxReplicateToken, "test-token")
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	fake := &fakeReplicateAPI{create: replicatePrediction{ID: "pred_cancel", Status: "processing", Logs: "start\n"}}
+	backend := newTestBackend(fake, io.Discard, io.Discard)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	result, err := backend.Run(ctx, RunRequest{Repo: testRepo(t), Command: []string{"sleep", "10"}, Reclaim: true, NoSync: true})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("result=%#v err=%v, want context canceled", result, err)
+	}
+	if !reflect.DeepEqual(fake.cancels, []string{"pred_cancel"}) {
+		t.Fatalf("cancels=%v", fake.cancels)
+	}
+}
+
+func TestRunDedupePredictionLogsDuringPolling(t *testing.T) {
+	t.Setenv(envCrabboxReplicateToken, "test-token")
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	fake := &fakeReplicateAPI{
+		create: replicatePrediction{ID: "pred_logs", Status: "processing", Logs: "line1\n"},
+		getSeq: []replicatePrediction{{
+			ID:     "pred_logs",
+			Status: "succeeded",
+			Logs:   "line1\nline2\n",
+			Output: rawJSON(`{"exit_code":0}`),
+		}},
+	}
+	var stderr bytes.Buffer
+	backend := newTestBackend(fake, io.Discard, &stderr)
+	result, err := backend.Run(context.Background(), RunRequest{Repo: testRepo(t), Command: []string{"true"}, Reclaim: true})
+	if err != nil || result.ExitCode != 0 {
+		t.Fatalf("result=%#v err=%v", result, err)
+	}
+	if strings.Count(stderr.String(), "line1\n") != 1 || !strings.Contains(stderr.String(), "line2\n") {
+		t.Fatalf("stderr=%q", stderr.String())
+	}
+}
+
+func TestRunRejectsUnsupportedSyncOptionsAndExistingID(t *testing.T) {
+	t.Setenv(envCrabboxReplicateToken, "test-token")
+	backend := newTestBackend(&fakeReplicateAPI{}, io.Discard, io.Discard)
+	for _, req := range []RunRequest{
+		{Command: []string{"true"}, ChecksumSync: true},
+		{Command: []string{"true"}, SyncOnly: true},
+		{Command: []string{"true"}, ID: "pred_existing"},
+	} {
+		if _, err := backend.Run(context.Background(), req); err == nil {
+			t.Fatalf("Run(%#v) unexpectedly passed", req)
+		}
+	}
+}
+
+func TestStatusSupportsRawPredictionIDAndClaimSlug(t *testing.T) {
+	t.Setenv(envCrabboxReplicateToken, "test-token")
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	fake := &fakeReplicateAPI{getSeq: []replicatePrediction{{ID: "pred_status", Status: "processing"}}}
+	backend := newTestBackend(fake, io.Discard, io.Discard)
+	view, err := backend.Status(context.Background(), StatusRequest{ID: "pred_status"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if view.ID != "rbx_pred_status" || view.ServerID != "pred_status" || view.State != "processing" {
+		t.Fatalf("raw status=%#v", view)
+	}
+
+	if err := claimLeaseForRepoProviderScopePond("rbx_pred_claimed", "blue", providerName, backend.claimScope(), "pond-a", "/repo", time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	fake.getSeq = []replicatePrediction{{ID: "pred_claimed", Status: "succeeded"}}
+	view, err = backend.Status(context.Background(), StatusRequest{ID: "blue"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if view.ID != "rbx_pred_claimed" || view.Slug != "blue" || view.Pond != "pond-a" || !view.Ready {
+		t.Fatalf("claimed status=%#v", view)
+	}
+}
+
+func TestListUsesOnlyLocalClaimsAndDoesNotListAccountPredictions(t *testing.T) {
+	t.Setenv(envCrabboxReplicateToken, "test-token")
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	fake := &fakeReplicateAPI{}
+	backend := newTestBackend(fake, io.Discard, io.Discard)
+	if err := claimLeaseForRepoProviderScopePond("rbx_owned", "owned", providerName, backend.claimScope(), "", "/repo", time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := claimLeaseForRepoProviderScopePond("rbx_other", "other", providerName, "replicate-endpoint-sha256:other", "", "/repo", time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	views, err := backend.List(context.Background(), ListRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fake.listed != 0 {
+		t.Fatalf("ListPredictions called %d times", fake.listed)
+	}
+	if len(views) != 1 || views[0].CloudID != "owned" || views[0].Labels["slug"] != "owned" {
+		t.Fatalf("views=%#v", views)
+	}
+}
+
+func TestStopCancelsPredictionAndRemovesClaim(t *testing.T) {
+	t.Setenv(envCrabboxReplicateToken, "test-token")
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	fake := &fakeReplicateAPI{cancel: replicatePrediction{ID: "pred_stop", Status: "canceled"}}
+	backend := newTestBackend(fake, io.Discard, io.Discard)
+	if err := claimLeaseForRepoProviderScopePond("rbx_pred_stop", "stop-me", providerName, backend.claimScope(), "", "/repo", time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := backend.Stop(context.Background(), StopRequest{ID: "stop-me"}); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(fake.cancels, []string{"pred_stop"}) {
+		t.Fatalf("cancels=%v", fake.cancels)
+	}
+	if _, ok, err := core.ResolveLeaseClaim("rbx_pred_stop"); err != nil || ok {
+		t.Fatalf("claim ok=%t err=%v, want removed", ok, err)
+	}
+}
+
+func newTestBackend(api *fakeReplicateAPI, stdout, stderr io.Writer) replicateBackend {
+	cfg := testReplicateConfig()
+	return replicateBackend{
+		spec:   Provider{}.Spec(),
+		cfg:    cfg,
+		rt:     Runtime{Stdout: stdout, Stderr: stderr},
+		client: api,
+	}
+}
+
+func testReplicateConfig() Config {
+	cfg := Config{Provider: providerName}
+	cfg.Replicate = ReplicateConfig{
+		APIURL:           "https://api.replicate.com/v1",
+		Deployment:       "owner/runner",
+		Workdir:          "/workspace/crabbox",
+		WaitSecs:         3,
+		PollIntervalSecs: 1,
+		ExecTimeoutSecs:  17,
+		CancelAfterSecs:  9,
+		MaxArchiveBytes:  1024 * 1024,
+	}
+	return cfg
+}
+
+func testRepo(t *testing.T) Repo {
+	t.Helper()
+	return core.Repo{Name: "my-app", Root: newReplicateTestRepo(t, map[string]string{"README.md": "ok\n"})}
+}
+
+func rawJSON(value string) json.RawMessage {
+	return json.RawMessage(value)
+}

--- a/internal/providers/replicate/backend_test.go
+++ b/internal/providers/replicate/backend_test.go
@@ -369,6 +369,45 @@ func TestListUsesOnlyLocalClaimsAndDoesNotListAccountPredictions(t *testing.T) {
 	}
 }
 
+func TestExistingPredictionOperationsDoNotRequireRunnerTarget(t *testing.T) {
+	t.Setenv(envCrabboxReplicateToken, "test-token")
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	fake := &fakeReplicateAPI{
+		getSeq: []replicatePrediction{{ID: "pred_status", Status: "processing"}},
+		cancel: replicatePrediction{
+			ID:     "pred_stop",
+			Status: "canceled",
+		},
+	}
+	backend := newTestBackend(fake, io.Discard, io.Discard)
+	backend.cfg.Replicate.Deployment = ""
+	backend.cfg.Replicate.Version = ""
+
+	view, err := backend.Status(context.Background(), StatusRequest{ID: "pred_status"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if view.ID != "rbx_pred_status" || view.ServerID != "pred_status" {
+		t.Fatalf("status=%#v", view)
+	}
+	if err := claimLeaseForRepoProviderScopePond("rbx_pred_list", "list-me", providerName, backend.claimScope(), "", "/repo", time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	views, err := backend.List(context.Background(), ListRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(views) != 1 || views[0].CloudID != "pred_list" {
+		t.Fatalf("views=%#v", views)
+	}
+	if err := backend.Stop(context.Background(), StopRequest{ID: "pred_stop"}); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(fake.cancels, []string{"pred_stop"}) {
+		t.Fatalf("cancels=%v", fake.cancels)
+	}
+}
+
 func TestStopCancelsPredictionAndRemovesClaim(t *testing.T) {
 	t.Setenv(envCrabboxReplicateToken, "test-token")
 	t.Setenv("XDG_STATE_HOME", t.TempDir())

--- a/internal/providers/replicate/backend_test.go
+++ b/internal/providers/replicate/backend_test.go
@@ -144,9 +144,14 @@ func TestRunCreatesPredictionWithArchiveInputAndMapsExitZero(t *testing.T) {
 	backend := newTestBackend(fake, &stdout, &stderr)
 
 	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:       core.Repo{Name: "my-app", Root: repoRoot},
-		Command:    []string{"go", "test", "./..."},
-		Env:        map[string]string{"CI": "1"},
+		Repo:    core.Repo{Name: "my-app", Root: repoRoot},
+		Command: []string{"go", "test", "./..."},
+		Env: map[string]string{
+			"CI":                     "1",
+			"PROJECT_TOKEN":          "project-secret",
+			envCrabboxReplicateToken: "crabbox-token",
+			envReplicateToken:        "vendor-token",
+		},
 		Label:      "unit",
 		TimingJSON: true,
 		NoSync:     false,
@@ -175,8 +180,14 @@ func TestRunCreatesPredictionWithArchiveInputAndMapsExitZero(t *testing.T) {
 	if req.Input["workdir"] != "/workspace/crabbox" || req.Input["timeout_secs"] != float64(17) || req.Input["cancel_after_secs"] != float64(9) {
 		t.Fatalf("runner input=%#v", req.Input)
 	}
-	if env, ok := req.Input["env"].(map[string]any); !ok || env["CI"] != "1" {
+	env, ok := req.Input["env"].(map[string]any)
+	if !ok || env["CI"] != "1" || env["PROJECT_TOKEN"] != "project-secret" {
 		t.Fatalf("env input=%#v", req.Input["env"])
+	}
+	for _, name := range []string{envCrabboxReplicateToken, envReplicateToken} {
+		if _, ok := env[name]; ok {
+			t.Fatalf("env input forwarded provider auth %s: %#v", name, env)
+		}
 	}
 	archive, _ := req.Input["archive_url"].(string)
 	if !strings.HasPrefix(archive, replicateArchiveDataURLPrefix) {
@@ -187,6 +198,14 @@ func TestRunCreatesPredictionWithArchiveInputAndMapsExitZero(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "runner boot\nwarn\n") {
 		t.Fatalf("stderr=%q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "did not forward provider authentication variables: CRABBOX_REPLICATE_API_TOKEN,REPLICATE_API_TOKEN") {
+		t.Fatalf("stderr missing auth stripping warning: %q", stderr.String())
+	}
+	for _, leaked := range []string{"crabbox-token", "vendor-token"} {
+		if strings.Contains(stderr.String(), leaked) {
+			t.Fatalf("stderr leaked auth token %q: %q", leaked, stderr.String())
+		}
 	}
 	if _, ok, err := core.ResolveLeaseClaim("rbx_pred_success"); err != nil || !ok {
 		t.Fatalf("claim ok=%t err=%v", ok, err)

--- a/internal/providers/replicate/backend_test.go
+++ b/internal/providers/replicate/backend_test.go
@@ -113,6 +113,11 @@ func TestWarmupRequiresTokenAndRunnerTarget(t *testing.T) {
 	if err := backend.Warmup(context.Background(), WarmupRequest{}); err == nil || !strings.Contains(err.Error(), "requires exactly one") {
 		t.Fatalf("Warmup err=%v, want target validation", err)
 	}
+
+	backend.cfg.Replicate.Deployment = "missing-slash"
+	if err := backend.Warmup(context.Background(), WarmupRequest{}); err == nil || !strings.Contains(err.Error(), "owner/name") {
+		t.Fatalf("Warmup err=%v, want deployment shape validation", err)
+	}
 }
 
 func TestReplicateWorkdirRejectsRelativeAndBroad(t *testing.T) {

--- a/internal/providers/replicate/backend_test.go
+++ b/internal/providers/replicate/backend_test.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"sync"
@@ -209,6 +211,33 @@ func TestRunCreatesPredictionWithArchiveInputAndMapsExitZero(t *testing.T) {
 	}
 	if _, ok, err := core.ResolveLeaseClaim("rbx_pred_success"); err != nil || !ok {
 		t.Fatalf("claim ok=%t err=%v", ok, err)
+	}
+}
+
+func TestRunCancelsPredictionWhenRequestedSlugAllocationFails(t *testing.T) {
+	t.Setenv(envCrabboxReplicateToken, "test-token")
+	stateFile := filepath.Join(t.TempDir(), "state-file")
+	if err := os.WriteFile(stateFile, []byte("not a directory"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("XDG_STATE_HOME", stateFile)
+	fake := &fakeReplicateAPI{create: replicatePrediction{ID: "pred_slug", Status: "processing"}}
+	backend := newTestBackend(fake, io.Discard, io.Discard)
+
+	result, err := backend.Run(context.Background(), RunRequest{
+		Repo:          testRepo(t),
+		Command:       []string{"true"},
+		NoSync:        true,
+		RequestedSlug: "needs-claim-store",
+	})
+	if err == nil || !strings.Contains(err.Error(), "read claims directory") {
+		t.Fatalf("err=%v, want claim-store read failure", err)
+	}
+	if result.LeaseID != "rbx_pred_slug" {
+		t.Fatalf("result=%#v", result)
+	}
+	if !reflect.DeepEqual(fake.cancels, []string{"pred_slug"}) {
+		t.Fatalf("cancels=%v, want cleanup cancel", fake.cancels)
 	}
 }
 

--- a/internal/providers/replicate/client.go
+++ b/internal/providers/replicate/client.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"time"
 )
 
 type replicateAPI interface {
@@ -331,11 +330,4 @@ func parsePredictionOutput(pred replicatePrediction) (RunnerOutput, error) {
 		return RunnerOutput{}, fmt.Errorf("replicate prediction %s has no runner output", pred.ID)
 	}
 	return ParseRunnerOutput(pred.Output)
-}
-
-func waitDuration(secs int) time.Duration {
-	if secs <= 0 {
-		return 0
-	}
-	return time.Duration(secs) * time.Second
 }

--- a/internal/providers/replicate/client.go
+++ b/internal/providers/replicate/client.go
@@ -1,0 +1,341 @@
+package replicate
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+type replicateAPI interface {
+	CreatePrediction(context.Context, replicateCreatePredictionRequest) (replicatePrediction, error)
+	GetPrediction(context.Context, string) (replicatePrediction, error)
+	ListPredictions(context.Context) (replicatePredictionList, error)
+	CancelPrediction(context.Context, string) (replicatePrediction, error)
+}
+
+type replicateClient struct {
+	http    *http.Client
+	baseURL string
+	token   string
+}
+
+type replicateCreatePredictionRequest struct {
+	Deployment      string
+	Version         string
+	Input           map[string]any
+	WaitSecs        int
+	CancelAfterSecs int
+}
+
+type replicatePrediction struct {
+	ID          string          `json:"id"`
+	Status      string          `json:"status"`
+	Logs        string          `json:"logs,omitempty"`
+	Output      json.RawMessage `json:"output,omitempty"`
+	Error       json.RawMessage `json:"error,omitempty"`
+	URLs        predictionURLs  `json:"urls,omitempty"`
+	Metrics     map[string]any  `json:"metrics,omitempty"`
+	CreatedAt   string          `json:"created_at,omitempty"`
+	StartedAt   string          `json:"started_at,omitempty"`
+	CompletedAt string          `json:"completed_at,omitempty"`
+}
+
+type predictionURLs struct {
+	Get    string `json:"get,omitempty"`
+	Cancel string `json:"cancel,omitempty"`
+	Stream string `json:"stream,omitempty"`
+}
+
+type replicatePredictionList struct {
+	Results []replicatePrediction `json:"results"`
+	Next    string                `json:"next,omitempty"`
+}
+
+func newReplicateClient(cfg Config, rt Runtime) (*replicateClient, error) {
+	baseURL, err := validateReplicateAPIURL(blank(strings.TrimSpace(cfg.Replicate.APIURL), defaultAPIURL))
+	if err != nil {
+		return nil, err
+	}
+	token, _, ok := ResolveAPIToken()
+	if !ok {
+		return nil, exit(2, "provider=replicate needs an API token; load CRABBOX_REPLICATE_API_TOKEN from a secret manager or set REPLICATE_API_TOKEN")
+	}
+	httpClient := rt.HTTP
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &replicateClient{http: secureReplicateHTTPClient(httpClient, baseURL), baseURL: baseURL, token: token}, nil
+}
+
+func validateReplicateAPIURL(raw string) (string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" || parsed.Opaque != "" {
+		return "", exit(2, "provider=replicate API URL must be an absolute HTTPS URL")
+	}
+	if parsed.User != nil || parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
+		return "", exit(2, "provider=replicate API URL must not contain userinfo, query parameters, or a fragment")
+	}
+	parsed.Scheme = strings.ToLower(parsed.Scheme)
+	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && isReplicateLoopbackHost(parsed.Hostname())) {
+		return "", exit(2, "provider=replicate API URL must use HTTPS except for loopback development endpoints")
+	}
+	host := canonicalReplicateHostname(parsed.Hostname())
+	port := parsed.Port()
+	if (parsed.Scheme == "https" && port == "443") || (parsed.Scheme == "http" && port == "80") {
+		port = ""
+	}
+	if port != "" {
+		parsed.Host = net.JoinHostPort(host, port)
+	} else if strings.Contains(host, ":") {
+		parsed.Host = "[" + host + "]"
+	} else {
+		parsed.Host = host
+	}
+	parsed.Path = strings.TrimRight(parsed.Path, "/")
+	parsed.RawPath = ""
+	return strings.TrimRight(parsed.String(), "/"), nil
+}
+
+func canonicalReplicateHostname(host string) string {
+	if zoneAt := strings.Index(host, "%"); zoneAt > 0 && strings.Contains(host[:zoneAt], ":") {
+		return strings.ToLower(host[:zoneAt]) + host[zoneAt:]
+	}
+	return strings.ToLower(host)
+}
+
+func isReplicateLoopbackHost(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+func secureReplicateHTTPClient(source *http.Client, baseURL string) *http.Client {
+	client := *source
+	trusted, _ := url.Parse(baseURL)
+	originalCheckRedirect := source.CheckRedirect
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if !sameReplicateOrigin(trusted, req.URL) {
+			return fmt.Errorf("replicate refused cross-origin redirect to %s", req.URL.Redacted())
+		}
+		if originalCheckRedirect != nil {
+			return originalCheckRedirect(req, via)
+		}
+		if len(via) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+		return nil
+	}
+	return &client
+}
+
+func sameReplicateOrigin(a, b *url.URL) bool {
+	return a != nil && b != nil &&
+		strings.EqualFold(a.Scheme, b.Scheme) &&
+		strings.EqualFold(a.Hostname(), b.Hostname()) &&
+		effectiveReplicatePort(a) == effectiveReplicatePort(b)
+}
+
+func effectiveReplicatePort(value *url.URL) string {
+	if port := value.Port(); port != "" {
+		return port
+	}
+	switch strings.ToLower(value.Scheme) {
+	case "https":
+		return "443"
+	case "http":
+		return "80"
+	default:
+		return ""
+	}
+}
+
+func (c *replicateClient) CreatePrediction(ctx context.Context, req replicateCreatePredictionRequest) (replicatePrediction, error) {
+	path, body, err := createPredictionPathAndBody(req)
+	if err != nil {
+		return replicatePrediction{}, err
+	}
+	headers := map[string]string{}
+	if req.WaitSecs > 0 {
+		headers["Prefer"] = fmt.Sprintf("wait=%d", req.WaitSecs)
+	}
+	if req.CancelAfterSecs > 0 {
+		headers["Cancel-After"] = fmt.Sprintf("%ds", req.CancelAfterSecs)
+	}
+	var out replicatePrediction
+	if err := c.doJSON(ctx, http.MethodPost, path, body, headers, &out); err != nil {
+		return replicatePrediction{}, err
+	}
+	return out, nil
+}
+
+func createPredictionPathAndBody(req replicateCreatePredictionRequest) (string, any, error) {
+	deployment := strings.TrimSpace(req.Deployment)
+	version := strings.TrimSpace(req.Version)
+	if deployment == "" && version == "" {
+		return "", nil, exit(2, "replicate prediction create requires deployment or version")
+	}
+	if deployment != "" && version != "" {
+		return "", nil, exit(2, "replicate prediction create accepts deployment or version, not both")
+	}
+	if deployment != "" {
+		owner, name, ok := strings.Cut(deployment, "/")
+		if !ok || strings.TrimSpace(owner) == "" || strings.TrimSpace(name) == "" || strings.Contains(name, "/") {
+			return "", nil, exit(2, "replicate deployment must use owner/name")
+		}
+		path := "/deployments/" + url.PathEscape(owner) + "/" + url.PathEscape(name) + "/predictions"
+		return path, map[string]any{"input": blankInput(req.Input)}, nil
+	}
+	return "/predictions", map[string]any{"version": version, "input": blankInput(req.Input)}, nil
+}
+
+func blankInput(input map[string]any) map[string]any {
+	if input == nil {
+		return map[string]any{}
+	}
+	return input
+}
+
+func (c *replicateClient) GetPrediction(ctx context.Context, id string) (replicatePrediction, error) {
+	path, err := predictionPath(id)
+	if err != nil {
+		return replicatePrediction{}, err
+	}
+	var out replicatePrediction
+	if err := c.doJSON(ctx, http.MethodGet, path, nil, nil, &out); err != nil {
+		return replicatePrediction{}, err
+	}
+	return out, nil
+}
+
+func (c *replicateClient) ListPredictions(ctx context.Context) (replicatePredictionList, error) {
+	var out replicatePredictionList
+	if err := c.doJSON(ctx, http.MethodGet, "/predictions", nil, nil, &out); err != nil {
+		return replicatePredictionList{}, err
+	}
+	return out, nil
+}
+
+func (c *replicateClient) CancelPrediction(ctx context.Context, id string) (replicatePrediction, error) {
+	path, err := predictionPath(id)
+	if err != nil {
+		return replicatePrediction{}, err
+	}
+	var out replicatePrediction
+	if err := c.doJSON(ctx, http.MethodPost, path+"/cancel", nil, nil, &out); err != nil {
+		return replicatePrediction{}, err
+	}
+	return out, nil
+}
+
+func predictionPath(id string) (string, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "", exit(2, "replicate prediction id is required")
+	}
+	return "/predictions/" + url.PathEscape(id), nil
+}
+
+func (c *replicateClient) doJSON(ctx context.Context, method, path string, body any, headers map[string]string, out any) error {
+	var reader io.Reader
+	if body != nil {
+		payload, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("replicate marshal %s: %w", path, err)
+		}
+		reader = bytes.NewReader(payload)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reader)
+	if err != nil {
+		return fmt.Errorf("replicate request %s: %w", path, err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("replicate %s %s: %s", method, path, redactReplicateSecrets(err.Error(), c.token))
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return c.responseError(method, path, resp)
+	}
+	if out == nil {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil
+	}
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		return fmt.Errorf("replicate decode %s: %w", path, err)
+	}
+	return nil
+}
+
+func (c *replicateClient) responseError(method, path string, resp *http.Response) error {
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	detail := strings.TrimSpace(string(body))
+	if detail == "" {
+		detail = resp.Status
+	}
+	detail = redactReplicateSecrets(detail, c.token)
+	return fmt.Errorf("replicate %s %s failed: status=%d body=%s", method, path, resp.StatusCode, detail)
+}
+
+func redactReplicateSecrets(text, token string) string {
+	out := text
+	if token != "" {
+		out = strings.ReplaceAll(out, token, "[REDACTED]")
+		out = strings.ReplaceAll(out, "Bearer "+token, "Bearer [REDACTED]")
+	}
+	out = redactBearerValues(out)
+	return out
+}
+
+func redactBearerValues(text string) string {
+	fields := strings.Fields(text)
+	for i, field := range fields {
+		if strings.EqualFold(strings.Trim(field, `"'`), "Bearer") && i+1 < len(fields) {
+			fields[i+1] = "[REDACTED]"
+		}
+		if strings.HasPrefix(strings.ToLower(field), "bearer=") {
+			fields[i] = "bearer=[REDACTED]"
+		}
+	}
+	return strings.Join(fields, " ")
+}
+
+func predictionTerminal(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "succeeded", "failed", "canceled":
+		return true
+	default:
+		return false
+	}
+}
+
+func parsePredictionOutput(pred replicatePrediction) (RunnerOutput, error) {
+	if len(pred.Output) == 0 || string(pred.Output) == "null" {
+		return RunnerOutput{}, fmt.Errorf("replicate prediction %s has no runner output", pred.ID)
+	}
+	return ParseRunnerOutput(pred.Output)
+}
+
+func waitDuration(secs int) time.Duration {
+	if secs <= 0 {
+		return 0
+	}
+	return time.Duration(secs) * time.Second
+}

--- a/internal/providers/replicate/client_test.go
+++ b/internal/providers/replicate/client_test.go
@@ -1,0 +1,321 @@
+package replicate
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestClientResolvesTokenAndSendsAuthorization(t *testing.T) {
+	t.Setenv(envReplicateToken, "vendor-token")
+	t.Setenv(envCrabboxReplicateToken, "crabbox-token")
+	var auth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth = r.Header.Get("Authorization")
+		_ = json.NewEncoder(w).Encode(map[string]any{"results": []any{}})
+	}))
+	defer srv.Close()
+
+	client, err := newReplicateClient(Config{Replicate: ReplicateConfig{APIURL: srv.URL}}, Runtime{HTTP: srv.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.ListPredictions(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if auth != "Bearer crabbox-token" {
+		t.Fatalf("Authorization=%q", auth)
+	}
+}
+
+func TestClientRequiresToken(t *testing.T) {
+	t.Setenv(envReplicateToken, "")
+	t.Setenv(envCrabboxReplicateToken, "")
+	_, err := newReplicateClient(Config{Replicate: ReplicateConfig{APIURL: "https://api.replicate.com/v1"}}, Runtime{})
+	if err == nil || !strings.Contains(err.Error(), "needs an API token") {
+		t.Fatalf("newReplicateClient error=%v", err)
+	}
+}
+
+func TestAPIURLValidation(t *testing.T) {
+	valid, err := validateReplicateAPIURL("https://API.Replicate.Com:443/v1/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if valid != "https://api.replicate.com/v1" {
+		t.Fatalf("validated URL=%q", valid)
+	}
+	if _, err := validateReplicateAPIURL("http://api.replicate.com/v1"); err == nil {
+		t.Fatal("non-loopback http URL unexpectedly passed")
+	}
+	if loopback, err := validateReplicateAPIURL("http://127.0.0.1:8080/v1"); err != nil || loopback != "http://127.0.0.1:8080/v1" {
+		t.Fatalf("loopback URL=%q err=%v", loopback, err)
+	}
+	if _, err := validateReplicateAPIURL("https://user:pass@api.replicate.com/v1"); err == nil {
+		t.Fatal("URL with userinfo unexpectedly passed")
+	}
+}
+
+func TestRedirectRefusesCrossOriginBeforeTokenReplay(t *testing.T) {
+	var targetRequests int
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		targetRequests++
+		t.Errorf("redirect target received %s %s auth=%q", r.Method, r.URL.Path, r.Header.Get("Authorization"))
+	}))
+	defer target.Close()
+
+	trusted := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/stolen", http.StatusTemporaryRedirect)
+	}))
+	defer trusted.Close()
+
+	t.Setenv(envCrabboxReplicateToken, "redirect-secret")
+	client, err := newReplicateClient(Config{Replicate: ReplicateConfig{APIURL: trusted.URL}}, Runtime{HTTP: trusted.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.ListPredictions(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "refused cross-origin redirect") {
+		t.Fatalf("ListPredictions error=%v", err)
+	}
+	if strings.Contains(err.Error(), "redirect-secret") {
+		t.Fatalf("error leaked token: %v", err)
+	}
+	if targetRequests != 0 {
+		t.Fatalf("redirect target requests=%d, want 0", targetRequests)
+	}
+}
+
+func TestRedirectFollowsSameOrigin(t *testing.T) {
+	var redirectedAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/predictions":
+			http.Redirect(w, r, "/v1/redirected", http.StatusTemporaryRedirect)
+		case "/v1/redirected":
+			redirectedAuth = r.Header.Get("Authorization")
+			_ = json.NewEncoder(w).Encode(map[string]any{"results": []any{}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv(envCrabboxReplicateToken, "same-origin-token")
+	client, err := newReplicateClient(Config{Replicate: ReplicateConfig{APIURL: server.URL + "/v1"}}, Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.ListPredictions(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if redirectedAuth != "Bearer same-origin-token" {
+		t.Fatalf("redirected Authorization=%q", redirectedAuth)
+	}
+}
+
+func TestRedactResponseErrors(t *testing.T) {
+	const token = "secret-token"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":"Authorization: Bearer secret-token token=secret-token"}`, http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	client := &replicateClient{http: server.Client(), baseURL: server.URL, token: token}
+	_, err := client.ListPredictions(context.Background())
+	if err == nil {
+		t.Fatal("ListPredictions unexpectedly passed")
+	}
+	if strings.Contains(err.Error(), token) {
+		t.Fatalf("error leaked token: %v", err)
+	}
+	if !strings.Contains(err.Error(), "[REDACTED]") {
+		t.Fatalf("error did not redact: %v", err)
+	}
+}
+
+func TestPredictionCreateDeploymentPreferAndCancelAfter(t *testing.T) {
+	var path, method, prefer, cancelAfter string
+	var body map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path = r.URL.Path
+		method = r.Method
+		prefer = r.Header.Get("Prefer")
+		cancelAfter = r.Header.Get("Cancel-After")
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":     "pred_123",
+			"status": "processing",
+			"logs":   "booting",
+			"output": map[string]any{"exit_code": 0, "stdout": "ok\n"},
+			"urls":   map[string]string{"get": "https://api.replicate.com/v1/predictions/pred_123", "cancel": "https://api.replicate.com/v1/predictions/pred_123/cancel"},
+		})
+	}))
+	defer server.Close()
+
+	client := &replicateClient{http: server.Client(), baseURL: server.URL, token: "tok"}
+	pred, err := client.CreatePrediction(context.Background(), replicateCreatePredictionRequest{
+		Deployment:      "alice/runner",
+		Input:           map[string]any{"archive_url": "data:application/gzip;base64,abc"},
+		WaitSecs:        5,
+		CancelAfterSecs: 30,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if method != http.MethodPost || path != "/deployments/alice/runner/predictions" {
+		t.Fatalf("request=%s %s", method, path)
+	}
+	if prefer != "wait=5" || cancelAfter != "30s" {
+		t.Fatalf("Prefer=%q Cancel-After=%q", prefer, cancelAfter)
+	}
+	input, ok := body["input"].(map[string]any)
+	if !ok || input["archive_url"] != "data:application/gzip;base64,abc" {
+		t.Fatalf("body=%v", body)
+	}
+	if pred.ID != "pred_123" || pred.Status != "processing" || pred.Logs != "booting" || pred.URLs.Cancel == "" {
+		t.Fatalf("prediction=%#v", pred)
+	}
+	out, err := parsePredictionOutput(pred)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.ExitCode != 0 || out.Stdout != "ok\n" {
+		t.Fatalf("runner output=%#v", out)
+	}
+}
+
+func TestPredictionCreateVersionPath(t *testing.T) {
+	var body map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/predictions" {
+			t.Fatalf("request=%s %s", r.Method, r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": "pred_version", "status": "starting"})
+	}))
+	defer server.Close()
+	client := &replicateClient{http: server.Client(), baseURL: server.URL, token: "tok"}
+	pred, err := client.CreatePrediction(context.Background(), replicateCreatePredictionRequest{
+		Version: "version-sha",
+		Input:   map[string]any{"command": []string{"go", "test"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if body["version"] != "version-sha" {
+		t.Fatalf("body=%v", body)
+	}
+	if pred.ID != "pred_version" {
+		t.Fatalf("prediction=%#v", pred)
+	}
+}
+
+func TestPredictionGetListAndCancel(t *testing.T) {
+	seen := []string{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = append(seen, r.Method+" "+r.URL.Path)
+		switch r.URL.Path {
+		case "/predictions":
+			_ = json.NewEncoder(w).Encode(map[string]any{"results": []map[string]any{{"id": "pred_1", "status": "succeeded"}}, "next": "cursor"})
+		case "/predictions/pred_1":
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "pred_1", "status": "succeeded", "output": map[string]any{"exit_code": 0}})
+		case "/predictions/pred_1/cancel":
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "pred_1", "status": "canceled"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	client := &replicateClient{http: server.Client(), baseURL: server.URL, token: "tok"}
+	list, err := client.ListPredictions(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list.Results) != 1 || list.Results[0].ID != "pred_1" || list.Next != "cursor" {
+		t.Fatalf("list=%#v", list)
+	}
+	got, err := client.GetPrediction(context.Background(), "pred_1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !predictionTerminal(got.Status) {
+		t.Fatalf("status %q should be terminal", got.Status)
+	}
+	canceled, err := client.CancelPrediction(context.Background(), "pred_1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if canceled.Status != "canceled" {
+		t.Fatalf("canceled=%#v", canceled)
+	}
+	want := []string{"GET /predictions", "GET /predictions/pred_1", "POST /predictions/pred_1/cancel"}
+	if !reflect.DeepEqual(seen, want) {
+		t.Fatalf("seen=%v want=%v", seen, want)
+	}
+}
+
+func TestPredictionAPIErrorsAndMalformedJSON(t *testing.T) {
+	t.Run("api error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, `{"detail":"bad"}`, http.StatusBadRequest)
+		}))
+		defer server.Close()
+		client := &replicateClient{http: server.Client(), baseURL: server.URL, token: "tok"}
+		_, err := client.GetPrediction(context.Background(), "pred")
+		if err == nil || !strings.Contains(err.Error(), "status=400") {
+			t.Fatalf("GetPrediction error=%v", err)
+		}
+	})
+	t.Run("malformed", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{`))
+		}))
+		defer server.Close()
+		client := &replicateClient{http: server.Client(), baseURL: server.URL, token: "tok"}
+		_, err := client.GetPrediction(context.Background(), "pred")
+		if err == nil || !strings.Contains(err.Error(), "decode") {
+			t.Fatalf("GetPrediction error=%v", err)
+		}
+	})
+}
+
+func TestPredictionCreateValidatesDeploymentTarget(t *testing.T) {
+	client := &replicateClient{http: http.DefaultClient, baseURL: "https://api.replicate.com/v1", token: "tok"}
+	_, err := client.CreatePrediction(context.Background(), replicateCreatePredictionRequest{Deployment: "missing-slash"})
+	if err == nil || !strings.Contains(err.Error(), "owner/name") {
+		t.Fatalf("CreatePrediction error=%v", err)
+	}
+}
+
+func TestClientUsesConfiguredRuntimeHTTP(t *testing.T) {
+	t.Setenv(envCrabboxReplicateToken, "tok")
+	client, err := newReplicateClient(Config{Replicate: ReplicateConfig{APIURL: "https://api.replicate.com/v1"}}, Runtime{HTTP: &http.Client{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.http == nil {
+		t.Fatal("client HTTP is nil")
+	}
+}
+
+func TestClientURLDefault(t *testing.T) {
+	t.Setenv(envCrabboxReplicateToken, "tok")
+	client, err := newReplicateClient(core.Config{}, Runtime{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.baseURL != defaultAPIURL {
+		t.Fatalf("baseURL=%q", client.baseURL)
+	}
+}

--- a/internal/providers/replicate/core.go
+++ b/internal/providers/replicate/core.go
@@ -1,9 +1,11 @@
 package replicate
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -15,6 +17,9 @@ type ReplicateConfig = core.ReplicateConfig
 type ProviderSpec = core.ProviderSpec
 type Runtime = core.Runtime
 type Backend = core.Backend
+type Repo = core.Repo
+type SyncManifest = core.SyncManifest
+type timingPhase = core.TimingPhase
 
 const (
 	providerName              = "replicate"
@@ -131,4 +136,24 @@ func flagWasSet(fs *flag.FlagSet, name string) bool {
 
 func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
+}
+
+func syncExcludes(root string, cfg Config) ([]string, error) {
+	return core.SyncExcludes(root, cfg)
+}
+
+func syncManifest(root string, excludes, includes []string) (SyncManifest, error) {
+	return core.BuildSyncManifestFiltered(root, excludes, includes)
+}
+
+func checkSyncPreflight(manifest SyncManifest, cfg Config, force bool, stderr io.Writer) error {
+	return core.CheckSyncPreflight(manifest, cfg, force, stderr)
+}
+
+func coreCreateSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, tempPattern string) (*os.File, error) {
+	return core.CreateSyncArchive(ctx, repo, manifest, tempPattern)
+}
+
+func blank(value, fallback string) string {
+	return core.Blank(value, fallback)
 }

--- a/internal/providers/replicate/core.go
+++ b/internal/providers/replicate/core.go
@@ -104,9 +104,6 @@ func ValidateConfig(cfg Config) error {
 	}
 	deployment := strings.TrimSpace(cfg.Replicate.Deployment)
 	version := strings.TrimSpace(cfg.Replicate.Version)
-	if deployment == "" && version == "" {
-		return core.Exit(2, "provider=replicate requires exactly one of replicate.deployment or replicate.version")
-	}
 	if deployment != "" && version != "" {
 		return core.Exit(2, "provider=replicate accepts exactly one of replicate.deployment or replicate.version, not both")
 	}
@@ -124,6 +121,18 @@ func ValidateConfig(cfg Config) error {
 	}
 	if cfg.Replicate.MaxArchiveBytes < 0 {
 		return core.Exit(2, "replicate maxArchiveBytes must be non-negative")
+	}
+	return nil
+}
+
+func validateRunnerTargetConfig(cfg Config) error {
+	deployment := strings.TrimSpace(cfg.Replicate.Deployment)
+	version := strings.TrimSpace(cfg.Replicate.Version)
+	if deployment == "" && version == "" {
+		return core.Exit(2, "provider=replicate requires exactly one of replicate.deployment or replicate.version")
+	}
+	if deployment != "" && version != "" {
+		return core.Exit(2, "provider=replicate accepts exactly one of replicate.deployment or replicate.version, not both")
 	}
 	return nil
 }

--- a/internal/providers/replicate/core.go
+++ b/internal/providers/replicate/core.go
@@ -102,6 +102,9 @@ func ValidateConfig(cfg Config) error {
 	if strings.TrimSpace(cfg.Provider) != providerName {
 		return nil
 	}
+	if cfg.Tailscale.Enabled || cfg.Network == core.NetworkTailscale {
+		return core.Exit(2, "provider=%s does not support Tailscale options", providerName)
+	}
 	deployment := strings.TrimSpace(cfg.Replicate.Deployment)
 	version := strings.TrimSpace(cfg.Replicate.Version)
 	if deployment != "" && version != "" {
@@ -133,6 +136,12 @@ func validateRunnerTargetConfig(cfg Config) error {
 	}
 	if deployment != "" && version != "" {
 		return core.Exit(2, "provider=replicate accepts exactly one of replicate.deployment or replicate.version, not both")
+	}
+	if deployment != "" {
+		owner, name, ok := strings.Cut(deployment, "/")
+		if !ok || strings.TrimSpace(owner) == "" || strings.TrimSpace(name) == "" || strings.Contains(name, "/") {
+			return core.Exit(2, "replicate deployment must use owner/name")
+		}
 	}
 	return nil
 }

--- a/internal/providers/replicate/core.go
+++ b/internal/providers/replicate/core.go
@@ -2,12 +2,15 @@ package replicate
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
@@ -17,8 +20,23 @@ type ReplicateConfig = core.ReplicateConfig
 type ProviderSpec = core.ProviderSpec
 type Runtime = core.Runtime
 type Backend = core.Backend
+type DoctorRequest = core.DoctorRequest
+type DoctorResult = core.DoctorResult
+type WarmupRequest = core.WarmupRequest
+type RunRequest = core.RunRequest
+type RunResult = core.RunResult
+type RunSessionHandle = core.RunSessionHandle
+type ListRequest = core.ListRequest
+type LeaseView = core.LeaseView
+type StatusRequest = core.StatusRequest
+type StatusView = core.StatusView
+type StopRequest = core.StopRequest
+type Server = core.Server
 type Repo = core.Repo
 type SyncManifest = core.SyncManifest
+type LeaseClaim = core.LeaseClaim
+type ExitError = core.ExitError
+type timingReport = core.TimingReport
 type timingPhase = core.TimingPhase
 
 const (
@@ -32,6 +50,10 @@ const (
 	defaultMaxArchiveBytes    = 10 * 1024 * 1024
 	envCrabboxReplicateToken  = "CRABBOX_REPLICATE_API_TOKEN"
 	envReplicateToken         = "REPLICATE_API_TOKEN"
+	leasePrefix               = "rbx_"
+	targetLinux               = core.TargetLinux
+	networkPublic             = core.NetworkPublic
+	statusViewReady           = "succeeded"
 	runnerExitCodeJSONName    = "exit_code"
 	runnerExitCodeAltJSONName = "exitCode"
 )
@@ -138,6 +160,30 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
+func writeTimingJSON(w io.Writer, report timingReport) error {
+	return core.WriteTimingJSON(w, report)
+}
+
+func timingReportWithRunResult(report timingReport, result RunResult, err error) timingReport {
+	return core.TimingReportWithRunResult(report, result, err)
+}
+
+func handleDelegatedRunFailure(w io.Writer, req RunRequest, provider, leaseID, slug string, idleTimeout, ttl time.Duration, acquired bool, shouldStop *bool) {
+	core.HandleDelegatedRunFailure(w, req, provider, leaseID, slug, idleTimeout, ttl, acquired, shouldStop)
+}
+
+func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {
+	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
+}
+
+func inventoryDoctorResult(provider string, leases int) DoctorResult {
+	return core.InventoryDoctorResult(provider, leases)
+}
+
+func rejectDelegatedSyncOptionsForSpec(spec ProviderSpec, req RunRequest) error {
+	return core.RejectDelegatedSyncOptionsForSpec(spec, req)
+}
+
 func syncExcludes(root string, cfg Config) ([]string, error) {
 	return core.SyncExcludes(root, cfg)
 }
@@ -156,4 +202,49 @@ func coreCreateSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest
 
 func blank(value, fallback string) string {
 	return core.Blank(value, fallback)
+}
+
+func newLeaseSlug(leaseID string) string {
+	return core.NewLeaseSlug(leaseID)
+}
+
+func normalizeLeaseSlug(value string) string {
+	return core.NormalizeLeaseSlug(value)
+}
+
+func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
+	return core.AllocateClaimLeaseSlug(leaseID, requested)
+}
+
+func claimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
+	return core.ClaimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot, idleTimeout, reclaim)
+}
+
+func readLeaseClaim(leaseID string) (core.LeaseClaim, error) {
+	return core.ReadLeaseClaim(leaseID)
+}
+
+func listReplicateLeaseClaims() ([]core.LeaseClaim, error) {
+	return core.ListLeaseClaimsWithPrefix(leasePrefix)
+}
+
+func removeLeaseClaim(leaseID string) {
+	core.RemoveLeaseClaim(leaseID)
+}
+
+func shouldUseShell(command []string) bool {
+	return core.ShouldUseShell(command)
+}
+
+func shellScriptFromArgv(command []string) string {
+	return core.ShellScriptFromArgv(command)
+}
+
+func shellQuote(s string) string {
+	return core.ShellQuote(s)
+}
+
+func replicateEndpointScope(baseURL string) string {
+	digest := sha256.Sum256([]byte(baseURL))
+	return "replicate-endpoint-sha256:" + hex.EncodeToString(digest[:])
 }

--- a/internal/providers/replicate/core.go
+++ b/internal/providers/replicate/core.go
@@ -1,0 +1,134 @@
+package replicate
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type Config = core.Config
+type ReplicateConfig = core.ReplicateConfig
+type ProviderSpec = core.ProviderSpec
+type Runtime = core.Runtime
+type Backend = core.Backend
+
+const (
+	providerName              = "replicate"
+	defaultAPIURL             = "https://api.replicate.com/v1"
+	defaultWorkdir            = "/workspace/crabbox"
+	defaultWaitSecs           = 0
+	defaultPollIntervalSecs   = 2
+	defaultExecTimeoutSecs    = 3600
+	defaultCancelAfterSecs    = 0
+	defaultMaxArchiveBytes    = 10 * 1024 * 1024
+	envCrabboxReplicateToken  = "CRABBOX_REPLICATE_API_TOKEN"
+	envReplicateToken         = "REPLICATE_API_TOKEN"
+	runnerExitCodeJSONName    = "exit_code"
+	runnerExitCodeAltJSONName = "exitCode"
+)
+
+type RunnerInput struct {
+	Command      []string          `json:"command"`
+	Workdir      string            `json:"workdir"`
+	ArchiveURL   string            `json:"archive_url,omitempty"`
+	Env          map[string]string `json:"env,omitempty"`
+	TimeoutSecs  int               `json:"timeout_secs,omitempty"`
+	CancelAfter  int               `json:"cancel_after_secs,omitempty"`
+	MaxLogBytes  int               `json:"max_log_bytes,omitempty"`
+	Metadata     map[string]string `json:"metadata,omitempty"`
+	OutputSchema string            `json:"output_schema,omitempty"`
+}
+
+type RunnerOutput struct {
+	ExitCode int    `json:"exit_code"`
+	Stdout   string `json:"stdout,omitempty"`
+	Stderr   string `json:"stderr,omitempty"`
+}
+
+func DefaultConfig() ReplicateConfig {
+	return ReplicateConfig{
+		APIURL:           defaultAPIURL,
+		Workdir:          defaultWorkdir,
+		WaitSecs:         defaultWaitSecs,
+		PollIntervalSecs: defaultPollIntervalSecs,
+		ExecTimeoutSecs:  defaultExecTimeoutSecs,
+		CancelAfterSecs:  defaultCancelAfterSecs,
+		MaxArchiveBytes:  defaultMaxArchiveBytes,
+	}
+}
+
+func ResolveAPIToken() (string, string, bool) {
+	if token := strings.TrimSpace(os.Getenv(envCrabboxReplicateToken)); token != "" {
+		return token, envCrabboxReplicateToken, true
+	}
+	if token := strings.TrimSpace(os.Getenv(envReplicateToken)); token != "" {
+		return token, envReplicateToken, true
+	}
+	return "", "", false
+}
+
+func ValidateConfig(cfg Config) error {
+	if strings.TrimSpace(cfg.Provider) != providerName {
+		return nil
+	}
+	deployment := strings.TrimSpace(cfg.Replicate.Deployment)
+	version := strings.TrimSpace(cfg.Replicate.Version)
+	if deployment == "" && version == "" {
+		return core.Exit(2, "provider=replicate requires exactly one of replicate.deployment or replicate.version")
+	}
+	if deployment != "" && version != "" {
+		return core.Exit(2, "provider=replicate accepts exactly one of replicate.deployment or replicate.version, not both")
+	}
+	if cfg.Replicate.WaitSecs < 0 {
+		return core.Exit(2, "replicate waitSecs must be non-negative")
+	}
+	if cfg.Replicate.PollIntervalSecs < 0 {
+		return core.Exit(2, "replicate pollIntervalSecs must be non-negative")
+	}
+	if cfg.Replicate.ExecTimeoutSecs < 0 {
+		return core.Exit(2, "replicate execTimeoutSecs must be non-negative")
+	}
+	if cfg.Replicate.CancelAfterSecs < 0 {
+		return core.Exit(2, "replicate cancelAfterSecs must be non-negative")
+	}
+	if cfg.Replicate.MaxArchiveBytes < 0 {
+		return core.Exit(2, "replicate maxArchiveBytes must be non-negative")
+	}
+	return nil
+}
+
+func ParseRunnerOutput(data []byte) (RunnerOutput, error) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return RunnerOutput{}, fmt.Errorf("decode replicate runner output: %w", err)
+	}
+	exitRaw, ok := raw[runnerExitCodeJSONName]
+	if !ok {
+		exitRaw, ok = raw[runnerExitCodeAltJSONName]
+	}
+	if !ok {
+		return RunnerOutput{}, fmt.Errorf("replicate runner output missing required exit_code")
+	}
+	var exitCode int
+	if err := json.Unmarshal(exitRaw, &exitCode); err != nil {
+		return RunnerOutput{}, fmt.Errorf("replicate runner output exit_code must be an integer: %w", err)
+	}
+	var out RunnerOutput
+	if err := json.Unmarshal(data, &out); err != nil {
+		return RunnerOutput{}, fmt.Errorf("decode replicate runner output fields: %w", err)
+	}
+	out.ExitCode = exitCode
+	return out, nil
+}
+
+func flagWasSet(fs *flag.FlagSet, name string) bool {
+	return core.FlagWasSet(fs, name)
+}
+
+func exit(code int, format string, args ...any) core.ExitError {
+	return core.Exit(code, format, args...)
+}

--- a/internal/providers/replicate/core_test.go
+++ b/internal/providers/replicate/core_test.go
@@ -1,0 +1,43 @@
+package replicate
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseRunnerOutputRequiresIntegerExitCode(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		payload string
+		wantErr string
+	}{
+		{name: "missing", payload: `{"stdout":"ok","status":"succeeded"}`, wantErr: "missing required exit_code"},
+		{name: "string", payload: `{"exit_code":"0"}`, wantErr: "must be an integer"},
+		{name: "float", payload: `{"exit_code":0.5}`, wantErr: "must be an integer"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := ParseRunnerOutput([]byte(tc.payload)); err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("ParseRunnerOutput error=%v want %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestParseRunnerOutputPreservesExitCode(t *testing.T) {
+	out, err := ParseRunnerOutput([]byte(`{"status":"succeeded","exit_code":7,"stdout":"out","stderr":"err"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.ExitCode != 7 || out.Stdout != "out" || out.Stderr != "err" {
+		t.Fatalf("output=%#v", out)
+	}
+}
+
+func TestResolveAPITokenPrecedence(t *testing.T) {
+	t.Setenv(envReplicateToken, "vendor-token")
+	t.Setenv(envCrabboxReplicateToken, "crabbox-token")
+	token, source, ok := ResolveAPIToken()
+	if !ok || token != "crabbox-token" || source != envCrabboxReplicateToken {
+		t.Fatalf("token=%q source=%q ok=%t", token, source, ok)
+	}
+}

--- a/internal/providers/replicate/flags.go
+++ b/internal/providers/replicate/flags.go
@@ -1,0 +1,72 @@
+package replicate
+
+import "flag"
+
+type replicateFlagValues struct {
+	APIURL           *string
+	Deployment       *string
+	Version          *string
+	Workdir          *string
+	WaitSecs         *int
+	PollIntervalSecs *int
+	ExecTimeoutSecs  *int
+	CancelAfterSecs  *int
+	MaxArchiveBytes  *int64
+}
+
+func RegisterReplicateProviderFlags(fs *flag.FlagSet, defaults Config) any {
+	return replicateFlagValues{
+		APIURL:           fs.String("replicate-api-url", defaults.Replicate.APIURL, "Replicate API base URL"),
+		Deployment:       fs.String("replicate-deployment", defaults.Replicate.Deployment, "Replicate deployment name or owner/name identifier"),
+		Version:          fs.String("replicate-version", defaults.Replicate.Version, "Replicate model version identifier"),
+		Workdir:          fs.String("replicate-workdir", defaults.Replicate.Workdir, "Absolute working directory inside the Replicate runner"),
+		WaitSecs:         fs.Int("replicate-wait-secs", defaults.Replicate.WaitSecs, "Replicate prediction wait window in seconds (0 = provider default)"),
+		PollIntervalSecs: fs.Int("replicate-poll-interval-secs", defaults.Replicate.PollIntervalSecs, "Replicate prediction polling interval in seconds"),
+		ExecTimeoutSecs:  fs.Int("replicate-exec-timeout-secs", defaults.Replicate.ExecTimeoutSecs, "Replicate command timeout in seconds"),
+		CancelAfterSecs:  fs.Int("replicate-cancel-after-secs", defaults.Replicate.CancelAfterSecs, "Cancel Replicate prediction after this many seconds (0 = disabled)"),
+		MaxArchiveBytes:  fs.Int64("replicate-max-archive-bytes", defaults.Replicate.MaxArchiveBytes, "Maximum archive size for Replicate data URL sync"),
+	}
+}
+
+func ApplyReplicateProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+	if cfg.Provider == providerName {
+		if flagWasSet(fs, "class") {
+			return exit(2, "--class is not supported for provider=replicate")
+		}
+		if flagWasSet(fs, "type") {
+			return exit(2, "--type is not supported for provider=replicate")
+		}
+	}
+	v, ok := values.(replicateFlagValues)
+	if !ok {
+		return nil
+	}
+	if flagWasSet(fs, "replicate-api-url") {
+		cfg.Replicate.APIURL = *v.APIURL
+	}
+	if flagWasSet(fs, "replicate-deployment") {
+		cfg.Replicate.Deployment = *v.Deployment
+	}
+	if flagWasSet(fs, "replicate-version") {
+		cfg.Replicate.Version = *v.Version
+	}
+	if flagWasSet(fs, "replicate-workdir") {
+		cfg.Replicate.Workdir = *v.Workdir
+	}
+	if flagWasSet(fs, "replicate-wait-secs") {
+		cfg.Replicate.WaitSecs = *v.WaitSecs
+	}
+	if flagWasSet(fs, "replicate-poll-interval-secs") {
+		cfg.Replicate.PollIntervalSecs = *v.PollIntervalSecs
+	}
+	if flagWasSet(fs, "replicate-exec-timeout-secs") {
+		cfg.Replicate.ExecTimeoutSecs = *v.ExecTimeoutSecs
+	}
+	if flagWasSet(fs, "replicate-cancel-after-secs") {
+		cfg.Replicate.CancelAfterSecs = *v.CancelAfterSecs
+	}
+	if flagWasSet(fs, "replicate-max-archive-bytes") {
+		cfg.Replicate.MaxArchiveBytes = *v.MaxArchiveBytes
+	}
+	return nil
+}

--- a/internal/providers/replicate/flags_test.go
+++ b/internal/providers/replicate/flags_test.go
@@ -1,0 +1,57 @@
+package replicate
+
+import (
+	"flag"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestApplyReplicateProviderFlagsOnlyWhenExplicit(t *testing.T) {
+	cfg := core.Config{
+		Provider: "replicate",
+		Replicate: ReplicateConfig{
+			APIURL:           "https://api.replicate.com/v1",
+			Deployment:       "owner/initial",
+			Workdir:          "/workspace/original",
+			WaitSecs:         1,
+			PollIntervalSecs: 2,
+			ExecTimeoutSecs:  3,
+			CancelAfterSecs:  4,
+			MaxArchiveBytes:  5,
+		},
+	}
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	values := RegisterReplicateProviderFlags(fs, cfg)
+	if err := fs.Parse([]string{
+		"--replicate-version", "version-123",
+		"--replicate-workdir", "/workspace/next",
+		"--replicate-wait-secs", "10",
+		"--replicate-poll-interval-secs", "11",
+		"--replicate-exec-timeout-secs", "12",
+		"--replicate-cancel-after-secs", "13",
+		"--replicate-max-archive-bytes", "14",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := ApplyReplicateProviderFlags(&cfg, fs, values); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Replicate.APIURL != "https://api.replicate.com/v1" {
+		t.Fatalf("APIURL changed without explicit flag: %#v", cfg.Replicate)
+	}
+	if cfg.Replicate.Deployment != "owner/initial" || cfg.Replicate.Version != "version-123" || cfg.Replicate.Workdir != "/workspace/next" {
+		t.Fatalf("string flags not applied correctly: %#v", cfg.Replicate)
+	}
+	if cfg.Replicate.WaitSecs != 10 || cfg.Replicate.PollIntervalSecs != 11 || cfg.Replicate.ExecTimeoutSecs != 12 || cfg.Replicate.CancelAfterSecs != 13 || cfg.Replicate.MaxArchiveBytes != 14 {
+		t.Fatalf("numeric flags not applied correctly: %#v", cfg.Replicate)
+	}
+}
+
+func TestReplicateProviderFlagsDoNotExposeToken(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	RegisterReplicateProviderFlags(fs, core.Config{Replicate: DefaultConfig()})
+	if fs.Lookup("replicate-api-token") != nil {
+		t.Fatal("unexpected --replicate-api-token flag")
+	}
+}

--- a/internal/providers/replicate/provider.go
+++ b/internal/providers/replicate/provider.go
@@ -1,0 +1,90 @@
+package replicate
+
+import (
+	"context"
+	"flag"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func init() {
+	core.RegisterProvider(Provider{})
+}
+
+type Provider struct{}
+
+func (Provider) Name() string      { return providerName }
+func (Provider) Aliases() []string { return nil }
+
+func (Provider) Spec() core.ProviderSpec {
+	return core.ProviderSpec{
+		Name:        providerName,
+		Family:      "replicate",
+		Kind:        core.ProviderKindDelegatedRun,
+		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:    core.FeatureSet{core.FeatureArchiveSync, core.FeatureRunSession},
+		Coordinator: core.CoordinatorNever,
+	}
+}
+
+func (Provider) RegisterFlags(fs *flag.FlagSet, defaults core.Config) any {
+	return RegisterReplicateProviderFlags(fs, defaults)
+}
+
+func (Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
+	return ApplyReplicateProviderFlags(cfg, fs, values)
+}
+
+func (Provider) ValidateConfig(cfg core.Config) error {
+	return ValidateConfig(cfg)
+}
+
+func (p Provider) Configure(core.Config, core.Runtime) (core.Backend, error) {
+	return replicateBackend{spec: p.Spec()}, nil
+}
+
+func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
+	backend, err := p.Configure(cfg, rt)
+	if err != nil {
+		return nil, err
+	}
+	doctor, ok := backend.(core.DoctorBackend)
+	if !ok {
+		return nil, core.Exit(2, "replicate doctor backend unavailable")
+	}
+	return doctor, nil
+}
+
+type replicateBackend struct {
+	spec core.ProviderSpec
+}
+
+func (b replicateBackend) Spec() core.ProviderSpec { return b.spec }
+
+func (b replicateBackend) Doctor(context.Context, core.DoctorRequest) (core.DoctorResult, error) {
+	return core.DoctorResult{
+		Provider: providerName,
+		Message:  "auth=unchecked control_plane=unchecked inventory=unchecked api=not-implemented mutation=false leases=0 runtime=unchecked",
+		Status:   "not-implemented",
+	}, nil
+}
+
+func (b replicateBackend) Warmup(context.Context, core.WarmupRequest) error {
+	return exit(2, "provider=replicate backend lifecycle is not implemented in this build")
+}
+
+func (b replicateBackend) Run(context.Context, core.RunRequest) (core.RunResult, error) {
+	return core.RunResult{}, exit(2, "provider=replicate backend lifecycle is not implemented in this build")
+}
+
+func (b replicateBackend) List(context.Context, core.ListRequest) ([]core.LeaseView, error) {
+	return nil, exit(2, "provider=replicate backend lifecycle is not implemented in this build")
+}
+
+func (b replicateBackend) Status(context.Context, core.StatusRequest) (core.StatusView, error) {
+	return core.StatusView{}, exit(2, "provider=replicate backend lifecycle is not implemented in this build")
+}
+
+func (b replicateBackend) Stop(context.Context, core.StopRequest) error {
+	return exit(2, "provider=replicate backend lifecycle is not implemented in this build")
+}

--- a/internal/providers/replicate/provider.go
+++ b/internal/providers/replicate/provider.go
@@ -1,7 +1,6 @@
 package replicate
 
 import (
-	"context"
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
@@ -39,8 +38,8 @@ func (Provider) ValidateConfig(cfg core.Config) error {
 	return ValidateConfig(cfg)
 }
 
-func (p Provider) Configure(core.Config, core.Runtime) (core.Backend, error) {
-	return replicateBackend{spec: p.Spec()}, nil
+func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
+	return NewReplicateBackend(p.Spec(), cfg, rt), nil
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
@@ -53,38 +52,4 @@ func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.Doctor
 		return nil, core.Exit(2, "replicate doctor backend unavailable")
 	}
 	return doctor, nil
-}
-
-type replicateBackend struct {
-	spec core.ProviderSpec
-}
-
-func (b replicateBackend) Spec() core.ProviderSpec { return b.spec }
-
-func (b replicateBackend) Doctor(context.Context, core.DoctorRequest) (core.DoctorResult, error) {
-	return core.DoctorResult{
-		Provider: providerName,
-		Message:  "auth=unchecked control_plane=unchecked inventory=unchecked api=not-implemented mutation=false leases=0 runtime=unchecked",
-		Status:   "not-implemented",
-	}, nil
-}
-
-func (b replicateBackend) Warmup(context.Context, core.WarmupRequest) error {
-	return exit(2, "provider=replicate backend lifecycle is not implemented in this build")
-}
-
-func (b replicateBackend) Run(context.Context, core.RunRequest) (core.RunResult, error) {
-	return core.RunResult{}, exit(2, "provider=replicate backend lifecycle is not implemented in this build")
-}
-
-func (b replicateBackend) List(context.Context, core.ListRequest) ([]core.LeaseView, error) {
-	return nil, exit(2, "provider=replicate backend lifecycle is not implemented in this build")
-}
-
-func (b replicateBackend) Status(context.Context, core.StatusRequest) (core.StatusView, error) {
-	return core.StatusView{}, exit(2, "provider=replicate backend lifecycle is not implemented in this build")
-}
-
-func (b replicateBackend) Stop(context.Context, core.StopRequest) error {
-	return exit(2, "provider=replicate backend lifecycle is not implemented in this build")
 }

--- a/internal/providers/replicate/provider_test.go
+++ b/internal/providers/replicate/provider_test.go
@@ -1,0 +1,54 @@
+package replicate
+
+import (
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestProviderSpec(t *testing.T) {
+	p := Provider{}
+	if p.Name() != "replicate" {
+		t.Fatalf("Name=%q", p.Name())
+	}
+	if p.Aliases() != nil {
+		t.Fatalf("Aliases=%v, want nil", p.Aliases())
+	}
+	spec := p.Spec()
+	if spec.Name != "replicate" || spec.Family != "replicate" || spec.Kind != core.ProviderKindDelegatedRun || spec.Coordinator != core.CoordinatorNever {
+		t.Fatalf("spec=%#v", spec)
+	}
+	if len(spec.Targets) != 1 || spec.Targets[0].OS != core.TargetLinux {
+		t.Fatalf("targets=%#v", spec.Targets)
+	}
+	if !spec.Features.Has(core.FeatureArchiveSync) || !spec.Features.Has(core.FeatureRunSession) {
+		t.Fatalf("features=%v", spec.Features)
+	}
+	if _, ok := any(replicateBackend{}).(core.DelegatedRunBackend); !ok {
+		t.Fatal("replicate backend does not satisfy delegated run contract")
+	}
+}
+
+func TestValidateConfigRequiresExactlyOneTarget(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cfg  core.Config
+		ok   bool
+	}{
+		{name: "deployment", cfg: core.Config{Provider: "replicate", Replicate: ReplicateConfig{Deployment: "owner/deploy"}}, ok: true},
+		{name: "version", cfg: core.Config{Provider: "replicate", Replicate: ReplicateConfig{Version: "v1"}}, ok: true},
+		{name: "missing", cfg: core.Config{Provider: "replicate"}, ok: false},
+		{name: "both", cfg: core.Config{Provider: "replicate", Replicate: ReplicateConfig{Deployment: "owner/deploy", Version: "v1"}}, ok: false},
+		{name: "other provider", cfg: core.Config{Provider: "modal"}, ok: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateConfig(tc.cfg)
+			if tc.ok && err != nil {
+				t.Fatalf("ValidateConfig unexpected error: %v", err)
+			}
+			if !tc.ok && err == nil {
+				t.Fatal("ValidateConfig unexpectedly passed")
+			}
+		})
+	}
+}

--- a/internal/providers/replicate/provider_test.go
+++ b/internal/providers/replicate/provider_test.go
@@ -39,6 +39,8 @@ func TestValidateConfigAllowsMissingRunnerTargetForExistingPredictionCommands(t 
 		{name: "version", cfg: core.Config{Provider: "replicate", Replicate: ReplicateConfig{Version: "v1"}}, ok: true},
 		{name: "missing", cfg: core.Config{Provider: "replicate"}, ok: true},
 		{name: "both", cfg: core.Config{Provider: "replicate", Replicate: ReplicateConfig{Deployment: "owner/deploy", Version: "v1"}}, ok: false},
+		{name: "tailscale enabled", cfg: core.Config{Provider: "replicate", Replicate: ReplicateConfig{Deployment: "owner/deploy"}, Tailscale: core.TailscaleConfig{Enabled: true}}, ok: false},
+		{name: "tailscale network", cfg: core.Config{Provider: "replicate", Replicate: ReplicateConfig{Deployment: "owner/deploy"}, Network: core.NetworkTailscale}, ok: false},
 		{name: "other provider", cfg: core.Config{Provider: "modal"}, ok: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/providers/replicate/provider_test.go
+++ b/internal/providers/replicate/provider_test.go
@@ -29,7 +29,7 @@ func TestProviderSpec(t *testing.T) {
 	}
 }
 
-func TestValidateConfigRequiresExactlyOneTarget(t *testing.T) {
+func TestValidateConfigAllowsMissingRunnerTargetForExistingPredictionCommands(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		cfg  core.Config
@@ -37,7 +37,7 @@ func TestValidateConfigRequiresExactlyOneTarget(t *testing.T) {
 	}{
 		{name: "deployment", cfg: core.Config{Provider: "replicate", Replicate: ReplicateConfig{Deployment: "owner/deploy"}}, ok: true},
 		{name: "version", cfg: core.Config{Provider: "replicate", Replicate: ReplicateConfig{Version: "v1"}}, ok: true},
-		{name: "missing", cfg: core.Config{Provider: "replicate"}, ok: false},
+		{name: "missing", cfg: core.Config{Provider: "replicate"}, ok: true},
 		{name: "both", cfg: core.Config{Provider: "replicate", Replicate: ReplicateConfig{Deployment: "owner/deploy", Version: "v1"}}, ok: false},
 		{name: "other provider", cfg: core.Config{Provider: "modal"}, ok: true},
 	} {

--- a/internal/providers/replicate/sync.go
+++ b/internal/providers/replicate/sync.go
@@ -1,0 +1,90 @@
+package replicate
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"os"
+	"time"
+)
+
+const replicateArchiveDataURLPrefix = "data:application/gzip;base64,"
+
+type replicateArchiveInput struct {
+	DataURL  string
+	Phases   []timingPhase
+	Duration time.Duration
+	Size     int64
+}
+
+func buildReplicateArchiveDataURL(ctx context.Context, cfg Config, rt Runtime, repo Repo, force bool) (replicateArchiveInput, error) {
+	now := time.Now
+	if rt.Clock != nil {
+		now = rt.Clock.Now
+	}
+	stderr := rt.Stderr
+	if stderr == nil {
+		stderr = io.Discard
+	}
+	start := now()
+	excludes, err := syncExcludes(repo.Root, cfg)
+	if err != nil {
+		return replicateArchiveInput{}, err
+	}
+	manifestStarted := now()
+	manifest, err := syncManifest(repo.Root, excludes, cfg.Sync.Includes)
+	if err != nil {
+		return replicateArchiveInput{}, exit(6, "build sync file list: %v", err)
+	}
+	manifestDuration := now().Sub(manifestStarted)
+	preflightStarted := now()
+	archiveManifest := manifest
+	archiveManifest.Changed = nil
+	archiveManifest.ChangedBytes = 0
+	if err := checkSyncPreflight(archiveManifest, cfg, force, stderr); err != nil {
+		return replicateArchiveInput{}, err
+	}
+	preflightDuration := now().Sub(preflightStarted)
+	archiveStarted := now()
+	archive, err := createReplicateSyncArchive(ctx, repo, manifest)
+	if err != nil {
+		return replicateArchiveInput{}, err
+	}
+	defer func() {
+		_ = archive.Close()
+		_ = os.Remove(archive.Name())
+	}()
+	archiveDuration := now().Sub(archiveStarted)
+	info, err := archive.Stat()
+	if err != nil {
+		return replicateArchiveInput{}, exit(6, "stat replicate sync archive: %v", err)
+	}
+	size := info.Size()
+	if cfg.Replicate.MaxArchiveBytes > 0 && size > cfg.Replicate.MaxArchiveBytes {
+		return replicateArchiveInput{}, exit(6, "replicate archive too large: %d bytes > replicate.maxArchiveBytes %d; reduce sync scope or increase replicate.maxArchiveBytes intentionally", size, cfg.Replicate.MaxArchiveBytes)
+	}
+	encodeStarted := now()
+	data, err := io.ReadAll(archive)
+	if err != nil {
+		return replicateArchiveInput{}, fmt.Errorf("read replicate sync archive: %w", err)
+	}
+	encodeDuration := now().Sub(encodeStarted)
+	total := now().Sub(start)
+	return replicateArchiveInput{
+		DataURL: replicateArchiveDataURLPrefix + base64.StdEncoding.EncodeToString(data),
+		Phases: []timingPhase{
+			{Name: "manifest", Ms: manifestDuration.Milliseconds()},
+			{Name: "preflight", Ms: preflightDuration.Milliseconds()},
+			{Name: "archive", Ms: archiveDuration.Milliseconds()},
+			{Name: "encode", Ms: encodeDuration.Milliseconds()},
+			{Name: "replicate_archive_sync", Ms: total.Milliseconds()},
+		},
+		Duration: total,
+		Size:     size,
+	}, nil
+}
+
+func createReplicateSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest) (*os.File, error) {
+	return coreCreateSyncArchive(ctx, repo, manifest, "crabbox-replicate-sync-*.tgz")
+}

--- a/internal/providers/replicate/sync_test.go
+++ b/internal/providers/replicate/sync_test.go
@@ -1,0 +1,149 @@
+package replicate
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/base64"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestArchiveDataURLBuildsGzipDataURL(t *testing.T) {
+	root := newReplicateTestRepo(t, map[string]string{"main.go": "package main\n", "README.md": "hello\n"})
+	result, err := buildReplicateArchiveDataURL(context.Background(), Config{
+		Replicate: ReplicateConfig{MaxArchiveBytes: 1024 * 1024},
+	}, Runtime{}, core.Repo{Root: root, Name: "repo"}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(result.DataURL, replicateArchiveDataURLPrefix) {
+		t.Fatalf("data URL prefix missing: %q", result.DataURL[:min(len(result.DataURL), len(replicateArchiveDataURLPrefix))])
+	}
+	payload := strings.TrimPrefix(result.DataURL, replicateArchiveDataURLPrefix)
+	raw, err := base64.StdEncoding.DecodeString(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	files := readArchiveFiles(t, raw)
+	if files["main.go"] != "package main\n" || files["README.md"] != "hello\n" {
+		t.Fatalf("archive files=%v", files)
+	}
+	if result.Size <= 0 || len(result.Phases) == 0 {
+		t.Fatalf("archive result=%#v", result)
+	}
+}
+
+func TestMaxArchiveRejectsBeforePredictionCreate(t *testing.T) {
+	root := newReplicateTestRepo(t, map[string]string{"large.txt": strings.Repeat("x", 4096)})
+	createCalled := false
+	_, err := buildArchiveThenCreatePrediction(context.Background(), Config{
+		Replicate: ReplicateConfig{MaxArchiveBytes: 1},
+	}, Runtime{}, core.Repo{Root: root, Name: "repo"}, func(context.Context, string) error {
+		createCalled = true
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "replicate archive too large") {
+		t.Fatalf("buildArchiveThenCreatePrediction error=%v", err)
+	}
+	if createCalled {
+		t.Fatal("prediction create callback was called after max archive failure")
+	}
+}
+
+func TestArchiveDataURLAllowsExplicitZeroMaxArchive(t *testing.T) {
+	root := newReplicateTestRepo(t, map[string]string{"file.txt": "ok\n"})
+	result, err := buildReplicateArchiveDataURL(context.Background(), Config{
+		Replicate: ReplicateConfig{MaxArchiveBytes: 0},
+	}, Runtime{}, core.Repo{Root: root, Name: "repo"}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.DataURL == "" {
+		t.Fatal("empty data URL")
+	}
+}
+
+func buildArchiveThenCreatePrediction(ctx context.Context, cfg Config, rt Runtime, repo Repo, create func(context.Context, string) error) (replicateArchiveInput, error) {
+	archive, err := buildReplicateArchiveDataURL(ctx, cfg, rt, repo, false)
+	if err != nil {
+		return replicateArchiveInput{}, err
+	}
+	if err := create(ctx, archive.DataURL); err != nil {
+		return replicateArchiveInput{}, err
+	}
+	return archive, nil
+}
+
+func newReplicateTestRepo(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	runGit(t, root, "init", "-b", "main")
+	runGit(t, root, "config", "user.email", "alice@example.com")
+	runGit(t, root, "config", "user.name", "Alice Example")
+	for name, content := range files {
+		full := filepath.Join(root, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	runGit(t, root, "add", ".")
+	runGit(t, root, "commit", "-m", "initial")
+	return root
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+func readArchiveFiles(t *testing.T, payload []byte) map[string]string {
+	t.Helper()
+	gz, err := gzip.NewReader(bytes.NewReader(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer gz.Close()
+	tr := tar.NewReader(gz)
+	files := map[string]string{}
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		if header.Typeflag != tar.TypeReg {
+			continue
+		}
+		data, err := io.ReadAll(tr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		files[header.Name] = string(data)
+	}
+	return files
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}


### PR DESCRIPTION
Closes https://github.com/openclaw/crabbox/issues/691

## Summary

Adds Replicate as a Linux delegated-run provider with:

- provider registration, config/env/flag support, metadata, docs, and provider matrix updates
- Replicate REST client support with API URL validation, redirect protection, token redaction, prediction create/get/cancel handling, and bounded archive data URL sync
- delegated run lifecycle for creating predictions, polling logs/status, mapping runner exit codes, storing local claims, listing local claims, status lookup, and stop/cancel cleanup
- safety checks for provider auth provenance, runner env forwarding, unsupported Tailscale configuration, malformed runner targets, claim setup failures, and existing-prediction cleanup without a configured runner target

No live Replicate billing smoke is included; docs classify live smoke script proof as deferred until a guarded script exists.

## Verification

- `go test -count=1 -race ./internal/providers/replicate`
- `go test -count=1 -race ./internal/providers/all ./internal/cli -run 'Replicate|ProviderFor|Config|CredentialDestination|ConfigMergeSourceBindsDirectProviderCredentials|Tailscale'`
- `go test -count=1 -race ./...`
- `scripts/test-go-modules.sh`
- `scripts/check-go-coverage.sh 90.0` (`Go core coverage 91.4% >= 90.0%`)
- `go vet ./...`
- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- `node scripts/generate-provider-matrix.mjs && node scripts/check-provider-matrix.mjs && scripts/check-docs.sh`
- `node --test scripts/*.test.js` (`343` tests passed)
- outside-source `crabbox providers --json` assertion for Replicate metadata
- outside-source missing-auth `crabbox doctor --provider replicate --replicate-deployment owner/runner --json` assertion with Replicate token env cleared
- `autoreview --mode branch --base origin/main` clean

