### PR TITLE
fix(azure): require canonical lease ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Prevented direct Azure list, stop, and cleanup paths from treating weak `crabbox=true` tags as ownership; destructive operations now require canonical Azure ownership tags and an exact matching lease ID. Thanks @coygeek.
 - Restricted brokered Azure image and OS-disk selectors to admin-authenticated requests while preserving user-selectable Azure placement. Thanks @coygeek.
 - Required exact resource-bound local lease claims before Apple Container, local-container, or Apple VZ stop operations can delete provider resources; legacy unbound claims require explicit `--reclaim` adoption before stop. Thanks @coygeek.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
-- Prevented direct Azure list, stop, and cleanup paths from treating weak `crabbox=true` tags as ownership; destructive operations now require canonical Azure ownership tags and an exact matching lease ID. Thanks @coygeek.
+- Prevented direct Azure list, stop, and cleanup paths from treating weak `crabbox=true` tags as ownership; destructive operations now require canonical Azure ownership tags and an exact matching lease ID, and successful deletion removes local lease keys. Thanks @coygeek.
 - Restricted brokered Azure image and OS-disk selectors to admin-authenticated requests while preserving user-selectable Azure placement. Thanks @coygeek.
 - Required exact resource-bound local lease claims before Apple Container, local-container, or Apple VZ stop operations can delete provider resources; legacy unbound claims require explicit `--reclaim` adoption before stop. Thanks @coygeek.
 

--- a/docs/providers/azure.md
+++ b/docs/providers/azure.md
@@ -300,9 +300,11 @@ Azure does not provision macOS through this provider. Use [AWS](aws.md) or
   Crabbox refuses to mutate them unless they carry the `managed_by=crabbox` tag.
   Tag them to adopt, choose different names in `azure.*` config, or let Crabbox
   create dedicated resources.
-- `crabbox stop --provider azure <name>` only acts on VMs that carry `crabbox=true`
-  (and either no `provider` tag or `provider=azure`). A manually named VM in the
-  resource group will not be deleted by Crabbox.
+- Direct Azure list, stop, and cleanup only treat a VM as Crabbox-owned when its
+  tags include `crabbox=true`, `created_by=crabbox`, `provider=azure`, a canonical
+  `cbx_` lease ID, and a non-empty slug. Stop additionally requires the resolved
+  lease ID to match the VM's lease tag. Legacy or manually tagged VMs are skipped;
+  retagging only with `crabbox=true` never authorizes deletion.
 - When `azure.sshCIDRs` is empty on the public network path, direct Azure
   provisioning detects the operator's outbound IPv4 and creates a `/32` SSH
   rule. If a shared NSG already has a different managed SSH CIDR, set

