### PR TITLE
fix: require claims for provider mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 ### Fixed
 
 - Bound GitHub browser-login owners to verified email addresses, recorded that provenance in a versioned user-token schema, and invalidated legacy tokens that could retain unverified owner identities. Thanks @coygeek.
+- Required exact local claims before Freestyle or Islo delete, pause, resume, and SSH reuse operations, while preserving explicit `--reclaim` adoption and read-only canonical-name recovery. Thanks @coygeek.
 - Restricted brokered AWS and GCP resource selectors to admin-authenticated requests so normal users cannot steer coordinator cloud credentials toward caller-selected networks, images, projects, tags, or instance identities. Thanks @coygeek.
 - Pinned NodeSource and Docker APT signing fingerprints across managed Linux image preparation and local-container Docker CLI bootstrap, preserving existing trust files, stopping image preparation on mismatch, and using distro packages for local-container fallback. Thanks @coygeek.
 - Bound non-admin coordinator provider-key names and automatic cleanup to verified, persisted lease ownership metadata, rejecting unsafe AWS and Hetzner name collisions while retaining legacy and Hetzner provider-unique shared key identities. Thanks @coygeek.

--- a/README.md
+++ b/README.md
@@ -64,11 +64,11 @@ supported boundary and [Operational security](docs/security.md) for deployment
 guidance.
 
 Within that boundary, credentialed HTTP redirects are confined to their
-configured origin, destructive provider recovery requires a local claim or an
-already-canonical Crabbox resource name, and artifact publication accepts only
-regular files from the selected bundle. Provider diagnostics redact configured
-credentials on the documented clients, but captured output and failure bundles
-are not automatically scrubbed; review them before sharing. See
+configured origin, destructive provider recovery requires an exact local claim
+or stronger provider-side ownership metadata, and artifact publication accepts
+only regular files from the selected bundle. Provider diagnostics redact
+configured credentials on the documented clients, but captured output and
+failure bundles are not automatically scrubbed; review them before sharing. See
 [Operational security](docs/security.md) and [Artifacts](docs/features/artifacts.md).
 
 ## How it works

--- a/docs/commands/stop.md
+++ b/docs/commands/stop.md
@@ -49,8 +49,13 @@ Crabbox lease ID and local slug:
 - `coder` — stops the Coder workspace by default and removes the local claim.
   Set `coder.deleteOnRelease` or pass `--coder-delete-on-release` to delete the
   workspace instead.
-- `islo` — accepts an `isb_...` ID, a Crabbox-created sandbox name, or a local
-  slug and deletes the Islo sandbox.
+- `islo` — accepts an exactly claimed `isb_...` ID, Crabbox-created sandbox
+  name, or local slug and deletes the Islo sandbox. Claimless canonical names
+  must first be adopted through an explicit supported `--reclaim` reuse.
+- `freestyle` — accepts an exactly claimed `fsb_...` ID, Crabbox-created VM
+  name, or local slug and deletes the Freestyle VM. Claimless canonical names
+  remain visible to status/list but cannot be deleted until explicit
+  `--reclaim` reuse persists a claim.
 - `e2b` — accepts a Crabbox lease ID, a local slug, or a Crabbox-owned E2B
   sandbox ID in raw or `e2b_<sandboxID>` form and deletes the E2B sandbox.
 - `vercel-sandbox` — accepts a Crabbox-created local slug or `vsbx_...` lease

--- a/docs/providers/freestyle.md
+++ b/docs/providers/freestyle.md
@@ -132,8 +132,18 @@ unavailable, Crabbox falls back to chunked base64 upload through exec. Sync stil
 completes reliably through the fallback path.
 
 The raw VM ID, Crabbox VM name, and generated slug shown by `crabbox list` can
-recover a Crabbox-owned VM after local claim state is lost. Recovery requires
-the provider VM name to already match Crabbox's canonical `crabbox-...` form.
+identify a VM after local claim state is lost. Read-only status recovery still
+requires the provider VM name to match Crabbox's canonical `crabbox-...` form.
+Reuse and deletion additionally require an exact local claim. To intentionally
+adopt a canonical VM, persist that claim before stopping it:
+
+```sh
+crabbox run --provider freestyle --id fsb_vm123 --reclaim --no-sync -- true
+crabbox stop --provider freestyle --id fsb_vm123
+```
+
+`--reclaim` is the explicit operator authorization: canonical name shape alone
+never reaches Freestyle command or delete operations.
 
 `--checksum` is not supported because Freestyle uses archive sync rather than
 Crabbox rsync checksum mode.

