### PR TITLE
fix(railway): require exact stop claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- Required an exact local or explicit `stop --reclaim` deployment claim before stopping an out-of-band Railway service, binding adoption to the configured endpoint, project, environment, service, and deployment. Thanks @coygeek.
 - Removed the Code viewer bootstrap bearer ticket from redirect URLs and browser history by handing it to the isolated lease origin through a no-store, POST-only form. Thanks @coygeek.
 - Revalidated cached GitHub and bearer admin grants before restoring bridge sockets or consuming durable bridge tickets and Code sessions, closing or downgrading sessions after admin revocation. Thanks @coygeek.
 - Replaced raw generated VNC credentials in copied WebVNC links with short-lived, one-time, authorization-checked handoff tickets. Thanks @coygeek.

--- a/docs/commands/stop.md
+++ b/docs/commands/stop.md
@@ -58,6 +58,11 @@ Crabbox lease ID and local slug:
   `--reclaim` reuse persists a claim.
 - `e2b` — accepts a Crabbox lease ID, a local slug, or a Crabbox-owned E2B
   sandbox ID in raw or `e2b_<sandboxID>` form and deletes the E2B sandbox.
+- `railway` — refuses unclaimed service IDs. Use `--reclaim` only after
+  inspecting the configured API endpoint, project, environment, service, and
+  current deployment; Crabbox persists that exact one-deployment binding before
+  stopping it. Failed stops retain the claim for an exact retry, while successful
+  stops remove it.
 - `vercel-sandbox` — accepts a Crabbox-created local slug or `vsbx_...` lease
   ID, verifies ownership metadata, deletes the Vercel Sandbox, and removes the
   local claim. Missing remote sandboxes preserve the claim unless
