### PR TITLE
fix: reactivate retained EC2 Mac leases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@
 ### Fixed
 
 - Scoped managed AWS security groups per coordinator actor and preserved lease-declared CIDRs across heartbeats, preventing concurrent leases from revoking SSH and WebVNC access.
-- Allowed owners to reuse their own released EC2 Mac hosts without admin-token pinning and made pinned launches wait for the previous instance's capacity handoff.
+- Allowed owners to reactivate their own retained EC2 Mac instances without admin-token pinning, avoiding replacement launches while the single-capacity host is occupied or undergoing AWS's post-termination sanitization.
 - Bridged native Windows VNC locally through SSH instead of sending oversized POSIX lifecycle scripts through PowerShell, restoring WebVNC startup on Windows guests.
 - Provisioned complete VNC, noVNC, and XFCE services when Linux Parallels leases request desktop capability, including upgrades from stale core-only readiness markers.
 - Forced managed AWS macOS leases onto Apple's socket-activated Remote Login port 22, preventing inherited SSH-port settings from producing unreachable lease metadata and stalled WebVNC bridges.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -364,8 +364,8 @@ Managed provider targets are intentionally narrow:
 - AWS also supports EC2 Mac (`--target macos`) when an available Mac Dedicated
   Host exists in the selected region. Brokered mode can discover an available
   host; explicit brokered host pinning requires admin authentication unless the
-  owner is reusing a host from their own released lease. Direct mode requires
-  `CRABBOX_HOST_ID` or `hostId`. `CRABBOX_AWS_MAC_HOST_ID`
+  owner is reactivating the retained instance from their own released lease.
+  Direct mode requires `CRABBOX_HOST_ID` or `hostId`. `CRABBOX_AWS_MAC_HOST_ID`
   and `aws.macHostId` remain AWS compatibility aliases. Azure has no managed macOS
   target.
 - Existing macOS and Windows machines belong on `provider: ssh`.

--- a/docs/commands/vnc.md
+++ b/docs/commands/vnc.md
@@ -296,9 +296,9 @@ from the logged-in console session using a scheduled task.
 make sure an available EC2 Mac Dedicated Host is allocated in the selected AWS
 region. Set `CRABBOX_HOST_ID` or `hostId` only when you want to pin a specific
 host or when running the direct AWS provider. Brokered host pinning requires
-admin authentication unless the host belongs to the same owner and
-organization's released lease; other users rely on automatic available-host
-discovery. `CRABBOX_AWS_MAC_HOST_ID` and `aws.macHostId` remain compatibility
+admin authentication unless the host has a retained instance from the same
+owner and organization's released lease; other users rely on automatic
+available-host discovery. `CRABBOX_AWS_MAC_HOST_ID` and `aws.macHostId` remain compatibility
 aliases.
 
 ## Related docs

--- a/docs/commands/warmup.md
+++ b/docs/commands/warmup.md
@@ -232,8 +232,8 @@ already allocated Dedicated Host. Crabbox can discover an available host in the
 selected region, or pin one with `CRABBOX_HOST_ID` / `hostId`
 (`CRABBOX_AWS_MAC_HOST_ID` and `aws.macHostId` remain AWS compatibility
 aliases). Brokered host pinning requires admin authentication unless the host
-belongs to the same owner and organization's released lease; other users rely
-on automatic available-host discovery. Use `--market on-demand`, and
+has a retained instance from the same owner and organization's released lease;
+other users rely on automatic available-host discovery. Use `--market on-demand`, and
 expect EC2 Mac host lifecycle rules to dominate cleanup and cost. Warmup never
 allocates a Dedicated Host implicitly; trusted operators manage host lifecycle with
 `crabbox admin hosts offerings|quota|list|allocate|release --provider aws --target macos`.

--- a/docs/features/aws.md
+++ b/docs/features/aws.md
@@ -179,10 +179,14 @@ EC2 Mac instances run only on Dedicated Hosts, and host lifecycle is explicit
 operator work. Admin-authenticated brokered mode can pin a host with
 `CRABBOX_HOST_ID` (legacy alias `CRABBOX_AWS_MAC_HOST_ID`). A normal broker user
 can pin a host only when a released AWS macOS lease proves that the same owner
