### PR TITLE
feat: add watch command for warm-lease reruns on local file changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added `crabbox watch` to reuse one warm SSH lease, coalesce qualifying local changes into sequential runs through the normal sync/history pipeline, and release newly acquired leases on bounded idle or exit. Thanks @yetval.
 - Added Vast.ai direct Linux GPU SSH leases with guarded offer cost and reliability selection, per-lease keys, account-bound cleanup, required-tool bootstrap, and billable live-smoke coverage. Thanks @coygeek.
 
 ### Fixed

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -42,6 +42,7 @@ crabbox warmup [lease flags]                 lease a box and wait until ready
 crabbox run -- <command...>                  sync, run a remote command, stream output
 crabbox run --pool <key> -- <command...>     borrow a hydrated ready-pool lease
 crabbox run --timing-record=default -- <cmd> append timing to the local benchmark ledger
+crabbox watch -- <command...>                re-run on a warm lease when local files change
 crabbox bench run --providers a,b -- <cmd>   run a workload and record benchmark timings
 crabbox status --id <id>                     show lease state (--wait to block)
 crabbox inspect --id <id>                     print lease/provider details
@@ -54,6 +55,7 @@ crabbox pool ready [key]                      list hydrated broker ready-pool le
 ```
 
 See [warmup](commands/warmup.md), [run](commands/run.md),
+[watch](commands/watch.md),
 [status](commands/status.md), [inspect](commands/inspect.md),
 [list](commands/list.md), [share](commands/share.md),
 [unshare](commands/unshare.md), [stop](commands/stop.md),

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -16,6 +16,7 @@ same order as the CLI help.
 - [warmup](warmup.md)
 - [prewarm](prewarm.md)
 - [run](run.md)
+- [watch](watch.md)
 - [bench](bench.md)
 - [job](job.md)
 - [desktop](desktop.md)

--- a/docs/commands/watch.md
+++ b/docs/commands/watch.md
@@ -31,7 +31,8 @@ rejected with an error; use `crabbox run` for those.
 The initial run starts immediately. After that, filesystem events are debounced
 (default `250ms`) and each batch is qualified against the exact sync universe:
 Git tracked and non-ignored untracked files, minus the built-in excludes,
-`sync.exclude` config, and `.crabboxignore` rules. Ignored churn such as
+`sync.exclude` config, and `.crabboxignore` rules, and limited to the
+`sync.include` whitelist when one is configured. Ignored churn such as
 `node_modules` or build output never triggers a run and never counts as
 activity. Edits to `.gitignore`, `.crabboxignore`, or repo-local config are
 picked up live. Newly created directories are watched recursively; symlinked

--- a/docs/commands/watch.md
+++ b/docs/commands/watch.md
@@ -1,0 +1,86 @@
+# watch
+
+`crabbox watch` runs a command on a warm lease, then watches the local
+repository and re-runs the command whenever synced files change. Each iteration
+goes through the normal [`crabbox run`](run.md) pipeline against the same held
+lease, so sync fingerprints, run history, results, artifacts, and
+[`attach`](attach.md) behave exactly as they do for `run`. It automates the
+manual warm-lease loop described in the [performance guide](../performance.md).
+
+```sh
+crabbox watch -- pnpm test:changed
+crabbox watch --id swift-crab -- go test ./...
+crabbox watch --debounce 500ms --idle-exit 10m -- pnpm check
+crabbox watch --provider hetzner --keep -- make test
+```
+
+Requires an SSH lease provider that advertises the `crabbox-sync` feature (see
+[`crabbox providers`](providers.md)). Delegated and archive-sync providers are
+rejected with an error; use `crabbox run` for those.
+
+## Lease lifecycle
+
+- With `--id`, watch reuses an existing claimed lease and never releases it;
+  exiting the loop leaves the box running, like `crabbox run --id`.
+- Without `--id`, watch acquires a fresh lease (all `warmup` lease-creation
+  flags apply) and releases it on every exit path: idle exit, Ctrl-C, and
+  failures. Pass `--keep` to retain the lease instead.
+
+## Change detection
+
+The initial run starts immediately. After that, filesystem events are debounced
+(default `250ms`) and each batch is qualified against the exact sync universe:
+Git tracked and non-ignored untracked files, minus the built-in excludes,
+`sync.exclude` config, and `.crabboxignore` rules. Ignored churn such as
+`node_modules` or build output never triggers a run and never counts as
+activity. Edits to `.gitignore`, `.crabboxignore`, or repo-local config are
+picked up live. Newly created directories are watched recursively; symlinked
+directories outside the repository root are not followed.
+
+Runs never overlap. A change that lands while a run is active queues exactly
+one rerun, which starts from the newest tree once the active run finishes. A
+non-zero remote exit is a normal iteration result and the loop keeps watching;
+watcher, lease, and sync failures end the loop. One Ctrl-C exits and applies
+the lease lifecycle rules above.
+
+The loop exits on its own after `--idle-exit` without qualifying local changes.
+It defaults to the effective lease idle timeout and must not exceed it; raise
+`--idle-timeout` as well for longer sessions.
+
+## Flags
+
+```text
+--id <id-or-slug>      Reuse an existing claimed lease instead of acquiring one.
+--keep                 Keep an acquired lease when the watch loop exits.
+--debounce <duration>  Quiet period before a change batch triggers a rerun (default 250ms).
+--idle-exit <duration> Exit after this period without qualifying changes; defaults to
+                       the lease idle timeout and must not exceed it.
+```
+
+Lease-creation flags (`--provider`, `--class`, `--ttl`, `--idle-timeout`,
+`--slug`, ...) apply when acquiring a fresh lease. Most other `run` flags, such
+as `--shell`, `--junit`, `--allow-env`, or `--preset`, pass through to every
+iteration. Flags that conflict with a persistent session are rejected:
+`--pool`, `--pool-return`, `--sync-only`, `--no-sync`, `--apply-local-patch`,
+`--fresh-pr`, `--script`, `--script-stdin`, `--stop-after`, `--lease-output`,
+`--keep-on-failure`, `--capture-stdout`, `--capture-stderr`, `--download`,
+`--emit-proof`, and `--proof-template`. `--label` is reserved: watch labels
+each iteration `watch #N` so runs stay readable in [`history`](history.md).
+
+## Output
+
+Lease and per-iteration run output match `crabbox run`. The loop itself prints
+progress to stderr:
+
+```text
+watch root=/home/alice/my-app debounce=250ms idle_exit=30m0s
+watch run=2 changes=3
+watch idle_exit=30m0s runs=2
+```
+
+## Related docs
+
+- [run](run.md) — the pipeline each iteration executes.
+- [warmup](warmup.md) — lease a reusable box explicitly.
+- [history](history.md) — recorded runs, one per iteration.
+- [Performance guide](../performance.md) — warm leases and sync behavior.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -48,6 +48,15 @@ bin/crabbox stop swift-crab
 You can pass the lease slug (for example `swift-crab`) or its canonical id
 (`cbx_…`) to `--id`.
 
+[`crabbox watch`](commands/watch.md) automates this loop: it holds one warm
+lease, re-runs the command on every qualifying local change, and exits after a
+quiet period (`--idle-exit`, capped at the lease idle timeout) so an abandoned
+watcher does not keep a box alive:
+
+```sh
+bin/crabbox watch --id swift-crab -- pnpm test:changed:max
+```
+
 ## Sync size
 
 `crabbox run` syncs a Git-derived manifest: tracked files plus non-ignored

