### PR TITLE
fix(fastapi-cloud): block cross-origin token redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Redacted broker URL userinfo, queries, and fragments from `login`, `whoami`, and `doctor` text and JSON output. Thanks @coygeek.
 - Redacted Parallels top-level, template, and fleet-host SSH private keys from `config show --json` while preserving non-secret routing metadata. Thanks @coygeek.
 - Redacted Proxmox token IDs, secrets, and authorization values from provider HTTP error bodies before returning diagnostics. Thanks @coygeek.
+- Prevented FastAPI Cloud bearer credentials from following cross-origin redirects, preserved caller redirect policies, and rejected unsafe credential-destination URL components. Thanks @coygeek.
 - Treated malformed percent-encoded portal cookies as absent instead of throwing before normal authentication handling. Thanks @coygeek.
 - Verified downloaded GitHub Actions runner archives against the exact upstream release-asset SHA-256 digest before replacing or extracting the installed runner. Thanks @coygeek.
 - Required W&B sandbox reuse, status, and stop to match an exact endpoint/entity/project/resource-bound local claim plus provider inventory ownership. Thanks @coygeek.

--- a/internal/providers/fastapicloud/backend_test.go
+++ b/internal/providers/fastapicloud/backend_test.go
@@ -45,6 +45,30 @@ func TestFastAPICloudClientRejectsBareHTTPURL(t *testing.T) {
 	}
 }
 
