### PR TITLE
fix: validate Sprites API endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### Fixed
 
+- Prevented Sprites API credentials from targeting unsafe endpoint URLs or following redirects outside the configured API origin. Thanks @coygeek.
 - Pinned the Google Linux package signing fingerprint, preserved its source-scoped APT keyring across Chrome installation, and failed closed to Chromium when verification fails. Thanks @coygeek.
 - Hardened coordinator image deletion so admin `image delete` requests fail closed unless stored Crabbox-created metadata proves ownership of the AWS, Azure, or GCP image or snapshot.
 - Prevented unused WebVNC and Code bridge tickets from surviving manager share revocation. Thanks @coygeek.

--- a/docs/features/sprites.md
+++ b/docs/features/sprites.md
@@ -52,6 +52,10 @@ environment:
 - `CRABBOX_SPRITES_API_URL` or `SPRITES_API_URL` → `sprites.apiUrl`
 - `CRABBOX_SPRITES_WORK_ROOT` → `sprites.workRoot`
 
+Custom API URLs require HTTPS unless the host is literal loopback. Userinfo,
+queries, and fragments are rejected, and authenticated requests cannot follow
+redirects to another origin.
+
 Equivalent one-off flags:
 
 ```sh

--- a/docs/providers/sprites.md
+++ b/docs/providers/sprites.md
@@ -87,7 +87,10 @@ SPRITES_API_URL
 CRABBOX_SPRITES_WORK_ROOT
 ```
 
-`CRABBOX_SPRITES_API_URL` wins over `SPRITES_API_URL`. The work root must be a
+`CRABBOX_SPRITES_API_URL` wins over `SPRITES_API_URL`. Custom API URLs must use
+HTTPS, except literal loopback hosts may use HTTP. Userinfo, queries, and
+fragments are rejected, and authenticated requests never follow redirects to a
+different scheme, host, or port. The work root must be a
 dedicated absolute path; broad roots such as `/`, `/home`, `/home/sprite`,
 `/tmp`, `/etc`, `/usr`, `/var`, and similar system directories are rejected
 before sync.

--- a/internal/providers/sprites/backend.go
+++ b/internal/providers/sprites/backend.go
@@ -68,7 +68,10 @@ func NewSpritesBackend(spec ProviderSpec, cfg Config, rt Runtime) (Backend, erro
 	if strings.TrimSpace(cfg.Sprites.Token) == "" {
 		return nil, exit(2, "provider=sprites requires SPRITES_TOKEN, SPRITE_TOKEN, SETUP_SPRITE_TOKEN, or CRABBOX_SPRITES_TOKEN")
 	}
-	client := newSpritesClient(cfg, rt)
+	client, err := newSpritesClient(cfg, rt)
+	if err != nil {
+		return nil, err
+	}
 	return &spritesBackend{spec: spec, cfg: cfg, rt: rt, client: client}, nil
 }
 

--- a/internal/providers/sprites/backend_test.go
+++ b/internal/providers/sprites/backend_test.go
@@ -7,9 +7,11 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
@@ -260,6 +262,179 @@ func TestSpritesRejectsUnsafeWorkRootBeforeBackend(t *testing.T) {
 	}
 }
 
