### PR TITLE
fix(hetzner): require exact destructive claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixed
 
+- Required canonical Hetzner labels plus an exact server-bound local claim before direct stop or cleanup can delete a server, and kept canonical lease IDs from falling through to slug or name aliases. Thanks @coygeek.
 - Kept WebVNC framebuffer and heartbeat traffic responsive while desktop themes apply, and fully detached long-lived Wayland wallpaper processes from their launching SSH sessions.
 - Required an exact local or explicit `stop --reclaim` deployment claim before stopping an out-of-band Railway service, binding adoption to the configured endpoint, project, environment, service, and deployment. Thanks @coygeek.
 - Refused repository-selected Static SSH, Parallels, and exe.dev control destinations when they would inherit trusted or ambient SSH authentication; explicit host overrides remain available for operator approval. Thanks @coygeek.

--- a/docs/commands/stop.md
+++ b/docs/commands/stop.md
@@ -63,6 +63,10 @@ Crabbox lease ID and local slug:
   current deployment; Crabbox persists that exact one-deployment binding before
   stopping it. Failed stops retain the claim for an exact retry, while successful
   stops remove it.
+- `hetzner` — requires canonical remote ownership labels and an exact local
+  claim bound to the server ID and lease ID. Unclaimed resources must first be
+  explicitly reclaimed through a normal reuse command; failed deletion keeps
+  the claim for an exact retry.
 - `vercel-sandbox` — accepts a Crabbox-created local slug or `vsbx_...` lease
   ID, verifies ownership metadata, deletes the Vercel Sandbox, and removes the
   local claim. Missing remote sandboxes preserve the claim unless

--- a/docs/providers/hetzner.md
+++ b/docs/providers/hetzner.md
@@ -92,6 +92,14 @@ AWS, GCP, Azure, or a container provider, whose image maps already point at a
 6. Delete the server (and managed SSH key) on release, `cleanup`, or — in
    brokered mode — coordinator expiry.
 
+Direct destructive operations require both canonical remote ownership labels
+and the exact local claim bound to the Hetzner server ID. A weakly labeled,
+unclaimed, or stale-claim server remains visible only through Hetzner's own
+tools; Crabbox will not adopt it during cleanup. To recover intentionally lost
+local state, first inspect the canonical server and explicitly reclaim it
+through a normal reuse command before stopping it. Failed server or SSH-key
+cleanup retains the claim for an exact retry.
+
 ## Classes and server types
 
 Classes expand to an ordered list of Hetzner server types; provisioning tries

--- a/docs/security.md
+++ b/docs/security.md
@@ -269,6 +269,10 @@ destructive ownership proof. Railway services are created out-of-band, so stop
 requires either an exact local endpoint/project/environment/service/deployment
 claim or explicit `stop --reclaim` adoption of the currently inspected
 deployment; a successful stop removes that one-deployment claim.
+Direct Hetzner release and cleanup similarly require canonical provider labels
+plus an unchanged local claim whose lease and cloud ID match the exact server.
+Cleanup skips weakly labeled, unclaimed, and stale-claim servers instead of
+turning provider inventory into ownership proof.
 
 Artifact publishing rejects symlinks, directories at reserved generated-output
 paths, and other non-regular bundle entries before upload side effects. Required

--- a/internal/cli/claim_test.go
+++ b/internal/cli/claim_test.go
@@ -568,6 +568,32 @@ func TestConditionalClaimActionUpdateRejectsChangedState(t *testing.T) {
 	}
 }
 
