### PR TITLE
fix(worker): require portal request intent

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -221,6 +221,12 @@ endpoints require HTTPS except for explicit localhost/loopback development
 URLs, and AWS region values are validated before constructing SigV4 service
 hosts.
 
+Cookie-authenticated portal mutations and portal viewer WebSocket upgrades
+require an exact same-origin browser `Origin` matching `CRABBOX_PUBLIC_URL` (or
+the request origin when no public URL is configured). Missing or sibling-origin
+intent is rejected before the portal cookie is converted into bearer authority;
+explicit bearer API clients remain independent of this browser-only boundary.
+
 Configured provider credentials are redacted from documented HTTP or streamed
 error diagnostics, including Azure Dynamic Sessions, Cloudflare runner, Daytona,
 E2B, Freestyle, Islo, Morph, OpenComputer, Railway, RunPod, Semaphore, SmolVM,

--- a/worker/src/coordinator-entry.ts
+++ b/worker/src/coordinator-entry.ts
@@ -92,6 +92,12 @@ export async function prepareCoordinatorRequest(
     };
   }
   const portal = url.pathname.startsWith("/portal");
+  if (portal && !portalCookieRequestIntentAllowed(request, env, url)) {
+    return {
+      response: json({ error: "portal_request_origin_forbidden" }, { status: 403 }),
+      authenticated: false,
+    };
+  }
   const authRequest = portal ? requestWithPortalCookie(request) : request;
   const auth = await authenticateRequest(authRequest, env, authContext);
   if (!auth?.authorized) {
@@ -112,6 +118,25 @@ export async function prepareCoordinatorRequest(
     };
   }
   return { request: requestWithAuthContext(authRequest, auth), authenticated: true };
+}
+
+function portalCookieRequestIntentAllowed(request: Request, env: Env, url: URL): boolean {
+  if (request.headers.get("authorization")) return true;
+  if (!cookieValue(request.headers.get("cookie") ?? "", "crabbox_session")) return true;
+  const method = request.method.toUpperCase();
+  const websocket =
+    method === "GET" && request.headers.get("upgrade")?.toLowerCase() === "websocket";
+  if (!websocket && (method === "GET" || method === "HEAD" || method === "OPTIONS")) return true;
+  const origin = request.headers.get("origin")?.trim();
+  if (!origin) return false;
+  try {
+    const trustedOrigin = env.CRABBOX_PUBLIC_URL
+      ? new URL(env.CRABBOX_PUBLIC_URL).origin
+      : url.origin;
+    return url.origin === trustedOrigin && new URL(origin).origin === trustedOrigin;
+  } catch {
+    return false;
+  }
 }
 
 function isWebVNCAgentUpgrade(request: Request, url: URL): boolean {

--- a/worker/test/http.test.ts
+++ b/worker/test/http.test.ts
@@ -22,6 +22,75 @@ function proxyIdentityRequest(secret?: string): Request {
 }
 
 describe("coordinator auth", () => {
+  it("requires same-origin intent for portal-cookie mutations and viewer sockets", async () => {
+    const env = {
+      CRABBOX_SESSION_SECRET: "session-secret",
+      CRABBOX_PUBLIC_URL: "https://broker.example.test",
+      CRABBOX_DEFAULT_ORG: "example-org",
+    } as Env;
+    const token = await issueUserToken(env, {
+      owner: "alice@example.com",
+      ownerSource: "github-verified-email",
+      org: "example-org",
+      login: "alice",
+    });
+    const cookie = `crabbox_session=${encodeURIComponent(token)}`;
+    const mutationURL = "https://broker.example.test/portal/leases/blue-lobster/share";
+    const viewerURL = "https://broker.example.test/portal/leases/blue-lobster/vnc/viewer";
+
+    const denied = await Promise.all(
+      [
+        new Request(mutationURL, { method: "POST", headers: { cookie } }),
+        new Request(mutationURL, {
+          method: "POST",
+          headers: { cookie, origin: "https://lease.code.example.test" },
+        }),
+        new Request(viewerURL, { headers: { cookie, upgrade: "websocket" } }),
+        new Request(viewerURL, {
+          headers: { cookie, origin: "https://attacker.example", upgrade: "websocket" },
+        }),
+      ].map((request) => prepareCoordinatorRequest(request, env)),
+    );
+    await Promise.all(
+      denied.map(async (prepared) => {
+        expect(prepared).toMatchObject({ authenticated: false, response: { status: 403 } });
+        if (!("response" in prepared)) throw new Error("cross-origin portal request was accepted");
+        await expect(prepared.response.json()).resolves.toEqual({
+          error: "portal_request_origin_forbidden",
+        });
+      }),
+    );
+
+    const accepted = await Promise.all(
+      [
+        new Request(mutationURL, {
+          method: "POST",
+          headers: { cookie, origin: "https://broker.example.test" },
+        }),
+        new Request(viewerURL, {
+          headers: {
+            cookie,
+            origin: "https://broker.example.test",
+            upgrade: "websocket",
+          },
+        }),
+        new Request("https://broker.example.test/portal/leases/blue-lobster", {
+          headers: { cookie },
+        }),
+        new Request(mutationURL, {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${token}`,
+            origin: "https://automation.example.test",
+          },
+        }),
+      ].map((request) => prepareCoordinatorRequest(request, env)),
+    );
+    for (const prepared of accepted) {
+      expect(prepared).toMatchObject({ authenticated: true });
+    }
+  });
+
   it("routes only the exact per-lease Code origin without portal-cookie authority", async () => {
     const env = {
       CRABBOX_CODE_ORIGIN_TEMPLATE: "https://{lease}.code.example.test",


### PR DESCRIPTION
## Summary

- require exact same-origin browser intent before a portal session cookie is converted into bearer authority for unsafe methods
- apply the same fail-closed origin boundary to portal WebSocket upgrades, including the WebVNC viewer
- reject missing, malformed, sibling-site, and cross-site origins with `403` before Fleet mutation or bridge dispatch
- preserve safe portal reads and explicit bearer API clients as separate non-cookie authentication paths

Closes https://github.com/openclaw/crabbox/issues/803
Closes https://github.com/openclaw/crabbox/issues/804

## Verification

- coordinator integration regression covers missing/cross-origin POST, same-site sibling POST, missing/cross-origin WebSocket, exact-origin success, safe GET, and explicit bearer use
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker` (26 files, 761 tests)
- `npm run build --prefix worker` (Wrangler dry-run)
- `scripts/check-docs.sh`
- `git diff --check`
- autoreview: clean

The guard runs before cookie-to-bearer conversion and before Fleet dispatch, so rejected requests cannot reach lease sharing/release/theme/VNC mutations or claim a WebVNC bridge agent.
