### PR TITLE
fix: derive coordinator lease provider keys

### DIFF
--- a/worker/src/config.ts
+++ b/worker/src/config.ts
@@ -317,7 +317,7 @@ export function leaseConfig(input: LeaseRequest, defaults: LeaseConfigDefaults =
     sshUser,
     sshPort: input.sshPort ?? "2222",
     sshFallbackPorts: validPorts(input.sshFallbackPorts ?? ["22"]),
-    providerKey: input.providerKey ?? "crabbox-steipete",
+    providerKey: input.providerKey?.trim() ?? "",
     workRoot: input.workRoot ?? defaultWorkRoot(target, windowsMode, sshUser),
     ttlSeconds,
     idleTimeoutSeconds,

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -1722,6 +1722,10 @@ export class FleetCoordinator {
     if (retainedMacHostLease && !config.serverTypeExplicit) {
       config = { ...config, serverType: retainedMacHostLease.serverType };
     }
+    const leaseID = validLeaseID(input.leaseID) ? input.leaseID : newLeaseID();
+    if (!config.providerKey) {
+      config = { ...config, providerKey: providerKeyForLease(leaseID) };
+    }
     config =
       (await this.provider(
         config.provider,
@@ -1743,7 +1747,6 @@ export class FleetCoordinator {
         { status: 424 },
       );
     }
-    const leaseID = validLeaseID(input.leaseID) ? input.leaseID : newLeaseID();
     const provider = this.provider(
       config.provider,
       providerRegionForConfig(config),
@@ -12102,6 +12105,10 @@ function newLeaseID(): string {
   const bytes = new Uint8Array(6);
   crypto.getRandomValues(bytes);
   return `cbx_${[...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("")}`;
+}
+
+function providerKeyForLease(leaseID: string): string {
+  return `crabbox-${leaseID.replaceAll("_", "-")}`;
 }
 
 function validWorkspaceID(value: string | undefined): value is string {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -3239,6 +3239,49 @@ describe("fleet lease identity and idle", () => {
     );
   });
 
+  it("derives a lease-scoped provider key for direct leases that omit one", async () => {
+    const storage = new MemoryStorage();
+    let preparedProviderKey = "";
+    let createdProviderKey = "";
+    const fleet = testFleet(storage, {
+      aws: fakeProvider(
+        (config) => {
+          createdProviderKey = config.providerKey;
+        },
+        {
+          provider: "aws",
+          onPrepareLeaseConfig: (config) => {
+            preparedProviderKey = config.providerKey;
+            return config;
+          },
+        },
+      ),
+    });
+
+    const response = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers: {
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
+        },
+        body: {
+          leaseID: "cbx_abcdef123456",
+          provider: "aws",
+          serverType: "c7a.8xlarge",
+          sshPublicKey: "ssh-ed25519 direct-test",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    const expectedProviderKey = "crabbox-cbx-abcdef123456";
+    expect(preparedProviderKey).toBe(expectedProviderKey);
+    expect(createdProviderKey).toBe(expectedProviderKey);
+    expect(storage.value<LeaseRecord>("lease:cbx_abcdef123456")?.providerKey).toBe(
+      expectedProviderKey,
+    );
+  });
+
   it("adapts workspaces onto owner-scoped lease lifecycle", async () => {
     const storage = new MemoryStorage();
     let createdClass = "";


### PR DESCRIPTION
Closes #696.

Summary:
- stop raw lease config from defaulting to the shared `crabbox-steipete` provider key
- derive a lease-scoped provider key once the coordinator finalizes the lease ID
- add regression coverage for direct AWS leases that omit `providerKey`

Upgrade context: direct coordinator API callers that omit `providerKey` now receive per-lease SSH key names instead of the legacy shared fallback. Callers that intentionally need a stable provider key should pass one explicitly; the separate explicit-key trust scope remains tracked in #706.

Proof: live direct coordinator output is posted in https://github.com/openclaw/crabbox/pull/747#issuecomment-4850641598.