--- a/go.mod
+++ b/go.mod
@@ -86,6 +86,7 @@ require (
 	github.com/daytonaio/daytona/libs/toolbox-api-client-go v0.183.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/fsnotify/fsnotify v1.10.1
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -77,6 +77,8 @@ func (a App) directCommandHelp(ctx context.Context, args []string) (error, bool)
 		return a.prewarm(ctx, helpArgs), true
 	case "run":
 		return a.runCommand(ctx, helpArgs), true
+	case "watch":
+		return a.watch(ctx, helpArgs), true
 	case "job":
 		return nil, false
 	case "sync-plan":
@@ -174,6 +176,7 @@ Commands:
   warmup      Lease a box and wait until it is ready
   prewarm     Lease and hydrate a reusable test-ready box
   run         Sync the repo, run a remote command, stream output
+  watch       Re-run a command on a warm lease when local files change
   bench       Record and report local benchmark timings
   job         Run named repo-local Crabbox jobs
   desktop     Launch apps into a visible desktop session

--- a/internal/cli/cli_kong.go
+++ b/internal/cli/cli_kong.go
@@ -20,6 +20,7 @@ type crabboxKongCLI struct {
 	Warmup      warmupKongCmd      `cmd:"" passthrough:"" help:"Lease a box and wait until it is ready."`
 	Prewarm     prewarmKongCmd     `cmd:"" passthrough:"" help:"Lease and hydrate a reusable test-ready box."`
 	Run         runKongCmd         `cmd:"" passthrough:"" help:"Sync the repo, run a remote command, stream output."`
+	Watch       watchKongCmd       `cmd:"" passthrough:"" help:"Re-run a command on a warm lease when local files change."`
 	Bench       benchKongCmd       `cmd:"" help:"Record and report local benchmark timings."`
 	Job         jobKongCmd         `cmd:"" help:"Run named repo-local Crabbox jobs."`
 	Desktop     desktopKongCmd     `cmd:"" help:"Launch apps into a visible desktop session."`
@@ -156,6 +157,9 @@ type prewarmKongCmd struct {
 	Args []string `arg:"" optional:""`
 }
 type runKongCmd struct {
+	Args []string `arg:"" optional:""`
+}
+type watchKongCmd struct {
 	Args []string `arg:"" optional:""`
 }
 type benchKongCmd struct {
@@ -602,6 +606,7 @@ func (c *doctorKongCmd) Run(ctx context.Context, app App) error  { return app.do
 func (c *warmupKongCmd) Run(ctx context.Context, app App) error  { return app.warmup(ctx, c.Args) }
 func (c *prewarmKongCmd) Run(ctx context.Context, app App) error { return app.prewarm(ctx, c.Args) }
 func (c *runKongCmd) Run(ctx context.Context, app App) error     { return app.runCommand(ctx, c.Args) }
+func (c *watchKongCmd) Run(ctx context.Context, app App) error   { return app.watch(ctx, c.Args) }
 func (c *benchRunKongCmd) Run(ctx context.Context, app App) error {
 	return app.benchRun(ctx, c.Args)
 }

--- a/internal/cli/watch.go
+++ b/internal/cli/watch.go
@@ -245,6 +245,13 @@ type watchSession struct {
 	stderr   io.Writer
 	excludes []string
 	watcher  *fsnotify.Watcher
+	paths    map[string]watchPathState
+}
+
+type watchPathState struct {
+	mode    fs.FileMode
+	size    int64
+	modTime int64
 }
 
 func (s *watchSession) run(ctx context.Context) error {
@@ -259,8 +266,13 @@ func (s *watchSession) run(ctx context.Context) error {
 	}
 	defer watcher.Close()
 	s.watcher = watcher
-	if _, err := addWatchTree(watcher, s.root, s.root, s.excludes); err != nil {
+	files, err := addWatchTree(watcher, s.root, s.root, s.excludes)
+	if err != nil {
 		return exit(1, "watch: watch %s: %v", s.root, err)
+	}
+	s.paths = make(map[string]watchPathState, len(files))
+	for _, rel := range files {
+		s.rememberPath(rel, filepath.Join(s.root, filepath.FromSlash(rel)))
 	}
 	fmt.Fprintf(s.stderr, "watch root=%s debounce=%s idle_exit=%s\n", s.root, s.debounce, s.idleExit)
 
@@ -387,10 +399,17 @@ func (s *watchSession) observeEvent(watcher *fsnotify.Watcher, event fsnotify.Ev
 	if rel == "." || !safeRepoRel(rel) || pathExcluded(rel, s.excludes) {
 		return false
 	}
+	if event.Op == fsnotify.Chmod && !s.rememberPath(rel, event.Name) {
+		return false
+	}
+	if event.Op != fsnotify.Chmod {
+		s.rememberPath(rel, event.Name)
+	}
 	if event.Op&fsnotify.Create != 0 {
 		if info, err := os.Lstat(event.Name); err == nil && info.IsDir() {
 			if files, err := addWatchTree(watcher, s.root, event.Name, s.excludes); err == nil {
 				for _, file := range files {
+					s.rememberPath(file, filepath.Join(s.root, filepath.FromSlash(file)))
 					batch[file] = struct{}{}
 				}
 			}
@@ -398,6 +417,22 @@ func (s *watchSession) observeEvent(watcher *fsnotify.Watcher, event fsnotify.Ev
 	}
 	batch[rel] = struct{}{}
 	return true
+}
+
+func (s *watchSession) rememberPath(rel, name string) bool {
+	if s.paths == nil {
+		s.paths = map[string]watchPathState{}
+	}
+	info, err := os.Lstat(name)
+	if err != nil {
+		_, existed := s.paths[rel]
+		delete(s.paths, rel)
+		return existed
+	}
+	current := watchPathState{mode: info.Mode(), size: info.Size(), modTime: info.ModTime().UnixNano()}
+	previous, existed := s.paths[rel]
+	s.paths[rel] = current
+	return !existed || current != previous
 }
 
 func (s *watchSession) qualifyBatch(paths []string) ([]string, error) {

--- a/internal/cli/watch.go
+++ b/internal/cli/watch.go
@@ -1,0 +1,640 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+type watchRunExecutor func(ctx context.Context, runArgs []string) error
+
+var watchForbiddenRunFlags = map[string]bool{
+	"pool":              true,
+	"pool-return":       true,
+	"sync-only":         true,
+	"no-sync":           true,
+	"apply-local-patch": true,
+	"fresh-pr":          true,
+	"script":            true,
+	"script-stdin":      true,
+	"stop-after":        true,
+	"lease-output":      true,
+	"keep-on-failure":   true,
+	"capture-stdout":    true,
+	"capture-stderr":    true,
+	"download":          true,
+	"emit-proof":        true,
+	"proof-template":    true,
+	"label":             true,
+}
+
+var watchOwnedOnlyFlags = map[string]bool{
+	"id":        true,
+	"keep":      true,
+	"debounce":  true,
+	"idle-exit": true,
+	"slug":      true,
+}
+
+var watchFilterSourceFiles = map[string]bool{
+	".crabboxignore": true,
+	"crabbox.yaml":   true,
+	".crabbox.yaml":  true,
+}
+
+type watchOptions struct {
+	LeaseID        string
+	Keep           bool
+	Reclaim        bool
+	Debounce       time.Duration
+	IdleExit       time.Duration
+	IdleExitSet    bool
+	IdleTimeoutSet bool
+	RequestedSlug  string
+	RunArgs        []string
+	Command        []string
+}
+
+func (a App) watch(ctx context.Context, args []string) error {
+	defaults := defaultConfig()
+	fs := newFlagSet("watch", a.Stderr)
+	fs.Usage = func() {
+		fmt.Fprintln(fs.Output(), "Usage:")
+		fmt.Fprintln(fs.Output(), "  crabbox watch [flags] -- <command...>")
+		fmt.Fprintln(fs.Output(), "")
+		fmt.Fprintln(fs.Output(), "Runs the command once on a warm lease, then watches the repository and")
+		fmt.Fprintln(fs.Output(), "re-runs it when synced files change. Reruns queue while a run is active;")
+		fmt.Fprintln(fs.Output(), "at most one rerun is pending. Requires an SSH lease provider with the")
+		fmt.Fprintln(fs.Output(), "crabbox-sync feature. Other run flags pass through to each iteration.")
+		fmt.Fprintln(fs.Output(), "")
+		fmt.Fprintln(fs.Output(), "Flags:")
+		fs.PrintDefaults()
+	}
+	leaseFlags := registerLeaseCreateFlags(fs, defaults)
+	leaseIDFlag := fs.String("id", "", "existing lease or server id")
+	keep := fs.Bool("keep", false, "keep an acquired lease when the watch loop exits")
+	reclaim := fs.Bool("reclaim", false, "claim this lease for the current repo")
+	debounce := fs.Duration("debounce", 250*time.Millisecond, "quiet period before a change batch triggers a rerun")
+	idleExit := fs.Duration("idle-exit", 0, "exit after this period without qualifying local changes; defaults to the lease idle timeout")
+	flagArgs, command := splitWatchArgs(args)
+	watchArgs, runArgs, err := partitionWatchRunArgs(fs, flagArgs)
+	if err != nil {
+		return err
+	}
+	if err := parseFlags(fs, watchArgs); err != nil {
+		return err
+	}
+	if fs.NArg() > 0 {
+		return exit(2, "unexpected argument %q; place the command after --", fs.Arg(0))
+	}
+	if len(command) == 0 {
+		return exit(2, "usage: crabbox watch [flags] -- <command...>")
+	}
+	if *debounce <= 0 {
+		return exit(2, "--debounce must be positive")
+	}
+	requestedSlug, err := requestedLeaseSlug(*leaseFlags.Slug)
+	if err != nil {
+		return err
+	}
+	if requestedSlug != "" && strings.TrimSpace(*leaseIDFlag) != "" {
+		return exit(2, "--slug only applies when creating a new lease; omit --id or use the existing slug")
+	}
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
+	}
+	if err := applyLeaseCreateFlagsForLease(&cfg, fs, leaseFlags, *leaseIDFlag); err != nil {
+		return err
+	}
+	repo, err := findRepo()
+	if err != nil {
+		return err
+	}
+	backend, err := loadBackend(cfg, runtimeForApp(a))
+	if err != nil {
+		return err
+	}
+	sshBackend, err := watchBackendGate(backend)
+	if err != nil {
+		return err
+	}
+	opts := watchOptions{
+		LeaseID:        strings.TrimSpace(*leaseIDFlag),
+		Keep:           *keep,
+		Reclaim:        *reclaim,
+		Debounce:       *debounce,
+		IdleExit:       *idleExit,
+		IdleExitSet:    flagWasSet(fs, "idle-exit"),
+		IdleTimeoutSet: flagWasSet(fs, "idle-timeout"),
+		RequestedSlug:  requestedSlug,
+		RunArgs:        runArgs,
+		Command:        command,
+	}
+	return a.watchWithBackend(ctx, opts, repo, cfg, sshBackend, func(runCtx context.Context, iterationArgs []string) error {
+		return a.runCommand(runCtx, iterationArgs)
+	})
+}
+
+func watchBackendGate(backend Backend) (SSHLeaseBackend, error) {
+	sshBackend, ok := backend.(SSHLeaseBackend)
+	if !ok || !backend.Spec().Features.Has(FeatureCrabboxSync) {
+		return nil, exit(2, "provider=%s does not support watch: it requires an SSH lease provider with the crabbox-sync feature; use crabbox run instead", backend.Spec().Name)
+	}
+	return sshBackend, nil
+}
+
+func (a App) watchWithBackend(ctx context.Context, opts watchOptions, repo Repo, cfg Config, backend SSHLeaseBackend, execute watchRunExecutor) error {
+	options := leaseOptionsFromConfig(cfg)
+	if opts.LeaseID != "" {
+		lease, err := resolveSSHLeaseTarget(ctx, backend, ResolveRequest{Repo: repo, Options: options, ID: opts.LeaseID, Reclaim: opts.Reclaim})
+		if err != nil {
+			return err
+		}
+		if !opts.IdleTimeoutSet {
+			if duration, ok := parseDurationSecondsLabel(lease.Server.Labels["idle_timeout_secs"]); ok {
+				cfg.IdleTimeout = duration
+			} else if duration, ok := parseDurationSecondsLabel(lease.Server.Labels["idle_timeout"]); ok {
+				cfg.IdleTimeout = duration
+			}
+		}
+		idleExit, err := watchEffectiveIdleExit(opts, cfg.IdleTimeout)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(a.Stdout, "watch lease=%s slug=%s provider=%s idle_timeout=%s idle_exit=%s\n", lease.LeaseID, blank(serverSlug(lease.Server), "-"), cfg.Provider, cfg.IdleTimeout, idleExit)
+		return a.watchLoop(ctx, opts, repo, cfg, lease.LeaseID, idleExit, execute)
+	}
+	idleExit, err := watchEffectiveIdleExit(opts, cfg.IdleTimeout)
+	if err != nil {
+		return err
+	}
+	lease, err := backend.Acquire(ctx, AcquireRequest{Repo: repo, Options: options, Keep: opts.Keep, Reclaim: opts.Reclaim, RequestedSlug: opts.RequestedSlug})
+	if err != nil {
+		return err
+	}
+	if !opts.Keep {
+		defer func() {
+			if releaseErr := a.releaseBackendLeaseBestEffort(context.Background(), backend, cfg, lease); releaseErr != nil {
+				fmt.Fprintf(a.Stderr, "warning: watch lease release failed for %s: %v\n", lease.LeaseID, releaseErr)
+			}
+		}()
+	}
+	applyResolvedServerConfig(&cfg, lease.Server)
+	if err := a.claimLeaseTargetForRepoAndRegister(ctx, lease.LeaseID, serverSlug(lease.Server), cfg, lease.Server, lease.SSH, repo.Root, opts.Reclaim); err != nil {
+		return err
+	}
+	fmt.Fprintf(a.Stdout, "leased %s slug=%s provider=%s idle_timeout=%s idle_exit=%s\n", lease.LeaseID, blank(serverSlug(lease.Server), "-"), cfg.Provider, cfg.IdleTimeout, idleExit)
+	return a.watchLoop(ctx, opts, repo, cfg, lease.LeaseID, idleExit, execute)
+}
+
+func watchEffectiveIdleExit(opts watchOptions, idleTimeout time.Duration) (time.Duration, error) {
+	if idleTimeout <= 0 {
+		return 0, exit(2, "lease idle timeout must be positive")
+	}
+	if !opts.IdleExitSet {
+		return idleTimeout, nil
+	}
+	if opts.IdleExit <= 0 || opts.IdleExit > idleTimeout {
+		return 0, exit(2, "--idle-exit must be positive and at most the lease idle timeout (%s); raise --idle-timeout for longer sessions", idleTimeout)
+	}
+	return opts.IdleExit, nil
+}
+
+func (a App) watchLoop(ctx context.Context, opts watchOptions, repo Repo, cfg Config, leaseID string, idleExit time.Duration, execute watchRunExecutor) error {
+	session := &watchSession{
+		root:     repo.Root,
+		leaseID:  leaseID,
+		runArgs:  opts.RunArgs,
+		command:  opts.Command,
+		debounce: opts.Debounce,
+		idleExit: idleExit,
+		cfg:      cfg,
+		execute:  execute,
+		stderr:   a.Stderr,
+	}
+	return session.run(ctx)
+}
+
+type watchSession struct {
+	root     string
+	leaseID  string
+	runArgs  []string
+	command  []string
+	debounce time.Duration
+	idleExit time.Duration
+	cfg      Config
+	execute  watchRunExecutor
+	stderr   io.Writer
+	excludes []string
+}
+
+func (s *watchSession) run(ctx context.Context) error {
+	excludes, err := syncExcludes(s.root, s.cfg)
+	if err != nil {
+		return err
+	}
+	s.excludes = excludes
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return exit(1, "watch: start watcher: %v", err)
+	}
+	defer watcher.Close()
+	if _, err := addWatchTree(watcher, s.root, s.root, s.excludes); err != nil {
+		return exit(1, "watch: watch %s: %v", s.root, err)
+	}
+	fmt.Fprintf(s.stderr, "watch root=%s debounce=%s idle_exit=%s\n", s.root, s.debounce, s.idleExit)
+
+	runDone := make(chan error, 1)
+	running := false
+	pending := false
+	idleExiting := false
+	iteration := 0
+	pendingChanges := 0
+	batch := map[string]struct{}{}
+	iterCancel := context.CancelFunc(func() {})
+	defer func() { iterCancel() }()
+	startRun := func(changes int) {
+		iteration++
+		iterCancel()
+		iterCtx, cancel := context.WithCancel(ctx)
+		iterCancel = cancel
+		iterationArgs := watchIterationArgs(s.leaseID, iteration, s.runArgs, s.command)
+		if iteration > 1 {
+			fmt.Fprintf(s.stderr, "watch run=%d changes=%d\n", iteration, changes)
+		}
+		running = true
+		go func() {
+			runDone <- s.execute(iterCtx, iterationArgs)
+		}()
+	}
+	awaitRun := func() {
+		if !running {
+			return
+		}
+		iterCancel()
+		<-runDone
+		running = false
+	}
+
+	debounceTimer := time.NewTimer(s.debounce)
+	debounceTimer.Stop()
+	defer debounceTimer.Stop()
+	idleTimer := time.NewTimer(s.idleExit)
+	defer idleTimer.Stop()
+	startRun(0)
+
+	for {
+		select {
+		case <-ctx.Done():
+			awaitRun()
+			fmt.Fprintf(s.stderr, "watch interrupted runs=%d\n", iteration)
+			return nil
+		case watchErr, ok := <-watcher.Errors:
+			awaitRun()
+			if !ok {
+				return exit(1, "watch: watcher closed unexpectedly")
+			}
+			return exit(1, "watch: watcher failed: %v; add noisy paths to .crabboxignore if event volume is the cause", watchErr)
+		case event, ok := <-watcher.Events:
+			if !ok {
+				awaitRun()
+				return exit(1, "watch: watcher closed unexpectedly")
+			}
+			if s.observeEvent(watcher, event, batch) {
+				debounceTimer.Reset(s.debounce)
+			}
+		case <-debounceTimer.C:
+			paths := make([]string, 0, len(batch))
+			for path := range batch {
+				paths = append(paths, path)
+			}
+			clear(batch)
+			qualified, err := s.qualifyBatch(paths)
+			if err != nil {
+				awaitRun()
+				return err
+			}
+			if len(qualified) == 0 {
+				continue
+			}
+			idleTimer.Reset(s.idleExit)
+			idleExiting = false
+			if running {
+				pending = true
+				pendingChanges += len(qualified)
+			} else {
+				startRun(len(qualified))
+			}
+		case runErr := <-runDone:
+			running = false
+			iterCancel()
+			if runErr != nil {
+				if ctx.Err() != nil {
+					fmt.Fprintf(s.stderr, "watch interrupted runs=%d\n", iteration)
+					return nil
+				}
+				if !isWatchIterationResult(runErr) {
+					return runErr
+				}
+				fmt.Fprintf(s.stderr, "watch run=%d result=nonzero watching for changes\n", iteration)
+			}
+			if idleExiting {
+				fmt.Fprintf(s.stderr, "watch idle_exit=%s runs=%d\n", s.idleExit, iteration)
+				return nil
+			}
+			if pending {
+				pending = false
+				changes := pendingChanges
+				pendingChanges = 0
+				startRun(changes)
+			}
+		case <-idleTimer.C:
+			if running {
+				idleExiting = true
+				continue
+			}
+			fmt.Fprintf(s.stderr, "watch idle_exit=%s runs=%d\n", s.idleExit, iteration)
+			return nil
+		}
+	}
+}
+
+func (s *watchSession) observeEvent(watcher *fsnotify.Watcher, event fsnotify.Event, batch map[string]struct{}) bool {
+	rel, err := filepath.Rel(s.root, event.Name)
+	if err != nil {
+		return false
+	}
+	rel = filepath.ToSlash(rel)
+	if rel == "." || !safeRepoRel(rel) || pathExcluded(rel, s.excludes) {
+		return false
+	}
+	if event.Op&fsnotify.Create != 0 {
+		if info, err := os.Lstat(event.Name); err == nil && info.IsDir() {
+			if files, err := addWatchTree(watcher, s.root, event.Name, s.excludes); err == nil {
+				for _, file := range files {
+					batch[file] = struct{}{}
+				}
+			}
+		}
+	}
+	batch[rel] = struct{}{}
+	return true
+}
+
+func (s *watchSession) qualifyBatch(paths []string) ([]string, error) {
+	if len(paths) == 0 {
+		return nil, nil
+	}
+	for _, path := range paths {
+		if watchFilterSourceFiles[path] {
+			cfg, err := loadConfig()
+			if err != nil {
+				return nil, err
+			}
+			s.cfg.Sync = cfg.Sync
+			break
+		}
+	}
+	excludes, err := syncExcludes(s.root, s.cfg)
+	if err != nil {
+		return nil, err
+	}
+	s.excludes = excludes
+	existing := make([]string, 0, len(paths))
+	missing := make([]string, 0, len(paths))
+	for _, path := range paths {
+		if !safeRepoRel(path) || pathExcluded(path, s.excludes) {
+			continue
+		}
+		if _, err := os.Lstat(filepath.Join(s.root, filepath.FromSlash(path))); err == nil {
+			existing = append(existing, path)
+		} else {
+			missing = append(missing, path)
+		}
+	}
+	qualified := map[string]struct{}{}
+	if len(existing) > 0 {
+		universe, err := watchGitPaths(s.root, existing, "ls-files", "--cached", "--others", "--exclude-standard", "-z", "--")
+		if err != nil {
+			return nil, err
+		}
+		for _, rel := range universe {
+			if safeRepoRel(rel) && !pathExcluded(rel, s.excludes) {
+				qualified[rel] = struct{}{}
+			}
+		}
+	}
+	if len(missing) > 0 {
+		tracked, err := watchGitPaths(s.root, missing, "ls-files", "--cached", "-z", "--")
+		if err != nil {
+			return nil, err
+		}
+		trackedSet := map[string]struct{}{}
+		for _, rel := range tracked {
+			trackedSet[rel] = struct{}{}
+			qualified[rel] = struct{}{}
+		}
+		untracked := make([]string, 0, len(missing))
+		for _, rel := range missing {
+			if _, ok := trackedSet[rel]; !ok {
+				untracked = append(untracked, rel)
+			}
+		}
+		if len(untracked) > 0 {
+			ignored, err := watchGitIgnored(s.root, untracked)
+			if err != nil {
+				return nil, err
+			}
+			for _, rel := range untracked {
+				if _, ok := ignored[rel]; !ok {
+					qualified[rel] = struct{}{}
+				}
+			}
+		}
+	}
+	result := make([]string, 0, len(qualified))
+	for rel := range qualified {
+		result = append(result, rel)
+	}
+	sort.Strings(result)
+	return result, nil
+}
+
+func watchGitPaths(root string, paths []string, gitArgs ...string) ([]string, error) {
+	cmd := exec.Command("git", append(gitArgs, paths...)...)
+	cmd.Dir = root
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, exit(1, "watch: git %s failed: %s", gitArgs[0], watchGitError(err))
+	}
+	return splitNul(out), nil
+}
+
+func watchGitIgnored(root string, paths []string) (map[string]struct{}, error) {
+	cmd := exec.Command("git", "check-ignore", "--stdin", "-z")
+	cmd.Dir = root
+	cmd.Stdin = strings.NewReader(strings.Join(paths, "\x00") + "\x00")
+	out, err := cmd.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return map[string]struct{}{}, nil
+		}
+		return nil, exit(1, "watch: git check-ignore failed: %s", watchGitError(err))
+	}
+	ignored := map[string]struct{}{}
+	for _, rel := range splitNul(out) {
+		ignored[rel] = struct{}{}
+	}
+	return ignored, nil
+}
+
+func watchGitError(err error) string {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
+		return strings.TrimSpace(string(exitErr.Stderr))
+	}
+	return err.Error()
+}
+
+func watchIterationArgs(leaseID string, iteration int, runArgs, command []string) []string {
+	args := make([]string, 0, len(runArgs)+len(command)+5)
+	args = append(args, "--id", leaseID, "--label", fmt.Sprintf("watch #%d", iteration))
+	args = append(args, runArgs...)
+	args = append(args, "--")
+	args = append(args, command...)
+	return args
+}
+
+func isWatchIterationResult(err error) bool {
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) {
+		return false
+	}
+	return strings.HasPrefix(exitErr.Message, "remote command exited") || strings.HasPrefix(exitErr.Message, "JUnit results contain")
+}
+
+func addWatchTree(watcher *fsnotify.Watcher, root, dir string, excludes []string) ([]string, error) {
+	var files []string
+	err := filepath.WalkDir(dir, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			if os.IsNotExist(walkErr) {
+				return nil
+			}
+			return walkErr
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return nil
+		}
+		rel = filepath.ToSlash(rel)
+		if entry.IsDir() {
+			if rel != "." && (!safeRepoRel(rel) || pathExcluded(rel, excludes)) {
+				return fs.SkipDir
+			}
+			if err := watcher.Add(path); err != nil {
+				if os.IsNotExist(err) {
+					return nil
+				}
+				return err
+			}
+			return nil
+		}
+		if entry.Type()&fs.ModeSymlink != 0 {
+			return nil
+		}
+		if !safeRepoRel(rel) || pathExcluded(rel, excludes) {
+			return nil
+		}
+		files = append(files, rel)
+		return nil
+	})
+	return files, err
+}
+
+func splitWatchArgs(args []string) ([]string, []string) {
+	for i, arg := range args {
+		if arg == "--" {
+			return args[:i], args[i+1:]
+		}
+	}
+	return args, nil
+}
+
+type boolValueFlag interface {
+	IsBoolFlag() bool
+}
+
+func watchFlagIsBool(fs *flag.FlagSet, name string) bool {
+	registered := fs.Lookup(name)
+	if registered == nil {
+		return false
+	}
+	value, ok := registered.Value.(boolValueFlag)
+	return ok && value.IsBoolFlag()
+}
+
+func partitionWatchRunArgs(fs *flag.FlagSet, flagArgs []string) ([]string, []string, error) {
+	watchArgs := []string{}
+	runArgs := []string{}
+	i := 0
+	for i < len(flagArgs) {
+		token := flagArgs[i]
+		if token == "-" || !strings.HasPrefix(token, "-") {
+			return nil, nil, exit(2, "unexpected argument %q; place the command after --", token)
+		}
+		name := strings.TrimLeft(token, "-")
+		hasValue := false
+		if eq := strings.Index(name, "="); eq >= 0 {
+			name = name[:eq]
+			hasValue = true
+		}
+		if name == "" {
+			return nil, nil, exit(2, "invalid flag %q", token)
+		}
+		if name == "h" || name == "help" {
+			watchArgs = append(watchArgs, token)
+			i++
+			continue
+		}
+		if watchForbiddenRunFlags[name] {
+			return nil, nil, exit(2, "--%s cannot be used with watch: it conflicts with a persistent watch session", name)
+		}
+		known := fs.Lookup(name) != nil
+		consume := 0
+		if !hasValue {
+			if known && !watchFlagIsBool(fs, name) {
+				if i+1 >= len(flagArgs) {
+					return nil, nil, exit(2, "flag needs an argument: --%s", name)
+				}
+				consume = 1
+			} else if !known && i+1 < len(flagArgs) && !strings.HasPrefix(flagArgs[i+1], "-") {
+				consume = 1
+			}
+		}
+		tokens := flagArgs[i : i+1+consume]
+		switch {
+		case watchOwnedOnlyFlags[name]:
+			watchArgs = append(watchArgs, tokens...)
+		case known:
+			watchArgs = append(watchArgs, tokens...)
+			runArgs = append(runArgs, tokens...)
+		default:
+			runArgs = append(runArgs, tokens...)
+		}
+		i += 1 + consume
+	}
+	return watchArgs, runArgs, nil
+}

