### PR TITLE
fix: require exact local VM claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Compared coordinator admin, shared-operator, runtime-adapter, proxy, and signed-session secrets without mismatch-position or early length exits. Thanks @coygeek.
 - Prevented direct Azure list, stop, and cleanup paths from treating weak `crabbox=true` tags as ownership; destructive operations now require canonical Azure ownership tags and an exact matching lease ID, and successful deletion removes local lease keys. Thanks @coygeek.
 - Restricted brokered Azure image and OS-disk selectors to admin-authenticated requests while preserving user-selectable Azure placement. Thanks @coygeek.
+- Required exact provider, resource, and local-claim ownership before Hyper-V, Multipass, or Parallels release and cleanup paths can delete virtual machines. Thanks @coygeek.
 - Required exact resource-bound local lease claims before Apple Container, local-container, or Apple VZ stop operations can delete provider resources; legacy unbound claims require explicit `--reclaim` adoption before stop. Thanks @coygeek.
 - Hardened Azure Windows snapshot forks to fail closed through credential rehydration and quarantine cleanup, reuse only writable NIC payloads, reject unknown differential disks, and retry in-use security-group cleanup. Thanks @fcoury-oai.
 

--- a/docs/providers/hyperv.md
+++ b/docs/providers/hyperv.md
@@ -166,13 +166,14 @@ installation.
 3. **List**: Lists all VMs with the `crabbox-` name prefix.
 4. **Release**: Stops the VM (`Stop-VM -Force`) and removes it
    (`Remove-VM -Force`), then cleans up the provider-created VHDX file.
-5. **Cleanup**: Scans for stale `crabbox-` prefixed VMs with expired or missing
-   lease claims and removes them.
+5. **Cleanup**: Scans for stale `crabbox-` prefixed VMs and removes only VMs
+   bound to an exact expired local claim.
 
 ## Notes
 
-- All VMs are named with a `crabbox-` prefix. Cleanup and release operations
-  refuse to touch VMs without this prefix.
+- All VMs are named with a `crabbox-` prefix, but the prefix is not ownership
+  proof. Cleanup and release require an exact local claim bound to the VM name;
+  recovered VMs must first be adopted through an explicit `--reclaim` reuse.
 - The selected SSH account must be a local account name containing only letters,
   digits, `.`, `_`, or `-`. Domain/UPN names and SSH pattern characters are
   rejected so `AllowUsers` cannot broaden access.

--- a/docs/providers/multipass.md
+++ b/docs/providers/multipass.md
@@ -168,10 +168,11 @@ CRABBOX_MULTIPASS_LAUNCH_TIMEOUT
    non-`keep` VMs whose local claim is stale past the idle timeout plus the
    direct-provider grace window.
 
-Multipass does not expose provider labels. Crabbox therefore treats the instance
-name and local lease claim as the source of ownership. Unclaimed user-created
-instances are ignored by `list` unless their name starts with `crabbox-`, and
-`cleanup` skips unclaimed running instances.
+Multipass does not expose provider labels. Crabbox therefore treats the exact
+instance-bound local lease claim as the source of ownership. `stop` and
+`cleanup` skip every unclaimed instance, including stopped `crabbox-`-prefixed
+instances. Adopt intentionally recovered instances through an explicit
+`--reclaim` reuse before destructive lifecycle operations.
 
 ## Limits And Caveats
 

--- a/docs/providers/parallels.md
+++ b/docs/providers/parallels.md
@@ -228,8 +228,11 @@ and their base snapshots while any checkpoint or clone depends on them.
 
 ## Safety
 
-Crabbox refuses to delete Parallels VMs unless their name starts with
-`crabbox-`. `stop` and `cleanup` are scoped to clones Crabbox created.
+Crabbox refuses to delete a Parallels VM unless an exact local claim binds the
+lease to the VM ID and selected Parallels host. A `crabbox-` name alone is not
+ownership proof. `stop` and `cleanup` skip unclaimed or mismatched clones;
+intentionally recovered clones must first be adopted through an explicit
+`--reclaim` reuse.
 
 Use `--dry-run` on direct fork, restore, and delete when validating a template
 or snapshot name. `checkpoint list` prints live Parallels state and marks

--- a/docs/security.md
+++ b/docs/security.md
@@ -245,7 +245,10 @@ a matching local claim. Freestyle and Islo canonical names remain available
 for read-only discovery, but delete, pause, resume, SSH reuse, and delegated
 reuse require an exact local claim. When local state was intentionally lost,
 an operator can use the provider's supported `--reclaim` reuse path to persist
-a new claim before any provider mutation.
+a new claim before any provider mutation. Hyper-V, Multipass, and Parallels
+likewise require exact resource-bound local claims before release or cleanup;
+provider names and `crabbox-` resource prefixes are discovery hints, not
+destructive ownership proof.
 
 Artifact publishing rejects symlinks, directories at reserved generated-output
 paths, and other non-regular bundle entries before upload side effects. Required

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -254,6 +254,16 @@ func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget,
 	if req.StatusOnly && !req.ReadyProbe {
 		return LeaseTarget{Server: b.serverFromInstance(inst, claim, cfg), LeaseID: claim.LeaseID}, nil
 	}
