### PR TITLE
fix: confine Islo redirects to configured origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Changed portal logout to an authenticated, same-origin `POST` with a read-only `GET` confirmation page, preventing cross-site top-level navigation from clearing portal cookies or revoking isolated Code viewer sessions. Thanks @coygeek.
 - Bound non-admin GitHub WebVNC, Code, and egress bridges to their encrypted user grant and portal session, closing active or restored bridges after logout, emergency revocation, membership loss, or membership-check failure without persisting plaintext GitHub credentials. Thanks @coygeek.
 - Prevented Git seed from forwarding HTTP(S) origin credentials to Linux or Windows lease runners; Crabbox now warns without printing the remote and falls back to file sync. Thanks @coygeek.
+- Confined Islo API redirects to the configured scheme, hostname, and effective port before replaying authorization or request bodies, while keeping rejected Location secrets out of diagnostics. Thanks @TurboTheTurtle.
 
 ## 0.36.0 - 2026-07-05
 

--- a/internal/providers/islo/client.go
+++ b/internal/providers/islo/client.go
@@ -142,6 +142,8 @@ func (e *isloRedirectError) Error() string {
 
 func isloSanitizeRedirectError(err error) error {
 	var redirectErr *isloRedirectError
+	// net/http wraps CheckRedirect failures in *url.Error, whose text includes
+	// the rejected URL. Return our origin-only error so Location secrets stay out.
 	if errors.As(err, &redirectErr) {
 		return redirectErr
 	}

--- a/internal/providers/islo/client.go
+++ b/internal/providers/islo/client.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -67,6 +68,10 @@ var newIsloClient = func(cfg Config, rt Runtime) (isloAPI, error) {
 	if httpClient == nil {
 		httpClient = defaultIsloHTTPClient()
 	}
+	httpClient, err := isloHTTPClientWithRedirectGuard(baseURL, httpClient)
+	if err != nil {
+		return nil, err
+	}
 	auth := customauth.NewProvider(baseURL, apiKey, 0, httpClient)
 	var baseTransport http.RoundTripper
 	var timeout time.Duration
@@ -75,8 +80,9 @@ var newIsloClient = func(cfg Config, rt Runtime) (isloAPI, error) {
 		timeout = httpClient.Timeout
 	}
 	sdkHTTPClient := &http.Client{
-		Transport: customauth.NewTransport(baseTransport, auth),
-		Timeout:   timeout,
+		Transport:     customauth.NewTransport(baseTransport, auth),
+		Timeout:       timeout,
+		CheckRedirect: isloSameOriginRedirectGuard(baseURL, nil),
 	}
 	sdk := client.NewClient(option.WithBaseURL(baseURL), option.WithHTTPClient(sdkHTTPClient))
 	return &isloSDKClient{sdk: sdk, auth: auth, baseURL: baseURL, httpClient: httpClient}, nil
@@ -92,20 +98,102 @@ func defaultIsloHTTPClient() *http.Client {
 	return &http.Client{Transport: transport}
 }
 
+func isloHTTPClientWithRedirectGuard(baseURL string, source *http.Client) (*http.Client, error) {
+	base, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("islo base URL: %w", err)
+	}
+	if base.Scheme == "" || base.Host == "" {
+		return nil, fmt.Errorf("islo base URL must include scheme and host")
+	}
+	if source == nil {
+		source = http.DefaultClient
+	}
+	client := *source
+	client.CheckRedirect = isloSameOriginRedirectGuard(baseURL, source.CheckRedirect)
+	return &client, nil
+}
+
+func isloSameOriginRedirectGuard(baseURL string, next func(*http.Request, []*http.Request) error) func(*http.Request, []*http.Request) error {
+	base, _ := url.Parse(baseURL)
+	baseOrigin := isloURLEffectiveOrigin(base)
+	return func(req *http.Request, via []*http.Request) error {
+		if len(via) >= 10 {
+			return fmt.Errorf("islo redirect stopped after 10 redirects")
+		}
+		if isloURLEffectiveOrigin(req.URL) != baseOrigin {
+			return &isloRedirectError{from: baseOrigin, to: isloURLEffectiveOrigin(req.URL)}
+		}
+		if next != nil {
+			return next(req, via)
+		}
+		return nil
+	}
+}
+
+type isloRedirectError struct {
+	from string
+	to   string
+}
+
+func (e *isloRedirectError) Error() string {
+	return fmt.Sprintf("refusing islo redirect from %s to %s", e.from, e.to)
+}
+
+func isloSanitizeRedirectError(err error) error {
+	var redirectErr *isloRedirectError
+	if errors.As(err, &redirectErr) {
+		return redirectErr
+	}
+	return err
+}
+
+func isloURLEffectiveOrigin(value *url.URL) string {
+	if value == nil {
+		return ""
+	}
+	port := value.Port()
+	if port == "" {
+		switch strings.ToLower(value.Scheme) {
+		case "http":
+			port = "80"
+		case "https":
+			port = "443"
+		}
+	}
+	return strings.ToLower(value.Scheme) + "://" + strings.ToLower(value.Hostname()) + ":" + port
+}
+
 func (c *isloSDKClient) CreateSandbox(ctx context.Context, req *gosdk.SandboxCreate) (*gosdk.SandboxResponse, error) {
-	return c.sdk.Sandboxes.CreateSandbox(ctx, req)
+	sandbox, err := c.sdk.Sandboxes.CreateSandbox(ctx, req)
+	if err != nil {
+		return nil, isloSanitizeRedirectError(err)
+	}
+	return sandbox, nil
 }
 
 func (c *isloSDKClient) GetSandbox(ctx context.Context, name string) (*gosdk.SandboxResponse, error) {
-	return c.sdk.Sandboxes.GetSandbox(ctx, &gosdk.GetSandboxRequest{SandboxName: name})
+	sandbox, err := c.sdk.Sandboxes.GetSandbox(ctx, &gosdk.GetSandboxRequest{SandboxName: name})
+	if err != nil {
+		return nil, isloSanitizeRedirectError(err)
+	}
+	return sandbox, nil
 }
 
 func (c *isloSDKClient) PauseSandbox(ctx context.Context, name string) (*gosdk.SandboxResponse, error) {
-	return c.sdk.Sandboxes.PauseSandbox(ctx, &gosdk.PauseSandboxRequest{SandboxName: name})
+	sandbox, err := c.sdk.Sandboxes.PauseSandbox(ctx, &gosdk.PauseSandboxRequest{SandboxName: name})
+	if err != nil {
+		return nil, isloSanitizeRedirectError(err)
+	}
+	return sandbox, nil
 }
 
 func (c *isloSDKClient) ResumeSandbox(ctx context.Context, name string) (*gosdk.SandboxResponse, error) {
-	return c.sdk.Sandboxes.ResumeSandbox(ctx, &gosdk.ResumeSandboxRequest{SandboxName: name})
+	sandbox, err := c.sdk.Sandboxes.ResumeSandbox(ctx, &gosdk.ResumeSandboxRequest{SandboxName: name})
+	if err != nil {
+		return nil, isloSanitizeRedirectError(err)
+	}
+	return sandbox, nil
 }
 
 func (c *isloSDKClient) ListSandboxes(ctx context.Context) ([]*gosdk.SandboxResponse, error) {
@@ -114,7 +202,7 @@ func (c *isloSDKClient) ListSandboxes(ctx context.Context) ([]*gosdk.SandboxResp
 	for offset := 0; ; offset += limit {
 		page, err := c.sdk.Sandboxes.ListSandboxes(ctx, &gosdk.ListSandboxesRequest{Limit: &limit, Offset: &offset})
 		if err != nil {
-			return nil, err
+			return nil, isloSanitizeRedirectError(err)
 		}
 		if page == nil {
 			return all, nil
@@ -147,7 +235,7 @@ func (c *isloSDKClient) DeleteSandbox(ctx context.Context, name string) error {
 	httpReq.Header.Set("Accept", "application/json")
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
-		return err
+		return isloSanitizeRedirectError(err)
 	}
 	defer resp.Body.Close()
 	// Mirror the >=400 failure convention used by the other raw endpoints, with
@@ -175,14 +263,14 @@ func (c *isloSDKClient) UploadArchive(ctx context.Context, name, targetPath stri
 	}
 	token, err := c.auth.Token(ctx)
 	if err != nil {
-		return fmt.Errorf("islo auth: %w", err)
+		return fmt.Errorf("islo auth: %w", isloSanitizeRedirectError(err))
 	}
 	httpReq.Header.Set("Authorization", "Bearer "+token)
 	httpReq.Header.Set("Content-Type", contentType)
 	httpReq.Header.Set("Accept", "application/json")
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
-		return fmt.Errorf("islo upload archive: %w", err)
+		return fmt.Errorf("islo upload archive: %w", isloSanitizeRedirectError(err))
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode >= 400 {
@@ -250,7 +338,7 @@ func (c *isloSDKClient) CreateShare(ctx context.Context, name string, port int, 
 	httpReq.Header.Set("Accept", "application/json")
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
-		return IsloShare{}, fmt.Errorf("islo create share: %w", err)
+		return IsloShare{}, fmt.Errorf("islo create share: %w", isloSanitizeRedirectError(err))
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode >= 400 {
@@ -276,7 +364,7 @@ func (c *isloSDKClient) ListShares(ctx context.Context, name string) ([]IsloShar
 	httpReq.Header.Set("Accept", "application/json")
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
-		return nil, fmt.Errorf("islo list shares: %w", err)
+		return nil, fmt.Errorf("islo list shares: %w", isloSanitizeRedirectError(err))
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusNotFound {
@@ -300,7 +388,7 @@ func (c *isloSDKClient) ListShares(ctx context.Context, name string) ([]IsloShar
 func (c *isloSDKClient) authorize(ctx context.Context, req *http.Request) error {
 	token, err := c.auth.Token(ctx)
 	if err != nil {
-		return fmt.Errorf("islo auth: %w", err)
+		return fmt.Errorf("islo auth: %w", isloSanitizeRedirectError(err))
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	return nil
@@ -335,14 +423,14 @@ func (c *isloSDKClient) ExecStream(ctx context.Context, name string, req *gosdk.
 	}
 	token, err := c.auth.Token(ctx)
 	if err != nil {
-		return 1, fmt.Errorf("islo auth: %w", err)
+		return 1, fmt.Errorf("islo auth: %w", isloSanitizeRedirectError(err))
 	}
 	httpReq.Header.Set("Authorization", "Bearer "+token)
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("Accept", "text/event-stream")
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
-		return 1, err
+		return 1, isloSanitizeRedirectError(err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode >= 400 {

--- a/internal/providers/islo/client.go
+++ b/internal/providers/islo/client.go
@@ -118,11 +118,11 @@ func isloSameOriginRedirectGuard(baseURL string, next func(*http.Request, []*htt
 	base, _ := url.Parse(baseURL)
 	baseOrigin := isloURLEffectiveOrigin(base)
 	return func(req *http.Request, via []*http.Request) error {
-		if len(via) >= 10 {
-			return fmt.Errorf("islo redirect stopped after 10 redirects")
-		}
 		if isloURLEffectiveOrigin(req.URL) != baseOrigin {
 			return &isloRedirectError{from: baseOrigin, to: isloURLEffectiveOrigin(req.URL)}
+		}
+		if len(via) >= 10 {
+			return &isloRedirectLimitError{}
 		}
 		if next != nil {
 			return next(req, via)
@@ -136,6 +136,12 @@ type isloRedirectError struct {
 	to   string
 }
 
+type isloRedirectLimitError struct{}
+
+func (*isloRedirectLimitError) Error() string {
+	return "islo redirect stopped after 10 redirects"
+}
+
 func (e *isloRedirectError) Error() string {
 	return fmt.Sprintf("refusing islo redirect from %s to %s", e.from, e.to)
 }
@@ -146,6 +152,10 @@ func isloSanitizeRedirectError(err error) error {
 	// the rejected URL. Return our origin-only error so Location secrets stay out.
 	if errors.As(err, &redirectErr) {
 		return redirectErr
+	}
+	var limitErr *isloRedirectLimitError
+	if errors.As(err, &limitErr) {
+		return limitErr
 	}
 	return err
 }

--- a/internal/providers/islo/client_test.go
+++ b/internal/providers/islo/client_test.go
@@ -69,6 +69,132 @@ func TestIsloClientDeleteSandboxHandlesEmptyAndMissing(t *testing.T) {
 	})
 }
 
+func TestIsloClientDeleteSandboxConfinesRedirects(t *testing.T) {
+	crossOriginHit := false
+	crossOrigin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		crossOriginHit = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer crossOrigin.Close()
+
+	var sameOriginRedirectHit bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/auth/token":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"session_token":"test-token"}`)
+		case r.URL.Path == "/sandboxes/same-origin":
+			http.Redirect(w, r, "/redirected-delete", http.StatusTemporaryRedirect)
+		case r.URL.Path == "/redirected-delete":
+			sameOriginRedirectHit = true
+			if r.Header.Get("Authorization") == "" {
+				t.Error("same-origin redirected request lost authorization")
+			}
+			w.WriteHeader(http.StatusNoContent)
+		case r.URL.Path == "/sandboxes/cross-origin":
+			http.Redirect(w, r, crossOrigin.URL+"/stolen", http.StatusTemporaryRedirect)
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer server.Close()
+
+	cfg := Config{}
+	cfg.Islo.APIKey = "test-key"
+	cfg.Islo.BaseURL = server.URL
+	client, err := newIsloClient(cfg, Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := client.DeleteSandbox(context.Background(), "same-origin"); err != nil {
+		t.Fatalf("same-origin redirect should be allowed: %v", err)
+	}
+	if !sameOriginRedirectHit {
+		t.Fatal("same-origin redirect target was not reached")
+	}
+	err = client.DeleteSandbox(context.Background(), "cross-origin")
+	if err == nil || !strings.Contains(err.Error(), "refusing islo redirect") {
+		t.Fatalf("cross-origin redirect error=%v, want refusal", err)
+	}
+	if crossOriginHit {
+		t.Fatal("cross-origin redirect target received request")
+	}
+}
+
+func TestIsloRedirectErrorsHideRejectedLocation(t *testing.T) {
+	crossOriginHit := false
+	crossOrigin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		crossOriginHit = true
+		t.Errorf("redirect target received %s %s auth=%q", r.Method, r.URL.RequestURI(), r.Header.Get("Authorization"))
+	}))
+	defer crossOrigin.Close()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/auth/token":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"session_token":"test-token"}`)
+		case "/sandboxes/raw-location":
+			http.Redirect(w, r, crossOrigin.URL+"/stolen?token=redirect-secret#fragment-secret", http.StatusTemporaryRedirect)
+		case "/sandboxes/sdk-location":
+			http.Redirect(w, r, crossOrigin.URL+"/sdk-stolen?token=redirect-secret#fragment-secret", http.StatusTemporaryRedirect)
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer server.Close()
+
+	cfg := Config{}
+	cfg.Islo.APIKey = "test-key"
+	cfg.Islo.BaseURL = server.URL
+	client, err := newIsloClient(cfg, Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, call := range map[string]func() error{
+		"raw delete": func() error {
+			return client.DeleteSandbox(context.Background(), "raw-location")
+		},
+		"sdk get": func() error {
+			_, err := client.GetSandbox(context.Background(), "sdk-location")
+			return err
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := call()
+			if err == nil || !strings.Contains(err.Error(), "refusing islo redirect") {
+				t.Fatalf("redirect error=%v, want refusal", err)
+			}
+			for _, leaked := range []string{"redirect-secret", "fragment-secret", "/stolen", "/sdk-stolen"} {
+				if strings.Contains(err.Error(), leaked) {
+					t.Fatalf("redirect error leaked %q: %v", leaked, err)
+				}
+			}
+		})
+	}
+	if crossOriginHit {
+		t.Fatal("cross-origin redirect target received request")
+	}
+}
+
+func TestIsloRedirectGuardUsesEffectiveOrigin(t *testing.T) {
+	guard := isloSameOriginRedirectGuard("https://api.islo.dev", nil)
+	samePort, err := http.NewRequest(http.MethodGet, "https://api.islo.dev:443/sandboxes", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := guard(samePort, nil); err != nil {
+		t.Fatalf("default HTTPS port should share origin: %v", err)
+	}
+	otherPort, err := http.NewRequest(http.MethodGet, "https://api.islo.dev:444/sandboxes", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := guard(otherPort, nil); err == nil {
+		t.Fatal("different effective port should be refused")
+	}
+}
+
 func TestIsloRawErrorsRedactSessionToken(t *testing.T) {
 	const secret = "islo-session-secret"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/providers/islo/client_test.go
+++ b/internal/providers/islo/client_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -130,14 +131,28 @@ func TestIsloRedirectErrorsHideRejectedLocation(t *testing.T) {
 	defer crossOrigin.Close()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/auth/token":
+		switch {
+		case r.URL.Path == "/auth/token":
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = io.WriteString(w, `{"session_token":"test-token"}`)
-		case "/sandboxes/raw-location":
+		case r.URL.Path == "/sandboxes/raw-location":
 			http.Redirect(w, r, crossOrigin.URL+"/stolen?token=redirect-secret#fragment-secret", http.StatusTemporaryRedirect)
-		case "/sandboxes/sdk-location":
+		case r.URL.Path == "/sandboxes/sdk-location":
 			http.Redirect(w, r, crossOrigin.URL+"/sdk-stolen?token=redirect-secret#fragment-secret", http.StatusTemporaryRedirect)
+		case r.URL.Path == "/sandboxes/redirect-limit":
+			http.Redirect(w, r, "/redirect-limit/1", http.StatusTemporaryRedirect)
+		case strings.HasPrefix(r.URL.Path, "/redirect-limit/"):
+			hop, err := strconv.Atoi(strings.TrimPrefix(r.URL.Path, "/redirect-limit/"))
+			if err != nil {
+				t.Errorf("parse redirect hop: %v", err)
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			if hop < 9 {
+				http.Redirect(w, r, "/redirect-limit/"+strconv.Itoa(hop+1), http.StatusTemporaryRedirect)
+				return
+			}
+			http.Redirect(w, r, "/limit-secret?token=limit-secret#limit-fragment", http.StatusTemporaryRedirect)
 		default:
 			w.WriteHeader(http.StatusInternalServerError)
 		}
@@ -151,21 +166,32 @@ func TestIsloRedirectErrorsHideRejectedLocation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for name, call := range map[string]func() error{
-		"raw delete": func() error {
-			return client.DeleteSandbox(context.Background(), "raw-location")
+	for name, tc := range map[string]struct {
+		call func() error
+		want string
+	}{
+		"raw delete": {
+			call: func() error { return client.DeleteSandbox(context.Background(), "raw-location") },
+			want: "refusing islo redirect",
 		},
-		"sdk get": func() error {
-			_, err := client.GetSandbox(context.Background(), "sdk-location")
-			return err
+		"sdk get": {
+			call: func() error {
+				_, err := client.GetSandbox(context.Background(), "sdk-location")
+				return err
+			},
+			want: "refusing islo redirect",
+		},
+		"redirect limit": {
+			call: func() error { return client.DeleteSandbox(context.Background(), "redirect-limit") },
+			want: "islo redirect stopped after 10 redirects",
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			err := call()
-			if err == nil || !strings.Contains(err.Error(), "refusing islo redirect") {
-				t.Fatalf("redirect error=%v, want refusal", err)
+			err := tc.call()
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("redirect error=%v, want %q", err, tc.want)
 			}
-			for _, leaked := range []string{"redirect-secret", "fragment-secret", "/stolen", "/sdk-stolen"} {
+			for _, leaked := range []string{"redirect-secret", "fragment-secret", "/stolen", "/sdk-stolen", "limit-secret", "limit-fragment"} {
 				if strings.Contains(err.Error(), leaked) {
 					t.Fatalf("redirect error leaked %q: %v", leaked, err)
 				}


### PR DESCRIPTION
Closes https://github.com/openclaw/crabbox/issues/935.

Adds an Islo-specific redirect guard for the raw client, token client, and SDK client so credential-bearing requests stay on the configured scheme, host, and effective port. Covers same-origin redirects, cross-origin refusal, and sanitized redirect errors with provider-client tests.

Compatibility note for maintainers: this intentionally fails closed for custom Islo endpoints that redirect outside the configured origin. If cross-origin redirects are supported deployment behavior, this should land with an explicit trusted-origin opt-in instead.

Maintainer decision: scheme, hostname, and effective port are the credential boundary. Cross-origin redirects remain incompatible by design; Crabbox will not add a trusted-origin escape hatch without a separate reviewed security contract.

Proof requested by ClawSweeper:

```text
$ python3 /tmp/crabbox-proof-938/islo_redirect_live_proof.py
base_url=http://127.0.0.1:62618
cross_origin_target=http://127.0.0.1:62617
running same-origin redirected stop
same_exit=0
same_stderr=released lease=isb_crabbox-same-origin sandbox=crabbox-same-origin
running cross-origin redirected stop
cross_exit=1
cross_stderr=islo delete sandbox: refusing islo redirect from http://127.0.0.1:62618 to http://127.0.0.1:62617
server_events=
{"authorization": "(none)", "method": "POST", "path": "/auth/token", "server": "islo-origin"}
{"action": "redirect-same-origin", "authorization": "Bearer [redacted]", "method": "DELETE", "path": "/sandboxes/crabbox-same-origin", "server": "islo-origin"}
{"action": "same-origin-delete-final", "authorization": "Bearer [redacted]", "method": "DELETE", "path": "/same-origin-delete", "server": "islo-origin"}
{"authorization": "(none)", "method": "POST", "path": "/auth/token", "server": "islo-origin"}
{"action": "redirect-cross-origin", "authorization": "Bearer [redacted]", "method": "DELETE", "path": "/sandboxes/crabbox-cross-origin", "server": "islo-origin"}
cross_origin_target_hits=0
```

The proof uses the built `cmd/crabbox` binary, isolated `XDG_STATE_HOME` lease claims, and loopback Islo-compatible HTTP servers. Same-origin redirect succeeds through the real `crabbox stop --provider islo` path with authorization preserved; cross-origin redirect fails before the redirected endpoint receives a request. The refusal error reports only effective origins, not the rejected redirect path, query, or fragment.

Maintainer verification on exact candidate `f60aeafd57e2317ebf9831dff39a2c237a660be7`:

```text
go test ./internal/providers/islo -run 'TestIsloClientDeleteSandboxConfinesRedirects|TestIsloRedirectErrorsHideRejectedLocation|TestIsloRedirectGuardUsesEffectiveOrigin' -count=1 -v
PASS

go vet ./...
go test -race ./...
go build -trimpath -o bin/crabbox ./cmd/crabbox
node scripts/build-docs-site.mjs
PASS

npm run format:check --prefix worker
npm run lint --prefix worker
npm run check --prefix worker
npm test --prefix worker
npm run build --prefix worker
830 passed, 2 skipped; PASS

autoreview --mode branch --base origin/main
findings: 0
```

Authenticated Islo create/use/destroy canary with the exact built candidate:

```text
baseline inventory: 9
run exit: 0
remote marker: present
credential in output: no
lease: isb_crabbox-islo-pr938-live-43f818
automatic delete: accepted asynchronously
confirmed final inventory: 9
exact lease/slug residue: 0
```

The canary used `--no-sync`, executed a marker through Islo's real command stream, and touched only its unique lease. The immediate inventory briefly showed the asynchronously deleting sandbox; a bounded follow-up poll confirmed it absent before publication.
