### PR TITLE
fix(worker): redact provider diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- Redacted configured credentials, authorization headers, signed URLs, URL userinfo, and secret-bearing JSON fields before coordinator provider diagnostics are stored or returned. Thanks @coygeek.
 - Required W&B sandbox reuse, status, and stop to match an exact endpoint/entity/project/resource-bound local claim plus provider inventory ownership. Thanks @coygeek.
 - Required RunPod stop to use an exact pod ID/name-bound local claim, with conflict-safe explicit `--reclaim` adoption for unclaimed or legacy pods. Thanks @coygeek.
 - Made coordinatorless generic provider live smokes skip coordinator-only history and always clean up acquired leases after later lifecycle failures.

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -54,7 +54,15 @@ import {
   hetznerProvisioningFailureRetryable,
   hetznerProvisioningResourceID,
 } from "./hetzner";
-import { bearerToken, errorMessage, json, pathParts, readJson, requestOwner } from "./http";
+import {
+  bearerToken,
+  errorMessage,
+  json,
+  pathParts,
+  readJson,
+  redactDiagnosticSecrets,
+  requestOwner,
+} from "./http";
 import {
   MarketplaceInputError,
   marketplaceQuote,
@@ -219,6 +227,36 @@ const workspaceTerminalSSHReadyTimeoutMs = 2 * 60_000;
 const workspaceSSHHostPrivateKeyHeader = "x-crabbox-workspace-ssh-host-private-key";
 const workspaceSSHHostPublicKeyHeader = "x-crabbox-workspace-ssh-host-public-key";
 const adminGrantRevalidationIntervalMs = 1_000;
+
+function coordinatorErrorMessage(env: Env, error: unknown): string {
+  return errorMessage(error, coordinatorDiagnosticSecrets(env));
+}
+
+function coordinatorDiagnosticText(env: Env, value: string): string {
+  return redactDiagnosticSecrets(value, coordinatorDiagnosticSecrets(env));
+}
+
+function coordinatorDiagnosticSecrets(env: Env): Array<string | undefined> {
+  return [
+    env.HETZNER_TOKEN,
+    env.AWS_ACCESS_KEY_ID,
+    env.AWS_SECRET_ACCESS_KEY,
+    env.AWS_SESSION_TOKEN,
+    env.AZURE_CLIENT_SECRET,
+    env.GCP_PRIVATE_KEY,
+    env.CRABBOX_RUNTIME_ADAPTER_TOKEN,
+    env.CRABBOX_SHARED_TOKEN,
+    env.CRABBOX_ADMIN_TOKEN,
+    env.CRABBOX_SESSION_SECRET,
+    env.CRABBOX_GITHUB_CLIENT_SECRET,
+    env.CRABBOX_WORKSPACE_SSH_PRIVATE_KEY,
+    env.CRABBOX_TRUSTED_PROXY_SECRET,
+    env.CRABBOX_TAILSCALE_CLIENT_SECRET,
+    env.CRABBOX_ARTIFACTS_ACCESS_KEY_ID,
+    env.CRABBOX_ARTIFACTS_SECRET_ACCESS_KEY,
+    env.CRABBOX_ARTIFACTS_SESSION_TOKEN,
+  ];
+}
 
 interface CachedAdminGrant {
   auth?: AuthContext["auth"];
@@ -1068,7 +1106,7 @@ export class FleetCoordinator {
       }
       return json({ error: "not_found" }, { status: 404 });
     } catch (error) {
-      return json({ error: errorMessage(error) }, { status: 500 });
+      return json({ error: coordinatorErrorMessage(this.env, error) }, { status: 500 });
     }
   }
 
