### PR TITLE
fix(cli): bind repository SSH destinations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 
 - Required an exact local or explicit `stop --reclaim` deployment claim before stopping an out-of-band Railway service, binding adoption to the configured endpoint, project, environment, service, and deployment. Thanks @coygeek.
+- Refused repository-selected Static SSH, Parallels, and exe.dev control destinations when they would inherit trusted or ambient SSH authentication; explicit host overrides remain available for operator approval. Thanks @coygeek.
 - Removed the Code viewer bootstrap bearer ticket from redirect URLs and browser history by handing it to the isolated lease origin through a no-store, POST-only form. Thanks @coygeek.
 - Replaced raw generated VNC credentials in copied WebVNC links with short-lived, one-time, authorization-checked handoff tickets. Thanks @coygeek.
 - Closed restored WebVNC viewer sockets that lack a complete current organization-bound principal instead of retaining owner-only legacy authorization. Thanks @coygeek.

--- a/docs/providers/exe-dev.md
+++ b/docs/providers/exe-dev.md
@@ -15,6 +15,11 @@ coordinator support for this provider.
 The control host calls (`new`, `ls`, `rm`) speak the exe.dev API over SSH. Your
 own shell commands run on the VM SSH target, not through the control host.
 
+Control-host authentication uses your ambient SSH configuration or agent. A
+repository-defined custom `exeDev.controlHost` therefore requires explicit
+operator approval through `--exe-dev-control-host` or
+`CRABBOX_EXE_DEV_CONTROL_HOST` before Crabbox opens an SSH connection.
+
 ## Quick start
 
 ```sh

--- a/docs/providers/parallels.md
+++ b/docs/providers/parallels.md
@@ -142,6 +142,14 @@ reaches the guest IP through an SSH `ProxyCommand` via the host. Normal SSH
 commands, desktop input helpers, screenshots, and VNC tunnels all use the same
 proxy path.
 
+A repository-defined remote host, including one selected through `templates`
+or `hosts`, cannot silently inherit a host key or ambient SSH authentication
+from a more trusted source. Define the remote host and a relative,
+symlink-resolved key file contained by the repository together, or approve the
+destination explicitly with `--parallels-host` or `CRABBOX_PARALLELS_HOST`.
+Absolute, missing, and repository-escaping key paths require explicit host
+approval.
+
 ### Fleet hosts
 
 ```yaml

--- a/docs/providers/ssh.md
+++ b/docs/providers/ssh.md
@@ -126,6 +126,13 @@ The SSH private key comes from the shared `ssh.key` field (or `CRABBOX_SSH_KEY`)
 There is no per-host key field; the static provider connects with your existing
 key, not a key Crabbox generates.
 