+	owned, err := exactHyperVClaimOwned(claim.LeaseID, inst.Name)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	if !owned && !req.Reclaim {
+		return LeaseTarget{}, exit(4, "hyperv lease %q has a legacy claim not bound to VM %q; adopt it with an explicit --reclaim reuse", claim.LeaseID, inst.Name)
+	}
+	if !owned && req.Repo.Root == "" {
+		return LeaseTarget{}, exit(2, "hyperv --reclaim requires repository context before binding VM %q", inst.Name)
+	}
 	ip := b.queryLiveIP(ctx, inst.Name)
 	if ip == "" {
 		ip = b.getIPFromClaim(claim)
@@ -263,7 +273,7 @@ func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget,
 		return LeaseTarget{}, err
 	}
 	if req.Repo.Root != "" {
-		if err := claimLeaseForRepoProviderScopePond(claim.LeaseID, claim.Slug, providerName, instanceScope(inst.Name), cfg.Pond, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
+		if err := claimLeaseForRepoProviderScopePondEndpoint(claim.LeaseID, claim.Slug, providerName, instanceScope(inst.Name), cfg.Pond, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, lease.Server, lease.SSH); err != nil {
 			return LeaseTarget{}, err
 		}
 	}
@@ -331,6 +341,9 @@ func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) err
 	if name == "" {
 		return exit(2, "provider=%s release requires a Hyper-V VM name", providerName)
 	}
+	if err := requireExactHyperVClaim(lease.LeaseID, name); err != nil {
+		return err
+	}
 	if err := b.removeVM(ctx, name); err != nil {
 		return err
 	}
@@ -375,6 +388,14 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 		shouldDelete, reason := shouldCleanup(server, claim, claim.LeaseID != "", now)
 		if !shouldDelete {
 			fmt.Fprintf(b.rt.Stderr, "skip instance name=%s reason=%s\n", inst.Name, reason)
+			continue
+		}
+		owned, err := exactHyperVClaimOwned(claim.LeaseID, inst.Name)
+		if err != nil {
+			return err
+		}
+		if !owned {
+			fmt.Fprintf(b.rt.Stderr, "skip instance name=%s reason=ownership: missing exact local claim\n", inst.Name)
 			continue
 		}
 		if req.DryRun {
@@ -1234,33 +1255,54 @@ func shouldCleanup(server Server, claim core.LeaseClaim, hasClaim bool, now time
 	if strings.EqualFold(server.Labels["keep"], "true") {
 		return false, "keep=true"
 	}
+	if !hasClaim {
+		return false, "missing claim"
+	}
 	if server.Status != "running" && server.Status != "ready" {
 		return true, "instance state=" + blank(server.Status, "unknown")
 	}
-	if hasClaim {
-		expiresAt := strings.TrimSpace(server.Labels["expires_at"])
-		if expiresAt == "" {
-			expiresAt = strings.TrimSpace(claim.Labels["expires_at"])
-		}
-		if display := core.LeaseLabelTimeDisplay(expiresAt); display != "" {
-			if parsed, err := time.Parse(time.RFC3339, display); err == nil && now.After(parsed) {
-				return true, "claim expired"
-			}
-		}
-		lastUsed, err := time.Parse(time.RFC3339, strings.TrimSpace(claim.LastUsedAt))
-		if err != nil || lastUsed.IsZero() {
-			return false, "claim active"
-		}
-		idle := time.Duration(claim.IdleTimeoutSeconds) * time.Second
-		if idle <= 0 {
-			return false, "claim active"
-		}
-		if now.After(lastUsed.Add(idle).Add(12 * time.Hour)) {
+	expiresAt := strings.TrimSpace(server.Labels["expires_at"])
+	if expiresAt == "" {
+		expiresAt = strings.TrimSpace(claim.Labels["expires_at"])
+	}
+	if display := core.LeaseLabelTimeDisplay(expiresAt); display != "" {
+		if parsed, err := time.Parse(time.RFC3339, display); err == nil && now.After(parsed) {
 			return true, "claim expired"
 		}
+	}
+	lastUsed, err := time.Parse(time.RFC3339, strings.TrimSpace(claim.LastUsedAt))
+	if err != nil || lastUsed.IsZero() {
 		return false, "claim active"
 	}
-	return false, "missing claim"
+	idle := time.Duration(claim.IdleTimeoutSeconds) * time.Second
+	if idle <= 0 {
+		return false, "claim active"
+	}
+	if now.After(lastUsed.Add(idle).Add(12 * time.Hour)) {
+		return true, "claim expired"
+	}
+	return false, "claim active"
+}
+
+func requireExactHyperVClaim(leaseID, instanceName string) error {
+	owned, err := exactHyperVClaimOwned(leaseID, instanceName)
+	if err != nil {
+		return err
+	}
+	if !owned {
+		return exit(4, "hyperv lease %q has no exact local claim bound to VM %q; adopt it with an explicit --reclaim reuse before stop", strings.TrimSpace(leaseID), strings.TrimSpace(instanceName))
+	}
+	return nil
+}
+
+func exactHyperVClaimOwned(leaseID, instanceName string) (bool, error) {
+	leaseID = strings.TrimSpace(leaseID)
+	instanceName = strings.TrimSpace(instanceName)
+	claim, ok, exact, err := core.ResolveLeaseClaimForProviderWithExact(leaseID, providerName)
+	if err != nil {
+		return false, err
+	}
+	return ok && exact && claim.LeaseID == leaseID && claim.CloudID == instanceName && claim.ProviderScope == instanceScope(instanceName) && instanceNameFromClaim(claim) == instanceName, nil
 }
 
 // hypervState maps Hyper-V State enum values to string labels.

--- a/internal/providers/hyperv/core.go
+++ b/internal/providers/hyperv/core.go
@@ -70,10 +70,6 @@ func touchDirectLeaseLabels(labels map[string]string, cfg Config, state string, 
 	return core.TouchDirectLeaseLabels(labels, cfg, state, now)
 }
 
-func claimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
-	return core.ClaimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot, idleTimeout, reclaim)
-}
-
 func claimLeaseForRepoProviderScopePondEndpoint(leaseID, slug, provider, providerScope, pond, repoRoot string, idleTimeout time.Duration, reclaim bool, server Server, target SSHTarget) error {
 	return core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, slug, provider, providerScope, pond, repoRoot, idleTimeout, reclaim, server, target)
 }

