### PR TITLE
fix(lambda): require claim-bound cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Confined Islo API redirects to the configured scheme, hostname, and effective port before replaying authorization or request bodies, while keeping rejected Location secrets out of diagnostics. Thanks @TurboTheTurtle.
 - Redacted colon-delimited and line-folded bearer credentials from CLI and coordinator diagnostics. Thanks @TurboTheTurtle.
 - Required coordinator AWS, Azure, and GCP release and provisioning-failure cleanup to re-read the stored cloud resource and verify exact provider, resource, lease, owner, and slug ownership before deletion; Azure now persists the exact subscription/resource-group scope for deferred retries and fails legacy unscoped cleanup closed for manual resolution. Thanks @coygeek.
-- Required Lambda inventory, stop, and cleanup to use an unchanged instance-bound local claim, with claim-bound SSH-key deletion and explicit per-lease-key recovery for ambiguous creates. Thanks @coygeek.
+- Required Lambda inventory, stop, and cleanup to use an unchanged instance-bound local claim, with claim-bound SSH-key deletion and durable unique-instance recovery for ambiguous creates. Thanks @coygeek.
 
 ## 0.36.0 - 2026-07-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Confined Islo API redirects to the configured scheme, hostname, and effective port before replaying authorization or request bodies, while keeping rejected Location secrets out of diagnostics. Thanks @TurboTheTurtle.
 - Redacted colon-delimited and line-folded bearer credentials from CLI and coordinator diagnostics. Thanks @TurboTheTurtle.
 - Required coordinator AWS, Azure, and GCP release and provisioning-failure cleanup to re-read the stored cloud resource and verify exact provider, resource, lease, owner, and slug ownership before deletion; Azure now persists the exact subscription/resource-group scope for deferred retries and fails legacy unscoped cleanup closed for manual resolution. Thanks @coygeek.
+- Required Lambda inventory, stop, and cleanup to use an unchanged instance-bound local claim, with claim-bound SSH-key deletion and explicit per-lease-key recovery for ambiguous creates. Thanks @coygeek.
 
 ## 0.36.0 - 2026-07-05
 

--- a/docs/providers/lambda.md
+++ b/docs/providers/lambda.md
@@ -156,7 +156,8 @@ Lambda has no safe tag-update path in this phase, and the launch path does not
 depend on provider-side tag persistence. Local Crabbox claims carry fresh touch
 and idle-timeout state. Explicit failed-create recovery remains claim-bound:
 ambiguous launches must match the unique per-lease Lambda SSH key before Crabbox
-can terminate them.
+persists the recovered instance binding before termination, so partial cleanup
+can safely resume after the instance disappears.
 
 Direct mode has no coordinator alarm. Use:
 

--- a/docs/providers/lambda.md
+++ b/docs/providers/lambda.md
@@ -121,8 +121,8 @@ classed doctor output rather than hidden behind generic errors.
 5. Claim the lease locally with Lambda instance and SSH-key metadata.
 6. Run normal Crabbox sync/run/ssh workflows over SSH.
 7. Terminate the Lambda instance and owned Lambda SSH key on `stop`; `cleanup`
-   deletes resources backed by a complete local Crabbox Lambda claim, and can
-   also reclaim complete Crabbox-tagged Lambda instances.
+   deletes only resources backed by an unchanged, exact local Crabbox Lambda
+   claim.
 
 If SSH-key creation, instance launch, or post-launch readiness becomes
 indeterminate, Crabbox records a local recovery claim with enough metadata to
@@ -147,15 +147,17 @@ expires_at=<unix-seconds>
 ttl_secs=<seconds>
 ```
 
-Release and cleanup require a complete ownership predicate: Crabbox marker,
-provider marker, lease id, slug, and Linux target. Lambda instances backed only
-by partial, foreign, or malformed Crabbox-like metadata are skipped or refused.
+Release and cleanup require an unchanged local claim that binds the exact Lambda
+instance, lease id, slug, provider, and SSH-key identity and ownership. Provider
+tags, names, and instance ids are discovery hints, not destructive authority;
+unclaimed Lambda inventory is skipped or refused.
 
 Lambda has no safe tag-update path in this phase, and the launch path does not
 depend on provider-side tag persistence. Local Crabbox claims carry fresh touch
-and idle-timeout state. Complete Crabbox-tagged Lambda instances are still
-understood by `list`, `stop`, and `cleanup` for compatibility with manually
-seeded or future provider metadata.
+and idle-timeout state. Explicit failed-create recovery remains claim-bound:
+ambiguous launches must match the unique per-lease Lambda SSH key before Crabbox
+can terminate them.
+
 Direct mode has no coordinator alarm. Use:
 
 ```sh

--- a/internal/cli/network.go
+++ b/internal/cli/network.go
@@ -345,6 +345,8 @@ func (a App) refreshTailscaleMetadata(ctx context.Context, cfg Config, backend B
 	if server == nil || !serverTailscaleMetadata(*server).Enabled {
 		return
 	}
+	original := *server
+	original.Labels = cloneStringMap(server.Labels)
 	meta, err := readRemoteTailscaleMetadata(ctx, target)
 	if err != nil {
 		meta = serverTailscaleMetadata(*server)
@@ -368,10 +370,11 @@ func (a App) refreshTailscaleMetadata(ctx context.Context, cfg Config, backend B
 			fmt.Fprintf(a.Stderr, "warning: tailscale metadata update failed for %s: %v\n", leaseID, err)
 		}
 	} else if direct, ok := backend.(TailscaleMetadataBackend); ok && leaseID != "" {
-		updated, err := direct.UpdateTailscaleMetadata(ctx, LeaseTarget{Server: *server, SSH: target, LeaseID: leaseID}, meta)
+		updated, err := direct.UpdateTailscaleMetadata(ctx, LeaseTarget{Server: original, SSH: target, LeaseID: leaseID}, meta)
 		if err == nil {
 			*server = updated
 		} else {
+			*server = original
 			fmt.Fprintf(a.Stderr, "warning: tailscale metadata update failed for %s: %v\n", leaseID, err)
 		}
 	}

--- a/internal/cli/provider_backend_test.go
+++ b/internal/cli/provider_backend_test.go
@@ -1410,3 +1410,22 @@ func TestRedactedSSHUserOnlyForDaytona(t *testing.T) {
 		t.Fatalf("redactedSSHUser daytona=%q", got)
 	}
 }
+
+func TestServerLeaseClaimSnapshotIsExplicitAndCloned(t *testing.T) {
+	server := Server{}
+	if _, exists, set := ServerLeaseClaimSnapshot(server); exists || set {
+		t.Fatalf("empty snapshot exists=%v set=%v", exists, set)
+	}
+	claim := LeaseClaim{LeaseID: "cbx_abcdef123456", Labels: map[string]string{"state": "ready"}}
+	SetServerLeaseClaimSnapshot(&server, claim, true)
+	claim.Labels["state"] = "changed"
+	got, exists, set := ServerLeaseClaimSnapshot(server)
+	if !exists || !set || got.LeaseID != claim.LeaseID || got.Labels["state"] != "ready" {
+		t.Fatalf("snapshot=%#v exists=%v set=%v", got, exists, set)
+	}
+	got.Labels["state"] = "mutated"
+	again, _, _ := ServerLeaseClaimSnapshot(server)
+	if again.Labels["state"] != "ready" {
+		t.Fatalf("snapshot alias=%#v", again)
+	}
+}

--- a/internal/cli/provider_exports.go
+++ b/internal/cli/provider_exports.go
@@ -257,6 +257,29 @@ func ReadLeaseClaimWithPresence(leaseID string) (LeaseClaim, bool, error) {
 	return readLeaseClaimWithPresence(leaseID)
 }
 
+// SetServerLeaseClaimSnapshot carries the exact claim state that authorized a
+// provider result into a later lifecycle operation.
+func SetServerLeaseClaimSnapshot(server *Server, claim LeaseClaim, exists bool) {
+	if server == nil {
+		return
+	}
+	server.claimSnapshotSet = true
+	server.claimSnapshotExists = exists
+	server.claimSnapshot = leaseClaim{}
+	if exists {
+		server.claimSnapshot = cloneLeaseClaim(claim)
+	}
+}
+
+// ServerLeaseClaimSnapshot returns the carried claim, whether it existed, and
+// whether a snapshot was explicitly attached.
+func ServerLeaseClaimSnapshot(server Server) (LeaseClaim, bool, bool) {
+	if !server.claimSnapshotSet {
+		return LeaseClaim{}, false, false
+	}
+	return cloneLeaseClaim(server.claimSnapshot), server.claimSnapshotExists, true
+}
+
 func OSImageWasExplicit(cfg Config) bool {
 	return cfg.osImageExplicit
 }

