### PR TITLE
build: update Go toolchain to 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/openclaw/crabbox
 
 go 1.26
 
-toolchain go1.26.3
+toolchain go1.26.4
 
 require (
 	cloud.google.com/go/compute v1.64.0


### PR DESCRIPTION
## Summary

- update the pinned Go toolchain from 1.26.3 to the current 1.26.4 security patch
- remove reachable standard-library findings in `crypto/x509` and `mime`/`net/textproto` paths
- keep the language version and dependency graph unchanged

## Verification

- `GOTOOLCHAIN=go1.26.4 govulncheck ./...` (no vulnerabilities found)
- `GOTOOLCHAIN=go1.26.4 go vet ./...`
- `GOTOOLCHAIN=go1.26.4 go test -p 1 ./...`
- focused reruns for two load-sensitive baseline tests, three passes each
- autoreview clean

The unconstrained parallel full test run initially hit two timing-sensitive baseline failures; both passed three focused reruns, and the full suite passed with package parallelism limited to one.

Security fixes: https://pkg.go.dev/vuln/GO-2026-5037 and https://pkg.go.dev/vuln/GO-2026-5039.
