### PR TITLE
[codex] feat: add data runs POC

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -177,7 +177,7 @@ Pick whichever matches your intent:
   [Security](security.md), [Auth and admin](features/auth-admin.md),
   [Repository onboarding](features/repository-onboarding.md),
   [SSH keys](features/ssh-keys.md), [Source Map](source-map.md).
-- **Forward-looking plans:** [Data Runs](plan/data-runs.md) proposal.
+- **POC and plans:** [Data Runs](plan/data-runs.md).
 
 ## About these docs
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -177,6 +177,7 @@ Pick whichever matches your intent:
   [Security](security.md), [Auth and admin](features/auth-admin.md),
   [Repository onboarding](features/repository-onboarding.md),
   [SSH keys](features/ssh-keys.md), [Source Map](source-map.md).
+- **Forward-looking plans:** [Data Runs](plan/data-runs.md) proposal.
 
 ## About these docs
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -65,9 +65,12 @@ See [warmup](commands/warmup.md), [run](commands/run.md),
 crabbox sync-plan [--limit <n>]              preview local sync manifest size hotspots
 crabbox job list                              list repo-local configured jobs
 crabbox job run <name>                        run a configured job
+crabbox data plan <name>                      validate a data run policy
+crabbox data run [--dry-run] <name>           run with data env and manifest proof
 ```
 
-See [sync-plan](commands/sync-plan.md), [job](commands/job.md).
+See [sync-plan](commands/sync-plan.md), [job](commands/job.md),
+[data](commands/data.md).
 
 ### Observability
 

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -18,6 +18,7 @@ same order as the CLI help.
 - [run](run.md)
 - [bench](bench.md)
 - [job](job.md)
+- [data](data.md)
 - [desktop](desktop.md)
 - [media](media.md)
 - [artifacts](artifacts.md)

--- a/docs/commands/data.md
+++ b/docs/commands/data.md
@@ -1,0 +1,144 @@
+# data
+
+Run policy-scoped data commands from repo config.
+
+`crabbox data` is a POC-level wrapper around the existing lease and run
+primitives. It loads `dataRuns.<name>` from config, injects data-specific
+environment variables, runs the configured command, and validates a JSON
+manifest for execute runs. It does not yet add broker-native data history,
+provider-enforced source/sink policy, or promotion.
+
+For the product and architecture plan, see [Data Runs](../plan/data-runs.md).
+
+## Subcommands
+
+| Command | Description |
+| --- | --- |
+| `crabbox data list` | List configured data runs. |
+| `crabbox data plan <name>` | Validate config and print the effective policy/run expansion. |
+| `crabbox data run <name>` | Run in execute mode and require a valid manifest. |
+| `crabbox data run --dry-run <name>` | Run in data dry-run mode. |
+| `crabbox data promote <run-id>` | Reserved; not implemented in the POC. |
+| `crabbox data manifest <run-id>` | Reserved; not implemented in the POC. |
+
+## data list
+
+```sh
+crabbox data list
+```
+
+Prints each configured data run with provider, target, source, sink, and the
+default execute manifest path.
+
+## data plan
+
+```sh
+crabbox data plan normalize-events
+crabbox data plan --mode dry-run normalize-events
+```
+
+`data plan` is read-only. It validates the data run config, prints source/sink
+metadata, shows which policy fields are enforced versus declared-only, and
+prints the expanded `crabbox run` command with the `CRABBOX_DATA_*` environment
+that will be forwarded.
+
+The POC enforces:
+
+- lease TTL and idle timeout through the normal lease path;
+- `policy.requireDryRun` by blocking execute mode when it is true;
+- execute manifest presence through `run --require-artifact`;
+- execute manifest JSON shape through a temporary post-run download.
+
+Source/sink access, identity, egress, row/byte caps, and PII logging policy are
+declared-only in the POC.
+
+## data run
+
+```sh
+crabbox data run normalize-events
+crabbox data run --dry-run normalize-events
+crabbox data run --id blue-lobster normalize-events
+crabbox data run --stop never normalize-events
+```
+
+Execute mode requires the configured command to write a JSON manifest to
+`$CRABBOX_DATA_MANIFEST`, unless `manifest.required: false` is set. The manifest
+must include positive `schemaVersion`, matching `dataRun` and `mode`, plus
+`source` and `sink` objects.
+
+`--dry-run` sets `CRABBOX_DATA_MODE=dry-run` and does not require an execute
+manifest. The command is still responsible for avoiding final-output writes.
+
+### Flags
+
+| Flag | Description |
+| --- | --- |
+| `--id <lease-or-slug>` | Run against an existing lease instead of creating one. |
+| `--no-hydrate` | Skip configured Actions hydration. |
+| `--github-runner` | Hydrate by registering a GitHub self-hosted runner. |
+| `--stop <policy>` | Override stop policy: `auto`, `always`, `success`, `failure`, or `never`. |
+| `--dry-run` | Run the data command in dry-run mode. |
+
+## Environment
+
+`data run` forwards these variables to the remote command:
+
+```text
+CRABBOX_DATA_RUN=1
+CRABBOX_DATA_RUN_NAME=<name>
+CRABBOX_DATA_MODE=execute|dry-run
+CRABBOX_DATA_SOURCE_KIND=<kind>
+CRABBOX_DATA_SOURCE_MODE=read
+CRABBOX_DATA_SOURCE_URI=<uri>
+CRABBOX_DATA_SOURCE_WATERMARK=<watermark>   # when configured
+CRABBOX_DATA_SINK_KIND=<kind>
+CRABBOX_DATA_SINK_MODE=write|write-staging
+CRABBOX_DATA_SINK_URI=<uri>
+CRABBOX_DATA_MANIFEST=<relative manifest path>
+```
+
+## Configuration
+
+```yaml
+dataRuns:
+  normalize-events:
+    provider: aws
+    target: linux
+    ttl: 90m
+
+    source:
+      kind: s3
+      mode: read
+      uri: s3://example-raw/events/
+
+    sink:
+      kind: s3
+      mode: write-staging
+      uri: s3://example-clean/events-staging/
+
+    policy:
+      requireDryRun: true
+      maxRows: 200000000
+      piiLogging: forbid
+
+    command: >
+      python pipelines/normalize_events.py
+        --source "$CRABBOX_DATA_SOURCE_URI"
+        --sink "$CRABBOX_DATA_SINK_URI"
+        --manifest "$CRABBOX_DATA_MANIFEST"
+```
+
+Supported POC fields:
+
+- job/routing fields shared with `jobs`: `provider`, `target`, `windows.mode`,
+  `profile`, `class`, `architecture`, `type`, `market`, `ttl`, `idleTimeout`,
+  `hydrate`, `actions`, `shell`, `command`, `noSync`, `checksum`,
+  `forceSyncLarge`, `label`, `downloads`, and `stop`;
+- `source.kind`, `source.mode`, `source.uri`, `source.watermark`;
+- `sink.kind`, `sink.mode`, `sink.uri`;
+- `policy.requireDryRun`, `policy.maxBytes`, `policy.maxRows`,
+  `policy.piiLogging`, `policy.egress.allow`;
+- `manifest.path`, `manifest.required`.
+
+`source.mode` must be `read`. `sink.mode` defaults to `write-staging` and may be
+`write`.

--- a/docs/commands/data.md
+++ b/docs/commands/data.md
@@ -52,6 +52,9 @@ The POC enforces:
 Source/sink access, identity, egress, row/byte caps, and PII logging policy are
 declared-only in the POC.
 
+Execute mode with a required manifest needs run-file download support. Delegated
+providers without that capability are rejected before lease creation.
+
 ## data run
 
 ```sh
@@ -121,6 +124,7 @@ dataRuns:
       maxRows: 200000000
       piiLogging: forbid
 
+    shell: true
     command: >
       python pipelines/normalize_events.py
         --source "$CRABBOX_DATA_SOURCE_URI"

--- a/docs/plan/data-runs.md
+++ b/docs/plan/data-runs.md
@@ -1,7 +1,8 @@
 # Crabbox Data Runs
 
-Status: proposal. This is not shipped behavior. Current behavior is documented in
-the run, configuration, provider, and artifact docs.
+Status: POC CLI wrapper shipped. Current behavior is documented in
+[data](../commands/data.md). Broker-native data history, provider-enforced
+source/sink policy, promotion, and manifest lookup remain proposed here.
 
 Read when:
 
@@ -108,6 +109,9 @@ crabbox data promote <run-id>
 crabbox data manifest <run-id>
 ```
 
+The POC implements `list`, `plan`, and `run`. `promote` and `manifest` are
+reserved command names that fail clearly until those phases exist.
+
 Later, the same primitive can sit under `run`:
 
 ```sh
@@ -192,10 +196,10 @@ Enforced policy is applied by Crabbox or a provider adapter. Examples:
 Plan output should be explicit:
 
 ```text
-policy source.mode=read enforced=identity
-policy sink.mode=write-staging enforced=identity
+policy ttl=90m enforced=lease
+policy requireDryRun=true enforced=execute-gate
 policy egress.allow declared=only
-policy maxBytes=500GiB enforced=manifest-check
+policy maxBytes=500GiB declared=only
 ```
 
 Core must stay provider-neutral. If policy enforcement needs cloud-specific
@@ -204,7 +208,7 @@ behavior, add a provider hook instead of adding `provider == ...` logic to core.
 ## Implementation
 
 Phase 1 adds `crabbox data` as a CLI wrapper over today's lease/run primitives.
-No Worker schema change is required.
+No Worker schema change is required. The POC slice is shipped.
 
 Phase 1 includes:
 
