### PR TITLE
fix(worker): bind provider keys to leases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 - Restricted brokered AWS and GCP resource selectors to admin-authenticated requests so normal users cannot steer coordinator cloud credentials toward caller-selected networks, images, projects, tags, or instance identities. Thanks @coygeek.
 - Pinned NodeSource and Docker APT signing fingerprints across managed Linux image preparation and local-container Docker CLI bootstrap, preserving existing trust files, stopping image preparation on mismatch, and using distro packages for local-container fallback. Thanks @coygeek.
+- Bound non-admin coordinator provider-key names and automatic cleanup to verified, persisted lease ownership metadata, rejecting unsafe AWS and Hetzner name collisions while retaining legacy and Hetzner provider-unique shared key identities. Thanks @coygeek.
 - Pinned the Windows developer-image Node MSI and Docker Engine archive to reviewed SHA-256 digests before privileged installation, with fail-closed digest requirements for version overrides. Thanks @coygeek.
 - Restored direct and brokered AWS Windows developer-image candidate capture by routing the guarded mint wrapper through native AMI checkpoints while retaining brokered promotion.
 - Prevented direct AWS raw-instance release from reaching deletion unless canonical Crabbox ownership tags match the resolved lease, with a second guard at the destructive provider boundary. Thanks @TurboTheTurtle.

--- a/docs/features/identifiers.md
+++ b/docs/features/identifiers.md
@@ -180,7 +180,18 @@ Keys are `ed25519` by default; AWS and Azure Windows leases use a 4096-bit RSA
 key instead (`ensureTestboxKeyForConfig`). The provisional-to-final lease ID
 move renames the whole directory so the private key, public key, and any
 `known_hosts` entries migrate together. The provider key name registered with
-the cloud account is `crabbox-cbx-abcdef123456` (`providerKeyForLease`).
+the cloud account is `crabbox-cbx-abcdef123456` (`providerKeyForLease`). Ordinary
+coordinator callers cannot override this lease-bound name; custom provider key
+names require admin authentication and are retained when a lease is released.
+Canonical `crabbox-cbx-*` names remain reserved for their encoded lease ID even
+for admin callers.
+AWS reuses an existing lease-bound key only when both its public key material
+and provider ownership metadata match the canonical lease ID. Hetzner applies
+the same check to an exact-name match. Because Hetzner makes public-key material
+account-unique, a differently named identity match is recorded as the lease's
+actual shared provider key without cleanup ownership and is retained. Cleanup
+requires that persisted ownership decision, re-reads provider ownership
+metadata, and leaves legacy, unowned, shared, or custom keys intact.
 
 ## Resolving An Identifier
 

--- a/worker/src/aws.ts
+++ b/worker/src/aws.ts
@@ -12,6 +12,12 @@ import {
   type LeaseConfig,
 } from "./config";
 import { osImageSpec } from "./os-image";
