### PR TITLE
fix(worker): bind GitHub OAuth callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- Required a canonical public origin for GitHub OAuth and bound callbacks to the initiating origin before exchanging codes or issuing sessions. Thanks @coygeek.
 - Redacted configured credentials, authorization headers, signed URLs, URL userinfo, and secret-bearing JSON fields before coordinator provider diagnostics are stored or returned. Thanks @coygeek.
 - Redacted broker URL userinfo, queries, and fragments from `login`, `whoami`, and `doctor` text and JSON output. Thanks @coygeek.
 - Redacted Parallels top-level, template, and fleet-host SSH private keys from `config show --json` while preserving non-secret routing metadata. Thanks @coygeek.

--- a/docs/features/broker-auth-routing.md
+++ b/docs/features/broker-auth-routing.md
@@ -141,7 +141,8 @@ https://broker.example.com/v1/auth/github/callback
 The OAuth app requests the scopes `read:user user:email read:org`. A self-hosted coordinator
 needs its own OAuth app: the callback URL must exactly match the public origin, and the
 `CRABBOX_PUBLIC_URL` must use that same origin (it is used to build the callback and
-to canonicalize portal redirects).
+to canonicalize portal redirects). GitHub OAuth refuses to start without this setting,
+and callbacks from another origin are rejected before code exchange or session issuance.
 
 The CLI treats that callback origin as a credential destination. If a login response
 from one broker points at a different callback origin, `crabbox login` fails before

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -216,13 +216,14 @@ Homepage URL: https://broker.example.com
 Callback URL: https://broker.example.com/v1/auth/github/callback
 ```
 
-The coordinator derives the callback from `CRABBOX_PUBLIC_URL` (falling back to
-the request origin). Inject the OAuth app values through the runtime's secret
-mechanism:
+The coordinator derives the callback from the required `CRABBOX_PUBLIC_URL` and
+rejects callbacks from other origins before code exchange. Inject the OAuth app
+values through the runtime's secret mechanism:
 
 ```text
 CRABBOX_GITHUB_CLIENT_ID
 CRABBOX_GITHUB_CLIENT_SECRET
+CRABBOX_PUBLIC_URL               # canonical HTTPS coordinator origin
 CRABBOX_SESSION_SECRET            # signs cbxu_ user tokens; required and distinct from CRABBOX_SHARED_TOKEN
 CRABBOX_GITHUB_ALLOWED_ORG       # or CRABBOX_GITHUB_ALLOWED_ORGS (comma-separated)
 CRABBOX_GITHUB_ALLOWED_TEAMS     # optional: restrict to org teams (alias CRABBOX_GITHUB_ALLOWED_TEAM)

--- a/docs/security.md
+++ b/docs/security.md
@@ -220,6 +220,9 @@ polling, or config write. Operators who are deliberately migrating between
 same-deployment broker aliases can allow specific callback origins with trusted
 user config `broker.loginRedirectOrigins` or
 `CRABBOX_BROKER_LOGIN_REDIRECT_ORIGINS`.
+The coordinator separately requires `CRABBOX_PUBLIC_URL` before GitHub OAuth can
+start, stores that exact callback with each pending login, and rejects callbacks
+from any other origin before exchanging the authorization code.
 
 Provider clients apply the same destination principle where custom endpoints
 are supported. Cloudflare runner, Morph, Railway, and RunPod requests reject

