### PR TITLE
Redact Daytona provider secrets in errors

### DIFF
--- a/internal/providers/daytona/backend_run_test.go
+++ b/internal/providers/daytona/backend_run_test.go
@@ -168,6 +168,31 @@ func TestUploadDaytonaFileStreamDoesNotPrebuffer(t *testing.T) {
 	}
 }
 
+func TestUploadDaytonaFileStreamRedactsAuthorizationFromError(t *testing.T) {
+	const token = "daytona-provider-secret"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer "+token {
+			t.Fatalf("authorization=%q", got)
+		}
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`{"authorization":"Bearer ` + token + `","message":"upload failed for ` + token + `"}`))
+	}))
+	defer srv.Close()
+
+	err := uploadDaytonaFileStream(t.Context(), srv.Client(), srv.URL+"/files/upload?path=%2Ftmp%2Farchive.tgz", map[string]string{
+		"Authorization": "Bearer " + token,
+	}, strings.NewReader("archive"), "archive.tgz")
+	if err == nil {
+		t.Fatal("expected upload error")
+	}
+	if strings.Contains(err.Error(), token) {
+		t.Fatalf("err=%q still contains token", err.Error())
+	}
+	if !strings.Contains(err.Error(), daytonaTokenRedacted) {
+		t.Fatalf("err=%q, want redacted token marker", err.Error())
+	}
+}
+
 func TestDaytonaAuthRequiresOrganizationForJWT(t *testing.T) {
 	cfg := baseConfig()
 	cfg.Provider = daytonaProvider

--- a/internal/providers/daytona/client.go
+++ b/internal/providers/daytona/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -236,7 +237,7 @@ func (c *daytonaSDKClient) CreateSandbox(ctx context.Context, body daytona.Creat
 		req = req.XDaytonaOrganizationID(c.orgID)
 	}
 	out, _, err := req.Execute()
-	return out, err
+	return out, c.redactError(err)
 }
 
 func (c *daytonaSDKClient) GetSandbox(ctx context.Context, id string) (*daytona.Sandbox, error) {
@@ -245,7 +246,7 @@ func (c *daytonaSDKClient) GetSandbox(ctx context.Context, id string) (*daytona.
 		req = req.XDaytonaOrganizationID(c.orgID)
 	}
 	out, _, err := req.Execute()
-	return out, err
+	return out, c.redactError(err)
 }
 
 func (c *daytonaSDKClient) ListCrabboxSandboxes(ctx context.Context) ([]daytona.Sandbox, error) {
@@ -262,7 +263,7 @@ func (c *daytonaSDKClient) ListCrabboxSandboxes(ctx context.Context) ([]daytona.
 		}
 		out, _, err := req.Execute()
 		if err != nil {
-			return nil, err
+			return nil, c.redactError(err)
 		}
 		if out == nil {
 			return all, nil
@@ -343,7 +344,7 @@ func (c *daytonaSDKClient) StartSandbox(ctx context.Context, id string) (*dayton
 		req = req.XDaytonaOrganizationID(c.orgID)
 	}
 	out, _, err := req.Execute()
-	return out, err
+	return out, c.redactError(err)
 }
 
 func (c *daytonaSDKClient) DeleteSandbox(ctx context.Context, id string) error {
@@ -352,7 +353,7 @@ func (c *daytonaSDKClient) DeleteSandbox(ctx context.Context, id string) error {
 		req = req.XDaytonaOrganizationID(c.orgID)
 	}
 	_, _, err := req.Execute()
-	return err
+	return c.redactError(err)
 }
 
 func (c *daytonaSDKClient) ReplaceLabels(ctx context.Context, id string, labels map[string]string) error {
@@ -361,7 +362,7 @@ func (c *daytonaSDKClient) ReplaceLabels(ctx context.Context, id string, labels 
 		req = req.XDaytonaOrganizationID(c.orgID)
 	}
 	_, _, err := req.Execute()
-	return err
+	return c.redactError(err)
 }
 
 func (c *daytonaSDKClient) UpdateLastActivity(ctx context.Context, id string) error {
@@ -370,7 +371,7 @@ func (c *daytonaSDKClient) UpdateLastActivity(ctx context.Context, id string) er
 		req = req.XDaytonaOrganizationID(c.orgID)
 	}
 	_, err := req.Execute()
-	return err
+	return c.redactError(err)
 }
 
 func (c *daytonaSDKClient) CreateSSHAccess(ctx context.Context, id string, ttl time.Duration) (daytonaSSHAccess, error) {
@@ -380,7 +381,7 @@ func (c *daytonaSDKClient) CreateSSHAccess(ctx context.Context, id string, ttl t
 	}
 	out, _, err := req.Execute()
 	if err != nil {
-		return daytonaSSHAccess{}, err
+		return daytonaSSHAccess{}, c.redactError(err)
 	}
 	if out == nil || out.GetToken() == "" {
 		return daytonaSSHAccess{}, fmt.Errorf("daytona ssh access response missing token")
@@ -388,18 +389,87 @@ func (c *daytonaSDKClient) CreateSSHAccess(ctx context.Context, id string, ttl t
 	return daytonaSSHAccess{Token: out.GetToken(), Command: out.GetSshCommand()}, nil
 }
 
-func daytonaError(action string, err error) error {
+func (c *daytonaSDKClient) redactError(err error) error {
 	if err == nil {
 		return nil
 	}
 	var apiErr *daytona.GenericOpenAPIError
 	if errors.As(err, &apiErr) {
-		body := strings.TrimSpace(summarizeJSON(apiErr.Body()))
+		return &redactedDaytonaAPIError{
+			err:     err,
+			message: redactDaytonaSecrets(apiErr.Error(), c.token),
+			body:    []byte(redactDaytonaSecrets(string(apiErr.Body()), c.token)),
+		}
+	}
+	return err
+}
+
+type redactedDaytonaAPIError struct {
+	err     error
+	message string
+	body    []byte
+}
+
+func (e *redactedDaytonaAPIError) Error() string {
+	return e.message
+}
+
+func (e *redactedDaytonaAPIError) Body() []byte {
+	return e.body
+}
+
+func (e *redactedDaytonaAPIError) Unwrap() error {
+	return e.err
+}
+
+func daytonaError(action string, err error) error {
+	if err == nil {
+		return nil
+	}
+	var redactedAPIError *redactedDaytonaAPIError
+	if errors.As(err, &redactedAPIError) {
+		body := strings.TrimSpace(redactDaytonaSecrets(summarizeJSON(redactedAPIError.Body())))
 		if body != "" {
-			return fmt.Errorf("daytona %s: %s: %s", action, apiErr.Error(), body)
+			return fmt.Errorf("daytona %s: %s: %s", action, redactDaytonaSecrets(redactedAPIError.Error()), body)
+		}
+		return fmt.Errorf("daytona %s: %s", action, redactDaytonaSecrets(redactedAPIError.Error()))
+	}
+	var apiErr *daytona.GenericOpenAPIError
+	if errors.As(err, &apiErr) {
+		body := strings.TrimSpace(redactDaytonaSecrets(summarizeJSON(apiErr.Body())))
+		if body != "" {
+			return fmt.Errorf("daytona %s: %s: %s", action, redactDaytonaSecrets(apiErr.Error()), body)
 		}
 	}
 	return fmt.Errorf("daytona %s: %w", action, err)
+}
+
+var daytonaBearerPattern = regexp.MustCompile(`(?i)\bbearer\s+[^\s"',;\\]+`)
+
+func redactDaytonaSecrets(value string, secrets ...string) string {
+	redacted := value
+	for _, secret := range secrets {
+		secret = strings.TrimSpace(secret)
+		if secret != "" {
+			redacted = strings.ReplaceAll(redacted, secret, daytonaTokenRedacted)
+		}
+	}
+	redacted = daytonaBearerPattern.ReplaceAllString(redacted, "Bearer "+daytonaTokenRedacted)
+	for _, key := range []string{"authorization", "apiKey", "api_key", "accessToken", "access_token", "jwtToken", "jwt_token", "token"} {
+		redacted = redactDaytonaJSONSecretField(redacted, key)
+	}
+	return redacted
+}
+
+func redactDaytonaJSONSecretField(value, key string) string {
+	pattern := regexp.MustCompile(`(?i)"` + regexp.QuoteMeta(key) + `"\s*:\s*"[^"]*"`)
+	return pattern.ReplaceAllStringFunc(value, func(match string) string {
+		colon := strings.Index(match, ":")
+		if colon < 0 {
+			return match
+		}
+		return match[:colon+1] + `"` + daytonaTokenRedacted + `"`
+	})
 }
 
 func daytonaIsNotFoundError(err error) bool {

--- a/internal/providers/daytona/client_test.go
+++ b/internal/providers/daytona/client_test.go
@@ -83,7 +83,7 @@ func TestResolveDaytonaSandboxDirectLookupErrorHandling(t *testing.T) {
 		case "/sandbox/missing":
 			http.Error(w, `{"message":"sandbox not found"}`, http.StatusNotFound)
 		case "/sandbox/denied":
-			http.Error(w, `{"message":"bad token"}`, http.StatusUnauthorized)
+			http.Error(w, `{"authorization":"Bearer api-token","message":"bad token api-token"}`, http.StatusUnauthorized)
 		default:
 			http.NotFound(w, r)
 		}
@@ -112,6 +112,9 @@ func TestResolveDaytonaSandboxDirectLookupErrorHandling(t *testing.T) {
 	_, _, err = resolveDaytonaSandbox(context.Background(), client, Config{}, "denied")
 	if err == nil || !strings.Contains(err.Error(), "daytona get sandbox: 401 Unauthorized") {
 		t.Fatalf("denied err=%v, want preserved get-sandbox failure", err)
+	}
+	if strings.Contains(err.Error(), "api-token") {
+		t.Fatalf("denied err=%v still contains token", err)
 	}
 	if strings.Contains(err.Error(), "sandbox not found") {
 		t.Fatalf("denied err=%v, want no not-found rewrite", err)

--- a/internal/providers/daytona/upload.go
+++ b/internal/providers/daytona/upload.go
@@ -102,7 +102,8 @@ func uploadDaytonaFileStream(ctx context.Context, client *http.Client, endpoint 
 		_ = pr.CloseWithError(fmt.Errorf("daytona upload archive: %s", resp.Status))
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		if len(body) > 0 {
-			return fmt.Errorf("daytona upload archive: %s: %s", resp.Status, strings.TrimSpace(string(body)))
+			message := strings.TrimSpace(redactDaytonaSecrets(string(body), daytonaHeaderSecrets(headers)...))
+			return fmt.Errorf("daytona upload archive: %s: %s", resp.Status, message)
 		}
 		return fmt.Errorf("daytona upload archive: %s", resp.Status)
 	}
@@ -127,4 +128,22 @@ func writeMultipartFile(pipe *io.PipeWriter, writer *multipart.Writer, file io.R
 		return err
 	}
 	return pipe.Close()
+}
+
+func daytonaHeaderSecrets(headers map[string]string) []string {
+	var secrets []string
+	for key, value := range headers {
+		if !strings.EqualFold(key, "Authorization") {
+			continue
+		}
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		secrets = append(secrets, value)
+		if strings.HasPrefix(strings.ToLower(value), "bearer ") {
+			secrets = append(secrets, strings.TrimSpace(value[len("bearer "):]))
+		}
+	}
+	return secrets
 }


### PR DESCRIPTION
Closes #722.

Summary:
- redact Daytona bearer and API tokens from generated API error bodies before formatting diagnostics
- redact toolbox upload error responses using the Authorization header as a known secret
- add coverage for both Daytona API and upload error body leaks

Proof:
```text
proof: upload diagnostic="daytona upload archive: 502 Bad Gateway: {\"authorization\":\"<token>\",\"message\":\"upload failed for <token>\"}" containsSecret=false redactedMarker=true
proof: api diagnostic="daytona get sandbox: 401 Unauthorized: {\"authorization\":\"<token>\",\"message\":\"bad token \\u003ctoken\\u003e\"}" containsSecret=false redactedMarker=true
PASS
```
