### PR TITLE
feat: broker native VNC workspace grants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added a foreground, loopback-only `crabbox vnc --native-handoff` contract for native viewers, with connection credentials delivered over a private JSON pipe and tunnel lifetime owned by the client process.
+- Added a foreground, loopback-only `crabbox vnc --native-handoff` contract for native viewers, including one-time workspace grants that relay VNC through the coordinator without exposing its SSH key; credentials and grants use private pipes and tunnel lifetime remains owned by the client process.
 - Enabled desktop-capable runtime-adapter workspaces instead of discarding Crabfleet's requested desktop capability, and report native VNC separately from browser VNC.
 - Added direct FastAPI Cloud application and deployment inspection through `status`, `list`, and `doctor`, including configured default application support. Thanks @zozo123.
 - Added normalized provider runtime capabilities and `--runtime` filters to `crabbox providers` and `crabbox providers recommend`.

--- a/docs/commands/adapter.md
+++ b/docs/commands/adapter.md
@@ -194,6 +194,7 @@ Allowed operations are exactly:
 - `GET /v1/workspaces/{id}`
 - `DELETE /v1/workspaces/{id}`
 - `POST /v1/workspaces/{id}/connections/desktop`
+- `POST /v1/workspaces/{id}/connections/native-vnc`
 
 There is no arbitrary URL, shell, argv, environment, file, or provider-command
 surface. Request and response bodies are UTF-8 strings bounded to 64 KiB.
@@ -202,7 +203,7 @@ requests time out after nine seconds, and the coordinator allows five more
 seconds for response delivery. Every frame carries that absolute Unix
 millisecond deadline; the connector rejects expired frames before local
 dispatch and caps the local request context to the earlier of that deadline or
-its own timeout. Desktop connection setup
+its own timeout. Desktop and native VNC connection setup
 gets the configured `--connection-timeout` plus 30 seconds of relay overhead,
 and the connector negotiates that deadline plus five seconds of response grace
 with the coordinator. The setup value may not exceed 24 hours. Set it to the

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -437,6 +437,11 @@ Desktop workspaces report `capabilities.nativeVnc=true` when the native CLI
 handoff is available. This does not imply a browser desktop endpoint:
 `capabilities.vnc` and `capabilities.desktop` remain false unless
 `POST /v1/workspaces/:id/connections/desktop` is supported.
+`POST /v1/workspaces/:id/connections/native-vnc` mints a one-minute,
+single-use grant. The native CLI passes that grant on stdin, and the coordinator
+uses its dedicated workspace SSH key to relay the loopback VNC service over an
+authenticated WebSocket. The workspace SSH private key never leaves the
+coordinator.
 
 When `CRABBOX_WORKSPACE_PREWARM_COUNT` is positive, the coordinator keeps that
 many hidden ready workspaces for each organization with active workspace demand.

--- a/internal/cli/adapter_connect.go
+++ b/internal/cli/adapter_connect.go
@@ -481,12 +481,16 @@ func adapterRelayCanonicalPath(method, requestPath string) (string, bool) {
 		return "", false
 	}
 	rest := strings.TrimPrefix(requestPath, prefix)
