### PR TITLE
fix(cli): redact broker URLs in output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 
 - Redacted configured credentials, authorization headers, signed URLs, URL userinfo, and secret-bearing JSON fields before coordinator provider diagnostics are stored or returned. Thanks @coygeek.
+- Redacted broker URL userinfo, queries, and fragments from `login`, `whoami`, and `doctor` text and JSON output. Thanks @coygeek.
 - Required W&B sandbox reuse, status, and stop to match an exact endpoint/entity/project/resource-bound local claim plus provider inventory ownership. Thanks @coygeek.
 - Required RunPod stop to use an exact pod ID/name-bound local claim, with conflict-safe explicit `--reclaim` adoption for unclaimed or legacy pods. Thanks @coygeek.
 - Made coordinatorless generic provider live smokes skip coordinator-only history and always clean up acquired leases after later lifecycle failures.

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -196,7 +196,7 @@ func (a App) finishLogin(ctx context.Context, coord *CoordinatorClient, path str
 	if jsonOut {
 		view := map[string]any{
 			"config":   path,
-			"broker":   cfg.Coordinator,
+			"broker":   redactedConfigURL(cfg.Coordinator),
 			"provider": cfg.Provider,
 			"identity": who,
 		}
@@ -209,7 +209,7 @@ func (a App) finishLogin(ctx context.Context, coord *CoordinatorClient, path str
 	if who.TokenExpiresAt != "" {
 		expires = " token_expires=" + who.TokenExpiresAt
 	}
-	fmt.Fprintf(a.Stdout, "logged in broker=%s provider=%s user=%s org=%s%s config=%s\n", cfg.Coordinator, cfg.Provider, who.Owner, who.Org, expires, path)
+	fmt.Fprintf(a.Stdout, "logged in broker=%s provider=%s user=%s org=%s%s config=%s\n", redactedConfigURL(cfg.Coordinator), cfg.Provider, who.Owner, who.Org, expires, path)
 	return nil
 }
 
@@ -399,7 +399,7 @@ func (a App) whoami(ctx context.Context, args []string) error {
 	if *jsonOut {
 		return json.NewEncoder(a.Stdout).Encode(who)
 	}
-	fmt.Fprintf(a.Stdout, "user=%s org=%s auth=%s broker=%s\n", who.Owner, who.Org, who.Auth, cfg.Coordinator)
+	fmt.Fprintf(a.Stdout, "user=%s org=%s auth=%s broker=%s\n", who.Owner, who.Org, who.Auth, redactedConfigURL(cfg.Coordinator))
 	return nil
 }
 

--- a/internal/cli/auth_test.go
+++ b/internal/cli/auth_test.go
@@ -98,6 +98,87 @@ func TestWriteBrokerLoginAcceptsDirectProviderInRegisteredMode(t *testing.T) {
 	}
 }
 
+func TestFinishLoginRedactsBrokerURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/whoami" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(CoordinatorWhoami{
+			Owner: "alice@example.test",
+			Org:   "example-org",
+			Auth:  "token",
+		})
+	}))
+	defer server.Close()
+
+	const brokerURL = "https://broker-user:broker-password@broker.example.test/path?token=query-secret#fragment-secret"
+	coord := &CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
+	for _, jsonOut := range []bool{false, true} {
+		var stdout bytes.Buffer
+		app := App{Stdout: &stdout, Stderr: &bytes.Buffer{}}
+		if err := app.finishLogin(context.Background(), coord, "/tmp/config.yaml", Config{
+			Coordinator: brokerURL,
+			Provider:    "aws",
+		}, jsonOut); err != nil {
+			t.Fatal(err)
+		}
+		output := stdout.String()
+		brokerOutput := output
+		if jsonOut {
+			var view map[string]any
+			if err := json.Unmarshal(stdout.Bytes(), &view); err != nil {
+				t.Fatal(err)
+			}
+			brokerOutput, _ = view["broker"].(string)
+		}
+		if !strings.Contains(brokerOutput, "https://<redacted>@broker.example.test/path") {
+			t.Fatalf("login output missing redacted broker URL: %q", output)
+		}
+		for _, secret := range []string{"broker-user", "broker-password", "query-secret", "fragment-secret"} {
+			if strings.Contains(output, secret) {
+				t.Fatalf("login output leaked %q: %q", secret, output)
+			}
+		}
+	}
+}
+
+func TestWhoamiRedactsBrokerURL(t *testing.T) {
+	clearConfigEnv(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/whoami" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(CoordinatorWhoami{
+			Owner: "alice@example.test",
+			Org:   "example-org",
+			Auth:  "token",
+		})
+	}))
+	defer server.Close()
+	brokerURL := strings.Replace(server.URL, "http://", "http://broker-user:broker-password@", 1)
+	t.Setenv("CRABBOX_COORDINATOR", brokerURL)
+
+	var stdout bytes.Buffer
+	if err := (App{Stdout: &stdout, Stderr: &bytes.Buffer{}}).whoami(context.Background(), nil); err != nil {
+		t.Fatal(err)
+	}
+	output := stdout.String()
+	if !strings.Contains(output, strings.Replace(server.URL, "http://", "http://<redacted>@", 1)) {
+		t.Fatalf("whoami output missing redacted broker URL: %q", output)
+	}
+	for _, secret := range []string{"broker-user", "broker-password"} {
+		if strings.Contains(output, secret) {
+			t.Fatalf("whoami output leaked %q: %q", secret, output)
+		}
+	}
+}
+
 func TestLoginRejectsInvalidConfigBeforeWriting(t *testing.T) {
 	home := t.TempDir()
 	configPath := filepath.Join(home, "config.yaml")

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -256,7 +256,8 @@ func (a App) doctor(ctx context.Context, args []string) error {
 				record("failed", "coord", err.Error(), nil)
 				ok = false
 			} else {
-				record("ok", "coord", fmt.Sprintf("%s access=%s", cfg.Coordinator, accessAuthState(cfg.Access)), map[string]string{"url": cfg.Coordinator, "access": accessAuthState(cfg.Access)})
+				coordinatorURL := redactedConfigURL(cfg.Coordinator)
+				record("ok", "coord", fmt.Sprintf("%s access=%s", coordinatorURL, accessAuthState(cfg.Access)), map[string]string{"url": coordinatorURL, "access": accessAuthState(cfg.Access)})
 				brokerOK := true
 				if whoami, err := coord.Whoami(ctx); err != nil {
 					class := doctorErrorClass(err)

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -315,7 +315,8 @@ func TestDoctorJSONCoordinatorOutput(t *testing.T) {
 		}
 	}))
 	defer server.Close()
