### PR TITLE
fix: verify provider ownership before cloud cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Prevented Git seed from forwarding HTTP(S) origin credentials to Linux or Windows lease runners; Crabbox now warns without printing the remote and falls back to file sync. Thanks @coygeek.
 - Confined Islo API redirects to the configured scheme, hostname, and effective port before replaying authorization or request bodies, while keeping rejected Location secrets out of diagnostics. Thanks @TurboTheTurtle.
 - Redacted colon-delimited and line-folded bearer credentials from CLI and coordinator diagnostics. Thanks @TurboTheTurtle.
+- Required coordinator AWS, Azure, and GCP release and provisioning-failure cleanup to re-read the stored cloud resource and verify exact provider, resource, lease, owner, and slug ownership before deletion; Azure now persists the exact subscription/resource-group scope for deferred retries and fails legacy unscoped cleanup closed for manual resolution. Thanks @coygeek.
 
 ## 0.36.0 - 2026-07-05
 

--- a/docs/providers/gcp.md
+++ b/docs/providers/gcp.md
@@ -203,6 +203,13 @@ Verify configuration:
 crabbox doctor --provider gcp
 ```
 
+Maintainers can exercise the coordinator's exact ownership boundary against a
+disposable `e2-micro`: set the three required secrets above plus
+`LIVE_SSH_PUBLIC_KEY`, then run
+`CRABBOX_GCP_RELEASE_LIVE=1 npm test --prefix worker -- --run test/gcp-release.live.test.ts`.
+The smoke proves a foreign owner claim is denied, the exact owner claim is
+deleted, and neither the instance nor its boot disk remains.
+
 The readiness check reports missing secret names without exposing values. Lease
 creation fails with `provider_not_configured` until the Worker has the
 service-account credentials.

--- a/worker/src/aws.ts
+++ b/worker/src/aws.ts
@@ -511,6 +511,16 @@ export class EC2SpotClient {
     throw new Error(`aws instance not found: ${instanceID}`);
   }
 
+  async findServer(instanceID: string): Promise<ProviderMachine | undefined> {
+    try {
+      return await this.getServer(instanceID);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (isAWSInstanceNotFoundError(message)) return undefined;
+      throw error;
+    }
+  }
+
   async waitForServerIP(instanceID: string): Promise<ProviderMachine> {
     const deadline = Date.now() + 600_000;
     while (Date.now() < deadline) {

--- a/worker/src/azure.ts
+++ b/worker/src/azure.ts
@@ -7,9 +7,19 @@ import {
   validatedCIDRs,
   type LeaseConfig,
 } from "./config";
-import { leaseProviderLabels } from "./provider-labels";
+import { leaseProviderLabels, providerLabelsOwnedByLease } from "./provider-labels";
+import {
+  ProviderProvisioningCleanupError,
+  providerProvisioningCleanupClaim,
+} from "./provider-provisioning";
 import { leaseProviderName } from "./slug";
-import type { Env, ProviderImage, ProviderMachine, ProvisioningAttempt } from "./types";
+import type {
+  Env,
+  LeaseRecord,
+  ProviderImage,
+  ProviderMachine,
+  ProvisioningAttempt,
+} from "./types";
 
 export { azureSupportsEphemeralFullCaching, azureSupportsEphemeralOS } from "./config";
 
@@ -58,6 +68,7 @@ interface AzureVM {
         diffDiskSettings?: { option?: string; placement?: string; enableFullCaching?: boolean };
       };
     };
+    networkProfile?: { networkInterfaces?: { id?: string }[] };
   };
 }
 
@@ -78,7 +89,31 @@ interface AzureSnapshot {
 interface AzurePublicIP {
   id?: string;
   name?: string;
+  tags?: Record<string, string>;
   properties?: { ipAddress?: string };
+}
+
+interface AzureNIC {
+  id?: string;
+  name?: string;
+  tags?: Record<string, string>;
+  properties?: {
+    ipConfigurations?: { properties?: { publicIPAddress?: { id?: string } } }[];
+  };
+}
+
+interface AzureDisk {
+  id?: string;
+  name?: string;
+  managedBy?: string;
+  tags?: Record<string, string>;
+}
+
+interface AzureOwnedDeleteResources {
+  vm: boolean;
+  nic: boolean;
+  pip: boolean;
+  disk: boolean;
 }
 
 interface AzureSecurityRule {
@@ -102,10 +137,25 @@ interface AzureARMOptions {
   terminalResourceState?: { path: string; apiVersion: string };
 }
 
+class AzureHTTPError extends Error {
+  constructor(
+    readonly method: string,
+    readonly path: string,
+    readonly status: number,
+    readonly body: string,
+  ) {
+    super(`azure ${method} ${path}: http ${status}: ${body}`);
+  }
+}
+
 export interface AzureDeferredCleanupRequest {
   name: string;
   location: string;
+  subscription: string;
   resourceGroup: string;
+  leaseID: string;
+  slug: string;
+  owner: string;
   createdAt: string;
 }
 
@@ -135,6 +185,8 @@ export class AzureClient {
       location?: string;
       vnet?: string;
       nsg?: string;
+      subscription?: string;
+      resourceGroup?: string;
       deferredCleanup?: (request: AzureDeferredCleanupRequest) => Promise<void>;
     } = {},
   ) {
@@ -142,12 +194,14 @@ export class AzureClient {
     if (!env.AZURE_TENANT_ID) throw new Error("AZURE_TENANT_ID secret is required");
     if (!env.AZURE_CLIENT_ID) throw new Error("AZURE_CLIENT_ID secret is required");
     if (!env.AZURE_CLIENT_SECRET) throw new Error("AZURE_CLIENT_SECRET secret is required");
-    if (!env.AZURE_SUBSCRIPTION_ID) throw new Error("AZURE_SUBSCRIPTION_ID secret is required");
+    const subscription = options.subscription?.trim() || env.AZURE_SUBSCRIPTION_ID?.trim();
+    if (!subscription) throw new Error("AZURE_SUBSCRIPTION_ID secret is required");
     this.tenant = env.AZURE_TENANT_ID;
     this.clientID = env.AZURE_CLIENT_ID;
     this.secret = env.AZURE_CLIENT_SECRET;
-    this.subscription = env.AZURE_SUBSCRIPTION_ID;
-    this.resourceGroup = env.CRABBOX_AZURE_RESOURCE_GROUP?.trim() || "crabbox-leases";
+    this.subscription = subscription;
+    this.resourceGroup =
+      options.resourceGroup?.trim() || env.CRABBOX_AZURE_RESOURCE_GROUP?.trim() || "crabbox-leases";
     this.vnet = options.vnet || env.CRABBOX_AZURE_VNET?.trim() || "crabbox-vnet";
     this.subnet = env.CRABBOX_AZURE_SUBNET?.trim() || "crabbox-subnet";
     this.nsg = options.nsg || env.CRABBOX_AZURE_NSG?.trim() || "crabbox-nsg";
@@ -177,6 +231,22 @@ export class AzureClient {
       ),
     );
     return tagged.map((vm, index) => toMachine(vm, ips[index] ?? ""));
+  }
+
+  async getServer(name: string): Promise<ProviderMachine> {
+    return toMachine(
+      await this.arm<AzureVM>("GET", vmPath(this.resourceGroup, name), API_VERSIONS.compute),
+      "",
+    );
+  }
+
+  async findServer(name: string): Promise<ProviderMachine | undefined> {
+    try {
+      return await this.getServer(name);
+    } catch (error) {
+      if (azureVMNotFound(error, name)) return undefined;
+      throw error;
+    }
   }
 
   async createServerWithFallback(
@@ -215,6 +285,7 @@ export class AzureClient {
           ? { ...result, server, attempts: allAttempts }
           : { ...result, server };
       } catch (error) {
+        if (providerProvisioningCleanupClaim(error)) throw error;
         const message = error instanceof Error ? error.message : String(error);
         attempts.push({
           region: location,
@@ -291,6 +362,7 @@ export class AzureClient {
           ? { server, serverType: vmSize, market: config.capacityMarket, attempts }
           : { server, serverType: vmSize, market: config.capacityMarket };
       } catch (error) {
+        if (providerProvisioningCleanupClaim(error)) throw error;
         const message = error instanceof Error ? error.message : String(error);
         attempts.push({
           region: location,
@@ -334,6 +406,7 @@ export class AzureClient {
             ? { server, serverType: vmSize, market: "on-demand", attempts }
             : { server, serverType: vmSize, market: "on-demand" };
         } catch (error) {
+          if (providerProvisioningCleanupClaim(error)) throw error;
           const message = error instanceof Error ? error.message : String(error);
           attempts.push({
             region: location,
@@ -366,84 +439,239 @@ export class AzureClient {
     }
   }
 
-  private async deleteServerOnce(name: string): Promise<{ errors: string[]; retry: boolean }> {
-    const result = { errors: [] as string[], retry: false };
-    await this.deleteResource("vm", vmPath(this.resourceGroup, name), API_VERSIONS.compute, result);
-    await this.deleteResource(
-      "nic",
-      networkPath(this.resourceGroup, "networkInterfaces", `${name}-nic`),
-      API_VERSIONS.network,
-      result,
-    );
-    await this.deleteResource(
-      "pip",
-      networkPath(this.resourceGroup, "publicIPAddresses", `${name}-pip`),
-      API_VERSIONS.network,
-      result,
-    );
-    await this.deleteResource(
-      "disk",
-      `/resourceGroups/${this.resourceGroup}/providers/Microsoft.Compute/disks/${name}-osdisk`,
-      API_VERSIONS.disks,
-      result,
-    );
-    return result;
-  }
-
-  private async requestDeleteServer(name: string): Promise<void> {
-    const result = { errors: [] as string[], retry: false };
-    await this.requestDeleteResource(
-      "vm",
-      vmPath(this.resourceGroup, name),
-      API_VERSIONS.compute,
-      result,
-    );
-    await this.requestDeleteResource(
-      "nic",
-      networkPath(this.resourceGroup, "networkInterfaces", `${name}-nic`),
-      API_VERSIONS.network,
-      result,
-    );
-    await this.requestDeleteResource(
-      "pip",
-      networkPath(this.resourceGroup, "publicIPAddresses", `${name}-pip`),
-      API_VERSIONS.network,
-      result,
-    );
-    await this.requestDeleteResource(
-      "disk",
-      `/resourceGroups/${this.resourceGroup}/providers/Microsoft.Compute/disks/${name}-osdisk`,
-      API_VERSIONS.disks,
-      result,
-    );
-    if (result.errors.length > 0) {
-      throw new Error(result.errors.join("; "));
+  async deleteOwnedServer(
+    lease: Pick<LeaseRecord, "id" | "slug" | "provider" | "cloudID" | "owner" | "providerScope">,
+  ): Promise<void> {
+    if (lease.providerScope !== this.providerScope()) {
+      throw new Error(
+        `refusing to delete Azure lease ${lease.id}: stored provider scope does not match the cleanup client`,
+      );
+    }
+    const order: (keyof AzureOwnedDeleteResources)[] = ["vm", "nic", "pip", "disk"];
+    for (const kind of order) {
+      for (let attempt = 0; ; attempt += 1) {
+        // Re-read every surviving resource before each destructive operation so
+        // a same-name replacement cannot inherit authorization from an older read.
+        // oxlint-disable-next-line eslint/no-await-in-loop -- every delete requires fresh ownership proof.
+        const resources = await this.ownedDeleteResources(lease);
+        if (!resources.vm && !resources.nic && !resources.pip && !resources.disk) return;
+        if (!resources[kind]) break;
+        const selected: AzureOwnedDeleteResources = {
+          vm: false,
+          nic: false,
+          pip: false,
+          disk: false,
+        };
+        selected[kind] = true;
+        // oxlint-disable-next-line eslint/no-await-in-loop -- each delete uses the fresh ownership proof above.
+        const result = await this.deleteServerOnce(lease.cloudID, selected, true);
+        if (result.errors.length === 0) break;
+        if (!result.retry || attempt >= DELETE_RETRY_ATTEMPTS - 1) {
+          throw new Error(result.errors.join("; "));
+        }
+        console.warn(
+          `azure owned delete retry name=${lease.cloudID} resource=${kind} attempt=${attempt + 1}/${DELETE_RETRY_ATTEMPTS}: ${result.errors.join("; ")}`,
+        );
+        // oxlint-disable-next-line eslint/no-await-in-loop -- the next ownership read follows this delay.
+        await sleep(DELETE_RETRY_DELAY_MS);
+      }
     }
   }
 
-  private async requestDeleteResource(
-    kind: string,
+  private async ownedDeleteResources(
+    lease: Pick<LeaseRecord, "id" | "slug" | "provider" | "cloudID" | "owner">,
+  ): Promise<AzureOwnedDeleteResources> {
+    const name = lease.cloudID;
+    const vmResourcePath = vmPath(this.resourceGroup, name);
+    const nicResourcePath = networkPath(this.resourceGroup, "networkInterfaces", `${name}-nic`);
+    const pipResourcePath = networkPath(this.resourceGroup, "publicIPAddresses", `${name}-pip`);
+    const diskResourcePath = `/resourceGroups/${this.resourceGroup}/providers/Microsoft.Compute/disks/${name}-osdisk`;
+    const [vm, nic, pip, disk] = await Promise.all([
+      this.ownedResource<AzureVM>(vmResourcePath, API_VERSIONS.compute, "virtualMachines", name),
+      this.ownedResource<AzureNIC>(
+        nicResourcePath,
+        API_VERSIONS.network,
+        "networkInterfaces",
+        `${name}-nic`,
+      ),
+      this.ownedResource<AzurePublicIP>(
+        pipResourcePath,
+        API_VERSIONS.network,
+        "publicIPAddresses",
+        `${name}-pip`,
+      ),
+      this.ownedResource<AzureDisk>(
+        diskResourcePath,
+        API_VERSIONS.disks,
+        "disks",
+        `${name}-osdisk`,
+      ),
+    ]);
+
+    if (vm) this.requireOwnedResource("VM", vm, vmResourcePath, lease);
+    if (nic) this.requireOwnedResource("NIC", nic, nicResourcePath, lease);
+    if (pip) this.requireOwnedResource("public IP", pip, pipResourcePath, lease);
+
+    const expectedNICID = this.resourceID(nicResourcePath);
+    const expectedPIPID = this.resourceID(pipResourcePath);
+    const expectedDiskID = this.resourceID(diskResourcePath);
+    if (
+      vm &&
+      !vm.properties?.networkProfile?.networkInterfaces?.some((item) =>
+        azureResourceIDEqual(item.id, expectedNICID),
+      )
+    ) {
+      throw new Error(
+        `refusing to delete Azure resources for ${name}: VM does not own ${name}-nic`,
+      );
+    }
+    if (
+      nic &&
+      pip &&
+      !nic.properties?.ipConfigurations?.some((config) =>
+        azureResourceIDEqual(config.properties?.publicIPAddress?.id, expectedPIPID),
+      )
+    ) {
+      throw new Error(
+        `refusing to delete Azure resources for ${name}: NIC does not own ${name}-pip`,
+      );
+    }
+
+    if (disk) {
+      const vmDiskID = vm?.properties?.storageProfile?.osDisk?.managedDisk?.id;
+      this.requireResourceIdentity("disk", disk, diskResourcePath, lease.id);
+      if (vm && !azureResourceIDEqual(vmDiskID, expectedDiskID)) {
+        throw new Error(
+          `refusing to delete Azure resources for ${name}: VM does not own ${name}-osdisk`,
+        );
+      }
+      if (!providerLabelsOwnedByLease(azureLabelsFromTags(disk.tags ?? {}), lease, "azure")) {
+        const diskLabels = azureLabelsFromTags(disk.tags ?? {});
+        if (azureHasOwnershipClaims(diskLabels)) {
+          throw new Error(
+            `refusing to delete Azure disk ${name}-osdisk: ownership does not match lease ${lease.id}`,
+          );
+        }
+        if (
+          !vm ||
+          !azureResourceIDEqual(vmDiskID, expectedDiskID) ||
+          !azureResourceIDEqual(disk.managedBy, this.resourceID(vmResourcePath))
+        ) {
+          throw new Error(
+            `refusing to delete Azure disk ${name}-osdisk: ownership does not match lease ${lease.id}`,
+          );
+        }
+        const ownershipTags = azureOwnershipTags(vm.tags ?? {}, lease);
+        // Azure-created OS disks do not inherit VM tags. Bind the disk while
+        // the verified VM association is live so a later retry remains safe.
+        await this.arm("PATCH", diskResourcePath, API_VERSIONS.disks, {
+          tags: { ...disk.tags, ...ownershipTags },
+        });
+        const taggedDisk = await this.arm<AzureDisk>("GET", diskResourcePath, API_VERSIONS.disks);
+        this.requireOwnedResource("disk", taggedDisk, diskResourcePath, lease);
+      } else {
+        this.requireOwnedResource("disk", disk, diskResourcePath, lease);
+      }
+    }
+
+    return { vm: Boolean(vm), nic: Boolean(nic), pip: Boolean(pip), disk: Boolean(disk) };
+  }
+
+  private async ownedResource<T>(
     path: string,
     apiVersion: string,
-    result: { errors: string[]; retry: boolean },
-  ): Promise<void> {
-    const token = await this.token();
-    const url = `https://management.azure.com/subscriptions/${this.subscription}${path}?api-version=${apiVersion}`;
-    const response = await this.fetcher(url, {
-      method: "DELETE",
-      headers: { authorization: `Bearer ${token}` },
-    });
-    if (
-      response.ok ||
-      response.status === 202 ||
-      response.status === 204 ||
-      response.status === 404
-    ) {
-      return;
+    kind: string,
+    name: string,
+  ): Promise<T | undefined> {
+    try {
+      return await this.arm<T>("GET", path, apiVersion);
+    } catch (error) {
+      if (azureResourceNotFound(error, kind, name)) return undefined;
+      throw error;
     }
-    const body = await safeBody(response);
-    result.errors.push(`delete ${kind} ${path}: http ${response.status}: ${body}`);
-    if (isRetryableDeleteError(body)) result.retry = true;
+  }
+
+  private requireOwnedResource(
+    kind: string,
+    resource: { id?: string; name?: string; tags?: Record<string, string> },
+    path: string,
+    lease: Pick<LeaseRecord, "id" | "slug" | "provider" | "owner">,
+  ): void {
+    this.requireResourceIdentity(kind, resource, path, lease.id);
+    if (!providerLabelsOwnedByLease(azureLabelsFromTags(resource.tags ?? {}), lease, "azure")) {
+      throw new Error(
+        `refusing to delete Azure ${kind} ${azureResourceName(path)}: ownership does not match lease ${lease.id}`,
+      );
+    }
+  }
+
+  private requireResourceIdentity(
+    kind: string,
+    resource: { id?: string; name?: string },
+    path: string,
+    leaseID: string,
+  ): void {
+    if (
+      resource.name !== azureResourceName(path) ||
+      !azureResourceIDEqual(resource.id, this.resourceID(path))
+    ) {
+      throw new Error(
+        `refusing to delete Azure ${kind} ${azureResourceName(path)}: identity does not match lease ${leaseID}`,
+      );
+    }
+  }
+
+  private resourceID(path: string): string {
+    return `/subscriptions/${this.subscription}${path}`;
+  }
+
+  providerScope(): string {
+    return `/subscriptions/${this.subscription}/resourceGroups/${this.resourceGroup}`;
+  }
+
+  private async deleteServerOnce(
+    name: string,
+    resources: AzureOwnedDeleteResources = { vm: true, nic: true, pip: true, disk: true },
+    exactNotFound = false,
+  ): Promise<{ errors: string[]; retry: boolean }> {
+    const result = { errors: [] as string[], retry: false };
+    if (resources.vm) {
+      await this.deleteResource(
+        "vm",
+        vmPath(this.resourceGroup, name),
+        API_VERSIONS.compute,
+        result,
+        exactNotFound ? { kind: "virtualMachines", name } : undefined,
+      );
+    }
+    if (resources.nic) {
+      await this.deleteResource(
+        "nic",
+        networkPath(this.resourceGroup, "networkInterfaces", `${name}-nic`),
+        API_VERSIONS.network,
+        result,
+        exactNotFound ? { kind: "networkInterfaces", name: `${name}-nic` } : undefined,
+      );
+    }
+    if (resources.pip) {
+      await this.deleteResource(
+        "pip",
+        networkPath(this.resourceGroup, "publicIPAddresses", `${name}-pip`),
+        API_VERSIONS.network,
+        result,
+        exactNotFound ? { kind: "publicIPAddresses", name: `${name}-pip` } : undefined,
+      );
+    }
+    if (resources.disk) {
+      await this.deleteResource(
+        "disk",
+        `/resourceGroups/${this.resourceGroup}/providers/Microsoft.Compute/disks/${name}-osdisk`,
+        API_VERSIONS.disks,
+        result,
+        exactNotFound ? { kind: "disks", name: `${name}-osdisk` } : undefined,
+      );
+    }
+    return result;
   }
 
   private async deleteResource(
@@ -451,11 +679,18 @@ export class AzureClient {
     path: string,
     apiVersion: string,
     result: { errors: string[]; retry: boolean },
+    exactNotFound?: { kind: string; name: string },
   ): Promise<void> {
     try {
       await this.arm("DELETE", path, apiVersion);
     } catch (error) {
-      if (isNotFound(error)) return;
+      if (
+        exactNotFound
+          ? azureResourceNotFound(error, exactNotFound.kind, exactNotFound.name)
+          : isNotFound(error)
+      ) {
+        return;
+      }
       result.errors.push(`delete ${kind}: ${errorMessage(error)}`);
       result.retry ||= isRetryableDeleteError(error);
     }
@@ -641,17 +876,36 @@ export class AzureClient {
       if (isAzureVMCreateTimeout(error)) {
         await this.deferredCleanup?.({
           name,
-          location: this.defaultLocation,
+          location,
+          subscription: this.subscription,
           resourceGroup: this.resourceGroup,
+          leaseID,
+          slug,
+          owner,
           createdAt: new Date().toISOString(),
         });
-        await this.requestDeleteServer(name).catch((cleanupError: unknown) => {
-          const message =
-            cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
-          console.warn(`azure spot timeout cleanup failed name=${name}: ${message}`);
-        });
       } else {
-        await this.deleteServer(name).catch(() => undefined);
+        try {
+          await this.deleteOwnedServer({
+            id: leaseID,
+            slug,
+            provider: "azure",
+            cloudID: name,
+            owner,
+            providerScope: this.providerScope(),
+          });
+        } catch (cleanupError) {
+          throw new ProviderProvisioningCleanupError(
+            `${errorMessage(error)}; Azure provisioning cleanup failed closed: ${errorMessage(cleanupError)}`,
+            {
+              provider: "azure",
+              cloudID: name,
+              region: location,
+              providerScope: this.providerScope(),
+            },
+            cleanupError,
+          );
+        }
       }
       throw error;
     }
@@ -771,6 +1025,17 @@ export class AzureClient {
       },
       vmLROTimeoutMs === undefined ? undefined : { lroTimeoutMs: vmLROTimeoutMs },
     );
+    const configuredOSDisk = storageProfile["osDisk"] as
+      | { diffDiskSettings?: { option?: string } }
+      | undefined;
+    if (!configuredOSDisk?.diffDiskSettings?.option) {
+      await this.arm(
+        "PATCH",
+        `/resourceGroups/${this.resourceGroup}/providers/Microsoft.Compute/disks/${name}-osdisk`,
+        API_VERSIONS.disks,
+        { tags },
+      );
+    }
     if (config.azureSnapshot && config.target !== "windows") {
       await this.installLinuxSSHKeyExtension(location, name, tags, config);
     }
@@ -1097,9 +1362,7 @@ export class AzureClient {
     if (body !== undefined) init.body = JSON.stringify(body);
     const response = await this.fetcher(url, init);
     if (!response.ok && response.status !== 201 && response.status !== 202) {
-      throw new Error(
-        `azure ${method} ${path}: http ${response.status}: ${await safeBody(response)}`,
-      );
+      throw new AzureHTTPError(method, path, response.status, await safeBody(response));
     }
     const initialText = await response.text();
     if (response.status === 201 || response.status === 202) {
@@ -1422,6 +1685,48 @@ function azureTagToLabelKey(key: string): string {
 function isNotFound(error: unknown): boolean {
   const message = errorMessage(error);
   return message.includes("http 404") || message.includes("ResourceNotFound");
+}
+
+function azureVMNotFound(error: unknown, name: string): boolean {
+  return azureResourceNotFound(error, "virtualMachines", name);
+}
+
+function azureResourceNotFound(error: unknown, kind: string, name: string): boolean {
+  if (!(error instanceof AzureHTTPError) || error.status !== 404) return false;
+  const namespace = kind === "virtualMachines" || kind === "disks" ? "compute" : "network";
+  const body = error.body.toLowerCase();
+  return (
+    body.includes("resourcenotfound") &&
+    body.includes(`microsoft.${namespace}/${kind.toLowerCase()}/${name.toLowerCase()}`)
+  );
+}
+
+function azureResourceIDEqual(actual: string | undefined, expected: string): boolean {
+  return actual?.trim().toLowerCase() === expected.trim().toLowerCase();
+}
+
+function azureHasOwnershipClaims(labels: Record<string, string>): boolean {
+  return ["crabbox", "created_by", "lease", "owner", "provider", "slug"].some(
+    (key) => (labels[key] ?? "").trim().length > 0,
+  );
+}
+
+function azureOwnershipTags(
+  tags: Record<string, string>,
+  lease: Pick<LeaseRecord, "id" | "slug" | "provider" | "owner">,
+): Record<string, string> {
+  const labels = azureLabelsFromTags(tags);
+  if (!providerLabelsOwnedByLease(labels, lease, "azure")) {
+    throw new Error(`Azure VM ownership does not match lease ${lease.id}`);
+  }
+  return azureTagsFromLabels({
+    crabbox: labels["crabbox"]!,
+    created_by: labels["created_by"]!,
+    lease: labels["lease"]!,
+    owner: labels["owner"]!,
+    provider: labels["provider"]!,
+    slug: labels["slug"]!,
+  });
 }
 
 function errorMessage(error: unknown): string {

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -22,6 +22,7 @@ import {
   awsProvisioningErrorCategory,
   awsRegionCandidates,
   isAWSInstanceCleanedAfterReadinessFailure,
+  isAWSInstanceNotFoundError,
   isRetryableAWSProvisioningError,
   isAWSSecurityGroupRuleLimitError,
   type AWSMacHost,
@@ -49,7 +50,7 @@ import {
   coordinatorRequestQueue,
   type CoordinatorRuntime,
 } from "./coordinator-runtime";
-import { GCPClient } from "./gcp";
+import { GCPClient, gcpProviderLabelValue } from "./gcp";
 import {
   HetznerClient,
   HetznerProvisioningError,
@@ -101,6 +102,13 @@ import {
   webVNCBridgeCommand,
 } from "./portal";
 import { leaseIDForProviderKey, providerKeyForLease, sshPublicKeyIdentity } from "./provider-key";
+import { providerMachineOwnedByLease, workspacePrewarmProviderOwner } from "./provider-labels";
+import {
+  ProviderProvisioningCleanupError,
+  providerProvisioningCleanupClaim,
+  type ProviderProvisioningCleanupClaim,
+  validatedProviderProvisioningCleanupClaim,
+} from "./provider-provisioning";
 import {
   readRuntimeAdapterRelayBody,
   runtimeAdapterProxyPath,
@@ -227,7 +235,7 @@ const workspaceMinimumTTLSeconds =
   (workspaceProvisionClaimMs + workspaceProvisionRecoveryGraceMs) / 1000;
 const workspaceMaxRecordsPerOwner = 100;
 const workspaceTerminalRetentionMs = 24 * 60 * 60_000;
-const workspacePrewarmOwner = "crabbox-internal-prewarm";
+const workspacePrewarmOwner = workspacePrewarmProviderOwner;
 const workspacePrewarmReplacementLeadMs = 5 * 60_000;
 const workspacePrewarmRetryDelayMs = 5 * 60_000;
 const workspaceTerminalMaxBufferedBytes = 1024 * 1024;
@@ -630,6 +638,14 @@ interface AzureDeferredCleanupRecord extends AzureDeferredCleanupRequest {
   updatedAt: string;
   retryAt: string;
   lastError?: string;
+  terminalAt?: string;
+}
+
+class ProviderCleanupManualResolutionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ProviderCleanupManualResolutionError";
+  }
 }
 
 interface AWSIngressReconcileTarget {
@@ -2351,6 +2367,7 @@ export class FleetCoordinator {
         code: config.code,
         cloudID: "",
         owner,
+        providerOwner: owner,
         org,
         profile: config.profile,
         class: config.class,
@@ -2601,12 +2618,28 @@ export class FleetCoordinator {
           : this.withAWSIngressOperationLock(provision);
     const { server, serverType, market, attempts } = await provisioned.catch(
       async (error: unknown) => {
+        const cleanupClaim = validatedProviderProvisioningCleanupClaim(error, config.provider);
         await this.state.runExclusive(async () => {
           if (prepared?.provisioning?.publishAccessBeforeProvisioning) {
             await this.deleteProviderAccess(record.id);
           }
           const current = await this.getLease(record.id);
           if (!current || current.state !== "provisioning") {
+            if (cleanupClaim) {
+              const failedAt = new Date().toISOString();
+              record = structuredClone(current ?? record);
+              if (record.state !== "released" && record.state !== "expired") {
+                record.state = "failed";
+                record.endedAt = failedAt;
+              }
+              retainProvisioningCleanupClaim(
+                record,
+                cleanupClaim,
+                coordinatorErrorMessage(this.env, error),
+                failedAt,
+              );
+              await this.putLease(record);
+            }
             await this.markAWSIngressReconcilePending(record);
             await this.scheduleAlarm();
             return;
@@ -2618,10 +2651,15 @@ export class FleetCoordinator {
           record.endedAt = failedAt;
           record.cleanupFailedAt = failedAt;
           record.cleanupError = coordinatorErrorMessage(this.env, error);
-          record.provisioningResourceMayExist =
-            config.provider === "hetzner" && hetznerProvisioningFailureMayHaveResource(error);
-          record.provisioningFailureRetryable =
-            config.provider === "hetzner" && hetznerProvisioningFailureRetryable(error);
+          record.provisioningResourceMayExist = cleanupClaim
+            ? true
+            : config.provider === "hetzner" && hetznerProvisioningFailureMayHaveResource(error);
+          record.provisioningFailureRetryable = cleanupClaim
+            ? false
+            : config.provider === "hetzner" && hetznerProvisioningFailureRetryable(error);
+          if (cleanupClaim) {
+            retainProvisioningCleanupClaim(record, cleanupClaim, record.cleanupError, failedAt);
+          }
           const failedHetznerServerID =
             config.provider === "hetzner" ? hetznerProvisioningResourceID(error) : undefined;
           if (failedHetznerServerID !== undefined) {
@@ -2636,7 +2674,11 @@ export class FleetCoordinator {
             record.providerKeyCleanupPending = true;
             record.providerKeyCleanupID = String(error.providerKeyCleanupID);
           }
-          if (failedHetznerServerID !== undefined || record.providerKeyCleanupPending) {
+          if (
+            cleanupClaim ||
+            failedHetznerServerID !== undefined ||
+            record.providerKeyCleanupPending
+          ) {
             record.cleanupRetryAt = new Date(
               Date.parse(failedAt) + leaseCleanupRetryDelayMs,
             ).toISOString();
@@ -2973,6 +3015,7 @@ export class FleetCoordinator {
     const createdAt = Date.parse(lease.createdAt);
     const adoptedTTLSeconds = Math.max(1, Math.ceil((expiresAt.getTime() - createdAt) / 1000));
     lease.workspaceID = input.id;
+    lease.providerOwner ??= lease.owner;
     lease.owner = input.owner;
     lease.org = input.org;
     lease.profile = input.profile;
@@ -10539,10 +10582,12 @@ export class FleetCoordinator {
       claims.map(async ({ claim, lease }) => {
         const cleanup = async () => {
           let failure: string | undefined;
+          let manualResolution = false;
           try {
             await this.deleteLeaseServer(lease);
           } catch (error) {
             failure = coordinatorErrorMessage(this.env, error);
+            manualResolution = error instanceof ProviderCleanupManualResolutionError;
           }
           await this.state.runExclusive(async () => {
             const current = await this.getLease(lease.id);
@@ -10551,6 +10596,11 @@ export class FleetCoordinator {
             }
             const nowDate = new Date();
             const nowISO = nowDate.toISOString();
+            if (failure && manualResolution) {
+              terminalizeManualProviderCleanup(current, failure, nowISO);
+              await this.putLease(current);
+              return;
+            }
             if (failure) {
               current.cleanupAttempts = (current.cleanupAttempts ?? 0) + 1;
               delete current.cleanupStartedAt;
@@ -10570,6 +10620,13 @@ export class FleetCoordinator {
             current.state = leaseIsLive(current) ? "expired" : current.state;
             current.updatedAt = nowISO;
             current.endedAt = nowISO;
+            if (current.state === "failed" && current.provisioningResourceMayExist) {
+              if (!current.failureError && current.cleanupError) {
+                current.failureError = current.cleanupError;
+              }
+              current.provisioningResourceMayExist = false;
+              current.provisioningFailureRetryable = false;
+            }
             delete current.releaseDeletesServer;
             clearLeaseCleanupMetadata(current);
             delete current.providerKeyCleanupPending;
@@ -10871,6 +10928,7 @@ export class FleetCoordinator {
       prefix: azureDeferredCleanupPrefix,
     });
     const times = [...records.values()]
+      .filter((record) => !record.terminalAt)
       .map((record) => Date.parse(record.retryAt))
       .filter((time) => Number.isFinite(time));
     if (times.length === 0) {
@@ -10888,25 +10946,40 @@ export class FleetCoordinator {
     const now = Date.now();
     await Promise.all(
       [...records.entries()].map(async ([key, record]) => {
+        if (record.terminalAt) {
+          return;
+        }
         const retryAt = Date.parse(record.retryAt);
         if (Number.isFinite(retryAt) && retryAt > now) {
           return;
         }
         try {
-          await new AzureClient(this.env, { location: record.location }).deleteServer(record.name);
+          const lease = azureDeferredCleanupLease(record);
+          const scope = azureProviderScope(lease.providerScope)!;
+          await new AzureClient(this.env, {
+            location: record.location,
+            subscription: scope.subscription,
+            resourceGroup: scope.resourceGroup,
+          }).deleteOwnedServer(lease);
         } catch (error) {
           await this.state.runExclusive(async () => {
             const current = await this.state.storage.get<AzureDeferredCleanupRecord>(key);
             if (!current || current.updatedAt !== record.updatedAt) {
               return;
             }
+            const terminal = error instanceof ProviderCleanupManualResolutionError;
             const nextRecord: AzureDeferredCleanupRecord = {
               ...current,
               attempts: current.attempts + 1,
               updatedAt: new Date().toISOString(),
-              retryAt: new Date(now + leaseCleanupRetryDelayMs).toISOString(),
+              retryAt: terminal
+                ? current.retryAt
+                : new Date(now + leaseCleanupRetryDelayMs).toISOString(),
               lastError: coordinatorErrorMessage(this.env, error),
             };
+            if (terminal) {
+              nextRecord.terminalAt = nextRecord.updatedAt;
+            }
             await this.state.storage.put(key, nextRecord);
             console.warn(
               `azure deferred cleanup failed name=${record.name} location=${record.location}: ${nextRecord.lastError}`,
@@ -12234,6 +12307,16 @@ export class FleetCoordinator {
       await this.state.runExclusive(async () => {
         const current = await this.getLease(preparation.lease.id);
         if (!current || current.cleanupStartedAt !== preparation.claim) {
+          return;
+        }
+        if (error instanceof ProviderCleanupManualResolutionError) {
+          terminalizeManualProviderCleanup(
+            current,
+            coordinatorErrorMessage(this.env, error),
+            new Date().toISOString(),
+          );
+          await this.putLease(current);
+          await this.scheduleAlarm();
           return;
         }
         const failedAt = new Date();
@@ -14239,6 +14322,60 @@ function providerResourceNotFound(error: unknown): boolean {
   return message.includes("http 404") || isCloudNotFoundError(message);
 }
 
+function azureProviderScope(
+  value: string | undefined,
+): { subscription: string; resourceGroup: string } | undefined {
+  const match = /^\/subscriptions\/([^/]+)\/resourceGroups\/([^/]+)$/i.exec(value?.trim() ?? "");
+  if (!match?.[1] || !match[2]) return undefined;
+  return { subscription: match[1], resourceGroup: match[2] };
+}
+
+function azureDeferredCleanupLease(
+  record: AzureDeferredCleanupRecord,
+): Pick<LeaseRecord, "id" | "slug" | "provider" | "cloudID" | "owner" | "providerScope"> {
+  const subscription = record.subscription?.trim();
+  const resourceGroup = record.resourceGroup?.trim();
+  const providerScope = `/subscriptions/${subscription}/resourceGroups/${resourceGroup}`;
+  if (
+    !subscription ||
+    !resourceGroup ||
+    !validLeaseID(record.leaseID) ||
+    !normalizeLeaseSlug(record.slug) ||
+    !record.owner?.trim() ||
+    !azureProviderScope(providerScope)
+  ) {
+    throw new ProviderCleanupManualResolutionError(
+      `refusing Azure deferred cleanup for ${record.name}: canonical lease claim and provider scope were not persisted`,
+    );
+  }
+  return {
+    id: record.leaseID,
+    slug: record.slug,
+    provider: "azure",
+    cloudID: record.name,
+    owner: record.owner,
+    providerScope,
+  };
+}
+
+async function ownedProviderMachineForRelease(
+  provider: Extract<Provider, "aws" | "azure" | "gcp">,
+  lease: LeaseRecord,
+  findServer: (id: string) => Promise<ProviderMachine | undefined>,
+  options: {
+    labelValue?: (value: string) => string;
+  } = {},
+): Promise<ProviderMachine | undefined> {
+  const machine = await findServer(lease.cloudID);
+  if (!machine) return undefined;
+  if (!providerMachineOwnedByLease(machine, lease, provider, options.labelValue)) {
+    throw new Error(
+      `refusing to delete ${provider} resource ${lease.cloudID}: ownership does not match lease ${lease.id}`,
+    );
+  }
+  return machine;
+}
+
 function checkpointStrategy(value: string | undefined): "image" | "disk-snapshot" | undefined {
   switch ((value ?? "").trim().toLowerCase()) {
     case "image":
@@ -14317,8 +14454,8 @@ function allowProviderImageDelete(): Promise<undefined> {
   return Promise.resolve(undefined);
 }
 
-function azureDeferredCleanupKey(location: string, name: string): string {
-  return `${azureDeferredCleanupPrefix}${location}:${name}`;
+function azureDeferredCleanupKey(request: AzureDeferredCleanupRequest): string {
+  return `${azureDeferredCleanupPrefix}${encodeURIComponent(request.subscription)}:${encodeURIComponent(request.resourceGroup)}:${encodeURIComponent(request.location)}:${encodeURIComponent(request.name)}`;
 }
 
 export function recordAzureDeferredCleanup(
@@ -14327,7 +14464,7 @@ export function recordAzureDeferredCleanup(
   request: AzureDeferredCleanupRequest,
 ): Promise<void> {
   return state.runExclusive(async () => {
-    const key = azureDeferredCleanupKey(request.location, request.name);
+    const key = azureDeferredCleanupKey(request);
     const current = await state.storage.get<AzureDeferredCleanupRecord>(key);
     const now = new Date().toISOString();
     const record: AzureDeferredCleanupRecord = {
@@ -15833,6 +15970,35 @@ function provisionedLeaseRecord(
   };
 }
 
+function retainProvisioningCleanupClaim(
+  lease: LeaseRecord,
+  claim: ProviderProvisioningCleanupClaim,
+  error: string,
+  failedAt: string,
+): void {
+  const retainResource = lease.state === "released" && lease.releaseDeletesServer === false;
+  lease.cloudID = claim.cloudID;
+  lease.serverName = claim.cloudID;
+  lease.serverID = claim.serverID ?? 0;
+  lease.updatedAt = failedAt;
+  if (claim.region) lease.region = claim.region;
+  if (claim.providerProject) lease.providerProject = claim.providerProject;
+  if (claim.providerScope) lease.providerScope = claim.providerScope;
+  if (retainResource) {
+    lease.keep = true;
+    clearLeaseCleanupMetadata(lease);
+    delete lease.provisioningResourceMayExist;
+    delete lease.provisioningFailureRetryable;
+    return;
+  }
+  lease.releaseDeletesServer = true;
+  lease.provisioningResourceMayExist = true;
+  lease.provisioningFailureRetryable = false;
+  lease.cleanupError = error;
+  lease.cleanupFailedAt = failedAt;
+  lease.cleanupRetryAt = new Date(Date.parse(failedAt) + leaseCleanupRetryDelayMs).toISOString();
+}
+
 function nextLeaseAlarmTime(lease: LeaseRecord): number {
   const now = Date.now();
   const expiresAt = Date.parse(lease.expiresAt);
@@ -15886,6 +16052,26 @@ function clearLeaseCleanupMetadata(lease: LeaseRecord): void {
   delete lease.cleanupError;
   delete lease.cleanupFailedAt;
   delete lease.cleanupRetryAt;
+}
+
+function terminalizeManualProviderCleanup(
+  lease: LeaseRecord,
+  error: string,
+  terminalAt: string,
+): void {
+  if (leaseIsLive(lease)) {
+    lease.state = "expired";
+  }
+  lease.keep = true;
+  lease.releaseDeletesServer = false;
+  lease.failureError = error;
+  lease.updatedAt = terminalAt;
+  lease.endedAt = terminalAt;
+  clearLeaseCleanupMetadata(lease);
+  delete lease.cleanupStartedAt;
+  delete lease.cleanupClaimExpiresAt;
+  delete lease.provisioningResourceMayExist;
+  delete lease.provisioningFailureRetryable;
 }
 
 function clearRuntimeAdapterDeleteMetadata(lease: LeaseRecord): void {
@@ -16743,7 +16929,7 @@ export class HetznerProvider implements CloudProvider {
   }
 }
 
-class AzureProvider implements CloudProvider {
+export class AzureProvider implements CloudProvider {
   private clientValue?: AzureClient;
 
   constructor(
@@ -16771,12 +16957,30 @@ class AzureProvider implements CloudProvider {
     return this.client.listCrabboxServers();
   }
 
+  getServer(id: string): Promise<ProviderMachine> {
+    return this.client.getServer(id);
+  }
+
+  findServer(id: string): Promise<ProviderMachine | undefined> {
+    return this.client.findServer(id);
+  }
+
   async prepareLeaseConfig(
     config: ReturnType<typeof leaseConfig>,
   ): Promise<ReturnType<typeof leaseConfig>> {
     return config.azureLocation
       ? config
       : { ...config, azureLocation: azureLocationFor(this.env, "") };
+  }
+
+  prepareLeaseCreate(
+    config: ReturnType<typeof leaseConfig>,
+    lease: LeaseRecord,
+  ): Promise<ProviderLeaseCreatePreparation> {
+    return Promise.resolve({
+      config,
+      lease: { ...lease, providerScope: this.client.providerScope() },
+    });
   }
 
   createServerWithFallback(
@@ -16797,6 +17001,23 @@ class AzureProvider implements CloudProvider {
     return this.client.deleteServer(id);
   }
 
+  deleteOwnedServer(lease: LeaseRecord): Promise<void> {
+    const scope = azureProviderScope(lease.providerScope);
+    if (!scope) {
+      return Promise.reject(
+        new ProviderCleanupManualResolutionError(
+          `refusing to delete Azure lease ${lease.id}: canonical provider scope was not persisted`,
+        ),
+      );
+    }
+    return new AzureClient(this.env, {
+      ...(this.location ? { location: this.location } : {}),
+      ...(this.deferredCleanup ? { deferredCleanup: this.deferredCleanup } : {}),
+      subscription: scope.subscription,
+      resourceGroup: scope.resourceGroup,
+    }).deleteOwnedServer(lease);
+  }
+
   async finalizeLeaseCreate(
     config: ReturnType<typeof leaseConfig>,
     lease: LeaseRecord,
@@ -16805,7 +17026,11 @@ class AzureProvider implements CloudProvider {
   ): Promise<ProviderLeaseCreateFinalization> {
     const region = server.region || config.azureLocation;
     const nextConfig = region ? { ...config, azureLocation: region } : config;
-    const nextLease: LeaseRecord = { ...lease, region };
+    const nextLease: LeaseRecord = {
+      ...lease,
+      region,
+      providerScope: this.client.providerScope(),
+    };
     const hints = capacityHints(this.env, nextConfig, nextLease, attempts);
     if (hints.length > 0) {
       nextLease.capacityHints = hints;
@@ -16814,7 +17039,7 @@ class AzureProvider implements CloudProvider {
   }
 
   async releaseLease(lease: LeaseRecord): Promise<void> {
-    await this.deleteServer(lease.cloudID);
+    await this.deleteOwnedServer(lease);
   }
 
   supportsNativeImages(): boolean {
@@ -16888,7 +17113,7 @@ class AzureProvider implements CloudProvider {
   }
 }
 
-class GCPProvider implements CloudProvider {
+export class GCPProvider implements CloudProvider {
   private clientValue?: GCPClient;
 
   constructor(
@@ -16920,6 +17145,10 @@ class GCPProvider implements CloudProvider {
 
   getServer(id: string): Promise<ProviderMachine> {
     return this.client.getServer(id);
+  }
+
+  findServer(id: string): Promise<ProviderMachine | undefined> {
+    return this.client.findServer(id);
   }
 
   recoverServer(lease: LeaseRecord): Promise<ProviderMachine | undefined> {
@@ -16980,6 +17209,13 @@ class GCPProvider implements CloudProvider {
   }
 
   async releaseLease(lease: LeaseRecord): Promise<void> {
+    if (
+      !(await ownedProviderMachineForRelease("gcp", lease, (id) => this.findServer(id), {
+        labelValue: gcpProviderLabelValue,
+      }))
+    ) {
+      return;
+    }
     await this.deleteServer(lease.cloudID);
   }
 
@@ -17091,6 +17327,10 @@ export class AWSProvider implements CloudProvider {
 
   getServer(id: string): Promise<ProviderMachine> {
     return this.client.getServer(id);
+  }
+
+  findServer(id: string): Promise<ProviderMachine | undefined> {
+    return this.client.findServer(id);
   }
 
   async prepareLeaseConfig(
@@ -17326,9 +17566,15 @@ export class AWSProvider implements CloudProvider {
             const deleteMessage =
               deleteError instanceof Error ? deleteError.message : String(deleteError);
             if (!isAWSInstanceCleanedAfterReadinessFailure(waitMessage, deleteMessage)) {
-              throw new Error(
+              throw new ProviderProvisioningCleanupError(
                 `${waitMessage}; cleanup failed for AWS instance ${server.cloudID}: ${deleteMessage}`,
-                { cause: deleteError },
+                {
+                  provider: "aws",
+                  cloudID: server.cloudID,
+                  region,
+                  serverID: server.id,
+                },
+                deleteError,
               );
             }
           }
@@ -17352,6 +17598,7 @@ export class AWSProvider implements CloudProvider {
         }
         return result;
       } catch (error) {
+        if (providerProvisioningCleanupClaim(error)) throw error;
         const message = error instanceof Error ? error.message : String(error);
         regionAttempts.push({
           region,
@@ -17393,11 +17640,14 @@ export class AWSProvider implements CloudProvider {
   }
 
   async releaseLease(lease: LeaseRecord): Promise<void> {
+    const server = await ownedProviderMachineForRelease("aws", lease, (id) => this.findServer(id));
     try {
-      await this.deleteServer(lease.cloudID);
+      if (server) {
+        await this.deleteServer(lease.cloudID);
+      }
     } catch (error) {
       const message = coordinatorErrorMessage(this.env, error);
-      if (!isCloudNotFoundError(message)) {
+      if (!isAWSInstanceNotFoundError(message)) {
         throw error;
       }
       console.warn(

--- a/worker/src/gcp.ts
+++ b/worker/src/gcp.ts
@@ -5,7 +5,15 @@ import {
   validatedCIDRs,
   type LeaseConfig,
 } from "./config";
-import { leaseProviderLabels } from "./provider-labels";
+import {
+  leaseProviderLabels,
+  providerLabelValue,
+  providerMachineOwnedByLease,
+} from "./provider-labels";
+import {
+  ProviderProvisioningCleanupError,
+  providerProvisioningCleanupClaim,
+} from "./provider-provisioning";
 import { leaseProviderName } from "./slug";
 import type { Env, ProviderImage, ProviderMachine, ProvisioningAttempt } from "./types";
 
@@ -18,6 +26,17 @@ const firewallVisibilityBackoffMs = [100, 200, 400, 800, 1_600, 3_200];
 interface TokenCache {
   token: string;
   expiresAt: number;
+}
+
+class GCPHTTPError extends Error {
+  constructor(
+    readonly method: string,
+    readonly path: string,
+    readonly status: number,
+    readonly body: string,
+  ) {
+    super(`gcp ${method} ${path}: http ${status}: ${body}`);
+  }
 }
 
 interface GCPInstance {
@@ -195,6 +214,7 @@ export class GCPClient {
           if (attempts.length > 0) result.attempts = attempts;
           return result;
         } catch (error) {
+          if (providerProvisioningCleanupClaim(error)) throw error;
           const message = errorMessage(error);
           failures.push(`${zone}/${machineType}: ${message}`);
           attempts.push({
@@ -240,6 +260,7 @@ export class GCPClient {
               attempts,
             };
           } catch (error) {
+            if (providerProvisioningCleanupClaim(error)) throw error;
             const message = errorMessage(error);
             failures.push(`on-demand ${zone}/${machineType}: ${message}`);
             if (!isFallbackProvisioningError(message)) {
@@ -335,9 +356,43 @@ export class GCPClient {
       await this.waitZoneOperation(op);
       return await this.getServer(name);
     } catch (error) {
-      await this.deleteServer(name).catch(() => undefined);
+      try {
+        await this.deleteServerOwnedByClaim(name, leaseID, slug, owner);
+      } catch (cleanupError) {
+        throw new ProviderProvisioningCleanupError(
+          `${errorMessage(error)}; GCP provisioning cleanup failed closed: ${errorMessage(cleanupError)}`,
+          {
+            provider: "gcp",
+            cloudID: name,
+            region: this.zone,
+            providerProject: project,
+          },
+          cleanupError,
+        );
+      }
       throw error;
     }
+  }
+
+  private async deleteServerOwnedByClaim(
+    name: string,
+    leaseID: string,
+    slug: string,
+    owner: string,
+  ): Promise<void> {
+    const machine = await this.findServer(name);
+    if (!machine) return;
+    if (
+      !providerMachineOwnedByLease(
+        machine,
+        { id: leaseID, slug, owner, provider: "gcp", cloudID: name },
+        "gcp",
+        gcpProviderLabelValue,
+      )
+    ) {
+      throw new Error(`GCP instance ${name} ownership does not match lease ${leaseID}`);
+    }
+    await this.deleteServer(name);
   }
 
   async getServer(name: string): Promise<ProviderMachine> {
@@ -345,6 +400,15 @@ export class GCPClient {
       await this.gcp<GCPInstance>("GET", `/zones/${this.zone}/instances/${name}`),
       this.zone,
     );
+  }
+
+  async findServer(name: string): Promise<ProviderMachine | undefined> {
+    try {
+      return await this.getServer(name);
+    } catch (error) {
+      if (gcpInstanceNotFound(error, this.project, this.zone, name)) return undefined;
+      throw error;
+    }
   }
 
   async waitForServerIP(name: string): Promise<ProviderMachine> {
@@ -364,7 +428,7 @@ export class GCPClient {
       "DELETE",
       `/zones/${this.zone}/instances/${name}`,
     ).catch((error) => {
-      if (isNotFound(error)) return undefined;
+      if (gcpInstanceNotFound(error, this.project, this.zone, name)) return undefined;
       throw error;
     });
     if (op) await this.waitZoneOperation(op);
@@ -579,7 +643,7 @@ export class GCPClient {
     const response = await this.fetcher(`${computeBaseURL}/projects/${this.project}${path}`, init);
     const text = await response.text();
     if (!response.ok) {
-      throw new Error(`gcp ${method} ${path}: http ${response.status}: ${text}`);
+      throw new GCPHTTPError(method, path, response.status, text);
     }
     return (text ? JSON.parse(text) : {}) as T;
   }
@@ -726,7 +790,7 @@ function gcpLabelKey(value: string): string {
   return /^[a-z]/.test(out) ? out : `x${out}`.slice(0, 63);
 }
 
-function gcpLabelValue(value: string): string {
+export function gcpLabelValue(value: string): string {
   let out = value
     .trim()
     .toLowerCase()
@@ -735,6 +799,10 @@ function gcpLabelValue(value: string): string {
     .replaceAll(/^[_-]+|[_-]+$/g, "");
   if (!out) out = "unknown";
   return out;
+}
+
+export function gcpProviderLabelValue(value: string): string {
+  return gcpLabelValue(providerLabelValue(value));
 }
 
 export function isFallbackProvisioningError(message: string): boolean {
@@ -779,6 +847,12 @@ export function operationDone(op: GCPOperation): boolean {
 
 function isNotFound(error: unknown): boolean {
   return errorMessage(error).includes("http 404");
+}
+
+function gcpInstanceNotFound(error: unknown, project: string, zone: string, name: string): boolean {
+  if (!(error instanceof GCPHTTPError) || error.status !== 404) return false;
+  const resource = `projects/${project}/zones/${zone}/instances/${name}`.toLowerCase();
+  return error.body.toLowerCase().includes(resource);
 }
 
 function errorMessage(error: unknown): string {

--- a/worker/src/provider-labels.ts
+++ b/worker/src/provider-labels.ts
@@ -1,5 +1,13 @@
 import type { LeaseConfig } from "./config";
 import { normalizeLeaseSlug } from "./slug";
+import type { LeaseRecord, Provider, ProviderMachine } from "./types";
+
+type ProviderOwnershipLease = Pick<
+  LeaseRecord,
+  "id" | "slug" | "provider" | "owner" | "providerOwner" | "workspaceID"
+>;
+
+export const workspacePrewarmProviderOwner = "crabbox-internal-prewarm";
 
 export function leaseProviderLabels(
   config: LeaseConfig,
@@ -73,6 +81,48 @@ export function providerLabelValue(value: string): string {
     .slice(0, 63)
     .replaceAll(/^[_.-]+|[_.-]+$/g, "");
   return cleaned || "unknown";
+}
+
+export function providerMachineOwnedByLease(
+  machine: Pick<ProviderMachine, "provider" | "cloudID" | "labels">,
+  lease: ProviderOwnershipLease & Pick<LeaseRecord, "cloudID">,
+  provider: Provider,
+  labelValue: (value: string) => string = providerLabelValue,
+): boolean {
+  return (
+    /^cbx_[a-f0-9]{12}$/.test(lease.id) &&
+    lease.provider === provider &&
+    machine.provider === provider &&
+    lease.cloudID.length > 0 &&
+    machine.cloudID === lease.cloudID &&
+    providerLabelsOwnedByLease(machine.labels ?? {}, lease, provider, labelValue)
+  );
+}
+
+export function providerLabelsOwnedByLease(
+  labels: Record<string, string>,
+  lease: ProviderOwnershipLease,
+  provider: Provider,
+  labelValue: (value: string) => string = providerLabelValue,
+): boolean {
+  const slug = normalizeLeaseSlug(lease.slug);
+  const providerOwners = lease.providerOwner?.trim()
+    ? [lease.providerOwner.trim()]
+    : [lease.owner.trim(), ...(lease.workspaceID ? [workspacePrewarmProviderOwner] : [])].filter(
+        Boolean,
+      );
+  return (
+    /^cbx_[a-f0-9]{12}$/.test(lease.id) &&
+    slug.length > 0 &&
+    providerOwners.length > 0 &&
+    lease.provider === provider &&
+    labels["crabbox"] === "true" &&
+    labels["created_by"] === "crabbox" &&
+    labels["lease"] === lease.id &&
+    providerOwners.some((owner) => labels["owner"] === labelValue(owner)) &&
+    labels["provider"] === provider &&
+    labels["slug"] === labelValue(slug)
+  );
 }
 
 function sanitizeLabels(labels: Record<string, string>): Record<string, string> {

--- a/worker/src/provider-provisioning.ts
+++ b/worker/src/provider-provisioning.ts
@@ -1,0 +1,67 @@
+import type { Provider } from "./types";
+
+export interface ProviderProvisioningCleanupClaim {
+  provider: Extract<Provider, "aws" | "azure" | "gcp">;
+  cloudID: string;
+  region?: string;
+  providerProject?: string;
+  providerScope?: string;
+  serverID?: number;
+}
+
+export class ProviderProvisioningCleanupError extends Error {
+  constructor(
+    message: string,
+    readonly cleanupClaim: ProviderProvisioningCleanupClaim,
+    cause: unknown,
+  ) {
+    super(message, { cause });
+    this.name = "ProviderProvisioningCleanupError";
+  }
+}
+
+export function providerProvisioningCleanupClaim(
+  error: unknown,
+): ProviderProvisioningCleanupClaim | undefined {
+  let current = error;
+  for (let depth = 0; depth < 8 && current instanceof Error; depth += 1) {
+    if (current instanceof ProviderProvisioningCleanupError) return current.cleanupClaim;
+    current = current.cause;
+  }
+  return undefined;
+}
+
+export function validatedProviderProvisioningCleanupClaim(
+  error: unknown,
+  provider: Provider,
+): ProviderProvisioningCleanupClaim | undefined {
+  const claim = providerProvisioningCleanupClaim(error);
+  if (
+    !claim ||
+    claim.provider !== provider ||
+    claim.cloudID !== claim.cloudID.trim() ||
+    !claim.cloudID
+  ) {
+    return undefined;
+  }
+  switch (claim.provider) {
+    case "aws":
+      return nonEmptyClaimValue(claim.region) ? claim : undefined;
+    case "azure":
+      return nonEmptyClaimValue(claim.region) && validAzureProviderScope(claim.providerScope)
+        ? claim
+        : undefined;
+    case "gcp":
+      return nonEmptyClaimValue(claim.region) && nonEmptyClaimValue(claim.providerProject)
+        ? claim
+        : undefined;
+  }
+}
+
+function nonEmptyClaimValue(value: string | undefined): boolean {
+  return Boolean(value && value === value.trim());
+}
+
+function validAzureProviderScope(value: string | undefined): boolean {
+  return /^\/subscriptions\/[^/]+\/resourceGroups\/[^/]+$/i.test(value ?? "");
+}

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -332,6 +332,8 @@ export interface LeaseRecord {
   cloudID: string;
   region?: string;
   providerProject?: string;
+  providerScope?: string;
+  providerOwner?: string;
   network?: LeaseNetworkState;
   owner: string;
   org: string;

--- a/worker/test/aws.test.ts
+++ b/worker/test/aws.test.ts
@@ -495,6 +495,28 @@ describe("aws provider", () => {
     );
   });
 
+  it("treats only EC2's exact missing-instance error as an absent server", async () => {
+    let code = "InvalidInstanceID.NotFound";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            `<Response><Errors><Error><Code>${code}</Code><Message>missing</Message></Error></Errors></Response>`,
+            { status: 400 },
+          ),
+      ),
+    );
+    const client = new EC2SpotClient(
+      { AWS_ACCESS_KEY_ID: "test", AWS_SECRET_ACCESS_KEY: "secret" } as never,
+      "us-east-1",
+    );
+
+    await expect(client.findServer("i-abcdef123456")).resolves.toBeUndefined();
+    code = "AuthFailure";
+    await expect(client.findServer("i-abcdef123456")).rejects.toThrow("AuthFailure");
+  });
+
   it("rejects invalid configured AWS SSH CIDRs before changing ingress", async () => {
     const calls: string[] = [];
     vi.stubGlobal(

--- a/worker/test/azure.test.ts
+++ b/worker/test/azure.test.ts
@@ -16,9 +16,11 @@ import {
   isRetryableProvisioningError,
   preserveNonCrabboxRules,
   summarizeAzureErrorBody,
+  type AzureDeferredCleanupRequest,
 } from "../src/azure";
 import type { LeaseConfig } from "../src/config";
-import type { Env } from "../src/types";
+import { providerProvisioningCleanupClaim } from "../src/provider-provisioning";
+import type { Env, LeaseRecord } from "../src/types";
 
 const baseEnv: Env = {
   FLEET: {} as DurableObjectNamespace,
@@ -33,6 +35,32 @@ afterEach(() => vi.useRealTimers());
 
 function isAzureLoginURL(value: string): boolean {
   return new URL(value).hostname === "login.microsoftonline.com";
+}
+
+function ownedAzureLease(): Pick<
+  LeaseRecord,
+  "id" | "slug" | "provider" | "cloudID" | "owner" | "providerScope"
+> {
+  return {
+    id: "cbx_abcdef123456",
+    slug: "blue-lobster",
+    provider: "azure",
+    cloudID: "crabbox-blue-lobster",
+    owner: "alice@example.com",
+    providerScope: "/subscriptions/sub/resourceGroups/crabbox-leases",
+  };
+}
+
+function ownedAzureTags(overrides: Record<string, string> = {}): Record<string, string> {
+  return {
+    crabbox: "true",
+    created_by: "crabbox",
+    lease: "cbx_abcdef123456",
+    owner: "alice_example.com",
+    provider: "azure",
+    slug: "blue-lobster",
+    ...overrides,
+  };
 }
 
 function testLeaseConfig(overrides: Partial<LeaseConfig> = {}): LeaseConfig {
@@ -101,6 +129,50 @@ function testLeaseConfig(overrides: Partial<LeaseConfig> = {}): LeaseConfig {
 }
 
 describe("azure provider", () => {
+  it("treats only an exact missing VM as absent", async () => {
+    const client = new AzureClient(baseEnv);
+    let body = JSON.stringify({
+      error: {
+        code: "ResourceNotFound",
+        message:
+          "The Resource 'Microsoft.Compute/virtualMachines/crabbox-blue-lobster' was not found.",
+      },
+    });
+    client.fetcher = async (input) => {
+      const url = new URL(String(input));
+      if (isAzureLoginURL(url.toString())) {
+        return Response.json({ access_token: "tkn", expires_in: 3600 });
+      }
+      return new Response(body, { status: 404 });
+    };
+
+    await expect(client.findServer("crabbox-blue-lobster")).resolves.toBeUndefined();
+    body = JSON.stringify({
+      error: { code: "ResourceGroupNotFound", message: "Resource group was not found." },
+    });
+    await expect(client.findServer("crabbox-blue-lobster")).rejects.toThrow(
+      "ResourceGroupNotFound",
+    );
+  });
+
+  it("refuses owned cleanup when the persisted Azure scope differs", async () => {
+    const client = new AzureClient(baseEnv);
+    await expect(
+      client.deleteOwnedServer({
+        ...ownedAzureLease(),
+        providerScope: "/subscriptions/other/resourceGroups/crabbox-leases",
+      }),
+    ).rejects.toThrow("stored provider scope does not match");
+  });
+
+  it("can bind an Azure client to a persisted scope instead of mutable defaults", () => {
+    const client = new AzureClient(
+      { ...baseEnv, AZURE_SUBSCRIPTION_ID: "current", CRABBOX_AZURE_RESOURCE_GROUP: "current-rg" },
+      { subscription: "stored", resourceGroup: "stored-rg" },
+    );
+    expect(client.providerScope()).toBe("/subscriptions/stored/resourceGroups/stored-rg");
+  });
+
   it("classifies Azure capacity and quota errors as retryable", () => {
     expect(isRetryableProvisioningError("SkuNotAvailable: D8s_v5 not available")).toBe(true);
     expect(isRetryableProvisioningError("QuotaExceeded for cores")).toBe(true);
@@ -442,6 +514,443 @@ describe("azure provider", () => {
 
     await expect(client.deleteServer("crabbox-blue-lobster")).resolves.toBeUndefined();
     expect(deletes).toHaveLength(4);
+  });
+
+  it("verifies every Azure companion before deleting an owned lease", async () => {
+    const client = new AzureClient(baseEnv);
+    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
+      token: "test-token",
+      expiresAt: Date.now() + 3_600_000,
+    };
+    const deletes: string[] = [];
+    client.fetcher = async (input, init) => {
+      const url = new URL(String(input));
+      const method = init?.method ?? "GET";
+      if (method === "DELETE") {
+        deletes.push(url.pathname);
+        return new Response(null, { status: 204 });
+      }
+      if (url.pathname.endsWith("/virtualMachines/crabbox-blue-lobster")) {
+        return Response.json({
+          id: url.pathname,
+          name: "crabbox-blue-lobster",
+          tags: ownedAzureTags(),
+          properties: {
+            networkProfile: {
+              networkInterfaces: [
+                {
+                  id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/networkInterfaces/crabbox-blue-lobster-nic",
+                },
+              ],
+            },
+            storageProfile: {
+              osDisk: {
+                managedDisk: {
+                  id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/disks/crabbox-blue-lobster-osdisk",
+                },
+              },
+            },
+          },
+        });
+      }
+      if (url.pathname.endsWith("/networkInterfaces/crabbox-blue-lobster-nic")) {
+        return Response.json({
+          id: url.pathname,
+          name: "crabbox-blue-lobster-nic",
+          tags: ownedAzureTags(),
+          properties: {
+            ipConfigurations: [
+              {
+                properties: {
+                  publicIPAddress: {
+                    id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/publicIPAddresses/crabbox-blue-lobster-pip",
+                  },
+                },
+              },
+            ],
+          },
+        });
+      }
+      if (url.pathname.endsWith("/publicIPAddresses/crabbox-blue-lobster-pip")) {
+        return Response.json({
+          id: url.pathname,
+          name: "crabbox-blue-lobster-pip",
+          tags: ownedAzureTags(),
+        });
+      }
+      if (url.pathname.endsWith("/disks/crabbox-blue-lobster-osdisk")) {
+        return Response.json({
+          id: url.pathname,
+          name: "crabbox-blue-lobster-osdisk",
+          tags: ownedAzureTags(),
+        });
+      }
+      return new Response("unexpected request", { status: 500 });
+    };
+
+    await expect(client.deleteOwnedServer(ownedAzureLease())).resolves.toBeUndefined();
+    expect(deletes).toHaveLength(4);
+  });
+
+  it("resumes verified Azure companion cleanup after the VM is gone", async () => {
+    const client = new AzureClient(baseEnv);
+    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
+      token: "test-token",
+      expiresAt: Date.now() + 3_600_000,
+    };
+    const deletes: string[] = [];
+    client.fetcher = async (input, init) => {
+      const url = new URL(String(input));
+      const method = init?.method ?? "GET";
+      if (method === "DELETE") {
+        deletes.push(url.pathname);
+        return new Response(null, { status: 204 });
+      }
+      if (url.pathname.endsWith("/virtualMachines/crabbox-blue-lobster")) {
+        return new Response(
+          JSON.stringify({
+            error: {
+              code: "ResourceNotFound",
+              message:
+                "The Resource 'Microsoft.Compute/virtualMachines/crabbox-blue-lobster' was not found.",
+            },
+          }),
+          { status: 404 },
+        );
+      }
+      const name = url.pathname.slice(url.pathname.lastIndexOf("/") + 1);
+      const properties = url.pathname.includes("/networkInterfaces/")
+        ? {
+            ipConfigurations: [
+              {
+                properties: {
+                  publicIPAddress: {
+                    id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/publicIPAddresses/crabbox-blue-lobster-pip",
+                  },
+                },
+              },
+            ],
+          }
+        : {};
+      return Response.json({ id: url.pathname, name, tags: ownedAzureTags(), properties });
+    };
+
+    await expect(client.deleteOwnedServer(ownedAzureLease())).resolves.toBeUndefined();
+    expect(deletes).toHaveLength(3);
+    expect(deletes.some((path) => path.includes("/virtualMachines/"))).toBe(false);
+  });
+
+  it("refuses all Azure deletion when a companion belongs to another lease", async () => {
+    const client = new AzureClient(baseEnv);
+    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
+      token: "test-token",
+      expiresAt: Date.now() + 3_600_000,
+    };
+    const deletes: string[] = [];
+    client.fetcher = async (input, init) => {
+      const url = new URL(String(input));
+      if (init?.method === "DELETE") {
+        deletes.push(url.pathname);
+        return new Response(null, { status: 204 });
+      }
+      const name = url.pathname.slice(url.pathname.lastIndexOf("/") + 1);
+      const tags = url.pathname.includes("/publicIPAddresses/")
+        ? ownedAzureTags({ lease: "cbx_000000000000" })
+        : ownedAzureTags();
+      const properties = url.pathname.includes("/virtualMachines/")
+        ? {
+            networkProfile: {
+              networkInterfaces: [
+                {
+                  id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/networkInterfaces/crabbox-blue-lobster-nic",
+                },
+              ],
+            },
+            storageProfile: {
+              osDisk: {
+                managedDisk: {
+                  id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/disks/crabbox-blue-lobster-osdisk",
+                },
+              },
+            },
+          }
+        : url.pathname.includes("/networkInterfaces/")
+          ? {
+              ipConfigurations: [
+                {
+                  properties: {
+                    publicIPAddress: {
+                      id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/publicIPAddresses/crabbox-blue-lobster-pip",
+                    },
+                  },
+                },
+              ],
+            }
+          : {};
+      return Response.json({ id: url.pathname, name, tags, properties });
+    };
+
+    await expect(client.deleteOwnedServer(ownedAzureLease())).rejects.toThrow(
+      "public IP crabbox-blue-lobster-pip: ownership does not match",
+    );
+    expect(deletes).toEqual([]);
+  });
+
+  it("binds an untagged Azure OS disk through the verified live VM before deletion", async () => {
+    const client = new AzureClient(baseEnv);
+    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
+      token: "test-token",
+      expiresAt: Date.now() + 3_600_000,
+    };
+    let diskTagged = false;
+    const methods: string[] = [];
+    client.fetcher = async (input, init) => {
+      const url = new URL(String(input));
+      const method = init?.method ?? "GET";
+      methods.push(`${method} ${url.pathname}`);
+      if (method === "DELETE") return new Response(null, { status: 204 });
+      if (method === "PATCH") {
+        diskTagged = true;
+        return Response.json({});
+      }
+      const name = url.pathname.slice(url.pathname.lastIndexOf("/") + 1);
+      const tags = url.pathname.includes("/disks/") && !diskTagged ? {} : ownedAzureTags();
+      const managedBy = url.pathname.includes("/disks/")
+        ? "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/virtualMachines/crabbox-blue-lobster"
+        : undefined;
+      const properties = url.pathname.includes("/virtualMachines/")
+        ? {
+            networkProfile: {
+              networkInterfaces: [
+                {
+                  id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/networkInterfaces/crabbox-blue-lobster-nic",
+                },
+              ],
+            },
+            storageProfile: {
+              osDisk: {
+                managedDisk: {
+                  id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/disks/crabbox-blue-lobster-osdisk",
+                },
+              },
+            },
+          }
+        : url.pathname.includes("/networkInterfaces/")
+          ? {
+              ipConfigurations: [
+                {
+                  properties: {
+                    publicIPAddress: {
+                      id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/publicIPAddresses/crabbox-blue-lobster-pip",
+                    },
+                  },
+                },
+              ],
+            }
+          : {};
+      return Response.json({ id: url.pathname, name, managedBy, tags, properties });
+    };
+
+    await expect(client.deleteOwnedServer(ownedAzureLease())).resolves.toBeUndefined();
+    expect(methods.some((call) => call.includes("PATCH") && call.includes("/disks/"))).toBe(true);
+  });
+
+  it.each([
+    ["conflicting ownership", ownedAzureTags({ lease: "cbx_000000000000" }), undefined],
+    ["missing managedBy", {}, undefined],
+    [
+      "wrong managedBy",
+      {},
+      "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/virtualMachines/crabbox-other",
+    ],
+  ])("refuses to adopt an Azure disk with %s", async (_case, diskTags, diskManagedBy) => {
+    const client = new AzureClient(baseEnv);
+    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
+      token: "test-token",
+      expiresAt: Date.now() + 3_600_000,
+    };
+    const deletes: string[] = [];
+    client.fetcher = async (input, init) => {
+      const url = new URL(String(input));
+      if (init?.method === "DELETE") {
+        deletes.push(url.pathname);
+        return new Response(null, { status: 204 });
+      }
+      const name = url.pathname.slice(url.pathname.lastIndexOf("/") + 1);
+      const isDisk = url.pathname.includes("/disks/");
+      const properties = url.pathname.includes("/virtualMachines/")
+        ? {
+            networkProfile: {
+              networkInterfaces: [
+                {
+                  id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/networkInterfaces/crabbox-blue-lobster-nic",
+                },
+              ],
+            },
+            storageProfile: {
+              osDisk: {
+                managedDisk: {
+                  id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/disks/crabbox-blue-lobster-osdisk",
+                },
+              },
+            },
+          }
+        : url.pathname.includes("/networkInterfaces/")
+          ? {
+              ipConfigurations: [
+                {
+                  properties: {
+                    publicIPAddress: {
+                      id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/publicIPAddresses/crabbox-blue-lobster-pip",
+                    },
+                  },
+                },
+              ],
+            }
+          : {};
+      return Response.json({
+        id: url.pathname,
+        name,
+        managedBy: isDisk ? diskManagedBy : undefined,
+        tags: isDisk ? diskTags : ownedAzureTags(),
+        properties,
+      });
+    };
+
+    await expect(client.deleteOwnedServer(ownedAzureLease())).rejects.toThrow(
+      "disk crabbox-blue-lobster-osdisk: ownership does not match",
+    );
+    expect(deletes).toEqual([]);
+  });
+
+  it("revalidates Azure companions after deleting the VM", async () => {
+    const client = new AzureClient(baseEnv);
+    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
+      token: "test-token",
+      expiresAt: Date.now() + 3_600_000,
+    };
+    let vmDeleted = false;
+    const deletes: string[] = [];
+    client.fetcher = async (input, init) => {
+      const url = new URL(String(input));
+      if (init?.method === "DELETE") {
+        deletes.push(url.pathname);
+        if (url.pathname.includes("/virtualMachines/")) vmDeleted = true;
+        return new Response(null, { status: 204 });
+      }
+      if (vmDeleted && url.pathname.includes("/virtualMachines/")) {
+        return new Response(
+          JSON.stringify({
+            error: {
+              code: "ResourceNotFound",
+              message:
+                "The Resource 'Microsoft.Compute/virtualMachines/crabbox-blue-lobster' was not found.",
+            },
+          }),
+          { status: 404 },
+        );
+      }
+      const name = url.pathname.slice(url.pathname.lastIndexOf("/") + 1);
+      const tags =
+        vmDeleted && url.pathname.includes("/networkInterfaces/")
+          ? ownedAzureTags({ lease: "cbx_000000000000" })
+          : ownedAzureTags();
+      const properties = url.pathname.includes("/virtualMachines/")
+        ? {
+            networkProfile: {
+              networkInterfaces: [
+                {
+                  id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/networkInterfaces/crabbox-blue-lobster-nic",
+                },
+              ],
+            },
+            storageProfile: {
+              osDisk: {
+                managedDisk: {
+                  id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/disks/crabbox-blue-lobster-osdisk",
+                },
+              },
+            },
+          }
+        : url.pathname.includes("/networkInterfaces/")
+          ? {
+              ipConfigurations: [
+                {
+                  properties: {
+                    publicIPAddress: {
+                      id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/publicIPAddresses/crabbox-blue-lobster-pip",
+                    },
+                  },
+                },
+              ],
+            }
+          : {};
+      return Response.json({ id: url.pathname, name, tags, properties });
+    };
+
+    await expect(client.deleteOwnedServer(ownedAzureLease())).rejects.toThrow(
+      "NIC crabbox-blue-lobster-nic: ownership does not match",
+    );
+    expect(deletes).toHaveLength(1);
+    expect(deletes[0]).toContain("/virtualMachines/");
+  });
+
+  it("fails closed when an owned Azure DELETE returns a scope-level 404", async () => {
+    const client = new AzureClient(baseEnv);
+    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
+      token: "test-token",
+      expiresAt: Date.now() + 3_600_000,
+    };
+    client.fetcher = async (input, init) => {
+      const url = new URL(String(input));
+      if (init?.method === "DELETE") {
+        return new Response(
+          JSON.stringify({
+            error: {
+              code: "ResourceNotFound",
+              message: "The Resource group 'crabbox-leases' was not found.",
+            },
+          }),
+          { status: 404 },
+        );
+      }
+      const name = url.pathname.slice(url.pathname.lastIndexOf("/") + 1);
+      const properties = url.pathname.includes("/virtualMachines/")
+        ? {
+            networkProfile: {
+              networkInterfaces: [
+                {
+                  id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/networkInterfaces/crabbox-blue-lobster-nic",
+                },
+              ],
+            },
+            storageProfile: {
+              osDisk: {
+                managedDisk: {
+                  id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/disks/crabbox-blue-lobster-osdisk",
+                },
+              },
+            },
+          }
+        : url.pathname.includes("/networkInterfaces/")
+          ? {
+              ipConfigurations: [
+                {
+                  properties: {
+                    publicIPAddress: {
+                      id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/publicIPAddresses/crabbox-blue-lobster-pip",
+                    },
+                  },
+                },
+              ],
+            }
+          : {};
+      return Response.json({ id: url.pathname, name, tags: ownedAzureTags(), properties });
+    };
+
+    await expect(client.deleteOwnedServer(ownedAzureLease())).rejects.toThrow(
+      "Resource group 'crabbox-leases' was not found",
+    );
   });
 
   it("requires the four Azure SP secrets", () => {
@@ -1461,7 +1970,7 @@ describe("azure provider", () => {
   it("starts Azure on-demand fallback without waiting for timed-out Spot cleanup", async () => {
     vi.useFakeTimers();
     try {
-      const cleanupRequests: Array<{ name: string; location: string; resourceGroup: string }> = [];
+      const cleanupRequests: AzureDeferredCleanupRequest[] = [];
       const client = new AzureClient(baseEnv, {
         deferredCleanup: (request) => {
           cleanupRequests.push(request);
@@ -1469,7 +1978,6 @@ describe("azure provider", () => {
         },
       });
       const vmPutPaths: string[] = [];
-      let spotCleanupStarted = false;
       const fakeFetch = ((input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
         const url = typeof input === "string" ? input : input.toString();
         const pathname = new URL(url).pathname;
@@ -1482,10 +1990,6 @@ describe("azure provider", () => {
         }
         if (url === "https://management.azure.com/spot-op") {
           return Promise.resolve(new Response(JSON.stringify({ status: "InProgress" })));
-        }
-        if (init?.method === "DELETE" && pathname.includes("/virtualMachines/")) {
-          spotCleanupStarted = true;
-          return Promise.resolve(new Response("", { status: 202 }));
         }
         if (pathname.endsWith("/resourceGroups/crabbox-leases")) {
           return Promise.resolve(
@@ -1571,14 +2075,55 @@ describe("azure provider", () => {
 
       expect(result.market).toBe("on-demand");
       expect(cleanupRequests).toMatchObject([
-        { location: "eastus", resourceGroup: "crabbox-leases" },
+        {
+          location: "eastus",
+          subscription: "sub",
+          resourceGroup: "crabbox-leases",
+          leaseID: "cbx_123456789abc",
+          slug: "blue-lobster",
+          owner: "owner",
+        },
       ]);
-      expect(spotCleanupStarted).toBe(true);
       expect(vmPutPaths).toHaveLength(2);
       expect(vmPutPaths[1]).not.toBe(vmPutPaths[0]);
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("returns an exact Azure cleanup claim when provisioning rollback fails", async () => {
+    const client = new AzureClient(baseEnv);
+    const internal = client as unknown as {
+      createVM(
+        config: LeaseConfig,
+        location: string,
+        leaseID: string,
+        slug: string,
+        owner: string,
+        infra: { vnet: string; nsg: string },
+      ): Promise<unknown>;
+      createVMUnchecked(): Promise<unknown>;
+    };
+    vi.spyOn(internal, "createVMUnchecked").mockRejectedValue(new Error("create failed"));
+    vi.spyOn(client, "deleteOwnedServer").mockRejectedValue(new Error("cleanup unavailable"));
+
+    const error = await internal
+      .createVM(
+        testLeaseConfig(),
+        "eastus",
+        "cbx_123456789abc",
+        "blue-lobster",
+        "alice@example.com",
+        { vnet: "crabbox-vnet", nsg: "crabbox-nsg" },
+      )
+      .catch((caught: unknown) => caught);
+
+    expect(providerProvisioningCleanupClaim(error)).toEqual({
+      provider: "azure",
+      cloudID: "crabbox-blue-lobster-ea753034",
+      region: "eastus",
+      providerScope: "/subscriptions/sub/resourceGroups/crabbox-leases",
+    });
   });
 
   it("bounds stalled Azure on-demand VM creates so SKU fallback can continue", async () => {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -15,7 +15,9 @@ import {
 import { routeCoordinatorRequest } from "../src/coordinator-entry";
 import {
   AWSProvider,
+  AzureProvider,
   FleetDurableObject,
+  GCPProvider,
   HetznerProvider,
   bridgeTicketFromRequest,
   boundedSocketReason,
@@ -32,6 +34,10 @@ import {
 } from "../src/fleet";
 import { HetznerClient, HetznerProvisioningError } from "../src/hetzner";
 import { portalCode } from "../src/portal";
+import {
+  ProviderProvisioningCleanupError,
+  providerProvisioningCleanupClaim,
+} from "../src/provider-provisioning";
 import {
   runtimeAdapterDesktopRelayTimeoutMs,
   runtimeAdapterRelayFrameLimit,
@@ -5290,10 +5296,20 @@ describe("fleet lease identity and idle", () => {
       providers.map(async (provider) => {
         vi.spyOn(provider, "deleteServer").mockResolvedValue();
         const deleteSSHKey = vi.spyOn(provider, "deleteSSHKey").mockResolvedValue();
+        if (provider instanceof AWSProvider) {
+          vi.spyOn(provider, "findServer").mockResolvedValue(
+            ownedTestMachine("aws", "i-abcdef123456"),
+          );
+        }
+        const providerLease =
+          provider instanceof AWSProvider
+            ? { provider: "aws" as const, cloudID: "i-abcdef123456" }
+            : {};
         await provider.releaseLease(
           testLease({
             id: "cbx_abcdef123456",
             providerKey: "crabbox-cbx-000000000001",
+            ...providerLease,
           }),
         );
         expect(deleteSSHKey).not.toHaveBeenCalled();
@@ -5303,12 +5319,212 @@ describe("fleet lease identity and idle", () => {
             id: "cbx_abcdef123456",
             providerKey: "crabbox-cbx-abcdef123456",
             providerKeyCleanupOwned: true,
+            ...providerLease,
           }),
         );
         expect(deleteSSHKey).toHaveBeenCalledOnce();
         expect(deleteSSHKey).toHaveBeenCalledWith("crabbox-cbx-abcdef123456", "cbx_abcdef123456");
       }),
     );
+  });
+
+  it("reads and verifies cloud ownership before AWS, Azure, or GCP release", async () => {
+    await Promise.all(
+      workerCloudReleaseCases()
+        .filter(({ providerName }) => providerName !== "azure")
+        .map(async ({ providerName, cloudID, provider }) => {
+          const findServer = vi
+            .spyOn(provider, "findServer")
+            .mockResolvedValue(ownedTestMachine(providerName, cloudID));
+          const deleteServer = vi.spyOn(provider, "deleteServer").mockResolvedValue();
+          const lease = testLease({
+            id: "cbx_abcdef123456",
+            provider: providerName,
+            cloudID,
+            providerKeyCleanupOwned: false,
+          });
+
+          await expect(provider.releaseLease(lease)).resolves.toBeUndefined();
+          expect(findServer).toHaveBeenCalledWith(cloudID);
+          expect(deleteServer).toHaveBeenCalledWith(cloudID);
+        }),
+    );
+  });
+
+  it("routes Azure release through its companion-aware ownership cleanup", async () => {
+    const provider = new AzureProvider({} as Env);
+    const deleteOwnedServer = vi.spyOn(provider, "deleteOwnedServer").mockResolvedValue();
+    const lease = testLease({
+      id: "cbx_abcdef123456",
+      provider: "azure",
+      cloudID: "crabbox-blue-lobster",
+    });
+
+    await expect(provider.releaseLease(lease)).resolves.toBeUndefined();
+    expect(deleteOwnedServer).toHaveBeenCalledWith(lease);
+  });
+
+  it("persists Azure provider scope before provisioning", async () => {
+    const provider = new AzureProvider({
+      FLEET: {} as DurableObjectNamespace,
+      AZURE_TENANT_ID: "tenant",
+      AZURE_CLIENT_ID: "client",
+      AZURE_CLIENT_SECRET: "secret",
+      AZURE_SUBSCRIPTION_ID: "stored-subscription",
+      CRABBOX_AZURE_RESOURCE_GROUP: "stored-resource-group",
+    } as Env);
+    const config = leaseConfig({ provider: "azure", sshPublicKey: "ssh-ed25519 test" });
+    const prepared = await provider.prepareLeaseCreate(
+      config,
+      testLease({ provider: "azure", cloudID: "" }),
+    );
+
+    expect(prepared.lease.providerScope).toBe(
+      "/subscriptions/stored-subscription/resourceGroups/stored-resource-group",
+    );
+  });
+
+  it("fails legacy Azure release closed when provider scope was never persisted", async () => {
+    const provider = new AzureProvider({} as Env);
+    await expect(
+      provider.releaseLease(
+        testLease({
+          id: "cbx_abcdef123456",
+          provider: "azure",
+          cloudID: "crabbox-blue-lobster",
+        }),
+      ),
+    ).rejects.toThrow("canonical provider scope was not persisted");
+  });
+
+  it("terminalizes legacy unscoped Azure cleanup for manual resolution", async () => {
+    const storage = new MemoryStorage();
+    const lease = testLease({
+      id: "cbx_abcdef123456",
+      owner: "alice@example.com",
+      org: "example-org",
+      provider: "azure",
+      cloudID: "crabbox-blue-lobster",
+    });
+    storage.seed(`lease:${lease.id}`, lease);
+    const fleet = testFleet(storage);
+
+    const response = await fleet.fetch(
+      request("POST", `/v1/leases/${lease.id}/release`, {
+        headers: {
+          "x-crabbox-owner": lease.owner,
+          "x-crabbox-org": lease.org,
+        },
+        body: { delete: true },
+      }),
+    );
+
+    expect(response.status).toBe(500);
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)).toMatchObject({
+      state: "released",
+      cloudID: lease.cloudID,
+      keep: true,
+      releaseDeletesServer: false,
+      failureError: expect.stringContaining("canonical provider scope was not persisted"),
+    });
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)?.cleanupRetryAt).toBeUndefined();
+    expect(storage.alarm()).toBeUndefined();
+  });
+
+  it("fails cloud release closed when ownership does not match the lease", async () => {
+    await Promise.all(
+      workerCloudReleaseCases()
+        .filter(({ providerName }) => providerName !== "azure")
+        .map(async ({ providerName, cloudID, provider }) => {
+          const machine = ownedTestMachine(providerName, cloudID);
+          vi.spyOn(provider, "findServer").mockResolvedValue({
+            ...machine,
+            labels: { ...machine.labels, lease: "cbx_000000000000" },
+          });
+          const deleteServer = vi.spyOn(provider, "deleteServer").mockResolvedValue();
+
+          await expect(
+            provider.releaseLease(
+              testLease({ id: "cbx_abcdef123456", provider: providerName, cloudID }),
+            ),
+          ).rejects.toThrow(`ownership does not match lease cbx_abcdef123456`);
+          expect(deleteServer).not.toHaveBeenCalled();
+        }),
+    );
+  });
+
+  it("completes AWS and GCP release only when the exact primary resource is absent", async () => {
+    await Promise.all(
+      workerCloudReleaseCases()
+        .filter(({ providerName }) => providerName !== "azure")
+        .map(async ({ providerName, cloudID, provider }) => {
+          vi.spyOn(provider, "findServer").mockResolvedValue(undefined);
+          const deleteServer = vi.spyOn(provider, "deleteServer").mockResolvedValue();
+
+          await expect(
+            provider.releaseLease(
+              testLease({ id: "cbx_abcdef123456", provider: providerName, cloudID }),
+            ),
+          ).resolves.toBeUndefined();
+          expect(deleteServer).not.toHaveBeenCalled();
+        }),
+    );
+  });
+
+  it("retains Azure cleanup when a missing VM leaves companion ownership unprovable", async () => {
+    const provider = new AzureProvider({} as Env);
+    vi.spyOn(provider, "deleteOwnedServer").mockRejectedValue(
+      new Error("companion resource ownership cannot be verified"),
+    );
+
+    await expect(
+      provider.releaseLease(
+        testLease({
+          id: "cbx_abcdef123456",
+          provider: "azure",
+          cloudID: "crabbox-blue-lobster",
+        }),
+      ),
+    ).rejects.toThrow("companion resource ownership cannot be verified");
+  });
+
+  it("fails cloud release closed on provider read errors", async () => {
+    await Promise.all(
+      workerCloudReleaseCases()
+        .filter(({ providerName }) => providerName !== "azure")
+        .map(async ({ providerName, cloudID, provider }) => {
+          vi.spyOn(provider, "findServer").mockRejectedValue(new Error("http 404: scope missing"));
+          const deleteServer = vi.spyOn(provider, "deleteServer").mockResolvedValue();
+
+          await expect(
+            provider.releaseLease(
+              testLease({ id: "cbx_abcdef123456", provider: providerName, cloudID }),
+            ),
+          ).rejects.toThrow("scope missing");
+          expect(deleteServer).not.toHaveBeenCalled();
+        }),
+    );
+  });
+
+  it("fails AWS release closed on a non-instance not-found DELETE", async () => {
+    const provider = new AWSProvider(
+      { AWS_ACCESS_KEY_ID: "test", AWS_SECRET_ACCESS_KEY: "secret" } as Env,
+      "eu-west-1",
+      new MemoryStorage(),
+    );
+    vi.spyOn(provider, "findServer").mockResolvedValue(ownedTestMachine("aws", "i-abcdef123456"));
+    vi.spyOn(provider, "deleteServer").mockRejectedValue(new Error("AWS resource group not found"));
+
+    await expect(
+      provider.releaseLease(
+        testLease({
+          id: "cbx_abcdef123456",
+          provider: "aws",
+          cloudID: "i-abcdef123456",
+          providerKeyCleanupOwned: false,
+        }),
+      ),
+    ).rejects.toThrow("resource group not found");
   });
 
   it("adapts workspaces onto owner-scoped lease lifecycle", async () => {
@@ -5760,6 +5976,7 @@ describe("fleet lease identity and idle", () => {
     expect(providerCreates).toBe(2);
     expect(storage.value<LeaseRecord>(`lease:${warmLeaseID}`)).toMatchObject({
       owner: "bob@example.com",
+      providerOwner: "crabbox-internal-prewarm",
       org: "example-org",
       workspaceID: "fleet-prewarm-bob",
     });
@@ -7435,6 +7652,233 @@ describe("fleet lease identity and idle", () => {
     });
   });
 
+  it("persists and retries an exact funded-provider cleanup claim", async () => {
+    const storage = new MemoryStorage();
+    const leaseID = "cbx_abcdef123456";
+    const cleanupLeases: LeaseRecord[] = [];
+    const fleet = testFleet(storage, {
+      gcp: fakeProvider(
+        async () => {
+          throw new ProviderProvisioningCleanupError(
+            "create failed; cleanup unavailable",
+            {
+              provider: "gcp",
+              cloudID: "crabbox-blue-lobster-c80c2195",
+              region: "us-central1-b",
+              providerProject: "stored-project",
+            },
+            new Error("cleanup unavailable"),
+          );
+        },
+        {
+          provider: "gcp",
+          onReleaseLease(lease) {
+            cleanupLeases.push(structuredClone(lease));
+          },
+        },
+      ),
+    });
+
+    const response = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        body: {
+          leaseID,
+          provider: "gcp",
+          target: "linux",
+          gcpProject: "request-project",
+          gcpZone: "us-central1-a",
+          sshPublicKey: "ssh-ed25519 cleanup-claim",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(500);
+    const failed = storage.value<LeaseRecord>(`lease:${leaseID}`)!;
+    expect(failed).toMatchObject({
+      state: "failed",
+      cloudID: "crabbox-blue-lobster-c80c2195",
+      region: "us-central1-b",
+      providerProject: "stored-project",
+      releaseDeletesServer: true,
+      provisioningResourceMayExist: true,
+    });
+    storage.seed(`lease:${leaseID}`, {
+      ...failed,
+      cleanupRetryAt: new Date(Date.now() - 1_000).toISOString(),
+    });
+
+    await fleet.alarm();
+
+    expect(cleanupLeases).toHaveLength(1);
+    expect(cleanupLeases[0]).toMatchObject({
+      cloudID: "crabbox-blue-lobster-c80c2195",
+      region: "us-central1-b",
+      providerProject: "stored-project",
+    });
+    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)).toMatchObject({
+      state: "failed",
+      provisioningResourceMayExist: false,
+      failureError: expect.stringContaining("cleanup unavailable"),
+    });
+  });
+
+  it("retains an exact cleanup claim after the lease state changes during provisioning", async () => {
+    const storage = new MemoryStorage();
+    const leaseID = "cbx_abcdef123456";
+    let providerStorage: MemoryStorage | undefined;
+    const cleanupLeases: LeaseRecord[] = [];
+    const fleet = testFleet(storage, {
+      gcp: fakeProvider(undefined, {
+        provider: "gcp",
+        onPrepareLeaseConfig(config, currentStorage) {
+          providerStorage = currentStorage;
+          return config;
+        },
+        async onCreateProvisioning() {
+          const current = providerStorage?.value<LeaseRecord>(`lease:${leaseID}`);
+          expect(current?.state).toBe("provisioning");
+          providerStorage?.seed(`lease:${leaseID}`, {
+            ...current!,
+            state: "released",
+            releaseDeletesServer: false,
+            keep: true,
+            endedAt: new Date().toISOString(),
+          });
+          throw new ProviderProvisioningCleanupError(
+            "create failed after concurrent release",
+            {
+              provider: "gcp",
+              cloudID: "crabbox-blue-lobster-c80c2195",
+              region: "us-central1-b",
+              providerProject: "stored-project",
+            },
+            new Error("cleanup unavailable"),
+          );
+        },
+        onReleaseLease(lease) {
+          cleanupLeases.push(structuredClone(lease));
+        },
+      }),
+    });
+
+    const response = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        body: {
+          leaseID,
+          provider: "gcp",
+          target: "linux",
+          gcpProject: "request-project",
+          gcpZone: "us-central1-a",
+          sshPublicKey: "ssh-ed25519 concurrent-release",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(500);
+    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)).toMatchObject({
+      state: "released",
+      cloudID: "crabbox-blue-lobster-c80c2195",
+      region: "us-central1-b",
+      providerProject: "stored-project",
+      releaseDeletesServer: false,
+      keep: true,
+    });
+    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)?.cleanupRetryAt).toBeUndefined();
+    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)?.provisioningResourceMayExist).toBe(
+      undefined,
+    );
+    await fleet.alarm();
+    expect(cleanupLeases).toHaveLength(0);
+  });
+
+  it("rejects a cleanup claim for a different provider", async () => {
+    const storage = new MemoryStorage();
+    const leaseID = "cbx_abcdef123456";
+    const fleet = testFleet(storage, {
+      gcp: fakeProvider(async () => {
+        throw new ProviderProvisioningCleanupError(
+          "mismatched cleanup claim",
+          {
+            provider: "aws",
+            cloudID: "i-abcdef123456",
+            region: "eu-west-1",
+          },
+          new Error("cleanup unavailable"),
+        );
+      }),
+    });
+
+    const response = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        body: {
+          leaseID,
+          provider: "gcp",
+          target: "linux",
+          gcpProject: "request-project",
+          gcpZone: "us-central1-a",
+          sshPublicKey: "ssh-ed25519 mismatched-claim",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(500);
+    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)).toMatchObject({
+      state: "failed",
+      cloudID: "",
+      provisioningResourceMayExist: false,
+      failureError: expect.stringContaining("mismatched cleanup claim"),
+    });
+  });
+
+  it("returns an exact AWS cleanup claim when readiness rollback fails", async () => {
+    vi.spyOn(EC2SpotClient.prototype, "createServerWithFallback").mockResolvedValue({
+      server: {
+        provider: "aws",
+        id: 42,
+        cloudID: "i-abcdef123456",
+        name: "crabbox-blue-lobster",
+        status: "pending",
+        labels: {},
+      },
+      serverType: "t3.small",
+    });
+    vi.spyOn(EC2SpotClient.prototype, "waitForServerIP").mockRejectedValue(
+      new Error("readiness timed out"),
+    );
+    vi.spyOn(EC2SpotClient.prototype, "deleteServer").mockRejectedValue(
+      new Error("temporary terminate failure"),
+    );
+    const provider = new AWSProvider(
+      { AWS_ACCESS_KEY_ID: "test", AWS_SECRET_ACCESS_KEY: "secret" } as Env,
+      "eu-west-1",
+      new MemoryStorage(),
+    );
+
+    const error = await provider
+      .createServerWithFallback(
+        leaseConfig({
+          provider: "aws",
+          serverType: "t3.small",
+          serverTypeExplicit: true,
+          awsRegion: "eu-west-1",
+          capacity: { market: "on-demand", fallback: "none" },
+          sshPublicKey: "ssh-ed25519 test",
+        }),
+        "cbx_abcdef123456",
+        "blue-lobster",
+        "alice@example.com",
+      )
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(ProviderProvisioningCleanupError);
+    expect(providerProvisioningCleanupClaim(error)).toEqual({
+      provider: "aws",
+      cloudID: "i-abcdef123456",
+      region: "eu-west-1",
+      serverID: 42,
+    });
+  });
+
   it("backs off durable Hetzner server and SSH key cleanup after rollback failure", async () => {
     const storage = new MemoryStorage();
     const leaseID = "cbx_abcdef123456";
@@ -9106,19 +9550,54 @@ describe("fleet lease identity and idle", () => {
       {
         name: "crabbox-deferred",
         location: "eastus",
+        subscription: "sub",
         resourceGroup: "crabbox-leases",
+        leaseID: "cbx_abcdef123456",
+        slug: "deferred",
+        owner: "alice@example.com",
         createdAt: new Date().toISOString(),
       },
     );
     staleBlocked.resolve();
     await Promise.all([staleSchedule, deferredCleanup]);
 
-    expect(storage.value("azure-cleanup:eastus:crabbox-deferred")).toMatchObject({
+    const records = await storage.list({ prefix: "azure-cleanup:" });
+    expect([...records.values()][0]).toMatchObject({
       attempts: 0,
       location: "eastus",
       name: "crabbox-deferred",
+      subscription: "sub",
+      leaseID: "cbx_abcdef123456",
     });
     expect(storage.alarm()).toBeLessThanOrEqual(Date.now() + 1500);
+  });
+
+  it("fails legacy Azure deferred cleanup closed without a persisted claim and scope", async () => {
+    const storage = new MemoryStorage();
+    const key = "azure-cleanup:legacy:eastus:crabbox-deferred";
+    storage.seed(key, {
+      name: "crabbox-deferred",
+      location: "eastus",
+      resourceGroup: "crabbox-leases",
+      createdAt: "2026-05-01T00:00:00.000Z",
+      attempts: 0,
+      updatedAt: "2026-05-01T00:00:00.000Z",
+      retryAt: "2026-05-01T00:00:00.000Z",
+    });
+    const fetcher = vi.fn<typeof fetch>();
+    vi.stubGlobal("fetch", fetcher);
+
+    await testFleet(storage).alarm();
+
+    expect(
+      storage.value<{ attempts: number; lastError: string; terminalAt: string }>(key),
+    ).toMatchObject({
+      attempts: 1,
+      lastError: expect.stringContaining("canonical lease claim and provider scope"),
+      terminalAt: expect.any(String),
+    });
+    expect(fetcher).not.toHaveBeenCalled();
+    expect(storage.alarm()).toBeUndefined();
   });
 
   it("bootstraps AWS orphan sweep maintenance from the Worker cron route", async () => {
@@ -23246,6 +23725,41 @@ function testMachine(overrides: Partial<ProviderMachine>): ProviderMachine {
     labels: { crabbox: "true" },
     ...overrides,
   };
+}
+
+function ownedTestMachine(provider: "aws" | "azure" | "gcp", cloudID: string): ProviderMachine {
+  return testMachine({
+    provider,
+    cloudID,
+    labels: {
+      crabbox: "true",
+      created_by: "crabbox",
+      lease: "cbx_abcdef123456",
+      owner: provider === "gcp" ? "peter_example_com" : "peter_example.com",
+      provider,
+      slug: "blue-lobster",
+    },
+  });
+}
+
+function workerCloudReleaseCases() {
+  return [
+    {
+      providerName: "aws" as const,
+      cloudID: "i-abcdef123456",
+      provider: new AWSProvider({} as Env, "eu-west-1", new MemoryStorage()),
+    },
+    {
+      providerName: "azure" as const,
+      cloudID: "crabbox-blue-lobster",
+      provider: new AzureProvider({} as Env),
+    },
+    {
+      providerName: "gcp" as const,
+      cloudID: "crabbox-blue-lobster",
+      provider: new GCPProvider({} as Env),
+    },
+  ];
 }
 
 function testLease(overrides: Partial<LeaseRecord>): LeaseRecord {

--- a/worker/test/gcp-release.live.test.ts
+++ b/worker/test/gcp-release.live.test.ts
@@ -1,0 +1,113 @@
+import { randomBytes } from "node:crypto";
+
+import { describe, expect, it } from "vitest";
+
+import { leaseConfig } from "../src/config";
+import { GCPProvider } from "../src/fleet";
+import { GCPClient } from "../src/gcp";
+import type { Env, LeaseRecord } from "../src/types";
+
+const live = process.env.CRABBOX_GCP_RELEASE_LIVE === "1" ? describe : describe.skip;
+
+live("GCP release ownership live", () => {
+  it("creates, reads, denies a foreign claim, releases the owned instance, and leaves no disk", async () => {
+    const project = requiredEnv("CRABBOX_GCP_PROJECT");
+    const zone = process.env.CRABBOX_GCP_ZONE || "europe-west2-a";
+    const env = {
+      FLEET: {} as DurableObjectNamespace,
+      GCP_CLIENT_EMAIL: requiredEnv("GCP_CLIENT_EMAIL"),
+      GCP_PRIVATE_KEY: requiredEnv("GCP_PRIVATE_KEY"),
+      CRABBOX_GCP_PROJECT: project,
+      CRABBOX_GCP_ZONE: zone,
+      CRABBOX_GCP_ROOT_GB: "10",
+    } as Env;
+    const client = new GCPClient(env, zone, project);
+    const provider = new GCPProvider(env, undefined, zone, project);
+    const leaseID =
+      process.env.CRABBOX_GCP_RELEASE_LIVE_LEASE_ID || `cbx_${randomBytes(6).toString("hex")}`;
+    const slug = "live-gcp-release";
+    const owner = "live-test@example.com";
+    const config = leaseConfig({
+      provider: "gcp",
+      target: "linux",
+      class: "standard",
+      serverType: "e2-micro",
+      serverTypeExplicit: true,
+      gcpProject: project,
+      gcpZone: zone,
+      gcpRootGB: 10,
+      capacity: { market: "on-demand", fallback: "none" },
+      sshPublicKey: requiredEnv("LIVE_SSH_PUBLIC_KEY"),
+    });
+    let cloudID = "";
+    let denied = false;
+    let released = false;
+    try {
+      const machine = await client.createServer(config, leaseID, slug, owner);
+      cloudID = machine.cloudID;
+      const readBack = await client.getServer(cloudID);
+      expect(readBack.host).not.toBe("");
+      expect(readBack.labels).toMatchObject({ lease: leaseID, provider: "gcp" });
+      const now = new Date().toISOString();
+      const lease = {
+        id: leaseID,
+        slug,
+        provider: "gcp",
+        target: "linux",
+        cloudID,
+        region: zone,
+        providerProject: project,
+        owner,
+        org: "live-proof",
+        profile: "default",
+        class: "standard",
+        serverType: "e2-micro",
+        serverID: 0,
+        serverName: cloudID,
+        providerKey: "",
+        host: readBack.host,
+        sshUser: "crabbox",
+        sshPort: "22",
+        workRoot: "/workspace",
+        keep: false,
+        ttlSeconds: 900,
+        estimatedHourlyUSD: 0,
+        maxEstimatedUSD: 0,
+        state: "active",
+        createdAt: now,
+        updatedAt: now,
+        expiresAt: new Date(Date.now() + 900_000).toISOString(),
+      } satisfies LeaseRecord;
+
+      await expect(
+        provider.releaseLease({ ...lease, owner: "foreign@example.com" }),
+      ).rejects.toThrow("ownership does not match");
+      denied = true;
+      await expect(client.getServer(cloudID)).resolves.toMatchObject({ cloudID });
+
+      await provider.releaseLease(lease);
+      released = true;
+      await expect(client.findServer(cloudID)).resolves.toBeUndefined();
+      const disks = await (
+        client as unknown as {
+          gcp<T>(method: string, path: string): Promise<T>;
+        }
+      ).gcp<{ items?: { name?: string }[] }>(
+        "GET",
+        `/zones/${zone}/disks?filter=${encodeURIComponent(`name = ${cloudID}`)}`,
+      );
+      expect(disks.items ?? []).toEqual([]);
+      console.log(JSON.stringify({ provider: "gcp", leaseID, denied, released, residue: 0 }));
+    } finally {
+      if (cloudID) {
+        await client.deleteServer(cloudID);
+      }
+    }
+  }, 600_000);
+});
+
+function requiredEnv(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}

--- a/worker/test/gcp.test.ts
+++ b/worker/test/gcp.test.ts
@@ -9,6 +9,7 @@ import {
   isFallbackProvisioningError,
   operationDone,
 } from "../src/gcp";
+import { providerProvisioningCleanupClaim } from "../src/provider-provisioning";
 import { leaseProviderName } from "../src/slug";
 import type { Env, ProviderMachine } from "../src/types";
 
@@ -43,6 +44,94 @@ describe("gcp provider", () => {
     expect(() => new GCPClient({ ...env, CRABBOX_GCP_SSH_CIDRS: "::::/128" })).toThrow(
       "CRABBOX_GCP_SSH_CIDRS entries must be valid",
     );
+  });
+
+  it("treats only the exact zonal instance as absent", async () => {
+    const client = new GCPClient(env);
+    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
+      token: "test-token",
+      expiresAt: Math.trunc(Date.now() / 1000) + 3600,
+    };
+    let message =
+      "The resource 'projects/default-project/zones/us-central1-a/instances/crabbox-blue-lobster' was not found";
+    client.fetcher = async () =>
+      new Response(JSON.stringify({ error: { code: 404, message } }), { status: 404 });
+
+    await expect(client.findServer("crabbox-blue-lobster")).resolves.toBeUndefined();
+    message = "The resource 'projects/default-project' was not found";
+    await expect(client.findServer("crabbox-blue-lobster")).rejects.toThrow(
+      "projects/default-project",
+    );
+  });
+
+  it("treats only an exact missing instance DELETE as complete", async () => {
+    const client = new GCPClient(env);
+    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
+      token: "test-token",
+      expiresAt: Math.trunc(Date.now() / 1000) + 3600,
+    };
+    let message =
+      "The resource 'projects/default-project/zones/us-central1-a/instances/crabbox-blue-lobster' was not found";
+    client.fetcher = async () =>
+      new Response(JSON.stringify({ error: { code: 404, message } }), { status: 404 });
+
+    await expect(client.deleteServer("crabbox-blue-lobster")).resolves.toBeUndefined();
+    message = "The resource 'projects/default-project' was not found";
+    await expect(client.deleteServer("crabbox-blue-lobster")).rejects.toThrow(
+      "projects/default-project",
+    );
+  });
+
+  it("does not delete a foreign same-name instance after a failed create", async () => {
+    const client = new GCPClient(env);
+    const calls: string[] = [];
+    const internal = client as unknown as {
+      ensureFirewall(config: ReturnType<typeof leaseConfig>): Promise<void>;
+      gcp<T>(method: string, path: string, body?: unknown): Promise<T>;
+    };
+    vi.spyOn(internal, "ensureFirewall").mockResolvedValue();
+    vi.spyOn(internal, "gcp").mockImplementation(async (method, path) => {
+      calls.push(`${method} ${path}`);
+      if (method === "POST") throw new Error("already exists");
+      return {
+        id: "1",
+        name: leaseProviderName("cbx_abcdef123456", "blue-lobster"),
+        zone: "projects/default-project/zones/us-central1-a",
+        machineType: "zones/us-central1-a/machineTypes/e2-micro",
+        labels: {
+          crabbox: "true",
+          created_by: "crabbox",
+          provider: "gcp",
+          lease: "cbx_000000000000",
+          owner: "foreign_example_com",
+          slug: "blue-lobster",
+        },
+      } as T;
+    });
+
+    const error = await client
+      .createServer(
+        leaseConfig({
+          provider: "gcp",
+          serverType: "e2-micro",
+          gcpProject: "default-project",
+          gcpZone: "us-central1-a",
+          sshPublicKey: "ssh-ed25519 test",
+        }),
+        "cbx_abcdef123456",
+        "blue-lobster",
+        "alice@example.com",
+      )
+      .catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(Error);
+    expect(String(error)).toContain("provisioning cleanup failed closed");
+    expect(providerProvisioningCleanupClaim(error)).toEqual({
+      provider: "gcp",
+      cloudID: leaseProviderName("cbx_abcdef123456", "blue-lobster"),
+      region: "us-central1-a",
+      providerProject: "default-project",
+    });
+    expect(calls.some((call) => call.startsWith("DELETE "))).toBe(false);
   });
 
   it("recovers when another create wins the shared firewall race", async () => {

--- a/worker/test/provider-labels.test.ts
+++ b/worker/test/provider-labels.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 
 import type { LeaseConfig } from "../src/config";
-import { leaseProviderLabels } from "../src/provider-labels";
+import { gcpLabelValue, gcpProviderLabelValue } from "../src/gcp";
+import { leaseProviderLabels, providerMachineOwnedByLease } from "../src/provider-labels";
+import type { LeaseRecord, ProviderMachine } from "../src/types";
 
 describe("provider labels", () => {
   it("caps expires_at at the shorter of ttl and idle timeout", () => {
@@ -223,5 +225,133 @@ describe("provider labels", () => {
       new Date("2026-05-01T12:00:00Z"),
     );
     expect(labels.pond).toBeUndefined();
+  });
+
+  it("binds release ownership to the exact provider, resource, lease, owner, and slug", () => {
+    const lease = {
+      id: "cbx_abcdef123456",
+      slug: "blue-lobster",
+      provider: "aws",
+      cloudID: "i-abcdef123456",
+      owner: "alice@example.com",
+    } satisfies Pick<LeaseRecord, "id" | "slug" | "provider" | "cloudID" | "owner">;
+    const machine = {
+      provider: "aws",
+      cloudID: lease.cloudID,
+      labels: {
+        crabbox: "true",
+        created_by: "crabbox",
+        lease: lease.id,
+        owner: "alice_example.com",
+        provider: "aws",
+        slug: lease.slug,
+      },
+    } satisfies Pick<ProviderMachine, "provider" | "cloudID" | "labels">;
+
+    expect(providerMachineOwnedByLease(machine, lease, "aws")).toBe(true);
+    for (const candidate of [
+      { ...machine, provider: "gcp" as const },
+      { ...machine, cloudID: "i-foreign" },
+      { ...machine, labels: { ...machine.labels, crabbox: "false" } },
+      { ...machine, labels: { ...machine.labels, created_by: "external" } },
+      { ...machine, labels: { ...machine.labels, lease: "cbx_000000000000" } },
+      { ...machine, labels: { ...machine.labels, owner: "bob_example.com" } },
+      { ...machine, labels: { ...machine.labels, provider: "azure" } },
+      { ...machine, labels: { ...machine.labels, slug: "red-lobster" } },
+    ]) {
+      expect(providerMachineOwnedByLease(candidate, lease, "aws")).toBe(false);
+    }
+    expect(providerMachineOwnedByLease(machine, { ...lease, id: "legacy-id" }, "aws")).toBe(false);
+    expect(providerMachineOwnedByLease(machine, { ...lease, slug: undefined }, "aws")).toBe(false);
+    expect(providerMachineOwnedByLease(machine, { ...lease, owner: "" }, "aws")).toBe(false);
+  });
+
+  it("compares GCP ownership using the labels stored by Compute Engine", () => {
+    const lease = {
+      id: "cbx_abcdef123456",
+      slug: "Blue.Lobster",
+      provider: "gcp",
+      cloudID: "crabbox-blue-lobster",
+      owner: "Alice@example.com",
+    } satisfies Pick<LeaseRecord, "id" | "slug" | "provider" | "cloudID" | "owner">;
+    const machine = {
+      provider: "gcp",
+      cloudID: lease.cloudID,
+      labels: {
+        crabbox: "true",
+        created_by: "crabbox",
+        lease: lease.id,
+        owner: "alice_example_com",
+        provider: "gcp",
+        slug: "blue-lobster",
+      },
+    } satisfies Pick<ProviderMachine, "provider" | "cloudID" | "labels">;
+
+    expect(providerMachineOwnedByLease(machine, lease, "gcp", gcpLabelValue)).toBe(true);
+    expect(providerMachineOwnedByLease(machine, lease, "gcp")).toBe(false);
+  });
+
+  it("matches the two-stage GCP label transform used during creation", () => {
+    const lease = {
+      id: "cbx_abcdef123456",
+      slug: "Blue.Lobster",
+      provider: "gcp",
+      cloudID: "crabbox-blue-lobster",
+      owner: "İ@example.com",
+    } satisfies Pick<LeaseRecord, "id" | "slug" | "provider" | "cloudID" | "owner">;
+    const machine = {
+      provider: "gcp",
+      cloudID: lease.cloudID,
+      labels: {
+        crabbox: "true",
+        created_by: "crabbox",
+        lease: lease.id,
+        owner: "example_com",
+        provider: "gcp",
+        slug: "blue-lobster",
+      },
+    } satisfies Pick<ProviderMachine, "provider" | "cloudID" | "labels">;
+
+    expect(providerMachineOwnedByLease(machine, lease, "gcp", gcpProviderLabelValue)).toBe(true);
+    expect(providerMachineOwnedByLease(machine, lease, "gcp", gcpLabelValue)).toBe(false);
+  });
+
+  it("uses the immutable provider owner after a workspace prewarm handoff", () => {
+    const lease = {
+      id: "cbx_abcdef123456",
+      slug: "blue-lobster",
+      provider: "aws",
+      cloudID: "i-abcdef123456",
+      workspaceID: "fleet-blue-lobster",
+      owner: "alice@example.com",
+      providerOwner: "crabbox-internal-prewarm",
+    } satisfies Pick<
+      LeaseRecord,
+      "id" | "slug" | "provider" | "cloudID" | "workspaceID" | "owner" | "providerOwner"
+    >;
+    const machine = {
+      provider: "aws",
+      cloudID: lease.cloudID,
+      labels: {
+        crabbox: "true",
+        created_by: "crabbox",
+        lease: lease.id,
+        owner: "crabbox-internal-prewarm",
+        provider: "aws",
+        slug: lease.slug,
+      },
+    } satisfies Pick<ProviderMachine, "provider" | "cloudID" | "labels">;
+
+    expect(providerMachineOwnedByLease(machine, lease, "aws")).toBe(true);
+    expect(
+      providerMachineOwnedByLease(machine, { ...lease, providerOwner: undefined }, "aws"),
+    ).toBe(true);
+    expect(
+      providerMachineOwnedByLease(
+        machine,
+        { ...lease, providerOwner: undefined, workspaceID: undefined },
+        "aws",
+      ),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- require coordinator AWS, Azure, and GCP release paths to read the live cloud resource and verify its exact provider, resource, lease, owner, and slug identity before deletion
- preserve only the non-secret provider scope needed to retry provisioning-failure cleanup, and fail closed when that scope or ownership proof is missing or conflicting
- make Azure deferred cleanup rehydrate the original subscription/resource-group scope and revalidate each VM and companion resource immediately before deletion
- add focused regression coverage for forged labels, cross-provider claims, stale resource identities, cleanup retries, and provisioning rollback

Closes https://github.com/openclaw/crabbox/issues/930
Closes https://github.com/openclaw/crabbox/issues/931

## Verification

- `go vet ./...`
- `go test -race ./...`
- Worker suite: 866 passed, 3 skipped
- scripts suite: 385 passed
- Worker format, lint, typecheck, and dry-run builds
- docs build and link checks
- `npm audit`: 0 vulnerabilities
- AutoReview: no actionable findings
- authenticated GCP create/read/foreign-owner-deny/owned-release live proof with zero instance and disk residue

Exact redacted GCP proof on `f48fcbc1761456ac50d1e9f7d91c1dcd9f67995b` (152.94 seconds):

```json
{"provider":"gcp","leaseID":"cbx_930000000001","denied":true,"released":true,"residue":0}
```

The test re-read the created VM, verified canonical lease/provider labels, proved a foreign-owner release was denied while the VM remained, released with the exact owner claim, then verified both the instance and its named disk were absent.

## Merge gate

Hosted CI/security must pass on the exact PR head. AWS and Azure authenticated create/use/foreign-owner-deny/owned-release/zero-residue live proof must also pass on that candidate, unless the owner explicitly waives the provider-specific live gate. No credentials are stored by this change.

Compatibility decision: legacy Azure leases or deferred-cleanup records without the exact persisted subscription/resource-group scope fail closed for manual recovery. Silently guessing that scope would weaken the destructive-operation ownership boundary this fix establishes.
