### PR TITLE
fix: prevent run event lease audit retagging

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -685,7 +685,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	recordCommand := runScriptRecordCommand(script, command)
 	timingRecordCommand = recordCommand
 	if useCoordinator {
-		recorder = newRunRecorder(ctx, coord, cfg, recordCommand, runLabelValue, a.Stderr)
+		recorder = newRunRecorder(ctx, coord, cfg, recordCommand, runLabelValue, a.Stderr, strings.TrimSpace(*leaseIDFlag) != "")
 		defer func() {
 			recorder.Failed(runFailure)
 		}()

--- a/internal/cli/run_recorder.go
+++ b/internal/cli/run_recorder.go
@@ -36,9 +36,13 @@ type runRecorder struct {
 	telemetryDone      chan struct{}
 }
 
-func newRunRecorder(ctx context.Context, coord *CoordinatorClient, cfg Config, command []string, label string, stderr io.Writer) *runRecorder {
+func newRunRecorder(ctx context.Context, coord *CoordinatorClient, cfg Config, command []string, label string, stderr io.Writer, createAfterLease bool) *runRecorder {
 	rec := &runRecorder{coord: coord, command: command, label: strings.TrimSpace(label), stderr: stderr}
 	if coord == nil {
+		return rec
+	}
+	if createAfterLease {
+		rec.createPending = true
 		return rec
 	}
 	run, err := coord.CreateRun(ctx, "", cfg, command, rec.label)

--- a/internal/cli/run_recorder_test.go
+++ b/internal/cli/run_recorder_test.go
@@ -130,7 +130,7 @@ func TestRunRecorderDefersCreateWhenCoordinatorRequiresLeaseID(t *testing.T) {
 		Provider:   "aws",
 		Class:      "standard",
 		ServerType: "t3.small",
-	}, []string{"pnpm", "test"}, "", &stderr)
+	}, []string{"pnpm", "test"}, "", &stderr, false)
 	rec.Event("leasing.started", "leasing", "")
 	rec.AttachLease("cbx_abcdef123456", "blue-lobster", Config{
 		Provider:   "aws",
@@ -146,6 +146,61 @@ func TestRunRecorderDefersCreateWhenCoordinatorRequiresLeaseID(t *testing.T) {
 	}
 	if got := createBodies[1]["leaseID"]; got != "cbx_abcdef123456" {
 		t.Fatalf("second create leaseID=%#v", got)
+	}
+	if got := eventBody["type"]; got != "lease.created" {
+		t.Fatalf("event body=%#v", eventBody)
+	}
+	if text := stderr.String(); strings.Contains(text, "warning:") || !strings.Contains(text, "recording run run_123") {
+		t.Fatalf("stderr=%q", text)
+	}
+}
+
+func TestRunRecorderDefersCreateForExplicitLeaseRuns(t *testing.T) {
+	var stderr bytes.Buffer
+	var createBodies []map[string]any
+	var eventBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs":
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatal(err)
+			}
+			createBodies = append(createBodies, body)
+			_, _ = w.Write([]byte(`{"run":{"id":"run_123","leaseID":"cbx_abcdef123456","owner":"bob@example.com","org":"elsewhere","provider":"aws","class":"standard","serverType":"t3.small","command":["pnpm","test"],"state":"running","phase":"starting","logBytes":0,"logTruncated":false,"startedAt":"2026-05-02T00:00:00Z"}}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs/run_123/events":
+			if err := json.NewDecoder(r.Body).Decode(&eventBody); err != nil {
+				t.Fatal(err)
+			}
+			_, _ = w.Write([]byte(`{"event":{"runID":"run_123","seq":1,"type":"lease.created","leaseID":"cbx_abcdef123456","createdAt":"2026-05-02T00:00:01Z"}}`))
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := &CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
+	rec := newRunRecorder(context.Background(), client, Config{
+		Provider:   "aws",
+		Class:      "standard",
+		ServerType: "t3.small",
+	}, []string{"pnpm", "test"}, "", &stderr, true)
+	rec.Event("leasing.started", "leasing", "")
+	if len(createBodies) != 0 {
+		t.Fatalf("create requests before lease=%d want 0", len(createBodies))
+	}
+
+	rec.AttachLease("cbx_abcdef123456", "blue-lobster", Config{
+		Provider:   "aws",
+		Class:      "standard",
+		ServerType: "t3.small",
+	})
+
+	if len(createBodies) != 1 {
+		t.Fatalf("create requests=%d want 1", len(createBodies))
+	}
+	if got := createBodies[0]["leaseID"]; got != "cbx_abcdef123456" {
+		t.Fatalf("create leaseID=%#v", got)
 	}
 	if got := eventBody["type"]; got != "lease.created" {
 		t.Fatalf("event body=%#v", eventBody)
@@ -188,7 +243,7 @@ func TestRunRecorderRetriesTransientCreateFailureAfterLease(t *testing.T) {
 		Provider:   "aws",
 		Class:      "standard",
 		ServerType: "t3.small",
-	}, []string{"go", "test"}, "", &stderr)
+	}, []string{"go", "test"}, "", &stderr, false)
 	rec.Event("leasing.started", "leasing", "")
 	rec.AttachLease("cbx_abcdef123456", "blue-lobster", Config{
 		Provider:   "aws",
@@ -247,7 +302,7 @@ func TestRunRecorderMarksHistoryUnavailableAfterPersistentCreateFailure(t *testi
 		Provider:   "aws",
 		Class:      "standard",
 		ServerType: "t3.small",
-	}, []string{"go", "test"}, "", &stderr)
+	}, []string{"go", "test"}, "", &stderr, false)
 	rec.AttachLease("cbx_abcdef123456", "blue-lobster", Config{
 		Provider:   "aws",
 		Class:      "standard",
@@ -307,7 +362,7 @@ func TestRunRecorderRetriesFailedLeaseCreateOnReplacementLease(t *testing.T) {
 		Provider:   "aws",
 		Class:      "standard",
 		ServerType: "t3.small",
-	}, []string{"go", "test"}, "", &stderr)
+	}, []string{"go", "test"}, "", &stderr, false)
 	rec.AttachLease("cbx_initial123456", "blue-lobster", Config{
 		Provider:   "aws",
 		Class:      "standard",
@@ -407,7 +462,7 @@ func TestRunRecorderSuppressesMissingEventEndpoint(t *testing.T) {
 		Provider:   "aws",
 		Class:      "standard",
 		ServerType: "t3.small",
-	}, []string{"pnpm", "test"}, "", &stderr)
+	}, []string{"pnpm", "test"}, "", &stderr, false)
 	rec.AttachLease("cbx_abcdef123456", "blue-lobster", Config{
 		Provider:   "aws",
 		Class:      "standard",

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -9336,7 +9336,7 @@ export class FleetCoordinator {
       const input = await readJson<RunEventRequest>(request);
       if (input.leaseID && input.leaseID !== run.leaseID) {
         const lease = validLeaseID(input.leaseID) ? await this.getLease(input.leaseID) : undefined;
-        if (!lease || !this.leaseVisibleToRequest(lease, request, isAdminRequest(request))) {
+        if (!lease || !this.leaseManageableByRequest(lease, request, isAdminRequest(request))) {
           return notFound();
         }
       }

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -16956,6 +16956,118 @@ describe("fleet run history", () => {
     ).toBe(404);
   });
 
+  it("allows use-share users to create validated lease-attributed runs", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const ownerHeaders = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const actorHeaders = {
+      "x-crabbox-owner": "bob@example.com",
+      "x-crabbox-org": "elsewhere",
+    };
+    storage.seed(
+      "lease:cbx_000000000001",
+      testLease({
+        id: "cbx_000000000001",
+        slug: "blue-lobster",
+        owner: "alice@example.com",
+        org: "example-org",
+        share: { users: { "bob@example.com": "use" } },
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      }),
+    );
+
+    const create = await fleet.fetch(
+      request("POST", "/v1/runs", {
+        headers: actorHeaders,
+        body: {
+          leaseID: "cbx_000000000001",
+          command: ["pnpm", "test"],
+        },
+      }),
+    );
+    expect(create.status).toBe(201);
+    const { run } = (await create.json()) as { run: RunRecord };
+    expect(run).toMatchObject({
+      owner: "bob@example.com",
+      org: "elsewhere",
+      leaseID: "cbx_000000000001",
+      leaseIDs: ["cbx_000000000001"],
+      leaseOwners: [{ owner: "alice@example.com", org: "example-org" }],
+    });
+
+    const ownerList = await fleet.fetch(
+      request("GET", "/v1/runs?leaseID=cbx_000000000001", { headers: ownerHeaders }),
+    );
+    await expect(ownerList.json()).resolves.toMatchObject({
+      runs: [{ id: run.id, owner: "bob@example.com" }],
+    });
+  });
+
+  it("blocks use-share users from re-tagging unrelated runs into lease owner audits", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const ownerHeaders = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const actorHeaders = {
+      "x-crabbox-owner": "bob@example.com",
+      "x-crabbox-org": "elsewhere",
+    };
+    storage.seed(
+      "lease:cbx_000000000001",
+      testLease({
+        id: "cbx_000000000001",
+        slug: "blue-lobster",
+        owner: "alice@example.com",
+        org: "example-org",
+        share: { users: { "bob@example.com": "use" } },
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      }),
+    );
+
+    const create = await fleet.fetch(
+      request("POST", "/v1/runs", {
+        headers: actorHeaders,
+        body: {
+          command: ["pnpm", "test"],
+        },
+      }),
+    );
+    expect(create.status).toBe(201);
+    const { run } = (await create.json()) as { run: RunRecord };
+    expect(run.leaseID).toBe("");
+
+    const reattribute = await fleet.fetch(
+      request("POST", `/v1/runs/${run.id}/events`, {
+        headers: actorHeaders,
+        body: {
+          type: "lease.created",
+          leaseID: "cbx_000000000001",
+          slug: "blue-lobster",
+        },
+      }),
+    );
+    expect(reattribute.status).toBe(404);
+
+    expect(storage.value<RunRecord>(`run:${run.id}`)).toMatchObject({
+      leaseID: "",
+      leaseIDs: [],
+      leaseOwners: [],
+      eventCount: 1,
+    });
+    const ownerList = await fleet.fetch(
+      request("GET", "/v1/runs?leaseID=cbx_000000000001", { headers: ownerHeaders }),
+    );
+    await expect(ownerList.json()).resolves.toEqual({ runs: [] });
+    expect(
+      (await fleet.fetch(request("GET", `/v1/runs/${run.id}`, { headers: ownerHeaders }))).status,
+    ).toBe(404);
+  });
+
   it("reconstructs backing lease audit access for legacy runs", async () => {
     const storage = new MemoryStorage();
     const fleet = testFleet(storage);


### PR DESCRIPTION
Closes #684.

Summary:
- require manage/admin access for post-create run event lease attribution changes
- preserve explicit existing-lease `crabbox run --id ...` audit attribution by creating run history after the lease is resolved
- add focused coverage for validated use-share runs and rejected unrelated re-tag attempts

Upgrade context: clients that need use-share run attribution should create run history with the resolved `leaseID` up front. Post-create event re-tagging now fails closed unless the requester can manage the lease.

Proof: live coordinator output is posted in https://github.com/openclaw/crabbox/pull/745#issuecomment-4850619048.
