### PR TITLE
fix: bind GitHub OAuth login to initiating device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- Bound GitHub OAuth CLI token release to a one-use callback on the initiating device, so forwarding an authorization URL cannot hand the resulting user token to another terminal. Thanks @coygeek.
+- Honored an explicit broker URL and freshly issued credential during immediate post-login identity verification, even when ambient coordinator overrides point elsewhere.
 - Kept coordinator restarts, run history, lease detail pages, and Azure orphan sweeps memory-bounded with exact lease restores, paged record scans, and batched terminal-run pruning after a configurable 30-day retention period.
 - Redacted coordinator URL userinfo, queries, and fragments from adapter relay connection status. Thanks @coygeek.
 - Closed restored legacy Code viewer sessions that lack a complete organization-bound principal during restore and after lease share revocation. Thanks @coygeek.

--- a/docs/commands/login.md
+++ b/docs/commands/login.md
@@ -14,11 +14,14 @@ command exits with an error.
 crabbox login --url <broker-url>
 ```
 
-This starts a GitHub OAuth login: Crabbox opens the login URL in your browser,
-polls the broker until you complete the flow, then stores the user-scoped bearer
-token it returns.
+This starts a GitHub OAuth login: Crabbox opens the login URL in your browser and
+listens on a random `127.0.0.1` port for a one-use browser confirmation. The
+broker releases the user-scoped bearer token only when the initiating terminal
+presents both that confirmation and its private polling secret.
 
-If the browser cannot open, print the URL and finish the flow manually:
+If the browser cannot open automatically, print the URL and open it manually in
+a browser on the same device. Cross-device completion intentionally fails
+closed because the browser must return to the initiating CLI's loopback listener:
 
 ```sh
 crabbox login --url https://broker.example.com --no-browser
@@ -36,7 +39,7 @@ logged in broker=https://broker.example.com provider=aws user=alice@example.com 
 ```text
 --url <url>                       broker URL (falls back to the configured broker)
 --provider hetzner|aws|azure|gcp  default brokered provider to store with the broker
---no-browser                      print the GitHub login URL instead of opening it
+--no-browser                      print the same-device GitHub login URL instead of opening it
 --token-stdin                     read a broker token from stdin (operator automation)
 --json                            print machine-readable JSON
 ```
@@ -77,6 +80,11 @@ crabbox config path
 Each broker owns its own GitHub OAuth credentials and admission policy. A
 separate organization or private deployment needs its own coordinator runtime,
 secret injection, and GitHub OAuth app.
+
+The coordinator requires current CLIs to provide an ephemeral HTTP loopback
+callback using the literal `127.0.0.1` address, a random port, and a random path.
+Old clients that can only poll for a completed browser token are rejected before
+OAuth starts.
 
 Configure that GitHub OAuth app with a callback URL that exactly matches the
 broker's public origin:

--- a/docs/features/auth-admin.md
+++ b/docs/features/auth-admin.md
@@ -36,7 +36,7 @@ again after upgrading the broker with this security fix.
 
 ```sh
 crabbox login --url https://broker.example.com
-crabbox login --url https://broker.example.com --no-browser   # print the URL instead of opening it
+crabbox login --url https://broker.example.com --no-browser   # print the URL; open it on this device
 crabbox login --url https://broker.example.com --provider aws # also set the default brokered provider
 ```
 

--- a/docs/features/broker-auth-routing.md
+++ b/docs/features/broker-auth-routing.md
@@ -144,6 +144,12 @@ needs its own OAuth app: the callback URL must exactly match the public origin, 
 to canonicalize portal redirects). GitHub OAuth refuses to start without this setting,
 and callbacks from another origin are rejected before code exchange or session issuance.
 
+For CLI login, the public callback redirects completion to a one-use
+`http://127.0.0.1:<random-port>/crabbox/oauth/<random-path>` listener created by
+the initiating CLI. The coordinator releases the token only when polling proves
+both the terminal-held polling secret and the browser-delivered confirmation.
+This makes copied authorization URLs non-transferable to another terminal.
+
 The CLI treats that callback origin as a credential destination. If a login response
 from one broker points at a different callback origin, `crabbox login` fails before
 opening the browser unless the alternate origin appears in trusted operator config:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -39,8 +39,9 @@ crabbox login --url https://broker.example.com
 ```
 
 `login` opens a browser to the GitHub OAuth flow (pass `--no-browser` to print
-the URL instead). The broker exchanges the OAuth code, verifies your GitHub org
-membership, writes a signed token to your user config, and confirms the result:
+the URL for a browser on the same device). The broker exchanges the OAuth code,
+verifies your GitHub org membership, and redirects a one-use confirmation to the
+CLI's loopback listener before writing the signed token to your user config:
 
 ```text
 logged in broker=https://broker.example.com provider=hetzner user=alice@example.com org=example-org config=/Users/alice/.config/crabbox/config.yaml

--- a/docs/security.md
+++ b/docs/security.md
@@ -88,6 +88,12 @@ by coordinator config:
   `user:email` scope. Public profile and unverified emails are never trusted as
   the token owner.
 