--- a/internal/providers/lambda/backend.go
+++ b/internal/providers/lambda/backend.go
@@ -38,6 +38,14 @@ func (e *ambiguousLambdaCreateError) Error() string {
 
 func (e *ambiguousLambdaCreateError) Unwrap() error { return e.err }
 
+type ambiguousLambdaRecoveryConflictError struct {
+	err core.ExitError
+}
+
+func (e *ambiguousLambdaRecoveryConflictError) Error() string { return e.err.Error() }
+
+func (e *ambiguousLambdaRecoveryConflictError) Unwrap() error { return e.err }
+
 type lambdaSSHKeyIdentity struct {
 	ID      string
 	Name    string
@@ -618,6 +626,10 @@ func (b *backend) ownedServersFromInstances(instances []Instance) ([]core.Server
 	for _, item := range instances {
 		server, claimed, err := claimedServerFromInstance(item, instances, b.cfg)
 		if err != nil {
+			var conflict *ambiguousLambdaRecoveryConflictError
+			if errors.As(err, &conflict) {
+				continue
+			}
 			return nil, err
 		}
 		if claimed {
@@ -751,7 +763,8 @@ func validateUniqueAmbiguousLaunchInstance(instanceID string, instances []Instan
 		}
 	}
 	if matches != 1 {
-		return core.Exit(2, "refusing Lambda recovery for lease=%s: recovery SSH key matches %d instances", claim.LeaseID, matches)
+		err := core.Exit(2, "refusing Lambda recovery for lease=%s: recovery SSH key matches %d instances", claim.LeaseID, matches)
+		return &ambiguousLambdaRecoveryConflictError{err: err}
 	}
 	if matchedID != instanceID {
 		return core.Exit(2, "refusing to release Lambda instance %s without its recovery SSH key binding", instanceID)

--- a/internal/providers/lambda/backend.go
+++ b/internal/providers/lambda/backend.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"strings"
 	"time"
@@ -324,9 +325,6 @@ func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.Le
 		return core.LeaseTarget{}, claimErr
 	} else if ok && claim.CloudID != "" {
 		if item, found := byID[claim.CloudID]; found {
-			if isOwnedInstance(item) {
-				return b.targetFromInstance(item, req)
-			}
 			return b.targetFromClaimedInstance(item, claim.Labels, req)
 		}
 	}
@@ -336,16 +334,10 @@ func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.Le
 		if !found {
 			return core.LeaseTarget{}, core.Exit(4, "lease/lambda instance not found: %s", req.ID)
 		}
-		if isOwnedInstance(item) {
-			return b.targetFromInstance(item, req)
-		}
 		return b.targetFromClaimedInstance(item, server.Labels, req)
 	}
 	if item, ok := byID[req.ID]; ok {
-		if isOwnedInstance(item) {
-			return b.targetFromInstance(item, req)
-		}
-		if server, claimed, claimErr := claimedServerFromInstance(item, b.cfg); claimErr != nil {
+		if server, claimed, claimErr := claimedServerFromInstance(item, instances, b.cfg); claimErr != nil {
 			return core.LeaseTarget{}, claimErr
 		} else if claimed {
 			return b.targetFromClaimedInstance(item, server.Labels, req)
@@ -382,29 +374,6 @@ func (b *backend) releaseTargetFromClaim(id string) (core.LeaseTarget, error) {
 	server.ServerType.Name = claim.Labels["server_type"]
 	return core.LeaseTarget{LeaseID: claim.LeaseID, Server: server}, nil
 }
-
-func (b *backend) targetFromInstance(item Instance, req core.ResolveRequest) (core.LeaseTarget, error) {
-	if err := validateLambdaLabels(item.Tags); err != nil {
-		return core.LeaseTarget{}, err
-	}
-	server, err := mergeLocalClaimLabels(serverFromInstance(item, b.cfg))
-	if err != nil {
-		return core.LeaseTarget{}, err
-	}
-	leaseID := server.Labels["lease"]
-	if req.ReleaseOnly {
-		return core.LeaseTarget{Server: server, LeaseID: leaseID}, nil
-	}
-	ssh := core.SSHTargetFromConfig(b.cfg, server.PublicNet.IPv4.IP)
-	core.UseStoredTestboxKey(&ssh, leaseID)
-	if req.Repo.Root != "" {
-		if err := core.ClaimLeaseTargetForRepoConfig(leaseID, server.Labels["slug"], b.cfg, server, ssh, req.Repo.Root, b.cfg.IdleTimeout, req.Reclaim); err != nil {
-			return core.LeaseTarget{}, err
-		}
-	}
-	return core.LeaseTarget{Server: server, SSH: ssh, LeaseID: leaseID}, nil
-}
-
 func (b *backend) targetFromClaimedInstance(item Instance, labels map[string]string, req core.ResolveRequest) (core.LeaseTarget, error) {
 	if err := validateLambdaLabels(labels); err != nil {
 		return core.LeaseTarget{}, err
@@ -504,69 +473,101 @@ func (b *backend) deleteServer(ctx context.Context, _ core.Config, server core.S
 	if err := validateLambdaLabels(server.Labels); err != nil {
 		return err
 	}
-	client, err := b.clientFactory(b.rt)
-	if err != nil {
-		return err
-	}
 	claim, claimExists, err := core.ReadLeaseClaimWithPresence(server.Labels["lease"])
 	if err != nil {
 		return fmt.Errorf("read lambda cleanup claim: %w", err)
 	}
-	if claimExists {
-		if claim.Provider != providerName {
-			return core.Exit(2, "lease=%s is claimed by provider=%s; refusing lambda cleanup", claim.LeaseID, claim.Provider)
-		}
-		if claim.CloudID != "" && server.CloudID != "" && claim.CloudID != server.CloudID {
-			return core.Exit(2, "refusing to release Lambda instance %s from stale local claim", server.CloudID)
-		}
+	if !claimExists {
+		return core.Exit(2, "lambda lease=%s has no exact local claim; refusing destructive operation", server.Labels["lease"])
+	}
+	if claim.Provider != providerName {
+		return core.Exit(2, "lease=%s is claimed by provider=%s; refusing lambda cleanup", claim.LeaseID, claim.Provider)
+	}
+	if err := validateLambdaLabels(claim.Labels); err != nil {
+		return core.Exit(2, "lambda lease=%s has an invalid local claim; refusing destructive operation", claim.LeaseID)
+	}
+	if claim.LeaseID != server.Labels["lease"] ||
+		claim.Slug != server.Labels["slug"] ||
+		claim.Labels["lease"] != claim.LeaseID ||
+		claim.Labels["slug"] != claim.Slug ||
+		!maps.Equal(claim.Labels, server.Labels) {
+		return core.Exit(2, "refusing to release Lambda instance %s from a stale local claim", server.DisplayID())
+	}
+	if claim.CloudID != "" && server.CloudID != "" && claim.CloudID != server.CloudID {
+		return core.Exit(2, "refusing to release Lambda instance %s from a stale local claim", server.CloudID)
 	}
 	instanceID := firstNonBlank(server.CloudID, claim.CloudID)
-	if server.CloudID == "" {
-		server.CloudID = instanceID
+	if claim.CloudID == "" {
+		switch claim.Labels[lambdaRecoveryKeyLabel] {
+		case "rollback-cleanup", "ambiguous-key-create":
+			if instanceID != "" {
+				return core.Exit(2, "refusing to release unbound Lambda instance %s", instanceID)
+			}
+		case "ambiguous-create":
+			if instanceID == "" {
+				return core.Exit(2, "lambda recovery is still pending for lease=%s; credentials and recovery claim retained", claim.LeaseID)
+			}
+		default:
+			return core.Exit(2, "lambda lease=%s has no instance-bound cleanup claim", claim.LeaseID)
+		}
 	}
-	liveFound := false
-	if instanceID != "" {
-		live, getErr := client.GetInstance(ctx, instanceID)
-		if getErr == nil {
-			liveFound = true
-			if err := validateLiveInstance(live, server); err != nil {
+	client, err := b.clientFactory(b.rt)
+	if err != nil {
+		return err
+	}
+	server.CloudID = instanceID
+	server.Labels = cloneLambdaLabels(claim.Labels)
+	keyID := claim.Labels[lambdaKeyIDLabel]
+	keyName := claim.Labels[lambdaKeyNameLabel]
+	keyOwned := claim.Labels[lambdaKeyOwnedLabel] == "true"
+	if err := core.RemoveLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, func() error {
+		liveFound := false
+		if instanceID != "" {
+			live, getErr := client.GetInstance(ctx, instanceID)
+			if getErr == nil {
+				liveFound = true
+				if claim.CloudID == "" {
+					instances, err := client.ListInstances(ctx)
+					if err != nil {
+						return err
+					}
+					if err := validateUniqueAmbiguousLaunchInstance(instanceID, instances, claim); err != nil {
+						return err
+					}
+				} else if err := validateLiveInstance(live, server); err != nil {
+					return err
+				}
+			} else if !isLambdaNotFound(getErr) {
+				return getErr
+			}
+		}
+		if claim.CloudID == "" && claim.Labels[lambdaRecoveryKeyLabel] == "ambiguous-create" && !liveFound {
+			return core.Exit(2, "lambda recovery is still pending for lease=%s; credentials and recovery claim retained", claim.LeaseID)
+		}
+		if liveFound {
+			if err := client.TerminateInstances(ctx, []string{instanceID}); err != nil {
 				return err
 			}
-			liveServer := serverFromInstance(live, b.cfg)
-			liveServer.Labels = cloneLambdaLabels(server.Labels)
-			server = liveServer
-		} else if !isLambdaNotFound(getErr) {
-			return getErr
 		}
+		if keyOwned && keyID == "" && keyName != "" {
+			resolvedID, found, err := resolveSSHKeyIDByName(ctx, client, keyName)
+			if err != nil {
+				return err
+			}
+			if found {
+				keyID = resolvedID
+			}
+		}
+		if keyOwned && keyID != "" {
+			if err := client.DeleteSSHKey(ctx, keyID); err != nil && !isLambdaNotFound(err) {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("finalize lambda cleanup claim: %w", err)
 	}
-	if liveFound {
-		if err := client.TerminateInstances(ctx, []string{instanceID}); err != nil {
-			return err
-		}
-	}
-	keyID := firstNonBlank(server.Labels[lambdaKeyIDLabel], claim.Labels[lambdaKeyIDLabel])
-	keyName := firstNonBlank(server.Labels[lambdaKeyNameLabel], claim.Labels[lambdaKeyNameLabel])
-	keyOwned := firstNonBlank(server.Labels[lambdaKeyOwnedLabel], claim.Labels[lambdaKeyOwnedLabel]) == "true"
-	if keyOwned && keyID == "" && keyName != "" {
-		resolvedID, found, err := resolveSSHKeyIDByName(ctx, client, keyName)
-		if err != nil {
-			return err
-		}
-		if found {
-			keyID = resolvedID
-		}
-	}
-	if keyOwned && keyID != "" {
-		if err := client.DeleteSSHKey(ctx, keyID); err != nil && !isLambdaNotFound(err) {
-			return err
-		}
-	}
-	if claimExists {
-		if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
-			return fmt.Errorf("finalize lambda cleanup claim: %w", err)
-		}
-	}
-	core.RemoveStoredTestboxKey(server.Labels["lease"])
+	core.RemoveStoredTestboxKey(claim.LeaseID)
 	return nil
 }
 
@@ -615,17 +616,7 @@ func (b *backend) listOwnedServers(ctx context.Context) ([]core.Server, error) {
 func (b *backend) ownedServersFromInstances(instances []Instance) ([]core.Server, error) {
 	servers := make([]core.Server, 0, len(instances))
 	for _, item := range instances {
-		if isOwnedInstance(item) {
-			server := serverFromInstance(item, b.cfg)
-			var err error
-			server, err = mergeLocalClaimLabels(server)
-			if err != nil {
-				return nil, err
-			}
-			servers = append(servers, server)
-			continue
-		}
-		server, claimed, err := claimedServerFromInstance(item, b.cfg)
+		server, claimed, err := claimedServerFromInstance(item, instances, b.cfg)
 		if err != nil {
 			return nil, err
 		}
@@ -636,7 +627,7 @@ func (b *backend) ownedServersFromInstances(instances []Instance) ([]core.Server
 	return servers, nil
 }
 
-func claimedServerFromInstance(item Instance, cfg core.Config) (core.Server, bool, error) {
+func claimedServerFromInstance(item Instance, instances []Instance, cfg core.Config) (core.Server, bool, error) {
 	if strings.TrimSpace(item.ID) == "" {
 		return core.Server{}, false, nil
 	}
@@ -645,7 +636,7 @@ func claimedServerFromInstance(item Instance, cfg core.Config) (core.Server, boo
 		return core.Server{}, false, err
 	}
 	if !ok {
-		claim, ok, err = ambiguousLaunchClaimForInstance(item)
+		claim, ok, err = ambiguousLaunchClaimForInstance(item, instances)
 		if err != nil {
 			return core.Server{}, false, err
 		}
@@ -664,7 +655,7 @@ func claimedServerFromInstance(item Instance, cfg core.Config) (core.Server, boo
 	return server, true, nil
 }
 
-func ambiguousLaunchClaimForInstance(item Instance) (core.LeaseClaim, bool, error) {
+func ambiguousLaunchClaimForInstance(item Instance, instances []Instance) (core.LeaseClaim, bool, error) {
 	keyNames := make(map[string]struct{}, len(item.SSHKeyNames))
 	for _, keyName := range item.SSHKeyNames {
 		keyName = strings.TrimSpace(keyName)
@@ -698,29 +689,12 @@ func ambiguousLaunchClaimForInstance(item Instance) (core.LeaseClaim, bool, erro
 		matched = claim
 		found = true
 	}
+	if found {
+		if err := validateUniqueAmbiguousLaunchInstance(item.ID, instances, matched); err != nil {
+			return core.LeaseClaim{}, false, err
+		}
+	}
 	return matched, found, nil
-}
-
-func mergeLocalClaimLabels(server core.Server) (core.Server, error) {
-	leaseID := server.Labels["lease"]
-	if leaseID == "" {
-		return server, nil
-	}
-	claim, ok, err := core.ReadLeaseClaimWithPresence(leaseID)
-	if err != nil {
-		return core.Server{}, fmt.Errorf("read lambda lease claim: %w", err)
-	}
-	if !ok || claim.Provider != providerName {
-		return server, nil
-	}
-	if claim.CloudID != "" && claim.CloudID != server.CloudID {
-		return core.Server{}, core.Exit(2, "refusing to list Lambda instance %s from stale local claim", server.CloudID)
-	}
-	if err := validateLambdaLabels(claim.Labels); err != nil {
-		return core.Server{}, err
-	}
-	server.Labels = cloneLambdaLabels(claim.Labels)
-	return server, nil
 }
 
 func serverFromInstance(item Instance, cfg core.Config) core.Server {
@@ -756,6 +730,31 @@ func validateLiveInstance(item Instance, expected core.Server) error {
 		labels["slug"] != expected.Labels["slug"] ||
 		labels["provider_key"] != expectedProviderKey {
 		return core.Exit(2, "refusing to operate on changed Lambda instance %s", expected.CloudID)
+	}
+	return nil
+}
+
+func validateUniqueAmbiguousLaunchInstance(instanceID string, instances []Instance, claim core.LeaseClaim) error {
+	if claim.Labels[lambdaRecoveryKeyLabel] != "ambiguous-create" {
+		return core.Exit(2, "refusing to release unbound Lambda instance %s", instanceID)
+	}
+	expectedKey := strings.TrimSpace(claim.Labels[lambdaKeyNameLabel])
+	matchedID := ""
+	matches := 0
+	for _, item := range instances {
+		for _, keyName := range item.SSHKeyNames {
+			if expectedKey != "" && strings.TrimSpace(keyName) == expectedKey {
+				matchedID = item.ID
+				matches++
+				break
+			}
+		}
+	}
+	if matches != 1 {
+		return core.Exit(2, "refusing Lambda recovery for lease=%s: recovery SSH key matches %d instances", claim.LeaseID, matches)
+	}
+	if matchedID != instanceID {
+		return core.Exit(2, "refusing to release Lambda instance %s without its recovery SSH key binding", instanceID)
 	}
 	return nil
 }

--- a/internal/providers/lambda/backend.go
+++ b/internal/providers/lambda/backend.go
@@ -215,6 +215,15 @@ func (b *backend) acquireOnce(ctx context.Context, req core.AcquireRequest) (tar
 	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, ssh, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
 		return core.LeaseTarget{}, err
 	}
+	claim, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
+	if err != nil {
+		return core.LeaseTarget{}, fmt.Errorf("read acquired lambda claim: %w", err)
+	}
+	if !exists {
+		return core.LeaseTarget{}, core.Exit(2, "lambda lease=%s claim is missing after acquire", leaseID)
+	}
+	core.SetServerLeaseClaimSnapshot(&server, claim, true)
+	target.Server = server
 	committed = true
 	fmt.Fprintf(b.rt.Stderr, "provisioned lease=%s lambda=%s type=%s\n", leaseID, server.DisplayID(), cfg.ServerType)
 	return target, nil
@@ -333,22 +342,26 @@ func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.Le
 		return core.LeaseTarget{}, claimErr
 	} else if ok && claim.CloudID != "" {
 		if item, found := byID[claim.CloudID]; found {
-			return b.targetFromClaimedInstance(item, claim.Labels, req)
+			server, err := serverFromLambdaClaim(item, b.cfg, claim)
+			if err != nil {
+				return core.LeaseTarget{}, err
+			}
+			return b.targetFromClaimedServer(server, req)
 		}
 	}
 	server, leaseID, err := core.FindServerByAlias(servers, req.ID)
 	if err == nil && leaseID != "" {
-		item, found := byID[server.CloudID]
+		_, found := byID[server.CloudID]
 		if !found {
 			return core.LeaseTarget{}, core.Exit(4, "lease/lambda instance not found: %s", req.ID)
 		}
-		return b.targetFromClaimedInstance(item, server.Labels, req)
+		return b.targetFromClaimedServer(server, req)
 	}
 	if item, ok := byID[req.ID]; ok {
 		if server, claimed, claimErr := claimedServerFromInstance(item, instances, b.cfg); claimErr != nil {
 			return core.LeaseTarget{}, claimErr
 		} else if claimed {
-			return b.targetFromClaimedInstance(item, server.Labels, req)
+			return b.targetFromClaimedServer(server, req)
 		}
 	}
 	if req.ReleaseOnly {
@@ -380,14 +393,14 @@ func (b *backend) releaseTargetFromClaim(id string) (core.LeaseTarget, error) {
 	server := core.Server{Provider: providerName, CloudID: claim.CloudID, Name: claim.Slug, Labels: claim.Labels}
 	server.PublicNet.IPv4.IP = claim.SSHHost
 	server.ServerType.Name = claim.Labels["server_type"]
+	core.SetServerLeaseClaimSnapshot(&server, claim, true)
 	return core.LeaseTarget{LeaseID: claim.LeaseID, Server: server}, nil
 }
-func (b *backend) targetFromClaimedInstance(item Instance, labels map[string]string, req core.ResolveRequest) (core.LeaseTarget, error) {
-	if err := validateLambdaLabels(labels); err != nil {
+
+func (b *backend) targetFromClaimedServer(server core.Server, req core.ResolveRequest) (core.LeaseTarget, error) {
+	if err := validateLambdaLabels(server.Labels); err != nil {
 		return core.LeaseTarget{}, err
 	}
-	server := serverFromInstance(item, b.cfg)
-	server.Labels = cloneLambdaLabels(labels)
 	leaseID := server.Labels["lease"]
 	if req.ReleaseOnly {
 		return core.LeaseTarget{Server: server, LeaseID: leaseID}, nil
@@ -398,6 +411,14 @@ func (b *backend) targetFromClaimedInstance(item Instance, labels map[string]str
 		if err := core.ClaimLeaseTargetForRepoConfig(leaseID, server.Labels["slug"], b.cfg, server, ssh, req.Repo.Root, b.cfg.IdleTimeout, req.Reclaim); err != nil {
 			return core.LeaseTarget{}, err
 		}
+		claim, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
+		if err != nil {
+			return core.LeaseTarget{}, err
+		}
+		if !exists {
+			return core.LeaseTarget{}, core.Exit(2, "lambda lease=%s claim disappeared during resolve", leaseID)
+		}
+		core.SetServerLeaseClaimSnapshot(&server, claim, true)
 	}
 	return core.LeaseTarget{Server: server, SSH: ssh, LeaseID: leaseID}, nil
 }
@@ -437,7 +458,8 @@ func (b *backend) Touch(ctx context.Context, req core.TouchRequest) (core.Server
 	_ = ctx
 	b.initDirect()
 	server := req.Lease.Server
-	if err := validateLambdaLabels(server.Labels); err != nil {
+	claim, err := revalidateLambdaClaimSnapshot(server)
+	if err != nil {
 		return core.Server{}, err
 	}
 	cfg := b.cfg
@@ -447,11 +469,11 @@ func (b *backend) Touch(ctx context.Context, req core.TouchRequest) (core.Server
 	labels := core.TouchDirectLeaseLabels(server.Labels, cfg, req.State, b.now())
 	labels[lambdaTouchLocalLabel] = "true"
 	server.Labels = labels
-	if claim, ok, err := core.ReadLeaseClaimWithPresence(req.Lease.LeaseID); err == nil && ok {
-		if _, err := core.UpdateLeaseClaimLabelsIfUnchanged(req.Lease.LeaseID, claim, labels); err != nil {
-			return core.Server{}, err
-		}
+	updated, err := core.UpdateLeaseClaimLabelsIfUnchanged(req.Lease.LeaseID, claim, labels)
+	if err != nil {
+		return core.Server{}, err
 	}
+	core.SetServerLeaseClaimSnapshot(&server, updated, true)
 	return server, nil
 }
 
@@ -459,50 +481,32 @@ func (b *backend) UpdateTailscaleMetadata(ctx context.Context, lease core.LeaseT
 	_ = ctx
 	b.initDirect()
 	server := lease.Server
-	if err := validateLambdaLabels(server.Labels); err != nil {
+	expected, exists, set := core.ServerLeaseClaimSnapshot(server)
+	if !set || !exists {
+		return core.Server{}, core.Exit(2, "lambda lease=%s has no exact local claim snapshot; refusing metadata update", lease.LeaseID)
+	}
+	baseline := server
+	baseline.Labels = cloneLambdaLabels(expected.Labels)
+	claim, err := revalidateLambdaClaimSnapshot(baseline)
+	if err != nil {
 		return core.Server{}, err
 	}
-	labels := make(map[string]string, len(server.Labels)+8)
-	for key, value := range server.Labels {
-		labels[key] = value
-	}
+	labels := cloneLambdaLabels(claim.Labels)
 	applyTailscaleMetadata(labels, meta)
 	labels[lambdaTouchLocalLabel] = "true"
 	server.Labels = labels
-	if claim, ok, err := core.ReadLeaseClaimWithPresence(lease.LeaseID); err == nil && ok {
-		if _, err := core.UpdateLeaseClaimLabelsIfUnchanged(lease.LeaseID, claim, labels); err != nil {
-			return core.Server{}, err
-		}
+	updated, err := core.UpdateLeaseClaimLabelsIfUnchanged(lease.LeaseID, claim, labels)
+	if err != nil {
+		return core.Server{}, err
 	}
+	core.SetServerLeaseClaimSnapshot(&server, updated, true)
 	return server, nil
 }
 
 func (b *backend) deleteServer(ctx context.Context, _ core.Config, server core.Server) error {
-	if err := validateLambdaLabels(server.Labels); err != nil {
-		return err
-	}
-	claim, claimExists, err := core.ReadLeaseClaimWithPresence(server.Labels["lease"])
+	claim, err := revalidateLambdaClaimSnapshot(server)
 	if err != nil {
-		return fmt.Errorf("read lambda cleanup claim: %w", err)
-	}
-	if !claimExists {
-		return core.Exit(2, "lambda lease=%s has no exact local claim; refusing destructive operation", server.Labels["lease"])
-	}
-	if claim.Provider != providerName {
-		return core.Exit(2, "lease=%s is claimed by provider=%s; refusing lambda cleanup", claim.LeaseID, claim.Provider)
-	}
-	if err := validateLambdaLabels(claim.Labels); err != nil {
-		return core.Exit(2, "lambda lease=%s has an invalid local claim; refusing destructive operation", claim.LeaseID)
-	}
-	if claim.LeaseID != server.Labels["lease"] ||
-		claim.Slug != server.Labels["slug"] ||
-		claim.Labels["lease"] != claim.LeaseID ||
-		claim.Labels["slug"] != claim.Slug ||
-		!maps.Equal(claim.Labels, server.Labels) {
-		return core.Exit(2, "refusing to release Lambda instance %s from a stale local claim", server.DisplayID())
-	}
-	if claim.CloudID != "" && server.CloudID != "" && claim.CloudID != server.CloudID {
-		return core.Exit(2, "refusing to release Lambda instance %s from a stale local claim", server.CloudID)
+		return err
 	}
 	instanceID := firstNonBlank(server.CloudID, claim.CloudID)
 	if claim.CloudID == "" {
@@ -525,6 +529,22 @@ func (b *backend) deleteServer(ctx context.Context, _ core.Config, server core.S
 	}
 	server.CloudID = instanceID
 	server.Labels = cloneLambdaLabels(claim.Labels)
+	if claim.CloudID == "" && claim.Labels[lambdaRecoveryKeyLabel] == "ambiguous-create" {
+		updated, err := core.UpdateLeaseClaimEndpointIfUnchangedAfter(claim.LeaseID, claim, server, core.SSHTarget{}, func() error {
+			instances, err := client.ListInstances(ctx)
+			if err != nil {
+				return err
+			}
+			return validateUniqueAmbiguousLaunchInstance(instanceID, instances, claim)
+		})
+		if err != nil {
+			return fmt.Errorf("bind ambiguous lambda recovery: %w", err)
+		}
+		claim = updated
+		instanceID = claim.CloudID
+		server.CloudID = instanceID
+		core.SetServerLeaseClaimSnapshot(&server, claim, true)
+	}
 	keyID := claim.Labels[lambdaKeyIDLabel]
 	keyName := claim.Labels[lambdaKeyNameLabel]
 	keyOwned := claim.Labels[lambdaKeyOwnedLabel] == "true"
@@ -534,23 +554,12 @@ func (b *backend) deleteServer(ctx context.Context, _ core.Config, server core.S
 			live, getErr := client.GetInstance(ctx, instanceID)
 			if getErr == nil {
 				liveFound = true
-				if claim.CloudID == "" {
-					instances, err := client.ListInstances(ctx)
-					if err != nil {
-						return err
-					}
-					if err := validateUniqueAmbiguousLaunchInstance(instanceID, instances, claim); err != nil {
-						return err
-					}
-				} else if err := validateLiveInstance(live, server); err != nil {
+				if err := validateLiveInstance(live, server); err != nil {
 					return err
 				}
 			} else if !isLambdaNotFound(getErr) {
 				return getErr
 			}
-		}
-		if claim.CloudID == "" && claim.Labels[lambdaRecoveryKeyLabel] == "ambiguous-create" && !liveFound {
-			return core.Exit(2, "lambda recovery is still pending for lease=%s; credentials and recovery claim retained", claim.LeaseID)
 		}
 		if liveFound {
 			if err := client.TerminateInstances(ctx, []string{instanceID}); err != nil {
@@ -577,6 +586,54 @@ func (b *backend) deleteServer(ctx context.Context, _ core.Config, server core.S
 	}
 	core.RemoveStoredTestboxKey(claim.LeaseID)
 	return nil
+}
+
+func revalidateLambdaClaimSnapshot(server core.Server) (core.LeaseClaim, error) {
+	if err := validateLambdaLabels(server.Labels); err != nil {
+		return core.LeaseClaim{}, err
+	}
+	expected, expectedExists, snapshotSet := core.ServerLeaseClaimSnapshot(server)
+	if !snapshotSet || !expectedExists {
+		return core.LeaseClaim{}, core.Exit(2, "lambda lease=%s has no exact local claim snapshot; refusing operation", server.Labels["lease"])
+	}
+	if expected.Provider != providerName ||
+		expected.LeaseID != server.Labels["lease"] ||
+		expected.Slug != server.Labels["slug"] ||
+		expected.Labels["lease"] != expected.LeaseID ||
+		expected.Labels["slug"] != expected.Slug ||
+		!maps.Equal(expected.Labels, server.Labels) ||
+		(expected.CloudID != "" && server.CloudID != "" && expected.CloudID != server.CloudID) {
+		return core.LeaseClaim{}, core.Exit(2, "refusing Lambda operation on %s from a stale local claim", server.DisplayID())
+	}
+	current, exists, err := core.ReadLeaseClaimWithPresence(expected.LeaseID)
+	if err != nil {
+		return core.LeaseClaim{}, fmt.Errorf("read lambda claim: %w", err)
+	}
+	if !exists ||
+		!lambdaClaimOwnershipMatches(expected, current) ||
+		!maps.Equal(current.Labels, server.Labels) {
+		return core.LeaseClaim{}, core.Exit(2, "lambda lease=%s claim changed; retry", expected.LeaseID)
+	}
+	if err := validateLambdaLabels(current.Labels); err != nil {
+		return core.LeaseClaim{}, core.Exit(2, "lambda lease=%s has an invalid local claim; refusing operation", current.LeaseID)
+	}
+	return current, nil
+}
+
+func lambdaClaimOwnershipMatches(expected, current core.LeaseClaim) bool {
+	return expected.LeaseID == current.LeaseID &&
+		expected.Slug == current.Slug &&
+		expected.Provider == current.Provider &&
+		expected.CloudID == current.CloudID &&
+		expected.ProviderScope == current.ProviderScope &&
+		expected.StaticHost == current.StaticHost &&
+		expected.StaticUser == current.StaticUser &&
+		expected.StaticPort == current.StaticPort &&
+		expected.StaticWorkRoot == current.StaticWorkRoot &&
+		expected.TargetOS == current.TargetOS &&
+		expected.WindowsMode == current.WindowsMode &&
+		expected.Pond == current.Pond &&
+		expected.RepoRoot == current.RepoRoot
 }
 
 func (b *backend) persistRecoveryClaim(leaseID, slug string, cfg core.Config, repoRoot string, key lambdaSSHKeyIdentity, cloudID, recovery string, keep bool, now time.Time) error {
@@ -659,12 +716,21 @@ func claimedServerFromInstance(item Instance, instances []Instance, cfg core.Con
 	if claim.CloudID != "" && claim.CloudID != item.ID {
 		return core.Server{}, false, nil
 	}
-	if err := validateLambdaLabels(claim.Labels); err != nil {
+	server, err := serverFromLambdaClaim(item, cfg, claim)
+	if err != nil {
 		return core.Server{}, false, err
+	}
+	return server, true, nil
+}
+
+func serverFromLambdaClaim(item Instance, cfg core.Config, claim core.LeaseClaim) (core.Server, error) {
+	if err := validateLambdaLabels(claim.Labels); err != nil {
+		return core.Server{}, err
 	}
 	server := serverFromInstance(item, cfg)
 	server.Labels = cloneLambdaLabels(claim.Labels)
-	return server, true, nil
+	core.SetServerLeaseClaimSnapshot(&server, claim, true)
+	return server, nil
 }
 
 func ambiguousLaunchClaimForInstance(item Instance, instances []Instance) (core.LeaseClaim, bool, error) {

--- a/internal/providers/lambda/backend_test.go
+++ b/internal/providers/lambda/backend_test.go
@@ -143,6 +143,16 @@ func newTestBackend(t *testing.T, api *fakeLambdaAPI) *backend {
 	return b
 }
 
+func attachLambdaClaimSnapshot(t *testing.T, server core.Server, leaseID string) core.Server {
+	t.Helper()
+	claim, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
+	if err != nil || !exists {
+		t.Fatalf("claim=%#v exists=%v err=%v", claim, exists, err)
+	}
+	core.SetServerLeaseClaimSnapshot(&server, claim, true)
+	return server
+}
+
 func TestListShowsOnlyClaimedLambdaInstances(t *testing.T) {
 	api := &fakeLambdaAPI{}
 	b := newTestBackend(t, api)
@@ -280,6 +290,7 @@ func TestAcquireReusesMatchingSSHKeyAndReleaseDoesNotDeleteIt(t *testing.T) {
 	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, b.cfg, server, core.SSHTarget{}, t.TempDir(), 0, false); err != nil {
 		t.Fatal(err)
 	}
+	server = attachLambdaClaimSnapshot(t, server, leaseID)
 	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: server}}); err != nil {
 		t.Fatal(err)
 	}
@@ -566,6 +577,7 @@ func TestReleaseRefusesAmbiguousLaunchWithoutClaimedSSHKey(t *testing.T) {
 	api.launchErr = nil
 	api.instances = append(api.instances, Instance{ID: "i-unbound", Name: "unbound", Status: "active", IP: "203.0.113.52", Type: defaultType, SSHKeyNames: []string{"different-key"}})
 	server := core.Server{Provider: providerName, CloudID: "i-unbound", Name: claim.Slug, Labels: claim.Labels}
+	core.SetServerLeaseClaimSnapshot(&server, claim, true)
 	err = b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: claim.LeaseID, Server: server}})
 	if err == nil || !strings.Contains(err.Error(), "matches 0 instances") {
 		t.Fatalf("err=%v", err)
@@ -588,6 +600,7 @@ func TestReleaseRefusesRequestSSHKeyOverride(t *testing.T) {
 	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "claimed-key", b.cfg, server, core.SSHTarget{}, t.TempDir(), 0, false); err != nil {
 		t.Fatal(err)
 	}
+	server = attachLambdaClaimSnapshot(t, server, leaseID)
 	requestLabels := cloneLambdaLabels(labels)
 	requestLabels[lambdaKeyIDLabel] = "key-unclaimed"
 	server.Labels = requestLabels
@@ -619,17 +632,73 @@ func TestReleaseRefusesRefreshedClaimSnapshot(t *testing.T) {
 	if err != nil || !ok {
 		t.Fatalf("claim=%#v ok=%v err=%v", claim, ok, err)
 	}
+	core.SetServerLeaseClaimSnapshot(&server, claim, true)
 	freshLabels := cloneLambdaLabels(labels)
 	freshLabels["last_touched_at"] = core.LeaseLabelTime(time.Now())
 	if _, err := core.UpdateLeaseClaimLabelsIfUnchanged(leaseID, claim, freshLabels); err != nil {
 		t.Fatal(err)
 	}
 	err = b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: server}})
-	if err == nil || !strings.Contains(err.Error(), "stale local claim") {
+	if err == nil || !strings.Contains(err.Error(), "claim changed; retry") {
 		t.Fatalf("err=%v", err)
 	}
 	if len(api.terminatedIDs) != 0 || len(api.deletedKeyIDs) != 0 {
 		t.Fatalf("refreshed claim mutated: terminated=%v keys=%v", api.terminatedIDs, api.deletedKeyIDs)
+	}
+}
+
+func TestReleaseRefusesTransferredClaimSnapshot(t *testing.T) {
+	api := &fakeLambdaAPI{}
+	b := newTestBackend(t, api)
+	leaseID := "cbx_abcdef123456"
+	labels := lambdaLabelsWithKey(leaseTags(b.cfg, leaseID, "transferred", "ready", false, time.Now()), lambdaSSHKeyIdentity{ID: "key-transferred", Name: providerKeyForLease(leaseID), Created: true})
+	api.instances = []Instance{{ID: "i-transferred", Name: "transferred", Status: "active", IP: "203.0.113.57", Type: defaultType, Tags: labels}}
+	server := core.Server{Provider: providerName, CloudID: "i-transferred", Name: "transferred", Labels: labels}
+	repoA := t.TempDir()
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "transferred", b.cfg, server, core.SSHTarget{}, repoA, 0, false); err != nil {
+		t.Fatal(err)
+	}
+	server = attachLambdaClaimSnapshot(t, server, leaseID)
+	repoB := t.TempDir()
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "transferred", b.cfg, server, core.SSHTarget{}, repoB, 0, true); err != nil {
+		t.Fatal(err)
+	}
+	claim, ok, err := core.ResolveLeaseClaimForProvider("transferred", providerName)
+	if err != nil || !ok || claim.RepoRoot != repoB {
+		t.Fatalf("claim=%#v ok=%v err=%v", claim, ok, err)
+	}
+	err = b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: server}})
+	if err == nil || !strings.Contains(err.Error(), "claim changed; retry") {
+		t.Fatalf("err=%v", err)
+	}
+	if len(api.terminatedIDs) != 0 || len(api.deletedKeyIDs) != 0 {
+		t.Fatalf("transferred claim mutated: terminated=%v keys=%v", api.terminatedIDs, api.deletedKeyIDs)
+	}
+}
+
+func TestReleaseAllowsSameOwnerEndpointRefresh(t *testing.T) {
+	api := &fakeLambdaAPI{}
+	b := newTestBackend(t, api)
+	leaseID := "cbx_abcdef123456"
+	labels := lambdaLabelsWithKey(leaseTags(b.cfg, leaseID, "endpoint-refresh", "ready", false, time.Now()), lambdaSSHKeyIdentity{ID: "key-endpoint-refresh", Name: providerKeyForLease(leaseID), Created: true})
+	api.instances = []Instance{{ID: "i-endpoint-refresh", Name: "endpoint-refresh", Status: "active", IP: "203.0.113.59", Type: defaultType, Tags: labels}}
+	server := core.Server{Provider: providerName, CloudID: "i-endpoint-refresh", Name: "endpoint-refresh", Labels: labels}
+	repoRoot := t.TempDir()
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "endpoint-refresh", b.cfg, server, core.SSHTarget{}, repoRoot, 0, false); err != nil {
+		t.Fatal(err)
+	}
+	server = attachLambdaClaimSnapshot(t, server, leaseID)
+	if err := core.UpdateLeaseClaimEndpoint(leaseID, server, core.SSHTarget{Host: "100.64.0.59", Port: "22"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "endpoint-refresh", b.cfg, server, core.SSHTarget{Host: "100.64.0.59", Port: "22"}, repoRoot, 0, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: server}}); err != nil {
+		t.Fatal(err)
+	}
+	if len(api.terminatedIDs) != 1 || api.terminatedIDs[0][0] != "i-endpoint-refresh" || len(api.deletedKeyIDs) != 1 || api.deletedKeyIDs[0] != "key-endpoint-refresh" {
+		t.Fatalf("terminated=%v deletedKeyIDs=%v", api.terminatedIDs, api.deletedKeyIDs)
 	}
 }
 
@@ -674,6 +743,7 @@ func TestAmbiguousLaunchRecoveryConflictIsScopedToRecoveryClaim(t *testing.T) {
 		t.Fatalf("resolve err=%v", err)
 	}
 	server := core.Server{Provider: providerName, CloudID: "i-duplicate-1", Name: claim.Slug, Labels: claim.Labels}
+	core.SetServerLeaseClaimSnapshot(&server, claim, true)
 	err = b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: claim.LeaseID, Server: server}})
 	if err == nil || !strings.Contains(err.Error(), "matches 2 instances") {
 		t.Fatalf("release err=%v", err)
@@ -802,6 +872,62 @@ func TestAmbiguousLaunchRecoveryFindsInstanceBySSHKeyName(t *testing.T) {
 	}
 }
 
+func TestAmbiguousLaunchRecoveryPersistsBindingBeforePartialCleanup(t *testing.T) {
+	api := &fakeLambdaAPI{launchErr: errors.New("transport closed")}
+	b := newTestBackend(t, api)
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "ambiguous-retry"})
+	if err == nil || !strings.Contains(err.Error(), "indeterminate") {
+		t.Fatalf("err=%v", err)
+	}
+	claim, ok, claimErr := core.ResolveLeaseClaimForProvider("ambiguous-retry", providerName)
+	if claimErr != nil || !ok || claim.CloudID != "" {
+		t.Fatalf("claim=%#v ok=%v err=%v", claim, ok, claimErr)
+	}
+	api.launchErr = nil
+	api.instances = append(api.instances, Instance{
+		ID:          "i-ambiguous-retry",
+		Name:        "ambiguous-retry",
+		Status:      "active",
+		IP:          "203.0.113.58",
+		Type:        defaultType,
+		SSHKeyNames: []string{claim.Labels[lambdaKeyNameLabel]},
+	})
+	target, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "ambiguous-retry", ReleaseOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	api.deleteKeyErr = errors.New("key deletion unavailable")
+	err = b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: target})
+	if err == nil || !strings.Contains(err.Error(), "key deletion unavailable") {
+		t.Fatalf("err=%v", err)
+	}
+	bound, ok, claimErr := core.ResolveLeaseClaimForProvider("ambiguous-retry", providerName)
+	if claimErr != nil || !ok || bound.CloudID != "i-ambiguous-retry" {
+		t.Fatalf("bound=%#v ok=%v err=%v", bound, ok, claimErr)
+	}
+	if len(api.terminatedIDs) != 1 || api.terminatedIDs[0][0] != "i-ambiguous-retry" {
+		t.Fatalf("terminated=%v", api.terminatedIDs)
+	}
+	api.instances = nil
+	api.deleteKeyErr = nil
+	retry, err := b.releaseTargetFromClaim("ambiguous-retry")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: retry}); err != nil {
+		t.Fatal(err)
+	}
+	if len(api.terminatedIDs) != 1 {
+		t.Fatalf("terminated on retry=%v", api.terminatedIDs)
+	}
+	if len(api.deletedKeyIDs) != 2 || api.deletedKeyIDs[1] != "key-700" {
+		t.Fatalf("deletedKeyIDs=%v", api.deletedKeyIDs)
+	}
+	if _, ok, err := core.ResolveLeaseClaimForProvider("ambiguous-retry", providerName); err != nil || ok {
+		t.Fatalf("claim ok=%v err=%v", ok, err)
+	}
+}
+
 func TestFailedRollbackRecoveryClaimKeepsInstanceIDForRetry(t *testing.T) {
 	api := &fakeLambdaAPI{terminateErr: errors.New("terminate unavailable")}
 	b := newTestBackend(t, api)
@@ -874,22 +1000,28 @@ func TestTouchAndTailscaleMetadataAreLocalOnly(t *testing.T) {
 	if touched.Labels["state"] != "running" || touched.Labels[lambdaTouchLocalLabel] != "true" {
 		t.Fatalf("touched labels=%v", touched.Labels)
 	}
-	updated, err := b.UpdateTailscaleMetadata(context.Background(), core.LeaseTarget{LeaseID: lease.LeaseID, Server: touched}, core.TailscaleMetadata{
+	meta := core.TailscaleMetadata{
 		Enabled:  true,
 		Hostname: "touch",
 		FQDN:     "touch.example.ts.net",
 		IPv4:     "100.64.1.10",
 		Tags:     []string{"tag:ci", "tag:crabbox"},
 		State:    "ready",
-	})
+		Version:  "1.80.3",
+		DeviceID: "node-lambda-touch",
+	}
+	pending := touched
+	pending.Labels = cloneLambdaLabels(touched.Labels)
+	applyTailscaleMetadata(pending.Labels, meta)
+	updated, err := b.UpdateTailscaleMetadata(context.Background(), core.LeaseTarget{LeaseID: lease.LeaseID, Server: pending}, meta)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if updated.Labels["tailscale_ipv4"] != "100.64.1.10" || updated.Labels["tailscale_tags"] != "tag:ci,tag:crabbox" || updated.Labels[lambdaTouchLocalLabel] != "true" {
+	if updated.Labels["tailscale_ipv4"] != "100.64.1.10" || updated.Labels["tailscale_tags"] != "tag:ci,tag:crabbox" || updated.Labels["tailscale_version"] != "1.80.3" || updated.Labels["tailscale_device_id"] != "node-lambda-touch" || updated.Labels[lambdaTouchLocalLabel] != "true" {
 		t.Fatalf("updated labels=%v", updated.Labels)
 	}
 	claim, ok, err := core.ResolveLeaseClaimForProvider("touch", providerName)
-	if err != nil || !ok || claim.Labels["tailscale_fqdn"] != "touch.example.ts.net" {
+	if err != nil || !ok || claim.Labels["tailscale_fqdn"] != "touch.example.ts.net" || claim.Labels["tailscale_version"] != "1.80.3" || claim.Labels["tailscale_device_id"] != "node-lambda-touch" {
 		t.Fatalf("claim=%#v ok=%v err=%v", claim, ok, err)
 	}
 }

--- a/internal/providers/lambda/backend_test.go
+++ b/internal/providers/lambda/backend_test.go
@@ -633,7 +633,7 @@ func TestReleaseRefusesRefreshedClaimSnapshot(t *testing.T) {
 	}
 }
 
-func TestAmbiguousLaunchRecoveryRefusesDuplicateSSHKeyMatches(t *testing.T) {
+func TestAmbiguousLaunchRecoveryConflictIsScopedToRecoveryClaim(t *testing.T) {
 	api := &fakeLambdaAPI{launchErr: errors.New("transport closed")}
 	b := newTestBackend(t, api)
 	_, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "ambiguous-duplicate"})
@@ -650,7 +650,27 @@ func TestAmbiguousLaunchRecoveryRefusesDuplicateSSHKeyMatches(t *testing.T) {
 		Instance{ID: "i-duplicate-1", Name: "duplicate-1", Status: "active", IP: "203.0.113.54", Type: defaultType, SSHKeyNames: []string{keyName}},
 		Instance{ID: "i-duplicate-2", Name: "duplicate-2", Status: "active", IP: "203.0.113.55", Type: defaultType, SSHKeyNames: []string{keyName}},
 	)
-	if _, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "ambiguous-duplicate", ReleaseOnly: true}); err == nil || !strings.Contains(err.Error(), "matches 2 instances") {
+	unrelatedLeaseID := "cbx_abcdef123457"
+	old := time.Now().Add(-48 * time.Hour)
+	unrelatedLabels := leaseTags(b.cfg, unrelatedLeaseID, "unrelated", "ready", false, old)
+	unrelatedLabels["expires_at"] = core.LeaseLabelTime(old.Add(time.Minute))
+	unrelated := Instance{ID: "i-unrelated", Name: "unrelated", Status: "active", IP: "203.0.113.56", Type: defaultType, Tags: unrelatedLabels}
+	api.instances = append(api.instances, unrelated)
+	unrelatedServer := core.Server{Provider: providerName, CloudID: unrelated.ID, Name: unrelated.Name, Labels: unrelatedLabels}
+	if err := core.ClaimLeaseTargetForRepoConfig(unrelatedLeaseID, "unrelated", b.cfg, unrelatedServer, core.SSHTarget{}, t.TempDir(), 0, false); err != nil {
+		t.Fatal(err)
+	}
+	views, err := b.List(context.Background(), core.ListRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(views) != 1 || views[0].CloudID != unrelated.ID {
+		t.Fatalf("views=%#v", views)
+	}
+	if target, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "unrelated", ReleaseOnly: true}); err != nil || target.Server.CloudID != unrelated.ID {
+		t.Fatalf("target=%#v err=%v", target, err)
+	}
+	if _, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "i-duplicate-1", ReleaseOnly: true}); err == nil || !strings.Contains(err.Error(), "matches 2 instances") {
 		t.Fatalf("resolve err=%v", err)
 	}
 	server := core.Server{Provider: providerName, CloudID: "i-duplicate-1", Name: claim.Slug, Labels: claim.Labels}
@@ -663,6 +683,15 @@ func TestAmbiguousLaunchRecoveryRefusesDuplicateSSHKeyMatches(t *testing.T) {
 	}
 	if _, ok, err := core.ResolveLeaseClaimForProvider("ambiguous-duplicate", providerName); err != nil || !ok {
 		t.Fatalf("claim ok=%v err=%v", ok, err)
+	}
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if len(api.terminatedIDs) != 1 || len(api.terminatedIDs[0]) != 1 || api.terminatedIDs[0][0] != unrelated.ID {
+		t.Fatalf("terminated=%v", api.terminatedIDs)
+	}
+	if _, ok, err := core.ResolveLeaseClaimForProvider("ambiguous-duplicate", providerName); err != nil || !ok {
+		t.Fatalf("recovery claim ok=%v err=%v", ok, err)
 	}
 }
 

--- a/internal/providers/lambda/backend_test.go
+++ b/internal/providers/lambda/backend_test.go
@@ -143,22 +143,26 @@ func newTestBackend(t *testing.T, api *fakeLambdaAPI) *backend {
 	return b
 }
 
-func TestListShowsOnlyCompleteOwnedLambdaInstances(t *testing.T) {
-	cfg := core.BaseConfig()
-	cfg.Provider = providerName
-	cfg.TargetOS = core.TargetLinux
-	cfg.ServerType = defaultType
-	owned := Instance{ID: "i-owned", Name: "owned", Status: "active", IP: "203.0.113.10", Type: defaultType, Tags: leaseTags(cfg, "cbx_abcdef123456", "owned", "ready", false, time.Now())}
-	api := &fakeLambdaAPI{instances: []Instance{
-		owned,
+func TestListShowsOnlyClaimedLambdaInstances(t *testing.T) {
+	api := &fakeLambdaAPI{}
+	b := newTestBackend(t, api)
+	claimedLabels := leaseTags(b.cfg, "cbx_abcdef123456", "claimed", "ready", false, time.Now())
+	providerOnlyLabels := leaseTags(b.cfg, "cbx_abcdef123457", "provider-only", "ready", false, time.Now())
+	api.instances = []Instance{
+		{ID: "i-claimed", Name: "claimed", Status: "active", IP: "203.0.113.10", Type: defaultType, Tags: claimedLabels},
+		{ID: "i-provider-only", Name: "provider-only", Status: "active", IP: "203.0.113.11", Type: defaultType, Tags: providerOnlyLabels},
 		{ID: "i-foreign", Name: "foreign", Tags: map[string]string{"crabbox": "true", "provider": "other"}},
 		{ID: "i-partial", Name: "partial", Tags: map[string]string{"crabbox": "true", "provider": providerName}},
-	}}
-	views, err := newTestBackend(t, api).List(context.Background(), core.ListRequest{})
+	}
+	server := core.Server{Provider: providerName, CloudID: "i-claimed", Name: "claimed", Labels: claimedLabels}
+	if err := core.ClaimLeaseTargetForRepoConfig("cbx_abcdef123456", "claimed", b.cfg, server, core.SSHTarget{}, t.TempDir(), 0, false); err != nil {
+		t.Fatal(err)
+	}
+	views, err := b.List(context.Background(), core.ListRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(views) != 1 || views[0].CloudID != "i-owned" || views[0].Status != "ready" {
+	if len(views) != 1 || views[0].CloudID != "i-claimed" || views[0].Status != "ready" {
 		t.Fatalf("views=%#v", views)
 	}
 }
@@ -501,7 +505,12 @@ func TestCleanupDryRunDoesNotMutate(t *testing.T) {
 	labels["last_touched_at"] = core.LeaseLabelTime(old)
 	labels["expires_at"] = core.LeaseLabelTime(old.Add(time.Minute))
 	api := &fakeLambdaAPI{instances: []Instance{{ID: "i-old", Name: "old", Status: "active", IP: "203.0.113.50", Type: defaultType, Tags: labels}}}
-	if err := newTestBackend(t, api).Cleanup(context.Background(), core.CleanupRequest{DryRun: true}); err != nil {
+	b := newTestBackend(t, api)
+	server := core.Server{Provider: providerName, CloudID: "i-old", Name: "old", Labels: labels}
+	if err := core.ClaimLeaseTargetForRepoConfig("cbx_abcdef123456", "old", b.cfg, server, core.SSHTarget{}, t.TempDir(), 0, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{DryRun: true}); err != nil {
 		t.Fatal(err)
 	}
 	if len(api.terminatedIDs) != 0 || len(api.deletedKeyIDs) != 0 {
@@ -509,7 +518,7 @@ func TestCleanupDryRunDoesNotMutate(t *testing.T) {
 	}
 }
 
-func TestCleanupDeletesProviderOnlyExpiredLambdaInstance(t *testing.T) {
+func TestCleanupSkipsProviderOnlyExpiredLambdaInstance(t *testing.T) {
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
 	cfg.TargetOS = core.TargetLinux
@@ -520,8 +529,140 @@ func TestCleanupDeletesProviderOnlyExpiredLambdaInstance(t *testing.T) {
 	if err := newTestBackend(t, api).Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
-	if len(api.terminatedIDs) != 1 || len(api.terminatedIDs[0]) != 1 || api.terminatedIDs[0][0] != "i-old" {
-		t.Fatalf("terminated=%v", api.terminatedIDs)
+	if len(api.terminatedIDs) != 0 || len(api.deletedKeyIDs) != 0 {
+		t.Fatalf("provider-only resource mutated: terminated=%v keys=%v", api.terminatedIDs, api.deletedKeyIDs)
+	}
+}
+
+func TestReleaseRefusesProviderOnlyLambdaInstance(t *testing.T) {
+	b := newTestBackend(t, &fakeLambdaAPI{})
+	labels := lambdaProviderLaunchTags(leaseTags(b.cfg, "cbx_abcdef123456", "provider-only", "ready", false, time.Now()), lambdaSSHKeyIdentity{ID: "key-provider-only", Name: "crabbox-cbx-provider-only", Created: true})
+	api := &fakeLambdaAPI{instances: []Instance{{ID: "i-provider-only", Name: "provider-only", Status: "active", IP: "203.0.113.50", Type: defaultType, Tags: labels}}}
+	b.clientFactory = func(core.Runtime) (lambdaAPI, error) { return api, nil }
+	if _, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "i-provider-only", ReleaseOnly: true}); err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("resolve err=%v", err)
+	}
+	server := core.Server{Provider: providerName, CloudID: "i-provider-only", Name: "provider-only", Labels: labels}
+	err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: labels["lease"], Server: server}})
+	if err == nil || !strings.Contains(err.Error(), "no exact local claim") {
+		t.Fatalf("err=%v", err)
+	}
+	if len(api.terminatedIDs) != 0 || len(api.deletedKeyIDs) != 0 {
+		t.Fatalf("provider-only resource mutated: terminated=%v keys=%v", api.terminatedIDs, api.deletedKeyIDs)
+	}
+}
+
+func TestReleaseRefusesAmbiguousLaunchWithoutClaimedSSHKey(t *testing.T) {
+	api := &fakeLambdaAPI{launchErr: errors.New("transport closed")}
+	b := newTestBackend(t, api)
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "ambiguous-unbound"})
+	if err == nil || !strings.Contains(err.Error(), "indeterminate") {
+		t.Fatalf("err=%v", err)
+	}
+	claim, ok, claimErr := core.ResolveLeaseClaimForProvider("ambiguous-unbound", providerName)
+	if claimErr != nil || !ok {
+		t.Fatalf("claim=%#v ok=%v err=%v", claim, ok, claimErr)
+	}
+	api.launchErr = nil
+	api.instances = append(api.instances, Instance{ID: "i-unbound", Name: "unbound", Status: "active", IP: "203.0.113.52", Type: defaultType, SSHKeyNames: []string{"different-key"}})
+	server := core.Server{Provider: providerName, CloudID: "i-unbound", Name: claim.Slug, Labels: claim.Labels}
+	err = b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: claim.LeaseID, Server: server}})
+	if err == nil || !strings.Contains(err.Error(), "matches 0 instances") {
+		t.Fatalf("err=%v", err)
+	}
+	if len(api.terminatedIDs) != 0 || len(api.deletedKeyIDs) != 0 {
+		t.Fatalf("unbound recovery mutated: terminated=%v keys=%v", api.terminatedIDs, api.deletedKeyIDs)
+	}
+	if _, ok, err := core.ResolveLeaseClaimForProvider("ambiguous-unbound", providerName); err != nil || !ok {
+		t.Fatalf("claim ok=%v err=%v", ok, err)
+	}
+}
+
+func TestReleaseRefusesRequestSSHKeyOverride(t *testing.T) {
+	api := &fakeLambdaAPI{}
+	b := newTestBackend(t, api)
+	leaseID := "cbx_abcdef123456"
+	labels := lambdaLabelsWithKey(leaseTags(b.cfg, leaseID, "claimed-key", "ready", false, time.Now()), lambdaSSHKeyIdentity{ID: "key-claimed", Name: providerKeyForLease(leaseID), Created: true})
+	api.instances = []Instance{{ID: "i-claimed-key", Name: "claimed-key", Status: "active", IP: "203.0.113.51", Type: defaultType, Tags: labels}}
+	server := core.Server{Provider: providerName, CloudID: "i-claimed-key", Name: "claimed-key", Labels: labels}
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "claimed-key", b.cfg, server, core.SSHTarget{}, t.TempDir(), 0, false); err != nil {
+		t.Fatal(err)
+	}
+	requestLabels := cloneLambdaLabels(labels)
+	requestLabels[lambdaKeyIDLabel] = "key-unclaimed"
+	server.Labels = requestLabels
+	err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: server}})
+	if err == nil || !strings.Contains(err.Error(), "stale local claim") {
+		t.Fatalf("err=%v", err)
+	}
+	if len(api.terminatedIDs) != 0 || len(api.deletedKeyIDs) != 0 {
+		t.Fatalf("mutated from request override: terminated=%v keys=%v", api.terminatedIDs, api.deletedKeyIDs)
+	}
+	if _, ok, err := core.ResolveLeaseClaimForProvider("claimed-key", providerName); err != nil || !ok {
+		t.Fatalf("claim ok=%v err=%v", ok, err)
+	}
+}
+
+func TestReleaseRefusesRefreshedClaimSnapshot(t *testing.T) {
+	api := &fakeLambdaAPI{}
+	b := newTestBackend(t, api)
+	leaseID := "cbx_abcdef123456"
+	old := time.Now().Add(-48 * time.Hour)
+	labels := lambdaLabelsWithKey(leaseTags(b.cfg, leaseID, "refreshed", "ready", false, old), lambdaSSHKeyIdentity{ID: "key-refreshed", Name: providerKeyForLease(leaseID), Created: true})
+	labels["expires_at"] = core.LeaseLabelTime(old.Add(time.Minute))
+	api.instances = []Instance{{ID: "i-refreshed", Name: "refreshed", Status: "active", IP: "203.0.113.53", Type: defaultType, Tags: labels}}
+	server := core.Server{Provider: providerName, CloudID: "i-refreshed", Name: "refreshed", Labels: labels}
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "refreshed", b.cfg, server, core.SSHTarget{}, t.TempDir(), 0, false); err != nil {
+		t.Fatal(err)
+	}
+	claim, ok, err := core.ResolveLeaseClaimForProvider("refreshed", providerName)
+	if err != nil || !ok {
+		t.Fatalf("claim=%#v ok=%v err=%v", claim, ok, err)
+	}
+	freshLabels := cloneLambdaLabels(labels)
+	freshLabels["last_touched_at"] = core.LeaseLabelTime(time.Now())
+	if _, err := core.UpdateLeaseClaimLabelsIfUnchanged(leaseID, claim, freshLabels); err != nil {
+		t.Fatal(err)
+	}
+	err = b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: server}})
+	if err == nil || !strings.Contains(err.Error(), "stale local claim") {
+		t.Fatalf("err=%v", err)
+	}
+	if len(api.terminatedIDs) != 0 || len(api.deletedKeyIDs) != 0 {
+		t.Fatalf("refreshed claim mutated: terminated=%v keys=%v", api.terminatedIDs, api.deletedKeyIDs)
+	}
+}
+
+func TestAmbiguousLaunchRecoveryRefusesDuplicateSSHKeyMatches(t *testing.T) {
+	api := &fakeLambdaAPI{launchErr: errors.New("transport closed")}
+	b := newTestBackend(t, api)
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "ambiguous-duplicate"})
+	if err == nil || !strings.Contains(err.Error(), "indeterminate") {
+		t.Fatalf("err=%v", err)
+	}
+	claim, ok, claimErr := core.ResolveLeaseClaimForProvider("ambiguous-duplicate", providerName)
+	if claimErr != nil || !ok {
+		t.Fatalf("claim=%#v ok=%v err=%v", claim, ok, claimErr)
+	}
+	api.launchErr = nil
+	keyName := claim.Labels[lambdaKeyNameLabel]
+	api.instances = append(api.instances,
+		Instance{ID: "i-duplicate-1", Name: "duplicate-1", Status: "active", IP: "203.0.113.54", Type: defaultType, SSHKeyNames: []string{keyName}},
+		Instance{ID: "i-duplicate-2", Name: "duplicate-2", Status: "active", IP: "203.0.113.55", Type: defaultType, SSHKeyNames: []string{keyName}},
+	)
+	if _, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "ambiguous-duplicate", ReleaseOnly: true}); err == nil || !strings.Contains(err.Error(), "matches 2 instances") {
+		t.Fatalf("resolve err=%v", err)
+	}
+	server := core.Server{Provider: providerName, CloudID: "i-duplicate-1", Name: claim.Slug, Labels: claim.Labels}
+	err = b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: claim.LeaseID, Server: server}})
+	if err == nil || !strings.Contains(err.Error(), "matches 2 instances") {
+		t.Fatalf("release err=%v", err)
+	}
+	if len(api.terminatedIDs) != 0 || len(api.deletedKeyIDs) != 0 {
+		t.Fatalf("duplicate recovery mutated: terminated=%v keys=%v", api.terminatedIDs, api.deletedKeyIDs)
+	}
+	if _, ok, err := core.ResolveLeaseClaimForProvider("ambiguous-duplicate", providerName); err != nil || !ok {
+		t.Fatalf("claim ok=%v err=%v", ok, err)
 	}
 }
 

