### PR TITLE
fix: pin mediated egress to public addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Restricted production releases to default-branch repository dispatches for existing version tags in reviewed history, so tag pushes and ref-selectable manual workflows cannot run credentialed release configuration. Thanks @coygeek.
 - Kept explicit `CRABBOX_CONFIG` files inside the active repository in the repository trust domain, including symlink aliases, so they cannot redirect inherited provider credentials. Thanks @coygeek.
+- Pinned mediated-egress connections to validated public DNS results and rejected private, loopback, link-local, and reserved destinations, preventing allowlisted hostnames from rebinding into the operator network. Thanks @coygeek.
 - Bound GitHub OAuth CLI token release to a one-use callback on the initiating device, so forwarding an authorization URL cannot hand the resulting user token to another terminal. Thanks @coygeek.
 - Honored an explicit broker URL and freshly issued credential during immediate post-login identity verification, even when ambient coordinator overrides point elsewhere.
 - Kept coordinator restarts, run history, lease detail pages, and Azure orphan sweeps memory-bounded with exact lease restores, paged record scans, and batched terminal-run pruning after a configurable 30-day retention period.

--- a/docs/features/egress.md
+++ b/docs/features/egress.md
@@ -79,7 +79,9 @@ Mediated egress has two long-running agents joined by one coordinator session:
   open each connection.
 - **Host egress agent** runs on the operator machine. It enforces the allowlist
   and opens the real outbound TCP connections, so remote services see the
-  operator's public IP.
+  operator's public IP. It resolves each allowed hostname once, rejects
+  non-public results, and dials the validated IP address directly so DNS cannot
+  retarget the connection after the allowlist check.
 - **Coordinator session** consumes one-use tickets, pairs the host and client
   sockets by `leaseID`/`sessionID`, and reports status. Cloudflare bridge
   sockets survive Durable Object hibernation. Node sockets are process-local;
@@ -259,14 +261,17 @@ Mediated egress defaults closed:
   `--profile` or `--allow`;
 - tickets are one-use, short-lived (120s), and bound to lease, owner/org, role,
   and session;
-- the host agent dials only allowlisted destinations;
+- the host agent dials only allowlisted destinations whose resolved address is
+  public; private, loopback, link-local, multicast, and reserved IP ranges are
+  rejected, including IP-literal requests;
 - a fatal bridge setup error (lease forbidden, gone, or conflicting session)
   stops the daemon instead of restarting it;
 - releasing or expiring the lease tears down the session.
 
 The host agent is powerful: it opens internet connections from the operator's
 network. Its startup line names the lease, session, profile, and allowlist so
-the operator can confirm scope before traffic flows.
+the operator can confirm scope before traffic flows. Mediated egress is
+internet-only; it does not provide an opt-in path to private network targets.
 
 ## Portal integration
 

--- a/internal/cli/egress.go
+++ b/internal/cli/egress.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/netip"
 	"net/url"
 	"os"
 	"os/exec"
@@ -431,7 +432,7 @@ func (b *egressBridge) hostOpen(ctx context.Context, msg egressProxyMessage, all
 		_ = b.writeJSON(ctx, egressProxyMessage{Type: "error", ID: msg.ID, Error: "host not allowed"})
 		return
 	}
