### PR TITLE
test: remove AgentSandbox wall-clock flake

### DIFF
--- a/internal/providers/agentsandbox/backend_test.go
+++ b/internal/providers/agentsandbox/backend_test.go
@@ -131,13 +131,9 @@ func TestWarmupReturnsDefinitiveCreateFailureWithoutReconciliation(t *testing.T)
 	fake.createErrs = []error{&kubernetesCreateError{err: errors.New("forbidden"), ambiguous: false}}
 	backend := testBackend(cfg, fake, nil, nil)
 
-	start := time.Now()
 	err := backend.Warmup(context.Background(), WarmupRequest{Repo: testGitRepo(t), RequestedSlug: "rejected-create"})
 	if err == nil || !strings.Contains(err.Error(), "forbidden") {
 		t.Fatalf("warmup err=%v", err)
-	}
-	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
-		t.Fatalf("definitive create failure entered reconciliation: %s", elapsed)
 	}
 	if len(fake.gets) != 0 {
 		t.Fatalf("definitive create failure performed reconciliation GETs: %#v", fake.gets)


### PR DESCRIPTION
## Summary

- Remove the load-sensitive 500 ms wall-clock assertion from the definitive AgentSandbox create-failure test.
- Keep the direct behavioral assertion that definitive failures perform zero reconciliation GETs.

The timing check flaked twice under the full race suite even though the fake client recorded no reconciliation calls. The zero-GET assertion is both stronger and deterministic.

## Verification

Exact candidate: `6bc28d0a19733a97b253b26a4474bb45a28c5397`

- `go test -race ./internal/providers/agentsandbox -run '^TestWarmupReturnsDefinitiveCreateFailureWithoutReconciliation$' -count=100`
  - observed: `ok github.com/openclaw/crabbox/internal/providers/agentsandbox 9.605s`
- `go test -race ./internal/providers/agentsandbox -count=1`
  - observed: `ok github.com/openclaw/crabbox/internal/providers/agentsandbox 16.748s`
- Autoreview clean
- `git diff --check`

No changelog: test-only reliability fix; production behavior unchanged.
