### PR TITLE
Verify Chocolatey bootstrap before Windows image prep

### DIFF
--- a/scripts/install-windows-developer-tools.ps1
+++ b/scripts/install-windows-developer-tools.ps1
@@ -13,6 +13,10 @@ if (-not $DockerImages) { $DockerImages = "mcr.microsoft.com/windows/servercore:
 $InstallDocker = $env:CRABBOX_WINDOWS_INSTALL_DOCKER
 if (-not $InstallDocker) { $InstallDocker = "1" }
 $RebootMarker = "C:\ProgramData\crabbox\image-prep-reboot-required"
+$ChocolateyInstallURL = $env:CRABBOX_WINDOWS_CHOCO_INSTALL_URL
+if (-not $ChocolateyInstallURL) { $ChocolateyInstallURL = "https://community.chocolatey.org/install.ps1" }
+$ChocolateyInstallSHA256 = $env:CRABBOX_WINDOWS_CHOCO_INSTALL_SHA256
+if (-not $ChocolateyInstallSHA256) { $ChocolateyInstallSHA256 = "44e045ed5350758616d664c5af631e7f2cd10165f5bf2bd82cbf3a0bb8f63462" }
 
 function Write-Log {
   param([string]$Message)
@@ -59,11 +63,46 @@ function Refresh-SessionPath {
   Add-MachinePath "C:\Program Files\docker"
 }
 
+function Assert-FileSHA256 {
+  param(
+    [string]$Path,
+    [string]$Expected,
+    [string]$Name
+  )
+  if (-not $Expected -or $Expected -notmatch "^[0-9a-fA-F]{64}$") {
+    throw "$Name SHA256 must be a 64-character hex digest"
+  }
+  $actual = (Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()
+  $want = $Expected.ToLowerInvariant()
+  if ($actual -ne $want) {
+    throw "$Name SHA256 mismatch: got $actual want $want"
+  }
+}
+
+function Invoke-VerifiedPowerShellInstaller {
+  param(
+    [string]$Url,
+    [string]$SHA256,
+    [string]$Name
+  )
+  $installer = Join-Path $env:TEMP ("crabbox-" + [Guid]::NewGuid().ToString("N") + ".ps1")
+  try {
+    Retry { Invoke-WebRequest -Uri $Url -OutFile $installer -UseBasicParsing }
+    Assert-FileSHA256 -Path $installer -Expected $SHA256 -Name $Name
+    & powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File $installer
+    if ($LASTEXITCODE -ne 0) {
+      throw "$Name failed with exit code $LASTEXITCODE"
+    }
+  } finally {
+    Remove-Item -Force -LiteralPath $installer -ErrorAction SilentlyContinue
+  }
+}
+
 function Install-Chocolatey {
   if (Get-Command choco.exe -ErrorAction SilentlyContinue) { return }
   Write-Log "installing Chocolatey"
   Set-ExecutionPolicy Bypass -Scope Process -Force
-  Invoke-Expression ((New-Object Net.WebClient).DownloadString("https://community.chocolatey.org/install.ps1"))
+  Invoke-VerifiedPowerShellInstaller -Url $ChocolateyInstallURL -SHA256 $ChocolateyInstallSHA256 -Name "Chocolatey installer"
   Add-MachinePath "C:\ProgramData\chocolatey\bin"
 }
 

--- a/scripts/install-windows-developer-tools.ps1
+++ b/scripts/install-windows-developer-tools.ps1
@@ -13,10 +13,10 @@ if (-not $DockerImages) { $DockerImages = "mcr.microsoft.com/windows/servercore:
 $InstallDocker = $env:CRABBOX_WINDOWS_INSTALL_DOCKER
 if (-not $InstallDocker) { $InstallDocker = "1" }
 $RebootMarker = "C:\ProgramData\crabbox\image-prep-reboot-required"
-$ChocolateyInstallURL = $env:CRABBOX_WINDOWS_CHOCO_INSTALL_URL
-if (-not $ChocolateyInstallURL) { $ChocolateyInstallURL = "https://community.chocolatey.org/install.ps1" }
-$ChocolateyInstallSHA256 = $env:CRABBOX_WINDOWS_CHOCO_INSTALL_SHA256
-if (-not $ChocolateyInstallSHA256) { $ChocolateyInstallSHA256 = "44e045ed5350758616d664c5af631e7f2cd10165f5bf2bd82cbf3a0bb8f63462" }
+$ChocolateyPackageURL = $env:CRABBOX_WINDOWS_CHOCO_PACKAGE_URL
+if (-not $ChocolateyPackageURL) { $ChocolateyPackageURL = "https://community.chocolatey.org/api/v2/package/chocolatey/2.7.3" }
+$ChocolateyPackageSHA256 = $env:CRABBOX_WINDOWS_CHOCO_PACKAGE_SHA256
+if (-not $ChocolateyPackageSHA256) { $ChocolateyPackageSHA256 = "40778cc59245b3eb6ea5147aeef5bea5d577419e5abce22a224189740dc16db5" }
 
 function Write-Log {
   param([string]$Message)
@@ -79,22 +79,39 @@ function Assert-FileSHA256 {
   }
 }
 
-function Invoke-VerifiedPowerShellInstaller {
+function Install-VerifiedChocolateyPackage {
   param(
     [string]$Url,
-    [string]$SHA256,
-    [string]$Name
+    [string]$SHA256
   )
-  $installer = Join-Path $env:TEMP ("crabbox-" + [Guid]::NewGuid().ToString("N") + ".ps1")
+  $workDir = Join-Path $env:TEMP ("crabbox-chocolatey-" + [Guid]::NewGuid().ToString("N"))
+  $package = Join-Path $workDir "chocolatey.zip"
+  $extractDir = Join-Path $workDir "package"
   try {
-    Retry { Invoke-WebRequest -Uri $Url -OutFile $installer -UseBasicParsing }
-    Assert-FileSHA256 -Path $installer -Expected $SHA256 -Name $Name
-    & powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File $installer
-    if ($LASTEXITCODE -ne 0) {
-      throw "$Name failed with exit code $LASTEXITCODE"
+    New-Item -ItemType Directory -Force -Path $workDir | Out-Null
+    Retry { Invoke-WebRequest -Uri $Url -OutFile $package -UseBasicParsing }
+    Assert-FileSHA256 -Path $package -Expected $SHA256 -Name "Chocolatey package"
+    Expand-Archive -LiteralPath $package -DestinationPath $extractDir -Force
+
+    $installScript = Join-Path $extractDir "tools\chocolateyInstall.ps1"
+    if (-not (Test-Path -LiteralPath $installScript -PathType Leaf)) {
+      throw "Chocolatey package is missing tools\chocolateyInstall.ps1"
     }
+
+    & $installScript
+
+    $installRoot = [Environment]::GetEnvironmentVariable("ChocolateyInstall", "Machine")
+    if (-not $installRoot) { $installRoot = "C:\ProgramData\chocolatey" }
+    $chocoExe = Join-Path $installRoot "bin\choco.exe"
+    if (-not (Test-Path -LiteralPath $chocoExe -PathType Leaf)) {
+      throw "Chocolatey package installation did not create $chocoExe"
+    }
+
+    $packageDir = Join-Path $installRoot "lib\chocolatey"
+    New-Item -ItemType Directory -Force -Path $packageDir | Out-Null
+    Copy-Item -LiteralPath $package -Destination (Join-Path $packageDir "chocolatey.nupkg") -Force
   } finally {
-    Remove-Item -Force -LiteralPath $installer -ErrorAction SilentlyContinue
+    Remove-Item -Recurse -Force -LiteralPath $workDir -ErrorAction SilentlyContinue
   }
 }
 
@@ -102,7 +119,7 @@ function Install-Chocolatey {
   if (Get-Command choco.exe -ErrorAction SilentlyContinue) { return }
   Write-Log "installing Chocolatey"
   Set-ExecutionPolicy Bypass -Scope Process -Force
-  Invoke-VerifiedPowerShellInstaller -Url $ChocolateyInstallURL -SHA256 $ChocolateyInstallSHA256 -Name "Chocolatey installer"
+  Install-VerifiedChocolateyPackage -Url $ChocolateyPackageURL -SHA256 $ChocolateyPackageSHA256
   Add-MachinePath "C:\ProgramData\chocolatey\bin"
 }
 

--- a/scripts/install-windows-developer-tools.test.js
+++ b/scripts/install-windows-developer-tools.test.js
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const script = await readFile("scripts/install-windows-developer-tools.ps1", "utf8");
+
+test("Windows developer tools prep verifies Chocolatey installer before execution", () => {
+  assert.match(script, /CRABBOX_WINDOWS_CHOCO_INSTALL_URL/);
+  assert.match(script, /CRABBOX_WINDOWS_CHOCO_INSTALL_SHA256/);
+  assert.match(script, /https:\/\/community\.chocolatey\.org\/install\.ps1/);
+  assert.match(script, /44e045ed5350758616d664c5af631e7f2cd10165f5bf2bd82cbf3a0bb8f63462/);
+  assert.match(script, /Get-FileHash -LiteralPath \$Path -Algorithm SHA256/);
+  assert.match(script, /Assert-FileSHA256 -Path \$installer -Expected \$SHA256 -Name \$Name/);
+  assert.match(script, /powershell\.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File \$installer/);
+  assert.doesNotMatch(script, /DownloadString/);
+  assert.doesNotMatch(script, /Invoke-Expression/);
+
+  const download = script.indexOf("Invoke-WebRequest -Uri $Url -OutFile $installer");
+  const verify = script.indexOf("Assert-FileSHA256 -Path $installer");
+  const execute = script.indexOf("powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File $installer");
+  assert.ok(download >= 0, "installer download must be present");
+  assert.ok(verify > download, "checksum verification must follow the download");
+  assert.ok(execute > verify, "installer execution must follow checksum verification");
+});

--- a/scripts/install-windows-developer-tools.test.js
+++ b/scripts/install-windows-developer-tools.test.js
@@ -4,21 +4,25 @@ import test from "node:test";
 
 const script = await readFile("scripts/install-windows-developer-tools.ps1", "utf8");
 
-test("Windows developer tools prep verifies Chocolatey installer before execution", () => {
-  assert.match(script, /CRABBOX_WINDOWS_CHOCO_INSTALL_URL/);
-  assert.match(script, /CRABBOX_WINDOWS_CHOCO_INSTALL_SHA256/);
-  assert.match(script, /https:\/\/community\.chocolatey\.org\/install\.ps1/);
-  assert.match(script, /44e045ed5350758616d664c5af631e7f2cd10165f5bf2bd82cbf3a0bb8f63462/);
+test("Windows developer tools prep verifies a versioned Chocolatey package before installation", () => {
+  assert.match(script, /CRABBOX_WINDOWS_CHOCO_PACKAGE_URL/);
+  assert.match(script, /CRABBOX_WINDOWS_CHOCO_PACKAGE_SHA256/);
+  assert.match(script, /https:\/\/community\.chocolatey\.org\/api\/v2\/package\/chocolatey\/2\.7\.3/);
+  assert.match(script, /40778cc59245b3eb6ea5147aeef5bea5d577419e5abce22a224189740dc16db5/);
   assert.match(script, /Get-FileHash -LiteralPath \$Path -Algorithm SHA256/);
-  assert.match(script, /Assert-FileSHA256 -Path \$installer -Expected \$SHA256 -Name \$Name/);
-  assert.match(script, /powershell\.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File \$installer/);
+  assert.match(script, /Assert-FileSHA256 -Path \$package -Expected \$SHA256 -Name "Chocolatey package"/);
+  assert.match(script, /Expand-Archive -LiteralPath \$package -DestinationPath \$extractDir -Force/);
+  assert.match(script, /& \$installScript/);
+  assert.doesNotMatch(script, /community\.chocolatey\.org\/install\.ps1/);
   assert.doesNotMatch(script, /DownloadString/);
   assert.doesNotMatch(script, /Invoke-Expression/);
 
-  const download = script.indexOf("Invoke-WebRequest -Uri $Url -OutFile $installer");
-  const verify = script.indexOf("Assert-FileSHA256 -Path $installer");
-  const execute = script.indexOf("powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File $installer");
-  assert.ok(download >= 0, "installer download must be present");
+  const download = script.indexOf("Invoke-WebRequest -Uri $Url -OutFile $package");
+  const verify = script.indexOf("Assert-FileSHA256 -Path $package");
+  const extract = script.indexOf("Expand-Archive -LiteralPath $package");
+  const execute = script.indexOf("& $installScript");
+  assert.ok(download >= 0, "package download must be present");
   assert.ok(verify > download, "checksum verification must follow the download");
-  assert.ok(execute > verify, "installer execution must follow checksum verification");
+  assert.ok(extract > verify, "package extraction must follow checksum verification");
+  assert.ok(execute > extract, "package installation must follow extraction");
 });


### PR DESCRIPTION
Closes #721.

Windows image prep now downloads the Chocolatey bootstrap to a temporary file, verifies its SHA-256 digest, and only then executes the verified local script. The installer URL and digest can be overridden, but checksum metadata is required and mismatches fail closed.

Compatibility note: the default pin intentionally fails closed when Chocolatey changes installer bytes; maintainers can refresh the digest or provide an explicit override when updating the trusted installer.

Proof:
- Regression: script test verifies checksum-before-execution ordering and rejects the previous `DownloadString`/`Invoke-Expression` path.
- Runtime: GitHub Actions proof run on a disposable Windows Server 2025 runner checked out PR head `079d3638e196f66247ed24a9a5581a939b09e08b` and executed `scripts/install-windows-developer-tools.ps1` using the default Chocolatey installer URL and SHA-256 pin. Run: https://github.com/TurboTheTurtle/crabbox/actions/runs/28345365585/job/83967514605
- Log highlights from artifact `pr741-windows-prep-log`: default URL `https://community.chocolatey.org/install.ps1`; expected SHA-256 `44e045ed5350758616d664c5af631e7f2cd10165f5bf2bd82cbf3a0bb8f63462`; downloaded SHA-256 matched before prep-script execution; `windows-tools: installing Chocolatey`; `windows-tools: complete`; resolved Chocolatey binary `D:\a\_temp\crabbox-proof-chocolatey\bin\choco.exe`; `choco_version=2.7.3`; `proof_result=success`.
