### PR TITLE
fix(worker): require isolated browser Code origins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 - Bound GitHub browser-login owners to verified email addresses, recorded that provenance in a versioned user-token schema, and invalidated legacy tokens that could retain unverified owner identities. Thanks @coygeek.
 - Required exact local claims before Freestyle or Islo delete, pause, resume, and SSH reuse operations, while preserving explicit `--reclaim` adoption and read-only canonical-name recovery. Thanks @coygeek.
+- Required a valid isolated per-lease origin before serving browser Code HTTP or WebSocket traffic, preventing lease-controlled pages from inheriting coordinator portal authority. Thanks @coygeek.
 - Restricted brokered AWS and GCP resource selectors to admin-authenticated requests so normal users cannot steer coordinator cloud credentials toward caller-selected networks, images, projects, tags, or instance identities. Thanks @coygeek.
 - Pinned NodeSource and Docker APT signing fingerprints across managed Linux image preparation and local-container Docker CLI bootstrap, preserving existing trust files, stopping image preparation on mismatch, and using distro packages for local-container fallback. Thanks @coygeek.
 - Bound non-admin coordinator provider-key names and automatic cleanup to verified, persisted lease ownership metadata, rejecting unsafe AWS and Hetzner name collisions while retaining legacy and Hetzner provider-unique shared key identities. Thanks @coygeek.

--- a/docs/commands/code.md
+++ b/docs/commands/code.md
@@ -14,6 +14,9 @@ crabbox code --id swift-crab --open
 
 - A configured coordinator login. The command refuses to run without one:
   `crabbox login --url broker.example.com` first.
+- A valid coordinator `CRABBOX_CODE_ORIGIN_TEMPLATE` backed by wildcard TLS and
+  WebSocket ingress. Browser Code fails closed when the template is absent or
+  invalid.
 - A lease created with the `code` capability (`crabbox warmup --code`). The
   Linux bootstrap installs `code-server` only for leases that request it, and
   reusing a lease checks for the matching `code=true` label.

--- a/docs/features/broker-auth-routing.md
+++ b/docs/features/broker-auth-routing.md
@@ -20,8 +20,8 @@ A deployment needs one canonical HTTPS origin:
 https://broker.example.com                       # public CLI + browser-login route
 ```
 
-For Code portal origin isolation, the same coordinator can also receive a
-wildcard route configured through:
+Browser Code requires the same coordinator to receive an isolated wildcard
+route configured through:
 
 ```text
 CRABBOX_CODE_ORIGIN_TEMPLATE=https://{lease}.code.example.com

--- a/docs/features/portable-coordinator.md
+++ b/docs/features/portable-coordinator.md
@@ -107,7 +107,7 @@ Core runtime:
 DATABASE_URL                         required PostgreSQL connection string; use verified TLS remotely
 PORT                                 listener port, default 8080
 CRABBOX_PUBLIC_URL                   canonical external origin
-CRABBOX_CODE_ORIGIN_TEMPLATE         optional HTTPS per-lease Code origin template; ingress needs wildcard TLS/WebSockets
+CRABBOX_CODE_ORIGIN_TEMPLATE         required for browser Code; HTTPS per-lease template needs wildcard TLS/WebSockets
 CRABBOX_DATABASE_POOL_SIZE           PostgreSQL pool size, default 10
 CRABBOX_DATABASE_CONNECT_TIMEOUT_MS  connection timeout, default 10000
 CRABBOX_SHUTDOWN_TIMEOUT_MS          graceful shutdown budget, default 120000

--- a/docs/features/portal.md
+++ b/docs/features/portal.md
@@ -55,8 +55,8 @@ health payload). When
 origin (for example a `*.workers.dev` preview URL), the Worker redirects to
 the canonical host first.
 
-Deployments can isolate lease-controlled code-server content from the
-coordinator and from other leases by setting
+Deployments that expose browser Code must isolate lease-controlled code-server
+content from the coordinator and from other leases by setting
 `CRABBOX_CODE_ORIGIN_TEMPLATE=https://{lease}.code.example.com` and routing
 `*.code.example.com` to the same coordinator. The existing
 `/portal/leases/{id-or-slug}/code/` URL remains the entrypoint: after normal
@@ -71,10 +71,9 @@ Portal logout revokes isolated Code viewer sessions server-side, so their
 separate host-scoped cookies cannot retain access after the portal cookie is
 cleared.
 
-The setting is opt-in because Crabbox cannot provision an operator's wildcard
-DNS, certificate, or ingress route. When the setting is absent or invalid, Code
-keeps its existing same-origin behavior for compatibility; operators who share
-a coordinator between people should configure the isolated origin.
+Crabbox cannot provision an operator's wildcard DNS, certificate, or ingress
+route. When the setting is absent or invalid, Code health remains available but
+browser HTTP and WebSocket traffic fails closed with `409 Code origin required`.
 
 ## Authentication and scope
 

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -165,7 +165,7 @@ Required service settings:
 DATABASE_URL                         # PostgreSQL connection string
 PORT                                 # optional; default 8080
 CRABBOX_PUBLIC_URL                   # canonical external origin
