### PR TITLE
fix: require exact Daytona sandbox claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@
 
 ### Fixed
 
-- Required exact Daytona provider/resource claims before existing sandboxes can be reused or deleted, rejecting direct IDs without canonical ownership labels and preserving explicit `--reclaim` adoption. Thanks @coygeek.
 - Compared coordinator admin, shared-operator, runtime-adapter, proxy, and signed-session secrets without mismatch-position or early length exits. Thanks @coygeek.
 - Prevented direct Azure list, stop, and cleanup paths from treating weak `crabbox=true` tags as ownership; destructive operations now require canonical Azure ownership tags and an exact matching lease ID, and successful deletion removes local lease keys. Thanks @coygeek.
 - Restricted brokered Azure image and OS-disk selectors to admin-authenticated requests while preserving user-selectable Azure placement. Thanks @coygeek.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- Required exact Daytona provider/resource claims before existing sandboxes can be reused or deleted, rejecting direct IDs without canonical ownership labels and preserving explicit `--reclaim` adoption. Thanks @coygeek.
 - Compared coordinator admin, shared-operator, runtime-adapter, proxy, and signed-session secrets without mismatch-position or early length exits. Thanks @coygeek.
 - Prevented direct Azure list, stop, and cleanup paths from treating weak `crabbox=true` tags as ownership; destructive operations now require canonical Azure ownership tags and an exact matching lease ID, and successful deletion removes local lease keys. Thanks @coygeek.
 - Restricted brokered Azure image and OS-disk selectors to admin-authenticated requests while preserving user-selectable Azure placement. Thanks @coygeek.

--- a/docs/features/daytona.md
+++ b/docs/features/daytona.md
@@ -116,8 +116,13 @@ crabbox stop --provider daytona swift-crab
   archive through Daytona toolbox file APIs, extracts it in the sandbox, and
   executes the command through Daytona toolbox process APIs. The command transport
   is Daytona's SDK — not direct SSH.
-- **`list`**, **`status`**, and **`stop`** find Crabbox-owned sandboxes via
-  Daytona sandbox labels.
+- **`list`** and **`status`** discover sandboxes only when Daytona labels bind
+  them to the Daytona provider and a canonical Crabbox lease. Direct IDs with
+  missing or mismatched ownership labels are rejected.
+- **`run --id`**, **`ssh`**, and **`stop`** additionally require a local claim
+  that binds the exact Daytona sandbox ID to that lease. A legacy labelled
+  sandbox with an unbound claim must be adopted explicitly with `--reclaim`
+  from its owning repository before it can be reused or deleted.
 - **`ssh`** mints a fresh Daytona SSH access token (TTL `daytona.sshAccessMinutes`,
   default 30 minutes), parses the host and port from Daytona's returned SSH
   command (falling back to `daytona.sshGatewayHost` and port 22), and prints the

