### PR TITLE
fix(worker): revoke live user bridges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Changed portal logout to an authenticated, same-origin `POST` with a read-only `GET` confirmation page, preventing cross-site top-level navigation from clearing portal cookies or revoking isolated Code viewer sessions. Thanks @coygeek.
+- Bound non-admin GitHub WebVNC, Code, and egress bridges to their encrypted user grant and portal session, closing active or restored bridges after logout, emergency revocation, membership loss, or membership-check failure without persisting plaintext GitHub credentials. Thanks @coygeek.
 
 ## 0.36.0 - 2026-07-05
 

--- a/docs/features/coordinator.md
+++ b/docs/features/coordinator.md
@@ -218,7 +218,8 @@ GET    /v1/images/{id}/fast-snapshot-restore
 The portal is the authenticated browser UI served by the same coordinator
 (`worker/src/portal.ts`). Login is unauthenticated; everything else uses the
 `crabbox_session` cookie. Logout confirmation is read-only, while logout itself
-requires a same-origin `POST`.
+requires a same-origin `POST` and closes WebVNC, Code, and mediated-egress
+bridges bound to that portal session.
 
 ```text
 GET    /portal

--- a/docs/features/portal.md
+++ b/docs/features/portal.md
@@ -34,7 +34,7 @@ GET  /portal/hosts/{provider}/{host-id}          dedicated host detail
 POST /portal/hosts/{provider}/{host-id}/vnc      enable VNC on the host's lease
 GET  /portal/login                               GitHub OAuth login redirect
 GET  /portal/logout                              confirm logout without changing session state
-POST /portal/logout                              end the portal and isolated Code sessions
+POST /portal/logout                              end the portal and its live bridge sessions
 ```
 
 The WebVNC viewer page also drives a small set of bridge sub-routes that the
@@ -68,10 +68,11 @@ use the Code session on other portal routes or lease origins. The ingress must
 provide wildcard TLS and WebSocket routing for the template.
 Proxied responses may set only code-server's `vscode-tkn` cookie; Crabbox removes
 domain scope and confines it to that lease's Code path.
-Portal logout revokes isolated Code viewer sessions server-side, so their
-separate host-scoped cookies cannot retain access after the portal cookie is
-cleared. Logout uses a same-origin `POST`; a cross-site top-level `GET` can show
-the confirmation page but cannot clear the cookie or revoke viewer sessions.
+Portal logout revokes WebVNC, isolated Code, and mediated-egress bridge sessions
+server-side, so their sockets or separate host-scoped cookies cannot retain
+access after the portal cookie is cleared. Logout uses a same-origin `POST`; a
+cross-site top-level `GET` can show the confirmation page but cannot clear the
+cookie or revoke bridge sessions.
 
 Crabbox cannot provision an operator's wildcard DNS, certificate, or ingress
 route. When the setting is absent or invalid, Code health remains available but

--- a/docs/security.md
+++ b/docs/security.md
@@ -179,6 +179,13 @@ flows. Legacy admin attachments without a verifiable source and version fail
 closed after upgrade. Restored Code viewer sessions without a complete
 organization-bound principal also fail closed during restore and whenever lease
 sharing access shrinks.
+Non-admin GitHub WebVNC, Code, and egress sessions bind to the exact portal
+session and preserve only the encrypted GitHub credential from its signed user
+token. Active traffic rechecks portal logout and emergency user revocation, and
+revalidates GitHub membership under the configured membership-cache window.
+Membership errors fail closed. Restored legacy GitHub bridge attachments without
+a complete encrypted grant and portal-session binding close before carrying
+traffic; plaintext GitHub credentials are never stored in bridge state.
 Shared-operator requests do **not** trust caller-supplied `X-Crabbox-Owner` /
 `X-Crabbox-Org` headers — pin that automation's identity with
 `CRABBOX_SHARED_OWNER` (and `CRABBOX_DEFAULT_ORG`), or prefer per-user signed
@@ -270,7 +277,8 @@ intent is rejected before the portal cookie is converted into bearer authority;
 explicit bearer API clients remain independent of this browser-only boundary.
 Portal logout follows the same boundary: `GET /portal/logout` only renders a
 confirmation page, and only a same-origin `POST` clears the portal cookie and
-revokes isolated Code viewer sessions.
+revokes all WebVNC, Code, and mediated-egress bridges bound to that portal
+session.
 
 Configured provider credentials are redacted from documented HTTP or streamed
 error diagnostics, including Azure Dynamic Sessions, Cloudflare runner, Daytona,

--- a/worker/src/auth.ts
+++ b/worker/src/auth.ts
@@ -29,6 +29,13 @@ export interface AuthContext {
   org: string;
   login?: string;
   tokenExpiresAt?: string;
+  githubGrant?: GitHubUserGrant;
+}
+
+export interface GitHubUserGrant {
+  tokenID: string;
+  sealedCredential: string;
+  expiresAt: string;
 }
 
 export interface AuthRequestContext {
@@ -139,6 +146,11 @@ export async function authenticateRequest(
         org: payload.org,
         login: payload.login,
         tokenExpiresAt: new Date(payload.exp * 1000).toISOString(),
+        githubGrant: {
+          tokenID: payload.jti,
+          sealedCredential: payload.githubCredential,
+          expiresAt: new Date(payload.exp * 1000).toISOString(),
+        },
       };
     }
   }
@@ -184,6 +196,13 @@ export function requestWithAuthContext(request: Request, auth: AuthContext): Req
   } else {
     headers.delete("x-crabbox-token-expires-at");
   }
+  if (auth.githubGrant) {
+    headers.set("x-crabbox-github-token-id", auth.githubGrant.tokenID);
+    headers.set("x-crabbox-github-sealed-credential", auth.githubGrant.sealedCredential);
+  } else {
+    headers.delete("x-crabbox-github-token-id");
+    headers.delete("x-crabbox-github-sealed-credential");
+  }
   return new Request(request, { headers });
 }
 
