### PR TITLE
fix: wait for EC2 Mac host reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,8 @@
 
 ### Fixed
 
-- Scoped managed AWS security groups per coordinator actor, preserved lease-declared CIDRs across heartbeats, and allowed owners to reuse their own released EC2 Mac hosts without admin-token pinning, preventing concurrent leases from revoking access and avoiding stranded presentation capacity.
+- Scoped managed AWS security groups per coordinator actor and preserved lease-declared CIDRs across heartbeats, preventing concurrent leases from revoking SSH and WebVNC access.
+- Allowed owners to reuse their own released EC2 Mac hosts without admin-token pinning and made pinned launches wait for the previous instance's capacity handoff.
 - Forced managed AWS macOS leases onto Apple's socket-activated Remote Login port 22, preventing inherited SSH-port settings from producing unreachable lease metadata and stalled WebVNC bridges.
 - Restored incomplete Linux Node.js toolchains through NodeSource when `npm` or Corepack is missing, preventing source installers from failing on otherwise valid images.
 - Rejected AWS developer-tool images older than Node.js 24 during candidate smoke validation.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -363,8 +363,9 @@ Managed provider targets are intentionally narrow:
   Windows for desktop/VNC; use WSL2 for Linux tooling on a Windows host.
 - AWS also supports EC2 Mac (`--target macos`) when an available Mac Dedicated
   Host exists in the selected region. Brokered mode can discover an available
-  host; explicit brokered host pinning requires admin authentication, while
-  direct mode requires `CRABBOX_HOST_ID` or `hostId`. `CRABBOX_AWS_MAC_HOST_ID`
+  host; explicit brokered host pinning requires admin authentication unless the
+  owner is reusing a host from their own released lease. Direct mode requires
+  `CRABBOX_HOST_ID` or `hostId`. `CRABBOX_AWS_MAC_HOST_ID`
   and `aws.macHostId` remain AWS compatibility aliases. Azure has no managed macOS
   target.
 - Existing macOS and Windows machines belong on `provider: ssh`.
@@ -495,7 +496,7 @@ CRABBOX_AWS_SUBNET_ID
 CRABBOX_AWS_INSTANCE_PROFILE
 CRABBOX_AWS_ROOT_GB
 CRABBOX_AWS_SSH_CIDRS
-CRABBOX_HOST_ID                       brokered use requires admin auth
+CRABBOX_HOST_ID                       brokered use requires admin auth except owned released hosts
 CRABBOX_AWS_MAC_HOST_ID            legacy AWS alias
 CRABBOX_CAPACITY_MARKET
 CRABBOX_CAPACITY_STRATEGY

--- a/docs/commands/vnc.md
+++ b/docs/commands/vnc.md
@@ -296,7 +296,8 @@ from the logged-in console session using a scheduled task.
 make sure an available EC2 Mac Dedicated Host is allocated in the selected AWS
 region. Set `CRABBOX_HOST_ID` or `hostId` only when you want to pin a specific
 host or when running the direct AWS provider. Brokered host pinning requires
-admin authentication; normal broker users rely on automatic available-host
+admin authentication unless the host belongs to the same owner and
+organization's released lease; other users rely on automatic available-host
 discovery. `CRABBOX_AWS_MAC_HOST_ID` and `aws.macHostId` remain compatibility
 aliases.
 

--- a/docs/commands/warmup.md
+++ b/docs/commands/warmup.md
@@ -231,8 +231,9 @@ hydration.
 already allocated Dedicated Host. Crabbox can discover an available host in the
 selected region, or pin one with `CRABBOX_HOST_ID` / `hostId`
 (`CRABBOX_AWS_MAC_HOST_ID` and `aws.macHostId` remain AWS compatibility
-aliases). Brokered host pinning requires admin authentication; normal broker
-users rely on automatic available-host discovery. Use `--market on-demand`, and
+aliases). Brokered host pinning requires admin authentication unless the host
+belongs to the same owner and organization's released lease; other users rely
+on automatic available-host discovery. Use `--market on-demand`, and
 expect EC2 Mac host lifecycle rules to dominate cleanup and cost. Warmup never
 allocates a Dedicated Host implicitly; trusted operators manage host lifecycle with
 `crabbox admin hosts offerings|quota|list|allocate|release --provider aws --target macos`.

--- a/docs/features/aws.md
+++ b/docs/features/aws.md
@@ -177,8 +177,12 @@ cadence and grace with
 
 EC2 Mac instances run only on Dedicated Hosts, and host lifecycle is explicit
 operator work. Admin-authenticated brokered mode can pin a host with