-	t.Setenv("CRABBOX_COORDINATOR", server.URL)
+	brokerURL := strings.Replace(server.URL, "http://", "http://broker-user:broker-password@", 1)
+	t.Setenv("CRABBOX_COORDINATOR", brokerURL)
 	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "token")
 
 	var stdout, stderr bytes.Buffer
@@ -331,10 +332,25 @@ func TestDoctorJSONCoordinatorOutput(t *testing.T) {
 		t.Fatalf("view=%#v", view)
 	}
 	found := false
+	foundCoordinator := false
 	for _, check := range view.Checks {
+		if check.Check == "coord" {
+			foundCoordinator = true
+			if !strings.Contains(check.Message, "http://<redacted>@") || !strings.Contains(check.Details["url"], "http://<redacted>@") {
+				t.Fatalf("coordinator URL was not redacted: %#v", check)
+			}
+			for _, secret := range []string{"broker-user", "broker-password"} {
+				if strings.Contains(check.Message, secret) || strings.Contains(check.Details["url"], secret) {
+					t.Fatalf("coordinator check leaked %q: %#v", secret, check)
+				}
+			}
+		}
 		if check.Check == "provider" && check.Details["provider"] == "aws" && check.Details["coordinator_secrets"] == "ready" {
 			found = true
 		}
+	}
+	if !foundCoordinator {
+		t.Fatalf("coordinator check missing from JSON: %#v", view.Checks)
 	}
 	if !found {
 		t.Fatalf("provider readiness missing from JSON: %#v", view.Checks)


### PR DESCRIPTION
## Summary

- redact broker URL userinfo, query strings, and fragments from successful `login` text/JSON output
- apply the same safe display boundary to `whoami` and `doctor` coordinator diagnostics
- preserve the real configured URL for network requests while preventing credentials from reaching logs or support output

Fixes https://github.com/openclaw/crabbox/issues/875
Fixes https://github.com/openclaw/crabbox/issues/876

## Verification

- `go test -race ./...`
- `go vet ./...`
- focused race regressions for login, whoami, and doctor URL redaction
- autoreview: clean

## E2E behavior proof

The regressions start real HTTP coordinator fixtures and exercise successful login, whoami, health, and provider-readiness flows. Text and JSON outputs retain the safe broker host/path while sentinel usernames, passwords, query secrets, and fragments are absent. This output-only fix needs no external provider resource or persistent credential.