+CLI login also binds token release to the initiating device. The CLI opens a
+one-use listener on a random `127.0.0.1` port and path; after GitHub authorization,
+the browser receives a random confirmation through that loopback URL. Polling
+requires both the CLI-held secret and the browser confirmation, so forwarding an
+authorization URL cannot deliver the resulting user token to the sender.
+
 User tokens can only mutate leases, runs, and usage for their own `owner`/`org`
 identity. Lease owners also have read-only audit access to run history, logs,
 events, telemetry, and live event subscriptions for work recorded against

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/http"
 	"net/url"
 	"os/exec"
 	"runtime"
@@ -83,6 +84,12 @@ func (a App) loginWithToken(ctx context.Context, brokerURL, provider string, bro
 }
 
 func (a App) loginWithGitHub(ctx context.Context, brokerURL, provider string, brokerMode BrokerMode, noBrowser, jsonOut bool) error {
+	loopback, err := startGitHubLoginLoopback()
+	if err != nil {
+		return exit(3, "start local GitHub login callback: %v", err)
+	}
+	defer loopback.Close()
+
 	pollSecret, err := randomHex(32)
 	if err != nil {
 		return err
@@ -92,7 +99,7 @@ func (a App) loginWithGitHub(ctx context.Context, brokerURL, provider string, br
 	if err != nil {
 		return err
 	}
-	start, err := client.StartGitHubLogin(ctx, pollSecretHash, provider)
+	start, err := client.StartGitHubLogin(ctx, pollSecretHash, provider, loopback.URL())
 	if err != nil {
 		return err
 	}
@@ -113,7 +120,7 @@ func (a App) loginWithGitHub(ctx context.Context, brokerURL, provider string, br
 		if err != nil {
 			return err
 		}
-		start, err = client.StartGitHubLogin(ctx, pollSecretHash, provider)
+		start, err = client.StartGitHubLogin(ctx, pollSecretHash, provider, loopback.URL())
 		if err != nil {
 			return err
 		}
@@ -130,9 +137,9 @@ func (a App) loginWithGitHub(ctx context.Context, brokerURL, provider string, br
 		}
 	}
 	if noBrowser {
-		fmt.Fprintf(a.Stderr, "open this GitHub login URL:\n%s\n", start.URL)
+		fmt.Fprintf(a.Stderr, "open this GitHub login URL in a browser on this device:\n%s\n", start.URL)
 	} else if err := openBrowser(start.URL); err != nil {
-		fmt.Fprintf(a.Stderr, "could not open browser: %v\nopen this GitHub login URL:\n%s\n", err, start.URL)
+		fmt.Fprintf(a.Stderr, "could not open browser: %v\nopen this GitHub login URL in a browser on this device:\n%s\n", err, start.URL)
 	} else {
 		fmt.Fprintln(a.Stderr, "opened GitHub login in your browser")
 	}
@@ -142,17 +149,25 @@ func (a App) loginWithGitHub(ctx context.Context, brokerURL, provider string, br
 			deadline = parsed
 		}
 	}
+	browserConfirmation := ""
 	for {
 		if time.Now().After(deadline) {
 			return exit(3, "GitHub login expired")
 		}
-		poll, err := client.PollGitHubLogin(ctx, start.LoginID, pollSecret)
+		select {
+		case browserConfirmation = <-loopback.confirmations:
+		default:
+		}
+		poll, err := client.PollGitHubLogin(ctx, start.LoginID, pollSecret, browserConfirmation)
 		if err != nil {
 			return err
 		}
 		switch poll.Status {
-		case "pending":
+		case "pending", "confirmation_required":
 		case "complete":
+			if browserConfirmation == "" {
+				return exit(3, "GitHub login completed before this device received the browser confirmation")
+			}
 			if poll.Token == "" {
 				return exit(3, "GitHub login completed without a broker token")
 			}
@@ -186,6 +201,77 @@ func (a App) loginWithGitHub(ctx context.Context, brokerURL, provider string, br
 		case <-timer.C:
 		}
 	}
+}
+
+type githubLoginLoopback struct {
+	listener      net.Listener
+	server        *http.Server
+	path          string
+	confirmations chan string
+}
+
+func startGitHubLoginLoopback() (*githubLoginLoopback, error) {
+	pathToken, err := randomHex(32)
+	if err != nil {
+		return nil, err
+	}
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		return nil, err
+	}
+	loopback := &githubLoginLoopback{
+		listener:      listener,
+		path:          "/crabbox/oauth/" + pathToken,
+		confirmations: make(chan string, 1),
+	}
+	loopback.server = &http.Server{
+		Handler:           http.HandlerFunc(loopback.handle),
+		ReadHeaderTimeout: 5 * time.Second,
+		IdleTimeout:       5 * time.Second,
+	}
+	go func() {
+		_ = loopback.server.Serve(listener)
+	}()
+	return loopback, nil
+}
+
+func (l *githubLoginLoopback) URL() string {
+	return "http://" + l.listener.Addr().String() + l.path
+}
+
+func (l *githubLoginLoopback) Close() {
+	_ = l.server.Close()
+}
+
+func (l *githubLoginLoopback) handle(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet || r.URL.Path != l.path {
+		http.NotFound(w, r)
+		return
+	}
+	confirmation := r.URL.Query().Get("confirmation")
+	if !validBrowserConfirmation(confirmation) {
+		http.Error(w, "invalid login confirmation", http.StatusBadRequest)
+		return
+	}
+	select {
+	case l.confirmations <- confirmation:
+	default:
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'")
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Referrer-Policy", "no-referrer")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(http.StatusOK)
+	_, _ = io.WriteString(w, "<!doctype html><html><head><meta charset=\"utf-8\"><title>Crabbox login complete</title></head><body><h1>Crabbox login complete</h1><p>You can close this tab and return to the terminal.</p></body></html>")
+}
+
+func validBrowserConfirmation(value string) bool {
+	if !strings.HasPrefix(value, "confirm_") || len(value) != len("confirm_")+32 {
+		return false
+	}
+	_, err := hex.DecodeString(strings.TrimPrefix(value, "confirm_"))
+	return err == nil
 }
 
 func (a App) finishLogin(ctx context.Context, coord *CoordinatorClient, path string, cfg Config, jsonOut bool) error {
@@ -431,5 +517,17 @@ func writeBrokerLogin(brokerURL, token, provider string, brokerMode BrokerMode) 
 		return "", Config{}, err
 	}
 	cfg, err := loadConfig()
-	return written, cfg, err
+	if err != nil {
+		return written, Config{}, err
+	}
+	// Verify the login against the broker and credential just written. Ambient
+	// coordinator overrides still apply to later commands, but must not redirect
+	// this one-shot verification away from an explicit login destination.
+	cfg.Coordinator = brokerURL
+	cfg.CoordToken = token
+	cfg.CoordTokenCommand = nil
+	cfg.BrokerMode = brokerMode
+	cfg.Provider = brokerProvider
+	cfg.brokerProvider = brokerProvider
+	return written, cfg, nil
 }

--- a/internal/cli/auth_test.go
+++ b/internal/cli/auth_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -32,6 +33,34 @@ func TestWriteBrokerLoginStoresTokenInUserConfig(t *testing.T) {
 	}
 	if cfg.Coordinator != "https://crabbox.example.test" || cfg.CoordToken != "secret" || cfg.Provider != "aws" {
 		t.Fatalf("unexpected config: %#v", cfg)
+	}
+}
+
+func TestWriteBrokerLoginReturnsWrittenBrokerDespiteEnvironmentOverrides(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(home, "config.yaml"))
+	t.Setenv("CRABBOX_COORDINATOR", "https://ambient.example.test")
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "ambient-token")
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN_COMMAND", `["printf","ambient-token"]`)
+
+	_, cfg, err := writeBrokerLogin(
+		"https://login.example.test",
+		"login-token",
+		"aws",
+		BrokerModeManaged,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Coordinator != "https://login.example.test" || cfg.CoordToken != "login-token" {
+		t.Fatalf("login verification config used ambient broker credentials: %#v", cfg)
+	}
+	if len(cfg.CoordTokenCommand) != 0 {
+		t.Fatalf("login verification retained ambient token command: %v", cfg.CoordTokenCommand)
+	}
+	if cfg.Provider != "aws" || cfg.brokerProvider != "aws" {
+		t.Fatalf("login verification retained ambient provider: %#v", cfg)
 	}
 }
 
