### PR TITLE
fix(vast): require reclaim for unclaimed instances

### DIFF
--- a/internal/providers/vast/backend.go
+++ b/internal/providers/vast/backend.go
@@ -407,7 +407,7 @@ func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.Le
 	}
 	if leaseID != "" {
 		if id, ok := parseVastInstanceID(server.CloudID); ok {
-			return b.targetFromInstance(byID[id], req)
+			return b.targetFromInstance(ctx, client, byID[id], req)
 		}
 	}
 	if claim, ok, claimErr := core.ResolveLeaseClaimForProvider(req.ID, providerName); claimErr != nil {
@@ -416,7 +416,7 @@ func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.Le
 		if id, parseOK := parseVastInstanceID(claim.CloudID); parseOK {
 			item, getErr := client.GetInstance(ctx, id)
 			if getErr == nil {
-				return b.targetFromInstance(item, req)
+				return b.targetFromInstance(ctx, client, item, req)
 			}
 			if req.ReleaseOnly {
 				return claimTarget(claim), nil
@@ -435,7 +435,7 @@ func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.Le
 				return b.releaseTargetFromClaim(req.ID, err, req.ReleaseOnly)
 			}
 		}
-		return b.targetFromInstance(item, req)
+		return b.targetFromInstance(ctx, client, item, req)
 	}
 	return core.LeaseTarget{}, exit(4, "lease/instance not found: %s", req.ID)
 }
@@ -454,7 +454,7 @@ func (b *backend) releaseTargetFromClaim(id string, cause error, releaseOnly boo
 	return claimTarget(claim), nil
 }
 
