### PR TITLE
fix: reject mismatched GitHub login callback origins

### DIFF
--- a/docs/features/broker-auth-routing.md
+++ b/docs/features/broker-auth-routing.md
@@ -141,6 +141,21 @@ needs its own OAuth app: the callback URL must exactly match the public origin, 
 `CRABBOX_PUBLIC_URL` must use that same origin (it is used to build the callback and
 to canonicalize portal redirects).
 
+The CLI treats that callback origin as a credential destination. If a login response
+from one broker points at a different callback origin, `crabbox login` fails before
+opening the browser unless the alternate origin appears in trusted operator config:
+
+```yaml
+broker:
+  url: https://broker-access.example.com
+  loginRedirectOrigins:
+    - https://broker.example.com
+```
+
+Use `broker.loginRedirectOrigins` or `CRABBOX_BROKER_LOGIN_REDIRECT_ORIGINS` only for
+known same-deployment aliases during a planned migration. Project config cannot grant
+this exception.
+
 Login is gated by GitHub org membership before a user token is minted:
 
 - The allowed org set comes from `CRABBOX_GITHUB_ALLOWED_ORG` or comma-separated

--- a/docs/security.md
+++ b/docs/security.md
@@ -201,6 +201,12 @@ hostname, and effective port remain unchanged. The curl transport fallback
 does not follow redirects and disables ambient curl configuration before
 loading Crabbox's generated request config. Configure the CLI with the final
 canonical coordinator or Access-protected origin, not a redirecting alias.
+GitHub browser login follows the same destination rule by default: a callback
+origin that differs from the selected broker is rejected before browser open,
+polling, or config write. Operators who are deliberately migrating between
+same-deployment broker aliases can allow specific callback origins with trusted
+user config `broker.loginRedirectOrigins` or
+`CRABBOX_BROKER_LOGIN_REDIRECT_ORIGINS`.
 
 Provider clients apply the same destination principle where custom endpoints
 are supported. Cloudflare runner and RunPod requests reject cross-origin

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -87,7 +87,7 @@ func (a App) loginWithGitHub(ctx context.Context, brokerURL, provider string, br
 		return err
 	}
 	pollSecretHash := sha256Hex(pollSecret)
-	client, err := coordinatorClientForLogin(brokerURL, provider)
+	client, cfg, err := coordinatorClientConfigForLogin(brokerURL, provider)
 	if err != nil {
 		return err
 	}