+import {
+  leaseIDForProviderKey,
+  providerKeyForLease,
+  providerKeyOwnedByLease,
+  sshPublicKeyIdentity,
+} from "./provider-key";
 import { leaseProviderLabels } from "./provider-labels";
 import { leaseProviderName } from "./slug";
 import type {
@@ -317,7 +323,7 @@ export class EC2SpotClient {
     market?: string;
     attempts?: ProvisioningAttempt[];
   }> {
-    await this.ensureSSHKey(config.providerKey, config.sshPublicKey);
+    await this.ensureSSHKey(config.providerKey, config.sshPublicKey, leaseID);
     let transientImageID = "";
     try {
       const defaultImageID = config.awsSnapshot
@@ -1020,8 +1026,30 @@ export class EC2SpotClient {
     throw lastError;
   }
 
-  async deleteSSHKey(name: string): Promise<void> {
-    await this.ec2("DeleteKeyPair", { KeyName: name }).catch((error: unknown) => {
+  async deleteSSHKey(name: string, leaseID: string): Promise<void> {
+    if (name !== providerKeyForLease(leaseID)) {
+      return;
+    }
+    let described: Record<string, unknown>;
+    try {
+      described = await this.ec2("DescribeKeyPairs", { "KeyName.1": name });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (message.includes("InvalidKeyPair.NotFound")) {
+        return;
+      }
+      throw error;
+    }
+    const existing = items(record(described["keySet"])["item"]).map(record)[0];
+    if (!existing || !providerKeyOwnedByLease(tagMap(existing["tagSet"]), leaseID)) {
+      console.warn(`AWS SSH key cleanup skipped unowned key lease=${leaseID} key=${name}`);
+      return;
+    }
+    const keyPairID = asString(existing["keyPairId"]);
+    if (!keyPairID) {
+      throw new Error(`AWS SSH key ${name} is missing its immutable key pair ID`);
+    }
+    await this.ec2("DeleteKeyPair", { KeyPairId: keyPairID }).catch((error: unknown) => {
       const message = error instanceof Error ? error.message : String(error);
       if (!message.includes("InvalidKeyPair.NotFound")) {
         throw error;
@@ -1035,17 +1063,42 @@ export class EC2SpotClient {
     await this.ec2("CreateTags", params);
   }
 
-  private async ensureSSHKey(name: string, publicKey: string): Promise<void> {
+  private async ensureSSHKey(name: string, publicKey: string, leaseID: string): Promise<void> {
+    const keyLeaseID = leaseIDForProviderKey(name);
+    if (keyLeaseID && keyLeaseID !== leaseID) {
+      throw new Error(`aws ssh key ${name} is reserved for lease ${keyLeaseID}`);
+    }
+    const leaseOwned = keyLeaseID === leaseID;
+    let described: Record<string, unknown> | undefined;
     try {
-      await this.ec2("DescribeKeyPairs", { "KeyName.1": name });
-      return;
+      described = await this.ec2("DescribeKeyPairs", {
+        IncludePublicKey: "true",
+        "KeyName.1": name,
+      });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       if (!message.includes("InvalidKeyPair.NotFound")) {
         throw error;
       }
     }
-    await this.ec2("ImportKeyPair", {
+    if (described) {
+      const existing = items(record(described["keySet"])["item"]).map(record)[0];
+      if (!existing) {
+        throw new Error(`aws ssh key ${name} could not be read`);
+      }
+      const existingPublicKey = asString(existing["publicKey"]);
+      if (
+        !existingPublicKey ||
+        sshPublicKeyIdentity(existingPublicKey) !== sshPublicKeyIdentity(publicKey)
+      ) {
+        throw new Error(`aws ssh key ${name} exists with different public key`);
+      }
+      if (leaseOwned && !providerKeyOwnedByLease(tagMap(existing["tagSet"]), leaseID)) {
+        throw new Error(`aws ssh key ${name} is not owned by lease ${leaseID}`);
+      }
+      return;
+    }
+    const params: Record<string, string> = {
       KeyName: name,
       PublicKeyMaterial: btoa(publicKey),
       "TagSpecification.1.ResourceType": "key-pair",
@@ -1053,7 +1106,12 @@ export class EC2SpotClient {
       "TagSpecification.1.Tag.1.Value": "true",
       "TagSpecification.1.Tag.2.Key": "created_by",
       "TagSpecification.1.Tag.2.Value": "crabbox",
-    });
+    };
+    if (leaseOwned) {
+      params["TagSpecification.1.Tag.3.Key"] = "lease";
+      params["TagSpecification.1.Tag.3.Value"] = leaseID;
+    }
+    await this.ec2("ImportKeyPair", params);
   }
 
   private async createServer(

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -14934,6 +14934,10 @@ function provisionedLeaseRecord(
   serverType: string,
 ): LeaseRecord {
   const providerProject = lease.providerProject ?? providerProjectForConfig(config);
+  const providerKey = server.providerKey?.trim() || config.providerKey;
+  const providerKeyCleanupOwned =
+    (config.provider === "aws" || config.provider === "hetzner") &&
+    providerKey === providerKeyForLease(lease.id);
   return {
     ...lease,
     state: "active",
@@ -14941,6 +14945,8 @@ function provisionedLeaseRecord(
     serverID: server.id,
     serverName: server.name,
     serverType,
+    providerKey,
+    providerKeyCleanupOwned,
     host: server.host,
     region: server.region ?? lease.region ?? providerRegionForConfig(config) ?? "",
     ...(providerProject ? { providerProject } : {}),

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -49,7 +49,6 @@ import {
   HetznerClient,
   hetznerProvisioningFailureMayHaveResource,
   hetznerProvisioningFailureRetryable,
-  sshPublicKeyIdentity,
 } from "./hetzner";
 import { bearerToken, errorMessage, json, pathParts, readJson, requestOwner } from "./http";
 import {
@@ -79,6 +78,7 @@ import {
   type PortalMacHostRecord,
   webVNCBridgeCommand,
 } from "./portal";
+import { leaseIDForProviderKey, providerKeyForLease, sshPublicKeyIdentity } from "./provider-key";
 import {
   readRuntimeAdapterRelayBody,
   runtimeAdapterProxyPath,
@@ -1771,9 +1771,38 @@ export class FleetCoordinator {
     if (retainedMacHostLease && !config.serverTypeExplicit) {
       config = { ...config, serverType: retainedMacHostLease.serverType };
     }
+    if (retainedMacHostLease) {
+      config = { ...config, providerKey: retainedMacHostLease.providerKey };
+    }
     const leaseID = validLeaseID(input.leaseID) ? input.leaseID : newLeaseID();
+    const canonicalProviderKey = providerKeyForLease(leaseID);
+    const providerKeyLeaseID = leaseIDForProviderKey(config.providerKey);
+    if (!retainedMacHostLease && providerKeyLeaseID && providerKeyLeaseID !== leaseID) {
+      return json(
+        {
+          error: "reserved_provider_key",
+          message: `provider key ${config.providerKey} is reserved for lease ${providerKeyLeaseID}`,
+        },
+        { status: 400 },
+      );
+    }
+    if (
+      !workspaceID &&
+      !retainedMacHostLease &&
+      !isAdminRequest(request) &&
+      config.providerKey &&
+      config.providerKey !== canonicalProviderKey
+    ) {
+      return json(
+        {
+          error: "admin_required",
+          message: "custom provider key names require admin-token auth",
+        },
+        { status: 403 },
+      );
+    }
     if (!config.providerKey) {
-      config = { ...config, providerKey: providerKeyForLease(leaseID) };
+      config = { ...config, providerKey: canonicalProviderKey };
     }
     config = (await configProvider.prepareLeaseConfig?.(config)) ?? config;
     const readiness = this.providerConfigurationReadiness(
@@ -12229,10 +12258,6 @@ function newLeaseID(): string {
   return `cbx_${[...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("")}`;
 }
 
-function providerKeyForLease(leaseID: string): string {
-  return `crabbox-${leaseID.replaceAll("_", "-")}`;
-}
-
 function validWorkspaceID(value: string | undefined): value is string {
   return (
     typeof value === "string" &&
@@ -13515,8 +13540,14 @@ export function recordAzureDeferredCleanup(
   });
 }
 
-function validCrabboxProviderKey(value: string | undefined): value is string {
-  return typeof value === "string" && /^crabbox-cbx-[a-f0-9]{12}$/.test(value);
+function leaseUsesCanonicalProviderKey(
+  lease: Pick<LeaseRecord, "id" | "providerKey" | "providerKeyCleanupOwned">,
+): boolean {
+  return (
+    lease.providerKeyCleanupOwned === true &&
+    validLeaseID(lease.id) &&
+    lease.providerKey === providerKeyForLease(lease.id)
+  );
 }
 
 function validExternalRunnerID(value: string | undefined): value is string {
@@ -15634,7 +15665,7 @@ interface CloudProvider {
     snapshotIDs: string[],
     availabilityZones?: string[],
   ): Promise<ProviderFastSnapshotRestore[]>;
-  deleteSSHKey(name: string): Promise<void>;
+  deleteSSHKey(name: string, leaseID: string): Promise<void>;
   hourlyPriceUSD(
     serverType: string,
     config: ReturnType<typeof leaseConfig>,
@@ -15704,17 +15735,30 @@ export class HetznerProvider implements CloudProvider {
     market?: string;
     attempts?: ProvisioningAttempt[];
   }> {
-    const { server, serverType } = await this.client.createServerWithFallback(
+    const { server, serverType, providerKey } = await this.client.createServerWithFallback(
       config,
       leaseID,
       slug,
       owner,
     );
-    return { server: this.client.toMachine(server), serverType };
+    return { server: { ...this.client.toMachine(server), providerKey }, serverType };
   }
 
   async deleteServer(id: string): Promise<void> {
     await this.client.deleteServer(Number(id));
+  }
+
+  async finalizeLeaseCreate(
+    config: ReturnType<typeof leaseConfig>,
+    lease: LeaseRecord,
+    server: ProviderMachine,
+  ): Promise<ProviderLeaseCreateFinalization> {
+    const providerKey = server.providerKey?.trim() || config.providerKey;
+    const providerKeyCleanupOwned = providerKey === providerKeyForLease(lease.id);
+    return {
+      config: { ...config, providerKey },
+      lease: { ...lease, providerKey, providerKeyCleanupOwned },
+    };
   }
 
   async releaseLease(lease: LeaseRecord): Promise<void> {
@@ -15725,11 +15769,8 @@ export class HetznerProvider implements CloudProvider {
         throw error;
       }
     }
-    if (
-      !lease.providerKey.startsWith(workspaceProviderKeyPrefix) &&
-      validCrabboxProviderKey(lease.providerKey)
-    ) {
-      await this.deleteSSHKey(lease.providerKey);
+    if (leaseUsesCanonicalProviderKey(lease)) {
+      await this.deleteSSHKey(lease.providerKey, lease.id);
     }
   }
 
@@ -15756,8 +15797,8 @@ export class HetznerProvider implements CloudProvider {
   decorateImage = passthroughProviderImage;
   validateDeleteImage = allowProviderImageDelete;
 
-  async deleteSSHKey(name: string): Promise<void> {
-    await this.client.deleteSSHKey(name);
+  async deleteSSHKey(name: string, leaseID: string): Promise<void> {
+    await this.client.deleteSSHKey(name, leaseID);
   }
 
   hourlyPriceUSD(
@@ -16397,7 +16438,11 @@ export class AWSProvider implements CloudProvider {
     attempts: ProvisioningAttempt[],
   ): Promise<ProviderLeaseCreateFinalization> {
     const nextConfig = server.region ? { ...config, awsRegion: server.region } : config;
-    const nextLease: LeaseRecord = { ...lease, region: server.region ?? nextConfig.awsRegion };
+    const nextLease: LeaseRecord = {
+      ...lease,
+      region: server.region ?? nextConfig.awsRegion,
+      providerKeyCleanupOwned: lease.providerKey === providerKeyForLease(lease.id),
+    };
     const hints = capacityHints(this.env, nextConfig, nextLease, attempts);
     if (hints.length > 0) {
       nextLease.capacityHints = hints;
@@ -16417,8 +16462,8 @@ export class AWSProvider implements CloudProvider {
         `AWS lease cleanup found missing instance lease=${lease.id} cloud=${lease.cloudID}: ${message}`,
       );
     }
-    if (validCrabboxProviderKey(lease.providerKey)) {
-      await this.deleteSSHKey(lease.providerKey);
+    if (leaseUsesCanonicalProviderKey(lease)) {
+      await this.deleteSSHKey(lease.providerKey, lease.id);
     }
   }
 
@@ -16682,8 +16727,8 @@ export class AWSProvider implements CloudProvider {
     return { image: promoted };
   }
 
-  async deleteSSHKey(name: string): Promise<void> {
-    await this.client.deleteSSHKey(name);
+  async deleteSSHKey(name: string, leaseID: string): Promise<void> {
+    await this.client.deleteSSHKey(name, leaseID);
   }
 
   hourlyPriceUSD(

--- a/worker/src/hetzner.ts
+++ b/worker/src/hetzner.ts
@@ -4,6 +4,13 @@ import {
   workspaceProviderKeyPrefix,
   type LeaseConfig,
 } from "./config";
+import {
+  leaseIDForProviderKey,
+  providerKeyForLease,
+  providerKeyOwnedByLease,
+  providerKeyOwnershipLabels,
+  sshPublicKeyIdentity,
+} from "./provider-key";
 import { leaseProviderLabels } from "./provider-labels";
 import { leaseProviderName } from "./slug";
 import type { Env, HetznerSSHKey, HetznerServer, ProviderMachine } from "./types";
@@ -94,8 +101,13 @@ export class HetznerClient {
     return response.servers[0];
   }
 
-  async ensureSSHKey(name: string, publicKey: string): Promise<HetznerSSHKey> {
+  async ensureSSHKey(name: string, publicKey: string, leaseID?: string): Promise<HetznerSSHKey> {
     const identity = sshPublicKeyIdentity(publicKey);
+    const keyLeaseID = leaseIDForProviderKey(name);
+    if (keyLeaseID && keyLeaseID !== leaseID) {
+      throw new Error(`hetzner ssh key ${name} is reserved for lease ${keyLeaseID}`);
+    }
+    const leaseOwned = leaseID !== undefined && keyLeaseID === leaseID;
     const byName = await this.request<HetznerListSSHKeysResponse>(
       "GET",
       `/ssh_keys?${new URLSearchParams({ name })}`,
@@ -105,32 +117,41 @@ export class HetznerClient {
         if (sshPublicKeyIdentity(key.public_key) !== identity) {
           throw new Error(`hetzner ssh key ${name} exists with different public key`);
         }
+        if (leaseOwned && !providerKeyOwnedByLease(key.labels ?? {}, leaseID)) {
+          throw new Error(`hetzner ssh key ${name} is not owned by lease ${leaseID}`);
+        }
         return key;
       }
     }
 
-    for (const key of await this.listSSHKeys()) {
-      if (sshPublicKeyIdentity(key.public_key) === identity) {
-        return key;
-      }
+    const existingIdentity = reusableHetznerSSHKey(
+      await this.listSSHKeys(),
+      name,
+      identity,
+      leaseOwned ? leaseID : undefined,
+    );
+    if (existingIdentity) {
+      return existingIdentity;
     }
 
     try {
       const created = await this.request<HetznerSSHKeyResponse>("POST", "/ssh_keys", {
         name,
         public_key: publicKey,
-        labels: {
-          crabbox: "true",
-          created_by: "crabbox",
-        },
+        labels: leaseOwned
+          ? providerKeyOwnershipLabels(leaseID)
+          : { crabbox: "true", created_by: "crabbox" },
       });
       return created.ssh_key;
     } catch (error) {
       if (!String(error).includes("uniqueness_error")) {
         throw error;
       }
-      const key = (await this.listSSHKeys()).find(
-        (entry) => sshPublicKeyIdentity(entry.public_key) === identity,
+      const key = reusableHetznerSSHKey(
+        await this.listSSHKeys(),
+        name,
+        identity,
+        leaseOwned ? leaseID : undefined,
       );
       if (key) {
         return key;
@@ -139,14 +160,19 @@ export class HetznerClient {
     }
   }
 
-  async deleteSSHKey(name: string): Promise<void> {
+  async deleteSSHKey(name: string, leaseID: string): Promise<void> {
+    if (name !== providerKeyForLease(leaseID)) {
+      return;
+    }
     const byName = await this.request<HetznerListSSHKeysResponse>(
       "GET",
       `/ssh_keys?${new URLSearchParams({ name })}`,
     );
     const key = byName.ssh_keys.find((entry) => entry.name === name);
-    if (key) {
+    if (key && providerKeyOwnedByLease(key.labels ?? {}, leaseID)) {
       await this.request<void>("DELETE", `/ssh_keys/${key.id}`);
+    } else if (key) {
+      console.warn(`Hetzner SSH key cleanup skipped unowned key lease=${leaseID} key=${name}`);
     }
   }
 
@@ -171,11 +197,11 @@ export class HetznerClient {
     leaseID: string,
     slug: string,
     owner: string,
-  ): Promise<{ server: HetznerServer; serverType: string }> {
+  ): Promise<{ server: HetznerServer; serverType: string; providerKey: string }> {
     const requireRunning = config.providerKey.startsWith(workspaceProviderKeyPrefix);
     let key: HetznerSSHKey;
     try {
-      key = await this.ensureSSHKey(config.providerKey, config.sshPublicKey);
+      key = await this.ensureSSHKey(config.providerKey, config.sshPublicKey, leaseID);
     } catch (error) {
       const message = errorText(error);
       throw new HetznerProvisioningError(message, false, transientHetznerError(message));
@@ -198,7 +224,7 @@ export class HetznerClient {
           owner,
           requireRunning,
         );
-        return { server, serverType };
+        return { server, serverType, providerKey: key.name };
       } catch (error) {
         const message = errorText(error);
         failures.push(`${serverType}: ${message}`);
@@ -336,11 +362,6 @@ export class HetznerClient {
   }
 }
 
-export function sshPublicKeyIdentity(publicKey: string): string {
-  const [type, encoded] = publicKey.trim().split(/\s+/, 3);
-  return type && encoded ? `${type} ${encoded}` : publicKey.trim();
-}
-
 export function isRetryableProvisioningError(message: string): boolean {
   return (
     message.includes("dedicated_core_limit") ||
@@ -348,6 +369,27 @@ export function isRetryableProvisioningError(message: string): boolean {
     message.includes("server_type_not_available") ||
     message.includes("location_not_available")
   );
+}
+
+function reusableHetznerSSHKey(
+  keys: HetznerSSHKey[],
+  requestedName: string,
+  identity: string,
+  leaseID?: string,
+): HetznerSSHKey | undefined {
+  const exact = keys.find((entry) => entry.name === requestedName);
+  if (exact) {
+    if (sshPublicKeyIdentity(exact.public_key) !== identity) {
+      throw new Error(`hetzner ssh key ${requestedName} exists with different public key`);
+    }
+    if (leaseID !== undefined && !providerKeyOwnedByLease(exact.labels ?? {}, leaseID)) {
+      throw new Error(`hetzner ssh key ${requestedName} is not owned by lease ${leaseID}`);
+    }
+    return exact;
+  }
+  // Hetzner makes public-key material account-unique. A differently named match
+  // is therefore shared and retained; lease finalization records its actual name.
+  return keys.find((entry) => sshPublicKeyIdentity(entry.public_key) === identity);
 }
 
 function prependUnique(first: string, rest: string[]): string[] {

--- a/worker/src/provider-key.ts
+++ b/worker/src/provider-key.ts
@@ -1,0 +1,22 @@
+export function providerKeyForLease(leaseID: string): string {
+  return `crabbox-${leaseID.replaceAll("_", "-")}`;
+}
+
+export function leaseIDForProviderKey(providerKey: string): string | undefined {
+  const match = /^crabbox-cbx-([a-f0-9]{12})$/.exec(providerKey);
+  return match ? `cbx_${match[1]}` : undefined;
+}
+
+export function providerKeyOwnershipLabels(leaseID: string): Record<string, string> {
+  return { crabbox: "true", created_by: "crabbox", lease: leaseID };
+}
+
+export function providerKeyOwnedByLease(labels: Record<string, string>, leaseID: string): boolean {
+  const expected = providerKeyOwnershipLabels(leaseID);
+  return Object.entries(expected).every(([key, value]) => labels[key] === value);
+}
+
+export function sshPublicKeyIdentity(publicKey: string): string {
+  const [type, encoded] = publicKey.trim().split(/\s+/, 3);
+  return type && encoded ? `${type} ${encoded}` : publicKey.trim();
+}

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -346,6 +346,7 @@ export interface LeaseRecord {
   serverID: number;
   serverName: string;
   providerKey: string;
+  providerKeyCleanupOwned?: boolean;
   host: string;
   sshUser: string;
   sshPort: string;
@@ -708,6 +709,7 @@ export interface HetznerSSHKey {
   name: string;
   fingerprint: string;
   public_key: string;
+  labels?: Record<string, string>;
 }
 
 export interface MachineView {
@@ -733,4 +735,5 @@ export interface ProviderMachine {
   hostID?: string;
   host: string;
   labels: Record<string, string>;
+  providerKey?: string;
 }

--- a/worker/test/aws.test.ts
+++ b/worker/test/aws.test.ts
@@ -37,6 +37,189 @@ afterEach(() => {
 });
 
 describe("aws provider", () => {
+  it("rejects a canonical SSH key name reserved for another lease", async () => {
+    const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>();
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new EC2SpotClient(
+      { AWS_ACCESS_KEY_ID: "test", AWS_SECRET_ACCESS_KEY: "secret" } as never,
+      "eu-west-1",
+    ) as unknown as {
+      ensureSSHKey(name: string, publicKey: string, leaseID: string): Promise<void>;
+    };
+
+    await expect(
+      client.ensureSSHKey(
+        "crabbox-cbx-000000000001",
+        "ssh-ed25519 requested-key",
+        "cbx_abcdef123456",
+      ),
+    ).rejects.toThrow("is reserved for lease cbx_000000000001");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("binds canonical SSH key reuse and deletion to lease ownership tags", async () => {
+    const actions: string[] = [];
+    let deleteParams: URLSearchParams | undefined;
+    let owned = false;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        const params = new URLSearchParams(await request.clone().text());
+        const action = params.get("Action") ?? "";
+        actions.push(action);
+        if (action === "DeleteKeyPair") deleteParams = params;
+        if (action === "DescribeKeyPairs") {
+          return ec2XMLResponse(`<DescribeKeyPairsResponse><keySet><item>
+            <keyName>crabbox-cbx-abcdef123456</keyName>
+            <publicKey>ssh-ed25519 requested-key old-comment</publicKey>
+            <keyPairId>key-immutable-1</keyPairId>
+            <tagSet><item><key>crabbox</key><value>true</value></item><item><key>created_by</key><value>crabbox</value></item><item><key>lease</key><value>${owned ? "cbx_abcdef123456" : "cbx_000000000001"}</value></item></tagSet>
+          </item></keySet></DescribeKeyPairsResponse>`);
+        }
+        return ec2XMLResponse(`<${action}Response />`);
+      }),
+    );
+    const client = new EC2SpotClient(
+      { AWS_ACCESS_KEY_ID: "test", AWS_SECRET_ACCESS_KEY: "secret" } as never,
+      "eu-west-1",
+    );
+    const keyClient = client as unknown as {
+      ensureSSHKey(name: string, publicKey: string, leaseID: string): Promise<void>;
+    };
+
+    await expect(
+      keyClient.ensureSSHKey(
+        "crabbox-cbx-abcdef123456",
+        "ssh-ed25519 requested-key new-comment",
+        "cbx_abcdef123456",
+      ),
+    ).rejects.toThrow("is not owned by lease cbx_abcdef123456");
+    owned = true;
+    await expect(
+      keyClient.ensureSSHKey(
+        "crabbox-cbx-abcdef123456",
+        "ssh-ed25519 requested-key new-comment",
+        "cbx_abcdef123456",
+      ),
+    ).resolves.toBeUndefined();
+
+    owned = false;
+    await client.deleteSSHKey("crabbox-cbx-abcdef123456", "cbx_abcdef123456");
+    owned = true;
+    await client.deleteSSHKey("crabbox-cbx-abcdef123456", "cbx_abcdef123456");
+    expect(actions).toEqual([
+      "DescribeKeyPairs",
+      "DescribeKeyPairs",
+      "DescribeKeyPairs",
+      "DescribeKeyPairs",
+      "DeleteKeyPair",
+    ]);
+    expect(deleteParams?.get("KeyPairId")).toBe("key-immutable-1");
+    expect(deleteParams?.get("KeyName")).toBeNull();
+  });
+
+  it("tags imported canonical SSH keys with their lease ID", async () => {
+    let importParams: URLSearchParams | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        const params = new URLSearchParams(await request.clone().text());
+        const action = params.get("Action") ?? "";
+        if (action === "DescribeKeyPairs") {
+          return ec2XMLResponse(
+            "<Response><Errors><Error><Code>InvalidKeyPair.NotFound</Code><Message>missing</Message></Error></Errors></Response>",
+            400,
+          );
+        }
+        importParams = params;
+        return ec2XMLResponse("<ImportKeyPairResponse />");
+      }),
+    );
+    const client = new EC2SpotClient(
+      { AWS_ACCESS_KEY_ID: "test", AWS_SECRET_ACCESS_KEY: "secret" } as never,
+      "eu-west-1",
+    ) as unknown as {
+      ensureSSHKey(name: string, publicKey: string, leaseID: string): Promise<void>;
+    };
+
+    await client.ensureSSHKey(
+      "crabbox-cbx-abcdef123456",
+      "ssh-ed25519 requested-key",
+      "cbx_abcdef123456",
+    );
+
+    expect(importParams?.get("Action")).toBe("ImportKeyPair");
+    expect(importParams?.get("TagSpecification.1.Tag.3.Key")).toBe("lease");
+    expect(importParams?.get("TagSpecification.1.Tag.3.Value")).toBe("cbx_abcdef123456");
+  });
+
+  it("refuses to delete an owned AWS SSH key without an immutable key pair ID", async () => {
+    const actions: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        const params = new URLSearchParams(await request.clone().text());
+        actions.push(params.get("Action") ?? "");
+        return ec2XMLResponse(`<DescribeKeyPairsResponse><keySet><item>
+          <keyName>crabbox-cbx-abcdef123456</keyName>
+          <tagSet><item><key>crabbox</key><value>true</value></item><item><key>created_by</key><value>crabbox</value></item><item><key>lease</key><value>cbx_abcdef123456</value></item></tagSet>
+        </item></keySet></DescribeKeyPairsResponse>`);
+      }),
+    );
+    const client = new EC2SpotClient(
+      { AWS_ACCESS_KEY_ID: "test", AWS_SECRET_ACCESS_KEY: "secret" } as never,
+      "eu-west-1",
+    );
+
+    await expect(
+      client.deleteSSHKey("crabbox-cbx-abcdef123456", "cbx_abcdef123456"),
+    ).rejects.toThrow("missing its immutable key pair ID");
+    expect(actions).toEqual(["DescribeKeyPairs"]);
+  });
+
+  it("rejects an existing SSH key with different public key material", async () => {
+    let describeParams: URLSearchParams | undefined;
+    const actions: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        const params = new URLSearchParams(await request.clone().text());
+        const action = params.get("Action") ?? "";
+        actions.push(action);
+        if (action === "DescribeKeyPairs") {
+          describeParams = params;
+          return ec2XMLResponse(
+            "<DescribeKeyPairsResponse><keySet><item><keyName>crabbox-cbx-abcdef123456</keyName><publicKey>ssh-ed25519 other-key</publicKey></item></keySet></DescribeKeyPairsResponse>",
+          );
+        }
+        return ec2XMLResponse("<UnexpectedResponse />", 500);
+      }),
+    );
+    const client = new EC2SpotClient(
+      { AWS_ACCESS_KEY_ID: "test", AWS_SECRET_ACCESS_KEY: "secret" } as never,
+      "eu-west-1",
+    );
+
+    await expect(
+      client.createServerWithFallback(
+        leaseConfig({
+          provider: "aws",
+          providerKey: "crabbox-cbx-abcdef123456",
+          sshPublicKey: "ssh-ed25519 requested-key",
+        }),
+        "cbx_abcdef123456",
+        "blue-lobster",
+        "alice@example.com",
+      ),
+    ).rejects.toThrow("aws ssh key crabbox-cbx-abcdef123456 exists with different public key");
+    expect(describeParams?.get("IncludePublicKey")).toBe("true");
+    expect(actions).toEqual(["DescribeKeyPairs"]);
+  });
+
   it("separates managed workspace and ordinary runner security groups", () => {
     expect(awsManagedSecurityGroupName({ providerKey: "crabbox-steipete" })).toBe(
       "crabbox-runners",
@@ -1254,7 +1437,9 @@ describe("aws provider", () => {
           return securityGroupResponse;
         }
         if (action === "DescribeKeyPairs") {
-          return ec2XMLResponse("<DescribeKeyPairsResponse />");
+          return ec2XMLResponse(
+            `<DescribeKeyPairsResponse><keySet><item><keyName>crabbox-cbx</keyName><publicKey>ssh-rsa ${"a".repeat(724)}</publicKey></item></keySet></DescribeKeyPairsResponse>`,
+          );
         }
         if (action === "DescribeImages") {
           return ec2XMLResponse(`<?xml version="1.0" encoding="UTF-8"?>
@@ -1345,7 +1530,9 @@ describe("aws provider", () => {
           return securityGroupResponse;
         }
         if (action === "DescribeKeyPairs") {
-          return ec2XMLResponse("<DescribeKeyPairsResponse />");
+          return ec2XMLResponse(
+            "<DescribeKeyPairsResponse><keySet><item><keyName>crabbox-cbx</keyName><publicKey>ssh-ed25519 test</publicKey></item></keySet></DescribeKeyPairsResponse>",
+          );
         }
         if (action === "DescribeImages") {
           const architecture = params.get("Filter.1.Value.1") ?? "";
@@ -1460,7 +1647,9 @@ describe("aws provider", () => {
           return securityGroupResponse;
         }
         if (action === "DescribeKeyPairs") {
-          return ec2XMLResponse("<DescribeKeyPairsResponse />");
+          return ec2XMLResponse(
+            "<DescribeKeyPairsResponse><keySet><item><keyName>crabbox-cbx</keyName><publicKey>ssh-ed25519 test</publicKey></item></keySet></DescribeKeyPairsResponse>",
+          );
         }
         if (action === "DescribeImages") {
           return ec2XMLResponse(`<?xml version="1.0" encoding="UTF-8"?>
@@ -1569,7 +1758,9 @@ describe("aws provider", () => {
           return securityGroupResponse;
         }
         if (action === "DescribeKeyPairs") {
-          return ec2XMLResponse("<DescribeKeyPairsResponse />");
+          return ec2XMLResponse(
+            "<DescribeKeyPairsResponse><keySet><item><keyName>crabbox-cbx</keyName><publicKey>ssh-ed25519 test</publicKey></item></keySet></DescribeKeyPairsResponse>",
+          );
         }
         if (action === "DescribeImages") {
           return ec2XMLResponse(`<?xml version="1.0" encoding="UTF-8"?>
@@ -1656,7 +1847,9 @@ describe("aws provider", () => {
         const securityGroupResponse = ec2ConfiguredSecurityGroupResponse(action, params);
         if (securityGroupResponse) return securityGroupResponse;
         if (action === "DescribeKeyPairs") {
-          return ec2XMLResponse("<DescribeKeyPairsResponse />");
+          return ec2XMLResponse(
+            "<DescribeKeyPairsResponse><keySet><item><keyName>crabbox-cbx</keyName><publicKey>ssh-ed25519 test</publicKey></item></keySet></DescribeKeyPairsResponse>",
+          );
         }
         if (action === "DescribeHosts") {
           describedHostIDs.push(params.get("HostId.1") ?? "");
@@ -1754,7 +1947,9 @@ describe("aws provider", () => {
           return securityGroupResponse;
         }
         if (action === "DescribeKeyPairs") {
-          return ec2XMLResponse("<DescribeKeyPairsResponse />");
+          return ec2XMLResponse(
+            "<DescribeKeyPairsResponse><keySet><item><keyName>crabbox-cbx</keyName><publicKey>ssh-ed25519 test</publicKey></item></keySet></DescribeKeyPairsResponse>",
+          );
         }
         if (action === "DescribeImages") {
           const architecture = params.get("Filter.1.Value.1") ?? "";
@@ -1857,7 +2052,9 @@ describe("aws provider", () => {
           return securityGroupResponse;
         }
         if (action === "DescribeKeyPairs") {
-          return ec2XMLResponse("<DescribeKeyPairsResponse />");
+          return ec2XMLResponse(
+            "<DescribeKeyPairsResponse><keySet><item><keyName>crabbox-cbx</keyName><publicKey>ssh-ed25519 test</publicKey></item></keySet></DescribeKeyPairsResponse>",
+          );
         }
         if (action === "DescribeImages") {
           return ec2XMLResponse(`<?xml version="1.0" encoding="UTF-8"?>
@@ -1956,7 +2153,9 @@ describe("aws provider", () => {
           return securityGroupResponse;
         }
         if (action === "DescribeKeyPairs") {
-          return ec2XMLResponse("<DescribeKeyPairsResponse />");
+          return ec2XMLResponse(
+            "<DescribeKeyPairsResponse><keySet><item><keyName>crabbox-cbx</keyName><publicKey>ssh-ed25519 test</publicKey></item></keySet></DescribeKeyPairsResponse>",
+          );
         }
         if (action === "DescribeHosts") {
           return ec2XMLResponse(`<?xml version="1.0" encoding="UTF-8"?>
@@ -2045,7 +2244,9 @@ describe("aws provider", () => {
           return securityGroupResponse;
         }
         if (action === "DescribeKeyPairs") {
-          return ec2XMLResponse("<DescribeKeyPairsResponse />");
+          return ec2XMLResponse(
+            "<DescribeKeyPairsResponse><keySet><item><keyName>crabbox-cbx</keyName><publicKey>ssh-ed25519 test</publicKey></item></keySet></DescribeKeyPairsResponse>",
+          );
         }
         if (action === "DescribeSubnets") {
           describeSubnetParams.push(params);

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -9858,6 +9858,80 @@ describe("fleet lease identity and idle", () => {
     });
   });
 
+  it.each([
+    { provider: "aws" as const, providerKey: "crabbox-cbx-abcdef123456", cleanupOwned: true },
+    {
+      provider: "hetzner" as const,
+      providerKey: "crabbox-cbx-abcdef123456",
+      cleanupOwned: true,
+    },
+    { provider: "hetzner" as const, providerKey: "shared-existing-key", cleanupOwned: false },
+  ])(
+    "preserves $provider provider-key ownership during provisioning cancellation cleanup",
+    async ({ provider, providerKey, cleanupOwned }) => {
+      const storage = new MemoryStorage();
+      const released: LeaseRecord[] = [];
+      let createStarted!: () => void;
+      let finishCreate!: () => void;
+      const createStartedPromise = new Promise<void>((resolve) => {
+        createStarted = resolve;
+      });
+      const finishCreatePromise = new Promise<void>((resolve) => {
+        finishCreate = resolve;
+      });
+      const fleet = testFleet(storage, {
+        [provider]: fakeProvider(
+          async () => {
+            createStarted();
+            await finishCreatePromise;
+          },
+          {
+            provider,
+            providerKey,
+            onReleaseLease: (lease) => {
+              released.push(structuredClone(lease));
+            },
+          },
+        ),
+      });
+      const headers = {
+        "x-crabbox-owner": "alice@example.com",
+        "x-crabbox-org": "example-org",
+      };
+      const createPromise = fleet.fetch(
+        request("POST", "/v1/leases", {
+          headers,
+          body: {
+            leaseID: "cbx_abcdef123456",
+            provider,
+            ...(provider === "aws" ? { awsUseStockImage: true } : {}),
+            ttlSeconds: 1200,
+            sshPublicKey: "ssh-ed25519 cancellation-test",
+          },
+        }),
+      );
+
+      await createStartedPromise;
+      const release = await fleet.fetch(
+        request("POST", "/v1/leases/cbx_abcdef123456/release", {
+          headers,
+          body: { delete: true },
+        }),
+      );
+      expect(release.status).toBe(200);
+
+      finishCreate();
+      expect((await createPromise).status).toBe(409);
+      expect(released).toHaveLength(1);
+      expect(released[0]).toMatchObject({
+        id: "cbx_abcdef123456",
+        provider,
+        providerKey,
+        providerKeyCleanupOwned: cleanupOwned,
+      });
+    },
+  );
+
   it("rejects a no-delete release after provisioning cleanup has started", async () => {
     const storage = new MemoryStorage();
     let createStarted!: () => void;
@@ -19614,6 +19688,7 @@ function fakeProvider(
     serverType?: string;
     hostID?: string;
     cloudID?: string;
+    providerKey?: string;
     region?: string;
     imageRegion?: string;
     market?: string;
@@ -19687,6 +19762,7 @@ function fakeProvider(
           lease: LeaseRecord;
         }
       | undefined;
+    onReleaseLease?: (lease: LeaseRecord) => Promise<void> | void;
     onRecoverServer?: (
       lease: LeaseRecord,
     ) => Promise<ProviderMachine | undefined> | ProviderMachine | undefined;
@@ -19826,6 +19902,7 @@ function fakeProvider(
           provider: result.provider ?? "hetzner",
           id: 123,
           cloudID: result.cloudID ?? "123",
+          ...(result.providerKey ? { providerKey: result.providerKey } : {}),
           name: `crabbox-${slug}`,
           status: "running",
           serverType: result.serverType ?? "cpx62",
@@ -19850,6 +19927,7 @@ function fakeProvider(
       await onDelete?.(id);
     },
     async releaseLease(lease: LeaseRecord) {
+      await result.onReleaseLease?.(lease);
       await onDelete?.(
         (lease.provider ?? result.provider) === "hetzner" ? String(lease.serverID) : lease.cloudID,
       );

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -3233,7 +3233,139 @@ describe("fleet lease identity and idle", () => {
     ).resolves.toEqual(existing);
   });
 
-  it("finds an existing Hetzner SSH key by identity on a later page", async () => {
+  it("rejects a canonical Hetzner uniqueness race without lease ownership", async () => {
+    const responses = [
+      jsonResponse({ ssh_keys: [] }),
+      jsonResponse({ ssh_keys: [] }),
+      jsonResponse({ error: { code: "uniqueness_error" } }, 409),
+      jsonResponse({
+        ssh_keys: [
+          {
+            id: 41,
+            name: "shared-existing-key",
+            fingerprint: "shared-fingerprint",
+            public_key: "ssh-ed25519 lease-test old-comment",
+            labels: { crabbox: "true", created_by: "crabbox" },
+          },
+          {
+            id: 42,
+            name: "crabbox-cbx-abcdef123456",
+            fingerprint: "fingerprint",
+            public_key: "ssh-ed25519 lease-test old-comment",
+            labels: {
+              crabbox: "true",
+              created_by: "crabbox",
+              lease: "cbx_000000000001",
+            },
+          },
+        ],
+      }),
+    ];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => responses.shift() ?? jsonResponse({}, 500)),
+    );
+    const client = new HetznerClient({ HETZNER_TOKEN: "test-token" } as Env);
+
+    await expect(
+      client.ensureSSHKey(
+        "crabbox-cbx-abcdef123456",
+        "ssh-ed25519 lease-test new-comment",
+        "cbx_abcdef123456",
+      ),
+    ).rejects.toThrow("is not owned by lease cbx_abcdef123456");
+  });
+
+  it("rejects a canonical Hetzner key name reserved for another lease", async () => {
+    const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>();
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new HetznerClient({ HETZNER_TOKEN: "test-token" } as Env);
+
+    await expect(
+      client.ensureSSHKey(
+        "crabbox-cbx-000000000001",
+        "ssh-ed25519 requested-key",
+        "cbx_abcdef123456",
+      ),
+    ).rejects.toThrow("is reserved for lease cbx_000000000001");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("binds canonical Hetzner SSH key reuse, creation, and deletion to lease labels", async () => {
+    const requests: Array<{ method: string; path: string; body?: Record<string, unknown> }> = [];
+    let mode: "wrong" | "missing" | "owned" = "wrong";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const httpRequest = input instanceof Request ? input : new Request(input, init);
+        const path = new URL(httpRequest.url).pathname;
+        const body = httpRequest.method === "POST" ? await httpRequest.clone().json() : undefined;
+        requests.push({ method: httpRequest.method, path, ...(body ? { body } : {}) });
+        if (httpRequest.method === "DELETE") return jsonResponse({});
+        if (httpRequest.method === "POST") {
+          return jsonResponse({
+            ssh_key: {
+              id: 2,
+              name: "crabbox-cbx-abcdef123456",
+              public_key: "ssh-ed25519 requested-key",
+              labels: { crabbox: "true", lease: "cbx_abcdef123456" },
+            },
+          });
+        }
+        if (mode === "missing") return jsonResponse({ ssh_keys: [] });
+        return jsonResponse({
+          ssh_keys: [
+            {
+              id: 1,
+              name: "crabbox-cbx-abcdef123456",
+              public_key: "ssh-ed25519 requested-key old-comment",
+              labels: {
+                crabbox: "true",
+                created_by: "crabbox",
+                lease: mode === "owned" ? "cbx_abcdef123456" : "cbx_000000000001",
+              },
+            },
+          ],
+        });
+      }),
+    );
+    const client = new HetznerClient({ HETZNER_TOKEN: "test-token" } as Env);
+
+    await expect(
+      client.ensureSSHKey(
+        "crabbox-cbx-abcdef123456",
+        "ssh-ed25519 requested-key new-comment",
+        "cbx_abcdef123456",
+      ),
+    ).rejects.toThrow("is not owned by lease cbx_abcdef123456");
+    mode = "owned";
+    await expect(
+      client.ensureSSHKey(
+        "crabbox-cbx-abcdef123456",
+        "ssh-ed25519 requested-key new-comment",
+        "cbx_abcdef123456",
+      ),
+    ).resolves.toMatchObject({ id: 1 });
+    mode = "wrong";
+    await client.deleteSSHKey("crabbox-cbx-abcdef123456", "cbx_abcdef123456");
+    mode = "owned";
+    await client.deleteSSHKey("crabbox-cbx-abcdef123456", "cbx_abcdef123456");
+    expect(requests.filter((entry) => entry.method === "DELETE")).toEqual([
+      { method: "DELETE", path: "/v1/ssh_keys/1" },
+    ]);
+
+    mode = "missing";
+    await client.ensureSSHKey(
+      "crabbox-cbx-abcdef123456",
+      "ssh-ed25519 requested-key",
+      "cbx_abcdef123456",
+    );
+    expect(requests.findLast((entry) => entry.method === "POST")?.body).toMatchObject({
+      labels: { crabbox: "true", created_by: "crabbox", lease: "cbx_abcdef123456" },
+    });
+  });
+
+  it("reuses a differently named Hetzner SSH key with the same identity", async () => {
     const existing = {
       id: 99,
       name: "older-workspace-key",
@@ -3258,7 +3390,11 @@ describe("fleet lease identity and idle", () => {
     const client = new HetznerClient({ HETZNER_TOKEN: "test-token" } as Env);
 
     await expect(
-      client.ensureSSHKey("crabbox-workspace-new", "ssh-ed25519 workspace-test new-comment"),
+      client.ensureSSHKey(
+        "crabbox-cbx-abcdef123456",
+        "ssh-ed25519 workspace-test new-comment",
+        "cbx_abcdef123456",
+      ),
     ).resolves.toEqual(existing);
   });
 
@@ -3320,6 +3456,34 @@ describe("fleet lease identity and idle", () => {
     });
 
     await expect(provider.releaseLease(lease)).resolves.toBeUndefined();
+  });
+
+  it("records a shared Hetzner key's actual name so cleanup retains it", async () => {
+    const provider = new HetznerProvider({} as Env);
+    const config = leaseConfig({
+      provider: "hetzner",
+      providerKey: "crabbox-cbx-abcdef123456",
+      sshPublicKey: "ssh-ed25519 shared-test",
+    });
+    const lease = testLease({
+      id: "cbx_abcdef123456",
+      provider: "hetzner",
+      providerKey: config.providerKey,
+    });
+
+    const finalized = await provider.finalizeLeaseCreate(
+      config,
+      lease,
+      testMachine({
+        provider: "hetzner",
+        labels: { provider_key: "sanitized-wrong-value" },
+        providerKey: "shared-existing-key!with-unsafe-label-chars",
+      }),
+    );
+
+    expect(finalized.config.providerKey).toBe("shared-existing-key!with-unsafe-label-chars");
+    expect(finalized.lease.providerKey).toBe("shared-existing-key!with-unsafe-label-chars");
+    expect(finalized.lease.providerKeyCleanupOwned).toBe(false);
   });
 
   it("reserves the shared workspace provider key from ordinary leases", async () => {
@@ -3562,6 +3726,85 @@ describe("fleet lease identity and idle", () => {
     await fleet.alarm();
     expect(restrictionChecks).toBe(0);
     expect(created).toBe(true);
+  });
+
+  it("requires admin auth for custom provider key names before provider preparation", async () => {
+    const createdProviderKeys: string[] = [];
+    let prepareCalls = 0;
+    const fleet = testFleet(undefined, {
+      aws: fakeProvider(
+        (config) => {
+          createdProviderKeys.push(config.providerKey);
+        },
+        {
+          provider: "aws",
+          onPrepareLeaseConfig: (config) => {
+            prepareCalls += 1;
+            return config;
+          },
+        },
+      ),
+    });
+    const create = (leaseID: string, providerKey: string, admin = false) =>
+      fleet.fetch(
+        request("POST", "/v1/leases", {
+          headers: admin ? { "x-crabbox-admin": "true" } : undefined,
+          body: {
+            leaseID,
+            provider: "aws",
+            providerKey,
+            sshPublicKey: "ssh-ed25519 direct-test",
+          },
+        }),
+      );
+
+    const denied = await create("cbx_abcdef123456", "foreign-key");
+    expect(denied.status).toBe(403);
+    await expect(denied.json()).resolves.toMatchObject({ error: "admin_required" });
+    expect(prepareCalls).toBe(0);
+    expect(createdProviderKeys).toEqual([]);
+
+    const reserved = await create("cbx_abcdef123456", "crabbox-cbx-000000000001", true);
+    expect(reserved.status).toBe(400);
+    await expect(reserved.json()).resolves.toMatchObject({ error: "reserved_provider_key" });
+    expect(prepareCalls).toBe(0);
+    expect(createdProviderKeys).toEqual([]);
+
+    const canonical = "crabbox-cbx-abcdef123456";
+    expect((await create("cbx_abcdef123456", canonical)).status).toBe(201);
+    expect((await create("cbx_abcdef123457", "shared-admin-key", true)).status).toBe(201);
+    expect(prepareCalls).toBe(2);
+    expect(createdProviderKeys).toEqual([canonical, "shared-admin-key"]);
+  });
+
+  it("only deletes provider keys canonically bound to the released lease", async () => {
+    const providers = [
+      new HetznerProvider({} as Env),
+      new AWSProvider({} as Env, "eu-west-1", new MemoryStorage()),
+    ];
+    await Promise.all(
+      providers.map(async (provider) => {
+        vi.spyOn(provider, "deleteServer").mockResolvedValue();
+        const deleteSSHKey = vi.spyOn(provider, "deleteSSHKey").mockResolvedValue();
+        await provider.releaseLease(
+          testLease({
+            id: "cbx_abcdef123456",
+            providerKey: "crabbox-cbx-000000000001",
+          }),
+        );
+        expect(deleteSSHKey).not.toHaveBeenCalled();
+
+        await provider.releaseLease(
+          testLease({
+            id: "cbx_abcdef123456",
+            providerKey: "crabbox-cbx-abcdef123456",
+            providerKeyCleanupOwned: true,
+          }),
+        );
+        expect(deleteSSHKey).toHaveBeenCalledOnce();
+        expect(deleteSSHKey).toHaveBeenCalledWith("crabbox-cbx-abcdef123456", "cbx_abcdef123456");
+      }),
+    );
   });
 
   it("adapts workspaces onto owner-scoped lease lifecycle", async () => {
@@ -5190,7 +5433,6 @@ describe("fleet lease identity and idle", () => {
         body: {
           leaseID: pending.providerResourceId,
           provider: "hetzner",
-          providerKey: "ordinary-key",
           sshPublicKey: "ssh-ed25519 ordinary-test",
         },
       }),
@@ -11157,7 +11399,10 @@ describe("fleet lease identity and idle", () => {
     const create = (leaseID: string, providerKey: string) =>
       fleet.fetch(
         request("POST", "/v1/leases", {
-          headers: { "cf-connecting-ip": "198.51.100.10" },
+          headers: {
+            "cf-connecting-ip": "198.51.100.10",
+            "x-crabbox-admin": "true",
+          },
           body: {
             leaseID,
             provider: "aws",
@@ -11630,6 +11875,7 @@ describe("fleet lease identity and idle", () => {
 
   it("requires admin auth for new AWS macOS host pins but reactivates an owner's retained Mac", async () => {
     let created = false;
+    let preparedProviderKey = "";
     const storage = new MemoryStorage();
     const reconciledLeaseIDs: string[][] = [];
     storage.seed(
@@ -11656,6 +11902,10 @@ describe("fleet lease identity and idle", () => {
           provider: "aws",
           serverType: "mac2.metal",
           hostID: "h-000000000001",
+          onPrepareLeaseConfig: (config) => {
+            preparedProviderKey = config.providerKey;
+            return config;
+          },
           onReconcileLeaseAccess: (_lease, context) => {
             reconciledLeaseIDs.push(context.activeLeases.map((candidate) => candidate.id));
           },
@@ -11754,6 +12004,7 @@ describe("fleet lease identity and idle", () => {
     );
     expect(reused.status).toBe(201);
     expect(created).toBe(false);
+    expect(preparedProviderKey).toBe(lease.providerKey);
     const { lease: reactivated } = (await reused.json()) as { lease: LeaseRecord };
     expect(reactivated.id).toBe(lease.id);
     expect(reactivated.state).toBe("active");


### PR DESCRIPTION
## Summary

- reject non-admin custom provider-key names before provider preparation and reserve canonical Crabbox key names for their matching lease
- persist explicit cleanup ownership and verify AWS tags/public material or Hetzner identity before deleting keys by immutable provider ID
- preserve legacy, admin-managed, and differently named shared Hetzner keys, including cancellation-race cleanup before normal lease finalization

Closes https://github.com/openclaw/crabbox/issues/706

## Verification

- `npm test --prefix worker` — 746 tests passed
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm run check:node --prefix worker`
- `npm run build --prefix worker`
- `node scripts/build-docs-site.mjs`
- local Worker integration: non-admin custom key rejected with `403 admin_required` before provider preparation and without persisted state
- local Worker integration: omitted canonical key crossed authorization and reached the intentionally unconfigured provider boundary without persisted state
- autoreview: clean after adding canonical/shared-key cancellation-race coverage

Real-provider credential canaries were not run; AWS and Hetzner ownership/deletion contracts are covered with provider API fixtures and Worker integration tests.