--- a/internal/providers/daytona/backend_doctor_test.go
+++ b/internal/providers/daytona/backend_doctor_test.go
@@ -10,9 +10,11 @@ import (
 )
 
 type fakeDaytonaDoctorAPI struct {
-	listCalls int
-	mutated   bool
-	sandboxes []apidaytona.Sandbox
+	listCalls    int
+	mutated      bool
+	sandboxes    []apidaytona.Sandbox
+	getSandboxes map[string]*apidaytona.Sandbox
+	deleted      []string
 }
 
 func (a *fakeDaytonaDoctorAPI) CreateSandbox(context.Context, apidaytona.CreateSandbox) (*apidaytona.Sandbox, error) {
@@ -20,8 +22,8 @@ func (a *fakeDaytonaDoctorAPI) CreateSandbox(context.Context, apidaytona.CreateS
 	return nil, nil
 }
 
-func (a *fakeDaytonaDoctorAPI) GetSandbox(context.Context, string) (*apidaytona.Sandbox, error) {
-	return nil, nil
+func (a *fakeDaytonaDoctorAPI) GetSandbox(_ context.Context, id string) (*apidaytona.Sandbox, error) {
+	return a.getSandboxes[id], nil
 }
 
 func (a *fakeDaytonaDoctorAPI) ListCrabboxSandboxes(context.Context) ([]apidaytona.Sandbox, error) {
@@ -34,8 +36,9 @@ func (a *fakeDaytonaDoctorAPI) StartSandbox(context.Context, string) (*apidayton
 	return nil, nil
 }
 
-func (a *fakeDaytonaDoctorAPI) DeleteSandbox(context.Context, string) error {
+func (a *fakeDaytonaDoctorAPI) DeleteSandbox(_ context.Context, id string) error {
 	a.mutated = true
+	a.deleted = append(a.deleted, id)
 	return nil
 }
 
@@ -55,9 +58,17 @@ func (a *fakeDaytonaDoctorAPI) CreateSSHAccess(context.Context, string, time.Dur
 }
 
 func TestDaytonaDoctorListsInventoryOnly(t *testing.T) {
-	sandbox := apidaytona.Sandbox{}
-	sandbox.SetId("sandbox-one")
-	fake := &fakeDaytonaDoctorAPI{sandboxes: []apidaytona.Sandbox{sandbox}}
+	owned := apidaytona.Sandbox{}
+	owned.SetId("sandbox-one")
+	owned.SetLabels(map[string]string{
+		"crabbox":  "true",
+		"provider": daytonaProvider,
+		"lease":    "cbx_666666666666",
+	})
+	weaklyLabelled := apidaytona.Sandbox{}
+	weaklyLabelled.SetId("sandbox-weak")
+	weaklyLabelled.SetLabels(map[string]string{"crabbox": "true"})
+	fake := &fakeDaytonaDoctorAPI{sandboxes: []apidaytona.Sandbox{owned, weaklyLabelled}}
 	old := newDaytonaClient
 	newDaytonaClient = func(Config, Runtime) (daytonaAPI, error) {
 		return fake, nil

--- a/internal/providers/daytona/backend_run.go
+++ b/internal/providers/daytona/backend_run.go
@@ -270,14 +270,15 @@ func (b *daytonaLeaseBackend) createDaytonaToolboxSandboxWithClient(ctx context.
 	if err != nil {
 		return nil, "", "", daytonaError("create sandbox", err)
 	}
-	if err := claimLeaseTargetForRepoConfig(leaseID, slug, cfg, Server{Provider: daytonaProvider, CloudID: sandbox.ID, Labels: labels}, SSHTarget{}, repo.Root, cfg.IdleTimeout, reclaim); err != nil {
+	labels["state"] = "ready"
+	labels["last_touched_at"] = leaseLabelTime(time.Now().UTC())
+	if _, err := establishDaytonaSandboxOwnership(ctx, apiClient, sandbox.ID, leaseID, labels); err != nil {
 		_ = sandbox.Delete(context.Background())
 		return nil, "", "", err
 	}
-	labels["state"] = "ready"
-	labels["last_touched_at"] = leaseLabelTime(time.Now().UTC())
-	if err := apiClient.ReplaceLabels(ctx, sandbox.ID, labels); err != nil {
-		fmt.Fprintf(b.rt.Stderr, "warning: set labels: %v\n", daytonaError("replace labels", err))
+	if err := claimLeaseTargetForRepoConfig(leaseID, slug, cfg, Server{Provider: daytonaProvider, CloudID: sandbox.ID, Labels: labels}, SSHTarget{}, repo.Root, cfg.IdleTimeout, reclaim); err != nil {
+		_ = sandbox.Delete(context.Background())
+		return nil, "", "", err
 	}
 	return sandbox, leaseID, slug, nil
 }

--- a/internal/providers/daytona/backend_run.go
+++ b/internal/providers/daytona/backend_run.go
@@ -61,18 +61,15 @@ func (b *daytonaLeaseBackend) Run(ctx context.Context, req RunRequest) (RunResul
 		fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=daytona sandbox=%s\n", leaseID, slug, sandbox.ID)
 		acquired = true
 	} else {
-		sandbox, leaseID, err = b.resolveDaytonaToolboxSandbox(ctx, client, req.ID)
+		sandbox, leaseID, err = b.resolveDaytonaToolboxSandbox(ctx, client, req.ID, req.Repo, req.Reclaim)
 		if err != nil {
 			return RunResult{}, err
 		}
 		slug = newLeaseSlug(leaseID)
-		if claim, ok, claimErr := resolveLeaseClaim(req.ID); claimErr != nil {
+		if claim, ok, claimErr := resolveLeaseClaimForProvider(leaseID, daytonaProvider); claimErr != nil {
 			return RunResult{}, claimErr
-		} else if ok && claim.Provider == daytonaProvider {
+		} else if ok {
 			slug = claim.Slug
-			if err := claimLeaseForRepoConfig(claim.LeaseID, claim.Slug, b.cfg, req.Repo.Root, b.cfg.IdleTimeout, req.Reclaim); err != nil {
-				return RunResult{}, err
-			}
 		}
 	}
 	shouldStop := acquired && !req.Keep
@@ -213,6 +210,9 @@ func (b *daytonaLeaseBackend) Stop(ctx context.Context, req StopRequest) error {
 	if err != nil {
 		return err
 	}
+	if err := requireExactDaytonaClaim(leaseID, sandbox); err != nil {
+		return err
+	}
 	if err := client.DeleteSandbox(ctx, sandbox.GetId()); err != nil {
 		return daytonaError("delete sandbox", err)
 	}
@@ -270,7 +270,7 @@ func (b *daytonaLeaseBackend) createDaytonaToolboxSandboxWithClient(ctx context.
 	if err != nil {
 		return nil, "", "", daytonaError("create sandbox", err)
 	}
-	if err := claimLeaseForRepoConfig(leaseID, slug, cfg, repo.Root, cfg.IdleTimeout, reclaim); err != nil {
+	if err := claimLeaseTargetForRepoConfig(leaseID, slug, cfg, Server{Provider: daytonaProvider, CloudID: sandbox.ID, Labels: labels}, SSHTarget{}, repo.Root, cfg.IdleTimeout, reclaim); err != nil {
 		_ = sandbox.Delete(context.Background())
 		return nil, "", "", err
 	}
@@ -282,7 +282,7 @@ func (b *daytonaLeaseBackend) createDaytonaToolboxSandboxWithClient(ctx context.
 	return sandbox, leaseID, slug, nil
 }
 
-func (b *daytonaLeaseBackend) resolveDaytonaToolboxSandbox(ctx context.Context, sdkClient *sdkdaytona.Client, id string) (*sdkdaytona.Sandbox, string, error) {
+func (b *daytonaLeaseBackend) resolveDaytonaToolboxSandbox(ctx context.Context, sdkClient *sdkdaytona.Client, id string, repo Repo, reclaim bool) (*sdkdaytona.Sandbox, string, error) {
 	apiClient, err := newDaytonaClient(b.cfg, b.rt)
 	if err != nil {
 		return nil, "", err
@@ -290,6 +290,20 @@ func (b *daytonaLeaseBackend) resolveDaytonaToolboxSandbox(ctx context.Context, 
 	apiSandbox, leaseID, err := resolveDaytonaSandbox(ctx, apiClient, b.cfg, id)
 	if err != nil {
 		return nil, "", err
+	}
+	server := daytonaSandboxToServer(apiSandbox, b.cfg)
+	if reclaim {
+		if err := claimLeaseTargetForRepoConfig(leaseID, serverSlug(server), b.cfg, server, SSHTarget{}, repo.Root, b.cfg.IdleTimeout, true); err != nil {
+			return nil, "", err
+		}
+	}
+	if err := requireExactDaytonaClaim(leaseID, apiSandbox); err != nil {
+		return nil, "", err
+	}
+	if !reclaim {
+		if err := claimLeaseTargetForRepoConfig(leaseID, serverSlug(server), b.cfg, server, SSHTarget{}, repo.Root, b.cfg.IdleTimeout, false); err != nil {
+			return nil, "", err
+		}
 	}
 	if !daytonaStateReady(daytonaSandboxState(apiSandbox)) {
 		if _, err := apiClient.StartSandbox(ctx, apiSandbox.GetId()); err != nil {

--- a/internal/providers/daytona/backend_run_test.go
+++ b/internal/providers/daytona/backend_run_test.go
@@ -358,6 +358,116 @@ func TestDeleteDaytonaToolboxSandboxUsesBoundedContext(t *testing.T) {
 	}
 }
 
+func TestDaytonaStopRequiresExactResourceClaim(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	leaseID := "cbx_333333333333"
+	sandbox := apidaytona.Sandbox{}
+	sandbox.SetId("sandbox-owned")
+	sandbox.SetName("crabbox-test-daytona")
+	sandbox.SetLabels(map[string]string{
+		"crabbox":  "true",
+		"provider": daytonaProvider,
+		"lease":    leaseID,
+		"slug":     "daytona-owned",
+	})
+	fake := &fakeDaytonaDoctorAPI{sandboxes: []apidaytona.Sandbox{sandbox}}
+	oldClient := newDaytonaClient
+	newDaytonaClient = func(Config, Runtime) (daytonaAPI, error) { return fake, nil }
+	t.Cleanup(func() { newDaytonaClient = oldClient })
+
+	cfg := baseConfig()
+	cfg.Provider = daytonaProvider
+	backend := &daytonaLeaseBackend{cfg: cfg, rt: Runtime{Stderr: io.Discard}}
+	err := backend.Stop(context.Background(), StopRequest{ID: leaseID})
+	if err == nil || !strings.Contains(err.Error(), "no exact local claim") {
+		t.Fatalf("Stop error=%v, want exact-claim refusal", err)
+	}
+	if len(fake.deleted) != 0 {
+		t.Fatalf("claimless stop deleted sandboxes: %#v", fake.deleted)
+	}
+
+	repoRoot := t.TempDir()
+	server := Server{Provider: daytonaProvider, CloudID: sandbox.GetId(), Labels: sandbox.GetLabels()}
+	if err := claimLeaseTargetForRepoConfig(leaseID, "daytona-owned", cfg, server, SSHTarget{}, repoRoot, time.Hour, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := backend.Stop(context.Background(), StopRequest{ID: leaseID}); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.deleted) != 1 || fake.deleted[0] != sandbox.GetId() {
+		t.Fatalf("exact-claim stop deleted %#v, want [%s]", fake.deleted, sandbox.GetId())
+	}
+}
+
+func TestDaytonaResolveRejectsClaimOwnedByAnotherRepo(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	leaseID := "cbx_444444444444"
+	sandbox := apidaytona.Sandbox{}
+	sandbox.SetId("sandbox-repo-owned")
+	sandbox.SetName("crabbox-test-daytona")
+	sandbox.SetLabels(map[string]string{
+		"crabbox":  "true",
+		"provider": daytonaProvider,
+		"lease":    leaseID,
+		"slug":     "daytona-repo-owned",
+	})
+	fake := &fakeDaytonaDoctorAPI{sandboxes: []apidaytona.Sandbox{sandbox}}
+	oldClient := newDaytonaClient
+	newDaytonaClient = func(Config, Runtime) (daytonaAPI, error) { return fake, nil }
+	t.Cleanup(func() { newDaytonaClient = oldClient })
+
+	cfg := baseConfig()
+	cfg.Provider = daytonaProvider
+	repoA := t.TempDir()
+	repoB := t.TempDir()
+	server := Server{Provider: daytonaProvider, CloudID: sandbox.GetId(), Labels: sandbox.GetLabels()}
+	if err := claimLeaseTargetForRepoConfig(leaseID, "daytona-repo-owned", cfg, server, SSHTarget{}, repoA, time.Hour, false); err != nil {
+		t.Fatal(err)
+	}
+
+	backend := &daytonaLeaseBackend{cfg: cfg, rt: Runtime{Stderr: io.Discard}}
+	_, err := backend.Resolve(context.Background(), ResolveRequest{ID: leaseID, Repo: Repo{Root: repoB}})
+	if err == nil || !strings.Contains(err.Error(), "is claimed by repo") || !strings.Contains(err.Error(), "use --reclaim") {
+		t.Fatalf("Resolve error=%v, want cross-repository claim refusal", err)
+	}
+	if fake.mutated {
+		t.Fatal("cross-repository resolve mutated the Daytona sandbox")
+	}
+}
+
+func TestDaytonaResolveRefusesImplicitAdoption(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	leaseID := "cbx_555555555555"
+	sandbox := apidaytona.Sandbox{}
+	sandbox.SetId("sandbox-unclaimed")
+	sandbox.SetLabels(map[string]string{
+		"crabbox":  "true",
+		"provider": daytonaProvider,
+		"lease":    leaseID,
+		"slug":     "daytona-unclaimed",
+	})
+	fake := &fakeDaytonaDoctorAPI{sandboxes: []apidaytona.Sandbox{sandbox}}
+	oldClient := newDaytonaClient
+	newDaytonaClient = func(Config, Runtime) (daytonaAPI, error) { return fake, nil }
+	t.Cleanup(func() { newDaytonaClient = oldClient })
+
+	cfg := baseConfig()
+	cfg.Provider = daytonaProvider
+	backend := &daytonaLeaseBackend{cfg: cfg, rt: Runtime{Stderr: io.Discard}}
+	_, err := backend.Resolve(context.Background(), ResolveRequest{ID: leaseID, Repo: Repo{Root: t.TempDir()}})
+	if err == nil || !strings.Contains(err.Error(), "no exact local claim") || !strings.Contains(err.Error(), "use --reclaim") {
+		t.Fatalf("Resolve error=%v, want explicit-adoption refusal", err)
+	}
+	if fake.mutated {
+		t.Fatal("claimless resolve mutated the Daytona sandbox")
+	}
+	if _, ok, claimErr := resolveLeaseClaimForProvider(leaseID, daytonaProvider); claimErr != nil {
+		t.Fatal(claimErr)
+	} else if ok {
+		t.Fatal("claimless resolve implicitly created a Daytona claim")
+	}
+}
+
 func TestDaytonaSSHTargetUsesReturnedSSHCommand(t *testing.T) {
 	cfg := baseConfig()
 	cfg.Daytona.SSHGatewayHost = "fallback.example"

--- a/internal/providers/daytona/backend_run_test.go
+++ b/internal/providers/daytona/backend_run_test.go
@@ -391,11 +391,52 @@ func TestDaytonaStopRequiresExactResourceClaim(t *testing.T) {
 	if err := claimLeaseTargetForRepoConfig(leaseID, "daytona-owned", cfg, server, SSHTarget{}, repoRoot, time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
+	// Daytona's label-filtered inventory can lag immediately after creation.
+	// Exact claims must still resolve their bound sandbox without widening trust.
+	fake.sandboxes = nil
+	fake.getSandboxes = map[string]*apidaytona.Sandbox{sandbox.GetId(): &sandbox}
 	if err := backend.Stop(context.Background(), StopRequest{ID: leaseID}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.deleted) != 1 || fake.deleted[0] != sandbox.GetId() {
 		t.Fatalf("exact-claim stop deleted %#v, want [%s]", fake.deleted, sandbox.GetId())
+	}
+}
+
+func TestDaytonaClaimLookupRejectsRemoteOwnershipMismatch(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	leaseID := "cbx_343434343434"
+	sandbox := apidaytona.Sandbox{}
+	sandbox.SetId("sandbox-mismatch")
+	sandbox.SetLabels(map[string]string{
+		"crabbox":  "true",
+		"provider": daytonaProvider,
+		"lease":    "cbx_353535353535",
+		"slug":     "daytona-mismatch",
+	})
+	cfg := baseConfig()
+	cfg.Provider = daytonaProvider
+	server := Server{Provider: daytonaProvider, CloudID: sandbox.GetId(), Labels: map[string]string{
+		"crabbox":  "true",
+		"provider": daytonaProvider,
+		"lease":    leaseID,
+		"slug":     "daytona-mismatch",
+	}}
+	if err := claimLeaseTargetForRepoConfig(leaseID, "daytona-mismatch", cfg, server, SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
+		t.Fatal(err)
+	}
+	fake := &fakeDaytonaDoctorAPI{getSandboxes: map[string]*apidaytona.Sandbox{sandbox.GetId(): &sandbox}}
+	oldClient := newDaytonaClient
+	newDaytonaClient = func(Config, Runtime) (daytonaAPI, error) { return fake, nil }
+	t.Cleanup(func() { newDaytonaClient = oldClient })
+
+	backend := &daytonaLeaseBackend{cfg: cfg, rt: Runtime{Stderr: io.Discard}}
+	err := backend.Stop(context.Background(), StopRequest{ID: leaseID})
+	if err == nil || !strings.Contains(err.Error(), "does not match exact local claim") {
+		t.Fatalf("Stop error=%v, want remote ownership mismatch refusal", err)
+	}
+	if len(fake.deleted) != 0 {
+		t.Fatalf("mismatched claim deleted sandboxes: %#v", fake.deleted)
 	}
 }
 

--- a/internal/providers/daytona/backend_ssh.go
+++ b/internal/providers/daytona/backend_ssh.go
@@ -156,6 +156,12 @@ func (b *daytonaLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (
 		}
 		return LeaseTarget{}, err
 	}
+	if err := claimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, target, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
+		if !req.Keep {
+			_ = client.DeleteSandbox(context.Background(), server.CloudID)
+		}
+		return LeaseTarget{}, err
+	}
 	fmt.Fprintf(b.rt.Stderr, "provisioned lease=%s sandbox=%s state=%s\n", leaseID, server.CloudID, server.Status)
 	return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 }
@@ -172,6 +178,20 @@ func (b *daytonaLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (
 	if err != nil {
 		return LeaseTarget{}, err
 	}
+	server := daytonaSandboxToServer(sandbox, b.cfg)
+	if req.Reclaim && !req.NoLocalStateMutations {
+		if err := claimLeaseTargetForRepoConfig(leaseID, serverSlug(server), b.cfg, server, SSHTarget{}, req.Repo.Root, b.cfg.IdleTimeout, true); err != nil {
+			return LeaseTarget{}, err
+		}
+	}
+	if err := requireExactDaytonaClaim(leaseID, sandbox); err != nil {
+		return LeaseTarget{}, err
+	}
+	if !req.Reclaim && !req.NoLocalStateMutations {
+		if err := claimLeaseTargetForRepoConfig(leaseID, serverSlug(server), b.cfg, server, SSHTarget{}, req.Repo.Root, b.cfg.IdleTimeout, false); err != nil {
+			return LeaseTarget{}, err
+		}
+	}
 	if !daytonaStateReady(daytonaSandboxState(sandbox)) {
 		if daytonaStateFailed(daytonaSandboxState(sandbox)) {
 			return LeaseTarget{}, exit(5, "daytona sandbox %s entered terminal state=%s", sandbox.GetId(), daytonaSandboxState(sandbox))
@@ -185,7 +205,7 @@ func (b *daytonaLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (
 			return LeaseTarget{}, err
 		}
 	}
-	server := daytonaSandboxToServer(sandbox, b.cfg)
+	server = daytonaSandboxToServer(sandbox, b.cfg)
 	target, err := daytonaSSHTargetFor(ctx, client, b.cfg, server)
 	if err != nil {
 		return LeaseTarget{}, err
@@ -203,7 +223,14 @@ func (b *daytonaLeaseBackend) List(ctx context.Context, req ListRequest) ([]Leas
 	if err != nil {
 		return nil, daytonaError("list sandboxes", err)
 	}
-	return daytonaSandboxesToServers(sandboxes, b.cfg), nil
+	servers := make([]Server, 0, len(sandboxes))
+	for i := range sandboxes {
+		if _, owned := daytonaSandboxOwnership(&sandboxes[i]); !owned {
+			continue
+		}
+		servers = append(servers, daytonaSandboxToServer(&sandboxes[i], b.cfg))
+	}
+	return servers, nil
 }
 
 func (b *daytonaLeaseBackend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
@@ -223,6 +250,9 @@ func (b *daytonaLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLease
 		return err
 	}
 	if req.Lease.Server.CloudID != "" {
+		if err := requireExactDaytonaResourceClaim(req.Lease.LeaseID, req.Lease.Server.CloudID); err != nil {
+			return err
+		}
 		if err := client.DeleteSandbox(ctx, req.Lease.Server.CloudID); err != nil {
 			return daytonaError("delete sandbox", err)
 		}
@@ -287,7 +317,7 @@ func resolveDaytonaSandbox(ctx context.Context, client daytonaAPI, cfg Config, i
 	}
 	if isCanonicalLeaseID(id) {
 		for i := range sandboxes {
-			if sandboxes[i].Labels["lease"] == id {
+			if leaseID, owned := daytonaSandboxOwnership(&sandboxes[i]); owned && leaseID == id {
 				return &sandboxes[i], id, nil
 			}
 		}
@@ -295,7 +325,7 @@ func resolveDaytonaSandbox(ctx context.Context, client daytonaAPI, cfg Config, i
 	slug := normalizeLeaseSlug(id)
 	var matches []*daytona.Sandbox
 	for i := range sandboxes {
-		if slug != "" && normalizeLeaseSlug(sandboxes[i].Labels["slug"]) == slug {
+		if _, owned := daytonaSandboxOwnership(&sandboxes[i]); owned && slug != "" && normalizeLeaseSlug(sandboxes[i].Labels["slug"]) == slug {
 			matches = append(matches, &sandboxes[i])
 		}
 	}
@@ -306,28 +336,62 @@ func resolveDaytonaSandbox(ctx context.Context, client daytonaAPI, cfg Config, i
 		return matches[0], matches[0].Labels["lease"], nil
 	}
 	for i := range sandboxes {
-		if sandboxes[i].GetId() == id || sandboxes[i].GetName() == id || sandboxes[i].Labels["lease_name"] == id {
-			return &sandboxes[i], blank(sandboxes[i].Labels["lease"], id), nil
+		if leaseID, owned := daytonaSandboxOwnership(&sandboxes[i]); owned && (sandboxes[i].GetId() == id || sandboxes[i].GetName() == id || sandboxes[i].Labels["lease_name"] == id) {
+			return &sandboxes[i], leaseID, nil
 		}
 	}
 	if claim, ok, err := resolveLeaseClaim(id); err != nil {
 		return nil, "", err
 	} else if ok && claim.Provider == daytonaProvider {
 		for i := range sandboxes {
-			if sandboxes[i].Labels["lease"] == claim.LeaseID {
+			if leaseID, owned := daytonaSandboxOwnership(&sandboxes[i]); owned && leaseID == claim.LeaseID {
 				return &sandboxes[i], claim.LeaseID, nil
 			}
 		}
 	}
 	sandbox, err := client.GetSandbox(ctx, id)
 	if err == nil && sandbox != nil && sandbox.GetId() != "" {
-		return sandbox, blank(sandbox.Labels["lease"], id), nil
+		if leaseID, owned := daytonaSandboxOwnership(sandbox); owned {
+			return sandbox, leaseID, nil
+		}
+		return nil, "", exit(4, "daytona sandbox %s is not owned by Crabbox", id)
 	}
 	if err != nil && !daytonaIsNotFoundError(err) {
 		return nil, "", daytonaError("get sandbox", err)
 	}
 	_ = cfg
 	return nil, "", exit(4, "daytona sandbox not found: %s", id)
+}
+
+func daytonaSandboxOwnership(sandbox *daytona.Sandbox) (string, bool) {
+	if sandbox == nil || strings.TrimSpace(sandbox.GetId()) == "" {
+		return "", false
+	}
+	labels := sandbox.GetLabels()
+	leaseID := strings.TrimSpace(labels["lease"])
+	return leaseID, strings.EqualFold(strings.TrimSpace(labels["crabbox"]), "true") &&
+		strings.EqualFold(strings.TrimSpace(labels["provider"]), daytonaProvider) &&
+		isCanonicalLeaseID(leaseID)
+}
+
+func requireExactDaytonaClaim(leaseID string, sandbox *daytona.Sandbox) error {
+	resourceID := ""
+	if sandbox != nil {
+		resourceID = strings.TrimSpace(sandbox.GetId())
+	}
+	return requireExactDaytonaResourceClaim(leaseID, resourceID)
+}
+
+func requireExactDaytonaResourceClaim(leaseID, resourceID string) error {
+	resourceID = strings.TrimSpace(resourceID)
+	claim, ok, err := resolveLeaseClaimForProvider(leaseID, daytonaProvider)
+	if err != nil {
+		return err
+	}
+	if !ok || strings.TrimSpace(claim.LeaseID) != strings.TrimSpace(leaseID) || strings.TrimSpace(claim.CloudID) != resourceID {
+		return exit(4, "daytona sandbox %s has no exact local claim for lease %s; use --reclaim from the owning repository before reuse or deletion", blank(resourceID, "-"), blank(leaseID, "-"))
+	}
+	return nil
 }
 
 func daytonaSSHTargetFor(ctx context.Context, client daytonaAPI, cfg Config, server Server) (SSHTarget, error) {

--- a/internal/providers/daytona/backend_ssh.go
+++ b/internal/providers/daytona/backend_ssh.go
@@ -140,9 +140,14 @@ func (b *daytonaLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (
 	}
 	server := daytonaSandboxToServer(sandbox, cfg)
 	server.Labels["state"] = "ready"
-	if err := client.ReplaceLabels(ctx, server.CloudID, server.Labels); err != nil {
-		fmt.Fprintf(b.rt.Stderr, "warning: set labels: %v\n", daytonaError("replace labels", err))
+	sandbox, err = establishDaytonaSandboxOwnership(ctx, client, server.CloudID, leaseID, server.Labels)
+	if err != nil {
+		if !req.Keep {
+			_ = client.DeleteSandbox(context.Background(), server.CloudID)
+		}
+		return LeaseTarget{}, err
 	}
+	server = daytonaSandboxToServer(sandbox, cfg)
 	target, err := daytonaSSHTargetFor(ctx, client, cfg, server)
 	if err != nil {
 		if !req.Keep {
@@ -340,13 +345,31 @@ func resolveDaytonaSandbox(ctx context.Context, client daytonaAPI, cfg Config, i
 			return &sandboxes[i], leaseID, nil
 		}
 	}
-	if claim, ok, err := resolveLeaseClaim(id); err != nil {
+	if claim, ok, err := resolveLeaseClaimForProvider(id, daytonaProvider); err != nil {
 		return nil, "", err
-	} else if ok && claim.Provider == daytonaProvider {
+	} else if ok {
 		for i := range sandboxes {
 			if leaseID, owned := daytonaSandboxOwnership(&sandboxes[i]); owned && leaseID == claim.LeaseID {
 				return &sandboxes[i], claim.LeaseID, nil
 			}
+		}
+		cloudID := strings.TrimSpace(claim.CloudID)
+		if cloudID != "" {
+			sandbox, getErr := client.GetSandbox(ctx, cloudID)
+			if getErr != nil {
+				if daytonaIsNotFoundError(getErr) {
+					return nil, "", exit(4, "daytona claim %s is bound to missing sandbox %s", claim.LeaseID, cloudID)
+				}
+				return nil, "", daytonaError("get claimed sandbox", getErr)
+			}
+			if sandbox == nil || strings.TrimSpace(sandbox.GetId()) == "" {
+				return nil, "", exit(4, "daytona claim %s is bound to missing sandbox %s", claim.LeaseID, cloudID)
+			}
+			leaseID, owned := daytonaSandboxOwnership(sandbox)
+			if strings.TrimSpace(sandbox.GetId()) != cloudID || !owned || leaseID != claim.LeaseID {
+				return nil, "", exit(4, "daytona sandbox %s does not match exact local claim for lease %s", cloudID, claim.LeaseID)
+			}
+			return sandbox, claim.LeaseID, nil
 		}
 	}
 	sandbox, err := client.GetSandbox(ctx, id)
@@ -372,6 +395,21 @@ func daytonaSandboxOwnership(sandbox *daytona.Sandbox) (string, bool) {
 	return leaseID, strings.EqualFold(strings.TrimSpace(labels["crabbox"]), "true") &&
 		strings.EqualFold(strings.TrimSpace(labels["provider"]), daytonaProvider) &&
 		isCanonicalLeaseID(leaseID)
+}
+
+func establishDaytonaSandboxOwnership(ctx context.Context, client daytonaAPI, resourceID, leaseID string, labels map[string]string) (*daytona.Sandbox, error) {
+	if err := client.ReplaceLabels(ctx, resourceID, labels); err != nil {
+		return nil, daytonaError("replace labels", err)
+	}
+	sandbox, err := client.GetSandbox(ctx, resourceID)
+	if err != nil {
+		return nil, daytonaError("verify sandbox labels", err)
+	}
+	verifiedLeaseID, owned := daytonaSandboxOwnership(sandbox)
+	if sandbox == nil || strings.TrimSpace(sandbox.GetId()) != strings.TrimSpace(resourceID) || !owned || verifiedLeaseID != strings.TrimSpace(leaseID) {
+		return nil, exit(4, "daytona sandbox %s did not persist exact Crabbox ownership labels for lease %s", blank(resourceID, "-"), blank(leaseID, "-"))
+	}
+	return sandbox, nil
 }
 
 func requireExactDaytonaClaim(leaseID string, sandbox *daytona.Sandbox) error {

--- a/internal/providers/daytona/client_test.go
+++ b/internal/providers/daytona/client_test.go
@@ -64,8 +64,8 @@ func TestDaytonaListCrabboxSandboxesUsesCursorPagination(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if resolved.GetId() != "sandbox-two" || leaseID != "lease-two" {
-		t.Fatalf("resolved=%s lease=%s, want sandbox-two lease-two", resolved.GetId(), leaseID)
+	if resolved.GetId() != "sandbox-two" || leaseID != "cbx_222222222222" {
+		t.Fatalf("resolved=%s lease=%s, want sandbox-two cbx_222222222222", resolved.GetId(), leaseID)
 	}
 	if len(cursors) != 4 || cursors[0] != "" || cursors[1] != "cursor-2" || cursors[2] != "" || cursors[3] != "cursor-2" {
 		t.Fatalf("cursors=%#v, want two cursor-paginated inventory scans", cursors)
@@ -80,6 +80,9 @@ func TestResolveDaytonaSandboxDirectLookupErrorHandling(t *testing.T) {
 			_, _ = w.Write([]byte(`{"items":[],"nextCursor":null}`))
 		case "/sandbox/direct-one":
 			_, _ = w.Write([]byte(daytonaListItemJSON("direct-one", "direct-slug")))
+		case "/sandbox/unowned":
+			unowned := strings.Replace(daytonaListItemJSON("unowned", "unowned"), `"provider": "daytona", `, "", 1)
+			_, _ = w.Write([]byte(unowned))
 		case "/sandbox/missing":
 			http.Error(w, `{"message":"sandbox not found"}`, http.StatusNotFound)
 		case "/sandbox/denied":
@@ -99,8 +102,8 @@ func TestResolveDaytonaSandboxDirectLookupErrorHandling(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.GetId() != "direct-one" || leaseID != "lease-one" {
-		t.Fatalf("direct lookup=%s lease=%s, want direct-one lease-one", got.GetId(), leaseID)
+	if got.GetId() != "direct-one" || leaseID != "cbx_111111111111" {
+		t.Fatalf("direct lookup=%s lease=%s, want direct-one cbx_111111111111", got.GetId(), leaseID)
 	}
 
 	_, _, err = resolveDaytonaSandbox(context.Background(), client, Config{}, "missing")
@@ -118,6 +121,11 @@ func TestResolveDaytonaSandboxDirectLookupErrorHandling(t *testing.T) {
 	}
 	if strings.Contains(err.Error(), "sandbox not found") {
 		t.Fatalf("denied err=%v, want no not-found rewrite", err)
+	}
+
+	_, _, err = resolveDaytonaSandbox(context.Background(), client, Config{}, "unowned")
+	if !errors.As(err, &exitErr) || exitErr.Code != 4 || !strings.Contains(err.Error(), "is not owned by Crabbox") {
+		t.Fatalf("unowned err=%v, want ownership refusal", err)
 	}
 }
 
@@ -162,6 +170,10 @@ func TestParseDaytonaCLIAuthConfigFallsBackWhenNoActiveProfile(t *testing.T) {
 }
 
 func daytonaListItemJSON(id, slug string) string {
+	leaseID := "cbx_111111111111"
+	if strings.HasSuffix(id, "two") {
+		leaseID = "cbx_222222222222"
+	}
 	return `{
 		"id": "` + id + `",
 		"organizationId": "org-123",
@@ -175,7 +187,7 @@ func daytonaListItemJSON(id, slug string) string {
 		"gpu": 0,
 		"memory": 4,
 		"disk": 20,
-		"labels": {"crabbox": "true", "lease": "lease-` + id[len(id)-3:] + `", "slug": "` + slug + `"},
+		"labels": {"crabbox": "true", "provider": "daytona", "lease": "` + leaseID + `", "slug": "` + slug + `"},
 		"toolboxProxyUrl": "https://toolbox.example/` + id + `",
 		"state": "started"
 	}`

--- a/internal/providers/daytona/core.go
+++ b/internal/providers/daytona/core.go
@@ -112,10 +112,6 @@ func removeLeaseClaim(leaseID string) {
 	core.RemoveLeaseClaim(leaseID)
 }
 
-func resolveLeaseClaim(identifier string) (core.LeaseClaim, bool, error) {
-	return core.ResolveLeaseClaim(identifier)
-}
-
 func claimLeaseTargetForRepoConfig(leaseID, slug string, cfg Config, server Server, target SSHTarget, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
 	return core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, target, repoRoot, idleTimeout, reclaim)
 }

--- a/internal/providers/daytona/core.go
+++ b/internal/providers/daytona/core.go
@@ -35,6 +35,7 @@ type Server = core.Server
 type Repo = core.Repo
 type LeaseTarget = core.LeaseTarget
 type SSHTarget = core.SSHTarget
+type LeaseClaim = core.LeaseClaim
 type SyncManifest = core.SyncManifest
 type ExitError = core.ExitError
 type timingReport = core.TimingReport
@@ -115,8 +116,12 @@ func resolveLeaseClaim(identifier string) (core.LeaseClaim, bool, error) {
 	return core.ResolveLeaseClaim(identifier)
 }
 
-func claimLeaseForRepoConfig(leaseID, slug string, cfg Config, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
-	return core.ClaimLeaseForRepoProvider(leaseID, slug, cfg.Provider, repoRoot, idleTimeout, reclaim)
+func claimLeaseTargetForRepoConfig(leaseID, slug string, cfg Config, server Server, target SSHTarget, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
+	return core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, target, repoRoot, idleTimeout, reclaim)
+}
+
+func resolveLeaseClaimForProvider(identifier, provider string) (LeaseClaim, bool, error) {
+	return core.ResolveLeaseClaimForProvider(identifier, provider)
 }
 
 func waitForSSHReady(ctx context.Context, target *SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {


### PR DESCRIPTION
## Summary

- require canonical Daytona ownership labels before sandboxes appear in inventory or resolve by ID/name/lease
- require a local claim binding the exact Daytona sandbox ID to the lease before reuse or deletion
- resolve an exact claimed sandbox by its bound cloud ID when Daytona's label-filtered inventory is still converging, then re-verify provider and lease labels before use or deletion
- persist and verify remote ownership labels before recording a new local claim; roll back creation when ownership cannot be established
- preserve explicit, conflict-safe `--reclaim` adoption while rejecting implicit or cross-repository adoption

Closes https://github.com/openclaw/crabbox/issues/800

## Verification

- `go vet ./...`
- `go test -race ./...`
- `go vet ./internal/providers/daytona`
- `go test -race ./internal/providers/daytona`
- `go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...`
- `node scripts/build-docs-site.mjs`
- `git diff --check origin/main...HEAD`
- autoreview: clean for both the hardening delta and the complete branch diff

Regression coverage proves direct unowned IDs are refused, claimless reuse cannot create a claim, another repository cannot reuse an existing claim without `--reclaim`, exact claims still resolve through delayed filtered inventory, remote ownership mismatches fail closed, and stop deletes only the resource named by the exact claim.

## Live proof

Behavioral candidate `f39b2e4ac7733404c8ce8ca43ce9e7e9b14bbf21` passed a disposable Daytona canary. Current head `d1eead8199e2e5dbdbae7086964c167f5f0aa5b0` differs only by deleting an unreachable adapter reported by the deadcode CI gate; focused race tests and the exact deadcode command pass on current head.

1. doctor reported auth/control-plane/inventory ready with zero leases
2. created a retained `daytona-small` sandbox and immediately ran `DAYTONA_EXACT_CLAIM_OK` through the exact local claim
3. confirmed the label-filtered inventory converged to that sandbox in `started` state
4. refused cross-repository implicit reuse before remote mutation
5. refused claimless reuse after temporarily removing the local claim
6. explicitly reclaimed the sandbox and ran `DAYTONA_RECLAIM_OK`
7. stopped the exact claimed sandbox; provider inventory converged to `[]` and the dashboard showed the resource as deleted

The disposable API key was revoked after the canary. No active sandbox or reusable test credential remains.