-CRABBOX_CODE_ORIGIN_TEMPLATE         # optional https://{lease}.code.example.com isolation route
+CRABBOX_CODE_ORIGIN_TEMPLATE         # required for browser Code; https://{lease}.code.example.com
 CRABBOX_SHUTDOWN_TIMEOUT_MS          # optional; default 120000
 ```
 
@@ -635,7 +635,7 @@ CRABBOX_ACCESS_TEAM_DOMAIN, CRABBOX_ACCESS_AUD   # Cloudflare Access route
 CRABBOX_TRUSTED_USER_HEADER, CRABBOX_TRUSTED_USER_ORG
 CRABBOX_TRUSTED_PROXY_CIDRS              # Node runtime peer allowlist
 CRABBOX_PUBLIC_URL                       # canonical coordinator URL for OAuth callback
-CRABBOX_CODE_ORIGIN_TEMPLATE             # optional per-lease Code origin template
+CRABBOX_CODE_ORIGIN_TEMPLATE             # required for browser Code; per-lease HTTPS origin template
 
 # Cost / limits
 CRABBOX_MAX_ACTIVE_LEASES[_PER_OWNER|_PER_ORG]

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -362,7 +362,7 @@ provider. Shared-token automation needs `CRABBOX_SHARED_TOKEN` and
 Provider choices are `HETZNER_TOKEN`, an AWS credential set, an Azure service
 principal, or a GCP service account. Node additionally requires `DATABASE_URL`.
 
-For a shared portal, configure
+For any portal that exposes browser Code, configure
 `CRABBOX_CODE_ORIGIN_TEMPLATE=https://{lease}.code.example.com` and route the
 matching wildcard hostname to the same coordinator with TLS and WebSocket
 support. This preserves the normal Code links while moving each lease's
@@ -384,7 +384,7 @@ CRABBOX_WORKSPACE_PREWARM_COUNT   optional ready spares per active organization;
 CRABBOX_GITHUB_CLIENT_ID          required for browser login
 CRABBOX_GITHUB_CLIENT_SECRET      required for browser login
 CRABBOX_SESSION_SECRET            required for browser login; must differ from CRABBOX_SHARED_TOKEN
-CRABBOX_CODE_ORIGIN_TEMPLATE      optional per-lease Code origin isolation
+CRABBOX_CODE_ORIGIN_TEMPLATE      required for browser Code; per-lease HTTPS origin template
 CRABBOX_GITHUB_ALLOWED_ORG or CRABBOX_GITHUB_ALLOWED_ORGS
 CRABBOX_GITHUB_ALLOWED_TEAMS      optional
 CRABBOX_ACCESS_TEAM_DOMAIN        required for Access JWT verification

--- a/docs/security.md
+++ b/docs/security.md
@@ -40,12 +40,12 @@ per-tenant isolation is not the current security boundary. Local providers and
 portal bridges are development execution surfaces, not a uniform sandbox for
 hostile project configuration or mutually adversarial workloads.
 
-For cooperative shared portals, configure the optional per-lease
+For any portal that exposes browser Code, configure the required per-lease
 `CRABBOX_CODE_ORIGIN_TEMPLATE` described in [Browser portal](features/portal.md).
 It keeps lease-controlled code-server HTML and JavaScript off the coordinator
 origin and off other leases' browser origins without changing the normal Code
-entry URL. This is defense-in-depth for supported sharing and admin inspection;
-it does not turn the broker into a hostile multitenant sandbox.
+entry URL. Browser Code fails closed when this setting is missing or invalid.
+This isolation does not turn the broker into a hostile multitenant sandbox.
 
 ## Authentication
 

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -7430,7 +7430,14 @@ export class FleetCoordinator {
       return this.codePortalHealth(lease, agent);
     }
     const isolatedOrigin = await codeOriginForLease(this.env, lease.id);