--- a/docs/providers/islo.md
+++ b/docs/providers/islo.md
@@ -41,6 +41,17 @@ crabbox list --provider islo --json
 Crabbox-created sandbox name printed by `warmup`/`run` can be passed to later
 commands via `--id`.
 
+If local claim state was intentionally lost, adopt a canonical Islo sandbox
+before lifecycle mutation, then use its new claim normally:
+
+```sh
+crabbox run --provider islo --id isb_crabbox-repo-abcdef --reclaim --no-sync -- true
+crabbox stop --provider islo --id isb_crabbox-repo-abcdef
+```
+
+Read-only status lookup can still use a canonical sandbox name without a claim.
+Delete, pause, resume, SSH reuse, and delegated reuse cannot.
+
 ## Auth
 
 ```sh
@@ -156,8 +167,10 @@ rejected before workspace preparation and sync.
   large-archive guardrail.
 - `--shell` passes the raw shell string to `bash -lc` in the workdir.
 - `--id` accepts a Crabbox slug, an `isb_<name>` lease ID, or a canonical
-  normalized sandbox name starting with `crabbox-`. Names that require case,
-  whitespace, or punctuation normalization and non-Crabbox sandboxes are rejected.
+  normalized sandbox name starting with `crabbox-`. A claimless canonical name
+  is read-only until an explicit supported `--reclaim` reuse persists a local
+  claim. Names that require case, whitespace, or punctuation normalization and
+  non-Crabbox sandboxes are rejected.
 
 Related docs:
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -233,9 +233,11 @@ bundles.
 
 Lifecycle recovery from raw provider identifiers is provider-specific and
 fails closed when ownership cannot be established. Cloudflare containers need
-a matching local claim; Freestyle and Islo recovery names must already be in
-their canonical Crabbox-generated form before reuse or deletion reaches the
-provider.
+a matching local claim. Freestyle and Islo canonical names remain available
+for read-only discovery, but delete, pause, resume, SSH reuse, and delegated
+reuse require an exact local claim. When local state was intentionally lost,
+an operator can use the provider's supported `--reclaim` reuse path to persist
+a new claim before any provider mutation.
 
 Artifact publishing rejects symlinks, directories at reserved generated-output
 paths, and other non-regular bundle entries before upload side effects. Required

--- a/internal/providers/freestyle/backend.go
+++ b/internal/providers/freestyle/backend.go
@@ -363,6 +363,9 @@ func (b *freestyleBackend) Stop(ctx context.Context, req StopRequest) error {
 	if err != nil {
 		return err
 	}
+	if err := requireFreestyleLeaseClaim(leaseID); err != nil {
+		return err
+	}
 	if err := client.DeleteVM(ctx, id); err != nil {
 		return freestyleError("delete vm", err)
 	}
@@ -409,13 +412,18 @@ func (b *freestyleBackend) createSandbox(ctx context.Context, client freestyleAP
 
 func (b *freestyleBackend) rollbackCreatedVM(client freestyleAPI, vmID string, cause error) error {
 	if cleanupErr := deleteFreestyleVMForCleanup(client, vmID); cleanupErr != nil {
-		leakErr := fmt.Errorf("cleanup freestyle vm %s after acquire failure: %w; run `crabbox stop --provider freestyle --id %s%s` to retry cleanup", vmID, cleanupErr, freestyleLeasePrefix, vmID)
+		leaseID := freestyleLeasePrefix + vmID
+		leakErr := fmt.Errorf("cleanup freestyle vm %s after acquire failure: %w; first run `%s`, then run `%s` to retry cleanup", vmID, cleanupErr, freestyleAdoptCommand(leaseID), freestyleCleanupCommand(leaseID))
 		if b.rt.Stderr != nil {
 			fmt.Fprintf(b.rt.Stderr, "warning: %v\n", leakErr)
 		}
 		return errors.Join(cause, leakErr)
 	}
 	return cause
+}
+
+func freestyleAdoptCommand(leaseID string) string {
+	return fmt.Sprintf("crabbox run --provider %s --id %s --reclaim --no-sync -- true", freestyleProvider, shellQuote(leaseID))
 }
 
 func deleteFreestyleVMForCleanup(client freestyleAPI, vmID string) error {
@@ -545,11 +553,41 @@ func (b *freestyleBackend) resolveLeaseID(ctx context.Context, client freestyleA
 		return "", "", exit(4, "freestyle vm %q is not claimed by Crabbox", id)
 	}
 	if repoRoot != "" {
-		if err := claimLeaseForRepoProviderPond(leaseID, newLeaseSlug(leaseID), freestyleProvider, b.cfg.Pond, repoRoot, b.cfg.IdleTimeout, reclaim); err != nil {
+		claim, ok, err := resolveExactFreestyleLeaseClaim(leaseID)
+		if err != nil {
+			return "", "", err
+		}
+		if ok {
+			if err := claimLeaseForRepoProviderPond(claim.LeaseID, claim.Slug, freestyleProvider, claim.Pond, repoRoot, time.Duration(claim.IdleTimeoutSeconds)*time.Second, reclaim); err != nil {
+				return "", "", err
+			}
+		} else if !reclaim {
+			return "", "", exit(4, "freestyle vm %q has no exact local claim; use --reclaim to adopt it before reuse", id)
+		} else if err := claimLeaseForRepoProviderPond(leaseID, newLeaseSlug(leaseID), freestyleProvider, b.cfg.Pond, repoRoot, b.cfg.IdleTimeout, true); err != nil {
 			return "", "", err
 		}
 	}
 	return leaseID, blank(vm.ID, vmID), nil
+}
+
+func resolveExactFreestyleLeaseClaim(leaseID string) (core.LeaseClaim, bool, error) {
+	claim, ok, err := resolveLeaseClaim(leaseID)
+	if err != nil {
+		return claim, ok, err
+	}
+	if ok && claim.Provider == freestyleProvider && claim.LeaseID == leaseID {
+		return claim, true, nil
+	}
+	return core.LeaseClaim{}, false, nil
+}
+
+func requireFreestyleLeaseClaim(leaseID string) error {
+	if _, ok, err := resolveExactFreestyleLeaseClaim(leaseID); err != nil {
+		return err
+	} else if !ok {
+		return exit(4, "freestyle lease %q has no exact local claim; adopt it with an explicit --reclaim reuse before stop", leaseID)
+	}
+	return nil
 }
 
 func freestyleVMToServer(vm freestyleVM) Server {

--- a/internal/providers/freestyle/backend_test.go
+++ b/internal/providers/freestyle/backend_test.go
@@ -223,6 +223,7 @@ func TestResolveFreestyleLeaseIDRejectsMalformedCrabboxNames(t *testing.T) {
 }
 
 func TestFreestyleStopRejectsMalformedCrabboxNameWithoutDelete(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	client := &fakeFreestyleClient{getVM: freestyleVM{
 		ID:    "vm123",
 		Name:  "crabbox repo abc123",
@@ -239,6 +240,47 @@ func TestFreestyleStopRejectsMalformedCrabboxNameWithoutDelete(t *testing.T) {
 	}
 	if len(client.deleteIDs) != 0 {
 		t.Fatalf("DeleteVM called for malformed name: %#v", client.deleteIDs)
+	}
+}
+
+func TestFreestyleStopRejectsCanonicalSandboxWithoutExactClaim(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	client := &fakeFreestyleClient{getVM: freestyleVM{
+		ID:    "vm123",
+		Name:  "crabbox-repo-abc123",
+		State: "running",
+	}}
+	oldClient := newFreestyleClient
+	newFreestyleClient = func(Config, Runtime) (freestyleAPI, error) { return client, nil }
+	t.Cleanup(func() { newFreestyleClient = oldClient })
+	backend := &freestyleBackend{rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+
+	err := backend.Stop(context.Background(), StopRequest{ID: "fsb_vm123"})
+	if err == nil || !strings.Contains(err.Error(), "no exact local claim") {
+		t.Fatalf("Stop error = %v, want exact-claim refusal", err)
+	}
+	if len(client.deleteIDs) != 0 {
+		t.Fatalf("DeleteVM called without an exact claim: %#v", client.deleteIDs)
+	}
+}
+
+func TestFreestyleStopDeletesExactlyClaimedSandbox(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	root := t.TempDir()
+	if err := claimLeaseForRepoProviderPond("fsb_vm123", "web", freestyleProvider, "", root, time.Hour, false); err != nil {
+		t.Fatal(err)
+	}
+	client := &fakeFreestyleClient{}
+	oldClient := newFreestyleClient
+	newFreestyleClient = func(Config, Runtime) (freestyleAPI, error) { return client, nil }
+	t.Cleanup(func() { newFreestyleClient = oldClient })
+	backend := &freestyleBackend{rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+
+	if err := backend.Stop(context.Background(), StopRequest{ID: "web"}); err != nil {
+		t.Fatal(err)
+	}
+	if len(client.deleteIDs) != 1 || client.deleteIDs[0] != "vm123" {
+		t.Fatalf("DeleteVM calls = %#v, want vm123", client.deleteIDs)
 	}
 }
 
@@ -266,6 +308,45 @@ func TestResolveFreestyleLeaseIDClaimsRawSandboxForRepo(t *testing.T) {
 	}
 	if gotLeaseID != "fsb_vm123" || gotSlug == "" || gotProvider != freestyleProvider || gotPond != "demo" || gotRepo != repoRoot || gotIdle != 7*time.Minute || !gotReclaim {
 		t.Fatalf("claim args lease=%q slug=%q provider=%q pond=%q repo=%q idle=%s reclaim=%v", gotLeaseID, gotSlug, gotProvider, gotPond, gotRepo, gotIdle, gotReclaim)
+	}
+}
+
+func TestResolveFreestyleLeaseIDRequiresExplicitReclaimForUnclaimedReuse(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	client := &fakeFreestyleClient{getVM: freestyleVM{
+		ID:    "vm123",
+		Name:  "crabbox-repo-abc123",
+		State: "running",
+	}}
+	backend := &freestyleBackend{}
+
+	if _, _, err := backend.resolveLeaseID(context.Background(), client, "fsb_vm123", t.TempDir(), false); err == nil || !strings.Contains(err.Error(), "--reclaim") {
+		t.Fatalf("resolve error = %v, want explicit reclaim refusal", err)
+	}
+	if _, ok, err := resolveLeaseClaim("fsb_vm123"); err != nil || ok {
+		t.Fatalf("claim created without reclaim: ok=%t err=%v", ok, err)
+	}
+}
+
+func TestResolveFreestyleLeaseIDAcceptsRawIdentifierWithExactClaim(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	root := t.TempDir()
+	if err := claimLeaseForRepoProviderPond("fsb_vm123", "web", freestyleProvider, "demo", root, time.Hour, false); err != nil {
+		t.Fatal(err)
+	}
+	client := &fakeFreestyleClient{listVMs: []freestyleVM{{
+		ID:    "vm123",
+		Name:  "crabbox-repo-abc123",
+		State: "running",
+	}}}
+	backend := &freestyleBackend{}
+
+	leaseID, vmID, err := backend.resolveLeaseID(context.Background(), client, "vm123", root, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if leaseID != "fsb_vm123" || vmID != "vm123" {
+		t.Fatalf("lease=%q vm=%q", leaseID, vmID)
 	}
 }
 
@@ -504,6 +585,7 @@ func TestFreestyleRunNoSyncDoesNotDeleteExistingWorkspace(t *testing.T) {
 	result, err := backend.Run(context.Background(), RunRequest{
 		ID:      "fsb_vm123",
 		Repo:    Repo{Root: t.TempDir(), Name: "repo"},
+		Reclaim: true,
 		NoSync:  true,
 		Command: []string{"test", "-f", "kept.txt"},
 	})
@@ -595,6 +677,7 @@ func TestFreestyleRunPrintsRedactedEnvSummary(t *testing.T) {
 	_, err := backend.Run(context.Background(), RunRequest{
 		ID:         "fsb_vm123",
 		Repo:       Repo{Root: t.TempDir(), Name: "repo"},
+		Reclaim:    true,
 		NoSync:     true,
 		Command:    []string{"printenv", "SECRET_TOKEN"},
 		Env:        map[string]string{"SECRET_TOKEN": "super-secret"},
@@ -742,7 +825,8 @@ func TestFreestyleCreateSandboxReportsBoundedCleanupFailure(t *testing.T) {
 		"claim write failed",
 		"cleanup freestyle vm vm-leaked",
 		"delete failed",
-		"crabbox stop --provider freestyle --id fsb_vm-leaked",
+		"crabbox run --provider freestyle --id 'fsb_vm-leaked' --reclaim --no-sync -- true",
+		"crabbox stop --provider freestyle --id 'fsb_vm-leaked'",
 	} {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("err=%v, want %q", err, want)

--- a/internal/providers/islo/backend.go
+++ b/internal/providers/islo/backend.go
@@ -183,7 +183,7 @@ func (b *isloBackend) Run(ctx context.Context, req RunRequest) (RunResult, error
 		tailnetEnrolled = b.cfg.Tailscale.Enabled
 		tailnetReady = b.cfg.Tailscale.Enabled
 	} else {
-		leaseID, name, slug, err = resolveIsloLeaseID(req.ID, req.Repo.Root, req.Reclaim)
+		leaseID, name, slug, err = b.resolveLeaseIDForRepo(ctx, client, req.ID, req.Repo.Root, req.Reclaim)
 		if err != nil {
 			return RunResult{}, err
 		}
@@ -550,6 +550,9 @@ func (b *isloBackend) Stop(ctx context.Context, req StopRequest) error {
 	if err != nil {
 		return err
 	}
+	if err := requireIsloLeaseClaim(leaseID, "stop"); err != nil {
+		return err
+	}
 	if err := client.DeleteSandbox(ctx, name); err != nil {
 		return isloError("delete sandbox", err)
 	}
@@ -569,6 +572,9 @@ func (b *isloBackend) Pause(ctx context.Context, req PauseRequest) error {
 	if err != nil {
 		return err
 	}
+	if err := requireIsloLeaseClaim(leaseID, "pause"); err != nil {
+		return err
+	}
 	if _, err := client.PauseSandbox(ctx, name); err != nil {
 		return isloError("pause sandbox", err)
 	}
@@ -584,6 +590,9 @@ func (b *isloBackend) Resume(ctx context.Context, req ResumeRequest) error {
 	}
 	leaseID, name, _, err := resolveIsloLeaseID(req.ID, "", false)
 	if err != nil {
+		return err
+	}
+	if err := requireIsloLeaseClaim(leaseID, "resume"); err != nil {
 		return err
 	}
 	if _, err := client.ResumeSandbox(ctx, name); err != nil {
@@ -635,13 +644,13 @@ func (b *isloBackend) createSandbox(ctx context.Context, client isloAPI, repo Re
 	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
 	if err != nil {
 		if cleanupErr := deleteIsloSandboxForCleanup(client, sandbox.GetName()); cleanupErr != nil {
-			return "", "", "", fmt.Errorf("%w; cleanup failed for islo sandbox %s: %v", err, sandbox.GetName(), cleanupErr)
+			return "", "", "", isloUnclaimedCleanupError(err, sandbox.GetName(), cleanupErr)
 		}
 		return "", "", "", err
 	}
 	if err := claimLeaseForRepoProviderWithPond(leaseID, slug, isloProvider, b.cfg.Pond, repo.Root, b.cfg.IdleTimeout, reclaim); err != nil {
 		if cleanupErr := deleteIsloSandboxForCleanup(client, sandbox.GetName()); cleanupErr != nil {
-			return "", "", "", fmt.Errorf("%w; cleanup failed for islo sandbox %s: %v", err, sandbox.GetName(), cleanupErr)
+			return "", "", "", isloUnclaimedCleanupError(err, sandbox.GetName(), cleanupErr)
 		}
 		return "", "", "", err
 	}
@@ -657,6 +666,12 @@ func (b *isloBackend) createSandbox(ctx context.Context, client isloAPI, repo Re
 		return "", "", "", err
 	}
 	return leaseID, sandbox.GetName(), slug, nil
+}
+
+func isloUnclaimedCleanupError(cause error, name string, cleanupErr error) error {
+	leaseID := isloLeasePrefix + name
+	adopt := fmt.Sprintf("crabbox run --provider %s --id %s --reclaim --no-sync -- true", isloProvider, shellQuote(leaseID))
+	return fmt.Errorf("%w; cleanup failed for islo sandbox %s: %v; first run `%s`, then run `%s` to retry cleanup", cause, name, cleanupErr, adopt, isloCleanupCommand(leaseID))
 }
 
 func deleteIsloSandboxForCleanup(client isloAPI, name string) error {
@@ -736,6 +751,41 @@ func resolveIsloLeaseID(id, repoRoot string, reclaim bool) (string, string, stri
 	}
 	leaseID := isloLeasePrefix + id
 	return leaseID, id, newLeaseSlug(leaseID), nil
+}
+
+func (b *isloBackend) resolveLeaseIDForRepo(ctx context.Context, client isloAPI, id, repoRoot string, reclaim bool) (string, string, string, error) {
+	leaseID, name, slug, err := resolveIsloLeaseID(id, repoRoot, reclaim)
+	if err != nil {
+		return "", "", "", err
+	}
+	if _, ok, err := resolveExactIsloLeaseClaim(leaseID); err != nil {
+		return "", "", "", err
+	} else if ok || repoRoot == "" {
+		return leaseID, name, slug, nil
+	}
+	if !reclaim {
+		return "", "", "", exit(4, "islo lease %q has no exact local claim; use --reclaim to adopt it before reuse", leaseID)
+	}
+	sandbox, err := client.GetSandbox(ctx, name)
+	if err != nil {
+		return "", "", "", isloError("get sandbox before reclaim", err)
+	}
+	if sandbox == nil || sandbox.GetName() != name {
+		return "", "", "", exit(4, "islo sandbox %q was not found; refusing to create a local claim", name)
+	}
+	if err := claimLeaseForRepoProviderWithPond(leaseID, slug, isloProvider, b.cfg.Pond, repoRoot, b.cfg.IdleTimeout, true); err != nil {
+		return "", "", "", err
+	}
+	return leaseID, name, slug, nil
+}
+
+func requireIsloLeaseClaim(leaseID, action string) error {
+	if _, ok, err := resolveExactIsloLeaseClaim(leaseID); err != nil {
+		return err
+	} else if !ok {
+		return exit(4, "islo lease %q has no exact local claim; adopt it with an explicit --reclaim reuse before %s", leaseID, action)
+	}
+	return nil
 }
 
 func resolveExactIsloLeaseClaim(leaseID string) (core.LeaseClaim, bool, error) {

--- a/internal/providers/islo/backend_test.go
+++ b/internal/providers/islo/backend_test.go
@@ -204,6 +204,7 @@ func TestResolveIsloLeaseIDRejectsUnclaimedRawSandbox(t *testing.T) {
 }
 
 func TestIsloStopRejectsNonCanonicalSandboxBeforeDelete(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	client := &fakeIsloSyncClient{}
 	restore := swapNewIsloClient(client)
 	t.Cleanup(restore)
@@ -216,6 +217,54 @@ func TestIsloStopRejectsNonCanonicalSandboxBeforeDelete(t *testing.T) {
 	}
 	if client.deleteCalls != 0 {
 		t.Fatalf("delete calls=%d, want 0", client.deleteCalls)
+	}
+}
+
+func TestIsloMutationsRejectCanonicalSandboxWithoutExactClaim(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	client := &fakeIsloSyncClient{}
+	restore := swapNewIsloClient(client)
+	t.Cleanup(restore)
+	backend := &isloBackend{
+		cfg: Config{Islo: IsloConfig{APIKey: "test"}},
+		rt:  Runtime{Stdout: io.Discard, Stderr: io.Discard},
+	}
+
+	for name, mutate := range map[string]func() error{
+		"stop":   func() error { return backend.Stop(context.Background(), StopRequest{ID: "crabbox-repo-abcdef"}) },
+		"pause":  func() error { return backend.Pause(context.Background(), PauseRequest{ID: "crabbox-repo-abcdef"}) },
+		"resume": func() error { return backend.Resume(context.Background(), ResumeRequest{ID: "crabbox-repo-abcdef"}) },
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := mutate()
+			if err == nil || !strings.Contains(err.Error(), "no exact local claim") {
+				t.Fatalf("error = %v, want exact-claim refusal", err)
+			}
+		})
+	}
+	if client.deleteCalls != 0 || client.pausedName != "" || client.resumedName != "" {
+		t.Fatalf("provider mutation without claim: delete=%d pause=%q resume=%q", client.deleteCalls, client.pausedName, client.resumedName)
+	}
+}
+
+func TestIsloStopDeletesExactlyClaimedSandbox(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	if err := claimLeaseForRepoProvider("isb_crabbox-repo-abcdef", "web", isloProvider, t.TempDir(), time.Hour, false); err != nil {
+		t.Fatal(err)
+	}
+	client := &fakeIsloSyncClient{}
+	restore := swapNewIsloClient(client)
+	t.Cleanup(restore)
+	backend := &isloBackend{
+		cfg: Config{Islo: IsloConfig{APIKey: "test"}},
+		rt:  Runtime{Stdout: io.Discard, Stderr: io.Discard},
+	}
+
+	if err := backend.Stop(context.Background(), StopRequest{ID: "web"}); err != nil {
+		t.Fatal(err)
+	}
+	if client.deleteCalls != 1 {
+		t.Fatalf("delete calls=%d, want 1", client.deleteCalls)
 	}
 }
 
@@ -235,6 +284,42 @@ func TestResolveIsloLeaseIDPreservesClaimSlug(t *testing.T) {
 		if gotLeaseID != leaseID || name != "crabbox-repo-abcdef" || slug != "web" {
 			t.Fatalf("id=%q lease=%q name=%q slug=%q", id, gotLeaseID, name, slug)
 		}
+	}
+}
+
+func TestResolveIsloLeaseIDForRepoRequiresExplicitVerifiedReclaim(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	root := t.TempDir()
+	backend := &isloBackend{cfg: Config{IdleTimeout: 7 * time.Minute, Pond: "demo"}}
+	client := &fakeIsloSyncClient{getSandbox: &gosdk.SandboxResponse{
+		Name:   "crabbox-repo-abcdef",
+		Status: "running",
+	}}
+
+	if _, _, _, err := backend.resolveLeaseIDForRepo(context.Background(), client, "crabbox-repo-abcdef", root, false); err == nil || !strings.Contains(err.Error(), "--reclaim") {
+		t.Fatalf("resolve error = %v, want explicit reclaim refusal", err)
+	}
+	leaseID, _, slug, err := backend.resolveLeaseIDForRepo(context.Background(), client, "crabbox-repo-abcdef", root, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim, ok, err := resolveExactIsloLeaseClaim(leaseID)
+	if err != nil || !ok || claim.RepoRoot != root || claim.Pond != "demo" || claim.IdleTimeoutSeconds != 420 || claim.Slug != slug {
+		t.Fatalf("claim ok=%t err=%v claim=%#v", ok, err, claim)
+	}
+}
+
+func TestResolveIsloLeaseIDForRepoDoesNotClaimMissingSandbox(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	backend := &isloBackend{}
+	client := &fakeIsloSyncClient{getSandboxGone: true}
+	leaseID := "isb_crabbox-repo-abcdef"
+
+	if _, _, _, err := backend.resolveLeaseIDForRepo(context.Background(), client, leaseID, t.TempDir(), true); err == nil || !strings.Contains(err.Error(), "refusing to create a local claim") {
+		t.Fatalf("resolve error = %v, want missing-sandbox refusal", err)
+	}
+	if _, ok, err := resolveExactIsloLeaseClaim(leaseID); err != nil || ok {
+		t.Fatalf("claim created for missing sandbox: ok=%t err=%v", ok, err)
 	}
 }
 
@@ -337,6 +422,11 @@ func TestIsloResolveSSHUsesSandboxHostnameDefaults(t *testing.T) {
 }
 
 func TestIsloResolveSSHHonorsExplicitSSHOverrides(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	leaseID := "isb_crabbox-repo-abcdef"
+	if err := claimLeaseForRepoProvider(leaseID, "web", isloProvider, t.TempDir(), time.Hour, false); err != nil {
+		t.Fatal(err)
+	}
 	client := &fakeIsloSyncClient{
 		getSandbox: &gosdk.SandboxResponse{Name: "crabbox-repo-abcdef", Status: "running"},
 	}
@@ -348,7 +438,7 @@ func TestIsloResolveSSHHonorsExplicitSSHOverrides(t *testing.T) {
 	core.MarkSSHKeyExplicit(&cfg)
 	backend := &isloBackend{cfg: cfg, rt: Runtime{Stderr: io.Discard}}
 
-	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "crabbox-repo-abcdef"})
+	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: leaseID})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -358,6 +448,8 @@ func TestIsloResolveSSHHonorsExplicitSSHOverrides(t *testing.T) {
 }
 
 func TestIsloResolveSSHResumesPausedSandbox(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	root := t.TempDir()
 	client := &fakeIsloSyncClient{
 		getSandbox: &gosdk.SandboxResponse{Name: "crabbox-repo-abcdef", Status: "paused"},
 	}
@@ -368,12 +460,43 @@ func TestIsloResolveSSHResumesPausedSandbox(t *testing.T) {
 		rt:  Runtime{Stderr: io.Discard},
 	}
 
-	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "crabbox-repo-abcdef"})
+	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{
+		ID:      "crabbox-repo-abcdef",
+		Repo:    Repo{Root: root},
+		Reclaim: true,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if client.resumeCalls != 1 || lease.Server.Status != "running" {
 		t.Fatalf("resumeCalls=%d status=%q", client.resumeCalls, lease.Server.Status)
+	}
+	if claim, ok, err := resolveExactIsloLeaseClaim(lease.LeaseID); err != nil || !ok || claim.RepoRoot != root {
+		t.Fatalf("adopted claim ok=%t err=%v claim=%#v", ok, err, claim)
+	}
+}
+
+func TestIsloResolveSSHRejectsUnclaimedSandboxBeforeResume(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	client := &fakeIsloSyncClient{
+		getSandbox: &gosdk.SandboxResponse{Name: "crabbox-repo-abcdef", Status: "paused"},
+	}
+	restore := swapNewIsloClient(client)
+	t.Cleanup(restore)
+	backend := &isloBackend{
+		cfg: Config{Islo: IsloConfig{APIKey: "test"}},
+		rt:  Runtime{Stderr: io.Discard},
+	}
+
+	_, err := backend.Resolve(context.Background(), core.ResolveRequest{
+		ID:   "crabbox-repo-abcdef",
+		Repo: Repo{Root: t.TempDir()},
+	})
+	if err == nil || !strings.Contains(err.Error(), "--reclaim") {
+		t.Fatalf("Resolve error = %v, want explicit reclaim refusal", err)
+	}
+	if client.resumeCalls != 0 {
+		t.Fatalf("resume calls=%d, want 0", client.resumeCalls)
 	}
 }
 
@@ -406,6 +529,11 @@ func TestIsloResolveSSHRejectsForeignClaimBeforeResume(t *testing.T) {
 }
 
 func TestIsloResolveSSHWaitsForStartingSandbox(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	leaseID := "isb_crabbox-repo-abcdef"
+	if err := claimLeaseForRepoProvider(leaseID, "web", isloProvider, t.TempDir(), time.Hour, false); err != nil {
+		t.Fatal(err)
+	}
 	client := &fakeIsloSyncClient{
 		getSandboxes: []*gosdk.SandboxResponse{
 			{Name: "crabbox-repo-abcdef", Status: "starting"},
@@ -419,7 +547,7 @@ func TestIsloResolveSSHWaitsForStartingSandbox(t *testing.T) {
 		rt:  Runtime{Stderr: io.Discard},
 	}
 
-	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "crabbox-repo-abcdef"})
+	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: leaseID})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1713,6 +1841,9 @@ func TestIsloSDKClientUploadArchiveStreamsMultipartTarball(t *testing.T) {
 
 func TestIsloPauseResumeCallProvider(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	if err := claimLeaseForRepoProvider("isb_crabbox-repo-abcdef", "web", isloProvider, t.TempDir(), time.Hour, false); err != nil {
+		t.Fatal(err)
+	}
 	client := &fakeIsloSyncClient{}
 	restore := swapNewIsloClient(client)
 	defer restore()

--- a/internal/providers/islo/ssh.go
+++ b/internal/providers/islo/ssh.go
@@ -18,9 +18,14 @@ func (b *isloBackend) Resolve(ctx context.Context, req core.ResolveRequest) (cor
 	if err != nil {
 		return core.LeaseTarget{}, err
 	}
-	leaseID, name, _, err := resolveIsloLeaseID(req.ID, req.Repo.Root, req.Reclaim)
+	leaseID, name, _, err := b.resolveLeaseIDForRepo(ctx, client, req.ID, req.Repo.Root, req.Reclaim)
 	if err != nil {
 		return core.LeaseTarget{}, err
+	}
+	if !req.StatusOnly {
+		if err := requireIsloLeaseClaim(leaseID, "SSH reuse"); err != nil {
+			return core.LeaseTarget{}, err
+		}
 	}
 	sandbox, err := b.resolveSSHReadySandbox(ctx, client, name, req)
 	if err != nil {


### PR DESCRIPTION
## Summary

- require an exact local provider-and-lease claim before Freestyle deletion and Islo deletion, pause, resume, SSH, or reuse
- keep status/list recovery read-only while making explicit `--reclaim` verify the provider resource before persisting a claim
- make partial-provisioning cleanup guidance adopt the surviving resource before retrying stop, with regression coverage for zero mutation before claim

Closes https://github.com/openclaw/crabbox/issues/714

## Verification

- `go test -race ./...`
- `go vet ./...`
- `node scripts/build-docs-site.mjs`
- source-blind Freestyle CLI validation:
  - claimless status succeeds
  - claimless stop exits 4 and sends zero DELETE requests
  - explicit reclaim followed by stop sends exactly one DELETE request
  - noncanonical identifiers are rejected with zero mutation
- autoreview: clean

Real Freestyle and Islo paid-provider canaries were not run because provider credentials were unavailable. The claim boundary and zero-mutation behavior are covered through provider API fixtures and source-blind CLI validation.
