### PR TITLE
fix(azure): harden snapshot fork quarantine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 
 ### Fixed
 
+- Hardened Azure Windows snapshot forks to fail closed through credential rehydration and quarantine cleanup, reuse only writable NIC payloads, reject unknown differential disks, and retry in-use security-group cleanup. Thanks @fcoury-oai.
 - Bound GitHub browser-login owners to verified email addresses, recorded that provenance in a versioned user-token schema, and invalidated legacy tokens that could retain unverified owner identities. Thanks @coygeek.
 - Required exact local claims before Freestyle or Islo delete, pause, resume, and SSH reuse operations, while preserving explicit `--reclaim` adoption and read-only canonical-name recovery. Thanks @coygeek.
 - Required a valid isolated per-lease origin before serving browser Code HTTP or WebSocket traffic, preventing lease-controlled pages from inheriting coordinator portal authority. Thanks @coygeek.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Prevented direct Azure list, stop, and cleanup paths from treating weak `crabbox=true` tags as ownership; destructive operations now require canonical Azure ownership tags and an exact matching lease ID, and successful deletion removes local lease keys. Thanks @coygeek.
 - Restricted brokered Azure image and OS-disk selectors to admin-authenticated requests while preserving user-selectable Azure placement. Thanks @coygeek.
 - Required exact resource-bound local lease claims before Apple Container, local-container, or Apple VZ stop operations can delete provider resources; legacy unbound claims require explicit `--reclaim` adoption before stop. Thanks @coygeek.
+- Hardened Azure Windows snapshot forks to fail closed through credential rehydration and quarantine cleanup, reuse only writable NIC payloads, reject unknown differential disks, and retry in-use security-group cleanup. Thanks @fcoury-oai.
 
 ## 0.34.0 - 2026-07-02
 
@@ -39,7 +40,6 @@
 
 ### Fixed
 
-- Hardened Azure Windows snapshot forks to fail closed through credential rehydration and quarantine cleanup, reuse only writable NIC payloads, reject unknown differential disks, and retry in-use security-group cleanup. Thanks @fcoury-oai.
 - Bound GitHub browser-login owners to verified email addresses, recorded that provenance in a versioned user-token schema, and invalidated legacy tokens that could retain unverified owner identities. Thanks @coygeek.
 - Required exact local claims before Freestyle or Islo delete, pause, resume, and SSH reuse operations, while preserving explicit `--reclaim` adoption and read-only canonical-name recovery. Thanks @coygeek.
 - Required a valid isolated per-lease origin before serving browser Code HTTP or WebSocket traffic, preventing lease-controlled pages from inheriting coordinator portal authority. Thanks @coygeek.

