### PR TITLE
fix: pin direct-provider Google signing key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 
 ### Fixed
 
-- Pinned the Google Linux package signing fingerprint and scoped its APT keyring in direct-provider browser bootstrap, failing closed to Chromium when verification fails. Thanks @coygeek.
+- Pinned the Google Linux package signing fingerprint, preserved its source-scoped APT keyring across Chrome installation, and failed closed to Chromium when verification fails. Thanks @coygeek.
 - Hardened coordinator image deletion so admin `image delete` requests fail closed unless stored Crabbox-created metadata proves ownership of the AWS, Azure, or GCP image or snapshot.
 - Prevented unused WebVNC and Code bridge tickets from surviving manager share revocation. Thanks @coygeek.
 - Prevented revoked lease managers from retaining mediated-egress bridges after lease sharing was removed or downgraded. Thanks @coygeek.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### Fixed
 
+- Pinned the Google Linux package signing fingerprint and scoped its APT keyring in direct-provider browser bootstrap, failing closed to Chromium when verification fails. Thanks @coygeek.
 - Hardened coordinator image deletion so admin `image delete` requests fail closed unless stored Crabbox-created metadata proves ownership of the AWS, Azure, or GCP image or snapshot.
 - Prevented unused WebVNC and Code bridge tickets from surviving manager share revocation. Thanks @coygeek.
 - Prevented revoked lease managers from retaining mediated-egress bridges after lease sharing was removed or downgraded. Thanks @coygeek.

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -1342,11 +1342,21 @@ chmod 0755 /usr/local/bin/crabbox-configure-desktop-theme
       fi
       rm -rf "$google_key_tmp"
       if [ "$google_key_ready" = 1 ]; then
-        echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/google-linux.gpg] https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list
+        install -d -m 0755 /etc/default
+        google_defaults_tmp="$(mktemp /etc/default/google-chrome.tmp.XXXXXX)"
+        if [ -f /etc/default/google-chrome ]; then
+          awk '!/^[[:space:]]*repo_add_once=/ && !/^[[:space:]]*repo_reenable_on_distupgrade=/' /etc/default/google-chrome > "$google_defaults_tmp"
+        fi
+        printf '%s\n' 'repo_add_once="false"' 'repo_reenable_on_distupgrade="false"' >> "$google_defaults_tmp"
+        chmod 0644 "$google_defaults_tmp"
+        mv -f "$google_defaults_tmp" /etc/default/google-chrome
+        rm -f /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources
+        echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/google-linux.gpg] https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/crabbox-google-chrome.list
         if apt-get update && retry apt-get install -y --no-install-recommends google-chrome-stable; then
+          rm -f /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources
           browser_path="$(command -v google-chrome || true)"
         else
