### PR TITLE
fix(worker): fail closed restored WebVNC principals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- Closed restored WebVNC viewer sockets that lack a complete current organization-bound principal instead of retaining owner-only legacy authorization. Thanks @coygeek.
 - Enforced key-only OpenSSH authentication across managed Windows desktop, core, and WSL2 bootstraps while retaining generated Windows passwords for console and VNC use. Thanks @coygeek.
 - Compared coordinator admin, shared-operator, runtime-adapter, proxy, and signed-session secrets without mismatch-position or early length exits. Thanks @coygeek.
 - Prevented direct Azure list, stop, and cleanup paths from treating weak `crabbox=true` tags as ownership; destructive operations now require canonical Azure ownership tags and an exact matching lease ID, and successful deletion removes local lease keys. Thanks @coygeek.

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -4963,26 +4963,10 @@ export class FleetCoordinator {
     lease: LeaseRecord,
     principal: { owner?: string; org?: string; admin?: boolean },
   ): boolean {
-    if (principal.admin === true) {
-      return true;
-    }
-    if (principal.owner && principal.org) {
-      return (
-        this.leaseAccessRoleForPrincipal(lease, {
-          owner: principal.owner,
-          org: principal.org,
-          admin: false,
-        }) !== undefined
-      );
-    }
-    if (!principal.owner) {
+    if (!completeBridgePrincipal(principal)) {
       return false;
     }
-    // Restored pre-hardening WebVNC attachments have no org binding.
-    return (
-      principal.owner === lease.owner ||
-      normalizedLeaseShare(lease.share).users[normalizeShareUser(principal.owner)] !== undefined
-    );
+    return this.leaseAccessRoleForPrincipal(lease, principal) !== undefined;
   }
 
   private whoami(request: Request): Response {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -448,6 +448,22 @@ describe("runtime adapter relay", () => {
       id: "viewer_retained",
       agentID: "agent_retained",
       owner: "owner@example.com",
+      org: "example-org",
+      admin: false,
+      label: "owner@example.com",
+    });
+    const legacyOwnerWebAgent = new FakeWebSocket({
+      kind: "webvnc-agent",
+      leaseID: lease.id,
+      id: "agent_legacy_owner",
+      capabilities: new Set<string>(),
+    });
+    const legacyOwnerWebViewer = new FakeWebSocket({
+      kind: "webvnc-viewer",
+      leaseID: lease.id,
+      id: "viewer_legacy_owner",
+      agentID: "agent_legacy_owner",
+      owner: "owner@example.com",
       label: "owner@example.com",
     });
     const fleet = new FleetDurableObject(
@@ -462,6 +478,8 @@ describe("runtime adapter relay", () => {
             revokedWebViewer,
             retainedWebAgent,
             retainedWebViewer,
+            legacyOwnerWebAgent,
+            legacyOwnerWebViewer,
           ] as unknown as WebSocket[],
       } as unknown as DurableObjectState,
       { CRABBOX_DEFAULT_ORG: "default-org" } as Env,
@@ -476,6 +494,9 @@ describe("runtime adapter relay", () => {
     expect(revokedWebAgent.closeCode).toBe(1011);
     expect(retainedWebViewer.closeCode).toBeUndefined();
     expect(retainedWebAgent.closeCode).toBeUndefined();
+    expect(legacyOwnerWebViewer.closeCode).toBe(1008);
+    expect(legacyOwnerWebViewer.closeReason).toBe("lease access revoked");
+    expect(legacyOwnerWebAgent.closeCode).toBe(1011);
     expect(codeAgent.sentJSON()).toEqual([
       {
         type: "ws_close",


### PR DESCRIPTION
## Summary

- remove the owner-only compatibility authorization for restored WebVNC viewers
- require every viewer principal to carry complete owner, organization, and admin state before role resolution
- close a same-owner legacy socket that cannot prove its current organization while retaining a complete current owner principal

Closes https://github.com/openclaw/crabbox/issues/827

## Verification

- `npm test --prefix worker -- fleet.test.ts` — 359 tests passed
- `npm test --prefix worker` — 26 files, 777 tests passed
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm run build --prefix worker`
- security autoreview reported no actionable findings

The focused Durable Object restore harness seeds a live lease plus hibernated WebVNC agent/viewer sockets. A legacy viewer with the exact current owner but no organization is closed with code 1008 (`lease access revoked`) and its agent is torn down; a complete matching owner/org/admin attachment remains connected.

## Compatibility

Current WebVNC viewer creation already persists owner, organization, and admin state. This intentionally drops only the pre-hardening restored-session fallback; affected viewers reconnect through the current ticket/session flow instead of retaining unprovable authorization.
