### PR TITLE
fix: scope user usage to owner and org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Kept explicit `CRABBOX_CONFIG` files inside the active repository in the repository trust domain, including symlink aliases, so they cannot redirect inherited provider credentials. Thanks @coygeek.
 - Pinned mediated-egress connections to validated public DNS results and rejected private, loopback, link-local, and reserved destinations, preventing allowlisted hostnames from rebinding into the operator network. Thanks @coygeek.
 - Confined artifact manifest fetches, downloads, and brokered uploads to same-origin redirects, preventing signed URLs and upload grants from reaching another origin. Thanks @coygeek.
+- Scoped user-visible usage totals to both the authenticated owner and organization, excluding same-owner leases from other organizations. Thanks @coygeek.
 - Bound GitHub OAuth CLI token release to a one-use callback on the initiating device, so forwarding an authorization URL cannot hand the resulting user token to another terminal. Thanks @coygeek.
 - Honored an explicit broker URL and freshly issued credential during immediate post-login identity verification, even when ambient coordinator overrides point elsewhere.
 - Kept coordinator restarts, run history, lease detail pages, and Azure orphan sweeps memory-bounded with exact lease restores, paged record scans, and batched terminal-run pruning after a configurable 30-day retention period.

--- a/docs/security.md
+++ b/docs/security.md
@@ -94,7 +94,7 @@ the browser receives a random confirmation through that loopback URL. Polling
 requires both the CLI-held secret and the browser confirmation, so forwarding an
 authorization URL cannot deliver the resulting user token to the sender.
 
-User tokens can only mutate leases, runs, and usage for their own `owner`/`org`
+User tokens can only mutate or read leases, runs, and usage for their own `owner`/`org`
 identity. Lease owners also have read-only audit access to run history, logs,
 events, telemetry, and live event subscriptions for work recorded against
 their leases, including runs that later replace the active backing lease. See

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -10143,10 +10143,15 @@ export class FleetCoordinator {
     const owner = admin
       ? (url.searchParams.get("owner") ?? requestOwner(request))
       : requestOwner(request);
+    const requestedOrg = url.searchParams.get("org") ?? undefined;
     const org = admin
-      ? (url.searchParams.get("org") ?? requestOrg(request, this.env))
+      ? (requestedOrg ?? (scope === "org" ? requestOrg(request, this.env) : undefined))
       : requestOrg(request, this.env);
-    const usage = usageSummary(await this.leaseRecords(), { scope, owner, org, month }, new Date());
+    const usage = usageSummary(
+      await this.leaseRecords(),
+      { scope, owner, month, ...(org ? { org } : {}) },
+      new Date(),
+    );
     return json({ usage, limits: costLimits(this.env) });
   }
 