--- a/internal/cli/watch.go
+++ b/internal/cli/watch.go
@@ -412,6 +412,7 @@ func (s *watchSession) qualifyBatch(paths []string) ([]string, error) {
 		return nil, err
 	}
 	s.excludes = excludes
+	includes := syncIncludes(s.cfg)
 	existing := make([]string, 0, len(paths))
 	missing := make([]string, 0, len(paths))
 	for _, path := range paths {
@@ -431,7 +432,7 @@ func (s *watchSession) qualifyBatch(paths []string) ([]string, error) {
 			return nil, err
 		}
 		for _, rel := range universe {
-			if safeRepoRel(rel) && !pathExcluded(rel, s.excludes) {
+			if safeRepoRel(rel) && !pathExcluded(rel, s.excludes) && pathIncluded(rel, includes) {
 				qualified[rel] = struct{}{}
 			}
 		}
@@ -444,7 +445,9 @@ func (s *watchSession) qualifyBatch(paths []string) ([]string, error) {
 		trackedSet := map[string]struct{}{}
 		for _, rel := range tracked {
 			trackedSet[rel] = struct{}{}
-			qualified[rel] = struct{}{}
+			if pathIncluded(rel, includes) {
+				qualified[rel] = struct{}{}
+			}
 		}
 		untracked := make([]string, 0, len(missing))
 		for _, rel := range missing {
@@ -458,7 +461,7 @@ func (s *watchSession) qualifyBatch(paths []string) ([]string, error) {
 				return nil, err
 			}
 			for _, rel := range untracked {
-				if _, ok := ignored[rel]; !ok {
+				if _, ok := ignored[rel]; !ok && pathIncluded(rel, includes) {
 					qualified[rel] = struct{}{}
 				}
 			}

--- a/internal/cli/watch.go
+++ b/internal/cli/watch.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -238,6 +239,7 @@ type watchSession struct {
 	execute  watchRunExecutor
 	stderr   io.Writer
 	excludes []string
+	watcher  *fsnotify.Watcher
 }
 
 func (s *watchSession) run(ctx context.Context) error {
@@ -251,6 +253,7 @@ func (s *watchSession) run(ctx context.Context) error {
 		return exit(1, "watch: start watcher: %v", err)
 	}
 	defer watcher.Close()
+	s.watcher = watcher
 	if _, err := addWatchTree(watcher, s.root, s.root, s.excludes); err != nil {
 		return exit(1, "watch: watch %s: %v", s.root, err)
 	}
@@ -411,7 +414,13 @@ func (s *watchSession) qualifyBatch(paths []string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	excludesChanged := !slices.Equal(excludes, s.excludes)
 	s.excludes = excludes
+	if excludesChanged && s.watcher != nil {
+		if _, err := addWatchTree(s.watcher, s.root, s.root, s.excludes); err != nil {
+			return nil, exit(1, "watch: rewatch %s after filter change: %v", s.root, err)
+		}
+	}
 	includes := syncIncludes(s.cfg)
 	existing := make([]string, 0, len(paths))
 	missing := make([]string, 0, len(paths))

--- a/internal/cli/watch.go
+++ b/internal/cli/watch.go
@@ -353,15 +353,14 @@ func (s *watchSession) run(ctx context.Context) error {
 				}
 				fmt.Fprintf(s.stderr, "watch run=%d result=nonzero watching for changes\n", iteration)
 			}
-			if idleExiting {
-				fmt.Fprintf(s.stderr, "watch idle_exit=%s runs=%d\n", s.idleExit, iteration)
-				return nil
-			}
 			if pending {
 				pending = false
 				changes := pendingChanges
 				pendingChanges = 0
 				startRun(changes)
+			} else if idleExiting {
+				fmt.Fprintf(s.stderr, "watch idle_exit=%s runs=%d\n", s.idleExit, iteration)
+				return nil
 			}
 		case <-idleTimer.C:
 			if running {

--- a/internal/cli/watch.go
+++ b/internal/cli/watch.go
@@ -86,6 +86,7 @@ func (a App) watch(ctx context.Context, args []string) error {
 	leaseIDFlag := fs.String("id", "", "existing lease or server id")
 	keep := fs.Bool("keep", false, "keep an acquired lease when the watch loop exits")
 	reclaim := fs.Bool("reclaim", false, "claim this lease for the current repo")
+	preset := fs.String("preset", "", "configured profile preset that provides the watched command")
 	debounce := fs.Duration("debounce", 250*time.Millisecond, "quiet period before a change batch triggers a rerun")
 	idleExit := fs.Duration("idle-exit", 0, "exit after this period without qualifying local changes; defaults to the lease idle timeout")
 	flagArgs, command := splitWatchArgs(args)
@@ -99,7 +100,7 @@ func (a App) watch(ctx context.Context, args []string) error {
 	if fs.NArg() > 0 {
 		return exit(2, "unexpected argument %q; place the command after --", fs.Arg(0))
 	}
-	if len(command) == 0 {
+	if len(command) == 0 && strings.TrimSpace(*preset) == "" {
 		return exit(2, "usage: crabbox watch [flags] -- <command...>")
 	}
 	if *debounce <= 0 {
@@ -114,6 +115,10 @@ func (a App) watch(ctx context.Context, args []string) error {
 	}
 	cfg, err := loadConfig()
 	if err != nil {
+		return err
+	}
+	cfg.Profile = *leaseFlags.Profile
+	if err := applySelectedProfileConfig(&cfg); err != nil {
 		return err
 	}
 	if err := applyLeaseCreateFlagsForLease(&cfg, fs, leaseFlags, *leaseIDFlag); err != nil {
@@ -484,7 +489,11 @@ func (s *watchSession) qualifyBatch(paths []string) ([]string, error) {
 }
 
 func watchGitPaths(root string, paths []string, gitArgs ...string) ([]string, error) {
-	cmd := exec.Command("git", append(gitArgs, paths...)...)
+	args := make([]string, 0, len(gitArgs)+len(paths)+1)
+	args = append(args, "--literal-pathspecs")
+	args = append(args, gitArgs...)
+	args = append(args, paths...)
+	cmd := exec.Command("git", args...)
 	cmd.Dir = root
 	out, err := cmd.Output()
 	if err != nil {

--- a/internal/cli/watch_test.go
+++ b/internal/cli/watch_test.go
@@ -497,6 +497,77 @@ func TestQualifyWatchBatch(t *testing.T) {
 	}
 }
 
+func TestQualifyWatchBatchHonorsSyncIncludes(t *testing.T) {
+	root := newWatchGitRepo(t)
+	watchTestWrite(t, root, "src/app.go", "package app\n")
+	watchTestWrite(t, root, "docs/readme.md", "docs\n")
+	watchTestWrite(t, root, "src/gone.go", "package app\n")
+	watchTestWrite(t, root, "docs/gone.md", "docs\n")
+	watchTestGit(t, root, "add", "src", "docs")
+	watchTestGit(t, root, "commit", "-q", "-m", "add src and docs")
+	for _, rel := range []string{"src/gone.go", "docs/gone.md"} {
+		if err := os.Remove(filepath.Join(root, filepath.FromSlash(rel))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	watchTestWrite(t, root, "src/new.txt", "new")
+	watchTestWrite(t, root, "notes.txt", "outside")
+	session := newWatchTestSession(root, nil, time.Millisecond, time.Second, nil)
+	session.cfg.Sync.Includes = []string{"src"}
+	for _, tc := range []struct {
+		name string
+		path string
+		want bool
+	}{
+		{name: "tracked inside include", path: "src/app.go", want: true},
+		{name: "untracked inside include", path: "src/new.txt", want: true},
+		{name: "tracked outside include", path: "docs/readme.md", want: false},
+		{name: "untracked outside include", path: "notes.txt", want: false},
+		{name: "root file outside include", path: "main.go", want: false},
+		{name: "deleted tracked inside include", path: "src/gone.go", want: true},
+		{name: "deleted tracked outside include", path: "docs/gone.md", want: false},
+		{name: "deleted untracked outside include", path: "gone.txt", want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			qualified, err := session.qualifyBatch([]string{tc.path})
+			if err != nil {
+				t.Fatalf("qualifyBatch(%q): %v", tc.path, err)
+			}
+			got := len(qualified) > 0
+			if got != tc.want {
+				t.Fatalf("qualifyBatch(%q)=%v, want qualified=%v", tc.path, qualified, tc.want)
+			}
+		})
+	}
+}
+
+func TestWatchIncludeWhitelistFiltersReruns(t *testing.T) {
+	root := newWatchGitRepo(t)
+	watchTestWrite(t, root, "src/app.go", "package app\n")
+	watchTestGit(t, root, "add", "src")
+	watchTestGit(t, root, "commit", "-q", "-m", "add src")
+	executor := newWatchTestExecutor()
+	session := newWatchTestSession(root, executor.run, 25*time.Millisecond, 900*time.Millisecond, nil)
+	session.cfg.Sync.Includes = []string{"src"}
+	done := make(chan error, 1)
+	go func() { done <- session.run(context.Background()) }()
+	executor.awaitStart(t)
+	time.Sleep(100 * time.Millisecond)
+	watchTestWrite(t, root, "outside.txt", "not synced")
+	time.Sleep(200 * time.Millisecond)
+	if executor.callCount() != 1 {
+		t.Fatalf("iterations=%d after outside-include churn, want 1", executor.callCount())
+	}
+	watchTestWrite(t, root, "src/app.go", "package app\nvar x = 1\n")
+	executor.awaitStart(t)
+	if err := <-done; err != nil {
+		t.Fatalf("session.run: %v", err)
+	}
+	if executor.callCount() != 2 {
+		t.Fatalf("iterations=%d, want 2", executor.callCount())
+	}
+}
+
 func TestWatchAcquiresLeaseWhenNoID(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	t.Setenv("CRABBOX_COORDINATOR", "")

--- a/internal/cli/watch_test.go
+++ b/internal/cli/watch_test.go
@@ -383,6 +383,30 @@ func TestWatchChangeDuringRunQueuesExactlyOnePendingRerun(t *testing.T) {
 	}
 }
 
+func TestWatchRunsQueuedRerunBeforeIdleExit(t *testing.T) {
+	root := newWatchGitRepo(t)
+	executor := newWatchTestExecutor()
+	executor.release = make(chan struct{}, 1)
+	session := newWatchTestSession(root, executor.run, 25*time.Millisecond, 250*time.Millisecond, nil)
+	done := make(chan error, 1)
+	go func() { done <- session.run(context.Background()) }()
+	executor.awaitStart(t)
+	watchTestWrite(t, root, "queued.txt", "queued while running")
+	time.Sleep(600 * time.Millisecond)
+	executor.release <- struct{}{}
+	executor.awaitStart(t)
+	executor.release <- struct{}{}
+	if err := <-done; err != nil {
+		t.Fatalf("session.run: %v", err)
+	}
+	if executor.callCount() != 2 {
+		t.Fatalf("iterations=%d, want 2 (queued rerun must run before idle exit)", executor.callCount())
+	}
+	if got := executor.call(1); !strings.Contains(strings.Join(got, " "), "watch #2") {
+		t.Fatalf("queued iteration args=%v, want watch #2 label", got)
+	}
+}
+
 func TestWatchContinuesAfterNonzeroRemoteExit(t *testing.T) {
 	root := newWatchGitRepo(t)
 	executor := newWatchTestExecutor()

--- a/internal/cli/watch_test.go
+++ b/internal/cli/watch_test.go
@@ -454,6 +454,29 @@ func TestWatchReloadsCrabboxIgnoreMidSession(t *testing.T) {
 	}
 }
 
+func TestWatchRewatchesDirectoriesWhenExclusionsRelax(t *testing.T) {
+	root := newWatchGitRepo(t)
+	watchTestWrite(t, root, ".crabboxignore", "generated\n")
+	watchTestWrite(t, root, "generated/seed.txt", "seeded before start")
+	executor := newWatchTestExecutor()
+	session := newWatchTestSession(root, executor.run, 25*time.Millisecond, 3*time.Second, nil)
+	done := make(chan error, 1)
+	go func() { done <- session.run(context.Background()) }()
+	executor.awaitStart(t)
+	time.Sleep(100 * time.Millisecond)
+	watchTestWrite(t, root, ".crabboxignore", "")
+	executor.awaitStart(t)
+	time.Sleep(100 * time.Millisecond)
+	watchTestWrite(t, root, "generated/data.txt", "now visible")
+	executor.awaitStart(t)
+	if err := <-done; err != nil {
+		t.Fatalf("session.run: %v", err)
+	}
+	if executor.callCount() != 3 {
+		t.Fatalf("iterations=%d, want 3 (relaxed exclusion must re-attach watches)", executor.callCount())
+	}
+}
+
 func TestQualifyWatchBatch(t *testing.T) {
 	root := newWatchGitRepo(t)
 	watchTestWrite(t, root, "keep.log", "tracked but gitignored")

--- a/internal/cli/watch_test.go
+++ b/internal/cli/watch_test.go
@@ -1,0 +1,853 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+const watchTestLeaseID = "cbx_abcdef123456"
+
+type watchTestBackend struct {
+	mu           sync.Mutex
+	acquireCalls int
+	resolveCalls int
+	releaseCalls int
+	releaseCtx   context.Context
+	acquireErr   error
+	resolveErr   error
+	labels       map[string]string
+	features     FeatureSet
+}
+
+func newWatchTestBackend() *watchTestBackend {
+	return &watchTestBackend{features: FeatureSet{FeatureSSH, FeatureCrabboxSync}}
+}
+
+func (b *watchTestBackend) Spec() ProviderSpec {
+	return ProviderSpec{Name: "watch-test", Kind: ProviderKindSSHLease, Features: b.features}
+}
+
+func (b *watchTestBackend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.acquireCalls++
+	if b.acquireErr != nil {
+		return LeaseTarget{}, b.acquireErr
+	}
+	server := Server{Provider: "watch-test", Labels: map[string]string{"lease": watchTestLeaseID}}
+	server.ServerType.Name = "test"
+	return LeaseTarget{LeaseID: watchTestLeaseID, Server: server}, nil
+}
+
+func (b *watchTestBackend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.resolveCalls++
+	if b.resolveErr != nil {
+		return LeaseTarget{}, b.resolveErr
+	}
+	labels := map[string]string{"lease": req.ID}
+	for key, value := range b.labels {
+		labels[key] = value
+	}
+	server := Server{Provider: "watch-test", Labels: labels}
+	server.ServerType.Name = "test"
+	return LeaseTarget{LeaseID: req.ID, Server: server}, nil
+}
+
+func (b *watchTestBackend) List(context.Context, ListRequest) ([]LeaseView, error) {
+	return nil, nil
+}
+
+func (b *watchTestBackend) ReleaseLease(ctx context.Context, _ ReleaseLeaseRequest) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.releaseCalls++
+	b.releaseCtx = ctx
+	return nil
+}
+
+func (b *watchTestBackend) Touch(context.Context, TouchRequest) (Server, error) {
+	return Server{}, nil
+}
+
+func (b *watchTestBackend) counts() (int, int, int) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.acquireCalls, b.resolveCalls, b.releaseCalls
+}
+
+type watchTestExecutor struct {
+	mu      sync.Mutex
+	calls   [][]string
+	started chan struct{}
+	release chan struct{}
+	errs    map[int]error
+}
+
+func newWatchTestExecutor() *watchTestExecutor {
+	return &watchTestExecutor{started: make(chan struct{}, 64), errs: map[int]error{}}
+}
+
+func (e *watchTestExecutor) run(ctx context.Context, args []string) error {
+	e.mu.Lock()
+	e.calls = append(e.calls, append([]string{}, args...))
+	iteration := len(e.calls)
+	err := e.errs[iteration]
+	e.mu.Unlock()
+	select {
+	case e.started <- struct{}{}:
+	default:
+	}
+	if e.release != nil {
+		select {
+		case <-e.release:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	if err != nil {
+		return err
+	}
+	return ctx.Err()
+}
+
+func (e *watchTestExecutor) callCount() int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return len(e.calls)
+}
+
+func (e *watchTestExecutor) call(index int) []string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if index >= len(e.calls) {
+		return nil
+	}
+	return e.calls[index]
+}
+
+func (e *watchTestExecutor) awaitStart(t *testing.T) {
+	t.Helper()
+	select {
+	case <-e.started:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for a watch iteration to start")
+	}
+}
+
+func watchTestGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@example.com",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@example.com",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+func watchTestWrite(t *testing.T, root, rel, content string) {
+	t.Helper()
+	full := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func newWatchGitRepo(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	watchTestGit(t, root, "init", "-q")
+	watchTestWrite(t, root, "main.go", "package main\n")
+	watchTestWrite(t, root, ".gitignore", "*.log\nignored.txt\n")
+	watchTestGit(t, root, "add", ".")
+	watchTestGit(t, root, "commit", "-q", "-m", "seed")
+	return root
+}
+
+func newWatchTestSession(root string, execute watchRunExecutor, debounce, idleExit time.Duration, stderr io.Writer) *watchSession {
+	if stderr == nil {
+		stderr = io.Discard
+	}
+	return &watchSession{
+		root:     root,
+		leaseID:  watchTestLeaseID,
+		command:  []string{"echo", "ok"},
+		debounce: debounce,
+		idleExit: idleExit,
+		cfg:      Config{},
+		execute:  execute,
+		stderr:   stderr,
+	}
+}
+
+func TestWatchRunsInitialIterationImmediately(t *testing.T) {
+	root := newWatchGitRepo(t)
+	executor := newWatchTestExecutor()
+	session := newWatchTestSession(root, executor.run, 25*time.Millisecond, 300*time.Millisecond, nil)
+	session.runArgs = []string{"--shell"}
+	if err := session.run(context.Background()); err != nil {
+		t.Fatalf("session.run: %v", err)
+	}
+	if executor.callCount() != 1 {
+		t.Fatalf("iterations=%d, want 1", executor.callCount())
+	}
+	want := []string{"--id", watchTestLeaseID, "--label", "watch #1", "--shell", "--", "echo", "ok"}
+	got := executor.call(0)
+	if strings.Join(got, " ") != strings.Join(want, " ") {
+		t.Fatalf("iteration args=%v, want %v", got, want)
+	}
+}
+
+func TestWatchIdleExitAfterQuietPeriod(t *testing.T) {
+	root := newWatchGitRepo(t)
+	executor := newWatchTestExecutor()
+	var stderr bytes.Buffer
+	session := newWatchTestSession(root, executor.run, 25*time.Millisecond, 250*time.Millisecond, &stderr)
+	start := time.Now()
+	if err := session.run(context.Background()); err != nil {
+		t.Fatalf("session.run: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed < 200*time.Millisecond {
+		t.Fatalf("idle exit fired too early: %s", elapsed)
+	}
+	if !strings.Contains(stderr.String(), "idle_exit") {
+		t.Fatalf("stderr missing idle_exit line:\n%s", stderr.String())
+	}
+}
+
+func TestWatchIdleExitWaitsForActiveRun(t *testing.T) {
+	root := newWatchGitRepo(t)
+	executor := newWatchTestExecutor()
+	executor.release = make(chan struct{})
+	session := newWatchTestSession(root, executor.run, 25*time.Millisecond, 150*time.Millisecond, nil)
+	done := make(chan error, 1)
+	go func() { done <- session.run(context.Background()) }()
+	executor.awaitStart(t)
+	time.Sleep(300 * time.Millisecond)
+	select {
+	case err := <-done:
+		t.Fatalf("session exited before the active run finished: %v", err)
+	default:
+	}
+	close(executor.release)
+	if err := <-done; err != nil {
+		t.Fatalf("session.run: %v", err)
+	}
+	if executor.callCount() != 1 {
+		t.Fatalf("iterations=%d, want 1", executor.callCount())
+	}
+}
+
+func TestWatchRerunsOnQualifyingChange(t *testing.T) {
+	root := newWatchGitRepo(t)
+	executor := newWatchTestExecutor()
+	session := newWatchTestSession(root, executor.run, 25*time.Millisecond, 2*time.Second, nil)
+	done := make(chan error, 1)
+	go func() { done <- session.run(context.Background()) }()
+	executor.awaitStart(t)
+	watchTestWrite(t, root, "main.go", "package main\nvar x = 1\n")
+	executor.awaitStart(t)
+	if got := executor.call(1); !strings.Contains(strings.Join(got, " "), "watch #2") {
+		t.Fatalf("second iteration args=%v, want watch #2 label", got)
+	}
+	watchTestWrite(t, root, "main.go", "package main\nvar x = 2\n")
+	executor.awaitStart(t)
+	if got := executor.call(2); !strings.Contains(strings.Join(got, " "), "watch #3") {
+		t.Fatalf("third iteration args=%v, want watch #3 label", got)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("session.run: %v", err)
+	}
+}
+
+func TestWatchIgnoredChurnDoesNotTriggerRunOrResetIdle(t *testing.T) {
+	root := newWatchGitRepo(t)
+	watchTestWrite(t, root, ".crabboxignore", "scratch\n")
+	executor := newWatchTestExecutor()
+	session := newWatchTestSession(root, executor.run, 25*time.Millisecond, 600*time.Millisecond, nil)
+	stop := make(chan struct{})
+	var churn sync.WaitGroup
+	churn.Add(1)
+	go func() {
+		defer churn.Done()
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			case <-time.After(50 * time.Millisecond):
+			}
+			watchTestWrite(t, root, "node_modules/dep.js", fmt.Sprintf("// %d", i))
+			watchTestWrite(t, root, "ignored.txt", fmt.Sprintf("%d", i))
+			watchTestWrite(t, root, "scratch/tmp.txt", fmt.Sprintf("%d", i))
+		}
+	}()
+	start := time.Now()
+	err := session.run(context.Background())
+	elapsed := time.Since(start)
+	close(stop)
+	churn.Wait()
+	if err != nil {
+		t.Fatalf("session.run: %v", err)
+	}
+	if executor.callCount() != 1 {
+		t.Fatalf("iterations=%d, want 1", executor.callCount())
+	}
+	if elapsed > 3*time.Second {
+		t.Fatalf("ignored churn kept the session alive for %s", elapsed)
+	}
+}
+
+func TestWatchWatchesNewlyCreatedDirectories(t *testing.T) {
+	root := newWatchGitRepo(t)
+	executor := newWatchTestExecutor()
+	session := newWatchTestSession(root, executor.run, 25*time.Millisecond, 3*time.Second, nil)
+	done := make(chan error, 1)
+	go func() { done <- session.run(context.Background()) }()
+	executor.awaitStart(t)
+	if err := os.MkdirAll(filepath.Join(root, "pkg", "util"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(150 * time.Millisecond)
+	watchTestWrite(t, root, "pkg/util/util.go", "package util\n")
+	executor.awaitStart(t)
+	if executor.callCount() < 2 {
+		t.Fatalf("iterations=%d, want at least 2", executor.callCount())
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("session.run: %v", err)
+	}
+}
+
+func TestWatchDebounceCoalescesBurstIntoOneRun(t *testing.T) {
+	root := newWatchGitRepo(t)
+	executor := newWatchTestExecutor()
+	session := newWatchTestSession(root, executor.run, 150*time.Millisecond, 2*time.Second, nil)
+	done := make(chan error, 1)
+	go func() { done <- session.run(context.Background()) }()
+	executor.awaitStart(t)
+	time.Sleep(200 * time.Millisecond)
+	for i := 0; i < 5; i++ {
+		watchTestWrite(t, root, fmt.Sprintf("burst%d.txt", i), "x")
+		time.Sleep(10 * time.Millisecond)
+	}
+	executor.awaitStart(t)
+	if err := <-done; err != nil {
+		t.Fatalf("session.run: %v", err)
+	}
+	if executor.callCount() != 2 {
+		t.Fatalf("iterations=%d, want 2", executor.callCount())
+	}
+}
+
+func TestWatchChangeDuringRunQueuesExactlyOnePendingRerun(t *testing.T) {
+	root := newWatchGitRepo(t)
+	executor := newWatchTestExecutor()
+	executor.release = make(chan struct{})
+	session := newWatchTestSession(root, executor.run, 25*time.Millisecond, 2*time.Second, nil)
+	done := make(chan error, 1)
+	go func() { done <- session.run(context.Background()) }()
+	executor.awaitStart(t)
+	watchTestWrite(t, root, "first.txt", "1")
+	time.Sleep(150 * time.Millisecond)
+	watchTestWrite(t, root, "second.txt", "2")
+	time.Sleep(150 * time.Millisecond)
+	executor.release <- struct{}{}
+	executor.awaitStart(t)
+	executor.release <- struct{}{}
+	if err := <-done; err != nil {
+		t.Fatalf("session.run: %v", err)
+	}
+	if executor.callCount() != 2 {
+		t.Fatalf("iterations=%d, want 2", executor.callCount())
+	}
+	if got := executor.call(1); !strings.Contains(strings.Join(got, " "), "watch #2") {
+		t.Fatalf("queued iteration args=%v, want watch #2 label", got)
+	}
+}
+
+func TestWatchContinuesAfterNonzeroRemoteExit(t *testing.T) {
+	root := newWatchGitRepo(t)
+	executor := newWatchTestExecutor()
+	executor.errs[1] = ExitError{Code: 1, Message: "remote command exited 1"}
+	var stderr bytes.Buffer
+	session := newWatchTestSession(root, executor.run, 25*time.Millisecond, 2*time.Second, &stderr)
+	done := make(chan error, 1)
+	go func() { done <- session.run(context.Background()) }()
+	executor.awaitStart(t)
+	time.Sleep(100 * time.Millisecond)
+	watchTestWrite(t, root, "main.go", "package main\nvar y = 1\n")
+	executor.awaitStart(t)
+	if err := <-done; err != nil {
+		t.Fatalf("session.run: %v", err)
+	}
+	if executor.callCount() != 2 {
+		t.Fatalf("iterations=%d, want 2", executor.callCount())
+	}
+	if !strings.Contains(stderr.String(), "result=nonzero") {
+		t.Fatalf("stderr missing nonzero result line:\n%s", stderr.String())
+	}
+}
+
+func TestWatchStopsOnFatalIterationError(t *testing.T) {
+	root := newWatchGitRepo(t)
+	executor := newWatchTestExecutor()
+	fatal := errors.New("ssh transport failed")
+	executor.errs[1] = fatal
+	session := newWatchTestSession(root, executor.run, 25*time.Millisecond, 2*time.Second, nil)
+	if err := session.run(context.Background()); !errors.Is(err, fatal) {
+		t.Fatalf("session.run error=%v, want %v", err, fatal)
+	}
+	if executor.callCount() != 1 {
+		t.Fatalf("iterations=%d, want 1", executor.callCount())
+	}
+}
+
+func TestWatchReloadsCrabboxIgnoreMidSession(t *testing.T) {
+	root := newWatchGitRepo(t)
+	executor := newWatchTestExecutor()
+	session := newWatchTestSession(root, executor.run, 25*time.Millisecond, 700*time.Millisecond, nil)
+	done := make(chan error, 1)
+	go func() { done <- session.run(context.Background()) }()
+	executor.awaitStart(t)
+	watchTestWrite(t, root, ".crabboxignore", "noise.txt\n")
+	executor.awaitStart(t)
+	stop := make(chan struct{})
+	var churn sync.WaitGroup
+	churn.Add(1)
+	go func() {
+		defer churn.Done()
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			case <-time.After(50 * time.Millisecond):
+			}
+			watchTestWrite(t, root, "noise.txt", fmt.Sprintf("%d", i))
+		}
+	}()
+	err := <-done
+	close(stop)
+	churn.Wait()
+	if err != nil {
+		t.Fatalf("session.run: %v", err)
+	}
+	if executor.callCount() != 2 {
+		t.Fatalf("iterations=%d, want 2", executor.callCount())
+	}
+}
+
+func TestQualifyWatchBatch(t *testing.T) {
+	root := newWatchGitRepo(t)
+	watchTestWrite(t, root, "keep.log", "tracked but gitignored")
+	watchTestGit(t, root, "add", "-f", "keep.log")
+	watchTestGit(t, root, "commit", "-q", "-m", "add keep.log")
+	watchTestWrite(t, root, ".crabboxignore", "vendor-notes.md\n")
+	watchTestWrite(t, root, "untracked.txt", "new")
+	watchTestWrite(t, root, "ignored.txt", "ignored")
+	watchTestWrite(t, root, "vendor-notes.md", "crabboxignored")
+	watchTestWrite(t, root, "deleted.txt", "to delete")
+	watchTestGit(t, root, "add", "deleted.txt")
+	watchTestGit(t, root, "commit", "-q", "-m", "add deleted.txt")
+	if err := os.Remove(filepath.Join(root, "deleted.txt")); err != nil {
+		t.Fatal(err)
+	}
+	session := newWatchTestSession(root, nil, time.Millisecond, time.Second, nil)
+	for _, tc := range []struct {
+		name string
+		path string
+		want bool
+	}{
+		{name: "tracked modified", path: "main.go", want: true},
+		{name: "untracked new", path: "untracked.txt", want: true},
+		{name: "gitignored", path: "ignored.txt", want: false},
+		{name: "tracked but gitignored", path: "keep.log", want: true},
+		{name: "crabboxignored", path: "vendor-notes.md", want: false},
+		{name: "deleted tracked", path: "deleted.txt", want: true},
+		{name: "deleted untracked ignored", path: "gone.log", want: false},
+		{name: "deleted untracked nonignored", path: "gone.txt", want: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			qualified, err := session.qualifyBatch([]string{tc.path})
+			if err != nil {
+				t.Fatalf("qualifyBatch(%q): %v", tc.path, err)
+			}
+			got := len(qualified) > 0
+			if got != tc.want {
+				t.Fatalf("qualifyBatch(%q)=%v, want qualified=%v", tc.path, qualified, tc.want)
+			}
+		})
+	}
+}
+
+func TestWatchAcquiresLeaseWhenNoID(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CRABBOX_COORDINATOR", "")
+	root := newWatchGitRepo(t)
+	backend := newWatchTestBackend()
+	executor := newWatchTestExecutor()
+	var stdout bytes.Buffer
+	app := App{Stdout: &stdout, Stderr: io.Discard}
+	opts := watchOptions{Debounce: 25 * time.Millisecond, IdleExit: 250 * time.Millisecond, IdleExitSet: true, Command: []string{"echo", "ok"}}
+	cfg := Config{Provider: "watch-test", IdleTimeout: time.Minute, TTL: time.Hour}
+	err := app.watchWithBackend(context.Background(), opts, Repo{Root: root, Name: "my-app"}, cfg, backend, executor.run)
+	if err != nil {
+		t.Fatalf("watchWithBackend: %v", err)
+	}
+	acquires, resolves, releases := backend.counts()
+	if acquires != 1 || resolves != 0 || releases != 1 {
+		t.Fatalf("acquire=%d resolve=%d release=%d, want 1/0/1", acquires, resolves, releases)
+	}
+	if !strings.Contains(stdout.String(), "leased "+watchTestLeaseID) {
+		t.Fatalf("stdout missing leased line:\n%s", stdout.String())
+	}
+	if got := executor.call(0); !strings.Contains(strings.Join(got, " "), "--id "+watchTestLeaseID) {
+		t.Fatalf("iteration args=%v, want injected --id", got)
+	}
+}
+
+func TestWatchWithIDResolvesAndNeverReleases(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CRABBOX_COORDINATOR", "")
+	root := newWatchGitRepo(t)
+	backend := newWatchTestBackend()
+	backend.labels = map[string]string{"idle_timeout_secs": "1800"}
+	executor := newWatchTestExecutor()
+	var stdout bytes.Buffer
+	app := App{Stdout: &stdout, Stderr: io.Discard}
+	opts := watchOptions{LeaseID: watchTestLeaseID, Debounce: 25 * time.Millisecond, IdleExit: 250 * time.Millisecond, IdleExitSet: true, Command: []string{"echo", "ok"}}
+	cfg := Config{Provider: "watch-test", IdleTimeout: time.Minute, TTL: time.Hour}
+	err := app.watchWithBackend(context.Background(), opts, Repo{Root: root, Name: "my-app"}, cfg, backend, executor.run)
+	if err != nil {
+		t.Fatalf("watchWithBackend: %v", err)
+	}
+	acquires, resolves, releases := backend.counts()
+	if acquires != 0 || resolves != 1 || releases != 0 {
+		t.Fatalf("acquire=%d resolve=%d release=%d, want 0/1/0", acquires, resolves, releases)
+	}
+	if !strings.Contains(stdout.String(), "idle_timeout=30m0s") {
+		t.Fatalf("stdout missing label-derived idle timeout:\n%s", stdout.String())
+	}
+}
+
+func TestWatchKeepSkipsRelease(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CRABBOX_COORDINATOR", "")
+	root := newWatchGitRepo(t)
+	backend := newWatchTestBackend()
+	executor := newWatchTestExecutor()
+	app := App{Stdout: io.Discard, Stderr: io.Discard}
+	opts := watchOptions{Keep: true, Debounce: 25 * time.Millisecond, IdleExit: 250 * time.Millisecond, IdleExitSet: true, Command: []string{"echo", "ok"}}
+	cfg := Config{Provider: "watch-test", IdleTimeout: time.Minute, TTL: time.Hour}
+	if err := app.watchWithBackend(context.Background(), opts, Repo{Root: root, Name: "my-app"}, cfg, backend, executor.run); err != nil {
+		t.Fatalf("watchWithBackend: %v", err)
+	}
+	acquires, _, releases := backend.counts()
+	if acquires != 1 || releases != 0 {
+		t.Fatalf("acquire=%d release=%d, want 1/0", acquires, releases)
+	}
+}
+
+func TestWatchCtrlCReleasesFreshLeaseWithBackgroundContext(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CRABBOX_COORDINATOR", "")
+	root := newWatchGitRepo(t)
+	backend := newWatchTestBackend()
+	executor := newWatchTestExecutor()
+	executor.release = make(chan struct{})
+	app := App{Stdout: io.Discard, Stderr: io.Discard}
+	opts := watchOptions{Debounce: 25 * time.Millisecond, IdleExit: 10 * time.Second, IdleExitSet: true, Command: []string{"echo", "ok"}}
+	cfg := Config{Provider: "watch-test", IdleTimeout: time.Minute, TTL: time.Hour}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- app.watchWithBackend(ctx, opts, Repo{Root: root, Name: "my-app"}, cfg, backend, executor.run)
+	}()
+	executor.awaitStart(t)
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("watchWithBackend: %v", err)
+	}
+	_, _, releases := backend.counts()
+	if releases != 1 {
+		t.Fatalf("release=%d, want 1", releases)
+	}
+	if backend.releaseCtx == nil || backend.releaseCtx.Err() != nil {
+		t.Fatalf("release context canceled: %v", backend.releaseCtx)
+	}
+}
+
+func TestWatchReleasesLeaseWhenWatcherSetupFails(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CRABBOX_COORDINATOR", "")
+	root := newWatchGitRepo(t)
+	if err := os.MkdirAll(filepath.Join(root, ".crabboxignore"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	backend := newWatchTestBackend()
+	executor := newWatchTestExecutor()
+	app := App{Stdout: io.Discard, Stderr: io.Discard}
+	opts := watchOptions{Debounce: 25 * time.Millisecond, IdleExit: 250 * time.Millisecond, IdleExitSet: true, Command: []string{"echo", "ok"}}
+	cfg := Config{Provider: "watch-test", IdleTimeout: time.Minute, TTL: time.Hour}
+	err := app.watchWithBackend(context.Background(), opts, Repo{Root: root, Name: "my-app"}, cfg, backend, executor.run)
+	if err == nil {
+		t.Fatal("watchWithBackend succeeded, want setup failure")
+	}
+	if executor.callCount() != 0 {
+		t.Fatalf("iterations=%d, want 0", executor.callCount())
+	}
+	_, _, releases := backend.counts()
+	if releases != 1 {
+		t.Fatalf("release=%d, want 1", releases)
+	}
+}
+
+func TestWatchReleasesLeaseOnFatalIterationError(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CRABBOX_COORDINATOR", "")
+	root := newWatchGitRepo(t)
+	backend := newWatchTestBackend()
+	executor := newWatchTestExecutor()
+	fatal := errors.New("sync failed")
+	executor.errs[1] = fatal
+	app := App{Stdout: io.Discard, Stderr: io.Discard}
+	opts := watchOptions{Debounce: 25 * time.Millisecond, IdleExit: 250 * time.Millisecond, IdleExitSet: true, Command: []string{"echo", "ok"}}
+	cfg := Config{Provider: "watch-test", IdleTimeout: time.Minute, TTL: time.Hour}
+	err := app.watchWithBackend(context.Background(), opts, Repo{Root: root, Name: "my-app"}, cfg, backend, executor.run)
+	if !errors.Is(err, fatal) {
+		t.Fatalf("watchWithBackend error=%v, want %v", err, fatal)
+	}
+	_, _, releases := backend.counts()
+	if releases != 1 {
+		t.Fatalf("release=%d, want 1", releases)
+	}
+}
+
+func TestWatchBackendGate(t *testing.T) {
+	if _, err := watchBackendGate(newWatchTestBackend()); err != nil {
+		t.Fatalf("crabbox-sync ssh lease backend rejected: %v", err)
+	}
+	noSync := newWatchTestBackend()
+	noSync.features = FeatureSet{FeatureSSH}
+	var exitErr ExitError
+	if _, err := watchBackendGate(noSync); !AsExitError(err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("backend without crabbox-sync: err=%v, want exit code 2", err)
+	}
+	if _, err := watchBackendGate(prewarmDelegatedTestBackend{}); !AsExitError(err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("delegated backend: err=%v, want exit code 2", err)
+	}
+}
+
+func TestWatchEffectiveIdleExit(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		opts        watchOptions
+		idleTimeout time.Duration
+		want        time.Duration
+		wantErr     bool
+	}{
+		{name: "defaults to idle timeout", opts: watchOptions{}, idleTimeout: 30 * time.Minute, want: 30 * time.Minute},
+		{name: "explicit below timeout", opts: watchOptions{IdleExit: 5 * time.Minute, IdleExitSet: true}, idleTimeout: 30 * time.Minute, want: 5 * time.Minute},
+		{name: "explicit equal to timeout", opts: watchOptions{IdleExit: 30 * time.Minute, IdleExitSet: true}, idleTimeout: 30 * time.Minute, want: 30 * time.Minute},
+		{name: "explicit above timeout", opts: watchOptions{IdleExit: time.Hour, IdleExitSet: true}, idleTimeout: 30 * time.Minute, wantErr: true},
+		{name: "explicit zero", opts: watchOptions{IdleExit: 0, IdleExitSet: true}, idleTimeout: 30 * time.Minute, wantErr: true},
+		{name: "explicit negative", opts: watchOptions{IdleExit: -time.Minute, IdleExitSet: true}, idleTimeout: 30 * time.Minute, wantErr: true},
+		{name: "nonpositive idle timeout", opts: watchOptions{}, idleTimeout: 0, wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := watchEffectiveIdleExit(tc.opts, tc.idleTimeout)
+			if tc.wantErr {
+				var exitErr ExitError
+				if !AsExitError(err, &exitErr) || exitErr.Code != 2 {
+					t.Fatalf("err=%v, want exit code 2", err)
+				}
+				return
+			}
+			if err != nil || got != tc.want {
+				t.Fatalf("got %s err=%v, want %s", got, err, tc.want)
+			}
+		})
+	}
+}
+
+func TestWatchRejectsConflictingRunFlags(t *testing.T) {
+	app := App{Stdout: io.Discard, Stderr: io.Discard}
+	for _, args := range [][]string{
+		{"--pool", "ready", "--", "echo", "ok"},
+		{"--pool-return", "auto", "--", "echo", "ok"},
+		{"--sync-only", "--", "echo", "ok"},
+		{"--no-sync", "--", "echo", "ok"},
+		{"--apply-local-patch", "--", "echo", "ok"},
+		{"--fresh-pr=123", "--", "echo", "ok"},
+		{"--script", "run.sh", "--", "echo", "ok"},
+		{"--script-stdin", "--", "echo", "ok"},
+		{"--stop-after", "success", "--", "echo", "ok"},
+		{"--lease-output", "lease.json", "--", "echo", "ok"},
+		{"--keep-on-failure", "--", "echo", "ok"},
+		{"--capture-stdout=out.log", "--", "echo", "ok"},
+		{"--capture-stderr", "err.log", "--", "echo", "ok"},
+		{"--download", "remote=local", "--", "echo", "ok"},
+		{"--emit-proof", "proof.md", "--", "echo", "ok"},
+		{"--proof-template", "default", "--", "echo", "ok"},
+		{"-label", "custom", "--", "echo", "ok"},
+	} {
+		t.Run(args[0], func(t *testing.T) {
+			err := app.watch(context.Background(), args)
+			var exitErr ExitError
+			if !AsExitError(err, &exitErr) || exitErr.Code != 2 {
+				t.Fatalf("watch(%v) err=%v, want exit code 2", args, err)
+			}
+			flagName := strings.TrimLeft(strings.SplitN(args[0], "=", 2)[0], "-")
+			if !strings.Contains(exitErr.Message, "--"+flagName) {
+				t.Fatalf("error %q does not name flag %q", exitErr.Message, flagName)
+			}
+		})
+	}
+}
+
+func TestWatchUsageValidation(t *testing.T) {
+	app := App{Stdout: io.Discard, Stderr: io.Discard}
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "missing command", args: []string{}, want: "usage: crabbox watch"},
+		{name: "missing command after flags", args: []string{"--debounce", "1s"}, want: "usage: crabbox watch"},
+		{name: "empty command", args: []string{"--"}, want: "usage: crabbox watch"},
+		{name: "positional before separator", args: []string{"echo", "ok"}, want: "place the command after --"},
+		{name: "zero debounce", args: []string{"--debounce", "0s", "--", "echo", "ok"}, want: "--debounce must be positive"},
+		{name: "negative debounce", args: []string{"--debounce=-1s", "--", "echo", "ok"}, want: "--debounce must be positive"},
+		{name: "slug with id", args: []string{"--id", watchTestLeaseID, "--slug", "my-slug", "--", "echo", "ok"}, want: "--slug only applies when creating a new lease"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := app.watch(context.Background(), tc.args)
+			var exitErr ExitError
+			if !AsExitError(err, &exitErr) || exitErr.Code != 2 {
+				t.Fatalf("watch(%v) err=%v, want exit code 2", tc.args, err)
+			}
+			if !strings.Contains(exitErr.Message, tc.want) {
+				t.Fatalf("error %q missing %q", exitErr.Message, tc.want)
+			}
+		})
+	}
+}
+
+func TestPartitionWatchRunArgs(t *testing.T) {
+	newFS := func() *flag.FlagSet {
+		fs := newFlagSet("watch", io.Discard)
+		fs.String("id", "", "")
+		fs.Bool("keep", false, "")
+		fs.Duration("debounce", 0, "")
+		fs.Duration("idle-exit", 0, "")
+		fs.String("slug", "", "")
+		fs.String("provider", "", "")
+		fs.Bool("desktop", false, "")
+		return fs
+	}
+	for _, tc := range []struct {
+		name      string
+		args      []string
+		wantWatch string
+		wantRun   string
+		wantErr   string
+	}{
+		{name: "empty", args: nil, wantWatch: "", wantRun: ""},
+		{name: "owned separated value", args: []string{"--id", "cbx_x"}, wantWatch: "--id cbx_x", wantRun: ""},
+		{name: "owned equals value", args: []string{"--debounce=1s"}, wantWatch: "--debounce=1s", wantRun: ""},
+		{name: "owned bool", args: []string{"--keep"}, wantWatch: "--keep", wantRun: ""},
+		{name: "slug never forwarded", args: []string{"--slug", "fast-crab"}, wantWatch: "--slug fast-crab", wantRun: ""},
+		{name: "shared goes to both", args: []string{"--provider", "hetzner"}, wantWatch: "--provider hetzner", wantRun: "--provider hetzner"},
+		{name: "shared bool goes to both", args: []string{"--desktop"}, wantWatch: "--desktop", wantRun: "--desktop"},
+		{name: "unknown forwarded with value", args: []string{"--junit", "results.xml"}, wantWatch: "", wantRun: "--junit results.xml"},
+		{name: "unknown bool then flag", args: []string{"--results-auto", "--provider", "aws"}, wantWatch: "--provider aws", wantRun: "--results-auto --provider aws"},
+		{name: "order preserved", args: []string{"--shell", "--id", "cbx_x", "--allow-env", "CI"}, wantWatch: "--id cbx_x", wantRun: "--shell --allow-env CI"},
+		{name: "single dash owned", args: []string{"-id", "cbx_x"}, wantWatch: "-id cbx_x", wantRun: ""},
+		{name: "forbidden", args: []string{"--sync-only"}, wantErr: "--sync-only cannot be used with watch"},
+		{name: "forbidden equals", args: []string{"--label=x"}, wantErr: "--label cannot be used with watch"},
+		{name: "forbidden after unknown bool", args: []string{"--results-auto", "--no-sync"}, wantErr: "--no-sync cannot be used with watch"},
+		{name: "positional", args: []string{"echo"}, wantErr: "place the command after --"},
+		{name: "owned missing value", args: []string{"--id"}, wantErr: "flag needs an argument"},
+		{name: "bare dashes", args: []string{"---"}, wantErr: "invalid flag"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			watchArgs, runArgs, err := partitionWatchRunArgs(newFS(), tc.args)
+			if tc.wantErr != "" {
+				var exitErr ExitError
+				if !AsExitError(err, &exitErr) || exitErr.Code != 2 || !strings.Contains(exitErr.Message, tc.wantErr) {
+					t.Fatalf("err=%v, want exit code 2 containing %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("partition: %v", err)
+			}
+			if got := strings.Join(watchArgs, " "); got != tc.wantWatch {
+				t.Fatalf("watchArgs=%q, want %q", got, tc.wantWatch)
+			}
+			if got := strings.Join(runArgs, " "); got != tc.wantRun {
+				t.Fatalf("runArgs=%q, want %q", got, tc.wantRun)
+			}
+		})
+	}
+}
+
+func TestIsWatchIterationResult(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "remote nonzero", err: ExitError{Code: 1, Message: "remote command exited 1"}, want: true},
+		{name: "junit failures", err: ExitError{Code: 1, Message: "JUnit results contain 2 failures and 0 errors"}, want: true},
+		{name: "sync too large", err: ExitError{Code: 6, Message: "sync manifest too large: 12 files >= limit 10"}, want: false},
+		{name: "plain error", err: errors.New("ssh transport failed"), want: false},
+		{name: "nil", err: nil, want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isWatchIterationResult(tc.err); got != tc.want {
+				t.Fatalf("isWatchIterationResult=%v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWatchHelpExitsZero(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	app := App{Stdout: &stdout, Stderr: &stderr}
+	err := app.Run(context.Background(), []string{"watch", "--help"})
+	var exitErr ExitError
+	if err != nil && (!AsExitError(err, &exitErr) || exitErr.Code != 0) {
+		t.Fatalf("watch --help err=%v, want exit code 0", err)
+	}
+	combined := stdout.String() + stderr.String()
+	if !strings.Contains(combined, "Usage:") || !strings.Contains(combined, "crabbox watch [flags] -- <command...>") {
+		t.Fatalf("help output missing usage:\n%s", combined)
+	}
+}
+
+func TestTopLevelHelpListsWatch(t *testing.T) {
+	var stdout bytes.Buffer
+	app := App{Stdout: &stdout, Stderr: io.Discard}
+	app.printHelp()
+	if !strings.Contains(stdout.String(), "\n  watch       ") {
+		t.Fatal("top-level help does not list watch")
+	}
+}

--- a/internal/cli/watch_test.go
+++ b/internal/cli/watch_test.go
@@ -14,6 +14,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/fsnotify/fsnotify"
 )
 
 const watchTestLeaseID = "cbx_abcdef123456"
@@ -598,6 +600,39 @@ func TestWatchGitPathsTreatsEventNamesLiterally(t *testing.T) {
 	}
 	if len(got) != 1 || got[0] != "*.go" {
 		t.Fatalf("paths=%q, want only the literal event path", got)
+	}
+}
+
+func TestWatchIgnoresUnchangedMetadataEvents(t *testing.T) {
+	root := newWatchGitRepo(t)
+	path := filepath.Join(root, "main.go")
+	session := &watchSession{root: root}
+	session.rememberPath("main.go", path)
+
+	batch := map[string]struct{}{}
+	if session.observeEvent(nil, fsnotify.Event{Name: path, Op: fsnotify.Chmod}, batch) {
+		t.Fatal("unchanged metadata event qualified")
+	}
+	if len(batch) != 0 {
+		t.Fatalf("batch=%v, want empty", batch)
+	}
+}
+
+func TestWatchKeepsExecutableModeChanges(t *testing.T) {
+	root := newWatchGitRepo(t)
+	path := filepath.Join(root, "main.go")
+	session := &watchSession{root: root}
+	session.rememberPath("main.go", path)
+
+	if err := os.Chmod(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	batch := map[string]struct{}{}
+	if !session.observeEvent(nil, fsnotify.Event{Name: path, Op: fsnotify.Chmod}, batch) {
+		t.Fatal("executable mode change did not qualify")
+	}
+	if _, ok := batch["main.go"]; !ok {
+		t.Fatalf("batch=%v, want main.go", batch)
 	}
 }
 

--- a/internal/cli/watch_test.go
+++ b/internal/cli/watch_test.go
@@ -588,6 +588,19 @@ func TestQualifyWatchBatchHonorsSyncIncludes(t *testing.T) {
 	}
 }
 
+func TestWatchGitPathsTreatsEventNamesLiterally(t *testing.T) {
+	root := newWatchGitRepo(t)
+	watchTestWrite(t, root, "*.go", "literal filename\n")
+
+	got, err := watchGitPaths(root, []string{"*.go"}, "ls-files", "--cached", "--others", "--exclude-standard", "-z", "--")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0] != "*.go" {
+		t.Fatalf("paths=%q, want only the literal event path", got)
+	}
+}
+
 func TestWatchIncludeWhitelistFiltersReruns(t *testing.T) {
 	root := newWatchGitRepo(t)
 	watchTestWrite(t, root, "src/app.go", "package app\n")
@@ -868,6 +881,42 @@ func TestWatchUsageValidation(t *testing.T) {
 	}
 }
 
+func TestWatchAllowsCommandlessPreset(t *testing.T) {
+	err := (App{Stdout: io.Discard, Stderr: io.Discard}).watch(context.Background(), []string{
+		"--provider", "e2b",
+		"--preset", "qa",
+		"--",
+	})
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 2 || !strings.Contains(exitErr.Message, "does not support watch") {
+		t.Fatalf("watch error=%v, want commandless preset to pass usage validation", err)
+	}
+}
+
+func TestWatchValidatesSelectedProfileBeforeLoadingProvider(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), ".crabbox.yaml")
+	t.Setenv("CRABBOX_CONFIG", cfgPath)
+	if err := os.WriteFile(cfgPath, []byte(`
+profiles:
+  invalid:
+    doctor:
+      enabled: true
+      tools: [not-a-real-tool]
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := (App{Stdout: io.Discard, Stderr: io.Discard}).watch(context.Background(), []string{
+		"--provider", "e2b",
+		"--profile", "invalid",
+		"--", "true",
+	})
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 2 || !strings.Contains(exitErr.Message, "unknown preflight tool") {
+		t.Fatalf("watch error=%v, want profile validation before provider loading", err)
+	}
+}
+
 func TestPartitionWatchRunArgs(t *testing.T) {
 	newFS := func() *flag.FlagSet {
 		fs := newFlagSet("watch", io.Discard)
@@ -876,6 +925,7 @@ func TestPartitionWatchRunArgs(t *testing.T) {
 		fs.Duration("debounce", 0, "")
 		fs.Duration("idle-exit", 0, "")
 		fs.String("slug", "", "")
+		fs.String("preset", "", "")
 		fs.String("provider", "", "")
 		fs.Bool("desktop", false, "")
 		return fs
@@ -892,6 +942,7 @@ func TestPartitionWatchRunArgs(t *testing.T) {
 		{name: "owned equals value", args: []string{"--debounce=1s"}, wantWatch: "--debounce=1s", wantRun: ""},
 		{name: "owned bool", args: []string{"--keep"}, wantWatch: "--keep", wantRun: ""},
 		{name: "slug never forwarded", args: []string{"--slug", "fast-crab"}, wantWatch: "--slug fast-crab", wantRun: ""},
+		{name: "preset forwarded and parsed", args: []string{"--preset", "qa"}, wantWatch: "--preset qa", wantRun: "--preset qa"},
 		{name: "shared goes to both", args: []string{"--provider", "hetzner"}, wantWatch: "--provider hetzner", wantRun: "--provider hetzner"},
 		{name: "shared bool goes to both", args: []string{"--desktop"}, wantWatch: "--desktop", wantRun: "--desktop"},
 		{name: "unknown forwarded with value", args: []string{"--junit", "results.xml"}, wantWatch: "", wantRun: "--junit results.xml"},


### PR DESCRIPTION
Implements the `crabbox watch` proposal from https://github.com/openclaw/crabbox/issues/784 on the v1 contract approved there by @steipete.

## Summary

`crabbox watch [flags] -- <command...>` runs the command once on a warm lease, then watches the repository and re-runs it when synced files change. Each iteration goes through the existing run path with an injected `--id` and a deterministic `watch #N` label, so sync fingerprints, run recording, history, results, artifacts, and attach behave exactly as they do for `run`. The run orchestrator is untouched; the command is a new `internal/cli/watch.go` plus registration, tests, and docs.

## Contract conformance

Point by point against the approved v1 contract:

- New `crabbox watch` command; each iteration calls the existing run path (`App.runCommand`) in process through a narrow executor seam. No shelling out to the CLI, no output scraping, no run orchestrator changes.
- Queue-and-coalesce default with no overlapping runs: at most one active run plus one pending rerun, started from the newest tree after the active run finishes (sync happens at run start). A pending rerun always runs before idle exit is honored, so a long iteration that outlasts the idle window cannot drop queued work; the loop then exits after that run unless new qualifying activity arrived during it. No interrupt-on-change in v1.
- One Ctrl-C exits the loop and applies the lease rules; no two-interrupt state machine. The release path runs on a fresh background context so cleanup survives the interrupt, matching the existing run cleanup pattern.
- `--idle-exit` defaults to the effective lease idle timeout (for `--id` leases, derived from the `idle_timeout_secs` label like `run` does) and must be positive and at most that timeout. Idle time is tracked from local qualifying filesystem activity only; run and claim bookkeeping never reset it, and ignored churn neither triggers runs nor counts as activity.
- Capability dispatch only: the backend must type-assert to `SSHLeaseBackend` and advertise the `crabbox-sync` feature, otherwise a clear error points at `crabbox run`. No provider-name branches.
- `--id` resolves an existing claimed lease through `resolveSSHLeaseTarget` (ownership and claim checks included) and never releases it. Without `--id`, watch acquires once (all `warmup` lease-creation flags apply), registers the repo claim, and releases on every exit path (idle exit, Ctrl-C, watcher or lease or sync failure, setup failure after acquire) unless `--keep` is set.
- Initial run starts immediately; `--debounce` defaults to 250ms; the repository root is watched recursively, newly created directories are attached on the fly, and symlinked directories are never followed. Excluded directories such as `node_modules` are never added to the watcher.
- Event qualification matches the exact sync universe: the same `git ls-files --cached --others --exclude-standard` semantics the sync manifest uses, plus `pathExcluded` over the built-in, `sync.exclude`, and `.crabboxignore` rules, plus the `sync.include` whitelist (`pathIncluded`) applied at the same layer `syncManifestFiltered` applies it, so a configured include list means changes outside it neither rerun nor reset idle time. Deletions are qualified via the index and `git check-ignore` so tracked and untracked-nonignored deletions rerun while ignored ones do not. Filter sources reload when they change: `.crabboxignore` and repo-local config edits take effect for the same batch, `.gitignore` is re-evaluated by git on every batch, and when a reload changes the exclude list the watcher re-walks the repository root so a directory whose exclusion was relaxed gets its watches attached (fsnotify Add is idempotent for directories already watched, and excluded subtrees are still skipped).
- A nonzero remote exit (or JUnit gate failure) is an iteration result and the loop continues; watcher, lease, sync, and SSH failures are fatal.
- Windows uses the same queue behavior; fsnotify is cross-platform and there is no platform fork. `GOOS=windows go build ./...` passes.
- Conflicting one-shot flags are rejected before any lease work with an error naming the flag: `--pool`, `--pool-return`, `--sync-only`, `--no-sync`, `--apply-local-patch`, `--fresh-pr`, `--script`, `--script-stdin`, `--stop-after`, `--lease-output`, `--keep-on-failure`, `--capture-stdout`, `--capture-stderr`, `--download`, `--emit-proof`, `--proof-template`, and `--label` (reserved for the deterministic iteration labels). Other run flags pass through to each iteration unchanged.
- Regression coverage for every listed behavior: initial run, ignore filtering (event-level and batch-level, including tracked-but-gitignored and deletion cases), recursive new directories, debounce coalescing, change during a run queuing exactly one rerun, nonzero continuation, fatal stop, idle exit (quiet period and while a run is active), a queued rerun surviving an idle window that expires mid-iteration, Ctrl-C releasing with a background context, acquisition and `--id` reuse, release and `--keep` and `--id` never-release, cleanup after setup and iteration failures, flag rejection in `--flag=v`, `--flag v`, and `-flag` forms, arg partitioning, capability gate, idle-exit bounds, filter reload mid-session, exclusion relaxation re-attaching watches to a directory skipped at startup, `sync.include` whitelist filtering (batch qualification table plus a live-loop test showing outside-include churn neither reruns nor resets idle), sequential labels, and help exit 0.
- Docs: `docs/commands/watch.md`, command index and CLI map entries, and a performance guide update. `scripts/check-docs.sh` passes (52 command docs). No `CHANGELOG.md` entry is included in this PR; happy to add one if you want it here rather than at release notes time.

The only mechanical dependency change is promoting `github.com/fsnotify/fsnotify` from an existing transitive entry to a direct require at the same version (v1.10.1).

## Real behavior proof

Head: 25ee0dd8. Provider: `external` protocol adapter backed by a localhost sshd, exercising the full real pipeline (acquire, claim, rsync sync, remote command over SSH, release). All transcripts recorded from a binary built at this head.

Before (pristine main at ab1c29f3, no watch command):

```text
$ crabbox watch -- ./test.sh
unexpected argument watch
(exit 2)
```

After, transcript 1: fresh acquire, edit-triggered rerun, coalesced queue during an active run, ignored churn, single Ctrl-C, zero residue. Notable moments: two edits land while run 2 is active and produce exactly one run 3 (`changes=2`) executing the newest content; the `node_modules` write triggers nothing; Ctrl-C releases the acquired lease and provider inventory is empty afterwards.

```text
$ crabbox watch --debounce 300ms --idle-exit 60s -- sh -c 'sleep 6; ./test.sh'
leased cbx_f11ffcb7b69e slug=golden-barnacle provider=external idle_timeout=30m0s idle_exit=1m0s
watch root=/root/my-app debounce=300ms idle_exit=1m0s
syncing /root/my-app -> 127.0.0.1:/root/crabbox-demo-work/cbx_f11ffcb7b69e/my-app
sync candidate: 3 files, 92 B dirty_delta=1 files, 41 B
sync complete in 245ms
running on 127.0.0.1 sh -c 'sleep 6; ./test.sh'
hello from my-app tests
run details ... label="watch #1" ...

### edit tracked file (run 1 finished, expect run 2)
watch run=2 changes=1
sync candidate: 3 files, 104 B dirty_delta=2 files, 94 B
running on 127.0.0.1 sh -c 'sleep 6; ./test.sh'
### edit again while run 2 is active (expect exactly one queued run 3)
### ignored churn: node_modules write (expect no extra run)
hello from my-app tests (edited v2)
run details ... label="watch #2" ...
watch run=3 changes=2
running on 127.0.0.1 sh -c 'sleep 6; ./test.sh'
hello from my-app tests (edited v4, coalesced)
run details ... label="watch #3" ...

### Ctrl-C (single SIGINT)
watch interrupted runs=3
releasing cbx_f11ffcb7b69e server=localhost-demo/cbx_f11ffcb7b69e
watch exit code: 0

$ cat adapter-state.json  # zero residue
{}
$ crabbox list
```

After, transcript 2: warm reuse with `--id`, idle exit, lease survives.

```text
$ crabbox warmup
leased cbx_92f6bbad6815 slug=jade-krill provider=external ... idle_timeout=30m0s ...
warmup complete total=110ms

$ crabbox watch --id jade-krill --debounce 300ms --idle-exit 20s -- ./test.sh
watch lease=cbx_92f6bbad6815 slug=jade-krill provider=external idle_timeout=30m0s idle_exit=20s
watch root=/root/my-app debounce=300ms idle_exit=20s
running on 127.0.0.1 ./test.sh
hello from my-app tests
run details ... label="watch #1" ...

### edit tracked file (expect run 2)
watch run=2 changes=1
running on 127.0.0.1 ./test.sh
hello from my-app tests (id-reuse edit)
run details ... label="watch #2" ...
watch idle_exit=20s runs=2
watch exit code: 0 (idle exit)

### lease survives --id watch exit
$ cat adapter-state.json
{"cbx_92f6bbad6815": {"leaseId": "cbx_92f6bbad6815", "slug": "jade-krill", "name": "crabbox-jade-krill-02aa2b5f"}}

$ crabbox stop jade-krill
released external lease=cbx_92f6bbad6815 name=crabbox-jade-krill-02aa2b5f
```

After, transcript 3: `sync.include` whitelist. With `sync.include: [src]` configured, the initial sync ships only the included file, edits outside the whitelist neither rerun nor reset the idle timer (the loop idle-exits on its original 12s schedule), and an edit inside the whitelist reruns.

```text
$ crabbox watch --debounce 300ms --idle-exit 12s -- sh src/run.sh   # sync.include: [src]
leased cbx_ddc9dde51520 slug=golden-lobster provider=external idle_timeout=30m0s idle_exit=12s
watch root=/root/my-app debounce=300ms idle_exit=12s
sync candidate: 1 files, 32 B
running on 127.0.0.1 sh src/run.sh
hello from src
run details ... label="watch #1" ...

### edit OUTSIDE the include whitelist (expect no rerun, no idle reset)
### edit INSIDE the include whitelist (expect run 2)
watch run=2 changes=1
sync candidate: 1 files, 41 B dirty_delta=1 files, 41 B
running on 127.0.0.1 sh src/run.sh
hello from src (edited)
run details ... label="watch #2" ...
watch idle_exit=12s runs=2
releasing cbx_ddc9dde51520 server=localhost-demo/cbx_ddc9dde51520
watch exit code: 0 (idle exit)
```

Full unabridged transcripts available on request; lines above are verbatim from the recorded runs, with repeated run-context blocks elided for length.

## Verification

```sh
gofmt -l $(git ls-files '*.go')                            # empty
go vet ./...                                               # clean
go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./... # no output
go test -race ./internal/cli/                              # ok
go test -race -count=5 -run 'TestWatch|TestQualify|TestPartition' ./internal/cli/  # ok, timer/goroutine shake
GOOS=windows go build ./...                                # ok
scripts/check-docs.sh                                      # 52 command docs ok, links ok, site builds
```

## Deferred by contract

- Interrupt-on-change (remote termination is not a provider-neutral contract yet); queue mode is the only v1 behavior.
- Delegated and archive-sync providers; they get the clear unsupported-provider error.
- No hooks, no extra UI, no new config keys beyond the command's own flags.

Closes https://github.com/openclaw/crabbox/issues/784.
