### PR TITLE
fix: release forks with a fresh context when provisioning fails after acquire

### DIFF
--- a/internal/cli/checkpoint.go
+++ b/internal/cli/checkpoint.go
@@ -844,11 +844,11 @@ func (a App) provisionCheckpointFork(ctx context.Context, cfg Config, backend Ba
 	}
 	applyResolvedServerConfig(&cfg, server)
 	if err := a.claimLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, server, target, repo.Root, reclaim); err != nil {
-		release(ctx)
+		release(context.Background())
 		return checkpointForkProvision{}, err
 	}
 	if resolved, err := resolveNetworkTarget(ctx, cfg, server, target); err != nil {
-		release(ctx)
+		release(context.Background())
 		return checkpointForkProvision{}, err
 	} else {
 		target = resolved.Target
@@ -863,11 +863,11 @@ func (a App) provisionCheckpointFork(ctx context.Context, cfg Config, backend Ba
 		}
 		workdir := nativeCheckpointForkWorkdir(cfg, leaseID, repo.Name, workdirOverride)
 		if err := validateCheckpointForkWorkdirs(ctx, backend, forkLease, record.Workdir, workdir); err != nil {
-			release(ctx)
+			release(context.Background())
 			return checkpointForkProvision{}, err
 		}
 		if err := relocateNativeCheckpointWorkdir(ctx, target, record.Workdir, workdir); err != nil {
-			release(ctx)
+			release(context.Background())
 			return checkpointForkProvision{}, err
 		}
 		return checkpointForkProvision{Lease: forkLease, Workdir: workdir, Release: release}, nil
@@ -877,11 +877,11 @@ func (a App) provisionCheckpointFork(ctx context.Context, cfg Config, backend Ba
 		workdir = defaultCheckpointRestoreWorkdir(cfg, leaseID, repo.Name, record.Workdir)
 	}
 	if err := validateCheckpointForkWorkdirs(ctx, backend, forkLease, workdir); err != nil {
-		release(ctx)
+		release(context.Background())
 		return checkpointForkProvision{}, err
 	}
 	if err := restoreCheckpointArchive(ctx, target, checkpointArchivePath(paths, record), record.ID, workdir, clear); err != nil {
-		release(ctx)
+		release(context.Background())
 		return checkpointForkProvision{}, err
 	}
 	return checkpointForkProvision{Lease: forkLease, Workdir: workdir, Release: release}, nil

--- a/internal/cli/checkpoint_test.go
+++ b/internal/cli/checkpoint_test.go
@@ -14,6 +14,43 @@ import (
 	"time"
 )
 
+func TestProvisionCheckpointForkReleasesWithFreshContextWhenCanceled(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+	t.Setenv("CRABBOX_COORDINATOR", "")
+	store, err := defaultCheckpointStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	created, err := store.Create(checkpointRecord{ID: "chk_cancel_release", Kind: checkpointKindArchive, CreatedAt: time.Now().UTC().Format(time.RFC3339)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, paths, err := store.Read(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend := newWatchTestBackend()
+	app := App{Stdout: io.Discard, Stderr: io.Discard}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	cfg := Config{Provider: "watch-test"}
+	_, provisionErr := app.provisionCheckpointFork(ctx, cfg, backend, backend, Repo{Root: t.TempDir(), Name: "my-app"}, record, paths, false, false, "", "", true)
+	if provisionErr == nil {
+		t.Fatal("provision succeeded under canceled context")
+	}
+	acquires, _, releases := backend.counts()
+	if acquires != 1 || releases != 1 {
+		t.Fatalf("acquire=%d release=%d, want 1/1", acquires, releases)
+	}
+	backend.mu.Lock()
+	releaseCtx := backend.releaseCtx
+	backend.mu.Unlock()
+	if releaseCtx == nil || releaseCtx.Err() != nil {
+		t.Fatalf("release used the canceled context: %v", releaseCtx)
+	}
+}
+
 func TestValidateCheckpointID(t *testing.T) {
 	if got, err := validateCheckpointID("chk_abc-123_DEF"); err != nil || got != "chk_abc-123_DEF" {
 		t.Fatalf("valid id got=%q err=%v", got, err)


### PR DESCRIPTION
Follow-up to https://github.com/openclaw/crabbox/pull/842. The final ClawSweeper review on that PR flagged a P1 ("Release acquired forks with a fresh context", `internal/cli/checkpoint.go`); the fix commit raced the merge by a few minutes and did not land, so this PR carries exactly that commit.

## Problem

`provisionCheckpointFork` (shared by `checkpoint fork` and `shard`) releases the just-acquired lease with the caller's context when a post-acquire step fails: claim, network resolution, workdir validation, native relocation, or archive restore. If the failure is caused by cancellation, that context is already canceled, `releaseBackendLeaseBestEffort` forwards it into `backend.ReleaseLease`, and the fork is left behind before the success-path defer (which already uses a fresh context) is installed.

The pre-#842 fork error paths passed the live context the same way, so this is inherited rather than introduced by the extraction; `crabbox shard` made it routinely reachable because `--fail-fast` and Ctrl-C cancel sibling shards mid-provision as a matter of course.

## Fix

All post-acquire error-path releases in `provisionCheckpointFork` now use `context.Background()`, matching the success-path defer and the run path's lease cleanup (`internal/cli/run.go` uses a fresh context for its deferred release for the same reason). One behavior change, no new surface.

## Real behavior proof

Regression test drives the real `provisionCheckpointFork` against a fake `SSHLeaseBackend` with an already-canceled context and asserts `ReleaseLease` receives an uncancelled context.

Before, on main at https://github.com/openclaw/crabbox/commit/991cd1cdeb30:

```text
=== RUN   TestProvisionCheckpointForkReleasesWithFreshContextWhenCanceled
    checkpoint_test.go:50: release used the canceled context: context.Background.WithCancel
--- FAIL: TestProvisionCheckpointForkReleasesWithFreshContextWhenCanceled (0.01s)
```

After, with this PR:

```text
=== RUN   TestProvisionCheckpointForkReleasesWithFreshContextWhenCanceled
--- PASS: TestProvisionCheckpointForkReleasesWithFreshContextWhenCanceled (0.01s)
ok      github.com/openclaw/crabbox/internal/cli
```

## Verification

```sh
gofmt -l $(git ls-files '*.go')     # clean
go vet ./internal/cli/              # clean
go test -race ./internal/cli/       # ok
```

No config or secret implications. No coordinator or worker changes.