--- a/internal/providers/azure/backend.go
+++ b/internal/providers/azure/backend.go
@@ -127,12 +127,12 @@ func (b *azureLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (Le
 		if !isCrabboxAzureLease(server) {
 			return LeaseTarget{}, exit(4, "lease/server not found: %s (vm exists but is not Crabbox-managed)", req.ID)
 		}
-		leaseID := blank(server.Labels["lease"], req.ID)
+		leaseID := server.Labels["lease"]
 		target := sshTargetFromConfig(b.Cfg, azureServerHost(server, b.Cfg.AzureNetwork))
 		useStoredTestboxKey(&target, leaseID)
 		return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 	}
-	servers, err := client.ListCrabboxServers(ctx)
+	servers, err := listOwnedAzureServers(ctx, client)
 	if err != nil {
 		return LeaseTarget{}, err
 	}
@@ -147,16 +147,13 @@ func (b *azureLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (Le
 }
 
 func isCrabboxAzureLease(server Server) bool {
-	if server.Labels == nil {
-		return false
-	}
-	if server.Labels["crabbox"] != "true" {
-		return false
-	}
-	if provider := server.Labels["provider"]; provider != "" && provider != "azure" {
-		return false
-	}
-	return true
+	labels := server.Labels
+	return labels != nil &&
+		labels["crabbox"] == "true" &&
+		labels["created_by"] == "crabbox" &&
+		labels["provider"] == "azure" &&
+		core.IsCanonicalLeaseID(labels["lease"]) &&
+		strings.TrimSpace(labels["slug"]) != ""
 }
 
 func (b *azureLeaseBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
@@ -165,7 +162,7 @@ func (b *azureLeaseBackend) List(ctx context.Context, req ListRequest) ([]LeaseV
 	if err != nil {
 		return nil, err
 	}
-	return client.ListCrabboxServers(ctx)
+	return listOwnedAzureServers(ctx, client)
 }
 
 func (b *azureLeaseBackend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
@@ -179,6 +176,9 @@ func (b *azureLeaseBackend) Doctor(ctx context.Context, _ core.DoctorRequest) (c
 }
 
 func (b *azureLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
+	if !isCrabboxAzureLease(req.Lease.Server) || req.Lease.LeaseID != req.Lease.Server.Labels["lease"] {
+		return exit(4, "refusing to release Azure VM %s without matching canonical Crabbox ownership tags", req.Lease.Server.DisplayID())
+	}
 	if err := deleteServer(ctx, b.Cfg, req.Lease.Server); err != nil {
 		return err
 	}
@@ -195,11 +195,51 @@ func (b *azureLeaseBackend) Touch(ctx context.Context, req TouchRequest) (Server
 }
 
 func (b *azureLeaseBackend) Cleanup(ctx context.Context, req CleanupRequest) error {
-	servers, err := b.List(ctx, ListRequest{Options: req.Options})
+	client, err := newAzureClient(ctx, b.Cfg)
 	if err != nil {
 		return err
 	}
-	return b.CleanupServers(ctx, req, servers)
+	servers, err := client.ListCrabboxServers(ctx)
+	if err != nil {
+		return err
+	}
+	now := time.Now().UTC()
+	if b.RT.Clock != nil {
+		now = b.RT.Clock.Now().UTC()
+	}
+	for _, server := range servers {
+		if !isCrabboxAzureLease(server) {
+			fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=canonical Crabbox ownership tags missing\n", server.DisplayID(), server.Name)
+			continue
+		}
+		shouldDelete, reason := core.ShouldCleanupServer(server, now)
+		if !shouldDelete {
+			fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=%s\n", server.DisplayID(), server.Name, reason)
+			continue
+		}
+		fmt.Fprintf(b.RT.Stderr, "delete server id=%s name=%s\n", server.DisplayID(), server.Name)
+		if req.DryRun {
+			continue
+		}
+		if err := deleteServer(ctx, b.Cfg, server); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func listOwnedAzureServers(ctx context.Context, client azureClient) ([]Server, error) {
+	servers, err := client.ListCrabboxServers(ctx)
+	if err != nil {
+		return nil, err
+	}
+	owned := make([]Server, 0, len(servers))
+	for _, server := range servers {
+		if isCrabboxAzureLease(server) {
+			owned = append(owned, server)
+		}
+	}
+	return owned, nil
 }
 
 func acquireAttemptsRetry(rt Runtime, keep bool, acquire func() (LeaseTarget, error)) (LeaseTarget, error) {
@@ -231,6 +271,9 @@ func sshTargetFromConfig(cfg Config, host string) SSHTarget {
 var bootstrapManagedWindowsDesktop = core.BootstrapManagedWindowsDesktop
 
 func deleteServer(ctx context.Context, cfg Config, server Server) error {
+	if !isCrabboxAzureLease(server) {
+		return exit(4, "refusing to delete Azure VM %s without canonical Crabbox ownership tags", server.DisplayID())
+	}
 	client, err := newAzureClient(ctx, cfg)
 	if err != nil {
 		return err
@@ -241,7 +284,6 @@ func deleteServer(ctx context.Context, cfg Config, server Server) error {
 	}
 	return client.DeleteServer(ctx, name)
 }
-func blank(value, fallback string) string { return core.Blank(value, fallback) }
 func useStoredTestboxKey(target *SSHTarget, leaseID string) {
 	if keyPath, err := core.TestboxKeyPath(leaseID); err == nil {
 		if _, statErr := os.Stat(keyPath); statErr == nil {

--- a/internal/providers/azure/backend.go
+++ b/internal/providers/azure/backend.go
@@ -183,6 +183,7 @@ func (b *azureLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRe
 		return err
 	}
 	removeLeaseClaim(req.Lease.LeaseID)
+	core.RemoveStoredTestboxKey(req.Lease.LeaseID)
 	return nil
 }
 
@@ -224,6 +225,9 @@ func (b *azureLeaseBackend) Cleanup(ctx context.Context, req CleanupRequest) err
 		if err := deleteServer(ctx, b.Cfg, server); err != nil {
 			return err
 		}
+		leaseID := server.Labels["lease"]
+		removeLeaseClaim(leaseID)
+		core.RemoveStoredTestboxKey(leaseID)
 	}
 	return nil
 }

--- a/internal/providers/azure/backend_test.go
+++ b/internal/providers/azure/backend_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -274,9 +276,38 @@ func TestAzureReleaseRejectsForgedOrMismatchedOwnership(t *testing.T) {
 	}
 }
 
+func TestAzureReleaseRemovesStoredLeaseKey(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	leaseID := "cbx_123456abcdef"
+	keyPath, _, err := core.EnsureTestboxKeyForConfig(Config{}, leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fake := &fakeAzureClient{}
+	oldClient := newAzureClient
+	newAzureClient = func(context.Context, Config) (azureClient, error) { return fake, nil }
+	t.Cleanup(func() { newAzureClient = oldClient })
+
+	lease := LeaseTarget{Server: azureTestServer("crabbox-owned", leaseID, "owned"), LeaseID: leaseID}
+	backend := NewAzureLeaseBackend(ProviderSpec{}, azureAcquireTestConfig(), Runtime{Stderr: io.Discard}).(*azureLeaseBackend)
+	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Dir(keyPath)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("stored lease key directory still exists: %v", err)
+	}
+}
+
 func TestAzureCleanupSkipsWeakTagsAndDeletesCanonicalExpiredVM(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	owned := azureTestServer("crabbox-owned", "cbx_123456abcdef", "owned")
 	owned.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
+	keyPath, _, err := core.EnsureTestboxKeyForConfig(Config{}, owned.Labels["lease"])
+	if err != nil {
+		t.Fatal(err)
+	}
 	weak := azureTestServer("crabbox-weak", "cbx_fedcba654321", "weak")
 	delete(weak.Labels, "created_by")
 	weak.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
@@ -295,6 +326,9 @@ func TestAzureCleanupSkipsWeakTagsAndDeletesCanonicalExpiredVM(t *testing.T) {
 	}
 	if len(fake.deleted) != 1 || fake.deleted[0] != owned.CloudID {
 		t.Fatalf("deleted=%v, want only canonical owned VM", fake.deleted)
+	}
+	if _, err := os.Stat(filepath.Dir(keyPath)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("stored lease key directory still exists: %v", err)
 	}
 }
 

--- a/internal/providers/azure/backend_test.go
+++ b/internal/providers/azure/backend_test.go
@@ -4,7 +4,11 @@ import (
 	"context"
 	"errors"
 	"io"
+	"strings"
 	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 type fakeAzureClient struct {
@@ -16,6 +20,7 @@ type fakeAzureClient struct {
 	createCfg Config
 	createErr error
 	waitErr   error
+	getErr    error
 }
 
 func (c *fakeAzureClient) ListCrabboxServers(context.Context) ([]Server, error) {
@@ -42,8 +47,16 @@ func (c *fakeAzureClient) WaitForServerIP(context.Context, string) (Server, erro
 	return c.created, nil
 }
 
-func (c *fakeAzureClient) GetServer(context.Context, string) (Server, error) {
-	return Server{}, nil
+func (c *fakeAzureClient) GetServer(_ context.Context, id string) (Server, error) {
+	if c.getErr != nil {
+		return Server{}, c.getErr
+	}
+	for _, server := range c.servers {
+		if server.CloudID == id || server.Name == id {
+			return server, nil
+		}
+	}
+	return Server{}, core.Exit(4, "azure vm not found: %s", id)
 }
 
 func (c *fakeAzureClient) DeleteServer(_ context.Context, name string) error {
@@ -183,5 +196,119 @@ func azureAcquireTestConfig() Config {
 		AzureLocation:      "eastus",
 		AzureResourceGroup: "rg",
 		AzureSSHCIDRs:      []string{"198.51.100.7/32"},
+	}
+}
+
+func TestAzureResolveRawVMRejectsWeakTags(t *testing.T) {
+	weak := azureTestServer("crabbox-weak", "cbx_123456abcdef", "weak")
+	delete(weak.Labels, "created_by")
+	fake := &fakeAzureClient{servers: []Server{weak}}
+	oldClient := newAzureClient
+	newAzureClient = func(context.Context, Config) (azureClient, error) { return fake, nil }
+	t.Cleanup(func() { newAzureClient = oldClient })
+
+	backend := NewAzureLeaseBackend(ProviderSpec{}, azureAcquireTestConfig(), Runtime{Stderr: io.Discard}).(*azureLeaseBackend)
+	lease, err := backend.Resolve(context.Background(), ResolveRequest{ID: weak.Name, ReleaseOnly: true})
+	if err == nil || !strings.Contains(err.Error(), "not Crabbox-managed") {
+		t.Fatalf("lease=%#v err=%v, want ownership rejection", lease, err)
+	}
+	if len(fake.deleted) != 0 {
+		t.Fatalf("deleted=%v, want no destructive call", fake.deleted)
+	}
+}
+
+func TestAzureListExcludesWeakTags(t *testing.T) {
+	owned := azureTestServer("crabbox-owned", "cbx_123456abcdef", "owned")
+	weak := azureTestServer("crabbox-weak", "cbx_fedcba654321", "weak")
+	delete(weak.Labels, "provider")
+	fake := &fakeAzureClient{servers: []Server{weak, owned}}
+	oldClient := newAzureClient
+	newAzureClient = func(context.Context, Config) (azureClient, error) { return fake, nil }
+	t.Cleanup(func() { newAzureClient = oldClient })
+
+	backend := NewAzureLeaseBackend(ProviderSpec{}, azureAcquireTestConfig(), Runtime{Stderr: io.Discard}).(*azureLeaseBackend)
+	servers, err := backend.List(context.Background(), ListRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(servers) != 1 || servers[0].CloudID != owned.CloudID {
+		t.Fatalf("servers=%#v, want only canonical owned VM", servers)
+	}
+}
+
+func TestAzureReleaseRejectsForgedOrMismatchedOwnership(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(*LeaseTarget)
+	}{
+		{
+			name: "missing created-by tag",
+			mutate: func(lease *LeaseTarget) {
+				delete(lease.Server.Labels, "created_by")
+			},
+		},
+		{
+			name: "mismatched lease tag",
+			mutate: func(lease *LeaseTarget) {
+				lease.LeaseID = "cbx_fedcba654321"
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fake := &fakeAzureClient{}
+			oldClient := newAzureClient
+			newAzureClient = func(context.Context, Config) (azureClient, error) { return fake, nil }
+			t.Cleanup(func() { newAzureClient = oldClient })
+
+			lease := LeaseTarget{Server: azureTestServer("crabbox-owned", "cbx_123456abcdef", "owned"), LeaseID: "cbx_123456abcdef"}
+			test.mutate(&lease)
+			backend := NewAzureLeaseBackend(ProviderSpec{}, azureAcquireTestConfig(), Runtime{Stderr: io.Discard}).(*azureLeaseBackend)
+			err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease})
+			if err == nil || !strings.Contains(err.Error(), "matching canonical Crabbox ownership tags") {
+				t.Fatalf("err=%v, want ownership rejection", err)
+			}
+			if len(fake.deleted) != 0 {
+				t.Fatalf("deleted=%v, want no destructive call", fake.deleted)
+			}
+		})
+	}
+}
+
+func TestAzureCleanupSkipsWeakTagsAndDeletesCanonicalExpiredVM(t *testing.T) {
+	owned := azureTestServer("crabbox-owned", "cbx_123456abcdef", "owned")
+	owned.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
+	weak := azureTestServer("crabbox-weak", "cbx_fedcba654321", "weak")
+	delete(weak.Labels, "created_by")
+	weak.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
+	fake := &fakeAzureClient{servers: []Server{weak, owned}}
+	oldClient := newAzureClient
+	newAzureClient = func(context.Context, Config) (azureClient, error) { return fake, nil }
+	t.Cleanup(func() { newAzureClient = oldClient })
+
+	var stderr strings.Builder
+	backend := NewAzureLeaseBackend(ProviderSpec{}, azureAcquireTestConfig(), Runtime{Stderr: &stderr}).(*azureLeaseBackend)
+	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stderr.String(), "skip server id=crabbox-weak") || !strings.Contains(stderr.String(), "canonical Crabbox ownership tags missing") {
+		t.Fatalf("stderr=%q, want weak-tag skip diagnostic", stderr.String())
+	}
+	if len(fake.deleted) != 1 || fake.deleted[0] != owned.CloudID {
+		t.Fatalf("deleted=%v, want only canonical owned VM", fake.deleted)
+	}
+}
+
+func azureTestServer(id, leaseID, slug string) Server {
+	return Server{
+		CloudID:  id,
+		Name:     id,
+		Provider: "azure",
+		Labels: map[string]string{
+			"crabbox":    "true",
+			"created_by": "crabbox",
+			"provider":   "azure",
+			"lease":      leaseID,
+			"slug":       slug,
+		},
 	}
 }

--- a/internal/providers/azure/provider_test.go
+++ b/internal/providers/azure/provider_test.go
@@ -7,8 +7,15 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-func TestIsCrabboxAzureLeaseRequiresProviderTag(t *testing.T) {
+func TestIsCrabboxAzureLeaseRequiresCanonicalTags(t *testing.T) {
 	t.Parallel()
+	canonical := map[string]string{
+		"crabbox":    "true",
+		"created_by": "crabbox",
+		"provider":   "azure",
+		"lease":      "cbx_123456abcdef",
+		"slug":       "owned",
+	}
 	cases := []struct {
 		name   string
 		labels map[string]string
@@ -17,8 +24,9 @@ func TestIsCrabboxAzureLeaseRequiresProviderTag(t *testing.T) {
 		{name: "nil labels", labels: nil, want: false},
 		{name: "no crabbox tag", labels: map[string]string{"managed_by": "crabbox"}, want: false},
 		{name: "different provider", labels: map[string]string{"crabbox": "true", "provider": "aws"}, want: false},
-		{name: "tagged azure", labels: map[string]string{"crabbox": "true", "provider": "azure"}, want: true},
-		{name: "tagged no provider", labels: map[string]string{"crabbox": "true"}, want: true},
+		{name: "weak azure tags", labels: map[string]string{"crabbox": "true", "provider": "azure"}, want: false},
+		{name: "missing provider", labels: map[string]string{"crabbox": "true", "created_by": "crabbox", "lease": "cbx_123456abcdef", "slug": "owned"}, want: false},
+		{name: "canonical", labels: canonical, want: true},
 	}
 	for _, tc := range cases {
 		tc := tc


### PR DESCRIPTION
Closes https://github.com/openclaw/crabbox/issues/796

## Summary

- require the full canonical Azure ownership label set before direct inventory or resolution treats a VM as Crabbox-managed
- require the resolved lease ID to match the VM lease tag before release
- re-check canonical ownership at the destructive delete boundary and skip weak-tagged VMs during cleanup
- remove local lease keys and claims only after confirmed provider deletion
- document the fail-closed legacy behavior and add regression coverage for weak-tag denial, canonical cleanup, and key removal

## Verification

- exact head: `b6cc8f4a59b444c6bcf0702fbe01a2109b014021`
- `go test -race ./internal/providers/azure ./internal/providers/aws ./internal/providers/shared`
- `go test -race ./internal/cli -run 'TestAzure' -count=1`
- `go test -race ./...`
- `go vet ./...`
- `scripts/check-docs.sh`
- Worker format, lint, typecheck, 758 tests, and dry-run build
- `.agents/skills/autoreview/scripts/autoreview --mode local --parallel-tests 'go test -race ./...'` — clean, no actionable findings; patch correct 0.88

## Live Azure proof

Exact head `b6cc8f4a59b444c6bcf0702fbe01a2109b014021`, 2026-07-03:

- created a direct on-demand `Standard_D2s_v5` Linux lease in a dedicated resource group and reached Crabbox's SSH-ready gate
- reused the lease with `crabbox run --id`, wrote/read/removed a remote marker, and verified Linux command execution
- confirmed the canonical lease appeared in `crabbox list`
- replaced its ownership tags with weak `crabbox=true` and `provider=azure` labels only: list excluded it, raw-ID stop failed closed with exit 4, cleanup logged the canonical-ownership skip, and Azure confirmed the VM remained
- restored the exact provider/resource/lease binding, then candidate stop deleted the VM and its disk, NIC, and public IP
- verified the local claim, private key, public key, and known-hosts directory were absent after candidate stop
- deleted the dedicated resource group and verified it absent, leaving zero provider or local residue

No credentials are stored by this change. AI-assisted: yes.