@@ -212,7 +216,7 @@ Phase 1 includes:
 - `data list`, `data plan`, `data run --dry-run`, and `data run`;
 - reserved env injection for run name, mode, source URI, sink URI, and manifest
   path;
-- manifest validation after command success;
+- execute manifest validation after command success;
 - artifact collection for the manifest and optional quality report;
 - tests for config validation, command expansion, and manifest failure.
 

--- a/docs/plan/data-runs.md
+++ b/docs/plan/data-runs.md
@@ -91,6 +91,7 @@ dataRuns:
       maxRows: 200000000
       piiLogging: forbid
 
+    shell: true
     command: >
       python pipelines/normalize_events.py
         --source "$CRABBOX_DATA_SOURCE_URI"
@@ -140,7 +141,7 @@ metadata and keeps the full file as a normal artifact.
 Suggested path:
 
 ```text
-.crabbox/data/<run-id>/data-manifest.json
+crabbox-data/<run-id>/data-manifest.json
 ```
 
 Minimal shape:
@@ -220,8 +221,8 @@ Phase 1 includes:
 - artifact collection for the manifest and optional quality report;
 - tests for config validation, command expansion, and manifest failure.
 
-Delegated providers that cannot download files after a run may return a bounded
-stdout manifest summary:
+Future delegated-provider support can use a bounded stdout manifest summary
+when the provider cannot download files after a run:
 
 ```text
 CRABBOX_DATA_MANIFEST_BEGIN
@@ -229,7 +230,8 @@ CRABBOX_DATA_MANIFEST_BEGIN
 CRABBOX_DATA_MANIFEST_END
 ```
 
-The file manifest remains preferred for SSH leases.
+The shipped POC validates downloaded file manifests. It rejects delegated
+providers that cannot download run files before lease creation.
 
 Phase 2 makes data runs first-class in brokered run history: run kind, data run
 name, mode, bounded manifest summary, portal/history rendering, and cost/usage

--- a/docs/plan/data-runs.md
+++ b/docs/plan/data-runs.md
@@ -1,0 +1,270 @@
+# Crabbox Data Runs
+
+Status: proposal. This is not shipped behavior. Current behavior is documented in
+the run, configuration, provider, and artifact docs.
+
+Read when:
+
+- evaluating ETL-shaped work for Crabbox;
+- designing runs with scoped production or customer-data access;
+- connecting Crabbox to a scheduler, ingestion tool, or data workflow;
+- reviewing the data boundary for disposable boxes.
+
+## Decision
+
+Build Data Runs as a run class, not an ETL platform.
+
+A data run is a normal Crabbox lease with a data policy attached:
+
+```text
+trigger -> lease box -> sync code -> attach scoped access
+        -> run command -> validate manifest -> record proof -> release
+```
+
+Crabbox owns the execution envelope: lease lifecycle, identity attachment,
+policy metadata, proof collection, audit trail, cost controls, and cleanup. The
+caller owns scheduling, retries, pipeline logic, and warehouse semantics.
+
+Product sentence:
+
+```text
+A short-lived box for every data run.
+```
+
+## Boundary
+
+Data Runs add data-specific proof to the existing loop:
+
+```text
+lease -> sync -> run -> record proof -> release
+```
+
+Do not build a connector catalog, visual pipeline editor, DAG scheduler,
+warehouse, lakehouse, central project secret store, or source-of-truth data
+system.
+
+The broker remains a control plane. Raw data stays on the runner-to-source and
+runner-to-sink path; it must not traverse the broker.
+
+Safe defaults:
+
+```text
+source: read
+scratch: read/write, lease-local, deleted with lease
+sink: write to staging
+promote: explicit, auditable, optional
+```
+
+In-place source mutation is not a default behavior. It needs an explicit promote
+or commit step and a policy that permits it.
+
+## Config Shape
+
+Repository config gets a `dataRuns` section. A data run is a command plus a
+source/sink contract:
+
+```yaml
+dataRuns:
+  normalize-events:
+    provider: aws
+    target: linux
+    ttl: 90m
+
+    source:
+      kind: s3
+      mode: read
+      uri: s3://example-raw/events/
+
+    sink:
+      kind: s3
+      mode: write-staging
+      uri: s3://example-clean/events-staging/
+
+    identity:
+      aws:
+        instanceProfile: crabbox-data-normalize-events
+
+    policy:
+      requireDryRun: true
+      maxBytes: 500GiB
+      maxRows: 200000000
+      piiLogging: forbid
+
+    command: >
+      python pipelines/normalize_events.py
+        --source "$CRABBOX_DATA_SOURCE_URI"
+        --sink "$CRABBOX_DATA_SINK_URI"
+        --manifest "$CRABBOX_DATA_MANIFEST"
+```
+
+Command surface:
+
+```sh
+crabbox data list
+crabbox data plan normalize-events
+crabbox data run normalize-events --dry-run
+crabbox data run normalize-events
+crabbox data promote <run-id>
+crabbox data manifest <run-id>
+```
+
+Later, the same primitive can sit under `run`:
+
+```sh
+crabbox run --data normalize-events --dry-run
+crabbox run --data normalize-events
+```
+
+## Modes
+
+| Mode | Writes | Purpose |
+| --- | --- | --- |
+| `plan` | none | Validate config, identity, reachability, schema, and enforcement tier. |
+| `dry-run` | scratch only | Run on a bounded sample or staging prefix and emit a quality report. |
+| `execute` | approved sink or staging | Run the deterministic command with policy and manifest checks. |
+| `promote` | final sink only | Commit approved staging output to the final target. |
+
+Reasoning or AI assistance belongs in `plan` and `dry-run`. Production writes
+should use pinned code, a pinned image, or a reviewed command.
+
+## Manifest
+
+Every successful `execute` run must emit a manifest unless the config explicitly
+sets `manifest.required: false`. Crabbox stores a bounded summary in run
+metadata and keeps the full file as a normal artifact.
+
+Suggested path:
+
+```text
+.crabbox/data/<run-id>/data-manifest.json
+```
+
+Minimal shape:
+
+```json
+{
+  "schemaVersion": 1,
+  "dataRun": "normalize-events",
+  "runID": "run_abc123",
+  "mode": "execute",
+  "source": {
+    "kind": "s3",
+    "uri": "s3://example-raw/events/",
+    "bytesRead": 1280000000,
+    "rowsRead": 4200000
+  },
+  "sink": {
+    "kind": "s3",
+    "uri": "s3://example-clean/events-staging/run_abc123/",
+    "bytesWritten": 620000000,
+    "rowsWritten": 4199800
+  },
+  "transform": {
+    "repo": "example-org/my-app",
+    "commit": "abc1234",
+    "commandHash": "sha256:..."
+  },
+  "quality": {
+    "status": "passed"
+  }
+}
+```
+
+The manifest is proof, not a data payload. It must not include rows, samples,
+credentials, signed URLs, or connection strings.
+
+## Policy Tiers
+
+Each policy field is either declared or enforced.
+
+Declared policy is visible in plan output, logs, portal views, and automation.
+It makes the contract reviewable even when Crabbox cannot enforce the field.
+
+Enforced policy is applied by Crabbox or a provider adapter. Examples:
+
+- lease TTL and idle timeout;
+- provider identity attachment, such as an instance profile or service account;
+- environment forwarding allowlists;
+- brokered run metadata and audit records;
+- artifact upload size limits;
+- provider or bridge egress allowlists where available.
+
+Plan output should be explicit:
+
+```text
+policy source.mode=read enforced=identity
+policy sink.mode=write-staging enforced=identity
+policy egress.allow declared=only
+policy maxBytes=500GiB enforced=manifest-check
+```
+
+Core must stay provider-neutral. If policy enforcement needs cloud-specific
+behavior, add a provider hook instead of adding `provider == ...` logic to core.
+
+## Implementation
+
+Phase 1 adds `crabbox data` as a CLI wrapper over today's lease/run primitives.
+No Worker schema change is required.
+
+Phase 1 includes:
+
+- config parsing for `dataRuns`;
+- `data list`, `data plan`, `data run --dry-run`, and `data run`;
+- reserved env injection for run name, mode, source URI, sink URI, and manifest
+  path;
+- manifest validation after command success;
+- artifact collection for the manifest and optional quality report;
+- tests for config validation, command expansion, and manifest failure.
+
+Delegated providers that cannot download files after a run may return a bounded
+stdout manifest summary:
+
+```text
+CRABBOX_DATA_MANIFEST_BEGIN
+{ "...": "bounded manifest summary" }
+CRABBOX_DATA_MANIFEST_END
+```
+
+The file manifest remains preferred for SSH leases.
+
+Phase 2 makes data runs first-class in brokered run history: run kind, data run
+name, mode, bounded manifest summary, portal/history rendering, and cost/usage
+grouping. Raw data still stays out of the broker.
+
+Phase 3 adds provider hooks for identity, egress, labeling, policy enforcement
+reporting, and bounded delegated artifact retrieval. The broker rejects a policy
+that requires enforcement when the selected provider cannot enforce it.
+
+Phase 4 adds `crabbox data promote <run-id>`. Promotion runs in a separate
+short-lived data box or provider-native operation with its own manifest. It is
+never a hidden side effect of `execute`.
+
+## Security Rules
+
+- Prefer provider-native short-lived or attached identity over forwarded
+  secrets.
+- Never pass secrets as CLI flags.
+- Do not forward broad cloud env such as `AWS_*` by default.
+- Do not print rows, samples, credentials, signed URLs, or connection strings.
+- Treat manifests and artifacts as potentially sensitive.
+- Make source mutation opt-in and separately reviewable.
+- Require dry-run for high-risk policies.
+- Keep untrusted tenants on separate brokers and cloud accounts.
+
+## First User
+
+The best first user is a software or data team that already has pipeline code,
+an external trigger, managed cloud credentials, and a need for isolated,
+audited, high-compute transforms.
+
+That lets Crabbox win with its strengths: disposable compute, policy metadata,
+remote execution, artifacts, and cleanup.
+
+## Acceptance Criteria
+
+- A dry-run cannot write final outputs.
+- A successful execute run without a required manifest fails.
+- The broker never receives raw source data.
+- Plan output distinguishes enforced policy from declared-only policy.
+- Provider-specific enforcement lives behind provider adapters.
+- Promotion is explicit, audited, and separately reversible.