@@ -99,8 +99,16 @@ func (a App) loginWithGitHub(ctx context.Context, brokerURL, provider string, br
 		return exit(3, "GitHub login returned an invalid authorization URL: %v", err)
 	}
 	if canonicalBrokerURL, ok := canonicalBrokerURLFromLoginURL(start.URL); ok && !sameBrokerURL(brokerURL, canonicalBrokerURL) {
+		if !brokerLoginRedirectOriginAllowed(cfg, canonicalBrokerURL) {
+			return exit(
+				3,
+				"GitHub login redirect_uri broker origin %s does not match selected broker %s; add it to broker.loginRedirectOrigins only if this is an intended same-deployment alias",
+				canonicalBrokerURL,
+				normalizedBrokerURL(brokerURL),
+			)
+		}
 		brokerURL = canonicalBrokerURL
-		client, err = coordinatorClientForLogin(brokerURL, provider)
+		client, cfg, err = coordinatorClientConfigForLogin(brokerURL, provider)
 		if err != nil {
 			return err
 		}
@@ -110,6 +118,14 @@ func (a App) loginWithGitHub(ctx context.Context, brokerURL, provider string, br
 		}
 		if err := validateGitHubLoginURL(start.URL); err != nil {
 			return exit(3, "GitHub login returned an invalid authorization URL: %v", err)
+		}
+		if nextBrokerURL, ok := canonicalBrokerURLFromLoginURL(start.URL); ok && !sameBrokerURL(brokerURL, nextBrokerURL) {
+			return exit(
+				3,
+				"GitHub login redirect_uri broker origin %s does not match approved broker %s; check CRABBOX_PUBLIC_URL",
+				nextBrokerURL,
+				normalizedBrokerURL(brokerURL),
+			)
 		}
 	}
 	if noBrowser {
@@ -197,19 +213,24 @@ func (a App) finishLogin(ctx context.Context, coord *CoordinatorClient, path str
 }
 
 func coordinatorClientForLogin(brokerURL, provider string) (*CoordinatorClient, error) {
+	coord, _, err := coordinatorClientConfigForLogin(brokerURL, provider)
+	return coord, err
+}
+
+func coordinatorClientConfigForLogin(brokerURL, provider string) (*CoordinatorClient, Config, error) {
 	cfg, err := loadConfigWithOverrides(brokerURL, provider)
 	if err != nil {
-		return nil, err
+		return nil, Config{}, err
 	}
 	cfg.CoordToken = ""
 	coord, ok, err := newCoordinatorClient(cfg)
 	if err != nil {
-		return nil, err
+		return nil, Config{}, err
 	}
 	if !ok {
-		return nil, exit(2, "login requires a broker URL")
+		return nil, Config{}, exit(2, "login requires a broker URL")
 	}
-	return coord, nil
+	return coord, cfg, nil
 }
 
 func validateGitHubLoginURL(loginURL string) error {
@@ -262,6 +283,15 @@ func canonicalBrokerURLFromLoginURL(loginURL string) (string, bool) {
 
 func sameBrokerURL(left, right string) bool {
 	return normalizedBrokerURL(left) == normalizedBrokerURL(right)
+}
+
+func brokerLoginRedirectOriginAllowed(cfg Config, brokerURL string) bool {
+	for _, origin := range cfg.BrokerLoginRedirectOrigins {
+		if sameBrokerURL(origin, brokerURL) {
+			return true
+		}
+	}
+	return false
 }
 
 func normalizedBrokerURL(value string) string {

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/url"
 	"os/exec"
 	"runtime"
@@ -298,6 +299,22 @@ func normalizedBrokerURL(value string) string {
 	u, err := url.Parse(value)
 	if err != nil {
 		return strings.TrimRight(value, "/")
+	}
+	u.Scheme = strings.ToLower(u.Scheme)
+	hostname := strings.ToLower(u.Hostname())
+	port := u.Port()
+	if (u.Scheme == "http" && port == "80") || (u.Scheme == "https" && port == "443") {
+		port = ""
+	}
+	if hostname != "" {
+		switch {
+		case port != "":
+			u.Host = net.JoinHostPort(hostname, port)
+		case strings.Contains(hostname, ":"):
+			u.Host = "[" + hostname + "]"
+		default:
+			u.Host = hostname
+		}
 	}
 	u.Path = strings.TrimRight(u.Path, "/")
 	u.RawQuery = ""

--- a/internal/cli/auth_test.go
+++ b/internal/cli/auth_test.go
@@ -536,7 +536,66 @@ func TestLoginWithTokenUsesEffectiveRegisteredMode(t *testing.T) {
 	}
 }
 
-func TestGitHubLoginMigratesToCanonicalRedirectOrigin(t *testing.T) {
+func TestGitHubLoginRejectsMismatchedRedirectOrigin(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("CRABBOX_CONFIG", "")
+	t.Setenv("CRABBOX_COORDINATOR", "")
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "")
+	t.Setenv("CRABBOX_PROVIDER", "")
+
+	callbackOrigin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer callbackOrigin.Close()
+
+	var startCount int
+	var pollCount int
+	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/auth/github/start":
+			startCount++
+			_ = json.NewEncoder(w).Encode(CoordinatorGitHubLoginStart{
+				LoginID:   "login_test",
+				URL:       githubAuthorizeURLForTest(callbackOrigin.URL),
+				ExpiresAt: time.Now().Add(time.Minute).Format(time.RFC3339),
+			})
+		case "/v1/auth/github/poll":
+			pollCount++
+			http.Error(w, "unexpected poll", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer broker.Close()
+
+	var stdout, stderr bytes.Buffer
+	app := App{Stdout: &stdout, Stderr: &stderr}
+	err := app.login(context.Background(), []string{"--url", broker.URL, "--provider", "aws", "--no-browser"})
+	if err == nil || !strings.Contains(err.Error(), "redirect_uri broker origin") {
+		t.Fatalf("error=%v", err)
+	}
+	if startCount != 1 || pollCount != 0 {
+		t.Fatalf("counts start=%d poll=%d", startCount, pollCount)
+	}
+	if strings.Contains(stderr.String(), "open this GitHub login URL") {
+		t.Fatalf("stderr=%q", stderr.String())
+	}
+	if stdout.String() != "" {
+		t.Fatalf("stdout=%q", stdout.String())
+	}
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Coordinator == callbackOrigin.URL || cfg.CoordToken != "" {
+		t.Fatalf("unexpected config: %#v", cfg)
+	}
+}
+
+func TestGitHubLoginMigratesToAllowedRedirectOrigin(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
@@ -605,6 +664,7 @@ func TestGitHubLoginMigratesToCanonicalRedirectOrigin(t *testing.T) {
 		}
 	}))
 	defer canonical.Close()
+	t.Setenv("CRABBOX_BROKER_LOGIN_REDIRECT_ORIGINS", canonical.URL)
 
 	var staleStartCount int
 	stale := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -618,7 +678,7 @@ func TestGitHubLoginMigratesToCanonicalRedirectOrigin(t *testing.T) {
 				ExpiresAt: time.Now().Add(time.Minute).Format(time.RFC3339),
 			})
 		case "/v1/auth/github/poll":
-			t.Fatal("poll should restart against canonical redirect origin")
+			t.Fatal("poll should restart against allowed redirect origin")
 		default:
 			http.NotFound(w, r)
 		}
@@ -645,6 +705,62 @@ func TestGitHubLoginMigratesToCanonicalRedirectOrigin(t *testing.T) {
 	}
 	if cfg.Coordinator != canonical.URL || cfg.CoordToken != "canonical-session-token" || cfg.Provider != "aws" {
 		t.Fatalf("unexpected config: %#v", cfg)
+	}
+}
+
+func TestGitHubLoginRejectsAllowedRedirectOriginThatChangesAgain(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("CRABBOX_CONFIG", "")
+	t.Setenv("CRABBOX_COORDINATOR", "")
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "")
+	t.Setenv("CRABBOX_PROVIDER", "")
+
+	nextOrigin := httptest.NewServer(http.NotFoundHandler())
+	defer nextOrigin.Close()
+
+	var canonical *httptest.Server
+	canonical = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/v1/auth/github/start" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(CoordinatorGitHubLoginStart{
+			LoginID:   "login_canonical",
+			URL:       githubAuthorizeURLForTest(nextOrigin.URL),
+			ExpiresAt: time.Now().Add(time.Minute).Format(time.RFC3339),
+		})
+	}))
+	defer canonical.Close()
+	t.Setenv("CRABBOX_BROKER_LOGIN_REDIRECT_ORIGINS", canonical.URL)
+
+	stale := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/v1/auth/github/start" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(CoordinatorGitHubLoginStart{
+			LoginID:   "login_stale",
+			URL:       githubAuthorizeURLForTest(canonical.URL),
+			ExpiresAt: time.Now().Add(time.Minute).Format(time.RFC3339),
+		})
+	}))
+	defer stale.Close()
+
+	var stdout, stderr bytes.Buffer
+	app := App{Stdout: &stdout, Stderr: &stderr}
+	err := app.login(context.Background(), []string{"--url", stale.URL, "--provider", "aws", "--no-browser"})
+	if err == nil || !strings.Contains(err.Error(), "does not match approved broker") {
+		t.Fatalf("error=%v", err)
+	}
+	if strings.Contains(stderr.String(), "open this GitHub login URL") {
+		t.Fatalf("stderr=%q", stderr.String())
+	}
+	if stdout.String() != "" {
+		t.Fatalf("stdout=%q", stdout.String())
 	}
 }
 