-`CRABBOX_HOST_ID` (legacy alias `CRABBOX_AWS_MAC_HOST_ID`); normal broker users
-rely on automatic available-host discovery in the region.
+`CRABBOX_HOST_ID` (legacy alias `CRABBOX_AWS_MAC_HOST_ID`). A normal broker user
+can pin a host only when a released AWS macOS lease proves that the same owner
+and organization previously used it; other host pins remain admin-only. Pinned
+launches wait through the bounded capacity handoff after the previous Mac
+instance terminates instead of failing immediately. Unpinned launches use
+automatic available-host discovery in the region.
 
 ```sh
 crabbox admin providers identity --provider aws --region eu-west-1
@@ -227,7 +231,7 @@ grants separately with `crabbox admin providers policy --provider aws` and
 AWS_ACCESS_KEY_ID
 AWS_SECRET_ACCESS_KEY
 AWS_SESSION_TOKEN              optional
-CRABBOX_HOST_ID               optional; admin-only explicit brokered host pin
+CRABBOX_HOST_ID               optional; admin-only except owner reuse of a released Mac host
 CRABBOX_AWS_MAC_HOST_ID       optional legacy alias for CRABBOX_HOST_ID
 ```
 

--- a/docs/features/vnc-macos.md
+++ b/docs/features/vnc-macos.md
@@ -64,8 +64,9 @@ allocation period, so the lifecycle differs from regular Linux/Windows leases:
   `mac-m4pro.metal`, `mac-m4max.metal`, `mac2-m1ultra.metal`, `mac-m3ultra.metal`)
   and finally `mac1.metal`;
 - to pin the lease to a specific host, set `CRABBOX_HOST_ID` or `hostId` in
-  config. Brokered pinning requires admin authentication; normal broker users
-  rely on automatic discovery. `CRABBOX_AWS_MAC_HOST_ID` and `aws.macHostId`
+  config. Brokered pinning requires admin authentication unless the host belongs
+  to the same owner and organization's released lease; other users rely on
+  automatic discovery. `CRABBOX_AWS_MAC_HOST_ID` and `aws.macHostId`
   remain accepted aliases.
 
 `crabbox warmup` does not allocate a Dedicated Host implicitly. Trusted
@@ -121,7 +122,8 @@ Static Macs work well over Tailscale: put the MagicDNS name or `100.x` address i
 
 **No host capacity (managed AWS).** Use `--market on-demand` and confirm an EC2
 Mac Dedicated Host is allocated in the region. Set `CRABBOX_HOST_ID` / `hostId`
-only to pin a specific host; brokered pinning requires admin authentication.
+only to pin a specific host; brokered pinning requires admin authentication
+unless the host belongs to the same owner and organization's released lease.
 Operators can inspect capacity:
 
 ```sh

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -333,7 +333,7 @@ Brokered credentials and host pinning (coordinator secrets):
 AWS_ACCESS_KEY_ID
 AWS_SECRET_ACCESS_KEY
 AWS_SESSION_TOKEN                # optional
-CRABBOX_HOST_ID                  # optional; admin-only explicit brokered host pin
+CRABBOX_HOST_ID                  # optional; admin-only except owner reuse of a released Mac host
 CRABBOX_AWS_MAC_HOST_ID          # optional legacy AWS alias for CRABBOX_HOST_ID
 ```
 