-func (b *backend) targetFromInstance(item vastInstance, req core.ResolveRequest) (core.LeaseTarget, error) {
+func (b *backend) targetFromInstance(ctx context.Context, client vastAPI, item vastInstance, req core.ResolveRequest) (core.LeaseTarget, error) {
 	if !isOwnedVastInstance(item) {
 		return core.LeaseTarget{}, exit(2, "refusing to operate on non-Crabbox Vast instance %d", item.ID)
 	}
@@ -464,6 +464,30 @@ func (b *backend) targetFromInstance(item vastInstance, req core.ResolveRequest)
 	server := serverFromInstance(item, b.cfg)
 	server = mergeVastClaimMetadata(server)
 	leaseID := server.Labels["lease"]
+	claim, claimExists, err := core.ReadLeaseClaimWithPresence(leaseID)
+	if err != nil {
+		return core.LeaseTarget{}, fmt.Errorf("read vast lease claim: %w", err)
+	}
+	if claimExists {
+		if err := validateVastClaimIdentity(claim, leaseID, server.Labels["slug"], server.CloudID); err != nil {
+			return core.LeaseTarget{}, err
+		}
+		if err := b.validateVastClaimProviderIdentity(ctx, client, claim, "resolve"); err != nil {
+			return core.LeaseTarget{}, err
+		}
+	} else if req.ReleaseOnly {
+		return core.LeaseTarget{}, exit(2, "vast lease=%s has no exact local claim; refusing release", leaseID)
+	} else if !req.NoLocalStateMutations && !req.StatusOnly {
+		if !req.Reclaim {
+			return core.LeaseTarget{}, exit(2, "vast lease=%s is unclaimed; use --reclaim to adopt it explicitly", leaseID)
+		}
+		if req.Repo.Root == "" {
+			return core.LeaseTarget{}, exit(2, "vast lease=%s cannot be reclaimed without a repository root", leaseID)
+		}
+		if err := b.populateVastClaimProviderIdentity(ctx, client, server.Labels); err != nil {
+			return core.LeaseTarget{}, err
+		}
+	}
 	target := core.LeaseTarget{Server: server, LeaseID: leaseID}
 	if !req.ReleaseOnly && (!req.StatusOnly || req.ReadyProbe) {
 		ssh, err := sshTargetFromInstance(b.cfg, item)
@@ -474,7 +498,7 @@ func (b *backend) targetFromInstance(item vastInstance, req core.ResolveRequest)
 		target.SSH = ssh
 	}
 	if req.Repo.Root != "" && !req.NoLocalStateMutations {
-		if err := core.ClaimLeaseTargetForRepoConfig(leaseID, server.Labels["slug"], b.cfg, target.Server, target.SSH, req.Repo.Root, b.cfg.IdleTimeout, req.Reclaim); err != nil {
+		if _, err := core.ClaimLeaseTargetForRepoConfigIfUnchanged(leaseID, server.Labels["slug"], b.cfg, target.Server, target.SSH, req.Repo.Root, b.cfg.IdleTimeout, req.Reclaim, claim, claimExists); err != nil {
 			return core.LeaseTarget{}, err
 		}
 	}
@@ -778,6 +802,27 @@ func validateLiveVastInstance(item vastInstance, expected core.Server) error {
 	return nil
 }
 
+func validateVastClaimIdentity(claim core.LeaseClaim, leaseID, slug, cloudID string) error {
+	if claim.LeaseID != leaseID ||
+		claim.Provider != providerName ||
+		claim.Slug == "" ||
+		(slug != "" && claim.Slug != slug) ||
+		claim.Labels["lease"] != leaseID ||
+		claim.Labels["slug"] != claim.Slug ||
+		claim.Labels["provider"] != providerName {
+		return exit(2, "vast lease claim identity does not match lease=%s slug=%s", leaseID, slug)
+	}
+	if cloudID != "" {
+		if claim.CloudID == "" {
+			return exit(2, "vast lease=%s claim has no instance identity", leaseID)
+		}
+		if claim.CloudID != cloudID {
+			return exit(2, "refusing to resolve Vast instance %s from stale local claim", cloudID)
+		}
+	}
+	return nil
+}
+
 func sshTargetFromInstance(cfg core.Config, item vastInstance) (core.SSHTarget, error) {
 	host := strings.TrimSpace(item.SSHHost)
 	if host == "" || item.SSHPort <= 0 {
@@ -880,24 +925,38 @@ func (b *backend) persistRecoveryClaim(leaseID, slug string, cfg core.Config, re
 }
 
 func (b *backend) validateVastCleanupIdentity(ctx context.Context, client vastAPI, claim core.LeaseClaim) error {
+	return b.validateVastClaimProviderIdentity(ctx, client, claim, "cleanup")
+}
+
+func (b *backend) validateVastClaimProviderIdentity(ctx context.Context, client vastAPI, claim core.LeaseClaim, action string) error {
 	expectedAPIURL := strings.TrimSpace(claim.Labels[vastAPIURLLabel])
 	if expectedAPIURL == "" {
-		return exit(2, "lease=%s has no stored Vast API endpoint identity; refusing cleanup", claim.LeaseID)
+		return exit(2, "lease=%s has no stored Vast API endpoint identity; refusing %s", claim.LeaseID, action)
 	}
 	if vastAPIEndpointIdentity(b.cfg.Vast.APIURL) != expectedAPIURL {
-		return exit(2, "lease=%s Vast API endpoint identity does not match current configuration; refusing cleanup", claim.LeaseID)
+		return exit(2, "lease=%s Vast API endpoint identity does not match current configuration; refusing %s", claim.LeaseID, action)
 	}
 	expectedAccountID := strings.TrimSpace(claim.Labels[vastAccountIDLabel])
 	if expectedAccountID == "" {
-		return exit(2, "lease=%s has no stored Vast account identity; refusing cleanup", claim.LeaseID)
+		return exit(2, "lease=%s has no stored Vast account identity; refusing %s", claim.LeaseID, action)
 	}
 	user, err := client.CheckAuth(ctx)
 	if err != nil {
 		return err
 	}
 	if strconv.Itoa(user.ID) != expectedAccountID {
-		return exit(2, "lease=%s Vast account identity does not match current credentials; refusing cleanup", claim.LeaseID)
+		return exit(2, "lease=%s Vast account identity does not match current credentials; refusing %s", claim.LeaseID, action)
 	}
+	return nil
+}
+
+func (b *backend) populateVastClaimProviderIdentity(ctx context.Context, client vastAPI, labels map[string]string) error {
+	labels[vastAPIURLLabel] = vastAPIEndpointIdentity(b.cfg.Vast.APIURL)
+	user, err := client.CheckAuth(ctx)
+	if err != nil {
+		return err
+	}
+	labels[vastAccountIDLabel] = strconv.Itoa(user.ID)
 	return nil
 }
 

--- a/internal/providers/vast/backend_test.go
+++ b/internal/providers/vast/backend_test.go
@@ -422,12 +422,60 @@ func TestResolvePreservesPersistedVastClaimMetadata(t *testing.T) {
 	}
 }
 
+func TestResolveNumericIDRequiresReclaimForUnclaimedProviderLabel(t *testing.T) {
+	api := &fakeVastAPI{instances: []vastInstance{{
+		ID:      8,
+		Label:   encodeVastOwnershipLabel("cbx_orphan", "orphan", "ready"),
+		Status:  "running",
+		SSHHost: "203.0.113.8",
+		SSHPort: 22,
+	}}}
+	b := newTestBackend(t, api)
+
+	_, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "8", Repo: core.Repo{Root: t.TempDir()}})
+	if err == nil || !strings.Contains(err.Error(), "vast lease=cbx_orphan is unclaimed; use --reclaim") {
+		t.Fatalf("err=%v", err)
+	}
+	if claim, exists, readErr := core.ReadLeaseClaimWithPresence("cbx_orphan"); readErr != nil || exists {
+		t.Fatalf("claim=%#v exists=%v err=%v", claim, exists, readErr)
+	}
+}
+
+func TestResolveNumericIDReclaimCreatesClaimForProviderLabel(t *testing.T) {
+	api := &fakeVastAPI{instances: []vastInstance{{
+		ID:      8,
+		Label:   encodeVastOwnershipLabel("cbx_orphan", "orphan", "ready"),
+		Status:  "running",
+		SSHHost: "203.0.113.8",
+		SSHPort: 22,
+	}}}
+	b := newTestBackend(t, api)
+
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "8", Repo: core.Repo{Root: t.TempDir()}, Reclaim: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.LeaseID != "cbx_orphan" || lease.Server.CloudID != "8" || lease.SSH.Host != "203.0.113.8" {
+		t.Fatalf("lease=%#v", lease)
+	}
+	claim, exists, readErr := core.ReadLeaseClaimWithPresence("cbx_orphan")
+	if readErr != nil || !exists || claim.Provider != providerName || claim.CloudID != "8" || claim.Slug != "orphan" || claim.Labels[vastAccountIDLabel] != "7" || claim.Labels[vastAPIURLLabel] != "https://console.vast.ai/api/v0" {
+		t.Fatalf("claim=%#v exists=%v err=%v", claim, exists, readErr)
+	}
+}
+
 func TestResolveRejectsTerminalStatusForRunButAllowsRelease(t *testing.T) {
 	api := &fakeVastAPI{instances: []vastInstance{{ID: 9, Label: encodeVastOwnershipLabel("cbx_failed", "failed", "ready"), Status: "failed", SSHHost: "203.0.113.9", SSHPort: 22}}}
 	b := newTestBackend(t, api)
 	_, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "failed"})
 	if err == nil || !strings.Contains(err.Error(), "terminal status failed") {
 		t.Fatalf("err=%v", err)
+	}
+	server := serverFromInstance(api.instances[0], b.cfg)
+	server.Labels[vastAccountIDLabel] = "7"
+	server.Labels[vastAPIURLLabel] = "https://console.vast.ai/api/v0"
+	if err := core.ClaimLeaseTargetForRepoConfig("cbx_failed", "failed", b.cfg, server, core.SSHTarget{}, t.TempDir(), time.Minute, false); err != nil {
+		t.Fatal(err)
 	}
 	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "failed", ReleaseOnly: true})
 	if err != nil {
@@ -477,6 +525,12 @@ func TestResolvePrefersNumericSlugOverInstanceID(t *testing.T) {
 		{ID: 100, Label: encodeVastOwnershipLabel("cbx_numeric", "123", "ready"), Status: "running", SSHHost: "203.0.113.100", SSHPort: 2200},
 	}}
 	b := newTestBackend(t, api)
+	server := serverFromInstance(api.instances[1], b.cfg)
+	server.Labels[vastAccountIDLabel] = "7"
+	server.Labels[vastAPIURLLabel] = "https://console.vast.ai/api/v0"
+	if err := core.ClaimLeaseTargetForRepoConfig("cbx_numeric", "123", b.cfg, server, core.SSHTarget{}, t.TempDir(), time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
 
 	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "123"})
 	if err != nil {


### PR DESCRIPTION
## Summary
- refuse Vast provider-labeled instances during normal `run --id` reuse when no exact local claim exists
- preserve explicit `--reclaim` adoption while persisting Vast account and API endpoint identity
- validate existing Vast claims before resolve and guard claim rewrites with unchanged-claim state

Fixes https://github.com/openclaw/crabbox/issues/865

## Validation
- `git diff --check`
- `go test -count=1 ./internal/providers/vast`
- `go test -count=1 ./internal/cli`
- `go test -count=1 ./...`

## Notes
- no live Vast credentials were available, so this is validated with source-level fake-provider regression coverage rather than a live provider run