@@ -1251,7 +1289,10 @@ export class FleetCoordinator {
       this.reconcileRestoredBridgeSockets().then(
         () => true,
         (error) => {
-          console.warn("could not reconcile restored bridges", errorMessage(error));
+          console.warn(
+            "could not reconcile restored bridges",
+            coordinatorErrorMessage(this.env, error),
+          );
           return false;
         },
       );
@@ -2406,7 +2447,7 @@ export class FleetCoordinator {
         ? provision()
         : prepared?.provisioning?.sshIngressReconcile === "additive"
           ? this.withAWSIngressAdditiveOperation(provision).catch(async (error: unknown) => {
-              if (!isAWSSecurityGroupRuleLimitError(errorMessage(error))) {
+              if (!isAWSSecurityGroupRuleLimitError(coordinatorErrorMessage(this.env, error))) {
                 throw error;
               }
               return await this.withAWSIngressOperationLock(async () => {
@@ -2460,7 +2501,7 @@ export class FleetCoordinator {
           record.updatedAt = failedAt;
           record.endedAt = failedAt;
           record.cleanupFailedAt = failedAt;
-          record.cleanupError = errorMessage(error);
+          record.cleanupError = coordinatorErrorMessage(this.env, error);
           record.provisioningResourceMayExist =
             config.provider === "hetzner" && hetznerProvisioningFailureMayHaveResource(error);
           record.provisioningFailureRetryable =
@@ -2672,7 +2713,7 @@ export class FleetCoordinator {
       provider = workspaceProvider(this.env.CRABBOX_WORKSPACE_PROVIDER);
     } catch (error) {
       return json(
-        { error: "workspace_not_configured", message: errorMessage(error) },
+        { error: "workspace_not_configured", message: coordinatorErrorMessage(this.env, error) },
         { status: 424 },
       );
     }
@@ -2761,7 +2802,9 @@ export class FleetCoordinator {
     try {
       await this.maintainWorkspacePrewarm();
     } catch (error) {
-      console.warn(`workspace prewarm maintenance deferred: ${errorMessage(error)}`);
+      console.warn(
+        `workspace prewarm maintenance deferred: ${coordinatorErrorMessage(this.env, error)}`,
+      );
     }
     await this.state.runExclusive(() => this.scheduleAlarm());
     return json(workspaceResponse(reservation.record, reservation.lease, this.env), {
@@ -3202,7 +3245,7 @@ export class FleetCoordinator {
       if (persistedLease && workspaceOwnsLease(workspace, persistedLease)) {
         await this.deferWorkspaceReconciliation(workspace, true);
       } else {
-        await this.recordWorkspaceError(workspace, errorMessage(error));
+        await this.recordWorkspaceError(workspace, coordinatorErrorMessage(this.env, error));
       }
       return;
     }
@@ -3602,7 +3645,11 @@ export class FleetCoordinator {
       admission.workspace,
       admission.lease,
     ).catch((error) =>
-      closeSocket(admission.upgrade.socket, 1011, boundedSocketReason(errorMessage(error))),
+      closeSocket(
+        admission.upgrade.socket,
+        1011,
+        boundedSocketReason(coordinatorErrorMessage(this.env, error)),
+      ),
     );
     return admission.upgrade.response;
   }
@@ -3691,7 +3738,7 @@ export class FleetCoordinator {
               queuedInputFrames -= 1;
             }
           })
-          .catch((error) => close(1011, errorMessage(error)));
+          .catch((error) => close(1011, coordinatorErrorMessage(this.env, error)));
       },
       close: () => close(1000, "native VNC closed"),
       error: () => close(1011, "native VNC websocket error"),
@@ -3741,9 +3788,11 @@ export class FleetCoordinator {
       });
       channel.once("close", () => close(1000, "native VNC tunnel closed"));
       connectedClient.once("close", () => close(1011, "SSH connection closed"));
-      connectedClient.once("error", (error) => close(1011, errorMessage(error)));
+      connectedClient.once("error", (error) =>
+        close(1011, coordinatorErrorMessage(this.env, error)),
+      );
     } catch (error) {
-      close(1011, errorMessage(error));
+      close(1011, coordinatorErrorMessage(this.env, error));
       throw error;
     }
   }
@@ -3810,7 +3859,7 @@ export class FleetCoordinator {
       const socket = upgrade.socket;
       this.trackWorkspaceTerminal(key, socket);
       void this.connectWorkspaceTerminal(socket, key, workspace, lease).catch((error) => {
-        closeSocket(socket, 1011, boundedSocketReason(errorMessage(error)));
+        closeSocket(socket, 1011, boundedSocketReason(coordinatorErrorMessage(this.env, error)));
       });
       return upgrade.response;
     });
@@ -3912,7 +3961,7 @@ export class FleetCoordinator {
               queuedInputFrames -= 1;
             }
           })
-          .catch((error) => close(1011, errorMessage(error)));
+          .catch((error) => close(1011, coordinatorErrorMessage(this.env, error)));
       },
       close: () => close(1000, "terminal closed"),
       error: () => close(1011, "terminal websocket error"),