-    if (!isolated && isolatedOrigin && new URL(request.url).origin !== isolatedOrigin) {
+    if (!isolatedOrigin) {
+      return portalError(
+        "Code origin required",
+        "Browser Code requires a valid CRABBOX_CODE_ORIGIN_TEMPLATE with wildcard TLS and WebSocket routing.",
+        409,
+      );
+    }
+    if (!isolated) {
       return await this.redirectCodeViewer(request, lease, isolatedOrigin);
     }
     if (!agent || agent.readyState !== WebSocket.OPEN) {

--- a/worker/test/code-origin.test.ts
+++ b/worker/test/code-origin.test.ts
@@ -17,7 +17,7 @@ describe("isolated Code origins", () => {
     await expect(codeOriginForLease(env, "cbx_000000000001")).resolves.toBe(first);
   });
 
-  it("rejects invalid templates without changing existing Code behavior", async () => {
+  it("rejects invalid templates so browser Code can fail closed", async () => {
     const templates = [
       "http://{lease}.code.example.test",
       "https://code.example.test/{lease}",

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { issueUserToken, sha256Hex } from "../src/auth";
 import { EC2SpotClient } from "../src/aws";
+import { codeOriginForLease } from "../src/code-origin";
 import {
   awsPromotedAMIConfigKey,
   leaseConfig,
@@ -13861,7 +13862,7 @@ describe("fleet lease identity and idle", () => {
     });
   });
 
-  it("serves code pages only for code leases and requires a bridge ticket", async () => {
+  it("fails closed without an isolated Code origin while retaining health and bridge tickets", async () => {
     const storage = new MemoryStorage();
     const fleet = testFleet(storage);
     const headers = {
@@ -13894,18 +13895,10 @@ describe("fleet lease identity and idle", () => {
     const page = await fleet.fetch(
       request("GET", "/portal/leases/blue-lobster/code/", { headers }),
     );
-    expect(page.status).toBe(200);
+    expect(page.status).toBe(409);
     const pageBody = await page.text();
-    expect(pageBody).toContain("crabbox code --id blue-lobster --open");
-    expect(pageBody).toContain('class="vnc-page code-wait-page"');
-    expect(pageBody).toContain("<h1>🦀 crabbox</h1>");
-    expect(pageBody).toContain("code blue-lobster");
-    expect(pageBody).toContain('id="code-status"');
-    expect(pageBody).toContain('id="code-copy"');
-    expect(pageBody).toContain("/portal/leases/cbx_000000000001/code/health");
-    expect(pageBody).toContain("window.location.reload()");
-    expect(pageBody).toContain("terminalStatusCodes");
-    expect(pageBody).toContain("stopPolling(message)");
+    expect(pageBody).toContain("Code origin required");
+    expect(pageBody).toContain("CRABBOX_CODE_ORIGIN_TEMPLATE");
 
     const health = await fleet.fetch(
       request("GET", "/portal/leases/blue-lobster/code/health", { headers }),
@@ -13942,6 +13935,94 @@ describe("fleet lease identity and idle", () => {
       }),
     );
     expect(missingTicket.status).toBe(401);
+  });
+
+  it("blocks Code HTTP and WebSocket proxying for invalid origin templates", async () => {
+    await Promise.all(
+      [undefined, "https://code.example.test/{lease}"].map(async (template) => {
+        const storage = new MemoryStorage();
+        const fleet = testFleet(storage, {}, { CRABBOX_CODE_ORIGIN_TEMPLATE: template });
+        const leaseID = "cbx_000000000001";
+        storage.seed(
+          `lease:${leaseID}`,
+          testLease({
+            id: leaseID,
+            slug: "blue-lobster",
+            owner: "alice@example.com",
+            org: "example-org",
+            code: true,
+            expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+          }),
+        );
+        const agent = new FakeWebSocket({ kind: "code-agent", leaseID });
+        const relay = fleet as unknown as { codeAgents: Map<string, WebSocket> };
+        relay.codeAgents.set(leaseID, agent as unknown as WebSocket);
+        const headers = {
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
+        };
+
+        const page = await fleet.fetch(
+          request("GET", "/portal/leases/blue-lobster/code/api/status", { headers }),
+        );
+        expect(page.status).toBe(409);
+        const socket = await fleet.fetch(
+          request("GET", "/portal/leases/blue-lobster/code/websocket", {
+            headers: { ...headers, origin: "https://example.test", upgrade: "websocket" },
+          }),
+        );
+        expect(socket.status).toBe(409);
+        expect(agent.sentJSON()).toEqual([]);
+      }),
+    );
+  });
+
+  it("redirects owners, managers, and admins to the isolated Code origin", async () => {
+    const storage = new MemoryStorage();
+    const env = { CRABBOX_CODE_ORIGIN_TEMPLATE: "https://{lease}.code.example.test" };
+    const fleet = testFleet(storage, {}, env);
+    const leaseID = "cbx_000000000001";
+    storage.seed(
+      `lease:${leaseID}`,
+      testLease({
+        id: leaseID,
+        slug: "blue-lobster",
+        owner: "owner@example.com",
+        org: "example-org",
+        code: true,
+        share: { users: { "manager@example.com": "manage" } },
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      }),
+    );
+    const isolatedOrigin = await codeOriginForLease(env, leaseID);
+    expect(isolatedOrigin).toBeDefined();
+    const viewers = [
+      {
+        "x-crabbox-auth": "bearer",
+        "x-crabbox-owner": "owner@example.com",
+        "x-crabbox-org": "example-org",
+      },
+      {
+        "x-crabbox-auth": "bearer",
+        "x-crabbox-owner": "manager@example.com",
+        "x-crabbox-org": "other-org",
+      },
+      {
+        "x-crabbox-auth": "bearer",
+        "x-crabbox-owner": "admin@example.com",
+        "x-crabbox-org": "other-org",
+        "x-crabbox-admin": "true",
+      },
+    ];
+    await Promise.all(
+      viewers.map(async (headers) => {
+        const redirect = await fleet.fetch(
+          request("GET", "/portal/leases/blue-lobster/code/", { headers }),
+        );
+        expect(redirect.status).toBe(302);
+        expect(new URL(redirect.headers.get("location") || "").origin).toBe(isolatedOrigin);
+      }),
+    );
   });
 
   it("bootstraps a one-time lease-scoped Code session on an isolated origin", async () => {
@@ -14610,7 +14691,8 @@ describe("fleet lease identity and idle", () => {
 
   it("strips Crabbox auth context from Code proxy bridge messages", async () => {
     const storage = new MemoryStorage();
-    const fleet = testFleet(storage);
+    const env = { CRABBOX_CODE_ORIGIN_TEMPLATE: "https://{lease}.code.example.test" };
+    const fleet = testFleet(storage, {}, env);
     const leaseID = "cbx_000000000001";
     storage.seed(
       `lease:${leaseID}`,
@@ -14626,6 +14708,19 @@ describe("fleet lease identity and idle", () => {
     const agent = new FakeWebSocket({ kind: "code-agent", leaseID });
     const relay = fleet as unknown as { codeAgents: Map<string, WebSocket> };
     relay.codeAgents.set(leaseID, agent as unknown as WebSocket);
+    const session = `code_session_${"a".repeat(32)}`;
+    storage.seed(`code-viewer-session:${session}`, {
+      session,
+      leaseID,
+      auth: "bearer",
+      admin: false,
+      owner: "alice@example.com",
+      org: "example-org",
+      createdAt: new Date().toISOString(),
+      expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+    });
+    const isolatedOrigin = await codeOriginForLease(env, leaseID);
+    expect(isolatedOrigin).toBeDefined();
     let forwarded: { id: string; headers: Record<string, string> } | undefined;
     agent.onSend = (data) => {
       forwarded = JSON.parse(data) as { id: string; headers: Record<string, string> };
@@ -14636,23 +14731,18 @@ describe("fleet lease identity and idle", () => {
     };
 
     const response = await fleet.fetch(
-      request("GET", "/portal/leases/blue-lobster/code/api/status", {
+      new Request(`${isolatedOrigin}/portal/leases/${leaseID}/code/api/status`, {
         headers: {
-          "x-crabbox-auth": "github",
-          "x-crabbox-admin": "false",
-          "x-crabbox-owner": "alice@example.com",
-          "x-crabbox-org": "example-org",
-          "x-crabbox-github-login": "alice",
-          "x-crabbox-token-expires-at": "2026-07-01T12:00:00Z",
+          cookie: `crabbox_code_session=${session}`,
           "x-client-trace": "trace-1",
-          origin: "https://broker.example.com",
+          origin: isolatedOrigin || "",
         },
       }),
     );
 
     expect(response.status).toBe(204);
     expect(forwarded?.headers).toMatchObject({
-      origin: "https://broker.example.com",
+      origin: isolatedOrigin,
       "x-client-trace": "trace-1",
     });
     expect(


### PR DESCRIPTION
## Summary

- fail closed with `409 Code origin required` before browser Code HTTP or WebSocket traffic can reach a bridge agent when the isolated-origin template is missing or invalid
- always redirect authorized non-isolated entrypoints to the canonical opaque per-lease origin while retaining the authenticated health JSON exception
- require isolated browser Code deployment in the security, portal, command, routing, infrastructure, and operations documentation

Closes https://github.com/openclaw/crabbox/issues/725

## Verification

- `npm test --prefix worker` — 734 tests passed
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm run check:node --prefix worker`
- `npm run build --prefix worker`
- `node scripts/build-docs-site.mjs`
- regression coverage proves missing and invalid templates block HTTP and WebSocket forwarding with zero agent messages
- regression coverage proves owner, manager, and admin entrypoints redirect to the isolated lease origin
- autoreview: clean

Live wildcard DNS, TLS, WebSocket ingress, and logged-in browser proof were not run because that deployment route is not currently available. The fail-closed boundary, redirects, session scoping, and zero-forwarding behavior are covered at the Worker integration boundary.
