### PR TITLE
feat: add Tencent Cloud CVM provider

### DIFF
--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -61,7 +61,7 @@ selection metadata. Regenerate it with `node scripts/generate-provider-matrix.mj
 `scripts/check-docs.sh` fails when provider registration, metadata, docs paths, or
 this generated table drift.
 
-Current built-in surface: 67 providers (39 SSH lease, 26 delegated run, 2 service control).
+Current built-in surface: 68 providers (40 SSH lease, 26 delegated run, 2 service control).
 
 Access terms:
 
@@ -130,6 +130,7 @@ Access terms:
 | [ssh](ssh.md) (`static`, `static-ssh`) | built-in; `ssh-lease` · byo-ssh | Crabbox-managed SSH; `crabbox-sync` · direct only; features: `ssh`, `crabbox-sync`, `desktop`, `browser`, `code` | `linux`, `windows/normal`, `windows/wsl2`, `macos`; Existing SSH host | `byo`; GPU: optional | user; none | Bring-your-own persistent Linux, macOS, or Windows host | Crabbox does not provision or clean up the host |
 | [superserve](superserve.md) | built-in; `delegated-run` · delegated-sandbox | No SSH; `archive-sync` · direct only; features: `archive-sync`, `cleanup`, `run-session` | `linux`; Superserve hosted sandbox | `provider-managed`; GPU: unknown | Superserve; sandbox delete | Hosted delegated Linux sandbox | Requires both control-plane and data-plane access |
 | [tart](tart.md) (`local-tart`, `macos-vm`) | built-in; `ssh-lease` · local-vm | Crabbox-managed SSH; `crabbox-sync` · direct only; features: `ssh`, `crabbox-sync`, `cleanup`, `desktop` | `macos`; Tart Apple silicon VM | `local`; GPU: no | Crabbox; VM delete | Local macOS VM testing | Apple silicon host and prepared Tart image required |
+| [tencentcloud](tencentcloud.md) (`tencent`, `tencent-cvm`, `cvm`) | built-in; `ssh-lease` · direct-cloud | Crabbox-managed SSH; `crabbox-sync` · direct only; features: `ssh`, `crabbox-sync`, `cleanup`, `tailscale` | `linux`; Tencent Cloud CVM instance | `cloud`; GPU: optional | Crabbox; instance termination | Linux SSH leases on Tencent Cloud CVM | Direct-only; requires CVM image, VPC/subnet/security-group planning, and Tencent Cloud API credentials |
 | [tenki](tenki.md) | built-in; `ssh-lease` · direct-cloud | Crabbox-managed SSH; `crabbox-sync` · direct only; features: `ssh`, `crabbox-sync` | `linux`; Tenki sandbox VM | `provider-managed`; GPU: unknown | Tenki; sandbox release | Managed Linux sandbox with SSH proxy | Gateway auth uses Tenki-managed key and certificate files |
 | [tensorlake](tensorlake.md) (`tl`, `tensorlake-sbx`) | built-in; `delegated-run` · delegated-sandbox | No SSH; `provider-owned` · direct only; features: `run-session` | `linux`; Tensorlake Firecracker sandbox | `provider-managed`; GPU: unknown | Tensorlake; provider sandbox cleanup | Hosted Firecracker-backed delegated execution | Does not expose raw Firecracker provisioning |
 | [upstash-box](upstash-box.md) (`upstash`, `box`, `upstashbox`) | built-in; `delegated-run` · delegated-sandbox | No SSH; `archive-sync` · direct only; features: `archive-sync`, `run-session` | `linux`; Upstash Box sandbox | `provider-managed`; GPU: no | Upstash; sandbox cleanup | Hosted short-lived delegated sandbox | No normal SSH access or coordinator routing |

--- a/docs/providers/provider-metadata.json
+++ b/docs/providers/provider-metadata.json
@@ -853,6 +853,20 @@
     "caveat": "Apple silicon host and prepared Tart image required",
     "docs": "tart.md"
   },
+  "tencentcloud": {
+    "status": "built-in",
+    "category": "direct-cloud",
+    "substrate": "Tencent Cloud CVM instance",
+    "location": "cloud",
+    "ssh": "crabbox-managed",
+    "sync": "crabbox-sync",
+    "gpu": "optional",
+    "lifecycle": "Crabbox",
+    "cleanup": "instance termination",
+    "bestFit": "Linux SSH leases on Tencent Cloud CVM",
+    "caveat": "Direct-only; requires CVM image, VPC/subnet/security-group planning, and Tencent Cloud API credentials",
+    "docs": "tencentcloud.md"
+  },
   "tenki": {
     "status": "built-in",
     "category": "direct-cloud",

--- a/docs/providers/tencentcloud.md
+++ b/docs/providers/tencentcloud.md
@@ -1,0 +1,236 @@
+# Tencent Cloud CVM Provider
+
+Read this when you are:
+
+- choosing `provider: tencentcloud`;
+- validating a direct Tencent Cloud CVM SSH lease;
+- changing `internal/providers/tencentcloud` or live smoke coverage.
+
+Tencent Cloud is registered as a Linux-only **SSH lease** provider. Crabbox
+creates a CVM instance, injects the standard Crabbox cloud-init bootstrap
+through CVM user data, writes Crabbox ownership metadata as Tencent Cloud tags,
+waits for public IPv4 and SSH readiness, then uses the normal Crabbox
+SSH/sync/run/stop/cleanup path.
+
+The provider is **direct-only** in this release. It does not run through the
+coordinator, so the local CLI must have Tencent Cloud API credentials and direct
+cleanup remains the operator's responsibility.
+
+## When To Use It
+
+Use Tencent Cloud CVM when you want Crabbox Linux leases in a Tencent Cloud
+account and local direct credentials are acceptable. Prefer AWS, Azure, GCP, or
+Hetzner when you need a brokered team path, coordinator-side credentials, or
+existing coordinator cost accounting.
+
+## Commands
+
+Auth and inventory can be checked without creating resources:
+
+```sh
+crabbox doctor --provider tencentcloud
+```
+
+The provider is available through the normal SSH-lease command surface:
+
+```sh
+crabbox warmup --provider tencentcloud --tencentcloud-image img-xxxxxxxx
+crabbox run --provider tencentcloud --tencentcloud-image img-xxxxxxxx -- pnpm test
+crabbox ssh --provider tencentcloud --id my-app
+crabbox stop --provider tencentcloud my-app
+crabbox cleanup --provider tencentcloud --dry-run
+```
+
+`--id` accepts the canonical lease id (`cbx_...`), friendly slug, or Tencent
+Cloud instance id (`ins-...`). `--type` is the generic Crabbox server type
+override; `--tencentcloud-type` is the CVM instance type override.
+
+## Configuration
+
+```yaml
+provider: tencentcloud
+target: linux
+class: standard
+tencentcloud:
+  region: ap-shanghai
+  zone: ap-shanghai-2
+  image: img-xxxxxxxx
+  type: SA5.MEDIUM2
+  vpcId: ""
+  subnetId: ""
+  securityGroupId: ""
+  rootGB: 50
+  internetChargeType: TRAFFIC_POSTPAID_BY_HOUR
+  internetMaxBandwidthOut: 5
+  sshCIDRs: []
+```
+
+Config keys under `tencentcloud:`:
+
+| Key | Maps to | Default | Notes |
+| --- | --- | --- | --- |
+| `region` | `cfg.TencentCloud.Region` | `ap-shanghai` | Tencent Cloud API region. |
+| `zone` | `cfg.TencentCloud.Zone` | `ap-shanghai-2` | CVM availability zone. |
+| `image` | `cfg.TencentCloud.Image` | empty | Required CVM image ID, such as a public Ubuntu image or a custom image. |
+| `type` | `cfg.TencentCloud.Type` | `SA5.MEDIUM2` | CVM instance type. |
+| `vpcId` | `cfg.TencentCloud.VPCID` | empty | Optional VPC ID. Most current CVM instance families, including the default `SA5.MEDIUM2`, require VPC networking. |
+| `subnetId` | `cfg.TencentCloud.SubnetID` | empty | Optional subnet ID. Set this with `vpcId` when the selected instance type requires VPC networking. |
+| `securityGroupId` | `cfg.TencentCloud.SecurityGroupID` | empty | Optional existing security group ID. Crabbox does not create or mutate security groups in Phase 1. |
+| `rootGB` | `cfg.TencentCloud.RootGB` | `50` | System disk size in GiB. |
+| `internetChargeType` | `cfg.TencentCloud.InternetChargeType` | `TRAFFIC_POSTPAID_BY_HOUR` | Public bandwidth charge type passed to CVM. |
+| `internetMaxBandwidthOut` | `cfg.TencentCloud.InternetMaxBandwidthOut` | `5` | Public outbound bandwidth in Mbps. |
+| `sshCIDRs` | `cfg.TencentCloud.SSHCIDRs` | empty | Reserved for future security-group mutation. Non-empty values fail fast. |
+| `apiEndpoint` | `cfg.TencentCloud.APIEndpoint` | `https://cvm.tencentcloudapi.com` | Optional CVM API endpoint override. Use `*.intl.tencentcloudapi.com` for international endpoint families when needed. |
+
+Provider-specific flags:
+
+```text
+--tencentcloud-region <region>
+--tencentcloud-zone <zone>
+--tencentcloud-image <image-id>
+--tencentcloud-type <instance-type>
+--tencentcloud-vpc-id <vpc-id>
+--tencentcloud-subnet-id <subnet-id>
+--tencentcloud-security-group-id <security-group-id>
+--tencentcloud-root-gb <gib>
+--tencentcloud-internet-charge-type <charge-type>
+--tencentcloud-internet-max-bandwidth-out <mbps>
+--tencentcloud-api-endpoint <url-or-host>
+```
+
+Tencent Cloud leases default to SSH user `ubuntu` on port `22` with no fallback
+port. Use an Ubuntu-compatible image, or set generic `ssh.user` if your image
+expects another account. Explicit generic `ssh.user` and `ssh.port` values
+remain authoritative.
+
+Environment overrides:
+
+```text
+TENCENTCLOUD_SECRET_ID                      Tencent Cloud API SecretId
+TENCENTCLOUD_SECRET_KEY                     Tencent Cloud API SecretKey
+TENCENTCLOUD_TOKEN                          Optional temporary credential token
+TENCENTCLOUD_ACCOUNT_ID                     Optional account UIN override for tag resource names
+CRABBOX_TENCENTCLOUD_REGION                 Override the region
+CRABBOX_TENCENTCLOUD_ZONE                   Override the zone
+CRABBOX_TENCENTCLOUD_IMAGE                  Override the image ID
+CRABBOX_TENCENTCLOUD_TYPE                   Override the CVM instance type
+CRABBOX_TENCENTCLOUD_VPC_ID                 Override the VPC ID
+CRABBOX_TENCENTCLOUD_SUBNET_ID              Override the subnet ID
+CRABBOX_TENCENTCLOUD_SECURITY_GROUP_ID      Override the security group ID
+CRABBOX_TENCENTCLOUD_ROOT_GB                Override the system disk size
+CRABBOX_TENCENTCLOUD_INTERNET_CHARGE_TYPE   Override the public bandwidth charge type
+CRABBOX_TENCENTCLOUD_INTERNET_MAX_BANDWIDTH_OUT
+CRABBOX_TENCENTCLOUD_API_ENDPOINT           Override the CVM API endpoint
+```
+
+Do not pass Tencent Cloud secrets as command-line arguments. Keep them in the
+environment, a local shell profile, or a secret manager.
+
+## Required Tencent Cloud Permissions
+
+The direct provider signs Tencent Cloud API v3 requests and uses CVM, Tag, and
+STS APIs. A minimal custom policy should allow:
+
+```text
+cvm:DescribeInstances
+cvm:RunInstances
+cvm:TerminateInstances
+tag:ModifyResourceTags
+sts:GetCallerIdentity
+```
+
+Add VPC, image, or security-group permissions required by your account policy
+when using custom images, subnets, or existing security groups. `doctor` calls
+STS and `DescribeInstances`; it does not create resources.
+
+## Lifecycle
+
+1. Generate a per-lease SSH key under the Crabbox testbox key directory.
+2. Create one CVM instance with configured region, zone, image, type, network,
+   optional security group, public bandwidth, cloud-init user data, and Crabbox
+   tags.
+3. Wait for public IPv4 and Crabbox SSH bootstrap readiness.
+4. Replace Crabbox tags with ready-state ownership metadata and claim the lease
+   locally.
+5. Run normal Crabbox sync/run/ssh workflows over SSH.
+6. Update timeout/Tailscale tags on touch.
+7. Terminate the CVM instance on `stop`; `cleanup` deletes only expired
+   resources whose live tags still prove Crabbox ownership.
+
+## Network And Security Groups
+
+Phase 1 does not create or mutate Tencent Cloud security groups. Operators own
+the selected VPC, subnet, default public IP behavior, and security-group
+policy. If `tencentcloud.securityGroupId` is set, Crabbox attaches that
+existing security group during `RunInstances`. If `tencentcloud.sshCIDRs` is
+non-empty, acquire fails fast because Crabbox does not yet create ingress rules.
+
+Use a preconfigured security group that allows SSH from trusted sources, short
+TTLs, and `cleanup --dry-run` during validation.
+
+## Guarded Live Smoke
+
+The repeatable live check is opt-in:
+
+```sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=tencentcloud scripts/live-smoke.sh
+```
+
+or directly:
+
+```sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=tencentcloud scripts/live-tencentcloud-smoke.sh
+```
+
+The script builds `bin/crabbox` unless `CRABBOX_BIN` points at an existing
+binary, verifies the Crabbox-owned Tencent Cloud inventory starts empty, creates
+one short-lived CVM lease, runs `echo ok`, verifies `list --json`, stops the
+lease, runs dry-run cleanup, and verifies the final inventory is empty.
+
+Required inputs:
+
+```text
+TENCENTCLOUD_SECRET_ID
+TENCENTCLOUD_SECRET_KEY
+CRABBOX_LIVE_TENCENTCLOUD_IMAGE or CRABBOX_TENCENTCLOUD_IMAGE or tencentcloud.image
+CRABBOX_TENCENTCLOUD_VPC_ID and CRABBOX_TENCENTCLOUD_SUBNET_ID for VPC-only instance types
+```
+
+Optional smoke overrides:
+
+```text
+CRABBOX_LIVE_TENCENTCLOUD_TYPE
+CRABBOX_TENCENTCLOUD_REGION
+CRABBOX_TENCENTCLOUD_ZONE
+CRABBOX_TENCENTCLOUD_SECURITY_GROUP_ID
+```
+
+Final classifications include:
+
+```text
+classification=live_tencentcloud_smoke_passed
+classification=environment_blocked
+classification=quota_blocked
+classification=validation_failed
+classification=cleanup_failed
+```
+
+## Capabilities
+
+- **SSH** and **Crabbox sync**: yes.
+- **Tailscale**: yes through the standard Linux cloud-init path when a direct
+  Tailscale auth key is configured.
+- **Desktop / browser / code**: not advertised in Phase 1.
+- **Cleanup**: yes, tag-owned only.
+- **Coordinator**: never; direct CLI only.
+
+## Gotchas
+
+- `tencentcloud.image` is required. Tencent Cloud image IDs can vary by region
+  and account, so Crabbox does not guess one.
+- Tag updates need the account UIN. Crabbox calls `sts:GetCallerIdentity`, or
+  uses `TENCENTCLOUD_ACCOUNT_ID` when set.
+- Instances are deleted only after live tags match the local claim's lease,
+  slug, provider, and provider key.
+- This provider does not yet support coordinator/broker mode, native
+  checkpointing, pause/resume, or managed security-group rule creation.

