### PR TITLE
feat: add crabbox shard for parallel checkpoint fan-out with a merged suite verdict

### DIFF
--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -17,6 +17,7 @@ same order as the CLI help.
 - [prewarm](prewarm.md)
 - [run](run.md)
 - [watch](watch.md)
+- [shard](shard.md)
 - [bench](bench.md)
 - [job](job.md)
 - [desktop](desktop.md)

--- a/docs/commands/checkpoint.md
+++ b/docs/commands/checkpoint.md
@@ -264,7 +264,9 @@ crabbox checkpoint fork --provider parallels --parallels-template ubuntu-fast --
 - *Command fan-out:* arguments after `--` run through `crabbox run --id <lease>`
   on each fork, so normal sync, command wrapping, history, and proof behavior are
   preserved. Use `{{index}}`, `{{total}}`, `{{lease}}`, and `{{slug}}` in command
-  arguments to specialize each fork.
+  arguments to specialize each fork. Forks and their commands run one after
+  another; for concurrent shards with one merged test verdict, use
+  [`crabbox shard`](shard.md).
 
 Fork multiple times to run scenarios in parallel:
 

--- a/docs/commands/shard.md
+++ b/docs/commands/shard.md
@@ -68,12 +68,14 @@ SHARD  LEASE          RUN         EXIT  TESTS  FAIL  ERR  SKIP  TIME
 3/3    cbx_g7h8i9     run_t3s2r1  0     121    0     0    1     40.9s
 shard verdict shards=3 failed_shards=0 tests=359 failures=1 errors=0 skipped=3 suite_time=125.9s wall=52.4s
 failed:
