### PR TITLE
fix: restrict releases to reviewed dispatches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,8 @@
 name: release
 
 on:
-  push:
-    tags:
-      - "v*"
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: "Tag to (re)release (e.g. v0.1.0)"
-        required: true
-        type: string
+  repository_dispatch:
+    types: [release]
 
 permissions:
   contents: write
@@ -27,38 +20,19 @@ jobs:
       - name: Verify Apple Silicon runner
         run: test "$(uname -m)" = arm64
 
-      - name: Verify manual release source and tag
-        if: ${{ github.event_name == 'workflow_dispatch' }}
+      - name: Verify release source and tag
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-          RELEASE_TAG: ${{ inputs.tag }}
+          RELEASE_TAG: ${{ github.event.client_payload.tag }}
           WORKFLOW_REF: ${{ github.ref }}
-        run: |
-          if [ "$WORKFLOW_REF" != "refs/heads/$DEFAULT_BRANCH" ]; then
-            echo "::error::manual releases must dispatch the workflow from $DEFAULT_BRANCH"
-            exit 1
-          fi
-          if ! [[ "$RELEASE_TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
-            echo "::error::manual release tag must match vMAJOR.MINOR.PATCH"
-            exit 1
-          fi
-          tag_ref="refs/tags/$RELEASE_TAG"
-          if ! git rev-parse --verify "$tag_ref^{commit}" >/dev/null; then
-            echo "::error::manual release tag does not exist: $RELEASE_TAG"
-            exit 1
-          fi
-          if ! git merge-base --is-ancestor "$tag_ref^{commit}" HEAD; then
-            echo "::error::manual release tag is not in $DEFAULT_BRANCH history: $RELEASE_TAG"
-            exit 1
-          fi
+        run: scripts/verify-release-source.sh
 
       - name: Stash current GoReleaser config
         run: cp .goreleaser.yaml /tmp/.goreleaser.yaml
 
       - name: Checkout release tag
-        if: ${{ github.event_name == 'workflow_dispatch' }}
         env:
-          RELEASE_TAG: ${{ inputs.tag }}
+          RELEASE_TAG: ${{ github.event.client_payload.tag }}
         run: git checkout --detach "refs/tags/$RELEASE_TAG"
 
       - name: Setup Go
@@ -70,10 +44,9 @@ jobs:
       - name: Resolve release tag
         id: release
         env:
-          DISPATCH_TAG: ${{ inputs.tag }}
-          REF_NAME: ${{ github.ref_name }}
+          DISPATCH_TAG: ${{ github.event.client_payload.tag }}
         run: |
-          tag="${DISPATCH_TAG:-$REF_NAME}"
+          tag="$DISPATCH_TAG"
           if [ -z "$tag" ]; then
             echo "::error::could not resolve release tag"
             exit 1
@@ -98,8 +71,7 @@ jobs:
             exit 1
           fi
 
-      - name: Remove incomplete manual release
-        if: ${{ github.event_name == 'workflow_dispatch' }}
+      - name: Remove incomplete release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ steps.release.outputs.tag }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- Restricted production releases to default-branch repository dispatches for existing version tags in reviewed history, so tag pushes and ref-selectable manual workflows cannot run credentialed release configuration. Thanks @coygeek.
 - Bound GitHub OAuth CLI token release to a one-use callback on the initiating device, so forwarding an authorization URL cannot hand the resulting user token to another terminal. Thanks @coygeek.
 - Honored an explicit broker URL and freshly issued credential during immediate post-login identity verification, even when ambient coordinator overrides point elsewhere.
 - Kept coordinator restarts, run history, lease detail pages, and Azure orphan sweeps memory-bounded with exact lease restores, paged record scans, and batched terminal-run pruning after a configurable 30-day retention period.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Crabbox banner](docs/assets/readme-banner.jpg)
 
 [![CI](https://github.com/openclaw/crabbox/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openclaw/crabbox/actions/workflows/ci.yml)
-[![Release](https://github.com/openclaw/crabbox/actions/workflows/release.yml/badge.svg?event=push)](https://github.com/openclaw/crabbox/actions/workflows/release.yml)
+[![Release](https://github.com/openclaw/crabbox/actions/workflows/release.yml/badge.svg?event=repository_dispatch)](https://github.com/openclaw/crabbox/actions/workflows/release.yml)
 [![Latest release](https://badgen.net/github/release/openclaw/crabbox/stable)](https://github.com/openclaw/crabbox/releases/latest)
 
 **Warm a box, sync the diff, run the suite.**

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -684,6 +684,6 @@ Before tagging a release:
 - `git diff --check`
 - Live smoke at least one coordinator-backed `crabbox run`, then verify `crabbox attach`, `crabbox events`, `crabbox logs`, and lease cleanup.
 - Push, pull, and wait for CI green on the release commit.
-- Tag and push `vX.Y.Z`, then wait for the release workflow. The workflow publishes GitHub release assets, copies the matching `CHANGELOG.md` section into the GitHub release body, and pushes the generated `Formula/crabbox.rb` update to `openclaw/homebrew-tap` with `HOMEBREW_TAP_GITHUB_TOKEN`; missing tap access is a release failure.
+- Tag and push `vX.Y.Z`, then send the default-branch release event with that exact tag: `gh api --method POST repos/openclaw/crabbox/dispatches -f event_type=release -f 'client_payload[tag]=vX.Y.Z'`. Tag pushes and ref-selectable workflow dispatches do not publish. The workflow verifies that the tag is in default-branch history before loading release credentials, publishes GitHub release assets, copies the matching `CHANGELOG.md` section into the GitHub release body, and pushes the generated `Formula/crabbox.rb` update to `openclaw/homebrew-tap` with `HOMEBREW_TAP_GITHUB_TOKEN`; missing tap access is a release failure.
 - Verify the GitHub release assets and the Homebrew formula update.
 - `brew update`, install or upgrade `openclaw/tap/crabbox`, run `crabbox --version`, and run a short live smoke from the installed binary.

--- a/docs/security.md
+++ b/docs/security.md
@@ -343,13 +343,14 @@ it to commands, print it, or store it in repo config.
 
 ## Release Integrity
 
-Release publication uses the GoReleaser configuration from the reviewed branch
-that dispatched the workflow, never configuration from a manually selected
-release tag. Manual re-releases must be dispatched from the default branch,
-accept only an existing exact `vMAJOR.MINOR.PATCH` tag in that branch's history,
-and may fail for historical tags that are incompatible with the current
-reviewed release configuration rather than falling back to tag-controlled
-publishing behavior.
+Production release publication accepts only a `repository_dispatch` release
+event, which GitHub runs from the default branch; version-tag pushes and
+ref-selectable workflow dispatches do not start the credentialed workflow. The
+workflow accepts only an existing exact `vMAJOR.MINOR.PATCH` tag in
+default-branch history and uses the GoReleaser configuration from the reviewed
+default-branch commit, never from the selected release tag. Re-releases may fail
+for historical tags that are incompatible with the current reviewed
+configuration rather than falling back to tag-controlled publishing behavior.
 
 ## Managed Windows Artifact Integrity
 

--- a/scripts/release-workflow.test.js
+++ b/scripts/release-workflow.test.js
@@ -1,27 +1,37 @@
 import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
 
-test("manual release checks out requested tag before setup-go reads go.mod", () => {
+test("repository dispatch checks out the requested default-branch tag", () => {
   const workflow = fs.readFileSync(path.join(repoRoot, ".github", "workflows", "release.yml"), "utf8");
-  const verifySource = workflow.indexOf("- name: Verify manual release source and tag");
+  const trigger = workflow.slice(workflow.indexOf("on:"), workflow.indexOf("permissions:"));
+  const verifySource = workflow.indexOf("- name: Verify release source and tag");
   const stashConfig = workflow.indexOf("- name: Stash current GoReleaser config");
   const checkoutTag = workflow.indexOf("- name: Checkout release tag");
   const setupGo = workflow.indexOf("- name: Setup Go");
 
+  assert.match(trigger, /repository_dispatch:[\s\S]*types:\s*\[release\]/);
+  assert.doesNotMatch(
+    trigger,
+    /workflow_dispatch:/,
+    "ref-selectable workflow dispatches must not start production releases",
+  );
+  assert.doesNotMatch(trigger, /push:/, "tag pushes must not start production releases");
   assert.notEqual(verifySource, -1);
   assert.notEqual(stashConfig, -1);
   assert.notEqual(checkoutTag, -1);
   assert.notEqual(setupGo, -1);
-  assert.ok(verifySource < stashConfig, "manual source and tag should be verified before config is saved");
+  assert.ok(verifySource < stashConfig, "release source and tag should be verified before config is saved");
   assert.ok(stashConfig < checkoutTag, "GoReleaser config should be saved before checking out historical tags");
   assert.ok(checkoutTag < setupGo, "setup-go should read go.mod from the requested release tag");
   assert.match(
     workflow.slice(verifySource, stashConfig),
-    /WORKFLOW_REF.*refs\/heads\/\$DEFAULT_BRANCH[\s\S]*\^v\(0\|\[1-9\]\[0-9\]\*\)[\s\S]*tag_ref="refs\/tags\/\$RELEASE_TAG"[\s\S]*git merge-base --is-ancestor "\$tag_ref\^\{commit\}" HEAD/,
+    /DEFAULT_BRANCH:[\s\S]*github\.event\.client_payload\.tag[\s\S]*WORKFLOW_REF:[\s\S]*run: scripts\/verify-release-source\.sh/,
   );
   assert.match(workflow.slice(checkoutTag, setupGo), /git checkout --detach "refs\/tags\/\$RELEASE_TAG"/);
   assert.doesNotMatch(
@@ -30,6 +40,91 @@ test("manual release checks out requested tag before setup-go reads go.mod", () 
     "the selected release tag must not replace the reviewed GoReleaser config",
   );
   assert.match(workflow.slice(setupGo), /go-version-file:\s+go\.mod/);
+});
+
+test("release source guard accepts only reviewed default-branch tags", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-release-source-"));
+  const guard = path.join(repoRoot, "scripts", "verify-release-source.sh");
+  const git = (...args) => execFileSync("git", args, { cwd: root, stdio: "pipe" });
+  const runGuard = (env) =>
+    spawnSync(guard, [], {
+      cwd: root,
+      env: { ...process.env, ...env },
+      encoding: "utf8",
+    });
+
+  try {
+    git("init", "-b", "main");
+    git("config", "user.name", "Crabbox Test");
+    git("config", "user.email", "test@example.com");
+    fs.writeFileSync(path.join(root, "reviewed.txt"), "reviewed\n");
+    git("add", "reviewed.txt");
+    git("commit", "-m", "reviewed");
+    git("tag", "--no-sign", "v1.2.3");
+
+    const valid = runGuard({
+      DEFAULT_BRANCH: "main",
+      RELEASE_TAG: "v1.2.3",
+      WORKFLOW_REF: "refs/heads/main",
+    });
+    assert.equal(valid.status, 0, valid.stderr || valid.stdout);
+
+    const wrongBranch = runGuard({
+      DEFAULT_BRANCH: "main",
+      RELEASE_TAG: "v1.2.3",
+      WORKFLOW_REF: "refs/heads/unreviewed",
+    });
+    assert.equal(wrongBranch.status, 1);
+    assert.match(wrongBranch.stdout, /release events must run from main/);
+
+    const malformed = runGuard({
+      DEFAULT_BRANCH: "main",
+      RELEASE_TAG: "v1.2",
+      WORKFLOW_REF: "refs/heads/main",
+    });
+    assert.equal(malformed.status, 1);
+    assert.match(malformed.stdout, /must match vMAJOR\.MINOR\.PATCH/);
+
+    const missing = runGuard({
+      DEFAULT_BRANCH: "main",
+      RELEASE_TAG: "v9.9.9",
+      WORKFLOW_REF: "refs/heads/main",
+    });
+    assert.equal(missing.status, 1);
+    assert.match(missing.stdout, /release tag does not exist/);
+
+    git("switch", "--orphan", "unreviewed");
+    fs.writeFileSync(path.join(root, "unreviewed.txt"), "unreviewed\n");
+    git("add", "unreviewed.txt");
+    git("commit", "-m", "unreviewed");
+    git("tag", "--no-sign", "v2.0.0");
+    git("switch", "main");
+
+    const outsideHistory = runGuard({
+      DEFAULT_BRANCH: "main",
+      RELEASE_TAG: "v2.0.0",
+      WORKFLOW_REF: "refs/heads/main",
+    });
+    assert.equal(outsideHistory.status, 1);
+    assert.match(outsideHistory.stdout, /not in main history/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("release credentials stay behind the dispatch source guard", () => {
+  const workflow = fs.readFileSync(path.join(repoRoot, ".github", "workflows", "release.yml"), "utf8");
+  const verifySource = workflow.indexOf("- name: Verify release source and tag");
+  const verifyTapToken = workflow.indexOf("- name: Verify Homebrew tap token");
+  const goreleaser = workflow.indexOf("- name: GoReleaser");
+
+  assert.ok(verifySource < verifyTapToken);
+  assert.ok(verifyTapToken < goreleaser);
+  assert.doesNotMatch(
+    workflow.slice(0, verifyTapToken),
+    /\$\{\{\s*secrets\./,
+    "release secrets must not be loaded before source and ancestry checks",
+  );
 });
 
 test("macOS GoReleaser jobs bound build parallelism", () => {
@@ -60,16 +155,15 @@ test("production and snapshot releases have the same build budget", () => {
   assert.match(releaseWorkflow, /goreleaser:[\s\S]*?timeout-minutes:\s+45/);
 });
 
-test("manual retries replace only incomplete releases", () => {
+test("retries replace only incomplete releases", () => {
   const workflow = fs.readFileSync(path.join(repoRoot, ".github", "workflows", "release.yml"), "utf8");
   const resolveTag = workflow.indexOf("- name: Resolve release tag");
-  const removeIncomplete = workflow.indexOf("- name: Remove incomplete manual release");
+  const removeIncomplete = workflow.indexOf("- name: Remove incomplete release");
   const goreleaser = workflow.indexOf("- name: GoReleaser");
   const retryStep = workflow.slice(removeIncomplete, goreleaser);
 
   assert.ok(resolveTag < removeIncomplete, "the release tag must be resolved before retry cleanup");
   assert.ok(removeIncomplete < goreleaser, "an incomplete release must be removed before publishing");
-  assert.match(retryStep, /if:\s+\$\{\{ github\.event_name == 'workflow_dispatch' \}\}/);
   assert.match(retryStep, /404\) exit 0/);
   assert.match(retryStep, /grep -q "\^## \$RELEASE_VERSION "/);
   assert.match(retryStep, /already finalized; refusing to replace its artifacts/);

--- a/scripts/verify-release-source.sh
+++ b/scripts/verify-release-source.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${DEFAULT_BRANCH:?DEFAULT_BRANCH is required}"
+: "${RELEASE_TAG:?RELEASE_TAG is required}"
+: "${WORKFLOW_REF:?WORKFLOW_REF is required}"
+
+if [[ "$WORKFLOW_REF" != "refs/heads/$DEFAULT_BRANCH" ]]; then
+  echo "::error::release events must run from $DEFAULT_BRANCH"
+  exit 1
+fi
+if [[ ! "$RELEASE_TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+  echo "::error::release tag must match vMAJOR.MINOR.PATCH"
+  exit 1
+fi
+
+tag_ref="refs/tags/$RELEASE_TAG"
+if ! git rev-parse --verify "$tag_ref^{commit}" >/dev/null; then
+  echo "::error::release tag does not exist: $RELEASE_TAG"
+  exit 1
+fi
+if ! git merge-base --is-ancestor "$tag_ref^{commit}" HEAD; then
+  echo "::error::release tag is not in $DEFAULT_BRANCH history: $RELEASE_TAG"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- replace tag-push and ref-selectable manual production releases with an explicit `repository_dispatch` event, which GitHub runs from the default branch
- validate the exact semantic-version tag exists in reviewed default-branch history before release credentials are loaded
- preserve the reviewed GoReleaser configuration while building the selected tag; document and regression-test the operator flow

GitHub documents that `repository_dispatch` runs from the last commit on the default branch: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#repository_dispatch

Fixes https://github.com/openclaw/crabbox/issues/905

## Verification

- `node --test scripts/release-workflow.test.js`
  - accepted a reviewed default-branch tag
  - rejected a wrong workflow ref, malformed tag, missing tag, and tag outside default-branch history
- `actionlint .github/workflows/release.yml`
- `scripts/check-docs.sh`
- `go vet ./...`
- `go test -race ./...`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker` (805 tests)
- `npm run build --prefix worker`
- autoreview: clean
- `git diff --check`

No production release was invoked; the release boundary and negative cases were exercised in a disposable local Git repository.
