### PR TITLE
fix: confine artifact redirects to their origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Restricted production releases to default-branch repository dispatches for existing version tags in reviewed history, so tag pushes and ref-selectable manual workflows cannot run credentialed release configuration. Thanks @coygeek.
 - Kept explicit `CRABBOX_CONFIG` files inside the active repository in the repository trust domain, including symlink aliases, so they cannot redirect inherited provider credentials. Thanks @coygeek.
 - Pinned mediated-egress connections to validated public DNS results and rejected private, loopback, link-local, and reserved destinations, preventing allowlisted hostnames from rebinding into the operator network. Thanks @coygeek.
+- Confined artifact manifest fetches, downloads, and brokered uploads to same-origin redirects, preventing signed URLs and upload grants from reaching another origin. Thanks @coygeek.
 - Bound GitHub OAuth CLI token release to a one-use callback on the initiating device, so forwarding an authorization URL cannot hand the resulting user token to another terminal. Thanks @coygeek.
 - Honored an explicit broker URL and freshly issued credential during immediate post-login identity verification, even when ambient coordinator overrides point elsewhere.
 - Kept coordinator restarts, run history, lease detail pages, and Azure orphan sweeps memory-bounded with exact lease restores, paged record scans, and batched terminal-run pruning after a configurable 30-day retention period.

