### PR TITLE
fix: recover ASCII Box snapshot-guarded release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### Fixed
 
+- Recovered ASCII Box release when the service temporarily requires a recent snapshot by shortening the sandbox TTL, waiting for the managed stop transition, and retrying deletion.
 - Prevented ASCII Box API credentials from reaching unsafe explicit base URLs by requiring HTTPS except for loopback development endpoints, rejecting ambiguous URL components, and supporting config discovery in the current Box CLI. Thanks @coygeek.
 - Pinned the Google Linux package signing fingerprint, preserved its source-scoped APT keyring across Chrome installation, and failed closed to Chromium when verification fails. Thanks @coygeek.
 - Hardened coordinator image deletion so admin `image delete` requests fail closed unless stored Crabbox-created metadata proves ownership of the AWS, Azure, or GCP image or snapshot.

--- a/docs/providers/ascii-box.md
+++ b/docs/providers/ascii-box.md
@@ -89,7 +89,10 @@ CRABBOX_ASCII_BOX_WORKDIR
 3. `crabbox status` resolves the local lease claim or raw Box id and reads Box
    state through `box info --json`.
 4. `crabbox stop` releases the Box with `box stop --json`, removes the Box
-   record with `box delete --json`, and removes the local lease claim.
+   record with `box delete --json`, and removes the local lease claim. If the
+   service temporarily refuses deletion until a recent snapshot exists,
+   Crabbox shortens the Box TTL, waits for its managed stop transition, and
+   retries deletion for up to two minutes.
 
 ## Limitations
 

