### PR TITLE
fix: redact provider credentials from errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@
 
 ### Fixed
 
-- Redacted reflected provider credentials from Morph, E2B, SmolVM, Railway, RunPod, Azure Dynamic Sessions, and Islo HTTP or streamed error diagnostics while preserving useful failure detail. Thanks @coygeek.
 - Compared coordinator admin, shared-operator, runtime-adapter, proxy, and signed-session secrets without mismatch-position or early length exits. Thanks @coygeek.
 - Prevented direct Azure list, stop, and cleanup paths from treating weak `crabbox=true` tags as ownership; destructive operations now require canonical Azure ownership tags and an exact matching lease ID, and successful deletion removes local lease keys. Thanks @coygeek.
 - Restricted brokered Azure image and OS-disk selectors to admin-authenticated requests while preserving user-selectable Azure placement. Thanks @coygeek.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- Redacted reflected provider credentials from Morph, E2B, SmolVM, Railway, RunPod, Azure Dynamic Sessions, and Islo HTTP or streamed error diagnostics while preserving useful failure detail. Thanks @coygeek.
 - Compared coordinator admin, shared-operator, runtime-adapter, proxy, and signed-session secrets without mismatch-position or early length exits. Thanks @coygeek.
 - Prevented direct Azure list, stop, and cleanup paths from treating weak `crabbox=true` tags as ownership; destructive operations now require canonical Azure ownership tags and an exact matching lease ID, and successful deletion removes local lease keys. Thanks @coygeek.
 - Restricted brokered Azure image and OS-disk selectors to admin-authenticated requests while preserving user-selectable Azure placement. Thanks @coygeek.

--- a/docs/security.md
+++ b/docs/security.md
@@ -221,9 +221,10 @@ endpoints require HTTPS except for explicit localhost/loopback development
 URLs, and AWS region values are validated before constructing SigV4 service
 hosts.
 
-Configured OpenComputer, Freestyle, Cloudflare runner, Semaphore, and Upstash
-Box credentials are redacted from their documented HTTP or streamed error
-diagnostics. GitHub Actions registration metadata and its short-lived runner
+Configured provider credentials are redacted from documented HTTP or streamed
+error diagnostics, including Azure Dynamic Sessions, Cloudflare runner, Daytona,
+E2B, Freestyle, Islo, Morph, OpenComputer, Railway, RunPod, Semaphore, SmolVM,
+and Upstash Box. GitHub Actions registration metadata and its short-lived runner
 token travel over SSH stdin rather than the remote command line. These
 guarantees apply to Crabbox-generated diagnostics and process arguments, not
 to arbitrary command output, downloaded artifacts, screenshots, or failure