-and organization previously used it; other host pins remain admin-only. Pinned
-launches wait through the bounded capacity handoff after the previous Mac
-instance terminates instead of failing immediately. Unpinned launches use
-automatic available-host discovery in the region.
+and organization previously used it; other host pins remain admin-only. If that
+lease retained its instance, Crabbox reactivates the existing lease and instance
+instead of launching a replacement onto the single-capacity host. Reactivation
+requires the retained instance to already provide every requested desktop,
+browser, and code capability. A terminated Mac instance can leave its host
+unavailable during AWS's sanitization window, so occupied explicit pins fail
+immediately; unpinned launches use automatic available-host discovery in the
+region.
 
 ```sh
 crabbox admin providers identity --provider aws --region eu-west-1

--- a/docs/features/vnc-macos.md
+++ b/docs/features/vnc-macos.md
@@ -64,9 +64,9 @@ allocation period, so the lifecycle differs from regular Linux/Windows leases:
   `mac-m4pro.metal`, `mac-m4max.metal`, `mac2-m1ultra.metal`, `mac-m3ultra.metal`)
   and finally `mac1.metal`;
 - to pin the lease to a specific host, set `CRABBOX_HOST_ID` or `hostId` in
-  config. Brokered pinning requires admin authentication unless the host belongs
-  to the same owner and organization's released lease; other users rely on
-  automatic discovery. `CRABBOX_AWS_MAC_HOST_ID` and `aws.macHostId`
+  config. Brokered pinning requires admin authentication unless the host has a
+  retained instance from the same owner and organization's released lease;
+  other users rely on automatic discovery. `CRABBOX_AWS_MAC_HOST_ID` and `aws.macHostId`
   remain accepted aliases.
 
 `crabbox warmup` does not allocate a Dedicated Host implicitly. Trusted
@@ -123,7 +123,8 @@ Static Macs work well over Tailscale: put the MagicDNS name or `100.x` address i
 **No host capacity (managed AWS).** Use `--market on-demand` and confirm an EC2
 Mac Dedicated Host is allocated in the region. Set `CRABBOX_HOST_ID` / `hostId`
 only to pin a specific host; brokered pinning requires admin authentication
-unless the host belongs to the same owner and organization's released lease.
+unless the host has a retained instance from the same owner and organization's
+released lease.
 Operators can inspect capacity:
 
 ```sh

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -333,7 +333,7 @@ Brokered credentials and host pinning (coordinator secrets):
 AWS_ACCESS_KEY_ID
 AWS_SECRET_ACCESS_KEY
 AWS_SESSION_TOKEN                # optional
-CRABBOX_HOST_ID                  # optional; admin-only except owner reuse of a released Mac host
+CRABBOX_HOST_ID                  # optional; admin-only except owner reactivation of a retained Mac instance
 CRABBOX_AWS_MAC_HOST_ID          # optional legacy AWS alias for CRABBOX_HOST_ID
 ```
 
@@ -619,7 +619,7 @@ is in [Node.js And PostgreSQL](#node-js-and-postgresql).
 # Providers (at least one set)
 HETZNER_TOKEN
 AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN (optional)
-CRABBOX_HOST_ID / CRABBOX_AWS_MAC_HOST_ID (optional; admin-only except owner reuse of a released Mac host)
+CRABBOX_HOST_ID / CRABBOX_AWS_MAC_HOST_ID (optional; admin-only except owner reactivation of a retained Mac instance)
 AZURE_* / CRABBOX_AZURE_* (Azure)
 GCP_* / CRABBOX_GCP_* (GCP)
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -372,7 +372,7 @@ proxied HTML and JavaScript to a separate browser origin.
 
 ```text
 AWS_SESSION_TOKEN                  optional
-CRABBOX_HOST_ID                    optional; admin-only except owner reuse of a released Mac host
+CRABBOX_HOST_ID                    optional; admin-only except owner reactivation of a retained Mac instance
 CRABBOX_AWS_MAC_HOST_ID            optional legacy AWS alias for CRABBOX_HOST_ID
 CRABBOX_SHARED_OWNER              optional fixed owner identity for shared-token automation
 CRABBOX_ADMIN_TOKEN               required for admin routes and image promotion

--- a/worker/src/aws.ts
+++ b/worker/src/aws.ts
@@ -56,8 +56,6 @@ const awsMacHostQuotaSpecs: Record<string, { quotaCode: string; quotaName: strin
 };
 const snapshotDeleteBackoffMs = [1_000, 2_000, 4_000, 8_000, 15_000, 30_000];
 const securityGroupVisibilityBackoffMs = [100, 200, 400, 800, 1_600, 3_200];