-  [2/3]  src/cart.test.ts failure  CartSuite.applies coupon — expected 3 got 2
+  [2/3] run=run_w6v5u4  src/cart.test.ts failure  CartSuite.applies coupon — expected 3 got 2
 ```
 
-The exit code aggregates across shards: if any shard's command exits non-zero,
-shard exits with that code (or `1` when failing shards disagree); shards that
-fail to provision or run exit `7`; and `--fail-on-test-failures` keeps its
+The exit code aggregates across shards: shards that fail to provision or run
+exit `7`, and that takes precedence over everything else because the verdict
+is incomplete; otherwise, if any shard's command exits non-zero, shard exits
+with that code (or `1` when failing shards disagree); and
+`--fail-on-test-failures` keeps its
 documented meaning evaluated against the merged summary, exiting `1` when the
 merged results contain failures or errors even though every command exited
 zero. Inside each shard the flag is forced off so the policy is applied once,

--- a/docs/commands/shard.md
+++ b/docs/commands/shard.md
@@ -1,0 +1,131 @@
+# shard
+
+`crabbox shard` forks a [checkpoint](checkpoint.md) into `--count` leases
+concurrently, runs the command on every fork in parallel through the normal
+[`crabbox run`](run.md) pipeline, and merges the collected JUnit results into
+one suite verdict. It is the parallel counterpart of
+[`checkpoint fork --count`](checkpoint.md): the same fork flow and
+`{{index}}`/`{{total}}`/`{{lease}}`/`{{slug}}` placeholders, but shards run at
+the same time and their [test results](../features/test-results.md) fold into
+a single answer with one aggregate exit code.
+
+```sh
+crabbox shard --count 8 --from chk_abc123 --results-auto -- pnpm test -- --shard '{{index}}/{{total}}'
+crabbox shard --count 4 --from chk_deps --junit junit.xml --fail-on-test-failures -- go test ./...
+crabbox shard --count 3 --from chk_abc123 --fail-fast --quiet -- pnpm vitest --shard '{{index}}/{{total}}'
+```
+
+The command template owns the sharding: crabbox never splits tests itself.
+`--count` is always explicit, the plan is printed before any lease is
+provisioned, and a repo config cap (`shard.maxCount`) bounds what a checkout
+may request. Requires an SSH lease provider that supports checkpoint fork;
+delegated providers are rejected. Provider-native snapshot fan-out stays on
+[`checkpoint fork --snapshot`](checkpoint.md).
+
+## Lease lifecycle
+
+Every shard forks its own lease from the checkpoint and runs with an injected
+`--id`, so sync, history, logs, artifacts, and results behave exactly as for
+`run`. Forks exist only for the duration of their shard: each lease is
+released when its shard finishes, on failure, and on Ctrl-C, always with a
+fresh context so cleanup survives cancellation. A shard that fails to
+provision does not orphan its siblings; the others run to completion and
+release normally. Pass `--keep` to retain all forked leases instead.
+
+## Streaming
+
+All shards stream live. Every line is prefixed with a stable shard marker so
+interleaved output stays readable:
+
+```text
+[3/8] running on cbx_a1b2c3 ...
+[3/8] ✓ auth.test.ts (14 tests)
+[1/8] ✓ cart.test.ts (9 tests)
+```
+
+`--quiet` suppresses the passthrough streams and keeps only the per-shard
+lifecycle lines (`shard 3/8 provisioned ...`, `shard 3/8 done exit=0 ...`),
+which are printed to stderr in both modes.
+
+## Merged results and exit codes
+
+A failing shard never aborts the others: the default is a complete verdict
+over the whole suite. `--fail-fast` opts into canceling the remaining shards
+after the first failure.
+
+With results wiring configured (`--junit`, `--results-auto`, or the repo
+`results` config), each shard's JUnit XML is parsed through the existing
+results pipeline and the per-shard summaries merge into one verdict: a
+per-shard table, merged totals with suite time versus wall clock, and every
+failed case with its shard index and run id. `--json` emits the same report as
+JSON.
+
+```text
+shard results
+SHARD  LEASE          RUN         EXIT  TESTS  FAIL  ERR  SKIP  TIME
+1/3    cbx_a1b2c3     run_x9y8z7  0     120    0     0    2     41.2s
+2/3    cbx_d4e5f6     run_w6v5u4  0     118    1     0    0     43.8s
+3/3    cbx_g7h8i9     run_t3s2r1  0     121    0     0    1     40.9s
+shard verdict shards=3 failed_shards=0 tests=359 failures=1 errors=0 skipped=3 suite_time=125.9s wall=52.4s
+failed:
+  [2/3]  src/cart.test.ts failure  CartSuite.applies coupon — expected 3 got 2
+```
+
+The exit code aggregates across shards: if any shard's command exits non-zero,
+shard exits with that code (or `1` when failing shards disagree); shards that
+fail to provision or run exit `7`; and `--fail-on-test-failures` keeps its
+documented meaning evaluated against the merged summary, exiting `1` when the
+merged results contain failures or errors even though every command exited
+zero. Inside each shard the flag is forced off so the policy is applied once,
+to the whole suite. Interrupting the command cancels the in-flight shards:
+they are reported as `canceled`, not failed, and a pure interrupt exits `130`.
+Under `--fail-fast` only the shard that actually failed counts toward the
+verdict; the canceled siblings are tallied separately.
+
+## Flags
+
+```text
+--count <n>              Number of parallel shards to run; required, no default.
+--from <checkpoint-id>   Checkpoint to fork each shard from; required.
+--fail-fast              Cancel remaining shards after the first failing shard.
+--keep                   Keep forked leases after their shard finishes.
+--quiet                  Suppress shard output streams; keep per-shard status lines.
+--json                   Print the merged verdict as JSON.
+--dry-run                Show the shard plan without provisioning.
+--fail-on-test-failures  Exit non-zero when the merged JUnit results contain
+                         failures or errors.
+```
+
+Lease-creation flags (`--provider`, `--class`, `--ttl`, `--slug`, ...) apply
+to every fork; `--slug` gets stable numeric suffixes exactly as
+`checkpoint fork --count` does. Restore flags (`--workdir`, `--clear`,
+`--reclaim`) match `checkpoint fork`. Most other `run` flags, such as
+`--junit`, `--results-auto`, `--shell`, `--allow-env`, or `--preset`, pass
+through to every shard's run. Flags that conflict with parallel shard runs are
+rejected: `--id`, `--pool`, `--pool-return`, `--sync-only`, `--no-sync`,
+`--apply-local-patch`, `--fresh-pr`, `--script`, `--script-stdin`,
+`--stop-after`, `--lease-output`, `--keep-on-failure`, `--capture-stdout`,
+`--capture-stderr`, `--download`, `--emit-proof`, `--proof-template`,
+`--timing-json`, and `--timing-record`. `--label` is reserved: shard labels
+each run `shard N/M` so runs stay readable in [`history`](history.md).
+
+## Limits
+
+- No automatic test splitting: the command template distributes work via
+  `{{index}}`/`{{total}}`, exactly as the runner's own sharding flag expects.
+- `shard.maxCount` in repo config bounds `--count`:
+
+  ```yaml
+  shard:
+    maxCount: 8
+  ```
+
+- The merged verdict is printed locally; each shard's run record keeps its own
+  JUnit summary on the coordinator, readable via [`results`](results.md).
+
+## Related docs
+
+- [checkpoint](checkpoint.md) — create checkpoints and serial fork fan-out.
+- [run](run.md) — the pipeline each shard executes.
+- [results](results.md) — per-run recorded test results.
+- [Test results](../features/test-results.md) — JUnit collection and storage.

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -13,6 +13,8 @@ type App struct {
 	Stdout io.Writer
 	Stderr io.Writer
 	Stdin  io.Reader
+
+	runOutcome *shardRunOutcome
 }
 
 func Run(ctx context.Context, args []string) error {
@@ -79,6 +81,8 @@ func (a App) directCommandHelp(ctx context.Context, args []string) (error, bool)
 		return a.runCommand(ctx, helpArgs), true
 	case "watch":
 		return a.watch(ctx, helpArgs), true
+	case "shard":
+		return a.shard(ctx, helpArgs), true
 	case "job":
 		return nil, false
 	case "sync-plan":
@@ -177,6 +181,7 @@ Commands:
   prewarm     Lease and hydrate a reusable test-ready box
   run         Sync the repo, run a remote command, stream output
   watch       Re-run a command on a warm lease when local files change
+  shard       Fork a checkpoint into parallel shards and merge their test results
   bench       Record and report local benchmark timings
   job         Run named repo-local Crabbox jobs
   desktop     Launch apps into a visible desktop session

--- a/internal/cli/checkpoint.go
+++ b/internal/cli/checkpoint.go
@@ -14,6 +14,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -823,70 +824,87 @@ func checkpointForkFanoutSlug(requestedSlug string, index, total int) string {
 	return base + suffix
 }
 
-func (a App) checkpointForkRecordOnce(ctx context.Context, cfg Config, backend Backend, sshBackend SSHLeaseBackend, repo Repo, record checkpointRecord, paths checkpointPaths, keep, reclaim bool, requestedSlug, workdirOverride string, clear bool, runOpts checkpointForkRunOptions) (err error) {
+type checkpointForkProvision struct {
+	Lease   LeaseTarget
+	Workdir string
+	Release func(context.Context)
+}
+
+func (a App) provisionCheckpointFork(ctx context.Context, cfg Config, backend Backend, sshBackend SSHLeaseBackend, repo Repo, record checkpointRecord, paths checkpointPaths, keep, reclaim bool, requestedSlug, workdirOverride string, clear bool) (checkpointForkProvision, error) {
 	lease, err := sshBackend.Acquire(ctx, AcquireRequest{Repo: repo, Options: leaseOptionsFromConfig(cfg), Keep: keep, Reclaim: reclaim, RequestedSlug: requestedSlug})
 	if err != nil {
-		return err
+		return checkpointForkProvision{}, err
 	}
 	server, target, leaseID := lease.Server, lease.SSH, lease.LeaseID
-	released := false
+	var releaseOnce sync.Once
 	release := func(releaseCtx context.Context) {
-		if released {
-			return
-		}
-		released = true
-		a.releaseBackendLeaseBestEffort(releaseCtx, sshBackend, cfg, LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: lease.Coordinator})
+		releaseOnce.Do(func() {
+			a.releaseBackendLeaseBestEffort(releaseCtx, sshBackend, cfg, LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: lease.Coordinator})
+		})
 	}
-	defer func() {
-		if !keep {
-			release(context.Background())
-		}
-	}()
 	applyResolvedServerConfig(&cfg, server)
 	if err := a.claimLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, server, target, repo.Root, reclaim); err != nil {
 		release(ctx)
-		return err
+		return checkpointForkProvision{}, err
 	}
 	if resolved, err := resolveNetworkTarget(ctx, cfg, server, target); err != nil {
 		release(ctx)
-		return err
+		return checkpointForkProvision{}, err
 	} else {
 		target = resolved.Target
 		if resolved.FallbackReason != "" {
 			fmt.Fprintf(a.Stderr, "network fallback %s\n", resolved.FallbackReason)
 		}
 	}
+	forkLease := LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: lease.Coordinator}
 	if isNativeCheckpointKind(record.Kind) {
 		if record.TargetOS == targetWindows {
-			fmt.Fprintf(a.Stdout, "checkpoint forked id=%s lease=%s slug=%s image=%s workdir=-\n", record.ID, leaseID, blank(serverSlug(server), "-"), nativeCheckpointResourceID(record))
-			return a.runCheckpointForkCommand(ctx, leaseID, serverSlug(server), runOpts)
+			return checkpointForkProvision{Lease: forkLease, Release: release}, nil
 		}
 		workdir := nativeCheckpointForkWorkdir(cfg, leaseID, repo.Name, workdirOverride)
-		if err := validateCheckpointForkWorkdirs(ctx, backend, LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: lease.Coordinator}, record.Workdir, workdir); err != nil {
+		if err := validateCheckpointForkWorkdirs(ctx, backend, forkLease, record.Workdir, workdir); err != nil {
 			release(ctx)
-			return err
+			return checkpointForkProvision{}, err
 		}
 		if err := relocateNativeCheckpointWorkdir(ctx, target, record.Workdir, workdir); err != nil {
 			release(ctx)
-			return err
+			return checkpointForkProvision{}, err
 		}
-		fmt.Fprintf(a.Stdout, "checkpoint forked id=%s lease=%s slug=%s image=%s workdir=%s\n", record.ID, leaseID, blank(serverSlug(server), "-"), nativeCheckpointResourceID(record), workdir)
-		return a.runCheckpointForkCommand(ctx, leaseID, serverSlug(server), runOpts)
+		return checkpointForkProvision{Lease: forkLease, Workdir: workdir, Release: release}, nil
 	}
 	workdir := strings.TrimSpace(workdirOverride)
 	if workdir == "" {
 		workdir = defaultCheckpointRestoreWorkdir(cfg, leaseID, repo.Name, record.Workdir)
 	}
-	if err := validateCheckpointForkWorkdirs(ctx, backend, LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: lease.Coordinator}, workdir); err != nil {
+	if err := validateCheckpointForkWorkdirs(ctx, backend, forkLease, workdir); err != nil {
 		release(ctx)
-		return err
+		return checkpointForkProvision{}, err
 	}
 	if err := restoreCheckpointArchive(ctx, target, checkpointArchivePath(paths, record), record.ID, workdir, clear); err != nil {
 		release(ctx)
+		return checkpointForkProvision{}, err
+	}
+	return checkpointForkProvision{Lease: forkLease, Workdir: workdir, Release: release}, nil
+}
+
+func (a App) checkpointForkRecordOnce(ctx context.Context, cfg Config, backend Backend, sshBackend SSHLeaseBackend, repo Repo, record checkpointRecord, paths checkpointPaths, keep, reclaim bool, requestedSlug, workdirOverride string, clear bool, runOpts checkpointForkRunOptions) error {
+	provision, err := a.provisionCheckpointFork(ctx, cfg, backend, sshBackend, repo, record, paths, keep, reclaim, requestedSlug, workdirOverride, clear)
+	if err != nil {
 		return err
 	}
-	fmt.Fprintf(a.Stdout, "checkpoint forked id=%s lease=%s slug=%s workdir=%s\n", record.ID, leaseID, blank(serverSlug(server), "-"), workdir)
-	return a.runCheckpointForkCommand(ctx, leaseID, serverSlug(server), runOpts)
+	defer func() {
+		if !keep {
+			provision.Release(context.Background())
+		}
+	}()
+	leaseID := provision.Lease.LeaseID
+	slug := serverSlug(provision.Lease.Server)
+	if isNativeCheckpointKind(record.Kind) {
+		fmt.Fprintf(a.Stdout, "checkpoint forked id=%s lease=%s slug=%s image=%s workdir=%s\n", record.ID, leaseID, blank(slug, "-"), nativeCheckpointResourceID(record), blank(provision.Workdir, "-"))
+	} else {
+		fmt.Fprintf(a.Stdout, "checkpoint forked id=%s lease=%s slug=%s workdir=%s\n", record.ID, leaseID, blank(slug, "-"), provision.Workdir)
+	}
+	return a.runCheckpointForkCommand(ctx, leaseID, slug, runOpts)
 }
 
 func (a App) runCheckpointForkCommand(ctx context.Context, leaseID, slug string, opts checkpointForkRunOptions) error {

--- a/internal/cli/cli_kong.go
+++ b/internal/cli/cli_kong.go
@@ -21,6 +21,7 @@ type crabboxKongCLI struct {
 	Prewarm     prewarmKongCmd     `cmd:"" passthrough:"" help:"Lease and hydrate a reusable test-ready box."`
 	Run         runKongCmd         `cmd:"" passthrough:"" help:"Sync the repo, run a remote command, stream output."`
 	Watch       watchKongCmd       `cmd:"" passthrough:"" help:"Re-run a command on a warm lease when local files change."`
+	Shard       shardKongCmd       `cmd:"" passthrough:"" help:"Fork a checkpoint into parallel shards and merge their test results."`
 	Bench       benchKongCmd       `cmd:"" help:"Record and report local benchmark timings."`
 	Job         jobKongCmd         `cmd:"" help:"Run named repo-local Crabbox jobs."`
 	Desktop     desktopKongCmd     `cmd:"" help:"Launch apps into a visible desktop session."`
@@ -160,6 +161,9 @@ type runKongCmd struct {
 	Args []string `arg:"" optional:""`
 }
 type watchKongCmd struct {
+	Args []string `arg:"" optional:""`
+}
+type shardKongCmd struct {
 	Args []string `arg:"" optional:""`
 }
 type benchKongCmd struct {
@@ -607,6 +611,7 @@ func (c *warmupKongCmd) Run(ctx context.Context, app App) error  { return app.wa
 func (c *prewarmKongCmd) Run(ctx context.Context, app App) error { return app.prewarm(ctx, c.Args) }
 func (c *runKongCmd) Run(ctx context.Context, app App) error     { return app.runCommand(ctx, c.Args) }
 func (c *watchKongCmd) Run(ctx context.Context, app App) error   { return app.watch(ctx, c.Args) }
+func (c *shardKongCmd) Run(ctx context.Context, app App) error   { return app.shard(ctx, c.Args) }
 func (c *benchRunKongCmd) Run(ctx context.Context, app App) error {
 	return app.benchRun(ctx, c.Args)
 }

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -232,6 +232,7 @@ type Config struct {
 	Tailscale                     TailscaleConfig
 	Static                        StaticConfig
 	Results                       ResultsConfig
+	Shard                         ShardConfig
 	Cache                         CacheConfig
 	Profiles                      map[string]ProfileConfig
 	Presets                       map[string]PresetConfig
@@ -1226,6 +1227,10 @@ type ResultsConfig struct {
 	JUnit          []string
 	Auto           bool
 	FailOnFailures bool
+}
+
+type ShardConfig struct {
+	MaxCount int
 }
 
 type CacheConfig struct {
@@ -3166,6 +3171,7 @@ type fileConfig struct {
 	Tailscale                *fileTailscaleConfig                `yaml:"tailscale,omitempty"`
 	Static                   *fileStaticConfig                   `yaml:"static,omitempty"`
 	Results                  *fileResultsConfig                  `yaml:"results,omitempty"`
+	Shard                    *fileShardConfig                    `yaml:"shard,omitempty"`
 	Cache                    *fileCacheConfig                    `yaml:"cache,omitempty"`
 	Lease                    *fileLeaseConfig                    `yaml:"lease,omitempty"`
 	Profiles                 map[string]fileProfileConfig        `yaml:"profiles,omitempty"`
@@ -4283,6 +4289,10 @@ type fileResultsConfig struct {
 	JUnit          []string `yaml:"junit,omitempty"`
 	Auto           *bool    `yaml:"auto,omitempty"`
 	FailOnFailures *bool    `yaml:"failOnFailures,omitempty"`
+}
+
+type fileShardConfig struct {
+	MaxCount *int `yaml:"maxCount,omitempty"`
 }
 
 type fileCacheConfig struct {
@@ -6971,6 +6981,9 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 		if file.Results.FailOnFailures != nil {
 			cfg.Results.FailOnFailures = *file.Results.FailOnFailures
 		}
+	}
+	if file.Shard != nil && file.Shard.MaxCount != nil {
+		cfg.Shard.MaxCount = *file.Shard.MaxCount
 	}
 	if file.Cache != nil {
 		if file.Cache.Pnpm != nil {

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -5127,6 +5127,8 @@ results:
   failOnFailures: true
   junit:
     - junit.xml
+shard:
+  maxCount: 12
 run:
   preflightTools:
     - node
@@ -5297,6 +5299,9 @@ ssh:
 	}
 	if len(cfg.Results.JUnit) != 1 || cfg.Results.JUnit[0] != "junit.xml" || !cfg.Results.Auto || !cfg.Results.FailOnFailures {
 		t.Fatalf("results config not loaded: %#v", cfg.Results)
+	}
+	if cfg.Shard.MaxCount != 12 {
+		t.Fatalf("shard config not loaded: %#v", cfg.Shard)
 	}
 	if len(cfg.Run.PreflightTools) != 2 || cfg.Run.PreflightTools[0] != "node" || cfg.Run.PreflightTools[1] != "bun" {
 		t.Fatalf("run config not loaded: %#v", cfg.Run)

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1595,6 +1595,12 @@ afterSync:
 		fmt.Fprintf(a.Stderr, "artifact kind=proof path=%s bytes=%d template=%s\n", proof.Path, proof.Bytes, blank(proof.Template, "default"))
 	}
 	recorder.Finish(ctx, target, code, timings.sync, timings.command, logBuffer.String(), logBuffer.Truncated(), results, classification)
+	if a.runOutcome != nil {
+		a.runOutcome.Recorded = true
+		a.runOutcome.ExitCode = code
+		a.runOutcome.RunID = recorder.runID
+		a.runOutcome.Results = results
+	}
 	fmt.Fprintf(a.Stderr, "command complete in %s total=%s\n", timings.command.Round(time.Millisecond), total.Round(time.Millisecond))
 	fmt.Fprintln(a.Stderr, formatRunSummary(timings, total, code))
 	labelField := ""

--- a/internal/cli/shard.go
+++ b/internal/cli/shard.go
@@ -436,7 +436,7 @@ func (a App) shardVerdict(opts shardOptions, results []shardResult, wall time.Du
 	if len(failedCases) > 0 {
 		fmt.Fprintln(a.Stdout, "failed:")
 		for _, failure := range failedCases {
-			fmt.Fprintf(a.Stdout, "  [%d/%d]", failure.Shard, opts.Count)
+			fmt.Fprintf(a.Stdout, "  [%d/%d] run=%s", failure.Shard, opts.Count, blank(failure.RunID, "-"))
 			printTestFailure(a.Stdout, failure.TestFailure)
 		}
 	}
@@ -480,6 +480,9 @@ func shardExitError(opts shardOptions, results []shardResult, merged *TestResult
 			commandFailures++
 		}
 	}
+	if infraFailures > 0 {
+		return exit(7, "%d of %d shards failed to provision or run", infraFailures, opts.Count)
+	}
 	if commandFailures > 0 {
 		code := 1
 		if len(commandCodes) == 1 {
@@ -490,9 +493,6 @@ func shardExitError(opts shardOptions, results []shardResult, merged *TestResult
 			}
 		}
 		return ExitError{Code: code, Message: fmt.Sprintf("%d of %d shards failed", failedShards, opts.Count)}
-	}
-	if infraFailures > 0 {
-		return exit(7, "%d of %d shards failed to provision or run", infraFailures, opts.Count)
 	}
 	if canceledShards > 0 {
 		return ExitError{Code: 130, Message: fmt.Sprintf("shard interrupted; %d of %d shards canceled", canceledShards, opts.Count)}

--- a/internal/cli/shard.go
+++ b/internal/cli/shard.go
@@ -1,0 +1,609 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const shardPartialLineLimit = 64 * 1024
+
+type shardRunOutcome struct {
+	Recorded bool
+	ExitCode int
+	RunID    string
+	Results  *TestResultSummary
+}
+
+var shardForbiddenRunFlags = map[string]bool{
+	"pool":              true,
+	"pool-return":       true,
+	"sync-only":         true,
+	"no-sync":           true,
+	"apply-local-patch": true,
+	"fresh-pr":          true,
+	"script":            true,
+	"script-stdin":      true,
+	"stop-after":        true,
+	"lease-output":      true,
+	"keep-on-failure":   true,
+	"capture-stdout":    true,
+	"capture-stderr":    true,
+	"download":          true,
+	"emit-proof":        true,
+	"proof-template":    true,
+	"label":             true,
+	"id":                true,
+	"timing-json":       true,
+	"timing-record":     true,
+}
+
+var shardOwnedOnlyFlags = map[string]bool{
+	"count":                 true,
+	"from":                  true,
+	"fail-fast":             true,
+	"keep":                  true,
+	"quiet":                 true,
+	"json":                  true,
+	"dry-run":               true,
+	"workdir":               true,
+	"clear":                 true,
+	"reclaim":               true,
+	"slug":                  true,
+	"fail-on-test-failures": true,
+}
+
+type shardOptions struct {
+	Checkpoint         string
+	Count              int
+	Keep               bool
+	FailFast           bool
+	Quiet              bool
+	JSON               bool
+	FailOnTestFailures bool
+	ResultsWired       bool
+	RequestedSlug      string
+	RunArgs            []string
+	Command            []string
+}
+
+type shardResult struct {
+	Index    int
+	LeaseID  string
+	Slug     string
+	RunID    string
+	ExitCode int
+	Recorded bool
+	Canceled bool
+	Results  *TestResultSummary
+	Err      error
+}
+
+func (r shardResult) commandFailed() bool {
+	return r.Recorded && r.ExitCode != 0 && !r.Canceled
+}
+
+func (r shardResult) infraFailed() bool {
+	return !r.Recorded && !r.Canceled && (r.Err != nil || r.LeaseID == "")
+}
+
+func (r shardResult) failed() bool {
+	return r.commandFailed() || r.infraFailed()
+}
+
+type shardProvisioner func(ctx context.Context, index int, slug string) (checkpointForkProvision, error)
+
+type shardRunExecutor func(ctx context.Context, index int, runArgs []string, outcome *shardRunOutcome) error
+
+func (a App) shard(ctx context.Context, args []string) error {
+	shardArgs, command := splitCheckpointForkRunArgs(args)
+	defaults := defaultConfig()
+	fs := newFlagSet("shard", a.Stderr)
+	fs.Usage = func() {
+		fmt.Fprintln(fs.Output(), "Usage:")
+		fmt.Fprintln(fs.Output(), "  crabbox shard --count <n> --from <checkpoint-id> [flags] -- <command...>")
+		fmt.Fprintln(fs.Output(), "")
+		fmt.Fprintln(fs.Output(), "Forks --count leases from a checkpoint concurrently, runs the command on")
+		fmt.Fprintln(fs.Output(), "every fork in parallel through the normal run pipeline, and merges the")
+		fmt.Fprintln(fs.Output(), "collected JUnit results into one suite verdict. The command may use the")
+		fmt.Fprintln(fs.Output(), "{{index}}, {{total}}, {{lease}}, and {{slug}} placeholders. Other run flags")
+		fmt.Fprintln(fs.Output(), "pass through to each shard's run.")
+		fmt.Fprintln(fs.Output(), "")
+		fmt.Fprintln(fs.Output(), "Flags:")
+		fs.PrintDefaults()
+	}
+	leaseFlags := registerLeaseCreateFlags(fs, defaults)
+	count := fs.Int("count", 0, "number of parallel shards to run")
+	from := fs.String("from", "", "checkpoint id to fork each shard from")
+	failFast := fs.Bool("fail-fast", false, "cancel remaining shards after the first failing shard")
+	keep := fs.Bool("keep", false, "keep forked leases after their shard finishes")
+	quiet := fs.Bool("quiet", false, "suppress shard output streams and print per-shard status lines only")
+	jsonOut := fs.Bool("json", false, "print the merged verdict as JSON")
+	dryRun := fs.Bool("dry-run", false, "show the shard plan without provisioning")
+	workdirOverride := fs.String("workdir", "", "remote restore workdir")
+	clear := fs.Bool("clear", true, "clear the remote workdir before restoring")
+	reclaim := fs.Bool("reclaim", false, "claim these leases for the current repo")
+	failOnTestFailures := fs.Bool("fail-on-test-failures", false, "exit non-zero when the merged JUnit results contain failures or errors")
+	junitResults := fs.String("junit", "", "comma-separated remote JUnit XML paths to record")
+	resultsAuto := fs.Bool("results-auto", false, "scan common remote JUnit XML paths after the command")
+	ownArgs, runArgs, err := partitionForwardedRunArgs(fs, shardArgs, shardOwnedOnlyFlags, shardForbiddenRunFlags, "shard: it conflicts with parallel shard runs")
+	if err != nil {
+		return err
+	}
+	if err := parseFlags(fs, ownArgs); err != nil {
+		return err
+	}
+	if fs.NArg() > 0 {
+		return exit(2, "unexpected argument %q; place the command after --", fs.Arg(0))
+	}
+	if *count < 1 {
+		return exit(2, "--count must be at least 1")
+	}
+	if strings.TrimSpace(*from) == "" {
+		return exit(2, "usage: crabbox shard --count <n> --from <checkpoint-id> [flags] -- <command...>")
+	}
+	if len(command) == 0 {
+		return exit(2, "usage: crabbox shard --count <n> --from <checkpoint-id> [flags] -- <command...>")
+	}
+	requestedSlug, err := requestedLeaseSlug(*leaseFlags.Slug)
+	if err != nil {
+		return err
+	}
+	store, err := defaultCheckpointStore()
+	if err != nil {
+		return err
+	}
+	record, paths, err := store.Read(strings.TrimSpace(*from))
+	if err != nil {
+		return err
+	}
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
+	}
+	if cfg.Shard.MaxCount > 0 && *count > cfg.Shard.MaxCount {
+		return exit(2, "--count %d exceeds shard.maxCount %d", *count, cfg.Shard.MaxCount)
+	}
+	nativeCheckpoint := isNativeCheckpointKind(record.Kind)
+	if nativeCheckpoint && record.TargetOS == targetMacOS && !flagWasSet(fs, "market") {
+		cfg.Capacity.Market = "on-demand"
+	}
+	if err := applyLeaseCreateFlags(&cfg, fs, leaseFlags); err != nil {
+		return err
+	}
+	if record.Kind != checkpointKindArchive && !nativeCheckpoint {
+		return exit(2, "checkpoint %s has kind=%s; shard requires %s or a native image checkpoint", record.ID, record.Kind, checkpointKindArchive)
+	}
+	if nativeCheckpoint {
+		if nativeCheckpointResourceID(record) == "" {
+			return exit(2, "checkpoint %s is pending; native provider resource is not recorded yet", record.ID)
+		}
+		if err := applyNativeCheckpointForkConfigAndFlags(&cfg, fs, record, leaseFlags.ProviderFlags); err != nil {
+			return err
+		}
+	}
+	if *junitResults != "" {
+		cfg.Results.JUnit = splitCommaList(*junitResults)
+	}
+	if flagWasSet(fs, "results-auto") {
+		cfg.Results.Auto = *resultsAuto
+	}
+	mergedPolicy := cfg.Results.FailOnFailures
+	if flagWasSet(fs, "fail-on-test-failures") {
+		mergedPolicy = *failOnTestFailures
+	}
+	if *dryRun {
+		for i := 1; i <= *count; i++ {
+			slug := checkpointForkFanoutSlug(requestedSlug, i, *count)
+			expandedCommand := checkpointForkRunCommand(command, checkpointForkRunContext{Index: i, Total: *count, Slug: slug})
+			fmt.Fprintf(a.Stdout, "would shard checkpoint id=%s provider=%s slug=%s keep=%t index=%d/%d command=%s\n", record.ID, cfg.Provider, blank(slug, "-"), *keep, i, *count, strconv.Quote(runCommandDisplay(expandedCommand, false)))
+		}
+		return nil
+	}
+	repo, err := findRepo()
+	if err != nil {
+		return err
+	}
+	backend, err := loadBackend(cfg, runtimeForApp(a))
+	if err != nil {
+		return err
+	}
+	sshBackend, ok := backend.(SSHLeaseBackend)
+	if !ok {
+		return exit(2, "provider=%s does not support shard: it requires an SSH lease provider that supports checkpoint fork", backend.Spec().Name)
+	}
+	opts := shardOptions{
+		Checkpoint:         record.ID,
+		Count:              *count,
+		Keep:               *keep,
+		FailFast:           *failFast,
+		Quiet:              *quiet,
+		JSON:               *jsonOut,
+		FailOnTestFailures: mergedPolicy,
+		ResultsWired:       len(cfg.Results.JUnit) > 0 || cfg.Results.Auto,
+		RequestedSlug:      requestedSlug,
+		RunArgs:            runArgs,
+		Command:            command,
+	}
+	fmt.Fprintf(a.Stderr, "shard plan checkpoint=%s provider=%s count=%d keep=%t fail_fast=%t command=%s\n", record.ID, cfg.Provider, opts.Count, opts.Keep, opts.FailFast, strconv.Quote(runCommandDisplay(command, false)))
+	mux := &shardOutputMux{}
+	workdir := strings.TrimSpace(*workdirOverride)
+	provision := func(provisionCtx context.Context, index int, slug string) (checkpointForkProvision, error) {
+		shardApp, flush := a.forShard(mux, index, opts.Count, opts.Quiet, nil)
+		defer flush()
+		return shardApp.provisionCheckpointFork(provisionCtx, cfg, backend, sshBackend, repo, record, paths, opts.Keep, *reclaim, slug, workdir, *clear)
+	}
+	execute := func(runCtx context.Context, index int, shardRunArgs []string, outcome *shardRunOutcome) error {
+		shardApp, flush := a.forShard(mux, index, opts.Count, opts.Quiet, outcome)
+		defer flush()
+		return shardApp.runCommand(runCtx, shardRunArgs)
+	}
+	return a.shardRun(ctx, opts, mux, provision, execute)
+}
+
+func (a App) forShard(mux *shardOutputMux, index, total int, quiet bool, outcome *shardRunOutcome) (App, func()) {
+	shardApp := a
+	shardApp.runOutcome = outcome
+	if quiet {
+		shardApp.Stdout = io.Discard
+		shardApp.Stderr = io.Discard
+		return shardApp, func() {}
+	}
+	prefix := shardLinePrefix(index, total)
+	stdout := &prefixLineWriter{mux: mux, out: a.Stdout, prefix: prefix}
+	stderr := &prefixLineWriter{mux: mux, out: a.Stderr, prefix: prefix}
+	shardApp.Stdout = stdout
+	shardApp.Stderr = stderr
+	return shardApp, func() {
+		stdout.Flush()
+		stderr.Flush()
+	}
+}
+
+func shardLinePrefix(index, total int) string {
+	width := len(strconv.Itoa(total))
+	return fmt.Sprintf("[%*d/%d] ", width, index, total)
+}
+
+func (a App) shardRun(ctx context.Context, opts shardOptions, mux *shardOutputMux, provision shardProvisioner, execute shardRunExecutor) error {
+	results := make([]shardResult, opts.Count)
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	var wg sync.WaitGroup
+	start := time.Now()
+	for i := 1; i <= opts.Count; i++ {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			slug := checkpointForkFanoutSlug(opts.RequestedSlug, index, opts.Count)
+			lease, err := provision(runCtx, index, slug)
+			if err != nil {
+				if runCtx.Err() != nil {
+					results[index-1] = shardResult{Index: index, Slug: slug, Canceled: true, Err: err}
+					mux.printf(a.Stderr, "shard %d/%d canceled\n", index, opts.Count)
+					return
+				}
+				results[index-1] = shardResult{Index: index, Slug: slug, ExitCode: shardErrorExitCode(err), Err: err}
+				mux.printf(a.Stderr, "shard %d/%d failed error=%q\n", index, opts.Count, err.Error())
+				if opts.FailFast {
+					cancel()
+				}
+				return
+			}
+			leaseID := lease.Lease.LeaseID
+			leaseSlug := serverSlug(lease.Lease.Server)
+			if !opts.Keep {
+				defer lease.Release(context.Background())
+			}
+			mux.printf(a.Stderr, "shard %d/%d provisioned lease=%s slug=%s\n", index, opts.Count, leaseID, blank(leaseSlug, "-"))
+			expanded := checkpointForkRunCommand(opts.Command, checkpointForkRunContext{Index: index, Total: opts.Count, LeaseID: leaseID, Slug: leaseSlug})
+			var outcome shardRunOutcome
+			err = execute(runCtx, index, shardRunArgs(leaseID, index, opts.Count, opts.RunArgs, expanded), &outcome)
+			result := shardResult{Index: index, LeaseID: leaseID, Slug: leaseSlug, RunID: outcome.RunID, Recorded: outcome.Recorded, Results: outcome.Results}
+			if outcome.Recorded {
+				result.ExitCode = outcome.ExitCode
+			} else {
+				result.ExitCode = shardErrorExitCode(err)
+				if err == nil {
+					err = errors.New("run finished without recording an outcome")
+				}
+				result.Err = err
+			}
+			if runCtx.Err() != nil && (!outcome.Recorded || outcome.ExitCode < 0) {
+				result.Canceled = true
+				result.ExitCode = 0
+			}
+			results[index-1] = result
+			a.printShardStatus(mux, opts, result)
+			if opts.Keep {
+				mux.printf(a.Stderr, "shard %d/%d kept lease=%s slug=%s\n", index, opts.Count, leaseID, blank(leaseSlug, "-"))
+			}
+			if result.failed() && opts.FailFast {
+				cancel()
+			}
+		}(i)
+	}
+	wg.Wait()
+	wall := time.Since(start)
+	return a.shardVerdict(opts, results, wall)
+}
+
+func (a App) printShardStatus(mux *shardOutputMux, opts shardOptions, result shardResult) {
+	if result.Canceled {
+		mux.printf(a.Stderr, "shard %d/%d canceled\n", result.Index, opts.Count)
+		return
+	}
+	if result.infraFailed() {
+		mux.printf(a.Stderr, "shard %d/%d failed error=%q\n", result.Index, opts.Count, result.Err.Error())
+		return
+	}
+	if result.Results != nil {
+		mux.printf(a.Stderr, "shard %d/%d done exit=%d tests=%d failures=%d errors=%d\n", result.Index, opts.Count, result.ExitCode, result.Results.Tests, result.Results.Failures, result.Results.Errors)
+		return
+	}
+	mux.printf(a.Stderr, "shard %d/%d done exit=%d\n", result.Index, opts.Count, result.ExitCode)
+}
+
+func shardErrorExitCode(err error) int {
+	var exitErr ExitError
+	if AsExitError(err, &exitErr) && exitErr.Code != 0 {
+		return exitErr.Code
+	}
+	return 1
+}
+
+func shardRunArgs(leaseID string, index, total int, runArgs, command []string) []string {
+	args := make([]string, 0, len(runArgs)+len(command)+7)
+	args = append(args, "--id", leaseID, "--keep", "--label", fmt.Sprintf("shard %d/%d", index, total), "--fail-on-test-failures=false")
+	args = append(args, runArgs...)
+	args = append(args, "--")
+	args = append(args, command...)
+	return args
+}
+
+func (a App) shardVerdict(opts shardOptions, results []shardResult, wall time.Duration) error {
+	merged := &TestResultSummary{Format: "junit", Files: []string{}, Failed: []TestFailure{}}
+	summaries := 0
+	failedShards := 0
+	infraFailures := 0
+	canceledShards := 0
+	commandCodes := map[int]bool{}
+	failedCases := []shardTestFailure{}
+	for _, result := range results {
+		if result.failed() {
+			failedShards++
+		}
+		if result.infraFailed() {
+			infraFailures++
+		}
+		if result.Canceled {
+			canceledShards++
+		}
+		if result.commandFailed() {
+			commandCodes[result.ExitCode] = true
+		}
+		if result.Results == nil {
+			continue
+		}
+		summaries++
+		mergeJUnitSummary(merged, result.Results)
+		for _, failure := range result.Results.Failed {
+			failedCases = append(failedCases, shardTestFailure{Shard: result.Index, RunID: result.RunID, TestFailure: failure})
+		}
+	}
+	if summaries == 0 {
+		merged = nil
+	}
+	err := shardExitError(opts, results, merged, commandCodes, failedShards, infraFailures, canceledShards)
+	if opts.JSON {
+		report := shardJSONReport{
+			Checkpoint: opts.Checkpoint,
+			Count:      opts.Count,
+			Shards:     shardJSONResults(results),
+			Merged:     merged,
+			Failed:     failedCases,
+			WallMs:     wall.Milliseconds(),
+		}
+		if err != nil {
+			var exitErr ExitError
+			if AsExitError(err, &exitErr) {
+				report.ExitCode = exitErr.Code
+			} else {
+				report.ExitCode = 1
+			}
+		}
+		if encodeErr := json.NewEncoder(a.Stdout).Encode(report); encodeErr != nil {
+			return encodeErr
+		}
+		return err
+	}
+	a.printShardTable(opts, results)
+	mergedLine := ""
+	if merged != nil {
+		mergedLine = fmt.Sprintf(" tests=%d failures=%d errors=%d skipped=%d suite_time=%.3fs", merged.Tests, merged.Failures, merged.Errors, merged.Skipped, merged.TimeSeconds)
+	}
+	canceledLine := ""
+	if canceledShards > 0 {
+		canceledLine = fmt.Sprintf(" canceled=%d", canceledShards)
+	}
+	fmt.Fprintf(a.Stdout, "shard verdict shards=%d failed_shards=%d%s%s wall=%.3fs\n", opts.Count, failedShards, canceledLine, mergedLine, wall.Seconds())
+	if len(failedCases) > 0 {
+		fmt.Fprintln(a.Stdout, "failed:")
+		for _, failure := range failedCases {
+			fmt.Fprintf(a.Stdout, "  [%d/%d]", failure.Shard, opts.Count)
+			printTestFailure(a.Stdout, failure.TestFailure)
+		}
+	}
+	return err
+}
+
+func (a App) printShardTable(opts shardOptions, results []shardResult) {
+	leaseWidth := len("LEASE")
+	runWidth := len("RUN")
+	for _, result := range results {
+		if len(result.LeaseID) > leaseWidth {
+			leaseWidth = len(result.LeaseID)
+		}
+		if len(result.RunID) > runWidth {
+			runWidth = len(result.RunID)
+		}
+	}
+	fmt.Fprintln(a.Stdout, "shard results")
+	fmt.Fprintf(a.Stdout, "SHARD  %-*s  %-*s  EXIT  TESTS  FAIL  ERR  SKIP  TIME\n", leaseWidth, "LEASE", runWidth, "RUN")
+	for _, result := range results {
+		tests, failures, errCount, skipped, elapsed := "-", "-", "-", "-", "-"
+		if result.Results != nil {
+			tests = strconv.Itoa(result.Results.Tests)
+			failures = strconv.Itoa(result.Results.Failures)
+			errCount = strconv.Itoa(result.Results.Errors)
+			skipped = strconv.Itoa(result.Results.Skipped)
+			elapsed = fmt.Sprintf("%.1fs", result.Results.TimeSeconds)
+		}
+		exitValue := strconv.Itoa(result.ExitCode)
+		if result.infraFailed() || result.Canceled {
+			exitValue = "-"
+		}
+		fmt.Fprintf(a.Stdout, "%-5s  %-*s  %-*s  %-4s  %-5s  %-4s  %-3s  %-4s  %s\n", fmt.Sprintf("%d/%d", result.Index, opts.Count), leaseWidth, blank(result.LeaseID, "-"), runWidth, blank(result.RunID, "-"), exitValue, tests, failures, errCount, skipped, elapsed)
+	}
+}
+
+func shardExitError(opts shardOptions, results []shardResult, merged *TestResultSummary, commandCodes map[int]bool, failedShards, infraFailures, canceledShards int) error {
+	commandFailures := 0
+	for _, result := range results {
+		if result.commandFailed() {
+			commandFailures++
+		}
+	}
+	if commandFailures > 0 {
+		code := 1
+		if len(commandCodes) == 1 {
+			for value := range commandCodes {
+				if value > 0 && value < 256 {
+					code = value
+				}
+			}
+		}
+		return ExitError{Code: code, Message: fmt.Sprintf("%d of %d shards failed", failedShards, opts.Count)}
+	}
+	if infraFailures > 0 {
+		return exit(7, "%d of %d shards failed to provision or run", infraFailures, opts.Count)
+	}
+	if canceledShards > 0 {
+		return ExitError{Code: 130, Message: fmt.Sprintf("shard interrupted; %d of %d shards canceled", canceledShards, opts.Count)}
+	}
+	if opts.FailOnTestFailures && merged != nil && (merged.Failures > 0 || merged.Errors > 0 || len(merged.Failed) > 0) {
+		return ExitError{Code: 1, Message: fmt.Sprintf("JUnit results contain %d failures and %d errors", merged.Failures, merged.Errors)}
+	}
+	return nil
+}
+
+type shardTestFailure struct {
+	Shard int    `json:"shard"`
+	RunID string `json:"runId,omitempty"`
+	TestFailure
+}
+
+type shardJSONReport struct {
+	Checkpoint string             `json:"checkpoint"`
+	Count      int                `json:"count"`
+	Shards     []shardJSONResult  `json:"shards"`
+	Merged     *TestResultSummary `json:"merged"`
+	Failed     []shardTestFailure `json:"failed"`
+	WallMs     int64              `json:"wallMs"`
+	ExitCode   int                `json:"exitCode"`
+}
+
+type shardJSONResult struct {
+	Index    int                `json:"index"`
+	LeaseID  string             `json:"leaseId,omitempty"`
+	Slug     string             `json:"slug,omitempty"`
+	RunID    string             `json:"runId,omitempty"`
+	ExitCode int                `json:"exitCode"`
+	Canceled bool               `json:"canceled,omitempty"`
+	Error    string             `json:"error,omitempty"`
+	Results  *TestResultSummary `json:"results"`
+}
+
+func shardJSONResults(results []shardResult) []shardJSONResult {
+	out := make([]shardJSONResult, 0, len(results))
+	for _, result := range results {
+		item := shardJSONResult{Index: result.Index, LeaseID: result.LeaseID, Slug: result.Slug, RunID: result.RunID, ExitCode: result.ExitCode, Canceled: result.Canceled, Results: result.Results}
+		if result.Err != nil {
+			item.Error = result.Err.Error()
+		}
+		out = append(out, item)
+	}
+	return out
+}
+
+type shardOutputMux struct {
+	mu sync.Mutex
+}
+
+func (m *shardOutputMux) printf(out io.Writer, format string, args ...any) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	fmt.Fprintf(out, format, args...)
+}
+
+type prefixLineWriter struct {
+	mux    *shardOutputMux
+	out    io.Writer
+	prefix string
+	buf    []byte
+}
+
+func (w *prefixLineWriter) Write(p []byte) (int, error) {
+	w.mux.mu.Lock()
+	defer w.mux.mu.Unlock()
+	w.buf = append(w.buf, p...)
+	for {
+		idx := -1
+		for i, b := range w.buf {
+			if b == '\n' {
+				idx = i
+				break
+			}
+		}
+		if idx < 0 {
+			break
+		}
+		if err := w.emitLocked(w.buf[:idx+1]); err != nil {
+			return len(p), err
+		}
+		w.buf = w.buf[idx+1:]
+	}
+	if len(w.buf) > shardPartialLineLimit {
+		line := append(w.buf, '\n')
+		w.buf = nil
+		if err := w.emitLocked(line); err != nil {
+			return len(p), err
+		}
+	}
+	return len(p), nil
+}
+
+func (w *prefixLineWriter) Flush() error {
+	w.mux.mu.Lock()
+	defer w.mux.mu.Unlock()
+	if len(w.buf) == 0 {
+		return nil
+	}
+	line := append(w.buf, '\n')
+	w.buf = nil
+	return w.emitLocked(line)
+}
+
+func (w *prefixLineWriter) emitLocked(line []byte) error {
+	if _, err := io.WriteString(w.out, w.prefix); err != nil {
+		return err
+	}
+	_, err := w.out.Write(line)
+	return err
+}

--- a/internal/cli/shard_test.go
+++ b/internal/cli/shard_test.go
@@ -280,6 +280,20 @@ func TestShardProvisionFailureDoesNotOrphanSiblings(t *testing.T) {
 	}
 }
 
+func TestShardInfraFailureTakesPrecedenceOverCommandFailure(t *testing.T) {
+	provisioner := newShardTestProvisioner()
+	provisioner.errs[3] = errors.New("acquire failed")
+	executor := newShardTestExecutor()
+	executor.outcomes[1] = recordedOutcome(4, nil)
+	executor.outcomes[2] = recordedOutcome(0, nil)
+	app := App{Stdout: io.Discard, Stderr: io.Discard}
+	err := app.shardRun(context.Background(), shardTestOptions(3), &shardOutputMux{}, provisioner.provision, executor.run)
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 7 || exitErr.Message != "1 of 3 shards failed to provision or run" {
+		t.Fatalf("err=%v, want infra exit 7 to take precedence over command exit 4", err)
+	}
+}
+
 func TestShardMergedVerdict(t *testing.T) {
 	provisioner := newShardTestProvisioner()
 	executor := newShardTestExecutor()
@@ -295,7 +309,7 @@ func TestShardMergedVerdict(t *testing.T) {
 		"shard results",
 		"shard verdict shards=2 failed_shards=0 tests=30 failures=1 errors=0 skipped=2 suite_time=6.000s",
 		"failed:",
-		"[1/2]",
+		"[1/2] run=run_test",
 		"TestA",
 	} {
 		if !strings.Contains(out, want) {

--- a/internal/cli/shard_test.go
+++ b/internal/cli/shard_test.go
@@ -1,0 +1,608 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+type shardTestProvisioner struct {
+	mu          sync.Mutex
+	calls       []int
+	errs        map[int]error
+	releases    int
+	releaseErrs []error
+}
+
+func newShardTestProvisioner() *shardTestProvisioner {
+	return &shardTestProvisioner{errs: map[int]error{}}
+}
+
+func (p *shardTestProvisioner) provision(ctx context.Context, index int, slug string) (checkpointForkProvision, error) {
+	p.mu.Lock()
+	p.calls = append(p.calls, index)
+	err := p.errs[index]
+	p.mu.Unlock()
+	if err != nil {
+		return checkpointForkProvision{}, err
+	}
+	lease := LeaseTarget{LeaseID: fmt.Sprintf("cbx_shard_%d", index), Server: Server{Labels: map[string]string{"slug": fmt.Sprintf("shard-%d", index)}}}
+	release := func(releaseCtx context.Context) {
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		p.releases++
+		p.releaseErrs = append(p.releaseErrs, releaseCtx.Err())
+	}
+	return checkpointForkProvision{Lease: lease, Workdir: "/work/my-app", Release: release}, nil
+}
+
+func (p *shardTestProvisioner) stats() (int, int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.calls), p.releases
+}
+
+type shardTestExecutor struct {
+	mu       sync.Mutex
+	calls    map[int][]string
+	started  chan int
+	unblock  chan struct{}
+	block    map[int]bool
+	errs     map[int]error
+	outcomes map[int]shardRunOutcome
+}
+
+func newShardTestExecutor() *shardTestExecutor {
+	return &shardTestExecutor{calls: map[int][]string{}, block: map[int]bool{}, errs: map[int]error{}, outcomes: map[int]shardRunOutcome{}}
+}
+
+func (e *shardTestExecutor) run(ctx context.Context, index int, runArgs []string, outcome *shardRunOutcome) error {
+	e.mu.Lock()
+	e.calls[index] = append([]string{}, runArgs...)
+	blocked := e.block[index]
+	e.mu.Unlock()
+	if e.started != nil {
+		e.started <- index
+	}
+	if blocked {
+		select {
+		case <-e.unblock:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if result, ok := e.outcomes[index]; ok {
+		*outcome = result
+	}
+	return e.errs[index]
+}
+
+func (e *shardTestExecutor) callCount() int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return len(e.calls)
+}
+
+func (e *shardTestExecutor) call(index int) []string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.calls[index]
+}
+
+func shardTestOptions(count int) shardOptions {
+	return shardOptions{Checkpoint: "chk_test", Count: count, ResultsWired: true, Command: []string{"pnpm", "test"}}
+}
+
+func recordedOutcome(exitCode int, results *TestResultSummary) shardRunOutcome {
+	return shardRunOutcome{Recorded: true, ExitCode: exitCode, RunID: "run_test", Results: results}
+}
+
+func TestShardRunsAllShardsConcurrently(t *testing.T) {
+	provisioner := newShardTestProvisioner()
+	executor := newShardTestExecutor()
+	executor.started = make(chan int, 3)
+	executor.unblock = make(chan struct{})
+	for i := 1; i <= 3; i++ {
+		executor.block[i] = true
+		executor.outcomes[i] = recordedOutcome(0, nil)
+	}
+	app := App{Stdout: io.Discard, Stderr: io.Discard}
+	done := make(chan error, 1)
+	go func() {
+		done <- app.shardRun(context.Background(), shardTestOptions(3), &shardOutputMux{}, provisioner.provision, executor.run)
+	}()
+	seen := map[int]bool{}
+	for len(seen) < 3 {
+		select {
+		case index := <-executor.started:
+			seen[index] = true
+		case <-time.After(5 * time.Second):
+			t.Fatalf("only %d of 3 shards started concurrently", len(seen))
+		}
+	}
+	close(executor.unblock)
+	if err := <-done; err != nil {
+		t.Fatalf("shardRun: %v", err)
+	}
+	provisions, releases := provisioner.stats()
+	if provisions != 3 || releases != 3 {
+		t.Fatalf("provisions=%d releases=%d, want 3/3", provisions, releases)
+	}
+}
+
+func TestShardContinuesAfterShardFailure(t *testing.T) {
+	provisioner := newShardTestProvisioner()
+	executor := newShardTestExecutor()
+	executor.outcomes[1] = recordedOutcome(0, nil)
+	executor.outcomes[2] = recordedOutcome(4, nil)
+	executor.outcomes[3] = recordedOutcome(0, nil)
+	app := App{Stdout: io.Discard, Stderr: io.Discard}
+	err := app.shardRun(context.Background(), shardTestOptions(3), &shardOutputMux{}, provisioner.provision, executor.run)
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 4 || exitErr.Message != "1 of 3 shards failed" {
+		t.Fatalf("err=%v, want code 4 with 1 of 3 shards failed", err)
+	}
+	if executor.callCount() != 3 {
+		t.Fatalf("calls=%d, want all 3 shards to run", executor.callCount())
+	}
+	if _, releases := provisioner.stats(); releases != 3 {
+		t.Fatalf("releases=%d, want 3", releases)
+	}
+}
+
+func TestShardMixedFailureCodesAggregateToOne(t *testing.T) {
+	provisioner := newShardTestProvisioner()
+	executor := newShardTestExecutor()
+	executor.outcomes[1] = recordedOutcome(3, nil)
+	executor.outcomes[2] = recordedOutcome(4, nil)
+	app := App{Stdout: io.Discard, Stderr: io.Discard}
+	err := app.shardRun(context.Background(), shardTestOptions(2), &shardOutputMux{}, provisioner.provision, executor.run)
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 1 || exitErr.Message != "2 of 2 shards failed" {
+		t.Fatalf("err=%v, want code 1 with 2 of 2 shards failed", err)
+	}
+}
+
+func TestShardFailFastCancelsSiblings(t *testing.T) {
+	provisioner := newShardTestProvisioner()
+	executor := newShardTestExecutor()
+	executor.started = make(chan int, 3)
+	executor.unblock = make(chan struct{})
+	executor.block[2] = true
+	executor.block[3] = true
+	executor.outcomes[1] = recordedOutcome(1, nil)
+	opts := shardTestOptions(3)
+	opts.FailFast = true
+	var stdout bytes.Buffer
+	app := App{Stdout: &stdout, Stderr: io.Discard}
+	err := app.shardRun(context.Background(), opts, &shardOutputMux{}, provisioner.provision, executor.run)
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 1 || exitErr.Message != "1 of 3 shards failed" {
+		t.Fatalf("err=%v, want code 1 with only the real failure counted", err)
+	}
+	if !strings.Contains(stdout.String(), "canceled=2") {
+		t.Fatalf("verdict missing canceled count:\n%s", stdout.String())
+	}
+	if _, releases := provisioner.stats(); releases != 3 {
+		t.Fatalf("releases=%d, want every provisioned shard released", releases)
+	}
+}
+
+func TestShardCancelReleasesWithBackgroundContext(t *testing.T) {
+	provisioner := newShardTestProvisioner()
+	executor := newShardTestExecutor()
+	executor.started = make(chan int, 2)
+	executor.unblock = make(chan struct{})
+	executor.block[1] = true
+	executor.block[2] = true
+	ctx, cancel := context.WithCancel(context.Background())
+	app := App{Stdout: io.Discard, Stderr: io.Discard}
+	done := make(chan error, 1)
+	go func() {
+		done <- app.shardRun(ctx, shardTestOptions(2), &shardOutputMux{}, provisioner.provision, executor.run)
+	}()
+	for i := 0; i < 2; i++ {
+		select {
+		case <-executor.started:
+		case <-time.After(5 * time.Second):
+			t.Fatal("shards did not start")
+		}
+	}
+	cancel()
+	err := <-done
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 130 || exitErr.Message != "shard interrupted; 2 of 2 shards canceled" {
+		t.Fatalf("err=%v, want exit 130 interrupt", err)
+	}
+	provisioner.mu.Lock()
+	defer provisioner.mu.Unlock()
+	if provisioner.releases != 2 {
+		t.Fatalf("releases=%d, want 2", provisioner.releases)
+	}
+	for _, releaseErr := range provisioner.releaseErrs {
+		if releaseErr != nil {
+			t.Fatalf("release context canceled: %v", releaseErr)
+		}
+	}
+}
+
+func TestShardKeepSkipsRelease(t *testing.T) {
+	provisioner := newShardTestProvisioner()
+	executor := newShardTestExecutor()
+	executor.outcomes[1] = recordedOutcome(0, nil)
+	executor.outcomes[2] = recordedOutcome(0, nil)
+	opts := shardTestOptions(2)
+	opts.Keep = true
+	var stderr bytes.Buffer
+	app := App{Stdout: io.Discard, Stderr: &stderr}
+	if err := app.shardRun(context.Background(), opts, &shardOutputMux{}, provisioner.provision, executor.run); err != nil {
+		t.Fatalf("shardRun: %v", err)
+	}
+	if _, releases := provisioner.stats(); releases != 0 {
+		t.Fatalf("releases=%d, want 0 with --keep", releases)
+	}
+	if !strings.Contains(stderr.String(), "kept lease=cbx_shard_1") {
+		t.Fatalf("stderr missing kept line:\n%s", stderr.String())
+	}
+}
+
+func TestShardProvisionFailureDoesNotOrphanSiblings(t *testing.T) {
+	provisioner := newShardTestProvisioner()
+	provisioner.errs[2] = errors.New("acquire failed")
+	executor := newShardTestExecutor()
+	executor.outcomes[1] = recordedOutcome(0, nil)
+	executor.outcomes[3] = recordedOutcome(0, nil)
+	app := App{Stdout: io.Discard, Stderr: io.Discard}
+	err := app.shardRun(context.Background(), shardTestOptions(3), &shardOutputMux{}, provisioner.provision, executor.run)
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 7 || exitErr.Message != "1 of 3 shards failed to provision or run" {
+		t.Fatalf("err=%v, want exit 7 provision failure", err)
+	}
+	if executor.callCount() != 2 {
+		t.Fatalf("calls=%d, want the failed shard skipped and siblings run", executor.callCount())
+	}
+	if executor.call(2) != nil {
+		t.Fatal("executor ran for the shard that failed to provision")
+	}
+	if _, releases := provisioner.stats(); releases != 2 {
+		t.Fatalf("releases=%d, want 2", releases)
+	}
+}
+
+func TestShardMergedVerdict(t *testing.T) {
+	provisioner := newShardTestProvisioner()
+	executor := newShardTestExecutor()
+	executor.outcomes[1] = recordedOutcome(0, &TestResultSummary{Format: "junit", Suites: 1, Tests: 10, Failures: 1, TimeSeconds: 2.5, Failed: []TestFailure{{Suite: "pkg", Name: "TestA", Kind: "failure", Message: "boom"}}})
+	executor.outcomes[2] = recordedOutcome(0, &TestResultSummary{Format: "junit", Suites: 1, Tests: 20, Skipped: 2, TimeSeconds: 3.5})
+	var stdout bytes.Buffer
+	app := App{Stdout: &stdout, Stderr: io.Discard}
+	if err := app.shardRun(context.Background(), shardTestOptions(2), &shardOutputMux{}, provisioner.provision, executor.run); err != nil {
+		t.Fatalf("shardRun: %v", err)
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"shard results",
+		"shard verdict shards=2 failed_shards=0 tests=30 failures=1 errors=0 skipped=2 suite_time=6.000s",
+		"failed:",
+		"[1/2]",
+		"TestA",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("stdout missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestShardFailOnTestFailuresAppliesToMergedSummary(t *testing.T) {
+	failing := &TestResultSummary{Format: "junit", Tests: 5, Failures: 1, Failed: []TestFailure{{Name: "TestB", Kind: "failure"}}}
+	cases := []struct {
+		name        string
+		exitCode    int
+		policy      bool
+		wantCode    int
+		wantMessage string
+	}{
+		{name: "policy fires on merged failures", exitCode: 0, policy: true, wantCode: 1, wantMessage: "JUnit results contain 1 failures and 0 errors"},
+		{name: "policy off keeps success", exitCode: 0, policy: false, wantCode: 0},
+		{name: "command failure takes precedence", exitCode: 2, policy: true, wantCode: 2, wantMessage: "1 of 1 shards failed"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			provisioner := newShardTestProvisioner()
+			executor := newShardTestExecutor()
+			executor.outcomes[1] = recordedOutcome(tc.exitCode, failing)
+			opts := shardTestOptions(1)
+			opts.FailOnTestFailures = tc.policy
+			app := App{Stdout: io.Discard, Stderr: io.Discard}
+			err := app.shardRun(context.Background(), opts, &shardOutputMux{}, provisioner.provision, executor.run)
+			if tc.wantCode == 0 {
+				if err != nil {
+					t.Fatalf("shardRun: %v", err)
+				}
+				return
+			}
+			var exitErr ExitError
+			if !AsExitError(err, &exitErr) || exitErr.Code != tc.wantCode || exitErr.Message != tc.wantMessage {
+				t.Fatalf("err=%v, want code=%d message=%q", err, tc.wantCode, tc.wantMessage)
+			}
+		})
+	}
+}
+
+func TestShardJSONReport(t *testing.T) {
+	provisioner := newShardTestProvisioner()
+	executor := newShardTestExecutor()
+	executor.outcomes[1] = recordedOutcome(0, &TestResultSummary{Format: "junit", Tests: 3, TimeSeconds: 1.5})
+	executor.outcomes[2] = recordedOutcome(2, nil)
+	opts := shardTestOptions(2)
+	opts.JSON = true
+	var stdout bytes.Buffer
+	app := App{Stdout: &stdout, Stderr: io.Discard}
+	err := app.shardRun(context.Background(), opts, &shardOutputMux{}, provisioner.provision, executor.run)
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("err=%v, want code 2", err)
+	}
+	var report shardJSONReport
+	if decodeErr := json.Unmarshal(stdout.Bytes(), &report); decodeErr != nil {
+		t.Fatalf("decode: %v\n%s", decodeErr, stdout.String())
+	}
+	if report.Checkpoint != "chk_test" || report.Count != 2 || len(report.Shards) != 2 || report.ExitCode != 2 {
+		t.Fatalf("report=%+v", report)
+	}
+	if report.Merged == nil || report.Merged.Tests != 3 {
+		t.Fatalf("merged=%+v", report.Merged)
+	}
+	if report.Failed == nil {
+		t.Fatal("failed must encode as [] not null")
+	}
+	if report.Shards[0].LeaseID != "cbx_shard_1" || report.Shards[1].ExitCode != 2 {
+		t.Fatalf("shards=%+v", report.Shards)
+	}
+}
+
+func TestShardRunArgsInjection(t *testing.T) {
+	args := shardRunArgs("cbx_123", 2, 4, []string{"--results-auto"}, []string{"pnpm", "test", "--", "--shard", "2/4"})
+	want := []string{"--id", "cbx_123", "--keep", "--label", "shard 2/4", "--fail-on-test-failures=false", "--results-auto", "--", "pnpm", "test", "--", "--shard", "2/4"}
+	if strings.Join(args, " ") != strings.Join(want, " ") {
+		t.Fatalf("args=%v\nwant=%v", args, want)
+	}
+}
+
+func TestPartitionShardRunArgs(t *testing.T) {
+	cases := []struct {
+		name    string
+		args    []string
+		wantOwn string
+		wantRun string
+		wantErr string
+	}{
+		{name: "owned only stays local", args: []string{"--count", "3", "--from", "chk_1", "--fail-fast"}, wantOwn: "--count 3 --from chk_1 --fail-fast"},
+		{name: "registered flags forward to both", args: []string{"--count", "2", "--junit", "junit.xml"}, wantOwn: "--count 2 --junit junit.xml", wantRun: "--junit junit.xml"},
+		{name: "unknown flags forward to run", args: []string{"--count", "2", "--no-hydrate"}, wantOwn: "--count 2", wantRun: "--no-hydrate"},
+		{name: "id is forbidden", args: []string{"--id", "cbx_1"}, wantErr: "--id cannot be used with shard"},
+		{name: "pool is forbidden", args: []string{"--pool", "ready"}, wantErr: "--pool cannot be used with shard"},
+		{name: "timing-record is forbidden", args: []string{"--timing-record", "default"}, wantErr: "--timing-record cannot be used with shard"},
+		{name: "capture-stdout is forbidden", args: []string{"--capture-stdout", "out.log"}, wantErr: "--capture-stdout cannot be used with shard"},
+		{name: "label is forbidden", args: []string{"--label", "mine"}, wantErr: "--label cannot be used with shard"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fs := newFlagSet("shard", io.Discard)
+			fs.Int("count", 0, "")
+			fs.String("from", "", "")
+			fs.Bool("fail-fast", false, "")
+			fs.String("junit", "", "")
+			own, run, err := partitionForwardedRunArgs(fs, tc.args, shardOwnedOnlyFlags, shardForbiddenRunFlags, "shard: it conflicts with parallel shard runs")
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err=%v, want %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("partition: %v", err)
+			}
+			if strings.Join(own, " ") != tc.wantOwn || strings.Join(run, " ") != tc.wantRun {
+				t.Fatalf("own=%v run=%v, want own=%q run=%q", own, run, tc.wantOwn, tc.wantRun)
+			}
+		})
+	}
+}
+
+func TestPrefixLineWriter(t *testing.T) {
+	cases := []struct {
+		name   string
+		writes []string
+		flush  bool
+		want   string
+	}{
+		{name: "single line", writes: []string{"hello\n"}, want: "[1/3] hello\n"},
+		{name: "multiple lines in one write", writes: []string{"a\nb\n"}, want: "[1/3] a\n[1/3] b\n"},
+		{name: "partial line buffers until newline", writes: []string{"par", "tial\n"}, want: "[1/3] partial\n"},
+		{name: "flush emits trailing partial", writes: []string{"tail"}, flush: true, want: "[1/3] tail\n"},
+		{name: "flush with empty buffer is silent", writes: []string{"done\n"}, flush: true, want: "[1/3] done\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var out bytes.Buffer
+			writer := &prefixLineWriter{mux: &shardOutputMux{}, out: &out, prefix: shardLinePrefix(1, 3)}
+			for _, chunk := range tc.writes {
+				if _, err := writer.Write([]byte(chunk)); err != nil {
+					t.Fatalf("write: %v", err)
+				}
+			}
+			if tc.flush {
+				if err := writer.Flush(); err != nil {
+					t.Fatalf("flush: %v", err)
+				}
+			}
+			if out.String() != tc.want {
+				t.Fatalf("out=%q, want %q", out.String(), tc.want)
+			}
+		})
+	}
+}
+
+func TestShardLinePrefixWidth(t *testing.T) {
+	if got := shardLinePrefix(3, 12); got != "[ 3/12] " {
+		t.Fatalf("prefix=%q", got)
+	}
+	if got := shardLinePrefix(11, 12); got != "[11/12] " {
+		t.Fatalf("prefix=%q", got)
+	}
+}
+
+func TestPrefixLineWriterOversizedPartialFlushes(t *testing.T) {
+	var out bytes.Buffer
+	writer := &prefixLineWriter{mux: &shardOutputMux{}, out: &out, prefix: "[1/2] "}
+	big := strings.Repeat("x", shardPartialLineLimit+1)
+	if _, err := writer.Write([]byte(big)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if !strings.HasPrefix(out.String(), "[1/2] xxx") || !strings.HasSuffix(out.String(), "x\n") {
+		t.Fatalf("oversized partial not flushed: len=%d", out.Len())
+	}
+}
+
+func TestPrefixLineWriterConcurrentLineIntegrity(t *testing.T) {
+	var out bytes.Buffer
+	mux := &shardOutputMux{}
+	var wg sync.WaitGroup
+	for i := 1; i <= 8; i++ {
+		writer := &prefixLineWriter{mux: mux, out: &out, prefix: shardLinePrefix(i, 8)}
+		wg.Add(1)
+		go func(index int, w *prefixLineWriter) {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				payload := fmt.Sprintf("shard%d-line%d", index, j)
+				w.Write([]byte(payload[:4]))
+				w.Write([]byte(payload[4:] + "\n"))
+			}
+		}(i, writer)
+	}
+	wg.Wait()
+	lines := strings.Split(strings.TrimSuffix(out.String(), "\n"), "\n")
+	if len(lines) != 400 {
+		t.Fatalf("lines=%d, want 400", len(lines))
+	}
+	for _, line := range lines {
+		rest := line
+		if !strings.HasPrefix(rest, "[") {
+			t.Fatalf("line missing prefix: %q", line)
+		}
+		end := strings.Index(rest, "] ")
+		if end < 0 {
+			t.Fatalf("line missing prefix close: %q", line)
+		}
+		payload := rest[end+2:]
+		if !strings.HasPrefix(payload, "shard") || !strings.Contains(payload, "-line") {
+			t.Fatalf("payload corrupted: %q", line)
+		}
+	}
+}
+
+func TestShardRejectsInvalidArgs(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "missing count", args: []string{"--from", "chk_1", "--", "pnpm", "test"}, want: "--count must be at least 1"},
+		{name: "zero count", args: []string{"--count", "0", "--from", "chk_1", "--", "pnpm", "test"}, want: "--count must be at least 1"},
+		{name: "missing from", args: []string{"--count", "2", "--", "pnpm", "test"}, want: "usage: crabbox shard"},
+		{name: "missing command", args: []string{"--count", "2", "--from", "chk_1"}, want: "usage: crabbox shard"},
+		{name: "positional argument", args: []string{"--count", "2", "--from", "chk_1", "stray", "--", "pnpm", "test"}, want: "place the command after --"},
+		{name: "forbidden run flag", args: []string{"--count", "2", "--from", "chk_1", "--pool", "ready", "--", "pnpm", "test"}, want: "--pool cannot be used with shard"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+			app := App{Stdout: io.Discard, Stderr: io.Discard}
+			err := app.shard(context.Background(), tc.args)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("err=%v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestShardMaxCountCap(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	configDir := t.TempDir()
+	configPath := filepath.Join(configDir, "crabbox.yaml")
+	if err := os.WriteFile(configPath, []byte("shard:\n  maxCount: 2\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CRABBOX_CONFIG", configPath)
+	store, err := defaultCheckpointStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := store.Create(checkpointRecord{ID: "chk_shard_cap", Kind: checkpointKindArchive, CreatedAt: time.Now().UTC().Format(time.RFC3339)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	app := App{Stdout: io.Discard, Stderr: io.Discard}
+	err = app.shard(context.Background(), []string{"--count", "3", "--from", record.ID, "--", "pnpm", "test"})
+	if err == nil || !strings.Contains(err.Error(), "--count 3 exceeds shard.maxCount 2") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestShardDryRunPrintsPlan(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+	store, err := defaultCheckpointStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := store.Create(checkpointRecord{ID: "chk_shard_dry", Kind: checkpointKindArchive, CreatedAt: time.Now().UTC().Format(time.RFC3339)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stdout bytes.Buffer
+	app := App{Stdout: &stdout, Stderr: io.Discard}
+	err = app.shard(context.Background(), []string{
+		"--count", "2", "--from", record.ID, "--dry-run", "--slug", "Suite",
+		"--", "pnpm", "test", "--", "--shard", "{{index}}/{{total}}",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		`would shard checkpoint id=chk_shard_dry`,
+		`slug=suite-1 keep=false index=1/2 command="pnpm test -- --shard 1/2"`,
+		`slug=suite-2 keep=false index=2/2 command="pnpm test -- --shard 2/2"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("stdout missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestShardHelpPrintsUsage(t *testing.T) {
+	var stderr bytes.Buffer
+	app := App{Stdout: io.Discard, Stderr: &stderr}
+	err := app.shard(context.Background(), []string{"--help"})
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 0 {
+		t.Fatalf("err=%v, want ExitError code 0", err)
+	}
+	if !strings.Contains(stderr.String(), "Usage:") {
+		t.Fatalf("help missing Usage block:\n%s", stderr.String())
+	}
+}

