### PR TITLE
fix: enforce W&B sandbox ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Required W&B sandbox reuse, status, and stop to match an exact endpoint/entity/project/resource-bound local claim plus provider inventory ownership. Thanks @coygeek.
 - Made coordinatorless generic provider live smokes skip coordinator-only history and always clean up acquired leases after later lifecycle failures.
 - Replaced privileged managed Linux Code Server and Tailscale installer scripts with checksum-verified archives or Tailscale's signed package repository with a pinned keyring in both CLI and coordinator bootstrap paths. Thanks @TurboTheTurtle.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 - Required exact resource-bound local lease claims before Apple Container, local-container, or Apple VZ stop operations can delete provider resources; legacy unbound claims require explicit `--reclaim` adoption before stop. Thanks @coygeek.
 - Hardened Azure Windows snapshot forks to fail closed through credential rehydration and quarantine cleanup, reuse only writable NIC payloads, reject unknown differential disks, and retry in-use security-group cleanup. Thanks @fcoury-oai.
 - Rolled back brokered Hetzner servers when post-create readiness fails, deleting only lease-owned SSH keys created by the failed attempt after server cleanup succeeds while preserving explicit no-delete retention until a later delete. Thanks @coygeek.
+- Required W&B existing-sandbox run, status, and stop operations to verify the provider-side Crabbox tag before accessing raw sandbox IDs. Thanks @coygeek.
 
 ## 0.34.0 - 2026-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,6 @@
 - Required exact resource-bound local lease claims before Apple Container, local-container, or Apple VZ stop operations can delete provider resources; legacy unbound claims require explicit `--reclaim` adoption before stop. Thanks @coygeek.
 - Hardened Azure Windows snapshot forks to fail closed through credential rehydration and quarantine cleanup, reuse only writable NIC payloads, reject unknown differential disks, and retry in-use security-group cleanup. Thanks @fcoury-oai.
 - Rolled back brokered Hetzner servers when post-create readiness fails, deleting only lease-owned SSH keys created by the failed attempt after server cleanup succeeds while preserving explicit no-delete retention until a later delete. Thanks @coygeek.
-- Required W&B existing-sandbox run, status, and stop operations to verify the provider-side Crabbox tag before accessing raw sandbox IDs. Thanks @coygeek.
 
 ## 0.34.0 - 2026-07-02
 

--- a/docs/providers/wandb.md
+++ b/docs/providers/wandb.md
@@ -111,17 +111,19 @@ Environment overrides:
 
 `crabbox run`:
 
-1. With `--id <sandbox-id>`, `Exec` against the existing sandbox and leave it
-   running.
+1. With `--id <sandbox-id>`, verify the sandbox appears in W&B inventory with
+   the provider-side `crabbox` tag, then `Exec` against it and leave it running.
 2. Otherwise, `Start` a sandbox with an idle keep-alive command, poll until it
    reaches `RUNNING` (200 ms backoff, ×1.5, capped at 2 s), `Exec` the
    command, then `Stop` it unless `--keep` is set.
 
-`status` renders the sandbox state (for example `running`; a `COMPLETED`
-sandbox is reported as `stopped` so `status --wait` treats it as terminal).
-`list` paginates sandboxes tagged `crabbox`. `stop` issues a graceful stop
-(15 s timeout). Acquire and exec apply a startup timeout that is the lesser of
-five minutes and the sandbox lifetime.
+`status` and `stop` likewise require the sandbox ID to appear in tagged
+Crabbox inventory before issuing Get or Stop. Unknown or untagged IDs fail
+closed. `status` renders the sandbox state (for example `running`; a
+`COMPLETED` sandbox is reported as `stopped` so `status --wait` treats it as
+terminal). `list` paginates sandboxes tagged `crabbox`. `stop` issues a
+graceful stop (15 s timeout). Acquire and exec apply a startup timeout that is
+the lesser of five minutes and the sandbox lifetime.
 
 ## Capabilities
 
@@ -146,6 +148,8 @@ five minutes and the sandbox lifetime.
   `--full-resync`, `--download`, `--artifact-glob`, and `--require-artifact`
   are rejected: W&B owns the sandbox lifecycle and there is no Crabbox
   SSH/rsync target.
+- `--reclaim` remains unsupported because the pinned W&B API has no safe way
+  to add the ownership tag to an existing sandbox after creation.
 - `--keep` retains a newly acquired sandbox after the run; `--keep-on-failure`
   retains it only when the command fails, so you can debug.
 - gRPC failures map to sysexits-aligned exit codes:

--- a/docs/providers/wandb.md
+++ b/docs/providers/wandb.md
@@ -125,7 +125,11 @@ Environment overrides:
 before issuing Get or Stop. A tagged sandbox without the matching local claim,
 or a claim from another endpoint, entity, or project, fails closed. Successful
 automatic or explicit stop removes the unchanged claim; failed cleanup keeps
-it so a later retry can still route to the owned resource. `status` renders
+it so a later retry can still route to the owned resource. If tagged inventory
+no longer contains a claimed sandbox, Crabbox probes that exact ID: a confirmed
+provider `NotFound` lets `stop` remove only the unchanged stale claim. An
+untagged but existing sandbox or any lookup error preserves the claim and fails
+closed. `status` renders
 the sandbox state (for example `running`; a
 `COMPLETED` sandbox is reported as `stopped` so `status --wait` treats it as
 terminal). `list` paginates sandboxes tagged `crabbox`. `stop` issues a

--- a/docs/providers/wandb.md
+++ b/docs/providers/wandb.md
@@ -111,15 +111,22 @@ Environment overrides:
 
 `crabbox run`:
 
-1. With `--id <sandbox-id>`, verify the sandbox appears in W&B inventory with
-   the provider-side `crabbox` tag, then `Exec` against it and leave it running.
+1. With `--id <sandbox-id>`, require the exact local claim created when
+   Crabbox acquired the sandbox, verify that the claim still matches the W&B
+   endpoint, entity, project, and sandbox ID, then require the provider-side
+   `crabbox` inventory tag before `Exec`.
 2. Otherwise, `Start` a sandbox with an idle keep-alive command, poll until it
-   reaches `RUNNING` (200 ms backoff, ×1.5, capped at 2 s), `Exec` the
-   command, then `Stop` it unless `--keep` is set.
+   reaches `RUNNING` (200 ms backoff, ×1.5, capped at 2 s), persist the exact
+   ownership claim, `Exec` the command, then `Stop` it unless `--keep` is set.
+   If claim persistence fails, Crabbox rolls back the acquired sandbox before
+   returning.
 