@@ -203,7 +222,9 @@ export function requestWithoutTrustedHeaders(request: Request): Request {
   if (
     !request.headers.has("x-crabbox-internal") &&
     !request.headers.has("x-crabbox-proxy-secret") &&
-    !request.headers.has("x-crabbox-admin-grant-version")
+    !request.headers.has("x-crabbox-admin-grant-version") &&
+    !request.headers.has("x-crabbox-github-token-id") &&
+    !request.headers.has("x-crabbox-github-sealed-credential")
   ) {
     return request;
   }
@@ -211,6 +232,8 @@ export function requestWithoutTrustedHeaders(request: Request): Request {
   headers.delete("x-crabbox-internal");
   headers.delete("x-crabbox-proxy-secret");
   headers.delete("x-crabbox-admin-grant-version");
+  headers.delete("x-crabbox-github-token-id");
+  headers.delete("x-crabbox-github-sealed-credential");
   return new Request(request, { headers });
 }
 
@@ -292,7 +315,43 @@ export async function authenticateUserTokenForRevocation(
     org: payload.org,
     login: payload.login,
     tokenExpiresAt: new Date(payload.exp * 1000).toISOString(),
+    githubGrant: {
+      tokenID: payload.jti,
+      sealedCredential: payload.githubCredential,
+      expiresAt: new Date(payload.exp * 1000).toISOString(),
+    },
   };
+}
+
+export async function githubUserGrantIsCurrent(
+  grant: GitHubUserGrant,
+  identity: Pick<GitHubMembershipIdentity, "owner" | "org" | "login">,
+  env: Pick<Env, "CRABBOX_SHARED_TOKEN" | "CRABBOX_SESSION_SECRET"> & GitHubMembershipEnv,
+  context: AuthRequestContext = {},
+): Promise<boolean> {
+  if (
+    !/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(grant.tokenID) ||
+    !grant.sealedCredential ||
+    !Number.isFinite(Date.parse(grant.expiresAt)) ||
+    Date.parse(grant.expiresAt) <= Date.now()
+  ) {
+    return false;
+  }
+  let accessToken: string;
+  try {
+    const opened = await openGitHubCredential(grant.sealedCredential, sessionSecret(env));
+    if (!opened) return false;
+    accessToken = opened;
+  } catch {
+    return false;
+  }
+  const membership = context.githubMembership ?? requireCurrentGitHubMembership;
+  try {
+    await membership({ accessToken, tokenID: grant.tokenID, ...identity }, env);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 async function verifyUserToken(

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -5,12 +5,14 @@ const { Client: SSHClientConstructor, utils: sshUtils } = ssh2;
 import { artifactUploadResponse, type ArtifactUploadRequest } from "./artifacts";
 import {
   adminGrantVersion as configuredAdminGrantVersion,
+  githubUserGrantIsCurrent,
   githubUserIsAdmin,
   isAdminRequest,
   requestWithAuthContext,
   sha256Hex,
   verifiedUserTokenExpiresAtForRevocation,
   type AuthContext,
+  type GitHubUserGrant,
 } from "./auth";
 import {
   EC2SpotClient,
@@ -239,6 +241,7 @@ const workspaceTerminalSSHReadyTimeoutMs = 2 * 60_000;
 const workspaceSSHHostPrivateKeyHeader = "x-crabbox-workspace-ssh-host-private-key";
 const workspaceSSHHostPublicKeyHeader = "x-crabbox-workspace-ssh-host-public-key";
 const adminGrantRevalidationIntervalMs = 1_000;
+const userGrantRevalidationIntervalMs = 1_000;
 
 function coordinatorErrorMessage(env: Env, error: unknown): string {
   return errorMessage(error, coordinatorDiagnosticSecrets(env));
@@ -277,6 +280,13 @@ interface CachedAdminGrant {
   adminGrantVersion?: string;
 }
 
+interface CachedBridgeGrant extends CachedAdminGrant {
+  auth?: AuthContext["auth"];
+  login?: string;
+  portalSessionHash?: string;
+  githubGrant?: GitHubUserGrant;
+}
+
 interface WebVNCTicketRecord extends CachedAdminGrant {
   ticket: string;
   leaseID: string;
@@ -307,7 +317,7 @@ interface CodeTicketRecord extends CachedAdminGrant {
   expiresAt: string;
 }
 
-interface CodeViewerTicketRecord extends CachedAdminGrant {
+interface CodeViewerTicketRecord extends CachedBridgeGrant {
   ticket: string;
   leaseID: string;
   auth: AuthContext["auth"];
@@ -322,7 +332,7 @@ interface CodeViewerTicketRecord extends CachedAdminGrant {
   expiresAt: string;
 }
 
-interface CodeViewerSessionRecord extends CachedAdminGrant {
+interface CodeViewerSessionRecord extends CachedBridgeGrant {
   session: string;
   leaseID: string;
   auth: AuthContext["auth"];
@@ -428,7 +438,7 @@ interface RuntimeAdapterLegacyDeleteCompletion {
 
 type EgressRole = "host" | "client";
 
-interface EgressTicketRecord extends CachedAdminGrant {
+interface EgressTicketRecord extends CachedBridgeGrant {
   ticket: string;
   leaseID: string;
   owner: string;
@@ -716,7 +726,7 @@ interface AzureOrphanSweepRecord {
 
 type BridgeAttachment =
   | { kind: "webvnc-agent"; leaseID: string; id: string; capabilities: Set<string> }
-  | {
+  | (CachedBridgeGrant & {
       kind: "webvnc-viewer";
       leaseID: string;
       id: string;
@@ -724,14 +734,10 @@ type BridgeAttachment =
       owner: string;
       org?: string;
       admin?: boolean;
-      auth?: AuthContext["auth"];
-      login?: string;
-      adminTokenHash?: string;
-      adminGrantVersion?: string;
       label: string;
-    }
+    })
   | { kind: "code-agent"; leaseID: string }
-  | {
+  | (CachedBridgeGrant & {
       kind: "code-viewer";
       leaseID: string;
       id: string;
@@ -739,35 +745,23 @@ type BridgeAttachment =
       owner?: string;
       org?: string;
       admin?: boolean;
-      login?: string;
-      adminTokenHash?: string;
-      adminGrantVersion?: string;
-      portalSessionHash?: string;
-    }
-  | {
+    })
+  | (CachedBridgeGrant & {
       kind: "egress-host";
       leaseID: string;
       sessionID: string;
       owner?: string;
       org?: string;
       admin?: boolean;
-      auth?: AuthContext["auth"];
-      login?: string;
-      adminTokenHash?: string;
-      adminGrantVersion?: string;
-    }
-  | {
+    })
+  | (CachedBridgeGrant & {
       kind: "egress-client";
       leaseID: string;
       sessionID: string;
       owner?: string;
       org?: string;
       admin?: boolean;
-      auth?: AuthContext["auth"];
-      login?: string;
-      adminTokenHash?: string;
-      adminGrantVersion?: string;
-    }
+    })
   | {
       kind: "runtime-adapter-agent";
       adapterID: string;
@@ -805,17 +799,13 @@ interface WebVNCEvent {
   reason?: string;
 }
 
-interface WebVNCViewerSession {
+interface WebVNCViewerSession extends CachedBridgeGrant {
   id: string;
   agentID: string;
   socket: WebSocket;
   owner: string;
   org?: string;
   admin?: boolean;
-  auth?: AuthContext["auth"];
-  login?: string;
-  adminTokenHash?: string;
-  adminGrantVersion?: string;
   label: string;
   connectedAt: string;
 }
@@ -841,6 +831,7 @@ export class FleetCoordinator {
   private readonly workspaceTerminals = new Map<string, Set<WebSocket>>();
   private readonly restoredBridgeSockets = new Set<WebSocket>();
   private readonly adminGrantValidationTimes = new WeakMap<WebSocket, number>();
+  private readonly userGrantValidationTimes = new WeakMap<WebSocket, number>();
   private currentAdminGrantVersion: string | undefined;
   private bridgeRestoreReady: Promise<boolean> | undefined;
   private readyPoolBorrowQueue: Promise<void> = Promise.resolve();
@@ -1201,8 +1192,17 @@ export class FleetCoordinator {
     const revokedAdmins = new Set<WebSocket>();
     const revokedAdminEgressSessions = new Map<string, { leaseID: string; sessionID: string }>();
     const revokedViewers = new Map<WebSocket, string>();
-    const revokedEgressSessions = new Map<string, { leaseID: string; sessionID: string }>();
-    const codeViewersToCheck: Array<{ socket: WebSocket; portalSessionHash?: string }> = [];
+    const revokedEgressSessions = new Map<
+      string,
+      { leaseID: string; sessionID: string; reason: string }
+    >();
+    const githubBridgesToCheck: Array<{
+      socket: WebSocket;
+      attachment: Extract<
+        BridgeAttachment,
+        { kind: "webvnc-viewer" | "code-viewer" | "egress-host" | "egress-client" }
+      >;
+    }> = [];
     for (const socket of this.restoredBridgeSockets) {
       const attachment = this.bridgeAttachment(socket);
       if (!attachment) {
@@ -1236,29 +1236,52 @@ export class FleetCoordinator {
         revokedEgressSessions.set(egressSocketKey(lease.id, attachment.sessionID), {
           leaseID: lease.id,
           sessionID: attachment.sessionID,
+          reason: "lease access revoked",
         });
         continue;
       }
-      if (attachment.kind === "code-viewer" && attachment.auth === "github") {
-        codeViewersToCheck.push({
-          socket,
-          ...(attachment.portalSessionHash
-            ? { portalSessionHash: attachment.portalSessionHash }
-            : {}),
-        });
+      if (revocableUserBridge(attachment)) {
+        const portalRevocationCanOverrideLeaseAccess =
+          attachment.kind === "code-viewer" &&
+          attachment.auth === "github" &&
+          validPortalSessionHash(attachment.portalSessionHash);
+        if (revokedViewers.has(socket) && !portalRevocationCanOverrideLeaseAccess) {
+          continue;
+        }
+        if (attachment.auth === undefined) {
+          if (attachment.kind === "egress-host" || attachment.kind === "egress-client") {
+            revokedEgressSessions.set(egressSocketKey(lease.id, attachment.sessionID), {
+              leaseID: lease.id,
+              sessionID: attachment.sessionID,
+              reason: "bridge authentication expired",
+            });
+          } else {
+            revokedViewers.set(socket, "bridge authentication expired");
+          }
+          continue;
+        }
+        if (attachment.auth === "github" && attachment.admin !== true) {
+          githubBridgesToCheck.push({ socket, attachment });
+        }
       }
     }
-    const codeViewerRevocations = await Promise.all(
-      codeViewersToCheck.map(async ({ socket, portalSessionHash }) => ({
+    const githubBridgeRevocations = await Promise.all(
+      githubBridgesToCheck.map(async ({ socket, attachment }) => ({
         socket,
-        revoked:
-          !validPortalSessionHash(portalSessionHash) ||
-          (await this.codeViewerPortalSessionRevoked(portalSessionHash)),
+        attachment,
+        reason: await this.githubBridgeGrantFailureReason(attachment),
       })),
     );
-    for (const { socket, revoked: portalSessionRevoked } of codeViewerRevocations) {
-      if (portalSessionRevoked) {
-        revokedViewers.set(socket, "portal session ended");
+    for (const { socket, attachment, reason } of githubBridgeRevocations) {
+      if (!reason) continue;
+      if (attachment.kind === "egress-host" || attachment.kind === "egress-client") {
+        revokedEgressSessions.set(egressSocketKey(attachment.leaseID, attachment.sessionID), {
+          leaseID: attachment.leaseID,
+          sessionID: attachment.sessionID,
+          reason,
+        });
+      } else {
+        revokedViewers.set(socket, reason);
       }
     }
     for (const socket of revokedAdmins) {
@@ -1279,8 +1302,8 @@ export class FleetCoordinator {
     for (const [leaseID, reason] of revoked) {
       this.closeLeaseBridges(leaseID, 1008, reason);
     }
-    for (const { leaseID, sessionID } of revokedEgressSessions.values()) {
-      this.clearEgressSession(leaseID, sessionID, 1008, "lease access revoked");
+    for (const { leaseID, sessionID, reason } of revokedEgressSessions.values()) {
+      this.clearEgressSession(leaseID, sessionID, 1008, reason);
     }
     for (const socket of this.restoredBridgeSockets) {
       const attachment = this.bridgeAttachment(socket);
@@ -1455,6 +1478,10 @@ export class FleetCoordinator {
           ...(attachment.adminGrantVersion
             ? { adminGrantVersion: attachment.adminGrantVersion }
             : {}),
+          ...(attachment.portalSessionHash
+            ? { portalSessionHash: attachment.portalSessionHash }
+            : {}),
+          ...(attachment.githubGrant ? { githubGrant: attachment.githubGrant } : {}),
           label: attachment.label,
           connectedAt: new Date().toISOString(),
         });
@@ -1722,7 +1749,7 @@ export class FleetCoordinator {
     if (socket.readyState !== WebSocket.OPEN || !this.bridgeSocketIsCurrent(socket, attachment)) {
       return;
     }
-    if (!(await this.activeBridgeAdminGrantIsCurrent(socket, attachment))) {
+    if (!(await this.activeBridgeGrantIsCurrent(socket, attachment))) {
       return;
     }
     switch (attachment.kind) {
@@ -1799,17 +1826,34 @@ export class FleetCoordinator {
     if (
       !attachment ||
       !this.bridgeSocketIsCurrent(socket, attachment) ||
-      !(await this.activeBridgeAdminGrantIsCurrent(socket, attachment))
+      !(await this.activeBridgeGrantIsCurrent(socket, attachment))
     ) {
       return undefined;
     }
     return socket;
   }
 
-  private async activeBridgeAdminGrantIsCurrent(
+  private async activeBridgeGrantIsCurrent(
     socket: WebSocket,
     attachment: BridgeAttachment,
   ): Promise<boolean> {
+    if (
+      revocableUserBridge(attachment) &&
+      attachment.auth === "github" &&
+      attachment.admin !== true
+    ) {
+      const now = Date.now();
+      const lastValidatedAt = this.userGrantValidationTimes.get(socket) ?? 0;
+      if (now - lastValidatedAt >= userGrantRevalidationIntervalMs) {
+        const failureReason = await this.githubBridgeGrantFailureReason(attachment);
+        if (failureReason) {
+          this.userGrantValidationTimes.delete(socket);
+          this.closeRevokedUserBridge(socket, attachment, failureReason);
+          return false;
+        }
+        this.userGrantValidationTimes.set(socket, now);
+      }
+    }
     if (!("admin" in attachment) || attachment.admin !== true) {
       return true;
     }
@@ -1835,6 +1879,54 @@ export class FleetCoordinator {
     this.handleBridgeClose(socket, 1008, "admin access revoked");
     closeSocket(socket, 1008, "admin access revoked");
     return false;
+  }
+
+  private async githubBridgeGrantFailureReason(
+    attachment: CachedBridgeGrant & { owner?: string; org?: string; admin?: boolean },
+  ): Promise<string | undefined> {
+    if (
+      validPortalSessionHash(attachment.portalSessionHash) &&
+      (await this.portalSessionIsRevoked(attachment.portalSessionHash))
+    ) {
+      return "portal session ended";
+    }
+    if (
+      typeof attachment.owner !== "string" ||
+      typeof attachment.org !== "string" ||
+      typeof attachment.admin !== "boolean" ||
+      typeof attachment.login !== "string" ||
+      !validPortalSessionHash(attachment.portalSessionHash) ||
+      !attachment.githubGrant
+    ) {
+      return "user access revoked";
+    }
+    return (await githubUserGrantIsCurrent(
+      attachment.githubGrant,
+      {
+        owner: attachment.owner,
+        org: attachment.org,
+        login: attachment.login,
+      },
+      this.env,
+    ))
+      ? undefined
+      : "user access revoked";
+  }
+
+  private closeRevokedUserBridge(
+    socket: WebSocket,
+    attachment: Extract<
+      BridgeAttachment,
+      { kind: "webvnc-viewer" | "code-viewer" | "egress-host" | "egress-client" }
+    >,
+    reason: string,
+  ): void {
+    if (attachment.kind === "egress-host" || attachment.kind === "egress-client") {
+      this.clearEgressSession(attachment.leaseID, attachment.sessionID, 1008, reason);
+      return;
+    }
+    this.handleBridgeClose(socket, 1008, reason);
+    closeSocket(socket, 1008, reason);
   }
 
   private handleBridgeClose(socket: WebSocket, code: number, reason: string): void {
@@ -6542,6 +6634,13 @@ export class FleetCoordinator {
         { status: 400 },
       );
     }
+    const bridgeGrant = await bridgeGrantForRequest(request, admin);
+    if (!bridgeGrant) {
+      return json(
+        { error: "user_session_invalid", message: "GitHub user session cannot be revalidated" },
+        { status: 401 },
+      );
+    }
     await this.cleanupExpiredEgressTickets();
     const now = new Date();
     const requestedSessionID = input.sessionID ?? input.sessionId;
@@ -6554,7 +6653,7 @@ export class FleetCoordinator {
       owner: requestOwner(request),
       org: requestOrg(request, this.env),
       admin,
-      ...(await adminGrantForRequest(request, admin)),
+      ...bridgeGrant,
       role,
       sessionID,
       allow: boundedEgressAllowlist(input.allow),
@@ -7741,6 +7840,12 @@ export class FleetCoordinator {
         owner: session.owner,
         org: session.org,
         ...(session.login ? { login: session.login } : {}),
+        ...(session.githubGrant
+          ? {
+              githubGrant: session.githubGrant,
+              tokenExpiresAt: session.githubGrant.expiresAt,
+            }
+          : {}),
       });
     }
     const lease = await this.resolvePortalLease(identifier, authorizedRequest);
@@ -7774,38 +7879,16 @@ export class FleetCoordinator {
       return portalCode(lease);
     }
     if (request.headers.get("upgrade")?.toLowerCase() === "websocket") {
-      const auth = viewerSession?.auth ?? requestAuthType(authorizedRequest);
-      const adminGrant: CachedAdminGrant = viewerSession
-        ? {
-            auth: viewerSession.auth,
-            ...(viewerSession.login ? { login: viewerSession.login } : {}),
-            ...(viewerSession.adminTokenHash
-              ? { adminTokenHash: viewerSession.adminTokenHash }
-              : {}),
-            ...(viewerSession.adminGrantVersion
-              ? { adminGrantVersion: viewerSession.adminGrantVersion }
-              : {}),
-          }
-        : await adminGrantForRequest(authorizedRequest, isAdminRequest(authorizedRequest));
-      let portalSessionHash = viewerSession?.portalSessionHash;
-      if (auth === "github" && !portalSessionHash) {
-        const token = bearerToken(authorizedRequest);
-        if (!token) {
-          return json(
-            { error: "code_viewer_session_revoked", message: "Code viewer session has ended" },
-            { status: 401, headers: { "cache-control": "no-store" } },
-          );
-        }
-        portalSessionHash = await sha256Hex(token);
+      const bridgeGrant = viewerSession
+        ? copyBridgeGrant(viewerSession)
+        : await bridgeGrantForRequest(authorizedRequest, isAdminRequest(authorizedRequest));
+      if (!bridgeGrant) {
+        return json(
+          { error: "code_viewer_session_revoked", message: "Code viewer session has ended" },
+          { status: 401, headers: { "cache-control": "no-store" } },
+        );
       }
-      return await this.codeViewerWebSocket(
-        authorizedRequest,
-        lease,
-        agent,
-        auth,
-        adminGrant,
-        portalSessionHash,
-      );
+      return await this.codeViewerWebSocket(authorizedRequest, lease, agent, bridgeGrant);
     }
     return await this.codeProxyHTTP(authorizedRequest, lease, agent);
   }
@@ -7819,37 +7902,31 @@ export class FleetCoordinator {
     const now = new Date();
     const auth = requestAuthType(request);
     const admin = isAdminRequest(request);
-    let portalSessionHash: string | undefined;
-    if (auth === "github") {
-      const token = bearerToken(request);
-      if (!token) {
-        return portalError("Code session ended", "Log in again to open Code.", 401);
-      }
-      portalSessionHash = await sha256Hex(token);
-      if (await this.codeViewerPortalSessionRevoked(portalSessionHash)) {
-        return portalError("Code session ended", "Log in again to open Code.", 401);
-      }
+    const bridgeGrant = await bridgeGrantForRequest(request, admin);
+    if (!bridgeGrant) {
+      return portalError("Code session ended", "Log in again to open Code.", 401);
+    }
+    if (
+      bridgeGrant.portalSessionHash &&
+      (await this.portalSessionIsRevoked(bridgeGrant.portalSessionHash))
+    ) {
+      return portalError("Code session ended", "Log in again to open Code.", 401);
     }
     const ticket: CodeViewerTicketRecord = {
       ticket: newCodeViewerTicket(),
       leaseID: lease.id,
       auth,
       admin,
-      ...(await adminGrantForRequest(request, admin)),
+      ...bridgeGrant,
       owner: requestOwner(request),
       org: requestOrg(request, this.env),
       returnTo: canonicalCodeReturnTo(request, lease.id),
       createdAt: now.toISOString(),
       expiresAt: new Date(now.getTime() + codeViewerTicketTTLSeconds * 1000).toISOString(),
     };
-    if (portalSessionHash) {
-      ticket.portalSessionHash = portalSessionHash;
-    }
-    const login = request.headers.get("x-crabbox-github-login")?.trim();
-    if (login) {
-      ticket.login = login;
-    }
-    const tokenExpiresAt = request.headers.get("x-crabbox-token-expires-at")?.trim();
+    const tokenExpiresAt =
+      bridgeGrant.githubGrant?.expiresAt ??
+      request.headers.get("x-crabbox-token-expires-at")?.trim();
     if (tokenExpiresAt && Number.isFinite(Date.parse(tokenExpiresAt))) {
       ticket.viewerExpiresAt = new Date(tokenExpiresAt).toISOString();
     }
@@ -7885,8 +7962,7 @@ export class FleetCoordinator {
     }
     if (
       (ticket.auth === "github" && !validPortalSessionHash(ticket.portalSessionHash)) ||
-      (ticket.portalSessionHash &&
-        (await this.codeViewerPortalSessionRevoked(ticket.portalSessionHash)))
+      (ticket.portalSessionHash && (await this.portalSessionIsRevoked(ticket.portalSessionHash)))
     ) {
       return json(
         { error: "code_viewer_session_revoked", message: "Code viewer session has ended" },
@@ -7906,21 +7982,10 @@ export class FleetCoordinator {
       admin: ticket.admin,
       owner: ticket.owner,
       org: ticket.org,
+      ...copyBridgeGrant(ticket),
       createdAt: now.toISOString(),
       expiresAt: new Date(expiresAt).toISOString(),
     };
-    if (ticket.login) {
-      session.login = ticket.login;
-    }
-    if (ticket.adminTokenHash) {
-      session.adminTokenHash = ticket.adminTokenHash;
-    }
-    if (ticket.adminGrantVersion) {
-      session.adminGrantVersion = ticket.adminGrantVersion;
-    }
-    if (ticket.portalSessionHash) {
-      session.portalSessionHash = ticket.portalSessionHash;
-    }
     await this.state.storage.put(codeViewerSessionKey(session.session), session);
     return new Response(null, {
       status: 303,
@@ -7954,7 +8019,8 @@ export class FleetCoordinator {
       Date.parse(session.expiresAt) <= Date.now() ||
       (session.auth === "github" && !validPortalSessionHash(session.portalSessionHash)) ||
       (session.portalSessionHash &&
-        (await this.codeViewerPortalSessionRevoked(session.portalSessionHash)))
+        (await this.portalSessionIsRevoked(session.portalSessionHash))) ||
+      (session.auth === "github" && (await this.githubBridgeGrantFailureReason(session)))
     ) {
       if (session) {
         await this.state.storage.delete(codeViewerSessionKey(value));
@@ -8063,14 +8129,14 @@ export class FleetCoordinator {
               expiresAt: new Date(expiresAt).toISOString(),
             },
           );
-          this.closeCodeViewersForPortalSession(portalSessionHash);
+          this.closeBridgesForPortalSession(portalSessionHash);
         });
       }
     }
     return githubPortalLogout();
   }
 
-  private async codeViewerPortalSessionRevoked(portalSessionHash: string): Promise<boolean> {
+  private async portalSessionIsRevoked(portalSessionHash: string): Promise<boolean> {
     const key = codeViewerSessionRevocationKey(portalSessionHash);
     const revocation = await this.state.storage.get<CodeViewerSessionRevocationRecord>(key);
     if (!revocation || revocation.portalSessionHash !== portalSessionHash) {
@@ -8146,9 +8212,7 @@ export class FleetCoordinator {
     request: Request,
     lease: LeaseRecord,
     agent: WebSocket,
-    auth: AuthContext["auth"],
-    adminGrant: CachedAdminGrant,
-    portalSessionHash?: string,
+    bridgeGrant: CachedBridgeGrant,
   ): Promise<Response> {
     return await this.withBridgeTicketLock(async () => {
       const currentLease = await this.resolvePortalLease(lease.id, request);
@@ -8156,8 +8220,10 @@ export class FleetCoordinator {
         return notFound();
       }
       if (
-        (auth === "github" && !validPortalSessionHash(portalSessionHash)) ||
-        (portalSessionHash && (await this.codeViewerPortalSessionRevoked(portalSessionHash)))
+        (bridgeGrant.auth === "github" &&
+          (!validPortalSessionHash(bridgeGrant.portalSessionHash) || !bridgeGrant.githubGrant)) ||
+        (bridgeGrant.portalSessionHash &&
+          (await this.portalSessionIsRevoked(bridgeGrant.portalSessionHash)))
       ) {
         return json(
           { error: "code_viewer_session_revoked", message: "Code viewer session has ended" },
@@ -8172,12 +8238,11 @@ export class FleetCoordinator {
         kind: "code-viewer",
         leaseID: lease.id,
         id,
-        auth,
+        auth: bridgeGrant.auth ?? requestAuthType(request),
         owner: requestOwner(request),
         org: requestOrg(request, this.env),
         admin: isAdminRequest(request),
-        ...adminGrant,
-        ...(portalSessionHash ? { portalSessionHash } : {}),
+        ...bridgeGrant,
       });
       const url = new URL(request.url);
       const open: CodeWebSocketOpen = {
@@ -8359,7 +8424,20 @@ export class FleetCoordinator {
     }
   }
 
-  private closeCodeViewersForPortalSession(portalSessionHash: string): void {
+  private closeBridgesForPortalSession(portalSessionHash: string): void {
+    for (const [leaseID, viewers] of this.webVNCViewers) {
+      for (const [id, viewer] of viewers) {
+        const attachment = this.bridgeAttachment(viewer.socket);
+        if (
+          attachment?.kind !== "webvnc-viewer" ||
+          attachment.portalSessionHash !== portalSessionHash
+        ) {
+          continue;
+        }
+        this.clearWebVNCViewer(leaseID, id, viewer.socket);
+        closeSocket(viewer.socket, 1008, "portal session ended");
+      }
+    }
     for (const [id, viewer] of this.codeViewers) {
       const attachment = this.bridgeAttachment(viewer);
       if (
@@ -8370,6 +8448,23 @@ export class FleetCoordinator {
       }
       this.clearCodeViewer(attachment.leaseID, id, viewer, 1008, "portal session ended");
       closeSocket(viewer, 1008, "portal session ended");
+    }
+    const egressSessions = new Map<string, { leaseID: string; sessionID: string }>();
+    for (const socket of [...this.egressHosts.values(), ...this.egressClients.values()]) {
+      const attachment = this.bridgeAttachment(socket);
+      if (
+        (attachment?.kind !== "egress-host" && attachment?.kind !== "egress-client") ||
+        attachment.portalSessionHash !== portalSessionHash
+      ) {
+        continue;
+      }
+      egressSessions.set(egressSocketKey(attachment.leaseID, attachment.sessionID), {
+        leaseID: attachment.leaseID,
+        sessionID: attachment.sessionID,
+      });
+    }
+    for (const { leaseID, sessionID } of egressSessions.values()) {
+      this.clearEgressSession(leaseID, sessionID, 1008, "portal session ended");
     }
   }
 
@@ -8482,6 +8577,25 @@ export class FleetCoordinator {
       if (error) {
         return json({ error: "webvnc_unavailable", message: error }, { status: 409 });
       }
+      const admin = isAdminRequest(request);
+      const bridgeGrant = await bridgeGrantForRequest(request, admin);
+      if (!bridgeGrant) {
+        return json(
+          { error: "user_session_invalid", message: "GitHub user session cannot be revalidated" },
+          { status: 401 },
+        );
+      }
+      const owner = requestOwner(request);
+      const org = requestOrg(request, this.env);
+      if (
+        bridgeGrant.auth === "github" &&
+        (await this.githubBridgeGrantFailureReason({ ...bridgeGrant, owner, org, admin }))
+      ) {
+        return json(
+          { error: "user_session_invalid", message: "GitHub user session cannot be revalidated" },
+          { status: 401 },
+        );
+      }
       const agent = this.claimIdleWebVNCAgent(lease.id);
       if (!agent) {
         const canManage = this.leaseManageableByRequest(lease, request, isAdminRequest(request));
@@ -8505,10 +8619,6 @@ export class FleetCoordinator {
 
       const upgrade = this.state.createWebSocketUpgrade();
       const viewer = upgrade.socket;
-      const owner = requestOwner(request);
-      const org = requestOrg(request, this.env);
-      const admin = isAdminRequest(request);
-      const adminGrant = await adminGrantForRequest(request, admin);
       const label = webVNCViewerLabel(owner);
 
       this.trackWebVNCViewer(lease.id, {
@@ -8518,7 +8628,7 @@ export class FleetCoordinator {
         owner,
         org,
         admin,
-        ...adminGrant,
+        ...bridgeGrant,
         label,
         connectedAt: new Date().toISOString(),
       });
@@ -8535,7 +8645,7 @@ export class FleetCoordinator {
         owner,
         org,
         admin,
-        ...adminGrant,
+        ...bridgeGrant,
         label,
       });
       flushPendingWebVNC(this.pendingWebVNCToViewer, webVNCBufferKey(lease.id, agent.id), viewer);
@@ -8909,6 +9019,13 @@ export class FleetCoordinator {
         ? withCurrentAdminGrant(ticket, await this.currentAdminGrantValidation())
         : ticket;
     if (!this.leaseManagerAuthorized(lease, leaseBridgeTicketPrincipal(currentTicket))) {
+      await this.state.storage.delete(key);
+      return { status: "invalid" };
+    }
+    if (
+      currentTicket.auth === "github" &&
+      (await this.githubBridgeGrantFailureReason(currentTicket))
+    ) {
       await this.state.storage.delete(key);
       return { status: "invalid" };
     }
@@ -11810,7 +11927,7 @@ export class FleetCoordinator {
         continue;
       }
       // oxlint-disable-next-line eslint/no-await-in-loop -- validate each control before its event can be sent.
-      if (!(await this.activeBridgeAdminGrantIsCurrent(socket, attachment))) {
+      if (!(await this.activeBridgeGrantIsCurrent(socket, attachment))) {
         continue;
       }
       const after = attachment.subscriptions?.[run.id];
@@ -13909,6 +14026,57 @@ async function adminGrantForRequest(request: Request, admin: boolean): Promise<C
   return { auth, ...(adminGrantVersion ? { adminGrantVersion } : {}) };
 }
 
+async function bridgeGrantForRequest(
+  request: Request,
+  admin: boolean,
+): Promise<CachedBridgeGrant | undefined> {
+  const auth = requestAuthType(request);
+  const adminGrant = await adminGrantForRequest(request, admin);
+  if (!request.headers.has("x-crabbox-auth")) {
+    return adminGrant;
+  }
+  if (auth !== "github") {
+    return { auth, ...adminGrant };
+  }
+  const token = bearerToken(request);
+  const login = request.headers.get("x-crabbox-github-login")?.trim();
+  const tokenID = request.headers.get("x-crabbox-github-token-id")?.trim();
+  const sealedCredential = request.headers.get("x-crabbox-github-sealed-credential")?.trim();
+  const expiresAt = request.headers.get("x-crabbox-token-expires-at")?.trim();
+  if (
+    !token ||
+    !login ||
+    !tokenID ||
+    !sealedCredential ||
+    !expiresAt ||
+    !Number.isFinite(Date.parse(expiresAt))
+  ) {
+    return undefined;
+  }
+  return {
+    auth,
+    login,
+    ...adminGrant,
+    portalSessionHash: await sha256Hex(token),
+    githubGrant: {
+      tokenID,
+      sealedCredential,
+      expiresAt: new Date(expiresAt).toISOString(),
+    },
+  };
+}
+
+function copyBridgeGrant(principal: CachedBridgeGrant): CachedBridgeGrant {
+  return {
+    ...(principal.auth ? { auth: principal.auth } : {}),
+    ...(principal.login ? { login: principal.login } : {}),
+    ...(principal.adminTokenHash ? { adminTokenHash: principal.adminTokenHash } : {}),
+    ...(principal.adminGrantVersion ? { adminGrantVersion: principal.adminGrantVersion } : {}),
+    ...(principal.portalSessionHash ? { portalSessionHash: principal.portalSessionHash } : {}),
+    ...(principal.githubGrant ? { githubGrant: principal.githubGrant } : {}),
+  };
+}
+
 type AdminGrantEnv = Pick<
   Env,
   "CRABBOX_ADMIN_TOKEN" | "CRABBOX_GITHUB_ADMIN_OWNERS" | "CRABBOX_GITHUB_ADMIN_LOGINS"
@@ -14715,6 +14883,20 @@ function completeBridgePrincipal(value: {
   );
 }
 
+function revocableUserBridge(
+  attachment: BridgeAttachment,
+): attachment is Extract<
+  BridgeAttachment,
+  { kind: "webvnc-viewer" | "code-viewer" | "egress-host" | "egress-client" }
+> {
+  return (
+    attachment.kind === "webvnc-viewer" ||
+    attachment.kind === "code-viewer" ||
+    attachment.kind === "egress-host" ||
+    attachment.kind === "egress-client"
+  );
+}
+
 function validOptionalEgressBridgePrincipal(value: {
   owner?: unknown;
   org?: unknown;
@@ -14725,8 +14907,8 @@ function validOptionalEgressBridgePrincipal(value: {
 }
 
 function leaseBridgeTicketPrincipal(
-  ticket: CachedAdminGrant & { owner: string; org: string; admin?: boolean },
-): CachedAdminGrant & {
+  ticket: CachedBridgeGrant & { owner: string; org: string; admin?: boolean },
+): CachedBridgeGrant & {
   owner: string;
   org: string;
   admin: boolean;
@@ -14739,6 +14921,8 @@ function leaseBridgeTicketPrincipal(
     ...(ticket.login ? { login: ticket.login } : {}),
     ...(ticket.adminTokenHash ? { adminTokenHash: ticket.adminTokenHash } : {}),
     ...(ticket.adminGrantVersion ? { adminGrantVersion: ticket.adminGrantVersion } : {}),
+    ...(ticket.portalSessionHash ? { portalSessionHash: ticket.portalSessionHash } : {}),
+    ...(ticket.githubGrant ? { githubGrant: ticket.githubGrant } : {}),
   };
 }
 

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -354,6 +354,238 @@ describe("runtime adapter relay", () => {
     expect(internal.codeViewers.has("code-rotated-admin")).toBe(false);
   });
 
+  it("fails closed active non-admin GitHub WebVNC and egress bridges after revocation", async () => {
+    const env = {
+      CRABBOX_SESSION_SECRET: "session-secret",
+      CRABBOX_DEFAULT_ORG: "example-org",
+      CRABBOX_GITHUB_REVOKED_USERS: "login:alice",
+    } as Env;
+    const token = await issueUserToken(env, {
+      owner: "alice@example.com",
+      ownerSource: "github-verified-email",
+      org: "example-org",
+      login: "alice",
+      githubAccessToken: "github-access-token",
+    });
+    const payload = decodeUserTokenPayload(token);
+    const portalSessionHash = await sha256Hex(token);
+    const grant = {
+      auth: "github" as const,
+      owner: "alice@example.com",
+      org: "example-org",
+      admin: false,
+      login: "alice",
+      portalSessionHash,
+      githubGrant: {
+        tokenID: payload.jti,
+        sealedCredential: payload.githubCredential,
+        expiresAt: new Date(payload.exp * 1000).toISOString(),
+      },
+    };
+    const fleet = testFleet(new MemoryStorage(), {}, env);
+    const leaseID = "cbx_000000000001";
+    const webAgent = new FakeWebSocket({
+      kind: "webvnc-agent",
+      leaseID,
+      id: "agent_revoked_user",
+      capabilities: new Set<string>(),
+    });
+    const webViewer = new FakeWebSocket({
+      kind: "webvnc-viewer",
+      leaseID,
+      id: "viewer_revoked_user",
+      agentID: "agent_revoked_user",
+      ...grant,
+      label: "alice",
+    });
+    const egressHost = new FakeWebSocket({
+      kind: "egress-host",
+      leaseID,
+      sessionID: "egress_revoked_user",
+      ...grant,
+    });
+    const egressClient = new FakeWebSocket({
+      kind: "egress-client",
+      leaseID,
+      sessionID: "egress_revoked_user",
+      ...grant,
+    });
+    const internal = fleet as unknown as {
+      env: Env;
+      webVNCAgents: Map<string, Map<string, WebSocket>>;
+      webVNCViewers: Map<
+        string,
+        Map<
+          string,
+          {
+            id: string;
+            agentID: string;
+            socket: WebSocket;
+            owner: string;
+            org: string;
+            admin: boolean;
+            auth: "github";
+            login: string;
+            portalSessionHash: string;
+            githubGrant: typeof grant.githubGrant;
+            label: string;
+            connectedAt: string;
+          }
+        >
+      >;
+      egressHosts: Map<string, WebSocket>;
+      egressClients: Map<string, WebSocket>;
+    };
+    internal.webVNCAgents.set(
+      leaseID,
+      new Map([["agent_revoked_user", webAgent as unknown as WebSocket]]),
+    );
+    internal.webVNCViewers.set(
+      leaseID,
+      new Map([
+        [
+          "viewer_revoked_user",
+          {
+            id: "viewer_revoked_user",
+            agentID: "agent_revoked_user",
+            socket: webViewer as unknown as WebSocket,
+            ...grant,
+            label: "alice",
+            connectedAt: new Date().toISOString(),
+          },
+        ],
+      ]),
+    );
+    internal.egressHosts.set(
+      `${leaseID}\u0000egress_revoked_user`,
+      egressHost as unknown as WebSocket,
+    );
+    internal.egressClients.set(
+      `${leaseID}\u0000egress_revoked_user`,
+      egressClient as unknown as WebSocket,
+    );
+    const githubFetch = vi.fn<() => Promise<Response>>(async () => {
+      throw new Error("revoked users must fail before GitHub API access");
+    });
+    vi.stubGlobal("fetch", githubFetch);
+
+    await fleet.webSocketMessage(webViewer as unknown as WebSocket, "vnc-frame");
+    await fleet.webSocketMessage(egressHost as unknown as WebSocket, "egress-frame");
+
+    expect(webViewer.closeCode).toBe(1008);
+    expect(webViewer.closeReason).toBe("user access revoked");
+    expect(webAgent.closeCode).toBe(1011);
+    expect(egressHost.closeCode).toBe(1008);
+    expect(egressHost.closeReason).toBe("user access revoked");
+    expect(egressClient.closeCode).toBe(1008);
+    expect(egressClient.closeReason).toBe("user access revoked");
+    expect(githubFetch).not.toHaveBeenCalled();
+
+    internal.env.CRABBOX_GITHUB_REVOKED_USERS = undefined;
+    const membershipFailureHost = new FakeWebSocket({
+      kind: "egress-host",
+      leaseID,
+      sessionID: "egress_membership_failure",
+      ...grant,
+    });
+    const membershipFailureClient = new FakeWebSocket({
+      kind: "egress-client",
+      leaseID,
+      sessionID: "egress_membership_failure",
+      ...grant,
+    });
+    internal.egressHosts.set(
+      `${leaseID}\u0000egress_membership_failure`,
+      membershipFailureHost as unknown as WebSocket,
+    );
+    internal.egressClients.set(
+      `${leaseID}\u0000egress_membership_failure`,
+      membershipFailureClient as unknown as WebSocket,
+    );
+
+    await fleet.webSocketMessage(membershipFailureHost as unknown as WebSocket, "egress-frame");
+
+    expect(membershipFailureHost.closeCode).toBe(1008);
+    expect(membershipFailureHost.closeReason).toBe("user access revoked");
+    expect(membershipFailureClient.closeCode).toBe(1008);
+    expect(membershipFailureClient.closeReason).toBe("user access revoked");
+    expect(githubFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a WebVNC upgrade revoked before its buffered desktop frames flush", async () => {
+    const storage = new MemoryStorage();
+    const env = {
+      CRABBOX_SESSION_SECRET: "session-secret",
+      CRABBOX_DEFAULT_ORG: "example-org",
+    } as Env;
+    const token = await issueUserToken(env, {
+      owner: "alice@example.com",
+      ownerSource: "github-verified-email",
+      org: "example-org",
+      login: "alice",
+      githubAccessToken: "github-access-token",
+    });
+    const payload = decodeUserTokenPayload(token);
+    const portalSessionHash = await sha256Hex(token);
+    const leaseID = "cbx_000000000001";
+    const agentID = "agent_logout_race";
+    storage.seed(
+      `lease:${leaseID}`,
+      testLease({
+        id: leaseID,
+        owner: "alice@example.com",
+        org: "example-org",
+        desktop: true,
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      }),
+    );
+    storage.seed(`code-viewer-session-revocation:${portalSessionHash}`, {
+      portalSessionHash,
+      createdAt: new Date().toISOString(),
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    const fleet = testFleet(storage, {}, env);
+    const agent = new FakeWebSocket({
+      kind: "webvnc-agent",
+      leaseID,
+      id: agentID,
+      capabilities: new Set<string>(),
+    });
+    const internal = fleet as unknown as {
+      webVNCAgents: Map<string, Map<string, WebSocket>>;
+      webVNCViewers: Map<string, Map<string, unknown>>;
+      pendingWebVNCToViewer: Map<string, { chunks: Array<string | ArrayBuffer>; bytes: number }>;
+    };
+    internal.webVNCAgents.set(leaseID, new Map([[agentID, agent as unknown as WebSocket]]));
+    internal.pendingWebVNCToViewer.set(`${leaseID}:${agentID}`, {
+      chunks: ["buffered-desktop-frame"],
+      bytes: 22,
+    });
+
+    const response = await fleet.fetch(
+      request("GET", `/portal/leases/${leaseID}/vnc/viewer`, {
+        headers: {
+          authorization: `Bearer ${token}`,
+          upgrade: "websocket",
+          "x-crabbox-auth": "github",
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
+          "x-crabbox-github-login": "alice",
+          "x-crabbox-github-token-id": payload.jti,
+          "x-crabbox-github-sealed-credential": payload.githubCredential,
+          "x-crabbox-token-expires-at": new Date(payload.exp * 1000).toISOString(),
+        },
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(agent.closeCode).toBeUndefined();
+    expect(internal.webVNCViewers.size).toBe(0);
+    expect(internal.pendingWebVNCToViewer.get(`${leaseID}:${agentID}`)?.chunks).toEqual([
+      "buffered-desktop-frame",
+    ]);
+  });
+
   it("restores unambiguous hibernated bridge sockets after validating lease state", async () => {
     const storage = new MemoryStorage();
     const list = vi.spyOn(storage, "list");
@@ -701,7 +933,7 @@ describe("runtime adapter relay", () => {
     expect(viewer.closeCode).toBe(1008);
     expect(viewer.closeReason).toBe("portal session ended");
     expect(legacyViewer.closeCode).toBe(1008);
-    expect(legacyViewer.closeReason).toBe("portal session ended");
+    expect(legacyViewer.closeReason).toBe("lease access revoked");
     expect(agent.sentJSON()).toEqual([
       {
         type: "ws_close",
@@ -713,7 +945,7 @@ describe("runtime adapter relay", () => {
         type: "ws_close",
         id: "viewer-legacy",
         code: 1008,
-        reason: "portal session ended",
+        reason: "lease access revoked",
       },
     ]);
     const relay = fleet as unknown as { codeViewers: Map<string, WebSocket> };
@@ -831,12 +1063,13 @@ describe("runtime adapter relay", () => {
     expect(revokedCodeViewer.closeReason).toBe("lease access revoked");
     expect(ownerCodeViewer.closeCode).toBeUndefined();
     expect(legacyCodeViewer.closeCode).toBe(1008);
-    expect(legacyCodeViewer.closeReason).toBe("lease access revoked");
+    expect(legacyCodeViewer.closeReason).toBe("user access revoked");
     expect(revokedWebViewer.closeCode).toBe(1008);
     expect(revokedWebViewer.closeReason).toBe("lease access revoked");
     expect(revokedWebAgent.closeCode).toBe(1011);
-    expect(retainedWebViewer.closeCode).toBeUndefined();
-    expect(retainedWebAgent.closeCode).toBeUndefined();
+    expect(retainedWebViewer.closeCode).toBe(1008);
+    expect(retainedWebViewer.closeReason).toBe("bridge authentication expired");
+    expect(retainedWebAgent.closeCode).toBe(1011);
     expect(legacyOwnerWebViewer.closeCode).toBe(1008);
     expect(legacyOwnerWebViewer.closeReason).toBe("lease access revoked");
     expect(legacyOwnerWebAgent.closeCode).toBe(1011);
@@ -851,7 +1084,7 @@ describe("runtime adapter relay", () => {
         type: "ws_close",
         id: "code-legacy",
         code: 1008,
-        reason: "lease access revoked",
+        reason: "user access revoked",
       },
     ]);
   });
@@ -15832,7 +16065,7 @@ describe("fleet lease identity and idle", () => {
     const tokenExpiresAt = new Date(Date.now() + 5 * 60 * 1000).toISOString();
     const headers = {
       authorization: "Bearer portal-session-token",
-      "x-crabbox-auth": "github",
+      "x-crabbox-auth": "bearer",
       "x-crabbox-owner": "alice@example.com",
       "x-crabbox-org": "example-org",
       "x-crabbox-github-login": "alice",
@@ -15957,7 +16190,7 @@ describe("fleet lease identity and idle", () => {
     const storage = new MemoryStorage();
     const env = {
       CRABBOX_CODE_ORIGIN_TEMPLATE: "https://{lease}.code.example.test",
-      CRABBOX_GITHUB_ADMIN_LOGINS: "current-admin",
+      CRABBOX_ADMIN_TOKEN: "current-admin-token",
     };
     const fleet = testFleet(storage, {}, env);
     const leaseID = "cbx_000000000001";
@@ -15975,11 +16208,11 @@ describe("fleet lease identity and idle", () => {
     const isolatedOrigin = await codeOriginForLease(env, leaseID);
     expect(isolatedOrigin).toBeDefined();
     const staleGrant = {
-      auth: "github",
+      auth: "bearer",
       admin: true,
       owner: "former-admin@example.com",
       org: "other-org",
-      login: "former-admin",
+      adminTokenHash: await sha256Hex("former-admin-token"),
       portalSessionHash: "a".repeat(64),
       createdAt: new Date().toISOString(),
       expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
@@ -16052,12 +16285,14 @@ describe("fleet lease identity and idle", () => {
       githubAccessToken: "github-access-token",
       ttlSeconds: 60 * 60,
     });
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () => {
-        throw new Error("GitHub unavailable during logout");
-      }),
+    const githubFetch = vi.fn<() => Promise<Response>>(
+      async () =>
+        new Response(JSON.stringify({ state: "active", organization: { login: "example-org" } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
     );
+    vi.stubGlobal("fetch", githubFetch);
     const portalCookie = `crabbox_session=${encodeURIComponent(token)}`;
     const throughCoordinator = async (input: Request): Promise<Response> =>
       await routeCoordinatorRequest(input, env, async (prepared) => await fleet.fetch(prepared), {
@@ -16090,6 +16325,7 @@ describe("fleet lease identity and idle", () => {
       new Request(isolatedPage, { headers: { cookie: codeCookie } }),
     );
     expect(page.status).toBe(200);
+    githubFetch.mockRejectedValue(new Error("GitHub unavailable during logout"));
 
     const activeViewerID = "active-code-viewer";
     const portalSessionHash = await sha256Hex(token);
@@ -16101,12 +16337,103 @@ describe("fleet lease identity and idle", () => {
       auth: "github",
       portalSessionHash,
     });
+    const activeWebAgent = new FakeWebSocket({
+      kind: "webvnc-agent",
+      leaseID,
+      id: "agent_active",
+      capabilities: new Set<string>(),
+    });
+    const activeWebViewer = new FakeWebSocket({
+      kind: "webvnc-viewer",
+      leaseID,
+      id: "viewer_active",
+      agentID: "agent_active",
+      owner: "alice@example.com",
+      org: "example-org",
+      admin: false,
+      auth: "github",
+      login: "alice",
+      portalSessionHash,
+      label: "alice",
+    });
+    const activeEgressHost = new FakeWebSocket({
+      kind: "egress-host",
+      leaseID,
+      sessionID: "active-egress-session",
+      owner: "alice@example.com",
+      org: "example-org",
+      admin: false,
+      auth: "github",
+      login: "alice",
+      portalSessionHash,
+    });
+    const activeEgressClient = new FakeWebSocket({
+      kind: "egress-client",
+      leaseID,
+      sessionID: "active-egress-session",
+      owner: "alice@example.com",
+      org: "example-org",
+      admin: false,
+      auth: "github",
+      login: "alice",
+      portalSessionHash,
+    });
     const codeBridgeState = fleet as unknown as {
       codeAgents: Map<string, WebSocket>;
       codeViewers: Map<string, WebSocket>;
+      webVNCAgents: Map<string, Map<string, WebSocket>>;
+      webVNCViewers: Map<
+        string,
+        Map<
+          string,
+          {
+            id: string;
+            agentID: string;
+            socket: WebSocket;
+            owner: string;
+            org: string;
+            admin: boolean;
+            auth: "github";
+            login: string;
+            portalSessionHash: string;
+            label: string;
+            connectedAt: string;
+          }
+        >
+      >;
+      egressHosts: Map<string, WebSocket>;
+      egressClients: Map<string, WebSocket>;
     };
     codeBridgeState.codeAgents.set(leaseID, activeAgent as unknown as WebSocket);
     codeBridgeState.codeViewers.set(activeViewerID, activeViewer as unknown as WebSocket);
+    codeBridgeState.webVNCAgents.set(
+      leaseID,
+      new Map([["agent_active", activeWebAgent as unknown as WebSocket]]),
+    );
+    codeBridgeState.webVNCViewers.set(
+      leaseID,
+      new Map([
+        [
+          "viewer_active",
+          {
+            id: "viewer_active",
+            agentID: "agent_active",
+            socket: activeWebViewer as unknown as WebSocket,
+            owner: "alice@example.com",
+            org: "example-org",
+            admin: false,
+            auth: "github",
+            login: "alice",
+            portalSessionHash,
+            label: "alice",
+            connectedAt: new Date().toISOString(),
+          },
+        ],
+      ]),
+    );
+    const egressKey = `${leaseID}\u0000active-egress-session`;
+    codeBridgeState.egressHosts.set(egressKey, activeEgressHost as unknown as WebSocket);
+    codeBridgeState.egressClients.set(egressKey, activeEgressClient as unknown as WebSocket);
 
     const expiredRevocationKey = `code-viewer-session-revocation:${"f".repeat(64)}`;
     storage.seed(expiredRevocationKey, {
@@ -16123,6 +16450,9 @@ describe("fleet lease identity and idle", () => {
     expect(crossSiteNavigation.headers.get("set-cookie")).toBeNull();
     expect(await crossSiteNavigation.text()).toContain('method="post"');
     expect(activeViewer.closeCode).toBeUndefined();
+    expect(activeWebViewer.closeCode).toBeUndefined();
+    expect(activeEgressHost.closeCode).toBeUndefined();
+    expect(activeEgressClient.closeCode).toBeUndefined();
 
     const logout = await throughCoordinator(
       new Request("https://crabbox.test/portal/logout", {
@@ -16136,6 +16466,13 @@ describe("fleet lease identity and idle", () => {
     expect(storage.value(expiredRevocationKey)).toBeUndefined();
     expect(activeViewer.closeCode).toBe(1008);
     expect(activeViewer.closeReason).toBe("portal session ended");
+    expect(activeWebViewer.closeCode).toBe(1008);
+    expect(activeWebViewer.closeReason).toBe("portal session ended");
+    expect(activeWebAgent.closeCode).toBe(1011);
+    expect(activeEgressHost.closeCode).toBe(1008);
+    expect(activeEgressHost.closeReason).toBe("portal session ended");
+    expect(activeEgressClient.closeCode).toBe(1008);
+    expect(activeEgressClient.closeReason).toBe("portal session ended");
     expect(activeAgent.sentJSON()).toEqual([
       {
         type: "ws_close",
@@ -23117,9 +23454,19 @@ async function sha256HexForTest(value: string): Promise<string> {
   return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
 }
 
-function decodeUserTokenPayload(token: string): { exp: number; iat: number } {
+function decodeUserTokenPayload(token: string): {
+  exp: number;
+  iat: number;
+  jti: string;
+  githubCredential: string;
+} {
   expect(token).toMatch(/^cbxu_/);
   const [payload] = token.slice("cbxu_".length).split(".");
   const decoded = Buffer.from(payload, "base64url").toString("utf8");
-  return JSON.parse(decoded) as { exp: number; iat: number };
+  return JSON.parse(decoded) as {
+    exp: number;
+    iat: number;
+    jti: string;
+    githubCredential: string;
+  };
 }

--- a/worker/test/http.test.ts
+++ b/worker/test/http.test.ts
@@ -5,6 +5,7 @@ import {
   adminGrantVersion,
   authenticateRequest,
   base64URL,
+  githubUserGrantIsCurrent,
   issueUserToken,
   requestWithAuthContext,
 } from "../src/auth";
@@ -151,6 +152,37 @@ describe("coordinator auth", () => {
       membershipUnavailable,
     );
     expect(normalMutation).toMatchObject({ authenticated: false, response: { status: 401 } });
+  });
+
+  it("fails closed when a live GitHub grant can no longer be decrypted", async () => {
+    const env = {
+      CRABBOX_SESSION_SECRET: "session-secret",
+      CRABBOX_DEFAULT_ORG: "example-org",
+    } as Env;
+    const token = await issueUserToken(env, {
+      owner: "alice@example.com",
+      ownerSource: "github-verified-email",
+      org: "example-org",
+      login: "alice",
+      githubAccessToken: "github-access-token",
+    });
+    const auth = await authenticateRequest(
+      new Request("https://broker.example.test/v1/whoami", {
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      env,
+      allowGitHubMembership,
+    );
+    expect(auth?.githubGrant).toBeDefined();
+
+    await expect(
+      githubUserGrantIsCurrent(
+        auth!.githubGrant!,
+        { owner: auth!.owner, org: auth!.org, login: auth!.login! },
+        { CRABBOX_SESSION_SECRET: "rotated-session-secret" },
+        allowGitHubMembership,
+      ),
+    ).resolves.toBe(false);
   });
 
   it("treats malformed portal cookies as absent across request types", async () => {
@@ -334,6 +366,8 @@ describe("coordinator auth", () => {
     requests.forEach((request) => {
       request.headers.set("x-crabbox-internal", "scheduled");
       request.headers.set("x-crabbox-admin-grant-version", "a".repeat(64));
+      request.headers.set("x-crabbox-github-token-id", "forged-token-id");
+      request.headers.set("x-crabbox-github-sealed-credential", "forged-credential");
     });
 
     const routedRequests = await Promise.all(
@@ -360,6 +394,12 @@ describe("coordinator auth", () => {
     ]);
     expect(
       routedRequests.map((request) => request.headers.get("x-crabbox-admin-grant-version")),
+    ).toEqual([null, null, null, null]);
+    expect(
+      routedRequests.map((request) => request.headers.get("x-crabbox-github-token-id")),
+    ).toEqual([null, null, null, null]);
+    expect(
+      routedRequests.map((request) => request.headers.get("x-crabbox-github-sealed-credential")),
     ).toEqual([null, null, null, null]);
   });
 


### PR DESCRIPTION
## Summary

- bind portal-backed WebVNC, Code viewer, and egress bridges to the exact signed user session that authorized them
- revoke pending and active bridges on portal logout, emergency user revocation, membership loss, or expired GitHub grants
- fail closed while restoring older/invalid bridge attachments, while preserving provider-neutral bridge lifecycle boundaries
- document the live-session revocation contract and add the required changelog entry

Closes https://github.com/openclaw/crabbox/issues/933

## Verification

Exact candidate: `09eeee5018f52df4ced73eb352bf1262eb2079db`

- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker` — 830 passed, 2 skipped
- `npm run build --prefix worker`
- `node scripts/build-docs-site.mjs`
- pre-ship autoreview clean after fixing its WebVNC logout race finding
- rebased patch-id exactly matches the reviewed candidate: `547b56e2535d9147016883eb413d27701c87d27b`
- public model identifier gate: pass; no model-bearing additions

## Authenticated live proof

Fresh actual local Wrangler Worker proof on exact head, using the authenticated `steipete` GitHub identity and a five-minute signed `steipete@gmail.com` session; credential values were never printed or persisted:

```json
{
  "exactHead": "09eeee50",
  "githubIdentity": "steipete",
  "registration": 201,
  "bridgeFrameForwarded": true,
  "crossSiteGet": {
    "status": 200,
    "socketsSurvived": true
  },
  "sameOriginLogout": {
    "status": 200
  },
  "hostClosed": {
    "code": 1008,
    "reason": "portal session ended"
  },
  "clientClosed": {
    "code": 1008,
    "reason": "portal session ended"
  },
  "zeroLiveBridgeResidue": true,
  "registrationReleased": true
}
```

The live sequence registered a disposable external lease, created session-bound host/client egress tickets, connected both real WebSockets, forwarded a frame, verified cross-site GET was read-only, performed same-origin logout, waited for both 1008 close handshakes, checked both status flags were false, and released the registration with no live bridge residue.