+func TestFastAPICloudClientRejectsUnsafeAPIURLComponents(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		apiURL string
+		secret string
+	}{
+		{name: "userinfo", apiURL: "https://user:url-secret@api.fastapicloud.com/api/v1", secret: "url-secret"},
+		{name: "query", apiURL: "https://api.fastapicloud.com/api/v1?token=query-secret", secret: "query-secret"},
+		{name: "empty query", apiURL: "https://api.fastapicloud.com/api/v1?"},
+		{name: "fragment", apiURL: "https://api.fastapicloud.com/api/v1#fragment-secret", secret: "fragment-secret"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := Config{FastAPICloud: FastAPICloudConfig{Token: "test-token", APIURL: test.apiURL}}
+			_, err := newFastAPICloudClient(cfg, Runtime{})
+			if err == nil || !strings.Contains(err.Error(), "must not contain userinfo, query parameters, or a fragment") {
+				t.Fatalf("newFastAPICloudClient error = %v, want unsafe URL rejection", err)
+			}
+			if test.secret != "" && strings.Contains(err.Error(), test.secret) {
+				t.Fatalf("newFastAPICloudClient error leaked URL secret: %v", err)
+			}
+		})
+	}
+}
+
 func TestFastAPICloudTokenFlagIsNotRegistered(t *testing.T) {
 	cfg := Config{}
 	cfg.FastAPICloud.Token = "secret-token"
@@ -138,6 +162,97 @@ func TestFastAPICloudClientSendsBearerAndUsesRESTPaths(t *testing.T) {
 	}
 	if len(got) != 3 {
 		t.Fatalf("got paths = %#v, want 3 requests", got)
+	}
+}
+
+func TestFastAPICloudClientRefusesCrossOriginRedirectBeforeReplay(t *testing.T) {
+	targetRequests := 0
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		targetRequests++
+		t.Errorf("redirect target received %s %s auth=%q", r.Method, r.URL.Path, r.Header.Get("Authorization"))
+	}))
+	defer target.Close()
+	trusted := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/stolen?token=redirect-secret#fragment-secret", http.StatusTemporaryRedirect)
+	}))
+	defer trusted.Close()
+
+	api, err := newFastAPICloudClient(
+		Config{FastAPICloud: FastAPICloudConfig{Token: "test-token", APIURL: trusted.URL}},
+		Runtime{HTTP: trusted.Client()},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = api.GetApp(context.Background(), "app-1")
+	if err == nil || !strings.Contains(err.Error(), "refused cross-origin redirect") {
+		t.Fatalf("GetApp error = %v, want cross-origin refusal", err)
+	}
+	for _, secret := range []string{"redirect-secret", "fragment-secret"} {
+		if strings.Contains(err.Error(), secret) {
+			t.Fatalf("GetApp error leaked redirect URL secret %q: %v", secret, err)
+		}
+	}
+	if targetRequests != 0 {
+		t.Fatalf("redirect target received %d requests, want 0", targetRequests)
+	}
+}
+
+func TestFastAPICloudClientFollowsSameOriginRedirect(t *testing.T) {
+	var redirectedAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/apps/app-1":
+			http.Redirect(w, r, "/redirected", http.StatusTemporaryRedirect)
+		case "/redirected":
+			redirectedAuth = r.Header.Get("Authorization")
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(fastAPICloudApp{ID: "app-1"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	api, err := newFastAPICloudClient(
+		Config{FastAPICloud: FastAPICloudConfig{Token: "test-token", APIURL: server.URL + "/api/v1"}},
+		Runtime{HTTP: server.Client()},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	app, err := api.GetApp(context.Background(), "app-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if app.ID != "app-1" || redirectedAuth != "Bearer test-token" {
+		t.Fatalf("app=%#v auth=%q, want app-1 with bearer token", app, redirectedAuth)
+	}
+}
+
+func TestFastAPICloudClientPreservesCallerRedirectPolicy(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/redirected", http.StatusFound)
+	}))
+	defer server.Close()
+	callerErr := errors.New("caller refused redirect")
+	callerChecks := 0
+	httpClient := server.Client()
+	httpClient.CheckRedirect = func(*http.Request, []*http.Request) error {
+		callerChecks++
+		return callerErr
+	}
+	api, err := newFastAPICloudClient(
+		Config{FastAPICloud: FastAPICloudConfig{Token: "test-token", APIURL: server.URL}},
+		Runtime{HTTP: httpClient},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = api.GetApp(context.Background(), "app-1")
+	if !errors.Is(err, callerErr) || callerChecks != 1 {
+		t.Fatalf("GetApp error = %v, caller checks = %d", err, callerChecks)
 	}
 }
 
@@ -551,18 +666,21 @@ func TestFastAPICloudClientLoopbackHTTPAccepted(t *testing.T) {
 }
 
 func TestFastAPICloudClientLoopbackSpoofRejected(t *testing.T) {
-	for _, u := range []string{
-		"http://localhost@evil.com/api/v1",
-		"http://127.0.0.1.evil.com/api/v1",
-		"http://localhost.evil.com/api/v1",
-		"http://0x7f000001/api/v1",
+	for _, test := range []struct {
+		apiURL string
+		want   string
+	}{
+		{apiURL: "http://localhost@evil.com/api/v1", want: "must not contain userinfo"},
+		{apiURL: "http://127.0.0.1.evil.com/api/v1", want: "must use HTTPS"},
+		{apiURL: "http://localhost.evil.com/api/v1", want: "must use HTTPS"},
+		{apiURL: "http://0x7f000001/api/v1", want: "must use HTTPS"},
 	} {
 		cfg := Config{}
 		cfg.FastAPICloud.Token = "t"
-		cfg.FastAPICloud.APIURL = u
+		cfg.FastAPICloud.APIURL = test.apiURL
 		_, err := newFastAPICloudClient(cfg, Runtime{})
-		if err == nil || !strings.Contains(err.Error(), "must use https") {
-			t.Fatalf("spoofed loopback %q: err = %v, want https rejection", u, err)
+		if err == nil || !strings.Contains(err.Error(), test.want) {
+			t.Fatalf("spoofed loopback %q: err = %v, want %q", test.apiURL, err, test.want)
 		}
 	}
 }
@@ -573,8 +691,8 @@ func TestFastAPICloudClientInvalidURL(t *testing.T) {
 		cfg.FastAPICloud.Token = "t"
 		cfg.FastAPICloud.APIURL = u
 		_, err := newFastAPICloudClient(cfg, Runtime{})
-		if err == nil || !strings.Contains(err.Error(), "is invalid") {
-			t.Fatalf("invalid url %q: err = %v, want invalid", u, err)
+		if err == nil || !strings.Contains(err.Error(), "must be an absolute HTTPS URL") {
+			t.Fatalf("invalid url %q: err = %v, want absolute HTTPS URL rejection", u, err)
 		}
 	}
 }

--- a/internal/providers/fastapicloud/client.go
+++ b/internal/providers/fastapicloud/client.go
@@ -3,6 +3,7 @@ package fastapicloud
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -131,19 +132,86 @@ func newFastAPICloudClient(cfg Config, rt Runtime) (fastAPICloudAPI, error) {
 	if token == "" {
 		return nil, exit(2, "provider=%s requires FASTAPI_CLOUD_TOKEN", providerName)
 	}
-	apiURL := strings.TrimRight(strings.TrimSpace(blank(cfg.FastAPICloud.APIURL, "https://api.fastapicloud.com/api/v1")), "/")
-	parsed, err := url.Parse(apiURL)
-	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
-		return nil, exit(2, "%s url %q is invalid", providerName, apiURL)
-	}
-	if parsed.Scheme != "https" && !isLoopbackHTTPURL(parsed) {
-		return nil, exit(2, "%s url %q must use https unless it targets localhost", providerName, apiURL)
+	apiURL, err := validateFastAPICloudAPIURL(blank(cfg.FastAPICloud.APIURL, "https://api.fastapicloud.com/api/v1"))
+	if err != nil {
+		return nil, err
 	}
 	httpClient := rt.HTTP
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
-	return &fastAPICloudClient{token: token, apiURL: apiURL, httpClient: httpClient}, nil
+	return &fastAPICloudClient{token: token, apiURL: apiURL, httpClient: secureFastAPICloudHTTPClient(httpClient, apiURL)}, nil
+}
+
+func validateFastAPICloudAPIURL(raw string) (string, error) {
+	apiURL := strings.TrimRight(strings.TrimSpace(raw), "/")
+	parsed, err := url.Parse(apiURL)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" || parsed.Opaque != "" {
+		return "", exit(2, "provider=%s API URL must be an absolute HTTPS URL", providerName)
+	}
+	if parsed.User != nil || parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
+		return "", exit(2, "provider=%s API URL must not contain userinfo, query parameters, or a fragment", providerName)
+	}
+	parsed.Scheme = strings.ToLower(parsed.Scheme)
+	if parsed.Scheme != "https" && !isLoopbackHTTPURL(parsed) {
+		return "", exit(2, "provider=%s API URL must use HTTPS except for loopback development endpoints", providerName)
+	}
+	return apiURL, nil
+}
+
+func secureFastAPICloudHTTPClient(source *http.Client, apiURL string) *http.Client {
+	client := *source
+	trusted, _ := url.Parse(apiURL)
+	originalCheckRedirect := source.CheckRedirect
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if !sameFastAPICloudOrigin(trusted, req.URL) {
+			return &fastAPICloudRedirectError{origin: fastAPICloudRedirectOrigin(req.URL)}
+		}
+		if originalCheckRedirect != nil {
+			return originalCheckRedirect(req, via)
+		}
+		if len(via) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+		return nil
+	}
+	return &client
+}
+
+func sameFastAPICloudOrigin(a, b *url.URL) bool {
+	return a != nil && b != nil &&
+		strings.EqualFold(a.Scheme, b.Scheme) &&
+		strings.EqualFold(a.Hostname(), b.Hostname()) &&
+		effectiveFastAPICloudPort(a) == effectiveFastAPICloudPort(b)
+}
+
+func effectiveFastAPICloudPort(value *url.URL) string {
+	if port := value.Port(); port != "" {
+		return port
+	}
+	switch strings.ToLower(value.Scheme) {
+	case "https":
+		return "443"
+	case "http":
+		return "80"
+	default:
+		return ""
+	}
+}
+
+type fastAPICloudRedirectError struct {
+	origin string
+}
+
+func (e *fastAPICloudRedirectError) Error() string {
+	return fmt.Sprintf("%s refused cross-origin redirect to %s", providerName, e.origin)
+}
+
+func fastAPICloudRedirectOrigin(value *url.URL) string {
+	if value == nil || value.Scheme == "" || value.Host == "" {
+		return "<redacted>"
+	}
+	return value.Scheme + "://" + value.Host
 }
 
 func (c *fastAPICloudClient) GetApp(ctx context.Context, appID string) (fastAPICloudApp, error) {
@@ -244,6 +312,11 @@ func (c *fastAPICloudClient) get(ctx context.Context, apiPath string, params url
 	req.Header.Set("Accept", "application/json")
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
+		// net/http wraps CheckRedirect failures with the untrusted Location URL.
+		var redirectErr *fastAPICloudRedirectError
+		if errors.As(err, &redirectErr) {
+			return redirectErr
+		}
 		return err
 	}
 	defer resp.Body.Close()


### PR DESCRIPTION
## Summary

- block FastAPI Cloud bearer-token redirects unless scheme, hostname, and effective port match the configured API origin
- preserve caller-supplied redirect policy and the standard ten-redirect limit
- sanitize redirect failures so untrusted query strings and fragments are not returned
- reject API URLs containing userinfo, query parameters, or fragments without echoing those values

Closes https://github.com/openclaw/crabbox/issues/869

## Verification

- `go test -race ./internal/providers/fastapicloud -count=3`
- `go vet ./...`
- autoreview: clean, no accepted/actionable findings

The redirect regression uses real local HTTP servers: the cross-origin target receives zero requests; same-origin redirects retain the expected bearer header; caller redirect callbacks still run.

### Exact-head remote proof

- head: `9e2218466391f3516f9d81b56ac7a4501dbe92ac`
- provider: `blacksmith-testbox`
- lease: `tbx_01kwqw03ceazrx8ny9kbjjnfmt` (`swift-krill`)
- run: https://github.com/openclaw/crabbox/actions/runs/28724828077
- remote Go: 1.26.4 on Linux/amd64
- command: `go test -race ./internal/providers/fastapicloud -count=3`
- result: pass; the remote checkout independently fetched `refs/pull/890/head` and asserted the full SHA before testing
- cleanup: lease stopped; exact-ID inventory returned empty

Terminal transcript:

```text
provider=blacksmith-testbox id=tbx_01kwqw03ceazrx8ny9kbjjnfmt sync=delegated auth=blacksmith
GitHub Actions run: https://github.com/openclaw/crabbox/actions/runs/28724828077
Testbox ready!
Changes synced in 4078ms (remote-fetch)
From https://github.com/openclaw/crabbox
 * branch            refs/pull/890/head -> FETCH_HEAD
HEAD is now at 9e22184 fix(fastapi-cloud): block cross-origin token redirects
proof_head=9e2218466391f3516f9d81b56ac7a4501dbe92ac
ok github.com/openclaw/crabbox/internal/providers/fastapicloud 1.313s
blacksmith run summary sync=delegated command=2m46.592s total=3m1.644s exit=0
Testbox tbx_01kwqw03ceazrx8ny9kbjjnfmt stopped (completed)
exact_id_inventory=[]
```

The linked hosting workflow is cancelled by the explicit Testbox stop after the command succeeds; the transcript above records the successful command result before that cleanup action.

## Configuration and secrets

No new secret or permission requirements. Existing custom FastAPI Cloud API URLs containing userinfo, query strings, or fragments are now rejected as unsafe credential destinations.
