### PR TITLE
fix: bind RunPod release to exact claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,6 @@
 - Required exact resource-bound local lease claims before Apple Container, local-container, or Apple VZ stop operations can delete provider resources; legacy unbound claims require explicit `--reclaim` adoption before stop. Thanks @coygeek.
 - Hardened Azure Windows snapshot forks to fail closed through credential rehydration and quarantine cleanup, reuse only writable NIC payloads, reject unknown differential disks, and retry in-use security-group cleanup. Thanks @fcoury-oai.
 - Rolled back brokered Hetzner servers when post-create readiness fails, deleting only lease-owned SSH keys created by the failed attempt after server cleanup succeeds while preserving explicit no-delete retention until a later delete. Thanks @coygeek.
-- Required an exact resource-bound local claim before RunPod stop can terminate a pod, with explicit conflict-safe `--reclaim` adoption and a fresh provider identity check at deletion. Thanks @coygeek.
 
 ## 0.34.0 - 2026-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 - Required W&B sandbox reuse, status, and stop to match an exact endpoint/entity/project/resource-bound local claim plus provider inventory ownership. Thanks @coygeek.
+- Required RunPod stop to use an exact pod ID/name-bound local claim, with conflict-safe explicit `--reclaim` adoption for unclaimed or legacy pods. Thanks @coygeek.
 - Made coordinatorless generic provider live smokes skip coordinator-only history and always clean up acquired leases after later lifecycle failures.
 - Replaced privileged managed Linux Code Server and Tailscale installer scripts with checksum-verified archives or Tailscale's signed package repository with a pinned keyring in both CLI and coordinator bootstrap paths. Thanks @TurboTheTurtle.
 
@@ -36,7 +37,6 @@
 - Reported Apple VZ helper startup failures deterministically instead of racing them into misleading readiness timeouts. Thanks @coygeek.
 - Preserved the configured controller identity binding when rendering redacted configuration and launching controller subprocesses.
 - Released checkpoint forks with a fresh cleanup context after post-acquire provisioning failures or caller cancellation. Thanks @yetval.
-- Required RunPod stop to use an exact pod ID/name-bound local claim, with conflict-safe explicit `--reclaim` adoption for unclaimed or legacy pods. Thanks @coygeek.
 - Required canonical Hetzner labels plus an exact server-bound local claim before direct stop or cleanup can delete a server, and kept canonical lease IDs from falling through to slug or name aliases. Thanks @coygeek.
 - Kept WebVNC framebuffer and heartbeat traffic responsive while desktop themes apply, and fully detached long-lived Wayland wallpaper processes from their launching SSH sessions.
 - Required an exact local or explicit `stop --reclaim` deployment claim before stopping an out-of-band Railway service, binding adoption to the configured endpoint, project, environment, service, and deployment. Thanks @coygeek.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - Required exact resource-bound local lease claims before Apple Container, local-container, or Apple VZ stop operations can delete provider resources; legacy unbound claims require explicit `--reclaim` adoption before stop. Thanks @coygeek.
 - Hardened Azure Windows snapshot forks to fail closed through credential rehydration and quarantine cleanup, reuse only writable NIC payloads, reject unknown differential disks, and retry in-use security-group cleanup. Thanks @fcoury-oai.
 - Rolled back brokered Hetzner servers when post-create readiness fails, deleting only lease-owned SSH keys created by the failed attempt after server cleanup succeeds while preserving explicit no-delete retention until a later delete. Thanks @coygeek.
+- Required an exact resource-bound local claim before RunPod stop can terminate a pod, with explicit conflict-safe `--reclaim` adoption and a fresh provider identity check at deletion. Thanks @coygeek.
 
 ## 0.34.0 - 2026-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Reported Apple VZ helper startup failures deterministically instead of racing them into misleading readiness timeouts. Thanks @coygeek.
 - Preserved the configured controller identity binding when rendering redacted configuration and launching controller subprocesses.
 - Released checkpoint forks with a fresh cleanup context after post-acquire provisioning failures or caller cancellation. Thanks @yetval.
+- Required RunPod stop to use an exact pod ID/name-bound local claim, with conflict-safe explicit `--reclaim` adoption for unclaimed or legacy pods. Thanks @coygeek.
 - Required canonical Hetzner labels plus an exact server-bound local claim before direct stop or cleanup can delete a server, and kept canonical lease IDs from falling through to slug or name aliases. Thanks @coygeek.
 - Kept WebVNC framebuffer and heartbeat traffic responsive while desktop themes apply, and fully detached long-lived Wayland wallpaper processes from their launching SSH sessions.
 - Required an exact local or explicit `stop --reclaim` deployment claim before stopping an out-of-band Railway service, binding adoption to the configured endpoint, project, environment, service, and deployment. Thanks @coygeek.

--- a/docs/commands/stop.md
+++ b/docs/commands/stop.md
@@ -56,6 +56,10 @@ Crabbox lease ID and local slug:
   name, or local slug and deletes the Freestyle VM. Claimless canonical names
   remain visible to status/list but cannot be deleted until explicit
   `--reclaim` reuse persists a claim.
+- `runpod` — accepts a lease ID, pod ID, pod name, or local slug only when an
+  exact local claim binds that RunPod id and provider-returned name. Unclaimed
+  and legacy pods remain visible to status/list but require explicit
+  `--reclaim` reuse before deletion.
 - `e2b` — accepts a Crabbox lease ID, a local slug, or a Crabbox-owned E2B
   sandbox ID in raw or `e2b_<sandboxID>` form and deletes the E2B sandbox.
 - `railway` — refuses unclaimed service IDs. Use `--reclaim` only after

--- a/docs/providers/runpod.md
+++ b/docs/providers/runpod.md
@@ -43,12 +43,17 @@ not manage that key.
 
 - **Acquire** — deploys a pod named `crabbox-<slug>-<leaseSuffix>`, then waits
   for the public TCP mapping for port 22.
-- **Resolve** — looks up an existing pod by lease id, pod id, or pod name.
+- **Resolve** — read-only status can look up a pod by lease id, pod id, or pod
+  name. Reusing an existing pod requires an exact local claim bound to its
+  RunPod id and name; use `--reclaim` once to adopt an unclaimed or legacy pod
+  explicitly.
 - **List** — enumerates the caller's pods via `GET /v1/pods` and filters to the
   `crabbox-` prefix unless `--all` is set.
-- **Release** — calls `DELETE /v1/pods/{id}`, terminating the pod immediately.
-- **Doctor** — runs read-only pod-list checks only; it never creates a pod, so
-  it is safe to run on every CI invocation.
+- **Release** — requires the exact resource-bound local claim, fetches the pod
+  again to match its id and name, then calls `DELETE /v1/pods/{id}`. Raw ids,
+  names, and legacy claims alone cannot terminate a pod.
+- **Doctor** — runs read-only identity and pod-list checks; it never creates a
+  pod, so it is safe to run on every CI invocation.
 
 ## Capabilities
 
@@ -153,8 +158,11 @@ CRABBOX_RUNPOD_WORK_ROOT
 
 Pods are terminated immediately on release. If `--keep` is set, the pod stays
 up and keeps accruing cost until you terminate it. Run
-`crabbox list --provider runpod` to spot leaked pods, and
-`crabbox stop --provider runpod <id>` to clean them up.
+`crabbox list --provider runpod` to spot leaked pods. A Crabbox-claimed pod can
+be cleaned up with `crabbox stop --provider runpod <id>`. Adopt an unclaimed
+pod first through a supported reuse command such as
+`crabbox run --provider runpod --id <pod-id> --reclaim -- true`, or terminate
+it directly in RunPod.
 
 ## Gotchas
 

--- a/internal/cli/provider_exports.go
+++ b/internal/cli/provider_exports.go
@@ -174,10 +174,11 @@ func VerifyLeaseClaimUnchanged(leaseID string, expected LeaseClaim) error {
 	return verifyLeaseClaimUnchanged(leaseID, expected)
 }
 
+// RemoveLeaseClaimIfUnchangedAfter holds the claim lock across action and
+// removes the claim only when it still matches expected.
 func RemoveLeaseClaimIfUnchangedAfter(leaseID string, expected LeaseClaim, action func() error) error {
 	return removeLeaseClaimIfUnchangedAfter(leaseID, expected, action)
 }
-
 func RestoreLeaseClaimIfUnchanged(leaseID string, current, previous LeaseClaim, previousExists bool) error {
 	return restoreLeaseClaimIfUnchanged(leaseID, current, previous, previousExists)
 }

