### PR TITLE
fix(config): preserve controller identity after redaction

### DIFF
--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -15,8 +15,12 @@ func (a App) configShow(args []string) error {
 	fs := newFlagSet("config show", a.Stderr)
 	jsonOut := fs.Bool("json", false, "print JSON")
 	providerOverride := fs.String("provider", "", "resolve config for this provider")
+	controllerIdentityOut := fs.Bool("controller-provider-identity", false, "internal: print the controller provider identity contract")
 	if err := parseFlags(fs, args); err != nil {
 		return err
+	}
+	if *controllerIdentityOut && !*jsonOut {
+		return exit(2, "--controller-provider-identity requires --json")
 	}
 	cfg, err := loadConfigWithOverrides("", strings.TrimSpace(*providerOverride))
 	if err != nil {
@@ -34,6 +38,16 @@ func (a App) configShow(args []string) error {
 	coordinatorRegistrationURL, err := coordinatorRegistrationURLForConfig(cfg)
 	if err != nil {
 		return err
+	}
+	if *controllerIdentityOut {
+		// This subprocess-only contract is bounded and parsed in-process. Public
+		// config diagnostics use the redacted view below.
+		return json.NewEncoder(a.Stdout).Encode(map[string]any{
+			"provider":                   provider,
+			"providerScope":              providerScope,
+			"idempotentLeaseId":          fixedLeaseID,
+			"coordinatorRegistrationUrl": coordinatorRegistrationURL,
+		})
 	}
 	cfg = effectiveConfigForShow(cfg)
 	if *jsonOut {

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -243,7 +243,7 @@ func configShowView(cfg Config) map[string]any {
 			"workRoot":      cfg.NvidiaBrev.WorkRoot,
 		},
 		"vast": map[string]any{
-			"apiUrl":         redactedConfigURLWithoutQuery(cfg.Vast.APIURL),
+			"apiUrl":         redactedConfigURL(cfg.Vast.APIURL),
 			"auth":           tokenState(cfg.Vast.APIKey),
 			"instanceType":   cfg.Vast.InstanceType,
 			"gpuName":        cfg.Vast.GPUName,
@@ -401,7 +401,7 @@ func configShowView(cfg Config) map[string]any {
 			"teamId": cfg.FastAPICloud.TeamID,
 		},
 		"cloudflareDynamicWorkers": map[string]any{
-			"loaderUrl":          redactedConfigURLWithoutQuery(cfg.CloudflareDynamicWorkers.LoaderURL),
+			"loaderUrl":          redactedConfigURL(cfg.CloudflareDynamicWorkers.LoaderURL),
 			"auth":               tokenState(cfg.CloudflareDynamicWorkers.Token),
 			"compatibilityDate":  cfg.CloudflareDynamicWorkers.CompatibilityDate,
 			"compatibilityFlags": cfg.CloudflareDynamicWorkers.CompatibilityFlags,
@@ -413,7 +413,7 @@ func configShowView(cfg Config) map[string]any {
 			"metadata":           cfg.CloudflareDynamicWorkers.Metadata,
 		},
 		"cloudflareSandbox": map[string]any{
-			"url":             redactedConfigURLWithoutQuery(cfg.CloudflareSandbox.BridgeURL),
+			"url":             redactedConfigURL(cfg.CloudflareSandbox.BridgeURL),
 			"auth":            tokenState(cfg.CloudflareSandbox.Token),
 			"workdir":         cfg.CloudflareSandbox.Workdir,
 			"execTimeoutSecs": cfg.CloudflareSandbox.ExecTimeoutSecs,
@@ -698,8 +698,8 @@ func writeConfigShowText(w io.Writer, cfg Config) {
 	fmt.Fprintf(w, "tart image=%s user=%s work_root=%s cpus=%d memory=%d disk=%d\n", cfg.Tart.Image, cfg.Tart.User, cfg.Tart.WorkRoot, cfg.Tart.CPUs, cfg.Tart.Memory, cfg.Tart.Disk)
 	fmt.Fprintf(w, "cloudflare api_url=%s workdir=%s auth=%s\n", blank(redactedConfigURL(cfg.Cloudflare.APIURL), "-"), cfg.Cloudflare.Workdir, tokenState(cfg.Cloudflare.Token))
 	fmt.Fprintf(w, "fastapi_cloud api_url=%s app_id=%s team_id=%s auth=%s\n", blank(redactedConfigURL(cfg.FastAPICloud.APIURL), "-"), blank(cfg.FastAPICloud.AppID, "-"), blank(cfg.FastAPICloud.TeamID, "-"), tokenState(cfg.FastAPICloud.Token))
-	fmt.Fprintf(w, "cloudflare_dynamic_workers loader_url=%s compatibility_date=%s compatibility_flags=%s cache_mode=%s egress=%s cpu_ms=%d subrequests=%d timeout_secs=%d metadata=%d auth=%s\n", blank(redactedConfigURLWithoutQuery(cfg.CloudflareDynamicWorkers.LoaderURL), "-"), blank(cfg.CloudflareDynamicWorkers.CompatibilityDate, "-"), blank(strings.Join(cfg.CloudflareDynamicWorkers.CompatibilityFlags, ","), "-"), cfg.CloudflareDynamicWorkers.CacheMode, cfg.CloudflareDynamicWorkers.Egress, cfg.CloudflareDynamicWorkers.CPUMs, cfg.CloudflareDynamicWorkers.Subrequests, cfg.CloudflareDynamicWorkers.TimeoutSecs, len(cfg.CloudflareDynamicWorkers.Metadata), tokenState(cfg.CloudflareDynamicWorkers.Token))
-	fmt.Fprintf(w, "cloudflare_sandbox url=%s workdir=%s exec_timeout_secs=%d forget_missing=%t auth=%s\n", blank(redactedConfigURLWithoutQuery(cfg.CloudflareSandbox.BridgeURL), "-"), cfg.CloudflareSandbox.Workdir, cfg.CloudflareSandbox.ExecTimeoutSecs, cfg.CloudflareSandbox.ForgetMissing, tokenState(cfg.CloudflareSandbox.Token))
+	fmt.Fprintf(w, "cloudflare_dynamic_workers loader_url=%s compatibility_date=%s compatibility_flags=%s cache_mode=%s egress=%s cpu_ms=%d subrequests=%d timeout_secs=%d metadata=%d auth=%s\n", blank(redactedConfigURL(cfg.CloudflareDynamicWorkers.LoaderURL), "-"), blank(cfg.CloudflareDynamicWorkers.CompatibilityDate, "-"), blank(strings.Join(cfg.CloudflareDynamicWorkers.CompatibilityFlags, ","), "-"), cfg.CloudflareDynamicWorkers.CacheMode, cfg.CloudflareDynamicWorkers.Egress, cfg.CloudflareDynamicWorkers.CPUMs, cfg.CloudflareDynamicWorkers.Subrequests, cfg.CloudflareDynamicWorkers.TimeoutSecs, len(cfg.CloudflareDynamicWorkers.Metadata), tokenState(cfg.CloudflareDynamicWorkers.Token))
+	fmt.Fprintf(w, "cloudflare_sandbox url=%s workdir=%s exec_timeout_secs=%d forget_missing=%t auth=%s\n", blank(redactedConfigURL(cfg.CloudflareSandbox.BridgeURL), "-"), cfg.CloudflareSandbox.Workdir, cfg.CloudflareSandbox.ExecTimeoutSecs, cfg.CloudflareSandbox.ForgetMissing, tokenState(cfg.CloudflareSandbox.Token))
 	fmt.Fprintf(w, "static id=%s name=%s host=%s user=%s port=%s work_root=%s\n", blank(cfg.Static.ID, "-"), blank(cfg.Static.Name, "-"), blank(cfg.Static.Host, "-"), blank(cfg.Static.User, "-"), blank(cfg.Static.Port, "-"), blank(cfg.Static.WorkRoot, "-"))
 	fmt.Fprintf(w, "results junit=%s auto=%t fail_on_failures=%t\n", blank(strings.Join(cfg.Results.JUnit, ","), "-"), cfg.Results.Auto, cfg.Results.FailOnFailures)
 	fmt.Fprintf(w, "cache pnpm=%t npm=%t docker=%t git=%t max_gb=%d purge_on_release=%t volumes=%d\n", cfg.Cache.Pnpm, cfg.Cache.Npm, cfg.Cache.Docker, cfg.Cache.Git, cfg.Cache.MaxGB, cfg.Cache.PurgeOnRelease, len(cfg.Cache.Volumes))
@@ -718,7 +718,7 @@ func writeConfigShowText(w io.Writer, cfg Config) {
 	fmt.Fprintf(w, "vultr region=%s os=%s image=%s snapshot=%s firewall_group=%s vpc_ids=%s ssh_cidrs=%s user_scheme=%s\n", cfg.Vultr.Region, blank(cfg.Vultr.OS, "-"), blank(cfg.Vultr.Image, "-"), blank(cfg.Vultr.Snapshot, "-"), blank(cfg.Vultr.FirewallGroup, "-"), blank(strings.Join(cfg.Vultr.VPCIDs, ","), "-"), blank(strings.Join(cfg.Vultr.SSHCIDRs, ","), "-"), blank(cfg.Vultr.UserScheme, "-"))
 	fmt.Fprintf(w, "linode region=%s image=%s type=%s firewall=%s ssh_cidrs=%s\n", cfg.Linode.Region, cfg.Linode.Image, cfg.Linode.Type, blank(cfg.Linode.FirewallID, "-"), blank(strings.Join(cfg.Linode.SSHCIDRs, ","), "-"))
 	fmt.Fprintf(w, "lambda region=%s type=%s image=%s image_family=%s firewall_ruleset=%s ssh_cidrs=%s filesystems=%s mounts=%d auth=%s\n", cfg.Lambda.Region, cfg.Lambda.Type, blank(cfg.Lambda.Image, "-"), blank(cfg.Lambda.ImageFamily, "-"), blank(cfg.Lambda.FirewallRuleset, "-"), blank(strings.Join(cfg.Lambda.SSHCIDRs, ","), "-"), blank(strings.Join(cfg.Lambda.FilesystemNames, ","), "-"), len(cfg.Lambda.FilesystemMounts), lambdaAuthState())
-	fmt.Fprintf(w, "vast api_url=%s instance_type=%s gpu_name=%s gpu_count=%d image=%s template_id=%s runtype=%s disk_gb=%d max_dph_total=%.4g min_reliability=%.4g order=%s user=%s work_root=%s release_action=%s auth=%s\n", blank(redactedConfigURLWithoutQuery(cfg.Vast.APIURL), "-"), blank(cfg.Vast.InstanceType, "-"), blank(cfg.Vast.GPUName, "-"), cfg.Vast.GPUCount, blank(cfg.Vast.Image, "-"), blank(cfg.Vast.TemplateID, "-"), blank(cfg.Vast.Runtype, "-"), cfg.Vast.DiskGB, cfg.Vast.MaxDphTotal, cfg.Vast.MinReliability, blank(cfg.Vast.Order, "-"), blank(cfg.Vast.User, "-"), blank(cfg.Vast.WorkRoot, "-"), blank(cfg.Vast.ReleaseAction, "-"), tokenState(cfg.Vast.APIKey))
+	fmt.Fprintf(w, "vast api_url=%s instance_type=%s gpu_name=%s gpu_count=%d image=%s template_id=%s runtype=%s disk_gb=%d max_dph_total=%.4g min_reliability=%.4g order=%s user=%s work_root=%s release_action=%s auth=%s\n", blank(redactedConfigURL(cfg.Vast.APIURL), "-"), blank(cfg.Vast.InstanceType, "-"), blank(cfg.Vast.GPUName, "-"), cfg.Vast.GPUCount, blank(cfg.Vast.Image, "-"), blank(cfg.Vast.TemplateID, "-"), blank(cfg.Vast.Runtype, "-"), cfg.Vast.DiskGB, cfg.Vast.MaxDphTotal, cfg.Vast.MinReliability, blank(cfg.Vast.Order, "-"), blank(cfg.Vast.User, "-"), blank(cfg.Vast.WorkRoot, "-"), blank(cfg.Vast.ReleaseAction, "-"), tokenState(cfg.Vast.APIKey))
 	fmt.Fprintf(w, "nvidia_brev cli=%s org=%s type=%s gpu_name=%s provider=%s mode=%s launchable=%s startup_script=%s release_action=%s target=%s user=%s work_root=%s auth=cli\n", blank(cfg.NvidiaBrev.CLI, "-"), blank(cfg.NvidiaBrev.Org, "-"), blank(cfg.NvidiaBrev.Type, "-"), blank(cfg.NvidiaBrev.GPUName, "-"), blank(cfg.NvidiaBrev.Provider, "-"), blank(cfg.NvidiaBrev.Mode, "-"), blank(cfg.NvidiaBrev.Launchable, "-"), blank(cfg.NvidiaBrev.StartupScript, "-"), blank(cfg.NvidiaBrev.ReleaseAction, "-"), blank(cfg.NvidiaBrev.Target, "-"), blank(cfg.NvidiaBrev.User, "-"), blank(cfg.NvidiaBrev.WorkRoot, "-"))
 	fmt.Fprintf(w, "nebius cli=%s profile=%s parent_id=%s subnet_id=%s platform=%s preset=%s image_family=%s disk_type=%s disk_size_gib=%d user=%s public_ip=%s security_group_ids=%s service_account_id=%s recovery_policy=%s auth=cli\n", blank(cfg.Nebius.CLI, "-"), blank(cfg.Nebius.Profile, "-"), blank(cfg.Nebius.ParentID, "-"), blank(cfg.Nebius.SubnetID, "-"), blank(cfg.Nebius.Platform, "-"), blank(cfg.Nebius.Preset, "-"), blank(cfg.Nebius.ImageFamily, "-"), blank(cfg.Nebius.DiskType, "-"), cfg.Nebius.DiskSizeGiB, blank(cfg.Nebius.User, "-"), blank(cfg.Nebius.PublicIP, "-"), blank(strings.Join(cfg.Nebius.SecurityGroupIDs, ","), "-"), blank(cfg.Nebius.ServiceAccountID, "-"), blank(cfg.Nebius.RecoveryPolicy, "-"))
 	fmt.Fprintf(w, "hostinger api_url=%s item_id=%s payment_method_id=%s template_id=%s data_center_id=%s hostname_prefix=%s user=%s work_root=%s allow_purchase=%t release_action=%s auth=%s\n", blank(redactedConfigURL(cfg.Hostinger.APIURL), "-"), blank(cfg.Hostinger.ItemID, "-"), blank(cfg.Hostinger.PaymentMethodID, "-"), blank(cfg.Hostinger.TemplateID, "-"), blank(cfg.Hostinger.DataCenterID, "-"), blank(cfg.Hostinger.HostnamePrefix, "-"), blank(cfg.Hostinger.User, "-"), blank(cfg.Hostinger.WorkRoot, "-"), cfg.Hostinger.AllowPurchase, blank(cfg.Hostinger.ReleaseAction, "-"), tokenState(cfg.Hostinger.APIToken))
@@ -745,42 +745,6 @@ func redactedConfigURL(value string) string {
 		addedScheme = true
 	}
 	u, err := url.Parse(parseValue)
-	if err != nil {
-		return sanitizedMalformedConfigURL(parseValue, addedScheme)
-	}
-	redacted := *u
-	if redacted.User != nil {
-		redacted.User = url.User("<redacted>")
-	}
-	redacted.RawQuery = ""
-	redacted.ForceQuery = false
-	redacted.Fragment = ""
-	out := strings.ReplaceAll(redacted.String(), "%3Credacted%3E", "<redacted>")
-	if addedScheme {
-		out = strings.TrimPrefix(out, "https://")
-	}
-	return out
-}
-
-func lambdaAuthState() string {
-	if strings.TrimSpace(os.Getenv("LAMBDA_API_KEY")) != "" {
-		return "env"
-	}
-	return "missing"
-}
-
-func redactedConfigURLWithoutQuery(value string) string {
-	raw := strings.TrimSpace(value)
-	if raw == "" {
-		return value
-	}
-	addedScheme := false
-	parseValue := raw
-	if !strings.Contains(parseValue, "://") {
-		parseValue = "https://" + parseValue
-		addedScheme = true
-	}
-	u, err := url.Parse(parseValue)
 	if err != nil || u.Opaque != "" || u.Host == "" {
 		return "<redacted>"
 	}
@@ -795,6 +759,13 @@ func redactedConfigURLWithoutQuery(value string) string {
 		out = strings.TrimPrefix(out, "https://")
 	}
 	return out
+}
+
+func lambdaAuthState() string {
+	if strings.TrimSpace(os.Getenv("LAMBDA_API_KEY")) != "" {
+		return "env"
+	}
+	return "missing"
 }
 
 // sanitizedMalformedConfigURL strips any userinfo from a malformed URL so

--- a/internal/cli/config_cmd_test.go
+++ b/internal/cli/config_cmd_test.go
@@ -421,25 +421,6 @@ cloudflareDynamicWorkers:
 	}
 }
 
-func TestRedactedConfigURLWithoutQueryStripsQueryAndFragmentWithoutUserinfo(t *testing.T) {
-	got := redactedConfigURLWithoutQuery("https://loader.example.test/v1?token=query-secret#fragment-secret")
-	if got != "https://loader.example.test/v1" {
-		t.Fatalf("redacted URL=%q", got)
-	}
-}
-
-func TestRedactedConfigURLWithoutQueryFailsClosedForMalformedURL(t *testing.T) {
-	for _, raw := range []string{
-		"https://loader.example.test/%zz?token=@query-secret",
-		"https://api-token:443#pass@host/%zz",
-	} {
-		got := redactedConfigURLWithoutQuery(raw)
-		if got != "<redacted>" || strings.Contains(got, "query-secret") || strings.Contains(got, "api-token") {
-			t.Fatalf("redacted URL for %q=%q", raw, got)
-		}
-	}
-}
-
 func TestConfigSetBrokerRejectsDirectOnlyProvider(t *testing.T) {
 	clearConfigEnv(t)
 	home := t.TempDir()
@@ -1892,11 +1873,13 @@ func TestConfigShowRedactsSchemeLessXCPNgAPIURLUserinfo(t *testing.T) {
 	}
 }
 
-func TestRedactedConfigURLRedactsUserinfoOnMalformedURL(t *testing.T) {
+func TestRedactedConfigURLFailsClosedForMalformedURL(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		raw  string
 	}{
+		{"query secret in malformed path", "https://loader.example.test/%zz?token=@query-secret"},
+		{"fragment secret in malformed URL", "https://api-token:443#pass@host/%zz"},
 		{"full URL with bad escape in host", "https://pool-user:pool-pass@%zz"},
 		{"full URL with bad escape in path", "https://pool-user:pool-pass@xcp-ng.example.test/%zz"},
 		{"full URL with bad port", "https://pool-user:pool-pass@xcp-ng.example.test:abc"},
@@ -1910,6 +1893,9 @@ func TestRedactedConfigURLRedactsUserinfoOnMalformedURL(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			got := redactedConfigURL(tc.raw)
+			if got != "<redacted>" {
+				t.Fatalf("redacted URL for %q=%q, want <redacted>", tc.raw, got)
+			}
 			for _, secret := range []string{"pool-user", "pool-pass", "pool/pass", "pool?pass", "pool#pass", "pool@pass", "pool-user:pool-pass"} {
 				if strings.Contains(got, secret) {
 					t.Fatalf("redacted URL leaked %q for %q: %s", secret, tc.raw, got)
@@ -1964,6 +1950,7 @@ func TestConfigShowRedactsAllEndpointURLComponents(t *testing.T) {
 	cfg.FastAPICloud.APIURL = rawURL
 	cfg.CloudflareDynamicWorkers.LoaderURL = rawURL
 	cfg.CloudflareSandbox.BridgeURL = rawURL
+	cfg.Nomad.Address = rawURL
 	cfg.Vast.APIURL = rawURL
 	cfg.Hostinger.APIURL = rawURL
 	cfg.OVH.Endpoint = rawURL

--- a/internal/cli/config_cmd_test.go
+++ b/internal/cli/config_cmd_test.go
@@ -365,6 +365,36 @@ func TestConfigShowExportsControllerProviderContract(t *testing.T) {
 	}
 }
 
+func TestConfigShowExportsRawControllerProviderIdentityContract(t *testing.T) {
+	clearConfigEnv(t)
+	home := t.TempDir()
+	configPath := filepath.Join(home, "config.yaml")
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("CRABBOX_CONFIG", configPath)
+	config := "provider: external\nbroker:\n  url: https://broker-user:broker-pass@broker.example.test/root/?token=query-secret#fragment-secret\n  mode: registered\nexternal:\n  command: provider-a\n  capabilities:\n    idempotentLeaseId: true\n"
+	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := App{Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	if err := app.configShow([]string{"--json", "--controller-provider-identity", "--provider", "external"}); err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 4 || got["provider"] != "external" || got["providerScope"] != "test-external:provider-a" || got["idempotentLeaseId"] != true || got["coordinatorRegistrationUrl"] != "https://broker-user:broker-pass@broker.example.test/root?token=query-secret#fragment-secret" {
+		t.Fatalf("controller provider identity contract=%#v", got)
+	}
+	stdout.Reset()
+	if err := app.configShow([]string{"--controller-provider-identity", "--provider", "external"}); err == nil || !strings.Contains(err.Error(), "requires --json") {
+		t.Fatalf("controller provider identity without JSON error=%v", err)
+	}
+}
+
 func TestConfigShowRedactsCloudflareDynamicWorkers(t *testing.T) {
 	clearConfigEnv(t)
 	home := t.TempDir()

--- a/internal/cli/controller_subprocess.go
+++ b/internal/cli/controller_subprocess.go
@@ -55,7 +55,7 @@ type controllerChildIdentity struct {
 func (r *execControllerWorkspaceRunner) ProviderIdentity(ctx context.Context) (controllerProviderIdentity, error) {
 	var output controllerLimitedBuffer
 	output.limit = 1 << 20
-	args := []string{"config", "show", "--json"}
+	args := []string{"config", "show", "--json", "--controller-provider-identity"}
 	if provider := strings.TrimSpace(r.opts.Provider); provider != "" {
 		args = append(args, "--provider", provider)
 	}

--- a/internal/cli/controller_subprocess_test.go
+++ b/internal/cli/controller_subprocess_test.go
@@ -71,7 +71,7 @@ func TestControllerWarmupArgsUseFixedRoutingAndCapabilities(t *testing.T) {
 
 func TestExecControllerRunnerReadsProviderIdentityContract(t *testing.T) {
 	binary := filepath.Join(t.TempDir(), "crabbox")
-	script := "#!/bin/sh\nprintf '%s\\n' '{\"provider\":\"external\",\"providerScope\":\"opaque-scope\",\"idempotentLeaseId\":true,\"coordinatorRegistrationUrl\":\"https://coordinator.example.test/root\"}'\n"
+	script := "#!/bin/sh\ncase \" $* \" in *\" --json \"*) ;; *) exit 42 ;; esac\ncase \" $* \" in *\" --controller-provider-identity \"*) ;; *) exit 42 ;; esac\nprintf '%s\\n' '{\"provider\":\"external\",\"providerScope\":\"opaque-scope\",\"idempotentLeaseId\":true,\"coordinatorRegistrationUrl\":\"https://coordinator.example.test/root\"}'\n"
 	if err := os.WriteFile(binary, []byte(script), 0o700); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary

- preserve the exact credential-bearing coordinator registration binding for controller subprocess lifecycle checks after https://github.com/openclaw/crabbox/pull/821
- keep public `config show` text and JSON fully redacted by moving the raw binding into a dedicated four-field internal contract
- consolidate duplicate endpoint URL display sanitizers, fail closed for malformed URLs, and cover the previously missing Nomad address

Follow-up to https://github.com/openclaw/crabbox/pull/821 and https://github.com/openclaw/crabbox/issues/799.

## Why this is needed

The merged PR correctly redacts `coordinatorRegistrationUrl` in public JSON diagnostics, but that field was also consumed by `execControllerWorkspaceRunner.ProviderIdentity`. A credential-bearing broker URL therefore no longer matched the canonical lifecycle binding. This repair separates the internal machine contract from public diagnostics instead of weakening redaction.

## Live proof

An exact-head `bin/crabbox` build consumed a disposable stdin config whose registered broker URL and 20 endpoint fields carried non-secret userinfo/query/fragment sentinels:

```text
live_config_show_passed endpoints=20 public_secret_scan=clean malformed=redacted internal_binding=canonical
{
  "coordinatorRegistrationUrl": "https://<redacted>@broker.example.test/root",
  "coordinator": "https://<redacted>@broker.example.test/root/",
  "morph": "https://<redacted>@api.example.test/v1",
  "nomad": "https://<redacted>@api.example.test/v1",
  "cloudflareDynamicWorkers": "https://<redacted>@api.example.test/v1",
  "xcpNg": "https://<redacted>@api.example.test/v1"
}
```

The internal controller identity output contained only its four contract fields and retained the exact canonical registration URL; that raw value was asserted in-process and not printed.

## Verification

- focused config/controller regression suite under `go test -race`
- `go test -race ./...`
- `go vet ./...`
- `deadcode -test ./...`
- `scripts/check-docs.sh`
- `git diff --check origin/main...HEAD`
- structured autoreview found the controller-binding P1 on the original branch; the focused rerun after this repair returned no accepted/actionable findings

No provider credentials or funded resources are needed: this is a local config-diagnostic and subprocess-contract path, exercised end to end through the built CLI.