--- a/internal/cli/auth_test.go
+++ b/internal/cli/auth_test.go
@@ -781,6 +781,26 @@ func TestCanonicalBrokerURLFromLoginURL(t *testing.T) {
 	}
 }
 
+func TestSameBrokerURLNormalizesDefaultPorts(t *testing.T) {
+	tests := []struct {
+		name  string
+		left  string
+		right string
+		want  bool
+	}{
+		{name: "https default port", left: "https://broker.example.com", right: "https://BROKER.example.com:443/", want: true},
+		{name: "http default port", left: "http://broker.example.com", right: "HTTP://broker.example.com:80", want: true},
+		{name: "custom port", left: "https://broker.example.com", right: "https://broker.example.com:8443"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := sameBrokerURL(test.left, test.right); got != test.want {
+				t.Fatalf("sameBrokerURL(%q, %q)=%v, want %v", test.left, test.right, got, test.want)
+			}
+		})
+	}
+}
+
 func TestValidateGitHubLoginURL(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/cli/auth_test.go
+++ b/internal/cli/auth_test.go
@@ -550,6 +550,16 @@ func TestGitHubLoginRejectsMismatchedRedirectOrigin(t *testing.T) {
 	}))
 	defer callbackOrigin.Close()
 
+	repo := t.TempDir()
+	if err := os.WriteFile(
+		filepath.Join(repo, ".crabbox.yaml"),
+		[]byte("broker:\n  loginRedirectOrigins:\n    - "+callbackOrigin.URL+"\n"),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repo)
+
 	var startCount int
 	var pollCount int
 	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -47,6 +47,7 @@ type Config struct {
 	Coordinator                   string
 	BrokerMode                    BrokerMode
 	brokerProvider                string
+	BrokerLoginRedirectOrigins    []string
 	BrokerAutoWebVNC              bool
 	CoordToken                    string
 	CoordTokenCommand             []string
@@ -2984,13 +2985,14 @@ type fileWindowsConfig struct {
 }
 
 type fileBrokerConfig struct {
-	URL        string            `yaml:"url,omitempty"`
-	Mode       string            `yaml:"mode,omitempty"`
-	AutoWebVNC *bool             `yaml:"autoWebVNC,omitempty"`
-	Token      string            `yaml:"token,omitempty"`
-	AdminToken string            `yaml:"adminToken,omitempty"`
-	Provider   string            `yaml:"provider,omitempty"`
-	Access     *fileAccessConfig `yaml:"access,omitempty"`
+	URL                  string            `yaml:"url,omitempty"`
+	Mode                 string            `yaml:"mode,omitempty"`
+	AutoWebVNC           *bool             `yaml:"autoWebVNC,omitempty"`
+	LoginRedirectOrigins []string          `yaml:"loginRedirectOrigins,omitempty"`
+	Token                string            `yaml:"token,omitempty"`
+	AdminToken           string            `yaml:"adminToken,omitempty"`
+	Provider             string            `yaml:"provider,omitempty"`
+	Access               *fileAccessConfig `yaml:"access,omitempty"`
 }
 
 type fileAccessConfig struct {
@@ -4478,6 +4480,9 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 		}
 		if file.Broker.AutoWebVNC != nil {
 			cfg.BrokerAutoWebVNC = *file.Broker.AutoWebVNC
+		}
+		if trusted && len(file.Broker.LoginRedirectOrigins) > 0 {
+			cfg.BrokerLoginRedirectOrigins = normalizeList(file.Broker.LoginRedirectOrigins)
 		}
 		if file.Broker.AdminToken != "" {
 			cfg.CoordAdminToken = file.Broker.AdminToken
@@ -6945,6 +6950,9 @@ func applyEnv(cfg *Config) error {
 	cfg.BrokerMode = BrokerMode(getenv("CRABBOX_COORDINATOR_MODE", string(cfg.BrokerMode)))
 	if value, ok := getenvBool("CRABBOX_COORDINATOR_AUTO_WEBVNC"); ok {
 		cfg.BrokerAutoWebVNC = value
+	}
+	if value := os.Getenv("CRABBOX_BROKER_LOGIN_REDIRECT_ORIGINS"); value != "" {
+		cfg.BrokerLoginRedirectOrigins = splitCommaList(value)
 	}
 	if value := os.Getenv("CRABBOX_COORDINATOR_TOKEN"); value != "" {
 		cfg.CoordToken = value

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -116,26 +116,27 @@ func effectiveConfigForShow(cfg Config) Config {
 
 func configShowView(cfg Config) map[string]any {
 	return map[string]any{
-		"profile":            cfg.Profile,
-		"provider":           cfg.Provider,
-		"target":             cfg.TargetOS,
-		"architecture":       effectiveArchitectureForConfig(cfg),
-		"os":                 cfg.OSImage,
-		"windowsMode":        cfg.WindowsMode,
-		"class":              cfg.Class,
-		"serverType":         cfg.ServerType,
-		"serverTypeExplicit": cfg.ServerTypeExplicit,
-		"coordinator":        cfg.Coordinator,
-		"brokerMode":         cfg.BrokerMode,
-		"brokerAutoWebVNC":   cfg.BrokerAutoWebVNC,
-		"brokerAuth":         coordinatorTokenState(cfg),
-		"brokerAdminAuth":    tokenState(cfg.CoordAdminToken),
-		"accessAuth":         accessAuthState(cfg.Access),
-		"sshKey":             cfg.SSHKey,
-		"sshUser":            cfg.SSHUser,
-		"sshPort":            cfg.SSHPort,
-		"sshFallbackPorts":   cfg.SSHFallbackPorts,
-		"workRoot":           cfg.WorkRoot,
+		"profile":                    cfg.Profile,
+		"provider":                   cfg.Provider,
+		"target":                     cfg.TargetOS,
+		"architecture":               effectiveArchitectureForConfig(cfg),
+		"os":                         cfg.OSImage,
+		"windowsMode":                cfg.WindowsMode,
+		"class":                      cfg.Class,
+		"serverType":                 cfg.ServerType,
+		"serverTypeExplicit":         cfg.ServerTypeExplicit,
+		"coordinator":                cfg.Coordinator,
+		"brokerMode":                 cfg.BrokerMode,
+		"brokerAutoWebVNC":           cfg.BrokerAutoWebVNC,
+		"brokerLoginRedirectOrigins": cfg.BrokerLoginRedirectOrigins,
+		"brokerAuth":                 coordinatorTokenState(cfg),
+		"brokerAdminAuth":            tokenState(cfg.CoordAdminToken),
+		"accessAuth":                 accessAuthState(cfg.Access),
+		"sshKey":                     cfg.SSHKey,
+		"sshUser":                    cfg.SSHUser,
+		"sshPort":                    cfg.SSHPort,
+		"sshFallbackPorts":           cfg.SSHFallbackPorts,
+		"workRoot":                   cfg.WorkRoot,
 		"sync": map[string]any{
 			"exclude":     configuredExcludes(cfg),
 			"include":     syncIncludes(cfg),
@@ -617,7 +618,7 @@ func configShowView(cfg Config) map[string]any {
 func writeConfigShowText(w io.Writer, cfg Config) {
 	fmt.Fprintf(w, "config=%s\n", userConfigPath())
 	fmt.Fprintf(w, "provider=%s target=%s arch=%s os=%s windows_mode=%s class=%s type=%s profile=%s\n", cfg.Provider, cfg.TargetOS, effectiveArchitectureForConfig(cfg), cfg.OSImage, cfg.WindowsMode, cfg.Class, cfg.ServerType, cfg.Profile)
-	fmt.Fprintf(w, "broker=%s mode=%s auto_webvnc=%t auth=%s admin_auth=%s\n", blank(cfg.Coordinator, "-"), cfg.BrokerMode, cfg.BrokerAutoWebVNC, coordinatorTokenState(cfg), tokenState(cfg.CoordAdminToken))
+	fmt.Fprintf(w, "broker=%s mode=%s auto_webvnc=%t login_redirect_origins=%s auth=%s admin_auth=%s\n", blank(cfg.Coordinator, "-"), cfg.BrokerMode, cfg.BrokerAutoWebVNC, blank(strings.Join(cfg.BrokerLoginRedirectOrigins, ","), "-"), coordinatorTokenState(cfg), tokenState(cfg.CoordAdminToken))
 	fmt.Fprintf(w, "access_auth=%s\n", accessAuthState(cfg.Access))
 	fmt.Fprintf(w, "ssh=%s@<host>:%s fallback_ports=%s key=%s\n", cfg.SSHUser, cfg.SSHPort, blank(strings.Join(cfg.SSHFallbackPorts, ","), "-"), cfg.SSHKey)
 	fmt.Fprintf(w, "sync delete=%t checksum=%t git_seed=%t fingerprint=%t base_ref=%s excludes=%d includes=%d timeout=%s\n", cfg.Sync.Delete, cfg.Sync.Checksum, cfg.Sync.GitSeed, cfg.Sync.Fingerprint, blank(cfg.Sync.BaseRef, "-"), len(configuredExcludes(cfg)), len(syncIncludes(cfg)), cfg.Sync.Timeout)
@@ -830,6 +831,7 @@ func (a App) configSetBroker(args []string) error {
 	provider := fs.String("provider", "", "default provider (managed coordinator provider or registered direct provider)")
 	mode := fs.String("mode", "", "lease mode: managed or registered")
 	autoWebVNC := fs.Bool("auto-webvnc", true, "start a portal WebVNC bridge for kept registered desktop leases")
+	loginRedirectOrigins := fs.String("login-redirect-origins", "", "comma-separated callback broker origins allowed for GitHub login migration")
 	tokenStdin := fs.Bool("token-stdin", false, "read broker token from stdin")
 	adminTokenStdin := fs.Bool("admin-token-stdin", false, "read broker admin token from stdin")
 	if err := parseFlags(fs, args); err != nil {
@@ -893,6 +895,9 @@ func (a App) configSetBroker(args []string) error {
 	}
 	if flagWasSet(fs, "auto-webvnc") {
 		file.Broker.AutoWebVNC = autoWebVNC
+	}
+	if flagWasSet(fs, "login-redirect-origins") {
+		file.Broker.LoginRedirectOrigins = splitCommaList(*loginRedirectOrigins)
 	}
 	if token != "" {
 		file.Broker.Token = token


### PR DESCRIPTION
Closes #683.

Summary:
- reject GitHub login callback-origin changes by default before browser open, polling, or config write
- preserve same-deployment broker migrations through trusted `broker.loginRedirectOrigins` / `CRABBOX_BROKER_LOGIN_REDIRECT_ORIGINS` allowlists
- document the credential-destination rule and add regressions for default rejection, approved migration, and second-hop rejection

Upgrade context: callback-origin broker switches now fail closed unless the operator configures the target as a trusted login redirect origin.

Proof: focused PR-head CLI behavior output is posted in https://github.com/openclaw/crabbox/pull/744#issuecomment-4850381555.