--- a/docs/features/artifacts.md
+++ b/docs/features/artifacts.md
@@ -167,7 +167,9 @@ crabbox artifacts pull https://artifacts.example.com/runs/abc/artifact-manifest.
 ```
 
 `artifacts pull` verifies SHA256 and size before reporting success and refuses
-path-escaping or symlinked entries. Use `--skip-manifest` (alias `--no-manifest`)
+path-escaping or symlinked entries. Remote manifest fetches, artifact downloads,
+and brokered uploads follow redirects only when the scheme, hostname, and
+effective port remain unchanged. Use `--skip-manifest` (alias `--no-manifest`)
 only for legacy Markdown-only output.
 
 ## Brokered publishing and the broker secret model

--- a/internal/cli/artifacts_manifest.go
+++ b/internal/cli/artifacts_manifest.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/url"
@@ -19,6 +20,8 @@ const (
 	artifactManifestFilename = "artifact-manifest.json"
 	maxPulledArtifactBytes   = int64(1024 * 1024 * 1024)
 )
+
+var errArtifactCrossOriginRedirect = errors.New("refused cross-origin artifact redirect")
 
 type artifactManifest struct {
 	SchemaVersion int                    `json:"schemaVersion"`
@@ -116,9 +119,9 @@ func readArtifactManifestRef(ctx context.Context, ref string) (artifactManifest,
 		if err != nil {
 			return artifactManifest{}, path, exit(2, "create artifact manifest request: %v", err)
 		}
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := artifactHTTPClient(req.URL).Do(req)
 		if err != nil {
-			return artifactManifest{}, path, exit(2, "download artifact manifest: %v", err)
+			return artifactManifest{}, path, exit(2, "download artifact manifest: %v", artifactRequestError(err))
 		}
 		defer resp.Body.Close()
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
@@ -330,9 +333,9 @@ func downloadArtifactURL(ctx context.Context, file artifactManifestFile, outPath
 	if err != nil {
 		return "", 0, "", exit(2, "create artifact download request for %s: %v", file.Name, err)
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := artifactHTTPClient(req.URL).Do(req)
 	if err != nil {
-		return "", 0, "", exit(2, "download artifact %s: %v", file.Name, err)
+		return "", 0, "", exit(2, "download artifact %s: %v", file.Name, artifactRequestError(err))
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
@@ -357,6 +360,22 @@ func downloadArtifactURL(ctx context.Context, file artifactManifestFile, outPath
 		return "", 0, "", exit(2, "artifact %s is too large: response exceeds limit %d", file.Name, limit)
 	}
 	return resp.Header.Get("content-type"), written, hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func artifactHTTPClient(origin *url.URL) *http.Client {
+	return redirectCheckedHTTPClient(nil, func(req *http.Request) error {
+		if !sameHTTPOrigin(origin, req.URL) {
+			return errArtifactCrossOriginRedirect
+		}
+		return nil
+	})
+}
+
+func artifactRequestError(err error) error {
+	if errors.Is(err, errArtifactCrossOriginRedirect) {
+		return errArtifactCrossOriginRedirect
+	}
+	return err
 }
 
 func artifactDownloadLimit(file artifactManifestFile) int64 {

--- a/internal/cli/artifacts_publish.go
+++ b/internal/cli/artifacts_publish.go
@@ -311,11 +311,19 @@ func uploadArtifactGrant(ctx context.Context, path string, grant CoordinatorArti
 		}
 		contentLength = expected
 	}
-	req, err := http.NewRequestWithContext(ctx, method, grant.Upload.URL, file)
+	// Keep redirect replays bound to the already-open file descriptor so a path
+	// replacement cannot change the bytes after the broker signs their length.
+	requestBody := func() io.ReadCloser {
+		return io.NopCloser(io.NewSectionReader(file, 0, contentLength))
+	}
+	req, err := http.NewRequestWithContext(ctx, method, grant.Upload.URL, requestBody())
 	if err != nil {
 		return exit(2, "create artifact upload request for %s: %v", grant.Name, err)
 	}
 	req.ContentLength = contentLength
+	req.GetBody = func() (io.ReadCloser, error) {
+		return requestBody(), nil
+	}
 	for key, value := range grant.Upload.Headers {
 		if strings.EqualFold(strings.TrimSpace(key), "content-length") {
 			continue
@@ -324,9 +332,9 @@ func uploadArtifactGrant(ctx context.Context, path string, grant CoordinatorArti
 			req.Header.Set(key, value)
 		}
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := artifactHTTPClient(req.URL).Do(req)
 	if err != nil {
-		return exit(2, "upload artifact %s: %v", grant.Name, err)
+		return exit(2, "upload artifact %s: %v", grant.Name, artifactRequestError(err))
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {

--- a/internal/cli/artifacts_test.go
+++ b/internal/cli/artifacts_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -679,6 +680,136 @@ func TestDownloadArtifactURLStopsStreamingAboveDeclaredSize(t *testing.T) {
 	}
 	if info.Size() > 4 {
 		t.Fatalf("artifact output grew past declared size: %d", info.Size())
+	}
+}
+
+func TestArtifactHTTPFlowsRejectCrossOriginRedirects(t *testing.T) {
+	var targetRequests atomic.Int32
+	target := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		targetRequests.Add(1)
+	}))
+	defer target.Close()
+
+	redirect := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/collect", http.StatusTemporaryRedirect)
+	}))
+	defer redirect.Close()
+
+	dir := t.TempDir()
+	uploadPath := filepath.Join(dir, "upload.txt")
+	mustWriteFile(t, uploadPath, "private artifact")
+	signedURL := redirect.URL + "/artifact?X-Amz-Signature=secret-signature"
+	tests := []struct {
+		name string
+		run  func() error
+	}{
+		{
+			name: "manifest",
+			run: func() error {
+				_, _, err := readArtifactManifestRef(context.Background(), signedURL)
+				return err
+			},
+		},
+		{
+			name: "download",
+			run: func() error {
+				_, _, _, err := downloadArtifactURL(context.Background(), artifactManifestFile{
+					Name: "artifact.txt",
+					URL:  signedURL,
+					Size: 64,
+				}, filepath.Join(dir, "download.txt"))
+				return err
+			},
+		},
+		{
+			name: "upload",
+			run: func() error {
+				return uploadArtifactGrant(context.Background(), uploadPath, CoordinatorArtifactUploadGrant{
+					Name: "artifact.txt",
+					Upload: struct {
+						Method    string            `json:"method"`
+						URL       string            `json:"url"`
+						Headers   map[string]string `json:"headers"`
+						ExpiresAt string            `json:"expiresAt"`
+					}{Method: http.MethodPut, URL: signedURL},
+				})
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.run()
+			if err == nil || !strings.Contains(err.Error(), errArtifactCrossOriginRedirect.Error()) {
+				t.Fatalf("error=%v, want cross-origin redirect rejection", err)
+			}
+			if strings.Contains(err.Error(), "secret-signature") {
+				t.Fatalf("error leaked signed URL: %v", err)
+			}
+		})
+	}
+	if got := targetRequests.Load(); got != 0 {
+		t.Fatalf("cross-origin target received %d requests", got)
+	}
+}
+
+func TestArtifactHTTPFlowsAllowSameOriginRedirects(t *testing.T) {
+	manifest := `{"schemaVersion":1,"generatedAt":"2026-07-05T00:00:00Z","storage":{"backend":"broker"},"files":[]}`
+	payload := "private artifact"
+	var uploadedMethod, uploadedBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/manifest-start":
+			http.Redirect(w, r, "/manifest", http.StatusFound)
+		case "/manifest":
+			w.Header().Set("content-type", "application/json")
+			_, _ = io.WriteString(w, manifest)
+		case "/download-start":
+			http.Redirect(w, r, "/download", http.StatusFound)
+		case "/download":
+			_, _ = io.WriteString(w, payload)
+		case "/upload-start":
+			http.Redirect(w, r, "/upload", http.StatusTemporaryRedirect)
+		case "/upload":
+			uploadedMethod = r.Method
+			body, _ := io.ReadAll(r.Body)
+			uploadedBody = string(body)
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	listed, _, err := readArtifactManifestRef(context.Background(), server.URL+"/manifest-start")
+	if err != nil || listed.SchemaVersion != 1 {
+		t.Fatalf("manifest=%#v err=%v", listed, err)
+	}
+	dir := t.TempDir()
+	_, size, _, err := downloadArtifactURL(context.Background(), artifactManifestFile{
+		Name: "artifact.txt",
+		URL:  server.URL + "/download-start",
+		Size: int64(len(payload)),
+	}, filepath.Join(dir, "download.txt"))
+	if err != nil || size != int64(len(payload)) {
+		t.Fatalf("download size=%d err=%v", size, err)
+	}
+	uploadPath := filepath.Join(dir, "upload.txt")
+	mustWriteFile(t, uploadPath, payload)
+	err = uploadArtifactGrant(context.Background(), uploadPath, CoordinatorArtifactUploadGrant{
+		Name: "artifact.txt",
+		Upload: struct {
+			Method    string            `json:"method"`
+			URL       string            `json:"url"`
+			Headers   map[string]string `json:"headers"`
+			ExpiresAt string            `json:"expiresAt"`
+		}{Method: http.MethodPut, URL: server.URL + "/upload-start"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if uploadedMethod != http.MethodPut || uploadedBody != payload {
+		t.Fatalf("redirected upload method=%q body=%q", uploadedMethod, uploadedBody)
 	}
 }
 

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -1764,47 +1764,13 @@ func (c *CoordinatorClient) doHTTP(ctx context.Context, method, path string, dat
 }
 
 func (c *CoordinatorClient) secureHTTPClient() *http.Client {
-	source := c.Client
-	if source == nil {
-		source = http.DefaultClient
-	}
-	client := *source
 	trusted, _ := url.Parse(c.BaseURL)
-	originalCheckRedirect := source.CheckRedirect
-	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		if !sameCoordinatorOrigin(trusted, req.URL) {
+	return redirectCheckedHTTPClient(c.Client, func(req *http.Request) error {
+		if !sameHTTPOrigin(trusted, req.URL) {
 			return fmt.Errorf("coordinator refused cross-origin redirect to %s", req.URL.Redacted())
 		}
-		if originalCheckRedirect != nil {
-			return originalCheckRedirect(req, via)
-		}
-		if len(via) >= 10 {
-			return errors.New("stopped after 10 redirects")
-		}
 		return nil
-	}
-	return &client
-}
-
-func sameCoordinatorOrigin(a, b *url.URL) bool {
-	return a != nil && b != nil &&
-		strings.EqualFold(a.Scheme, b.Scheme) &&
-		strings.EqualFold(a.Hostname(), b.Hostname()) &&
-		effectiveCoordinatorPort(a) == effectiveCoordinatorPort(b)
-}
-
-func effectiveCoordinatorPort(value *url.URL) string {
-	if port := value.Port(); port != "" {
-		return port
-	}
-	switch strings.ToLower(value.Scheme) {
-	case "https":
-		return "443"
-	case "http":
-		return "80"
-	default:
-		return ""
-	}
+	})
 }
 
 func (c *CoordinatorClient) addRequestHeaders(ctx context.Context, headers http.Header) error {

--- a/internal/cli/http_redirect.go
+++ b/internal/cli/http_redirect.go
@@ -1,0 +1,52 @@
+package cli
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// redirectCheckedHTTPClient clones source so callers can constrain redirects
+// without mutating a shared client or discarding its transport and timeouts.
+func redirectCheckedHTTPClient(source *http.Client, check func(*http.Request) error) *http.Client {
+	if source == nil {
+		source = http.DefaultClient
+	}
+	client := *source
+	originalCheckRedirect := source.CheckRedirect
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if err := check(req); err != nil {
+			return err
+		}
+		if originalCheckRedirect != nil {
+			return originalCheckRedirect(req, via)
+		}
+		if len(via) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+		return nil
+	}
+	return &client
+}
+
+func sameHTTPOrigin(a, b *url.URL) bool {
+	return a != nil && b != nil &&
+		strings.EqualFold(a.Scheme, b.Scheme) &&
+		strings.EqualFold(a.Hostname(), b.Hostname()) &&
+		effectiveHTTPPort(a) == effectiveHTTPPort(b)
+}
+
+func effectiveHTTPPort(value *url.URL) string {
+	if port := value.Port(); port != "" {
+		return port
+	}
+	switch strings.ToLower(value.Scheme) {
+	case "https":
+		return "443"
+	case "http":
+		return "80"
+	default:
+		return ""
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/openclaw/crabbox/issues/900
Fixes https://github.com/openclaw/crabbox/issues/908

## Summary

- confine remote manifest, artifact download, and brokered upload redirects to the original scheme, hostname, and effective port
- preserve same-origin redirects and safely replay 307/308 uploads from the already-open file descriptor
- share the redirect-policy client cloning and origin comparison with coordinator HTTP without mutating shared clients
- strip signed request URLs from cross-origin redirect errors

## Verification

- end-to-end local HTTP proof: all three artifact flows rejected cross-origin redirects and the sink received zero requests
- end-to-end local HTTP proof: same-origin manifest/download redirects succeeded and a same-origin 307 upload preserved PUT plus body
- `go test ./internal/cli -run 'TestArtifact|TestArtifacts|TestDownloadArtifactURL|TestUploadArtifactGrant|TestCoordinatorHTTP' -count=1`
- `go vet ./...`
- `node scripts/build-docs-site.mjs`
- `go test -race ./...`
- structured autoreview: clean
