### PR TITLE
fix: isolate artifact broker namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### Fixed
 
+- Isolated brokered artifact uploads by opaque organization and owner namespaces so identities and caller prefixes cannot collide across authorization scopes. Thanks @coygeek.
 - Pinned the Google Linux package signing fingerprint, preserved its source-scoped APT keyring across Chrome installation, and failed closed to Chromium when verification fails. Thanks @coygeek.
 - Hardened coordinator image deletion so admin `image delete` requests fail closed unless stored Crabbox-created metadata proves ownership of the AWS, Azure, or GCP image or snapshot.
 - Prevented unused WebVNC and Code bridge tickets from surviving manager share revocation. Thanks @coygeek.

--- a/docs/commands/artifacts.md
+++ b/docs/commands/artifacts.md
@@ -249,6 +249,10 @@ signing grants. When `--prefix` is omitted for hosted publishing, the CLI
 derives a unique prefix from the PR number, bundle directory, and current time
 so later QA comments do not overwrite earlier evidence.
 
+The coordinator scopes each new grant under opaque encodings of the exact
+authenticated organization and owner. Caller prefixes cannot cross or replace
+that authorization namespace.
+
 ## Manifest, list, and pull
 
 Every publish writes and publishes an `artifact-manifest.json` by default. The

--- a/docs/features/artifacts.md
+++ b/docs/features/artifacts.md
@@ -182,6 +182,11 @@ per-request aggregate cap before minting upload URLs. When you do not pass
 `--prefix`, hosted publishing adds a unique PR/bundle/timestamp prefix so later
 bundles cannot overwrite links from earlier QA comments.
 
+New brokered grants use a versioned object namespace containing opaque encodings
+of the authenticated organization and owner before the caller prefix. Existing
+object URLs remain unchanged; the coordinator does not dual-write or translate
+legacy keys.
+
 Coordinator artifact variables describe the backend:
 
 - `CRABBOX_ARTIFACTS_BACKEND`: `s3` or `r2`.

--- a/docs/security.md
+++ b/docs/security.md
@@ -260,7 +260,9 @@ repo:
 - `CRABBOX_ARTIFACTS_ACCESS_KEY_ID`, `CRABBOX_ARTIFACTS_SECRET_ACCESS_KEY`,
   and optional `CRABBOX_ARTIFACTS_SESSION_TOKEN` — brokered artifact publishing.
   Scope these to the artifact bucket/prefix and use them only to sign
-  short-lived upload/read URLs.
+  short-lived upload/read URLs. New grants encode the exact authenticated
+  owner/org identity in an opaque versioned namespace; existing object URLs are
+  not rewritten or resolved through a legacy lookup path.
 
 Deployments that previously relied on `CRABBOX_SHARED_TOKEN` as the implicit
 user-token signing key must configure a new `CRABBOX_SESSION_SECRET`. Existing

--- a/worker/src/artifacts.ts
+++ b/worker/src/artifacts.ts
@@ -1,5 +1,6 @@
 import { AwsClient } from "aws4fetch";
 
