### PR TITLE
fix(worker): bound run-history storage to stop Fleet DO OOM (Azure lease churn)

### DIFF
--- a/worker/src/coordinator-runtime.ts
+++ b/worker/src/coordinator-runtime.ts
@@ -2,7 +2,14 @@ export interface CoordinatorStorage {
   get<T>(key: string): Promise<T | undefined>;
   put<T>(key: string, value: T): Promise<void>;
   delete(key: string): Promise<unknown>;
-  list<T>(options?: { prefix?: string }): Promise<Map<string, T>>;
+  // limit/startAfter map straight to DurableObjectStorage.list; they let callers
+  // page a large key-space (e.g. run history) instead of loading it whole and
+  // OOMing the 128MB isolate.
+  list<T>(options?: {
+    prefix?: string;
+    limit?: number;
+    startAfter?: string;
+  }): Promise<Map<string, T>>;
 }
 
 export type CoordinatorRequestQueue = "direct" | "lifecycle";

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -214,6 +214,20 @@ const workspaceMinimumTTLSeconds =
   (workspaceProvisionClaimMs + workspaceProvisionRecoveryGraceMs) / 1000;
 const workspaceMaxRecordsPerOwner = 100;
 const workspaceTerminalRetentionMs = 24 * 60 * 60_000;
+// Run history is otherwise unbounded: run IDs are random (not time-ordered) and
+// runs were never deleted, so `run:*` grows until the DO isolate OOMs on any
+// list-all (which then resets the DO mid-lease-create and churns provisioning).
+// Retain a bounded window; drain the backlog in the alarm; cap history reads.
+const runRetentionMs = 7 * 24 * 60 * 60_000;
+const runPruneBatchSize = 100;
+const runPruneCursorKey = "meta:run-prune-cursor";
+// Ceiling on run records pulled into the 128MB isolate by any read path. Run
+// keys are random, so a bounded scan is not guaranteed newest-first; the ceiling
+// is set well above the retained volume so in practice reads cover the whole
+// retained window. If run volume ever exceeds it within the retention window,
+// listRuns can miss some records — the durable fix is a time-ordered run index
+// (tracked in the PR as follow-up), but the ceiling is what prevents the OOM.
+const maxRunScanRecords = 5000;
 const workspacePrewarmOwner = "crabbox-internal-prewarm";
 const workspacePrewarmReplacementLeadMs = 5 * 60_000;
 const workspacePrewarmRetryDelayMs = 5 * 60_000;
@@ -1860,6 +1874,7 @@ export class FleetCoordinator {
     await this.provisionPendingWorkspace();
     await this.maintainWorkspacePrewarm();
     await this.pruneTerminalWorkspaces();
+    await this.pruneOldRuns();
     await this.runAzureDeferredCleanups();
     await this.runAWSOrphanSweepIfDue("alarm");
     await this.runAzureOrphanSweepIfDue("alarm");
@@ -3041,6 +3056,53 @@ export class FleetCoordinator {
         this.reconcileWorkspace(workspace, leasesByID.get(workspace.leaseID)),
       ),
     );
