### PR TITLE
fix: keep captured capsules private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Pinned mediated-egress connections to validated public DNS results and rejected private, loopback, link-local, and reserved destinations, preventing allowlisted hostnames from rebinding into the operator network. Thanks @coygeek.
 - Confined artifact manifest fetches, downloads, and brokered uploads to same-origin redirects, preventing signed URLs and upload grants from reaching another origin. Thanks @coygeek.
 - Scoped user-visible usage totals to both the authenticated owner and organization, excluding same-owner leases from other organizations. Thanks @coygeek.
+- Wrote captured capsule manifests and failed Actions logs with private Unix permissions, repairing broader modes when an output path is reused. Thanks @coygeek.
 - Bound GitHub OAuth CLI token release to a one-use callback on the initiating device, so forwarding an authorization URL cannot hand the resulting user token to another terminal. Thanks @coygeek.
 - Honored an explicit broker URL and freshly issued credential during immediate post-login identity verification, even when ambient coordinator overrides point elsewhere.
 - Kept coordinator restarts, run history, lease detail pages, and Azure orphan sweeps memory-bounded with exact lease restores, paged record scans, and batched terminal-run pruning after a configurable 30-day retention period.

--- a/docs/features/capsules.md
+++ b/docs/features/capsules.md
@@ -51,6 +51,8 @@ crabbox capsule from-actions https://github.com/example-org/my-app/actions/runs/
 ```
 
 This writes `capsules/example-org-my-app-actions-123/capsule.yaml` by default.
+On Unix, capsule directories use mode `0700`; manifests and captured logs use
+mode `0600`. Reusing an existing output path repairs broader permissions.
 Replay it on a normal lease:
 
 ```sh

