### PR TITLE
fix: bind local provider deletes to exact claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Restricted brokered Azure image and OS-disk selectors to admin-authenticated requests while preserving user-selectable Azure placement. Thanks @coygeek.
+- Required exact resource-bound local lease claims before Apple Container, local-container, or Apple VZ stop operations can delete provider resources; legacy unbound claims require explicit `--reclaim` adoption before stop. Thanks @coygeek.
 
 ## 0.34.0 - 2026-07-02
 

--- a/internal/providers/applecontainer/backend.go
+++ b/internal/providers/applecontainer/backend.go
@@ -161,6 +161,12 @@ func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.Le
 		}
 		return core.LeaseTarget{}, err
 	}
+	if err := core.UpdateLeaseClaimEndpoint(leaseID, lease.Server, lease.SSH); err != nil {
+		if !req.Keep {
+			_ = b.removeContainer(context.Background(), containerID)
+		}
+		return core.LeaseTarget{}, err
+	}
 	cleanupKey = false
 	fmt.Fprintf(b.rt.Stderr, "provisioned lease=%s container=%s state=ready\n", leaseID, c.id())
 	return lease, nil
@@ -175,6 +181,17 @@ func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.Le
 	if err != nil {
 		return core.LeaseTarget{}, err
 	}
+	readOnlyStatus := req.StatusOnly && !req.ReleaseOnly
+	if strings.TrimSpace(leaseID) == "" && (!readOnlyStatus || req.Reclaim) {
+		return core.LeaseTarget{}, appleContainerOwnershipError(leaseID, c.id())
+	}
+	owned, conflict, err := appleContainerClaimStatus(leaseID, c.id())
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	if (conflict && (!readOnlyStatus || req.Reclaim)) || (!owned && !readOnlyStatus && (req.ReleaseOnly || !req.Reclaim)) {
+		return core.LeaseTarget{}, appleContainerOwnershipError(leaseID, c.id())
+	}
 	if req.ReleaseOnly {
 		return core.LeaseTarget{Server: b.serverFromContainer(c, cfg), LeaseID: leaseID}, nil
 	}
@@ -182,8 +199,8 @@ func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.Le
 	if err != nil {
 		return core.LeaseTarget{}, err
 	}
-	if req.Repo.Root != "" {
-		if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, slug, providerName, "", cfg.Pond, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
+	if req.Repo.Root != "" && (!readOnlyStatus || req.Reclaim) {
+		if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, slug, providerName, "", cfg.Pond, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, lease.Server, lease.SSH); err != nil {
 			return core.LeaseTarget{}, err
 		}
 	}
@@ -252,11 +269,48 @@ func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest
 	if id == "" {
 		return exit(2, "provider=%s release requires a container id", providerName)
 	}
+	if err := requireExactAppleContainerClaim(lease.LeaseID, id); err != nil {
+		return err
+	}
 	if err := b.removeContainer(ctx, id); err != nil {
 		return err
 	}
 	core.RemoveLeaseClaim(lease.LeaseID)
 	core.RemoveStoredTestboxKey(lease.LeaseID)
+	return nil
+}
+
+func appleContainerClaimStatus(leaseID, containerID string) (owned, conflict bool, err error) {
+	leaseID = strings.TrimSpace(leaseID)
+	claim, ok, exact, err := core.ResolveLeaseClaimForProviderWithExact(leaseID, providerName)
+	if err != nil {
+		return false, false, err
+	}
+	if !ok || !exact || claim.LeaseID != leaseID {
+		return false, false, nil
+	}
+	boundID := strings.TrimSpace(claim.CloudID)
+	if boundID == "" {
+		return false, false, nil
+	}
+	if boundID != strings.TrimSpace(containerID) {
+		return false, true, nil
+	}
+	return true, false, nil
+}
+
+func appleContainerOwnershipError(leaseID, containerID string) error {
+	return exit(4, "apple-container lease %q has no exact local claim bound to container %q; adopt it with an explicit --reclaim reuse before stop", strings.TrimSpace(leaseID), strings.TrimSpace(containerID))
+}
+
+func requireExactAppleContainerClaim(leaseID, containerID string) error {
+	owned, _, err := appleContainerClaimStatus(leaseID, containerID)
+	if err != nil {
+		return err
+	}
+	if !owned {
+		return appleContainerOwnershipError(leaseID, containerID)
+	}
 	return nil
 }
 
