### PR TITLE
fix: pin Linux APT signing keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 ### Fixed
 
 - Restricted brokered AWS and GCP resource selectors to admin-authenticated requests so normal users cannot steer coordinator cloud credentials toward caller-selected networks, images, projects, tags, or instance identities. Thanks @coygeek.
+- Pinned NodeSource and Docker APT signing fingerprints across managed Linux image preparation and local-container Docker CLI bootstrap, preserving existing trust files, stopping image preparation on mismatch, and using distro packages for local-container fallback. Thanks @coygeek.
 - Pinned the Windows developer-image Node MSI and Docker Engine archive to reviewed SHA-256 digests before privileged installation, with fail-closed digest requirements for version overrides. Thanks @coygeek.
 - Restored direct and brokered AWS Windows developer-image candidate capture by routing the guarded mint wrapper through native AMI checkpoints while retaining brokered promotion.
 - Prevented direct AWS raw-instance release from reaching deletion unless canonical Crabbox ownership tags match the resolved lease, with a second guard at the destructive provider boundary. Thanks @TurboTheTurtle.

--- a/docs/features/image-bake-runbook.md
+++ b/docs/features/image-bake-runbook.md
@@ -312,10 +312,12 @@ scripts/mint-aws-devtools-image.sh \
 - **Linux** (`scripts/install-linux-developer-tools.sh`): common CLI/build
   tooling, GitHub CLI, Node 24, corepack/pnpm, Chrome or Chromium for browser
   lanes, desktop/VNC helpers, Docker Engine, Compose, buildx, and a small
-  default Docker image set. Chrome's APT repository uses a scoped keyring whose
-  Google-published primary fingerprint is checked before installation; primary
-  key rotations require a reviewed code update and a fresh image-bake smoke;
-  failed verification skips Chrome and tries the distro Chromium package.
+  default Docker image set. NodeSource, Docker, and Chrome APT repositories use
+  scoped keyrings whose primary fingerprints are checked before installation;
+  primary-key rotations require a reviewed code update and a fresh image-bake
+  smoke. Failed NodeSource or Docker verification stops image preparation;
+  failed Google verification skips Chrome and tries the distro Chromium
+  package.
 - **Windows** (`scripts/install-windows-developer-tools.ps1`): common CLI/build
   tooling, GitHub CLI, Node 24, corepack/pnpm, and Windows Server container
   support with Docker Engine. It deliberately avoids Docker Desktop because

--- a/docs/providers/local-container.md
+++ b/docs/providers/local-container.md
@@ -109,6 +109,12 @@ ownership under those paths. System paths such as `/etc`, `/usr`, `/var`,
 `/home`, and `/tmp` are also rejected; use an application mount point such as
 `/mnt/my-app` or `/cache`.
 
+`--local-container-docker-socket` installs Docker's CLI when the image does not
+already provide it. On Debian and Ubuntu, Crabbox accepts Docker's APT
+repository only after its primary signing fingerprint matches the reviewed
+pin; failed verification preserves existing trust files and falls back to the
+distro `docker.io` package.
+
 **Host access:** This flag is CLI-only. Crabbox does not load bind mounts from
 repo-local `.crabbox.yaml`; operators must name each host path explicitly on
 the command line.

--- a/docs/security.md
+++ b/docs/security.md
@@ -310,19 +310,28 @@ versions require matching SHA-256 environment overrides, and missing, malformed,
 or mismatched values fail closed before installation, extraction, or service
 registration.
 
-## Managed Linux Browser Trust
+## Managed Linux APT Trust
 
-Managed Linux browser bootstrap pins Google's active Linux package-signing
-primary fingerprint. The bootstrap imports downloaded key material into an
-isolated temporary GnuPG home, exports only the approved primary key and its
-signing subkeys into a repository-scoped keyring, and binds the Chrome APT
-source to that keyring with `signed-by`. A missing or changed primary key fails
-closed before replacing the prior keyring or repository source; browser setup
-then tries the distro Chromium package without trusting the unexpected key.
+Managed Linux developer-image bootstrap pins the active NodeSource, Docker, and
+Google Linux package-signing primary fingerprints. Local-container Docker
+socket bootstrap applies the same Docker pin before adding Docker's CLI
+repository. Each path imports downloaded key material into an isolated
+temporary GnuPG home, exports only the approved primary key and its signing
+subkeys into a repository-scoped keyring, and binds the matching APT source to
+that keyring with `signed-by`.
 