--- a/internal/providers/azuredynamicsessions/client.go
+++ b/internal/providers/azuredynamicsessions/client.go
@@ -14,6 +14,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type azureDynamicSessionsAPI interface {
@@ -306,7 +308,7 @@ func (c *azureDynamicSessionsClient) ExecStream(ctx context.Context, identifier 
 			if event.Error == "" {
 				event.Error = "stream error"
 			}
-			return exitCode, errors.New(event.Error)
+			return exitCode, errors.New(shared.RedactErrorSecrets(event.Error, c.token))
 		case "start", "heartbeat":
 		default:
 			return exitCode, fmt.Errorf("unknown %s stream event %q", providerName, event.Type)
@@ -411,7 +413,7 @@ func (c *azureDynamicSessionsClient) doJSONURL(ctx context.Context, method, endp
 		return err
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return &azureDynamicSessionsAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: summarizeJSON(data)}
+		return &azureDynamicSessionsAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: shared.RedactErrorSecrets(summarizeJSON(data), c.token)}
 	}
 	if out != nil && len(data) > 0 {
 		if err := json.Unmarshal(data, out); err != nil {
@@ -423,7 +425,7 @@ func (c *azureDynamicSessionsClient) doJSONURL(ctx context.Context, method, endp
 
 func (c *azureDynamicSessionsClient) responseError(resp *http.Response) error {
 	data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-	return &azureDynamicSessionsAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: summarizeJSON(data)}
+	return &azureDynamicSessionsAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: shared.RedactErrorSecrets(summarizeJSON(data), c.token)}
 }
 
 func (c *azureDynamicSessionsClient) secureHTTPClient() *http.Client {

--- a/internal/providers/azuredynamicsessions/client_test.go
+++ b/internal/providers/azuredynamicsessions/client_test.go
@@ -392,6 +392,45 @@ func TestAzureDynamicSessionsExecStreamRejectsIncompleteStream(t *testing.T) {
 	}
 }
 
+func TestAzureDynamicSessionsClientRedactsReflectedCredential(t *testing.T) {
+	const secret = "azure-session-secret"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, `{"message":"Bearer `+secret+` quota exceeded"}`)
+	}))
+	defer server.Close()
+	client := &azureDynamicSessionsClient{endpoint: server.URL, token: secret, httpClient: server.Client()}
+
+	for name, call := range map[string]func() error{
+		"JSON": func() error { return client.CheckRunner(context.Background(), "azds-test") },
+		"stream": func() error {
+			_, err := client.ExecStream(context.Background(), "azds-test", azureDynamicSessionsExecRequest{Command: "true"}, nil, nil)
+			return err
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := call()
+			if err == nil || strings.Contains(err.Error(), secret) || !strings.Contains(err.Error(), "[redacted]") || !strings.Contains(err.Error(), "quota exceeded") {
+				t.Fatalf("error=%v, want redacted useful provider error", err)
+			}
+		})
+	}
+}
+
+func TestAzureDynamicSessionsClientRedactsStreamErrorCredential(t *testing.T) {
+	const secret = "azure-stream-secret"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = io.WriteString(w, `{"type":"error","error":"Bearer `+secret+` quota exceeded"}`+"\n")
+	}))
+	defer server.Close()
+	client := &azureDynamicSessionsClient{endpoint: server.URL, token: secret, httpClient: server.Client()}
+	_, err := client.ExecStream(context.Background(), "azds-test", azureDynamicSessionsExecRequest{Command: "true"}, nil, nil)
+	if err == nil || strings.Contains(err.Error(), secret) || !strings.Contains(err.Error(), "[redacted]") || !strings.Contains(err.Error(), "quota exceeded") {
+		t.Fatalf("ExecStream error=%v, want redacted useful stream error", err)
+	}
+}
+
 func TestAzureDynamicSessionsExecStreamReturnsWriterErrors(t *testing.T) {
 	for _, tc := range []struct {
 		name    string

--- a/internal/providers/e2b/backend_test.go
+++ b/internal/providers/e2b/backend_test.go
@@ -22,6 +22,68 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
+type e2bRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn e2bRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func TestE2BClientRedactsReflectedCredentials(t *testing.T) {
+	t.Run("API key", func(t *testing.T) {
+		const secret = "e2b-api-secret"
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = io.WriteString(w, `{"message":"X-API-Key: `+secret+` quota exceeded"}`)
+		}))
+		defer server.Close()
+		client := &e2bClient{apiKey: secret, apiURL: server.URL, httpClient: server.Client()}
+		_, err := client.ListSandboxes(context.Background(), nil)
+		assertE2BRedactedError(t, err, secret)
+	})
+
+	t.Run("envd access token", func(t *testing.T) {
+		const secret = "envd-access-secret"
+		httpClient := &http.Client{Transport: e2bRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusUnauthorized,
+				Status:     "401 Unauthorized",
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"message":"Bearer ` + secret + ` quota exceeded"}`)),
+				Request:    req,
+			}, nil
+		})}
+		client := &e2bClient{httpClient: httpClient}
+		_, err := client.StartProcess(context.Background(), e2bSession{SandboxID: "sbx_1", Domain: "example.test", EnvdAccessToken: secret}, e2bProcessRequest{Command: "true"})
+		assertE2BRedactedError(t, err, secret)
+	})
+}
+
+func assertE2BRedactedError(t *testing.T, err error, secret string) {
+	t.Helper()
+	if err == nil || strings.Contains(err.Error(), secret) || !strings.Contains(err.Error(), "[redacted]") || !strings.Contains(err.Error(), "quota exceeded") {
+		t.Fatalf("error=%v, want redacted useful provider error", err)
+	}
+}
+
+func TestE2BProcessStreamRedactsReflectedCredential(t *testing.T) {
+	const secret = "envd-stream-secret"
+	t.Run("end stream error", func(t *testing.T) {
+		body := e2bTestEnvelope(2, map[string]any{"error": map[string]any{"code": "unauthorized", "message": "Bearer " + secret + " quota exceeded"}})
+		_, err := parseE2BProcessStream(bytes.NewReader(body), io.Discard, io.Discard, secret)
+		assertE2BRedactedError(t, err, secret)
+	})
+	t.Run("process end diagnostic", func(t *testing.T) {
+		body := e2bTestEnvelope(0, map[string]any{"event": map[string]any{"end": map[string]any{"exitCode": 1, "exited": false, "error": "Bearer " + secret + " quota exceeded"}}})
+		var stderr bytes.Buffer
+		if _, err := parseE2BProcessStream(bytes.NewReader(body), io.Discard, &stderr, secret); err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(stderr.String(), secret) || !strings.Contains(stderr.String(), "[redacted]") || !strings.Contains(stderr.String(), "quota exceeded") {
+			t.Fatalf("stderr=%q, want redacted useful process diagnostic", stderr.String())
+		}
+	})
+}
+
 func TestParseE2BProcessStream(t *testing.T) {
 	body := bytes.Join([][]byte{
 		e2bTestEnvelope(0, map[string]any{"event": map[string]any{"start": map[string]any{"pid": 42}}}),

--- a/internal/providers/e2b/client.go
+++ b/internal/providers/e2b/client.go
@@ -15,6 +15,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type e2bAPI interface {
@@ -312,7 +314,7 @@ func (c *e2bClient) UploadFile(ctx context.Context, session e2bSession, targetPa
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return &e2bAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: summarizeJSON(data)}
+		return &e2bAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: shared.RedactErrorSecrets(summarizeJSON(data), session.EnvdAccessToken)}
 	}
 	_, _ = io.Copy(io.Discard, resp.Body)
 	return nil
@@ -364,9 +366,9 @@ func (c *e2bClient) StartProcess(ctx context.Context, session e2bSession, req e2
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
 		data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return 1, &e2bAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: summarizeJSON(data)}
+		return 1, &e2bAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: shared.RedactErrorSecrets(summarizeJSON(data), session.EnvdAccessToken)}
 	}
-	return parseE2BProcessStream(resp.Body, req.Stdout, req.Stderr)
+	return parseE2BProcessStream(resp.Body, req.Stdout, req.Stderr, session.EnvdAccessToken)
 }
 
 func (c *e2bClient) doJSON(ctx context.Context, method, path string, query url.Values, body any, out any) error {
@@ -406,7 +408,7 @@ func (c *e2bClient) doJSONWithHeaders(ctx context.Context, method, path string, 
 		return nil, err
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, &e2bAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: summarizeJSON(data)}
+		return nil, &e2bAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: shared.RedactErrorSecrets(summarizeJSON(data), c.apiKey)}
 	}
 	if out != nil && len(data) > 0 {
 		if err := json.Unmarshal(data, out); err != nil {
@@ -484,7 +486,7 @@ func encodeConnectJSONEnvelope(v any) ([]byte, error) {
 	return out.Bytes(), nil
 }
 
-func parseE2BProcessStream(r io.Reader, stdout, stderr io.Writer) (int, error) {
+func parseE2BProcessStream(r io.Reader, stdout, stderr io.Writer, secrets ...string) (int, error) {
 	exitCode := 0
 	seenEnd := false
 	for {
@@ -512,7 +514,7 @@ func parseE2BProcessStream(r io.Reader, stdout, stderr io.Writer) (int, error) {
 				}
 			}
 			if end.Error != nil {
-				return 1, fmt.Errorf("%s: %s", end.Error.Code, end.Error.Message)
+				return 1, errors.New(shared.RedactErrorSecrets(end.Error.Code+": "+end.Error.Message, secrets...))
 			}
 			break
 		}
@@ -532,7 +534,7 @@ func parseE2BProcessStream(r io.Reader, stdout, stderr io.Writer) (int, error) {
 			exitCode = event.Event.End.ExitCode
 			seenEnd = true
 			if !event.Event.End.Exited && event.Event.End.Error != "" {
-				fmt.Fprintln(stderr, event.Event.End.Error)
+				fmt.Fprintln(stderr, shared.RedactErrorSecrets(event.Event.End.Error, secrets...))
 			}
 		}
 	}

--- a/internal/providers/islo/client.go
+++ b/internal/providers/islo/client.go
@@ -18,6 +18,7 @@ import (
 	"github.com/islo-labs/go-sdk/client"
 	"github.com/islo-labs/go-sdk/customauth"
 	"github.com/islo-labs/go-sdk/option"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type isloAPI interface {
@@ -142,6 +143,7 @@ func (c *isloSDKClient) DeleteSandbox(ctx context.Context, name string) error {
 	if err := c.authorize(ctx, httpReq); err != nil {
 		return err
 	}
+	token := strings.TrimPrefix(httpReq.Header.Get("Authorization"), "Bearer ")
 	httpReq.Header.Set("Accept", "application/json")
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
@@ -152,7 +154,7 @@ func (c *isloSDKClient) DeleteSandbox(ctx context.Context, name string) error {
 	// 404 carved out so an already-gone sandbox is an idempotent success.
 	if resp.StatusCode >= 400 && resp.StatusCode != http.StatusNotFound {
 		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return fmt.Errorf("islo delete sandbox %s: %s", resp.Status, strings.TrimSpace(string(snippet)))
+		return fmt.Errorf("islo delete sandbox %s: %s", resp.Status, shared.RedactErrorSecrets(strings.TrimSpace(string(snippet)), token))
 	}
 	_, _ = io.Copy(io.Discard, resp.Body)
 	return nil
@@ -185,7 +187,7 @@ func (c *isloSDKClient) UploadArchive(ctx context.Context, name, targetPath stri
 	defer resp.Body.Close()
 	if resp.StatusCode >= 400 {
 		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return fmt.Errorf("islo upload archive %s: %s", resp.Status, strings.TrimSpace(string(snippet)))
+		return fmt.Errorf("islo upload archive %s: %s", resp.Status, shared.RedactErrorSecrets(strings.TrimSpace(string(snippet)), token))
 	}
 	_, _ = io.Copy(io.Discard, resp.Body)
 	return nil
@@ -243,6 +245,7 @@ func (c *isloSDKClient) CreateShare(ctx context.Context, name string, port int, 
 	if err := c.authorize(ctx, httpReq); err != nil {
 		return IsloShare{}, err
 	}
+	token := strings.TrimPrefix(httpReq.Header.Get("Authorization"), "Bearer ")
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("Accept", "application/json")
 	resp, err := c.httpClient.Do(httpReq)
@@ -252,7 +255,7 @@ func (c *isloSDKClient) CreateShare(ctx context.Context, name string, port int, 
 	defer resp.Body.Close()
 	if resp.StatusCode >= 400 {
 		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return IsloShare{}, fmt.Errorf("islo create share %s: %s", resp.Status, strings.TrimSpace(string(snippet)))
+		return IsloShare{}, fmt.Errorf("islo create share %s: %s", resp.Status, shared.RedactErrorSecrets(strings.TrimSpace(string(snippet)), token))
 	}
 	var raw isloShareResponse
 	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
@@ -269,6 +272,7 @@ func (c *isloSDKClient) ListShares(ctx context.Context, name string) ([]IsloShar
 	if err := c.authorize(ctx, httpReq); err != nil {
 		return nil, err
 	}
+	token := strings.TrimPrefix(httpReq.Header.Get("Authorization"), "Bearer ")
 	httpReq.Header.Set("Accept", "application/json")
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
@@ -280,7 +284,7 @@ func (c *isloSDKClient) ListShares(ctx context.Context, name string) ([]IsloShar
 	}
 	if resp.StatusCode >= 400 {
 		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return nil, fmt.Errorf("islo list shares %s: %s", resp.Status, strings.TrimSpace(string(snippet)))
+		return nil, fmt.Errorf("islo list shares %s: %s", resp.Status, shared.RedactErrorSecrets(strings.TrimSpace(string(snippet)), token))
 	}
 	var raw []isloShareResponse
 	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
@@ -343,12 +347,12 @@ func (c *isloSDKClient) ExecStream(ctx context.Context, name string, req *gosdk.
 	defer resp.Body.Close()
 	if resp.StatusCode >= 400 {
 		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return 1, fmt.Errorf("islo exec stream %s: %s", resp.Status, strings.TrimSpace(string(snippet)))
+		return 1, fmt.Errorf("islo exec stream %s: %s", resp.Status, shared.RedactErrorSecrets(strings.TrimSpace(string(snippet)), token))
 	}
-	return parseIsloSSE(resp.Body, stdout, stderr)
+	return parseIsloSSE(resp.Body, stdout, stderr, token)
 }
 
-func parseIsloSSE(r io.Reader, stdout, stderr io.Writer) (int, error) {
+func parseIsloSSE(r io.Reader, stdout, stderr io.Writer, secrets ...string) (int, error) {
 	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
 	exitCode := 0
@@ -418,7 +422,7 @@ func parseIsloSSE(r io.Reader, stdout, stderr io.Writer) (int, error) {
 	}
 	if !seenExit {
 		if streamErr != "" {
-			return 1, fmt.Errorf("islo exec stream error: %s", streamErr)
+			return 1, fmt.Errorf("islo exec stream error: %s", shared.RedactErrorSecrets(streamErr, secrets...))
 		}
 		return 1, fmt.Errorf("islo exec stream ended without exit event")
 	}

--- a/internal/providers/islo/client_test.go
+++ b/internal/providers/islo/client_test.go
@@ -5,8 +5,11 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
+
+	gosdk "github.com/islo-labs/go-sdk"
 )
 
 // TestIsloClientDeleteSandboxHandlesEmptyAndMissing verifies the raw DELETE
@@ -64,6 +67,62 @@ func TestIsloClientDeleteSandboxHandlesEmptyAndMissing(t *testing.T) {
 			t.Fatal("expected error for 500 delete, got nil")
 		}
 	})
+}
+
+func TestIsloRawErrorsRedactSessionToken(t *testing.T) {
+	const secret = "islo-session-secret"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/auth/token" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"session_token":"`+secret+`"}`)
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, `{"message":"Bearer `+secret+` quota exceeded"}`)
+	}))
+	defer server.Close()
+	cfg := Config{}
+	cfg.Islo.APIKey = "test-key"
+	cfg.Islo.BaseURL = server.URL
+	client, err := newIsloClient(cfg, Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for name, call := range map[string]func() error{
+		"delete": func() error { return client.DeleteSandbox(context.Background(), "sandbox") },
+		"upload": func() error {
+			return client.UploadArchive(context.Background(), "sandbox", "/workspace", strings.NewReader("archive"))
+		},
+		"create share": func() error {
+			_, err := client.CreateShare(context.Background(), "sandbox", 8080, time.Minute)
+			return err
+		},
+		"list shares": func() error {
+			_, err := client.ListShares(context.Background(), "sandbox")
+			return err
+		},
+		"exec stream": func() error {
+			_, err := client.ExecStream(context.Background(), "sandbox", &gosdk.ExecRequest{}, io.Discard, io.Discard)
+			return err
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := call()
+			if err == nil || strings.Contains(err.Error(), secret) || !strings.Contains(err.Error(), "[redacted]") || !strings.Contains(err.Error(), "quota exceeded") {
+				t.Fatalf("error=%v, want redacted useful provider error", err)
+			}
+		})
+	}
+}
+
+func TestIsloSSEErrorRedactsSessionToken(t *testing.T) {
+	const secret = "islo-stream-secret"
+	body := "event: error\ndata: Bearer " + secret + " quota exceeded\n\n"
+	_, err := parseIsloSSE(strings.NewReader(body), io.Discard, io.Discard, secret)
+	if err == nil || strings.Contains(err.Error(), secret) || !strings.Contains(err.Error(), "[redacted]") || !strings.Contains(err.Error(), "quota exceeded") {
+		t.Fatalf("parseIsloSSE error=%v, want redacted useful stream error", err)
+	}
 }
 
 func TestIsloShareFromAPIMarksInvalidExpiryAsSet(t *testing.T) {

--- a/internal/providers/morph/client.go
+++ b/internal/providers/morph/client.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type morphAPI interface {
@@ -302,7 +304,7 @@ func (c *morphClient) doRaw(ctx context.Context, method, path string, query url.
 		return nil, &morphAPIError{
 			StatusCode: resp.StatusCode,
 			Status:     resp.Status,
-			Body:       summarizeMorphResponse(data),
+			Body:       shared.RedactErrorSecrets(summarizeMorphResponse(data), c.apiKey),
 		}
 	}
 	return data, nil

--- a/internal/providers/morph/client_test.go
+++ b/internal/providers/morph/client_test.go
@@ -6,8 +6,24 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
+
+func TestMorphClientRedactsReflectedCredential(t *testing.T) {
+	const secret = "morph-secret-token"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, `{"message":"Bearer `+secret+` quota exceeded"}`)
+	}))
+	defer server.Close()
+
+	client := &morphClient{apiURL: server.URL, apiKey: secret, httpClient: server.Client()}
+	err := client.DeleteInstance(context.Background(), "inst_1")
+	if err == nil || strings.Contains(err.Error(), secret) || !strings.Contains(err.Error(), "[redacted]") || !strings.Contains(err.Error(), "quota exceeded") {
+		t.Fatalf("DeleteInstance error=%v, want redacted useful provider error", err)
+	}
+}
 
 func TestMorphClientBootSnapshotUsesAPIBaseAndAuth(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/providers/railway/backend_test.go
+++ b/internal/providers/railway/backend_test.go
@@ -177,7 +177,7 @@ func TestRailwayClientRejectsEmptyRedeployResponse(t *testing.T) {
 
 func TestRailwayClientSurfacesNon2xxAsAPIError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "forbidden by token", http.StatusForbidden)
+		http.Error(w, "forbidden by wrong-token", http.StatusForbidden)
 	}))
 	defer server.Close()
 