-          rm -f /etc/apt/sources.list.d/google-chrome.list
+          rm -f /etc/apt/sources.list.d/crabbox-google-chrome.list /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources
           retry apt-get update || true
         fi
       else

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -8,17 +8,18 @@ import (
 )
 
 const (
-	tightVNCMSIURL              = "https://www.tightvnc.com/download/2.8.85/tightvnc-2.8.85-gpl-setup-64bit.msi"
-	tightVNCMSISHA256           = "d8fbed7b27ebab86df6f780f6e86f723668f3715cee521ccaa4568812aef5f3e"
-	gitForWindowsSetupURL       = "https://github.com/git-for-windows/git/releases/download/v2.52.0.windows.1/Git-2.52.0-64-bit.exe"
-	gitForWindowsSetupSHA256    = "d8de7a3152266c8bb13577eab850ea1df6dccf8c2aa48be5b4a1c58b7190d62c"
-	openSSHWin64ZipURL          = "https://github.com/PowerShell/Win32-OpenSSH/releases/download/v9.8.3.0p2-Preview/OpenSSH-Win64.zip"
-	openSSHWin64ZipSHA256       = "0ca131f3a78f404dc819a6336606caec0db1663a692ccc3af1e90232706ada54"
-	ubuntuWSLRootFSURL          = "https://cloud-images.ubuntu.com/wsl/releases/24.04/20240423/ubuntu-noble-wsl-amd64-wsl.rootfs.tar.gz"
-	ubuntuWSLRootFSSHA256       = "8251e27ffff381a4af5f41dcb94d867de3e0d9774a9241908ab34555d99315ea"
-	defaultTailscaleVersion     = "1.98.4"
-	defaultTailscaleAMD64SHA256 = "e6c08a8ee7e63e69aaf1b62ecd12672b3883fbcd2a176bf6cfa42a15fdce0b6b"
-	defaultTailscaleARM64SHA256 = "3cb068eb1368b6bb218d0ef0aa0a7a679a7156b7c979e2279cc2c2321b5f05c7"
+	tightVNCMSIURL                   = "https://www.tightvnc.com/download/2.8.85/tightvnc-2.8.85-gpl-setup-64bit.msi"
+	tightVNCMSISHA256                = "d8fbed7b27ebab86df6f780f6e86f723668f3715cee521ccaa4568812aef5f3e"
+	gitForWindowsSetupURL            = "https://github.com/git-for-windows/git/releases/download/v2.52.0.windows.1/Git-2.52.0-64-bit.exe"
+	gitForWindowsSetupSHA256         = "d8de7a3152266c8bb13577eab850ea1df6dccf8c2aa48be5b4a1c58b7190d62c"
+	openSSHWin64ZipURL               = "https://github.com/PowerShell/Win32-OpenSSH/releases/download/v9.8.3.0p2-Preview/OpenSSH-Win64.zip"
+	openSSHWin64ZipSHA256            = "0ca131f3a78f404dc819a6336606caec0db1663a692ccc3af1e90232706ada54"
+	ubuntuWSLRootFSURL               = "https://cloud-images.ubuntu.com/wsl/releases/24.04/20240423/ubuntu-noble-wsl-amd64-wsl.rootfs.tar.gz"
+	ubuntuWSLRootFSSHA256            = "8251e27ffff381a4af5f41dcb94d867de3e0d9774a9241908ab34555d99315ea"
+	defaultTailscaleVersion          = "1.98.4"
+	defaultTailscaleAMD64SHA256      = "e6c08a8ee7e63e69aaf1b62ecd12672b3883fbcd2a176bf6cfa42a15fdce0b6b"
+	defaultTailscaleARM64SHA256      = "3cb068eb1368b6bb218d0ef0aa0a7a679a7156b7c979e2279cc2c2321b5f05c7"
+	googleLinuxSigningKeyFingerprint = "EB4C1BFD4F042F6DDDCCEC917721F63BD38B4796"
 )
 
 func awsUserData(cfg Config, publicKey string) string {
@@ -1323,15 +1324,33 @@ chmod 0755 /usr/local/bin/crabbox-configure-desktop-theme
 		parts = append(parts, `    retry apt-get install -y --no-install-recommends gnupg build-essential python3
     browser_path=""
     if [ "$(dpkg --print-architecture)" = "amd64" ]; then
-      install -d -m 0755 /etc/apt/trusted.gpg.d
-      curl -fsSL https://dl.google.com/linux/linux_signing_key.pub > /etc/apt/trusted.gpg.d/google.asc
-      chmod 0644 /etc/apt/trusted.gpg.d/google.asc
-      echo "deb [arch=amd64] https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list
-      if apt-get update && retry apt-get install -y --no-install-recommends google-chrome-stable; then
-        browser_path="$(command -v google-chrome || true)"
+      install -d -m 0755 /etc/apt/keyrings
+      google_key_tmp="$(mktemp -d /etc/apt/keyrings/google-linux.gpg.tmp.XXXXXX)"
+      google_key_home="$google_key_tmp/gnupg"
+      install -d -m 0700 "$google_key_home"
+      google_key_ready=0
+      if curl -fsSL https://dl.google.com/linux/linux_signing_key.pub > "$google_key_tmp/google.asc" &&
+         GNUPGHOME="$google_key_home" gpg --batch --import "$google_key_tmp/google.asc" >/dev/null 2>&1; then
+        google_key_fingerprint="$(GNUPGHOME="$google_key_home" gpg --batch --with-colons --fingerprint `+googleLinuxSigningKeyFingerprint+` 2>/dev/null | awk -F: '$1 == "fpr" { print $10; exit }' || true)"
+        if [ "$google_key_fingerprint" = "`+googleLinuxSigningKeyFingerprint+`" ] &&
+           GNUPGHOME="$google_key_home" gpg --batch --export `+googleLinuxSigningKeyFingerprint+` > "$google_key_tmp/google-linux.gpg" &&
+           [ -s "$google_key_tmp/google-linux.gpg" ]; then
+          chmod 0644 "$google_key_tmp/google-linux.gpg"
+          mv -f "$google_key_tmp/google-linux.gpg" /etc/apt/keyrings/google-linux.gpg
+          google_key_ready=1
+        fi
+      fi
+      rm -rf "$google_key_tmp"
+      if [ "$google_key_ready" = 1 ]; then
+        echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/google-linux.gpg] https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list
+        if apt-get update && retry apt-get install -y --no-install-recommends google-chrome-stable; then
+          browser_path="$(command -v google-chrome || true)"
+        else
+          rm -f /etc/apt/sources.list.d/google-chrome.list
+          retry apt-get update || true
+        fi
       else
-        rm -f /etc/apt/sources.list.d/google-chrome.list
-        retry apt-get update || true
+        echo "Google Linux signing key verification failed; trying Chromium fallback" >&2
       fi
     fi
     if [ -z "$browser_path" ]; then

--- a/internal/cli/bootstrap_test.go
+++ b/internal/cli/bootstrap_test.go
@@ -353,6 +353,10 @@ func TestCloudInitBrowserWrapper(t *testing.T) {
 		"gpg --batch --export " + googleLinuxSigningKeyFingerprint,
 		`mv -f "$google_key_tmp/google-linux.gpg" /etc/apt/keyrings/google-linux.gpg`,
 		"signed-by=/etc/apt/keyrings/google-linux.gpg",
+		`repo_add_once="false"`,
+		`repo_reenable_on_distupgrade="false"`,
+		"/etc/apt/sources.list.d/crabbox-google-chrome.list",
+		"rm -f /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources",
 		"Google Linux signing key verification failed; trying Chromium fallback",
 		"https://dl.google.com/linux/chrome/deb/",
 		"google-chrome-stable",
@@ -373,6 +377,8 @@ func TestCloudInitBrowserWrapper(t *testing.T) {
 	}
 	for _, notWant := range []string{
 		"/etc/apt/trusted.gpg.d/google.asc",
+		"> /etc/apt/sources.list.d/google-chrome.list",
+		"> /etc/apt/sources.list.d/google-chrome.sources",
 		"<<'EOF'",
 		"<<EOF",
 		"\nEOF",

--- a/internal/cli/bootstrap_test.go
+++ b/internal/cli/bootstrap_test.go
@@ -347,7 +347,13 @@ func TestCloudInitBrowserWrapper(t *testing.T) {
 	for _, want := range []string{
 		"gnupg build-essential python3",
 		"https://dl.google.com/linux/linux_signing_key.pub",
-		"chmod 0644 /etc/apt/trusted.gpg.d/google.asc",
+		googleLinuxSigningKeyFingerprint,
+		`GNUPGHOME="$google_key_home" gpg --batch --import`,
+		`awk -F: '$1 == "fpr" { print $10; exit }' || true`,
+		"gpg --batch --export " + googleLinuxSigningKeyFingerprint,
+		`mv -f "$google_key_tmp/google-linux.gpg" /etc/apt/keyrings/google-linux.gpg`,
+		"signed-by=/etc/apt/keyrings/google-linux.gpg",
+		"Google Linux signing key verification failed; trying Chromium fallback",
 		"https://dl.google.com/linux/chrome/deb/",
 		"google-chrome-stable",
 		"apt-cache show chromium",
@@ -366,6 +372,7 @@ func TestCloudInitBrowserWrapper(t *testing.T) {
 		}
 	}
 	for _, notWant := range []string{
+		"/etc/apt/trusted.gpg.d/google.asc",
 		"<<'EOF'",
 		"<<EOF",
 		"\nEOF",

--- a/scripts/install-linux-developer-tools.sh
+++ b/scripts/install-linux-developer-tools.sh
@@ -14,6 +14,7 @@ chrome_policy_dir="${CRABBOX_LINUX_CHROME_POLICY_DIR:-/etc/opt/chrome/policies/m
 chromium_policy_dir="${CRABBOX_LINUX_CHROMIUM_POLICY_DIR:-/etc/chromium/policies/managed}"
 browser_bin_dir="${CRABBOX_LINUX_BROWSER_BIN_DIR:-/usr/local/bin}"
 browser_state_dir="${CRABBOX_LINUX_BROWSER_STATE_DIR:-/var/lib/crabbox}"
+chrome_defaults_file="${CRABBOX_LINUX_CHROME_DEFAULTS_FILE:-/etc/default/google-chrome}"
 google_linux_signing_key_fingerprint="EB4C1BFD4F042F6DDDCCEC917721F63BD38B4796"
 
 log() {
@@ -164,18 +165,29 @@ add_docker_repo() {
 
 install_chrome_or_chromium() {
   local browser_path=""
+  local chrome_defaults_tmp=""
   if [[ "$(dpkg --print-architecture)" == "amd64" ]]; then
     install -d -m 0755 "$apt_sources_dir"
     if install_apt_keyring \
       https://dl.google.com/linux/linux_signing_key.pub \
       "$apt_keyrings_dir/google-linux.gpg" \
       "$google_linux_signing_key_fingerprint"; then
+      install -d -m 0755 "$(dirname "$chrome_defaults_file")"
+      chrome_defaults_tmp="$(mktemp "${chrome_defaults_file}.tmp.XXXXXX")"
+      if [[ -f "$chrome_defaults_file" ]]; then
+        awk '!/^[[:space:]]*repo_add_once=/ && !/^[[:space:]]*repo_reenable_on_distupgrade=/' "$chrome_defaults_file" >"$chrome_defaults_tmp"
+      fi
+      printf '%s\n' 'repo_add_once="false"' 'repo_reenable_on_distupgrade="false"' >>"$chrome_defaults_tmp"
+      chmod 0644 "$chrome_defaults_tmp"
+      mv -f "$chrome_defaults_tmp" "$chrome_defaults_file"
+      rm -f "$apt_sources_dir/google-chrome.list" "$apt_sources_dir/google-chrome.sources"
       printf 'deb [arch=amd64 signed-by=%s/google-linux.gpg] https://dl.google.com/linux/chrome/deb/ stable main\n' "$apt_keyrings_dir" \
-        >"$apt_sources_dir/google-chrome.list"
+        >"$apt_sources_dir/crabbox-google-chrome.list"
       if retry apt-get update && apt_install google-chrome-stable; then
+        rm -f "$apt_sources_dir/google-chrome.list" "$apt_sources_dir/google-chrome.sources"
         browser_path="$(command -v google-chrome || true)"
       else
-        rm -f "$apt_sources_dir/google-chrome.list"
+        rm -f "$apt_sources_dir/crabbox-google-chrome.list" "$apt_sources_dir/google-chrome.list" "$apt_sources_dir/google-chrome.sources"
         retry apt-get update || true
       fi
     else

--- a/scripts/install-linux-developer-tools.test.js
+++ b/scripts/install-linux-developer-tools.test.js
@@ -80,6 +80,7 @@ test("linux developer tool repository setup rewrites keyrings idempotently", () 
 	const chromiumPolicy = path.join(dir, "chromium-policy");
 	const browserBin = path.join(dir, "browser-bin");
 	const browserState = path.join(dir, "browser-state");
+	const chromeDefaults = path.join(dir, "defaults", "google-chrome");
 	const osRelease = path.join(dir, "os-release");
 	const log = path.join(dir, "gpg.log");
 	fs.mkdirSync(bin);
@@ -169,6 +170,7 @@ exit 1
 				CRABBOX_LINUX_CHROMIUM_POLICY_DIR: chromiumPolicy,
 				CRABBOX_LINUX_BROWSER_BIN_DIR: browserBin,
 				CRABBOX_LINUX_BROWSER_STATE_DIR: browserState,
+				CRABBOX_LINUX_CHROME_DEFAULTS_FILE: chromeDefaults,
 			},
 			encoding: "utf8",
 		},
@@ -186,7 +188,11 @@ exit 1
 	assert.equal(fs.readFileSync(log, "utf8").trim().split("\n").length, 6);
 	assert.match(fs.readFileSync(path.join(sources, "nodesource.list"), "utf8"), new RegExp(`signed-by=${keyrings}/nodesource.gpg`));
 	assert.match(fs.readFileSync(path.join(sources, "docker.list"), "utf8"), new RegExp(`signed-by=${keyrings}/docker.gpg`));
-	assert.match(fs.readFileSync(path.join(sources, "google-chrome.list"), "utf8"), new RegExp(`signed-by=${keyrings}/google-linux.gpg`));
+	assert.match(fs.readFileSync(path.join(sources, "crabbox-google-chrome.list"), "utf8"), new RegExp(`signed-by=${keyrings}/google-linux.gpg`));
+	assert.equal(fs.existsSync(path.join(sources, "google-chrome.list")), false);
+	assert.equal(fs.existsSync(path.join(sources, "google-chrome.sources")), false);
+	assert.match(fs.readFileSync(chromeDefaults, "utf8"), /repo_add_once="false"/);
+	assert.match(fs.readFileSync(chromeDefaults, "utf8"), /repo_reenable_on_distupgrade="false"/);
 	assert.equal(fs.existsSync(path.join(chromePolicy, "crabbox.json")), true);
 	assert.equal(fs.existsSync(path.join(chromiumPolicy, "crabbox.json")), true);
 	assert.equal(fs.existsSync(path.join(browserBin, "crabbox-browser")), true);
@@ -207,7 +213,7 @@ test("linux developer tool setup preserves Google trust files and falls back on 
 	const browserBin = path.join(dir, "browser-bin");
 	const browserState = path.join(dir, "browser-state");
 	const target = path.join(keyrings, "google-linux.gpg");
-	const source = path.join(sources, "google-chrome.list");
+	const source = path.join(sources, "crabbox-google-chrome.list");
 	const log = path.join(dir, "gpg.log");
 	fs.mkdirSync(bin);
 	fs.mkdirSync(keyrings);

--- a/worker/src/bootstrap.ts
+++ b/worker/src/bootstrap.ts
@@ -1416,11 +1416,21 @@ ${themeConfigure}    systemctl daemon-reload
       fi
       rm -rf "$google_key_tmp"
       if [ "$google_key_ready" = 1 ]; then
-        echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/google-linux.gpg] https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list
+        install -d -m 0755 /etc/default
+        google_defaults_tmp="$(mktemp /etc/default/google-chrome.tmp.XXXXXX)"
+        if [ -f /etc/default/google-chrome ]; then
+          awk '!/^[[:space:]]*repo_add_once=/ && !/^[[:space:]]*repo_reenable_on_distupgrade=/' /etc/default/google-chrome > "$google_defaults_tmp"
+        fi
+        printf '%s\\n' 'repo_add_once="false"' 'repo_reenable_on_distupgrade="false"' >> "$google_defaults_tmp"
+        chmod 0644 "$google_defaults_tmp"
+        mv -f "$google_defaults_tmp" /etc/default/google-chrome
+        rm -f /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources
+        echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/google-linux.gpg] https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/crabbox-google-chrome.list
         if apt-get update && retry apt-get install -y --no-install-recommends google-chrome-stable; then
+          rm -f /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources
           browser_path="$(command -v google-chrome || true)"
         else
-          rm -f /etc/apt/sources.list.d/google-chrome.list
+          rm -f /etc/apt/sources.list.d/crabbox-google-chrome.list /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources
           retry apt-get update || true
         fi
       else

--- a/worker/test/bootstrap.test.ts
+++ b/worker/test/bootstrap.test.ts
@@ -372,8 +372,16 @@ describe("cloud-init bootstrap", () => {
       'mv -f "$google_key_tmp/google-linux.gpg" /etc/apt/keyrings/google-linux.gpg',
     );
     expect(got).toContain("signed-by=/etc/apt/keyrings/google-linux.gpg");
+    expect(got).toContain('repo_add_once="false"');
+    expect(got).toContain('repo_reenable_on_distupgrade="false"');
+    expect(got).toContain("/etc/apt/sources.list.d/crabbox-google-chrome.list");
+    expect(got).toContain(
+      "rm -f /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources",
+    );
     expect(got).toContain("Google Linux signing key verification failed; trying Chromium fallback");
     expect(got).not.toContain("/etc/apt/trusted.gpg.d/google.asc");
+    expect(got).not.toContain("> /etc/apt/sources.list.d/google-chrome.list");
+    expect(got).not.toContain("> /etc/apt/sources.list.d/google-chrome.sources");
     expect(got).toContain("https://dl.google.com/linux/chrome/deb/");
     expect(got).toContain("google-chrome-stable");
     expect(got).toContain("apt-cache show chromium");


### PR DESCRIPTION
Closes https://github.com/openclaw/crabbox/issues/760.

## Summary

- Pin Google's Linux package-signing primary fingerprint in Go-generated direct-provider cloud-init.
- Import the downloaded key in an isolated temporary GnuPG home, export only the approved key, atomically install a source-scoped keyring, and bind the Chrome APT source with `signed-by`.
- Prevent Chrome's package scripts from replacing the pinned source across the Go, Worker, and standalone Linux installer paths by disabling repo auto-management, using a Crabbox-owned source filename, and removing package-managed source files.
- Fail closed to the existing Chromium fallback when fingerprint verification fails.
- Replace the legacy global APT trust assertion with regression contracts and add an Unreleased changelog entry thanking @coygeek.

Maintainer decision: a missing or changed Google primary key intentionally falls back to Chromium. This is the documented managed-browser security contract.

## Verification

- `go vet ./...`
- `go test -race ./...` — passed, including `internal/cli` in 174.651s.
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker` — 24 files, 701 tests passed.
- `npm run build --prefix worker`
- `node --test scripts/*.test.js` — 345 tests passed.
- `git diff --check`
- `/Users/steipete/Projects/agent-skills/skills/autoreview/scripts/autoreview --mode local --parallel-tests 'go test -race ./internal/cli && node --test scripts/install-linux-developer-tools.test.js && npm test --prefix worker -- bootstrap.test.ts' --stream-engine-output` — clean, no accepted/actionable findings; patch correct at 0.82 confidence.

The focused regression contracts cover the exact approved fingerprint, isolated import/export, scoped keyring, package-source suppression, absence of the legacy global trust path, and deterministic Chromium fallback on fingerprint mismatch.

## Live behavior proof

Built the exact PR head `5d5263f71397d17f9c7b9d34236d2a4f7162adcb` and ran it with a scratch config in direct-provider mode against a disposable Hetzner Ubuntu 24.04 lease with `--browser`:

- exported keyring primary fingerprint matched `EB4C1BFD4F042F6DDDCCEC917721F63BD38B4796`;
- `/etc/apt/trusted.gpg.d/google.asc` was absent;
- Crabbox's Chrome source used `signed-by=/etc/apt/keyrings/google-linux.gpg`;
- package-managed `google-chrome.list` and `google-chrome.sources` were absent;
- `repo_add_once` and `repo_reenable_on_distupgrade` were both disabled;
- Google Chrome 150 launched and reported its version;
- the disposable server was deleted by the `always` cleanup policy.

No coordinator or production lease was used, and no credential or provider identifier is included in this proof.