-Signing-subkey rotations beneath the approved primary key continue without a
-Crabbox update. A Google primary-key rotation requires a reviewed fingerprint
-update against [Google's official Linux repository key page](https://www.google.com/linuxrepositories/)
+A missing or changed primary key fails closed before replacing the prior
+keyring or repository source. Managed image preparation stops rather than
+trusting unexpected NodeSource or Docker key material. Browser setup instead
+tries the distro Chromium package, and local-container Docker CLI setup instead
+tries the distro `docker.io` package.
+
+Signing-subkey rotations beneath an approved primary key continue without a
+Crabbox update. A primary-key rotation requires a reviewed fingerprint update
+against the official [NodeSource setup](https://github.com/nodesource/distributions/blob/master/scripts/deb/setup_24.x),
+[Docker Ubuntu](https://docs.docker.com/engine/install/ubuntu/),
+[Docker Debian](https://docs.docker.com/engine/install/debian/), or
+[Google Linux repository key](https://www.google.com/linuxrepositories/) source
 and fresh bootstrap proof; there is no fallback to an unpinned key.
 
 ## SSH

--- a/internal/providers/localcontainer/backend.go
+++ b/internal/providers/localcontainer/backend.go
@@ -1567,12 +1567,47 @@ func isDefaultWorkRoot(value string) bool {
 	return value == "" || value == "/work/crabbox"
 }
 
+const localContainerDockerSigningKeyFingerprint = "9DC858229FC7DD38854AE2D88D81803C0EBFCD88"
+
+const installVerifiedAPTKeyringScript = `
+install_verified_apt_keyring() {
+  apt_key_url="$1"
+  apt_key_target="$2"
+  apt_key_expected_fingerprint="$3"
+  install -m 0755 -d "$(dirname "$apt_key_target")"
+  apt_key_tmp_dir="$(mktemp -d "${apt_key_target}.tmp.XXXXXX")"
+  apt_key_download="$apt_key_tmp_dir/downloaded.asc"
+  apt_key_home="$apt_key_tmp_dir/gnupg"
+  apt_key_output="$apt_key_tmp_dir/keyring.gpg"
+  install -m 0700 -d "$apt_key_home"
+  if curl -fsSL "$apt_key_url" >"$apt_key_download" &&
+    GNUPGHOME="$apt_key_home" gpg --batch --import "$apt_key_download" >/dev/null 2>&1; then
+    apt_key_actual_fingerprint="$(
+      GNUPGHOME="$apt_key_home" gpg --batch --with-colons --fingerprint "$apt_key_expected_fingerprint" 2>/dev/null |
+        awk -F: '$1 == "fpr" { print $10; exit }' || true
+    )"
+    if [ "$apt_key_actual_fingerprint" = "$apt_key_expected_fingerprint" ] &&
+      GNUPGHOME="$apt_key_home" gpg --batch --export "$apt_key_expected_fingerprint" >"$apt_key_output" &&
+      [ -s "$apt_key_output" ]; then
+      chmod 0644 "$apt_key_output"
+      mv -f "$apt_key_output" "$apt_key_target"
+      rm -rf "$apt_key_tmp_dir"
+      return 0
+    fi
+  fi
+  rm -rf "$apt_key_tmp_dir"
+  return 1
+}
+`
+
 const bootstrapScript = `
 set -eu
 export DEBIAN_FRONTEND=noninteractive
 user="${CRABBOX_SSH_USER:-crabbox}"
 work_root="${CRABBOX_WORK_ROOT:-/work/crabbox}"
 ssh_port="${CRABBOX_SSH_PORT:-2222}"
+docker_signing_key_fingerprint="` + localContainerDockerSigningKeyFingerprint + `"
+` + installVerifiedAPTKeyringScript + `
 home_dir=""
 if [ -r /etc/passwd ]; then
   while IFS=: read -r account _ _ _ _ account_home _; do
@@ -1682,26 +1717,38 @@ fi
 if [ "${CRABBOX_DOCKER_SOCKET:-0}" = "1" ] && ! command -v docker >/dev/null 2>&1 && command -v apt-get >/dev/null 2>&1; then
   apt-get update
   install_docker_cli=0
-  if [ -r /etc/os-release ]; then
-    . /etc/os-release
-    case "${ID:-}" in
-      debian|ubuntu)
-        install -m 0755 -d /etc/apt/keyrings
-        if curl -fsSL "https://download.docker.com/linux/${ID}/gpg" -o /etc/apt/keyrings/docker.asc; then
-          chmod a+r /etc/apt/keyrings/docker.asc
-          codename="${VERSION_CODENAME:-}"
-          if [ -n "$codename" ]; then
-            arch="$(dpkg --print-architecture)"
-            printf 'deb [arch=%s signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/%s %s stable\n' "$arch" "$ID" "$codename" > /etc/apt/sources.list.d/docker.list
-            if apt-get update && apt-get install -y --no-install-recommends docker-ce-cli; then
-              install_docker_cli=1
-            else
-              rm -f /etc/apt/sources.list.d/docker.list
+  if command -v gpg >/dev/null 2>&1 || apt-get install -y --no-install-recommends gnupg; then
+    if [ -r /etc/os-release ]; then
+      . /etc/os-release
+      case "${ID:-}" in
+        debian|ubuntu)
+          install -m 0755 -d /etc/apt/keyrings /etc/apt/sources.list.d
+          if install_verified_apt_keyring "https://download.docker.com/linux/${ID}/gpg" /etc/apt/keyrings/docker.gpg "$docker_signing_key_fingerprint"; then
+            codename="${VERSION_CODENAME:-}"
+            if [ -n "$codename" ]; then
+              arch="$(dpkg --print-architecture)"
+              docker_source_tmp="$(mktemp /etc/apt/sources.list.d/docker.list.tmp.XXXXXX)"
+              if printf 'deb [arch=%s signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/%s %s stable\n' "$arch" "$ID" "$codename" >"$docker_source_tmp" &&
+                chmod 0644 "$docker_source_tmp" &&
+                mv -f "$docker_source_tmp" /etc/apt/sources.list.d/docker.list; then
+                rm -f /etc/apt/keyrings/docker.asc
+                if apt-get update && apt-get install -y --no-install-recommends docker-ce-cli; then
+                  install_docker_cli=1
+                else
+                  rm -f /etc/apt/sources.list.d/docker.list
+                fi
+              else
+                rm -f "$docker_source_tmp"
+              fi
             fi
+          else
+            echo "Docker APT signing key verification failed; falling back to distro Docker CLI" >&2
           fi
-        fi
-        ;;
-    esac
+          ;;
+      esac
+    fi
+  else
+    echo "Docker APT signing key verification unavailable; falling back to distro Docker CLI" >&2
   fi
   if [ "$install_docker_cli" != "1" ]; then
     apt-get install -y --no-install-recommends docker.io

--- a/internal/providers/localcontainer/backend_test.go
+++ b/internal/providers/localcontainer/backend_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"slices"
@@ -1469,6 +1470,14 @@ func TestBootstrapScriptSupportsDockerSocketCLI(t *testing.T) {
 	for _, want := range []string{
 		`[ "${CRABBOX_DOCKER_SOCKET:-0}" = "1" ] && ! command -v docker`,
 		`https://download.docker.com/linux/${ID}/gpg`,
+		localContainerDockerSigningKeyFingerprint,
+		`install_verified_apt_keyring`,
+		`GNUPGHOME="$apt_key_home" gpg --batch --import`,
+		`GNUPGHOME="$apt_key_home" gpg --batch --export`,
+		`signed-by=/etc/apt/keyrings/docker.gpg`,
+		`mv -f "$apt_key_output" "$apt_key_target"`,
+		`rm -f /etc/apt/keyrings/docker.asc`,
+		`Docker APT signing key verification failed; falling back to distro Docker CLI`,
 		`if apt-get update && apt-get install -y --no-install-recommends docker-ce-cli; then`,
 		`rm -f /etc/apt/sources.list.d/docker.list`,
 		`apt-get install -y --no-install-recommends docker-ce-cli`,
@@ -1480,6 +1489,102 @@ func TestBootstrapScriptSupportsDockerSocketCLI(t *testing.T) {
 		if !strings.Contains(bootstrapScript, want) {
 			t.Fatalf("bootstrap script missing %q", want)
 		}
+	}
+	if strings.Contains(bootstrapScript, `curl -fsSL "https://download.docker.com/linux/${ID}/gpg" -o /etc/apt/keyrings/docker.asc`) {
+		t.Fatal("bootstrap script downloads Docker trust directly into the final keyring")
+	}
+	cmd := exec.Command("sh", "-n")
+	cmd.Stdin = strings.NewReader(bootstrapScript)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("bootstrap script syntax: %v\n%s", err, output)
+	}
+}
+
+func TestInstallVerifiedAPTKeyringScript(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		actualFingerprint string
+		wantSuccess       bool
+	}{
+		{name: "matching primary", actualFingerprint: localContainerDockerSigningKeyFingerprint, wantSuccess: true},
+		{name: "mismatched primary", actualFingerprint: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", wantSuccess: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			bin := filepath.Join(dir, "bin")
+			if err := os.Mkdir(bin, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			curlScript := "#!/bin/sh\nset -eu\nprintf 'fake-docker-key\\n'\n"
+			if err := os.WriteFile(filepath.Join(bin, "curl"), []byte(curlScript), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			gpgScript := `#!/bin/sh
+set -eu
+mode=""
+value=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --batch|--with-colons) shift ;;
+    --import|--fingerprint|--export)
+      mode="${1#--}"
+      value="${2:-}"
+      shift 2
+      ;;
+    *) exit 64 ;;
+  esac
+done
+case "$mode" in
+  import) [ -s "$value" ] ;;
+  fingerprint) printf 'fpr:::::::::%s:\n' "$FAKE_GPG_FINGERPRINT" ;;
+  export) printf 'fake-export:%s\n' "$value" ;;
+  *) exit 65 ;;
+esac
+`
+			if err := os.WriteFile(filepath.Join(bin, "gpg"), []byte(gpgScript), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			target := filepath.Join(dir, "keyrings", "docker.gpg")
+			if err := os.Mkdir(filepath.Dir(target), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(target, []byte("existing-keyring\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			script := "set -eu\n" + installVerifiedAPTKeyringScript + `
+install_verified_apt_keyring "$1" "$2" "$3"
+`
+			cmd := exec.Command("sh", "-c", script, "test", "https://download.docker.com/linux/ubuntu/gpg", target, localContainerDockerSigningKeyFingerprint)
+			cmd.Env = append(os.Environ(),
+				"PATH="+bin+string(os.PathListSeparator)+os.Getenv("PATH"),
+				"FAKE_GPG_FINGERPRINT="+tc.actualFingerprint,
+			)
+			output, err := cmd.CombinedOutput()
+			if tc.wantSuccess && err != nil {
+				t.Fatalf("verified key install failed: %v\n%s", err, output)
+			}
+			if !tc.wantSuccess && err == nil {
+				t.Fatal("mismatched key install succeeded")
+			}
+			got, readErr := os.ReadFile(target)
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			want := "existing-keyring\n"
+			if tc.wantSuccess {
+				want = "fake-export:" + localContainerDockerSigningKeyFingerprint + "\n"
+			}
+			if string(got) != want {
+				t.Fatalf("keyring = %q, want %q", got, want)
+			}
+			tempFiles, globErr := filepath.Glob(target + ".tmp.*")
+			if globErr != nil {
+				t.Fatal(globErr)
+			}
+			if len(tempFiles) != 0 {
+				t.Fatalf("temporary key state remains: %v", tempFiles)
+			}
+		})
 	}
 }
 

--- a/scripts/install-linux-developer-tools.sh
+++ b/scripts/install-linux-developer-tools.sh
@@ -15,6 +15,8 @@ chromium_policy_dir="${CRABBOX_LINUX_CHROMIUM_POLICY_DIR:-/etc/chromium/policies
 browser_bin_dir="${CRABBOX_LINUX_BROWSER_BIN_DIR:-/usr/local/bin}"
 browser_state_dir="${CRABBOX_LINUX_BROWSER_STATE_DIR:-/var/lib/crabbox}"
 chrome_defaults_file="${CRABBOX_LINUX_CHROME_DEFAULTS_FILE:-/etc/default/google-chrome}"
+nodesource_signing_key_fingerprint="6F71F525282841EEDAF851B42F59B5F99B1BE0B4"
+docker_signing_key_fingerprint="9DC858229FC7DD38854AE2D88D81803C0EBFCD88"
 google_linux_signing_key_fingerprint="EB4C1BFD4F042F6DDDCCEC917721F63BD38B4796"
 
 log() {
@@ -66,42 +68,32 @@ os_release_value() {
 install_apt_keyring() {
   local url="$1"
   local target="$2"
-  local expected_fingerprint="${3:-}"
+  local expected_fingerprint="$3"
   local actual_fingerprint=""
-  local downloaded_key=""
-  local key_home=""
+  local downloaded_key
+  local key_home
   local tmp_dir
   local tmp_key
   install -d -m 0755 "$(dirname "$target")"
   tmp_dir="$(mktemp -d "${target}.tmp.XXXXXX")"
   tmp_key="$tmp_dir/keyring.gpg"
-  if [[ -n "$expected_fingerprint" ]]; then
-    downloaded_key="$tmp_dir/downloaded.asc"
-    key_home="$tmp_dir/gnupg"
-    install -d -m 0700 "$key_home"
-    if curl -fsSL "$url" >"$downloaded_key" &&
-      GNUPGHOME="$key_home" gpg --batch --import "$downloaded_key" >/dev/null 2>&1; then
-      actual_fingerprint="$(
-        GNUPGHOME="$key_home" gpg --batch --with-colons --fingerprint "$expected_fingerprint" 2>/dev/null |
-          awk -F: '$1 == "fpr" { print $10; exit }' || true
-      )"
-      if [[ "$actual_fingerprint" == "$expected_fingerprint" ]] &&
-        GNUPGHOME="$key_home" gpg --batch --export "$expected_fingerprint" >"$tmp_key" &&
-        [[ -s "$tmp_key" ]]; then
-        chmod 0644 "$tmp_key"
-        mv -f "$tmp_key" "$target"
-        rm -rf "$tmp_dir"
-        return 0
-      fi
+  downloaded_key="$tmp_dir/downloaded.asc"
+  key_home="$tmp_dir/gnupg"
+  install -d -m 0700 "$key_home"
+  if curl -fsSL "$url" >"$downloaded_key" &&
+    GNUPGHOME="$key_home" gpg --batch --import "$downloaded_key" >/dev/null 2>&1; then
+    actual_fingerprint="$(
+      GNUPGHOME="$key_home" gpg --batch --with-colons --fingerprint "$expected_fingerprint" 2>/dev/null |
+        awk -F: '$1 == "fpr" { print $10; exit }' || true
+    )"
+    if [[ "$actual_fingerprint" == "$expected_fingerprint" ]] &&
+      GNUPGHOME="$key_home" gpg --batch --export "$expected_fingerprint" >"$tmp_key" &&
+      [[ -s "$tmp_key" ]]; then
+      chmod 0644 "$tmp_key"
+      mv -f "$tmp_key" "$target"
+      rm -rf "$tmp_dir"
+      return 0
     fi
-    rm -rf "$tmp_dir"
-    return 1
-  fi
-  if curl -fsSL "$url" | gpg --batch --yes --dearmor -o "$tmp_key"; then
-    chmod 0644 "$tmp_key"
-    mv -f "$tmp_key" "$target"
-    rmdir "$tmp_dir" 2>/dev/null || rm -rf "$tmp_dir"
-    return 0
   fi
   rm -rf "$tmp_dir"
   return 1
@@ -125,17 +117,28 @@ node_toolchain_ready() {
 }
 
 add_nodesource() {
-  if node_toolchain_ready; then
+  local source="$apt_sources_dir/nodesource.list"
+  local source_tmp
+  if node_toolchain_ready && [[ ! -e "$source" ]]; then
     return 0
   fi
   install -d -m 0755 "$apt_sources_dir"
-  install_apt_keyring "https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key" "$apt_keyrings_dir/nodesource.gpg"
-  printf 'deb [signed-by=%s/nodesource.gpg] https://deb.nodesource.com/node_%s.x nodistro main\n' "$apt_keyrings_dir" "$node_major" \
-    >"$apt_sources_dir/nodesource.list"
+  install_apt_keyring \
+    "https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key" \
+    "$apt_keyrings_dir/nodesource.gpg" \
+    "$nodesource_signing_key_fingerprint"
+  source_tmp="$(mktemp "${source}.tmp.XXXXXX")"
+  if ! printf 'deb [signed-by=%s/nodesource.gpg] https://deb.nodesource.com/node_%s.x nodistro main\n' "$apt_keyrings_dir" "$node_major" \
+    >"$source_tmp" || ! chmod 0644 "$source_tmp" || ! mv -f "$source_tmp" "$source"; then
+    rm -f "$source_tmp"
+    return 1
+  fi
 }
 
 add_docker_repo() {
-  if docker_packages_installed; then
+  local source="$apt_sources_dir/docker.list"
+  local source_tmp
+  if docker_packages_installed && [[ ! -e "$source" ]]; then
     return 0
   fi
   local distro_id codename arch
@@ -158,9 +161,16 @@ add_docker_repo() {
     exit 2
   fi
   install -d -m 0755 "$apt_sources_dir"
-  install_apt_keyring "https://download.docker.com/linux/${distro_id}/gpg" "$apt_keyrings_dir/docker.gpg"
-  printf 'deb [arch=%s signed-by=%s/docker.gpg] https://download.docker.com/linux/%s %s stable\n' "$arch" "$apt_keyrings_dir" "$distro_id" "$codename" \
-    >"$apt_sources_dir/docker.list"
+  install_apt_keyring \
+    "https://download.docker.com/linux/${distro_id}/gpg" \
+    "$apt_keyrings_dir/docker.gpg" \
+    "$docker_signing_key_fingerprint"
+  source_tmp="$(mktemp "${source}.tmp.XXXXXX")"
+  if ! printf 'deb [arch=%s signed-by=%s/docker.gpg] https://download.docker.com/linux/%s %s stable\n' "$arch" "$apt_keyrings_dir" "$distro_id" "$codename" \
+    >"$source_tmp" || ! chmod 0644 "$source_tmp" || ! mv -f "$source_tmp" "$source"; then
+    rm -f "$source_tmp"
+    return 1
+  fi
 }
 
 install_chrome_or_chromium() {

--- a/scripts/install-linux-developer-tools.test.js
+++ b/scripts/install-linux-developer-tools.test.js
@@ -6,6 +6,8 @@ import { spawnSync } from "node:child_process";
 import test from "node:test";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
+const nodesourceSigningKeyFingerprint = "6F71F525282841EEDAF851B42F59B5F99B1BE0B4";
+const dockerSigningKeyFingerprint = "9DC858229FC7DD38854AE2D88D81803C0EBFCD88";
 const googleLinuxSigningKeyFingerprint = "EB4C1BFD4F042F6DDDCCEC917721F63BD38B4796";
 
 function writeExecutable(file, body) {
@@ -19,24 +21,15 @@ function writeFakeGPG(bin) {
 		`#!/usr/bin/env bash
 set -euo pipefail
 mode=""
-output=""
 value=""
 while [[ "$#" -gt 0 ]]; do
   case "$1" in
-    --batch|--yes|--with-colons)
-      shift
-      ;;
-    --dearmor)
-      mode="dearmor"
+    --batch|--with-colons)
       shift
       ;;
     --import|--fingerprint|--export)
       mode="\${1#--}"
       value="\${2:-}"
-      shift 2
-      ;;
-    -o)
-      output="\${2:-}"
       shift 2
       ;;
     *)
@@ -46,17 +39,12 @@ while [[ "$#" -gt 0 ]]; do
   esac
 done
 case "$mode" in
-  dearmor)
-    [[ -n "$output" ]] || exit 65
-    cat >"$output"
-    printf '%s\\n' "$output" >>"$CRABBOX_FAKE_GPG_LOG"
-    ;;
   import)
     [[ -s "$value" ]] || exit 66
     ;;
   fingerprint)
     printf 'pub:-:4096:1:7721F63BD38B4796:0::::::scSC::::::23::0:\\n'
-    printf 'fpr:::::::::%s:\\n' "\${CRABBOX_FAKE_GPG_FINGERPRINT:-${googleLinuxSigningKeyFingerprint}}"
+    printf 'fpr:::::::::%s:\\n' "\${CRABBOX_FAKE_GPG_FINGERPRINT:-$value}"
     ;;
   export)
     printf 'fake-export:%s\\n' "$value"
@@ -198,10 +186,149 @@ exit 1
 	assert.equal(fs.existsSync(path.join(browserBin, "crabbox-browser")), true);
 	assert.match(fs.readFileSync(path.join(browserState, "browser.env"), "utf8"), new RegExp(`CHROME_BIN=${browserBin}/crabbox-browser`));
 	assert.equal(
+		fs.readFileSync(path.join(keyrings, "nodesource.gpg"), "utf8"),
+		`fake-export:${nodesourceSigningKeyFingerprint}\n`,
+	);
+	assert.equal(
+		fs.readFileSync(path.join(keyrings, "docker.gpg"), "utf8"),
+		`fake-export:${dockerSigningKeyFingerprint}\n`,
+	);
+	assert.equal(
 		fs.readFileSync(path.join(keyrings, "google-linux.gpg"), "utf8"),
 		`fake-export:${googleLinuxSigningKeyFingerprint}\n`,
 	);
 });