--- a/docs/source-map.md
+++ b/docs/source-map.md
@@ -175,6 +175,7 @@ Provider docs:
 - Native Windows target archive sync and PowerShell command wrapping: `internal/cli/sync_windows_target.go`, `internal/cli/ssh.go`
 - SSH command output, direct SSH touch, per-lease known_hosts and ControlMaster config: `internal/cli/ssh.go`, `internal/cli/ssh_cmd.go`
 - Named repo-local job orchestration: `internal/cli/job.go`
+- POC data-run orchestration and manifest validation: `internal/cli/data.go`
 - GitHub Actions hydrate/register/dispatch bridge: `internal/cli/actions.go`
 - Actions-first failure capsules: `internal/cli/capsule.go`
 - VM/workspace checkpoints (create/list/inspect/restore/fork/delete/prune): `internal/cli/checkpoint.go`, `internal/cli/checkpoint_native.go`, `internal/cli/checkpoint_store.go`
@@ -211,6 +212,7 @@ Provider docs:
 
 - Configuration precedence and YAML schema: `docs/features/configuration.md` (code: `internal/cli/config.go`, `internal/cli/config_cmd.go`)
 - Jobs: `docs/features/jobs.md` (code: `internal/cli/job.go`)
+- Data Runs: `docs/commands/data.md`, `docs/plan/data-runs.md` (code: `internal/cli/data.go`, config in `internal/cli/config.go`)
 - Identifiers (lease IDs, slugs, claims, run IDs): `docs/features/identifiers.md` (code: `internal/cli/lease.go`, `internal/cli/slug.go`, `internal/cli/claim.go`)
 - Doctor checks: `docs/features/doctor.md` (code: `internal/cli/doctor.go`; readiness API in `worker/src/fleet.ts`)
 - Network and reachability: `docs/features/network.md` (code: `internal/cli/network.go`)

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -77,6 +77,8 @@ func (a App) directCommandHelp(ctx context.Context, args []string) (error, bool)
 		return a.prewarm(ctx, helpArgs), true
 	case "run":
 		return a.runCommand(ctx, helpArgs), true
+	case "data":
+		return nil, false
 	case "job":
 		return nil, false
 	case "sync-plan":
@@ -176,6 +178,7 @@ Commands:
   run         Sync the repo, run a remote command, stream output
   bench       Record and report local benchmark timings
   job         Run named repo-local Crabbox jobs
+  data        Run policy-scoped data commands with manifest proof
   desktop     Launch apps into a visible desktop session
   media       Create preview artifacts from recorded desktop videos
   artifacts   Collect, transform, and publish QA artifacts
@@ -227,6 +230,8 @@ Common Flows:
   crabbox run --timing-record=default -- pnpm test
   crabbox bench run --providers aws,hetzner --repeats 3 -- pnpm test
   crabbox bench report --since 7d
+  crabbox data plan normalize-events
+  crabbox data run --dry-run normalize-events
   crabbox connect blue-lobster
   crabbox ssh --id blue-lobster
   crabbox ports --id blue-lobster --publish 8080

