### PR TITLE
fix(worker): secure shared WebVNC credential handoffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- Replaced raw generated VNC credentials in copied WebVNC links with short-lived, one-time, authorization-checked handoff tickets. Thanks @coygeek.
 - Closed restored WebVNC viewer sockets that lack a complete current organization-bound principal instead of retaining owner-only legacy authorization. Thanks @coygeek.
 - Enforced key-only OpenSSH authentication across managed Windows desktop, core, and WSL2 bootstraps while retaining generated Windows passwords for console and VNC use. Thanks @coygeek.
 - Compared coordinator admin, shared-operator, runtime-adapter, proxy, and signed-session secrets without mismatch-position or early length exits. Thanks @coygeek.

--- a/worker/node/node-runtime.ts
+++ b/worker/node/node-runtime.ts
@@ -14,6 +14,7 @@ import type {
 import { PostgresCoordinatorStorage } from "./postgres-storage";
 
 const alarmQueue = "coordinator-alarm";
+const alarmTimeStorageKey = "node-runtime:alarm-time";
 const reconcileQueue = "coordinator-reconcile";
 const bridgeDataAttachmentKinds = new Set([
   "webvnc-agent",
@@ -220,6 +221,15 @@ export class NodeCoordinatorRuntime implements CoordinatorRuntime {
     this.acceptWebSocket(socket, { kind: "workspace-terminal" }, [], handlers);
   }
 
+  async getAlarm(): Promise<number | undefined> {
+    const value = await this.storage.get<unknown>(alarmTimeStorageKey);
+    return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+  }
+
+  take<T>(key: string): Promise<T | undefined> {
+    return this.storage.take<T>(key);
+  }
+
   async scheduleAlarm(time: number): Promise<void> {
     await this.boss.deleteQueuedJobs(alarmQueue);
     await this.boss.send(alarmQueue, null, {
@@ -229,10 +239,12 @@ export class NodeCoordinatorRuntime implements CoordinatorRuntime {
       retryDelay: 5,
       retryBackoff: true,
     });
+    await this.storage.put(alarmTimeStorageKey, time);
   }
 
   async clearAlarm(): Promise<void> {
     await this.boss.deleteQueuedJobs(alarmQueue);
+    await this.storage.delete(alarmTimeStorageKey);
   }
 
   private runAlarm(): Promise<void> {

--- a/worker/node/postgres-storage.ts
+++ b/worker/node/postgres-storage.ts
@@ -90,6 +90,22 @@ export class PostgresCoordinatorStorage implements CoordinatorStorage {
     await this.pool.query(`delete from ${table} where key = $1`, [key]);
   }
 
+  async take<T>(key: string): Promise<T | undefined> {
+    const result = await this.pool.query<{ encoded_value: unknown }>(
+      `
+        delete from ${table}
+        where key = $1
+        returning case
+          when value_text_updated_at = updated_at then value_text
+          else value::text
+        end as encoded_value
+      `,
+      [key],
+    );
+    const row = result.rows[0];
+    return row ? decodeStoredValue<T>(row.encoded_value) : undefined;
+  }
+
   async list<T>({ prefix = "" }: { prefix?: string } = {}): Promise<Map<string, T>> {
     const result = await this.pool.query<{ key: string; encoded_value: unknown }>(
       `

--- a/worker/src/coordinator-runtime.ts
+++ b/worker/src/coordinator-runtime.ts
@@ -128,6 +128,8 @@ export interface CoordinatorRuntime {
     handlers: CoordinatorSocketHandlers,
   ): void;
   acceptEphemeralWebSocket(socket: WebSocket, handlers: CoordinatorSocketHandlers): void;
+  take<T>(key: string): Promise<T | undefined>;
+  getAlarm(): Promise<number | undefined>;
   scheduleAlarm(time: number): Promise<void>;
   clearAlarm(): Promise<void>;
 }
@@ -213,6 +215,20 @@ export class CloudflareCoordinatorRuntime implements CoordinatorRuntime {
     });
     socket.addEventListener("error", () => {
       handlers.error();
+    });
+  }
+
+  async getAlarm(): Promise<number | undefined> {
+    return (await this.state.storage.getAlarm()) ?? undefined;
+  }
+
+  take<T>(key: string): Promise<T | undefined> {
+    return this.state.storage.transaction(async (transaction) => {
+      const value = await transaction.get<T>(key);
+      if (value !== undefined) {
+        await transaction.delete(key);
+      }
+      return value;
     });
   }
 

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -145,6 +145,7 @@ import type {
 } from "./types";
 import { coordinatorProviders, coordinatorProviderSpec, isCoordinatorProvider } from "./types";
 import { costLimits, enforceCostLimits, leaseCost, requestOrg, usageSummary } from "./usage";
+import { WebVNCCredentialHandoffs } from "./webvnc-handoff";
 
 const fleetID = "default";
 const maxStoredRunLogBytes = 8 * 1024 * 1024;
@@ -761,12 +762,14 @@ export class FleetCoordinator {
   private awsIngressBarrier: Promise<void> = Promise.resolve();
   private readonly awsIngressAdditiveOperations = new Set<Promise<void>>();
   private providerMaintenanceQueue: Promise<void> = Promise.resolve();
+  private readonly webVNCCredentialHandoffs: WebVNCCredentialHandoffs;
 
   constructor(
     private readonly state: CoordinatorRuntime,
     private readonly env: Env,
     private readonly testProviders: Partial<Record<Provider, CloudProvider>> = {},
   ) {
+    this.webVNCCredentialHandoffs = new WebVNCCredentialHandoffs(state);
     this.restoreBridgeWebSockets();
   }
 
@@ -1629,6 +1632,7 @@ export class FleetCoordinator {
       throw new Error("restored bridge lease state is temporarily unavailable");
     }
     await this.expireLeases();
+    await this.webVNCCredentialHandoffs.cleanupExpired();
     await this.reconcileRuntimeAdapterDeletes();
     await this.maintainWorkspacePrewarm();
     await this.provisionPendingWorkspace();
@@ -5193,6 +5197,16 @@ export class FleetCoordinator {
       });
     }
     if (
+      method === "POST" &&
+      parts[1] === "leases" &&
+      parts[2] &&
+      parts[3] === "vnc" &&
+      parts[4] === "handoff" &&
+      parts[5] === undefined
+    ) {
+      return await this.webVNCCredentialHandoff(request, parts[2]);
+    }
+    if (
       method === "GET" &&
       parts[1] === "leases" &&
       parts[2] &&
@@ -7176,6 +7190,53 @@ export class FleetCoordinator {
           ? `WebVNC daemon not running; run: ${command}`
           : "WebVNC daemon not running; ask a lease manager to start or refresh the bridge",
     });
+  }
+
+  private async webVNCCredentialHandoff(request: Request, identifier: string): Promise<Response> {
+    const lease = await this.resolvePortalLease(identifier, request);
+    if (!lease) {
+      return notFound();
+    }
+    const error = webVNCLeaseError(lease);
+    if (error) {
+      return json({ error: "webvnc_unavailable", message: error }, { status: 409 });
+    }
+    const body = (await request.json().catch(() => undefined)) as
+      | { ticket?: unknown; username?: unknown; password?: unknown }
+      | undefined;
+    if (typeof body?.ticket === "string") {
+      const result = await this.webVNCCredentialHandoffs.consume(lease.id, body.ticket);
+      if (result.status !== "accepted") {
+        const expired = result.status === "expired";
+        return json(
+          {
+            error: expired ? "expired_handoff" : "invalid_handoff",
+            message: expired ? "VNC handoff expired" : "valid VNC handoff required",
+          },
+          { status: 401 },
+        );
+      }
+      return json(
+        { username: result.username, password: result.password },
+        { headers: { "cache-control": "no-store" } },
+      );
+    }
+    if (!this.leaseManageableByRequest(lease, request, isAdminRequest(request))) {
+      return json({ error: "forbidden", message: "lease manage access required" }, { status: 403 });
+    }
+    const username = typeof body?.username === "string" ? body.username : "";
+    const password = typeof body?.password === "string" ? body.password : "";
+    if ((!username && !password) || username.length > 256 || password.length > 1024) {
+      return json(
+        { error: "invalid_credentials", message: "valid VNC credentials required" },
+        { status: 400 },
+      );
+    }
+    const handoff = await this.webVNCCredentialHandoffs.issue(lease.id, { username, password });
+    return json(
+      { ticket: handoff.ticket, expiresAt: handoff.expiresAt },
+      { headers: { "cache-control": "no-store" } },
+    );
   }
 
   private async webVNCReset(request: Request, identifier: string): Promise<Response> {
@@ -10108,6 +10169,7 @@ export class FleetCoordinator {
       })
       .map((lease) => nextLeaseAlarmTime(lease))
       .filter((time) => Number.isFinite(time));
+    alarmTimes.push(...(await this.webVNCCredentialHandoffs.alarmTimes(now)));
     const leasesByID = new Map([...leases.values()].map((lease) => [lease.id, lease]));
     const workspaceAlarm = [...workspaces.values()]
       .map((workspace) =>

--- a/worker/src/portal.ts
+++ b/worker/src/portal.ts
@@ -1017,6 +1017,7 @@ export function portalVNC(lease: LeaseRecord, options: { canManage?: boolean } =
   const statusPath = `/portal/leases/${encodeURIComponent(lease.id)}/vnc/status`;
   const controlPath = `/portal/leases/${encodeURIComponent(lease.id)}/vnc/control`;
   const themePath = `/portal/leases/${encodeURIComponent(lease.id)}/vnc/theme`;
+  const handoffPath = `/portal/leases/${encodeURIComponent(lease.id)}/vnc/handoff`;
   const sharePath = `/portal/leases/${encodeURIComponent(lease.id)}/share`;
   const shareAPIPath = `${sharePath}?format=json`;
   const canManage = options.canManage === true;
@@ -1132,6 +1133,7 @@ export function portalVNC(lease: LeaseRecord, options: { canManage?: boolean } =
       const statusURL = new URL(${JSON.stringify(statusPath)}, window.location.href);
       const controlURL = new URL(${JSON.stringify(controlPath)}, window.location.href);
       const themeURL = new URL(${JSON.stringify(themePath)}, window.location.href);
+      const handoffURL = new URL(${JSON.stringify(handoffPath)}, window.location.href);
       const sharePageURL = new URL(${JSON.stringify(sharePath)}, window.location.href);
       const shareAPIURL = new URL(${JSON.stringify(shareAPIPath)}, window.location.href);
       const shareInitial = ${scriptJSON(shareData)};
@@ -1140,16 +1142,38 @@ export function portalVNC(lease: LeaseRecord, options: { canManage?: boolean } =
       statusURL.searchParams.set("viewer", viewerID);
       const fragment = new URLSearchParams(window.location.hash.slice(1));
       const target = ${JSON.stringify(target)};
-      const username = fragment.get("username") || "";
-      const password = fragment.get("password") || "";
+      let username = fragment.get("username") || "";
+      let password = fragment.get("password") || "";
+      const handoffTicket = fragment.get("handoff") || "";
+      let credentialsReady = !handoffTicket;
       const takeControlOnConnect = fragment.get("control") === "take";
       const bridgeMissingMessage = ${JSON.stringify(bridgeMissingMessage)};
-      const credentials = {};
-      if (username) credentials.username = username;
-      if (password) credentials.password = password;
-      const options = Object.keys(credentials).length ? { credentials } : {};
       const missingVNCCredentialMessage = "VNC credentials missing; open WebVNC from crabbox webvnc status";
       const failedVNCCredentialMessage = "VNC authentication failed; reopen WebVNC from crabbox webvnc status";
+      function rfbOptions() {
+        const credentials = {};
+        if (username) credentials.username = username;
+        if (password) credentials.password = password;
+        return Object.keys(credentials).length ? { credentials } : {};
+      }
+      async function loadHandoffCredentials() {
+        if (credentialsReady) return;
+        const response = await fetch(handoffURL, {
+          method: "POST",
+          headers: { "content-type": "application/json", accept: "application/json" },
+          body: JSON.stringify({ ticket: handoffTicket }),
+        });
+        const body = await response.json().catch(() => ({}));
+        if (!response.ok) throw new Error(body.message || body.error || "VNC handoff failed");
+        username = typeof body.username === "string" ? body.username : "";
+        password = typeof body.password === "string" ? body.password : "";
+        credentialsReady = true;
+        const cleanFragment = new URLSearchParams(window.location.hash.slice(1));
+        cleanFragment.delete("handoff");
+        const cleanURL = new URL(window.location.href);
+        cleanURL.hash = cleanFragment.toString();
+        window.history.replaceState(null, "", cleanURL);
+      }
       function setStatus(value, tone = "") {
         status.textContent = value;
         status.dataset.tone = tone;
@@ -1359,6 +1383,7 @@ export function portalVNC(lease: LeaseRecord, options: { canManage?: boolean } =
         authenticationFailed = false;
         screen.replaceChildren();
         try {
+          await loadHandoffCredentials();
           const state = await bridgeState();
           if (state?.terminal) {
             stopPolling(state.message || "WebVNC bridge unavailable");
@@ -1382,7 +1407,7 @@ export function portalVNC(lease: LeaseRecord, options: { canManage?: boolean } =
           }
           setStatus(retryAttempt ? "bridge connected; opening viewer" : "connecting");
           clearDesktopThemeSyncState();
-          rfb = new RFB(screen, wsURL.toString(), options);
+          rfb = new RFB(screen, wsURL.toString(), rfbOptions());
           rfb.showDotCursor = true;
           rfb.focusOnClick = true;
           rfb.scaleViewport = true;
@@ -1509,11 +1534,18 @@ export function portalVNC(lease: LeaseRecord, options: { canManage?: boolean } =
       function normalizedShareUser(value) {
         return String(value || "").trim().toLowerCase();
       }
-      function shareableWebVNCURL() {
+      async function shareableWebVNCURL() {
+        if (!username && !password) throw new Error(missingVNCCredentialMessage);
+        const response = await fetch(handoffURL, {
+          method: "POST",
+          headers: { "content-type": "application/json", accept: "application/json" },
+          body: JSON.stringify({ username, password }),
+        });
+        const body = await response.json().catch(() => ({}));
+        if (!response.ok) throw new Error(body.message || body.error || "VNC handoff failed");
         const url = new URL(window.location.href);
         const linkFragment = new URLSearchParams();
-        if (username) linkFragment.set("username", username);
-        if (password) linkFragment.set("password", password);
+        linkFragment.set("handoff", body.ticket);
         url.hash = linkFragment.toString();
         return url.toString();
       }
@@ -1687,7 +1719,7 @@ export function portalVNC(lease: LeaseRecord, options: { canManage?: boolean } =
       });
       shareCopyLinkBtn?.addEventListener("click", async () => {
         try {
-          await writeClipboardText(shareableWebVNCURL());
+          await writeClipboardText(await shareableWebVNCURL());
           setShareStatus("WebVNC link copied", "ok");
         } catch (error) {
           setShareStatus(error instanceof Error ? error.message : String(error), "bad");

--- a/worker/src/webvnc-handoff.ts
+++ b/worker/src/webvnc-handoff.ts
@@ -1,0 +1,93 @@
+import type { CoordinatorRuntime } from "./coordinator-runtime";
+
+const ticketPrefix = "vnc_handoff_";
+const storagePrefix = "webvnc-credential-handoff:";
+const ttlSeconds = 5 * 60;
+
+interface WebVNCCredentialHandoffRecord {
+  ticket: string;
+  leaseID: string;
+  username: string;
+  password: string;
+  createdAt: string;
+  expiresAt: string;
+}
+
+export type WebVNCCredentialHandoffResult =
+  | { status: "accepted"; username: string; password: string }
+  | { status: "expired" | "invalid" };
+
+export class WebVNCCredentialHandoffs {
+  constructor(private readonly runtime: CoordinatorRuntime) {}
+
+  async issue(
+    leaseID: string,
+    credentials: { username: string; password: string },
+  ): Promise<{ ticket: string; expiresAt: string }> {
+    await this.cleanupExpired();
+    const now = new Date();
+    const record: WebVNCCredentialHandoffRecord = {
+      ticket: newTicket(),
+      leaseID,
+      ...credentials,
+      createdAt: now.toISOString(),
+      expiresAt: new Date(now.getTime() + ttlSeconds * 1000).toISOString(),
+    };
+    await this.runtime.storage.put(storageKey(leaseID, record.ticket), record);
+    const expiresAt = Date.parse(record.expiresAt);
+    const currentAlarm = await this.runtime.getAlarm();
+    if (currentAlarm === undefined || expiresAt < currentAlarm) {
+      await this.runtime.scheduleAlarm(expiresAt);
+    }
+    return { ticket: record.ticket, expiresAt: record.expiresAt };
+  }
+
+  async consume(leaseID: string, ticket: string): Promise<WebVNCCredentialHandoffResult> {
+    if (!validTicket(ticket)) {
+      return { status: "invalid" };
+    }
+    const record = await this.runtime.take<WebVNCCredentialHandoffRecord>(
+      storageKey(leaseID, ticket),
+    );
+    if (!record || record.ticket !== ticket || record.leaseID !== leaseID) {
+      return { status: "invalid" };
+    }
+    if (Date.parse(record.expiresAt) <= Date.now()) {
+      return { status: "expired" };
+    }
+    return { status: "accepted", username: record.username, password: record.password };
+  }
+
+  async cleanupExpired(now = Date.now()): Promise<void> {
+    const handoffs = await this.records();
+    await Promise.all(
+      [...handoffs.entries()]
+        .filter(([, handoff]) => Date.parse(handoff.expiresAt) <= now)
+        .map(([key]) => this.runtime.storage.delete(key)),
+    );
+  }
+
+  async alarmTimes(now = Date.now()): Promise<number[]> {
+    return [...(await this.records()).values()]
+      .map((handoff) => Date.parse(handoff.expiresAt))
+      .filter((time) => Number.isFinite(time) && time > now);
+  }
+
+  private records(): Promise<Map<string, WebVNCCredentialHandoffRecord>> {
+    return this.runtime.storage.list<WebVNCCredentialHandoffRecord>({ prefix: storagePrefix });
+  }
+}
+
+function newTicket(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return `${ticketPrefix}${[...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("")}`;
+}
+
+function validTicket(value: string): boolean {
+  return /^vnc_handoff_[a-f0-9]{32}$/.test(value);
+}
+
+function storageKey(leaseID: string, ticket: string): string {
+  return `${storagePrefix}${leaseID}:${ticket}`;
+}

--- a/worker/test/coordinator-runtime.test.ts
+++ b/worker/test/coordinator-runtime.test.ts
@@ -117,6 +117,18 @@ class MemoryRuntime implements CoordinatorRuntime {
 
   acceptEphemeralWebSocket(_socket: WebSocket, _handlers: CoordinatorSocketHandlers): void {}
 
+  async take<T>(key: string): Promise<T | undefined> {
+    const value = await this.storage.get<T>(key);
+    if (value !== undefined) {
+      await this.storage.delete(key);
+    }
+    return value;
+  }
+
+  async getAlarm(): Promise<number | undefined> {
+    return this.alarmTime;
+  }
+
   async scheduleAlarm(time: number): Promise<void> {
     this.alarmTime = time;
   }
@@ -609,9 +621,15 @@ describe("coordinator runtimes", () => {
   });
 
   it("maps Cloudflare alarms and hibernating socket attachments", async () => {
+    const transactionGet = vi.fn<() => Promise<unknown>>(async () => ({ ticket: "one-time" }));
+    const transactionDelete = vi.fn<() => Promise<void>>(async () => {});
     const storage = {
+      getAlarm: vi.fn<() => Promise<number | null>>(async () => 1234),
       setAlarm: vi.fn<(time: number) => Promise<void>>(async () => {}),
       deleteAlarm: vi.fn<() => Promise<void>>(async () => {}),
+      transaction: vi.fn<
+        (callback: (transaction: unknown) => Promise<unknown>) => Promise<unknown>
+      >(async (callback) => callback({ get: transactionGet, delete: transactionDelete })),
     };
     const acceptWebSocket = vi.fn<(socket: WebSocket, tags?: string[]) => void>();
     const state = {
@@ -629,12 +647,17 @@ describe("coordinator runtimes", () => {
       close: () => {},
       error: () => {},
     });
+    await expect(runtime.take("ticket:one-time")).resolves.toEqual({ ticket: "one-time" });
+    await expect(runtime.getAlarm()).resolves.toBe(1234);
     await runtime.scheduleAlarm(1234);
     await runtime.clearAlarm();
 
     expect(acceptWebSocket).toHaveBeenCalledWith(socket, ["control:client-1"]);
     expect(serializeAttachment).toHaveBeenCalledWith(attachment);
     expect(runtime.socketAttachment(socket)).toBe(attachment);
+    expect(storage.getAlarm).toHaveBeenCalledOnce();
+    expect(transactionGet).toHaveBeenCalledWith("ticket:one-time");
+    expect(transactionDelete).toHaveBeenCalledWith("ticket:one-time");
     expect(storage.setAlarm).toHaveBeenCalledWith(1234);
     expect(storage.deleteAlarm).toHaveBeenCalledOnce();
   });

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -74,8 +74,16 @@ class MemoryStorage {
     this.alarmTime = undefined;
   }
 
+  async getAlarm(): Promise<number | null> {
+    return this.alarmTime ?? null;
+  }
+
   async setAlarm(time: number): Promise<void> {
     this.alarmTime = time;
+  }
+
+  async transaction<T>(callback: (transaction: MemoryStorage) => Promise<T>): Promise<T> {
+    return await callback(this);
   }
 
   async list<T>({ prefix = "" }: { prefix?: string } = {}): Promise<Map<string, T>> {
@@ -16047,10 +16055,12 @@ describe("fleet lease identity and idle", () => {
     expect(pageBody).toContain("saveShare");
     expect(pageBody).toContain("teammate@example.com");
     expect(pageBody).toContain("shareableWebVNCURL");
-    expect(pageBody).toContain('linkFragment.set("username", username)');
-    expect(pageBody).toContain('linkFragment.set("password", password)');
+    expect(pageBody).toContain("/portal/leases/cbx_000000000001/vnc/handoff");
+    expect(pageBody).toContain('linkFragment.set("handoff", body.ticket)');
+    expect(pageBody).not.toContain('linkFragment.set("username", username)');
+    expect(pageBody).not.toContain('linkFragment.set("password", password)');
     expect(pageBody).toContain("await refreshShareState()");
-    expect(pageBody).toContain("writeClipboardText(shareableWebVNCURL())");
+    expect(pageBody).toContain("writeClipboardText(await shareableWebVNCURL())");
     expect(pageBody).toContain('document.getElementById("vnc-share")');
     expect(pageBody).toContain("vnc-copy-remote");
     expect(pageBody).toContain("vnc-paste");
@@ -16212,6 +16222,72 @@ describe("fleet lease identity and idle", () => {
       viewerConnected: false,
       events: [],
     });
+
+    const issuedHandoff = await fleet.fetch(
+      request("POST", "/portal/leases/blue-lobster/vnc/handoff", {
+        headers,
+        body: { username: "vnc-user", password: "generated-vnc-password" },
+      }),
+    );
+    expect(issuedHandoff.status).toBe(200);
+    expect(issuedHandoff.headers.get("cache-control")).toBe("no-store");
+    const issuedHandoffBody = (await issuedHandoff.json()) as {
+      ticket: string;
+      expiresAt: string;
+    };
+    expect(issuedHandoffBody.ticket).toMatch(/^vnc_handoff_[a-f0-9]{32}$/);
+    expect(storage.alarm()).toBe(Date.parse(issuedHandoffBody.expiresAt));
+    expect(issuedHandoffBody).not.toHaveProperty("username");
+    expect(issuedHandoffBody).not.toHaveProperty("password");
+
+    const friendCannotIssue = await fleet.fetch(
+      request("POST", "/portal/leases/blue-lobster/vnc/handoff", {
+        headers: {
+          "x-crabbox-owner": "friend@example.com",
+          "x-crabbox-org": "example-org",
+        },
+        body: { username: "vnc-user", password: "generated-vnc-password" },
+      }),
+    );
+    expect(friendCannotIssue.status).toBe(403);
+
+    const outsiderCannotRedeem = await fleet.fetch(
+      request("POST", "/portal/leases/blue-lobster/vnc/handoff", {
+        headers: {
+          "x-crabbox-owner": "outsider@example.com",
+          "x-crabbox-org": "other-org",
+        },
+        body: { ticket: issuedHandoffBody.ticket },
+      }),
+    );
+    expect(outsiderCannotRedeem.status).toBe(404);
+
+    const redeemedHandoff = await fleet.fetch(
+      request("POST", "/portal/leases/blue-lobster/vnc/handoff", {
+        headers: {
+          "x-crabbox-owner": "friend@example.com",
+          "x-crabbox-org": "example-org",
+        },
+        body: { ticket: issuedHandoffBody.ticket },
+      }),
+    );
+    expect(redeemedHandoff.status).toBe(200);
+    expect(redeemedHandoff.headers.get("cache-control")).toBe("no-store");
+    await expect(redeemedHandoff.json()).resolves.toEqual({
+      username: "vnc-user",
+      password: "generated-vnc-password",
+    });
+
+    const replayedHandoff = await fleet.fetch(
+      request("POST", "/portal/leases/blue-lobster/vnc/handoff", {
+        headers: {
+          "x-crabbox-owner": "friend@example.com",
+          "x-crabbox-org": "example-org",
+        },
+        body: { ticket: issuedHandoffBody.ticket },
+      }),
+    );
+    expect(replayedHandoff.status).toBe(401);
 
     const invalidTheme = await fleet.fetch(
       request("POST", "/portal/leases/blue-lobster/vnc/theme", {

--- a/worker/test/node-runtime.test.ts
+++ b/worker/test/node-runtime.test.ts
@@ -27,6 +27,10 @@ const mocks = vi.hoisted(() => {
   const storage = {
     initialize: vi.fn<() => Promise<void>>(async () => {}),
     close: vi.fn<() => Promise<void>>(async () => {}),
+    get: vi.fn<(key: string) => Promise<unknown>>(async () => undefined),
+    put: vi.fn<(key: string, value: unknown) => Promise<void>>(async () => {}),
+    delete: vi.fn<(key: string) => Promise<void>>(async () => {}),
+    take: vi.fn<(key: string) => Promise<unknown>>(async () => undefined),
   };
   return { boss, storage };
 });
@@ -59,6 +63,18 @@ describe("NodeCoordinatorRuntime", () => {
       "coordinator-alarm",
       expect.objectContaining({ policy: "short" }),
     );
+  });
+
+  it("persists the scheduled alarm time across Node coordinator restarts", async () => {
+    const runtime = new NodeCoordinatorRuntime("postgresql://example.invalid/test");
+    mocks.storage.get.mockResolvedValueOnce(1234);
+
+    await expect(runtime.getAlarm()).resolves.toBe(1234);
+    await runtime.scheduleAlarm(5678);
+    await runtime.clearAlarm();
+
+    expect(mocks.storage.put).toHaveBeenCalledWith("node-runtime:alarm-time", 5678);
+    expect(mocks.storage.delete).toHaveBeenCalledWith("node-runtime:alarm-time");
   });
 
   it("contains WebSocket message handler failures to the offending socket", async () => {

--- a/worker/test/postgres-storage.test.ts
+++ b/worker/test/postgres-storage.test.ts
@@ -70,6 +70,20 @@ describe("PostgresCoordinatorStorage", () => {
     ]);
     expect(records).toEqual(new Map([["run:100%_x", { id: "100" }]]));
   });
+
+  it("atomically takes one stored value", async () => {
+    const pool = fakePool([{ encoded_value: '{"ticket":"one-time"}' }]);
+    const storage = new PostgresCoordinatorStorage("postgres://unused", pool);
+
+    const value = await storage.take<{ ticket: string }>("handoff:1");
+
+    expect(pool.query).toHaveBeenCalledWith(
+      expect.stringContaining("delete from crabbox.coordinator_kv"),
+      ["handoff:1"],
+    );
+    expect(String(pool.query.mock.calls[0]?.[0])).toContain("returning case");
+    expect(value).toEqual({ ticket: "one-time" });
+  });
 });
 
 function fakePool(rows: QueryResultRow[] = []) {


### PR DESCRIPTION
Closes https://github.com/openclaw/crabbox/issues/831.

## Summary

- replace copied WebVNC username/password fragments with opaque five-minute handoff tickets
- require lease manage access to issue tickets and current lease visibility to redeem them
- consume tickets atomically across Cloudflare Durable Objects and Node/Postgres replicas, reject replays, and remove expired records through coordinator alarms
- retain existing raw fragment consumption for CLI/browser launch compatibility

## Verification

- `npm test --prefix worker` (26 files, 779 tests)
- `npm run check --prefix worker`
- `npm run lint --prefix worker`
- `npm run format:check --prefix worker`
- `npm run build --prefix worker`
- `go test ./internal/cli -run WebVNC`
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` (clean; no accepted/actionable findings)

## Security

- copied URLs contain only a short-lived opaque ticket, never raw generated VNC credentials
- issuance remains manager-only; redemption rechecks current share authorization
- successful handoff responses use `Cache-Control: no-store`
- tickets are lease-bound, atomically one-time, replay-rejected, and alarm-cleaned after expiry
