### PR TITLE
fix(portal): require same-origin logout post

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.36.1 - Unreleased
 
+### Fixed
+
+- Changed portal logout to an authenticated, same-origin `POST` with a read-only `GET` confirmation page, preventing cross-site top-level navigation from clearing portal cookies or revoking isolated Code viewer sessions. Thanks @coygeek.
+
 ## 0.36.0 - 2026-07-05
 
 ### Changed

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -116,8 +116,9 @@ adapter's `Spec()`; the type definitions live in
 Node runtime:
 
 - `GET /v1/health` returns liveness; `GET /` redirects to `/portal`.
-- `/v1/auth/*`, `/portal/login`, `/portal/logout`, and WebSocket upgrades for
-  the live bridges go to `FleetCoordinator`.
+- `/v1/auth/*`, `/portal/login`, and WebSocket upgrades for the live bridges go
+  to `FleetCoordinator` without the normal portal-session authentication;
+  `/portal/logout` remains authenticated and same-origin gated.
 - `/v1/internal/*` is 404 externally; runtime schedulers invoke maintenance
   internally.
 - Everything else passes through `authenticateRequest` and is forwarded with

--- a/docs/features/broker-auth-routing.md
+++ b/docs/features/broker-auth-routing.md
@@ -45,7 +45,7 @@ https://fallback.example.com                       # additional fallback
 complete a browser GitHub OAuth flow. The coordinator still requires Crabbox
 auth on every API route; the unauthenticated
 exceptions are `GET /v1/health`, the GitHub login/OAuth routes (`/v1/auth/*`,
-`/portal/login`, `/portal/logout`), and the per-lease websocket agent upgrades that
+`/portal/login`), and the per-lease websocket agent upgrades that
 authenticate via short-lived bridge tickets instead.
 
 `https://broker-access.example.com` is the **same** Worker fronted by a Cloudflare Access

--- a/docs/features/coordinator.md
+++ b/docs/features/coordinator.md
@@ -216,13 +216,15 @@ GET    /v1/images/{id}/fast-snapshot-restore
 ## Browser portal surface
 
 The portal is the authenticated browser UI served by the same coordinator
-(`worker/src/portal.ts`). Login and logout are unauthenticated; everything else
-uses the `crabbox_session` cookie.
+(`worker/src/portal.ts`). Login is unauthenticated; everything else uses the
+`crabbox_session` cookie. Logout confirmation is read-only, while logout itself
+requires a same-origin `POST`.
 
 ```text
 GET    /portal
 GET    /portal/login
 GET    /portal/logout
+POST   /portal/logout
 GET    /portal/leases/{id-or-slug}
 GET    /portal/leases/{id-or-slug}/share
 POST   /portal/leases/{id-or-slug}/share

--- a/docs/features/portal.md
+++ b/docs/features/portal.md
@@ -33,7 +33,8 @@ GET  /portal/runners/{provider}/{runner-id}      external runner detail
 GET  /portal/hosts/{provider}/{host-id}          dedicated host detail
 POST /portal/hosts/{provider}/{host-id}/vnc      enable VNC on the host's lease
 GET  /portal/login                               GitHub OAuth login redirect
-GET  /portal/logout                              end the portal and isolated Code sessions
+GET  /portal/logout                              confirm logout without changing session state
+POST /portal/logout                              end the portal and isolated Code sessions
 ```
 
 The WebVNC viewer page also drives a small set of bridge sub-routes that the
@@ -69,7 +70,8 @@ Proxied responses may set only code-server's `vscode-tkn` cookie; Crabbox remove
 domain scope and confines it to that lease's Code path.
 Portal logout revokes isolated Code viewer sessions server-side, so their
 separate host-scoped cookies cannot retain access after the portal cookie is
-cleared.
+cleared. Logout uses a same-origin `POST`; a cross-site top-level `GET` can show
+the confirmation page but cannot clear the cookie or revoke viewer sessions.
 
 Crabbox cannot provision an operator's wildcard DNS, certificate, or ingress
 route. When the setting is absent or invalid, Code health remains available but

--- a/docs/security.md
+++ b/docs/security.md
@@ -53,7 +53,7 @@ Every non-health route normally requires a Bearer token; requests without one
 are rejected `401 unauthorized`. The Node runtime can instead accept an
 explicitly configured trusted reverse-proxy identity from allowlisted peer
 CIDRs. The generally unauthenticated routes are `GET /v1/health`, the GitHub
