### PR TITLE
fix: preserve repository config trust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 
 - Restricted production releases to default-branch repository dispatches for existing version tags in reviewed history, so tag pushes and ref-selectable manual workflows cannot run credentialed release configuration. Thanks @coygeek.
+- Kept explicit `CRABBOX_CONFIG` files inside the active repository in the repository trust domain, including symlink aliases, so they cannot redirect inherited provider credentials. Thanks @coygeek.
 - Bound GitHub OAuth CLI token release to a one-use callback on the initiating device, so forwarding an authorization URL cannot hand the resulting user token to another terminal. Thanks @coygeek.
 - Honored an explicit broker URL and freshly issued credential during immediate post-login identity verification, even when ambient coordinator overrides point elsewhere.
 - Kept coordinator restarts, run history, lease detail pages, and Azure orphan sweeps memory-bounded with exact lease restores, paged record scans, and batched terminal-run pruning after a configurable 30-day retention period.

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -36,7 +36,9 @@ The merge combines, in order: the user config file, then any repo-local
 `crabbox.yaml` or `.crabbox.yaml` found in the current directory (a repo file
 overrides user defaults for that checkout), then environment variables. When
 `CRABBOX_CONFIG` is set, only that file is read (the repo-local files are
-skipped). `config show` reflects the resulting effective values, including
+skipped). This changes selection only: an explicit path inside the active
+repository, or a symlink that resolves into it, still has repository trust.
+`config show` reflects the resulting effective values, including
 provider defaults applied at load time; per-command flags are not part of what
 it reports.
 

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -60,6 +60,10 @@ read (in that order).
 
 If `CRABBOX_CONFIG` is set, it replaces the entire file search: only that file
 is loaded, and neither the user config nor the repo-local files are read. The
+override changes file selection, not its trust domain. A selected path inside
+the active repository remains repository configuration, including a path that
+enters the repository through a symlink; use the OS user config path or an
+explicit file outside the repository for trusted operator settings. The
 CLI writes new user config (for example via `crabbox login` or
 `crabbox config set-broker`) with `0600` permissions and warns if an existing
 file is group- or world-readable.
@@ -419,7 +423,7 @@ remains account-owned after Crabbox release. Repo-local config also cannot
 set the API token, API URL, item, payment method, template, data center, or
 purchase opt-in. Put those account and purchase selections in environment
 variables, CLI flags, private user config, or an explicit `CRABBOX_CONFIG`
-file. `paymentMethodId` may be omitted only when the account has exactly one
+file outside the active repository. `paymentMethodId` may be omitted only when the account has exactly one
 active default payment method; otherwise set it explicitly. Use
 `crabbox doctor --provider hostinger --json` to discover available ids without
 making a purchase.
@@ -482,7 +486,7 @@ XCP-ng password command-line flag. Prefer a pool-master `apiUrl`; if XAPI
 returns `HOST_IS_SLAVE`, Crabbox retries login once against the reported master.
 For credential safety, repository-local `crabbox.yaml` and `.crabbox.yaml`
 files cannot override `apiUrl` or `insecureTLS`; set those in user config, an
-explicit `CRABBOX_CONFIG` file, or environment variables.
+explicit `CRABBOX_CONFIG` file outside the active repository, or environment variables.
 
 `target: linux` describes the current Crabbox lease surface, not an XCP-ng
 hypervisor limitation. XCP-ng itself can host Linux, Windows, and BSD guests on

--- a/docs/providers/agent-sandbox.md
+++ b/docs/providers/agent-sandbox.md
@@ -313,8 +313,8 @@ The guarded live smoke is opt-in and creates one short-lived Crabbox-owned
 `SandboxClaim` only when explicit live configuration is present. Because the
 smoke forces replacement sync and verifies that a remote-only stale file is
 removed on retained reuse, it accepts cluster access, workload selectors, and
