### PR TITLE
fix(gcp): revalidate release ownership before delete

### DIFF
--- a/internal/providers/gcp/backend.go
+++ b/internal/providers/gcp/backend.go
@@ -195,6 +195,10 @@ func (b *gcpLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequ
 	if err != nil {
 		return err
 	}
+	cloudID := strings.TrimSpace(req.Lease.Server.CloudID)
+	if cloudID == "" {
+		return exit(4, "refusing to delete gcp lease=%s: missing cloud id", req.Lease.LeaseID)
+	}
 	if zone := req.Lease.Server.Labels["zone"]; zone != "" {
 		cfg := b.Cfg
 		cfg.GCPZone = zone
@@ -203,7 +207,24 @@ func (b *gcpLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequ
 			return err
 		}
 	}
-	if err := client.DeleteServer(ctx, req.Lease.Server.CloudID); err != nil {
+	live, err := client.GetServer(ctx, cloudID)
+	if err != nil {
+		if core.IsGCPNotFound(err) {
+			removeLeaseClaim(req.Lease.LeaseID)
+			return nil
+		}
+		return err
+	}
+	if strings.TrimSpace(live.CloudID) != cloudID {
+		return exit(4, "refusing to delete gcp lease=%s: live instance cloud id %q does not match stored cloud id %q", req.Lease.LeaseID, live.CloudID, cloudID)
+	}
+	if !isCrabboxGCPLease(live) {
+		return exit(4, "refusing to delete gcp instance %q for lease=%s: live instance is not canonical Crabbox-owned", cloudID, req.Lease.LeaseID)
+	}
+	if liveLeaseID := strings.TrimSpace(live.Labels["lease"]); liveLeaseID != req.Lease.LeaseID {
+		return exit(4, "refusing to delete gcp instance %q for lease=%s: live instance belongs to lease=%s", cloudID, req.Lease.LeaseID, blank(liveLeaseID, "-"))
+	}
+	if err := client.DeleteServer(ctx, cloudID); err != nil {
 		return err
 	}
 	removeLeaseClaim(req.Lease.LeaseID)

--- a/internal/providers/gcp/backend_doctor_test.go
+++ b/internal/providers/gcp/backend_doctor_test.go
@@ -17,6 +17,8 @@ type fakeGCPDoctorClient struct {
 	deleted   []string
 	mutated   bool
 	servers   []Server
+	get       map[string]Server
+	getErr    error
 	created   Server
 	createCfg Config
 	createErr error
@@ -51,8 +53,16 @@ func (c *fakeGCPDoctorClient) WaitForServerIP(context.Context, string) (Server, 
 	return c.created, nil
 }
 
-func (c *fakeGCPDoctorClient) GetServer(context.Context, string) (Server, error) {
-	return Server{}, nil
+func (c *fakeGCPDoctorClient) GetServer(_ context.Context, name string) (Server, error) {
+	if c.getErr != nil {
+		return Server{}, c.getErr
+	}
+	if c.get != nil {
+		if server, ok := c.get[name]; ok {
+			return server, nil
+		}
+	}
+	return Server{}, errors.New("gcp server not found: " + name)
 }
 
 func (c *fakeGCPDoctorClient) DeleteServer(_ context.Context, name string) error {
@@ -64,6 +74,23 @@ func (c *fakeGCPDoctorClient) DeleteServer(_ context.Context, name string) error
 func (c *fakeGCPDoctorClient) SetLabels(context.Context, string, map[string]string) error {
 	c.mutated = true
 	return nil
+}
+
+func canonicalGCPTestServer(leaseID, slug string) Server {
+	name := core.LeaseProviderName(leaseID, slug)
+	return Server{
+		Provider: "gcp",
+		CloudID:  name,
+		Name:     name,
+		Labels: map[string]string{
+			"crabbox":    "true",
+			"created_by": "crabbox",
+			"provider":   "gcp",
+			"lease":      leaseID,
+			"slug":       slug,
+			"zone":       "us-central1-b",
+		},
+	}
 }
 
 func TestGCPAcquireCleansUpCreatedServerOnIPFailure(t *testing.T) {
@@ -196,6 +223,129 @@ func TestGCPCleanupRemovesDeletedAndStaleClaims(t *testing.T) {
 	if !strings.Contains(out, "delete server id="+core.LeaseProviderName(expiredLeaseID, "expired-box")) ||
 		!strings.Contains(out, "remove stale claim lease="+staleLeaseID) {
 		t.Fatalf("cleanup output=%q", out)
+	}
+}
+
+func TestGCPReleaseLeaseRequiresCanonicalLiveOwnership(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	repo := t.TempDir()
+	leaseID := "cbx_777777777777"
+	slug := "release-box"
+	if err := core.ClaimLeaseForRepoProviderScope(leaseID, slug, "gcp", "project:project-a", repo, time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	live := canonicalGCPTestServer(leaseID, slug)
+	fake := &fakeGCPDoctorClient{get: map[string]Server{live.CloudID: live}}
+	old := newGCPClient
+	newGCPClient = func(context.Context, Config) (gcpClient, error) {
+		return fake, nil
+	}
+	t.Cleanup(func() { newGCPClient = old })
+
+	backend := NewGCPLeaseBackend(core.ProviderSpec{}, Config{Provider: "gcp", GCPProject: "project-a", GCPZone: "us-central1-b"}, Runtime{Stderr: io.Discard}).(*gcpLeaseBackend)
+	err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{
+		Lease: LeaseTarget{
+			LeaseID: leaseID,
+			Server:  Server{CloudID: live.CloudID, Name: live.Name, Labels: map[string]string{"zone": "us-central1-b"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ReleaseLease() error=%v", err)
+	}
+	if len(fake.deleted) != 1 || fake.deleted[0] != live.CloudID {
+		t.Fatalf("deleted=%v want %s", fake.deleted, live.CloudID)
+	}
+	claim, err := core.ReadLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claim.LeaseID != "" {
+		t.Fatalf("claim still present after verified release: %#v", claim)
+	}
+}
+
+func TestGCPReleaseLeaseRefusesWrongLiveLease(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	repo := t.TempDir()
+	leaseID := "cbx_888888888888"
+	if err := core.ClaimLeaseForRepoProviderScope(leaseID, "release-box", "gcp", "project:project-a", repo, time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	live := canonicalGCPTestServer("cbx_999999999999", "other-box")
+	fake := &fakeGCPDoctorClient{get: map[string]Server{live.CloudID: live}}
+	old := newGCPClient
+	newGCPClient = func(context.Context, Config) (gcpClient, error) {
+		return fake, nil
+	}
+	t.Cleanup(func() { newGCPClient = old })
+
+	backend := NewGCPLeaseBackend(core.ProviderSpec{}, Config{Provider: "gcp", GCPProject: "project-a", GCPZone: "us-central1-b"}, Runtime{Stderr: io.Discard}).(*gcpLeaseBackend)
+	err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{
+		Lease: LeaseTarget{
+			LeaseID: leaseID,
+			Server:  Server{CloudID: live.CloudID, Name: live.Name, Labels: map[string]string{"zone": "us-central1-b"}},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "live instance belongs to lease=cbx_999999999999") {
+		t.Fatalf("ReleaseLease() error=%v, want wrong-lease refusal", err)
+	}
+	if len(fake.deleted) != 0 {
+		t.Fatalf("deleted=%v want no delete", fake.deleted)
+	}
+	claim, err := core.ReadLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claim.LeaseID == "" {
+		t.Fatal("claim was removed after refused release")
+	}
+}
+
+func TestGCPReleaseLeaseRefusesNonCanonicalLiveInstance(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	repo := t.TempDir()
+	leaseID := "cbx_aaaaaaaaaaaa"
+	cloudID := "crabbox-forged"
+	if err := core.ClaimLeaseForRepoProviderScope(leaseID, "release-box", "gcp", "project:project-a", repo, time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	fake := &fakeGCPDoctorClient{get: map[string]Server{
+		cloudID: {
+			Provider: "gcp",
+			CloudID:  cloudID,
+			Name:     cloudID,
+			Labels: map[string]string{
+				"crabbox": "true",
+				"lease":   leaseID,
+				"zone":    "us-central1-b",
+			},
+		},
+	}}
+	old := newGCPClient
+	newGCPClient = func(context.Context, Config) (gcpClient, error) {
+		return fake, nil
+	}
+	t.Cleanup(func() { newGCPClient = old })
+
+	backend := NewGCPLeaseBackend(core.ProviderSpec{}, Config{Provider: "gcp", GCPProject: "project-a", GCPZone: "us-central1-b"}, Runtime{Stderr: io.Discard}).(*gcpLeaseBackend)
+	err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{
+		Lease: LeaseTarget{
+			LeaseID: leaseID,
+			Server:  Server{CloudID: cloudID, Name: cloudID, Labels: map[string]string{"zone": "us-central1-b"}},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "not canonical Crabbox-owned") {
+		t.Fatalf("ReleaseLease() error=%v, want noncanonical refusal", err)
+	}
+	if len(fake.deleted) != 0 {
+		t.Fatalf("deleted=%v want no delete", fake.deleted)
+	}
+	claim, err := core.ReadLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claim.LeaseID == "" {
+		t.Fatal("claim was removed after refused release")
 	}
 }
 


### PR DESCRIPTION
## Summary
- re-fetch the live GCP instance before direct release deletion
- refuse missing, non-canonical, mismatched CloudID, or wrong-lease live targets before calling DeleteServer
- preserve refused local claims, while removing stale claims when the live GCP instance is already gone

Fixes https://github.com/openclaw/crabbox/issues/861

## Verification
- git diff --check
- go test -count=1 ./internal/providers/gcp
- go test -count=1 ./internal/cli -run 'Test.*GCP|TestIsCanonicalGCPServer'\n- go test ./...\n\n## Credentials\n- no live GCP credentials used; regression covered with fake GCP client ownership tests