### PR TITLE
fix: guard Morph and Railway redirects

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -215,11 +215,11 @@ user config `broker.loginRedirectOrigins` or
 `CRABBOX_BROKER_LOGIN_REDIRECT_ORIGINS`.
 
 Provider clients apply the same destination principle where custom endpoints
-are supported. Cloudflare runner and RunPod requests reject cross-origin
-redirects before replaying authorization headers or request bodies. E2B API
-endpoints require HTTPS except for explicit localhost/loopback development
-URLs, and AWS region values are validated before constructing SigV4 service
-hosts.
+are supported. Cloudflare runner, Morph, Railway, and RunPod requests reject
+cross-origin redirects before replaying authorization headers or request
+bodies. E2B API endpoints require HTTPS except for explicit localhost/loopback
+development URLs, and AWS region values are validated before constructing
+SigV4 service hosts.
 
 Cookie-authenticated portal mutations and portal viewer WebSocket upgrades
 require an exact same-origin browser `Origin` matching `CRABBOX_PUBLIC_URL` (or

--- a/internal/providers/morph/client.go
+++ b/internal/providers/morph/client.go
@@ -44,7 +44,7 @@ var newMorphClient = func(cfg Config, rt Runtime) (morphAPI, error) {
 	return &morphClient{
 		apiURL:     apiURL,
 		apiKey:     apiKey,
-		httpClient: httpClient,
+		httpClient: secureMorphHTTPClient(httpClient, apiURL),
 	}, nil
 }
 
@@ -52,6 +52,46 @@ type morphClient struct {
 	apiURL     string
 	apiKey     string
 	httpClient *http.Client
+}
+
+func secureMorphHTTPClient(source *http.Client, apiURL string) *http.Client {
+	client := *source
+	trusted, _ := url.Parse(apiURL)
+	originalCheckRedirect := source.CheckRedirect
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if !sameMorphOrigin(trusted, req.URL) {
+			return fmt.Errorf("%s refused cross-origin redirect to %s", providerName, req.URL.Redacted())
+		}
+		if originalCheckRedirect != nil {
+			return originalCheckRedirect(req, via)
+		}
+		if len(via) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+		return nil
+	}
+	return &client
+}
+
+func sameMorphOrigin(a, b *url.URL) bool {
+	return a != nil && b != nil &&
+		strings.EqualFold(a.Scheme, b.Scheme) &&
+		strings.EqualFold(a.Hostname(), b.Hostname()) &&
+		effectiveMorphPort(a) == effectiveMorphPort(b)
+}
+
+func effectiveMorphPort(value *url.URL) string {
+	if port := value.Port(); port != "" {
+		return port
+	}
+	switch strings.ToLower(value.Scheme) {
+	case "https":
+		return "443"
+	case "http":
+		return "80"
+	default:
+		return ""
+	}
 }
 
 type morphAPIError struct {

--- a/internal/providers/morph/client.go
+++ b/internal/providers/morph/client.go
@@ -60,7 +60,7 @@ func secureMorphHTTPClient(source *http.Client, apiURL string) *http.Client {
 	originalCheckRedirect := source.CheckRedirect
 	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 		if !sameMorphOrigin(trusted, req.URL) {
-			return fmt.Errorf("%s refused cross-origin redirect to %s", providerName, req.URL.Redacted())
+			return &morphRedirectError{origin: morphRedirectOrigin(req.URL)}
 		}
 		if originalCheckRedirect != nil {
 			return originalCheckRedirect(req, via)
@@ -92,6 +92,21 @@ func effectiveMorphPort(value *url.URL) string {
 	default:
 		return ""
 	}
+}
+
+type morphRedirectError struct {
+	origin string
+}
+
+func (e *morphRedirectError) Error() string {
+	return fmt.Sprintf("%s refused cross-origin redirect to %s", providerName, e.origin)
+}
+
+func morphRedirectOrigin(value *url.URL) string {
+	if value == nil || value.Scheme == "" || value.Host == "" {
+		return "<redacted>"
+	}
+	return value.Scheme + "://" + value.Host
 }
 
 type morphAPIError struct {
@@ -333,6 +348,11 @@ func (c *morphClient) doRaw(ctx context.Context, method, path string, query url.
 	}
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
+		// net/http wraps CheckRedirect failures with the untrusted Location URL.
+		var redirectErr *morphRedirectError
+		if errors.As(err, &redirectErr) {
+			return nil, redirectErr
+		}
 		return nil, err
 	}
 	defer resp.Body.Close()

--- a/internal/providers/morph/client_test.go
+++ b/internal/providers/morph/client_test.go
@@ -3,9 +3,11 @@ package morph
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 )
@@ -59,6 +61,113 @@ func TestMorphClientBootSnapshotUsesAPIBaseAndAuth(t *testing.T) {
 	}
 	if instance.ID != "inst_1" || instance.Refs.SnapshotID != "snapshot_123" {
 		t.Fatalf("unexpected instance: %#v", instance)
+	}
+}
+
+func TestMorphClientRefusesCrossOriginRedirectBeforeReplay(t *testing.T) {
+	targetRequests := 0
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		targetRequests++
+		t.Errorf("redirect target received %s %s auth=%q", r.Method, r.URL.Path, r.Header.Get("Authorization"))
+	}))
+	defer target.Close()
+	trusted := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/stolen", http.StatusTemporaryRedirect)
+	}))
+	defer trusted.Close()
+
+	client, err := newMorphClient(
+		Config{Morph: MorphConfig{APIKey: "test-key", APIURL: trusted.URL}},
+		Runtime{HTTP: trusted.Client()},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.GetSnapshot(context.Background(), "snapshot_123")
+	if err == nil || !strings.Contains(err.Error(), "refused cross-origin redirect") {
+		t.Fatalf("GetSnapshot error = %v, want cross-origin refusal", err)
+	}
+	if targetRequests != 0 {
+		t.Fatalf("redirect target received %d requests, want 0", targetRequests)
+	}
+}
+
+func TestMorphClientFollowsSameOriginRedirect(t *testing.T) {
+	var redirectedAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/snapshot/snapshot_123":
+			http.Redirect(w, r, "/api/redirected", http.StatusTemporaryRedirect)
+		case "/api/redirected":
+			redirectedAuth = r.Header.Get("Authorization")
+			_, _ = io.WriteString(w, `{"id":"snapshot_123"}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client, err := newMorphClient(
+		Config{Morph: MorphConfig{APIKey: "test-key", APIURL: server.URL}},
+		Runtime{HTTP: server.Client()},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := client.GetSnapshot(context.Background(), "snapshot_123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.ID != "snapshot_123" || redirectedAuth != "Bearer test-key" {
+		t.Fatalf("snapshot=%#v auth=%q", snapshot, redirectedAuth)
+	}
+}
+
+func TestMorphClientPreservesCallerRedirectPolicy(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/api/redirected", http.StatusFound)
+	}))
+	defer server.Close()
+	callerErr := errors.New("caller refused redirect")
+	callerChecks := 0
+	httpClient := server.Client()
+	httpClient.CheckRedirect = func(*http.Request, []*http.Request) error {
+		callerChecks++
+		return callerErr
+	}
+	client, err := newMorphClient(
+		Config{Morph: MorphConfig{APIKey: "test-key", APIURL: server.URL}},
+		Runtime{HTTP: httpClient},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.GetSnapshot(context.Background(), "snapshot_123")
+	if !errors.Is(err, callerErr) || callerChecks != 1 {
+		t.Fatalf("GetSnapshot error = %v, caller checks = %d", err, callerChecks)
+	}
+}
+
+func TestSameMorphOrigin(t *testing.T) {
+	trusted, _ := url.Parse("https://api.example.com:443/v1")
+	for _, test := range []struct {
+		name string
+		raw  string
+		want bool
+	}{
+		{name: "default https port", raw: "https://api.example.com/next", want: true},
+		{name: "case insensitive host", raw: "https://API.EXAMPLE.COM/next", want: true},
+		{name: "scheme drift", raw: "http://api.example.com/next"},
+		{name: "subdomain drift", raw: "https://redirect.api.example.com/next"},
+		{name: "port drift", raw: "https://api.example.com:444/next"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			candidate, _ := url.Parse(test.raw)
+			if got := sameMorphOrigin(trusted, candidate); got != test.want {
+				t.Fatalf("sameMorphOrigin(%q)=%v, want %v", test.raw, got, test.want)
+			}
+		})
 	}
 }
 

--- a/internal/providers/morph/client_test.go
+++ b/internal/providers/morph/client_test.go
@@ -72,7 +72,7 @@ func TestMorphClientRefusesCrossOriginRedirectBeforeReplay(t *testing.T) {
 	}))
 	defer target.Close()
 	trusted := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Redirect(w, r, target.URL+"/stolen", http.StatusTemporaryRedirect)
+		http.Redirect(w, r, target.URL+"/stolen?token=redirect-secret", http.StatusTemporaryRedirect)
 	}))
 	defer trusted.Close()
 
@@ -86,6 +86,9 @@ func TestMorphClientRefusesCrossOriginRedirectBeforeReplay(t *testing.T) {
 	_, err = client.GetSnapshot(context.Background(), "snapshot_123")
 	if err == nil || !strings.Contains(err.Error(), "refused cross-origin redirect") {
 		t.Fatalf("GetSnapshot error = %v, want cross-origin refusal", err)
+	}
+	if strings.Contains(err.Error(), "redirect-secret") {
+		t.Fatalf("GetSnapshot error leaked redirect query: %v", err)
 	}
 	if targetRequests != 0 {
 		t.Fatalf("redirect target received %d requests, want 0", targetRequests)

--- a/internal/providers/railway/backend_test.go
+++ b/internal/providers/railway/backend_test.go
@@ -142,7 +142,7 @@ func TestRailwayClientRefusesCrossOriginRedirectBeforeReplay(t *testing.T) {
 	}))
 	defer target.Close()
 	trusted := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Redirect(w, r, target.URL+"/stolen", http.StatusTemporaryRedirect)
+		http.Redirect(w, r, target.URL+"/stolen?token=redirect-secret", http.StatusTemporaryRedirect)
 	}))
 	defer trusted.Close()
 
@@ -156,6 +156,9 @@ func TestRailwayClientRefusesCrossOriginRedirectBeforeReplay(t *testing.T) {
 	err = api.(*railwayClient).do(context.Background(), "query { me { id } }", nil, nil)
 	if err == nil || !strings.Contains(err.Error(), "refused cross-origin redirect") {
 		t.Fatalf("do error = %v, want cross-origin refusal", err)
+	}
+	if strings.Contains(err.Error(), "redirect-secret") {
+		t.Fatalf("do error leaked redirect query: %v", err)
 	}
 	if targetRequests != 0 {
 		t.Fatalf("redirect target received %d requests, want 0", targetRequests)

--- a/internal/providers/railway/backend_test.go
+++ b/internal/providers/railway/backend_test.go
@@ -3,11 +3,13 @@ package railway
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"sync"
 	"testing"
@@ -129,6 +131,117 @@ func TestRailwayClientSendsBearerAndGraphQLBody(t *testing.T) {
 	}
 	if deployID != "dep-1" {
 		t.Fatalf("deployID = %q, want dep-1", deployID)
+	}
+}
+
+func TestRailwayClientRefusesCrossOriginRedirectBeforeReplay(t *testing.T) {
+	targetRequests := 0
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		targetRequests++
+		t.Errorf("redirect target received %s %s auth=%q", r.Method, r.URL.Path, r.Header.Get("Authorization"))
+	}))
+	defer target.Close()
+	trusted := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/stolen", http.StatusTemporaryRedirect)
+	}))
+	defer trusted.Close()
+
+	api, err := newRailwayClient(
+		Config{Railway: RailwayConfig{APIToken: "test-token", APIURL: trusted.URL}},
+		Runtime{HTTP: trusted.Client()},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = api.(*railwayClient).do(context.Background(), "query { me { id } }", nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "refused cross-origin redirect") {
+		t.Fatalf("do error = %v, want cross-origin refusal", err)
+	}
+	if targetRequests != 0 {
+		t.Fatalf("redirect target received %d requests, want 0", targetRequests)
+	}
+}
+
+func TestRailwayClientFollowsSameOriginRedirect(t *testing.T) {
+	var redirectedAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/graphql":
+			http.Redirect(w, r, "/redirected", http.StatusTemporaryRedirect)
+		case "/redirected":
+			redirectedAuth = r.Header.Get("Authorization")
+			_, _ = io.WriteString(w, `{"data":{"me":{"id":"user_1"}}}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	api, err := newRailwayClient(
+		Config{Railway: RailwayConfig{APIToken: "test-token", APIURL: server.URL + "/graphql"}},
+		Runtime{HTTP: server.Client()},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out struct {
+		Me struct {
+			ID string `json:"id"`
+		} `json:"me"`
+	}
+	if err := api.(*railwayClient).do(context.Background(), "query { me { id } }", nil, &out); err != nil {
+		t.Fatal(err)
+	}
+	if out.Me.ID != "user_1" || redirectedAuth != "Bearer test-token" {
+		t.Fatalf("out=%#v auth=%q", out, redirectedAuth)
+	}
+}
+
+func TestRailwayClientPreservesCallerRedirectPolicy(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/redirected", http.StatusFound)
+	}))
+	defer server.Close()
+	callerErr := errors.New("caller refused redirect")
+	callerChecks := 0
+	httpClient := server.Client()
+	httpClient.CheckRedirect = func(*http.Request, []*http.Request) error {
+		callerChecks++
+		return callerErr
+	}
+	api, err := newRailwayClient(
+		Config{Railway: RailwayConfig{APIToken: "test-token", APIURL: server.URL}},
+		Runtime{HTTP: httpClient},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = api.(*railwayClient).do(context.Background(), "query { me { id } }", nil, nil)
+	if !errors.Is(err, callerErr) || callerChecks != 1 {
+		t.Fatalf("do error = %v, caller checks = %d", err, callerChecks)
+	}
+}
+
+func TestSameRailwayOrigin(t *testing.T) {
+	trusted, _ := url.Parse("https://api.example.com:443/graphql")
+	for _, test := range []struct {
+		name string
+		raw  string
+		want bool
+	}{
+		{name: "default https port", raw: "https://api.example.com/next", want: true},
+		{name: "case insensitive host", raw: "https://API.EXAMPLE.COM/next", want: true},
+		{name: "scheme drift", raw: "http://api.example.com/next"},
+		{name: "subdomain drift", raw: "https://redirect.api.example.com/next"},
+		{name: "port drift", raw: "https://api.example.com:444/next"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			candidate, _ := url.Parse(test.raw)
+			if got := sameRailwayOrigin(trusted, candidate); got != test.want {
+				t.Fatalf("sameRailwayOrigin(%q)=%v, want %v", test.raw, got, test.want)
+			}
+		})
 	}
 }
 

