### PR TITLE
fix(worker): keep Code bootstrap tickets out of URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- Removed the Code viewer bootstrap bearer ticket from redirect URLs and browser history by handing it to the isolated lease origin through a no-store, POST-only form. Thanks @coygeek.
 - Revalidated cached GitHub and bearer admin grants before restoring bridge sockets or consuming durable bridge tickets and Code sessions, closing or downgrading sessions after admin revocation. Thanks @coygeek.
 - Replaced raw generated VNC credentials in copied WebVNC links with short-lived, one-time, authorization-checked handoff tickets. Thanks @coygeek.
 - Closed restored WebVNC viewer sockets that lack a complete current organization-bound principal instead of retaining owner-only legacy authorization. Thanks @coygeek.

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -64,6 +64,7 @@ import { githubAuthRoute, githubPortalLogin, githubPortalLogout } from "./oauth"
 import { defaultOSImage, normalizeOSImage } from "./os-image";
 import {
   portalCode,
+  portalCodeBootstrapHandoff,
   portalAdmin,
   portalError,
   portalExternalRunnerDetail,
@@ -7653,19 +7654,24 @@ export class FleetCoordinator {
       `/portal/leases/${encodeURIComponent(lease.id)}/code/__crabbox_bootstrap`,
       isolatedOrigin,
     );
-    location.searchParams.set("ticket", ticket.ticket);
-    return new Response(null, {
-      status: 302,
-      headers: {
-        "cache-control": "no-store",
-        location: location.toString(),
-        "referrer-policy": "no-referrer",
-      },
-    });
+    return portalCodeBootstrapHandoff(location, ticket.ticket);
   }
 
   private async bootstrapCodeViewer(request: Request, leaseID: string): Promise<Response> {
-    const value = new URL(request.url).searchParams.get("ticket") ?? "";
+    if (request.method !== "POST") {
+      return json(
+        { error: "method_not_allowed", message: "Code viewer bootstrap requires POST" },
+        { status: 405, headers: { allow: "POST", "cache-control": "no-store" } },
+      );
+    }
+    const contentType = request.headers.get("content-type")?.split(";", 1)[0]?.trim().toLowerCase();
+    if (contentType !== "application/x-www-form-urlencoded") {
+      return json(
+        { error: "unsupported_media_type", message: "form-encoded Code viewer ticket required" },
+        { status: 415, headers: { "cache-control": "no-store" } },
+      );
+    }
+    const value = new URLSearchParams(await request.text()).get("ticket") ?? "";
     const ticket = await this.consumeCodeViewerTicket(value, leaseID);
     if (!ticket) {
       return json(

--- a/worker/src/portal.ts
+++ b/worker/src/portal.ts
@@ -1957,6 +1957,52 @@ export function portalCode(lease: LeaseRecord): Response {
   );
 }
 
+export function portalCodeBootstrapHandoff(action: URL, ticket: string): Response {
+  const nonce = scriptNonce();
+  const actionURL = action.toString();
+  const contentSecurityPolicy = [
+    "default-src 'none'",
+    "base-uri 'none'",
+    `form-action ${action.origin}`,
+    "frame-ancestors 'none'",
+    `script-src 'nonce-${nonce}'`,
+    `style-src 'nonce-${nonce}'`,
+  ].join("; ");
+  return new Response(
+    `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Opening Code</title>
+  <style nonce="${nonce}">
+    :root { color-scheme: dark light; font: 16px/1.5 system-ui,sans-serif; }
+    body { min-height: 100vh; margin: 0; display: grid; place-items: center; }
+    form { text-align: center; }
+    button { font: inherit; padding: .55rem 1rem; }
+  </style>
+</head>
+<body>
+  <form id="code-bootstrap" method="post" action="${escapeHTML(actionURL)}" autocomplete="off">
+    <input type="hidden" name="ticket" value="${escapeHTML(ticket)}">
+    <p>Opening Code…</p>
+    <button type="submit">Continue</button>
+  </form>
+  <script nonce="${nonce}">document.getElementById("code-bootstrap").requestSubmit();</script>
+</body>
+</html>`,
+    {
+      headers: {
+        "cache-control": "no-store",
+        "content-security-policy": contentSecurityPolicy,
+        "content-type": "text/html; charset=utf-8",
+        "referrer-policy": "no-referrer",
+        "x-content-type-options": "nosniff",
+      },
+    },
+  );
+}
+
 export function codeBridgeCommand(lease: LeaseRecord): string {
   return ["crabbox", "code", "--id", lease.slug || lease.id, "--open"].map(shellArg).join(" ");
 }

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -15130,11 +15130,12 @@ describe("fleet lease identity and idle", () => {
     ];
     await Promise.all(
       viewers.map(async (headers) => {
-        const redirect = await fleet.fetch(
+        const handoff = await fleet.fetch(
           request("GET", "/portal/leases/blue-lobster/code/", { headers }),
         );
-        expect(redirect.status).toBe(302);
-        expect(new URL(redirect.headers.get("location") || "").origin).toBe(isolatedOrigin);
+        expect(handoff.status).toBe(200);
+        const bootstrap = await readCodeBootstrapHandoff(handoff);
+        expect(bootstrap.url.origin).toBe(isolatedOrigin);
       }),
     );
   });
@@ -15177,18 +15178,29 @@ describe("fleet lease identity and idle", () => {
       code: { agentConnected: false },
     });
 
-    const redirect = await fleet.fetch(
+    const handoff = await fleet.fetch(
       request("GET", "/portal/leases/blue-lobster/code/?folder=%2Fwork%2Frepo", { headers }),
     );
-    expect(redirect.status).toBe(302);
-    expect(redirect.headers.get("cache-control")).toBe("no-store");
-    expect(redirect.headers.get("referrer-policy")).toBe("no-referrer");
-    const bootstrapURL = new URL(redirect.headers.get("location") || "");
+    expect(handoff.status).toBe(200);
+    expect(handoff.headers.get("location")).toBeNull();
+    expect(handoff.headers.get("cache-control")).toBe("no-store");
+    expect(handoff.headers.get("referrer-policy")).toBe("no-referrer");
+    expect(handoff.headers.get("content-security-policy")).toContain("default-src 'none'");
+    expect(handoff.headers.get("content-security-policy")).toContain("frame-ancestors 'none'");
+    const bootstrapHandoff = await readCodeBootstrapHandoff(handoff);
+    const bootstrapURL = bootstrapHandoff.url;
     expect(bootstrapURL.hostname).toMatch(/^cbx-[a-f0-9]{32}\.code\.example\.test$/);
     expect(bootstrapURL.pathname).toBe(`/portal/leases/${leaseID}/code/__crabbox_bootstrap`);
-    expect(bootstrapURL.searchParams.get("ticket")).toMatch(/^code_view_[a-f0-9]{32}$/);
+    expect(bootstrapURL.search).toBe("");
+    expect(bootstrapHandoff.ticket).toMatch(/^code_view_[a-f0-9]{32}$/);
 
-    const bootstrap = await fleet.fetch(new Request(bootstrapURL));
+    const copiedURL = await fleet.fetch(new Request(bootstrapURL));
+    expect(copiedURL.status).toBe(405);
+    expect(copiedURL.headers.get("set-cookie")).toBeNull();
+
+    const bootstrap = await fleet.fetch(
+      codeBootstrapRequest(bootstrapURL, bootstrapHandoff.ticket),
+    );
     expect(bootstrap.status).toBe(303);
     expect(bootstrap.headers.get("location")).toBe(
       `/portal/leases/${leaseID}/code/?folder=%2Fwork%2Frepo`,
@@ -15202,7 +15214,7 @@ describe("fleet lease identity and idle", () => {
     expect(maxAge).toBeGreaterThanOrEqual(295);
     expect(maxAge).toBeLessThanOrEqual(300);
 
-    const replay = await fleet.fetch(new Request(bootstrapURL));
+    const replay = await fleet.fetch(codeBootstrapRequest(bootstrapURL, bootstrapHandoff.ticket));
     expect(replay.status).toBe(401);
 
     const page = await fleet.fetch(
@@ -15314,8 +15326,9 @@ describe("fleet lease identity and idle", () => {
       ...staleGrant,
     });
     const bootstrap = await fleet.fetch(
-      new Request(
-        `${isolatedOrigin}/portal/leases/${leaseID}/code/__crabbox_bootstrap?ticket=${ticket}`,
+      codeBootstrapRequest(
+        `${isolatedOrigin}/portal/leases/${leaseID}/code/__crabbox_bootstrap`,
+        ticket,
       ),
     );
     expect(bootstrap.status).toBe(303);
@@ -15360,20 +15373,24 @@ describe("fleet lease identity and idle", () => {
       await routeCoordinatorRequest(input, env, async (prepared) => await fleet.fetch(prepared));
     const codeEntry = "https://crabbox.test/portal/leases/blue-lobster/code/";
 
-    const redirect = await throughCoordinator(
+    const handoff = await throughCoordinator(
       new Request(codeEntry, { headers: { cookie: portalCookie } }),
     );
-    expect(redirect.status).toBe(302);
-    const bootstrapURL = redirect.headers.get("location") || "";
-    expect(bootstrapURL).toContain("/__crabbox_bootstrap?ticket=code_view_");
+    expect(handoff.status).toBe(200);
+    const bootstrapHandoff = await readCodeBootstrapHandoff(handoff);
+    const bootstrapURL = bootstrapHandoff.url;
+    expect(bootstrapURL.pathname).toContain("/__crabbox_bootstrap");
+    expect(bootstrapURL.search).toBe("");
 
-    const pendingRedirect = await throughCoordinator(
+    const pendingHandoff = await throughCoordinator(
       new Request(codeEntry, { headers: { cookie: portalCookie } }),
     );
-    const pendingBootstrapURL = pendingRedirect.headers.get("location") || "";
-    expect(pendingRedirect.status).toBe(302);
+    expect(pendingHandoff.status).toBe(200);
+    const pendingBootstrap = await readCodeBootstrapHandoff(pendingHandoff);
 
-    const bootstrap = await throughCoordinator(new Request(bootstrapURL));
+    const bootstrap = await throughCoordinator(
+      codeBootstrapRequest(bootstrapURL, bootstrapHandoff.ticket),
+    );
     expect(bootstrap.status).toBe(303);
     const codeCookie = (bootstrap.headers.get("set-cookie") || "").split(";", 1)[0] || "";
     const isolatedPage = new URL(bootstrap.headers.get("location") || "", bootstrapURL).toString();
@@ -15435,7 +15452,9 @@ describe("fleet lease identity and idle", () => {
       `https://crabbox.test/portal/leases/${leaseID}/code/`,
     );
 
-    const staleBootstrap = await throughCoordinator(new Request(pendingBootstrapURL));
+    const staleBootstrap = await throughCoordinator(
+      codeBootstrapRequest(pendingBootstrap.url, pendingBootstrap.ticket),
+    );
     expect(staleBootstrap.status).toBe(401);
     await expect(staleBootstrap.json()).resolves.toMatchObject({
       error: "code_viewer_session_revoked",
@@ -22043,6 +22062,24 @@ function request(
       ...init.headers,
     },
     body: init.body === undefined ? undefined : JSON.stringify(init.body),
+  });
+}
+
+async function readCodeBootstrapHandoff(response: Response): Promise<{ url: URL; ticket: string }> {
+  const body = await response.text();
+  const action = /<form\b[^>]*\baction="([^"]+)"/.exec(body)?.[1];
+  const ticket = /<input\b[^>]*\bname="ticket"[^>]*\bvalue="([^"]+)"/.exec(body)?.[1];
+  if (!action || !ticket) {
+    throw new Error("Code bootstrap handoff form is incomplete");
+  }
+  return { url: new URL(action), ticket };
+}
+
+function codeBootstrapRequest(url: URL | string, ticket: string): Request {
+  return new Request(url, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({ ticket }),
   });
 }
 


### PR DESCRIPTION
## Summary

- replace the cross-origin Code viewer ticket redirect with a no-store auto-submitting POST handoff
- require form-encoded POST at the isolated bootstrap endpoint; clean copied bootstrap URLs cannot mint sessions
- retain one-time consumption, expiry, portal logout revocation, and clean post-bootstrap redirects
- add regression coverage for CSP, URL-copy failure, successful handoff, replay rejection, and stale sessions

Fixes https://github.com/openclaw/crabbox/issues/845

## Verification

- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker -- --run test/fleet.test.ts` (362 tests)
- `npm test --prefix worker` (782 tests)
- `npm run build --prefix worker`
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` (clean, confidence 0.83)

## Security

The single-use bearer ticket remains in the TLS-protected response body but no longer appears in a URL, redirect header, browser history, referrer, or ordinary access log. The handoff page is non-cacheable and uses a nonce-scoped script plus a restrictive CSP whose `form-action` is limited to the exact isolated lease origin.
