### PR TITLE
feat: add native VNC handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Added a foreground, loopback-only `crabbox vnc --native-handoff` contract for native viewers, with connection credentials delivered over a private JSON pipe and tunnel lifetime owned by the client process.
+- Enabled desktop-capable runtime-adapter workspaces instead of discarding Crabfleet's requested desktop capability, and report native VNC separately from browser VNC.
 - Added direct FastAPI Cloud application and deployment inspection through `status`, `list`, and `doctor`, including configured default application support. Thanks @zozo123.
 - Added normalized provider runtime capabilities and `--runtime` filters to `crabbox providers` and `crabbox providers recommend`.
 - Added `crabbox providers recommend fanout-testing` for forkable workspace and best-of-N test selection guidance.

--- a/docs/commands/vnc.md
+++ b/docs/commands/vnc.md
@@ -43,6 +43,7 @@ of `--id`.
 --network auto|tailscale|public  Network path used to reach the box.
 --local-port <port>          Local tunnel port. Auto-picks 5901-5999 if unset.
 --open                       Start the tunnel (if needed) and open a VNC client.
+--native-handoff             Emit one JSON handoff and own its foreground tunnel.
 --host-managed               Allow --open against a static host-managed VNC.
 --reclaim                    Claim this lease for the current repo.
 ```
@@ -110,6 +111,13 @@ OS's URL handler. Dedicated VNC and WebVNC tunnels explicitly set
 `ForkAfterAuthentication=no`, so they cannot silently reuse, background, or
 leave behind an SSH connection whose listener is no longer owned by the
 tracked process. Opening URLs is supported on macOS, Linux, and Windows.
+
+`--native-handoff` is the machine-readable native-client contract. After its
+loopback tunnel is ready it writes exactly one JSON line to stdout, with schema
+`crabbox/vnc-handoff/v1`, loopback host and port, and the in-memory VNC
+credentials. It remains in the foreground until the client closes it. The flag
+is incompatible with `--open`; clients should consume stdout as a private pipe
+and terminate the Crabbox process when the viewer disconnects.
 
 For the same desktop inside the authenticated broker portal instead of a native
 VNC client, use [`crabbox webvnc --id <lease> --open`](webvnc.md). WebVNC still

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -433,6 +433,10 @@ also receives a coordinator-generated SSH host identity whose fingerprint is
 persisted before provisioning, so first attachment does not rely on TOFU.
 The versioned workspace `attachUrl` is a bearer-authenticated server-to-server
 endpoint for control planes such as Crabfleet, not a browser portal URL.
+Desktop workspaces report `capabilities.nativeVnc=true` when the native CLI
+handoff is available. This does not imply a browser desktop endpoint:
+`capabilities.vnc` and `capabilities.desktop` remain false unless
+`POST /v1/workspaces/:id/connections/desktop` is supported.
 
 When `CRABBOX_WORKSPACE_PREWARM_COUNT` is positive, the coordinator keeps that
 many hidden ready workspaces for each organization with active workspace demand.

--- a/internal/cli/vnc.go
+++ b/internal/cli/vnc.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os/exec"
 	"runtime"
@@ -29,12 +30,16 @@ func (a App) vnc(ctx context.Context, args []string) error {
 	reclaim := fs.Bool("reclaim", false, "claim this lease for the current repo")
 	localPort := fs.String("local-port", "", "local VNC tunnel port")
 	openClient := fs.Bool("open", false, "open the VNC client locally")
+	nativeHandoff := fs.Bool("native-handoff", false, "emit a native-client JSON handoff and keep its tunnel in the foreground")
 	hostManaged := fs.Bool("host-managed", false, "allow opening host-managed static VNC")
 	providerFlags := registerProviderFlags(fs, defaults)
 	targetFlags := registerTargetFlags(fs, defaults)
 	networkFlags := registerNetworkModeFlag(fs, defaults)
 	if err := parseFlags(fs, args); err != nil {
 		return err
+	}
+	if *nativeHandoff && *openClient {
+		return exit(2, "--native-handoff and --open cannot be used together")
 	}
 	setIDFromFirstArg(fs, id)
 	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{LeaseID: *id, Desktop: true})
@@ -67,15 +72,25 @@ func (a App) vnc(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	if *localPort == "" {
-		*localPort = availableLocalVNCPort()
-	}
 	password := ""
 	if endpoint.Managed {
 		password, _ = runSSHOutput(ctx, target, vncPasswordCommand(target))
 	}
 	if !isStaticProvider(cfg.Provider) && password == "" {
 		password, _ = runSSHOutput(ctx, target, vncPasswordCommand(target))
+	}
+	if *nativeHandoff {
+		if endpoint.Direct {
+			return exit(2, "--native-handoff requires a loopback SSH tunnel")
+		}
+		username := ""
+		if endpoint.Managed && (target.TargetOS == targetWindows || target.TargetOS == targetMacOS) {
+			username = target.User
+		}
+		return runVNCNativeHandoff(ctx, a.Stdout, target, *localPort, endpoint, username, strings.TrimSpace(password))
+	}
+	if *localPort == "" {
+		*localPort = availableLocalVNCPort()
 	}
 	tunnel := vncTunnelCommand(target, *localPort)
 	staticHostVNC := isStaticProvider(cfg.Provider) && !endpoint.Managed
@@ -154,6 +169,57 @@ func (a App) vnc(ctx context.Context, args []string) error {
 		fmt.Fprintln(a.Stdout, "Keep the tunnel process running while connected.")
 	}
 	return nil
+}
+
+const vncNativeHandoffSchema = "crabbox/vnc-handoff/v1"
+
+type vncNativeHandoff struct {
+	Schema   string `json:"schema"`
+	Host     string `json:"host"`
+	Port     int    `json:"port"`
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+func runVNCNativeHandoff(
+	ctx context.Context,
+	stdout interface{ Write([]byte) (int, error) },
+	target SSHTarget,
+	requestedPort string,
+	endpoint vncEndpoint,
+	username, password string,
+) error {
+	tunnel, localPort, err := startVNCForegroundTunnelOnReservedPort(
+		ctx,
+		target,
+		requestedPort,
+		endpoint.Host,
+		endpoint.Port,
+	)
+	if err != nil {
+		return err
+	}
+	defer stopProcess(tunnel)
+	port, err := strconv.Atoi(localPort)
+	if err != nil || port < 1 || port > 65535 {
+		return exit(5, "invalid reserved VNC tunnel port")
+	}
+	if len(username) > 256 || len(password) > 4096 {
+		return exit(5, "native VNC credentials exceed the handoff limit")
+	}
+	handoff := vncNativeHandoff{
+		Schema: vncNativeHandoffSchema, Host: vncLoopbackHost, Port: port,
+		Username: username, Password: password,
+	}
+	if err := json.NewEncoder(stdout).Encode(handoff); err != nil {
+		return fmt.Errorf("write native VNC handoff: %w", err)
+	}
+	select {
+	case <-ctx.Done():
+		return context.Cause(ctx)
+	case <-tunnel.Done():
+		return tunnel.ExitError()
+	}
 }
 
 func vncTunnelCommand(target SSHTarget, localPort string) string {

--- a/internal/cli/vnc.go
+++ b/internal/cli/vnc.go
@@ -80,8 +80,8 @@ func (a App) vnc(ctx context.Context, args []string) error {
 		password, _ = runSSHOutput(ctx, target, vncPasswordCommand(target))
 	}
 	if *nativeHandoff {
-		if endpoint.Direct {
-			return exit(2, "--native-handoff requires a loopback SSH tunnel")
+		if err := validateNativeVNCHandoffEndpoint(endpoint); err != nil {
+			return err
 		}
 		username := ""
 		if endpoint.Managed && (target.TargetOS == targetWindows || target.TargetOS == targetMacOS) {
@@ -179,6 +179,16 @@ type vncNativeHandoff struct {
 	Port     int    `json:"port"`
 	Username string `json:"username"`
 	Password string `json:"password"`
+}
+
+func validateNativeVNCHandoffEndpoint(endpoint vncEndpoint) error {
+	if !endpoint.Managed {
+		return exit(2, "--native-handoff requires a Crabbox-managed desktop over a loopback SSH tunnel")
+	}
+	if endpoint.Direct {
+		return exit(2, "--native-handoff requires a loopback SSH tunnel")
+	}
+	return nil
 }
 
 func runVNCNativeHandoff(

--- a/internal/cli/vnc_test.go
+++ b/internal/cli/vnc_test.go
@@ -1,7 +1,9 @@
 package cli
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -9,6 +11,30 @@ import (
 	"testing"
 	"time"
 )
+
+func TestVNCNativeHandoffJSONContract(t *testing.T) {
+	var output bytes.Buffer
+	handoff := vncNativeHandoff{
+		Schema:   vncNativeHandoffSchema,
+		Host:     vncLoopbackHost,
+		Port:     5907,
+		Username: "operator",
+		Password: "private value",
+	}
+	if err := json.NewEncoder(&output).Encode(handoff); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Count(output.String(), "\n") != 1 {
+		t.Fatalf("handoff must be exactly one JSON line: %q", output.String())
+	}
+	var decoded vncNativeHandoff
+	if err := json.Unmarshal(output.Bytes(), &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded != handoff {
+		t.Fatalf("decoded handoff=%#v want=%#v", decoded, handoff)
+	}
+}
 
 func TestVNCTunnelCommandQuotesKeyPath(t *testing.T) {
 	got := vncTunnelCommand(SSHTarget{

--- a/internal/cli/vnc_test.go
+++ b/internal/cli/vnc_test.go
@@ -36,6 +36,22 @@ func TestVNCNativeHandoffJSONContract(t *testing.T) {
 	}
 }
 
+func TestVNCNativeHandoffRejectsHostManagedEndpoints(t *testing.T) {
+	for _, endpoint := range []vncEndpoint{
+		{Host: "127.0.0.1", Port: managedVNCPort},
+		{Direct: true, Host: "192.0.2.10", Port: managedVNCPort},
+	} {
+		if err := validateNativeVNCHandoffEndpoint(endpoint); err == nil || !strings.Contains(err.Error(), "Crabbox-managed") {
+			t.Fatalf("endpoint=%#v error=%v, want Crabbox-managed rejection", endpoint, err)
+		}
+	}
+	if err := validateNativeVNCHandoffEndpoint(vncEndpoint{
+		Host: "127.0.0.1", Port: managedVNCPort, Managed: true,
+	}); err != nil {
+		t.Fatalf("managed loopback endpoint rejected: %v", err)
+	}
+}
+
 func TestVNCTunnelCommandQuotesKeyPath(t *testing.T) {
 	got := vncTunnelCommand(SSHTarget{
 		Key:  "/tmp/Application Support/crabbox/id_ed25519",

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -2327,7 +2327,7 @@ export class FleetCoordinator {
         { status: 400 },
       );
     }
-    const desktop = false;
+    const desktop = input.capabilities?.desktop === true;
     const key = workspaceKey(owner, org, id);
     const existingResponse = await this.state.runExclusive(async () => {
       const existing = await this.state.storage.get<WorkspaceRecord>(key);
@@ -12522,6 +12522,7 @@ function workspaceResponse(
       takeover: false,
       vnc: false,
       desktop: false,
+      nativeVnc: workspace.desktop && Boolean(terminalUrl),
       logs: false,
       artifacts: false,
     },

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -408,6 +408,7 @@ interface WorkspaceRecord {
   provider: Provider;
   class: string;
   desktop: boolean;
+  desktopCapabilityVersion?: 1;
   ttlSeconds: number;
   idleTimeoutSeconds: number;
   createdAt: string;
@@ -2447,6 +2448,7 @@ export class FleetCoordinator {
         provider,
         class: machineClass,
         desktop,
+        desktopCapabilityVersion: 1,
         ttlSeconds,
         idleTimeoutSeconds,
         createdAt: nowISO,
@@ -2552,6 +2554,7 @@ export class FleetCoordinator {
       provider: input.provider,
       class: input.class,
       desktop: input.desktop,
+      desktopCapabilityVersion: 1,
       ttlSeconds: input.ttlSeconds,
       idleTimeoutSeconds: input.idleTimeoutSeconds,
       createdAt: nowISO,
@@ -2650,6 +2653,7 @@ export class FleetCoordinator {
               provider: template.provider,
               class: template.class,
               desktop: template.desktop,
+              desktopCapabilityVersion: 1,
               ttlSeconds: template.ttlSeconds,
               idleTimeoutSeconds: template.idleTimeoutSeconds,
               createdAt: nowISO,
@@ -12108,12 +12112,15 @@ function workspaceConflictResponse(
   ttlSeconds: number,
   idleTimeoutSeconds: number,
 ): Response | undefined {
+  const desktopMatches =
+    workspace.desktop === desktop ||
+    (workspace.desktopCapabilityVersion === undefined && !workspace.desktop && desktop);
   if (
     workspace.profile === profile &&
     (workspace.repo ?? "") === repo &&
     (workspace.branch ?? "main") === branch &&
     (workspace.command ?? "exec bash -l") === command &&
-    workspace.desktop === desktop &&
+    desktopMatches &&
     workspace.ttlSeconds === ttlSeconds &&
     workspace.idleTimeoutSeconds === idleTimeoutSeconds
   ) {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -3330,14 +3330,19 @@ describe("fleet lease identity and idle", () => {
     const ready = await fleet.fetch(request("GET", `/v1/workspaces/${body.id}`, { headers }));
     const readyBody = (await ready.json()) as {
       attachUrl: string;
-      capabilities: { terminal: boolean };
+      capabilities: {
+        terminal: boolean;
+        desktop: boolean;
+        vnc: boolean;
+        nativeVnc: boolean;
+      };
       providerResourceId: string;
       status: string;
     };
     expect(readyBody).toMatchObject({
       providerResourceId: created.providerResourceId,
       status: "ready",
-      capabilities: { terminal: true },
+      capabilities: { terminal: true, desktop: false, vnc: false, nativeVnc: true },
     });
     const terminalURL = new URL(readyBody.attachUrl);
     expect(terminalURL.origin).toBe("wss://crabbox.example.com");

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -3406,6 +3406,33 @@ describe("fleet lease identity and idle", () => {
       providerResourceId: created.providerResourceId,
       status: "ready",
     });
+    expect(
+      storage.value<{ desktopCapabilityVersion?: number }>(
+        "workspace:example-org:alice%40example.com:fleet-is-101",
+      )?.desktopCapabilityVersion,
+    ).toBe(1);
+
+    const legacyID = "fleet-legacy-desktop";
+    storage.seed(`workspace:example-org:alice%40example.com:${legacyID}`, {
+      ...storage.value<Record<string, unknown>>(
+        "workspace:example-org:alice%40example.com:fleet-is-101",
+      ),
+      id: legacyID,
+      leaseID: "cbx_legacydesktop",
+      desktop: false,
+      desktopCapabilityVersion: undefined,
+    });
+    const legacyDuplicate = await fleet.fetch(
+      request("POST", "/v1/workspaces", {
+        headers,
+        body: { ...body, id: legacyID },
+      }),
+    );
+    expect(legacyDuplicate.status).toBe(202);
+    await expect(legacyDuplicate.json()).resolves.toMatchObject({
+      providerResourceId: "cbx_legacydesktop",
+      capabilities: { desktop: false, vnc: false, nativeVnc: false },
+    });
 
     const otherOwner = await fleet.fetch(
       request("POST", "/v1/workspaces", {


### PR DESCRIPTION
## Summary

- honor desktop capability requests in runtime-adapter workspaces
- add a versioned foreground native VNC handoff over a private JSON pipe
- distinguish native VNC availability from unsupported browser VNC

## Testing

- `GOCACHE=/private/tmp/crabbox-go-cache go test ./...`
- `cd worker && ./node_modules/.bin/tsgo --noEmit`
- `cd worker && ./node_modules/.bin/vitest run --reporter=dot`
- `cd worker && ./node_modules/.bin/oxfmt --check .`