--- a/docs/providers/tencentcloud.md
+++ b/docs/providers/tencentcloud.md
@@ -1,0 +1,237 @@
+# Tencent Cloud CVM Provider
+
+Read this when you are:
+
+- choosing `provider: tencentcloud`;
+- validating a direct Tencent Cloud CVM SSH lease;
+- changing `internal/providers/tencentcloud` or live smoke coverage.
+
+Tencent Cloud is registered as a Linux-only **SSH lease** provider. Crabbox
+creates a CVM instance, injects the standard Crabbox cloud-init bootstrap
+through CVM user data, writes Crabbox ownership metadata as Tencent Cloud tags,
+waits for public IPv4 and SSH readiness, then uses the normal Crabbox
+SSH/sync/run/stop/cleanup path.
+
+The provider is **direct-only** in this release. It does not run through the
+coordinator, so the local CLI must have Tencent Cloud API credentials and direct
+cleanup remains the operator's responsibility.
+
+## When To Use It
+
+Use Tencent Cloud CVM when you want Crabbox Linux leases in a Tencent Cloud
+account and local direct credentials are acceptable. Prefer AWS, Azure, GCP, or
+Hetzner when you need a brokered team path, coordinator-side credentials, or
+existing coordinator cost accounting.
+
+## Commands
+
+Auth and inventory can be checked without creating resources:
+
+```sh
+crabbox doctor --provider tencentcloud
+```
+
+The provider is available through the normal SSH-lease command surface:
+
+```sh
+crabbox warmup --provider tencentcloud --tencentcloud-image img-xxxxxxxx
+crabbox run --provider tencentcloud --tencentcloud-image img-xxxxxxxx -- pnpm test
+crabbox ssh --provider tencentcloud --id my-app
+crabbox stop --provider tencentcloud my-app
+crabbox cleanup --provider tencentcloud --dry-run
+```
+
+`--id` accepts the canonical lease id (`cbx_...`), friendly slug, or Tencent
+Cloud instance id (`ins-...`). `--type` is the generic Crabbox server type
+override; `--tencentcloud-type` is the CVM instance type override.
+
+## Configuration
+
+```yaml
+provider: tencentcloud
+target: linux
+class: standard
+tencentcloud:
+  region: ap-shanghai
+  zone: ap-shanghai-2
+  image: img-xxxxxxxx
+  type: SA5.MEDIUM2
+  vpcId: ""
+  subnetId: ""
+  securityGroupId: ""
+  rootGB: 50
+  internetChargeType: TRAFFIC_POSTPAID_BY_HOUR
+  internetMaxBandwidthOut: 5
+  sshCIDRs: []
+```
+
+Config keys under `tencentcloud:`:
+
+| Key | Maps to | Default | Notes |
+| --- | --- | --- | --- |
+| `region` | `cfg.TencentCloud.Region` | `ap-shanghai` | Tencent Cloud API region. |
+| `zone` | `cfg.TencentCloud.Zone` | `ap-shanghai-2` | CVM availability zone. |
+| `image` | `cfg.TencentCloud.Image` | empty | Required CVM image ID, such as a public Ubuntu image or a custom image. |
+| `type` | `cfg.TencentCloud.Type` | `SA5.MEDIUM2` | CVM instance type. |
+| `vpcId` | `cfg.TencentCloud.VPCID` | empty | Optional VPC ID. |
+| `subnetId` | `cfg.TencentCloud.SubnetID` | empty | Optional subnet ID. |
+| `securityGroupId` | `cfg.TencentCloud.SecurityGroupID` | empty | Optional existing security group ID. Crabbox does not create or mutate security groups in Phase 1. |
+| `rootGB` | `cfg.TencentCloud.RootGB` | `50` | System disk size in GiB. |
+| `internetChargeType` | `cfg.TencentCloud.InternetChargeType` | `TRAFFIC_POSTPAID_BY_HOUR` | Public bandwidth charge type passed to CVM. |
+| `internetMaxBandwidthOut` | `cfg.TencentCloud.InternetMaxBandwidthOut` | `5` | Public outbound bandwidth in Mbps. |
+| `sshCIDRs` | `cfg.TencentCloud.SSHCIDRs` | empty | Reserved for future security-group mutation. Non-empty values fail fast. |
+| `apiEndpoint` | `cfg.TencentCloud.APIEndpoint` | `https://cvm.tencentcloudapi.com` | Optional CVM API endpoint override. Use `*.intl.tencentcloudapi.com` for international endpoint families when needed. |
+
+Provider-specific flags:
+
+```text
+--tencentcloud-region <region>
+--tencentcloud-zone <zone>
+--tencentcloud-image <image-id>
+--tencentcloud-type <instance-type>
+--tencentcloud-vpc-id <vpc-id>
+--tencentcloud-subnet-id <subnet-id>
+--tencentcloud-security-group-id <security-group-id>
+--tencentcloud-root-gb <gib>
+--tencentcloud-internet-charge-type <charge-type>
+--tencentcloud-internet-max-bandwidth-out <mbps>
+--tencentcloud-api-endpoint <url-or-host>
+```
+
+Tencent Cloud leases default to SSH user `ubuntu` on port `22` with no fallback
+port. Use an Ubuntu-compatible image, or set generic `ssh.user` if your image
+expects another account. Explicit generic `ssh.user` and `ssh.port` values
+remain authoritative.
+
+Environment overrides:
+
+```text
+TENCENTCLOUD_SECRET_ID                      Tencent Cloud API SecretId
+TENCENTCLOUD_SECRET_KEY                     Tencent Cloud API SecretKey
+TENCENTCLOUD_TOKEN                          Optional temporary credential token
+TENCENTCLOUD_ACCOUNT_ID                     Optional account UIN override for tag resource names
+CRABBOX_TENCENTCLOUD_REGION                 Override the region
+CRABBOX_TENCENTCLOUD_ZONE                   Override the zone
+CRABBOX_TENCENTCLOUD_IMAGE                  Override the image ID
+CRABBOX_TENCENTCLOUD_TYPE                   Override the CVM instance type
+CRABBOX_TENCENTCLOUD_VPC_ID                 Override the VPC ID
+CRABBOX_TENCENTCLOUD_SUBNET_ID              Override the subnet ID
+CRABBOX_TENCENTCLOUD_SECURITY_GROUP_ID      Override the security group ID
+CRABBOX_TENCENTCLOUD_ROOT_GB                Override the system disk size
+CRABBOX_TENCENTCLOUD_INTERNET_CHARGE_TYPE   Override the public bandwidth charge type
+CRABBOX_TENCENTCLOUD_INTERNET_MAX_BANDWIDTH_OUT
+CRABBOX_TENCENTCLOUD_API_ENDPOINT           Override the CVM API endpoint
+```
+
+Do not pass Tencent Cloud secrets as command-line arguments. Keep them in the
+environment, a local shell profile, or a secret manager.
+
+## Required Tencent Cloud Permissions
+
+The direct provider signs Tencent Cloud API v3 requests and uses CVM, Tag, and
+STS APIs. A minimal custom policy should allow:
+
+```text
+cvm:DescribeInstances
+cvm:RunInstances
+cvm:TerminateInstances
+tag:ModifyResourceTags
+sts:GetCallerIdentity
+```
+
+Add VPC, image, or security-group permissions required by your account policy
+when using custom images, subnets, or existing security groups. `doctor` calls
+STS and `DescribeInstances`; it does not create resources.
+
+## Lifecycle
+
+1. Generate a per-lease SSH key under the Crabbox testbox key directory.
+2. Create one CVM instance with configured region, zone, image, type, network,
+   optional security group, public bandwidth, cloud-init user data, and Crabbox
+   tags.
+3. Wait for public IPv4 and Crabbox SSH bootstrap readiness.
+4. Replace Crabbox tags with ready-state ownership metadata and claim the lease
+   locally.
+5. Run normal Crabbox sync/run/ssh workflows over SSH.
+6. Update timeout/Tailscale tags on touch.
+7. Terminate the CVM instance on `stop`; `cleanup` deletes only expired
+   resources whose live tags still prove Crabbox ownership.
+
+## Network And Security Groups
+
+Phase 1 does not create or mutate Tencent Cloud security groups. Operators own
+the selected VPC, subnet, default public IP behavior, and security-group
+policy. If `tencentcloud.securityGroupId` is set, Crabbox attaches that
+existing security group during `RunInstances`. If `tencentcloud.sshCIDRs` is
+non-empty, acquire fails fast because Crabbox does not yet create ingress rules.
+
+Use a preconfigured security group that allows SSH from trusted sources, short
+TTLs, and `cleanup --dry-run` during validation.
+
+## Guarded Live Smoke
+
+The repeatable live check is opt-in:
+
+```sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=tencentcloud scripts/live-smoke.sh
+```
+
+or directly:
+
+```sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=tencentcloud scripts/live-tencentcloud-smoke.sh
+```
+
+The script builds `bin/crabbox` unless `CRABBOX_BIN` points at an existing
+binary, verifies the Crabbox-owned Tencent Cloud inventory starts empty, creates
+one short-lived CVM lease, runs `echo ok`, verifies `list --json`, stops the
+lease, runs dry-run cleanup, and verifies the final inventory is empty.
+
+Required inputs:
+
+```text
+TENCENTCLOUD_SECRET_ID
+TENCENTCLOUD_SECRET_KEY
+CRABBOX_LIVE_TENCENTCLOUD_IMAGE or CRABBOX_TENCENTCLOUD_IMAGE or tencentcloud.image
+```
+
+Optional smoke overrides:
+
+```text
+CRABBOX_LIVE_TENCENTCLOUD_TYPE
+CRABBOX_TENCENTCLOUD_REGION
+CRABBOX_TENCENTCLOUD_ZONE
+CRABBOX_TENCENTCLOUD_VPC_ID
+CRABBOX_TENCENTCLOUD_SUBNET_ID
+CRABBOX_TENCENTCLOUD_SECURITY_GROUP_ID
+```
+
+Final classifications include:
+
+```text
+classification=live_tencentcloud_smoke_passed
+classification=environment_blocked
+classification=quota_blocked
+classification=validation_failed
+classification=cleanup_failed
+```
+
+## Capabilities
+
+- **SSH** and **Crabbox sync**: yes.
+- **Tailscale**: yes through the standard Linux cloud-init path when a direct
+  Tailscale auth key is configured.
+- **Desktop / browser / code**: not advertised in Phase 1.
+- **Cleanup**: yes, tag-owned only.
+- **Coordinator**: never; direct CLI only.
+
+## Gotchas
+
+- `tencentcloud.image` is required. Tencent Cloud image IDs can vary by region
+  and account, so Crabbox does not guess one.
+- Tag updates need the account UIN. Crabbox calls `sts:GetCallerIdentity`, or
+  uses `TENCENTCLOUD_ACCOUNT_ID` when set.
+- Instances are deleted only after live tags match the local claim's lease,
+  slug, provider, and provider key.
+- This provider does not yet support coordinator/broker mode, native
+  checkpointing, pause/resume, or managed security-group rule creation.

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -121,6 +121,11 @@ type Config struct {
 	scalewayZoneExplicit          bool
 	scalewayImageExplicit         bool
 	scalewayTypeExplicit          bool
+	TencentCloud                  TencentCloudConfig
+	tencentCloudRegionExplicit    bool
+	tencentCloudZoneExplicit      bool
+	tencentCloudImageExplicit     bool
+	tencentCloudTypeExplicit      bool
 	Incus                         IncusConfig
 	Proxmox                       ProxmoxConfig
 	Firecracker                   FirecrackerConfig
@@ -349,6 +354,25 @@ type ScalewayConfig struct {
 	OrganizationID string
 	SecurityGroup  string
 	SSHCIDRs       []string
+}
+
+// TencentCloudConfig contains non-secret Tencent Cloud CVM settings. Tencent
+// Cloud API credentials are intentionally read from TENCENTCLOUD_SECRET_ID and
+// TENCENTCLOUD_SECRET_KEY by the provider client and are not persisted in
+// Crabbox config.
+type TencentCloudConfig struct {
+	Region                  string
+	Zone                    string
+	Image                   string
+	Type                    string
+	VPCID                   string
+	SubnetID                string
+	SecurityGroupID         string
+	SSHCIDRs                []string
+	RootGB                  int64
+	InternetChargeType      string
+	InternetMaxBandwidthOut int64
+	APIEndpoint             string
 }
 
 type ActionsConfig struct {
@@ -1775,6 +1799,52 @@ func applyProviderConfigDefaults(cfg *Config) error {
 		normalizeTargetConfig(cfg)
 		return validateTargetConfig(*cfg)
 	}
+	if cfg.Provider == "tencentcloud" {
+		if cfg.TencentCloud.Region == "" {
+			cfg.TencentCloud.Region = "ap-shanghai"
+		}
+		if cfg.TencentCloud.Zone == "" {
+			cfg.TencentCloud.Zone = "ap-shanghai-2"
+		}
+		if cfg.TencentCloud.Type == "" {
+			cfg.TencentCloud.Type = "SA5.MEDIUM2"
+		}
+		if cfg.TencentCloud.RootGB == 0 {
+			cfg.TencentCloud.RootGB = 50
+		}
+		if cfg.TencentCloud.InternetChargeType == "" {
+			cfg.TencentCloud.InternetChargeType = "TRAFFIC_POSTPAID_BY_HOUR"
+		}
+		if cfg.TencentCloud.InternetMaxBandwidthOut == 0 {
+			cfg.TencentCloud.InternetMaxBandwidthOut = 5
+		}
+		if !IsTargetExplicit(cfg) {
+			cfg.TargetOS = targetLinux
+		}
+		if cfg.explicitWindowsMode != "" {
+			cfg.WindowsMode = cfg.explicitWindowsMode
+		} else {
+			cfg.WindowsMode = windowsModeNormal
+		}
+		if cfg.explicitWorkRoot != "" {
+			cfg.WorkRoot = cfg.explicitWorkRoot
+		} else {
+			cfg.WorkRoot = defaultPOSIXWorkRoot
+		}
+		if cfg.explicitSSHUser != "" {
+			cfg.SSHUser = cfg.explicitSSHUser
+		} else {
+			cfg.SSHUser = "ubuntu"
+		}
+		if cfg.explicitSSHPort != "" {
+			cfg.SSHPort = cfg.explicitSSHPort
+		} else {
+			cfg.SSHPort = "22"
+		}
+		cfg.SSHFallbackPorts = nil
+		normalizeTargetConfig(cfg)
+		return validateTargetConfig(*cfg)
+	}
 	if cfg.Provider == "hyperv" {
 		if !IsTargetExplicit(cfg) {
 			cfg.TargetOS = targetWindows
@@ -2822,6 +2892,7 @@ type fileConfig struct {
 	Nebius                   *fileNebiusConfig                   `yaml:"nebius,omitempty"`
 	OVH                      *fileOVHConfig                      `yaml:"ovh,omitempty"`
 	Scaleway                 *fileScalewayConfig                 `yaml:"scaleway,omitempty"`
+	TencentCloud             *fileTencentCloudConfig             `yaml:"tencentcloud,omitempty"`
 	AWS                      *fileAWSConfig                      `yaml:"aws,omitempty"`
 	AWSLambdaMicroVM         *fileAWSLambdaMicroVMConfig         `yaml:"awsLambdaMicroVM,omitempty"`
 	Azure                    *fileAzureConfig                    `yaml:"azure,omitempty"`
@@ -2996,6 +3067,21 @@ type fileScalewayConfig struct {
 	OrganizationID string   `yaml:"organizationId,omitempty"`
 	SecurityGroup  string   `yaml:"securityGroup,omitempty"`
 	SSHCIDRs       []string `yaml:"sshCIDRs,omitempty"`
+}
+
+type fileTencentCloudConfig struct {
+	Region                  string   `yaml:"region,omitempty"`
+	Zone                    string   `yaml:"zone,omitempty"`
+	Image                   string   `yaml:"image,omitempty"`
+	Type                    string   `yaml:"type,omitempty"`
+	VPCID                   string   `yaml:"vpcId,omitempty"`
+	SubnetID                string   `yaml:"subnetId,omitempty"`
+	SecurityGroupID         string   `yaml:"securityGroupId,omitempty"`
+	SSHCIDRs                []string `yaml:"sshCIDRs,omitempty"`
+	RootGB                  int64    `yaml:"rootGB,omitempty"`
+	InternetChargeType      string   `yaml:"internetChargeType,omitempty"`
+	InternetMaxBandwidthOut int64    `yaml:"internetMaxBandwidthOut,omitempty"`
+	APIEndpoint             string   `yaml:"apiEndpoint,omitempty"`
 }
 
 type fileAWSConfig struct {
@@ -4544,6 +4630,48 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 		}
 		if len(file.Scaleway.SSHCIDRs) > 0 {
 			cfg.Scaleway.SSHCIDRs = file.Scaleway.SSHCIDRs
+		}
+	}
+	if file.TencentCloud != nil {
+		if file.TencentCloud.Region != "" {
+			cfg.TencentCloud.Region = file.TencentCloud.Region
+			cfg.tencentCloudRegionExplicit = true
+		}
+		if file.TencentCloud.Zone != "" {
+			cfg.TencentCloud.Zone = file.TencentCloud.Zone
+			cfg.tencentCloudZoneExplicit = true
+		}
+		if file.TencentCloud.Image != "" {
+			cfg.TencentCloud.Image = file.TencentCloud.Image
+			cfg.tencentCloudImageExplicit = true
+		}
+		if file.TencentCloud.Type != "" {
+			cfg.TencentCloud.Type = file.TencentCloud.Type
+			cfg.tencentCloudTypeExplicit = true
+		}
+		if file.TencentCloud.VPCID != "" {
+			cfg.TencentCloud.VPCID = file.TencentCloud.VPCID
+		}
+		if file.TencentCloud.SubnetID != "" {
+			cfg.TencentCloud.SubnetID = file.TencentCloud.SubnetID
+		}
+		if file.TencentCloud.SecurityGroupID != "" {
+			cfg.TencentCloud.SecurityGroupID = file.TencentCloud.SecurityGroupID
+		}
+		if len(file.TencentCloud.SSHCIDRs) > 0 {
+			cfg.TencentCloud.SSHCIDRs = file.TencentCloud.SSHCIDRs
+		}
+		if file.TencentCloud.RootGB > 0 {
+			cfg.TencentCloud.RootGB = file.TencentCloud.RootGB
+		}
+		if file.TencentCloud.InternetChargeType != "" {
+			cfg.TencentCloud.InternetChargeType = file.TencentCloud.InternetChargeType
+		}
+		if file.TencentCloud.InternetMaxBandwidthOut > 0 {
+			cfg.TencentCloud.InternetMaxBandwidthOut = file.TencentCloud.InternetMaxBandwidthOut
+		}
+		if trusted && file.TencentCloud.APIEndpoint != "" {
+			cfg.TencentCloud.APIEndpoint = file.TencentCloud.APIEndpoint
 		}
 	}
 	if file.AWS != nil {
@@ -7016,6 +7144,32 @@ func applyEnv(cfg *Config) error {
 	if cidrs := os.Getenv("CRABBOX_SCALEWAY_SSH_CIDRS"); cidrs != "" {
 		cfg.Scaleway.SSHCIDRs = splitCommaList(cidrs)
 	}
+	if region := os.Getenv("CRABBOX_TENCENTCLOUD_REGION"); region != "" {
+		cfg.TencentCloud.Region = region
+		cfg.tencentCloudRegionExplicit = true
+	}
+	if zone := os.Getenv("CRABBOX_TENCENTCLOUD_ZONE"); zone != "" {
+		cfg.TencentCloud.Zone = zone
+		cfg.tencentCloudZoneExplicit = true
+	}
+	if image := os.Getenv("CRABBOX_TENCENTCLOUD_IMAGE"); image != "" {
+		cfg.TencentCloud.Image = image
+		cfg.tencentCloudImageExplicit = true
+	}
+	if serverType := os.Getenv("CRABBOX_TENCENTCLOUD_TYPE"); serverType != "" {
+		cfg.TencentCloud.Type = serverType
+		cfg.tencentCloudTypeExplicit = true
+	}
+	cfg.TencentCloud.VPCID = getenv("CRABBOX_TENCENTCLOUD_VPC_ID", cfg.TencentCloud.VPCID)
+	cfg.TencentCloud.SubnetID = getenv("CRABBOX_TENCENTCLOUD_SUBNET_ID", cfg.TencentCloud.SubnetID)
+	cfg.TencentCloud.SecurityGroupID = getenv("CRABBOX_TENCENTCLOUD_SECURITY_GROUP_ID", cfg.TencentCloud.SecurityGroupID)
+	if cidrs := os.Getenv("CRABBOX_TENCENTCLOUD_SSH_CIDRS"); cidrs != "" {
+		cfg.TencentCloud.SSHCIDRs = splitCommaList(cidrs)
+	}
+	cfg.TencentCloud.RootGB = getenvInt64("CRABBOX_TENCENTCLOUD_ROOT_GB", cfg.TencentCloud.RootGB)
+	cfg.TencentCloud.InternetChargeType = getenv("CRABBOX_TENCENTCLOUD_INTERNET_CHARGE_TYPE", cfg.TencentCloud.InternetChargeType)
+	cfg.TencentCloud.InternetMaxBandwidthOut = getenvInt64("CRABBOX_TENCENTCLOUD_INTERNET_MAX_BANDWIDTH_OUT", cfg.TencentCloud.InternetMaxBandwidthOut)
+	cfg.TencentCloud.APIEndpoint = getenv("CRABBOX_TENCENTCLOUD_API_ENDPOINT", cfg.TencentCloud.APIEndpoint)
 	if value := os.Getenv("CRABBOX_PROXMOX_API_URL"); value != "" {
 		cfg.Proxmox.APIURL = value
 		cfg.credentialProvenance.proxmoxAPIURL = credentialSourceEnvironment
@@ -8543,6 +8697,18 @@ func getenvInt32(name string, fallback int32) int32 {
 		return fallback
 	}
 	return int32(n)
+}
+
+func getenvInt64(name string, fallback int64) int64 {
+	v := os.Getenv(name)
+	if v == "" {
+		return fallback
+	}
+	n, err := strconv.ParseInt(v, 10, 64)
+	if err != nil {
+		return fallback
+	}
+	return n
 }
 
 func getenvFloat(name string, fallback float64) float64 {

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -91,6 +91,16 @@ func effectiveConfigForShow(cfg Config) Config {
 		}
 		cfg.SSHFallbackPorts = nil
 	}
+	if cfg.Provider == "tencentcloud" {
+		base := baseConfig()
+		if !IsSSHUserExplicit(&cfg) && (cfg.SSHUser == "" || cfg.SSHUser == base.SSHUser) {
+			cfg.SSHUser = "ubuntu"
+		}
+		if !IsSSHPortExplicit(&cfg) && (cfg.SSHPort == "" || cfg.SSHPort == base.SSHPort) {
+			cfg.SSHPort = "22"
+		}
+		cfg.SSHFallbackPorts = nil
+	}
 	if cfg.Provider == "hostinger" {
 		cfg.WorkRoot = cfg.Hostinger.WorkRoot
 		cfg.SSHUser = cfg.Hostinger.User
@@ -269,6 +279,21 @@ func configShowView(cfg Config) map[string]any {
 			"securityGroup":  cfg.Scaleway.SecurityGroup,
 			"sshCIDRs":       cfg.Scaleway.SSHCIDRs,
 			"auth":           scalewayAuthState(),
+		},
+		"tencentcloud": map[string]any{
+			"region":                  cfg.TencentCloud.Region,
+			"zone":                    cfg.TencentCloud.Zone,
+			"image":                   cfg.TencentCloud.Image,
+			"type":                    cfg.TencentCloud.Type,
+			"vpcId":                   cfg.TencentCloud.VPCID,
+			"subnetId":                cfg.TencentCloud.SubnetID,
+			"securityGroupId":         cfg.TencentCloud.SecurityGroupID,
+			"sshCIDRs":                cfg.TencentCloud.SSHCIDRs,
+			"rootGB":                  cfg.TencentCloud.RootGB,
+			"internetChargeType":      cfg.TencentCloud.InternetChargeType,
+			"internetMaxBandwidthOut": cfg.TencentCloud.InternetMaxBandwidthOut,
+			"apiEndpoint":             redactedConfigURL(cfg.TencentCloud.APIEndpoint),
+			"auth":                    tencentCloudAuthState(),
 		},
 		"azureDynamicSessions": map[string]any{
 			"endpoint":        cfg.AzureDynamicSessions.Endpoint,
@@ -643,6 +668,7 @@ func writeConfigShowText(w io.Writer, cfg Config) {
 	fmt.Fprintf(w, "hostinger api_url=%s item_id=%s payment_method_id=%s template_id=%s data_center_id=%s hostname_prefix=%s user=%s work_root=%s allow_purchase=%t release_action=%s auth=%s\n", blank(cfg.Hostinger.APIURL, "-"), blank(cfg.Hostinger.ItemID, "-"), blank(cfg.Hostinger.PaymentMethodID, "-"), blank(cfg.Hostinger.TemplateID, "-"), blank(cfg.Hostinger.DataCenterID, "-"), blank(cfg.Hostinger.HostnamePrefix, "-"), blank(cfg.Hostinger.User, "-"), blank(cfg.Hostinger.WorkRoot, "-"), cfg.Hostinger.AllowPurchase, blank(cfg.Hostinger.ReleaseAction, "-"), tokenState(cfg.Hostinger.APIToken))
 	fmt.Fprintf(w, "ovh endpoint=%s project_id=%s region=%s image=%s flavor=%s auth=%s\n", blank(redactedConfigURL(cfg.OVH.Endpoint), "-"), blank(cfg.OVH.ProjectID, "-"), blank(cfg.OVH.Region, "-"), blank(cfg.OVH.Image, "-"), blank(cfg.OVH.Flavor, "-"), ovhAuthState())
 	fmt.Fprintf(w, "scaleway region=%s zone=%s image=%s type=%s project_id=%s organization_id=%s security_group=%s ssh_cidrs=%s auth=%s\n", blank(cfg.Scaleway.Region, "-"), blank(cfg.Scaleway.Zone, "-"), blank(cfg.Scaleway.Image, "-"), blank(cfg.Scaleway.Type, "-"), blank(cfg.Scaleway.ProjectID, "-"), blank(cfg.Scaleway.OrganizationID, "-"), blank(cfg.Scaleway.SecurityGroup, "-"), blank(strings.Join(cfg.Scaleway.SSHCIDRs, ","), "-"), scalewayAuthState())
+	fmt.Fprintf(w, "tencentcloud region=%s zone=%s image=%s type=%s vpc_id=%s subnet_id=%s security_group_id=%s root_gb=%d internet_charge_type=%s internet_max_bandwidth_out=%d ssh_cidrs=%s api_endpoint=%s auth=%s\n", blank(cfg.TencentCloud.Region, "-"), blank(cfg.TencentCloud.Zone, "-"), blank(cfg.TencentCloud.Image, "-"), blank(cfg.TencentCloud.Type, "-"), blank(cfg.TencentCloud.VPCID, "-"), blank(cfg.TencentCloud.SubnetID, "-"), blank(cfg.TencentCloud.SecurityGroupID, "-"), cfg.TencentCloud.RootGB, blank(cfg.TencentCloud.InternetChargeType, "-"), cfg.TencentCloud.InternetMaxBandwidthOut, blank(strings.Join(cfg.TencentCloud.SSHCIDRs, ","), "-"), blank(redactedConfigURL(cfg.TencentCloud.APIEndpoint), "-"), tencentCloudAuthState())
 	fmt.Fprintf(w, "azure_dynamic_sessions endpoint=%s unsupported_pool=%s api_version=%s workdir=%s timeout_secs=%d\n", blank(cfg.AzureDynamicSessions.Endpoint, "-"), blank(cfg.AzureDynamicSessions.Pool, "-"), cfg.AzureDynamicSessions.APIVersion, cfg.AzureDynamicSessions.Workdir, cfg.AzureDynamicSessions.TimeoutSecs)
 	fmt.Fprintf(w, "gcp project=%s zone=%s image=%s network=%s subnet=%s root_gb=%d ssh_cidrs=%s\n", blank(cfg.GCPProject, "-"), cfg.GCPZone, cfg.GCPImage, cfg.GCPNetwork, blank(cfg.GCPSubnet, "-"), cfg.GCPRootGB, blank(strings.Join(cfg.GCPSSHCIDRs, ","), "-"))
 	fmt.Fprintf(w, "proxmox api_url=%s node=%s template_id=%d storage=%s pool=%s bridge=%s user=%s work_root=%s full_clone=%t auth=%s\n", blank(redactedConfigURL(cfg.Proxmox.APIURL), "-"), blank(cfg.Proxmox.Node, "-"), cfg.Proxmox.TemplateID, blank(cfg.Proxmox.Storage, "-"), blank(cfg.Proxmox.Pool, "-"), blank(cfg.Proxmox.Bridge, "-"), cfg.Proxmox.User, cfg.Proxmox.WorkRoot, cfg.Proxmox.FullClone, tokenState(cfg.Proxmox.TokenSecret))
@@ -964,6 +990,27 @@ func scalewayAuthState() string {
 	values := []string{
 		os.Getenv("SCW_ACCESS_KEY"),
 		os.Getenv("SCW_SECRET_KEY"),
+	}
+	configured := 0
+	for _, value := range values {
+		if value != "" {
+			configured++
+		}
+	}
+	switch configured {
+	case 0:
+		return "missing"
+	case len(values):
+		return "configured"
+	default:
+		return "partial"
+	}
+}
+
+func tencentCloudAuthState() string {
+	values := []string{
+		os.Getenv("TENCENTCLOUD_SECRET_ID"),
+		os.Getenv("TENCENTCLOUD_SECRET_KEY"),
 	}
 	configured := 0
 	for _, value := range values {

--- a/internal/cli/provider_categories_generated.go
+++ b/internal/cli/provider_categories_generated.go
@@ -62,6 +62,7 @@ var benchmarkProviderCategories = map[string]string{
 	"ssh":                        "byo-ssh",
 	"superserve":                 "delegated-sandbox",
 	"tart":                       "local-vm",
+	"tencentcloud":               "direct-cloud",
 	"tenki":                      "direct-cloud",
 	"tensorlake":                 "delegated-sandbox",
 	"upstash-box":                "delegated-sandbox",

--- a/internal/cli/provider_exports.go
+++ b/internal/cli/provider_exports.go
@@ -308,6 +308,38 @@ func SetScalewayTypeExplicit(cfg *Config) {
 	cfg.scalewayTypeExplicit = true
 }
 
+func TencentCloudRegionWasExplicit(cfg Config) bool {
+	return cfg.tencentCloudRegionExplicit
+}
+
+func SetTencentCloudRegionExplicit(cfg *Config) {
+	cfg.tencentCloudRegionExplicit = true
+}
+
+func TencentCloudZoneWasExplicit(cfg Config) bool {
+	return cfg.tencentCloudZoneExplicit
+}
+
+func SetTencentCloudZoneExplicit(cfg *Config) {
+	cfg.tencentCloudZoneExplicit = true
+}
+
+func TencentCloudImageWasExplicit(cfg Config) bool {
+	return cfg.tencentCloudImageExplicit
+}
+
+func SetTencentCloudImageExplicit(cfg *Config) {
+	cfg.tencentCloudImageExplicit = true
+}
+
+func TencentCloudTypeWasExplicit(cfg Config) bool {
+	return cfg.tencentCloudTypeExplicit
+}
+
+func SetTencentCloudTypeExplicit(cfg *Config) {
+	cfg.tencentCloudTypeExplicit = true
+}
+
 func CrabboxStateDir() (string, error) {
 	return crabboxStateDir()
 }

--- a/internal/providers/all/all.go
+++ b/internal/providers/all/all.go
@@ -60,6 +60,7 @@ import (
 	_ "github.com/openclaw/crabbox/internal/providers/ssh"
 	_ "github.com/openclaw/crabbox/internal/providers/superserve"
 	_ "github.com/openclaw/crabbox/internal/providers/tart"
+	_ "github.com/openclaw/crabbox/internal/providers/tencentcloud"
 	_ "github.com/openclaw/crabbox/internal/providers/tenki"
 	_ "github.com/openclaw/crabbox/internal/providers/tensorlake"
 	_ "github.com/openclaw/crabbox/internal/providers/upstashbox"

--- a/internal/providers/all/all_test.go
+++ b/internal/providers/all/all_test.go
@@ -1183,6 +1183,7 @@ func allBuiltInProviderNames() []string {
 		"ssh",
 		"superserve",
 		"tart",
+		"tencentcloud",
 		"tenki",
 		"tensorlake",
 		"upstash-box",

--- a/internal/providers/tencentcloud/backend.go
+++ b/internal/providers/tencentcloud/backend.go
@@ -1,0 +1,584 @@
+package tencentcloud
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
+)
+
+type Backend struct {
+	shared.DirectSSHBackend
+	clientFactory func(core.Config, core.Runtime) (tencentCloudAPI, error)
+	waitSSH       func(context.Context, *core.SSHTarget, string, time.Duration) error
+	now           func() time.Time
+}
+
+func NewBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
+	cfg = cfgForRun(cfg)
+	b := &Backend{
+		DirectSSHBackend: shared.DirectSSHBackend{SpecValue: spec, Cfg: cfg, RT: rt, StoredLeaseKeys: true},
+		clientFactory: func(cfg core.Config, rt core.Runtime) (tencentCloudAPI, error) {
+			return newClient(cfg, rt)
+		},
+		waitSSH: func(ctx context.Context, target *core.SSHTarget, phase string, timeout time.Duration) error {
+			return core.WaitForSSHReady(ctx, target, rt.Stderr, phase, timeout)
+		},
+		now: time.Now,
+	}
+	if rt.Clock != nil {
+		b.now = func() time.Time { return rt.Clock.Now().UTC() }
+	}
+	b.Delete = b.deleteServer
+	return b
+}
+
+func (b *Backend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
+	client, err := b.clientFactory(b.Cfg, b.RT)
+	if err != nil {
+		return core.DoctorResult{Provider: providerName, Message: err.Error(), Status: "failed", Checks: []core.DoctorCheck{{
+			Status:  "failed",
+			Check:   "auth",
+			Message: err.Error(),
+			Details: map[string]string{"mutation": "false"},
+		}}}, nil
+	}
+	if _, err := client.AccountID(ctx); err != nil {
+		return core.DoctorResult{}, err
+	}
+	instances, err := client.ListInstances(ctx)
+	if err != nil {
+		return core.DoctorResult{}, err
+	}
+	count := 0
+	for _, item := range instances {
+		if ownedLabels(labelsFromTags(item.Tags)) {
+			count++
+		}
+	}
+	result := core.InventoryDoctorResult(providerName, count)
+	result.Message += fmt.Sprintf(" region=%s zone=%s type=%s image=%s", regionForConfig(b.Cfg), zoneForConfig(b.Cfg), serverTypeForConfig(b.Cfg), blank(imageForConfig(b.Cfg), "-"))
+	return result, nil
+}
+
+func (b *Backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.LeaseTarget, error) {
+	return shared.AcquireAttemptsRetry(b.RT, req.Keep, func() (core.LeaseTarget, error) {
+		return b.acquireOnce(ctx, req)
+	})
+}
+
+func (b *Backend) acquireOnce(ctx context.Context, req core.AcquireRequest) (target core.LeaseTarget, err error) {
+	cfg := cfgForRun(b.Cfg)
+	if err := validateAcquireConfig(cfg); err != nil {
+		return core.LeaseTarget{}, err
+	}
+	if cfg.Tailscale.Enabled && cfg.Tailscale.AuthKey == "" {
+		return core.LeaseTarget{}, core.Exit(2, "direct --tailscale requires %s to contain a Tailscale auth key", cfg.Tailscale.AuthKeyEnv)
+	}
+	client, err := b.clientFactory(cfg, b.RT)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	accountID, err := client.AccountID(ctx)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	leaseID := core.NewLeaseID()
+	instances, err := client.ListInstances(ctx)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	servers := make([]core.Server, 0, len(instances))
+	for _, item := range instances {
+		if ownedLabels(labelsFromTags(item.Tags)) {
+			servers = append(servers, serverFromInstance(item, cfg))
+		}
+	}
+	slug, err := core.AllocateDirectLeaseSlug(leaseID, req.RequestedSlug, servers)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	keyPath, publicKey, err := core.EnsureTestboxKeyForConfig(cfg, leaseID)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	createdID := ""
+	committed := false
+	defer func() {
+		if err == nil || committed {
+			return
+		}
+		if createdID != "" {
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+			cleanupErr := client.TerminateInstance(cleanupCtx, createdID)
+			cancel()
+			if cleanupErr != nil {
+				err = fmt.Errorf("%v; tencentcloud cleanup failed: %w", err, cleanupErr)
+			}
+		}
+		core.RemoveStoredTestboxKey(leaseID)
+	}()
+	cfg.SSHKey = keyPath
+	cfg.ProviderKey = core.ProviderKeyForLease(leaseID)
+	cfg.ServerType = serverTypeForConfig(cfg)
+	if cfg.Tailscale.Enabled && cfg.Tailscale.Hostname == "" {
+		cfg.Tailscale.Hostname = core.RenderTailscaleHostname(cfg.Tailscale.HostnameTemplate, leaseID, slug, cfg.Provider)
+	}
+	now := b.clockNow()
+	createTags := leaseTags(cfg, leaseID, slug, "provisioning", req.Keep, now)
+	createTags = append(createTags, tag{Key: accountLabel, Value: accountID})
+	createReq := buildRunInstanceRequest(cfg, leaseID, slug, publicKey, createTags)
+	fmt.Fprintf(b.RT.Stderr, "provisioning provider=tencentcloud lease=%s slug=%s type=%s region=%s zone=%s image=%s keep=%v\n", leaseID, slug, cfg.ServerType, regionForConfig(cfg), zoneForConfig(cfg), imageForConfig(cfg), req.Keep)
+	createdID, err = client.RunInstance(ctx, createReq)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	instance, err := b.waitForInstanceIP(ctx, client, createdID)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	server := serverFromInstance(instance, cfg)
+	ssh := core.SSHTargetFromConfig(cfg, server.PublicNet.IPv4.IP)
+	if err := b.waitSSH(ctx, &ssh, "tencentcloud bootstrap", core.BootstrapWaitTimeout(cfg)); err != nil {
+		return core.LeaseTarget{}, err
+	}
+	readyLabels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", req.Keep, now)
+	readyLabels["state"] = "ready"
+	readyLabels[accountLabel] = accountID
+	if err := client.ReplaceInstanceTags(ctx, createdID, instance.Tags, tagsFromLabels(readyLabels)); err != nil {
+		return core.LeaseTarget{}, err
+	}
+	server.Labels = readyLabels
+	server.Status = "ready"
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, ssh, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
+		return core.LeaseTarget{}, err
+	}
+	committed = true
+	fmt.Fprintf(b.RT.Stderr, "provisioned lease=%s tencentcloud_instance=%s type=%s\n", leaseID, server.DisplayID(), cfg.ServerType)
+	return core.LeaseTarget{Server: server, SSH: ssh, LeaseID: leaseID}, nil
+}
+
+func buildRunInstanceRequest(cfg core.Config, leaseID, slug, publicKey string, tags []tag) runInstanceRequest {
+	req := runInstanceRequest{
+		InstanceChargeType: "POSTPAID_BY_HOUR",
+		Placement:          placement{Zone: zoneForConfig(cfg)},
+		ImageID:            imageForConfig(cfg),
+		InstanceType:       serverTypeForConfig(cfg),
+		InstanceCount:      1,
+		InstanceName:       core.LeaseProviderName(leaseID, slug),
+		UserData:           base64.StdEncoding.EncodeToString([]byte(core.CloudInitUserData(cfg, publicKey))),
+		ClientToken:        strings.ReplaceAll(core.ProviderKeyForLease(leaseID), "_", "-"),
+		TagSpecification: []tagSpecification{{
+			ResourceType: "instance",
+			Tags:         tags,
+		}},
+	}
+	if cfg.TencentCloud.RootGB > 0 {
+		req.SystemDisk = &systemDisk{DiskSize: cfg.TencentCloud.RootGB}
+	}
+	if cfg.TencentCloud.VPCID != "" || cfg.TencentCloud.SubnetID != "" {
+		req.VirtualPrivateCloud = &virtualPrivateCloud{VPCID: cfg.TencentCloud.VPCID, SubnetID: cfg.TencentCloud.SubnetID}
+	}
+	if cfg.TencentCloud.InternetMaxBandwidthOut > 0 {
+		req.InternetAccessible = &internetAccessible{
+			InternetChargeType:      cfg.TencentCloud.InternetChargeType,
+			InternetMaxBandwidthOut: cfg.TencentCloud.InternetMaxBandwidthOut,
+			PublicIPAssigned:        true,
+		}
+	}
+	if cfg.TencentCloud.SecurityGroupID != "" {
+		req.SecurityGroupIDs = []string{cfg.TencentCloud.SecurityGroupID}
+	}
+	return req
+}
+
+func (b *Backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.LeaseTarget, error) {
+	cfg := cfgForRun(b.Cfg)
+	client, err := b.clientFactory(cfg, b.RT)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	accountID, err := client.AccountID(ctx)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	instances, err := client.ListInstances(ctx)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	servers := make([]core.Server, 0, len(instances))
+	byID := map[string]instance{}
+	for _, item := range instances {
+		if !ownedLabels(labelsFromTags(item.Tags)) {
+			continue
+		}
+		server := serverFromInstance(item, cfg)
+		servers = append(servers, server)
+		byID[server.CloudID] = item
+	}
+	server, leaseID, err := core.FindServerByAlias(servers, req.ID)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	if leaseID != "" {
+		return b.targetFromInstance(byID[server.CloudID], req, accountID)
+	}
+	if isTencentInstanceID(req.ID) {
+		item, err := client.GetInstance(ctx, req.ID)
+		if err != nil {
+			if req.ReleaseOnly && isNotFound(err) {
+				return b.releaseTargetFromClaim(req.ID, accountID)
+			}
+			return core.LeaseTarget{}, err
+		}
+		return b.targetFromInstance(item, req, accountID)
+	}
+	if req.ReleaseOnly {
+		return b.releaseTargetFromClaim(req.ID, accountID)
+	}
+	return core.LeaseTarget{}, core.Exit(4, "lease/tencentcloud instance not found: %s", req.ID)
+}
+
+func (b *Backend) releaseTargetFromClaim(id, accountID string) (core.LeaseTarget, error) {
+	claim, ok, exact, err := core.ResolveLeaseClaimForProviderWithExact(id, providerName)
+	if err == nil && exact && (!ok || claim.LeaseID != id) {
+		return core.LeaseTarget{}, core.Exit(2, "tencentcloud exact lease identifier %q does not match a valid tencentcloud claim", id)
+	}
+	if err == nil && !ok && isTencentInstanceID(id) {
+		claim, ok, err = core.ResolveLeaseClaimForProviderCloudID(id, providerName)
+	}
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	if !ok || claim.LeaseID == "" {
+		return core.LeaseTarget{}, core.Exit(4, "lease/tencentcloud instance not found: %s", id)
+	}
+	if !core.LeaseClaimMatchesIdentifier(claim, id) {
+		return core.LeaseTarget{}, core.Exit(2, "tencentcloud lease claim does not match requested identifier %q", id)
+	}
+	if err := validateClaimIdentity(claim, claim.LeaseID, claim.Slug); err != nil {
+		return core.LeaseTarget{}, err
+	}
+	if expected := strings.TrimSpace(claim.Labels[accountLabel]); expected != "" && expected != accountID {
+		return core.LeaseTarget{}, core.Exit(3, "tencentcloud account mismatch: current account %s does not match lease account %s", accountID, expected)
+	}
+	server := core.Server{
+		Provider: providerName,
+		CloudID:  claim.CloudID,
+		Name:     core.LeaseProviderName(claim.LeaseID, claim.Slug),
+		Labels:   claim.Labels,
+	}
+	return core.LeaseTarget{LeaseID: claim.LeaseID, Server: server}, nil
+}
+
+func (b *Backend) targetFromInstance(item instance, req core.ResolveRequest, accountID string) (core.LeaseTarget, error) {
+	labels := labelsFromTags(item.Tags)
+	if !ownedLabels(labels) {
+		return core.LeaseTarget{}, core.Exit(2, "refusing to operate on non-crabbox Tencent Cloud instance %s", item.InstanceID)
+	}
+	labels[accountLabel] = accountID
+	server := serverFromInstance(item, b.Cfg)
+	server.Labels = labels
+	leaseID := labels["lease"]
+	if leaseID == "" {
+		return core.LeaseTarget{}, core.Exit(2, "tencentcloud instance %s is missing lease tag", item.InstanceID)
+	}
+	claim, claimExists, claimErr := core.ReadLeaseClaimWithPresence(leaseID)
+	if claimErr != nil {
+		return core.LeaseTarget{}, fmt.Errorf("read tencentcloud lease claim: %w", claimErr)
+	}
+	if claimExists {
+		if claim.Provider != providerName {
+			return core.LeaseTarget{}, core.Exit(2, "lease=%s is claimed by provider=%s; refusing tencentcloud claim rewrite", leaseID, claim.Provider)
+		}
+		if err := validateClaimIdentity(claim, leaseID, labels["slug"]); err != nil {
+			return core.LeaseTarget{}, err
+		}
+		if expected := strings.TrimSpace(claim.Labels[accountLabel]); expected != "" && expected != accountID {
+			return core.LeaseTarget{}, core.Exit(3, "tencentcloud account mismatch: current account %s does not match lease account %s", accountID, expected)
+		}
+		if claim.CloudID != "" && claim.CloudID != server.CloudID {
+			return core.LeaseTarget{}, core.Exit(2, "refusing to resolve Tencent Cloud instance %s from stale local claim", server.CloudID)
+		}
+	}
+	if req.ReleaseOnly {
+		return core.LeaseTarget{Server: server, LeaseID: leaseID}, nil
+	}
+	cfg := cfgForRun(b.Cfg)
+	ssh := core.SSHTargetFromConfig(cfg, server.PublicNet.IPv4.IP)
+	if keyPath, err := core.TestboxKeyPath(leaseID); err == nil {
+		if _, statErr := os.Stat(keyPath); statErr == nil {
+			ssh.Key = keyPath
+		}
+	}
+	if req.Repo.Root != "" {
+		if _, err := core.ClaimLeaseTargetForRepoConfigIfUnchanged(leaseID, labels["slug"], cfg, server, ssh, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, claim, claimExists); err != nil {
+			return core.LeaseTarget{}, err
+		}
+	}
+	return core.LeaseTarget{Server: server, SSH: ssh, LeaseID: leaseID}, nil
+}
+
+func (b *Backend) List(ctx context.Context, _ core.ListRequest) ([]core.LeaseView, error) {
+	client, err := b.clientFactory(b.Cfg, b.RT)
+	if err != nil {
+		return nil, err
+	}
+	instances, err := client.ListInstances(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]core.LeaseView, 0, len(instances))
+	for _, item := range instances {
+		if ownedLabels(labelsFromTags(item.Tags)) {
+			out = append(out, serverFromInstance(item, b.Cfg))
+		}
+	}
+	return out, nil
+}
+
+func (b *Backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest) error {
+	return b.deleteServer(ctx, b.Cfg, req.Lease.Server)
+}
+
+func (b *Backend) ReleaseLeaseMessage(lease core.LeaseTarget) string {
+	return fmt.Sprintf("deleted lease=%s tencentcloud_instance=%s name=%s", lease.LeaseID, lease.Server.DisplayID(), lease.Server.Name)
+}
+
+func (b *Backend) Touch(ctx context.Context, req core.TouchRequest) (core.Server, error) {
+	server := req.Lease.Server
+	if !ownedLabels(server.Labels) {
+		return core.Server{}, core.Exit(2, "refusing to touch non-crabbox Tencent Cloud instance %s", server.DisplayID())
+	}
+	client, err := b.clientFactory(b.Cfg, b.RT)
+	if err != nil {
+		return core.Server{}, err
+	}
+	item, err := client.GetInstance(ctx, server.CloudID)
+	if err != nil {
+		return core.Server{}, err
+	}
+	if err := validateLiveInstance(item, server); err != nil {
+		return core.Server{}, err
+	}
+	labels := labelsFromTags(item.Tags)
+	if accountID := strings.TrimSpace(server.Labels[accountLabel]); accountID != "" {
+		labels[accountLabel] = accountID
+	}
+	cfg := b.Cfg
+	if req.IdleTimeout > 0 {
+		cfg.IdleTimeout = req.IdleTimeout
+		delete(labels, "idle_timeout")
+		delete(labels, "idle_timeout_secs")
+	}
+	labels = core.TouchDirectLeaseLabels(labels, cfg, req.State, b.clockNow())
+	if err := client.ReplaceInstanceTags(ctx, server.CloudID, item.Tags, tagsFromLabels(labels)); err != nil {
+		return core.Server{}, err
+	}
+	server.Labels = labels
+	return server, nil
+}
+
+func (b *Backend) UpdateTailscaleMetadata(ctx context.Context, lease core.LeaseTarget, meta core.TailscaleMetadata) (core.Server, error) {
+	server := lease.Server
+	if !ownedLabels(server.Labels) {
+		return core.Server{}, core.Exit(2, "refusing to update tailscale metadata on non-crabbox Tencent Cloud instance %s", server.DisplayID())
+	}
+	client, err := b.clientFactory(b.Cfg, b.RT)
+	if err != nil {
+		return core.Server{}, err
+	}
+	item, err := client.GetInstance(ctx, server.CloudID)
+	if err != nil {
+		return core.Server{}, err
+	}
+	if err := validateLiveInstance(item, server); err != nil {
+		return core.Server{}, err
+	}
+	labels := labelsFromTags(item.Tags)
+	if accountID := strings.TrimSpace(server.Labels[accountLabel]); accountID != "" {
+		labels[accountLabel] = accountID
+	}
+	applyTailscaleMetadata(labels, meta)
+	if err := client.ReplaceInstanceTags(ctx, server.CloudID, item.Tags, tagsFromLabels(labels)); err != nil {
+		return core.Server{}, err
+	}
+	server.Labels = labels
+	return server, nil
+}
+
+func (b *Backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
+	servers, err := b.List(ctx, core.ListRequest{Options: req.Options})
+	if err != nil {
+		return err
+	}
+	return b.CleanupServers(ctx, req, servers)
+}
+
+func (b *Backend) deleteServer(ctx context.Context, _ core.Config, server core.Server) error {
+	if !ownedLabels(server.Labels) {
+		return core.Exit(2, "refusing to delete non-crabbox Tencent Cloud instance %s", server.DisplayID())
+	}
+	client, err := b.clientFactory(b.Cfg, b.RT)
+	if err != nil {
+		return err
+	}
+	accountID, err := client.AccountID(ctx)
+	if err != nil {
+		return err
+	}
+	if expected := strings.TrimSpace(server.Labels[accountLabel]); expected != "" && expected != accountID {
+		return core.Exit(3, "tencentcloud account mismatch: current account %s does not match lease account %s", accountID, expected)
+	}
+	live := false
+	if server.CloudID != "" {
+		item, err := client.GetInstance(ctx, server.CloudID)
+		if err == nil {
+			if err := validateLiveInstance(item, server); err != nil {
+				return err
+			}
+			live = true
+		} else if !isNotFound(err) {
+			return err
+		}
+	}
+	leaseID := server.Labels["lease"]
+	claim, claimExists, err := core.ReadLeaseClaimWithPresence(leaseID)
+	if err != nil {
+		return fmt.Errorf("read tencentcloud cleanup claim: %w", err)
+	}
+	if claimExists {
+		if claim.Provider == providerName {
+			if err := validateClaimIdentity(claim, leaseID, server.Labels["slug"]); err != nil {
+				return err
+			}
+			if claim.CloudID != "" && claim.CloudID != server.CloudID {
+				return core.Exit(2, "refusing to release Tencent Cloud instance %s from stale local claim", server.CloudID)
+			}
+		}
+	}
+	if live {
+		if err := client.TerminateInstance(ctx, server.CloudID); err != nil {
+			return err
+		}
+	}
+	if claimExists && claim.Provider == providerName {
+		if err := core.RemoveLeaseClaimIfUnchanged(leaseID, claim); err != nil {
+			return fmt.Errorf("finalize tencentcloud cleanup claim: %w", err)
+		}
+	}
+	core.RemoveStoredTestboxKey(leaseID)
+	return nil
+}
+
+func (b *Backend) waitForInstanceIP(ctx context.Context, client tencentCloudAPI, id string) (instance, error) {
+	deadline := b.clockNow().Add(5 * time.Minute)
+	for {
+		item, err := client.GetInstance(ctx, id)
+		if err != nil {
+			return instance{}, err
+		}
+		if publicIPv4(item) != "" {
+			return item, nil
+		}
+		if b.clockNow().After(deadline) {
+			return instance{}, core.Exit(5, "timed out waiting for Tencent Cloud instance IP")
+		}
+		timer := time.NewTimer(3 * time.Second)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return instance{}, ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func (b *Backend) clockNow() time.Time {
+	if b.now != nil {
+		return b.now().UTC()
+	}
+	return time.Now().UTC()
+}
+
+func serverFromInstance(item instance, cfg core.Config) core.Server {
+	labels := labelsFromTags(item.Tags)
+	server := core.Server{
+		CloudID:  item.InstanceID,
+		Provider: providerName,
+		Name:     item.InstanceName,
+		Status:   normalizeInstanceState(item.InstanceState),
+		Labels:   labels,
+	}
+	server.PublicNet.IPv4.IP = publicIPv4(item)
+	server.ServerType.Name = firstNonBlank(item.InstanceType, cfg.ServerType, serverTypeForConfig(cfg))
+	return server
+}
+
+func publicIPv4(item instance) string {
+	for _, ip := range item.PublicIPAddresses {
+		if strings.Contains(ip, ".") {
+			return ip
+		}
+	}
+	return ""
+}
+
+func normalizeInstanceState(state string) string {
+	switch strings.ToUpper(strings.TrimSpace(state)) {
+	case "RUNNING":
+		return "ready"
+	case "":
+		return "unknown"
+	default:
+		return strings.ToLower(state)
+	}
+}
+
+func validateLiveInstance(item instance, expected core.Server) error {
+	labels := labelsFromTags(item.Tags)
+	if !ownedLabels(labels) {
+		return core.Exit(2, "refusing to operate on non-crabbox Tencent Cloud instance %s", item.InstanceID)
+	}
+	expectedProviderKey := expected.Labels["provider_key"]
+	if expectedProviderKey == "" && expected.Labels["lease"] != "" {
+		expectedProviderKey = core.ProviderKeyForLease(expected.Labels["lease"])
+	}
+	if item.InstanceID != expected.CloudID ||
+		item.InstanceName != expected.Name ||
+		labels["lease"] != expected.Labels["lease"] ||
+		labels["slug"] != expected.Labels["slug"] ||
+		labels["provider_key"] != expectedProviderKey {
+		return core.Exit(2, "refusing to operate on changed Tencent Cloud instance %s", expected.DisplayID())
+	}
+	return nil
+}
+
+func validateClaimIdentity(claim core.LeaseClaim, leaseID, slug string) error {
+	if claim.LeaseID != leaseID ||
+		claim.Provider != providerName ||
+		claim.Slug == "" ||
+		(slug != "" && claim.Slug != slug) ||
+		claim.Labels["lease"] != leaseID ||
+		claim.Labels["slug"] != claim.Slug ||
+		claim.Labels["provider"] != providerName {
+		return core.Exit(2, "tencentcloud lease claim identity does not match lease=%s slug=%s", leaseID, slug)
+	}
+	return nil
+}
+
+func isTencentInstanceID(id string) bool {
+	return strings.HasPrefix(strings.TrimSpace(id), "ins-")
+}
+
+func blank(value, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return value
+}

--- a/internal/providers/tencentcloud/backend.go
+++ b/internal/providers/tencentcloud/backend.go
@@ -1,0 +1,584 @@
+package tencentcloud
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
+)
+
+type Backend struct {
+	shared.DirectSSHBackend
+	clientFactory func(core.Config, core.Runtime) (tencentCloudAPI, error)
+	waitSSH       func(context.Context, *core.SSHTarget, string, time.Duration) error
+	now           func() time.Time
+}
+
+func NewBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
+	cfg = cfgForRun(cfg)
+	b := &Backend{
+		DirectSSHBackend: shared.DirectSSHBackend{SpecValue: spec, Cfg: cfg, RT: rt, StoredLeaseKeys: true},
+		clientFactory: func(cfg core.Config, rt core.Runtime) (tencentCloudAPI, error) {
+			return newClient(cfg, rt)
+		},
+		waitSSH: func(ctx context.Context, target *core.SSHTarget, phase string, timeout time.Duration) error {
+			return core.WaitForSSHReady(ctx, target, rt.Stderr, phase, timeout)
+		},
+		now: time.Now,
+	}
+	if rt.Clock != nil {
+		b.now = func() time.Time { return rt.Clock.Now().UTC() }
+	}
+	b.Delete = b.deleteServer
+	return b
+}
+
+func (b *Backend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
+	client, err := b.clientFactory(b.Cfg, b.RT)
+	if err != nil {
+		return core.DoctorResult{Provider: providerName, Message: err.Error(), Status: "failed", Checks: []core.DoctorCheck{{
+			Status:  "failed",
+			Check:   "auth",
+			Message: err.Error(),
+			Details: map[string]string{"mutation": "false"},
+		}}}, nil
+	}
+	if _, err := client.AccountID(ctx); err != nil {
+		return core.DoctorResult{}, err
+	}
+	instances, err := client.ListInstances(ctx)
+	if err != nil {
+		return core.DoctorResult{}, err
+	}
+	count := 0
+	for _, item := range instances {
+		if ownedLabels(labelsFromTags(item.TagSet)) {
+			count++
+		}
+	}
+	result := core.InventoryDoctorResult(providerName, count)
+	result.Message += fmt.Sprintf(" region=%s zone=%s type=%s image=%s", regionForConfig(b.Cfg), zoneForConfig(b.Cfg), serverTypeForConfig(b.Cfg), blank(imageForConfig(b.Cfg), "-"))
+	return result, nil
+}
+
+func (b *Backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.LeaseTarget, error) {
+	return shared.AcquireAttemptsRetry(b.RT, req.Keep, func() (core.LeaseTarget, error) {
+		return b.acquireOnce(ctx, req)
+	})
+}
+
+func (b *Backend) acquireOnce(ctx context.Context, req core.AcquireRequest) (target core.LeaseTarget, err error) {
+	cfg := cfgForRun(b.Cfg)
+	if err := validateAcquireConfig(cfg); err != nil {
+		return core.LeaseTarget{}, err
+	}
+	if cfg.Tailscale.Enabled && cfg.Tailscale.AuthKey == "" {
+		return core.LeaseTarget{}, core.Exit(2, "direct --tailscale requires %s to contain a Tailscale auth key", cfg.Tailscale.AuthKeyEnv)
+	}
+	client, err := b.clientFactory(cfg, b.RT)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	accountID, err := client.AccountID(ctx)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	leaseID := core.NewLeaseID()
+	instances, err := client.ListInstances(ctx)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	servers := make([]core.Server, 0, len(instances))
+	for _, item := range instances {
+		if ownedLabels(labelsFromTags(item.TagSet)) {
+			servers = append(servers, serverFromInstance(item, cfg))
+		}
+	}
+	slug, err := core.AllocateDirectLeaseSlug(leaseID, req.RequestedSlug, servers)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	keyPath, publicKey, err := core.EnsureTestboxKeyForConfig(cfg, leaseID)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	createdID := ""
+	committed := false
+	defer func() {
+		if err == nil || committed {
+			return
+		}
+		if createdID != "" {
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+			cleanupErr := client.TerminateInstance(cleanupCtx, createdID)
+			cancel()
+			if cleanupErr != nil {
+				err = fmt.Errorf("%v; tencentcloud cleanup failed: %w", err, cleanupErr)
+			}
+		}
+		core.RemoveStoredTestboxKey(leaseID)
+	}()
+	cfg.SSHKey = keyPath
+	cfg.ProviderKey = core.ProviderKeyForLease(leaseID)
+	cfg.ServerType = serverTypeForConfig(cfg)
+	if cfg.Tailscale.Enabled && cfg.Tailscale.Hostname == "" {
+		cfg.Tailscale.Hostname = core.RenderTailscaleHostname(cfg.Tailscale.HostnameTemplate, leaseID, slug, cfg.Provider)
+	}
+	now := b.clockNow()
+	createTags := leaseTags(cfg, leaseID, slug, "provisioning", req.Keep, now)
+	createTags = append(createTags, tag{Key: accountLabel, Value: accountID})
+	createReq := buildRunInstanceRequest(cfg, leaseID, slug, publicKey, createTags)
+	fmt.Fprintf(b.RT.Stderr, "provisioning provider=tencentcloud lease=%s slug=%s type=%s region=%s zone=%s image=%s keep=%v\n", leaseID, slug, cfg.ServerType, regionForConfig(cfg), zoneForConfig(cfg), imageForConfig(cfg), req.Keep)
+	createdID, err = client.RunInstance(ctx, createReq)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	instance, err := b.waitForInstanceIP(ctx, client, createdID)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	server := serverFromInstance(instance, cfg)
+	ssh := core.SSHTargetFromConfig(cfg, server.PublicNet.IPv4.IP)
+	if err := b.waitSSH(ctx, &ssh, "tencentcloud bootstrap", core.BootstrapWaitTimeout(cfg)); err != nil {
+		return core.LeaseTarget{}, err
+	}
+	readyLabels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", req.Keep, now)
+	readyLabels["state"] = "ready"
+	readyLabels[accountLabel] = accountID
+	if err := client.ReplaceInstanceTags(ctx, createdID, tagsFromLabels(readyLabels)); err != nil {
+		return core.LeaseTarget{}, err
+	}
+	server.Labels = readyLabels
+	server.Status = "ready"
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, ssh, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
+		return core.LeaseTarget{}, err
+	}
+	committed = true
+	fmt.Fprintf(b.RT.Stderr, "provisioned lease=%s tencentcloud_instance=%s type=%s\n", leaseID, server.DisplayID(), cfg.ServerType)
+	return core.LeaseTarget{Server: server, SSH: ssh, LeaseID: leaseID}, nil
+}
+
+func buildRunInstanceRequest(cfg core.Config, leaseID, slug, publicKey string, tags []tag) runInstanceRequest {
+	req := runInstanceRequest{
+		InstanceChargeType: "POSTPAID_BY_HOUR",
+		Placement:          placement{Zone: zoneForConfig(cfg)},
+		ImageID:            imageForConfig(cfg),
+		InstanceType:       serverTypeForConfig(cfg),
+		InstanceCount:      1,
+		InstanceName:       core.LeaseProviderName(leaseID, slug),
+		UserData:           base64.StdEncoding.EncodeToString([]byte(core.CloudInitUserData(cfg, publicKey))),
+		ClientToken:        strings.ReplaceAll(core.ProviderKeyForLease(leaseID), "_", "-"),
+		TagSpecification: []tagSpecification{{
+			ResourceType: "instance",
+			Tags:         tags,
+		}},
+	}
+	if cfg.TencentCloud.RootGB > 0 {
+		req.SystemDisk = &systemDisk{DiskSize: cfg.TencentCloud.RootGB}
+	}
+	if cfg.TencentCloud.VPCID != "" || cfg.TencentCloud.SubnetID != "" {
+		req.VirtualPrivateCloud = &virtualPrivateCloud{VPCID: cfg.TencentCloud.VPCID, SubnetID: cfg.TencentCloud.SubnetID}
+	}
+	if cfg.TencentCloud.InternetMaxBandwidthOut > 0 {
+		req.InternetAccessible = &internetAccessible{
+			InternetChargeType:      cfg.TencentCloud.InternetChargeType,
+			InternetMaxBandwidthOut: cfg.TencentCloud.InternetMaxBandwidthOut,
+			PublicIPAssigned:        true,
+		}
+	}
+	if cfg.TencentCloud.SecurityGroupID != "" {
+		req.SecurityGroupIDs = []string{cfg.TencentCloud.SecurityGroupID}
+	}
+	return req
+}
+
+func (b *Backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.LeaseTarget, error) {
+	cfg := cfgForRun(b.Cfg)
+	client, err := b.clientFactory(cfg, b.RT)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	accountID, err := client.AccountID(ctx)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	instances, err := client.ListInstances(ctx)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	servers := make([]core.Server, 0, len(instances))
+	byID := map[string]instance{}
+	for _, item := range instances {
+		if !ownedLabels(labelsFromTags(item.TagSet)) {
+			continue
+		}
+		server := serverFromInstance(item, cfg)
+		servers = append(servers, server)
+		byID[server.CloudID] = item
+	}
+	server, leaseID, err := core.FindServerByAlias(servers, req.ID)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	if leaseID != "" {
+		return b.targetFromInstance(byID[server.CloudID], req, accountID)
+	}
+	if isTencentInstanceID(req.ID) {
+		item, err := client.GetInstance(ctx, req.ID)
+		if err != nil {
+			if req.ReleaseOnly && isNotFound(err) {
+				return b.releaseTargetFromClaim(req.ID, accountID)
+			}
+			return core.LeaseTarget{}, err
+		}
+		return b.targetFromInstance(item, req, accountID)
+	}
+	if req.ReleaseOnly {
+		return b.releaseTargetFromClaim(req.ID, accountID)
+	}
+	return core.LeaseTarget{}, core.Exit(4, "lease/tencentcloud instance not found: %s", req.ID)
+}
+
+func (b *Backend) releaseTargetFromClaim(id, accountID string) (core.LeaseTarget, error) {
+	claim, ok, exact, err := core.ResolveLeaseClaimForProviderWithExact(id, providerName)
+	if err == nil && exact && (!ok || claim.LeaseID != id) {
+		return core.LeaseTarget{}, core.Exit(2, "tencentcloud exact lease identifier %q does not match a valid tencentcloud claim", id)
+	}
+	if err == nil && !ok && isTencentInstanceID(id) {
+		claim, ok, err = core.ResolveLeaseClaimForProviderCloudID(id, providerName)
+	}
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	if !ok || claim.LeaseID == "" {
+		return core.LeaseTarget{}, core.Exit(4, "lease/tencentcloud instance not found: %s", id)
+	}
+	if !core.LeaseClaimMatchesIdentifier(claim, id) {
+		return core.LeaseTarget{}, core.Exit(2, "tencentcloud lease claim does not match requested identifier %q", id)
+	}
+	if err := validateClaimIdentity(claim, claim.LeaseID, claim.Slug); err != nil {
+		return core.LeaseTarget{}, err
+	}
+	if expected := strings.TrimSpace(claim.Labels[accountLabel]); expected != "" && expected != accountID {
+		return core.LeaseTarget{}, core.Exit(3, "tencentcloud account mismatch: current account %s does not match lease account %s", accountID, expected)
+	}
+	server := core.Server{
+		Provider: providerName,
+		CloudID:  claim.CloudID,
+		Name:     core.LeaseProviderName(claim.LeaseID, claim.Slug),
+		Labels:   claim.Labels,
+	}
+	return core.LeaseTarget{LeaseID: claim.LeaseID, Server: server}, nil
+}
+
+func (b *Backend) targetFromInstance(item instance, req core.ResolveRequest, accountID string) (core.LeaseTarget, error) {
+	labels := labelsFromTags(item.TagSet)
+	if !ownedLabels(labels) {
+		return core.LeaseTarget{}, core.Exit(2, "refusing to operate on non-crabbox Tencent Cloud instance %s", item.InstanceID)
+	}
+	labels[accountLabel] = accountID
+	server := serverFromInstance(item, b.Cfg)
+	server.Labels = labels
+	leaseID := labels["lease"]
+	if leaseID == "" {
+		return core.LeaseTarget{}, core.Exit(2, "tencentcloud instance %s is missing lease tag", item.InstanceID)
+	}
+	claim, claimExists, claimErr := core.ReadLeaseClaimWithPresence(leaseID)
+	if claimErr != nil {
+		return core.LeaseTarget{}, fmt.Errorf("read tencentcloud lease claim: %w", claimErr)
+	}
+	if claimExists {
+		if claim.Provider != providerName {
+			return core.LeaseTarget{}, core.Exit(2, "lease=%s is claimed by provider=%s; refusing tencentcloud claim rewrite", leaseID, claim.Provider)
+		}
+		if err := validateClaimIdentity(claim, leaseID, labels["slug"]); err != nil {
+			return core.LeaseTarget{}, err
+		}
+		if expected := strings.TrimSpace(claim.Labels[accountLabel]); expected != "" && expected != accountID {
+			return core.LeaseTarget{}, core.Exit(3, "tencentcloud account mismatch: current account %s does not match lease account %s", accountID, expected)
+		}
+		if claim.CloudID != "" && claim.CloudID != server.CloudID {
+			return core.LeaseTarget{}, core.Exit(2, "refusing to resolve Tencent Cloud instance %s from stale local claim", server.CloudID)
+		}
+	}
+	if req.ReleaseOnly {
+		return core.LeaseTarget{Server: server, LeaseID: leaseID}, nil
+	}
+	cfg := cfgForRun(b.Cfg)
+	ssh := core.SSHTargetFromConfig(cfg, server.PublicNet.IPv4.IP)
+	if keyPath, err := core.TestboxKeyPath(leaseID); err == nil {
+		if _, statErr := os.Stat(keyPath); statErr == nil {
+			ssh.Key = keyPath
+		}
+	}
+	if req.Repo.Root != "" {
+		if _, err := core.ClaimLeaseTargetForRepoConfigIfUnchanged(leaseID, labels["slug"], cfg, server, ssh, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, claim, claimExists); err != nil {
+			return core.LeaseTarget{}, err
+		}
+	}
+	return core.LeaseTarget{Server: server, SSH: ssh, LeaseID: leaseID}, nil
+}
+
+func (b *Backend) List(ctx context.Context, _ core.ListRequest) ([]core.LeaseView, error) {
+	client, err := b.clientFactory(b.Cfg, b.RT)
+	if err != nil {
+		return nil, err
+	}
+	instances, err := client.ListInstances(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]core.LeaseView, 0, len(instances))
+	for _, item := range instances {
+		if ownedLabels(labelsFromTags(item.TagSet)) {
+			out = append(out, serverFromInstance(item, b.Cfg))
+		}
+	}
+	return out, nil
+}
+
+func (b *Backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest) error {
+	return b.deleteServer(ctx, b.Cfg, req.Lease.Server)
+}
+
+func (b *Backend) ReleaseLeaseMessage(lease core.LeaseTarget) string {
+	return fmt.Sprintf("deleted lease=%s tencentcloud_instance=%s name=%s", lease.LeaseID, lease.Server.DisplayID(), lease.Server.Name)
+}
+
+func (b *Backend) Touch(ctx context.Context, req core.TouchRequest) (core.Server, error) {
+	server := req.Lease.Server
+	if !ownedLabels(server.Labels) {
+		return core.Server{}, core.Exit(2, "refusing to touch non-crabbox Tencent Cloud instance %s", server.DisplayID())
+	}
+	client, err := b.clientFactory(b.Cfg, b.RT)
+	if err != nil {
+		return core.Server{}, err
+	}
+	item, err := client.GetInstance(ctx, server.CloudID)
+	if err != nil {
+		return core.Server{}, err
+	}
+	if err := validateLiveInstance(item, server); err != nil {
+		return core.Server{}, err
+	}
+	labels := labelsFromTags(item.TagSet)
+	if accountID := strings.TrimSpace(server.Labels[accountLabel]); accountID != "" {
+		labels[accountLabel] = accountID
+	}
+	cfg := b.Cfg
+	if req.IdleTimeout > 0 {
+		cfg.IdleTimeout = req.IdleTimeout
+		delete(labels, "idle_timeout")
+		delete(labels, "idle_timeout_secs")
+	}
+	labels = core.TouchDirectLeaseLabels(labels, cfg, req.State, b.clockNow())
+	if err := client.ReplaceInstanceTags(ctx, server.CloudID, tagsFromLabels(labels)); err != nil {
+		return core.Server{}, err
+	}
+	server.Labels = labels
+	return server, nil
+}
+
+func (b *Backend) UpdateTailscaleMetadata(ctx context.Context, lease core.LeaseTarget, meta core.TailscaleMetadata) (core.Server, error) {
+	server := lease.Server
+	if !ownedLabels(server.Labels) {
+		return core.Server{}, core.Exit(2, "refusing to update tailscale metadata on non-crabbox Tencent Cloud instance %s", server.DisplayID())
+	}
+	client, err := b.clientFactory(b.Cfg, b.RT)
+	if err != nil {
+		return core.Server{}, err
+	}
+	item, err := client.GetInstance(ctx, server.CloudID)
+	if err != nil {
+		return core.Server{}, err
+	}
+	if err := validateLiveInstance(item, server); err != nil {
+		return core.Server{}, err
+	}
+	labels := labelsFromTags(item.TagSet)
+	if accountID := strings.TrimSpace(server.Labels[accountLabel]); accountID != "" {
+		labels[accountLabel] = accountID
+	}
+	applyTailscaleMetadata(labels, meta)
+	if err := client.ReplaceInstanceTags(ctx, server.CloudID, tagsFromLabels(labels)); err != nil {
+		return core.Server{}, err
+	}
+	server.Labels = labels
+	return server, nil
+}
+
+func (b *Backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
+	servers, err := b.List(ctx, core.ListRequest{Options: req.Options})
+	if err != nil {
+		return err
+	}
+	return b.CleanupServers(ctx, req, servers)
+}
+
+func (b *Backend) deleteServer(ctx context.Context, _ core.Config, server core.Server) error {
+	if !ownedLabels(server.Labels) {
+		return core.Exit(2, "refusing to delete non-crabbox Tencent Cloud instance %s", server.DisplayID())
+	}
+	client, err := b.clientFactory(b.Cfg, b.RT)
+	if err != nil {
+		return err
+	}
+	accountID, err := client.AccountID(ctx)
+	if err != nil {
+		return err
+	}
+	if expected := strings.TrimSpace(server.Labels[accountLabel]); expected != "" && expected != accountID {
+		return core.Exit(3, "tencentcloud account mismatch: current account %s does not match lease account %s", accountID, expected)
+	}
+	live := false
+	if server.CloudID != "" {
+		item, err := client.GetInstance(ctx, server.CloudID)
+		if err == nil {
+			if err := validateLiveInstance(item, server); err != nil {
+				return err
+			}
+			live = true
+		} else if !isNotFound(err) {
+			return err
+		}
+	}
+	leaseID := server.Labels["lease"]
+	claim, claimExists, err := core.ReadLeaseClaimWithPresence(leaseID)
+	if err != nil {
+		return fmt.Errorf("read tencentcloud cleanup claim: %w", err)
+	}
+	if claimExists {
+		if claim.Provider == providerName {
+			if err := validateClaimIdentity(claim, leaseID, server.Labels["slug"]); err != nil {
+				return err
+			}
+			if claim.CloudID != "" && claim.CloudID != server.CloudID {
+				return core.Exit(2, "refusing to release Tencent Cloud instance %s from stale local claim", server.CloudID)
+			}
+		}
+	}
+	if live {
+		if err := client.TerminateInstance(ctx, server.CloudID); err != nil {
+			return err
+		}
+	}
+	if claimExists && claim.Provider == providerName {
+		if err := core.RemoveLeaseClaimIfUnchanged(leaseID, claim); err != nil {
+			return fmt.Errorf("finalize tencentcloud cleanup claim: %w", err)
+		}
+	}
+	core.RemoveStoredTestboxKey(leaseID)
+	return nil
+}
+
+func (b *Backend) waitForInstanceIP(ctx context.Context, client tencentCloudAPI, id string) (instance, error) {
+	deadline := b.clockNow().Add(5 * time.Minute)
+	for {
+		item, err := client.GetInstance(ctx, id)
+		if err != nil {
+			return instance{}, err
+		}
+		if publicIPv4(item) != "" {
+			return item, nil
+		}
+		if b.clockNow().After(deadline) {
+			return instance{}, core.Exit(5, "timed out waiting for Tencent Cloud instance IP")
+		}
+		timer := time.NewTimer(3 * time.Second)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return instance{}, ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func (b *Backend) clockNow() time.Time {
+	if b.now != nil {
+		return b.now().UTC()
+	}
+	return time.Now().UTC()
+}
+
+func serverFromInstance(item instance, cfg core.Config) core.Server {
+	labels := labelsFromTags(item.TagSet)
+	server := core.Server{
+		CloudID:  item.InstanceID,
+		Provider: providerName,
+		Name:     item.InstanceName,
+		Status:   normalizeInstanceState(item.InstanceState),
+		Labels:   labels,
+	}
+	server.PublicNet.IPv4.IP = publicIPv4(item)
+	server.ServerType.Name = firstNonBlank(item.InstanceType, cfg.ServerType, serverTypeForConfig(cfg))
+	return server
+}
+
+func publicIPv4(item instance) string {
+	for _, ip := range item.PublicIPAddresses {
+		if strings.Contains(ip, ".") {
+			return ip
+		}
+	}
+	return ""
+}
+
+func normalizeInstanceState(state string) string {
+	switch strings.ToUpper(strings.TrimSpace(state)) {
+	case "RUNNING":
+		return "ready"
+	case "":
+		return "unknown"
+	default:
+		return strings.ToLower(state)
+	}
+}
+
+func validateLiveInstance(item instance, expected core.Server) error {
+	labels := labelsFromTags(item.TagSet)
+	if !ownedLabels(labels) {
+		return core.Exit(2, "refusing to operate on non-crabbox Tencent Cloud instance %s", item.InstanceID)
+	}
+	expectedProviderKey := expected.Labels["provider_key"]
+	if expectedProviderKey == "" && expected.Labels["lease"] != "" {
+		expectedProviderKey = core.ProviderKeyForLease(expected.Labels["lease"])
+	}
+	if item.InstanceID != expected.CloudID ||
+		item.InstanceName != expected.Name ||
+		labels["lease"] != expected.Labels["lease"] ||
+		labels["slug"] != expected.Labels["slug"] ||
+		labels["provider_key"] != expectedProviderKey {
+		return core.Exit(2, "refusing to operate on changed Tencent Cloud instance %s", expected.DisplayID())
+	}
+	return nil
+}
+
+func validateClaimIdentity(claim core.LeaseClaim, leaseID, slug string) error {
+	if claim.LeaseID != leaseID ||
+		claim.Provider != providerName ||
+		claim.Slug == "" ||
+		(slug != "" && claim.Slug != slug) ||
+		claim.Labels["lease"] != leaseID ||
+		claim.Labels["slug"] != claim.Slug ||
+		claim.Labels["provider"] != providerName {
+		return core.Exit(2, "tencentcloud lease claim identity does not match lease=%s slug=%s", leaseID, slug)
+	}
+	return nil
+}
+
+func isTencentInstanceID(id string) bool {
+	return strings.HasPrefix(strings.TrimSpace(id), "ins-")
+}
+
+func blank(value, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return value
+}

--- a/internal/providers/tencentcloud/client.go
+++ b/internal/providers/tencentcloud/client.go
@@ -1,0 +1,357 @@
+package tencentcloud
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+const (
+	cvmService = "cvm"
+	tagService = "tag"
+	stsService = "sts"
+
+	cvmVersion = "2017-03-12"
+	tagVersion = "2018-08-13"
+	stsVersion = "2018-08-13"
+)
+
+type tencentCloudAPI interface {
+	AccountID(context.Context) (string, error)
+	ListInstances(context.Context) ([]instance, error)
+	GetInstance(context.Context, string) (instance, error)
+	RunInstance(context.Context, runInstanceRequest) (string, error)
+	TerminateInstance(context.Context, string) error
+	ReplaceInstanceTags(context.Context, string, []tag, []tag) error
+}
+
+type client struct {
+	secretID     string
+	secretKey    string
+	token        string
+	httpClient   *http.Client
+	region       string
+	cvmEndpoint  string
+	tagEndpoint  string
+	stsEndpoint  string
+	accountID    string
+	accountReady bool
+}
+
+type apiError struct {
+	Action    string
+	Code      string
+	Message   string
+	RequestID string
+	Status    int
+	Body      string
+}
+
+func (e *apiError) Error() string {
+	if e.Code != "" {
+		return fmt.Sprintf("tencentcloud %s: %s: %s request=%s", e.Action, e.Code, e.Message, e.RequestID)
+	}
+	return fmt.Sprintf("tencentcloud %s: http %d: %s", e.Action, e.Status, e.Body)
+}
+
+func newClient(cfg core.Config, rt core.Runtime) (*client, error) {
+	secretID := strings.TrimSpace(os.Getenv("TENCENTCLOUD_SECRET_ID"))
+	secretKey := strings.TrimSpace(os.Getenv("TENCENTCLOUD_SECRET_KEY"))
+	if secretID == "" || secretKey == "" {
+		return nil, core.Exit(3, "TENCENTCLOUD_SECRET_ID and TENCENTCLOUD_SECRET_KEY are required")
+	}
+	httpClient := rt.HTTP
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 60 * time.Second}
+	}
+	return &client{
+		secretID:    secretID,
+		secretKey:   secretKey,
+		token:       strings.TrimSpace(os.Getenv("TENCENTCLOUD_TOKEN")),
+		httpClient:  httpClient,
+		region:      regionForConfig(cfg),
+		cvmEndpoint: cvmEndpointForConfig(cfg),
+		tagEndpoint: tagEndpointForConfig(cfg),
+		stsEndpoint: stsEndpointForConfig(cfg),
+	}, nil
+}
+
+func (c *client) AccountID(ctx context.Context) (string, error) {
+	if c.accountReady {
+		return c.accountID, nil
+	}
+	if value := strings.TrimSpace(os.Getenv("TENCENTCLOUD_ACCOUNT_ID")); value != "" {
+		c.accountID = value
+		c.accountReady = true
+		return c.accountID, nil
+	}
+	var out getCallerIdentityResponse
+	if err := c.do(ctx, stsService, c.stsEndpoint, "GetCallerIdentity", stsVersion, c.region, map[string]any{}, &out); err != nil {
+		return "", err
+	}
+	c.accountID = firstNonBlank(out.AccountID, out.UIN)
+	if c.accountID == "" {
+		return "", core.Exit(3, "tencentcloud GetCallerIdentity response did not include AccountId or Uin")
+	}
+	c.accountReady = true
+	return c.accountID, nil
+}
+
+func (c *client) ListInstances(ctx context.Context) ([]instance, error) {
+	var out []instance
+	for offset := int64(0); ; offset += 100 {
+		var res describeInstancesResponse
+		err := c.do(ctx, cvmService, c.cvmEndpoint, "DescribeInstances", cvmVersion, c.region, map[string]any{
+			"Offset": offset,
+			"Limit":  int64(100),
+		}, &res)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, res.InstanceSet...)
+		if int64(len(out)) >= res.TotalCount || len(res.InstanceSet) == 0 {
+			return out, nil
+		}
+	}
+}
+
+func (c *client) GetInstance(ctx context.Context, id string) (instance, error) {
+	var res describeInstancesResponse
+	err := c.do(ctx, cvmService, c.cvmEndpoint, "DescribeInstances", cvmVersion, c.region, map[string]any{
+		"InstanceIds": []string{id},
+	}, &res)
+	if err != nil {
+		return instance{}, err
+	}
+	if len(res.InstanceSet) == 0 {
+		return instance{}, &apiError{Action: "DescribeInstances", Code: "ResourceNotFound.Instance", Message: "instance not found"}
+	}
+	return res.InstanceSet[0], nil
+}
+
+func (c *client) RunInstance(ctx context.Context, req runInstanceRequest) (string, error) {
+	var res runInstancesResponse
+	if err := c.do(ctx, cvmService, c.cvmEndpoint, "RunInstances", cvmVersion, c.region, req, &res); err != nil {
+		return "", err
+	}
+	if len(res.InstanceIDSet) == 0 {
+		return "", core.Exit(3, "tencentcloud RunInstances response did not include InstanceIdSet")
+	}
+	return res.InstanceIDSet[0], nil
+}
+
+func (c *client) TerminateInstance(ctx context.Context, id string) error {
+	return c.do(ctx, cvmService, c.cvmEndpoint, "TerminateInstances", cvmVersion, c.region, map[string]any{
+		"InstanceIds": []string{id},
+	}, nil)
+}
+
+func (c *client) ReplaceInstanceTags(ctx context.Context, instanceID string, currentTags, desiredTags []tag) error {
+	accountID, err := c.AccountID(ctx)
+	if err != nil {
+		return err
+	}
+	replaceTags := tagUpdateSet(desiredTags)
+	deleteTags := tagDeleteSet(currentTags, desiredTags)
+	if len(replaceTags) == 0 && len(deleteTags) == 0 {
+		return nil
+	}
+	body := map[string]any{
+		"Resource": resourceName(c.region, accountID, instanceID),
+	}
+	if len(replaceTags) > 0 {
+		body["ReplaceTags"] = replaceTags
+	}
+	if len(deleteTags) > 0 {
+		body["DeleteTags"] = deleteTags
+	}
+	return c.do(ctx, tagService, c.tagEndpoint, "ModifyResourceTags", tagVersion, c.region, body, nil)
+}
+
+func (c *client) do(ctx context.Context, service, endpoint, action, version, region string, body any, out any) error {
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return err
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return fmt.Errorf("invalid Tencent Cloud endpoint %q", endpoint)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, parsed.String(), bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	now := time.Now().UTC()
+	signTencentCloudRequest(req, signInput{
+		SecretID:  c.secretID,
+		SecretKey: c.secretKey,
+		Token:     c.token,
+		Service:   service,
+		Action:    action,
+		Version:   version,
+		Region:    region,
+		Timestamp: now.Unix(),
+		Payload:   payload,
+	})
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	data, readErr := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		if len(data) > 800 {
+			data = data[:800]
+		}
+		body := c.redact(strings.TrimSpace(string(data)))
+		if readErr != nil {
+			if body != "" {
+				body += "; "
+			}
+			body += "response body read failed: " + readErr.Error()
+		}
+		return &apiError{Action: action, Status: resp.StatusCode, Body: body}
+	}
+	if readErr != nil {
+		return fmt.Errorf("tencentcloud %s response body: %w", action, readErr)
+	}
+	if len(data) == 0 {
+		return nil
+	}
+	var envelope struct {
+		Response json.RawMessage `json:"Response"`
+	}
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return fmt.Errorf("tencentcloud %s decode envelope: %w", action, err)
+	}
+	if len(envelope.Response) == 0 {
+		return fmt.Errorf("tencentcloud %s response missing Response", action)
+	}
+	var probe struct {
+		Error *struct {
+			Code    string `json:"Code"`
+			Message string `json:"Message"`
+		} `json:"Error"`
+		RequestID string `json:"RequestId"`
+	}
+	if err := json.Unmarshal(envelope.Response, &probe); err == nil && probe.Error != nil {
+		return &apiError{Action: action, Code: probe.Error.Code, Message: c.redact(probe.Error.Message), RequestID: probe.RequestID}
+	}
+	if out == nil {
+		return nil
+	}
+	if err := json.Unmarshal(envelope.Response, out); err != nil {
+		return fmt.Errorf("tencentcloud %s decode response: %w", action, err)
+	}
+	return nil
+}
+
+func (c *client) redact(value string) string {
+	for _, secret := range []string{c.secretID, c.secretKey, c.token} {
+		if secret != "" {
+			value = strings.ReplaceAll(value, secret, "<redacted>")
+		}
+	}
+	return value
+}
+
+type signInput struct {
+	SecretID  string
+	SecretKey string
+	Token     string
+	Service   string
+	Action    string
+	Version   string
+	Region    string
+	Timestamp int64
+	Payload   []byte
+}
+
+func signTencentCloudRequest(req *http.Request, in signInput) {
+	const algorithm = "TC3-HMAC-SHA256"
+	date := time.Unix(in.Timestamp, 0).UTC().Format("2006-01-02")
+	hashedPayload := sha256Hex(in.Payload)
+	canonicalHeaders := "content-type:application/json; charset=utf-8\nhost:" + req.URL.Host + "\nx-tc-action:" + strings.ToLower(in.Action) + "\n"
+	signedHeaders := "content-type;host;x-tc-action"
+	canonicalRequest := strings.Join([]string{
+		http.MethodPost,
+		"/",
+		"",
+		canonicalHeaders,
+		signedHeaders,
+		hashedPayload,
+	}, "\n")
+	credentialScope := date + "/" + in.Service + "/tc3_request"
+	stringToSign := strings.Join([]string{
+		algorithm,
+		fmt.Sprint(in.Timestamp),
+		credentialScope,
+		sha256Hex([]byte(canonicalRequest)),
+	}, "\n")
+	secretDate := hmacSHA256([]byte("TC3"+in.SecretKey), date)
+	secretService := hmacSHA256(secretDate, in.Service)
+	secretSigning := hmacSHA256(secretService, "tc3_request")
+	signature := hex.EncodeToString(hmacSHA256(secretSigning, stringToSign))
+	authorization := fmt.Sprintf("%s Credential=%s/%s, SignedHeaders=%s, Signature=%s", algorithm, in.SecretID, credentialScope, signedHeaders, signature)
+
+	req.Header.Set("Authorization", authorization)
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	req.Header.Set("Host", req.URL.Host)
+	req.Header.Set("X-TC-Action", in.Action)
+	req.Header.Set("X-TC-Version", in.Version)
+	req.Header.Set("X-TC-Timestamp", fmt.Sprint(in.Timestamp))
+	if in.Region != "" {
+		req.Header.Set("X-TC-Region", in.Region)
+	}
+	if in.Token != "" {
+		req.Header.Set("X-TC-Token", in.Token)
+	}
+}
+
+func sha256Hex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func hmacSHA256(key []byte, value string) []byte {
+	h := hmac.New(sha256.New, key)
+	_, _ = h.Write([]byte(value))
+	return h.Sum(nil)
+}
+
+func resourceName(region, accountID, instanceID string) string {
+	return fmt.Sprintf("qcs::cvm:%s:uin/%s:instance/%s", region, accountID, instanceID)
+}
+
+func firstNonBlank(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func isNotFound(err error) bool {
+	var apiErr *apiError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	return strings.Contains(strings.ToLower(apiErr.Code), "notfound") || strings.Contains(strings.ToLower(apiErr.Code), "not found")
+}

--- a/internal/providers/tencentcloud/client.go
+++ b/internal/providers/tencentcloud/client.go
@@ -1,0 +1,346 @@
+package tencentcloud
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+const (
+	cvmService = "cvm"
+	tagService = "tag"
+	stsService = "sts"
+
+	cvmVersion = "2017-03-12"
+	tagVersion = "2018-08-13"
+	stsVersion = "2018-08-13"
+)
+
+type tencentCloudAPI interface {
+	AccountID(context.Context) (string, error)
+	ListInstances(context.Context) ([]instance, error)
+	GetInstance(context.Context, string) (instance, error)
+	RunInstance(context.Context, runInstanceRequest) (string, error)
+	TerminateInstance(context.Context, string) error
+	ReplaceInstanceTags(context.Context, string, []tag) error
+}
+
+type client struct {
+	secretID     string
+	secretKey    string
+	token        string
+	httpClient   *http.Client
+	region       string
+	cvmEndpoint  string
+	tagEndpoint  string
+	stsEndpoint  string
+	accountID    string
+	accountReady bool
+}
+
+type apiError struct {
+	Action    string
+	Code      string
+	Message   string
+	RequestID string
+	Status    int
+	Body      string
+}
+
+func (e *apiError) Error() string {
+	if e.Code != "" {
+		return fmt.Sprintf("tencentcloud %s: %s: %s request=%s", e.Action, e.Code, e.Message, e.RequestID)
+	}
+	return fmt.Sprintf("tencentcloud %s: http %d: %s", e.Action, e.Status, e.Body)
+}
+
+func newClient(cfg core.Config, rt core.Runtime) (*client, error) {
+	secretID := strings.TrimSpace(os.Getenv("TENCENTCLOUD_SECRET_ID"))
+	secretKey := strings.TrimSpace(os.Getenv("TENCENTCLOUD_SECRET_KEY"))
+	if secretID == "" || secretKey == "" {
+		return nil, core.Exit(3, "TENCENTCLOUD_SECRET_ID and TENCENTCLOUD_SECRET_KEY are required")
+	}
+	httpClient := rt.HTTP
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 60 * time.Second}
+	}
+	return &client{
+		secretID:    secretID,
+		secretKey:   secretKey,
+		token:       strings.TrimSpace(os.Getenv("TENCENTCLOUD_TOKEN")),
+		httpClient:  httpClient,
+		region:      regionForConfig(cfg),
+		cvmEndpoint: cvmEndpointForConfig(cfg),
+		tagEndpoint: tagEndpointForConfig(cfg),
+		stsEndpoint: stsEndpointForConfig(cfg),
+	}, nil
+}
+
+func (c *client) AccountID(ctx context.Context) (string, error) {
+	if c.accountReady {
+		return c.accountID, nil
+	}
+	if value := strings.TrimSpace(os.Getenv("TENCENTCLOUD_ACCOUNT_ID")); value != "" {
+		c.accountID = value
+		c.accountReady = true
+		return c.accountID, nil
+	}
+	var out getCallerIdentityResponse
+	if err := c.do(ctx, stsService, c.stsEndpoint, "GetCallerIdentity", stsVersion, "", map[string]any{}, &out); err != nil {
+		return "", err
+	}
+	c.accountID = firstNonBlank(out.AccountID, out.UIN)
+	if c.accountID == "" {
+		return "", core.Exit(3, "tencentcloud GetCallerIdentity response did not include AccountId or Uin")
+	}
+	c.accountReady = true
+	return c.accountID, nil
+}
+
+func (c *client) ListInstances(ctx context.Context) ([]instance, error) {
+	var out []instance
+	for offset := int64(0); ; offset += 100 {
+		var res describeInstancesResponse
+		err := c.do(ctx, cvmService, c.cvmEndpoint, "DescribeInstances", cvmVersion, c.region, map[string]any{
+			"Offset": offset,
+			"Limit":  int64(100),
+		}, &res)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, res.InstanceSet...)
+		if int64(len(out)) >= res.TotalCount || len(res.InstanceSet) == 0 {
+			return out, nil
+		}
+	}
+}
+
+func (c *client) GetInstance(ctx context.Context, id string) (instance, error) {
+	var res describeInstancesResponse
+	err := c.do(ctx, cvmService, c.cvmEndpoint, "DescribeInstances", cvmVersion, c.region, map[string]any{
+		"InstanceIds": []string{id},
+	}, &res)
+	if err != nil {
+		return instance{}, err
+	}
+	if len(res.InstanceSet) == 0 {
+		return instance{}, &apiError{Action: "DescribeInstances", Code: "ResourceNotFound.Instance", Message: "instance not found"}
+	}
+	return res.InstanceSet[0], nil
+}
+
+func (c *client) RunInstance(ctx context.Context, req runInstanceRequest) (string, error) {
+	var res runInstancesResponse
+	if err := c.do(ctx, cvmService, c.cvmEndpoint, "RunInstances", cvmVersion, c.region, req, &res); err != nil {
+		return "", err
+	}
+	if len(res.InstanceIDSet) == 0 {
+		return "", core.Exit(3, "tencentcloud RunInstances response did not include InstanceIdSet")
+	}
+	return res.InstanceIDSet[0], nil
+}
+
+func (c *client) TerminateInstance(ctx context.Context, id string) error {
+	return c.do(ctx, cvmService, c.cvmEndpoint, "TerminateInstances", cvmVersion, c.region, map[string]any{
+		"InstanceIds": []string{id},
+	}, nil)
+}
+
+func (c *client) ReplaceInstanceTags(ctx context.Context, instanceID string, tags []tag) error {
+	accountID, err := c.AccountID(ctx)
+	if err != nil {
+		return err
+	}
+	return c.do(ctx, tagService, c.tagEndpoint, "ModifyResourceTags", tagVersion, c.region, map[string]any{
+		"Resource":    resourceName(c.region, accountID, instanceID),
+		"ReplaceTags": tags,
+	}, nil)
+}
+
+func (c *client) do(ctx context.Context, service, endpoint, action, version, region string, body any, out any) error {
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return err
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return fmt.Errorf("invalid Tencent Cloud endpoint %q", endpoint)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, parsed.String(), bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	now := time.Now().UTC()
+	signTencentCloudRequest(req, signInput{
+		SecretID:  c.secretID,
+		SecretKey: c.secretKey,
+		Token:     c.token,
+		Service:   service,
+		Action:    action,
+		Version:   version,
+		Region:    region,
+		Timestamp: now.Unix(),
+		Payload:   payload,
+	})
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	data, readErr := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		if len(data) > 800 {
+			data = data[:800]
+		}
+		body := c.redact(strings.TrimSpace(string(data)))
+		if readErr != nil {
+			if body != "" {
+				body += "; "
+			}
+			body += "response body read failed: " + readErr.Error()
+		}
+		return &apiError{Action: action, Status: resp.StatusCode, Body: body}
+	}
+	if readErr != nil {
+		return fmt.Errorf("tencentcloud %s response body: %w", action, readErr)
+	}
+	if len(data) == 0 {
+		return nil
+	}
+	var envelope struct {
+		Response json.RawMessage `json:"Response"`
+	}
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return fmt.Errorf("tencentcloud %s decode envelope: %w", action, err)
+	}
+	if len(envelope.Response) == 0 {
+		return fmt.Errorf("tencentcloud %s response missing Response", action)
+	}
+	var probe struct {
+		Error *struct {
+			Code    string `json:"Code"`
+			Message string `json:"Message"`
+		} `json:"Error"`
+		RequestID string `json:"RequestId"`
+	}
+	if err := json.Unmarshal(envelope.Response, &probe); err == nil && probe.Error != nil {
+		return &apiError{Action: action, Code: probe.Error.Code, Message: c.redact(probe.Error.Message), RequestID: probe.RequestID}
+	}
+	if out == nil {
+		return nil
+	}
+	if err := json.Unmarshal(envelope.Response, out); err != nil {
+		return fmt.Errorf("tencentcloud %s decode response: %w", action, err)
+	}
+	return nil
+}
+
+func (c *client) redact(value string) string {
+	for _, secret := range []string{c.secretID, c.secretKey, c.token} {
+		if secret != "" {
+			value = strings.ReplaceAll(value, secret, "<redacted>")
+		}
+	}
+	return value
+}
+
+type signInput struct {
+	SecretID  string
+	SecretKey string
+	Token     string
+	Service   string
+	Action    string
+	Version   string
+	Region    string
+	Timestamp int64
+	Payload   []byte
+}
+
+func signTencentCloudRequest(req *http.Request, in signInput) {
+	const algorithm = "TC3-HMAC-SHA256"
+	date := time.Unix(in.Timestamp, 0).UTC().Format("2006-01-02")
+	hashedPayload := sha256Hex(in.Payload)
+	canonicalHeaders := "content-type:application/json; charset=utf-8\nhost:" + req.URL.Host + "\nx-tc-action:" + strings.ToLower(in.Action) + "\n"
+	signedHeaders := "content-type;host;x-tc-action"
+	canonicalRequest := strings.Join([]string{
+		http.MethodPost,
+		"/",
+		"",
+		canonicalHeaders,
+		signedHeaders,
+		hashedPayload,
+	}, "\n")
+	credentialScope := date + "/" + in.Service + "/tc3_request"
+	stringToSign := strings.Join([]string{
+		algorithm,
+		fmt.Sprint(in.Timestamp),
+		credentialScope,
+		sha256Hex([]byte(canonicalRequest)),
+	}, "\n")
+	secretDate := hmacSHA256([]byte("TC3"+in.SecretKey), date)
+	secretService := hmacSHA256(secretDate, in.Service)
+	secretSigning := hmacSHA256(secretService, "tc3_request")
+	signature := hex.EncodeToString(hmacSHA256(secretSigning, stringToSign))
+	authorization := fmt.Sprintf("%s Credential=%s/%s, SignedHeaders=%s, Signature=%s", algorithm, in.SecretID, credentialScope, signedHeaders, signature)
+
+	req.Header.Set("Authorization", authorization)
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	req.Header.Set("Host", req.URL.Host)
+	req.Header.Set("X-TC-Action", in.Action)
+	req.Header.Set("X-TC-Version", in.Version)
+	req.Header.Set("X-TC-Timestamp", fmt.Sprint(in.Timestamp))
+	if in.Region != "" {
+		req.Header.Set("X-TC-Region", in.Region)
+	}
+	if in.Token != "" {
+		req.Header.Set("X-TC-Token", in.Token)
+	}
+}
+
+func sha256Hex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func hmacSHA256(key []byte, value string) []byte {
+	h := hmac.New(sha256.New, key)
+	_, _ = h.Write([]byte(value))
+	return h.Sum(nil)
+}
+
+func resourceName(region, accountID, instanceID string) string {
+	return fmt.Sprintf("qcs::cvm:%s:uin/%s:instance/%s", region, accountID, instanceID)
+}
+
+func firstNonBlank(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func isNotFound(err error) bool {
+	var apiErr *apiError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	return strings.Contains(strings.ToLower(apiErr.Code), "notfound") || strings.Contains(strings.ToLower(apiErr.Code), "not found")
+}

--- a/internal/providers/tencentcloud/config.go
+++ b/internal/providers/tencentcloud/config.go
@@ -1,0 +1,159 @@
+package tencentcloud
+
+import (
+	"net/url"
+	"strings"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+const (
+	defaultRegion                  = "ap-shanghai"
+	defaultZone                    = "ap-shanghai-2"
+	defaultType                    = "SA5.MEDIUM2"
+	defaultRootGB                  = int64(50)
+	defaultInternetChargeType      = "TRAFFIC_POSTPAID_BY_HOUR"
+	defaultInternetMaxBandwidthOut = int64(5)
+	defaultCVMEndpoint             = "https://cvm.tencentcloudapi.com"
+	defaultTagEndpoint             = "https://tag.tencentcloudapi.com"
+	defaultSTSEndpoint             = "https://sts.tencentcloudapi.com"
+)
+
+func cfgForRun(cfg core.Config) core.Config {
+	cfg.Provider = providerName
+	if cfg.TargetOS == "" {
+		cfg.TargetOS = core.TargetLinux
+	}
+	if cfg.TencentCloud.Region == "" {
+		cfg.TencentCloud.Region = defaultRegion
+	}
+	if cfg.TencentCloud.Zone == "" {
+		cfg.TencentCloud.Zone = defaultZone
+	}
+	if cfg.TencentCloud.Type == "" {
+		cfg.TencentCloud.Type = serverTypeForClass(cfg.Class)
+	}
+	if cfg.TencentCloud.RootGB == 0 {
+		cfg.TencentCloud.RootGB = defaultRootGB
+	}
+	if cfg.TencentCloud.InternetChargeType == "" {
+		cfg.TencentCloud.InternetChargeType = defaultInternetChargeType
+	}
+	if cfg.TencentCloud.InternetMaxBandwidthOut == 0 {
+		cfg.TencentCloud.InternetMaxBandwidthOut = defaultInternetMaxBandwidthOut
+	}
+	if !core.IsSSHUserExplicit(&cfg) && (cfg.SSHUser == "" || cfg.SSHUser == core.BaseConfig().SSHUser) {
+		cfg.SSHUser = "ubuntu"
+	}
+	if !core.IsSSHPortExplicit(&cfg) && (cfg.SSHPort == "" || cfg.SSHPort == core.BaseConfig().SSHPort) {
+		cfg.SSHPort = "22"
+	}
+	cfg.SSHFallbackPorts = nil
+	if !cfg.ServerTypeExplicit || cfg.ServerType == "" {
+		cfg.ServerType = cfg.TencentCloud.Type
+	}
+	return cfg
+}
+
+func regionForConfig(cfg core.Config) string {
+	if value := strings.TrimSpace(cfg.TencentCloud.Region); value != "" {
+		return value
+	}
+	return defaultRegion
+}
+
+func zoneForConfig(cfg core.Config) string {
+	if value := strings.TrimSpace(cfg.TencentCloud.Zone); value != "" {
+		return value
+	}
+	return defaultZone
+}
+
+func imageForConfig(cfg core.Config) string {
+	return strings.TrimSpace(cfg.TencentCloud.Image)
+}
+
+func serverTypeForConfig(cfg core.Config) string {
+	if cfg.ServerTypeExplicit && strings.TrimSpace(cfg.ServerType) != "" {
+		return strings.TrimSpace(cfg.ServerType)
+	}
+	if value := strings.TrimSpace(cfg.TencentCloud.Type); value != "" {
+		return value
+	}
+	return serverTypeForClass(cfg.Class)
+}
+
+func serverTypeForClass(class string) string {
+	switch strings.ToLower(strings.TrimSpace(class)) {
+	case "fast":
+		return "SA5.LARGE8"
+	case "large":
+		return "SA5.2XLARGE16"
+	case "beast":
+		return "SA5.8XLARGE64"
+	default:
+		return defaultType
+	}
+}
+
+func validateAcquireConfig(cfg core.Config) error {
+	if cfg.TargetOS != "" && cfg.TargetOS != core.TargetLinux {
+		return core.Exit(2, "provider=tencentcloud only supports target=linux")
+	}
+	if strings.TrimSpace(regionForConfig(cfg)) == "" {
+		return core.Exit(2, "tencentcloud region is required")
+	}
+	if strings.TrimSpace(zoneForConfig(cfg)) == "" {
+		return core.Exit(2, "tencentcloud zone is required")
+	}
+	if strings.TrimSpace(imageForConfig(cfg)) == "" {
+		return core.Exit(2, "tencentcloud image is required; set tencentcloud.image, --tencentcloud-image, or CRABBOX_TENCENTCLOUD_IMAGE to a CVM image ID")
+	}
+	if strings.TrimSpace(serverTypeForConfig(cfg)) == "" {
+		return core.Exit(2, "tencentcloud type is required")
+	}
+	if cfg.TencentCloud.RootGB < 0 {
+		return core.Exit(2, "tencentcloud rootGB must be non-negative")
+	}
+	if cfg.TencentCloud.InternetMaxBandwidthOut < 0 {
+		return core.Exit(2, "tencentcloud internetMaxBandwidthOut must be non-negative")
+	}
+	if len(cfg.TencentCloud.SSHCIDRs) > 0 {
+		return core.Exit(2, "provider=tencentcloud does not yet manage security-group SSH CIDRs; attach a preconfigured tencentcloud.securityGroupId or remove tencentcloud.sshCIDRs")
+	}
+	return nil
+}
+
+func cvmEndpointForConfig(cfg core.Config) string {
+	if value := strings.TrimSpace(cfg.TencentCloud.APIEndpoint); value != "" {
+		return normalizeEndpoint(value)
+	}
+	return defaultCVMEndpoint
+}
+
+func tagEndpointForConfig(cfg core.Config) string {
+	cvm := cvmEndpointForConfig(cfg)
+	if strings.Contains(cvm, ".intl.tencentcloudapi.com") {
+		return "https://tag.intl.tencentcloudapi.com"
+	}
+	return defaultTagEndpoint
+}
+
+func stsEndpointForConfig(cfg core.Config) string {
+	cvm := cvmEndpointForConfig(cfg)
+	if strings.Contains(cvm, ".intl.tencentcloudapi.com") {
+		return "https://sts.intl.tencentcloudapi.com"
+	}
+	return defaultSTSEndpoint
+}
+
+func normalizeEndpoint(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	if parsed, err := url.Parse(value); err == nil && parsed.Scheme != "" && parsed.Host != "" {
+		return value
+	}
+	return "https://" + strings.TrimPrefix(value, "//")
+}

--- a/internal/providers/tencentcloud/provider.go
+++ b/internal/providers/tencentcloud/provider.go
@@ -1,0 +1,150 @@
+package tencentcloud
+
+import (
+	"flag"
+	"strings"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+const providerName = "tencentcloud"
+
+func init() {
+	core.RegisterProvider(Provider{})
+}
+
+type Provider struct{}
+
+func (Provider) Name() string { return providerName }
+func (Provider) Aliases() []string {
+	return []string{"tencent", "tencent-cvm", "cvm"}
+}
+
+func (Provider) Spec() core.ProviderSpec {
+	return core.ProviderSpec{
+		Name:        providerName,
+		Family:      providerName,
+		Kind:        core.ProviderKindSSHLease,
+		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureTailscale},
+		Coordinator: core.CoordinatorNever,
+	}
+}
+
+type flagValues struct {
+	Region                  *string
+	Zone                    *string
+	Image                   *string
+	Type                    *string
+	VPCID                   *string
+	SubnetID                *string
+	SecurityGroupID         *string
+	SSHCIDRs                *string
+	RootGB                  *int64
+	InternetChargeType      *string
+	InternetMaxBandwidthOut *int64
+	APIEndpoint             *string
+}
+
+func (Provider) RegisterFlags(fs *flag.FlagSet, defaults core.Config) any {
+	return flagValues{
+		Region:                  fs.String("tencentcloud-region", defaults.TencentCloud.Region, "Tencent Cloud CVM region"),
+		Zone:                    fs.String("tencentcloud-zone", defaults.TencentCloud.Zone, "Tencent Cloud CVM availability zone"),
+		Image:                   fs.String("tencentcloud-image", defaults.TencentCloud.Image, "Tencent Cloud CVM image ID"),
+		Type:                    fs.String("tencentcloud-type", defaults.TencentCloud.Type, "Tencent Cloud CVM instance type"),
+		VPCID:                   fs.String("tencentcloud-vpc-id", defaults.TencentCloud.VPCID, "Tencent Cloud VPC ID"),
+		SubnetID:                fs.String("tencentcloud-subnet-id", defaults.TencentCloud.SubnetID, "Tencent Cloud subnet ID"),
+		SecurityGroupID:         fs.String("tencentcloud-security-group-id", defaults.TencentCloud.SecurityGroupID, "Tencent Cloud security group ID"),
+		SSHCIDRs:                fs.String("tencentcloud-ssh-cidrs", "", "comma-separated Tencent Cloud SSH source CIDRs; reserved for managed security-group support"),
+		RootGB:                  fs.Int64("tencentcloud-root-gb", defaults.TencentCloud.RootGB, "Tencent Cloud CVM system disk size in GiB"),
+		InternetChargeType:      fs.String("tencentcloud-internet-charge-type", defaults.TencentCloud.InternetChargeType, "Tencent Cloud public bandwidth charge type"),
+		InternetMaxBandwidthOut: fs.Int64("tencentcloud-internet-max-bandwidth-out", defaults.TencentCloud.InternetMaxBandwidthOut, "Tencent Cloud public outbound bandwidth in Mbps"),
+		APIEndpoint:             fs.String("tencentcloud-api-endpoint", defaults.TencentCloud.APIEndpoint, "Tencent Cloud CVM API endpoint"),
+	}
+}
+
+func (Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
+	v, ok := values.(flagValues)
+	if !ok {
+		return nil
+	}
+	if core.FlagWasSet(fs, "tencentcloud-region") {
+		cfg.TencentCloud.Region = *v.Region
+		core.SetTencentCloudRegionExplicit(cfg)
+	}
+	if core.FlagWasSet(fs, "tencentcloud-zone") {
+		cfg.TencentCloud.Zone = *v.Zone
+		core.SetTencentCloudZoneExplicit(cfg)
+	}
+	if core.FlagWasSet(fs, "tencentcloud-image") {
+		cfg.TencentCloud.Image = *v.Image
+		core.SetTencentCloudImageExplicit(cfg)
+	}
+	if core.FlagWasSet(fs, "tencentcloud-type") {
+		cfg.TencentCloud.Type = *v.Type
+		core.SetTencentCloudTypeExplicit(cfg)
+	}
+	if core.FlagWasSet(fs, "tencentcloud-vpc-id") {
+		cfg.TencentCloud.VPCID = *v.VPCID
+	}
+	if core.FlagWasSet(fs, "tencentcloud-subnet-id") {
+		cfg.TencentCloud.SubnetID = *v.SubnetID
+	}
+	if core.FlagWasSet(fs, "tencentcloud-security-group-id") {
+		cfg.TencentCloud.SecurityGroupID = *v.SecurityGroupID
+	}
+	if core.FlagWasSet(fs, "tencentcloud-ssh-cidrs") {
+		cfg.TencentCloud.SSHCIDRs = splitCommaList(*v.SSHCIDRs)
+	}
+	if core.FlagWasSet(fs, "tencentcloud-root-gb") {
+		cfg.TencentCloud.RootGB = *v.RootGB
+	}
+	if core.FlagWasSet(fs, "tencentcloud-internet-charge-type") {
+		cfg.TencentCloud.InternetChargeType = *v.InternetChargeType
+	}
+	if core.FlagWasSet(fs, "tencentcloud-internet-max-bandwidth-out") {
+		cfg.TencentCloud.InternetMaxBandwidthOut = *v.InternetMaxBandwidthOut
+	}
+	if core.FlagWasSet(fs, "tencentcloud-api-endpoint") {
+		cfg.TencentCloud.APIEndpoint = *v.APIEndpoint
+	}
+	return nil
+}
+
+func (Provider) ServerTypeForConfig(cfg core.Config) string {
+	if cfg.ServerTypeExplicit && cfg.ServerType != "" {
+		return cfg.ServerType
+	}
+	if cfg.TencentCloud.Type != "" {
+		return cfg.TencentCloud.Type
+	}
+	return serverTypeForClass(cfg.Class)
+}
+
+func (Provider) ServerTypeForClass(class string) string {
+	return serverTypeForClass(class)
+}
+
+func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
+	return NewBackend(p.Spec(), cfg, rt), nil
+}
+
+func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
+	backend := NewBackend(p.Spec(), cfg, rt)
+	doctor, ok := backend.(core.DoctorBackend)
+	if !ok {
+		return nil, core.Exit(2, "tencentcloud doctor backend unavailable")
+	}
+	return doctor, nil
+}
+
+func splitCommaList(value string) []string {
+	var out []string
+	for _, part := range strings.Split(value, ",") {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}

--- a/internal/providers/tencentcloud/provider_test.go
+++ b/internal/providers/tencentcloud/provider_test.go
@@ -1,0 +1,332 @@
+package tencentcloud
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"flag"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
+)
+
+func TestProviderFlagsApply(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	provider := Provider{}
+	values := provider.RegisterFlags(fs, core.Config{})
+	args := []string{
+		"--tencentcloud-region", "ap-guangzhou",
+		"--tencentcloud-zone", "ap-guangzhou-7",
+		"--tencentcloud-image", "img-test",
+		"--tencentcloud-type", "S5.SMALL2",
+		"--tencentcloud-vpc-id", "vpc-test",
+		"--tencentcloud-subnet-id", "subnet-test",
+		"--tencentcloud-security-group-id", "sg-test",
+		"--tencentcloud-root-gb", "80",
+		"--tencentcloud-internet-charge-type", "BANDWIDTH_POSTPAID_BY_HOUR",
+		"--tencentcloud-internet-max-bandwidth-out", "10",
+		"--tencentcloud-api-endpoint", "cvm.intl.tencentcloudapi.com",
+	}
+	if err := fs.Parse(args); err != nil {
+		t.Fatal(err)
+	}
+	cfg := core.Config{}
+	if err := provider.ApplyFlags(&cfg, fs, values); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.TencentCloud.Region != "ap-guangzhou" || !core.TencentCloudRegionWasExplicit(cfg) {
+		t.Fatalf("region=%q explicit=%v", cfg.TencentCloud.Region, core.TencentCloudRegionWasExplicit(cfg))
+	}
+	if cfg.TencentCloud.Zone != "ap-guangzhou-7" || !core.TencentCloudZoneWasExplicit(cfg) {
+		t.Fatalf("zone=%q explicit=%v", cfg.TencentCloud.Zone, core.TencentCloudZoneWasExplicit(cfg))
+	}
+	if cfg.TencentCloud.Image != "img-test" || !core.TencentCloudImageWasExplicit(cfg) {
+		t.Fatalf("image=%q explicit=%v", cfg.TencentCloud.Image, core.TencentCloudImageWasExplicit(cfg))
+	}
+	if cfg.TencentCloud.Type != "S5.SMALL2" || !core.TencentCloudTypeWasExplicit(cfg) {
+		t.Fatalf("type=%q explicit=%v", cfg.TencentCloud.Type, core.TencentCloudTypeWasExplicit(cfg))
+	}
+	if cfg.TencentCloud.VPCID != "vpc-test" || cfg.TencentCloud.SubnetID != "subnet-test" || cfg.TencentCloud.SecurityGroupID != "sg-test" {
+		t.Fatalf("network config=%+v", cfg.TencentCloud)
+	}
+	if cfg.TencentCloud.RootGB != 80 || cfg.TencentCloud.InternetChargeType != "BANDWIDTH_POSTPAID_BY_HOUR" || cfg.TencentCloud.InternetMaxBandwidthOut != 10 {
+		t.Fatalf("capacity config=%+v", cfg.TencentCloud)
+	}
+	if cfg.TencentCloud.APIEndpoint != "cvm.intl.tencentcloudapi.com" {
+		t.Fatalf("api endpoint=%q", cfg.TencentCloud.APIEndpoint)
+	}
+}
+
+func TestBuildRunInstanceRequest(t *testing.T) {
+	cfg := cfgForRun(core.Config{
+		TargetOS: core.TargetLinux,
+		Class:    "standard",
+		TencentCloud: core.TencentCloudConfig{
+			Region:                  "ap-shanghai",
+			Zone:                    "ap-shanghai-2",
+			Image:                   "img-test",
+			Type:                    "S5.SMALL2",
+			VPCID:                   "vpc-test",
+			SubnetID:                "subnet-test",
+			SecurityGroupID:         "sg-test",
+			RootGB:                  80,
+			InternetChargeType:      "TRAFFIC_POSTPAID_BY_HOUR",
+			InternetMaxBandwidthOut: 10,
+		},
+	})
+	cfg.ProviderKey = core.ProviderKeyForLease("cbx_abcdef123456")
+	cfg.ServerType = serverTypeForConfig(cfg)
+	tags := leaseTags(cfg, "cbx_abcdef123456", "my-app", "provisioning", false, time.Unix(1700000000, 0))
+	req := buildRunInstanceRequest(cfg, "cbx_abcdef123456", "my-app", "ssh-ed25519 AAAATEST", tags)
+
+	if req.Placement.Zone != "ap-shanghai-2" || req.ImageID != "img-test" || req.InstanceType != "S5.SMALL2" {
+		t.Fatalf("basic request=%+v", req)
+	}
+	if req.InstanceName != core.LeaseProviderName("cbx_abcdef123456", "my-app") {
+		t.Fatalf("instance name=%q", req.InstanceName)
+	}
+	if req.VirtualPrivateCloud == nil || req.VirtualPrivateCloud.VPCID != "vpc-test" || req.VirtualPrivateCloud.SubnetID != "subnet-test" {
+		t.Fatalf("vpc=%+v", req.VirtualPrivateCloud)
+	}
+	if len(req.SecurityGroupIDs) != 1 || req.SecurityGroupIDs[0] != "sg-test" {
+		t.Fatalf("security groups=%v", req.SecurityGroupIDs)
+	}
+	if req.SystemDisk == nil || req.SystemDisk.DiskSize != 80 {
+		t.Fatalf("system disk=%+v", req.SystemDisk)
+	}
+	if req.InternetAccessible == nil || !req.InternetAccessible.PublicIPAssigned || req.InternetAccessible.InternetMaxBandwidthOut != 10 {
+		t.Fatalf("internet=%+v", req.InternetAccessible)
+	}
+	userData, err := base64.StdEncoding.DecodeString(req.UserData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(userData), "ssh-ed25519 AAAATEST") {
+		t.Fatalf("user data does not contain public key")
+	}
+	if len(req.TagSpecification) != 1 || req.TagSpecification[0].ResourceType != "instance" {
+		t.Fatalf("tag spec=%+v", req.TagSpecification)
+	}
+}
+
+func TestSignTencentCloudRequest(t *testing.T) {
+	req, err := http.NewRequest(http.MethodPost, "https://cvm.tencentcloudapi.com", strings.NewReader("{}"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	signTencentCloudRequest(req, signInput{
+		SecretID:  "secret-id",
+		SecretKey: "secret-key",
+		Service:   cvmService,
+		Action:    "DescribeInstances",
+		Version:   cvmVersion,
+		Region:    "ap-shanghai",
+		Timestamp: 1700000000,
+		Payload:   []byte("{}"),
+	})
+	if req.Header.Get("X-TC-Action") != "DescribeInstances" || req.Header.Get("X-TC-Version") != cvmVersion || req.Header.Get("X-TC-Region") != "ap-shanghai" {
+		t.Fatalf("headers=%v", req.Header)
+	}
+	auth := req.Header.Get("Authorization")
+	for _, want := range []string{"TC3-HMAC-SHA256", "Credential=secret-id/2023-11-14/cvm/tc3_request", "SignedHeaders=content-type;host;x-tc-action", "Signature="} {
+		if !strings.Contains(auth, want) {
+			t.Fatalf("authorization %q missing %q", auth, want)
+		}
+	}
+}
+
+func TestResourceName(t *testing.T) {
+	got := resourceName("ap-shanghai", "100000000001", "ins-abc")
+	want := "qcs::cvm:ap-shanghai:uin/100000000001:instance/ins-abc"
+	if got != want {
+		t.Fatalf("resourceName=%q, want %q", got, want)
+	}
+}
+
+func TestTagUpdateSetUsesTagAPIFieldNames(t *testing.T) {
+	got := tagUpdateSet([]tag{{Key: "state", Value: "ready"}, {Key: "", Value: "skip"}})
+	if len(got) != 1 {
+		t.Fatalf("tag updates=%+v", got)
+	}
+	if got[0].TagKey != "state" || got[0].TagValue != "ready" {
+		t.Fatalf("tag update=%+v", got[0])
+	}
+}
+
+func TestTagDeleteSetDeletesObsoleteManagedTagsOnly(t *testing.T) {
+	got := tagDeleteSet(
+		[]tag{
+			{Key: "crabbox", Value: "true"},
+			{Key: "provider", Value: providerName},
+			{Key: "state", Value: "ready"},
+			{Key: "tailscale_error", Value: "old failure"},
+			{Key: "owner", Value: "external"},
+		},
+		[]tag{
+			{Key: "crabbox", Value: "true"},
+			{Key: "provider", Value: providerName},
+			{Key: "state", Value: "ready"},
+		},
+	)
+	if len(got) != 1 || got[0].TagKey != "tailscale_error" {
+		t.Fatalf("tag deletes=%+v", got)
+	}
+}
+
+func TestReplaceInstanceTagsSendsDeleteTagsForObsoleteManagedTags(t *testing.T) {
+	var payload struct {
+		Resource    string      `json:"Resource"`
+		ReplaceTags []tagUpdate `json:"ReplaceTags"`
+		DeleteTags  []tagDelete `json:"DeleteTags"`
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-TC-Action") != "ModifyResourceTags" {
+			t.Fatalf("X-TC-Action=%q", r.Header.Get("X-TC-Action"))
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatal(err)
+		}
+		_, _ = w.Write([]byte(`{"Response":{"RequestId":"req-test"}}`))
+	}))
+	defer server.Close()
+
+	client := &client{
+		secretID:     "secret-id",
+		secretKey:    "secret-key",
+		httpClient:   server.Client(),
+		region:       "ap-shanghai",
+		tagEndpoint:  server.URL,
+		accountID:    "100000000001",
+		accountReady: true,
+	}
+	err := client.ReplaceInstanceTags(
+		context.Background(),
+		"ins-test",
+		[]tag{
+			{Key: "crabbox", Value: "true"},
+			{Key: "provider", Value: providerName},
+			{Key: "tailscale_error", Value: "old failure"},
+			{Key: "owner", Value: "external"},
+		},
+		[]tag{
+			{Key: "crabbox", Value: "true"},
+			{Key: "provider", Value: providerName},
+			{Key: "state", Value: "ready"},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if payload.Resource != "qcs::cvm:ap-shanghai:uin/100000000001:instance/ins-test" {
+		t.Fatalf("resource=%q", payload.Resource)
+	}
+	if len(payload.DeleteTags) != 1 || payload.DeleteTags[0].TagKey != "tailscale_error" {
+		t.Fatalf("delete tags=%+v", payload.DeleteTags)
+	}
+	for _, item := range payload.DeleteTags {
+		if item.TagKey == "owner" {
+			t.Fatalf("external tag was deleted: %+v", payload.DeleteTags)
+		}
+	}
+	if len(payload.ReplaceTags) == 0 || payload.ReplaceTags[0].TagKey == "" {
+		t.Fatalf("replace tags=%+v", payload.ReplaceTags)
+	}
+}
+
+func TestInstanceDecodesTencentCloudTags(t *testing.T) {
+	var got instance
+	if err := json.Unmarshal([]byte(`{"InstanceId":"ins-test","Tags":[{"Key":"crabbox","Value":"true"}]}`), &got); err != nil {
+		t.Fatal(err)
+	}
+	labels := labelsFromTags(got.Tags)
+	if labels["crabbox"] != "true" {
+		t.Fatalf("labels=%v", labels)
+	}
+}
+
+func TestUpdateTailscaleMetadataPassesCurrentAndDesiredTags(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.TargetOS = core.TargetLinux
+	cfg.ServerType = "SA5.MEDIUM2"
+	cfg.ProviderKey = core.ProviderKeyForLease("cbx_abcdef123456")
+	tags := leaseTags(cfg, "cbx_abcdef123456", "tailnet", "ready", false, time.Unix(1700000000, 0))
+	tags = append(tags, tag{Key: "tailscale_error", Value: "old failure"})
+	item := instance{
+		InstanceID:    "ins-test",
+		InstanceName:  core.LeaseProviderName("cbx_abcdef123456", "tailnet"),
+		InstanceState: "RUNNING",
+		Tags:          tags,
+	}
+	api := &fakeTencentCloudAPI{item: item}
+	backend := &Backend{
+		DirectSSHBackend: shared.DirectSSHBackend{Cfg: cfg},
+		clientFactory: func(core.Config, core.Runtime) (tencentCloudAPI, error) {
+			return api, nil
+		},
+	}
+	server := serverFromInstance(item, cfg)
+	updated, err := backend.UpdateTailscaleMetadata(context.Background(), core.LeaseTarget{Server: server, LeaseID: "cbx_abcdef123456"}, core.TailscaleMetadata{
+		Enabled: true,
+		State:   "ready",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := updated.Labels["tailscale_error"]; ok {
+		t.Fatalf("updated labels still include tailscale_error: %v", updated.Labels)
+	}
+	if !hasTag(api.replacedCurrent, "tailscale_error") {
+		t.Fatalf("current tags did not include stale error: %+v", api.replacedCurrent)
+	}
+	if hasTag(api.replacedDesired, "tailscale_error") {
+		t.Fatalf("desired tags still include stale error: %+v", api.replacedDesired)
+	}
+}
+
+type fakeTencentCloudAPI struct {
+	item            instance
+	replacedCurrent []tag
+	replacedDesired []tag
+}
+
+func (f *fakeTencentCloudAPI) AccountID(context.Context) (string, error) {
+	return "100000000001", nil
+}
+
+func (f *fakeTencentCloudAPI) ListInstances(context.Context) ([]instance, error) {
+	return []instance{f.item}, nil
+}
+
+func (f *fakeTencentCloudAPI) GetInstance(context.Context, string) (instance, error) {
+	return f.item, nil
+}
+
+func (f *fakeTencentCloudAPI) RunInstance(context.Context, runInstanceRequest) (string, error) {
+	return "ins-test", nil
+}
+
+func (f *fakeTencentCloudAPI) TerminateInstance(context.Context, string) error {
+	return nil
+}
+
+func (f *fakeTencentCloudAPI) ReplaceInstanceTags(_ context.Context, _ string, current, desired []tag) error {
+	f.replacedCurrent = append([]tag(nil), current...)
+	f.replacedDesired = append([]tag(nil), desired...)
+	f.item.Tags = append([]tag(nil), desired...)
+	return nil
+}
+
+func hasTag(tags []tag, key string) bool {
+	for _, item := range tags {
+		if item.Key == key {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/providers/tencentcloud/provider_test.go
+++ b/internal/providers/tencentcloud/provider_test.go
@@ -1,0 +1,145 @@
+package tencentcloud
+
+import (
+	"encoding/base64"
+	"flag"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestProviderFlagsApply(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	provider := Provider{}
+	values := provider.RegisterFlags(fs, core.Config{})
+	args := []string{
+		"--tencentcloud-region", "ap-guangzhou",
+		"--tencentcloud-zone", "ap-guangzhou-7",
+		"--tencentcloud-image", "img-test",
+		"--tencentcloud-type", "S5.SMALL2",
+		"--tencentcloud-vpc-id", "vpc-test",
+		"--tencentcloud-subnet-id", "subnet-test",
+		"--tencentcloud-security-group-id", "sg-test",
+		"--tencentcloud-root-gb", "80",
+		"--tencentcloud-internet-charge-type", "BANDWIDTH_POSTPAID_BY_HOUR",
+		"--tencentcloud-internet-max-bandwidth-out", "10",
+		"--tencentcloud-api-endpoint", "cvm.intl.tencentcloudapi.com",
+	}
+	if err := fs.Parse(args); err != nil {
+		t.Fatal(err)
+	}
+	cfg := core.Config{}
+	if err := provider.ApplyFlags(&cfg, fs, values); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.TencentCloud.Region != "ap-guangzhou" || !core.TencentCloudRegionWasExplicit(cfg) {
+		t.Fatalf("region=%q explicit=%v", cfg.TencentCloud.Region, core.TencentCloudRegionWasExplicit(cfg))
+	}
+	if cfg.TencentCloud.Zone != "ap-guangzhou-7" || !core.TencentCloudZoneWasExplicit(cfg) {
+		t.Fatalf("zone=%q explicit=%v", cfg.TencentCloud.Zone, core.TencentCloudZoneWasExplicit(cfg))
+	}
+	if cfg.TencentCloud.Image != "img-test" || !core.TencentCloudImageWasExplicit(cfg) {
+		t.Fatalf("image=%q explicit=%v", cfg.TencentCloud.Image, core.TencentCloudImageWasExplicit(cfg))
+	}
+	if cfg.TencentCloud.Type != "S5.SMALL2" || !core.TencentCloudTypeWasExplicit(cfg) {
+		t.Fatalf("type=%q explicit=%v", cfg.TencentCloud.Type, core.TencentCloudTypeWasExplicit(cfg))
+	}
+	if cfg.TencentCloud.VPCID != "vpc-test" || cfg.TencentCloud.SubnetID != "subnet-test" || cfg.TencentCloud.SecurityGroupID != "sg-test" {
+		t.Fatalf("network config=%+v", cfg.TencentCloud)
+	}
+	if cfg.TencentCloud.RootGB != 80 || cfg.TencentCloud.InternetChargeType != "BANDWIDTH_POSTPAID_BY_HOUR" || cfg.TencentCloud.InternetMaxBandwidthOut != 10 {
+		t.Fatalf("capacity config=%+v", cfg.TencentCloud)
+	}
+	if cfg.TencentCloud.APIEndpoint != "cvm.intl.tencentcloudapi.com" {
+		t.Fatalf("api endpoint=%q", cfg.TencentCloud.APIEndpoint)
+	}
+}
+
+func TestBuildRunInstanceRequest(t *testing.T) {
+	cfg := cfgForRun(core.Config{
+		TargetOS: core.TargetLinux,
+		Class:    "standard",
+		TencentCloud: core.TencentCloudConfig{
+			Region:                  "ap-shanghai",
+			Zone:                    "ap-shanghai-2",
+			Image:                   "img-test",
+			Type:                    "S5.SMALL2",
+			VPCID:                   "vpc-test",
+			SubnetID:                "subnet-test",
+			SecurityGroupID:         "sg-test",
+			RootGB:                  80,
+			InternetChargeType:      "TRAFFIC_POSTPAID_BY_HOUR",
+			InternetMaxBandwidthOut: 10,
+		},
+	})
+	cfg.ProviderKey = core.ProviderKeyForLease("cbx_abcdef123456")
+	cfg.ServerType = serverTypeForConfig(cfg)
+	tags := leaseTags(cfg, "cbx_abcdef123456", "my-app", "provisioning", false, time.Unix(1700000000, 0))
+	req := buildRunInstanceRequest(cfg, "cbx_abcdef123456", "my-app", "ssh-ed25519 AAAATEST", tags)
+
+	if req.Placement.Zone != "ap-shanghai-2" || req.ImageID != "img-test" || req.InstanceType != "S5.SMALL2" {
+		t.Fatalf("basic request=%+v", req)
+	}
+	if req.InstanceName != core.LeaseProviderName("cbx_abcdef123456", "my-app") {
+		t.Fatalf("instance name=%q", req.InstanceName)
+	}
+	if req.VirtualPrivateCloud == nil || req.VirtualPrivateCloud.VPCID != "vpc-test" || req.VirtualPrivateCloud.SubnetID != "subnet-test" {
+		t.Fatalf("vpc=%+v", req.VirtualPrivateCloud)
+	}
+	if len(req.SecurityGroupIDs) != 1 || req.SecurityGroupIDs[0] != "sg-test" {
+		t.Fatalf("security groups=%v", req.SecurityGroupIDs)
+	}
+	if req.SystemDisk == nil || req.SystemDisk.DiskSize != 80 {
+		t.Fatalf("system disk=%+v", req.SystemDisk)
+	}
+	if req.InternetAccessible == nil || !req.InternetAccessible.PublicIPAssigned || req.InternetAccessible.InternetMaxBandwidthOut != 10 {
+		t.Fatalf("internet=%+v", req.InternetAccessible)
+	}
+	userData, err := base64.StdEncoding.DecodeString(req.UserData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(userData), "ssh-ed25519 AAAATEST") {
+		t.Fatalf("user data does not contain public key")
+	}
+	if len(req.TagSpecification) != 1 || req.TagSpecification[0].ResourceType != "instance" {
+		t.Fatalf("tag spec=%+v", req.TagSpecification)
+	}
+}
+
+func TestSignTencentCloudRequest(t *testing.T) {
+	req, err := http.NewRequest(http.MethodPost, "https://cvm.tencentcloudapi.com", strings.NewReader("{}"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	signTencentCloudRequest(req, signInput{
+		SecretID:  "secret-id",
+		SecretKey: "secret-key",
+		Service:   cvmService,
+		Action:    "DescribeInstances",
+		Version:   cvmVersion,
+		Region:    "ap-shanghai",
+		Timestamp: 1700000000,
+		Payload:   []byte("{}"),
+	})
+	if req.Header.Get("X-TC-Action") != "DescribeInstances" || req.Header.Get("X-TC-Version") != cvmVersion || req.Header.Get("X-TC-Region") != "ap-shanghai" {
+		t.Fatalf("headers=%v", req.Header)
+	}
+	auth := req.Header.Get("Authorization")
+	for _, want := range []string{"TC3-HMAC-SHA256", "Credential=secret-id/2023-11-14/cvm/tc3_request", "SignedHeaders=content-type;host;x-tc-action", "Signature="} {
+		if !strings.Contains(auth, want) {
+			t.Fatalf("authorization %q missing %q", auth, want)
+		}
+	}
+}
+
+func TestResourceName(t *testing.T) {
+	got := resourceName("ap-shanghai", "100000000001", "ins-abc")
+	want := "qcs::cvm:ap-shanghai:uin/100000000001:instance/ins-abc"
+	if got != want {
+		t.Fatalf("resourceName=%q, want %q", got, want)
+	}
+}

--- a/internal/providers/tencentcloud/tags.go
+++ b/internal/providers/tencentcloud/tags.go
@@ -1,0 +1,214 @@
+package tencentcloud
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+const (
+	tencentTagValueLimit = 255
+	accountLabel         = "provider_account"
+)
+
+type tag struct {
+	Key   string `json:"Key"`
+	Value string `json:"Value"`
+}
+
+type tagUpdate struct {
+	TagKey   string `json:"TagKey"`
+	TagValue string `json:"TagValue"`
+}
+
+type tagDelete struct {
+	TagKey string `json:"TagKey"`
+}
+
+func tagUpdateSet(tags []tag) []tagUpdate {
+	out := make([]tagUpdate, 0, len(tags))
+	for _, item := range tags {
+		if item.Key == "" {
+			continue
+		}
+		out = append(out, tagUpdate{TagKey: item.Key, TagValue: item.Value})
+	}
+	return out
+}
+
+func tagDeleteSet(currentTags, desiredTags []tag) []tagDelete {
+	desired := make(map[string]bool, len(desiredTags))
+	for _, item := range desiredTags {
+		key := normalizeTagKey(item.Key)
+		if key != "" {
+			desired[key] = true
+		}
+	}
+	seen := map[string]bool{}
+	out := make([]tagDelete, 0)
+	for _, item := range currentTags {
+		key := normalizeTagKey(item.Key)
+		if key == "" || seen[key] || desired[key] || !crabboxManagedTagKey(key) {
+			continue
+		}
+		seen[key] = true
+		out = append(out, tagDelete{TagKey: key})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].TagKey < out[j].TagKey })
+	return out
+}
+
+func crabboxManagedTagKey(key string) bool {
+	if strings.HasPrefix(key, "tailscale_") {
+		return true
+	}
+	switch key {
+	case "browser",
+		"class",
+		"code",
+		"crabbox",
+		"crabbox_exposed_ports",
+		"created_at",
+		"created_by",
+		"desktop",
+		"desktop_env",
+		"expires_at",
+		"idle_timeout",
+		"idle_timeout_secs",
+		"keep",
+		"last_touched_at",
+		"lease",
+		"market",
+		"pond",
+		"profile",
+		"provider",
+		"provider_account",
+		"provider_key",
+		"server_type",
+		"slug",
+		"state",
+		"tailscale",
+		"target",
+		"ttl_secs",
+		"windows_mode":
+		return true
+	default:
+		return false
+	}
+}
+
+func leaseTags(cfg core.Config, leaseID, slug, state string, keep bool, now time.Time) []tag {
+	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", keep, now)
+	labels["state"] = state
+	if cfg.Tailscale.Enabled && len(cfg.Tailscale.Tags) > 0 {
+		labels["tailscale_tags"] = strings.Join(cfg.Tailscale.Tags, ",")
+	}
+	return tagsFromLabels(labels)
+}
+
+func tagsFromLabels(labels map[string]string) []tag {
+	keys := make([]string, 0, len(labels))
+	for key, value := range labels {
+		key = normalizeTagKey(key)
+		if key == "" || strings.TrimSpace(value) == "" {
+			continue
+		}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	out := make([]tag, 0, len(keys))
+	seen := map[string]bool{}
+	for _, key := range keys {
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		value := labels[key]
+		if value == "" {
+			value = labels[strings.ToLower(key)]
+		}
+		out = append(out, tag{Key: key, Value: truncateTagValue(value)})
+	}
+	return out
+}
+
+func labelsFromTags(tags []tag) map[string]string {
+	labels := map[string]string{}
+	for _, item := range tags {
+		key := normalizeTagKey(item.Key)
+		if key == "" {
+			continue
+		}
+		labels[key] = strings.TrimSpace(item.Value)
+	}
+	return labels
+}
+
+func normalizeTagKey(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" {
+		return ""
+	}
+	var out strings.Builder
+	for _, r := range value {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_' || r == '-' {
+			out.WriteRune(r)
+		} else {
+			out.WriteByte('_')
+		}
+	}
+	value = strings.Trim(out.String(), "_-")
+	if value == "" {
+		return ""
+	}
+	if len(value) > 127 {
+		value = value[:127]
+	}
+	return value
+}
+
+func truncateTagValue(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) <= tencentTagValueLimit {
+		return value
+	}
+	return value[:tencentTagValueLimit]
+}
+
+func ownedLabels(labels map[string]string) bool {
+	return labels["crabbox"] == "true" && labels["provider"] == providerName
+}
+
+func applyTailscaleMetadata(labels map[string]string, meta core.TailscaleMetadata) {
+	if meta.Enabled {
+		labels["tailscale"] = "true"
+	}
+	if meta.Hostname != "" {
+		labels["tailscale_hostname"] = meta.Hostname
+	}
+	if meta.FQDN != "" {
+		labels["tailscale_fqdn"] = meta.FQDN
+	}
+	if meta.IPv4 != "" {
+		labels["tailscale_ipv4"] = meta.IPv4
+	}
+	if len(meta.Tags) > 0 {
+		labels["tailscale_tags"] = strings.Join(meta.Tags, ",")
+	}
+	if meta.State != "" {
+		labels["tailscale_state"] = meta.State
+	}
+	if meta.Error != "" {
+		labels["tailscale_error"] = meta.Error
+	} else {
+		delete(labels, "tailscale_error")
+	}
+	if meta.ExitNode != "" {
+		labels["tailscale_exit_node"] = meta.ExitNode
+	}
+	if meta.ExitNodeAllowLANAccess {
+		labels["tailscale_exit_node_allow_lan_access"] = "true"
+	}
+}

--- a/internal/providers/tencentcloud/tags.go
+++ b/internal/providers/tencentcloud/tags.go
@@ -1,0 +1,133 @@
+package tencentcloud
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+const (
+	tencentTagValueLimit = 255
+	accountLabel         = "provider_account"
+)
+
+type tag struct {
+	Key   string `json:"Key"`
+	Value string `json:"Value"`
+}
+
+func leaseTags(cfg core.Config, leaseID, slug, state string, keep bool, now time.Time) []tag {
+	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", keep, now)
+	labels["state"] = state
+	if cfg.Tailscale.Enabled && len(cfg.Tailscale.Tags) > 0 {
+		labels["tailscale_tags"] = strings.Join(cfg.Tailscale.Tags, ",")
+	}
+	return tagsFromLabels(labels)
+}
+
+func tagsFromLabels(labels map[string]string) []tag {
+	keys := make([]string, 0, len(labels))
+	for key, value := range labels {
+		key = normalizeTagKey(key)
+		if key == "" || strings.TrimSpace(value) == "" {
+			continue
+		}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	out := make([]tag, 0, len(keys))
+	seen := map[string]bool{}
+	for _, key := range keys {
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		value := labels[key]
+		if value == "" {
+			value = labels[strings.ToLower(key)]
+		}
+		out = append(out, tag{Key: key, Value: truncateTagValue(value)})
+	}
+	return out
+}
+
+func labelsFromTags(tags []tag) map[string]string {
+	labels := map[string]string{}
+	for _, item := range tags {
+		key := normalizeTagKey(item.Key)
+		if key == "" {
+			continue
+		}
+		labels[key] = strings.TrimSpace(item.Value)
+	}
+	return labels
+}
+
+func normalizeTagKey(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" {
+		return ""
+	}
+	var out strings.Builder
+	for _, r := range value {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_' || r == '-' {
+			out.WriteRune(r)
+		} else {
+			out.WriteByte('_')
+		}
+	}
+	value = strings.Trim(out.String(), "_-")
+	if value == "" {
+		return ""
+	}
+	if len(value) > 127 {
+		value = value[:127]
+	}
+	return value
+}
+
+func truncateTagValue(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) <= tencentTagValueLimit {
+		return value
+	}
+	return value[:tencentTagValueLimit]
+}
+
+func ownedLabels(labels map[string]string) bool {
+	return labels["crabbox"] == "true" && labels["provider"] == providerName
+}
+
+func applyTailscaleMetadata(labels map[string]string, meta core.TailscaleMetadata) {
+	if meta.Enabled {
+		labels["tailscale"] = "true"
+	}
+	if meta.Hostname != "" {
+		labels["tailscale_hostname"] = meta.Hostname
+	}
+	if meta.FQDN != "" {
+		labels["tailscale_fqdn"] = meta.FQDN
+	}
+	if meta.IPv4 != "" {
+		labels["tailscale_ipv4"] = meta.IPv4
+	}
+	if len(meta.Tags) > 0 {
+		labels["tailscale_tags"] = strings.Join(meta.Tags, ",")
+	}
+	if meta.State != "" {
+		labels["tailscale_state"] = meta.State
+	}
+	if meta.Error != "" {
+		labels["tailscale_error"] = meta.Error
+	} else {
+		delete(labels, "tailscale_error")
+	}
+	if meta.ExitNode != "" {
+		labels["tailscale_exit_node"] = meta.ExitNode
+	}
+	if meta.ExitNodeAllowLANAccess {
+		labels["tailscale_exit_node_allow_lan_access"] = "true"
+	}
+}

--- a/internal/providers/tencentcloud/types.go
+++ b/internal/providers/tencentcloud/types.go
@@ -1,0 +1,72 @@
+package tencentcloud
+
+type getCallerIdentityResponse struct {
+	AccountID string `json:"AccountId"`
+	UIN       string `json:"Uin"`
+	UserID    string `json:"UserId"`
+	Arn       string `json:"Arn"`
+	RequestID string `json:"RequestId"`
+}
+
+type describeInstancesResponse struct {
+	TotalCount  int64      `json:"TotalCount"`
+	InstanceSet []instance `json:"InstanceSet"`
+	RequestID   string     `json:"RequestId"`
+}
+
+type runInstancesResponse struct {
+	InstanceIDSet []string `json:"InstanceIdSet"`
+	RequestID     string   `json:"RequestId"`
+}
+
+type instance struct {
+	InstanceID         string    `json:"InstanceId"`
+	InstanceName       string    `json:"InstanceName"`
+	InstanceState      string    `json:"InstanceState"`
+	InstanceType       string    `json:"InstanceType"`
+	PublicIPAddresses  []string  `json:"PublicIpAddresses"`
+	PrivateIPAddresses []string  `json:"PrivateIpAddresses"`
+	Placement          placement `json:"Placement"`
+	Tags               []tag     `json:"Tags"`
+	CreatedTime        string    `json:"CreatedTime"`
+}
+
+type placement struct {
+	Zone string `json:"Zone"`
+}
+
+type runInstanceRequest struct {
+	InstanceChargeType  string               `json:"InstanceChargeType,omitempty"`
+	Placement           placement            `json:"Placement"`
+	ImageID             string               `json:"ImageId"`
+	InstanceType        string               `json:"InstanceType"`
+	SystemDisk          *systemDisk          `json:"SystemDisk,omitempty"`
+	VirtualPrivateCloud *virtualPrivateCloud `json:"VirtualPrivateCloud,omitempty"`
+	InternetAccessible  *internetAccessible  `json:"InternetAccessible,omitempty"`
+	InstanceCount       int64                `json:"InstanceCount,omitempty"`
+	InstanceName        string               `json:"InstanceName,omitempty"`
+	SecurityGroupIDs    []string             `json:"SecurityGroupIds,omitempty"`
+	UserData            string               `json:"UserData,omitempty"`
+	TagSpecification    []tagSpecification   `json:"TagSpecification,omitempty"`
+	ClientToken         string               `json:"ClientToken,omitempty"`
+}
+
+type systemDisk struct {
+	DiskSize int64 `json:"DiskSize,omitempty"`
+}
+
+type virtualPrivateCloud struct {
+	VPCID    string `json:"VpcId,omitempty"`
+	SubnetID string `json:"SubnetId,omitempty"`
+}
+
+type internetAccessible struct {
+	InternetChargeType      string `json:"InternetChargeType,omitempty"`
+	InternetMaxBandwidthOut int64  `json:"InternetMaxBandwidthOut,omitempty"`
+	PublicIPAssigned        bool   `json:"PublicIpAssigned"`
+}
+
+type tagSpecification struct {
+	ResourceType string `json:"ResourceType"`
+	Tags         []tag  `json:"Tags"`
+}

--- a/internal/providers/tencentcloud/types.go
+++ b/internal/providers/tencentcloud/types.go
@@ -1,0 +1,72 @@
+package tencentcloud
+
+type getCallerIdentityResponse struct {
+	AccountID string `json:"AccountId"`
+	UIN       string `json:"Uin"`
+	UserID    string `json:"UserId"`
+	Arn       string `json:"Arn"`
+	RequestID string `json:"RequestId"`
+}
+
+type describeInstancesResponse struct {
+	TotalCount  int64      `json:"TotalCount"`
+	InstanceSet []instance `json:"InstanceSet"`
+	RequestID   string     `json:"RequestId"`
+}
+
+type runInstancesResponse struct {
+	InstanceIDSet []string `json:"InstanceIdSet"`
+	RequestID     string   `json:"RequestId"`
+}
+
+type instance struct {
+	InstanceID         string    `json:"InstanceId"`
+	InstanceName       string    `json:"InstanceName"`
+	InstanceState      string    `json:"InstanceState"`
+	InstanceType       string    `json:"InstanceType"`
+	PublicIPAddresses  []string  `json:"PublicIpAddresses"`
+	PrivateIPAddresses []string  `json:"PrivateIpAddresses"`
+	Placement          placement `json:"Placement"`
+	TagSet             []tag     `json:"TagSet"`
+	CreatedTime        string    `json:"CreatedTime"`
+}
+
+type placement struct {
+	Zone string `json:"Zone"`
+}
+
+type runInstanceRequest struct {
+	InstanceChargeType  string               `json:"InstanceChargeType,omitempty"`
+	Placement           placement            `json:"Placement"`
+	ImageID             string               `json:"ImageId"`
+	InstanceType        string               `json:"InstanceType"`
+	SystemDisk          *systemDisk          `json:"SystemDisk,omitempty"`
+	VirtualPrivateCloud *virtualPrivateCloud `json:"VirtualPrivateCloud,omitempty"`
+	InternetAccessible  *internetAccessible  `json:"InternetAccessible,omitempty"`
+	InstanceCount       int64                `json:"InstanceCount,omitempty"`
+	InstanceName        string               `json:"InstanceName,omitempty"`
+	SecurityGroupIDs    []string             `json:"SecurityGroupIds,omitempty"`
+	UserData            string               `json:"UserData,omitempty"`
+	TagSpecification    []tagSpecification   `json:"TagSpecification,omitempty"`
+	ClientToken         string               `json:"ClientToken,omitempty"`
+}
+
+type systemDisk struct {
+	DiskSize int64 `json:"DiskSize,omitempty"`
+}
+
+type virtualPrivateCloud struct {
+	VPCID    string `json:"VpcId,omitempty"`
+	SubnetID string `json:"SubnetId,omitempty"`
+}
+
+type internetAccessible struct {
+	InternetChargeType      string `json:"InternetChargeType,omitempty"`
+	InternetMaxBandwidthOut int64  `json:"InternetMaxBandwidthOut,omitempty"`
+	PublicIPAssigned        bool   `json:"PublicIpAssigned"`
+}
+
+type tagSpecification struct {
+	ResourceType string `json:"ResourceType"`
+	Tags         []tag  `json:"Tags"`
+}

--- a/scripts/live-smoke.sh
+++ b/scripts/live-smoke.sh
@@ -1010,6 +1010,10 @@ if has_provider scaleway; then
   "$root/scripts/live-scaleway-smoke.sh"
 fi
 
+if has_provider tencentcloud || has_provider tencent || has_provider tencent-cvm || has_provider cvm; then
+  "$root/scripts/live-tencentcloud-smoke.sh"
+fi
+
 if has_provider linode; then
   "$root/scripts/live-linode-smoke.sh"
 fi

--- a/scripts/live-tencentcloud-smoke.sh
+++ b/scripts/live-tencentcloud-smoke.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+provider_enabled() {
+  local list="${CRABBOX_LIVE_PROVIDERS:-tencentcloud}"
+  local item
+  IFS=',' read -ra items <<<"$list"
+  for item in "${items[@]}"; do
+    item="${item//[[:space:]]/}"
+    case "$item" in
+      tencentcloud|tencent|tencent-cvm|cvm) return 0 ;;
+    esac
+  done
+  return 1
+}
+
+classify_blocker() {
+  local command="$1"
+  local status="$2"
+  local output="$3"
+  local classification="environment_blocked"
+  local lower
+  lower="$(printf '%s' "$output" | tr '[:upper:]' '[:lower:]')"
+  if [[ "$lower" == *quota* || "$lower" == *"insufficient"* || "$lower" == *capacity* || "$lower" == *limit* || "$lower" == *"not enough"* ]]; then
+    classification="quota_blocked"
+  fi
+  printf 'classification=%s command=%q exit=%s\n' "$classification" "$command" "$status" >&2
+  printf '%s\n' "$output" >&2
+}
+
+classify_validation_failure() {
+  local command="$1"
+  local status="$2"
+  local output="$3"
+  printf 'classification=validation_failed command=%q exit=%s\n' "$command" "$status" >&2
+  printf '%s\n' "$output" >&2
+}
+
+run_capture() {
+  local command="$1"
+  shift
+  local output
+  set +e
+  output="$("$@" 2>&1)"
+  local status=$?
+  set -e
+  if [ "$status" -ne 0 ]; then
+    classify_blocker "$command" "$status" "$output"
+    exit "$status"
+  fi
+  printf '%s\n' "$output"
+}
+
+validate_list_json_contains_slug() {
+  local command="$1"
+  local output="$2"
+  local validation_output=""
+  local status=0
+  set +e
+  validation_output="$(CRABBOX_SMOKE_SLUG="$slug" python3 -c '
+import json
+import os
+import sys
+
+slug = os.environ["CRABBOX_SMOKE_SLUG"]
+try:
+    payload = json.load(sys.stdin)
+except Exception as exc:
+    print(f"invalid JSON: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+def has_slug(value):
+    if isinstance(value, dict):
+        labels = value.get("labels")
+        if isinstance(labels, dict) and labels.get("slug") == slug:
+            return True
+        if value.get("slug") == slug or value.get("name") == slug or value.get("id") == slug or value.get("leaseId") == slug:
+            return True
+        return any(has_slug(child) for child in value.values())
+    if isinstance(value, list):
+        return any(has_slug(child) for child in value)
+    return False
+
+if not has_slug(payload):
+    print(f"list JSON did not include slug {slug}", file=sys.stderr)
+    sys.exit(1)
+' <<<"$output" 2>&1)"
+  status=$?
+  set -e
+  if [ "$status" -ne 0 ]; then
+    classify_validation_failure "$command" "$status" "$validation_output"
+    exit "$status"
+  fi
+}
+
+validate_list_json_empty() {
+	local command="$1"
+	local output="$2"
+	local validation_output=""
+  local status=0
+  set +e
+  validation_output="$(python3 -c '
+import json
+import sys
+
+try:
+    payload = json.load(sys.stdin)
+except Exception as exc:
+    print(f"invalid JSON: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+if payload != []:
+    print("Tencent Cloud Crabbox inventory is not empty", file=sys.stderr)
+    sys.exit(1)
+' <<<"$output" 2>&1)"
+  status=$?
+  set -e
+  if [ "$status" -ne 0 ]; then
+    classify_validation_failure "$command" "$status" "$validation_output"
+    exit "$status"
+	fi
+}
+
+list_json_empty() {
+	local output="$1"
+	python3 -c '
+import json
+import sys
+
+try:
+    payload = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+sys.exit(0 if payload == [] else 1)
+' <<<"$output" >/dev/null 2>&1
+}
+
+wait_list_json_empty() {
+	local command="$1"
+	shift
+	local output=""
+	for _ in {1..18}; do
+		output="$(run_capture "$command" "$@")"
+		if list_json_empty "$output"; then
+			printf '%s\n' "$output"
+			return 0
+		fi
+		sleep 10
+	done
+	classify_validation_failure "$command" 1 "Tencent Cloud Crabbox inventory is not empty after waiting"
+	exit 1
+}
+
+config_image() {
+	"$crabbox_bin" config show --provider tencentcloud --json | python3 -c '
+import json
+import sys
+
+payload = json.load(sys.stdin)
+print(((payload.get("tencentcloud") or {}).get("image") or "").strip())
+'
+}
+
+cleanup_armed=0
+slug="tencentcloud-smoke-$(date +%Y%m%d%H%M%S)-$$"
+crabbox_bin=""
+
+cleanup() {
+  local status=$?
+  if [ "$cleanup_armed" -eq 1 ]; then
+    set +e
+    local cleanup_output
+    cleanup_output="$("$crabbox_bin" stop --provider tencentcloud "$slug" 2>&1)"
+    local cleanup_status=$?
+    set -e
+    if [ "$cleanup_status" -ne 0 ]; then
+      printf 'classification=cleanup_failed command=%q exit=%s slug=%s\n' "$crabbox_bin stop --provider tencentcloud $slug" "$cleanup_status" "$slug" >&2
+      printf '%s\n' "$cleanup_output" >&2
+      if [ "$status" -eq 0 ]; then
+        status="$cleanup_status"
+      fi
+    fi
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
+
+if [[ "${CRABBOX_LIVE:-}" != "1" ]]; then
+  printf 'classification=environment_blocked reason=CRABBOX_LIVE_not_enabled\n'
+  exit 0
+fi
+
+if ! provider_enabled; then
+  printf 'classification=environment_blocked reason=tencentcloud_not_selected providers=%q\n' "${CRABBOX_LIVE_PROVIDERS:-}"
+  exit 0
+fi
+
+if [[ -z "${TENCENTCLOUD_SECRET_ID:-}" || -z "${TENCENTCLOUD_SECRET_KEY:-}" ]]; then
+  printf 'classification=environment_blocked reason=TENCENTCLOUD_SECRET_ID_or_SECRET_KEY_missing\n'
+  exit 0
+fi
+
+crabbox_bin="${CRABBOX_BIN:-bin/crabbox}"
+if [[ -z "${CRABBOX_BIN:-}" ]]; then
+  mkdir -p "$(dirname "$crabbox_bin")"
+  go build -trimpath -o "$crabbox_bin" ./cmd/crabbox
+fi
+
+image="${CRABBOX_LIVE_TENCENTCLOUD_IMAGE:-${CRABBOX_TENCENTCLOUD_IMAGE:-}}"
+if [[ -z "$image" ]]; then
+  image="$(config_image)"
+fi
+if [[ -z "$image" ]]; then
+  printf 'classification=environment_blocked reason=tencentcloud_image_missing\n'
+  exit 0
+fi
+
+type_arg="${CRABBOX_LIVE_TENCENTCLOUD_TYPE:-${CRABBOX_TENCENTCLOUD_TYPE:-SA5.MEDIUM2}}"
+
+doctor_output="$(run_capture "$crabbox_bin doctor --provider tencentcloud" "$crabbox_bin" doctor --provider tencentcloud)"
+printf '%s\n' "$doctor_output"
+
+list_output="$(run_capture "$crabbox_bin list --provider tencentcloud --json" "$crabbox_bin" list --provider tencentcloud --json)"
+validate_list_json_empty "$crabbox_bin list --provider tencentcloud --json" "$list_output"
+
+cleanup_armed=1
+warmup_output="$(run_capture "$crabbox_bin warmup --provider tencentcloud --slug $slug --keep --tencentcloud-image $image --tencentcloud-type $type_arg --ttl 20m --idle-timeout 5m" "$crabbox_bin" warmup --provider tencentcloud --slug "$slug" --keep --tencentcloud-image "$image" --tencentcloud-type "$type_arg" --ttl 20m --idle-timeout 5m)"
+printf '%s\n' "$warmup_output"
+
+run_capture "$crabbox_bin status --provider tencentcloud --id $slug --wait --wait-timeout 300s" "$crabbox_bin" status --provider tencentcloud --id "$slug" --wait --wait-timeout 300s >/dev/null
+run_output="$(run_capture "$crabbox_bin run --provider tencentcloud --id $slug --no-sync -- echo ok" "$crabbox_bin" run --provider tencentcloud --id "$slug" --no-sync -- echo ok)"
+printf '%s\n' "$run_output"
+if [[ "$run_output" != *ok* ]]; then
+  classify_validation_failure "$crabbox_bin run --provider tencentcloud --id $slug --no-sync -- echo ok" 1 "$run_output"
+  exit 1
+fi
+
+list_output="$(run_capture "$crabbox_bin list --provider tencentcloud --json" "$crabbox_bin" list --provider tencentcloud --json)"
+validate_list_json_contains_slug "$crabbox_bin list --provider tencentcloud --json" "$list_output"
+
+stop_output="$(run_capture "$crabbox_bin stop --provider tencentcloud $slug" "$crabbox_bin" stop --provider tencentcloud "$slug")"
+printf '%s\n' "$stop_output"
+cleanup_armed=0
+
+wait_list_json_empty "$crabbox_bin list --provider tencentcloud --json" "$crabbox_bin" list --provider tencentcloud --json >/dev/null
+
+cleanup_output="$(run_capture "$crabbox_bin cleanup --provider tencentcloud --dry-run" "$crabbox_bin" cleanup --provider tencentcloud --dry-run)"
+printf '%s\n' "$cleanup_output"
+
+list_output="$(run_capture "$crabbox_bin list --provider tencentcloud --json" "$crabbox_bin" list --provider tencentcloud --json)"
+validate_list_json_empty "$crabbox_bin list --provider tencentcloud --json" "$list_output"
+
+printf 'classification=live_tencentcloud_smoke_passed slug=%s image=%s type=%s\n' "$slug" "$image" "$type_arg"

--- a/scripts/live-tencentcloud-smoke.sh
+++ b/scripts/live-tencentcloud-smoke.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+provider_enabled() {
+  local list="${CRABBOX_LIVE_PROVIDERS:-tencentcloud}"
+  local item
+  IFS=',' read -ra items <<<"$list"
+  for item in "${items[@]}"; do
+    item="${item//[[:space:]]/}"
+    case "$item" in
+      tencentcloud|tencent|tencent-cvm|cvm) return 0 ;;
+    esac
+  done
+  return 1
+}
+
+classify_blocker() {
+  local command="$1"
+  local status="$2"
+  local output="$3"
+  local classification="environment_blocked"
+  local lower
+  lower="$(printf '%s' "$output" | tr '[:upper:]' '[:lower:]')"
+  if [[ "$lower" == *quota* || "$lower" == *"insufficient"* || "$lower" == *capacity* || "$lower" == *limit* || "$lower" == *"not enough"* ]]; then
+    classification="quota_blocked"
+  fi
+  printf 'classification=%s command=%q exit=%s\n' "$classification" "$command" "$status" >&2
+  printf '%s\n' "$output" >&2
+}
+
+classify_validation_failure() {
+  local command="$1"
+  local status="$2"
+  local output="$3"
+  printf 'classification=validation_failed command=%q exit=%s\n' "$command" "$status" >&2
+  printf '%s\n' "$output" >&2
+}
+
+run_capture() {
+  local command="$1"
+  shift
+  local output
+  set +e
+  output="$("$@" 2>&1)"
+  local status=$?
+  set -e
+  if [ "$status" -ne 0 ]; then
+    classify_blocker "$command" "$status" "$output"
+    exit "$status"
+  fi
+  printf '%s\n' "$output"
+}
+
+validate_list_json_contains_slug() {
+  local command="$1"
+  local output="$2"
+  local validation_output=""
+  local status=0
+  set +e
+  validation_output="$(CRABBOX_SMOKE_SLUG="$slug" python3 -c '
+import json
+import os
+import sys
+
+slug = os.environ["CRABBOX_SMOKE_SLUG"]
+try:
+    payload = json.load(sys.stdin)
+except Exception as exc:
+    print(f"invalid JSON: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+def has_slug(value):
+    if isinstance(value, dict):
+        labels = value.get("labels")
+        if isinstance(labels, dict) and labels.get("slug") == slug:
+            return True
+        if value.get("slug") == slug or value.get("name") == slug or value.get("id") == slug or value.get("leaseId") == slug:
+            return True
+        return any(has_slug(child) for child in value.values())
+    if isinstance(value, list):
+        return any(has_slug(child) for child in value)
+    return False
+
+if not has_slug(payload):
+    print(f"list JSON did not include slug {slug}", file=sys.stderr)
+    sys.exit(1)
+' <<<"$output" 2>&1)"
+  status=$?
+  set -e
+  if [ "$status" -ne 0 ]; then
+    classify_validation_failure "$command" "$status" "$validation_output"
+    exit "$status"
+  fi
+}
+
+validate_list_json_empty() {
+  local command="$1"
+  local output="$2"
+  local validation_output=""
+  local status=0
+  set +e
+  validation_output="$(python3 -c '
+import json
+import sys
+
+try:
+    payload = json.load(sys.stdin)
+except Exception as exc:
+    print(f"invalid JSON: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+if payload != []:
+    print("Tencent Cloud Crabbox inventory is not empty", file=sys.stderr)
+    sys.exit(1)
+' <<<"$output" 2>&1)"
+  status=$?
+  set -e
+  if [ "$status" -ne 0 ]; then
+    classify_validation_failure "$command" "$status" "$validation_output"
+    exit "$status"
+  fi
+}
+
+config_image() {
+  "$crabbox_bin" config show --provider tencentcloud --json | python3 -c '
+import json
+import sys
+
+payload = json.load(sys.stdin)
+print(((payload.get("tencentcloud") or {}).get("image") or "").strip())
+'
+}
+
+cleanup_armed=0
+slug="tencentcloud-smoke-$(date +%Y%m%d%H%M%S)-$$"
+crabbox_bin=""
+
+cleanup() {
+  local status=$?
+  if [ "$cleanup_armed" -eq 1 ]; then
+    set +e
+    local cleanup_output
+    cleanup_output="$("$crabbox_bin" stop --provider tencentcloud "$slug" 2>&1)"
+    local cleanup_status=$?
+    set -e
+    if [ "$cleanup_status" -ne 0 ]; then
+      printf 'classification=cleanup_failed command=%q exit=%s slug=%s\n' "$crabbox_bin stop --provider tencentcloud $slug" "$cleanup_status" "$slug" >&2
+      printf '%s\n' "$cleanup_output" >&2
+      if [ "$status" -eq 0 ]; then
+        status="$cleanup_status"
+      fi
+    fi
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
+
+if [[ "${CRABBOX_LIVE:-}" != "1" ]]; then
+  printf 'classification=environment_blocked reason=CRABBOX_LIVE_not_enabled\n'
+  exit 0
+fi
+
+if ! provider_enabled; then
+  printf 'classification=environment_blocked reason=tencentcloud_not_selected providers=%q\n' "${CRABBOX_LIVE_PROVIDERS:-}"
+  exit 0
+fi
+
+if [[ -z "${TENCENTCLOUD_SECRET_ID:-}" || -z "${TENCENTCLOUD_SECRET_KEY:-}" ]]; then
+  printf 'classification=environment_blocked reason=TENCENTCLOUD_SECRET_ID_or_SECRET_KEY_missing\n'
+  exit 0
+fi
+
+crabbox_bin="${CRABBOX_BIN:-bin/crabbox}"
+if [[ -z "${CRABBOX_BIN:-}" ]]; then
+  mkdir -p "$(dirname "$crabbox_bin")"
+  go build -trimpath -o "$crabbox_bin" ./cmd/crabbox
+fi
+
+image="${CRABBOX_LIVE_TENCENTCLOUD_IMAGE:-${CRABBOX_TENCENTCLOUD_IMAGE:-}}"
+if [[ -z "$image" ]]; then
+  image="$(config_image)"
+fi
+if [[ -z "$image" ]]; then
+  printf 'classification=environment_blocked reason=tencentcloud_image_missing\n'
+  exit 0
+fi
+
+type_arg="${CRABBOX_LIVE_TENCENTCLOUD_TYPE:-${CRABBOX_TENCENTCLOUD_TYPE:-SA5.MEDIUM2}}"
+
+doctor_output="$(run_capture "$crabbox_bin doctor --provider tencentcloud" "$crabbox_bin" doctor --provider tencentcloud)"
+printf '%s\n' "$doctor_output"
+
+list_output="$(run_capture "$crabbox_bin list --provider tencentcloud --json" "$crabbox_bin" list --provider tencentcloud --json)"
+validate_list_json_empty "$crabbox_bin list --provider tencentcloud --json" "$list_output"
+
+cleanup_armed=1
+warmup_output="$(run_capture "$crabbox_bin warmup --provider tencentcloud --slug $slug --keep --tencentcloud-image $image --tencentcloud-type $type_arg --ttl 20m --idle-timeout 5m" "$crabbox_bin" warmup --provider tencentcloud --slug "$slug" --keep --tencentcloud-image "$image" --tencentcloud-type "$type_arg" --ttl 20m --idle-timeout 5m)"
+printf '%s\n' "$warmup_output"
+
+run_capture "$crabbox_bin status --provider tencentcloud --id $slug --wait --wait-timeout 300s" "$crabbox_bin" status --provider tencentcloud --id "$slug" --wait --wait-timeout 300s >/dev/null
+run_output="$(run_capture "$crabbox_bin run --provider tencentcloud --id $slug --no-sync -- echo ok" "$crabbox_bin" run --provider tencentcloud --id "$slug" --no-sync -- echo ok)"
+printf '%s\n' "$run_output"
+if [[ "$run_output" != *ok* ]]; then
+  classify_validation_failure "$crabbox_bin run --provider tencentcloud --id $slug --no-sync -- echo ok" 1 "$run_output"
+  exit 1
+fi
+
+list_output="$(run_capture "$crabbox_bin list --provider tencentcloud --json" "$crabbox_bin" list --provider tencentcloud --json)"
+validate_list_json_contains_slug "$crabbox_bin list --provider tencentcloud --json" "$list_output"
+
+stop_output="$(run_capture "$crabbox_bin stop --provider tencentcloud $slug" "$crabbox_bin" stop --provider tencentcloud "$slug")"
+printf '%s\n' "$stop_output"
+cleanup_armed=0
+
+cleanup_output="$(run_capture "$crabbox_bin cleanup --provider tencentcloud --dry-run" "$crabbox_bin" cleanup --provider tencentcloud --dry-run)"
+printf '%s\n' "$cleanup_output"
+
+list_output="$(run_capture "$crabbox_bin list --provider tencentcloud --json" "$crabbox_bin" list --provider tencentcloud --json)"
+validate_list_json_empty "$crabbox_bin list --provider tencentcloud --json" "$list_output"
+
+printf 'classification=live_tencentcloud_smoke_passed slug=%s image=%s type=%s\n' "$slug" "$image" "$type_arg"


### PR DESCRIPTION
## Summary
- add a direct Tencent Cloud CVM SSH lease provider with TC3-signed CVM/Tag/STS API calls
- wire Tencent Cloud config, flags, env overrides, config show output, provider registry, and provider matrix metadata
- add provider docs plus a guarded live smoke script for Tencent Cloud CVM
- delete obsolete Crabbox-managed Tencent Cloud tags during metadata replacement while preserving external tags

## Verification
- `GO111MODULE=on go test ./internal/providers/tencentcloud ./internal/providers/all`
- `GO111MODULE=on go test ./internal/cli -run 'TestConfig|TestProvider|TestProviders'`
- `GO111MODULE=on bash scripts/check-docs.sh`
- `GO111MODULE=on go build -trimpath -o bin/crabbox ./cmd/crabbox`
- Live Tencent Cloud smoke passed on 2026-06-29 with user-provided credentials, image `img-dk53t5vb`, type `SA5.MEDIUM2`, an existing security group, and a VPC/subnet in `ap-shanghai-2`: `classification=live_tencentcloud_smoke_passed`.
- After the ClawSweeper tag-deletion repair, live Tencent Cloud smoke passed again on 2026-06-29: `classification=live_tencentcloud_smoke_passed slug=tencentcloud-smoke-20260629141741-18621 image=img-dk53t5vb type=SA5.MEDIUM2`.

## Notes
- Current Tencent Cloud instance families such as `SA5.MEDIUM2` require VPC networking, so live runs should provide `CRABBOX_TENCENTCLOUD_VPC_ID` and `CRABBOX_TENCENTCLOUD_SUBNET_ID`.
- Phase 1 attaches existing security groups but does not create or mutate Tencent Cloud security-group rules.