### PR TITLE
fix(cli): redact Parallels keys in config output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Redacted configured credentials, authorization headers, signed URLs, URL userinfo, and secret-bearing JSON fields before coordinator provider diagnostics are stored or returned. Thanks @coygeek.
 - Redacted broker URL userinfo, queries, and fragments from `login`, `whoami`, and `doctor` text and JSON output. Thanks @coygeek.
+- Redacted Parallels top-level, template, and fleet-host SSH private keys from `config show --json` while preserving non-secret routing metadata. Thanks @coygeek.
 - Required W&B sandbox reuse, status, and stop to match an exact endpoint/entity/project/resource-bound local claim plus provider inventory ownership. Thanks @coygeek.
 - Required RunPod stop to use an exact pod ID/name-bound local claim, with conflict-safe explicit `--reclaim` adoption for unclaimed or legacy pods. Thanks @coygeek.
 - Made coordinatorless generic provider live smokes skip coordinator-only history and always clean up acquired leases after later lifecycle failures.

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -676,15 +676,38 @@ func configShowView(cfg Config) map[string]any {
 			"cloneMode":        cfg.Parallels.CloneMode,
 			"host":             cfg.Parallels.Host,
 			"hostUser":         cfg.Parallels.HostUser,
-			"hostKey":          cfg.Parallels.HostKey,
+			"hostKey":          tokenState(cfg.Parallels.HostKey),
 			"vmRoot":           cfg.Parallels.VMRoot,
 			"user":             cfg.Parallels.User,
 			"workRoot":         cfg.Parallels.WorkRoot,
 			"startupTimeout":   cfg.Parallels.StartupTimeout.String(),
-			"templates":        cfg.Parallels.Templates,
-			"hosts":            cfg.Parallels.Hosts,
+			"templates":        redactedParallelsTemplateConfigs(cfg.Parallels.Templates),
+			"hosts":            redactedParallelsHostConfigs(cfg.Parallels.Hosts),
 		},
 	}
+}
+
+func redactedParallelsTemplateConfigs(templates map[string]ParallelsTemplateConfig) map[string]ParallelsTemplateConfig {
+	if templates == nil {
+		return nil
+	}
+	redacted := make(map[string]ParallelsTemplateConfig, len(templates))
+	for name, template := range templates {
+		template.HostKey = tokenState(template.HostKey)
+		redacted[name] = template
+	}
+	return redacted
+}
+
+func redactedParallelsHostConfigs(hosts []ParallelsHostConfig) []ParallelsHostConfig {
+	if hosts == nil {
+		return nil
+	}
+	redacted := append(make([]ParallelsHostConfig, 0, len(hosts)), hosts...)
+	for i := range redacted {
+		redacted[i].Key = tokenState(redacted[i].Key)
+	}
+	return redacted
 }
 
 func writeConfigShowText(w io.Writer, cfg Config) {

--- a/internal/cli/config_cmd_test.go
+++ b/internal/cli/config_cmd_test.go
@@ -2035,6 +2035,68 @@ func TestConfigShowRedactsAllEndpointURLComponents(t *testing.T) {
 	}
 }
 
+func TestConfigShowRedactsParallelsSSHKeys(t *testing.T) {
+	const (
+		topLevelKey = "top-level-private-key-sentinel"
+		templateKey = "template-private-key-sentinel"
+		hostKey     = "host-private-key-sentinel"
+	)
+	cfg := Config{}
+	cfg.Parallels.HostKey = topLevelKey
+	cfg.Parallels.Templates = map[string]ParallelsTemplateConfig{
+		"macos": {
+			Source:  "macOS Tahoe",
+			Host:    "template-host.example.test",
+			HostKey: templateKey,
+		},
+	}
+	cfg.Parallels.Hosts = []ParallelsHostConfig{{
+		Name: "builder",
+		Host: "builder.example.test",
+		Key:  hostKey,
+	}}
+
+	var text bytes.Buffer
+	writeConfigShowText(&text, cfg)
+	jsonData, err := json.Marshal(configShowView(cfg))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, output := range map[string]string{"text": text.String(), "json": string(jsonData)} {
+		for _, secret := range []string{topLevelKey, templateKey, hostKey} {
+			if strings.Contains(output, secret) {
+				t.Fatalf("%s config output leaked %q: %s", name, secret, output)
+			}
+		}
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(jsonData, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	parallels := decoded["parallels"].(map[string]any)
+	if parallels["hostKey"] != "configured" {
+		t.Fatalf("top-level hostKey=%#v, want configured", parallels["hostKey"])
+	}
+	templates := parallels["templates"].(map[string]any)
+	template := templates["macos"].(map[string]any)
+	if template["HostKey"] != "configured" || template["Source"] != "macOS Tahoe" {
+		t.Fatalf("template view=%#v", template)
+	}
+	hosts := parallels["hosts"].([]any)
+	host := hosts[0].(map[string]any)
+	if host["Key"] != "configured" || host["Host"] != "builder.example.test" {
+		t.Fatalf("host view=%#v", host)
+	}
+
+	if cfg.Parallels.HostKey != topLevelKey || cfg.Parallels.Templates["macos"].HostKey != templateKey || cfg.Parallels.Hosts[0].Key != hostKey {
+		t.Fatal("config-show redaction mutated the effective Parallels config")
+	}
+	if redactedParallelsTemplateConfigs(nil) != nil || redactedParallelsHostConfigs(nil) != nil {
+		t.Fatal("config-show redaction changed nil Parallels collections")
+	}
+}
+
 func TestRoutingSafeURLRedactsUserinfoOnMalformedURL(t *testing.T) {
 	for _, tc := range []struct {
 		name string


### PR DESCRIPTION
## Summary

- redact the top-level Parallels host SSH private key from `config show --json`
- redact named-template and fleet-host private keys without mutating the effective runtime config
- preserve non-secret Parallels routing and template metadata

Fixes https://github.com/openclaw/crabbox/issues/877

## Verification

- `go test -race ./internal/cli -run '^TestConfigShowRedactsParallelsSSHKeys$' -count=3`
- `go test -race ./...`
- `go vet ./...`
- structured autoreview: clean
- live CLI smoke with top-level, template, and fleet-host dummy private-key sentinels: no sentinel appeared; all three JSON fields returned `configured`; routing metadata remained intact

## Configuration / secrets

No new configuration or credentials. This closes an output-redaction gap for existing Parallels SSH key settings.