-// EC2 can accept TerminateInstances several minutes before a single-capacity Mac host is reusable.
-const macHostCapacityBackoffMs = [5_000, 10_000, 20_000, 30_000, ...Array(9).fill(60_000)];
 
 export function awsManagedSecurityGroupName(
   config: Pick<LeaseConfig, "providerKey"> & Partial<Pick<LeaseConfig, "awsSGName">>,
@@ -331,7 +329,22 @@ export class EC2SpotClient {
           ? ""
           : await this.resolveAMI(config);
       const securityGroupID = await this.ensureSecurityGroup(config, options);
-      const candidates = awsLaunchCandidates(config);
+      const pinnedMacHostID = config.target === "macos" ? config.hostID || config.awsMacHostID : "";
+      // An explicit Mac host is tied to one hardware family. Resolve that family once so a
+      // defaulted --type cannot send an incompatible instance type to the pinned host.
+      const pinnedMacHostType = pinnedMacHostID
+        ? await this.macHostInstanceType(pinnedMacHostID)
+        : "";
+      if (
+        pinnedMacHostType &&
+        config.serverTypeExplicit &&
+        pinnedMacHostType !== config.serverType
+      ) {
+        throw new Error(
+          `EC2 Mac Dedicated Host ${pinnedMacHostID} requires ${pinnedMacHostType}, not requested ${config.serverType}`,
+        );
+      }
+      const candidates = pinnedMacHostType ? [pinnedMacHostType] : awsLaunchCandidates(config);
       const failures: string[] = [];
       const attempts: ProvisioningAttempt[] = [];
       const quotaCache = new Map<string, number | undefined>();
@@ -1130,29 +1143,6 @@ export class EC2SpotClient {
       const message = error instanceof Error ? error.message : String(error);
       if (
         config.target === "macos" &&
-        configuredMacHostID &&
-        isAWSInsufficientCapacityOnHostError(message)
-      ) {
-        let lastError = error;
-        for (const delay of macHostCapacityBackoffMs) {
-          // oxlint-disable-next-line eslint/no-await-in-loop -- pinned Mac host reuse needs bounded EC2 capacity polling.
-          await sleep(delay);
-          try {
-            // oxlint-disable-next-line eslint/no-await-in-loop -- retries the same explicit host; never fails over.
-            return await run(configuredMacHostID);
-          } catch (retryError) {
-            const retryMessage =
-              retryError instanceof Error ? retryError.message : String(retryError);
-            if (!isAWSInsufficientCapacityOnHostError(retryMessage)) {
-              throw retryError;
-            }
-            lastError = retryError;
-          }
-        }
-        throw lastError;
-      }
-      if (
-        config.target === "macos" &&
         ((configuredMacHostID && isAWSInvalidHostIDError(message)) ||
           (!configuredMacHostID && isAWSInsufficientCapacityOnHostError(message)))
       ) {
@@ -1420,6 +1410,17 @@ export class EC2SpotClient {
     });
     const root = await this.ec2("DescribeHosts", params);
     return items(record(root["hostSet"])["item"]).map((host) => this.macHostFromDescribeHost(host));
+  }
+
+  private async macHostInstanceType(hostID: string): Promise<string> {
+    const host = (await this.describeMacHostsByID([hostID]))[0];
+    if (!host) {
+      throw new Error(`AWS EC2 Mac Dedicated Host not found: ${hostID}`);
+    }
+    if (!host.instanceType.startsWith("mac")) {
+      throw new Error(`AWS Dedicated Host ${hostID} is not an EC2 Mac host`);
+    }
+    return host.instanceType;
   }
 
   private macHostsFromAllocatedIDs(

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -1661,19 +1661,24 @@ export class FleetCoordinator {
       );
     }
     const requestedHostID = config.hostID || config.awsMacHostID;
-    const reusesOwnedReleasedMacHost =
-      requestedHostID &&
-      config.provider === "aws" &&
-      config.target === "macos" &&
-      (await this.leaseRecords()).some(
-        (lease) =>
-          lease.state === "released" &&
-          lease.owner === owner &&
-          lease.org === org &&
-          lease.provider === "aws" &&
-          lease.target === "macos" &&
-          leaseHostID(lease) === requestedHostID,
-      );
+    const retainedMacHostLease =
+      requestedHostID && config.provider === "aws" && config.target === "macos"
+        ? (await this.leaseRecords())
+            .filter(
+              (lease) =>
+                lease.state === "released" &&
+                lease.releaseDeletesServer === false &&
+                Boolean(lease.cloudID) &&
+                lease.owner === owner &&
+                lease.org === org &&
+                lease.provider === "aws" &&
+                lease.target === "macos" &&
+                leaseHostID(lease) === requestedHostID &&
+                (!config.serverTypeExplicit || lease.serverType === config.serverType),
+            )
+            .toSorted((left, right) => right.updatedAt.localeCompare(left.updatedAt))[0]
+        : undefined;
+    const reusesOwnedReleasedMacHost = Boolean(retainedMacHostLease);
     if (!isAdminRequest(request) && requestedHostID && !reusesOwnedReleasedMacHost) {
       return json(
         {
@@ -1682,6 +1687,25 @@ export class FleetCoordinator {
         },
         { status: 403 },
       );
+    }
+    if (retainedMacHostLease) {
+      const missingCapabilities = [
+        config.desktop && !retainedMacHostLease.desktop ? "desktop" : "",
+        config.browser && !retainedMacHostLease.browser ? "browser" : "",
+        config.code && !retainedMacHostLease.code ? "code" : "",
+      ].filter(Boolean);
+      if (missingCapabilities.length > 0) {
+        return json(
+          {
+            error: "retained_instance_capability_mismatch",
+            message: `retained EC2 Mac instance lacks requested capabilities: ${missingCapabilities.join(", ")}`,
+          },
+          { status: 409 },
+        );
+      }
+    }
+    if (retainedMacHostLease && !config.serverTypeExplicit) {
+      config = { ...config, serverType: retainedMacHostLease.serverType };
     }
     config =
       (await this.provider(
@@ -1720,6 +1744,136 @@ export class FleetCoordinator {
       config.ttlSeconds,
       providerHourlyUSD,
     );
+    if (!workspaceID && retainedMacHostLease) {
+      const reactivation = await this.state.runExclusive(async () => {
+        const leases = await this.leaseRecords();
+        const current = leases.find(
+          (lease) =>
+            lease.id === retainedMacHostLease.id &&
+            lease.state === "released" &&
+            lease.releaseDeletesServer === false &&
+            Boolean(lease.cloudID) &&
+            lease.owner === owner &&
+            lease.org === org &&
+            lease.provider === "aws" &&
+            lease.target === "macos" &&
+            leaseHostID(lease) === requestedHostID &&
+            lease.serverType === config.serverType,
+        );
+        if (!current) {
+          return undefined;
+        }
+        const blocked = await reservationGuard?.();
+        if (blocked) {
+          return blocked;
+        }
+        const now = new Date();
+        let reactivated: LeaseRecord = {
+          ...current,
+          profile: config.profile,
+          class: config.class,
+          requestedServerType: config.serverType,
+          keep: config.keep,
+          ttlSeconds: config.ttlSeconds,
+          idleTimeoutSeconds: config.idleTimeoutSeconds,
+          estimatedHourlyUSD: cost.hourlyUSD,
+          maxEstimatedUSD: cost.maxUSD,
+          state: "active",
+          createdAt: now.toISOString(),
+          updatedAt: now.toISOString(),
+          lastTouchedAt: now.toISOString(),
+          expiresAt: leaseExpiresAt(
+            now,
+            now,
+            config.ttlSeconds,
+            config.idleTimeoutSeconds,
+          ).toISOString(),
+        };
+        const sourceCIDRs = awsLeaseSSHSourceCIDRs(
+          config,
+          providerAccessContext(
+            requestSourceCIDRs(request),
+            mergeProviderAccessState(leases, await this.providerAccessRecords()),
+          ),
+        );
+        reactivated = withLeaseSSHSourceCIDRs(
+          reactivated,
+          uniqueNonEmpty([...(current.network?.sshSourceCIDRs ?? []), ...sourceCIDRs]),
+          Boolean(
+            current.network?.sshSourceCIDRsComplete ||
+            sourceCIDRs.length > 0 ||
+            awsGlobalSSHSourceCIDRs(this.env).length > 0,
+          ),
+        );
+        if (config.awsSSHCIDRsPinned) {
+          reactivated.network = {
+            ...reactivated.network,
+            sshPinnedSourceCIDRs: uniqueNonEmpty([
+              ...(current.network?.sshPinnedSourceCIDRs ?? []),
+              ...config.awsSSHCIDRs,
+            ]),
+          };
+        }
+        delete reactivated.releasedAt;
+        delete reactivated.endedAt;
+        delete reactivated.releaseDeletesServer;
+        delete reactivated.failureError;
+        delete reactivated.provisioningRequestStartedAt;
+        clearLeaseCleanupMetadata(reactivated);
+        const otherLeases = mergeProviderAccessState(
+          leases.filter((lease) => lease.id !== current.id),
+          await this.providerAccessRecords(),
+        );
+        const limitError = enforceCostLimits(otherLeases, reactivated, costLimits(this.env), now);
+        if (limitError) {
+          return json({ error: "cost_limit_exceeded", message: limitError }, { status: 429 });
+        }
+        await this.putLease(reactivated);
+        await this.markAWSIngressReconcilePending(reactivated);
+        await this.scheduleAlarm();
+        return { previous: structuredClone(current), reactivated };
+      });
+      if (reactivation instanceof Response) {
+        return reactivation;
+      }
+      if (reactivation) {
+        try {
+          if (provider.reconcileLeaseAccess) {
+            const leases = await this.leaseRecords();
+            const providerAccessLeases = await this.providerAccessRecords();
+            await this.withAWSIngressOperationLock(() =>
+              provider.reconcileLeaseAccess!(
+                reactivation.reactivated,
+                providerAccessContext(
+                  requestSourceCIDRs(request),
+                  mergeProviderAccessState(leases, providerAccessLeases),
+                ),
+              ),
+            );
+          }
+        } catch (error) {
+          await this.state.runExclusive(async () => {
+            const current = await this.getLease(reactivation.reactivated.id);
+            if (
+              current?.state === "active" &&
+              current.updatedAt === reactivation.reactivated.updatedAt
+            ) {
+              await this.putLease(reactivation.previous);
+              await this.scheduleAlarm();
+            }
+          });
+          throw error;
+        }
+        return json({ lease: reactivation.reactivated }, { status: 201 });
+      }
+      return json(
+        {
+          error: "retained_instance_unavailable",
+          message: "retained EC2 Mac instance is no longer available for reactivation",
+        },
+        { status: 409 },
+      );
+    }
     const reservation = await this.state.runExclusive(async () => {
       const blocked = await reservationGuard?.();
       if (blocked) {

--- a/worker/test/aws.test.ts
+++ b/worker/test/aws.test.ts
@@ -1552,6 +1552,7 @@ describe("aws provider", () => {
 
   it("fails an occupied explicit macOS host pin without retrying or failing over", async () => {
     const runHosts: string[] = [];
+    const describedHostIDs: string[] = [];
     vi.stubGlobal(
       "fetch",
       vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -1584,7 +1585,7 @@ describe("aws provider", () => {
 </DescribeImagesResponse>`);
         }
         if (action === "DescribeHosts") {
-          expect(params.get("HostId.1")).toBe("h-occupied");
+          describedHostIDs.push(params.get("HostId.1") ?? "");
           return ec2XMLResponse(`<?xml version="1.0" encoding="UTF-8"?>
 <DescribeHostsResponse>
   <hostSet>
@@ -1634,11 +1635,13 @@ describe("aws provider", () => {
         "alice@example.com",
       ),
     ).rejects.toThrow("InsufficientCapacityOnHost");
+    expect(describedHostIDs).toEqual(["h-occupied"]);
     expect(runHosts).toEqual(["h-occupied"]);
   });
 
   it("uses the pinned macOS host family when the server type was defaulted", async () => {
     const runTypes: string[] = [];
+    const describedHostIDs: string[] = [];
     vi.stubGlobal(
       "fetch",
       vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -1656,7 +1659,7 @@ describe("aws provider", () => {
           return ec2XMLResponse("<DescribeKeyPairsResponse />");
         }
         if (action === "DescribeHosts") {
-          expect(params.get("HostId.1")).toBe("h-m4");
+          describedHostIDs.push(params.get("HostId.1") ?? "");
           return ec2XMLResponse(`<?xml version="1.0" encoding="UTF-8"?>
 <DescribeHostsResponse>
   <hostSet>
@@ -1725,6 +1728,7 @@ describe("aws provider", () => {
       "alice@example.com",
     );
 
+    expect(describedHostIDs).toEqual(["h-m4"]);
     expect(runTypes).toEqual(["mac-m4.metal"]);
     expect(result.serverType).toBe("mac-m4.metal");
     expect(result.server.hostID).toBe("h-m4");

--- a/worker/test/aws.test.ts
+++ b/worker/test/aws.test.ts
@@ -1550,10 +1550,8 @@ describe("aws provider", () => {
     expect(result.server.hostID).toBe("h-spare");
   });
 
-  it("waits for an explicit macOS host pin to regain capacity without failing over", async () => {
-    vi.useFakeTimers();
+  it("fails an occupied explicit macOS host pin without retrying or failing over", async () => {
     const runHosts: string[] = [];
-    let runCalls = 0;
     vi.stubGlobal(
       "fetch",
       vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -1585,22 +1583,113 @@ describe("aws provider", () => {
   </imagesSet>
 </DescribeImagesResponse>`);
         }
+        if (action === "DescribeHosts") {
+          expect(params.get("HostId.1")).toBe("h-occupied");
+          return ec2XMLResponse(`<?xml version="1.0" encoding="UTF-8"?>
+<DescribeHostsResponse>
+  <hostSet>
+    <item>
+      <hostId>h-occupied</hostId>
+      <hostState>available</hostState>
+      <hostProperties><instanceType>mac2.metal</instanceType></hostProperties>
+    </item>
+  </hostSet>
+</DescribeHostsResponse>`);
+        }
         if (action === "RunInstances") {
           runHosts.push(params.get("Placement.HostId") ?? "");
-          runCalls += 1;
-          if (runCalls < 3) {
-            return ec2XMLResponse(
-              `<Response><Errors><Error><Code>InsufficientCapacityOnHost</Code><Message>Dedicated host h-occupied has insufficient capacity.</Message></Error></Errors></Response>`,
-              400,
-            );
-          }
+          return ec2XMLResponse(
+            `<Response><Errors><Error><Code>InsufficientCapacityOnHost</Code><Message>Dedicated host h-occupied has insufficient capacity.</Message></Error></Errors></Response>`,
+            400,
+          );
+        }
+        return ec2XMLResponse(
+          `<Response><Errors><Error><Code>Unexpected</Code><Message>${action}</Message></Error></Errors></Response>`,
+          500,
+        );
+      }),
+    );
+
+    const client = new EC2SpotClient(
+      {
+        AWS_ACCESS_KEY_ID: "test",
+        AWS_SECRET_ACCESS_KEY: "secret",
+        CRABBOX_AWS_SECURITY_GROUP_ID: "sg-123",
+        CRABBOX_AWS_SSH_CIDRS: "203.0.113.7/32",
+      } as never,
+      "eu-west-1",
+    );
+    await expect(
+      client.createServerWithFallback(
+        leaseConfig({
+          provider: "aws",
+          target: "macos",
+          capacity: { market: "on-demand" },
+          hostID: "h-occupied",
+          serverType: "mac2.metal",
+          sshPublicKey: "ssh-ed25519 test",
+        }),
+        "cbx_abcdef123456",
+        "violet-prawn",
+        "alice@example.com",
+      ),
+    ).rejects.toThrow("InsufficientCapacityOnHost");
+    expect(runHosts).toEqual(["h-occupied"]);
+  });
+
+  it("uses the pinned macOS host family when the server type was defaulted", async () => {
+    const runTypes: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        if (new URL(request.url).hostname.startsWith("servicequotas.")) {
+          return new Response(JSON.stringify({ Quota: { Value: 999 } }), {
+            headers: { "content-type": "application/json" },
+          });
+        }
+        const params = new URLSearchParams(await request.clone().text());
+        const action = params.get("Action") ?? "";
+        const securityGroupResponse = ec2ConfiguredSecurityGroupResponse(action, params);
+        if (securityGroupResponse) return securityGroupResponse;
+        if (action === "DescribeKeyPairs") {
+          return ec2XMLResponse("<DescribeKeyPairsResponse />");
+        }
+        if (action === "DescribeHosts") {
+          expect(params.get("HostId.1")).toBe("h-m4");
+          return ec2XMLResponse(`<?xml version="1.0" encoding="UTF-8"?>
+<DescribeHostsResponse>
+  <hostSet>
+    <item>
+      <hostId>h-m4</hostId>
+      <hostState>available</hostState>
+      <hostProperties><instanceType>mac-m4.metal</instanceType></hostProperties>
+    </item>
+  </hostSet>
+</DescribeHostsResponse>`);
+        }
+        if (action === "DescribeImages") {
+          return ec2XMLResponse(`<?xml version="1.0" encoding="UTF-8"?>
+<DescribeImagesResponse>
+  <imagesSet>
+    <item>
+      <imageId>ami-m4</imageId>
+      <name>macos</name>
+      <imageState>available</imageState>
+      <creationDate>2026-05-01T00:00:00.000Z</creationDate>
+    </item>
+  </imagesSet>
+</DescribeImagesResponse>`);
+        }
+        if (action === "RunInstances") {
+          runTypes.push(params.get("InstanceType") ?? "");
           return ec2XMLResponse(`<?xml version="1.0" encoding="UTF-8"?>
 <RunInstancesResponse>
   <instancesSet>
     <item>
-      <instanceId>i-mac2</instanceId>
-      <instanceType>mac2.metal</instanceType>
-      <placement><hostId>h-occupied</hostId></placement>
+      <instanceId>i-m4</instanceId>
+      <instanceType>mac-m4.metal</instanceType>
+      <placement><hostId>h-m4</hostId></placement>
       <ipAddress>203.0.113.44</ipAddress>
       <instanceState><name>pending</name></instanceState>
     </item>
@@ -1623,26 +1712,22 @@ describe("aws provider", () => {
       } as never,
       "eu-west-1",
     );
-    const creation = client.createServerWithFallback(
+    const result = await client.createServerWithFallback(
       leaseConfig({
         provider: "aws",
         target: "macos",
         capacity: { market: "on-demand" },
-        hostID: "h-occupied",
-        serverType: "mac2.metal",
+        hostID: "h-m4",
         sshPublicKey: "ssh-ed25519 test",
       }),
       "cbx_abcdef123456",
       "violet-prawn",
       "alice@example.com",
     );
-    await vi.waitFor(() => expect(runCalls).toBe(1));
-    await vi.advanceTimersByTimeAsync(5_000);
-    await vi.waitFor(() => expect(runCalls).toBe(2));
-    await vi.advanceTimersByTimeAsync(10_000);
 
-    await expect(creation).resolves.toMatchObject({ server: { hostID: "h-occupied" } });
-    expect(runHosts).toEqual(["h-occupied", "h-occupied", "h-occupied"]);
+    expect(runTypes).toEqual(["mac-m4.metal"]);
+    expect(result.serverType).toBe("mac-m4.metal");
+    expect(result.server.hostID).toBe("h-m4");
   });
 
   it("does not reuse a pinned macOS AMI after changing fallback host families", async () => {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -11057,9 +11057,26 @@ describe("fleet lease identity and idle", () => {
     });
   });
 
-  it("requires admin auth for new AWS macOS host pins but permits owner reuse", async () => {
+  it("requires admin auth for new AWS macOS host pins but reactivates an owner's retained Mac", async () => {
     let created = false;
-    const fleet = testFleet(new MemoryStorage(), {
+    const storage = new MemoryStorage();
+    const reconciledLeaseIDs: string[][] = [];
+    storage.seed(
+      "lease:cbx_000000000098",
+      testLease({
+        id: "cbx_000000000098",
+        provider: "aws",
+        target: "macos",
+        state: "released",
+        owner: "admin@example.com",
+        org: "example-org",
+        hostId: "h-000000000001",
+        serverType: "mac2.metal",
+        providerKey: "crabbox-steipete",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      }),
+    );
+    const fleet = testFleet(storage, {
       aws: fakeProvider(
         () => {
           created = true;
@@ -11068,6 +11085,9 @@ describe("fleet lease identity and idle", () => {
           provider: "aws",
           serverType: "mac2.metal",
           hostID: "h-000000000001",
+          onReconcileLeaseAccess: (_lease, context) => {
+            reconciledLeaseIDs.push(context.activeLeases.map((candidate) => candidate.id));
+          },
         },
       ),
     });
@@ -11078,6 +11098,7 @@ describe("fleet lease identity and idle", () => {
       serverType: "mac2.metal",
       hostId: "h-000000000001",
       capacity: { market: "on-demand" as const },
+      keep: true,
       sshPublicKey: "ssh-ed25519 test",
     };
     const denied = await fleet.fetch(
@@ -11122,17 +11143,182 @@ describe("fleet lease identity and idle", () => {
     expect(released.status).toBe(200);
 
     created = false;
+    reconciledLeaseIDs.length = 0;
+    storage.seed(
+      "provider-access:cbx_000000000099",
+      testLease({
+        id: "cbx_000000000099",
+        provider: "aws",
+        state: "provisioning",
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      }),
+    );
+    const incompatible = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers: {
+          "x-crabbox-owner": "admin@example.com",
+          "x-crabbox-org": "example-org",
+        },
+        body: { ...body, desktop: true, leaseID: "cbx_abcdef123458" },
+      }),
+    );
+    expect(incompatible.status).toBe(409);
+    await expect(incompatible.json()).resolves.toMatchObject({
+      error: "retained_instance_capability_mismatch",
+    });
+    expect(created).toBe(false);
+
     const reused = await fleet.fetch(
       request("POST", "/v1/leases", {
         headers: {
           "x-crabbox-owner": "admin@example.com",
           "x-crabbox-org": "example-org",
         },
-        body: { ...body, leaseID: "cbx_abcdef123458" },
+        body: {
+          ...body,
+          providerKey: "crabbox-new-request",
+          leaseID: "cbx_abcdef123458",
+        },
       }),
     );
     expect(reused.status).toBe(201);
-    expect(created).toBe(true);
+    expect(created).toBe(false);
+    const { lease: reactivated } = (await reused.json()) as { lease: LeaseRecord };
+    expect(reactivated.id).toBe(lease.id);
+    expect(reactivated.state).toBe("active");
+    expect(reactivated.createdAt).toBe(reactivated.lastTouchedAt);
+    expect(reactivated.cloudID).toBe(lease.cloudID);
+    expect(reactivated.hostId).toBe("h-000000000001");
+    expect(reactivated.providerKey).toBe(lease.providerKey);
+    expect(reconciledLeaseIDs.at(-1)).toContain("cbx_000000000099");
+
+    const deleted = await fleet.fetch(
+      request("POST", `/v1/leases/${lease.id}/release`, {
+        headers: {
+          "x-crabbox-owner": "admin@example.com",
+          "x-crabbox-org": "example-org",
+        },
+        body: { delete: true },
+      }),
+    );
+    expect(deleted.status).toBe(200);
+
+    const deletedHostReuse = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers: {
+          "x-crabbox-owner": "admin@example.com",
+          "x-crabbox-org": "example-org",
+        },
+        body: { ...body, leaseID: "cbx_abcdef123459" },
+      }),
+    );
+    expect(deletedHostReuse.status).toBe(403);
+    await expect(deletedHostReuse.json()).resolves.toMatchObject({ error: "admin_required" });
+  });
+
+  it("reactivates a retained pinned Mac host family when the request type was defaulted", async () => {
+    const storage = new MemoryStorage();
+    storage.seed(
+      "lease:cbx_000000000100",
+      testLease({
+        id: "cbx_000000000100",
+        provider: "aws",
+        target: "macos",
+        state: "released",
+        owner: "alice@example.com",
+        org: "example-org",
+        hostId: "h-m4",
+        serverType: "mac-m4.metal",
+        providerKey: "crabbox-steipete",
+        releaseDeletesServer: false,
+      }),
+    );
+    const fleet = testFleet(storage, {
+      aws: fakeProvider(
+        () => {
+          throw new Error("retained instance must not launch a replacement");
+        },
+        { provider: "aws" },
+      ),
+    });
+
+    const response = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers: {
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
+        },
+        body: {
+          provider: "aws",
+          target: "macos",
+          hostId: "h-m4",
+          capacity: { market: "on-demand" },
+          keep: true,
+          sshPublicKey: "ssh-ed25519 test",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    const { lease } = (await response.json()) as { lease: LeaseRecord };
+    expect(lease.id).toBe("cbx_000000000100");
+    expect(lease.serverType).toBe("mac-m4.metal");
+    expect(lease.requestedServerType).toBe("mac-m4.metal");
+  });
+
+  it("does not launch a replacement when a retained Mac is claimed concurrently", async () => {
+    const storage = new MemoryStorage();
+    const retained = testLease({
+      id: "cbx_000000000101",
+      provider: "aws",
+      target: "macos",
+      state: "released",
+      owner: "alice@example.com",
+      org: "example-org",
+      hostId: "h-mac2",
+      serverType: "mac2.metal",
+      providerKey: "crabbox-steipete",
+      releaseDeletesServer: false,
+    });
+    storage.seed(`lease:${retained.id}`, retained);
+    let created = false;
+    const fleet = testFleet(storage, {
+      aws: fakeProvider(
+        () => {
+          created = true;
+        },
+        {
+          provider: "aws",
+          onPrepareLeaseConfig: (config, currentStorage) => {
+            currentStorage?.seed(`lease:${retained.id}`, { ...retained, state: "active" });
+            return config;
+          },
+        },
+      ),
+    });
+
+    const response = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers: {
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
+        },
+        body: {
+          provider: "aws",
+          target: "macos",
+          hostId: "h-mac2",
+          capacity: { market: "on-demand" },
+          keep: true,
+          sshPublicKey: "ssh-ed25519 test",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "retained_instance_unavailable",
+    });
+    expect(created).toBe(false);
   });
 
   it("only applies target-matching promoted AWS images", async () => {


### PR DESCRIPTION
## Summary

- reactivate an owner's retained EC2 Mac lease and instance instead of launching a replacement onto its single-capacity Dedicated Host
- preserve lease capabilities and ingress reservations while resetting lifecycle and cost accounting atomically
- reject deleted historical host claims, fail occupied terminated-host pins immediately, and derive a pinned host's actual Mac family
- document the retained-instance lifecycle and add coordinator/AWS regressions

## Why

Production end-to-end testing of the prior bounded-retry fix showed that EC2 Mac host sanitization can outlive a request by far more than ten minutes. Retaining and reactivating the existing instance avoids that AWS lifecycle gap entirely; terminated instances now fail fast rather than tying up the coordinator.

## Verification

- `npm run check --prefix worker`
- `npm run format:check --prefix worker`
- `npm test --prefix worker` (24 files, 684 tests)
- `scripts/check-docs.sh`
- `git diff --check`
- autoreview
