### PR TITLE
fix: validate ASCII Box API endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### Fixed
 
+- Prevented ASCII Box API credentials from reaching unsafe explicit base URLs by requiring HTTPS except for loopback development endpoints, rejecting ambiguous URL components, and supporting config discovery in the current Box CLI. Thanks @coygeek.
 - Pinned the Google Linux package signing fingerprint, preserved its source-scoped APT keyring across Chrome installation, and failed closed to Chromium when verification fails. Thanks @coygeek.
 - Hardened coordinator image deletion so admin `image delete` requests fail closed unless stored Crabbox-created metadata proves ownership of the AWS, Azure, or GCP image or snapshot.
 - Prevented unused WebVNC and Code bridge tickets from surviving manager share revocation. Thanks @coygeek.

--- a/docs/providers/ascii-box.md
+++ b/docs/providers/ascii-box.md
@@ -23,9 +23,9 @@ of exposing SSH.
 
 - Create an ASCII Box account at <https://box.ascii.dev>.
 - Export the API key as `ASCII_BOX_API_KEY` or `CRABBOX_ASCII_BOX_API_KEY`.
-- Install the official `box` CLI. Crabbox writes a private Box CLI config from
-  the API key under its state directory and does not require a pre-existing
-  `box login`.
+- Install the official `box` CLI. Crabbox discovers the platform-specific config
+  path through `box status --json`, writes a private config from the API key
+  under its state directory, and does not require a pre-existing `box login`.
 
 ## Commands
 
@@ -44,7 +44,9 @@ export ASCII_BOX_API_KEY=...
 ```
 
 `CRABBOX_ASCII_BOX_BASE_URL` or `asciiBox.baseUrl` can override the default
-`https://ascii.dev`.
+`https://ascii.dev`. Custom endpoints require HTTPS, except literal loopback
+hosts may use HTTP. Userinfo, queries, and fragments are rejected before the
+API key is written to Box CLI configuration or passed to the CLI.
 
 ## Config
 