@@ -428,6 +457,8 @@ func TestGitHubLoginNoBrowserStoresReturnedToken(t *testing.T) {
 	t.Setenv("CRABBOX_ACCESS_CLIENT_SECRET", "access-secret")
 
 	var seenPollSecretHash string
+	var loopbackResult = make(chan error, 1)
+	const browserConfirmation = "confirm_0123456789abcdef0123456789abcdef"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
@@ -439,8 +470,9 @@ func TestGitHubLoginNoBrowserStoresReturnedToken(t *testing.T) {
 				t.Fatalf("start CF-Access-Client-Secret=%q", got)
 			}
 			var body struct {
-				PollSecretHash string `json:"pollSecretHash"`
-				Provider       string `json:"provider"`
+				PollSecretHash      string `json:"pollSecretHash"`
+				Provider            string `json:"provider"`
+				LoopbackRedirectURI string `json:"loopbackRedirectURI"`
 			}
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 				t.Fatal(err)
@@ -452,11 +484,29 @@ func TestGitHubLoginNoBrowserStoresReturnedToken(t *testing.T) {
 				t.Fatalf("poll secret hash=%q", body.PollSecretHash)
 			}
 			seenPollSecretHash = body.PollSecretHash
+			loopbackURL, err := url.Parse(body.LoopbackRedirectURI)
+			if err != nil || loopbackURL.Scheme != "http" || loopbackURL.Hostname() != "127.0.0.1" || loopbackURL.Port() == "" {
+				t.Fatalf("loopback redirect URI=%q err=%v", body.LoopbackRedirectURI, err)
+			}
 			_ = json.NewEncoder(w).Encode(CoordinatorGitHubLoginStart{
 				LoginID:   "login_test",
 				URL:       "https://github.com/login/oauth/authorize?state=test",
 				ExpiresAt: time.Now().Add(time.Minute).Format(time.RFC3339),
 			})
+			go func() {
+				callback := *loopbackURL
+				query := callback.Query()
+				query.Set("confirmation", browserConfirmation)
+				callback.RawQuery = query.Encode()
+				response, err := http.Get(callback.String())
+				if err == nil {
+					defer response.Body.Close()
+					if response.StatusCode != http.StatusOK {
+						err = fmt.Errorf("loopback callback status=%d", response.StatusCode)
+					}
+				}
+				loopbackResult <- err
+			}()
 		case "/v1/auth/github/poll":
 			if got := r.Header.Get("CF-Access-Client-Id"); got != "access-client" {
 				t.Fatalf("poll CF-Access-Client-Id=%q", got)
@@ -465,8 +515,9 @@ func TestGitHubLoginNoBrowserStoresReturnedToken(t *testing.T) {
 				t.Fatalf("poll CF-Access-Client-Secret=%q", got)
 			}
 			var body struct {
-				LoginID    string `json:"loginID"`
-				PollSecret string `json:"pollSecret"`
+				LoginID             string `json:"loginID"`
+				PollSecret          string `json:"pollSecret"`
+				BrowserConfirmation string `json:"browserConfirmation"`
 			}
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 				t.Fatal(err)
@@ -476,6 +527,10 @@ func TestGitHubLoginNoBrowserStoresReturnedToken(t *testing.T) {
 			}
 			if sha256Hex(body.PollSecret) != seenPollSecretHash {
 				t.Fatal("poll secret did not match start hash")
+			}
+			if body.BrowserConfirmation != browserConfirmation {
+				_ = json.NewEncoder(w).Encode(CoordinatorGitHubLoginPoll{Status: "confirmation_required"})
+				return
 			}
 			_ = json.NewEncoder(w).Encode(CoordinatorGitHubLoginPoll{
 				Status:   "complete",
@@ -511,6 +566,9 @@ func TestGitHubLoginNoBrowserStoresReturnedToken(t *testing.T) {
 	if err := app.login(context.Background(), []string{"--url", server.URL, "--provider", "aws", "--no-browser"}); err != nil {
 		t.Fatal(err)
 	}
+	if err := <-loopbackResult; err != nil {
+		t.Fatal(err)
+	}
 	if !strings.Contains(stderr.String(), "open this GitHub login URL") {
 		t.Fatalf("stderr=%q", stderr.String())
 	}
@@ -523,6 +581,96 @@ func TestGitHubLoginNoBrowserStoresReturnedToken(t *testing.T) {
 	}
 	if cfg.Coordinator != server.URL || cfg.CoordToken != "github-session-token" || cfg.Provider != "aws" {
 		t.Fatalf("unexpected config: %#v", cfg)
+	}
+}
+
+func TestGitHubLoginLoopbackRejectsUnboundRequests(t *testing.T) {
+	loopback, err := startGitHubLoginLoopback()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer loopback.Close()
+
+	wrongPath, err := http.Get("http://" + loopback.listener.Addr().String() + "/wrong")
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrongPath.Body.Close()
+	if wrongPath.StatusCode != http.StatusNotFound {
+		t.Fatalf("wrong path status=%d", wrongPath.StatusCode)
+	}
+
+	invalid, err := http.Get(loopback.URL() + "?confirmation=wrong")
+	if err != nil {
+		t.Fatal(err)
+	}
+	invalid.Body.Close()
+	if invalid.StatusCode != http.StatusBadRequest {
+		t.Fatalf("invalid confirmation status=%d", invalid.StatusCode)
+	}
+
+	const confirmation = "confirm_0123456789abcdef0123456789abcdef"
+	valid, err := http.Get(loopback.URL() + "?confirmation=" + confirmation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	valid.Body.Close()
+	if valid.StatusCode != http.StatusOK {
+		t.Fatalf("valid confirmation status=%d", valid.StatusCode)
+	}
+	if got := valid.Header.Get("Referrer-Policy"); got != "no-referrer" {
+		t.Fatalf("referrer policy=%q", got)
+	}
+	select {
+	case got := <-loopback.confirmations:
+		if got != confirmation {
+			t.Fatalf("confirmation=%q", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for loopback confirmation")
+	}
+}
+
+func TestGitHubLoginRejectsCompletionWithoutLoopbackConfirmation(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("CRABBOX_CONFIG", "")
+	t.Setenv("CRABBOX_COORDINATOR", "")
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "")
+	t.Setenv("CRABBOX_PROVIDER", "")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/auth/github/start":
+			_ = json.NewEncoder(w).Encode(CoordinatorGitHubLoginStart{
+				LoginID:   "login_downgrade",
+				URL:       githubAuthorizeURLForTest("http://" + r.Host),
+				ExpiresAt: time.Now().Add(time.Minute).Format(time.RFC3339),
+			})
+		case "/v1/auth/github/poll":
+			_ = json.NewEncoder(w).Encode(CoordinatorGitHubLoginPoll{
+				Status: "complete",
+				Token:  "unbound-session-token",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	app := App{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}
+	err := app.login(context.Background(), []string{"--url", server.URL, "--no-browser"})
+	if err == nil || !strings.Contains(err.Error(), "before this device received") {
+		t.Fatalf("error=%v", err)
+	}
+	cfg, loadErr := loadConfig()
+	if loadErr != nil {
+		t.Fatal(loadErr)
+	}
+	if cfg.CoordToken != "" {
+		t.Fatal("unbound broker token was persisted")
 	}
 }
 
@@ -696,6 +844,8 @@ func TestGitHubLoginMigratesToAllowedRedirectOrigin(t *testing.T) {
 	t.Setenv("CRABBOX_PROVIDER", "")
 
 	var seenPollSecretHash string
+	const browserConfirmation = "confirm_0123456789abcdef0123456789abcdef"
+	loopbackResult := make(chan error, 1)
 	var canonicalStartCount int
 	var canonical *httptest.Server
 	canonical = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -704,8 +854,9 @@ func TestGitHubLoginMigratesToAllowedRedirectOrigin(t *testing.T) {
 		case "/v1/auth/github/start":
 			canonicalStartCount++
 			var body struct {
-				PollSecretHash string `json:"pollSecretHash"`
-				Provider       string `json:"provider"`
+				PollSecretHash      string `json:"pollSecretHash"`
+				Provider            string `json:"provider"`
+				LoopbackRedirectURI string `json:"loopbackRedirectURI"`
 			}
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 				t.Fatal(err)
@@ -714,15 +865,31 @@ func TestGitHubLoginMigratesToAllowedRedirectOrigin(t *testing.T) {
 				t.Fatalf("provider=%q", body.Provider)
 			}
 			seenPollSecretHash = body.PollSecretHash
+			loopbackURL, err := url.Parse(body.LoopbackRedirectURI)
+			if err != nil {
+				t.Fatal(err)
+			}
 			_ = json.NewEncoder(w).Encode(CoordinatorGitHubLoginStart{
 				LoginID:   "login_canonical",
 				URL:       githubAuthorizeURLForTest(canonical.URL),
 				ExpiresAt: time.Now().Add(time.Minute).Format(time.RFC3339),
 			})
+			go func() {
+				callback := *loopbackURL
+				query := callback.Query()
+				query.Set("confirmation", browserConfirmation)
+				callback.RawQuery = query.Encode()
+				response, err := http.Get(callback.String())
+				if err == nil {
+					response.Body.Close()
+				}
+				loopbackResult <- err
+			}()
 		case "/v1/auth/github/poll":
 			var body struct {
-				LoginID    string `json:"loginID"`
-				PollSecret string `json:"pollSecret"`
+				LoginID             string `json:"loginID"`
+				PollSecret          string `json:"pollSecret"`
+				BrowserConfirmation string `json:"browserConfirmation"`
 			}
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 				t.Fatal(err)
@@ -732,6 +899,10 @@ func TestGitHubLoginMigratesToAllowedRedirectOrigin(t *testing.T) {
 			}
 			if sha256Hex(body.PollSecret) != seenPollSecretHash {
 				t.Fatal("poll secret did not match canonical start hash")
+			}
+			if body.BrowserConfirmation != browserConfirmation {
+				_ = json.NewEncoder(w).Encode(CoordinatorGitHubLoginPoll{Status: "confirmation_required"})
+				return
 			}
 			_ = json.NewEncoder(w).Encode(CoordinatorGitHubLoginPoll{
 				Status:   "complete",
@@ -779,6 +950,9 @@ func TestGitHubLoginMigratesToAllowedRedirectOrigin(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	app := App{Stdout: &stdout, Stderr: &stderr}
 	if err := app.login(context.Background(), []string{"--url", stale.URL, "--provider", "aws", "--no-browser"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := <-loopbackResult; err != nil {
 		t.Fatal(err)
 	}
 	if staleStartCount != 1 || canonicalStartCount != 1 {

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -1177,9 +1177,12 @@ func (c *CoordinatorClient) ProviderReadiness(ctx context.Context, cfg Config) (
 	return res, err
 }
 
-func (c *CoordinatorClient) StartGitHubLogin(ctx context.Context, pollSecretHash, provider string) (CoordinatorGitHubLoginStart, error) {
+func (c *CoordinatorClient) StartGitHubLogin(ctx context.Context, pollSecretHash, provider, loopbackRedirectURI string) (CoordinatorGitHubLoginStart, error) {
 	var res CoordinatorGitHubLoginStart
-	body := map[string]any{"pollSecretHash": pollSecretHash}
+	body := map[string]any{
+		"pollSecretHash":      pollSecretHash,
+		"loopbackRedirectURI": loopbackRedirectURI,
+	}
 	if provider != "" {
 		body["provider"] = provider
 	}
@@ -1187,12 +1190,16 @@ func (c *CoordinatorClient) StartGitHubLogin(ctx context.Context, pollSecretHash
 	return res, err
 }
 
-func (c *CoordinatorClient) PollGitHubLogin(ctx context.Context, loginID, pollSecret string) (CoordinatorGitHubLoginPoll, error) {
+func (c *CoordinatorClient) PollGitHubLogin(ctx context.Context, loginID, pollSecret, browserConfirmation string) (CoordinatorGitHubLoginPoll, error) {
 	var res CoordinatorGitHubLoginPoll
-	err := c.do(ctx, http.MethodPost, "/v1/auth/github/poll", map[string]any{
+	body := map[string]any{
 		"loginID":    loginID,
 		"pollSecret": pollSecret,
-	}, &res)
+	}
+	if browserConfirmation != "" {
+		body["browserConfirmation"] = browserConfirmation
+	}
+	err := c.do(ctx, http.MethodPost, "/v1/auth/github/poll", body, &res)
 	return res, err
 }
 

--- a/worker/src/oauth.ts
+++ b/worker/src/oauth.ts
@@ -22,9 +22,11 @@ interface OAuthPending {
   id: string;
   state: string;
   pollSecretHash?: string;
+  browserConfirmationHash?: string;
   mode?: "cli" | "portal";
   provider?: Provider;
   returnTo?: string;
+  loopbackRedirectURI?: string;
   redirectURI: string;
   createdAt: string;
   expiresAt: string;
@@ -146,9 +148,20 @@ async function githubAuthStart(
   const input = await readJson<{
     pollSecretHash?: string;
     provider?: Provider;
+    loopbackRedirectURI?: string;
   }>(request);
   if (!input.pollSecretHash || !/^[a-f0-9]{64}$/.test(input.pollSecretHash)) {
     return json({ error: "invalid_poll_secret_hash" }, { status: 400 });
+  }
+  const loopbackRedirectURI = validLoopbackRedirectURI(input.loopbackRedirectURI);
+  if (!loopbackRedirectURI) {
+    return json(
+      {
+        error: "loopback_redirect_required",
+        message: "Upgrade the Crabbox CLI to complete GitHub login on this device.",
+      },
+      { status: 400 },
+    );
   }
   const pendingCount = await cleanupExpiredPendingOAuth(storage);
   if (pendingCount >= maxPendingOAuthLogins) {
@@ -163,6 +176,7 @@ async function githubAuthStart(
   const pending = newPendingOAuth({
     mode: "cli",
     pollSecretHash: input.pollSecretHash,
+    loopbackRedirectURI,
     redirectURI: oauthConfig.redirectURI,
   });
   if (input.provider === "aws" || input.provider === "hetzner" || input.provider === "gcp") {
@@ -290,7 +304,11 @@ async function githubAuthCallback(
     if (tokenExpiresAt) {
       completion.tokenExpiresAt = tokenExpiresAt;
     }
-    const completed = await finishPendingOAuth(runtime, pending.id, claim, completion);
+    const browserConfirmation = randomID("confirm");
+    const completed = await finishPendingOAuth(runtime, pending.id, claim, {
+      ...completion,
+      browserConfirmationHash: await sha256Hex(browserConfirmation),
+    });
     if (!completed) {
       return expiredOAuthResponse();
     }
@@ -300,10 +318,20 @@ async function githubAuthCallback(
         "set-cookie": portalSessionCookie(token, ttlSeconds),
       });
     }
-    return html(
-      "Crabbox login complete",
-      "GitHub authorized Crabbox. You can close this tab and return to the terminal.",
-    );
+    if (!completed.loopbackRedirectURI) {
+      await runtime.runExclusive(() => deletePendingOAuth(runtime.storage, completed));
+      return html(
+        "Crabbox login unavailable",
+        "This login was started by an outdated client. Upgrade Crabbox and try again.",
+        400,
+      );
+    }
+    const loopback = new URL(completed.loopbackRedirectURI);
+    loopback.searchParams.set("confirmation", browserConfirmation);
+    return redirect(loopback.toString(), 303, {
+      "cache-control": "no-store",
+      "referrer-policy": "no-referrer",
+    });
   } catch (err) {
     await finishPendingOAuth(runtime, pending.id, claim, { error: errorMessage(err) });
     if (err instanceof GitHubAuthorizationError) {
@@ -349,7 +377,10 @@ async function finishPendingOAuth(
   id: string,
   claim: string,
   result: Partial<
-    Pick<OAuthPending, "token" | "tokenExpiresAt" | "owner" | "org" | "login" | "error">
+    Pick<
+      OAuthPending,
+      "token" | "tokenExpiresAt" | "owner" | "org" | "login" | "error" | "browserConfirmationHash"
+    >
   >,
 ): Promise<OAuthPending | undefined> {
   return runtime.runExclusive(async () => {
@@ -377,7 +408,11 @@ function expiredOAuthResponse(): Response {
 }
 
 async function githubAuthPoll(request: Request, storage: CoordinatorStorage): Promise<Response> {
-  const input = await readJson<{ loginID?: string; pollSecret?: string }>(request);
+  const input = await readJson<{
+    loginID?: string;
+    pollSecret?: string;
+    browserConfirmation?: string;
+  }>(request);
   if (!input.loginID || !input.pollSecret) {
     return json({ error: "invalid_poll" }, { status: 400 });
   }
@@ -400,6 +435,22 @@ async function githubAuthPoll(request: Request, storage: CoordinatorStorage): Pr
   }
   if (!pending.token) {
     return json({ status: "pending", expiresAt: pending.expiresAt });
+  }
+  if (!pending.loopbackRedirectURI || !pending.browserConfirmationHash) {
+    await deletePendingOAuth(storage, pending);
+    return json(
+      { status: "failed", error: "This login was started by an outdated client." },
+      { status: 400 },
+    );
+  }
+  if (!input.browserConfirmation) {
+    return json({ status: "confirmation_required", expiresAt: pending.expiresAt });
+  }
+  if (
+    !/^confirm_[a-f0-9]{32}$/.test(input.browserConfirmation) ||
+    (await sha256Hex(input.browserConfirmation)) !== pending.browserConfirmationHash
+  ) {
+    return json({ error: "forbidden" }, { status: 403 });
   }
   const response = {
     status: "complete",
@@ -424,6 +475,34 @@ function userTokenTTLSeconds(env: Pick<Env, "CRABBOX_USER_TOKEN_TTL_SECONDS">): 
     return defaultUserTokenTTLSeconds;
   }
   return Math.min(maxUserTokenTTLSeconds, Math.max(minUserTokenTTLSeconds, Math.trunc(value)));
+}
+
+function validLoopbackRedirectURI(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return undefined;
+  }
+  const port = Number(parsed.port);
+  if (
+    parsed.protocol !== "http:" ||
+    parsed.hostname !== "127.0.0.1" ||
+    !Number.isInteger(port) ||
+    port < 1 ||
+    port > 65535 ||
+    parsed.username !== "" ||
+    parsed.password !== "" ||
+    parsed.search !== "" ||
+    parsed.hash !== "" ||
+    !/^\/crabbox\/oauth\/[a-f0-9]{64}$/.test(parsed.pathname)
+  ) {
+    return undefined;
+  }
+  return parsed.toString();
 }
 
 function githubOAuthConfiguration(

--- a/worker/test/coordinator-runtime.test.ts
+++ b/worker/test/coordinator-runtime.test.ts
@@ -568,7 +568,10 @@ describe("coordinator runtimes", () => {
         new Request("https://coordinator.test/v1/auth/github/start", {
           method: "POST",
           headers: { "content-type": "application/json" },
-          body: JSON.stringify({ pollSecretHash: "0".repeat(64) }),
+          body: JSON.stringify({
+            pollSecretHash: "0".repeat(64),
+            loopbackRedirectURI: `http://127.0.0.1:54321/crabbox/oauth/${"a".repeat(64)}`,
+          }),
         }),
         "start",
         runtime,
@@ -626,7 +629,7 @@ describe("coordinator runtimes", () => {
     expect(duplicate.status).toBe(409);
 
     releaseTokenExchange();
-    await expect(callback).resolves.toMatchObject({ status: 200 });
+    await expect(callback).resolves.toMatchObject({ status: 303 });
   });
 
   it("runs the fleet coordinator without a Durable Object", async () => {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -20942,6 +20942,7 @@ describe("fleet identity", () => {
         body: {
           pollSecretHash: await sha256HexForTest(pollSecret),
           provider: "aws",
+          loopbackRedirectURI: testLoopbackRedirectURI,
         },
       }),
     );
@@ -20966,6 +20967,40 @@ describe("fleet identity", () => {
     );
     expect(poll.status).toBe(200);
     await expect(poll.json()).resolves.toMatchObject({ status: "pending" });
+  });
+
+  it.each([
+    ["missing", undefined],
+    ["remote host", `http://example.test:54321/crabbox/oauth/${"a".repeat(64)}`],
+    ["https", `https://127.0.0.1:54321/crabbox/oauth/${"a".repeat(64)}`],
+    ["default port", `http://127.0.0.1:80/crabbox/oauth/${"a".repeat(64)}`],
+    ["short path secret", "http://127.0.0.1:54321/crabbox/oauth/abc"],
+    ["query", `${testLoopbackRedirectURI}?next=https://example.test`],
+    ["fragment", `${testLoopbackRedirectURI}#fragment`],
+  ])("rejects a %s GitHub CLI loopback redirect", async (_name, loopbackRedirectURI) => {
+    const fleet = testFleet(
+      undefined,
+      {},
+      {
+        CRABBOX_DEFAULT_ORG: "openclaw",
+        CRABBOX_PUBLIC_URL: "https://broker.example.test",
+        CRABBOX_GITHUB_CLIENT_ID: "github-client",
+        CRABBOX_GITHUB_CLIENT_SECRET: "github-secret",
+        CRABBOX_SESSION_SECRET: "session-secret",
+      },
+    );
+    const response = await fleet.fetch(
+      request("POST", "/v1/auth/github/start", {
+        body: {
+          pollSecretHash: await sha256HexForTest("local-poll-secret"),
+          ...(loopbackRedirectURI ? { loopbackRedirectURI } : {}),
+        },
+      }),
+    );
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "loopback_redirect_required",
+    });
   });
 
   it("requires a canonical public origin before GitHub login starts", async () => {
@@ -21017,7 +21052,7 @@ describe("fleet identity", () => {
     const canonical = await fleet.fetch(
       request("GET", `/v1/auth/github/callback?code=ok&state=${state}`),
     );
-    expect(canonical.status).toBe(200);
+    expect(canonical.status).toBe(303);
     expect(fetchMock).toHaveBeenCalled();
   });
 
@@ -21180,6 +21215,7 @@ describe("fleet identity", () => {
         body: {
           pollSecretHash: await sha256HexForTest("new-secret"),
           provider: "aws",
+          loopbackRedirectURI: testLoopbackRedirectURI,
         },
       }),
     );
@@ -21212,20 +21248,42 @@ describe("fleet identity", () => {
     });
   });
 
-  it("mints GitHub login tokens for allowed org members", async () => {
+  it("binds allowed-member token release to the browser confirmation", async () => {
     const { fleet, loginID, state, pollSecret } = await startGitHubLogin();
     vi.stubGlobal("fetch", githubFetchMock({ member: true }));
 
     const callback = await fleet.fetch(
       request("GET", `/v1/auth/github/callback?code=ok&state=${state}`),
     );
-    expect(callback.status).toBe(200);
+    const browserConfirmation = browserConfirmationFromCallback(callback);
+
+    const unconfirmed = await fleet.fetch(
+      request("POST", "/v1/auth/github/poll", {
+        body: { loginID, pollSecret },
+      }),
+    );
+    expect(unconfirmed.status).toBe(200);
+    await expect(unconfirmed.json()).resolves.toMatchObject({
+      status: "confirmation_required",
+    });
+
+    const forged = await fleet.fetch(
+      request("POST", "/v1/auth/github/poll", {
+        body: {
+          loginID,
+          pollSecret,
+          browserConfirmation: `confirm_${"0".repeat(32)}`,
+        },
+      }),
+    );
+    expect(forged.status).toBe(403);
 
     const poll = await fleet.fetch(
       request("POST", "/v1/auth/github/poll", {
         body: {
           loginID,
           pollSecret,
+          browserConfirmation,
         },
       }),
     );
@@ -21313,13 +21371,14 @@ describe("fleet identity", () => {
     const callback = await fleet.fetch(
       request("GET", `/v1/auth/github/callback?code=ok&state=${state}`),
     );
-    expect(callback.status).toBe(200);
+    const browserConfirmation = browserConfirmationFromCallback(callback);
 
     const poll = await fleet.fetch(
       request("POST", "/v1/auth/github/poll", {
         body: {
           loginID,
           pollSecret,
+          browserConfirmation,
         },
       }),
     );
@@ -21345,13 +21404,14 @@ describe("fleet identity", () => {
     const callback = await fleet.fetch(
       request("GET", `/v1/auth/github/callback?code=ok&state=${state}`),
     );
-    expect(callback.status).toBe(200);
+    const browserConfirmation = browserConfirmationFromCallback(callback);
 
     const poll = await fleet.fetch(
       request("POST", "/v1/auth/github/poll", {
         body: {
           loginID,
           pollSecret,
+          browserConfirmation,
         },
       }),
     );
@@ -21410,13 +21470,14 @@ describe("fleet identity", () => {
     const callback = await fleet.fetch(
       request("GET", `/v1/auth/github/callback?code=ok&state=${state}`),
     );
-    expect(callback.status).toBe(200);
+    const browserConfirmation = browserConfirmationFromCallback(callback);
 
     const poll = await fleet.fetch(
       request("POST", "/v1/auth/github/poll", {
         body: {
           loginID,
           pollSecret,
+          browserConfirmation,
         },
       }),
     );
@@ -21598,6 +21659,7 @@ async function startGitHubLogin(env: Partial<Env> = {}): Promise<{
       body: {
         pollSecretHash: await sha256HexForTest(pollSecret),
         provider: "aws",
+        loopbackRedirectURI: testLoopbackRedirectURI,
       },
     }),
   );
@@ -21607,6 +21669,21 @@ async function startGitHubLogin(env: Partial<Env> = {}): Promise<{
   const state = url.searchParams.get("state");
   expect(state).toBeTruthy();
   return { fleet, loginID: body.loginID, pollSecret, state: state || "" };
+}
+
+const testLoopbackRedirectURI = `http://127.0.0.1:54321/crabbox/oauth/${"a".repeat(64)}`;
+
+function browserConfirmationFromCallback(callback: Response): string {
+  expect(callback.status).toBe(303);
+  expect(callback.headers.get("cache-control")).toBe("no-store");
+  expect(callback.headers.get("referrer-policy")).toBe("no-referrer");
+  const location = callback.headers.get("location");
+  expect(location).toBeTruthy();
+  const redirect = new URL(location ?? "");
+  expect(redirect.origin + redirect.pathname).toBe(testLoopbackRedirectURI);
+  const confirmation = redirect.searchParams.get("confirmation");
+  expect(confirmation).toMatch(/^confirm_[a-f0-9]{32}$/);
+  return confirmation ?? "";
 }
 
 function githubFetchMock({


### PR DESCRIPTION
## Summary

- bind GitHub OAuth CLI token release to a random loopback listener on the initiating device
- require the terminal-held poll secret and browser-delivered confirmation; reject legacy or nonconforming completion without both proofs
- keep explicit `login --url` credentials authoritative during immediate identity verification
- document the same-device login contract and old-client fail-closed behavior

Fixes https://github.com/openclaw/crabbox/issues/901

## Security design

The CLI opens an ephemeral IPv4 listener at `http://127.0.0.1:<random-port>/crabbox/oauth/<random-path>`. The coordinator validates that exact shape, sends a one-use random confirmation through the browser redirect, stores only its hash, and releases the signed user token only when polling proves both the original poll secret and the browser confirmation. The CLI independently refuses a completed poll until its loopback listener has received the confirmation.

## Live proof

- registered a disposable GitHub OAuth application and deployed the candidate Worker to a disposable Cloudflare Worker
- completed real GitHub authorization in the existing signed-in browser; the callback reached the candidate CLI loopback listener and `whoami` returned the GitHub-backed owner and organization
- repeated with an attacker-owned start/poll client and a different loopback destination: unconfirmed polling returned `confirmation_required` with no token; a forged confirmation returned HTTP 403 with no token
- verified explicit broker login still completed while an ambient coordinator override pointed elsewhere
- deleted the OAuth application, OAuth grants/tokens, Cloudflare Worker, temporary 1Password item, local tokens, configs, scripts, and binary; the deleted Worker endpoint returns HTTP 404

## Verification

- `go vet ./...`
- `go test -race ./...`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker` (805 tests)
- `npm run build --prefix worker`
- `node scripts/build-docs-site.mjs`
- autoreview clean after resolving its downgrade-path finding