@@ -3972,7 +4021,7 @@ export class FleetCoordinator {
             updateOutputBackpressure();
           }
         } catch (error) {
-          close(1011, errorMessage(error));
+          close(1011, coordinatorErrorMessage(this.env, error));
         } finally {
           outputFlushing = false;
           if (
@@ -4016,7 +4065,9 @@ export class FleetCoordinator {
       channel.stderr.on("data", sendOutput);
       channel.once("close", () => close(1000, "terminal process exited"));
       connectedClient.once("close", () => close(1011, "SSH connection closed"));
-      connectedClient.once("error", (error) => close(1011, errorMessage(error)));
+      connectedClient.once("error", (error) =>
+        close(1011, coordinatorErrorMessage(this.env, error)),
+      );
       await writeWorkspaceTerminalChannel(
         channel,
         `${workspaceTerminalBootstrapCommand(workspace, lease)}\n`,
@@ -4032,7 +4083,7 @@ export class FleetCoordinator {
       await flushPending();
       terminalReady = true;
     } catch (error) {
-      close(1011, errorMessage(error));
+      close(1011, coordinatorErrorMessage(this.env, error));
       throw error;
     }
   }
@@ -4792,7 +4843,7 @@ export class FleetCoordinator {
         description: `crabbox ${leaseID} ${slug}`,
       });
     } catch (error) {
-      const message = errorMessage(error);
+      const message = coordinatorErrorMessage(this.env, error);
       if (message.includes("tags not allowed") || message.includes("requires at least one")) {
         return json({ error: "invalid_tailscale_tags", message }, { status: 400 });
       }
@@ -5464,7 +5515,9 @@ export class FleetCoordinator {
         ...(host.allocationTime ? { allocationTime: host.allocationTime } : {}),
       }));
     } catch (error) {
-      console.warn(`portal mac host inventory unavailable: ${errorMessage(error)}`);
+      console.warn(
+        `portal mac host inventory unavailable: ${coordinatorErrorMessage(this.env, error)}`,
+      );
       return [];
     }
   }
@@ -5595,7 +5648,7 @@ export class FleetCoordinator {
         totalLeases: providerLeases.length,
         users,
         recentLeases,
-        error: errorMessage(error),
+        error: coordinatorErrorMessage(this.env, error),
       };
     }
   }
@@ -9336,7 +9389,7 @@ export class FleetCoordinator {
         return json(
           {
             error: "mac_host_quota_failed",
-            message: sanitizeMacHostQuotaError(errorMessage(error)),
+            message: sanitizeMacHostQuotaError(coordinatorErrorMessage(this.env, error)),
           },
           { status: 502 },
         );
@@ -9444,7 +9497,7 @@ export class FleetCoordinator {
               { status: 201 },
             );
           } catch (error) {
-            const message = errorMessage(error);
+            const message = coordinatorErrorMessage(this.env, error);
             failures.push(`${offering.availabilityZone}: ${message}`);
           }
         }