+func TestSpritesRejectsUnsafeAPIURLBeforeBackend(t *testing.T) {
+	cfg := Config{Sprites: SpritesConfig{
+		Token:    "test-token",
+		APIURL:   "http://api.sprites.dev",
+		WorkRoot: "/home/sprite/crabbox",
+	}}
+	_, err := NewSpritesBackend(Provider{}.Spec(), cfg, Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: &recordingRunner{}})
+	if err == nil || !strings.Contains(err.Error(), "must use HTTPS") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestSpritesAPIURLValidation(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "canonical https", raw: "HTTPS://API.SPRITES.DEV:443/tenant/", want: "https://api.sprites.dev/tenant"},
+		{name: "escaped path", raw: "https://api.sprites.dev/tenant%2F/", want: "https://api.sprites.dev/tenant%2F"},
+		{name: "localhost", raw: "http://localhost:8080/", want: "http://localhost:8080"},
+		{name: "ipv4 loopback", raw: "http://127.0.0.2:8080/api", want: "http://127.0.0.2:8080/api"},
+		{name: "ipv6 loopback", raw: "http://[::1]:80/", want: "http://[::1]"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, _, err := validateSpritesAPIURL(test.raw)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != test.want {
+				t.Fatalf("url=%q want %q", got, test.want)
+			}
+		})
+	}
+
+	for _, test := range []struct {
+		name string
+		raw  string
+	}{
+		{name: "public http", raw: "http://api.sprites.dev"},
+		{name: "relative", raw: "/v1/sprites"},
+		{name: "schemeless", raw: "api.sprites.dev"},
+		{name: "missing host", raw: "https:///v1/sprites"},
+		{name: "opaque", raw: "https:api.sprites.dev"},
+		{name: "other scheme", raw: "ftp://api.sprites.dev"},
+		{name: "userinfo", raw: "https://token@api.sprites.dev"},
+		{name: "query", raw: "https://api.sprites.dev?region=us"},
+		{name: "bare query", raw: "https://api.sprites.dev?"},
+		{name: "fragment", raw: "https://api.sprites.dev#fragment"},
+		{name: "malformed port", raw: "https://api.sprites.dev:bad"},
+		{name: "loopback lookalike", raw: "http://localhost.example.com"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if _, _, err := validateSpritesAPIURL(test.raw); err == nil {
+				t.Fatalf("expected %q to be rejected", test.raw)
+			}
+		})
+	}
+}
+
+func TestSpritesClientDefaultsAPIURL(t *testing.T) {
+	client, err := newSpritesClient(Config{Sprites: SpritesConfig{Token: "test-token"}}, Runtime{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := client.(*spritesClient).apiURL; got != "https://api.sprites.dev" {
+		t.Fatalf("apiURL=%q", got)
+	}
+}
+
+func TestSpritesClientRejectsCrossOriginRedirect(t *testing.T) {
+	targetRequests := 0
+	target := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		targetRequests++
+	}))
+	defer target.Close()
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/capture", http.StatusTemporaryRedirect)
+	}))
+	defer origin.Close()
+
+	client, err := newSpritesClient(
+		Config{Sprites: SpritesConfig{Token: "test-token", APIURL: origin.URL}},
+		Runtime{HTTP: origin.Client()},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.ListSprites(context.Background(), "")
+	if err == nil || !strings.Contains(err.Error(), "redirect changed API origin") {
+		t.Fatalf("err=%v", err)
+	}
+	if targetRequests != 0 {
+		t.Fatalf("target requests=%d", targetRequests)
+	}
+}
+
+func TestSpritesClientPreservesAuthOnSameOriginRedirect(t *testing.T) {
+	var redirected bool
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/sprites" {
+			http.Redirect(w, r, srv.URL+"/redirected", http.StatusTemporaryRedirect)
+			return
+		}
+		redirected = true
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Fatalf("auth=%q", got)
+		}
+		_ = json.NewEncoder(w).Encode(spritesListResponse{})
+	}))
+	defer srv.Close()
+
+	client, err := newSpritesClient(
+		Config{Sprites: SpritesConfig{Token: "test-token", APIURL: srv.URL}},
+		Runtime{HTTP: srv.Client()},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.ListSprites(context.Background(), ""); err != nil {
+		t.Fatal(err)
+	}
+	if !redirected {
+		t.Fatal("same-origin redirect was not followed")
+	}
+}
+
+func TestSpritesClientPreservesCustomRedirectPolicy(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/redirected", http.StatusTemporaryRedirect)
+	}))
+	defer srv.Close()
+	source := srv.Client()
+	source.Timeout = 3 * time.Second
+	source.CheckRedirect = func(*http.Request, []*http.Request) error {
+		called = true
+		return errors.New("custom redirect stop")
+	}
+
+	client, err := newSpritesClient(
+		Config{Sprites: SpritesConfig{Token: "test-token", APIURL: srv.URL}},
+		Runtime{HTTP: source},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.ListSprites(context.Background(), "")
+	if err == nil || !strings.Contains(err.Error(), "custom redirect stop") {
+		t.Fatalf("err=%v", err)
+	}
+	if !called {
+		t.Fatal("custom redirect policy was not called")
+	}
+	secured := client.(*spritesClient).httpClient
+	if secured == source || secured.Timeout != source.Timeout || secured.Transport != source.Transport {
+		t.Fatal("HTTP client settings were not preserved in a clone")
+	}
+}
+
+func TestSpritesSameOriginUsesEffectiveDefaultPorts(t *testing.T) {
+	a, _ := url.Parse("https://api.sprites.dev/path")
+	b, _ := url.Parse("https://API.SPRITES.DEV:443/other")
+	c, _ := url.Parse("http://api.sprites.dev:443/other")
+	if !sameSpritesOrigin(a, b) {
+		t.Fatal("default HTTPS port should be the same origin")
+	}
+	if sameSpritesOrigin(a, c) {
+		t.Fatal("scheme change should not be the same origin")
+	}
+}
+
 func TestSpritesClientLifecycleRequests(t *testing.T) {
 	var sawCreate bool
 	var sawDelete bool
@@ -295,7 +470,10 @@ func TestSpritesClientLifecycleRequests(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := newSpritesClient(Config{Sprites: SpritesConfig{Token: "test-token", APIURL: srv.URL}}, Runtime{HTTP: srv.Client()})
+	client, err := newSpritesClient(Config{Sprites: SpritesConfig{Token: "test-token", APIURL: srv.URL}}, Runtime{HTTP: srv.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
 	sprite, err := client.CreateSprite(context.Background(), "crabbox-blue-lobster-12345678", []string{"crabbox"})
 	if err != nil {
 		t.Fatal(err)
@@ -337,8 +515,11 @@ func TestSpritesClientRejectsBadPagination(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			client := newSpritesClient(Config{Sprites: SpritesConfig{Token: "test-token", APIURL: srv.URL}}, Runtime{HTTP: srv.Client()})
-			_, err := client.ListSprites(context.Background(), "crabbox-")
+			client, err := newSpritesClient(Config{Sprites: SpritesConfig{Token: "test-token", APIURL: srv.URL}}, Runtime{HTTP: srv.Client()})
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = client.ListSprites(context.Background(), "crabbox-")
 			if err == nil {
 				t.Fatal("expected pagination error")
 			}

--- a/internal/providers/sprites/client.go
+++ b/internal/providers/sprites/client.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -52,13 +54,110 @@ func (e *spritesAPIError) Error() string {
 	return e.Status + ": " + e.Body
 }
 
-func newSpritesClient(cfg Config, rt Runtime) spritesAPI {
+func newSpritesClient(cfg Config, rt Runtime) (spritesAPI, error) {
+	apiURL, origin, err := validateSpritesAPIURL(blank(cfg.Sprites.APIURL, "https://api.sprites.dev"))
+	if err != nil {
+		return nil, err
+	}
 	httpClient := rt.HTTP
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
-	apiURL := strings.TrimRight(blank(cfg.Sprites.APIURL, "https://api.sprites.dev"), "/")
-	return &spritesClient{token: strings.TrimSpace(cfg.Sprites.Token), apiURL: apiURL, httpClient: httpClient}
+	return &spritesClient{
+		token:      strings.TrimSpace(cfg.Sprites.Token),
+		apiURL:     apiURL,
+		httpClient: secureSpritesHTTPClient(httpClient, origin),
+	}, nil
+}
+
+func validateSpritesAPIURL(raw string) (string, *url.URL, error) {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return "", nil, exit(2, "provider=sprites API URL must be an absolute HTTP(S) URL")
+	}
+	if !parsed.IsAbs() || parsed.Host == "" || parsed.Hostname() == "" || parsed.Opaque != "" {
+		return "", nil, exit(2, "provider=sprites API URL must be an absolute HTTP(S) URL")
+	}
+	if parsed.User != nil {
+		return "", nil, exit(2, "provider=sprites API URL must not contain userinfo")
+	}
+	if parsed.RawQuery != "" || parsed.ForceQuery {
+		return "", nil, exit(2, "provider=sprites API URL must not contain a query")
+	}
+	if parsed.Fragment != "" {
+		return "", nil, exit(2, "provider=sprites API URL must not contain a fragment")
+	}
+	parsed.Scheme = strings.ToLower(parsed.Scheme)
+	hostname := canonicalSpritesHostname(parsed.Hostname())
+	if parsed.Scheme != "https" && (parsed.Scheme != "http" || !isSpritesLoopbackHost(hostname)) {
+		return "", nil, exit(2, "provider=sprites API URL must use HTTPS except for loopback HTTP")
+	}
+	port := parsed.Port()
+	if (parsed.Scheme == "https" && port == "443") || (parsed.Scheme == "http" && port == "80") {
+		port = ""
+	}
+	parsed.Host = hostname
+	if strings.Contains(hostname, ":") {
+		parsed.Host = "[" + hostname + "]"
+	}
+	if port != "" {
+		parsed.Host = net.JoinHostPort(hostname, port)
+	}
+	return strings.TrimRight(parsed.String(), "/"), parsed, nil
+}
+
+func canonicalSpritesHostname(hostname string) string {
+	hostname = strings.ToLower(hostname)
+	if ip := net.ParseIP(strings.TrimSuffix(hostname, ".")); ip != nil {
+		return ip.String()
+	}
+	return hostname
+}
+
+func isSpritesLoopbackHost(hostname string) bool {
+	if hostname == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(hostname)
+	return ip != nil && ip.IsLoopback()
+}
+
+func secureSpritesHTTPClient(source *http.Client, origin *url.URL) *http.Client {
+	client := *source
+	checkRedirect := source.CheckRedirect
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if !sameSpritesOrigin(origin, req.URL) {
+			return fmt.Errorf("sprites redirect changed API origin")
+		}
+		if checkRedirect != nil {
+			return checkRedirect(req, via)
+		}
+		if len(via) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+		return nil
+	}
+	return &client
+}
+
+func sameSpritesOrigin(a, b *url.URL) bool {
+	return a != nil && b != nil &&
+		strings.EqualFold(a.Scheme, b.Scheme) &&
+		canonicalSpritesHostname(a.Hostname()) == canonicalSpritesHostname(b.Hostname()) &&
+		effectiveSpritesPort(a) == effectiveSpritesPort(b)
+}
+
+func effectiveSpritesPort(value *url.URL) string {
+	if port := value.Port(); port != "" {
+		return port
+	}
+	if strings.EqualFold(value.Scheme, "https") {
+		return "443"
+	}
+	if strings.EqualFold(value.Scheme, "http") {
+		return "80"
+	}
+	return ""
 }
 
 func (c *spritesClient) CreateSprite(ctx context.Context, name string, labels []string) (spritesInfo, error) {


### PR DESCRIPTION
Closes https://github.com/openclaw/crabbox/issues/762.

## Summary

- Require absolute Sprites API endpoints with HTTPS, allowing HTTP only for literal loopback hosts.
- Reject opaque URLs, userinfo, queries, bare query delimiters, fragments, malformed ports, and loopback lookalikes before any authenticated request.
- Canonicalize scheme, host, default ports, and trailing path separators while preserving custom path prefixes.
- Clone the configured HTTP client and reject redirects that change scheme, hostname, or effective port while preserving same-origin redirects and caller policy.
- Document the endpoint contract and add an Unreleased changelog entry thanking @coygeek.

## Verification

- `go test -race ./internal/providers/sprites`
- `go test ./internal/cli -run 'TestRepositoryCredentialDestinationsRejectInheritedCredentials|TestLoadBackendRejectsRepositoryCredentialDestination' -count=1`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --parallel-tests 'go test -race ./internal/providers/sprites && go test ./internal/cli -run "TestRepositoryCredentialDestinationsRejectInheritedCredentials|TestLoadBackendRejectsRepositoryCredentialDestination" -count=1' --stream-engine-output` — clean, no accepted/actionable findings; final patch correct at 0.86 confidence.

Regression coverage includes canonical HTTPS/path handling, IPv4 and IPv6 loopback development endpoints, invalid component rejection, backend error propagation, cross-origin redirect blocking before the target receives a request, same-origin bearer preservation, default-port equivalence, and caller redirect-policy preservation.

## Behavior proof

- Built exact commit `f1a547dd76f297f9ab29d564e8c18aa678339e6f`; `list` with a test-only token plus `http://api.sprites.dev` failed before networking with the HTTPS policy error and exit 2.
- The existing official Sprites CLI is authenticated against `https://api.sprites.dev`; a read-only production list completed with exit 0. No token was extracted or printed.
- Fresh brokered AWS run `run_638f46045e00` checked out the exact PR head, resolved Go 1.26.4, and passed the focused race and credential-provenance suites.
- Disposable lease `cbx_8ce9001b7d9a` finished in 2m11s and is verified `released` with no cleanup error.

Redacted exact-head transcript:

```console
$ git rev-parse HEAD
f1a547dd76f297f9ab29d564e8c18aa678339e6f
$ CRABBOX_SPRITES_TOKEN='[test-only]' bin/crabbox list --provider sprites --sprites-api-url http://api.sprites.dev
provider=sprites API URL must use HTTPS except for loopback HTTP
$ echo $?
2
$ sprite list >/dev/null
$ echo $?
0
```

Maintainer accepts the intentional fail-closed behavior for unsafe custom endpoints. The changelog entry remains because repository policy requires maintainer-authored coverage for user-facing fixes.