-`workdir` only from environment variables or an explicit `CRABBOX_CONFIG` file,
-not repository-local config:
+`workdir` only from environment variables or an explicit `CRABBOX_CONFIG` file
+outside the active repository, not repository-local config:
 
 ```sh
 CRABBOX_LIVE=1 \

--- a/docs/providers/hostinger.md
+++ b/docs/providers/hostinger.md
@@ -93,7 +93,7 @@ Repo-local config cannot set `apiToken`, `apiUrl`, `itemId`,
 `paymentMethodId`, `templateId`, `dataCenterId`, or enable `allowPurchase`.
 This prevents a repository from selecting the Hostinger account, redirecting
 credentials, or choosing billable inputs. Set those through flags, environment
-variables, private user config, or an explicit `CRABBOX_CONFIG` file.
+variables, private user config, or an explicit `CRABBOX_CONFIG` file outside the active repository.
 
 Provider flags:
 
@@ -172,7 +172,7 @@ crabbox warmup --provider hostinger --hostinger-allow-purchase
 ```
 
 ```yaml
-# Private user config, or a file explicitly selected with CRABBOX_CONFIG.
+# Private user config, or a file outside the active repository selected with CRABBOX_CONFIG.
 hostinger:
   allowPurchase: true
 ```

--- a/docs/providers/nomad.md
+++ b/docs/providers/nomad.md
@@ -278,7 +278,7 @@ scripts/live-nomad-smoke.sh
 ```
 
 `scripts/live-nomad-smoke.sh` accepts Nomad credential destinations only from
-environment variables or an explicit trusted `CRABBOX_CONFIG` file. It does not
+environment variables or an explicit `CRABBOX_CONFIG` file outside the active repository. It does not
 read repo-local `crabbox.yaml` or `.crabbox.yaml` for `nomad.address` or
 `nomad.tokenEnv`, because the script re-emits those values as explicit CLI flags
 while running a live credentialed smoke.
@@ -302,7 +302,7 @@ It emits one classification:
 - `diagnostic_only`
 
 Missing `CRABBOX_LIVE=1`, missing `CRABBOX_LIVE_PROVIDERS=nomad`, and missing
-`NOMAD_ADDR` or trusted `nomad.address` from `CRABBOX_CONFIG` are classified as
+`NOMAD_ADDR` or trusted `nomad.address` from `CRABBOX_CONFIG` outside the active repository are classified as
 `environment_blocked` before any mutation. ACL-enabled endpoints that reject an
 unset or invalid token fail during read-only `doctor` before job creation. If
 the smoke is interrupted after a job is created, rerun:
@@ -315,7 +315,7 @@ crabbox cleanup --provider nomad --dry-run
 ## Troubleshooting
 
 - `nomad address is required`: set `NOMAD_ADDR`, set `nomad.address` in an
-  explicit trusted `CRABBOX_CONFIG` file, or pass `--nomad-address`.
+  explicit `CRABBOX_CONFIG` file outside the active repository, or pass `--nomad-address`.
 - `missing_token`: the cluster rejected anonymous access; export the environment
   variable named by `tokenEnv` (`NOMAD_TOKEN` by default). Do not place the
   token on argv.

--- a/docs/providers/xcp-ng.md
+++ b/docs/providers/xcp-ng.md
@@ -161,7 +161,7 @@ login once against the master address reported by XAPI.
 Repository-local `crabbox.yaml` and `.crabbox.yaml` files cannot override
 `apiUrl` or `insecureTLS`, so a checkout cannot redirect inherited credentials.
 Configure those connection-trust settings in user config, an explicit
-`CRABBOX_CONFIG` file, or environment variables.
+`CRABBOX_CONFIG` file outside the active repository, or environment variables.
 
 Keep the password in a private config file with `0600` permissions, in an
 environment variable, or in a secret manager. Do not pass it on argv. Crabbox

--- a/docs/security.md
+++ b/docs/security.md
@@ -239,6 +239,12 @@ bodies. E2B API endpoints require HTTPS except for explicit localhost/loopback
 development URLs, and AWS region values are validated before constructing
 SigV4 service hosts.
 
+`CRABBOX_CONFIG` changes which file is loaded, not its trust domain. An explicit
+path inside the active repository remains repository-sourced for credential
+destination checks, including a symlink outside the checkout that resolves
+back into it. The canonical user config and explicit files outside the active
+repository remain operator-trusted sources.
+
 Repository-selected Static SSH, remote Parallels, and exe.dev control hosts
 cannot inherit a key, SSH agent, or local SSH configuration from a more trusted
 source. Put both a Static SSH or Parallels host and a relative, symlink-resolved

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -1482,11 +1482,12 @@ func loadConfig() (Config, error) {
 func loadConfigWithOverrides(coordinator, provider string) (Config, error) {
 	cfg := baseConfig()
 	for _, path := range configPaths() {
+		trust := classifyConfigPath(path)
 		freestyleAPIURL := cfg.Freestyle.APIURL
-		if err := applyConfigFile(&cfg, path); err != nil {
+		if err := applyConfigFile(&cfg, path, trust); err != nil {
 			return Config{}, err
 		}
-		if !trustedProviderEndpointConfigPath(path) {
+		if !trust.trusted {
 			cfg.Freestyle.APIURL = freestyleAPIURL
 		}
 	}
@@ -4491,13 +4492,6 @@ func configPaths() []string {
 	return paths
 }
 
-func trustedProviderEndpointConfigPath(path string) bool {
-	if explicit := os.Getenv("CRABBOX_CONFIG"); explicit != "" {
-		return path == explicit
-	}
-	return path == userConfigPath()
-}
-
 func userConfigPath() string {
 	dir, err := os.UserConfigDir()
 	if err != nil {
@@ -4631,30 +4625,66 @@ func writableConfigPath() string {
 	return userConfigPath()
 }
 
-func applyConfigFile(cfg *Config, path string) error {
+type configPathTrust struct {
+	trusted        bool
+	repositoryRoot string
+}
+
+func applyConfigFile(cfg *Config, path string, trust configPathTrust) error {
 	file, err := readFileConfig(path)
 	if err != nil {
 		return err
 	}
-	trusted := trustedConfigPath(path)
-	if !trusted {
-		if root, err := filepath.Abs(filepath.Dir(path)); err == nil {
-			cfg.credentialProvenance.repositoryRoot = root
-		}
+	if !trust.trusted && trust.repositoryRoot != "" {
+		cfg.credentialProvenance.repositoryRoot = trust.repositoryRoot
 	}
-	return applyFileConfigWithTrust(cfg, file, trusted)
+	return applyFileConfigWithTrust(cfg, file, trust.trusted)
 }
 
 func applyFileConfig(cfg *Config, file fileConfig) error {
 	return applyFileConfigWithTrust(cfg, file, true)
 }
 
-func trustedConfigPath(path string) bool {
-	if explicit := strings.TrimSpace(os.Getenv("CRABBOX_CONFIG")); explicit != "" {
-		return filepath.Clean(path) == filepath.Clean(explicit)
+func classifyConfigPath(path string) configPathTrust {
+	if sameConfigPath(path, userConfigPath()) {
+		return configPathTrust{trusted: true}
 	}
-	userPath := userConfigPath()
-	return userPath != "" && filepath.Clean(path) == filepath.Clean(userPath)
+	repo, _ := findRepo()
+	root, _ := filepath.Abs(repo.Root)
+	if explicit := strings.TrimSpace(os.Getenv("CRABBOX_CONFIG")); explicit != "" &&
+		sameConfigPath(path, explicit) && !configPathWithinRoot(path, root) {
+		return configPathTrust{trusted: true}
+	}
+	return configPathTrust{repositoryRoot: root}
+}
+
+func sameConfigPath(left, right string) bool {
+	return left != "" && right != "" && filepath.Clean(left) == filepath.Clean(right)
+}
+
+func configPathWithinRoot(path, root string) bool {
+	if path == "" || root == "" {
+		return false
+	}
+	pathAbs, err := filepath.Abs(path)
+	if err != nil {
+		return false
+	}
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		return false
+	}
+	if pathWithinRoot(pathAbs, rootAbs) {
+		return true
+	}
+	resolvedPath, pathErr := filepath.EvalSymlinks(pathAbs)
+	resolvedRoot, rootErr := filepath.EvalSymlinks(rootAbs)
+	return pathErr == nil && rootErr == nil && pathWithinRoot(resolvedPath, resolvedRoot)
+}
+
+func pathWithinRoot(path, root string) bool {
+	rel, err := filepath.Rel(root, path)
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel)
 }
 
 func inlineSSHPublicKey(value string) bool {

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -4773,6 +4773,97 @@ func TestRepoConfigCannotOverrideFreestyleAPIURL(t *testing.T) {
 	}
 }
 
+func TestExplicitRepoConfigCannotRedirectInheritedMorphCredential(t *testing.T) {
+	clearConfigEnv(t)
+	home := t.TempDir()
+	repo := t.TempDir()
+	runGit(t, repo, "init")
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("CRABBOX_MORPH_API_KEY", "inherited-test-key")
+
+	configPath := filepath.Join(repo, ".crabbox.yaml")
+	if err := os.WriteFile(configPath, []byte("provider: morph\nmorph:\n  apiUrl: https://attacker.example.test\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	subdir := filepath.Join(repo, "nested")
+	if err := os.Mkdir(subdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(subdir)
+	t.Setenv("CRABBOX_CONFIG", configPath)
+
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.credentialProvenance.morphAPIURL != credentialSourceRepository {
+		t.Fatalf("explicit repository endpoint source=%v, want repository", cfg.credentialProvenance.morphAPIURL)
+	}
+	err = validateProviderCredentialDestination(cfg)
+	if err == nil || !strings.Contains(err.Error(), "morph.apiUrl") {
+		t.Fatalf("destination validation err=%v, want morph.apiUrl rejection", err)
+	}
+}
+
+func TestExplicitConfigSymlinkIntoRepoRemainsUntrusted(t *testing.T) {
+	clearConfigEnv(t)
+	repo := t.TempDir()
+	runGit(t, repo, "init")
+	configPath := filepath.Join(repo, ".crabbox.yaml")
+	if err := os.WriteFile(configPath, []byte("provider: morph\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	linkPath := filepath.Join(t.TempDir(), "explicit.yaml")
+	if err := os.Symlink(configPath, linkPath); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	t.Chdir(repo)
+	t.Setenv("CRABBOX_CONFIG", linkPath)
+
+	trust := classifyConfigPath(linkPath)
+	if trust.trusted {
+		t.Fatal("explicit symlink into repository was trusted")
+	}
+	wantRoot, err := filepath.EvalSymlinks(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if trust.repositoryRoot != wantRoot {
+		t.Fatalf("repository root=%q, want %q", trust.repositoryRoot, wantRoot)
+	}
+}
+
+func TestUserConfigRemainsTrustedForInheritedMorphCredential(t *testing.T) {
+	clearConfigEnv(t)
+	home := t.TempDir()
+	repo := t.TempDir()
+	runGit(t, repo, "init")
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("CRABBOX_CONFIG", "")
+	t.Setenv("CRABBOX_MORPH_API_KEY", "inherited-test-key")
+	userPath := userConfigPath()
+	if err := os.MkdirAll(filepath.Dir(userPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(userPath, []byte("provider: morph\nmorph:\n  apiUrl: https://trusted.example.test\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repo)
+
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.credentialProvenance.morphAPIURL != credentialSourceTrustedFile {
+		t.Fatalf("user endpoint source=%v, want trusted file", cfg.credentialProvenance.morphAPIURL)
+	}
+	if err := validateProviderCredentialDestination(cfg); err != nil {
+		t.Fatalf("trusted user config rejected: %v", err)
+	}
+}
+
 func TestCacheVolumesOmittedKeepsInheritedConfig(t *testing.T) {
 	clearConfigEnv(t)
 	cfg := baseConfig()


### PR DESCRIPTION
## Summary

- classify an explicit `CRABBOX_CONFIG` path inside the active repository as repository-sourced instead of operator-trusted
- keep the boundary through symlink aliases and record the actual repository root for same-source credential checks
- use one trust classification for provider endpoint policy and config provenance; document the selection-versus-trust distinction

Fixes https://github.com/openclaw/crabbox/issues/910

## Verification

- real temporary Git repository + explicit repo config + inherited Morph key: endpoint provenance stayed repository-sourced and destination validation rejected it
- outside symlink resolving into the repository: rejected as repository-sourced
- canonical user config + inherited Morph key: remained trusted and accepted
- `go test ./internal/cli -count=1`
- `go vet ./...`
- `scripts/check-docs.sh`
- autoreview: clean
- `git diff --check`
