### PR TITLE
fix(worker): restrict broker cloud selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### Fixed
 
+- Restricted brokered AWS and GCP resource selectors to admin-authenticated requests so normal users cannot steer coordinator cloud credentials toward caller-selected networks, images, projects, tags, or instance identities. Thanks @coygeek.
 - Pinned the Windows developer-image Node MSI and Docker Engine archive to reviewed SHA-256 digests before privileged installation, with fail-closed digest requirements for version overrides. Thanks @coygeek.
 - Restored direct and brokered AWS Windows developer-image candidate capture by routing the guarded mint wrapper through native AMI checkpoints while retaining brokered promotion.
 - Prevented direct AWS raw-instance release from reaching deletion unless canonical Crabbox ownership tags match the resolved lease, with a second guard at the destructive provider boundary. Thanks @TurboTheTurtle.

--- a/docs/providers/aws.md
+++ b/docs/providers/aws.md
@@ -119,6 +119,10 @@ Notes:
 - For brokered AWS, the cloud credentials live in the Worker, not on developer
   machines. See `crabbox config set-broker --provider aws` and the brokered
   IAM policy from `crabbox admin aws-policy`.
+- In brokered mode, explicit `aws.ami`, `aws.securityGroupId`, `aws.subnetId`,
+  and `aws.instanceProfile` selectors require admin-token authentication.
+  Normal broker users receive the coordinator-managed image, network, and
+  instance identity. Direct mode keeps these local configuration overrides.
 
 ## Targets
 

--- a/docs/providers/gcp.md
+++ b/docs/providers/gcp.md
@@ -192,6 +192,11 @@ CRABBOX_GCP_ROOT_GB
 CRABBOX_GCP_SERVICE_ACCOUNT
 ```
 
+Explicit broker requests for `gcp.project`, `gcp.image`, `gcp.network`,
+`gcp.subnet`, `gcp.tags`, or `gcp.serviceAccount` require admin-token
+authentication. Normal broker users receive the coordinator-managed values.
+Direct mode keeps these local configuration overrides.
+
 Verify configuration:
 
 ```sh

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -1697,6 +1697,24 @@ export class FleetCoordinator {
         { status: 400 },
       );
     }
