### PR TITLE
fix(actions): verify runner archive digests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Redacted configured credentials, authorization headers, signed URLs, URL userinfo, and secret-bearing JSON fields before coordinator provider diagnostics are stored or returned. Thanks @coygeek.
 - Redacted broker URL userinfo, queries, and fragments from `login`, `whoami`, and `doctor` text and JSON output. Thanks @coygeek.
 - Redacted Parallels top-level, template, and fleet-host SSH private keys from `config show --json` while preserving non-secret routing metadata. Thanks @coygeek.
+- Verified downloaded GitHub Actions runner archives against the exact upstream release-asset SHA-256 digest before replacing or extracting the installed runner. Thanks @coygeek.
 - Required W&B sandbox reuse, status, and stop to match an exact endpoint/entity/project/resource-bound local claim plus provider inventory ownership. Thanks @coygeek.
 - Required RunPod stop to use an exact pod ID/name-bound local claim, with conflict-safe explicit `--reclaim` adoption for unclaimed or legacy pods. Thanks @coygeek.
 - Made coordinatorless generic provider live smokes skip coordinator-only history and always clean up acquired leases after later lifecycle failures.

--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -2493,17 +2493,37 @@ if [ "$(id -u)" = 0 ]; then
   export RUNNER_ALLOW_RUNASROOT=1
 fi
 if [ "$version" = latest ]; then
-  version="$(curl -fsSL https://api.github.com/repos/actions/runner/releases/latest | jq -r '.tag_name' | sed 's/^v//')"
+  release_url=https://api.github.com/repos/actions/runner/releases/latest
+else
+  release_url="https://api.github.com/repos/actions/runner/releases/tags/v${version}"
 fi
+release_json="$(curl -fsSL "$release_url")"
+resolved_version="$(jq -er '.tag_name | strings | sub("^v"; "")' <<<"$release_json")"
+if [ "$version" != latest ] && [ "$resolved_version" != "$version" ]; then
+  echo "runner release metadata resolved unexpected version: wanted=$version got=$resolved_version" >&2
+  exit 1
+fi
+version="$resolved_version"
+archive_name="actions-runner-linux-${runner_arch}-${version}.tar.gz"
+expected_sha="$(jq -er --arg name "$archive_name" '.assets[] | select(.name == $name) | .digest | strings | select(test("^sha256:[0-9a-fA-F]{64}$")) | sub("^sha256:"; "") | ascii_downcase' <<<"$release_json")"
 runner_dir="$HOME/actions-runner"
 mkdir -p "$runner_dir"
 cd "$runner_dir"
