### PR TITLE
fix(sync): block credential-bearing git seeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Changed portal logout to an authenticated, same-origin `POST` with a read-only `GET` confirmation page, preventing cross-site top-level navigation from clearing portal cookies or revoking isolated Code viewer sessions. Thanks @coygeek.
 - Bound non-admin GitHub WebVNC, Code, and egress bridges to their encrypted user grant and portal session, closing active or restored bridges after logout, emergency revocation, membership loss, or membership-check failure without persisting plaintext GitHub credentials. Thanks @coygeek.
+- Prevented Git seed from forwarding HTTP(S) origin credentials to Linux or Windows lease runners; Crabbox now warns without printing the remote and falls back to file sync. Thanks @coygeek.
 
 ## 0.36.0 - 2026-07-05
 

--- a/docs/features/sync.md
+++ b/docs/features/sync.md
@@ -100,6 +100,10 @@ the remote fingerprint and forces a clean transfer.
 Git seeding (`sync.gitSeed`, default on) clones or fetches the base tree on the
 runner before rsync, so only your diff travels over the wire. It activates only
 when the local `HEAD` commit is reachable from a remote ref.
+Crabbox disables Git seeding when the origin is an HTTP(S) URL with embedded
+userinfo, warns without printing the URL, and uses the normal file sync instead.
+This prevents credentials stored in local Git remotes from reaching lease
+command arguments or the seeded worktree's Git configuration.
 
 ## Large-sync guardrails
 

