### PR TITLE
fix: validate forwarded environment names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
 
 ### Fixed
 
+- Dropped invalid allowlisted environment names before rendering remote POSIX or Windows commands, preventing shell metacharacters in ambient names from creating unintended commands. Thanks @coygeek.
 - Pinned Windows Chocolatey image bootstrap to a checksum-verified versioned package before privileged installation. Thanks @TurboTheTurtle.
 - Redacted Daytona API and upload credentials from provider error diagnostics, including reflected authorization headers and token-bearing JSON fields. Thanks @TurboTheTurtle.
 - Recognized current Windows 11 Sandbox host processes during run monitoring and cleanup, preventing false early exits and orphaned sandboxes on 24H2 and newer builds. Thanks @paulcam206.

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -179,6 +179,9 @@ func allowedEnv(allow []string) map[string]string {
 		if !ok {
 			continue
 		}
+		if !validEnvName(k) {
+			continue
+		}
 		if envAllowed(k, allow) {
 			out[k] = v
 		}

--- a/internal/cli/run_env_profile.go
+++ b/internal/cli/run_env_profile.go
@@ -31,7 +31,7 @@ func loadEnvProfiles(paths []string) (map[string]string, error) {
 func allowedEnvFromProfiles(allow []string, profileEnv map[string]string) map[string]string {
 	out := allowedEnv(allow)
 	for key, value := range profileEnv {
-		if envAllowed(key, allow) {
+		if validEnvName(key) && envAllowed(key, allow) {
 			out[key] = value
 		}
 	}
@@ -41,7 +41,7 @@ func allowedEnvFromProfiles(allow []string, profileEnv map[string]string) map[st
 func allowedProfileEnv(allow []string, profileEnv map[string]string) map[string]string {
 	out := map[string]string{}
 	for key, value := range profileEnv {
-		if envAllowed(key, allow) {
+		if validEnvName(key) && envAllowed(key, allow) {
 			out[key] = value
 		}
 	}

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -1254,6 +1254,9 @@ func writeRemoteCommandPrefix(b *strings.Builder, workdir string, env map[string
 		b.WriteString("; fi && ")
 	}
 	for k, v := range env {
+		if !validEnvName(k) {
+			continue
+		}
 		b.WriteString(k)
 		b.WriteByte('=')
 		b.WriteString(shellQuote(v))

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -43,6 +43,20 @@ func TestRemoteCommandQuotesWorkdirEnvAndArgs(t *testing.T) {
 	}
 }
 
+func TestRemoteCommandDropsInvalidEnvNames(t *testing.T) {
+	invalid := `PROJECT_$(touch /tmp/cbx-env-pwn)#`
+	got := remoteCommand("/work/repo", map[string]string{
+		"CI":    "1",
+		invalid: "ignored",
+	}, []string{"true"})
+	if !strings.Contains(got, "CI='1'") {
+		t.Fatalf("remoteCommand() missing valid environment variable in %q", got)
+	}
+	if strings.Contains(got, invalid) || strings.Contains(got, "$(touch") {
+		t.Fatalf("remoteCommand() rendered invalid environment name in %q", got)
+	}
+}
+
 func TestRemoteShellCommandRunsScript(t *testing.T) {
 	got := remoteShellCommand("/work/crabbox/cbx_1/repo", map[string]string{"CI": "1"}, "pnpm install && pnpm test")
 	for _, want := range []string{
@@ -126,6 +140,21 @@ func TestWindowsNativeRemoteCommandUsesPowerShell(t *testing.T) {
 	decoded := decodePowerShellCommand(t, got)
 	if !strings.HasPrefix(decoded, "$ProgressPreference = \"SilentlyContinue\"\n") {
 		t.Fatalf("windows command should suppress PowerShell progress records: %q", decoded)
+	}
+}
+
+func TestWindowsNativeRemoteCommandDropsInvalidEnvNames(t *testing.T) {
+	invalid := `PROJECT_$(touch C:\cbx-env-pwn)#`
+	got := windowsRemoteCommandWithEnvFile(`C:\crabbox\cbx\repo`, map[string]string{
+		"CI":    "1",
+		invalid: "ignored",
+	}, "", []string{"cmd.exe", "/c", "exit", "0"})
+	decoded := decodePowerShellCommand(t, got)
+	if !strings.Contains(decoded, `$env:CI = '1'`) {
+		t.Fatalf("windows command missing valid environment variable in %q", decoded)
+	}
+	if strings.Contains(decoded, invalid) || strings.Contains(decoded, "$(touch") {
+		t.Fatalf("windows command rendered invalid environment name in %q", decoded)
 	}
 }
 
@@ -401,6 +430,15 @@ func TestEnvAllowlistRejectsEmptyWildcardPrefix(t *testing.T) {
 	}
 	if !envAllowed("PROJECT_FLAG", []string{"PROJECT_*"}) {
 		t.Fatal("non-empty prefix wildcard should still work")
+	}
+}
+
+func TestAllowedEnvDropsInvalidNames(t *testing.T) {
+	invalid := `PROJECT_$(touch /tmp/cbx-env-pwn)#`
+	t.Setenv(invalid, "1")
+	got := allowedEnv([]string{"PROJECT_*"})
+	if _, ok := got[invalid]; ok {
+		t.Fatalf("allowedEnv() forwarded invalid environment name: %#v", got)
 	}
 }
 

--- a/internal/cli/sync_windows_target.go
+++ b/internal/cli/sync_windows_target.go
@@ -241,6 +241,9 @@ if (-not [string]::IsNullOrWhiteSpace($env:RUNNER_TOOL_CACHE)) {
 `)
 	}
 	for key, value := range env {
+		if !validEnvName(key) {
+			continue
+		}
 		b.WriteString(`$env:` + key + ` = ` + psQuote(value) + "\n")
 	}
 }


### PR DESCRIPTION
## Summary

- drop malformed environment names while collecting allowlisted ambient and profile values
- revalidate names before rendering both POSIX and Windows remote command prefixes
- add regressions for the reported command-substitution name and the Windows path

Closes https://github.com/openclaw/crabbox/issues/695

## Verification

- `go test ./internal/cli -run 'Test(RemoteCommandDropsInvalidEnvNames|WindowsNativeRemoteCommandDropsInvalidEnvNames|AllowedEnvDropsInvalidNames)$' -count=1`
- `go test ./internal/cli -count=1`
- autoreview clean

## Security/config implications

Invalid names outside `[A-Za-z_][A-Za-z0-9_]*` are now dropped consistently. Valid exact and prefix allowlists are unchanged; no secrets or config migrations are involved.
