### PR TITLE
fix(aws): require exact cleanup claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- Required an unchanged region-bound local claim before direct AWS cleanup can terminate an instance discovered through provider tags. Thanks @coygeek.
 - Required W&B sandbox reuse, status, and stop to match an exact endpoint/entity/project/resource-bound local claim plus provider inventory ownership. Thanks @coygeek.
 - Required RunPod stop to use an exact pod ID/name-bound local claim, with conflict-safe explicit `--reclaim` adoption for unclaimed or legacy pods. Thanks @coygeek.
 - Made coordinatorless generic provider live smokes skip coordinator-only history and always clean up acquired leases after later lifecycle failures.

--- a/internal/providers/aws/backend.go
+++ b/internal/providers/aws/backend.go
@@ -265,11 +265,16 @@ func (b *awsLeaseBackend) Cleanup(ctx context.Context, req CleanupRequest) error
 			fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=%s\n", server.DisplayID(), server.Name, reason)
 			continue
 		}
+		claim, claimErr := requireExactAWSClaim(server, server.Labels["lease"])
+		if claimErr != nil {
+			fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=exact local claim missing or stale\n", server.DisplayID(), server.Name)
+			continue
+		}
 		fmt.Fprintf(b.RT.Stderr, "delete server id=%s name=%s\n", server.DisplayID(), server.Name)
 		if req.DryRun {
 			continue
 		}
-		if err := deleteServer(ctx, awsConfigForServer(b.Cfg, server), server); err != nil {
+		if err := deleteClaimedAWSServer(ctx, awsConfigForServer(b.Cfg, server), server, claim); err != nil {
 			return err
 		}
 	}
@@ -381,6 +386,47 @@ func deleteServer(ctx context.Context, cfg Config, server Server) error {
 		}
 	}
 	return nil
+}
+
+func requireExactAWSClaim(server Server, expectedLeaseID string) (core.LeaseClaim, error) {
+	claim, exists, err := core.ReadLeaseClaimWithPresence(expectedLeaseID)
+	if err != nil {
+		return core.LeaseClaim{}, err
+	}
+	if !exists {
+		return core.LeaseClaim{}, exit(2, "aws lease=%s has no exact local claim; refusing destructive operation", expectedLeaseID)
+	}
+	if !isCrabboxAWSLease(server) ||
+		claim.LeaseID != expectedLeaseID ||
+		claim.Provider != "aws" ||
+		claim.CloudID == "" ||
+		claim.CloudID != server.CloudID ||
+		claim.Slug == "" ||
+		claim.Slug != server.Labels["slug"] ||
+		server.Labels["lease"] != expectedLeaseID ||
+		awsServerRegion(server) == "" ||
+		strings.TrimSpace(claim.Labels["aws_region"]) != awsServerRegion(server) {
+		return core.LeaseClaim{}, exit(2, "refusing to operate on AWS instance %s from a missing or stale exact local claim", server.DisplayID())
+	}
+	return claim, nil
+}
+
+func deleteClaimedAWSServer(ctx context.Context, cfg Config, server Server, claim core.LeaseClaim) error {
+	var cleanupErr error
+	err := core.RemoveLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, func() error {
+		cleanupErr = deleteServer(ctx, cfg, server)
+		var keyErr *awsProviderKeyCleanupError
+		if errors.As(cleanupErr, &keyErr) {
+			// The instance is already gone; retain the key-specific error but do
+			// not retain a claim whose exact cloud resource no longer exists.
+			return nil
+		}
+		return cleanupErr
+	})
+	if err != nil {
+		return err
+	}
+	return cleanupErr
 }
 
 type awsProviderKeyCleanupError struct {

--- a/internal/providers/aws/backend_test.go
+++ b/internal/providers/aws/backend_test.go
@@ -387,15 +387,21 @@ func TestAWSTouchUsesFallbackRegion(t *testing.T) {
 	}
 }
 
