### PR TITLE
fix(worker): revoke active admin grants

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -156,6 +156,13 @@ Admin scope comes from `CRABBOX_ADMIN_TOKEN`, or from a signed GitHub user token
 whose verified email or login matches `CRABBOX_GITHUB_ADMIN_OWNERS` or
 `CRABBOX_GITHUB_ADMIN_LOGINS`. Locally, admin commands can still send the admin
 bearer via `CRABBOX_COORDINATOR_ADMIN_TOKEN` or `broker.adminToken`.
+Long-lived control, WebVNC, Code, and egress sessions bind cached admin authority
+to the exact GitHub identity or bearer token plus a deployment grant version.
+Changing any configured admin source revokes older active, restored, ticketed,
+or durable-session grants on the next authenticated request or scheduled
+reconciliation; active senders and recipients are also revalidated while data
+flows. Legacy admin attachments without a verifiable source and version fail
+closed after upgrade.
 Shared-operator requests do **not** trust caller-supplied `X-Crabbox-Owner` /
 `X-Crabbox-Org` headers — pin that automation's identity with
 `CRABBOX_SHARED_OWNER` (and `CRABBOX_DEFAULT_ORG`), or prefer per-user signed

--- a/worker/src/auth.ts
+++ b/worker/src/auth.ts
@@ -150,16 +150,30 @@ export function requestWithAuthContext(request: Request, auth: AuthContext): Req
   return new Request(request, { headers });
 }
 
+export async function requestWithAdminGrantVersion(
+  request: Request,
+  env: Pick<
+    Env,
+    "CRABBOX_ADMIN_TOKEN" | "CRABBOX_GITHUB_ADMIN_OWNERS" | "CRABBOX_GITHUB_ADMIN_LOGINS"
+  >,
+): Promise<Request> {
+  const headers = new Headers(request.headers);
+  headers.set("x-crabbox-admin-grant-version", await adminGrantVersion(env));
+  return new Request(request, { headers });
+}
+
 export function requestWithoutTrustedHeaders(request: Request): Request {
   if (
     !request.headers.has("x-crabbox-internal") &&
-    !request.headers.has("x-crabbox-proxy-secret")
+    !request.headers.has("x-crabbox-proxy-secret") &&
+    !request.headers.has("x-crabbox-admin-grant-version")
   ) {
     return request;
   }
   const headers = new Headers(request.headers);
   headers.delete("x-crabbox-internal");
   headers.delete("x-crabbox-proxy-secret");
+  headers.delete("x-crabbox-admin-grant-version");
   return new Request(request, { headers });
 }
 