--- a/internal/cli/azure.go
+++ b/internal/cli/azure.go
@@ -28,23 +28,24 @@ import (
 )
 
 const (
-	azureAddressSpace             = "10.42.0.0/16"
-	azureSubnetCIDR               = "10.42.0.0/24"
-	azureProviderTag              = "crabbox"
-	AzureOSDiskAuto               = "auto"
-	AzureOSDiskEphemeral          = "ephemeral"
-	AzureOSDiskEphemeralPreview   = "ephemeral-preview"
-	AzureOSDiskManaged            = "managed"
-	azureComputePreviewAPIVersion = "2025-04-01"
-	defaultAzureLinuxImage        = "Canonical:ubuntu-26_04-lts:server:latest"
-	defaultAzureLinuxARM64Image   = "Canonical:ubuntu-26_04-lts:server-arm64:latest"
-	azureNobleLinuxImage          = "Canonical:ubuntu-24_04-lts:server:latest"
-	azureNobleLinuxARM64Image     = "Canonical:ubuntu-24_04-lts:server-arm64:latest"
-	legacyAzureJammyImage         = "Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest"
-	legacyAzureNobleGen2Image     = "Canonical:0001-com-ubuntu-server-noble:24_04-lts-gen2:latest"
-	defaultAzureWindowsImage      = "MicrosoftWindowsServer:windowsserver2022:2022-datacenter-smalldisk-g2:latest"
-	azureDeleteRetryDelay         = 15 * time.Second
-	azureDeleteRetryAttempts      = 13
+	azureAddressSpace                = "10.42.0.0/16"
+	azureSubnetCIDR                  = "10.42.0.0/24"
+	azureProviderTag                 = "crabbox"
+	AzureOSDiskAuto                  = "auto"
+	AzureOSDiskEphemeral             = "ephemeral"
+	AzureOSDiskEphemeralPreview      = "ephemeral-preview"
+	AzureOSDiskManaged               = "managed"
+	azureComputePreviewAPIVersion    = "2025-04-01"
+	defaultAzureLinuxImage           = "Canonical:ubuntu-26_04-lts:server:latest"
+	defaultAzureLinuxARM64Image      = "Canonical:ubuntu-26_04-lts:server-arm64:latest"
+	azureNobleLinuxImage             = "Canonical:ubuntu-24_04-lts:server:latest"
+	azureNobleLinuxARM64Image        = "Canonical:ubuntu-24_04-lts:server-arm64:latest"
+	legacyAzureJammyImage            = "Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest"
+	legacyAzureNobleGen2Image        = "Canonical:0001-com-ubuntu-server-noble:24_04-lts-gen2:latest"
+	defaultAzureWindowsImage         = "MicrosoftWindowsServer:windowsserver2022:2022-datacenter-smalldisk-g2:latest"
+	azureDeleteRetryDelay            = 15 * time.Second
+	azureDeleteRetryAttempts         = 13
+	azureSnapshotQuarantineNSGSuffix = "-q-nsg"
 )
 
 type AzureClient struct {
@@ -939,7 +940,7 @@ func (c *AzureClient) createServerSteps(ctx context.Context, cfg Config, publicK
 	pipName := name + "-pip"
 	nicName := name + "-nic"
 	diskName := name + "-osdisk"
-	quarantineNSGName := name + "-q-nsg"
+	quarantineNSGName := name + azureSnapshotQuarantineNSGSuffix
 
 	if cfg.Tailscale.Enabled && cfg.Tailscale.Hostname == "" {
 		cfg.Tailscale.Hostname = renderTailscaleHostname(cfg.Tailscale.HostnameTemplate, leaseID, slug, cfg.Provider)
@@ -951,19 +952,19 @@ func (c *AzureClient) createServerSteps(ctx context.Context, cfg Config, publicK
 		c.SubscriptionID, c.ResourceGroup, c.NSG)
 	quarantinedSnapshot := cfg.AzureSnapshot != "" && cfg.TargetOS == targetWindows
 
-	var nicID string
+	var network azureLeaseNetwork
 	var snapshotDiskID string
 	var err error
 	if cfg.AzureSnapshot != "" {
-		nicID, snapshotDiskID, err = runAzureSnapshotPrerequisites(
+		network, snapshotDiskID, err = runAzureSnapshotPrerequisites(
 			ctx,
-			func(workCtx context.Context) (string, error) {
+			func(workCtx context.Context) (azureLeaseNetwork, error) {
 				nsgID := sharedNSGID
 				if quarantinedSnapshot {
 					var createErr error
 					nsgID, createErr = c.createSnapshotQuarantineNSG(workCtx, quarantineNSGName, tags)
 					if createErr != nil {
-						return "", createErr
+						return azureLeaseNetwork{}, createErr
 					}
 				}
 				return c.createLeaseNetwork(workCtx, pipName, nicName, nsgID, tags)
@@ -979,7 +980,7 @@ func (c *AzureClient) createServerSteps(ctx context.Context, cfg Config, publicK
 			},
 		)
 	} else {
-		nicID, err = c.createLeaseNetwork(ctx, pipName, nicName, sharedNSGID, tags)
+		network, err = c.createLeaseNetwork(ctx, pipName, nicName, sharedNSGID, tags)
 	}
 	if err != nil {
 		return Server{}, err
@@ -1028,7 +1029,7 @@ func (c *AzureClient) createServerSteps(ctx context.Context, cfg Config, publicK
 			Version:   to.Ptr(c.Image.Version),
 		}
 	}
-	networkInterface := &armcompute.NetworkInterfaceReference{ID: to.Ptr(nicID)}
+	networkInterface := &armcompute.NetworkInterfaceReference{ID: to.Ptr(network.id)}
 	if cfg.AzureSnapshot != "" {
 		networkInterface.Properties = &armcompute.NetworkInterfaceReferenceProperties{
 			DeleteOption: to.Ptr(armcompute.DeleteOptionsDelete),
@@ -1080,16 +1081,21 @@ func (c *AzureClient) createServerSteps(ctx context.Context, cfg Config, publicK
 				return Server{}, err
 			}
 		}
-		if err := c.installWindowsBootstrapExtension(ctx, name, tags, command); err != nil {
+		if quarantinedSnapshot {
+			releaseRequest, err := azureSnapshotNICReleaseRequest(network.nicCreateRequest, sharedNSGID)
+			if err != nil {
+				return Server{}, err
+			}
+			if err := runAzureSnapshotExposureSequence(
+				func() error { return c.installWindowsBootstrapExtension(ctx, name, tags, command) },
+				func() error { return c.releaseSnapshotNIC(ctx, nicName, releaseRequest) },
+				func() error { return c.deleteSnapshotQuarantineNSGWithRetry(ctx, quarantineNSGName) },
+			); err != nil {
+				return Server{}, err
+			}
+		} else if err := c.installWindowsBootstrapExtension(ctx, name, tags, command); err != nil {
 			return Server{}, err
 		}
-	}
-	if quarantinedSnapshot {
-		if err := c.releaseSnapshotNIC(ctx, nicName, sharedNSGID); err != nil {
-			return Server{}, err
-		}
-		// The fork is safe and usable once released; lease deletion retries quarantine cleanup.
-		_ = c.deleteSnapshotQuarantineNSG(ctx, quarantineNSGName)
 	}
 	return azureVMToServer(createdVM, "", ""), nil
 }
@@ -1356,29 +1362,35 @@ func (c *AzureClient) azureOSProfile(cfg Config, publicKey, name, leaseID string
 }
 
 type azureSnapshotPrerequisiteResult struct {
-	kind string
-	id   string
-	err  error
+	kind    string
+	network azureLeaseNetwork
+	diskID  string
+	err     error
+}
+
+type azureLeaseNetwork struct {
+	id               string
+	nicCreateRequest armnetwork.Interface
 }
 
 func runAzureSnapshotPrerequisites(
 	ctx context.Context,
-	createNetwork func(context.Context) (string, error),
+	createNetwork func(context.Context) (azureLeaseNetwork, error),
 	createDisk func(context.Context) (string, error),
-) (string, string, error) {
+) (azureLeaseNetwork, string, error) {
 	workCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	results := make(chan azureSnapshotPrerequisiteResult, 2)
 	go func() {
-		id, err := createNetwork(workCtx)
-		results <- azureSnapshotPrerequisiteResult{kind: "network", id: id, err: err}
+		network, err := createNetwork(workCtx)
+		results <- azureSnapshotPrerequisiteResult{kind: "network", network: network, err: err}
 	}()
 	go func() {
 		id, err := createDisk(workCtx)
-		results <- azureSnapshotPrerequisiteResult{kind: "disk", id: id, err: err}
+		results <- azureSnapshotPrerequisiteResult{kind: "disk", diskID: id, err: err}
 	}()
 
-	var networkID string
+	var network azureLeaseNetwork
 	var diskID string
 	var errs []error
 	for range 2 {
@@ -1389,18 +1401,18 @@ func runAzureSnapshotPrerequisites(
 			continue
 		}
 		if result.kind == "network" {
-			networkID = result.id
+			network = result.network
 		} else {
-			diskID = result.id
+			diskID = result.diskID
 		}
 	}
 	if len(errs) > 0 {
-		return "", "", joinErrors(errs)
+		return azureLeaseNetwork{}, "", joinErrors(errs)
 	}
-	return networkID, diskID, nil
+	return network, diskID, nil
 }
 
-func (c *AzureClient) createLeaseNetwork(ctx context.Context, pipName, nicName, nsgID string, tags map[string]*string) (string, error) {
+func (c *AzureClient) createLeaseNetwork(ctx context.Context, pipName, nicName, nsgID string, tags map[string]*string) (azureLeaseNetwork, error) {
 	pipPoller, err := c.pipc.BeginCreateOrUpdate(ctx, c.ResourceGroup, pipName, armnetwork.PublicIPAddress{
 		Location: to.Ptr(c.Location),
 		Tags:     tags,
@@ -1412,19 +1424,19 @@ func (c *AzureClient) createLeaseNetwork(ctx context.Context, pipName, nicName, 
 		},
 	}, nil)
 	if err != nil {
-		return "", fmt.Errorf("begin public ip: %w", err)
+		return azureLeaseNetwork{}, fmt.Errorf("begin public ip: %w", err)
 	}
 	pipResp, err := pipPoller.PollUntilDone(ctx, nil)
 	if err != nil {
-		return "", fmt.Errorf("public ip: %w", err)
+		return azureLeaseNetwork{}, fmt.Errorf("public ip: %w", err)
 	}
 	if pipResp.ID == nil || *pipResp.ID == "" {
-		return "", errors.New("public ip has no resource id")
+		return azureLeaseNetwork{}, errors.New("public ip has no resource id")
 	}
 
 	subnetID := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/%s/subnets/%s",
 		c.SubscriptionID, c.ResourceGroup, c.VNet, c.Subnet)
-	nicPoller, err := c.nicc.BeginCreateOrUpdate(ctx, c.ResourceGroup, nicName, armnetwork.Interface{
+	nicCreateRequest := armnetwork.Interface{
 		Location: to.Ptr(c.Location),
 		Tags:     tags,
 		Properties: &armnetwork.InterfacePropertiesFormat{
@@ -1438,18 +1450,19 @@ func (c *AzureClient) createLeaseNetwork(ctx context.Context, pipName, nicName, 
 			}},
 			NetworkSecurityGroup: &armnetwork.SecurityGroup{ID: to.Ptr(nsgID)},
 		},
-	}, nil)
+	}
+	nicPoller, err := c.nicc.BeginCreateOrUpdate(ctx, c.ResourceGroup, nicName, nicCreateRequest, nil)
 	if err != nil {
-		return "", fmt.Errorf("begin nic: %w", err)
+		return azureLeaseNetwork{}, fmt.Errorf("begin nic: %w", err)
 	}
 	nicResp, err := nicPoller.PollUntilDone(ctx, nil)
 	if err != nil {
-		return "", fmt.Errorf("nic: %w", err)
+		return azureLeaseNetwork{}, fmt.Errorf("nic: %w", err)
 	}
 	if nicResp.ID == nil || *nicResp.ID == "" {
-		return "", errors.New("nic has no resource id")
+		return azureLeaseNetwork{}, errors.New("nic has no resource id")
 	}
-	return *nicResp.ID, nil
+	return azureLeaseNetwork{id: *nicResp.ID, nicCreateRequest: nicCreateRequest}, nil
 }
 
 func (c *AzureClient) createManagedDiskFromSnapshot(ctx context.Context, diskName, snapshotID, sku string, tags map[string]*string) (string, error) {
@@ -1517,16 +1530,36 @@ func azureSnapshotQuarantineSecurityGroup(location string, tags map[string]*stri
 	}
 }
 
-func (c *AzureClient) releaseSnapshotNIC(ctx context.Context, nicName, sharedNSGID string) error {
-	response, err := c.nicc.Get(ctx, c.ResourceGroup, nicName, nil)
-	if err != nil {
-		return fmt.Errorf("get quarantined snapshot nic: %w", err)
+// azureSnapshotNICReleaseRequest derives the release PUT from the original NIC
+// create request. Azure's GET model includes read-only response fields that
+// must not be echoed into BeginCreateOrUpdate.
+func azureSnapshotNICReleaseRequest(createRequest armnetwork.Interface, sharedNSGID string) (armnetwork.Interface, error) {
+	if createRequest.Properties == nil {
+		return armnetwork.Interface{}, errors.New("snapshot network interface create request has no properties")
 	}
-	if response.Properties == nil {
-		return errors.New("quarantined snapshot nic has no properties")
+	properties := *createRequest.Properties
+	properties.NetworkSecurityGroup = &armnetwork.SecurityGroup{ID: to.Ptr(sharedNSGID)}
+	createRequest.Properties = &properties
+	return createRequest, nil
+}
+
+// runAzureSnapshotExposureSequence keeps copied source credentials unreachable
+// until the guest agent has replaced every per-lease credential and host key.
+func runAzureSnapshotExposureSequence(rehydrate, expose, cleanupQuarantine func() error) error {
+	if err := rehydrate(); err != nil {
+		return fmt.Errorf("rehydrate snapshot credentials: %w", err)
 	}
-	response.Properties.NetworkSecurityGroup = &armnetwork.SecurityGroup{ID: to.Ptr(sharedNSGID)}
-	poller, err := c.nicc.BeginCreateOrUpdate(ctx, c.ResourceGroup, nicName, response.Interface, nil)
+	if err := expose(); err != nil {
+		return fmt.Errorf("expose rehydrated snapshot network: %w", err)
+	}
+	if err := cleanupQuarantine(); err != nil {
+		return fmt.Errorf("delete snapshot quarantine network security group: %w", err)
+	}
+	return nil
+}
+
+func (c *AzureClient) releaseSnapshotNIC(ctx context.Context, nicName string, releaseRequest armnetwork.Interface) error {
+	poller, err := c.nicc.BeginCreateOrUpdate(ctx, c.ResourceGroup, nicName, releaseRequest, nil)
 	if err != nil {
 		return fmt.Errorf("begin release snapshot nic: %w", err)
 	}
@@ -1548,6 +1581,32 @@ func (c *AzureClient) deleteSnapshotQuarantineNSG(ctx context.Context, name stri
 		return fmt.Errorf("delete snapshot quarantine nsg %s: %w", name, err)
 	}
 	return nil
+}
+
+func (c *AzureClient) deleteSnapshotQuarantineNSGWithRetry(ctx context.Context, name string) error {
+	return retryAzureSnapshotQuarantineCleanup(ctx, azureDeleteRetryAttempts, azureDeleteRetryDelay, func() error {
+		return c.deleteSnapshotQuarantineNSG(ctx, name)
+	})
+}
+
+func retryAzureSnapshotQuarantineCleanup(ctx context.Context, attempts int, delay time.Duration, deleteQuarantine func() error) error {
+	if attempts < 1 {
+		attempts = 1
+	}
+	for attempt := 0; ; attempt++ {
+		err := deleteQuarantine()
+		if err == nil {
+			return nil
+		}
+		if !isAzureRetryableDeleteError(err) || attempt >= attempts-1 {
+			return err
+		}
+		select {
+		case <-ctx.Done():
+			return joinErrors([]error{err, ctx.Err()})
+		case <-time.After(delay):
+		}
+	}
 }
 
 func (c *AzureClient) installWindowsBootstrapExtension(ctx context.Context, vmName string, tags map[string]*string, command string) error {
@@ -1831,9 +1890,10 @@ func azureSnapshotOSDiskID(vmName string, osDisk *armcompute.OSDisk) (string, er
 		return "", errors.New("snapshot source VM has no managed OS disk")
 	}
 	if osDisk.DiffDiskSettings != nil && osDisk.DiffDiskSettings.Option != nil &&
-		*osDisk.DiffDiskSettings.Option == armcompute.DiffDiskOptionsLocal {
+		strings.TrimSpace(string(*osDisk.DiffDiskSettings.Option)) != "" {
 		return "", fmt.Errorf(
-			"azure ephemeral OS disk on vm %s cannot be snapshotted; use --mode archive or relaunch the lease with a managed Azure OS disk",
+			"azure differential OS disk option %q on vm %s cannot be snapshotted; use --mode archive or relaunch the lease with a managed Azure OS disk",
+			*osDisk.DiffDiskSettings.Option,
 			vmName,
 		)
 	}
@@ -1901,6 +1961,7 @@ func (c *AzureClient) deleteVMResources(ctx context.Context, name string) error 
 func (c *AzureClient) deleteVMResourcesOnce(ctx context.Context, name string) ([]error, bool) {
 	var errs []error
 	retry := false
+	quarantineNSGName := name + azureSnapshotQuarantineNSGSuffix
 	if poller, err := c.vmc.BeginDelete(ctx, c.ResourceGroup, name, &armcompute.VirtualMachinesClientBeginDeleteOptions{
 		ForceDeletion: to.Ptr(true),
 	}); err == nil {
@@ -1927,7 +1988,7 @@ func (c *AzureClient) deleteVMResourcesOnce(ctx context.Context, name string) ([
 			retry = retry || isAzureRetryableDeleteError(err)
 		}
 	}
-	if err := c.deleteSnapshotQuarantineNSG(ctx, name+"-q-nsg"); err != nil {
+	if err := c.deleteSnapshotQuarantineNSG(ctx, quarantineNSGName); err != nil {
 		errs = append(errs, err)
 		retry = retry || isAzureRetryableDeleteError(err)
 	}
@@ -1951,8 +2012,8 @@ func (c *AzureClient) deleteVMResourcesOnce(ctx context.Context, name string) ([
 			_, err := c.diskc.Get(ctx, c.ResourceGroup, name+"-osdisk", nil)
 			return err
 		}},
-		{name: "snapshot quarantine nsg " + name + "-q-nsg", get: func() error {
-			_, err := c.sgc.Get(ctx, c.ResourceGroup, name+"-q-nsg", nil)
+		{name: "snapshot quarantine nsg " + quarantineNSGName, get: func() error {
+			_, err := c.sgc.Get(ctx, c.ResourceGroup, quarantineNSGName, nil)
 			return err
 		}},
 	}
@@ -2154,6 +2215,7 @@ func isAzureRetryableDeleteError(err error) bool {
 	s := err.Error()
 	return strings.Contains(s, "NicReservedForAnotherVm") ||
 		strings.Contains(s, "PublicIPAddressCannotBeDeleted") ||
+		strings.Contains(s, "NetworkSecurityGroupCannotBeDeleted") ||
 		strings.Contains(s, "DiskInUse") ||
 		strings.Contains(s, "DiskIsAttachedToVM") ||
 		strings.Contains(s, "DiskAttached") ||

--- a/internal/cli/azure_test.go
+++ b/internal/cli/azure_test.go
@@ -310,6 +310,158 @@ func TestAzureSnapshotQuarantineSecurityGroupDeniesAllInbound(t *testing.T) {
 	}
 }
 
+func TestAzureSnapshotNICReleaseRequestUsesWritableCreatePayload(t *testing.T) {
+	t.Parallel()
+	quarantineNSGID := "/subscriptions/test/resourceGroups/test/providers/Microsoft.Network/networkSecurityGroups/lease-q-nsg"
+	sharedNSGID := "/subscriptions/test/resourceGroups/test/providers/Microsoft.Network/networkSecurityGroups/crabbox-nsg"
+	createRequest := armnetwork.Interface{
+		Location: to.Ptr("westus2"),
+		Tags:     map[string]*string{"lease_id": to.Ptr("cbx_123")},
+		Properties: &armnetwork.InterfacePropertiesFormat{
+			IPConfigurations: []*armnetwork.InterfaceIPConfiguration{{
+				Name: to.Ptr("ipconfig"),
+				Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+					PrivateIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodDynamic),
+					Subnet:                    &armnetwork.Subnet{ID: to.Ptr("/subscriptions/test/subnets/default")},
+					PublicIPAddress:           &armnetwork.PublicIPAddress{ID: to.Ptr("/subscriptions/test/publicIPAddresses/lease")},
+				},
+			}},
+			NetworkSecurityGroup: &armnetwork.SecurityGroup{ID: to.Ptr(quarantineNSGID)},
+		},
+	}
+
+	releaseRequest, err := azureSnapshotNICReleaseRequest(createRequest, sharedNSGID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := *createRequest.Properties.NetworkSecurityGroup.ID; got != quarantineNSGID {
+		t.Fatalf("create request NSG=%q, want quarantine preserved", got)
+	}
+	if got := *releaseRequest.Properties.NetworkSecurityGroup.ID; got != sharedNSGID {
+		t.Fatalf("release request NSG=%q, want shared NSG", got)
+	}
+	payload, err := json.Marshal(releaseRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var object map[string]any
+	if err := json.Unmarshal(payload, &object); err != nil {
+		t.Fatal(err)
+	}
+	for _, readOnly := range []string{"etag", "id", "name", "type"} {
+		if _, ok := object[readOnly]; ok {
+			t.Fatalf("release PUT includes top-level read-only field %q: %s", readOnly, payload)
+		}
+	}
+	properties, ok := object["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("release PUT properties=%T", object["properties"])
+	}
+	for _, readOnly := range []string{"macAddress", "provisioningState", "resourceGuid", "virtualMachine"} {
+		if _, ok := properties[readOnly]; ok {
+			t.Fatalf("release PUT includes read-only property %q: %s", readOnly, payload)
+		}
+	}
+}
+
+func TestAzureSnapshotNICReleaseRequestRequiresProperties(t *testing.T) {
+	t.Parallel()
+	_, err := azureSnapshotNICReleaseRequest(armnetwork.Interface{}, "shared-nsg")
+	if err == nil || err.Error() != "snapshot network interface create request has no properties" {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestAzureSnapshotExposureSequence(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		failAt     string
+		wantEvents []string
+		wantErr    string
+	}{
+		{name: "success", wantEvents: []string{"rehydrate", "expose", "cleanup"}},
+		{name: "rehydrate failure stays quarantined", failAt: "rehydrate", wantEvents: []string{"rehydrate"}, wantErr: "rehydrate snapshot credentials"},
+		{name: "exposure failure stays quarantined", failAt: "expose", wantEvents: []string{"rehydrate", "expose"}, wantErr: "expose rehydrated snapshot network"},
+		{name: "cleanup failure fails creation", failAt: "cleanup", wantEvents: []string{"rehydrate", "expose", "cleanup"}, wantErr: "delete snapshot quarantine network security group"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			var events []string
+			step := func(name string) func() error {
+				return func() error {
+					events = append(events, name)
+					if test.failAt == name {
+						return errors.New("injected failure")
+					}
+					return nil
+				}
+			}
+			err := runAzureSnapshotExposureSequence(step("rehydrate"), step("expose"), step("cleanup"))
+			if test.wantErr == "" {
+				if err != nil {
+					t.Fatal(err)
+				}
+			} else if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("error=%v, want containing %q", err, test.wantErr)
+			}
+			if !reflect.DeepEqual(events, test.wantEvents) {
+				t.Fatalf("events=%v, want %v", events, test.wantEvents)
+			}
+		})
+	}
+}
+
+func TestAzureSnapshotQuarantineCleanupRetries(t *testing.T) {
+	t.Parallel()
+	t.Run("retryable error then success", func(t *testing.T) {
+		attempts := 0
+		err := retryAzureSnapshotQuarantineCleanup(context.Background(), 3, 0, func() error {
+			attempts++
+			if attempts < 3 {
+				return errors.New("NetworkSecurityGroupCannotBeDeleted because in use")
+			}
+			return nil
+		})
+		if err != nil || attempts != 3 {
+			t.Fatalf("error=%v attempts=%d", err, attempts)
+		}
+	})
+	t.Run("non-retryable error", func(t *testing.T) {
+		attempts := 0
+		err := retryAzureSnapshotQuarantineCleanup(context.Background(), 3, 0, func() error {
+			attempts++
+			return errors.New("permission denied")
+		})
+		if err == nil || err.Error() != "permission denied" || attempts != 1 {
+			t.Fatalf("error=%v attempts=%d", err, attempts)
+		}
+	})
+	t.Run("retry exhaustion", func(t *testing.T) {
+		attempts := 0
+		err := retryAzureSnapshotQuarantineCleanup(context.Background(), 2, 0, func() error {
+			attempts++
+			return errors.New("NetworkSecurityGroupCannotBeDeleted because in use")
+		})
+		if err == nil || attempts != 2 {
+			t.Fatalf("error=%v attempts=%d", err, attempts)
+		}
+	})
+	t.Run("context cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		attempts := 0
+		err := retryAzureSnapshotQuarantineCleanup(ctx, 3, time.Hour, func() error {
+			attempts++
+			return errors.New("NetworkSecurityGroupCannotBeDeleted because in use")
+		})
+		if err == nil || !strings.Contains(err.Error(), context.Canceled.Error()) || attempts != 1 {
+			t.Fatalf("error=%v attempts=%d", err, attempts)
+		}
+	})
+}
+
 func TestAzureWindowsSnapshotRehydrateRotatesServiceVNCCredentials(t *testing.T) {
 	t.Parallel()
 	cfg := baseConfig()
@@ -514,17 +666,22 @@ func TestAzureSnapshotPrerequisitesRunConcurrently(t *testing.T) {
 	started := make(chan string, 2)
 	release := make(chan struct{})
 	result := make(chan struct {
-		network string
+		network azureLeaseNetwork
 		disk    string
 		err     error
 	}, 1)
 	go func() {
 		network, disk, err := runAzureSnapshotPrerequisites(
 			context.Background(),
-			func(context.Context) (string, error) {
+			func(context.Context) (azureLeaseNetwork, error) {
 				started <- "network"
 				<-release
-				return "nic-id", nil
+				return azureLeaseNetwork{
+					id: "nic-id",
+					nicCreateRequest: armnetwork.Interface{
+						Location: to.Ptr("westus2"),
+					},
+				}, nil
 			},
 			func(context.Context) (string, error) {
 				started <- "disk"
@@ -533,7 +690,7 @@ func TestAzureSnapshotPrerequisitesRunConcurrently(t *testing.T) {
 			},
 		)
 		result <- struct {
-			network string
+			network azureLeaseNetwork
 			disk    string
 			err     error
 		}{network: network, disk: disk, err: err}
@@ -550,8 +707,11 @@ func TestAzureSnapshotPrerequisitesRunConcurrently(t *testing.T) {
 	}
 	close(release)
 	completed := <-result
-	if completed.err != nil || completed.network != "nic-id" || completed.disk != "disk-id" {
+	if completed.err != nil || completed.network.id != "nic-id" || completed.disk != "disk-id" {
 		t.Fatalf("result=%+v", completed)
+	}
+	if completed.network.nicCreateRequest.Location == nil || *completed.network.nicCreateRequest.Location != "westus2" {
+		t.Fatalf("NIC create request lost across prerequisite result: %#v", completed.network.nicCreateRequest)
 	}
 	if !seen["network"] || !seen["disk"] {
 		t.Fatalf("started=%v", seen)
@@ -663,7 +823,7 @@ func TestAzureSnapshotOSDiskID(t *testing.T) {
 				DiffDiskSettings: &armcompute.DiffDiskSettings{Option: to.Ptr(armcompute.DiffDiskOptionsLocal)},
 				ManagedDisk:      &armcompute.ManagedDiskParameters{ID: to.Ptr(managedDiskID)},
 			},
-			wantErr: "azure ephemeral OS disk on vm source-vm cannot be snapshotted; use --mode archive or relaunch the lease with a managed Azure OS disk",
+			wantErr: `azure differential OS disk option "Local" on vm source-vm cannot be snapshotted; use --mode archive or relaunch the lease with a managed Azure OS disk`,
 		},
 		{
 			name: "unknown future option",
@@ -671,7 +831,7 @@ func TestAzureSnapshotOSDiskID(t *testing.T) {
 				DiffDiskSettings: &armcompute.DiffDiskSettings{Option: &futureOption},
 				ManagedDisk:      &armcompute.ManagedDiskParameters{ID: to.Ptr(managedDiskID)},
 			},
-			want: managedDiskID,
+			wantErr: `azure differential OS disk option "FutureSchemaValue" on vm source-vm cannot be snapshotted; use --mode archive or relaunch the lease with a managed Azure OS disk`,
 		},
 		{
 			name:   "managed disk",
@@ -890,12 +1050,13 @@ func TestIsAzureRetryableDeleteError(t *testing.T) {
 	cases := map[string]bool{
 		"":                  false,
 		"validation failed": false,
-		"NicReservedForAnotherVm retry after 180 seconds": true,
-		"PublicIPAddressCannotBeDeleted because in use":   true,
-		"DiskIsAttachedToVM: disk is still attached":      true,
-		"DiskInUse: managed disk has active lease":        true,
-		"AnotherOperationInProgress":                      true,
-		"OperationNotAllowed retry after 180 seconds":     true,
+		"NicReservedForAnotherVm retry after 180 seconds":    true,
+		"PublicIPAddressCannotBeDeleted because in use":      true,
+		"NetworkSecurityGroupCannotBeDeleted because in use": true,
+		"DiskIsAttachedToVM: disk is still attached":         true,
+		"DiskInUse: managed disk has active lease":           true,
+		"AnotherOperationInProgress":                         true,
+		"OperationNotAllowed retry after 180 seconds":        true,
 	}
 	for msg, want := range cases {
 		var err error


### PR DESCRIPTION
## Summary

- keep restored Azure Windows snapshots quarantined until credential and host-key rehydration succeeds
- release the NIC with the original writable create payload instead of echoing Azure response-only fields
- require quarantine NSG deletion, with bounded retries for Azure's transient in-use state
- reject every differential OS-disk mode from native snapshot capture and verify quarantine cleanup during lease deletion

Follow-up hardening for https://github.com/openclaw/crabbox/pull/698 and https://github.com/openclaw/crabbox/pull/731.

## Verification

Exact head: `742b04d141688c434fe949d3167b8d419ce39d2e` (rebased onto current `main`). Hosted exact-head CI is running.

- `go test -race ./internal/cli -run 'TestAzure(SnapshotPrerequisites|SnapshotNICReleaseRequest|SnapshotExposureSequence|SnapshotQuarantineCleanup|SnapshotOSDiskID)|TestIsAzureRetryableDeleteError' -count=1`
- `go vet ./...`
- `go test -race -timeout 8m ./...` — all packages passed
- `scripts/check-docs.sh` and `node scripts/build-docs-site.mjs`
- Codex whole-branch autoreview: clean, no accepted/actionable findings

## Live proof

Exact-candidate funded canary passed in a disposable `swedencentral` resource group using `Standard_D2s_v5`:

- created a native Windows desktop source, connected over SSH, and opened an owned loopback VNC tunnel
- created a managed-OS-disk snapshot with the required source deallocate/restart cycle
- observed the fork NIC attached to the deny-all quarantine NSG before rehydration; public port 5900 was unreachable
- verified the released fork over SSH and an owned loopback VNC tunnel while public port 5900 remained unreachable
- verified the fork host key and VNC credential differed from the source
- verified the quarantine NSG was deleted and the fork NIC was reassociated with the shared NSG
- stopped source and fork, deleted the checkpoint, deleted the disposable resource group, and confirmed zero residue