@@ -569,10 +623,12 @@ func (b *backend) resolveContainer(ctx context.Context, identifier string) (insp
 	if identifier == "" {
 		return inspectContainer{}, "", "", exit(2, "provider=%s requires --id <lease-id-or-slug-or-container>", providerName)
 	}
+	var resolvedClaim core.LeaseClaim
 	var wantLease, wantSlug string
 	if claim, ok, err := core.ResolveLeaseClaimForProvider(identifier, providerName); err != nil {
 		return inspectContainer{}, "", "", err
 	} else if ok {
+		resolvedClaim = claim
 		wantLease = claim.LeaseID
 		wantSlug = claim.Slug
 	}
@@ -580,16 +636,37 @@ func (b *backend) resolveContainer(ctx context.Context, identifier string) (insp
 	if err != nil {
 		return inspectContainer{}, "", "", err
 	}
+	if boundID := strings.TrimSpace(resolvedClaim.CloudID); boundID != "" {
+		for _, c := range containers {
+			if c.id() == boundID {
+				labels := c.labels()
+				return c, firstNonBlank(resolvedClaim.LeaseID, labels["lease"]), firstNonBlank(resolvedClaim.Slug, labels["slug"]), nil
+			}
+		}
+		return inspectContainer{}, "", "", exit(4, "apple-container lease not found: %s", identifier)
+	}
 	normalized := core.NormalizeLeaseSlug(identifier)
+	var matched *inspectContainer
+	var matchedLease, matchedSlug string
 	for _, c := range containers {
 		labels := c.labels()
 		leaseID := labels["lease"]
 		slug := labels["slug"]
 		if wantLease != "" && leaseID == wantLease {
-			return c, leaseID, slug, nil
+			if matched != nil {
+				return inspectContainer{}, "", "", exit(2, "apple-container lease %s matches multiple containers; use an exact claimed container id", wantLease)
+			}
+			candidate := c
+			matched, matchedLease, matchedSlug = &candidate, leaseID, slug
+			continue
 		}
 		if wantSlug != "" && core.NormalizeLeaseSlug(slug) == core.NormalizeLeaseSlug(wantSlug) {
-			return c, leaseID, slug, nil
+			if matched != nil {
+				return inspectContainer{}, "", "", exit(2, "apple-container slug %s matches multiple containers; use a lease id", wantSlug)
+			}
+			candidate := c
+			matched, matchedLease, matchedSlug = &candidate, leaseID, slug
+			continue
 		}
 		if wantLease != "" || wantSlug != "" {
 			continue
@@ -597,6 +674,9 @@ func (b *backend) resolveContainer(ctx context.Context, identifier string) (insp
 		if c.id() == identifier || leaseID == identifier || (normalized != "" && core.NormalizeLeaseSlug(slug) == normalized) {
 			return c, leaseID, slug, nil
 		}
+	}
+	if matched != nil {
+		return *matched, matchedLease, matchedSlug, nil
 	}
 	return inspectContainer{}, "", "", exit(4, "apple-container lease not found: %s", identifier)
 }

--- a/internal/providers/applecontainer/backend_test.go
+++ b/internal/providers/applecontainer/backend_test.go
@@ -582,6 +582,239 @@ func TestRemoveContainerUsesDeleteForce(t *testing.T) {
 	}
 }
 
+func TestRequireExactAppleContainerClaim(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	leaseID := "cbx_claimed_apple_container"
+	if err := requireExactAppleContainerClaim(leaseID, "owned-container"); err == nil || !strings.Contains(err.Error(), "no exact local claim") {
+		t.Fatalf("unclaimed error=%v, want exact-claim rejection", err)
+	}
+	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(
+		leaseID,
+		"claimed-apple-container",
+		providerName,
+		"",
+		"",
+		t.TempDir(),
+		time.Minute,
+		false,
+		core.Server{CloudID: "owned-container", Provider: providerName, Labels: map[string]string{"provider": providerName, "slug": "claimed-apple-container"}},
+		core.SSHTarget{},
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := requireExactAppleContainerClaim(leaseID, "other-container"); err == nil || !strings.Contains(err.Error(), "bound to container") {
+		t.Fatalf("mismatched container error=%v, want resource-binding rejection", err)
+	}
+	if err := requireExactAppleContainerClaim(leaseID, "owned-container"); err != nil {
+		t.Fatalf("claimed lease rejected: %v", err)
+	}
+}
+
+func TestResolveRawAppleContainerRequiresExplicitReclaimAndPersistsBinding(t *testing.T) {
+	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
+		t.Skip("apple-container resolve only runs on macOS/Apple silicon")
+	}
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+		commandKey([]string{"ls", "--all", "--format", "json"}):          {Stdout: sampleInspectJSON("raw-apple-container", "raw-apple", "cbx_raw_apple")},
+		commandKey([]string{"delete", "--force", "raw-apple-container"}): {},
+	}}
+	b := testBackend(runner)
+	repo := core.Repo{Root: t.TempDir()}
+	if _, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "raw-apple-container", Repo: repo}); err == nil || !strings.Contains(err.Error(), "explicit --reclaim") {
+		t.Fatalf("Resolve without reclaim error=%v", err)
+	}
+	if claim, err := core.ReadLeaseClaim("cbx_raw_apple"); err != nil {
+		t.Fatal(err)
+	} else if claim.LeaseID != "" {
+		t.Fatalf("non-reclaim resolve minted claim: %#v", claim)
+	}
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "raw-apple-container", Repo: repo, Reclaim: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim, err := core.ReadLeaseClaim("cbx_raw_apple")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claim.CloudID != "raw-apple-container" {
+		t.Fatalf("reclaim binding=%#v", claim)
+	}
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+	if !commandWasCalled(runner.calls, "delete") {
+		t.Fatalf("reclaimed container was not released: %#v", runner.calls)
+	}
+}
+
+func TestLegacyAppleContainerClaimRequiresReclaimBeforeStop(t *testing.T) {
+	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
+		t.Skip("apple-container resolve only runs on macOS/Apple silicon")
+	}
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	leaseID := "cbx_legacy_apple"
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "legacy-apple", providerName, "", "", t.TempDir(), time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+		commandKey([]string{"ls", "--all", "--format", "json"}):             {Stdout: sampleInspectJSON("legacy-apple-container", "legacy-apple", leaseID)},
+		commandKey([]string{"delete", "--force", "legacy-apple-container"}): {},
+	}}
+	b := testBackend(runner)
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: core.Server{CloudID: "legacy-apple-container"}}}); err == nil || !strings.Contains(err.Error(), "explicit --reclaim") {
+		t.Fatalf("legacy direct stop error=%v", err)
+	}
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: leaseID, Repo: core.Repo{Root: t.TempDir()}, Reclaim: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim, err := core.ReadLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claim.CloudID != "legacy-apple-container" {
+		t.Fatalf("legacy reclaim binding=%#v", claim)
+	}
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestResolveReclaimDoesNotRetargetBoundAppleContainerClaim(t *testing.T) {
+	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
+		t.Skip("apple-container resolve only runs on macOS/Apple silicon")
+	}
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	leaseID := "cbx_bound_apple"
+	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(
+		leaseID,
+		"bound-apple",
+		providerName,
+		"",
+		"",
+		t.TempDir(),
+		time.Minute,
+		false,
+		core.Server{CloudID: "container-a", Provider: providerName, Labels: map[string]string{"provider": providerName, "slug": "bound-apple"}},
+		core.SSHTarget{},
+	); err != nil {
+		t.Fatal(err)
+	}
+	listJSON := `[
+		{"status":"running","configuration":{"id":"container-b","image":{"reference":"debian:bookworm"},"labels":{"crabbox":"true","provider":"apple-container","lease":"cbx_bound_apple","slug":"bound-apple","state":"ready","ssh_user":"runner","work_root":"/work/crabbox"}},"networks":[{"address":"192.168.64.8/24"}]},
+		{"status":"running","configuration":{"id":"container-a","image":{"reference":"debian:bookworm"},"labels":{"crabbox":"true","provider":"apple-container","lease":"cbx_stale_label","slug":"stale-label","state":"ready","ssh_user":"runner","work_root":"/work/crabbox"}},"networks":[{"address":"192.168.64.7/24"}]}
+	]`
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+		commandKey([]string{"ls", "--all", "--format", "json"}): {Stdout: listJSON},
+	}}
+	b := testBackend(runner)
+	repo := core.Repo{Root: t.TempDir()}
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: leaseID, Repo: repo, Reclaim: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.Server.CloudID != "container-a" || lease.LeaseID != leaseID {
+		t.Fatalf("exact claim resolved container=%q lease=%q, want container-a/%s", lease.Server.CloudID, lease.LeaseID, leaseID)
+	}
+	if _, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "container-b", Repo: repo, Reclaim: true}); err == nil || !strings.Contains(err.Error(), "bound to container") {
+		t.Fatalf("raw conflicting reclaim error=%v", err)
+	}
+	claim, err := core.ReadLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claim.CloudID != "container-a" {
+		t.Fatalf("bound claim was retargeted: %#v", claim)
+	}
+}
+
+func TestResolveStatusOnlyAllowsClaimlessAppleContainerWithoutClaiming(t *testing.T) {
+	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
+		t.Skip("apple-container resolve only runs on macOS/Apple silicon")
+	}
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+		commandKey([]string{"ls", "--all", "--format", "json"}): {Stdout: sampleInspectJSON("status-apple", "status-apple", "cbx_status_apple")},
+	}}
+	b := testBackend(runner)
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "status-apple", Repo: core.Repo{Root: t.TempDir()}, StatusOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.Server.CloudID != "status-apple" {
+		t.Fatalf("status lease=%#v", lease)
+	}
+	if claim, err := core.ReadLeaseClaim("cbx_status_apple"); err != nil {
+		t.Fatal(err)
+	} else if claim.LeaseID != "" {
+		t.Fatalf("status-only resolve minted claim: %#v", claim)
+	}
+	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(
+		"cbx_status_apple",
+		"status-apple",
+		providerName,
+		"",
+		"",
+		t.TempDir(),
+		time.Minute,
+		false,
+		lease.Server,
+		lease.SSH,
+	); err != nil {
+		t.Fatal(err)
+	}
+	before, err := core.ReadLeaseClaim("cbx_status_apple")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "status-apple", Repo: core.Repo{Root: t.TempDir()}, StatusOnly: true}); err != nil {
+		t.Fatalf("owned status-only resolve: %v", err)
+	}
+	after, err := core.ReadLeaseClaim("cbx_status_apple")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.RepoRoot != before.RepoRoot || after.LastUsedAt != before.LastUsedAt || after.CloudID != before.CloudID {
+		t.Fatalf("status-only resolve mutated claim: before=%#v after=%#v", before, after)
+	}
+}
+
+func TestResolveReclaimRejectsMetadataLessAppleContainer(t *testing.T) {
+	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
+		t.Skip("apple-container resolve only runs on macOS/Apple silicon")
+	}
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+		commandKey([]string{"ls", "--all", "--format", "json"}): {Stdout: sampleInspectJSON("metadata-less", "", "")},
+	}}
+	b := testBackend(runner)
+	if _, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "metadata-less", Repo: core.Repo{Root: t.TempDir()}, Reclaim: true}); err == nil || !strings.Contains(err.Error(), "no exact local claim") {
+		t.Fatalf("metadata-less reclaim error=%v", err)
+	}
+}
+
+func TestReleaseLeaseRejectsUnclaimedContainer(t *testing.T) {
+	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
+		t.Skip("apple-container release only runs on macOS/Apple silicon")
+	}
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+		commandKey([]string{"delete", "--force", "unclaimed-container"}): {},
+	}}
+	b := testBackend(runner)
+	err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{
+		LeaseID: "cbx_unclaimed_apple_container",
+		Server:  core.Server{CloudID: "unclaimed-container"},
+	}})
+	if err == nil || !strings.Contains(err.Error(), "no exact local claim") {
+		t.Fatalf("ReleaseLease error=%v, want exact-claim rejection", err)
+	}
+	if commandWasCalled(runner.calls, "delete") {
+		t.Fatalf("unclaimed container reached delete: %#v", runner.calls)
+	}
+}
+
 func TestDoctorReportsMissingCLI(t *testing.T) {
 	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
 		t.Skip("doctor CLI probe only exercised on macOS/Apple silicon")

--- a/internal/providers/applevz/backend.go
+++ b/internal/providers/applevz/backend.go
@@ -222,11 +222,19 @@ func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.Le
 	slug := firstNonBlank(claim.Slug, inst.Slug)
 	claim.LeaseID = leaseID
 	claim.Slug = slug
+	if leaseID == "" {
+		return core.LeaseTarget{}, exit(4, "apple-vz instance %q has no Crabbox lease metadata; clean it up with `crabbox cleanup --provider apple-vz`", inst.Name)
+	}
+	owned, conflict, err := appleVZClaimStatus(leaseID, inst.Name)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	readOnlyStatus := req.StatusOnly && !req.ReleaseOnly
+	if (conflict && (!readOnlyStatus || req.Reclaim)) || (!owned && !readOnlyStatus && (req.ReleaseOnly || !req.Reclaim)) {
+		return core.LeaseTarget{}, appleVZOwnershipError(leaseID, inst.Name)
+	}
 	if req.ReleaseOnly {
 		return core.LeaseTarget{Server: b.serverFromInstance(inst, claim, cfg), LeaseID: leaseID}, nil
-	}
-	if leaseID == "" {
-		return core.LeaseTarget{}, exit(4, "apple-vz instance %q has no Crabbox lease metadata; stop it with `crabbox stop --provider apple-vz %s`", inst.Name, inst.Name)
 	}
 	if !appleVZRunning(inst.Status) && !req.StatusOnly {
 		return core.LeaseTarget{}, exit(5, "apple-vz instance %s is %s; start a new lease with `crabbox run` or clean it up with `crabbox cleanup --provider apple-vz`", inst.Name, core.Blank(inst.Status, "stopped"))
@@ -238,7 +246,7 @@ func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.Le
 	if err != nil {
 		return core.LeaseTarget{}, err
 	}
-	if req.Repo.Root != "" {
+	if req.Repo.Root != "" && (!readOnlyStatus || req.Reclaim) {
 		if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, slug, providerName, instanceScope(inst.Name), cfg.Pond, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, lease.Server, lease.SSH); err != nil {
 			return core.LeaseTarget{}, err
 		}
@@ -326,6 +334,9 @@ func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest
 		}
 	}
 	if name != "" {
+		if err := requireExactAppleVZClaim(leaseID, name); err != nil {
+			return err
+		}
 		if err := b.deleteInstance(ctx, cfg, name); err != nil {
 			return err
 		}
@@ -336,6 +347,43 @@ func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest
 	}
 	if name == "" && leaseID == "" {
 		return exit(2, "provider=%s release requires an apple-vz instance name or lease id", providerName)
+	}
+	return nil
+}
+
+func appleVZClaimStatus(leaseID, instanceName string) (owned, conflict bool, err error) {
+	leaseID = strings.TrimSpace(leaseID)
+	claim, ok, exact, err := core.ResolveLeaseClaimForProviderWithExact(leaseID, providerName)
+	if err != nil {
+		return false, false, err
+	}
+	if !ok || !exact || claim.LeaseID != leaseID {
+		return false, false, nil
+	}
+	binding := strings.TrimSpace(claim.ProviderScope)
+	if binding == "" {
+		binding = strings.TrimSpace(claim.Labels["instance"])
+	}
+	if binding == "" {
+		return false, false, nil
+	}
+	if binding != instanceScope(instanceName) {
+		return false, true, nil
+	}
+	return true, false, nil
+}
+
+func appleVZOwnershipError(leaseID, instanceName string) error {
+	return exit(4, "apple-vz lease %q has no exact local claim bound to instance %q; adopt it with an explicit --reclaim reuse before stop", strings.TrimSpace(leaseID), strings.TrimSpace(instanceName))
+}
+
+func requireExactAppleVZClaim(leaseID, instanceName string) error {
+	owned, _, err := appleVZClaimStatus(leaseID, instanceName)
+	if err != nil {
+		return err
+	}
+	if !owned {
+		return appleVZOwnershipError(leaseID, instanceName)
 	}
 	return nil
 }