--- a/internal/providers/runpod/backend.go
+++ b/internal/providers/runpod/backend.go
@@ -183,6 +183,15 @@ func (b *runpodLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (L
 	} else {
 		pod, leaseID, slug, err = b.resolveUnclaimedPod(ctx, client, req.ID)
 		if err == nil {
+			var legacy bool
+			claim, legacy, err = findRunpodClaimForPodName(pod)
+			if err == nil && legacy {
+				claimed = true
+				leaseID = claim.LeaseID
+				slug = claim.Slug
+			}
+		}
+		if err == nil {
 			err = ensureRunpodAdoptionDoesNotRetargetClaim(leaseID, pod)
 		}
 	}
@@ -470,6 +479,27 @@ func resolveRunpodClaim(identifier string) (LeaseClaim, bool, error) {
 		return match, true, nil
 	}
 	return resolveLeaseClaimForProvider(identifier, providerName)
+}
+
+func findRunpodClaimForPodName(pod runpodPod) (LeaseClaim, bool, error) {
+	claims, err := listLeaseClaims()
+	if err != nil {
+		return LeaseClaim{}, false, err
+	}
+	_, podSlug := runpodLeaseIdentity(pod.Name)
+	var match LeaseClaim
+	for _, claim := range claims {
+		if claim.Provider != providerName ||
+			normalizeLeaseSlug(claim.Slug) != normalizeLeaseSlug(podSlug) ||
+			leaseProviderName(claim.LeaseID, claim.Slug) != pod.Name {
+			continue
+		}
+		if match.LeaseID != "" {
+			return LeaseClaim{}, false, exit(2, "multiple provider=%s claims match pod name %s", providerName, pod.Name)
+		}
+		match = claim
+	}
+	return match, match.LeaseID != "", nil
 }
 
 func ensureRunpodAdoptionDoesNotRetargetClaim(leaseID string, pod runpodPod) error {

--- a/internal/providers/runpod/backend.go
+++ b/internal/providers/runpod/backend.go
@@ -110,6 +110,12 @@ func (b *runpodLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (L
 		}
 		return LeaseTarget{}, err
 	}
+	if err := validateCreatedRunpodPod(ready, pod.ID, name); err != nil {
+		if !req.Keep {
+			err = b.cleanupFailedAcquire(client, pod.ID, err)
+		}
+		return LeaseTarget{}, err
+	}
 
 	lease, err := b.prepareLease(ctx, cfg, ready, leaseID, slug, req.Keep, true)
 	if err != nil {
@@ -118,7 +124,7 @@ func (b *runpodLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (L
 		}
 		return LeaseTarget{}, err
 	}
-	if err := claimLeaseForRepoProvider(leaseID, slug, providerName, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
+	if err := claimLeaseTargetForRepoConfig(leaseID, slug, cfg, lease.Server, lease.SSH, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
 		if !req.Keep {
 			err = b.cleanupFailedAcquire(client, pod.ID, err)
 		}
@@ -147,19 +153,51 @@ func (b *runpodLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (L
 	if err != nil {
 		return LeaseTarget{}, err
 	}
-	pod, leaseID, slug, err := b.resolvePod(ctx, client, req.ID)
+	if req.ReleaseOnly {
+		claim, ok, err := resolveRunpodClaim(req.ID)
+		if err != nil {
+			return LeaseTarget{}, err
+		}
+		if !ok {
+			return LeaseTarget{}, unclaimedRunpodError(req.ID)
+		}
+		pod, err := b.resolveClaimedPod(ctx, client, claim, true)
+		if err != nil {
+			return LeaseTarget{}, err
+		}
+		return LeaseTarget{Server: runpodServer(pod, claim.LeaseID, claim.Slug, cfg, true), LeaseID: claim.LeaseID}, nil
+	}
+	claim, claimed, err := resolveRunpodClaim(req.ID)
 	if err != nil {
 		return LeaseTarget{}, err
 	}
-	if req.ReleaseOnly {
-		return LeaseTarget{Server: runpodServer(pod, leaseID, slug, cfg, true), LeaseID: leaseID}, nil
+	var (
+		pod     runpodPod
+		leaseID string
+		slug    string
+	)
+	if claimed {
+		pod, err = b.resolveClaimedPod(ctx, client, claim, false)
+		leaseID = claim.LeaseID
+		slug = blank(claim.Slug, newLeaseSlug(claim.LeaseID))
+	} else {
+		pod, leaseID, slug, err = b.resolveUnclaimedPod(ctx, client, req.ID)
+		if err == nil {
+			err = ensureRunpodAdoptionDoesNotRetargetClaim(leaseID, pod)
+		}
+	}
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	if req.Repo.Root != "" && (!claimed || !runpodClaimIsBound(claim)) && !req.Reclaim {
+		return LeaseTarget{}, exit(2, "runpod pod %s is not bound to an exact local claim; retry with --reclaim to adopt it", pod.ID)
 	}
 	lease, err := b.prepareLease(ctx, cfg, pod, leaseID, slug, true, false)
 	if err != nil {
 		return LeaseTarget{}, err
 	}
 	if req.Repo.Root != "" {
-		if err := claimLeaseForRepoProvider(leaseID, slug, providerName, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
+		if err := claimLeaseTargetForRepoConfig(leaseID, slug, cfg, lease.Server, lease.SSH, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
 			return LeaseTarget{}, err
 		}
 	}
@@ -200,23 +238,40 @@ func (b *runpodLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseR
 	if err != nil {
 		return err
 	}
-	podID := strings.TrimSpace(req.Lease.Server.CloudID)
-	if podID == "" {
-		// Fall back to a fresh resolve so release works against legacy lease
-		// records that only carry the lease id.
-		pod, _, _, err := b.resolvePod(ctx, client, req.Lease.LeaseID)
+	identifier := strings.TrimSpace(req.Lease.LeaseID)
+	if identifier == "" {
+		identifier = strings.TrimSpace(req.Lease.Server.CloudID)
+	}
+	if identifier == "" {
+		identifier = strings.TrimSpace(req.Lease.Server.Name)
+	}
+	claim, ok, err := resolveRunpodClaim(identifier)
+	if err != nil {
+		return err
+	}
+	if !ok || !runpodClaimIsBound(claim) {
+		return unclaimedRunpodError(identifier)
+	}
+	if leaseID := strings.TrimSpace(req.Lease.LeaseID); leaseID != "" && leaseID != claim.LeaseID {
+		return exit(2, "runpod release lease %s does not match bound claim %s", leaseID, claim.LeaseID)
+	}
+	if podID := strings.TrimSpace(req.Lease.Server.CloudID); podID != "" && podID != claim.CloudID {
+		return exit(2, "runpod release pod %s does not match bound claim pod %s", podID, claim.CloudID)
+	}
+	err = removeLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, func() error {
+		pod, err := b.resolveClaimedPod(ctx, client, claim, true)
 		if err != nil {
 			return err
 		}
-		podID = pod.ID
+		if err := client.TerminatePod(ctx, pod.ID); err != nil {
+			return exit(1, "runpod terminate pod %s failed: %v", pod.ID, err)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
-	if podID == "" {
-		return exit(2, "provider=%s release requires a pod id", providerName)
-	}
-	if err := client.TerminatePod(ctx, podID); err != nil {
-		return exit(1, "runpod terminate pod %s failed: %v", podID, err)
-	}
-	removeLeaseClaim(req.Lease.LeaseID)
+	removeStoredTestboxKey(claim.LeaseID)
 	return nil
 }
 
@@ -376,18 +431,104 @@ func runpodBootstrapToolsCommand() string {
 	}, "\n")
 }
 
-func (b *runpodLeaseBackend) resolvePod(ctx context.Context, client runpodAPI, identifier string) (runpodPod, string, string, error) {
+func resolveRunpodClaim(identifier string) (LeaseClaim, bool, error) {
+	identifier = strings.TrimSpace(identifier)
+	if identifier == "" {
+		return LeaseClaim{}, false, exit(2, "provider=%s requires --id <pod-id-or-lease>", providerName)
+	}
+	if claim, ok, exact, err := resolveLeaseClaimForProviderWithExact(identifier, providerName); err != nil {
+		return LeaseClaim{}, false, err
+	} else if exact && !ok {
+		return LeaseClaim{}, false, exit(2, "local claim %s belongs to provider=%s, not provider=%s", identifier, blank(claim.Provider, "<unknown>"), providerName)
+	} else if exact {
+		return claim, true, nil
+	}
+	if claim, ok, err := resolveLeaseClaimForProviderCloudID(identifier, providerName); err != nil {
+		return LeaseClaim{}, false, err
+	} else if ok {
+		return claim, true, nil
+	}
+	claims, err := listLeaseClaims()
+	if err != nil {
+		return LeaseClaim{}, false, err
+	}
+	var match LeaseClaim
+	for _, claim := range claims {
+		if claim.Provider != providerName || strings.TrimSpace(claim.Labels["name"]) != identifier {
+			continue
+		}
+		if match.LeaseID != "" {
+			return LeaseClaim{}, false, exit(2, "multiple provider=%s claims match pod name %s", providerName, identifier)
+		}
+		match = claim
+	}
+	if match.LeaseID != "" {
+		return match, true, nil
+	}
+	return resolveLeaseClaimForProvider(identifier, providerName)
+}
+
+func ensureRunpodAdoptionDoesNotRetargetClaim(leaseID string, pod runpodPod) error {
+	claim, ok, exact, err := resolveLeaseClaimForProviderWithExact(leaseID, providerName)
+	if err != nil {
+		return err
+	}
+	if !exact {
+		return nil
+	}
+	if !ok {
+		return exit(2, "cannot adopt RunPod pod %s as lease %s because that local claim belongs to provider=%s", pod.ID, leaseID, blank(claim.Provider, "<unknown>"))
+	}
+	if !runpodClaimIsBound(claim) {
+		return nil
+	}
+	if claim.CloudID != pod.ID || strings.TrimSpace(claim.Labels["name"]) != pod.Name {
+		return exit(2, "cannot retarget RunPod claim %s from pod %s (%s) to pod %s (%s)", claim.LeaseID, claim.CloudID, claim.Labels["name"], pod.ID, pod.Name)
+	}
+	return nil
+}
+
+func runpodClaimIsBound(claim LeaseClaim) bool {
+	return claim.Provider == providerName &&
+		strings.TrimSpace(claim.LeaseID) != "" &&
+		strings.TrimSpace(claim.CloudID) != "" &&
+		strings.TrimSpace(claim.Labels["name"]) != ""
+}
+
+func (b *runpodLeaseBackend) resolveClaimedPod(ctx context.Context, client runpodAPI, claim LeaseClaim, requireBound bool) (runpodPod, error) {
+	bound := runpodClaimIsBound(claim)
+	if requireBound && !bound {
+		return runpodPod{}, unclaimedRunpodError(claim.LeaseID)
+	}
+	var (
+		pod runpodPod
+		err error
+	)
+	if strings.TrimSpace(claim.CloudID) != "" {
+		pod, err = client.GetPod(ctx, claim.CloudID)
+	} else {
+		slug := blank(claim.Slug, newLeaseSlug(claim.LeaseID))
+		pod, err = b.findPodByName(ctx, client, leaseProviderName(claim.LeaseID, slug))
+	}
+	if err != nil {
+		return runpodPod{}, err
+	}
+	if !bound {
+		return pod, nil
+	}
+	if pod.ID != claim.CloudID {
+		return runpodPod{}, exit(2, "runpod claim %s expects pod %s but provider returned %s", claim.LeaseID, claim.CloudID, blank(pod.ID, "<empty>"))
+	}
+	if name := strings.TrimSpace(claim.Labels["name"]); pod.Name != name {
+		return runpodPod{}, exit(2, "runpod claim %s expects pod name %s but provider returned %s", claim.LeaseID, name, blank(pod.Name, "<empty>"))
+	}
+	return pod, nil
+}
+
+func (b *runpodLeaseBackend) resolveUnclaimedPod(ctx context.Context, client runpodAPI, identifier string) (runpodPod, string, string, error) {
 	identifier = strings.TrimSpace(identifier)
 	if identifier == "" {
 		return runpodPod{}, "", "", exit(2, "provider=%s requires --id <pod-id-or-lease>", providerName)
-	}
-	if claim, ok, err := resolveLeaseClaimForProvider(identifier, providerName); err != nil {
-		return runpodPod{}, "", "", err
-	} else if ok {
-		slug := blank(claim.Slug, newLeaseSlug(claim.LeaseID))
-		name := leaseProviderName(claim.LeaseID, slug)
-		pod, err := b.findPodByName(ctx, client, name)
-		return pod, claim.LeaseID, slug, err
 	}
 	if strings.HasPrefix(identifier, "cbx_") {
 		pod, ok, err := b.findPodByLeaseName(ctx, client, identifier)
@@ -415,6 +556,20 @@ func (b *runpodLeaseBackend) resolvePod(ctx context.Context, client runpodAPI, i
 	}
 	leaseID, slug := runpodLeaseIdentity(pod.Name)
 	return pod, leaseID, slug, nil
+}
+
+func unclaimedRunpodError(identifier string) error {
+	return exit(2, "runpod pod %s has no exact resource-bound local claim; adopt it from a reuse command with --reclaim before stopping it", blank(strings.TrimSpace(identifier), "<unknown>"))
+}
+
+func validateCreatedRunpodPod(pod runpodPod, expectedID, expectedName string) error {
+	if strings.TrimSpace(expectedID) == "" || pod.ID != expectedID {
+		return exit(1, "runpod create returned pod %s but readiness resolved %s", blank(expectedID, "<empty>"), blank(pod.ID, "<empty>"))
+	}
+	if strings.TrimSpace(expectedName) == "" || pod.Name != expectedName {
+		return exit(1, "runpod create expected pod name %s but readiness returned %s", blank(expectedName, "<empty>"), blank(pod.Name, "<empty>"))
+	}
+	return nil
 }
 
 func (b *runpodLeaseBackend) findPodByName(ctx context.Context, client runpodAPI, name string) (runpodPod, error) {

--- a/internal/providers/runpod/backend.go
+++ b/internal/providers/runpod/backend.go
@@ -442,6 +442,10 @@ func resolveRunpodClaim(identifier string) (LeaseClaim, bool, error) {
 		return LeaseClaim{}, false, exit(2, "local claim %s belongs to provider=%s, not provider=%s", identifier, blank(claim.Provider, "<unknown>"), providerName)
 	} else if exact {
 		return claim, true, nil
+	} else if ok {
+		// A local lease alias is stronger evidence of operator intent than a
+		// different claim whose provider ID or pod name happens to collide.
+		return claim, true, nil
 	}
 	if claim, ok, err := resolveLeaseClaimForProviderCloudID(identifier, providerName); err != nil {
 		return LeaseClaim{}, false, err

--- a/internal/providers/runpod/backend.go
+++ b/internal/providers/runpod/backend.go
@@ -577,11 +577,30 @@ func (b *runpodLeaseBackend) findPodByName(ctx context.Context, client runpodAPI
 	if err != nil {
 		return runpodPod{}, err
 	}
-	normalized := normalizeLeaseSlug(name)
+	exact := make([]runpodPod, 0, 1)
 	for _, pod := range pods {
-		if pod.Name == name || normalizeLeaseSlug(pod.Name) == normalized || pod.ID == name {
-			return pod, nil
+		if pod.Name == name || pod.ID == name {
+			exact = append(exact, pod)
 		}
+	}
+	if len(exact) == 1 {
+		return exact[0], nil
+	}
+	if len(exact) > 1 {
+		return runpodPod{}, exit(2, "multiple RunPod pods match exact identifier %s", name)
+	}
+	normalized := normalizeLeaseSlug(name)
+	matches := make([]runpodPod, 0, 1)
+	for _, pod := range pods {
+		if normalizeLeaseSlug(pod.Name) == normalized {
+			matches = append(matches, pod)
+		}
+	}
+	if len(matches) == 1 {
+		return matches[0], nil
+	}
+	if len(matches) > 1 {
+		return runpodPod{}, exit(2, "multiple RunPod pods match normalized name %s", name)
 	}
 	return runpodPod{}, exit(4, "runpod pod not found: %s", name)
 }
@@ -591,10 +610,17 @@ func (b *runpodLeaseBackend) findPodByLeaseName(ctx context.Context, client runp
 	if err != nil {
 		return runpodPod{}, false, err
 	}
+	matches := make([]runpodPod, 0, 1)
 	for _, pod := range pods {
 		if id, _ := runpodLeaseIdentity(pod.Name); id == leaseID {
-			return pod, true, nil
+			matches = append(matches, pod)
 		}
+	}
+	if len(matches) == 1 {
+		return matches[0], true, nil
+	}
+	if len(matches) > 1 {
+		return runpodPod{}, false, exit(2, "multiple RunPod pods match lease %s", leaseID)
 	}
 	return runpodPod{}, false, nil
 }

--- a/internal/providers/runpod/backend_test.go
+++ b/internal/providers/runpod/backend_test.go
@@ -690,6 +690,44 @@ func TestRunpodLegacyClaimRequiresReclaimToBindExactPod(t *testing.T) {
 	}
 }
 
+func TestRunpodReclaimByPodIDUpgradesLegacySlugClaim(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	const leaseID = "cbx_abcdef123456"
+	const slug = "blue"
+	repo := core.Repo{Root: t.TempDir()}
+	if err := core.ClaimLeaseForRepoProvider(leaseID, slug, providerName, repo.Root, 0, false); err != nil {
+		t.Fatal(err)
+	}
+	pod := runpodPod{ID: "pod-legacy", Name: leaseProviderName(leaseID, slug), DesiredStatus: "RUNNING"}
+	fake := &fakeRunpodAPI{getPod: func(string) (runpodPod, error) { return pod, nil }}
+	backend := &runpodLeaseBackend{cfg: Config{Runpod: RunpodConfig{APIKey: "k"}}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: fake}
+
+	lease, err := backend.Resolve(context.Background(), ResolveRequest{ID: pod.ID, Repo: repo, Reclaim: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.LeaseID != leaseID {
+		t.Fatalf("leaseID=%q, want legacy claim %q", lease.LeaseID, leaseID)
+	}
+	claims, err := core.ListLeaseClaims()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(claims) != 1 || claims[0].LeaseID != leaseID || claims[0].CloudID != pod.ID || claims[0].Labels["name"] != pod.Name {
+		t.Fatalf("claims=%#v, want one upgraded legacy claim", claims)
+	}
+	releaseLease, err := backend.Resolve(context.Background(), ResolveRequest{ID: slug, ReleaseOnly: true})
+	if err != nil {
+		t.Fatalf("resolve upgraded claim by slug: %v", err)
+	}
+	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: releaseLease}); err != nil {
+		t.Fatalf("release upgraded claim by slug: %v", err)
+	}
+	if len(fake.terminated) != 1 || fake.terminated[0] != pod.ID {
+		t.Fatalf("terminated=%v, want %s", fake.terminated, pod.ID)
+	}
+}
+
 func TestRunpodReleaseLeaseRechecksBoundClaimAndTerminatesPod(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	pod := runpodPod{ID: "pod_z", Name: "crabbox-blue-abcdef12", DesiredStatus: "RUNNING"}

--- a/internal/providers/runpod/backend_test.go
+++ b/internal/providers/runpod/backend_test.go
@@ -593,6 +593,45 @@ func TestRunpodReclaimCannotRetargetBoundClaim(t *testing.T) {
 	}
 }
 
+func TestRunpodFindPodByNamePrefersExactMatchOverNormalizedAlias(t *testing.T) {
+	fake := &fakeRunpodAPI{listPods: []runpodPod{
+		{ID: "pod_alias", Name: "manual_pod"},
+		{ID: "pod_exact", Name: "manual-pod"},
+	}}
+	backend := &runpodLeaseBackend{}
+	pod, err := backend.findPodByName(context.Background(), fake, "manual-pod")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pod.ID != "pod_exact" {
+		t.Fatalf("pod=%#v, want exact name match", pod)
+	}
+}
+
+func TestRunpodFindPodByNameRejectsAmbiguousNormalizedAlias(t *testing.T) {
+	fake := &fakeRunpodAPI{listPods: []runpodPod{
+		{ID: "pod_a", Name: "manual_pod"},
+		{ID: "pod_b", Name: "manual.pod"},
+	}}
+	backend := &runpodLeaseBackend{}
+	_, err := backend.findPodByName(context.Background(), fake, "manual-pod")
+	if err == nil || !strings.Contains(err.Error(), "multiple RunPod pods match normalized name") {
+		t.Fatalf("err=%v, want ambiguous normalized-name refusal", err)
+	}
+}
+
+func TestRunpodFindPodByLeaseNameRejectsAmbiguousIdentity(t *testing.T) {
+	fake := &fakeRunpodAPI{listPods: []runpodPod{
+		{ID: "pod_a", Name: "crabbox-blue-abcdef12"},
+		{ID: "pod_b", Name: "crabbox-green-abcdef12"},
+	}}
+	backend := &runpodLeaseBackend{}
+	_, _, err := backend.findPodByLeaseName(context.Background(), fake, "rpod_abcdef12")
+	if err == nil || !strings.Contains(err.Error(), "multiple RunPod pods match lease") {
+		t.Fatalf("err=%v, want ambiguous lease-identity refusal", err)
+	}
+}
+
 func TestRunpodLegacyClaimRequiresReclaimToBindExactPod(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	const leaseID = "rpod_abcdef12"

--- a/internal/providers/runpod/backend_test.go
+++ b/internal/providers/runpod/backend_test.go
@@ -544,6 +544,36 @@ func TestRunpodResolveReleaseOnlyRejectsUnclaimedPodWithoutProviderLookup(t *tes
 	}
 }
 
+func TestRunpodResolveReleaseOnlyPrefersLocalSlugOverProviderAlias(t *testing.T) {
+	tests := []struct {
+		name       string
+		identifier string
+		pod        runpodPod
+	}{
+		{name: "provider id", identifier: "pod-collision", pod: runpodPod{ID: "pod-collision", Name: "crabbox-remote-456789ab", DesiredStatus: "RUNNING"}},
+		{name: "pod name", identifier: "name-collision", pod: runpodPod{ID: "pod-remote", Name: "name-collision", DesiredStatus: "RUNNING"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			if err := core.ClaimLeaseForRepoProvider("rpod_local123", tt.identifier, providerName, t.TempDir(), 0, false); err != nil {
+				t.Fatal(err)
+			}
+			claimRunpodPod(t, "rpod_456789ab", "remote", tt.pod)
+			fake := &fakeRunpodAPI{getPod: func(string) (runpodPod, error) { return tt.pod, nil }}
+			backend := &runpodLeaseBackend{cfg: Config{Runpod: RunpodConfig{APIKey: "k"}}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: fake}
+
+			_, err := backend.Resolve(context.Background(), ResolveRequest{ID: tt.identifier, ReleaseOnly: true})
+			if err == nil || !strings.Contains(err.Error(), "no exact resource-bound local claim") {
+				t.Fatalf("err=%v, want local slug claim refusal", err)
+			}
+			if len(fake.getCalls) != 0 || len(fake.terminated) != 0 {
+				t.Fatalf("getCalls=%v terminated=%v, want no access to the colliding pod", fake.getCalls, fake.terminated)
+			}
+		})
+	}
+}
+
 func TestRunpodResolveRequiresExplicitReclaimBeforeBindingPod(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	pod := runpodPod{ID: "pod_manual", Name: "manual-pod", DesiredStatus: "RUNNING"}

--- a/internal/providers/runpod/backend_test.go
+++ b/internal/providers/runpod/backend_test.go
@@ -323,6 +323,7 @@ type fakeRunpodAPI struct {
 	whoamiCalls  int
 	listCalls    int
 	deployCalls  []runpodDeployInput
+	getCalls     []string
 	terminated   []string
 	listPods     []runpodPod
 	getPod       func(string) (runpodPod, error)
@@ -343,10 +344,15 @@ func (f *fakeRunpodAPI) DeployPod(_ context.Context, input runpodDeployInput) (r
 	return f.deployPod, nil
 }
 func (f *fakeRunpodAPI) GetPod(_ context.Context, podID string) (runpodPod, error) {
-	if f.getPod != nil {
-		return f.getPod(podID)
+	f.mu.Lock()
+	f.getCalls = append(f.getCalls, podID)
+	getPod := f.getPod
+	deployPod := f.deployPod
+	f.mu.Unlock()
+	if getPod != nil {
+		return getPod(podID)
 	}
-	return f.deployPod, nil
+	return deployPod, nil
 }
 func (f *fakeRunpodAPI) ListPods(_ context.Context) ([]runpodPod, error) {
 	f.mu.Lock()
@@ -486,29 +492,203 @@ func TestRunpodAcquireRollbackCannotBlockForever(t *testing.T) {
 		pollTimeoutOverride:    5 * time.Millisecond,
 		cleanupTimeoutOverride: 20 * time.Millisecond,
 	}
-	start := time.Now()
-
 	_, err := backend.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: t.TempDir()}})
 	if err == nil || !strings.Contains(err.Error(), "cleanup failed") || !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("err=%v, want bounded cleanup deadline error", err)
-	}
-	if elapsed := time.Since(start); elapsed > time.Second {
-		t.Fatalf("Acquire took %s, cleanup should be bounded", elapsed)
 	}
 	if len(fake.terminated) != 1 || fake.terminated[0] != "pod_blocked" {
 		t.Fatalf("terminated=%v", fake.terminated)
 	}
 }
 
-func TestRunpodReleaseLeaseTerminatesPod(t *testing.T) {
+func TestRunpodAcquireRejectsMismatchedReadyPodAndRollsBack(t *testing.T) {
+	fake := &fakeRunpodAPI{
+		deployPod: runpodPod{ID: "pod_created", Name: "crabbox-blue-12345678"},
+		getPod: func(string) (runpodPod, error) {
+			return runpodPod{
+				ID:            "pod_other",
+				Name:          "crabbox-blue-12345678",
+				DesiredStatus: "RUNNING",
+				Runtime: &runpodRuntime{Ports: []runpodRuntimePort{{
+					IP: "203.0.113.9", PrivatePort: 22, PublicPort: 41200, IsIPPublic: true, Type: "tcp",
+				}}},
+			}, nil
+		},
+	}
+	backend := &runpodLeaseBackend{
+		cfg:    Config{Runpod: RunpodConfig{APIKey: "k"}},
+		rt:     Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		client: fake,
+	}
+
+	_, err := backend.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: t.TempDir()}})
+	if err == nil || !strings.Contains(err.Error(), "readiness resolved pod_other") {
+		t.Fatalf("err=%v, want create/readiness identity mismatch", err)
+	}
+	if len(fake.terminated) != 1 || fake.terminated[0] != "pod_created" {
+		t.Fatalf("terminated=%v, want exact created pod rollback", fake.terminated)
+	}
+}
+
+func TestRunpodResolveReleaseOnlyRejectsUnclaimedPodWithoutProviderLookup(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := &fakeRunpodAPI{}
 	backend := &runpodLeaseBackend{cfg: Config{Runpod: RunpodConfig{APIKey: "k"}}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: fake}
-	req := ReleaseLeaseRequest{Lease: LeaseTarget{Server: Server{CloudID: "pod_z"}, LeaseID: "rpod_abcdef12"}}
+
+	_, err := backend.Resolve(context.Background(), ResolveRequest{ID: "pod_manual", ReleaseOnly: true})
+	if err == nil || !strings.Contains(err.Error(), "no exact resource-bound local claim") {
+		t.Fatalf("err=%v, want unclaimed refusal", err)
+	}
+	if len(fake.getCalls) != 0 || len(fake.terminated) != 0 {
+		t.Fatalf("getCalls=%v terminated=%v, want no provider mutation path", fake.getCalls, fake.terminated)
+	}
+}
+
+func TestRunpodResolveRequiresExplicitReclaimBeforeBindingPod(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	pod := runpodPod{ID: "pod_manual", Name: "manual-pod", DesiredStatus: "RUNNING"}
+	fake := &fakeRunpodAPI{getPod: func(string) (runpodPod, error) { return pod, nil }}
+	backend := &runpodLeaseBackend{cfg: Config{Runpod: RunpodConfig{APIKey: "k"}}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: fake}
+	repo := core.Repo{Root: t.TempDir()}
+
+	_, err := backend.Resolve(context.Background(), ResolveRequest{ID: pod.ID, Repo: repo})
+	if err == nil || !strings.Contains(err.Error(), "retry with --reclaim") {
+		t.Fatalf("err=%v, want explicit reclaim requirement", err)
+	}
+	if _, exists, err := core.ReadLeaseClaimWithPresence("rpod_manual-pod"); err != nil || exists {
+		t.Fatalf("claim before reclaim: exists=%v err=%v", exists, err)
+	}
+
+	lease, err := backend.Resolve(context.Background(), ResolveRequest{ID: pod.ID, Repo: repo, Reclaim: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim, exists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+	if err != nil || !exists {
+		t.Fatalf("claim after reclaim: exists=%v err=%v", exists, err)
+	}
+	if claim.Provider != providerName || claim.CloudID != pod.ID || claim.Labels["name"] != pod.Name {
+		t.Fatalf("claim=%#v, want exact provider/id/name binding", claim)
+	}
+}
+
+func TestRunpodReclaimCannotRetargetBoundClaim(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	claimed := runpodPod{ID: "pod_original", Name: "manual-pod", DesiredStatus: "RUNNING"}
+	claimRunpodPod(t, "rpod_manual-pod", "manual-pod", claimed)
+	replacement := runpodPod{ID: "pod_replacement", Name: claimed.Name, DesiredStatus: "RUNNING"}
+	fake := &fakeRunpodAPI{getPod: func(string) (runpodPod, error) { return replacement, nil }}
+	backend := &runpodLeaseBackend{cfg: Config{Runpod: RunpodConfig{APIKey: "k"}}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: fake}
+
+	_, err := backend.Resolve(context.Background(), ResolveRequest{ID: replacement.ID, Repo: core.Repo{Root: t.TempDir()}, Reclaim: true})
+	if err == nil || !strings.Contains(err.Error(), "cannot retarget RunPod claim") {
+		t.Fatalf("err=%v, want retarget refusal", err)
+	}
+	claim, err := core.ReadLeaseClaim("rpod_manual-pod")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claim.CloudID != claimed.ID || claim.Labels["name"] != claimed.Name {
+		t.Fatalf("claim=%#v, want original resource binding", claim)
+	}
+}
+
+func TestRunpodLegacyClaimRequiresReclaimToBindExactPod(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	const leaseID = "rpod_abcdef12"
+	const slug = "blue"
+	repo := core.Repo{Root: t.TempDir()}
+	if err := core.ClaimLeaseForRepoProvider(leaseID, slug, providerName, repo.Root, 0, false); err != nil {
+		t.Fatal(err)
+	}
+	pod := runpodPod{ID: "pod_legacy", Name: leaseProviderName(leaseID, slug), DesiredStatus: "RUNNING"}
+	fake := &fakeRunpodAPI{listPods: []runpodPod{pod}}
+	backend := &runpodLeaseBackend{cfg: Config{Runpod: RunpodConfig{APIKey: "k"}}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: fake}
+
+	_, err := backend.Resolve(context.Background(), ResolveRequest{ID: leaseID, Repo: repo})
+	if err == nil || !strings.Contains(err.Error(), "retry with --reclaim") {
+		t.Fatalf("err=%v, want legacy claim reclaim requirement", err)
+	}
+	if _, err := backend.Resolve(context.Background(), ResolveRequest{ID: leaseID, Repo: repo, Reclaim: true}); err != nil {
+		t.Fatal(err)
+	}
+	claim, err := core.ReadLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claim.CloudID != pod.ID || claim.Labels["name"] != pod.Name {
+		t.Fatalf("claim=%#v, want exact pod binding", claim)
+	}
+}
+
+func TestRunpodReleaseLeaseRechecksBoundClaimAndTerminatesPod(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	pod := runpodPod{ID: "pod_z", Name: "crabbox-blue-abcdef12", DesiredStatus: "RUNNING"}
+	claimRunpodPod(t, "rpod_abcdef12", "blue", pod)
+	fake := &fakeRunpodAPI{getPod: func(string) (runpodPod, error) { return pod, nil }}
+	backend := &runpodLeaseBackend{cfg: Config{Runpod: RunpodConfig{APIKey: "k"}}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: fake}
+	req := ReleaseLeaseRequest{Lease: LeaseTarget{Server: Server{CloudID: pod.ID}, LeaseID: "rpod_abcdef12"}}
 	if err := backend.ReleaseLease(context.Background(), req); err != nil {
 		t.Fatal(err)
 	}
-	if len(fake.terminated) != 1 || fake.terminated[0] != "pod_z" {
-		t.Fatalf("terminated=%v", fake.terminated)
+	if len(fake.getCalls) != 1 || fake.getCalls[0] != pod.ID || len(fake.terminated) != 1 || fake.terminated[0] != pod.ID {
+		t.Fatalf("getCalls=%v terminated=%v", fake.getCalls, fake.terminated)
+	}
+	if _, exists, err := core.ReadLeaseClaimWithPresence("rpod_abcdef12"); err != nil || exists {
+		t.Fatalf("claim after release: exists=%v err=%v", exists, err)
+	}
+}
+
+func TestRunpodReleaseLeaseRejectsResourceOutsideBoundClaim(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	pod := runpodPod{ID: "pod_owned", Name: "crabbox-blue-abcdef12", DesiredStatus: "RUNNING"}
+	claimRunpodPod(t, "rpod_abcdef12", "blue", pod)
+	fake := &fakeRunpodAPI{getPod: func(string) (runpodPod, error) { return pod, nil }}
+	backend := &runpodLeaseBackend{cfg: Config{Runpod: RunpodConfig{APIKey: "k"}}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: fake}
+
+	err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{
+		Server:  Server{CloudID: "pod_other"},
+		LeaseID: "rpod_abcdef12",
+	}})
+	if err == nil || !strings.Contains(err.Error(), "does not match bound claim pod") {
+		t.Fatalf("err=%v, want forged resource refusal", err)
+	}
+	if len(fake.getCalls) != 0 || len(fake.terminated) != 0 {
+		t.Fatalf("getCalls=%v terminated=%v, want no provider mutation", fake.getCalls, fake.terminated)
+	}
+}
+
+func TestRunpodReleaseLeaseRejectsProviderNameMismatch(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	claimed := runpodPod{ID: "pod_owned", Name: "crabbox-blue-abcdef12", DesiredStatus: "RUNNING"}
+	claimRunpodPod(t, "rpod_abcdef12", "blue", claimed)
+	changed := claimed
+	changed.Name = "renamed-outside-crabbox"
+	fake := &fakeRunpodAPI{getPod: func(string) (runpodPod, error) { return changed, nil }}
+	backend := &runpodLeaseBackend{cfg: Config{Runpod: RunpodConfig{APIKey: "k"}}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: fake}
+
+	err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{
+		Server:  Server{CloudID: claimed.ID},
+		LeaseID: "rpod_abcdef12",
+	}})
+	if err == nil || !strings.Contains(err.Error(), "expects pod name") {
+		t.Fatalf("err=%v, want provider identity mismatch", err)
+	}
+	if len(fake.terminated) != 0 {
+		t.Fatalf("terminated=%v, want no termination", fake.terminated)
+	}
+	if _, exists, err := core.ReadLeaseClaimWithPresence("rpod_abcdef12"); err != nil || !exists {
+		t.Fatalf("claim after refusal: exists=%v err=%v", exists, err)
+	}
+}
+
+func claimRunpodPod(t *testing.T, leaseID, slug string, pod runpodPod) {
+	t.Helper()
+	cfg := Config{Provider: providerName}
+	applyRunpodDefaults(&cfg)
+	server := runpodServer(pod, leaseID, slug, cfg, true)
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, runpodSSHTarget(cfg, pod), t.TempDir(), 0, false); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/internal/providers/runpod/core.go
+++ b/internal/providers/runpod/core.go
@@ -27,6 +27,7 @@ type LeaseTarget = core.LeaseTarget
 type Server = core.Server
 type SSHTarget = core.SSHTarget
 type TailscaleConfig = core.TailscaleConfig
+type LeaseClaim = core.LeaseClaim
 
 const (
 	providerName  = "runpod"
@@ -66,16 +67,32 @@ func allocateDirectLeaseSlug(leaseID, requested string, servers []Server) (strin
 	return core.AllocateDirectLeaseSlug(leaseID, requested, servers)
 }
 
-func claimLeaseForRepoProvider(leaseID, slug, provider, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
-	return core.ClaimLeaseForRepoProvider(leaseID, slug, provider, repoRoot, idleTimeout, reclaim)
+func claimLeaseTargetForRepoConfig(leaseID, slug string, cfg Config, server Server, target SSHTarget, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
+	return core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, target, repoRoot, idleTimeout, reclaim)
 }
 
 func resolveLeaseClaimForProvider(identifier, provider string) (core.LeaseClaim, bool, error) {
 	return core.ResolveLeaseClaimForProvider(identifier, provider)
 }
 
-func removeLeaseClaim(leaseID string) {
-	core.RemoveLeaseClaim(leaseID)
+func resolveLeaseClaimForProviderWithExact(identifier, provider string) (core.LeaseClaim, bool, bool, error) {
+	return core.ResolveLeaseClaimForProviderWithExact(identifier, provider)
+}
+
+func resolveLeaseClaimForProviderCloudID(cloudID, provider string) (core.LeaseClaim, bool, error) {
+	return core.ResolveLeaseClaimForProviderCloudID(cloudID, provider)
+}
+
+func listLeaseClaims() ([]core.LeaseClaim, error) {
+	return core.ListLeaseClaims()
+}
+
+func removeLeaseClaimIfUnchangedAfter(leaseID string, expected core.LeaseClaim, action func() error) error {
+	return core.RemoveLeaseClaimIfUnchangedAfter(leaseID, expected, action)
+}
+
+func removeStoredTestboxKey(leaseID string) {
+	core.RemoveStoredTestboxKey(leaseID)
 }
 
 func directLeaseLabels(cfg Config, leaseID, slug, provider, market string, keep bool, now time.Time) map[string]string {

--- a/scripts/live-runpod-smoke.sh
+++ b/scripts/live-runpod-smoke.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+provider_enabled() {
+  local list="${CRABBOX_LIVE_PROVIDERS:-runpod}"
+  local item
+  IFS=',' read -ra items <<<"$list"
+  for item in "${items[@]}"; do
+    item="${item//[[:space:]]/}"
+    if [[ "$item" == "runpod" || "$item" == "run-pod" || "$item" == "runpodio" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+classify_blocker() {
+  local command="$1"
+  local status="$2"
+  local output="$3"
+  local classification="environment_blocked"
+  local lower
+  lower="$(printf '%s' "$output" | tr '[:upper:]' '[:lower:]')"
+  if [[ "$lower" == *quota* || "$lower" == *"rate limit"* || "$lower" == *capacity* || "$lower" == *"insufficient funds"* || "$lower" == *"account limit"* ]]; then
+    classification="quota_blocked"
+  fi
+  printf 'classification=%s command=%q exit=%s\n' "$classification" "$command" "$status" >&2
+  printf '%s\n' "$output" >&2
+}
+
+classify_validation_failure() {
+  local command="$1"
+  local status="$2"
+  local output="$3"
+  printf 'classification=validation_failed command=%q exit=%s\n' "$command" "$status" >&2
+  printf '%s\n' "$output" >&2
+}
+
+run_capture() {
+  local command="$1"
+  shift
+  local output
+  set +e
+  output="$("$@" 2>&1)"
+  local status=$?
+  set -e
+  if [ "$status" -ne 0 ]; then
+    classify_blocker "$command" "$status" "$output"
+    exit "$status"
+  fi
+  printf '%s\n' "$output"
+}
+
+validate_list_json_contains_slug() {
+  local command="$1"
+  local output="$2"
+  local validation_output=""
+  local status=0
+  set +e
+  validation_output="$(CRABBOX_SMOKE_SLUG="$slug" python3 -c '
+import json
+import os
+import sys
+
+slug = os.environ["CRABBOX_SMOKE_SLUG"]
+try:
+    payload = json.load(sys.stdin)
+except Exception as exc:
+    print(f"invalid JSON: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+def has_slug(value):
+    if isinstance(value, dict):
+        labels = value.get("labels")
+        if isinstance(labels, dict) and labels.get("slug") == slug:
+            return True
+        return any(has_slug(child) for child in value.values())
+    if isinstance(value, list):
+        return any(has_slug(child) for child in value)
+    return False
+
+if not has_slug(payload):
+    print(f"list JSON did not include slug {slug}", file=sys.stderr)
+    sys.exit(1)
+' <<<"$output" 2>&1)"
+  status=$?
+  set -e
+  if [ "$status" -ne 0 ]; then
+    classify_validation_failure "$command" "$status" "$validation_output"
+    exit "$status"
+  fi
+}
+
+validate_list_json_empty() {
+  local command="$1"
+  local output="$2"
+  local validation_output=""
+  local status=0
+  set +e
+  validation_output="$(python3 -c '
+import json
+import sys
+
+try:
+    payload = json.load(sys.stdin)
+except Exception as exc:
+    print(f"invalid JSON: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+if payload != []:
+    print("RunPod Crabbox inventory is not empty", file=sys.stderr)
+    sys.exit(1)
+' <<<"$output" 2>&1)"
+  status=$?
+  set -e
+  if [ "$status" -ne 0 ]; then
+    classify_validation_failure "$command" "$status" "$validation_output"
+    exit "$status"
+  fi
+}
+
+raw_runpod_delete_slug() {
+  CRABBOX_SMOKE_SLUG="$slug" python3 -c '
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+slug = os.environ["CRABBOX_SMOKE_SLUG"]
+token = os.environ["RUNPOD_API_KEY"]
+base_url = os.environ.get("CRABBOX_RUNPOD_API_URL") or os.environ.get("RUNPOD_API_URL") or "https://rest.runpod.io/v1"
+url = base_url.rstrip("/") + "/pods"
+prefix = f"crabbox-{slug}-"
+
+def request(method="GET", target=url):
+    req = urllib.request.Request(
+        target,
+        method=method,
+        headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=30) as response:
+        if method == "GET":
+            return json.load(response)
+        return None
+
+try:
+    pods = request()
+    matches = [pod for pod in pods if str(pod.get("name", "")).startswith(prefix)]
+    if len(matches) > 1:
+        print(f"multiple RunPod pods match cleanup slug {slug}", file=sys.stderr)
+        sys.exit(3)
+    if not matches:
+        sys.exit(0)
+    pod_id = str(matches[0].get("id", "")).strip()
+    if not pod_id:
+        print(f"RunPod cleanup match for {slug} has no id", file=sys.stderr)
+        sys.exit(3)
+    request("DELETE", url + "/" + urllib.parse.quote(pod_id, safe=""))
+    for _ in range(30):
+        pods = request()
+        if not any(str(pod.get("name", "")).startswith(prefix) for pod in pods):
+            sys.exit(0)
+        time.sleep(2)
+except urllib.error.HTTPError as exc:
+    print(f"RunPod cleanup HTTP {exc.code}", file=sys.stderr)
+except Exception as exc:
+    print(f"RunPod cleanup failed: {exc}", file=sys.stderr)
+sys.exit(1)
+'
+}
+
+cleanup_armed=0
+slug="runpod-smoke-$(date +%Y%m%d%H%M%S)-$$"
+crabbox_bin="${CRABBOX_BIN:-bin/crabbox}"
+config_file=""
+state_root=""
+
+cleanup() {
+  local status=$?
+  if [ "$cleanup_armed" -eq 1 ]; then
+    local cleanup_output=""
+    local cleanup_status=1
+    set +e
+    cleanup_output="$("$crabbox_bin" stop --provider runpod "$slug" 2>&1)"
+    cleanup_status=$?
+    set -e
+    if [ "$cleanup_status" -ne 0 ]; then
+      set +e
+      cleanup_output="$(raw_runpod_delete_slug 2>&1)"
+      cleanup_status=$?
+      set -e
+    fi
+    if [ "$cleanup_status" -ne 0 ]; then
+      printf 'classification=cleanup_failed command=%q exit=%s slug=%s\n' "$crabbox_bin stop --provider runpod $slug" "$cleanup_status" "$slug" >&2
+      printf '%s\n' "$cleanup_output" >&2
+      if [ "$status" -eq 0 ]; then
+        status="$cleanup_status"
+      fi
+    fi
+  fi
+  if [ -n "$config_file" ]; then
+    rm -f "$config_file"
+  fi
+  if [ -n "$state_root" ]; then
+    rm -rf "$state_root"
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
+
+if [[ "${CRABBOX_LIVE:-}" != "1" ]]; then
+  printf 'classification=environment_blocked reason=CRABBOX_LIVE_not_enabled\n'
+  exit 0
+fi
+
+if ! provider_enabled; then
+  printf 'classification=environment_blocked reason=runpod_not_selected providers=%q\n' "${CRABBOX_LIVE_PROVIDERS:-}"
+  exit 0
+fi
+
+runpod_api_key="${CRABBOX_RUNPOD_API_KEY:-${RUNPOD_API_KEY:-}}"
+if [[ -z "$runpod_api_key" ]]; then
+  printf 'classification=environment_blocked reason=RUNPOD_API_KEY_missing\n'
+  exit 0
+fi
+RUNPOD_API_KEY="$runpod_api_key"
+
+if [[ -z "${CRABBOX_BIN:-}" ]]; then
+  mkdir -p "$(dirname "$crabbox_bin")"
+  go build -trimpath -o "$crabbox_bin" ./cmd/crabbox
+fi
+
+state_root="$(mktemp -d)"
+config_file="$(mktemp)"
+cat >"$config_file" <<'YAML'
+provider: runpod
+target: linux
+YAML
+
+export CRABBOX_CONFIG="$config_file"
+export CRABBOX_COORDINATOR=
+export XDG_CONFIG_HOME="$state_root/config"
+export XDG_STATE_HOME="$state_root/state"
+export RUNPOD_API_KEY
+
+doctor_output="$(run_capture "$crabbox_bin doctor --provider runpod" "$crabbox_bin" doctor --provider runpod)"
+printf '%s\n' "$doctor_output"
+initial_list_output="$(run_capture "$crabbox_bin list --provider runpod --json" "$crabbox_bin" list --provider runpod --json)"
+validate_list_json_empty "$crabbox_bin list --provider runpod --json" "$initial_list_output"
+cleanup_armed=1
+run_capture "$crabbox_bin warmup --provider runpod --slug $slug --keep --ttl 20m --idle-timeout 5m" "$crabbox_bin" warmup --provider runpod --slug "$slug" --keep --ttl 20m --idle-timeout 5m >/dev/null
+run_capture "$crabbox_bin status --provider runpod --id $slug --wait --wait-timeout 600s" "$crabbox_bin" status --provider runpod --id "$slug" --wait --wait-timeout 600s >/dev/null
+run_capture "$crabbox_bin run --provider runpod --id $slug --no-sync -- echo ok" "$crabbox_bin" run --provider runpod --id "$slug" --no-sync -- echo ok >/dev/null
+list_output="$(run_capture "$crabbox_bin list --provider runpod --json" "$crabbox_bin" list --provider runpod --json)"
+printf '%s\n' "$list_output"
+validate_list_json_contains_slug "$crabbox_bin list --provider runpod --json" "$list_output"
+run_capture "$crabbox_bin stop --provider runpod $slug" "$crabbox_bin" stop --provider runpod "$slug" >/dev/null
+post_list_output="$(run_capture "$crabbox_bin list --provider runpod --json" "$crabbox_bin" list --provider runpod --json)"
+validate_list_json_empty "$crabbox_bin list --provider runpod --json" "$post_list_output"
+cleanup_armed=0
+printf '%s\n' "$post_list_output"
+printf 'classification=live_runpod_smoke_passed slug=%s cleanup=complete\n' "$slug"

--- a/scripts/live-runpod-smoke.test.js
+++ b/scripts/live-runpod-smoke.test.js
@@ -1,0 +1,267 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+
+function writeExecutable(file, body) {
+  fs.writeFileSync(file, body, "utf8");
+  fs.chmodSync(file, 0o755);
+}
+
+function prepareSmokeRepo(dir) {
+  const tempRoot = path.join(dir, "repo");
+  const tempScripts = path.join(tempRoot, "scripts");
+  const smokeScript = path.join(tempScripts, "live-runpod-smoke.sh");
+  fs.mkdirSync(tempScripts, { recursive: true });
+  fs.copyFileSync(path.join(repoRoot, "scripts", "live-runpod-smoke.sh"), smokeScript);
+  fs.chmodSync(smokeScript, 0o755);
+  return { tempRoot, smokeScript };
+}
+
+function writeGoStub(binDir, scriptBody) {
+  writeExecutable(
+    path.join(binDir, "go"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+out=""
+while [[ "$#" -gt 0 ]]; do
+  if [[ "$1" == "-o" ]]; then
+    out="$2"
+    shift 2
+    continue
+  fi
+  shift
+done
+mkdir -p "$(dirname "$out")"
+cat >"$out" <<'SCRIPT'
+${scriptBody}
+SCRIPT
+chmod +x "$out"
+`,
+  );
+}
+
+test("live RunPod smoke embedded cleanup Python compiles", () => {
+  const script = fs.readFileSync(path.join(repoRoot, "scripts", "live-runpod-smoke.sh"), "utf8");
+  const match = script.match(/raw_runpod_delete_slug\(\) \{\n  CRABBOX_SMOKE_SLUG="\$slug" python3 -c '\n([\s\S]*?)\n'\n\}/);
+  assert.ok(match, "raw_runpod_delete_slug Python block should be extractable");
+  const result = spawnSync("python3", ["-c", `compile(${JSON.stringify(match[1])}, "raw_runpod_delete_slug", "exec")`], {
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test("live RunPod smoke skips unless opted in", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-runpod-skip-"));
+  const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
+  const result = spawnSync("bash", [smokeScript], {
+    cwd: tempRoot,
+    env: { ...process.env, CRABBOX_LIVE: "", CRABBOX_RUNPOD_API_KEY: "", RUNPOD_API_KEY: "" },
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /classification=environment_blocked reason=CRABBOX_LIVE_not_enabled/);
+});
+
+test("live RunPod smoke skips unless provider filter selects RunPod", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-runpod-filter-"));
+  const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
+  const result = spawnSync("bash", [smokeScript], {
+    cwd: tempRoot,
+    env: {
+      ...process.env,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_PROVIDERS: "aws,digitalocean",
+      RUNPOD_API_KEY: "test-secret-token",
+    },
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /classification=environment_blocked reason=runpod_not_selected/);
+});
+
+test("live RunPod smoke requires a token before building", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-runpod-token-"));
+  const binDir = path.join(dir, "bin");
+  const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
+  fs.mkdirSync(binDir, { recursive: true });
+  writeExecutable(path.join(binDir, "go"), "#!/usr/bin/env bash\nexit 99\n");
+  const result = spawnSync("bash", [smokeScript], {
+    cwd: tempRoot,
+    env: {
+      ...process.env,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_PROVIDERS: "runpod",
+      CRABBOX_RUNPOD_API_KEY: "",
+      RUNPOD_API_KEY: "",
+    },
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /classification=environment_blocked reason=RUNPOD_API_KEY_missing/);
+});
+
+test("live RunPod smoke runs guarded lifecycle without exposing the token", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-runpod-"));
+  const binDir = path.join(dir, "bin");
+  const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
+  const calls = path.join(dir, "calls.log");
+  const slugFile = path.join(dir, "slug.txt");
+  fs.mkdirSync(binDir, { recursive: true });
+  writeGoStub(
+    binDir,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${calls}"
+if [[ "\${RUNPOD_API_KEY:-}" != "test-secret-token" ]]; then
+  exit 91
+fi
+case "$1" in
+  doctor)
+    printf 'auth=ready control_plane=ready inventory=ready mutation=false leases=0\n'
+    ;;
+  warmup)
+    printf '%s\n' "$5" >"${slugFile}"
+    ;;
+  status)
+    printf 'status=ready\n'
+    ;;
+  run)
+    printf 'ok\n'
+    ;;
+  list)
+    slug="$(cat "${slugFile}" 2>/dev/null || true)"
+    if [[ -z "$slug" || -f "${slugFile}.stopped" ]]; then
+      printf '[]\n'
+    else
+      printf '[{"labels":{"slug":"%s"}}]\n' "$slug"
+    fi
+    ;;
+  stop)
+    printf stopped >"${slugFile}.stopped"
+    ;;
+  *)
+    exit 99
+    ;;
+esac
+`,
+  );
+
+  const result = spawnSync("bash", [smokeScript], {
+    cwd: tempRoot,
+    env: {
+      ...process.env,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_PROVIDERS: "runpod",
+      CRABBOX_RUNPOD_API_KEY: "test-secret-token",
+      RUNPOD_API_KEY: "",
+    },
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /classification=live_runpod_smoke_passed/);
+  assert.doesNotMatch(result.stdout + result.stderr, /test-secret-token/);
+
+  const seen = fs.readFileSync(calls, "utf8").trim().split("\n");
+  assert.equal(seen[0], "doctor --provider runpod");
+  assert.equal(seen[1], "list --provider runpod --json");
+  assert.match(seen[2], /^warmup --provider runpod --slug runpod-smoke-\d{14}-\d+ --keep --ttl 20m --idle-timeout 5m$/);
+  assert.match(seen[3], /^status --provider runpod --id runpod-smoke-\d{14}-\d+ --wait --wait-timeout 600s$/);
+  assert.match(seen[4], /^run --provider runpod --id runpod-smoke-\d{14}-\d+ --no-sync -- echo ok$/);
+  assert.equal(seen[5], "list --provider runpod --json");
+  assert.match(seen[6], /^stop --provider runpod runpod-smoke-\d{14}-\d+$/);
+  assert.equal(seen[7], "list --provider runpod --json");
+});
+
+test("live RunPod smoke attempts cleanup after a partial failure", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-runpod-fail-"));
+  const binDir = path.join(dir, "bin");
+  const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
+  const stopped = path.join(dir, "stopped.log");
+  fs.mkdirSync(binDir, { recursive: true });
+  writeGoStub(
+    binDir,
+    `#!/usr/bin/env bash
+set -euo pipefail
+case "$1" in
+  doctor|list)
+    printf '[]\n'
+    ;;
+  warmup)
+    printf 'created RunPod pod before failing\n' >&2
+    exit 37
+    ;;
+  stop)
+    printf '%s\n' "$4" >>"${stopped}"
+    ;;
+  *)
+    exit 99
+    ;;
+esac
+`,
+  );
+  const result = spawnSync("bash", [smokeScript], {
+    cwd: tempRoot,
+    env: {
+      ...process.env,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_PROVIDERS: "runpod",
+      RUNPOD_API_KEY: "test-secret-token",
+    },
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 37, result.stdout + result.stderr);
+  assert.match(result.stderr, /classification=environment_blocked/);
+  assert.match(fs.readFileSync(stopped, "utf8"), /^runpod-smoke-\d{14}-\d+\n$/);
+});
+
+test("live RunPod smoke refuses non-empty inventory before mutation", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-runpod-nonempty-"));
+  const binDir = path.join(dir, "bin");
+  const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
+  const calls = path.join(dir, "calls.log");
+  fs.mkdirSync(binDir, { recursive: true });
+  writeGoStub(
+    binDir,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${calls}"
+case "$1" in
+  doctor)
+    printf 'auth=ready\n'
+    ;;
+  list)
+    printf '[{"labels":{"slug":"existing"}}]\n'
+    ;;
+  *)
+    exit 99
+    ;;
+esac
+`,
+  );
+  const result = spawnSync("bash", [smokeScript], {
+    cwd: tempRoot,
+    env: {
+      ...process.env,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_PROVIDERS: "runpod",
+      RUNPOD_API_KEY: "test-secret-token",
+    },
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 1, result.stdout + result.stderr);
+  assert.match(result.stderr, /classification=validation_failed/);
+  assert.match(result.stderr, /inventory is not empty/);
+  assert.deepEqual(fs.readFileSync(calls, "utf8").trim().split("\n"), [
+    "doctor --provider runpod",
+    "list --provider runpod --json",
+  ]);
+});

--- a/scripts/live-smoke.sh
+++ b/scripts/live-smoke.sh
@@ -1012,6 +1012,10 @@ if has_provider vultr; then
   "$root/scripts/live-vultr-smoke.sh"
 fi
 
+if has_provider runpod || has_provider run-pod || has_provider runpodio; then
+  "$root/scripts/live-runpod-smoke.sh"
+fi
+
 if has_provider digitalocean || has_provider do; then
   "$root/scripts/live-digitalocean-smoke.sh"
 fi

--- a/scripts/live-smoke.test.js
+++ b/scripts/live-smoke.test.js
@@ -2426,6 +2426,14 @@ esac
   assert.equal(seen[8], "list --provider linode --json");
 });
 
+test("RunPod live smoke dispatches to the provider-specific script", () => {
+  const script = fs.readFileSync(path.join(repoRoot, "scripts", "live-smoke.sh"), "utf8");
+  assert.match(
+    script,
+    /if has_provider runpod \|\| has_provider run-pod \|\| has_provider runpodio; then\n  "\$root\/scripts\/live-runpod-smoke\.sh"\nfi/,
+  );
+});
+
 test("vultr live smoke dispatches to the provider-specific smoke", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-vultr-dispatch-"));
   const bin = path.join(dir, "bin");


### PR DESCRIPTION
## Summary

- bind RunPod destructive operations to exact local claims containing provider ID and pod name
- require explicit `--reclaim` adoption for unclaimed or legacy pods; never silently retarget an existing claim
- upgrade the unique legacy claim matching a resolved pod's exact generated name/slug instead of creating a second synthetic claim during raw-ID reclaim
- re-read the pod under the release lock and verify both ID and name before deletion
- reject ambiguous exact, normalized-name, derived-lease, local-slug/provider-ID, and local-slug/pod-name lookups
- preserve exact created-pod identity through readiness-failure cleanup
- add a cleanup-armed, isolated-state RunPod live lifecycle canary and top-level live-smoke dispatch

Closes https://github.com/openclaw/crabbox/issues/801

## Verification

Current candidate: `f58483e2f5af68e40d4f491bc2db36a32d6b94c8`

- `go test -race ./internal/providers/runpod ./internal/cli -count=1` — pass.
- `go vet ./internal/providers/runpod ./internal/cli` — pass.
- `node --test scripts/live-runpod-smoke.test.js scripts/live-smoke.test.js` — 59 tests pass, including cleanup, secret-redaction, non-empty-inventory refusal, dispatch, and both alias-collision forms.
- `scripts/check-docs.sh` — pass (53 command docs, 71 providers, 209 Markdown files, docs-site build).
- `git diff --check origin/main...HEAD` — pass.
- Exact rebased branch autoreview — clean (0.84), with no accepted/actionable findings.

All inline review findings are fixed, answered, and resolved. The legacy raw-ID reclaim regression proves one upgraded claim remains and stop-by-slug deletes the intended pod.

## Exact-head live proof

The exact candidate binary (`4c1ad02283d17075fb35ffa8654f67665c2b8369f014758747101276383b9d0b`) completed the authenticated RunPod lifecycle with lease `rpod_efb75a51`:

- read-only doctor and initial inventory passed with zero pods;
- a funded pod was created and reached public-key-only SSH readiness;
- `crabbox run` reused the owned pod and executed the remote command;
- list returned the exact RunPod ID/name-bound claim;
- exact-claim stop deleted the pod;
- Crabbox post-stop inventory and an independent raw RunPod API audit both reported zero residue.

The dedicated restricted key was injected from approved secret storage only for the isolated canary; it was not written to repository or Crabbox configuration state.

## Security / configuration

No new persisted-secret requirement. The live canary accepts `CRABBOX_RUNPOD_API_KEY` or `RUNPOD_API_KEY` only from the process environment and isolates its Crabbox state.