--- a/internal/providers/hyperv/provider_test.go
+++ b/internal/providers/hyperv/provider_test.go
@@ -408,8 +408,31 @@ func TestShouldCleanupSkipsMissingClaim(t *testing.T) {
 
 func TestShouldCleanupStoppedVM(t *testing.T) {
 	server := Server{Status: "off", Labels: map[string]string{}}
-	if ok, reason := shouldCleanup(server, core.LeaseClaim{}, false, time.Now()); !ok {
-		t.Fatalf("should cleanup stopped VM, got cleanup=%v reason=%s", ok, reason)
+	if ok, reason := shouldCleanup(server, core.LeaseClaim{}, false, time.Now()); ok || reason != "missing claim" {
+		t.Fatalf("cleanup=%v reason=%s, want false missing claim", ok, reason)
+	}
+}
+
+func TestReleaseRequiresExactClaim(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	oldOS := hypervHostOS
+	hypervHostOS = "windows"
+	t.Cleanup(func() { hypervHostOS = oldOS })
+	const leaseID = "cbx_unclaimed12345"
+	const name = "crabbox-unclaimed-1234"
+	runner := &recordingRunner{}
+	b := testBackend(runner)
+	lease := LeaseTarget{
+		LeaseID: leaseID,
+		Server:  Server{CloudID: name, Labels: map[string]string{"lease": leaseID, "instance": name}},
+	}
+	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err == nil || !strings.Contains(err.Error(), "no exact local claim") {
+		t.Fatalf("ReleaseLease unclaimed err=%v", err)
+	}
+	for _, call := range runner.calls {
+		if len(call.Args) > 0 && strings.Contains(call.Args[len(call.Args)-1], "Remove-VM") {
+			t.Fatalf("unclaimed release called Remove-VM: %#v", call)
+		}
 	}
 }
 

--- a/internal/providers/multipass/backend.go
+++ b/internal/providers/multipass/backend.go
@@ -195,12 +195,22 @@ func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget,
 	if claim.LeaseID == "" {
 		return LeaseTarget{}, exit(4, "multipass instance %q has no Crabbox lease claim; use `crabbox stop --provider multipass %s` to delete it or warm a new lease", inst.Name, inst.Name)
 	}
+	owned, err := exactMultipassClaimOwned(claim.LeaseID, inst.Name)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	if !owned && !req.Reclaim {
+		return LeaseTarget{}, exit(4, "multipass lease %q has a legacy claim not bound to instance %q; adopt it with an explicit --reclaim reuse", claim.LeaseID, inst.Name)
+	}
+	if !owned && req.Repo.Root == "" {
+		return LeaseTarget{}, exit(2, "multipass --reclaim requires repository context before binding instance %q", inst.Name)
+	}
 	lease, err := b.prepareLease(ctx, cfg, inst, claim, false)
 	if err != nil {
 		return LeaseTarget{}, err
 	}
 	if req.Repo.Root != "" {
-		if err := claimLeaseForRepoProviderScopePond(claim.LeaseID, claim.Slug, providerName, instanceScope(inst.Name), cfg.Pond, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
+		if err := claimLeaseForRepoProviderScopePondEndpoint(claim.LeaseID, claim.Slug, providerName, instanceScope(inst.Name), cfg.Pond, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, lease.Server, lease.SSH); err != nil {
 			return LeaseTarget{}, err
 		}
 	}
@@ -265,6 +275,9 @@ func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) err
 	if name == "" {
 		return exit(2, "provider=%s release requires a Multipass instance name", providerName)
 	}
+	if err := requireExactMultipassClaim(lease.LeaseID, name); err != nil {
+		return err
+	}
 	if err := b.removeInstance(ctx, name); err != nil {
 		return err
 	}
@@ -301,6 +314,14 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 		shouldDelete, reason := shouldCleanup(server, claim, claim.LeaseID != "", now)
 		if !shouldDelete {
 			fmt.Fprintf(b.rt.Stderr, "skip instance name=%s reason=%s\n", inst.Name, reason)
+			continue
+		}
+		owned, err := exactMultipassClaimOwned(claim.LeaseID, inst.Name)
+		if err != nil {
+			return err
+		}
+		if !owned {
+			fmt.Fprintf(b.rt.Stderr, "skip instance name=%s reason=ownership: missing exact local claim\n", inst.Name)
 			continue
 		}
 		if req.DryRun {
@@ -729,24 +750,45 @@ func shouldCleanup(server Server, claim core.LeaseClaim, hasClaim bool, now time
 	if strings.EqualFold(server.Labels["keep"], "true") {
 		return false, "keep=true"
 	}
+	if !hasClaim {
+		return false, "missing claim"
+	}
 	if !instanceRunning(server.Status) && server.Status != "ready" {
 		return true, "instance state=" + blank(server.Status, "unknown")
 	}
-	if hasClaim {
-		lastUsed, err := time.Parse(time.RFC3339, strings.TrimSpace(claim.LastUsedAt))
-		if err != nil || lastUsed.IsZero() {
-			return false, "claim active"
-		}
-		idle := time.Duration(claim.IdleTimeoutSeconds) * time.Second
-		if idle <= 0 {
-			return false, "claim active"
-		}
-		if now.After(lastUsed.Add(idle).Add(12 * time.Hour)) {
-			return true, "claim expired"
-		}
+	lastUsed, err := time.Parse(time.RFC3339, strings.TrimSpace(claim.LastUsedAt))
+	if err != nil || lastUsed.IsZero() {
 		return false, "claim active"
 	}
-	return false, "missing claim"
+	idle := time.Duration(claim.IdleTimeoutSeconds) * time.Second
+	if idle <= 0 {
+		return false, "claim active"
+	}
+	if now.After(lastUsed.Add(idle).Add(12 * time.Hour)) {
+		return true, "claim expired"
+	}
+	return false, "claim active"
+}
+
+func requireExactMultipassClaim(leaseID, instanceName string) error {
+	owned, err := exactMultipassClaimOwned(leaseID, instanceName)
+	if err != nil {
+		return err
+	}
+	if !owned {
+		return exit(4, "multipass lease %q has no exact local claim bound to instance %q; adopt it with an explicit --reclaim reuse before stop", strings.TrimSpace(leaseID), strings.TrimSpace(instanceName))
+	}
+	return nil
+}
+
+func exactMultipassClaimOwned(leaseID, instanceName string) (bool, error) {
+	leaseID = strings.TrimSpace(leaseID)
+	instanceName = strings.TrimSpace(instanceName)
+	claim, ok, exact, err := core.ResolveLeaseClaimForProviderWithExact(leaseID, providerName)
+	if err != nil {
+		return false, err
+	}
+	return ok && exact && claim.LeaseID == leaseID && claim.CloudID == instanceName && claim.ProviderScope == instanceScope(instanceName) && instanceNameFromClaim(claim) == instanceName, nil
 }
 
 func (b *backend) multipass(ctx context.Context, args []string, stdout, stderr io.Writer) (LocalCommandResult, error) {

--- a/internal/providers/multipass/backend.go
+++ b/internal/providers/multipass/backend.go
@@ -195,6 +195,9 @@ func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget,
 	if claim.LeaseID == "" {
 		return LeaseTarget{}, exit(4, "multipass instance %q has no Crabbox lease claim; use `crabbox stop --provider multipass %s` to delete it or warm a new lease", inst.Name, inst.Name)
 	}
+	if req.StatusOnly && !req.ReadyProbe {
+		return LeaseTarget{Server: b.serverFromInstance(inst, claim, cfg), LeaseID: claim.LeaseID}, nil
+	}
 	owned, err := exactMultipassClaimOwned(claim.LeaseID, inst.Name)
 	if err != nil {
 		return LeaseTarget{}, err

--- a/internal/providers/multipass/backend_test.go
+++ b/internal/providers/multipass/backend_test.go
@@ -311,6 +311,13 @@ func TestResolveReclaimBindsLegacyClaimEndpoint(t *testing.T) {
 		commandKey([]string{"info", "--format", "json", name}): {Stdout: sampleInfoJSON(name)},
 	}}
 	b := testBackend(runner)
+	status, err := b.Resolve(context.Background(), core.ResolveRequest{ID: leaseID, StatusOnly: true})
+	if err != nil {
+		t.Fatalf("read-only status for legacy claim: %v", err)
+	}
+	if status.LeaseID != leaseID || status.Server.CloudID != name {
+		t.Fatalf("status=%#v", status)
+	}
 	if _, err := b.Resolve(context.Background(), core.ResolveRequest{
 		ID:   leaseID,
 		Repo: core.Repo{Root: t.TempDir()},

--- a/internal/providers/multipass/backend_test.go
+++ b/internal/providers/multipass/backend_test.go
@@ -296,6 +296,52 @@ func TestListAndResolveInstancesWithClaim(t *testing.T) {
 	}
 }
 
+func TestResolveReclaimBindsLegacyClaimEndpoint(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
+	const leaseID = "cbx_legacy123456"
+	const name = "crabbox-blue-1234abcd"
+	if err := claimLeaseForRepoProviderScopePond(leaseID, "blue-lobster", providerName, instanceScope(name), "", t.TempDir(), 30*time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+		commandKey([]string{"list", "--format", "json"}):       {Stdout: sampleListJSON()},
+		commandKey([]string{"info", "--format", "json", name}): {Stdout: sampleInfoJSON(name)},
+	}}
+	b := testBackend(runner)
+	if _, err := b.Resolve(context.Background(), core.ResolveRequest{
+		ID:   leaseID,
+		Repo: core.Repo{Root: t.TempDir()},
+	}); err == nil || !strings.Contains(err.Error(), "explicit --reclaim") {
+		t.Fatalf("normal resolve legacy claim err=%v", err)
+	}
+	if owned, err := exactMultipassClaimOwned(leaseID, name); err != nil {
+		t.Fatal(err)
+	} else if owned {
+		t.Fatal("normal resolve silently adopted a legacy claim")
+	}
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{
+		ID:      leaseID,
+		Reclaim: true,
+		Repo:    core.Repo{Root: t.TempDir()},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.Server.CloudID != name {
+		t.Fatalf("CloudID=%q want %q", lease.Server.CloudID, name)
+	}
+	owned, err := exactMultipassClaimOwned(leaseID, name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !owned {
+		t.Fatal("reclaim did not persist an exact resource-bound claim")
+	}
+}
+
 func TestDoctorReady(t *testing.T) {
 	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
 		commandKey([]string{"version"}):                  {Stdout: "multipass 1.16.0\nmultipassd 1.16.0\n"},
@@ -640,6 +686,40 @@ func TestShouldCleanupSkipsMissingClaim(t *testing.T) {
 	server := Server{Status: "running", Labels: map[string]string{}}
 	if ok, reason := shouldCleanup(server, core.LeaseClaim{}, false, time.Now()); ok || reason != "missing claim" {
 		t.Fatalf("cleanup=%v reason=%s", ok, reason)
+	}
+}
+
+func TestShouldCleanupSkipsStoppedMissingClaim(t *testing.T) {
+	server := Server{Status: "stopped", Labels: map[string]string{}}
+	if ok, reason := shouldCleanup(server, core.LeaseClaim{}, false, time.Now()); ok || reason != "missing claim" {
+		t.Fatalf("cleanup=%v reason=%s", ok, reason)
+	}
+}
+
+func TestReleaseRequiresExactClaim(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	const leaseID = "cbx_release123456"
+	const name = "crabbox-release-1234"
+	runner := &recordingRunner{}
+	b := testBackend(runner)
+	lease := LeaseTarget{
+		LeaseID: leaseID,
+		Server:  Server{CloudID: name, Labels: map[string]string{"lease": leaseID, "instance": name}},
+	}
+	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err == nil || !strings.Contains(err.Error(), "no exact local claim") {
+		t.Fatalf("ReleaseLease unclaimed err=%v", err)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("unclaimed release mutated provider: %#v", runner.calls)
+	}
+	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, "release", providerName, instanceScope(name), "", t.TempDir(), time.Minute, false, lease.Server, SSHTarget{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatalf("ReleaseLease exact claim: %v", err)
+	}
+	if got := recordedArgsForCommand(t, runner, "delete"); !strings.Contains(got, "--purge\n"+name) {
+		t.Fatalf("delete args=%q", got)
 	}
 }
 

--- a/internal/providers/multipass/core.go
+++ b/internal/providers/multipass/core.go
@@ -74,6 +74,10 @@ var claimLeaseForRepoProviderScopePond = func(leaseID, slug, provider, providerS
 	return core.ClaimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot, idleTimeout, reclaim)
 }
 
+var claimLeaseForRepoProviderScopePondEndpoint = func(leaseID, slug, provider, providerScope, pond, repoRoot string, idleTimeout time.Duration, reclaim bool, server Server, target SSHTarget) error {
+	return core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, slug, provider, providerScope, pond, repoRoot, idleTimeout, reclaim, server, target)
+}
+
 func resolveLeaseClaimForProvider(identifier, provider string) (core.LeaseClaim, bool, error) {
 	return core.ResolveLeaseClaimForProvider(identifier, provider)
 }

--- a/internal/providers/parallels/backend.go
+++ b/internal/providers/parallels/backend.go
@@ -182,6 +182,11 @@ func (b *leaseBackend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTa
 			server.ServerType.Name = core.ServerTypeForProviderClass("parallels", candidate.Class)
 			normalizedID := strings.ReplaceAll(id, "_", "-")
 			if vm.ID == id || vm.Name == id || leaseID == id || strings.ReplaceAll(leaseID, "_", "-") == normalizedID || core.NormalizeLeaseSlug(slug) == core.NormalizeLeaseSlug(id) {
+				leaseID = firstNonEmpty(leaseID, vm.ID)
+				adopt, err := authorizeParallelsResolve(req, leaseID, vm.ID, parallelsHostName(candidate))
+				if err != nil {
+					return LeaseTarget{}, err
+				}
 				if vm.IP == "" && strings.EqualFold(vm.State, "running") {
 					vm, _ = client.WaitForIP(ctx, vm.ID, 30*time.Second)
 				}
@@ -203,7 +208,12 @@ func (b *leaseBackend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTa
 					target.ProxyCommand = parallelsProxyCommand(candidate, vm.IP)
 					target.SSHConfigProxy = true
 				}
-				return LeaseTarget{Server: server, SSH: target, LeaseID: firstNonEmpty(leaseID, vm.ID)}, nil
+				if adopt {
+					if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, candidate, server, target, req.Repo.Root, candidate.IdleTimeout, true); err != nil {
+						return LeaseTarget{}, err
+					}
+				}
+				return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 			}
 		}
 	}
@@ -211,6 +221,24 @@ func (b *leaseBackend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTa
 		return LeaseTarget{}, fmt.Errorf("parallels fleet inventory incomplete while resolving %s: %w", req.ID, errors.Join(hostErrs...))
 	}
 	return LeaseTarget{}, core.Exit(4, "parallels lease not found: %s", req.ID)
+}
+
+func authorizeParallelsResolve(req ResolveRequest, leaseID, vmID, host string) (bool, error) {
+	owned, err := exactParallelsClaimOwned(leaseID, vmID, host)
+	if err != nil {
+		return false, err
+	}
+	readOnlyStatus := req.StatusOnly && !req.ReleaseOnly && !req.Reclaim
+	if owned || readOnlyStatus {
+		return false, nil
+	}
+	if req.ReleaseOnly || !req.Reclaim {
+		return false, parallelsOwnershipError(leaseID, vmID, host)
+	}
+	if strings.TrimSpace(req.Repo.Root) == "" {
+		return false, core.Exit(2, "parallels --reclaim requires repository context before binding VM %q on host %q", strings.TrimSpace(vmID), strings.TrimSpace(host))
+	}
+	return true, nil
 }
 
 func (b *leaseBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
@@ -344,9 +372,13 @@ func requireExactParallelsClaim(leaseID, vmID, host string) error {
 		return err
 	}
 	if !owned {
-		return core.Exit(4, "parallels lease %q has no exact local claim bound to VM %q on host %q; adopt it with an explicit --reclaim reuse before stop", strings.TrimSpace(leaseID), strings.TrimSpace(vmID), strings.TrimSpace(host))
+		return parallelsOwnershipError(leaseID, vmID, host)
 	}
 	return nil
+}
+
+func parallelsOwnershipError(leaseID, vmID, host string) error {
+	return core.Exit(4, "parallels lease %q has no exact local claim bound to VM %q on host %q; adopt it with an explicit --reclaim reuse before stop", strings.TrimSpace(leaseID), strings.TrimSpace(vmID), strings.TrimSpace(host))
 }
 
 func exactParallelsClaimOwned(leaseID, vmID, host string) (bool, error) {

--- a/internal/providers/parallels/backend.go
+++ b/internal/providers/parallels/backend.go
@@ -143,6 +143,10 @@ func (b *leaseBackend) acquireOnce(ctx context.Context, keep bool, requestedSlug
 	}
 	server.Status = "ready"
 	server.Labels = core.TouchDirectLeaseLabels(server.Labels, cfg, "ready", time.Now().UTC())
+	if err := core.ClaimLeaseTargetForConfig(leaseID, slug, cfg, server, target, cfg.IdleTimeout); err != nil {
+		cleanupVM(server.CloudID)
+		return LeaseTarget{}, err
+	}
 	fmt.Fprintf(b.RT.Stderr, "provisioned lease=%s vm=%s ip=%s\n", leaseID, server.DisplayID(), vm.IP)
 	keepKey = true
 	return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
@@ -278,6 +282,9 @@ func (b *leaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest
 	}
 	id := firstNonEmpty(req.Lease.Server.CloudID, req.Lease.LeaseID)
 	cfg := b.configForLease(ctx, req.Lease)
+	if err := requireExactParallelsClaim(req.Lease.LeaseID, id, parallelsHostName(cfg)); err != nil {
+		return err
+	}
 	if err := core.NewParallelsClient(cfg, b.RT.Exec).Delete(ctx, id); err != nil {
 		return err
 	}
@@ -304,22 +311,53 @@ func (b *leaseBackend) Cleanup(ctx context.Context, req CleanupRequest) error {
 			fmt.Fprintf(b.RT.Stderr, "skip vm id=%s name=%s reason=%s\n", server.DisplayID(), server.Name, reason)
 			continue
 		}
+		leaseID := server.Labels["lease"]
+		cfg := b.configForLease(ctx, LeaseTarget{
+			Server:  server,
+			LeaseID: leaseID,
+		})
+		owned, err := exactParallelsClaimOwned(leaseID, server.CloudID, parallelsHostName(cfg))
+		if err != nil {
+			return err
+		}
+		if !owned {
+			fmt.Fprintf(b.RT.Stderr, "skip vm id=%s name=%s reason=ownership: missing exact local claim\n", server.DisplayID(), server.Name)
+			continue
+		}
 		fmt.Fprintf(b.RT.Stderr, "delete vm id=%s name=%s\n", server.DisplayID(), server.Name)
 		if req.DryRun {
 			continue
 		}
-		client := core.NewParallelsClient(b.configForLease(ctx, LeaseTarget{
-			Server:  server,
-			LeaseID: server.Labels["lease"],
-		}), b.RT.Exec)
+		client := core.NewParallelsClient(cfg, b.RT.Exec)
 		if err := client.Delete(ctx, server.CloudID); err != nil {
 			return err
 		}
-		leaseID := server.Labels["lease"]
 		core.RemoveLeaseClaim(leaseID)
 		core.RemoveStoredTestboxKey(leaseID)
 	}
 	return nil
+}
+
+func requireExactParallelsClaim(leaseID, vmID, host string) error {
+	owned, err := exactParallelsClaimOwned(leaseID, vmID, host)
+	if err != nil {
+		return err
+	}
+	if !owned {
+		return core.Exit(4, "parallels lease %q has no exact local claim bound to VM %q on host %q; adopt it with an explicit --reclaim reuse before stop", strings.TrimSpace(leaseID), strings.TrimSpace(vmID), strings.TrimSpace(host))
+	}
+	return nil
+}
+
+func exactParallelsClaimOwned(leaseID, vmID, host string) (bool, error) {
+	leaseID = strings.TrimSpace(leaseID)
+	vmID = strings.TrimSpace(vmID)
+	host = strings.TrimSpace(host)
+	claim, ok, exact, err := core.ResolveLeaseClaimForProviderWithExact(leaseID, "parallels")
+	if err != nil {
+		return false, err
+	}
+	return ok && exact && claim.LeaseID == leaseID && claim.CloudID == vmID && strings.TrimSpace(claim.Labels["host"]) == host, nil
 }
 
 func parallelsProxyCommand(cfg Config, guestIP string) string {

--- a/internal/providers/parallels/provider_test.go
+++ b/internal/providers/parallels/provider_test.go
@@ -231,6 +231,31 @@ func TestCleanupKeepsClaimAndStoredKeyWhenDeleteFails(t *testing.T) {
 	}
 }
 
+func TestReleaseRequiresExactClaim(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("HOME", filepath.Join(root, "home"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(root, "config"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(root, "state"))
+	runner := &parallelsCleanupRunner{}
+	backend := &leaseBackend{
+		DirectSSHBackend: sharedBackend(testParallelsCleanupConfig(), runner),
+	}
+	lease := LeaseTarget{
+		LeaseID: "cbx_unclaimed",
+		Server: core.Server{
+			CloudID: "vm-good",
+			Name:    "crabbox-cbx-unclaimed-blue",
+			Labels:  map[string]string{"lease": "cbx_unclaimed", "host": "local"},
+		},
+	}
+	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err == nil || !strings.Contains(err.Error(), "no exact local claim") {
+		t.Fatalf("ReleaseLease unclaimed err=%v", err)
+	}
+	if runner.deleteCalls != 0 {
+		t.Fatalf("deleteCalls=%d want 0", runner.deleteCalls)
+	}
+}
+
 func TestAcquireRemovesStoredKeyAfterPostKeyFailure(t *testing.T) {
 	if _, err := exec.LookPath("ssh-keygen"); err != nil {
 		t.Skip("ssh-keygen not available")
@@ -342,7 +367,13 @@ func seedParallelsCleanupState(t *testing.T) (string, string) {
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(root, "config"))
 	t.Setenv("XDG_STATE_HOME", filepath.Join(root, "state"))
 	leaseID := "cbx_good"
-	if err := core.ClaimLeaseForRepoProvider(leaseID, "blue", "parallels", "/repo", time.Minute, false); err != nil {
+	server := core.Server{
+		CloudID:  "vm-good",
+		Provider: "parallels",
+		Name:     "crabbox-cbx-good-blue",
+		Labels:   map[string]string{"provider": "parallels", "lease": leaseID, "slug": "blue", "host": "local"},
+	}
+	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, "blue", "parallels", "", "", "/repo", time.Minute, false, server, core.SSHTarget{}); err != nil {
 		t.Fatal(err)
 	}
 	keyPath, err := core.TestboxKeyPath(leaseID)

--- a/internal/providers/parallels/provider_test.go
+++ b/internal/providers/parallels/provider_test.go
@@ -256,6 +256,53 @@ func TestReleaseRequiresExactClaim(t *testing.T) {
 	}
 }
 
+func TestResolveUnclaimedVMRequiresExplicitAdoption(t *testing.T) {
+	tests := []struct {
+		name    string
+		request ResolveRequest
+		wantErr string
+	}{
+		{name: "reuse", request: ResolveRequest{ID: "vm-good", Repo: core.Repo{Root: "/repo"}}, wantErr: "explicit --reclaim"},
+		{name: "status", request: ResolveRequest{ID: "vm-good", StatusOnly: true}},
+		{name: "reclaim", request: ResolveRequest{ID: "vm-good", Repo: core.Repo{Root: "/repo"}, Reclaim: true}},
+		{name: "release", request: ResolveRequest{ID: "vm-good", ReleaseOnly: true}, wantErr: "no exact local claim"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			t.Setenv("HOME", filepath.Join(root, "home"))
+			t.Setenv("XDG_CONFIG_HOME", filepath.Join(root, "config"))
+			t.Setenv("XDG_STATE_HOME", filepath.Join(root, "state"))
+			backend := &leaseBackend{
+				DirectSSHBackend: sharedBackend(testParallelsCleanupConfig(), &parallelsCleanupRunner{}),
+			}
+
+			lease, err := backend.Resolve(context.Background(), test.request)
+			if test.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+					t.Fatalf("Resolve err=%v, want %q", err, test.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if lease.LeaseID != "cbx_good" || lease.Server.CloudID != "vm-good" {
+				t.Fatalf("Resolve lease=%#v", lease)
+			}
+			if test.request.Reclaim {
+				owned, err := exactParallelsClaimOwned(lease.LeaseID, lease.Server.CloudID, "local")
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !owned {
+					t.Fatal("explicit reclaim did not persist an exact VM/host claim")
+				}
+			}
+		})
+	}
+}
+
 func TestAcquireRemovesStoredKeyAfterPostKeyFailure(t *testing.T) {
 	if _, err := exec.LookPath("ssh-keygen"); err != nil {
 		t.Skip("ssh-keygen not available")


### PR DESCRIPTION
Closes https://github.com/openclaw/crabbox/issues/813.
Closes https://github.com/openclaw/crabbox/issues/814.
Closes https://github.com/openclaw/crabbox/issues/815.

## Summary

- Require exact provider/resource/local-claim ownership before Hyper-V, Multipass, or Parallels release and cleanup can delete a VM.
- Treat `crabbox-` names as discovery hints only; stopped claimless VMs are no longer cleanup candidates.
- Preserve explicit conflict-safe adoption: legacy claims must pass `--reclaim` with repository context before endpoint/CloudID binding.
- Persist the exact Parallels claim before returning an acquired VM so generic post-acquire rollback can still remove it safely.
- Fail cleanup on claim-read errors while skipping ordinary unowned/mismatched inventory.
- Document the boundary and add the Unreleased changelog entry with @coygeek credit.

## Verification

Candidate: `f9ef3d962735676388b2cb5e20d212f7c735cb23`.

- `go test -race ./internal/providers/multipass ./internal/providers/hyperv ./internal/providers/parallels`
- `go test -race ./...` reached all packages; the three changed providers passed, while unrelated AgentSandbox timing test `TestWarmupReturnsDefinitiveCreateFailureWithoutReconciliation` exceeded its 500 ms wall-clock cutoff under full-suite load
- `go vet ./...`
- `go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...`
- `scripts/check-docs.sh`
- `git diff --check`
- Autoreview drove exact Parallels claim persistence and read-only Multipass compatibility fixes; final branch review clean.

## Live proof

- Multipass: real 26.04 VM created, reached SSH readiness, synced this repository, executed the remote canary, and exact-claim stop removed the VM; final Crabbox and native Multipass inventories were empty.
- Multipass deny path: a separate claimless disposable VM was rejected with exit 4, remained present after Crabbox refusal, then was manually deleted; final native inventory had zero canary residue.
- Parallels exact-head proof on `f9ef3d962735676388b2cb5e20d212f7c735cb23`: a disposable no-disk VM was visible to read-only `status`, while both unclaimed `run` and `stop` returned exit 4 with `has no exact local claim bound to VM`. Native inventory confirmed the stopped VM remained present.
- Explicit `run --reclaim` then wrote lease `cbx_pr818head`, provider `parallels`, exact CloudID `22a05a88-3885-41a9-b352-6735ded2b75e`, host `local`, and a repository binding before the intentionally diskless VM timed out waiting for SSH.
- A subsequent ordinary `stop cbx_pr818head` reported `deleted lease=cbx_pr818head server=22a05a88-3885-41a9-b352-6735ded2b75e`; native inventory and isolated Crabbox state both contained zero canary residue.
- Hyper-V: unavailable on this macOS host; exact-claim allow/deny and cleanup behavior are covered through the PowerShell fake-runner regression suite.

The generic live-smoke wrapper's optional run-history lookup hit an unrelated configured coordinator HTTP 500 / Cloudflare 1101 after the successful Multipass remote command. Provider lifecycle cleanup was completed manually and verified empty.

## Security / compatibility

Legacy unbound claims can no longer authorize destructive operations. Operators intentionally recovering one of these local VMs must first reuse it with explicit `--reclaim`; ordinary read-only discovery remains available.
