### PR TITLE
fix(vnc): resize managed Linux desktops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
 
 ### Fixed
 
+- Replaced fixed-size Xvfb/x11vnc desktops on managed Linux workspaces with loopback-only TigerVNC displays that honor native viewer resize requests while preserving VNC authentication and existing-service health fallbacks.
 - Mounted the implicit local-container Docker-socket cache root at `/work/crabbox` while preserving explicit work roots, restoring access for the unprivileged guest user. Thanks @hxy91819.
 - Rewrote credential-bearing user config atomically so failed updates preserve the previous readable file, owner-only permissions, and configured symlinks. Thanks @clawsweeper.
 - Scoped managed AWS security groups per coordinator actor and preserved lease-declared CIDRs across heartbeats, preventing concurrent leases from revoking SSH and WebVNC access.

--- a/docs/commands/desktop.md
+++ b/docs/commands/desktop.md
@@ -197,8 +197,8 @@ service, and interactive user state on Windows; `DISPLAY`, remote `ffmpeg`,
 
 `crabbox desktop doctor` checks the selected lease without syncing the repo. For
 Linux desktop leases it reports VM/session health separately from portal health:
-`DISPLAY`, Xvfb/window manager/panel (or Wayland session for Wayland envs), VNC
-listener, `xdotool`/`wtype`, clipboard tool, browser binary, `ffmpeg`, screen
+`DISPLAY`, TigerVNC/window manager/panel (or Wayland session for Wayland envs),
+VNC listener, `xdotool`/`wtype`, clipboard tool, browser binary, `ffmpeg`, screen
 size, and screenshot capture. On coordinator-backed leases it also reports the
 WebVNC bridge/viewer state. Failures carry a one-line repair suggestion so you
 can tell a session bug apart from a WebVNC/browser-portal bug. Non-Linux targets

--- a/docs/commands/vnc.md
+++ b/docs/commands/vnc.md
@@ -228,7 +228,7 @@ host's VNC or Screen Sharing prompt.
 
 | Provider / target | Managed VNC | Notes |
 | --- | --- | --- |
-| Hetzner Linux | Yes | Requires `--desktop`; installs slim XFCE, Xvfb, x11vnc, and capture tools. |
+| Hetzner Linux | Yes | Requires `--desktop`; installs slim XFCE, resize-capable TigerVNC, and capture tools. |
 | AWS Linux | Yes | Requires `--desktop`; same Linux desktop profile. |
 | Azure Linux | Yes | Requires `--desktop`; same Linux desktop profile. |
 | AWS Windows | Yes | Requires `--target windows --desktop`; installs Git for Windows and TightVNC after EC2Launch enables OpenSSH. Spot or On-Demand follows the AWS capacity config. |

--- a/docs/commands/warmup.md
+++ b/docs/commands/warmup.md
@@ -72,7 +72,8 @@ Capabilities are opt-in features requested at warm time and validated against
 the provider's feature set. See [capabilities](../features/capabilities.md).
 
 - `--desktop` provisions a visible UI and loopback-bound VNC for automation and