--- a/internal/cli/watch.go
+++ b/internal/cli/watch.go
@@ -642,7 +642,11 @@ func watchFlagIsBool(fs *flag.FlagSet, name string) bool {
 }
 
 func partitionWatchRunArgs(fs *flag.FlagSet, flagArgs []string) ([]string, []string, error) {
-	watchArgs := []string{}
+	return partitionForwardedRunArgs(fs, flagArgs, watchOwnedOnlyFlags, watchForbiddenRunFlags, "watch: it conflicts with a persistent watch session")
+}
+
+func partitionForwardedRunArgs(fs *flag.FlagSet, flagArgs []string, ownedOnly, forbidden map[string]bool, forbiddenReason string) ([]string, []string, error) {
+	ownArgs := []string{}
 	runArgs := []string{}
 	i := 0
 	for i < len(flagArgs) {
@@ -660,12 +664,12 @@ func partitionWatchRunArgs(fs *flag.FlagSet, flagArgs []string) ([]string, []str
 			return nil, nil, exit(2, "invalid flag %q", token)
 		}
 		if name == "h" || name == "help" {
-			watchArgs = append(watchArgs, token)
+			ownArgs = append(ownArgs, token)
 			i++
 			continue
 		}
-		if watchForbiddenRunFlags[name] {
-			return nil, nil, exit(2, "--%s cannot be used with watch: it conflicts with a persistent watch session", name)
+		if forbidden[name] {
+			return nil, nil, exit(2, "--%s cannot be used with %s", name, forbiddenReason)
 		}
 		known := fs.Lookup(name) != nil
 		consume := 0
@@ -681,15 +685,15 @@ func partitionWatchRunArgs(fs *flag.FlagSet, flagArgs []string) ([]string, []str
 		}
 		tokens := flagArgs[i : i+1+consume]
 		switch {
-		case watchOwnedOnlyFlags[name]:
-			watchArgs = append(watchArgs, tokens...)
+		case ownedOnly[name]:
+			ownArgs = append(ownArgs, tokens...)
 		case known:
-			watchArgs = append(watchArgs, tokens...)
+			ownArgs = append(ownArgs, tokens...)
 			runArgs = append(runArgs, tokens...)
 		default:
 			runArgs = append(runArgs, tokens...)
 		}
 		i += 1 + consume
 	}
-	return watchArgs, runArgs, nil
+	return ownArgs, runArgs, nil
 }


### PR DESCRIPTION
Implements the approved proposal https://github.com/openclaw/crabbox/issues/839. @steipete replied "seems worthwhile" to the proposal, so this is the bounded v1 described there: a new `crabbox shard` command that forks a checkpoint into `--count` leases concurrently, runs the templated command on every fork in parallel through the normal run pipeline, and merges the per-shard JUnit summaries into one locally printed suite verdict with an aggregate exit code.

## Problem

The command fan-out shipped in https://github.com/openclaw/crabbox/pull/836 documents test sharding as its flagship example, but the `--count` loop in `internal/cli/checkpoint.go` is strictly sequential and returns on the first error, and nothing merges the per-run JUnit summaries. Three shards cost the full suite runtime plus three fork setups, a failing shard hides the state of the rest of the suite, and answering "did the suite pass" means walking N run ids by hand.

## What this PR does

- `crabbox shard --count <n> --from <checkpoint-id> [run flags] -- <command...>`: forks concurrently via the exact provisioning flow `checkpoint fork` uses, then runs every shard in parallel through `crabbox run` with an injected `--id` and a `shard N/M` label, so sync, history, logs, artifacts, and results behave exactly as for `run`. The `{{index}}`/`{{total}}`/`{{lease}}`/`{{slug}}` placeholders and slug suffixing are reused unchanged.
- Live streaming with a stable `[i/N]` line prefix across all shards (one shared mutex, line-buffered writers); `--quiet` keeps only the per-shard lifecycle lines.
- A failing shard does not abort the others; `--fail-fast` opts into canceling the remaining shards. Interrupted shards are reported as `canceled`, never as failed, and a pure interrupt exits 130.
- With results wiring (`--junit`, `--results-auto`, or repo config), per-shard summaries merge through the existing `mergeJUnitSummary` into one verdict: per-shard table, merged totals with suite time vs wall clock, and every failed case with its shard index and run id, as text or `--json`.
- Aggregate exit code, in precedence order: 7 when any shard failed to provision or run (the verdict is incomplete, so infrastructure failures are never masked by test failures); otherwise the failing shards' command exit code (or 1 when they disagree); otherwise `--fail-on-test-failures` evaluated against the merged summary only (the flag is forced off inside each shard so the policy applies once, to the whole suite).
- Guaranteed release: every fork is released on success, failure, and Ctrl-C via a fresh context; a shard that fails to provision does not orphan its siblings; `--keep` retains the forks.
- Cost stance: `--count` is required with no default, the plan is printed before provisioning, forks exist only for the duration of their shard, and a new repo config key `shard.maxCount` bounds what a checkout may request.

## Delegated design decisions

The proposal asked three questions that were left open, so v1 ships the defaults stated on the issue; all three are easy to change if you prefer otherwise:

1. Command shape: a new top-level `crabbox shard` rather than `checkpoint fork --parallel`.
2. Failure mode: run-all-shards-to-completion by default, `--fail-fast` opt-in.
3. Persistence: the merged verdict is printed locally only; each shard's run record keeps its own JUnit summary on the coordinator; no coordinator or worker changes.

## Implementation notes

- `internal/cli/checkpoint.go`: the provisioning sequence of `checkpointForkRecordOnce` (acquire, claim, network resolve, restore) is extracted into `provisionCheckpointFork` so fork and shard share it; fork behavior is unchanged and the existing fork tests pass untouched. The release guard is upgraded from a bool to `sync.Once` so it is safe under concurrent callers.
- `internal/cli/run.go`: a 6-line outcome sink after `recorder.Finish` surfaces each run's exit code, run id, and parsed `TestResultSummary` to in-process callers; the sink is nil for every existing caller.
- `internal/cli/watch.go`: `partitionWatchRunArgs` is generalized into `partitionForwardedRunArgs` (same behavior, parameterized flag sets) so shard reuses the watch arg-partitioning rules; flags that conflict with parallel runs (`--id`, `--pool`, `--capture-stdout`, `--timing-record`, `--label`, ...) are rejected with a clear error.
- Provider-neutral: dispatch goes through the same `SSHLeaseBackend` seam as `checkpoint fork`; delegated providers keep a clear error; provider-native snapshot fan-out stays on `checkpoint fork --snapshot`.

Review updates: infrastructure failures now take precedence over command failures in the aggregate exit code (a mixed test+infra run exits 7 instead of looking like an ordinary suite failure); text-verdict failed case lines carry the shard's run id (`[2/3] run=run_...`), matching the documented attribution; and post-acquire provisioning failures release the fork with a fresh context, so cancellation during claim, network resolution, or restore can no longer leak the just-acquired lease (the pre-PR fork error paths passed the live context too, so this also hardens `checkpoint fork` under Ctrl-C; shard's fail-fast made it routinely reachable). All three changes have regression tests.

