### PR TITLE
fix(worker): require verified GitHub token owners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### Fixed
 
+- Bound GitHub browser-login owners to verified email addresses, recorded that provenance in a versioned user-token schema, and invalidated legacy tokens that could retain unverified owner identities. Thanks @coygeek.
 - Restricted brokered AWS and GCP resource selectors to admin-authenticated requests so normal users cannot steer coordinator cloud credentials toward caller-selected networks, images, projects, tags, or instance identities. Thanks @coygeek.
 - Pinned NodeSource and Docker APT signing fingerprints across managed Linux image preparation and local-container Docker CLI bootstrap, preserving existing trust files, stopping image preparation on mismatch, and using distro packages for local-container fallback. Thanks @coygeek.
 - Bound non-admin coordinator provider-key names and automatic cleanup to verified, persisted lease ownership metadata, rejecting unsafe AWS and Hetzner name collisions while retaining legacy and Hetzner provider-unique shared key identities. Thanks @coygeek.

--- a/docs/features/auth-admin.md
+++ b/docs/features/auth-admin.md
@@ -27,8 +27,12 @@ exchanges the OAuth code, then verifies the user is an **active member of an
 allowed GitHub org** (`CRABBOX_GITHUB_ALLOWED_ORGS`, or the singular
 `CRABBOX_GITHUB_ALLOWED_ORG`) and, if any **allowed teams** are configured
 (`CRABBOX_GITHUB_ALLOWED_TEAMS` / `CRABBOX_GITHUB_ALLOWED_TEAM`), a member of one