-	if method == http.MethodPost && strings.HasSuffix(rest, "/connections/desktop") {
-		workspaceID := strings.TrimSuffix(rest, "/connections/desktop")
+	if method == http.MethodPost && (strings.HasSuffix(rest, "/connections/desktop") || strings.HasSuffix(rest, "/connections/native-vnc")) {
+		suffix := "/connections/desktop"
+		if strings.HasSuffix(rest, "/connections/native-vnc") {
+			suffix = "/connections/native-vnc"
+		}
+		workspaceID := strings.TrimSuffix(rest, suffix)
 		if !validControllerWorkspaceID(workspaceID) {
 			return "", false
 		}
-		return prefix + url.PathEscape(workspaceID) + "/connections/desktop", true
+		return prefix + url.PathEscape(workspaceID) + suffix, true
 	}
 	if (method != http.MethodGet && method != http.MethodDelete) || !validControllerWorkspaceID(rest) {
 		return "", false

--- a/internal/cli/adapter_connect.go
+++ b/internal/cli/adapter_connect.go
@@ -418,7 +418,7 @@ func (r *adapterRelay) handle(ctx context.Context, request adapterRelayRequest) 
 }
 
 func adapterRelayTimeoutForRequest(request adapterRelayRequest, desktopTimeout time.Duration) time.Duration {
-	if request.Method == http.MethodPost && strings.HasSuffix(request.Path, "/connections/desktop") {
+	if request.Method == http.MethodPost && (strings.HasSuffix(request.Path, "/connections/desktop") || strings.HasSuffix(request.Path, "/connections/native-vnc")) {
 		if desktopTimeout <= 0 {
 			desktopTimeout = adapterRelayDefaultConnectionTime + adapterRelayConnectionOverhead
 		}

--- a/internal/cli/adapter_connect_test.go
+++ b/internal/cli/adapter_connect_test.go
@@ -83,6 +83,7 @@ func TestAdapterRelayRouteAllowlist(t *testing.T) {
 		{http.MethodGet, "/v1/workspaces/fleet-a-is-101", true},
 		{http.MethodDelete, "/v1/workspaces/fleet-a-is-101", true},
 		{http.MethodPost, "/v1/workspaces/fleet-a-is-101/connections/desktop", true},
+		{http.MethodPost, "/v1/workspaces/fleet-a-is-101/connections/native-vnc", true},
 		{http.MethodGet, "/healthz", false},
 		{http.MethodPut, "/v1/workspaces/fleet-a-is-101", false},
 		{http.MethodPost, "/v1/workspaces/fleet-a-is-101/reboot", false},

--- a/internal/cli/adapter_connect_test.go
+++ b/internal/cli/adapter_connect_test.go
@@ -254,6 +254,10 @@ func TestAdapterRelayDesktopTimeoutCoversConnectionSetup(t *testing.T) {
 	if got := adapterRelayTimeoutForRequest(desktop, 11*time.Minute); got != 11*time.Minute {
 		t.Fatalf("desktop timeout=%s", got)
 	}
+	nativeVNC := adapterRelayRequest{Method: http.MethodPost, Path: "/v1/workspaces/fleet-a-is-101/connections/native-vnc"}
+	if got := adapterRelayTimeoutForRequest(nativeVNC, 11*time.Minute); got != 11*time.Minute {
+		t.Fatalf("native VNC timeout=%s", got)
+	}
 	ordinary := adapterRelayRequest{Method: http.MethodGet, Path: "/v1/workspaces/fleet-a-is-101"}
 	if got := adapterRelayTimeoutForRequest(ordinary, 11*time.Minute); got != 9*time.Second {
 		t.Fatalf("ordinary timeout=%s", got)

--- a/internal/cli/vnc.go
+++ b/internal/cli/vnc.go
@@ -5,11 +5,17 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
 	"os/exec"
 	"runtime"
 	"strconv"
 	"strings"
 	"time"
+
+	"nhooyr.io/websocket"
 )
 
 const (
@@ -31,6 +37,8 @@ func (a App) vnc(ctx context.Context, args []string) error {
 	localPort := fs.String("local-port", "", "local VNC tunnel port")
 	openClient := fs.Bool("open", false, "open the VNC client locally")
 	nativeHandoff := fs.Bool("native-handoff", false, "emit a native-client JSON handoff and keep its tunnel in the foreground")
+	nativeGrantURL := fs.String("native-grant-url", "", "coordinator URL for a one-time native VNC grant")
+	nativeGrantStdin := fs.Bool("native-grant-stdin", false, "read a one-time native VNC grant from stdin")
 	hostManaged := fs.Bool("host-managed", false, "allow opening host-managed static VNC")
 	providerFlags := registerProviderFlags(fs, defaults)
 	targetFlags := registerTargetFlags(fs, defaults)
@@ -41,7 +49,13 @@ func (a App) vnc(ctx context.Context, args []string) error {
 	if *nativeHandoff && *openClient {
 		return exit(2, "--native-handoff and --open cannot be used together")
 	}
+	if (*nativeGrantURL != "" || *nativeGrantStdin) && (!*nativeHandoff || *nativeGrantURL == "" || !*nativeGrantStdin) {
+		return exit(2, "--native-grant-url and --native-grant-stdin must be used together with --native-handoff")
+	}
 	setIDFromFirstArg(fs, id)
+	if *nativeGrantURL != "" {
+		return a.vncFromNativeGrant(ctx, *id, *nativeGrantURL, *localPort)
+	}
 	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{LeaseID: *id, Desktop: true})
 	if err != nil {
 		return err
@@ -169,6 +183,162 @@ func (a App) vnc(ctx context.Context, args []string) error {
 		fmt.Fprintln(a.Stdout, "Keep the tunnel process running while connected.")
 	}
 	return nil
+}
+
+func (a App) vncFromNativeGrant(ctx context.Context, expectedLeaseID, brokerURL, localPort string) error {
+	parsed, err := url.Parse(strings.TrimSpace(brokerURL))
+	if err != nil || parsed.Host == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" ||
+		(parsed.Scheme != "https" && !(parsed.Scheme == "http" && isNativeVNCLoopbackHost(parsed.Hostname()))) {
+		return exit(2, "--native-grant-url must be an HTTPS coordinator URL or loopback HTTP URL")
+	}
+	ticketBytes, err := io.ReadAll(io.LimitReader(a.input(), 4097))
+	if err != nil {
+		return exit(2, "read native VNC grant: %v", err)
+	}
+	ticket := strings.TrimSuffix(string(ticketBytes), "\n")
+	ticket = strings.TrimSuffix(ticket, "\r")
+	if len(ticketBytes) > 4096 || !validNativeVNCTicket(ticket) {
+		return exit(2, "native VNC grant is invalid")
+	}
+	parsed.Path = "/v1/native-vnc/handoff"
+	parsed.RawPath = ""
+	if parsed.Scheme == "https" {
+		parsed.Scheme = "wss"
+	} else {
+		parsed.Scheme = "ws"
+	}
+	header := http.Header{}
+	header.Set("Authorization", "Bearer "+ticket)
+	ws, response, err := websocket.Dial(ctx, parsed.String(), &websocket.DialOptions{HTTPHeader: header})
+	if err != nil {
+		if response != nil {
+			return exit(5, "native VNC coordinator websocket: http %d", response.StatusCode)
+		}
+		return exit(5, "native VNC coordinator websocket: %v", err)
+	}
+	defer ws.Close(websocket.StatusNormalClosure, "native VNC closed")
+	ws.SetReadLimit(1 << 20)
+	messageType, payload, err := ws.Read(ctx)
+	if err != nil || messageType != websocket.MessageText {
+		return exit(5, "native VNC coordinator returned an invalid ready message")
+	}
+	var ready struct {
+		Schema   string `json:"schema"`
+		LeaseID  string `json:"leaseId"`
+		Username string `json:"username"`
+		Password string `json:"password"`
+	}
+	if err := json.Unmarshal(payload, &ready); err != nil || ready.Schema != "crabbox/native-vnc-ready/v1" ||
+		ready.LeaseID == "" || len(ready.LeaseID) > 256 || len(ready.Username) > 256 ||
+		ready.Password == "" || len(ready.Password) > 256 ||
+		strings.ContainsAny(ready.LeaseID+ready.Username+ready.Password, "\x00\r\n") {
+		return exit(5, "native VNC coordinator returned an invalid ready message")
+	}
+	if expectedLeaseID != "" && ready.LeaseID != expectedLeaseID {
+		return exit(5, "native VNC grant returned a different lease")
+	}
+	return runNativeVNCWebSocketHandoff(ctx, a.Stdout, ws, localPort, ready.Username, ready.Password)
+}
+
+func runNativeVNCWebSocketHandoff(
+	ctx context.Context,
+	stdout interface{ Write([]byte) (int, error) },
+	ws *websocket.Conn,
+	requestedPort, username, password string,
+) error {
+	address := net.JoinHostPort(vncLoopbackHost, requestedPort)
+	if requestedPort == "" {
+		address = net.JoinHostPort(vncLoopbackHost, "0")
+	}
+	listener, err := net.Listen("tcp", address)
+	if err != nil {
+		return exit(5, "reserve native VNC loopback port: %v", err)
+	}
+	defer listener.Close()
+	port := listener.Addr().(*net.TCPAddr).Port
+	handoff := vncNativeHandoff{
+		Schema:   vncNativeHandoffSchema,
+		Host:     vncLoopbackHost,
+		Port:     port,
+		Username: username,
+		Password: password,
+	}
+	if err := json.NewEncoder(stdout).Encode(handoff); err != nil {
+		return err
+	}
+	acceptDone := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = listener.Close()
+		case <-acceptDone:
+		}
+	}()
+	tcp, err := listener.Accept()
+	close(acceptDone)
+	if err != nil {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		return exit(5, "accept native VNC client: %v", err)
+	}
+	defer tcp.Close()
+	if err := ws.Write(ctx, websocket.MessageText, []byte("start")); err != nil {
+		return exit(5, "start native VNC coordinator tunnel: %v", err)
+	}
+	relayCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	errors := make(chan error, 2)
+	go func() { errors <- copyNativeVNCWebSocketToTCP(relayCtx, ws, tcp) }()
+	go func() { errors <- copyTCPToWebSocket(relayCtx, ws, tcp) }()
+	err = <-errors
+	cancel()
+	if err != nil && ctx.Err() == nil && !isExpectedNativeVNCRelayClose(err) {
+		return exit(5, "native VNC tunnel: %v", err)
+	}
+	return nil
+}
+
+func validNativeVNCTicket(ticket string) bool {
+	const prefix = "native_vnc_"
+	if len(ticket) != len(prefix)+32 || !strings.HasPrefix(ticket, prefix) {
+		return false
+	}
+	for _, character := range ticket[len(prefix):] {
+		if !((character >= '0' && character <= '9') || (character >= 'a' && character <= 'f')) {
+			return false
+		}
+	}
+	return true
+}
+
+func isNativeVNCLoopbackHost(host string) bool {
+	switch strings.ToLower(host) {
+	case "localhost", "127.0.0.1", "::1":
+		return true
+	default:
+		return false
+	}
+}
+
+func copyNativeVNCWebSocketToTCP(ctx context.Context, ws *websocket.Conn, tcp net.Conn) error {
+	for {
+		messageType, payload, err := ws.Read(ctx)
+		if err != nil {
+			return err
+		}
+		if messageType != websocket.MessageBinary {
+			return fmt.Errorf("coordinator sent a non-binary VNC frame")
+		}
+		if _, err := tcp.Write(payload); err != nil {
+			return err
+		}
+	}
+}
+
+func isExpectedNativeVNCRelayClose(err error) bool {
+	status := websocket.CloseStatus(err)
+	return status == websocket.StatusNormalClosure || status == websocket.StatusGoingAway
 }
 
 const vncNativeHandoffSchema = "crabbox/vnc-handoff/v1"

--- a/internal/cli/vnc_test.go
+++ b/internal/cli/vnc_test.go
@@ -1,15 +1,24 @@
 package cli
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"nhooyr.io/websocket"
 )
 
 func TestVNCNativeHandoffJSONContract(t *testing.T) {
@@ -33,6 +42,123 @@ func TestVNCNativeHandoffJSONContract(t *testing.T) {
 	}
 	if decoded != handoff {
 		t.Fatalf("decoded handoff=%#v want=%#v", decoded, handoff)
+	}
+}
+
+func TestVNCNativeGrantRelaysCoordinatorWebSocketToLoopback(t *testing.T) {
+	const ticket = "native_vnc_0123456789abcdef0123456789abcdef"
+	serverErr := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/native-vnc/handoff" || r.Header.Get("Authorization") != "Bearer "+ticket {
+			serverErr <- fmt.Errorf("request path=%q authorization=%q", r.URL.Path, r.Header.Get("Authorization"))
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		ws, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			serverErr <- err
+			return
+		}
+		defer ws.Close(websocket.StatusNormalClosure, "done")
+		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+		defer cancel()
+		ready := `{"schema":"crabbox/native-vnc-ready/v1","leaseId":"cbx_native123","username":"dev","password":"private"}`
+		if err := ws.Write(ctx, websocket.MessageText, []byte(ready)); err != nil {
+			serverErr <- err
+			return
+		}
+		typ, start, err := ws.Read(ctx)
+		if err != nil || typ != websocket.MessageText || string(start) != "start" {
+			serverErr <- fmt.Errorf("start type=%v value=%q error=%v", typ, start, err)
+			return
+		}
+		if err := ws.Write(ctx, websocket.MessageBinary, []byte("RFB 003.008\n")); err != nil {
+			serverErr <- err
+			return
+		}
+		typ, client, err := ws.Read(ctx)
+		if err != nil || typ != websocket.MessageBinary || string(client) != "client-vnc" {
+			serverErr <- fmt.Errorf("client type=%v value=%q error=%v", typ, client, err)
+			return
+		}
+		serverErr <- nil
+	}))
+	defer server.Close()
+
+	stdoutReader, stdoutWriter := io.Pipe()
+	app := App{Stdout: stdoutWriter, Stderr: io.Discard, Stdin: strings.NewReader(ticket + "\n")}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	result := make(chan error, 1)
+	go func() {
+		result <- app.vncFromNativeGrant(ctx, "cbx_native123", server.URL, "")
+		_ = stdoutWriter.Close()
+	}()
+	line, err := bufio.NewReader(stdoutReader).ReadBytes('\n')
+	if err != nil {
+		t.Fatal(err)
+	}
+	var handoff vncNativeHandoff
+	if err := json.Unmarshal(line, &handoff); err != nil {
+		t.Fatal(err)
+	}
+	if handoff.Host != vncLoopbackHost || handoff.Username != "dev" || handoff.Password != "private" {
+		t.Fatalf("handoff=%#v", handoff)
+	}
+	local, err := net.DialTimeout("tcp", net.JoinHostPort(handoff.Host, strconv.Itoa(handoff.Port)), time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer local.Close()
+	buffer := make([]byte, len("RFB 003.008\n"))
+	if _, err := io.ReadFull(local, buffer); err != nil {
+		t.Fatal(err)
+	}
+	if string(buffer) != "RFB 003.008\n" {
+		t.Fatalf("server VNC bytes=%q", buffer)
+	}
+	if _, err := local.Write([]byte("client-vnc")); err != nil {
+		t.Fatal(err)
+	}
+	if err := <-serverErr; err != nil {
+		t.Fatal(err)
+	}
+	_ = local.Close()
+	if err := <-result; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidNativeVNCTicket(t *testing.T) {
+	for _, ticket := range []string{
+		"native_vnc_0123456789abcdef0123456789abcdef",
+	} {
+		if !validNativeVNCTicket(ticket) {
+			t.Fatalf("valid ticket rejected: %q", ticket)
+		}
+	}
+	for _, ticket := range []string{
+		"native_vnc_0123456789abcdef",
+		"native_vnc_0123456789ABCDEF0123456789ABCDEF",
+		"native_vnc_0123456789abcdef0123456789abcdeg",
+		" native_vnc_0123456789abcdef0123456789abcdef",
+	} {
+		if validNativeVNCTicket(ticket) {
+			t.Fatalf("invalid ticket accepted: %q", ticket)
+		}
+	}
+}
+
+func TestNativeVNCLoopbackHost(t *testing.T) {
+	for _, host := range []string{"localhost", "LOCALHOST", "127.0.0.1", "::1"} {
+		if !isNativeVNCLoopbackHost(host) {
+			t.Fatalf("loopback host rejected: %q", host)
+		}
+	}
+	for _, host := range []string{"", "0.0.0.0", "127.0.0.2", "localhost.example.com"} {
+		if isNativeVNCLoopbackHost(host) {
+			t.Fatalf("non-loopback host accepted: %q", host)
+		}
 	}
 }
 

--- a/worker/src/coordinator-entry.ts
+++ b/worker/src/coordinator-entry.ts
@@ -54,6 +54,13 @@ export async function prepareCoordinatorRequest(
   if (url.pathname === "/portal/login" || url.pathname === "/portal/logout") {
     return { request: requestWithoutTrustedHeaders(request), authenticated: false };
   }
+  if (
+    request.method === "GET" &&
+    url.pathname === "/v1/native-vnc/handoff" &&
+    request.headers.get("upgrade")?.toLowerCase() === "websocket"
+  ) {
+    return { request: requestWithoutTrustedHeaders(request), authenticated: false };
+  }
   const route = pathParts(request);
   if (route[0] === "v1" && route[1] === "internal") {
     return {

--- a/worker/src/coordinator-runtime.ts
+++ b/worker/src/coordinator-runtime.ts
@@ -20,6 +20,9 @@ export function coordinatorRequestQueue(request: Request): CoordinatorRequestQue
   if (path[0] === "v1" && path[1] === "workspaces") {
     return "direct";
   }
+  if (method === "GET" && path.join("/") === "v1/native-vnc/handoff") {
+    return "direct";
+  }
   if (method === "POST" && path.join("/") === "v1/internal/scheduled") {
     return "direct";
   }

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -3270,17 +3270,38 @@ export class FleetCoordinator {
       return json({ error: "native_vnc_unavailable", message: unavailable }, { status: 409 });
     }
     const key = workspaceKey(lease.workspace.owner, lease.workspace.org, lease.workspace.id);
-    const upgrade = await this.state.runExclusive(async () => {
-      if (this.workspaceConnectionLimitReached(key, lease.workspace.owner, lease.workspace.org)) {
-        return undefined;
+    const admission = await this.state.runExclusive(async () => {
+      const currentWorkspace = await this.state.storage.get<WorkspaceRecord>(key);
+      const currentLease = currentWorkspace
+        ? await this.getLease(currentWorkspace.leaseID)
+        : undefined;
+      const currentUnavailable = currentWorkspace
+        ? workspaceNativeVNCError(currentWorkspace, currentLease, this.env)
+        : "workspace is unavailable";
+      if (
+        currentUnavailable ||
+        !currentWorkspace ||
+        !currentLease ||
+        currentLease.id !== lease.lease.id
+      ) {
+        return {
+          error: "unavailable" as const,
+          message: currentUnavailable ?? "workspace lease changed",
+        };
       }
-      const accepted = this.state.createWebSocketUpgrade({
+      if (this.workspaceConnectionLimitReached(key, lease.workspace.owner, lease.workspace.org)) {
+        return { error: "limit" as const };
+      }
+      const upgrade = this.state.createWebSocketUpgrade({
         maxPayload: workspaceTerminalMaxBufferedBytes,
       });
-      this.trackWorkspaceTerminal(key, accepted.socket);
-      return accepted;
+      this.trackWorkspaceTerminal(key, upgrade.socket);
+      return { upgrade, workspace: currentWorkspace, lease: currentLease };
     });
-    if (!upgrade) {
+    if ("error" in admission && admission.error === "unavailable") {
+      return json({ error: "native_vnc_unavailable", message: admission.message }, { status: 409 });
+    }
+    if ("error" in admission) {
       return json(
         {
           error: "native_vnc_connection_limit",
@@ -3289,10 +3310,15 @@ export class FleetCoordinator {
         { status: 429, headers: { "retry-after": "5" } },
       );
     }
-    void this.connectWorkspaceNativeVNC(upgrade.socket, key, lease.workspace, lease.lease).catch(
-      (error) => closeSocket(upgrade.socket, 1011, boundedSocketReason(errorMessage(error))),
+    void this.connectWorkspaceNativeVNC(
+      admission.upgrade.socket,
+      key,
+      admission.workspace,
+      admission.lease,
+    ).catch((error) =>
+      closeSocket(admission.upgrade.socket, 1011, boundedSocketReason(errorMessage(error))),
     );
-    return upgrade.response;
+    return admission.upgrade.response;
   }
 
   private async connectWorkspaceNativeVNC(

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -12901,6 +12901,7 @@ function workspaceResponse(
 ): Record<string, unknown> {
   const status = workspaceStatus(workspace, lease);
   const terminalUrl = env ? workspaceTerminalURL(workspace, lease, env) : undefined;
+  const nativeVnc = env ? !workspaceNativeVNCError(workspace, lease, env) : false;
   return {
     id: workspace.id,
     workspaceId: workspace.id,
@@ -12912,7 +12913,7 @@ function workspaceResponse(
       takeover: false,
       vnc: false,
       desktop: false,
-      nativeVnc: workspace.desktop && Boolean(terminalUrl),
+      nativeVnc,
       logs: false,
       artifacts: false,
     },

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -3269,10 +3269,27 @@ export class FleetCoordinator {
     if (unavailable) {
       return json({ error: "native_vnc_unavailable", message: unavailable }, { status: 409 });
     }
-    const upgrade = this.state.createWebSocketUpgrade({
-      maxPayload: workspaceTerminalMaxBufferedBytes,
+    const key = workspaceKey(lease.workspace.owner, lease.workspace.org, lease.workspace.id);
+    const upgrade = await this.state.runExclusive(async () => {
+      if (this.workspaceConnectionLimitReached(key, lease.workspace.owner, lease.workspace.org)) {
+        return undefined;
+      }
+      const accepted = this.state.createWebSocketUpgrade({
+        maxPayload: workspaceTerminalMaxBufferedBytes,
+      });
+      this.trackWorkspaceTerminal(key, accepted.socket);
+      return accepted;
     });
-    void this.connectWorkspaceNativeVNC(upgrade.socket, lease.workspace, lease.lease).catch(
+    if (!upgrade) {
+      return json(
+        {
+          error: "native_vnc_connection_limit",
+          message: "workspace connection limit reached",
+        },
+        { status: 429, headers: { "retry-after": "5" } },
+      );
+    }
+    void this.connectWorkspaceNativeVNC(upgrade.socket, key, lease.workspace, lease.lease).catch(
       (error) => closeSocket(upgrade.socket, 1011, boundedSocketReason(errorMessage(error))),
     );
     return upgrade.response;
@@ -3280,6 +3297,7 @@ export class FleetCoordinator {
 
   private async connectWorkspaceNativeVNC(
     socket: WebSocket,
+    workspaceKeyValue: string,
     workspace: WorkspaceRecord,
     lease: LeaseRecord,
   ): Promise<void> {
@@ -3315,6 +3333,7 @@ export class FleetCoordinator {
       closed = true;
       clearStartTimer();
       clearTimeout(expiryTimer);
+      this.untrackWorkspaceTerminal(workspaceKeyValue, socket);
       rejectStart?.(new Error(reason));
       channel?.close();
       connectingClient?.end();
@@ -3463,28 +3482,7 @@ export class FleetCoordinator {
           { status: 409 },
         );
       }
-      const ownerPrefix = workspaceKey(owner, org, "");
-      let ownerConnections = 0;
-      let globalConnections = 0;
-      for (const [terminalKey, sockets] of this.workspaceTerminals) {
-        globalConnections += sockets.size;
-        if (terminalKey.startsWith(ownerPrefix)) {
-          ownerConnections += sockets.size;
-        }
-      }
-      const transportConnectionLimit = Math.max(
-        1,
-        Math.floor(
-          workspaceTerminalTransportMemoryBudgetBytes /
-            this.state.ephemeralWebSocketMaxPayloadBytes,
-        ),
-      );
-      if (
-        (this.workspaceTerminals.get(key)?.size ?? 0) >=
-          Math.min(workspaceTerminalMaxPerWorkspace, transportConnectionLimit) ||
-        ownerConnections >= Math.min(workspaceTerminalMaxPerOwner, transportConnectionLimit) ||
-        globalConnections >= Math.min(workspaceTerminalMaxGlobal, transportConnectionLimit)
-      ) {
+      if (this.workspaceConnectionLimitReached(key, owner, org)) {
         return json(
           {
             error: "terminal_connection_limit",
@@ -3732,6 +3730,30 @@ export class FleetCoordinator {
     sockets.add(socket);
     this.workspaceTerminals.set(key, sockets);
     socket.addEventListener("close", () => this.untrackWorkspaceTerminal(key, socket));
+  }
+
+  private workspaceConnectionLimitReached(key: string, owner: string, org: string): boolean {
+    const ownerPrefix = workspaceKey(owner, org, "");
+    let ownerConnections = 0;
+    let globalConnections = 0;
+    for (const [terminalKey, sockets] of this.workspaceTerminals) {
+      globalConnections += sockets.size;
+      if (terminalKey.startsWith(ownerPrefix)) {
+        ownerConnections += sockets.size;
+      }
+    }
+    const transportConnectionLimit = Math.max(
+      1,
+      Math.floor(
+        workspaceTerminalTransportMemoryBudgetBytes / this.state.ephemeralWebSocketMaxPayloadBytes,
+      ),
+    );
+    return (
+      (this.workspaceTerminals.get(key)?.size ?? 0) >=
+        Math.min(workspaceTerminalMaxPerWorkspace, transportConnectionLimit) ||
+      ownerConnections >= Math.min(workspaceTerminalMaxPerOwner, transportConnectionLimit) ||
+      globalConnections >= Math.min(workspaceTerminalMaxGlobal, transportConnectionLimit)
+    );
   }
 
   private untrackWorkspaceTerminal(key: string, socket: WebSocket): void {

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -3303,12 +3303,17 @@ export class FleetCoordinator {
       resolveStart = resolve;
       rejectStart = reject;
     });
-    let startTimer: ReturnType<typeof setTimeout> | null = null;
+    let startTimer: ReturnType<typeof setTimeout> | undefined;
     let expiryTimer: ReturnType<typeof setTimeout>;
+    const clearStartTimer = () => {
+      const timer = startTimer;
+      startTimer = undefined;
+      if (timer !== undefined) clearTimeout(timer as unknown as number);
+    };
     const close = (code: number, reason: string) => {
       if (closed) return;
       closed = true;
-      clearTimeout(startTimer);
+      clearStartTimer();
       clearTimeout(expiryTimer);
       rejectStart?.(new Error(reason));
       channel?.close();
@@ -3326,7 +3331,7 @@ export class FleetCoordinator {
         if (!started) {
           if (data === "start") {
             started = true;
-            clearTimeout(startTimer);
+            clearStartTimer();
             resolveStart?.();
           } else {
             close(1008, "native VNC start required");

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -156,6 +156,7 @@ const codeViewerTicketTTLSeconds = 120;
 const codeViewerSessionTTLSeconds = 8 * 60 * 60;
 const egressTicketTTLSeconds = 120;
 const runtimeAdapterTicketTTLSeconds = 120;
+const nativeVNCTicketTTLSeconds = 60;
 const runtimeAdapterProvisionalClaimTTLSeconds = 10 * 60;
 const runtimeAdapterDeleteRetryBaseMs = 5_000;
 const runtimeAdapterDeleteRetryMaxMs = 60_000;
@@ -214,6 +215,16 @@ const workspaceSSHHostPublicKeyHeader = "x-crabbox-workspace-ssh-host-public-key
 
 interface WebVNCTicketRecord {
   ticket: string;
+  leaseID: string;
+  owner: string;
+  org: string;
+  createdAt: string;
+  expiresAt: string;
+}
+
+interface NativeVNCTicketRecord {
+  ticket: string;
+  workspaceID: string;
   leaseID: string;
   owner: string;
   org: string;
@@ -873,6 +884,9 @@ export class FleetCoordinator {
       }
       if (method === "POST" && parts.join("/") === "v1/workspaces") {
         return await this.createWorkspace(request);
+      }
+      if (method === "GET" && parts.join("/") === "v1/native-vnc/handoff") {
+        return await this.workspaceNativeVNC(request);
       }
       if (
         method === "GET" &&
@@ -3124,6 +3138,9 @@ export class FleetCoordinator {
         { status: 409 },
       );
     }
+    if (method === "POST" && action === "connections" && connection === "native-vnc") {
+      return await this.createWorkspaceNativeVNCTicket(request, key, workspaceID);
+    }
     if (method === "DELETE" && action === undefined) {
       const release = await this.state.runExclusive(async () => {
         const record = await this.state.storage.get<WorkspaceRecord>(key);
@@ -3169,6 +3186,241 @@ export class FleetCoordinator {
       return json(workspaceResponse(record, lease, this.env));
     }
     return json({ error: "not_found" }, { status: 404 });
+  }
+
+  private async createWorkspaceNativeVNCTicket(
+    request: Request,
+    key: string,
+    workspaceID: string,
+  ): Promise<Response> {
+    const brokerURL = workspacePublicURL(this.env);
+    if (!brokerURL) {
+      return json(
+        { error: "native_vnc_unavailable", message: "workspace public URL is not configured" },
+        { status: 409 },
+      );
+    }
+    const result = await this.state.runExclusive(async () => {
+      const workspace = await this.state.storage.get<WorkspaceRecord>(key);
+      if (!workspace || workspace.prewarm || workspace.id !== workspaceID) return undefined;
+      const lease = await this.getLease(workspace.leaseID);
+      const unavailable = workspaceNativeVNCError(workspace, lease, this.env);
+      if (unavailable || !lease) {
+        return { unavailable: unavailable ?? "workspace lease is unavailable" };
+      }
+      const now = new Date();
+      const ticket: NativeVNCTicketRecord = {
+        ticket: newNativeVNCTicket(),
+        workspaceID: workspace.id,
+        leaseID: lease.id,
+        owner: workspace.owner,
+        org: workspace.org,
+        createdAt: now.toISOString(),
+        expiresAt: new Date(now.getTime() + nativeVNCTicketTTLSeconds * 1000).toISOString(),
+      };
+      await this.cleanupExpiredNativeVNCTickets(now.getTime());
+      await this.state.storage.put(nativeVNCTicketKey(ticket.ticket), ticket);
+      return { ticket };
+    });
+    if (!result) return notFound();
+    if ("unavailable" in result) {
+      return json(
+        { error: "native_vnc_unavailable", message: result.unavailable },
+        { status: 409 },
+      );
+    }
+    return json(
+      {
+        schema: "crabbox/native-vnc-grant/v1",
+        brokerUrl: brokerURL,
+        leaseId: result.ticket.leaseID,
+        ticket: result.ticket.ticket,
+        expiresAt: result.ticket.expiresAt,
+      },
+      { headers: { "cache-control": "no-store" } },
+    );
+  }
+
+  private async workspaceNativeVNC(request: Request): Promise<Response> {
+    if (request.headers.get("upgrade")?.toLowerCase() !== "websocket") {
+      return json({ error: "upgrade_required" }, { status: 426 });
+    }
+    const token = bearerToken(request);
+    if (!validNativeVNCTicket(token)) {
+      return json({ error: "native_vnc_ticket_required" }, { status: 401 });
+    }
+    const lease = await this.state.runExclusive(async () => {
+      const key = nativeVNCTicketKey(token);
+      const ticket = await this.state.storage.get<NativeVNCTicketRecord>(key);
+      await this.state.storage.delete(key);
+      if (!ticket || ticket.ticket !== token || Date.parse(ticket.expiresAt) <= Date.now()) {
+        return undefined;
+      }
+      const workspace = await this.state.storage.get<WorkspaceRecord>(
+        workspaceKey(ticket.owner, ticket.org, ticket.workspaceID),
+      );
+      const current = workspace ? await this.getLease(ticket.leaseID) : undefined;
+      return workspace && current && workspaceOwnsLease(workspace, current)
+        ? { workspace, lease: current }
+        : undefined;
+    });
+    if (!lease) return json({ error: "native_vnc_ticket_invalid" }, { status: 401 });
+    const unavailable = workspaceNativeVNCError(lease.workspace, lease.lease, this.env);
+    if (unavailable) {
+      return json({ error: "native_vnc_unavailable", message: unavailable }, { status: 409 });
+    }
+    const upgrade = this.state.createWebSocketUpgrade({
+      maxPayload: workspaceTerminalMaxBufferedBytes,
+    });
+    void this.connectWorkspaceNativeVNC(upgrade.socket, lease.workspace, lease.lease).catch(
+      (error) => closeSocket(upgrade.socket, 1011, boundedSocketReason(errorMessage(error))),
+    );
+    return upgrade.response;
+  }
+
+  private async connectWorkspaceNativeVNC(
+    socket: WebSocket,
+    workspace: WorkspaceRecord,
+    lease: LeaseRecord,
+  ): Promise<void> {
+    const privateKey = this.env.CRABBOX_WORKSPACE_SSH_PRIVATE_KEY?.trim();
+    const expectedHostKey = workspace.sshHostKeySha256;
+    if (!privateKey || !expectedHostKey || !lease.host) {
+      throw new Error("workspace native VNC SSH access is not configured");
+    }
+
+    let client: SSHClient | undefined;
+    let connectingClient: SSHClient | undefined;
+    let channel: ClientChannel | undefined;
+    let closed = false;
+    let started = false;
+    let resolveStart: (() => void) | undefined;
+    let rejectStart: ((error: Error) => void) | undefined;
+    let inputQueue = Promise.resolve();
+    let queuedInputBytes = 0;
+    let queuedInputFrames = 0;
+    const start = new Promise<void>((resolve, reject) => {
+      resolveStart = resolve;
+      rejectStart = reject;
+    });
+    let startTimer: ReturnType<typeof setTimeout>;
+    let expiryTimer: ReturnType<typeof setTimeout>;
+    const close = (code: number, reason: string) => {
+      if (closed) return;
+      closed = true;
+      clearTimeout(startTimer);
+      clearTimeout(expiryTimer);
+      rejectStart?.(new Error(reason));
+      channel?.close();
+      connectingClient?.end();
+      client?.end();
+      closeSocket(socket, code, boundedSocketReason(reason));
+    };
+    startTimer = setTimeout(
+      () => rejectStart?.(new Error("native VNC viewer did not connect")),
+      30_000,
+    );
+    expiryTimer = setTimeout(
+      () => close(1008, "workspace expired"),
+      Math.min(Math.max(0, Date.parse(lease.expiresAt) - Date.now()), 2_147_483_647),
+    );
+    this.state.acceptEphemeralWebSocket(socket, {
+      message: (data) => {
+        if (closed) return;
+        if (!started) {
+          if (data === "start") {
+            started = true;
+            clearTimeout(startTimer);
+            resolveStart?.();
+          } else {
+            close(1008, "native VNC start required");
+          }
+          return;
+        }
+        const length = workspaceTerminalDataLength(data);
+        if (
+          queuedInputFrames >= workspaceTerminalMaxBufferedFrames ||
+          queuedInputBytes + length > workspaceTerminalMaxBufferedBytes
+        ) {
+          close(1009, "native VNC input buffer exceeded");
+          return;
+        }
+        queuedInputBytes += length;
+        queuedInputFrames += 1;
+        inputQueue = inputQueue
+          .then(async () => {
+            try {
+              const value = await workspaceTerminalMessage(data);
+              if (typeof value === "string") throw new Error("native VNC binary frame required");
+              if (channel) await writeWorkspaceTerminalChannel(channel, value);
+              return undefined;
+            } finally {
+              queuedInputBytes -= length;
+              queuedInputFrames -= 1;
+            }
+          })
+          .catch((error) => close(1011, errorMessage(error)));
+      },
+      close: () => close(1000, "native VNC closed"),
+      error: () => close(1011, "native VNC websocket error"),
+    });
+
+    try {
+      client = await connectWorkspaceSSH(privateKey, expectedHostKey, lease, {
+        shouldStop: () => closed,
+        connecting: (candidate) => {
+          connectingClient = candidate;
+        },
+      });
+      connectingClient = undefined;
+      const password = await readWorkspaceVNCPassword(client, lease);
+      const username = lease.target === "windows" || lease.target === "macos" ? lease.sshUser : "";
+      socket.send(
+        JSON.stringify({
+          schema: "crabbox/native-vnc-ready/v1",
+          leaseId: lease.id,
+          username: username ?? "",
+          password,
+        }),
+      );
+      await start;
+      if (closed) return;
+      const connectedClient = client;
+      channel = await new Promise<ClientChannel>((resolve, reject) => {
+        connectedClient.forwardOut("127.0.0.1", 0, "127.0.0.1", 5900, (error, opened) =>
+          error ? reject(error) : resolve(opened),
+        );
+      });
+      channel.on("data", (data: Uint8Array) => {
+        if (closed || socket.readyState !== WebSocket.OPEN) return;
+        if (
+          data.byteLength > workspaceTerminalMaxBufferedBytes ||
+          workspaceTerminalSocketBufferedBytes(socket) + data.byteLength >
+            workspaceTerminalMaxBufferedBytes
+        ) {
+          close(1009, "native VNC output buffer exceeded");
+          return;
+        }
+        socket.send(data.slice());
+      });
+      channel.once("close", () => close(1000, "native VNC tunnel closed"));
+      connectedClient.once("close", () => close(1011, "SSH connection closed"));
+      connectedClient.once("error", (error) => close(1011, errorMessage(error)));
+    } catch (error) {
+      close(1011, errorMessage(error));
+      throw error;
+    }
+  }
+
+  private async cleanupExpiredNativeVNCTickets(now = Date.now()): Promise<void> {
+    const tickets = await this.state.storage.list<NativeVNCTicketRecord>({
+      prefix: nativeVNCTicketPrefix(),
+    });
+    await Promise.all(
+      [...tickets.entries()]
+        .filter(([, ticket]) => Date.parse(ticket.expiresAt) <= now)
+        .map(([key]) => this.state.storage.delete(key)),
+    );
   }
 
   private async workspaceTerminal(request: Request, workspaceID: string): Promise<Response> {
@@ -3352,83 +3604,13 @@ export class FleetCoordinator {
     });
 
     try {
-      const readyDeadline = Date.now() + workspaceTerminalSSHReadyTimeoutMs;
-      const terminalPorts = uniqueNonEmpty([lease.sshPort, ...(lease.sshFallbackPorts ?? [])]);
-      let lastConnectError: unknown = new Error("workspace SSH service is not ready");
-      let lastObservedHostKey = "";
-      connect: while (Date.now() < readyDeadline) {
-        for (const port of terminalPorts) {
-          if (closed) break connect;
-          const candidate = new SSHClientConstructor();
+      client = await connectWorkspaceSSH(privateKey, expectedHostKey, lease, {
+        shouldStop: () => closed,
+        connecting: (candidate) => {
           connectingClient = candidate;
-          try {
-            // oxlint-disable-next-line eslint/no-await-in-loop -- SSH readiness retries are sequential.
-            await new Promise<void>((resolve, reject) => {
-              let settled = false;
-              const settle = (callback: () => void) => {
-                if (settled) return;
-                settled = true;
-                callback();
-              };
-              candidate
-                .once("ready", () => settle(resolve))
-                .once("error", (error) => settle(() => reject(error)))
-                .once("close", () =>
-                  settle(() => reject(new Error("SSH connection closed before ready"))),
-                )
-                .connect({
-                  host: lease.host,
-                  port: Number.parseInt(port || "22", 10) || 22,
-                  username: lease.sshUser || "root",
-                  privateKey,
-                  readyTimeout: 10_000,
-                  keepaliveInterval: 15_000,
-                  keepaliveCountMax: 3,
-                  algorithms: {
-                    serverHostKey: ["ssh-ed25519"],
-                    cipher: ["aes128-ctr", "aes192-ctr", "aes256-ctr"],
-                    hmac: [
-                      "hmac-sha2-256-etm@openssh.com",
-                      "hmac-sha2-512-etm@openssh.com",
-                      "hmac-sha2-256",
-                      "hmac-sha2-512",
-                    ],
-                  },
-                  hostHash: "sha256",
-                  hostVerifier: (fingerprint: string) => {
-                    lastObservedHostKey = fingerprint;
-                    return expectedHostKey === fingerprint;
-                  },
-                });
-            });
-            if (closed) {
-              candidate.end();
-              connectingClient = undefined;
-              break connect;
-            }
-            client = candidate;
-            connectingClient = undefined;
-            lastConnectError = undefined;
-            break connect;
-          } catch (error) {
-            lastConnectError = error;
-            candidate.end();
-            if (connectingClient === candidate) connectingClient = undefined;
-          }
-        }
-        if (!closed && Date.now() < readyDeadline) {
-          // oxlint-disable-next-line eslint/no-await-in-loop -- delay before the next SSH sweep.
-          await new Promise<void>((resolve) => setTimeout(resolve, 2_000));
-        }
-      }
-      if (lastConnectError || !client) {
-        if (lastObservedHostKey && lastObservedHostKey !== expectedHostKey) {
-          throw new Error(
-            `workspace SSH host key mismatch expected=${expectedHostKey.slice(0, 16)} observed=${lastObservedHostKey.slice(0, 16)}`,
-          );
-        }
-        throw lastConnectError;
-      }
+        },
+      });
+      connectingClient = undefined;
       if (closed) return;
       const connectedClient = client;
 
@@ -11758,6 +11940,14 @@ function runtimeAdapterTicketKey(ticket: string): string {
   return `${runtimeAdapterTicketPrefix()}${ticket}`;
 }
 
+function nativeVNCTicketPrefix(): string {
+  return "native-vnc-ticket:";
+}
+
+function nativeVNCTicketKey(ticket: string): string {
+  return `${nativeVNCTicketPrefix()}${ticket}`;
+}
+
 function runtimeAdapterIdentityKey(adapterID: string): string {
   return `runtime-adapter-identity:${adapterID}`;
 }
@@ -12312,6 +12502,32 @@ function workspaceTerminalError(
   return undefined;
 }
 
+function workspaceNativeVNCError(
+  workspace: WorkspaceRecord,
+  lease: LeaseRecord | undefined,
+  env: Env,
+): string | undefined {
+  if (!workspace.desktop) return "workspace desktop access was not requested";
+  return workspaceTerminalError(workspace, lease, env);
+}
+
+function workspacePublicURL(env: Env): string | undefined {
+  const value = env.CRABBOX_PUBLIC_URL?.trim();
+  if (!value) return undefined;
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "https:" && !(url.protocol === "http:" && url.hostname === "127.0.0.1")) {
+      return undefined;
+    }
+    url.pathname = url.pathname.replace(/\/+$/, "");
+    url.search = "";
+    url.hash = "";
+    return url.toString().replace(/\/$/, "");
+  } catch {
+    return undefined;
+  }
+}
+
 // Controller-to-controller URL; callers attach with bearer auth through their browser-facing proxy.
 function workspaceTerminalURL(
   workspace: WorkspaceRecord,
@@ -12343,6 +12559,155 @@ async function workspaceTerminalMessage(
   if (typeof value === "string") return value;
   if (value instanceof ArrayBuffer) return new Uint8Array(value);
   return new Uint8Array(await value.arrayBuffer());
+}
+
+async function connectWorkspaceSSH(
+  privateKey: string,
+  expectedHostKey: string,
+  lease: LeaseRecord,
+  options: {
+    shouldStop?: () => boolean;
+    connecting?: (client: SSHClient) => void;
+  } = {},
+): Promise<SSHClient> {
+  const readyDeadline = Date.now() + workspaceTerminalSSHReadyTimeoutMs;
+  const ports = uniqueNonEmpty([lease.sshPort, ...(lease.sshFallbackPorts ?? [])]);
+  let lastError: unknown = new Error("workspace SSH service is not ready");
+  let observedHostKey = "";
+  while (Date.now() < readyDeadline) {
+    for (const port of ports) {
+      if (options.shouldStop?.()) throw new Error("workspace connection closed");
+      const candidate = new SSHClientConstructor();
+      options.connecting?.(candidate);
+      try {
+        // oxlint-disable-next-line eslint/no-await-in-loop -- SSH readiness retries are sequential.
+        await new Promise<void>((resolve, reject) => {
+          let settled = false;
+          const settle = (callback: () => void) => {
+            if (settled) return;
+            settled = true;
+            callback();
+          };
+          candidate
+            .once("ready", () => settle(resolve))
+            .once("error", (error) => settle(() => reject(error)))
+            .once("close", () =>
+              settle(() => reject(new Error("SSH connection closed before ready"))),
+            )
+            .connect({
+              host: lease.host,
+              port: Number.parseInt(port || "22", 10) || 22,
+              username: lease.sshUser || "root",
+              privateKey,
+              readyTimeout: 10_000,
+              keepaliveInterval: 15_000,
+              keepaliveCountMax: 3,
+              algorithms: {
+                serverHostKey: ["ssh-ed25519"],
+                cipher: ["aes128-ctr", "aes192-ctr", "aes256-ctr"],
+                hmac: [
+                  "hmac-sha2-256-etm@openssh.com",
+                  "hmac-sha2-512-etm@openssh.com",
+                  "hmac-sha2-256",
+                  "hmac-sha2-512",
+                ],
+              },
+              hostHash: "sha256",
+              hostVerifier: (fingerprint: string) => {
+                observedHostKey = fingerprint;
+                return expectedHostKey === fingerprint;
+              },
+            });
+        });
+        if (options.shouldStop?.()) {
+          candidate.end();
+          throw new Error("workspace connection closed");
+        }
+        return candidate;
+      } catch (error) {
+        lastError = error;
+        candidate.end();
+      }
+    }
+    if (!options.shouldStop?.() && Date.now() < readyDeadline) {
+      // oxlint-disable-next-line eslint/no-await-in-loop -- delay before the next SSH sweep.
+      await new Promise<void>((resolve) => setTimeout(resolve, 2_000));
+    }
+  }
+  if (observedHostKey && observedHostKey !== expectedHostKey) {
+    throw new Error(
+      `workspace SSH host key mismatch expected=${expectedHostKey.slice(0, 16)} observed=${observedHostKey.slice(0, 16)}`,
+    );
+  }
+  throw lastError;
+}
+
+async function readWorkspaceVNCPassword(client: SSHClient, lease: LeaseRecord): Promise<string> {
+  const output = await new Promise<Uint8Array>((resolve, reject) => {
+    client.exec(workspaceVNCPasswordCommand(lease), (error, channel) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      const chunks: Uint8Array[] = [];
+      let bytes = 0;
+      let exitCode: number | undefined;
+      let settled = false;
+      const fail = (failure: Error) => {
+        if (settled) return;
+        settled = true;
+        reject(failure);
+      };
+      channel.on("data", (chunk: Uint8Array) => {
+        if (settled) return;
+        bytes += chunk.byteLength;
+        if (bytes > 4096) {
+          channel.close();
+          fail(new Error("workspace VNC password output is too large"));
+          return;
+        }
+        chunks.push(chunk.slice());
+      });
+      channel.once("exit", (code?: number) => {
+        exitCode = code;
+      });
+      channel.once("close", () => {
+        if (settled) return;
+        if (exitCode !== undefined && exitCode !== 0) {
+          fail(new Error("workspace VNC password command failed"));
+          return;
+        }
+        const joined = new Uint8Array(bytes);
+        let offset = 0;
+        for (const chunk of chunks) {
+          joined.set(chunk, offset);
+          offset += chunk.byteLength;
+        }
+        settled = true;
+        resolve(joined);
+      });
+    });
+  });
+  const password = new TextDecoder().decode(output).trim();
+  if (
+    !password ||
+    password.length > 256 ||
+    [...password].some((character) => {
+      const code = character.charCodeAt(0);
+      return code === 0 || code === 10 || code === 13;
+    })
+  ) {
+    throw new Error("workspace VNC password is invalid");
+  }
+  return password;
+}
+
+function workspaceVNCPasswordCommand(lease: LeaseRecord): string {
+  if (lease.target === "windows") {
+    return "powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command \"Get-Content -Raw -LiteralPath 'C:\\\\ProgramData\\\\crabbox\\\\vnc.password'\"";
+  }
+  if (lease.target === "macos") return "sudo cat '/var/db/crabbox/vnc.password'";
+  return "cat '/var/lib/crabbox/vnc.password'";
 }
 
 function workspaceTerminalDataLength(value: string | ArrayBuffer | Blob | Uint8Array): number {
@@ -12597,6 +12962,14 @@ function newRuntimeAdapterTicket(): string {
   const bytes = new Uint8Array(16);
   crypto.getRandomValues(bytes);
   return `adapter_${[...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("")}`;
+}
+
+function newNativeVNCTicket(): string {
+  return randomHexToken("native_vnc_");
+}
+
+function validNativeVNCTicket(value: string): boolean {
+  return /^native_vnc_[a-f0-9]{32}$/.test(value);
 }
 
 function newCodeViewerTicket(): string {

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -3303,7 +3303,7 @@ export class FleetCoordinator {
       resolveStart = resolve;
       rejectStart = reject;
     });
-    let startTimer: ReturnType<typeof setTimeout>;
+    let startTimer: ReturnType<typeof setTimeout> | null = null;
     let expiryTimer: ReturnType<typeof setTimeout>;
     const close = (code: number, reason: string) => {
       if (closed) return;
@@ -3316,10 +3316,6 @@ export class FleetCoordinator {
       client?.end();
       closeSocket(socket, code, boundedSocketReason(reason));
     };
-    startTimer = setTimeout(
-      () => rejectStart?.(new Error("native VNC viewer did not connect")),
-      30_000,
-    );
     expiryTimer = setTimeout(
       () => close(1008, "workspace expired"),
       Math.min(Math.max(0, Date.parse(lease.expiresAt) - Date.now()), 2_147_483_647),
@@ -3382,6 +3378,10 @@ export class FleetCoordinator {
           username: username ?? "",
           password,
         }),
+      );
+      startTimer = setTimeout(
+        () => rejectStart?.(new Error("native VNC viewer did not connect")),
+        30_000,
       );
       await start;
       if (closed) return;
@@ -12491,6 +12491,17 @@ function workspaceTerminalError(
   lease: LeaseRecord | undefined,
   env: Env,
 ): string | undefined {
+  const sshError = workspaceSSHError(workspace, lease, env);
+  if (sshError) return sshError;
+  if (!workspaceTerminalPublicURL(env)) return "workspace public URL is not configured";
+  return undefined;
+}
+
+function workspaceSSHError(
+  workspace: WorkspaceRecord,
+  lease: LeaseRecord | undefined,
+  env: Env,
+): string | undefined {
   if (workspaceStatus(workspace, lease) !== "ready") return "workspace is not ready";
   if (!lease || !workspaceOwnsLease(workspace, lease)) return "workspace lease is unavailable";
   if (!lease.host?.trim()) return "workspace SSH host is unavailable";
@@ -12498,7 +12509,6 @@ function workspaceTerminalError(
   if (!env.CRABBOX_WORKSPACE_SSH_PRIVATE_KEY?.trim()) {
     return "workspace terminal SSH access is not configured";
   }
-  if (!workspaceTerminalPublicURL(env)) return "workspace public URL is not configured";
   return undefined;
 }
 
@@ -12508,7 +12518,10 @@ function workspaceNativeVNCError(
   env: Env,
 ): string | undefined {
   if (!workspace.desktop) return "workspace desktop access was not requested";
-  return workspaceTerminalError(workspace, lease, env);
+  const sshError = workspaceSSHError(workspace, lease, env);
+  if (sshError) return sshError;
+  if (!workspacePublicURL(env)) return "workspace public URL is not configured";
+  return undefined;
 }
 
 function workspacePublicURL(env: Env): string | undefined {

--- a/worker/src/runtime-adapter-relay.ts
+++ b/worker/src/runtime-adapter-relay.ts
@@ -45,8 +45,12 @@ export function runtimeAdapterProxyPath(parts: string[]): string | undefined {
   if (parts.length === 3) {
     return `/v1/workspaces/${parts[2]}`;
   }
-  if (parts.length === 5 && parts[3] === "connections" && parts[4] === "desktop") {
-    return `/v1/workspaces/${parts[2]}/connections/desktop`;
+  if (
+    parts.length === 5 &&
+    parts[3] === "connections" &&
+    (parts[4] === "desktop" || parts[4] === "native-vnc")
+  ) {
+    return `/v1/workspaces/${parts[2]}/connections/${parts[4]}`;
   }
   return undefined;
 }
@@ -55,7 +59,7 @@ export function runtimeAdapterRelayMethodAllowed(method: string, path: string): 
   if (path === "/v1/workspaces") {
     return method === "POST";
   }
-  if (path.endsWith("/connections/desktop")) {
+  if (path.endsWith("/connections/desktop") || path.endsWith("/connections/native-vnc")) {
     return method === "POST";
   }
   return method === "GET" || method === "DELETE";

--- a/worker/src/runtime-adapter-relay.ts
+++ b/worker/src/runtime-adapter-relay.ts
@@ -83,7 +83,9 @@ export function validRuntimeAdapterDesktopRelayTimeout(value: unknown): value is
 }
 
 export function runtimeAdapterRelayTimeoutForPath(path: string, desktopTimeoutMs?: number): number {
-  if (!path.endsWith("/connections/desktop")) return runtimeAdapterRelayTimeoutMs;
+  if (!path.endsWith("/connections/desktop") && !path.endsWith("/connections/native-vnc")) {
+    return runtimeAdapterRelayTimeoutMs;
+  }
   return validRuntimeAdapterDesktopRelayTimeout(desktopTimeoutMs)
     ? desktopTimeoutMs
     : runtimeAdapterDesktopRelayTimeoutMs;

--- a/worker/src/ssh2.d.ts
+++ b/worker/src/ssh2.d.ts
@@ -12,6 +12,7 @@ declare module "ssh2" {
     off(event: "close" | "drain", listener: () => void): this;
     once(event: "close", listener: () => void): this;
     once(event: "drain", listener: () => void): this;
+    once(event: "exit", listener: (code?: number) => void): this;
   }
 
   export class Client {
@@ -44,6 +45,17 @@ declare module "ssh2" {
         width: number;
         height: number;
       },
+      callback: (error: Error | undefined, channel: ClientChannel) => void,
+    ): this;
+    exec(
+      command: string,
+      callback: (error: Error | undefined, channel: ClientChannel) => void,
+    ): this;
+    forwardOut(
+      sourceIP: string,
+      sourcePort: number,
+      destinationIP: string,
+      destinationPort: number,
       callback: (error: Error | undefined, channel: ClientChannel) => void,
     ): this;
     end(): void;

--- a/worker/test/coordinator-runtime.test.ts
+++ b/worker/test/coordinator-runtime.test.ts
@@ -169,6 +169,7 @@ describe("coordinator runtimes", () => {
       ["POST", "/v1/workspaces"],
       ["GET", "/v1/workspaces/fleet-is-101"],
       ["DELETE", "/v1/workspaces/fleet-is-101"],
+      ["GET", "/v1/native-vnc/handoff"],
       ["GET", "/v1/adapters/applied-alice"],
       ["POST", "/v1/adapters/applied-alice/proxy/v1/workspaces"],
     ]) {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -3349,10 +3349,14 @@ describe("fleet lease identity and idle", () => {
     expect(terminalURL.pathname).toBe("/v1/workspaces/fleet-is-101/terminal");
     expect(terminalURL.search).toBe("?flow=ack-v1");
 
-    const loopbackFleet = testFleet(storage, {}, {
-      CRABBOX_PUBLIC_URL: "http://127.0.0.1:8787",
-      CRABBOX_WORKSPACE_SSH_PRIVATE_KEY: "workspace-private-key",
-    });
+    const loopbackFleet = testFleet(
+      storage,
+      {},
+      {
+        CRABBOX_PUBLIC_URL: "http://127.0.0.1:8787",
+        CRABBOX_WORKSPACE_SSH_PRIVATE_KEY: "workspace-private-key",
+      },
+    );
     const loopbackReady = await loopbackFleet.fetch(
       request("GET", `/v1/workspaces/${body.id}`, { headers }),
     );

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -3401,6 +3401,52 @@ describe("fleet lease identity and idle", () => {
     );
     expect(otherOwnerDesktop.status).toBe(404);
 
+    const nativeVNC = await fleet.fetch(
+      request("POST", `/v1/workspaces/${body.id}/connections/native-vnc`, { headers }),
+    );
+    expect(nativeVNC.status).toBe(200);
+    expect(nativeVNC.headers.get("cache-control")).toBe("no-store");
+    const nativeVNCGrant = (await nativeVNC.json()) as {
+      schema: string;
+      brokerUrl: string;
+      leaseId: string;
+      ticket: string;
+      expiresAt: string;
+    };
+    expect(nativeVNCGrant).toMatchObject({
+      schema: "crabbox/native-vnc-grant/v1",
+      brokerUrl: "https://crabbox.example.com",
+      leaseId: created.providerResourceId,
+      ticket: expect.stringMatching(/^native_vnc_[a-f0-9]{32}$/),
+      expiresAt: expect.any(String),
+    });
+    expect(Date.parse(nativeVNCGrant.expiresAt)).toBeGreaterThan(Date.now());
+    expect(storage.value(`native-vnc-ticket:${nativeVNCGrant.ticket}`)).toMatchObject({
+      workspaceID: body.id,
+      leaseID: created.providerResourceId,
+    });
+    const invalidNativeVNCTicket = await fleet.fetch(
+      request("GET", "/v1/native-vnc/handoff", {
+        headers: {
+          authorization: "Bearer native_vnc_00000000000000000000000000000000",
+          upgrade: "websocket",
+        },
+      }),
+    );
+    expect(invalidNativeVNCTicket.status).toBe(401);
+    await expect(invalidNativeVNCTicket.json()).resolves.toEqual({
+      error: "native_vnc_ticket_invalid",
+    });
+    const otherOwnerNativeVNC = await fleet.fetch(
+      request("POST", `/v1/workspaces/${body.id}/connections/native-vnc`, {
+        headers: {
+          "x-crabbox-owner": "bob@example.com",
+          "x-crabbox-org": "example-org",
+        },
+      }),
+    );
+    expect(otherOwnerNativeVNC.status).toBe(404);
+
     const duplicate = await fleet.fetch(request("POST", "/v1/workspaces", { headers, body }));
     await expect(duplicate.json()).resolves.toMatchObject({
       providerResourceId: created.providerResourceId,
@@ -4498,6 +4544,9 @@ describe("fleet lease identity and idle", () => {
     const start = source.indexOf("private async connectWorkspaceTerminal");
     const end = source.indexOf("private trackWorkspaceTerminal", start);
     const terminal = source.slice(start, end);
+    const sshStart = source.indexOf("async function connectWorkspaceSSH");
+    const sshEnd = source.indexOf("async function readWorkspaceVNCPassword", sshStart);
+    const ssh = source.slice(sshStart, sshEnd);
 
     expect(terminal).toContain("queuedOutputFrames >= workspaceTerminalMaxBufferedFrames");
     expect(terminal).toContain("queuedOutputBytes + unacknowledgedOutputBytes + data.byteLength");
@@ -4505,26 +4554,26 @@ describe("fleet lease identity and idle", () => {
     expect(terminal).toContain("workspaceTerminalAcknowledgement(value)");
     expect(terminal).toContain("bytes > unacknowledgedOutputBytes");
     expect(terminal).toContain("workspaceTerminalSocketBufferedBytes(socket)");
-    expect(terminal).toContain('serverHostKey: ["ssh-ed25519"]');
-    expect(terminal).toContain('cipher: ["aes128-ctr", "aes192-ctr", "aes256-ctr"]');
-    expect(terminal).toContain('"hmac-sha2-256-etm@openssh.com"');
-    expect(terminal).toContain('"hmac-sha2-512"');
-    expect(terminal).toContain("workspace SSH host key mismatch expected=");
+    expect(ssh).toContain('serverHostKey: ["ssh-ed25519"]');
+    expect(ssh).toContain('cipher: ["aes128-ctr", "aes192-ctr", "aes256-ctr"]');
+    expect(ssh).toContain('"hmac-sha2-256-etm@openssh.com"');
+    expect(ssh).toContain('"hmac-sha2-512"');
+    expect(ssh).toContain("workspace SSH host key mismatch expected=");
     expect(source).toContain("value.length > workspaceTerminalMaxBufferedBytes");
   });
 
   it("tries every configured SSH port before delaying terminal readiness", async () => {
     const source = await readFile(new URL("../src/fleet.ts", import.meta.url), "utf8");
-    const start = source.indexOf("private async connectWorkspaceTerminal");
-    const end = source.indexOf("private trackWorkspaceTerminal", start);
-    const terminal = source.slice(start, end);
+    const start = source.indexOf("async function connectWorkspaceSSH");
+    const end = source.indexOf("async function readWorkspaceVNCPassword", start);
+    const ssh = source.slice(start, end);
 
-    expect(terminal).toContain("...(lease.sshFallbackPorts ?? [])");
-    expect(terminal).toContain("for (const port of terminalPorts)");
-    expect(terminal).toContain('Number.parseInt(port || "22", 10)');
-    expect(terminal).toContain("connectingClient?.end()");
-    expect(terminal.indexOf("for (const port of terminalPorts)")).toBeLessThan(
-      terminal.indexOf("setTimeout(resolve, 2_000)"),
+    expect(ssh).toContain("...(lease.sshFallbackPorts ?? [])");
+    expect(ssh).toContain("for (const port of ports)");
+    expect(ssh).toContain('Number.parseInt(port || "22", 10)');
+    expect(ssh).toContain("candidate.end()");
+    expect(ssh.indexOf("for (const port of ports)")).toBeLessThan(
+      ssh.indexOf("setTimeout(resolve, 2_000)"),
     );
   });
 

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -4562,6 +4562,23 @@ describe("fleet lease identity and idle", () => {
     expect(source).toContain("value.length > workspaceTerminalMaxBufferedBytes");
   });
 
+  it("starts the native VNC viewer timeout after readiness and accepts loopback broker URLs", async () => {
+    const source = await readFile(new URL("../src/fleet.ts", import.meta.url), "utf8");
+    const start = source.indexOf("private async connectWorkspaceNativeVNC");
+    const end = source.indexOf("private async cleanupExpiredNativeVNCTickets", start);
+    const nativeVNC = source.slice(start, end);
+    const errorStart = source.indexOf("function workspaceNativeVNCError");
+    const errorEnd = source.indexOf("function workspacePublicURL", errorStart);
+    const nativeVNCError = source.slice(errorStart, errorEnd);
+
+    expect(nativeVNC.indexOf("socket.send(")).toBeLessThan(
+      nativeVNC.indexOf("native VNC viewer did not connect"),
+    );
+    expect(nativeVNCError).toContain("workspaceSSHError(workspace, lease, env)");
+    expect(nativeVNCError).toContain("workspacePublicURL(env)");
+    expect(nativeVNCError).not.toContain("workspaceTerminalError");
+  });
+
   it("tries every configured SSH port before delaying terminal readiness", async () => {
     const source = await readFile(new URL("../src/fleet.ts", import.meta.url), "utf8");
     const start = source.indexOf("async function connectWorkspaceSSH");

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -3467,6 +3467,28 @@ describe("fleet lease identity and idle", () => {
       error: "native_vnc_connection_limit",
     });
     nativeVNCInternals.workspaceTerminals.delete(nativeVNCConnectionKey);
+    const stoppingGrantResponse = await fleet.fetch(
+      request("POST", `/v1/workspaces/${body.id}/connections/native-vnc`, { headers }),
+    );
+    const stoppingGrant = (await stoppingGrantResponse.json()) as { ticket: string };
+    const activeWorkspace = storage.value<WorkspaceRecord>(nativeVNCConnectionKey)!;
+    storage.seed(nativeVNCConnectionKey, {
+      ...activeWorkspace,
+      releaseRequestedAt: new Date().toISOString(),
+    });
+    const stoppingNativeVNC = await fleet.fetch(
+      request("GET", "/v1/native-vnc/handoff", {
+        headers: {
+          authorization: `Bearer ${stoppingGrant.ticket}`,
+          upgrade: "websocket",
+        },
+      }),
+    );
+    expect(stoppingNativeVNC.status).toBe(409);
+    await expect(stoppingNativeVNC.json()).resolves.toMatchObject({
+      error: "native_vnc_unavailable",
+    });
+    storage.seed(nativeVNCConnectionKey, activeWorkspace);
     const invalidNativeVNCTicket = await fleet.fetch(
       request("GET", "/v1/native-vnc/handoff", {
         headers: {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -3349,6 +3349,17 @@ describe("fleet lease identity and idle", () => {
     expect(terminalURL.pathname).toBe("/v1/workspaces/fleet-is-101/terminal");
     expect(terminalURL.search).toBe("?flow=ack-v1");
 
+    const loopbackFleet = testFleet(storage, {}, {
+      CRABBOX_PUBLIC_URL: "http://127.0.0.1:8787",
+      CRABBOX_WORKSPACE_SSH_PRIVATE_KEY: "workspace-private-key",
+    });
+    const loopbackReady = await loopbackFleet.fetch(
+      request("GET", `/v1/workspaces/${body.id}`, { headers }),
+    );
+    await expect(loopbackReady.json()).resolves.toMatchObject({
+      capabilities: { terminal: false, nativeVnc: true },
+    });
+
     const oversizedRepo = await fleet.fetch(
       request("POST", "/v1/workspaces", {
         headers,

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -3440,6 +3440,33 @@ describe("fleet lease identity and idle", () => {
       workspaceID: body.id,
       leaseID: created.providerResourceId,
     });
+    const nativeVNCConnectionKey = "workspace:example-org:alice%40example.com:fleet-is-101";
+    const nativeVNCInternals = fleet as unknown as {
+      workspaceTerminals: Map<string, Set<WebSocket>>;
+    };
+    nativeVNCInternals.workspaceTerminals.set(
+      nativeVNCConnectionKey,
+      new Set(
+        Array.from(
+          { length: 4 },
+          () =>
+            ({ readyState: WebSocket.OPEN, close: vi.fn<() => void>() }) as unknown as WebSocket,
+        ),
+      ),
+    );
+    const limitedNativeVNC = await fleet.fetch(
+      request("GET", "/v1/native-vnc/handoff", {
+        headers: {
+          authorization: `Bearer ${nativeVNCGrant.ticket}`,
+          upgrade: "websocket",
+        },
+      }),
+    );
+    expect(limitedNativeVNC.status).toBe(429);
+    await expect(limitedNativeVNC.json()).resolves.toMatchObject({
+      error: "native_vnc_connection_limit",
+    });
+    nativeVNCInternals.workspaceTerminals.delete(nativeVNCConnectionKey);
     const invalidNativeVNCTicket = await fleet.fetch(
       request("GET", "/v1/native-vnc/handoff", {
         headers: {

--- a/worker/test/http.test.ts
+++ b/worker/test/http.test.ts
@@ -221,6 +221,26 @@ describe("coordinator auth", () => {
     expect(prepared).toMatchObject({ authenticated: false, response: { status: 401 } });
   });
 
+  it("lets one-time native VNC websocket tickets bypass user authentication", async () => {
+    const prepared = await prepareCoordinatorRequest(
+      new Request("https://example.test/v1/native-vnc/handoff", {
+        headers: { upgrade: "websocket", authorization: "Bearer native_vnc_ticket" },
+      }),
+      {} as Env,
+    );
+    expect(prepared).toMatchObject({ authenticated: false });
+    if ("response" in prepared) throw new Error("native VNC websocket was rejected");
+    expect(prepared.request.headers.get("authorization")).toBe("Bearer native_vnc_ticket");
+
+    const plain = await prepareCoordinatorRequest(
+      new Request("https://example.test/v1/native-vnc/handoff", {
+        headers: { authorization: "Bearer native_vnc_ticket" },
+      }),
+      {} as Env,
+    );
+    expect(plain).toMatchObject({ authenticated: false, response: { status: 401 } });
+  });
+
   it("accepts the runtime adapter token only for workspace routes", async () => {
     const env = {
       CRABBOX_DEFAULT_ORG: "openclaw",
@@ -231,6 +251,9 @@ describe("coordinator auth", () => {
         new Request("https://example.test/v1/workspaces", { method: "POST" }),
         new Request("https://example.test/v1/workspaces/fleet-is-101"),
         new Request("https://example.test/v1/workspaces/fleet-is-101/connections/desktop", {
+          method: "POST",
+        }),
+        new Request("https://example.test/v1/workspaces/fleet-is-101/connections/native-vnc", {
           method: "POST",
         }),
       ].map((request) => {
@@ -249,6 +272,7 @@ describe("coordinator auth", () => {
             },
       ),
     ).toEqual([
+      { authenticated: true, owner: "service@openclaw.org", org: "openclaw" },
       { authenticated: true, owner: "service@openclaw.org", org: "openclaw" },
       { authenticated: true, owner: "service@openclaw.org", org: "openclaw" },
       { authenticated: true, owner: "service@openclaw.org", org: "openclaw" },

--- a/worker/test/node-runtime.test.ts
+++ b/worker/test/node-runtime.test.ts
@@ -144,6 +144,9 @@ describe("NodeCoordinatorRuntime", () => {
     const start = source.indexOf("private async connectWorkspaceTerminal");
     const end = source.indexOf("private trackWorkspaceTerminal", start);
     const terminal = source.slice(start, end);
+    const sshStart = source.indexOf("async function connectWorkspaceSSH");
+    const sshEnd = source.indexOf("async function readWorkspaceVNCPassword", sshStart);
+    const ssh = source.slice(sshStart, sshEnd);
 
     expect(terminal).toContain("workspaceTerminalMaxBufferedFrames");
     expect(source).toContain("workspaceTerminalTransportMemoryBudgetBytes");
@@ -151,14 +154,14 @@ describe("NodeCoordinatorRuntime", () => {
     expect(terminal).toContain("pending.length + queuedInputFrames");
     expect(terminal).toContain("queuedInputFrames -= 1");
     expect(terminal).toContain("if (length === 0) return");
-    expect(terminal).toContain("lastObservedHostKey = fingerprint");
-    expect(terminal).toContain("return expectedHostKey === fingerprint");
-    expect(terminal).toContain('cipher: ["aes128-ctr", "aes192-ctr", "aes256-ctr"]');
-    expect(terminal).toContain('"hmac-sha2-256-etm@openssh.com"');
-    expect(terminal).toContain('"hmac-sha2-512"');
-    expect(terminal).toContain("workspaceTerminalSSHReadyTimeoutMs");
-    expect(terminal).toContain("for (const port of terminalPorts)");
-    expect(terminal).toContain("await new Promise<void>((resolve) => setTimeout(resolve, 2_000))");
+    expect(ssh).toContain("observedHostKey = fingerprint");
+    expect(ssh).toContain("return expectedHostKey === fingerprint");
+    expect(ssh).toContain('cipher: ["aes128-ctr", "aes192-ctr", "aes256-ctr"]');
+    expect(ssh).toContain('"hmac-sha2-256-etm@openssh.com"');
+    expect(ssh).toContain('"hmac-sha2-512"');
+    expect(ssh).toContain("workspaceTerminalSSHReadyTimeoutMs");
+    expect(ssh).toContain("for (const port of ports)");
+    expect(ssh).toContain("await new Promise<void>((resolve) => setTimeout(resolve, 2_000))");
     expect(terminal).not.toContain("!workspace.sshHostKeySha256");
   });
 

--- a/worker/test/runtime-adapter-relay.test.ts
+++ b/worker/test/runtime-adapter-relay.test.ts
@@ -38,6 +38,15 @@ describe("runtime adapter relay", () => {
       runtimeAdapterProxyPath(["v1", "workspaces", "example-workspace", "connections", "desktop"]),
     ).toBe("/v1/workspaces/example-workspace/connections/desktop");
     expect(
+      runtimeAdapterProxyPath([
+        "v1",
+        "workspaces",
+        "example-workspace",
+        "connections",
+        "native-vnc",
+      ]),
+    ).toBe("/v1/workspaces/example-workspace/connections/native-vnc");
+    expect(
       runtimeAdapterProxyPath(["v1", "workspaces", "example-workspace", "shell"]),
     ).toBeUndefined();
     expect(runtimeAdapterProxyPath(["v1", "workspaces", ".."])).toBeUndefined();
@@ -54,11 +63,24 @@ describe("runtime adapter relay", () => {
         "/v1/workspaces/example-workspace/connections/desktop",
       ),
     ).toBe(true);
+    expect(
+      runtimeAdapterRelayMethodAllowed(
+        "POST",
+        "/v1/workspaces/example-workspace/connections/native-vnc",
+      ),
+    ).toBe(true);
     expect(runtimeAdapterRelayBodyAllowed("POST", "/v1/workspaces", "{}")).toBe(true);
     expect(
       runtimeAdapterRelayBodyAllowed(
         "POST",
         "/v1/workspaces/example-workspace/connections/desktop",
+        undefined,
+      ),
+    ).toBe(true);
+    expect(
+      runtimeAdapterRelayBodyAllowed(
+        "POST",
+        "/v1/workspaces/example-workspace/connections/native-vnc",
         undefined,
       ),
     ).toBe(true);

--- a/worker/test/runtime-adapter-relay.test.ts
+++ b/worker/test/runtime-adapter-relay.test.ts
@@ -98,8 +98,17 @@ describe("runtime adapter relay", () => {
       runtimeAdapterRelayTimeoutForPath("/v1/workspaces/example-workspace/connections/desktop"),
     ).toBe(runtimeAdapterDesktopRelayTimeoutMs);
     expect(
+      runtimeAdapterRelayTimeoutForPath("/v1/workspaces/example-workspace/connections/native-vnc"),
+    ).toBe(runtimeAdapterDesktopRelayTimeoutMs);
+    expect(
       runtimeAdapterRelayTimeoutForPath(
         "/v1/workspaces/example-workspace/connections/desktop",
+        11 * 60 * 1_000,
+      ),
+    ).toBe(11 * 60 * 1_000);
+    expect(
+      runtimeAdapterRelayTimeoutForPath(
+        "/v1/workspaces/example-workspace/connections/native-vnc",
         11 * 60 * 1_000,
       ),
     ).toBe(11 * 60 * 1_000);


### PR DESCRIPTION
## Summary

- mint short-lived, one-time native VNC grants for controlled runtime-adapter workspaces
- relay VNC through the coordinator's authenticated SSH connection instead of requiring the local CLI identity to own the provider lease
- keep tickets off argv/URLs, preserve loopback-only native handoff, and bound relay queues/lifetimes

## Test plan

- `GOCACHE=/tmp/crabbox-go-cache go test ./internal/cli -run 'Test(VNCNativeGrantRelaysCoordinatorWebSocketToLoopback|ValidNativeVNCTicket|NativeVNCLoopbackHost)$'`
- `npm test` (685 tests)
- `tsgo --noEmit`
- `oxlint --config .oxlintrc.json .`
- focused Worker relay/runtime tests (296 tests)
- full `go test -timeout=3m ./internal/cli` reached one unrelated provisioning timing flake; exact failing test passed on immediate rerun