--- a/worker/src/usage.ts
+++ b/worker/src/usage.ts
@@ -232,7 +232,9 @@ function leaseMatchesUsageFilter(lease: LeaseRecord, filter: UsageFilter): boole
     return false;
   }
   if (filter.scope === "user") {
-    return !filter.owner || lease.owner === filter.owner;
+    return (
+      (!filter.owner || lease.owner === filter.owner) && (!filter.org || lease.org === filter.org)
+    );
   }
   if (filter.scope === "org") {
     return !filter.org || lease.org === filter.org;

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -14000,7 +14000,7 @@ describe("fleet lease identity and idle", () => {
     expect(lease.capacityHints?.[0]?.regionsTried).toEqual(["eu-west-1", "eu-west-2"]);
   });
 
-  it("scopes non-admin usage to the current owner", async () => {
+  it("scopes non-admin usage to the current owner and org", async () => {
     const storage = new MemoryStorage();
     const fleet = testFleet(storage);
     const createdAt = new Date().toISOString();
@@ -14029,6 +14029,18 @@ describe("fleet lease identity and idle", () => {
         expiresAt,
       }),
     );
+    storage.seed(
+      "lease:cbx_000000000003",
+      testLease({
+        id: "cbx_000000000003",
+        owner: "friend@example.com",
+        org: "example-org",
+        estimatedHourlyUSD: 1,
+        maxEstimatedUSD: 1,
+        createdAt,
+        expiresAt,
+      }),
+    );
     const usage = await fleet.fetch(
       request("GET", `/v1/usage?scope=all&owner=peter@example.com&month=${createdAt.slice(0, 7)}`, {
         headers: {
@@ -14039,11 +14051,66 @@ describe("fleet lease identity and idle", () => {
     );
     expect(usage.status).toBe(200);
     const body = (await usage.json()) as {
-      usage: { scope: string; owner: string; leases: number };
+      usage: {
+        scope: string;
+        owner: string;
+        org: string;
+        leases: number;
+        byOrg: { key: string }[];
+      };
     };
     expect(body.usage.scope).toBe("user");
     expect(body.usage.owner).toBe("friend@example.com");
+    expect(body.usage.org).toBe("example-org");
     expect(body.usage.leases).toBe(1);
+    expect(body.usage.byOrg.map((group) => group.key)).toEqual(["example-org"]);
+  });
+
+  it("keeps admin user usage cross-org unless an org is explicit", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const createdAt = new Date().toISOString();
+    const expiresAt = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    for (const [id, org] of [
+      ["cbx_000000000001", "org-a"],
+      ["cbx_000000000002", "org-b"],
+    ]) {
+      storage.seed(
+        `lease:${id}`,
+        testLease({
+          id,
+          owner: "alice@example.com",
+          org,
+          createdAt,
+          expiresAt,
+        }),
+      );
+    }
+    const headers = {
+      "x-crabbox-admin": "true",
+      "x-crabbox-owner": "admin@example.com",
+      "x-crabbox-org": "default-org",
+    };
+    const month = createdAt.slice(0, 7);
+
+    const allOrgs = await fleet.fetch(
+      request("GET", `/v1/usage?scope=user&owner=alice@example.com&month=${month}`, { headers }),
+    );
+    const allBody = (await allOrgs.json()) as {
+      usage: { leases: number; org?: string; byOrg: { key: string }[] };
+    };
+    expect(allBody.usage.leases).toBe(2);
+    expect(allBody.usage.org).toBeUndefined();
+    expect(allBody.usage.byOrg.map((group) => group.key)).toEqual(["org-a", "org-b"]);
+
+    const oneOrg = await fleet.fetch(
+      request("GET", `/v1/usage?scope=user&owner=alice@example.com&org=org-a&month=${month}`, {
+        headers,
+      }),
+    );
+    const oneBody = (await oneOrg.json()) as { usage: { leases: number; org?: string } };
+    expect(oneBody.usage.leases).toBe(1);
+    expect(oneBody.usage.org).toBe("org-a");
   });
 
   it("reports marketplace gateway status with credits disabled by default", async () => {

--- a/worker/test/usage.test.ts
+++ b/worker/test/usage.test.ts
@@ -39,6 +39,25 @@ describe("usage accounting", () => {
     expect(usage.byOrg[0]?.key).toBe("openclaw");
   });
 
+  it("keeps user-visible usage inside the requested owner and org", () => {
+    const now = new Date("2026-05-01T02:00:00Z");
+    const matching = testLease({ owner: "alice@example.com", org: "org-a" });
+    const otherOrg = testLease({
+      id: "cbx_other_org",
+      owner: "alice@example.com",
+      org: "org-b",
+    });
+
+    const usage = usageSummary(
+      [matching, otherOrg],
+      { scope: "user", owner: "alice@example.com", org: "org-a", month: "2026-05" },
+      now,
+    );
+
+    expect(usage.leases).toBe(1);
+    expect(usage.byOrg.map((group) => group.key)).toEqual(["org-a"]);
+  });
+
   it("blocks new leases when owner monthly budget would be exceeded", () => {
     const now = new Date("2026-05-01T02:00:00Z");
     const existing = testLease({


### PR DESCRIPTION
Fixes https://github.com/openclaw/crabbox/issues/911

## Summary

- require both owner and org to match for non-admin user-visible usage summaries
- preserve intentional owner-wide monthly budget accounting when no org filter is supplied
- preserve admin `scope=user` reports across orgs unless the admin explicitly selects an org
- document the read boundary and cover both focused accounting and coordinator-route behavior

## Verification

- coordinator route test proves a non-admin response excludes a same-owner lease from another org
- coordinator route test proves admin owner reports remain cross-org by default and narrow only with an explicit org
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker` (26 files, 807 tests)
- `npm run build --prefix worker`
- `node scripts/build-docs-site.mjs`
- structured autoreview: initial admin-scope regression fixed; rerun clean