-	conn, err := (&net.Dialer{Timeout: egressDialTimeout}).DialContext(ctx, "tcp", net.JoinHostPort(msg.Host, msg.Port))
+	conn, err := dialPublicEgressHost(ctx, msg.Host, msg.Port)
 	if err != nil {
 		_ = b.writeJSON(ctx, egressProxyMessage{Type: "error", ID: msg.ID, Error: err.Error()})
 		return
@@ -444,6 +445,111 @@ func (b *egressBridge) hostOpen(ctx context.Context, msg egressProxyMessage, all
 		return
 	}
 	go b.copyConnToBridge(ctx, msg.ID, conn)
+}
+
+func dialPublicEgressHost(ctx context.Context, host, port string) (net.Conn, error) {
+	dialer := &net.Dialer{}
+	return dialPublicEgressHostWith(ctx, host, port, net.DefaultResolver.LookupNetIP, dialer.DialContext)
+}
+
+func dialPublicEgressHostWith(
+	ctx context.Context,
+	host, port string,
+	lookup func(context.Context, string, string) ([]netip.Addr, error),
+	dial func(context.Context, string, string) (net.Conn, error),
+) (net.Conn, error) {
+	portNumber, err := strconv.Atoi(strings.TrimSpace(port))
+	if err != nil || portNumber < 1 || portNumber > 65535 {
+		return nil, errors.New("invalid destination port")
+	}
+
+	dialCtx, cancel := context.WithTimeout(ctx, egressDialTimeout)
+	defer cancel()
+	addresses, err := resolveEgressHost(dialCtx, host, lookup)
+	if err != nil {
+		return nil, err
+	}
+	var lastErr error
+	for _, address := range addresses {
+		if !publicEgressAddress(address) {
+			continue
+		}
+		conn, dialErr := dial(dialCtx, "tcp", net.JoinHostPort(address.String(), strconv.Itoa(portNumber)))
+		if dialErr == nil {
+			return conn, nil
+		}
+		lastErr = dialErr
+	}
+	if lastErr != nil {
+		return nil, fmt.Errorf("dial allowed destination: %w", lastErr)
+	}
+	return nil, errors.New("destination did not resolve to a public address")
+}
+
+func resolveEgressHost(
+	ctx context.Context,
+	host string,
+	lookup func(context.Context, string, string) ([]netip.Addr, error),
+) ([]netip.Addr, error) {
+	host = strings.TrimSpace(strings.Trim(host, "[]"))
+	if host == "" {
+		return nil, errors.New("missing destination host")
+	}
+	if address, err := netip.ParseAddr(host); err == nil {
+		return []netip.Addr{address.Unmap()}, nil
+	}
+	addresses, err := lookup(ctx, "ip", host)
+	if err != nil {
+		return nil, fmt.Errorf("resolve allowed destination: %w", err)
+	}
+	seen := make(map[netip.Addr]bool, len(addresses))
+	resolved := make([]netip.Addr, 0, len(addresses))
+	for _, address := range addresses {
+		address = address.Unmap()
+		if address.IsValid() && !seen[address] {
+			seen[address] = true
+			resolved = append(resolved, address)
+		}
+	}
+	if len(resolved) == 0 {
+		return nil, errors.New("destination did not resolve to an address")
+	}
+	return resolved, nil
+}
+
+var blockedEgressPrefixes = []netip.Prefix{
+	netip.MustParsePrefix("100.64.0.0/10"),
+	netip.MustParsePrefix("192.0.0.0/24"),
+	netip.MustParsePrefix("192.0.2.0/24"),
+	netip.MustParsePrefix("192.88.99.0/24"),
+	netip.MustParsePrefix("198.18.0.0/15"),
+	netip.MustParsePrefix("198.51.100.0/24"),
+	netip.MustParsePrefix("203.0.113.0/24"),
+	netip.MustParsePrefix("240.0.0.0/4"),
+	netip.MustParsePrefix("64:ff9b:1::/48"),
+	netip.MustParsePrefix("100::/64"),
+	netip.MustParsePrefix("2001::/23"),
+	netip.MustParsePrefix("2001:db8::/32"),
+	netip.MustParsePrefix("2002::/16"),
+}
+
+var wellKnownNAT64Prefix = netip.MustParsePrefix("64:ff9b::/96")
+
+func publicEgressAddress(address netip.Addr) bool {
+	address = address.Unmap()
+	if wellKnownNAT64Prefix.Contains(address) {
+		bytes := address.As16()
+		return publicEgressAddress(netip.AddrFrom4([4]byte{bytes[12], bytes[13], bytes[14], bytes[15]}))
+	}
+	if !address.IsValid() || !address.IsGlobalUnicast() || address.IsPrivate() {
+		return false
+	}
+	for _, prefix := range blockedEgressPrefixes {
+		if prefix.Contains(address) {
+			return false
+		}
+	}
+	return true
 }
 
 func (b *egressBridge) serveClient(ctx context.Context, listen string) error {

--- a/internal/cli/egress_test.go
+++ b/internal/cli/egress_test.go
@@ -3,9 +3,12 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/netip"
 	"net/url"
+	"os"
 	"slices"
 	"strings"
 	"testing"
@@ -35,6 +38,123 @@ func TestEgressAllowlistRejectsBareWildcard(t *testing.T) {
 	}
 	if egressHostAllowed("example.com", []string{"*"}) {
 		t.Fatal("bare wildcard should not allow every host")
+	}
+}
+
+func TestPublicEgressAddressRejectsPrivateAndReservedRanges(t *testing.T) {
+	tests := map[string]bool{
+		"8.8.8.8":                true,
+		"2606:4700:4700::1111":   true,
+		"0.0.0.0":                false,
+		"10.0.0.1":               false,
+		"100.64.0.1":             false,
+		"127.0.0.1":              false,
+		"169.254.169.254":        false,
+		"192.0.2.1":              false,
+		"192.168.1.1":            false,
+		"198.18.0.1":             false,
+		"224.0.0.1":              false,
+		"::1":                    false,
+		"64:ff9b::808:808":       true,
+		"64:ff9b::a00:1":         false,
+		"64:ff9b::a9fe:a9fe":     false,
+		"64:ff9b:1::1":           false,
+		"2001:db8::1":            false,
+		"fc00::1":                false,
+		"fe80::1":                false,
+		"::ffff:127.0.0.1":       false,
+		"::ffff:169.254.169.254": false,
+	}
+	for raw, want := range tests {
+		t.Run(raw, func(t *testing.T) {
+			if got := publicEgressAddress(netip.MustParseAddr(raw)); got != want {
+				t.Fatalf("publicEgressAddress(%s)=%t, want %t", raw, got, want)
+			}
+		})
+	}
+}
+
+func TestDialPublicEgressHostPinsValidatedAddress(t *testing.T) {
+	var dialed string
+	lookup := func(context.Context, string, string) ([]netip.Addr, error) {
+		return []netip.Addr{
+			netip.MustParseAddr("127.0.0.1"),
+			netip.MustParseAddr("8.8.8.8"),
+			netip.MustParseAddr("8.8.8.8"),
+		}, nil
+	}
+	dial := func(_ context.Context, network, address string) (net.Conn, error) {
+		if network != "tcp" {
+			t.Fatalf("network=%q, want tcp", network)
+		}
+		dialed = address
+		conn, peer := net.Pipe()
+		_ = peer.Close()
+		return conn, nil
+	}
+
+	conn, err := dialPublicEgressHostWith(context.Background(), "allowed.example", "443", lookup, dial)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	if dialed != "8.8.8.8:443" {
+		t.Fatalf("dialed=%q, want pinned public address", dialed)
+	}
+}
+
+func TestDialPublicEgressHostRejectsPrivateResolutionBeforeDial(t *testing.T) {
+	dialed := false
+	lookup := func(context.Context, string, string) ([]netip.Addr, error) {
+		return []netip.Addr{netip.MustParseAddr("169.254.169.254")}, nil
+	}
+	dial := func(context.Context, string, string) (net.Conn, error) {
+		dialed = true
+		return nil, nil
+	}
+
+	_, err := dialPublicEgressHostWith(context.Background(), "allowed.example", "80", lookup, dial)
+	if err == nil || !strings.Contains(err.Error(), "public address") {
+		t.Fatalf("err=%v, want public-address rejection", err)
+	}
+	if dialed {
+		t.Fatal("private resolved address reached dialer")
+	}
+}
+
+func TestDialPublicEgressHostRejectsPrivateIPLiteralWithoutDNS(t *testing.T) {
+	lookedUp := false
+	dialed := false
+	lookup := func(context.Context, string, string) ([]netip.Addr, error) {
+		lookedUp = true
+		return nil, nil
+	}
+	dial := func(context.Context, string, string) (net.Conn, error) {
+		dialed = true
+		return nil, nil
+	}
+
+	_, err := dialPublicEgressHostWith(context.Background(), "127.0.0.1", "8080", lookup, dial)
+	if err == nil || !strings.Contains(err.Error(), "public address") {
+		t.Fatalf("err=%v, want public-address rejection", err)
+	}
+	if lookedUp || dialed {
+		t.Fatalf("private IP literal lookedUp=%t dialed=%t", lookedUp, dialed)
+	}
+}
+
+func TestLivePublicEgressDial(t *testing.T) {
+	if os.Getenv("CRABBOX_LIVE") != "1" {
+		t.Skip("set CRABBOX_LIVE=1 to exercise public DNS and TCP egress")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	conn, err := dialPublicEgressHost(ctx, "example.com", "443")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := conn.Close(); err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- resolve allowlisted mediated-egress hostnames once and pin the TCP dial to a validated IP address
- reject private, loopback, link-local, multicast, reserved, and private-IPv4-over-NAT64 destinations, including IP literals
- preserve public IPv4/IPv6 fallback behavior and document that mediated egress is internet-only

Fixes https://github.com/openclaw/crabbox/issues/912

## Verification

- `CRABBOX_LIVE=1 go test ./internal/cli -run 'Test(LivePublicEgressDial|PublicEgressAddress|DialPublicEgressHost)' -count=1`
  - real DNS + TCP connection to `example.com:443` passed
  - metadata, private, loopback, link-local, reserved, IPv4-mapped, and NAT64-encoded private targets were rejected before dialing
  - mixed public/private DNS results dialed only the pinned public address
- `go test ./internal/cli -count=1`
- `go vet ./...`
- `scripts/check-docs.sh`
- autoreview: first pass found the NAT64 edge; fixed; second pass clean
- `git diff --check`
