### PR TITLE
fix: redact stop-command URL credentials

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -224,11 +224,12 @@ hosts.
 Configured provider credentials are redacted from documented HTTP or streamed
 error diagnostics, including Azure Dynamic Sessions, Cloudflare runner, Daytona,
 E2B, Freestyle, Islo, Morph, OpenComputer, Railway, RunPod, Semaphore, SmolVM,
-and Upstash Box. GitHub Actions registration metadata and its short-lived runner
-token travel over SSH stdin rather than the remote command line. These
-guarantees apply to Crabbox-generated diagnostics and process arguments, not
-to arbitrary command output, downloaded artifacts, screenshots, or failure
-bundles.
+and Upstash Box. Generated stop and failure-routing commands retain provider
+endpoint routing but remove URL userinfo before they are printed or stored.
+GitHub Actions registration metadata and its short-lived runner token travel
+over SSH stdin rather than the remote command line. These guarantees apply to
+Crabbox-generated diagnostics and process arguments, not to arbitrary command
+output, downloaded artifacts, screenshots, or failure bundles.
 
 ### Resource and artifact boundaries
 

--- a/internal/cli/profiles_test.go
+++ b/internal/cli/profiles_test.go
@@ -721,6 +721,53 @@ func TestRunStopCommandIncludesXCPNgRoutingFlagsWithoutPassword(t *testing.T) {
 	}
 }
 
+func TestRunStopCommandRedactsProviderURLUserinfo(t *testing.T) {
+	const rawURL = "https://api-user:api-secret@provider.example.test/path?view=1"
+	for _, test := range []struct {
+		name     string
+		cfg      Config
+		wantFlag string
+	}{
+		{
+			name:     "proxmox",
+			cfg:      Config{Provider: "proxmox", Proxmox: ProxmoxConfig{APIURL: rawURL}},
+			wantFlag: "--proxmox-api-url 'https://provider.example.test/path?view=1'",
+		},
+		{
+			name:     "daytona",
+			cfg:      Config{Provider: "daytona", Daytona: DaytonaConfig{APIURL: rawURL}},
+			wantFlag: "--daytona-api-url 'https://provider.example.test/path?view=1'",
+		},
+		{
+			name:     "sprites",
+			cfg:      Config{Provider: "sprites", Sprites: SpritesConfig{APIURL: rawURL}},
+			wantFlag: "--sprites-api-url 'https://provider.example.test/path?view=1'",
+		},
+		{
+			name:     "morph",
+			cfg:      Config{Provider: "morph", Morph: MorphConfig{APIURL: rawURL}},
+			wantFlag: "--morph-api-url 'https://provider.example.test/path?view=1'",
+		},
+		{
+			name:     "hostinger",
+			cfg:      Config{Provider: "hostinger", Hostinger: HostingerConfig{APIURL: rawURL}},
+			wantFlag: "--hostinger-url 'https://provider.example.test/path?view=1'",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := runStopCommand(test.cfg, "cbx_123")
+			if !strings.Contains(got, test.wantFlag) {
+				t.Fatalf("stop command missing safe URL %q:\n%s", test.wantFlag, got)
+			}
+			for _, secret := range []string{"api-user", "api-secret", "api-user:api-secret"} {
+				if strings.Contains(got, secret) {
+					t.Fatalf("stop command leaked %q:\n%s", secret, got)
+				}
+			}
+		})
+	}
+}
+
 func TestRunStopCommandIncludesSemaphoreRoutingFlags(t *testing.T) {
 	got := runStopCommand(Config{
 		Provider: "semaphore",

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1839,7 +1839,7 @@ func appendProviderStopRoutingArgs(args []string, cfg Config, id string) []strin
 		}
 	case "proxmox":
 		if strings.TrimSpace(cfg.Proxmox.APIURL) != "" {
-			args = append(args, "--proxmox-api-url", cfg.Proxmox.APIURL)
+			args = append(args, "--proxmox-api-url", routingSafeURL(cfg.Proxmox.APIURL))
 		}
 		if strings.TrimSpace(cfg.Proxmox.Node) != "" {
 			args = append(args, "--proxmox-node", cfg.Proxmox.Node)
@@ -1898,7 +1898,7 @@ func appendProviderStopRoutingArgs(args []string, cfg Config, id string) []strin
 		args = append(args, fmt.Sprintf("--coder-delete-on-release=%t", cfg.Coder.DeleteOnRelease))
 	case "daytona":
 		if strings.TrimSpace(cfg.Daytona.APIURL) != "" {
-			args = append(args, "--daytona-api-url", cfg.Daytona.APIURL)
+			args = append(args, "--daytona-api-url", routingSafeURL(cfg.Daytona.APIURL))
 		}
 		if strings.TrimSpace(cfg.Daytona.Target) != "" {
 			args = append(args, "--daytona-target", cfg.Daytona.Target)
@@ -1908,7 +1908,7 @@ func appendProviderStopRoutingArgs(args []string, cfg Config, id string) []strin
 		}
 	case "sprites":
 		if strings.TrimSpace(cfg.Sprites.APIURL) != "" {
-			args = append(args, "--sprites-api-url", cfg.Sprites.APIURL)
+			args = append(args, "--sprites-api-url", routingSafeURL(cfg.Sprites.APIURL))
 		}
 	case "semaphore":
 		if strings.TrimSpace(cfg.Semaphore.Host) != "" {
@@ -1920,14 +1920,14 @@ func appendProviderStopRoutingArgs(args []string, cfg Config, id string) []strin
 		}
 	case "morph":
 		if strings.TrimSpace(cfg.Morph.APIURL) != "" {
-			args = append(args, "--morph-api-url", cfg.Morph.APIURL)
+			args = append(args, "--morph-api-url", routingSafeURL(cfg.Morph.APIURL))
 		}
 		if DeleteOnReleaseExplicit(cfg, "morph") {
 			args = append(args, fmt.Sprintf("--morph-delete-on-release=%t", cfg.Morph.DeleteOnRelease))
 		}
 	case "hostinger":
 		if strings.TrimSpace(cfg.Hostinger.APIURL) != "" {
-			args = append(args, "--hostinger-url", cfg.Hostinger.APIURL)
+			args = append(args, "--hostinger-url", routingSafeURL(cfg.Hostinger.APIURL))
 		}
 	case "vast", "vast-ai", "vastai":
 		if apiURL := strings.TrimSpace(cfg.Vast.APIURL); apiURL != "" {


### PR DESCRIPTION
## Summary

- remove URL userinfo before Proxmox, Daytona, Sprites, Morph, or Hostinger endpoints enter generated stop commands
- preserve the scheme, host, path, query, and fragment needed to route later cleanup
- cover all five provider paths with a table-driven diagnostic regression and document the boundary

Closes https://github.com/openclaw/crabbox/issues/797

## Verification

- `go test -race ./internal/cli -run 'TestRunStopCommand(RedactsProviderURLUserinfo|IncludesProviderRoutingFlags|IncludesMorphRoutingFlags|IncludesHostingerRoutingFlags)' -count=1`
- `go test -race ./...`
- `scripts/check-docs.sh`
- `git diff --check`
- autoreview: clean, no accepted/actionable findings

## End-to-end proof

The regression runs the production `runStopCommand` formatter for every affected provider with a credential-bearing URL. Each generated command retains the usable endpoint and query string, contains neither username nor password, and remains shell-quoted as expected. This path is deterministic and local; it does not need a provider credential or funded resource.
