### PR TITLE
fix: centralize diagnostic secret redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- Centralized credential redaction for provider and `doctor` diagnostics, covering configured secrets, authorization headers, signed URLs, secret-bearing JSON fields, and private keys, and applied it to Sprites API errors. Thanks @coygeek.
 - Restricted production releases to default-branch repository dispatches for existing version tags in reviewed history, so tag pushes and ref-selectable manual workflows cannot run credentialed release configuration. Thanks @coygeek.
 - Bound GitHub OAuth CLI token release to a one-use callback on the initiating device, so forwarding an authorization URL cannot hand the resulting user token to another terminal. Thanks @coygeek.
 - Honored an explicit broker URL and freshly issued credential during immediate post-login identity verification, even when ambient coordinator overrides point elsewhere.

--- a/docs/commands/doctor.md
+++ b/docs/commands/doctor.md
@@ -187,6 +187,13 @@ exits `0` unless another check fails.
 and `checks` fields. Each check includes `status`, `check`, `message`, and
 parsed `details` when available.
 
+Both output modes apply the same final diagnostic redaction to coordinator and
+provider messages and details. Configured credentials, authorization headers,
+credential-bearing URL components, common secret JSON fields, and private-key
+blocks render as `[redacted]`; non-secret routing and failure context remains.
+This protection covers Crabbox-generated diagnostics, not arbitrary output from
+the optional remote command probe.
+
 Exit codes:
 
 - `0` — no failures (skips and warnings do not change this).

--- a/docs/security.md
+++ b/docs/security.md
@@ -258,7 +258,11 @@ explicit bearer API clients remain independent of this browser-only boundary.
 Configured provider credentials are redacted from documented HTTP or streamed
 error diagnostics, including Azure Dynamic Sessions, Cloudflare runner, Daytona,
 E2B, Freestyle, Islo, Morph, OpenComputer, Railway, RunPod, Semaphore, SmolVM,
-and Upstash Box. Generated stop and failure-routing commands retain provider
+Sprites, and Upstash Box. The same final redaction covers `doctor` text and JSON
+messages/details. It removes exact configured secrets, authorization and API-key
+headers, credential-bearing URL query/userinfo components, common secret JSON
+fields, bearer values, and PEM private keys while retaining non-secret routing
+context. Generated stop and failure-routing commands retain provider
 endpoint routing but remove URL userinfo before they are printed or stored.
 GitHub Actions registration metadata and its short-lived runner token travel
 over SSH stdin rather than the remote command line. These guarantees apply to

