### PR TITLE
ci: auto-deploy crabbox-coordinator on main

### DIFF
--- a/.github/workflows/coordinator-deploy.yml
+++ b/.github/workflows/coordinator-deploy.yml
@@ -1,0 +1,56 @@
+name: Deploy Coordinator
+
+# Deploys the crabbox-coordinator Worker whenever worker/** lands on main, so
+# production tracks main instead of drifting behind a manual `wrangler deploy`
+# (stale deploys are how a fixed-on-main OOM stayed broken in prod). Also
+# runnable on demand from the Actions tab.
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "worker/**"
+      - ".github/workflows/coordinator-deploy.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: coordinator-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy crabbox-coordinator
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Scope the Cloudflare token to this environment; add required reviewers here
+    # to gate production deploys without changing the workflow.
+    environment: coordinator
+    steps:
+      - name: Check out
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: worker/package-lock.json
+
+      - name: Install
+        run: npm ci
+        working-directory: worker
+
+      - name: Deploy
+        # `npm run deploy` runs the predeploy bundle (vendor-novnc) then
+        # `wrangler deploy`; a bundling failure fails the job before publishing.
+        run: npm run deploy
+        working-directory: worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          # OpenClaw account that hosts crabbox.openclaw.ai; not secret. The
+          # worker's wrangler.jsonc omits account_id so local deploys stay
+          # account-agnostic, so CI supplies it explicitly.
+          CLOUDFLARE_ACCOUNT_ID: "91b59577e757131d68d55a471fe32aca"

--- a/.github/workflows/coordinator-deploy.yml
+++ b/.github/workflows/coordinator-deploy.yml
@@ -29,10 +29,26 @@ jobs:
     # to gate production deploys without changing the workflow.
     environment: coordinator
     steps:
+      # Stay green (skip, don't fail) until the deploy secret is wired, so
+      # landing this workflow doesn't red-X main before activation.
+      - name: Check for deploy token
+        id: token
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          if [ -z "${CLOUDFLARE_API_TOKEN}" ]; then
+            echo "::notice::CLOUDFLARE_API_TOKEN is not set; skipping deploy. Add it to the 'coordinator' environment to activate."
+            echo "ready=false" >> "${GITHUB_OUTPUT}"
+          else
+            echo "ready=true" >> "${GITHUB_OUTPUT}"
+          fi
+
       - name: Check out
+        if: steps.token.outputs.ready == 'true'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Node
+        if: steps.token.outputs.ready == 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
@@ -40,10 +56,12 @@ jobs:
           cache-dependency-path: worker/package-lock.json
 
       - name: Install
+        if: steps.token.outputs.ready == 'true'
         run: npm ci
         working-directory: worker
 
       - name: Deploy
+        if: steps.token.outputs.ready == 'true'
         # `npm run deploy` runs the predeploy bundle (vendor-novnc) then
         # `wrangler deploy`; a bundling failure fails the job before publishing.
         run: npm run deploy


### PR DESCRIPTION
## What Problem This Solves

The `crabbox-coordinator` Worker has no deploy pipeline — it's shipped by a manual local `wrangler deploy`, so production drifts behind `main`. This is not hypothetical: the run-history Durable Object OOM was fixed on `main` by #909, but the deployed coordinator predated it (last deployed 2026-06-26), so production kept OOMing and churning Azure leases for days after the fix landed (see #862).

## Why This Change Was Made

Make production track `main`. This workflow deploys the coordinator whenever `worker/**` lands on `main`, and can also be run on demand from the Actions tab.

- `on: push` to `main` filtered to `worker/**` (+ the workflow file), plus `workflow_dispatch`.
- `concurrency: coordinator-deploy` with `cancel-in-progress: false` so deploys serialize rather than clobber each other.
- Matches the repo's `Worker` CI job setup (Node 24, `npm ci` in `worker/`, pinned action SHAs).
- Deploy step is `npm run deploy`, which runs the predeploy bundle then `wrangler deploy`; a bundling failure fails the job before anything publishes.
- Uses a `coordinator` GitHub Environment so the Cloudflare token is scoped there and required reviewers can gate production deploys without touching the workflow.

## User Impact

Operational only — no runtime/API change. After activation, a merged coordinator fix reaches production automatically instead of waiting for someone to remember to deploy.

## Activation (one-time)

1. Mint a Cloudflare API token on the OpenClaw account (`91b59577…`) with **Account → Workers Scripts: Edit** and **Account → Account Settings: Read** (add **Workers Tail: Read** if you also want CI tailing).
2. Create a `coordinator` Environment in repo settings (optionally add required reviewers).
3. Add the token as environment secret `CLOUDFLARE_API_TOKEN`.

The account id is not secret and is set inline in the workflow.

## Evidence

- `actionlint` clean; YAML parses.
- Deploy step mirrors the exact command (`npm run deploy`) used to deploy the current live coordinator during the #862 investigation, which published successfully and was verified OOM-free.