-  operator takeover. Linux defaults to Xvfb, a slim XFCE, and x11vnc. Use
+  operator takeover. Managed cloud Linux defaults to resize-capable TigerVNC
+  with a slim XFCE session; local containers retain Xvfb/x11vnc. Use
   `--desktop-env wayland` for the experimental labwc/WayVNC profile on
   Ubuntu 26.04-compatible images, or `--desktop-env gnome` for a GNOME-apps
   profile with GNOME Panel taskbars over labwc/WayVNC (GNOME-profile app

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -186,8 +186,9 @@ deletions, missing manifest entries, and other suspicious sync outcomes. See
 
 ## Capabilities
 
-**Desktop** - lease capability (`--desktop`) that adds a visible session: Xvfb +
-XFCE + x11vnc on loopback by default, or Wayland/GNOME. Required for `crabbox
+**Desktop** - lease capability (`--desktop`) that adds a visible session:
+resize-capable TigerVNC + XFCE on managed cloud Linux, Xvfb + XFCE + x11vnc in
+local containers, or Wayland/GNOME. Required for `crabbox
 vnc`, `crabbox webvnc`, and most `--browser` UI runs.
 
 **Browser** - lease capability (`--browser`) that installs Chrome/Chromium and

--- a/docs/features/azure.md
+++ b/docs/features/azure.md
@@ -229,9 +229,9 @@ back to the public IP. The default is `public`.
 
 ## Desktop
 
-Azure Linux desktop leases use the standard VNC path: Xvfb, a lightweight
-desktop session, x11vnc bound to `127.0.0.1:5900`, and an SSH local tunnel
-created by `crabbox vnc`. Azure native Windows desktop leases use the shared
+Azure Linux desktop leases use the standard VNC path: resize-capable TigerVNC,
+a lightweight XFCE session, VNC bound to `127.0.0.1:5900`, and an SSH local
+tunnel created by `crabbox vnc`. Azure native Windows desktop leases use the shared
 managed Windows bootstrap to install TightVNC, create the local `crabbox`
 administrator, enable auto-logon, and expose VNC only through an SSH tunnel.
 The OpenSSH, Git for Windows, and TightVNC downloads are pinned and SHA-256

--- a/docs/features/capabilities.md
+++ b/docs/features/capabilities.md
@@ -63,9 +63,9 @@ desktop.
 When a managed Linux lease is created with `--desktop` (default `xfce`),
 bootstrap (`internal/cli/bootstrap.go`) installs and enables systemd units for:
 
-- Xvfb on display `:99`;
+- resize-capable TigerVNC on display `:99`;
 - an XFCE4 session (`xfce4-session`, panel, terminal, settings, theme);
-- x11vnc bound to `127.0.0.1:5900` with `-localhost`;
+- VNC bound to `127.0.0.1:5900` with `-localhost yes`;
 - a randomized VNC password at `/var/lib/crabbox/vnc.password`;
 - screenshot and capture tooling: `scrot`, `ffmpeg`, plus input helpers
   (`xdotool`, `wmctrl`, `xclip`, `xsel`).
@@ -205,8 +205,8 @@ For static SSH hosts, capability validation degrades to probe-based detection,
 because Crabbox does not install software on operator-owned machines:
 
 - `--desktop`: probe loopback VNC at `127.0.0.1:5900` over SSH (X11 checks for
-  Xvfb/x11vnc; Wayland/GNOME checks for the compositor and WayVNC). Fail with a
-  clear error if the desktop is not running.
+  Xtigervnc or legacy Xvfb/x11vnc; Wayland/GNOME checks for the compositor and
+  WayVNC). Fail with a clear error if the desktop is not running.
 - `--browser`: probe for a browser binary using the OS-specific search list;
   fail if none is found.
 - `--code` is rejected (managed Linux only).

--- a/docs/features/hetzner.md
+++ b/docs/features/hetzner.md
@@ -91,9 +91,9 @@ CRABBOX_HETZNER_SSH_KEY    # hetzner.sshKey    (reuse a named Hetzner key)
 The Hetzner adapter advertises `ssh`, `crabbox-sync`, `cleanup`, `desktop`,
 `browser`, `code`, and `tailscale`.
 
-- `--desktop` / `--browser` use the Linux VNC path: Xvfb, a lightweight desktop
-  session, and x11vnc bound to `127.0.0.1:5900`. `crabbox vnc` opens an SSH
-  local tunnel to it. See [Linux VNC](vnc-linux.md).
+- `--desktop` / `--browser` use the Linux VNC path: resize-capable TigerVNC and
+  a lightweight XFCE session, with VNC bound to `127.0.0.1:5900`. `crabbox vnc`
+  opens an SSH local tunnel to it. See [Linux VNC](vnc-linux.md).
 - `--code` provisions code-server, bridgeable into the portal with
   `crabbox code`.
 - `--tailscale` joins the lease to a tailnet. In direct mode this requires an

--- a/docs/features/image-bake-runbook.md
+++ b/docs/features/image-bake-runbook.md
@@ -34,7 +34,7 @@ Bake **machine capabilities** that are stable across runs:
 
 - current OS security updates;
 - SSH, Git, rsync, curl, jq, and the readiness helpers;
-- Xvfb / slim XFCE / VNC for desktop leases;
+- TigerVNC / slim XFCE for resize-capable desktop leases;
 - Chrome or Chromium for browser leases;
 - `ffmpeg`, `ffprobe`, `scrot`, `xdotool`, and other capture helpers;
 - Node 24, npm, corepack, pnpm;
@@ -104,7 +104,8 @@ crabbox run \
    command -v pnpm
    command -v ffmpeg
    command -v scrot
-   command -v x11vnc
+   command -v Xtigervnc
+   command -v tigervncpasswd
    command -v google-chrome || command -v chromium || command -v chromium-browser
    test -d /work/crabbox
    sudo mkdir -p /var/cache/crabbox/pnpm

--- a/docs/features/interactive-desktop-vnc.md
+++ b/docs/features/interactive-desktop-vnc.md
@@ -68,9 +68,9 @@ A scenario layer on top of Crabbox owns:
 
 | Target | Managed by Crabbox | Desktop access | Primary page |
 | --- | --- | --- | --- |
-| Linux on Hetzner | Yes | Xvfb/XFCE + x11vnc, or Wayland + WayVNC, over SSH tunnel | [Linux VNC](vnc-linux.md) |
-| Linux on AWS | Yes | Xvfb/XFCE + x11vnc, or Wayland + WayVNC, over SSH tunnel | [Linux VNC](vnc-linux.md) |
-| Linux on Azure | Yes | Xvfb/XFCE + x11vnc, or Wayland + WayVNC, over SSH tunnel | [Linux VNC](vnc-linux.md) |
+| Linux on Hetzner | Yes | TigerVNC/XFCE, or Wayland + WayVNC, over SSH tunnel | [Linux VNC](vnc-linux.md) |
+| Linux on AWS | Yes | TigerVNC/XFCE, or Wayland + WayVNC, over SSH tunnel | [Linux VNC](vnc-linux.md) |
+| Linux on Azure | Yes | TigerVNC/XFCE, or Wayland + WayVNC, over SSH tunnel | [Linux VNC](vnc-linux.md) |
 | AWS Windows | Yes | VNC service over SSH tunnel | [Windows VNC](vnc-windows.md) |
 | Azure Windows | Yes | VNC service over SSH tunnel | [Windows VNC](vnc-windows.md) |
 | AWS EC2 Mac | Yes | Screen Sharing/VNC over SSH tunnel | [macOS VNC](vnc-macos.md) |

--- a/docs/features/prebaked-images.md
+++ b/docs/features/prebaked-images.md
@@ -47,8 +47,8 @@ Bake stable machine capabilities:
 
 - current OS security updates and base packages;
 - core access tooling: SSH, Git, rsync, curl, jq, and the readiness helpers;
-- desktop and browser capabilities for `--desktop --browser` leases (Xvfb, a
-  slim XFCE, x11vnc, Chrome or Chromium);
+- desktop and browser capabilities for `--desktop --browser` leases
+  (resize-capable TigerVNC, slim XFCE, Chrome or Chromium);
 - capture tools such as `ffmpeg`, `ffprobe`, `scrot`, and `xdotool`;
 - language and build toolchains the image targets: Node 24 with corepack/pnpm,
   `build-essential`, Python, and common native-addon headers;

--- a/docs/features/runner-bootstrap.md
+++ b/docs/features/runner-bootstrap.md
@@ -75,8 +75,9 @@ Interactive tooling is opt-in per lease, never part of the minimal bootstrap.
 Each requested capability appends both its install steps and its `crabbox-ready`
 checks, and is gated by the provider's declared feature set.
 
-- `--desktop` — installs a headless desktop. The default XFCE environment adds
-  Xvfb on display `:99`, an XFCE session, and a loopback `x11vnc` on `127.0.0.1:5900`.
+- `--desktop` — installs a headless desktop. The default managed XFCE environment
+  adds resize-capable TigerVNC on display `:99` and an XFCE session, with VNC on
+  `127.0.0.1:5900`.
   With `--desktop-env wayland` (labwc) or `--desktop-env gnome` it installs a
   Wayland session driven by `wayvnc` instead. Readiness checks the relevant
   systemd units and that something is listening on `127.0.0.1:5900`.

--- a/docs/features/vnc-linux.md
+++ b/docs/features/vnc-linux.md
@@ -4,7 +4,7 @@ Read when:
 
 - using `--desktop` on a managed Linux lease (Hetzner, AWS, or Azure);
 - choosing a desktop environment with `--desktop-env` (xfce, wayland, gnome);
-- debugging Xvfb, the window-manager session, x11vnc/WayVNC, or screenshots on a
+- debugging TigerVNC, the window-manager session, WayVNC, or screenshots on a
   Linux lease;
 - preparing a static (BYO) Linux host to serve a Crabbox VNC desktop.
 
@@ -32,10 +32,10 @@ crabbox warmup --desktop --desktop-env gnome
 
 A managed Linux desktop lease provides:
 
-- Xvfb on `:99` (XFCE) or a Wayland compositor (wayland/gnome);
+- resize-capable TigerVNC on `:99` (XFCE) or a Wayland compositor (wayland/gnome);
 - a window-manager / desktop session (`xfce4-session` with `xfwm4`,
   `xfce4-panel`, and `xfce4-terminal` for XFCE);
-- x11vnc (XFCE) or WayVNC (wayland/gnome) bound to `127.0.0.1:5900`;
+- TigerVNC (XFCE) or WayVNC (wayland/gnome) bound to `127.0.0.1:5900`;
 - screenshot and video capture tools (`scrot` and `ffmpeg`);
 - input helpers (`xdotool`, `wmctrl`) and clipboard tools (`xclip`/`xsel`);
 - a generated per-lease VNC password at `/var/lib/crabbox/vnc.password`;
@@ -100,7 +100,8 @@ with the matching `--desktop-env`.
 
 `target=linux does not expose a loopback X11 VNC desktop`
 
-For managed leases, inspect cloud-init and service logs or warm a fresh box.
+For managed leases, inspect the `crabbox-xvfb.service` TigerVNC unit and desktop
+session logs or warm a fresh box.
 For static hosts, start Xvfb/x11vnc on `127.0.0.1:5900`, or warm with
 `--desktop-env wayland` or `--desktop-env gnome` for a configured Wayland
 target.

--- a/docs/plan/vnc.md
+++ b/docs/plan/vnc.md
@@ -117,20 +117,21 @@ These are hard requirements and remain enforced:
 - TTL, idle-timeout, and cleanup behavior are unchanged: cleanup is VM deletion
   for managed providers and a no-op for static hosts.
 
-Linux uses loopback-bound x11vnc with `rfbauth`:
+Managed XFCE Linux uses loopback-bound TigerVNC with password authentication
+and client-requested desktop resizing:
 
 ```text
-x11vnc -display :99 -localhost -rfbport 5900 -forever -shared -rfbauth /var/lib/crabbox/vnc.pass
+Xtigervnc :99 -localhost yes -rfbport 5900 -SecurityTypes VncAuth -PasswordFile=/var/lib/crabbox/vnc.pass -AlwaysShared -AcceptSetDesktopSize
 ```
 
 ## Managed Linux Bootstrap (shipped)
 
 The default bootstrap stays tiny; desktop/browser/code packages are installed
 only when the matching capability is requested. The XFCE path installs a
-lightweight visible-session stack (Xvfb, an XFCE session, x11vnc, fonts, dbus),
-runs it under systemd units (`crabbox-xvfb`, `crabbox-desktop`,
-`crabbox-x11vnc`), and gates readiness checks behind `desktop=true` so plain
-leases never run them. `--browser` installs Chrome stable (Chromium fallback)
+lightweight visible-session stack (TigerVNC, an XFCE session, fonts, dbus),
+runs it under systemd units (`crabbox-xvfb`, `crabbox-desktop`, and
+`crabbox-desktop-session`), and gates readiness checks behind `desktop=true` so
+plain leases never run them. `--browser` installs Chrome stable (Chromium fallback)
 and records the discovered binary path; `--code` installs code-server. Wayland
 and GNOME variants follow the same shape with their own units. Source
 `internal/cli/bootstrap.go`; see [runner-bootstrap](../features/runner-bootstrap.md).

--- a/docs/source-map.md
+++ b/docs/source-map.md
@@ -139,7 +139,7 @@ Bootstrap:
 Bootstrap stays intentionally small unless optional lease capabilities are
 requested: OpenSSH, CA certificates, curl, Git, rsync, jq, the work root
 (`/work/crabbox` on Linux), cache directories, and the `crabbox-ready` readiness
-marker. `--desktop` adds Xvfb, a slim XFCE session, and loopback x11vnc;
+marker. `--desktop` adds resize-capable TigerVNC and a slim XFCE session;
 `--browser` adds Chrome stable with a Chromium fallback; `--code` adds
 code-server for the authenticated portal editor. Project runtimes (Go, Node,
 pnpm, Docker, databases) are repository-owned setup, usually driven through

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -651,7 +651,6 @@ func cloudInitOptionalReadyChecks(cfg Config) string {
 			b.WriteString("      systemctl is-active --quiet crabbox-xvfb.service\n")
 			b.WriteString("      systemctl is-active --quiet crabbox-desktop.service\n")
 			b.WriteString("      systemctl is-active --quiet crabbox-desktop-session.service\n")
-			b.WriteString("      systemctl is-active --quiet crabbox-x11vnc.service\n")
 		}
 		b.WriteString("      ss -ltn | grep -q '127.0.0.1:5900'\n")
 	}
@@ -680,12 +679,12 @@ func cloudInitOptionalWriteFiles(cfg Config) string {
     permissions: '0644'
     content: |
       [Unit]
-      Description=Crabbox Xvfb display
+      Description=Crabbox resize-capable TigerVNC display
       After=network.target
 
       [Service]
       User=crabbox
-      ExecStart=/usr/bin/Xvfb :99 -screen 0 1920x1080x24 -nolisten tcp -ac
+      ExecStart=/usr/bin/Xtigervnc :99 -geometry 1920x1080 -depth 24 -localhost yes -rfbport 5900 -SecurityTypes VncAuth -PasswordFile=/var/lib/crabbox/vnc.pass -AlwaysShared -AcceptSetDesktopSize -nolisten tcp -ac
       Restart=always
 
       [Install]
@@ -939,21 +938,6 @@ func cloudInitOptionalWriteFiles(cfg Config) string {
       User=crabbox
       Environment=DISPLAY=:99
       ExecStart=/usr/local/bin/crabbox-desktop-session
-      Restart=always
-
-      [Install]
-      WantedBy=multi-user.target
-  - path: /etc/systemd/system/crabbox-x11vnc.service
-    permissions: '0644'
-    content: |
-      [Unit]
-      Description=Crabbox loopback VNC server
-      After=crabbox-xvfb.service
-      Requires=crabbox-xvfb.service
-
-      [Service]
-      User=crabbox
-      ExecStart=/usr/bin/x11vnc -display :99 -localhost -rfbport 5900 -forever -shared -rfbauth /var/lib/crabbox/vnc.pass -wait 16 -defer 8 -nowait_bog
       Restart=always
 
       [Install]
@@ -1315,12 +1299,12 @@ chmod 0755 /usr/local/bin/crabbox-configure-desktop-theme
     systemctl enable crabbox-desktop.service crabbox-wayvnc.service
     systemctl restart crabbox-desktop.service crabbox-wayvnc.service`)
 	} else if cfg.Desktop {
-		parts = append(parts, `    retry apt-get install -y --no-install-recommends xvfb xfce4-session xfwm4 xfce4-panel xfdesktop4 xfce4-terminal xfconf xfce4-settings x11vnc xauth dbus-x11 x11-xserver-utils xterm scrot ffmpeg xdotool wmctrl xclip xsel fonts-dejavu-core fonts-liberation iproute2 openssl arc-theme util-linux novnc websockify
+		parts = append(parts, `    retry apt-get install -y --no-install-recommends tigervnc-standalone-server tigervnc-tools xfce4-session xfwm4 xfce4-panel xfdesktop4 xfce4-terminal xfconf xfce4-settings xauth dbus-x11 x11-xserver-utils xterm scrot ffmpeg xdotool wmctrl xclip xsel fonts-dejavu-core fonts-liberation iproute2 openssl arc-theme util-linux novnc websockify
     install -d -m 0750 -o crabbox -g crabbox /var/lib/crabbox
     if [ ! -s /var/lib/crabbox/vnc.password ]; then
       (umask 077 && openssl rand -base64 18 > /var/lib/crabbox/vnc.password)
     fi
-    { head -c 8 /var/lib/crabbox/vnc.password; printf '\n'; head -c 8 /var/lib/crabbox/vnc.password; printf '\n\n'; } | x11vnc -storepasswd /var/lib/crabbox/vnc.pass >/dev/null 2>&1
+    head -c 8 /var/lib/crabbox/vnc.password | tigervncpasswd -f > /var/lib/crabbox/vnc.pass
     chown crabbox:crabbox /var/lib/crabbox/vnc.password /var/lib/crabbox/vnc.pass
     chmod 0600 /var/lib/crabbox/vnc.password /var/lib/crabbox/vnc.pass
     printf 'CRABBOX_DESKTOP_ENV=xfce\nDISPLAY=:99\n' >/var/lib/crabbox/desktop.env
@@ -1328,9 +1312,9 @@ chmod 0755 /usr/local/bin/crabbox-configure-desktop-theme
     chmod 0644 /var/lib/crabbox/desktop.env
     CRABBOX_DESKTOP_USER=crabbox /usr/local/bin/crabbox-configure-desktop-theme
     systemctl daemon-reload
-    systemctl disable --now crabbox-wayvnc.service 2>/dev/null || true
-    systemctl enable crabbox-xvfb.service crabbox-desktop.service crabbox-desktop-session.service crabbox-x11vnc.service
-    systemctl restart crabbox-xvfb.service crabbox-desktop.service crabbox-desktop-session.service crabbox-x11vnc.service`)
+    systemctl disable --now crabbox-wayvnc.service crabbox-x11vnc.service 2>/dev/null || true
+    systemctl enable crabbox-xvfb.service crabbox-desktop.service crabbox-desktop-session.service
+    systemctl restart crabbox-xvfb.service crabbox-desktop.service crabbox-desktop-session.service`)
 	}
 	if cfg.Provider == "gcp" {
 		parts = append(parts, cloudInitGCPExpiryGuardBootstrap())

--- a/internal/cli/bootstrap_test.go
+++ b/internal/cli/bootstrap_test.go
@@ -117,7 +117,7 @@ func TestCloudInitStartsSSHBeforeOptionalDesktopBootstrap(t *testing.T) {
 	cfg.Desktop = true
 	got := cloudInit(cfg, "ssh-ed25519 test")
 	sshIndex := strings.Index(got, "timeout 30s systemctl restart ssh")
-	desktopIndex := strings.Index(got, "retry apt-get install -y --no-install-recommends xvfb")
+	desktopIndex := strings.Index(got, "retry apt-get install -y --no-install-recommends tigervnc-standalone-server")
 	bootstrappedIndex := strings.Index(got, "touch /var/lib/crabbox/bootstrapped")
 	if sshIndex < 0 || desktopIndex < 0 || bootstrappedIndex < 0 {
 		t.Fatalf("cloudInit(desktop) missing expected bootstrap markers")
@@ -135,8 +135,8 @@ func TestCloudInitDesktopProfile(t *testing.T) {
 	cfg.Desktop = true
 	got := cloudInit(cfg, "ssh-ed25519 test")
 	for _, want := range []string{
-		"xvfb xfce4-session xfwm4 xfce4-panel xfdesktop4 xfce4-terminal",
-		"xfconf xfce4-settings x11vnc xauth dbus-x11",
+		"tigervnc-standalone-server tigervnc-tools xfce4-session xfwm4 xfce4-panel",
+		"xfconf xfce4-settings xauth dbus-x11",
 		"x11-xserver-utils xterm scrot ffmpeg xdotool wmctrl xclip xsel",
 		"arc-theme",
 		"util-linux",
@@ -146,7 +146,10 @@ func TestCloudInitDesktopProfile(t *testing.T) {
 		"/etc/systemd/system/crabbox-desktop.service",
 		"/usr/local/bin/crabbox-desktop-session",
 		"/etc/systemd/system/crabbox-desktop-session.service",
-		"/etc/systemd/system/crabbox-x11vnc.service",
+		"ExecStart=/usr/bin/Xtigervnc :99",
+		"-AcceptSetDesktopSize",
+		"-localhost yes",
+		"-SecurityTypes VncAuth",
 		"ExecStart=/usr/bin/startxfce4",
 		"systemctl is-active --quiet crabbox-desktop.service",
 		"systemctl is-active --quiet crabbox-desktop-session.service",
@@ -196,17 +199,18 @@ func TestCloudInitDesktopProfile(t *testing.T) {
 		"xfce4-terminal --title='Crabbox Desktop'",
 		"xterm -title 'Crabbox Desktop'",
 		"(umask 077 && openssl rand -base64 18 > /var/lib/crabbox/vnc.password)",
-		"x11vnc -storepasswd",
-		"-rfbauth /var/lib/crabbox/vnc.pass",
-		"-wait 16 -defer 8 -nowait_bog",
+		"tigervncpasswd -f > /var/lib/crabbox/vnc.pass",
 		"ss -ltn | grep -q '127.0.0.1:5900'",
-		"systemctl disable --now crabbox-wayvnc.service 2>/dev/null || true",
-		"systemctl enable crabbox-xvfb.service crabbox-desktop.service crabbox-desktop-session.service crabbox-x11vnc.service",
-		"systemctl restart crabbox-xvfb.service crabbox-desktop.service crabbox-desktop-session.service crabbox-x11vnc.service",
+		"systemctl disable --now crabbox-wayvnc.service crabbox-x11vnc.service 2>/dev/null || true",
+		"systemctl enable crabbox-xvfb.service crabbox-desktop.service crabbox-desktop-session.service",
+		"systemctl restart crabbox-xvfb.service crabbox-desktop.service crabbox-desktop-session.service",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("cloudInit(desktop) missing %q", want)
 		}
+	}
+	if strings.Contains(got, "/etc/systemd/system/crabbox-x11vnc.service") {
+		t.Fatal("cloudInit(desktop) should not install the fixed-size x11vnc service")
 	}
 }
 

--- a/internal/cli/capabilities.go
+++ b/internal/cli/capabilities.go
@@ -210,7 +210,7 @@ func probeStaticDesktop(ctx context.Context, cfg Config, target SSHTarget) error
 		if isWaylandDesktopEnv(cfg.DesktopEnv) {
 			return exit(2, "target=linux does not expose a Crabbox Wayland desktop; create %s with CRABBOX_DESKTOP_ENV=wayland or gnome, XDG_RUNTIME_DIR, and WAYLAND_DISPLAY, then start the compositor and WayVNC on 127.0.0.1:5900", desktopEnvPath)
 		}
-		return exit(2, "target=linux does not expose a loopback X11 VNC desktop; start Xvfb/x11vnc on 127.0.0.1:5900 or request --desktop-env wayland or gnome for a configured Wayland target")
+		return exit(2, "target=linux does not expose a loopback X11 VNC desktop; start Xtigervnc or Xvfb/x11vnc on 127.0.0.1:5900, or request --desktop-env wayland or gnome")
 	}
 	return nil
 }
@@ -228,7 +228,7 @@ func staticDesktopProbeCommand(cfg Config, target SSHTarget) string {
 			`test -S "$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY" && ` +
 			compositorCheck + ` && pgrep -x wayvnc >/dev/null && ` + vncLoopbackCheckCommand(target)
 	}
-	return `pgrep -f 'Xvfb :99' >/dev/null && pgrep -f x11vnc >/dev/null && ` + vncLoopbackCheckCommand(target)
+	return `{ pgrep -f 'Xtigervnc :99' >/dev/null || { pgrep -f 'Xvfb :99' >/dev/null && pgrep -f x11vnc >/dev/null; }; } && ` + vncLoopbackCheckCommand(target)
 }
 
 func probeDesktopEnv(ctx context.Context, target SSHTarget) (map[string]string, error) {

--- a/internal/cli/coordinator_capabilities_test.go
+++ b/internal/cli/coordinator_capabilities_test.go
@@ -129,7 +129,7 @@ func TestProbeDesktopEnvCommandIncludesXAuthority(t *testing.T) {
 
 func TestStaticDesktopProbeCommandDefaultsToX11(t *testing.T) {
 	got := staticDesktopProbeCommand(Config{}, SSHTarget{TargetOS: targetLinux})
-	for _, want := range []string{"Xvfb :99", "x11vnc"} {
+	for _, want := range []string{"Xtigervnc :99", "Xvfb :99", "x11vnc"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("static x11 probe missing %q:\n%s", want, got)
 		}

--- a/internal/cli/desktop_input.go
+++ b/internal/cli/desktop_input.go
@@ -641,10 +641,10 @@ check() {
   fi
 }
 CRABBOX_REPAIR="ensure DISPLAY=:99 is exported"; [ -n "$DISPLAY" ] && echo "session ok DISPLAY=$DISPLAY" || echo "session failed DISPLAY repair=export DISPLAY=:99"
-CRABBOX_REPAIR="restart crabbox-xvfb.service"; check session xvfb pgrep -f "Xvfb :99"
+CRABBOX_REPAIR="restart crabbox-xvfb.service"; check session display sh -c 'pgrep -f "Xtigervnc :99" >/dev/null || pgrep -f "Xvfb :99" >/dev/null'
 CRABBOX_REPAIR="restart crabbox-desktop.service"; check session xfwm4 pgrep -x xfwm4
 CRABBOX_REPAIR="restart crabbox-desktop.service"; check session panel pgrep -x xfce4-panel
-CRABBOX_REPAIR="restart crabbox-x11vnc.service"; check vm vnc ss -ltn sport = :5900
+CRABBOX_REPAIR="restart crabbox-xvfb.service"; check vm vnc ss -ltn sport = :5900
 CRABBOX_REPAIR="warm a new --desktop lease or install xdotool"; check input xdotool command -v xdotool
 CRABBOX_REPAIR="warm a new --desktop lease or install xclip"; if command -v xclip >/dev/null 2>&1 || command -v xsel >/dev/null 2>&1 || command -v wl-copy >/dev/null 2>&1; then echo "input ok clipboard"; else echo "input failed clipboard repair=$CRABBOX_REPAIR"; fi
 CRABBOX_REPAIR="warm with --browser or install Chrome/Chromium"; if [ -f /var/lib/crabbox/browser.env ]; then . /var/lib/crabbox/browser.env; fi; if [ -n "${BROWSER:-}" ] && [ -x "$BROWSER" ]; then echo "session ok browser=$BROWSER"; elif command -v google-chrome >/dev/null 2>&1 || command -v chromium >/dev/null 2>&1 || command -v chromium-browser >/dev/null 2>&1; then echo "session ok browser"; else echo "session failed browser repair=$CRABBOX_REPAIR"; fi

--- a/internal/cli/webvnc.go
+++ b/internal/cli/webvnc.go
@@ -2163,6 +2163,8 @@ if [ -x /usr/local/bin/crabbox-start-desktop ]; then
   sudo /bin/bash /usr/local/bin/crabbox-start-desktop
 elif [ "${CRABBOX_DESKTOP_ENV:-xfce}" != "xfce" ]; then
   sudo systemctl restart crabbox-desktop.service crabbox-wayvnc.service
+elif systemctl cat crabbox-xvfb.service 2>/dev/null | grep -q Xtigervnc; then
+  sudo systemctl restart crabbox-xvfb.service crabbox-desktop.service crabbox-desktop-session.service
 elif systemctl cat crabbox-desktop.service >/dev/null 2>&1; then
   sudo systemctl restart crabbox-desktop.service crabbox-x11vnc.service
 else

--- a/internal/cli/webvnc_test.go
+++ b/internal/cli/webvnc_test.go
@@ -345,6 +345,7 @@ func TestWebVNCResetRemoteCommandHandlesWaylandAndX11(t *testing.T) {
 		"/usr/local/bin/crabbox-start-desktop",
 		`CRABBOX_DESKTOP_ENV:-xfce`,
 		"crabbox-desktop.service crabbox-wayvnc.service",
+		"crabbox-xvfb.service crabbox-desktop.service crabbox-desktop-session.service",
 		"crabbox-desktop.service crabbox-x11vnc.service",
 		"crabbox-desktop-session.service crabbox-x11vnc.service",
 	} {

--- a/worker/src/bootstrap.ts
+++ b/worker/src/bootstrap.ts
@@ -661,7 +661,6 @@ function optionalReadyChecks(config: LeaseConfig): string {
         "      systemctl is-active --quiet crabbox-xvfb.service",
         "      systemctl is-active --quiet crabbox-desktop.service",
         "      systemctl is-active --quiet crabbox-desktop-session.service",
-        "      systemctl is-active --quiet crabbox-x11vnc.service",
         "      ss -ltn | grep -q '127.0.0.1:5900'",
       );
     }
@@ -780,12 +779,12 @@ ${displayEnv}      EOF
     permissions: '0644'
     content: |
       [Unit]
-      Description=Crabbox Xvfb display
+      Description=Crabbox resize-capable TigerVNC display
       After=network.target
 
       [Service]
       User=crabbox
-      ExecStart=/usr/bin/Xvfb :99 -screen 0 1920x1080x24 -nolisten tcp -ac
+      ExecStart=/usr/bin/Xtigervnc :99 -geometry 1920x1080 -depth 24 -localhost yes -rfbport 5900 -SecurityTypes VncAuth -PasswordFile=/var/lib/crabbox/vnc.pass -AlwaysShared -AcceptSetDesktopSize -nolisten tcp -ac
       Restart=always
 
       [Install]
@@ -1093,21 +1092,6 @@ ${displayEnv}      EOF
 
       [Install]
       WantedBy=multi-user.target
-  - path: /etc/systemd/system/crabbox-x11vnc.service
-    permissions: '0644'
-    content: |
-      [Unit]
-      Description=Crabbox loopback VNC server
-      After=crabbox-xvfb.service
-      Requires=crabbox-xvfb.service
-
-      [Service]
-      User=crabbox
-      ExecStart=/usr/bin/x11vnc -display :99 -localhost -rfbport 5900 -forever -shared -rfbauth /var/lib/crabbox/vnc.pass -wait 16 -defer 8 -nowait_bog
-      Restart=always
-
-      [Install]
-      WantedBy=multi-user.target
 `;
 }
 
@@ -1392,12 +1376,12 @@ ${themeConfigure}    systemctl daemon-reload
     systemctl enable crabbox-desktop.service crabbox-wayvnc.service
     systemctl restart crabbox-desktop.service crabbox-wayvnc.service`);
   } else if (config.desktop) {
-    parts.push(`    retry apt-get install -y --no-install-recommends xvfb xfce4-session xfwm4 xfce4-panel xfdesktop4 xfce4-terminal xfconf xfce4-settings x11vnc xauth dbus-x11 x11-xserver-utils xterm scrot ffmpeg xdotool wmctrl xclip xsel fonts-dejavu-core fonts-liberation iproute2 openssl arc-theme util-linux novnc websockify
+    parts.push(`    retry apt-get install -y --no-install-recommends tigervnc-standalone-server tigervnc-tools xfce4-session xfwm4 xfce4-panel xfdesktop4 xfce4-terminal xfconf xfce4-settings xauth dbus-x11 x11-xserver-utils xterm scrot ffmpeg xdotool wmctrl xclip xsel fonts-dejavu-core fonts-liberation iproute2 openssl arc-theme util-linux novnc websockify
     install -d -m 0750 -o crabbox -g crabbox /var/lib/crabbox
     if [ ! -s /var/lib/crabbox/vnc.password ]; then
       (umask 077 && openssl rand -base64 18 > /var/lib/crabbox/vnc.password)
     fi
-    { head -c 8 /var/lib/crabbox/vnc.password; printf '\\n'; head -c 8 /var/lib/crabbox/vnc.password; printf '\\n\\n'; } | x11vnc -storepasswd /var/lib/crabbox/vnc.pass >/dev/null 2>&1
+    head -c 8 /var/lib/crabbox/vnc.password | tigervncpasswd -f > /var/lib/crabbox/vnc.pass
     chown crabbox:crabbox /var/lib/crabbox/vnc.password /var/lib/crabbox/vnc.pass
     chmod 0600 /var/lib/crabbox/vnc.password /var/lib/crabbox/vnc.pass
     printf 'CRABBOX_DESKTOP_ENV=xfce\\nDISPLAY=:99\\n' >/var/lib/crabbox/desktop.env
@@ -1405,9 +1389,9 @@ ${themeConfigure}    systemctl daemon-reload
     chmod 0644 /var/lib/crabbox/desktop.env
     CRABBOX_DESKTOP_USER=crabbox /usr/local/bin/crabbox-configure-desktop-theme
     systemctl daemon-reload
-    systemctl disable --now crabbox-wayvnc.service 2>/dev/null || true
-    systemctl enable crabbox-xvfb.service crabbox-desktop.service crabbox-desktop-session.service crabbox-x11vnc.service
-    systemctl restart crabbox-xvfb.service crabbox-desktop.service crabbox-desktop-session.service crabbox-x11vnc.service`);
+    systemctl disable --now crabbox-wayvnc.service crabbox-x11vnc.service 2>/dev/null || true
+    systemctl enable crabbox-xvfb.service crabbox-desktop.service crabbox-desktop-session.service
+    systemctl restart crabbox-xvfb.service crabbox-desktop.service crabbox-desktop-session.service`);
   }
   if (config.browser) {
     parts.push(`    retry apt-get install -y --no-install-recommends gnupg build-essential python3

--- a/worker/test/bootstrap.test.ts
+++ b/worker/test/bootstrap.test.ts
@@ -122,8 +122,10 @@ describe("cloud-init bootstrap", () => {
 
   it("adds desktop services only when requested", () => {
     const got = cloudInit({ ...config, desktop: true });
-    expect(got).toContain("xvfb xfce4-session xfwm4 xfce4-panel xfdesktop4 xfce4-terminal");
-    expect(got).toContain("xfconf xfce4-settings x11vnc xauth dbus-x11");
+    expect(got).toContain(
+      "tigervnc-standalone-server tigervnc-tools xfce4-session xfwm4 xfce4-panel",
+    );
+    expect(got).toContain("xfconf xfce4-settings xauth dbus-x11");
     expect(got).toContain("arc-theme");
     expect(got).toContain("util-linux");
     expect(got).toContain("novnc websockify");
@@ -132,7 +134,11 @@ describe("cloud-init bootstrap", () => {
     expect(got).toContain("/etc/systemd/system/crabbox-desktop.service");
     expect(got).toContain("/usr/local/bin/crabbox-desktop-session");
     expect(got).toContain("/etc/systemd/system/crabbox-desktop-session.service");
-    expect(got).toContain("/etc/systemd/system/crabbox-x11vnc.service");
+    expect(got).not.toContain("/etc/systemd/system/crabbox-x11vnc.service");
+    expect(got).toContain("ExecStart=/usr/bin/Xtigervnc :99");
+    expect(got).toContain("-AcceptSetDesktopSize");
+    expect(got).toContain("-localhost yes");
+    expect(got).toContain("-SecurityTypes VncAuth");
     expect(got).toContain("ExecStart=/usr/bin/startxfce4");
     expect(got).toContain("systemctl is-active --quiet crabbox-desktop.service");
     expect(got).toContain("systemctl is-active --quiet crabbox-desktop-session.service");
@@ -202,15 +208,16 @@ describe("cloud-init bootstrap", () => {
     expect(got).toContain("xfce4-terminal --title='Crabbox Desktop'");
     expect(got).toContain("xterm -title 'Crabbox Desktop'");
     expect(got).toContain("(umask 077 && openssl rand -base64 18 > /var/lib/crabbox/vnc.password)");
-    expect(got).toContain("-rfbauth /var/lib/crabbox/vnc.pass");
-    expect(got).toContain("-wait 16 -defer 8 -nowait_bog");
+    expect(got).toContain("tigervncpasswd -f > /var/lib/crabbox/vnc.pass");
     expect(got).toContain("ss -ltn | grep -q '127.0.0.1:5900'");
-    expect(got).toContain("systemctl disable --now crabbox-wayvnc.service 2>/dev/null || true");
     expect(got).toContain(
-      "systemctl enable crabbox-xvfb.service crabbox-desktop.service crabbox-desktop-session.service crabbox-x11vnc.service",
+      "systemctl disable --now crabbox-wayvnc.service crabbox-x11vnc.service 2>/dev/null || true",
     );
     expect(got).toContain(
-      "systemctl restart crabbox-xvfb.service crabbox-desktop.service crabbox-desktop-session.service crabbox-x11vnc.service",
+      "systemctl enable crabbox-xvfb.service crabbox-desktop.service crabbox-desktop-session.service",
+    );
+    expect(got).toContain(
+      "systemctl restart crabbox-xvfb.service crabbox-desktop.service crabbox-desktop-session.service",
     );
   });
 
@@ -323,7 +330,9 @@ describe("cloud-init bootstrap", () => {
   it("starts ssh before optional desktop and browser bootstrap", () => {
     const got = cloudInit({ ...config, desktop: true, browser: true });
     const sshIndex = got.indexOf("systemctl restart ssh");
-    const desktopIndex = got.indexOf("retry apt-get install -y --no-install-recommends xvfb");
+    const desktopIndex = got.indexOf(
+      "retry apt-get install -y --no-install-recommends tigervnc-standalone-server",
+    );
     const browserIndex = got.indexOf("retry apt-get install -y --no-install-recommends gnupg");
     const bootstrappedIndex = got.indexOf("touch /var/lib/crabbox/bootstrapped");
     expect(sshIndex).toBeGreaterThanOrEqual(0);


### PR DESCRIPTION
## Summary

- replace fixed-size Xvfb/x11vnc for managed XFCE workspaces with a loopback-only TigerVNC virtual X server
- preserve the existing VNC password and loopback security boundary
- keep probes and repair paths compatible with already-running Xvfb/x11vnc workspaces
- remove the separate x11vnc service from newly provisioned workspaces

## Testing

- `go test ./internal/cli -run '^(TestCloudInit.*|TestStaticDesktopProbeCommandDefaultsToX11|TestWebVNCResetRemoteCommandHandlesWaylandAndX11)$' -count=1`
- `go test ./internal/cli -run '^$'`
- `worker/node_modules/.bin/vitest run` (24 files, 686 tests)
- `worker/node_modules/.bin/tsgo --noEmit`
- `worker/node_modules/.bin/oxlint --config .oxlintrc.json src/bootstrap.ts test/bootstrap.test.ts`
- `node scripts/build-docs-site.mjs`
- Ubuntu 24.04 package/flag smoke: `/usr/bin/Xtigervnc`, `/usr/bin/tigervncpasswd`, `AcceptSetDesktopSize`, loopback, password, and shared-session flags available
- Ubuntu 24.04 live VNC resize: client requested 1280×720; server reported `current 1280 x 720`, from initial 1920×1080

The full `go test ./internal/cli` run reached unrelated controller lifecycle flakes; the full package compiles and all changed-path tests pass.

## Review follow-up

- updated managed Linux, provider, command, capability, and image-bake docs from Xvfb/x11vnc to resize-capable TigerVNC
- retained legacy Xvfb/x11vnc wording only for static hosts, local containers, the public reusable bootstrap, and compatibility probes
- retained the changelog entry because workspace policy requires maintainer/AI changelog coverage for user-facing fixes
