### PR TITLE
fix: pin Google Linux signing key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 
 ### Fixed
 
+- Pinned the Google Chrome Linux APT trust key to Google's published primary fingerprint and scoped it to the Chrome repository before managed browser installation. Thanks @coygeek.
 - Prevented revoked lease managers from retaining mediated-egress bridges after lease sharing was removed or downgraded. Thanks @coygeek.
 - Prevented the Code portal proxy from forwarding coordinator authentication context to lease-controlled code-server requests. Thanks @coygeek.
 - Rejected GitHub login callback origins that differ from the selected broker unless explicitly allowlisted as a trusted alias, preventing OAuth callbacks from silently redirecting stored credentials. Thanks @TurboTheTurtle.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,6 @@
 
 ### Fixed
 
-- Pinned the Google Chrome Linux APT trust key to Google's published primary fingerprint and scoped it to the Chrome repository before managed browser installation. Thanks @coygeek.
 - Prevented revoked lease managers from retaining mediated-egress bridges after lease sharing was removed or downgraded. Thanks @coygeek.
 - Prevented the Code portal proxy from forwarding coordinator authentication context to lease-controlled code-server requests. Thanks @coygeek.
 - Rejected GitHub login callback origins that differ from the selected broker unless explicitly allowlisted as a trusted alias, preventing OAuth callbacks from silently redirecting stored credentials. Thanks @TurboTheTurtle.

--- a/docs/features/image-bake-runbook.md
+++ b/docs/features/image-bake-runbook.md
@@ -307,7 +307,9 @@ scripts/mint-aws-devtools-image.sh \
 - **Linux** (`scripts/install-linux-developer-tools.sh`): common CLI/build
   tooling, GitHub CLI, Node 24, corepack/pnpm, Chrome or Chromium for browser
   lanes, desktop/VNC helpers, Docker Engine, Compose, buildx, and a small
-  default Docker image set.
+  default Docker image set. Chrome's APT repository uses a scoped keyring whose
+  Google-published primary fingerprint is checked before installation; primary
+  key rotations require a reviewed code update and a fresh image-bake smoke.
 - **Windows** (`scripts/install-windows-developer-tools.ps1`): common CLI/build
   tooling, GitHub CLI, Node 24, corepack/pnpm, and Windows Server container
   support with Docker Engine. It deliberately avoids Docker Desktop because

--- a/docs/features/image-bake-runbook.md
+++ b/docs/features/image-bake-runbook.md
@@ -309,7 +309,8 @@ scripts/mint-aws-devtools-image.sh \
   lanes, desktop/VNC helpers, Docker Engine, Compose, buildx, and a small
   default Docker image set. Chrome's APT repository uses a scoped keyring whose
   Google-published primary fingerprint is checked before installation; primary
-  key rotations require a reviewed code update and a fresh image-bake smoke.
+  key rotations require a reviewed code update and a fresh image-bake smoke;
+  failed verification skips Chrome and tries the distro Chromium package.
 - **Windows** (`scripts/install-windows-developer-tools.ps1`): common CLI/build
   tooling, GitHub CLI, Node 24, corepack/pnpm, and Windows Server container
   support with Docker Engine. It deliberately avoids Docker Desktop because

--- a/docs/security.md
+++ b/docs/security.md
@@ -301,6 +301,20 @@ digests embedded alongside their URLs. Generated PowerShell verifies every
 download before extraction, execution, or WSL import, removes mismatched bytes,
 and fails bootstrap closed. URL and digest updates are reviewed together.
 