+A repository-defined `static.host` cannot silently inherit a key or ambient SSH
+authentication from user config, the environment, an SSH agent, or local SSH
+config. Define `static.host` and a relative, symlink-resolved `ssh.key` file
+contained by the repository in the same repository config, or approve the
+destination explicitly with `--static-host` or `CRABBOX_STATIC_HOST`. Absolute,
+missing, and repository-escaping key paths require explicit host approval.
+
 ### Flags
 
 ```text

--- a/docs/security.md
+++ b/docs/security.md
@@ -228,6 +228,16 @@ bodies. E2B API endpoints require HTTPS except for explicit localhost/loopback
 development URLs, and AWS region values are validated before constructing
 SigV4 service hosts.
 
+Repository-selected Static SSH, remote Parallels, and exe.dev control hosts
+cannot inherit a key, SSH agent, or local SSH configuration from a more trusted
+source. Put both a Static SSH or Parallels host and a relative, symlink-resolved
+key file contained by the repository in the same repository config, or
+explicitly approve the destination with the matching host flag or environment
+variable. Absolute, missing, and repository-escaping key paths do not count as
+same-source credentials. Because exe.dev control authentication is always
+ambient, a repository-defined custom control host requires an explicit
+`--exe-dev-control-host` or `CRABBOX_EXE_DEV_CONTROL_HOST` override.
+
 Cookie-authenticated portal mutations and portal viewer WebSocket upgrades
 require an exact same-origin browser `Origin` matching `CRABBOX_PUBLIC_URL` (or
 the request origin when no public URL is configured). Missing or sibling-origin

--- a/internal/cli/checkpoint.go
+++ b/internal/cli/checkpoint.go
@@ -451,6 +451,8 @@ func applyParallelsHostRefConfig(cfg *Config, hostRef string) {
 		cfg.Parallels.Host = host.Host
 		cfg.Parallels.HostUser = host.User
 		cfg.Parallels.HostKey = host.Key
+		cfg.credentialProvenance.parallelsHost = host.hostSource
+		cfg.credentialProvenance.parallelsHostKey = host.keySource
 		cfg.Parallels.SelectedHost = firstNonBlank(host.Name, host.Host, "local")
 		if host.VMRoot != "" {
 			cfg.Parallels.VMRoot = host.VMRoot

--- a/internal/cli/checkpoint_test.go
+++ b/internal/cli/checkpoint_test.go
@@ -512,11 +512,13 @@ func TestApplyParallelsCheckpointHostConfigPreservesFleetHostAuth(t *testing.T) 
 	cfg := baseConfig()
 	cfg.Provider = "ssh"
 	cfg.Parallels.Hosts = []ParallelsHostConfig{{
-		Name:   "mac-fleet-1",
-		Host:   "mac-host.example.net",
-		User:   "builder",
-		Key:    "~/.ssh/mac-host",
-		VMRoot: "/Users/builder/Parallels",
+		Name:       "mac-fleet-1",
+		Host:       "mac-host.example.net",
+		User:       "builder",
+		Key:        "~/.ssh/mac-host",
+		VMRoot:     "/Users/builder/Parallels",
+		hostSource: credentialSourceTrustedFile,
+		keySource:  credentialSourceTrustedFile,
 	}}
 	record := checkpointRecord{Kind: checkpointKindParallels}
 	record.Native.Region = "mac-host.example.net"
@@ -527,6 +529,25 @@ func TestApplyParallelsCheckpointHostConfigPreservesFleetHostAuth(t *testing.T) 
 	}
 	if got := parallelsHostRefForConfig(cfg); got != "mac-fleet-1" {
 		t.Fatalf("host ref=%q", got)
+	}
+	if cfg.credentialProvenance.parallelsHost != credentialSourceTrustedFile || cfg.credentialProvenance.parallelsHostKey != credentialSourceTrustedFile {
+		t.Fatalf("provenance=%#v", cfg.credentialProvenance)
+	}
+}
+
+func TestApplyParallelsCheckpointHostConfigPreservesRepositoryProvenance(t *testing.T) {
+	cfg := baseConfig()
+	cfg.Parallels.Hosts = []ParallelsHostConfig{{
+		Name:       "repo-fleet",
+		Host:       "repo.example.test",
+		hostSource: credentialSourceRepository,
+	}}
+	record := checkpointRecord{Kind: checkpointKindParallels}
+	record.Native.Region = "repo-fleet"
+
+	applyParallelsCheckpointHostConfig(&cfg, record)
+	if err := validateProviderCredentialDestination(cfg); err == nil || !strings.Contains(err.Error(), "parallels.host") {
+		t.Fatalf("repository checkpoint host error=%v", err)
 	}
 }
 

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -1094,16 +1094,20 @@ type ParallelsTemplateConfig struct {
 	VMRoot           string
 	User             string
 	WorkRoot         string
+	hostSource       credentialValueSource
+	hostKeySource    credentialValueSource
 }
 
 type ParallelsHostConfig struct {
-	Name    string
-	Host    string
-	User    string
-	Key     string
-	VMRoot  string
-	Targets []string
-	MaxVMs  int
+	Name       string
+	Host       string
+	User       string
+	Key        string
+	VMRoot     string
+	Targets    []string
+	MaxVMs     int
+	hostSource credentialValueSource
+	keySource  credentialValueSource
 }
 
 type SemaphoreConfig struct {
@@ -4631,7 +4635,13 @@ func applyConfigFile(cfg *Config, path string) error {
 	if err != nil {
 		return err
 	}
-	return applyFileConfigWithTrust(cfg, file, trustedConfigPath(path))
+	trusted := trustedConfigPath(path)
+	if !trusted {
+		if root, err := filepath.Abs(filepath.Dir(path)); err == nil {
+			cfg.credentialProvenance.repositoryRoot = root
+		}
+	}
+	return applyFileConfigWithTrust(cfg, file, trusted)
 }
 
 func applyFileConfig(cfg *Config, file fileConfig) error {
@@ -4661,6 +4671,11 @@ func inlineSSHPublicKey(value string) bool {
 
 func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error {
 	credentialSource := credentialSourceForFile(trusted)
+	if !trusted && cfg.credentialProvenance.repositoryRoot == "" {
+		if root, err := os.Getwd(); err == nil {
+			cfg.credentialProvenance.repositoryRoot = root
+		}
+	}
 	if file.Profile != "" {
 		cfg.Profile = file.Profile
 	}
@@ -5393,12 +5408,14 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 		}
 		if file.Parallels.Host != "" {
 			cfg.Parallels.Host = file.Parallels.Host
+			cfg.credentialProvenance.parallelsHost = credentialSource
 		}
 		if file.Parallels.HostUser != "" {
 			cfg.Parallels.HostUser = file.Parallels.HostUser
 		}
 		if file.Parallels.HostKey != "" {
 			cfg.Parallels.HostKey = expandUserPath(file.Parallels.HostKey)
+			cfg.credentialProvenance.parallelsHostKey = credentialSource
 		}
 		if file.Parallels.VMRoot != "" {
 			cfg.Parallels.VMRoot = expandUserPath(file.Parallels.VMRoot)
@@ -5419,13 +5436,27 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 				if name == "" {
 					continue
 				}
-				cfg.Parallels.Templates[name] = applyFileParallelsTemplateConfig(cfg.Parallels.Templates[name], template)
+				merged := applyFileParallelsTemplateConfig(cfg.Parallels.Templates[name], template)
+				if template.Host != "" {
+					merged.hostSource = credentialSource
+				}
+				if template.HostKey != "" {
+					merged.hostKeySource = credentialSource
+				}
+				cfg.Parallels.Templates[name] = merged
 			}
 		}
 		if len(file.Parallels.Hosts) > 0 {
 			cfg.Parallels.Hosts = cfg.Parallels.Hosts[:0]
 			for _, host := range file.Parallels.Hosts {
-				cfg.Parallels.Hosts = append(cfg.Parallels.Hosts, applyFileParallelsHostConfig(host))
+				merged := applyFileParallelsHostConfig(host)
+				if host.Host != "" {
+					merged.hostSource = credentialSource
+				}
+				if host.Key != "" {
+					merged.keySource = credentialSource
+				}
+				cfg.Parallels.Hosts = append(cfg.Parallels.Hosts, merged)
 			}
 		}
 	}
@@ -5437,6 +5468,7 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 		if file.SSH.Key != "" {
 			cfg.SSHKey = expandUserPath(file.SSH.Key)
 			MarkSSHKeyExplicit(cfg)
+			cfg.credentialProvenance.sshKey = credentialSource
 		}
 		if file.SSH.Port != "" {
 			cfg.SSHPort = file.SSH.Port
@@ -5864,6 +5896,7 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 	if file.ExeDev != nil {
 		if file.ExeDev.ControlHost != "" {
 			cfg.ExeDev.ControlHost = file.ExeDev.ControlHost
+			cfg.credentialProvenance.exeDevControlHost = credentialSource
 		}
 		if file.ExeDev.Image != "" {
 			cfg.ExeDev.Image = file.ExeDev.Image
@@ -6960,6 +6993,7 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 		}
 		if file.Static.Host != "" {
 			cfg.Static.Host = file.Static.Host
+			cfg.credentialProvenance.staticHost = credentialSource
 		}
 		if file.Static.User != "" {
 			cfg.Static.User = file.Static.User
@@ -7775,9 +7809,17 @@ func applyEnv(cfg *Config) error {
 	cfg.Parallels.SourceSnapshotID = getenv("CRABBOX_PARALLELS_SOURCE_SNAPSHOT_ID", cfg.Parallels.SourceSnapshotID)
 	cfg.Parallels.Template = getenv("CRABBOX_PARALLELS_TEMPLATE", cfg.Parallels.Template)
 	cfg.Parallels.CloneMode = getenv("CRABBOX_PARALLELS_CLONE_MODE", cfg.Parallels.CloneMode)
-	cfg.Parallels.Host = getenv("CRABBOX_PARALLELS_HOST", cfg.Parallels.Host)
+	if value := os.Getenv("CRABBOX_PARALLELS_HOST"); value != "" {
+		cfg.Parallels.Host = value
+		cfg.Parallels.Hosts = nil
+		cfg.Parallels.SelectedHost = ""
+		cfg.credentialProvenance.parallelsHost = credentialSourceEnvironment
+	}
 	cfg.Parallels.HostUser = getenv("CRABBOX_PARALLELS_HOST_USER", cfg.Parallels.HostUser)
-	cfg.Parallels.HostKey = expandUserPath(getenv("CRABBOX_PARALLELS_HOST_KEY", cfg.Parallels.HostKey))
+	if value := os.Getenv("CRABBOX_PARALLELS_HOST_KEY"); value != "" {
+		cfg.Parallels.HostKey = expandUserPath(value)
+		cfg.credentialProvenance.parallelsHostKey = credentialSourceEnvironment
+	}
 	cfg.Parallels.VMRoot = expandUserPath(getenv("CRABBOX_PARALLELS_VM_ROOT", cfg.Parallels.VMRoot))
 	cfg.Parallels.User = getenv("CRABBOX_PARALLELS_USER", cfg.Parallels.User)
 	cfg.Parallels.WorkRoot = getenv("CRABBOX_PARALLELS_WORK_ROOT", cfg.Parallels.WorkRoot)
@@ -7791,6 +7833,7 @@ func applyEnv(cfg *Config) error {
 	if sshKey := os.Getenv("CRABBOX_SSH_KEY"); sshKey != "" {
 		cfg.SSHKey = sshKey
 		MarkSSHKeyExplicit(cfg)
+		cfg.credentialProvenance.sshKey = credentialSourceEnvironment
 	}
 	if sshPort := os.Getenv("CRABBOX_SSH_PORT"); sshPort != "" {
 		cfg.SSHPort = sshPort
@@ -7993,7 +8036,10 @@ func applyEnv(cfg *Config) error {
 	cfg.E2B.Template = getenv("CRABBOX_E2B_TEMPLATE", cfg.E2B.Template)
 	cfg.E2B.Workdir = getenv("CRABBOX_E2B_WORKDIR", cfg.E2B.Workdir)
 	cfg.E2B.User = getenv("CRABBOX_E2B_USER", cfg.E2B.User)
-	cfg.ExeDev.ControlHost = getenv("CRABBOX_EXE_DEV_CONTROL_HOST", getenv("EXE_DEV_CONTROL_HOST", cfg.ExeDev.ControlHost))
+	if value, ok := firstNonEmptyEnv("CRABBOX_EXE_DEV_CONTROL_HOST", "EXE_DEV_CONTROL_HOST"); ok {
+		cfg.ExeDev.ControlHost = value
+		cfg.credentialProvenance.exeDevControlHost = credentialSourceEnvironment
+	}
 	cfg.ExeDev.Image = getenv("CRABBOX_EXE_DEV_IMAGE", getenv("EXE_DEV_IMAGE", cfg.ExeDev.Image))
 	cfg.ExeDev.CPUs = getenvInt("CRABBOX_EXE_DEV_CPUS", cfg.ExeDev.CPUs)
 	cfg.ExeDev.Memory = getenv("CRABBOX_EXE_DEV_MEMORY", getenv("EXE_DEV_MEMORY", cfg.ExeDev.Memory))
@@ -8664,7 +8710,10 @@ func applyEnv(cfg *Config) error {
 	}
 	cfg.Static.ID = getenv("CRABBOX_STATIC_ID", cfg.Static.ID)
 	cfg.Static.Name = getenv("CRABBOX_STATIC_NAME", cfg.Static.Name)
-	cfg.Static.Host = getenv("CRABBOX_STATIC_HOST", cfg.Static.Host)
+	if value := os.Getenv("CRABBOX_STATIC_HOST"); value != "" {
+		cfg.Static.Host = value
+		cfg.credentialProvenance.staticHost = credentialSourceEnvironment
+	}
 	cfg.Static.User = getenv("CRABBOX_STATIC_USER", cfg.Static.User)
 	cfg.Static.Port = getenv("CRABBOX_STATIC_PORT", cfg.Static.Port)
 	cfg.Static.WorkRoot = getenv("CRABBOX_STATIC_WORK_ROOT", cfg.Static.WorkRoot)
@@ -9025,12 +9074,14 @@ func ApplyParallelsTemplateConfig(cfg *Config, name string) error {
 	}
 	if template.Host != "" {
 		cfg.Parallels.Host = template.Host
+		cfg.credentialProvenance.parallelsHost = template.hostSource
 	}
 	if template.HostUser != "" {
 		cfg.Parallels.HostUser = template.HostUser
 	}
 	if template.HostKey != "" {
 		cfg.Parallels.HostKey = template.HostKey
+		cfg.credentialProvenance.parallelsHostKey = template.hostKeySource
 	}
 	if template.VMRoot != "" {
 		cfg.Parallels.VMRoot = template.VMRoot

--- a/internal/cli/credential_provenance.go
+++ b/internal/cli/credential_provenance.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"flag"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -67,6 +68,12 @@ type credentialDestinationProvenance struct {
 	semaphoreToken      credentialValueSource
 	spritesAPIURL       credentialValueSource
 	spritesToken        credentialValueSource
+	parallelsHost       credentialValueSource
+	parallelsHostKey    credentialValueSource
+	staticHost          credentialValueSource
+	sshKey              credentialValueSource
+	exeDevControlHost   credentialValueSource
+	repositoryRoot      string
 }
 
 type sourcedCredential struct {
@@ -173,6 +180,18 @@ func markCredentialDestinationFlagSources(cfg *Config, fs *flag.FlagSet) {
 	}
 	if flagWasSet(fs, "azure-dynamic-sessions-endpoint") {
 		provenance.azSessionsEndpoint = credentialSourceFlag
+	}
+	if flagWasSet(fs, "parallels-host") {
+		provenance.parallelsHost = credentialSourceFlag
+	}
+	if flagWasSet(fs, "parallels-host-key") {
+		provenance.parallelsHostKey = credentialSourceFlag
+	}
+	if flagWasSet(fs, "static-host") {
+		provenance.staticHost = credentialSourceFlag
+	}
+	if flagWasSet(fs, "exe-dev-control-host") {
+		provenance.exeDevControlHost = credentialSourceFlag
 	}
 }
 
@@ -310,6 +329,23 @@ func validateProviderCredentialDestination(cfg Config) error {
 			inheritedCredential(sourcedCredential{cfg.Sprites.Token, provenance.spritesToken}) {
 			return repositoryCredentialDestinationError("sprites", "sprites.apiUrl", "CRABBOX_SPRITES_API_URL or --sprites-api-url")
 		}
+	case "parallels":
+		for _, candidate := range ParallelsCandidateConfigs(cfg) {
+			candidateProvenance := candidate.credentialProvenance
+			if candidateProvenance.parallelsHost == credentialSourceRepository &&
+				repositorySSHDestinationUsesInheritedAuth(candidate.Parallels.HostKey, candidateProvenance.parallelsHostKey, candidateProvenance.repositoryRoot) {
+				return repositoryCredentialDestinationError("parallels", "parallels.host", "CRABBOX_PARALLELS_HOST or --parallels-host")
+			}
+		}
+	case staticProvider:
+		if provenance.staticHost == credentialSourceRepository &&
+			repositorySSHDestinationUsesInheritedAuth(cfg.SSHKey, provenance.sshKey, provenance.repositoryRoot) {
+			return repositoryCredentialDestinationError(staticProvider, "static.host", "CRABBOX_STATIC_HOST or --static-host")
+		}
+	case "exe-dev":
+		if provenance.exeDevControlHost == credentialSourceRepository {
+			return repositoryCredentialDestinationError("exe-dev", "exeDev.controlHost", "CRABBOX_EXE_DEV_CONTROL_HOST or --exe-dev-control-host")
+		}
 	}
 	return nil
 }
@@ -348,6 +384,35 @@ func inheritedCredential(credentials ...sourcedCredential) bool {
 		}
 	}
 	return false
+}
+
+func repositorySSHDestinationUsesInheritedAuth(key string, source credentialValueSource, repositoryRoot string) bool {
+	// An empty key delegates authentication to ambient SSH config or an agent.
+	if strings.TrimSpace(key) == "" || source != credentialSourceRepository {
+		return true
+	}
+	return !repositoryContainsSSHKey(repositoryRoot, key)
+}
+
+func repositoryContainsSSHKey(repositoryRoot, key string) bool {
+	key = strings.TrimSpace(key)
+	if repositoryRoot == "" || key == "" || filepath.IsAbs(key) {
+		return false
+	}
+	root, err := filepath.EvalSymlinks(repositoryRoot)
+	if err != nil {
+		return false
+	}
+	resolved, err := filepath.EvalSymlinks(filepath.Join(root, key))
+	if err != nil {
+		return false
+	}
+	rel, err := filepath.Rel(root, resolved)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false
+	}
+	info, err := os.Stat(resolved)
+	return err == nil && info.Mode().IsRegular()
 }
 
 func nomadSelectedTokenEnvHasValue(cfg Config) bool {

--- a/internal/cli/credential_provenance_test.go
+++ b/internal/cli/credential_provenance_test.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -756,4 +758,349 @@ func TestConfigMergeAllowsRepositoryEndpointAndCredentialPair(t *testing.T) {
 	if cfg.Proxmox.Node != "pve-project" {
 		t.Fatalf("proxmox node=%q", cfg.Proxmox.Node)
 	}
+}
+
+func TestRepositorySSHDestinationsRejectInheritedOrAmbientAuthentication(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+		want string
+	}{
+		{
+			name: "static ambient auth",
+			cfg: Config{
+				Provider: staticProvider,
+				Static:   StaticConfig{Host: "repo.example.test"},
+				credentialProvenance: credentialDestinationProvenance{
+					staticHost: credentialSourceRepository,
+				},
+			},
+			want: "static.host",
+		},
+		{
+			name: "static inherited key",
+			cfg: Config{
+				Provider: staticProvider,
+				Static:   StaticConfig{Host: "repo.example.test"},
+				SSHKey:   "/trusted/id_ed25519",
+				credentialProvenance: credentialDestinationProvenance{
+					staticHost: credentialSourceRepository,
+					sshKey:     credentialSourceTrustedFile,
+				},
+			},
+			want: "static.host",
+		},
+		{
+			name: "parallels ambient auth",
+			cfg: Config{
+				Provider:  "parallels",
+				Parallels: ParallelsConfig{Host: "repo.example.test"},
+				credentialProvenance: credentialDestinationProvenance{
+					parallelsHost: credentialSourceRepository,
+				},
+			},
+			want: "parallels.host",
+		},
+		{
+			name: "parallels inherited key",
+			cfg: Config{
+				Provider:  "parallels",
+				Parallels: ParallelsConfig{Host: "repo.example.test", HostKey: "/trusted/id_ed25519"},
+				credentialProvenance: credentialDestinationProvenance{
+					parallelsHost:    credentialSourceRepository,
+					parallelsHostKey: credentialSourceEnvironment,
+				},
+			},
+			want: "parallels.host",
+		},
+		{
+			name: "parallels fleet ambient auth",
+			cfg: Config{
+				Provider: "parallels",
+				Parallels: ParallelsConfig{Hosts: []ParallelsHostConfig{{
+					Host:       "repo.example.test",
+					hostSource: credentialSourceRepository,
+				}}},
+			},
+			want: "parallels.host",
+		},
+		{
+			name: "exe dev ambient auth",
+			cfg: Config{
+				Provider: "exe-dev",
+				ExeDev:   ExeDevConfig{ControlHost: "repo.example.test"},
+				credentialProvenance: credentialDestinationProvenance{
+					exeDevControlHost: credentialSourceRepository,
+				},
+			},
+			want: "exeDev.controlHost",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateProviderCredentialDestination(test.cfg)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error=%v want field %s", err, test.want)
+			}
+		})
+	}
+}
+
+func TestRepositorySSHDestinationsAllowSameSourceKeys(t *testing.T) {
+	repositoryRoot, key := repositorySSHKeyFixture(t)
+	tests := []Config{
+		{
+			Provider: staticProvider,
+			Static:   StaticConfig{Host: "repo.example.test"},
+			SSHKey:   key,
+			credentialProvenance: credentialDestinationProvenance{
+				staticHost:     credentialSourceRepository,
+				sshKey:         credentialSourceRepository,
+				repositoryRoot: repositoryRoot,
+			},
+		},
+		{
+			Provider:  "parallels",
+			Parallels: ParallelsConfig{Host: "repo.example.test", HostKey: key},
+			credentialProvenance: credentialDestinationProvenance{
+				parallelsHost:    credentialSourceRepository,
+				parallelsHostKey: credentialSourceRepository,
+				repositoryRoot:   repositoryRoot,
+			},
+		},
+		{
+			Provider: "parallels",
+			Parallels: ParallelsConfig{Hosts: []ParallelsHostConfig{{
+				Host:       "repo.example.test",
+				Key:        key,
+				hostSource: credentialSourceRepository,
+				keySource:  credentialSourceRepository,
+			}}},
+			credentialProvenance: credentialDestinationProvenance{repositoryRoot: repositoryRoot},
+		},
+	}
+
+	for _, cfg := range tests {
+		if err := validateProviderCredentialDestination(cfg); err != nil {
+			t.Fatalf("provider=%s rejected same-source SSH config: %v", cfg.Provider, err)
+		}
+	}
+}
+
+func TestRepositorySSHDestinationsRejectExternalSameSourceKeyPaths(t *testing.T) {
+	repositoryRoot, key := repositorySSHKeyFixture(t)
+	externalRoot := t.TempDir()
+	externalKey := filepath.Join(externalRoot, "external-key")
+	if err := os.WriteFile(externalKey, []byte("external-test-key"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	escapingKey, err := filepath.Rel(repositoryRoot, externalKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(externalKey, filepath.Join(repositoryRoot, "outward-link")); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, candidate := range []string{
+		filepath.Join(repositoryRoot, key),
+		escapingKey,
+		"outward-link",
+		"missing-key",
+	} {
+		cfg := Config{
+			Provider: staticProvider,
+			Static:   StaticConfig{Host: "repo.example.test"},
+			SSHKey:   candidate,
+			credentialProvenance: credentialDestinationProvenance{
+				staticHost:     credentialSourceRepository,
+				sshKey:         credentialSourceRepository,
+				repositoryRoot: repositoryRoot,
+			},
+		}
+		if err := validateProviderCredentialDestination(cfg); err == nil {
+			t.Fatalf("unsafe repository key path %q was accepted", candidate)
+		}
+	}
+}
+
+func repositorySSHKeyFixture(t *testing.T) (string, string) {
+	t.Helper()
+	repositoryRoot := t.TempDir()
+	key := "repo-test-key"
+	if err := os.WriteFile(filepath.Join(repositoryRoot, key), []byte("repository-test-key"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return repositoryRoot, key
+}
+
+func TestConfigMergeTracksSSHDestinationSources(t *testing.T) {
+	clearConfigEnv(t)
+
+	t.Run("static inherited key rejected then environment host approved", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Provider = staticProvider
+		if err := applyFileConfigWithTrust(&cfg, fileConfig{SSH: &fileSSHConfig{Key: "/trusted/id_ed25519"}}, true); err != nil {
+			t.Fatal(err)
+		}
+		if err := applyFileConfigWithTrust(&cfg, fileConfig{Static: &fileStaticConfig{Host: "repo.example.test"}}, false); err != nil {
+			t.Fatal(err)
+		}
+		if err := validateProviderCredentialDestination(cfg); err == nil {
+			t.Fatal("repository static host with inherited key was accepted")
+		}
+
+		t.Setenv("CRABBOX_STATIC_HOST", "approved.example.test")
+		if err := applyEnv(&cfg); err != nil {
+			t.Fatal(err)
+		}
+		if err := validateProviderCredentialDestination(cfg); err != nil {
+			t.Fatalf("explicit static host rejected: %v", err)
+		}
+	})
+
+	t.Run("same repository static host and key allowed", func(t *testing.T) {
+		repositoryRoot, key := repositorySSHKeyFixture(t)
+		cfg := baseConfig()
+		cfg.Provider = staticProvider
+		cfg.credentialProvenance.repositoryRoot = repositoryRoot
+		if err := applyFileConfigWithTrust(&cfg, fileConfig{
+			Static: &fileStaticConfig{Host: "repo.example.test"},
+			SSH:    &fileSSHConfig{Key: key},
+		}, false); err != nil {
+			t.Fatal(err)
+		}
+		if err := validateProviderCredentialDestination(cfg); err != nil {
+			t.Fatalf("same-source static config rejected: %v", err)
+		}
+	})
+
+	t.Run("parallels fleet source follows each host", func(t *testing.T) {
+		repositoryRoot, key := repositorySSHKeyFixture(t)
+		cfg := baseConfig()
+		cfg.Provider = "parallels"
+		cfg.credentialProvenance.repositoryRoot = repositoryRoot
+		if err := applyFileConfigWithTrust(&cfg, fileConfig{Parallels: &fileParallelsConfig{
+			Hosts: []fileParallelsHostConfig{{Host: "repo.example.test", Key: key}},
+		}}, false); err != nil {
+			t.Fatal(err)
+		}
+		if err := validateProviderCredentialDestination(cfg); err != nil {
+			t.Fatalf("same-source fleet host rejected: %v", err)
+		}
+
+		cfg.Parallels.Hosts[0].Key = ""
+		if err := validateProviderCredentialDestination(cfg); err == nil {
+			t.Fatal("repository fleet host with ambient auth was accepted")
+		}
+
+		t.Setenv("CRABBOX_PARALLELS_HOST", "approved.example.test")
+		if err := applyEnv(&cfg); err != nil {
+			t.Fatal(err)
+		}
+		if len(cfg.Parallels.Hosts) != 0 {
+			t.Fatalf("explicit host retained repository fleet: %#v", cfg.Parallels.Hosts)
+		}
+		if err := validateProviderCredentialDestination(cfg); err != nil {
+			t.Fatalf("explicit parallels host rejected: %v", err)
+		}
+	})
+
+	t.Run("exe dev environment host approves ambient auth", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Provider = "exe-dev"
+		if err := applyFileConfigWithTrust(&cfg, fileConfig{ExeDev: &fileExeDevConfig{ControlHost: "repo.example.test"}}, false); err != nil {
+			t.Fatal(err)
+		}
+		if err := validateProviderCredentialDestination(cfg); err == nil {
+			t.Fatal("repository exe.dev control host was accepted")
+		}
+
+		t.Setenv("CRABBOX_EXE_DEV_CONTROL_HOST", "approved.example.test")
+		if err := applyEnv(&cfg); err != nil {
+			t.Fatal(err)
+		}
+		if err := validateProviderCredentialDestination(cfg); err != nil {
+			t.Fatalf("explicit exe.dev control host rejected: %v", err)
+		}
+	})
+}
+
+func TestRepositorySSHDestinationsAllowExplicitFlagOverride(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+		args []string
+	}{
+		{
+			name: "parallels",
+			cfg: Config{
+				Provider:  "parallels",
+				Parallels: ParallelsConfig{Host: "repo.example.test"},
+				credentialProvenance: credentialDestinationProvenance{
+					parallelsHost: credentialSourceRepository,
+				},
+			},
+			args: []string{"--parallels-host", "approved.example.test"},
+		},
+		{
+			name: "exe dev",
+			cfg: Config{
+				Provider: "exe-dev",
+				ExeDev:   ExeDevConfig{ControlHost: "repo.example.test"},
+				credentialProvenance: credentialDestinationProvenance{
+					exeDevControlHost: credentialSourceRepository,
+				},
+			},
+			args: []string{"--exe-dev-control-host", "approved.example.test"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := test.cfg
+			fs := newFlagSet("test", io.Discard)
+			var parallelsHost *string
+			if cfg.Provider == "parallels" {
+				parallelsHost = fs.String("parallels-host", cfg.Parallels.Host, "")
+			}
+			values := registerProviderFlags(fs, cfg)
+			if err := parseFlags(fs, test.args); err != nil {
+				t.Fatal(err)
+			}
+			if err := applyProviderFlags(&cfg, fs, values); err != nil {
+				t.Fatal(err)
+			}
+			if parallelsHost != nil {
+				cfg.Parallels.Host = *parallelsHost
+				cfg.Parallels.Hosts = nil
+				markCredentialDestinationFlagSources(&cfg, fs)
+			}
+			if err := validateProviderCredentialDestination(cfg); err != nil {
+				t.Fatalf("explicit host flag rejected: %v", err)
+			}
+		})
+	}
+
+	t.Run("static", func(t *testing.T) {
+		cfg := Config{
+			Provider: staticProvider,
+			Static:   StaticConfig{Host: "repo.example.test"},
+			credentialProvenance: credentialDestinationProvenance{
+				staticHost: credentialSourceRepository,
+			},
+		}
+		fs := newFlagSet("test", io.Discard)
+		values := registerTargetFlags(fs, cfg)
+		if err := parseFlags(fs, []string{"--static-host", "approved.example.test"}); err != nil {
+			t.Fatal(err)
+		}
+		if err := applyTargetFlagOverrides(&cfg, fs, values); err != nil {
+			t.Fatal(err)
+		}
+		if err := validateProviderCredentialDestination(cfg); err != nil {
+			t.Fatalf("explicit static host rejected: %v", err)
+		}
+	})
 }

--- a/internal/cli/parallels.go
+++ b/internal/cli/parallels.go
@@ -64,6 +64,8 @@ func ParallelsCandidateConfigs(cfg Config) []Config {
 		next.Parallels.Host = host.Host
 		next.Parallels.HostUser = host.User
 		next.Parallels.HostKey = host.Key
+		next.credentialProvenance.parallelsHost = host.hostSource
+		next.credentialProvenance.parallelsHostKey = host.keySource
 		if host.VMRoot != "" {
 			next.Parallels.VMRoot = host.VMRoot
 		}

--- a/internal/cli/static.go
+++ b/internal/cli/static.go
@@ -45,6 +45,7 @@ func applyTargetFlagOverrides(cfg *Config, fs *flag.FlagSet, values targetFlagVa
 	}
 	if flagWasSet(fs, "static-host") {
 		cfg.Static.Host = *values.StaticHost
+		cfg.credentialProvenance.staticHost = credentialSourceFlag
 	}
 	if flagWasSet(fs, "static-user") {
 		cfg.Static.User = *values.StaticUser


### PR DESCRIPTION
## Summary

- bind repository-selected Static SSH, Parallels, and exe.dev control destinations to SSH authentication provenance
- fail closed before SSH when the destination would inherit a trusted key, ambient agent, or local SSH configuration
- preserve explicit host approval through the existing host flags and environment variables
- allow same-repository Static SSH and Parallels key pairing only for existing relative regular files that remain inside the repository after symlink resolution
- propagate Parallels provenance through templates, fleet candidates, and checkpoint/native host selection
- document the approval and repository-key boundaries

Closes https://github.com/openclaw/crabbox/issues/834

## Exact live proof

Built the candidate CLI and ran it from an isolated repository config against a real SSH process spy.

- Static SSH with a repository host plus trusted user key: exit 2, zero SSH invocations
- Static SSH with an existing absolute local key named by repository config: exit 2, zero SSH invocations
- Static SSH with a repository-contained relative key: reached SSH
- Static SSH with CRABBOX_STATIC_HOST approval: reached SSH
- Parallels with a repository host and ambient auth: exit 2, zero SSH invocations
- Parallels with CRABBOX_PARALLELS_HOST approval: reached SSH
- exe.dev with a repository control host and ambient auth: exit 2, zero SSH invocations
- exe.dev with CRABBOX_EXE_DEV_CONTROL_HOST approval: reached SSH

No provider resources or credentials were used or created; this boundary executes before provider access.

## Verification

- go vet ./...
- go test -race ./...
- focused race tests for SSH provenance, config merging, Parallels candidate routing, and checkpoint host routing
- npm run format:check --prefix worker
- npm run lint --prefix worker
- npm run check --prefix worker
- npm test --prefix worker (782 tests)
- npm run build --prefix worker
- scripts/check-docs.sh
- node scripts/build-docs-site.mjs
- git diff --check
- autoreview: clean, no accepted/actionable findings (0.82)

Autoreview found and drove two fixes before the clean pass: checkpoint/native Parallels host-ref provenance propagation, and rejection of absolute, missing, escaping, or outward-symlink repository key paths.