-if [ ! -x ./config.sh ] || [ ! -f ".crabbox-runner-version-$version-$runner_arch" ]; then
+version_marker=".crabbox-runner-version-$version-$runner_arch-sha256-$expected_sha"
+if [ ! -x ./config.sh ] || [ ! -f "$version_marker" ]; then
+  archive="$(mktemp "${TMPDIR:-/tmp}/crabbox-actions-runner.XXXXXX.tar.gz")"
+  trap 'rm -f "$archive"' EXIT
+  curl -fsSL -o "$archive" "https://github.com/actions/runner/releases/download/v${version}/${archive_name}"
+  actual_sha="$(sha256sum "$archive" | cut -d' ' -f1 | tr '[:upper:]' '[:lower:]')"
+  if [ "$actual_sha" != "$expected_sha" ]; then
+    echo "runner archive checksum mismatch: expected=$expected_sha actual=$actual_sha" >&2
+    exit 1
+  fi
   rm -rf ./*
-  curl -fsSL -o actions-runner.tar.gz "https://github.com/actions/runner/releases/download/v${version}/actions-runner-linux-${runner_arch}-${version}.tar.gz"
-  tar xzf actions-runner.tar.gz
-  rm actions-runner.tar.gz
-  touch ".crabbox-runner-version-$version-$runner_arch"
+  tar xzf "$archive"
+  rm -f "$archive"
+  trap - EXIT
+  touch "$version_marker"
 fi
 if [ -f .runner ]; then
   ./config.sh remove --unattended --token "$RUNNER_TOKEN" || true
@@ -2621,20 +2641,44 @@ switch -Regex ($arch) {
   default { throw "unsupported runner arch: $arch" }
 }
 if ($version -eq "latest") {
-  $release = Invoke-RestMethod -Uri "https://api.github.com/repos/actions/runner/releases/latest" -UseBasicParsing
-  $version = ($release.tag_name -replace "^v", "")
+  $releaseUri = "https://api.github.com/repos/actions/runner/releases/latest"
+} else {
+  $releaseUri = "https://api.github.com/repos/actions/runner/releases/tags/v$version"
 }
+$release = Invoke-RestMethod -Uri $releaseUri -UseBasicParsing
+$resolvedVersion = ($release.tag_name -replace "^v", "")
+if ($version -ne "latest" -and $resolvedVersion -ne $version) {
+  throw "runner release metadata resolved unexpected version: wanted=$version got=$resolvedVersion"
+}
+$version = $resolvedVersion
+$archiveName = "actions-runner-win-$runnerArch-$version.zip"
+$asset = @($release.assets | Where-Object { $_.name -eq $archiveName })
+if ($asset.Count -ne 1) {
+  throw "runner release metadata has no unique asset named $archiveName"
+}
+$digestMatch = [Regex]::Match([string]$asset[0].digest, "^sha256:(?<sha>[0-9a-fA-F]{64})$")
+if (-not $digestMatch.Success) {
+  throw "runner release asset has no valid SHA-256 digest for $archiveName"
+}
+$expectedSha = $digestMatch.Groups["sha"].Value.ToLowerInvariant()
 $runnerDir = Join-Path $HOME "actions-runner"
 New-Item -ItemType Directory -Force -Path $runnerDir | Out-Null
 Set-Location -LiteralPath $runnerDir
-$versionMarker = ".crabbox-runner-version-$version-$runnerArch"
+$versionMarker = ".crabbox-runner-version-$version-$runnerArch-sha256-$expectedSha"
 if (-not (Test-Path -LiteralPath ".\config.cmd") -or -not (Test-Path -LiteralPath $versionMarker)) {
-  Get-ChildItem -Force -LiteralPath $runnerDir | Remove-Item -Recurse -Force
-  $zip = Join-Path $runnerDir "actions-runner.zip"
-  Invoke-WebRequest -Uri "https://github.com/actions/runner/releases/download/v$version/actions-runner-win-$runnerArch-$version.zip" -OutFile $zip -UseBasicParsing
-  Expand-Archive -LiteralPath $zip -DestinationPath $runnerDir -Force
-  Remove-Item -LiteralPath $zip -Force
-  New-Item -ItemType File -Path $versionMarker -Force | Out-Null
+  $zip = Join-Path ([IO.Path]::GetTempPath()) ("crabbox-actions-runner-" + [Guid]::NewGuid().ToString("N") + ".zip")
+  try {
+    Invoke-WebRequest -Uri "https://github.com/actions/runner/releases/download/v$version/$archiveName" -OutFile $zip -UseBasicParsing
+    $actualSha = (Get-FileHash -LiteralPath $zip -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($actualSha -ne $expectedSha) {
+      throw "runner archive checksum mismatch: expected=$expectedSha actual=$actualSha"
+    }
+    Get-ChildItem -Force -LiteralPath $runnerDir | Remove-Item -Recurse -Force
+    Expand-Archive -LiteralPath $zip -DestinationPath $runnerDir -Force
+    New-Item -ItemType File -Path $versionMarker -Force | Out-Null
+  } finally {
+    Remove-Item -LiteralPath $zip -Force -ErrorAction SilentlyContinue
+  }
 }
 if (Test-Path -LiteralPath ".\.runner") {
   & .\config.cmd remove --unattended --token $env:RUNNER_TOKEN

--- a/internal/cli/actions_test.go
+++ b/internal/cli/actions_test.go
@@ -146,7 +146,11 @@ func TestGitHubActionsRunnerInstallScriptUsesOfficialRunner(t *testing.T) {
 	got := githubActionsRunnerInstallScript("latest", true)
 	for _, want := range []string{
 		"https://api.github.com/repos/actions/runner/releases/latest",
+		"https://api.github.com/repos/actions/runner/releases/tags/v${version}",
 		"https://github.com/actions/runner/releases/download/",
+		".assets[] | select(.name == $name) | .digest",
+		"sha256sum \"$archive\"",
+		"runner archive checksum mismatch",
 		"RUNNER_ALLOW_RUNASROOT=1",
 		"grep -qi microsoft /proc/version",
 		"sudo rm -rf /var/lib/apt/lists/*",
@@ -160,13 +164,24 @@ func TestGitHubActionsRunnerInstallScriptUsesOfficialRunner(t *testing.T) {
 			t.Fatalf("install script missing %q", want)
 		}
 	}
+	checksum := strings.Index(got, "actual_sha=")
+	clearRunner := strings.Index(got, "rm -rf ./*")
+	extract := strings.Index(got, "tar xzf")
+	if checksum < 0 || clearRunner < checksum || extract < clearRunner {
+		t.Fatalf("runner installer must verify checksum before replacing/extracting: checksum=%d clear=%d extract=%d", checksum, clearRunner, extract)
+	}
 }
 
 func TestGitHubActionsRunnerInstallPowerShellScriptUsesOfficialWindowsRunner(t *testing.T) {
 	got := githubActionsRunnerInstallScriptForTarget("latest", true, SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeNormal})
 	for _, want := range []string{
 		"https://api.github.com/repos/actions/runner/releases/latest",
+		"https://api.github.com/repos/actions/runner/releases/tags/v$version",
 		"actions-runner-win-$runnerArch-$version.zip",
+		"$release.assets | Where-Object { $_.name -eq $archiveName }",
+		"^sha256:(?<sha>[0-9a-fA-F]{64})$",
+		"Get-FileHash -LiteralPath $zip -Algorithm SHA256",
+		"runner archive checksum mismatch",
 		".\\config.cmd",
 		"--ephemeral",
 		"New-ScheduledTaskAction",
@@ -178,6 +193,68 @@ func TestGitHubActionsRunnerInstallPowerShellScriptUsesOfficialWindowsRunner(t *
 		if !strings.Contains(got, want) {
 			t.Fatalf("windows install script missing %q", want)
 		}
+	}
+	checksum := strings.Index(got, "Get-FileHash")
+	clearRunner := strings.Index(got, "Get-ChildItem -Force -LiteralPath $runnerDir | Remove-Item")
+	extract := strings.Index(got, "Expand-Archive")
+	if checksum < 0 || clearRunner < checksum || extract < clearRunner {
+		t.Fatalf("Windows runner installer must verify checksum before replacing/extracting: checksum=%d clear=%d extract=%d", checksum, clearRunner, extract)
+	}
+}
+
+func TestGitHubActionsRunnerInstallScriptRejectsChecksumMismatchBeforeExtraction(t *testing.T) {
+	root := t.TempDir()
+	binDir := filepath.Join(root, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	commands := map[string]string{
+		"curl": `#!/bin/sh
+out=
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-o" ]; then shift; out="$1"; fi
+  shift
+done
+if [ -n "$out" ]; then printf archive >"$out"; else printf '{}'; fi
+`,
+		"jq": `#!/bin/sh
+case "$*" in
+  *tag_name*) printf '2.335.1' ;;
+  *digest*) printf 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' ;;
+  *) exit 2 ;;
+esac
+`,
+		"sha256sum": `#!/bin/sh
+printf 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  %s\n' "$1"
+`,
+		"tar": `#!/bin/sh
+touch "$TAR_CALLED"
+exit 99
+`,
+	}
+	for name, script := range commands {
+		commandPath := filepath.Join(binDir, name)
+		if err := os.WriteFile(commandPath, []byte(script), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	tarCalled := filepath.Join(root, "tar-called")
+	cmd := exec.Command("bash", "-c", githubActionsRunnerInstallScript("2.335.1", true))
+	cmd.Env = append(os.Environ(),
+		"HOME="+root,
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"RUNNER_REPO=example-org/my-app",
+		"RUNNER_NAME=test-runner",
+		"RUNNER_TOKEN=test-token",
+		"RUNNER_LABELS=test",
+		"TAR_CALLED="+tarCalled,
+	)
+	output, err := cmd.CombinedOutput()
+	if err == nil || !strings.Contains(string(output), "runner archive checksum mismatch") {
+		t.Fatalf("install err=%v output=%q, want checksum rejection", err, output)
+	}
+	if _, err := os.Stat(tarCalled); !os.IsNotExist(err) {
+		t.Fatalf("archive extraction ran before checksum rejection: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- resolve the exact GitHub Actions runner release and select the matching platform asset metadata
- require the asset's official `sha256:` digest and verify the downloaded archive before replacing or extracting the installed runner
- fail closed on missing, malformed, or mismatched digests on Linux and Windows
- preserve an existing runner install when verification fails and bind the cache marker to the verified digest

Fixes https://github.com/openclaw/crabbox/issues/879

## Verification

- `go test -race ./internal/cli -run 'TestGitHubActionsRunnerInstall' -count=3`
- `go test -race ./...`
- `go vet ./...`
- structured autoreview: clean after the final rebase
- Linux live proof: generated exact-candidate installer downloaded the real `actions/runner` 2.335.1 ARM64 archive, matched GitHub asset digest `sha256:6d1e85bfd1a506a8b17c1f1b9b57dba458ffed90898799aaa9f599520b0d9207`, extracted successfully, created a digest-bound marker, and removed the temporary archive
- Windows live proof: disposable Parallels Windows 11 clone `cbx_256288e07d70` downloaded the real 2.335.1 x64 archive, matched GitHub asset digest `sha256:eb65c95277af42bcf3778a799c41359d224ba2a67b4de26b7cea1729b09c803d`, extracted, registered an online ephemeral repository runner, and created the digest-bound marker
- cleanup proof: the Windows VM clone, local lease claim, repository runner record, and temporary archives were all removed; post-cleanup provider and runner queries returned zero matching resources

## Configuration / secrets

No new credentials or persistent configuration. Existing `latest` and explicit-version behavior remains, but every selected release must now expose one exact valid GitHub asset digest.
