### PR TITLE
fix(worker): compare static secrets in constant time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Compared coordinator admin, shared-operator, runtime-adapter, proxy, and signed-session secrets without mismatch-position or early length exits. Thanks @coygeek.
 - Prevented direct Azure list, stop, and cleanup paths from treating weak `crabbox=true` tags as ownership; destructive operations now require canonical Azure ownership tags and an exact matching lease ID, and successful deletion removes local lease keys. Thanks @coygeek.
 - Restricted brokered Azure image and OS-disk selectors to admin-authenticated requests while preserving user-selectable Azure placement. Thanks @coygeek.
 - Required exact resource-bound local lease claims before Apple Container, local-container, or Apple VZ stop operations can delete provider resources; legacy unbound claims require explicit `--reclaim` adoption before stop. Thanks @coygeek.

--- a/worker/src/auth.ts
+++ b/worker/src/auth.ts
@@ -1,4 +1,5 @@
 import { bearerToken } from "./http";
+import { timingSafeEqual } from "./timing-safe";
 import type { Env } from "./types";
 
 const tokenPrefix = "cbxu_";
@@ -62,7 +63,7 @@ export async function authenticateRequest(
 ): Promise<AuthContext | undefined> {
   const token = bearerToken(request);
   const trustedIdentity = context.trustedProxy ? trustedProxyIdentity(request, env) : undefined;
-  if (env.CRABBOX_ADMIN_TOKEN && token === env.CRABBOX_ADMIN_TOKEN) {
+  if (env.CRABBOX_ADMIN_TOKEN && timingSafeEqual(token ?? "", env.CRABBOX_ADMIN_TOKEN)) {
     const accessIdentity = await verifiedAccessIdentity(request, env).catch(() => undefined);
     return {
       authorized: true,
@@ -76,7 +77,7 @@ export async function authenticateRequest(
       org: request.headers.get("x-crabbox-org") ?? env.CRABBOX_DEFAULT_ORG ?? "unknown",
     };
   }
-  if (env.CRABBOX_SHARED_TOKEN && token === env.CRABBOX_SHARED_TOKEN) {
+  if (env.CRABBOX_SHARED_TOKEN && timingSafeEqual(token ?? "", env.CRABBOX_SHARED_TOKEN)) {
     const accessIdentity = await verifiedAccessIdentity(request, env).catch(() => undefined);
     return {
       authorized: true,
@@ -215,7 +216,7 @@ async function verifyUserToken(
   }
   const { encodedPayload, signature } = parts;
   const expected = await sign(encodedPayload, sessionSecret(env));
-  if (!constantTimeEqual(signature, expected)) {
+  if (!timingSafeEqual(signature, expected)) {
     return undefined;
   }
   const payload = decodeUserTokenPayload(token);
@@ -274,7 +275,10 @@ export function userTokenSigningConfigurationError(
   if (!env.CRABBOX_SESSION_SECRET) {
     return "CRABBOX_SESSION_SECRET is required for signed user tokens";
   }
-  if (env.CRABBOX_SHARED_TOKEN && env.CRABBOX_SESSION_SECRET === env.CRABBOX_SHARED_TOKEN) {
+  if (
+    env.CRABBOX_SHARED_TOKEN &&
+    timingSafeEqual(env.CRABBOX_SESSION_SECRET, env.CRABBOX_SHARED_TOKEN)
+  ) {
     return "CRABBOX_SESSION_SECRET must differ from CRABBOX_SHARED_TOKEN";
   }
   return undefined;
@@ -296,7 +300,7 @@ function trustedProxyIdentity(
   if (
     requiredSecret !== undefined &&
     (!requiredSecret ||
-      !constantTimeEqual(request.headers.get("x-crabbox-proxy-secret") ?? "", requiredSecret))
+      !timingSafeEqual(request.headers.get("x-crabbox-proxy-secret") ?? "", requiredSecret))
   ) {
     return undefined;
   }
@@ -619,15 +623,4 @@ function base64URLDecode(value: string): Uint8Array {
     out[i] = binary.charCodeAt(i);
   }
   return out;
-}
-
-function constantTimeEqual(a: string, b: string): boolean {
-  if (a.length !== b.length) {
-    return false;
-  }
-  let diff = 0;
-  for (let i = 0; i < a.length; i += 1) {
-    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
-  }
-  return diff === 0;
 }

--- a/worker/src/coordinator-entry.ts
+++ b/worker/src/coordinator-entry.ts
@@ -8,6 +8,7 @@ import {
 import { codeProxyRequestBodyBytes, isIsolatedCodeRequest } from "./code-origin";
 import { bearerToken, json, pathParts } from "./http";
 import { runtimeAdapterProxyPath, runtimeAdapterRelayMethodAllowed } from "./runtime-adapter-relay";
+import { timingSafeEqual } from "./timing-safe";
 import type { Env } from "./types";
 
 export type CoordinatorFetch = (request: Request) => Promise<Response>;
@@ -155,7 +156,7 @@ function runtimeAdapterServiceAuth(
     return undefined;
   }
   const expected = env.CRABBOX_RUNTIME_ADAPTER_TOKEN?.trim();
-  if (!expected || bearerToken(request) !== expected) {
+  if (!expected || !timingSafeEqual(bearerToken(request) ?? "", expected)) {
     return undefined;
   }
   return {

--- a/worker/src/timing-safe.ts
+++ b/worker/src/timing-safe.ts
@@ -1,0 +1,10 @@
+export function timingSafeEqual(a: string, b: string): boolean {
+  let difference = a.length ^ b.length;
+  const length = Math.max(a.length, b.length);
+
+  for (let index = 0; index < length; index += 1) {
+    difference |= (a.charCodeAt(index) | 0) ^ (b.charCodeAt(index) | 0);
+  }
+
+  return difference === 0;
+}

--- a/worker/test/http.test.ts
+++ b/worker/test/http.test.ts
@@ -60,10 +60,22 @@ describe("coordinator auth", () => {
 
   it("requires the configured bearer token", async () => {
     const denied = new Request("https://example.test/v1/pool");
+    const wrongSameLength = new Request("https://example.test/v1/pool", {
+      headers: { authorization: "Bearer secres" },
+    });
+    const wrongLength = new Request("https://example.test/v1/pool", {
+      headers: { authorization: "Bearer secret-extra" },
+    });
     const allowed = new Request("https://example.test/v1/pool", {
       headers: { authorization: "Bearer secret" },
     });
     await expect(isAuthorized(denied, { CRABBOX_SHARED_TOKEN: "secret" })).resolves.toBe(false);
+    await expect(isAuthorized(wrongSameLength, { CRABBOX_SHARED_TOKEN: "secret" })).resolves.toBe(
+      false,
+    );
+    await expect(isAuthorized(wrongLength, { CRABBOX_SHARED_TOKEN: "secret" })).resolves.toBe(
+      false,
+    );
     await expect(isAuthorized(allowed, { CRABBOX_SHARED_TOKEN: "secret" })).resolves.toBe(true);
   });
 

--- a/worker/test/timing-safe-auth.test.ts
+++ b/worker/test/timing-safe-auth.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+import { timingSafeEqual } from "../src/timing-safe";
+
+describe("timing-safe authentication", () => {
+  it("preserves exact string equality semantics", () => {
+    expect(timingSafeEqual("", "")).toBe(true);
+    expect(timingSafeEqual("shared-secret", "shared-secret")).toBe(true);
+    expect(timingSafeEqual("Shared-secret", "shared-secret")).toBe(false);
+    expect(timingSafeEqual("shared-secreu", "shared-secret")).toBe(false);
+    expect(timingSafeEqual("shared-secret-extra", "shared-secret")).toBe(false);
+    expect(timingSafeEqual("shared", "shared-secret")).toBe(false);
+  });
+
+  it("keeps static coordinator secrets off direct string comparisons", () => {
+    const authSource = readFileSync(new URL("../src/auth.ts", import.meta.url), "utf8");
+    const coordinatorSource = readFileSync(
+      new URL("../src/coordinator-entry.ts", import.meta.url),
+      "utf8",
+    );
+
+    expect(authSource).not.toMatch(/token\s*={2,3}\s*env\.CRABBOX_(?:ADMIN|SHARED)_TOKEN/);
+    expect(coordinatorSource).not.toMatch(/bearerToken\([^)]*\)\s*!={1,2}\s*expected/);
+    expect(`${authSource}\n${coordinatorSource}`).not.toMatch(
+      /env\.CRABBOX_[A-Z_]*(?:TOKEN|SECRET)\s*(?:={2,3}|!={1,2})/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- use one full-scan comparison helper for coordinator admin, shared-operator, runtime-adapter, trusted-proxy, and signed-session secrets
- fold length differences into the comparison result instead of returning early
- add semantic regression coverage and a source guard against direct static-secret comparisons
- document the security fix in the changelog

Closes https://github.com/openclaw/crabbox/issues/805

## Verification

- `npm test --prefix worker` — 26 files, 760 tests passed
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm run check:node --prefix worker`
- `npm run build --prefix worker`
- autoreview — no accepted or actionable findings

## Live proof

Exact commit `91a3e791416bd925248debff4144c10e369fbb4c` was deployed as a disposable Cloudflare Worker with independent ephemeral admin, shared-operator, and runtime-adapter credentials.

- valid shared credential: authenticated `GET /v1/whoami` with the configured non-admin identity
- valid admin credential: authenticated `GET /v1/whoami` with admin scope
- valid runtime-adapter credential: crossed the service-auth boundary and reached the expected missing-workspace `404`
- same-length near misses for all three credentials: `401`
- wrong-length variants for all three credentials: `401`
- missing credential: `401`

The disposable Worker, its Durable Object state, and local ephemeral credential files were deleted after the matrix passed. Its former URL now returns `404`.