+## Managed Linux Browser Trust
+
+Managed Linux browser bootstrap pins Google's active Linux package-signing
+primary fingerprint. The bootstrap imports downloaded key material into an
+isolated temporary GnuPG home, exports only the approved primary key and its
+signing subkeys into a repository-scoped keyring, and binds the Chrome APT
+source to that keyring with `signed-by`. A missing or changed primary key fails
+closed before replacing the prior keyring or repository source.
+
+Signing-subkey rotations beneath the approved primary key continue without a
+Crabbox update. A Google primary-key rotation requires a reviewed fingerprint
+update against [Google's official Linux repository key page](https://www.google.com/linuxrepositories/)
+and fresh bootstrap proof; there is no fallback to an unpinned key.
+
 ## SSH
 
 SSH is the control and data path to a leased box; the broker manages leases but

--- a/docs/security.md
+++ b/docs/security.md
@@ -308,7 +308,8 @@ primary fingerprint. The bootstrap imports downloaded key material into an
 isolated temporary GnuPG home, exports only the approved primary key and its
 signing subkeys into a repository-scoped keyring, and binds the Chrome APT
 source to that keyring with `signed-by`. A missing or changed primary key fails
-closed before replacing the prior keyring or repository source.
+closed before replacing the prior keyring or repository source; browser setup
+then tries the distro Chromium package without trusting the unexpected key.
 
 Signing-subkey rotations beneath the approved primary key continue without a
 Crabbox update. A Google primary-key rotation requires a reviewed fingerprint

--- a/scripts/install-linux-developer-tools.sh
+++ b/scripts/install-linux-developer-tools.sh
@@ -166,17 +166,20 @@ install_chrome_or_chromium() {
   local browser_path=""
   if [[ "$(dpkg --print-architecture)" == "amd64" ]]; then
     install -d -m 0755 "$apt_sources_dir"
-    install_apt_keyring \
+    if install_apt_keyring \
       https://dl.google.com/linux/linux_signing_key.pub \
       "$apt_keyrings_dir/google-linux.gpg" \
-      "$google_linux_signing_key_fingerprint"
-    printf 'deb [arch=amd64 signed-by=%s/google-linux.gpg] https://dl.google.com/linux/chrome/deb/ stable main\n' "$apt_keyrings_dir" \
-      >"$apt_sources_dir/google-chrome.list"
-    if retry apt-get update && apt_install google-chrome-stable; then
-      browser_path="$(command -v google-chrome || true)"
+      "$google_linux_signing_key_fingerprint"; then
+      printf 'deb [arch=amd64 signed-by=%s/google-linux.gpg] https://dl.google.com/linux/chrome/deb/ stable main\n' "$apt_keyrings_dir" \
+        >"$apt_sources_dir/google-chrome.list"
+      if retry apt-get update && apt_install google-chrome-stable; then
+        browser_path="$(command -v google-chrome || true)"
+      else
+        rm -f "$apt_sources_dir/google-chrome.list"
+        retry apt-get update || true
+      fi
     else
-      rm -f "$apt_sources_dir/google-chrome.list"
-      retry apt-get update || true
+      log "Google Linux signing key verification failed; trying Chromium fallback"
     fi
   fi
   if [[ -z "$browser_path" ]]; then

--- a/scripts/install-linux-developer-tools.sh
+++ b/scripts/install-linux-developer-tools.sh
@@ -14,6 +14,7 @@ chrome_policy_dir="${CRABBOX_LINUX_CHROME_POLICY_DIR:-/etc/opt/chrome/policies/m
 chromium_policy_dir="${CRABBOX_LINUX_CHROMIUM_POLICY_DIR:-/etc/chromium/policies/managed}"
 browser_bin_dir="${CRABBOX_LINUX_BROWSER_BIN_DIR:-/usr/local/bin}"
 browser_state_dir="${CRABBOX_LINUX_BROWSER_STATE_DIR:-/var/lib/crabbox}"
+google_linux_signing_key_fingerprint="EB4C1BFD4F042F6DDDCCEC917721F63BD38B4796"
 
 log() {
   printf 'linux-tools: %s\n' "$*" >&2
@@ -64,11 +65,37 @@ os_release_value() {
 install_apt_keyring() {
   local url="$1"
   local target="$2"
+  local expected_fingerprint="${3:-}"
+  local actual_fingerprint=""
+  local downloaded_key=""
+  local key_home=""
   local tmp_dir
   local tmp_key
   install -d -m 0755 "$(dirname "$target")"
   tmp_dir="$(mktemp -d "${target}.tmp.XXXXXX")"
   tmp_key="$tmp_dir/keyring.gpg"
+  if [[ -n "$expected_fingerprint" ]]; then
+    downloaded_key="$tmp_dir/downloaded.asc"
+    key_home="$tmp_dir/gnupg"
+    install -d -m 0700 "$key_home"
+    if curl -fsSL "$url" >"$downloaded_key" &&
+      GNUPGHOME="$key_home" gpg --batch --import "$downloaded_key" >/dev/null 2>&1; then
+      actual_fingerprint="$(
+        GNUPGHOME="$key_home" gpg --batch --with-colons --fingerprint "$expected_fingerprint" 2>/dev/null |
+          awk -F: '$1 == "fpr" { print $10; exit }' || true
+      )"
+      if [[ "$actual_fingerprint" == "$expected_fingerprint" ]] &&
+        GNUPGHOME="$key_home" gpg --batch --export "$expected_fingerprint" >"$tmp_key" &&
+        [[ -s "$tmp_key" ]]; then
+        chmod 0644 "$tmp_key"
+        mv -f "$tmp_key" "$target"
+        rm -rf "$tmp_dir"
+        return 0
+      fi
+    fi
+    rm -rf "$tmp_dir"
+    return 1
+  fi
   if curl -fsSL "$url" | gpg --batch --yes --dearmor -o "$tmp_key"; then
     chmod 0644 "$tmp_key"
     mv -f "$tmp_key" "$target"
@@ -139,7 +166,10 @@ install_chrome_or_chromium() {
   local browser_path=""
   if [[ "$(dpkg --print-architecture)" == "amd64" ]]; then
     install -d -m 0755 "$apt_sources_dir"
-    install_apt_keyring https://dl.google.com/linux/linux_signing_key.pub "$apt_keyrings_dir/google-linux.gpg"
+    install_apt_keyring \
+      https://dl.google.com/linux/linux_signing_key.pub \
+      "$apt_keyrings_dir/google-linux.gpg" \
+      "$google_linux_signing_key_fingerprint"
     printf 'deb [arch=amd64 signed-by=%s/google-linux.gpg] https://dl.google.com/linux/chrome/deb/ stable main\n' "$apt_keyrings_dir" \
       >"$apt_sources_dir/google-chrome.list"
     if retry apt-get update && apt_install google-chrome-stable; then

--- a/scripts/install-linux-developer-tools.test.js
+++ b/scripts/install-linux-developer-tools.test.js
@@ -6,10 +6,68 @@ import { spawnSync } from "node:child_process";
 import test from "node:test";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
+const googleLinuxSigningKeyFingerprint = "EB4C1BFD4F042F6DDDCCEC917721F63BD38B4796";
 
 function writeExecutable(file, body) {
 	fs.writeFileSync(file, body, "utf8");
 	fs.chmodSync(file, 0o755);
+}
+
+function writeFakeGPG(bin) {
+	writeExecutable(
+		path.join(bin, "gpg"),
+		`#!/usr/bin/env bash
+set -euo pipefail
+mode=""
+output=""
+value=""
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --batch|--yes|--with-colons)
+      shift
+      ;;
+    --dearmor)
+      mode="dearmor"
+      shift
+      ;;
+    --import|--fingerprint|--export)
+      mode="\${1#--}"
+      value="\${2:-}"
+      shift 2
+      ;;
+    -o)
+      output="\${2:-}"
+      shift 2
+      ;;
+    *)
+      printf 'unexpected gpg arg: %s\\n' "$1" >&2
+      exit 64
+      ;;
+  esac
+done
+case "$mode" in
+  dearmor)
+    [[ -n "$output" ]] || exit 65
+    cat >"$output"
+    printf '%s\\n' "$output" >>"$CRABBOX_FAKE_GPG_LOG"
+    ;;
+  import)
+    [[ -s "$value" ]] || exit 66
+    ;;
+  fingerprint)
+    printf 'pub:-:4096:1:7721F63BD38B4796:0::::::scSC::::::23::0:\\n'
+    printf 'fpr:::::::::%s:\\n' "\${CRABBOX_FAKE_GPG_FINGERPRINT:-${googleLinuxSigningKeyFingerprint}}"
+    ;;
+  export)
+    printf 'fake-export:%s\\n' "$value"
+    printf 'export:%s\\n' "$value" >>"$CRABBOX_FAKE_GPG_LOG"
+    ;;
+  *)
+    exit 67
+    ;;
+esac
+`,
+	);
 }
 
 test("linux developer tool repository setup rewrites keyrings idempotently", () => {
@@ -34,41 +92,7 @@ set -euo pipefail
 printf 'fake-key:%s\\n' "$*"
 `,
 	);
-	writeExecutable(
-		path.join(bin, "gpg"),
-		`#!/usr/bin/env bash
-set -euo pipefail
-batch=0
-yes=0
-output=""
-while [[ "$#" -gt 0 ]]; do
-  case "$1" in
-    --batch)
-      batch=1
-      shift
-      ;;
-    --yes)
-      yes=1
-      shift
-      ;;
-    --dearmor)
-      shift
-      ;;
-    -o)
-      output="\${2:-}"
-      shift 2
-      ;;
-    *)
-      printf 'unexpected gpg arg: %s\\n' "$1" >&2
-      exit 64
-      ;;
-  esac
-done
-[[ "$batch" == "1" && "$yes" == "1" && -n "$output" ]] || exit 65
-cat >"$output"
-printf '%s\\n' "$output" >>"$CRABBOX_FAKE_GPG_LOG"
-`,
-	);
+	writeFakeGPG(bin);
 	writeExecutable(
 		path.join(bin, "node"),
 		`#!/usr/bin/env bash
@@ -167,4 +191,72 @@ exit 1
 	assert.equal(fs.existsSync(path.join(chromiumPolicy, "crabbox.json")), true);
 	assert.equal(fs.existsSync(path.join(browserBin, "crabbox-browser")), true);
 	assert.match(fs.readFileSync(path.join(browserState, "browser.env"), "utf8"), new RegExp(`CHROME_BIN=${browserBin}/crabbox-browser`));
+	assert.equal(
+		fs.readFileSync(path.join(keyrings, "google-linux.gpg"), "utf8"),
+		`fake-export:${googleLinuxSigningKeyFingerprint}\n`,
+	);
+});
+
+test("linux developer tool setup preserves the existing Google keyring on fingerprint mismatch", () => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-linux-tools-mismatch-"));
+	const bin = path.join(dir, "bin");
+	const keyrings = path.join(dir, "keyrings");
+	const sources = path.join(dir, "sources");
+	const target = path.join(keyrings, "google-linux.gpg");
+	const source = path.join(sources, "google-chrome.list");
+	const log = path.join(dir, "gpg.log");
+	fs.mkdirSync(bin);
+	fs.mkdirSync(keyrings);
+	fs.mkdirSync(sources);
+	fs.writeFileSync(target, "existing-keyring\n", "utf8");
+	fs.writeFileSync(source, "existing-source\n", "utf8");
+	fs.writeFileSync(log, "", "utf8");
+	writeExecutable(
+		path.join(bin, "curl"),
+		`#!/usr/bin/env bash
+set -euo pipefail
+printf 'fake-key:%s\\n' "$*"
+`,
+	);
+	writeExecutable(
+		path.join(bin, "dpkg"),
+		`#!/usr/bin/env bash
+[[ "$*" == "--print-architecture" ]] && printf 'amd64\\n'
+`,
+	);
+	writeFakeGPG(bin);
+
+	const result = spawnSync(
+		"bash",
+		[
+			"-c",
+			[
+				"set -euo pipefail",
+				"source scripts/install-linux-developer-tools.sh",
+				"install_chrome_or_chromium",
+			].join("\n"),
+		],
+		{
+			cwd: repoRoot,
+			env: {
+				...process.env,
+				PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}`,
+				CRABBOX_FAKE_GPG_FINGERPRINT: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+				CRABBOX_FAKE_GPG_LOG: log,
+				CRABBOX_LINUX_APT_KEYRINGS_DIR: keyrings,
+				CRABBOX_LINUX_APT_SOURCES_DIR: sources,
+			},
+			encoding: "utf8",
+		},
+	);
+
+	assert.notEqual(result.status, 0, "fingerprint mismatch should fail closed");
+	assert.equal(fs.readFileSync(target, "utf8"), "existing-keyring\n");
+	assert.equal(fs.readFileSync(source, "utf8"), "existing-source\n");
+	assert.equal(fs.readFileSync(log, "utf8"), "", "mismatched keys should not be exported");
+	assert.equal(
+		fs.readdirSync(keyrings).filter((name) => name.includes(".tmp.")).length,
+		0,
+		"temporary keyring directories should be removed",
+	);
 });

--- a/scripts/install-linux-developer-tools.test.js
+++ b/scripts/install-linux-developer-tools.test.js
@@ -197,11 +197,15 @@ exit 1
 	);
 });
 
-test("linux developer tool setup preserves the existing Google keyring on fingerprint mismatch", () => {
+test("linux developer tool setup preserves Google trust files and falls back on fingerprint mismatch", () => {
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-linux-tools-mismatch-"));
 	const bin = path.join(dir, "bin");
 	const keyrings = path.join(dir, "keyrings");
 	const sources = path.join(dir, "sources");
+	const chromePolicy = path.join(dir, "chrome-policy");
+	const chromiumPolicy = path.join(dir, "chromium-policy");
+	const browserBin = path.join(dir, "browser-bin");
+	const browserState = path.join(dir, "browser-state");
 	const target = path.join(keyrings, "google-linux.gpg");
 	const source = path.join(sources, "google-chrome.list");
 	const log = path.join(dir, "gpg.log");
@@ -222,6 +226,24 @@ printf 'fake-key:%s\\n' "$*"
 		path.join(bin, "dpkg"),
 		`#!/usr/bin/env bash
 [[ "$*" == "--print-architecture" ]] && printf 'amd64\\n'
+`,
+	);
+	writeExecutable(
+		path.join(bin, "apt-cache"),
+		`#!/usr/bin/env bash
+[[ "$*" == "show chromium" ]]
+`,
+	);
+	writeExecutable(
+		path.join(bin, "apt-get"),
+		`#!/usr/bin/env bash
+exit 0
+`,
+	);
+	writeExecutable(
+		path.join(bin, "chromium"),
+		`#!/usr/bin/env bash
+exit 0
 `,
 	);
 	writeFakeGPG(bin);
@@ -245,15 +267,21 @@ printf 'fake-key:%s\\n' "$*"
 				CRABBOX_FAKE_GPG_LOG: log,
 				CRABBOX_LINUX_APT_KEYRINGS_DIR: keyrings,
 				CRABBOX_LINUX_APT_SOURCES_DIR: sources,
+				CRABBOX_LINUX_CHROME_POLICY_DIR: chromePolicy,
+				CRABBOX_LINUX_CHROMIUM_POLICY_DIR: chromiumPolicy,
+				CRABBOX_LINUX_BROWSER_BIN_DIR: browserBin,
+				CRABBOX_LINUX_BROWSER_STATE_DIR: browserState,
 			},
 			encoding: "utf8",
 		},
 	);
 
-	assert.notEqual(result.status, 0, "fingerprint mismatch should fail closed");
+	assert.equal(result.status, 0, result.stderr || result.stdout);
+	assert.match(result.stderr, /verification failed; trying Chromium fallback/);
 	assert.equal(fs.readFileSync(target, "utf8"), "existing-keyring\n");
 	assert.equal(fs.readFileSync(source, "utf8"), "existing-source\n");
 	assert.equal(fs.readFileSync(log, "utf8"), "", "mismatched keys should not be exported");
+	assert.match(fs.readFileSync(path.join(browserBin, "crabbox-browser"), "utf8"), new RegExp(`${bin}/chromium`));
 	assert.equal(
 		fs.readdirSync(keyrings).filter((name) => name.includes(".tmp.")).length,
 		0,

--- a/worker/src/bootstrap.ts
+++ b/worker/src/bootstrap.ts
@@ -1405,7 +1405,7 @@ ${themeConfigure}    systemctl daemon-reload
       google_key_ready=0
       if curl -fsSL https://dl.google.com/linux/linux_signing_key.pub > "$google_key_tmp/google.asc" &&
          GNUPGHOME="$google_key_home" gpg --batch --import "$google_key_tmp/google.asc" >/dev/null 2>&1; then
-        google_key_fingerprint="$(GNUPGHOME="$google_key_home" gpg --batch --with-colons --fingerprint ${googleLinuxSigningKeyFingerprint} 2>/dev/null | awk -F: '$1 == "fpr" { print $10; exit }')"
+        google_key_fingerprint="$(GNUPGHOME="$google_key_home" gpg --batch --with-colons --fingerprint ${googleLinuxSigningKeyFingerprint} 2>/dev/null | awk -F: '$1 == "fpr" { print $10; exit }' || true)"
         if [ "$google_key_fingerprint" = "${googleLinuxSigningKeyFingerprint}" ] &&
            GNUPGHOME="$google_key_home" gpg --batch --export ${googleLinuxSigningKeyFingerprint} > "$google_key_tmp/google-linux.gpg" &&
            [ -s "$google_key_tmp/google-linux.gpg" ]; then

--- a/worker/src/bootstrap.ts
+++ b/worker/src/bootstrap.ts
@@ -1402,29 +1402,29 @@ ${themeConfigure}    systemctl daemon-reload
       google_key_tmp="$(mktemp -d /etc/apt/keyrings/google-linux.gpg.tmp.XXXXXX)"
       google_key_home="$google_key_tmp/gnupg"
       install -d -m 0700 "$google_key_home"
-      if ! curl -fsSL https://dl.google.com/linux/linux_signing_key.pub > "$google_key_tmp/google.asc" ||
-         ! GNUPGHOME="$google_key_home" gpg --batch --import "$google_key_tmp/google.asc" >/dev/null 2>&1; then
-        rm -rf "$google_key_tmp"
-        echo "failed to import Google Linux signing key" >&2
-        exit 1
+      google_key_ready=0
+      if curl -fsSL https://dl.google.com/linux/linux_signing_key.pub > "$google_key_tmp/google.asc" &&
+         GNUPGHOME="$google_key_home" gpg --batch --import "$google_key_tmp/google.asc" >/dev/null 2>&1; then
+        google_key_fingerprint="$(GNUPGHOME="$google_key_home" gpg --batch --with-colons --fingerprint ${googleLinuxSigningKeyFingerprint} 2>/dev/null | awk -F: '$1 == "fpr" { print $10; exit }')"
+        if [ "$google_key_fingerprint" = "${googleLinuxSigningKeyFingerprint}" ] &&
+           GNUPGHOME="$google_key_home" gpg --batch --export ${googleLinuxSigningKeyFingerprint} > "$google_key_tmp/google-linux.gpg" &&
+           [ -s "$google_key_tmp/google-linux.gpg" ]; then
+          chmod 0644 "$google_key_tmp/google-linux.gpg"
+          mv -f "$google_key_tmp/google-linux.gpg" /etc/apt/keyrings/google-linux.gpg
+          google_key_ready=1
+        fi
       fi
-      google_key_fingerprint="$(GNUPGHOME="$google_key_home" gpg --batch --with-colons --fingerprint ${googleLinuxSigningKeyFingerprint} 2>/dev/null | awk -F: '$1 == "fpr" { print $10; exit }')"
-      if [ "$google_key_fingerprint" != "${googleLinuxSigningKeyFingerprint}" ] ||
-         ! GNUPGHOME="$google_key_home" gpg --batch --export ${googleLinuxSigningKeyFingerprint} > "$google_key_tmp/google-linux.gpg" ||
-         [ ! -s "$google_key_tmp/google-linux.gpg" ]; then
-        rm -rf "$google_key_tmp"
-        echo "Google Linux signing key fingerprint mismatch" >&2
-        exit 1
-      fi
-      chmod 0644 "$google_key_tmp/google-linux.gpg"
-      mv -f "$google_key_tmp/google-linux.gpg" /etc/apt/keyrings/google-linux.gpg
       rm -rf "$google_key_tmp"
-      echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/google-linux.gpg] https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list
-      if apt-get update && retry apt-get install -y --no-install-recommends google-chrome-stable; then
-        browser_path="$(command -v google-chrome || true)"
+      if [ "$google_key_ready" = 1 ]; then
+        echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/google-linux.gpg] https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list
+        if apt-get update && retry apt-get install -y --no-install-recommends google-chrome-stable; then
+          browser_path="$(command -v google-chrome || true)"
+        else
+          rm -f /etc/apt/sources.list.d/google-chrome.list
+          retry apt-get update || true
+        fi
       else
-        rm -f /etc/apt/sources.list.d/google-chrome.list
-        retry apt-get update || true
+        echo "Google Linux signing key verification failed; trying Chromium fallback" >&2
       fi
     fi
     if [ -z "$browser_path" ]; then

--- a/worker/src/bootstrap.ts
+++ b/worker/src/bootstrap.ts
@@ -12,6 +12,7 @@ const openSSHWin64ZipSHA256 = "0ca131f3a78f404dc819a6336606caec0db1663a692ccc3af
 const ubuntuWSLRootFSURL =
   "https://cloud-images.ubuntu.com/wsl/releases/24.04/20240423/ubuntu-noble-wsl-amd64-wsl.rootfs.tar.gz";
 const ubuntuWSLRootFSSHA256 = "8251e27ffff381a4af5f41dcb94d867de3e0d9774a9241908ab34555d99315ea";
+const googleLinuxSigningKeyFingerprint = "EB4C1BFD4F042F6DDDCCEC917721F63BD38B4796";
 
 export function awsUserData(config: LeaseConfig): string {
   if (config.target === "windows") {
@@ -1397,10 +1398,28 @@ ${themeConfigure}    systemctl daemon-reload
     parts.push(`    retry apt-get install -y --no-install-recommends gnupg build-essential python3
     browser_path=""
     if [ "$(dpkg --print-architecture)" = "amd64" ]; then
-      install -d -m 0755 /etc/apt/trusted.gpg.d
-      curl -fsSL https://dl.google.com/linux/linux_signing_key.pub > /etc/apt/trusted.gpg.d/google.asc
-      chmod 0644 /etc/apt/trusted.gpg.d/google.asc
-      echo "deb [arch=amd64] https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list
+      install -d -m 0755 /etc/apt/keyrings
+      google_key_tmp="$(mktemp -d /etc/apt/keyrings/google-linux.gpg.tmp.XXXXXX)"
+      google_key_home="$google_key_tmp/gnupg"
+      install -d -m 0700 "$google_key_home"
+      if ! curl -fsSL https://dl.google.com/linux/linux_signing_key.pub > "$google_key_tmp/google.asc" ||
+         ! GNUPGHOME="$google_key_home" gpg --batch --import "$google_key_tmp/google.asc" >/dev/null 2>&1; then
+        rm -rf "$google_key_tmp"
+        echo "failed to import Google Linux signing key" >&2
+        exit 1
+      fi
+      google_key_fingerprint="$(GNUPGHOME="$google_key_home" gpg --batch --with-colons --fingerprint ${googleLinuxSigningKeyFingerprint} 2>/dev/null | awk -F: '$1 == "fpr" { print $10; exit }')"
+      if [ "$google_key_fingerprint" != "${googleLinuxSigningKeyFingerprint}" ] ||
+         ! GNUPGHOME="$google_key_home" gpg --batch --export ${googleLinuxSigningKeyFingerprint} > "$google_key_tmp/google-linux.gpg" ||
+         [ ! -s "$google_key_tmp/google-linux.gpg" ]; then
+        rm -rf "$google_key_tmp"
+        echo "Google Linux signing key fingerprint mismatch" >&2
+        exit 1
+      fi
+      chmod 0644 "$google_key_tmp/google-linux.gpg"
+      mv -f "$google_key_tmp/google-linux.gpg" /etc/apt/keyrings/google-linux.gpg
+      rm -rf "$google_key_tmp"
+      echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/google-linux.gpg] https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list
       if apt-get update && retry apt-get install -y --no-install-recommends google-chrome-stable; then
         browser_path="$(command -v google-chrome || true)"
       else

--- a/worker/test/bootstrap.test.ts
+++ b/worker/test/bootstrap.test.ts
@@ -366,6 +366,7 @@ describe("cloud-init bootstrap", () => {
     expect(got).toContain("https://dl.google.com/linux/linux_signing_key.pub");
     expect(got).toContain("EB4C1BFD4F042F6DDDCCEC917721F63BD38B4796");
     expect(got).toContain('GNUPGHOME="$google_key_home" gpg --batch --import');
+    expect(got).toContain(`awk -F: '$1 == "fpr" { print $10; exit }' || true`);
     expect(got).toContain("gpg --batch --export EB4C1BFD4F042F6DDDCCEC917721F63BD38B4796");
     expect(got).toContain(
       'mv -f "$google_key_tmp/google-linux.gpg" /etc/apt/keyrings/google-linux.gpg',

--- a/worker/test/bootstrap.test.ts
+++ b/worker/test/bootstrap.test.ts
@@ -364,7 +364,14 @@ describe("cloud-init bootstrap", () => {
     const got = cloudInit({ ...config, browser: true });
     expect(got).toContain("gnupg build-essential python3");
     expect(got).toContain("https://dl.google.com/linux/linux_signing_key.pub");
-    expect(got).toContain("chmod 0644 /etc/apt/trusted.gpg.d/google.asc");
+    expect(got).toContain("EB4C1BFD4F042F6DDDCCEC917721F63BD38B4796");
+    expect(got).toContain('GNUPGHOME="$google_key_home" gpg --batch --import');
+    expect(got).toContain("gpg --batch --export EB4C1BFD4F042F6DDDCCEC917721F63BD38B4796");
+    expect(got).toContain(
+      'mv -f "$google_key_tmp/google-linux.gpg" /etc/apt/keyrings/google-linux.gpg',
+    );
+    expect(got).toContain("signed-by=/etc/apt/keyrings/google-linux.gpg");
+    expect(got).not.toContain("/etc/apt/trusted.gpg.d/google.asc");
     expect(got).toContain("https://dl.google.com/linux/chrome/deb/");
     expect(got).toContain("google-chrome-stable");
     expect(got).toContain("apt-cache show chromium");

--- a/worker/test/bootstrap.test.ts
+++ b/worker/test/bootstrap.test.ts
@@ -371,6 +371,7 @@ describe("cloud-init bootstrap", () => {
       'mv -f "$google_key_tmp/google-linux.gpg" /etc/apt/keyrings/google-linux.gpg',
     );
     expect(got).toContain("signed-by=/etc/apt/keyrings/google-linux.gpg");
+    expect(got).toContain("Google Linux signing key verification failed; trying Chromium fallback");
     expect(got).not.toContain("/etc/apt/trusted.gpg.d/google.asc");
     expect(got).toContain("https://dl.google.com/linux/chrome/deb/");
     expect(got).toContain("google-chrome-stable");


### PR DESCRIPTION
## Summary

- Pin the Google Linux repository key to Google's published primary fingerprint before adding the Chrome APT source.
- Import in an isolated GnuPG home and scope Chrome trust with `signed-by=/etc/apt/keyrings/google-linux.gpg`.
- Preserve existing trust files on verification failure, skip Chrome, and try the distro Chromium fallback without trusting unexpected key material.
- Apply the same fail-closed contract to the standalone Linux installer and managed worker bootstrap; document and regression-test both paths.

Closes #719.

## Security contract

Expected primary fingerprint: `EB4C 1BFD 4F04 2F6D DDCC EC91 7721 F63B D38B 4796`, matching Google's current Linux repository signing-key page. Signing-subkey rotation remains supported because the primary key is pinned. A primary-key mismatch never updates the keyring or source list and never falls back to unpinned Google trust.

## Verification

- `bash -n scripts/install-linux-developer-tools.sh`
- `shellcheck scripts/install-linux-developer-tools.sh`
- `node --test scripts/install-linux-developer-tools.test.js` — 2/2
- `npm test --prefix worker -- test/bootstrap.test.ts` — 17/17
- Worker format, lint, typechecks, builds, and full tests — 24 files / 700 tests
- Repository script suite — 345/345
- Documentation checks/site build — passed
- `go build -trimpath -o /tmp/crabbox ./cmd/crabbox`
- `go vet ./...`
- Exact retries of two unrelated race-suite timing flakes — 3/3 each
- Disposable Ubuntu 24.04 amd64: verified the approved fingerprint, installed `Google Chrome 150.0.7871.46` from a scoped pre-install source, confirmed no legacy global trust file, rejected a wrong primary fingerprint, and preserved the prior keyring bytes
- Autoreview: local repair delta and complete base-to-head diff both clean; zero actionable findings

## Scope

This resolves the Google Chrome trust portion of #687. NodeSource and Docker trust hardening remain separate work.