-login/OAuth and portal login/logout routes, and bridge agent upgrades that use
+login/OAuth and portal login routes, and bridge agent upgrades that use
 short-lived tickets. The workspace lifecycle and desktop-connection routes also
 accept the dedicated `CRABBOX_RUNTIME_ADAPTER_TOKEN` as a non-admin service
 identity. That credential cannot attach workspace terminals and is rejected from
@@ -268,6 +268,9 @@ require an exact same-origin browser `Origin` matching `CRABBOX_PUBLIC_URL` (or
 the request origin when no public URL is configured). Missing or sibling-origin
 intent is rejected before the portal cookie is converted into bearer authority;
 explicit bearer API clients remain independent of this browser-only boundary.
+Portal logout follows the same boundary: `GET /portal/logout` only renders a
+confirmation page, and only a same-origin `POST` clears the portal cookie and
+revokes isolated Code viewer sessions.
 
 Configured provider credentials are redacted from documented HTTP or streamed
 error diagnostics, including Azure Dynamic Sessions, Cloudflare runner, Daytona,

--- a/worker/src/auth.ts
+++ b/worker/src/auth.ts
@@ -271,6 +271,30 @@ export async function verifiedUserTokenExpiresAtForRevocation(
   return payload ? new Date(payload.exp * 1000).toISOString() : undefined;
 }
 