--- a/internal/providers/railway/client.go
+++ b/internal/providers/railway/client.go
@@ -179,7 +179,7 @@ func secureRailwayHTTPClient(source *http.Client, apiURL string) *http.Client {
 	originalCheckRedirect := source.CheckRedirect
 	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 		if !sameRailwayOrigin(trusted, req.URL) {
-			return fmt.Errorf("%s refused cross-origin redirect to %s", providerName, req.URL.Redacted())
+			return &railwayRedirectError{origin: railwayRedirectOrigin(req.URL)}
 		}
 		if originalCheckRedirect != nil {
 			return originalCheckRedirect(req, via)
@@ -213,6 +213,21 @@ func effectiveRailwayPort(value *url.URL) string {
 	}
 }
 
+type railwayRedirectError struct {
+	origin string
+}
+
+func (e *railwayRedirectError) Error() string {
+	return fmt.Sprintf("%s refused cross-origin redirect to %s", providerName, e.origin)
+}
+
+func railwayRedirectOrigin(value *url.URL) string {
+	if value == nil || value.Scheme == "" || value.Host == "" {
+		return "<redacted>"
+	}
+	return value.Scheme + "://" + value.Host
+}
+
 type graphqlRequest struct {
 	Query     string         `json:"query"`
 	Variables map[string]any `json:"variables,omitempty"`
@@ -241,6 +256,11 @@ func (c *railwayClient) do(ctx context.Context, query string, vars map[string]an
 	req.Header.Set("Accept", "application/json")
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
+		// net/http wraps CheckRedirect failures with the untrusted Location URL.
+		var redirectErr *railwayRedirectError
+		if errors.As(err, &redirectErr) {
+			return redirectErr
+		}
 		return err
 	}
 	defer resp.Body.Close()

--- a/internal/providers/railway/client.go
+++ b/internal/providers/railway/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -169,7 +170,47 @@ func newRailwayClient(cfg Config, rt Runtime) (railwayAPI, error) {
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
-	return &railwayClient{apiToken: apiToken, apiURL: apiURL, httpClient: httpClient}, nil
+	return &railwayClient{apiToken: apiToken, apiURL: apiURL, httpClient: secureRailwayHTTPClient(httpClient, apiURL)}, nil
+}
+
+func secureRailwayHTTPClient(source *http.Client, apiURL string) *http.Client {
+	client := *source
+	trusted, _ := url.Parse(apiURL)
+	originalCheckRedirect := source.CheckRedirect
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if !sameRailwayOrigin(trusted, req.URL) {
+			return fmt.Errorf("%s refused cross-origin redirect to %s", providerName, req.URL.Redacted())
+		}
+		if originalCheckRedirect != nil {
+			return originalCheckRedirect(req, via)
+		}
+		if len(via) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+		return nil
+	}
+	return &client
+}
+
+func sameRailwayOrigin(a, b *url.URL) bool {
+	return a != nil && b != nil &&
+		strings.EqualFold(a.Scheme, b.Scheme) &&
+		strings.EqualFold(a.Hostname(), b.Hostname()) &&
+		effectiveRailwayPort(a) == effectiveRailwayPort(b)
+}
+
+func effectiveRailwayPort(value *url.URL) string {
+	if port := value.Port(); port != "" {
+		return port
+	}
+	switch strings.ToLower(value.Scheme) {
+	case "https":
+		return "443"
+	case "http":
+		return "80"
+	default:
+		return ""
+	}
 }
 
 type graphqlRequest struct {


### PR DESCRIPTION
## Summary

- clone the configured HTTP client for Morph and Railway and enforce the documented same-scheme, same-host, same-effective-port redirect boundary
- refuse lower-trust redirects before replaying bearer credentials or request bodies, while preserving caller redirect hooks and Go's default ten-redirect limit
- document the provider boundary and add adversarial allow/deny regression coverage

Closes https://github.com/openclaw/crabbox/issues/808
Closes https://github.com/openclaw/crabbox/issues/810

## Verification

- `go test -race ./internal/providers/morph ./internal/providers/railway`
- `go test -race ./...`
- CI-equivalent `deadcode -test ./...`
- `scripts/check-docs.sh`
- `git diff --check`
- autoreview: clean, no accepted/actionable findings

## Live proof

The focused tests use real loopback HTTP servers and the production clients:

- a credential-bearing request receives a temporary redirect to a different live origin; the client refuses it and the target records zero requests
- a temporary redirect within the configured origin succeeds and retains the expected bearer header and request body
- scheme, hostname/subdomain, and effective-port drift are denied; default-port equivalence is allowed

No persistent credentials or funded provider resources are required for this redirect-boundary proof.