-func TestAWSCleanupDeletesFallbackRegionServer(t *testing.T) {
-	stale := awsTestServer("i-stale", "cbx_111111111111", "stale", "us-west-2")
-	stale.Labels["provider_key"] = "crabbox-cbx-111111111111"
-	stale.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
+func TestAWSCleanupRequiresExactClaimForFallbackRegionServer(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	tagOnly := awsTestServer("i-tag-only", "cbx_111111111111", "tag-only", "us-west-2")
+	tagOnly.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
+	staleClaim := awsTestServer("i-stale", "cbx_333333333333", "stale", "us-west-2")
+	staleClaim.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
+	owned := awsTestServer("i-owned", "cbx_444444444444", "owned", "us-west-2")
+	owned.Labels["provider_key"] = "crabbox-cbx-444444444444"
+	owned.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
 	unowned := awsTestServer("i-unowned", "cbx_222222222222", "unowned", "us-west-2")
 	delete(unowned.Labels, "created_by")
 	unowned.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
 	east := &fakeAWSClient{}
-	west := &fakeAWSClient{servers: []Server{unowned, stale}}
+	west := &fakeAWSClient{servers: []Server{unowned, tagOnly, staleClaim, owned}}
 	oldClient := newAWSClient
 	newAWSClient = func(_ context.Context, cfg Config) (awsClient, error) {
 		switch cfg.AWSRegion {
@@ -412,6 +418,14 @@ func TestAWSCleanupDeletesFallbackRegionServer(t *testing.T) {
 
 	cfg := Config{Provider: "aws", AWSRegion: "us-east-1"}
 	cfg.Capacity.Regions = []string{"us-east-1", "us-west-2"}
+	claimCfg := Config{Provider: "aws", AWSRegion: "us-west-2"}
+	staleOriginal := awsTestServer("i-stale-original", staleClaim.Labels["lease"], staleClaim.Labels["slug"], "us-west-2")
+	if err := core.ClaimLeaseTargetForConfig(staleClaim.Labels["lease"], staleClaim.Labels["slug"], claimCfg, staleOriginal, SSHTarget{}, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if err := core.ClaimLeaseTargetForConfig(owned.Labels["lease"], owned.Labels["slug"], claimCfg, owned, SSHTarget{}, time.Hour); err != nil {
+		t.Fatal(err)
+	}
 	var stderr strings.Builder
 	backend := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: &stderr}).(*awsLeaseBackend)
 	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
@@ -420,14 +434,57 @@ func TestAWSCleanupDeletesFallbackRegionServer(t *testing.T) {
 	if !strings.Contains(stderr.String(), "skip server id=i-unowned") || !strings.Contains(stderr.String(), "canonical Crabbox ownership tags missing") {
 		t.Fatalf("stderr=%q, want unowned skip diagnostic", stderr.String())
 	}
+	if !strings.Contains(stderr.String(), "skip server id=i-tag-only") || !strings.Contains(stderr.String(), "skip server id=i-stale") || !strings.Contains(stderr.String(), "exact local claim missing or stale") {
+		t.Fatalf("stderr=%q, want missing and stale claim skip diagnostics", stderr.String())
+	}
 	if len(east.deletedInstances) != 0 || len(east.deletedKeys) != 0 {
 		t.Fatalf("east cleanup should be untouched: instances=%v keys=%v", east.deletedInstances, east.deletedKeys)
 	}
-	if len(west.deletedInstances) != 1 || west.deletedInstances[0] != "i-stale" {
-		t.Fatalf("west deleted instances=%v, want i-stale", west.deletedInstances)
+	if len(west.deletedInstances) != 1 || west.deletedInstances[0] != "i-owned" {
+		t.Fatalf("west deleted instances=%v, want i-owned", west.deletedInstances)
 	}
-	if len(west.deletedKeys) != 1 || west.deletedKeys[0] != "crabbox-cbx-111111111111" {
-		t.Fatalf("west deleted keys=%v, want stale provider key", west.deletedKeys)
+	if len(west.deletedKeys) != 1 || west.deletedKeys[0] != "crabbox-cbx-444444444444" {
+		t.Fatalf("west deleted keys=%v, want owned provider key", west.deletedKeys)
+	}
+	if _, ok, err := core.ResolveLeaseClaim(owned.Labels["lease"]); err != nil || ok {
+		t.Fatalf("owned claim ok=%v err=%v, want removed after deletion", ok, err)
+	}
+	claim, ok, err := core.ResolveLeaseClaim(staleClaim.Labels["lease"])
+	if err != nil || !ok || claim.CloudID != "i-stale-original" {
+		t.Fatalf("stale claim=%+v ok=%v err=%v, want unchanged", claim, ok, err)
+	}
+}
+
+func TestAWSCleanupDryRunRetainsExactClaim(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	server := awsTestServer("i-dry-run", "cbx_555555555555", "dry-run", "us-west-2")
+	server.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
+	fake := &fakeAWSClient{servers: []Server{server}}
+	oldClient := newAWSClient
+	newAWSClient = func(context.Context, Config) (awsClient, error) {
+		return fake, nil
+	}
+	t.Cleanup(func() { newAWSClient = oldClient })
+
+	cfg := Config{Provider: "aws", AWSRegion: "us-west-2"}
+	if err := core.ClaimLeaseTargetForConfig(server.Labels["lease"], server.Labels["slug"], cfg, server, SSHTarget{}, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	var stderr strings.Builder
+	backend := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: &stderr}).(*awsLeaseBackend)
+	if err := backend.Cleanup(context.Background(), CleanupRequest{DryRun: true}); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.deletedInstances) != 0 || len(fake.deletedKeys) != 0 {
+		t.Fatalf("dry-run cleanup mutated provider: instances=%v keys=%v", fake.deletedInstances, fake.deletedKeys)
+	}
+	claim, ok, err := core.ResolveLeaseClaim(server.Labels["lease"])
+	if err != nil || !ok || claim.CloudID != server.CloudID {
+		t.Fatalf("claim=%+v ok=%v err=%v, want retained", claim, ok, err)
+	}
+	if !strings.Contains(stderr.String(), "delete server id=i-dry-run") {
+		t.Fatalf("stderr=%q, want report-only delete candidate", stderr.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

- require an exact local AWS lease claim before direct cleanup can terminate a tag-discovered EC2 instance
- bind cleanup authority to the canonical lease, provider, cloud ID, slug, and AWS region
- hold the unchanged claim lock through deletion, remove the claim only after the exact resource is gone, and preserve key-cleanup errors
- keep dry-run report-only and add missing-claim, stale-claim, exact-claim, fallback-region, and dry-run regression coverage

Fixes https://github.com/openclaw/crabbox/issues/871

## Verification

- `go test -race -count=3 ./internal/providers/aws`
- `go vet ./internal/providers/aws`
- `go test -race -timeout 20m ./...` (all packages passed)
- `.agents/skills/autoreview/scripts/autoreview --mode local --parallel-tests 'go test -race -timeout 20m ./...' --stream-engine-output` (clean; no accepted/actionable findings)

## Live gate

No provider resources were created. The configured AWS credentials are rejected by STS, and no valid AWS credential is currently available in 1Password. Keep this PR unmerged until an exact-head disposable canary proves an exact claimed instance is deleted, a tag-only instance is skipped, and cleanup leaves zero residue, or that item-specific gate is explicitly waived.
