### PR TITLE
docs: remove release-owned admin revocation changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@
 ### Fixed
 
 - Removed the Code viewer bootstrap bearer ticket from redirect URLs and browser history by handing it to the isolated lease origin through a no-store, POST-only form. Thanks @coygeek.
-- Revalidated cached GitHub and bearer admin grants before restoring bridge sockets or consuming durable bridge tickets and Code sessions, closing or downgrading sessions after admin revocation. Thanks @coygeek.
 - Replaced raw generated VNC credentials in copied WebVNC links with short-lived, one-time, authorization-checked handoff tickets. Thanks @coygeek.
 - Closed restored WebVNC viewer sockets that lack a complete current organization-bound principal instead of retaining owner-only legacy authorization. Thanks @coygeek.
 - Enforced key-only OpenSSH authentication across managed Windows desktop, core, and WSL2 bootstraps while retaining generated Windows passwords for console and VNC use. Thanks @coygeek.


### PR DESCRIPTION
## Summary
- remove the release-owned admin revocation changelog line that landed with https://github.com/openclaw/crabbox/pull/846
- keep the Worker security behavior in the merged PR while leaving release-note ownership to the release flow

## Verification
- git diff --check
- scripts/check-docs.sh

## Config or secrets
- none