--- a/internal/cli/cli_kong.go
+++ b/internal/cli/cli_kong.go
@@ -22,6 +22,7 @@ type crabboxKongCLI struct {
 	Run         runKongCmd         `cmd:"" passthrough:"" help:"Sync the repo, run a remote command, stream output."`
 	Bench       benchKongCmd       `cmd:"" help:"Record and report local benchmark timings."`
 	Job         jobKongCmd         `cmd:"" help:"Run named repo-local Crabbox jobs."`
+	Data        dataKongCmd        `cmd:"" help:"Run policy-scoped data commands with manifest proof."`
 	Desktop     desktopKongCmd     `cmd:"" help:"Launch apps into a visible desktop session."`
 	Media       mediaKongCmd       `cmd:"" help:"Create preview artifacts from recorded desktop videos."`
 	Artifacts   artifactsKongCmd   `cmd:"" help:"Collect, transform, and publish QA artifacts."`
@@ -127,7 +128,7 @@ func normalizeKongHelpArgs(args []string) []string {
 
 func isKongCommandGroup(command string) bool {
 	switch command {
-	case "actions", "adapter", "admin", "artifacts", "azure", "bench", "cache", "capsule", "checkpoint", "config", "pond", "desktop", "image", "job", "machine", "marketplace", "media", "pool":
+	case "actions", "adapter", "admin", "artifacts", "azure", "bench", "cache", "capsule", "checkpoint", "config", "data", "pond", "desktop", "image", "job", "machine", "marketplace", "media", "pool":
 		return true
 	default:
 		return false
@@ -180,6 +181,28 @@ type jobListKongCmd struct {
 	Args []string `arg:"" optional:""`
 }
 type jobRunKongCmd struct {
+	Args []string `arg:"" optional:""`
+}
+type dataKongCmd struct {
+	List     dataListKongCmd     `cmd:"" passthrough:"" help:"List configured data runs."`
+	Plan     dataPlanKongCmd     `cmd:"" passthrough:"" help:"Validate and print the effective data policy."`
+	Run      dataRunKongCmd      `cmd:"" passthrough:"" help:"Run a configured data run."`
+	Promote  dataPromoteKongCmd  `cmd:"" passthrough:"" help:"Promote staged data output (not implemented in POC)."`
+	Manifest dataManifestKongCmd `cmd:"" passthrough:"" help:"Show a data run manifest (not implemented in POC)."`
+}
+type dataListKongCmd struct {
+	Args []string `arg:"" optional:""`
+}
+type dataPlanKongCmd struct {
+	Args []string `arg:"" optional:""`
+}
+type dataRunKongCmd struct {
+	Args []string `arg:"" optional:""`
+}
+type dataPromoteKongCmd struct {
+	Args []string `arg:"" optional:""`
+}
+type dataManifestKongCmd struct {
 	Args []string `arg:"" optional:""`
 }
 type syncPlanKongCmd struct {
@@ -611,8 +634,17 @@ func (c *benchRecordKongCmd) Run(ctx context.Context, app App) error {
 func (c *benchReportKongCmd) Run(ctx context.Context, app App) error {
 	return app.benchReport(ctx, c.Args)
 }
-func (c *jobListKongCmd) Run(ctx context.Context, app App) error   { return app.jobList(ctx, c.Args) }
-func (c *jobRunKongCmd) Run(ctx context.Context, app App) error    { return app.jobRun(ctx, c.Args) }
+func (c *jobListKongCmd) Run(ctx context.Context, app App) error  { return app.jobList(ctx, c.Args) }
+func (c *jobRunKongCmd) Run(ctx context.Context, app App) error   { return app.jobRun(ctx, c.Args) }
+func (c *dataListKongCmd) Run(ctx context.Context, app App) error { return app.dataList(ctx, c.Args) }
+func (c *dataPlanKongCmd) Run(ctx context.Context, app App) error { return app.dataPlan(ctx, c.Args) }
+func (c *dataRunKongCmd) Run(ctx context.Context, app App) error  { return app.dataRun(ctx, c.Args) }
+func (c *dataPromoteKongCmd) Run(ctx context.Context, app App) error {
+	return app.dataPromote(ctx, c.Args)
+}
+func (c *dataManifestKongCmd) Run(ctx context.Context, app App) error {
+	return app.dataManifest(ctx, c.Args)
+}
 func (c *syncPlanKongCmd) Run(ctx context.Context, app App) error  { return app.syncPlan(ctx, c.Args) }
 func (c *providersKongCmd) Run(ctx context.Context, app App) error { return app.providers(ctx, c.Args) }
 func (c *historyKongCmd) Run(ctx context.Context, app App) error   { return app.history(ctx, c.Args) }

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -230,6 +230,7 @@ type Config struct {
 	Presets                       map[string]PresetConfig
 	ProofTemplates                map[string]ProofTemplateConfig
 	Jobs                          map[string]JobConfig
+	DataRuns                      map[string]DataRunConfig
 }
 
 type SyncConfig struct {
@@ -1375,6 +1376,55 @@ type JobActionsConfig struct {
 	Job      string
 	Ref      string
 	Fields   []string
+}
+
+type DataRunConfig struct {
+	Job      JobConfig
+	Source   DataRunEndpointConfig
+	Sink     DataRunEndpointConfig
+	Identity DataRunIdentityConfig
+	Policy   DataRunPolicyConfig
+	Manifest DataRunManifestConfig
+}
+
+type DataRunEndpointConfig struct {
+	Kind      string
+	Mode      string
+	URI       string
+	Watermark string
+}
+
+type DataRunIdentityConfig struct {
+	AWS   DataRunAWSIdentityConfig
+	GCP   DataRunGCPIdentityConfig
+	Azure DataRunAzureIdentityConfig
+}
+
+type DataRunAWSIdentityConfig struct {
+	InstanceProfile string
+}
+
+type DataRunGCPIdentityConfig struct {
+	ServiceAccount string
+}
+
+type DataRunAzureIdentityConfig struct {
+	ManagedIdentity string
+}
+
+type DataRunPolicyConfig struct {
+	RequireDryRun     bool
+	MaxBytes          string
+	MaxRows           int64
+	AllowSchemaChange *bool
+	PIILogging        string
+	EgressAllow       []string
+}
+
+type DataRunManifestConfig struct {
+	Path        string
+	Required    bool
+	RequiredSet bool
 }
 
 type AccessConfig struct {
@@ -2974,6 +3024,7 @@ type fileConfig struct {
 	Presets                  map[string]filePresetConfig         `yaml:"presets,omitempty"`
 	ProofTemplates           map[string]fileProofTemplateConfig  `yaml:"proofTemplates,omitempty"`
 	Jobs                     map[string]fileJobConfig            `yaml:"jobs,omitempty"`
+	DataRuns                 map[string]fileDataRunConfig        `yaml:"dataRuns,omitempty"`
 	TTL                      string                              `yaml:"ttl,omitempty"`
 	IdleTimeout              string                              `yaml:"idleTimeout,omitempty"`
 	WorkRoot                 string                              `yaml:"workRoot,omitempty"`
@@ -4206,6 +4257,56 @@ type fileJobActionsConfig struct {
 	Job      string   `yaml:"job,omitempty"`
 	Ref      string   `yaml:"ref,omitempty"`
 	Fields   []string `yaml:"fields,omitempty"`
+}
+
+type fileDataRunConfig struct {
+	fileJobConfig `yaml:",inline"`
+	Source        *fileDataRunEndpointConfig `yaml:"source,omitempty"`
+	Sink          *fileDataRunEndpointConfig `yaml:"sink,omitempty"`
+	Identity      *fileDataRunIdentityConfig `yaml:"identity,omitempty"`
+	Policy        *fileDataRunPolicyConfig   `yaml:"policy,omitempty"`
+	Manifest      *fileDataRunManifestConfig `yaml:"manifest,omitempty"`
+}
+
+type fileDataRunEndpointConfig struct {
+	Kind      string `yaml:"kind,omitempty"`
+	Mode      string `yaml:"mode,omitempty"`
+	URI       string `yaml:"uri,omitempty"`
+	Watermark string `yaml:"watermark,omitempty"`
+}
+
+type fileDataRunIdentityConfig struct {
+	AWS   *fileDataRunAWSIdentityConfig   `yaml:"aws,omitempty"`
+	GCP   *fileDataRunGCPIdentityConfig   `yaml:"gcp,omitempty"`
+	Azure *fileDataRunAzureIdentityConfig `yaml:"azure,omitempty"`
+}
+
+type fileDataRunAWSIdentityConfig struct {
+	InstanceProfile string `yaml:"instanceProfile,omitempty"`
+}
+
+type fileDataRunGCPIdentityConfig struct {
+	ServiceAccount string `yaml:"serviceAccount,omitempty"`
+}
+
+type fileDataRunAzureIdentityConfig struct {
+	ManagedIdentity string `yaml:"managedIdentity,omitempty"`
+}
+
+type fileDataRunPolicyConfig struct {
+	RequireDryRun     *bool  `yaml:"requireDryRun,omitempty"`
+	MaxBytes          string `yaml:"maxBytes,omitempty"`
+	MaxRows           int64  `yaml:"maxRows,omitempty"`
+	AllowSchemaChange *bool  `yaml:"allowSchemaChange,omitempty"`
+	PIILogging        string `yaml:"piiLogging,omitempty"`
+	Egress            *struct {
+		Allow []string `yaml:"allow,omitempty"`
+	} `yaml:"egress,omitempty"`
+}
+
+type fileDataRunManifestConfig struct {
+	Path     string `yaml:"path,omitempty"`
+	Required *bool  `yaml:"required,omitempty"`
 }
 
 func configPaths() []string {
@@ -6629,6 +6730,18 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 			cfg.Jobs[name] = applyFileJobConfig(cfg.Jobs[name], job)
 		}
 	}
+	if len(file.DataRuns) > 0 {
+		if cfg.DataRuns == nil {
+			cfg.DataRuns = map[string]DataRunConfig{}
+		}
+		for name, run := range file.DataRuns {
+			name = strings.TrimSpace(name)
+			if name == "" {
+				continue
+			}
+			cfg.DataRuns[name] = applyFileDataRunConfig(cfg.DataRuns[name], run)
+		}
+	}
 	return nil
 }
 
@@ -6877,6 +6990,74 @@ func applyFileJobConfig(job JobConfig, file fileJobConfig) JobConfig {
 		job.Stop = file.Stop
 	}
 	return job
+}
+
+func applyFileDataRunConfig(run DataRunConfig, file fileDataRunConfig) DataRunConfig {
+	run.Job = applyFileJobConfig(run.Job, file.fileJobConfig)
+	if file.Source != nil {
+		run.Source = applyFileDataRunEndpointConfig(run.Source, *file.Source)
+	}
+	if file.Sink != nil {
+		run.Sink = applyFileDataRunEndpointConfig(run.Sink, *file.Sink)
+	}
+	if file.Identity != nil {
+		if file.Identity.AWS != nil && file.Identity.AWS.InstanceProfile != "" {
+			run.Identity.AWS.InstanceProfile = file.Identity.AWS.InstanceProfile
+		}
+		if file.Identity.GCP != nil && file.Identity.GCP.ServiceAccount != "" {
+			run.Identity.GCP.ServiceAccount = file.Identity.GCP.ServiceAccount
+		}
+		if file.Identity.Azure != nil && file.Identity.Azure.ManagedIdentity != "" {
+			run.Identity.Azure.ManagedIdentity = file.Identity.Azure.ManagedIdentity
+		}
+	}
+	if file.Policy != nil {
+		if file.Policy.RequireDryRun != nil {
+			run.Policy.RequireDryRun = *file.Policy.RequireDryRun
+		}
+		if file.Policy.MaxBytes != "" {
+			run.Policy.MaxBytes = file.Policy.MaxBytes
+		}
+		if file.Policy.MaxRows > 0 {
+			run.Policy.MaxRows = file.Policy.MaxRows
+		}
+		if file.Policy.AllowSchemaChange != nil {
+			value := *file.Policy.AllowSchemaChange
+			run.Policy.AllowSchemaChange = &value
+		}
+		if file.Policy.PIILogging != "" {
+			run.Policy.PIILogging = file.Policy.PIILogging
+		}
+		if file.Policy.Egress != nil && len(file.Policy.Egress.Allow) > 0 {
+			run.Policy.EgressAllow = appendUniqueStrings(nil, file.Policy.Egress.Allow...)
+		}
+	}
+	if file.Manifest != nil {
+		if file.Manifest.Path != "" {
+			run.Manifest.Path = file.Manifest.Path
+		}
+		if file.Manifest.Required != nil {
+			run.Manifest.Required = *file.Manifest.Required
+			run.Manifest.RequiredSet = true
+		}
+	}
+	return run
+}
+
+func applyFileDataRunEndpointConfig(endpoint DataRunEndpointConfig, file fileDataRunEndpointConfig) DataRunEndpointConfig {
+	if file.Kind != "" {
+		endpoint.Kind = file.Kind
+	}
+	if file.Mode != "" {
+		endpoint.Mode = file.Mode
+	}
+	if file.URI != "" {
+		endpoint.URI = file.URI
+	}
+	if file.Watermark != "" {
+		endpoint.Watermark = file.Watermark
+	}
+	return endpoint
 }
 
 func applyLeaseDuration(target *time.Duration, value string) {

--- a/internal/cli/data.go
+++ b/internal/cli/data.go
@@ -1,0 +1,457 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const (
+	dataRunModeExecute = "execute"
+	dataRunModeDryRun  = "dry-run"
+)
+
+func (a App) dataList(_ context.Context, args []string) error {
+	fs := newFlagSet("data list", a.Stderr)
+	if err := parseFlags(fs, args); err != nil {
+		return err
+	}
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
+	}
+	names := make([]string, 0, len(cfg.DataRuns))
+	for name := range cfg.DataRuns {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	if len(names) == 0 {
+		fmt.Fprintln(a.Stdout, "no data runs configured")
+		return nil
+	}
+	for _, name := range names {
+		run := cfg.DataRuns[name]
+		manifestPath, _ := dataRunManifestPath(name, dataRunModeExecute, run)
+		fmt.Fprintf(a.Stdout, "%s provider=%s target=%s source=%s:%s sink=%s:%s manifest=%s\n",
+			name,
+			blank(run.Job.Provider, "-"),
+			blank(run.Job.Target, "-"),
+			blank(run.Source.Kind, "-"),
+			blank(run.Source.URI, "-"),
+			blank(run.Sink.Kind, "-"),
+			blank(run.Sink.URI, "-"),
+			blank(manifestPath, "-"),
+		)
+	}
+	return nil
+}
+
+func (a App) dataPlan(_ context.Context, args []string) error {
+	fs := newFlagSet("data plan", a.Stderr)
+	modeFlag := fs.String("mode", dataRunModeExecute, "data run mode: execute or dry-run")
+	if err := parseFlags(fs, args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return exit(2, "usage: crabbox data plan <name>")
+	}
+	mode, err := normalizeDataRunMode(*modeFlag)
+	if err != nil {
+		return err
+	}
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
+	}
+	name := fs.Arg(0)
+	run, err := configuredDataRun(cfg, name)
+	if err != nil {
+		return err
+	}
+	if err := validateDataRunConfig(name, run); err != nil {
+		return err
+	}
+	manifestPath, err := dataRunManifestPath(name, mode, run)
+	if err != nil {
+		return err
+	}
+	dataRunPrintPlan(a.Stdout, cfg, name, run, mode, manifestPath)
+	return nil
+}
+
+func (a App) dataRun(ctx context.Context, args []string) (err error) {
+	fs := newFlagSet("data run", a.Stderr)
+	id := fs.String("id", "", "existing lease id or slug")
+	noHydrate := fs.Bool("no-hydrate", false, "skip configured Actions hydration")
+	githubRunner := fs.Bool("github-runner", false, "hydrate by registering a GitHub self-hosted runner instead of local SSH execution")
+	stopOverride := fs.String("stop", "", "stop policy: auto, always, success, failure, never")
+	dryRun := fs.Bool("dry-run", false, "run in data dry-run mode instead of execute mode")
+	if err := parseFlags(fs, args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return exit(2, "usage: crabbox data run <name>")
+	}
+	mode := dataRunModeExecute
+	if *dryRun {
+		mode = dataRunModeDryRun
+	}
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
+	}
+	name := fs.Arg(0)
+	run, err := configuredDataRun(cfg, name)
+	if err != nil {
+		return err
+	}
+	if err := validateDataRunConfig(name, run); err != nil {
+		return err
+	}
+	if mode == dataRunModeExecute && run.Policy.RequireDryRun {
+		return exit(2, "data run %q requires dry-run first; run `crabbox data run --dry-run %s`, then set policy.requireDryRun=false for execute until broker dry-run history exists", name, name)
+	}
+	stopPolicy := normalizeJobStopPolicy(run.Job.Stop, *stopOverride)
+	if err := validateJobStopPolicy(stopPolicy); err != nil {
+		return err
+	}
+	manifestPath, err := dataRunManifestPath(name, mode, run)
+	if err != nil {
+		return err
+	}
+	leaseID := strings.TrimSpace(*id)
+	createdLease := leaseID == ""
+	runNoHydrate := *noHydrate || !run.Job.Hydrate.Actions
+	if createdLease {
+		var out strings.Builder
+		warmupApp := App{Stdout: io.MultiWriter(a.Stdout, &out), Stderr: a.Stderr}
+		if err := warmupApp.warmup(ctx, append(jobLeaseCreateArgs(cfg, run.Job), "--keep=true")); err != nil {
+			return err
+		}
+		leaseID = parseWarmupLeaseID(out.String())
+		if leaseID == "" {
+			return exit(2, "data run %q could not parse warmup lease id", name)
+		}
+	}
+	shouldStop := false
+	if createdLease {
+		shouldStop = stopPolicy == "" || stopPolicy == "auto" || stopPolicy == "always" || stopPolicy == "success" || stopPolicy == "failure"
+	} else {
+		shouldStop = stopPolicy == "always" || stopPolicy == "success" || stopPolicy == "failure"
+	}
+	defer func() {
+		if !shouldStop {
+			return
+		}
+		if stopPolicy == "success" && err != nil {
+			return
+		}
+		if stopPolicy == "failure" && err == nil {
+			return
+		}
+		stopArgs := append(jobStopRoutingArgs(run.Job), leaseID)
+		if stopErr := a.stop(context.Background(), stopArgs); stopErr != nil && err == nil {
+			err = stopErr
+		}
+	}()
+	if run.Job.Hydrate.Actions && !*noHydrate {
+		if hydrateErr := a.actionsHydrate(ctx, jobActionsHydrateArgs(run.Job, leaseID, *githubRunner)); hydrateErr != nil {
+			err = hydrateErr
+			return err
+		}
+	}
+	manifestDownload := ""
+	if dataRunManifestRequired(mode, run) {
+		tmp, err := os.MkdirTemp("", "crabbox-data-manifest-*")
+		if err != nil {
+			return exit(2, "create data manifest temp dir: %v", err)
+		}
+		defer os.RemoveAll(tmp)
+		manifestDownload = filepath.Join(tmp, safeCaptureName(name)+"-manifest.json")
+	}
+	env := dataRunEnv(name, mode, run, manifestPath)
+	restoreEnv := setTemporaryEnv(env)
+	defer restoreEnv()
+	err = a.runCommand(ctx, dataRunRunArgs(cfg, name, run, leaseID, runNoHydrate, mode, manifestPath, manifestDownload))
+	if err != nil {
+		return err
+	}
+	if manifestDownload != "" {
+		if err := validateDataRunManifestFile(manifestDownload, name, mode); err != nil {
+			return err
+		}
+		info, statErr := os.Stat(manifestDownload)
+		if statErr == nil {
+			fmt.Fprintf(a.Stderr, "data manifest validated path=%s bytes=%d\n", manifestPath, info.Size())
+		}
+	}
+	return nil
+}
+
+func (a App) dataPromote(_ context.Context, args []string) error {
+	fs := newFlagSet("data promote", a.Stderr)
+	if err := parseFlags(fs, args); err != nil {
+		return err
+	}
+	return exit(2, "crabbox data promote is not implemented in the POC; promote staging output outside Crabbox and keep the manifest artifact")
+}
+
+func (a App) dataManifest(_ context.Context, args []string) error {
+	fs := newFlagSet("data manifest", a.Stderr)
+	if err := parseFlags(fs, args); err != nil {
+		return err
+	}
+	return exit(2, "crabbox data manifest is not implemented in the POC; use the validated manifest artifact from data run output")
+}
+
+func configuredDataRun(cfg Config, name string) (DataRunConfig, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return DataRunConfig{}, exit(2, "data run name is required")
+	}
+	run, ok := cfg.DataRuns[name]
+	if !ok {
+		return DataRunConfig{}, exit(2, "data run %q is not configured", name)
+	}
+	return run, nil
+}
+
+func validateDataRunConfig(name string, run DataRunConfig) error {
+	if strings.TrimSpace(run.Job.Command) == "" {
+		return exit(2, "data run %q requires command", name)
+	}
+	if run.Job.SyncOnly {
+		return exit(2, "data run %q cannot use syncOnly", name)
+	}
+	sourceMode := dataRunSourceMode(run)
+	if sourceMode != "read" {
+		return exit(2, "data run %q source.mode must be read", name)
+	}
+	sinkMode := dataRunSinkMode(run)
+	switch sinkMode {
+	case "write", "write-staging":
+	default:
+		return exit(2, "data run %q sink.mode must be write or write-staging", name)
+	}
+	if strings.TrimSpace(run.Source.Kind) == "" || strings.TrimSpace(run.Source.URI) == "" {
+		return exit(2, "data run %q requires source.kind and source.uri", name)
+	}
+	if strings.TrimSpace(run.Sink.Kind) == "" || strings.TrimSpace(run.Sink.URI) == "" {
+		return exit(2, "data run %q requires sink.kind and sink.uri", name)
+	}
+	if run.Policy.PIILogging != "" {
+		switch strings.ToLower(strings.TrimSpace(run.Policy.PIILogging)) {
+		case "forbid", "redact", "allow":
+		default:
+			return exit(2, "data run %q policy.piiLogging must be forbid, redact, or allow", name)
+		}
+	}
+	if _, err := dataRunManifestPath(name, dataRunModeExecute, run); err != nil {
+		return err
+	}
+	return nil
+}
+
+func normalizeDataRunMode(value string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", dataRunModeExecute:
+		return dataRunModeExecute, nil
+	case dataRunModeDryRun, "dryrun", "dry_run":
+		return dataRunModeDryRun, nil
+	default:
+		return "", exit(2, "data run mode must be execute or dry-run")
+	}
+}
+
+func dataRunSourceMode(run DataRunConfig) string {
+	return firstNonBlank(strings.ToLower(strings.TrimSpace(run.Source.Mode)), "read")
+}
+
+func dataRunSinkMode(run DataRunConfig) string {
+	return firstNonBlank(strings.ToLower(strings.TrimSpace(run.Sink.Mode)), "write-staging")
+}
+
+func dataRunManifestRequired(mode string, run DataRunConfig) bool {
+	return mode == dataRunModeExecute && (!run.Manifest.RequiredSet || run.Manifest.Required)
+}
+
+func dataRunManifestPath(name, mode string, run DataRunConfig) (string, error) {
+	value := strings.TrimSpace(run.Manifest.Path)
+	if value == "" {
+		value = ".crabbox/data/" + safeCaptureName(name) + "/" + mode + "-manifest.json"
+	}
+	clean, err := cleanDataRunManifestPath(value)
+	if err != nil {
+		return "", err
+	}
+	return clean, nil
+}
+
+func cleanDataRunManifestPath(value string) (string, error) {
+	value = strings.TrimSpace(strings.ReplaceAll(value, `\`, "/"))
+	if value == "" {
+		return "", exit(2, "data manifest path must not be empty")
+	}
+	if strings.HasPrefix(value, "/") {
+		return "", exit(2, "data manifest path must be relative to the run workdir")
+	}
+	clean := path.Clean(value)
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, "../") {
+		return "", exit(2, "data manifest path must stay inside the run workdir")
+	}
+	return clean, nil
+}
+
+func dataRunEnv(name, mode string, run DataRunConfig, manifestPath string) map[string]string {
+	env := map[string]string{
+		"CRABBOX_DATA_RUN":         "1",
+		"CRABBOX_DATA_RUN_NAME":    strings.TrimSpace(name),
+		"CRABBOX_DATA_MODE":        mode,
+		"CRABBOX_DATA_SOURCE_KIND": strings.TrimSpace(run.Source.Kind),
+		"CRABBOX_DATA_SOURCE_MODE": dataRunSourceMode(run),
+		"CRABBOX_DATA_SOURCE_URI":  strings.TrimSpace(run.Source.URI),
+		"CRABBOX_DATA_SINK_KIND":   strings.TrimSpace(run.Sink.Kind),
+		"CRABBOX_DATA_SINK_MODE":   dataRunSinkMode(run),
+		"CRABBOX_DATA_SINK_URI":    strings.TrimSpace(run.Sink.URI),
+		"CRABBOX_DATA_MANIFEST":    manifestPath,
+	}
+	if strings.TrimSpace(run.Source.Watermark) != "" {
+		env["CRABBOX_DATA_SOURCE_WATERMARK"] = strings.TrimSpace(run.Source.Watermark)
+	}
+	return env
+}
+
+func dataRunEnvNames(env map[string]string) []string {
+	names := make([]string, 0, len(env))
+	for name := range env {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func setTemporaryEnv(values map[string]string) func() {
+	type previous struct {
+		value string
+		ok    bool
+	}
+	old := map[string]previous{}
+	for key, value := range values {
+		current, ok := os.LookupEnv(key)
+		old[key] = previous{value: current, ok: ok}
+		_ = os.Setenv(key, value)
+	}
+	return func() {
+		for key, value := range old {
+			if value.ok {
+				_ = os.Setenv(key, value.value)
+			} else {
+				_ = os.Unsetenv(key)
+			}
+		}
+	}
+}
+
+func dataRunRunArgs(cfg Config, name string, run DataRunConfig, leaseID string, noHydrate bool, mode string, manifestPath string, manifestDownload string) []string {
+	job := run.Job
+	if strings.TrimSpace(job.Label) == "" {
+		job.Label = "data:" + name + ":" + mode
+	}
+	args := jobRunArgs(cfg, job, leaseID, noHydrate)
+	env := dataRunEnv(name, mode, run, manifestPath)
+	extra := []string{"--allow-env", strings.Join(dataRunEnvNames(env), ",")}
+	if dataRunManifestRequired(mode, run) {
+		extra = append(extra, "--require-artifact", manifestPath)
+		if strings.TrimSpace(manifestDownload) != "" {
+			extra = append(extra, "--download", manifestPath+"="+manifestDownload)
+		}
+	}
+	return insertRunArgsBeforeCommand(args, extra...)
+}
+
+func insertRunArgsBeforeCommand(args []string, extra ...string) []string {
+	if len(extra) == 0 {
+		return args
+	}
+	for i, arg := range args {
+		if arg == "--" {
+			out := make([]string, 0, len(args)+len(extra))
+			out = append(out, args[:i]...)
+			out = append(out, extra...)
+			out = append(out, args[i:]...)
+			return out
+		}
+	}
+	return append(args, extra...)
+}
+
+func dataRunPrintPlan(w io.Writer, cfg Config, name string, run DataRunConfig, mode string, manifestPath string) {
+	fmt.Fprintf(w, "data run %s mode=%s status=poc\n", name, mode)
+	fmt.Fprintf(w, "provider=%s target=%s\n", blank(firstNonBlank(run.Job.Provider, cfg.Provider), "-"), blank(firstNonBlank(run.Job.Target, cfg.TargetOS), "-"))
+	fmt.Fprintf(w, "source kind=%s mode=%s uri=%s\n", run.Source.Kind, dataRunSourceMode(run), run.Source.URI)
+	fmt.Fprintf(w, "sink kind=%s mode=%s uri=%s\n", run.Sink.Kind, dataRunSinkMode(run), run.Sink.URI)
+	fmt.Fprintf(w, "manifest path=%s required=%t\n", manifestPath, dataRunManifestRequired(mode, run))
+	fmt.Fprintf(w, "policy source.mode=%s declared=only\n", dataRunSourceMode(run))
+	fmt.Fprintf(w, "policy sink.mode=%s declared=only\n", dataRunSinkMode(run))
+	if run.Job.TTL > 0 {
+		fmt.Fprintf(w, "policy ttl=%s enforced=lease\n", run.Job.TTL)
+	}
+	if run.Policy.RequireDryRun {
+		fmt.Fprintln(w, "policy requireDryRun=true enforced=execute-gate")
+	}
+	if run.Policy.MaxBytes != "" {
+		fmt.Fprintf(w, "policy maxBytes=%s declared=only\n", run.Policy.MaxBytes)
+	}
+	if run.Policy.MaxRows > 0 {
+		fmt.Fprintf(w, "policy maxRows=%d declared=only\n", run.Policy.MaxRows)
+	}
+	if len(run.Policy.EgressAllow) > 0 {
+		fmt.Fprintln(w, "policy egress.allow declared=only")
+	}
+	env := dataRunEnv(name, mode, run, manifestPath)
+	envWords := []string{"env"}
+	for _, key := range dataRunEnvNames(env) {
+		envWords = append(envWords, key+"="+env[key])
+	}
+	runArgs := dataRunRunArgs(cfg, name, run, "<lease>", true, mode, manifestPath, "")
+	fmt.Fprintln(w, strings.Join(readableShellWords(append(envWords, append([]string{"crabbox", "run"}, runArgs...)...)), " "))
+}
+
+func validateDataRunManifestFile(localPath, name, mode string) error {
+	data, err := os.ReadFile(localPath)
+	if err != nil {
+		return exit(7, "read data manifest: %v", err)
+	}
+	var manifest struct {
+		SchemaVersion int             `json:"schemaVersion"`
+		DataRun       string          `json:"dataRun"`
+		Mode          string          `json:"mode"`
+		Source        json.RawMessage `json:"source"`
+		Sink          json.RawMessage `json:"sink"`
+	}
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return exit(7, "data manifest is not valid JSON: %v", err)
+	}
+	if manifest.SchemaVersion <= 0 {
+		return exit(7, "data manifest missing positive schemaVersion")
+	}
+	if strings.TrimSpace(manifest.DataRun) != name {
+		return exit(7, "data manifest dataRun=%q, want %q", manifest.DataRun, name)
+	}
+	if strings.TrimSpace(manifest.Mode) != mode {
+		return exit(7, "data manifest mode=%q, want %q", manifest.Mode, mode)
+	}
+	if len(manifest.Source) == 0 || string(manifest.Source) == "null" {
+		return exit(7, "data manifest missing source")
+	}
+	if len(manifest.Sink) == 0 || string(manifest.Sink) == "null" {
+		return exit(7, "data manifest missing sink")
+	}
+	return nil
+}

--- a/internal/cli/data.go
+++ b/internal/cli/data.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 )
 
 const (
@@ -77,6 +78,9 @@ func (a App) dataPlan(_ context.Context, args []string) error {
 	if err := validateDataRunConfig(name, run); err != nil {
 		return err
 	}
+	if err := validateDataRunExecutionSupport(cfg, name, run, mode); err != nil {
+		return err
+	}
 	manifestPath, err := dataRunManifestPath(name, mode, run)
 	if err != nil {
 		return err
@@ -117,6 +121,9 @@ func (a App) dataRun(ctx context.Context, args []string) (err error) {
 	if mode == dataRunModeExecute && run.Policy.RequireDryRun {
 		return exit(2, "data run %q requires dry-run first; run `crabbox data run --dry-run %s`, then set policy.requireDryRun=false for execute until broker dry-run history exists", name, name)
 	}
+	if err := validateDataRunExecutionSupport(cfg, name, run, mode); err != nil {
+		return err
+	}
 	stopPolicy := normalizeJobStopPolicy(run.Job.Stop, *stopOverride)
 	if err := validateJobStopPolicy(stopPolicy); err != nil {
 		return err
@@ -130,12 +137,17 @@ func (a App) dataRun(ctx context.Context, args []string) (err error) {
 	runNoHydrate := *noHydrate || !run.Job.Hydrate.Actions
 	if createdLease {
 		var out strings.Builder
+		requestedSlug := dataRunLeaseSlug(name)
 		warmupApp := App{Stdout: io.MultiWriter(a.Stdout, &out), Stderr: a.Stderr}
-		if err := warmupApp.warmup(ctx, append(jobLeaseCreateArgs(cfg, run.Job), "--keep=true")); err != nil {
+		if err := warmupApp.warmup(ctx, append(jobLeaseCreateArgs(cfg, run.Job), "--keep=true", "--slug", requestedSlug)); err != nil {
 			return err
 		}
 		leaseID = parseWarmupLeaseID(out.String())
 		if leaseID == "" {
+			stopArgs := append(jobStopRoutingArgs(run.Job), requestedSlug)
+			if stopErr := a.stop(context.Background(), stopArgs); stopErr != nil {
+				return exit(2, "data run %q could not parse warmup lease id; cleanup by slug %s failed: %v", name, requestedSlug, stopErr)
+			}
 			return exit(2, "data run %q could not parse warmup lease id", name)
 		}
 	}
@@ -258,6 +270,35 @@ func validateDataRunConfig(name string, run DataRunConfig) error {
 	return nil
 }
 
+func validateDataRunExecutionSupport(cfg Config, name string, run DataRunConfig, mode string) error {
+	if !dataRunManifestRequired(mode, run) {
+		return nil
+	}
+	manifestPath, err := dataRunManifestPath(name, mode, run)
+	if err != nil {
+		return err
+	}
+	if dataRunManifestPathIgnoredByArtifacts(manifestPath) {
+		return exit(2, "data run %q manifest.path must not be under .crabbox when manifest is required", name)
+	}
+	providerName := strings.TrimSpace(firstNonBlank(run.Job.Provider, cfg.Provider))
+	if providerName == "" {
+		return nil
+	}
+	provider, err := ProviderFor(providerName)
+	if err != nil {
+		return err
+	}
+	spec := provider.Spec()
+	if spec.Kind != ProviderKindDelegatedRun {
+		return nil
+	}
+	if featureSetHas(spec.Features, FeatureRunDownloads) {
+		return nil
+	}
+	return exit(2, "data run %q execute mode requires manifest download support; provider %s delegates run execution and cannot download required artifacts", name, spec.Name)
+}
+
 func normalizeDataRunMode(value string) (string, error) {
 	switch strings.ToLower(strings.TrimSpace(value)) {
 	case "", dataRunModeExecute:
@@ -284,13 +325,34 @@ func dataRunManifestRequired(mode string, run DataRunConfig) bool {
 func dataRunManifestPath(name, mode string, run DataRunConfig) (string, error) {
 	value := strings.TrimSpace(run.Manifest.Path)
 	if value == "" {
-		value = ".crabbox/data/" + safeCaptureName(name) + "/" + mode + "-manifest.json"
+		value = "crabbox-data/" + safeCaptureName(name) + "/" + mode + "-manifest.json"
 	}
 	clean, err := cleanDataRunManifestPath(value)
 	if err != nil {
 		return "", err
 	}
 	return clean, nil
+}
+
+func dataRunManifestPathIgnoredByArtifacts(value string) bool {
+	clean := path.Clean(strings.TrimSpace(strings.ReplaceAll(value, `\`, "/")))
+	return clean == ".crabbox" || strings.HasPrefix(clean, ".crabbox/")
+}
+
+func dataRunLeaseSlug(name string) string {
+	base := normalizeLeaseSlug("data-" + name)
+	if base == "" {
+		base = "data-run"
+	}
+	suffix := fmt.Sprintf("%06x", uint64(time.Now().UnixNano())&0xffffff)
+	maxBase := maxRequestedLeaseSlugLength - len(suffix) - 1
+	if len(base) > maxBase {
+		base = strings.Trim(base[:maxBase], "-")
+	}
+	if base == "" {
+		base = "data"
+	}
+	return base + "-" + suffix
 }
 
 func cleanDataRunManifestPath(value string) (string, error) {

--- a/internal/cli/data_test.go
+++ b/internal/cli/data_test.go
@@ -1,0 +1,190 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadConfigDataRuns(t *testing.T) {
+	clearConfigEnv(t)
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, ".config"))
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, ".crabbox.yaml"))
+	if err := os.WriteFile(filepath.Join(dir, ".crabbox.yaml"), []byte(`dataRuns:
+  normalize-events:
+    provider: aws
+    target: linux
+    ttl: 90m
+    source:
+      kind: s3
+      mode: read
+      uri: s3://example-raw/events/
+      watermark: updated_at
+    sink:
+      kind: s3
+      mode: write-staging
+      uri: s3://example-clean/events-staging/
+    identity:
+      aws:
+        instanceProfile: crabbox-data-normalize-events
+    policy:
+      requireDryRun: true
+      maxBytes: 500GiB
+      maxRows: 200000000
+      piiLogging: forbid
+      egress:
+        allow:
+          - s3.amazonaws.com
+    manifest:
+      path: .crabbox/data/custom.json
+      required: true
+    shell: true
+    command: python pipelines/normalize_events.py
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	run := cfg.DataRuns["normalize-events"]
+	if run.Job.Provider != "aws" || run.Job.Target != targetLinux || run.Job.TTL.String() != "1h30m0s" || !run.Job.Shell {
+		t.Fatalf("job fields not loaded: %#v", run.Job)
+	}
+	if run.Source.Kind != "s3" || run.Source.URI != "s3://example-raw/events/" || run.Source.Watermark != "updated_at" {
+		t.Fatalf("source not loaded: %#v", run.Source)
+	}
+	if run.Sink.Mode != "write-staging" || run.Sink.URI != "s3://example-clean/events-staging/" {
+		t.Fatalf("sink not loaded: %#v", run.Sink)
+	}
+	if run.Identity.AWS.InstanceProfile != "crabbox-data-normalize-events" {
+		t.Fatalf("identity not loaded: %#v", run.Identity)
+	}
+	if !run.Policy.RequireDryRun || run.Policy.MaxBytes != "500GiB" || run.Policy.MaxRows != 200000000 || len(run.Policy.EgressAllow) != 1 {
+		t.Fatalf("policy not loaded: %#v", run.Policy)
+	}
+	if run.Manifest.Path != ".crabbox/data/custom.json" || !run.Manifest.Required || !run.Manifest.RequiredSet {
+		t.Fatalf("manifest not loaded: %#v", run.Manifest)
+	}
+}
+
+func TestDataPlanPrintsEffectivePolicyAndRunCommand(t *testing.T) {
+	clearConfigEnv(t)
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, ".config"))
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, ".crabbox.yaml"))
+	if err := os.WriteFile(filepath.Join(dir, ".crabbox.yaml"), []byte(`dataRuns:
+  normalize-events:
+    provider: aws
+    target: linux
+    ttl: 90m
+    source:
+      kind: s3
+      uri: s3://example-raw/events/
+    sink:
+      kind: s3
+      uri: s3://example-clean/events-staging/
+    policy:
+      requireDryRun: true
+      maxRows: 100
+    command: python pipelines/normalize_events.py
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	app := App{Stdout: &stdout, Stderr: &stderr}
+	if err := app.Run(context.Background(), []string{"data", "plan", "normalize-events"}); err != nil {
+		t.Fatalf("data plan failed: %v\nstderr=%s", err, stderr.String())
+	}
+	got := stdout.String()
+	for _, want := range []string{
+		"data run normalize-events mode=execute status=poc",
+		"policy requireDryRun=true enforced=execute-gate",
+		"policy maxRows=100 declared=only",
+		"CRABBOX_DATA_MANIFEST=.crabbox/data/normalize-events/execute-manifest.json",
+		"crabbox run --provider aws --target linux --ttl 1h30m0s --id '<lease>' --no-hydrate --label data:normalize-events:execute --allow-env",
+		"--require-artifact .crabbox/data/normalize-events/execute-manifest.json",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("plan output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestDataRunRejectsExecuteWhenDryRunRequired(t *testing.T) {
+	clearConfigEnv(t)
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, ".config"))
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, ".crabbox.yaml"))
+	if err := os.WriteFile(filepath.Join(dir, ".crabbox.yaml"), []byte(`dataRuns:
+  normalize-events:
+    source:
+      kind: s3
+      uri: s3://example-raw/events/
+    sink:
+      kind: s3
+      uri: s3://example-clean/events-staging/
+    policy:
+      requireDryRun: true
+    command: python pipelines/normalize_events.py
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).Run(context.Background(), []string{"data", "run", "normalize-events"})
+	if err == nil || !strings.Contains(err.Error(), "requires dry-run first") {
+		t.Fatalf("data run err=%v, want requireDryRun gate", err)
+	}
+}
+
+func TestDataRunArgsRequireAndDownloadExecuteManifest(t *testing.T) {
+	cfg := defaultConfig()
+	run := DataRunConfig{
+		Job: JobConfig{
+			Provider: "aws",
+			Target:   targetLinux,
+			Command:  "python pipelines/normalize_events.py",
+		},
+		Source: DataRunEndpointConfig{Kind: "s3", URI: "s3://example-raw/events/"},
+		Sink:   DataRunEndpointConfig{Kind: "s3", URI: "s3://example-clean/events-staging/"},
+	}
+	args := dataRunRunArgs(cfg, "normalize-events", run, "blue-lobster", true, dataRunModeExecute, ".crabbox/data/normalize-events/execute-manifest.json", "/tmp/manifest.json")
+	got := strings.Join(args, " ")
+	for _, want := range []string{
+		"--allow-env",
+		"CRABBOX_DATA_MANIFEST",
+		"--require-artifact .crabbox/data/normalize-events/execute-manifest.json",
+		"--download .crabbox/data/normalize-events/execute-manifest.json=/tmp/manifest.json",
+		"-- python pipelines/normalize_events.py",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("run args missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestValidateDataRunManifestFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "manifest.json")
+	if err := os.WriteFile(path, []byte(`{"schemaVersion":1,"dataRun":"normalize-events","mode":"execute","source":{"kind":"s3"},"sink":{"kind":"s3"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateDataRunManifestFile(path, "normalize-events", dataRunModeExecute); err != nil {
+		t.Fatalf("valid manifest rejected: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(`{"schemaVersion":1,"dataRun":"other","mode":"execute","source":{},"sink":{}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateDataRunManifestFile(path, "normalize-events", dataRunModeExecute); err == nil || !strings.Contains(err.Error(), `dataRun="other"`) {
+		t.Fatalf("mismatched manifest err=%v", err)
+	}
+}

--- a/internal/cli/data_test.go
+++ b/internal/cli/data_test.go
@@ -41,7 +41,7 @@ func TestLoadConfigDataRuns(t *testing.T) {
         allow:
           - s3.amazonaws.com
     manifest:
-      path: .crabbox/data/custom.json
+      path: crabbox-data/custom.json
       required: true
     shell: true
     command: python pipelines/normalize_events.py
@@ -69,7 +69,7 @@ func TestLoadConfigDataRuns(t *testing.T) {
 	if !run.Policy.RequireDryRun || run.Policy.MaxBytes != "500GiB" || run.Policy.MaxRows != 200000000 || len(run.Policy.EgressAllow) != 1 {
 		t.Fatalf("policy not loaded: %#v", run.Policy)
 	}
-	if run.Manifest.Path != ".crabbox/data/custom.json" || !run.Manifest.Required || !run.Manifest.RequiredSet {
+	if run.Manifest.Path != "crabbox-data/custom.json" || !run.Manifest.Required || !run.Manifest.RequiredSet {
 		t.Fatalf("manifest not loaded: %#v", run.Manifest)
 	}
 }
@@ -109,9 +109,9 @@ func TestDataPlanPrintsEffectivePolicyAndRunCommand(t *testing.T) {
 		"data run normalize-events mode=execute status=poc",
 		"policy requireDryRun=true enforced=execute-gate",
 		"policy maxRows=100 declared=only",
-		"CRABBOX_DATA_MANIFEST=.crabbox/data/normalize-events/execute-manifest.json",
+		"CRABBOX_DATA_MANIFEST=crabbox-data/normalize-events/execute-manifest.json",
 		"crabbox run --provider aws --target linux --ttl 1h30m0s --id '<lease>' --no-hydrate --label data:normalize-events:execute --allow-env",
-		"--require-artifact .crabbox/data/normalize-events/execute-manifest.json",
+		"--require-artifact crabbox-data/normalize-events/execute-manifest.json",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("plan output missing %q:\n%s", want, got)
@@ -158,18 +158,61 @@ func TestDataRunArgsRequireAndDownloadExecuteManifest(t *testing.T) {
 		Source: DataRunEndpointConfig{Kind: "s3", URI: "s3://example-raw/events/"},
 		Sink:   DataRunEndpointConfig{Kind: "s3", URI: "s3://example-clean/events-staging/"},
 	}
-	args := dataRunRunArgs(cfg, "normalize-events", run, "blue-lobster", true, dataRunModeExecute, ".crabbox/data/normalize-events/execute-manifest.json", "/tmp/manifest.json")
+	args := dataRunRunArgs(cfg, "normalize-events", run, "blue-lobster", true, dataRunModeExecute, "crabbox-data/normalize-events/execute-manifest.json", "/tmp/manifest.json")
 	got := strings.Join(args, " ")
 	for _, want := range []string{
 		"--allow-env",
 		"CRABBOX_DATA_MANIFEST",
-		"--require-artifact .crabbox/data/normalize-events/execute-manifest.json",
-		"--download .crabbox/data/normalize-events/execute-manifest.json=/tmp/manifest.json",
+		"--require-artifact crabbox-data/normalize-events/execute-manifest.json",
+		"--download crabbox-data/normalize-events/execute-manifest.json=/tmp/manifest.json",
 		"-- python pipelines/normalize_events.py",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("run args missing %q:\n%s", want, got)
 		}
+	}
+}
+
+func TestValidateDataRunExecutionSupportRejectsDelegatedWithoutDownloads(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.Provider = "e2b"
+	run := DataRunConfig{}
+
+	err := validateDataRunExecutionSupport(cfg, "normalize-events", run, dataRunModeExecute)
+	if err == nil || !strings.Contains(err.Error(), "requires manifest download support") {
+		t.Fatalf("execute support err=%v, want delegated manifest download rejection", err)
+	}
+	if err := validateDataRunExecutionSupport(cfg, "normalize-events", run, dataRunModeDryRun); err != nil {
+		t.Fatalf("dry-run should not require manifest download support: %v", err)
+	}
+	run.Manifest.Required = false
+	run.Manifest.RequiredSet = true
+	if err := validateDataRunExecutionSupport(cfg, "normalize-events", run, dataRunModeExecute); err != nil {
+		t.Fatalf("manifest.required=false should not require manifest download support: %v", err)
+	}
+}
+
+func TestValidateDataRunExecutionSupportRejectsIgnoredManifestPath(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.Provider = "aws"
+	run := DataRunConfig{Manifest: DataRunManifestConfig{Path: ".crabbox/data/manifest.json"}}
+
+	err := validateDataRunExecutionSupport(cfg, "normalize-events", run, dataRunModeExecute)
+	if err == nil || !strings.Contains(err.Error(), "manifest.path must not be under .crabbox") {
+		t.Fatalf("execute support err=%v, want ignored manifest path rejection", err)
+	}
+}
+
+func TestDataRunLeaseSlugIsRequestedSlugSafe(t *testing.T) {
+	slug := dataRunLeaseSlug("Normalize Events With A Very Long Name That Needs Truncation")
+	if slug != normalizeLeaseSlug(slug) {
+		t.Fatalf("slug %q is not normalized", slug)
+	}
+	if len(slug) > maxRequestedLeaseSlugLength {
+		t.Fatalf("slug length=%d, want <= %d: %q", len(slug), maxRequestedLeaseSlugLength, slug)
+	}
+	if !strings.HasPrefix(slug, "data-normalize-events") {
+		t.Fatalf("slug %q missing data-run prefix", slug)
 	}
 }
 

--- a/scripts/build-docs-site.mjs
+++ b/scripts/build-docs-site.mjs
@@ -16,6 +16,7 @@ const sections = [
     "Operate",
     ["operations.md", "observability.md", "troubleshooting.md", "performance.md", "infrastructure.md", "security.md"],
   ],
+  ["Plans", rels("plan")],
 ];
 
 fs.rmSync(outDir, { recursive: true, force: true });
@@ -370,7 +371,7 @@ function standardHero(page, sectionName, editUrl) {
 function landingHero(rootPrefix) {
   const features = [
     ["Local loop, remote box", "Keep your editor and git workflow. Crabbox rsyncs your dirty checkout to a leased remote box and streams the run back."],
-    ["Brokered, not BYO creds", "A Cloudflare Worker holds provider credentials and serializes lease state. Your CLI only carries a bearer token."],
+    ["Brokered, not BYO creds", "A coordinator holds provider credentials and serializes lease state. Your CLI only carries a bearer token."],
     ["Cost-aware leases", "TTL-bounded machines, monthly spend caps, and per-user / per-org / per-provider usage from the broker."],
     ["Reuse what's warm", "<code>crabbox warmup</code> keeps a box hot. Reuse it with <code>--id</code> across runs, SSH, and CI hydration."],
     ["Many providers, one loop", "Brokered Hetzner / AWS / Azure, delegated E2B / Daytona / Blacksmith / Semaphore, or static SSH targets - Linux, Windows, and macOS."],
@@ -383,9 +384,9 @@ function landingHero(rootPrefix) {
     .join("");
   return `<header class="hero hero-home">
         <div class="hero-text">
-          <p class="eyebrow">OpenClaw - remote testbox</p>
+          <p class="eyebrow">Remote testbox</p>
           <h1>A short-lived box for every <em>run</em>.</h1>
-          <p class="lede">Crabbox gives maintainers and agents a fast local loop on shared cloud capacity: lease, sync, run, release. The CLI keeps the developer story simple; a Cloudflare-hosted broker keeps the fleet safe.</p>
+          <p class="lede">Crabbox gives maintainers and agents a fast local loop on shared cloud capacity: lease, sync, run, release. The CLI keeps the developer story simple; the coordinator keeps the fleet safe.</p>
           <div class="cta">
             <a class="cta-primary" href="${rootPrefix}how-it-works.html">Read the overview</a>
             <a class="cta-secondary" href="https://github.com/openclaw/crabbox" rel="noopener">View on GitHub</a>


### PR DESCRIPTION
## Summary

- Add `crabbox data list|plan|run` as a POC wrapper over existing lease/run primitives.
- Add `dataRuns` config, `CRABBOX_DATA_*` env forwarding, execute dry-run gating, artifact-visible manifest defaults, manifest require/download/JSON validation, and reserved promote/manifest stubs.
- Guard execute mode before lease creation when required manifests cannot be validated, including delegated providers without run-file downloads and manifest paths under `.crabbox`.
- Update command docs, CLI docs, docs site navigation, source map, and the Data Runs plan to distinguish shipped POC behavior from broker/provider follow-up work.

## Validation

- `go test ./internal/cli -run 'Test(LoadConfigDataRuns|DataPlanPrintsEffectivePolicyAndRunCommand|DataRunRejectsExecuteWhenDryRunRequired|DataRunArgsRequireAndDownloadExecuteManifest|ValidateDataRunExecutionSupportRejectsDelegatedWithoutDownloads|ValidateDataRunExecutionSupportRejectsIgnoredManifestPath|DataRunLeaseSlugIsRequestedSlugSafe|ValidateDataRunManifestFile)'`
- `scripts/check-docs.sh`
- `git diff --check`
- `git ls-files -z '*.go' | xargs -0 gofmt -l`
- `go vet ./...`
- `go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...`
- `npm ci --prefix worker`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm run check:node --prefix worker`
- `npm test --prefix worker`
- `npm run build --prefix worker`
- `npm run build:cloudflare-dynamic-workers --prefix worker`
- `npm run build:node --prefix worker`
- `node scripts/check-docker-base-images.mjs`
- `node --test scripts/*.test.js`
- `go build -trimpath -o /tmp/crabbox ./cmd/crabbox`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --engine claude --fallback-model claude-opus-4-8,claude-sonnet-4-6`

## Notes

- Local Docker daemon was unavailable, so the Worker Docker image build is covered by GitHub CI.
- Local macOS `go test ./...` and `go test -race ./...` hit `TestControllerTrackedChildDiesWithControllerProcess`, which reproduces on clean `origin/main`; GitHub Linux Go CI remains the authoritative gate for this PR.