### PR TITLE
fix: guard Cloudflare Sandbox redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
 
 ### Fixed
 
+- Prevented Cloudflare Sandbox bridge credentials and request bodies from following redirects outside the configured bridge origin while preserving same-origin redirects. Thanks @coygeek.
 - Dropped invalid allowlisted environment names before rendering remote POSIX or Windows commands, preventing shell metacharacters in ambient names from creating unintended commands. Thanks @coygeek.
 - Pinned Windows Chocolatey image bootstrap to a checksum-verified versioned package before privileged installation. Thanks @TurboTheTurtle.
 - Redacted Daytona API and upload credentials from provider error diagnostics, including reflected authorization headers and token-bearing JSON fields. Thanks @TurboTheTurtle.

--- a/internal/providers/cloudflaresandbox/client.go
+++ b/internal/providers/cloudflaresandbox/client.go
@@ -111,8 +111,55 @@ func newBridgeClient(cfg Config, rt Runtime) (bridgeClient, error) {
 	return &client{
 		baseURL: baseURL,
 		token:   strings.TrimSpace(cfg.CloudflareSandbox.Token),
-		http:    httpClient,
+		http:    secureCloudflareSandboxHTTPClient(httpClient, baseURL),
 	}, nil
+}
+
+func secureCloudflareSandboxHTTPClient(source *http.Client, baseURL string) *http.Client {
+	client := *source
+	trusted, _ := url.Parse(baseURL)
+	originalCheckRedirect := source.CheckRedirect
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if !sameCloudflareSandboxOrigin(trusted, req.URL) {
+			return fmt.Errorf("%s refused cross-origin redirect to %s", providerName, cloudflareSandboxRedirectOrigin(req.URL))
+		}
+		if originalCheckRedirect != nil {
+			return originalCheckRedirect(req, via)
+		}
+		if len(via) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+		return nil
+	}
+	return &client
+}
+
+func sameCloudflareSandboxOrigin(a, b *url.URL) bool {
+	return a != nil && b != nil &&
+		strings.EqualFold(a.Scheme, b.Scheme) &&
+		strings.EqualFold(a.Hostname(), b.Hostname()) &&
+		effectiveCloudflareSandboxPort(a) == effectiveCloudflareSandboxPort(b)
+}
+
+func effectiveCloudflareSandboxPort(value *url.URL) string {
+	if port := value.Port(); port != "" {
+		return port
+	}
+	switch strings.ToLower(value.Scheme) {
+	case "https":
+		return "443"
+	case "http":
+		return "80"
+	default:
+		return ""
+	}
+}
+
+func cloudflareSandboxRedirectOrigin(value *url.URL) string {
+	if value == nil || value.Scheme == "" || value.Host == "" {
+		return "<redacted>"
+	}
+	return value.Scheme + "://" + value.Host
 }
 
 func (c *client) Health(ctx context.Context) (healthResponse, error) {
@@ -431,7 +478,12 @@ func (c *client) doRequest(ctx context.Context, method, route string, authentica
 	}
 	resp, err := c.http.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("%s %s %s: %s", providerName, method, route, c.redact(err.Error()))
+		requestErr := err
+		var urlErr *url.Error
+		if errors.As(err, &urlErr) && urlErr.Err != nil {
+			requestErr = urlErr.Err
+		}
+		return nil, fmt.Errorf("%s %s %s: %s", providerName, method, route, c.redact(requestErr.Error()))
 	}
 	return resp, nil
 }