## Real behavior proof

Recorded against a live external-provider lease fleet (local SSH adapter), archive checkpoint of a repo with a 3-way shardable suite where each shard takes ~6s. Full transcript available on request.

Before, on main: the documented fan-out is serial (~20s for 3 x 6s shards) and aborts on the first failing shard:

```text
$ time crabbox checkpoint fork chk_8dc76c9ccc34a469 --keep=false --count 3 -- sh ./suite.sh '{{index}}' '{{total}}'
checkpoint fork command lease=cbx_9d7eb76e964a slug=brisk-barnacle index=1/3 command=sh ./suite.sh 1 3
suite shard 1/3 finished mode=pass
checkpoint fork command lease=cbx_35d85d0f1118 slug=swift-lobster index=2/3 command=sh ./suite.sh 2 3
suite shard 2/3 finished mode=pass
checkpoint fork command lease=cbx_14b752aa273e slug=golden-crayfish index=3/3 command=sh ./suite.sh 3 3
suite shard 3/3 finished mode=pass
real 20.186s

$ crabbox checkpoint fork chk_8dc76c9ccc34a469 --keep=false --count 3 -- sh ./suite.sh '{{index}}' '{{total}}' fail
checkpoint fork command lease=cbx_fd646cd4bc57 slug=coral-shrimp index=1/3 command=sh ./suite.sh 1 3 fail
checkpoint fork command lease=cbx_52527bf06c05 slug=silver-barnacle index=2/3 command=sh ./suite.sh 2 3 fail
remote command exited 1
exit=1   (shard 3 never ran; no merged verdict)
```

