### PR TITLE
fix: enforce key-only managed Windows SSH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- Enforced key-only OpenSSH authentication across managed Windows desktop, core, and WSL2 bootstraps while retaining generated Windows passwords for console and VNC use. Thanks @coygeek.
 - Compared coordinator admin, shared-operator, runtime-adapter, proxy, and signed-session secrets without mismatch-position or early length exits. Thanks @coygeek.
 - Prevented direct Azure list, stop, and cleanup paths from treating weak `crabbox=true` tags as ownership; destructive operations now require canonical Azure ownership tags and an exact matching lease ID, and successful deletion removes local lease keys. Thanks @coygeek.
 - Restricted brokered Azure image and OS-disk selectors to admin-authenticated requests while preserving user-selectable Azure placement. Thanks @coygeek.

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -238,16 +238,14 @@ foreach ($line in ($sshdConfig -split "\r?\n")) {
   if (-not $inMatch -and $line -match '^\s*Port\s+\d+\s*$') { continue }
   if (-not $inMatch -and $line -match '^\s*Subsystem\s+sftp\s+') { continue }
   if (-not $inMatch -and $line -match '^\s*HostKey\s+') { continue }
-  if ($enforceKeyAuth -and -not $inMatch -and $line -match '^\s*(PasswordAuthentication|PubkeyAuthentication)\s+') { continue }
+  if (-not $inMatch -and $line -match '^\s*(PasswordAuthentication|PubkeyAuthentication)\s+') { continue }
   if ($inMatch) { $matchLines += $line } else { $globalLines += $line }
 }
 foreach ($port in $sshPorts) { $globalLines += "Port $port" }
 $globalLines += "Subsystem sftp internal-sftp"
 $globalLines += "HostKey __PROGRAMDATA__/ssh/ssh_host_ed25519_key"
