### PR TITLE
fix(worker): revoke incomplete legacy Code viewers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- Closed restored legacy Code viewer sessions that lack a complete organization-bound principal during restore and after lease share revocation. Thanks @coygeek.
 - Required a canonical public origin for GitHub OAuth and bound callbacks to the initiating origin before exchanging codes or issuing sessions. Thanks @coygeek.
 - Redacted configured credentials, authorization headers, signed URLs, URL userinfo, and secret-bearing JSON fields before coordinator provider diagnostics are stored or returned. Thanks @coygeek.
 - Redacted broker URL userinfo, queries, and fragments from `login`, `whoami`, and `doctor` text and JSON output. Thanks @coygeek.

--- a/docs/security.md
+++ b/docs/security.md
@@ -162,7 +162,9 @@ Changing any configured admin source revokes older active, restored, ticketed,
 or durable-session grants on the next authenticated request or scheduled
 reconciliation; active senders and recipients are also revalidated while data
 flows. Legacy admin attachments without a verifiable source and version fail
-closed after upgrade.
+closed after upgrade. Restored Code viewer sessions without a complete
+organization-bound principal also fail closed during restore and whenever lease
+sharing access shrinks.
 Shared-operator requests do **not** trust caller-supplied `X-Crabbox-Owner` /
 `X-Crabbox-Org` headers — pin that automation's identity with
 `CRABBOX_SHARED_OWNER` (and `CRABBOX_DEFAULT_ORG`), or prefer per-user signed

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -1200,12 +1200,10 @@ export class FleetCoordinator {
         continue;
       }
       if (
-        (attachment.kind === "webvnc-viewer" ||
-          (attachment.kind === "code-viewer" && completeBridgePrincipal(attachment))) &&
+        (attachment.kind === "webvnc-viewer" || attachment.kind === "code-viewer") &&
         !this.leaseViewerAuthorized(lease, attachment)
       ) {
         revokedViewers.set(socket, "lease access revoked");
-        continue;
       }
       if (
         (attachment.kind === "egress-host" || attachment.kind === "egress-client") &&
@@ -5162,7 +5160,6 @@ export class FleetCoordinator {
       if (
         attachment?.kind !== "code-viewer" ||
         attachment.leaseID !== lease.id ||
-        !completeBridgePrincipal(attachment) ||
         this.leaseViewerAuthorized(lease, withCurrentAdminGrant(attachment, adminGrants))
       ) {
         continue;

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -725,6 +725,13 @@ describe("runtime adapter relay", () => {
       org: "example-org",
       admin: false,
     });
+    const legacyCodeViewer = new FakeWebSocket({
+      kind: "code-viewer",
+      leaseID: lease.id,
+      id: "code-legacy",
+      auth: "github",
+      portalSessionHash: "a".repeat(64),
+    });
     const revokedWebAgent = new FakeWebSocket({
       kind: "webvnc-agent",
       leaseID: lease.id,
@@ -777,6 +784,7 @@ describe("runtime adapter relay", () => {
             codeAgent,
             revokedCodeViewer,
             ownerCodeViewer,
+            legacyCodeViewer,
             revokedWebAgent,
             revokedWebViewer,
             retainedWebAgent,
@@ -792,6 +800,8 @@ describe("runtime adapter relay", () => {
     expect(revokedCodeViewer.closeCode).toBe(1008);
     expect(revokedCodeViewer.closeReason).toBe("lease access revoked");
     expect(ownerCodeViewer.closeCode).toBeUndefined();
+    expect(legacyCodeViewer.closeCode).toBe(1008);
+    expect(legacyCodeViewer.closeReason).toBe("lease access revoked");
     expect(revokedWebViewer.closeCode).toBe(1008);
     expect(revokedWebViewer.closeReason).toBe("lease access revoked");
     expect(revokedWebAgent.closeCode).toBe(1011);
@@ -804,6 +814,12 @@ describe("runtime adapter relay", () => {
       {
         type: "ws_close",
         id: "code-revoked",
+        code: 1008,
+        reason: "lease access revoked",
+      },
+      {
+        type: "ws_close",
+        id: "code-legacy",
         code: 1008,
         reason: "lease access revoked",
       },
@@ -10093,16 +10109,23 @@ describe("fleet lease identity and idle", () => {
     expect(retainedCodeViewer.closeCode).toBeUndefined();
     expect(ownerCodeViewer.closeCode).toBeUndefined();
     expect(adminCodeViewer.closeCode).toBeUndefined();
-    expect(legacyCodeViewer.closeCode).toBeUndefined();
+    expect(legacyCodeViewer.closeCode).toBe(1008);
+    expect(legacyCodeViewer.closeReason).toBe("lease access revoked");
     expect(relay.codeViewers.has("code-revoked")).toBe(false);
     expect(relay.codeViewers.has("code-retained")).toBe(true);
     expect(relay.codeViewers.has("code-owner")).toBe(true);
     expect(relay.codeViewers.has("code-admin")).toBe(true);
-    expect(relay.codeViewers.has("code-legacy")).toBe(true);
+    expect(relay.codeViewers.has("code-legacy")).toBe(false);
     expect(codeAgent.sentJSON()).toEqual([
       {
         type: "ws_close",
         id: "code-revoked",
+        code: 1008,
+        reason: "lease access revoked",
+      },
+      {
+        type: "ws_close",
+        id: "code-legacy",
         code: 1008,
         reason: "lease access revoked",
       },
@@ -10112,8 +10135,8 @@ describe("fleet lease identity and idle", () => {
       retainedCodeViewer as unknown as WebSocket,
       JSON.stringify({ retained: true }),
     );
-    expect(codeAgent.sentJSON()).toHaveLength(2);
-    expect(codeAgent.sentJSON()[1]).toMatchObject({ type: "ws_data", id: "code-retained" });
+    expect(codeAgent.sentJSON()).toHaveLength(3);
+    expect(codeAgent.sentJSON()[2]).toMatchObject({ type: "ws_data", id: "code-retained" });
     await fleet.webSocketMessage(
       retainedWebViewer as unknown as WebSocket,
       JSON.stringify({ retained: true }),


### PR DESCRIPTION
Closes https://github.com/openclaw/crabbox/issues/895

## Summary

- fail closed restored Code viewer sockets that lack a complete owner/org/admin principal
- apply the same rule when lease sharing access shrinks, while retaining authorized owner, shared-user, and current-admin viewers
- preserve the more specific `portal session ended` reason when both the principal and portal-session checks fail
- document the compatibility boundary and add the Unreleased changelog entry

## Verification

- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker` (26 files, 796 tests)
- `npm run build --prefix worker`
- `go test -race ./...`
- `go vet ./...`
- `node scripts/build-docs-site.mjs`
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` (clean, confidence 0.86)

## Live proof

Deployed the candidate to a disposable Cloudflare Worker plus a disposable service-bound Code-origin front. Using independently signed owner and shared-user sessions, a real isolated Code WebSocket attached to the Durable Object, received the backend `ws_open`, and was then revoked through the owner share API. The viewer and backend notification both closed with code `1008` and reason `lease access revoked`; replay with the old Code session returned `404`.

Both disposable Workers were deleted after proof, both public URLs returned `404`, and the registered external proof lease was released. No production route, credential, or state changed.