--- a/internal/cli/capsule.go
+++ b/internal/cli/capsule.go
@@ -23,6 +23,8 @@ const (
 	repoBuildReplayClass    = "repo-build-replay"
 	repoBuildReplayVersion  = "0.1.0"
 	capsuleManifestFileName = "capsule.yaml"
+	privateCapsuleDirMode   = 0o700
+	privateCapsuleFileMode  = 0o600
 
 	capsuleOutcomePass           = "pass"
 	capsuleOutcomeFailReproduced = "fail_reproduced"
@@ -244,7 +246,10 @@ func (a App) capsuleFromActions(ctx context.Context, args []string) error {
 	if dir == "" {
 		dir = filepath.Join("capsules", defaultCapsuleOutputName(runRef, job, step, *jobName != "" || capsuleRunHasMultipleFailures(view.Jobs)))
 	}
-	if err := os.MkdirAll(filepath.Join(dir, "logs"), 0o755); err != nil {
+	if err := ensurePrivateCapsuleDir(dir); err != nil {
+		return err
+	}
+	if err := ensurePrivateCapsuleDir(filepath.Join(dir, "logs")); err != nil {
 		return err
 	}
 	logRef, failureSignature := capsuleArtifactRef{}, ""
@@ -255,7 +260,7 @@ func (a App) capsuleFromActions(ctx context.Context, args []string) error {
 		} else if logText != "" {
 			logText = boundString(logText, *maxLogBytes)
 			logPath := filepath.Join(dir, "logs", "failed.log")
-			if err := os.WriteFile(logPath, []byte(logText), 0o644); err != nil {
+			if err := writePrivateCapsuleFile(logPath, []byte(logText)); err != nil {
 				return err
 			}
 			logDigest := sha256String(logText)
@@ -897,14 +902,41 @@ func boundString(value string, maxBytes int) string {
 }
 
 func writeCapsuleManifest(path string, manifest capsuleManifest) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return err
-	}
 	data, err := yaml.Marshal(manifest)
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, data, 0o644)
+	return writePrivateCapsuleFile(path, data)
+}
+
+func ensurePrivateCapsuleDir(path string) error {
+	if err := os.MkdirAll(path, privateCapsuleDirMode); err != nil {
+		return err
+	}
+	return os.Chmod(path, privateCapsuleDirMode)
+}
+
+func writePrivateCapsuleFile(path string, data []byte) error {
+	// Create missing capsule parents privately without changing permissions on
+	// an existing repository, shared directory, or the current working directory.
+	if err := os.MkdirAll(filepath.Dir(path), privateCapsuleDirMode); err != nil {
+		return err
+	}
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, privateCapsuleFileMode)
+	if err != nil {
+		return err
+	}
+	// OpenFile preserves an existing file's mode. Tighten it before writing so
+	// reused capsule paths never expose newly captured logs through old modes.
+	if err := file.Chmod(privateCapsuleFileMode); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if _, err := file.Write(data); err != nil {
+		_ = file.Close()
+		return err
+	}
+	return file.Close()
 }
 
 func readCapsuleManifest(path string) (capsuleManifest, error) {

--- a/internal/cli/capsule_test.go
+++ b/internal/cli/capsule_test.go
@@ -1,7 +1,9 @@
 package cli
 
 import (
+	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -131,6 +133,93 @@ func TestCapsuleManifestRoundTrip(t *testing.T) {
 	}
 	if got.CapsuleID != manifest.CapsuleID || got.Replay.Command != manifest.Replay.Command {
 		t.Fatalf("got=%#v want=%#v", got, manifest)
+	}
+}
+
+func TestCapsuleFilesRepairPrivatePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission bits are not enforced on Windows")
+	}
+	dir := filepath.Join(t.TempDir(), "capsule")
+	logsDir := filepath.Join(dir, "logs")
+	if err := os.MkdirAll(logsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{dir, logsDir} {
+		if err := os.Chmod(path, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	logPath := filepath.Join(logsDir, "failed.log")
+	manifestPath := filepath.Join(dir, capsuleManifestFileName)
+	for _, path := range []string{logPath, manifestPath} {
+		if err := os.WriteFile(path, []byte("old"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chmod(path, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := ensurePrivateCapsuleDir(dir); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensurePrivateCapsuleDir(logsDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := writePrivateCapsuleFile(logPath, []byte("secret log")); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeCapsuleManifest(manifestPath, capsuleManifest{CapsuleVersion: capsuleVersion}); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{dir, logsDir} {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := info.Mode().Perm(); got != privateCapsuleDirMode {
+			t.Fatalf("directory %s mode=%#o, want %#o", path, got, privateCapsuleDirMode)
+		}
+	}
+	for _, path := range []string{logPath, manifestPath} {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := info.Mode().Perm(); got != privateCapsuleFileMode {
+			t.Fatalf("file %s mode=%#o, want %#o", path, got, privateCapsuleFileMode)
+		}
+	}
+}
+
+func TestWriteCapsuleManifestDoesNotChangeExistingParentPermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission bits are not enforced on Windows")
+	}
+	dir := filepath.Join(t.TempDir(), "shared")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, capsuleManifestFileName)
+	if err := writeCapsuleManifest(path, capsuleManifest{CapsuleVersion: capsuleVersion}); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o755 {
+		t.Fatalf("existing parent mode=%#o, want unchanged 0755", got)
+	}
+	info, err = os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != privateCapsuleFileMode {
+		t.Fatalf("manifest mode=%#o, want %#o", got, privateCapsuleFileMode)
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/openclaw/crabbox/issues/907

## Summary

- create `capsule from-actions` output and log directories with Unix mode `0700`
- write `capsule.yaml` and captured failed logs with mode `0600`
- repair reused capsule directory/file modes before writing new sensitive content
- leave unrelated existing parents, including a repository/current directory, unchanged

## Verification

- live capture from https://github.com/openclaw/crabbox/actions/runs/28736216961 selected the real failed Go job, fetched its failed log, produced an inspectable capsule, and wrote both files as `0600` under `0700` directories
- live second capture repaired deliberately broadened `0755`/`0644` modes
- `go test -race ./internal/cli -run 'Test(Capsule|WriteCapsuleManifest)' -count=1`
- `go vet ./...`
- `node scripts/build-docs-site.mjs`
- structured autoreview: initial parent-directory scope finding fixed; rerun clean