--- a/worker/src/oauth.ts
+++ b/worker/src/oauth.ts
@@ -25,6 +25,7 @@ interface OAuthPending {
   mode?: "cli" | "portal";
   provider?: Provider;
   returnTo?: string;
+  redirectURI: string;
   createdAt: string;
   expiresAt: string;
   token?: string;
@@ -87,6 +88,10 @@ export async function githubPortalLogin(
   if (!clientID || !env.CRABBOX_GITHUB_CLIENT_SECRET) {
     return html("Crabbox login unavailable", "GitHub OAuth is not configured.", 503);
   }
+  const oauthConfig = githubOAuthConfiguration(env);
+  if ("error" in oauthConfig) {
+    return html("Crabbox login unavailable", oauthConfig.message, 503);
+  }
   const signingError = userTokenSigningConfigurationError(env);
   if (signingError) {
     return html("Crabbox login unavailable", signingError, 503);
@@ -99,10 +104,11 @@ export async function githubPortalLogin(
   const pending = newPendingOAuth({
     mode: "portal",
     returnTo: safePortalReturnTo(url.searchParams.get("returnTo")),
+    redirectURI: oauthConfig.redirectURI,
   });
   await storePendingOAuth(storage, pending);
 
-  return redirect(githubAuthorizeURLFor(request, env, clientID, pending.state), 302);
+  return redirect(githubAuthorizeURLFor(clientID, pending.state, pending.redirectURI), 302);
 }
 
 export function githubPortalLogout(): Response {
@@ -129,6 +135,10 @@ async function githubAuthStart(
       { status: 503 },
     );
   }
+  const oauthConfig = githubOAuthConfiguration(env);
+  if ("error" in oauthConfig) {
+    return json({ error: oauthConfig.error, message: oauthConfig.message }, { status: 503 });
+  }
   const signingError = userTokenSigningConfigurationError(env);
   if (signingError) {
     return json({ error: "github_session_secret_invalid", message: signingError }, { status: 503 });
@@ -153,6 +163,7 @@ async function githubAuthStart(
   const pending = newPendingOAuth({
     mode: "cli",
     pollSecretHash: input.pollSecretHash,
+    redirectURI: oauthConfig.redirectURI,
   });
   if (input.provider === "aws" || input.provider === "hetzner" || input.provider === "gcp") {
     pending.provider = input.provider;
@@ -161,7 +172,7 @@ async function githubAuthStart(
 
   return json({
     loginID: pending.id,
-    url: githubAuthorizeURLFor(request, env, clientID, pending.state),
+    url: githubAuthorizeURLFor(clientID, pending.state, pending.redirectURI),
     expiresAt: pending.expiresAt,
   });
 }
@@ -187,15 +198,10 @@ async function storePendingOAuth(
   await storage.put(oauthStateKey(pending.state), pending.id);
 }
 
-function githubAuthorizeURLFor(
-  request: Request,
-  env: Env,
-  clientID: string,
-  state: string,
-): string {
+function githubAuthorizeURLFor(clientID: string, state: string, redirectURI: string): string {
   const authorize = new URL(githubAuthorizeURL);
   authorize.searchParams.set("client_id", clientID);
-  authorize.searchParams.set("redirect_uri", githubRedirectURI(request, env));
+  authorize.searchParams.set("redirect_uri", redirectURI);
   authorize.searchParams.set("scope", "read:user user:email read:org");
   authorize.searchParams.set("state", state);
   return authorize.toString();
@@ -207,6 +213,17 @@ async function githubAuthCallback(
   env: Env,
 ): Promise<Response> {
   const url = new URL(request.url);
+  const oauthConfig = githubOAuthConfiguration(env);
+  if ("error" in oauthConfig) {
+    return html("Crabbox login unavailable", oauthConfig.message, 503);
+  }
+  if (url.origin !== new URL(oauthConfig.redirectURI).origin) {
+    return html(
+      "Crabbox login denied",
+      "The GitHub OAuth callback did not arrive on the configured public origin.",
+      403,
+    );
+  }
   const code = url.searchParams.get("code") ?? "";
   const state = url.searchParams.get("state") ?? "";
   const error = url.searchParams.get("error") ?? "";
@@ -215,6 +232,11 @@ async function githubAuthCallback(
     return claimed.response;
   }
   const { pending, claim } = claimed;
+  if (pending.redirectURI !== oauthConfig.redirectURI) {
+    const message = "The GitHub OAuth public origin changed. Start a new login.";
+    await finishPendingOAuth(runtime, pending.id, claim, { error: message });
+    return html("Crabbox login unavailable", message, 503);
+  }
   if (error || !code) {
     await finishPendingOAuth(runtime, pending.id, claim, {
       error: error || "missing_code",
@@ -227,7 +249,7 @@ async function githubAuthCallback(
     return html("Crabbox login unavailable", signingError, 503);
   }
   try {
-    const accessToken = await exchangeGitHubCode(code, githubRedirectURI(request, env), env);
+    const accessToken = await exchangeGitHubCode(code, pending.redirectURI, env);
     const identity = await githubIdentity(accessToken);
     const requestedOrg = requestOrg(
       new Request(request.url, {
@@ -404,9 +426,42 @@ function userTokenTTLSeconds(env: Pick<Env, "CRABBOX_USER_TOKEN_TTL_SECONDS">): 
   return Math.min(maxUserTokenTTLSeconds, Math.max(minUserTokenTTLSeconds, Math.trunc(value)));
 }
 
-function githubRedirectURI(request: Request, env: Env): string {
-  const base = env.CRABBOX_PUBLIC_URL || new URL(request.url).origin;
-  return `${base.replace(/\/+$/, "")}/v1/auth/github/callback`;
+function githubOAuthConfiguration(
+  env: Pick<Env, "CRABBOX_PUBLIC_URL">,
+): { redirectURI: string } | { error: string; message: string } {
+  const configured = env.CRABBOX_PUBLIC_URL?.trim();
+  if (!configured) {
+    return {
+      error: "github_public_url_required",
+      message: "CRABBOX_PUBLIC_URL is required before GitHub OAuth can start.",
+    };
+  }
+  let publicURL: URL;
+  try {
+    publicURL = new URL(configured);
+  } catch {
+    return {
+      error: "github_public_url_invalid",
+      message: "CRABBOX_PUBLIC_URL must be a valid canonical HTTPS origin.",
+    };
+  }
+  const loopbackHTTP =
+    publicURL.protocol === "http:" &&
+    (publicURL.hostname === "localhost" ||
+      publicURL.hostname === "127.0.0.1" ||
+      publicURL.hostname === "[::1]");
+  if (
+    (publicURL.protocol !== "https:" && !loopbackHTTP) ||
+    publicURL.username !== "" ||
+    publicURL.password !== ""
+  ) {
+    return {
+      error: "github_public_url_invalid",
+      message:
+        "CRABBOX_PUBLIC_URL must be a canonical HTTPS origin (HTTP is allowed only for loopback development).",
+    };
+  }
+  return { redirectURI: `${publicURL.origin}/v1/auth/github/callback` };
 }
 
 async function exchangeGitHubCode(code: string, redirectURI: string, env: Env): Promise<string> {

--- a/worker/test/coordinator-runtime.test.ts
+++ b/worker/test/coordinator-runtime.test.ts
@@ -545,6 +545,7 @@ describe("coordinator runtimes", () => {
     const runtime = new MemoryRuntime();
     const env = {
       CRABBOX_DEFAULT_ORG: "example-org",
+      CRABBOX_PUBLIC_URL: "https://coordinator.test",
       CRABBOX_GITHUB_CLIENT_ID: "github-client",
       CRABBOX_GITHUB_CLIENT_SECRET: "github-secret",
       CRABBOX_SHARED_TOKEN: "shared",

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -20725,6 +20725,7 @@ describe("fleet identity", () => {
       { storage } as unknown as DurableObjectState,
       {
         CRABBOX_DEFAULT_ORG: "openclaw",
+        CRABBOX_PUBLIC_URL: "https://broker.example.test",
         CRABBOX_GITHUB_CLIENT_ID: "github-client",
         CRABBOX_GITHUB_CLIENT_SECRET: "github-secret",
         CRABBOX_SHARED_TOKEN: "shared",
@@ -20746,6 +20747,9 @@ describe("fleet identity", () => {
     const url = new URL(body.url);
     expect(url.origin + url.pathname).toBe("https://github.com/login/oauth/authorize");
     expect(url.searchParams.get("client_id")).toBe("github-client");
+    expect(url.searchParams.get("redirect_uri")).toBe(
+      "https://broker.example.test/v1/auth/github/callback",
+    );
     expect(url.searchParams.get("scope")).toBe("read:user user:email read:org");
 
     const poll = await fleet.fetch(
@@ -20760,12 +20764,66 @@ describe("fleet identity", () => {
     await expect(poll.json()).resolves.toMatchObject({ status: "pending" });
   });
 
+  it("requires a canonical public origin before GitHub login starts", async () => {
+    const storage = new MemoryStorage();
+    const fleet = new FleetDurableObject(
+      { storage } as unknown as DurableObjectState,
+      {
+        CRABBOX_DEFAULT_ORG: "openclaw",
+        CRABBOX_GITHUB_CLIENT_ID: "github-client",
+        CRABBOX_GITHUB_CLIENT_SECRET: "github-secret",
+        CRABBOX_SHARED_TOKEN: "shared",
+        CRABBOX_SESSION_SECRET: "session-secret",
+      } as Env,
+    );
+
+    const start = await fleet.fetch(
+      request("POST", "/v1/auth/github/start", {
+        body: { pollSecretHash: await sha256HexForTest("local-poll-secret") },
+      }),
+    );
+    expect(start.status).toBe(503);
+    await expect(start.json()).resolves.toMatchObject({
+      error: "github_public_url_required",
+      message: "CRABBOX_PUBLIC_URL is required before GitHub OAuth can start.",
+    });
+
+    const portal = await fleet.fetch(request("GET", "/portal/login"));
+    expect(portal.status).toBe(503);
+    expect(await portal.text()).toContain(
+      "CRABBOX_PUBLIC_URL is required before GitHub OAuth can start.",
+    );
+    expect((await storage.list({ prefix: "oauth:" })).size).toBe(0);
+  });
+
+  it("rejects GitHub callbacks from a different origin before code exchange", async () => {
+    const { fleet, state } = await startGitHubLogin();
+    const fetchMock = githubFetchMock({ member: true });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const wrongOrigin = await fleet.fetch(
+      new Request(`https://attacker.example/v1/auth/github/callback?code=ok&state=${state}`),
+    );
+    expect(wrongOrigin.status).toBe(403);
+    expect(await wrongOrigin.text()).toContain(
+      "The GitHub OAuth callback did not arrive on the configured public origin.",
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    const canonical = await fleet.fetch(
+      request("GET", `/v1/auth/github/callback?code=ok&state=${state}`),
+    );
+    expect(canonical.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalled();
+  });
+
   it("reports missing signing material before GitHub login starts", async () => {
     const storage = new MemoryStorage();
     const fleet = new FleetDurableObject(
       { storage } as unknown as DurableObjectState,
       {
         CRABBOX_DEFAULT_ORG: "openclaw",
+        CRABBOX_PUBLIC_URL: "https://crabbox.test",
         CRABBOX_GITHUB_CLIENT_ID: "github-client",
         CRABBOX_GITHUB_CLIENT_SECRET: "github-secret",
         CRABBOX_SHARED_TOKEN: "shared",
@@ -20795,6 +20853,7 @@ describe("fleet identity", () => {
       { storage: new MemoryStorage() } as unknown as DurableObjectState,
       {
         CRABBOX_DEFAULT_ORG: "openclaw",
+        CRABBOX_PUBLIC_URL: "https://crabbox.test",
         CRABBOX_GITHUB_CLIENT_ID: "github-client",
         CRABBOX_GITHUB_CLIENT_SECRET: "github-secret",
         CRABBOX_SHARED_TOKEN: "shared",
@@ -20820,6 +20879,7 @@ describe("fleet identity", () => {
       { storage } as unknown as DurableObjectState,
       {
         CRABBOX_DEFAULT_ORG: "openclaw",
+        CRABBOX_PUBLIC_URL: "https://crabbox.test",
         CRABBOX_GITHUB_CLIENT_ID: "github-client",
         CRABBOX_GITHUB_CLIENT_SECRET: "github-secret",
         CRABBOX_SHARED_TOKEN: "shared",
@@ -20855,6 +20915,7 @@ describe("fleet identity", () => {
       { storage } as unknown as DurableObjectState,
       {
         CRABBOX_DEFAULT_ORG: "openclaw",
+        CRABBOX_PUBLIC_URL: "https://crabbox.test",
         CRABBOX_GITHUB_CLIENT_ID: "github-client",
         CRABBOX_GITHUB_CLIENT_SECRET: "github-secret",
         CRABBOX_SHARED_TOKEN: "shared",
@@ -20894,6 +20955,7 @@ describe("fleet identity", () => {
       { storage } as unknown as DurableObjectState,
       {
         CRABBOX_DEFAULT_ORG: "openclaw",
+        CRABBOX_PUBLIC_URL: "https://crabbox.test",
         CRABBOX_GITHUB_CLIENT_ID: "github-client",
         CRABBOX_GITHUB_CLIENT_SECRET: "github-secret",
         CRABBOX_SHARED_TOKEN: "shared",
@@ -21318,6 +21380,7 @@ async function startGitHubLogin(env: Partial<Env> = {}): Promise<{
     { storage } as unknown as DurableObjectState,
     {
       CRABBOX_DEFAULT_ORG: "openclaw",
+      CRABBOX_PUBLIC_URL: "https://crabbox.test",
       CRABBOX_GITHUB_CLIENT_ID: "github-client",
       CRABBOX_GITHUB_CLIENT_SECRET: "github-secret",
       CRABBOX_SHARED_TOKEN: "shared",


### PR DESCRIPTION
## Summary

- require `CRABBOX_PUBLIC_URL` before CLI or portal GitHub OAuth can start
- accept HTTPS canonical origins, plus loopback HTTP for local development
- store the exact callback URI with each pending login and use it for authorization and token exchange
- reject callbacks from any other origin before claiming state, exchanging the code, or issuing a session

Fixes https://github.com/openclaw/crabbox/issues/867

## Verification

- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker` (26 files, 796 tests)
- `npm run build --prefix worker`
- `node scripts/build-docs-site.mjs`
- `go test ./...`
- `go vet ./...`
- structured autoreview: no accepted/actionable findings

Regression coverage verifies that missing canonical configuration creates no pending OAuth state, the authorization URL uses the configured callback, a wrong-origin callback performs no GitHub request, and the same pending state still completes on the canonical origin.

## Live proof

Deployed the exact runtime source from this PR as a disposable Cloudflare Worker with non-secret placeholder OAuth values and deliberately omitted `CRABBOX_PUBLIC_URL`. The current head adds only a documentation follow-up after that live run.

- `GET /portal/login` returned HTTP 503 with `CRABBOX_PUBLIC_URL is required before GitHub OAuth can start.`
- `POST /v1/auth/github/start` returned HTTP 503 with `github_public_url_required`.
- deleted the disposable Worker and verified its URL returned 404.

No production route, OAuth credential, or coordinator state was changed.
