### PR TITLE
fix: pin Windows developer tool artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 ### Fixed
 
 - Pinned the Windows developer-image Node MSI and Docker Engine archive to reviewed SHA-256 digests before privileged installation, with fail-closed digest requirements for version overrides. Thanks @coygeek.
-- Restored direct AWS developer-image candidate capture by routing the guarded mint wrapper through native checkpoints while retaining brokered promotion.
+- Restored direct and brokered AWS Windows developer-image candidate capture by routing the guarded mint wrapper through native AMI checkpoints while retaining brokered promotion.
 - Prevented direct AWS raw-instance release from reaching deletion unless canonical Crabbox ownership tags match the resolved lease, with a second guard at the destructive provider boundary. Thanks @TurboTheTurtle.
 - Prevented Sprites API credentials from targeting unsafe endpoint URLs or following redirects outside the configured API origin. Thanks @coygeek.
 - Recovered ASCII Box release when the service temporarily requires a recent snapshot by shortening the sandbox TTL, waiting for the managed stop transition, and retrying deletion.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### Fixed
 
+- Pinned the Windows developer-image Node MSI and Docker Engine archive to reviewed SHA-256 digests before privileged installation, with fail-closed digest requirements for version overrides. Thanks @coygeek.
 - Prevented direct AWS raw-instance release from reaching deletion unless canonical Crabbox ownership tags match the resolved lease, with a second guard at the destructive provider boundary. Thanks @TurboTheTurtle.
 - Prevented Sprites API credentials from targeting unsafe endpoint URLs or following redirects outside the configured API origin. Thanks @coygeek.
 - Recovered ASCII Box release when the service temporarily requires a recent snapshot by shortening the sandbox TTL, waiting for the managed stop transition, and retrying deletion.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 ### Fixed
 
 - Pinned the Windows developer-image Node MSI and Docker Engine archive to reviewed SHA-256 digests before privileged installation, with fail-closed digest requirements for version overrides. Thanks @coygeek.
+- Restored direct AWS developer-image candidate capture by routing the guarded mint wrapper through native checkpoints while retaining brokered promotion.
 - Prevented direct AWS raw-instance release from reaching deletion unless canonical Crabbox ownership tags match the resolved lease, with a second guard at the destructive provider boundary. Thanks @TurboTheTurtle.
 - Prevented Sprites API credentials from targeting unsafe endpoint URLs or following redirects outside the configured API origin. Thanks @coygeek.
 - Recovered ASCII Box release when the service temporarily requires a recent snapshot by shortening the sandbox TTL, waiting for the managed stop transition, and retrying deletion.

--- a/docs/features/image-bake-runbook.md
+++ b/docs/features/image-bake-runbook.md
@@ -288,6 +288,11 @@ scripts/mint-aws-devtools-image.sh \
   --run
 ```
 
+The wrapper captures its candidate through `crabbox checkpoint create`, so the
+same source/candidate proof works with direct AWS credentials and with an
+admin-authenticated broker. Promotion updates broker-managed image defaults;
+use `--no-promote` when validating a direct-only AWS configuration.
+
 Enable FSR for hot lanes that need lower first-boot variance, in the AZs you
 actually launch from:
 

--- a/docs/features/image-bake-runbook.md
+++ b/docs/features/image-bake-runbook.md
@@ -315,7 +315,9 @@ scripts/mint-aws-devtools-image.sh \
   tooling, GitHub CLI, Node 24, corepack/pnpm, and Windows Server container
   support with Docker Engine. It deliberately avoids Docker Desktop because
   headless image bakes should not depend on a user-session desktop app or
-  Docker Desktop licensing.
+  Docker Desktop licensing. The Chocolatey package, Node MSI, and Docker Engine
+  archive are pinned to reviewed SHA-256 digests and verified before privileged
+  installation or extraction.
 
 Windows developer bakes are headless by default for faster boot and fewer
 desktop-bootstrap moving parts. Pass `--desktop` only when the image must back
@@ -330,10 +332,18 @@ capture.
 ```bash
 CRABBOX_LINUX_DOCKER_IMAGES='hello-world ubuntu:24.04 node:24-bookworm'
 CRABBOX_WINDOWS_DOCKER_IMAGES='mcr.microsoft.com/windows/servercore:ltsc2022'