-of them. On success the broker issues a signed user token (prefix `cbxu_`,
+of them. The account must also expose a verified email through GitHub's
+`user:email` scope; the broker never uses a public profile or unverified email
+as the owner. On success the broker issues a signed user token (prefix `cbxu_`,
 HMAC-SHA256, default 180-day expiry) and the CLI stores it in the user config.
+Tokens from the older unversioned schema are rejected, so users must log in
+again after upgrading the broker with this security fix.
 
 ```sh
 crabbox login --url https://broker.example.com

--- a/docs/features/broker-auth-routing.md
+++ b/docs/features/broker-auth-routing.md
@@ -84,8 +84,10 @@ matches the token in this precedence (`worker/src/auth.ts`):
 3. **Signed user token** — a token with the `cbxu_` prefix, an HMAC-SHA256 signature over a
    base64url payload, verified only with `CRABBOX_SESSION_SECRET`. The session
    secret must be configured and distinct from `CRABBOX_SHARED_TOKEN`. Minted by
-   `crabbox login`, with a default 180-day expiry.
-   User tokens are non-admin unless their GitHub email or login matches
+   `crabbox login` only after GitHub returns a verified owner email, with a
+   default 180-day expiry. The payload records the verified-email provenance;
+   older unversioned user tokens are rejected and require a fresh login.
+   User tokens are non-admin unless their verified GitHub email or login matches
    `CRABBOX_GITHUB_ADMIN_OWNERS` or `CRABBOX_GITHUB_ADMIN_LOGINS`.
 
 Anything else returns `401 unauthorized`.

--- a/docs/security.md
+++ b/docs/security.md
@@ -67,9 +67,12 @@ every other coordinator route. Normal authentication is resolved in
 3. **Signed user token** — a `cbxu_`-prefixed token issued by GitHub browser
    login. It is an HMAC-SHA256 signature (verified in constant time) over a
    base64url payload signed with `CRABBOX_SESSION_SECRET`, which must be set and
-   must differ from `CRABBOX_SHARED_TOKEN`. The payload carries `owner`, `org`,
-   and GitHub `login`, has a default 180-day expiry, and is rejected if it
-   carries an `admin` claim — browser login can never mint admin tokens.
+   must differ from `CRABBOX_SHARED_TOKEN`. The versioned payload carries a
+   verified-email `owner`, its `github-verified-email` provenance, `org`, and
+   GitHub `login`, has a default 180-day expiry, and is rejected if it carries
+   an `admin` claim — browser login can never mint admin tokens. Tokens from
+   older schemas are rejected; users must log in again after this security
+   upgrade.
 
 ### GitHub browser login
 
@@ -81,6 +84,9 @@ by coordinator config:
   members of the listed GitHub org(s).
 - `CRABBOX_GITHUB_ALLOWED_TEAMS` (or `CRABBOX_GITHUB_ALLOWED_TEAM`) further
   narrows access to selected team slugs after org membership passes.
+- The GitHub account must expose at least one verified email through the OAuth
+  `user:email` scope. Public profile and unverified emails are never trusted as
+  the token owner.
 
 User tokens can only mutate leases, runs, and usage for their own `owner`/`org`
 identity. Lease owners also have read-only audit access to run history, logs,

--- a/worker/src/auth.ts
+++ b/worker/src/auth.ts
@@ -10,6 +10,7 @@ const accessKidMaxChars = 256;
 const accessKeySetTTLMS = 5 * 60 * 1000;
 const accessKeySetFailureTTLMS = 30 * 1000;
 const accessKeySetCacheMaxEntries = 8;
+const userTokenVersion = 2;
 const accessKeySetCache = new Map<string, AccessKeySetCacheEntry>();
 const accessKeySetLoads = new Map<string, Promise<AccessKeySetCacheEntry>>();
 
@@ -29,6 +30,8 @@ export interface AuthRequestContext {
 
 interface UserTokenPayload {
   typ: "crabbox-user";
+  version: typeof userTokenVersion;
+  ownerSource: "github-verified-email";
   jti?: string;
   owner: string;
   org: string;
@@ -167,6 +170,7 @@ export async function issueUserToken(
   env: Pick<Env, "CRABBOX_SHARED_TOKEN" | "CRABBOX_SESSION_SECRET">,
   input: {
     owner: string;
+    ownerSource: "github-verified-email";
     org: string;
     login: string;
     name?: string;
@@ -176,6 +180,8 @@ export async function issueUserToken(
   const now = Math.floor(Date.now() / 1000);
   const payload: UserTokenPayload = {
     typ: "crabbox-user",
+    version: userTokenVersion,
+    ownerSource: input.ownerSource,
     jti: crypto.randomUUID(),
     owner: input.owner,
     org: input.org,
@@ -215,6 +221,8 @@ async function verifyUserToken(
   const payload = decodeUserTokenPayload(token);
   if (
     payload.typ !== "crabbox-user" ||
+    payload.version !== userTokenVersion ||
+    payload.ownerSource !== "github-verified-email" ||
     typeof payload.owner !== "string" ||
     typeof payload.org !== "string" ||
     typeof payload.login !== "string" ||

--- a/worker/src/oauth.ts
+++ b/worker/src/oauth.ts
@@ -39,7 +39,6 @@ interface OAuthPending {
 interface GitHubUser {
   login?: string;
   name?: string | null;
-  email?: string | null;
 }
 
 interface GitHubEmail {
@@ -241,10 +240,18 @@ async function githubAuthCallback(
     const ttlSeconds = userTokenTTLSeconds(env);
     const tokenInput = {
       owner: identity.owner,
+      ownerSource: identity.ownerSource,
       org,
       login: identity.login,
       ttlSeconds,
-    } as { owner: string; org: string; login: string; name?: string; ttlSeconds: number };
+    } as {
+      owner: string;
+      ownerSource: "github-verified-email";
+      org: string;
+      login: string;
+      name?: string;
+      ttlSeconds: number;
+    };
     if (identity.name) {
       tokenInput.name = identity.name;
     }
@@ -427,6 +434,7 @@ async function exchangeGitHubCode(code: string, redirectURI: string, env: Env): 
 
 async function githubIdentity(accessToken: string): Promise<{
   owner: string;
+  ownerSource: "github-verified-email";
   login: string;
   name?: string;
 }> {
@@ -442,22 +450,30 @@ async function githubIdentity(accessToken: string): Promise<{
   }
   const user = (await userResponse.json()) as GitHubUser;
   const login = user.login || "unknown";
-  let owner = user.email || "";
   const emailResponse = await fetch(`${githubAPIURL}/user/emails`, { headers });
-  if (emailResponse.ok) {
-    const emails = (await emailResponse.json()) as GitHubEmail[];
-    owner =
-      emails.find((email) => email.primary && email.verified)?.email ||
-      emails.find((email) => email.verified)?.email ||
-      owner;
+  if (!emailResponse.ok) {
+    throw new Error(`github email lookup failed: ${emailResponse.status}`);
   }
+  const emails = (await emailResponse.json()) as GitHubEmail[];
+  const verifiedEmails = emails.filter(
+    (email) => email.verified && typeof email.email === "string" && email.email.trim(),
+  );
+  const owner = (
+    verifiedEmails.find((email) => email.primary)?.email || verifiedEmails[0]?.email
+  )?.trim();
   if (!owner) {
-    owner = `${login}@users.noreply.github.com`;
+    throw new GitHubAuthorizationError("GitHub account must have a verified email to use Crabbox.");
   }
   const identity = {
     owner,
+    ownerSource: "github-verified-email",
     login,
-  } as { owner: string; login: string; name?: string };
+  } as {
+    owner: string;
+    ownerSource: "github-verified-email";
+    login: string;
+    name?: string;
+  };
   if (user.name) {
     identity.name = user.name;
   }

--- a/worker/test/coordinator-runtime.test.ts
+++ b/worker/test/coordinator-runtime.test.ts
@@ -566,10 +566,10 @@ describe("coordinator runtimes", () => {
           return Response.json({ access_token: "github-access-token" });
         }
         if (url === "https://api.github.com/user") {
-          return Response.json({ login: "friend", email: "friend@example.com" });
+          return Response.json({ login: "friend", email: "public@example.com" });
         }
         if (url === "https://api.github.com/user/emails") {
-          return Response.json([]);
+          return Response.json([{ email: "friend@example.com", primary: true, verified: true }]);
         }
         if (url === "https://api.github.com/user/memberships/orgs/example-org") {
           return Response.json({

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -14087,6 +14087,7 @@ describe("fleet lease identity and idle", () => {
     );
     const token = await issueUserToken(env, {
       owner: "alice@example.com",
+      ownerSource: "github-verified-email",
       org: "example-org",
       login: "alice",
       ttlSeconds: 60 * 60,
@@ -19284,6 +19285,62 @@ describe("fleet identity", () => {
     expect(body.tokenExpiresAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
   });
 
+  it("rejects GitHub login when only public or unverified emails are available", async () => {
+    const { fleet, loginID, state, pollSecret } = await startGitHubLogin();
+    vi.stubGlobal(
+      "fetch",
+      githubFetchMock({
+        member: true,
+        profileEmail: "victim@example.com",
+        emails: [{ email: "attacker@example.com", primary: true, verified: false }],
+      }),
+    );
+
+    const callback = await fleet.fetch(
+      request("GET", `/v1/auth/github/callback?code=ok&state=${state}`),
+    );
+    expect(callback.status).toBe(403);
+
+    const poll = await fleet.fetch(
+      request("POST", "/v1/auth/github/poll", {
+        body: { loginID, pollSecret },
+      }),
+    );
+    expect(poll.status).toBe(400);
+    await expect(poll.json()).resolves.toMatchObject({
+      status: "failed",
+      error: "GitHub account must have a verified email to use Crabbox.",
+    });
+  });
+
+  it("does not fall back to a public email when GitHub email lookup fails", async () => {
+    const { fleet, loginID, state, pollSecret } = await startGitHubLogin();
+    vi.stubGlobal(
+      "fetch",
+      githubFetchMock({
+        member: true,
+        profileEmail: "victim@example.com",
+        emailStatus: 500,
+      }),
+    );
+
+    const callback = await fleet.fetch(
+      request("GET", `/v1/auth/github/callback?code=ok&state=${state}`),
+    );
+    expect(callback.status).toBe(500);
+
+    const poll = await fleet.fetch(
+      request("POST", "/v1/auth/github/poll", {
+        body: { loginID, pollSecret },
+      }),
+    );
+    expect(poll.status).toBe(400);
+    await expect(poll.json()).resolves.toMatchObject({
+      status: "failed",
+      error: "github email lookup failed: 500",
+    });
+  });
+
   it("honors configured GitHub user token TTL", async () => {
     const { fleet, loginID, state, pollSecret } = await startGitHubLogin({
       CRABBOX_USER_TOKEN_TTL_SECONDS: "7200",
@@ -19592,10 +19649,16 @@ function githubFetchMock({
   member,
   org = "openclaw",
   teams = [],
+  profileEmail = null,
+  emails = [{ email: "friend@example.com", primary: true, verified: true }],
+  emailStatus = 200,
 }: {
   member: boolean;
   org?: string;
   teams?: Array<{ slug: string; organization: { login: string } }>;
+  profileEmail?: string | null;
+  emails?: Array<{ email?: string; primary?: boolean; verified?: boolean }>;
+  emailStatus?: number;
 }) {
   return vi.fn<(input: RequestInfo | URL) => Promise<Response>>(async (input) => {
     const url =
@@ -19604,10 +19667,13 @@ function githubFetchMock({
       return jsonResponse({ access_token: "github-access-token" });
     }
     if (url === "https://api.github.com/user") {
-      return jsonResponse({ login: "friend", name: "Friendly User", email: null });
+      return jsonResponse({ login: "friend", name: "Friendly User", email: profileEmail });
     }
     if (url === "https://api.github.com/user/emails") {
-      return jsonResponse([{ email: "friend@example.com", primary: true, verified: true }]);
+      return jsonResponse(
+        emailStatus === 200 ? emails : { message: "email lookup failed" },
+        emailStatus,
+      );
     }
     if (url === `https://api.github.com/user/memberships/orgs/${encodeURIComponent(org)}`) {
       return member

--- a/worker/test/http.test.ts
+++ b/worker/test/http.test.ts
@@ -590,6 +590,7 @@ describe("coordinator auth", () => {
     };
     const token = await issueUserToken(env, {
       owner: "friend@example.com",
+      ownerSource: "github-verified-email",
       org: "openclaw",
       login: "friend",
     });
@@ -616,6 +617,7 @@ describe("coordinator auth", () => {
     };
     const token = await issueUserToken(env, {
       owner: "friend@example.com",
+      ownerSource: "github-verified-email",
       org: "example-org",
       login: "friend",
     });
@@ -637,6 +639,7 @@ describe("coordinator auth", () => {
     const env = { CRABBOX_SESSION_SECRET: "session-secret" };
     const input = {
       owner: "friend@example.com",
+      ownerSource: "github-verified-email" as const,
       org: "openclaw",
       login: "friend",
     };
@@ -645,6 +648,36 @@ describe("coordinator auth", () => {
     const second = await issueUserToken(env, input);
 
     expect(second).not.toBe(first);
+  });
+
+  it.each([
+    ["legacy schema", {}],
+    ["unverified owner provenance", { version: 2, ownerSource: "github-public-email" }],
+  ])("rejects signed user tokens with %s", async (_label, schema) => {
+    const env = {
+      CRABBOX_SHARED_TOKEN: "shared",
+      CRABBOX_SESSION_SECRET: "session-secret",
+      CRABBOX_DEFAULT_ORG: "openclaw",
+    };
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signedUserToken("session-secret", {
+      typ: "crabbox-user",
+      ...schema,
+      owner: "friend@example.com",
+      org: "openclaw",
+      login: "friend",
+      iat: now,
+      exp: now + 300,
+    });
+
+    const auth = await authenticateRequest(
+      new Request("https://example.test/v1/whoami", {
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      env,
+    );
+
+    expect(auth).toBeUndefined();
   });
 
   it("promotes configured GitHub user tokens to admin", async () => {
@@ -657,11 +690,13 @@ describe("coordinator auth", () => {
     };
     const ownerToken = await issueUserToken(env, {
       owner: "vincentkoc@ieee.org",
+      ownerSource: "github-verified-email",
       org: "openclaw",
       login: "vincentkoc",
     });
     const loginToken = await issueUserToken(env, {
       owner: "peter@example.com",
+      ownerSource: "github-verified-email",
       org: "openclaw",
       login: "steipete",
     });
@@ -698,6 +733,8 @@ describe("coordinator auth", () => {
     const now = Math.floor(Date.now() / 1000);
     const token = await signedUserToken("session-secret", {
       typ: "crabbox-user",
+      version: 2,
+      ownerSource: "github-verified-email",
       owner: "friend@example.com",
       org: "openclaw",
       login: "friend",
@@ -720,6 +757,8 @@ describe("coordinator auth", () => {
     const now = Math.floor(Date.now() / 1000);
     const token = await signedUserToken("session-secret", {
       typ: "crabbox-user",
+      version: 2,
+      ownerSource: "github-verified-email",
       owner: "friend@example.com",
       org: "openclaw",
       login: "friend",
@@ -753,6 +792,8 @@ describe("coordinator auth", () => {
     const now = Math.floor(Date.now() / 1000);
     const token = await signedUserToken("shared", {
       typ: "crabbox-user",
+      version: 2,
+      ownerSource: "github-verified-email",
       owner: "friend@example.com",
       org: "openclaw",
       login: "friend",
@@ -777,6 +818,7 @@ describe("coordinator auth", () => {
   it("requires independent signing material when issuing user tokens", async () => {
     const input = {
       owner: "friend@example.com",
+      ownerSource: "github-verified-email" as const,
       org: "openclaw",
       login: "friend",
     };


### PR DESCRIPTION
## Summary

- derive GitHub OAuth owners only from the primary verified email or another verified account email; fail closed when the email API is unavailable or returns no verified address
- version signed user tokens and record `github-verified-email` provenance so legacy owner schemas are rejected and users reauthenticate after the security upgrade
- document the verified-email requirement and cover callback, runtime, token, and authorization regressions

Closes https://github.com/openclaw/crabbox/issues/697

## Verification

- `npm test --prefix worker` — 736 tests passed
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm run check:node --prefix worker`
- `npm run build --prefix worker`
- `node scripts/build-docs-site.mjs`
- autoreview: clean

The issue's full live exploit path is not reproducible with a normal GitHub account because GitHub currently requires a verified email before OAuth authorization. The defense-in-depth regression is covered at the OAuth HTTP boundary and signed-token verification boundary; no live exploit claim is made.

## Upgrade note

Existing signed user tokens use the older schema and are intentionally invalidated. Browser and CLI users must log in again once this change deploys.