--- a/internal/providers/asciibox/backend_test.go
+++ b/internal/providers/asciibox/backend_test.go
@@ -80,7 +80,6 @@ func TestClientUsesOfficialAsciiBoxCLI(t *testing.T) {
 		"box --no-update --json --api-url https://ascii.dev list",
 		"box --no-update --json --api-url https://ascii.dev status",
 		"box --no-update --json --api-url https://ascii.dev stop bx_1",
-		"box --no-update --json --api-url https://ascii.dev status",
 		"box --no-update --json --api-url https://ascii.dev delete bx_1",
 	}
 	if !reflect.DeepEqual(runner.commands, want) {
@@ -99,6 +98,106 @@ func TestClientUsesOfficialAsciiBoxCLI(t *testing.T) {
 	}
 	if !hasEnv(runner.env[3], "SSH_AUTH_SOCK=") {
 		t.Fatalf("ssh setup env should disable agent identities: %v", runner.env[3])
+	}
+}
+
+func TestReleaseBoxRecoversFromRecentSnapshotGuard(t *testing.T) {
+	runner := &releaseCommandRunner{
+		configPath: filepath.Join(t.TempDir(), "config.json"),
+		outcomes: map[string][]commandOutcome{
+			"stop":   {snapshotGuardOutcome()},
+			"delete": {snapshotGuardOutcome(), {result: LocalCommandResult{Stdout: `{"id":"bx_guard","status":"deleted"}`}}},
+			"extend": {{result: LocalCommandResult{Stdout: `{"id":"bx_guard","archiveAfter":"soon"}`}}},
+			"info": {
+				{result: LocalCommandResult{Stdout: `{"box":{"id":"bx_guard","state":"idle"}}`}},
+				{result: LocalCommandResult{Stdout: `{"box":{"id":"bx_guard","state":"idle","status":"stopping"}}`}},
+			},
+		},
+	}
+	client := &client{
+		apiKey:              "box_key",
+		apiURL:              "https://ascii.dev",
+		cliPath:             "box",
+		home:                t.TempDir(),
+		runner:              runner,
+		releasePollInterval: time.Nanosecond,
+	}
+
+	if err := client.ReleaseBox(context.Background(), "bx_guard"); err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		"box --no-update --json --api-url https://ascii.dev status",
+		"box --no-update --json --api-url https://ascii.dev stop bx_guard",
+		"box --no-update --json --api-url https://ascii.dev delete bx_guard",
+		"box --no-update --json --api-url https://ascii.dev extend bx_guard --ttl 1",
+		"box --no-update --json --api-url https://ascii.dev info bx_guard",
+		"box --no-update --json --api-url https://ascii.dev info bx_guard",
+		"box --no-update --json --api-url https://ascii.dev delete bx_guard",
+	}
+	if !reflect.DeepEqual(runner.commands, want) {
+		t.Fatalf("commands=%v want=%v", runner.commands, want)
+	}
+}
+
+func TestReleaseBoxDoesNotRecoverUnrelatedDeleteFailure(t *testing.T) {
+	runner := &releaseCommandRunner{
+		configPath: filepath.Join(t.TempDir(), "config.json"),
+		outcomes: map[string][]commandOutcome{
+			"stop":   {{result: LocalCommandResult{}}},
+			"delete": {{result: LocalCommandResult{Stderr: "permission denied"}, err: fmt.Errorf("exit status 1")}},
+		},
+	}
+	client := &client{apiKey: "box_key", apiURL: "https://ascii.dev", cliPath: "box", home: t.TempDir(), runner: runner}
+
+	err := client.ReleaseBox(context.Background(), "bx_guard")
+	if err == nil || !strings.Contains(err.Error(), "permission denied") {
+		t.Fatalf("ReleaseBox err=%v", err)
+	}
+	if containsCommand(runner.commands, "box --no-update --json --api-url https://ascii.dev extend bx_guard --ttl 1") {
+		t.Fatalf("unexpected snapshot recovery commands=%v", runner.commands)
+	}
+}
+
+func TestReleaseBoxReportsSnapshotRecoveryExtendFailure(t *testing.T) {
+	runner := &releaseCommandRunner{
+		configPath: filepath.Join(t.TempDir(), "config.json"),
+		outcomes: map[string][]commandOutcome{
+			"stop":   {snapshotGuardOutcome()},
+			"delete": {snapshotGuardOutcome()},
+			"extend": {{result: LocalCommandResult{Stderr: "extend throttled"}, err: fmt.Errorf("exit status 1")}},
+		},
+	}
+	client := &client{apiKey: "box_key", apiURL: "https://ascii.dev", cliPath: "box", home: t.TempDir(), runner: runner}
+
+	err := client.ReleaseBox(context.Background(), "bx_guard")
+	if err == nil || !strings.Contains(err.Error(), "snapshot recovery extend: extend throttled") {
+		t.Fatalf("ReleaseBox err=%v", err)
+	}
+}
+
+func TestReleaseBoxSkipsSnapshotRecoveryAfterCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	runner := &releaseCommandRunner{
+		configPath: filepath.Join(t.TempDir(), "config.json"),
+		outcomes: map[string][]commandOutcome{
+			"stop":   {snapshotGuardOutcome()},
+			"delete": {snapshotGuardOutcome()},
+		},
+		onAction: func(action string) {
+			if action == "delete" {
+				cancel()
+			}
+		},
+	}
+	client := &client{apiKey: "box_key", apiURL: "https://ascii.dev", cliPath: "box", home: t.TempDir(), runner: runner}
+
+	err := client.ReleaseBox(ctx, "bx_guard")
+	if err == nil || !strings.Contains(err.Error(), "snapshot recovery: context canceled") {
+		t.Fatalf("ReleaseBox err=%v", err)
+	}
+	if containsCommand(runner.commands, "box --no-update --json --api-url https://ascii.dev extend bx_guard --ttl 1") {
+		t.Fatalf("unexpected snapshot recovery commands=%v", runner.commands)
 	}
 }
 
