### PR TITLE
fix: require exact claims for direct cloud cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Renamed the `apple-vz` provider to `apple-vm`; the old provider name/aliases, `appleVZ:` config keys, `--apple-vz-*` flags, and `CRABBOX_APPLE_VZ_*` environment variables keep working as deprecated aliases, existing leases and claims stay manageable, and the state directory migrates automatically.
 - Replaced the Code-Hex/vz cgo dependency with `crabbox-apple-vm-vmd`, a dependency-free Swift Virtualization.framework daemon embedded in the now pure-Go `crabbox-apple-vm-helper`; the helper installs and entitlement-signs the daemon itself, so Crabbox no longer copies or codesigns helper binaries.
+
 - Updated Go SSH and OS support libraries, including upstream authentication-attempt, malformed-session, key-size, KDF, and known-host validation hardening.
 - Updated the Node/PostgreSQL coordinator to pg 8.22 and pg-boss 12.25, including current protocol parsing, startup retry, queue-cache, migration-deadlock, and scheduling fixes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 - Renamed the `apple-vz` provider to `apple-vm`; the old provider name/aliases, `appleVZ:` config keys, `--apple-vz-*` flags, and `CRABBOX_APPLE_VZ_*` environment variables keep working as deprecated aliases, existing leases and claims stay manageable, and the state directory migrates automatically.
 - Replaced the Code-Hex/vz cgo dependency with `crabbox-apple-vm-vmd`, a dependency-free Swift Virtualization.framework daemon embedded in the now pure-Go `crabbox-apple-vm-helper`; the helper installs and entitlement-signs the daemon itself, so Crabbox no longer copies or codesigns helper binaries.
-
 - Updated Go SSH and OS support libraries, including upstream authentication-attempt, malformed-session, key-size, KDF, and known-host validation hardening.
 - Updated the Node/PostgreSQL coordinator to pg 8.22 and pg-boss 12.25, including current protocol parsing, startup retry, queue-cache, migration-deadlock, and scheduling fixes.
 
@@ -37,6 +36,7 @@
 - Revalidated live AWS, Azure, and GCP instance identity, ownership, lease binding, cleanup eligibility, and any destructive companion-resource identity immediately before direct cleanup deletion. Thanks @coygeek.
 - Required W&B sandbox reuse, status, and stop to match an exact endpoint/entity/project/resource-bound local claim plus provider inventory ownership. Thanks @coygeek.
 - Required RunPod stop to use an exact pod ID/name-bound local claim, with conflict-safe explicit `--reclaim` adoption for unclaimed or legacy pods. Thanks @coygeek.
+- Required DigitalOcean, Linode, Scaleway, and Vultr inventory and destructive actions to use canonical lease identities and exact provider/resource-bound local claims, with explicit `--reclaim` adoption for claimless resources. Thanks @coygeek and @vincentkoc.
 - Made coordinatorless generic provider live smokes skip coordinator-only history and always clean up acquired leases after later lifecycle failures.
 - Replaced privileged managed Linux Code Server and Tailscale installer scripts with checksum-verified archives or Tailscale's signed package repository with a pinned keyring in both CLI and coordinator bootstrap paths. Thanks @TurboTheTurtle.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
 - Revalidated live AWS, Azure, and GCP instance identity, ownership, lease binding, cleanup eligibility, and any destructive companion-resource identity immediately before direct cleanup deletion. Thanks @coygeek.
 - Required W&B sandbox reuse, status, and stop to match an exact endpoint/entity/project/resource-bound local claim plus provider inventory ownership. Thanks @coygeek.
 - Required RunPod stop to use an exact pod ID/name-bound local claim, with conflict-safe explicit `--reclaim` adoption for unclaimed or legacy pods. Thanks @coygeek.
-- Required DigitalOcean, Linode, Scaleway, and Vultr inventory and destructive actions to use canonical lease identities and exact provider/resource-bound local claims, with explicit `--reclaim` adoption for claimless resources. Thanks @coygeek and @vincentkoc.
+- Required DigitalOcean, Linode, Scaleway, and Vultr inventory and destructive actions to use canonical lease identities and exact provider/resource-bound local claims, with explicit `--reclaim` adoption for claimless resources and recovery-safe Vultr instance/key rollback ordering. Thanks @coygeek and @vincentkoc.
 - Made coordinatorless generic provider live smokes skip coordinator-only history and always clean up acquired leases after later lifecycle failures.
 - Replaced privileged managed Linux Code Server and Tailscale installer scripts with checksum-verified archives or Tailscale's signed package repository with a pinned keyring in both CLI and coordinator bootstrap paths. Thanks @TurboTheTurtle.
 

--- a/docs/commands/status.md
+++ b/docs/commands/status.md
@@ -61,7 +61,9 @@ seconds until the box is ready or reaches a terminal state
 `terminated`), and exits non-zero (code 5) if it times out (`--wait-timeout`,
 default `5m`) or the lease becomes terminal before it is ready. For direct
 SSH-lease providers, each poll while waiting also touches the lease to keep it
-from idling out.
+from idling out only when an exact local claim matches the configured provider
+scope and live resource identity. Claimless or mismatched resources remain
+strictly read-only while status waits.
 
 ## Flags
 

--- a/docs/commands/stop.md
+++ b/docs/commands/stop.md
@@ -113,6 +113,11 @@ The action `stop` takes depends on how the lease was created:
   `stopped lease=<id> instance=<name> retained=true` for retained Incus
   instances). Hostinger is stop-only and prints `billing=still-owned`; it does
   not delete or cancel the subscription.
+- **DigitalOcean, Linode, Vultr, and Scaleway** — require canonical live
+  ownership tags plus an exact local claim for the same provider account or
+  project and resource before reuse or deletion. Claimless resources remain
+  visible in read-only inventory and require explicit supported `--reclaim`
+  reuse before `stop` may delete them.
 - **Delegated runners** — call the provider's own teardown for the resolved
   sandbox.
 

--- a/docs/providers/digitalocean.md
+++ b/docs/providers/digitalocean.md
@@ -126,9 +126,9 @@ explicit VPC. Do not broaden scopes inside scripts.
 5. Add ready-state Crabbox tags and claim the lease locally.
 6. Run normal Crabbox sync/run/ssh workflows over SSH.
 7. Delete the Droplet and managed SSH key on `stop`; `cleanup` deletes only
-   resources with a complete Crabbox DigitalOcean ownership tag set. Failed
-   post-delete or key-only rollback cleanup retains an account-scoped local
-   claim so `stop` can retry it.
+   resources with complete Crabbox DigitalOcean ownership tags and an exact
+   account- and Droplet-bound local claim. Failed post-delete or key-only
+   rollback cleanup retains that claim so `stop` can retry it.
 
 If Droplet creation returns an indeterminate transport or server failure,
 Crabbox retains the SSH credentials and records a pending local recovery claim.
@@ -152,9 +152,12 @@ crabbox:target:linux
 crabbox:expires_at:<unix-seconds>
 ```
 
-Release and cleanup require a complete ownership predicate: Crabbox marker,
-provider marker, lease id, slug, and Linux target. Droplets with partial,
-foreign, or malformed Crabbox-like tags are skipped/refused.
+Read-only inventory requires a complete ownership predicate: Crabbox marker,
+provider marker, canonical lease id, slug, and Linux target. Reuse and deletion
+also require an exact local claim for the same DigitalOcean account, lease, and
+Droplet id. Droplets with partial, foreign, malformed, claimless, or mismatched
+ownership are skipped or refused; a claimless Droplet must first be adopted
+through explicit supported `--reclaim` reuse.
 
 Tag updates apply only the set difference. Crabbox detaches obsolete tags from
 the Droplet but does not delete account-level tag objects: DigitalOcean tag

--- a/docs/providers/linode.md
+++ b/docs/providers/linode.md
@@ -114,8 +114,9 @@ and adjust token scopes before retrying. Do not broaden scopes inside scripts.
 3. Wait for a public IPv4 address and Crabbox SSH bootstrap readiness.
 4. Add ready-state Crabbox tags and claim the lease locally.
 5. Run normal Crabbox sync/run/ssh workflows over SSH.
-6. Delete the Linode instance on `stop`; `cleanup` deletes only resources with a
-   complete Crabbox Linode ownership tag set.
+6. Delete the Linode instance on `stop`; `cleanup` deletes only resources with
+   complete Crabbox Linode ownership tags and an exact account- and
+   instance-bound local claim.
 
 If instance creation returns an indeterminate transport or server failure,
 Crabbox retains the SSH credentials and records a pending local recovery claim.
@@ -138,9 +139,12 @@ crabbox:target:linux
 crabbox:expires_at:<unix-seconds>
 ```
 
-Release and cleanup require a complete ownership predicate: Crabbox marker,
-provider marker, lease id, slug, and Linux target. Linodes with partial,
-foreign, or malformed Crabbox-like tags are skipped/refused.
+Read-only inventory requires a complete ownership predicate: Crabbox marker,
+provider marker, canonical lease id, slug, and Linux target. Reuse and deletion
+also require an exact local claim for the same Linode account, lease, and
+instance id. Linodes with partial, foreign, malformed, claimless, or mismatched
+ownership are skipped or refused; a claimless Linode must first be adopted
+through explicit supported `--reclaim` reuse.
 
 Tag updates replace only Crabbox's namespaced tags and preserve unrelated
 operator tags already attached to the instance. Direct mode has no coordinator

--- a/docs/providers/scaleway.md
+++ b/docs/providers/scaleway.md
@@ -187,11 +187,13 @@ The provider implements a direct Linux SSH lease over Scaleway Instances:
 6. Run normal Crabbox sync/run/ssh workflows over SSH.
 7. Update timeout tags on touch.
 8. Delete owned Scaleway Instances and managed IAM SSH keys on `stop`; `cleanup`
-   deletes only resources with a complete Crabbox Scaleway ownership tag set.
+   deletes only resources with complete Crabbox Scaleway ownership tags and an
+   exact project-, zone-, and server-bound local claim.
 
-`list` uses all-pages Scaleway inventory. `resolve` accepts local claims and
-live tag-owned resources. Recovery claims retain enough Scaleway identity to
-finish release or cleanup after interrupted acquire paths.
+`list` uses all-pages Scaleway inventory. `resolve` may inspect complete,
+canonical live ownership tags without a claim, but reuse requires explicit
+supported `--reclaim` adoption. Recovery claims retain enough Scaleway identity
+to finish release or cleanup after interrupted acquire paths.
 
 ## Ownership And Cleanup
 
@@ -206,13 +208,15 @@ crabbox:target:linux
 crabbox:expires_at:<unix-seconds>
 ```
 
-Release and cleanup require a complete ownership predicate: Crabbox marker,
-provider marker, lease id, slug, and Linux target. Resources with partial,
-foreign, or malformed Crabbox-like tags are skipped or refused. A stale local
-claim is not enough for destructive release: Crabbox re-fetches the live
-Scaleway Instance by ID and validates current tags before deletion. If Scaleway
-confirms the Instance is already absent, release removes the managed SSH key and
-local claim idempotently.
+Read-only inventory requires a complete ownership predicate: Crabbox marker,
+provider marker, canonical lease id, slug, and Linux target. Reuse and deletion
+also require an exact local claim for the same Scaleway project, zone, lease,
+and server id. Resources with partial, foreign, malformed, claimless, or
+mismatched ownership are skipped or refused. A local claim alone is not enough
+for destructive release: Crabbox re-fetches the live Scaleway Instance by ID
+and validates current tags before deletion. If Scaleway confirms the Instance
+is already absent, release removes the managed SSH key and local claim
+idempotently.
 
 `crabbox cleanup --provider scaleway --dry-run` reports expired owned resources
 without deleting them. Use the Scaleway console or `scw` only for manual account

--- a/docs/providers/vultr.md
+++ b/docs/providers/vultr.md
@@ -122,7 +122,8 @@ scripts.
 5. Add ready-state Crabbox tags and claim the lease locally.
 6. Run normal Crabbox sync/run/ssh workflows over SSH.
 7. Delete the instance and managed SSH key on `stop`; `cleanup` deletes only
-   resources with a complete Crabbox Vultr ownership tag set.
+   resources with complete Crabbox Vultr ownership tags and an exact account-
+   and instance-bound local claim.
 
 If instance or SSH-key creation returns an indeterminate transport or server
 failure, Crabbox retains the SSH credentials and records a pending local
@@ -147,9 +148,12 @@ crabbox:target:linux
 crabbox:expires_at:<unix-seconds>
 ```
 
-Release and cleanup require a complete ownership predicate: Crabbox marker,
-provider marker, lease id, slug, and Linux target. Instances with partial,
-foreign, or malformed Crabbox-like tags are skipped/refused.
+Read-only inventory requires a complete ownership predicate: Crabbox marker,
+provider marker, canonical lease id, slug, and Linux target. Reuse and deletion
+also require an exact local claim for the same Vultr account, lease, and
+instance UUID. Instances with partial, foreign, malformed, claimless, or
+mismatched ownership are skipped or refused; a claimless instance must first
+be adopted through explicit supported `--reclaim` reuse.
 
 Direct mode has no coordinator alarm. Use:
 

