### PR TITLE
fix(proxmox): redact credentials from API errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Redacted configured credentials, authorization headers, signed URLs, URL userinfo, and secret-bearing JSON fields before coordinator provider diagnostics are stored or returned. Thanks @coygeek.
 - Redacted broker URL userinfo, queries, and fragments from `login`, `whoami`, and `doctor` text and JSON output. Thanks @coygeek.
 - Redacted Parallels top-level, template, and fleet-host SSH private keys from `config show --json` while preserving non-secret routing metadata. Thanks @coygeek.
+- Redacted Proxmox token IDs, secrets, and authorization values from provider HTTP error bodies before returning diagnostics. Thanks @coygeek.
 - Verified downloaded GitHub Actions runner archives against the exact upstream release-asset SHA-256 digest before replacing or extracting the installed runner. Thanks @coygeek.
 - Required W&B sandbox reuse, status, and stop to match an exact endpoint/entity/project/resource-bound local claim plus provider inventory ownership. Thanks @coygeek.
 - Required RunPod stop to use an exact pod ID/name-bound local claim, with conflict-safe explicit `--reclaim` adoption for unclaimed or legacy pods. Thanks @coygeek.

--- a/internal/cli/proxmox.go
+++ b/internal/cli/proxmox.go
@@ -36,7 +36,7 @@ type ProxmoxReadinessCheck struct {
 var (
 	proxmoxRunSSHQuietWithOptions = runSSHQuietWithOptions
 	proxmoxRunSSHInputQuiet       = runSSHInputQuiet
-	proxmoxAPITokenPattern        = regexp.MustCompile(`PVEAPIToken=[^[:space:]]+`)
+	proxmoxAPITokenPattern        = regexp.MustCompile(`PVEAPIToken=[A-Za-z0-9@._!%+=:/~-]+`)
 )
 
 type ProxmoxError struct {
@@ -130,7 +130,7 @@ func (c *ProxmoxClient) doEnvelope(ctx context.Context, method, path string, for
 		return err
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return &ProxmoxError{Method: method, Path: path, StatusCode: resp.StatusCode, Body: summarizeJSON(data)}
+		return &ProxmoxError{Method: method, Path: path, StatusCode: resp.StatusCode, Body: summarizeJSON([]byte(c.redactErrorBody(string(data))))}
 	}
 	if out == nil {
 		return nil
@@ -148,6 +148,19 @@ func (c *ProxmoxClient) doEnvelope(ctx context.Context, method, path string, for
 		return fmt.Errorf("proxmox %s %s: missing required data in response", method, path)
 	}
 	return json.Unmarshal(envelope.Data, out)
+}
+
+func (c *ProxmoxClient) redactErrorBody(body string) string {
+	redacted := body
+	if strings.TrimSpace(c.TokenID) != "" && strings.TrimSpace(c.TokenSecret) != "" {
+		redacted = strings.ReplaceAll(redacted, "PVEAPIToken="+c.TokenID+"="+c.TokenSecret, "PVEAPIToken=<redacted>")
+	}
+	for _, secret := range []string{c.TokenID, c.TokenSecret} {
+		if strings.TrimSpace(secret) != "" {
+			redacted = strings.ReplaceAll(redacted, secret, "<redacted>")
+		}
+	}
+	return proxmoxAPITokenPattern.ReplaceAllString(redacted, "PVEAPIToken=<redacted>")
 }
 
 type proxmoxStorage struct {

--- a/internal/cli/proxmox_test.go
+++ b/internal/cli/proxmox_test.go
@@ -58,6 +58,57 @@ func TestNewProxmoxClientStripsAPIPathAndUsesTokenAuth(t *testing.T) {
 	}
 }
 
+func TestProxmoxClientRedactsCredentialsFromHTTPErrorBody(t *testing.T) {
+	const (
+		tokenID     = "runner@pve!crabbox"
+		tokenSecret = "super-secret-token"
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authorization := r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusUnauthorized)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"authorization": authorization,
+			"message":       "permission denied for " + tokenID,
+			"token_secret":  tokenSecret,
+		})
+	}))
+	defer server.Close()
+
+	cfg := baseConfig()
+	cfg.Proxmox.APIURL = server.URL
+	cfg.Proxmox.TokenID = tokenID
+	cfg.Proxmox.TokenSecret = tokenSecret
+	cfg.Proxmox.Node = "pve1"
+	client, err := NewProxmoxClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.nextID(context.Background())
+	if err == nil {
+		t.Fatal("nextID succeeded, want HTTP error")
+	}
+	text := err.Error()
+	for _, secret := range []string{tokenID, tokenSecret, "PVEAPIToken=" + tokenID + "=" + tokenSecret} {
+		if strings.Contains(text, secret) {
+			t.Fatalf("Proxmox HTTP error leaked %q: %s", secret, text)
+		}
+	}
+	if !strings.Contains(text, "permission denied for") || !strings.Contains(text, "redacted") {
+		t.Fatalf("Proxmox HTTP error lost useful redacted context: %s", text)
+	}
+	var apiErr *ProxmoxError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error type=%T, want *ProxmoxError", err)
+	}
+	var payload map[string]string
+	if err := json.Unmarshal([]byte(apiErr.Body), &payload); err != nil {
+		t.Fatalf("redacted error body is not valid JSON: %v: %s", err, apiErr.Body)
+	}
+	if payload["authorization"] != "PVEAPIToken=<redacted>" || payload["message"] != "permission denied for <redacted>" || payload["token_secret"] != "<redacted>" {
+		t.Fatalf("redacted error payload=%#v", payload)
+	}
+}
+
 func TestProxmoxDoctorReadinessChecksNonMutatingPrerequisites(t *testing.T) {
 	var calls []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

- redact configured Proxmox token IDs and token secrets before non-success API response bodies reach `ProxmoxError`
- recognize and redact complete `PVEAPIToken` authorization values while preserving valid JSON and useful provider context
- cover the normal non-doctor client path with a real loopback HTTP server that reflects every credential form

Fixes https://github.com/openclaw/crabbox/issues/885

## Verification

- `go test -race ./internal/cli -run 'TestProxmox' -count=1`
- `go test -race ./internal/cli -run 'TestProxmox(ClientRedactsCredentialsFromHTTPErrorBody|SafeError|CreateServerFlow|NewProxmoxClient)' -count=3`
- `go vet ./...`
- uncommitted autoreview: clean
- exact PR-head Linux proof: cloned `pull/888/head`, asserted and printed `proof_head=2781e302d34fa8c53b9fe4599225dfde1e051941`, then ran `go test -race ./internal/cli -run TestProxmoxClientRedactsCredentialsFromHTTPErrorBody -count=3`
- exact-head proof provider: `blacksmith-testbox`; lease: `tbx_01kwqsr93ajq2mjp1wsce1pywx`; run: https://github.com/openclaw/crabbox/actions/runs/28723982259; exit 0; one-shot Testbox stopped after success

## Security

Redaction occurs before JSON summarization so truncation cannot leave partial configured credentials behind. No real Proxmox credential was used in testing; the regression uses synthetic values and a loopback HTTP endpoint.