--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -540,7 +540,11 @@ func (a App) syncLocalActionsWorkspace(ctx context.Context, cfg Config, repo Rep
 	if err := runSSHQuiet(ctx, target, remoteMkdir(workdir)); err != nil {
 		return exit(7, "create remote workdir: %v", err)
 	}
-	if syncGitSeedEnabled(cfg, repo) {
+	gitSeed, credentialBlocked := syncGitSeedDecision(cfg, repo)
+	if credentialBlocked {
+		warnCredentialBearingGitSeed(a.Stderr)
+	}
+	if gitSeed {
 		if err := runSSHQuiet(ctx, target, remoteGitSeed(workdir, repo.RemoteURL, repo.Head)); err != nil {
 			fmt.Fprintf(a.Stderr, "warning: remote git seed failed: %v\n", err)
 		}

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -142,7 +142,22 @@ func syncIncludes(cfg Config) []string {
 }
 
 func syncGitSeedEnabled(cfg Config, repo Repo) bool {
-	return cfg.Sync.GitSeed && len(syncIncludes(cfg)) == 0 && remoteGitSeedCandidate(repo)
+	enabled, _ := syncGitSeedDecision(cfg, repo)
+	return enabled
+}
+
+func syncGitSeedDecision(cfg Config, repo Repo) (enabled, credentialBlocked bool) {
+	if !cfg.Sync.GitSeed || len(syncIncludes(cfg)) != 0 || !remoteGitSeedSourceCandidate(repo) {
+		return false, false
+	}
+	if gitRemoteURLHasCredentials(repo.RemoteURL) {
+		return false, true
+	}
+	return true, false
+}
+
+func warnCredentialBearingGitSeed(w io.Writer) {
+	fmt.Fprintln(w, "warning: git seed disabled because origin URL contains embedded HTTP credentials; continuing with file sync without forwarding the remote URL")
 }
 
 func SyncExcludes(root string, cfg Config) ([]string, error) {
@@ -223,10 +238,36 @@ func gitOutput(root string, args ...string) string {
 }
 
 func remoteGitSeedCandidate(repo Repo) bool {
+	return remoteGitSeedSourceCandidate(repo) && !gitRemoteURLHasCredentials(repo.RemoteURL)
+}
+
+func remoteGitSeedSourceCandidate(repo Repo) bool {
 	if repo.Root == "" || repo.RemoteURL == "" || repo.Head == "" {
 		return false
 	}
 	return gitOutput(repo.Root, "for-each-ref", "--contains", repo.Head, "--format=%(refname)", "refs/remotes") != ""
+}
+
+func gitRemoteURLHasCredentials(remoteURL string) bool {
+	raw := strings.TrimSpace(remoteURL)
+	lower := strings.ToLower(raw)
+	schemeEnd := 0
+	switch {
+	case strings.HasPrefix(lower, "https://"):
+		schemeEnd = len("https://")
+	case strings.HasPrefix(lower, "http://"):
+		schemeEnd = len("http://")
+	default:
+		return false
+	}
+	if parsed, err := url.Parse(raw); err == nil && parsed.User != nil {
+		return true
+	}
+	authority := raw[schemeEnd:]
+	if end := strings.IndexAny(authority, "/?#"); end >= 0 {
+		authority = authority[:end]
+	}
+	return strings.Contains(authority, "@")
 }
 
 func defaultBaseRef(root string) string {

--- a/internal/cli/repo_test.go
+++ b/internal/cli/repo_test.go
@@ -178,6 +178,47 @@ func TestSyncGitSeedDisabledByIncludeWhitelist(t *testing.T) {
 	}
 }
 
+func TestSyncGitSeedRejectsCredentialBearingHTTPRemote(t *testing.T) {
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.email", "test@example.com")
+	runGit(t, dir, "config", "user.name", "Test")
+	writeFile(t, filepath.Join(dir, "main.go"), "package main\n")
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-m", "init")
+	runGit(t, dir, "update-ref", "refs/remotes/origin/main", "HEAD")
+	repo := Repo{Root: dir, RemoteURL: "https://runner:do-not-forward@example.test/repo.git", Head: gitOutput(dir, "rev-parse", "HEAD")}
+
+	if enabled, blocked := syncGitSeedDecision(baseConfig(), repo); enabled || !blocked {
+		t.Fatalf("enabled=%v blocked=%v", enabled, blocked)
+	}
+	if remoteGitSeedCandidate(repo) {
+		t.Fatal("credential-bearing remote must not be a seed candidate")
+	}
+}
+
+func TestGitRemoteURLHasCredentials(t *testing.T) {
+	tests := []struct {
+		remote string
+		want   bool
+	}{
+		{remote: "https://example.test/repo.git", want: false},
+		{remote: "https://runner@example.test/repo.git", want: true},
+		{remote: "https://runner:token@example.test/repo.git", want: true},
+		{remote: "HTTPS://runner:token@example.test/repo.git", want: true},
+		{remote: "https://runner%zz@example.test/repo.git", want: true},
+		{remote: "ssh://git@example.test/repo.git", want: false},
+		{remote: "git@example.test:repo.git", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.remote, func(t *testing.T) {
+			if got := gitRemoteURLHasCredentials(tt.remote); got != tt.want {
+				t.Fatalf("got=%v want=%v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestSyncManifestPrunesNestedDefaultExcludes(t *testing.T) {
 	dir := t.TempDir()
 	runGit(t, dir, "init")

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1195,7 +1195,11 @@ retrySync:
 			recorder.Event("sync.finished", "synced", fmt.Sprintf("duration=%s mode=archive", timings.sync.Round(time.Millisecond)))
 			goto afterSync
 		}
-		if syncGitSeedEnabled(cfg, repo) {
+		gitSeed, credentialBlocked := syncGitSeedDecision(cfg, repo)
+		if credentialBlocked {
+			warnCredentialBearingGitSeed(a.Stderr)
+		}
+		if gitSeed {
 			stepStart = time.Now()
 			if err := runSSHQuiet(ctx, target, remoteGitSeed(workdir, repo.RemoteURL, repo.Head)); err != nil {
 				fmt.Fprintf(a.Stderr, "warning: remote git seed failed: %v\n", err)

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -1335,6 +1335,9 @@ func remoteGitSeed(workdir, remoteURL, head string) string {
 }
 
 func normalizeGitRemoteURL(remoteURL string) string {
+	if gitRemoteURLHasCredentials(remoteURL) {
+		return ""
+	}
 	if strings.HasPrefix(remoteURL, "git@github.com:") {
 		return "https://github.com/" + strings.TrimSuffix(strings.TrimPrefix(remoteURL, "git@github.com:"), ".git") + ".git"
 	}

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -272,6 +272,29 @@ exit 0
 	if got, want := strings.Count(string(logData), "ssh\n"), 4; got != want {
 		t.Fatalf("ssh calls=%d want %d; log:\n%s", got, want, logData)
 	}
+
+	if err := os.Remove(logPath); err != nil {
+		t.Fatal(err)
+	}
+	const secret = "do-not-forward"
+	repo.RemoteURL = "https://runner:" + secret + "@example.test/repo.git"
+	var stderr bytes.Buffer
+	if err := syncWindowsNative(context.Background(), target, repo, cfg, `C:\crabbox\cbx\repo`, manifest, io.Discard, &stderr, rsyncOptions{FullResync: true}); err != nil {
+		t.Fatal(err)
+	}
+	logData, err = os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := strings.Count(string(logData), "ssh\n"), 2; got != want {
+		t.Fatalf("credential-blocked ssh calls=%d want %d; log:\n%s", got, want, logData)
+	}
+	if !strings.Contains(stderr.String(), "origin URL contains embedded HTTP credentials") {
+		t.Fatalf("missing safe warning: %q", stderr.String())
+	}
+	if strings.Contains(stderr.String(), secret) || strings.Contains(stderr.String(), "example.test") {
+		t.Fatalf("warning leaked credential-bearing remote: %q", stderr.String())
+	}
 }
 
 func decodePowerShellCommand(t *testing.T, command string) string {
@@ -1356,6 +1379,69 @@ func TestRemoteGitSeedRemovesFailedCheckout(t *testing.T) {
 	}
 	if strings.Contains(got, "git checkout --quiet FETCH_HEAD || true") {
 		t.Fatalf("remoteGitSeed should not keep failed checkouts: %q", got)
+	}
+}
+
+func TestGitSeedCommandsRejectCredentialBearingHTTPRemote(t *testing.T) {
+	const secret = "do-not-forward"
+	remote := "https://runner:" + secret + "@example.test/repo.git"
+	for name, command := range map[string]string{
+		"linux":   remoteGitSeed("/work/repo", remote, "abc123"),
+		"windows": windowsGitSeed(`C:\crabbox\repo`, remote, "abc123"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if strings.Contains(command, secret) || strings.Contains(command, "example.test") {
+				t.Fatalf("credential-bearing remote reached %s seed command: %q", name, command)
+			}
+			if strings.Contains(command, "git clone") {
+				t.Fatalf("%s seed command should be disabled: %q", name, command)
+			}
+		})
+	}
+}
+
+func TestRemoteGitSeedLocalCanary(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "source")
+	if err := os.Mkdir(source, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, source, "init")
+	runGit(t, source, "config", "user.email", "test@example.com")
+	runGit(t, source, "config", "user.name", "Test")
+	mustWriteTestFile(t, filepath.Join(source, "proof.txt"), "safe seed\n")
+	runGit(t, source, "add", ".")
+	runGit(t, source, "commit", "-m", "seed")
+	head := gitOutput(source, "rev-parse", "HEAD")
+	origin := filepath.Join(root, "origin.git")
+	clone := exec.Command("git", "clone", "--bare", source, origin)
+	if out, err := clone.CombinedOutput(); err != nil {
+		t.Fatalf("create bare origin: %v\n%s", err, out)
+	}
+
+	workdir := filepath.Join(root, "safe-workdir")
+	seed := exec.Command("bash", "-lc", remoteGitSeed(workdir, origin, head))
+	if out, err := seed.CombinedOutput(); err != nil {
+		t.Fatalf("run safe seed: %v\n%s", err, out)
+	}
+	if got := gitOutput(workdir, "remote", "get-url", "origin"); got != origin {
+		t.Fatalf("seeded origin=%q want %q", got, origin)
+	}
+	proof, err := os.ReadFile(filepath.Join(workdir, "proof.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(string(proof)); got != "safe seed" {
+		t.Fatalf("seeded proof=%q", got)
+	}
+
+	blockedWorkdir := filepath.Join(root, "blocked-workdir")
+	blocked := exec.Command("bash", "-lc", remoteGitSeed(blockedWorkdir, "https://runner:do-not-forward@example.test/repo.git", head))
+	if out, err := blocked.CombinedOutput(); err != nil {
+		t.Fatalf("run blocked seed: %v\n%s", err, out)
+	}
+	if _, err := os.Stat(blockedWorkdir); !os.IsNotExist(err) {
+		t.Fatalf("credential-blocked seed created workdir: %v", err)
 	}
 }
 

--- a/internal/cli/sync_windows_target.go
+++ b/internal/cli/sync_windows_target.go
@@ -13,7 +13,10 @@ func syncWindowsNative(ctx context.Context, target SSHTarget, repo Repo, cfg Con
 	if err := runSSHQuiet(ctx, target, windowsPrepareWorkdir(workdir, cfg.Sync.Delete)); err != nil {
 		return exit(7, "prepare remote workdir: %v", err)
 	}
-	gitSeed := syncGitSeedEnabled(cfg, repo)
+	gitSeed, credentialBlocked := syncGitSeedDecision(cfg, repo)
+	if credentialBlocked {
+		warnCredentialBearingGitSeed(stderr)
+	}
 	if gitSeed {
 		if err := runSSHQuiet(ctx, target, windowsGitSeed(workdir, repo.RemoteURL, repo.Head)); err != nil {
 			fmt.Fprintf(stderr, "warning: remote git seed failed: %v\n", err)


### PR DESCRIPTION
## Summary

- reject HTTP(S) Git seed origins that contain embedded userinfo before any remote command is built
- warn without printing the origin, then fall back to normal file sync on Linux, native Windows, and local Actions paths
- keep a defense-in-depth block in both Linux and Windows seed command builders
- document the credential boundary and credit the reporter

## Verification

- `go vet ./...`
- `go test -race ./...`
- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- `node scripts/build-docs-site.mjs`
- `go test ./internal/cli -run 'TestRemoteGitSeedLocalCanary|TestGitSeedCommandsRejectCredentialBearingHTTPRemote|TestSyncWindowsNativeFullResyncPrunesAfterGitSeed' -v`

The runtime canary creates a disposable local source and bare origin, executes the generated Git seed command, and verifies the safe clone and checked-out content. It then executes both generated credential-blocked paths and verifies that no worktree is created, no clone command is emitted, the embedded secret never reaches the generated command or warning, and native Windows sync falls back to the expected file-sync path.

The rebased code patch (excluding the expected Unreleased changelog conflict resolution) has the same stable patch ID as the reviewed candidate: `cb95a9bc72b7466312e7cb484f231f758498de12`.

## Exact-head runtime proof

Candidate: `128eb4d9f69f96bacfa597b884929d641ac49c5c`

```text
=== RUN   TestSyncWindowsNativeFullResyncPrunesAfterGitSeed
--- PASS: TestSyncWindowsNativeFullResyncPrunesAfterGitSeed (0.46s)
=== RUN   TestGitSeedCommandsRejectCredentialBearingHTTPRemote
=== RUN   TestGitSeedCommandsRejectCredentialBearingHTTPRemote/linux
=== RUN   TestGitSeedCommandsRejectCredentialBearingHTTPRemote/windows
--- PASS: TestGitSeedCommandsRejectCredentialBearingHTTPRemote (0.00s)
    --- PASS: TestGitSeedCommandsRejectCredentialBearingHTTPRemote/linux (0.00s)
    --- PASS: TestGitSeedCommandsRejectCredentialBearingHTTPRemote/windows (0.00s)
=== RUN   TestRemoteGitSeedLocalCanary
--- PASS: TestRemoteGitSeedLocalCanary (0.36s)
PASS
ok github.com/openclaw/crabbox/internal/cli 1.490s
```

The canary executed the generated safe seed command against a disposable real Git source and bare origin, then executed the credential-blocked Linux and Windows command builders. Its assertions require: safe clone content present; blocked worktree absent; no `git clone` in blocked commands; no embedded credential or remote host in commands or warning; and Windows fallback completing through file sync. No secret value or credential-bearing URL is printed.

Maintainer decision: accept skip-and-warn file-sync fallback. The credential must not cross the lease boundary, while normal file sync preserves the requested run and reports the lost optimization without exposing the remote.

Closes https://github.com/openclaw/crabbox/issues/928