--- a/internal/providers/asciibox/backend_test.go
+++ b/internal/providers/asciibox/backend_test.go
@@ -70,17 +70,17 @@ func TestClientUsesOfficialAsciiBoxCLI(t *testing.T) {
 		t.Fatal(err)
 	}
 	want := []string{
-		"box --no-update --json config",
+		"box --no-update --json --api-url https://ascii.dev status",
 		"box --no-update --json --api-url https://ascii.dev new --ttl 1800",
-		"box --no-update --json config",
+		"box --no-update --json --api-url https://ascii.dev status",
 		"box --no-update --json --api-url https://ascii.dev ssh bx_1 -- true",
-		"box --no-update --json config",
+		"box --no-update --json --api-url https://ascii.dev status",
 		"box --no-update --json --api-url https://ascii.dev info bx_1",
-		"box --no-update --json config",
+		"box --no-update --json --api-url https://ascii.dev status",
 		"box --no-update --json --api-url https://ascii.dev list",
-		"box --no-update --json config",
+		"box --no-update --json --api-url https://ascii.dev status",
 		"box --no-update --json --api-url https://ascii.dev stop bx_1",
-		"box --no-update --json config",
+		"box --no-update --json --api-url https://ascii.dev status",
 		"box --no-update --json --api-url https://ascii.dev delete bx_1",
 	}
 	if !reflect.DeepEqual(runner.commands, want) {
@@ -99,6 +99,86 @@ func TestClientUsesOfficialAsciiBoxCLI(t *testing.T) {
 	}
 	if !hasEnv(runner.env[3], "SSH_AUTH_SOCK=") {
 		t.Fatalf("ssh setup env should disable agent identities: %v", runner.env[3])
+	}
+}
+
+func TestAsciiBoxBaseURLValidation(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "canonical https", raw: "HTTPS://ASCII.DEV:443/", want: "https://ascii.dev"},
+		{name: "https path", raw: "https://ascii.dev/api/", want: "https://ascii.dev/api"},
+		{name: "escaped path", raw: "https://ascii.dev/tenant%2F/", want: "https://ascii.dev/tenant%2F"},
+		{name: "localhost", raw: "http://localhost:8080/", want: "http://localhost:8080"},
+		{name: "ipv4 loopback", raw: "http://127.0.0.2:8080/api", want: "http://127.0.0.2:8080/api"},
+		{name: "ipv6 loopback", raw: "http://[::1]:80/", want: "http://[::1]"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := validateAsciiBoxBaseURL(test.raw)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != test.want {
+				t.Fatalf("url=%q want %q", got, test.want)
+			}
+		})
+	}
+
+	for _, test := range []struct {
+		name string
+		raw  string
+	}{
+		{name: "public http", raw: "http://ascii.dev"},
+		{name: "relative", raw: "/api"},
+		{name: "schemeless", raw: "ascii.dev"},
+		{name: "missing host", raw: "https:///api"},
+		{name: "opaque", raw: "https:ascii.dev"},
+		{name: "other scheme", raw: "ftp://ascii.dev"},
+		{name: "userinfo", raw: "https://token@ascii.dev"},
+		{name: "query", raw: "https://ascii.dev?token=1"},
+		{name: "bare query", raw: "https://ascii.dev?"},
+		{name: "fragment", raw: "https://ascii.dev#fragment"},
+		{name: "malformed port", raw: "https://ascii.dev:bad"},
+		{name: "loopback lookalike", raw: "http://localhost.example.com"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := validateAsciiBoxBaseURL(test.raw); err == nil {
+				t.Fatalf("expected %q to be rejected", test.raw)
+			}
+		})
+	}
+}
+
+func TestNewAPIRejectsUnsafeBaseURLBeforeCommandOrConfigWrite(t *testing.T) {
+	home := t.TempDir()
+	configPath := filepath.Join(home, "config.json")
+	runner := &fakeCommandRunner{configPath: configPath}
+	cfg := testConfig()
+	cfg.AsciiBox.BaseURL = "http://ascii.dev"
+
+	client, err := newAPI(cfg, Runtime{Exec: runner})
+	if err == nil || client != nil || !strings.Contains(err.Error(), "must use HTTPS") {
+		t.Fatalf("client=%#v err=%v", client, err)
+	}
+	if len(runner.commands) != 0 {
+		t.Fatalf("commands=%v", runner.commands)
+	}
+	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+		t.Fatalf("config path exists or returned unexpected error: %v", err)
+	}
+}
+
+func TestNewAPICanonicalizesBaseURL(t *testing.T) {
+	cfg := testConfig()
+	cfg.AsciiBox.BaseURL = " HTTPS://ASCII.DEV:443/api/ "
+	got, err := newAPI(cfg, Runtime{Exec: &fakeCommandRunner{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.(*client).apiURL != "https://ascii.dev/api" {
+		t.Fatalf("apiURL=%q", got.(*client).apiURL)
 	}
 }
 
@@ -510,8 +590,8 @@ func (r *fakeCommandRunner) Run(_ context.Context, req LocalCommandRequest) (Loc
 	r.env = append(r.env, req.Env)
 	joined := strings.Join(req.Args, " ")
 	switch {
-	case strings.Contains(joined, " config"):
-		return LocalCommandResult{Stdout: fmt.Sprintf(`{"loggedIn":false,"path":%q}`, r.configPath)}, nil
+	case strings.Contains(joined, " status"):
+		return LocalCommandResult{Stdout: fmt.Sprintf(`{"account":null,"api":{},"config":{"path":%q}}`, r.configPath)}, nil
 	case strings.Contains(joined, " new "):
 		if r.newStdout != "" || r.newErr != nil {
 			return LocalCommandResult{Stdout: r.newStdout}, r.newErr

--- a/internal/providers/asciibox/client.go
+++ b/internal/providers/asciibox/client.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -58,6 +60,10 @@ var newAPI = func(cfg Config, rt Runtime) (api, error) {
 	if apiKey == "" {
 		return nil, exit(2, "provider=%s requires ASCII_BOX_API_KEY", providerName)
 	}
+	apiURL, err := validateAsciiBoxBaseURL(blank(strings.TrimSpace(cfg.AsciiBox.BaseURL), "https://ascii.dev"))
+	if err != nil {
+		return nil, err
+	}
 	if rt.Exec == nil {
 		return nil, exit(2, "provider=%s requires a local command runner", providerName)
 	}
@@ -65,8 +71,56 @@ var newAPI = func(cfg Config, rt Runtime) (api, error) {
 	if cliPath == "" {
 		cliPath = "box"
 	}
-	apiURL := strings.TrimRight(blank(strings.TrimSpace(cfg.AsciiBox.BaseURL), "https://ascii.dev"), "/")
 	return &client{apiKey: apiKey, apiURL: apiURL, cliPath: cliPath, home: asciiBoxCLIHome(), runner: rt.Exec}, nil
+}
+
+func validateAsciiBoxBaseURL(raw string) (string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || !parsed.IsAbs() || parsed.Host == "" || parsed.Hostname() == "" || parsed.Opaque != "" {
+		return "", exit(2, "provider=%s API base URL must be an absolute HTTP(S) URL", providerName)
+	}
+	if parsed.User != nil {
+		return "", exit(2, "provider=%s API base URL must not contain userinfo", providerName)
+	}
+	if parsed.RawQuery != "" || parsed.ForceQuery {
+		return "", exit(2, "provider=%s API base URL must not contain a query", providerName)
+	}
+	if parsed.Fragment != "" {
+		return "", exit(2, "provider=%s API base URL must not contain a fragment", providerName)
+	}
+	parsed.Scheme = strings.ToLower(parsed.Scheme)
+	hostname := canonicalAsciiBoxHostname(parsed.Hostname())
+	if parsed.Scheme != "https" && (parsed.Scheme != "http" || !isAsciiBoxLoopbackHost(hostname)) {
+		return "", exit(2, "provider=%s API base URL must use HTTPS except for loopback HTTP", providerName)
+	}
+	port := parsed.Port()
+	if (parsed.Scheme == "https" && port == "443") || (parsed.Scheme == "http" && port == "80") {
+		port = ""
+	}
+	parsed.Host = hostname
+	if strings.Contains(hostname, ":") {
+		parsed.Host = "[" + hostname + "]"
+	}
+	if port != "" {
+		parsed.Host = net.JoinHostPort(hostname, port)
+	}
+	return strings.TrimRight(parsed.String(), "/"), nil
+}
+
+func canonicalAsciiBoxHostname(hostname string) string {
+	hostname = strings.ToLower(hostname)
+	if ip := net.ParseIP(strings.TrimSuffix(hostname, ".")); ip != nil {
+		return ip.String()
+	}
+	return hostname
+}
+
+func isAsciiBoxLoopbackHost(hostname string) bool {
+	if hostname == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(hostname)
+	return ip != nil && ip.IsLoopback()
 }
 
 func (c *client) CreateBox(ctx context.Context, req createRequest) (boxData, error) {
@@ -194,21 +248,23 @@ func (c *client) ensureConfig(ctx context.Context) error {
 	}
 	result, err := c.runner.Run(ctx, LocalCommandRequest{
 		Name: c.cliPath,
-		Args: []string{"--no-update", "--json", "config"},
+		Args: []string{"--no-update", "--json", "--api-url", c.apiURL, "status"},
 		Env:  c.env(),
 	})
 	if err != nil {
-		return fmt.Errorf("ascii-box CLI config failed: %s", c.formatError(result, err))
+		return fmt.Errorf("ascii-box CLI status failed: %s", c.formatError(result, err))
 	}
 	var cfg struct {
-		Path string `json:"path"`
+		Config struct {
+			Path string `json:"path"`
+		} `json:"config"`
 	}
 	if err := json.Unmarshal([]byte(result.Stdout), &cfg); err != nil {
-		return fmt.Errorf("decode ascii-box CLI config: %w", err)
+		return fmt.Errorf("decode ascii-box CLI status: %w", err)
 	}
-	configPath := strings.TrimSpace(cfg.Path)
+	configPath := strings.TrimSpace(cfg.Config.Path)
 	if configPath == "" {
-		return fmt.Errorf("ascii-box CLI config response missing path")
+		return fmt.Errorf("ascii-box CLI status response missing config path")
 	}
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
 		return err

--- a/internal/providers/asciibox/flags.go
+++ b/internal/providers/asciibox/flags.go
@@ -12,7 +12,7 @@ type flagValues struct {
 
 func RegisterAsciiBoxProviderFlags(fs *flag.FlagSet, defaults Config) any {
 	return flagValues{
-		BaseURL: fs.String("ascii-box-base-url", defaults.AsciiBox.BaseURL, "ASCII Box API base URL"),
+		BaseURL: fs.String("ascii-box-base-url", defaults.AsciiBox.BaseURL, "trusted ASCII Box API base URL"),
 		CLIPath: fs.String("ascii-box-cli", defaults.AsciiBox.CLIPath, "ASCII Box CLI path"),
 		Workdir: fs.String("ascii-box-workdir", defaults.AsciiBox.Workdir, "absolute working directory inside the ASCII Box"),
 	}


### PR DESCRIPTION
## Summary

- validate and canonicalize the explicit ASCII Box API base URL before any CLI invocation or config write
- require HTTPS except for literal loopback development endpoints; reject userinfo, queries, fragments, opaque, relative, and malformed URLs
- discover the platform-specific config path through the current official `box status --json` surface
- document the trust boundary and credit @coygeek

Closes https://github.com/openclaw/crabbox/issues/763

## Verification

- `go test -race ./...`
- `go vet ./...`
- `node scripts/build-docs-site.mjs`
- exact-binary unsafe endpoint proof: exit 2 before a CLI call or config write
- official Box CLI `0.1.114-ascii-prod1`: isolated production doctor and list succeeded
- disposable production sandbox reached the remote shell and emitted the expected marker; final provider inventory is zero
- autoreview: no accepted or actionable findings

The live canary also exposed an existing service snapshot guard on immediate stop/delete. The sandbox was deleted through TTL-expiry recovery and inventory was rechecked at zero; release recovery is intentionally being handled as a separate narrow follow-up.
