### PR TITLE
fix: roll back failed Hetzner readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### Fixed
 
+- Rolled back ordinary brokered Hetzner servers when post-create readiness fails and persisted the server ID for alarm-driven cleanup when rollback cannot complete. Thanks @coygeek.
 - Pinned the Google Linux package signing fingerprint, preserved its source-scoped APT keyring across Chrome installation, and failed closed to Chromium when verification fails. Thanks @coygeek.
 - Hardened coordinator image deletion so admin `image delete` requests fail closed unless stored Crabbox-created metadata proves ownership of the AWS, Azure, or GCP image or snapshot.
 - Prevented unused WebVNC and Code bridge tickets from surviving manager share revocation. Thanks @coygeek.

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -50,6 +50,7 @@ import {
   hetznerProvisioningFailureMayHaveResource,
   hetznerProvisioningFailureRetryable,
   hetznerProvisioningResourceID,
+  hetznerProvisioningSSHKeyCleanupRequired,
   sshPublicKeyIdentity,
 } from "./hetzner";
 import { bearerToken, errorMessage, json, pathParts, readJson, requestOwner } from "./http";
@@ -2240,9 +2241,15 @@ export class FleetCoordinator {
             config.provider === "hetzner" && !workspaceID
               ? hetznerProvisioningResourceID(error)
               : undefined;
-          if (hetznerServerID !== undefined) {
-            record.cloudID = String(hetznerServerID);
-            record.serverID = hetznerServerID;
+          const hetznerSSHKeyCleanupRequired =
+            config.provider === "hetzner" &&
+            !workspaceID &&
+            hetznerProvisioningSSHKeyCleanupRequired(error);
+          if (hetznerServerID !== undefined || hetznerSSHKeyCleanupRequired) {
+            if (hetznerServerID !== undefined) {
+              record.cloudID = String(hetznerServerID);
+              record.serverID = hetznerServerID;
+            }
             record.releaseDeletesServer = true;
             record.cleanupRetryAt = new Date(
               Date.parse(failedAt) + leaseCleanupRetryDelayMs,
@@ -11502,7 +11509,7 @@ export class FleetCoordinator {
       const deleteServer = options.deleteServer && !isRegisteredLease(current);
       const shouldDelete = Boolean(
         deleteServer &&
-        current.cloudID &&
+        leaseHasProviderCleanup(current) &&
         (leaseIsLive(current) ||
           current.releaseDeletesServer !== undefined ||
           current.cleanupError),
@@ -11569,6 +11576,7 @@ export class FleetCoordinator {
         return current ?? preparation.lease;
       }
       const released = finalizedReleasedLease(current, true, options.keep);
+      delete released.releaseDeletesServer;
       await this.putLease(released);
       await this.clearWorkspaceReleaseError(released);
       await this.markAWSIngressReconcilePending(released);
@@ -14851,7 +14859,16 @@ function leaseNeedsCleanup(lease: LeaseRecord, now: number): boolean {
     return true;
   }
   return Boolean(
-    !leaseIsLive(lease) && lease.cloudID && (lease.cleanupError || lease.cleanupStartedAt),
+    !leaseIsLive(lease) &&
+    leaseHasProviderCleanup(lease) &&
+    (lease.cleanupError || lease.cleanupStartedAt),
+  );
+}
+
+function leaseHasProviderCleanup(lease: LeaseRecord): boolean {
+  // Hetzner reuses this marker for key-only cleanup; other providers require a cloud resource ID.
+  return Boolean(
+    lease.cloudID || (lease.provider === "hetzner" && lease.releaseDeletesServer === true),
   );
 }
 
@@ -15717,11 +15734,13 @@ export class HetznerProvider implements CloudProvider {
   }
 
   async releaseLease(lease: LeaseRecord): Promise<void> {
-    try {
-      await this.deleteServer(String(lease.serverID));
-    } catch (error) {
-      if (!providerResourceNotFound(error)) {
-        throw error;
+    if (Number.isSafeInteger(lease.serverID) && (lease.serverID ?? 0) > 0) {
+      try {
+        await this.deleteServer(String(lease.serverID));
+      } catch (error) {
+        if (!providerResourceNotFound(error)) {
+          throw error;
+        }
       }
     }
     if (

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -49,6 +49,7 @@ import {
   HetznerClient,
   hetznerProvisioningFailureMayHaveResource,
   hetznerProvisioningFailureRetryable,
+  hetznerProvisioningResourceID,
   sshPublicKeyIdentity,
 } from "./hetzner";
 import { bearerToken, errorMessage, json, pathParts, readJson, requestOwner } from "./http";
@@ -2235,6 +2236,18 @@ export class FleetCoordinator {
             config.provider === "hetzner" && hetznerProvisioningFailureMayHaveResource(error);
           record.provisioningFailureRetryable =
             config.provider === "hetzner" && hetznerProvisioningFailureRetryable(error);
+          const hetznerServerID =
+            config.provider === "hetzner" && !workspaceID
+              ? hetznerProvisioningResourceID(error)
+              : undefined;
+          if (hetznerServerID !== undefined) {
+            record.cloudID = String(hetznerServerID);
+            record.serverID = hetznerServerID;
+            record.releaseDeletesServer = true;
+            record.cleanupRetryAt = new Date(
+              Date.parse(failedAt) + leaseCleanupRetryDelayMs,
+            ).toISOString();
+          }
           if (record.provisioningResourceMayExist || record.provisioningFailureRetryable) {
             delete record.failureError;
           } else {

--- a/worker/src/hetzner.ts
+++ b/worker/src/hetzner.ts
@@ -20,6 +20,11 @@ interface HetznerSSHKeyResponse {
   ssh_key: HetznerSSHKey;
 }
 
+interface HetznerSSHKeyResolution {
+  key: HetznerSSHKey;
+  created: boolean;
+}
+
 interface HetznerServerResponse {
   server: HetznerServer;
 }
@@ -47,6 +52,7 @@ export class HetznerProvisioningError extends Error {
     readonly resourceMayExist: boolean,
     readonly retryable: boolean,
     readonly serverID?: number,
+    readonly sshKeyCleanupRequired = false,
   ) {
     super(message);
     this.name = "HetznerProvisioningError";
@@ -68,6 +74,10 @@ export function hetznerProvisioningFailureRetryable(error: unknown): boolean {
 export function hetznerProvisioningResourceID(error: unknown): number | undefined {
   const serverID = error instanceof HetznerProvisioningError ? error.serverID : undefined;
   return Number.isSafeInteger(serverID) && (serverID ?? 0) > 0 ? serverID : undefined;
+}
+
+export function hetznerProvisioningSSHKeyCleanupRequired(error: unknown): boolean {
+  return error instanceof HetznerProvisioningError && error.sshKeyCleanupRequired;
 }
 
 export class HetznerClient {
@@ -99,6 +109,10 @@ export class HetznerClient {
   }
 
   async ensureSSHKey(name: string, publicKey: string): Promise<HetznerSSHKey> {
+    return (await this.resolveSSHKey(name, publicKey)).key;
+  }
+
+  private async resolveSSHKey(name: string, publicKey: string): Promise<HetznerSSHKeyResolution> {
     const identity = sshPublicKeyIdentity(publicKey);
     const byName = await this.request<HetznerListSSHKeysResponse>(
       "GET",
@@ -109,13 +123,13 @@ export class HetznerClient {
         if (sshPublicKeyIdentity(key.public_key) !== identity) {
           throw new Error(`hetzner ssh key ${name} exists with different public key`);
         }
-        return key;
+        return { key, created: false };
       }
     }
 
     for (const key of await this.listSSHKeys()) {
       if (sshPublicKeyIdentity(key.public_key) === identity) {
-        return key;
+        return { key, created: false };
       }
     }
 
@@ -128,7 +142,7 @@ export class HetznerClient {
           created_by: "crabbox",
         },
       });
-      return created.ssh_key;
+      return { key: created.ssh_key, created: true };
     } catch (error) {
       if (!String(error).includes("uniqueness_error")) {
         throw error;
@@ -137,7 +151,7 @@ export class HetznerClient {
         (entry) => sshPublicKeyIdentity(entry.public_key) === identity,
       );
       if (key) {
-        return key;
+        return { key, created: false };
       }
       throw error;
     }
@@ -150,8 +164,12 @@ export class HetznerClient {
     );
     const key = byName.ssh_keys.find((entry) => entry.name === name);
     if (key) {
-      await this.request<void>("DELETE", `/ssh_keys/${key.id}`);
+      await this.deleteSSHKeyByID(key.id);
     }
+  }
+
+  private async deleteSSHKeyByID(id: number): Promise<void> {
+    await this.request<void>("DELETE", `/ssh_keys/${id}`);
   }
 
   async hourlyPriceUSD(name: string, location: string): Promise<number | undefined> {
@@ -177,14 +195,14 @@ export class HetznerClient {
     owner: string,
   ): Promise<{ server: HetznerServer; serverType: string }> {
     const requireRunning = config.providerKey.startsWith(workspaceProviderKeyPrefix);
-    let key: HetznerSSHKey;
+    let keyResolution: HetznerSSHKeyResolution;
     try {
-      key = await this.ensureSSHKey(config.providerKey, config.sshPublicKey);
+      keyResolution = await this.resolveSSHKey(config.providerKey, config.sshPublicKey);
     } catch (error) {
       const message = errorText(error);
       throw new HetznerProvisioningError(message, false, transientHetznerError(message));
     }
-    const resolvedConfig = { ...config, providerKey: key.name };
+    const resolvedConfig = { ...config, providerKey: keyResolution.key.name };
     const candidates = prependUnique(
       resolvedConfig.serverType,
       serverTypeCandidatesForClass(resolvedConfig.class),
@@ -215,7 +233,24 @@ export class HetznerClient {
         }
       }
     }
-    throw new HetznerProvisioningError(failures.join("; "), resourceMayExist, retryable, serverID);
+    let sshKeyCleanupRequired = false;
+    if (keyResolution.created && managedLeaseSSHKey(keyResolution.key.name) && !resourceMayExist) {
+      try {
+        await this.deleteSSHKeyByID(keyResolution.key.id);
+      } catch (cleanupError) {
+        if (!hetznerResourceNotFound(cleanupError)) {
+          failures.push(`ssh key rollback failed: ${errorText(cleanupError)}`);
+          sshKeyCleanupRequired = true;
+        }
+      }
+    }
+    throw new HetznerProvisioningError(
+      failures.join("; "),
+      resourceMayExist,
+      retryable,
+      serverID,
+      sshKeyCleanupRequired,
+    );
   }
 
   async getServer(id: number): Promise<HetznerServer> {
@@ -374,6 +409,11 @@ export function isRetryableProvisioningError(message: string): boolean {
 
 function prependUnique(first: string, rest: string[]): string[] {
   return [first, ...rest.filter((value) => value !== first)];
+}
+
+function managedLeaseSSHKey(name: string): boolean {
+  // Caller-named keys remain user-managed even when Crabbox had to create them.
+  return /^crabbox-cbx-[a-f0-9]{12}$/.test(name);
 }
 
 function eurToUSD(env: Env): number {

--- a/worker/src/hetzner.ts
+++ b/worker/src/hetzner.ts
@@ -46,6 +46,7 @@ export class HetznerProvisioningError extends Error {
     message: string,
     readonly resourceMayExist: boolean,
     readonly retryable: boolean,
+    readonly serverID?: number,
   ) {
     super(message);
     this.name = "HetznerProvisioningError";
@@ -53,17 +54,20 @@ export class HetznerProvisioningError extends Error {
 }
 
 export function hetznerProvisioningFailureMayHaveResource(error: unknown): boolean {
-  return (
-    (error instanceof HetznerProvisioningError && error.resourceMayExist) ||
-    errorText(error).includes("timed out waiting for server IP")
-  );
+  return error instanceof HetznerProvisioningError
+    ? error.resourceMayExist
+    : errorText(error).includes("timed out waiting for server IP");
 }
 
 export function hetznerProvisioningFailureRetryable(error: unknown): boolean {
-  return (
-    (error instanceof HetznerProvisioningError && error.retryable) ||
-    errorText(error).includes("timed out waiting for server IP")
-  );
+  return error instanceof HetznerProvisioningError
+    ? error.retryable
+    : errorText(error).includes("timed out waiting for server IP");
+}
+
+export function hetznerProvisioningResourceID(error: unknown): number | undefined {
+  const serverID = error instanceof HetznerProvisioningError ? error.serverID : undefined;
+  return Number.isSafeInteger(serverID) && (serverID ?? 0) > 0 ? serverID : undefined;
 }
 
 export class HetznerClient {
@@ -188,6 +192,7 @@ export class HetznerClient {
     const failures: string[] = [];
     let resourceMayExist = false;
     let retryable = false;
+    let serverID: number | undefined;
     for (const serverType of candidates) {
       try {
         // oxlint-disable-next-line eslint/no-await-in-loop -- server-type fallback must stay sequential.
@@ -204,12 +209,13 @@ export class HetznerClient {
         failures.push(`${serverType}: ${message}`);
         resourceMayExist = hetznerProvisioningFailureMayHaveResource(error);
         retryable = hetznerProvisioningFailureRetryable(error);
+        serverID = hetznerProvisioningResourceID(error);
         if (resourceMayExist || !isRetryableProvisioningError(message)) {
           break;
         }
       }
     }
-    throw new HetznerProvisioningError(failures.join("; "), resourceMayExist, retryable);
+    throw new HetznerProvisioningError(failures.join("; "), resourceMayExist, retryable, serverID);
   }
 
   async getServer(id: number): Promise<HetznerServer> {
@@ -291,7 +297,23 @@ export class HetznerClient {
     try {
       return await this.waitForServerIP(response.server.id, requireRunning);
     } catch (error) {
-      throw new HetznerProvisioningError(errorText(error), true, true);
+      const message = errorText(error);
+      if (requireRunning) {
+        throw new HetznerProvisioningError(message, true, true, response.server.id);
+      }
+      try {
+        await this.deleteServer(response.server.id);
+      } catch (cleanupError) {
+        if (!hetznerResourceNotFound(cleanupError)) {
+          throw new HetznerProvisioningError(
+            `${message}; rollback failed: ${errorText(cleanupError)}`,
+            true,
+            true,
+            response.server.id,
+          );
+        }
+      }
+      throw new HetznerProvisioningError(message, false, true);
     }
   }
 
@@ -391,4 +413,8 @@ function transientHetznerError(message: string): boolean {
     Number.parseInt(status, 10) === 429 ||
     Number.parseInt(status, 10) >= 500
   );
+}
+
+function hetznerResourceNotFound(error: unknown): boolean {
+  return /hetzner \w+ [^:]+: http 404(?:\D|$)/u.test(errorText(error));
 }

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -3123,6 +3123,155 @@ describe("fleet lease identity and idle", () => {
     });
   });
 
+  it.each([
+    { cleanupStatus: 204, label: "deletes the allocated server" },
+    { cleanupStatus: 404, label: "accepts an already-absent allocated server" },
+  ])("rolls back ordinary Hetzner readiness failures when it $label", async ({ cleanupStatus }) => {
+    const fetchMock = hetznerReadinessFailureFetch(cleanupStatus);
+    vi.stubGlobal("fetch", fetchMock);
+    const wait = vi
+      .spyOn(HetznerClient.prototype, "waitForServerIP")
+      .mockRejectedValueOnce(new Error("timed out waiting for server IP: 123"));
+    const client = new HetznerClient({ HETZNER_TOKEN: "test-token" } as Env);
+    const config = leaseConfig({
+      provider: "hetzner",
+      providerKey: "ordinary-key",
+      sshPublicKey: "ssh-ed25519 ordinary-test",
+    });
+
+    try {
+      const error = await client
+        .createServerWithFallback(config, "cbx_abcdef123456", "ordinary", "alice@example.com")
+        .catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(HetznerProvisioningError);
+      expect(error).toMatchObject({ resourceMayExist: false, retryable: true });
+      expect((error as HetznerProvisioningError).serverID).toBeUndefined();
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://api.hetzner.cloud/v1/servers/123",
+        expect.objectContaining({ method: "DELETE" }),
+      );
+    } finally {
+      wait.mockRestore();
+    }
+  });
+
+  it("keeps the allocated Hetzner server ID when readiness rollback fails", async () => {
+    const fetchMock = hetznerReadinessFailureFetch(503);
+    vi.stubGlobal("fetch", fetchMock);
+    const wait = vi
+      .spyOn(HetznerClient.prototype, "waitForServerIP")
+      .mockRejectedValueOnce(new Error("timed out waiting for server IP: 123"));
+    const client = new HetznerClient({ HETZNER_TOKEN: "test-token" } as Env);
+    const config = leaseConfig({
+      provider: "hetzner",
+      providerKey: "ordinary-key",
+      sshPublicKey: "ssh-ed25519 ordinary-test",
+    });
+
+    try {
+      const error = await client
+        .createServerWithFallback(config, "cbx_abcdef123456", "ordinary", "alice@example.com")
+        .catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(HetznerProvisioningError);
+      expect(error).toMatchObject({ resourceMayExist: true, retryable: true, serverID: 123 });
+      expect((error as Error).message).toContain("rollback failed");
+    } finally {
+      wait.mockRestore();
+    }
+  });
+
+  it("leaves workspace Hetzner readiness recovery unchanged", async () => {
+    const fetchMock = hetznerReadinessFailureFetch(204);
+    vi.stubGlobal("fetch", fetchMock);
+    const wait = vi
+      .spyOn(HetznerClient.prototype, "waitForServerIP")
+      .mockRejectedValueOnce(new Error("timed out waiting for server IP: 123"));
+    const client = new HetznerClient({ HETZNER_TOKEN: "test-token" } as Env);
+    const config = leaseConfig({
+      provider: "hetzner",
+      providerKey: "crabbox-workspace-deadbeef0000",
+      sshPublicKey: "ssh-ed25519 workspace-test",
+    });
+
+    try {
+      const error = await client
+        .createServerWithFallback(config, "cbx_abcdef123456", "workspace", "alice@example.com")
+        .catch((caught: unknown) => caught);
+
+      expect(error).toMatchObject({ resourceMayExist: true, retryable: true, serverID: 123 });
+      expect(fetchMock).not.toHaveBeenCalledWith(
+        "https://api.hetzner.cloud/v1/servers/123",
+        expect.objectContaining({ method: "DELETE" }),
+      );
+    } finally {
+      wait.mockRestore();
+    }
+  });
+
+  it("persists failed ordinary Hetzner cleanup and retries by server ID", async () => {
+    const storage = new MemoryStorage();
+    const deleted: string[] = [];
+    const fleet = testFleet(storage, {
+      hetzner: fakeProvider(
+        async () => {
+          throw new HetznerProvisioningError(
+            "timed out waiting for server IP: 777; rollback failed: provider unavailable",
+            true,
+            true,
+            777,
+          );
+        },
+        {},
+        async (id) => {
+          deleted.push(id);
+        },
+      ),
+    });
+
+    const response = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers: {
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
+        },
+        body: {
+          leaseID: "cbx_abcdef123456",
+          provider: "hetzner",
+          sshPublicKey: "ssh-ed25519 ordinary-test",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(500);
+    const failed = storage.value<LeaseRecord>("lease:cbx_abcdef123456")!;
+    expect(failed).toMatchObject({
+      state: "failed",
+      cloudID: "777",
+      serverID: 777,
+      releaseDeletesServer: true,
+      provisioningResourceMayExist: true,
+      cleanupRetryAt: expect.any(String),
+    });
+    expect(storage.alarm()).toBe(Date.parse(failed.cleanupRetryAt ?? ""));
+
+    failed.cleanupRetryAt = new Date(Date.now() - 1_000).toISOString();
+    storage.seed("lease:cbx_abcdef123456", failed);
+    await fleet.alarm();
+
+    expect(deleted).toEqual(["777"]);
+    expect(storage.value<LeaseRecord>("lease:cbx_abcdef123456")).toMatchObject({
+      state: "failed",
+      cloudID: "777",
+      serverID: 777,
+    });
+    expect(storage.value<LeaseRecord>("lease:cbx_abcdef123456")?.cleanupError).toBeUndefined();
+    expect(
+      storage.value<LeaseRecord>("lease:cbx_abcdef123456")?.releaseDeletesServer,
+    ).toBeUndefined();
+  });
+
   it("uses the terminating Hetzner fallback error to decide retryability", async () => {
     const responses = [
       jsonResponse({ ssh_keys: [] }),
@@ -19018,6 +19167,50 @@ function jsonResponse(body: unknown, status = 200): Response {
     status,
     headers: { "content-type": "application/json" },
   });
+}
+
+function hetznerReadinessFailureFetch(cleanupStatus: number) {
+  return vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+    async (input, init) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const parsed = new URL(url);
+      const method = init?.method ?? "GET";
+      if (method === "GET" && parsed.pathname === "/v1/ssh_keys") {
+        return jsonResponse({ ssh_keys: [] });
+      }
+      if (method === "POST" && parsed.pathname === "/v1/ssh_keys") {
+        return jsonResponse({
+          ssh_key: {
+            id: 1,
+            name: "ordinary-key",
+            public_key: "ssh-ed25519 ordinary-test",
+          },
+        });
+      }
+      if (method === "POST" && parsed.pathname === "/v1/servers") {
+        return jsonResponse({
+          server: {
+            id: 123,
+            name: "crabbox-ordinary",
+            status: "initializing",
+            server_type: { name: "cpx62" },
+            public_net: { ipv4: { ip: "" } },
+            labels: {},
+          },
+        });
+      }
+      if (method === "DELETE" && parsed.pathname === "/v1/servers/123") {
+        return cleanupStatus === 204
+          ? new Response(null, { status: 204 })
+          : jsonResponse(
+              { error: { code: cleanupStatus === 404 ? "not_found" : "server_error" } },
+              cleanupStatus,
+            );
+      }
+      return jsonResponse({ error: { code: "unexpected_request" } }, 500);
+    },
+  );
 }
 
 function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -3112,7 +3112,7 @@ describe("fleet lease identity and idle", () => {
     const client = new HetznerClient({ HETZNER_TOKEN: "test-token" } as Env);
     const config = leaseConfig({
       provider: "hetzner",
-      providerKey: "ordinary-key",
+      providerKey: "crabbox-cbx-abcdef123456",
       sshPublicKey: "ssh-ed25519 ordinary-test",
     });
 
@@ -3135,7 +3135,7 @@ describe("fleet lease identity and idle", () => {
     const client = new HetznerClient({ HETZNER_TOKEN: "test-token" } as Env);
     const config = leaseConfig({
       provider: "hetzner",
-      providerKey: "ordinary-key",
+      providerKey: "crabbox-cbx-abcdef123456",
       sshPublicKey: "ssh-ed25519 ordinary-test",
     });
 
@@ -3149,6 +3149,10 @@ describe("fleet lease identity and idle", () => {
       expect((error as HetznerProvisioningError).serverID).toBeUndefined();
       expect(fetchMock).toHaveBeenCalledWith(
         "https://api.hetzner.cloud/v1/servers/123",
+        expect.objectContaining({ method: "DELETE" }),
+      );
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://api.hetzner.cloud/v1/ssh_keys/1",
         expect.objectContaining({ method: "DELETE" }),
       );
     } finally {
@@ -3165,7 +3169,7 @@ describe("fleet lease identity and idle", () => {
     const client = new HetznerClient({ HETZNER_TOKEN: "test-token" } as Env);
     const config = leaseConfig({
       provider: "hetzner",
-      providerKey: "ordinary-key",
+      providerKey: "crabbox-cbx-abcdef123456",
       sshPublicKey: "ssh-ed25519 ordinary-test",
     });
 
@@ -3177,6 +3181,10 @@ describe("fleet lease identity and idle", () => {
       expect(error).toBeInstanceOf(HetznerProvisioningError);
       expect(error).toMatchObject({ resourceMayExist: true, retryable: true, serverID: 123 });
       expect((error as Error).message).toContain("rollback failed");
+      expect(fetchMock).not.toHaveBeenCalledWith(
+        "https://api.hetzner.cloud/v1/ssh_keys/1",
+        expect.objectContaining({ method: "DELETE" }),
+      );
     } finally {
       wait.mockRestore();
     }
@@ -3203,6 +3211,99 @@ describe("fleet lease identity and idle", () => {
       expect(error).toMatchObject({ resourceMayExist: true, retryable: true, serverID: 123 });
       expect(fetchMock).not.toHaveBeenCalledWith(
         "https://api.hetzner.cloud/v1/servers/123",
+        expect.objectContaining({ method: "DELETE" }),
+      );
+      expect(fetchMock).not.toHaveBeenCalledWith(
+        "https://api.hetzner.cloud/v1/ssh_keys/1",
+        expect.objectContaining({ method: "DELETE" }),
+      );
+    } finally {
+      wait.mockRestore();
+    }
+  });
+
+  it("preserves a reused Hetzner SSH key after readiness rollback", async () => {
+    const fetchMock = hetznerReadinessFailureFetch(204, { existingSSHKey: true });
+    vi.stubGlobal("fetch", fetchMock);
+    const wait = vi
+      .spyOn(HetznerClient.prototype, "waitForServerIP")
+      .mockRejectedValueOnce(new Error("timed out waiting for server IP: 123"));
+    const client = new HetznerClient({ HETZNER_TOKEN: "test-token" } as Env);
+    const config = leaseConfig({
+      provider: "hetzner",
+      providerKey: "ordinary-key",
+      sshPublicKey: "ssh-ed25519 ordinary-test",
+    });
+
+    try {
+      const error = await client
+        .createServerWithFallback(config, "cbx_abcdef123456", "ordinary", "alice@example.com")
+        .catch((caught: unknown) => caught);
+
+      expect(error).toMatchObject({ resourceMayExist: false, retryable: true });
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://api.hetzner.cloud/v1/servers/123",
+        expect.objectContaining({ method: "DELETE" }),
+      );
+      expect(fetchMock).not.toHaveBeenCalledWith(
+        "https://api.hetzner.cloud/v1/ssh_keys/1",
+        expect.objectContaining({ method: "DELETE" }),
+      );
+    } finally {
+      wait.mockRestore();
+    }
+  });
+
+  it("marks failed Hetzner SSH key rollback for durable cleanup", async () => {
+    const fetchMock = hetznerReadinessFailureFetch(204, { sshKeyCleanupStatus: 503 });
+    vi.stubGlobal("fetch", fetchMock);
+    const wait = vi
+      .spyOn(HetznerClient.prototype, "waitForServerIP")
+      .mockRejectedValueOnce(new Error("timed out waiting for server IP: 123"));
+    const client = new HetznerClient({ HETZNER_TOKEN: "test-token" } as Env);
+    const config = leaseConfig({
+      provider: "hetzner",
+      providerKey: "crabbox-cbx-abcdef123456",
+      sshPublicKey: "ssh-ed25519 ordinary-test",
+    });
+
+    try {
+      const error = await client
+        .createServerWithFallback(config, "cbx_abcdef123456", "ordinary", "alice@example.com")
+        .catch((caught: unknown) => caught);
+
+      expect(error).toMatchObject({
+        resourceMayExist: false,
+        retryable: true,
+        sshKeyCleanupRequired: true,
+      });
+      expect((error as Error).message).toContain("ssh key rollback failed");
+    } finally {
+      wait.mockRestore();
+    }
+  });
+
+  it("preserves a newly created caller-named Hetzner SSH key after readiness rollback", async () => {
+    const fetchMock = hetznerReadinessFailureFetch(204, { sshKeyName: "ordinary-key" });
+    vi.stubGlobal("fetch", fetchMock);
+    const wait = vi
+      .spyOn(HetznerClient.prototype, "waitForServerIP")
+      .mockRejectedValueOnce(new Error("timed out waiting for server IP: 123"));
+    const client = new HetznerClient({ HETZNER_TOKEN: "test-token" } as Env);
+    const config = leaseConfig({
+      provider: "hetzner",
+      providerKey: "ordinary-key",
+      sshPublicKey: "ssh-ed25519 ordinary-test",
+    });
+
+    try {
+      const error = await client
+        .createServerWithFallback(config, "cbx_abcdef123456", "ordinary", "alice@example.com")
+        .catch((caught: unknown) => caught);
+
+      expect(error).toMatchObject({ resourceMayExist: false, sshKeyCleanupRequired: false });
+      expect(fetchMock).not.toHaveBeenCalledWith(
+        "https://api.hetzner.cloud/v1/ssh_keys/1",
         expect.objectContaining({ method: "DELETE" }),
       );
     } finally {
@@ -3270,6 +3371,175 @@ describe("fleet lease identity and idle", () => {
     expect(
       storage.value<LeaseRecord>("lease:cbx_abcdef123456")?.releaseDeletesServer,
     ).toBeUndefined();
+  });
+
+  it("persists failed Hetzner SSH key rollback and retries provider cleanup", async () => {
+    const storage = new MemoryStorage();
+    const cleaned: LeaseRecord[] = [];
+    const fleet = testFleet(storage, {
+      hetzner: fakeProvider(
+        async () => {
+          throw new HetznerProvisioningError(
+            "timed out waiting for server IP; ssh key rollback failed: provider unavailable",
+            false,
+            true,
+            undefined,
+            true,
+          );
+        },
+        {
+          onReleaseLease: (lease) => {
+            cleaned.push(structuredClone(lease));
+            if (cleaned.length === 1) {
+              throw new Error("provider unavailable");
+            }
+          },
+        },
+      ),
+    });
+
+    const response = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers: {
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
+        },
+        body: {
+          leaseID: "cbx_abcdef123456",
+          provider: "hetzner",
+          sshPublicKey: "ssh-ed25519 ordinary-test",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(500);
+    const failed = storage.value<LeaseRecord>("lease:cbx_abcdef123456")!;
+    expect(failed).toMatchObject({
+      state: "failed",
+      releaseDeletesServer: true,
+      provisioningResourceMayExist: false,
+      cleanupRetryAt: expect.any(String),
+    });
+    expect(failed.cloudID).toBe("");
+    expect(storage.alarm()).toBe(Date.parse(failed.cleanupRetryAt ?? ""));
+
+    failed.cleanupRetryAt = new Date(Date.now() - 1_000).toISOString();
+    storage.seed("lease:cbx_abcdef123456", failed);
+    await fleet.alarm();
+
+    expect(cleaned).toHaveLength(1);
+    const retry = storage.value<LeaseRecord>("lease:cbx_abcdef123456")!;
+    expect(retry).toMatchObject({
+      releaseDeletesServer: true,
+      cleanupError: "provider unavailable",
+      cleanupRetryAt: expect.any(String),
+    });
+
+    retry.cleanupRetryAt = new Date(Date.now() - 1_000).toISOString();
+    storage.seed("lease:cbx_abcdef123456", retry);
+    await fleet.alarm();
+
+    expect(cleaned).toHaveLength(2);
+    expect(cleaned[1]?.providerKey).toBe(failed.providerKey);
+    expect(storage.value<LeaseRecord>("lease:cbx_abcdef123456")?.cleanupError).toBeUndefined();
+    expect(
+      storage.value<LeaseRecord>("lease:cbx_abcdef123456")?.releaseDeletesServer,
+    ).toBeUndefined();
+  });
+
+  it("keeps failed Hetzner SSH key cleanup through an explicit release", async () => {
+    const storage = new MemoryStorage();
+    const cleaned: LeaseRecord[] = [];
+    const fleet = testFleet(storage, {
+      hetzner: fakeProvider(
+        async () => {
+          throw new HetznerProvisioningError(
+            "timed out waiting for server IP; ssh key rollback failed: provider unavailable",
+            false,
+            true,
+            undefined,
+            true,
+          );
+        },
+        {
+          onReleaseLease: (lease) => {
+            cleaned.push(structuredClone(lease));
+          },
+        },
+      ),
+    });
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+
+    expect(
+      (
+        await fleet.fetch(
+          request("POST", "/v1/leases", {
+            headers,
+            body: {
+              leaseID: "cbx_abcdef123456",
+              provider: "hetzner",
+              sshPublicKey: "ssh-ed25519 ordinary-test",
+            },
+          }),
+        )
+      ).status,
+    ).toBe(500);
+
+    const response = await fleet.fetch(
+      request("POST", "/v1/leases/cbx_abcdef123456/release", {
+        headers,
+        body: { delete: true },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(cleaned).toHaveLength(1);
+    expect(storage.value<LeaseRecord>("lease:cbx_abcdef123456")).toMatchObject({
+      state: "released",
+    });
+    expect(storage.value<LeaseRecord>("lease:cbx_abcdef123456")?.cleanupError).toBeUndefined();
+    expect(
+      storage.value<LeaseRecord>("lease:cbx_abcdef123456")?.releaseDeletesServer,
+    ).toBeUndefined();
+  });
+
+  it("does not treat an ID-less Azure release marker as a cleanup target", async () => {
+    const storage = new MemoryStorage();
+    const deleted: string[] = [];
+    const fleet = testFleet(storage, {
+      azure: fakeProvider(undefined, { provider: "azure" }, async (id) => {
+        deleted.push(id);
+      }),
+    });
+    const lease = testLease({
+      id: "cbx_abcdef123456",
+      provider: "azure",
+      cloudID: "",
+      serverID: 0,
+      state: "released",
+      releaseDeletesServer: true,
+    });
+    storage.seed(`lease:${lease.id}`, lease);
+
+    const response = await fleet.fetch(
+      request("POST", `/v1/leases/${lease.id}/release`, {
+        headers: {
+          "x-crabbox-owner": lease.owner,
+          "x-crabbox-org": lease.org,
+        },
+        body: { delete: true },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(deleted).toEqual([]);
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)).toMatchObject({
+      state: "released",
+      releaseDeletesServer: true,
+    });
   });
 
   it("uses the terminating Hetzner fallback error to decide retryability", async () => {
@@ -3447,6 +3717,54 @@ describe("fleet lease identity and idle", () => {
     });
 
     await expect(provider.releaseLease(lease)).resolves.toBeUndefined();
+  });
+
+  it("retries only the canonical Hetzner key when no server ID was persisted", async () => {
+    const providerKey = "crabbox-cbx-abcdef123456";
+    const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+      async (input, init) => {
+        const url =
+          typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+        const parsed = new URL(url);
+        const method = init?.method ?? "GET";
+        if (method === "GET" && parsed.pathname === "/v1/ssh_keys") {
+          return jsonResponse({
+            ssh_keys: [
+              {
+                id: 1,
+                name: providerKey,
+                public_key: "ssh-ed25519 ordinary-test",
+              },
+            ],
+          });
+        }
+        if (method === "DELETE" && parsed.pathname === "/v1/ssh_keys/1") {
+          return new Response(null, { status: 204 });
+        }
+        return jsonResponse({ error: { code: "unexpected_request" } }, 500);
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const provider = new HetznerProvider({ HETZNER_TOKEN: "test-token" } as Env);
+    const lease = testLease({
+      provider: "hetzner",
+      cloudID: "",
+      serverID: undefined,
+      providerKey,
+    });
+
+    await expect(provider.releaseLease(lease)).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledWith(
+      `https://api.hetzner.cloud/v1/ssh_keys?name=${providerKey}`,
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.hetzner.cloud/v1/ssh_keys/1",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+    expect(fetchMock.mock.calls.some(([input]) => String(input).includes("/v1/servers/"))).toBe(
+      false,
+    );
   });
 
   it("reserves the shared workspace provider key from ordinary leases", async () => {
@@ -19254,7 +19572,14 @@ function jsonResponse(body: unknown, status = 200): Response {
   });
 }
 
-function hetznerReadinessFailureFetch(cleanupStatus: number) {
+function hetznerReadinessFailureFetch(
+  cleanupStatus: number,
+  {
+    existingSSHKey = false,
+    sshKeyCleanupStatus = 204,
+    sshKeyName = "crabbox-cbx-abcdef123456",
+  }: { existingSSHKey?: boolean; sshKeyCleanupStatus?: number; sshKeyName?: string } = {},
+) {
   return vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
     async (input, init) => {
       const url =
@@ -19262,13 +19587,23 @@ function hetznerReadinessFailureFetch(cleanupStatus: number) {
       const parsed = new URL(url);
       const method = init?.method ?? "GET";
       if (method === "GET" && parsed.pathname === "/v1/ssh_keys") {
-        return jsonResponse({ ssh_keys: [] });
+        return jsonResponse({
+          ssh_keys: existingSSHKey
+            ? [
+                {
+                  id: 1,
+                  name: sshKeyName,
+                  public_key: "ssh-ed25519 ordinary-test",
+                },
+              ]
+            : [],
+        });
       }
       if (method === "POST" && parsed.pathname === "/v1/ssh_keys") {
         return jsonResponse({
           ssh_key: {
             id: 1,
-            name: "ordinary-key",
+            name: sshKeyName,
             public_key: "ssh-ed25519 ordinary-test",
           },
         });
@@ -19292,6 +19627,11 @@ function hetznerReadinessFailureFetch(cleanupStatus: number) {
               { error: { code: cleanupStatus === 404 ? "not_found" : "server_error" } },
               cleanupStatus,
             );
+      }
+      if (method === "DELETE" && parsed.pathname === "/v1/ssh_keys/1") {
+        return sshKeyCleanupStatus === 204
+          ? new Response(null, { status: 204 })
+          : jsonResponse({ error: { code: "server_error" } }, sshKeyCleanupStatus);
       }
       return jsonResponse({ error: { code: "unexpected_request" } }, 500);
     },
@@ -19433,6 +19773,7 @@ function fakeProvider(
     onRecoverServer?: (
       lease: LeaseRecord,
     ) => Promise<ProviderMachine | undefined> | ProviderMachine | undefined;
+    onReleaseLease?: (lease: LeaseRecord) => Promise<void> | void;
   } = {},
   onDelete?: (id: string) => Promise<void>,
   onGet?: (id: string) => Promise<ProviderMachine> | ProviderMachine,
@@ -19590,6 +19931,10 @@ function fakeProvider(
       await onDelete?.(id);
     },
     async releaseLease(lease: LeaseRecord) {
+      if (result.onReleaseLease) {
+        await result.onReleaseLease(lease);
+        return;
+      }
       await onDelete?.(
         (lease.provider ?? result.provider) === "hetzner" ? String(lease.serverID) : lease.cloudID,
       );


### PR DESCRIPTION
Closes https://github.com/openclaw/crabbox/issues/761.

## Summary

- Roll back ordinary brokered Hetzner servers when post-create IP readiness fails.
- Treat a successful DELETE or already-absent server as a deterministic no-resource failure.
- Preserve the exact server ID when rollback fails, then persist cleanup metadata so release and alarm retry paths can delete the billable server.
- Keep workspace provisioning recovery unchanged and avoid deleting potentially shared SSH keys.
- Add an Unreleased changelog entry thanking @coygeek.

## Verification

- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker` — 25 files, 714 tests passed.
- `npm run build --prefix worker`
- `git diff --check`
- `/Users/steipete/Projects/agent-skills/skills/autoreview/scripts/autoreview --mode branch --base origin/main --parallel-tests 'npm test --prefix worker -- fleet.test.ts && npm run check --prefix worker' --stream-engine-output` — clean; no accepted/actionable findings; correct at 0.86 confidence.

Regression coverage proves successful and 404 rollback, rollback-failure server-ID retention, unchanged workspace recovery, and alarm-driven cleanup retry by the persisted ID.

Fresh exact-head remote proof for `d7bbc0d935367c2cf43330edb01428f9468be4d8`: run `run_c0402ec520d0`, lease `cbx_9e930c569e5d`; Node 22.22.1/npm 9.2.0; focused fleet suite (306 tests) and typecheck passed; lease released without cleanup error.

## Hetzner live gate

Run `run_f478a736f584` reached the Hetzner credential preflight, then the coordinator's read-only `GET /ssh_keys` returned HTTP 401 (`token invalid`) before any server-create request. The sole local `hcloud` context fails with the same invalid saved token. Provider inventory remains empty (`crabbox list --provider hetzner --json`: 0 leases), so this attempt created no resource.

The forced-readiness rollback canary remains blocked on valid Hetzner credentials. Keep this PR unmerged until that exact live path proves server deletion and clean inventory.