+func TestConditionalClaimActionFailureRetainsClaim(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	leaseID := "cbx_conditionalfailure123"
+	if err := claimLeaseTargetForRepoConfig(leaseID, "first", Config{Provider: "aws"}, Server{Provider: "aws", CloudID: "i-123"}, SSHTarget{}, "/repo", time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	expected, err := readLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	actionErr := errors.New("provider stop failed")
+	_, err = updateLeaseClaimLabelsIfUnchangedAfter(leaseID, expected, map[string]string{"state": "stopped"}, func() error {
+		return actionErr
+	})
+	if !errors.Is(err, actionErr) {
+		t.Fatalf("conditional action err=%v, want provider failure", err)
+	}
+	retained, err := readLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(retained, expected) {
+		t.Fatalf("claim changed after failed action:\n got %#v\nwant %#v", retained, expected)
+	}
+}
+
 func TestConditionalClaimEndpointActionUpdatesAtomically(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	leaseID := "cbx_conditionalendpoint123"

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -572,27 +572,18 @@ func TestIsloCreateDefaultsTrackExplicitConfigAndEnvironment(t *testing.T) {
 	}
 }
 
-func TestExplicitConfigMarkerAPIs(t *testing.T) {
+func TestProviderExplicitMarkerHelpers(t *testing.T) {
 	cfg := Config{
-		SSHUser:                    "alice",
-		SSHKey:                     "/keys/id_ed25519",
-		SSHPort:                    "2222",
-		WorkRoot:                   "/workspace",
-		appleVZImageSHA256Explicit: true,
+		SSHUser:  "alice",
+		SSHKey:   "/keys/id_ed25519",
+		SSHPort:  "2222",
+		WorkRoot: "/workspace",
 	}
 
 	MarkIsloImageExplicit(&cfg)
 	MarkIsloVCPUsExplicit(&cfg)
 	MarkIsloMemoryMBExplicit(&cfg)
 	MarkIsloDiskGBExplicit(&cfg)
-	MarkLocalContainerImageExplicit(&cfg)
-	MarkLocalContainerRuntimeExplicit(&cfg)
-	MarkLocalContainerWorkRootExplicit(&cfg)
-	MarkAppleContainerImageExplicit(&cfg)
-	MarkAppleVZImageExplicit(&cfg)
-	if cfg.appleVZImageSHA256Explicit {
-		t.Fatal("explicit Apple VZ image must clear the inherited checksum marker")
-	}
 	MarkAppleVZImageSHA256Explicit(&cfg)
 	MarkAppleVZCPUsExplicit(&cfg)
 	MarkAppleVZMemoryExplicit(&cfg)
@@ -609,9 +600,7 @@ func TestExplicitConfigMarkerAPIs(t *testing.T) {
 	MarkWorkRootExplicit(&cfg)
 
 	if !IsloImageExplicit(cfg) || !IsloVCPUsExplicit(cfg) || !IsloMemoryMBExplicit(cfg) || !IsloDiskGBExplicit(cfg) ||
-		!cfg.localContainerImageExplicit || !LocalContainerRuntimeExplicit(cfg) || !LocalContainerWorkRootExplicit(cfg) ||
-		!AppleContainerImageExplicit(cfg) || !AppleVZImageExplicit(cfg) || !cfg.appleVZImageSHA256Explicit ||
-		!AppleVZCPUsExplicit(cfg) || !AppleVZMemoryExplicit(cfg) || !AppleVZDiskExplicit(cfg) ||
+		!cfg.appleVZImageSHA256Explicit || !AppleVZCPUsExplicit(cfg) || !AppleVZMemoryExplicit(cfg) || !AppleVZDiskExplicit(cfg) ||
 		!cfg.multipassImageExplicit || !cfg.tartImageExplicit || !IsTartDiskExplicit(&cfg) ||
 		!IsTartCPUsExplicit(&cfg) || !IsTartMemoryExplicit(&cfg) || !IsTargetExplicit(&cfg) ||
 		!IsSSHUserExplicit(&cfg) || !IsSSHKeyExplicit(&cfg) || !IsSSHPortExplicit(&cfg) || !IsWorkRootExplicit(&cfg) {

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -572,6 +572,53 @@ func TestIsloCreateDefaultsTrackExplicitConfigAndEnvironment(t *testing.T) {
 	}
 }
 
+func TestExplicitConfigMarkerAPIs(t *testing.T) {
+	cfg := Config{
+		SSHUser:                    "alice",
+		SSHKey:                     "/keys/id_ed25519",
+		SSHPort:                    "2222",
+		WorkRoot:                   "/workspace",
+		appleVZImageSHA256Explicit: true,
+	}
+
+	MarkIsloImageExplicit(&cfg)
+	MarkIsloVCPUsExplicit(&cfg)
+	MarkIsloMemoryMBExplicit(&cfg)
+	MarkIsloDiskGBExplicit(&cfg)
+	MarkLocalContainerImageExplicit(&cfg)
+	MarkLocalContainerRuntimeExplicit(&cfg)
+	MarkLocalContainerWorkRootExplicit(&cfg)
+	MarkAppleContainerImageExplicit(&cfg)
+	MarkAppleVZImageExplicit(&cfg)
+	if cfg.appleVZImageSHA256Explicit {
+		t.Fatal("explicit Apple VZ image must clear the inherited checksum marker")
+	}
+	MarkAppleVZImageSHA256Explicit(&cfg)
+	MarkAppleVZCPUsExplicit(&cfg)
+	MarkAppleVZMemoryExplicit(&cfg)
+	MarkAppleVZDiskExplicit(&cfg)
+	MarkMultipassImageExplicit(&cfg)
+	MarkTartImageExplicit(&cfg)
+	MarkTartDiskExplicit(&cfg)
+	MarkTartCPUsExplicit(&cfg)
+	MarkTartMemoryExplicit(&cfg)
+	MarkTargetExplicit(&cfg)
+	MarkSSHUserExplicit(&cfg)
+	MarkSSHKeyExplicit(&cfg)
+	MarkSSHPortExplicit(&cfg)
+	MarkWorkRootExplicit(&cfg)
+
+	if !IsloImageExplicit(cfg) || !IsloVCPUsExplicit(cfg) || !IsloMemoryMBExplicit(cfg) || !IsloDiskGBExplicit(cfg) ||
+		!cfg.localContainerImageExplicit || !LocalContainerRuntimeExplicit(cfg) || !LocalContainerWorkRootExplicit(cfg) ||
+		!AppleContainerImageExplicit(cfg) || !AppleVZImageExplicit(cfg) || !cfg.appleVZImageSHA256Explicit ||
+		!AppleVZCPUsExplicit(cfg) || !AppleVZMemoryExplicit(cfg) || !AppleVZDiskExplicit(cfg) ||
+		!cfg.multipassImageExplicit || !cfg.tartImageExplicit || !IsTartDiskExplicit(&cfg) ||
+		!IsTartCPUsExplicit(&cfg) || !IsTartMemoryExplicit(&cfg) || !IsTargetExplicit(&cfg) ||
+		!IsSSHUserExplicit(&cfg) || !IsSSHKeyExplicit(&cfg) || !IsSSHPortExplicit(&cfg) || !IsWorkRootExplicit(&cfg) {
+		t.Fatalf("explicit marker API did not preserve every setting: %#v", cfg)
+	}
+}
+
 func TestNvidiaBrevConfigDefaultsFileAndEnv(t *testing.T) {
 	clearConfigEnv(t)
 	cfg := baseConfig()

--- a/internal/cli/providers_builtin_test.go
+++ b/internal/cli/providers_builtin_test.go
@@ -55,6 +55,7 @@ func init() {
 	RegisterProvider(testParallelsProvider{})
 	RegisterProvider(testWandbProvider{})
 	RegisterProvider(testServiceControlProvider{})
+	RegisterProvider(testStopReclaimProvider{})
 	RegisterProvider(testWindowsSandboxProvider{})
 }
 
@@ -2254,6 +2255,37 @@ type testDelegatedBackend struct {
 	spec        ProviderSpec
 	portsOutput string
 	copyErr     error
+}
+
+type testStopReclaimProvider struct{}
+
+func (testStopReclaimProvider) Name() string      { return "stop-reclaim-test" }
+func (testStopReclaimProvider) Aliases() []string { return nil }
+func (testStopReclaimProvider) Spec() ProviderSpec {
+	return ProviderSpec{
+		Name:        "stop-reclaim-test",
+		Kind:        ProviderKindDelegatedRun,
+		Targets:     []TargetSpec{{OS: targetLinux}},
+		Coordinator: CoordinatorNever,
+	}
+}
+func (testStopReclaimProvider) RegisterFlags(*flag.FlagSet, Config) any { return nil }
+func (testStopReclaimProvider) ApplyFlags(*Config, *flag.FlagSet, any) error {
+	return nil
+}
+func (p testStopReclaimProvider) Configure(Config, Runtime) (Backend, error) {
+	return testStopReclaimBackend{testDelegatedBackend: testDelegatedBackend{spec: p.Spec()}}, nil
+}
+
+type testStopReclaimBackend struct{ testDelegatedBackend }
+
+var testStopReclaimHook func(StopRequest) error
+
+func (testStopReclaimBackend) ReclaimAndStop(_ context.Context, req StopRequest) error {
+	if testStopReclaimHook != nil {
+		return testStopReclaimHook(req)
+	}
+	return nil
 }
 
 type testIsloBackend struct {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -2893,6 +2893,8 @@ func findServerByAlias(servers []Server, id string) (Server, string, error) {
 				return server, server.Labels["lease"], nil
 			}
 		}
+		// Canonical lease IDs are exact identities, never aliases.
+		return Server{}, "", nil
 	}
 	matches := make([]Server, 0, 2)
 	slug := normalizeLeaseSlug(id)

--- a/internal/cli/slug_test.go
+++ b/internal/cli/slug_test.go
@@ -239,6 +239,21 @@ func TestFindServerByAliasPrefersCanonicalID(t *testing.T) {
 	}
 }
 
+func TestFindServerByAliasDoesNotRetargetMissingCanonicalID(t *testing.T) {
+	id := "cbx_222222222222"
+	servers := []Server{{
+		Name:   id,
+		Labels: map[string]string{"lease": "cbx_111111111111", "slug": id},
+	}}
+	server, leaseID, err := findServerByAlias(servers, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if leaseID != "" || server.DisplayID() != "0" {
+		t.Fatalf("matched server=%s lease=%q, want no alias fallback", server.DisplayID(), leaseID)
+	}
+}
+
 func TestFindServerByAliasMatchesCloudInstanceName(t *testing.T) {
 	servers := []Server{
 		{Name: "crabbox-fallback-zone", CloudID: "crabbox-fallback-zone", Labels: map[string]string{"lease": "cbx_333333333333", "slug": "fallback-zone"}},

--- a/internal/cli/static_route_test.go
+++ b/internal/cli/static_route_test.go
@@ -358,3 +358,34 @@ func TestStopRejectsReclaimForProviderWithoutAdoptionContract(t *testing.T) {
 		t.Fatalf("stop --reclaim err=%v, want unsupported-provider rejection", err)
 	}
 }
+
+func TestStopDispatchesExplicitReclaimContract(t *testing.T) {
+	called := false
+	testStopReclaimHook = func(req StopRequest) error {
+		called = true
+		if req.ID != "service-123" {
+			t.Fatalf("reclaim id=%q", req.ID)
+		}
+		return nil
+	}
+	t.Cleanup(func() { testStopReclaimHook = nil })
+
+	err := (App{Stdout: io.Discard, Stderr: io.Discard}).stop(context.Background(), []string{
+		"--provider", "stop-reclaim-test", "--id", "service-123", "--reclaim",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Fatal("stop did not dispatch the explicit reclaim contract")
+	}
+}
+
+func TestStopRejectsReclaimForSSHLeaseProvider(t *testing.T) {
+	err := (App{Stdout: io.Discard, Stderr: io.Discard}).stop(context.Background(), []string{
+		"--provider", "ssh", "--static-host", "host.example.test", "--id", "static_host-example-test", "--reclaim",
+	})
+	if err == nil || !strings.Contains(err.Error(), "does not support stop --reclaim") {
+		t.Fatalf("stop --reclaim err=%v, want SSH-provider rejection", err)
+	}
+}

--- a/internal/providers/hetzner/backend.go
+++ b/internal/providers/hetzner/backend.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
@@ -40,7 +41,16 @@ type hetznerClient interface {
 	SetLabels(context.Context, int64, map[string]string) error
 }
 
-type hetznerLeaseBackend struct{ shared.DirectSSHBackend }
+type hetznerLeaseBackend struct {
+	shared.DirectSSHBackend
+	acquired sync.Map
+}
+
+type acquiredHetznerLease struct {
+	LeaseID string
+	CloudID string
+	ID      int64
+}
 
 func NewHetznerLeaseBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
 	cfg.Provider = providerName
@@ -125,7 +135,9 @@ func (b *hetznerLeaseBackend) acquireOnce(ctx context.Context, keep bool, reques
 		fmt.Fprintf(b.RT.Stderr, "warning: set labels: %v\n", err)
 	}
 	committed = true
-	return LeaseTarget{Server: server, SSH: ssh, LeaseID: leaseID}, nil
+	target = LeaseTarget{Server: server, SSH: ssh, LeaseID: leaseID}
+	b.acquired.Store(leaseID, acquiredHetznerLease{LeaseID: leaseID, CloudID: server.CloudID, ID: server.ID})
+	return target, nil
 }
 
 func (b *hetznerLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {
@@ -192,14 +204,40 @@ func (b *hetznerLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLease
 	server := normalizeHetznerServer(req.Lease.Server)
 	claim, err := requireExactHetznerClaim(server, req.Lease.LeaseID)
 	if err != nil {
-		return err
+		if !b.matchesAcquiredLease(server, req.Lease.LeaseID) {
+			return err
+		}
+		client, clientErr := newHetznerClient()
+		if clientErr != nil {
+			return clientErr
+		}
+		serverGone, deleteErr := deleteServerWithClient(ctx, client, server, true, req.Lease.LeaseID)
+		if serverGone {
+			b.acquired.Delete(req.Lease.LeaseID)
+		}
+		return deleteErr
 	}
 	client, err := newHetznerClient()
 	if err != nil {
 		return err
 	}
-	_, err = deleteClaimedHetznerServer(ctx, client, server, claim)
+	serverGone, err := deleteClaimedHetznerServer(ctx, client, server, claim)
+	if serverGone {
+		b.acquired.Delete(req.Lease.LeaseID)
+	}
 	return err
+}
+
+func (b *hetznerLeaseBackend) matchesAcquiredLease(server Server, leaseID string) bool {
+	if validateHetznerServerOwnership(server, false) != nil || server.Labels["lease"] != leaseID {
+		return false
+	}
+	value, ok := b.acquired.Load(leaseID)
+	if !ok {
+		return false
+	}
+	acquired, ok := value.(acquiredHetznerLease)
+	return ok && acquired.LeaseID == leaseID && acquired.CloudID == server.CloudID && acquired.ID == server.ID
 }
 
 func (b *hetznerLeaseBackend) ReleaseLeaseMessage(lease LeaseTarget) string {
@@ -423,7 +461,8 @@ func ownedHetznerServers(servers []Server) []Server {
 	for _, raw := range servers {
 		server := normalizeHetznerServer(raw)
 		claim, claimExists, err := core.ReadLeaseClaimWithPresence(server.Labels["lease"])
-		allowLegacyProvider := err == nil && claimExists && validateHetznerClaim(claim, server, server.Labels["lease"]) == nil
+		allowLegacyProvider := err == nil && claimExists &&
+			(validateHetznerClaim(claim, server, server.Labels["lease"]) == nil || upgradeableHetznerClaim(claim, server))
 		if validateHetznerServerOwnership(server, allowLegacyProvider) == nil {
 			owned = append(owned, server)
 		}

--- a/internal/providers/hetzner/backend.go
+++ b/internal/providers/hetzner/backend.go
@@ -454,7 +454,6 @@ func useStoredTestboxKey(target *SSHTarget, leaseID string) {
 func findServerByAlias(servers []Server, id string) (Server, string, error) {
 	return core.FindServerByAlias(servers, id)
 }
-func removeLeaseClaim(leaseID string) { core.RemoveLeaseClaim(leaseID) }
 
 var (
 	newHetznerClient          = func() (hetznerClient, error) { return core.NewHetznerClient() }

--- a/internal/providers/hetzner/backend.go
+++ b/internal/providers/hetzner/backend.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -105,6 +106,7 @@ func (b *hetznerLeaseBackend) acquireOnce(ctx context.Context, keep bool, reques
 	if err != nil {
 		return LeaseTarget{}, err
 	}
+	server = normalizeHetznerServer(server)
 	rollbackServer = server
 	rollbackServerCreated = true
 	fmt.Fprintf(b.RT.Stderr, "provisioned lease=%s server=%d type=%s\n", leaseID, server.ID, cfg.ServerType)
@@ -112,6 +114,7 @@ func (b *hetznerLeaseBackend) acquireOnce(ctx context.Context, keep bool, reques
 	if err != nil {
 		return LeaseTarget{}, err
 	}
+	server = normalizeHetznerServer(server)
 	rollbackServer = server
 	ssh := sshTargetFromConfig(cfg, server.PublicNet.IPv4.IP)
 	if err := waitForSSHReady(ctx, &ssh, b.RT.Stderr, "bootstrap", bootstrapWaitTimeout(cfg)); err != nil {
@@ -135,7 +138,8 @@ func (b *hetznerLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (
 		if err != nil {
 			return LeaseTarget{}, err
 		}
-		if err := validateHetznerServerOwnership(server); err != nil {
+		server = normalizeHetznerServer(server)
+		if err := validateHetznerResolveOwnership(server, req); err != nil {
 			return LeaseTarget{}, err
 		}
 		leaseID := blank(server.Labels["lease"], req.ID)
@@ -147,10 +151,11 @@ func (b *hetznerLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (
 	if err != nil {
 		return LeaseTarget{}, err
 	}
+	servers = ownedHetznerServers(servers)
 	if server, leaseID, err := findServerByAlias(servers, req.ID); err != nil {
 		return LeaseTarget{}, err
 	} else if leaseID != "" {
-		if err := validateHetznerServerOwnership(server); err != nil {
+		if err := validateHetznerResolveOwnership(server, req); err != nil {
 			return LeaseTarget{}, err
 		}
 		target := sshTargetFromConfig(b.Cfg, server.PublicNet.IPv4.IP)
@@ -166,7 +171,11 @@ func (b *hetznerLeaseBackend) List(ctx context.Context, req ListRequest) ([]Leas
 	if err != nil {
 		return nil, err
 	}
-	return client.ListCrabboxServers(ctx)
+	servers, err := client.ListCrabboxServers(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return ownedHetznerServers(servers), nil
 }
 
 func (b *hetznerLeaseBackend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
@@ -180,14 +189,17 @@ func (b *hetznerLeaseBackend) Doctor(ctx context.Context, _ core.DoctorRequest) 
 }
 
 func (b *hetznerLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
-	serverGone, err := deleteServerForRelease(ctx, b.Cfg, req.Lease.Server)
+	server := normalizeHetznerServer(req.Lease.Server)
+	claim, err := requireExactHetznerClaim(server, req.Lease.LeaseID)
 	if err != nil {
 		return err
 	}
-	if serverGone {
-		removeLeaseClaim(req.Lease.LeaseID)
+	client, err := newHetznerClient()
+	if err != nil {
+		return err
 	}
-	return nil
+	_, err = deleteClaimedHetznerServer(ctx, client, server, claim)
+	return err
 }
 
 func (b *hetznerLeaseBackend) ReleaseLeaseMessage(lease LeaseTarget) string {
@@ -199,11 +211,43 @@ func (b *hetznerLeaseBackend) Touch(ctx context.Context, req TouchRequest) (Serv
 }
 
 func (b *hetznerLeaseBackend) Cleanup(ctx context.Context, req CleanupRequest) error {
-	servers, err := b.List(ctx, ListRequest{Options: req.Options})
+	client, err := newHetznerClient()
 	if err != nil {
 		return err
 	}
-	return b.CleanupServers(ctx, req, servers)
+	servers, err := client.ListCrabboxServers(ctx)
+	if err != nil {
+		return err
+	}
+	now := time.Now().UTC()
+	if b.RT.Clock != nil {
+		now = b.RT.Clock.Now().UTC()
+	}
+	for _, raw := range servers {
+		server := normalizeHetznerServer(raw)
+		if err := validateHetznerServerOwnership(server, false); err != nil {
+			fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=canonical Crabbox ownership labels missing\n", server.DisplayID(), server.Name)
+			continue
+		}
+		shouldDelete, reason := core.ShouldCleanupServer(server, now)
+		if !shouldDelete {
+			fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=%s\n", server.DisplayID(), server.Name, reason)
+			continue
+		}
+		claim, claimErr := requireExactHetznerClaim(server, server.Labels["lease"])
+		if claimErr != nil {
+			fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=exact local claim missing or stale\n", server.DisplayID(), server.Name)
+			continue
+		}
+		fmt.Fprintf(b.RT.Stderr, "delete server id=%s name=%s\n", server.DisplayID(), server.Name)
+		if req.DryRun {
+			continue
+		}
+		if _, err := deleteClaimedHetznerServer(ctx, client, server, claim); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func acquireAttemptsRetry(rt Runtime, keep bool, acquire func() (LeaseTarget, error)) (LeaseTarget, error) {
@@ -223,47 +267,174 @@ func deleteServer(ctx context.Context, cfg Config, server Server) error {
 	return err
 }
 func deleteServerForRelease(ctx context.Context, cfg Config, server Server) (bool, error) {
-	if err := validateHetznerServerOwnership(server); err != nil {
+	_ = cfg
+	server = normalizeHetznerServer(server)
+	if err := validateHetznerServerOwnership(server, true); err != nil {
+		return false, err
+	}
+	claim, err := requireExactHetznerClaim(server, server.Labels["lease"])
+	if err != nil {
 		return false, err
 	}
 	client, err := newHetznerClient()
 	if err != nil {
 		return false, err
 	}
-	return deleteServerWithClient(ctx, client, server, true)
+	return deleteClaimedHetznerServer(ctx, client, server, claim)
 }
-func deleteServerWithClient(ctx context.Context, client hetznerClient, server Server, deleteKey bool) (bool, error) {
-	if err := validateHetznerServerOwnership(server); err != nil {
+
+func deleteClaimedHetznerServer(ctx context.Context, client hetznerClient, server Server, claim core.LeaseClaim) (bool, error) {
+	serverGone := false
+	updated, err := core.UpdateLeaseClaimLabelsIfUnchangedAfter(claim.LeaseID, claim, claim.Labels, func() error {
+		var deleteErr error
+		serverGone, deleteErr = deleteServerWithClient(ctx, client, server, true, claim.LeaseID)
+		return deleteErr
+	})
+	if err != nil {
 		return false, err
+	}
+	if serverGone {
+		if err := core.RemoveLeaseClaimIfUnchanged(updated.LeaseID, updated); err != nil {
+			return false, fmt.Errorf("finalize Hetzner cleanup claim: %w", err)
+		}
+	}
+	return serverGone, nil
+}
+
+func deleteServerWithClient(ctx context.Context, client hetznerClient, server Server, deleteKey bool, expectedLeaseID string) (bool, error) {
+	server = normalizeHetznerServer(server)
+	if err := validateHetznerServerOwnership(server, true); err != nil {
+		return false, err
+	}
+	if server.Labels["lease"] != expectedLeaseID {
+		return false, exit(2, "refusing to delete Hetzner server %s for mismatched lease %s", server.DisplayID(), expectedLeaseID)
+	}
+	if !core.IsCanonicalLeaseID(expectedLeaseID) {
+		return false, exit(2, "refusing to delete Hetzner server %s for non-canonical lease %s", server.DisplayID(), expectedLeaseID)
+	}
+	// Delete the auxiliary key first. If that fails, retaining the server keeps
+	// the exact claim reachable through normal resolve-and-release retries.
+	if keyName := core.ServerProviderKey(server); deleteKey && core.ValidCrabboxProviderKey(keyName) {
+		if err := client.DeleteSSHKey(ctx, keyName); err != nil {
+			return false, err
+		}
 	}
 	if err := client.DeleteServer(ctx, server.ID); err != nil {
 		if !hetznerServerAlreadyAbsent(err, server.ID) {
 			return false, err
 		}
 	}
-	if keyName := core.ServerProviderKey(server); deleteKey && core.ValidCrabboxProviderKey(keyName) {
-		return true, client.DeleteSSHKey(ctx, keyName)
-	}
 	return true, nil
 }
 func hetznerServerAlreadyAbsent(err error, serverID int64) bool {
 	return strings.HasPrefix(err.Error(), fmt.Sprintf("hetzner DELETE /servers/%d: http 404:", serverID))
 }
-func validateHetznerServerOwnership(server Server) error {
+func validateHetznerServerOwnership(server Server, allowLegacyProvider bool) error {
+	provider := strings.TrimSpace(server.Labels["provider"])
 	if server.Labels == nil ||
 		server.Labels["crabbox"] != "true" ||
 		server.Labels["created_by"] != "crabbox" ||
-		(server.Labels["provider"] != "" && server.Labels["provider"] != providerName) ||
-		server.Labels["lease"] == "" {
+		(provider != providerName && !(allowLegacyProvider && provider == "")) ||
+		!core.IsCanonicalLeaseID(server.Labels["lease"]) ||
+		strings.TrimSpace(server.Labels["slug"]) == "" {
 		return exit(2, "refusing to operate on non-Crabbox Hetzner server: %s", server.DisplayID())
 	}
 	return nil
+}
+
+func validateHetznerResolveOwnership(server Server, req ResolveRequest) error {
+	claim, claimExists, err := core.ReadLeaseClaimWithPresence(server.Labels["lease"])
+	if err != nil {
+		return err
+	}
+	if err := validateHetznerServerOwnership(server, claimExists); err != nil {
+		return err
+	}
+	if claimExists {
+		if upgradeableHetznerClaim(claim, server) && req.Reclaim && !req.ReleaseOnly && !req.NoLocalStateMutations {
+			return nil
+		}
+		if err := validateHetznerClaim(claim, server, server.Labels["lease"]); err != nil {
+			return err
+		}
+		return nil
+	}
+	if req.ReleaseOnly {
+		return exit(2, "hetzner lease=%s has no exact local claim; refusing release", server.Labels["lease"])
+	}
+	if req.NoLocalStateMutations {
+		return nil
+	}
+	if !req.Reclaim {
+		return exit(2, "hetzner lease=%s is unclaimed; use --reclaim to adopt it explicitly", server.Labels["lease"])
+	}
+	if req.Repo.Root == "" {
+		return exit(2, "hetzner lease=%s cannot be reclaimed without a repository root", server.Labels["lease"])
+	}
+	return nil
+}
+
+func upgradeableHetznerClaim(claim core.LeaseClaim, server Server) bool {
+	return claim.LeaseID == server.Labels["lease"] &&
+		(claim.Provider == "" || claim.Provider == providerName) &&
+		claim.CloudID == "" &&
+		(claim.Slug == "" || claim.Slug == server.Labels["slug"])
+}
+
+func requireExactHetznerClaim(server Server, expectedLeaseID string) (core.LeaseClaim, error) {
+	claim, exists, err := core.ReadLeaseClaimWithPresence(expectedLeaseID)
+	if err != nil {
+		return core.LeaseClaim{}, err
+	}
+	if !exists {
+		return core.LeaseClaim{}, exit(2, "hetzner lease=%s has no exact local claim; refusing destructive operation", expectedLeaseID)
+	}
+	if err := validateHetznerServerOwnership(server, true); err != nil {
+		return core.LeaseClaim{}, err
+	}
+	if err := validateHetznerClaim(claim, server, expectedLeaseID); err != nil {
+		return core.LeaseClaim{}, err
+	}
+	return claim, nil
+}
+
+func validateHetznerClaim(claim core.LeaseClaim, server Server, expectedLeaseID string) error {
+	if claim.LeaseID != expectedLeaseID ||
+		claim.Provider != providerName ||
+		claim.CloudID == "" ||
+		claim.CloudID != server.CloudID ||
+		server.Labels["lease"] != expectedLeaseID ||
+		(claim.Slug != "" && claim.Slug != server.Labels["slug"]) {
+		return exit(2, "refusing to operate on Hetzner server %s from a missing or stale exact local claim", server.DisplayID())
+	}
+	return nil
+}
+
+func normalizeHetznerServer(server Server) Server {
+	if server.CloudID == "" && server.ID > 0 {
+		server.CloudID = strconv.FormatInt(server.ID, 10)
+	}
+	server.Provider = providerName
+	return server
+}
+
+func ownedHetznerServers(servers []Server) []Server {
+	owned := make([]Server, 0, len(servers))
+	for _, raw := range servers {
+		server := normalizeHetznerServer(raw)
+		claim, claimExists, err := core.ReadLeaseClaimWithPresence(server.Labels["lease"])
+		allowLegacyProvider := err == nil && claimExists && validateHetznerClaim(claim, server, server.Labels["lease"]) == nil
+		if validateHetznerServerOwnership(server, allowLegacyProvider) == nil {
+			owned = append(owned, server)
+		}
+	}
+	return owned
 }
 func rollbackHetznerAcquire(client hetznerClient, server Server, serverCreated bool, keyName string, keyCreated bool) error {
 	cleanupCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 	if serverCreated {
-		_, err := deleteServerWithClient(cleanupCtx, client, server, keyCreated)
+		_, err := deleteServerWithClient(cleanupCtx, client, server, keyCreated, server.Labels["lease"])
 		return err
 	}
 	if keyCreated && core.ValidCrabboxProviderKey(keyName) {

--- a/internal/providers/hetzner/backend_test.go
+++ b/internal/providers/hetzner/backend_test.go
@@ -285,6 +285,59 @@ func TestHetznerReleaseRejectsClaimForDifferentServer(t *testing.T) {
 	}
 }
 
+func TestHetznerReleaseRollsBackExactLeaseAcquiredByBackendBeforeClaim(t *testing.T) {
+	leaseID := "cbx_abcdef123456"
+	server := crabboxHetznerServer(42, leaseID)
+	client := &fakeHetznerClient{
+		servers:      map[int64]Server{42: server},
+		createServer: server,
+		keyCreated:   true,
+	}
+	installHetznerTestHooks(t, client)
+	installHetznerClaimState(t)
+
+	backend := NewHetznerLeaseBackend(ProviderSpec{}, Config{}, Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
+	lease, err := backend.Acquire(context.Background(), AcquireRequest{})
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatalf("ReleaseLease before claim: %v", err)
+	}
+	if len(client.deletedServers) != 1 || client.deletedServers[0] != 42 {
+		t.Fatalf("deletedServers=%v, want [42]", client.deletedServers)
+	}
+	if want := core.ProviderKeyForLease(leaseID); len(client.deletedKeys) != 1 || client.deletedKeys[0] != want {
+		t.Fatalf("deletedKeys=%v, want [%s]", client.deletedKeys, want)
+	}
+}
+
+func TestHetznerReleaseRejectsUnclaimedLeaseAcquiredByDifferentBackend(t *testing.T) {
+	leaseID := "cbx_abcdef123456"
+	server := crabboxHetznerServer(42, leaseID)
+	client := &fakeHetznerClient{
+		servers:      map[int64]Server{42: server},
+		createServer: server,
+		keyCreated:   true,
+	}
+	installHetznerTestHooks(t, client)
+	installHetznerClaimState(t)
+
+	acquiringBackend := NewHetznerLeaseBackend(ProviderSpec{}, Config{}, Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
+	lease, err := acquiringBackend.Acquire(context.Background(), AcquireRequest{})
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	otherBackend := NewHetznerLeaseBackend(ProviderSpec{}, Config{}, Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
+	err = otherBackend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease})
+	if err == nil || !strings.Contains(err.Error(), "no exact local claim") {
+		t.Fatalf("err=%v, want exact-claim refusal", err)
+	}
+	if len(client.deletedServers) != 0 || len(client.deletedKeys) != 0 {
+		t.Fatalf("deleted servers=%v keys=%v, want none", client.deletedServers, client.deletedKeys)
+	}
+}
+
 func TestHetznerCleanupSkipsWeakAndUnclaimedServers(t *testing.T) {
 	now := time.Now().UTC()
 	weak := crabboxHetznerServer(41, "cbx_111111111111")
@@ -331,6 +384,38 @@ func TestHetznerResolveRequiresExplicitReclaimForUnclaimedServer(t *testing.T) {
 	}
 	if _, err := backend.Resolve(context.Background(), ResolveRequest{ID: "42", NoLocalStateMutations: true}); err != nil {
 		t.Fatalf("read-only resolve: %v", err)
+	}
+}
+
+func TestHetznerResolveAliasAllowsExplicitUpgradeOfLegacyClaim(t *testing.T) {
+	leaseID := "cbx_abcdef123456"
+	server := crabboxHetznerServer(42, leaseID)
+	delete(server.Labels, "provider")
+	client := &fakeHetznerClient{list: []Server{server}}
+	installHetznerTestHooks(t, client)
+	installHetznerClaimState(t)
+	seedHetznerClaim(t, server)
+	claim, ok, err := core.ResolveLeaseClaim(leaseID)
+	if err != nil || !ok {
+		t.Fatalf("ResolveLeaseClaim: claim=%+v ok=%v err=%v", claim, ok, err)
+	}
+	legacy := claim
+	legacy.Provider = ""
+	legacy.CloudID = ""
+	if err := core.ReplaceLeaseClaimIfUnchanged(leaseID, claim, legacy); err != nil {
+		t.Fatalf("replace with legacy claim: %v", err)
+	}
+
+	backend := NewHetznerLeaseBackend(ProviderSpec{}, Config{}, Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
+	if _, err := backend.Resolve(context.Background(), ResolveRequest{ID: "test", Repo: core.Repo{Root: "/repo"}}); err == nil {
+		t.Fatal("legacy alias resolved without explicit reclaim")
+	}
+	lease, err := backend.Resolve(context.Background(), ResolveRequest{ID: "test", Repo: core.Repo{Root: "/repo"}, Reclaim: true})
+	if err != nil {
+		t.Fatalf("explicit legacy alias reclaim: %v", err)
+	}
+	if lease.LeaseID != leaseID || lease.Server.CloudID != "42" {
+		t.Fatalf("lease=%+v, want exact legacy server", lease)
 	}
 }
 

--- a/internal/providers/hetzner/backend_test.go
+++ b/internal/providers/hetzner/backend_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -119,8 +120,8 @@ func TestHetznerResolveAliasRejectsUnownedServer(t *testing.T) {
 
 	backend := NewHetznerLeaseBackend(ProviderSpec{}, Config{}, Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
 	_, err := backend.Resolve(context.Background(), ResolveRequest{ID: "test"})
-	if err == nil || !strings.Contains(err.Error(), "refusing to operate on non-Crabbox Hetzner server") {
-		t.Fatalf("err=%v, want ownership refusal", err)
+	if err == nil || !strings.Contains(err.Error(), "lease/server not found") {
+		t.Fatalf("err=%v, want filtered inventory miss", err)
 	}
 }
 
@@ -146,9 +147,11 @@ func TestHetznerDeleteAllowsLegacyServerWithoutProviderLabel(t *testing.T) {
 	leaseID := "cbx_abcdef123456"
 	client := &fakeHetznerClient{}
 	installHetznerTestHooks(t, client)
+	installHetznerClaimState(t)
 
 	server := crabboxHetznerServer(42, leaseID)
 	delete(server.Labels, "provider")
+	seedHetznerClaim(t, server)
 	if err := deleteServer(context.Background(), Config{}, server); err != nil {
 		t.Fatal(err)
 	}
@@ -157,24 +160,22 @@ func TestHetznerDeleteAllowsLegacyServerWithoutProviderLabel(t *testing.T) {
 	}
 }
 
-func TestHetznerReleaseRetainsClaimUntilKeyDeleteSucceeds(t *testing.T) {
+func TestHetznerReleaseKeepsServerReachableUntilKeyDeleteSucceeds(t *testing.T) {
 	leaseID := "cbx_abcdef123456"
 	keyErr := errors.New("delete key failed")
 	client := &fakeHetznerClient{keyDeleteErr: keyErr}
 	installHetznerTestHooks(t, client)
 	installHetznerClaimState(t)
 
-	if err := core.ClaimLeaseForRepoProvider(leaseID, "test", providerName, "/repo", 30*time.Minute, false); err != nil {
-		t.Fatalf("seed claim: %v", err)
-	}
+	seedHetznerClaim(t, crabboxHetznerServer(42, leaseID))
 
 	backend := NewHetznerLeaseBackend(ProviderSpec{}, Config{}, Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
 	err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: crabboxHetznerServer(42, leaseID)}})
 	if !errors.Is(err, keyErr) {
 		t.Fatalf("err=%v, want key delete failure", err)
 	}
-	if len(client.deletedServers) != 1 || client.deletedServers[0] != 42 {
-		t.Fatalf("deletedServers=%v, want [42]", client.deletedServers)
+	if len(client.deletedServers) != 0 {
+		t.Fatalf("deletedServers=%v, want server retained for retry", client.deletedServers)
 	}
 	if want := core.ProviderKeyForLease(leaseID); len(client.deletedKeys) != 1 || client.deletedKeys[0] != want {
 		t.Fatalf("deletedKeys=%v, want [%s]", client.deletedKeys, want)
@@ -183,14 +184,13 @@ func TestHetznerReleaseRetainsClaimUntilKeyDeleteSucceeds(t *testing.T) {
 		t.Fatalf("claim=%+v ok=%v err=%v, want retained claim", claim, ok, err)
 	}
 
-	client.deleteErr = errors.New(`hetzner DELETE /servers/42: http 404: {"error":{"code":"not_found"}}`)
 	client.keyDeleteErr = nil
 	err = backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: crabboxHetznerServer(42, leaseID)}})
 	if err != nil {
 		t.Fatalf("retry ReleaseLease: %v", err)
 	}
-	if len(client.deletedServers) != 2 || client.deletedServers[1] != 42 {
-		t.Fatalf("deletedServers=%v, want second delete of 42", client.deletedServers)
+	if len(client.deletedServers) != 1 || client.deletedServers[0] != 42 {
+		t.Fatalf("deletedServers=%v, want [42] after successful key delete", client.deletedServers)
 	}
 	if want := core.ProviderKeyForLease(leaseID); len(client.deletedKeys) != 2 || client.deletedKeys[1] != want {
 		t.Fatalf("deletedKeys=%v, want second delete of %s", client.deletedKeys, want)
@@ -206,9 +206,7 @@ func TestHetznerReleaseTreatsMissingServerAsGone(t *testing.T) {
 	installHetznerTestHooks(t, client)
 	installHetznerClaimState(t)
 
-	if err := core.ClaimLeaseForRepoProvider(leaseID, "test", providerName, "/repo", 30*time.Minute, false); err != nil {
-		t.Fatalf("seed claim: %v", err)
-	}
+	seedHetznerClaim(t, crabboxHetznerServer(42, leaseID))
 
 	backend := NewHetznerLeaseBackend(ProviderSpec{}, Config{}, Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
 	err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: crabboxHetznerServer(42, leaseID)}})
@@ -233,20 +231,106 @@ func TestHetznerReleaseDoesNotTreatBodyMentioned404AsMissingServer(t *testing.T)
 	installHetznerTestHooks(t, client)
 	installHetznerClaimState(t)
 
-	if err := core.ClaimLeaseForRepoProvider(leaseID, "test", providerName, "/repo", 30*time.Minute, false); err != nil {
-		t.Fatalf("seed claim: %v", err)
-	}
+	seedHetznerClaim(t, crabboxHetznerServer(42, leaseID))
 
 	backend := NewHetznerLeaseBackend(ProviderSpec{}, Config{}, Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
 	err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: crabboxHetznerServer(42, leaseID)}})
 	if !errors.Is(err, deleteErr) {
 		t.Fatalf("err=%v, want server delete failure", err)
 	}
-	if len(client.deletedKeys) != 0 {
-		t.Fatalf("deletedKeys=%v, want none", client.deletedKeys)
+	if want := core.ProviderKeyForLease(leaseID); len(client.deletedKeys) != 1 || client.deletedKeys[0] != want {
+		t.Fatalf("deletedKeys=%v, want [%s] before server delete", client.deletedKeys, want)
 	}
 	if claim, ok, err := core.ResolveLeaseClaim(leaseID); err != nil || !ok || claim.LeaseID != leaseID {
 		t.Fatalf("claim=%+v ok=%v err=%v, want retained claim", claim, ok, err)
+	}
+}
+
+func TestHetznerReleaseRejectsMismatchedLeaseBeforeDelete(t *testing.T) {
+	server := crabboxHetznerServer(42, "cbx_abcdef123456")
+	client := &fakeHetznerClient{}
+	installHetznerTestHooks(t, client)
+	installHetznerClaimState(t)
+	seedHetznerClaim(t, server)
+
+	backend := NewHetznerLeaseBackend(ProviderSpec{}, Config{}, Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
+	err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{
+		LeaseID: "cbx_fedcba654321",
+		Server:  server,
+	}})
+	if err == nil || !strings.Contains(err.Error(), "no exact local claim") {
+		t.Fatalf("err=%v, want exact-claim refusal", err)
+	}
+	if len(client.deletedServers) != 0 || len(client.deletedKeys) != 0 {
+		t.Fatalf("deleted servers=%v keys=%v", client.deletedServers, client.deletedKeys)
+	}
+}
+
+func TestHetznerReleaseRejectsClaimForDifferentServer(t *testing.T) {
+	leaseID := "cbx_abcdef123456"
+	claimed := crabboxHetznerServer(42, leaseID)
+	client := &fakeHetznerClient{}
+	installHetznerTestHooks(t, client)
+	installHetznerClaimState(t)
+	seedHetznerClaim(t, claimed)
+
+	replacement := crabboxHetznerServer(43, leaseID)
+	backend := NewHetznerLeaseBackend(ProviderSpec{}, Config{}, Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
+	err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: replacement}})
+	if err == nil || !strings.Contains(err.Error(), "stale exact local claim") {
+		t.Fatalf("err=%v, want stale-claim refusal", err)
+	}
+	if len(client.deletedServers) != 0 || len(client.deletedKeys) != 0 {
+		t.Fatalf("deleted servers=%v keys=%v", client.deletedServers, client.deletedKeys)
+	}
+}
+
+func TestHetznerCleanupSkipsWeakAndUnclaimedServers(t *testing.T) {
+	now := time.Now().UTC()
+	weak := crabboxHetznerServer(41, "cbx_111111111111")
+	delete(weak.Labels, "created_by")
+	weak.Labels["expires_at"] = core.LeaseLabelTime(now.Add(-time.Hour))
+	unclaimed := crabboxHetznerServer(42, "cbx_222222222222")
+	unclaimed.Labels["expires_at"] = core.LeaseLabelTime(now.Add(-time.Hour))
+	claimed := crabboxHetznerServer(43, "cbx_333333333333")
+	claimed.Labels["expires_at"] = core.LeaseLabelTime(now.Add(-time.Hour))
+	client := &fakeHetznerClient{list: []Server{weak, unclaimed, claimed}}
+	installHetznerTestHooks(t, client)
+	installHetznerClaimState(t)
+	seedHetznerClaim(t, claimed)
+
+	var stderr strings.Builder
+	backend := NewHetznerLeaseBackend(ProviderSpec{}, Config{}, Runtime{Stderr: &stderr}).(*hetznerLeaseBackend)
+	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if len(client.deletedServers) != 1 || client.deletedServers[0] != claimed.ID {
+		t.Fatalf("deletedServers=%v, want [%d]", client.deletedServers, claimed.ID)
+	}
+	if !strings.Contains(stderr.String(), "canonical Crabbox ownership labels missing") || !strings.Contains(stderr.String(), "exact local claim missing or stale") {
+		t.Fatalf("stderr=%q, want ownership skip diagnostics", stderr.String())
+	}
+	if _, ok, err := core.ResolveLeaseClaim(claimed.Labels["lease"]); err != nil || ok {
+		t.Fatalf("claimed cleanup claim ok=%v err=%v, want removed", ok, err)
+	}
+}
+
+func TestHetznerResolveRequiresExplicitReclaimForUnclaimedServer(t *testing.T) {
+	server := crabboxHetznerServer(42, "cbx_abcdef123456")
+	client := &fakeHetznerClient{servers: map[int64]Server{42: server}}
+	installHetznerTestHooks(t, client)
+	installHetznerClaimState(t)
+	backend := NewHetznerLeaseBackend(ProviderSpec{}, Config{}, Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
+
+	_, err := backend.Resolve(context.Background(), ResolveRequest{ID: "42", Repo: core.Repo{Root: "/repo"}})
+	if err == nil || !strings.Contains(err.Error(), "use --reclaim") {
+		t.Fatalf("err=%v, want explicit reclaim refusal", err)
+	}
+	if _, err := backend.Resolve(context.Background(), ResolveRequest{ID: "42", Repo: core.Repo{Root: "/repo"}, Reclaim: true}); err != nil {
+		t.Fatalf("explicit reclaim resolve: %v", err)
+	}
+	if _, err := backend.Resolve(context.Background(), ResolveRequest{ID: "42", NoLocalStateMutations: true}); err != nil {
+		t.Fatalf("read-only resolve: %v", err)
 	}
 }
 
@@ -332,12 +416,21 @@ func TestHetznerAcquireKeepsExistingProviderKeyWhenCreateFails(t *testing.T) {
 
 func crabboxHetznerServer(id int64, leaseID string) Server {
 	server := Server{
-		ID:     id,
-		Name:   "crabbox-test",
-		Labels: map[string]string{"crabbox": "true", "created_by": "crabbox", "provider": providerName, "lease": leaseID},
+		CloudID: strconv.FormatInt(id, 10),
+		ID:      id,
+		Name:    "crabbox-test",
+		Labels:  map[string]string{"crabbox": "true", "created_by": "crabbox", "provider": providerName, "lease": leaseID, "slug": "test"},
 	}
 	server.PublicNet.IPv4.IP = "203.0.113.10"
 	return server
+}
+
+func seedHetznerClaim(t *testing.T, server Server) {
+	t.Helper()
+	cfg := Config{Provider: providerName}
+	if err := core.ClaimLeaseTargetForRepoConfig(server.Labels["lease"], server.Labels["slug"], cfg, normalizeHetznerServer(server), SSHTarget{}, "/repo", 30*time.Minute, false); err != nil {
+		t.Fatalf("seed claim: %v", err)
+	}
 }
 
 func installHetznerClaimState(t *testing.T) {


### PR DESCRIPTION
## Summary

- require canonical Hetzner ownership labels and an exact local claim bound to the server ID before direct release or cleanup
- make unclaimed reuse explicit through `--reclaim`, while preserving read-only inspection and a narrow upgrade path for legacy same-resource claims
- keep claims and provider resources retryable across partial cleanup failures; prevent canonical lease IDs from falling through to slug or name aliases
- document the destructive-ownership boundary and add focused CLI/provider regression coverage

Closes https://github.com/openclaw/crabbox/issues/826
Closes https://github.com/openclaw/crabbox/issues/829

## Verification

- `go test -race ./internal/providers/hetzner -count=1`
- focused CLI claim, stop/reclaim, and canonical-alias tests
- `go vet ./internal/providers/hetzner ./internal/cli`
- `node scripts/build-docs-site.mjs`
- `git diff --check`
- local autoreview: clean after fixing the partial SSH-key cleanup retry path

## Live proof

No valid disposable Hetzner credential is currently available in the configured environment or CLI context, so this change is covered by fake-client lifecycle tests and should remain gated on exact-head CI. No config or secret format changes.