+    const configProvider = this.provider(
+      config.provider,
+      providerRegionForConfig(config),
+      providerProjectForConfig(config),
+    );
+    if (!workspaceID && !isAdminRequest(request)) {
+      const restrictedFields = configProvider.restrictedLeaseRequestFields?.(input) ?? [];
+      if (restrictedFields.length > 0) {
+        return json(
+          {
+            error: "admin_required",
+            message: `brokered ${config.provider} resource selectors require admin-token auth: ${restrictedFields.join(", ")}`,
+            fields: restrictedFields,
+          },
+          { status: 403 },
+        );
+      }
+    }
     if (!isAdminRequest(request) && hasNativeLeaseSource(config)) {
       return json(
         {
@@ -1757,12 +1775,7 @@ export class FleetCoordinator {
     if (!config.providerKey) {
       config = { ...config, providerKey: providerKeyForLease(leaseID) };
     }
-    config =
-      (await this.provider(
-        config.provider,
-        providerRegionForConfig(config),
-        providerProjectForConfig(config),
-      ).prepareLeaseConfig?.(config)) ?? config;
+    config = (await configProvider.prepareLeaseConfig?.(config)) ?? config;
     const readiness = this.providerConfigurationReadiness(
       config.provider,
       providerProjectForConfig(config),
@@ -15542,6 +15555,7 @@ function parseProviderLabelTime(value: string | undefined): number {
 
 interface CloudProvider {
   listCrabboxServers(): Promise<ProviderMachine[]>;
+  restrictedLeaseRequestFields?(input: LeaseRequest): string[];
   recoverServer?(lease: LeaseRecord): Promise<ProviderMachine | undefined>;
   findServerByLease?(leaseID: string): Promise<ProviderMachine | undefined>;
   getServer?(id: string): Promise<ProviderMachine>;
@@ -15908,6 +15922,17 @@ class GCPProvider implements CloudProvider {
     return this.clientValue;
   }
 
+  restrictedLeaseRequestFields(input: LeaseRequest): string[] {
+    return [
+      input.gcpProject ? "gcpProject" : "",
+      input.gcpImage ? "gcpImage" : "",
+      input.gcpNetwork ? "gcpNetwork" : "",
+      input.gcpSubnet ? "gcpSubnet" : "",
+      input.gcpTags?.length ? "gcpTags" : "",
+      input.gcpServiceAccount ? "gcpServiceAccount" : "",
+    ].filter(Boolean);
+  }
+
   listCrabboxServers(): Promise<ProviderMachine[]> {
     return this.client.listCrabboxServers();
   }
@@ -16068,6 +16093,15 @@ export class AWSProvider implements CloudProvider {
   private get client(): EC2SpotClient {
     this.clientValue ??= new EC2SpotClient(this.env, this.region);
     return this.clientValue;
+  }
+
+  restrictedLeaseRequestFields(input: LeaseRequest): string[] {
+    return [
+      input.awsAMI ? "awsAMI" : "",
+      input.awsSGID ? "awsSGID" : "",
+      input.awsSubnetID ? "awsSubnetID" : "",
+      input.awsProfile ? "awsProfile" : "",
+    ].filter(Boolean);
   }
 
   listCrabboxServers(): Promise<ProviderMachine[]> {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -40,6 +40,7 @@ import type {
   Env,
   ExternalRunnerRecord,
   LeaseRecord,
+  LeaseRequest,
   ProviderFastSnapshotRestore,
   ProviderImage,
   ProviderMachine,
@@ -107,6 +108,27 @@ class HookedMemoryStorage extends MemoryStorage {
     await super.put(key, value);
   }
 }
+
+const restrictedBrokerSelectorCases = [
+  { provider: "aws" as const, field: "awsAMI", value: "ami-000000000001" },
+  { provider: "aws" as const, field: "awsSGID", value: "sg-000000000001" },
+  { provider: "aws" as const, field: "awsSubnetID", value: "subnet-000000000001" },
+  { provider: "aws" as const, field: "awsProfile", value: "crabbox-runner" },
+  { provider: "gcp" as const, field: "gcpProject", value: "other-project" },
+  {
+    provider: "gcp" as const,
+    field: "gcpImage",
+    value: "projects/example/global/images/custom-runner",
+  },
+  { provider: "gcp" as const, field: "gcpNetwork", value: "other-network" },
+  { provider: "gcp" as const, field: "gcpSubnet", value: "other-subnet" },
+  { provider: "gcp" as const, field: "gcpTags", value: ["other-runner"] },
+  {
+    provider: "gcp" as const,
+    field: "gcpServiceAccount",
+    value: "runner@other-project.iam.gserviceaccount.com",
+  },
+];
 
 class FakeWebSocket {
   readyState = WebSocket.OPEN;
@@ -3365,6 +3387,181 @@ describe("fleet lease identity and idle", () => {
     expect(storage.value<LeaseRecord>("lease:cbx_abcdef123456")?.providerKey).toBe(
       expectedProviderKey,
     );
+  });
+
+  it.each(restrictedBrokerSelectorCases)(
+    "requires admin auth for brokered $provider selector $field",
+    async ({ provider, field, value }) => {
+      const storage = new MemoryStorage();
+      const providerFetch = vi.fn<typeof fetch>();
+      vi.stubGlobal("fetch", providerFetch);
+      const fleet = testFleet(storage);
+
+      const response = await fleet.fetch(
+        request("POST", "/v1/leases", {
+          headers: {
+            "x-crabbox-owner": "alice@example.com",
+            "x-crabbox-org": "example-org",
+          },
+          body: {
+            leaseID: "cbx_abcdef123456",
+            provider,
+            sshPublicKey: "ssh-ed25519 restricted-selector-test",
+            [field]: value,
+          },
+        }),
+      );
+
+      expect(response.status).toBe(403);
+      await expect(response.json()).resolves.toMatchObject({
+        error: "admin_required",
+        fields: [field],
+      });
+      expect(providerFetch).not.toHaveBeenCalled();
+      expect((await storage.list()).size).toBe(0);
+      expect(storage.alarm()).toBeUndefined();
+    },
+  );
+
+  it.each(restrictedBrokerSelectorCases)(
+    "preserves brokered $provider selector $field for admins",
+    async ({ provider, field, value }) => {
+      let preparedConfig: LeaseConfig | undefined;
+      let restrictionChecks = 0;
+      const fleet = testFleet(new MemoryStorage(), {
+        [provider]: fakeProvider(
+          (config) => {
+            preparedConfig = config;
+          },
+          {
+            provider,
+            onRestrictedLeaseRequestFields: () => {
+              restrictionChecks += 1;
+              return [field];
+            },
+          },
+        ),
+      });
+
+      const response = await fleet.fetch(
+        request("POST", "/v1/leases", {
+          headers: {
+            "x-crabbox-admin": "true",
+            "x-crabbox-owner": "admin@example.com",
+            "x-crabbox-org": "example-org",
+          },
+          body: {
+            leaseID: "cbx_abcdef123456",
+            provider,
+            sshPublicKey: "ssh-ed25519 admin-selector-test",
+            [field]: value,
+          },
+        }),
+      );
+
+      expect(response.status).toBe(201);
+      expect(restrictionChecks).toBe(0);
+      expect(preparedConfig?.[field as keyof LeaseConfig]).toEqual(value);
+    },
+  );
+
+  it.each([
+    {
+      provider: "aws" as const,
+      env: {
+        CRABBOX_AWS_AMI: "ami-operator-default",
+        CRABBOX_AWS_SECURITY_GROUP_ID: "sg-operator-default",
+        CRABBOX_AWS_SUBNET_ID: "subnet-operator-default",
+        CRABBOX_AWS_INSTANCE_PROFILE: "operator-default",
+      },
+      body: {},
+    },
+    {
+      provider: "gcp" as const,
+      env: {
+        CRABBOX_GCP_PROJECT: "operator-project",
+        CRABBOX_GCP_IMAGE: "projects/example/global/images/operator-default",
+        CRABBOX_GCP_NETWORK: "operator-network",
+        CRABBOX_GCP_SUBNET: "operator-subnet",
+        CRABBOX_GCP_TAGS: "operator-runner",
+        CRABBOX_GCP_SERVICE_ACCOUNT: "runner@operator-project.iam.gserviceaccount.com",
+      },
+      body: { os: "ubuntu:24.04" },
+    },
+  ])(
+    "does not treat coordinator $provider defaults as caller-supplied selectors",
+    async ({ provider, env, body }) => {
+      const storage = new MemoryStorage();
+      const providerFetch = vi.fn<typeof fetch>();
+      vi.stubGlobal("fetch", providerFetch);
+      const fleet = testFleet(storage, {}, env);
+
+      const response = await fleet.fetch(
+        request("POST", "/v1/leases", {
+          body: {
+            leaseID: "cbx_abcdef123456",
+            provider,
+            sshPublicKey: "ssh-ed25519 operator-default-test",
+            ...body,
+          },
+        }),
+      );
+
+      expect(response.status).toBe(424);
+      await expect(response.json()).resolves.toMatchObject({
+        error: "provider_not_configured",
+        provider,
+      });
+      expect(providerFetch).not.toHaveBeenCalled();
+      expect((await storage.list()).size).toBe(0);
+    },
+  );
+
+  it("skips broker selector restrictions for internal workspace provisioning", async () => {
+    let created = false;
+    let restrictionChecks = 0;
+    const fleet = testFleet(
+      new MemoryStorage(),
+      {
+        aws: fakeProvider(
+          () => {
+            created = true;
+          },
+          {
+            provider: "aws",
+            onRestrictedLeaseRequestFields: () => {
+              restrictionChecks += 1;
+              return ["awsAMI"];
+            },
+          },
+        ),
+      },
+      {
+        CRABBOX_WORKSPACE_PROVIDER: "aws",
+        CRABBOX_WORKSPACE_SSH_PUBLIC_KEY: "ssh-ed25519 workspace-selector-test",
+        CRABBOX_WORKSPACE_SSH_PRIVATE_KEY: "workspace-private-key",
+      },
+    );
+
+    const response = await fleet.fetch(
+      request("POST", "/v1/workspaces", {
+        headers: {
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
+        },
+        body: {
+          id: "selector-policy-workspace",
+          runtime: "crabbox",
+          ttlSeconds: 1800,
+          idleTimeoutSeconds: 360,
+        },
+      }),
+    );
+
+    expect(response.status).toBe(202);
+    await fleet.alarm();
+    expect(restrictionChecks).toBe(0);
+    expect(created).toBe(true);
   });
 
   it("adapts workspaces onto owner-scoped lease lifecycle", async () => {
@@ -11923,6 +12120,7 @@ describe("fleet lease identity and idle", () => {
     const create = await fleet.fetch(
       request("POST", "/v1/leases", {
         headers: {
+          "x-crabbox-admin": "true",
           "x-crabbox-owner": "peter@example.com",
           "x-crabbox-org": "openclaw",
         },
@@ -19225,6 +19423,7 @@ function fakeProvider(
       config: LeaseConfig,
       storage: MemoryStorage | undefined,
     ) => Promise<LeaseConfig> | LeaseConfig;
+    onRestrictedLeaseRequestFields?: (input: LeaseRequest) => string[];
     onFinalizeLeaseCreate?: (
       config: LeaseConfig,
       lease: LeaseRecord,
@@ -19254,6 +19453,9 @@ function fakeProvider(
         return await result.onList();
       }
       return result.servers ?? [];
+    },
+    restrictedLeaseRequestFields(input: LeaseRequest) {
+      return result.onRestrictedLeaseRequestFields?.(input) ?? [];
     },
     ...(result.onRecoverServer
       ? {


### PR DESCRIPTION
## Summary

- require administrator authentication for caller-supplied AWS AMI, security-group, subnet, and instance-profile selectors in brokered leases
- require administrator authentication for caller-supplied GCP project, image, network, subnet, tags, and service-account selectors in brokered leases
- reject restricted selectors before provider preparation, cloud API access, or durable lease mutation
- document the strict broker policy while preserving coordinator defaults, administrator requests, internal workspace provisioning, and direct-mode local overrides

This intentionally chooses an administrator-only compatibility policy for explicit broker resource selectors. Per-user provider allowlists are not introduced by this change.

Closes https://github.com/openclaw/crabbox/issues/704
Closes https://github.com/openclaw/crabbox/issues/705

## Verification

- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker` — 732 tests
- `npm run build --prefix worker`
- `node scripts/build-docs-site.mjs`
- local Wrangler proof: non-admin AWS and GCP requests containing every restricted selector returned `403 admin_required`; follow-up reads returned `404 not_found` for both lease IDs
- Codex autoreview: clean
