### PR TITLE
Reject unsafe portal return targets

### DIFF
--- a/worker/src/oauth.ts
+++ b/worker/src/oauth.ts
@@ -673,10 +673,18 @@ function safePortalReturnTo(value: string | null): string {
   if (!value || !value.startsWith("/portal")) {
     return "/portal";
   }
-  if (value.startsWith("//") || value.includes("://")) {
+  if (value.startsWith("//") || value.includes("://") || hasHeaderControlCharacter(value)) {
     return "/portal";
   }
   return value;
+}
+
+function hasHeaderControlCharacter(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code <= 0x1f || code === 0x7f) return true;
+  }
+  return false;
 }
 
 function escapeHTML(value: string): string {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -18003,7 +18003,13 @@ describe("fleet identity", () => {
     expect(callback.headers.get("set-cookie")).toContain("crabbox_session=cbxu_");
   });
 
-  it("drops portal return targets with header control characters", async () => {
+  it.each([
+    ["CRLF", "/portal/leases/cbx_1/vnc%0d%0aSet-Cookie:%20oops"],
+    ["CR", "/portal/leases/cbx_1/vnc%0dSet-Cookie:%20oops"],
+    ["LF", "/portal/leases/cbx_1/vnc%0aSet-Cookie:%20oops"],
+    ["NUL", "/portal/leases/cbx_1/vnc%00oops"],
+    ["DEL", "/portal/leases/cbx_1/vnc%7foops"],
+  ])("drops portal return targets containing %s", async (_label, returnTo) => {
     const storage = new MemoryStorage();
     const fleet = new FleetDurableObject(
       { storage } as unknown as DurableObjectState,
@@ -18015,9 +18021,7 @@ describe("fleet identity", () => {
         CRABBOX_SESSION_SECRET: "session-secret",
       } as Env,
     );
-    const start = await fleet.fetch(
-      request("GET", "/portal/login?returnTo=/portal/leases/cbx_1/vnc%0d%0aSet-Cookie:%20oops"),
-    );
+    const start = await fleet.fetch(request("GET", `/portal/login?returnTo=${returnTo}`));
     expect(start.status).toBe(302);
     const location = start.headers.get("location") ?? "";
     const state = new URL(location).searchParams.get("state");

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -18003,6 +18003,35 @@ describe("fleet identity", () => {
     expect(callback.headers.get("set-cookie")).toContain("crabbox_session=cbxu_");
   });
 
+  it("drops portal return targets with header control characters", async () => {
+    const storage = new MemoryStorage();
+    const fleet = new FleetDurableObject(
+      { storage } as unknown as DurableObjectState,
+      {
+        CRABBOX_DEFAULT_ORG: "openclaw",
+        CRABBOX_GITHUB_CLIENT_ID: "github-client",
+        CRABBOX_GITHUB_CLIENT_SECRET: "github-secret",
+        CRABBOX_SHARED_TOKEN: "shared",
+        CRABBOX_SESSION_SECRET: "session-secret",
+      } as Env,
+    );
+    const start = await fleet.fetch(
+      request("GET", "/portal/login?returnTo=/portal/leases/cbx_1/vnc%0d%0aSet-Cookie:%20oops"),
+    );
+    expect(start.status).toBe(302);
+    const location = start.headers.get("location") ?? "";
+    const state = new URL(location).searchParams.get("state");
+    expect(state).toBeTruthy();
+
+    vi.stubGlobal("fetch", githubFetchMock({ member: true }));
+    const callback = await fleet.fetch(
+      request("GET", `/v1/auth/github/callback?code=ok&state=${state}`),
+    );
+    expect(callback.status).toBe(302);
+    expect(callback.headers.get("location")).toBe("/portal");
+    expect(callback.headers.get("set-cookie")).toContain("crabbox_session=cbxu_");
+  });
+
   it("clears portal session on logout without restarting OAuth", async () => {
     const fleet = testFleet();
     const logout = await fleet.fetch(request("GET", "/portal/logout"));


### PR DESCRIPTION
Closes https://github.com/openclaw/crabbox/issues/717.

Summary:

- reject portal return targets containing HTTP header control characters before storing OAuth state
- cover CRLF, CR, LF, NUL, and DEL targets through the complete portal OAuth callback flow

Verification:

- `npm test --prefix worker -- fleet.test.ts -t 'drops portal return targets containing'` (5 passed)
- `npm test --prefix worker` (24 files, 691 tests passed)
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- autoreview clean (0.88)