@@ -650,14 +698,43 @@ func (b *backend) resolveInstance(ctx context.Context, cfg core.Config, identifi
 	if err != nil {
 		return applevzhelper.Instance{}, core.LeaseClaim{}, err
 	}
+	requestedClaim, hasRequestedClaim, err := core.ResolveLeaseClaimForProvider(identifier, providerName)
+	if err != nil {
+		return applevzhelper.Instance{}, core.LeaseClaim{}, err
+	}
+	if hasRequestedClaim {
+		boundName := strings.TrimSpace(requestedClaim.ProviderScope)
+		if boundName == "" {
+			boundName = strings.TrimSpace(requestedClaim.Labels["instance"])
+		}
+		if boundName != "" {
+			for _, inst := range instances {
+				if inst.Name == boundName {
+					return inst, requestedClaim, nil
+				}
+			}
+			return applevzhelper.Instance{}, requestedClaim, &missingInstanceError{
+				err: exit(4, "apple-vz lease %q points to a missing instance; run `crabbox cleanup --provider apple-vz`", identifier),
+			}
+		}
+	}
+	var matched *applevzhelper.Instance
+	var matchedClaim core.LeaseClaim
 	for _, inst := range instances {
 		claim := claims[inst.Name]
 		if inst.Name == identifier || inst.LeaseID == identifier || inst.Slug == identifier || claim.LeaseID == identifier || claim.Slug == identifier {
-			return inst, claim, nil
+			if matched != nil {
+				return applevzhelper.Instance{}, core.LeaseClaim{}, exit(2, "apple-vz identifier %s matches multiple instances; use an exact claimed instance name", identifier)
+			}
+			candidate := inst
+			matched, matchedClaim = &candidate, claim
 		}
 	}
-	if claim, ok, err := core.ResolveLeaseClaimForProvider(identifier, providerName); err == nil && ok {
-		return applevzhelper.Instance{}, claim, &missingInstanceError{
+	if matched != nil {
+		return *matched, matchedClaim, nil
+	}
+	if hasRequestedClaim {
+		return applevzhelper.Instance{}, requestedClaim, &missingInstanceError{
 			err: exit(4, "apple-vz lease %q points to a missing instance; run `crabbox cleanup --provider apple-vz`", identifier),
 		}
 	}

--- a/internal/providers/applevz/provider_test.go
+++ b/internal/providers/applevz/provider_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"flag"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -64,6 +65,23 @@ func mustJSON(t *testing.T, value any) string {
 		t.Fatal(err)
 	}
 	return string(data)
+}
+
+func writeAppleVZInstanceClaim(t *testing.T, inst applevzhelper.Instance) {
+	t.Helper()
+	server := core.Server{CloudID: inst.Name, Provider: providerName, Name: inst.Name, Labels: map[string]string{
+		"instance": inst.Name,
+		"lease":    inst.LeaseID,
+		"provider": providerName,
+		"slug":     inst.Slug,
+	}}
+	target := core.SSHTarget{Host: inst.SSHHost, User: inst.SSHUser}
+	if inst.SSHPort > 0 {
+		target.Port = fmt.Sprint(inst.SSHPort)
+	}
+	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(inst.LeaseID, inst.Slug, providerName, instanceScope(inst.Name), "", t.TempDir(), 5*time.Minute, false, server, target); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func testBackend(t *testing.T, runner *recordingRunner) *backend {
@@ -588,11 +606,8 @@ func TestAcquireResolveListAndRelease(t *testing.T) {
 	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
 	b := testBackend(t, runner)
 	root, _ := b.stateRoot()
-	name := "crabbox-cbx123-demo"
+	name := ""
 	startInstance := applevzhelper.Instance{
-		Name:      name,
-		LeaseID:   "cbx_fake123456",
-		Slug:      "demo",
 		Status:    applevzhelper.StatusRunning,
 		Image:     b.configForRun().AppleVZ.Image,
 		SSHUser:   b.configForRun().AppleVZ.User,
@@ -605,7 +620,17 @@ func TestAcquireResolveListAndRelease(t *testing.T) {
 	runner.responses[commandKey("helper", []string{
 		"list", "--state-root", root,
 	})] = core.LocalCommandResult{Stdout: mustJSON(t, applevzhelper.ListResponse{})}
-	runner.responses["helper\x00start"] = core.LocalCommandResult{Stdout: mustJSON(t, applevzhelper.StartResponse{Instance: startInstance})}
+	runner.hook = func(req core.LocalCommandRequest) (core.LocalCommandResult, error, bool) {
+		if req.Name != "helper" || len(req.Args) == 0 || req.Args[0] != "start" {
+			return core.LocalCommandResult{}, nil, false
+		}
+		name = argumentValue(req.Args, "--name")
+		instance := startInstance
+		instance.Name = name
+		instance.LeaseID = argumentValue(req.Args, "--lease-id")
+		instance.Slug = argumentValue(req.Args, "--slug")
+		return core.LocalCommandResult{Stdout: mustJSON(t, applevzhelper.StartResponse{Instance: instance})}, nil, true
+	}
 
 	req := core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "demo"}
 	lease, err := b.Acquire(context.Background(), req)
@@ -674,6 +699,7 @@ func TestResolveStatusOnlyAllowsStartingInstanceWithoutSSHEndpoint(t *testing.T)
 	runner.responses[commandKey("helper", []string{"list", "--state-root", root})] = core.LocalCommandResult{
 		Stdout: mustJSON(t, applevzhelper.ListResponse{Instances: []applevzhelper.Instance{inst}}),
 	}
+	writeAppleVZInstanceClaim(t, inst)
 
 	for _, readyProbe := range []bool{false, true} {
 		lease, err := b.Resolve(context.Background(), core.ResolveRequest{
@@ -752,6 +778,208 @@ func TestReleaseLeasePreservesClaimAndKeyWhenInstanceLookupFails(t *testing.T) {
 	}
 }
 
+func TestReleaseLeaseRejectsUnclaimedRawInstance(t *testing.T) {
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+		"helper\x00delete": {Stdout: mustJSON(t, applevzhelper.DeleteResponse{Deleted: true})},
+	}}
+	b := testBackend(t, runner)
+	leaseID := "cbx_unclaimed_apple_vz"
+	name := core.LeaseProviderName(leaseID, "unclaimed")
+	err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{
+		LeaseID: leaseID,
+		Server:  core.Server{CloudID: name},
+	}})
+	if err == nil || !strings.Contains(err.Error(), "no exact local claim") {
+		t.Fatalf("ReleaseLease error=%v, want exact-claim rejection", err)
+	}
+	for _, call := range runner.calls {
+		if len(call.Args) > 0 && call.Args[0] == "delete" {
+			t.Fatalf("unclaimed instance reached helper delete: %+v", call)
+		}
+	}
+}
+
+func TestRequireExactAppleVZClaimRequiresInstanceBinding(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		providerScope string
+		labelInstance string
+		wantAllowed   bool
+	}{
+		{name: "unbound"},
+		{name: "mismatched scope", providerScope: "other-instance"},
+		{name: "matching scope", providerScope: "owned-instance", wantAllowed: true},
+		{name: "matching legacy label", labelInstance: "owned-instance", wantAllowed: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+			_ = testBackend(t, runner)
+			leaseID := "cbx_bound_apple_vz"
+			if err := core.ClaimLeaseForRepoProviderScopePond(
+				leaseID,
+				"bound-apple-vz",
+				providerName,
+				tc.providerScope,
+				"",
+				t.TempDir(),
+				5*time.Minute,
+				false,
+			); err != nil {
+				t.Fatal(err)
+			}
+			if tc.labelInstance != "" {
+				if err := core.UpdateLeaseClaimEndpoint(leaseID, core.Server{Provider: providerName, CloudID: tc.labelInstance, Labels: map[string]string{
+					"instance": tc.labelInstance,
+					"provider": providerName,
+					"slug":     "bound-apple-vz",
+				}}, core.SSHTarget{}); err != nil {
+					t.Fatal(err)
+				}
+			}
+			err := requireExactAppleVZClaim(leaseID, "owned-instance")
+			if tc.wantAllowed && err != nil {
+				t.Fatalf("bound claim rejected: %v", err)
+			}
+			if !tc.wantAllowed && (err == nil || !strings.Contains(err.Error(), "bound to instance")) {
+				t.Fatalf("unbound claim error=%v", err)
+			}
+		})
+	}
+}
+
+func TestResolveRawAppleVZRequiresExplicitReclaimAndPersistsBinding(t *testing.T) {
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	b := testBackend(t, runner)
+	root, _ := b.stateRoot()
+	inst := applevzhelper.Instance{
+		Name:      "crabbox-cbx123-raw",
+		LeaseID:   "cbx_raw_apple_vz",
+		Slug:      "raw-apple-vz",
+		Status:    applevzhelper.StatusRunning,
+		Image:     b.configForRun().AppleVZ.Image,
+		SSHUser:   b.configForRun().AppleVZ.User,
+		WorkRoot:  b.configForRun().AppleVZ.WorkRoot,
+		SSHHost:   "127.0.0.1",
+		SSHPort:   43023,
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}
+	runner.responses[commandKey("helper", []string{"list", "--state-root", root})] = core.LocalCommandResult{
+		Stdout: mustJSON(t, applevzhelper.ListResponse{Instances: []applevzhelper.Instance{inst}}),
+	}
+	runner.responses["helper\x00delete"] = core.LocalCommandResult{Stdout: mustJSON(t, applevzhelper.DeleteResponse{Deleted: true, Instance: inst})}
+	repo := core.Repo{Root: t.TempDir()}
+	if _, err := b.Resolve(context.Background(), core.ResolveRequest{ID: inst.Name, Repo: repo}); err == nil || !strings.Contains(err.Error(), "explicit --reclaim") {
+		t.Fatalf("Resolve without reclaim error=%v", err)
+	}
+	if claim, err := core.ReadLeaseClaim(inst.LeaseID); err != nil {
+		t.Fatal(err)
+	} else if claim.LeaseID != "" {
+		t.Fatalf("non-reclaim resolve minted claim: %#v", claim)
+	}
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: inst.Name, Repo: repo, Reclaim: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim, err := core.ReadLeaseClaim(inst.LeaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claim.ProviderScope != inst.Name || claim.CloudID != inst.Name {
+		t.Fatalf("reclaim binding=%#v", claim)
+	}
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+	if !slices.ContainsFunc(runner.calls, func(call core.LocalCommandRequest) bool {
+		return len(call.Args) > 0 && call.Args[0] == "delete"
+	}) {
+		t.Fatalf("reclaimed instance was not released: %+v", runner.calls)
+	}
+}
+
+func TestResolveReclaimDoesNotRetargetBoundAppleVZClaim(t *testing.T) {
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	b := testBackend(t, runner)
+	root, _ := b.stateRoot()
+	instA := applevzhelper.Instance{Name: "instance-a", LeaseID: "cbx_bound_apple_vz", Slug: "bound-apple-vz", Status: applevzhelper.StatusRunning, SSHHost: "127.0.0.1", SSHPort: 43024, SSHUser: "runner"}
+	instB := instA
+	instB.Name = "instance-b"
+	instB.SSHPort = 43025
+	writeAppleVZInstanceClaim(t, instA)
+	runner.responses[commandKey("helper", []string{"list", "--state-root", root})] = core.LocalCommandResult{
+		Stdout: mustJSON(t, applevzhelper.ListResponse{Instances: []applevzhelper.Instance{instB, instA}}),
+	}
+	repo := core.Repo{Root: t.TempDir()}
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: instA.LeaseID, Repo: repo, Reclaim: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.Server.CloudID != instA.Name {
+		t.Fatalf("exact claim resolved instance %q, want %q", lease.Server.CloudID, instA.Name)
+	}
+	if _, err := b.Resolve(context.Background(), core.ResolveRequest{ID: instB.Name, Repo: repo, Reclaim: true}); err == nil || !strings.Contains(err.Error(), "bound to instance") {
+		t.Fatalf("raw conflicting reclaim error=%v", err)
+	}
+	claim, err := core.ReadLeaseClaim(instA.LeaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claim.ProviderScope != instA.Name || claim.CloudID != instA.Name {
+		t.Fatalf("bound claim was retargeted: %#v", claim)
+	}
+}
+
+func TestResolveStatusOnlyAllowsClaimlessAppleVZWithoutClaiming(t *testing.T) {
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	b := testBackend(t, runner)
+	root, _ := b.stateRoot()
+	inst := applevzhelper.Instance{Name: "status-instance", LeaseID: "cbx_status_apple_vz", Slug: "status-apple-vz", Status: applevzhelper.StatusStarting}
+	runner.responses[commandKey("helper", []string{"list", "--state-root", root})] = core.LocalCommandResult{
+		Stdout: mustJSON(t, applevzhelper.ListResponse{Instances: []applevzhelper.Instance{inst}}),
+	}
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: inst.Name, Repo: core.Repo{Root: t.TempDir()}, StatusOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.Server.CloudID != inst.Name {
+		t.Fatalf("status lease=%#v", lease)
+	}
+	if claim, err := core.ReadLeaseClaim(inst.LeaseID); err != nil {
+		t.Fatal(err)
+	} else if claim.LeaseID != "" {
+		t.Fatalf("status-only resolve minted claim: %#v", claim)
+	}
+	writeAppleVZInstanceClaim(t, inst)
+	before, err := core.ReadLeaseClaim(inst.LeaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.Resolve(context.Background(), core.ResolveRequest{ID: inst.Name, Repo: core.Repo{Root: t.TempDir()}, StatusOnly: true}); err != nil {
+		t.Fatalf("owned status-only resolve: %v", err)
+	}
+	after, err := core.ReadLeaseClaim(inst.LeaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.RepoRoot != before.RepoRoot || after.LastUsedAt != before.LastUsedAt || after.CloudID != before.CloudID || after.ProviderScope != before.ProviderScope {
+		t.Fatalf("status-only resolve mutated claim: before=%#v after=%#v", before, after)
+	}
+}
+
+func TestResolveMetadataLessAppleVZDirectsCleanup(t *testing.T) {
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	b := testBackend(t, runner)
+	root, _ := b.stateRoot()
+	inst := applevzhelper.Instance{Name: "metadata-less", Status: applevzhelper.StatusStopped}
+	runner.responses[commandKey("helper", []string{"list", "--state-root", root})] = core.LocalCommandResult{
+		Stdout: mustJSON(t, applevzhelper.ListResponse{Instances: []applevzhelper.Instance{inst}}),
+	}
+	if _, err := b.Resolve(context.Background(), core.ResolveRequest{ID: inst.Name, ReleaseOnly: true}); err == nil || !strings.Contains(err.Error(), "crabbox cleanup --provider apple-vz") {
+		t.Fatalf("metadata-less resolve error=%v", err)
+	}
+}
+
 func TestReleaseLeaseRemovesClaimAndKeyWhenInstanceIsMissing(t *testing.T) {
 	runner := &recordingRunner{
 		responses: map[string]core.LocalCommandResult{},
@@ -826,6 +1054,7 @@ func TestResolveStatusReadyProbeIncludesPublishedSSHEndpoint(t *testing.T) {
 	runner.responses[commandKey("helper", []string{"list", "--state-root", root})] = core.LocalCommandResult{
 		Stdout: mustJSON(t, applevzhelper.ListResponse{Instances: []applevzhelper.Instance{inst}}),
 	}
+	writeAppleVZInstanceClaim(t, inst)
 
 	for _, readyProbe := range []bool{false, true} {
 		lease, err := b.Resolve(context.Background(), core.ResolveRequest{

--- a/internal/providers/localcontainer/backend.go
+++ b/internal/providers/localcontainer/backend.go
@@ -161,6 +161,17 @@ func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.Le
 		return core.LeaseTarget{}, err
 	}
 	cfg := b.configForRun()
+	readOnlyStatus := req.StatusOnly && !req.ReleaseOnly
+	if strings.TrimSpace(leaseID) == "" && (!readOnlyStatus || req.Reclaim) {
+		return core.LeaseTarget{}, localContainerOwnershipError(leaseID, container.ID)
+	}
+	owned, conflict, err := b.localContainerClaimStatus(ctx, leaseID, container.ID)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	if (conflict && (!readOnlyStatus || req.Reclaim)) || (!owned && !readOnlyStatus && (req.ReleaseOnly || !req.Reclaim)) {
+		return core.LeaseTarget{}, localContainerOwnershipError(leaseID, container.ID)
+	}
 	if req.ReleaseOnly {
 		return core.LeaseTarget{Server: b.serverFromContainer(container, cfg), LeaseID: leaseID}, nil
 	}
@@ -168,8 +179,8 @@ func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.Le
 	if err != nil {
 		return core.LeaseTarget{}, err
 	}
-	if req.Repo.Root != "" {
-		if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, slug, providerName, b.claimScope(ctx), cfg.Pond, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
+	if req.Repo.Root != "" && (!readOnlyStatus || req.Reclaim) {
+		if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, slug, providerName, b.claimScope(ctx), cfg.Pond, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, lease.Server, lease.SSH); err != nil {
 			return core.LeaseTarget{}, err
 		}
 	}
@@ -238,6 +249,9 @@ func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest
 	if id == "" {
 		return core.Exit(2, "provider=%s release requires a container id", providerName)
 	}
+	if err := b.requireExactLocalContainerClaim(ctx, lease.LeaseID, id); err != nil {
+		return err
+	}
 	hostLeaseRoot := hostLeaseWorkRoot(lease)
 	bootstrapDir := strings.TrimSpace(lease.Server.Labels["bootstrap_dir"])
 	if err := b.removeContainer(ctx, id); err != nil {
@@ -256,6 +270,45 @@ func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest
 	core.RemoveStoredTestboxKey(lease.LeaseID)
 	if cleanupErr != nil {
 		return core.Exit(2, "remove local-container host work root %s: %v", hostLeaseRoot, cleanupErr)
+	}
+	return nil
+}
+
+func (b *backend) localContainerClaimStatus(ctx context.Context, leaseID, containerID string) (owned, conflict bool, err error) {
+	leaseID = strings.TrimSpace(leaseID)
+	claim, ok, exact, err := core.ResolveLeaseClaimForProviderWithExact(leaseID, providerName)
+	if err != nil {
+		return false, false, err
+	}
+	if !ok || !exact || claim.LeaseID != leaseID {
+		return false, false, nil
+	}
+	claimScope := strings.TrimSpace(claim.ProviderScope)
+	currentScope := strings.TrimSpace(b.claimScope(ctx))
+	claimCloudID := strings.TrimSpace(claim.CloudID)
+	if claimScope != "" && claimScope != currentScope {
+		return false, true, nil
+	}
+	if claimCloudID != "" && claimCloudID != strings.TrimSpace(containerID) {
+		return false, true, nil
+	}
+	if claimScope == "" || currentScope == "" || claimCloudID == "" {
+		return false, false, nil
+	}
+	return true, false, nil
+}
+
+func localContainerOwnershipError(leaseID, containerID string) error {
+	return core.Exit(4, "local-container lease %q has no exact local claim bound to container %q in the current runtime scope; adopt it with an explicit --reclaim reuse before stop", strings.TrimSpace(leaseID), strings.TrimSpace(containerID))
+}
+
+func (b *backend) requireExactLocalContainerClaim(ctx context.Context, leaseID, containerID string) error {
+	owned, _, err := b.localContainerClaimStatus(ctx, leaseID, containerID)
+	if err != nil {
+		return err
+	}
+	if !owned {
+		return localContainerOwnershipError(leaseID, containerID)
 	}
 	return nil
 }
@@ -1057,11 +1110,29 @@ func (b *backend) findContainerForClaim(ctx context.Context, claim core.LeaseCla
 	if err != nil {
 		return inspectContainer{}, "", "", err
 	}
+	if boundID := strings.TrimSpace(claim.CloudID); boundID != "" {
+		for _, container := range containers {
+			if strings.TrimSpace(container.ID) == boundID {
+				labels := container.Config.Labels
+				return container, firstNonBlank(claim.LeaseID, labels["lease"]), firstNonBlank(claim.Slug, labels["slug"]), nil
+			}
+		}
+		return inspectContainer{}, "", "", core.Exit(4, "local-container lease not found: %s", firstNonBlank(claim.Slug, claim.LeaseID))
+	}
+	var matched *inspectContainer
 	for _, container := range containers {
 		labels := container.Config.Labels
 		if labels["lease"] == claim.LeaseID {
-			return container, labels["lease"], labels["slug"], nil
+			if matched != nil {
+				return inspectContainer{}, "", "", core.Exit(2, "local-container lease %s matches multiple containers; reclaim by exact container id", claim.LeaseID)
+			}
+			candidate := container
+			matched = &candidate
 		}
+	}
+	if matched != nil {
+		labels := matched.Config.Labels
+		return *matched, labels["lease"], labels["slug"], nil
 	}
 	return inspectContainer{}, "", "", core.Exit(4, "local-container lease not found: %s", firstNonBlank(claim.Slug, claim.LeaseID))
 }

--- a/internal/providers/localcontainer/backend_test.go
+++ b/internal/providers/localcontainer/backend_test.go
@@ -1630,6 +1630,8 @@ func TestListAndResolveContainers(t *testing.T) {
 			commandKey([]string{"inspect", "abcdef1234567890"}): {Stdout: inspectJSON},
 		},
 	}
+	addDefaultLocalContainerScopeResponses(runner)
+	writeLocalContainerReleaseClaim(t, "cbx_123", "abcdef1234567890")
 	b := testBackend(runner)
 
 	views, err := b.List(context.Background(), core.ListRequest{})
@@ -1755,12 +1757,226 @@ func TestReleaseLeaseRemovesStoredKey(t *testing.T) {
 			commandKey([]string{"rm", "-f", "container123"}): {},
 		},
 	}
+	addDefaultLocalContainerScopeResponses(runner)
+	writeLocalContainerReleaseClaim(t, "cbx_release", "container123")
 	b := testBackend(runner)
 	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: "cbx_release", Server: core.Server{CloudID: "container123"}}}); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(keyPath); !os.IsNotExist(err) {
 		t.Fatalf("stored key still exists after release: %v", err)
+	}
+}
+
+func TestReleaseLeaseRejectsUnclaimedContainer(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+		commandKey([]string{"rm", "-f", "unclaimed-container"}): {},
+	}}
+	b := testBackend(runner)
+	err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{
+		LeaseID: "cbx_unclaimed_local_container",
+		Server:  core.Server{CloudID: "unclaimed-container"},
+	}})
+	if err == nil || !strings.Contains(err.Error(), "no exact local claim") {
+		t.Fatalf("ReleaseLease error=%v, want exact-claim rejection", err)
+	}
+	for _, call := range runner.calls {
+		if len(call.Args) > 0 && call.Args[0] == "rm" {
+			t.Fatalf("unclaimed container reached rm: %#v", runner.calls)
+		}
+	}
+}
+
+func TestReleaseLeaseRejectsClaimBoundToDifferentContainerOrScope(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		claimID    string
+		claimScope string
+		targetID   string
+	}{
+		{name: "container", claimID: "owned-container", claimScope: "runtime:docker/context:default", targetID: "other-container"},
+		{name: "runtime scope", claimID: "owned-container", claimScope: "runtime:docker/context:remote", targetID: "owned-container"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+			addDefaultLocalContainerScopeResponses(runner)
+			writeLocalContainerReleaseClaimWithScope(t, "cbx_bound_local_container", tc.claimID, tc.claimScope)
+			b := testBackend(runner)
+			err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{
+				LeaseID: "cbx_bound_local_container",
+				Server:  core.Server{CloudID: tc.targetID},
+			}})
+			if err == nil || !strings.Contains(err.Error(), "current runtime scope") {
+				t.Fatalf("ReleaseLease error=%v, want resource-binding rejection", err)
+			}
+			for _, call := range runner.calls {
+				if len(call.Args) > 0 && call.Args[0] == "rm" {
+					t.Fatalf("mismatched claim reached rm: %#v", runner.calls)
+				}
+			}
+		})
+	}
+}
+
+func TestResolveRawContainerRequiresExplicitReclaimAndPersistsBinding(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	inspectJSON := `[{
+		"Id":"raw-container",
+		"Name":"/crabbox-raw",
+		"Config":{"Image":"ubuntu:24.04","Labels":{"crabbox":"true","provider":"local-container","lease":"cbx_raw_local","slug":"raw-local","state":"ready","ssh_user":"runner","work_root":"/workspace/crabbox"}},
+		"State":{"Status":"running","Running":true},
+		"NetworkSettings":{"Ports":{"2222/tcp":[{"HostIp":"127.0.0.1","HostPort":"49155"}]}}
+	}]`
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+		commandKey([]string{"ps", "-a", "--filter", "label=crabbox=true", "--filter", "label=provider=local-container", "--format", "{{.ID}}"}): {Stdout: "raw-container\n"},
+		commandKey([]string{"inspect", "raw-container"}):  {Stdout: inspectJSON},
+		commandKey([]string{"rm", "-f", "raw-container"}): {},
+	}}
+	addDefaultLocalContainerScopeResponses(runner)
+	b := testBackend(runner)
+	repo := core.Repo{Root: t.TempDir()}
+	if _, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "raw-container", Repo: repo}); err == nil || !strings.Contains(err.Error(), "explicit --reclaim") {
+		t.Fatalf("Resolve without reclaim error=%v", err)
+	}
+	if claim, err := core.ReadLeaseClaim("cbx_raw_local"); err != nil {
+		t.Fatal(err)
+	} else if claim.LeaseID != "" {
+		t.Fatalf("non-reclaim resolve minted claim: %#v", claim)
+	}
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "raw-container", Repo: repo, Reclaim: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim, err := core.ReadLeaseClaim("cbx_raw_local")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claim.CloudID != "raw-container" || claim.ProviderScope != "runtime:docker/context:default" {
+		t.Fatalf("reclaim binding=%#v", claim)
+	}
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+	if !slices.ContainsFunc(runner.calls, func(call core.LocalCommandRequest) bool {
+		return commandKey(call.Args) == commandKey([]string{"rm", "-f", "raw-container"})
+	}) {
+		t.Fatalf("reclaimed container was not released: %#v", runner.calls)
+	}
+}
+
+func TestLegacyLocalContainerClaimRequiresReclaimBeforeStop(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	leaseID := "cbx_legacy_local"
+	if err := writeLocalContainerClaim(t, leaseID, "legacy-local", "runtime:docker/context:default", time.Now().UTC(), time.Minute); err != nil {
+		t.Fatal(err)
+	}
+	inspectJSON := `[{"Id":"legacy-container","Name":"/legacy-container","Config":{"Image":"ubuntu:24.04","Labels":{"crabbox":"true","provider":"local-container","lease":"cbx_legacy_local","slug":"legacy-local","state":"ready","ssh_user":"runner","work_root":"/workspace/crabbox"}},"State":{"Status":"running","Running":true},"NetworkSettings":{"Ports":{"2222/tcp":[{"HostIp":"127.0.0.1","HostPort":"49160"}]}}}]`
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+		commandKey([]string{"ps", "-a", "--filter", "label=crabbox=true", "--filter", "label=provider=local-container", "--format", "{{.ID}}"}): {Stdout: "legacy-container\n"},
+		commandKey([]string{"inspect", "legacy-container"}):  {Stdout: inspectJSON},
+		commandKey([]string{"rm", "-f", "legacy-container"}): {},
+	}}
+	addDefaultLocalContainerScopeResponses(runner)
+	b := testBackend(runner)
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: core.Server{CloudID: "legacy-container"}}}); err == nil || !strings.Contains(err.Error(), "explicit --reclaim") {
+		t.Fatalf("legacy direct stop error=%v", err)
+	}
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: leaseID, Repo: core.Repo{Root: t.TempDir()}, Reclaim: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim, err := core.ReadLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claim.CloudID != "legacy-container" || claim.ProviderScope != "runtime:docker/context:default" {
+		t.Fatalf("legacy reclaim binding=%#v", claim)
+	}
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestResolveReclaimDoesNotRetargetBoundLocalContainerClaim(t *testing.T) {
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	addDefaultLocalContainerScopeResponses(runner)
+	writeLocalContainerReleaseClaim(t, "cbx_bound_local", "container-a")
+	inspectA := `[{"Id":"container-a","Name":"/container-a","Config":{"Image":"ubuntu:24.04","Labels":{"crabbox":"true","provider":"local-container","lease":"cbx_stale_label","slug":"stale-label","state":"ready","ssh_user":"runner","work_root":"/workspace/crabbox"}},"State":{"Status":"running","Running":true},"NetworkSettings":{"Ports":{"2222/tcp":[{"HostIp":"127.0.0.1","HostPort":"49156"}]}}}]`
+	inspectB := `[{"Id":"container-b","Name":"/container-b","Config":{"Image":"ubuntu:24.04","Labels":{"crabbox":"true","provider":"local-container","lease":"cbx_bound_local","slug":"bound-local","state":"ready","ssh_user":"runner","work_root":"/workspace/crabbox"}},"State":{"Status":"running","Running":true},"NetworkSettings":{"Ports":{"2222/tcp":[{"HostIp":"127.0.0.1","HostPort":"49157"}]}}}]`
+	runner.responses[commandKey([]string{"ps", "-a", "--filter", "label=crabbox=true", "--filter", "label=provider=local-container", "--format", "{{.ID}}"})] = core.LocalCommandResult{Stdout: "container-b\ncontainer-a\n"}
+	runner.responses[commandKey([]string{"inspect", "container-a"})] = core.LocalCommandResult{Stdout: inspectA}
+	runner.responses[commandKey([]string{"inspect", "container-b"})] = core.LocalCommandResult{Stdout: inspectB}
+	b := testBackend(runner)
+	repo := core.Repo{Root: t.TempDir()}
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "cbx_bound_local", Repo: repo, Reclaim: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.Server.CloudID != "container-a" || lease.LeaseID != "cbx_bound_local" {
+		t.Fatalf("exact claim resolved container=%q lease=%q, want container-a/cbx_bound_local", lease.Server.CloudID, lease.LeaseID)
+	}
+	if _, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "container-b", Repo: repo, Reclaim: true}); err == nil || !strings.Contains(err.Error(), "bound to container") {
+		t.Fatalf("raw conflicting reclaim error=%v", err)
+	}
+	claim, err := core.ReadLeaseClaim("cbx_bound_local")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claim.CloudID != "container-a" || claim.ProviderScope != "runtime:docker/context:default" {
+		t.Fatalf("bound claim was retargeted: %#v", claim)
+	}
+}
+
+func TestResolveStatusOnlyAllowsClaimlessLocalContainerWithoutClaiming(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	inspectJSON := `[{"Id":"status-container","Name":"/status-container","Config":{"Image":"ubuntu:24.04","Labels":{"crabbox":"true","provider":"local-container","lease":"cbx_status_local","slug":"status-local","state":"ready","ssh_user":"runner","work_root":"/workspace/crabbox"}},"State":{"Status":"running","Running":true},"NetworkSettings":{"Ports":{"2222/tcp":[{"HostIp":"127.0.0.1","HostPort":"49158"}]}}}]`
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+		commandKey([]string{"ps", "-a", "--filter", "label=crabbox=true", "--filter", "label=provider=local-container", "--format", "{{.ID}}"}): {Stdout: "status-container\n"},
+		commandKey([]string{"inspect", "status-container"}): {Stdout: inspectJSON},
+	}}
+	addDefaultLocalContainerScopeResponses(runner)
+	b := testBackend(runner)
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "status-container", Repo: core.Repo{Root: t.TempDir()}, StatusOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.Server.CloudID != "status-container" {
+		t.Fatalf("status lease=%#v", lease)
+	}
+	if claim, err := core.ReadLeaseClaim("cbx_status_local"); err != nil {
+		t.Fatal(err)
+	} else if claim.LeaseID != "" {
+		t.Fatalf("status-only resolve minted claim: %#v", claim)
+	}
+	writeLocalContainerReleaseClaim(t, "cbx_status_local", "status-container")
+	before, err := core.ReadLeaseClaim("cbx_status_local")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "status-container", Repo: core.Repo{Root: t.TempDir()}, StatusOnly: true}); err != nil {
+		t.Fatalf("owned status-only resolve: %v", err)
+	}
+	after, err := core.ReadLeaseClaim("cbx_status_local")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.RepoRoot != before.RepoRoot || after.LastUsedAt != before.LastUsedAt || after.CloudID != before.CloudID || after.ProviderScope != before.ProviderScope {
+		t.Fatalf("status-only resolve mutated claim: before=%#v after=%#v", before, after)
+	}
+}
+
+func TestResolveReclaimRejectsMetadataLessLocalContainer(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	inspectJSON := `[{"Id":"metadata-less","Name":"/metadata-less","Config":{"Image":"ubuntu:24.04","Labels":{"crabbox":"true","provider":"local-container","state":"ready","ssh_user":"runner","work_root":"/workspace/crabbox"}},"State":{"Status":"running","Running":true},"NetworkSettings":{"Ports":{"2222/tcp":[{"HostIp":"127.0.0.1","HostPort":"49159"}]}}}]`
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+		commandKey([]string{"ps", "-a", "--filter", "label=crabbox=true", "--filter", "label=provider=local-container", "--format", "{{.ID}}"}): {Stdout: "metadata-less\n"},
+		commandKey([]string{"inspect", "metadata-less"}): {Stdout: inspectJSON},
+	}}
+	addDefaultLocalContainerScopeResponses(runner)
+	b := testBackend(runner)
+	if _, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "metadata-less", Repo: core.Repo{Root: t.TempDir()}, Reclaim: true}); err == nil || !strings.Contains(err.Error(), "no exact local claim") {
+		t.Fatalf("metadata-less reclaim error=%v", err)
 	}
 }
 
