### PR TITLE
fix(worker): revoke stale admin bridge grants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- Revalidated cached GitHub and bearer admin grants before restoring bridge sockets or consuming durable bridge tickets and Code sessions, closing or downgrading sessions after admin revocation. Thanks @coygeek.
 - Replaced raw generated VNC credentials in copied WebVNC links with short-lived, one-time, authorization-checked handoff tickets. Thanks @coygeek.
 - Closed restored WebVNC viewer sockets that lack a complete current organization-bound principal instead of retaining owner-only legacy authorization. Thanks @coygeek.
 - Enforced key-only OpenSSH authentication across managed Windows desktop, core, and WSL2 bootstraps while retaining generated Windows passwords for console and VNC use. Thanks @coygeek.

--- a/worker/src/auth.ts
+++ b/worker/src/auth.ts
@@ -108,8 +108,8 @@ export async function authenticateRequest(
   return trustedIdentity;
 }
 
-function githubUserIsAdmin(
-  payload: Pick<UserTokenPayload, "owner" | "login">,
+export function githubUserIsAdmin(
+  payload: { owner: string; login: string },
   env: Pick<Env, "CRABBOX_GITHUB_ADMIN_OWNERS" | "CRABBOX_GITHUB_ADMIN_LOGINS">,
 ): boolean {
   const owner = payload.owner.trim().toLowerCase();

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -5,6 +5,7 @@ const { Client: SSHClientConstructor, utils: sshUtils } = ssh2;
 import { artifactUploadResponse, type ArtifactUploadRequest } from "./artifacts";
 import {
   authenticateRequest,
+  githubUserIsAdmin,
   isAdminRequest,
   requestWithAuthContext,
   sha256Hex,
@@ -216,7 +217,13 @@ const workspaceTerminalSSHReadyTimeoutMs = 2 * 60_000;
 const workspaceSSHHostPrivateKeyHeader = "x-crabbox-workspace-ssh-host-private-key";
 const workspaceSSHHostPublicKeyHeader = "x-crabbox-workspace-ssh-host-public-key";
 
-interface WebVNCTicketRecord {
+interface CachedAdminGrant {
+  auth?: AuthContext["auth"];
+  login?: string;
+  adminTokenHash?: string;
+}
+
+interface WebVNCTicketRecord extends CachedAdminGrant {
   ticket: string;
   leaseID: string;
   owner: string;
@@ -236,7 +243,7 @@ interface NativeVNCTicketRecord {
   expiresAt: string;
 }
 
-interface CodeTicketRecord {
+interface CodeTicketRecord extends CachedAdminGrant {
   ticket: string;
   leaseID: string;
   owner: string;
@@ -246,7 +253,7 @@ interface CodeTicketRecord {
   expiresAt: string;
 }
 
-interface CodeViewerTicketRecord {
+interface CodeViewerTicketRecord extends CachedAdminGrant {
   ticket: string;
   leaseID: string;
   auth: AuthContext["auth"];
@@ -261,7 +268,7 @@ interface CodeViewerTicketRecord {
   expiresAt: string;
 }
 
-interface CodeViewerSessionRecord {
+interface CodeViewerSessionRecord extends CachedAdminGrant {
   session: string;
   leaseID: string;
   auth: AuthContext["auth"];
@@ -367,7 +374,7 @@ interface RuntimeAdapterLegacyDeleteCompletion {
 
 type EgressRole = "host" | "client";
 
-interface EgressTicketRecord {
+interface EgressTicketRecord extends CachedAdminGrant {
   ticket: string;
   leaseID: string;
   owner: string;
@@ -663,6 +670,9 @@ type BridgeAttachment =
       owner: string;
       org?: string;
       admin?: boolean;
+      auth?: AuthContext["auth"];
+      login?: string;
+      adminTokenHash?: string;
       label: string;
     }
   | { kind: "code-agent"; leaseID: string }
@@ -674,6 +684,8 @@ type BridgeAttachment =
       owner?: string;
       org?: string;
       admin?: boolean;
+      login?: string;
+      adminTokenHash?: string;
       portalSessionHash?: string;
     }
   | {
@@ -683,6 +695,9 @@ type BridgeAttachment =
       owner?: string;
       org?: string;
       admin?: boolean;
+      auth?: AuthContext["auth"];
+      login?: string;
+      adminTokenHash?: string;
     }
   | {
       kind: "egress-client";
@@ -691,6 +706,9 @@ type BridgeAttachment =
       owner?: string;
       org?: string;
       admin?: boolean;
+      auth?: AuthContext["auth"];
+      login?: string;
+      adminTokenHash?: string;
     }
   | {
       kind: "runtime-adapter-agent";
@@ -705,6 +723,9 @@ type BridgeAttachment =
       owner: string;
       org: string;
       admin?: boolean;
+      auth?: AuthContext["auth"];
+      login?: string;
+      adminTokenHash?: string;
       subscriptions?: Record<string, number>;
     };
 
@@ -732,6 +753,9 @@ interface WebVNCViewerSession {
   owner: string;
   org?: string;
   admin?: boolean;
+  auth?: AuthContext["auth"];
+  login?: string;
+  adminTokenHash?: string;
   label: string;
   connectedAt: string;
 }
@@ -755,7 +779,7 @@ export class FleetCoordinator {
   private readonly runtimeAdapterDeleteQueues = new Map<string, Promise<void>>();
   private readonly controlSockets = new Map<string, WebSocket>();
   private readonly workspaceTerminals = new Map<string, Set<WebSocket>>();
-  private readonly restoredLeaseBridgeSockets = new Set<WebSocket>();
+  private readonly restoredBridgeSockets = new Set<WebSocket>();
   private bridgeRestoreReady: Promise<boolean> | undefined;
   private readyPoolBorrowQueue: Promise<void> = Promise.resolve();
   private bridgeTicketQueue: Promise<void> = Promise.resolve();
@@ -775,7 +799,7 @@ export class FleetCoordinator {
 
   async fetch(request: Request): Promise<Response> {
     try {
-      if (!(await this.restoredLeaseBridgesReady())) {
+      if (!(await this.restoredBridgesReady())) {
         return json(
           {
             error: "bridge_state_unavailable",
@@ -1087,22 +1111,32 @@ export class FleetCoordinator {
         continue;
       }
       this.trackBridgeSocket(socket, attachment);
-      if ("leaseID" in attachment) {
-        this.restoredLeaseBridgeSockets.add(socket);
-      }
+      this.restoredBridgeSockets.add(socket);
     }
   }
 
-  private async revokeInactiveRestoredBridgeSockets(): Promise<void> {
-    const leases = await this.state.storage.list<LeaseRecord>({ prefix: "lease:" });
+  private async reconcileRestoredBridgeSockets(): Promise<void> {
+    const [leases, adminGrants] = await Promise.all([
+      this.state.storage.list<LeaseRecord>({ prefix: "lease:" }),
+      adminGrantValidation(this.env),
+    ]);
     const now = Date.now();
     const revoked = new Map<string, string>();
+    const revokedAdmins = new Set<WebSocket>();
+    const revokedAdminEgressSessions = new Map<string, { leaseID: string; sessionID: string }>();
     const revokedViewers = new Map<WebSocket, string>();
     const revokedEgressSessions = new Map<string, { leaseID: string; sessionID: string }>();
     const codeViewersToCheck: Array<{ socket: WebSocket; portalSessionHash?: string }> = [];
-    for (const socket of this.restoredLeaseBridgeSockets) {
+    for (const socket of this.restoredBridgeSockets) {
       const attachment = this.bridgeAttachment(socket);
-      if (!attachment || !("leaseID" in attachment)) {
+      if (!attachment) {
+        continue;
+      }
+      if ("admin" in attachment && !cachedAdminGrantIsCurrent(attachment, adminGrants)) {
+        revokedAdmins.add(socket);
+        continue;
+      }
+      if (!("leaseID" in attachment)) {
         continue;
       }
       const lease = leases.get(leaseKey(attachment.leaseID));
@@ -1153,13 +1187,28 @@ export class FleetCoordinator {
         revokedViewers.set(socket, "portal session ended");
       }
     }
+    for (const socket of revokedAdmins) {
+      const attachment = this.bridgeAttachment(socket);
+      if (attachment?.kind === "egress-host" || attachment?.kind === "egress-client") {
+        revokedAdminEgressSessions.set(egressSocketKey(attachment.leaseID, attachment.sessionID), {
+          leaseID: attachment.leaseID,
+          sessionID: attachment.sessionID,
+        });
+        continue;
+      }
+      this.handleBridgeClose(socket, 1008, "admin access revoked");
+      closeSocket(socket, 1008, "admin access revoked");
+    }
+    for (const { leaseID, sessionID } of revokedAdminEgressSessions.values()) {
+      this.clearEgressSession(leaseID, sessionID, 1008, "admin access revoked");
+    }
     for (const [leaseID, reason] of revoked) {
       this.closeLeaseBridges(leaseID, 1008, reason);
     }
     for (const { leaseID, sessionID } of revokedEgressSessions.values()) {
       this.clearEgressSession(leaseID, sessionID, 1008, "lease access revoked");
     }
-    for (const socket of this.restoredLeaseBridgeSockets) {
+    for (const socket of this.restoredBridgeSockets) {
       const attachment = this.bridgeAttachment(socket);
       const reason =
         attachment && "leaseID" in attachment ? revoked.get(attachment.leaseID) : undefined;
@@ -1177,19 +1226,19 @@ export class FleetCoordinator {
         closeSocket(socket, 1008, reason);
       }
     }
-    this.restoredLeaseBridgeSockets.clear();
+    this.restoredBridgeSockets.clear();
   }
 
-  private async restoredLeaseBridgesReady(): Promise<boolean> {
-    if (this.restoredLeaseBridgeSockets.size === 0) {
+  private async restoredBridgesReady(): Promise<boolean> {
+    if (this.restoredBridgeSockets.size === 0) {
       return true;
     }
     const pending =
       this.bridgeRestoreReady ??
-      this.revokeInactiveRestoredBridgeSockets().then(
+      this.reconcileRestoredBridgeSockets().then(
         () => true,
         (error) => {
-          console.warn("could not reconcile restored lease bridges", errorMessage(error));
+          console.warn("could not reconcile restored bridges", errorMessage(error));
           return false;
         },
       );
@@ -1268,6 +1317,9 @@ export class FleetCoordinator {
           owner: attachment.owner,
           ...(attachment.org ? { org: attachment.org } : {}),
           ...(attachment.admin !== undefined ? { admin: attachment.admin } : {}),
+          ...(attachment.auth ? { auth: attachment.auth } : {}),
+          ...(attachment.login ? { login: attachment.login } : {}),
+          ...(attachment.adminTokenHash ? { adminTokenHash: attachment.adminTokenHash } : {}),
           label: attachment.label,
           connectedAt: new Date().toISOString(),
         });
@@ -1370,12 +1422,14 @@ export class FleetCoordinator {
     }
     const upgrade = this.state.createWebSocketUpgrade();
     const server = upgrade.socket;
+    const admin = isAdminRequest(request);
     const attachment: BridgeAttachment = {
       kind: "control",
       clientID: crypto.randomUUID(),
       owner: requestOwner(request),
       org: requestOrg(request, this.env),
-      admin: isAdminRequest(request),
+      admin,
+      ...(await adminGrantForRequest(request, admin)),
       subscriptions: {},
     };
     this.controlSockets.set(attachment.clientID, server);
@@ -1525,8 +1579,8 @@ export class FleetCoordinator {
       this.rejectRestoredBridgeSocket(socket, attachment);
       return;
     }
-    if (!(await this.restoredLeaseBridgesReady())) {
-      this.restoredLeaseBridgeSockets.delete(socket);
+    if (!(await this.restoredBridgesReady())) {
+      this.restoredBridgeSockets.delete(socket);
       this.rejectRestoredBridgeSocket(socket, attachment);
       return;
     }
@@ -1592,7 +1646,7 @@ export class FleetCoordinator {
   }
 
   private handleBridgeClose(socket: WebSocket, code: number, reason: string): void {
-    this.restoredLeaseBridgeSockets.delete(socket);
+    this.restoredBridgeSockets.delete(socket);
     const attachment = this.bridgeAttachment(socket);
     if (!attachment || !this.bridgeSocketIsCurrent(socket, attachment)) {
       return;
@@ -1628,7 +1682,7 @@ export class FleetCoordinator {
   }
 
   async alarm(): Promise<void> {
-    if (!(await this.restoredLeaseBridgesReady())) {
+    if (!(await this.restoredBridgesReady())) {
       throw new Error("restored bridge lease state is temporarily unavailable");
     }
     await this.expireLeases();
@@ -4907,16 +4961,17 @@ export class FleetCoordinator {
     await this.withBridgeTicketLock(async () => {
       await this.putLease(lease);
       if (leaseShareAccessShrank(previousShare, normalizedLeaseShare(lease.share))) {
-        this.revokeUnauthorizedLeaseBridges(lease);
+        await this.revokeUnauthorizedLeaseBridges(lease);
       }
     });
   }
 
-  private revokeUnauthorizedLeaseBridges(lease: LeaseRecord): void {
+  private async revokeUnauthorizedLeaseBridges(lease: LeaseRecord): Promise<void> {
     const code = 1008;
     const reason = "lease access revoked";
+    const adminGrants = await adminGrantValidation(this.env);
     for (const viewer of this.openWebVNCViewers(lease.id)) {
-      if (this.leaseViewerAuthorized(lease, viewer)) {
+      if (this.leaseViewerAuthorized(lease, withCurrentAdminGrant(viewer, adminGrants))) {
         continue;
       }
       this.clearWebVNCViewer(lease.id, viewer.id, viewer.socket);
@@ -4928,7 +4983,7 @@ export class FleetCoordinator {
         attachment?.kind !== "code-viewer" ||
         attachment.leaseID !== lease.id ||
         !completeBridgePrincipal(attachment) ||
-        this.leaseViewerAuthorized(lease, attachment)
+        this.leaseViewerAuthorized(lease, withCurrentAdminGrant(attachment, adminGrants))
       ) {
         continue;
       }
@@ -4941,7 +4996,7 @@ export class FleetCoordinator {
       if (
         (attachment?.kind !== "egress-host" && attachment?.kind !== "egress-client") ||
         attachment.leaseID !== lease.id ||
-        this.leaseManagerAuthorized(lease, attachment)
+        this.leaseManagerAuthorized(lease, withCurrentAdminGrant(attachment, adminGrants))
       ) {
         continue;
       }
@@ -6297,6 +6352,7 @@ export class FleetCoordinator {
       owner: requestOwner(request),
       org: requestOrg(request, this.env),
       admin,
+      ...(await adminGrantForRequest(request, admin)),
       role,
       sessionID,
       allow: boundedEgressAllowlist(input.allow),
@@ -7119,6 +7175,7 @@ export class FleetCoordinator {
       owner: requestOwner(request),
       org: requestOrg(request, this.env),
       admin,
+      ...(await adminGrantForRequest(request, admin)),
       createdAt: now.toISOString(),
       expiresAt: new Date(now.getTime() + webVNCTicketTTLSeconds * 1000).toISOString(),
     };
@@ -7406,6 +7463,7 @@ export class FleetCoordinator {
       owner: requestOwner(request),
       org: requestOrg(request, this.env),
       admin,
+      ...(await adminGrantForRequest(request, admin)),
       createdAt: now.toISOString(),
       expiresAt: new Date(now.getTime() + codeTicketTTLSeconds * 1000).toISOString(),
     };
@@ -7515,6 +7573,15 @@ export class FleetCoordinator {
     }
     if (request.headers.get("upgrade")?.toLowerCase() === "websocket") {
       const auth = viewerSession?.auth ?? requestAuthType(authorizedRequest);
+      const adminGrant: CachedAdminGrant = viewerSession
+        ? {
+            auth: viewerSession.auth,
+            ...(viewerSession.login ? { login: viewerSession.login } : {}),
+            ...(viewerSession.adminTokenHash
+              ? { adminTokenHash: viewerSession.adminTokenHash }
+              : {}),
+          }
+        : await adminGrantForRequest(authorizedRequest, isAdminRequest(authorizedRequest));
       let portalSessionHash = viewerSession?.portalSessionHash;
       if (auth === "github" && !portalSessionHash) {
         const token = bearerToken(authorizedRequest);
@@ -7531,6 +7598,7 @@ export class FleetCoordinator {
         lease,
         agent,
         auth,
+        adminGrant,
         portalSessionHash,
       );
     }
@@ -7545,6 +7613,7 @@ export class FleetCoordinator {
     await this.cleanupExpiredCodeViewerAuth();
     const now = new Date();
     const auth = requestAuthType(request);
+    const admin = isAdminRequest(request);
     let portalSessionHash: string | undefined;
     if (auth === "github") {
       const token = bearerToken(request);
@@ -7560,7 +7629,8 @@ export class FleetCoordinator {
       ticket: newCodeViewerTicket(),
       leaseID: lease.id,
       auth,
-      admin: isAdminRequest(request),
+      admin,
+      ...(await adminGrantForRequest(request, admin)),
       owner: requestOwner(request),
       org: requestOrg(request, this.env),
       returnTo: canonicalCodeReturnTo(request, lease.id),
@@ -7632,6 +7702,9 @@ export class FleetCoordinator {
     if (ticket.login) {
       session.login = ticket.login;
     }
+    if (ticket.adminTokenHash) {
+      session.adminTokenHash = ticket.adminTokenHash;
+    }
     if (ticket.portalSessionHash) {
       session.portalSessionHash = ticket.portalSessionHash;
     }
@@ -7675,7 +7748,11 @@ export class FleetCoordinator {
       }
       return undefined;
     }
-    return session;
+    const currentSession = withCurrentAdminGrant(session, await adminGrantValidation(this.env));
+    if (currentSession !== session) {
+      await this.state.storage.put(codeViewerSessionKey(value), currentSession);
+    }
+    return currentSession;
   }
 
   private codeViewerAuthenticationRequired(request: Request, leaseID: string): Response {
@@ -7722,7 +7799,7 @@ export class FleetCoordinator {
         return undefined;
       }
       await this.state.storage.delete(key);
-      return ticket;
+      return withCurrentAdminGrant(ticket, await adminGrantValidation(this.env));
     });
   }
 
@@ -7854,6 +7931,7 @@ export class FleetCoordinator {
     lease: LeaseRecord,
     agent: WebSocket,
     auth: AuthContext["auth"],
+    adminGrant: CachedAdminGrant,
     portalSessionHash?: string,
   ): Promise<Response> {
     return await this.withBridgeTicketLock(async () => {
@@ -7882,6 +7960,7 @@ export class FleetCoordinator {
         owner: requestOwner(request),
         org: requestOrg(request, this.env),
         admin: isAdminRequest(request),
+        ...adminGrant,
         ...(portalSessionHash ? { portalSessionHash } : {}),
       });
       const url = new URL(request.url);
@@ -8213,6 +8292,7 @@ export class FleetCoordinator {
       const owner = requestOwner(request);
       const org = requestOrg(request, this.env);
       const admin = isAdminRequest(request);
+      const adminGrant = await adminGrantForRequest(request, admin);
       const label = webVNCViewerLabel(owner);
 
       this.trackWebVNCViewer(lease.id, {
@@ -8222,6 +8302,7 @@ export class FleetCoordinator {
         owner,
         org,
         admin,
+        ...adminGrant,
         label,
         connectedAt: new Date().toISOString(),
       });
@@ -8238,6 +8319,7 @@ export class FleetCoordinator {
         owner,
         org,
         admin,
+        ...adminGrant,
         label,
       });
       flushPendingWebVNC(this.pendingWebVNCToViewer, webVNCBufferKey(lease.id, agent.id), viewer);
@@ -8495,12 +8577,13 @@ export class FleetCoordinator {
     if (!lease || !identifierMatchesLease(identifier, lease)) {
       return { status: "not_found" };
     }
-    if (!this.leaseManagerAuthorized(lease, leaseBridgeTicketPrincipal(ticket))) {
+    const currentTicket = withCurrentAdminGrant(ticket, await adminGrantValidation(this.env));
+    if (!this.leaseManagerAuthorized(lease, leaseBridgeTicketPrincipal(currentTicket))) {
       await this.state.storage.delete(key);
       return { status: "invalid" };
     }
     await this.state.storage.delete(key);
-    return { status: "accepted", ticket, lease };
+    return { status: "accepted", ticket: currentTicket, lease };
   }
 
   private async cleanupExpiredWebVNCTickets(): Promise<void> {
@@ -8543,12 +8626,13 @@ export class FleetCoordinator {
     if (!lease || !identifierMatchesLease(identifier, lease)) {
       return { status: "not_found" };
     }
-    if (!this.leaseManagerAuthorized(lease, leaseBridgeTicketPrincipal(ticket))) {
+    const currentTicket = withCurrentAdminGrant(ticket, await adminGrantValidation(this.env));
+    if (!this.leaseManagerAuthorized(lease, leaseBridgeTicketPrincipal(currentTicket))) {
       await this.state.storage.delete(key);
       return { status: "invalid" };
     }
     await this.state.storage.delete(key);
-    return { status: "accepted", ticket, lease };
+    return { status: "accepted", ticket: currentTicket, lease };
   }
 
   private async cleanupExpiredCodeTickets(): Promise<void> {
@@ -8598,12 +8682,13 @@ export class FleetCoordinator {
     if (!lease || !identifierMatchesLease(identifier, lease)) {
       return { status: "not_found" };
     }
-    if (!this.leaseManagerAuthorized(lease, leaseBridgeTicketPrincipal(ticket))) {
+    const currentTicket = withCurrentAdminGrant(ticket, await adminGrantValidation(this.env));
+    if (!this.leaseManagerAuthorized(lease, leaseBridgeTicketPrincipal(currentTicket))) {
       await this.state.storage.delete(key);
       return { status: "invalid" };
     }
     await this.state.storage.delete(key);
-    return { status: "accepted", ticket, lease };
+    return { status: "accepted", ticket: currentTicket, lease };
   }
 
   private async cleanupExpiredEgressTickets(): Promise<void> {
@@ -13416,6 +13501,77 @@ function requestAuthType(request: Request): AuthContext["auth"] {
   return auth === "bearer" || auth === "github" || auth === "proxy" ? auth : "github";
 }
 
+async function adminGrantForRequest(request: Request, admin: boolean): Promise<CachedAdminGrant> {
+  if (!admin) {
+    return {};
+  }
+  const auth = requestAuthType(request);
+  if (auth === "github") {
+    const login = request.headers.get("x-crabbox-github-login")?.trim();
+    return { auth, ...(login ? { login } : {}) };
+  }
+  if (auth === "bearer") {
+    const token = bearerToken(request);
+    return {
+      auth,
+      ...(token ? { adminTokenHash: await sha256Hex(token) } : {}),
+    };
+  }
+  return { auth };
+}
+
+type AdminGrantEnv = Pick<
+  Env,
+  "CRABBOX_ADMIN_TOKEN" | "CRABBOX_GITHUB_ADMIN_OWNERS" | "CRABBOX_GITHUB_ADMIN_LOGINS"
+>;
+
+interface AdminGrantValidation {
+  env: AdminGrantEnv;
+  adminTokenHash?: string;
+}
+
+async function adminGrantValidation(env: AdminGrantEnv): Promise<AdminGrantValidation> {
+  return {
+    env,
+    ...(env.CRABBOX_ADMIN_TOKEN
+      ? { adminTokenHash: await sha256Hex(env.CRABBOX_ADMIN_TOKEN) }
+      : {}),
+  };
+}
+
+function cachedAdminGrantIsCurrent(
+  principal: CachedAdminGrant & { admin?: boolean; owner?: string },
+  validation: AdminGrantValidation,
+): boolean {
+  if (principal.admin !== true) {
+    return true;
+  }
+  if (
+    principal.auth === "github" &&
+    typeof principal.owner === "string" &&
+    typeof principal.login === "string"
+  ) {
+    return githubUserIsAdmin({ owner: principal.owner, login: principal.login }, validation.env);
+  }
+  if (
+    principal.auth === "bearer" &&
+    /^[a-f0-9]{64}$/.test(principal.adminTokenHash ?? "") &&
+    validation.adminTokenHash
+  ) {
+    return principal.adminTokenHash === validation.adminTokenHash;
+  }
+  return false;
+}
+
+function withCurrentAdminGrant<T extends CachedAdminGrant & { admin?: boolean; owner?: string }>(
+  principal: T,
+  validation: AdminGrantValidation,
+): T {
+  return cachedAdminGrantIsCurrent(principal, validation)
+    ? principal
+    : { ...principal, admin: false };
+}
+
 function isolatedCodeRequestOriginAllowed(request: Request): boolean {
   const requestOrigin = new URL(request.url).origin;
   const origin = request.headers.get("origin")?.trim();
@@ -14060,20 +14216,27 @@ function bridgeAttachment(value: unknown): BridgeAttachment | undefined {
     case "code-agent":
       return typeof attachment.leaseID === "string" ? attachment : undefined;
     case "code-viewer":
-      if (typeof attachment.leaseID !== "string" || typeof attachment.id !== "string") {
+      const serializedCodeViewer = attachment as Omit<typeof attachment, "auth"> & {
+        auth?: AuthContext["auth"];
+      };
+      if (
+        typeof serializedCodeViewer.leaseID !== "string" ||
+        typeof serializedCodeViewer.id !== "string"
+      ) {
         return undefined;
       }
-      if (attachment.auth === undefined) {
-        // Pre-revocation attachments carried no auth binding; restore them only long enough to
-        // fail closed through the normal viewer/agent shutdown path.
-        return { ...attachment, auth: "github" };
+      if (serializedCodeViewer.auth === undefined) {
+        // Old attachments had no auth binding. Treat them as GitHub sessions so the existing
+        // portal-session revocation path closes them before any restored traffic is accepted.
+        return { ...serializedCodeViewer, auth: "github" };
       }
-      return (attachment.auth === "bearer" ||
-        attachment.auth === "github" ||
-        attachment.auth === "proxy") &&
-        validOptionalBridgePrincipal(attachment) &&
-        (attachment.auth !== "github" || validPortalSessionHash(attachment.portalSessionHash))
-        ? attachment
+      return (serializedCodeViewer.auth === "bearer" ||
+        serializedCodeViewer.auth === "github" ||
+        serializedCodeViewer.auth === "proxy") &&
+        validOptionalBridgePrincipal(serializedCodeViewer) &&
+        (serializedCodeViewer.auth !== "github" ||
+          validPortalSessionHash(serializedCodeViewer.portalSessionHash))
+        ? (serializedCodeViewer as Extract<BridgeAttachment, { kind: "code-viewer" }>)
         : undefined;
     case "egress-host":
     case "egress-client":
@@ -14141,12 +14304,21 @@ function validOptionalEgressBridgePrincipal(value: {
   return legacy || completeBridgePrincipal(value);
 }
 
-function leaseBridgeTicketPrincipal(ticket: { owner: string; org: string; admin?: boolean }): {
+function leaseBridgeTicketPrincipal(
+  ticket: CachedAdminGrant & { owner: string; org: string; admin?: boolean },
+): CachedAdminGrant & {
   owner: string;
   org: string;
   admin: boolean;
 } {
-  return { owner: ticket.owner, org: ticket.org, admin: ticket.admin === true };
+  return {
+    owner: ticket.owner,
+    org: ticket.org,
+    admin: ticket.admin === true,
+    ...(ticket.auth ? { auth: ticket.auth } : {}),
+    ...(ticket.login ? { login: ticket.login } : {}),
+    ...(ticket.adminTokenHash ? { adminTokenHash: ticket.adminTokenHash } : {}),
+  };
 }
 
 function bridgeTags(attachment: BridgeAttachment): string[] {

--- a/worker/test/coordinator-runtime.test.ts
+++ b/worker/test/coordinator-runtime.test.ts
@@ -326,6 +326,7 @@ describe("coordinator runtimes", () => {
     const runtime = new MemoryRuntime();
     const coordinator = new FleetCoordinator(runtime, {
       CRABBOX_DEFAULT_ORG: "example-org",
+      CRABBOX_GITHUB_ADMIN_LOGINS: "admin",
     } as Env);
     const lease: LeaseRecord = {
       id: "cbx_000000000001",
@@ -371,6 +372,8 @@ describe("coordinator runtimes", () => {
       "x-crabbox-owner": "admin@example.com",
       "x-crabbox-org": "example-org",
       "x-crabbox-admin": "true",
+      "x-crabbox-auth": "github",
+      "x-crabbox-github-login": "admin",
     };
     const createTicket = async (
       kind: "webvnc" | "code",

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -303,6 +303,8 @@ describe("runtime adapter relay", () => {
           owner: "admin@example.com",
           org: "other-org",
           admin: true,
+          auth: "github",
+          login: "current-admin",
         }),
     );
     const fleet = new FleetDurableObject(
@@ -310,7 +312,10 @@ describe("runtime adapter relay", () => {
         storage,
         getWebSockets: () => [...revoked, ...legacy, ...admin] as unknown as WebSocket[],
       } as unknown as DurableObjectState,
-      { CRABBOX_DEFAULT_ORG: "default-org" } as Env,
+      {
+        CRABBOX_DEFAULT_ORG: "default-org",
+        CRABBOX_GITHUB_ADMIN_LOGINS: "current-admin",
+      } as Env,
     );
 
     expect((await fleet.fetch(request("GET", "/v1/health"))).status).toBe(200);
@@ -331,6 +336,149 @@ describe("runtime adapter relay", () => {
     expect(relay.egressSessions.has(revokedLease.id)).toBe(false);
     expect(relay.egressSessions.has(legacyLease.id)).toBe(false);
     expect(relay.egressSessions.get(adminLease.id)?.sessionID).toBe("egress_admin");
+  });
+
+  it("revokes stale admin grants on every restored principal-bearing bridge", async () => {
+    const storage = new MemoryStorage();
+    const lease = testLease({
+      id: "cbx_000000000021",
+      provider: "external",
+      lifecycle: "registered",
+      state: "active",
+      owner: "owner@example.com",
+      org: "example-org",
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    storage.seed(`lease:${lease.id}`, lease);
+    const revokedGrant = {
+      owner: "former-admin@example.com",
+      org: "other-org",
+      admin: true,
+      auth: "github",
+      login: "former-admin",
+    } as const;
+    const codeAgent = new FakeWebSocket({ kind: "code-agent", leaseID: lease.id });
+    const revokedCodeViewer = new FakeWebSocket({
+      kind: "code-viewer",
+      leaseID: lease.id,
+      id: "code-revoked-admin",
+      portalSessionHash: "a".repeat(64),
+      ...revokedGrant,
+    });
+    const webVNCAgent = new FakeWebSocket({
+      kind: "webvnc-agent",
+      leaseID: lease.id,
+      id: "agent_revoked_admin",
+      capabilities: new Set<string>(),
+    });
+    const revokedWebVNCViewer = new FakeWebSocket({
+      kind: "webvnc-viewer",
+      leaseID: lease.id,
+      id: "viewer_revoked_admin",
+      agentID: "agent_revoked_admin",
+      label: "former-admin",
+      ...revokedGrant,
+    });
+    const revokedEgress = ["egress-host", "egress-client"].map(
+      (kind) =>
+        new FakeWebSocket({
+          kind,
+          leaseID: lease.id,
+          sessionID: "egress_revoked_admin",
+          ...revokedGrant,
+        }),
+    );
+    const revokedControl = new FakeWebSocket({
+      kind: "control",
+      clientID: "control-revoked-admin",
+      subscriptions: {},
+      ...revokedGrant,
+    });
+    const legacyControl = new FakeWebSocket({
+      kind: "control",
+      clientID: "control-legacy-admin",
+      owner: "legacy-admin@example.com",
+      org: "other-org",
+      admin: true,
+      subscriptions: {},
+    });
+    const currentGitHubControl = new FakeWebSocket({
+      kind: "control",
+      clientID: "control-current-github-admin",
+      owner: "current-admin@example.com",
+      org: "other-org",
+      admin: true,
+      auth: "github",
+      login: "current-admin",
+      subscriptions: {},
+    });
+    const currentAdminToken = "current-admin-token";
+    const currentBearerControl = new FakeWebSocket({
+      kind: "control",
+      clientID: "control-current-bearer-admin",
+      owner: "bearer-admin@example.com",
+      org: "other-org",
+      admin: true,
+      auth: "bearer",
+      adminTokenHash: await sha256Hex(currentAdminToken),
+      subscriptions: {},
+    });
+    const rotatedBearerControl = new FakeWebSocket({
+      kind: "control",
+      clientID: "control-rotated-bearer-admin",
+      owner: "bearer-admin@example.com",
+      org: "other-org",
+      admin: true,
+      auth: "bearer",
+      adminTokenHash: await sha256Hex("old-admin-token"),
+      subscriptions: {},
+    });
+    const sockets = [
+      codeAgent,
+      revokedCodeViewer,
+      webVNCAgent,
+      revokedWebVNCViewer,
+      ...revokedEgress,
+      revokedControl,
+      legacyControl,
+      currentGitHubControl,
+      currentBearerControl,
+      rotatedBearerControl,
+    ];
+    const fleet = new FleetDurableObject(
+      {
+        storage,
+        getWebSockets: () => sockets as unknown as WebSocket[],
+      } as unknown as DurableObjectState,
+      {
+        CRABBOX_ADMIN_TOKEN: currentAdminToken,
+        CRABBOX_DEFAULT_ORG: "default-org",
+        CRABBOX_GITHUB_ADMIN_LOGINS: "current-admin",
+      } as Env,
+    );
+
+    expect((await fleet.fetch(request("GET", "/v1/health"))).status).toBe(200);
+    for (const socket of [
+      revokedCodeViewer,
+      revokedWebVNCViewer,
+      ...revokedEgress,
+      revokedControl,
+      legacyControl,
+      rotatedBearerControl,
+    ]) {
+      expect(socket.closeCode).toBe(1008);
+      expect(socket.closeReason).toBe("admin access revoked");
+    }
+    expect(currentGitHubControl.closeCode).toBeUndefined();
+    expect(currentBearerControl.closeCode).toBeUndefined();
+    expect(codeAgent.sentJSON()).toEqual([
+      {
+        type: "ws_close",
+        id: "code-revoked-admin",
+        code: 1008,
+        reason: "admin access revoked",
+      },
+    ]);
   });
 
   it("rejects hibernated Code viewers whose portal session logged out", async () => {
@@ -9540,7 +9688,8 @@ describe("fleet lease identity and idle", () => {
 
   it("revokes only unauthorized live viewers after an API share removal", async () => {
     const storage = new MemoryStorage();
-    const fleet = testFleet(storage);
+    const adminToken = "current-admin-token";
+    const fleet = testFleet(storage, {}, { CRABBOX_ADMIN_TOKEN: adminToken });
     const leaseID = "cbx_000000000001";
     const ownerHeaders = {
       "x-crabbox-owner": "owner@example.com",
@@ -9633,6 +9782,7 @@ describe("fleet lease identity and idle", () => {
       owner: "admin@example.com",
       org: "other-org",
       admin: true,
+      adminTokenHash: await sha256Hex(adminToken),
     });
     const legacyCodeViewer = new FakeWebSocket({
       kind: "code-viewer",
@@ -15110,6 +15260,74 @@ describe("fleet lease identity and idle", () => {
     expect(malformedSession.status).toBe(302);
   });
 
+  it("downgrades stale admin grants in durable Code viewer tickets and sessions", async () => {
+    const storage = new MemoryStorage();
+    const env = {
+      CRABBOX_CODE_ORIGIN_TEMPLATE: "https://{lease}.code.example.test",
+      CRABBOX_GITHUB_ADMIN_LOGINS: "current-admin",
+    };
+    const fleet = testFleet(storage, {}, env);
+    const leaseID = "cbx_000000000001";
+    storage.seed(
+      `lease:${leaseID}`,
+      testLease({
+        id: leaseID,
+        slug: "blue-lobster",
+        owner: "owner@example.com",
+        org: "example-org",
+        code: true,
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      }),
+    );
+    const isolatedOrigin = await codeOriginForLease(env, leaseID);
+    expect(isolatedOrigin).toBeDefined();
+    const staleGrant = {
+      auth: "github",
+      admin: true,
+      owner: "former-admin@example.com",
+      org: "other-org",
+      login: "former-admin",
+      portalSessionHash: "a".repeat(64),
+      createdAt: new Date().toISOString(),
+      expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+    } as const;
+    const session = `code_session_${"a".repeat(32)}`;
+    storage.seed(`code-viewer-session:${session}`, {
+      session,
+      leaseID,
+      ...staleGrant,
+    });
+
+    const staleSession = await fleet.fetch(
+      new Request(`${isolatedOrigin}/portal/leases/${leaseID}/code/health`, {
+        headers: { cookie: `crabbox_code_session=${session}` },
+      }),
+    );
+    expect(staleSession.status).toBe(404);
+    expect(storage.value<{ admin: boolean }>(`code-viewer-session:${session}`)?.admin).toBe(false);
+
+    const ticket = `code_view_${"b".repeat(32)}`;
+    storage.seed(`code-viewer-ticket:${ticket}`, {
+      ticket,
+      leaseID,
+      returnTo: `/portal/leases/${leaseID}/code/`,
+      ...staleGrant,
+    });
+    const bootstrap = await fleet.fetch(
+      new Request(
+        `${isolatedOrigin}/portal/leases/${leaseID}/code/__crabbox_bootstrap?ticket=${ticket}`,
+      ),
+    );
+    expect(bootstrap.status).toBe(303);
+    const issuedSession = /crabbox_code_session=([^;]+)/.exec(
+      bootstrap.headers.get("set-cookie") ?? "",
+    )?.[1];
+    expect(issuedSession).toMatch(/^code_session_[a-f0-9]{32}$/);
+    expect(storage.value<{ admin: boolean }>(`code-viewer-session:${issuedSession}`)?.admin).toBe(
+      false,
+    );
+  });
+
   it("revokes isolated Code viewer access end to end when the portal session logs out", async () => {
     const storage = new MemoryStorage();
     const env = {
@@ -15712,6 +15930,45 @@ describe("fleet lease identity and idle", () => {
     expect(
       Object.keys(forwarded?.headers ?? {}).filter((key) => key.startsWith("x-crabbox-")),
     ).toEqual([]);
+  });
+
+  it("rejects bridge tickets whose cached admin grant was revoked", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage, {}, { CRABBOX_GITHUB_ADMIN_LOGINS: "current-admin" });
+    const leaseID = "cbx_000000000001";
+    storage.seed(
+      `lease:${leaseID}`,
+      testLease({
+        id: leaseID,
+        slug: "blue-lobster",
+        owner: "owner@example.com",
+        org: "example-org",
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      }),
+    );
+    const ticket = `egress_${"a".repeat(32)}`;
+    storage.seed(`egress-ticket:${ticket}`, {
+      ticket,
+      leaseID,
+      owner: "former-admin@example.com",
+      org: "other-org",
+      admin: true,
+      auth: "github",
+      login: "former-admin",
+      role: "host",
+      sessionID: "egress_revoked_ticket",
+      createdAt: new Date().toISOString(),
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    const response = await fleet.fetch(
+      request("GET", "/v1/leases/blue-lobster/egress/host", {
+        headers: { authorization: `Bearer ${ticket}`, upgrade: "websocket" },
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(storage.value(`egress-ticket:${ticket}`)).toBeUndefined();
   });
 
   it("creates scoped egress tickets and reports bridge status", async () => {


### PR DESCRIPTION
## Summary

- bind cached admin authority to its original GitHub identity or bearer-token hash
- revalidate restored control, WebVNC, Code, and egress sockets before accepting traffic
- downgrade durable bridge tickets and Code viewer sessions when their admin grant is no longer current
- fail closed for legacy admin attachments without a verifiable grant while preserving non-admin access checks

Closes https://github.com/openclaw/crabbox/issues/830

## Verification

- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker` (26 files, 782 tests)
- `npm run build --prefix worker`
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` (clean; no accepted/actionable findings)