@@ -619,7 +619,7 @@ is in [Node.js And PostgreSQL](#node-js-and-postgresql).
 # Providers (at least one set)
 HETZNER_TOKEN
 AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN (optional)
-CRABBOX_HOST_ID / CRABBOX_AWS_MAC_HOST_ID (optional; admin-only explicit brokered Mac host pin)
+CRABBOX_HOST_ID / CRABBOX_AWS_MAC_HOST_ID (optional; admin-only except owner reuse of a released Mac host)
 AZURE_* / CRABBOX_AZURE_* (Azure)
 GCP_* / CRABBOX_GCP_* (GCP)
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -372,7 +372,7 @@ proxied HTML and JavaScript to a separate browser origin.
 
 ```text
 AWS_SESSION_TOKEN                  optional
-CRABBOX_HOST_ID                    optional; admin-only explicit brokered host pin
+CRABBOX_HOST_ID                    optional; admin-only except owner reuse of a released Mac host
 CRABBOX_AWS_MAC_HOST_ID            optional legacy AWS alias for CRABBOX_HOST_ID
 CRABBOX_SHARED_OWNER              optional fixed owner identity for shared-token automation
 CRABBOX_ADMIN_TOKEN               required for admin routes and image promotion

--- a/docs/providers/aws.md
+++ b/docs/providers/aws.md
@@ -98,7 +98,7 @@ CRABBOX_AWS_SUBNET_ID
 CRABBOX_AWS_INSTANCE_PROFILE
 CRABBOX_AWS_ROOT_GB
 CRABBOX_AWS_SSH_CIDRS               # comma-separated
-CRABBOX_HOST_ID                     # pin a Dedicated Host; brokered use requires admin auth
+CRABBOX_HOST_ID                     # brokered pin requires admin auth except owned released hosts
 CRABBOX_AWS_MAC_HOST_ID             # legacy alias for the Mac host id
 CRABBOX_CAPACITY_REGIONS            # comma-separated fallback regions
 CRABBOX_CAPACITY_AVAILABILITY_ZONES
@@ -127,7 +127,7 @@ Notes:
 | Linux | Ubuntu bootstrap, SSH, rsync sync, optional desktop/browser/code, Tailscale, Actions hydration. |
 | Windows native | EC2Launch bootstrap, OpenSSH, Git for Windows, archive sync; optional desktop with `--desktop`. |
 | Windows WSL2 | `--windows-mode wsl2`; launches on nested-virtualization families (`c8i`/`m8i`/`m8i-flex`/`r8i`); POSIX sync and commands run inside WSL. |
-| macOS | Requires an available EC2 Mac Dedicated Host in the region; On-Demand only. Admin-authenticated broker requests can pin a host with `CRABBOX_HOST_ID` / `aws.macHostId` (`CRABBOX_AWS_MAC_HOST_ID` is a legacy alias); normal broker users use automatic discovery. |
+| macOS | Requires an available EC2 Mac Dedicated Host in the region; On-Demand only. Admin-authenticated broker requests can pin any host with `CRABBOX_HOST_ID` / `aws.macHostId` (`CRABBOX_AWS_MAC_HOST_ID` is a legacy alias); normal broker users can pin only a host from their own released lease and otherwise use automatic discovery. |
 
 ## Lifecycle
 

--- a/worker/src/aws.ts
+++ b/worker/src/aws.ts
@@ -56,6 +56,8 @@ const awsMacHostQuotaSpecs: Record<string, { quotaCode: string; quotaName: strin
 };
 const snapshotDeleteBackoffMs = [1_000, 2_000, 4_000, 8_000, 15_000, 30_000];
 const securityGroupVisibilityBackoffMs = [100, 200, 400, 800, 1_600, 3_200];
+// EC2 can accept TerminateInstances several minutes before a single-capacity Mac host is reusable.
+const macHostCapacityBackoffMs = [5_000, 10_000, 20_000, 30_000, ...Array(9).fill(60_000)];
 
 export function awsManagedSecurityGroupName(
   config: Pick<LeaseConfig, "providerKey"> & Partial<Pick<LeaseConfig, "awsSGName">>,
@@ -1128,6 +1130,29 @@ export class EC2SpotClient {
       const message = error instanceof Error ? error.message : String(error);
       if (
         config.target === "macos" &&
+        configuredMacHostID &&
+        isAWSInsufficientCapacityOnHostError(message)
+      ) {
+        let lastError = error;
+        for (const delay of macHostCapacityBackoffMs) {
+          // oxlint-disable-next-line eslint/no-await-in-loop -- pinned Mac host reuse needs bounded EC2 capacity polling.
+          await sleep(delay);
+          try {
+            // oxlint-disable-next-line eslint/no-await-in-loop -- retries the same explicit host; never fails over.
+            return await run(configuredMacHostID);
+          } catch (retryError) {
+            const retryMessage =
+              retryError instanceof Error ? retryError.message : String(retryError);
+            if (!isAWSInsufficientCapacityOnHostError(retryMessage)) {
+              throw retryError;
+            }
+            lastError = retryError;
+          }
+        }
+        throw lastError;
+      }
+      if (
+        config.target === "macos" &&
         ((configuredMacHostID && isAWSInvalidHostIDError(message)) ||
           (!configuredMacHostID && isAWSInsufficientCapacityOnHostError(message)))
       ) {
@@ -1138,15 +1163,7 @@ export class EC2SpotClient {
         );
         return run(discovered);
       }
-      if (config.target !== "macos" || !configuredMacHostID || !isAWSInvalidHostIDError(message)) {
-        throw error;
-      }
-      const discovered = await this.discoverMacHostID(
-        config.serverType,
-        configuredMacHostID,
-        macHostAvailabilityZone,
-      );
-      return run(discovered);
+      throw error;
     }
   }
 

--- a/worker/test/aws.test.ts
+++ b/worker/test/aws.test.ts
@@ -1550,8 +1550,10 @@ describe("aws provider", () => {
     expect(result.server.hostID).toBe("h-spare");
   });
 
-  it("does not fail over from an explicit macOS host pin after host capacity is exhausted", async () => {
+  it("waits for an explicit macOS host pin to regain capacity without failing over", async () => {
+    vi.useFakeTimers();
     const runHosts: string[] = [];
+    let runCalls = 0;
     vi.stubGlobal(
       "fetch",
       vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -1585,10 +1587,25 @@ describe("aws provider", () => {
         }
         if (action === "RunInstances") {
           runHosts.push(params.get("Placement.HostId") ?? "");
-          return ec2XMLResponse(
-            `<Response><Errors><Error><Code>InsufficientCapacityOnHost</Code><Message>Dedicated host h-occupied has insufficient capacity.</Message></Error></Errors></Response>`,
-            400,
-          );
+          runCalls += 1;
+          if (runCalls < 3) {
+            return ec2XMLResponse(
+              `<Response><Errors><Error><Code>InsufficientCapacityOnHost</Code><Message>Dedicated host h-occupied has insufficient capacity.</Message></Error></Errors></Response>`,
+              400,
+            );
+          }
+          return ec2XMLResponse(`<?xml version="1.0" encoding="UTF-8"?>
+<RunInstancesResponse>
+  <instancesSet>
+    <item>
+      <instanceId>i-mac2</instanceId>
+      <instanceType>mac2.metal</instanceType>
+      <placement><hostId>h-occupied</hostId></placement>
+      <ipAddress>203.0.113.44</ipAddress>
+      <instanceState><name>pending</name></instanceState>
+    </item>
+  </instancesSet>
+</RunInstancesResponse>`);
         }
         return ec2XMLResponse(
           `<Response><Errors><Error><Code>Unexpected</Code><Message>${action}</Message></Error></Errors></Response>`,
@@ -1606,24 +1623,26 @@ describe("aws provider", () => {
       } as never,
       "eu-west-1",
     );
-    await expect(
-      client.createServerWithFallback(
-        leaseConfig({
-          provider: "aws",
-          target: "macos",
-          capacity: { market: "on-demand" },
-          hostID: "h-occupied",
-          serverType: "mac2.metal",
-          sshPublicKey: "ssh-ed25519 test",
-        }),
-        "cbx_abcdef123456",
-        "violet-prawn",
-        "alice@example.com",
-      ),
-    ).rejects.toThrow("InsufficientCapacityOnHost");
+    const creation = client.createServerWithFallback(
+      leaseConfig({
+        provider: "aws",
+        target: "macos",
+        capacity: { market: "on-demand" },
+        hostID: "h-occupied",
+        serverType: "mac2.metal",
+        sshPublicKey: "ssh-ed25519 test",
+      }),
+      "cbx_abcdef123456",
+      "violet-prawn",
+      "alice@example.com",
+    );
+    await vi.waitFor(() => expect(runCalls).toBe(1));
+    await vi.advanceTimersByTimeAsync(5_000);
+    await vi.waitFor(() => expect(runCalls).toBe(2));
+    await vi.advanceTimersByTimeAsync(10_000);
 
-    expect(runHosts.length).toBeGreaterThan(0);
-    expect(new Set(runHosts)).toEqual(new Set(["h-occupied"]));
+    await expect(creation).resolves.toMatchObject({ server: { hostID: "h-occupied" } });
+    expect(runHosts).toEqual(["h-occupied", "h-occupied", "h-occupied"]);
   });
 
   it("does not reuse a pinned macOS AMI after changing fallback host families", async () => {


### PR DESCRIPTION
## Summary

- retry an explicitly pinned EC2 Mac Dedicated Host while AWS completes the previous instance's capacity handoff
- preserve the explicit host boundary instead of failing over to another host
- document the owner-scoped released-host reuse contract consistently

## Root cause

EC2 accepts `TerminateInstances` before a single-capacity Mac Dedicated Host can launch its replacement. Crabbox immediately retried `RunInstances`, received `InsufficientCapacityOnHost`, and failed the lease even though the host was in a normal transient handoff. The coordinator now retries only that pinned host with a bounded backoff.

## Validation

- `npm run check --prefix worker`
- `npm run format:check --prefix worker`
- `npm test --prefix worker` (681 tests)
- `go test ./internal/applevzhelper -run TestRunStartReportsHelperExitWithoutWaitingForReadinessTimeout -count=1`
- structured Codex autoreview: clean

The full `go test ./...` run also exposed an unrelated Apple VZ timing flake; its exact test passed immediately on rerun.