+import { base64URL } from "./auth";
 import type { Env } from "./types";
 
 export interface ArtifactUploadRequest {
@@ -58,13 +59,14 @@ export async function artifactUploadResponse(
   env: Env,
   request: ArtifactUploadRequest,
   owner: string,
+  org: string,
 ): Promise<ArtifactUploadResponse> {
   const config = artifactConfig(env);
   const files = normalizeArtifactFiles(request.files ?? []);
   if (files.length === 0) {
     throw new Error("artifacts upload request requires at least one file");
   }
-  const prefix = artifactPrefix(config.prefix, owner, request.prefix);
+  const prefix = artifactPrefix(config.prefix, org, owner, request.prefix);
   const now = new Date();
   const uploadExpiresAt = new Date(
     now.getTime() + config.uploadExpiresSeconds * 1000,
@@ -190,15 +192,24 @@ function normalizeHash(value: string | undefined): string {
 
 function artifactPrefix(
   configPrefix: string,
+  org: string,
   owner: string,
   requestPrefix: string | undefined,
 ): string {
   const parts = [
     normalizePrefixPart(configPrefix),
-    normalizePrefixPart(owner),
+    "v2",
+    "org",
+    opaqueArtifactIdentity(org),
+    "owner",
+    opaqueArtifactIdentity(owner),
     normalizePrefixPart(requestPrefix),
   ].filter(Boolean);
   return parts.join("/");
+}
+
+function opaqueArtifactIdentity(value: string): string {
+  return base64URL(new TextEncoder().encode(value));
 }
 
 function normalizePrefixPart(value: string | undefined): string {

--- a/worker/src/artifacts.ts
+++ b/worker/src/artifacts.ts
@@ -35,6 +35,11 @@ export interface ArtifactUploadResponse {
   files: ArtifactUploadGrant[];
 }
 
+export interface ArtifactUploadScope {
+  org: string;
+  owner: string;
+}
+
 interface ArtifactConfig {
   backend: "s3" | "r2";
   bucket: string;
@@ -58,10 +63,11 @@ const maxArtifactBatchBytes = 5 * 1024 * 1024 * 1024;
 export async function artifactUploadResponse(
   env: Env,
   request: ArtifactUploadRequest,
-  owner: string,
-  org: string,
+  scope: ArtifactUploadScope,
 ): Promise<ArtifactUploadResponse> {
   const config = artifactConfig(env);
+  const org = artifactIdentity(scope.org, "organization");
+  const owner = artifactIdentity(scope.owner, "owner");
   const files = normalizeArtifactFiles(request.files ?? []);
   if (files.length === 0) {
     throw new Error("artifacts upload request requires at least one file");
@@ -210,6 +216,13 @@ function artifactPrefix(
 
 function opaqueArtifactIdentity(value: string): string {
   return base64URL(new TextEncoder().encode(value));
+}
+
+function artifactIdentity(value: string, label: string): string {
+  if (!value.trim()) {
+    throw new Error(`artifact upload ${label} identity is required`);
+  }
+  return value;
 }
 
 function normalizePrefixPart(value: string | undefined): string {

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -9393,12 +9393,11 @@ export class FleetCoordinator {
     try {
       const input = await readJson<ArtifactUploadRequest>(request);
       return json(
-        await artifactUploadResponse(
-          this.env,
-          input,
-          requestOwner(request),
-          requestOrg(request, this.env),
-        ),
+        await artifactUploadResponse(this.env, input, {
+          owner: requestOwner(request),
+          // Artifact keys encode auth identity bytes exactly; usage org normalization is lossy.
+          org: request.headers.get("x-crabbox-org") ?? this.env.CRABBOX_DEFAULT_ORG ?? "",
+        }),
         { status: 201 },
       );
     } catch (error) {

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -9392,9 +9392,15 @@ export class FleetCoordinator {
   private async createArtifactUploads(request: Request): Promise<Response> {
     try {
       const input = await readJson<ArtifactUploadRequest>(request);
-      return json(await artifactUploadResponse(this.env, input, requestOwner(request)), {
-        status: 201,
-      });
+      return json(
+        await artifactUploadResponse(
+          this.env,
+          input,
+          requestOwner(request),
+          requestOrg(request, this.env),
+        ),
+        { status: 201 },
+      );
     } catch (error) {
       return json(
         { error: "artifact_upload_unavailable", message: errorMessage(error) },

--- a/worker/test/artifacts.test.ts
+++ b/worker/test/artifacts.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { artifactUploadResponse } from "../src/artifacts";
+import type { Env } from "../src/types";
+
+describe("artifact broker namespaces", () => {
+  it("encodes slash, backslash, and Unicode identity values opaquely", async () => {
+    const org = "org/团队";
+    const owner = "alice\\团队";
+    const response = await artifactUploadResponse(
+      {
+        CRABBOX_ARTIFACTS_BACKEND: "r2",
+        CRABBOX_ARTIFACTS_BUCKET: "qa-artifacts",
+        CRABBOX_ARTIFACTS_PREFIX: "qa",
+        CRABBOX_ARTIFACTS_ENDPOINT_URL: "https://account.r2.cloudflarestorage.com",
+        CRABBOX_ARTIFACTS_ACCESS_KEY_ID: "access-key",
+        CRABBOX_ARTIFACTS_SECRET_ACCESS_KEY: "super-secret",
+      } as Env,
+      { prefix: "proof", files: [{ name: "result.txt", size: 1 }] },
+      owner,
+      org,
+    );
+
+    const expected = `qa/v2/org/${Buffer.from(org).toString("base64url")}/owner/${Buffer.from(owner).toString("base64url")}/proof`;
+    expect(response.prefix).toBe(expected);
+    expect(response.files[0].key).toBe(`${expected}/result.txt`);
+  });
+});

--- a/worker/test/artifacts.test.ts
+++ b/worker/test/artifacts.test.ts
@@ -17,12 +17,51 @@ describe("artifact broker namespaces", () => {
         CRABBOX_ARTIFACTS_SECRET_ACCESS_KEY: "super-secret",
       } as Env,
       { prefix: "proof", files: [{ name: "result.txt", size: 1 }] },
-      owner,
-      org,
+      { org, owner },
     );
 
     const expected = `qa/v2/org/${Buffer.from(org).toString("base64url")}/owner/${Buffer.from(owner).toString("base64url")}/proof`;
     expect(response.prefix).toBe(expected);
     expect(response.files[0].key).toBe(`${expected}/result.txt`);
+  });
+
+  it("preserves distinct UTF-8 identity byte sequences", async () => {
+    const [composed, decomposed] = await Promise.all(
+      ["caf\u00e9", "cafe\u0301"].map(async (org) =>
+        artifactUploadResponse(
+          {
+            CRABBOX_ARTIFACTS_BACKEND: "r2",
+            CRABBOX_ARTIFACTS_BUCKET: "qa-artifacts",
+            CRABBOX_ARTIFACTS_ENDPOINT_URL: "https://account.r2.cloudflarestorage.com",
+            CRABBOX_ARTIFACTS_ACCESS_KEY_ID: "access-key",
+            CRABBOX_ARTIFACTS_SECRET_ACCESS_KEY: "super-secret",
+          } as Env,
+          { files: [{ name: "result.txt", size: 1 }] },
+          { org, owner: "alice" },
+        ),
+      ),
+    );
+    expect(composed.files[0].key).not.toBe(decomposed.files[0].key);
+  });
+
+  it.each([
+    { label: "organization", scope: { org: "", owner: "alice" } },
+    { label: "organization", scope: { org: "  ", owner: "alice" } },
+    { label: "owner", scope: { org: "example-org", owner: "" } },
+    { label: "owner", scope: { org: "example-org", owner: "\t" } },
+  ])("rejects an empty $label identity", async ({ label, scope }) => {
+    await expect(
+      artifactUploadResponse(
+        {
+          CRABBOX_ARTIFACTS_BACKEND: "r2",
+          CRABBOX_ARTIFACTS_BUCKET: "qa-artifacts",
+          CRABBOX_ARTIFACTS_ENDPOINT_URL: "https://account.r2.cloudflarestorage.com",
+          CRABBOX_ARTIFACTS_ACCESS_KEY_ID: "access-key",
+          CRABBOX_ARTIFACTS_SECRET_ACCESS_KEY: "super-secret",
+        } as Env,
+        { files: [{ name: "result.txt", size: 1 }] },
+        scope,
+      ),
+    ).rejects.toThrow(`artifact upload ${label} identity is required`);
   });
 });

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -16917,10 +16917,12 @@ describe("fleet lease identity and idle", () => {
     };
     expect(body.backend).toBe("r2");
     expect(body.bucket).toBe("qa-artifacts");
-    expect(body.prefix).toBe("qa/peter@example.com/pr-42");
-    expect(body.files[0].key).toBe("qa/peter@example.com/pr-42/screenshots/after.png");
+    const org = Buffer.from("default-org").toString("base64url");
+    const owner = Buffer.from("peter@example.com").toString("base64url");
+    expect(body.prefix).toBe(`qa/v2/org/${org}/owner/${owner}/pr-42`);
+    expect(body.files[0].key).toBe(`qa/v2/org/${org}/owner/${owner}/pr-42/screenshots/after.png`);
     expect(body.files[0].url).toBe(
-      "https://artifacts.example.com/qa/peter%40example.com/pr-42/screenshots/after.png",
+      `https://artifacts.example.com/qa/v2/org/${org}/owner/${owner}/pr-42/screenshots/after.png`,
     );
     expect(body.files[0].upload.headers["content-length"]).toBe("123");
     expect(body.files[0].upload.headers["content-type"]).toBe("image/png");
@@ -16929,6 +16931,41 @@ describe("fleet lease identity and idle", () => {
       "content-length",
     );
     expect(JSON.stringify(body)).not.toContain("super-secret");
+  });
+
+  it("isolates artifact grants by opaque organization and owner identities", async () => {
+    const fleet = testFleet(
+      new MemoryStorage(),
+      {},
+      {
+        CRABBOX_ARTIFACTS_BACKEND: "r2",
+        CRABBOX_ARTIFACTS_BUCKET: "qa-artifacts",
+        CRABBOX_ARTIFACTS_PREFIX: "qa",
+        CRABBOX_ARTIFACTS_ENDPOINT_URL: "https://account.r2.cloudflarestorage.com",
+        CRABBOX_ARTIFACTS_ACCESS_KEY_ID: "access-key",
+        CRABBOX_ARTIFACTS_SECRET_ACCESS_KEY: "super-secret",
+      },
+    );
+    const grant = async (org: string, owner: string, prefix: string) => {
+      const response = await fleet.fetch(
+        request("POST", "/v1/artifacts/uploads", {
+          headers: { "x-crabbox-org": org, "x-crabbox-owner": owner },
+          body: { prefix, files: [{ name: "proof.txt", size: 1 }] },
+        }),
+      );
+      expect(response.status).toBe(201);
+      return (await response.json()) as { prefix: string; files: Array<{ key: string }> };
+    };
+
+    const orgA = await grant("org-a", "alice/team", "run-1");
+    const orgB = await grant("org-b", "alice/team", "run-1");
+    const shiftedBoundary = await grant("org-a", "alice", "team/run-1");
+
+    expect(orgA.files[0].key).not.toBe(orgB.files[0].key);
+    expect(orgA.files[0].key).not.toBe(shiftedBoundary.files[0].key);
+    expect(orgA.prefix).toContain(
+      `/org/${Buffer.from("org-a").toString("base64url")}/owner/${Buffer.from("alice/team").toString("base64url")}/`,
+    );
   });
 
   it("reports artifact broker setup errors without provider-specific local credentials", async () => {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -16888,7 +16888,7 @@ describe("fleet lease identity and idle", () => {
 
     const response = await fleet.fetch(
       request("POST", "/v1/artifacts/uploads", {
-        headers: { "x-crabbox-owner": "peter@example.com" },
+        headers: { "x-crabbox-owner": "alice@example.com" },
         body: {
           prefix: "pr-42",
           files: [
@@ -16918,7 +16918,7 @@ describe("fleet lease identity and idle", () => {
     expect(body.backend).toBe("r2");
     expect(body.bucket).toBe("qa-artifacts");
     const org = Buffer.from("default-org").toString("base64url");
-    const owner = Buffer.from("peter@example.com").toString("base64url");
+    const owner = Buffer.from("alice@example.com").toString("base64url");
     expect(body.prefix).toBe(`qa/v2/org/${org}/owner/${owner}/pr-42`);
     expect(body.files[0].key).toBe(`qa/v2/org/${org}/owner/${owner}/pr-42/screenshots/after.png`);
     expect(body.files[0].url).toBe(

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -16954,18 +16954,66 @@ describe("fleet lease identity and idle", () => {
         }),
       );
       expect(response.status).toBe(201);
-      return (await response.json()) as { prefix: string; files: Array<{ key: string }> };
+      return (await response.json()) as {
+        prefix: string;
+        files: Array<{ key: string; url: string; upload: { url: string } }>;
+      };
     };
 
     const orgA = await grant("org-a", "alice/team", "run-1");
     const orgB = await grant("org-b", "alice/team", "run-1");
     const shiftedBoundary = await grant("org-a", "alice", "team/run-1");
 
-    expect(orgA.files[0].key).not.toBe(orgB.files[0].key);
-    expect(orgA.files[0].key).not.toBe(shiftedBoundary.files[0].key);
+    const slashOrg = await grant("org/team", "alice", "run-1");
+    const backslashOrg = await grant("org\\team", "alice", "run-1");
+
+    for (const [left, right] of [
+      [orgA, orgB],
+      [orgA, shiftedBoundary],
+      [slashOrg, backslashOrg],
+    ]) {
+      expect(left.prefix).not.toBe(right.prefix);
+      expect(left.files[0].key).not.toBe(right.files[0].key);
+      expect(new URL(left.files[0].url).pathname).not.toBe(new URL(right.files[0].url).pathname);
+      expect(new URL(left.files[0].upload.url).pathname).not.toBe(
+        new URL(right.files[0].upload.url).pathname,
+      );
+    }
     expect(orgA.prefix).toContain(
       `/org/${Buffer.from("org-a").toString("base64url")}/owner/${Buffer.from("alice/team").toString("base64url")}/`,
     );
+  });
+
+  it("rejects empty artifact authorization identities", async () => {
+    const fleet = testFleet(
+      new MemoryStorage(),
+      {},
+      {
+        CRABBOX_DEFAULT_ORG: "",
+        CRABBOX_ARTIFACTS_BACKEND: "r2",
+        CRABBOX_ARTIFACTS_BUCKET: "qa-artifacts",
+        CRABBOX_ARTIFACTS_ENDPOINT_URL: "https://account.r2.cloudflarestorage.com",
+        CRABBOX_ARTIFACTS_ACCESS_KEY_ID: "access-key",
+        CRABBOX_ARTIFACTS_SECRET_ACCESS_KEY: "super-secret",
+      },
+    );
+    const grant = async (headers: Record<string, string>) => {
+      const response = await fleet.fetch(
+        request("POST", "/v1/artifacts/uploads", {
+          headers,
+          body: { files: [{ name: "proof.txt", size: 1 }] },
+        }),
+      );
+      expect(response.status).toBe(400);
+      return (await response.json()) as { message: string };
+    };
+
+    await expect(grant({ "x-crabbox-owner": "alice", "x-crabbox-org": "" })).resolves.toMatchObject(
+      { message: "artifact upload organization identity is required" },
+    );
+    await expect(
+      grant({ "x-crabbox-owner": "", "x-crabbox-org": "example-org" }),
+    ).resolves.toMatchObject({ message: "artifact upload owner identity is required" });
   });
 
   it("reports artifact broker setup errors without provider-specific local credentials", async () => {


### PR DESCRIPTION
Closes https://github.com/openclaw/crabbox/issues/702.

## Summary

- Namespace new brokered artifact grants by authenticated organization and owner.
- Encode both identities as base64url UTF-8 under an explicit `v2/org/.../owner/...` key contract, preventing cross-org and owner/prefix boundary collisions.
- Preserve existing objects and URLs: this changes only newly signed upload grants and needs no legacy lookup or dual-write path.
- Preserve exact authenticated identity bytes before opaque encoding; cover cross-org,
  slash-boundary, backslash, Unicode, and composed/decomposed Unicode identities.
- Add an Unreleased changelog entry thanking @coygeek.

## Verification

- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker -- artifacts.test.ts fleet.test.ts` — 307 tests passed.
- `npm run build --prefix worker` — Wrangler dry-run passed.
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --parallel-tests 'npm test --prefix worker -- artifacts.test.ts fleet.test.ts && npm run check --prefix worker' --stream-engine-output` — clean, no accepted/actionable findings; final patch correct at 0.88 confidence.

The route-level integration proof shows identical owner/prefix/name tuples produce different keys across orgs, and an owner containing a path separator cannot collide with the same separator moved into the caller prefix.

## Fresh-checkout remote proof

- Exact PR head `89572cbe5b8f93003385b541cc68a0ddf417d2c7` was checked out on a fresh brokered AWS `c7a.8xlarge` lease after merging current `main`.
- Run `run_45dc16dc41c5` installed Node.js 22.22.1/npm 9.2.0 and passed both focused files: 2 files, 307 tests.
- Lease `cbx_df7bf89adf79` finished in 1m13s and is verified `released` with no cleanup error.
