### PR TITLE
fix: disable git seed for credentialed HTTPS remotes

### DIFF
--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -226,7 +226,22 @@ func remoteGitSeedCandidate(repo Repo) bool {
 	if repo.Root == "" || repo.RemoteURL == "" || repo.Head == "" {
 		return false
 	}
+	if !remoteGitSeedURLSafe(repo.RemoteURL) {
+		return false
+	}
 	return gitOutput(repo.Root, "for-each-ref", "--contains", repo.Head, "--format=%(refname)", "refs/remotes") != ""
+}
+
+func remoteGitSeedURLSafe(remoteURL string) bool {
+	remoteURL = strings.TrimSpace(remoteURL)
+	if !strings.Contains(remoteURL, "://") {
+		return true
+	}
+	u, err := url.Parse(remoteURL)
+	if err != nil || u.User == nil {
+		return true
+	}
+	return u.Scheme != "http" && u.Scheme != "https"
 }
 
 func defaultBaseRef(root string) string {

--- a/internal/cli/repo_test.go
+++ b/internal/cli/repo_test.go
@@ -420,6 +420,19 @@ func TestRemoteGitSeedCandidateRequiresRemoteTrackingRef(t *testing.T) {
 	if !remoteGitSeedCandidate(repo) {
 		t.Fatal("head in a remote-tracking ref should be a seed candidate")
 	}
+
+	repo.RemoteURL = "https://token@github.com/openclaw/crabbox.git"
+	if remoteGitSeedCandidate(repo) {
+		t.Fatal("credential-bearing HTTPS remote should not be a seed candidate")
+	}
+	repo.RemoteURL = "https://user:token@github.com/openclaw/crabbox.git"
+	if remoteGitSeedCandidate(repo) {
+		t.Fatal("HTTPS remote with password userinfo should not be a seed candidate")
+	}
+	repo.RemoteURL = "ssh://git@github.com/openclaw/crabbox.git"
+	if !remoteGitSeedCandidate(repo) {
+		t.Fatal("SSH remotes with a username should remain seed candidates")
+	}
 }
 
 func TestCheckSyncPreflightFailsLargeCandidate(t *testing.T) {


### PR DESCRIPTION
Closes #928.

Prevents git seed from cloning HTTPS remotes that include URL userinfo, so credential-bearing remotes fall back to the normal sync path instead of being sent to lease runners. Keeps SSH remotes with ordinary usernames eligible for git seed.