--- a/internal/providers/lambda/tags.go
+++ b/internal/providers/lambda/tags.go
@@ -56,6 +56,8 @@ func applyTailscaleMetadata(labels map[string]string, meta core.TailscaleMetadat
 		delete(labels, "tailscale_ipv4")
 		delete(labels, "tailscale_fqdn")
 		delete(labels, "tailscale_error")
+		delete(labels, "tailscale_version")
+		delete(labels, "tailscale_device_id")
 		delete(labels, "tailscale_exit_node")
 		delete(labels, "tailscale_exit_node_allow_lan_access")
 		return
@@ -78,6 +80,12 @@ func applyTailscaleMetadata(labels map[string]string, meta core.TailscaleMetadat
 	}
 	if meta.Error != "" {
 		labels["tailscale_error"] = meta.Error
+	}
+	if meta.Version != "" {
+		labels["tailscale_version"] = meta.Version
+	}
+	if meta.DeviceID != "" {
+		labels["tailscale_device_id"] = meta.DeviceID
 	}
 	if meta.ExitNode != "" {
 		labels["tailscale_exit_node"] = meta.ExitNode

--- a/internal/providers/lambda/tags.go
+++ b/internal/providers/lambda/tags.go
@@ -24,10 +24,6 @@ func leaseTags(cfg core.Config, leaseID, slug, state string, keep bool, now time
 	return labels
 }
 
-func isOwnedInstance(item Instance) bool {
-	return validateLambdaLabels(item.Tags) == nil
-}
-
 func validateLambdaLabels(labels map[string]string) error {
 	if labels == nil ||
 		labels["crabbox"] != "true" ||


### PR DESCRIPTION
Fixes https://github.com/openclaw/crabbox/issues/927

## Summary

- require an exact local Lambda claim before inventory, raw-ID resolution, stop, or cleanup can act on an instance
- carry a cloned claim-generation snapshot through every lifecycle mutation and fail closed when ownership or cleanup eligibility changes
- bind ambiguous-create recovery to exactly one live instance carrying the recorded per-lease SSH key, then persist that instance binding before termination so partial cleanup is retryable
- remove tag-only compatibility behavior and document provider tags, names, and IDs as discovery hints only

## Verification

- `go vet ./...`
- `go test -race -p=1 ./...`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker`
- `npm run build --prefix worker`
- `node scripts/build-docs-site.mjs`
- AutoReview: clean after accepted ownership-transfer, lifecycle-generation, recovery-conflict, durable-binding, and Tailscale metadata findings

The first parallel full-race run hit the existing Apple helper readiness timing test once; the isolated test then passed three race-enabled reruns, and the serialized full race suite passed.

## Live proof gate

Authenticated Lambda create/use/destroy proof could not run because no launch-capable API credential is currently available. The owner explicitly waived this item-specific live gate on July 6, 2026; local lifecycle regression proof and exact-head hosted CI remain required before merge.