+  }
+
+  // Drains the run-history backlog in bounded, cursor-paginated batches so the
+  // alarm itself never loads the whole `run:*` keyspace (which would OOM the
+  // isolate and wedge maintenance). Each expired run's metadata, log, log
+  // chunks, and events are deleted. The cursor advances every tick and resets at
+  // the end so the scan wraps around and keeps holding retention.
+  private async pruneOldRuns(): Promise<void> {
+    const cutoff = Date.now() - runRetentionMs;
+    const cursor = (await this.state.storage.get<string>(runPruneCursorKey)) ?? "";
+    const batch = await this.state.storage.list<RunRecord>({
+      prefix: "run:",
+      limit: runPruneBatchSize,
+      ...(cursor ? { startAfter: cursor } : {}),
+    });
+    if (batch.size === 0) {
+      if (cursor) {
+        await this.state.storage.delete(runPruneCursorKey);
+      }
+      return;
+    }
+    const keys = [...batch.keys()];
+    const lastKey = keys[keys.length - 1];
+    const expired = [...batch.values()].filter((run) => {
+      // Never delete an in-flight run: its runner still writes events/logs and
+      // reads its record. Retain by completion time so a long run that only just
+      // finished keeps its history for the full window.
+      if (run.state === "running") {
+        return false;
+      }
+      const terminalAt = Date.parse(run.endedAt ?? run.startedAt);
+      return Number.isFinite(terminalAt) && terminalAt <= cutoff;
+    });
+    await this.state.runExclusive(async () => {
+      await Promise.all(
+        expired.map(async (run) => {
+          await this.deleteRunLogChunks(run.id);
+          const events = await this.state.storage.list({ prefix: runEventPrefix(run.id) });
+          await Promise.all(
+            [runLogKey(run.id), ...events.keys(), runKey(run.id)].map((key) =>
+              this.state.storage.delete(key),
+            ),
+          );
+        }),
+      );
+      await this.state.storage.put(runPruneCursorKey, lastKey);
+    });
   }
 
   private async pruneTerminalWorkspaces(): Promise<void> {
@@ -11336,7 +11398,12 @@ export class FleetCoordinator {
   }
 
   private async runRecords(): Promise<RunRecord[]> {
-    const runs = await this.state.storage.list<RunRecord>({ prefix: "run:" });
+    // Bounded: never load the whole `run:*` keyspace into the isolate. See
+    // maxRunScanRecords — the retention prune keeps the true total under it.
+    const runs = await this.state.storage.list<RunRecord>({
+      prefix: "run:",
+      limit: maxRunScanRecords,
+    });
     return [...runs.values()];
   }
 

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -22507,37 +22507,50 @@ function decodeUserTokenPayload(token: string): { exp: number; iat: number } {
   return JSON.parse(decoded) as { exp: number; iat: number };
 }
 
+function retentionRunRecord(
+  id: string,
+  startedAt: string,
+  state: RunRecord["state"],
+  endedAt?: string,
+): RunRecord {
+  return {
+    id,
+    leaseID: "lease-x",
+    owner: "owner",
+    org: "default-org",
+    provider: "aws",
+    class: "standard",
+    serverType: "t",
+    command: [],
+    state,
+    logBytes: 0,
+    logTruncated: false,
+    startedAt,
+    ...(endedAt ? { endedAt } : {}),
+  };
+}
+
 describe("fleet run retention", () => {
   it("alarm prunes expired terminal runs, keeps recent and in-flight runs", async () => {
     const storage = new MemoryStorage();
     const fleet = testFleet(storage);
     const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60_000).toISOString();
     const oneMinuteAgo = new Date(Date.now() - 60_000).toISOString();
-    const run = (id: string, startedAt: string, state: RunRecord["state"], endedAt?: string) =>
-      ({
-        id,
-        leaseID: "lease-x",
-        owner: "owner",
-        org: "default-org",
-        provider: "aws",
-        class: "standard",
-        serverType: "t",
-        command: [],
-        state,
-        logBytes: 0,
-        logTruncated: false,
-        startedAt,
-        ...(endedAt ? { endedAt } : {}),
-      }) satisfies RunRecord;
 
-    storage.seed("run:run_old_done", run("run_old_done", eightDaysAgo, "succeeded", eightDaysAgo));
+    storage.seed(
+      "run:run_old_done",
+      retentionRunRecord("run_old_done", eightDaysAgo, "succeeded", eightDaysAgo),
+    );
     storage.seed("runlog:run_old_done", "old log");
     storage.seed("runlog:run_old_done:chunk:000000", "chunk");
     storage.seed("runevent:run_old_done:000000000000", { seq: 0 });
-    storage.seed("run:run_old_running", run("run_old_running", eightDaysAgo, "running"));
+    storage.seed(
+      "run:run_old_running",
+      retentionRunRecord("run_old_running", eightDaysAgo, "running"),
+    );
     storage.seed(
       "run:run_recent_done",
-      run("run_recent_done", oneMinuteAgo, "succeeded", oneMinuteAgo),
+      retentionRunRecord("run_recent_done", oneMinuteAgo, "succeeded", oneMinuteAgo),
     );
 
     await fleet.alarm();

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -22506,3 +22506,50 @@ function decodeUserTokenPayload(token: string): { exp: number; iat: number } {
   const decoded = Buffer.from(payload, "base64url").toString("utf8");
   return JSON.parse(decoded) as { exp: number; iat: number };
 }
+
+describe("fleet run retention", () => {
+  it("alarm prunes expired terminal runs, keeps recent and in-flight runs", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60_000).toISOString();
+    const oneMinuteAgo = new Date(Date.now() - 60_000).toISOString();
+    const run = (id: string, startedAt: string, state: RunRecord["state"], endedAt?: string) =>
+      ({
+        id,
+        leaseID: "lease-x",
+        owner: "owner",
+        org: "default-org",
+        provider: "aws",
+        class: "standard",
+        serverType: "t",
+        command: [],
+        state,
+        logBytes: 0,
+        logTruncated: false,
+        startedAt,
+        ...(endedAt ? { endedAt } : {}),
+      }) satisfies RunRecord;
+
+    storage.seed("run:run_old_done", run("run_old_done", eightDaysAgo, "succeeded", eightDaysAgo));
+    storage.seed("runlog:run_old_done", "old log");
+    storage.seed("runlog:run_old_done:chunk:000000", "chunk");
+    storage.seed("runevent:run_old_done:000000000000", { seq: 0 });
+    storage.seed("run:run_old_running", run("run_old_running", eightDaysAgo, "running"));
+    storage.seed(
+      "run:run_recent_done",
+      run("run_recent_done", oneMinuteAgo, "succeeded", oneMinuteAgo),
+    );
+
+    await fleet.alarm();
+
+    // expired terminal run and all of its side data are gone
+    expect(storage.value("run:run_old_done")).toBeUndefined();
+    expect(storage.value("runlog:run_old_done")).toBeUndefined();
+    expect(storage.value("runlog:run_old_done:chunk:000000")).toBeUndefined();
+    expect(storage.value("runevent:run_old_done:000000000000")).toBeUndefined();
+    // never delete an in-flight run, even past the retention window
+    expect(storage.value("run:run_old_running")).toBeDefined();
+    // recent history stays
+    expect(storage.value("run:run_recent_done")).toBeDefined();
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

The Crabbox coordinator's Fleet Durable Object OOMs (Cloudflare 128 MB isolate limit) and resets mid-request. Live tail of the deployed coordinator, provoked with an Azure lease, shows it on both `POST /v1/leases` and `GET /v1/runs`:

```
Error: Durable Object's isolate exceeded its memory limit and was reset.
```

Root cause: the run-history feature accumulates `run:*` records forever — run IDs are random (`newRunID`), there is no run retention (the alarm prunes only terminal *workspaces*), and `runRecords()` plus the maintenance alarm load the entire key-space with unbounded `storage.list`. DO isolates are reused across requests, so a `/v1/runs` load bloats the heap and the next request (a lease create) OOMs, loses the lease record, and the CLI retries — producing the ~16 s Azure VM create/teardown churn and the stranded `keep:false` orphans reported in #862.

## Why This Change Was Made

Stop the OOM so lease provisioning (Azure especially) stops churning, and keep run history bounded going forward.

- 7-day run retention, drained in **bounded, cursor-paginated batches** in the alarm so the maintenance path itself never loads the whole key-space (which would OOM and wedge the DO). Pruning deletes each expired run's metadata, log, log chunks, and events. In-flight runs (`state: "running"`) are never deleted; retention is measured from completion time.
- A read ceiling (`maxRunScanRecords`) so no read path (`listRuns`, portal history) loads the whole `run:*` key-space; retention keeps the true total under the ceiling. Follow-up: a time-ordered run index for exact newest-N ordering when volume exceeds the ceiling (noted in code).
- `CoordinatorStorage.list` is widened to expose the native `DurableObjectStorage` `limit`/`startAfter` options the bounded scan and pagination rely on (the abstraction is the real DO storage; only the type was narrowed).

## User Impact

Azure leases provision instead of churning; `GET /v1/runs` and portal lease history stop 500ing. No config or API surface change. Existing legacy `run:*` records drain out over the retention window.

## Evidence

- `tsgo`/tsc typecheck clean.
- `worker`: 382 tests pass (`vitest run test/fleet.test.ts test/coordinator-runtime.test.ts`), including a new test asserting the alarm prunes expired terminal runs (with log/chunk/event side data) while keeping recent and in-flight runs.
- Diagnosis with live coordinator tail on the OpenClaw Cloudflare account: openclaw/crabbox#862.
- Post-merge: deploy to the coordinator and verify a real Azure lease provisions end-to-end (no OOM in tail).

Refs #862