+CRABBOX_WINDOWS_NODE_VERSION='<version>'
+CRABBOX_WINDOWS_NODE_SHA256='<reviewed-64-hex-sha256>'
+CRABBOX_WINDOWS_DOCKER_VERSION='<version>'
+CRABBOX_WINDOWS_DOCKER_SHA256='<reviewed-64-hex-sha256>'
 CRABBOX_LINUX_BROWSER=0
 CRABBOX_LINUX_DESKTOP_TOOLS=0
 CRABBOX_WINDOWS_INSTALL_DOCKER=0
 ```
+
+The bundled Node and Docker versions use embedded reviewed digests. Override a
+version only together with its matching SHA-256 value; unpaired or malformed
+overrides fail before the artifact is downloaded.
 
 ### Wrapper behavior
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -295,13 +295,20 @@ and may fail for historical tags that are incompatible with the current
 reviewed release configuration rather than falling back to tag-controlled
 publishing behavior.
 
-## Managed Windows Bootstrap Integrity
+## Managed Windows Artifact Integrity
 
 Managed Windows bootstrap pins the OpenSSH-Win64 archive, Git for Windows
 installer, TightVNC installer, and versioned Ubuntu WSL rootfs to SHA-256
 digests embedded alongside their URLs. Generated PowerShell verifies every
 download before extraction, execution, or WSL import, removes mismatched bytes,
 and fails bootstrap closed. URL and digest updates are reviewed together.
+
+The documented Windows developer-image prep applies the same rule to its
+versioned Chocolatey package, Node MSI, and Docker Engine archive. The bundled
+versions use embedded reviewed digests. Operator-selected Node or Docker
+versions require matching SHA-256 environment overrides, and missing, malformed,
+or mismatched values fail closed before installation, extraction, or service
+registration.
 
 ## Managed Linux Browser Trust
 

--- a/internal/cli/checkpoint_native.go
+++ b/internal/cli/checkpoint_native.go
@@ -84,8 +84,10 @@ func (coordinatorCheckpointDriver) Create(ctx context.Context, req checkpointNat
 	if err != nil {
 		return CoordinatorImage{}, err
 	}
-	if err := prepareNativeImageSource(ctx, req.Target); err != nil {
-		return CoordinatorImage{}, err
+	if !isWindowsNativeTarget(req.Target) {
+		if err := prepareNativeImageSource(ctx, req.Target); err != nil {
+			return CoordinatorImage{}, err
+		}
 	}
 	image, err := coord.CreateImage(ctx, req.LeaseID, name, req.NoReboot, strategy)
 	if err != nil {

--- a/internal/cli/checkpoint_test.go
+++ b/internal/cli/checkpoint_test.go
@@ -734,6 +734,9 @@ func TestCheckpointCreateModeSupportsAWSWindowsAMI(t *testing.T) {
 			if got := checkpointCreateMode("native", checkpointStrategyImage, cfg, server, target, false); got != checkpointKindAWSAMI {
 				t.Fatalf("native image mode=%q, want %q", got, checkpointKindAWSAMI)
 			}
+			if got := checkpointCreateMode("native", checkpointStrategyAuto, cfg, server, target, false); got != checkpointKindAWSAMI {
+				t.Fatalf("native automatic mode=%q, want %q", got, checkpointKindAWSAMI)
+			}
 			if got := checkpointCreateMode("snapshot", checkpointStrategyDiskSnapshot, cfg, server, target, false); got != "unsupported" {
 				t.Fatalf("disk snapshot mode=%q, want unsupported", got)
 			}

--- a/internal/cli/checkpoint_test.go
+++ b/internal/cli/checkpoint_test.go
@@ -720,6 +720,27 @@ func TestCheckpointCreateModeNativeSupportsDirectAWSAMI(t *testing.T) {
 	}
 }
 
+func TestCheckpointCreateModeSupportsAWSWindowsAMI(t *testing.T) {
+	server := Server{Provider: "aws", CloudID: "i-123"}
+	target := SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeNormal}
+	for _, coordinator := range []string{"", "https://coordinator.example"} {
+		t.Run(map[bool]string{true: "direct", false: "brokered"}[coordinator == ""], func(t *testing.T) {
+			cfg := defaultConfig()
+			cfg.Provider = "aws"
+			cfg.Coordinator = coordinator
+			cfg.TargetOS = targetWindows
+			cfg.WindowsMode = windowsModeNormal
+
+			if got := checkpointCreateMode("native", checkpointStrategyImage, cfg, server, target, false); got != checkpointKindAWSAMI {
+				t.Fatalf("native image mode=%q, want %q", got, checkpointKindAWSAMI)
+			}
+			if got := checkpointCreateMode("snapshot", checkpointStrategyDiskSnapshot, cfg, server, target, false); got != "unsupported" {
+				t.Fatalf("disk snapshot mode=%q, want unsupported", got)
+			}
+		})
+	}
+}
+
 func TestCheckpointCreateModeParallelsRejectsImageStrategy(t *testing.T) {
 	cfg := defaultConfig()
 	cfg.Provider = "parallels"

--- a/internal/cli/providers_builtin_test.go
+++ b/internal/cli/providers_builtin_test.go
@@ -607,7 +607,7 @@ func (testAWSProvider) NativeCheckpointCapability(req NativeCheckpointRequest) (
 	targetOS := firstNonBlank(req.Target.TargetOS, req.Config.TargetOS)
 	strategy := normalizeCheckpointStrategy(req.Strategy)
 	if isWindowsNativeTarget(req.Target) {
-		if strategy != checkpointStrategyImage {
+		if req.StrategyExplicit && strategy != checkpointStrategyImage {
 			return NativeCheckpointCapability{}, false
 		}
 		return NativeCheckpointCapability{

--- a/internal/cli/providers_builtin_test.go
+++ b/internal/cli/providers_builtin_test.go
@@ -601,14 +601,23 @@ func (p testAWSProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
 	return testSSHBackend{spec: p.Spec()}, nil
 }
 func (testAWSProvider) NativeCheckpointCapability(req NativeCheckpointRequest) (NativeCheckpointCapability, bool) {
-	if req.Server.CloudID == "" || isWindowsNativeTarget(req.Target) {
+	if req.Server.CloudID == "" {
 		return NativeCheckpointCapability{}, false
 	}
 	targetOS := firstNonBlank(req.Target.TargetOS, req.Config.TargetOS)
+	strategy := normalizeCheckpointStrategy(req.Strategy)
+	if isWindowsNativeTarget(req.Target) {
+		if strategy != checkpointStrategyImage {
+			return NativeCheckpointCapability{}, false
+		}
+		return NativeCheckpointCapability{
+			Kind:   checkpointKindAWSAMI,
+			Direct: req.Config.Coordinator == "",
+		}, true
+	}
 	if targetOS != targetLinux && targetOS != targetMacOS {
 		return NativeCheckpointCapability{}, false
 	}
-	strategy := normalizeCheckpointStrategy(req.Strategy)
 	if req.Config.Coordinator == "" {
 		if targetOS != targetMacOS && strategy != checkpointStrategyImage {
 			return NativeCheckpointCapability{}, false

--- a/internal/providers/aws/provider.go
+++ b/internal/providers/aws/provider.go
@@ -59,14 +59,23 @@ func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.Doctor
 }
 
 func (Provider) NativeCheckpointCapability(req core.NativeCheckpointRequest) (core.NativeCheckpointCapability, bool) {
-	if req.Server.CloudID == "" || isWindowsNativeTarget(req) {
+	if req.Server.CloudID == "" {
 		return core.NativeCheckpointCapability{}, false
 	}
 	targetOS := firstNonBlank(req.Target.TargetOS, req.Config.TargetOS)
+	strategy := core.NormalizeCheckpointStrategy(req.Strategy)
+	if isWindowsNativeTarget(req) {
+		if strategy != core.CheckpointStrategyImage {
+			return core.NativeCheckpointCapability{}, false
+		}
+		return core.NativeCheckpointCapability{
+			Kind:   core.CheckpointKindAWSAMI,
+			Direct: req.Config.Coordinator == "",
+		}, true
+	}
 	if targetOS != core.TargetLinux && targetOS != core.TargetMacOS {
 		return core.NativeCheckpointCapability{}, false
 	}
-	strategy := core.NormalizeCheckpointStrategy(req.Strategy)
 	if req.Config.Coordinator == "" {
 		if targetOS != core.TargetMacOS && strategy != core.CheckpointStrategyImage {
 			return core.NativeCheckpointCapability{}, false

--- a/internal/providers/aws/provider.go
+++ b/internal/providers/aws/provider.go
@@ -65,7 +65,7 @@ func (Provider) NativeCheckpointCapability(req core.NativeCheckpointRequest) (co
 	targetOS := firstNonBlank(req.Target.TargetOS, req.Config.TargetOS)
 	strategy := core.NormalizeCheckpointStrategy(req.Strategy)
 	if isWindowsNativeTarget(req) {
-		if strategy != core.CheckpointStrategyImage {
+		if req.StrategyExplicit && strategy != core.CheckpointStrategyImage {
 			return core.NativeCheckpointCapability{}, false
 		}
 		return core.NativeCheckpointCapability{

--- a/internal/providers/aws/provider_test.go
+++ b/internal/providers/aws/provider_test.go
@@ -1,0 +1,31 @@
+package aws
+
+import (
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestNativeCheckpointCapabilitySupportsWindowsImages(t *testing.T) {
+	req := core.NativeCheckpointRequest{
+		Server:   core.Server{CloudID: "i-123"},
+		Target:   core.SSHTarget{TargetOS: core.TargetWindows, WindowsMode: core.WindowsModeNormal},
+		Strategy: core.CheckpointStrategyImage,
+	}
+
+	direct, ok := (Provider{}).NativeCheckpointCapability(req)
+	if !ok || direct.Kind != core.CheckpointKindAWSAMI || !direct.Direct {
+		t.Fatalf("direct capability=%#v ok=%v, want direct AWS AMI", direct, ok)
+	}
+
+	req.Config.Coordinator = "https://coordinator.example"
+	brokered, ok := (Provider{}).NativeCheckpointCapability(req)
+	if !ok || brokered.Kind != core.CheckpointKindAWSAMI || brokered.Direct {
+		t.Fatalf("brokered capability=%#v ok=%v, want brokered AWS AMI", brokered, ok)
+	}
+
+	req.Strategy = core.CheckpointStrategyDiskSnapshot
+	if capability, ok := (Provider{}).NativeCheckpointCapability(req); ok {
+		t.Fatalf("disk snapshot capability=%#v, want unsupported", capability)
+	}
+}

--- a/internal/providers/aws/provider_test.go
+++ b/internal/providers/aws/provider_test.go
@@ -8,9 +8,10 @@ import (
 
 func TestNativeCheckpointCapabilitySupportsWindowsImages(t *testing.T) {
 	req := core.NativeCheckpointRequest{
-		Server:   core.Server{CloudID: "i-123"},
-		Target:   core.SSHTarget{TargetOS: core.TargetWindows, WindowsMode: core.WindowsModeNormal},
-		Strategy: core.CheckpointStrategyImage,
+		Server:           core.Server{CloudID: "i-123"},
+		Target:           core.SSHTarget{TargetOS: core.TargetWindows, WindowsMode: core.WindowsModeNormal},
+		Strategy:         core.CheckpointStrategyImage,
+		StrategyExplicit: true,
 	}
 
 	direct, ok := (Provider{}).NativeCheckpointCapability(req)
@@ -27,5 +28,11 @@ func TestNativeCheckpointCapabilitySupportsWindowsImages(t *testing.T) {
 	req.Strategy = core.CheckpointStrategyDiskSnapshot
 	if capability, ok := (Provider{}).NativeCheckpointCapability(req); ok {
 		t.Fatalf("disk snapshot capability=%#v, want unsupported", capability)
+	}
+
+	req.StrategyExplicit = false
+	automatic, ok := (Provider{}).NativeCheckpointCapability(req)
+	if !ok || automatic.Kind != core.CheckpointKindAWSAMI || automatic.Direct {
+		t.Fatalf("automatic capability=%#v ok=%v, want brokered AWS AMI", automatic, ok)
 	}
 }

--- a/scripts/install-windows-developer-tools.ps1
+++ b/scripts/install-windows-developer-tools.ps1
@@ -2,16 +2,42 @@ $ErrorActionPreference = "Stop"
 $ProgressPreference = "SilentlyContinue"
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
+$DefaultNodeVersion = "24.11.1"
+$DefaultNodeSHA256 = "208ba5ca1dab0b330f457909e0797de340c40b34ddf2edf40d26f382f733297e"
 $NodeVersion = $env:CRABBOX_WINDOWS_NODE_VERSION
-if (-not $NodeVersion) { $NodeVersion = "24.11.1" }
+if (-not $NodeVersion) { $NodeVersion = $DefaultNodeVersion }
+$NodeSHA256 = $env:CRABBOX_WINDOWS_NODE_SHA256
+if (-not $NodeSHA256) {
+  if ($NodeVersion -ne $DefaultNodeVersion) {
+    throw "CRABBOX_WINDOWS_NODE_SHA256 is required when CRABBOX_WINDOWS_NODE_VERSION overrides $DefaultNodeVersion"
+  }
+  $NodeSHA256 = $DefaultNodeSHA256
+}
+if ($NodeSHA256 -notmatch "^[0-9a-fA-F]{64}$") {
+  throw "CRABBOX_WINDOWS_NODE_SHA256 must be a 64-character hex digest"
+}
 $PnpmVersion = $env:CRABBOX_WINDOWS_PNPM_VERSION
 if (-not $PnpmVersion) { $PnpmVersion = "11.1.0" }
-$DockerVersion = $env:CRABBOX_WINDOWS_DOCKER_VERSION
-if (-not $DockerVersion) { $DockerVersion = "29.5.1" }
-$DockerImages = $env:CRABBOX_WINDOWS_DOCKER_IMAGES
-if (-not $DockerImages) { $DockerImages = "mcr.microsoft.com/windows/servercore:ltsc2022" }
 $InstallDocker = $env:CRABBOX_WINDOWS_INSTALL_DOCKER
 if (-not $InstallDocker) { $InstallDocker = "1" }
+$DefaultDockerVersion = "29.5.1"
+$DefaultDockerSHA256 = "7008d54da30461fa745d4539beb87d3d14dd38c7ab0110657720526e16f5f2d3"
+$DockerVersion = $env:CRABBOX_WINDOWS_DOCKER_VERSION
+if (-not $DockerVersion) { $DockerVersion = $DefaultDockerVersion }
+$DockerSHA256 = $env:CRABBOX_WINDOWS_DOCKER_SHA256
+if ($InstallDocker -eq "1") {
+  if (-not $DockerSHA256) {
+    if ($DockerVersion -ne $DefaultDockerVersion) {
+      throw "CRABBOX_WINDOWS_DOCKER_SHA256 is required when CRABBOX_WINDOWS_DOCKER_VERSION overrides $DefaultDockerVersion"
+    }
+    $DockerSHA256 = $DefaultDockerSHA256
+  }
+  if ($DockerSHA256 -notmatch "^[0-9a-fA-F]{64}$") {
+    throw "CRABBOX_WINDOWS_DOCKER_SHA256 must be a 64-character hex digest"
+  }
+}
+$DockerImages = $env:CRABBOX_WINDOWS_DOCKER_IMAGES
+if (-not $DockerImages) { $DockerImages = "mcr.microsoft.com/windows/servercore:ltsc2022" }
 $RebootMarker = "C:\ProgramData\crabbox\image-prep-reboot-required"
 $ChocolateyPackageURL = $env:CRABBOX_WINDOWS_CHOCO_PACKAGE_URL
 if (-not $ChocolateyPackageURL) { $ChocolateyPackageURL = "https://community.chocolatey.org/api/v2/package/chocolatey/2.7.3" }
@@ -134,11 +160,19 @@ function Install-Node {
     if ($current -eq $NodeVersion) { return }
   }
   $arch = "x64"
-  $msi = Join-Path $env:TEMP "node-v$NodeVersion-$arch.msi"
+  $workDir = Join-Path $env:TEMP ("crabbox-node-" + [Guid]::NewGuid().ToString("N"))
+  $msi = Join-Path $workDir "node-v$NodeVersion-$arch.msi"
   $url = "https://nodejs.org/dist/v$NodeVersion/node-v$NodeVersion-$arch.msi"
   Write-Log "installing Node $NodeVersion"
-  Retry { Invoke-WebRequest -Uri $url -OutFile $msi -UseBasicParsing }
-  Start-Process -FilePath "msiexec.exe" -ArgumentList "/i", $msi, "/qn", "/norestart" -Wait
+  try {
+    New-Item -ItemType Directory -Force -Path $workDir | Out-Null
+    Retry { Invoke-WebRequest -Uri $url -OutFile $msi -UseBasicParsing }
+    Assert-FileSHA256 -Path $msi -Expected $NodeSHA256 -Name "Node MSI"
+    Write-Log "verified Node $NodeVersion $arch MSI SHA256 $($NodeSHA256.ToLowerInvariant())"
+    Start-Process -FilePath "msiexec.exe" -ArgumentList "/i", $msi, "/qn", "/norestart" -Wait
+  } finally {
+    Remove-Item -Recurse -Force -LiteralPath $workDir -ErrorAction SilentlyContinue
+  }
   Add-MachinePath "C:\Program Files\nodejs"
 }
 
@@ -152,16 +186,26 @@ function Install-StaticDockerEngine {
   $dockerBin = Join-Path $env:ProgramFiles "docker"
   $dockerd = Join-Path $dockerBin "dockerd.exe"
   $dockerExe = Join-Path $dockerBin "docker.exe"
-  if (-not (Test-Path $dockerd) -or -not (Test-Path $dockerExe)) {
-    $zip = Join-Path $env:TEMP "docker-$DockerVersion.zip"
+  $dockerService = Get-Service -Name docker -ErrorAction SilentlyContinue
+  # A service-less directory is not installation proof; refresh it from the verified archive before registration.
+  if (-not (Test-Path $dockerd) -or -not (Test-Path $dockerExe) -or -not $dockerService) {
+    $workDir = Join-Path $env:TEMP ("crabbox-docker-" + [Guid]::NewGuid().ToString("N"))
+    $zip = Join-Path $workDir "docker-$DockerVersion.zip"
     $url = "https://download.docker.com/win/static/stable/x86_64/docker-$DockerVersion.zip"
     Write-Log "installing Docker Engine $DockerVersion"
-    Retry { Invoke-WebRequest -Uri $url -OutFile $zip -UseBasicParsing }
-    Expand-Archive -Path $zip -DestinationPath $env:ProgramFiles -Force
+    try {
+      New-Item -ItemType Directory -Force -Path $workDir | Out-Null
+      Retry { Invoke-WebRequest -Uri $url -OutFile $zip -UseBasicParsing }
+      Assert-FileSHA256 -Path $zip -Expected $DockerSHA256 -Name "Docker Engine archive"
+      Write-Log "verified Docker Engine $DockerVersion x86_64 archive SHA256 $($DockerSHA256.ToLowerInvariant())"
+      Expand-Archive -LiteralPath $zip -DestinationPath $env:ProgramFiles -Force
+    } finally {
+      Remove-Item -Recurse -Force -LiteralPath $workDir -ErrorAction SilentlyContinue
+    }
   }
   Add-MachinePath $dockerBin
   Refresh-SessionPath
-  if (-not (Get-Service -Name docker -ErrorAction SilentlyContinue)) {
+  if (-not $dockerService) {
     & $dockerd --register-service
   }
 }

--- a/scripts/install-windows-developer-tools.test.js
+++ b/scripts/install-windows-developer-tools.test.js
@@ -26,3 +26,50 @@ test("Windows developer tools prep verifies a versioned Chocolatey package befor
   assert.ok(extract > verify, "package extraction must follow checksum verification");
   assert.ok(execute > extract, "package installation must follow extraction");
 });
+
+test("Windows developer tools prep verifies the Node MSI before installation", () => {
+  assert.match(script, /CRABBOX_WINDOWS_NODE_SHA256/);
+  assert.match(script, /208ba5ca1dab0b330f457909e0797de340c40b34ddf2edf40d26f382f733297e/);
+  assert.match(
+    script,
+    /CRABBOX_WINDOWS_NODE_SHA256 is required when CRABBOX_WINDOWS_NODE_VERSION overrides \$DefaultNodeVersion/,
+  );
+
+  const start = script.indexOf("function Install-Node");
+  const end = script.indexOf("function Enable-CorepackPnpm");
+  const installNode = script.slice(start, end);
+  const download = installNode.indexOf("Invoke-WebRequest -Uri $url -OutFile $msi");
+  const verify = installNode.indexOf('Assert-FileSHA256 -Path $msi -Expected $NodeSHA256 -Name "Node MSI"');
+  const install = installNode.indexOf('Start-Process -FilePath "msiexec.exe"');
+  const cleanup = installNode.indexOf("Remove-Item -Recurse -Force -LiteralPath $workDir");
+  assert.ok(download >= 0, "Node MSI download must be present");
+  assert.ok(verify > download, "Node MSI verification must follow the download");
+  assert.ok(install > verify, "Node MSI installation must follow verification");
+  assert.ok(cleanup > install, "Node MSI cleanup must follow installation");
+});
+
+test("Windows developer tools prep verifies the Docker archive before extraction and service registration", () => {
+  assert.match(script, /CRABBOX_WINDOWS_DOCKER_SHA256/);
+  assert.match(script, /7008d54da30461fa745d4539beb87d3d14dd38c7ab0110657720526e16f5f2d3/);
+  assert.match(
+    script,
+    /CRABBOX_WINDOWS_DOCKER_SHA256 is required when CRABBOX_WINDOWS_DOCKER_VERSION overrides \$DefaultDockerVersion/,
+  );
+
+  const start = script.indexOf("function Install-StaticDockerEngine");
+  const end = script.indexOf("function Install-DockerEngine");
+  const installDocker = script.slice(start, end);
+  assert.match(installDocker, /-not \$dockerService\) \{/);
+  const download = installDocker.indexOf("Invoke-WebRequest -Uri $url -OutFile $zip");
+  const verify = installDocker.indexOf(
+    'Assert-FileSHA256 -Path $zip -Expected $DockerSHA256 -Name "Docker Engine archive"',
+  );
+  const extract = installDocker.indexOf("Expand-Archive -LiteralPath $zip");
+  const cleanup = installDocker.indexOf("Remove-Item -Recurse -Force -LiteralPath $workDir");
+  const register = installDocker.indexOf("& $dockerd --register-service");
+  assert.ok(download >= 0, "Docker archive download must be present");
+  assert.ok(verify > download, "Docker archive verification must follow the download");
+  assert.ok(extract > verify, "Docker archive extraction must follow verification");
+  assert.ok(cleanup > extract, "Docker archive cleanup must follow extraction");
+  assert.ok(register > cleanup, "Docker service registration must follow verified extraction");
+});

--- a/scripts/mint-aws-devtools-image.sh
+++ b/scripts/mint-aws-devtools-image.sh
@@ -619,11 +619,15 @@ run_prep "$source_lease"
 reboot_windows_source_if_needed "$source_lease"
 smoke "$source_lease"
 
-image_json="$("$CRABBOX_BIN" image create --id "$source_lease" --name "$image_name" --no-reboot=false --wait --wait-timeout "$wait_timeout" --json)"
-printf '%s\n' "$image_json" | jq .
-ami_id="$(printf '%s\n' "$image_json" | jq -r '.id // .image.id // empty')"
+image_env=()
+[[ -n "$region" ]] && image_env+=(CRABBOX_AWS_REGION="$region" AWS_REGION="$region")
+image_output="$(env "${image_env[@]}" "$CRABBOX_BIN" checkpoint create \
+  --provider aws --target "$target" --id "$source_lease" --name "$image_name" \
+  --mode native --strategy image --no-reboot=false --wait --wait-timeout "$wait_timeout")"
+printf '%s\n' "$image_output"
+ami_id="$(printf '%s\n' "$image_output" | sed -nE 's/.* resource=(ami-[^[:space:]]+).*/\1/p' | tail -n 1)"
 if [[ -z "$ami_id" ]]; then
-  printf 'image create did not return an AMI id\n' >&2
+  printf 'checkpoint create did not return an AMI id\n' >&2
   exit 1
 fi
 

--- a/scripts/mint-aws-devtools-image.test.js
+++ b/scripts/mint-aws-devtools-image.test.js
@@ -75,10 +75,13 @@ case "$1" in
     fi
     printf 'devtools-smoke-ok\\n'
     ;;
-  image)
+  checkpoint)
     if [[ "$2" == "create" ]]; then
-      printf '{"id":"ami-devtools"}\\n'
-    elif [[ "$2" == "promote" ]]; then
+      printf 'checkpoint created id=chk_devtools kind=aws-ami resource=ami-devtools state=available region=us-west-2 workdir=-\\n'
+    fi
+    ;;
+  image)
+    if [[ "$2" == "promote" ]]; then
       printf '{"image":{"id":"ami-devtools"}}\\n'
     fi
     ;;
@@ -164,7 +167,8 @@ test("AWS devtools mint wrapper runs linux source candidate and promoted proof",
   assert.doesNotMatch(log, /warmup .*--region us-west-2/);
   assert.match(log, /run --provider aws --target linux --id cbx_source --no-sync --script/);
   assert.match(log, /docker image inspect hello-world ubuntu:24\.04 node:24-bookworm/);
-  assert.match(log, /image create --id cbx_source --name crabbox-linux-devtools-/);
+  assert.match(log, /env CRABBOX_AWS_REGION=us-west-2 AWS_REGION=us-west-2 CRABBOX_AWS_AMI= args checkpoint create --provider aws --target linux --id cbx_source --name crabbox-linux-devtools-/);
+  assert.match(log, /--mode native --strategy image --no-reboot=false --wait --wait-timeout 60m/);
   assert.match(log, /image promote --target linux --json --region us-west-2 --fast-snapshot-restore --fsr-az us-west-2a ami-devtools/);
 });
 
@@ -376,7 +380,7 @@ test("AWS devtools mint wrapper retries windows prep upload disconnects", async 
   assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- Write-Output "windows-ssh-ready"/);
   assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- if \(Test-Path/);
   assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- shutdown \/r \/t 5 \/f/);
-  assert.match(log, /image create --id cbx_source --name crabbox-windows-devtools-/);
+  assert.match(log, /checkpoint create --provider aws --target windows --id cbx_source --name crabbox-windows-devtools-/);
 });
 
 test("AWS devtools mint wrapper cleans up lease when warmup fails after allocation", async () => {


### PR DESCRIPTION
Closes https://github.com/openclaw/crabbox/issues/686.

## Summary

- Pin the default Windows developer-image Node 24.11.1 MSI and Docker Engine 29.5.1 archive to reviewed SHA-256 digests.
- Require every non-default Node or Docker version override to provide a valid matching digest before any download.
- Verify Node before `msiexec` and Docker before extraction or service registration.
- Use unique temporary directories with unconditional cleanup, and refresh service-less Docker directories only from the verified archive.
- Support image-only native AMI checkpoints for direct and brokered AWS Windows leases so the guarded wrapper can prove the captured candidate; keep Windows disk snapshots unsupported.
- Document the version/digest pairing contract and add an Unreleased changelog entry thanking @coygeek.

## Verification

Exact head: `df692f5d6381ce0cff2cc842add841251c5b0b6c`.

- `node --test scripts/install-windows-developer-tools.test.js` — 3/3 passed.
- `node --test scripts/*.test.js` — 347/347 passed.
- `go test ./internal/providers/aws ./internal/cli -count=1` — passed.
- `go vet ./...` — passed.
- `node --test scripts/mint-aws-devtools-image.test.js` — 8/8 passed.
- `scripts/check-docs.sh` — 51 command docs, 68-provider matrix, 201 Markdown files, and docs build passed.
- `git diff --check` — clean.
- Autoreview after both checkpoint-routing repairs — clean, no accepted/actionable findings; latest correctness 0.86.
- Official Node checksum manifest and streamed MSI both matched `208ba5ca1dab0b330f457909e0797de340c40b34ddf2edf40d26f382f733297e`.
- The official Docker archive stream matched `7008d54da30461fa745d4539beb87d3d14dd38c7ab0110657720526e16f5f2d3`; Docker publishes no checksum sidecar for this archive.

## Live proof

Disposable AWS Windows proof passed at parent `98ace1f645eb02022c74239538ca37c202a7ec68` with binary SHA-256 `2b322691ba9b5ec4598028057974b8758447dbdc6f86a6ce2807db2d1718fad1`. The only later change makes implicit brokered Windows native strategy select the same live-proven AMI path; exact-head provider/CLI tests and autoreview cover that routing change.

- Verified Node 24.11.1 MSI SHA-256 before install.
- Completed the planned Windows Containers reboot and SSH recovery.
- Verified Docker Engine 29.5.1 archive SHA-256 before extraction, then proved Docker client/server and the pulled Windows Server Core base image.
- Captured an image through the repaired native AWS Windows AMI checkpoint path.
- Booted the captured candidate AMI and repeated the full Node/Docker smoke successfully.
- Deleted the source and candidate leases plus the disposable AMI/snapshot; final audit: `images=0 instances=0 keys=0`.