@@ -199,14 +199,14 @@ func TestRailwayClientSurfacesNon2xxAsAPIError(t *testing.T) {
 	if apiErr.StatusCode != http.StatusForbidden {
 		t.Fatalf("status = %d, want 403", apiErr.StatusCode)
 	}
-	if !strings.Contains(apiErr.Body, "forbidden by token") {
-		t.Fatalf("body = %q, want forbidden snippet", apiErr.Body)
+	if strings.Contains(apiErr.Body, "wrong-token") || !strings.Contains(apiErr.Body, "forbidden by [redacted]") {
+		t.Fatalf("body = %q, want redacted forbidden snippet", apiErr.Body)
 	}
 }
 
 func TestRailwayClientSurfacesGraphQLErrorsAsAPIError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = io.WriteString(w, `{"errors":[{"message":"Project not found"}]}`)
+		_, _ = io.WriteString(w, `{"errors":[{"message":"Bearer test-token Project not found"}]}`)
 	}))
 	defer server.Close()
 
@@ -225,8 +225,8 @@ func TestRailwayClientSurfacesGraphQLErrorsAsAPIError(t *testing.T) {
 	if !ok {
 		t.Fatalf("err = %T, want *railwayAPIError", err)
 	}
-	if !strings.Contains(apiErr.Body, "Project not found") {
-		t.Fatalf("err body = %q, want Project not found", apiErr.Body)
+	if strings.Contains(apiErr.Body, "test-token") || !strings.Contains(apiErr.Body, "Bearer [redacted] Project not found") {
+		t.Fatalf("err body = %q, want redacted Project not found", apiErr.Body)
 	}
 }
 

--- a/internal/providers/railway/client.go
+++ b/internal/providers/railway/client.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 // railwayAPI is the minimal Railway GraphQL surface the provider needs.
@@ -209,7 +211,7 @@ func (c *railwayClient) do(ctx context.Context, query string, vars map[string]an
 		return fmt.Errorf("railway response exceeds %d bytes", railwayMaxGraphQLResponseBytes)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return &railwayAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: strings.TrimSpace(string(data))}
+		return &railwayAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: shared.RedactErrorSecrets(strings.TrimSpace(string(data)), c.apiToken)}
 	}
 	var envelope graphqlResponse
 	if err := json.Unmarshal(data, &envelope); err != nil {
@@ -220,7 +222,7 @@ func (c *railwayClient) do(ctx context.Context, query string, vars map[string]an
 		for _, e := range envelope.Errors {
 			msgs = append(msgs, e.Message)
 		}
-		return &railwayAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: strings.Join(msgs, "; ")}
+		return &railwayAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: shared.RedactErrorSecrets(strings.Join(msgs, "; "), c.apiToken)}
 	}
 	if out != nil {
 		if err := json.Unmarshal(envelope.Data, out); err != nil {

--- a/internal/providers/runpod/backend_test.go
+++ b/internal/providers/runpod/backend_test.go
@@ -30,6 +30,24 @@ func TestRunpodProviderSpec(t *testing.T) {
 	}
 }
 
+func TestRunpodClientRedactsReflectedCredential(t *testing.T) {
+	const secret = "runpod-secret-token"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, `{"message":"Bearer `+secret+` quota exceeded"}`)
+	}))
+	defer server.Close()
+
+	client, err := newRunpodClient(Config{Runpod: RunpodConfig{APIKey: secret, APIURL: server.URL}}, Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.Whoami(context.Background())
+	if err == nil || strings.Contains(err.Error(), secret) || !strings.Contains(err.Error(), "[redacted]") || !strings.Contains(err.Error(), "quota exceeded") {
+		t.Fatalf("Whoami error=%v, want redacted useful provider error", err)
+	}
+}
+
 func TestRunpodIsRunpodProviderNameAcceptsAliases(t *testing.T) {
 	for _, name := range []string{"runpod", "Run-Pod", "  runpodio  ", "RUNPOD"} {
 		if !isRunpodProviderName(name) {

--- a/internal/providers/runpod/client.go
+++ b/internal/providers/runpod/client.go
@@ -11,6 +11,8 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 // runpodAPI is the minimal RunPod REST surface the provider needs. The
@@ -204,7 +206,7 @@ func (c *runpodClient) do(ctx context.Context, method, path string, body any, ou
 		return fmt.Errorf("runpod response exceeds %d bytes", runpodMaxResponseBytes)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return &runpodAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: strings.TrimSpace(string(data))}
+		return &runpodAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: shared.RedactErrorSecrets(strings.TrimSpace(string(data)), c.apiKey)}
 	}
 	if out != nil && len(strings.TrimSpace(string(data))) > 0 {
 		if err := json.Unmarshal(data, out); err != nil {

--- a/internal/providers/shared/redact.go
+++ b/internal/providers/shared/redact.go
@@ -1,0 +1,48 @@
+package shared
+
+import (
+	"regexp"
+	"strings"
+)
+
+const redactedProviderSecret = "[redacted]"
+
+var (
+	providerBearerPattern = regexp.MustCompile(`(?i)\bbearer[ \t]+[^\s"',;\\}]+`)
+	providerHeaderPattern = regexp.MustCompile(`(?i)\b(authorization|x-api-key|api-key|api_key)[ \t]*[:=][ \t]*[^\s"',;\\}]+`)
+)
+
+// RedactErrorSecrets removes credentials from untrusted provider response text
+// while preserving the surrounding status and diagnostic detail.
+func RedactErrorSecrets(value string, secrets ...string) string {
+	redacted := value
+	for _, secret := range secrets {
+		secret = strings.TrimSpace(secret)
+		if secret != "" {
+			redacted = strings.ReplaceAll(redacted, secret, redactedProviderSecret)
+		}
+	}
+	redacted = providerBearerPattern.ReplaceAllString(redacted, "Bearer "+redactedProviderSecret)
+	redacted = providerHeaderPattern.ReplaceAllStringFunc(redacted, func(match string) string {
+		separator := strings.IndexAny(match, ":=")
+		if separator < 0 {
+			return match
+		}
+		return match[:separator+1] + " " + redactedProviderSecret
+	})
+	for _, key := range []string{"authorization", "apiKey", "api_key", "accessToken", "access_token", "token"} {
+		redacted = redactProviderJSONField(redacted, key)
+	}
+	return redacted
+}
+
+func redactProviderJSONField(value, key string) string {
+	pattern := regexp.MustCompile(`(?i)"` + regexp.QuoteMeta(key) + `"\s*:\s*"[^"]*(?:"|$)`)
+	return pattern.ReplaceAllStringFunc(value, func(match string) string {
+		separator := strings.Index(match, ":")
+		if separator < 0 {
+			return match
+		}
+		return match[:separator+1] + `"` + redactedProviderSecret + `"`
+	})
+}

--- a/internal/providers/shared/redact_test.go
+++ b/internal/providers/shared/redact_test.go
@@ -1,0 +1,27 @@
+package shared
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRedactErrorSecrets(t *testing.T) {
+	secret := "provider-secret-token"
+	value := `request failed: Bearer ` + secret + ` X-API-Key: ` + secret + ` {"accessToken":"derived-token","message":"quota exceeded"}`
+	got := RedactErrorSecrets(value, secret, " ")
+	for _, leaked := range []string{secret, "derived-token"} {
+		if strings.Contains(got, leaked) {
+			t.Fatalf("redacted error leaked %q: %s", leaked, got)
+		}
+	}
+	if !strings.Contains(got, "quota exceeded") || strings.Count(got, redactedProviderSecret) < 3 {
+		t.Fatalf("redacted error lost useful detail: %s", got)
+	}
+	if plain := RedactErrorSecrets("ordinary provider failure", ""); plain != "ordinary provider failure" {
+		t.Fatalf("plain error changed: %q", plain)
+	}
+	truncated := RedactErrorSecrets(`{"token":"` + strings.Repeat("secret-prefix", 50))
+	if strings.Contains(truncated, "secret-prefix") || !strings.Contains(truncated, `"token":"[redacted]"`) {
+		t.Fatalf("truncated JSON credential was not redacted: %s", truncated)
+	}
+}

--- a/internal/providers/smolvm/backend_test.go
+++ b/internal/providers/smolvm/backend_test.go
@@ -52,6 +52,21 @@ func TestProviderSpecAndAliases(t *testing.T) {
 	}
 }
 
+func TestSmolVMClientRedactsReflectedCredential(t *testing.T) {
+	const secret = "smolvm-secret-token"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, `{"message":"Bearer `+secret+` quota exceeded"}`)
+	}))
+	defer server.Close()
+
+	client := &client{apiKey: secret, base: server.URL, http: server.Client()}
+	_, err := client.GetMachine(context.Background(), "machine_1")
+	if err == nil || strings.Contains(err.Error(), secret) || !strings.Contains(err.Error(), "[redacted]") || !strings.Contains(err.Error(), "quota exceeded") {
+		t.Fatalf("GetMachine error=%v, want redacted useful provider error", err)
+	}
+}
+
 func TestClientUsesSmolvmRESTShape(t *testing.T) {
 	var createBody map[string]any
 	injectSeen := false

--- a/internal/providers/smolvm/client.go
+++ b/internal/providers/smolvm/client.go
@@ -14,6 +14,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type api interface {
@@ -434,7 +436,7 @@ func (c *client) doJSON(ctx context.Context, method, path string, query url.Valu
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return apiError(resp)
+		return apiError(resp, c.apiKey)
 	}
 	if out == nil {
 		return nil
@@ -457,9 +459,9 @@ func (c *client) addHeaders(req *http.Request) {
 	req.Header.Set("Accept", "application/json")
 }
 
-func apiError(resp *http.Response) error {
+func apiError(resp *http.Response, apiKey string) error {
 	data, _ := io.ReadAll(io.LimitReader(resp.Body, 8192))
-	msg := strings.TrimSpace(string(data))
+	msg := shared.RedactErrorSecrets(strings.TrimSpace(string(data)), apiKey)
 	if msg == "" {
 		msg = resp.Status
 	}


### PR DESCRIPTION
## Summary

- redact exact configured provider credentials plus bearer/header/JSON credential forms from untrusted provider errors
- cover Morph, E2B, SmolVM, Railway, RunPod, Azure Dynamic Sessions, and Islo HTTP error bodies
- close successful-response stream bypasses in E2B Connect, Azure NDJSON, and Islo SSE diagnostics
- redact truncated JSON credential fields through the end of bounded snippets while retaining status and useful error context

Closes https://github.com/openclaw/crabbox/issues/798

## Verification

- reflected-credential loopback/transport canaries for all seven providers and every raw Islo operation
- stream-event regressions for E2B, Azure Dynamic Sessions, and Islo
- `go test -race ./internal/providers/shared ./internal/providers/morph ./internal/providers/e2b ./internal/providers/smolvm ./internal/providers/railway ./internal/providers/runpod ./internal/providers/azuredynamicsessions ./internal/providers/islo`
- `go vet ./internal/providers/shared ./internal/providers/morph ./internal/providers/e2b ./internal/providers/smolvm ./internal/providers/railway ./internal/providers/runpod ./internal/providers/azuredynamicsessions ./internal/providers/islo`
- `go test -race ./...`
- `scripts/check-docs.sh`
- `git diff --check`
- autoreview: clean after fixing stream-event and truncated-JSON leak paths

The test servers echo the credential actually sent on each request and assert that the returned diagnostic contains `[redacted]`, never the credential, while preserving provider failure context.
