### PR TITLE
Fix Azure lease readiness cleanup

### DIFF
--- a/worker/src/azure.ts
+++ b/worker/src/azure.ts
@@ -28,10 +28,12 @@ const MIN_LRO_POLL_INTERVAL_MS = 15_000;
 const DEFAULT_AZURE_NETWORK_LRO_TIMEOUT_MS = 60_000;
 const DEFAULT_AZURE_VM_CREATE_TIMEOUT_MS = 180_000;
 const DEFAULT_AZURE_SPOT_FALLBACK_MS = 120_000;
-const DEFAULT_AZURE_LINUX_IMAGE = "Canonical:ubuntu-26_04-lts:server:latest";
-const DEFAULT_AZURE_LINUX_ARM64_IMAGE = "Canonical:ubuntu-26_04-lts:server-arm64:latest";
 const AZURE_NOBLE_LINUX_IMAGE = "Canonical:ubuntu-24_04-lts:server:latest";
 const AZURE_NOBLE_LINUX_ARM64_IMAGE = "Canonical:ubuntu-24_04-lts:server-arm64:latest";
+const DEFAULT_AZURE_LINUX_IMAGE = AZURE_NOBLE_LINUX_IMAGE;
+const DEFAULT_AZURE_LINUX_ARM64_IMAGE = AZURE_NOBLE_LINUX_ARM64_IMAGE;
+const AZURE_ORACULAR_LINUX_IMAGE = "Canonical:ubuntu-26_04-lts:server:latest";
+const AZURE_ORACULAR_LINUX_ARM64_IMAGE = "Canonical:ubuntu-26_04-lts:server-arm64:latest";
 const LEGACY_AZURE_JAMMY_IMAGE = "Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest";
 const LEGACY_AZURE_NOBLE_GEN2_IMAGE =
   "Canonical:0001-com-ubuntu-server-noble:24_04-lts-gen2:latest";
@@ -1685,6 +1687,8 @@ function isAzureDefaultLinuxImage(image: string): boolean {
     image.trim() === DEFAULT_AZURE_LINUX_ARM64_IMAGE ||
     image.trim() === AZURE_NOBLE_LINUX_IMAGE ||
     image.trim() === AZURE_NOBLE_LINUX_ARM64_IMAGE ||
+    image.trim() === AZURE_ORACULAR_LINUX_IMAGE ||
+    image.trim() === AZURE_ORACULAR_LINUX_ARM64_IMAGE ||
     image.trim() === LEGACY_AZURE_JAMMY_IMAGE ||
     image.trim() === LEGACY_AZURE_NOBLE_GEN2_IMAGE
   );

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -11070,7 +11070,9 @@ export class FleetCoordinator {
             now,
           );
           recordCloudOrphanSweepOwnership(candidate, ownershipLease);
-          if (config.deleteEnabled && ownershipLease) {
+          const deleteTagOwnedAzureOrphan =
+            config.deleteEnabled && azureTagOwnedOrphanSweepCandidateDeletable(candidate);
+          if (config.deleteEnabled && (ownershipLease || deleteTagOwnedAzureOrphan)) {
             try {
               // oxlint-disable-next-line eslint/no-await-in-loop -- delete failures must stay attached to the candidate.
               await this.provider("azure", candidateRegion).deleteServer(
@@ -16011,6 +16013,14 @@ function recordCloudOrphanSweepOwnership(
   }
   candidate.ownership = "coordinator-lease";
   candidate.ownershipLeaseID = lease.id;
+}
+
+function azureTagOwnedOrphanSweepCandidateDeletable(candidate: CloudOrphanSweepCandidate): boolean {
+  return (
+    candidate.ownership === "provider-tags-only" &&
+    Boolean(candidate.leaseID) &&
+    (candidate.reason === "no-active-lease" || candidate.reason === "expired-provider-tag")
+  );
 }
 
 function leaseOwnsCloudResourceDuringSweep(lease: LeaseRecord, now: number): boolean {

--- a/worker/test/azure.test.ts
+++ b/worker/test/azure.test.ts
@@ -143,6 +143,17 @@ describe("azure provider", () => {
     ).toBe("Canonical:custom-linux:image:latest");
   });
 
+  it("defaults Azure Linux leases to the stable 24.04 LTS image family", () => {
+    const client = new AzureClient(baseEnv);
+    const imageForConfig = (
+      client as unknown as { imageForConfig(config: LeaseConfig): string }
+    ).imageForConfig.bind(client);
+
+    expect(imageForConfig(testLeaseConfig({ azureImage: "" }))).toBe(
+      "Canonical:ubuntu-24_04-lts:server:latest",
+    );
+  });
+
   it("orders Azure region candidates from defaults, env, and capacity regions", () => {
     expect(
       azureRegionCandidates(

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -8812,7 +8812,7 @@ describe("fleet lease identity and idle", () => {
     });
   });
 
-  it("deletes only coordinator-owned Azure orphan sweep candidates", async () => {
+  it("deletes coordinator-owned and stale tag-owned Azure orphan sweep candidates", async () => {
     const storage = new MemoryStorage();
     const deleted: string[] = [];
     const oldSeconds = String(Math.trunc((Date.now() - 60 * 60 * 1000) / 1000));
@@ -8920,6 +8920,16 @@ describe("fleet lease identity and idle", () => {
               }),
               testMachine({
                 provider: "azure",
+                cloudID: "vm-missing-lease-label",
+                region: "westus2",
+                name: "vm-missing-lease-label",
+                labels: {
+                  crabbox: "true",
+                  created_at: oldSeconds,
+                },
+              }),
+              testMachine({
+                provider: "azure",
                 cloudID: "vm-provisioning",
                 name: "vm-provisioning",
                 labels: {
@@ -8987,8 +8997,8 @@ describe("fleet lease identity and idle", () => {
       terminated: number;
       candidates: Array<Record<string, unknown>>;
     }>("azure-orphan-sweep:last");
-    expect(deleted).toEqual(["vm-orphan"]);
-    expect(sweep).toMatchObject({ mode: "delete", terminated: 1 });
+    expect(deleted).toEqual(["vm-orphan", "vm-tag-only"]);
+    expect(sweep).toMatchObject({ mode: "delete", terminated: 2 });
     expect(sweep?.candidates).toEqual([
       expect.objectContaining({
         cloudID: "vm-orphan",
@@ -9002,6 +9012,14 @@ describe("fleet lease identity and idle", () => {
       expect.objectContaining({
         cloudID: "vm-tag-only",
         region: "westus2",
+        leaseID: "cbx_missing",
+        ownership: "provider-tags-only",
+        action: "terminated",
+      }),
+      expect.objectContaining({
+        cloudID: "vm-missing-lease-label",
+        region: "westus2",
+        reason: "missing-lease-label",
         ownership: "provider-tags-only",
         action: "reported",
       }),


### PR DESCRIPTION
Closes #862.

Restores Azure's default worker image to Ubuntu 24.04 LTS while keeping the 26.04 image family available as an explicit selector. Azure orphan sweep deletion remains claim-backed; stale tag-only resources stay report-only.