After, with this PR: the same three shards run concurrently (~7s wall for 18s of suite time) with one merged verdict:

```text
$ time crabbox shard --count 3 --from chk_8dc76c9ccc34a469 --junit junit-shard.xml -- sh ./suite.sh '{{index}}' '{{total}}'
[3/3] running on 127.0.0.1 sh ./suite.sh 3 3
[2/3] running on 127.0.0.1 sh ./suite.sh 2 3
[1/3] running on 127.0.0.1 sh ./suite.sh 1 3
...
shard results
SHARD  LEASE             RUN  EXIT  TESTS  FAIL  ERR  SKIP  TIME
1/3    cbx_324ca5499b92  -    0     4      0     0    1     6.0s
2/3    cbx_497cab1dae1a  -    0     4      0     0    1     6.0s
3/3    cbx_0684531e5214  -    0     4      0     0    1     6.0s
shard verdict shards=3 failed_shards=0 tests=12 failures=0 errors=0 skipped=3 suite_time=18.000s wall=6.942s
real 6.999s
exit=0
```

A failing shard no longer hides the rest of the suite, and the failed case is attributed to its shard and run (run ids are `-` here because the fleet runs without a coordinator; with one configured the recorded `run_...` id is printed):

```text
$ crabbox shard --count 3 --from chk_8dc76c9ccc34a469 --junit junit-shard.xml -- sh ./suite.sh '{{index}}' '{{total}}' fail
shard verdict shards=3 failed_shards=1 tests=12 failures=1 errors=0 skipped=2 suite_time=18.100s wall=7.009s
failed:
  [2/3] run=-  src/cart.test.js failure  my-app.shard2.test_cart_coupon — expected 3 got 2
1 of 3 shards failed
exit=1
```