@@ -583,6 +682,53 @@ type fakeCommandRunner struct {
 	newErr     error
 
 	infoResponses []string
+}
+
+type commandOutcome struct {
+	result LocalCommandResult
+	err    error
+}
+
+type releaseCommandRunner struct {
+	commands   []string
+	configPath string
+	outcomes   map[string][]commandOutcome
+	onAction   func(string)
+}
+
+func (r *releaseCommandRunner) Run(_ context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+	r.commands = append(r.commands, strings.Join(append([]string{req.Name}, req.Args...), " "))
+	action := boxCLIAction(req.Args)
+	if action == "status" {
+		return LocalCommandResult{Stdout: fmt.Sprintf(`{"account":null,"api":{},"config":{"path":%q}}`, r.configPath)}, nil
+	}
+	queue := r.outcomes[action]
+	if len(queue) == 0 {
+		return LocalCommandResult{Stderr: "unexpected command"}, fmt.Errorf("unexpected %s command", action)
+	}
+	outcome := queue[0]
+	r.outcomes[action] = queue[1:]
+	if r.onAction != nil {
+		r.onAction(action)
+	}
+	return outcome.result, outcome.err
+}
+
+func boxCLIAction(args []string) string {
+	for _, arg := range args {
+		switch arg {
+		case "status", "stop", "delete", "extend", "info":
+			return arg
+		}
+	}
+	return ""
+}
+
+func snapshotGuardOutcome() commandOutcome {
+	return commandOutcome{
+		result: LocalCommandResult{Stdout: `{"code":"snapshot_required","error":"Refusing request: no successful snapshot in the last 30 minutes.","status":409}`},
+		err:    fmt.Errorf("exit status 1"),
+	}
 }
 
 func (r *fakeCommandRunner) Run(_ context.Context, req LocalCommandRequest) (LocalCommandResult, error) {

--- a/internal/providers/asciibox/client.go
+++ b/internal/providers/asciibox/client.go
@@ -25,11 +25,12 @@ type api interface {
 }
 
 type client struct {
-	apiKey  string
-	apiURL  string
-	cliPath string
-	home    string
-	runner  CommandRunner
+	apiKey              string
+	apiURL              string
+	cliPath             string
+	home                string
+	runner              CommandRunner
+	releasePollInterval time.Duration
 }
 
 type createRequest struct {
@@ -190,15 +191,143 @@ func (c *client) ListBoxes(ctx context.Context) ([]boxData, error) {
 }
 
 func (c *client) ReleaseBox(ctx context.Context, id string) error {
-	stopResult, stopErr := c.run(ctx, "stop", id)
-	deleteResult, deleteErr := c.run(ctx, "delete", id)
-	if deleteErr != nil {
-		if stopErr != nil {
-			return fmt.Errorf("ascii-box CLI release failed: stop: %s; delete: %s", c.formatError(stopResult, stopErr), c.formatError(deleteResult, deleteErr))
+	if err := c.ensureConfig(ctx); err != nil {
+		return fmt.Errorf("prepare ascii-box CLI release: %w", err)
+	}
+	stopResult, stopErr := c.runPrepared(ctx, "stop", id)
+	deleteResult, deleteErr := c.runPrepared(ctx, "delete", id)
+	if deleteErr == nil {
+		return nil
+	}
+	if !c.snapshotGuardConflict(deleteResult, deleteErr) {
+		return c.releaseError(stopResult, stopErr, deleteResult, deleteErr, "")
+	}
+	return c.releaseAfterSnapshotGuard(ctx, id, stopResult, stopErr, deleteResult, deleteErr)
+}
+
+func (c *client) releaseAfterSnapshotGuard(
+	ctx context.Context,
+	id string,
+	stopResult LocalCommandResult,
+	stopErr error,
+	deleteResult LocalCommandResult,
+	deleteErr error,
+) error {
+	if err := ctx.Err(); err != nil {
+		return c.releaseError(
+			stopResult,
+			stopErr,
+			deleteResult,
+			deleteErr,
+			"snapshot recovery: "+err.Error(),
+		)
+	}
+	recoveryCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+
+	extendResult, extendErr := c.runPrepared(recoveryCtx, "extend", id, "--ttl", "1")
+	if extendErr != nil {
+		return c.releaseError(
+			stopResult,
+			stopErr,
+			deleteResult,
+			deleteErr,
+			"snapshot recovery extend: "+c.formatError(extendResult, extendErr),
+		)
+	}
+
+	pollInterval := c.releasePollInterval
+	if pollInterval <= 0 {
+		pollInterval = 2 * time.Second
+	}
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-recoveryCtx.Done():
+			return c.releaseError(
+				stopResult,
+				stopErr,
+				deleteResult,
+				deleteErr,
+				"snapshot recovery: "+recoveryCtx.Err().Error(),
+			)
+		case <-ticker.C:
+			infoResult, infoErr := c.runPrepared(recoveryCtx, "info", id)
+			if infoErr != nil {
+				return c.releaseError(
+					stopResult,
+					stopErr,
+					deleteResult,
+					deleteErr,
+					"snapshot recovery info: "+c.formatError(infoResult, infoErr),
+				)
+			}
+			box, err := decodeBox([]byte(infoResult.Stdout))
+			if err != nil {
+				return c.releaseError(
+					stopResult,
+					stopErr,
+					deleteResult,
+					deleteErr,
+					"snapshot recovery info: "+err.Error(),
+				)
+			}
+			if !boxReadyForDelete(box) {
+				continue
+			}
+			retryResult, retryErr := c.runPrepared(recoveryCtx, "delete", id)
+			if retryErr == nil {
+				return nil
+			}
+			if c.snapshotGuardConflict(retryResult, retryErr) {
+				continue
+			}
+			return c.releaseError(
+				stopResult,
+				stopErr,
+				deleteResult,
+				deleteErr,
+				"snapshot recovery delete: "+c.formatError(retryResult, retryErr),
+			)
 		}
+	}
+}
+
+func boxReadyForDelete(box boxData) bool {
+	switch boxState(box) {
+	case "stopping", "stopped", "terminated", "deleted", "archived":
+		return true
+	default:
+		return false
+	}
+}
+
+func (c *client) snapshotGuardConflict(result LocalCommandResult, err error) bool {
+	message := strings.ToLower(c.formatError(result, err))
+	return strings.Contains(message, "no successful snapshot") &&
+		strings.Contains(message, "last 30 minutes")
+}
+
+func (c *client) releaseError(
+	stopResult LocalCommandResult,
+	stopErr error,
+	deleteResult LocalCommandResult,
+	deleteErr error,
+	recovery string,
+) error {
+	if stopErr == nil && recovery == "" {
 		return fmt.Errorf("ascii-box CLI delete failed: %s", c.formatError(deleteResult, deleteErr))
 	}
-	return nil
+	parts := make([]string, 0, 3)
+	if stopErr != nil {
+		parts = append(parts, "stop: "+c.formatError(stopResult, stopErr))
+	}
+	parts = append(parts, "delete: "+c.formatError(deleteResult, deleteErr))
+	if recovery != "" {
+		parts = append(parts, recovery)
+	}
+	return fmt.Errorf("ascii-box CLI release failed: %s", strings.Join(parts, "; "))
 }
 
 func (c *client) run(ctx context.Context, args ...string) (LocalCommandResult, error) {
@@ -209,6 +338,14 @@ func (c *client) runWithEnv(ctx context.Context, env []string, args ...string) (
 	if err := c.ensureConfig(ctx); err != nil {
 		return LocalCommandResult{}, err
 	}
+	return c.runPreparedWithEnv(ctx, env, args...)
+}
+
+func (c *client) runPrepared(ctx context.Context, args ...string) (LocalCommandResult, error) {
+	return c.runPreparedWithEnv(ctx, c.env(), args...)
+}
+
+func (c *client) runPreparedWithEnv(ctx context.Context, env []string, args ...string) (LocalCommandResult, error) {
 	if _, ok := ctx.Deadline(); !ok {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, cliTimeout(args))
@@ -233,7 +370,7 @@ func cliTimeout(args []string) time.Duration {
 	switch args[0] {
 	case "new":
 		return 5 * time.Minute
-	case "ssh", "delete", "stop":
+	case "ssh", "delete", "stop", "extend":
 		return 2 * time.Minute
 	default:
 		return 30 * time.Second


### PR DESCRIPTION
## Summary

- preserve the normal ASCII Box `stop` then `delete` release path
- recover only the service's exact recent-snapshot guard by shortening TTL to one second, polling the managed state for up to two minutes, and retrying deletion
- prepare Box CLI configuration once for the release sequence and retain redacted stage diagnostics on recovery failure
- add success, unrelated-error, extend-failure, cancellation, and status-precedence regression coverage
- document the bounded recovery behavior and add an Unreleased changelog entry

## Verification

Current exact head: `d470f3c5b996c13c3b842f7e4e30c173f170d309`.

- `go test -race ./...`
- `go vet ./...`
- `node scripts/build-docs-site.mjs`
- `git diff --check`
- focused post-main-sync `go test -race ./internal/providers/asciibox`
- autoreview — clean, no accepted/actionable findings; patch correct at 0.83 confidence
- the only main-sync conflict was the Unreleased changelog list; both user-facing entries were retained

## Production canary

Functional commit `6c31c95014c5d19a70206912e8dfc3f31ea471ef`, an ancestor of the current exact head, was built and run with the current official Box CLI against the production ASCII Box endpoint:

- initial provider inventory: zero Boxes
- disposable sandbox remote command: expected marker emitted
- immediate stop/delete reproduced the service snapshot guard
- Crabbox shortened TTL, observed the managed transition, and retried deletion automatically
- run exit: 0
- manual cleanup path: not used
- final provider inventory: zero Boxes
