### PR TITLE
fix(worker): reject malformed portal cookies safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Redacted broker URL userinfo, queries, and fragments from `login`, `whoami`, and `doctor` text and JSON output. Thanks @coygeek.
 - Redacted Parallels top-level, template, and fleet-host SSH private keys from `config show --json` while preserving non-secret routing metadata. Thanks @coygeek.
 - Redacted Proxmox token IDs, secrets, and authorization values from provider HTTP error bodies before returning diagnostics. Thanks @coygeek.
+- Treated malformed percent-encoded portal cookies as absent instead of throwing before normal authentication handling. Thanks @coygeek.
 - Verified downloaded GitHub Actions runner archives against the exact upstream release-asset SHA-256 digest before replacing or extracting the installed runner. Thanks @coygeek.
 - Required W&B sandbox reuse, status, and stop to match an exact endpoint/entity/project/resource-bound local claim plus provider inventory ownership. Thanks @coygeek.
 - Required RunPod stop to use an exact pod ID/name-bound local claim, with conflict-safe explicit `--reclaim` adoption for unclaimed or legacy pods. Thanks @coygeek.

--- a/worker/src/cookies.ts
+++ b/worker/src/cookies.ts
@@ -1,0 +1,13 @@
+export function cookieValue(header: string, name: string): string {
+  for (const part of header.split(";")) {
+    const [key, ...value] = part.trim().split("=");
+    if (key === name) {
+      try {
+        return decodeURIComponent(value.join("="));
+      } catch {
+        return "";
+      }
+    }
+  }
+  return "";
+}

--- a/worker/src/coordinator-entry.ts
+++ b/worker/src/coordinator-entry.ts
@@ -7,6 +7,7 @@ import {
   type AuthRequestContext,
 } from "./auth";
 import { codeProxyRequestBodyBytes, isIsolatedCodeRequest } from "./code-origin";
+import { cookieValue } from "./cookies";
 import { bearerToken, json, pathParts } from "./http";
 import { runtimeAdapterProxyPath, runtimeAdapterRelayMethodAllowed } from "./runtime-adapter-relay";
 import { timingSafeEqual } from "./timing-safe";
@@ -239,14 +240,4 @@ function requestWithPortalCookie(request: Request): Request {
   const headers = new Headers(request.headers);
   headers.set("authorization", `Bearer ${token}`);
   return new Request(request, { headers });
-}
-
-function cookieValue(header: string, name: string): string {
-  for (const part of header.split(";")) {
-    const [rawKey, ...rawValue] = part.trim().split("=");
-    if (rawKey === name) {
-      return decodeURIComponent(rawValue.join("="));
-    }
-  }
-  return "";
 }

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -40,6 +40,7 @@ import {
   type LeaseConfig,
   type LeaseConfigDefaults,
 } from "./config";
+import { cookieValue } from "./cookies";
 import {
   CloudflareCoordinatorRuntime,
   bufferCoordinatorRequestBody,
@@ -13825,20 +13826,6 @@ function isolatedCodeRequestOriginAllowed(request: Request): boolean {
     (method === "GET" && request.headers.get("upgrade")?.toLowerCase() !== "websocket") ||
     method === "HEAD"
   );
-}
-
-function cookieValue(header: string, name: string): string {
-  for (const part of header.split(";")) {
-    const [key, ...value] = part.trim().split("=");
-    if (key === name) {
-      try {
-        return decodeURIComponent(value.join("="));
-      } catch {
-        return "";
-      }
-    }
-  }
-  return "";
 }
 
 function codeViewerSessionCookie(session: CodeViewerSessionRecord, maxAgeSeconds: number): string {

--- a/worker/test/http.test.ts
+++ b/worker/test/http.test.ts
@@ -92,6 +92,41 @@ describe("coordinator auth", () => {
     }
   });
 
+  it("treats malformed portal cookies as absent across request types", async () => {
+    const env = {
+      CRABBOX_SESSION_SECRET: "session-secret",
+      CRABBOX_PUBLIC_URL: "https://broker.example.test",
+    } as Env;
+    const cookie = "crabbox_session=%ZZ";
+
+    const portalGet = await prepareCoordinatorRequest(
+      new Request("https://broker.example.test/portal?provider=aws", { headers: { cookie } }),
+      env,
+    );
+    expect(portalGet).toMatchObject({ authenticated: false, response: { status: 302 } });
+    if (!("response" in portalGet)) throw new Error("malformed portal cookie authenticated");
+    expect(portalGet.response.headers.get("location")).toBe(
+      "/portal/login?returnTo=%2Fportal%3Fprovider%3Daws",
+    );
+
+    const unauthorized = await Promise.all(
+      [
+        new Request("https://broker.example.test/portal/leases/blue-lobster/share", {
+          method: "POST",
+          headers: { cookie, origin: "https://attacker.example" },
+        }),
+        new Request("https://broker.example.test/v1/pool", { headers: { cookie } }),
+      ].map((request) => prepareCoordinatorRequest(request, env)),
+    );
+    await Promise.all(
+      unauthorized.map(async (prepared) => {
+        expect(prepared).toMatchObject({ authenticated: false, response: { status: 401 } });
+        if (!("response" in prepared)) throw new Error("malformed portal cookie authenticated");
+        await expect(prepared.response.json()).resolves.toEqual({ error: "unauthorized" });
+      }),
+    );
+  });
+
   it("routes only the exact per-lease Code origin without portal-cookie authority", async () => {
     const env = {
       CRABBOX_CODE_ORIGIN_TEMPLATE: "https://{lease}.code.example.test",


### PR DESCRIPTION
## Summary

- move coordinator and fleet cookie parsing to one shared decoder that treats malformed percent-encoding as an absent cookie
- preserve the existing valid-cookie behavior without catching unrelated request failures at the Worker entrypoint
- cover portal GET, unsafe portal mutation, and API-style unauthenticated request paths

Fixes https://github.com/openclaw/crabbox/issues/868

## Verification

- `npm test --prefix worker -- --run test/http.test.ts`
- `npm test --prefix worker` — 26 files, 794 tests
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm run build --prefix worker`
- uncommitted autoreview: clean
- local Wrangler HTTP smoke with `Cookie: crabbox_session=%ZZ`: `GET /portal?provider=aws` returned 302 to `/portal/login?returnTo=%2Fportal%3Fprovider%3Daws`; `POST /portal/leases/blue-lobster/share` returned 401 `{"error":"unauthorized"}`; `GET /v1/pool` returned 401 `{"error":"unauthorized"}`; no 500s or thrown decoder errors
- exact PR-head Linux proof: cloned `pull/889/head`, asserted and printed `proof_head=3154644a9e7d147e7adc716898d652a14ed9fb19`, installed the locked Worker dependencies, then passed all 41 `worker/test/http.test.ts` tests
- exact-head proof provider: `blacksmith-testbox`; lease: `tbx_01kwqtkp0qd75jagc6sk9wk39f`; run: https://github.com/openclaw/crabbox/actions/runs/28724301726; exit 0; one-shot Testbox stopped after success

## Security

Malformed session cookies receive exactly the same authority as missing cookies. No authentication, mutation, or API request proceeds with cookie-derived credentials.
