### PR TITLE
fix(worker): restrict Azure lease selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Restricted brokered Azure image and OS-disk selectors to admin-authenticated requests while preserving user-selectable Azure placement. Thanks @coygeek.
+
 ## 0.34.0 - 2026-07-02
 
 ### Added

--- a/docs/providers/azure.md
+++ b/docs/providers/azure.md
@@ -183,8 +183,10 @@ Brokered leases reuse the same Azure service-principal secrets on the coordinato
 `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, and
 `AZURE_SUBSCRIPTION_ID`. Operators own the resource group, vnet, subnet, NSG, OS
 disk mode, and SSH CIDR defaults through the `CRABBOX_AZURE_*` env vars on the
-Worker. A lease request may override only `azureLocation`, `azureImage`, and
-`azureOSDisk`.
+Worker. Explicit broker requests for `azureImage` and `azureOSDisk` require
+admin-token authentication. Normal broker users receive coordinator-managed
+image and OS-disk values; `azureLocation` remains user-selectable for capacity
+routing. Direct mode keeps these local overrides.
 Set `CRABBOX_AZURE_WINDOWS_ARM64_IMAGE` on the coordinator when brokered Azure
 Windows ARM64 leases need a default ARM64 Windows image without changing the
 global `CRABBOX_AZURE_IMAGE` fallback used by existing custom-image leases.

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -15840,6 +15840,12 @@ class AzureProvider implements CloudProvider {
     return this.clientValue;
   }
 
+  restrictedLeaseRequestFields(input: LeaseRequest): string[] {
+    return [input.azureImage ? "azureImage" : "", input.azureOSDisk ? "azureOSDisk" : ""].filter(
+      Boolean,
+    );
+  }
+
   listCrabboxServers(): Promise<ProviderMachine[]> {
     return this.client.listCrabboxServers();
   }

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -129,6 +129,12 @@ const restrictedBrokerSelectorCases = [
     field: "gcpServiceAccount",
     value: "runner@other-project.iam.gserviceaccount.com",
   },
+  {
+    provider: "azure" as const,
+    field: "azureImage",
+    value: "Canonical:0001-com-ubuntu-server-noble:24_04-lts-gen2:latest",
+  },
+  { provider: "azure" as const, field: "azureOSDisk", value: "ephemeral" },
 ];
 
 class FakeWebSocket {
@@ -3653,6 +3659,14 @@ describe("fleet lease identity and idle", () => {
       },
       body: { os: "ubuntu:24.04" },
     },
+    {
+      provider: "azure" as const,
+      env: {
+        CRABBOX_AZURE_IMAGE: "Canonical:0001-com-ubuntu-server-noble:24_04-lts-gen2:latest",
+        CRABBOX_AZURE_OS_DISK: "ephemeral",
+      },
+      body: {},
+    },
   ])(
     "does not treat coordinator $provider defaults as caller-supplied selectors",
     async ({ provider, env, body }) => {
@@ -3681,6 +3695,37 @@ describe("fleet lease identity and idle", () => {
       expect((await storage.list()).size).toBe(0);
     },
   );
+
+  it("allows brokered Azure location selection without admin auth", async () => {
+    const storage = new MemoryStorage();
+    const providerFetch = vi.fn<typeof fetch>();
+    vi.stubGlobal("fetch", providerFetch);
+    const fleet = testFleet(storage);
+
+    const response = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers: {
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
+        },
+        body: {
+          leaseID: "cbx_abcdef123456",
+          provider: "azure",
+          azureLocation: "westus3",
+          sshPublicKey: "ssh-ed25519 azure-location-test",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(424);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "provider_not_configured",
+      provider: "azure",
+    });
+    expect(providerFetch).not.toHaveBeenCalled();
+    expect((await storage.list()).size).toBe(0);
+    expect(storage.alarm()).toBeUndefined();
+  });
 
   it("skips broker selector restrictions for internal workspace provisioning", async () => {
     let created = false;


### PR DESCRIPTION
## Summary

- require admin authentication for brokered Azure image and OS-disk selectors
- preserve non-admin Azure location selection for capacity routing
- keep coordinator-managed defaults and direct-mode overrides unchanged
- document the authorization boundary and add the Unreleased changelog entry

Closes https://github.com/openclaw/crabbox/issues/785

## Verification

- `npm test --prefix worker -- test/fleet.test.ts` (343 passed)
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- autoreview: clean, no accepted/actionable findings

The regression tests prove denial occurs before provider fetch, storage writes, or alarm scheduling; live Azure mutation cannot strengthen that preflight authorization proof.
