### PR TITLE
fix(providers): revalidate cloud cleanup candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Prevented FastAPI Cloud bearer credentials from following cross-origin redirects, preserved caller redirect policies, and rejected unsafe credential-destination URL components. Thanks @coygeek.
 - Treated malformed percent-encoded portal cookies as absent instead of throwing before normal authentication handling. Thanks @coygeek.
 - Verified downloaded GitHub Actions runner archives against the exact upstream release-asset SHA-256 digest before replacing or extracting the installed runner. Thanks @coygeek.
+- Revalidated live AWS, Azure, and GCP instance identity, ownership, lease binding, and cleanup eligibility immediately before direct cleanup deletion. Thanks @coygeek.
 - Required W&B sandbox reuse, status, and stop to match an exact endpoint/entity/project/resource-bound local claim plus provider inventory ownership. Thanks @coygeek.
 - Required RunPod stop to use an exact pod ID/name-bound local claim, with conflict-safe explicit `--reclaim` adoption for unclaimed or legacy pods. Thanks @coygeek.
 - Made coordinatorless generic provider live smokes skip coordinator-only history and always clean up acquired leases after later lifecycle failures.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - Prevented FastAPI Cloud bearer credentials from following cross-origin redirects, preserved caller redirect policies, and rejected unsafe credential-destination URL components. Thanks @coygeek.
 - Treated malformed percent-encoded portal cookies as absent instead of throwing before normal authentication handling. Thanks @coygeek.
 - Verified downloaded GitHub Actions runner archives against the exact upstream release-asset SHA-256 digest before replacing or extracting the installed runner. Thanks @coygeek.
-- Revalidated live AWS, Azure, and GCP instance identity, ownership, lease binding, and cleanup eligibility immediately before direct cleanup deletion. Thanks @coygeek.
+- Revalidated live AWS, Azure, and GCP instance identity, ownership, lease binding, cleanup eligibility, and any destructive companion-resource identity immediately before direct cleanup deletion. Thanks @coygeek.
 - Required W&B sandbox reuse, status, and stop to match an exact endpoint/entity/project/resource-bound local claim plus provider inventory ownership. Thanks @coygeek.
 - Required RunPod stop to use an exact pod ID/name-bound local claim, with conflict-safe explicit `--reclaim` adoption for unclaimed or legacy pods. Thanks @coygeek.
 - Made coordinatorless generic provider live smokes skip coordinator-only history and always clean up acquired leases after later lifecycle failures.

--- a/internal/cli/aws.go
+++ b/internal/cli/aws.go
@@ -10,6 +10,7 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"math/big"
 	"sort"
@@ -355,6 +356,54 @@ func (c *AWSClient) DeleteSSHKey(ctx context.Context, name string) error {
 		return nil
 	}
 	return err
+}
+
+type awsCleanupKeyOwnershipError struct{ err error }
+
+func (e *awsCleanupKeyOwnershipError) Error() string { return e.err.Error() }
+func (e *awsCleanupKeyOwnershipError) Unwrap() error { return e.err }
+
+// IsAWSCleanupKeyOwnershipError reports a cleanup-time key ownership mismatch
+// that must skip the instance instead of deleting either resource.
+func IsAWSCleanupKeyOwnershipError(err error) bool {
+	var ownershipErr *awsCleanupKeyOwnershipError
+	return errors.As(err, &ownershipErr)
+}
+
+func NewAWSCleanupKeyOwnershipError(message string) error {
+	return &awsCleanupKeyOwnershipError{err: errors.New(message)}
+}
+
+func validateAWSCleanupKeyPair(name string, keyPairs []types.KeyPairInfo) error {
+	if len(keyPairs) != 1 || strings.TrimSpace(aws.ToString(keyPairs[0].KeyName)) != strings.TrimSpace(name) {
+		return &awsCleanupKeyOwnershipError{err: fmt.Errorf("AWS cleanup key %q did not resolve to one exact key pair", name)}
+	}
+	tags := make(map[string]string, len(keyPairs[0].Tags))
+	for _, tag := range keyPairs[0].Tags {
+		tags[aws.ToString(tag.Key)] = aws.ToString(tag.Value)
+	}
+	if tags["crabbox"] != "true" || tags["created_by"] != "crabbox" {
+		return &awsCleanupKeyOwnershipError{err: fmt.Errorf("AWS cleanup key %q lacks canonical Crabbox ownership tags", name)}
+	}
+	return nil
+}
+
+func (c *AWSClient) ValidateCleanupSSHKey(ctx context.Context, name string) error {
+	out, err := c.ec2.DescribeKeyPairs(ctx, &ec2.DescribeKeyPairsInput{KeyNames: []string{name}})
+	if err != nil {
+		if strings.Contains(err.Error(), "InvalidKeyPair.NotFound") {
+			return nil
+		}
+		return err
+	}
+	return validateAWSCleanupKeyPair(name, out.KeyPairs)
+}
+
+func (c *AWSClient) DeleteCleanupSSHKey(ctx context.Context, name string) error {
+	if err := c.ValidateCleanupSSHKey(ctx, name); err != nil {
+		return err
+	}
+	return c.DeleteSSHKey(ctx, name)
 }
 
 func (c *AWSClient) CreateServerWithFallback(ctx context.Context, cfg Config, publicKey, leaseID, slug string, keep bool, logf func(string, ...any)) (Server, Config, error) {

--- a/internal/cli/aws_test.go
+++ b/internal/cli/aws_test.go
@@ -20,6 +20,26 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 )
 