-if ($enforceKeyAuth) {
-  $globalLines += "PubkeyAuthentication yes"
-  $globalLines += "PasswordAuthentication no"
-}
+$globalLines += "PubkeyAuthentication yes"
+$globalLines += "PasswordAuthentication no"
 if (($matchLines -join [Environment]::NewLine) -notmatch '(?im)^\s*Match\s+Group\s+administrators\b') {
   $matchLines += "Match Group administrators"
   $matchLines += "       AuthorizedKeysFile __PROGRAMDATA__/ssh/administrators_authorized_keys"
@@ -327,7 +325,6 @@ func windowsManagedCorePreludePowerShell(cfg Config) string {
 	$passwordPath = $vncPasswordPath
 	$usernamePath = $windowsUsernamePath
 	$passwordMirrorPath = $windowsPasswordPath
-	$enforceKeyAuth = $false
 	$tightVNCInstaller = "$env:TEMP\tightvnc-2.8.85-gpl-setup-64bit.msi"
 	`
 	}
@@ -337,7 +334,6 @@ func windowsManagedCorePreludePowerShell(cfg Config) string {
 	$passwordPath = $windowsPasswordPath
 	$usernamePath = $windowsUsernamePath
 	$passwordMirrorPath = $null
-	$enforceKeyAuth = $false
 	`
 }
 
@@ -582,7 +578,6 @@ func azureWindowsBootstrapPowerShell(cfg Config, publicKey string) string {
 $passwordPath = Join-Path $base "windows.password"
 $usernamePath = Join-Path $base "windows.username"
 $passwordMirrorPath = $null
-$enforceKeyAuth = $true
 ` + windowsBootstrapCorePowerShell() + `
 git --version | Out-Null
 tar --version | Out-Null

--- a/internal/cli/bootstrap_test.go
+++ b/internal/cli/bootstrap_test.go
@@ -566,6 +566,8 @@ func TestAWSUserDataWindowsProfile(t *testing.T) {
 		"Match Group administrators",
 		"Subsystem sftp internal-sftp",
 		"HostKey __PROGRAMDATA__/ssh/ssh_host_ed25519_key",
+		"PubkeyAuthentication yes",
+		"PasswordAuthentication no",
 		`$openSSHSystemRoot = Join-Path $env:WINDIR "System32\OpenSSH"`,
 		"function Resolve-CrabboxOpenSSHCommand",
 		`$sshKeygen = Resolve-CrabboxOpenSSHCommand "ssh-keygen.exe"`,
@@ -651,6 +653,8 @@ func TestAWSUserDataWindowsCoreProfileSkipsDesktop(t *testing.T) {
 		gitForWindowsSetupSHA256,
 		"$passwordPath = $windowsPasswordPath",
 		"$credentialPaths = @($passwordPath)",
+		"PubkeyAuthentication yes",
+		"PasswordAuthentication no",
 		`icacls.exe $credentialPath /inheritance:r /grant "*${userSID}:F" /grant "*S-1-5-32-544:F" /grant "*S-1-5-18:F"`,
 		"Restart-Service sshd -Force",
 		"Set-Content -NoNewline -Encoding ASCII -Path $setupCompletePath",
@@ -719,6 +723,8 @@ func TestAWSUserDataWindowsWSL2Profile(t *testing.T) {
 		"cat >/usr/local/bin/crabbox-ready",
 		`wslpath -w '/work/crabbox'`,
 		`test -w '/work/crabbox'`,
+		"PubkeyAuthentication yes",
+		"PasswordAuthentication no",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("windows WSL2 bootstrap missing %q", want)

--- a/worker/src/bootstrap.ts
+++ b/worker/src/bootstrap.ts
@@ -246,16 +246,14 @@ foreach ($line in ($sshdConfig -split "\\r?\\n")) {
   if (-not $inMatch -and $line -match '^\\s*Port\\s+\\d+\\s*$') { continue }
   if (-not $inMatch -and $line -match '^\\s*Subsystem\\s+sftp\\s+') { continue }
   if (-not $inMatch -and $line -match '^\\s*HostKey\\s+') { continue }
-  if ($enforceKeyAuth -and -not $inMatch -and $line -match '^\\s*(PasswordAuthentication|PubkeyAuthentication)\\s+') { continue }
+  if (-not $inMatch -and $line -match '^\\s*(PasswordAuthentication|PubkeyAuthentication)\\s+') { continue }
   if ($inMatch) { $matchLines += $line } else { $globalLines += $line }
 }
 foreach ($port in $sshPorts) { $globalLines += "Port $port" }
 $globalLines += "Subsystem sftp internal-sftp"
 $globalLines += "HostKey __PROGRAMDATA__/ssh/ssh_host_ed25519_key"
-if ($enforceKeyAuth) {
-  $globalLines += "PubkeyAuthentication yes"
-  $globalLines += "PasswordAuthentication no"
-}
+$globalLines += "PubkeyAuthentication yes"
+$globalLines += "PasswordAuthentication no"
 if (($matchLines -join [Environment]::NewLine) -notmatch '(?im)^\\s*Match\\s+Group\\s+administrators\\b') {
   $matchLines += "Match Group administrators"
   $matchLines += "       AuthorizedKeysFile __PROGRAMDATA__/ssh/administrators_authorized_keys"
@@ -329,7 +327,6 @@ function windowsManagedCorePreludePowerShell(config: LeaseConfig): string {
 	$passwordPath = $vncPasswordPath
 	$usernamePath = $windowsUsernamePath
 	$passwordMirrorPath = $windowsPasswordPath
-	$enforceKeyAuth = $false
 	$tightVNCInstaller = "$env:TEMP\\tightvnc-2.8.85-gpl-setup-64bit.msi"
 	`;
   }
@@ -339,7 +336,6 @@ function windowsManagedCorePreludePowerShell(config: LeaseConfig): string {
 	$passwordPath = $windowsPasswordPath
 	$usernamePath = $windowsUsernamePath
 	$passwordMirrorPath = $null
-	$enforceKeyAuth = $false
 	`;
 }
 
@@ -538,7 +534,6 @@ export function azureWindowsBootstrapPowerShell(config: LeaseConfig): string {
 $passwordPath = Join-Path $base "windows.password"
 $usernamePath = Join-Path $base "windows.username"
 $passwordMirrorPath = $null
-$enforceKeyAuth = $true
 ` +
     windowsBootstrapCorePowerShell() +
     `

--- a/worker/test/bootstrap.test.ts
+++ b/worker/test/bootstrap.test.ts
@@ -503,6 +503,8 @@ describe("cloud-init bootstrap", () => {
     expect(got).toContain("Port $port");
     expect(got).toContain("Subsystem sftp internal-sftp");
     expect(got).toContain("HostKey __PROGRAMDATA__/ssh/ssh_host_ed25519_key");
+    expect(got).toContain("PubkeyAuthentication yes");
+    expect(got).toContain("PasswordAuthentication no");
     expect(got).toContain('Start-Process -FilePath "C:\\Program Files\\OpenSSH\\ssh-keygen.exe"');
     expect(got).toContain('-q -t ed25519 -N "" -f "');
     expect(got).toContain("$hostKey + '\"'");
@@ -573,6 +575,8 @@ describe("cloud-init bootstrap", () => {
     expect(got).toContain("d8de7a3152266c8bb13577eab850ea1df6dccf8c2aa48be5b4a1c58b7190d62c");
     expect(got).toContain("$passwordPath = $windowsPasswordPath");
     expect(got).toContain("$credentialPaths = @($passwordPath)");
+    expect(got).toContain("PubkeyAuthentication yes");
+    expect(got).toContain("PasswordAuthentication no");
     expect(got).toContain(
       'icacls.exe $credentialPath /inheritance:r /grant "*${userSID}:F" /grant "*S-1-5-32-544:F" /grant "*S-1-5-18:F"',
     );
@@ -625,6 +629,8 @@ describe("cloud-init bootstrap", () => {
     expect(got).toContain(":WSLInterop:M::MZ::/init:PF");
     expect(got).toContain("test -e /proc/sys/fs/binfmt_misc/WSLInterop");
     expect(got).toContain("test -w '/work/crabbox'");
+    expect(got).toContain("PubkeyAuthentication yes");
+    expect(got).toContain("PasswordAuthentication no");
     expect(got.lastIndexOf("Assert-CrabboxFileSHA256 $wslRootfs")).toBeLessThan(
       got.indexOf("wsl.exe --import $wslDistro"),
     );


### PR DESCRIPTION
## Summary

- make key-only OpenSSH authentication unconditional in the shared managed Windows bootstrap
- remove the weaker `enforceKeyAuth` branch from both Go and Worker generators
- preserve generated Windows passwords for local console and VNC use without allowing SSH password login
- cover native desktop, native core, WSL2, and Azure-generated PowerShell

Closes https://github.com/openclaw/crabbox/issues/835

## Verification

- `go test -race ./internal/cli -run 'TestAWSUserDataWindows(Profile|CoreProfileSkipsDesktop|WSL2Profile)|TestAzureWindows' -count=1`
- `npm test --prefix worker -- bootstrap.test.ts` — 17 tests passed
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker` — 26 files, 777 tests passed
- `npm run build --prefix worker`
- `go vet ./...`
- `scripts/check-docs.sh` — 52 command docs, 71 providers, 205 Markdown files, generated docs site
- security autoreview reported no actionable findings

The broad local `go test -race ./...` run reached unrelated existing timing failures in controller, history, and Tart tests, then the `internal/cli` package timeout. The exact changed Go scope is race-clean; exact-head CI provides the isolated full-suite gate.

## Security impact

Generated `sshd_config` now removes any pre-existing global `PasswordAuthentication` or `PubkeyAuthentication` directive and always appends:

```text
PubkeyAuthentication yes
PasswordAuthentication no
```

This restores the documented per-lease key-only SSH boundary without changing Windows desktop or VNC credentials.

## Live AWS Windows proof

Built the CLI from exact commit `52d187a54e54c0f651f7c7cb85ee2fed0c8c5361`, then created a disposable brokered AWS Windows `m7i.large` lease. The branch bootstrap completed over SSH, moved the managed connection to port 2222, and the live OpenSSH effective configuration reported:

```text
pubkeyauthentication yes
passwordauthentication no
```

The exact lease was deleted after inspection and its coordinator state was verified as `released`. Provider, lease, host, and server identifiers are omitted from the public proof.