+
+for (const repository of [
+	{
+		name: "NodeSource",
+		functionCall: "node_toolchain_ready() { return 0; }; add_nodesource",
+		keyring: "nodesource.gpg",
+		source: "nodesource.list",
+		expectedFingerprint: nodesourceSigningKeyFingerprint,
+	},
+	{
+		name: "Docker",
+		functionCall: "docker_packages_installed() { return 0; }; add_docker_repo",
+		keyring: "docker.gpg",
+		source: "docker.list",
+		expectedFingerprint: dockerSigningKeyFingerprint,
+	},
+]) {
+	test(`linux developer tool setup preserves installed ${repository.name} trust files on fingerprint mismatch`, () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-linux-tools-repo-mismatch-"));
+		const bin = path.join(dir, "bin");
+		const keyrings = path.join(dir, "keyrings");
+		const sources = path.join(dir, "sources");
+		const osRelease = path.join(dir, "os-release");
+		const target = path.join(keyrings, repository.keyring);
+		const source = path.join(sources, repository.source);
+		const log = path.join(dir, "gpg.log");
+		fs.mkdirSync(bin);
+		fs.mkdirSync(keyrings);
+		fs.mkdirSync(sources);
+		fs.writeFileSync(osRelease, "ID='ubuntu'\nVERSION_CODENAME='noble'\n", "utf8");
+		fs.writeFileSync(target, "existing-keyring\n", "utf8");
+		fs.writeFileSync(source, "existing-source\n", "utf8");
+		fs.writeFileSync(log, "", "utf8");
+		writeExecutable(
+			path.join(bin, "curl"),
+			`#!/usr/bin/env bash
+set -euo pipefail
+printf 'unexpected-key\n'
+`,
+		);
+		writeExecutable(
+			path.join(bin, "dpkg"),
+			`#!/usr/bin/env bash
+[[ "$*" == "--print-architecture" ]] && printf 'amd64\n'
+`,
+		);
+		writeFakeGPG(bin);
+
+		const result = spawnSync(
+			"bash",
+			["-c", ["set -euo pipefail", "source scripts/install-linux-developer-tools.sh", repository.functionCall].join("\n")],
+			{
+				cwd: repoRoot,
+				env: {
+					...process.env,
+					PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}`,
+					CRABBOX_FAKE_GPG_FINGERPRINT: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+					CRABBOX_FAKE_GPG_LOG: log,
+					CRABBOX_LINUX_APT_KEYRINGS_DIR: keyrings,
+					CRABBOX_LINUX_APT_SOURCES_DIR: sources,
+					CRABBOX_LINUX_OS_RELEASE_FILE: osRelease,
+				},
+				encoding: "utf8",
+			},
+		);
+
+		assert.notEqual(result.status, 0, "mismatched repository keys must fail closed");
+		assert.equal(fs.readFileSync(target, "utf8"), "existing-keyring\n");
+		assert.equal(fs.readFileSync(source, "utf8"), "existing-source\n");
+		assert.equal(fs.readFileSync(log, "utf8"), "", "mismatched keys should not be exported");
+		assert.equal(
+			fs.readdirSync(keyrings).filter((name) => name.includes(".tmp.")).length,
+			0,
+			"temporary keyring directories should be removed",
+		);
+	});
+
+	test(`linux developer tool setup refreshes installed ${repository.name} trust files after fingerprint verification`, () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-linux-tools-repo-refresh-"));
+		const bin = path.join(dir, "bin");
+		const keyrings = path.join(dir, "keyrings");
+		const sources = path.join(dir, "sources");
+		const osRelease = path.join(dir, "os-release");
+		const target = path.join(keyrings, repository.keyring);
+		const source = path.join(sources, repository.source);
+		const log = path.join(dir, "gpg.log");
+		fs.mkdirSync(bin);
+		fs.mkdirSync(keyrings);
+		fs.mkdirSync(sources);
+		fs.writeFileSync(osRelease, "ID='ubuntu'\nVERSION_CODENAME='noble'\n", "utf8");
+		fs.writeFileSync(target, "existing-keyring\n", "utf8");
+		fs.writeFileSync(source, "existing-source\n", "utf8");
+		fs.writeFileSync(log, "", "utf8");
+		writeExecutable(
+			path.join(bin, "curl"),
+			`#!/usr/bin/env bash
+set -euo pipefail
+printf 'reviewed-key\n'
+`,
+		);
+		writeExecutable(
+			path.join(bin, "dpkg"),
+			`#!/usr/bin/env bash
+[[ "$*" == "--print-architecture" ]] && printf 'amd64\n'
+`,
+		);
+		writeFakeGPG(bin);
+
+		const result = spawnSync(
+			"bash",
+			["-c", ["set -euo pipefail", "source scripts/install-linux-developer-tools.sh", repository.functionCall].join("\n")],
+			{
+				cwd: repoRoot,
+				env: {
+					...process.env,
+					PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}`,
+					CRABBOX_FAKE_GPG_LOG: log,
+					CRABBOX_LINUX_APT_KEYRINGS_DIR: keyrings,
+					CRABBOX_LINUX_APT_SOURCES_DIR: sources,
+					CRABBOX_LINUX_OS_RELEASE_FILE: osRelease,
+				},
+				encoding: "utf8",
+			},
+		);
+
+		assert.equal(result.status, 0, result.stderr || result.stdout);
+		assert.equal(fs.readFileSync(target, "utf8"), `fake-export:${repository.expectedFingerprint}\n`);
+		assert.notEqual(fs.readFileSync(source, "utf8"), "existing-source\n");
+		assert.match(fs.readFileSync(source, "utf8"), new RegExp(`signed-by=${keyrings}/${repository.keyring}`));
+	});
+}
 
 test("linux developer tool setup preserves Google trust files and falls back on fingerprint mismatch", () => {
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-linux-tools-mismatch-"));


### PR DESCRIPTION
## Summary

- pin the reviewed NodeSource and Docker primary signing fingerprints in managed Linux image preparation
- import keys into isolated temporary GnuPG homes and atomically replace repository-scoped keyrings only after exact primary-fingerprint verification
- reverify managed NodeSource and Docker sources even when their toolchains are already installed, preserving prior keyrings and source files on mismatch
- apply the Docker pin to local-container Docker CLI bootstrap, with a distro `docker.io` fallback when verification is unavailable or fails
- document the managed Linux APT trust and intentional key-rotation process

Google's Linux repository key is already pinned by the prior browser-trust fix; this completes the remaining NodeSource and Docker scope.

Closes https://github.com/openclaw/crabbox/issues/687

## Verification

- `bash -n scripts/install-linux-developer-tools.sh`
- `shellcheck scripts/install-linux-developer-tools.sh`
- `node --test scripts/install-linux-developer-tools.test.js`
- `node --test scripts/*.test.js` — 351 tests
- `go test -race ./internal/providers/localcontainer -count=1`
- `go vet ./...`
- `node scripts/build-docs-site.mjs`
- Codex autoreview: clean

## Live compatibility proof

Read-only Docker canaries passed on Ubuntu 24.04, Ubuntu 26.04, Debian bookworm, and Debian trixie. Every image verified the exact NodeSource and Docker fingerprints, generated exact `signed-by` source entries, completed `apt-get update`, and exposed install candidates for Node.js 24, Docker CE/CLI, and containerd. All containers used `--rm`; final canary inventory was empty.