+// Logout must remain available when GitHub membership revalidation is unavailable or revoked.
+export async function authenticateUserTokenForRevocation(
+  token: string,
+  env: Pick<
+    Env,
+    | "CRABBOX_SHARED_TOKEN"
+    | "CRABBOX_SESSION_SECRET"
+    | "CRABBOX_GITHUB_ADMIN_OWNERS"
+    | "CRABBOX_GITHUB_ADMIN_LOGINS"
+  >,
+): Promise<AuthContext | undefined> {
+  const payload = await verifyUserToken(token, env).catch(() => undefined);
+  if (!payload) return undefined;
+  return {
+    authorized: true,
+    admin: githubUserIsAdmin(payload, env),
+    auth: "github",
+    owner: payload.owner,
+    org: payload.org,
+    login: payload.login,
+    tokenExpiresAt: new Date(payload.exp * 1000).toISOString(),
+  };
+}
+
 async function verifyUserToken(
   token: string,
   env: Pick<Env, "CRABBOX_SHARED_TOKEN" | "CRABBOX_SESSION_SECRET">,

--- a/worker/src/coordinator-entry.ts
+++ b/worker/src/coordinator-entry.ts
@@ -1,4 +1,5 @@
 import {
+  authenticateUserTokenForRevocation,
   authenticateRequest,
   requestWithAdminGrantVersion,
   requestWithAuthContext,
@@ -54,7 +55,7 @@ export async function prepareCoordinatorRequest(
   if (url.pathname.startsWith("/v1/auth/")) {
     return { request: requestWithoutTrustedHeaders(request), authenticated: false };
   }
-  if (url.pathname === "/portal/login" || url.pathname === "/portal/logout") {
+  if (url.pathname === "/portal/login") {
     return { request: requestWithoutTrustedHeaders(request), authenticated: false };
   }
   if (
@@ -104,7 +105,16 @@ export async function prepareCoordinatorRequest(
     };
   }
   const authRequest = portal ? requestWithPortalCookie(request) : request;
-  const auth = await authenticateRequest(authRequest, env, authContext);
+  const portalLogoutToken =
+    portal &&
+    request.method === "POST" &&
+    url.pathname === "/portal/logout" &&
+    !request.headers.has("authorization")
+      ? cookieValue(request.headers.get("cookie") ?? "", "crabbox_session")
+      : undefined;
+  const auth = portalLogoutToken
+    ? await authenticateUserTokenForRevocation(portalLogoutToken, env)
+    : await authenticateRequest(authRequest, env, authContext);
   if (!auth?.authorized) {
     if (portal && request.method === "GET" && request.headers.get("upgrade") !== "websocket") {
       const login = new URL("/portal/login", url.origin);

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -71,7 +71,12 @@ import {
   marketplaceStatus,
   type MarketplaceQuoteRequest,
 } from "./marketplace";
-import { githubAuthRoute, githubPortalLogin, githubPortalLogout } from "./oauth";
+import {
+  githubAuthRoute,
+  githubPortalLogin,
+  githubPortalLogout,
+  githubPortalLogoutConfirmation,
+} from "./oauth";
 import { defaultOSImage, normalizeOSImage } from "./os-image";
 import {
   portalCode,
@@ -885,6 +890,9 @@ export class FleetCoordinator {
         return await githubPortalLogin(request, this.state.storage, this.env);
       }
       if (method === "GET" && parts.join("/") === "portal/logout") {
+        return githubPortalLogoutConfirmation();
+      }
+      if (method === "POST" && parts.join("/") === "portal/logout") {
         return await this.portalLogout(request);
       }
       if (parts[0] === "portal") {

--- a/worker/src/oauth.ts
+++ b/worker/src/oauth.ts
@@ -117,6 +117,20 @@ export function githubPortalLogout(): Response {
   );
 }
 
+export function githubPortalLogoutConfirmation(): Response {
+  return html(
+    "Log out of Crabbox?",
+    "This ends your portal session and any isolated Code viewer sessions.",
+    200,
+    {
+      "content-security-policy":
+        "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; frame-ancestors 'none'; base-uri 'none'",
+      "x-frame-options": "DENY",
+    },
+    `<form method="post" action="/portal/logout"><button type="submit">Log out</button></form><p><a href="/portal">Cancel</a></p>`,
+  );
+}
+
 async function githubAuthStart(
   request: Request,
   storage: CoordinatorStorage,

--- a/worker/src/portal.ts
+++ b/worker/src/portal.ts
@@ -183,7 +183,7 @@ export function portalHome(
     `<main class="portal-shell">
       ${portalHeader({
         meta: `${escapeHTML(new URL(request.url).host)}${admin ? ` <span class="pill admin-pill">admin</span>` : ""}`,
-        actions: `${admin ? `<a class="button secondary admin-nav-link" href="/portal/admin">${lockIcon}<span>admin</span></a>` : ""}<a class="button secondary" href="/portal/logout">log out</a>`,
+        actions: `${admin ? `<a class="button secondary admin-nav-link" href="/portal/admin">${lockIcon}<span>admin</span></a>` : ""}${portalLogoutButton()}`,
       })}
       ${admin ? portalAdminSummary({ owner, org, active: active.length, ended, runners: sortedRunners.length, system, providers: portalProviderSummary(sortedLeases, sortedRunners, macHosts) }) : ""}
       <section class="panel table-panel">
@@ -253,7 +253,7 @@ export function portalAdmin(
         actions: `
           <a class="button secondary" href="/portal">leases</a>
           <a class="button secondary admin-nav-link" href="/portal/admin">${lockIcon}<span>admin</span></a>
-          <a class="button secondary" href="/portal/logout">log out</a>
+          ${portalLogoutButton()}
         `,
       })}
       ${adminTabs(tab, providerFilter)}
@@ -549,7 +549,7 @@ export function portalLeaseDetail(
               : ""
           }
           <a class="button secondary" href="/portal">leases</a>
-          <a class="button secondary" href="/portal/logout">log out</a>
+          ${portalLogoutButton()}
         `,
       })}
       <section class="detail-grid">
@@ -649,7 +649,7 @@ export function portalShareLease(
               actions: `
                 <a class="button secondary" href="/portal/leases/${encodeURIComponent(lease.id)}">back to lease</a>
                 <a class="button secondary" href="/portal">leases</a>
-                <a class="button secondary" href="/portal/logout">log out</a>
+                ${portalLogoutButton()}
               `,
             })
       }
@@ -720,7 +720,7 @@ export function portalExternalRunnerDetail(
         meta: `${escapeHTML(runner.id)} · ${escapeHTML(runner.provider)} external runner`,
         actions: `
           <a class="button secondary" href="/portal">leases</a>
-          <a class="button secondary" href="/portal/logout">log out</a>
+          ${portalLogoutButton()}
         `,
       })}
       <section class="detail-grid">
@@ -831,7 +831,7 @@ export function portalMacHostDetail(
         meta: `${escapeHTML(host.id)} · ${escapeHTML(host.provider)} ${escapeHTML(host.target)} dedicated host`,
         actions: `
           <a class="button secondary" href="/portal">leases</a>
-          <a class="button secondary" href="/portal/logout">log out</a>
+          ${portalLogoutButton()}
         `,
       })}
       <section class="detail-grid">
@@ -916,7 +916,7 @@ export function portalRunDetail(
         actions: `
           <a class="button secondary" href="/portal/leases/${encodeURIComponent(run.leaseID)}">lease</a>
           <a class="button secondary" href="/portal">leases</a>
-          <a class="button secondary" href="/portal/logout">log out</a>
+          ${portalLogoutButton()}
         `,
       })}
       <section class="detail-grid">