--- a/internal/cli/controller_service_test.go
+++ b/internal/cli/controller_service_test.go
@@ -1514,7 +1514,7 @@ func TestControllerPreAcquireAckFailureRetainsStoppingUntilStableAbsence(t *test
 	var stopping controllerWorkspaceRecord
 	for time.Now().Before(deadline) {
 		current, ok := service.workspace("pre-ack-absent-box")
-		if ok && current.Status == "stopping" && current.FailureAfterCleanup != "" {
+		if ok && current.Status == "stopping" && current.FailureAfterCleanup != "" && current.ProviderAbsentSince != "" {
 			stopping = current
 			break
 		}
@@ -1523,7 +1523,7 @@ func TestControllerPreAcquireAckFailureRetainsStoppingUntilStableAbsence(t *test
 	if stopping.Status != "stopping" || stopping.AttemptLeaseID == "" || stopping.Slug == "" || stopping.CreateObserved {
 		t.Fatalf("pre-ack failure did not retain stable cleanup identity: %#v", stopping)
 	}
-	time.Sleep(100 * time.Millisecond)
+	waitControllerWorkspaceInactive(t, service, stopping.Request.ID)
 	current, _ := service.workspace(stopping.Request.ID)
 	if current.Status != "stopping" || current.AttemptLeaseID != stopping.AttemptLeaseID || current.Slug != stopping.Slug {
 		t.Fatalf("workspace escaped late-materialization recovery window: %#v", current)

--- a/internal/cli/controller_service_test.go
+++ b/internal/cli/controller_service_test.go
@@ -1493,7 +1493,13 @@ func TestControllerPreAcquireAckFailureRetainsStoppingUntilStableAbsence(t *test
 	defer cancel()
 	service.opts.CreateTimeout = 2 * time.Second
 	base := time.Now().UTC()
-	service.now = func() time.Time { return base }
+	var clockMu sync.RWMutex
+	currentTime := base
+	service.now = func() time.Time {
+		clockMu.RLock()
+		defer clockMu.RUnlock()
+		return currentTime
+	}
 
 	created := controllerHTTP(service, http.MethodPost, "/v1/workspaces", "test-token", controllerWorkspaceRequest{ID: "pre-ack-absent-box"})
 	if created.Code != http.StatusAccepted {
@@ -1523,7 +1529,9 @@ func TestControllerPreAcquireAckFailureRetainsStoppingUntilStableAbsence(t *test
 		t.Fatalf("workspace escaped late-materialization recovery window: %#v", current)
 	}
 
-	service.now = func() time.Time { return base.Add(3 * time.Second) }
+	clockMu.Lock()
+	currentTime = base.Add(3 * time.Second)
+	clockMu.Unlock()
 	service.enqueue(stopping.Request.ID)
 	failed := waitControllerWorkspaceStatus(t, service, stopping.Request.ID, "failed")
 	if failed.Message != "workspace provisioning failed before provider identity acknowledgment" {

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -101,6 +101,12 @@ type SSHLeaseBackend interface {
 	ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error
 }
 
+// StatusTouchClaimValidator lets a provider require identity labels that core
+// cannot interpret before status --wait extends a remotely visible lease.
+type StatusTouchClaimValidator interface {
+	StatusTouchClaimMatches(LeaseTarget, LeaseClaim) bool
+}
+
 type ResolvedLeaseTargetRebinder interface {
 	RebindResolvedLeaseTarget(target *LeaseTarget, leaseID string) error
 }

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -629,6 +629,12 @@ type ResolveRequest struct {
 	ExpectedProviderIdentity ProviderIdentityExpectation
 }
 
+// IsReadOnlyStatus reports whether resolution may inspect provider inventory
+// without trusting or rewriting local claim state.
+func (r ResolveRequest) IsReadOnlyStatus() bool {
+	return r.StatusOnly && r.NoLocalStateMutations && !r.ReleaseOnly && !r.Reclaim
+}
+
 type ReleaseLeaseRequest struct {
 	Lease                    LeaseTarget
 	Force                    bool

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -2893,7 +2893,8 @@ func findServerByAlias(servers []Server, id string) (Server, string, error) {
 				return server, server.Labels["lease"], nil
 			}
 		}
-		// Canonical lease IDs are exact identities, never aliases.
+		// Canonical IDs are exact identities, never aliases. Falling through to
+		// slug or provider-name matching could retarget a destructive operation.
 		return Server{}, "", nil
 	}
 	matches := make([]Server, 0, 2)

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -68,9 +68,14 @@ func (a App) status(ctx context.Context, args []string) error {
 			if err == nil {
 				state, err = statusViewFromLeaseTarget(statusCtx, cfg, lease)
 				if err == nil && *wait {
-					_, touchErr := sshBackend.Touch(statusCtx, TouchRequest{Lease: lease, State: state.State, IdleTimeout: cfg.IdleTimeout})
-					if touchErr != nil {
-						fmt.Fprintf(a.Stderr, "warning: touch failed for %s: %v\n", lease.LeaseID, touchErr)
+					claimed, claimErr := statusLeaseHasExactClaim(lease, backend.Spec().Name, leaseOptionsFromConfig(cfg).ProviderScope)
+					if claimErr != nil {
+						fmt.Fprintf(a.Stderr, "warning: touch skipped for %s: %v\n", lease.LeaseID, claimErr)
+					} else if claimed {
+						_, touchErr := sshBackend.Touch(statusCtx, TouchRequest{Lease: lease, State: state.State, IdleTimeout: cfg.IdleTimeout})
+						if touchErr != nil {
+							fmt.Fprintf(a.Stderr, "warning: touch failed for %s: %v\n", lease.LeaseID, touchErr)
+						}
 					}
 				}
 			}
@@ -129,6 +134,21 @@ func (a App) status(ctx context.Context, args []string) error {
 
 func statusWaitDone(state statusView) bool {
 	return state.Ready || statusTerminalState(state.State)
+}
+
+func statusLeaseHasExactClaim(lease LeaseTarget, fallbackProvider, providerScope string) (bool, error) {
+	provider := canonicalClaimProvider(blank(lease.Server.Provider, fallbackProvider))
+	if lease.LeaseID == "" || provider == "" {
+		return false, nil
+	}
+	claim, claimed, exact, err := resolveLeaseClaimForProviderWithExact(lease.LeaseID, provider)
+	if err != nil {
+		return false, fmt.Errorf("read exact %s lease claim: %w", provider, err)
+	}
+	resourceID := strings.TrimSpace(lease.Server.CloudID)
+	return claimed && exact &&
+		claim.ProviderScope == providerScope &&
+		resourceID != "" && claim.CloudID == resourceID, nil
 }
 
 func statusWaitTerminalError(id string, state statusView) error {

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -64,7 +64,7 @@ func (a App) status(ctx context.Context, args []string) error {
 			state, err = delegated.Status(statusCtx, StatusRequest{Options: leaseOptionsFromConfig(cfg), ID: *id, Wait: *wait, WaitTimeout: *waitTimeout})
 		} else if isSSH {
 			var lease LeaseTarget
-			lease, err = sshBackend.Resolve(statusCtx, ResolveRequest{Options: leaseOptionsFromConfig(cfg), ID: *id, StatusOnly: true, ReadyProbe: *wait})
+			lease, err = sshBackend.Resolve(statusCtx, ResolveRequest{Options: leaseOptionsFromConfig(cfg), ID: *id, StatusOnly: true, ReadyProbe: *wait, NoLocalStateMutations: true})
 			if err == nil {
 				state, err = statusViewFromLeaseTarget(statusCtx, cfg, lease)
 				if err == nil && *wait {
@@ -252,7 +252,7 @@ func (a App) leaseStatus(ctx context.Context, cfg Config, id string) (statusView
 	if !ok {
 		return statusView{}, exit(2, "provider=%s does not support status", backend.Spec().Name)
 	}
-	lease, err := sshBackend.Resolve(ctx, ResolveRequest{Options: leaseOptionsFromConfig(cfg), ID: id, StatusOnly: true})
+	lease, err := sshBackend.Resolve(ctx, ResolveRequest{Options: leaseOptionsFromConfig(cfg), ID: id, StatusOnly: true, NoLocalStateMutations: true})
 	if err != nil {
 		return statusView{}, err
 	}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -68,7 +68,7 @@ func (a App) status(ctx context.Context, args []string) error {
 			if err == nil {
 				state, err = statusViewFromLeaseTarget(statusCtx, cfg, lease)
 				if err == nil && *wait {
-					claimed, claimErr := statusLeaseHasExactClaim(lease, backend.Spec().Name, leaseOptionsFromConfig(cfg).ProviderScope)
+					claimed, claimErr := statusLeaseHasExactClaim(backend, lease, backend.Spec().Name, leaseOptionsFromConfig(cfg).ProviderScope)
 					if claimErr != nil {
 						fmt.Fprintf(a.Stderr, "warning: touch skipped for %s: %v\n", lease.LeaseID, claimErr)
 					} else if claimed {
@@ -136,7 +136,7 @@ func statusWaitDone(state statusView) bool {
 	return state.Ready || statusTerminalState(state.State)
 }
 
-func statusLeaseHasExactClaim(lease LeaseTarget, fallbackProvider, providerScope string) (bool, error) {
+func statusLeaseHasExactClaim(backend Backend, lease LeaseTarget, fallbackProvider, providerScope string) (bool, error) {
 	provider := canonicalClaimProvider(blank(lease.Server.Provider, fallbackProvider))
 	if lease.LeaseID == "" || provider == "" {
 		return false, nil
@@ -146,9 +146,16 @@ func statusLeaseHasExactClaim(lease LeaseTarget, fallbackProvider, providerScope
 		return false, fmt.Errorf("read exact %s lease claim: %w", provider, err)
 	}
 	resourceID := strings.TrimSpace(lease.Server.CloudID)
-	return claimed && exact &&
+	matched := claimed && exact &&
 		claim.ProviderScope == providerScope &&
-		resourceID != "" && claim.CloudID == resourceID, nil
+		resourceID != "" && claim.CloudID == resourceID
+	if !matched {
+		return false, nil
+	}
+	if validator, ok := backend.(StatusTouchClaimValidator); ok && !validator.StatusTouchClaimMatches(lease, claim) {
+		return false, nil
+	}
+	return true, nil
 }
 
 func statusWaitTerminalError(id string, state statusView) error {

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -82,6 +82,7 @@ func TestLeaseStatusStateCanBeReadyRejectsTerminalStates(t *testing.T) {
 }
 
 func TestStatusWaitRequestsReadyProbe(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
 	t.Setenv("CRABBOX_COORDINATOR", "")
 	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "")
@@ -123,6 +124,44 @@ func TestStatusWaitRequestsReadyProbe(t *testing.T) {
 	}
 	if !backend.requests[0].ReadyProbe {
 		t.Fatal("status --wait should request SSH readiness data")
+	}
+	if len(backend.touches) != 0 {
+		t.Fatalf("claimless status --wait touch calls=%d want 0", len(backend.touches))
+	}
+
+	cfg := defaultConfig()
+	cfg.Provider = "aws"
+	claimServer := Server{
+		Provider: "aws",
+		CloudID:  "i-status",
+		Labels: map[string]string{
+			"lease":    "cbx_status",
+			"slug":     "status",
+			"provider": "aws",
+		},
+	}
+	if err := claimLeaseTargetForRepoConfig("cbx_status", "status", cfg, claimServer, SSHTarget{}, "/repo", time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	providerScope := leaseOptionsFromConfig(cfg).ProviderScope
+	claimed, err := statusLeaseHasExactClaim(LeaseTarget{LeaseID: "cbx_status", Server: claimServer}, "aws", providerScope)
+	if err != nil || !claimed {
+		t.Fatalf("matching exact claim allowed=%t err=%v", claimed, err)
+	}
+	if claimed, err := statusLeaseHasExactClaim(LeaseTarget{LeaseID: "cbx_status", Server: claimServer}, "aws", providerScope+"-other"); err != nil || claimed {
+		t.Fatalf("scope-mismatched claim allowed=%t err=%v", claimed, err)
+	}
+	wrongResource := claimServer
+	wrongResource.CloudID = "i-other"
+	if claimed, err := statusLeaseHasExactClaim(LeaseTarget{LeaseID: "cbx_status", Server: wrongResource}, "aws", providerScope); err != nil || claimed {
+		t.Fatalf("resource-mismatched claim allowed=%t err=%v", claimed, err)
+	}
+	err = app.status(context.Background(), []string{"--provider", "aws", "--id", "cbx_status", "--wait", "--wait-timeout", "1ns"})
+	if !AsExitError(err, &exitErr) || exitErr.Code != 5 {
+		t.Fatalf("claimed status --wait error = %#v, want timeout exit 5", err)
+	}
+	if len(backend.touches) != 1 {
+		t.Fatalf("claimed status --wait touch calls=%d want 1", len(backend.touches))
 	}
 }
 
@@ -169,6 +208,7 @@ func TestStatusWaitPreservesBackendTimeoutDetail(t *testing.T) {
 type statusResolveRecordingBackend struct {
 	testSSHBackend
 	requests      []ResolveRequest
+	touches       []TouchRequest
 	block         bool
 	timeoutDetail string
 }
@@ -185,12 +225,21 @@ func (b *statusResolveRecordingBackend) Resolve(ctx context.Context, req Resolve
 	return LeaseTarget{
 		Server: Server{
 			Provider: "aws",
+			CloudID:  "i-status",
 			Status:   "running",
 			Labels: map[string]string{
+				"lease":             "cbx_status",
+				"slug":              "status",
+				"provider":          "aws",
 				"state":             "ready",
 				"idle_timeout_secs": "60",
 			},
 		},
 		LeaseID: "cbx_status",
 	}, nil
+}
+
+func (b *statusResolveRecordingBackend) Touch(_ context.Context, req TouchRequest) (Server, error) {
+	b.touches = append(b.touches, req)
+	return req.Lease.Server, nil
 }

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -144,16 +144,20 @@ func TestStatusWaitRequestsReadyProbe(t *testing.T) {
 		t.Fatal(err)
 	}
 	providerScope := leaseOptionsFromConfig(cfg).ProviderScope
-	claimed, err := statusLeaseHasExactClaim(LeaseTarget{LeaseID: "cbx_status", Server: claimServer}, "aws", providerScope)
+	claimed, err := statusLeaseHasExactClaim(backend, LeaseTarget{LeaseID: "cbx_status", Server: claimServer}, "aws", providerScope)
 	if err != nil || !claimed {
 		t.Fatalf("matching exact claim allowed=%t err=%v", claimed, err)
 	}
-	if claimed, err := statusLeaseHasExactClaim(LeaseTarget{LeaseID: "cbx_status", Server: claimServer}, "aws", providerScope+"-other"); err != nil || claimed {
+	rejecting := &statusTouchClaimRejectingBackend{statusResolveRecordingBackend: backend}
+	if claimed, err := statusLeaseHasExactClaim(rejecting, LeaseTarget{LeaseID: "cbx_status", Server: claimServer}, "aws", providerScope); err != nil || claimed {
+		t.Fatalf("provider identity-rejected claim allowed=%t err=%v", claimed, err)
+	}
+	if claimed, err := statusLeaseHasExactClaim(backend, LeaseTarget{LeaseID: "cbx_status", Server: claimServer}, "aws", providerScope+"-other"); err != nil || claimed {
 		t.Fatalf("scope-mismatched claim allowed=%t err=%v", claimed, err)
 	}
 	wrongResource := claimServer
 	wrongResource.CloudID = "i-other"
-	if claimed, err := statusLeaseHasExactClaim(LeaseTarget{LeaseID: "cbx_status", Server: wrongResource}, "aws", providerScope); err != nil || claimed {
+	if claimed, err := statusLeaseHasExactClaim(backend, LeaseTarget{LeaseID: "cbx_status", Server: wrongResource}, "aws", providerScope); err != nil || claimed {
 		t.Fatalf("resource-mismatched claim allowed=%t err=%v", claimed, err)
 	}
 	err = app.status(context.Background(), []string{"--provider", "aws", "--id", "cbx_status", "--wait", "--wait-timeout", "1ns"})
@@ -211,6 +215,14 @@ type statusResolveRecordingBackend struct {
 	touches       []TouchRequest
 	block         bool
 	timeoutDetail string
+}
+
+type statusTouchClaimRejectingBackend struct {
+	*statusResolveRecordingBackend
+}
+
+func (*statusTouchClaimRejectingBackend) StatusTouchClaimMatches(LeaseTarget, LeaseClaim) bool {
+	return false
 }
 
 func (b *statusResolveRecordingBackend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -99,6 +99,9 @@ func TestStatusWaitRequestsReadyProbe(t *testing.T) {
 	if !backend.requests[0].StatusOnly {
 		t.Fatal("plain status should use status-only resolve")
 	}
+	if !backend.requests[0].NoLocalStateMutations {
+		t.Fatal("plain status should not mutate local claims")
+	}
 	if backend.requests[0].ReadyProbe {
 		t.Fatal("plain status should not request a readiness probe")
 	}
@@ -114,6 +117,9 @@ func TestStatusWaitRequestsReadyProbe(t *testing.T) {
 	}
 	if !backend.requests[0].StatusOnly {
 		t.Fatal("status --wait should still use status-only resolve")
+	}
+	if !backend.requests[0].NoLocalStateMutations {
+		t.Fatal("status --wait should not mutate local claims")
 	}
 	if !backend.requests[0].ReadyProbe {
 		t.Fatal("status --wait should request SSH readiness data")

--- a/internal/providers/digitalocean/backend.go
+++ b/internal/providers/digitalocean/backend.go
@@ -796,6 +796,11 @@ func (b *digitalOceanLeaseBackend) ReleaseLeaseMessage(lease core.LeaseTarget) s
 	return fmt.Sprintf("deleted lease=%s droplet=%s name=%s", lease.LeaseID, lease.Server.DisplayID(), lease.Server.Name)
 }
 
+func (b *digitalOceanLeaseBackend) StatusTouchClaimMatches(lease core.LeaseTarget, claim core.LeaseClaim) bool {
+	expected := strings.TrimSpace(claim.Labels[digitalOceanAccountLabel])
+	return expected != "" && expected == strings.TrimSpace(lease.Server.Labels[digitalOceanAccountLabel])
+}
+
 func (b *digitalOceanLeaseBackend) Touch(ctx context.Context, req core.TouchRequest) (core.Server, error) {
 	server := req.Lease.Server
 	if err := validateDropletLabels(server.Labels); err != nil {

--- a/internal/providers/digitalocean/backend.go
+++ b/internal/providers/digitalocean/backend.go
@@ -890,8 +890,17 @@ func (b *digitalOceanLeaseBackend) Cleanup(ctx context.Context, req core.Cleanup
 	return b.CleanupServers(ctx, req, servers)
 }
 
-func (b *digitalOceanLeaseBackend) cleanupEligible(server core.Server) (bool, error) {
-	_, err := b.ensureCleanupClaim(server, true)
+func (b *digitalOceanLeaseBackend) cleanupEligible(ctx context.Context, server core.Server) (bool, error) {
+	client, err := b.clientFactory(b.RT)
+	if err != nil {
+		return false, err
+	}
+	accountID, err := client.AccountID(ctx)
+	if err != nil {
+		return false, err
+	}
+	server = shared.ServerWithDefaultLabel(server, digitalOceanAccountLabel, accountID)
+	_, err = b.ensureCleanupClaim(server, true)
 	return shared.CleanupClaimEligible(err)
 }
 

--- a/internal/providers/digitalocean/backend.go
+++ b/internal/providers/digitalocean/backend.go
@@ -59,6 +59,7 @@ func NewDigitalOceanLeaseBackend(spec core.ProviderSpec, cfg core.Config, rt cor
 		return core.WaitForSSHReady(ctx, target, b.RT.Stderr, phase, timeout)
 	}
 	b.Delete = b.deleteServer
+	b.CleanupEligible = b.cleanupEligible
 	return b
 }
 
@@ -887,6 +888,11 @@ func (b *digitalOceanLeaseBackend) Cleanup(ctx context.Context, req core.Cleanup
 		return err
 	}
 	return b.CleanupServers(ctx, req, servers)
+}
+
+func (b *digitalOceanLeaseBackend) cleanupEligible(server core.Server) (bool, error) {
+	_, err := b.ensureCleanupClaim(server, true)
+	return shared.CleanupClaimEligible(err)
 }
 
 func applyTailscaleMetadata(labels map[string]string, meta core.TailscaleMetadata) {

--- a/internal/providers/digitalocean/backend.go
+++ b/internal/providers/digitalocean/backend.go
@@ -327,6 +327,9 @@ func (b *digitalOceanLeaseBackend) Resolve(ctx context.Context, req core.Resolve
 	servers := make([]core.Server, 0, len(droplets))
 	byID := map[int64]droplet{}
 	for _, item := range droplets {
+		if !isOwnedDroplet(item) {
+			continue
+		}
 		server := serverFromDroplet(item, b.Cfg)
 		servers = append(servers, server)
 		byID[server.ID] = item
@@ -717,6 +720,15 @@ func (b *digitalOceanLeaseBackend) targetFromDroplet(item droplet, req core.Reso
 			return core.LeaseTarget{}, core.Exit(2, "digitalocean lease claim has no Droplet identity or valid pending recovery state for lease=%s", leaseID)
 		}
 		preserveDigitalOceanKeyIdentity(server.Labels, claim.Labels)
+	} else if req.ReleaseOnly {
+		return core.LeaseTarget{}, core.Exit(2, "digitalocean lease=%s has no exact local claim; refusing release", leaseID)
+	} else if !req.NoLocalStateMutations {
+		if !req.Reclaim {
+			return core.LeaseTarget{}, core.Exit(2, "digitalocean lease=%s is unclaimed; use --reclaim to adopt it explicitly", leaseID)
+		}
+		if req.Repo.Root == "" {
+			return core.LeaseTarget{}, core.Exit(2, "digitalocean lease=%s cannot be reclaimed without a repository root", leaseID)
+		}
 	}
 	if req.ReleaseOnly {
 		target := core.LeaseTarget{Server: server, LeaseID: leaseID}
@@ -731,7 +743,7 @@ func (b *digitalOceanLeaseBackend) targetFromDroplet(item droplet, req core.Reso
 			ssh.Key = keyPath
 		}
 	}
-	if req.Repo.Root != "" {
+	if req.Repo.Root != "" && !req.NoLocalStateMutations {
 		if _, err := core.ClaimLeaseTargetForRepoConfigIfUnchanged(leaseID, server.Labels["slug"], b.Cfg, server, ssh, req.Repo.Root, b.Cfg.IdleTimeout, req.Reclaim, claim, claimExists); err != nil {
 			return core.LeaseTarget{}, err
 		}
@@ -751,6 +763,9 @@ func (b *digitalOceanLeaseBackend) List(ctx context.Context, req core.ListReques
 	}
 	out := make([]core.LeaseView, 0, len(droplets))
 	for _, item := range droplets {
+		if !isOwnedDroplet(item) {
+			continue
+		}
 		out = append(out, serverFromDroplet(item, b.Cfg))
 	}
 	return out, nil
@@ -960,13 +975,12 @@ func (b *digitalOceanLeaseBackend) deleteServer(ctx context.Context, _ core.Conf
 	}
 	recoveryKeyID := strings.TrimSpace(claim.Labels[digitalOceanRecoveryKeyIDLabel])
 	keyOwned := strings.TrimSpace(claim.Labels[digitalOceanKeyOwnedLabel])
-	foreignClaim := claim.Provider != providerName
 	if server.ID != 0 {
 		if err := client.DeleteDroplet(ctx, server.ID); err != nil {
 			return err
 		}
 	}
-	if !foreignClaim && (keyOwned == "" || keyOwned == "unknown") {
+	if keyOwned == "" || keyOwned == "unknown" {
 		keyID, owned, known, recoveryErr := b.recoverDigitalOceanKeyIdentity(ctx, client, leaseID)
 		if recoveryErr != nil {
 			return recoveryErr
@@ -984,7 +998,7 @@ func (b *digitalOceanLeaseBackend) deleteServer(ctx context.Context, _ core.Conf
 		recoveryKeyID = strings.TrimSpace(claim.Labels[digitalOceanRecoveryKeyIDLabel])
 		keyOwned = strings.TrimSpace(claim.Labels[digitalOceanKeyOwnedLabel])
 	}
-	if !foreignClaim && keyOwned == "true" && recoveryKeyID != "" {
+	if keyOwned == "true" && recoveryKeyID != "" {
 		keyID, parseErr := strconv.ParseInt(recoveryKeyID, 10, 64)
 		if parseErr != nil || keyID <= 0 {
 			return core.Exit(2, "invalid digitalocean recovery SSH key id %q", recoveryKeyID)
@@ -1001,13 +1015,10 @@ func (b *digitalOceanLeaseBackend) deleteServer(ctx context.Context, _ core.Conf
 		if err := client.DeleteSSHKey(ctx, keyID); err != nil {
 			return err
 		}
-	} else if !foreignClaim && keyOwned == "true" {
+	} else if keyOwned == "true" {
 		return core.Exit(2, "digitalocean lease=%s owns an SSH key but its immutable key id is missing", leaseID)
-	} else if !foreignClaim && keyOwned != "false" {
+	} else if keyOwned != "false" {
 		return core.Exit(4, "digitalocean SSH key ownership remains indeterminate for lease=%s; local claim and credentials retained", leaseID)
-	}
-	if foreignClaim {
-		return nil
 	}
 	if err := core.RemoveLeaseClaimIfUnchanged(leaseID, claim); err != nil {
 		return fmt.Errorf("finalize digitalocean cleanup claim: %w", err)
@@ -1027,32 +1038,14 @@ func (b *digitalOceanLeaseBackend) ensureCleanupClaim(server core.Server, liveDr
 			return core.LeaseClaim{}, core.Exit(2, "digitalocean lease claim is incomplete for lease=%s", leaseID)
 		}
 	} else {
-		repoRoot, err := os.Getwd()
-		if err != nil {
-			return core.LeaseClaim{}, fmt.Errorf("resolve cleanup claim working directory: %w", err)
-		}
-		claim, err = core.ClaimLeaseTargetForRepoConfigIfUnchanged(
-			leaseID,
-			server.Labels["slug"],
-			b.Cfg,
-			server,
-			core.SSHTarget{},
-			repoRoot,
-			b.Cfg.IdleTimeout,
-			false,
-			claim,
-			false,
-		)
-		if err != nil {
-			return core.LeaseClaim{}, fmt.Errorf("persist digitalocean cleanup claim: %w", err)
-		}
+		return core.LeaseClaim{}, core.Exit(2, "digitalocean lease=%s has no exact local claim; refusing cleanup", leaseID)
 	}
 	cloudID := firstNonBlank(server.CloudID, strconv.FormatInt(server.ID, 10))
 	if claim.Provider == providerName && claim.CloudID != "" && claim.CloudID != cloudID {
 		return core.LeaseClaim{}, core.Exit(2, "refusing to release DigitalOcean Droplet %d from stale local claim", server.ID)
 	}
 	if claim.Provider != providerName {
-		return claim, nil
+		return core.LeaseClaim{}, core.Exit(2, "lease=%s is claimed by provider=%s; refusing digitalocean cleanup", leaseID, claim.Provider)
 	}
 	if err := validateDigitalOceanClaimIdentity(claim, leaseID, server.Labels["slug"]); err != nil {
 		return core.LeaseClaim{}, err

--- a/internal/providers/digitalocean/backend.go
+++ b/internal/providers/digitalocean/backend.go
@@ -372,7 +372,7 @@ func (b *digitalOceanLeaseBackend) releaseTargetFromClaim(ctx context.Context, c
 	} else {
 		var exact bool
 		claim, ok, exact, err = core.ResolveLeaseClaimForProviderWithExact(id, providerName)
-		if err == nil && exact && (!ok || claim.LeaseID != id) {
+		if err == nil && (exact || core.IsCanonicalLeaseID(id)) && (!exact || !ok || claim.LeaseID != id) {
 			return core.LeaseTarget{}, core.Exit(2, "digitalocean exact lease identifier %q does not match a valid digitalocean claim", id)
 		}
 	}

--- a/internal/providers/digitalocean/backend.go
+++ b/internal/providers/digitalocean/backend.go
@@ -698,7 +698,7 @@ func (b *digitalOceanLeaseBackend) targetFromDroplet(item droplet, req core.Reso
 	if claimErr != nil {
 		return core.LeaseTarget{}, fmt.Errorf("read digitalocean lease claim: %w", claimErr)
 	}
-	if claimExists {
+	if claimExists && !req.IsReadOnlyStatus() {
 		if claim.Provider != providerName {
 			return core.LeaseTarget{}, core.Exit(2, "lease=%s is claimed by provider=%s; refusing digitalocean claim rewrite", leaseID, claim.Provider)
 		}
@@ -720,9 +720,9 @@ func (b *digitalOceanLeaseBackend) targetFromDroplet(item droplet, req core.Reso
 			return core.LeaseTarget{}, core.Exit(2, "digitalocean lease claim has no Droplet identity or valid pending recovery state for lease=%s", leaseID)
 		}
 		preserveDigitalOceanKeyIdentity(server.Labels, claim.Labels)
-	} else if req.ReleaseOnly {
+	} else if !claimExists && req.ReleaseOnly {
 		return core.LeaseTarget{}, core.Exit(2, "digitalocean lease=%s has no exact local claim; refusing release", leaseID)
-	} else if !req.NoLocalStateMutations {
+	} else if !claimExists && !req.NoLocalStateMutations {
 		if !req.Reclaim {
 			return core.LeaseTarget{}, core.Exit(2, "digitalocean lease=%s is unclaimed; use --reclaim to adopt it explicitly", leaseID)
 		}

--- a/internal/providers/digitalocean/backend_test.go
+++ b/internal/providers/digitalocean/backend_test.go
@@ -256,7 +256,7 @@ func TestSuccessfulAcquireDoesNotDeleteReusedSSHKey(t *testing.T) {
 	}
 }
 
-func TestReleaseUsesLeaseKeyIdentityWhenClaimIsMissing(t *testing.T) {
+func TestReleaseRefusesLeaseWhenClaimIsMissing(t *testing.T) {
 	api := &fakeDigitalOceanAPI{}
 	backend := newTestBackend(t, api)
 	lease, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "missing-claim"})
@@ -265,10 +265,10 @@ func TestReleaseUsesLeaseKeyIdentityWhenClaimIsMissing(t *testing.T) {
 	}
 	core.RemoveLeaseClaim(lease.LeaseID)
 
-	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
-		t.Fatal(err)
+	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err == nil || !strings.Contains(err.Error(), "no exact local claim") {
+		t.Fatalf("ReleaseLease err=%v", err)
 	}
-	if len(api.deleted) != 1 || api.deleted[0] != 100 || len(api.deletedKeyIDs) != 1 || api.deletedKeyIDs[0] != 700 {
+	if len(api.deleted) != 0 || len(api.deletedKeyIDs) != 0 {
 		t.Fatalf("deleted=%v deletedKeyIDs=%v", api.deleted, api.deletedKeyIDs)
 	}
 }
@@ -950,12 +950,34 @@ func TestResolveVisibleDropletIgnoresUnrelatedCorruptClaim(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: slug, ReleaseOnly: true})
+	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: slug, Repo: core.Repo{Root: t.TempDir()}, Reclaim: true})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if lease.Server.ID != item.ID || lease.LeaseID != leaseID {
 		t.Fatalf("lease=%#v", lease)
+	}
+}
+
+func TestResolveReadOnlyDoesNotClaimVisibleDroplet(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.TargetOS = core.TargetLinux
+	leaseID := "cbx_abcdef123459"
+	slug := "read-only"
+	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", false, time.Now())
+	item := droplet{ID: 109, Name: core.LeaseProviderName(leaseID, slug), Status: "active", Tags: tagsFromLabels(labels)}
+	backend := newTestBackend(t, &fakeDigitalOceanAPI{droplets: []droplet{item}})
+
+	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: slug, Repo: core.Repo{Root: t.TempDir()}, NoLocalStateMutations: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.LeaseID != leaseID || lease.Server.ID != item.ID {
+		t.Fatalf("lease=%#v", lease)
+	}
+	if _, exists, err := core.ReadLeaseClaimWithPresence(leaseID); err != nil || exists {
+		t.Fatalf("read-only resolve wrote claim: exists=%v err=%v", exists, err)
 	}
 }
 
@@ -970,9 +992,10 @@ func TestResolveNumericIdentifierPrefersDropletIDOverSlug(t *testing.T) {
 		{ID: 106, Name: core.LeaseProviderName("cbx_abcdef123421", "105"), Status: "active", Tags: tagsFromLabels(slugLabels)},
 	}}
 	backend := newTestBackend(t, api)
+	repoRoot := t.TempDir()
 
 	for _, identifier := range []string{"105", " 105 ", "+105"} {
-		lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: identifier, ReleaseOnly: true})
+		lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: identifier, Repo: core.Repo{Root: repoRoot}, Reclaim: true})
 		if err != nil {
 			t.Fatalf("Resolve(%q) err=%v", identifier, err)
 		}
@@ -1658,15 +1681,12 @@ func TestResolveBySlugAndReleaseDeletesOwnedDroplet(t *testing.T) {
 	}{IPAddress: "203.0.113.77", Type: "public"})
 	api := &fakeDigitalOceanAPI{droplets: []droplet{item}}
 	backend := newTestBackend(t, api)
-	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "resolve-me"})
+	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "resolve-me", Repo: core.Repo{Root: t.TempDir()}, Reclaim: true})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if lease.LeaseID != "cbx_abcdef123456" || lease.SSH.Host != "203.0.113.77" {
 		t.Fatalf("lease=%#v", lease)
-	}
-	if err := core.ClaimLeaseTargetForRepoConfig(lease.LeaseID, "resolve-me", backend.Cfg, lease.Server, lease.SSH, t.TempDir(), 0, false); err != nil {
-		t.Fatal(err)
 	}
 	keyPath := writeStoredTestboxKey(t, lease.LeaseID)
 	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
@@ -2132,7 +2152,7 @@ func TestReleaseRefusesUnownedDroplet(t *testing.T) {
 	api := &fakeDigitalOceanAPI{}
 	backend := newTestBackend(t, api)
 	server := core.Server{ID: 9, Name: "foreign", Labels: map[string]string{"crabbox": "true"}}
-	err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{Server: server, LeaseID: "cbx_9"}})
+	err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{Server: server, LeaseID: "cbx_999999999999"}})
 	if err == nil {
 		t.Fatal("ReleaseLease accepted unowned server")
 	}
@@ -2141,7 +2161,7 @@ func TestReleaseRefusesUnownedDroplet(t *testing.T) {
 	}
 }
 
-func TestReleaseRemovesStoredKeyWithoutClaim(t *testing.T) {
+func TestReleaseWithoutClaimPreservesStoredKey(t *testing.T) {
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
 	cfg.TargetOS = core.TargetLinux
@@ -2154,55 +2174,42 @@ func TestReleaseRemovesStoredKeyWithoutClaim(t *testing.T) {
 	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{
 		Server:  serverFromDroplet(item, backend.Cfg),
 		LeaseID: leaseID,
-	}}); err != nil {
-		t.Fatal(err)
+	}}); err == nil || !strings.Contains(err.Error(), "no exact local claim") {
+		t.Fatalf("ReleaseLease err=%v", err)
 	}
-	if _, err := os.Stat(keyPath); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("stored key still exists after unclaimed release: %v", err)
+	if _, err := os.Stat(keyPath); err != nil {
+		t.Fatalf("stored key removed after refused unclaimed release: %v", err)
 	}
 	if len(api.deletedKeyIDs) != 0 || len(api.deletedKeys) != 0 {
 		t.Fatalf("claimless cleanup deletedKeyIDs=%v deletedKeys=%v", api.deletedKeyIDs, api.deletedKeys)
 	}
+	if len(api.deleted) != 0 {
+		t.Fatalf("claimless cleanup deleted droplets=%v", api.deleted)
+	}
 }
 
-func TestReleasePersistsClaimBeforeUnclaimedDeleteFailure(t *testing.T) {
+func TestReleaseDoesNotPersistClaimForUnclaimedServer(t *testing.T) {
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
 	cfg.TargetOS = core.TargetLinux
 	leaseID := "cbx_abcdef123461"
 	item := droplet{ID: 92, Name: "retry-delete", Status: "active", Tags: leaseTags(cfg, leaseID, "retry-delete", "ready", false, time.Now())}
-	api := &fakeDigitalOceanAPI{
-		droplets:  []droplet{item},
-		deleteErr: errors.New("delete response lost"),
-	}
+	api := &fakeDigitalOceanAPI{droplets: []droplet{item}}
 	backend := newTestBackend(t, api)
 	keyPath := writeStoredTestboxKey(t, leaseID)
 	lease := core.LeaseTarget{Server: serverFromDroplet(item, backend.Cfg), LeaseID: leaseID}
 
-	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err == nil || !strings.Contains(err.Error(), "delete response lost") {
+	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err == nil || !strings.Contains(err.Error(), "no exact local claim") {
 		t.Fatalf("ReleaseLease err=%v", err)
 	}
-	claim, ok, err := core.ResolveLeaseClaimForProvider(leaseID, providerName)
-	if err != nil || !ok || claim.CloudID != strconv.FormatInt(item.ID, 10) {
+	if claim, ok, err := core.ResolveLeaseClaimForProvider(leaseID, providerName); err != nil || ok {
 		t.Fatalf("claim=%#v ok=%v err=%v", claim, ok, err)
 	}
 	if _, err := os.Stat(keyPath); err != nil {
-		t.Fatalf("stored key removed after failed delete: %v", err)
+		t.Fatalf("stored key removed after refused delete: %v", err)
 	}
-
-	api.deleteErr = nil
-	retry, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: leaseID, ReleaseOnly: true})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: retry}); err != nil {
-		t.Fatal(err)
-	}
-	if _, ok, err := core.ResolveLeaseClaimForProvider(leaseID, providerName); err != nil || ok {
-		t.Fatalf("claim after retry ok=%v err=%v", ok, err)
-	}
-	if _, err := os.Stat(keyPath); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("stored key after retry: %v", err)
+	if len(api.deleted) != 0 {
+		t.Fatalf("unclaimed release deleted=%v", api.deleted)
 	}
 }
 
@@ -2273,7 +2280,7 @@ func TestCleanupPreservesLocalStateForMismatchedProviderClaim(t *testing.T) {
 	cfg.Provider = providerName
 	cfg.TargetOS = core.TargetLinux
 	cfg.TTL = time.Nanosecond
-	leaseID := "cbx_shared123456"
+	leaseID := "cbx_123456abcdef"
 	item := droplet{ID: 89, Name: "old", Status: "active", Tags: leaseTags(cfg, leaseID, "old", "ready", false, time.Now().Add(-time.Hour))}
 	api := &fakeDigitalOceanAPI{droplets: []droplet{item}}
 	backend := newTestBackend(t, api)
@@ -2296,10 +2303,10 @@ func TestCleanupPreservesLocalStateForMismatchedProviderClaim(t *testing.T) {
 	}
 	keyPath := writeStoredTestboxKey(t, leaseID)
 
-	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
-		t.Fatal(err)
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err == nil || !strings.Contains(err.Error(), "claimed by provider=aws") {
+		t.Fatalf("Cleanup err=%v", err)
 	}
-	if len(api.deleted) != 1 || api.deleted[0] != 89 {
+	if len(api.deleted) != 0 {
 		t.Fatalf("deleted=%v", api.deleted)
 	}
 	if len(api.deletedKeyIDs) != 0 {
@@ -2315,6 +2322,24 @@ func TestCleanupPreservesLocalStateForMismatchedProviderClaim(t *testing.T) {
 	}
 	if _, err := os.Stat(keyPath); err != nil {
 		t.Fatalf("other provider key removed by cleanup: %v", err)
+	}
+}
+
+func claimDigitalOceanServer(t *testing.T, backend *digitalOceanLeaseBackend, server core.Server) {
+	t.Helper()
+	server.Labels[digitalOceanAccountLabel] = "team:test-account"
+	leaseID := server.Labels["lease"]
+	if err := core.ClaimLeaseTargetForRepoConfig(
+		leaseID,
+		server.Labels["slug"],
+		backend.Cfg,
+		server,
+		core.SSHTarget{},
+		t.TempDir(),
+		backend.Cfg.IdleTimeout,
+		false,
+	); err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -2508,6 +2533,7 @@ func TestReleaseWithoutKeyOwnershipDoesNotDeleteByName(t *testing.T) {
 	api := &fakeDigitalOceanAPI{droplets: []droplet{item}}
 	backend := newTestBackend(t, api)
 	server := serverFromDroplet(item, backend.Cfg)
+	claimDigitalOceanServer(t, backend, server)
 
 	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{
 		Server:  server,
@@ -2534,9 +2560,11 @@ func TestReleaseDeletesDropletBeforeRetryableKeyIdentityLookup(t *testing.T) {
 		},
 	}
 	backend := newTestBackend(t, api)
+	server := serverFromDroplet(item, backend.Cfg)
+	claimDigitalOceanServer(t, backend, server)
 
 	err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{
-		Server:  serverFromDroplet(item, backend.Cfg),
+		Server:  server,
 		LeaseID: leaseID,
 	}})
 	if err == nil || !strings.Contains(err.Error(), "key lookup failed") {
@@ -2569,9 +2597,11 @@ func TestReleaseCompletesWithoutDeletingUnprovenMatchingKey(t *testing.T) {
 	}
 	backend := newTestBackend(t, api)
 	writeStoredTestboxKey(t, leaseID)
+	server := serverFromDroplet(item, backend.Cfg)
+	claimDigitalOceanServer(t, backend, server)
 
 	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{
-		Server:  serverFromDroplet(item, backend.Cfg),
+		Server:  server,
 		LeaseID: leaseID,
 	}}); err != nil {
 		t.Fatal(err)
@@ -2600,9 +2630,11 @@ func TestReleaseCompletesWithoutDeletingNamedKeyLackingLocalProof(t *testing.T) 
 		}},
 	}
 	backend := newTestBackend(t, api)
+	server := serverFromDroplet(item, backend.Cfg)
+	claimDigitalOceanServer(t, backend, server)
 
 	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{
-		Server:  serverFromDroplet(item, backend.Cfg),
+		Server:  server,
 		LeaseID: leaseID,
 	}}); err != nil {
 		t.Fatal(err)

--- a/internal/providers/digitalocean/backend_test.go
+++ b/internal/providers/digitalocean/backend_test.go
@@ -2313,8 +2313,9 @@ func TestCleanupDryRunDoesNotDelete(t *testing.T) {
 	cfg.Provider = providerName
 	cfg.TargetOS = core.TargetLinux
 	cfg.TTL = time.Nanosecond
+	claimless := droplet{ID: 87, Name: "claimless", Status: "active", Tags: leaseTags(cfg, "cbx_111111111111", "claimless", "ready", false, time.Now().Add(-time.Hour))}
 	item := droplet{ID: 88, Name: "old", Status: "active", Tags: leaseTags(cfg, "cbx_deadbeef1234", "old", "ready", false, time.Now().Add(-time.Hour))}
-	api := &fakeDigitalOceanAPI{droplets: []droplet{item}}
+	api := &fakeDigitalOceanAPI{droplets: []droplet{claimless, item}}
 	backend := newTestBackend(t, api)
 	server := serverFromDroplet(item, backend.Cfg)
 	server.Labels[digitalOceanAccountLabel] = "team:test-account"
@@ -2376,8 +2377,8 @@ func TestCleanupPreservesLocalStateForMismatchedProviderClaim(t *testing.T) {
 	}
 	keyPath := writeStoredTestboxKey(t, leaseID)
 
-	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err == nil || !strings.Contains(err.Error(), "claimed by provider=aws") {
-		t.Fatalf("Cleanup err=%v", err)
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+		t.Fatalf("Cleanup should skip mismatched claim: %v", err)
 	}
 	if len(api.deleted) != 0 {
 		t.Fatalf("deleted=%v", api.deleted)

--- a/internal/providers/digitalocean/backend_test.go
+++ b/internal/providers/digitalocean/backend_test.go
@@ -981,6 +981,36 @@ func TestResolveReadOnlyDoesNotClaimVisibleDroplet(t *testing.T) {
 	}
 }
 
+func TestResolveReadOnlyIgnoresStaleDropletClaim(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.TargetOS = core.TargetLinux
+	leaseID := "cbx_abcdef12345a"
+	slug := "stale-read-only"
+	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", false, time.Now())
+	item := droplet{ID: 110, Name: core.LeaseProviderName(leaseID, slug), Status: "active", Tags: tagsFromLabels(labels)}
+	backend := newTestBackend(t, &fakeDigitalOceanAPI{droplets: []droplet{item}})
+	labels[digitalOceanAccountLabel] = "team:test-account"
+	claimServer := core.Server{Provider: providerName, CloudID: "999", ID: 999, Name: item.Name, Labels: labels}
+	if err := core.ClaimLeaseTargetForConfig(leaseID, slug, backend.Cfg, claimServer, core.SSHTarget{}, backend.Cfg.IdleTimeout); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: slug, NoLocalStateMutations: true}); err == nil || !strings.Contains(err.Error(), "stale local claim") {
+		t.Fatalf("identity-bound resolve err=%v", err)
+	}
+	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: slug, StatusOnly: true, NoLocalStateMutations: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.LeaseID != leaseID || lease.Server.ID != item.ID {
+		t.Fatalf("lease=%#v", lease)
+	}
+	claim, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
+	if err != nil || !exists || claim.CloudID != "999" {
+		t.Fatalf("read-only resolve changed stale claim: claim=%#v exists=%v err=%v", claim, exists, err)
+	}
+}
+
 func TestResolveNumericIdentifierPrefersDropletIDOverSlug(t *testing.T) {
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName

--- a/internal/providers/digitalocean/backend_test.go
+++ b/internal/providers/digitalocean/backend_test.go
@@ -2313,10 +2313,16 @@ func TestCleanupDryRunDoesNotDelete(t *testing.T) {
 	cfg.Provider = providerName
 	cfg.TargetOS = core.TargetLinux
 	cfg.TTL = time.Nanosecond
+	stale := droplet{ID: 86, Name: "stale-account", Status: "active", Tags: leaseTags(cfg, "cbx_222222222222", "stale-account", "ready", false, time.Now().Add(-time.Hour))}
 	claimless := droplet{ID: 87, Name: "claimless", Status: "active", Tags: leaseTags(cfg, "cbx_111111111111", "claimless", "ready", false, time.Now().Add(-time.Hour))}
 	item := droplet{ID: 88, Name: "old", Status: "active", Tags: leaseTags(cfg, "cbx_deadbeef1234", "old", "ready", false, time.Now().Add(-time.Hour))}
-	api := &fakeDigitalOceanAPI{droplets: []droplet{claimless, item}}
+	api := &fakeDigitalOceanAPI{droplets: []droplet{stale, claimless, item}}
 	backend := newTestBackend(t, api)
+	staleServer := serverFromDroplet(stale, backend.Cfg)
+	staleServer.Labels[digitalOceanAccountLabel] = "team:stale-account"
+	if err := core.ClaimLeaseTargetForRepoConfig("cbx_222222222222", "stale-account", backend.Cfg, staleServer, core.SSHTarget{}, t.TempDir(), 0, false); err != nil {
+		t.Fatal(err)
+	}
 	server := serverFromDroplet(item, backend.Cfg)
 	server.Labels[digitalOceanAccountLabel] = "team:test-account"
 	if err := core.ClaimLeaseTargetForRepoConfig("cbx_deadbeef1234", "old", backend.Cfg, server, core.SSHTarget{}, t.TempDir(), 0, false); err != nil {
@@ -2340,6 +2346,9 @@ func TestCleanupDryRunDoesNotDelete(t *testing.T) {
 	}
 	if len(api.deleted) != 1 || api.deleted[0] != 88 {
 		t.Fatalf("deleted=%v", api.deleted)
+	}
+	if _, ok, err := core.ResolveLeaseClaimForProvider("cbx_222222222222", providerName); err != nil || !ok {
+		t.Fatalf("stale-account claim after cleanup ok=%v err=%v", ok, err)
 	}
 	if _, ok, err := core.ResolveLeaseClaimForProvider("old", providerName); err != nil || ok {
 		t.Fatalf("claim after cleanup ok=%v err=%v", ok, err)

--- a/internal/providers/digitalocean/backend_test.go
+++ b/internal/providers/digitalocean/backend_test.go
@@ -1011,6 +1011,23 @@ func TestResolveReadOnlyIgnoresStaleDropletClaim(t *testing.T) {
 	}
 }
 
+func TestStatusTouchClaimRequiresMatchingAccount(t *testing.T) {
+	backend := &digitalOceanLeaseBackend{}
+	claim := core.LeaseClaim{Labels: map[string]string{digitalOceanAccountLabel: "team:account-a"}}
+	lease := core.LeaseTarget{Server: core.Server{Labels: map[string]string{digitalOceanAccountLabel: "team:account-a"}}}
+	if !backend.StatusTouchClaimMatches(lease, claim) {
+		t.Fatal("matching account identity was rejected")
+	}
+	lease.Server.Labels[digitalOceanAccountLabel] = "team:account-b"
+	if backend.StatusTouchClaimMatches(lease, claim) {
+		t.Fatal("mismatched account identity was accepted")
+	}
+	delete(claim.Labels, digitalOceanAccountLabel)
+	if backend.StatusTouchClaimMatches(lease, claim) {
+		t.Fatal("missing claim account identity was accepted")
+	}
+}
+
 func TestResolveNumericIdentifierPrefersDropletIDOverSlug(t *testing.T) {
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName

--- a/internal/providers/digitalocean/backend_test.go
+++ b/internal/providers/digitalocean/backend_test.go
@@ -1042,6 +1042,32 @@ func TestReleaseNumericIdentifierPrefersClaimCloudIDOverSlug(t *testing.T) {
 	}
 }
 
+func TestReleaseCanonicalIdentifierDoesNotFallBackToClaimSlug(t *testing.T) {
+	api := &fakeDigitalOceanAPI{}
+	backend := newTestBackend(t, api)
+	const (
+		requestedID = "cbx_aaaaaaaaaaaa"
+		lookalikeID = "cbx_bbbbbbbbbbbb"
+	)
+	labels := core.DirectLeaseLabels(backend.Cfg, lookalikeID, requestedID, providerName, "", false, time.Now())
+	labels[digitalOceanAccountLabel] = "team:test-account"
+	server := core.Server{
+		Provider: providerName,
+		CloudID:  "105",
+		ID:       105,
+		Name:     core.LeaseProviderName(lookalikeID, requestedID),
+		Labels:   labels,
+	}
+	if err := core.ClaimLeaseTargetForRepoConfig(lookalikeID, requestedID, backend.Cfg, server, core.SSHTarget{}, t.TempDir(), backend.Cfg.IdleTimeout, false); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: requestedID, ReleaseOnly: true})
+	if err == nil || !strings.Contains(err.Error(), "exact lease identifier") {
+		t.Fatalf("Resolve release-only err=%v", err)
+	}
+}
+
 func TestResolveVisibleDropletRejectsAccountMismatchBeforePreservingKeyIdentity(t *testing.T) {
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName

--- a/internal/providers/digitalocean/client_test.go
+++ b/internal/providers/digitalocean/client_test.go
@@ -464,7 +464,7 @@ func TestDigitalOceanClientReplaceDropletTagsSkipsUnchangedSet(t *testing.T) {
 		t.Fatal(err)
 	}
 	client.baseURL = server.URL
-	tags := []string{tagCrabbox, "crabbox:lease:cbx_1", "crabbox:state:ready"}
+	tags := []string{tagCrabbox, "crabbox:lease:cbx_111111111111", "crabbox:state:ready"}
 	if err := client.ReplaceDropletTags(context.Background(), 42, tags, append([]string(nil), tags...)); err != nil {
 		t.Fatal(err)
 	}
@@ -1191,15 +1191,15 @@ func TestListCrabboxDropletsFiltersAndPaginates(t *testing.T) {
 			t.Fatalf("tag_name=%q", r.URL.Query().Get("tag_name"))
 		}
 		if r.URL.Query().Get("type") == "gpus" {
-			_, _ = w.Write([]byte(`{"droplets":[{"id":4,"name":"gpu-owned","tags":["crabbox","crabbox:provider:digitalocean","crabbox:lease:cbx_4","crabbox:slug:gpu","crabbox:target:linux"]}],"links":{"pages":{}}}`))
+			_, _ = w.Write([]byte(`{"droplets":[{"id":4,"name":"gpu-owned","tags":["crabbox","crabbox:provider:digitalocean","crabbox:lease:cbx_444444444444","crabbox:slug:gpu","crabbox:target:linux"]}],"links":{"pages":{}}}`))
 			return
 		}
 		standardPage++
 		if standardPage == 1 {
-			_, _ = w.Write([]byte(`{"droplets":[{"id":1,"name":"owned","tags":["Crabbox","Crabbox:Provider:DigitalOcean","Crabbox:Lease:cbx_1","Crabbox:Slug:one","Crabbox:Target:Linux"]},{"id":2,"name":"foreign","tags":["Crabbox"]}],"links":{"pages":{"next":"yes"}}}`))
+			_, _ = w.Write([]byte(`{"droplets":[{"id":1,"name":"owned","tags":["Crabbox","Crabbox:Provider:DigitalOcean","Crabbox:Lease:cbx_111111111111","Crabbox:Slug:one","Crabbox:Target:Linux"]},{"id":2,"name":"foreign","tags":["Crabbox"]}],"links":{"pages":{"next":"yes"}}}`))
 			return
 		}
-		_, _ = w.Write([]byte(`{"droplets":[{"id":3,"name":"owned2","tags":["crabbox","crabbox:provider:digitalocean","crabbox:lease:cbx_2","crabbox:slug:two","crabbox:target:linux"]}],"links":{"pages":{}}}`))
+		_, _ = w.Write([]byte(`{"droplets":[{"id":3,"name":"owned2","tags":["crabbox","crabbox:provider:digitalocean","crabbox:lease:cbx_222222222222","crabbox:slug:two","crabbox:target:linux"]}],"links":{"pages":{}}}`))
 	}))
 	defer server.Close()
 	t.Setenv("DIGITALOCEAN_TOKEN", "token")

--- a/internal/providers/digitalocean/tags.go
+++ b/internal/providers/digitalocean/tags.go
@@ -311,7 +311,7 @@ func validateDropletLabels(labels map[string]string) error {
 		labels["crabbox"] != "true" ||
 		labels["created_by"] != "crabbox" ||
 		labels["provider"] != providerName ||
-		labels["lease"] == "" ||
+		!core.IsCanonicalLeaseID(labels["lease"]) ||
 		labels["slug"] == "" ||
 		labels["target"] != core.TargetLinux {
 		return core.Exit(2, "refusing to operate on non-Crabbox DigitalOcean Droplet")

--- a/internal/providers/digitalocean/tags_test.go
+++ b/internal/providers/digitalocean/tags_test.go
@@ -46,6 +46,7 @@ func TestValidateDropletLabelsRejectsPartialOwnership(t *testing.T) {
 	}{
 		{name: "nil", labels: nil},
 		{name: "generic crabbox only", labels: map[string]string{"crabbox": "true"}},
+		{name: "non-canonical lease", labels: map[string]string{"crabbox": "true", "created_by": "crabbox", "provider": providerName, "lease": "legacy-lease-1", "slug": "x", "target": core.TargetLinux}},
 		{name: "wrong provider", labels: map[string]string{"crabbox": "true", "created_by": "crabbox", "provider": "hetzner", "lease": "cbx_1", "slug": "x", "target": core.TargetLinux}},
 		{name: "missing lease", labels: map[string]string{"crabbox": "true", "created_by": "crabbox", "provider": providerName, "slug": "x", "target": core.TargetLinux}},
 		{name: "wrong target", labels: map[string]string{"crabbox": "true", "created_by": "crabbox", "provider": providerName, "lease": "cbx_1", "slug": "x", "target": "windows"}},

--- a/internal/providers/linode/backend.go
+++ b/internal/providers/linode/backend.go
@@ -544,6 +544,11 @@ func (b *linodeLeaseBackend) ReleaseLeaseMessage(lease core.LeaseTarget) string 
 	return fmt.Sprintf("deleted lease=%s linode=%s name=%s", lease.LeaseID, lease.Server.DisplayID(), lease.Server.Name)
 }
 
+func (b *linodeLeaseBackend) StatusTouchClaimMatches(lease core.LeaseTarget, claim core.LeaseClaim) bool {
+	expected := strings.TrimSpace(claim.Labels[linodeAccountLabel])
+	return expected != "" && expected == strings.TrimSpace(lease.Server.Labels[linodeAccountLabel])
+}
+
 func (b *linodeLeaseBackend) Touch(ctx context.Context, req core.TouchRequest) (core.Server, error) {
 	server := req.Lease.Server
 	if err := validateLinodeLabels(server.Labels); err != nil {

--- a/internal/providers/linode/backend.go
+++ b/internal/providers/linode/backend.go
@@ -442,7 +442,7 @@ func (b *linodeLeaseBackend) targetFromLinode(item linodeInstance, req core.Reso
 	if claimErr != nil {
 		return core.LeaseTarget{}, fmt.Errorf("read linode lease claim: %w", claimErr)
 	}
-	if claimExists {
+	if claimExists && !req.IsReadOnlyStatus() {
 		if claim.Provider != providerName {
 			return core.LeaseTarget{}, core.Exit(2, "lease=%s is claimed by provider=%s; refusing linode claim rewrite", leaseID, claim.Provider)
 		}
@@ -463,9 +463,9 @@ func (b *linodeLeaseBackend) targetFromLinode(item linodeInstance, req core.Reso
 		if claim.CloudID == "" && !isPendingRecoveryClaim(claim, leaseID) {
 			return core.LeaseTarget{}, core.Exit(2, "linode lease claim has no instance identity or valid pending recovery state for lease=%s", leaseID)
 		}
-	} else if req.ReleaseOnly {
+	} else if !claimExists && req.ReleaseOnly {
 		return core.LeaseTarget{}, core.Exit(2, "linode lease=%s has no exact local claim; refusing release", leaseID)
-	} else if !req.NoLocalStateMutations {
+	} else if !claimExists && !req.NoLocalStateMutations {
 		if !req.Reclaim {
 			return core.LeaseTarget{}, core.Exit(2, "linode lease=%s is unclaimed; use --reclaim to adopt it explicitly", leaseID)
 		}

--- a/internal/providers/linode/backend.go
+++ b/internal/providers/linode/backend.go
@@ -634,8 +634,17 @@ func (b *linodeLeaseBackend) Cleanup(ctx context.Context, req core.CleanupReques
 	return b.CleanupServers(ctx, req, servers)
 }
 
-func (b *linodeLeaseBackend) cleanupEligible(server core.Server) (bool, error) {
-	_, err := b.ensureCleanupClaim(server, true)
+func (b *linodeLeaseBackend) cleanupEligible(ctx context.Context, server core.Server) (bool, error) {
+	client, err := b.clientFactory(b.RT)
+	if err != nil {
+		return false, err
+	}
+	accountID, err := client.AccountID(ctx)
+	if err != nil {
+		return false, err
+	}
+	server = shared.ServerWithDefaultLabel(server, linodeAccountLabel, accountID)
+	_, err = b.ensureCleanupClaim(server, true)
 	return shared.CleanupClaimEligible(err)
 }
 

--- a/internal/providers/linode/backend.go
+++ b/internal/providers/linode/backend.go
@@ -463,6 +463,15 @@ func (b *linodeLeaseBackend) targetFromLinode(item linodeInstance, req core.Reso
 		if claim.CloudID == "" && !isPendingRecoveryClaim(claim, leaseID) {
 			return core.LeaseTarget{}, core.Exit(2, "linode lease claim has no instance identity or valid pending recovery state for lease=%s", leaseID)
 		}
+	} else if req.ReleaseOnly {
+		return core.LeaseTarget{}, core.Exit(2, "linode lease=%s has no exact local claim; refusing release", leaseID)
+	} else if !req.NoLocalStateMutations {
+		if !req.Reclaim {
+			return core.LeaseTarget{}, core.Exit(2, "linode lease=%s is unclaimed; use --reclaim to adopt it explicitly", leaseID)
+		}
+		if req.Repo.Root == "" {
+			return core.LeaseTarget{}, core.Exit(2, "linode lease=%s cannot be reclaimed without a repository root", leaseID)
+		}
 	}
 	if req.ReleaseOnly {
 		target := core.LeaseTarget{Server: server, LeaseID: leaseID}
@@ -477,7 +486,7 @@ func (b *linodeLeaseBackend) targetFromLinode(item linodeInstance, req core.Reso
 			ssh.Key = keyPath
 		}
 	}
-	if req.Repo.Root != "" {
+	if req.Repo.Root != "" && !req.NoLocalStateMutations {
 		if _, err := core.ClaimLeaseTargetForRepoConfigIfUnchanged(leaseID, server.Labels["slug"], b.Cfg, server, ssh, req.Repo.Root, b.Cfg.IdleTimeout, req.Reclaim, claim, claimExists); err != nil {
 			return core.LeaseTarget{}, err
 		}
@@ -675,14 +684,10 @@ func (b *linodeLeaseBackend) deleteServer(ctx context.Context, _ core.Config, se
 			}
 		}
 	}
-	foreignClaim := claim.Provider != providerName
 	if item.ID != 0 {
 		if err := client.DeleteLinode(ctx, server.ID); err != nil {
 			return err
 		}
-	}
-	if foreignClaim {
-		return nil
 	}
 	if err := core.RemoveLeaseClaimIfUnchanged(leaseID, claim); err != nil {
 		return fmt.Errorf("finalize linode cleanup claim: %w", err)
@@ -702,21 +707,14 @@ func (b *linodeLeaseBackend) ensureCleanupClaim(server core.Server, liveLinodeVe
 			return core.LeaseClaim{}, core.Exit(2, "linode lease claim is incomplete for lease=%s", leaseID)
 		}
 	} else {
-		repoRoot, err := os.Getwd()
-		if err != nil {
-			return core.LeaseClaim{}, fmt.Errorf("resolve cleanup claim working directory: %w", err)
-		}
-		claim, err = core.ClaimLeaseTargetForRepoConfigIfUnchanged(leaseID, server.Labels["slug"], b.Cfg, server, core.SSHTarget{}, repoRoot, b.Cfg.IdleTimeout, false, claim, false)
-		if err != nil {
-			return core.LeaseClaim{}, fmt.Errorf("persist linode cleanup claim: %w", err)
-		}
+		return core.LeaseClaim{}, core.Exit(2, "linode lease=%s has no exact local claim; refusing cleanup", leaseID)
 	}
 	cloudID := firstNonBlank(server.CloudID, strconv.FormatInt(server.ID, 10))
 	if claim.Provider == providerName && claim.CloudID != "" && claim.CloudID != cloudID {
 		return core.LeaseClaim{}, core.Exit(2, "refusing to release Linode instance %d from stale local claim", server.ID)
 	}
 	if claim.Provider != providerName {
-		return claim, nil
+		return core.LeaseClaim{}, core.Exit(2, "lease=%s is claimed by provider=%s; refusing linode cleanup", leaseID, claim.Provider)
 	}
 	if err := validateLinodeClaimIdentity(claim, leaseID, server.Labels["slug"]); err != nil {
 		return core.LeaseClaim{}, err

--- a/internal/providers/linode/backend.go
+++ b/internal/providers/linode/backend.go
@@ -71,6 +71,7 @@ func newLinodeLeaseBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runt
 		return core.WaitForSSHReady(ctx, target, b.RT.Stderr, phase, timeout)
 	}
 	b.Delete = b.deleteServer
+	b.CleanupEligible = b.cleanupEligible
 	return b
 }
 
@@ -631,6 +632,11 @@ func (b *linodeLeaseBackend) Cleanup(ctx context.Context, req core.CleanupReques
 		return err
 	}
 	return b.CleanupServers(ctx, req, servers)
+}
+
+func (b *linodeLeaseBackend) cleanupEligible(server core.Server) (bool, error) {
+	_, err := b.ensureCleanupClaim(server, true)
+	return shared.CleanupClaimEligible(err)
 }
 
 func (b *linodeLeaseBackend) deleteServer(ctx context.Context, _ core.Config, server core.Server) error {

--- a/internal/providers/linode/backend.go
+++ b/internal/providers/linode/backend.go
@@ -313,7 +313,7 @@ func (b *linodeLeaseBackend) releaseTargetFromClaim(ctx context.Context, client 
 	)
 	var exact bool
 	claim, ok, exact, err = core.ResolveLeaseClaimForProviderWithExact(id, providerName)
-	if err == nil && exact && (!ok || claim.LeaseID != id) {
+	if err == nil && (exact || core.IsCanonicalLeaseID(id)) && (!exact || !ok || claim.LeaseID != id) {
 		return core.LeaseTarget{}, core.Exit(2, "linode exact lease identifier %q does not match a valid linode claim", id)
 	}
 	if err == nil && !ok {

--- a/internal/providers/linode/backend_test.go
+++ b/internal/providers/linode/backend_test.go
@@ -365,6 +365,32 @@ func TestResolveNumericSlugBeforeRawLinodeID(t *testing.T) {
 	}
 }
 
+func TestReleaseCanonicalIdentifierDoesNotFallBackToClaimSlug(t *testing.T) {
+	api := &fakeLinodeAPI{}
+	backend := newTestBackend(t, api)
+	const (
+		requestedID = "cbx_aaaaaaaaaaaa"
+		lookalikeID = "cbx_bbbbbbbbbbbb"
+	)
+	labels := core.DirectLeaseLabels(backend.Cfg, lookalikeID, requestedID, providerName, "", false, time.Now())
+	labels[linodeAccountLabel] = "euuid:A1BC2DEF-34GH-567I-J890KLMN12O34P56"
+	server := core.Server{
+		Provider: providerName,
+		CloudID:  "456",
+		ID:       456,
+		Name:     core.LeaseProviderName(lookalikeID, requestedID),
+		Labels:   labels,
+	}
+	if err := core.ClaimLeaseTargetForRepoConfig(lookalikeID, requestedID, backend.Cfg, server, core.SSHTarget{}, t.TempDir(), backend.Cfg.IdleTimeout, false); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: requestedID, ReleaseOnly: true})
+	if err == nil || !strings.Contains(err.Error(), "exact lease identifier") {
+		t.Fatalf("Resolve release-only err=%v", err)
+	}
+}
+
 func TestResolveReadOnlyDoesNotClaimVisibleLinode(t *testing.T) {
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName

--- a/internal/providers/linode/backend_test.go
+++ b/internal/providers/linode/backend_test.go
@@ -557,16 +557,25 @@ func TestCleanupDryRunSkipsKeepAndDeletesExpiredWhenLive(t *testing.T) {
 	claimlessLabels["state"] = "ready"
 	claimlessLabels[linodeAccountLabel] = "euuid:A1BC2DEF-34GH-567I-J890KLMN12O34P56"
 	claimlessLabels["expires_at"] = "1"
+	staleLabels := core.DirectLeaseLabels(cfg, "cbx_222222222222", "stale-account", providerName, "", false, now.Add(-2*time.Hour))
+	staleLabels["state"] = "ready"
+	staleLabels["expires_at"] = "1"
 	keepLabels := core.DirectLeaseLabels(cfg, "cbx_555555555555", "keep", providerName, "", true, now.Add(-2*time.Hour))
 	keepLabels["state"] = "ready"
 	keepLabels[linodeAccountLabel] = "euuid:A1BC2DEF-34GH-567I-J890KLMN12O34P56"
 	api := &fakeLinodeAPI{linodes: []linodeInstance{
+		{ID: 8, Label: core.LeaseProviderName("cbx_222222222222", "stale-account"), Status: "running", Type: "g6-standard-1", IPv4: []string{"203.0.113.8"}, Tags: tagsFromLabels(staleLabels)},
 		{ID: 9, Label: core.LeaseProviderName("cbx_333333333333", "claimless"), Status: "running", Type: "g6-standard-1", IPv4: []string{"203.0.113.9"}, Tags: tagsFromLabels(claimlessLabels)},
 		{ID: 10, Label: core.LeaseProviderName("cbx_444444444444", "expired"), Status: "running", Type: "g6-standard-1", IPv4: []string{"203.0.113.10"}, Tags: tagsFromLabels(expiredLabels)},
 		{ID: 11, Label: core.LeaseProviderName("cbx_555555555555", "keep"), Status: "running", Type: "g6-standard-1", IPv4: []string{"203.0.113.11"}, Tags: tagsFromLabels(keepLabels)},
 	}}
 	backend := newTestBackend(t, api)
 	backend.RT.Clock = fakeClock{t: now}
+	staleServer := serverFromLinode(api.linodes[0], cfg)
+	staleServer.Labels[linodeAccountLabel] = "euuid:stale-account"
+	if err := core.ClaimLeaseTargetForRepoConfig("cbx_222222222222", "stale-account", cfg, staleServer, core.SSHTarget{}, t.TempDir(), cfg.IdleTimeout, false); err != nil {
+		t.Fatal(err)
+	}
 
 	if err := backend.Cleanup(context.Background(), core.CleanupRequest{DryRun: true}); err != nil {
 		t.Fatal(err)
@@ -574,7 +583,7 @@ func TestCleanupDryRunSkipsKeepAndDeletesExpiredWhenLive(t *testing.T) {
 	if len(api.deleted) != 0 {
 		t.Fatalf("dry-run deleted=%v", api.deleted)
 	}
-	server := serverFromLinode(api.linodes[1], cfg)
+	server := serverFromLinode(api.linodes[2], cfg)
 	server.Labels[linodeAccountLabel] = expiredLabels[linodeAccountLabel]
 	if err := core.ClaimLeaseTargetForRepoConfig(
 		"cbx_444444444444",
@@ -593,6 +602,9 @@ func TestCleanupDryRunSkipsKeepAndDeletesExpiredWhenLive(t *testing.T) {
 	}
 	if len(api.deleted) != 1 || api.deleted[0] != 10 {
 		t.Fatalf("deleted=%v", api.deleted)
+	}
+	if _, ok, err := core.ResolveLeaseClaimForProvider("cbx_222222222222", providerName); err != nil || !ok {
+		t.Fatalf("stale-account claim after cleanup ok=%v err=%v", ok, err)
 	}
 }
 

--- a/internal/providers/linode/backend_test.go
+++ b/internal/providers/linode/backend_test.go
@@ -300,7 +300,7 @@ func TestListFiltersForeignAndPartialLinodes(t *testing.T) {
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
 	cfg.TargetOS = core.TargetLinux
-	owned := linodeInstance{ID: 1, Label: "crabbox-cbx_one-owned", Status: "running", Type: "g6-standard-1", IPv4: []string{"203.0.113.1"}, Tags: leaseTags(cfg, "cbx_one", "owned", "ready", false, time.Unix(1, 0))}
+	owned := linodeInstance{ID: 1, Label: "crabbox-cbx-111111111111-owned", Status: "running", Type: "g6-standard-1", IPv4: []string{"203.0.113.1"}, Tags: leaseTags(cfg, "cbx_111111111111", "owned", "ready", false, time.Unix(1, 0))}
 	partial := linodeInstance{ID: 2, Label: "partial", Tags: []string{tagCrabbox, "crabbox:provider:linode"}}
 	foreign := linodeInstance{ID: 3, Label: "foreign", Tags: []string{tagCrabbox, "crabbox:provider:aws", "crabbox:target:linux", "crabbox:lease:cbx_two", "crabbox:slug:foreign"}}
 	backend := newTestBackend(t, &fakeLinodeAPI{linodes: []linodeInstance{owned, partial, foreign}})
@@ -356,7 +356,7 @@ func TestResolveNumericSlugBeforeRawLinodeID(t *testing.T) {
 	api := &fakeLinodeAPI{linodes: []linodeInstance{item}}
 	backend := newTestBackend(t, api)
 
-	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "123"})
+	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "123", Repo: core.Repo{Root: t.TempDir()}, Reclaim: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -365,8 +365,30 @@ func TestResolveNumericSlugBeforeRawLinodeID(t *testing.T) {
 	}
 }
 
+func TestResolveReadOnlyDoesNotClaimVisibleLinode(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.TargetOS = core.TargetLinux
+	cfg.ServerType = defaultType
+	leaseID := "cbx_abcdef123457"
+	slug := "read-only"
+	item := linodeInstance{ID: 457, Label: core.LeaseProviderName(leaseID, slug), Status: "running", Type: defaultType, IPv4: []string{"203.0.113.124"}, Tags: leaseTags(cfg, leaseID, slug, "ready", false, time.Now())}
+	backend := newTestBackend(t, &fakeLinodeAPI{linodes: []linodeInstance{item}})
+
+	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: slug, Repo: core.Repo{Root: t.TempDir()}, NoLocalStateMutations: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.LeaseID != leaseID || lease.Server.ID != item.ID {
+		t.Fatalf("lease=%#v", lease)
+	}
+	if _, exists, err := core.ReadLeaseClaimWithPresence(leaseID); err != nil || exists {
+		t.Fatalf("read-only resolve wrote claim: exists=%v err=%v", exists, err)
+	}
+}
+
 func TestResolveReleaseOnlyNumericSlugClaimBeforeRawLinodeID(t *testing.T) {
-	leaseID := "cbx_numeric"
+	leaseID := "cbx_222222222222"
 	slug := "123"
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
@@ -414,7 +436,7 @@ func TestReleaseRefusesAccountMismatch(t *testing.T) {
 }
 
 func TestReleaseMissingLiveLinodeFinalizesLocalClaim(t *testing.T) {
-	leaseID := "cbx_missing"
+	leaseID := "cbx_333333333333"
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
 	cfg.TargetOS = core.TargetLinux
@@ -456,16 +478,16 @@ func TestCleanupDryRunSkipsKeepAndDeletesExpiredWhenLive(t *testing.T) {
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
 	cfg.TargetOS = core.TargetLinux
-	expiredLabels := core.DirectLeaseLabels(cfg, "cbx_expired", "expired", providerName, "", false, now.Add(-2*time.Hour))
+	expiredLabels := core.DirectLeaseLabels(cfg, "cbx_444444444444", "expired", providerName, "", false, now.Add(-2*time.Hour))
 	expiredLabels["state"] = "ready"
 	expiredLabels[linodeAccountLabel] = "euuid:A1BC2DEF-34GH-567I-J890KLMN12O34P56"
 	expiredLabels["expires_at"] = "1"
-	keepLabels := core.DirectLeaseLabels(cfg, "cbx_keep", "keep", providerName, "", true, now.Add(-2*time.Hour))
+	keepLabels := core.DirectLeaseLabels(cfg, "cbx_555555555555", "keep", providerName, "", true, now.Add(-2*time.Hour))
 	keepLabels["state"] = "ready"
 	keepLabels[linodeAccountLabel] = "euuid:A1BC2DEF-34GH-567I-J890KLMN12O34P56"
 	api := &fakeLinodeAPI{linodes: []linodeInstance{
-		{ID: 10, Label: core.LeaseProviderName("cbx_expired", "expired"), Status: "running", Type: "g6-standard-1", IPv4: []string{"203.0.113.10"}, Tags: tagsFromLabels(expiredLabels)},
-		{ID: 11, Label: core.LeaseProviderName("cbx_keep", "keep"), Status: "running", Type: "g6-standard-1", IPv4: []string{"203.0.113.11"}, Tags: tagsFromLabels(keepLabels)},
+		{ID: 10, Label: core.LeaseProviderName("cbx_444444444444", "expired"), Status: "running", Type: "g6-standard-1", IPv4: []string{"203.0.113.10"}, Tags: tagsFromLabels(expiredLabels)},
+		{ID: 11, Label: core.LeaseProviderName("cbx_555555555555", "keep"), Status: "running", Type: "g6-standard-1", IPv4: []string{"203.0.113.11"}, Tags: tagsFromLabels(keepLabels)},
 	}}
 	backend := newTestBackend(t, api)
 	backend.RT.Clock = fakeClock{t: now}
@@ -475,6 +497,20 @@ func TestCleanupDryRunSkipsKeepAndDeletesExpiredWhenLive(t *testing.T) {
 	}
 	if len(api.deleted) != 0 {
 		t.Fatalf("dry-run deleted=%v", api.deleted)
+	}
+	server := serverFromLinode(api.linodes[0], cfg)
+	server.Labels[linodeAccountLabel] = expiredLabels[linodeAccountLabel]
+	if err := core.ClaimLeaseTargetForRepoConfig(
+		"cbx_444444444444",
+		"expired",
+		cfg,
+		server,
+		core.SSHTarget{},
+		t.TempDir(),
+		cfg.IdleTimeout,
+		false,
+	); err != nil {
+		t.Fatal(err)
 	}
 	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)

--- a/internal/providers/linode/backend_test.go
+++ b/internal/providers/linode/backend_test.go
@@ -441,6 +441,23 @@ func TestResolveReadOnlyIgnoresStaleLinodeClaim(t *testing.T) {
 	}
 }
 
+func TestStatusTouchClaimRequiresMatchingAccount(t *testing.T) {
+	backend := &linodeLeaseBackend{}
+	claim := core.LeaseClaim{Labels: map[string]string{linodeAccountLabel: "euuid:account-a"}}
+	lease := core.LeaseTarget{Server: core.Server{Labels: map[string]string{linodeAccountLabel: "euuid:account-a"}}}
+	if !backend.StatusTouchClaimMatches(lease, claim) {
+		t.Fatal("matching account identity was rejected")
+	}
+	lease.Server.Labels[linodeAccountLabel] = "euuid:account-b"
+	if backend.StatusTouchClaimMatches(lease, claim) {
+		t.Fatal("mismatched account identity was accepted")
+	}
+	delete(claim.Labels, linodeAccountLabel)
+	if backend.StatusTouchClaimMatches(lease, claim) {
+		t.Fatal("missing claim account identity was accepted")
+	}
+}
+
 func TestResolveReleaseOnlyNumericSlugClaimBeforeRawLinodeID(t *testing.T) {
 	leaseID := "cbx_222222222222"
 	slug := "123"

--- a/internal/providers/linode/backend_test.go
+++ b/internal/providers/linode/backend_test.go
@@ -413,6 +413,34 @@ func TestResolveReadOnlyDoesNotClaimVisibleLinode(t *testing.T) {
 	}
 }
 
+func TestResolveReadOnlyIgnoresStaleLinodeClaim(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.TargetOS = core.TargetLinux
+	cfg.ServerType = defaultType
+	leaseID := "cbx_abcdef123458"
+	slug := "stale-read-only"
+	item := linodeInstance{ID: 458, Label: core.LeaseProviderName(leaseID, slug), Status: "running", Type: defaultType, IPv4: []string{"203.0.113.125"}, Tags: leaseTags(cfg, leaseID, slug, "ready", false, time.Now())}
+	backend := newTestBackend(t, &fakeLinodeAPI{linodes: []linodeInstance{item}})
+	labels := labelsFromTags(item.Tags)
+	labels[linodeAccountLabel] = "euuid:A1BC2DEF-34GH-567I-J890KLMN12O34P56"
+	claimServer := core.Server{Provider: providerName, CloudID: "999", ID: 999, Name: item.Label, Labels: labels}
+	if err := core.ClaimLeaseTargetForConfig(leaseID, slug, backend.Cfg, claimServer, core.SSHTarget{}, backend.Cfg.IdleTimeout); err != nil {
+		t.Fatal(err)
+	}
+	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: slug, StatusOnly: true, NoLocalStateMutations: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.LeaseID != leaseID || lease.Server.ID != item.ID {
+		t.Fatalf("lease=%#v", lease)
+	}
+	claim, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
+	if err != nil || !exists || claim.CloudID != "999" {
+		t.Fatalf("read-only resolve changed stale claim: claim=%#v exists=%v err=%v", claim, exists, err)
+	}
+}
+
 func TestResolveReleaseOnlyNumericSlugClaimBeforeRawLinodeID(t *testing.T) {
 	leaseID := "cbx_222222222222"
 	slug := "123"

--- a/internal/providers/linode/backend_test.go
+++ b/internal/providers/linode/backend_test.go
@@ -553,10 +553,15 @@ func TestCleanupDryRunSkipsKeepAndDeletesExpiredWhenLive(t *testing.T) {
 	expiredLabels["state"] = "ready"
 	expiredLabels[linodeAccountLabel] = "euuid:A1BC2DEF-34GH-567I-J890KLMN12O34P56"
 	expiredLabels["expires_at"] = "1"
+	claimlessLabels := core.DirectLeaseLabels(cfg, "cbx_333333333333", "claimless", providerName, "", false, now.Add(-2*time.Hour))
+	claimlessLabels["state"] = "ready"
+	claimlessLabels[linodeAccountLabel] = "euuid:A1BC2DEF-34GH-567I-J890KLMN12O34P56"
+	claimlessLabels["expires_at"] = "1"
 	keepLabels := core.DirectLeaseLabels(cfg, "cbx_555555555555", "keep", providerName, "", true, now.Add(-2*time.Hour))
 	keepLabels["state"] = "ready"
 	keepLabels[linodeAccountLabel] = "euuid:A1BC2DEF-34GH-567I-J890KLMN12O34P56"
 	api := &fakeLinodeAPI{linodes: []linodeInstance{
+		{ID: 9, Label: core.LeaseProviderName("cbx_333333333333", "claimless"), Status: "running", Type: "g6-standard-1", IPv4: []string{"203.0.113.9"}, Tags: tagsFromLabels(claimlessLabels)},
 		{ID: 10, Label: core.LeaseProviderName("cbx_444444444444", "expired"), Status: "running", Type: "g6-standard-1", IPv4: []string{"203.0.113.10"}, Tags: tagsFromLabels(expiredLabels)},
 		{ID: 11, Label: core.LeaseProviderName("cbx_555555555555", "keep"), Status: "running", Type: "g6-standard-1", IPv4: []string{"203.0.113.11"}, Tags: tagsFromLabels(keepLabels)},
 	}}
@@ -569,7 +574,7 @@ func TestCleanupDryRunSkipsKeepAndDeletesExpiredWhenLive(t *testing.T) {
 	if len(api.deleted) != 0 {
 		t.Fatalf("dry-run deleted=%v", api.deleted)
 	}
-	server := serverFromLinode(api.linodes[0], cfg)
+	server := serverFromLinode(api.linodes[1], cfg)
 	server.Labels[linodeAccountLabel] = expiredLabels[linodeAccountLabel]
 	if err := core.ClaimLeaseTargetForRepoConfig(
 		"cbx_444444444444",

--- a/internal/providers/linode/tags.go
+++ b/internal/providers/linode/tags.go
@@ -424,7 +424,7 @@ func validateLinodeLabels(labels map[string]string) error {
 		labels["crabbox"] != "true" ||
 		labels["created_by"] != "crabbox" ||
 		labels["provider"] != providerName ||
-		labels["lease"] == "" ||
+		!core.IsCanonicalLeaseID(labels["lease"]) ||
 		labels["slug"] == "" ||
 		labels["target"] != core.TargetLinux {
 		return core.Exit(2, "refusing to operate on non-Crabbox Linode instance")

--- a/internal/providers/linode/tags_test.go
+++ b/internal/providers/linode/tags_test.go
@@ -17,13 +17,13 @@ func TestLinodeLeaseTagsRoundTripOwnershipLabels(t *testing.T) {
 	cfg.Tailscale.Tags = []string{"tag:crabbox", "tag:ci runner"}
 	now := time.Unix(1700000000, 0).UTC()
 
-	labels := labelsFromTags(leaseTags(cfg, "cbx_test", "my-app", "ready", true, now))
+	labels := labelsFromTags(leaseTags(cfg, "cbx_abcdef123456", "my-app", "ready", true, now))
 	for _, key := range []string{"crabbox", "created_by", "provider", "target", "lease", "slug", "state", "keep", "server_type", "provider_key"} {
 		if labels[key] == "" {
 			t.Fatalf("labels missing %s: %v", key, labels)
 		}
 	}
-	if labels["provider"] != providerName || labels["target"] != core.TargetLinux || labels["lease"] != "cbx_test" || labels["slug"] != "my-app" || labels["state"] != "ready" || labels["keep"] != "true" {
+	if labels["provider"] != providerName || labels["target"] != core.TargetLinux || labels["lease"] != "cbx_abcdef123456" || labels["slug"] != "my-app" || labels["state"] != "ready" || labels["keep"] != "true" {
 		t.Fatalf("labels=%v", labels)
 	}
 	if labels["tailscale_tags"] != "tag:crabbox,tag:ci runner" {
@@ -56,7 +56,7 @@ func TestLinodeOwnedPredicateRequiresCompleteTags(t *testing.T) {
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
 	cfg.TargetOS = core.TargetLinux
-	item := linodeInstance{ID: 1, Label: "crabbox-cbx_test-my-app", Tags: leaseTags(cfg, "cbx_test", "my-app", "ready", false, time.Unix(1, 0))}
+	item := linodeInstance{ID: 1, Label: "crabbox-cbx-abcdef123456-my-app", Tags: leaseTags(cfg, "cbx_abcdef123456", "my-app", "ready", false, time.Unix(1, 0))}
 	if !isOwnedLinode(item) {
 		t.Fatalf("expected owned item")
 	}
@@ -67,6 +67,16 @@ func TestLinodeOwnedPredicateRequiresCompleteTags(t *testing.T) {
 	item.Tags = []string{tagCrabbox, "crabbox:provider:aws", "crabbox:target:linux", "crabbox:lease:cbx_test", "crabbox:slug:my-app"}
 	if isOwnedLinode(item) {
 		t.Fatalf("foreign provider should not be owned")
+	}
+}
+
+func TestLinodeOwnedPredicateRejectsNonCanonicalLease(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.TargetOS = core.TargetLinux
+	item := linodeInstance{ID: 1, Label: "legacy", Tags: leaseTags(cfg, "legacy-lease-1", "legacy", "ready", false, time.Unix(1, 0))}
+	if isOwnedLinode(item) {
+		t.Fatal("non-canonical lease must not be treated as owned")
 	}
 }
 

--- a/internal/providers/scaleway/backend_lifecycle_test.go
+++ b/internal/providers/scaleway/backend_lifecycle_test.go
@@ -140,7 +140,7 @@ func TestStatusTouchClaimRequiresMatchingProviderIdentity(t *testing.T) {
 	if !backend.StatusTouchClaimMatches(lease, claim) {
 		t.Fatal("matching provider identity was rejected")
 	}
-	for _, key := range []string{"scaleway_project", "scaleway_organization", "scaleway_zone"} {
+	for _, key := range []string{"scaleway_project", "scaleway_zone"} {
 		mismatched := lease
 		mismatched.Server.Labels = maps.Clone(lease.Server.Labels)
 		mismatched.Server.Labels[key] = "other"
@@ -153,6 +153,18 @@ func TestStatusTouchClaimRequiresMatchingProviderIdentity(t *testing.T) {
 		if backend.StatusTouchClaimMatches(lease, missing) {
 			t.Fatalf("missing claim %s was accepted", key)
 		}
+	}
+	withoutOrganization := claim
+	withoutOrganization.Labels = maps.Clone(claim.Labels)
+	delete(withoutOrganization.Labels, "scaleway_organization")
+	if !backend.StatusTouchClaimMatches(lease, withoutOrganization) {
+		t.Fatal("optional organization was required")
+	}
+	mismatchedOrganization := lease
+	mismatchedOrganization.Server.Labels = maps.Clone(lease.Server.Labels)
+	mismatchedOrganization.Server.Labels["scaleway_organization"] = "other"
+	if backend.StatusTouchClaimMatches(mismatchedOrganization, claim) {
+		t.Fatal("present organization mismatch was accepted")
 	}
 }
 

--- a/internal/providers/scaleway/backend_lifecycle_test.go
+++ b/internal/providers/scaleway/backend_lifecycle_test.go
@@ -250,11 +250,15 @@ func TestScalewayCleanupSkipsForeignAndDeletesExpiredOwned(t *testing.T) {
 	ownedLabels["scaleway_project"] = "project-1"
 	ownedLabels["scaleway_zone"] = "fr-par-1"
 	ownedLabels["scaleway_ssh_key_id"] = "key-owned"
+	claimlessLabels := core.DirectLeaseLabels(backend.cfgForRun(), "cbx_000000000000", "claimless", providerName, "", false, now.Add(-3*time.Hour))
+	claimlessLabels["scaleway_project"] = "project-1"
+	claimlessLabels["scaleway_zone"] = "fr-par-1"
 	fake.servers = []*instance.Server{
+		testServer("srv-claimless", "crabbox-cbx-claimless", tagsFromLabels(claimlessLabels), "203.0.113.10"),
 		testServer("srv-owned", "crabbox-cbx-owned", tagsFromLabels(ownedLabels), "203.0.113.11"),
 		testServer("srv-foreign", "foreign", []string{"crabbox", "crabbox:provider:other"}, "203.0.113.12"),
 	}
-	claimServer := backend.serverFromScaleway(fake.servers[0])
+	claimServer := backend.serverFromScaleway(fake.servers[1])
 	if err := core.ClaimLeaseTargetForConfig(
 		"cbx_111111111111",
 		"owned",

--- a/internal/providers/scaleway/backend_lifecycle_test.go
+++ b/internal/providers/scaleway/backend_lifecycle_test.go
@@ -178,13 +178,24 @@ func TestScalewayAcquireRejectsUnsupportedPortableOSBeforeDefaultingImage(t *tes
 func TestScalewayCleanupSkipsForeignAndDeletesExpiredOwned(t *testing.T) {
 	backend, fake := newTestBackend(t)
 	now := backend.clockNow()
-	ownedLabels := core.DirectLeaseLabels(backend.cfgForRun(), "cbx_owned", "owned", providerName, "", false, now.Add(-3*time.Hour))
+	ownedLabels := core.DirectLeaseLabels(backend.cfgForRun(), "cbx_111111111111", "owned", providerName, "", false, now.Add(-3*time.Hour))
 	ownedLabels["scaleway_project"] = "project-1"
 	ownedLabels["scaleway_zone"] = "fr-par-1"
 	ownedLabels["scaleway_ssh_key_id"] = "key-owned"
 	fake.servers = []*instance.Server{
 		testServer("srv-owned", "crabbox-cbx-owned", tagsFromLabels(ownedLabels), "203.0.113.11"),
 		testServer("srv-foreign", "foreign", []string{"crabbox", "crabbox:provider:other"}, "203.0.113.12"),
+	}
+	claimServer := backend.serverFromScaleway(fake.servers[0])
+	if err := core.ClaimLeaseTargetForConfig(
+		"cbx_111111111111",
+		"owned",
+		backend.cfgForRun(),
+		claimServer,
+		core.SSHTarget{},
+		backend.cfgForRun().IdleTimeout,
+	); err != nil {
+		t.Fatal(err)
 	}
 	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatalf("Cleanup: %v", err)
@@ -199,7 +210,7 @@ func TestScalewayCleanupSkipsForeignAndDeletesExpiredOwned(t *testing.T) {
 
 func TestScalewayCleanupRefusesMismatchedProject(t *testing.T) {
 	backend, fake := newTestBackend(t)
-	labels := core.DirectLeaseLabels(backend.cfgForRun(), "cbx_bad", "bad", providerName, "", false, backend.clockNow().Add(-3*time.Hour))
+	labels := core.DirectLeaseLabels(backend.cfgForRun(), "cbx_abcdefabcdef", "bad", providerName, "", false, backend.clockNow().Add(-3*time.Hour))
 	labels["scaleway_project"] = "other-project"
 	labels["scaleway_zone"] = "fr-par-1"
 	fake.servers = []*instance.Server{testServer("srv-bad", "crabbox-cbx-bad", tagsFromLabels(labels), "203.0.113.13")}
@@ -264,10 +275,10 @@ func TestScalewayAmbiguousSSHKeyCreateReconcilesCleanableKey(t *testing.T) {
 func TestScalewayReleaseOnlyPreservesAmbiguousSlugError(t *testing.T) {
 	backend, fake := newTestBackend(t)
 	cfg := backend.cfgForRun()
-	labelsA := core.DirectLeaseLabels(cfg, "cbx_a", "duplicate", providerName, "", false, backend.clockNow())
+	labelsA := core.DirectLeaseLabels(cfg, "cbx_222222222222", "duplicate", providerName, "", false, backend.clockNow())
 	labelsA["scaleway_project"] = "project-1"
 	labelsA["scaleway_zone"] = "fr-par-1"
-	labelsB := core.DirectLeaseLabels(cfg, "cbx_b", "duplicate", providerName, "", false, backend.clockNow())
+	labelsB := core.DirectLeaseLabels(cfg, "cbx_333333333333", "duplicate", providerName, "", false, backend.clockNow())
 	labelsB["scaleway_project"] = "project-1"
 	labelsB["scaleway_zone"] = "fr-par-1"
 	fake.servers = []*instance.Server{
@@ -275,7 +286,7 @@ func TestScalewayReleaseOnlyPreservesAmbiguousSlugError(t *testing.T) {
 		testServer("srv-b", "duplicate-b", tagsFromLabels(labelsB), "203.0.113.22"),
 	}
 	claimServer := backend.serverFromScaleway(fake.servers[0])
-	if err := core.ClaimLeaseTargetForConfig("cbx_a", "duplicate", cfg, claimServer, core.SSHTarget{}, cfg.IdleTimeout); err != nil {
+	if err := core.ClaimLeaseTargetForConfig("cbx_222222222222", "duplicate", cfg, claimServer, core.SSHTarget{}, cfg.IdleTimeout); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "duplicate", ReleaseOnly: true}); err == nil || !strings.Contains(err.Error(), "matches multiple active leases") {
@@ -367,19 +378,19 @@ func TestScalewayMissingCreateIdentityPersistsRecoveryClaim(t *testing.T) {
 func TestScalewayReleaseRetainsIdentitylessRecoveryClaim(t *testing.T) {
 	backend, _ := newTestBackend(t)
 	cfg := backend.cfgForRun()
-	labels := core.DirectLeaseLabels(cfg, "cbx_recover", "recover", providerName, "", false, backend.clockNow())
+	labels := core.DirectLeaseLabels(cfg, "cbx_444444444444", "recover", providerName, "", false, backend.clockNow())
 	labels["recovery"] = "ambiguous-create"
 	labels["scaleway_project"] = "project-1"
 	labels["scaleway_zone"] = "fr-par-1"
 	server := core.Server{Provider: providerName, Name: "recover", Labels: labels}
-	if err := core.ClaimLeaseTargetForConfig("cbx_recover", "recover", cfg, server, core.SSHTarget{}, cfg.IdleTimeout); err != nil {
+	if err := core.ClaimLeaseTargetForConfig("cbx_444444444444", "recover", cfg, server, core.SSHTarget{}, cfg.IdleTimeout); err != nil {
 		t.Fatal(err)
 	}
-	err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: "cbx_recover", Server: server}})
+	err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: "cbx_444444444444", Server: server}})
 	if err == nil || !strings.Contains(err.Error(), "claim retained") {
 		t.Fatalf("ReleaseLease err=%v", err)
 	}
-	if _, ok, claimErr := core.ResolveLeaseClaimForProvider("cbx_recover", providerName); claimErr != nil || !ok {
+	if _, ok, claimErr := core.ResolveLeaseClaimForProvider("cbx_444444444444", providerName); claimErr != nil || !ok {
 		t.Fatalf("claim retained ok=%t err=%v", ok, claimErr)
 	}
 }
@@ -387,22 +398,22 @@ func TestScalewayReleaseRetainsIdentitylessRecoveryClaim(t *testing.T) {
 func TestScalewayReleaseCleansIdentitylessRollbackKeyClaim(t *testing.T) {
 	backend, fake := newTestBackend(t)
 	cfg := backend.cfgForRun()
-	labels := core.DirectLeaseLabels(cfg, "cbx_key_recover", "key-recover", providerName, "", false, backend.clockNow())
+	labels := core.DirectLeaseLabels(cfg, "cbx_555555555555", "key-recover", providerName, "", false, backend.clockNow())
 	labels["recovery"] = "rollback-key-cleanup"
 	labels["scaleway_project"] = "project-1"
 	labels["scaleway_zone"] = "fr-par-1"
 	labels["scaleway_ssh_key_id"] = "key-recover"
 	server := core.Server{Provider: providerName, Name: "key-recover", Labels: labels}
-	if err := core.ClaimLeaseTargetForConfig("cbx_key_recover", "key-recover", cfg, server, core.SSHTarget{}, cfg.IdleTimeout); err != nil {
+	if err := core.ClaimLeaseTargetForConfig("cbx_555555555555", "key-recover", cfg, server, core.SSHTarget{}, cfg.IdleTimeout); err != nil {
 		t.Fatal(err)
 	}
-	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: "cbx_key_recover", Server: server}}); err != nil {
+	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: "cbx_555555555555", Server: server}}); err != nil {
 		t.Fatalf("ReleaseLease: %v", err)
 	}
 	if !fake.deletedKey {
 		t.Fatal("release did not delete the identityless recovery key")
 	}
-	if _, ok, claimErr := core.ResolveLeaseClaimForProvider("cbx_key_recover", providerName); claimErr != nil || ok {
+	if _, ok, claimErr := core.ResolveLeaseClaimForProvider("cbx_555555555555", providerName); claimErr != nil || ok {
 		t.Fatalf("claim after recovery-key cleanup ok=%t err=%v", ok, claimErr)
 	}
 }
@@ -411,21 +422,21 @@ func TestScalewayReleaseCleansClaimAndKeyWhenServerAlreadyDeleted(t *testing.T) 
 	backend, fake := newTestBackend(t)
 	fake.getErr = &scw.ResourceNotFoundError{}
 	cfg := backend.cfgForRun()
-	labels := core.DirectLeaseLabels(cfg, "cbx_gone", "gone", providerName, "", false, backend.clockNow())
+	labels := core.DirectLeaseLabels(cfg, "cbx_666666666666", "gone", providerName, "", false, backend.clockNow())
 	labels["scaleway_project"] = "project-1"
 	labels["scaleway_zone"] = "fr-par-1"
 	labels["scaleway_ssh_key_id"] = "key-gone"
 	server := core.Server{Provider: providerName, CloudID: "srv-gone", Name: "gone", Labels: labels}
-	if err := core.ClaimLeaseTargetForConfig("cbx_gone", "gone", cfg, server, core.SSHTarget{}, cfg.IdleTimeout); err != nil {
+	if err := core.ClaimLeaseTargetForConfig("cbx_666666666666", "gone", cfg, server, core.SSHTarget{}, cfg.IdleTimeout); err != nil {
 		t.Fatal(err)
 	}
-	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: "cbx_gone", Server: server}}); err != nil {
+	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: "cbx_666666666666", Server: server}}); err != nil {
 		t.Fatalf("ReleaseLease: %v", err)
 	}
 	if !fake.deletedKey {
 		t.Fatal("release did not delete managed SSH key after server not found")
 	}
-	if _, ok, claimErr := core.ResolveLeaseClaimForProvider("cbx_gone", providerName); claimErr != nil || ok {
+	if _, ok, claimErr := core.ResolveLeaseClaimForProvider("cbx_666666666666", providerName); claimErr != nil || ok {
 		t.Fatalf("claim after stale release ok=%t err=%v", ok, claimErr)
 	}
 }
@@ -433,16 +444,16 @@ func TestScalewayReleaseCleansClaimAndKeyWhenServerAlreadyDeleted(t *testing.T) 
 func TestScalewayReleaseOnlyRefusesLiveServerWithChangedTags(t *testing.T) {
 	backend, fake := newTestBackend(t)
 	cfg := backend.cfgForRun()
-	labels := core.DirectLeaseLabels(cfg, "cbx_stale", "stale", providerName, "", false, backend.clockNow())
+	labels := core.DirectLeaseLabels(cfg, "cbx_777777777777", "stale", providerName, "", false, backend.clockNow())
 	labels["scaleway_project"] = "project-1"
 	labels["scaleway_zone"] = "fr-par-1"
 	labels["scaleway_ssh_key_id"] = "key-stale"
 	claimServer := core.Server{Provider: providerName, CloudID: "srv-stale", Name: "stale", Labels: labels}
-	if err := core.ClaimLeaseTargetForConfig("cbx_stale", "stale", cfg, claimServer, core.SSHTarget{}, cfg.IdleTimeout); err != nil {
+	if err := core.ClaimLeaseTargetForConfig("cbx_777777777777", "stale", cfg, claimServer, core.SSHTarget{}, cfg.IdleTimeout); err != nil {
 		t.Fatal(err)
 	}
 	fake.server = testServer("srv-stale", "changed", []string{"foreign"}, "203.0.113.20")
-	_, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "cbx_stale", ReleaseOnly: true})
+	_, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "cbx_777777777777", ReleaseOnly: true})
 	if err == nil || !strings.Contains(err.Error(), "non-Crabbox Scaleway") {
 		t.Fatalf("Resolve release-only err=%v", err)
 	}
@@ -466,7 +477,7 @@ func TestScalewayReleaseLeaseRefusesLiveServerWithChangedTags(t *testing.T) {
 
 func TestScalewayDoctorReportsInventoryAndMissingAuth(t *testing.T) {
 	backend, fake := newTestBackend(t)
-	labels := core.DirectLeaseLabels(backend.cfgForRun(), "cbx_doc", "doc", providerName, "", false, backend.clockNow())
+	labels := core.DirectLeaseLabels(backend.cfgForRun(), "cbx_888888888888", "doc", providerName, "", false, backend.clockNow())
 	labels["scaleway_project"] = "project-1"
 	labels["scaleway_zone"] = "fr-par-1"
 	fake.servers = []*instance.Server{testServer("srv-doc", "crabbox-cbx-doc", tagsFromLabels(labels), "203.0.113.14")}

--- a/internal/providers/scaleway/backend_lifecycle_test.go
+++ b/internal/providers/scaleway/backend_lifecycle_test.go
@@ -533,28 +533,32 @@ func TestScalewayReleaseCleansIdentitylessRollbackKeyClaim(t *testing.T) {
 }
 
 func TestScalewayRejectsKeyOnlyRecoveryClaimForLiveServer(t *testing.T) {
-	backend, fake := newTestBackend(t)
-	cfg := backend.cfgForRun()
-	leaseID := "cbx_565656565656"
-	slug := "key-only-live"
-	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", false, backend.clockNow())
-	labels["recovery"] = "rollback-key-cleanup"
-	labels["scaleway_project"] = "project-1"
-	labels["scaleway_organization"] = "organization-1"
-	labels["scaleway_zone"] = "fr-par-1"
-	labels["scaleway_ssh_key_id"] = "key-recover"
-	claimServer := core.Server{Provider: providerName, Name: slug, Labels: labels}
-	if err := core.ClaimLeaseTargetForConfig(leaseID, slug, cfg, claimServer, core.SSHTarget{}, cfg.IdleTimeout); err != nil {
-		t.Fatal(err)
-	}
-	fake.server = testServer("server-live", core.LeaseProviderName(leaseID, slug), tagsFromLabels(labels), "203.0.113.23")
-	server := backend.serverFromScaleway(fake.server)
-	err := backend.deleteServer(context.Background(), fake, server)
-	if err == nil || !strings.Contains(err.Error(), "no server identity or valid recovery state") {
-		t.Fatalf("deleteServer err=%v", err)
-	}
-	if fake.deletedServer || fake.deletedKey {
-		t.Fatalf("key-only recovery mutated live resources: deletedServer=%t deletedKey=%t", fake.deletedServer, fake.deletedKey)
+	for _, recovery := range []string{"ambiguous-key-create", "rollback-key-cleanup", "rollback-cleanup"} {
+		t.Run(recovery, func(t *testing.T) {
+			backend, fake := newTestBackend(t)
+			cfg := backend.cfgForRun()
+			leaseID := "cbx_565656565656"
+			slug := "key-only-live"
+			labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", false, backend.clockNow())
+			labels["recovery"] = recovery
+			labels["scaleway_project"] = "project-1"
+			labels["scaleway_organization"] = "organization-1"
+			labels["scaleway_zone"] = "fr-par-1"
+			labels["scaleway_ssh_key_id"] = "key-recover"
+			claimServer := core.Server{Provider: providerName, Name: slug, Labels: labels}
+			if err := core.ClaimLeaseTargetForConfig(leaseID, slug, cfg, claimServer, core.SSHTarget{}, cfg.IdleTimeout); err != nil {
+				t.Fatal(err)
+			}
+			fake.server = testServer("server-live", core.LeaseProviderName(leaseID, slug), tagsFromLabels(labels), "203.0.113.23")
+			server := backend.serverFromScaleway(fake.server)
+			err := backend.deleteServer(context.Background(), fake, server)
+			if err == nil || !strings.Contains(err.Error(), "no server identity or valid recovery state") {
+				t.Fatalf("deleteServer err=%v", err)
+			}
+			if fake.deletedServer || fake.deletedKey {
+				t.Fatalf("key-only recovery mutated live resources: deletedServer=%t deletedKey=%t", fake.deletedServer, fake.deletedKey)
+			}
+		})
 	}
 }
 

--- a/internal/providers/scaleway/backend_lifecycle_test.go
+++ b/internal/providers/scaleway/backend_lifecycle_test.go
@@ -298,6 +298,64 @@ func TestScalewayReleaseOnlyPreservesAmbiguousSlugError(t *testing.T) {
 	}
 }
 
+func TestScalewayReleaseOnlyDoesNotRetargetForeignExactClaimToSlug(t *testing.T) {
+	backend, fake := newTestBackend(t)
+	cfg := backend.cfgForRun()
+	const (
+		requestedID = "cbx_222222222222"
+		lookalikeID = "cbx_333333333333"
+	)
+
+	foreignCfg := cfg
+	foreignCfg.Provider = "aws"
+	foreignLabels := core.DirectLeaseLabels(foreignCfg, requestedID, "foreign", "aws", "", false, backend.clockNow())
+	if err := core.ClaimLeaseTargetForConfig(requestedID, "foreign", foreignCfg, core.Server{Provider: "aws", CloudID: "i-foreign", Labels: foreignLabels}, core.SSHTarget{}, cfg.IdleTimeout); err != nil {
+		t.Fatal(err)
+	}
+
+	labels := core.DirectLeaseLabels(cfg, lookalikeID, requestedID, providerName, "", false, backend.clockNow())
+	labels["scaleway_project"] = "project-1"
+	labels["scaleway_zone"] = "fr-par-1"
+	fake.server = testServer("srv-lookalike", "lookalike", tagsFromLabels(labels), "203.0.113.23")
+	server := backend.serverFromScaleway(fake.server)
+	if err := core.ClaimLeaseTargetForConfig(lookalikeID, requestedID, cfg, server, core.SSHTarget{}, cfg.IdleTimeout); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: requestedID, ReleaseOnly: true})
+	if err == nil || !strings.Contains(err.Error(), "exact lease identifier") {
+		t.Fatalf("Resolve release-only err=%v", err)
+	}
+	if fake.deletedServer || fake.deletedKey {
+		t.Fatalf("retargeted cleanup deleted server=%t key=%t", fake.deletedServer, fake.deletedKey)
+	}
+}
+
+func TestScalewayReleaseOnlyDoesNotFallBackToCanonicalClaimSlug(t *testing.T) {
+	backend, fake := newTestBackend(t)
+	cfg := backend.cfgForRun()
+	const (
+		requestedID = "cbx_aaaaaaaaaaaa"
+		lookalikeID = "cbx_bbbbbbbbbbbb"
+	)
+	labels := core.DirectLeaseLabels(cfg, lookalikeID, requestedID, providerName, "", false, backend.clockNow())
+	labels["scaleway_project"] = "project-1"
+	labels["scaleway_zone"] = "fr-par-1"
+	fake.server = testServer("srv-lookalike", "lookalike", tagsFromLabels(labels), "203.0.113.24")
+	server := backend.serverFromScaleway(fake.server)
+	if err := core.ClaimLeaseTargetForConfig(lookalikeID, requestedID, cfg, server, core.SSHTarget{}, cfg.IdleTimeout); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: requestedID, ReleaseOnly: true})
+	if err == nil || !strings.Contains(err.Error(), "exact lease identifier") {
+		t.Fatalf("Resolve release-only err=%v", err)
+	}
+	if fake.deletedServer || fake.deletedKey {
+		t.Fatalf("retargeted cleanup deleted server=%t key=%t", fake.deletedServer, fake.deletedKey)
+	}
+}
+
 func TestScalewayUpdateTailscaleMetadataPersistsTagsAndClaim(t *testing.T) {
 	backend, fake := newTestBackend(t)
 	lease, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "tailnet"})

--- a/internal/providers/scaleway/backend_lifecycle_test.go
+++ b/internal/providers/scaleway/backend_lifecycle_test.go
@@ -100,6 +100,33 @@ func TestScalewayAcquireListResolveTouchReleaseLifecycle(t *testing.T) {
 	}
 }
 
+func TestScalewayResolveReadOnlyIgnoresStaleClaim(t *testing.T) {
+	backend, fake := newTestBackend(t)
+	cfg := backend.cfgForRun()
+	leaseID := "cbx_121212121212"
+	slug := "stale-read-only"
+	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", false, backend.clockNow())
+	labels["scaleway_project"] = "project-1"
+	labels["scaleway_zone"] = "fr-par-1"
+	fake.server = testServer("srv-live", core.LeaseProviderName(leaseID, slug), tagsFromLabels(labels), "203.0.113.21")
+	claimServer := core.Server{Provider: providerName, CloudID: "srv-stale", Name: fake.server.Name, Labels: labels}
+	if err := core.ClaimLeaseTargetForConfig(leaseID, slug, cfg, claimServer, core.SSHTarget{}, cfg.IdleTimeout); err != nil {
+		t.Fatal(err)
+	}
+
+	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: slug, StatusOnly: true, NoLocalStateMutations: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.LeaseID != leaseID || lease.Server.CloudID != fake.server.ID {
+		t.Fatalf("lease=%#v", lease)
+	}
+	claim, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
+	if err != nil || !exists || claim.CloudID != "srv-stale" {
+		t.Fatalf("read-only resolve changed stale claim: claim=%#v exists=%v err=%v", claim, exists, err)
+	}
+}
+
 func TestScalewayAcquireOnAcquiredErrorRollsBack(t *testing.T) {
 	backend, fake := newTestBackend(t)
 	_, err := backend.Acquire(context.Background(), core.AcquireRequest{

--- a/internal/providers/scaleway/backend_lifecycle_test.go
+++ b/internal/providers/scaleway/backend_lifecycle_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"maps"
 	"net"
 	"strings"
 	"testing"
@@ -124,6 +125,34 @@ func TestScalewayResolveReadOnlyIgnoresStaleClaim(t *testing.T) {
 	claim, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
 	if err != nil || !exists || claim.CloudID != "srv-stale" {
 		t.Fatalf("read-only resolve changed stale claim: claim=%#v exists=%v err=%v", claim, exists, err)
+	}
+}
+
+func TestStatusTouchClaimRequiresMatchingProviderIdentity(t *testing.T) {
+	backend := &Backend{}
+	labels := map[string]string{
+		"scaleway_project":      "project-a",
+		"scaleway_organization": "organization-a",
+		"scaleway_zone":         "fr-par-1",
+	}
+	claim := core.LeaseClaim{Labels: maps.Clone(labels)}
+	lease := core.LeaseTarget{Server: core.Server{Labels: maps.Clone(labels)}}
+	if !backend.StatusTouchClaimMatches(lease, claim) {
+		t.Fatal("matching provider identity was rejected")
+	}
+	for _, key := range []string{"scaleway_project", "scaleway_organization", "scaleway_zone"} {
+		mismatched := lease
+		mismatched.Server.Labels = maps.Clone(lease.Server.Labels)
+		mismatched.Server.Labels[key] = "other"
+		if backend.StatusTouchClaimMatches(mismatched, claim) {
+			t.Fatalf("mismatched %s was accepted", key)
+		}
+		missing := claim
+		missing.Labels = maps.Clone(claim.Labels)
+		delete(missing.Labels, key)
+		if backend.StatusTouchClaimMatches(lease, missing) {
+			t.Fatalf("missing claim %s was accepted", key)
+		}
 	}
 }
 

--- a/internal/providers/scaleway/backend_lifecycle_test.go
+++ b/internal/providers/scaleway/backend_lifecycle_test.go
@@ -128,6 +128,37 @@ func TestScalewayResolveReadOnlyIgnoresStaleClaim(t *testing.T) {
 	}
 }
 
+func TestScalewayNoMutationResolveDoesNotBindAmbiguousRecovery(t *testing.T) {
+	backend, fake := newTestBackend(t)
+	cfg := backend.cfgForRun()
+	leaseID := "cbx_131313131313"
+	slug := "no-mutation-recovery"
+	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", false, backend.clockNow())
+	labels["recovery"] = "ambiguous-create"
+	labels["scaleway_project"] = "project-1"
+	labels["scaleway_zone"] = "fr-par-1"
+	labels["scaleway_ssh_key_id"] = "key-no-mutation"
+	claimServer := core.Server{Provider: providerName, Name: slug, Labels: labels}
+	if err := core.ClaimLeaseTargetForConfig(leaseID, slug, cfg, claimServer, core.SSHTarget{}, cfg.IdleTimeout); err != nil {
+		t.Fatal(err)
+	}
+	liveLabels := maps.Clone(labels)
+	delete(liveLabels, "recovery")
+	fake.server = testServer("srv-no-mutation", core.LeaseProviderName(leaseID, slug), tagsFromLabels(liveLabels), "203.0.113.22")
+
+	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: slug, NoLocalStateMutations: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.Server.CloudID != "srv-no-mutation" {
+		t.Fatalf("lease=%#v", lease)
+	}
+	claim, exists, claimErr := core.ReadLeaseClaimWithPresence(leaseID)
+	if claimErr != nil || !exists || claim.CloudID != "" || claim.Labels["recovery"] != "ambiguous-create" {
+		t.Fatalf("no-mutation resolve changed claim: claim=%#v exists=%t err=%v", claim, exists, claimErr)
+	}
+}
+
 func TestStatusTouchClaimRequiresMatchingProviderIdentity(t *testing.T) {
 	backend := &Backend{}
 	labels := map[string]string{
@@ -522,6 +553,98 @@ func TestScalewayReleaseRetainsIdentitylessRecoveryClaim(t *testing.T) {
 	}
 	if _, ok, claimErr := core.ResolveLeaseClaimForProvider("cbx_444444444444", providerName); claimErr != nil || !ok {
 		t.Fatalf("claim retained ok=%t err=%v", ok, claimErr)
+	}
+}
+
+func TestScalewayAmbiguousCreateBindsUniqueServerBeforeCleanup(t *testing.T) {
+	backend, fake := newTestBackend(t)
+	cfg := backend.cfgForRun()
+	leaseID := "cbx_454545454545"
+	slug := "recovered"
+	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", false, backend.clockNow())
+	labels["recovery"] = "ambiguous-create"
+	labels["scaleway_project"] = "project-1"
+	labels["scaleway_zone"] = "fr-par-1"
+	labels["scaleway_ssh_key_id"] = "key-recovered"
+	claimServer := core.Server{Provider: providerName, Name: slug, Labels: labels}
+	if err := core.ClaimLeaseTargetForConfig(leaseID, slug, cfg, claimServer, core.SSHTarget{}, cfg.IdleTimeout); err != nil {
+		t.Fatal(err)
+	}
+	liveLabels := maps.Clone(labels)
+	delete(liveLabels, "recovery")
+	fake.server = testServer("srv-recovered", core.LeaseProviderName(leaseID, slug), tagsFromLabels(liveLabels), "203.0.113.24")
+	fake.deleteKeyErr = errors.New("key cleanup failed")
+
+	err := backend.deleteServer(context.Background(), fake, backend.serverFromScaleway(fake.server))
+	if err == nil || !strings.Contains(err.Error(), "key cleanup failed") {
+		t.Fatalf("deleteServer err=%v", err)
+	}
+	if !fake.deletedServer {
+		t.Fatal("recovered server was not deleted")
+	}
+	claim, ok, claimErr := core.ReadLeaseClaimWithPresence(leaseID)
+	if claimErr != nil || !ok || claim.CloudID != "srv-recovered" || claim.Labels["scaleway_ssh_key_id"] != "key-recovered" {
+		t.Fatalf("bound recovery claim=%#v ok=%t err=%v", claim, ok, claimErr)
+	}
+}
+
+func TestScalewayAmbiguousCreateRefusesDuplicateServers(t *testing.T) {
+	backend, fake := newTestBackend(t)
+	cfg := backend.cfgForRun()
+	leaseID := "cbx_464646464646"
+	slug := "duplicates"
+	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", false, backend.clockNow())
+	labels["recovery"] = "ambiguous-create"
+	labels["scaleway_project"] = "project-1"
+	labels["scaleway_zone"] = "fr-par-1"
+	labels["scaleway_ssh_key_id"] = "key-duplicates"
+	claimServer := core.Server{Provider: providerName, Name: slug, Labels: labels}
+	if err := core.ClaimLeaseTargetForConfig(leaseID, slug, cfg, claimServer, core.SSHTarget{}, cfg.IdleTimeout); err != nil {
+		t.Fatal(err)
+	}
+	liveLabels := maps.Clone(labels)
+	delete(liveLabels, "recovery")
+	fake.servers = []*instance.Server{
+		testServer("srv-first", core.LeaseProviderName(leaseID, slug), tagsFromLabels(liveLabels), "203.0.113.25"),
+		testServer("srv-second", core.LeaseProviderName(leaseID, slug), tagsFromLabels(liveLabels), "203.0.113.26"),
+	}
+
+	err := backend.deleteServer(context.Background(), fake, backend.serverFromScaleway(fake.servers[0]))
+	if err == nil || !strings.Contains(err.Error(), "found 2 matching servers") {
+		t.Fatalf("deleteServer err=%v", err)
+	}
+	if fake.deletedServer || fake.deletedKey {
+		t.Fatalf("ambiguous cleanup mutated resources: server=%t key=%t", fake.deletedServer, fake.deletedKey)
+	}
+	claim, ok, claimErr := core.ReadLeaseClaimWithPresence(leaseID)
+	if claimErr != nil || !ok || claim.CloudID != "" {
+		t.Fatalf("ambiguous claim=%#v ok=%t err=%v", claim, ok, claimErr)
+	}
+}
+
+func TestScalewayCleanupRefusesChangedLiveSSHKeyIdentity(t *testing.T) {
+	backend, fake := newTestBackend(t)
+	cfg := backend.cfgForRun()
+	leaseID := "cbx_474747474747"
+	slug := "changed-key"
+	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", false, backend.clockNow())
+	labels["scaleway_project"] = "project-1"
+	labels["scaleway_zone"] = "fr-par-1"
+	labels["scaleway_ssh_key_id"] = "key-claimed"
+	claimServer := core.Server{Provider: providerName, CloudID: "srv-changed-key", Name: slug, Labels: labels}
+	if err := core.ClaimLeaseTargetForConfig(leaseID, slug, cfg, claimServer, core.SSHTarget{}, cfg.IdleTimeout); err != nil {
+		t.Fatal(err)
+	}
+	liveLabels := maps.Clone(labels)
+	liveLabels["scaleway_ssh_key_id"] = "key-other"
+	fake.server = testServer("srv-changed-key", core.LeaseProviderName(leaseID, slug), tagsFromLabels(liveLabels), "203.0.113.27")
+
+	err := backend.deleteServer(context.Background(), fake, claimServer)
+	if err == nil || !strings.Contains(err.Error(), "SSH key identity does not match") {
+		t.Fatalf("deleteServer err=%v", err)
+	}
+	if fake.deletedServer || fake.deletedKey {
+		t.Fatalf("changed key cleanup mutated resources: server=%t key=%t", fake.deletedServer, fake.deletedKey)
 	}
 }
 

--- a/internal/providers/scaleway/backend_lifecycle_test.go
+++ b/internal/providers/scaleway/backend_lifecycle_test.go
@@ -532,6 +532,32 @@ func TestScalewayReleaseCleansIdentitylessRollbackKeyClaim(t *testing.T) {
 	}
 }
 
+func TestScalewayRejectsKeyOnlyRecoveryClaimForLiveServer(t *testing.T) {
+	backend, fake := newTestBackend(t)
+	cfg := backend.cfgForRun()
+	leaseID := "cbx_565656565656"
+	slug := "key-only-live"
+	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", false, backend.clockNow())
+	labels["recovery"] = "rollback-key-cleanup"
+	labels["scaleway_project"] = "project-1"
+	labels["scaleway_organization"] = "organization-1"
+	labels["scaleway_zone"] = "fr-par-1"
+	labels["scaleway_ssh_key_id"] = "key-recover"
+	claimServer := core.Server{Provider: providerName, Name: slug, Labels: labels}
+	if err := core.ClaimLeaseTargetForConfig(leaseID, slug, cfg, claimServer, core.SSHTarget{}, cfg.IdleTimeout); err != nil {
+		t.Fatal(err)
+	}
+	fake.server = testServer("server-live", core.LeaseProviderName(leaseID, slug), tagsFromLabels(labels), "203.0.113.23")
+	server := backend.serverFromScaleway(fake.server)
+	err := backend.deleteServer(context.Background(), fake, server)
+	if err == nil || !strings.Contains(err.Error(), "no server identity or valid recovery state") {
+		t.Fatalf("deleteServer err=%v", err)
+	}
+	if fake.deletedServer || fake.deletedKey {
+		t.Fatalf("key-only recovery mutated live resources: deletedServer=%t deletedKey=%t", fake.deletedServer, fake.deletedKey)
+	}
+}
+
 func TestScalewayReleaseCleansClaimAndKeyWhenServerAlreadyDeleted(t *testing.T) {
 	backend, fake := newTestBackend(t)
 	fake.getErr = &scw.ResourceNotFoundError{}

--- a/internal/providers/scaleway/provider.go
+++ b/internal/providers/scaleway/provider.go
@@ -703,16 +703,16 @@ func (b *Backend) targetFromServer(ctx context.Context, client Client, item *ins
 	if err != nil {
 		return core.LeaseTarget{}, err
 	}
-	if exists {
+	if exists && !req.IsReadOnlyStatus() {
 		if err := validateScalewayClaimIdentity(claim, server); err != nil {
 			return core.LeaseTarget{}, err
 		}
 		if err := b.validateProviderIdentity(claim.Labels, client); err != nil {
 			return core.LeaseTarget{}, err
 		}
-	} else if req.ReleaseOnly {
+	} else if !exists && req.ReleaseOnly {
 		return core.LeaseTarget{}, core.Exit(2, "scaleway lease=%s has no exact local claim; refusing release", leaseID)
-	} else if !req.NoLocalStateMutations {
+	} else if !exists && !req.NoLocalStateMutations {
 		if !req.Reclaim {
 			return core.LeaseTarget{}, core.Exit(2, "scaleway lease=%s is unclaimed; use --reclaim to adopt it explicitly", leaseID)
 		}

--- a/internal/providers/scaleway/provider.go
+++ b/internal/providers/scaleway/provider.go
@@ -607,6 +607,15 @@ func (b *Backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 			fmt.Fprintf(b.rt.Stderr, "skip scaleway_server=%s reason=%s\n", item.ID, reason)
 			continue
 		}
+		_, claimErr := b.cleanupClaim(client, server)
+		eligible, err := shared.CleanupClaimEligible(claimErr)
+		if err != nil {
+			return err
+		}
+		if !eligible {
+			fmt.Fprintf(b.rt.Stderr, "skip scaleway_server=%s reason=no-exact-local-claim\n", item.ID)
+			continue
+		}
 		if req.DryRun {
 			fmt.Fprintf(b.rt.Stdout, "would delete scaleway_server=%s lease=%s reason=%s\n", item.ID, server.Labels["lease"], reason)
 			continue
@@ -811,22 +820,13 @@ func (b *Backend) deleteServer(ctx context.Context, client Client, server core.S
 		return err
 	}
 	leaseID := server.Labels["lease"]
-	claim, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
+	claim, err := b.cleanupClaim(client, server)
 	if err != nil {
-		return err
-	}
-	if !exists {
-		return core.Exit(2, "scaleway lease=%s has no exact local claim; refusing cleanup", leaseID)
-	}
-	if err := validateScalewayClaimIdentity(claim, server); err != nil {
-		return err
-	}
-	if err := b.validateProviderIdentity(claim.Labels, client); err != nil {
 		return err
 	}
 	if server.CloudID == "" {
 		if server.Labels["recovery"] == "rollback-key-cleanup" {
-			return b.deleteIdentitylessRecoveryKey(ctx, client, server, claim, exists)
+			return b.deleteIdentitylessRecoveryKey(ctx, client, server, claim, true)
 		}
 		// Ambiguous create responses may represent a server that has not reached
 		// inventory yet. Retain its access key and claim for explicit recovery.
@@ -868,6 +868,24 @@ func (b *Backend) deleteServer(ctx context.Context, client Client, server core.S
 	}
 	core.RemoveStoredTestboxKey(leaseID)
 	return nil
+}
+
+func (b *Backend) cleanupClaim(client Client, server core.Server) (core.LeaseClaim, error) {
+	leaseID := server.Labels["lease"]
+	claim, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
+	if err != nil {
+		return core.LeaseClaim{}, err
+	}
+	if !exists {
+		return core.LeaseClaim{}, core.Exit(2, "scaleway lease=%s has no exact local claim; refusing cleanup", leaseID)
+	}
+	if err := validateScalewayClaimIdentity(claim, server); err != nil {
+		return core.LeaseClaim{}, err
+	}
+	if err := b.validateProviderIdentity(claim.Labels, client); err != nil {
+		return core.LeaseClaim{}, err
+	}
+	return claim, nil
 }
 
 func (b *Backend) deleteServerResource(ctx context.Context, client Client, serverID string) error {

--- a/internal/providers/scaleway/provider.go
+++ b/internal/providers/scaleway/provider.go
@@ -466,6 +466,16 @@ func (b *Backend) ReleaseLeaseMessage(lease core.LeaseTarget) string {
 	return fmt.Sprintf("deleted lease=%s scaleway_server=%s name=%s", lease.LeaseID, lease.Server.DisplayID(), lease.Server.Name)
 }
 
+func (b *Backend) StatusTouchClaimMatches(lease core.LeaseTarget, claim core.LeaseClaim) bool {
+	for _, key := range []string{"scaleway_project", "scaleway_organization", "scaleway_zone"} {
+		expected := strings.TrimSpace(claim.Labels[key])
+		if expected == "" || expected != strings.TrimSpace(lease.Server.Labels[key]) {
+			return false
+		}
+	}
+	return true
+}
+
 func (b *Backend) Touch(ctx context.Context, req core.TouchRequest) (core.Server, error) {
 	client, err := b.newClient(b.cfgForRun(), b.rt)
 	if err != nil {

--- a/internal/providers/scaleway/provider.go
+++ b/internal/providers/scaleway/provider.go
@@ -1114,7 +1114,11 @@ func validateScalewayClaimIdentity(claim core.LeaseClaim, server core.Server) er
 		}
 	} else {
 		switch claim.Labels["recovery"] {
-		case "ambiguous-create", "ambiguous-create-response", "ambiguous-key-create", "rollback-cleanup", "rollback-key-cleanup":
+		case "ambiguous-create", "ambiguous-create-response", "rollback-cleanup":
+		case "ambiguous-key-create", "rollback-key-cleanup":
+			if server.CloudID != "" {
+				return core.Exit(2, "scaleway lease claim has no server identity or valid recovery state for lease=%s", leaseID)
+			}
 		default:
 			return core.Exit(2, "scaleway lease claim has no server identity or valid recovery state for lease=%s", leaseID)
 		}

--- a/internal/providers/scaleway/provider.go
+++ b/internal/providers/scaleway/provider.go
@@ -699,16 +699,33 @@ func (b *Backend) targetFromServer(ctx context.Context, client Client, item *ins
 		return core.LeaseTarget{}, err
 	}
 	leaseID := server.Labels["lease"]
+	claim, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	if exists {
+		if err := validateScalewayClaimIdentity(claim, server); err != nil {
+			return core.LeaseTarget{}, err
+		}
+		if err := b.validateProviderIdentity(claim.Labels, client); err != nil {
+			return core.LeaseTarget{}, err
+		}
+	} else if req.ReleaseOnly {
+		return core.LeaseTarget{}, core.Exit(2, "scaleway lease=%s has no exact local claim; refusing release", leaseID)
+	} else if !req.NoLocalStateMutations {
+		if !req.Reclaim {
+			return core.LeaseTarget{}, core.Exit(2, "scaleway lease=%s is unclaimed; use --reclaim to adopt it explicitly", leaseID)
+		}
+		if req.Repo.Root == "" {
+			return core.LeaseTarget{}, core.Exit(2, "scaleway lease=%s cannot be reclaimed without a repository root", leaseID)
+		}
+	}
 	if req.ReleaseOnly {
 		return core.LeaseTarget{Server: server, LeaseID: leaseID}, nil
 	}
 	ssh := core.SSHTargetFromConfig(b.cfgForRun(), server.PublicNet.IPv4.IP)
 	core.UseStoredTestboxKey(&ssh, leaseID)
 	if req.Repo.Root != "" && !req.NoLocalStateMutations {
-		claim, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
-		if err != nil {
-			return core.LeaseTarget{}, err
-		}
 		if _, err := core.ClaimLeaseTargetForRepoConfigIfUnchanged(leaseID, server.Labels["slug"], b.cfgForRun(), server, ssh, req.Repo.Root, b.cfgForRun().IdleTimeout, req.Reclaim, claim, exists); err != nil {
 			return core.LeaseTarget{}, err
 		}
@@ -781,10 +798,14 @@ func (b *Backend) deleteServer(ctx context.Context, client Client, server core.S
 	if err != nil {
 		return err
 	}
-	if exists && claim.Provider == providerName {
-		if claim.CloudID != "" && server.CloudID != "" && claim.CloudID != server.CloudID {
-			return core.Exit(2, "refusing to release Scaleway server %s from stale local claim", server.CloudID)
-		}
+	if !exists {
+		return core.Exit(2, "scaleway lease=%s has no exact local claim; refusing cleanup", leaseID)
+	}
+	if err := validateScalewayClaimIdentity(claim, server); err != nil {
+		return err
+	}
+	if err := b.validateProviderIdentity(claim.Labels, client); err != nil {
+		return err
 	}
 	if server.CloudID == "" {
 		if server.Labels["recovery"] == "rollback-key-cleanup" {
@@ -825,12 +846,8 @@ func (b *Backend) deleteServer(ctx context.Context, client Client, server core.S
 			return err
 		}
 	}
-	if exists && claim.Provider == providerName {
-		if err := core.RemoveLeaseClaimIfUnchanged(leaseID, claim); err != nil {
-			return fmt.Errorf("finalize Scaleway cleanup claim: %w", err)
-		}
-	} else {
-		core.RemoveLeaseClaim(leaseID)
+	if err := core.RemoveLeaseClaimIfUnchanged(leaseID, claim); err != nil {
+		return fmt.Errorf("finalize Scaleway cleanup claim: %w", err)
 	}
 	core.RemoveStoredTestboxKey(leaseID)
 	return nil
@@ -895,6 +912,12 @@ func (b *Backend) deleteServerResource(ctx context.Context, client Client, serve
 
 func (b *Backend) deleteIdentitylessRecoveryKey(ctx context.Context, client Client, server core.Server, claim core.LeaseClaim, claimExists bool) error {
 	leaseID := server.Labels["lease"]
+	if !claimExists {
+		return core.Exit(2, "scaleway lease=%s has no exact local claim; refusing SSH key cleanup", leaseID)
+	}
+	if err := validateScalewayClaimIdentity(claim, server); err != nil {
+		return err
+	}
 	keyID := strings.TrimSpace(server.Labels["scaleway_ssh_key_id"])
 	if keyID == "" {
 		return core.Exit(4, "scaleway recovery claim for lease=%s has no SSH key identity; claim retained", leaseID)
@@ -902,12 +925,8 @@ func (b *Backend) deleteIdentitylessRecoveryKey(ctx context.Context, client Clie
 	if err := client.IAM().DeleteSSHKey(&iam.DeleteSSHKeyRequest{SSHKeyID: keyID}, scw.WithContext(ctx)); err != nil && !isScalewayNotFound(err) {
 		return err
 	}
-	if claimExists && claim.Provider == providerName {
-		if err := core.RemoveLeaseClaimIfUnchanged(leaseID, claim); err != nil {
-			return fmt.Errorf("finalize Scaleway recovery-key cleanup claim: %w", err)
-		}
-	} else {
-		core.RemoveLeaseClaim(leaseID)
+	if err := core.RemoveLeaseClaimIfUnchanged(leaseID, claim); err != nil {
+		return fmt.Errorf("finalize Scaleway recovery-key cleanup claim: %w", err)
 	}
 	core.RemoveStoredTestboxKey(leaseID)
 	return nil
@@ -1051,10 +1070,41 @@ func validateScalewayLabels(labels map[string]string) error {
 		labels["crabbox"] != "true" ||
 		labels["created_by"] != "crabbox" ||
 		labels["provider"] != providerName ||
-		labels["lease"] == "" ||
+		!core.IsCanonicalLeaseID(labels["lease"]) ||
 		labels["slug"] == "" ||
 		labels["target"] != core.TargetLinux {
 		return core.Exit(2, "refusing to operate on non-Crabbox Scaleway Instance")
+	}
+	return nil
+}
+
+func validateScalewayClaimIdentity(claim core.LeaseClaim, server core.Server) error {
+	leaseID := server.Labels["lease"]
+	slug := server.Labels["slug"]
+	if claim.LeaseID != leaseID ||
+		claim.Provider != providerName ||
+		claim.Slug == "" ||
+		(slug != "" && claim.Slug != slug) ||
+		claim.Labels["lease"] != leaseID ||
+		claim.Labels["slug"] != claim.Slug ||
+		claim.Labels["provider"] != providerName ||
+		(claim.CloudID != "" && server.CloudID != "" && claim.CloudID != server.CloudID) {
+		return core.Exit(2, "scaleway lease claim identity does not match lease=%s slug=%s", leaseID, slug)
+	}
+	if strings.TrimSpace(claim.Labels["scaleway_project"]) == "" ||
+		strings.TrimSpace(claim.Labels["scaleway_zone"]) == "" {
+		return core.Exit(3, "scaleway lease claim has no project or zone identity; refusing lifecycle operation")
+	}
+	if claim.CloudID != "" {
+		if server.CloudID == "" || claim.CloudID != server.CloudID {
+			return core.Exit(2, "refusing to release Scaleway server %s from stale local claim", server.CloudID)
+		}
+	} else {
+		switch claim.Labels["recovery"] {
+		case "ambiguous-create", "ambiguous-create-response", "ambiguous-key-create", "rollback-cleanup", "rollback-key-cleanup":
+		default:
+			return core.Exit(2, "scaleway lease claim has no server identity or valid recovery state for lease=%s", leaseID)
+		}
 	}
 	return nil
 }

--- a/internal/providers/scaleway/provider.go
+++ b/internal/providers/scaleway/provider.go
@@ -733,6 +733,12 @@ func (b *Backend) targetFromServer(ctx context.Context, client Client, item *ins
 		if err := b.validateProviderIdentity(claim.Labels, client); err != nil {
 			return core.LeaseTarget{}, err
 		}
+		if !req.NoLocalStateMutations {
+			claim, err = b.bindPendingRecoveryServer(ctx, client, server, claim)
+			if err != nil {
+				return core.LeaseTarget{}, err
+			}
+		}
 	} else if !exists && req.ReleaseOnly {
 		return core.LeaseTarget{}, core.Exit(2, "scaleway lease=%s has no exact local claim; refusing release", leaseID)
 	} else if !exists && !req.NoLocalStateMutations {
@@ -824,6 +830,10 @@ func (b *Backend) deleteServer(ctx context.Context, client Client, server core.S
 	if err != nil {
 		return err
 	}
+	claim, err = b.bindPendingRecoveryServer(ctx, client, server, claim)
+	if err != nil {
+		return err
+	}
 	if server.CloudID == "" {
 		if server.Labels["recovery"] == "rollback-key-cleanup" {
 			return b.deleteIdentitylessRecoveryKey(ctx, client, server, claim, true)
@@ -832,7 +842,7 @@ func (b *Backend) deleteServer(ctx context.Context, client Client, server core.S
 		// inventory yet. Retain its access key and claim for explicit recovery.
 		return core.Exit(4, "scaleway recovery claim for lease=%s has no server identity; credentials and claim retained", leaseID)
 	}
-	keyID := strings.TrimSpace(server.Labels["scaleway_ssh_key_id"])
+	keyID := strings.TrimSpace(claim.Labels["scaleway_ssh_key_id"])
 	resp, err := client.Instance().GetServer(&instance.GetServerRequest{Zone: scw.Zone(client.Zone()), ServerID: server.CloudID}, scw.WithContext(ctx))
 	if err != nil && !isScalewayNotFound(err) {
 		return err
@@ -848,11 +858,8 @@ func (b *Backend) deleteServer(ctx context.Context, client Client, server core.S
 		if err := b.validateProviderIdentity(live.Labels, client); err != nil {
 			return err
 		}
-		if liveKeyID := strings.TrimSpace(live.Labels["scaleway_ssh_key_id"]); liveKeyID != "" {
-			if keyID != "" && keyID != liveKeyID {
-				return core.Exit(2, "refusing to release Scaleway server %s with changed SSH key identity", server.CloudID)
-			}
-			keyID = liveKeyID
+		if err := validateScalewayClaimIdentity(claim, live); err != nil {
+			return err
 		}
 		if err := b.deleteServerResource(ctx, client, server.CloudID); err != nil {
 			return err
@@ -886,6 +893,37 @@ func (b *Backend) cleanupClaim(client Client, server core.Server) (core.LeaseCla
 		return core.LeaseClaim{}, err
 	}
 	return claim, nil
+}
+
+func (b *Backend) bindPendingRecoveryServer(ctx context.Context, client Client, server core.Server, claim core.LeaseClaim) (core.LeaseClaim, error) {
+	if claim.CloudID != "" || (claim.Labels["recovery"] != "ambiguous-create" && claim.Labels["recovery"] != "ambiguous-create-response") {
+		return claim, nil
+	}
+	if server.CloudID == "" {
+		return claim, nil
+	}
+	items, err := b.listScalewayServers(ctx, client)
+	if err != nil {
+		return core.LeaseClaim{}, err
+	}
+	matches := make([]core.Server, 0, 1)
+	for _, item := range items {
+		candidate := b.serverFromScaleway(item)
+		if validateScalewayClaimIdentity(claim, candidate) == nil && b.validateProviderIdentity(candidate.Labels, client) == nil {
+			matches = append(matches, candidate)
+		}
+	}
+	if len(matches) != 1 {
+		return core.LeaseClaim{}, core.Exit(2, "scaleway ambiguous create recovery found %d matching servers for lease=%s", len(matches), claim.LeaseID)
+	}
+	if matches[0].CloudID != server.CloudID {
+		return core.LeaseClaim{}, core.Exit(2, "refusing to bind Scaleway ambiguous create recovery to mismatched server=%s lease=%s", server.CloudID, claim.LeaseID)
+	}
+	updated, err := core.UpdateLeaseClaimEndpointIfUnchangedWithProviderMetadata(claim.LeaseID, claim, matches[0], core.SSHTarget{})
+	if err != nil {
+		return core.LeaseClaim{}, fmt.Errorf("persist recovered Scaleway server: %w", err)
+	}
+	return updated, nil
 }
 
 func (b *Backend) deleteServerResource(ctx context.Context, client Client, serverID string) error {
@@ -1129,6 +1167,9 @@ func validateScalewayClaimIdentity(claim core.LeaseClaim, server core.Server) er
 	if strings.TrimSpace(claim.Labels["scaleway_project"]) == "" ||
 		strings.TrimSpace(claim.Labels["scaleway_zone"]) == "" {
 		return core.Exit(3, "scaleway lease claim has no project or zone identity; refusing lifecycle operation")
+	}
+	if strings.TrimSpace(claim.Labels["scaleway_ssh_key_id"]) != strings.TrimSpace(server.Labels["scaleway_ssh_key_id"]) {
+		return core.Exit(2, "scaleway lease claim SSH key identity does not match lease=%s slug=%s", leaseID, slug)
 	}
 	if claim.CloudID != "" {
 		if server.CloudID == "" || claim.CloudID != server.CloudID {

--- a/internal/providers/scaleway/provider.go
+++ b/internal/providers/scaleway/provider.go
@@ -1114,8 +1114,8 @@ func validateScalewayClaimIdentity(claim core.LeaseClaim, server core.Server) er
 		}
 	} else {
 		switch claim.Labels["recovery"] {
-		case "ambiguous-create", "ambiguous-create-response", "rollback-cleanup":
-		case "ambiguous-key-create", "rollback-key-cleanup":
+		case "ambiguous-create", "ambiguous-create-response":
+		case "ambiguous-key-create", "rollback-key-cleanup", "rollback-cleanup":
 			if server.CloudID != "" {
 				return core.Exit(2, "scaleway lease claim has no server identity or valid recovery state for lease=%s", leaseID)
 			}

--- a/internal/providers/scaleway/provider.go
+++ b/internal/providers/scaleway/provider.go
@@ -735,7 +735,10 @@ func (b *Backend) targetFromServer(ctx context.Context, client Client, item *ins
 }
 
 func (b *Backend) releaseTargetFromClaim(ctx context.Context, client Client, id string) (core.LeaseTarget, error) {
-	claim, ok, err := core.ResolveLeaseClaimForProvider(id, providerName)
+	claim, ok, exact, err := core.ResolveLeaseClaimForProviderWithExact(id, providerName)
+	if err == nil && (exact || core.IsCanonicalLeaseID(id)) && (!exact || !ok || claim.LeaseID != id) {
+		return core.LeaseTarget{}, core.Exit(2, "scaleway exact lease identifier %q does not match a valid scaleway claim", id)
+	}
 	if err != nil {
 		return core.LeaseTarget{}, err
 	}

--- a/internal/providers/scaleway/provider.go
+++ b/internal/providers/scaleway/provider.go
@@ -467,11 +467,15 @@ func (b *Backend) ReleaseLeaseMessage(lease core.LeaseTarget) string {
 }
 
 func (b *Backend) StatusTouchClaimMatches(lease core.LeaseTarget, claim core.LeaseClaim) bool {
-	for _, key := range []string{"scaleway_project", "scaleway_organization", "scaleway_zone"} {
+	for _, key := range []string{"scaleway_project", "scaleway_zone"} {
 		expected := strings.TrimSpace(claim.Labels[key])
 		if expected == "" || expected != strings.TrimSpace(lease.Server.Labels[key]) {
 			return false
 		}
+	}
+	if organization := strings.TrimSpace(claim.Labels["scaleway_organization"]); organization != "" &&
+		organization != strings.TrimSpace(lease.Server.Labels["scaleway_organization"]) {
+		return false
 	}
 	return true
 }

--- a/internal/providers/scaleway/tags_test.go
+++ b/internal/providers/scaleway/tags_test.go
@@ -16,22 +16,36 @@ func TestLeaseTagsRoundTripOwnershipLabels(t *testing.T) {
 		ServerType: "DEV1-S",
 		Profile:    "daily",
 	}
-	tags := leaseTags(cfg, "cbx_123", "blue-box", "ready", true, time.Unix(1700000000, 0).UTC())
-	for _, want := range []string{tagCrabbox, "crabbox:provider:scaleway", "crabbox:target:linux", "crabbox:lease:cbx_123", "crabbox:slug:blue-box", "crabbox:state:ready"} {
+	tags := leaseTags(cfg, "cbx_999999999999", "blue-box", "ready", true, time.Unix(1700000000, 0).UTC())
+	for _, want := range []string{tagCrabbox, "crabbox:provider:scaleway", "crabbox:target:linux", "crabbox:lease:cbx_999999999999", "crabbox:slug:blue-box", "crabbox:state:ready"} {
 		if !containsTag(tags, want) {
 			t.Fatalf("tags=%v missing %q", tags, want)
 		}
 	}
 	labels := labelsFromTags(tags)
-	if labels["provider"] != providerName || labels["lease"] != "cbx_123" || labels["slug"] != "blue-box" || labels["state"] != "ready" || labels["target"] != core.TargetLinux {
+	if labels["provider"] != providerName || labels["lease"] != "cbx_999999999999" || labels["slug"] != "blue-box" || labels["state"] != "ready" || labels["target"] != core.TargetLinux {
 		t.Fatalf("labels=%v", labels)
+	}
+}
+
+func TestValidateScalewayLabelsRejectsNonCanonicalLease(t *testing.T) {
+	labels := map[string]string{
+		"crabbox":    "true",
+		"created_by": "crabbox",
+		"provider":   providerName,
+		"lease":      "legacy-lease-1",
+		"slug":       "legacy",
+		"target":     core.TargetLinux,
+	}
+	if err := validateScalewayLabels(labels); err == nil {
+		t.Fatal("non-canonical lease must not be treated as owned")
 	}
 }
 
 func TestExactTagsPreserveTailscaleValues(t *testing.T) {
 	labels := map[string]string{
 		"provider":           providerName,
-		"lease":              "cbx_123",
+		"lease":              "cbx_999999999999",
 		"slug":               "blue-box",
 		"target":             core.TargetLinux,
 		"tailscale_hostname": "cbx-blue.example.ts.net",

--- a/internal/providers/shared/direct.go
+++ b/internal/providers/shared/direct.go
@@ -13,7 +13,7 @@ type DirectSSHBackend struct {
 	Cfg             core.Config
 	RT              core.Runtime
 	Delete          func(context.Context, core.Config, core.Server) error
-	CleanupEligible func(core.Server) (bool, error)
+	CleanupEligible func(context.Context, core.Server) (bool, error)
 	StoredLeaseKeys bool
 }
 
@@ -38,7 +38,7 @@ func (b *DirectSSHBackend) CleanupServers(ctx context.Context, req core.CleanupR
 			continue
 		}
 		if b.CleanupEligible != nil {
-			eligible, err := b.CleanupEligible(s)
+			eligible, err := b.CleanupEligible(ctx, s)
 			if err != nil {
 				return err
 			}
@@ -58,6 +58,18 @@ func (b *DirectSSHBackend) CleanupServers(ctx context.Context, req core.CleanupR
 		}
 	}
 	return nil
+}
+
+func ServerWithDefaultLabel(server core.Server, key, value string) core.Server {
+	labels := make(map[string]string, len(server.Labels)+1)
+	for label, current := range server.Labels {
+		labels[label] = current
+	}
+	if labels[key] == "" {
+		labels[key] = value
+	}
+	server.Labels = labels
+	return server
 }
 
 func CleanupClaimEligible(err error) (bool, error) {

--- a/internal/providers/shared/direct.go
+++ b/internal/providers/shared/direct.go
@@ -13,6 +13,7 @@ type DirectSSHBackend struct {
 	Cfg             core.Config
 	RT              core.Runtime
 	Delete          func(context.Context, core.Config, core.Server) error
+	CleanupEligible func(core.Server) (bool, error)
 	StoredLeaseKeys bool
 }
 
@@ -36,6 +37,16 @@ func (b *DirectSSHBackend) CleanupServers(ctx context.Context, req core.CleanupR
 			fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=%s\n", s.DisplayID(), s.Name, reason)
 			continue
 		}
+		if b.CleanupEligible != nil {
+			eligible, err := b.CleanupEligible(s)
+			if err != nil {
+				return err
+			}
+			if !eligible {
+				fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=no-exact-local-claim\n", s.DisplayID(), s.Name)
+				continue
+			}
+		}
 		fmt.Fprintf(b.RT.Stderr, "delete server id=%s name=%s\n", s.DisplayID(), s.Name)
 		if !req.DryRun {
 			if b.Delete == nil {
@@ -47,6 +58,17 @@ func (b *DirectSSHBackend) CleanupServers(ctx context.Context, req core.CleanupR
 		}
 	}
 	return nil
+}
+
+func CleanupClaimEligible(err error) (bool, error) {
+	if err == nil {
+		return true, nil
+	}
+	var exitErr core.ExitError
+	if core.AsExitError(err, &exitErr) {
+		return false, nil
+	}
+	return false, err
 }
 
 func (b *DirectSSHBackend) Touch(ctx context.Context, server core.Server, state string) core.Server {

--- a/internal/providers/shared/direct_test.go
+++ b/internal/providers/shared/direct_test.go
@@ -116,7 +116,7 @@ func TestCleanupServersSkipsIneligibleAndContinues(t *testing.T) {
 	var deleted []string
 	backend := DirectSSHBackend{
 		RT: core.Runtime{Stderr: &stderr, Clock: clock},
-		CleanupEligible: func(server core.Server) (bool, error) {
+		CleanupEligible: func(_ context.Context, server core.Server) (bool, error) {
 			return server.Name == "claimed", nil
 		},
 		Delete: func(_ context.Context, _ core.Config, server core.Server) error {
@@ -149,6 +149,21 @@ func TestCleanupClaimEligible(t *testing.T) {
 	want := errors.New("read claim")
 	if eligible, err := CleanupClaimEligible(want); eligible || !errors.Is(err, want) {
 		t.Fatalf("read failure eligible=%v err=%v", eligible, err)
+	}
+}
+
+func TestServerWithDefaultLabelCopiesLabels(t *testing.T) {
+	original := core.Server{Labels: map[string]string{"lease": "cbx_123456789abc"}}
+	updated := ServerWithDefaultLabel(original, "provider_account", "account:test")
+	if updated.Labels["provider_account"] != "account:test" || updated.Labels["lease"] != original.Labels["lease"] {
+		t.Fatalf("updated labels=%v", updated.Labels)
+	}
+	if _, ok := original.Labels["provider_account"]; ok {
+		t.Fatalf("original labels mutated: %v", original.Labels)
+	}
+	existing := ServerWithDefaultLabel(updated, "provider_account", "account:other")
+	if existing.Labels["provider_account"] != "account:test" {
+		t.Fatalf("existing label overwritten: %v", existing.Labels)
 	}
 }
 

--- a/internal/providers/shared/direct_test.go
+++ b/internal/providers/shared/direct_test.go
@@ -110,6 +110,48 @@ func TestCleanupServersRequiresDeleteAndPropagatesDeleteErrors(t *testing.T) {
 	}
 }
 
+func TestCleanupServersSkipsIneligibleAndContinues(t *testing.T) {
+	clock := &testCleanupClock{now: time.Date(2030, 1, 2, 3, 4, 5, 0, time.UTC)}
+	var stderr bytes.Buffer
+	var deleted []string
+	backend := DirectSSHBackend{
+		RT: core.Runtime{Stderr: &stderr, Clock: clock},
+		CleanupEligible: func(server core.Server) (bool, error) {
+			return server.Name == "claimed", nil
+		},
+		Delete: func(_ context.Context, _ core.Config, server core.Server) error {
+			deleted = append(deleted, server.Name)
+			return nil
+		},
+	}
+	servers := []core.Server{
+		testCleanupServer("claimless", clock.now.Add(-time.Hour)),
+		testCleanupServer("claimed", clock.now.Add(-time.Hour)),
+	}
+	if err := backend.CleanupServers(context.Background(), core.CleanupRequest{}, servers); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Join(deleted, ",") != "claimed" {
+		t.Fatalf("deleted=%v, want claimed", deleted)
+	}
+	if !strings.Contains(stderr.String(), "skip server id=claimless name=claimless reason=no-exact-local-claim") {
+		t.Fatalf("stderr=%q", stderr.String())
+	}
+}
+
+func TestCleanupClaimEligible(t *testing.T) {
+	if eligible, err := CleanupClaimEligible(nil); err != nil || !eligible {
+		t.Fatalf("nil error eligible=%v err=%v", eligible, err)
+	}
+	if eligible, err := CleanupClaimEligible(core.Exit(2, "claim mismatch")); err != nil || eligible {
+		t.Fatalf("claim mismatch eligible=%v err=%v", eligible, err)
+	}
+	want := errors.New("read claim")
+	if eligible, err := CleanupClaimEligible(want); eligible || !errors.Is(err, want) {
+		t.Fatalf("read failure eligible=%v err=%v", eligible, err)
+	}
+}
+
 func TestAcquireAttemptsRetry(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		lease := core.LeaseTarget{LeaseID: "lease-1"}

--- a/internal/providers/vultr/backend.go
+++ b/internal/providers/vultr/backend.go
@@ -401,6 +401,9 @@ func (b *backend) targetFromInstance(item vultrInstance, req core.ResolveRequest
 		if claim.CloudID != "" && claim.CloudID != server.CloudID {
 			return core.LeaseTarget{}, core.Exit(2, "refusing to resolve Vultr instance %s from stale local claim", server.CloudID)
 		}
+		if claim.CloudID == "" && !isPendingVultrRecoveryClaim(claim, leaseID) {
+			return core.LeaseTarget{}, core.Exit(2, "vultr lease claim has no instance identity or valid pending recovery state for lease=%s", leaseID)
+		}
 		preserveVultrIdentity(server.Labels, claim.Labels)
 	} else if req.ReleaseOnly {
 		return core.LeaseTarget{}, core.Exit(2, "vultr lease=%s has no exact local claim; refusing release", leaseID)
@@ -485,6 +488,13 @@ func (b *backend) persistRecoveryClaim(leaseID, slug string, cfg core.Config, re
 		Labels:   labels,
 	}
 	return core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, core.SSHTarget{}, repoRoot, cfg.IdleTimeout, false)
+}
+
+func isPendingVultrRecoveryClaim(claim core.LeaseClaim, leaseID string) bool {
+	return claim.LeaseID == leaseID &&
+		claim.Provider == providerName &&
+		strings.TrimSpace(claim.CloudID) == "" &&
+		claim.Labels["recovery"] == "ambiguous-create"
 }
 
 func (b *backend) ensureCleanupClaim(server core.Server) (core.LeaseClaim, error) {

--- a/internal/providers/vultr/backend.go
+++ b/internal/providers/vultr/backend.go
@@ -388,7 +388,7 @@ func (b *backend) targetFromInstance(item vultrInstance, req core.ResolveRequest
 	if err != nil {
 		return core.LeaseTarget{}, fmt.Errorf("read vultr lease claim: %w", err)
 	}
-	if claimExists {
+	if claimExists && !req.IsReadOnlyStatus() {
 		if claim.Provider != providerName {
 			return core.LeaseTarget{}, core.Exit(2, "lease=%s is claimed by provider=%s; refusing vultr claim rewrite", leaseID, claim.Provider)
 		}
@@ -405,9 +405,9 @@ func (b *backend) targetFromInstance(item vultrInstance, req core.ResolveRequest
 			return core.LeaseTarget{}, core.Exit(2, "vultr lease claim has no instance identity or valid pending recovery state for lease=%s", leaseID)
 		}
 		preserveVultrIdentity(server.Labels, claim.Labels)
-	} else if req.ReleaseOnly {
+	} else if !claimExists && req.ReleaseOnly {
 		return core.LeaseTarget{}, core.Exit(2, "vultr lease=%s has no exact local claim; refusing release", leaseID)
-	} else if !req.NoLocalStateMutations {
+	} else if !claimExists && !req.NoLocalStateMutations {
 		if !req.Reclaim {
 			return core.LeaseTarget{}, core.Exit(2, "vultr lease=%s is unclaimed; use --reclaim to adopt it explicitly", leaseID)
 		}

--- a/internal/providers/vultr/backend.go
+++ b/internal/providers/vultr/backend.go
@@ -270,6 +270,11 @@ func (b *backend) Touch(ctx context.Context, req core.TouchRequest) (core.Server
 	return server, nil
 }
 
+func (b *backend) StatusTouchClaimMatches(lease core.LeaseTarget, claim core.LeaseClaim) bool {
+	expected := strings.TrimSpace(claim.Labels[vultrAccountLabel])
+	return expected != "" && expected == strings.TrimSpace(lease.Server.Labels[vultrAccountLabel])
+}
+
 func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest) error {
 	return b.deleteServer(ctx, b.Cfg, req.Lease.Server)
 }

--- a/internal/providers/vultr/backend.go
+++ b/internal/providers/vultr/backend.go
@@ -292,8 +292,17 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 	return b.CleanupServers(ctx, req, servers)
 }
 
-func (b *backend) cleanupEligible(server core.Server) (bool, error) {
-	_, err := b.ensureCleanupClaim(server)
+func (b *backend) cleanupEligible(ctx context.Context, server core.Server) (bool, error) {
+	client, err := b.clientFactory(b.RT)
+	if err != nil {
+		return false, err
+	}
+	accountID, err := client.AccountID(ctx)
+	if err != nil {
+		return false, err
+	}
+	server = shared.ServerWithDefaultLabel(server, vultrAccountLabel, accountID)
+	_, err = b.ensureCleanupClaim(server)
 	return shared.CleanupClaimEligible(err)
 }
 

--- a/internal/providers/vultr/backend.go
+++ b/internal/providers/vultr/backend.go
@@ -436,7 +436,7 @@ func (b *backend) releaseTargetFromClaim(id, accountID string) (core.LeaseTarget
 	} else {
 		var exact bool
 		claim, ok, exact, err = core.ResolveLeaseClaimForProviderWithExact(id, providerName)
-		if err == nil && exact && (!ok || claim.LeaseID != id) {
+		if err == nil && (exact || core.IsCanonicalLeaseID(id)) && (!exact || !ok || claim.LeaseID != id) {
 			return core.LeaseTarget{}, core.Exit(2, "vultr exact lease identifier %q does not match a valid vultr claim", id)
 		}
 	}

--- a/internal/providers/vultr/backend.go
+++ b/internal/providers/vultr/backend.go
@@ -139,7 +139,7 @@ func (b *backend) acquireOnce(ctx context.Context, req core.AcquireRequest) (tar
 		}
 		return core.LeaseTarget{}, err
 	}
-	waited, err := b.waitForInstanceReady(ctx, client, created.ID)
+	waited, err := b.waitForInstanceReady(ctx, client, created.ID, core.BootstrapWaitTimeout(cfg))
 	if err != nil {
 		return core.LeaseTarget{}, err
 	}
@@ -375,8 +375,10 @@ func (b *backend) deleteServer(ctx context.Context, _ core.Config, server core.S
 	if keyOwned != "true" && keyOwned != "false" {
 		return core.Exit(4, "vultr SSH key ownership remains indeterminate for lease=%s; local claim and credentials retained", leaseID)
 	}
+	keyPresent := false
 	if keyOwned == "true" {
-		if err := authorizeVultrSSHKeyDelete(ctx, client, leaseID, keyID); err != nil {
+		keyPresent, err = authorizeVultrSSHKeyDelete(ctx, client, leaseID, keyID)
+		if err != nil {
 			return err
 		}
 	}
@@ -385,7 +387,7 @@ func (b *backend) deleteServer(ctx context.Context, _ core.Config, server core.S
 			return err
 		}
 	}
-	if keyOwned == "true" {
+	if keyPresent {
 		if err := client.DeleteSSHKey(ctx, keyID); err != nil {
 			return err
 		}
@@ -568,8 +570,8 @@ func validateVultrClaimIdentity(claim core.LeaseClaim, leaseID, slug string) err
 	return nil
 }
 
-func (b *backend) waitForInstanceReady(ctx context.Context, client vultrAPI, id string) (vultrInstance, error) {
-	deadline := b.now().Add(5 * time.Minute)
+func (b *backend) waitForInstanceReady(ctx context.Context, client vultrAPI, id string, timeout time.Duration) (vultrInstance, error) {
+	deadline := b.now().Add(timeout)
 	for {
 		item, err := client.GetInstance(ctx, id)
 		if err != nil {
@@ -603,18 +605,19 @@ func instanceReady(item vultrInstance) bool {
 func rollbackVultrAcquire(client vultrAPI, instanceID, keyID string, keyCreated bool) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	var errs []error
 	if instanceID != "" {
 		if err := client.DeleteInstance(ctx, instanceID); err != nil {
-			errs = append(errs, err)
+			// Keep the SSH key while the instance still exists. A later recovery
+			// cleanup needs it to verify ownership and regain access if required.
+			return err
 		}
 	}
 	if keyCreated && keyID != "" {
 		if err := client.DeleteSSHKey(ctx, keyID); err != nil {
-			errs = append(errs, err)
+			return err
 		}
 	}
-	return errors.Join(errs...)
+	return nil
 }
 
 func validateLiveInstance(item vultrInstance, expected core.Server) error {
@@ -683,33 +686,42 @@ func preserveVultrIdentity(labels, stored map[string]string) {
 	}
 }
 
-func authorizeVultrSSHKeyDelete(ctx context.Context, client vultrAPI, leaseID, keyID string) error {
+func authorizeVultrSSHKeyDelete(ctx context.Context, client vultrAPI, leaseID, keyID string) (bool, error) {
 	keyPath, err := core.TestboxKeyPath(leaseID)
 	if err != nil {
-		return err
+		return false, err
 	}
 	publicKeyBytes, err := os.ReadFile(keyPath + ".pub")
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return core.Exit(4, "vultr SSH key deletion for lease=%s requires retained local public key; local claim and credentials retained", leaseID)
+			return false, core.Exit(4, "vultr SSH key deletion for lease=%s requires retained local public key; local claim and credentials retained", leaseID)
 		}
-		return fmt.Errorf("read retained vultr SSH public key: %w", err)
+		return false, fmt.Errorf("read retained vultr SSH public key: %w", err)
 	}
 	publicKey := strings.TrimSpace(string(publicKeyBytes))
 	if publicKey == "" {
-		return core.Exit(2, "retained vultr SSH public key is empty for lease=%s", leaseID)
+		return false, core.Exit(2, "retained vultr SSH public key is empty for lease=%s", leaseID)
 	}
-	key, found, err := client.FindSSHKey(ctx, providerKeyForLease(leaseID), publicKey)
+	key, found, err := client.FindSSHKeyByID(ctx, keyID)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if !found {
-		return core.Exit(4, "vultr SSH key for lease=%s could not be verified; local claim and credentials retained", leaseID)
+		matched, matchFound, err := client.FindSSHKey(ctx, providerKeyForLease(leaseID), publicKey)
+		if err != nil {
+			return false, err
+		}
+		if matchFound {
+			return false, core.Exit(2, "refusing to delete Vultr SSH key %s for lease=%s; canonical key still exists with immutable id %s", keyID, leaseID, matched.ID)
+		}
+		// The provider already removed the exact key. Instance ownership remains
+		// independently bound by the claim, account, cloud ID, name, and tags.
+		return false, nil
 	}
-	if key.ID != keyID {
-		return core.Exit(2, "refusing to delete Vultr SSH key %s for lease=%s; verified key id is %s", keyID, leaseID, key.ID)
+	if key.ID != keyID || normalizedSSHKey(key) != publicKey {
+		return false, core.Exit(2, "refusing to delete Vultr SSH key %s for lease=%s; immutable id or public key does not match retained ownership", keyID, leaseID)
 	}
-	return nil
+	return true, nil
 }
 
 func validateVultrUserScheme(cfg core.Config) error {

--- a/internal/providers/vultr/backend.go
+++ b/internal/providers/vultr/backend.go
@@ -37,6 +37,7 @@ func NewBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.B
 		return core.WaitForSSHReady(ctx, target, b.RT.Stderr, phase, timeout)
 	}
 	b.Delete = b.deleteServer
+	b.CleanupEligible = b.cleanupEligible
 	return b
 }
 
@@ -289,6 +290,11 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 		return err
 	}
 	return b.CleanupServers(ctx, req, servers)
+}
+
+func (b *backend) cleanupEligible(server core.Server) (bool, error) {
+	_, err := b.ensureCleanupClaim(server)
+	return shared.CleanupClaimEligible(err)
 }
 
 func (b *backend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {

--- a/internal/providers/vultr/backend.go
+++ b/internal/providers/vultr/backend.go
@@ -183,6 +183,9 @@ func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.Le
 	servers := make([]core.Server, 0, len(instances))
 	byCloudID := map[string]vultrInstance{}
 	for _, item := range instances {
+		if !isOwnedInstance(item) {
+			continue
+		}
 		server := serverFromInstance(item, b.Cfg)
 		servers = append(servers, server)
 		byCloudID[server.CloudID] = item
@@ -225,6 +228,9 @@ func (b *backend) List(ctx context.Context, req core.ListRequest) ([]core.LeaseV
 	}
 	out := make([]core.LeaseView, 0, len(instances))
 	for _, item := range instances {
+		if !isOwnedInstance(item) {
+			continue
+		}
 		out = append(out, serverFromInstance(item, b.Cfg))
 	}
 	return out, nil
@@ -396,13 +402,22 @@ func (b *backend) targetFromInstance(item vultrInstance, req core.ResolveRequest
 			return core.LeaseTarget{}, core.Exit(2, "refusing to resolve Vultr instance %s from stale local claim", server.CloudID)
 		}
 		preserveVultrIdentity(server.Labels, claim.Labels)
+	} else if req.ReleaseOnly {
+		return core.LeaseTarget{}, core.Exit(2, "vultr lease=%s has no exact local claim; refusing release", leaseID)
+	} else if !req.NoLocalStateMutations {
+		if !req.Reclaim {
+			return core.LeaseTarget{}, core.Exit(2, "vultr lease=%s is unclaimed; use --reclaim to adopt it explicitly", leaseID)
+		}
+		if req.Repo.Root == "" {
+			return core.LeaseTarget{}, core.Exit(2, "vultr lease=%s cannot be reclaimed without a repository root", leaseID)
+		}
 	}
 	if req.ReleaseOnly {
 		return core.LeaseTarget{Server: server, LeaseID: leaseID}, nil
 	}
 	ssh := core.SSHTargetFromConfig(b.Cfg, server.PublicNet.IPv4.IP)
 	core.UseStoredTestboxKey(&ssh, leaseID)
-	if req.Repo.Root != "" {
+	if req.Repo.Root != "" && !req.NoLocalStateMutations {
 		if _, err := core.ClaimLeaseTargetForRepoConfigIfUnchanged(leaseID, server.Labels["slug"], b.Cfg, server, ssh, req.Repo.Root, b.Cfg.IdleTimeout, req.Reclaim, claim, claimExists); err != nil {
 			return core.LeaseTarget{}, err
 		}
@@ -479,20 +494,21 @@ func (b *backend) ensureCleanupClaim(server core.Server) (core.LeaseClaim, error
 		return core.LeaseClaim{}, fmt.Errorf("read vultr cleanup claim: %w", err)
 	}
 	if !claimExists {
-		repoRoot, err := os.Getwd()
-		if err != nil {
-			return core.LeaseClaim{}, fmt.Errorf("resolve cleanup claim working directory: %w", err)
-		}
-		claim, err = core.ClaimLeaseTargetForRepoConfigIfUnchanged(leaseID, server.Labels["slug"], b.Cfg, server, core.SSHTarget{}, repoRoot, b.Cfg.IdleTimeout, false, claim, false)
-		if err != nil {
-			return core.LeaseClaim{}, fmt.Errorf("persist vultr cleanup claim: %w", err)
-		}
+		return core.LeaseClaim{}, core.Exit(2, "vultr lease=%s has no exact local claim; refusing cleanup", leaseID)
 	}
 	if err := validateVultrClaimIdentity(claim, leaseID, server.Labels["slug"]); err != nil {
 		return core.LeaseClaim{}, err
 	}
-	if claim.CloudID != "" && server.CloudID != "" && claim.CloudID != server.CloudID {
-		return core.LeaseClaim{}, core.Exit(2, "refusing to release Vultr instance %s from stale local claim", server.CloudID)
+	if claim.CloudID != "" {
+		if server.CloudID == "" || claim.CloudID != server.CloudID {
+			return core.LeaseClaim{}, core.Exit(2, "refusing to release Vultr instance %s from stale local claim", server.CloudID)
+		}
+	} else {
+		switch claim.Labels["recovery"] {
+		case "ambiguous-create", "ambiguous-key-create", "rollback-cleanup":
+		default:
+			return core.LeaseClaim{}, core.Exit(2, "vultr lease claim has no instance identity or valid recovery state for lease=%s", leaseID)
+		}
 	}
 	expectedAccount := strings.TrimSpace(claim.Labels[vultrAccountLabel])
 	currentAccount := strings.TrimSpace(server.Labels[vultrAccountLabel])

--- a/internal/providers/vultr/backend.go
+++ b/internal/providers/vultr/backend.go
@@ -520,7 +520,11 @@ func (b *backend) ensureCleanupClaim(server core.Server) (core.LeaseClaim, error
 		}
 	} else {
 		switch claim.Labels["recovery"] {
-		case "ambiguous-create", "ambiguous-key-create", "rollback-cleanup":
+		case "ambiguous-create":
+		case "ambiguous-key-create", "rollback-cleanup":
+			if server.CloudID != "" {
+				return core.LeaseClaim{}, core.Exit(2, "vultr key-only recovery claim cannot authorize instance cleanup for lease=%s", leaseID)
+			}
 		default:
 			return core.LeaseClaim{}, core.Exit(2, "vultr lease claim has no instance identity or valid recovery state for lease=%s", leaseID)
 		}

--- a/internal/providers/vultr/backend_test.go
+++ b/internal/providers/vultr/backend_test.go
@@ -730,8 +730,37 @@ func TestCleanupDryRunDoesNotDelete(t *testing.T) {
 	if len(api.deleted) != 0 {
 		t.Fatalf("deleted=%v", api.deleted)
 	}
-	if !strings.Contains(stderr.String(), "delete server id=22222222-2222-4222-8222-222222222222") {
+	if !strings.Contains(stderr.String(), "skip server id=22222222-2222-4222-8222-222222222222") || !strings.Contains(stderr.String(), "reason=no-exact-local-claim") {
 		t.Fatalf("stderr=%q", stderr.String())
+	}
+}
+
+func TestCleanupSkipsClaimlessBeforeClaimedInstance(t *testing.T) {
+	var stderr bytes.Buffer
+	api := &fakeVultrAPI{}
+	b := newTestBackend(t, api)
+	b.RT.Stderr = &stderr
+	expired := time.Now().Add(-time.Hour)
+	claimlessLabels := labelsFromTags(leaseTagsWithExpiry(b.Cfg, "cbx_aaaaaaaaaaaa", "claimless", expired))
+	claimlessLabels[vultrAccountLabel] = "account:test-account"
+	claimedLabels := labelsFromTags(leaseTagsWithExpiry(b.Cfg, "cbx_bbbbbbbbbbbb", "claimed", expired))
+	claimedLabels[vultrAccountLabel] = "account:test-account"
+	setVultrKeyIdentity(claimedLabels, "", false)
+	api.instances = []vultrInstance{
+		{ID: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", Label: core.LeaseProviderName("cbx_aaaaaaaaaaaa", "claimless"), Status: "active", PowerStatus: "running", ServerStatus: "ok", Plan: b.Cfg.ServerType, Tags: tagsFromLabels(claimlessLabels)},
+		{ID: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb", Label: core.LeaseProviderName("cbx_bbbbbbbbbbbb", "claimed"), Status: "active", PowerStatus: "running", ServerStatus: "ok", Plan: b.Cfg.ServerType, Tags: tagsFromLabels(claimedLabels)},
+	}
+	claimedID := api.instances[1].ID
+	claimedServer := serverFromInstance(api.instances[1], b.Cfg)
+	claimedServer.Labels[vultrAccountLabel] = "account:test-account"
+	if err := core.ClaimLeaseTargetForRepoConfig("cbx_bbbbbbbbbbbb", "claimed", b.Cfg, claimedServer, core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if len(api.deleted) != 1 || api.deleted[0] != claimedID {
+		t.Fatalf("deleted=%v stderr=%q, want only claimed instance", api.deleted, stderr.String())
 	}
 }
 

--- a/internal/providers/vultr/backend_test.go
+++ b/internal/providers/vultr/backend_test.go
@@ -323,6 +323,49 @@ func TestResolveReadOnlyDoesNotClaimVisibleInstance(t *testing.T) {
 	}
 }
 
+func TestResolveRejectsCloudlessClaimBeforeRebinding(t *testing.T) {
+	api := &fakeVultrAPI{}
+	b := newTestBackend(t, api)
+	const (
+		leaseID  = "cbx_222222222224"
+		slug     = "cloudless"
+		cloudID  = "33333333-3333-4333-8333-333333333335"
+		repoRoot = "/tmp/repo"
+	)
+	labels := labelsFromTags(leaseTags(b.Cfg, leaseID, slug, "ready", false, time.Now()))
+	labels[vultrAccountLabel] = "account:test-account"
+	claimServer := core.Server{
+		Provider: providerName,
+		Name:     core.LeaseProviderName(leaseID, slug),
+		Labels:   labels,
+	}
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, b.Cfg, claimServer, core.SSHTarget{}, repoRoot, b.Cfg.IdleTimeout, false); err != nil {
+		t.Fatal(err)
+	}
+	api.instances = []vultrInstance{{
+		ID:           cloudID,
+		Label:        core.LeaseProviderName(leaseID, slug),
+		MainIP:       "203.0.113.42",
+		Status:       "active",
+		PowerStatus:  "running",
+		ServerStatus: "ok",
+		Plan:         b.Cfg.ServerType,
+		Tags:         tagsFromLabels(labels),
+	}}
+
+	_, err := b.Resolve(context.Background(), core.ResolveRequest{ID: slug, Repo: core.Repo{Root: t.TempDir()}})
+	if err == nil || !strings.Contains(err.Error(), "no instance identity") {
+		t.Fatalf("Resolve err=%v", err)
+	}
+	claim, claimErr := core.ReadLeaseClaim(leaseID)
+	if claimErr != nil {
+		t.Fatal(claimErr)
+	}
+	if claim.CloudID != "" {
+		t.Fatalf("cloudless claim was rebound: %#v", claim)
+	}
+}
+
 func TestReleaseRefusesUnknownKeyOwnershipBeforeDeleting(t *testing.T) {
 	api := &fakeVultrAPI{}
 	b := newTestBackend(t, api)

--- a/internal/providers/vultr/backend_test.go
+++ b/internal/providers/vultr/backend_test.go
@@ -558,6 +558,32 @@ func TestReleaseOnlyResolveRejectsExactNonVultrLeaseID(t *testing.T) {
 	}
 }
 
+func TestReleaseCanonicalIdentifierDoesNotFallBackToClaimSlug(t *testing.T) {
+	api := &fakeVultrAPI{}
+	b := newTestBackend(t, api)
+	const (
+		requestedID = "cbx_aaaaaaaaaaaa"
+		lookalikeID = "cbx_bbbbbbbbbbbb"
+	)
+	labels := core.DirectLeaseLabels(b.Cfg, lookalikeID, requestedID, providerName, "", false, time.Now())
+	labels[vultrAccountLabel] = "account:test-account"
+	labels[vultrKeyOwnedLabel] = "false"
+	server := core.Server{
+		Provider: providerName,
+		CloudID:  "99999999-9999-4999-8999-999999999999",
+		Name:     core.LeaseProviderName(lookalikeID, requestedID),
+		Labels:   labels,
+	}
+	if err := core.ClaimLeaseTargetForRepoConfig(lookalikeID, requestedID, b.Cfg, server, core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := b.Resolve(context.Background(), core.ResolveRequest{ID: requestedID, ReleaseOnly: true})
+	if err == nil || !strings.Contains(err.Error(), "exact lease identifier") {
+		t.Fatalf("Resolve release-only err=%v", err)
+	}
+}
+
 func TestTouchAppliesIdleTimeoutOverride(t *testing.T) {
 	api := &fakeVultrAPI{}
 	b := newTestBackend(t, api)

--- a/internal/providers/vultr/backend_test.go
+++ b/internal/providers/vultr/backend_test.go
@@ -227,26 +227,26 @@ func TestAcquireCreatesInstanceClaimsLeaseAndMarksReady(t *testing.T) {
 func TestReleaseRefusesAccountMismatchAndForeignTags(t *testing.T) {
 	api := &fakeVultrAPI{accountID: "account:current"}
 	b := newTestBackend(t, api)
-	labels := leaseTags(b.Cfg, "cbx_abc", "blue", "ready", false, time.Now())
+	labels := leaseTags(b.Cfg, "cbx_111111111111", "blue", "ready", false, time.Now())
 	server := serverFromInstance(vultrInstance{
 		ID:           "11111111-1111-4111-8111-111111111111",
 		MainIP:       "203.0.113.20",
 		Status:       "active",
 		PowerStatus:  "running",
 		ServerStatus: "ok",
-		Label:        core.LeaseProviderName("cbx_abc", "blue"),
+		Label:        core.LeaseProviderName("cbx_111111111111", "blue"),
 		Plan:         b.Cfg.ServerType,
 		Tags:         labels,
 	}, b.Cfg)
 	server.Labels[vultrAccountLabel] = "account:other"
-	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: "cbx_abc", Server: server}}); err == nil || !strings.Contains(err.Error(), "account mismatch") {
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: "cbx_111111111111", Server: server}}); err == nil || !strings.Contains(err.Error(), "account mismatch") {
 		t.Fatalf("err=%v", err)
 	}
 	if len(api.deleted) != 0 {
 		t.Fatalf("deleted=%v", api.deleted)
 	}
 	server.Labels = map[string]string{"crabbox": "true", "provider": providerName}
-	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: "cbx_abc", Server: server}}); err == nil || !strings.Contains(err.Error(), "non-Crabbox Vultr instance") {
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: "cbx_111111111111", Server: server}}); err == nil || !strings.Contains(err.Error(), "non-Crabbox Vultr instance") {
 		t.Fatalf("foreign err=%v", err)
 	}
 }
@@ -275,10 +275,10 @@ func TestReleaseDeletesOwnedInstanceKeyAndClaim(t *testing.T) {
 func TestResolveHyphenatedSlugDoesNotUseInstanceIDLookup(t *testing.T) {
 	api := &fakeVultrAPI{}
 	b := newTestBackend(t, api)
-	tags := leaseTags(b.Cfg, "cbx_slugtest", "my-long-app", "ready", false, time.Now())
+	tags := leaseTags(b.Cfg, "cbx_222222222222", "my-long-app", "ready", false, time.Now())
 	api.instances = []vultrInstance{{
 		ID:           "33333333-3333-4333-8333-333333333333",
-		Label:        core.LeaseProviderName("cbx_slugtest", "my-long-app"),
+		Label:        core.LeaseProviderName("cbx_222222222222", "my-long-app"),
 		MainIP:       "203.0.113.40",
 		Status:       "active",
 		PowerStatus:  "running",
@@ -286,22 +286,50 @@ func TestResolveHyphenatedSlugDoesNotUseInstanceIDLookup(t *testing.T) {
 		Plan:         b.Cfg.ServerType,
 		Tags:         tags,
 	}}
-	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "my-long-app", Repo: core.Repo{Root: t.TempDir()}})
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "my-long-app", Repo: core.Repo{Root: t.TempDir()}, Reclaim: true})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if lease.LeaseID != "cbx_slugtest" || lease.Server.CloudID != "33333333-3333-4333-8333-333333333333" {
+	if lease.LeaseID != "cbx_222222222222" || lease.Server.CloudID != "33333333-3333-4333-8333-333333333333" {
 		t.Fatalf("lease=%#v", lease)
+	}
+}
+
+func TestResolveReadOnlyDoesNotClaimVisibleInstance(t *testing.T) {
+	api := &fakeVultrAPI{}
+	b := newTestBackend(t, api)
+	leaseID := "cbx_222222222223"
+	slug := "read-only"
+	api.instances = []vultrInstance{{
+		ID:           "33333333-3333-4333-8333-333333333334",
+		Label:        core.LeaseProviderName(leaseID, slug),
+		MainIP:       "203.0.113.41",
+		Status:       "active",
+		PowerStatus:  "running",
+		ServerStatus: "ok",
+		Plan:         b.Cfg.ServerType,
+		Tags:         leaseTags(b.Cfg, leaseID, slug, "ready", false, time.Now()),
+	}}
+
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: slug, Repo: core.Repo{Root: t.TempDir()}, NoLocalStateMutations: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.LeaseID != leaseID || lease.Server.CloudID != api.instances[0].ID {
+		t.Fatalf("lease=%#v", lease)
+	}
+	if _, exists, err := core.ReadLeaseClaimWithPresence(leaseID); err != nil || exists {
+		t.Fatalf("read-only resolve wrote claim: exists=%v err=%v", exists, err)
 	}
 }
 
 func TestReleaseRefusesUnknownKeyOwnershipBeforeDeleting(t *testing.T) {
 	api := &fakeVultrAPI{}
 	b := newTestBackend(t, api)
-	tags := leaseTags(b.Cfg, "cbx_unknownkey", "blue", "ready", false, time.Now())
+	tags := leaseTags(b.Cfg, "cbx_333333333333", "blue", "ready", false, time.Now())
 	api.instances = []vultrInstance{{
 		ID:           "44444444-4444-4444-8444-444444444444",
-		Label:        core.LeaseProviderName("cbx_unknownkey", "blue"),
+		Label:        core.LeaseProviderName("cbx_333333333333", "blue"),
 		MainIP:       "203.0.113.50",
 		Status:       "active",
 		PowerStatus:  "running",
@@ -311,7 +339,10 @@ func TestReleaseRefusesUnknownKeyOwnershipBeforeDeleting(t *testing.T) {
 	}}
 	server := serverFromInstance(api.instances[0], b.Cfg)
 	server.Labels[vultrAccountLabel] = "account:test-account"
-	err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: "cbx_unknownkey", Server: server}})
+	if err := core.ClaimLeaseTargetForRepoConfig("cbx_333333333333", "blue", b.Cfg, server, core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false); err != nil {
+		t.Fatal(err)
+	}
+	err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: "cbx_333333333333", Server: server}})
 	if err == nil || !strings.Contains(err.Error(), "SSH key ownership remains indeterminate") {
 		t.Fatalf("err=%v", err)
 	}
@@ -320,20 +351,20 @@ func TestReleaseRefusesUnknownKeyOwnershipBeforeDeleting(t *testing.T) {
 	}
 }
 
-func TestReleaseFromCloudTagsWithoutLocalClaimUsesPersistedKeyIdentity(t *testing.T) {
+func TestReleaseFromCloudTagsWithoutLocalClaimFailsClosed(t *testing.T) {
 	api := &fakeVultrAPI{}
 	b := newTestBackend(t, api)
-	_, publicKey, err := core.EnsureTestboxKeyForConfig(b.Cfg, "cbx_cloudonly")
+	_, publicKey, err := core.EnsureTestboxKeyForConfig(b.Cfg, "cbx_444444444444")
 	if err != nil {
 		t.Fatal(err)
 	}
-	api.sshKeys = append(api.sshKeys, vultrSSHKey{ID: "key-cloud", Name: providerKeyForLease("cbx_cloudonly"), SSHKey: publicKey})
-	labels := labelsFromTags(leaseTags(b.Cfg, "cbx_cloudonly", "blue", "ready", false, time.Now()))
+	api.sshKeys = append(api.sshKeys, vultrSSHKey{ID: "key-cloud", Name: providerKeyForLease("cbx_444444444444"), SSHKey: publicKey})
+	labels := labelsFromTags(leaseTags(b.Cfg, "cbx_444444444444", "blue", "ready", false, time.Now()))
 	setVultrKeyIdentity(labels, "key-cloud", true)
 	tags := tagsFromLabels(labels)
 	api.instances = []vultrInstance{{
 		ID:           "66666666-6666-4666-8666-666666666666",
-		Label:        core.LeaseProviderName("cbx_cloudonly", "blue"),
+		Label:        core.LeaseProviderName("cbx_444444444444", "blue"),
 		MainIP:       "203.0.113.60",
 		Status:       "active",
 		PowerStatus:  "running",
@@ -343,13 +374,13 @@ func TestReleaseFromCloudTagsWithoutLocalClaimUsesPersistedKeyIdentity(t *testin
 	}}
 	server := serverFromInstance(api.instances[0], b.Cfg)
 	server.Labels[vultrAccountLabel] = "account:test-account"
-	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: "cbx_cloudonly", Server: server}}); err != nil {
-		t.Fatal(err)
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: "cbx_444444444444", Server: server}}); err == nil || !strings.Contains(err.Error(), "no exact local claim") {
+		t.Fatalf("ReleaseLease err=%v", err)
 	}
-	if len(api.deleted) != 1 || api.deleted[0] != server.CloudID {
+	if len(api.deleted) != 0 {
 		t.Fatalf("deleted=%v", api.deleted)
 	}
-	if len(api.deletedKeys) != 1 || api.deletedKeys[0] != "key-cloud" {
+	if len(api.deletedKeys) != 0 {
 		t.Fatalf("deletedKeys=%v", api.deletedKeys)
 	}
 }
@@ -357,16 +388,16 @@ func TestReleaseFromCloudTagsWithoutLocalClaimUsesPersistedKeyIdentity(t *testin
 func TestReleaseRefusesTamperedProviderKeyIDBeforeDeleting(t *testing.T) {
 	api := &fakeVultrAPI{}
 	b := newTestBackend(t, api)
-	_, publicKey, err := core.EnsureTestboxKeyForConfig(b.Cfg, "cbx_tampered")
+	_, publicKey, err := core.EnsureTestboxKeyForConfig(b.Cfg, "cbx_555555555555")
 	if err != nil {
 		t.Fatal(err)
 	}
-	api.sshKeys = append(api.sshKeys, vultrSSHKey{ID: "real-key", Name: providerKeyForLease("cbx_tampered"), SSHKey: publicKey})
-	labels := labelsFromTags(leaseTags(b.Cfg, "cbx_tampered", "blue", "ready", false, time.Now()))
+	api.sshKeys = append(api.sshKeys, vultrSSHKey{ID: "real-key", Name: providerKeyForLease("cbx_555555555555"), SSHKey: publicKey})
+	labels := labelsFromTags(leaseTags(b.Cfg, "cbx_555555555555", "blue", "ready", false, time.Now()))
 	setVultrKeyIdentity(labels, "other-key", true)
 	api.instances = []vultrInstance{{
 		ID:           "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
-		Label:        core.LeaseProviderName("cbx_tampered", "blue"),
+		Label:        core.LeaseProviderName("cbx_555555555555", "blue"),
 		MainIP:       "203.0.113.61",
 		Status:       "active",
 		PowerStatus:  "running",
@@ -376,7 +407,10 @@ func TestReleaseRefusesTamperedProviderKeyIDBeforeDeleting(t *testing.T) {
 	}}
 	server := serverFromInstance(api.instances[0], b.Cfg)
 	server.Labels[vultrAccountLabel] = "account:test-account"
-	err = b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: "cbx_tampered", Server: server}})
+	if err := core.ClaimLeaseTargetForRepoConfig("cbx_555555555555", "blue", b.Cfg, server, core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false); err != nil {
+		t.Fatal(err)
+	}
+	err = b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: "cbx_555555555555", Server: server}})
 	if err == nil || !strings.Contains(err.Error(), "refusing to delete Vultr SSH key") {
 		t.Fatalf("err=%v", err)
 	}
@@ -388,24 +422,24 @@ func TestReleaseRefusesTamperedProviderKeyIDBeforeDeleting(t *testing.T) {
 func TestReleaseOnlyResolveFallsBackToLocalClaimBySlug(t *testing.T) {
 	api := &fakeVultrAPI{}
 	b := newTestBackend(t, api)
-	labels := core.DirectLeaseLabels(b.Cfg, "cbx_stale", "stale-slug", providerName, "", false, time.Now())
+	labels := core.DirectLeaseLabels(b.Cfg, "cbx_666666666666", "stale-slug", providerName, "", false, time.Now())
 	labels["state"] = "ready"
 	labels[vultrAccountLabel] = "account:test-account"
 	labels[vultrKeyOwnedLabel] = "false"
 	server := core.Server{
 		Provider: providerName,
 		CloudID:  "55555555-5555-4555-8555-555555555555",
-		Name:     core.LeaseProviderName("cbx_stale", "stale-slug"),
+		Name:     core.LeaseProviderName("cbx_666666666666", "stale-slug"),
 		Labels:   labels,
 	}
-	if err := core.ClaimLeaseTargetForRepoConfig("cbx_stale", "stale-slug", b.Cfg, server, core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig("cbx_666666666666", "stale-slug", b.Cfg, server, core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false); err != nil {
 		t.Fatal(err)
 	}
 	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "stale-slug", ReleaseOnly: true})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if lease.LeaseID != "cbx_stale" || lease.Server.CloudID != server.CloudID {
+	if lease.LeaseID != "cbx_666666666666" || lease.Server.CloudID != server.CloudID {
 		t.Fatalf("lease=%#v", lease)
 	}
 }
@@ -450,12 +484,12 @@ func TestReleaseOnlyClaimFallbackUsesProviderNameForLiveValidation(t *testing.T)
 func TestReleaseOnlyResolveDoesNotHideLiveAliasAmbiguity(t *testing.T) {
 	api := &fakeVultrAPI{}
 	b := newTestBackend(t, api)
-	tagsA := leaseTags(b.Cfg, "cbx_ambigua", "same-slug", "ready", false, time.Now())
-	tagsB := leaseTags(b.Cfg, "cbx_ambiguo", "same-slug", "ready", false, time.Now())
+	tagsA := leaseTags(b.Cfg, "cbx_777777777777", "same-slug", "ready", false, time.Now())
+	tagsB := leaseTags(b.Cfg, "cbx_888888888888", "same-slug", "ready", false, time.Now())
 	api.instances = []vultrInstance{
 		{
 			ID:           "77777777-7777-4777-8777-777777777777",
-			Label:        core.LeaseProviderName("cbx_ambigua", "same-slug"),
+			Label:        core.LeaseProviderName("cbx_777777777777", "same-slug"),
 			MainIP:       "203.0.113.70",
 			Status:       "active",
 			PowerStatus:  "running",
@@ -465,7 +499,7 @@ func TestReleaseOnlyResolveDoesNotHideLiveAliasAmbiguity(t *testing.T) {
 		},
 		{
 			ID:           "88888888-8888-4888-8888-888888888888",
-			Label:        core.LeaseProviderName("cbx_ambiguo", "same-slug"),
+			Label:        core.LeaseProviderName("cbx_888888888888", "same-slug"),
 			MainIP:       "203.0.113.71",
 			Status:       "active",
 			PowerStatus:  "running",
@@ -474,7 +508,7 @@ func TestReleaseOnlyResolveDoesNotHideLiveAliasAmbiguity(t *testing.T) {
 			Tags:         tagsB,
 		},
 	}
-	err := core.ClaimLeaseTargetForRepoConfig("cbx_local", "same-slug", b.Cfg, serverFromInstance(api.instances[0], b.Cfg), core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false)
+	err := core.ClaimLeaseTargetForRepoConfig("cbx_999999999999", "same-slug", b.Cfg, serverFromInstance(api.instances[0], b.Cfg), core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -497,28 +531,28 @@ func TestReleaseOnlyResolveRejectsExactNonVultrLeaseID(t *testing.T) {
 			"crabbox":    "true",
 			"created_by": "crabbox",
 			"provider":   "digitalocean",
-			"lease":      "cbx_exact",
+			"lease":      "cbx_aaaaaaaaaaaa",
 			"slug":       "other",
 			"target":     core.TargetLinux,
 		},
 	}
-	if err := core.ClaimLeaseTargetForRepoConfig("cbx_exact", "other", otherCfg, otherServer, core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig("cbx_aaaaaaaaaaaa", "other", otherCfg, otherServer, core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false); err != nil {
 		t.Fatal(err)
 	}
-	labels := core.DirectLeaseLabels(b.Cfg, "cbx_vultr", "cbx_exact", providerName, "", false, time.Now())
+	labels := core.DirectLeaseLabels(b.Cfg, "cbx_bbbbbbbbbbbb", "cbx_aaaaaaaaaaaa", providerName, "", false, time.Now())
 	labels["state"] = "ready"
 	labels[vultrAccountLabel] = "account:test-account"
 	labels[vultrKeyOwnedLabel] = "false"
 	server := core.Server{
 		Provider: providerName,
 		CloudID:  "99999999-9999-4999-8999-999999999999",
-		Name:     core.LeaseProviderName("cbx_vultr", "cbx_exact"),
+		Name:     core.LeaseProviderName("cbx_bbbbbbbbbbbb", "cbx_aaaaaaaaaaaa"),
 		Labels:   labels,
 	}
-	if err := core.ClaimLeaseTargetForRepoConfig("cbx_vultr", "cbx_exact", b.Cfg, server, core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig("cbx_bbbbbbbbbbbb", "cbx_aaaaaaaaaaaa", b.Cfg, server, core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false); err != nil {
 		t.Fatal(err)
 	}
-	_, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "cbx_exact", ReleaseOnly: true})
+	_, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "cbx_aaaaaaaaaaaa", ReleaseOnly: true})
 	if err == nil || !strings.Contains(err.Error(), "exact lease identifier") {
 		t.Fatalf("err=%v", err)
 	}
@@ -560,13 +594,13 @@ func TestCleanupDryRunDoesNotDelete(t *testing.T) {
 	expired := time.Now().Add(-time.Hour)
 	api.instances = []vultrInstance{{
 		ID:           "22222222-2222-4222-8222-222222222222",
-		Label:        core.LeaseProviderName("cbx_old", "old"),
+		Label:        core.LeaseProviderName("cbx_cccccccccccc", "old"),
 		MainIP:       "203.0.113.30",
 		Status:       "active",
 		PowerStatus:  "running",
 		ServerStatus: "ok",
 		Plan:         b.Cfg.ServerType,
-		Tags:         leaseTagsWithExpiry(b.Cfg, "cbx_old", "old", expired),
+		Tags:         leaseTagsWithExpiry(b.Cfg, "cbx_cccccccccccc", "old", expired),
 	}}
 	if err := b.Cleanup(context.Background(), core.CleanupRequest{DryRun: true}); err != nil {
 		t.Fatal(err)
@@ -613,23 +647,23 @@ func TestAmbiguousCreatePreservesRecoveryClaimAndKey(t *testing.T) {
 func TestAmbiguousCreateRecoveryWithoutCloudIDDoesNotDropClaimOrKey(t *testing.T) {
 	api := &fakeVultrAPI{}
 	b := newTestBackend(t, api)
-	labels := core.DirectLeaseLabels(b.Cfg, "cbx_recover", "recover", providerName, "", false, time.Now())
+	labels := core.DirectLeaseLabels(b.Cfg, "cbx_dddddddddddd", "recover", providerName, "", false, time.Now())
 	labels["state"] = "provisioning"
 	labels["recovery"] = "ambiguous-create"
 	labels[vultrAccountLabel] = "account:test-account"
 	setVultrKeyIdentity(labels, "key-recover", true)
-	server := core.Server{Provider: providerName, Name: core.LeaseProviderName("cbx_recover", "recover"), Labels: labels}
-	if err := core.ClaimLeaseTargetForRepoConfig("cbx_recover", "recover", b.Cfg, server, core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false); err != nil {
+	server := core.Server{Provider: providerName, Name: core.LeaseProviderName("cbx_dddddddddddd", "recover"), Labels: labels}
+	if err := core.ClaimLeaseTargetForRepoConfig("cbx_dddddddddddd", "recover", b.Cfg, server, core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false); err != nil {
 		t.Fatal(err)
 	}
-	err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: "cbx_recover", Server: server}})
+	err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: "cbx_dddddddddddd", Server: server}})
 	if err == nil || !strings.Contains(err.Error(), "ambiguous create recovery is still indeterminate") {
 		t.Fatalf("err=%v", err)
 	}
 	if len(api.deleted) != 0 || len(api.deletedKeys) != 0 {
 		t.Fatalf("deleted instance/key: %v %v", api.deleted, api.deletedKeys)
 	}
-	if _, ok, err := core.ReadLeaseClaimWithPresence("cbx_recover"); err != nil || !ok {
+	if _, ok, err := core.ReadLeaseClaimWithPresence("cbx_dddddddddddd"); err != nil || !ok {
 		t.Fatalf("claim retained ok=%v err=%v", ok, err)
 	}
 }
@@ -637,23 +671,23 @@ func TestAmbiguousCreateRecoveryWithoutCloudIDDoesNotDropClaimOrKey(t *testing.T
 func TestAmbiguousCreateRecoveryDeletesAfterLiveInstanceIsFound(t *testing.T) {
 	api := &fakeVultrAPI{}
 	b := newTestBackend(t, api)
-	_, publicKey, err := core.EnsureTestboxKeyForConfig(b.Cfg, "cbx_found")
+	_, publicKey, err := core.EnsureTestboxKeyForConfig(b.Cfg, "cbx_eeeeeeeeeeee")
 	if err != nil {
 		t.Fatal(err)
 	}
-	api.sshKeys = append(api.sshKeys, vultrSSHKey{ID: "key-found", Name: providerKeyForLease("cbx_found"), SSHKey: publicKey})
-	labels := core.DirectLeaseLabels(b.Cfg, "cbx_found", "found", providerName, "", false, time.Now())
+	api.sshKeys = append(api.sshKeys, vultrSSHKey{ID: "key-found", Name: providerKeyForLease("cbx_eeeeeeeeeeee"), SSHKey: publicKey})
+	labels := core.DirectLeaseLabels(b.Cfg, "cbx_eeeeeeeeeeee", "found", providerName, "", false, time.Now())
 	labels["state"] = "provisioning"
 	labels["recovery"] = "ambiguous-create"
 	labels[vultrAccountLabel] = "account:test-account"
 	setVultrKeyIdentity(labels, "key-found", true)
-	claimServer := core.Server{Provider: providerName, Name: core.LeaseProviderName("cbx_found", "found"), Labels: labels}
-	if err := core.ClaimLeaseTargetForRepoConfig("cbx_found", "found", b.Cfg, claimServer, core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false); err != nil {
+	claimServer := core.Server{Provider: providerName, Name: core.LeaseProviderName("cbx_eeeeeeeeeeee", "found"), Labels: labels}
+	if err := core.ClaimLeaseTargetForRepoConfig("cbx_eeeeeeeeeeee", "found", b.Cfg, claimServer, core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false); err != nil {
 		t.Fatal(err)
 	}
 	live := vultrInstance{
 		ID:           "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
-		Label:        core.LeaseProviderName("cbx_found", "found"),
+		Label:        core.LeaseProviderName("cbx_eeeeeeeeeeee", "found"),
 		MainIP:       "203.0.113.90",
 		Status:       "active",
 		PowerStatus:  "running",
@@ -664,7 +698,7 @@ func TestAmbiguousCreateRecoveryDeletesAfterLiveInstanceIsFound(t *testing.T) {
 	api.instances = []vultrInstance{live}
 	server := serverFromInstance(live, b.Cfg)
 	preserveVultrIdentity(server.Labels, labels)
-	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: "cbx_found", Server: server}}); err != nil {
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: "cbx_eeeeeeeeeeee", Server: server}}); err != nil {
 		t.Fatal(err)
 	}
 	if len(api.deleted) != 1 || api.deleted[0] != live.ID {
@@ -673,7 +707,7 @@ func TestAmbiguousCreateRecoveryDeletesAfterLiveInstanceIsFound(t *testing.T) {
 	if len(api.deletedKeys) != 1 || api.deletedKeys[0] != "key-found" {
 		t.Fatalf("deletedKeys=%v", api.deletedKeys)
 	}
-	if _, ok, err := core.ReadLeaseClaimWithPresence("cbx_found"); err != nil || ok {
+	if _, ok, err := core.ReadLeaseClaimWithPresence("cbx_eeeeeeeeeeee"); err != nil || ok {
 		t.Fatalf("claim ok=%v err=%v", ok, err)
 	}
 }

--- a/internal/providers/vultr/backend_test.go
+++ b/internal/providers/vultr/backend_test.go
@@ -879,6 +879,46 @@ func TestSSHKeyRollbackCleanupFailurePreservesRecoveryClaim(t *testing.T) {
 	}
 }
 
+func TestKeyOnlyRollbackRecoveryCannotDeleteLiveInstance(t *testing.T) {
+	api := &fakeVultrAPI{}
+	b := newTestBackend(t, api)
+	const leaseID = "cbx_fefefefefefe"
+	const slug = "key-only"
+	labels := core.DirectLeaseLabels(b.Cfg, leaseID, slug, providerName, "", false, time.Now())
+	labels["state"] = "provisioning"
+	labels["recovery"] = "rollback-cleanup"
+	labels[vultrAccountLabel] = "account:test-account"
+	setVultrKeyIdentity(labels, "key-only-rollback", true)
+	claimServer := core.Server{Provider: providerName, Name: core.LeaseProviderName(leaseID, slug), Labels: labels}
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, b.Cfg, claimServer, core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false); err != nil {
+		t.Fatal(err)
+	}
+	live := vultrInstance{
+		ID:           "fefefefe-fefe-4efe-8efe-fefefefefefe",
+		Label:        core.LeaseProviderName(leaseID, slug),
+		MainIP:       "203.0.113.91",
+		Status:       "active",
+		PowerStatus:  "running",
+		ServerStatus: "ok",
+		Plan:         b.Cfg.ServerType,
+		Tags:         tagsFromLabels(labels),
+	}
+	api.instances = []vultrInstance{live}
+	server := serverFromInstance(live, b.Cfg)
+	server.Labels[vultrAccountLabel] = "account:test-account"
+
+	err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: server}})
+	if err == nil || !strings.Contains(err.Error(), "key-only recovery claim cannot authorize instance cleanup") {
+		t.Fatalf("err=%v", err)
+	}
+	if len(api.deleted) != 0 || len(api.deletedKeys) != 0 {
+		t.Fatalf("deleted instance/key: %v %v", api.deleted, api.deletedKeys)
+	}
+	if _, ok, err := core.ReadLeaseClaimWithPresence(leaseID); err != nil || !ok {
+		t.Fatalf("claim retained ok=%v err=%v", ok, err)
+	}
+}
+
 func TestAcquireRejectsSSHCIDRsWithoutFirewallGroup(t *testing.T) {
 	api := &fakeVultrAPI{}
 	b := newTestBackend(t, api)

--- a/internal/providers/vultr/backend_test.go
+++ b/internal/providers/vultr/backend_test.go
@@ -3,6 +3,7 @@ package vultr
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"os"
 	"strings"
@@ -113,6 +114,15 @@ func (f *fakeVultrAPI) DeleteInstance(_ context.Context, id string) error {
 
 func (f *fakeVultrAPI) FindSSHKey(_ context.Context, name, publicKey string) (vultrSSHKey, bool, error) {
 	return selectVultrSSHKey(f.sshKeys, name, publicKey)
+}
+
+func (f *fakeVultrAPI) FindSSHKeyByID(_ context.Context, id string) (vultrSSHKey, bool, error) {
+	for _, key := range f.sshKeys {
+		if key.ID == id {
+			return key, true, nil
+		}
+	}
+	return vultrSSHKey{}, false, nil
 }
 
 func (f *fakeVultrAPI) DeleteSSHKey(_ context.Context, id string) error {
@@ -269,6 +279,58 @@ func TestReleaseDeletesOwnedInstanceKeyAndClaim(t *testing.T) {
 	}
 	if _, ok, err := core.ReadLeaseClaimWithPresence(lease.LeaseID); err != nil || ok {
 		t.Fatalf("claim ok=%v err=%v", ok, err)
+	}
+}
+
+func TestReleaseDeletesOwnedInstanceWhenSSHKeyAlreadyGone(t *testing.T) {
+	api := &fakeVultrAPI{}
+	b := newTestBackend(t, api)
+	lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "blue"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	api.sshKeys = nil
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+	if len(api.deleted) != 1 || api.deleted[0] != lease.Server.CloudID {
+		t.Fatalf("deleted=%v", api.deleted)
+	}
+	if len(api.deletedKeys) != 0 {
+		t.Fatalf("deletedKeys=%v", api.deletedKeys)
+	}
+	if _, ok, err := core.ReadLeaseClaimWithPresence(lease.LeaseID); err != nil || ok {
+		t.Fatalf("claim ok=%v err=%v", ok, err)
+	}
+}
+
+func TestReleaseDeletesOwnedRenamedSSHKeyByImmutableID(t *testing.T) {
+	api := &fakeVultrAPI{}
+	b := newTestBackend(t, api)
+	lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "blue"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	api.sshKeys[0].Name = "renamed-outside-crabbox"
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+	if len(api.deletedKeys) != 1 || api.deletedKeys[0] != "key-123" {
+		t.Fatalf("deletedKeys=%v", api.deletedKeys)
+	}
+}
+
+func TestRollbackVultrAcquireRetainsSSHKeyWhenInstanceDeleteFails(t *testing.T) {
+	api := &fakeVultrAPI{deleteErr: os.ErrPermission}
+	err := rollbackVultrAcquire(api, "instance-123", "key-123", true)
+	if !errors.Is(err, os.ErrPermission) {
+		t.Fatalf("err=%v", err)
+	}
+	if len(api.deleted) != 1 || api.deleted[0] != "instance-123" {
+		t.Fatalf("deleted=%v", api.deleted)
+	}
+	if len(api.deletedKeys) != 0 {
+		t.Fatalf("deletedKeys=%v", api.deletedKeys)
 	}
 }
 

--- a/internal/providers/vultr/backend_test.go
+++ b/internal/providers/vultr/backend_test.go
@@ -359,6 +359,23 @@ func TestResolveReadOnlyIgnoresStaleInstanceClaim(t *testing.T) {
 	}
 }
 
+func TestStatusTouchClaimRequiresMatchingAccount(t *testing.T) {
+	backend := &backend{}
+	claim := core.LeaseClaim{Labels: map[string]string{vultrAccountLabel: "account:account-a"}}
+	lease := core.LeaseTarget{Server: core.Server{Labels: map[string]string{vultrAccountLabel: "account:account-a"}}}
+	if !backend.StatusTouchClaimMatches(lease, claim) {
+		t.Fatal("matching account identity was rejected")
+	}
+	lease.Server.Labels[vultrAccountLabel] = "account:account-b"
+	if backend.StatusTouchClaimMatches(lease, claim) {
+		t.Fatal("mismatched account identity was accepted")
+	}
+	delete(claim.Labels, vultrAccountLabel)
+	if backend.StatusTouchClaimMatches(lease, claim) {
+		t.Fatal("missing claim account identity was accepted")
+	}
+}
+
 func TestResolveRejectsCloudlessClaimBeforeRebinding(t *testing.T) {
 	api := &fakeVultrAPI{}
 	b := newTestBackend(t, api)

--- a/internal/providers/vultr/backend_test.go
+++ b/internal/providers/vultr/backend_test.go
@@ -323,6 +323,42 @@ func TestResolveReadOnlyDoesNotClaimVisibleInstance(t *testing.T) {
 	}
 }
 
+func TestResolveReadOnlyIgnoresStaleInstanceClaim(t *testing.T) {
+	api := &fakeVultrAPI{}
+	b := newTestBackend(t, api)
+	leaseID := "cbx_222222222225"
+	slug := "stale-read-only"
+	cloudID := "33333333-3333-4333-8333-333333333336"
+	api.instances = []vultrInstance{{
+		ID:           cloudID,
+		Label:        core.LeaseProviderName(leaseID, slug),
+		MainIP:       "203.0.113.42",
+		Status:       "active",
+		PowerStatus:  "running",
+		ServerStatus: "ok",
+		Plan:         b.Cfg.ServerType,
+		Tags:         leaseTags(b.Cfg, leaseID, slug, "ready", false, time.Now()),
+	}}
+	labels := labelsFromTags(api.instances[0].Tags)
+	labels[vultrAccountLabel] = "account:test-account"
+	claimServer := core.Server{Provider: providerName, CloudID: "stale-cloud-id", Name: api.instances[0].Label, Labels: labels}
+	if err := core.ClaimLeaseTargetForConfig(leaseID, slug, b.Cfg, claimServer, core.SSHTarget{}, b.Cfg.IdleTimeout); err != nil {
+		t.Fatal(err)
+	}
+
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: slug, StatusOnly: true, NoLocalStateMutations: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.LeaseID != leaseID || lease.Server.CloudID != cloudID {
+		t.Fatalf("lease=%#v", lease)
+	}
+	claim, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
+	if err != nil || !exists || claim.CloudID != "stale-cloud-id" {
+		t.Fatalf("read-only resolve changed stale claim: claim=%#v exists=%v err=%v", claim, exists, err)
+	}
+}
+
 func TestResolveRejectsCloudlessClaimBeforeRebinding(t *testing.T) {
 	api := &fakeVultrAPI{}
 	b := newTestBackend(t, api)

--- a/internal/providers/vultr/backend_test.go
+++ b/internal/providers/vultr/backend_test.go
@@ -741,17 +741,24 @@ func TestCleanupSkipsClaimlessBeforeClaimedInstance(t *testing.T) {
 	b := newTestBackend(t, api)
 	b.RT.Stderr = &stderr
 	expired := time.Now().Add(-time.Hour)
+	staleLabels := labelsFromTags(leaseTagsWithExpiry(b.Cfg, "cbx_cccccccccccc", "stale-account", expired))
 	claimlessLabels := labelsFromTags(leaseTagsWithExpiry(b.Cfg, "cbx_aaaaaaaaaaaa", "claimless", expired))
 	claimlessLabels[vultrAccountLabel] = "account:test-account"
 	claimedLabels := labelsFromTags(leaseTagsWithExpiry(b.Cfg, "cbx_bbbbbbbbbbbb", "claimed", expired))
 	claimedLabels[vultrAccountLabel] = "account:test-account"
 	setVultrKeyIdentity(claimedLabels, "", false)
 	api.instances = []vultrInstance{
+		{ID: "cccccccc-cccc-4ccc-8ccc-cccccccccccc", Label: core.LeaseProviderName("cbx_cccccccccccc", "stale-account"), Status: "active", PowerStatus: "running", ServerStatus: "ok", Plan: b.Cfg.ServerType, Tags: tagsFromLabels(staleLabels)},
 		{ID: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", Label: core.LeaseProviderName("cbx_aaaaaaaaaaaa", "claimless"), Status: "active", PowerStatus: "running", ServerStatus: "ok", Plan: b.Cfg.ServerType, Tags: tagsFromLabels(claimlessLabels)},
 		{ID: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb", Label: core.LeaseProviderName("cbx_bbbbbbbbbbbb", "claimed"), Status: "active", PowerStatus: "running", ServerStatus: "ok", Plan: b.Cfg.ServerType, Tags: tagsFromLabels(claimedLabels)},
 	}
-	claimedID := api.instances[1].ID
-	claimedServer := serverFromInstance(api.instances[1], b.Cfg)
+	staleServer := serverFromInstance(api.instances[0], b.Cfg)
+	staleServer.Labels[vultrAccountLabel] = "account:stale-account"
+	if err := core.ClaimLeaseTargetForRepoConfig("cbx_cccccccccccc", "stale-account", b.Cfg, staleServer, core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false); err != nil {
+		t.Fatal(err)
+	}
+	claimedID := api.instances[2].ID
+	claimedServer := serverFromInstance(api.instances[2], b.Cfg)
 	claimedServer.Labels[vultrAccountLabel] = "account:test-account"
 	if err := core.ClaimLeaseTargetForRepoConfig("cbx_bbbbbbbbbbbb", "claimed", b.Cfg, claimedServer, core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false); err != nil {
 		t.Fatal(err)
@@ -761,6 +768,9 @@ func TestCleanupSkipsClaimlessBeforeClaimedInstance(t *testing.T) {
 	}
 	if len(api.deleted) != 1 || api.deleted[0] != claimedID {
 		t.Fatalf("deleted=%v stderr=%q, want only claimed instance", api.deleted, stderr.String())
+	}
+	if _, ok, err := core.ResolveLeaseClaimForProvider("cbx_cccccccccccc", providerName); err != nil || !ok {
+		t.Fatalf("stale-account claim after cleanup ok=%v err=%v", ok, err)
 	}
 }
 

--- a/internal/providers/vultr/client.go
+++ b/internal/providers/vultr/client.go
@@ -28,6 +28,7 @@ type vultrAPI interface {
 	GetInstance(context.Context, string) (vultrInstance, error)
 	CreateInstance(context.Context, core.Config, string, string, string, bool, time.Time) (vultrInstance, error)
 	DeleteInstance(context.Context, string) error
+	FindSSHKeyByID(context.Context, string) (vultrSSHKey, bool, error)
 	FindSSHKey(context.Context, string, string) (vultrSSHKey, bool, error)
 	DeleteSSHKey(context.Context, string) error
 	UpdateInstanceTags(context.Context, string, []string) error
@@ -522,6 +523,19 @@ func (c *vultrClient) FindSSHKey(ctx context.Context, name, publicKey string) (v
 		return vultrSSHKey{}, false, err
 	}
 	return selectVultrSSHKey(keys, name, publicKey)
+}
+
+func (c *vultrClient) FindSSHKeyByID(ctx context.Context, id string) (vultrSSHKey, bool, error) {
+	keys, err := c.ListSSHKeys(ctx)
+	if err != nil {
+		return vultrSSHKey{}, false, err
+	}
+	for _, key := range keys {
+		if key.ID == id {
+			return key, true, nil
+		}
+	}
+	return vultrSSHKey{}, false, nil
 }
 
 func selectVultrSSHKey(keys []vultrSSHKey, name, publicKey string) (vultrSSHKey, bool, error) {

--- a/internal/providers/vultr/client_test.go
+++ b/internal/providers/vultr/client_test.go
@@ -116,7 +116,7 @@ func TestVultrClientCursorPaginationAndRateLimit(t *testing.T) {
 			}
 			_, _ = w.Write([]byte(`{"instances":[{"id":"one","label":"foreign"}],"meta":{"links":{"next":"` + baseURL + `/instances?cursor=next"}}}`))
 		case "/instances?cursor=next":
-			_, _ = w.Write([]byte(`{"instances":[{"id":"two","label":"cbx_abc-blue","tags":["crabbox","crabbox:provider:vultr","crabbox:target:linux","crabbox:lease:cbx_abc","crabbox:slug:blue"]}],"meta":{"links":{}}}`))
+			_, _ = w.Write([]byte(`{"instances":[{"id":"two","label":"cbx_111111111111-blue","tags":["crabbox","crabbox:provider:vultr","crabbox:target:linux","crabbox:lease:cbx_111111111111","crabbox:slug:blue"]}],"meta":{"links":{}}}`))
 		default:
 			t.Fatalf("unexpected request %s", r.URL.RequestURI())
 		}
@@ -236,7 +236,7 @@ func TestVultrClientRejectsMultipleBootSources(t *testing.T) {
 	cfg := core.BaseConfig()
 	cfg.Vultr.OS = "2284"
 	cfg.Vultr.Image = "image-123"
-	_, err = client.createInstanceBody(context.Background(), cfg, "ssh-ed25519 test", "key", "cbx_abc", "blue", false, time.Now())
+	_, err = client.createInstanceBody(context.Background(), cfg, "ssh-ed25519 test", "key", "cbx_111111111111", "blue", false, time.Now())
 	if err == nil || !strings.Contains(err.Error(), "exactly one boot source") {
 		t.Fatalf("err=%v", err)
 	}

--- a/internal/providers/vultr/tags.go
+++ b/internal/providers/vultr/tags.go
@@ -189,7 +189,7 @@ func validateInstanceLabels(labels map[string]string) error {
 		labels["crabbox"] != "true" ||
 		labels["created_by"] != "crabbox" ||
 		labels["provider"] != providerName ||
-		labels["lease"] == "" ||
+		!core.IsCanonicalLeaseID(labels["lease"]) ||
 		labels["slug"] == "" ||
 		labels["target"] != core.TargetLinux {
 		return core.Exit(2, "refusing to operate on non-Crabbox Vultr instance")

--- a/internal/providers/vultr/tags_test.go
+++ b/internal/providers/vultr/tags_test.go
@@ -24,7 +24,11 @@ func TestVultrTagsRoundTripOwnership(t *testing.T) {
 }
 
 func TestVultrTagsRejectPartialForeignAndConflictingOwnership(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.TargetOS = core.TargetLinux
 	for name, tags := range map[string][]string{
+		"non-canonical lease": leaseTags(cfg, "legacy-lease-1", "blue", "ready", false, time.Unix(1, 0)),
 		"partial": {
 			tagCrabbox,
 			"crabbox:provider:vultr",
@@ -33,7 +37,7 @@ func TestVultrTagsRejectPartialForeignAndConflictingOwnership(t *testing.T) {
 			tagCrabbox,
 			"crabbox:provider:digitalocean",
 			"crabbox:target:linux",
-			"crabbox:lease:cbx_abc",
+			"crabbox:lease:cbx_111111111111",
 			"crabbox:slug:blue",
 		},
 		"conflict": {
@@ -41,7 +45,7 @@ func TestVultrTagsRejectPartialForeignAndConflictingOwnership(t *testing.T) {
 			"crabbox:provider:vultr",
 			"crabbox:provider:other",
 			"crabbox:target:linux",
-			"crabbox:lease:cbx_abc",
+			"crabbox:lease:cbx_111111111111",
 			"crabbox:slug:blue",
 		},
 	} {


### PR DESCRIPTION
## Summary

- require canonical lease IDs before DigitalOcean, Linode, Vultr, or Scaleway resources enter Crabbox inventory
- require exact provider/account-or-project/resource-bound local claims before reuse, stop, status-touch, or cleanup
- skip claimless or mismatched cleanup candidates without aborting cleanup of later exactly claimed resources
- keep claimless canonical resources read-only until explicit `--reclaim` adoption; never synthesize destructive ownership from remote tags
- preserve interrupted-create recovery while validating exact provider identity
- bind Scaleway ambiguous-create recovery to one unique server before deletion and bind SSH-key cleanup to the immutable claim
- restrict key-only or cloudless rollback Scaleway and Vultr recovery claims to identityless cleanup; they cannot authorize live server deletion
- keep read-only and explicit no-mutation resolve paths from writing claims
- document the ownership boundary in provider and stop documentation

Closes https://github.com/openclaw/crabbox/issues/811

## Verification

Current candidate: `6a8ceb954f163bd0f534d883bd2328a07dc24e3a`.

- `go test -race ./internal/providers/shared ./internal/providers/digitalocean ./internal/providers/linode ./internal/providers/vultr ./internal/providers/scaleway -count=1`
- `go test -race ./internal/cli -run '^TestControllerPreAcquireAckFailureRetainsStoppingUntilStableAbsence$' -count=50`
- `go vet ./internal/cli ./internal/providers/shared ./internal/providers/digitalocean ./internal/providers/linode ./internal/providers/vultr ./internal/providers/scaleway`
- `scripts/check-docs.sh`
- `node scripts/generate-provider-matrix.mjs --check`
- `node scripts/check-provider-matrix.mjs`
- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- `go test -race ./...`
- `git diff --check main...HEAD`
- exact candidate binary SHA-256: `7a39ec8947a41f934b9ae7ef928458ba0a498b0c0eb8ec368017bbac29f88f0e`
- rebased cleanly onto current `main` at `8b1242493774f496178eeacd31a31f603420960f`
- branch AutoReview findings fixed: identityless Scaleway recovery deletion, mutable live SSH-key tag authorization, and no-mutation resolve semantics
- the advertised repeated controller proof exposed a remaining scheduling flake; the test now waits for persisted provider absence and an inactive reconcile before advancing its fake clock
- focused and full-branch structured Codex AutoReview clean after the fixes, with no accepted/actionable findings

Hosted CI is running on the exact candidate.

## Provider-live proof

The exact candidate completed real DigitalOcean, Linode, and Scaleway canaries. Each began with empty managed inventory, created a funded instance and per-lease key, reached ready through status-touch, ran a remote command, stopped through its exact local claim, and ended with empty provider inventory and no local or provider key residue.

Vultr remains credential-blocked: targeted environment and 1Password lookup found no API credential; the saved web login reaches the API-key creation reCAPTCHA boundary.

Keep this PR unmerged until the four exact-head provider canaries prove create, status-touch, use, stop, bulk cleanup where applicable, and empty inventory.

## Compatibility decision

Accepted fail-closed behavior: claimless, provider-identity-mismatched, recovery-ambiguous, or SSH-key-identity-mismatched resources remain inspectable but cannot be touched or deleted until an exact claim is established.
