### PR TITLE
fix: revoke stale bridge tickets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 ### Fixed
 
 - Hardened coordinator image deletion so admin `image delete` requests fail closed unless stored Crabbox-created metadata proves ownership of the AWS, Azure, or GCP image or snapshot.
+- Prevented unused WebVNC and Code bridge tickets from surviving manager share revocation. Thanks @coygeek.
 - Prevented revoked lease managers from retaining mediated-egress bridges after lease sharing was removed or downgraded. Thanks @coygeek.
 - Prevented the Code portal proxy from forwarding coordinator authentication context to lease-controlled code-server requests. Thanks @coygeek.
 - Rejected GitHub login callback origins that differ from the selected broker unless explicitly allowlisted as a trusted alias, preventing OAuth callbacks from silently redirecting stored credentials. Thanks @TurboTheTurtle.

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -6158,35 +6158,37 @@ export class FleetCoordinator {
         { status: 426 },
       );
     }
-    const consumed = await this.consumeWebVNCTicket(request, identifier);
-    if (consumed.status === "invalid") {
-      return json(
-        { error: "webvnc_ticket_required", message: "valid WebVNC bridge ticket required" },
-        { status: 401 },
-      );
-    }
-    if (consumed.status === "not_found") {
-      return notFound();
-    }
-    const { lease } = consumed;
-    const error = webVNCLeaseError(lease);
-    if (error) {
-      return json({ error: "webvnc_unavailable", message: error }, { status: 409 });
-    }
-    const upgrade = this.state.createWebSocketUpgrade();
-    const agent = upgrade.socket;
+    return await this.withBridgeTicketLock(async () => {
+      const consumed = await this.consumeWebVNCTicketUnderLock(request, identifier);
+      if (consumed.status === "invalid") {
+        return json(
+          { error: "webvnc_ticket_required", message: "valid WebVNC bridge ticket required" },
+          { status: 401 },
+        );
+      }
+      if (consumed.status === "not_found") {
+        return notFound();
+      }
+      const { lease } = consumed;
+      const error = webVNCLeaseError(lease);
+      if (error) {
+        return json({ error: "webvnc_unavailable", message: error }, { status: 409 });
+      }
+      const upgrade = this.state.createWebSocketUpgrade();
+      const agent = upgrade.socket;
 
-    const agentID = newWebVNCSessionID("agent");
-    const capabilities = webVNCAgentCapabilities(request);
-    this.trackWebVNCAgent(lease.id, agentID, agent, capabilities);
-    this.recordWebVNCEvent(lease.id, "bridge_connected");
-    this.acceptBridgeWebSocket(agent, {
-      kind: "webvnc-agent",
-      leaseID: lease.id,
-      id: agentID,
-      capabilities,
+      const agentID = newWebVNCSessionID("agent");
+      const capabilities = webVNCAgentCapabilities(request);
+      this.trackWebVNCAgent(lease.id, agentID, agent, capabilities);
+      this.recordWebVNCEvent(lease.id, "bridge_connected");
+      this.acceptBridgeWebSocket(agent, {
+        kind: "webvnc-agent",
+        leaseID: lease.id,
+        id: agentID,
+        capabilities,
+      });
+      return upgrade.response;
     });
-    return upgrade.response;
   }
 
   private async createEgressTicket(request: Request, identifier: string): Promise<Response> {
@@ -7310,29 +7312,31 @@ export class FleetCoordinator {
         { status: 426 },
       );
     }
-    const consumed = await this.consumeCodeTicket(request, identifier);
-    if (consumed.status === "invalid") {
-      return json(
-        { error: "code_ticket_required", message: "valid code bridge ticket required" },
-        { status: 401 },
-      );
-    }
-    if (consumed.status === "not_found") {
-      return notFound();
-    }
-    const { lease } = consumed;
-    const error = codeLeaseError(lease);
-    if (error) {
-      return json({ error: "code_unavailable", message: error }, { status: 409 });
-    }
-    const upgrade = this.state.createWebSocketUpgrade();
-    const agent = upgrade.socket;
+    return await this.withBridgeTicketLock(async () => {
+      const consumed = await this.consumeCodeTicketUnderLock(request, identifier);
+      if (consumed.status === "invalid") {
+        return json(
+          { error: "code_ticket_required", message: "valid code bridge ticket required" },
+          { status: 401 },
+        );
+      }
+      if (consumed.status === "not_found") {
+        return notFound();
+      }
+      const { lease } = consumed;
+      const error = codeLeaseError(lease);
+      if (error) {
+        return json({ error: "code_unavailable", message: error }, { status: 409 });
+      }
+      const upgrade = this.state.createWebSocketUpgrade();
+      const agent = upgrade.socket;
 
-    closeSocket(this.codeAgents.get(lease.id), 1012, "replaced by a newer code bridge");
-    this.clearCodeLease(lease.id);
-    this.codeAgents.set(lease.id, agent);
-    this.acceptBridgeWebSocket(agent, { kind: "code-agent", leaseID: lease.id });
-    return upgrade.response;
+      closeSocket(this.codeAgents.get(lease.id), 1012, "replaced by a newer code bridge");
+      this.clearCodeLease(lease.id);
+      this.codeAgents.set(lease.id, agent);
+      this.acceptBridgeWebSocket(agent, { kind: "code-agent", leaseID: lease.id });
+      return upgrade.response;
+    });
   }
 
   private async codePortalProxy(
@@ -8348,31 +8352,36 @@ export class FleetCoordinator {
     request: Request,
     identifier: string,
   ): Promise<LeaseBridgeTicketConsumption<WebVNCTicketRecord>> {
+    return this.withBridgeTicketLock(() => this.consumeWebVNCTicketUnderLock(request, identifier));
+  }
+
+  private async consumeWebVNCTicketUnderLock(
+    request: Request,
+    identifier: string,
+  ): Promise<LeaseBridgeTicketConsumption<WebVNCTicketRecord>> {
     const value = bridgeTicketFromRequest(request, this.env);
     if (!validWebVNCTicket(value)) {
       return { status: "invalid" };
     }
-    return this.withBridgeTicketLock(async () => {
-      const key = webVNCTicketKey(value);
-      const ticket = await this.state.storage.get<WebVNCTicketRecord>(key);
-      if (!ticket || ticket.ticket !== value) {
-        return { status: "invalid" };
-      }
-      if (Date.parse(ticket.expiresAt) <= Date.now()) {
-        await this.state.storage.delete(key);
-        return { status: "invalid" };
-      }
-      const lease = await this.getLease(ticket.leaseID);
-      if (!lease || !identifierMatchesLease(identifier, lease)) {
-        return { status: "not_found" };
-      }
-      if (!this.leaseManagerAuthorized(lease, leaseBridgeTicketPrincipal(ticket))) {
-        await this.state.storage.delete(key);
-        return { status: "invalid" };
-      }
+    const key = webVNCTicketKey(value);
+    const ticket = await this.state.storage.get<WebVNCTicketRecord>(key);
+    if (!ticket || ticket.ticket !== value) {
+      return { status: "invalid" };
+    }
+    if (Date.parse(ticket.expiresAt) <= Date.now()) {
       await this.state.storage.delete(key);
-      return { status: "accepted", ticket, lease };
-    });
+      return { status: "invalid" };
+    }
+    const lease = await this.getLease(ticket.leaseID);
+    if (!lease || !identifierMatchesLease(identifier, lease)) {
+      return { status: "not_found" };
+    }
+    if (!this.leaseManagerAuthorized(lease, leaseBridgeTicketPrincipal(ticket))) {
+      await this.state.storage.delete(key);
+      return { status: "invalid" };
+    }
+    await this.state.storage.delete(key);
+    return { status: "accepted", ticket, lease };
   }
 
   private async cleanupExpiredWebVNCTickets(): Promise<void> {
@@ -8391,31 +8400,36 @@ export class FleetCoordinator {
     request: Request,
     identifier: string,
   ): Promise<LeaseBridgeTicketConsumption<CodeTicketRecord>> {
+    return this.withBridgeTicketLock(() => this.consumeCodeTicketUnderLock(request, identifier));
+  }
+
+  private async consumeCodeTicketUnderLock(
+    request: Request,
+    identifier: string,
+  ): Promise<LeaseBridgeTicketConsumption<CodeTicketRecord>> {
     const value = bridgeTicketFromRequest(request, this.env);
     if (!validCodeTicket(value)) {
       return { status: "invalid" };
     }
-    return this.withBridgeTicketLock(async () => {
-      const key = codeTicketKey(value);
-      const ticket = await this.state.storage.get<CodeTicketRecord>(key);
-      if (!ticket || ticket.ticket !== value) {
-        return { status: "invalid" };
-      }
-      if (Date.parse(ticket.expiresAt) <= Date.now()) {
-        await this.state.storage.delete(key);
-        return { status: "invalid" };
-      }
-      const lease = await this.getLease(ticket.leaseID);
-      if (!lease || !identifierMatchesLease(identifier, lease)) {
-        return { status: "not_found" };
-      }
-      if (!this.leaseManagerAuthorized(lease, leaseBridgeTicketPrincipal(ticket))) {
-        await this.state.storage.delete(key);
-        return { status: "invalid" };
-      }
+    const key = codeTicketKey(value);
+    const ticket = await this.state.storage.get<CodeTicketRecord>(key);
+    if (!ticket || ticket.ticket !== value) {
+      return { status: "invalid" };
+    }
+    if (Date.parse(ticket.expiresAt) <= Date.now()) {
       await this.state.storage.delete(key);
-      return { status: "accepted", ticket, lease };
-    });
+      return { status: "invalid" };
+    }
+    const lease = await this.getLease(ticket.leaseID);
+    if (!lease || !identifierMatchesLease(identifier, lease)) {
+      return { status: "not_found" };
+    }
+    if (!this.leaseManagerAuthorized(lease, leaseBridgeTicketPrincipal(ticket))) {
+      await this.state.storage.delete(key);
+      return { status: "invalid" };
+    }
+    await this.state.storage.delete(key);
+    return { status: "accepted", ticket, lease };
   }
 
   private async cleanupExpiredCodeTickets(): Promise<void> {

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -218,6 +218,7 @@ interface WebVNCTicketRecord {
   leaseID: string;
   owner: string;
   org: string;
+  admin?: boolean;
   createdAt: string;
   expiresAt: string;
 }
@@ -237,6 +238,7 @@ interface CodeTicketRecord {
   leaseID: string;
   owner: string;
   org: string;
+  admin?: boolean;
   createdAt: string;
   expiresAt: string;
 }
@@ -6280,7 +6282,7 @@ export class FleetCoordinator {
       }
       const upgrade = this.state.createWebSocketUpgrade();
       const agent = upgrade.socket;
-      const principal = egressTicketPrincipal(ticket);
+      const principal = leaseBridgeTicketPrincipal(ticket);
       const attachment: BridgeAttachment = {
         kind: role === "host" ? "egress-host" : "egress-client",
         leaseID: lease.id,
@@ -7049,6 +7051,7 @@ export class FleetCoordinator {
       leaseID: lease.id,
       owner: requestOwner(request),
       org: requestOrg(request, this.env),
+      admin,
       createdAt: now.toISOString(),
       expiresAt: new Date(now.getTime() + webVNCTicketTTLSeconds * 1000).toISOString(),
     };
@@ -7288,6 +7291,7 @@ export class FleetCoordinator {
       leaseID: lease.id,
       owner: requestOwner(request),
       org: requestOrg(request, this.env),
+      admin,
       createdAt: now.toISOString(),
       expiresAt: new Date(now.getTime() + codeTicketTTLSeconds * 1000).toISOString(),
     };
@@ -8362,6 +8366,10 @@ export class FleetCoordinator {
       if (!lease || !identifierMatchesLease(identifier, lease)) {
         return { status: "not_found" };
       }
+      if (!this.leaseManagerAuthorized(lease, leaseBridgeTicketPrincipal(ticket))) {
+        await this.state.storage.delete(key);
+        return { status: "invalid" };
+      }
       await this.state.storage.delete(key);
       return { status: "accepted", ticket, lease };
     });
@@ -8400,6 +8408,10 @@ export class FleetCoordinator {
       const lease = await this.getLease(ticket.leaseID);
       if (!lease || !identifierMatchesLease(identifier, lease)) {
         return { status: "not_found" };
+      }
+      if (!this.leaseManagerAuthorized(lease, leaseBridgeTicketPrincipal(ticket))) {
+        await this.state.storage.delete(key);
+        return { status: "invalid" };
       }
       await this.state.storage.delete(key);
       return { status: "accepted", ticket, lease };
@@ -8453,7 +8465,7 @@ export class FleetCoordinator {
     if (!lease || !identifierMatchesLease(identifier, lease)) {
       return { status: "not_found" };
     }
-    if (!this.leaseManagerAuthorized(lease, egressTicketPrincipal(ticket))) {
+    if (!this.leaseManagerAuthorized(lease, leaseBridgeTicketPrincipal(ticket))) {
       await this.state.storage.delete(key);
       return { status: "invalid" };
     }
@@ -13969,7 +13981,7 @@ function validOptionalEgressBridgePrincipal(value: {
   return legacy || completeBridgePrincipal(value);
 }
 
-function egressTicketPrincipal(ticket: EgressTicketRecord): {
+function leaseBridgeTicketPrincipal(ticket: { owner: string; org: string; admin?: boolean }): {
   owner: string;
   org: string;
   admin: boolean;

--- a/worker/test/coordinator-runtime.test.ts
+++ b/worker/test/coordinator-runtime.test.ts
@@ -308,6 +308,114 @@ describe("coordinator runtimes", () => {
     expect(runtime.socketCloses).toContainEqual({ code: 1008, reason: "lease access revoked" });
   });
 
+  it("reauthorizes WebVNC and Code agent tickets before acceptance", async () => {
+    const runtime = new MemoryRuntime();
+    const coordinator = new FleetCoordinator(runtime, {
+      CRABBOX_DEFAULT_ORG: "example-org",
+    } as Env);
+    const lease: LeaseRecord = {
+      id: "cbx_000000000001",
+      slug: "shared-bridges",
+      provider: "external",
+      lifecycle: "registered",
+      target: "linux",
+      cloudID: "external-shared-bridges",
+      owner: "owner@example.com",
+      org: "example-org",
+      share: { users: { "manager@example.com": "manage" } },
+      profile: "default",
+      class: "default",
+      serverType: "external",
+      serverID: 0,
+      serverName: "shared-bridges",
+      providerKey: "external-shared-bridges",
+      host: "127.0.0.1",
+      sshUser: "crabbox",
+      sshPort: "22",
+      workRoot: "/work/crabbox",
+      keep: true,
+      ttlSeconds: 3600,
+      estimatedHourlyUSD: 0,
+      maxEstimatedUSD: 0,
+      state: "active",
+      desktop: true,
+      code: true,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    };
+    await runtime.storage.put(`lease:${lease.id}`, lease);
+    const managerHeaders = {
+      "x-crabbox-owner": "manager@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const ownerHeaders = {
+      "x-crabbox-owner": "owner@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const adminHeaders = {
+      "x-crabbox-owner": "admin@example.com",
+      "x-crabbox-org": "example-org",
+      "x-crabbox-admin": "true",
+    };
+    const createTicket = async (
+      kind: "webvnc" | "code",
+      headers: Record<string, string> = managerHeaders,
+    ): Promise<string> => {
+      const response = await coordinator.fetch(
+        new Request(`https://coordinator.test/v1/leases/shared-bridges/${kind}/ticket`, {
+          method: "POST",
+          headers,
+        }),
+      );
+      expect(response.status).toBe(200);
+      return ((await response.json()) as { ticket: string }).ticket;
+    };
+    const connect = async (kind: "webvnc" | "code", ticket: string): Promise<Response> =>
+      await coordinator.fetch(
+        new Request(`https://coordinator.test/v1/leases/shared-bridges/${kind}/agent`, {
+          headers: {
+            upgrade: "websocket",
+            authorization: `Bearer ${ticket}`,
+          },
+        }),
+      );
+
+    const acceptedWebVNCTicket = await createTicket("webvnc");
+    expect((await connect("webvnc", acceptedWebVNCTicket)).status).toBe(200);
+    expect(runtime.acceptedAttachment).toMatchObject({
+      kind: "webvnc-agent",
+      leaseID: lease.id,
+    });
+
+    const acceptedCodeTicket = await createTicket("code");
+    expect((await connect("code", acceptedCodeTicket)).status).toBe(200);
+    expect(runtime.acceptedAttachment).toEqual({ kind: "code-agent", leaseID: lease.id });
+
+    expect((await connect("webvnc", await createTicket("webvnc", adminHeaders))).status).toBe(200);
+    expect((await connect("code", await createTicket("code", adminHeaders))).status).toBe(200);
+
+    const revokedWebVNCTicket = await createTicket("webvnc");
+    const revokedCodeTicket = await createTicket("code");
+    const downgraded = await coordinator.fetch(
+      new Request("https://coordinator.test/v1/leases/shared-bridges/share", {
+        method: "PUT",
+        headers: { ...ownerHeaders, "content-type": "application/json" },
+        body: JSON.stringify({ users: { "manager@example.com": "use" } }),
+      }),
+    );
+    expect(downgraded.status).toBe(200);
+
+    runtime.acceptedAttachment = undefined;
+    expect((await connect("webvnc", revokedWebVNCTicket)).status).toBe(401);
+    expect(runtime.acceptedAttachment).toBeUndefined();
+    expect(runtime.storage.value(`webvnc-ticket:${revokedWebVNCTicket}`)).toBeUndefined();
+
+    expect((await connect("code", revokedCodeTicket)).status).toBe(401);
+    expect(runtime.acceptedAttachment).toBeUndefined();
+    expect(runtime.storage.value(`code-ticket:${revokedCodeTicket}`)).toBeUndefined();
+  });
+
   it("keeps provider-backed portal requests outside the lifecycle queue", () => {
     for (const [method, path] of [
       ["GET", "/portal"],

--- a/worker/test/coordinator-runtime.test.ts
+++ b/worker/test/coordinator-runtime.test.ts
@@ -54,6 +54,7 @@ class MemoryRuntime implements CoordinatorRuntime {
   upgradeOptions?: CoordinatorWebSocketUpgradeOptions;
   acceptedTags?: string[];
   acceptedAttachment?: unknown;
+  onAcceptWebSocket?: (attachment: unknown) => void;
   readonly socketCloses: Array<{ code?: number; reason?: string }> = [];
   private readonly attachments = new WeakMap<WebSocket, unknown>();
   private exclusiveTail: Promise<void> = Promise.resolve();
@@ -111,6 +112,7 @@ class MemoryRuntime implements CoordinatorRuntime {
     this.attachments.set(socket, attachment);
     this.acceptedTags = tags;
     this.acceptedAttachment = attachment;
+    this.onAcceptWebSocket?.(attachment);
   }
 
   acceptEphemeralWebSocket(_socket: WebSocket, _handlers: CoordinatorSocketHandlers): void {}
@@ -308,7 +310,7 @@ describe("coordinator runtimes", () => {
     expect(runtime.socketCloses).toContainEqual({ code: 1008, reason: "lease access revoked" });
   });
 
-  it("reauthorizes WebVNC and Code agent tickets before acceptance", async () => {
+  it("reauthorizes WebVNC and Code agent tickets through socket acceptance", async () => {
     const runtime = new MemoryRuntime();
     const coordinator = new FleetCoordinator(runtime, {
       CRABBOX_DEFAULT_ORG: "example-org",
@@ -414,6 +416,70 @@ describe("coordinator runtimes", () => {
     expect((await connect("code", revokedCodeTicket)).status).toBe(401);
     expect(runtime.acceptedAttachment).toBeUndefined();
     expect(runtime.storage.value(`code-ticket:${revokedCodeTicket}`)).toBeUndefined();
+
+    const expectAtomicAcceptance = async (kind: "webvnc" | "code") => {
+      const restored = await coordinator.fetch(
+        new Request("https://coordinator.test/v1/leases/shared-bridges/share", {
+          method: "PUT",
+          headers: { ...ownerHeaders, "content-type": "application/json" },
+          body: JSON.stringify({ users: { "manager@example.com": "manage" } }),
+        }),
+      );
+      expect(restored.status).toBe(200);
+      const ticket = await createTicket(kind);
+      let ticketRead!: () => void;
+      let allowTicketRead!: () => void;
+      const ticketReadStarted = new Promise<void>((resolve) => {
+        ticketRead = resolve;
+      });
+      const ticketReadMayFinish = new Promise<void>((resolve) => {
+        allowTicketRead = resolve;
+      });
+      runtime.storage.beforeGet = async (key) => {
+        if (key === `${kind}-ticket:${ticket}`) {
+          ticketRead();
+          await ticketReadMayFinish;
+        }
+      };
+
+      runtime.acceptedAttachment = undefined;
+      let roleAtAccept: string | undefined;
+      runtime.onAcceptWebSocket = (attachment) => {
+        if ((attachment as { kind?: string }).kind === `${kind}-agent`) {
+          roleAtAccept = runtime.storage.value<LeaseRecord>(`lease:${lease.id}`)?.share?.users?.[
+            "manager@example.com"
+          ];
+        }
+      };
+      const connecting = connect(kind, ticket);
+      await ticketReadStarted;
+      const revoking = coordinator.fetch(
+        new Request("https://coordinator.test/v1/leases/shared-bridges/share", {
+          method: "PUT",
+          headers: { ...ownerHeaders, "content-type": "application/json" },
+          body: JSON.stringify({ users: { "manager@example.com": "use" } }),
+        }),
+      );
+      allowTicketRead();
+
+      expect((await connecting).status).toBe(200);
+      expect((await revoking).status).toBe(200);
+      expect(runtime.acceptedAttachment).toMatchObject({
+        kind: `${kind}-agent`,
+        leaseID: lease.id,
+      });
+      expect(roleAtAccept).toBe("manage");
+      expect(
+        runtime.storage.value<LeaseRecord>(`lease:${lease.id}`)?.share?.users?.[
+          "manager@example.com"
+        ],
+      ).toBe("use");
+      expect(runtime.storage.value(`${kind}-ticket:${ticket}`)).toBeUndefined();
+      runtime.storage.beforeGet = undefined;
+      runtime.onAcceptWebSocket = undefined;
+    };
+    await expectAtomicAcceptance("webvnc");
+    await expectAtomicAcceptance("code");
   });
 
   it("keeps provider-backed portal requests outside the lifecycle queue", () => {


### PR DESCRIPTION
Closes https://github.com/openclaw/crabbox/issues/759.

## Summary

- Bind WebVNC and Code bridge tickets to the issuing owner, organization, and admin state.
- Re-check current lease manager authorization when each unused ticket is consumed, deleting and rejecting stale tickets after a share downgrade or removal.
- Keep reauthorization, ticket deletion, socket tracking, and WebSocket acceptance in one bridge-ticket critical section so a concurrent share downgrade cannot linearize between acceptance checks and attachment.
- Reuse the same principal normalization as mediated egress and retain compatibility for owner/manager tickets created before the optional admin field existed.
- Add an Unreleased changelog entry thanking @coygeek.

## Verification

- `npm test --prefix worker -- coordinator-runtime.test.ts` — 10 tests passed.
- `npm test --prefix worker` — 24 files, 701 tests passed.
- `npm run check --prefix worker`
- `npm run lint --prefix worker`
- `npm run format:check --prefix worker`
- `npm run build --prefix worker`
- `git diff --check`
- `/Users/steipete/Projects/agent-skills/skills/autoreview/scripts/autoreview --mode local --parallel-tests 'npm test --prefix worker && npm run build --prefix worker' --stream-engine-output` — clean, no accepted/actionable findings; patch correct at 0.84 confidence.

The endpoint-level behavior regression covers valid manager and admin consumption, completed manage-to-use revocation for WebVNC and Code, rejection before socket attachment, stale-ticket deletion, and a deterministic concurrent downgrade queued while ticket storage is blocked. It proves socket acceptance observes `manage`, then the queued downgrade commits `use`; this closes the review-identified reauthorization-to-attachment window.

## Live behavior proof

Ran the exact PR head in an isolated local Wrangler Durable Object runtime with disposable bearer tokens and a registered external lease:

- lease registration: HTTP 201, active desktop+code lease;
- manager share: HTTP 200 with `manage`;
- WebVNC and Code agent ticket minting: HTTP 200;
- owner downgrade: HTTP 200 with manager role `use`;
- real HTTP/1.1 WebSocket upgrade to WebVNC agent with the pre-downgrade ticket: HTTP 401 `webvnc_ticket_required`;
- real HTTP/1.1 WebSocket upgrade to Code agent with the pre-downgrade ticket: HTTP 401 `code_ticket_required`;
- WebVNC status after both attempts: `bridgeConnected=false`, zero viewers, no events;
- disposable registered lease release: HTTP 200, state `released`.

The local runtime request log independently recorded ticket creation, share downgrade, both 401 upgrade rejections, status read, and cleanup. No production deployment, provider resource, or persistent credential was used.