--- a/internal/providers/cloudflaresandbox/client_test.go
+++ b/internal/providers/cloudflaresandbox/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -84,6 +85,116 @@ func TestBridgeClientClassifiesOnlyHTTP404AsNotFound(t *testing.T) {
 	status = http.StatusUnauthorized
 	if _, err := api.GetSandbox(context.Background(), "missing"); err == nil || isCloudflareSandboxNotFound(err) {
 		t.Fatalf("401 err=%v, want non-not-found error", err)
+	}
+}
+
+func TestBridgeClientRefusesCrossOriginRedirectBeforeReplay(t *testing.T) {
+	var targetRequests int
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		targetRequests++
+		t.Errorf("redirect target received %s %s auth=%q", r.Method, r.URL.Path, r.Header.Get("Authorization"))
+		http.Error(w, "unexpected request", http.StatusInternalServerError)
+	}))
+	defer target.Close()
+
+	location := strings.Replace(target.URL, "http://", "http://user:password@", 1) + "/stolen?query-secret=1#fragment-secret"
+	trusted := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", location)
+		w.WriteHeader(http.StatusTemporaryRedirect)
+	}))
+	defer trusted.Close()
+
+	cfg := testConfig()
+	cfg.CloudflareSandbox.BridgeURL = trusted.URL
+	cfg.CloudflareSandbox.Token = "cf_sandbox_test_token"
+	api, err := newBridgeClient(cfg, Runtime{HTTP: trusted.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = api.CreateSandbox(context.Background(), createSandboxRequest{Name: "test"})
+	if err == nil || !strings.Contains(err.Error(), "refused cross-origin redirect") {
+		t.Fatalf("CreateSandbox error = %v, want cross-origin refusal", err)
+	}
+	if targetRequests != 0 {
+		t.Fatalf("redirect target received %d requests, want 0", targetRequests)
+	}
+	for _, secret := range []string{"cf_sandbox_test_token", "user", "password", "query-secret", "fragment-secret"} {
+		if strings.Contains(err.Error(), secret) {
+			t.Fatalf("redirect error leaked %q: %v", secret, err)
+		}
+	}
+}
+
+func TestBridgeClientFollowsSameOriginRedirect(t *testing.T) {
+	var redirectedAuth, redirectedBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/sandbox":
+			http.Redirect(w, r, "/redirected", http.StatusTemporaryRedirect)
+		case "/redirected":
+			redirectedAuth = r.Header.Get("Authorization")
+			body, _ := io.ReadAll(r.Body)
+			redirectedBody = string(body)
+			writeTestJSON(w, sandboxSummary{ID: "sb_123"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	cfg := testConfig()
+	cfg.CloudflareSandbox.BridgeURL = server.URL
+	cfg.CloudflareSandbox.Token = "cf_sandbox_test_token"
+	api, err := newBridgeClient(cfg, Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := api.CreateSandbox(context.Background(), createSandboxRequest{Name: "test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.ID != "sb_123" || redirectedAuth != "Bearer cf_sandbox_test_token" || !strings.Contains(redirectedBody, `"name":"test"`) {
+		t.Fatalf("result=%#v auth=%q body=%q", result, redirectedAuth, redirectedBody)
+	}
+}
+
+func TestBridgeClientPreservesCallerRedirectPolicy(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/redirected", http.StatusFound)
+	}))
+	defer server.Close()
+
+	callerErr := errors.New("caller refused redirect")
+	callerChecks := 0
+	httpClient := server.Client()
+	httpClient.CheckRedirect = func(*http.Request, []*http.Request) error {
+		callerChecks++
+		return callerErr
+	}
+	cfg := testConfig()
+	cfg.CloudflareSandbox.BridgeURL = server.URL
+	api, err := newBridgeClient(cfg, Runtime{HTTP: httpClient})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = api.OpenAPI(context.Background())
+	if err == nil || !strings.Contains(err.Error(), callerErr.Error()) || callerChecks != 1 {
+		t.Fatalf("OpenAPI error = %v, caller checks = %d", err, callerChecks)
+	}
+}
+
+func TestBridgeClientRetainsDefaultRedirectLimitWithoutMutatingSource(t *testing.T) {
+	source := &http.Client{}
+	secured := secureCloudflareSandboxHTTPClient(source, "http://localhost")
+	req, err := http.NewRequest(http.MethodGet, "http://localhost/redirected", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := secured.CheckRedirect(req, make([]*http.Request, 10)); err == nil || !strings.Contains(err.Error(), "stopped after 10 redirects") {
+		t.Fatalf("CheckRedirect error = %v, want default redirect limit", err)
+	}
+	if source.CheckRedirect != nil {
+		t.Fatal("secure client mutated caller-provided http.Client")
 	}
 }
 


### PR DESCRIPTION
## Summary

- clone the configured Cloudflare Sandbox bridge HTTP client and enforce exact scheme, hostname, and effective-port redirects
- preserve same-origin redirects, caller redirect policy, and the standard ten-redirect cap
- strip Go's full redirect URL wrapper from surfaced errors so userinfo, query, and fragment data cannot leak
- cover authenticated POST replay, same-origin body/auth preservation, caller policy, client immutability, redirect limits, and error redaction

Closes https://github.com/openclaw/crabbox/issues/729

## Verification

- `go test ./internal/providers/cloudflaresandbox -count=1`
- `go vet ./internal/providers/cloudflaresandbox`
- autoreview clean (0.90)

## Security/config implications

Authenticated bridge traffic can no longer leave the configured exact origin through redirects. Existing bridge URL/token configuration is unchanged; no new secrets or migration are required.