@@ -1847,6 +2063,9 @@ func TestReleaseLeaseRemovesBootstrapDirAfterContainer(t *testing.T) {
 	}
 	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
 	runner.run = func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		if result, ok := defaultLocalContainerScopeResponse(req); ok {
+			return result, nil
+		}
 		if commandKey(req.Args) == commandKey([]string{"rm", "-f", "container123"}) {
 			if _, err := os.Stat(bootstrapDir); err != nil {
 				t.Fatalf("bootstrap directory removed before container teardown: %v", err)
@@ -1854,6 +2073,7 @@ func TestReleaseLeaseRemovesBootstrapDirAfterContainer(t *testing.T) {
 		}
 		return core.LocalCommandResult{}, nil
 	}
+	writeLocalContainerReleaseClaim(t, "cbx_release", "container123")
 	b := testBackend(runner)
 	lease := core.LeaseTarget{
 		LeaseID: "cbx_release",
@@ -1882,6 +2102,8 @@ func TestReleaseLeaseDoesNotRemoveUntrustedBootstrapDir(t *testing.T) {
 			commandKey([]string{"rm", "-f", "container123"}): {},
 		},
 	}
+	addDefaultLocalContainerScopeResponses(runner)
+	writeLocalContainerReleaseClaim(t, "cbx_release", "container123")
 	b := testBackend(runner)
 	lease := core.LeaseTarget{
 		LeaseID: "cbx_release",
@@ -1911,6 +2133,8 @@ func TestReleaseLeaseRemovesDockerSocketHostWorkRoot(t *testing.T) {
 			commandKey([]string{"rm", "-f", "container123"}): {},
 		},
 	}
+	addDefaultLocalContainerScopeResponses(runner)
+	writeLocalContainerReleaseClaim(t, "cbx_release", "container123")
 	b := testBackend(runner)
 	lease := core.LeaseTarget{
 		LeaseID: "cbx_release",
@@ -1954,6 +2178,8 @@ func TestReleaseLeaseWithIDResolvesHostWorkRoot(t *testing.T) {
 			commandKey([]string{"rm", "-f", "container1234567890"}): {},
 		},
 	}
+	addDefaultLocalContainerScopeResponses(runner)
+	writeLocalContainerReleaseClaim(t, "cbx_release", "container1234567890")
 	b := testBackend(runner)
 	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: "cbx_release"}}); err != nil {
 		t.Fatal(err)
@@ -2195,6 +2421,49 @@ func writeLocalContainerClaimAndKey(t *testing.T, leaseID, slug string, scopes .
 		scope = scopes[0]
 	}
 	return writeLocalContainerClaimAndKeyAt(t, leaseID, slug, scope, time.Now().UTC(), time.Minute)
+}
+
+func writeLocalContainerReleaseClaim(t *testing.T, leaseID, containerID string) {
+	writeLocalContainerReleaseClaimWithScope(t, leaseID, containerID, "runtime:docker/context:default")
+}
+
+func writeLocalContainerReleaseClaimWithScope(t *testing.T, leaseID, containerID, scope string) {
+	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	stateHome := os.Getenv("XDG_STATE_HOME")
+	claimDir := filepath.Join(stateHome, "crabbox", "claims")
+	if err := os.MkdirAll(claimDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	data := []byte(`{"leaseID":` + strconv.Quote(leaseID) + `,"slug":"release","provider":` + strconv.Quote(providerName) + `,"cloudID":` + strconv.Quote(containerID) + `,"providerScope":` + strconv.Quote(scope) + `,"repoRoot":` + strconv.Quote(t.TempDir()) + `,"claimedAt":` + strconv.Quote(now) + `,"lastUsedAt":` + strconv.Quote(now) + `,"idleTimeoutSeconds":60}`)
+	if err := os.WriteFile(filepath.Join(claimDir, leaseID+".json"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func defaultLocalContainerScopeResponse(req core.LocalCommandRequest) (core.LocalCommandResult, bool) {
+	switch commandKey(req.Args) {
+	case commandKey([]string{"context", "show"}):
+		return core.LocalCommandResult{Stdout: "default\n"}, true
+	case commandKey([]string{"context", "inspect", "--format", "{{json .Endpoints.docker.Host}}"}):
+		return core.LocalCommandResult{}, true
+	default:
+		return core.LocalCommandResult{}, false
+	}
+}
+
+func addDefaultLocalContainerScopeResponses(runner *recordingRunner) {
+	if runner.responses == nil {
+		runner.responses = map[string]core.LocalCommandResult{}
+	}
+	for _, args := range [][]string{
+		{"context", "show"},
+		{"context", "inspect", "--format", "{{json .Endpoints.docker.Host}}"},
+	} {
+		result, _ := defaultLocalContainerScopeResponse(core.LocalCommandRequest{Args: args})
+		runner.responses[commandKey(args)] = result
+	}
 }
 
 func writeLocalContainerClaimAndKeyAt(t *testing.T, leaseID, slug, scope string, lastUsed time.Time, idle time.Duration) string {


### PR DESCRIPTION
## Summary

- require exact resource-bound claims immediately before Apple Container, local-container, and Apple VZ deletion
- keep ordinary reuse fail-closed; allow explicit `--reclaim` to adopt only unbound resources, never retarget an existing binding
- preserve read-only status without claim mutation and prioritize stored claim identity over stale provider labels
- persist Apple Container endpoint bindings and document the legacy two-step reclaim migration

Fixes https://github.com/openclaw/crabbox/issues/793

## Verification

- `go test ./...`
- `go test -race ./internal/providers/applecontainer ./internal/providers/localcontainer ./internal/providers/applevz ./internal/providers/dockersandbox`
- `go vet ./...`
- `.agents/skills/autoreview/scripts/autoreview --mode local` (clean)
- independent adversarial ownership/reclaim review (clean)