+func TestValidateAWSCleanupKeyPair(t *testing.T) {
+	name := "crabbox-cbx-123456abcdef"
+	owned := types.KeyPairInfo{
+		KeyName: aws.String(name),
+		Tags: []types.Tag{
+			{Key: aws.String("crabbox"), Value: aws.String("true")},
+			{Key: aws.String("created_by"), Value: aws.String("crabbox")},
+		},
+	}
+	if err := validateAWSCleanupKeyPair(name, []types.KeyPairInfo{owned}); err != nil {
+		t.Fatalf("owned key rejected: %v", err)
+	}
+	unowned := owned
+	unowned.Tags = []types.Tag{{Key: aws.String("crabbox"), Value: aws.String("true")}}
+	err := validateAWSCleanupKeyPair(name, []types.KeyPairInfo{unowned})
+	if err == nil || !IsAWSCleanupKeyOwnershipError(err) {
+		t.Fatalf("unowned key error=%v", err)
+	}
+}
+
 func TestAWSEnsureSSHKeyAcceptsMatchingExistingFingerprint(t *testing.T) {
 	publicKey := testOpenSSHPublicKey("ssh-ed25519", testBytes(32, 1))
 	fingerprints, err := awsImportedPublicKeyFingerprints(publicKey)

--- a/internal/cli/azure.go
+++ b/internal/cli/azure.go
@@ -1817,6 +1817,49 @@ func (c *AzureClient) DeleteServer(ctx context.Context, name string) error {
 	return c.deleteVMResources(ctx, name)
 }
 
+type azureCleanupSkipError struct{ err error }
+
+func (e *azureCleanupSkipError) Error() string { return e.err.Error() }
+func (e *azureCleanupSkipError) Unwrap() error { return e.err }
+
+type azureCleanupResourceReadError struct{ err error }
+
+func (e *azureCleanupResourceReadError) Error() string { return e.err.Error() }
+func (e *azureCleanupResourceReadError) Unwrap() error { return e.err }
+
+// IsAzureCleanupSkipError reports a cleanup-time ownership or association
+// mismatch that must be reported and skipped rather than treated as fatal.
+func IsAzureCleanupSkipError(err error) bool {
+	var skipErr *azureCleanupSkipError
+	return errors.As(err, &skipErr)
+}
+
+// DeleteCleanupServer revalidates a cleanup candidate and every associated
+// resource consumed by deletion at the Azure mutation boundary.
+func (c *AzureClient) DeleteCleanupServer(ctx context.Context, expected Server, now time.Time) error {
+	name := strings.TrimSpace(expected.CloudID)
+	if name == "" {
+		return errors.New("azure cleanup candidate has no cloud id")
+	}
+	vmResponse, err := c.vmc.Get(ctx, c.ResourceGroup, name, nil)
+	if err != nil {
+		return fmt.Errorf("re-read Azure cleanup VM %s: %w", name, err)
+	}
+	live := azureVMToServer(vmResponse.VirtualMachine, "", "")
+	if err := validateAzureCleanupVM(expected, live, now); err != nil {
+		return &azureCleanupSkipError{err: err}
+	}
+	resources, err := c.azureCleanupDeleteResources(ctx, name, vmResponse.VirtualMachine, live.Labels)
+	if err != nil {
+		var readErr *azureCleanupResourceReadError
+		if errors.As(err, &readErr) && !isAzureNotFoundError(readErr.err) {
+			return err
+		}
+		return &azureCleanupSkipError{err: err}
+	}
+	return c.deleteVMResourcesWith(ctx, name, resources)
+}
+
 func (c *AzureClient) CreateOSDiskSnapshot(ctx context.Context, vmName, snapshotName, sku string) (image NativeCheckpointImage, err error) {
 	vm, err := c.vmc.Get(ctx, c.ResourceGroup, vmName, nil)
 	if err != nil {
@@ -1940,9 +1983,206 @@ func (c *AzureClient) DeleteOSDiskSnapshot(ctx context.Context, snapshotID strin
 	return nil
 }
 
+type azureVMDeleteResources struct {
+	nic           string
+	publicIP      string
+	disk          string
+	quarantineNSG string
+}
+
+func validateAzureCleanupVM(expected, live Server, now time.Time) error {
+	expectedID := strings.TrimSpace(expected.CloudID)
+	if expectedID == "" || strings.TrimSpace(live.CloudID) != expectedID {
+		return fmt.Errorf("live Azure cloud id %q does not match cleanup candidate %q", live.CloudID, expected.CloudID)
+	}
+	labels := live.Labels
+	if labels == nil || labels["crabbox"] != "true" || labels["created_by"] != "crabbox" || labels["provider"] != "azure" ||
+		!isCanonicalLeaseID(labels["lease"]) || strings.TrimSpace(labels["slug"]) == "" {
+		return fmt.Errorf("live Azure VM %s no longer has canonical Crabbox ownership tags", expectedID)
+	}
+	if liveLeaseID, expectedLeaseID := strings.TrimSpace(labels["lease"]), strings.TrimSpace(expected.Labels["lease"]); liveLeaseID != expectedLeaseID {
+		return fmt.Errorf("live Azure VM lease %q does not match cleanup candidate lease %q", liveLeaseID, expectedLeaseID)
+	}
+	if liveSlug, expectedSlug := strings.TrimSpace(labels["slug"]), strings.TrimSpace(expected.Labels["slug"]); liveSlug != expectedSlug {
+		return fmt.Errorf("live Azure VM slug %q does not match cleanup candidate slug %q", liveSlug, expectedSlug)
+	}
+	if shouldDelete, reason := shouldCleanupServer(live, now); !shouldDelete {
+		return fmt.Errorf("live Azure VM is no longer cleanup eligible: %s", reason)
+	}
+	return nil
+}
+
+func validateAzureCleanupResourceTags(kind, name string, tags map[string]*string, expected map[string]string) error {
+	labels := make(map[string]string, len(tags))
+	for key, value := range tags {
+		if value != nil {
+			labels[azureTagToLabelKey(key)] = *value
+		}
+	}
+	if labels["crabbox"] != "true" || labels["created_by"] != "crabbox" || labels["provider"] != "azure" {
+		return fmt.Errorf("Azure cleanup %s %s lacks canonical Crabbox ownership tags", kind, name)
+	}
+	if leaseID := strings.TrimSpace(labels["lease"]); !isCanonicalLeaseID(leaseID) || leaseID != strings.TrimSpace(expected["lease"]) {
+		return fmt.Errorf("Azure cleanup %s %s lease %q does not match VM lease %q", kind, name, leaseID, expected["lease"])
+	}
+	if slug := strings.TrimSpace(labels["slug"]); slug == "" || slug != strings.TrimSpace(expected["slug"]) {
+		return fmt.Errorf("Azure cleanup %s %s slug %q does not match VM slug %q", kind, name, slug, expected["slug"])
+	}
+	return nil
+}
+
+func azureScopedResourceName(id, subscriptionID, resourceGroup, namespace, resourceType string) (string, error) {
+	parts := strings.Split(strings.Trim(strings.TrimSpace(id), "/"), "/")
+	if len(parts) != 8 || !strings.EqualFold(parts[0], "subscriptions") || !strings.EqualFold(parts[1], subscriptionID) ||
+		!strings.EqualFold(parts[2], "resourceGroups") || !strings.EqualFold(parts[3], resourceGroup) ||
+		!strings.EqualFold(parts[4], "providers") || !strings.EqualFold(parts[5], namespace) ||
+		!strings.EqualFold(parts[6], resourceType) || strings.TrimSpace(parts[7]) == "" {
+		return "", fmt.Errorf("Azure resource id %q is not a %s/%s resource in subscription %s resource group %s", id, namespace, resourceType, subscriptionID, resourceGroup)
+	}
+	return parts[7], nil
+}
+
+func requireAzureResourceID(kind, name, actual, expected string) error {
+	if strings.TrimSpace(actual) == "" || !strings.EqualFold(strings.TrimSpace(actual), strings.TrimSpace(expected)) {
+		return fmt.Errorf("Azure cleanup %s %s id %q does not match VM reference %q", kind, name, actual, expected)
+	}
+	return nil
+}
+
+func (c *AzureClient) azureCleanupDeleteResources(ctx context.Context, vmName string, vm armcompute.VirtualMachine, labels map[string]string) (azureVMDeleteResources, error) {
+	var resources azureVMDeleteResources
+	if vm.Properties == nil || vm.Properties.NetworkProfile == nil || len(vm.Properties.NetworkProfile.NetworkInterfaces) != 1 ||
+		vm.Properties.NetworkProfile.NetworkInterfaces[0] == nil || vm.Properties.NetworkProfile.NetworkInterfaces[0].ID == nil {
+		return resources, fmt.Errorf("live Azure VM %s does not have exactly one identifiable network interface", vmName)
+	}
+	nicID := strings.TrimSpace(*vm.Properties.NetworkProfile.NetworkInterfaces[0].ID)
+	nicName, err := azureScopedResourceName(nicID, c.SubscriptionID, c.ResourceGroup, "Microsoft.Network", "networkInterfaces")
+	if err != nil {
+		return resources, err
+	}
+	if !strings.EqualFold(nicName, vmName+"-nic") {
+		return resources, fmt.Errorf("live Azure VM %s references unexpected network interface %s", vmName, nicName)
+	}
+	nic, err := c.nicc.Get(ctx, c.ResourceGroup, nicName, nil)
+	if err != nil {
+		return resources, &azureCleanupResourceReadError{err: fmt.Errorf("re-read Azure cleanup NIC %s: %w", nicName, err)}
+	}
+	if err := requireAzureResourceID("NIC", nicName, stringValue(nic.ID), nicID); err != nil {
+		return resources, err
+	}
+	if err := validateAzureCleanupResourceTags("NIC", nicName, nic.Tags, labels); err != nil {
+		return resources, err
+	}
+	resources.nic = nicName
+
+	var publicIPID string
+	if nic.Properties == nil {
+		return resources, fmt.Errorf("Azure cleanup NIC %s has no properties", nicName)
+	}
+	for _, config := range nic.Properties.IPConfigurations {
+		if config == nil || config.Properties == nil || config.Properties.PublicIPAddress == nil || config.Properties.PublicIPAddress.ID == nil {
+			continue
+		}
+		candidate := strings.TrimSpace(*config.Properties.PublicIPAddress.ID)
+		if candidate == "" {
+			continue
+		}
+		if publicIPID != "" && !strings.EqualFold(publicIPID, candidate) {
+			return resources, fmt.Errorf("Azure cleanup NIC %s references multiple public IP addresses", nicName)
+		}
+		publicIPID = candidate
+	}
+	if publicIPID == "" {
+		return resources, fmt.Errorf("Azure cleanup NIC %s has no identifiable public IP address", nicName)
+	}
+	publicIPName, err := azureScopedResourceName(publicIPID, c.SubscriptionID, c.ResourceGroup, "Microsoft.Network", "publicIPAddresses")
+	if err != nil {
+		return resources, err
+	}
+	if !strings.EqualFold(publicIPName, vmName+"-pip") {
+		return resources, fmt.Errorf("live Azure VM %s references unexpected public IP address %s", vmName, publicIPName)
+	}
+	publicIP, err := c.pipc.Get(ctx, c.ResourceGroup, publicIPName, nil)
+	if err != nil {
+		return resources, &azureCleanupResourceReadError{err: fmt.Errorf("re-read Azure cleanup public IP %s: %w", publicIPName, err)}
+	}
+	if err := requireAzureResourceID("public IP", publicIPName, stringValue(publicIP.ID), publicIPID); err != nil {
+		return resources, err
+	}
+	if err := validateAzureCleanupResourceTags("public IP", publicIPName, publicIP.Tags, labels); err != nil {
+		return resources, err
+	}
+	resources.publicIP = publicIPName
+
+	if vm.Properties.StorageProfile == nil || vm.Properties.StorageProfile.OSDisk == nil {
+		return resources, fmt.Errorf("live Azure VM %s has no identifiable OS disk", vmName)
+	}
+	osDisk := vm.Properties.StorageProfile.OSDisk
+	ephemeral := osDisk.DiffDiskSettings != nil && osDisk.DiffDiskSettings.Option != nil &&
+		strings.EqualFold(string(*osDisk.DiffDiskSettings.Option), string(armcompute.DiffDiskOptionsLocal))
+	if !ephemeral {
+		if osDisk.ManagedDisk == nil || osDisk.ManagedDisk.ID == nil || strings.TrimSpace(*osDisk.ManagedDisk.ID) == "" {
+			return resources, fmt.Errorf("live Azure VM %s has no identifiable managed OS disk", vmName)
+		}
+		diskID := strings.TrimSpace(*osDisk.ManagedDisk.ID)
+		diskName, err := azureScopedResourceName(diskID, c.SubscriptionID, c.ResourceGroup, "Microsoft.Compute", "disks")
+		if err != nil {
+			return resources, err
+		}
+		if !strings.EqualFold(diskName, vmName+"-osdisk") {
+			return resources, fmt.Errorf("live Azure VM %s references unexpected OS disk %s", vmName, diskName)
+		}
+		disk, err := c.diskc.Get(ctx, c.ResourceGroup, diskName, nil)
+		if err != nil {
+			return resources, &azureCleanupResourceReadError{err: fmt.Errorf("re-read Azure cleanup disk %s: %w", diskName, err)}
+		}
+		if err := requireAzureResourceID("disk", diskName, stringValue(disk.ID), diskID); err != nil {
+			return resources, err
+		}
+		// Image-created managed OS disks do not inherit VM tags. The exact
+		// storage-profile resource ID, Azure scope, and deterministic name bind
+		// the disk to the already verified live VM.
+		resources.disk = diskName
+	}
+
+	if nic.Properties.NetworkSecurityGroup == nil || nic.Properties.NetworkSecurityGroup.ID == nil {
+		return resources, fmt.Errorf("Azure cleanup NIC %s has no identifiable network security group", nicName)
+	}
+	nsgID := strings.TrimSpace(*nic.Properties.NetworkSecurityGroup.ID)
+	nsgName, err := azureScopedResourceName(nsgID, c.SubscriptionID, c.ResourceGroup, "Microsoft.Network", "networkSecurityGroups")
+	if err != nil {
+		return resources, err
+	}
+	if strings.EqualFold(nsgName, vmName+azureSnapshotQuarantineNSGSuffix) {
+		nsg, err := c.sgc.Get(ctx, c.ResourceGroup, nsgName, nil)
+		if err != nil {
+			return resources, &azureCleanupResourceReadError{err: fmt.Errorf("re-read Azure cleanup quarantine NSG %s: %w", nsgName, err)}
+		}
+		if err := requireAzureResourceID("quarantine NSG", nsgName, stringValue(nsg.ID), nsgID); err != nil {
+			return resources, err
+		}
+		if err := validateAzureCleanupResourceTags("quarantine NSG", nsgName, nsg.Tags, labels); err != nil {
+			return resources, err
+		}
+		resources.quarantineNSG = nsgName
+	} else if !strings.EqualFold(nsgName, c.NSG) && !strings.EqualFold(nsgName, azureRegionalName(c.NSG, c.Location)) {
+		return resources, fmt.Errorf("Azure cleanup NIC %s references unexpected network security group %s", nicName, nsgName)
+	}
+	return resources, nil
+}
+
 func (c *AzureClient) deleteVMResources(ctx context.Context, name string) error {
+	return c.deleteVMResourcesWith(ctx, name, azureVMDeleteResources{
+		nic:           name + "-nic",
+		publicIP:      name + "-pip",
+		disk:          name + "-osdisk",
+		quarantineNSG: name + azureSnapshotQuarantineNSGSuffix,
+	})
+}
+
+func (c *AzureClient) deleteVMResourcesWith(ctx context.Context, name string, resources azureVMDeleteResources) error {
 	for attempt := 0; ; attempt++ {
-		errs, retry := c.deleteVMResourcesOnce(ctx, name)
+		errs, retry := c.deleteVMResourcesOnce(ctx, name, resources)
 		if len(errs) == 0 {
 			return nil
 		}
@@ -1958,10 +2198,9 @@ func (c *AzureClient) deleteVMResources(ctx context.Context, name string) error 
 	}
 }
 
-func (c *AzureClient) deleteVMResourcesOnce(ctx context.Context, name string) ([]error, bool) {
+func (c *AzureClient) deleteVMResourcesOnce(ctx context.Context, name string, resources azureVMDeleteResources) ([]error, bool) {
 	var errs []error
 	retry := false
-	quarantineNSGName := name + azureSnapshotQuarantineNSGSuffix
 	if poller, err := c.vmc.BeginDelete(ctx, c.ResourceGroup, name, &armcompute.VirtualMachinesClientBeginDeleteOptions{
 		ForceDeletion: to.Ptr(true),
 	}); err == nil {
@@ -1973,10 +2212,15 @@ func (c *AzureClient) deleteVMResourcesOnce(ctx context.Context, name string) ([
 		errs = append(errs, fmt.Errorf("begin delete vm: %w", err))
 		retry = retry || isAzureRetryableDeleteError(err)
 	}
-	dependentDeletes := []func() error{
-		func() error { return c.deleteNIC(ctx, name+"-nic") },
-		func() error { return c.deletePublicIP(ctx, name+"-pip") },
-		func() error { return c.deleteDisk(ctx, name+"-osdisk") },
+	dependentDeletes := make([]func() error, 0, 3)
+	if resources.nic != "" {
+		dependentDeletes = append(dependentDeletes, func() error { return c.deleteNIC(ctx, resources.nic) })
+	}
+	if resources.publicIP != "" {
+		dependentDeletes = append(dependentDeletes, func() error { return c.deletePublicIP(ctx, resources.publicIP) })
+	}
+	if resources.disk != "" {
+		dependentDeletes = append(dependentDeletes, func() error { return c.deleteDisk(ctx, resources.disk) })
 	}
 	deleteResults := make(chan error, len(dependentDeletes))
 	for _, deleteResource := range dependentDeletes {
@@ -1988,9 +2232,11 @@ func (c *AzureClient) deleteVMResourcesOnce(ctx context.Context, name string) ([
 			retry = retry || isAzureRetryableDeleteError(err)
 		}
 	}
-	if err := c.deleteSnapshotQuarantineNSG(ctx, quarantineNSGName); err != nil {
-		errs = append(errs, err)
-		retry = retry || isAzureRetryableDeleteError(err)
+	if resources.quarantineNSG != "" {
+		if err := c.deleteSnapshotQuarantineNSG(ctx, resources.quarantineNSG); err != nil {
+			errs = append(errs, err)
+			retry = retry || isAzureRetryableDeleteError(err)
+		}
 	}
 	absenceChecks := []struct {
 		name string
@@ -2000,22 +2246,42 @@ func (c *AzureClient) deleteVMResourcesOnce(ctx context.Context, name string) ([
 			_, err := c.vmc.Get(ctx, c.ResourceGroup, name, nil)
 			return err
 		}},
-		{name: "nic " + name + "-nic", get: func() error {
-			_, err := c.nicc.Get(ctx, c.ResourceGroup, name+"-nic", nil)
+	}
+	if resources.nic != "" {
+		absenceChecks = append(absenceChecks, struct {
+			name string
+			get  func() error
+		}{name: "nic " + resources.nic, get: func() error {
+			_, err := c.nicc.Get(ctx, c.ResourceGroup, resources.nic, nil)
 			return err
-		}},
-		{name: "public ip " + name + "-pip", get: func() error {
-			_, err := c.pipc.Get(ctx, c.ResourceGroup, name+"-pip", nil)
+		}})
+	}
+	if resources.publicIP != "" {
+		absenceChecks = append(absenceChecks, struct {
+			name string
+			get  func() error
+		}{name: "public ip " + resources.publicIP, get: func() error {
+			_, err := c.pipc.Get(ctx, c.ResourceGroup, resources.publicIP, nil)
 			return err
-		}},
-		{name: "disk " + name + "-osdisk", get: func() error {
-			_, err := c.diskc.Get(ctx, c.ResourceGroup, name+"-osdisk", nil)
+		}})
+	}
+	if resources.disk != "" {
+		absenceChecks = append(absenceChecks, struct {
+			name string
+			get  func() error
+		}{name: "disk " + resources.disk, get: func() error {
+			_, err := c.diskc.Get(ctx, c.ResourceGroup, resources.disk, nil)
 			return err
-		}},
-		{name: "snapshot quarantine nsg " + quarantineNSGName, get: func() error {
-			_, err := c.sgc.Get(ctx, c.ResourceGroup, quarantineNSGName, nil)
+		}})
+	}
+	if resources.quarantineNSG != "" {
+		absenceChecks = append(absenceChecks, struct {
+			name string
+			get  func() error
+		}{name: "snapshot quarantine nsg " + resources.quarantineNSG, get: func() error {
+			_, err := c.sgc.Get(ctx, c.ResourceGroup, resources.quarantineNSG, nil)
 			return err
-		}},
+		}})
 	}
 	for _, check := range absenceChecks {
 		err := check.get()

--- a/internal/cli/azure_test.go
+++ b/internal/cli/azure_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"maps"
 	"reflect"
 	"strings"
 	"testing"
@@ -67,6 +68,67 @@ func TestParseAzureImageRef(t *testing.T) {
 				t.Fatalf("got %+v, want %+v", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestValidateAzureCleanupVM(t *testing.T) {
+	now := time.Date(2026, 7, 5, 0, 0, 0, 0, time.UTC)
+	expected := Server{
+		CloudID: "crabbox-live",
+		Labels: map[string]string{
+			"crabbox":    "true",
+			"created_by": "crabbox",
+			"provider":   "azure",
+			"lease":      "cbx_123456abcdef",
+			"slug":       "live",
+			"expires_at": leaseLabelTime(now.Add(-time.Hour)),
+		},
+	}
+	if err := validateAzureCleanupVM(expected, expected, now); err != nil {
+		t.Fatalf("valid cleanup VM rejected: %v", err)
+	}
+
+	changedSlug := expected
+	changedSlug.Labels = maps.Clone(expected.Labels)
+	changedSlug.Labels["slug"] = "other"
+	if err := validateAzureCleanupVM(expected, changedSlug, now); err == nil || !strings.Contains(err.Error(), "slug") {
+		t.Fatalf("changed slug error=%v", err)
+	}
+
+	renewed := expected
+	renewed.Labels = maps.Clone(expected.Labels)
+	renewed.Labels["expires_at"] = leaseLabelTime(now.Add(time.Hour))
+	if err := validateAzureCleanupVM(expected, renewed, now); err == nil || !strings.Contains(err.Error(), "no longer cleanup eligible") {
+		t.Fatalf("renewed VM error=%v", err)
+	}
+}
+
+func TestValidateAzureCleanupResourceTags(t *testing.T) {
+	labels := map[string]string{
+		"crabbox":    "true",
+		"created_by": "crabbox",
+		"provider":   "azure",
+		"lease":      "cbx_123456abcdef",
+		"slug":       "live",
+	}
+	if err := validateAzureCleanupResourceTags("NIC", "crabbox-live-nic", azureLabelsToTags(labels), labels); err != nil {
+		t.Fatalf("valid resource tags rejected: %v", err)
+	}
+	wrongLease := maps.Clone(labels)
+	wrongLease["lease"] = "cbx_fedcba654321"
+	if err := validateAzureCleanupResourceTags("NIC", "crabbox-live-nic", azureLabelsToTags(wrongLease), labels); err == nil || !strings.Contains(err.Error(), "lease") {
+		t.Fatalf("wrong lease error=%v", err)
+	}
+}
+
+func TestAzureScopedResourceName(t *testing.T) {
+	id := "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/crabbox-live-nic"
+	name, err := azureScopedResourceName(id, "sub", "rg", "Microsoft.Network", "networkInterfaces")
+	if err != nil || name != "crabbox-live-nic" {
+		t.Fatalf("name=%q err=%v", name, err)
+	}
+	if _, err := azureScopedResourceName(id, "other", "rg", "Microsoft.Network", "networkInterfaces"); err == nil {
+		t.Fatal("cross-subscription resource id accepted")
 	}
 }
 

--- a/internal/providers/aws/backend.go
+++ b/internal/providers/aws/backend.go
@@ -40,6 +40,8 @@ type awsClient interface {
 	GetServer(context.Context, string) (Server, error)
 	DeleteServer(context.Context, string) error
 	DeleteSSHKey(context.Context, string) error
+	ValidateCleanupSSHKey(context.Context, string) error
+	DeleteCleanupSSHKey(context.Context, string) error
 	SetTags(context.Context, string, map[string]string) error
 	CapacityDoctorChecks(context.Context, Config) []core.DoctorCheck
 	SpotPlacementScores(context.Context, Config) ([]ec2types.SpotPlacementScore, error)
@@ -290,8 +292,17 @@ func (b *awsLeaseBackend) Cleanup(ctx context.Context, req CleanupRequest) error
 			fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=live instance %s\n", server.DisplayID(), server.Name, reason)
 			continue
 		}
+		if keyName := core.ServerProviderKey(live); core.ValidCrabboxProviderKey(keyName) {
+			if err := client.ValidateCleanupSSHKey(ctx, keyName); err != nil {
+				if core.IsAWSCleanupKeyOwnershipError(err) {
+					fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=%v\n", server.DisplayID(), server.Name, err)
+					continue
+				}
+				return fmt.Errorf("re-read AWS cleanup key %s: %w", keyName, err)
+			}
+		}
 		fmt.Fprintf(b.RT.Stderr, "delete server id=%s name=%s\n", live.DisplayID(), live.Name)
-		if err := deleteAWSServerWithClient(ctx, client, live); err != nil {
+		if err := deleteAWSCleanupServerWithClient(ctx, client, live); err != nil {
 			return err
 		}
 	}
@@ -403,6 +414,18 @@ func deleteAWSServerWithClient(ctx context.Context, client awsClient, server Ser
 	}
 	if keyName := core.ServerProviderKey(server); core.ValidCrabboxProviderKey(keyName) {
 		if err := client.DeleteSSHKey(ctx, keyName); err != nil {
+			return &awsProviderKeyCleanupError{keyName: keyName, err: err}
+		}
+	}
+	return nil
+}
+
+func deleteAWSCleanupServerWithClient(ctx context.Context, client awsClient, server Server) error {
+	if err := client.DeleteServer(ctx, server.CloudID); err != nil {
+		return err
+	}
+	if keyName := core.ServerProviderKey(server); core.ValidCrabboxProviderKey(keyName) {
+		if err := client.DeleteCleanupSSHKey(ctx, keyName); err != nil {
 			return &awsProviderKeyCleanupError{keyName: keyName, err: err}
 		}
 	}

--- a/internal/providers/aws/backend.go
+++ b/internal/providers/aws/backend.go
@@ -421,6 +421,10 @@ func validateAWSCleanupLiveServer(expected, live Server) error {
 	if liveLeaseID := strings.TrimSpace(live.Labels["lease"]); liveLeaseID != expectedLeaseID {
 		return fmt.Errorf("live instance lease %q does not match cleanup candidate lease %q", liveLeaseID, expectedLeaseID)
 	}
+	expectedProviderKey := strings.TrimSpace(core.ServerProviderKey(expected))
+	if liveProviderKey := strings.TrimSpace(core.ServerProviderKey(live)); liveProviderKey != expectedProviderKey {
+		return fmt.Errorf("live instance provider key %q does not match cleanup candidate provider key %q", liveProviderKey, expectedProviderKey)
+	}
 	return nil
 }
 

--- a/internal/providers/aws/backend.go
+++ b/internal/providers/aws/backend.go
@@ -265,11 +265,33 @@ func (b *awsLeaseBackend) Cleanup(ctx context.Context, req CleanupRequest) error
 			fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=%s\n", server.DisplayID(), server.Name, reason)
 			continue
 		}
-		fmt.Fprintf(b.RT.Stderr, "delete server id=%s name=%s\n", server.DisplayID(), server.Name)
 		if req.DryRun {
+			fmt.Fprintf(b.RT.Stderr, "delete server id=%s name=%s\n", server.DisplayID(), server.Name)
 			continue
 		}
-		if err := deleteServer(ctx, awsConfigForServer(b.Cfg, server), server); err != nil {
+		cfg := awsConfigForServer(b.Cfg, server)
+		client, err := newAWSClient(ctx, cfg)
+		if err != nil {
+			return err
+		}
+		live, err := client.GetServer(ctx, server.CloudID)
+		if err != nil {
+			if isAWSResolveNotFound(err) {
+				fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=live instance no longer exists\n", server.DisplayID(), server.Name)
+				continue
+			}
+			return fmt.Errorf("re-read AWS cleanup candidate %s: %w", server.DisplayID(), err)
+		}
+		if err := validateAWSCleanupLiveServer(server, live); err != nil {
+			fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=%v\n", server.DisplayID(), server.Name, err)
+			continue
+		}
+		if shouldDelete, reason := core.ShouldCleanupServer(live, now); !shouldDelete {
+			fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=live instance %s\n", server.DisplayID(), server.Name, reason)
+			continue
+		}
+		fmt.Fprintf(b.RT.Stderr, "delete server id=%s name=%s\n", live.DisplayID(), live.Name)
+		if err := deleteAWSServerWithClient(ctx, client, live); err != nil {
 			return err
 		}
 	}
@@ -372,6 +394,10 @@ func deleteServer(ctx context.Context, cfg Config, server Server) error {
 	if err != nil {
 		return err
 	}
+	return deleteAWSServerWithClient(ctx, client, server)
+}
+
+func deleteAWSServerWithClient(ctx context.Context, client awsClient, server Server) error {
 	if err := client.DeleteServer(ctx, server.CloudID); err != nil {
 		return err
 	}
@@ -379,6 +405,21 @@ func deleteServer(ctx context.Context, cfg Config, server Server) error {
 		if err := client.DeleteSSHKey(ctx, keyName); err != nil {
 			return &awsProviderKeyCleanupError{keyName: keyName, err: err}
 		}
+	}
+	return nil
+}
+
+func validateAWSCleanupLiveServer(expected, live Server) error {
+	cloudID := strings.TrimSpace(expected.CloudID)
+	if cloudID == "" || strings.TrimSpace(live.CloudID) != cloudID {
+		return fmt.Errorf("live cloud id %q does not match cleanup candidate %q", live.CloudID, expected.CloudID)
+	}
+	if !isCrabboxAWSLease(live) {
+		return errors.New("live instance no longer has canonical Crabbox ownership tags")
+	}
+	expectedLeaseID := strings.TrimSpace(expected.Labels["lease"])
+	if liveLeaseID := strings.TrimSpace(live.Labels["lease"]); liveLeaseID != expectedLeaseID {
+		return fmt.Errorf("live instance lease %q does not match cleanup candidate lease %q", liveLeaseID, expectedLeaseID)
 	}
 	return nil
 }

--- a/internal/providers/aws/backend_test.go
+++ b/internal/providers/aws/backend_test.go
@@ -28,6 +28,8 @@ type fakeAWSClient struct {
 	deletedInstances []string
 	deletedKeys      []string
 	deleteKeyErr     error
+	validatedKeys    []string
+	validateKeyErr   error
 	tagged           []string
 }
 
@@ -84,6 +86,19 @@ func (c *fakeAWSClient) DeleteServer(_ context.Context, id string) error {
 }
 
 func (c *fakeAWSClient) DeleteSSHKey(_ context.Context, name string) error {
+	c.deletedKeys = append(c.deletedKeys, name)
+	return c.deleteKeyErr
+}
+
+func (c *fakeAWSClient) ValidateCleanupSSHKey(_ context.Context, name string) error {
+	c.validatedKeys = append(c.validatedKeys, name)
+	return c.validateKeyErr
+}
+
+func (c *fakeAWSClient) DeleteCleanupSSHKey(ctx context.Context, name string) error {
+	if err := c.ValidateCleanupSSHKey(ctx, name); err != nil {
+		return err
+	}
 	c.deletedKeys = append(c.deletedKeys, name)
 	return c.deleteKeyErr
 }
@@ -504,6 +519,32 @@ func TestAWSCleanupRejectsChangedLiveProviderKey(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "live instance provider key") {
 		t.Fatalf("stderr=%q, want changed-provider-key skip", stderr.String())
+	}
+}
+
+func TestAWSCleanupSkipsUnownedLiveProviderKey(t *testing.T) {
+	server := awsTestServer("i-stale", "cbx_111111111111", "stale", "us-east-1")
+	server.Labels["provider_key"] = "crabbox-cbx-111111111111"
+	server.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
+	fake := &fakeAWSClient{
+		servers:        []Server{server},
+		get:            map[string]Server{server.CloudID: server},
+		validateKeyErr: core.NewAWSCleanupKeyOwnershipError("provider key ownership changed"),
+	}
+	oldClient := newAWSClient
+	newAWSClient = func(context.Context, Config) (awsClient, error) { return fake, nil }
+	t.Cleanup(func() { newAWSClient = oldClient })
+
+	var stderr strings.Builder
+	backend := NewAWSLeaseBackend(ProviderSpec{}, Config{Provider: "aws", AWSRegion: "us-east-1"}, Runtime{Stderr: &stderr}).(*awsLeaseBackend)
+	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.deletedInstances) != 0 || len(fake.deletedKeys) != 0 {
+		t.Fatalf("cleanup crossed provider-key ownership mismatch: instances=%v keys=%v", fake.deletedInstances, fake.deletedKeys)
+	}
+	if !strings.Contains(stderr.String(), "provider key ownership changed") {
+		t.Fatalf("stderr=%q, want provider-key ownership skip", stderr.String())
 	}
 }
 

--- a/internal/providers/aws/backend_test.go
+++ b/internal/providers/aws/backend_test.go
@@ -479,6 +479,34 @@ func TestAWSCleanupRevalidatesLiveOwnershipBeforeDelete(t *testing.T) {
 	}
 }
 
+func TestAWSCleanupRejectsChangedLiveProviderKey(t *testing.T) {
+	snapshot := awsTestServer("i-stale", "cbx_111111111111", "stale", "us-east-1")
+	snapshot.Labels["provider_key"] = "crabbox-cbx-111111111111"
+	snapshot.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
+	live := snapshot
+	live.Labels = maps.Clone(snapshot.Labels)
+	live.Labels["provider_key"] = "crabbox-cbx-222222222222"
+	fake := &fakeAWSClient{
+		servers: []Server{snapshot},
+		get:     map[string]Server{snapshot.CloudID: live},
+	}
+	oldClient := newAWSClient
+	newAWSClient = func(context.Context, Config) (awsClient, error) { return fake, nil }
+	t.Cleanup(func() { newAWSClient = oldClient })
+
+	var stderr strings.Builder
+	backend := NewAWSLeaseBackend(ProviderSpec{}, Config{Provider: "aws", AWSRegion: "us-east-1"}, Runtime{Stderr: &stderr}).(*awsLeaseBackend)
+	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.deletedInstances) != 0 || len(fake.deletedKeys) != 0 {
+		t.Fatalf("cleanup trusted changed provider key: instances=%v keys=%v", fake.deletedInstances, fake.deletedKeys)
+	}
+	if !strings.Contains(stderr.String(), "live instance provider key") {
+		t.Fatalf("stderr=%q, want changed-provider-key skip", stderr.String())
+	}
+}
+
 func TestAWSCleanupRevalidatesLiveEligibilityBeforeDelete(t *testing.T) {
 	snapshot := awsTestServer("i-renewed", "cbx_111111111111", "renewed", "us-east-1")
 	snapshot.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))

--- a/internal/providers/aws/backend_test.go
+++ b/internal/providers/aws/backend_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"maps"
 	"strings"
 	"testing"
 	"time"
@@ -20,6 +21,10 @@ type fakeAWSClient struct {
 	createCfg        Config
 	createErr        error
 	waitErr          error
+	get              map[string]Server
+	getErrs          map[string]error
+	getErr           error
+	getIDs           []string
 	deletedInstances []string
 	deletedKeys      []string
 	deleteKeyErr     error
@@ -53,6 +58,18 @@ func (c *fakeAWSClient) WaitForServerIP(context.Context, string) (Server, error)
 }
 
 func (c *fakeAWSClient) GetServer(_ context.Context, id string) (Server, error) {
+	c.getIDs = append(c.getIDs, id)
+	if err := c.getErrs[id]; err != nil {
+		return Server{}, err
+	}
+	if c.getErr != nil {
+		return Server{}, c.getErr
+	}
+	if c.get != nil {
+		if server, ok := c.get[id]; ok {
+			return server, nil
+		}
+	}
 	for _, server := range c.servers {
 		if server.CloudID == id {
 			return server, nil
@@ -428,6 +445,89 @@ func TestAWSCleanupDeletesFallbackRegionServer(t *testing.T) {
 	}
 	if len(west.deletedKeys) != 1 || west.deletedKeys[0] != "crabbox-cbx-111111111111" {
 		t.Fatalf("west deleted keys=%v, want stale provider key", west.deletedKeys)
+	}
+}
+
+func TestAWSCleanupRevalidatesLiveOwnershipBeforeDelete(t *testing.T) {
+	snapshot := awsTestServer("i-stale", "cbx_111111111111", "stale", "us-east-1")
+	snapshot.Labels["provider_key"] = "crabbox-cbx-111111111111"
+	snapshot.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
+	live := snapshot
+	live.Labels = maps.Clone(snapshot.Labels)
+	delete(live.Labels, "created_by")
+	fake := &fakeAWSClient{
+		servers: []Server{snapshot},
+		get:     map[string]Server{snapshot.CloudID: live},
+	}
+	oldClient := newAWSClient
+	newAWSClient = func(context.Context, Config) (awsClient, error) { return fake, nil }
+	t.Cleanup(func() { newAWSClient = oldClient })
+
+	var stderr strings.Builder
+	backend := NewAWSLeaseBackend(ProviderSpec{}, Config{Provider: "aws", AWSRegion: "us-east-1"}, Runtime{Stderr: &stderr}).(*awsLeaseBackend)
+	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.getIDs) != 1 || fake.getIDs[0] != snapshot.CloudID {
+		t.Fatalf("live lookups=%v, want %s", fake.getIDs, snapshot.CloudID)
+	}
+	if len(fake.deletedInstances) != 0 || len(fake.deletedKeys) != 0 {
+		t.Fatalf("cleanup crossed changed ownership: instances=%v keys=%v", fake.deletedInstances, fake.deletedKeys)
+	}
+	if !strings.Contains(stderr.String(), "live instance no longer has canonical Crabbox ownership tags") {
+		t.Fatalf("stderr=%q, want changed-ownership skip", stderr.String())
+	}
+}
+
+func TestAWSCleanupRevalidatesLiveEligibilityBeforeDelete(t *testing.T) {
+	snapshot := awsTestServer("i-renewed", "cbx_111111111111", "renewed", "us-east-1")
+	snapshot.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
+	live := snapshot
+	live.Labels = maps.Clone(snapshot.Labels)
+	live.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(time.Hour))
+	fake := &fakeAWSClient{servers: []Server{snapshot}, get: map[string]Server{snapshot.CloudID: live}}
+	oldClient := newAWSClient
+	newAWSClient = func(context.Context, Config) (awsClient, error) { return fake, nil }
+	t.Cleanup(func() { newAWSClient = oldClient })
+
+	var stderr strings.Builder
+	backend := NewAWSLeaseBackend(ProviderSpec{}, Config{Provider: "aws", AWSRegion: "us-east-1"}, Runtime{Stderr: &stderr}).(*awsLeaseBackend)
+	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.deletedInstances) != 0 {
+		t.Fatalf("cleanup deleted renewed instance: %v", fake.deletedInstances)
+	}
+	if !strings.Contains(stderr.String(), "reason=live instance") {
+		t.Fatalf("stderr=%q, want renewed-live skip", stderr.String())
+	}
+}
+
+func TestAWSCleanupContinuesWhenLiveCandidateAlreadyGone(t *testing.T) {
+	missing := awsTestServer("i-missing", "cbx_111111111111", "missing", "us-east-1")
+	remaining := awsTestServer("i-remaining", "cbx_222222222222", "remaining", "us-east-1")
+	for _, server := range []*Server{&missing, &remaining} {
+		server.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
+	}
+	fake := &fakeAWSClient{
+		servers: []Server{missing, remaining},
+		get:     map[string]Server{remaining.CloudID: remaining},
+		getErrs: map[string]error{missing.CloudID: core.Exit(4, "aws instance not found: %s", missing.CloudID)},
+	}
+	oldClient := newAWSClient
+	newAWSClient = func(context.Context, Config) (awsClient, error) { return fake, nil }
+	t.Cleanup(func() { newAWSClient = oldClient })
+
+	var stderr strings.Builder
+	backend := NewAWSLeaseBackend(ProviderSpec{}, Config{Provider: "aws", AWSRegion: "us-east-1"}, Runtime{Stderr: &stderr}).(*awsLeaseBackend)
+	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.deletedInstances) != 1 || fake.deletedInstances[0] != remaining.CloudID {
+		t.Fatalf("deleted=%v, want only remaining candidate", fake.deletedInstances)
+	}
+	if !strings.Contains(stderr.String(), "reason=live instance no longer exists") {
+		t.Fatalf("stderr=%q, want already-gone skip", stderr.String())
 	}
 }
 

--- a/internal/providers/azure/backend.go
+++ b/internal/providers/azure/backend.go
@@ -2,11 +2,13 @@ package azure
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
@@ -218,11 +220,29 @@ func (b *azureLeaseBackend) Cleanup(ctx context.Context, req CleanupRequest) err
 			fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=%s\n", server.DisplayID(), server.Name, reason)
 			continue
 		}
-		fmt.Fprintf(b.RT.Stderr, "delete server id=%s name=%s\n", server.DisplayID(), server.Name)
 		if req.DryRun {
+			fmt.Fprintf(b.RT.Stderr, "delete server id=%s name=%s\n", server.DisplayID(), server.Name)
 			continue
 		}
-		if err := deleteServer(ctx, b.Cfg, server); err != nil {
+		live, err := client.GetServer(ctx, server.CloudID)
+		if err != nil {
+			if isAzureCleanupNotFound(err) {
+				fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=live VM no longer exists\n", server.DisplayID(), server.Name)
+				// Do not delete deterministically named companion resources without a live VM proving this lease still owns them.
+				continue
+			}
+			return fmt.Errorf("re-read Azure cleanup candidate %s: %w", server.DisplayID(), err)
+		}
+		if err := validateAzureCleanupLiveServer(server, live); err != nil {
+			fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=%v\n", server.DisplayID(), server.Name, err)
+			continue
+		}
+		if shouldDelete, reason := core.ShouldCleanupServer(live, now); !shouldDelete {
+			fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=live VM %s\n", server.DisplayID(), server.Name, reason)
+			continue
+		}
+		fmt.Fprintf(b.RT.Stderr, "delete server id=%s name=%s\n", live.DisplayID(), live.Name)
+		if err := deleteAzureServerWithClient(ctx, client, live); err != nil {
 			return err
 		}
 		leaseID := server.Labels["lease"]
@@ -282,12 +302,45 @@ func deleteServer(ctx context.Context, cfg Config, server Server) error {
 	if err != nil {
 		return err
 	}
+	return deleteAzureServerWithClient(ctx, client, server)
+}
+
+func deleteAzureServerWithClient(ctx context.Context, client azureClient, server Server) error {
 	name := server.CloudID
 	if name == "" {
 		name = server.Name
 	}
 	return client.DeleteServer(ctx, name)
 }
+
+func validateAzureCleanupLiveServer(expected, live Server) error {
+	cloudID := strings.TrimSpace(expected.CloudID)
+	if cloudID == "" || strings.TrimSpace(live.CloudID) != cloudID {
+		return fmt.Errorf("live cloud id %q does not match cleanup candidate %q", live.CloudID, expected.CloudID)
+	}
+	if !isCrabboxAzureLease(live) {
+		return fmt.Errorf("live VM no longer has canonical Crabbox ownership tags")
+	}
+	expectedLeaseID := strings.TrimSpace(expected.Labels["lease"])
+	if liveLeaseID := strings.TrimSpace(live.Labels["lease"]); liveLeaseID != expectedLeaseID {
+		return fmt.Errorf("live VM lease %q does not match cleanup candidate lease %q", liveLeaseID, expectedLeaseID)
+	}
+	return nil
+}
+
+func isAzureCleanupNotFound(err error) bool {
+	var exitErr core.ExitError
+	if core.AsExitError(err, &exitErr) && exitErr.Code == 4 {
+		return true
+	}
+	var responseErr *azcore.ResponseError
+	if errors.As(err, &responseErr) && responseErr.StatusCode == 404 {
+		return true
+	}
+	message := err.Error()
+	return strings.Contains(message, "ResourceNotFound") || strings.Contains(message, "NotFound")
+}
+
 func useStoredTestboxKey(target *SSHTarget, leaseID string) {
 	if keyPath, err := core.TestboxKeyPath(leaseID); err == nil {
 		if _, statErr := os.Stat(keyPath); statErr == nil {

--- a/internal/providers/azure/backend.go
+++ b/internal/providers/azure/backend.go
@@ -228,6 +228,11 @@ func (b *azureLeaseBackend) Cleanup(ctx context.Context, req CleanupRequest) err
 		if err != nil {
 			if isAzureCleanupNotFound(err) {
 				fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=live VM no longer exists\n", server.DisplayID(), server.Name)
+				leaseID := strings.TrimSpace(server.Labels["lease"])
+				if leaseID != "" {
+					removeLeaseClaim(leaseID)
+					core.RemoveStoredTestboxKey(leaseID)
+				}
 				// Do not delete deterministically named companion resources without a live VM proving this lease still owns them.
 				continue
 			}

--- a/internal/providers/azure/backend.go
+++ b/internal/providers/azure/backend.go
@@ -228,12 +228,7 @@ func (b *azureLeaseBackend) Cleanup(ctx context.Context, req CleanupRequest) err
 		if err != nil {
 			if isAzureCleanupNotFound(err) {
 				fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=live VM no longer exists\n", server.DisplayID(), server.Name)
-				leaseID := strings.TrimSpace(server.Labels["lease"])
-				if leaseID != "" {
-					removeLeaseClaim(leaseID)
-					core.RemoveStoredTestboxKey(leaseID)
-				}
-				// Do not delete deterministically named companion resources without a live VM proving this lease still owns them.
+				// Keep local recovery state: neither deterministically named companion resources nor the claim can be cleared without a live VM proving ownership.
 				continue
 			}
 			return fmt.Errorf("re-read Azure cleanup candidate %s: %w", server.DisplayID(), err)

--- a/internal/providers/azure/backend.go
+++ b/internal/providers/azure/backend.go
@@ -38,6 +38,7 @@ type azureClient interface {
 	WaitForServerIP(context.Context, string) (Server, error)
 	GetServer(context.Context, string) (Server, error)
 	DeleteServer(context.Context, string) error
+	DeleteCleanupServer(context.Context, Server, time.Time) error
 	SetTags(context.Context, string, map[string]string) error
 }
 
@@ -241,10 +242,18 @@ func (b *azureLeaseBackend) Cleanup(ctx context.Context, req CleanupRequest) err
 			fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=live VM %s\n", server.DisplayID(), server.Name, reason)
 			continue
 		}
-		fmt.Fprintf(b.RT.Stderr, "delete server id=%s name=%s\n", live.DisplayID(), live.Name)
-		if err := deleteAzureServerWithClient(ctx, client, live); err != nil {
+		if err := client.DeleteCleanupServer(ctx, server, now); err != nil {
+			if core.IsAzureCleanupSkipError(err) {
+				fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=%v\n", live.DisplayID(), live.Name, err)
+				continue
+			}
+			if isAzureCleanupNotFound(err) {
+				fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=live VM no longer exists at delete boundary\n", live.DisplayID(), live.Name)
+				continue
+			}
 			return err
 		}
+		fmt.Fprintf(b.RT.Stderr, "delete server id=%s name=%s\n", live.DisplayID(), live.Name)
 		leaseID := server.Labels["lease"]
 		removeLeaseClaim(leaseID)
 		core.RemoveStoredTestboxKey(leaseID)

--- a/internal/providers/azure/backend_test.go
+++ b/internal/providers/azure/backend_test.go
@@ -431,8 +431,8 @@ func TestAzureCleanupContinuesWhenLiveCandidateAlreadyGone(t *testing.T) {
 	if !strings.Contains(stderr.String(), "reason=live VM no longer exists") {
 		t.Fatalf("stderr=%q, want already-gone skip", stderr.String())
 	}
-	if _, err := os.Stat(filepath.Dir(keyPath)); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("stored lease key directory still exists: %v", err)
+	if _, err := os.Stat(keyPath); err != nil {
+		t.Fatalf("stored lease key was not retained for recovery: %v", err)
 	}
 }
 

--- a/internal/providers/azure/backend_test.go
+++ b/internal/providers/azure/backend_test.go
@@ -400,10 +400,16 @@ func TestAzureCleanupRevalidatesLiveEligibilityBeforeDelete(t *testing.T) {
 }
 
 func TestAzureCleanupContinuesWhenLiveCandidateAlreadyGone(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	missing := azureTestServer("missing", "cbx_111111111111", "missing")
 	remaining := azureTestServer("remaining", "cbx_222222222222", "remaining")
 	for _, server := range []*Server{&missing, &remaining} {
 		server.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
+	}
+	keyPath, _, err := core.EnsureTestboxKeyForConfig(Config{}, missing.Labels["lease"])
+	if err != nil {
+		t.Fatal(err)
 	}
 	fake := &fakeAzureClient{
 		servers: []Server{missing, remaining},
@@ -424,6 +430,9 @@ func TestAzureCleanupContinuesWhenLiveCandidateAlreadyGone(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "reason=live VM no longer exists") {
 		t.Fatalf("stderr=%q, want already-gone skip", stderr.String())
+	}
+	if _, err := os.Stat(filepath.Dir(keyPath)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("stored lease key directory still exists: %v", err)
 	}
 }
 

--- a/internal/providers/azure/backend_test.go
+++ b/internal/providers/azure/backend_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -23,6 +24,9 @@ type fakeAzureClient struct {
 	createErr error
 	waitErr   error
 	getErr    error
+	get       map[string]Server
+	getErrs   map[string]error
+	getIDs    []string
 }
 
 func (c *fakeAzureClient) ListCrabboxServers(context.Context) ([]Server, error) {
@@ -50,8 +54,17 @@ func (c *fakeAzureClient) WaitForServerIP(context.Context, string) (Server, erro
 }
 
 func (c *fakeAzureClient) GetServer(_ context.Context, id string) (Server, error) {
+	c.getIDs = append(c.getIDs, id)
+	if err := c.getErrs[id]; err != nil {
+		return Server{}, err
+	}
 	if c.getErr != nil {
 		return Server{}, c.getErr
+	}
+	if c.get != nil {
+		if server, ok := c.get[id]; ok {
+			return server, nil
+		}
 	}
 	for _, server := range c.servers {
 		if server.CloudID == id || server.Name == id {
@@ -329,6 +342,88 @@ func TestAzureCleanupSkipsWeakTagsAndDeletesCanonicalExpiredVM(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Dir(keyPath)); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("stored lease key directory still exists: %v", err)
+	}
+}
+
+func TestAzureCleanupRevalidatesLiveOwnershipBeforeDelete(t *testing.T) {
+	snapshot := azureTestServer("crabbox-stale", "cbx_123456abcdef", "stale")
+	snapshot.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
+	live := snapshot
+	live.Labels = maps.Clone(snapshot.Labels)
+	live.Labels["lease"] = "cbx_fedcba654321"
+	fake := &fakeAzureClient{
+		servers: []Server{snapshot},
+		get:     map[string]Server{snapshot.CloudID: live},
+	}
+	oldClient := newAzureClient
+	newAzureClient = func(context.Context, Config) (azureClient, error) { return fake, nil }
+	t.Cleanup(func() { newAzureClient = oldClient })
+
+	var stderr strings.Builder
+	backend := NewAzureLeaseBackend(ProviderSpec{}, azureAcquireTestConfig(), Runtime{Stderr: &stderr}).(*azureLeaseBackend)
+	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.getIDs) != 1 || fake.getIDs[0] != snapshot.CloudID {
+		t.Fatalf("live lookups=%v, want %s", fake.getIDs, snapshot.CloudID)
+	}
+	if len(fake.deleted) != 0 {
+		t.Fatalf("cleanup crossed changed ownership: deleted=%v", fake.deleted)
+	}
+	if !strings.Contains(stderr.String(), "does not match cleanup candidate lease") {
+		t.Fatalf("stderr=%q, want changed-lease skip", stderr.String())
+	}
+}
+
+func TestAzureCleanupRevalidatesLiveEligibilityBeforeDelete(t *testing.T) {
+	snapshot := azureTestServer("crabbox-renewed", "cbx_123456abcdef", "renewed")
+	snapshot.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
+	live := snapshot
+	live.Labels = maps.Clone(snapshot.Labels)
+	live.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(time.Hour))
+	fake := &fakeAzureClient{servers: []Server{snapshot}, get: map[string]Server{snapshot.CloudID: live}}
+	oldClient := newAzureClient
+	newAzureClient = func(context.Context, Config) (azureClient, error) { return fake, nil }
+	t.Cleanup(func() { newAzureClient = oldClient })
+
+	var stderr strings.Builder
+	backend := NewAzureLeaseBackend(ProviderSpec{}, azureAcquireTestConfig(), Runtime{Stderr: &stderr}).(*azureLeaseBackend)
+	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.deleted) != 0 {
+		t.Fatalf("cleanup deleted renewed VM: %v", fake.deleted)
+	}
+	if !strings.Contains(stderr.String(), "reason=live VM") {
+		t.Fatalf("stderr=%q, want renewed-live skip", stderr.String())
+	}
+}
+
+func TestAzureCleanupContinuesWhenLiveCandidateAlreadyGone(t *testing.T) {
+	missing := azureTestServer("missing", "cbx_111111111111", "missing")
+	remaining := azureTestServer("remaining", "cbx_222222222222", "remaining")
+	for _, server := range []*Server{&missing, &remaining} {
+		server.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
+	}
+	fake := &fakeAzureClient{
+		servers: []Server{missing, remaining},
+		get:     map[string]Server{remaining.CloudID: remaining},
+		getErrs: map[string]error{missing.CloudID: core.Exit(4, "azure vm not found: %s", missing.CloudID)},
+	}
+	oldClient := newAzureClient
+	newAzureClient = func(context.Context, Config) (azureClient, error) { return fake, nil }
+	t.Cleanup(func() { newAzureClient = oldClient })
+
+	var stderr strings.Builder
+	backend := NewAzureLeaseBackend(ProviderSpec{}, azureAcquireTestConfig(), Runtime{Stderr: &stderr}).(*azureLeaseBackend)
+	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.deleted) != 1 || fake.deleted[0] != remaining.CloudID {
+		t.Fatalf("deleted=%v, want only remaining candidate", fake.deleted)
+	}
+	if !strings.Contains(stderr.String(), "reason=live VM no longer exists") {
+		t.Fatalf("stderr=%q, want already-gone skip", stderr.String())
 	}
 }
 

--- a/internal/providers/azure/backend_test.go
+++ b/internal/providers/azure/backend_test.go
@@ -15,18 +15,19 @@ import (
 )
 
 type fakeAzureClient struct {
-	deleted   []string
-	tagged    []string
-	servers   []Server
-	listErr   error
-	created   Server
-	createCfg Config
-	createErr error
-	waitErr   error
-	getErr    error
-	get       map[string]Server
-	getErrs   map[string]error
-	getIDs    []string
+	deleted         []string
+	cleanupExpected []Server
+	tagged          []string
+	servers         []Server
+	listErr         error
+	created         Server
+	createCfg       Config
+	createErr       error
+	waitErr         error
+	getErr          error
+	get             map[string]Server
+	getErrs         map[string]error
+	getIDs          []string
 }
 
 func (c *fakeAzureClient) ListCrabboxServers(context.Context) ([]Server, error) {
@@ -76,6 +77,12 @@ func (c *fakeAzureClient) GetServer(_ context.Context, id string) (Server, error
 
 func (c *fakeAzureClient) DeleteServer(_ context.Context, name string) error {
 	c.deleted = append(c.deleted, name)
+	return nil
+}
+
+func (c *fakeAzureClient) DeleteCleanupServer(_ context.Context, server Server, _ time.Time) error {
+	c.cleanupExpected = append(c.cleanupExpected, server)
+	c.deleted = append(c.deleted, server.CloudID)
 	return nil
 }
 
@@ -396,6 +403,26 @@ func TestAzureCleanupRevalidatesLiveEligibilityBeforeDelete(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "reason=live VM") {
 		t.Fatalf("stderr=%q, want renewed-live skip", stderr.String())
+	}
+}
+
+func TestAzureCleanupDeleteBoundaryUsesOriginalCandidate(t *testing.T) {
+	snapshot := azureTestServer("candidate", "cbx_111111111111", "original")
+	snapshot.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
+	live := snapshot
+	live.Labels = maps.Clone(snapshot.Labels)
+	live.Labels["slug"] = "changed"
+	fake := &fakeAzureClient{servers: []Server{snapshot}, get: map[string]Server{snapshot.CloudID: live}}
+	oldClient := newAzureClient
+	newAzureClient = func(context.Context, Config) (azureClient, error) { return fake, nil }
+	t.Cleanup(func() { newAzureClient = oldClient })
+
+	backend := NewAzureLeaseBackend(ProviderSpec{}, azureAcquireTestConfig(), Runtime{Stderr: io.Discard}).(*azureLeaseBackend)
+	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.cleanupExpected) != 1 || fake.cleanupExpected[0].Labels["slug"] != "original" {
+		t.Fatalf("cleanup boundary candidates=%v, want original list candidate", fake.cleanupExpected)
 	}
 }
 

--- a/internal/providers/gcp/backend.go
+++ b/internal/providers/gcp/backend.go
@@ -278,14 +278,15 @@ func (b *gcpLeaseBackend) Cleanup(ctx context.Context, req CleanupRequest) error
 			liveLeaseIDs[leaseID] = struct{}{}
 		}
 	}
+	now := time.Now().UTC()
 	for _, server := range servers {
-		shouldDelete, reason := core.ShouldCleanupServer(server, time.Now().UTC())
+		shouldDelete, reason := core.ShouldCleanupServer(server, now)
 		if !shouldDelete {
 			fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=%s\n", server.DisplayID(), server.Name, reason)
 			continue
 		}
-		fmt.Fprintf(b.RT.Stderr, "delete server id=%s name=%s\n", server.DisplayID(), server.Name)
 		if req.DryRun {
+			fmt.Fprintf(b.RT.Stderr, "delete server id=%s name=%s\n", server.DisplayID(), server.Name)
 			continue
 		}
 		cfg := b.Cfg
@@ -296,7 +297,27 @@ func (b *gcpLeaseBackend) Cleanup(ctx context.Context, req CleanupRequest) error
 		if err != nil {
 			return err
 		}
-		if err := client.DeleteServer(ctx, server.CloudID); err != nil {
+		live, err := client.GetServer(ctx, server.CloudID)
+		if err != nil {
+			if core.IsGCPNotFound(err) {
+				fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=live instance no longer exists\n", server.DisplayID(), server.Name)
+				if leaseID := strings.TrimSpace(server.Labels["lease"]); leaseID != "" {
+					removeLeaseClaim(leaseID)
+				}
+				continue
+			}
+			return fmt.Errorf("re-read GCP cleanup candidate %s: %w", server.DisplayID(), err)
+		}
+		if err := validateGCPCleanupLiveServer(server, live); err != nil {
+			fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=%v\n", server.DisplayID(), server.Name, err)
+			continue
+		}
+		if shouldDelete, reason := core.ShouldCleanupServer(live, now); !shouldDelete {
+			fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=live instance %s\n", server.DisplayID(), server.Name, reason)
+			continue
+		}
+		fmt.Fprintf(b.RT.Stderr, "delete server id=%s name=%s\n", live.DisplayID(), live.Name)
+		if err := client.DeleteServer(ctx, live.CloudID); err != nil {
 			return err
 		}
 		if leaseID := strings.TrimSpace(server.Labels["lease"]); leaseID != "" {
@@ -305,6 +326,21 @@ func (b *gcpLeaseBackend) Cleanup(ctx context.Context, req CleanupRequest) error
 	}
 	if err := b.pruneStaleClaims(liveLeaseIDs, req.DryRun); err != nil {
 		return err
+	}
+	return nil
+}
+
+func validateGCPCleanupLiveServer(expected, live Server) error {
+	cloudID := strings.TrimSpace(expected.CloudID)
+	if cloudID == "" || strings.TrimSpace(live.CloudID) != cloudID {
+		return fmt.Errorf("live cloud id %q does not match cleanup candidate %q", live.CloudID, expected.CloudID)
+	}
+	if !isCrabboxGCPLease(live) {
+		return fmt.Errorf("live instance no longer has canonical Crabbox ownership labels")
+	}
+	expectedLeaseID := strings.TrimSpace(expected.Labels["lease"])
+	if liveLeaseID := strings.TrimSpace(live.Labels["lease"]); liveLeaseID != expectedLeaseID {
+		return fmt.Errorf("live instance lease %q does not match cleanup candidate lease %q", liveLeaseID, expectedLeaseID)
 	}
 	return nil
 }

--- a/internal/providers/gcp/backend_doctor_test.go
+++ b/internal/providers/gcp/backend_doctor_test.go
@@ -5,11 +5,14 @@ import (
 	"context"
 	"errors"
 	"io"
+	"maps"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"google.golang.org/api/googleapi"
 )
 
 type fakeGCPDoctorClient struct {
@@ -165,26 +168,28 @@ func TestGCPCleanupRemovesDeletedAndStaleClaims(t *testing.T) {
 	if err := core.ClaimLeaseForRepoProviderScope(otherProjectLeaseID, "other-box", "gcp", "project:project-b", repo, time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
-	fake := &fakeGCPDoctorClient{servers: []Server{
-		{
-			CloudID: core.LeaseProviderName(expiredLeaseID, "expired-box"),
-			Name:    core.LeaseProviderName(expiredLeaseID, "expired-box"),
-			Labels: map[string]string{
-				"crabbox": "true", "created_by": "crabbox", "provider": "gcp",
-				"lease": expiredLeaseID, "slug": "expired-box",
-				"state": "ready", "expires_at": core.LeaseLabelTime(time.Now().Add(-time.Hour)),
-			},
+	expired := Server{
+		CloudID: core.LeaseProviderName(expiredLeaseID, "expired-box"),
+		Name:    core.LeaseProviderName(expiredLeaseID, "expired-box"),
+		Labels: map[string]string{
+			"crabbox": "true", "created_by": "crabbox", "provider": "gcp",
+			"lease": expiredLeaseID, "slug": "expired-box",
+			"state": "ready", "expires_at": core.LeaseLabelTime(time.Now().Add(-time.Hour)),
 		},
-		{
-			CloudID: "crabbox-forged",
-			Name:    "crabbox-forged",
-			Labels: map[string]string{
-				"crabbox": "true", "created_by": "crabbox", "provider": "gcp",
-				"lease": "cbx_444444444444", "slug": "forged",
-				"state": "ready", "expires_at": core.LeaseLabelTime(time.Now().Add(-time.Hour)),
-			},
-		},
-	}}
+	}
+	fake := &fakeGCPDoctorClient{
+		servers: []Server{expired,
+			{
+				CloudID: "crabbox-forged",
+				Name:    "crabbox-forged",
+				Labels: map[string]string{
+					"crabbox": "true", "created_by": "crabbox", "provider": "gcp",
+					"lease": "cbx_444444444444", "slug": "forged",
+					"state": "ready", "expires_at": core.LeaseLabelTime(time.Now().Add(-time.Hour)),
+				},
+			}},
+		get: map[string]Server{expired.CloudID: expired},
+	}
 	old := newGCPClient
 	newGCPClient = func(context.Context, Config) (gcpClient, error) {
 		return fake, nil
@@ -223,6 +228,95 @@ func TestGCPCleanupRemovesDeletedAndStaleClaims(t *testing.T) {
 	if !strings.Contains(out, "delete server id="+core.LeaseProviderName(expiredLeaseID, "expired-box")) ||
 		!strings.Contains(out, "remove stale claim lease="+staleLeaseID) {
 		t.Fatalf("cleanup output=%q", out)
+	}
+}
+
+func TestGCPCleanupRevalidatesLiveOwnershipBeforeDelete(t *testing.T) {
+	snapshot := canonicalGCPTestServer("cbx_111111111111", "stale")
+	snapshot.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
+	live := snapshot
+	live.Labels = maps.Clone(snapshot.Labels)
+	delete(live.Labels, "created_by")
+	fake := &fakeGCPDoctorClient{
+		servers: []Server{snapshot},
+		get:     map[string]Server{snapshot.CloudID: live},
+	}
+	old := newGCPClient
+	newGCPClient = func(context.Context, Config) (gcpClient, error) { return fake, nil }
+	t.Cleanup(func() { newGCPClient = old })
+
+	var stderr bytes.Buffer
+	backend := NewGCPLeaseBackend(core.ProviderSpec{}, Config{Provider: "gcp", GCPProject: "project-a"}, Runtime{Stderr: &stderr}).(*gcpLeaseBackend)
+	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.deleted) != 0 {
+		t.Fatalf("cleanup crossed changed ownership: deleted=%v", fake.deleted)
+	}
+	if !strings.Contains(stderr.String(), "live instance no longer has canonical Crabbox ownership labels") {
+		t.Fatalf("stderr=%q, want changed-ownership skip", stderr.String())
+	}
+}
+
+func TestGCPCleanupRevalidatesLiveEligibilityBeforeDelete(t *testing.T) {
+	snapshot := canonicalGCPTestServer("cbx_111111111111", "renewed")
+	snapshot.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
+	live := snapshot
+	live.Labels = maps.Clone(snapshot.Labels)
+	live.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(time.Hour))
+	fake := &fakeGCPDoctorClient{servers: []Server{snapshot}, get: map[string]Server{snapshot.CloudID: live}}
+	old := newGCPClient
+	newGCPClient = func(context.Context, Config) (gcpClient, error) { return fake, nil }
+	t.Cleanup(func() { newGCPClient = old })
+
+	var stderr bytes.Buffer
+	backend := NewGCPLeaseBackend(core.ProviderSpec{}, Config{Provider: "gcp", GCPProject: "project-a"}, Runtime{Stderr: &stderr}).(*gcpLeaseBackend)
+	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.deleted) != 0 {
+		t.Fatalf("cleanup deleted renewed instance: %v", fake.deleted)
+	}
+	if !strings.Contains(stderr.String(), "reason=live instance") {
+		t.Fatalf("stderr=%q, want renewed-live skip", stderr.String())
+	}
+}
+
+func TestGCPCleanupTreatsMissingLiveInstanceAsAlreadyDeleted(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	repo := t.TempDir()
+	leaseID := "cbx_111111111111"
+	slug := "gone"
+	if err := core.ClaimLeaseForRepoProviderScope(leaseID, slug, "gcp", "project:project-a", repo, time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	snapshot := canonicalGCPTestServer(leaseID, slug)
+	snapshot.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
+	fake := &fakeGCPDoctorClient{
+		servers: []Server{snapshot},
+		getErr:  &googleapi.Error{Code: http.StatusNotFound, Message: "instance gone"},
+	}
+	old := newGCPClient
+	newGCPClient = func(context.Context, Config) (gcpClient, error) { return fake, nil }
+	t.Cleanup(func() { newGCPClient = old })
+
+	var stderr bytes.Buffer
+	backend := NewGCPLeaseBackend(core.ProviderSpec{}, Config{Provider: "gcp", GCPProject: "project-a"}, Runtime{Stderr: &stderr}).(*gcpLeaseBackend)
+	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.deleted) != 0 {
+		t.Fatalf("cleanup retried delete for missing instance: %v", fake.deleted)
+	}
+	claim, err := core.ReadLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claim.LeaseID != "" {
+		t.Fatalf("missing-instance claim was not removed: %#v", claim)
+	}
+	if !strings.Contains(stderr.String(), "live instance no longer exists") {
+		t.Fatalf("stderr=%q, want already-deleted diagnostic", stderr.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

- re-read AWS, Azure, and GCP cleanup candidates from the provider immediately before destructive cleanup
- require exact provider identity, canonical Crabbox ownership, lease binding, provider key, and current cleanup eligibility
- verify AWS key-pair ownership and Azure NIC, public IP, managed disk, and quarantine NSG identity before deleting companion resources
- fail closed on drift and preserve local recovery state when a candidate is missing, changed, or no longer owned

Fixes https://github.com/openclaw/crabbox/issues/880

## Verification

- `go test -race ./...`
- `go vet ./...`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker` (26 files, 794 tests)
- `npm run build --prefix worker`
- `node scripts/build-docs-site.mjs`
- structured autoreview: no accepted/actionable findings

## Live proof

Azure exact PR head `881bf2dcebec9293069b37abe9a5e54058127166`:

1. Created a dedicated resource group and a real disposable spot VM through the direct Azure provider.
2. Ran a command over SSH and observed `issue880-exact-live-use-ok`.
3. Changed the associated NIC ownership tag to an external value.
4. Ran cleanup and verified it refused deletion, left the VM running, and preserved the local recovery claim.
5. Restored canonical ownership, ran cleanup, and verified the VM, NIC, public IP, and managed disk were deleted.
6. Verified only the shared VNet and NSG remained, deleted the dedicated resource group, verified the group no longer exists, and verified no local lease remained.

## Merge gate

Do not merge until the exact PR head has equivalent authenticated create/use/drift-denial/destroy/zero-residue proof for AWS and GCP, or the owner gives an explicit provider-specific waiver.

- AWS: no valid local CLI or targeted 1Password credential was available.
- GCP: user CLI auth is valid, but application-default credentials require browser consent.
- Existing Chrome automation is blocked because the Codex native-host manifest is missing; no isolated-browser or persistent-key workaround was used.