@@ -9537,7 +9590,7 @@ export class FleetCoordinator {
       audit.cleanupAttempts = lease.cleanupAttempts;
     }
     if (lease.cleanupError) {
-      audit.cleanupError = lease.cleanupError;
+      audit.cleanupError = coordinatorDiagnosticText(this.env, lease.cleanupError);
     }
     if (lease.cleanupRetryAt) {
       audit.cleanupRetryAt = lease.cleanupRetryAt;
@@ -9560,7 +9613,7 @@ export class FleetCoordinator {
         cloudServerType: server.serverType,
       };
     } catch (error) {
-      const message = errorMessage(error);
+      const message = coordinatorErrorMessage(this.env, error);
       if (isCloudNotFoundError(message)) {
         return { ...audit, cloudStatus: "missing", message };
       }
@@ -9607,7 +9660,7 @@ export class FleetCoordinator {
       audit.cleanupAttempts = lease.cleanupAttempts;
     }
     if (lease.cleanupError) {
-      audit.cleanupError = lease.cleanupError;
+      audit.cleanupError = coordinatorDiagnosticText(this.env, lease.cleanupError);
     }
     if (lease.cleanupRetryAt) {
       audit.cleanupRetryAt = lease.cleanupRetryAt;
@@ -9635,7 +9688,7 @@ export class FleetCoordinator {
         cloudServerType: server.serverType,
       };
     } catch (error) {
-      const message = errorMessage(error);
+      const message = coordinatorErrorMessage(this.env, error);
       if (isCloudNotFoundError(message)) {
         return { ...audit, cloudStatus: "missing", message };
       }
@@ -9759,7 +9812,10 @@ export class FleetCoordinator {
       );
     } catch (error) {
       return json(
-        { error: "artifact_upload_unavailable", message: errorMessage(error) },
+        {
+          error: "artifact_upload_unavailable",
+          message: coordinatorErrorMessage(this.env, error),
+        },
         { status: 400 },
       );
     }
@@ -10336,7 +10392,7 @@ export class FleetCoordinator {
           try {
             await this.deleteLeaseServer(lease);
           } catch (error) {
-            failure = errorMessage(error);
+            failure = coordinatorErrorMessage(this.env, error);
           }
           await this.state.runExclusive(async () => {
             const current = await this.getLease(lease.id);
@@ -10614,7 +10670,7 @@ export class FleetCoordinator {
               providerAccessContext([], fresh.accessState),
             );
           } catch (error) {
-            failure = errorMessage(error);
+            failure = coordinatorErrorMessage(this.env, error);
             console.warn(
               `AWS SSH ingress reconciliation failed lease=${fresh.target.anchor.id} region=${fresh.target.anchor.region ?? ""}: ${failure}`,
             );
@@ -10696,7 +10752,7 @@ export class FleetCoordinator {
               attempts: current.attempts + 1,
               updatedAt: new Date().toISOString(),
               retryAt: new Date(now + leaseCleanupRetryDelayMs).toISOString(),
-              lastError: errorMessage(error),
+              lastError: coordinatorErrorMessage(this.env, error),
             };
             await this.state.storage.put(key, nextRecord);
             console.warn(
@@ -10814,7 +10870,7 @@ export class FleetCoordinator {
               candidate.action = "terminated";
             } catch (error) {
               candidate.action = "terminate_failed";
-              candidate.error = errorMessage(error);
+              candidate.error = coordinatorErrorMessage(this.env, error);
               console.warn(
                 `aws orphan sweep terminate failed region=${region} cloud=${machine.cloudID}: ${candidate.error}`,
               );
@@ -10846,7 +10902,7 @@ export class FleetCoordinator {
                 candidate.action = "released";
               } catch (error) {
                 candidate.action = "release_failed";
-                candidate.error = errorMessage(error);
+                candidate.error = coordinatorErrorMessage(this.env, error);
                 console.warn(
                   `aws orphan sweep mac host release failed region=${region} host=${host.id}: ${candidate.error}`,
                 );
@@ -10856,7 +10912,7 @@ export class FleetCoordinator {
           }
         }
       } catch (error) {
-        const message = errorMessage(error);
+        const message = coordinatorErrorMessage(this.env, error);
         errors.push({ region, message });
         console.warn(`aws orphan sweep failed region=${region}: ${message}`);
       }
@@ -11022,7 +11078,7 @@ export class FleetCoordinator {
               candidate.action = "terminated";
             } catch (error) {
               candidate.action = "terminate_failed";
-              candidate.error = errorMessage(error);
+              candidate.error = coordinatorErrorMessage(this.env, error);
               console.warn(
                 `azure orphan sweep terminate failed region=${region} cloud=${machine.cloudID}: ${candidate.error}`,
               );
@@ -11031,7 +11087,7 @@ export class FleetCoordinator {
           candidates.push(candidate);
         }
       } catch (error) {
-        const message = errorMessage(error);
+        const message = coordinatorErrorMessage(this.env, error);
         errors.push({ region, message });
         console.warn(`azure orphan sweep failed region=${region}: ${message}`);
       }
@@ -11338,11 +11394,16 @@ export class FleetCoordinator {
   }
 
   private leaseForRequest(lease: LeaseRecord, request: Request, admin: boolean): LeaseRecord {
-    if (!lease.share || this.leaseManageableByRequest(lease, request, admin)) {
-      return lease;
-    }
     const visible = { ...lease };
-    delete visible.share;
+    if (visible.cleanupError) {
+      visible.cleanupError = coordinatorDiagnosticText(this.env, visible.cleanupError);
+    }
+    if (visible.failureError) {
+      visible.failureError = coordinatorDiagnosticText(this.env, visible.failureError);
+    }
+    if (visible.share && !this.leaseManageableByRequest(lease, request, admin)) {
+      delete visible.share;
+    }
     return visible;
   }
 
@@ -11738,7 +11799,7 @@ export class FleetCoordinator {
         delete cleanupLease.cleanupStartedAt;
         delete cleanupLease.cleanupClaimExpiresAt;
         cleanupLease.cleanupFailedAt = failedAt;
-        cleanupLease.cleanupError = errorMessage(error);
+        cleanupLease.cleanupError = coordinatorErrorMessage(this.env, error);
         cleanupLease.cleanupRetryAt = new Date(Date.now() + leaseCleanupRetryDelayMs).toISOString();
         cleanupLease.expiresAt = failedAt;
         cleanupLease.updatedAt = failedAt;
@@ -11903,7 +11964,7 @@ export class FleetCoordinator {
         current.cleanupAttempts = (current.cleanupAttempts ?? 0) + 1;
         delete current.cleanupStartedAt;
         delete current.cleanupClaimExpiresAt;
-        current.cleanupError = errorMessage(error);
+        current.cleanupError = coordinatorErrorMessage(this.env, error);
         current.cleanupFailedAt = failedAt.toISOString();
         current.cleanupRetryAt = new Date(
           failedAt.getTime() + leaseCleanupRetryDelayMs,
@@ -13443,6 +13504,19 @@ function workspaceResponse(
   const status = workspaceStatus(workspace, lease);
   const terminalUrl = env ? workspaceTerminalURL(workspace, lease, env) : undefined;
   const nativeVnc = env ? !workspaceNativeVNCError(workspace, lease, env) : false;
+  const message =
+    workspace.error ??
+    (lease && !workspaceOwnsLease(workspace, lease)
+      ? "workspace lease reservation conflicts with another lifecycle"
+      : undefined) ??
+    lease?.failureError ??
+    (lease?.state === "failed" ? "workspace provisioning recovery pending" : undefined) ??
+    lease?.cleanupError ??
+    (status === "ready"
+      ? "workspace ready"
+      : status === "failed"
+        ? "workspace provisioning failed"
+        : `workspace ${status}`);
   return {
     id: workspace.id,
     workspaceId: workspace.id,
@@ -13460,19 +13534,7 @@ function workspaceResponse(
     },
     ...(terminalUrl ? { attachUrl: terminalUrl } : {}),
     ...(lease?.expiresAt ? { expiresAt: lease.expiresAt } : {}),
-    message:
-      workspace.error ??
-      (lease && !workspaceOwnsLease(workspace, lease)
-        ? "workspace lease reservation conflicts with another lifecycle"
-        : undefined) ??
-      lease?.failureError ??
-      (lease?.state === "failed" ? "workspace provisioning recovery pending" : undefined) ??
-      lease?.cleanupError ??
-      (status === "ready"
-        ? "workspace ready"
-        : status === "failed"
-          ? "workspace provisioning failed"
-          : `workspace ${status}`),
+    message: env ? coordinatorDiagnosticText(env, message) : redactDiagnosticSecrets(message),
   };
 }
 
@@ -16744,7 +16806,9 @@ export class AWSProvider implements CloudProvider {
     try {
       await this.reconcileLeaseAccess(nextLease, { ...context, activeLeases });
     } catch (error) {
-      console.warn(`refresh AWS SSH ingress failed for ${lease.id}: ${errorMessage(error)}`);
+      console.warn(
+        `refresh AWS SSH ingress failed for ${lease.id}: ${coordinatorErrorMessage(this.env, error)}`,
+      );
     }
     return nextLease;
   }
@@ -16944,7 +17008,7 @@ export class AWSProvider implements CloudProvider {
     try {
       await this.deleteServer(lease.cloudID);
     } catch (error) {
-      const message = errorMessage(error);
+      const message = coordinatorErrorMessage(this.env, error);
       if (!isCloudNotFoundError(message)) {
         throw error;
       }
@@ -17119,7 +17183,10 @@ export class AWSProvider implements CloudProvider {
       try {
         imageOS = normalizeOSImage(requestedOS ?? fallbackOS);
       } catch (error) {
-        return json({ error: "invalid_os", message: errorMessage(error) }, { status: 400 });
+        return json(
+          { error: "invalid_os", message: coordinatorErrorMessage(this.env, error) },
+          { status: 400 },
+        );
       }
     }
     const rawRegion = input.region ?? url.searchParams.get("region") ?? known?.region ?? "";

--- a/worker/src/http.ts
+++ b/worker/src/http.ts
@@ -33,8 +33,58 @@ export function pathParts(request: Request): string[] {
   return new URL(request.url).pathname.split("/").filter(Boolean);
 }
 
-export function errorMessage(error: unknown): string {
-  return firstLine(error instanceof Error ? error.message : String(error));
+export function errorMessage(
+  error: unknown,
+  secrets: readonly (string | undefined)[] = [],
+): string {
+  return redactDiagnosticSecrets(
+    firstLine(error instanceof Error ? error.message : String(error)),
+    secrets,
+  );
+}
+
+export function redactDiagnosticSecrets(
+  value: string,
+  secrets: readonly (string | undefined)[] = [],
+): string {
+  let redacted = value;
+  const exactSecrets = [
+    ...new Set(
+      secrets.flatMap((secret) => {
+        const trimmed = secret?.trim();
+        return trimmed ? [trimmed] : [];
+      }),
+    ),
+  ].toSorted((left, right) => right.length - left.length);
+  for (const secret of exactSecrets) {
+    redacted = redacted.replaceAll(secret, "[redacted]");
+  }
+  redacted = redacted.replaceAll(
+    /\b(authorization|proxy-authorization|x-api-key|api-key|api_key|access-token|access_token|client-secret|client_secret|session-token|session_token|token|password)[ \t]*[:=][ \t]*(?:(?:bearer|basic)[ \t]+)?[^\s"',;\\}]+/gi,
+    (match) => {
+      const colon = match.indexOf(":");
+      const equals = match.indexOf("=");
+      const separator = colon < 0 ? equals : equals < 0 ? colon : Math.min(colon, equals);
+      return separator >= 0 ? `${match.slice(0, separator + 1)} [redacted]` : match;
+    },
+  );
+  redacted = redacted.replaceAll(
+    /"(authorization|proxy-authorization|x-api-key|apiKey|api-key|api_key|accessToken|access-token|access_token|clientSecret|client-secret|client_secret|credential|credentials|privateKey|private-key|private_key|secret|sessionToken|session-token|session_token|token|password)"\s*:\s*"(?:\\[\s\S]|[^"\\])*(?:"|$)/gi,
+    (match) => {
+      const separator = match.indexOf(":");
+      return separator >= 0 ? `${match.slice(0, separator + 1)}"[redacted]"` : match;
+    },
+  );
+  redacted = redacted.replaceAll(
+    /([?&](?:api[_-]?key|access[_-]?token|client[_-]?secret|password|token|signature|sig|x-amz-credential|x-amz-signature|x-amz-security-token)=)[^&#\s]+/gi,
+    "$1[redacted]",
+  );
+  redacted = redacted.replaceAll(/\b(https?:\/\/)[^/\s:@]+:[^@\s/]+@/gi, "$1[redacted]@");
+  redacted = redacted.replaceAll(/\bbearer[ \t]+[^\s"',;\\}]+/gi, "Bearer [redacted]");
+  return redacted.replaceAll(
+    /-----BEGIN ([A-Z0-9 ]*PRIVATE KEY)-----[\s\S]*?(?:-----END \1-----|$)/gi,
+    "[redacted]",
+  );
 }
 
 function redactStackTraceFields(value: unknown, seen = new WeakSet<object>()): unknown {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -5634,6 +5634,56 @@ describe("fleet lease identity and idle", () => {
     expect(providerCreates).toBe(1);
   });
 
+  it("redacts legacy provider diagnostics from workspace responses", async () => {
+    const storage = new MemoryStorage();
+    const configuredSecret = "configured-workspace-secret";
+    const reflectedSecret = "legacy-workspace-secret";
+    const now = new Date().toISOString();
+    storage.seed("workspace:example-org:alice%40example.com:fleet-is-redacted", {
+      id: "fleet-is-redacted",
+      leaseID: "cbx_abcdef123456",
+      owner: "alice@example.com",
+      org: "example-org",
+      profile: "default",
+      provider: "aws",
+      class: "standard",
+      desktop: false,
+      ttlSeconds: 1800,
+      idleTimeoutSeconds: 360,
+      createdAt: now,
+      updatedAt: now,
+    });
+    storage.seed(
+      "lease:cbx_abcdef123456",
+      testLease({
+        id: "cbx_abcdef123456",
+        slug: "fleet-is-redacted",
+        workspaceID: "fleet-is-redacted",
+        owner: "alice@example.com",
+        org: "example-org",
+        provider: "aws",
+        state: "failed",
+        failureError: `provision failed ${configuredSecret} token=${reflectedSecret}`,
+      }),
+    );
+    const fleet = testFleet(storage, {}, { AWS_SECRET_ACCESS_KEY: configuredSecret });
+
+    const response = await fleet.fetch(
+      request("GET", "/v1/workspaces/fleet-is-redacted", {
+        headers: {
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain("[redacted]");
+    expect(body).not.toContain(configuredSecret);
+    expect(body).not.toContain(reflectedSecret);
+  });
+
   it("waits for an unexpired provisioning claim when no lease was written", async () => {
     const storage = new MemoryStorage();
     let providerCreates = 0;
@@ -8141,7 +8191,7 @@ describe("fleet lease identity and idle", () => {
     const storage = new MemoryStorage();
     const fleet = testFleet(storage, {
       aws: fakeProvider(undefined, { provider: "aws" }, async () => {
-        throw new Error("aws terminate throttled");
+        throw new Error("aws terminate throttled X-API-Key: cleanup-secret");
       }),
     });
     storage.seed(
@@ -8159,7 +8209,8 @@ describe("fleet lease identity and idle", () => {
     const lease = storage.value<LeaseRecord>("lease:cbx_000000000001");
     expect(lease?.state).toBe("active");
     expect(lease?.cleanupAttempts).toBe(1);
-    expect(lease?.cleanupError).toContain("aws terminate throttled");
+    expect(lease?.cleanupError).toBe("aws terminate throttled X-API-Key: [redacted]");
+    expect(lease?.cleanupError).not.toContain("cleanup-secret");
     expect(Date.parse(lease?.cleanupRetryAt ?? "")).toBeGreaterThan(Date.now());
     expect(storage.alarm()).toBe(Date.parse(lease?.cleanupRetryAt ?? ""));
   });
@@ -11018,6 +11069,93 @@ describe("fleet lease identity and idle", () => {
     expect(lease?.endedAt).toBeTruthy();
   });
 
+  it("redacts provider credentials before persisting and returning provisioning failures", async () => {
+    const storage = new MemoryStorage();
+    const configuredSecret = "configured-azure-client-secret";
+    const reflectedSecret = "reflected-provider-secret";
+    const fleet = testFleet(
+      storage,
+      {
+        azure: fakeProvider(
+          () => {
+            throw new Error(
+              `azure create failed ${configuredSecret} Authorization: Bearer ${reflectedSecret}`,
+            );
+          },
+          { provider: "azure", region: "eastus" },
+        ),
+      },
+      { AZURE_CLIENT_SECRET: configuredSecret },
+    );
+
+    const create = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers: {
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
+        },
+        body: {
+          leaseID: "cbx_abcdef123456",
+          provider: "azure",
+          azureLocation: "eastus",
+          sshPublicKey: "ssh-ed25519 test",
+        },
+      }),
+    );
+
+    expect(create.status).toBe(500);
+    const stored = storage.value<LeaseRecord>("lease:cbx_abcdef123456");
+    expect(stored?.cleanupError).toContain("[redacted]");
+    expect(stored?.failureError).toContain("[redacted]");
+    expect(JSON.stringify(stored)).not.toContain(configuredSecret);
+    expect(JSON.stringify(stored)).not.toContain(reflectedSecret);
+    const responseText = await create.text();
+    expect(responseText).toContain("[redacted]");
+    expect(responseText).not.toContain(configuredSecret);
+    expect(responseText).not.toContain(reflectedSecret);
+  });
+
+  it("redacts legacy stored diagnostics from lease get and list responses", async () => {
+    const storage = new MemoryStorage();
+    const configuredSecret = "configured-aws-secret";
+    const reflectedSecret = "legacy-reflected-secret";
+    storage.seed(
+      "lease:cbx_abcdef123456",
+      testLease({
+        id: "cbx_abcdef123456",
+        owner: "alice@example.com",
+        org: "example-org",
+        cleanupError: `cleanup failed ${configuredSecret}`,
+        failureError: `X-API-Key: ${reflectedSecret}`,
+      }),
+    );
+    const fleet = testFleet(storage, {}, { AWS_SECRET_ACCESS_KEY: configuredSecret });
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+
+    const [get, list] = await Promise.all([
+      fleet.fetch(request("GET", "/v1/leases/cbx_abcdef123456", { headers })),
+      fleet.fetch(request("GET", "/v1/leases", { headers })),
+    ]);
+
+    const bodies = await Promise.all(
+      [get, list].map(async (response) => {
+        expect(response.status).toBe(200);
+        return await response.text();
+      }),
+    );
+    for (const body of bodies) {
+      expect(body).toContain("[redacted]");
+      expect(body).not.toContain(configuredSecret);
+      expect(body).not.toContain(reflectedSecret);
+    }
+    expect(storage.value<LeaseRecord>("lease:cbx_abcdef123456")?.cleanupError).toContain(
+      configuredSecret,
+    );
+  });
+
   it("can release a provisioning lease before cloud resources are known", async () => {
     const storage = new MemoryStorage();
     const deleted: string[] = [];
@@ -11711,7 +11849,7 @@ describe("fleet lease identity and idle", () => {
         async (id) => {
           deleted.push(id);
           if (failDelete) {
-            throw new Error("azure delete throttled");
+            throw new Error("azure delete throttled Authorization: Bearer release-secret");
           }
         },
       ),
@@ -11755,9 +11893,10 @@ describe("fleet lease identity and idle", () => {
       provider: "azure",
       state: "released",
       cloudID: "vm-cbx-abcdef123456",
-      cleanupError: "azure delete throttled",
+      cleanupError: "azure delete throttled Authorization: [redacted]",
       releaseDeletesServer: true,
     });
+    expect(failedCleanup?.cleanupError).not.toContain("release-secret");
 
     failDelete = false;
     const retryDelete = await fleet.fetch(
@@ -20449,7 +20588,7 @@ describe("fleet identity", () => {
         region: "eu-west-1",
         state: "expired",
         cleanupAttempts: 1,
-        cleanupError: "terminated",
+        cleanupError: "terminated configured-audit-secret",
         createdAt: "2026-05-01T00:01:00.000Z",
       }),
     );
@@ -20476,24 +20615,30 @@ describe("fleet identity", () => {
         state: "active",
       }),
     );
-    const fleet = testFleet(storage, {
-      aws: fakeProvider(undefined, { provider: "aws" }, undefined, async (id) => {
-        if (id === "i-gone") {
-          throw new Error("aws instance not found: i-gone");
-        }
-        return {
-          provider: "aws",
-          id: 123,
-          cloudID: id,
-          region: "eu-west-1",
-          name: `crabbox-${id}`,
-          status: id === "i-terminated" ? "terminated" : "running",
-          serverType: "c7i.2xlarge",
-          host: "192.0.2.20",
-          labels: {},
-        };
-      }),
-    });
+    const fleet = testFleet(
+      storage,
+      {
+        aws: fakeProvider(undefined, { provider: "aws" }, undefined, async (id) => {
+          if (id === "i-gone") {
+            throw new Error(
+              "aws instance not found: i-gone https://audit-user:audit-password@example.test",
+            );
+          }
+          return {
+            provider: "aws",
+            id: 123,
+            cloudID: id,
+            region: "eu-west-1",
+            name: `crabbox-${id}`,
+            status: id === "i-terminated" ? "terminated" : "running",
+            serverType: "c7i.2xlarge",
+            host: "192.0.2.20",
+            labels: {},
+          };
+        }),
+      },
+      { AWS_SECRET_ACCESS_KEY: "configured-audit-secret" },
+    );
 
     const response = await fleet.fetch(
       request("GET", "/v1/admin/lease-audit?state=expired&provider=aws", {
@@ -20509,6 +20654,11 @@ describe("fleet identity", () => {
       { leaseID: "cbx_000000000002", cloudStatus: "missing" },
       { leaseID: "cbx_000000000001", cloudStatus: "found", cloudState: "running" },
     ]);
+    const serialized = JSON.stringify(body);
+    expect(serialized).toContain("[redacted]");
+    expect(serialized).not.toContain("configured-audit-secret");
+    expect(serialized).not.toContain("audit-user");
+    expect(serialized).not.toContain("audit-password");
   });
 
   it("audits expired Azure leases against cloud state", async () => {

--- a/worker/test/http.test.ts
+++ b/worker/test/http.test.ts
@@ -10,7 +10,7 @@ import {
 } from "../src/auth";
 import { codeOriginForLease } from "../src/code-origin";
 import { prepareCoordinatorRequest } from "../src/coordinator-entry";
-import { errorMessage, json, requestOwner } from "../src/http";
+import { errorMessage, json, redactDiagnosticSecrets, requestOwner } from "../src/http";
 import type { Env } from "../src/types";
 
 function proxyIdentityRequest(secret?: string): Request {
@@ -1068,6 +1068,48 @@ describe("http responses", () => {
 
   it("keeps public error messages to the first line", () => {
     expect(errorMessage(new Error("boom\n    at hidden"))).toBe("boom");
+  });
+
+  it("redacts configured and structured credentials from diagnostics", () => {
+    const secrets = ["configured-provider-secret", "longer-configured-provider-secret", undefined];
+    const diagnostic = [
+      "provider failed",
+      "longer-configured-provider-secret",
+      "configured-provider-secret",
+      "Authorization: Bearer bearer-secret",
+      "Proxy-Authorization=Basic basic-secret",
+      "X-API-Key=header-secret",
+      "client_secret=plain-secret",
+      '{"token":"json-secret\\\"escaped-tail-leak","clientSecret":"client-secret","x-api-key":"json-api-secret"}',
+      "https://alice:password@example.test/path?api_key=query-secret&X-Amz-Signature=signed-secret",
+      "-----BEGIN PRIVATE KEY-----\nprivate-key-body\n-----END PRIVATE KEY-----",
+      "safe suffix",
+    ].join("\n");
+
+    const redacted = redactDiagnosticSecrets(diagnostic, secrets);
+
+    for (const secret of [
+      "configured-provider-secret",
+      "longer-configured-provider-secret",
+      "bearer-secret",
+      "basic-secret",
+      "header-secret",
+      "plain-secret",
+      "json-secret",
+      "escaped-tail-leak",
+      "client-secret",
+      "json-api-secret",
+      "alice",
+      "password",
+      "query-secret",
+      "signed-secret",
+      "PRIVATE KEY",
+      "private-key-body",
+    ]) {
+      expect(redacted).not.toContain(secret);
+    }
+    expect(redacted).toContain("[redacted]");
+    expect(redacted).toContain("safe suffix");
   });
 });
 


### PR DESCRIPTION
## Summary

- redact configured credentials plus common authorization, signed-URL, URL-userinfo, JSON-secret, and private-key forms before provider diagnostics are persisted or returned
- sanitize legacy stored lease, workspace, cleanup, and cloud-audit diagnostics at the response boundary
- cover provisioning, release, cleanup, audit, and legacy-read paths with coordinator integration regressions

Fixes https://github.com/openclaw/crabbox/issues/878

## Verification

- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker` (793 tests)
- `npm run build --prefix worker`
- autoreview: clean after fixing complete PEM-block, escaped-JSON-value, and legacy workspace-response findings

## Behavior proof

The Worker integration tests drive real Fleet provisioning, cleanup, release, audit, and workspace response paths with credential-bearing provider failures. They verify both stored records and returned responses contain redaction markers and none of the injected secret material. No provider resource or persistent credential is required for this deterministic boundary.