@@ -602,6 +616,22 @@ async function sign(value: string, secret: string): Promise<string> {
 export async function sha256Hex(value: string): Promise<string> {
   const digest = await crypto.subtle.digest("SHA-256", encoder.encode(value));
   return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+export async function adminGrantVersion(
+  env: Pick<
+    Env,
+    "CRABBOX_ADMIN_TOKEN" | "CRABBOX_GITHUB_ADMIN_OWNERS" | "CRABBOX_GITHUB_ADMIN_LOGINS"
+  >,
+): Promise<string> {
+  const tokenHash = env.CRABBOX_ADMIN_TOKEN ? await sha256Hex(env.CRABBOX_ADMIN_TOKEN) : "";
+  return sha256Hex(
+    JSON.stringify({
+      tokenHash,
+      owners: [...new Set(envList(env.CRABBOX_GITHUB_ADMIN_OWNERS))].toSorted(),
+      logins: [...new Set(envList(env.CRABBOX_GITHUB_ADMIN_LOGINS))].toSorted(),
+    }),
+  );
 }
 
 export function base64URL(data: Uint8Array): string {

--- a/worker/src/coordinator-entry.ts
+++ b/worker/src/coordinator-entry.ts
@@ -1,5 +1,6 @@
 import {
   authenticateRequest,
+  requestWithAdminGrantVersion,
   requestWithAuthContext,
   requestWithoutTrustedHeaders,
   type AuthContext,
@@ -87,7 +88,10 @@ export async function prepareCoordinatorRequest(
   const runtimeAdapterAuth = runtimeAdapterServiceAuth(request, env, route);
   if (runtimeAdapterAuth) {
     return {
-      request: requestWithAuthContext(requestWithoutTrustedHeaders(request), runtimeAdapterAuth),
+      request: await requestWithAdminGrantVersion(
+        requestWithAuthContext(requestWithoutTrustedHeaders(request), runtimeAdapterAuth),
+        env,
+      ),
       authenticated: true,
     };
   }
@@ -117,7 +121,10 @@ export async function prepareCoordinatorRequest(
       authenticated: false,
     };
   }
-  return { request: requestWithAuthContext(authRequest, auth), authenticated: true };
+  return {
+    request: await requestWithAdminGrantVersion(requestWithAuthContext(authRequest, auth), env),
+    authenticated: true,
+  };
 }
 
 function portalCookieRequestIntentAllowed(request: Request, env: Env, url: URL): boolean {

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -217,6 +217,7 @@ const workspaceCommandMaxBootstrapBytes = 3_000;
 const workspaceTerminalSSHReadyTimeoutMs = 2 * 60_000;
 const workspaceSSHHostPrivateKeyHeader = "x-crabbox-workspace-ssh-host-private-key";
 const workspaceSSHHostPublicKeyHeader = "x-crabbox-workspace-ssh-host-public-key";
+const adminGrantRevalidationIntervalMs = 1_000;
 
 interface CachedAdminGrant {
   auth?: AuthContext["auth"];
@@ -781,6 +782,7 @@ export class FleetCoordinator {
   private readonly controlSockets = new Map<string, WebSocket>();
   private readonly workspaceTerminals = new Map<string, Set<WebSocket>>();
   private readonly restoredBridgeSockets = new Set<WebSocket>();
+  private readonly adminGrantValidationTimes = new WeakMap<WebSocket, number>();
   private bridgeRestoreReady: Promise<boolean> | undefined;
   private readyPoolBorrowQueue: Promise<void> = Promise.resolve();
   private bridgeTicketQueue: Promise<void> = Promise.resolve();
@@ -1588,11 +1590,16 @@ export class FleetCoordinator {
     if (socket.readyState !== WebSocket.OPEN || !this.bridgeSocketIsCurrent(socket, attachment)) {
       return;
     }
+    if (!(await this.activeBridgeAdminGrantIsCurrent(socket, attachment))) {
+      return;
+    }
     switch (attachment.kind) {
       case "webvnc-agent":
         await forwardOrBufferWebVNC(
           message,
-          this.webVNCViewerForAgent(attachment.leaseID, attachment.id)?.socket,
+          await this.currentBridgeRecipient(
+            this.webVNCViewerForAgent(attachment.leaseID, attachment.id)?.socket,
+          ),
           this.pendingWebVNCToViewer,
           webVNCBufferKey(attachment.leaseID, attachment.id),
         );
@@ -1627,13 +1634,17 @@ export class FleetCoordinator {
       case "egress-host":
         await forwardEgress(
           message,
-          this.egressClients.get(egressSocketKey(attachment.leaseID, attachment.sessionID)),
+          await this.currentBridgeRecipient(
+            this.egressClients.get(egressSocketKey(attachment.leaseID, attachment.sessionID)),
+          ),
         );
         break;
       case "egress-client":
         await forwardEgress(
           message,
-          this.egressHosts.get(egressSocketKey(attachment.leaseID, attachment.sessionID)),
+          await this.currentBridgeRecipient(
+            this.egressHosts.get(egressSocketKey(attachment.leaseID, attachment.sessionID)),
+          ),
         );
         break;
       case "runtime-adapter-agent":
@@ -1644,6 +1655,54 @@ export class FleetCoordinator {
         break;
     }
     void socket;
+  }
+
+  private async currentBridgeRecipient(
+    socket: WebSocket | undefined,
+  ): Promise<WebSocket | undefined> {
+    if (!socket || socket.readyState !== WebSocket.OPEN) {
+      return undefined;
+    }
+    const attachment = this.bridgeAttachment(socket);
+    if (
+      !attachment ||
+      !this.bridgeSocketIsCurrent(socket, attachment) ||
+      !(await this.activeBridgeAdminGrantIsCurrent(socket, attachment))
+    ) {
+      return undefined;
+    }
+    return socket;
+  }
+
+  private async activeBridgeAdminGrantIsCurrent(
+    socket: WebSocket,
+    attachment: BridgeAttachment,
+  ): Promise<boolean> {
+    if (!("admin" in attachment) || attachment.admin !== true) {
+      return true;
+    }
+    const now = Date.now();
+    const lastValidatedAt = this.adminGrantValidationTimes.get(socket) ?? 0;
+    if (now - lastValidatedAt < adminGrantRevalidationIntervalMs) {
+      return true;
+    }
+    if (cachedAdminGrantIsCurrent(attachment, await adminGrantValidation(this.env))) {
+      this.adminGrantValidationTimes.set(socket, now);
+      return true;
+    }
+    this.adminGrantValidationTimes.delete(socket);
+    if (attachment.kind === "egress-host" || attachment.kind === "egress-client") {
+      this.clearEgressSession(
+        attachment.leaseID,
+        attachment.sessionID,
+        1008,
+        "admin access revoked",
+      );
+      return false;
+    }
+    this.handleBridgeClose(socket, 1008, "admin access revoked");
+    closeSocket(socket, 1008, "admin access revoked");
+    return false;
   }
 
   private handleBridgeClose(socket: WebSocket, code: number, reason: string): void {
@@ -8009,9 +8068,9 @@ export class FleetCoordinator {
     agent.send(JSON.stringify(end));
   }
 
-  private sendCodeDataToViewer(message: CodeWebSocketData): void {
-    const viewer = this.codeViewers.get(message.id);
-    if (viewer?.readyState !== WebSocket.OPEN) {
+  private async sendCodeDataToViewer(message: CodeWebSocketData): Promise<void> {
+    const viewer = await this.currentBridgeRecipient(this.codeViewers.get(message.id));
+    if (!viewer) {
       return;
     }
     const data = base64ToBytes(message.body);
@@ -8075,7 +8134,7 @@ export class FleetCoordinator {
       return;
     }
     if (message.type === "ws_data" && message.id) {
-      this.sendCodeDataToViewer(message as CodeWebSocketData);
+      await this.sendCodeDataToViewer(message as CodeWebSocketData);
       return;
     }
     if (message.type === "ws_start" && message.id) {
@@ -8101,7 +8160,7 @@ export class FleetCoordinator {
       const pending = this.pendingCodeFrames.get(end.chunkID);
       this.pendingCodeFrames.delete(end.chunkID);
       if (pending) {
-        this.sendCodeDataToViewer({
+        await this.sendCodeDataToViewer({
           type: "ws_data",
           id: pending.id,
           frame: pending.frame,
@@ -11421,7 +11480,7 @@ export class FleetCoordinator {
     run.lastEventAt = now;
     await this.state.storage.put(runEventKey(run.id, seq), event);
     await this.putRun(run);
-    this.broadcastRunEvent(run, event);
+    await this.broadcastRunEvent(run, event);
     return event;
   }
 
@@ -11433,13 +11492,17 @@ export class FleetCoordinator {
     }
   }
 
-  private broadcastRunEvent(run: RunRecord, event: RunEventRecord): void {
+  private async broadcastRunEvent(run: RunRecord, event: RunEventRecord): Promise<void> {
     for (const socket of this.controlSockets.values()) {
       if (socket.readyState !== WebSocket.OPEN) {
         continue;
       }
       const attachment = this.bridgeAttachment(socket);
       if (!attachment || attachment.kind !== "control") {
+        continue;
+      }
+      // oxlint-disable-next-line eslint/no-await-in-loop -- validate each control before its event can be sent.
+      if (!(await this.activeBridgeAdminGrantIsCurrent(socket, attachment))) {
         continue;
       }
       const after = attachment.subscriptions?.[run.id];

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -5,6 +5,7 @@ const { Client: SSHClientConstructor, utils: sshUtils } = ssh2;
 import { artifactUploadResponse, type ArtifactUploadRequest } from "./artifacts";
 import {
   authenticateRequest,
+  adminGrantVersion as configuredAdminGrantVersion,
   githubUserIsAdmin,
   isAdminRequest,
   requestWithAuthContext,
@@ -223,6 +224,7 @@ interface CachedAdminGrant {
   auth?: AuthContext["auth"];
   login?: string;
   adminTokenHash?: string;
+  adminGrantVersion?: string;
 }
 
 interface WebVNCTicketRecord extends CachedAdminGrant {
@@ -675,6 +677,7 @@ type BridgeAttachment =
       auth?: AuthContext["auth"];
       login?: string;
       adminTokenHash?: string;
+      adminGrantVersion?: string;
       label: string;
     }
   | { kind: "code-agent"; leaseID: string }
@@ -688,6 +691,7 @@ type BridgeAttachment =
       admin?: boolean;
       login?: string;
       adminTokenHash?: string;
+      adminGrantVersion?: string;
       portalSessionHash?: string;
     }
   | {
@@ -700,6 +704,7 @@ type BridgeAttachment =
       auth?: AuthContext["auth"];
       login?: string;
       adminTokenHash?: string;
+      adminGrantVersion?: string;
     }
   | {
       kind: "egress-client";
@@ -711,6 +716,7 @@ type BridgeAttachment =
       auth?: AuthContext["auth"];
       login?: string;
       adminTokenHash?: string;
+      adminGrantVersion?: string;
     }
   | {
       kind: "runtime-adapter-agent";
@@ -728,6 +734,7 @@ type BridgeAttachment =
       auth?: AuthContext["auth"];
       login?: string;
       adminTokenHash?: string;
+      adminGrantVersion?: string;
       subscriptions?: Record<string, number>;
     };
 
@@ -758,6 +765,7 @@ interface WebVNCViewerSession {
   auth?: AuthContext["auth"];
   login?: string;
   adminTokenHash?: string;
+  adminGrantVersion?: string;
   label: string;
   connectedAt: string;
 }
@@ -783,6 +791,7 @@ export class FleetCoordinator {
   private readonly workspaceTerminals = new Map<string, Set<WebSocket>>();
   private readonly restoredBridgeSockets = new Set<WebSocket>();
   private readonly adminGrantValidationTimes = new WeakMap<WebSocket, number>();
+  private currentAdminGrantVersion: string | undefined;
   private bridgeRestoreReady: Promise<boolean> | undefined;
   private readyPoolBorrowQueue: Promise<void> = Promise.resolve();
   private bridgeTicketQueue: Promise<void> = Promise.resolve();
@@ -802,6 +811,7 @@ export class FleetCoordinator {
 
   async fetch(request: Request): Promise<Response> {
     try {
+      this.reconcileAdminGrantVersion(request);
       if (!(await this.restoredBridgesReady())) {
         return json(
           {
@@ -1121,7 +1131,7 @@ export class FleetCoordinator {
   private async reconcileRestoredBridgeSockets(): Promise<void> {
     const [leases, adminGrants] = await Promise.all([
       this.state.storage.list<LeaseRecord>({ prefix: "lease:" }),
-      adminGrantValidation(this.env),
+      this.currentAdminGrantValidation(),
     ]);
     const now = Date.now();
     const revoked = new Map<string, string>();
@@ -1253,6 +1263,61 @@ export class FleetCoordinator {
     return ready;
   }
 
+  private reconcileAdminGrantVersion(request: Request): void {
+    const version = trustedAdminGrantVersion(request);
+    if (!version || version === this.currentAdminGrantVersion) {
+      return;
+    }
+    this.currentAdminGrantVersion = version;
+    const sockets = new Set<WebSocket>([
+      ...this.controlSockets.values(),
+      ...this.codeViewers.values(),
+      ...this.egressHosts.values(),
+      ...this.egressClients.values(),
+    ]);
+    for (const viewers of this.webVNCViewers.values()) {
+      for (const viewer of viewers.values()) {
+        sockets.add(viewer.socket);
+      }
+    }
+    const revokedEgressSessions = new Set<string>();
+    for (const socket of sockets) {
+      const attachment = this.bridgeAttachment(socket);
+      if (
+        !attachment ||
+        !("admin" in attachment) ||
+        attachment.admin !== true ||
+        attachment.adminGrantVersion === version
+      ) {
+        continue;
+      }
+      this.adminGrantValidationTimes.delete(socket);
+      if (attachment.kind === "egress-host" || attachment.kind === "egress-client") {
+        const key = egressSocketKey(attachment.leaseID, attachment.sessionID);
+        if (!revokedEgressSessions.has(key)) {
+          revokedEgressSessions.add(key);
+          this.clearEgressSession(
+            attachment.leaseID,
+            attachment.sessionID,
+            1008,
+            "admin access revoked",
+          );
+        }
+        continue;
+      }
+      this.handleBridgeClose(socket, 1008, "admin access revoked");
+      closeSocket(socket, 1008, "admin access revoked");
+    }
+  }
+
+  private async currentAdminGrantValidation(): Promise<AdminGrantValidation> {
+    if (!this.currentAdminGrantVersion) {
+      const derivedVersion = await configuredAdminGrantVersion(this.env);
+      this.currentAdminGrantVersion ||= derivedVersion;
+    }
+    return adminGrantValidation(this.env, this.currentAdminGrantVersion);
+  }
+
   private rejectRestoredBridgeSocket(
     socket: WebSocket,
     attachment: BridgeAttachment | undefined,
@@ -1323,6 +1388,9 @@ export class FleetCoordinator {
           ...(attachment.auth ? { auth: attachment.auth } : {}),
           ...(attachment.login ? { login: attachment.login } : {}),
           ...(attachment.adminTokenHash ? { adminTokenHash: attachment.adminTokenHash } : {}),
+          ...(attachment.adminGrantVersion
+            ? { adminGrantVersion: attachment.adminGrantVersion }
+            : {}),
           label: attachment.label,
           connectedAt: new Date().toISOString(),
         });
@@ -1686,7 +1754,7 @@ export class FleetCoordinator {
     if (now - lastValidatedAt < adminGrantRevalidationIntervalMs) {
       return true;
     }
-    if (cachedAdminGrantIsCurrent(attachment, await adminGrantValidation(this.env))) {
+    if (cachedAdminGrantIsCurrent(attachment, await this.currentAdminGrantValidation())) {
       this.adminGrantValidationTimes.set(socket, now);
       return true;
     }
@@ -5029,7 +5097,7 @@ export class FleetCoordinator {
   private async revokeUnauthorizedLeaseBridges(lease: LeaseRecord): Promise<void> {
     const code = 1008;
     const reason = "lease access revoked";
-    const adminGrants = await adminGrantValidation(this.env);
+    const adminGrants = await this.currentAdminGrantValidation();
     for (const viewer of this.openWebVNCViewers(lease.id)) {
       if (this.leaseViewerAuthorized(lease, withCurrentAdminGrant(viewer, adminGrants))) {
         continue;
@@ -7640,6 +7708,9 @@ export class FleetCoordinator {
             ...(viewerSession.adminTokenHash
               ? { adminTokenHash: viewerSession.adminTokenHash }
               : {}),
+            ...(viewerSession.adminGrantVersion
+              ? { adminGrantVersion: viewerSession.adminGrantVersion }
+              : {}),
           }
         : await adminGrantForRequest(authorizedRequest, isAdminRequest(authorizedRequest));
       let portalSessionHash = viewerSession?.portalSessionHash;
@@ -7770,6 +7841,9 @@ export class FleetCoordinator {
     if (ticket.adminTokenHash) {
       session.adminTokenHash = ticket.adminTokenHash;
     }
+    if (ticket.adminGrantVersion) {
+      session.adminGrantVersion = ticket.adminGrantVersion;
+    }
     if (ticket.portalSessionHash) {
       session.portalSessionHash = ticket.portalSessionHash;
     }
@@ -7813,7 +7887,10 @@ export class FleetCoordinator {
       }
       return undefined;
     }
-    const currentSession = withCurrentAdminGrant(session, await adminGrantValidation(this.env));
+    const currentSession =
+      session.admin === true
+        ? withCurrentAdminGrant(session, await this.currentAdminGrantValidation())
+        : session;
     if (currentSession !== session) {
       await this.state.storage.put(codeViewerSessionKey(value), currentSession);
     }
@@ -7864,7 +7941,9 @@ export class FleetCoordinator {
         return undefined;
       }
       await this.state.storage.delete(key);
-      return withCurrentAdminGrant(ticket, await adminGrantValidation(this.env));
+      return ticket.admin === true
+        ? withCurrentAdminGrant(ticket, await this.currentAdminGrantValidation())
+        : ticket;
     });
   }
 
@@ -8642,7 +8721,10 @@ export class FleetCoordinator {
     if (!lease || !identifierMatchesLease(identifier, lease)) {
       return { status: "not_found" };
     }
-    const currentTicket = withCurrentAdminGrant(ticket, await adminGrantValidation(this.env));
+    const currentTicket =
+      ticket.admin === true
+        ? withCurrentAdminGrant(ticket, await this.currentAdminGrantValidation())
+        : ticket;
     if (!this.leaseManagerAuthorized(lease, leaseBridgeTicketPrincipal(currentTicket))) {
       await this.state.storage.delete(key);
       return { status: "invalid" };
@@ -8691,7 +8773,10 @@ export class FleetCoordinator {
     if (!lease || !identifierMatchesLease(identifier, lease)) {
       return { status: "not_found" };
     }
-    const currentTicket = withCurrentAdminGrant(ticket, await adminGrantValidation(this.env));
+    const currentTicket =
+      ticket.admin === true
+        ? withCurrentAdminGrant(ticket, await this.currentAdminGrantValidation())
+        : ticket;
     if (!this.leaseManagerAuthorized(lease, leaseBridgeTicketPrincipal(currentTicket))) {
       await this.state.storage.delete(key);
       return { status: "invalid" };
@@ -8747,7 +8832,10 @@ export class FleetCoordinator {
     if (!lease || !identifierMatchesLease(identifier, lease)) {
       return { status: "not_found" };
     }
-    const currentTicket = withCurrentAdminGrant(ticket, await adminGrantValidation(this.env));
+    const currentTicket =
+      ticket.admin === true
+        ? withCurrentAdminGrant(ticket, await this.currentAdminGrantValidation())
+        : ticket;
     if (!this.leaseManagerAuthorized(lease, leaseBridgeTicketPrincipal(currentTicket))) {
       await this.state.storage.delete(key);
       return { status: "invalid" };
@@ -13570,23 +13658,34 @@ function requestAuthType(request: Request): AuthContext["auth"] {
   return auth === "bearer" || auth === "github" || auth === "proxy" ? auth : "github";
 }
 
+function trustedAdminGrantVersion(request: Request): string | undefined {
+  const version = request.headers.get("x-crabbox-admin-grant-version")?.trim();
+  return version && /^[a-f0-9]{64}$/.test(version) ? version : undefined;
+}
+
 async function adminGrantForRequest(request: Request, admin: boolean): Promise<CachedAdminGrant> {
   if (!admin) {
     return {};
   }
   const auth = requestAuthType(request);
+  const adminGrantVersion = trustedAdminGrantVersion(request);
   if (auth === "github") {
     const login = request.headers.get("x-crabbox-github-login")?.trim();
-    return { auth, ...(login ? { login } : {}) };
+    return {
+      auth,
+      ...(login ? { login } : {}),
+      ...(adminGrantVersion ? { adminGrantVersion } : {}),
+    };
   }
   if (auth === "bearer") {
     const token = bearerToken(request);
     return {
       auth,
       ...(token ? { adminTokenHash: await sha256Hex(token) } : {}),
+      ...(adminGrantVersion ? { adminGrantVersion } : {}),
     };
   }
-  return { auth };
+  return { auth, ...(adminGrantVersion ? { adminGrantVersion } : {}) };
 }
 
 type AdminGrantEnv = Pick<
@@ -13597,14 +13696,19 @@ type AdminGrantEnv = Pick<
 interface AdminGrantValidation {
   env: AdminGrantEnv;
   adminTokenHash?: string;
+  adminGrantVersion?: string;
 }
 
-async function adminGrantValidation(env: AdminGrantEnv): Promise<AdminGrantValidation> {
+async function adminGrantValidation(
+  env: AdminGrantEnv,
+  adminGrantVersion?: string,
+): Promise<AdminGrantValidation> {
   return {
     env,
     ...(env.CRABBOX_ADMIN_TOKEN
       ? { adminTokenHash: await sha256Hex(env.CRABBOX_ADMIN_TOKEN) }
       : {}),
+    ...(adminGrantVersion ? { adminGrantVersion } : {}),
   };
 }
 
@@ -13614,6 +13718,9 @@ function cachedAdminGrantIsCurrent(
 ): boolean {
   if (principal.admin !== true) {
     return true;
+  }
+  if (validation.adminGrantVersion) {
+    return principal.adminGrantVersion === validation.adminGrantVersion;
   }
   if (
     principal.auth === "github" &&
@@ -14387,6 +14494,7 @@ function leaseBridgeTicketPrincipal(
     ...(ticket.auth ? { auth: ticket.auth } : {}),
     ...(ticket.login ? { login: ticket.login } : {}),
     ...(ticket.adminTokenHash ? { adminTokenHash: ticket.adminTokenHash } : {}),
+    ...(ticket.adminGrantVersion ? { adminGrantVersion: ticket.adminGrantVersion } : {}),
   };
 }
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,4 +1,4 @@
-import { authenticateRequest } from "./auth";
+import { authenticateRequest, requestWithAdminGrantVersion } from "./auth";
 import { routeCoordinatorRequest } from "./coordinator-entry";
 import { FleetDurableObject } from "./fleet";
 import type { Env } from "./types";
@@ -20,10 +20,13 @@ export default {
   ): Promise<void> {
     const id = env.FLEET.idFromName("default");
     ctx.waitUntil(
-      env.FLEET.get(id).fetch("https://crabbox.internal/v1/internal/scheduled", {
-        method: "POST",
-        headers: { "x-crabbox-internal": "scheduled" },
-      }),
+      requestWithAdminGrantVersion(
+        new Request("https://crabbox.internal/v1/internal/scheduled", {
+          method: "POST",
+          headers: { "x-crabbox-internal": "scheduled" },
+        }),
+        env,
+      ).then((request) => env.FLEET.get(id).fetch(request)),
     );
   },
 };

--- a/worker/test/coordinator-runtime.test.ts
+++ b/worker/test/coordinator-runtime.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { adminGrantVersion } from "../src/auth";
 import {
   CloudflareCoordinatorRuntime,
   coordinatorRequestQueue,
@@ -324,10 +325,12 @@ describe("coordinator runtimes", () => {
 
   it("reauthorizes WebVNC and Code agent tickets through socket acceptance", async () => {
     const runtime = new MemoryRuntime();
-    const coordinator = new FleetCoordinator(runtime, {
+    const env = {
       CRABBOX_DEFAULT_ORG: "example-org",
       CRABBOX_GITHUB_ADMIN_LOGINS: "admin",
-    } as Env);
+    } as Env;
+    const coordinator = new FleetCoordinator(runtime, env);
+    const currentGrantVersion = await adminGrantVersion(env);
     const lease: LeaseRecord = {
       id: "cbx_000000000001",
       slug: "shared-bridges",
@@ -374,6 +377,7 @@ describe("coordinator runtimes", () => {
       "x-crabbox-admin": "true",
       "x-crabbox-auth": "github",
       "x-crabbox-github-login": "admin",
+      "x-crabbox-admin-grant-version": currentGrantVersion,
     };
     const createTicket = async (
       kind: "webvnc" | "code",

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -187,6 +187,111 @@ class FakeWebSocket {
 }
 
 describe("runtime adapter relay", () => {
+  it("revalidates active admin control sockets against the current grant source", async () => {
+    const oldAdminToken = "old-admin-token";
+    const fleet = testFleet(new MemoryStorage(), {}, { CRABBOX_ADMIN_TOKEN: oldAdminToken });
+    const socket = new FakeWebSocket({
+      kind: "control",
+      clientID: "control-rotated-admin",
+      owner: "admin@example.com",
+      org: "example-org",
+      admin: true,
+      auth: "bearer",
+      adminTokenHash: await sha256Hex(oldAdminToken),
+      subscriptions: {},
+    });
+    const internal = fleet as unknown as {
+      env: Env;
+      controlSockets: Map<string, WebSocket>;
+    };
+    internal.controlSockets.set("control-rotated-admin", socket as unknown as WebSocket);
+    internal.env.CRABBOX_ADMIN_TOKEN = "new-admin-token";
+
+    await fleet.webSocketMessage(
+      socket as unknown as WebSocket,
+      JSON.stringify({ type: "subscribe", leaseIDs: [] }),
+    );
+
+    expect(socket.closeCode).toBe(1008);
+    expect(socket.closeReason).toBe("admin access revoked");
+    expect(internal.controlSockets.has("control-rotated-admin")).toBe(false);
+  });
+
+  it("revalidates idle admin controls before broadcasting subscribed run events", async () => {
+    const oldAdminToken = "old-admin-token";
+    const fleet = testFleet(new MemoryStorage(), {}, { CRABBOX_ADMIN_TOKEN: oldAdminToken });
+    const run = testRun({ id: "run_admin_revocation", owner: "other@example.com" });
+    const socket = new FakeWebSocket({
+      kind: "control",
+      clientID: "control-idle-rotated-admin",
+      owner: "admin@example.com",
+      org: "example-org",
+      admin: true,
+      auth: "bearer",
+      adminTokenHash: await sha256Hex(oldAdminToken),
+      subscriptions: { [run.id]: 0 },
+    });
+    const internal = fleet as unknown as {
+      env: Env;
+      controlSockets: Map<string, WebSocket>;
+      broadcastRunEvent(run: RunRecord, event: unknown): Promise<void>;
+    };
+    internal.controlSockets.set("control-idle-rotated-admin", socket as unknown as WebSocket);
+    internal.env.CRABBOX_ADMIN_TOKEN = "new-admin-token";
+
+    await internal.broadcastRunEvent(run, {
+      seq: 1,
+      runID: run.id,
+      type: "log",
+      createdAt: "2026-07-04T00:00:00.000Z",
+      log: "private output",
+    });
+
+    expect(socket.closeCode).toBe(1008);
+    expect(socket.closeReason).toBe("admin access revoked");
+    expect(socket.sentJSON()).toEqual([]);
+  });
+
+  it("revalidates idle admin viewers before forwarding agent data", async () => {
+    const oldAdminToken = "old-admin-token";
+    const fleet = testFleet(new MemoryStorage(), {}, { CRABBOX_ADMIN_TOKEN: oldAdminToken });
+    const leaseID = "cbx_000000000001";
+    const agent = new FakeWebSocket({ kind: "code-agent", leaseID });
+    const viewer = new FakeWebSocket({
+      kind: "code-viewer",
+      leaseID,
+      id: "code-rotated-admin",
+      auth: "bearer",
+      owner: "admin@example.com",
+      org: "example-org",
+      admin: true,
+      adminTokenHash: await sha256Hex(oldAdminToken),
+    });
+    const internal = fleet as unknown as {
+      env: Env;
+      codeAgents: Map<string, WebSocket>;
+      codeViewers: Map<string, WebSocket>;
+    };
+    internal.codeAgents.set(leaseID, agent as unknown as WebSocket);
+    internal.codeViewers.set("code-rotated-admin", viewer as unknown as WebSocket);
+    internal.env.CRABBOX_ADMIN_TOKEN = "new-admin-token";
+
+    await fleet.webSocketMessage(
+      agent as unknown as WebSocket,
+      JSON.stringify({
+        type: "ws_data",
+        id: "code-rotated-admin",
+        frame: "text",
+        body: btoa("private output"),
+      }),
+    );
+
+    expect(viewer.closeCode).toBe(1008);
+    expect(viewer.closeReason).toBe("admin access revoked");
+    expect(viewer.sentJSON()).toEqual([]);
+    expect(internal.codeViewers.has("code-rotated-admin")).toBe(false);
+  });
+
   it("restores unambiguous hibernated bridge sockets after validating lease state", async () => {
     const storage = new MemoryStorage();
     const list = vi.spyOn(storage, "list");

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -3,7 +3,7 @@ import { Script, createContext } from "node:vm";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { issueUserToken, sha256Hex } from "../src/auth";
+import { adminGrantVersion, issueUserToken, sha256Hex } from "../src/auth";
 import { EC2SpotClient } from "../src/aws";
 import { codeOriginForLease } from "../src/code-origin";
 import {
@@ -217,6 +217,38 @@ describe("runtime adapter relay", () => {
     expect(internal.controlSockets.has("control-rotated-admin")).toBe(false);
   });
 
+  it("revokes active admin sockets when a new deployment forwards a new grant version", async () => {
+    const oldAdminToken = "old-admin-token";
+    const newAdminToken = "new-admin-token";
+    const oldVersion = await adminGrantVersion({ CRABBOX_ADMIN_TOKEN: oldAdminToken });
+    const newVersion = await adminGrantVersion({ CRABBOX_ADMIN_TOKEN: newAdminToken });
+    const fleet = testFleet(new MemoryStorage(), {}, { CRABBOX_ADMIN_TOKEN: oldAdminToken });
+    const socket = new FakeWebSocket({
+      kind: "control",
+      clientID: "control-old-deployment-admin",
+      owner: "admin@example.com",
+      org: "example-org",
+      admin: true,
+      auth: "bearer",
+      adminTokenHash: await sha256Hex(oldAdminToken),
+      adminGrantVersion: oldVersion,
+      subscriptions: {},
+    });
+    const internal = fleet as unknown as { controlSockets: Map<string, WebSocket> };
+    internal.controlSockets.set("control-old-deployment-admin", socket as unknown as WebSocket);
+
+    const response = await fleet.fetch(
+      request("GET", "/v1/leases", {
+        headers: { "x-crabbox-admin-grant-version": newVersion },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(socket.closeCode).toBe(1008);
+    expect(socket.closeReason).toBe("admin access revoked");
+    expect(internal.controlSockets.has("control-old-deployment-admin")).toBe(false);
+  });
+
   it("revalidates idle admin controls before broadcasting subscribed run events", async () => {
     const oldAdminToken = "old-admin-token";
     const fleet = testFleet(new MemoryStorage(), {}, { CRABBOX_ADMIN_TOKEN: oldAdminToken });
@@ -380,6 +412,9 @@ describe("runtime adapter relay", () => {
     for (const lease of [revokedLease, legacyLease, adminLease]) {
       storage.seed(`lease:${lease.id}`, lease);
     }
+    const currentGrantVersion = await adminGrantVersion({
+      CRABBOX_GITHUB_ADMIN_LOGINS: "current-admin",
+    });
     const revoked = ["egress-host", "egress-client"].map(
       (kind) =>
         new FakeWebSocket({
@@ -410,6 +445,7 @@ describe("runtime adapter relay", () => {
           admin: true,
           auth: "github",
           login: "current-admin",
+          adminGrantVersion: currentGrantVersion,
         }),
     );
     const fleet = new FleetDurableObject(
@@ -455,6 +491,11 @@ describe("runtime adapter relay", () => {
       expiresAt: new Date(Date.now() + 60_000).toISOString(),
     });
     storage.seed(`lease:${lease.id}`, lease);
+    const currentAdminToken = "current-admin-token";
+    const currentGrantVersion = await adminGrantVersion({
+      CRABBOX_ADMIN_TOKEN: currentAdminToken,
+      CRABBOX_GITHUB_ADMIN_LOGINS: "current-admin",
+    });
     const revokedGrant = {
       owner: "former-admin@example.com",
       org: "other-org",
@@ -515,9 +556,9 @@ describe("runtime adapter relay", () => {
       admin: true,
       auth: "github",
       login: "current-admin",
+      adminGrantVersion: currentGrantVersion,
       subscriptions: {},
     });
-    const currentAdminToken = "current-admin-token";
     const currentBearerControl = new FakeWebSocket({
       kind: "control",
       clientID: "control-current-bearer-admin",
@@ -526,6 +567,7 @@ describe("runtime adapter relay", () => {
       admin: true,
       auth: "bearer",
       adminTokenHash: await sha256Hex(currentAdminToken),
+      adminGrantVersion: currentGrantVersion,
       subscriptions: {},
     });
     const rotatedBearerControl = new FakeWebSocket({
@@ -9794,6 +9836,7 @@ describe("fleet lease identity and idle", () => {
   it("revokes only unauthorized live viewers after an API share removal", async () => {
     const storage = new MemoryStorage();
     const adminToken = "current-admin-token";
+    const currentGrantVersion = await adminGrantVersion({ CRABBOX_ADMIN_TOKEN: adminToken });
     const fleet = testFleet(storage, {}, { CRABBOX_ADMIN_TOKEN: adminToken });
     const leaseID = "cbx_000000000001";
     const ownerHeaders = {
@@ -9888,6 +9931,7 @@ describe("fleet lease identity and idle", () => {
       org: "other-org",
       admin: true,
       adminTokenHash: await sha256Hex(adminToken),
+      adminGrantVersion: currentGrantVersion,
     });
     const legacyCodeViewer = new FakeWebSocket({
       kind: "code-viewer",

--- a/worker/test/http.test.ts
+++ b/worker/test/http.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import coordinator, { isAuthorized } from "../src";
 import {
+  adminGrantVersion,
   authenticateRequest,
   base64URL,
   issueUserToken,
@@ -234,7 +235,10 @@ describe("coordinator auth", () => {
         },
       }),
     ];
-    requests.forEach((request) => request.headers.set("x-crabbox-internal", "scheduled"));
+    requests.forEach((request) => {
+      request.headers.set("x-crabbox-internal", "scheduled");
+      request.headers.set("x-crabbox-admin-grant-version", "a".repeat(64));
+    });
 
     const routedRequests = await Promise.all(
       requests.map(async (request) => {
@@ -258,6 +262,33 @@ describe("coordinator auth", () => {
       null,
       null,
     ]);
+    expect(
+      routedRequests.map((request) => request.headers.get("x-crabbox-admin-grant-version")),
+    ).toEqual([null, null, null, null]);
+  });
+
+  it("replaces caller-supplied admin grant versions after authentication", async () => {
+    const env = {
+      CRABBOX_ADMIN_TOKEN: "admin-secret",
+      CRABBOX_DEFAULT_ORG: "example-org",
+    } as Env;
+    const forgedVersion = "a".repeat(64);
+    const prepared = await prepareCoordinatorRequest(
+      new Request("https://example.test/v1/admin/leases", {
+        headers: {
+          authorization: "Bearer admin-secret",
+          "x-crabbox-admin-grant-version": forgedVersion,
+        },
+      }),
+      env,
+    );
+
+    expect(prepared).toMatchObject({ authenticated: true });
+    if ("response" in prepared) throw new Error("admin request was rejected");
+    expect(prepared.request.headers.get("x-crabbox-admin-grant-version")).toBe(
+      await adminGrantVersion(env),
+    );
+    expect(prepared.request.headers.get("x-crabbox-admin-grant-version")).not.toBe(forgedVersion);
   });
 
   it("requires normal coordinator authentication for workspace terminals", async () => {


### PR DESCRIPTION
## Summary

- revoke active admin control, Code, WebVNC, and egress bridges before forwarding inbound or outbound traffic after their grant changes
- bind cached admin authority to a non-secret version of the exact bearer and GitHub admin configuration, including durable tickets and Code sessions
- strip caller-supplied grant versions at public boundaries and fail closed for legacy or unverifiable admin state

This completes the active-session and cross-deployment revocation boundary left after https://github.com/openclaw/crabbox/pull/846 merged.

## Verification

- exact candidate: `e237522c4fd36d221980c64734c56511ecfdb85d`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker` — 26 files, 787 tests
- `npm run build --prefix worker`
- `scripts/check-docs.sh`
- `git diff --check origin/main...HEAD`
- branch-wide autoreview clean, confidence 0.82

## Exact live proof

Deployed this exact head to a disposable Cloudflare Worker with provider creation, prewarming, and orphan cleanup disabled. Opened an admin control WebSocket with token A, rotated the Worker secret to token B, verified token B returned 200 while token A returned 401, observed the stale control close with code 1008 and reason `admin access revoked`, then opened a fresh control socket with token B. Deleted the Worker afterward and verified its URL returned 404. No lease or other persistent test state was created.

## Documentation

`docs/security.md` now records the exact grant-version binding, active and restored revocation behavior, and fail-closed legacy policy. The release-owned changelog remains outside this follow-up; add or consolidate its entry when selecting this PR for merge.