--- a/internal/cli/diagnostic_redaction.go
+++ b/internal/cli/diagnostic_redaction.go
@@ -29,9 +29,22 @@ func RedactDiagnosticSecrets(value string, secrets ...string) string {
 	redacted = diagnosticHeaderPattern.ReplaceAllStringFunc(redacted, redactDiagnosticAssignment)
 	redacted = diagnosticJSONPattern.ReplaceAllStringFunc(redacted, redactDiagnosticJSONField)
 	redacted = diagnosticQueryPattern.ReplaceAllString(redacted, `$1`+diagnosticRedaction)
-	redacted = diagnosticURLPattern.ReplaceAllString(redacted, `$1`+diagnosticRedaction+`@`)
+	redacted = diagnosticURLPattern.ReplaceAllStringFunc(redacted, redactDiagnosticURLUserinfo)
 	redacted = diagnosticBearerPattern.ReplaceAllString(redacted, "Bearer "+diagnosticRedaction)
 	return diagnosticPEMPattern.ReplaceAllString(redacted, diagnosticRedaction)
+}
+
+func redactDiagnosticURLUserinfo(match string) string {
+	separator := strings.Index(match, "://")
+	if separator < 0 {
+		return match
+	}
+	prefixEnd := separator + 3
+	userinfo := strings.TrimSuffix(match[prefixEnd:], "@")
+	if userinfo == "<redacted>" || userinfo == diagnosticRedaction {
+		return match
+	}
+	return match[:prefixEnd] + diagnosticRedaction + "@"
 }
 
 func normalizedDiagnosticSecrets(values []string) []string {

--- a/internal/cli/diagnostic_redaction.go
+++ b/internal/cli/diagnostic_redaction.go
@@ -1,0 +1,156 @@
+package cli
+
+import (
+	"os"
+	"reflect"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+const diagnosticRedaction = "[redacted]"
+
+var (
+	diagnosticHeaderPattern = regexp.MustCompile(`(?i)\b(authorization|proxy-authorization|x-api-key|api-key|api_key|access-token|access_token|client-secret|client_secret|session-token|session_token|token|password)[ \t]*[:=][ \t]*(?:(?:bearer|basic)[ \t]+)?[^\s"',;\\}&#?]+`)
+	diagnosticJSONPattern   = regexp.MustCompile(`(?i)"(authorization|proxy-authorization|x-api-key|apiKey|api-key|api_key|accessToken|access-token|access_token|clientSecret|client-secret|client_secret|credential|credentials|privateKey|private-key|private_key|secret|sessionToken|session-token|session_token|token|password)"\s*:\s*"(?:\\[\s\S]|[^"\\])*(?:"|$)`)
+	diagnosticQueryPattern  = regexp.MustCompile(`(?i)([?&](?:api[_-]?key|access[_-]?token|client[_-]?secret|password|token|signature|sig|x-amz-credential|x-amz-signature|x-amz-security-token|x-goog-credential|x-goog-signature|x-goog-security-token)=)[^&#\s]+`)
+	diagnosticURLPattern    = regexp.MustCompile(`(?i)\b(https?://)[^/@\s]+@`)
+	diagnosticBearerPattern = regexp.MustCompile(`(?i)\bbearer[ \t]+[^\s"',;\\}]+`)
+	diagnosticPEMPattern    = regexp.MustCompile(`(?is)-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?(?:-----END [A-Z0-9 ]*PRIVATE KEY-----|$)`)
+)
+
+// RedactDiagnosticSecrets removes credentials from untrusted diagnostic text
+// while preserving non-secret routing and failure context.
+func RedactDiagnosticSecrets(value string, secrets ...string) string {
+	redacted := value
+	for _, secret := range normalizedDiagnosticSecrets(secrets) {
+		redacted = strings.ReplaceAll(redacted, secret, diagnosticRedaction)
+	}
+	redacted = diagnosticHeaderPattern.ReplaceAllStringFunc(redacted, redactDiagnosticAssignment)
+	redacted = diagnosticJSONPattern.ReplaceAllStringFunc(redacted, redactDiagnosticJSONField)
+	redacted = diagnosticQueryPattern.ReplaceAllString(redacted, `$1`+diagnosticRedaction)
+	redacted = diagnosticURLPattern.ReplaceAllString(redacted, `$1`+diagnosticRedaction+`@`)
+	redacted = diagnosticBearerPattern.ReplaceAllString(redacted, "Bearer "+diagnosticRedaction)
+	return diagnosticPEMPattern.ReplaceAllString(redacted, diagnosticRedaction)
+}
+
+func normalizedDiagnosticSecrets(values []string) []string {
+	seen := make(map[string]bool, len(values))
+	secrets := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" && !seen[value] {
+			seen[value] = true
+			secrets = append(secrets, value)
+		}
+	}
+	sort.Slice(secrets, func(i, j int) bool { return len(secrets[i]) > len(secrets[j]) })
+	return secrets
+}
+
+func redactDiagnosticAssignment(match string) string {
+	separator := strings.IndexAny(match, ":=")
+	if separator < 0 {
+		return match
+	}
+	return match[:separator+1] + " " + diagnosticRedaction
+}
+
+func redactDiagnosticJSONField(match string) string {
+	separator := strings.Index(match, ":")
+	if separator < 0 {
+		return match
+	}
+	return match[:separator+1] + `"` + diagnosticRedaction + `"`
+}
+
+func redactDiagnosticDetails(details map[string]string, secrets []string) map[string]string {
+	if details == nil {
+		return nil
+	}
+	redacted := make(map[string]string, len(details))
+	for key, value := range details {
+		redactedKey := RedactDiagnosticSecrets(key, secrets...)
+		redacted[redactedKey] = RedactDiagnosticSecrets(value, secrets...)
+	}
+	return redacted
+}
+
+func configuredDiagnosticSecrets(cfg Config) []string {
+	seen := map[string]bool{}
+	collectConfiguredDiagnosticSecrets(reflect.ValueOf(cfg), "", seen)
+	for _, name := range []string{
+		"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN",
+		"AZURE_CLIENT_SECRET", "CLOUDFLARE_API_TOKEN", "DIGITALOCEAN_TOKEN",
+		"HCLOUD_TOKEN", "HETZNER_TOKEN", "LAMBDA_API_KEY", "OVH_APPLICATION_KEY",
+		"OVH_APPLICATION_SECRET", "OVH_CONSUMER_KEY", "SCW_ACCESS_KEY", "SCW_SECRET_KEY",
+		"TENCENTCLOUD_SECRET_ID", "TENCENTCLOUD_SECRET_KEY", "TENCENTCLOUD_TOKEN",
+		"TS_API_KEY", "VULTR_API_KEY",
+	} {
+		if value := strings.TrimSpace(os.Getenv(name)); len(value) >= 4 {
+			seen[value] = true
+		}
+	}
+	if name := strings.TrimSpace(cfg.Nomad.TokenEnv); name != "" {
+		if value := strings.TrimSpace(os.Getenv(name)); len(value) >= 4 {
+			seen[value] = true
+		}
+	}
+	secrets := make([]string, 0, len(seen))
+	for secret := range seen {
+		secrets = append(secrets, secret)
+	}
+	return secrets
+}
+
+func collectConfiguredDiagnosticSecrets(value reflect.Value, name string, seen map[string]bool) {
+	if !value.IsValid() {
+		return
+	}
+	for value.Kind() == reflect.Pointer || value.Kind() == reflect.Interface {
+		if value.IsNil() {
+			return
+		}
+		value = value.Elem()
+	}
+	switch value.Kind() {
+	case reflect.String:
+		if diagnosticSecretField(name) {
+			if secret := strings.TrimSpace(value.String()); len(secret) >= 4 {
+				seen[secret] = true
+			}
+		}
+	case reflect.Struct:
+		typeOfValue := value.Type()
+		for i := 0; i < value.NumField(); i++ {
+			field := typeOfValue.Field(i)
+			if field.PkgPath == "" {
+				collectConfiguredDiagnosticSecrets(value.Field(i), field.Name, seen)
+			}
+		}
+	case reflect.Map:
+		iterator := value.MapRange()
+		for iterator.Next() {
+			key := iterator.Key()
+			fieldName := name
+			if key.Kind() == reflect.String {
+				fieldName = key.String()
+			}
+			collectConfiguredDiagnosticSecrets(iterator.Value(), fieldName, seen)
+		}
+	case reflect.Slice, reflect.Array:
+		for i := 0; i < value.Len(); i++ {
+			collectConfiguredDiagnosticSecrets(value.Index(i), name, seen)
+		}
+	}
+}
+
+func diagnosticSecretField(name string) bool {
+	name = strings.ToLower(strings.NewReplacer("_", "", "-", "").Replace(name))
+	for _, suffix := range []string{"token", "secret", "password", "apikey", "authkey", "privatekey", "accesskey", "consumerkey", "applicationkey"} {
+		if strings.HasSuffix(name, suffix) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/diagnostic_redaction_test.go
+++ b/internal/cli/diagnostic_redaction_test.go
@@ -36,6 +36,13 @@ func TestRedactDiagnosticSecretsCoversCredentialEncodings(t *testing.T) {
 	}
 }
 
+func TestRedactDiagnosticSecretsPreservesSafeURLPlaceholders(t *testing.T) {
+	value := "http://<redacted>@broker.example.test https://[redacted]@api.example.test"
+	if got := RedactDiagnosticSecrets(value); got != value {
+		t.Fatalf("already-redacted URLs changed: %q", got)
+	}
+}
+
 func TestConfiguredDiagnosticSecretsFindsConfigAndSelectedEnvironment(t *testing.T) {
 	t.Setenv("AWS_SESSION_TOKEN", "environment-session-secret")
 	t.Setenv("CUSTOM_NOMAD_TOKEN", "nomad-environment-secret")

--- a/internal/cli/diagnostic_redaction_test.go
+++ b/internal/cli/diagnostic_redaction_test.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRedactDiagnosticSecretsCoversCredentialEncodings(t *testing.T) {
+	exact := "configured-provider-secret"
+	value := strings.Join([]string{
+		"exact=" + exact,
+		"Authorization: Bearer header-token",
+		"Proxy-Authorization=Basic proxy-value",
+		`{"clientSecret":"json-secret","privateKey":"json-key","message":"quota exceeded"}`,
+		"https://alice:password@example.test/path?access_token=query-token&x-amz-signature=signed-value&x-goog-credential=gcs-credential&x-goog-signature=gcs-signature&region=eu",
+		"https://single-userinfo-token@other.example.test/path",
+		"-----BEGIN OPENSSH PRIVATE KEY-----\nprivate-material\n-----END OPENSSH PRIVATE KEY-----",
+	}, "\n")
+
+	got := RedactDiagnosticSecrets(value, exact)
+	for _, leaked := range []string{
+		exact, "header-token", "proxy-value", "json-secret", "json-key", "alice", "password",
+		"query-token", "signed-value", "gcs-credential", "gcs-signature", "single-userinfo-token", "private-material",
+	} {
+		if strings.Contains(got, leaked) {
+			t.Fatalf("diagnostic redaction leaked %q:\n%s", leaked, got)
+		}
+	}
+	for _, preserved := range []string{"quota exceeded", "example.test/path", "region=eu"} {
+		if !strings.Contains(got, preserved) {
+			t.Fatalf("diagnostic redaction removed %q:\n%s", preserved, got)
+		}
+	}
+	if strings.Count(got, diagnosticRedaction) < 8 {
+		t.Fatalf("missing redaction markers:\n%s", got)
+	}
+}
+
+func TestConfiguredDiagnosticSecretsFindsConfigAndSelectedEnvironment(t *testing.T) {
+	t.Setenv("AWS_SESSION_TOKEN", "environment-session-secret")
+	t.Setenv("CUSTOM_NOMAD_TOKEN", "nomad-environment-secret")
+	cfg := Config{
+		CoordToken: "coordinator-secret",
+		Morph:      MorphConfig{APIKey: "morph-secret"},
+		Nomad:      NomadConfig{TokenEnv: "CUSTOM_NOMAD_TOKEN"},
+		Profiles: map[string]ProfileConfig{
+			"test": {Env: map[string]string{"SERVICE_TOKEN": "profile-secret"}},
+		},
+	}
+	secrets := configuredDiagnosticSecrets(cfg)
+	redacted := RedactDiagnosticSecrets(strings.Join([]string{
+		"coordinator-secret", "morph-secret", "environment-session-secret", "nomad-environment-secret", "profile-secret",
+	}, " "), secrets...)
+	if strings.Contains(redacted, "secret") || strings.Count(redacted, diagnosticRedaction) != 5 {
+		t.Fatalf("configured secrets were not collected: %s", redacted)
+	}
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -69,6 +69,11 @@ func (a App) doctor(ctx context.Context, args []string) error {
 	ok := true
 	var checks []doctorJSONCheck
 	record := func(status, check, message string, details map[string]string) {
+		secrets := configuredDiagnosticSecrets(cfg)
+		status = RedactDiagnosticSecrets(status, secrets...)
+		check = RedactDiagnosticSecrets(check, secrets...)
+		message = RedactDiagnosticSecrets(message, secrets...)
+		details = redactDiagnosticDetails(details, secrets)
 		if *jsonOut {
 			item := doctorJSONCheck{Status: status, Check: check, Message: message, Details: details}
 			if details != nil {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -357,6 +357,79 @@ func TestDoctorJSONCoordinatorOutput(t *testing.T) {
 	}
 }
 
+func TestDoctorRedactsCoordinatorAndProviderDiagnostics(t *testing.T) {
+	for _, tool := range []string{"git", "ssh", "ssh-keygen", "rsync"} {
+		if _, err := exec.LookPath(tool); err != nil {
+			t.Skipf("missing local doctor tool %s: %v", tool, err)
+		}
+	}
+	clearConfigEnv(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("CRABBOX_CONFIG", "")
+	const configuredSecret = "exact-doctor-secret"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/health":
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+		case "/v1/whoami":
+			_ = json.NewEncoder(w).Encode(CoordinatorWhoami{Auth: "token", Owner: "alice@example.test", Org: "example-org"})
+		case "/v1/providers/aws/readiness":
+			_ = json.NewEncoder(w).Encode(CoordinatorProviderReadiness{
+				Provider:   "aws",
+				Configured: true,
+				Checks: []DoctorCheck{{
+					Status:  "warning",
+					Check:   "diagnostic",
+					Message: "quota warning exact=" + configuredSecret + " Authorization: Bearer reflected-bearer",
+					Details: map[string]string{
+						"url":  "https://user:pass@example.test/path?token=query-secret&region=eu",
+						"json": `{"clientSecret":"json-secret","message":"detail retained"}`,
+						"pem":  "-----BEGIN PRIVATE KEY-----\nprivate-material\n-----END PRIVATE KEY-----",
+					},
+				}},
+			})
+		default:
+			http.Error(w, "unexpected "+r.URL.Path, http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+	t.Setenv("CRABBOX_COORDINATOR", server.URL)
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", configuredSecret)
+
+	for _, jsonOutput := range []bool{false, true} {
+		name := "text"
+		args := []string{"--provider", "aws"}
+		if jsonOutput {
+			name = "json"
+			args = append(args, "--json")
+		}
+		t.Run(name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			if err := (App{Stdout: &stdout, Stderr: &stderr}).doctor(context.Background(), args); err != nil {
+				t.Fatalf("doctor error=%v stdout=%q stderr=%q", err, stdout.String(), stderr.String())
+			}
+			output := stdout.String()
+			for _, leaked := range []string{configuredSecret, "reflected-bearer", "user", "pass", "query-secret", "json-secret", "private-material"} {
+				if strings.Contains(output, leaked) {
+					t.Fatalf("doctor %s leaked %q:\n%s", name, leaked, output)
+				}
+			}
+			preserved := []string{"quota warning", "[redacted]"}
+			if jsonOutput {
+				preserved = append(preserved, "detail retained", "region=eu")
+			}
+			for _, preserved := range preserved {
+				if !strings.Contains(output, preserved) {
+					t.Fatalf("doctor %s lost %q:\n%s", name, preserved, output)
+				}
+			}
+		})
+	}
+}
+
 func TestDoctorJSONCoordinatorOutputIncludesCapacityWarnings(t *testing.T) {
 	for _, tool := range []string{"git", "ssh", "ssh-keygen", "rsync"} {
 		if _, err := exec.LookPath(tool); err != nil {

--- a/internal/providers/shared/redact.go
+++ b/internal/providers/shared/redact.go
@@ -1,48 +1,11 @@
 package shared
 
-import (
-	"regexp"
-	"strings"
-)
+import core "github.com/openclaw/crabbox/internal/cli"
 
 const redactedProviderSecret = "[redacted]"
-
-var (
-	providerBearerPattern = regexp.MustCompile(`(?i)\bbearer[ \t]+[^\s"',;\\}]+`)
-	providerHeaderPattern = regexp.MustCompile(`(?i)\b(authorization|x-api-key|api-key|api_key)[ \t]*[:=][ \t]*[^\s"',;\\}]+`)
-)
 
 // RedactErrorSecrets removes credentials from untrusted provider response text
 // while preserving the surrounding status and diagnostic detail.
 func RedactErrorSecrets(value string, secrets ...string) string {
-	redacted := value
-	for _, secret := range secrets {
-		secret = strings.TrimSpace(secret)
-		if secret != "" {
-			redacted = strings.ReplaceAll(redacted, secret, redactedProviderSecret)
-		}
-	}
-	redacted = providerBearerPattern.ReplaceAllString(redacted, "Bearer "+redactedProviderSecret)
-	redacted = providerHeaderPattern.ReplaceAllStringFunc(redacted, func(match string) string {
-		separator := strings.IndexAny(match, ":=")
-		if separator < 0 {
-			return match
-		}
-		return match[:separator+1] + " " + redactedProviderSecret
-	})
-	for _, key := range []string{"authorization", "apiKey", "api_key", "accessToken", "access_token", "token"} {
-		redacted = redactProviderJSONField(redacted, key)
-	}
-	return redacted
-}
-
-func redactProviderJSONField(value, key string) string {
-	pattern := regexp.MustCompile(`(?i)"` + regexp.QuoteMeta(key) + `"\s*:\s*"[^"]*(?:"|$)`)
-	return pattern.ReplaceAllStringFunc(value, func(match string) string {
-		separator := strings.Index(match, ":")
-		if separator < 0 {
-			return match
-		}
-		return match[:separator+1] + `"` + redactedProviderSecret + `"`
-	})
+	return core.RedactDiagnosticSecrets(value, secrets...)
 }

--- a/internal/providers/shared/redact_test.go
+++ b/internal/providers/shared/redact_test.go
@@ -7,9 +7,11 @@ import (
 
 func TestRedactErrorSecrets(t *testing.T) {
 	secret := "provider-secret-token"
-	value := `request failed: Bearer ` + secret + ` X-API-Key: ` + secret + ` {"accessToken":"derived-token","message":"quota exceeded"}`
+	value := `request failed: Bearer ` + secret + ` X-API-Key: ` + secret + ` {"accessToken":"derived-token","clientSecret":"client-secret","message":"quota exceeded"} https://user:pass@example.test/path?token=query-secret -----BEGIN PRIVATE KEY-----
+private-material
+-----END PRIVATE KEY-----`
 	got := RedactErrorSecrets(value, secret, " ")
-	for _, leaked := range []string{secret, "derived-token"} {
+	for _, leaked := range []string{secret, "derived-token", "client-secret", "user", "pass", "query-secret", "private-material"} {
 		if strings.Contains(got, leaked) {
 			t.Fatalf("redacted error leaked %q: %s", leaked, got)
 		}

--- a/internal/providers/sprites/backend_test.go
+++ b/internal/providers/sprites/backend_test.go
@@ -496,6 +496,66 @@ func TestSpritesClientLifecycleRequests(t *testing.T) {
 	}
 }
 
+func TestSpritesClientRedactsErrorResponseCredentials(t *testing.T) {
+	const token = "sprites-provider-secret"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer "+token {
+			t.Fatalf("auth=%q", got)
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, `{"message":"request denied","authorization":"Bearer `+token+`","clientSecret":"secondary-secret","url":"https://user:pass@example.test/?token=query-secret"}`)
+	}))
+	defer srv.Close()
+
+	client, err := newSpritesClient(Config{Sprites: SpritesConfig{Token: token, APIURL: srv.URL}}, Runtime{HTTP: srv.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.ListSprites(context.Background(), "")
+	if err == nil {
+		t.Fatal("expected Sprites API error")
+	}
+	text := err.Error()
+	for _, leaked := range []string{token, "secondary-secret", "user", "pass", "query-secret"} {
+		if strings.Contains(text, leaked) {
+			t.Fatalf("Sprites error leaked %q: %s", leaked, text)
+		}
+	}
+	if !strings.Contains(text, "request denied") || !strings.Contains(text, "[redacted]") {
+		t.Fatalf("Sprites error lost useful diagnostic context: %s", text)
+	}
+}
+
+func TestSpritesClientRedactsErrorStatusText(t *testing.T) {
+	const token = "sprites-provider-secret"
+	httpClient := &http.Client{Transport: spritesRoundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if got := r.Header.Get("Authorization"); got != "Bearer "+token {
+			t.Fatalf("auth=%q", got)
+		}
+		return &http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Status:     "401 Bearer " + token,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"message":"denied"}`)),
+			Request:    r,
+		}, nil
+	})}
+	client, err := newSpritesClient(Config{Sprites: SpritesConfig{Token: token}}, Runtime{HTTP: httpClient})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.ListSprites(context.Background(), "")
+	if err == nil || strings.Contains(err.Error(), token) || !strings.Contains(err.Error(), "[redacted]") {
+		t.Fatalf("Sprites status redaction err=%v", err)
+	}
+}
+
+type spritesRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f spritesRoundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}
+
 func TestSpritesClientRejectsBadPagination(t *testing.T) {
 	for name, response := range map[string]spritesListResponse{
 		"missing token": {HasMore: true},

--- a/internal/providers/sprites/client.go
+++ b/internal/providers/sprites/client.go
@@ -11,6 +11,8 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type spritesAPI interface {
@@ -252,7 +254,11 @@ func (c *spritesClient) doJSON(ctx context.Context, method, requestPath string, 
 		return err
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return &spritesAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: summarizeSpritesBody(data)}
+		return &spritesAPIError{
+			StatusCode: resp.StatusCode,
+			Status:     shared.RedactErrorSecrets(resp.Status, c.token),
+			Body:       shared.RedactErrorSecrets(summarizeSpritesBody(data), c.token),
+		}
 	}
 	if out == nil || len(data) == 0 {
 		return nil


### PR DESCRIPTION
## Summary

- centralize Go diagnostic redaction for exact configured secrets, authorization/API-key headers, bearer values, secret-bearing JSON, URL userinfo and signed query parameters, and PEM private keys
- apply the final sanitizer to every `doctor` text/JSON message and detail, using credentials from resolved config and supported provider environment sources
- route shared provider error redaction through the same control and sanitize both Sprites HTTP status text and response bodies

Fixes https://github.com/openclaw/crabbox/issues/899
Fixes https://github.com/openclaw/crabbox/issues/903
Fixes https://github.com/openclaw/crabbox/issues/906

## Verification

- local coordinator HTTP fixture: provider readiness returned reflected configured token, bearer header, signed URL, JSON secret, and PEM key; both `doctor` text and JSON output retained useful context and leaked none
- local Sprites HTTP fixture: real client request sent the configured bearer token; hostile status/body reflections returned only redaction markers and safe diagnostic context
- `go test -race ./...`
- targeted post-review race tests for CLI/shared/Sprites redaction
- `go vet ./...`
- `go list ./...`
- `scripts/check-docs.sh`
- autoreview iterations fixed GCS signed URLs, hostile HTTP status text, and passwordless URL userinfo; final review clean
- `git diff --check`
