### PR TITLE
fix(cli): redact adapter relay coordinator URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
   go:
     name: Go
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
 
     steps:
       - name: Check out

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- Redacted coordinator URL userinfo, queries, and fragments from adapter relay connection status. Thanks @coygeek.
 - Closed restored legacy Code viewer sessions that lack a complete organization-bound principal during restore and after lease share revocation. Thanks @coygeek.
 - Required a canonical public origin for GitHub OAuth and bound callbacks to the initiating origin before exchanging codes or issuing sessions. Thanks @coygeek.
 - Redacted configured credentials, authorization headers, signed URLs, URL userinfo, and secret-bearing JSON fields before coordinator provider diagnostics are stored or returned. Thanks @coygeek.

--- a/internal/cli/adapter_connect.go
+++ b/internal/cli/adapter_connect.go
@@ -238,7 +238,7 @@ func connectAdapterRelay(
 	}
 	defer ws.Close(websocket.StatusNormalClosure, "adapter relay stopped")
 	if status != nil {
-		fmt.Fprintf(status, "adapter relay connected id=%s coordinator=%s local_socket=%s\n", adapterID, coord.BaseURL, localSocket)
+		fmt.Fprintf(status, "adapter relay connected id=%s coordinator=%s local_socket=%s\n", adapterID, redactedConfigURL(coord.BaseURL), localSocket)
 	}
 	return relay.serve(ctx)
 }

--- a/internal/cli/adapter_connect_test.go
+++ b/internal/cli/adapter_connect_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -460,19 +461,39 @@ func TestConnectAdapterRelayUsesTicketHeaderAndRelaysResponse(t *testing.T) {
 	defer coordinator.Close()
 
 	baseCoordinatorClient := coordinator.Client()
+	coordinatorTarget := coordinator.URL
+	displayCoordinatorURL := strings.Replace(coordinator.URL, "http://", "http://status-user:status-password@", 1) + "/broker?token=query-secret#fragment-secret"
 	var coordinatorRequests atomic.Int32
 	coordinatorClient := &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
 		coordinatorRequests.Add(1)
-		return baseCoordinatorClient.Transport.RoundTrip(request)
+		rewritten := request.Clone(request.Context())
+		target := *request.URL
+		target.Scheme = "http"
+		target.Host = strings.TrimPrefix(coordinatorTarget, "http://")
+		target.User = nil
+		target.RawQuery = ""
+		target.Fragment = ""
+		switch request.Method {
+		case http.MethodPost:
+			target.Path = "/v1/adapters/mac-lab/ticket"
+		case http.MethodGet:
+			target.Path = "/v1/adapters/mac-lab/agent"
+		default:
+			t.Fatalf("unexpected coordinator request method=%s", request.Method)
+		}
+		rewritten.URL = &target
+		rewritten.Host = ""
+		return baseCoordinatorClient.Transport.RoundTrip(rewritten)
 	})}
 	coord := &CoordinatorClient{
-		BaseURL: coordinator.URL,
+		BaseURL: displayCoordinatorURL,
 		Token:   "coordinator-token",
 		Client:  coordinatorClient,
 		Access:  AccessConfig{ClientID: "access-client", ClientSecret: "access-secret", Token: "access-token"},
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
+	var status bytes.Buffer
 	err := connectAdapterRelay(
 		ctx,
 		coord,
@@ -482,7 +503,7 @@ func TestConnectAdapterRelayUsesTicketHeaderAndRelaysResponse(t *testing.T) {
 		func() (string, error) { return "local-token", nil },
 		local.Client(),
 		150*time.Second,
-		io.Discard,
+		&status,
 	)
 	var closeError websocket.CloseError
 	if err == nil || !errors.As(err, &closeError) || closeError.Code != websocket.StatusNormalClosure {
@@ -498,6 +519,15 @@ func TestConnectAdapterRelayUsesTicketHeaderAndRelaysResponse(t *testing.T) {
 	}
 	if got := coordinatorRequests.Load(); got != 2 {
 		t.Fatalf("configured coordinator transport requests=%d want ticket+websocket", got)
+	}
+	statusText := status.String()
+	if want := "coordinator=" + redactedConfigURL(displayCoordinatorURL); !strings.Contains(statusText, want) {
+		t.Fatalf("relay status=%q want %q", statusText, want)
+	}
+	for _, secret := range []string{"status-user", "status-password", "query-secret", "fragment-secret"} {
+		if strings.Contains(statusText, secret) {
+			t.Fatalf("relay status leaked %q: %q", secret, statusText)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- redact coordinator URL userinfo, queries, and fragments from adapter relay connection status
- preserve the non-secret coordinator origin and path for useful diagnostics
- cover the complete ticket, WebSocket relay, local request, response, and close path with a credential-bearing display URL
- allow the repository's full Go CI gate to finish instead of canceling Coverage at the previous 15-minute job timeout

Fixes https://github.com/openclaw/crabbox/issues/896

## Verification

- `go test -race ./...`
- `go vet ./...`
- `go build -trimpath -o /tmp/crabbox-issue896 ./cmd/crabbox`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker` (26 files, 796 tests)
- `npm run build --prefix worker`
- `node scripts/build-docs-site.mjs`
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` (clean for the application patch and the CI timeout follow-up; no actionable findings)

## Live-path proof

The regression test runs a real local HTTP coordinator, adapter-ticket request, WebSocket upgrade, relayed workspace request, local HTTP response, and normal WebSocket close. The status assertion verifies that useful coordinator origin/path context remains while all synthetic userinfo, query-token, and fragment-token material is absent.

Exact head `81a7cf4d50680da91de15d776ee192ab62b7d18b` also passed a disposable real-CLI canary. The built `crabbox adapter connect` process used an environment-approved coordinator URL containing synthetic userinfo, query, and fragment credentials; a disposable local HTTP proxy issued the authenticated adapter ticket and completed the WebSocket upgrade. Redacted terminal output:

```text
adapter relay connected id=live-proof coordinator=http://<redacted>@credential.invalid/broker local_socket=<private-temp>/adapter.sock
live-proof:pass ticket=1 websocket=1 cleanup=complete
```

The canary asserted that every synthetic credential component was absent from the connected line, then removed its private token file/temp directory and closed the proxy. No production coordinator, credentials, adapter, or state were used.

The first hosted Go job completed formatting, vet, deadcode, the full race suite, and all Go modules, then GitHub canceled Coverage exactly at the 15-minute job limit. The follow-up raises only that Go job limit to 30 minutes; the exact-head hosted rerun is the final merge gate.

## Maintainer decisions

- Keep the `CHANGELOG.md` entry: this is a user-visible security fix, and repository policy requires the release note plus reporter credit.
- The production change remains status-rendering-only; the raw coordinator URL still drives ticket and WebSocket routing.

## Configuration / secrets

No runtime configuration changes. Runtime routing still uses the original coordinator URL; only its user-visible status rendering is redacted. The CI-only change raises the Go job timeout from 15 to 30 minutes.