@@ -1064,7 +1064,7 @@ export function portalVNC(lease: LeaseRecord, options: { canManage?: boolean } =
           <button id="vnc-fullscreen" class="icon-btn" type="button" title="fullscreen" aria-label="toggle fullscreen">${fullscreenIcon}</button>
           ${canManage ? `<button id="vnc-share" class="button secondary" type="button">share</button>` : ""}
           <a class="button secondary" href="/portal">leases</a>
-          <a class="button secondary" href="/portal/logout">log out</a>
+          ${portalLogoutButton()}
         `,
       })}
       <section id="screen" class="screen" aria-label="WebVNC display" tabindex="0"></section>
@@ -1855,7 +1855,7 @@ export function portalCode(lease: LeaseRecord): Response {
           <span id="code-status" class="status-pill">checking bridge</span>
           <button id="code-reload" class="icon-btn" type="button" title="reload" aria-label="reload">${reloadIcon}</button>
           <a class="button secondary" href="/portal">leases</a>
-          <a class="button secondary" href="/portal/logout">log out</a>
+          ${portalLogoutButton()}
         `,
       })}
       <section class="screen code-wait-screen" aria-label="Code bridge waiting state">
@@ -2534,6 +2534,10 @@ function portalHeader(options: PortalHeaderOptions): string {
     </div>
     ${actions}
   </header>`;
+}
+
+function portalLogoutButton(): string {
+  return `<form method="post" action="/portal/logout"><button class="button secondary" type="submit">log out</button></form>`;
 }
 
 function leaseOwnership(lease: LeaseRecord, owner: string, org: string): "mine" | "system" {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -8265,10 +8265,14 @@ describe("fleet lease identity and idle", () => {
     const portalHTML = await portal.text();
     expect(portalHTML).toContain("client managed");
     expect(portalHTML).toContain("remove registration");
+    expect(portalHTML).toContain('<form method="post" action="/portal/logout">');
+    expect(portalHTML).not.toContain('href="/portal/logout"');
 
     const portalIndex = await fleet.fetch(request("GET", "/portal", { headers: ownerHeaders }));
     expect(portalIndex.status).toBe(200);
     const portalIndexHTML = await portalIndex.text();
+    expect(portalIndexHTML).toContain('<form method="post" action="/portal/logout">');
+    expect(portalIndexHTML).not.toContain('href="/portal/logout"');
     expect(portalIndexHTML).toContain('data-release-kind="registered"');
     expect(portalIndexHTML).toContain('title="Remove test-box registration"');
     expect(portalIndexHTML).toContain(
@@ -16110,9 +16114,20 @@ describe("fleet lease identity and idle", () => {
       createdAt: new Date(Date.now() - 2_000).toISOString(),
       expiresAt: new Date(Date.now() - 1_000).toISOString(),
     });
+    const crossSiteNavigation = await throughCoordinator(
+      new Request("https://crabbox.test/portal/logout", {
+        headers: { cookie: portalCookie, origin: "https://attacker.example" },
+      }),
+    );
+    expect(crossSiteNavigation.status).toBe(200);
+    expect(crossSiteNavigation.headers.get("set-cookie")).toBeNull();
+    expect(await crossSiteNavigation.text()).toContain('method="post"');
+    expect(activeViewer.closeCode).toBeUndefined();
+
     const logout = await throughCoordinator(
       new Request("https://crabbox.test/portal/logout", {
-        headers: { cookie: portalCookie },
+        method: "POST",
+        headers: { cookie: portalCookie, origin: "https://crabbox.test" },
       }),
     );
     expect(logout.status).toBe(200);
@@ -21509,9 +21524,19 @@ describe("fleet identity", () => {
     expect(callback.headers.get("set-cookie")).toContain("crabbox_session=cbxu_");
   });
 
-  it("clears portal session on logout without restarting OAuth", async () => {
+  it("requires a POST before clearing the portal session", async () => {
     const fleet = testFleet();
-    const logout = await fleet.fetch(request("GET", "/portal/logout"));
+    const confirmation = await fleet.fetch(request("GET", "/portal/logout"));
+    expect(confirmation.status).toBe(200);
+    expect(confirmation.headers.get("set-cookie")).toBeNull();
+    expect(confirmation.headers.get("content-security-policy")).toContain("form-action 'self'");
+    expect(confirmation.headers.get("content-security-policy")).toContain("frame-ancestors 'none'");
+    expect(confirmation.headers.get("x-frame-options")).toBe("DENY");
+    const confirmationBody = await confirmation.text();
+    expect(confirmationBody).toContain('method="post"');
+    expect(confirmationBody).toContain('action="/portal/logout"');
+
+    const logout = await fleet.fetch(request("POST", "/portal/logout"));
     expect(logout.status).toBe(200);
     expect(logout.headers.get("location")).toBeNull();
     expect(logout.headers.get("set-cookie")).toContain("crabbox_session=");

--- a/worker/test/http.test.ts
+++ b/worker/test/http.test.ts
@@ -51,6 +51,14 @@ describe("coordinator auth", () => {
           method: "POST",
           headers: { cookie, origin: "https://lease.code.example.test" },
         }),
+        new Request("https://broker.example.test/portal/logout", {
+          method: "POST",
+          headers: { cookie },
+        }),
+        new Request("https://broker.example.test/portal/logout", {
+          method: "POST",
+          headers: { cookie, origin: "https://attacker.example" },
+        }),
         new Request(viewerURL, { headers: { cookie, upgrade: "websocket" } }),
         new Request(viewerURL, {
           headers: { cookie, origin: "https://attacker.example", upgrade: "websocket" },
@@ -72,6 +80,13 @@ describe("coordinator auth", () => {
         new Request(mutationURL, {
           method: "POST",
           headers: { cookie, origin: "https://broker.example.test" },
+        }),
+        new Request("https://broker.example.test/portal/logout", {
+          method: "POST",
+          headers: { cookie, origin: "https://broker.example.test" },
+        }),
+        new Request("https://broker.example.test/portal/logout", {
+          headers: { cookie, origin: "https://attacker.example" },
         }),
         new Request(viewerURL, {
           headers: {
@@ -95,6 +110,47 @@ describe("coordinator auth", () => {
     for (const prepared of accepted) {
       expect(prepared).toMatchObject({ authenticated: true });
     }
+  });
+
+  it("allows a verified same-origin portal logout without GitHub membership", async () => {
+    const env = {
+      CRABBOX_SESSION_SECRET: "session-secret",
+      CRABBOX_PUBLIC_URL: "https://broker.example.test",
+      CRABBOX_DEFAULT_ORG: "example-org",
+    } as Env;
+    const token = await issueUserToken(env, {
+      owner: "alice@example.com",
+      ownerSource: "github-verified-email",
+      org: "example-org",
+      login: "alice",
+      githubAccessToken: "github-access-token",
+    });
+    const headers = {
+      cookie: `crabbox_session=${encodeURIComponent(token)}`,
+      origin: "https://broker.example.test",
+    };
+    const membershipUnavailable = {
+      githubMembership: async (): Promise<void> => {
+        throw new Error("GitHub unavailable");
+      },
+    };
+
+    const logout = await prepareCoordinatorRequest(
+      new Request("https://broker.example.test/portal/logout", { method: "POST", headers }),
+      env,
+      membershipUnavailable,
+    );
+    expect(logout).toMatchObject({ authenticated: true });
+
+    const normalMutation = await prepareCoordinatorRequest(
+      new Request("https://broker.example.test/portal/leases/blue-lobster/share", {
+        method: "POST",
+        headers,
+      }),
+      env,
+      membershipUnavailable,
+    );
+    expect(normalMutation).toMatchObject({ authenticated: false, response: { status: 401 } });
   });
 
   it("treats malformed portal cookies as absent across request types", async () => {


### PR DESCRIPTION
## Summary

- make `GET /portal/logout` a read-only confirmation page
- require an authenticated same-origin `POST` before clearing the portal cookie or revoking viewer sessions
- preserve logout during GitHub outages by validating the signed session locally, and document the boundary

Closes https://github.com/openclaw/crabbox/issues/929
Also resolves the duplicate https://github.com/openclaw/crabbox/issues/932

## Verification

- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker`
- `npm run build --prefix worker`
- `node scripts/build-docs-site.mjs`
- autoreview clean with no actionable findings
- live local Wrangler proof in the existing Chrome profile: cross-site/top-level `GET` rendered confirmation without clearing the cookie or revoking the active viewer; same-origin form `POST` cleared the cookie and rendered the logged-out state

Public model identifier gate: PASS; this diff has no model-bearing code or artifacts.