-`status` and `stop` likewise require the sandbox ID to appear in tagged
-Crabbox inventory before issuing Get or Stop. Unknown or untagged IDs fail
-closed. `status` renders the sandbox state (for example `running`; a
+`status` and `stop` enforce the same exact claim and tagged-inventory checks
+before issuing Get or Stop. A tagged sandbox without the matching local claim,
+or a claim from another endpoint, entity, or project, fails closed. Successful
+automatic or explicit stop removes the unchanged claim; failed cleanup keeps
+it so a later retry can still route to the owned resource. `status` renders
+the sandbox state (for example `running`; a
 `COMPLETED` sandbox is reported as `stopped` so `status --wait` treats it as
 terminal). `list` paginates sandboxes tagged `crabbox`. `stop` issues a
 graceful stop (15 s timeout). Acquire and exec apply a startup timeout that is
@@ -149,9 +156,10 @@ the lesser of five minutes and the sandbox lifetime.
   are rejected: W&B owns the sandbox lifecycle and there is no Crabbox
   SSH/rsync target.
 - `--reclaim` remains unsupported because the pinned W&B API has no safe way
-  to add the ownership tag to an existing sandbox after creation.
+  to adopt a tagged external sandbox into a conflict-safe exact local claim.
 - `--keep` retains a newly acquired sandbox after the run; `--keep-on-failure`
-  retains it only when the command fails, so you can debug.
+  retains it only when the command fails, so you can debug. Both paths retain
+  the exact local claim needed by later `run --id`, `status`, and `stop` calls.
 - gRPC failures map to sysexits-aligned exit codes:
   `77` (unauthenticated / permission denied), `4` (not found), `124`
   (deadline exceeded), `69` (unavailable / resource exhausted).
@@ -172,10 +180,12 @@ CRABBOX_LIVE_REPO=/path/to/my-app \
 scripts/live-smoke.sh
 ```
 
-The shared harness exits before any W&B `doctor`, `run`, or `list` command when
-no API key is exported. With the API key and entity configured, it runs
-`doctor`, executes one no-sync command with a 60-second sandbox lifetime, and
-prints normalized W&B inventory.
+The shared harness exits before any W&B provider command when no API key is
+exported. With the API key and entity configured, it runs `doctor`, creates a
+kept sandbox with a 60-second lifetime, proves status and reuse through the
+exact claim, proves that the provider tag alone cannot authorize stop, then
+stops the sandbox and confirms no active remote inventory or local claim
+residue.
 
 For manual debugging, run the same lifecycle directly:
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -258,15 +258,17 @@ output, downloaded artifacts, screenshots, or failure bundles.
 
 Lifecycle recovery from raw provider identifiers is provider-specific and
 fails closed when ownership cannot be established. Cloudflare containers need
-a matching local claim. Freestyle and Islo canonical names remain available
-for read-only discovery, but delete, pause, resume, SSH reuse, and delegated
-reuse require an exact local claim. When local state was intentionally lost,
-an operator can use the provider's supported `--reclaim` reuse path to persist
-a new claim before any provider mutation. Hyper-V, Multipass, and Parallels
-likewise require exact resource-bound local claims before release or cleanup;
-provider names and `crabbox-` resource prefixes are discovery hints, not
-destructive ownership proof. Railway services are created out-of-band, so stop
-requires either an exact local endpoint/project/environment/service/deployment
+a matching local claim. W&B sandbox reuse, status, and stop require an exact
+local claim bound to the sandbox ID, API endpoint, entity, and project as well
+as the provider-side Crabbox inventory tag. Freestyle and Islo canonical names
+remain available for read-only discovery, but delete, pause, resume, SSH reuse,
+and delegated reuse require an exact local claim. When local state was
+intentionally lost, an operator can use the provider's supported `--reclaim`
+reuse path to persist a new claim before any provider mutation. Hyper-V,
+Multipass, and Parallels likewise require exact resource-bound local claims
+before release or cleanup; provider names and `crabbox-` resource prefixes are
+discovery hints, not destructive ownership proof. Railway services are created
+out-of-band, so stop requires either an exact local endpoint/project/environment/service/deployment
 claim or explicit `stop --reclaim` adoption of the currently inspected
 deployment; a successful stop removes that one-deployment claim.
 Direct Hetzner release and cleanup similarly require canonical provider labels

--- a/internal/cli/claim.go
+++ b/internal/cli/claim.go
@@ -277,9 +277,14 @@ func claimLeaseTargetForConfig(leaseID, slug string, cfg Config, server Server, 
 }
 
 func claimLeaseTargetForConfigIfUnchanged(leaseID, slug string, cfg Config, server Server, target SSHTarget, idleTimeout time.Duration, expected leaseClaim, expectedExists bool) (leaseClaim, error) {
+	provider, _ := claimProviderDetailsForConfig(cfg)
+	return claimLeaseTargetForConfigScopeIfUnchanged(leaseID, slug, cfg, providerClaimScope(provider, cfg), server, target, idleTimeout, expected, expectedExists)
+}
+
+func claimLeaseTargetForConfigScopeIfUnchanged(leaseID, slug string, cfg Config, providerScope string, server Server, target SSHTarget, idleTimeout time.Duration, expected leaseClaim, expectedExists bool) (leaseClaim, error) {
 	provider, staticDetails := claimProviderDetailsForConfig(cfg)
 	var updated leaseClaim
-	err := claimLeaseForRepoProviderScopePondDetailsMetadata(leaseID, slug, provider, providerClaimScope(provider, cfg), cfg.Pond, staticDetails, "", idleTimeout, false, claimMetadata{
+	err := claimLeaseForRepoProviderScopePondDetailsMetadata(leaseID, slug, provider, providerScope, cfg.Pond, staticDetails, "", idleTimeout, false, claimMetadata{
 		setCacheVolumes:    true,
 		cacheVolumes:       CacheVolumeStickyDiskSpecs(cfg.Cache.Volumes),
 		setEndpoint:        true,
@@ -1007,6 +1012,26 @@ func removeLeaseClaim(leaseID string) {
 
 func removeLeaseClaimIfUnchanged(leaseID string, expected leaseClaim) error {
 	return removeLeaseClaimIfUnchangedAfter(leaseID, expected, nil)
+}
+
+func verifyLeaseClaimUnchanged(leaseID string, expected leaseClaim) error {
+	path, err := leaseClaimPath(leaseID)
+	if err != nil {
+		return err
+	}
+	return withLeaseClaimLock(path, func() error {
+		claim, exists, err := readLeaseClaimPathWithPresence(path)
+		if err != nil {
+			return err
+		}
+		if err := validateLeaseClaimFileIdentity(leaseID, claim, exists); err != nil {
+			return err
+		}
+		if err := unchangedLeaseClaimGuard(leaseID, expected, true)(claim, exists); err != nil {
+			return err
+		}
+		return nil
+	})
 }
 
 func removeLeaseClaimIfUnchangedAfter(leaseID string, expected leaseClaim, action func() error) error {

--- a/internal/cli/claim_test.go
+++ b/internal/cli/claim_test.go
@@ -268,6 +268,48 @@ func TestConditionalClaimMutationRejectsChangedState(t *testing.T) {
 	}
 }
 
+func TestConditionalConfigClaimCanBindProviderScope(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	cfg := Config{Provider: "external"}
+	server := Server{Provider: "external", CloudID: "resource-1"}
+	const providerScope = "account:example-org/project:example-project"
+
+	claimed, err := claimLeaseTargetForConfigScopeIfUnchanged(
+		"cbx_scoped_config",
+		"scoped",
+		cfg,
+		providerScope,
+		server,
+		SSHTarget{Host: "192.0.2.10", Port: "22"},
+		time.Minute,
+		leaseClaim{},
+		false,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claimed.ProviderScope != providerScope || claimed.CloudID != "resource-1" {
+		t.Fatalf("scoped claim=%#v", claimed)
+	}
+
+	defaultClaim, err := claimLeaseTargetForConfigIfUnchanged(
+		"cbx_default_config",
+		"default",
+		cfg,
+		server,
+		SSHTarget{},
+		time.Minute,
+		leaseClaim{},
+		false,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if defaultClaim.ProviderScope != "" {
+		t.Fatalf("default claim scope=%q", defaultClaim.ProviderScope)
+	}
+}
+
 func TestVerifyLeaseClaimUnchanged(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	const leaseID = "cbx_guarded_action"

--- a/internal/cli/claim_test.go
+++ b/internal/cli/claim_test.go
@@ -268,6 +268,30 @@ func TestConditionalClaimMutationRejectsChangedState(t *testing.T) {
 	}
 }
 
+func TestVerifyLeaseClaimUnchanged(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	const leaseID = "cbx_guarded_action"
+	cfg := Config{Provider: "external"}
+	server := Server{Provider: "external", CloudID: "resource-1"}
+	if err := claimLeaseTargetForConfig(leaseID, "guarded", cfg, server, SSHTarget{}, time.Minute); err != nil {
+		t.Fatal(err)
+	}
+	claim, err := readLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := verifyLeaseClaimUnchanged(leaseID, claim); err != nil {
+		t.Fatal(err)
+	}
+
+	stale := claim
+	stale.CloudID = "resource-2"
+	err = verifyLeaseClaimUnchanged(leaseID, stale)
+	if err == nil || !strings.Contains(err.Error(), "claim changed") {
+		t.Fatalf("stale guard err=%v", err)
+	}
+}
+
 func TestConditionalRepoClaimCanBeRestored(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	leaseID := "cbx_transaction123"

--- a/internal/cli/provider_exports.go
+++ b/internal/cli/provider_exports.go
@@ -128,6 +128,12 @@ func ClaimLeaseTargetForConfigIfUnchanged(leaseID, slug string, cfg Config, serv
 	return claimLeaseTargetForConfigIfUnchanged(leaseID, slug, cfg, server, target, idleTimeout, expected, expectedExists)
 }
 
+// ClaimLeaseTargetForConfigScopeIfUnchanged lets a provider bind a claim to
+// routing identity that is intentionally not part of the shared Config model.
+func ClaimLeaseTargetForConfigScopeIfUnchanged(leaseID, slug string, cfg Config, providerScope string, server Server, target SSHTarget, idleTimeout time.Duration, expected LeaseClaim, expectedExists bool) (LeaseClaim, error) {
+	return claimLeaseTargetForConfigScopeIfUnchanged(leaseID, slug, cfg, providerScope, server, target, idleTimeout, expected, expectedExists)
+}
+
 func ClaimLeaseTargetForRepoConfigIfUnchanged(leaseID, slug string, cfg Config, server Server, target SSHTarget, repoRoot string, idleTimeout time.Duration, reclaim bool, expected LeaseClaim, expectedExists bool) (LeaseClaim, error) {
 	return claimLeaseTargetForRepoConfigIfUnchanged(leaseID, slug, cfg, server, target, repoRoot, idleTimeout, reclaim, expected, expectedExists)
 }
@@ -162,6 +168,14 @@ func RemoveLeaseClaim(leaseID string) {
 
 func RemoveLeaseClaimIfUnchanged(leaseID string, expected LeaseClaim) error {
 	return removeLeaseClaimIfUnchanged(leaseID, expected)
+}
+
+func VerifyLeaseClaimUnchanged(leaseID string, expected LeaseClaim) error {
+	return verifyLeaseClaimUnchanged(leaseID, expected)
+}
+
+func RemoveLeaseClaimIfUnchangedAfter(leaseID string, expected LeaseClaim, action func() error) error {
+	return removeLeaseClaimIfUnchangedAfter(leaseID, expected, action)
 }
 
 func RestoreLeaseClaimIfUnchanged(leaseID string, current, previous LeaseClaim, previousExists bool) error {

--- a/internal/providers/wandb/backend.go
+++ b/internal/providers/wandb/backend.go
@@ -47,6 +47,10 @@ func (b *wandbBackend) Run(ctx context.Context, req RunRequest) (RunResult, erro
 		return RunResult{}, err
 	}
 	defer b.closeClientAfterOperation()
+	providerScope, err := wandbProviderScope()
+	if err != nil {
+		return RunResult{}, err
+	}
 	started := b.now()
 	cfg := b.cfg
 	image := blank(strings.TrimSpace(cfg.Wandb.DefaultImage), "ubuntu:24.04")
@@ -54,6 +58,7 @@ func (b *wandbBackend) Run(ctx context.Context, req RunRequest) (RunResult, erro
 
 	sandboxID := strings.TrimSpace(req.ID)
 	acquired := false
+	var claim LeaseClaim
 	if sandboxID == "" {
 		fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s image=%s max_lifetime=%ds\n", providerName, image, maxLifetime)
 		sb, err := client.Acquire(ctx, wandbAcquireRequest{
@@ -68,6 +73,15 @@ func (b *wandbBackend) Run(ctx context.Context, req RunRequest) (RunResult, erro
 		sandboxID = sb.ID
 		acquired = true
 		fmt.Fprintf(b.rt.Stderr, "provisioned sandbox=%s status=%s\n", sb.ID, sb.Status)
+		claim, err = claimWandbSandbox(sandboxID, providerScope, cfg)
+		if err != nil {
+			stopCtx, cancel := context.WithTimeout(context.Background(), wandbStopTimeout)
+			defer cancel()
+			if stopErr := client.Stop(stopCtx, sandboxID, 10, true); stopErr != nil {
+				return RunResult{}, fmt.Errorf("persist wandb sandbox %s ownership claim: %w (rollback stop also failed: %v)", sandboxID, err, stopErr)
+			}
+			return RunResult{}, fmt.Errorf("persist wandb sandbox %s ownership claim: %w", sandboxID, err)
+		}
 		if req.EnvSummary {
 			printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
 		}
@@ -80,7 +94,8 @@ func (b *wandbBackend) Run(ctx context.Context, req RunRequest) (RunResult, erro
 			// configs may select without the user asking for env forwarding.
 			return RunResult{}, exit(2, "provider=%s cannot forward env vars to an existing sandbox (--id); rerun without --id or omit --allow-env", providerName)
 		}
-		if err := requireWandbOwnership(ctx, client, sandboxID); err != nil {
+		claim, sandboxID, err = requireWandbOwnership(ctx, client, sandboxID, providerScope)
+		if err != nil {
 			return RunResult{}, err
 		}
 	}
@@ -96,7 +111,9 @@ func (b *wandbBackend) Run(ctx context.Context, req RunRequest) (RunResult, erro
 		}
 		stopCtx, cancel := context.WithTimeout(context.Background(), wandbStopTimeout)
 		defer cancel()
-		if err := client.Stop(stopCtx, sandboxID, 10, true); err != nil {
+		if err := removeWandbClaimAfter(claim, func() error {
+			return client.Stop(stopCtx, sandboxID, 10, true)
+		}); err != nil {
 			fmt.Fprintf(b.rt.Stderr, "warning: wandb stop failed for %s: %v\n", sandboxID, err)
 		}
 	}()
@@ -116,12 +133,18 @@ func (b *wandbBackend) Run(ctx context.Context, req RunRequest) (RunResult, erro
 	}
 
 	commandStarted := b.now()
-	exitCode, execErr := client.Exec(ctx, wandbExecRequest{
-		SandboxID: sandboxID,
-		Command:   req.Command,
-		Stdout:    b.rt.Stdout,
-		Stderr:    b.rt.Stderr,
-	})
+	var exitCode int
+	var execErr error
+	if err := verifyWandbClaim(claim); err != nil {
+		execErr = err
+	} else {
+		exitCode, execErr = client.Exec(ctx, wandbExecRequest{
+			SandboxID: sandboxID,
+			Command:   req.Command,
+			Stdout:    b.rt.Stdout,
+			Stderr:    b.rt.Stderr,
+		})
+	}
 	if execErr != nil && exitCode == 0 {
 		var ee ExitError
 		if errors.As(execErr, &ee) && ee.Code != 0 {
@@ -169,7 +192,24 @@ func wandbCleanupCommand(sandboxID string) string {
 	return fmt.Sprintf("crabbox stop --provider %s --id %s", providerName, shellQuote(sandboxID))
 }
 
-func requireWandbOwnership(ctx context.Context, client wandbAPI, sandboxID string) error {
+func requireWandbOwnership(ctx context.Context, client wandbAPI, identifier, providerScope string) (LeaseClaim, string, error) {
+	claim, ok, err := resolveWandbClaim(identifier)
+	if err != nil {
+		return LeaseClaim{}, "", err
+	}
+	if !ok || claim.CloudID == "" {
+		return LeaseClaim{}, "", exit(4, "wandb sandbox %q has no matching local ownership claim", identifier)
+	}
+	if claim.ProviderScope == "" || claim.ProviderScope != providerScope {
+		return LeaseClaim{}, "", exit(4, "wandb sandbox %q ownership claim belongs to a different endpoint, entity, or project", identifier)
+	}
+	if err := requireWandbInventoryOwnership(ctx, client, claim.CloudID); err != nil {
+		return LeaseClaim{}, "", err
+	}
+	return claim, claim.CloudID, nil
+}
+
+func requireWandbInventoryOwnership(ctx context.Context, client wandbAPI, sandboxID string) error {
 	sandboxes, err := client.List(ctx, []string{"crabbox"}, "all")
 	if err != nil {
 		return err
@@ -179,7 +219,7 @@ func requireWandbOwnership(ctx context.Context, client wandbAPI, sandboxID strin
 			return nil
 		}
 	}
-	return exit(4, "wandb sandbox %q is not Crabbox-managed or no longer exists", sandboxID)
+	return exit(4, "wandb sandbox %q is not tagged as Crabbox-managed or no longer exists", sandboxID)
 }
 
 func (b *wandbBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
@@ -219,7 +259,12 @@ func (b *wandbBackend) Status(ctx context.Context, req StatusRequest) (StatusVie
 		return StatusView{}, err
 	}
 	defer b.closeClientAfterOperation()
-	if err := requireWandbOwnership(ctx, client, sandboxID); err != nil {
+	providerScope, err := wandbProviderScope()
+	if err != nil {
+		return StatusView{}, err
+	}
+	_, sandboxID, err = requireWandbOwnership(ctx, client, sandboxID, providerScope)
+	if err != nil {
 		return StatusView{}, err
 	}
 	sb, err := client.Status(ctx, sandboxID)
@@ -252,10 +297,17 @@ func (b *wandbBackend) Stop(ctx context.Context, req StopRequest) error {
 		return err
 	}
 	defer b.closeClientAfterOperation()
-	if err := requireWandbOwnership(ctx, client, sandboxID); err != nil {
+	providerScope, err := wandbProviderScope()
+	if err != nil {
 		return err
 	}
-	return client.Stop(ctx, sandboxID, 10, false)
+	claim, sandboxID, err := requireWandbOwnership(ctx, client, sandboxID, providerScope)
+	if err != nil {
+		return err
+	}
+	return removeWandbClaimAfter(claim, func() error {
+		return client.Stop(ctx, sandboxID, 10, false)
+	})
 }
 
 // Doctor mirrors the modal/e2b/runpod pattern: dial, probe auth via a cheap

--- a/internal/providers/wandb/backend.go
+++ b/internal/providers/wandb/backend.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"google.golang.org/grpc/codes"
 )
 
 const wandbStopTimeout = 15 * time.Second
@@ -192,6 +194,22 @@ func wandbCleanupCommand(sandboxID string) string {
 	return fmt.Sprintf("crabbox stop --provider %s --id %s", providerName, shellQuote(sandboxID))
 }
 
+type wandbSandboxMissingError struct {
+	sandboxID string
+}
+
+func (e *wandbSandboxMissingError) Error() string {
+	return fmt.Sprintf("wandb sandbox %q is not tagged as Crabbox-managed or no longer exists", e.sandboxID)
+}
+
+func (e *wandbSandboxMissingError) As(target any) bool {
+	if exitErr, ok := target.(*ExitError); ok {
+		*exitErr = ExitError{Code: 4, Message: e.Error()}
+		return true
+	}
+	return false
+}
+
 func requireWandbOwnership(ctx context.Context, client wandbAPI, identifier, providerScope string) (LeaseClaim, string, error) {
 	claim, ok, err := resolveWandbClaim(identifier)
 	if err != nil {
@@ -204,7 +222,7 @@ func requireWandbOwnership(ctx context.Context, client wandbAPI, identifier, pro
 		return LeaseClaim{}, "", exit(4, "wandb sandbox %q ownership claim belongs to a different endpoint, entity, or project", identifier)
 	}
 	if err := requireWandbInventoryOwnership(ctx, client, claim.CloudID); err != nil {
-		return LeaseClaim{}, "", err
+		return claim, claim.CloudID, err
 	}
 	return claim, claim.CloudID, nil
 }
@@ -218,6 +236,13 @@ func requireWandbInventoryOwnership(ctx context.Context, client wandbAPI, sandbo
 		if sandbox.ID == sandboxID {
 			return nil
 		}
+	}
+	if _, err := client.Status(ctx, sandboxID); err != nil {
+		var apiErr *wandbAPIError
+		if errors.As(err, &apiErr) && apiErr.Code == codes.NotFound {
+			return &wandbSandboxMissingError{sandboxID: sandboxID}
+		}
+		return err
 	}
 	return exit(4, "wandb sandbox %q is not tagged as Crabbox-managed or no longer exists", sandboxID)
 }
@@ -303,6 +328,10 @@ func (b *wandbBackend) Stop(ctx context.Context, req StopRequest) error {
 	}
 	claim, sandboxID, err := requireWandbOwnership(ctx, client, sandboxID, providerScope)
 	if err != nil {
+		var missing *wandbSandboxMissingError
+		if errors.As(err, &missing) {
+			return removeWandbClaimAfter(claim, func() error { return nil })
+		}
 		return err
 	}
 	return removeWandbClaimAfter(claim, func() error {

--- a/internal/providers/wandb/backend.go
+++ b/internal/providers/wandb/backend.go
@@ -244,7 +244,7 @@ func requireWandbInventoryOwnership(ctx context.Context, client wandbAPI, sandbo
 		}
 		return err
 	}
-	return exit(4, "wandb sandbox %q is not tagged as Crabbox-managed or no longer exists", sandboxID)
+	return exit(4, "wandb sandbox %q still exists but is not tagged as Crabbox-managed", sandboxID)
 }
 
 func (b *wandbBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {

--- a/internal/providers/wandb/backend.go
+++ b/internal/providers/wandb/backend.go
@@ -71,13 +71,18 @@ func (b *wandbBackend) Run(ctx context.Context, req RunRequest) (RunResult, erro
 		if req.EnvSummary {
 			printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
 		}
-	} else if len(req.Env) > 0 && !wandbExistingIDEnvIsImplicitDefault(req) {
-		// CoreWeave Sandboxes apply environment variables at Start time only;
-		// the v1beta2 Exec RPC has no env field, so we can't honour
-		// selected env on an already-running sandbox. The only exception is
-		// Crabbox's built-in implicit CI/NODE_OPTIONS allowlist, which older
-		// configs may select without the user asking for env forwarding.
-		return RunResult{}, exit(2, "provider=%s cannot forward env vars to an existing sandbox (--id); rerun without --id or omit --allow-env", providerName)
+	} else {
+		if len(req.Env) > 0 && !wandbExistingIDEnvIsImplicitDefault(req) {
+			// CoreWeave Sandboxes apply environment variables at Start time only;
+			// the v1beta2 Exec RPC has no env field, so we can't honour
+			// selected env on an already-running sandbox. The only exception is
+			// Crabbox's built-in implicit CI/NODE_OPTIONS allowlist, which older
+			// configs may select without the user asking for env forwarding.
+			return RunResult{}, exit(2, "provider=%s cannot forward env vars to an existing sandbox (--id); rerun without --id or omit --allow-env", providerName)
+		}
+		if err := requireWandbOwnership(ctx, client, sandboxID); err != nil {
+			return RunResult{}, err
+		}
 	}
 
 	// Stop semantics match the modal/e2b/islo/tensorlake sibling pattern:
@@ -164,6 +169,19 @@ func wandbCleanupCommand(sandboxID string) string {
 	return fmt.Sprintf("crabbox stop --provider %s --id %s", providerName, shellQuote(sandboxID))
 }
 
+func requireWandbOwnership(ctx context.Context, client wandbAPI, sandboxID string) error {
+	sandboxes, err := client.List(ctx, []string{"crabbox"}, "all")
+	if err != nil {
+		return err
+	}
+	for _, sandbox := range sandboxes {
+		if sandbox.ID == sandboxID {
+			return nil
+		}
+	}
+	return exit(4, "wandb sandbox %q is not Crabbox-managed or no longer exists", sandboxID)
+}
+
 func (b *wandbBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
 	client, err := b.api()
 	if err != nil {
@@ -192,7 +210,8 @@ func (b *wandbBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, 
 }
 
 func (b *wandbBackend) Status(ctx context.Context, req StatusRequest) (StatusView, error) {
-	if req.ID == "" {
+	sandboxID := strings.TrimSpace(req.ID)
+	if sandboxID == "" {
 		return StatusView{}, exit(2, "provider=%s status requires --id <sandbox-id>", providerName)
 	}
 	client, err := b.api()
@@ -200,7 +219,10 @@ func (b *wandbBackend) Status(ctx context.Context, req StatusRequest) (StatusVie
 		return StatusView{}, err
 	}
 	defer b.closeClientAfterOperation()
-	sb, err := client.Status(ctx, req.ID)
+	if err := requireWandbOwnership(ctx, client, sandboxID); err != nil {
+		return StatusView{}, err
+	}
+	sb, err := client.Status(ctx, sandboxID)
 	if err != nil {
 		return StatusView{}, err
 	}
@@ -221,7 +243,8 @@ func (b *wandbBackend) Status(ctx context.Context, req StatusRequest) (StatusVie
 }
 
 func (b *wandbBackend) Stop(ctx context.Context, req StopRequest) error {
-	if req.ID == "" {
+	sandboxID := strings.TrimSpace(req.ID)
+	if sandboxID == "" {
 		return exit(2, "provider=%s stop requires --id <sandbox-id>", providerName)
 	}
 	client, err := b.api()
@@ -229,7 +252,10 @@ func (b *wandbBackend) Stop(ctx context.Context, req StopRequest) error {
 		return err
 	}
 	defer b.closeClientAfterOperation()
-	return client.Stop(ctx, req.ID, 10, false)
+	if err := requireWandbOwnership(ctx, client, sandboxID); err != nil {
+		return err
+	}
+	return client.Stop(ctx, sandboxID, 10, false)
 }
 
 // Doctor mirrors the modal/e2b/runpod pattern: dial, probe auth via a cheap

--- a/internal/providers/wandb/backend_test.go
+++ b/internal/providers/wandb/backend_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"flag"
 	"io"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -249,7 +250,11 @@ func (f *fakeWandbAPI) Status(_ context.Context, id string) (wandbSandbox, error
 	return f.statusValue, f.statusErr
 }
 
-func newWandbBackendForTest(api wandbAPI) *wandbBackend {
+func newWandbBackendForTest(t *testing.T, api wandbAPI) *wandbBackend {
+	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("WANDB_ENTITY_NAME", "test-entity")
+	t.Setenv("WANDB_PROJECT", "test-project")
 	cfg := Config{Provider: providerName}
 	applyWandbDefaults(&cfg)
 	return &wandbBackend{
@@ -258,6 +263,19 @@ func newWandbBackendForTest(api wandbAPI) *wandbBackend {
 		rt:     Runtime{Stdout: io.Discard, Stderr: io.Discard},
 		client: api,
 	}
+}
+
+func seedWandbClaim(t *testing.T, backend *wandbBackend, sandboxID string) LeaseClaim {
+	t.Helper()
+	scope, err := wandbProviderScope()
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim, err := claimWandbSandbox(sandboxID, scope, backend.cfg)
+	if err != nil {
+		t.Fatalf("claim sandbox: %v", err)
+	}
+	return claim
 }
 
 func TestWandbProviderAdvertisesRunSession(t *testing.T) {
@@ -272,7 +290,7 @@ func TestWandbRunHappyPathAcquireExecStop(t *testing.T) {
 		acquired: wandbSandbox{ID: "sb-abc", Status: "RUNNING"},
 		execCode: 0,
 	}
-	backend := newWandbBackendForTest(api)
+	backend := newWandbBackendForTest(t, api)
 	result, err := backend.Run(context.Background(), RunRequest{NoSync: true, Command: []string{"echo", "hello"}})
 	if err != nil {
 		t.Fatalf("Run err: %v", err)
@@ -304,6 +322,30 @@ func TestWandbRunHappyPathAcquireExecStop(t *testing.T) {
 	if api.stopID != "sb-abc" {
 		t.Fatalf("Stop id = %q, want sb-abc (auto-stop after run)", api.stopID)
 	}
+	if _, ok, err := resolveWandbClaim("sb-abc"); err != nil || ok {
+		t.Fatalf("auto-stop left claim ok=%v err=%v", ok, err)
+	}
+}
+
+func TestWandbRunRollsBackWhenClaimCannotBePersisted(t *testing.T) {
+	api := &fakeWandbAPI{acquired: wandbSandbox{ID: "sb-rollback", Status: "running"}}
+	backend := newWandbBackendForTest(t, api)
+	blockedState := t.TempDir() + "/not-a-directory"
+	if err := os.WriteFile(blockedState, []byte("blocked"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("XDG_STATE_HOME", blockedState)
+
+	_, err := backend.Run(context.Background(), RunRequest{NoSync: true, Command: []string{"true"}})
+	if err == nil || !strings.Contains(err.Error(), "ownership claim") {
+		t.Fatalf("Run err = %v, want claim persistence failure", err)
+	}
+	if api.execID != "" {
+		t.Fatalf("claim failure reached Exec(%q)", api.execID)
+	}
+	if api.stopID != "sb-rollback" || !api.stopMissingOK {
+		t.Fatalf("rollback stop id=%q missingOK=%v", api.stopID, api.stopMissingOK)
+	}
 }
 
 func TestWandbRunClosesCachedClientAfterOperation(t *testing.T) {
@@ -314,7 +356,7 @@ func TestWandbRunClosesCachedClientAfterOperation(t *testing.T) {
 			execCode: 0,
 		},
 	}
-	backend := newWandbBackendForTest(api)
+	backend := newWandbBackendForTest(t, api)
 	if _, err := backend.Run(context.Background(), RunRequest{NoSync: true, Command: []string{"echo", "hello"}}); err != nil {
 		t.Fatalf("Run err: %v", err)
 	}
@@ -338,7 +380,8 @@ func TestWandbRunClosesCachedClientAfterOperation(t *testing.T) {
 func TestWandbRunWithExistingIDSkipsAcquireAndStop(t *testing.T) {
 	t.Setenv("WANDB_API_KEY", "fake")
 	api := &fakeWandbAPI{execCode: 0, listValue: []wandbSandbox{{ID: "sb-supplied"}}}
-	backend := newWandbBackendForTest(api)
+	backend := newWandbBackendForTest(t, api)
+	seedWandbClaim(t, backend, "sb-supplied")
 	result, err := backend.Run(context.Background(), RunRequest{
 		ID:      "sb-supplied",
 		NoSync:  true,
@@ -369,10 +412,10 @@ func TestWandbRunWithExistingIDSkipsAcquireAndStop(t *testing.T) {
 }
 
 func TestWandbRunRejectsUnownedExistingID(t *testing.T) {
-	api := &fakeWandbAPI{}
-	backend := newWandbBackendForTest(api)
+	api := &fakeWandbAPI{listValue: []wandbSandbox{{ID: "sb-foreign"}}}
+	backend := newWandbBackendForTest(t, api)
 	_, err := backend.Run(context.Background(), RunRequest{ID: "sb-foreign", NoSync: true, Command: []string{"echo"}})
-	if err == nil || !strings.Contains(err.Error(), "not Crabbox-managed") {
+	if err == nil || !strings.Contains(err.Error(), "no matching local ownership claim") {
 		t.Fatalf("Run err = %v, want ownership rejection", err)
 	}
 	if api.execID != "" || api.stopID != "" {
@@ -383,7 +426,8 @@ func TestWandbRunRejectsUnownedExistingID(t *testing.T) {
 func TestWandbRunFailsClosedWhenOwnershipListFails(t *testing.T) {
 	wantErr := errors.New("list unavailable")
 	api := &fakeWandbAPI{listErr: wantErr}
-	backend := newWandbBackendForTest(api)
+	backend := newWandbBackendForTest(t, api)
+	seedWandbClaim(t, backend, "sb-unknown")
 	_, err := backend.Run(context.Background(), RunRequest{ID: "sb-unknown", NoSync: true, Command: []string{"echo"}})
 	if !errors.Is(err, wantErr) {
 		t.Fatalf("Run err = %v, want %v", err, wantErr)
@@ -396,7 +440,7 @@ func TestWandbRunFailsClosedWhenOwnershipListFails(t *testing.T) {
 func TestWandbRunNonZeroExecMapsToExit(t *testing.T) {
 	t.Setenv("WANDB_API_KEY", "fake")
 	api := &fakeWandbAPI{acquired: wandbSandbox{ID: "sb-abc", Status: "RUNNING"}, execCode: 7}
-	backend := newWandbBackendForTest(api)
+	backend := newWandbBackendForTest(t, api)
 	result, err := backend.Run(context.Background(), RunRequest{NoSync: true, Command: []string{"false"}})
 	if err == nil {
 		t.Fatal("Run accepted non-zero exec exit")
@@ -412,7 +456,8 @@ func TestWandbStatusReturnsView(t *testing.T) {
 		listValue:   []wandbSandbox{{ID: "sb-abc"}},
 		statusValue: wandbSandbox{ID: "sb-abc", Status: "RUNNING", CreatedAt: "2026-05-18T00:00:00Z"},
 	}
-	backend := newWandbBackendForTest(api)
+	backend := newWandbBackendForTest(t, api)
+	seedWandbClaim(t, backend, "sb-abc")
 	view, err := backend.Status(context.Background(), StatusRequest{ID: "sb-abc"})
 	if err != nil {
 		t.Fatalf("Status err: %v", err)
@@ -426,7 +471,7 @@ func TestWandbStatusReturnsView(t *testing.T) {
 }
 
 func TestWandbStatusRequiresID(t *testing.T) {
-	backend := newWandbBackendForTest(&fakeWandbAPI{})
+	backend := newWandbBackendForTest(t, &fakeWandbAPI{})
 	for _, id := range []string{"", "  \t"} {
 		if _, err := backend.Status(context.Background(), StatusRequest{ID: id}); err == nil {
 			t.Fatalf("Status accepted empty id %q", id)
@@ -435,10 +480,10 @@ func TestWandbStatusRequiresID(t *testing.T) {
 }
 
 func TestWandbStatusRejectsUnownedID(t *testing.T) {
-	api := &fakeWandbAPI{}
-	backend := newWandbBackendForTest(api)
+	api := &fakeWandbAPI{listValue: []wandbSandbox{{ID: "sb-foreign"}}}
+	backend := newWandbBackendForTest(t, api)
 	_, err := backend.Status(context.Background(), StatusRequest{ID: "sb-foreign"})
-	if err == nil || !strings.Contains(err.Error(), "not Crabbox-managed") {
+	if err == nil || !strings.Contains(err.Error(), "no matching local ownership claim") {
 		t.Fatalf("Status err = %v, want ownership rejection", err)
 	}
 	if api.statusID != "" {
@@ -451,7 +496,7 @@ func TestWandbListEnumeratesSandboxes(t *testing.T) {
 		{ID: "sb-1", Status: "RUNNING"},
 		{ID: "sb-2", Status: "COMPLETED"},
 	}}
-	backend := newWandbBackendForTest(api)
+	backend := newWandbBackendForTest(t, api)
 	servers, err := backend.List(context.Background(), ListRequest{})
 	if err != nil {
 		t.Fatalf("List err: %v", err)
@@ -462,7 +507,7 @@ func TestWandbListEnumeratesSandboxes(t *testing.T) {
 }
 
 func TestWandbStopRequiresID(t *testing.T) {
-	backend := newWandbBackendForTest(&fakeWandbAPI{})
+	backend := newWandbBackendForTest(t, &fakeWandbAPI{})
 	for _, id := range []string{"", "  \t"} {
 		if err := backend.Stop(context.Background(), StopRequest{ID: id}); err == nil {
 			t.Fatalf("Stop accepted empty id %q", id)
@@ -472,7 +517,8 @@ func TestWandbStopRequiresID(t *testing.T) {
 
 func TestWandbStopCallsClient(t *testing.T) {
 	api := &fakeWandbAPI{listValue: []wandbSandbox{{ID: "sb-abc"}}}
-	backend := newWandbBackendForTest(api)
+	backend := newWandbBackendForTest(t, api)
+	seedWandbClaim(t, backend, "sb-abc")
 	if err := backend.Stop(context.Background(), StopRequest{ID: "sb-abc"}); err != nil {
 		t.Fatalf("Stop err: %v", err)
 	}
@@ -485,13 +531,47 @@ func TestWandbStopCallsClient(t *testing.T) {
 	if !contains(api.listTags, "crabbox") || api.listStatusFilter != "all" {
 		t.Fatalf("ownership list tags=%#v status=%q", api.listTags, api.listStatusFilter)
 	}
+	if _, ok, err := resolveWandbClaim("sb-abc"); err != nil || ok {
+		t.Fatalf("successful stop left claim ok=%v err=%v", ok, err)
+	}
+}
+
+func TestWandbStopFailurePreservesClaim(t *testing.T) {
+	wantErr := errors.New("stop unavailable")
+	api := &fakeWandbAPI{listValue: []wandbSandbox{{ID: "sb-abc"}}, stopErr: wantErr}
+	backend := newWandbBackendForTest(t, api)
+	seedWandbClaim(t, backend, "sb-abc")
+
+	err := backend.Stop(context.Background(), StopRequest{ID: "sb-abc"})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("Stop err = %v, want %v", err, wantErr)
+	}
+	claim, ok, resolveErr := resolveWandbClaim("sb-abc")
+	if resolveErr != nil || !ok || claim.CloudID != "sb-abc" {
+		t.Fatalf("failed stop claim=%#v ok=%v err=%v", claim, ok, resolveErr)
+	}
+}
+
+func TestWandbStopRejectsClaimFromAnotherScope(t *testing.T) {
+	api := &fakeWandbAPI{listValue: []wandbSandbox{{ID: "sb-abc"}}}
+	backend := newWandbBackendForTest(t, api)
+	seedWandbClaim(t, backend, "sb-abc")
+	t.Setenv("WANDB_PROJECT", "another-project")
+
+	err := backend.Stop(context.Background(), StopRequest{ID: "sb-abc"})
+	if err == nil || !strings.Contains(err.Error(), "different endpoint, entity, or project") {
+		t.Fatalf("Stop err = %v, want scope rejection", err)
+	}
+	if api.stopID != "" {
+		t.Fatalf("scope mismatch reached Stop(%q)", api.stopID)
+	}
 }
 
 func TestWandbStopRejectsUnownedID(t *testing.T) {
-	api := &fakeWandbAPI{}
-	backend := newWandbBackendForTest(api)
+	api := &fakeWandbAPI{listValue: []wandbSandbox{{ID: "sb-foreign"}}}
+	backend := newWandbBackendForTest(t, api)
 	err := backend.Stop(context.Background(), StopRequest{ID: "sb-foreign"})
-	if err == nil || !strings.Contains(err.Error(), "not Crabbox-managed") {
+	if err == nil || !strings.Contains(err.Error(), "no matching local ownership claim") {
 		t.Fatalf("Stop err = %v, want ownership rejection", err)
 	}
 	if api.stopID != "" {
@@ -524,7 +604,7 @@ func TestWandbDoctorReturnsInventoryResult(t *testing.T) {
 func TestWandbDoctorSurfacesAuthError(t *testing.T) {
 	t.Setenv("WANDB_API_KEY", "fake")
 	api := &fakeWandbAPI{versionErr: errors.New("UNAUTHENTICATED: invalid key")}
-	backend := newWandbBackendForTest(api)
+	backend := newWandbBackendForTest(t, api)
 	_, err := backend.Doctor(context.Background(), DoctorRequest{})
 	if err == nil {
 		t.Fatal("Doctor accepted a Version() failure")
@@ -543,7 +623,7 @@ func TestWandbKeepOnFailureRetainsSandbox(t *testing.T) {
 		execCode: 7,
 	}
 	var stderr bytes.Buffer
-	backend := newWandbBackendForTest(api)
+	backend := newWandbBackendForTest(t, api)
 	backend.rt.Stderr = &stderr
 	result, err := backend.Run(context.Background(), RunRequest{
 		NoSync:        true,
@@ -566,6 +646,10 @@ func TestWandbKeepOnFailureRetainsSandbox(t *testing.T) {
 	if result.Session == nil || !result.Session.Kept {
 		t.Fatalf("session = %#v, want kept failure handle", result.Session)
 	}
+	claim, ok, resolveErr := resolveWandbClaim("sb-abc")
+	if resolveErr != nil || !ok || claim.CloudID != "sb-abc" || claim.ProviderScope == "" {
+		t.Fatalf("kept sandbox claim=%#v ok=%v err=%v", claim, ok, resolveErr)
+	}
 }
 
 func TestWandbCleanupCommandQuotesSandboxID(t *testing.T) {
@@ -582,7 +666,7 @@ func TestWandbRunForwardsEnvToAcquire(t *testing.T) {
 		acquired: wandbSandbox{ID: "sb-abc", Status: "running"},
 		execCode: 0,
 	}
-	backend := newWandbBackendForTest(api)
+	backend := newWandbBackendForTest(t, api)
 	if _, err := backend.Run(context.Background(), RunRequest{
 		NoSync:  true,
 		Command: []string{"echo", "hi"},
@@ -597,7 +681,7 @@ func TestWandbRunForwardsEnvToAcquire(t *testing.T) {
 
 func TestWandbRunRejectsIDWithEnv(t *testing.T) {
 	t.Setenv("WANDB_API_KEY", "fake")
-	backend := newWandbBackendForTest(&fakeWandbAPI{})
+	backend := newWandbBackendForTest(t, &fakeWandbAPI{})
 	_, err := backend.Run(context.Background(), RunRequest{
 		ID:         "sb-existing",
 		NoSync:     true,
@@ -612,7 +696,7 @@ func TestWandbRunRejectsIDWithEnv(t *testing.T) {
 
 func TestWandbRunRejectsIDWithConfiguredEnv(t *testing.T) {
 	t.Setenv("WANDB_API_KEY", "fake")
-	backend := newWandbBackendForTest(&fakeWandbAPI{})
+	backend := newWandbBackendForTest(t, &fakeWandbAPI{})
 	_, err := backend.Run(context.Background(), RunRequest{
 		ID:      "sb-existing",
 		NoSync:  true,
@@ -631,7 +715,7 @@ func TestWandbRunEmitsTimingJSONOnFailure(t *testing.T) {
 		execCode: 7,
 	}
 	var stderr bytes.Buffer
-	backend := newWandbBackendForTest(api)
+	backend := newWandbBackendForTest(t, api)
 	backend.rt.Stderr = &stderr
 	if _, err := backend.Run(context.Background(), RunRequest{
 		NoSync:     true,
@@ -670,7 +754,7 @@ func TestWandbRunTimingJSONUsesExecErrorCode(t *testing.T) {
 		execErr:  ExitError{Code: 69, Message: "unavailable"},
 	}
 	var stderr bytes.Buffer
-	backend := newWandbBackendForTest(api)
+	backend := newWandbBackendForTest(t, api)
 	backend.rt.Stderr = &stderr
 	if _, err := backend.Run(context.Background(), RunRequest{
 		NoSync:     true,
@@ -699,7 +783,7 @@ func TestWandbRunTimingJSONUsesExecErrorCode(t *testing.T) {
 
 func TestWandbListAllIncludesStopped(t *testing.T) {
 	api := &fakeWandbAPI{listValue: []wandbSandbox{{ID: "sb-done", Status: "completed"}}}
-	backend := newWandbBackendForTest(api)
+	backend := newWandbBackendForTest(t, api)
 	if _, err := backend.List(context.Background(), ListRequest{All: true}); err != nil {
 		t.Fatalf("List err: %v", err)
 	}
@@ -712,7 +796,7 @@ func TestWandbListAllIncludesStopped(t *testing.T) {
 }
 
 func TestWandbWarmupRejected(t *testing.T) {
-	backend := newWandbBackendForTest(&fakeWandbAPI{})
+	backend := newWandbBackendForTest(t, &fakeWandbAPI{})
 	err := backend.Warmup(context.Background(), WarmupRequest{})
 	if err == nil || !strings.Contains(err.Error(), "does not support warmup") {
 		t.Fatalf("err = %v, want warmup rejection", err)

--- a/internal/providers/wandb/backend_test.go
+++ b/internal/providers/wandb/backend_test.go
@@ -201,6 +201,7 @@ type fakeWandbAPI struct {
 	listErr          error
 	listTags         []string
 	listStatusFilter string
+	statusID         string
 	statusValue      wandbSandbox
 	statusErr        error
 }
@@ -243,7 +244,8 @@ func (f *fakeWandbAPI) List(_ context.Context, tags []string, statusFilter strin
 	return f.listValue, f.listErr
 }
 
-func (f *fakeWandbAPI) Status(_ context.Context, _ string) (wandbSandbox, error) {
+func (f *fakeWandbAPI) Status(_ context.Context, id string) (wandbSandbox, error) {
+	f.statusID = id
 	return f.statusValue, f.statusErr
 }
 
@@ -335,7 +337,7 @@ func TestWandbRunClosesCachedClientAfterOperation(t *testing.T) {
 
 func TestWandbRunWithExistingIDSkipsAcquireAndStop(t *testing.T) {
 	t.Setenv("WANDB_API_KEY", "fake")
-	api := &fakeWandbAPI{execCode: 0}
+	api := &fakeWandbAPI{execCode: 0, listValue: []wandbSandbox{{ID: "sb-supplied"}}}
 	backend := newWandbBackendForTest(api)
 	result, err := backend.Run(context.Background(), RunRequest{
 		ID:      "sb-supplied",
@@ -361,6 +363,34 @@ func TestWandbRunWithExistingIDSkipsAcquireAndStop(t *testing.T) {
 	if api.stopID != "" {
 		t.Fatalf("Stop should not be called for user-supplied id; got %q", api.stopID)
 	}
+	if !contains(api.listTags, "crabbox") || api.listStatusFilter != "all" {
+		t.Fatalf("ownership list tags=%#v status=%q", api.listTags, api.listStatusFilter)
+	}
+}
+
+func TestWandbRunRejectsUnownedExistingID(t *testing.T) {
+	api := &fakeWandbAPI{}
+	backend := newWandbBackendForTest(api)
+	_, err := backend.Run(context.Background(), RunRequest{ID: "sb-foreign", NoSync: true, Command: []string{"echo"}})
+	if err == nil || !strings.Contains(err.Error(), "not Crabbox-managed") {
+		t.Fatalf("Run err = %v, want ownership rejection", err)
+	}
+	if api.execID != "" || api.stopID != "" {
+		t.Fatalf("unowned sandbox reached exec=%q stop=%q", api.execID, api.stopID)
+	}
+}
+
+func TestWandbRunFailsClosedWhenOwnershipListFails(t *testing.T) {
+	wantErr := errors.New("list unavailable")
+	api := &fakeWandbAPI{listErr: wantErr}
+	backend := newWandbBackendForTest(api)
+	_, err := backend.Run(context.Background(), RunRequest{ID: "sb-unknown", NoSync: true, Command: []string{"echo"}})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("Run err = %v, want %v", err, wantErr)
+	}
+	if api.execID != "" {
+		t.Fatalf("ownership list failure reached Exec(%q)", api.execID)
+	}
 }
 
 func TestWandbRunNonZeroExecMapsToExit(t *testing.T) {
@@ -378,7 +408,10 @@ func TestWandbRunNonZeroExecMapsToExit(t *testing.T) {
 
 func TestWandbStatusReturnsView(t *testing.T) {
 	t.Setenv("WANDB_API_KEY", "fake")
-	api := &fakeWandbAPI{statusValue: wandbSandbox{ID: "sb-abc", Status: "RUNNING", CreatedAt: "2026-05-18T00:00:00Z"}}
+	api := &fakeWandbAPI{
+		listValue:   []wandbSandbox{{ID: "sb-abc"}},
+		statusValue: wandbSandbox{ID: "sb-abc", Status: "RUNNING", CreatedAt: "2026-05-18T00:00:00Z"},
+	}
 	backend := newWandbBackendForTest(api)
 	view, err := backend.Status(context.Background(), StatusRequest{ID: "sb-abc"})
 	if err != nil {
@@ -386,6 +419,30 @@ func TestWandbStatusReturnsView(t *testing.T) {
 	}
 	if view.ID != "sb-abc" || view.Provider != providerName || !view.Ready || view.State != "running" {
 		t.Fatalf("view = %#v", view)
+	}
+	if api.statusID != "sb-abc" || !contains(api.listTags, "crabbox") || api.listStatusFilter != "all" {
+		t.Fatalf("status id=%q list tags=%#v filter=%q", api.statusID, api.listTags, api.listStatusFilter)
+	}
+}
+
+func TestWandbStatusRequiresID(t *testing.T) {
+	backend := newWandbBackendForTest(&fakeWandbAPI{})
+	for _, id := range []string{"", "  \t"} {
+		if _, err := backend.Status(context.Background(), StatusRequest{ID: id}); err == nil {
+			t.Fatalf("Status accepted empty id %q", id)
+		}
+	}
+}
+
+func TestWandbStatusRejectsUnownedID(t *testing.T) {
+	api := &fakeWandbAPI{}
+	backend := newWandbBackendForTest(api)
+	_, err := backend.Status(context.Background(), StatusRequest{ID: "sb-foreign"})
+	if err == nil || !strings.Contains(err.Error(), "not Crabbox-managed") {
+		t.Fatalf("Status err = %v, want ownership rejection", err)
+	}
+	if api.statusID != "" {
+		t.Fatalf("unowned sandbox reached Status(%q)", api.statusID)
 	}
 }
 
@@ -406,13 +463,15 @@ func TestWandbListEnumeratesSandboxes(t *testing.T) {
 
 func TestWandbStopRequiresID(t *testing.T) {
 	backend := newWandbBackendForTest(&fakeWandbAPI{})
-	if err := backend.Stop(context.Background(), StopRequest{}); err == nil {
-		t.Fatal("Stop accepted empty id")
+	for _, id := range []string{"", "  \t"} {
+		if err := backend.Stop(context.Background(), StopRequest{ID: id}); err == nil {
+			t.Fatalf("Stop accepted empty id %q", id)
+		}
 	}
 }
 
 func TestWandbStopCallsClient(t *testing.T) {
-	api := &fakeWandbAPI{}
+	api := &fakeWandbAPI{listValue: []wandbSandbox{{ID: "sb-abc"}}}
 	backend := newWandbBackendForTest(api)
 	if err := backend.Stop(context.Background(), StopRequest{ID: "sb-abc"}); err != nil {
 		t.Fatalf("Stop err: %v", err)
@@ -422,6 +481,21 @@ func TestWandbStopCallsClient(t *testing.T) {
 	}
 	if api.stopMissingOK {
 		t.Fatal("explicit Stop used missingOK=true")
+	}
+	if !contains(api.listTags, "crabbox") || api.listStatusFilter != "all" {
+		t.Fatalf("ownership list tags=%#v status=%q", api.listTags, api.listStatusFilter)
+	}
+}
+
+func TestWandbStopRejectsUnownedID(t *testing.T) {
+	api := &fakeWandbAPI{}
+	backend := newWandbBackendForTest(api)
+	err := backend.Stop(context.Background(), StopRequest{ID: "sb-foreign"})
+	if err == nil || !strings.Contains(err.Error(), "not Crabbox-managed") {
+		t.Fatalf("Stop err = %v, want ownership rejection", err)
+	}
+	if api.stopID != "" {
+		t.Fatalf("unowned sandbox reached Stop(%q)", api.stopID)
 	}
 }
 

--- a/internal/providers/wandb/backend_test.go
+++ b/internal/providers/wandb/backend_test.go
@@ -576,14 +576,56 @@ func TestWandbStopPreservesClaimWhenSandboxLostManagedTag(t *testing.T) {
 	seedWandbClaim(t, backend, "sb-abc")
 
 	err := backend.Stop(context.Background(), StopRequest{ID: "sb-abc"})
-	if err == nil || !strings.Contains(err.Error(), "not tagged as Crabbox-managed") {
+	if err == nil || !strings.Contains(err.Error(), "still exists but is not tagged as Crabbox-managed") {
 		t.Fatalf("Stop err=%v, want untagged refusal", err)
 	}
-	if api.stopID != "" {
-		t.Fatalf("untagged sandbox reached Stop(%q)", api.stopID)
+	if api.statusID != "sb-abc" || api.stopID != "" {
+		t.Fatalf("untagged sandbox status=%q stop=%q", api.statusID, api.stopID)
 	}
 	if claim, ok, resolveErr := resolveWandbClaim("sb-abc"); resolveErr != nil || !ok || claim.CloudID != "sb-abc" {
 		t.Fatalf("untagged sandbox claim=%#v ok=%v err=%v", claim, ok, resolveErr)
+	}
+}
+
+func TestWandbStopPreservesClaimWhenOwnershipLookupFails(t *testing.T) {
+	tests := []struct {
+		name string
+		api  *fakeWandbAPI
+	}{
+		{name: "list", api: &fakeWandbAPI{listErr: errors.New("list unavailable")}},
+		{name: "status", api: &fakeWandbAPI{statusErr: errors.New("status unavailable")}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			backend := newWandbBackendForTest(t, tt.api)
+			seedWandbClaim(t, backend, "sb-unknown")
+
+			if err := backend.Stop(context.Background(), StopRequest{ID: "sb-unknown"}); err == nil {
+				t.Fatal("Stop succeeded despite ownership lookup failure")
+			}
+			if tt.api.stopID != "" {
+				t.Fatalf("ownership lookup failure reached Stop(%q)", tt.api.stopID)
+			}
+			claim, ok, resolveErr := resolveWandbClaim("sb-unknown")
+			if resolveErr != nil || !ok || claim.CloudID != "sb-unknown" {
+				t.Fatalf("ownership lookup failure claim=%#v ok=%v err=%v", claim, ok, resolveErr)
+			}
+		})
+	}
+}
+
+func TestWandbStatusMissingPreservesClaimAndReturnsExitError(t *testing.T) {
+	api := &fakeWandbAPI{statusErr: &wandbAPIError{Code: codes.NotFound, ExitCode: 4, Stderr: "Get: not found"}}
+	backend := newWandbBackendForTest(t, api)
+	seedWandbClaim(t, backend, "sb-abc")
+
+	_, err := backend.Status(context.Background(), StatusRequest{ID: "sb-abc"})
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 4 {
+		t.Fatalf("Status err=%v, want ExitError code 4", err)
+	}
+	if claim, ok, resolveErr := resolveWandbClaim("sb-abc"); resolveErr != nil || !ok || claim.CloudID != "sb-abc" {
+		t.Fatalf("missing status claim=%#v ok=%v err=%v", claim, ok, resolveErr)
 	}
 }
 

--- a/internal/providers/wandb/backend_test.go
+++ b/internal/providers/wandb/backend_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"google.golang.org/grpc/codes"
 )
 
 // wandbRecordingRunner mirrors the recording-runner pattern used by
@@ -549,6 +551,39 @@ func TestWandbStopFailurePreservesClaim(t *testing.T) {
 	claim, ok, resolveErr := resolveWandbClaim("sb-abc")
 	if resolveErr != nil || !ok || claim.CloudID != "sb-abc" {
 		t.Fatalf("failed stop claim=%#v ok=%v err=%v", claim, ok, resolveErr)
+	}
+}
+
+func TestWandbStopRemovesStaleClaimWhenSandboxIsGone(t *testing.T) {
+	api := &fakeWandbAPI{statusErr: &wandbAPIError{Code: codes.NotFound, ExitCode: 4, Stderr: "Get: not found"}}
+	backend := newWandbBackendForTest(t, api)
+	seedWandbClaim(t, backend, "sb-abc")
+
+	if err := backend.Stop(context.Background(), StopRequest{ID: "sb-abc"}); err != nil {
+		t.Fatalf("Stop err: %v", err)
+	}
+	if api.statusID != "sb-abc" || api.stopID != "" {
+		t.Fatalf("statusID=%q stopID=%q, want missing check without provider stop", api.statusID, api.stopID)
+	}
+	if _, ok, err := resolveWandbClaim("sb-abc"); err != nil || ok {
+		t.Fatalf("stale claim remains ok=%v err=%v", ok, err)
+	}
+}
+
+func TestWandbStopPreservesClaimWhenSandboxLostManagedTag(t *testing.T) {
+	api := &fakeWandbAPI{statusValue: wandbSandbox{ID: "sb-abc", Status: "RUNNING"}}
+	backend := newWandbBackendForTest(t, api)
+	seedWandbClaim(t, backend, "sb-abc")
+
+	err := backend.Stop(context.Background(), StopRequest{ID: "sb-abc"})
+	if err == nil || !strings.Contains(err.Error(), "not tagged as Crabbox-managed") {
+		t.Fatalf("Stop err=%v, want untagged refusal", err)
+	}
+	if api.stopID != "" {
+		t.Fatalf("untagged sandbox reached Stop(%q)", api.stopID)
+	}
+	if claim, ok, resolveErr := resolveWandbClaim("sb-abc"); resolveErr != nil || !ok || claim.CloudID != "sb-abc" {
+		t.Fatalf("untagged sandbox claim=%#v ok=%v err=%v", claim, ok, resolveErr)
 	}
 }
 

--- a/internal/providers/wandb/client.go
+++ b/internal/providers/wandb/client.go
@@ -159,6 +159,23 @@ func newWandbClient(cfg Config, _ Runtime) (wandbAPI, error) {
 	return &wandbClient{conn: conn, gw: sandboxv1.NewGatewayServiceClient(conn)}, nil
 }
 
+// wandbProviderScope binds a local claim to the exact remote namespace without
+// retaining the API key. The client validates that entity is present before a
+// production operation reaches ownership checks.
+func wandbProviderScope() (string, error) {
+	endpoint := strings.TrimSpace(os.Getenv("CWSANDBOX_BASE_URL"))
+	if endpoint == "" {
+		endpoint = defaultEndpoint
+	}
+	resolved, _, err := resolveEndpoint(endpoint)
+	if err != nil {
+		return "", err
+	}
+	return "endpoint:" + url.QueryEscape(resolved) +
+		"|entity:" + url.QueryEscape(strings.TrimSpace(os.Getenv("WANDB_ENTITY_NAME"))) +
+		"|project:" + url.QueryEscape(strings.TrimSpace(os.Getenv("WANDB_PROJECT"))), nil
+}
+
 func (c *wandbClient) Close() error {
 	if c == nil || c.conn == nil {
 		return nil

--- a/internal/providers/wandb/client_test.go
+++ b/internal/providers/wandb/client_test.go
@@ -156,6 +156,25 @@ func TestResolveEndpoint(t *testing.T) {
 	}
 }
 
+func TestWandbProviderScopeBindsRoutingWithoutAPIKey(t *testing.T) {
+	t.Setenv("CWSANDBOX_BASE_URL", "https://api.cwsandbox.com:443")
+	t.Setenv("WANDB_ENTITY_NAME", "team|blue")
+	t.Setenv("WANDB_PROJECT", "project one")
+	t.Setenv("CRABBOX_WANDB_API_KEY", "must-not-appear")
+
+	scope, err := wandbProviderScope()
+	if err != nil {
+		t.Fatal(err)
+	}
+	const want = "endpoint:api.cwsandbox.com%3A443|entity:team%7Cblue|project:project+one"
+	if scope != want {
+		t.Fatalf("scope = %q, want %q", scope, want)
+	}
+	if strings.Contains(scope, "must-not-appear") {
+		t.Fatal("provider scope retained API key")
+	}
+}
+
 func TestResolveEndpointRejectsURLPath(t *testing.T) {
 	for _, endpoint := range []string{
 		"https://api.cwsandbox.com:443/v2",

--- a/internal/providers/wandb/core.go
+++ b/internal/providers/wandb/core.go
@@ -25,6 +25,8 @@ type StopRequest = core.StopRequest
 type DoctorRequest = core.DoctorRequest
 type DoctorResult = core.DoctorResult
 type Server = core.Server
+type LeaseClaim = core.LeaseClaim
+type SSHTarget = core.SSHTarget
 type Repo = core.Repo
 type ExitError = core.ExitError
 type FeatureSet = core.FeatureSet
@@ -54,6 +56,27 @@ func blank(value, fallback string) string {
 
 func shellQuote(value string) string {
 	return core.ShellQuote(value)
+}
+
+func claimWandbSandbox(leaseID, scope string, cfg Config) (LeaseClaim, error) {
+	server := Server{CloudID: leaseID, Provider: providerName, Name: leaseID}
+	return core.ClaimLeaseTargetForConfigScopeIfUnchanged(leaseID, leaseID, cfg, scope, server, SSHTarget{}, cfg.IdleTimeout, LeaseClaim{}, false)
+}
+
+func resolveWandbClaim(identifier string) (LeaseClaim, bool, error) {
+	claim, ok, err := core.ResolveLeaseClaimForProvider(identifier, providerName)
+	if err != nil || ok {
+		return claim, ok, err
+	}
+	return core.ResolveLeaseClaimForProviderCloudID(identifier, providerName)
+}
+
+func removeWandbClaimAfter(claim LeaseClaim, action func() error) error {
+	return core.RemoveLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, action)
+}
+
+func verifyWandbClaim(claim LeaseClaim) error {
+	return core.VerifyLeaseClaimUnchanged(claim.LeaseID, claim)
 }
 
 func inventoryDoctorResult(provider string, leases int) DoctorResult {

--- a/scripts/live-smoke.sh
+++ b/scripts/live-smoke.sh
@@ -536,20 +536,7 @@ semaphore_smoke() {
 }
 
 wandb_smoke() {
-  need_tool jq
-
-  if [[ -z "${CRABBOX_WANDB_API_KEY:-${WANDB_API_KEY:-}}" ]]; then
-    echo "wandb smoke requires CRABBOX_WANDB_API_KEY or WANDB_API_KEY" >&2
-    return 2
-  fi
-
-  run_in_repo "$cb" doctor --provider wandb
-  run_in_repo "$cb" run \
-    --provider wandb \
-    --no-sync \
-    --wandb-max-lifetime 60 \
-    -- echo crabbox-wandb-ok
-  run_in_repo "$cb" list --provider wandb --json | jq 'map({id:(.id // .CloudID),provider:(.provider // .Provider),state:(.status // .state)})'
+  CRABBOX_BIN="$cb" CRABBOX_LIVE_REPO="$repo" "$root/scripts/wandb-smoke.sh"
 }
 
 incus_smoke() {

--- a/scripts/wandb-smoke.sh
+++ b/scripts/wandb-smoke.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
+
+smoke_root=""
+sandbox_id=""
+claim_path=""
+claim_backup=""
 
 if [[ "${CRABBOX_LIVE:-}" != "1" ]]; then
   echo "set CRABBOX_LIVE=1 to run the W&B live smoke" >&2
@@ -35,11 +40,83 @@ run_in_repo() {
   (cd "$repo" && "$@")
 }
 
+cleanup() {
+  local status=$?
+  if [[ -z "$sandbox_id" && -n "$smoke_root" && -d "$XDG_STATE_HOME/crabbox/claims" ]]; then
+    local claims=("$XDG_STATE_HOME"/crabbox/claims/*.json)
+    if [[ "${#claims[@]}" -eq 1 && -f "${claims[0]}" ]]; then
+      sandbox_id="${claims[0]##*/}"
+      sandbox_id="${sandbox_id%.json}"
+    fi
+  fi
+  if [[ -n "$claim_backup" && -e "$claim_backup" && -n "$claim_path" && ! -e "$claim_path" ]]; then
+    mv -- "$claim_backup" "$claim_path"
+  fi
+  if [[ -n "$sandbox_id" ]]; then
+    run_in_repo "$cb" stop --provider wandb --id "$sandbox_id" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "$smoke_root" ]]; then
+    rm -rf -- "$smoke_root"
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
+
+smoke_root="$(mktemp -d "${TMPDIR:-/tmp}/crabbox-wandb-smoke.XXXXXX")"
+export XDG_STATE_HOME="$smoke_root/state"
+shopt -s nullglob
+lease_json="$smoke_root/lease.json"
+
 run_in_repo "$cb" doctor --provider wandb
 run_in_repo "$cb" run \
   --provider wandb \
   --no-sync \
+  --keep \
+  --lease-output "$lease_json" \
   --wandb-max-lifetime 60 \
   -- echo crabbox-wandb-ok
-run_in_repo "$cb" list --provider wandb --json | jq 'map({id:(.id // .CloudID),provider:(.provider // .Provider),state:(.status // .state)})'
+sandbox_id="$(jq -r '.leaseId // .LeaseID // .slug // empty' "$lease_json")"
+if [[ -z "$sandbox_id" ]]; then
+  echo "wandb smoke lease output did not contain a sandbox id" >&2
+  exit 1
+fi
+claim_path="$XDG_STATE_HOME/crabbox/claims/$sandbox_id.json"
+if [[ ! -f "$claim_path" ]]; then
+  echo "wandb smoke did not persist the expected local claim" >&2
+  exit 1
+fi
+
+run_in_repo "$cb" status --provider wandb --id "$sandbox_id" >/dev/null
+
+# Prove the provider-side tag alone is insufficient. Restore the exact claim
+# before cleanup regardless of how the denial assertion exits.
+claim_backup="$smoke_root/claim.json"
+mv -- "$claim_path" "$claim_backup"
+set +e
+denied_output="$(run_in_repo "$cb" stop --provider wandb --id "$sandbox_id" 2>&1)"
+denied_status=$?
+set -e
+if [[ "$denied_status" -eq 0 || "$denied_output" != *"no matching local ownership claim"* ]]; then
+  echo "wandb smoke expected tagged-but-unclaimed stop denial" >&2
+  exit 1
+fi
+mv -- "$claim_backup" "$claim_path"
+claim_backup=""
+run_in_repo "$cb" status --provider wandb --id "$sandbox_id" >/dev/null
+
+run_in_repo "$cb" run \
+  --provider wandb \
+  --no-sync \
+  --id "$sandbox_id" \
+  -- echo crabbox-wandb-reuse-ok
+run_in_repo "$cb" stop --provider wandb --id "$sandbox_id"
+if [[ -e "$claim_path" ]]; then
+  echo "wandb smoke stop left local claim residue" >&2
+  exit 1
+fi
+if ! run_in_repo "$cb" list --provider wandb --json | jq -e --arg id "$sandbox_id" 'map(.id // .CloudID) | index($id) == null' >/dev/null; then
+  echo "wandb smoke stop left active remote inventory residue" >&2
+  exit 1
+fi
+sandbox_id=""
 printf 'wandb live smoke complete\n'

--- a/scripts/wandb-smoke.sh
+++ b/scripts/wandb-smoke.sh
@@ -109,6 +109,8 @@ run_in_repo "$cb" run \
   --no-sync \
   --id "$sandbox_id" \
   -- echo crabbox-wandb-reuse-ok
+claim_backup="$smoke_root/claim.json"
+cp -- "$claim_path" "$claim_backup"
 run_in_repo "$cb" stop --provider wandb --id "$sandbox_id"
 if [[ -e "$claim_path" ]]; then
   echo "wandb smoke stop left local claim residue" >&2
@@ -118,5 +120,7 @@ if ! run_in_repo "$cb" list --provider wandb --json | jq -e --arg id "$sandbox_i
   echo "wandb smoke stop left active remote inventory residue" >&2
   exit 1
 fi
+rm -- "$claim_backup"
+claim_backup=""
 sandbox_id=""
 printf 'wandb live smoke complete\n'

--- a/scripts/wandb-smoke.sh
+++ b/scripts/wandb-smoke.sh
@@ -114,7 +114,7 @@ if [[ -e "$claim_path" ]]; then
   echo "wandb smoke stop left local claim residue" >&2
   exit 1
 fi
-if ! run_in_repo "$cb" list --provider wandb --json | jq -e --arg id "$sandbox_id" 'map(.id // .CloudID) | index($id) == null' >/dev/null; then
+if ! run_in_repo "$cb" list --provider wandb --json | jq -e --arg id "$sandbox_id" 'map(.CloudID // .id) | index($id) == null' >/dev/null; then
   echo "wandb smoke stop left active remote inventory residue" >&2
   exit 1
 fi

--- a/scripts/wandb-smoke.test.js
+++ b/scripts/wandb-smoke.test.js
@@ -20,6 +20,7 @@ test("wandb smoke resolves relative CRABBOX_BIN before changing repo", () => {
 	const calls = path.join(dir, "calls.log");
 	const trap = path.join(dir, "trap.log");
 	const active = path.join(dir, "active");
+	const leftRemoteOnce = path.join(dir, "left-remote-once");
 	fs.mkdirSync(path.join(caller, "bin"), { recursive: true });
 	fs.mkdirSync(path.join(target, "bin"), { recursive: true });
 	fs.mkdirSync(tools);
@@ -60,7 +61,9 @@ case "\${1:-}" in
       exit 4
     fi
     rm -f "$XDG_STATE_HOME/crabbox/claims/sb-live.json"
-    if [[ "\${CRABBOX_FAKE_LEAVE_REMOTE:-}" != "1" ]]; then
+    if [[ "\${CRABBOX_FAKE_LEAVE_REMOTE:-}" == "1" && ! -e "${leftRemoteOnce}" ]]; then
+	  : >"${leftRemoteOnce}"
+	else
       rm -f "${active}"
     fi
     ;;
@@ -169,4 +172,5 @@ esac
 	});
 	assert.equal(residueResult.status, 1, residueResult.stderr || residueResult.stdout);
 	assert.match(residueResult.stderr, /wandb smoke stop left active remote inventory residue/);
+	assert.equal(fs.existsSync(active), false, "cleanup retry left remote sandbox residue");
 });

--- a/scripts/wandb-smoke.test.js
+++ b/scripts/wandb-smoke.test.js
@@ -59,10 +59,17 @@ case "\${1:-}" in
       printf 'wandb sandbox "sb-live" has no matching local ownership claim\\n' >&2
       exit 4
     fi
-    rm -f "$XDG_STATE_HOME/crabbox/claims/sb-live.json" "${active}"
+    rm -f "$XDG_STATE_HOME/crabbox/claims/sb-live.json"
+    if [[ "\${CRABBOX_FAKE_LEAVE_REMOTE:-}" != "1" ]]; then
+      rm -f "${active}"
+    fi
     ;;
   list)
-    printf '[]\\n'
+    if [[ -e "${active}" ]]; then
+      printf '[{"id":"friendly-name","CloudID":"sb-live"}]\\n'
+    else
+      printf '[]\\n'
+    fi
     ;;
   *)
     printf 'unexpected crabbox args: %s\\n' "$*" >&2
@@ -88,7 +95,20 @@ case "\${1:-}" in
     sed -n 's/.*"leaseId":"\\([^"]*\\)".*/\\1/p' "\${3:?}"
     ;;
   -e)
-    cat >/dev/null
+    input="$(cat)"
+    case "$*" in
+      *'.CloudID // .id'*)
+        if [[ "$input" == *'"CloudID":"sb-live"'* ]]; then
+          exit 1
+        fi
+        ;;
+      *'.id // .CloudID'*)
+        # A display id masks CloudID with this ordering, reproducing the bug.
+        ;;
+      *)
+        exit 64
+        ;;
+    esac
     ;;
   *)
     exit 64
@@ -132,4 +152,21 @@ esac
 	);
 	assert.equal(seen[6], "stop --provider wandb --id sb-live");
 	assert.equal(seen[7], "list --provider wandb --json");
+
+	const residueResult = spawnSync("bash", [path.join(repoRoot, "scripts", "wandb-smoke.sh")], {
+		cwd: caller,
+		env: {
+			...process.env,
+			PATH: `${tools}${path.delimiter}${process.env.PATH ?? ""}`,
+			CRABBOX_LIVE: "1",
+			CRABBOX_BIN: "./bin/crabbox",
+			CRABBOX_LIVE_REPO: target,
+			CRABBOX_FAKE_LEAVE_REMOTE: "1",
+			WANDB_API_KEY: "test-key",
+			WANDB_ENTITY_NAME: "example-org",
+		},
+		encoding: "utf8",
+	});
+	assert.equal(residueResult.status, 1, residueResult.stderr || residueResult.stdout);
+	assert.match(residueResult.stderr, /wandb smoke stop left active remote inventory residue/);
 });

--- a/scripts/wandb-smoke.test.js
+++ b/scripts/wandb-smoke.test.js
@@ -19,6 +19,7 @@ test("wandb smoke resolves relative CRABBOX_BIN before changing repo", () => {
 	const tools = path.join(dir, "tools");
 	const calls = path.join(dir, "calls.log");
 	const trap = path.join(dir, "trap.log");
+	const active = path.join(dir, "active");
 	fs.mkdirSync(path.join(caller, "bin"), { recursive: true });
 	fs.mkdirSync(path.join(target, "bin"), { recursive: true });
 	fs.mkdirSync(tools);
@@ -29,8 +30,36 @@ test("wandb smoke resolves relative CRABBOX_BIN before changing repo", () => {
 set -euo pipefail
 printf '%s|%s\\n' "$PWD" "$*" >>"${calls}"
 case "\${1:-}" in
-  doctor|run)
+  doctor)
     exit 0
+    ;;
+  run)
+    lease_output=""
+    args=("$@")
+    for ((i = 0; i < \${#args[@]}; i++)); do
+      if [[ "\${args[$i]}" == "--lease-output" ]]; then
+        lease_output="\${args[$((i + 1))]}"
+      fi
+    done
+    if [[ -n "$lease_output" ]]; then
+      mkdir -p "$XDG_STATE_HOME/crabbox/claims"
+      printf '{"leaseId":"sb-live"}\\n' >"$lease_output"
+      printf '{"leaseID":"sb-live"}\\n' >"$XDG_STATE_HOME/crabbox/claims/sb-live.json"
+      : >"${active}"
+    elif [[ ! -f "$XDG_STATE_HOME/crabbox/claims/sb-live.json" ]]; then
+      printf 'missing claim for reuse\\n' >&2
+      exit 4
+    fi
+    ;;
+  status)
+    test -f "$XDG_STATE_HOME/crabbox/claims/sb-live.json"
+    ;;
+  stop)
+    if [[ ! -f "$XDG_STATE_HOME/crabbox/claims/sb-live.json" ]]; then
+      printf 'wandb sandbox "sb-live" has no matching local ownership claim\\n' >&2
+      exit 4
+    fi
+    rm -f "$XDG_STATE_HOME/crabbox/claims/sb-live.json" "${active}"
     ;;
   list)
     printf '[]\\n'
@@ -54,8 +83,17 @@ exit 66
 		path.join(tools, "jq"),
 		`#!/usr/bin/env bash
 set -euo pipefail
-cat >/dev/null
-printf '[]\\n'
+case "\${1:-}" in
+  -r)
+    sed -n 's/.*"leaseId":"\\([^"]*\\)".*/\\1/p' "\${3:?}"
+    ;;
+  -e)
+    cat >/dev/null
+    ;;
+  *)
+    exit 64
+    ;;
+esac
 `,
 	);
 
@@ -77,6 +115,21 @@ printf '[]\\n'
 	assert.equal(fs.existsSync(trap), false, "target repo relative CRABBOX_BIN was executed");
 	const callLog = fs.readFileSync(calls, "utf8");
 	assert.match(callLog, new RegExp(`${target.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\|doctor --provider wandb`));
-	assert.match(callLog, /\|run --provider wandb --no-sync --wandb-max-lifetime 60 -- echo crabbox-wandb-ok/);
+	assert.match(callLog, /\|run --provider wandb --no-sync --keep --lease-output .+ --wandb-max-lifetime 60 -- echo crabbox-wandb-ok/);
 	assert.match(callLog, /\|list --provider wandb --json/);
+	const seen = callLog
+		.trim()
+		.split("\n")
+		.map((line) => line.slice(target.length + 1));
+	assert.equal(seen.length, 8, JSON.stringify(seen));
+	assert.equal(seen[0], "doctor --provider wandb");
+	assert.equal(seen[2], "status --provider wandb --id sb-live");
+	assert.equal(seen[3], "stop --provider wandb --id sb-live");
+	assert.equal(seen[4], "status --provider wandb --id sb-live");
+	assert.equal(
+		seen[5],
+		"run --provider wandb --no-sync --id sb-live -- echo crabbox-wandb-reuse-ok",
+	);
+	assert.equal(seen[6], "stop --provider wandb --id sb-live");
+	assert.equal(seen[7], "list --provider wandb --json");
 });


### PR DESCRIPTION
## Summary

- bind W&B existing-sandbox run, status, and stop paths to an exact local claim containing the provider sandbox ID and W&B endpoint/entity/project scope
- require the claimed sandbox to remain present in provider inventory with the `crabbox` tag; labels, names, or raw IDs alone never authorize use or deletion
- re-verify the unchanged claim immediately before command execution and serialize stop/claim deletion under the claim lock
- distinguish an already-gone sandbox from an existing sandbox that lost its managed tag, removing only an unchanged stale claim in the former case
- roll back a newly created remote sandbox when claim persistence fails
- add a cleanup-armed, isolated-state W&B live canary that preserves a claim backup until remote zero-residue is proven; `--reclaim` remains unsupported because the pinned API cannot establish safe adoption

Closes https://github.com/openclaw/crabbox/issues/786

## Verification

Current candidate: `e8dc372f726fa461d5f2501ba192c4b45c067b8a`

- `git diff --check origin/main...HEAD`
- `go test -race ./internal/providers/wandb ./internal/cli -count=1`
- `go vet ./internal/providers/wandb ./internal/cli`
- `scripts/check-docs.sh`
- `node --test scripts/wandb-smoke.test.js scripts/live-smoke.test.js` — 52 passed, including CloudID residue detection and cleanup retry after deliberate remote residue
- full-branch autoreview clean with no accepted/actionable findings (0.82); focused cleanup-patch autoreview also clean (0.86)
- exact-head Worker format, lint, typecheck, 789-test suite, Wrangler dry-run build, docs checks, and site build
- one unrelated full-suite controller timing miss passed 20 consecutive focused race runs immediately afterward

All inline review findings are fixed, answered, and resolved.

## Provider-live proof

- Built and tested exact head `e8dc372f726fa461d5f2501ba192c4b45c067b8a` with a dedicated W&B API key injected from approved secret storage; no credential was written to the repository or passed on argv.
- Authenticated doctor reported ready control plane and zero starting inventory.
- Created a disposable W&B/CoreWeave sandbox, executed the fresh-sandbox path, and persisted the exact scoped claim.
- Removed the claim and proved destructive stop denied the otherwise tagged sandbox; restored it and proved status, existing-ID reuse, and owned stop.
- CloudID-aware cleanup verification and an independent post-run list both reported zero remote residue; isolated local smoke residue was also zero.

The exact-head authenticated live gate is satisfied. Merge after hosted checks are terminal green.

## Security / configuration

No new credential or persisted-secret requirement. The live canary accepts `CRABBOX_WANDB_API_KEY` or `WANDB_API_KEY` only from the process environment and uses isolated Crabbox state.
