### PR TITLE
fix: map local-container socket work root into container

### DIFF
--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -198,6 +198,7 @@ type Config struct {
 	LocalContainer                LocalContainerConfig
 	localContainerRuntimeExplicit bool
 	localContainerImageExplicit   bool
+	localContainerRootExplicit    bool
 	AppleContainer                AppleContainerConfig
 	appleContainerImageExplicit   bool
 	AppleVZ                       AppleVZConfig
@@ -2165,6 +2166,14 @@ func MarkLocalContainerRuntimeExplicit(cfg *Config) {
 
 func LocalContainerRuntimeExplicit(cfg Config) bool {
 	return cfg.localContainerRuntimeExplicit
+}
+
+func MarkLocalContainerWorkRootExplicit(cfg *Config) {
+	cfg.localContainerRootExplicit = true
+}
+
+func LocalContainerWorkRootExplicit(cfg Config) bool {
+	return cfg.localContainerRootExplicit
 }
 
 func MarkAppleContainerImageExplicit(cfg *Config) {
@@ -6079,6 +6088,7 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 		}
 		if file.LocalContainer.WorkRoot != "" {
 			cfg.LocalContainer.WorkRoot = file.LocalContainer.WorkRoot
+			cfg.localContainerRootExplicit = true
 		}
 		if file.LocalContainer.CPUs > 0 {
 			cfg.LocalContainer.CPUs = file.LocalContainer.CPUs
@@ -7756,7 +7766,10 @@ func applyEnv(cfg *Config) error {
 		cfg.localContainerImageExplicit = true
 	}
 	cfg.LocalContainer.User = getenv("CRABBOX_LOCAL_CONTAINER_USER", cfg.LocalContainer.User)
-	cfg.LocalContainer.WorkRoot = getenv("CRABBOX_LOCAL_CONTAINER_WORK_ROOT", cfg.LocalContainer.WorkRoot)
+	if workRoot := os.Getenv("CRABBOX_LOCAL_CONTAINER_WORK_ROOT"); workRoot != "" {
+		cfg.LocalContainer.WorkRoot = workRoot
+		cfg.localContainerRootExplicit = true
+	}
 	cfg.LocalContainer.CPUs = getenvInt("CRABBOX_LOCAL_CONTAINER_CPUS", cfg.LocalContainer.CPUs)
 	cfg.LocalContainer.Memory = getenv("CRABBOX_LOCAL_CONTAINER_MEMORY", cfg.LocalContainer.Memory)
 	cfg.LocalContainer.Network = getenv("CRABBOX_LOCAL_CONTAINER_NETWORK", cfg.LocalContainer.Network)

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -627,6 +627,35 @@ func TestNvidiaBrevUntrustedConfigCannotRedirectCLI(t *testing.T) {
 	}
 }
 
+func TestLocalContainerWorkRootExplicitSources(t *testing.T) {
+	cfg := baseConfig()
+	if err := applyFileConfig(&cfg, fileConfig{
+		LocalContainer: &fileLocalContainerConfig{
+			WorkRoot: "/workspace/file",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.LocalContainer.WorkRoot != "/workspace/file" {
+		t.Fatalf("file local-container work root=%q", cfg.LocalContainer.WorkRoot)
+	}
+	if !LocalContainerWorkRootExplicit(cfg) {
+		t.Fatal("file local-container work root not marked explicit")
+	}
+
+	cfg = baseConfig()
+	t.Setenv("CRABBOX_LOCAL_CONTAINER_WORK_ROOT", "/workspace/env")
+	if err := applyEnv(&cfg); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.LocalContainer.WorkRoot != "/workspace/env" {
+		t.Fatalf("env local-container work root=%q", cfg.LocalContainer.WorkRoot)
+	}
+	if !LocalContainerWorkRootExplicit(cfg) {
+		t.Fatal("env local-container work root not marked explicit")
+	}
+}
+
 func TestEffectiveNvidiaBrevWorkRootDoesNotInheritAnotherProviderDefault(t *testing.T) {
 	cfg := baseConfig()
 	cfg.Provider = "xcp-ng"
@@ -5442,6 +5471,9 @@ func TestEnvOverridesConfig(t *testing.T) {
 	}
 	if cfg.LocalContainer.Runtime != "docker" || cfg.LocalContainer.Image != "ubuntu:env" || cfg.LocalContainer.User != "runner-env" || cfg.LocalContainer.WorkRoot != "/workspace/env" || cfg.LocalContainer.CPUs != 6 || cfg.LocalContainer.Memory != "12g" || cfg.LocalContainer.Network != "bridge" || !cfg.LocalContainer.DockerSocket {
 		t.Fatalf("unexpected local-container env: %#v", cfg.LocalContainer)
+	}
+	if !LocalContainerWorkRootExplicit(cfg) {
+		t.Fatal("env local-container work root not marked explicit")
 	}
 	if cfg.Blacksmith.IdleTimeout != 2*time.Hour || !cfg.Blacksmith.Debug {
 		t.Fatalf("unexpected blacksmith env: %#v", cfg.Blacksmith)

--- a/internal/providers/localcontainer/backend.go
+++ b/internal/providers/localcontainer/backend.go
@@ -532,7 +532,7 @@ func applyDefaults(cfg *core.Config) {
 	if cfg.LocalContainer.User == "" {
 		cfg.LocalContainer.User = "crabbox"
 	}
-	if cfg.LocalContainer.DockerSocket && isDefaultWorkRoot(cfg.LocalContainer.WorkRoot) && isDefaultWorkRoot(cfg.WorkRoot) {
+	if cfg.LocalContainer.DockerSocket && !localContainerWorkRootExplicit(*cfg) && isDefaultWorkRoot(cfg.LocalContainer.WorkRoot) && isDefaultWorkRoot(cfg.WorkRoot) {
 		if runtime.GOOS == "windows" {
 			cfg.LocalContainer.WorkRoot = "/work/crabbox"
 		} else {
@@ -817,10 +817,18 @@ func dockerSocketMountPathFromHostForGOOS(host, goos string) (string, error) {
 }
 
 func dockerSocketWorkRoots(cfg core.Config) (string, string) {
-	return dockerSocketWorkRootsForGOOS(cfg.LocalContainer.WorkRoot, runtime.GOOS)
+	return dockerSocketWorkRootsForGOOSExplicit(cfg.LocalContainer.WorkRoot, runtime.GOOS, localContainerWorkRootExplicit(cfg))
 }
 
 func dockerSocketWorkRootsForGOOS(workRoot, goos string) (string, string) {
+	return dockerSocketWorkRootsForGOOSExplicit(workRoot, goos, false)
+}
+
+func localContainerWorkRootExplicit(cfg core.Config) bool {
+	return core.IsWorkRootExplicit(&cfg) || core.LocalContainerWorkRootExplicit(cfg)
+}
+
+func dockerSocketWorkRootsForGOOSExplicit(workRoot, goos string, explicit bool) (string, string) {
 	workRoot = strings.TrimSpace(workRoot)
 	if workRoot == "" {
 		workRoot = "/work/crabbox"
@@ -830,6 +838,12 @@ func dockerSocketWorkRootsForGOOS(workRoot, goos string) (string, string) {
 			return workRoot, "/work/crabbox"
 		}
 		return defaultDockerSocketWorkRoot(), workRoot
+	}
+	// Default Docker-socket work roots are host cache paths. Keep that host
+	// storage location, but mount it somewhere the unprivileged SSH user can
+	// traverse inside the container.
+	if !explicit && filepath.Clean(workRoot) == filepath.Clean(defaultDockerSocketWorkRoot()) {
+		return workRoot, "/work/crabbox"
 	}
 	return workRoot, workRoot
 }
@@ -1441,7 +1455,15 @@ func localContainerReadyCheck(cfg core.Config) string {
 			"\"$BROWSER\" --version >>/tmp/crabbox-ready.log 2>&1",
 		)
 	}
+	for i, check := range checks {
+		checks[i] = localContainerReadyCheckWithDiagnostics(check)
+	}
 	return strings.Join(checks, " && ")
+}
+
+func localContainerReadyCheckWithDiagnostics(check string) string {
+	message := "local-container ready-check failed: " + check
+	return "{ " + check + "; } || { status=$?; printf '%s\n' " + shellQuote(message) + " >&2; if [ -f /tmp/crabbox-ready.log ]; then printf '%s\n' '--- /tmp/crabbox-ready.log ---' >&2; cat /tmp/crabbox-ready.log >&2; fi; exit \"$status\"; }"
 }
 
 func validateLocalContainerHostVolumes(cfg core.Config, workRoot string) ([]string, error) {

--- a/internal/providers/localcontainer/backend_test.go
+++ b/internal/providers/localcontainer/backend_test.go
@@ -896,6 +896,85 @@ func TestCreateContainerCanMountDockerSocket(t *testing.T) {
 	}
 }
 
+func TestCreateContainerMapsDefaultDockerSocketWorkRootToContainerPath(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("default Docker socket cache-root traversal bug is Linux-specific")
+	}
+	cacheRoot := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", cacheRoot)
+	socketDir := t.TempDir()
+	socketPath := filepath.Join(socketDir, "docker.sock")
+	listener := listenUnixSocketOrSkip(t, socketPath)
+	defer listener.Close()
+	t.Setenv("DOCKER_HOST", "unix://"+socketPath)
+	runner := &recordingRunner{
+		responses: map[string]core.LocalCommandResult{},
+	}
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.LocalContainer.DockerSocket = true
+	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}).(*backend)
+	cfg = b.configForRun()
+	hostWorkRoot := defaultDockerSocketWorkRoot()
+	if cfg.LocalContainer.WorkRoot != hostWorkRoot || cfg.WorkRoot != hostWorkRoot {
+		t.Fatalf("default host work root local=%q global=%q want %q", cfg.LocalContainer.WorkRoot, cfg.WorkRoot, hostWorkRoot)
+	}
+	runner.responses[commandKey([]string{"run"})] = core.LocalCommandResult{Stdout: "container123456\n"}
+
+	_, _, err := b.createContainer(context.Background(), cfg, "crabbox-blue", "cbx_123", "blue-lobster", "ssh-ed25519 AAAA test", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	args := recordedArgsForCommand(t, runner, "run")
+	for _, want := range []string{
+		"--label\nhost_work_root=" + hostWorkRoot,
+		"--label\nwork_root=/work/crabbox",
+		"-e\nCRABBOX_WORK_ROOT=/work/crabbox",
+		"-v\n" + hostWorkRoot + ":/work/crabbox",
+	} {
+		if !strings.Contains(args, want) {
+			t.Fatalf("default docker socket work root args missing %q:\n%s", want, args)
+		}
+	}
+	if strings.Contains(args, "-v\n"+hostWorkRoot+":"+hostWorkRoot) {
+		t.Fatalf("default docker socket work root mounted to host path inside container:\n%s", args)
+	}
+
+	container := inspectContainer{
+		ID:   "container1234567890",
+		Name: "/crabbox-blue",
+		Config: inspectConfig{
+			Image: "ubuntu:24.04",
+			Labels: map[string]string{
+				"crabbox":        "true",
+				"provider":       providerName,
+				"lease":          "cbx_123",
+				"slug":           "blue-lobster",
+				"state":          "ready",
+				"server_type":    "ubuntu:24.04",
+				"ssh_user":       "crabbox",
+				"docker_socket":  "1",
+				"host_work_root": hostWorkRoot,
+				"work_root":      "/work/crabbox",
+			},
+		},
+		State: inspectState{Status: "running", Running: true},
+		NetworkSettings: inspectNetworking{
+			Ports: map[string][]inspectPort{"2222/tcp": {{HostIP: "127.0.0.1", HostPort: "49153"}}},
+		},
+	}
+	lease, err := b.prepareLease(context.Background(), cfg, container, "cbx_123", "blue-lobster", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(lease.SSH.ReadyCheck, "test -d '/work/crabbox'") {
+		t.Fatalf("ready check did not use container work root: %q", lease.SSH.ReadyCheck)
+	}
+	if strings.Contains(lease.SSH.ReadyCheck, hostWorkRoot) || strings.Contains(lease.SSH.ReadyCheck, "/root/") {
+		t.Fatalf("ready check used host-only work root: %q", lease.SSH.ReadyCheck)
+	}
+}
+
 func TestCreateContainerMountsDockerHostUnixSocket(t *testing.T) {
 	socketDir := t.TempDir()
 	socketPath := filepath.Join(socketDir, "docker.sock")
@@ -1081,6 +1160,27 @@ func TestDockerSocketWorkRootsUseLinuxGuestPathForWindows(t *testing.T) {
 	}
 }
 
+func TestDockerSocketWorkRootsUseContainerPathForDefaultLinuxRoot(t *testing.T) {
+	hostDefault := defaultDockerSocketWorkRoot()
+	host, guest := dockerSocketWorkRootsForGOOS(hostDefault, "linux")
+	if host != hostDefault {
+		t.Fatalf("host root=%q, want %q", host, hostDefault)
+	}
+	if guest != "/work/crabbox" {
+		t.Fatalf("guest root=%q, want /work/crabbox", guest)
+	}
+
+	host, guest = dockerSocketWorkRootsForGOOSExplicit(hostDefault, "linux", true)
+	if host != hostDefault || guest != hostDefault {
+		t.Fatalf("explicit default-path work root should preserve existing behavior, host=%q guest=%q", host, guest)
+	}
+
+	host, guest = dockerSocketWorkRootsForGOOS("/tmp/custom-crabbox", "linux")
+	if host != "/tmp/custom-crabbox" || guest != "/tmp/custom-crabbox" {
+		t.Fatalf("custom Linux socket roots host=%q guest=%q", host, guest)
+	}
+}
+
 func TestPrepareLeaseUsesLabeledGuestWorkRootForReadyCheck(t *testing.T) {
 	b := testBackend(&recordingRunner{responses: map[string]core.LocalCommandResult{}})
 	cfg := b.configForRun()
@@ -1143,6 +1243,70 @@ func TestConfigForRunUsesHostVisibleWorkRootWithDockerSocket(t *testing.T) {
 	}
 	if !strings.Contains(got.LocalContainer.WorkRoot, "crabbox") || got.WorkRoot != got.LocalContainer.WorkRoot {
 		t.Fatalf("unexpected docker socket work root: workRoot=%q local=%q", got.WorkRoot, got.LocalContainer.WorkRoot)
+	}
+}
+
+func TestConfigForRunPreservesExplicitDockerSocketWorkRoot(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.LocalContainer.DockerSocket = true
+	cfg.LocalContainer.WorkRoot = "/work/crabbox"
+	cfg.WorkRoot = "/work/crabbox"
+	core.MarkWorkRootExplicit(&cfg)
+	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
+	got := b.configForRun()
+	if got.LocalContainer.WorkRoot != "/work/crabbox" || got.WorkRoot != "/work/crabbox" {
+		t.Fatalf("explicit work root was replaced: workRoot=%q local=%q", got.WorkRoot, got.LocalContainer.WorkRoot)
+	}
+}
+
+func TestConfigForRunPreservesProviderSpecificExplicitDockerSocketWorkRoot(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.LocalContainer.DockerSocket = true
+	cfg.LocalContainer.WorkRoot = "/work/crabbox"
+	cfg.WorkRoot = "/work/crabbox"
+	core.MarkLocalContainerWorkRootExplicit(&cfg)
+	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
+	got := b.configForRun()
+	if got.LocalContainer.WorkRoot != "/work/crabbox" || got.WorkRoot != "/work/crabbox" {
+		t.Fatalf("provider-specific explicit work root was replaced: workRoot=%q local=%q", got.WorkRoot, got.LocalContainer.WorkRoot)
+	}
+}
+
+func TestLocalContainerWorkRootFlagMarksWorkRootExplicit(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	values := registerFlags(fs, cfg)
+	if err := fs.Set("local-container-work-root", "/work/crabbox"); err != nil {
+		t.Fatal(err)
+	}
+	if err := applyFlags(&cfg, fs, values); err != nil {
+		t.Fatal(err)
+	}
+	if !core.IsWorkRootExplicit(&cfg) {
+		t.Fatal("local-container work root flag did not mark work root explicit")
+	}
+	if !core.LocalContainerWorkRootExplicit(cfg) {
+		t.Fatal("local-container work root flag did not mark provider work root explicit")
+	}
+}
+
+func TestLocalContainerReadyCheckReportsFailureDiagnostics(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.LocalContainer.WorkRoot = "/work/crabbox"
+	got := localContainerReadyCheck(cfg)
+	for _, want := range []string{
+		"local-container ready-check failed:",
+		"/tmp/crabbox-ready.log",
+		"cat /tmp/crabbox-ready.log >&2",
+		"test -d '/work/crabbox'",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("ready check missing diagnostic %q: %s", want, got)
+		}
 	}
 }
 

--- a/internal/providers/localcontainer/flags.go
+++ b/internal/providers/localcontainer/flags.go
@@ -69,6 +69,8 @@ func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	if core.FlagWasSet(fs, "local-container-work-root") {
 		cfg.LocalContainer.WorkRoot = *v.WorkRoot
 		cfg.WorkRoot = *v.WorkRoot
+		core.MarkWorkRootExplicit(cfg)
+		core.MarkLocalContainerWorkRootExplicit(cfg)
 	}
 	if core.FlagWasSet(fs, "local-container-cpus") {
 		cfg.LocalContainer.CPUs = *v.CPUs


### PR DESCRIPTION
## Summary

- Keep the Docker-socket default host work root in the user cache, but mount it inside local-container leases at `/work/crabbox` so the `crabbox` SSH user can traverse it.
- Preserve explicit `--local-container-work-root`, config-file, and environment work-root behavior through a local-container explicit marker.
- Add ready-check diagnostics that print the failed check and `/tmp/crabbox-ready.log`.
- Add regression coverage for default socket work-root mapping, explicit work-root preservation, ready-check paths, and config/env explicit markers.

## Verification

- `go test ./internal/providers/localcontainer`
- `env -u CRABBOX_PROVIDER go test ./internal/cli`
- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
  - Final result: `autoreview clean: no accepted/actionable findings reported`
- Root-user Docker socket smoke:
  - `bin/crabbox run --provider local-container --local-container-docker-socket --no-sync --shell -- 'echo ok'`
  - Result: command completed with workdir under `/work/crabbox/...`
- Root-user sync smoke:
  - `bin/crabbox run --provider local-container --local-container-docker-socket --shell -- 'test -f go.mod && echo sync-ok'`
  - Result: sync completed, `manifest_write` succeeded, and command printed `sync-ok`

Note: the requested `test -f package.json && echo sync-ok` acceptance shape was adapted to `go.mod` because this repository root does not contain `package.json`.
