### PR TITLE
fix(worker): verify Hetzner cleanup ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Verified downloaded GitHub Actions runner archives against the exact upstream release-asset SHA-256 digest before replacing or extracting the installed runner. Thanks @coygeek.
 - Required an unchanged region-bound local claim before direct AWS cleanup can terminate an instance discovered through provider tags. Thanks @coygeek.
 - Revalidated live AWS, Azure, and GCP instance identity, ownership, lease binding, cleanup eligibility, and any destructive companion-resource identity immediately before direct cleanup deletion. Thanks @coygeek.
+- Required coordinator Hetzner cleanup to re-read the stored server and verify exact canonical lease ownership labels before deletion. Thanks @coygeek.
 - Required W&B sandbox reuse, status, and stop to match an exact endpoint/entity/project/resource-bound local claim plus provider inventory ownership. Thanks @coygeek.
 - Required RunPod stop to use an exact pod ID/name-bound local claim, with conflict-safe explicit `--reclaim` adoption for unclaimed or legacy pods. Thanks @coygeek.
 - Required DigitalOcean, Linode, Scaleway, and Vultr inventory and destructive actions to use canonical lease identities and exact provider/resource-bound local claims, with explicit `--reclaim` adoption for claimless resources and recovery-safe Vultr instance/key rollback ordering. Thanks @coygeek and @vincentkoc.

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -16488,7 +16488,7 @@ export class HetznerProvider implements CloudProvider {
       if (server) {
         if (
           server.id !== serverID ||
-          !hetznerServerOwnedByLease(server, lease.id, lease.slug ?? "")
+          !hetznerServerOwnedByLease(server, lease.id, lease.slug, lease.serverName)
         ) {
           throw new Error(
             `refusing to delete Hetzner server ${serverID}: ownership does not match lease ${lease.id}`,

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -54,6 +54,7 @@ import {
   hetznerProvisioningFailureMayHaveResource,
   hetznerProvisioningFailureRetryable,
   hetznerProvisioningResourceID,
+  hetznerServerOwnedByLease,
 } from "./hetzner";
 import {
   bearerToken,
@@ -126,6 +127,7 @@ import type {
   ExternalRunnerInput,
   ExternalRunnerRecord,
   ExternalRunnerSyncRequest,
+  HetznerServer,
   LeaseRecord,
   LeaseRegistrationRequest,
   LeaseRequest,
@@ -16466,21 +16468,30 @@ export class HetznerProvider implements CloudProvider {
 
   async releaseLease(lease: LeaseRecord): Promise<void> {
     let serverID = Number(lease.serverID);
+    let server: HetznerServer | undefined;
     if (
       (!Number.isSafeInteger(serverID) || serverID <= 0) &&
       lease.providerKeyCleanupPending &&
       lease.provisioningResourceMayExist
     ) {
-      const recovered = await this.client.findServerByLease(lease.id);
-      serverID = recovered?.id ?? Number.NaN;
+      server = await this.client.findServerByLease(lease.id);
+      serverID = server?.id ?? Number.NaN;
     }
     if (Number.isSafeInteger(serverID) && serverID > 0) {
       try {
-        await this.deleteServer(String(serverID));
+        server ??= await this.client.getServer(serverID);
       } catch (error) {
         if (!providerResourceNotFound(error)) {
           throw error;
         }
+      }
+      if (server) {
+        if (server.id !== serverID || !hetznerServerOwnedByLease(server, lease.id)) {
+          throw new Error(
+            `refusing to delete Hetzner server ${serverID}: ownership does not match lease ${lease.id}`,
+          );
+        }
+        await this.deleteServer(String(serverID));
       }
     }
     if (lease.providerKeyCleanupPending) {

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -16494,7 +16494,13 @@ export class HetznerProvider implements CloudProvider {
             `refusing to delete Hetzner server ${serverID}: ownership does not match lease ${lease.id}`,
           );
         }
-        await this.deleteServer(String(serverID));
+        try {
+          await this.deleteServer(String(serverID));
+        } catch (error) {
+          if (!providerResourceNotFound(error)) {
+            throw error;
+          }
+        }
       }
     }
     if (lease.providerKeyCleanupPending) {

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -16486,7 +16486,10 @@ export class HetznerProvider implements CloudProvider {
         }
       }
       if (server) {
-        if (server.id !== serverID || !hetznerServerOwnedByLease(server, lease.id)) {
+        if (
+          server.id !== serverID ||
+          !hetznerServerOwnedByLease(server, lease.id, lease.slug ?? "")
+        ) {
           throw new Error(
             `refusing to delete Hetzner server ${serverID}: ownership does not match lease ${lease.id}`,
           );

--- a/worker/src/hetzner.ts
+++ b/worker/src/hetzner.ts
@@ -92,17 +92,29 @@ export function hetznerProvisioningResourceID(error: unknown): number | undefine
 export function hetznerServerOwnedByLease(
   server: HetznerServer,
   leaseID: string,
-  slug: string,
+  slug: string | undefined,
+  serverName: string,
 ): boolean {
   const labels = server.labels ?? {};
+  if (
+    !/^cbx_[a-f0-9]{12}$/.test(leaseID) ||
+    labels["crabbox"] !== "true" ||
+    labels["created_by"] !== "crabbox" ||
+    labels["lease"] !== leaseID
+  ) {
+    return false;
+  }
+  if (slug?.trim()) {
+    return labels["provider"] === "hetzner" && labels["slug"] === providerLabelValue(slug);
+  }
+
+  // Pre-slug leases used the lease ID as the server name and had neither modern label.
+  const legacyServerName = `crabbox-${leaseID.replaceAll("_", "-")}`;
   return (
-    /^cbx_[a-f0-9]{12}$/.test(leaseID) &&
-    slug.trim().length > 0 &&
-    labels["crabbox"] === "true" &&
-    labels["created_by"] === "crabbox" &&
-    labels["provider"] === "hetzner" &&
-    labels["lease"] === leaseID &&
-    labels["slug"] === providerLabelValue(slug)
+    serverName === legacyServerName &&
+    server.name === serverName &&
+    labels["provider"] === undefined &&
+    labels["slug"] === undefined
   );
 }
 

--- a/worker/src/hetzner.ts
+++ b/worker/src/hetzner.ts
@@ -89,6 +89,18 @@ export function hetznerProvisioningResourceID(error: unknown): number | undefine
     : undefined;
 }
 
+export function hetznerServerOwnedByLease(server: HetznerServer, leaseID: string): boolean {
+  const labels = server.labels ?? {};
+  return (
+    /^cbx_[a-f0-9]{12}$/.test(leaseID) &&
+    labels["crabbox"] === "true" &&
+    labels["created_by"] === "crabbox" &&
+    labels["provider"] === "hetzner" &&
+    labels["lease"] === leaseID &&
+    (labels["slug"] ?? "").trim().length > 0
+  );
+}
+
 export class HetznerClient {
   private readonly token: string;
 

--- a/worker/src/hetzner.ts
+++ b/worker/src/hetzner.ts
@@ -11,7 +11,7 @@ import {
   providerKeyOwnershipLabels,
   sshPublicKeyIdentity,
 } from "./provider-key";
-import { leaseProviderLabels } from "./provider-labels";
+import { leaseProviderLabels, providerLabelValue } from "./provider-labels";
 import { leaseProviderName } from "./slug";
 import type { Env, HetznerSSHKey, HetznerServer, ProviderMachine } from "./types";
 
@@ -89,15 +89,20 @@ export function hetznerProvisioningResourceID(error: unknown): number | undefine
     : undefined;
 }
 
-export function hetznerServerOwnedByLease(server: HetznerServer, leaseID: string): boolean {
+export function hetznerServerOwnedByLease(
+  server: HetznerServer,
+  leaseID: string,
+  slug: string,
+): boolean {
   const labels = server.labels ?? {};
   return (
     /^cbx_[a-f0-9]{12}$/.test(leaseID) &&
+    slug.trim().length > 0 &&
     labels["crabbox"] === "true" &&
     labels["created_by"] === "crabbox" &&
     labels["provider"] === "hetzner" &&
     labels["lease"] === leaseID &&
-    (labels["slug"] ?? "").trim().length > 0
+    labels["slug"] === providerLabelValue(slug)
   );
 }
 

--- a/worker/src/provider-labels.ts
+++ b/worker/src/provider-labels.ts
@@ -17,7 +17,7 @@ export function leaseProviderLabels(
     keep: String(config.keep),
     lease: leaseID,
     slug: normalizeLeaseSlug(slug),
-    owner: sanitizeLabel(owner),
+    owner: providerLabelValue(owner),
     profile: config.profile,
     provider_key: config.providerKey,
     provider,
@@ -66,7 +66,7 @@ export function leaseProviderLabels(
   return sanitizeLabels({ ...labels, ...extra });
 }
 
-function sanitizeLabel(value: string): string {
+export function providerLabelValue(value: string): string {
   const cleaned = value
     .trim()
     .replaceAll(/[^a-zA-Z0-9_.-]/g, "_")
@@ -77,7 +77,7 @@ function sanitizeLabel(value: string): string {
 
 function sanitizeLabels(labels: Record<string, string>): Record<string, string> {
   return Object.fromEntries(
-    Object.entries(labels).map(([key, value]) => [key, sanitizeLabel(value)]),
+    Object.entries(labels).map(([key, value]) => [key, providerLabelValue(value)]),
   );
 }
 

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -4350,6 +4350,53 @@ describe("fleet lease identity and idle", () => {
     await expect(provider.releaseLease(lease)).resolves.toBeUndefined();
   });
 
+  it("finishes retained key cleanup when a validated Hetzner server disappears", async () => {
+    const requests: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = new URL(String(input));
+        const method = init?.method ?? "GET";
+        requests.push(`${method} ${url.pathname}`);
+        if (method === "GET") {
+          return jsonResponse({
+            server: {
+              id: 123,
+              name: "crabbox-blue-lobster",
+              status: "running",
+              server_type: { name: "cx23" },
+              public_net: { ipv4: { ip: "192.0.2.1" } },
+              labels: {
+                crabbox: "true",
+                created_by: "crabbox",
+                provider: "hetzner",
+                lease: "cbx_000000000000",
+                slug: "blue-lobster",
+              },
+            },
+          });
+        }
+        if (url.pathname === "/v1/servers/123") {
+          return jsonResponse({ error: { code: "not_found" } }, 404);
+        }
+        return new Response(null, { status: 204 });
+      }),
+    );
+    const provider = new HetznerProvider({ HETZNER_TOKEN: "test-token" } as Env);
+
+    await expect(
+      provider.releaseLease(
+        testLease({ providerKeyCleanupPending: true, providerKeyCleanupID: "7" }),
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(requests).toEqual([
+      "GET /v1/servers/123",
+      "DELETE /v1/servers/123",
+      "DELETE /v1/ssh_keys/7",
+    ]);
+  });
+
   it("deletes a persisted Hetzner server before its retained SSH key", async () => {
     const requests: string[] = [];
     vi.stubGlobal(

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -4395,7 +4395,10 @@ describe("fleet lease identity and idle", () => {
     ]);
   });
 
-  it("refuses to delete a persisted Hetzner server owned by another lease", async () => {
+  it.each([
+    ["another lease", { lease: "cbx_111111111111", slug: "blue-lobster" }],
+    ["another slug", { lease: "cbx_000000000000", slug: "other" }],
+  ])("refuses to delete a persisted Hetzner server owned by %s", async (_case, labels) => {
     const requests: string[] = [];
     vi.stubGlobal(
       "fetch",
@@ -4413,8 +4416,7 @@ describe("fleet lease identity and idle", () => {
               crabbox: "true",
               created_by: "crabbox",
               provider: "hetzner",
-              lease: "cbx_111111111111",
-              slug: "other",
+              ...labels,
             },
           },
         });
@@ -4433,6 +4435,54 @@ describe("fleet lease identity and idle", () => {
     );
 
     expect(requests).toEqual(["GET /v1/servers/123"]);
+  });
+
+  it("accepts the encoded provider label for a long Hetzner lease slug", async () => {
+    const slug = `blue-${"lobster".repeat(10)}`;
+    const requests: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = new URL(String(input));
+        requests.push(`${init?.method ?? "GET"} ${url.pathname}`);
+        if ((init?.method ?? "GET") === "GET") {
+          return jsonResponse({
+            server: {
+              id: 123,
+              name: "crabbox-blue-lobster",
+              status: "running",
+              server_type: { name: "cx23" },
+              public_net: { ipv4: { ip: "192.0.2.1" } },
+              labels: {
+                crabbox: "true",
+                created_by: "crabbox",
+                provider: "hetzner",
+                lease: "cbx_000000000000",
+                slug: slug.slice(0, 63),
+              },
+            },
+          });
+        }
+        return new Response(null, { status: 204 });
+      }),
+    );
+    const provider = new HetznerProvider({ HETZNER_TOKEN: "test-token" } as Env);
+
+    await expect(
+      provider.releaseLease(
+        testLease({
+          slug,
+          providerKeyCleanupPending: true,
+          providerKeyCleanupID: "7",
+        }),
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(requests).toEqual([
+      "GET /v1/servers/123",
+      "DELETE /v1/servers/123",
+      "DELETE /v1/ssh_keys/7",
+    ]);
   });
 
   it("recovers an unknown Hetzner server before deleting its retained SSH key", async () => {
@@ -4470,6 +4520,7 @@ describe("fleet lease identity and idle", () => {
     const provider = new HetznerProvider({ HETZNER_TOKEN: "test-token" } as Env);
     const lease = testLease({
       id: "cbx_abcdef123456",
+      slug: "rollback",
       provider: "hetzner",
       serverID: 0,
       provisioningResourceMayExist: true,
@@ -22730,6 +22781,7 @@ function testMachine(overrides: Partial<ProviderMachine>): ProviderMachine {
 function testLease(overrides: Partial<LeaseRecord>): LeaseRecord {
   return {
     id: "cbx_000000000000",
+    slug: "blue-lobster",
     provider: "hetzner",
     cloudID: "123",
     owner: "peter@example.com",

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -4486,56 +4486,65 @@ describe("fleet lease identity and idle", () => {
   });
 
   it.each([
-    ["canonical name", "crabbox-cbx-000000000000", true],
-    ["unexpected name", "crabbox-other", false],
-  ])("handles a legacy Hetzner lease with its %s", async (_case, serverName, owned) => {
-    const requests: string[] = [];
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-        const url = new URL(String(input));
-        requests.push(`${init?.method ?? "GET"} ${url.pathname}`);
-        if ((init?.method ?? "GET") === "GET") {
-          return jsonResponse({
-            server: {
-              id: 123,
-              name: serverName,
-              status: "running",
-              server_type: { name: "cx23" },
-              public_net: { ipv4: { ip: "192.0.2.1" } },
-              labels: {
-                crabbox: "true",
-                created_by: "crabbox",
-                lease: "cbx_000000000000",
+    [
+      "canonical name",
+      "crabbox-cbx-000000000000",
+      "released",
+      ["GET /v1/servers/123", "DELETE /v1/servers/123", "DELETE /v1/ssh_keys/7"],
+    ],
+    [
+      "unexpected name",
+      "crabbox-other",
+      "refusing to delete Hetzner server 123: ownership does not match lease cbx_000000000000",
+      ["GET /v1/servers/123"],
+    ],
+  ])(
+    "handles a legacy Hetzner lease with its %s",
+    async (_case, serverName, expectedOutcome, expectedRequests) => {
+      const requests: string[] = [];
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+          const url = new URL(String(input));
+          requests.push(`${init?.method ?? "GET"} ${url.pathname}`);
+          if ((init?.method ?? "GET") === "GET") {
+            return jsonResponse({
+              server: {
+                id: 123,
+                name: serverName,
+                status: "running",
+                server_type: { name: "cx23" },
+                public_net: { ipv4: { ip: "192.0.2.1" } },
+                labels: {
+                  crabbox: "true",
+                  created_by: "crabbox",
+                  lease: "cbx_000000000000",
+                },
               },
-            },
-          });
-        }
-        return new Response(null, { status: 204 });
-      }),
-    );
-    const provider = new HetznerProvider({ HETZNER_TOKEN: "test-token" } as Env);
-    const release = provider.releaseLease(
-      testLease({
-        slug: undefined,
-        serverName,
-        providerKeyCleanupPending: true,
-        providerKeyCleanupID: "7",
-      }),
-    );
+            });
+          }
+          return new Response(null, { status: 204 });
+        }),
+      );
+      const provider = new HetznerProvider({ HETZNER_TOKEN: "test-token" } as Env);
+      const outcome = await provider
+        .releaseLease(
+          testLease({
+            slug: undefined,
+            serverName,
+            providerKeyCleanupPending: true,
+            providerKeyCleanupID: "7",
+          }),
+        )
+        .then(
+          () => "released",
+          (error: unknown) => (error instanceof Error ? error.message : String(error)),
+        );
 
-    if (owned) {
-      await expect(release).resolves.toBeUndefined();
-      expect(requests).toEqual([
-        "GET /v1/servers/123",
-        "DELETE /v1/servers/123",
-        "DELETE /v1/ssh_keys/7",
-      ]);
-    } else {
-      await expect(release).rejects.toThrow("ownership does not match lease cbx_000000000000");
-      expect(requests).toEqual(["GET /v1/servers/123"]);
-    }
-  });
+      expect(outcome).toBe(expectedOutcome);
+      expect(requests).toEqual(expectedRequests);
+    },
+  );
 
   it("recovers an unknown Hetzner server before deleting its retained SSH key", async () => {
     const requests: string[] = [];

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -4485,6 +4485,58 @@ describe("fleet lease identity and idle", () => {
     ]);
   });
 
+  it.each([
+    ["canonical name", "crabbox-cbx-000000000000", true],
+    ["unexpected name", "crabbox-other", false],
+  ])("handles a legacy Hetzner lease with its %s", async (_case, serverName, owned) => {
+    const requests: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = new URL(String(input));
+        requests.push(`${init?.method ?? "GET"} ${url.pathname}`);
+        if ((init?.method ?? "GET") === "GET") {
+          return jsonResponse({
+            server: {
+              id: 123,
+              name: serverName,
+              status: "running",
+              server_type: { name: "cx23" },
+              public_net: { ipv4: { ip: "192.0.2.1" } },
+              labels: {
+                crabbox: "true",
+                created_by: "crabbox",
+                lease: "cbx_000000000000",
+              },
+            },
+          });
+        }
+        return new Response(null, { status: 204 });
+      }),
+    );
+    const provider = new HetznerProvider({ HETZNER_TOKEN: "test-token" } as Env);
+    const release = provider.releaseLease(
+      testLease({
+        slug: undefined,
+        serverName,
+        providerKeyCleanupPending: true,
+        providerKeyCleanupID: "7",
+      }),
+    );
+
+    if (owned) {
+      await expect(release).resolves.toBeUndefined();
+      expect(requests).toEqual([
+        "GET /v1/servers/123",
+        "DELETE /v1/servers/123",
+        "DELETE /v1/ssh_keys/7",
+      ]);
+    } else {
+      await expect(release).rejects.toThrow("ownership does not match lease cbx_000000000000");
+      expect(requests).toEqual(["GET /v1/servers/123"]);
+    }
+  });
+
   it("recovers an unknown Hetzner server before deleting its retained SSH key", async () => {
     const requests: string[] = [];
     let labelSelector: string | null = null;

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -4357,6 +4357,24 @@ describe("fleet lease identity and idle", () => {
       vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = new URL(String(input));
         requests.push(`${init?.method ?? "GET"} ${url.pathname}`);
+        if ((init?.method ?? "GET") === "GET") {
+          return jsonResponse({
+            server: {
+              id: 123,
+              name: "crabbox-blue-lobster",
+              status: "running",
+              server_type: { name: "cx23" },
+              public_net: { ipv4: { ip: "192.0.2.1" } },
+              labels: {
+                crabbox: "true",
+                created_by: "crabbox",
+                provider: "hetzner",
+                lease: "cbx_000000000000",
+                slug: "blue-lobster",
+              },
+            },
+          });
+        }
         return new Response(null, { status: 204 });
       }),
     );
@@ -4370,7 +4388,51 @@ describe("fleet lease identity and idle", () => {
 
     await expect(provider.releaseLease(lease)).resolves.toBeUndefined();
 
-    expect(requests).toEqual(["DELETE /v1/servers/123", "DELETE /v1/ssh_keys/7"]);
+    expect(requests).toEqual([
+      "GET /v1/servers/123",
+      "DELETE /v1/servers/123",
+      "DELETE /v1/ssh_keys/7",
+    ]);
+  });
+
+  it("refuses to delete a persisted Hetzner server owned by another lease", async () => {
+    const requests: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = new URL(String(input));
+        requests.push(`${init?.method ?? "GET"} ${url.pathname}`);
+        return jsonResponse({
+          server: {
+            id: 123,
+            name: "crabbox-other",
+            status: "running",
+            server_type: { name: "cx23" },
+            public_net: { ipv4: { ip: "192.0.2.1" } },
+            labels: {
+              crabbox: "true",
+              created_by: "crabbox",
+              provider: "hetzner",
+              lease: "cbx_111111111111",
+              slug: "other",
+            },
+          },
+        });
+      }),
+    );
+    const provider = new HetznerProvider({ HETZNER_TOKEN: "test-token" } as Env);
+    const lease = testLease({
+      provider: "hetzner",
+      serverID: 123,
+      providerKeyCleanupPending: true,
+      providerKeyCleanupID: "7",
+    });
+
+    await expect(provider.releaseLease(lease)).rejects.toThrow(
+      "ownership does not match lease cbx_000000000000",
+    );
+
+    expect(requests).toEqual(["GET /v1/servers/123"]);
   });
 
   it("recovers an unknown Hetzner server before deleting its retained SSH key", async () => {
@@ -4391,7 +4453,13 @@ describe("fleet lease identity and idle", () => {
                 status: "running",
                 server_type: { name: "cx23" },
                 public_net: { ipv4: { ip: "192.0.2.1" } },
-                labels: { crabbox: "true", lease: "cbx_abcdef123456" },
+                labels: {
+                  crabbox: "true",
+                  created_by: "crabbox",
+                  provider: "hetzner",
+                  lease: "cbx_abcdef123456",
+                  slug: "rollback",
+                },
               },
             ],
           });
@@ -4439,7 +4507,7 @@ describe("fleet lease identity and idle", () => {
 
     await expect(provider.releaseLease(lease)).rejects.toThrow("http 503");
 
-    expect(requests).toEqual(["DELETE /v1/servers/123"]);
+    expect(requests).toEqual(["GET /v1/servers/123"]);
   });
 
   it("records a shared Hetzner key's actual name so cleanup retains it", async () => {
@@ -4801,8 +4869,29 @@ describe("fleet lease identity and idle", () => {
   });
 
   it("only deletes provider keys canonically bound to the released lease", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse({
+          server: {
+            id: 123,
+            name: "crabbox-blue-lobster",
+            status: "running",
+            server_type: { name: "cx23" },
+            public_net: { ipv4: { ip: "192.0.2.1" } },
+            labels: {
+              crabbox: "true",
+              created_by: "crabbox",
+              provider: "hetzner",
+              lease: "cbx_abcdef123456",
+              slug: "blue-lobster",
+            },
+          },
+        }),
+      ),
+    );
     const providers = [
-      new HetznerProvider({} as Env),
+      new HetznerProvider({ HETZNER_TOKEN: "test-token" } as Env),
       new AWSProvider({} as Env, "eu-west-1", new MemoryStorage()),
     ];
     await Promise.all(


### PR DESCRIPTION
## Summary

- re-read the exact persisted Hetzner server before coordinator cleanup
- require canonical Crabbox, provider, lease, and encoded slug ownership labels before deletion
- preserve pre-slug durable leases only under their narrower canonical-name and legacy-label contract
- fail closed before deleting either the server or retained SSH key when ownership does not match
- preserve idempotent cleanup when an owned server disappears between validation and deletion
- add regression coverage and an Unreleased changelog entry

Fixes https://github.com/openclaw/crabbox/issues/873

## Verification

Exact candidate: `e5f55a5f4657bf4d28fd71eecd6e2fe97dd14a97`.

- `npm test --prefix worker -- fleet.test.ts -t Hetzner` (31 passed)
- `npm test --prefix worker` (811 passed)
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm run build --prefix worker`
- full branch AutoReview clean after fixing long-slug label encoding, pre-slug durable-lease compatibility, and delete-after-read 404 idempotency findings

## Live gate

No provider resources were created. The locally configured `hcloud` token is rejected by Hetzner. Targeted 1Password lookup found saved login and SSH-key items but no API token. Keep this PR unmerged until an exact-head disposable canary proves unowned denial, owned server/key deletion, and zero residue, or until the item-specific live gate is explicitly waived.