`--fail-on-test-failures` fires on the merged summary even though every shard command exited 0:

```text
$ crabbox shard --count 3 --from chk_8dc76c9ccc34a469 --junit junit-shard.xml --fail-on-test-failures --quiet -- sh ./suite.sh '{{index}}' '{{total}}' softfail
shard 2/3 done exit=0 tests=4 failures=1 errors=0
shard verdict shards=3 failed_shards=0 tests=12 failures=1 errors=0 skipped=2 suite_time=18.100s wall=6.899s
JUnit results contain 1 failures and 0 errors
exit=1
```

Ctrl-C mid-run cancels cleanly and releases every fork; the provider state afterwards holds only the kept base lease:

```text
$ crabbox shard --count 3 --from chk_8dc76c9ccc34a469 --quiet -- sh ./suite.sh '{{index}}' '{{total}}' &  sleep 4; kill -INT $!
shard 3/3 canceled
shard 2/3 canceled
shard 1/3 canceled
shard verdict shards=3 failed_shards=0 canceled=3 wall=6.806s
shard interrupted; 3 of 3 shards canceled
exit=130

$ cat adapter-state.json
['cbx_43c1cadc3525']   (only the kept base lease; all forks created across the session were released)
```

The serial `checkpoint fork` demo above was recorded with this PR's binary, confirming the extraction left fork behavior unchanged.

## Verification

```sh
gofmt -l $(git ls-files '*.go')                                   # clean
go vet ./...                                                      # clean
go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...        # clean
go test -race ./internal/cli/                                     # ok
go test ./... -covermode=atomic -coverprofile=...                 # core coverage 90.0% >= 90.0%
scripts/check-docs.sh                                             # 53 command docs, links ok
```

New tests in `internal/cli/shard_test.go` cover: shards actually overlapping (blocking executor), run-all-after-failure, fail-fast cancellation, releases on every path including interrupt with a fresh context, `--keep`, provision failure not orphaning siblings, infra-over-command exit precedence, merged verdict math with run-id attribution, the merged `--fail-on-test-failures` policy and its precedence, JSON report shape, arg partitioning and every forbidden flag, the prefix writer including concurrent line integrity under `-race`, `shard.maxCount`, dry-run, and `--help`.

Config implications: one new optional repo config key, `shard.maxCount` (bounds `--count`; unset means no cap). No secrets, no coordinator or worker changes. CHANGELOG intentionally left to maintainers.