@@ -122,6 +127,7 @@ client are cleaned up before the provider release runs.
 ```text
 --provider <name>          provider to act against (see crabbox providers)
 --id <lease-or-slug>        lease ID or slug (equivalent to the positional arg)
+--reclaim                   explicitly adopt a provider resource when that provider supports safe stop adoption
 --target linux|macos|windows
 --windows-mode normal|wsl2
 --static-host <host>        static SSH host (provider=ssh)

--- a/docs/providers/railway.md
+++ b/docs/providers/railway.md
@@ -32,11 +32,14 @@ Railway API. Railway runs whatever start command the service is configured with
 (via `railway.toml`, the dashboard, or `serviceInstanceUpdate`), so accepting a
 generic Crabbox command would create false-positive test results.
 
-`status` returns the latest deployment status and readiness. `stop` calls
-`deploymentStop` on the latest deployment for the service. `list` enumerates one
-row per service across every project the token can see. `warmup` is rejected so
-Crabbox never silently provisions billable Railway resources — create the
-service yourself in the dashboard or via `serviceCreate` first.
+`status` returns the latest deployment status and readiness. Because Railway
+services are created outside Crabbox, the first `stop` requires explicit
+`--reclaim` adoption. Crabbox binds a local claim to the configured API endpoint,
+project, environment, service, and exact latest deployment before calling
+`deploymentStop`. A changed or unclaimed deployment fails closed. `list`
+enumerates one row per service across every project the token can see. `warmup`
+is rejected so Crabbox never silently provisions billable Railway resources —
+create the service yourself in the dashboard or via `serviceCreate` first.
 
 ## Commands
 
@@ -49,7 +52,7 @@ crabbox run --provider railway --no-sync --id "$RAILWAY_SERVICE_ID" -- false
 crabbox status --provider railway --id "$RAILWAY_SERVICE_ID" \
   --railway-project "$RAILWAY_PROJECT_ID" \
   --railway-environment "$RAILWAY_ENVIRONMENT_ID"
-crabbox stop   --provider railway --id "$RAILWAY_SERVICE_ID" \
+crabbox stop   --provider railway --id "$RAILWAY_SERVICE_ID" --reclaim \
   --railway-project "$RAILWAY_PROJECT_ID" \
   --railway-environment "$RAILWAY_ENVIRONMENT_ID"
 crabbox list   --provider railway
@@ -57,8 +60,10 @@ crabbox list   --provider railway
 
 `warmup` is rejected; service creation must happen out-of-band. `run` is rejected
 because there is no Railway exec API. `status` and `stop` require `--id`,
-`--railway-project`, and `--railway-environment`. `list` needs only the API
-token.
+`--railway-project`, and `--railway-environment`. The first stop of an exact
+deployment also requires `--reclaim`; a provider failure retains that binding so
+a retry can omit `--reclaim`. A successful stop removes it. `list` needs only the
+API token.
 
 ## Auth
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -248,7 +248,10 @@ an operator can use the provider's supported `--reclaim` reuse path to persist
 a new claim before any provider mutation. Hyper-V, Multipass, and Parallels
 likewise require exact resource-bound local claims before release or cleanup;
 provider names and `crabbox-` resource prefixes are discovery hints, not
-destructive ownership proof.
+destructive ownership proof. Railway services are created out-of-band, so stop
+requires either an exact local endpoint/project/environment/service/deployment
+claim or explicit `stop --reclaim` adoption of the currently inspected
+deployment; a successful stop removes that one-deployment claim.
 
 Artifact publishing rejects symlinks, directories at reserved generated-output
 paths, and other non-regular bundle entries before upload side effects. Required

--- a/internal/cli/claim.go
+++ b/internal/cli/claim.go
@@ -783,6 +783,13 @@ func providerClaimScope(provider string, cfg Config) string {
 		if endpoint != "" && node != "" {
 			return "endpoint:" + endpoint + "|node:" + node
 		}
+	case "railway":
+		endpoint := strings.TrimRight(strings.TrimSpace(routingSafeURL(cfg.Railway.APIURL)), "/")
+		projectID := strings.TrimSpace(cfg.Railway.ProjectID)
+		environmentID := strings.TrimSpace(cfg.Railway.EnvironmentID)
+		if endpoint != "" && projectID != "" && environmentID != "" {
+			return "endpoint:" + endpoint + "|project:" + projectID + "|environment:" + environmentID
+		}
 	}
 	return ""
 }

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -119,6 +119,13 @@ type DelegatedRunBackend interface {
 	Stop(ctx context.Context, req StopRequest) error
 }
 
+// StopReclaimBackend supports an explicit one-shot adoption before a delegated
+// provider stop. Providers without a strong adoption contract do not implement it.
+type StopReclaimBackend interface {
+	Backend
+	ReclaimAndStop(ctx context.Context, req StopRequest) error
+}
+
 type DelegatedRunArtifactBackend interface {
 	Backend
 	CollectRunArtifacts(ctx context.Context, req DelegatedRunArtifactRequest) (DelegatedRunArtifactResult, error)

--- a/internal/cli/provider_exports.go
+++ b/internal/cli/provider_exports.go
@@ -207,6 +207,10 @@ func UpdateLeaseClaimLabelsIfUnchanged(leaseID string, expected LeaseClaim, labe
 	return updateLeaseClaimLabelsIfUnchanged(leaseID, expected, labels)
 }
 
+func UpdateLeaseClaimLabelsIfUnchangedAfter(leaseID string, expected LeaseClaim, labels map[string]string, action func() error) (LeaseClaim, error) {
+	return updateLeaseClaimLabelsIfUnchangedAfter(leaseID, expected, labels, action)
+}
+
 // UpdateLeaseClaimTailscale records a tailnet endpoint (IPv4 and/or FQDN) on an
 // existing claim. Used by delegated-run providers that join the tailnet
 // out-of-band rather than through a Crabbox-managed SSH lease.

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -2929,6 +2929,7 @@ func (a App) stop(ctx context.Context, args []string) error {
 	fs := newFlagSet("stop", a.Stderr)
 	provider := fs.String("provider", defaults.Provider, providerHelpAll())
 	id := fs.String("id", "", "lease id or slug")
+	reclaim := fs.Bool("reclaim", false, "adopt an unclaimed provider resource before stopping it")
 	expectedLeaseID := fs.String("expected-provider-lease-id", "", "internal: immutable provider lease identity")
 	expectedAttemptLeaseID := fs.String("expected-provider-attempt-lease-id", "", "internal: immutable provider attempt identity")
 	expectedSlug := fs.String("expected-provider-slug", "", "internal: immutable provider slug identity")
@@ -3071,7 +3072,17 @@ func (a App) stop(ctx context.Context, args []string) error {
 		if !expectedIdentity.empty() {
 			return exit(2, "provider=%s cannot validate an expected release identity", backend.Spec().Name)
 		}
+		if *reclaim {
+			reclaimer, ok := backend.(StopReclaimBackend)
+			if !ok {
+				return exit(2, "provider=%s does not support stop --reclaim", backend.Spec().Name)
+			}
+			return reclaimer.ReclaimAndStop(ctx, StopRequest{Options: leaseOptionsFromConfig(cfg), ID: *id})
+		}
 		return delegated.Stop(ctx, StopRequest{Options: leaseOptionsFromConfig(cfg), ID: *id})
+	}
+	if *reclaim {
+		return exit(2, "provider=%s does not support stop --reclaim", backend.Spec().Name)
 	}
 	sshBackend, ok := backend.(SSHLeaseBackend)
 	if !ok {

--- a/internal/cli/static_route_test.go
+++ b/internal/cli/static_route_test.go
@@ -349,3 +349,12 @@ func TestStopRejectsIDFlagWithExtraPositional(t *testing.T) {
 		t.Fatalf("expected usage error for --id plus positional, got %v", err)
 	}
 }
+
+func TestStopRejectsReclaimForProviderWithoutAdoptionContract(t *testing.T) {
+	err := (App{Stdout: io.Discard, Stderr: io.Discard}).stop(context.Background(), []string{
+		"--provider", "e2b", "--id", "box_123", "--reclaim",
+	})
+	if err == nil || !strings.Contains(err.Error(), "does not support stop --reclaim") {
+		t.Fatalf("stop --reclaim err=%v, want unsupported-provider rejection", err)
+	}
+}

--- a/internal/providers/railway/backend.go
+++ b/internal/providers/railway/backend.go
@@ -2,6 +2,8 @@ package railway
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"math/rand"
@@ -16,12 +18,16 @@ import (
 // jitter so a long deployment doesn't hammer the API while a short one still
 // feels snappy.
 const (
-	railwayPollInitialInterval  = 5 * time.Second
-	railwayPollMaxInterval      = 30 * time.Second
-	railwayPollOverallTimeout   = 30 * time.Minute
-	railwayDeployResolveTimeout = 2 * time.Minute
-	railwayPollJitterFraction   = 0.2
-	railwayPollLogLimit         = 500
+	railwayPollInitialInterval   = 5 * time.Second
+	railwayPollMaxInterval       = 30 * time.Second
+	railwayPollOverallTimeout    = 30 * time.Minute
+	railwayDeployResolveTimeout  = 2 * time.Minute
+	railwayPollJitterFraction    = 0.2
+	railwayPollLogLimit          = 500
+	railwayClaimServiceLabel     = "railwayServiceId"
+	railwayClaimProjectLabel     = "railwayProjectId"
+	railwayClaimEnvironmentLabel = "railwayEnvironmentId"
+	railwayClaimDeploymentLabel  = "railwayDeploymentId"
 )
 
 // railwayPollRand seeds a private rand.Source on first use so jitter doesn't
@@ -381,25 +387,146 @@ func (b *railwayBackend) Status(ctx context.Context, req StatusRequest) (StatusV
 }
 
 func (b *railwayBackend) Stop(ctx context.Context, req StopRequest) error {
+	claim, err := b.resolveStopClaim(req.ID)
+	if err != nil {
+		return err
+	}
+	service, deployment, err := b.railwayStopTarget(ctx, req.ID)
+	if err != nil {
+		return err
+	}
+	if deployment.ID != claim.Labels[railwayClaimDeploymentLabel] {
+		return exit(4, "provider=%s service=%s latest deployment changed from claimed %s to %s; inspect it and rerun stop --reclaim to adopt the new deployment", providerName, req.ID, claim.Labels[railwayClaimDeploymentLabel], deployment.ID)
+	}
+	return b.stopClaimedDeployment(ctx, service, deployment, claim)
+}
+
+func (b *railwayBackend) ReclaimAndStop(ctx context.Context, req StopRequest) error {
 	if req.ID == "" {
 		return exit(2, "provider=%s stop requires --id <railway-service-id>", providerName)
 	}
+	service, deployment, err := b.railwayStopTarget(ctx, req.ID)
+	if err != nil {
+		return err
+	}
+	claimID := railwayClaimID(b.cfg, req.ID)
+	previous, previousExists, err := resolveLeaseClaim(claimID)
+	if err != nil {
+		return err
+	}
+	labels := railwayClaimLabels(b.cfg, req.ID, deployment.ID)
+	claim, err := claimLeaseTargetForConfigIfUnchanged(
+		claimID,
+		b.cfg,
+		Server{CloudID: req.ID, Provider: providerName, Name: service.Name, Labels: labels},
+		previous,
+		previousExists,
+	)
+	if err != nil {
+		return err
+	}
+	if err := validateRailwayStopClaim(b.cfg, req.ID, claim); err != nil {
+		return err
+	}
+	return b.stopClaimedDeployment(ctx, service, deployment, claim)
+}
+
+func (b *railwayBackend) resolveStopClaim(serviceID string) (LeaseClaim, error) {
+	if serviceID == "" {
+		return LeaseClaim{}, exit(2, "provider=%s stop requires --id <railway-service-id>", providerName)
+	}
+	if _, _, err := b.requireProjectEnv(); err != nil {
+		return LeaseClaim{}, exit(2, "provider=%s stop requires --railway-project and --railway-environment", providerName)
+	}
+	claim, ok, err := resolveLeaseClaimForProviderCloudID(serviceID)
+	if err != nil {
+		return LeaseClaim{}, err
+	}
+	if !ok {
+		return LeaseClaim{}, exit(4, "provider=%s service=%s is not claimed; inspect the configured project and environment, then use stop --reclaim for explicit one-deployment adoption", providerName, serviceID)
+	}
+	if err := validateRailwayStopClaim(b.cfg, serviceID, claim); err != nil {
+		return LeaseClaim{}, err
+	}
+	return claim, nil
+}
+
+func (b *railwayBackend) railwayStopTarget(ctx context.Context, serviceID string) (railwayService, railwayDeployment, error) {
+	if serviceID == "" {
+		return railwayService{}, railwayDeployment{}, exit(2, "provider=%s stop requires --id <railway-service-id>", providerName)
+	}
 	projectID, environmentID, err := b.requireProjectEnv()
 	if err != nil {
-		return exit(2, "provider=%s stop requires --railway-project and --railway-environment", providerName)
+		return railwayService{}, railwayDeployment{}, exit(2, "provider=%s stop requires --railway-project and --railway-environment", providerName)
 	}
+	client, err := b.api()
+	if err != nil {
+		return railwayService{}, railwayDeployment{}, err
+	}
+	service, err := client.GetService(ctx, serviceID)
+	if err != nil {
+		return railwayService{}, railwayDeployment{}, err
+	}
+	if service.ID != serviceID || service.ProjectID != projectID {
+		return railwayService{}, railwayDeployment{}, exit(4, "provider=%s service=%s does not belong to configured project=%s", providerName, serviceID, projectID)
+	}
+	deployment, err := client.LatestDeployment(ctx, projectID, environmentID, serviceID)
+	if err != nil {
+		return railwayService{}, railwayDeployment{}, err
+	}
+	if deployment.ID == "" {
+		return railwayService{}, railwayDeployment{}, exit(5, "provider=%s service=%s has no deployment to stop", providerName, serviceID)
+	}
+	return service, deployment, nil
+}
+
+func (b *railwayBackend) stopClaimedDeployment(ctx context.Context, service railwayService, deployment railwayDeployment, claim LeaseClaim) error {
 	client, err := b.api()
 	if err != nil {
 		return err
 	}
-	deployment, err := client.LatestDeployment(ctx, projectID, environmentID, req.ID)
+	updated, err := updateLeaseClaimLabelsIfUnchangedAfter(claim.LeaseID, claim, claim.Labels, func() error {
+		return client.StopDeployment(ctx, deployment.ID)
+	})
 	if err != nil {
 		return err
 	}
-	if deployment.ID == "" {
-		return exit(5, "provider=%s service=%s has no deployment to stop", providerName, req.ID)
+	if err := removeLeaseClaimIfUnchanged(updated.LeaseID, updated); err != nil {
+		return fmt.Errorf("remove stopped Railway claim: %w", err)
 	}
-	return client.StopDeployment(ctx, deployment.ID)
+	fmt.Fprintf(b.rt.Stderr, "stopped %s service=%s deployment=%s\n", providerName, service.ID, deployment.ID)
+	return nil
+}
+
+func railwayClaimID(cfg Config, serviceID string) string {
+	sum := sha256.Sum256([]byte(providerClaimScope(cfg) + "\x00" + strings.TrimSpace(serviceID)))
+	return "railway_" + hex.EncodeToString(sum[:16])
+}
+
+func railwayClaimLabels(cfg Config, serviceID, deploymentID string) map[string]string {
+	return map[string]string{
+		railwayClaimServiceLabel:     strings.TrimSpace(serviceID),
+		railwayClaimProjectLabel:     strings.TrimSpace(cfg.Railway.ProjectID),
+		railwayClaimEnvironmentLabel: strings.TrimSpace(cfg.Railway.EnvironmentID),
+		railwayClaimDeploymentLabel:  strings.TrimSpace(deploymentID),
+	}
+}
+
+func validateRailwayStopClaim(cfg Config, serviceID string, claim LeaseClaim) error {
+	expectedID := railwayClaimID(cfg, serviceID)
+	expectedLabels := railwayClaimLabels(cfg, serviceID, claim.Labels[railwayClaimDeploymentLabel])
+	if claim.LeaseID != expectedID || claim.Provider != providerName || claim.CloudID != serviceID || claim.ProviderScope != providerClaimScope(cfg) {
+		return exit(4, "provider=%s service=%s local claim does not match the configured endpoint, project, and environment; use stop --reclaim only after inspecting the target", providerName, serviceID)
+	}
+	if expectedLabels[railwayClaimDeploymentLabel] == "" {
+		return exit(4, "provider=%s service=%s local claim has no exact deployment binding", providerName, serviceID)
+	}
+	for key, expected := range expectedLabels {
+		if claim.Labels[key] != expected {
+			return exit(4, "provider=%s service=%s local claim %s mismatch", providerName, serviceID, key)
+		}
+	}
+	return nil
 }
 
 func (b *railwayBackend) api() (railwayAPI, error) {

--- a/internal/providers/railway/backend_test.go
+++ b/internal/providers/railway/backend_test.go
@@ -625,7 +625,9 @@ type fakeRailwayAPI struct {
 	deploymentBlock chan struct{}
 	services        []railwayService
 	service         railwayService
+	getServiceCalls int
 	stopID          string
+	stopErr         error
 	triggerErr      error
 	logsErr         error
 	listErr         error
@@ -705,7 +707,7 @@ func (f *fakeRailwayAPI) StopDeployment(_ context.Context, id string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.stopID = id
-	return nil
+	return f.stopErr
 }
 
 func (f *fakeRailwayAPI) ListServices(_ context.Context) ([]railwayService, error) {
@@ -717,6 +719,7 @@ func (f *fakeRailwayAPI) ListServices(_ context.Context) ([]railwayService, erro
 func (f *fakeRailwayAPI) GetService(_ context.Context, _ string) (railwayService, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.getServiceCalls++
 	return f.service, nil
 }
 
@@ -1051,19 +1054,135 @@ func TestRailwayStopRequiresID(t *testing.T) {
 	}
 }
 
-func TestRailwayStopCallsDeploymentStop(t *testing.T) {
-	api := &fakeRailwayAPI{deployment: railwayDeployment{ID: "dep-1", Status: "BUILDING"}}
+func TestRailwayStopRejectsUnclaimedServiceBeforeRemoteReads(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	api := &fakeRailwayAPI{
+		service:    railwayService{ID: "svc-1", Name: "api", ProjectID: "proj-1"},
+		deployment: railwayDeployment{ID: "dep-1", Status: "BUILDING"},
+	}
 	cfg := Config{Provider: providerName}
 	cfg.Railway.APIToken = "test-token"
 	cfg.Railway.APIURL = "https://backboard.railway.com/graphql/v2"
 	cfg.Railway.ProjectID = "proj-1"
 	cfg.Railway.EnvironmentID = "env-1"
 	backend := &railwayBackend{cfg: cfg, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: api}
-	if err := backend.Stop(context.Background(), StopRequest{ID: "svc-1"}); err != nil {
-		t.Fatalf("Stop err: %v", err)
+	err := backend.Stop(context.Background(), StopRequest{ID: "svc-1"})
+	if err == nil || !strings.Contains(err.Error(), "not claimed") {
+		t.Fatalf("Stop err=%v, want unclaimed rejection", err)
+	}
+	if api.getServiceCalls != 0 || api.latestCalls != 0 || api.stopID != "" {
+		t.Fatalf("unclaimed stop touched Railway: service=%d latest=%d stop=%q", api.getServiceCalls, api.latestCalls, api.stopID)
+	}
+}
+
+func TestRailwayReclaimAndStopBindsExactDeployment(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	api := &fakeRailwayAPI{
+		service:    railwayService{ID: "svc-1", Name: "api", ProjectID: "proj-1"},
+		deployment: railwayDeployment{ID: "dep-1", Status: "BUILDING"},
+	}
+	backend := newRailwayBackendForTest(api)
+	if err := backend.ReclaimAndStop(context.Background(), StopRequest{ID: "svc-1"}); err != nil {
+		t.Fatalf("ReclaimAndStop err: %v", err)
 	}
 	if api.stopID != "dep-1" {
 		t.Fatalf("stop called with id=%q, want dep-1", api.stopID)
+	}
+	if _, ok, err := resolveLeaseClaimForProviderCloudID("svc-1"); err != nil || ok {
+		t.Fatalf("successful stop left claim: ok=%t err=%v", ok, err)
+	}
+}
+
+func TestRailwayFailedStopPreservesClaimForExactRetry(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	api := &fakeRailwayAPI{
+		service:    railwayService{ID: "svc-1", Name: "api", ProjectID: "proj-1"},
+		deployment: railwayDeployment{ID: "dep-1", Status: "BUILDING"},
+		stopErr:    errors.New("stop unavailable"),
+	}
+	backend := newRailwayBackendForTest(api)
+	err := backend.ReclaimAndStop(context.Background(), StopRequest{ID: "svc-1"})
+	if err == nil || !strings.Contains(err.Error(), "stop unavailable") {
+		t.Fatalf("ReclaimAndStop err=%v, want provider failure", err)
+	}
+	claim, ok, err := resolveLeaseClaimForProviderCloudID("svc-1")
+	if err != nil || !ok {
+		t.Fatalf("failed stop claim: ok=%t err=%v", ok, err)
+	}
+	if claim.Labels[railwayClaimDeploymentLabel] != "dep-1" {
+		t.Fatalf("claim labels=%#v", claim.Labels)
+	}
+	api.stopErr = nil
+	api.stopID = ""
+	if err := backend.Stop(context.Background(), StopRequest{ID: "svc-1"}); err != nil {
+		t.Fatalf("claimed retry err: %v", err)
+	}
+	if api.stopID != "dep-1" {
+		t.Fatalf("retry stopped %q, want dep-1", api.stopID)
+	}
+}
+
+func TestRailwayStopRejectsChangedDeployment(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	api := &fakeRailwayAPI{
+		service:    railwayService{ID: "svc-1", Name: "api", ProjectID: "proj-1"},
+		deployment: railwayDeployment{ID: "dep-1", Status: "BUILDING"},
+		stopErr:    errors.New("retain claim"),
+	}
+	backend := newRailwayBackendForTest(api)
+	if err := backend.ReclaimAndStop(context.Background(), StopRequest{ID: "svc-1"}); err == nil {
+		t.Fatal("ReclaimAndStop unexpectedly succeeded")
+	}
+	api.stopErr = nil
+	api.stopID = ""
+	api.deployment = railwayDeployment{ID: "dep-2", Status: "BUILDING"}
+	err := backend.Stop(context.Background(), StopRequest{ID: "svc-1"})
+	if err == nil || !strings.Contains(err.Error(), "latest deployment changed") {
+		t.Fatalf("Stop err=%v, want changed deployment rejection", err)
+	}
+	if api.stopID != "" {
+		t.Fatalf("changed deployment stop called with %q", api.stopID)
+	}
+}
+
+func TestRailwayStopRejectsClaimFromDifferentEnvironmentBeforeRemoteReads(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	api := &fakeRailwayAPI{
+		service:    railwayService{ID: "svc-1", Name: "api", ProjectID: "proj-1"},
+		deployment: railwayDeployment{ID: "dep-1", Status: "BUILDING"},
+		stopErr:    errors.New("retain claim"),
+	}
+	backend := newRailwayBackendForTest(api)
+	if err := backend.ReclaimAndStop(context.Background(), StopRequest{ID: "svc-1"}); err == nil {
+		t.Fatal("ReclaimAndStop unexpectedly succeeded")
+	}
+	api.getServiceCalls = 0
+	api.latestCalls = 0
+	api.stopErr = nil
+	api.stopID = ""
+	backend.cfg.Railway.EnvironmentID = "env-other"
+	err := backend.Stop(context.Background(), StopRequest{ID: "svc-1"})
+	if err == nil || !strings.Contains(err.Error(), "does not match the configured endpoint") {
+		t.Fatalf("Stop err=%v, want scope rejection", err)
+	}
+	if api.getServiceCalls != 0 || api.latestCalls != 0 || api.stopID != "" {
+		t.Fatalf("scope mismatch touched Railway: service=%d latest=%d stop=%q", api.getServiceCalls, api.latestCalls, api.stopID)
+	}
+}
+
+func TestRailwayReclaimRejectsServiceFromDifferentProject(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	api := &fakeRailwayAPI{
+		service:    railwayService{ID: "svc-1", Name: "api", ProjectID: "proj-other"},
+		deployment: railwayDeployment{ID: "dep-1", Status: "BUILDING"},
+	}
+	backend := newRailwayBackendForTest(api)
+	err := backend.ReclaimAndStop(context.Background(), StopRequest{ID: "svc-1"})
+	if err == nil || !strings.Contains(err.Error(), "does not belong") {
+		t.Fatalf("ReclaimAndStop err=%v, want project rejection", err)
+	}
+	if api.latestCalls != 0 || api.stopID != "" {
+		t.Fatalf("project mismatch touched deployment: latest=%d stop=%q", api.latestCalls, api.stopID)
 	}
 }
 

--- a/internal/providers/railway/core.go
+++ b/internal/providers/railway/core.go
@@ -26,6 +26,7 @@ type Repo = core.Repo
 type ExitError = core.ExitError
 type FeatureSet = core.FeatureSet
 type Feature = core.Feature
+type LeaseClaim = core.LeaseClaim
 
 const (
 	providerName = "railway"
@@ -48,4 +49,28 @@ func blank(value, fallback string) string {
 
 func inventoryDoctorResult(provider string, leases int) DoctorResult {
 	return core.InventoryDoctorResult(provider, leases)
+}
+
+func claimLeaseTargetForConfigIfUnchanged(leaseID string, cfg Config, server Server, expected LeaseClaim, expectedExists bool) (LeaseClaim, error) {
+	return core.ClaimLeaseTargetForConfigIfUnchanged(leaseID, "", cfg, server, core.SSHTarget{}, 0, expected, expectedExists)
+}
+
+func resolveLeaseClaim(identifier string) (LeaseClaim, bool, error) {
+	return core.ResolveLeaseClaim(identifier)
+}
+
+func resolveLeaseClaimForProviderCloudID(cloudID string) (LeaseClaim, bool, error) {
+	return core.ResolveLeaseClaimForProviderCloudID(cloudID, providerName)
+}
+
+func providerClaimScope(cfg Config) string {
+	return core.ProviderClaimScope(providerName, cfg)
+}
+
+func updateLeaseClaimLabelsIfUnchangedAfter(leaseID string, expected LeaseClaim, labels map[string]string, action func() error) (LeaseClaim, error) {
+	return core.UpdateLeaseClaimLabelsIfUnchangedAfter(leaseID, expected, labels, action)
+}
+
+func removeLeaseClaimIfUnchanged(leaseID string, expected LeaseClaim) error {
+	return core.RemoveLeaseClaimIfUnchanged(leaseID, expected)
 }


### PR DESCRIPTION
## Summary

- require an exact local Railway ownership claim before destructive stop operations
- add explicit `stop --reclaim` adoption bound to endpoint, project, environment, service, and deployment
- retain claims after failed stops for exact retries and remove them only after successful unchanged stops
- document the new Railway stop boundary and add regression coverage for changed deployments, environments, and projects

## Verification

- `go test -race ./internal/providers/railway -count=1`
- `go test ./internal/cli -run 'TestStop(AcceptsIDFlag|RejectsIDFlagWithExtraPositional|RejectsReclaimForProviderWithoutAdoptionContract)$|TestClaimLeaseForRepoConfigScopesProviderClaims$' -count=1`
- `go vet ./internal/providers/railway ./internal/cli`
- `node scripts/build-docs-site.mjs`
- autoreview: no actionable findings

Live Railway proof was not run because no Railway credential is available in the configured environment or restricted credential vault.

Fixes https://github.com/openclaw/crabbox/issues/833
