### PR TITLE
fix: bind exe.dev deletion to exact claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 - Redacted colon-delimited and line-folded bearer credentials from CLI and coordinator diagnostics. Thanks @TurboTheTurtle.
 - Required coordinator AWS, Azure, and GCP release and provisioning-failure cleanup to re-read the stored cloud resource and verify exact provider, resource, lease, owner, and slug ownership before deletion; Azure now persists the exact subscription/resource-group scope for deferred retries and fails legacy unscoped cleanup closed for manual resolution. Thanks @coygeek.
 - Required Lambda inventory, stop, and cleanup to use an unchanged instance-bound local claim, with claim-bound SSH-key deletion and durable unique-instance recovery for ambiguous creates. Thanks @coygeek.
-- Required exe.dev reuse and deletion to match a canonical remote ownership tag set, deterministic VM name, unchanged exact local claim, authenticated account fingerprint, and current control route, retaining the claim after failed deletion. Thanks @coygeek.
+- Required exe.dev reuse and deletion to match a canonical remote ownership tag set, random resource generation, deterministic VM name, unchanged exact local claim, authenticated account fingerprint, and current control route, retaining the claim after failed deletion. Thanks @coygeek.
 
 ## 0.36.0 - 2026-07-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Redacted colon-delimited and line-folded bearer credentials from CLI and coordinator diagnostics. Thanks @TurboTheTurtle.
 - Required coordinator AWS, Azure, and GCP release and provisioning-failure cleanup to re-read the stored cloud resource and verify exact provider, resource, lease, owner, and slug ownership before deletion; Azure now persists the exact subscription/resource-group scope for deferred retries and fails legacy unscoped cleanup closed for manual resolution. Thanks @coygeek.
 - Required Lambda inventory, stop, and cleanup to use an unchanged instance-bound local claim, with claim-bound SSH-key deletion and durable unique-instance recovery for ambiguous creates. Thanks @coygeek.
+- Required exe.dev reuse and deletion to match a canonical remote ownership tag set, deterministic VM name, unchanged exact local claim, and current control route, retaining the claim after failed deletion. Thanks @coygeek.
 
 ## 0.36.0 - 2026-07-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 - Redacted colon-delimited and line-folded bearer credentials from CLI and coordinator diagnostics. Thanks @TurboTheTurtle.
 - Required coordinator AWS, Azure, and GCP release and provisioning-failure cleanup to re-read the stored cloud resource and verify exact provider, resource, lease, owner, and slug ownership before deletion; Azure now persists the exact subscription/resource-group scope for deferred retries and fails legacy unscoped cleanup closed for manual resolution. Thanks @coygeek.
 - Required Lambda inventory, stop, and cleanup to use an unchanged instance-bound local claim, with claim-bound SSH-key deletion and durable unique-instance recovery for ambiguous creates. Thanks @coygeek.
-- Required exe.dev reuse and deletion to match a canonical remote ownership tag set, deterministic VM name, unchanged exact local claim, and current control route, retaining the claim after failed deletion. Thanks @coygeek.
+- Required exe.dev reuse and deletion to match a canonical remote ownership tag set, deterministic VM name, unchanged exact local claim, authenticated account fingerprint, and current control route, retaining the claim after failed deletion. Thanks @coygeek.
 
 ## 0.36.0 - 2026-07-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 - Redacted colon-delimited and line-folded bearer credentials from CLI and coordinator diagnostics. Thanks @TurboTheTurtle.
 - Required coordinator AWS, Azure, and GCP release and provisioning-failure cleanup to re-read the stored cloud resource and verify exact provider, resource, lease, owner, and slug ownership before deletion; Azure now persists the exact subscription/resource-group scope for deferred retries and fails legacy unscoped cleanup closed for manual resolution. Thanks @coygeek.
 - Required Lambda inventory, stop, and cleanup to use an unchanged instance-bound local claim, with claim-bound SSH-key deletion and durable unique-instance recovery for ambiguous creates. Thanks @coygeek.
-- Required exe.dev reuse and deletion to match a canonical remote ownership tag set, random resource generation, deterministic VM name, unchanged exact local claim, authenticated account fingerprint, and current control route, retaining the claim after failed deletion. Thanks @coygeek.
+- Required exe.dev reuse and deletion to match canonical ownership tags, random resource generation, deterministic VM name, unchanged SSH endpoint and exact local claim, authenticated account fingerprint, and current control route; lifecycle lookups now remain account-local and failed deletion retains the claim. Thanks @coygeek.
 
 ## 0.36.0 - 2026-07-05
 

--- a/docs/commands/stop.md
+++ b/docs/commands/stop.md
@@ -41,8 +41,11 @@ Crabbox lease ID and local slug:
 - `morph` — pauses the instance by default and retains its local claim and SSH
   key for reuse. Set `morph.deleteOnRelease` (or pass
   `--morph-delete-on-release`) to delete the instance and key instead.
-- `exe-dev` — accepts a Crabbox lease ID, local slug, or exe.dev VM name and
-  deletes the VM through `ssh exe.dev rm`.
+- `exe-dev` — accepts a Crabbox lease ID, local slug, or exe.dev VM name only
+  when an unchanged local claim binds the exact deterministic VM name,
+  complete remote ownership tags, and current control route. Claimless tagged
+  VMs require explicit `--reclaim` through a normal reuse command before stop;
+  untagged VMs remain read-only inventory. Failed deletion keeps the claim.
 - `semaphore` — stops the Semaphore CI job and removes the local claim.
 - `sprites` — deletes the Sprites sprite and removes the local claim.
 - `daytona` — deletes the Daytona sandbox.

--- a/docs/commands/stop.md
+++ b/docs/commands/stop.md
@@ -43,9 +43,10 @@ Crabbox lease ID and local slug:
   `--morph-delete-on-release`) to delete the instance and key instead.
 - `exe-dev` — accepts a Crabbox lease ID, local slug, or exe.dev VM name only
   when an unchanged local claim binds the exact deterministic VM name,
-  complete remote ownership tags, and current control route. Claimless tagged
-  VMs require explicit `--reclaim` through a normal reuse command before stop;
-  untagged VMs remain read-only inventory. Failed deletion keeps the claim.
+  complete remote ownership tags, and current control route. Claimless or
+  legacy unscoped tagged VMs require explicit `--reclaim` through a normal
+  reuse command before stop; untagged VMs remain read-only inventory. Failed
+  deletion keeps the claim.
 - `semaphore` — stops the Semaphore CI job and removes the local claim.
 - `sprites` — deletes the Sprites sprite and removes the local claim.
 - `daytona` — deletes the Daytona sandbox.

--- a/docs/providers/exe-dev.md
+++ b/docs/providers/exe-dev.md
@@ -95,11 +95,20 @@ top-level `workRoot` propagates to the VM when `exeDev.workRoot` is unset.
    `--no-email`, `--image`, `--cpu`, `--memory`, `--disk`, and `--command` as
    configured.
 2. Crabbox waits for SSH readiness on the returned `ssh_dest`, then uses its
-   standard rsync + remote command execution.
-3. `list --provider exe-dev` calls `ls --l --json` and shows the Crabbox-tagged
-   VMs.
-4. `stop --provider exe-dev <id>` calls `rm <vm-name> --json` and removes the
-   local claim.
+   standard rsync + remote command execution and persists the exact VM name,
+   SSH endpoint, ownership tags, and exe.dev control route in the local claim.
+3. `list --provider exe-dev` calls `ls --l --json` and shows only VMs with the
+   complete `crabbox`, canonical lease, and slug tag set. Pass `--all` to inspect
+   unowned or incomplete inventory; names that merely start with `crabbox-` do
+   not establish ownership.
+4. Reusing a completely tagged VM without a local claim requires explicit
+   `--reclaim`. Crabbox refuses untagged adoption and never retargets a claim
+   already bound to another VM or control route.
+5. `stop --provider exe-dev <id>` deletes only when the unchanged local claim,
+   exact VM name, deterministic lease name, complete remote tags, and current
+   control route all agree. It rechecks inventory while holding the claim lock,
+   calls `rm <vm-name> --json`, and removes the claim only after deletion
+   succeeds. Failed or ambiguous deletion keeps the claim for an exact retry.
 
 ## Limits
 
@@ -116,9 +125,17 @@ top-level `workRoot` propagates to the VM when `exeDev.workRoot` is unset.
 
 ```sh
 ssh -o BatchMode=yes exe.dev whoami --json
-ssh -o BatchMode=yes exe.dev ls --json
+ssh -o BatchMode=yes exe.dev ls --l --json
 crabbox run --provider exe-dev --slug exe-smoke --no-sync -- uname -a
 crabbox stop --provider exe-dev exe-smoke
+```
+
+To adopt an existing fully tagged VM after inspecting it, run a normal reuse
+with explicit ownership intent before stopping it:
+
+```sh
+crabbox run --provider exe-dev --id <vm-or-lease> --reclaim --no-sync -- true
+crabbox stop --provider exe-dev <vm-or-lease>
 ```
 
 If VM creation returns an active-plan error, resolve billing at

--- a/docs/providers/exe-dev.md
+++ b/docs/providers/exe-dev.md
@@ -96,7 +96,8 @@ top-level `workRoot` propagates to the VM when `exeDev.workRoot` is unset.
    configured.
 2. Crabbox waits for SSH readiness on the returned `ssh_dest`, then uses its
    standard rsync + remote command execution and persists the exact VM name,
-   SSH endpoint, ownership tags, and exe.dev control route in the local claim.
+   SSH endpoint, ownership tags, exe.dev control route, and a non-secret hash
+   of the authenticated exe.dev account in the local claim.
 3. `list --provider exe-dev` calls `ls --l --json` and shows only VMs with the
    complete `crabbox`, canonical lease, and slug tag set. Pass `--all` to inspect
    unowned or incomplete inventory; names that merely start with `crabbox-` do
@@ -106,8 +107,8 @@ top-level `workRoot` propagates to the VM when `exeDev.workRoot` is unset.
    Crabbox refuses untagged adoption and never retargets a claim already bound
    to another VM or control route.
 5. `stop --provider exe-dev <id>` deletes only when the unchanged local claim,
-   exact VM name, deterministic lease name, complete remote tags, and current
-   control route all agree. It rechecks inventory while holding the claim lock,
+   exact VM name, deterministic lease name, complete remote tags, current
+   control route, and authenticated account fingerprint all agree. It rechecks inventory while holding the claim lock,
    calls `rm <vm-name> --json`, and removes the claim only after deletion
    succeeds. Failed or ambiguous deletion keeps the claim for an exact retry.
 

--- a/docs/providers/exe-dev.md
+++ b/docs/providers/exe-dev.md
@@ -101,9 +101,10 @@ top-level `workRoot` propagates to the VM when `exeDev.workRoot` is unset.
    complete `crabbox`, canonical lease, and slug tag set. Pass `--all` to inspect
    unowned or incomplete inventory; names that merely start with `crabbox-` do
    not establish ownership.
-4. Reusing a completely tagged VM without a local claim requires explicit
-   `--reclaim`. Crabbox refuses untagged adoption and never retargets a claim
-   already bound to another VM or control route.
+4. Reusing a completely tagged VM without a local claim, or upgrading a legacy
+   claim that lacks a control-route scope, requires explicit `--reclaim`.
+   Crabbox refuses untagged adoption and never retargets a claim already bound
+   to another VM or control route.
 5. `stop --provider exe-dev <id>` deletes only when the unchanged local claim,
    exact VM name, deterministic lease name, complete remote tags, and current
    control route all agree. It rechecks inventory while holding the claim lock,

--- a/docs/providers/exe-dev.md
+++ b/docs/providers/exe-dev.md
@@ -110,7 +110,9 @@ top-level `workRoot` propagates to the VM when `exeDev.workRoot` is unset.
    exact VM name, deterministic lease name, complete remote tags, current
    control route, and authenticated account fingerprint all agree. It rechecks inventory while holding the claim lock,
    calls `rm <vm-name> --json`, and removes the claim only after deletion
-   succeeds. Failed or ambiguous deletion keeps the claim for an exact retry.
+   succeeds. Failed or ambiguous deletion keeps the claim for an exact retry;
+   if a complete account-bound inventory later confirms the exact VM is absent,
+   the retry removes only the still-unchanged local claim.
 
 ## Limits
 

--- a/docs/providers/exe-dev.md
+++ b/docs/providers/exe-dev.md
@@ -91,7 +91,8 @@ top-level `workRoot` propagates to the VM when `exeDev.workRoot` is unset.
 
 1. `warmup` lists existing exe.dev VMs, allocates a Crabbox slug, then creates a
    VM with the control-host call `new --name <crabbox-name> --json`, adding the
-   tags `crabbox`, `crabbox-lease-<id>`, and `crabbox-slug-<slug>`, plus
+   tags `crabbox`, `crabbox-lease-<id>`, and `crabbox-slug-<slug>`, a random
+   `crabbox-claim-<generation>` resource-binding tag, plus
    `--no-email`, `--image`, `--cpu`, `--memory`, `--disk`, and `--command` as
    configured.
 2. Crabbox waits for SSH readiness on the returned `ssh_dest`, then uses its
@@ -103,12 +104,15 @@ top-level `workRoot` propagates to the VM when `exeDev.workRoot` is unset.
    unowned or incomplete inventory; names that merely start with `crabbox-` do
    not establish ownership.
 4. Reusing a completely tagged VM without a local claim, or upgrading a legacy
-   claim that lacks a control-route scope, requires explicit `--reclaim`.
+   claim that lacks a control-route scope or matching remote claim generation,
+   requires explicit `--reclaim`. Reclaim rotates the remote generation while
+   holding the unchanged local claim lock.
    Crabbox refuses untagged adoption and never retargets a claim already bound
    to another VM or control route.
 5. `stop --provider exe-dev <id>` deletes only when the unchanged local claim,
-   exact VM name, deterministic lease name, complete remote tags, current
-   control route, and authenticated account fingerprint all agree. It rechecks inventory while holding the claim lock,
+   exact VM name, deterministic lease name, complete remote tags, remote claim
+   generation, current control route, and authenticated account fingerprint all
+   agree. It rechecks inventory while holding the claim lock,
    calls `rm <vm-name> --json`, and removes the claim only after deletion
    succeeds. Failed or ambiguous deletion keeps the claim for an exact retry;
    if a complete account-bound inventory later confirms the exact VM is absent,

--- a/internal/cli/coordinator_registration.go
+++ b/internal/cli/coordinator_registration.go
@@ -52,6 +52,8 @@ func (a App) claimLeaseTargetForRepoAndRegisterMode(
 	var err error
 	if resolved {
 		expected, expectedExists, err = resolvedLeaseClaimSnapshot(leaseID, server)
+	} else if server.claimSnapshotSet {
+		expected, expectedExists, err = resolvedLeaseClaimSnapshot(leaseID, server)
 	} else {
 		expected, expectedExists, err = readLeaseClaimWithPresence(leaseID)
 	}

--- a/internal/cli/coordinator_registration_test.go
+++ b/internal/cli/coordinator_registration_test.go
@@ -174,6 +174,47 @@ func TestResolveSSHLeaseTargetRejectsUnattestedClaimChange(t *testing.T) {
 	}
 }
 
+func TestClaimAcquiredLeaseRejectsChangeAfterProviderSnapshot(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CRABBOX_COORDINATOR", "")
+	cfg := baseConfig()
+	cfg.Provider = "aws"
+	leaseID := "cbx_acquiresnapshot1"
+	server := Server{
+		CloudID:  "i-acquired",
+		Provider: "aws",
+		Labels:   map[string]string{"provider": "aws", "lease": leaseID, "slug": "acquired", "state": "ready"},
+	}
+	target := SSHTarget{Host: "192.0.2.60", Port: "22"}
+	if err := claimLeaseTargetForRepoConfig(leaseID, "acquired", cfg, server, target, "/repo", time.Hour, false); err != nil {
+		t.Fatal(err)
+	}
+	acquired, err := readLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server.claimSnapshot = acquired
+	server.claimSnapshotExists = true
+	server.claimSnapshotSet = true
+	changedLabels := cloneStringMap(acquired.Labels)
+	changedLabels["state"] = "reclaimed"
+	if _, err := updateLeaseClaimLabelsIfUnchanged(leaseID, acquired, changedLabels); err != nil {
+		t.Fatal(err)
+	}
+
+	err = (App{}).claimLeaseTargetForRepoAndRegister(context.Background(), leaseID, "acquired", cfg, server, target, "/repo", true)
+	if err == nil || !strings.Contains(err.Error(), "claim changed") {
+		t.Fatalf("err=%v, want acquisition-snapshot conflict", err)
+	}
+	current, err := readLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current.Labels["state"] != "reclaimed" {
+		t.Fatalf("claim state=%q, want concurrent change preserved", current.Labels["state"])
+	}
+}
+
 func TestResolveSSHLeaseTargetAcceptsMinimalProviderClaim(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	leaseID := "cbx_minimalclaim123"

--- a/internal/cli/egress.go
+++ b/internal/cli/egress.go
@@ -1094,11 +1094,15 @@ func (a App) cleanupMediatedEgressBestEffort(ctx context.Context, requestedID st
 			fmt.Fprintf(a.Stderr, "warning: egress host daemon cleanup failed for %s: %v\n", id, err)
 		}
 	}
+	a.cleanupMediatedEgressRemoteBestEffort(ctx, lease)
+}
+
+func (a App) cleanupMediatedEgressRemoteBestEffort(ctx context.Context, lease LeaseTarget) {
 	if !supportsRemoteEgressClientCleanup(lease.SSH) {
 		return
 	}
 	if err := runSSHQuiet(ctx, lease.SSH, remoteStopEgressClientCommand()); err != nil {
-		fmt.Fprintf(a.Stderr, "warning: egress remote client cleanup failed for %s: %v\n", blank(lease.LeaseID, requestedID), err)
+		fmt.Fprintf(a.Stderr, "warning: egress remote client cleanup failed for %s: %v\n", lease.LeaseID, err)
 	}
 }
 

--- a/internal/cli/prewarm.go
+++ b/internal/cli/prewarm.go
@@ -90,14 +90,18 @@ func (a App) prewarm(ctx context.Context, args []string) error {
 		return nil
 	}
 	var out bytes.Buffer
+	var acquiredLease LeaseTarget
 	warmupStarted := time.Now()
 	warmupApp := App{Stdout: io.MultiWriter(a.Stdout, &out), Stderr: a.Stderr}
-	if err := warmupApp.warmup(ctx, leaseArgs); err != nil {
+	if err := warmupApp.warmupWithLeaseObserver(ctx, leaseArgs, func(lease LeaseTarget) { acquiredLease = lease }); err != nil {
 		return err
 	}
 	leaseID := parseWarmupLeaseID(out.String())
 	if leaseID == "" {
 		return exit(2, "prewarm could not parse warmup lease id")
+	}
+	if backend.Spec().Kind != ProviderKindDelegatedRun && acquiredLease.LeaseID != leaseID {
+		return exit(2, "prewarm warmup lease identity was not preserved")
 	}
 	warmupMs := time.Since(warmupStarted).Milliseconds()
 	hydration := "skipped"
@@ -109,7 +113,7 @@ func (a App) prewarm(ctx context.Context, args []string) error {
 		hydration = "actions"
 		hydrateStarted := time.Now()
 		hydrateArgs = prewarmHydrateArgs(cfg, leaseID, *githubRunner, *waitTimeout, *keepAliveMinutes, followupArgs)
-		if err := a.runPrewarmPostWarmupStep(ctx, backend, cfg, leaseID, "actions hydration", func() error {
+		if err := a.runPrewarmPostWarmupStep(ctx, backend, cfg, acquiredLease, "actions hydration", func() error {
 			return a.actionsHydrate(ctx, hydrateArgs)
 		}); err != nil {
 			return err
@@ -121,7 +125,7 @@ func (a App) prewarm(ctx context.Context, args []string) error {
 	probeMs := int64(0)
 	if strings.TrimSpace(*probeCommand) != "" {
 		probeStarted := time.Now()
-		if err := a.runPrewarmPostWarmupStep(ctx, backend, cfg, leaseID, "probe", func() error {
+		if err := a.runPrewarmPostWarmupStep(ctx, backend, cfg, acquiredLease, "probe", func() error {
 			return a.runCommand(ctx, prewarmProbeArgs(cfg, leaseID, *probeCommand, followupArgs))
 		}); err != nil {
 			return err
@@ -129,7 +133,7 @@ func (a App) prewarm(ctx context.Context, args []string) error {
 		probeMs = time.Since(probeStarted).Milliseconds()
 	}
 	if readyPoolKey != "" {
-		if err := a.runPrewarmPostWarmupStep(ctx, backend, cfg, leaseID, "pool registration", func() error {
+		if err := a.runPrewarmPostWarmupStep(ctx, backend, cfg, acquiredLease, "pool registration", func() error {
 			return a.registerPrewarmedLeaseInReadyPool(ctx, cfg, leaseID, readyPoolKey, *githubRunner)
 		}); err != nil {
 			return err
@@ -244,18 +248,30 @@ func (a App) registerPrewarmedLeaseInReadyPool(ctx context.Context, cfg Config, 
 	return nil
 }
 
-func (a App) runPrewarmPostWarmupStep(ctx context.Context, backend Backend, cfg Config, leaseID, stage string, step func() error) error {
+func (a App) runPrewarmPostWarmupStep(ctx context.Context, backend Backend, cfg Config, lease LeaseTarget, stage string, step func() error) error {
 	err := step()
 	if err == nil {
 		return nil
 	}
-	a.releasePrewarmLeaseAfterFailure(ctx, backend, cfg, leaseID, stage)
+	a.releasePrewarmLeaseAfterFailure(ctx, backend, cfg, lease, stage)
 	return err
 }
 
-func (a App) releasePrewarmLeaseAfterFailure(ctx context.Context, backend Backend, cfg Config, leaseID, stage string) {
+func (a App) releasePrewarmLeaseAfterFailure(ctx context.Context, backend Backend, cfg Config, acquired LeaseTarget, stage string) {
 	sshBackend, ok := backend.(SSHLeaseBackend)
 	if !ok {
+		return
+	}
+	leaseID := acquired.LeaseID
+	if _, guarded := backend.(ReleaseLeaseTargetRefresher); guarded {
+		releaseCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), prewarmFailureCleanupTimeout)
+		defer cancel()
+		fmt.Fprintf(a.Stderr, "prewarm cleanup: releasing id=%s after %s failure\n", leaseID, stage)
+		if err := a.releaseBackendLeaseBestEffort(releaseCtx, sshBackend, cfg, acquired); err != nil {
+			fmt.Fprintf(a.Stderr, "warning: prewarm %s failed; automatic release of %s failed: %v; next: crabbox stop --provider %s --id %s\n", stage, leaseID, err, cfg.Provider, leaseID)
+			return
+		}
+		fmt.Fprintf(a.Stderr, "prewarm cleanup: released id=%s after %s failure\n", leaseID, stage)
 		return
 	}
 	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), prewarmFailureCleanupTimeout)
@@ -376,7 +392,6 @@ func prewarmProviderPassthroughFlags(defaults Config) map[string]bool {
 	fs := flag.NewFlagSet("prewarm-followup", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	_ = registerProviderFlags(fs, defaults)
-	fs.Bool("reclaim", false, "claim this lease for the current repo")
 	flags := map[string]bool{}
 	fs.VisitAll(func(f *flag.Flag) {
 		takesValue := true

--- a/internal/cli/prewarm_test.go
+++ b/internal/cli/prewarm_test.go
@@ -73,7 +73,7 @@ func TestPrewarmPostWarmupFailuresReleaseSSHLease(t *testing.T) {
 			var stderr bytes.Buffer
 			app := App{Stdout: io.Discard, Stderr: &stderr}
 
-			err := app.runPrewarmPostWarmupStep(ctx, backend, Config{Provider: "prewarm-cleanup-test"}, "cbx_abcdef123456", stage, func() error {
+			err := app.runPrewarmPostWarmupStep(ctx, backend, Config{Provider: "prewarm-cleanup-test"}, LeaseTarget{LeaseID: "cbx_abcdef123456"}, stage, func() error {
 				return cause
 			})
 
@@ -104,10 +104,29 @@ func TestPrewarmPostWarmupFailuresReleaseSSHLease(t *testing.T) {
 func TestPrewarmSuccessfulStepDoesNotReleaseLease(t *testing.T) {
 	backend := &prewarmCleanupTestBackend{}
 	err := (App{Stdout: io.Discard, Stderr: io.Discard}).runPrewarmPostWarmupStep(
-		context.Background(), backend, Config{Provider: "prewarm-cleanup-test"}, "cbx_abcdef123456", "probe", func() error { return nil },
+		context.Background(), backend, Config{Provider: "prewarm-cleanup-test"}, LeaseTarget{LeaseID: "cbx_abcdef123456"}, "probe", func() error { return nil },
 	)
 	if err != nil || backend.resolveCalls != 0 || backend.releaseCalls != 0 {
 		t.Fatalf("successful step err=%v resolve=%d release=%d", err, backend.resolveCalls, backend.releaseCalls)
+	}
+}
+
+func TestPrewarmGuardedCleanupUsesAcquiredLeaseFence(t *testing.T) {
+	base := &warmupFailureReleaseBackend{}
+	backend := &ownershipChangedReleaseBackend{warmupFailureReleaseBackend: base}
+	cause := errors.New("probe failed")
+	var stderr bytes.Buffer
+	err := (App{Stdout: io.Discard, Stderr: &stderr}).runPrewarmPostWarmupStep(
+		context.Background(), backend, Config{Provider: "exe-dev"}, LeaseTarget{LeaseID: "cbx_abcdef123456"}, "probe", func() error { return cause },
+	)
+	if !errors.Is(err, cause) {
+		t.Fatalf("step error=%v, want %v", err, cause)
+	}
+	if base.resolves != 0 || base.releases != 0 {
+		t.Fatalf("guarded cleanup resolves=%d releases=%d, want ownership-fenced stop", base.resolves, base.releases)
+	}
+	if !strings.Contains(stderr.String(), "release lease ownership changed") {
+		t.Fatalf("stderr missing ownership fence:\n%s", stderr.String())
 	}
 }
 
@@ -124,7 +143,7 @@ func TestPrewarmCleanupFailurePrintsStopCommand(t *testing.T) {
 			var stderr bytes.Buffer
 			cause := errors.New("hydrate failed")
 			err := (App{Stdout: io.Discard, Stderr: &stderr}).runPrewarmPostWarmupStep(
-				context.Background(), tc.backend, Config{Provider: "prewarm-cleanup-test"}, "cbx_abcdef123456", "actions hydration", func() error { return cause },
+				context.Background(), tc.backend, Config{Provider: "prewarm-cleanup-test"}, LeaseTarget{LeaseID: "cbx_abcdef123456"}, "actions hydration", func() error { return cause },
 			)
 			if !errors.Is(err, cause) {
 				t.Fatalf("step error=%v, want %v", err, cause)
@@ -142,7 +161,7 @@ func TestPrewarmFailureDoesNotReleaseDelegatedProvider(t *testing.T) {
 	cause := errors.New("delegated step failed")
 	var stderr bytes.Buffer
 	err := (App{Stdout: io.Discard, Stderr: &stderr}).runPrewarmPostWarmupStep(
-		context.Background(), prewarmDelegatedTestBackend{}, Config{Provider: "prewarm-delegated-test"}, "run_abcdef123456", "probe", func() error { return cause },
+		context.Background(), prewarmDelegatedTestBackend{}, Config{Provider: "prewarm-delegated-test"}, LeaseTarget{LeaseID: "run_abcdef123456"}, "probe", func() error { return cause },
 	)
 	if !errors.Is(err, cause) {
 		t.Fatalf("step error=%v, want %v", err, cause)
@@ -181,7 +200,7 @@ func TestPrewarmCoordinatorCleanupReleasesByIDWhenResolveFails(t *testing.T) {
 	var stderr bytes.Buffer
 	cause := errors.New("probe failed")
 	err = (App{Stdout: io.Discard, Stderr: &stderr}).runPrewarmPostWarmupStep(
-		context.Background(), backend, cfg, "cbx_abcdef123456", "probe", func() error { return cause },
+		context.Background(), backend, cfg, LeaseTarget{LeaseID: "cbx_abcdef123456"}, "probe", func() error { return cause },
 	)
 	if !errors.Is(err, cause) {
 		t.Fatalf("step error=%v, want %v", err, cause)
@@ -307,6 +326,17 @@ func TestPrewarmDryRunKeepsLocalContainerVolumeOnWarmupOnly(t *testing.T) {
 	}
 	if strings.Contains(lines[1], "--local-container-volume") || !strings.Contains(lines[1], "--id '<lease>'") {
 		t.Fatalf("probe plan should reuse the mounted lease without forwarding the creation-only flag:\n%s", stdout.String())
+	}
+}
+
+func TestPrewarmFollowupDoesNotForwardReclaim(t *testing.T) {
+	args := prewarmProviderPassthroughArgs([]string{"--provider", "exe-dev", "--reclaim", "--exe-dev-control-host", "user@exe.dev"}, defaultConfig())
+	joined := strings.Join(args, " ")
+	if strings.Contains(joined, "--reclaim") {
+		t.Fatalf("follow-up args forwarded ownership transfer: %v", args)
+	}
+	if !strings.Contains(joined, "--exe-dev-control-host user@exe.dev") {
+		t.Fatalf("follow-up args lost provider routing: %v", args)
 	}
 }
 

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -194,6 +194,12 @@ type ReleaseLeaseReporter interface {
 	ReleaseLeaseMessage(lease LeaseTarget) string
 }
 
+// ReleaseLeaseTargetRefresher opts a provider into refreshing authorization
+// and connection metadata immediately before automatic lease cleanup.
+type ReleaseLeaseTargetRefresher interface {
+	RefreshReleaseLeaseTarget(context.Context, LeaseTarget) (LeaseTarget, error)
+}
+
 type CheckpointForkWorkdirValidator interface {
 	ValidateCheckpointForkWorkdir(ctx context.Context, lease LeaseTarget, workdir string) error
 }

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -198,7 +198,12 @@ type ReleaseLeaseReporter interface {
 // and connection metadata immediately before automatic lease cleanup.
 type ReleaseLeaseTargetRefresher interface {
 	RefreshReleaseLeaseTarget(context.Context, LeaseTarget) (LeaseTarget, error)
+	// ReleaseLeaseConnectionCleanupSafe reports whether generic remote cleanup
+	// may run between the refresh and the provider's guarded release.
+	ReleaseLeaseConnectionCleanupSafe() bool
 }
+
+var ErrReleaseLeaseOwnershipChanged = errors.New("release lease ownership changed")
 
 type CheckpointForkWorkdirValidator interface {
 	ValidateCheckpointForkWorkdir(ctx context.Context, lease LeaseTarget, workdir string) error

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -669,6 +669,9 @@ type ReleaseLeaseRequest struct {
 	Lease                    LeaseTarget
 	Force                    bool
 	ExpectedProviderIdentity ProviderIdentityExpectation
+	// GuardedRemoteCleanup lets providers that fence release authorization run
+	// generic remote teardown only after ownership is verified under that fence.
+	GuardedRemoteCleanup func(context.Context, LeaseTarget)
 }
 
 // ConfirmedAbsentLocalCleanupRequest carries the immutable provider identity

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -194,13 +194,19 @@ type ReleaseLeaseReporter interface {
 	ReleaseLeaseMessage(lease LeaseTarget) string
 }
 
+// ReleaseLeaseConnectionCleanupPolicy lets a provider defer generic connection
+// cleanup until after its guarded release succeeds.
+type ReleaseLeaseConnectionCleanupPolicy interface {
+	// ReleaseLeaseConnectionCleanupSafe reports whether generic remote cleanup
+	// may run before the provider's guarded release.
+	ReleaseLeaseConnectionCleanupSafe() bool
+}
+
 // ReleaseLeaseTargetRefresher opts a provider into refreshing authorization
 // and connection metadata immediately before automatic lease cleanup.
 type ReleaseLeaseTargetRefresher interface {
+	ReleaseLeaseConnectionCleanupPolicy
 	RefreshReleaseLeaseTarget(context.Context, LeaseTarget) (LeaseTarget, error)
-	// ReleaseLeaseConnectionCleanupSafe reports whether generic remote cleanup
-	// may run between the refresh and the provider's guarded release.
-	ReleaseLeaseConnectionCleanupSafe() bool
 }
 
 var ErrReleaseLeaseOwnershipChanged = errors.New("release lease ownership changed")

--- a/internal/cli/provider_exports.go
+++ b/internal/cli/provider_exports.go
@@ -138,6 +138,12 @@ func ClaimLeaseTargetForRepoConfigIfUnchanged(leaseID, slug string, cfg Config, 
 	return claimLeaseTargetForRepoConfigIfUnchanged(leaseID, slug, cfg, server, target, repoRoot, idleTimeout, reclaim, expected, expectedExists)
 }
 
+// ClaimLeaseTargetForRepoConfigScopeIfUnchanged lets a provider bind a
+// repository-scoped claim to routing identity outside the shared Config model.
+func ClaimLeaseTargetForRepoConfigScopeIfUnchanged(leaseID, slug string, cfg Config, providerScope string, server Server, target SSHTarget, repoRoot string, idleTimeout time.Duration, reclaim bool, expected LeaseClaim, expectedExists bool) (LeaseClaim, error) {
+	return claimLeaseTargetForRepoConfigScopeIfUnchanged(leaseID, slug, cfg, providerScope, server, target, repoRoot, idleTimeout, reclaim, expected, expectedExists)
+}
+
 // ClaimLeaseTargetForRepoConfigScopeReplacingEndpointIfUnchanged binds an
 // exact resource while atomically replacing any previously published route.
 func ClaimLeaseTargetForRepoConfigScopeReplacingEndpointIfUnchanged(leaseID, slug string, cfg Config, providerScope string, server Server, target SSHTarget, repoRoot string, idleTimeout time.Duration, reclaim bool, expected LeaseClaim, expectedExists bool) (LeaseClaim, error) {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -2755,6 +2755,20 @@ func (result leaseCleanupResult) apply(report *timingReport) {
 }
 
 func (a App) releaseBackendLeaseBestEffort(ctx context.Context, backend SSHLeaseBackend, cfg Config, lease LeaseTarget) error {
+	if refresher, ok := backend.(ReleaseLeaseTargetRefresher); ok {
+		refreshed, err := refresher.RefreshReleaseLeaseTarget(ctx, lease)
+		if err != nil {
+			fmt.Fprintf(a.Stderr, "warning: could not refresh lease %s before cleanup: %v; attempting release with acquired target\n", lease.LeaseID, err)
+		} else {
+			if refreshed.SSH.Host == "" {
+				refreshed.SSH = lease.SSH
+			}
+			if refreshed.Coordinator == nil {
+				refreshed.Coordinator = lease.Coordinator
+			}
+			lease = refreshed
+		}
+	}
 	a.cleanupBackendLeaseConnectionsBestEffort(ctx, lease)
 	return a.releaseBackendLease(ctx, backend, cfg, lease)
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -41,6 +41,10 @@ func applyServerTypeFlagOverrides(cfg *Config, fs *flag.FlagSet, serverType stri
 }
 
 func (a App) warmup(ctx context.Context, args []string) error {
+	return a.warmupWithLeaseObserver(ctx, args, nil)
+}
+
+func (a App) warmupWithLeaseObserver(ctx context.Context, args []string, observe func(LeaseTarget)) error {
 	started := time.Now()
 	defaults := defaultConfig()
 	fs := newFlagSet("warmup", a.Stderr)
@@ -119,6 +123,9 @@ func (a App) warmup(ctx context.Context, args []string) error {
 	if err := a.claimLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, server, target, repo.Root, *reclaim); err != nil {
 		a.releaseWarmupLeaseAfterFailure(ctx, sshBackend, cfg, LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: lease.Coordinator}, controllerOwnsCleanup.Load())
 		return err
+	}
+	if observe != nil {
+		observe(LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: lease.Coordinator})
 	}
 	if serverTailscaleMetadata(server).Enabled {
 		target = bootstrapNetworkTarget(cfg, server, target)
@@ -2755,9 +2762,14 @@ func (result leaseCleanupResult) apply(report *timingReport) {
 }
 
 func (a App) releaseBackendLeaseBestEffort(ctx context.Context, backend SSHLeaseBackend, cfg Config, lease LeaseTarget) error {
+	connectionCleanupSafe := true
 	if refresher, ok := backend.(ReleaseLeaseTargetRefresher); ok {
+		connectionCleanupSafe = refresher.ReleaseLeaseConnectionCleanupSafe()
 		refreshed, err := refresher.RefreshReleaseLeaseTarget(ctx, lease)
 		if err != nil {
+			if errors.Is(err, ErrReleaseLeaseOwnershipChanged) {
+				return err
+			}
 			fmt.Fprintf(a.Stderr, "warning: could not refresh lease %s before cleanup: %v; attempting release with acquired target\n", lease.LeaseID, err)
 		} else {
 			if refreshed.SSH.Host == "" {
@@ -2769,8 +2781,22 @@ func (a App) releaseBackendLeaseBestEffort(ctx context.Context, backend SSHLease
 			lease = refreshed
 		}
 	}
-	a.cleanupBackendLeaseConnectionsBestEffort(ctx, lease)
-	return a.releaseBackendLease(ctx, backend, cfg, lease)
+	if connectionCleanupSafe {
+		a.cleanupBackendLeaseConnectionsBestEffort(ctx, lease)
+	}
+	if err := a.releaseBackendLease(ctx, backend, cfg, lease); err != nil {
+		return err
+	}
+	if !connectionCleanupSafe {
+		a.cleanupBackendLeaseLocalConnectionsBestEffort(lease.LeaseID)
+	}
+	return nil
+}
+
+func (a App) cleanupBackendLeaseLocalConnectionsBestEffort(leaseID string) {
+	if _, err := a.stopEgressHostDaemon(leaseID); err != nil {
+		fmt.Fprintf(a.Stderr, "warning: egress host daemon cleanup failed for %s: %v\n", leaseID, err)
+	}
 }
 
 func (a App) cleanupBackendLeaseConnectionsBestEffort(ctx context.Context, lease LeaseTarget) {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -2762,9 +2762,8 @@ func (result leaseCleanupResult) apply(report *timingReport) {
 }
 
 func (a App) releaseBackendLeaseBestEffort(ctx context.Context, backend SSHLeaseBackend, cfg Config, lease LeaseTarget) error {
-	connectionCleanupSafe := true
+	connectionCleanupSafe := releaseLeaseConnectionCleanupSafe(backend)
 	if refresher, ok := backend.(ReleaseLeaseTargetRefresher); ok {
-		connectionCleanupSafe = refresher.ReleaseLeaseConnectionCleanupSafe()
 		refreshed, err := refresher.RefreshReleaseLeaseTarget(ctx, lease)
 		if err != nil {
 			if errors.Is(err, ErrReleaseLeaseOwnershipChanged) {
@@ -2793,9 +2792,22 @@ func (a App) releaseBackendLeaseBestEffort(ctx context.Context, backend SSHLease
 	return nil
 }
 
-func (a App) cleanupBackendLeaseLocalConnectionsBestEffort(leaseID string) {
-	if _, err := a.stopEgressHostDaemon(leaseID); err != nil {
-		fmt.Fprintf(a.Stderr, "warning: egress host daemon cleanup failed for %s: %v\n", leaseID, err)
+func releaseLeaseConnectionCleanupSafe(backend SSHLeaseBackend) bool {
+	policy, ok := backend.(ReleaseLeaseConnectionCleanupPolicy)
+	return !ok || policy.ReleaseLeaseConnectionCleanupSafe()
+}
+
+func (a App) cleanupBackendLeaseLocalConnectionsBestEffort(leaseIDs ...string) {
+	seen := map[string]bool{}
+	for _, leaseID := range leaseIDs {
+		leaseID = strings.TrimSpace(leaseID)
+		if leaseID == "" || seen[leaseID] {
+			continue
+		}
+		seen[leaseID] = true
+		if _, err := a.stopEgressHostDaemon(leaseID); err != nil {
+			fmt.Fprintf(a.Stderr, "warning: egress host daemon cleanup failed for %s: %v\n", leaseID, err)
+		}
 	}
 }
 
@@ -3185,17 +3197,23 @@ func (a App) stop(ctx context.Context, args []string) error {
 	if err := ValidateLeaseTargetProviderIdentity(lease, expectedIdentity); err != nil {
 		return err
 	}
-	if lease.SSH.Host != "" {
-		a.writeActionsHydrationStopBestEffort(ctx, lease.SSH, lease.LeaseID)
+	connectionCleanupSafe := releaseLeaseConnectionCleanupSafe(sshBackend)
+	if connectionCleanupSafe {
+		if lease.SSH.Host != "" {
+			a.writeActionsHydrationStopBestEffort(ctx, lease.SSH, lease.LeaseID)
+		}
+		a.cleanupMediatedEgressBestEffort(ctx, *id, lease)
+		a.logoutRemoteTailscaleBestEffort(ctx, lease)
 	}
-	a.cleanupMediatedEgressBestEffort(ctx, *id, lease)
-	a.logoutRemoteTailscaleBestEffort(ctx, lease)
 	if err := sshBackend.ReleaseLease(ctx, ReleaseLeaseRequest{
 		Lease:                    lease,
 		Force:                    true,
 		ExpectedProviderIdentity: expectedIdentity,
 	}); err != nil {
 		return err
+	}
+	if !connectionCleanupSafe {
+		a.cleanupBackendLeaseLocalConnectionsBestEffort(*id, lease.LeaseID)
 	}
 	a.releaseRegisteredCoordinatorLeaseBestEffort(ctx, cfg, lease.LeaseID)
 	if backendCoordinator(backend) != nil {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -2812,14 +2812,23 @@ func (a App) cleanupBackendLeaseLocalConnectionsBestEffort(leaseIDs ...string) {
 }
 
 func (a App) cleanupBackendLeaseConnectionsBestEffort(ctx context.Context, lease LeaseTarget) {
+	a.cleanupBackendLeaseLocalConnectionsBestEffort(lease.LeaseID)
+	a.cleanupBackendLeaseRemoteConnectionsBestEffort(ctx, lease)
+}
+
+func (a App) cleanupBackendLeaseRemoteConnectionsBestEffort(ctx context.Context, lease LeaseTarget) {
 	a.writeActionsHydrationStopBestEffort(ctx, lease.SSH, lease.LeaseID)
-	a.cleanupMediatedEgressBestEffort(ctx, lease.LeaseID, lease)
+	a.cleanupMediatedEgressRemoteBestEffort(ctx, lease)
 	a.logoutRemoteTailscaleBestEffort(ctx, lease)
 }
 
 func (a App) releaseBackendLease(ctx context.Context, backend SSHLeaseBackend, cfg Config, lease LeaseTarget) error {
 	fmt.Fprintf(a.Stderr, "releasing %s server=%s\n", lease.LeaseID, lease.Server.DisplayID())
-	if err := backend.ReleaseLease(ctx, ReleaseLeaseRequest{Lease: lease, Force: true}); err != nil {
+	request := ReleaseLeaseRequest{Lease: lease, Force: true}
+	if !releaseLeaseConnectionCleanupSafe(backend) {
+		request.GuardedRemoteCleanup = a.cleanupBackendLeaseRemoteConnectionsBestEffort
+	}
+	if err := backend.ReleaseLease(ctx, request); err != nil {
 		fmt.Fprintf(a.Stderr, "warning: release failed for %s: %v\n", lease.LeaseID, err)
 		return err
 	}
@@ -3205,11 +3214,15 @@ func (a App) stop(ctx context.Context, args []string) error {
 		a.cleanupMediatedEgressBestEffort(ctx, *id, lease)
 		a.logoutRemoteTailscaleBestEffort(ctx, lease)
 	}
-	if err := sshBackend.ReleaseLease(ctx, ReleaseLeaseRequest{
+	request := ReleaseLeaseRequest{
 		Lease:                    lease,
 		Force:                    true,
 		ExpectedProviderIdentity: expectedIdentity,
-	}); err != nil {
+	}
+	if !connectionCleanupSafe {
+		request.GuardedRemoteCleanup = a.cleanupBackendLeaseRemoteConnectionsBestEffort
+	}
+	if err := sshBackend.ReleaseLease(ctx, request); err != nil {
 		return err
 	}
 	if !connectionCleanupSafe {

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -27,6 +27,7 @@ func init() {
 
 type warmupFailureReleaseBackend struct {
 	releases int
+	resolves int
 }
 
 func (b *warmupFailureReleaseBackend) Spec() ProviderSpec {
@@ -36,6 +37,7 @@ func (b *warmupFailureReleaseBackend) Acquire(context.Context, AcquireRequest) (
 	return LeaseTarget{}, nil
 }
 func (b *warmupFailureReleaseBackend) Resolve(context.Context, ResolveRequest) (LeaseTarget, error) {
+	b.resolves++
 	return LeaseTarget{}, nil
 }
 func (b *warmupFailureReleaseBackend) List(context.Context, ListRequest) ([]LeaseView, error) {
@@ -60,6 +62,9 @@ func TestWarmupFailureLeavesAcknowledgedLeaseForControllerReleaseGate(t *testing
 	app.releaseWarmupLeaseAfterFailure(context.Background(), backend, defaultConfig(), lease, false)
 	if backend.releases != 1 {
 		t.Fatalf("standalone warmup cleanup releases=%d", backend.releases)
+	}
+	if backend.resolves != 0 {
+		t.Fatalf("standalone warmup cleanup resolves=%d, want no implicit preparation", backend.resolves)
 	}
 }
 

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"flag"
+	"fmt"
 	"io"
 	"net"
 	"os"
@@ -161,6 +162,54 @@ func TestStopCleansMediatedEgressBeforeRelease(t *testing.T) {
 	}
 }
 
+func TestStopDefersUnsafeLocalConnectionCleanupUntilRelease(t *testing.T) {
+	clearConfigEnv(t)
+	dir := t.TempDir()
+	isolateRunTestUserDirs(t, dir)
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, ".crabbox.yaml"))
+	leaseID := "cbx_env_profile_test"
+	requestedID := "friendly-slug"
+	pidPaths := map[string]string{}
+	for _, id := range []string{requestedID, leaseID} {
+		_, pidPath, err := egressDaemonPaths(id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(filepath.Dir(pidPath), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(pidPath, []byte("99999999\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		pidPaths[id] = pidPath
+	}
+	runEnvProfileTestConnectionCleanupSafe = false
+	t.Cleanup(func() { runEnvProfileTestConnectionCleanupSafe = true })
+	runEnvProfileTestReleaseHook = func() error {
+		for id, pidPath := range pidPaths {
+			if _, err := os.Stat(pidPath); err != nil {
+				return fmt.Errorf("local connection cleanup for %s ran before guarded release", id)
+			}
+		}
+		return nil
+	}
+	t.Cleanup(func() { runEnvProfileTestReleaseHook = nil })
+
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).stop(context.Background(), []string{
+		"--provider", "run-env-profile-test",
+		"--id", requestedID,
+	})
+	if err != nil {
+		t.Fatalf("stop error=%v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	for id, pidPath := range pidPaths {
+		if _, err := os.Stat(pidPath); !os.IsNotExist(err) {
+			t.Fatalf("egress pid path for %s still exists after release: %v", id, err)
+		}
+	}
+}
+
 func installRecordingSSH(t *testing.T, dir string) string {
 	t.Helper()
 	logPath := filepath.Join(dir, "ssh.log")
@@ -287,6 +336,7 @@ type runEnvProfileTestBackend struct {
 
 var runEnvProfileTestReleaseErr error
 var runEnvProfileTestReleaseHook func() error
+var runEnvProfileTestConnectionCleanupSafe = true
 
 func (b runEnvProfileTestBackend) Spec() ProviderSpec { return b.spec }
 func (b runEnvProfileTestBackend) Acquire(context.Context, AcquireRequest) (LeaseTarget, error) {
@@ -318,6 +368,9 @@ func (b runEnvProfileTestBackend) ReleaseLease(context.Context, ReleaseLeaseRequ
 }
 func (b runEnvProfileTestBackend) Touch(context.Context, TouchRequest) (Server, error) {
 	return Server{Provider: b.spec.Name}, nil
+}
+func (b runEnvProfileTestBackend) ReleaseLeaseConnectionCleanupSafe() bool {
+	return runEnvProfileTestConnectionCleanupSafe
 }
 
 type runPrepareTestProvider struct{}

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -166,7 +166,9 @@ func TestStopDefersUnsafeLocalConnectionCleanupUntilRelease(t *testing.T) {
 	clearConfigEnv(t)
 	dir := t.TempDir()
 	isolateRunTestUserDirs(t, dir)
+	logPath := installRecordingSSH(t, dir)
 	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, ".crabbox.yaml"))
+	t.Setenv("CRABBOX_FAKE_SSH_PORT", "22")
 	leaseID := "cbx_env_profile_test"
 	requestedID := "friendly-slug"
 	pidPaths := map[string]string{}
@@ -186,6 +188,7 @@ func TestStopDefersUnsafeLocalConnectionCleanupUntilRelease(t *testing.T) {
 	runEnvProfileTestConnectionCleanupSafe = false
 	t.Cleanup(func() { runEnvProfileTestConnectionCleanupSafe = true })
 	runEnvProfileTestReleaseHook = func() error {
+		assertSSHLogContains(t, logPath, remoteStopEgressClientCommand())
 		for id, pidPath := range pidPaths {
 			if _, err := os.Stat(pidPath); err != nil {
 				return fmt.Errorf("local connection cleanup for %s ran before guarded release", id)
@@ -358,7 +361,10 @@ func (b runEnvProfileTestBackend) Resolve(context.Context, ResolveRequest) (Leas
 func (b runEnvProfileTestBackend) List(context.Context, ListRequest) ([]LeaseView, error) {
 	return nil, nil
 }
-func (b runEnvProfileTestBackend) ReleaseLease(context.Context, ReleaseLeaseRequest) error {
+func (b runEnvProfileTestBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
+	if req.GuardedRemoteCleanup != nil {
+		req.GuardedRemoteCleanup(ctx, req.Lease)
+	}
 	if runEnvProfileTestReleaseHook != nil {
 		if err := runEnvProfileTestReleaseHook(); err != nil {
 			return err

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -30,6 +30,16 @@ type warmupFailureReleaseBackend struct {
 	resolves int
 }
 
+type ownershipChangedReleaseBackend struct {
+	*warmupFailureReleaseBackend
+}
+
+func (b *ownershipChangedReleaseBackend) RefreshReleaseLeaseTarget(context.Context, LeaseTarget) (LeaseTarget, error) {
+	return LeaseTarget{}, ErrReleaseLeaseOwnershipChanged
+}
+
+func (b *ownershipChangedReleaseBackend) ReleaseLeaseConnectionCleanupSafe() bool { return false }
+
 func (b *warmupFailureReleaseBackend) Spec() ProviderSpec {
 	return ProviderSpec{Name: "warmup-release-test"}
 }
@@ -65,6 +75,19 @@ func TestWarmupFailureLeavesAcknowledgedLeaseForControllerReleaseGate(t *testing
 	}
 	if backend.resolves != 0 {
 		t.Fatalf("standalone warmup cleanup resolves=%d, want no implicit preparation", backend.resolves)
+	}
+}
+
+func TestReleaseBackendLeaseStopsBeforeCleanupAfterOwnershipChange(t *testing.T) {
+	base := &warmupFailureReleaseBackend{}
+	backend := &ownershipChangedReleaseBackend{warmupFailureReleaseBackend: base}
+	lease := LeaseTarget{LeaseID: "cbx_abcdef123456", SSH: SSHTarget{Host: "192.0.2.70"}}
+	err := (App{Stdout: io.Discard, Stderr: io.Discard}).releaseBackendLeaseBestEffort(context.Background(), backend, defaultConfig(), lease)
+	if !errors.Is(err, ErrReleaseLeaseOwnershipChanged) {
+		t.Fatalf("err=%v, want ownership-change sentinel", err)
+	}
+	if base.releases != 0 {
+		t.Fatalf("releases=%d, want no cleanup or release after ownership change", base.releases)
 	}
 }
 

--- a/internal/cli/watch.go
+++ b/internal/cli/watch.go
@@ -192,7 +192,7 @@ func (a App) watchWithBackend(ctx context.Context, opts watchOptions, repo Repo,
 	}
 	if !opts.Keep {
 		defer func() {
-			if releaseErr := a.releaseWatchLeaseBestEffort(context.Background(), backend, repo, options, cfg, lease); releaseErr != nil {
+			if releaseErr := a.releaseBackendLeaseBestEffort(context.Background(), backend, cfg, lease); releaseErr != nil {
 				fmt.Fprintf(a.Stderr, "warning: watch lease release failed for %s: %v\n", lease.LeaseID, releaseErr)
 			}
 		}()
@@ -203,27 +203,6 @@ func (a App) watchWithBackend(ctx context.Context, opts watchOptions, repo Repo,
 	}
 	fmt.Fprintf(a.Stdout, "leased %s slug=%s provider=%s idle_timeout=%s idle_exit=%s\n", lease.LeaseID, blank(serverSlug(lease.Server), "-"), cfg.Provider, cfg.IdleTimeout, idleExit)
 	return a.watchLoop(ctx, opts, repo, cfg, lease.LeaseID, idleExit, execute)
-}
-
-func (a App) releaseWatchLeaseBestEffort(ctx context.Context, backend SSHLeaseBackend, repo Repo, options LeaseOptions, cfg Config, acquired LeaseTarget) error {
-	lease, err := backend.Resolve(ctx, ResolveRequest{
-		Repo:        repo,
-		Options:     options,
-		ID:          acquired.LeaseID,
-		ReleaseOnly: true,
-	})
-	if err != nil {
-		fmt.Fprintf(a.Stderr, "warning: could not refresh watch lease %s before cleanup: %v; attempting release with acquired target\n", acquired.LeaseID, err)
-		lease = acquired
-	} else {
-		if lease.SSH.Host == "" {
-			lease.SSH = acquired.SSH
-		}
-		if lease.Coordinator == nil {
-			lease.Coordinator = acquired.Coordinator
-		}
-	}
-	return a.releaseBackendLeaseBestEffort(ctx, backend, cfg, lease)
 }
 
 func watchEffectiveIdleExit(opts watchOptions, idleTimeout time.Duration) (time.Duration, error) {

--- a/internal/cli/watch.go
+++ b/internal/cli/watch.go
@@ -192,7 +192,7 @@ func (a App) watchWithBackend(ctx context.Context, opts watchOptions, repo Repo,
 	}
 	if !opts.Keep {
 		defer func() {
-			if releaseErr := a.releaseBackendLeaseBestEffort(context.Background(), backend, cfg, lease); releaseErr != nil {
+			if releaseErr := a.releaseWatchLeaseBestEffort(context.Background(), backend, repo, options, cfg, lease); releaseErr != nil {
 				fmt.Fprintf(a.Stderr, "warning: watch lease release failed for %s: %v\n", lease.LeaseID, releaseErr)
 			}
 		}()
@@ -203,6 +203,27 @@ func (a App) watchWithBackend(ctx context.Context, opts watchOptions, repo Repo,
 	}
 	fmt.Fprintf(a.Stdout, "leased %s slug=%s provider=%s idle_timeout=%s idle_exit=%s\n", lease.LeaseID, blank(serverSlug(lease.Server), "-"), cfg.Provider, cfg.IdleTimeout, idleExit)
 	return a.watchLoop(ctx, opts, repo, cfg, lease.LeaseID, idleExit, execute)
+}
+
+func (a App) releaseWatchLeaseBestEffort(ctx context.Context, backend SSHLeaseBackend, repo Repo, options LeaseOptions, cfg Config, acquired LeaseTarget) error {
+	lease, err := backend.Resolve(ctx, ResolveRequest{
+		Repo:        repo,
+		Options:     options,
+		ID:          acquired.LeaseID,
+		ReleaseOnly: true,
+	})
+	if err != nil {
+		fmt.Fprintf(a.Stderr, "warning: could not refresh watch lease %s before cleanup: %v; attempting release with acquired target\n", acquired.LeaseID, err)
+		lease = acquired
+	} else {
+		if lease.SSH.Host == "" {
+			lease.SSH = acquired.SSH
+		}
+		if lease.Coordinator == nil {
+			lease.Coordinator = acquired.Coordinator
+		}
+	}
+	return a.releaseBackendLeaseBestEffort(ctx, backend, cfg, lease)
 }
 
 func watchEffectiveIdleExit(opts watchOptions, idleTimeout time.Duration) (time.Duration, error) {

--- a/internal/cli/watch_test.go
+++ b/internal/cli/watch_test.go
@@ -31,6 +31,7 @@ type watchTestBackend struct {
 	acquireErr   error
 	resolveErr   error
 	labels       map[string]string
+	resolveSSH   string
 	features     FeatureSet
 }
 
@@ -68,7 +69,11 @@ func (b *watchTestBackend) Resolve(ctx context.Context, req ResolveRequest) (Lea
 	}
 	server := Server{Provider: "watch-test", Labels: labels}
 	server.ServerType.Name = "test"
-	return LeaseTarget{LeaseID: req.ID, Server: server}, nil
+	return LeaseTarget{LeaseID: req.ID, Server: server, SSH: SSHTarget{Host: b.resolveSSH}}, nil
+}
+
+func (b *watchTestBackend) RefreshReleaseLeaseTarget(ctx context.Context, lease LeaseTarget) (LeaseTarget, error) {
+	return b.Resolve(ctx, ResolveRequest{ID: lease.LeaseID, ReleaseOnly: true})
 }
 
 func (b *watchTestBackend) List(context.Context, ListRequest) ([]LeaseView, error) {
@@ -699,6 +704,7 @@ func TestWatchRefreshesReleaseAuthorizationAfterIterations(t *testing.T) {
 	root := newWatchGitRepo(t)
 	backend := newWatchTestBackend()
 	backend.labels = map[string]string{"claim_revision": "after-run"}
+	backend.resolveSSH = "refreshed.example"
 	executor := newWatchTestExecutor()
 	app := App{Stdout: io.Discard, Stderr: io.Discard}
 	opts := watchOptions{Debounce: 25 * time.Millisecond, IdleExit: 250 * time.Millisecond, IdleExitSet: true, Command: []string{"echo", "ok"}}
@@ -710,14 +716,14 @@ func TestWatchRefreshesReleaseAuthorizationAfterIterations(t *testing.T) {
 
 	backend.mu.Lock()
 	defer backend.mu.Unlock()
-	if !backend.resolveReq.ReleaseOnly || backend.resolveReq.ID != watchTestLeaseID || backend.resolveReq.Repo.Root != root {
-		t.Fatalf("resolve request=%+v, want repository-scoped release-only refresh", backend.resolveReq)
+	if !backend.resolveReq.ReleaseOnly || backend.resolveReq.ID != watchTestLeaseID {
+		t.Fatalf("resolve request=%+v, want release-only refresh", backend.resolveReq)
 	}
 	if got := backend.releaseLease.Server.Labels["claim_revision"]; got != "after-run" {
 		t.Fatalf("released claim revision=%q, want refreshed snapshot", got)
 	}
-	if got := backend.releaseLease.SSH.Host; got != "acquired.example" {
-		t.Fatalf("released SSH host=%q, want acquired connection metadata", got)
+	if got := backend.releaseLease.SSH.Host; got != "refreshed.example" {
+		t.Fatalf("released SSH host=%q, want refreshed connection metadata", got)
 	}
 }
 

--- a/internal/cli/watch_test.go
+++ b/internal/cli/watch_test.go
@@ -76,6 +76,8 @@ func (b *watchTestBackend) RefreshReleaseLeaseTarget(ctx context.Context, lease 
 	return b.Resolve(ctx, ResolveRequest{ID: lease.LeaseID, ReleaseOnly: true})
 }
 
+func (b *watchTestBackend) ReleaseLeaseConnectionCleanupSafe() bool { return true }
+
 func (b *watchTestBackend) List(context.Context, ListRequest) ([]LeaseView, error) {
 	return nil, nil
 }

--- a/internal/cli/watch_test.go
+++ b/internal/cli/watch_test.go
@@ -26,6 +26,8 @@ type watchTestBackend struct {
 	resolveCalls int
 	releaseCalls int
 	releaseCtx   context.Context
+	releaseLease LeaseTarget
+	resolveReq   ResolveRequest
 	acquireErr   error
 	resolveErr   error
 	labels       map[string]string
@@ -49,13 +51,14 @@ func (b *watchTestBackend) Acquire(ctx context.Context, req AcquireRequest) (Lea
 	}
 	server := Server{Provider: "watch-test", Labels: map[string]string{"lease": watchTestLeaseID}}
 	server.ServerType.Name = "test"
-	return LeaseTarget{LeaseID: watchTestLeaseID, Server: server}, nil
+	return LeaseTarget{LeaseID: watchTestLeaseID, Server: server, SSH: SSHTarget{Host: "acquired.example"}}, nil
 }
 
 func (b *watchTestBackend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.resolveCalls++
+	b.resolveReq = req
 	if b.resolveErr != nil {
 		return LeaseTarget{}, b.resolveErr
 	}
@@ -72,11 +75,12 @@ func (b *watchTestBackend) List(context.Context, ListRequest) ([]LeaseView, erro
 	return nil, nil
 }
 
-func (b *watchTestBackend) ReleaseLease(ctx context.Context, _ ReleaseLeaseRequest) error {
+func (b *watchTestBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.releaseCalls++
 	b.releaseCtx = ctx
+	b.releaseLease = req.Lease
 	return nil
 }
 
@@ -678,14 +682,64 @@ func TestWatchAcquiresLeaseWhenNoID(t *testing.T) {
 		t.Fatalf("watchWithBackend: %v", err)
 	}
 	acquires, resolves, releases := backend.counts()
-	if acquires != 1 || resolves != 0 || releases != 1 {
-		t.Fatalf("acquire=%d resolve=%d release=%d, want 1/0/1", acquires, resolves, releases)
+	if acquires != 1 || resolves != 1 || releases != 1 {
+		t.Fatalf("acquire=%d resolve=%d release=%d, want 1/1/1", acquires, resolves, releases)
 	}
 	if !strings.Contains(stdout.String(), "leased "+watchTestLeaseID) {
 		t.Fatalf("stdout missing leased line:\n%s", stdout.String())
 	}
 	if got := executor.call(0); !strings.Contains(strings.Join(got, " "), "--id "+watchTestLeaseID) {
 		t.Fatalf("iteration args=%v, want injected --id", got)
+	}
+}
+
+func TestWatchRefreshesReleaseAuthorizationAfterIterations(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CRABBOX_COORDINATOR", "")
+	root := newWatchGitRepo(t)
+	backend := newWatchTestBackend()
+	backend.labels = map[string]string{"claim_revision": "after-run"}
+	executor := newWatchTestExecutor()
+	app := App{Stdout: io.Discard, Stderr: io.Discard}
+	opts := watchOptions{Debounce: 25 * time.Millisecond, IdleExit: 250 * time.Millisecond, IdleExitSet: true, Command: []string{"echo", "ok"}}
+	cfg := Config{Provider: "watch-test", IdleTimeout: time.Minute, TTL: time.Hour}
+
+	if err := app.watchWithBackend(context.Background(), opts, Repo{Root: root, Name: "my-app"}, cfg, backend, executor.run); err != nil {
+		t.Fatalf("watchWithBackend: %v", err)
+	}
+
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	if !backend.resolveReq.ReleaseOnly || backend.resolveReq.ID != watchTestLeaseID || backend.resolveReq.Repo.Root != root {
+		t.Fatalf("resolve request=%+v, want repository-scoped release-only refresh", backend.resolveReq)
+	}
+	if got := backend.releaseLease.Server.Labels["claim_revision"]; got != "after-run" {
+		t.Fatalf("released claim revision=%q, want refreshed snapshot", got)
+	}
+	if got := backend.releaseLease.SSH.Host; got != "acquired.example" {
+		t.Fatalf("released SSH host=%q, want acquired connection metadata", got)
+	}
+}
+
+func TestWatchAttemptsReleaseWithAcquiredTargetWhenRefreshFails(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CRABBOX_COORDINATOR", "")
+	root := newWatchGitRepo(t)
+	backend := newWatchTestBackend()
+	backend.resolveErr = errors.New("temporary inventory failure")
+	executor := newWatchTestExecutor()
+	app := App{Stdout: io.Discard, Stderr: io.Discard}
+	opts := watchOptions{Debounce: 25 * time.Millisecond, IdleExit: 250 * time.Millisecond, IdleExitSet: true, Command: []string{"echo", "ok"}}
+	cfg := Config{Provider: "watch-test", IdleTimeout: time.Minute, TTL: time.Hour}
+
+	if err := app.watchWithBackend(context.Background(), opts, Repo{Root: root, Name: "my-app"}, cfg, backend, executor.run); err != nil {
+		t.Fatalf("watchWithBackend: %v", err)
+	}
+
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	if backend.releaseCalls != 1 || backend.releaseLease.LeaseID != watchTestLeaseID || backend.releaseLease.SSH.Host != "acquired.example" {
+		t.Fatalf("release calls=%d lease=%+v, want acquired target release attempt", backend.releaseCalls, backend.releaseLease)
 	}
 }
 

--- a/internal/providers/exedev/backend.go
+++ b/internal/providers/exedev/backend.go
@@ -217,7 +217,7 @@ func (b *exeDevLeaseBackend) resolveReleaseTarget(ctx context.Context, cfg Confi
 	if err := b.validateAbsentCleanupClaim(ctx, claim); err != nil {
 		return LeaseTarget{}, err
 	}
-	vms, err := b.listVMs(ctx, false)
+	vms, err := b.listVMs(ctx)
 	if err != nil {
 		return LeaseTarget{}, err
 	}
@@ -281,7 +281,7 @@ func (b *exeDevLeaseBackend) confirmClaimedVMAbsent(ctx context.Context, claim L
 	if err := b.validateAbsentCleanupClaim(ctx, claim); err != nil {
 		return err
 	}
-	vms, err := b.listVMs(ctx, false)
+	vms, err := b.listVMs(ctx)
 	if err != nil {
 		return err
 	}
@@ -716,7 +716,7 @@ func (b *exeDevLeaseBackend) resolveVM(ctx context.Context, identifier string) (
 }
 
 func (b *exeDevLeaseBackend) findVM(ctx context.Context, identifier string) (exeDevVM, error) {
-	vms, err := b.listVMs(ctx, false)
+	vms, err := b.listVMs(ctx)
 	if err != nil {
 		return exeDevVM{}, err
 	}
@@ -730,7 +730,7 @@ func (b *exeDevLeaseBackend) findVM(ctx context.Context, identifier string) (exe
 }
 
 func (b *exeDevLeaseBackend) findVMByExactName(ctx context.Context, name string) (exeDevVM, error) {
-	vms, err := b.listVMs(ctx, false)
+	vms, err := b.listVMs(ctx)
 	if err != nil {
 		return exeDevVM{}, err
 	}
@@ -743,7 +743,7 @@ func (b *exeDevLeaseBackend) findVMByExactName(ctx context.Context, name string)
 }
 
 func (b *exeDevLeaseBackend) findVMByLeaseID(ctx context.Context, leaseID string) (exeDevVM, bool, error) {
-	vms, err := b.listVMs(ctx, false)
+	vms, err := b.listVMs(ctx)
 	if err != nil {
 		return exeDevVM{}, false, err
 	}
@@ -763,7 +763,9 @@ func (b *exeDevLeaseBackend) findVMByLeaseID(ctx context.Context, leaseID string
 }
 
 func (b *exeDevLeaseBackend) listServers(ctx context.Context, all bool) ([]LeaseView, error) {
-	vms, err := b.listVMs(ctx, all)
+	// all widens only Crabbox's ownership filter. exe.dev scopes inventory to
+	// the authenticated account and its current CLI has no cross-account flag.
+	vms, err := b.listVMs(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -808,12 +810,8 @@ func fallbackExeDevIdentity(vm exeDevVM) (string, string) {
 	return leaseID, slug
 }
 
-func (b *exeDevLeaseBackend) listVMs(ctx context.Context, all bool) ([]exeDevVM, error) {
-	args := []string{"ls", "--l", "--json"}
-	if all {
-		args = append(args, "-a")
-	}
-	out, err := b.controlOutput(ctx, args)
+func (b *exeDevLeaseBackend) listVMs(ctx context.Context) ([]exeDevVM, error) {
+	out, err := b.controlOutput(ctx, []string{"ls", "--l", "--json"})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/providers/exedev/backend.go
+++ b/internal/providers/exedev/backend.go
@@ -176,6 +176,9 @@ func (b *exeDevLeaseBackend) resolveReleaseTarget(ctx context.Context, cfg Confi
 	}
 	for _, vm := range vms {
 		if vm.Name() != claim.CloudID {
+			if exeDevVMReferencesLease(vm, claim.LeaseID) {
+				return LeaseTarget{}, exit(2, "exe.dev lease %s is present on unexpected VM %s; refusing absent-claim cleanup", claim.LeaseID, vm.Name())
+			}
 			continue
 		}
 		if err := b.validateVMClaimBinding(ctx, vm, claim, claim.LeaseID, claim.Slug); err != nil {
@@ -233,11 +236,21 @@ func (b *exeDevLeaseBackend) confirmClaimedVMAbsent(ctx context.Context, claim L
 		return err
 	}
 	for _, vm := range vms {
-		if vm.Name() == claim.CloudID {
-			return exit(2, "exe.dev VM %s is present; refusing absent-claim cleanup", claim.CloudID)
+		if vm.Name() == claim.CloudID || exeDevVMReferencesLease(vm, claim.LeaseID) {
+			return exit(2, "exe.dev lease %s is present on VM %s; refusing absent-claim cleanup", claim.LeaseID, vm.Name())
 		}
 	}
 	return nil
+}
+
+func exeDevVMReferencesLease(vm exeDevVM, leaseID string) bool {
+	want := "crabbox-lease-" + leaseID
+	for _, tag := range vm.Tags {
+		if tag == want {
+			return true
+		}
+	}
+	return false
 }
 
 func (b *exeDevLeaseBackend) RefreshReleaseLeaseTarget(ctx context.Context, lease LeaseTarget) (LeaseTarget, error) {

--- a/internal/providers/exedev/backend.go
+++ b/internal/providers/exedev/backend.go
@@ -147,11 +147,53 @@ func (b *exeDevLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseR
 		if err := b.validateVMClaimBinding(ctx, vm, claim, claim.LeaseID, claim.Slug); err != nil {
 			return err
 		}
+		if req.GuardedRemoteCleanup != nil {
+			cleanupLease := req.Lease
+			cleanupLease.SSH = exeDevSSHTarget(b.configForRun(), vm)
+			cleanupLease.Server = exeDevCleanupServer(b.configForRun(), vm, claim)
+			req.GuardedRemoteCleanup(ctx, cleanupLease)
+			vm, err = b.findVMByExactName(ctx, claim.CloudID)
+			if err != nil {
+				return err
+			}
+			if err := b.validateVMClaimBinding(ctx, vm, claim, claim.LeaseID, claim.Slug); err != nil {
+				return err
+			}
+		}
 		// exe.dev exposes only name-based deletion. The account-bound random
 		// generation tag is the strongest provider-visible resource identity;
 		// actors able to replace it also already hold unconditional `rm` access.
 		return b.deleteVM(ctx, claim.CloudID)
 	})
+}
+
+func exeDevCleanupServer(cfg Config, vm exeDevVM, claim LeaseClaim) Server {
+	server := exeDevServer(vm, claim.LeaseID, claim.Slug, cfg, true)
+	for key, value := range claim.Labels {
+		server.Labels[key] = value
+	}
+	if claim.TailscaleIPv4 != "" || claim.TailscaleFQDN != "" || claim.TailscaleHostname != "" {
+		server.Labels["tailscale"] = "true"
+	}
+	if claim.TailscaleIPv4 != "" {
+		server.Labels["tailscale_ipv4"] = claim.TailscaleIPv4
+	}
+	if claim.TailscaleFQDN != "" {
+		server.Labels["tailscale_fqdn"] = claim.TailscaleFQDN
+	}
+	if claim.TailscaleHostname != "" {
+		server.Labels["tailscale_hostname"] = claim.TailscaleHostname
+	}
+	if len(claim.TailscaleTags) > 0 {
+		server.Labels["tailscale_tags"] = strings.Join(claim.TailscaleTags, ",")
+	}
+	if claim.TailscaleExitNode != "" {
+		server.Labels["tailscale_exit_node"] = claim.TailscaleExitNode
+	}
+	if claim.TailscaleExitLAN {
+		server.Labels["tailscale_exit_node_allow_lan_access"] = "true"
+	}
+	return server
 }
 
 func (b *exeDevLeaseBackend) resolveReleaseTarget(ctx context.Context, cfg Config, identifier string) (LeaseTarget, error) {
@@ -170,7 +212,7 @@ func (b *exeDevLeaseBackend) resolveReleaseTarget(ctx context.Context, cfg Confi
 		}
 		server := exeDevServer(vm, leaseID, slug, cfg, true)
 		setServerLeaseClaimSnapshot(&server, claim, true)
-		return LeaseTarget{Server: server, LeaseID: leaseID}, nil
+		return LeaseTarget{Server: server, SSH: exeDevSSHTarget(cfg, vm), LeaseID: leaseID}, nil
 	}
 	if err := b.validateAbsentCleanupClaim(ctx, claim); err != nil {
 		return LeaseTarget{}, err
@@ -191,7 +233,7 @@ func (b *exeDevLeaseBackend) resolveReleaseTarget(ctx context.Context, cfg Confi
 		}
 		server := exeDevServer(vm, claim.LeaseID, claim.Slug, cfg, true)
 		setServerLeaseClaimSnapshot(&server, claim, true)
-		return LeaseTarget{Server: server, LeaseID: claim.LeaseID}, nil
+		return LeaseTarget{Server: server, SSH: exeDevSSHTarget(cfg, vm), LeaseID: claim.LeaseID}, nil
 	}
 	server := Server{
 		CloudID:  claim.CloudID,

--- a/internal/providers/exedev/backend.go
+++ b/internal/providers/exedev/backend.go
@@ -19,6 +19,8 @@ type exeDevLeaseBackend struct {
 	rt   Runtime
 }
 
+const exeDevClaimGenerationLabel = "claim_generation"
+
 func NewExeDevLeaseBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
 	cfg.Provider = providerName
 	applyExeDevDefaults(&cfg)
@@ -58,6 +60,7 @@ func (b *exeDevLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (L
 		}
 		return LeaseTarget{}, err
 	}
+	lease.Server.Labels[exeDevClaimGenerationLabel] = newLeaseID()
 	claim, err := claimLeaseTargetForRepoConfigScopeIfUnchanged(leaseID, slug, cfg, providerScope, lease.Server, lease.SSH, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, LeaseClaim{}, false)
 	if err != nil {
 		if !req.Keep {
@@ -143,7 +146,54 @@ func (b *exeDevLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseR
 }
 
 func (b *exeDevLeaseBackend) RefreshReleaseLeaseTarget(ctx context.Context, lease LeaseTarget) (LeaseTarget, error) {
-	return b.Resolve(ctx, ResolveRequest{ID: lease.LeaseID, ReleaseOnly: true})
+	acquired, acquiredExists, snapshotSet := serverLeaseClaimSnapshot(lease.Server)
+	if !snapshotSet || !acquiredExists {
+		return LeaseTarget{}, exit(2, "provider=%s release refresh requires the acquisition claim snapshot", providerName)
+	}
+	if changed, err := exeDevClaimOwnershipChanged(acquired); err != nil {
+		return LeaseTarget{}, err
+	} else if changed {
+		return LeaseTarget{}, exeDevOwnershipChangedError(lease.LeaseID)
+	}
+	refreshed, err := b.Resolve(ctx, ResolveRequest{ID: lease.LeaseID, ReleaseOnly: true})
+	if err != nil {
+		if changed, claimErr := exeDevClaimOwnershipChanged(acquired); claimErr == nil && changed {
+			return LeaseTarget{}, exeDevOwnershipChangedError(lease.LeaseID)
+		}
+		return LeaseTarget{}, err
+	}
+	current, currentExists, currentSnapshotSet := serverLeaseClaimSnapshot(refreshed.Server)
+	if !currentSnapshotSet || !currentExists || !sameExeDevClaimLineage(acquired, current) {
+		return LeaseTarget{}, exeDevOwnershipChangedError(lease.LeaseID)
+	}
+	return refreshed, nil
+}
+
+func (b *exeDevLeaseBackend) ReleaseLeaseConnectionCleanupSafe() bool { return false }
+
+func exeDevClaimOwnershipChanged(acquired LeaseClaim) (bool, error) {
+	current, exists, err := readLeaseClaimWithPresence(acquired.LeaseID)
+	if err != nil {
+		return false, err
+	}
+	return !exists || !sameExeDevClaimLineage(acquired, current), nil
+}
+
+func exeDevOwnershipChangedError(leaseID string) error {
+	return errors.Join(errReleaseLeaseOwnershipChanged, exit(2, "lease %s claim ownership changed after acquisition; refusing automatic release", leaseID))
+}
+
+func sameExeDevClaimLineage(acquired, current LeaseClaim) bool {
+	return acquired.LeaseID == current.LeaseID &&
+		acquired.Provider == current.Provider &&
+		acquired.ProviderScope == current.ProviderScope &&
+		acquired.CloudID == current.CloudID &&
+		acquired.CloudNumericID == current.CloudNumericID &&
+		acquired.CloudImmutableID == current.CloudImmutableID &&
+		normalizeLeaseSlug(acquired.Slug) == normalizeLeaseSlug(current.Slug) &&
+		acquired.RepoRoot == current.RepoRoot &&
+		strings.TrimSpace(acquired.Labels[exeDevClaimGenerationLabel]) != "" &&
+		acquired.Labels[exeDevClaimGenerationLabel] == current.Labels[exeDevClaimGenerationLabel]
 }
 
 func (b *exeDevLeaseBackend) Touch(_ context.Context, req TouchRequest) (Server, error) {
@@ -276,6 +326,17 @@ func (b *exeDevLeaseBackend) claimResolvedVM(lease LeaseTarget, vm exeDevVM, lea
 	if err != nil {
 		return LeaseClaim{}, err
 	}
+	generation := ""
+	if exists && !req.Reclaim {
+		generation = strings.TrimSpace(previous.Labels[exeDevClaimGenerationLabel])
+		if generation == "" {
+			return LeaseClaim{}, exit(2, "lease %s has a legacy generationless claim; reuse with --reclaim before operating on it", leaseID)
+		}
+	}
+	if generation == "" {
+		generation = newLeaseID()
+	}
+	lease.Server.Labels[exeDevClaimGenerationLabel] = generation
 	claim, err := claimLeaseTargetForRepoConfigScopeIfUnchanged(leaseID, slug, cfg, providerScope, lease.Server, lease.SSH, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, previous, exists)
 	if err != nil {
 		return LeaseClaim{}, err

--- a/internal/providers/exedev/backend.go
+++ b/internal/providers/exedev/backend.go
@@ -56,14 +56,14 @@ func (b *exeDevLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (L
 	lease, err := b.prepareLease(ctx, cfg, vm, leaseID, slug, req.Keep, true)
 	if err != nil {
 		if !req.Keep {
-			err = b.rollbackCreatedVM(name, err)
+			err = b.rollbackCreatedVM(name, leaseID, slug, generation, err)
 		}
 		return LeaseTarget{}, err
 	}
 	providerScope, err := b.controlScope(ctx)
 	if err != nil {
 		if !req.Keep {
-			err = b.rollbackCreatedVM(name, err)
+			err = b.rollbackCreatedVM(name, leaseID, slug, generation, err)
 		}
 		return LeaseTarget{}, err
 	}
@@ -71,7 +71,7 @@ func (b *exeDevLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (L
 	claim, err := claimLeaseTargetForRepoConfigScopeIfUnchanged(leaseID, slug, cfg, providerScope, lease.Server, lease.SSH, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, LeaseClaim{}, false)
 	if err != nil {
 		if !req.Keep {
-			err = b.rollbackCreatedVM(name, err)
+			err = b.rollbackCreatedVM(name, leaseID, slug, generation, err)
 		}
 		return LeaseTarget{}, err
 	}
@@ -795,9 +795,19 @@ func (b *exeDevLeaseBackend) control(ctx context.Context, args []string, stdout,
 	return b.rt.Exec.Run(ctx, LocalCommandRequest{Name: "ssh", Args: sshArgs, Stdout: stdout, Stderr: stderr})
 }
 
-func (b *exeDevLeaseBackend) rollbackCreatedVM(name string, cause error) error {
+func (b *exeDevLeaseBackend) rollbackCreatedVM(name, leaseID, slug, generation string, cause error) error {
 	cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+	vm, err := b.findVMByExactName(cleanupCtx, name)
+	if err != nil {
+		return exit(exitCodeForError(cause), "%v; exe.dev cleanup could not verify VM %s; manual cleanup: %s: %v", cause, name, b.manualDeleteCommand(name), err)
+	}
+	if err := validateExeDevVMOwnership(vm, leaseID, slug, "provisioning rollback"); err != nil {
+		return exit(exitCodeForError(cause), "%v; exe.dev cleanup refused unverified VM %s; manual cleanup: %s: %v", cause, name, b.manualDeleteCommand(name), err)
+	}
+	if err := validateExeDevClaimGeneration(vm, generation); err != nil {
+		return exit(exitCodeForError(cause), "%v; exe.dev cleanup refused replacement VM %s; manual cleanup: %s: %v", cause, name, b.manualDeleteCommand(name), err)
+	}
 	if err := b.deleteVM(cleanupCtx, name); err != nil {
 		return exit(exitCodeForError(cause), "%v; exe.dev cleanup failed for VM %s; manual cleanup: %s: %v", cause, name, b.manualDeleteCommand(name), err)
 	}

--- a/internal/providers/exedev/backend.go
+++ b/internal/providers/exedev/backend.go
@@ -142,6 +142,10 @@ func (b *exeDevLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseR
 	})
 }
 
+func (b *exeDevLeaseBackend) RefreshReleaseLeaseTarget(ctx context.Context, lease LeaseTarget) (LeaseTarget, error) {
+	return b.Resolve(ctx, ResolveRequest{ID: lease.LeaseID, ReleaseOnly: true})
+}
+
 func (b *exeDevLeaseBackend) Touch(_ context.Context, req TouchRequest) (Server, error) {
 	server := req.Lease.Server
 	if server.Labels == nil {
@@ -532,9 +536,21 @@ func (b *exeDevLeaseBackend) rollbackCreatedVM(name string, cause error) error {
 	cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	if err := b.deleteVM(cleanupCtx, name); err != nil {
-		return exit(exitCodeForError(cause), "%v; exe.dev cleanup failed for VM %s; manual cleanup: crabbox stop --provider exe-dev --id %s: %v", cause, name, name, err)
+		return exit(exitCodeForError(cause), "%v; exe.dev cleanup failed for VM %s; manual cleanup: %s: %v", cause, name, b.manualDeleteCommand(name), err)
 	}
 	return cause
+}
+
+func (b *exeDevLeaseBackend) manualDeleteCommand(name string) string {
+	dest, port, err := exeDevControlDestination(b.configForRun().ExeDev.ControlHost)
+	if err != nil {
+		return "ssh <configured-exe-dev-control-host> rm " + shellQuote(name)
+	}
+	args := []string{"ssh"}
+	if port != "" {
+		args = append(args, "-p", port)
+	}
+	return shellQuoteArgs(append(args, dest, "rm", name))
 }
 
 func exitCodeForError(err error) int {

--- a/internal/providers/exedev/backend.go
+++ b/internal/providers/exedev/backend.go
@@ -51,12 +51,14 @@ func (b *exeDevLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (L
 		}
 		return LeaseTarget{}, err
 	}
-	if err := claimLeaseForRepoProvider(leaseID, slug, providerName, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
+	claim, err := claimLeaseTargetForRepoConfigIfUnchanged(leaseID, slug, cfg, lease.Server, lease.SSH, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, LeaseClaim{}, false)
+	if err != nil {
 		if !req.Keep {
 			err = b.rollbackCreatedVM(name, err)
 		}
 		return LeaseTarget{}, err
 	}
+	setServerLeaseClaimSnapshot(&lease.Server, claim, true)
 	fmt.Fprintf(b.rt.Stderr, "provisioned lease=%s name=%s state=ready\n", leaseID, name)
 	return lease, nil
 }
@@ -68,16 +70,35 @@ func (b *exeDevLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (L
 		return LeaseTarget{}, err
 	}
 	if req.ReleaseOnly {
-		return LeaseTarget{Server: exeDevServer(vm, leaseID, slug, cfg, true), LeaseID: leaseID}, nil
+		server := exeDevServer(vm, leaseID, slug, cfg, true)
+		claim, err := b.claimForVMRelease(vm, leaseID, slug)
+		if err != nil {
+			return LeaseTarget{}, err
+		}
+		setServerLeaseClaimSnapshot(&server, claim, true)
+		return LeaseTarget{Server: server, LeaseID: leaseID}, nil
 	}
 	lease, err := b.prepareLease(ctx, cfg, vm, leaseID, slug, true, false)
 	if err != nil {
 		return LeaseTarget{}, err
 	}
 	if req.Repo.Root != "" {
-		if err := claimLeaseForRepoProvider(leaseID, slug, providerName, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
+		claim, err := b.claimResolvedVM(lease, vm, leaseID, slug, req)
+		if err != nil {
 			return LeaseTarget{}, err
 		}
+		setServerLeaseClaimSnapshot(&lease.Server, claim, true)
+	} else if claim, exists, err := readLeaseClaimWithPresence(leaseID); err != nil {
+		return LeaseTarget{}, err
+	} else {
+		if exists {
+			if err := b.validateVMClaimBinding(vm, claim, leaseID, slug); err != nil {
+				return LeaseTarget{}, err
+			}
+		} else if !req.IsReadOnlyStatus() {
+			return LeaseTarget{}, exit(2, "provider=%s lease %s has no exact local claim; use a repository-scoped reuse with --reclaim before operating on it", providerName, leaseID)
+		}
+		setServerLeaseClaimSnapshot(&lease.Server, claim, exists)
 	}
 	return lease, nil
 }
@@ -95,22 +116,23 @@ func (b *exeDevLeaseBackend) Doctor(ctx context.Context, _ DoctorRequest) (Docto
 }
 
 func (b *exeDevLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
-	name := strings.TrimSpace(req.Lease.Server.Name)
-	if name == "" {
-		vm, _, _, err := b.resolveVM(ctx, req.Lease.LeaseID)
+	claim, exists, snapshotSet := serverLeaseClaimSnapshot(req.Lease.Server)
+	if !snapshotSet || !exists {
+		return exit(2, "provider=%s release requires an exact local claim snapshot", providerName)
+	}
+	if err := b.validateReleaseTarget(req.Lease, claim); err != nil {
+		return err
+	}
+	return removeLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, func() error {
+		vm, err := b.findVMByExactName(ctx, claim.CloudID)
 		if err != nil {
 			return err
 		}
-		name = vm.Name()
-	}
-	if name == "" {
-		return exit(2, "provider=%s release requires a VM name", providerName)
-	}
-	if err := b.deleteVM(ctx, name); err != nil {
-		return err
-	}
-	removeLeaseClaim(req.Lease.LeaseID)
-	return nil
+		if err := b.validateVMClaimBinding(vm, claim, claim.LeaseID, claim.Slug); err != nil {
+			return err
+		}
+		return b.deleteVM(ctx, claim.CloudID)
+	})
 }
 
 func (b *exeDevLeaseBackend) Touch(_ context.Context, req TouchRequest) (Server, error) {
@@ -205,6 +227,129 @@ func (b *exeDevLeaseBackend) deleteVM(ctx context.Context, name string) error {
 	return nil
 }
 
+func (b *exeDevLeaseBackend) claimResolvedVM(lease LeaseTarget, vm exeDevVM, leaseID, slug string, req ResolveRequest) (LeaseClaim, error) {
+	if err := b.validateResolvedLeaseTarget(lease, vm, leaseID, slug); err != nil {
+		return LeaseClaim{}, err
+	}
+	previous, exists, err := readLeaseClaimWithPresence(leaseID)
+	if err != nil {
+		return LeaseClaim{}, err
+	}
+	if !exists && !req.Reclaim {
+		return LeaseClaim{}, exit(2, "exe.dev VM %s is not locally claimed; inspect it, then reuse with --reclaim before operating on it", vm.Name())
+	}
+	if exists {
+		if previous.Provider != "" && previous.Provider != providerName {
+			return LeaseClaim{}, exit(2, "lease %s is already claimed by provider=%s", leaseID, previous.Provider)
+		}
+		if previous.Provider == "" && !req.Reclaim {
+			return LeaseClaim{}, exit(2, "lease %s has a legacy providerless claim; reuse with --reclaim to bind provider=%s", leaseID, providerName)
+		}
+		if previous.CloudID != "" && previous.CloudID != vm.Name() {
+			return LeaseClaim{}, exit(2, "lease %s is already bound to exe.dev VM %s, refusing retarget to %s", leaseID, previous.CloudID, vm.Name())
+		}
+		if err := b.validateExistingClaimRoute(previous); err != nil {
+			return LeaseClaim{}, err
+		}
+	}
+	cfg := b.configForRun()
+	claim, err := claimLeaseTargetForRepoConfigIfUnchanged(leaseID, slug, cfg, lease.Server, lease.SSH, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, previous, exists)
+	if err != nil {
+		return LeaseClaim{}, err
+	}
+	return claim, nil
+}
+
+func (b *exeDevLeaseBackend) validateResolvedLeaseTarget(lease LeaseTarget, vm exeDevVM, leaseID, slug string) error {
+	if err := validateExeDevVMOwnership(vm, leaseID, slug, "reuse"); err != nil {
+		return err
+	}
+	wantScope, err := exeDevControlScope(b.configForRun())
+	if err != nil {
+		return err
+	}
+	wantHost := vm.SSHAddress().Host
+	if lease.LeaseID != leaseID || lease.Server.Provider != providerName || lease.Server.CloudID != vm.Name() || lease.Server.Name != vm.Name() || lease.SSH.Host != wantHost {
+		return exit(2, "exe.dev VM %s resolved to inconsistent provider metadata", vm.Name())
+	}
+	if lease.Server.Labels["provider"] != providerName || lease.Server.Labels["lease"] != leaseID || normalizeLeaseSlug(lease.Server.Labels["slug"]) != normalizeLeaseSlug(slug) || lease.Server.Labels["name"] != vm.Name() || lease.Server.Labels[exeDevControlScopeLabel] != wantScope {
+		return exit(2, "exe.dev VM %s resolved to incomplete claim metadata", vm.Name())
+	}
+	return nil
+}
+
+func (b *exeDevLeaseBackend) claimForVMRelease(vm exeDevVM, leaseID, slug string) (LeaseClaim, error) {
+	claim, exists, err := readLeaseClaimWithPresence(leaseID)
+	if err != nil {
+		return LeaseClaim{}, err
+	}
+	if !exists {
+		return LeaseClaim{}, exit(2, "exe.dev VM %s has no exact local claim; refusing deletion", vm.Name())
+	}
+	if err := b.validateVMClaimBinding(vm, claim, leaseID, slug); err != nil {
+		return LeaseClaim{}, err
+	}
+	return claim, nil
+}
+
+func (b *exeDevLeaseBackend) validateExistingClaimRoute(claim LeaseClaim) error {
+	want, err := exeDevControlScope(b.configForRun())
+	if err != nil {
+		return err
+	}
+	if got := strings.TrimSpace(claim.Labels[exeDevControlScopeLabel]); got != "" && got != want {
+		return exit(2, "lease %s is bound to a different exe.dev control route", claim.LeaseID)
+	}
+	return nil
+}
+
+func (b *exeDevLeaseBackend) validateVMClaimBinding(vm exeDevVM, claim LeaseClaim, leaseID, slug string) error {
+	if err := validateExeDevVMOwnership(vm, leaseID, slug, "deletion"); err != nil {
+		return err
+	}
+	slug = normalizeLeaseSlug(slug)
+	if claim.LeaseID != leaseID || claim.Provider != providerName || normalizeLeaseSlug(claim.Slug) != slug || claim.CloudID != vm.Name() {
+		return exit(2, "exe.dev VM %s is not bound to an exact provider/resource claim", vm.Name())
+	}
+	wantScope, err := exeDevControlScope(b.configForRun())
+	if err != nil {
+		return err
+	}
+	if claim.Labels["provider"] != providerName || claim.Labels["lease"] != leaseID || normalizeLeaseSlug(claim.Labels["slug"]) != slug || claim.Labels["name"] != vm.Name() || claim.Labels[exeDevControlScopeLabel] != wantScope {
+		return exit(2, "exe.dev VM %s claim metadata does not attest the current provider binding", vm.Name())
+	}
+	return nil
+}
+
+func validateExeDevVMOwnership(vm exeDevVM, leaseID, slug, operation string) error {
+	remoteLeaseID, remoteSlug, owned, err := exeDevOwnershipIdentity(vm)
+	if err != nil {
+		return err
+	}
+	if !owned {
+		return exit(2, "exe.dev VM %s has no complete Crabbox ownership tags; refusing %s", vm.Name(), operation)
+	}
+	slug = normalizeLeaseSlug(slug)
+	if remoteLeaseID != leaseID || remoteSlug != slug {
+		return exit(2, "exe.dev VM %s ownership tags do not match lease=%s slug=%s", vm.Name(), leaseID, slug)
+	}
+	wantName := leaseProviderName(leaseID, slug)
+	if vm.Name() != wantName {
+		return exit(2, "exe.dev VM %s does not match the claimed provider name %s", vm.Name(), wantName)
+	}
+	return nil
+}
+
+func (b *exeDevLeaseBackend) validateReleaseTarget(lease LeaseTarget, claim LeaseClaim) error {
+	if lease.LeaseID != claim.LeaseID || lease.Server.Provider != providerName || lease.Server.CloudID != claim.CloudID || lease.Server.Name != claim.CloudID {
+		return exit(2, "provider=%s release target does not match its claim snapshot", providerName)
+	}
+	if lease.Server.Labels["lease"] != claim.LeaseID || normalizeLeaseSlug(lease.Server.Labels["slug"]) != normalizeLeaseSlug(claim.Slug) {
+		return exit(2, "provider=%s release labels do not match their claim snapshot", providerName)
+	}
+	return b.validateExistingClaimRoute(claim)
+}
+
 func (b *exeDevLeaseBackend) prepareLease(ctx context.Context, cfg Config, vm exeDevVM, leaseID, slug string, keep, wait bool) (LeaseTarget, error) {
 	server := exeDevServer(vm, leaseID, slug, cfg, keep)
 	target := exeDevSSHTarget(cfg, vm)
@@ -272,13 +417,30 @@ func (b *exeDevLeaseBackend) findVM(ctx context.Context, identifier string) (exe
 	return exeDevVM{}, exit(4, "exe.dev VM not found: %s", identifier)
 }
 
+func (b *exeDevLeaseBackend) findVMByExactName(ctx context.Context, name string) (exeDevVM, error) {
+	vms, err := b.listVMs(ctx, true)
+	if err != nil {
+		return exeDevVM{}, err
+	}
+	for _, vm := range vms {
+		if vm.Name() == name {
+			return vm, nil
+		}
+	}
+	return exeDevVM{}, exit(4, "exe.dev VM not found: %s", name)
+}
+
 func (b *exeDevLeaseBackend) findVMByLeaseID(ctx context.Context, leaseID string) (exeDevVM, bool, error) {
 	vms, err := b.listVMs(ctx, true)
 	if err != nil {
 		return exeDevVM{}, false, err
 	}
 	for _, vm := range vms {
-		if taggedLeaseID, _ := exeDevTaggedIdentity(vm); taggedLeaseID == leaseID {
+		taggedLeaseID, _, owned, err := exeDevOwnershipIdentity(vm)
+		if err != nil {
+			return exeDevVM{}, false, err
+		}
+		if owned && taggedLeaseID == leaseID {
 			return vm, true, nil
 		}
 	}
@@ -293,8 +455,14 @@ func (b *exeDevLeaseBackend) listServers(ctx context.Context, all bool) ([]Lease
 	cfg := b.configForRun()
 	servers := make([]Server, 0, len(vms))
 	for _, vm := range vms {
-		if !all && !strings.HasPrefix(vm.Name(), "crabbox-") {
-			continue
+		if !all {
+			_, _, owned, err := exeDevOwnershipIdentity(vm)
+			if err != nil {
+				return nil, err
+			}
+			if !owned {
+				continue
+			}
 		}
 		leaseID, slug, err := b.leaseIdentityForVM(vm)
 		if err != nil {
@@ -305,11 +473,8 @@ func (b *exeDevLeaseBackend) listServers(ctx context.Context, all bool) ([]Lease
 	return servers, nil
 }
 
-func (b *exeDevLeaseBackend) listVMs(ctx context.Context, all bool) ([]exeDevVM, error) {
+func (b *exeDevLeaseBackend) listVMs(ctx context.Context, _ bool) ([]exeDevVM, error) {
 	args := []string{"ls", "--l", "--json"}
-	if all {
-		args = append(args, "--a")
-	}
 	out, err := b.controlOutput(ctx, args)
 	if err != nil {
 		return nil, err
@@ -461,11 +626,24 @@ func commandExitCode(result LocalCommandResult) int {
 	return 1
 }
 
+const exeDevControlScopeLabel = "exe_dev_control_scope"
+
+func exeDevControlScope(cfg Config) (string, error) {
+	destination, port, err := exeDevControlDestination(cfg.ExeDev.ControlHost)
+	if err != nil {
+		return "", err
+	}
+	return "ssh:" + destination + "|port:" + blank(port, "default"), nil
+}
+
 func exeDevServer(vm exeDevVM, leaseID, slug string, cfg Config, keep bool) Server {
 	labels := directLeaseLabels(cfg, leaseID, slug, providerName, "", keep, time.Now().UTC())
 	labels["name"] = vm.Name()
 	labels["state"] = blank(vm.Status, "unknown")
 	labels["work_root"] = cfg.WorkRoot
+	if scope, err := exeDevControlScope(cfg); err == nil {
+		labels[exeDevControlScopeLabel] = scope
+	}
 	if vm.Region != "" {
 		labels["region"] = vm.Region
 	}
@@ -530,8 +708,10 @@ func shellQuote(value string) string {
 }
 
 func (b *exeDevLeaseBackend) leaseIdentityForVM(vm exeDevVM) (string, string, error) {
-	if leaseID, slug := exeDevTaggedIdentity(vm); leaseID != "" {
-		return leaseID, blank(slug, newLeaseSlug(leaseID)), nil
+	if leaseID, slug, owned, err := exeDevOwnershipIdentity(vm); err != nil {
+		return "", "", err
+	} else if owned {
+		return leaseID, slug, nil
 	}
 	if slug := inferExeDevSlugFromName(vm.Name()); slug != "" {
 		if claim, ok, err := resolveLeaseClaimForProvider(slug, providerName); err != nil {
@@ -551,19 +731,46 @@ func (b *exeDevLeaseBackend) leaseIdentityForVM(vm exeDevVM) (string, string, er
 	return leaseID, slug, nil
 }
 
-func exeDevTaggedIdentity(vm exeDevVM) (string, string) {
-	leaseID := ""
-	slug := ""
+func exeDevOwnershipIdentity(vm exeDevVM) (string, string, bool, error) {
+	leaseIDs := map[string]struct{}{}
+	slugs := map[string]struct{}{}
+	baseTag := false
 	for _, tag := range vm.Tags {
 		tag = strings.TrimSpace(tag)
+		if tag == "crabbox" {
+			baseTag = true
+		}
 		if strings.HasPrefix(tag, "crabbox-lease-") {
-			leaseID = strings.TrimPrefix(tag, "crabbox-lease-")
+			leaseID := strings.TrimSpace(strings.TrimPrefix(tag, "crabbox-lease-"))
+			if leaseID != "" {
+				leaseIDs[leaseID] = struct{}{}
+			}
 		}
 		if strings.HasPrefix(tag, "crabbox-slug-") {
-			slug = normalizeLeaseSlug(strings.TrimPrefix(tag, "crabbox-slug-"))
+			slug := normalizeLeaseSlug(strings.TrimPrefix(tag, "crabbox-slug-"))
+			if slug != "" {
+				slugs[slug] = struct{}{}
+			}
 		}
 	}
-	return leaseID, slug
+	if len(leaseIDs) > 1 || len(slugs) > 1 {
+		return "", "", false, exit(2, "exe.dev VM %s has conflicting Crabbox ownership tags", vm.Name())
+	}
+	if !baseTag || len(leaseIDs) != 1 || len(slugs) != 1 {
+		return "", "", false, nil
+	}
+	leaseID := ""
+	for value := range leaseIDs {
+		leaseID = value
+	}
+	if !isCanonicalLeaseID(leaseID) {
+		return "", "", false, exit(2, "exe.dev VM %s has an invalid Crabbox lease tag", vm.Name())
+	}
+	slug := ""
+	for value := range slugs {
+		slug = value
+	}
+	return leaseID, slug, true, nil
 }
 
 func inferExeDevSlugFromName(name string) string {

--- a/internal/providers/exedev/backend.go
+++ b/internal/providers/exedev/backend.go
@@ -51,7 +51,14 @@ func (b *exeDevLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (L
 		}
 		return LeaseTarget{}, err
 	}
-	claim, err := claimLeaseTargetForRepoConfigIfUnchanged(leaseID, slug, cfg, lease.Server, lease.SSH, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, LeaseClaim{}, false)
+	providerScope, err := exeDevControlScope(cfg)
+	if err != nil {
+		if !req.Keep {
+			err = b.rollbackCreatedVM(name, err)
+		}
+		return LeaseTarget{}, err
+	}
+	claim, err := claimLeaseTargetForRepoConfigScopeIfUnchanged(leaseID, slug, cfg, providerScope, lease.Server, lease.SSH, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, LeaseClaim{}, false)
 	if err != nil {
 		if !req.Keep {
 			err = b.rollbackCreatedVM(name, err)
@@ -248,12 +255,24 @@ func (b *exeDevLeaseBackend) claimResolvedVM(lease LeaseTarget, vm exeDevVM, lea
 		if previous.CloudID != "" && previous.CloudID != vm.Name() {
 			return LeaseClaim{}, exit(2, "lease %s is already bound to exe.dev VM %s, refusing retarget to %s", leaseID, previous.CloudID, vm.Name())
 		}
-		if err := b.validateExistingClaimRoute(previous); err != nil {
-			return LeaseClaim{}, err
+		// Released versions did not bind exe.dev claims to a control route.
+		// Explicit reclaim is the migration boundary after remote ownership and
+		// exact resource identity have both been revalidated above.
+		if previous.ProviderScope == "" && !req.Reclaim {
+			return LeaseClaim{}, exit(2, "lease %s has a legacy unscoped claim; reuse with --reclaim to bind the exe.dev control route", leaseID)
+		}
+		if previous.ProviderScope != "" {
+			if err := b.validateExistingClaimRoute(previous); err != nil {
+				return LeaseClaim{}, err
+			}
 		}
 	}
 	cfg := b.configForRun()
-	claim, err := claimLeaseTargetForRepoConfigIfUnchanged(leaseID, slug, cfg, lease.Server, lease.SSH, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, previous, exists)
+	providerScope, err := exeDevControlScope(cfg)
+	if err != nil {
+		return LeaseClaim{}, err
+	}
+	claim, err := claimLeaseTargetForRepoConfigScopeIfUnchanged(leaseID, slug, cfg, providerScope, lease.Server, lease.SSH, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, previous, exists)
 	if err != nil {
 		return LeaseClaim{}, err
 	}
@@ -264,15 +283,11 @@ func (b *exeDevLeaseBackend) validateResolvedLeaseTarget(lease LeaseTarget, vm e
 	if err := validateExeDevVMOwnership(vm, leaseID, slug, "reuse"); err != nil {
 		return err
 	}
-	wantScope, err := exeDevControlScope(b.configForRun())
-	if err != nil {
-		return err
-	}
 	wantHost := vm.SSHAddress().Host
 	if lease.LeaseID != leaseID || lease.Server.Provider != providerName || lease.Server.CloudID != vm.Name() || lease.Server.Name != vm.Name() || lease.SSH.Host != wantHost {
 		return exit(2, "exe.dev VM %s resolved to inconsistent provider metadata", vm.Name())
 	}
-	if lease.Server.Labels["provider"] != providerName || lease.Server.Labels["lease"] != leaseID || normalizeLeaseSlug(lease.Server.Labels["slug"]) != normalizeLeaseSlug(slug) || lease.Server.Labels["name"] != vm.Name() || lease.Server.Labels[exeDevControlScopeLabel] != wantScope {
+	if lease.Server.Labels["provider"] != providerName || lease.Server.Labels["lease"] != leaseID || normalizeLeaseSlug(lease.Server.Labels["slug"]) != normalizeLeaseSlug(slug) || lease.Server.Labels["name"] != vm.Name() {
 		return exit(2, "exe.dev VM %s resolved to incomplete claim metadata", vm.Name())
 	}
 	return nil
@@ -297,7 +312,7 @@ func (b *exeDevLeaseBackend) validateExistingClaimRoute(claim LeaseClaim) error 
 	if err != nil {
 		return err
 	}
-	if got := strings.TrimSpace(claim.Labels[exeDevControlScopeLabel]); got != "" && got != want {
+	if got := strings.TrimSpace(claim.ProviderScope); got == "" || got != want {
 		return exit(2, "lease %s is bound to a different exe.dev control route", claim.LeaseID)
 	}
 	return nil
@@ -311,11 +326,10 @@ func (b *exeDevLeaseBackend) validateVMClaimBinding(vm exeDevVM, claim LeaseClai
 	if claim.LeaseID != leaseID || claim.Provider != providerName || normalizeLeaseSlug(claim.Slug) != slug || claim.CloudID != vm.Name() {
 		return exit(2, "exe.dev VM %s is not bound to an exact provider/resource claim", vm.Name())
 	}
-	wantScope, err := exeDevControlScope(b.configForRun())
-	if err != nil {
+	if err := b.validateExistingClaimRoute(claim); err != nil {
 		return err
 	}
-	if claim.Labels["provider"] != providerName || claim.Labels["lease"] != leaseID || normalizeLeaseSlug(claim.Labels["slug"]) != slug || claim.Labels["name"] != vm.Name() || claim.Labels[exeDevControlScopeLabel] != wantScope {
+	if claim.Labels["provider"] != providerName || claim.Labels["lease"] != leaseID || normalizeLeaseSlug(claim.Labels["slug"]) != slug || claim.Labels["name"] != vm.Name() {
 		return exit(2, "exe.dev VM %s claim metadata does not attest the current provider binding", vm.Name())
 	}
 	return nil
@@ -626,8 +640,6 @@ func commandExitCode(result LocalCommandResult) int {
 	return 1
 }
 
-const exeDevControlScopeLabel = "exe_dev_control_scope"
-
 func exeDevControlScope(cfg Config) (string, error) {
 	destination, port, err := exeDevControlDestination(cfg.ExeDev.ControlHost)
 	if err != nil {
@@ -641,9 +653,6 @@ func exeDevServer(vm exeDevVM, leaseID, slug string, cfg Config, keep bool) Serv
 	labels["name"] = vm.Name()
 	labels["state"] = blank(vm.Status, "unknown")
 	labels["work_root"] = cfg.WorkRoot
-	if scope, err := exeDevControlScope(cfg); err == nil {
-		labels[exeDevControlScopeLabel] = scope
-	}
 	if vm.Region != "" {
 		labels["region"] = vm.Region
 	}

--- a/internal/providers/exedev/backend.go
+++ b/internal/providers/exedev/backend.go
@@ -21,7 +21,10 @@ type exeDevLeaseBackend struct {
 	rt   Runtime
 }
 
-const exeDevClaimGenerationLabel = "claim_generation"
+const (
+	exeDevClaimGenerationLabel = "claim_generation"
+	exeDevConfirmedAbsentLabel = "exe_dev_confirmed_absent"
+)
 
 func NewExeDevLeaseBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
 	cfg.Provider = providerName
@@ -77,18 +80,12 @@ func (b *exeDevLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (L
 
 func (b *exeDevLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {
 	cfg := b.configForRun()
+	if req.ReleaseOnly {
+		return b.resolveReleaseTarget(ctx, cfg, req.ID)
+	}
 	vm, leaseID, slug, err := b.resolveVM(ctx, req.ID)
 	if err != nil {
 		return LeaseTarget{}, err
-	}
-	if req.ReleaseOnly {
-		server := exeDevServer(vm, leaseID, slug, cfg, true)
-		claim, err := b.claimForVMRelease(ctx, vm, leaseID, slug)
-		if err != nil {
-			return LeaseTarget{}, err
-		}
-		setServerLeaseClaimSnapshot(&server, claim, true)
-		return LeaseTarget{Server: server, LeaseID: leaseID}, nil
 	}
 	lease, err := b.prepareLease(ctx, cfg, vm, leaseID, slug, true, false)
 	if err != nil {
@@ -135,6 +132,11 @@ func (b *exeDevLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseR
 	if err := b.validateReleaseTarget(req.Lease, claim); err != nil {
 		return err
 	}
+	if req.Lease.Server.Labels[exeDevConfirmedAbsentLabel] == "true" {
+		return removeLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, func() error {
+			return b.confirmClaimedVMAbsent(ctx, claim)
+		})
+	}
 	return removeLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, func() error {
 		vm, err := b.findVMByExactName(ctx, claim.CloudID)
 		if err != nil {
@@ -145,6 +147,97 @@ func (b *exeDevLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseR
 		}
 		return b.deleteVM(ctx, claim.CloudID)
 	})
+}
+
+func (b *exeDevLeaseBackend) resolveReleaseTarget(ctx context.Context, cfg Config, identifier string) (LeaseTarget, error) {
+	claim, claimed, err := resolveExeDevReleaseClaim(identifier)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	if !claimed {
+		vm, leaseID, slug, err := b.resolveVM(ctx, identifier)
+		if err != nil {
+			return LeaseTarget{}, err
+		}
+		claim, err := b.claimForVMRelease(ctx, vm, leaseID, slug)
+		if err != nil {
+			return LeaseTarget{}, err
+		}
+		server := exeDevServer(vm, leaseID, slug, cfg, true)
+		setServerLeaseClaimSnapshot(&server, claim, true)
+		return LeaseTarget{Server: server, LeaseID: leaseID}, nil
+	}
+	if err := b.validateAbsentCleanupClaim(ctx, claim); err != nil {
+		return LeaseTarget{}, err
+	}
+	vms, err := b.listVMs(ctx, true)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	for _, vm := range vms {
+		if vm.Name() != claim.CloudID {
+			continue
+		}
+		if err := b.validateVMClaimBinding(ctx, vm, claim, claim.LeaseID, claim.Slug); err != nil {
+			return LeaseTarget{}, err
+		}
+		server := exeDevServer(vm, claim.LeaseID, claim.Slug, cfg, true)
+		setServerLeaseClaimSnapshot(&server, claim, true)
+		return LeaseTarget{Server: server, LeaseID: claim.LeaseID}, nil
+	}
+	server := Server{
+		CloudID:  claim.CloudID,
+		Provider: providerName,
+		Name:     claim.CloudID,
+		Labels: map[string]string{
+			"provider":                 providerName,
+			"lease":                    claim.LeaseID,
+			"slug":                     claim.Slug,
+			"name":                     claim.CloudID,
+			exeDevConfirmedAbsentLabel: "true",
+		},
+	}
+	setServerLeaseClaimSnapshot(&server, claim, true)
+	return LeaseTarget{Server: server, LeaseID: claim.LeaseID}, nil
+}
+
+func resolveExeDevReleaseClaim(identifier string) (LeaseClaim, bool, error) {
+	claim, claimed, err := resolveLeaseClaimForProvider(identifier, providerName)
+	if err != nil || claimed {
+		return claim, claimed, err
+	}
+	cloudID := strings.TrimSpace(identifier)
+	if strings.HasSuffix(cloudID, ".exe.xyz") {
+		cloudID = strings.TrimSuffix(cloudID, ".exe.xyz")
+	}
+	return resolveLeaseClaimForProviderCloudID(cloudID, providerName)
+}
+
+func (b *exeDevLeaseBackend) validateAbsentCleanupClaim(ctx context.Context, claim LeaseClaim) error {
+	slug := normalizeLeaseSlug(claim.Slug)
+	if !isCanonicalLeaseID(claim.LeaseID) || claim.Provider != providerName || slug == "" || claim.CloudID != leaseProviderName(claim.LeaseID, slug) {
+		return exit(2, "lease %s has no exact exe.dev resource binding for absent cleanup", claim.LeaseID)
+	}
+	if claim.Labels["provider"] != providerName || claim.Labels["lease"] != claim.LeaseID || normalizeLeaseSlug(claim.Labels["slug"]) != slug || claim.Labels["name"] != claim.CloudID {
+		return exit(2, "lease %s claim metadata does not attest absent exe.dev cleanup", claim.LeaseID)
+	}
+	return b.validateExistingClaimRoute(ctx, claim)
+}
+
+func (b *exeDevLeaseBackend) confirmClaimedVMAbsent(ctx context.Context, claim LeaseClaim) error {
+	if err := b.validateAbsentCleanupClaim(ctx, claim); err != nil {
+		return err
+	}
+	vms, err := b.listVMs(ctx, true)
+	if err != nil {
+		return err
+	}
+	for _, vm := range vms {
+		if vm.Name() == claim.CloudID {
+			return exit(2, "exe.dev VM %s is present; refusing absent-claim cleanup", claim.CloudID)
+		}
+	}
+	return nil
 }
 
 func (b *exeDevLeaseBackend) RefreshReleaseLeaseTarget(ctx context.Context, lease LeaseTarget) (LeaseTarget, error) {

--- a/internal/providers/exedev/backend.go
+++ b/internal/providers/exedev/backend.go
@@ -22,8 +22,9 @@ type exeDevLeaseBackend struct {
 }
 
 const (
-	exeDevClaimGenerationLabel = "claim_generation"
-	exeDevConfirmedAbsentLabel = "exe_dev_confirmed_absent"
+	exeDevClaimGenerationLabel     = "claim_generation"
+	exeDevClaimGenerationTagPrefix = "crabbox-claim-"
+	exeDevConfirmedAbsentLabel     = "exe_dev_confirmed_absent"
 )
 
 func NewExeDevLeaseBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
@@ -46,8 +47,9 @@ func (b *exeDevLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (L
 	}
 	cfg := b.configForRun()
 	name := leaseProviderName(leaseID, slug)
+	generation := newLeaseID()
 	fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s name=%s image=%s cpus=%d memory=%s disk=%s keep=%v\n", providerName, leaseID, slug, name, exeDevImage(cfg), cfg.ExeDev.CPUs, cfg.ExeDev.Memory, cfg.ExeDev.Disk, req.Keep)
-	vm, err := b.createVM(ctx, cfg, name, leaseID, slug)
+	vm, err := b.createVM(ctx, cfg, name, leaseID, slug, generation)
 	if err != nil {
 		return LeaseTarget{}, err
 	}
@@ -65,7 +67,7 @@ func (b *exeDevLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (L
 		}
 		return LeaseTarget{}, err
 	}
-	lease.Server.Labels[exeDevClaimGenerationLabel] = newLeaseID()
+	lease.Server.Labels[exeDevClaimGenerationLabel] = generation
 	claim, err := claimLeaseTargetForRepoConfigScopeIfUnchanged(leaseID, slug, cfg, providerScope, lease.Server, lease.SSH, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, LeaseClaim{}, false)
 	if err != nil {
 		if !req.Keep {
@@ -145,6 +147,9 @@ func (b *exeDevLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseR
 		if err := b.validateVMClaimBinding(ctx, vm, claim, claim.LeaseID, claim.Slug); err != nil {
 			return err
 		}
+		// exe.dev exposes only name-based deletion. The account-bound random
+		// generation tag is the strongest provider-visible resource identity;
+		// actors able to replace it also already hold unconditional `rm` access.
 		return b.deleteVM(ctx, claim.CloudID)
 	})
 }
@@ -223,6 +228,9 @@ func (b *exeDevLeaseBackend) validateAbsentCleanupClaim(ctx context.Context, cla
 	}
 	if claim.Labels["provider"] != providerName || claim.Labels["lease"] != claim.LeaseID || normalizeLeaseSlug(claim.Labels["slug"]) != slug || claim.Labels["name"] != claim.CloudID {
 		return exit(2, "lease %s claim metadata does not attest absent exe.dev cleanup", claim.LeaseID)
+	}
+	if !isCanonicalLeaseID(strings.TrimSpace(claim.Labels[exeDevClaimGenerationLabel])) {
+		return exit(2, "lease %s has no canonical exe.dev claim generation for absent cleanup", claim.LeaseID)
 	}
 	return b.validateExistingClaimRoute(ctx, claim)
 }
@@ -356,8 +364,8 @@ func applyExeDevDefaults(cfg *Config) {
 	cfg.ServerType = exeDevImage(*cfg)
 }
 
-func (b *exeDevLeaseBackend) createVM(ctx context.Context, cfg Config, name, leaseID, slug string) (exeDevVM, error) {
-	args := []string{"new", "--name", name, "--json", "--tag", "crabbox", "--tag", "crabbox-lease-" + leaseID, "--tag", "crabbox-slug-" + slug}
+func (b *exeDevLeaseBackend) createVM(ctx context.Context, cfg Config, name, leaseID, slug, generation string) (exeDevVM, error) {
+	args := []string{"new", "--name", name, "--json", "--tag", "crabbox", "--tag", "crabbox-lease-" + leaseID, "--tag", "crabbox-slug-" + slug, "--tag", exeDevClaimGenerationTagPrefix + generation}
 	if cfg.ExeDev.NoEmail {
 		args = append(args, "--no-email")
 	}
@@ -449,6 +457,14 @@ func (b *exeDevLeaseBackend) claimResolvedVM(ctx context.Context, lease LeaseTar
 	if err != nil {
 		return LeaseClaim{}, err
 	}
+	if req.Reclaim {
+		return updateLeaseClaimLabelsIfUnchangedAfter(leaseID, claim, claim.Labels, func() error {
+			return b.replaceVMClaimGeneration(ctx, vm, generation)
+		})
+	}
+	if err := validateExeDevClaimGeneration(vm, generation); err != nil {
+		return LeaseClaim{}, err
+	}
 	return claim, nil
 }
 
@@ -505,7 +521,62 @@ func (b *exeDevLeaseBackend) validateVMClaimBinding(ctx context.Context, vm exeD
 	if claim.Labels["provider"] != providerName || claim.Labels["lease"] != leaseID || normalizeLeaseSlug(claim.Labels["slug"]) != slug || claim.Labels["name"] != vm.Name() {
 		return exit(2, "exe.dev VM %s claim metadata does not attest the current provider binding", vm.Name())
 	}
+	return validateExeDevClaimGeneration(vm, claim.Labels[exeDevClaimGenerationLabel])
+}
+
+func validateExeDevClaimGeneration(vm exeDevVM, expected string) error {
+	expected = strings.TrimSpace(expected)
+	if !isCanonicalLeaseID(expected) {
+		return exit(2, "exe.dev VM %s has no canonical claim generation; reuse with --reclaim before operating on it", vm.Name())
+	}
+	actual, exists, err := exeDevVMClaimGeneration(vm)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return exit(2, "exe.dev VM %s has no remote claim generation; reuse with --reclaim before operating on it", vm.Name())
+	}
+	if actual != expected {
+		return exit(2, "exe.dev VM %s claim generation does not match the exact local claim", vm.Name())
+	}
 	return nil
+}
+
+func (b *exeDevLeaseBackend) replaceVMClaimGeneration(ctx context.Context, vm exeDevVM, generation string) error {
+	if !isCanonicalLeaseID(generation) {
+		return exit(2, "invalid exe.dev claim generation")
+	}
+	want := exeDevClaimGenerationTagPrefix + generation
+	existing := exeDevClaimGenerationTags(vm)
+	hasWant := false
+	for _, tag := range existing {
+		if tag == want {
+			hasWant = true
+		}
+	}
+	if !hasWant {
+		if _, err := b.controlOutput(ctx, []string{"tag", vm.Name(), want, "--json"}); err != nil {
+			return err
+		}
+	}
+	remove := make([]string, 0, len(existing))
+	for _, tag := range existing {
+		if tag != want {
+			remove = append(remove, tag)
+		}
+	}
+	if len(remove) > 0 {
+		args := append([]string{"tag", "-d", vm.Name()}, remove...)
+		args = append(args, "--json")
+		if _, err := b.controlOutput(ctx, args); err != nil {
+			return err
+		}
+	}
+	current, err := b.findVMByExactName(ctx, vm.Name())
+	if err != nil {
+		return err
+	}
+	return validateExeDevClaimGeneration(current, generation)
 }
 
 func validateExeDevVMOwnership(vm exeDevVM, leaseID, slug, operation string) error {
@@ -648,6 +719,9 @@ func (b *exeDevLeaseBackend) listServers(ctx context.Context, all bool) ([]Lease
 		if !all {
 			_, _, owned, err := exeDevOwnershipIdentity(vm)
 			if err != nil || !owned {
+				continue
+			}
+			if _, _, err := exeDevVMClaimGeneration(vm); err != nil {
 				continue
 			}
 		}
@@ -1008,6 +1082,32 @@ func exeDevOwnershipIdentity(vm exeDevVM) (string, string, bool, error) {
 		slug = value
 	}
 	return leaseID, slug, true, nil
+}
+
+func exeDevVMClaimGeneration(vm exeDevVM) (string, bool, error) {
+	tags := exeDevClaimGenerationTags(vm)
+	if len(tags) > 1 {
+		return "", false, exit(2, "exe.dev VM %s has conflicting claim-generation tags", vm.Name())
+	}
+	if len(tags) == 0 {
+		return "", false, nil
+	}
+	generation := strings.TrimSpace(strings.TrimPrefix(tags[0], exeDevClaimGenerationTagPrefix))
+	if !isCanonicalLeaseID(generation) {
+		return "", false, exit(2, "exe.dev VM %s has an invalid claim-generation tag", vm.Name())
+	}
+	return generation, true, nil
+}
+
+func exeDevClaimGenerationTags(vm exeDevVM) []string {
+	var tags []string
+	for _, tag := range vm.Tags {
+		tag = strings.TrimSpace(tag)
+		if strings.HasPrefix(tag, exeDevClaimGenerationTagPrefix) {
+			tags = append(tags, tag)
+		}
+	}
+	return tags
 }
 
 func inferExeDevSlugFromName(name string) string {

--- a/internal/providers/exedev/backend.go
+++ b/internal/providers/exedev/backend.go
@@ -597,7 +597,7 @@ func (b *exeDevLeaseBackend) replaceVMClaimGeneration(ctx context.Context, vm ex
 		}
 	}
 	if !hasWant {
-		if _, err := b.controlOutput(ctx, []string{"tag", vm.Name(), want, "--json"}); err != nil {
+		if _, err := b.controlOutput(ctx, []string{"tag", "--json", vm.Name(), want}); err != nil {
 			return err
 		}
 	}
@@ -608,8 +608,9 @@ func (b *exeDevLeaseBackend) replaceVMClaimGeneration(ctx context.Context, vm ex
 		}
 	}
 	if len(remove) > 0 {
-		args := append([]string{"tag", "-d", vm.Name()}, remove...)
-		args = append(args, "--json")
+		// exe.dev's tag command accepts multiple positional tags, so options
+		// must precede the VM name or they are parsed as tag names.
+		args := append([]string{"tag", "--json", "-d", vm.Name()}, remove...)
 		if _, err := b.controlOutput(ctx, args); err != nil {
 			return err
 		}

--- a/internal/providers/exedev/backend.go
+++ b/internal/providers/exedev/backend.go
@@ -37,7 +37,7 @@ func (b *exeDevLeaseBackend) Spec() ProviderSpec { return b.spec }
 
 func (b *exeDevLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
 	leaseID := newLeaseID()
-	servers, err := b.listServers(ctx, true)
+	servers, err := b.listServers(ctx, false)
 	if err != nil {
 		return LeaseTarget{}, err
 	}
@@ -217,7 +217,7 @@ func (b *exeDevLeaseBackend) resolveReleaseTarget(ctx context.Context, cfg Confi
 	if err := b.validateAbsentCleanupClaim(ctx, claim); err != nil {
 		return LeaseTarget{}, err
 	}
-	vms, err := b.listVMs(ctx, true)
+	vms, err := b.listVMs(ctx, false)
 	if err != nil {
 		return LeaseTarget{}, err
 	}
@@ -281,7 +281,7 @@ func (b *exeDevLeaseBackend) confirmClaimedVMAbsent(ctx context.Context, claim L
 	if err := b.validateAbsentCleanupClaim(ctx, claim); err != nil {
 		return err
 	}
-	vms, err := b.listVMs(ctx, true)
+	vms, err := b.listVMs(ctx, false)
 	if err != nil {
 		return err
 	}
@@ -557,6 +557,14 @@ func (b *exeDevLeaseBackend) validateVMClaimBinding(ctx context.Context, vm exeD
 	if claim.LeaseID != leaseID || claim.Provider != providerName || normalizeLeaseSlug(claim.Slug) != slug || claim.CloudID != vm.Name() {
 		return exit(2, "exe.dev VM %s is not bound to an exact provider/resource claim", vm.Name())
 	}
+	target := exeDevSSHTarget(b.configForRun(), vm)
+	port, err := strconv.Atoi(strings.TrimSpace(target.Port))
+	if err != nil || port <= 0 || strings.TrimSpace(target.Host) == "" {
+		return exit(2, "exe.dev VM %s has an invalid SSH endpoint", vm.Name())
+	}
+	if strings.TrimSpace(claim.SSHHost) != strings.TrimSpace(target.Host) || claim.SSHPort != port {
+		return exit(2, "exe.dev VM %s SSH endpoint does not match the exact local claim", vm.Name())
+	}
 	if err := b.validateExistingClaimRoute(ctx, claim); err != nil {
 		return err
 	}
@@ -707,7 +715,7 @@ func (b *exeDevLeaseBackend) resolveVM(ctx context.Context, identifier string) (
 }
 
 func (b *exeDevLeaseBackend) findVM(ctx context.Context, identifier string) (exeDevVM, error) {
-	vms, err := b.listVMs(ctx, true)
+	vms, err := b.listVMs(ctx, false)
 	if err != nil {
 		return exeDevVM{}, err
 	}
@@ -721,7 +729,7 @@ func (b *exeDevLeaseBackend) findVM(ctx context.Context, identifier string) (exe
 }
 
 func (b *exeDevLeaseBackend) findVMByExactName(ctx context.Context, name string) (exeDevVM, error) {
-	vms, err := b.listVMs(ctx, true)
+	vms, err := b.listVMs(ctx, false)
 	if err != nil {
 		return exeDevVM{}, err
 	}
@@ -734,14 +742,17 @@ func (b *exeDevLeaseBackend) findVMByExactName(ctx context.Context, name string)
 }
 
 func (b *exeDevLeaseBackend) findVMByLeaseID(ctx context.Context, leaseID string) (exeDevVM, bool, error) {
-	vms, err := b.listVMs(ctx, true)
+	vms, err := b.listVMs(ctx, false)
 	if err != nil {
 		return exeDevVM{}, false, err
 	}
 	for _, vm := range vms {
 		taggedLeaseID, _, owned, err := exeDevOwnershipIdentity(vm)
 		if err != nil {
-			return exeDevVM{}, false, err
+			if exeDevVMReferencesLease(vm, leaseID) {
+				return exeDevVM{}, false, err
+			}
+			continue
 		}
 		if owned && taggedLeaseID == leaseID {
 			return vm, true, nil
@@ -796,8 +807,11 @@ func fallbackExeDevIdentity(vm exeDevVM) (string, string) {
 	return leaseID, slug
 }
 
-func (b *exeDevLeaseBackend) listVMs(ctx context.Context, _ bool) ([]exeDevVM, error) {
+func (b *exeDevLeaseBackend) listVMs(ctx context.Context, all bool) ([]exeDevVM, error) {
 	args := []string{"ls", "--l", "--json"}
+	if all {
+		args = append(args, "-a")
+	}
 	out, err := b.controlOutput(ctx, args)
 	if err != nil {
 		return nil, err

--- a/internal/providers/exedev/backend.go
+++ b/internal/providers/exedev/backend.go
@@ -2,6 +2,8 @@ package exedev
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -53,7 +55,7 @@ func (b *exeDevLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (L
 		}
 		return LeaseTarget{}, err
 	}
-	providerScope, err := exeDevControlScope(cfg)
+	providerScope, err := b.controlScope(ctx)
 	if err != nil {
 		if !req.Keep {
 			err = b.rollbackCreatedVM(name, err)
@@ -81,7 +83,7 @@ func (b *exeDevLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (L
 	}
 	if req.ReleaseOnly {
 		server := exeDevServer(vm, leaseID, slug, cfg, true)
-		claim, err := b.claimForVMRelease(vm, leaseID, slug)
+		claim, err := b.claimForVMRelease(ctx, vm, leaseID, slug)
 		if err != nil {
 			return LeaseTarget{}, err
 		}
@@ -93,7 +95,7 @@ func (b *exeDevLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (L
 		return LeaseTarget{}, err
 	}
 	if req.Repo.Root != "" {
-		claim, err := b.claimResolvedVM(lease, vm, leaseID, slug, req)
+		claim, err := b.claimResolvedVM(ctx, lease, vm, leaseID, slug, req)
 		if err != nil {
 			return LeaseTarget{}, err
 		}
@@ -102,7 +104,7 @@ func (b *exeDevLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (L
 		return LeaseTarget{}, err
 	} else {
 		if exists {
-			if err := b.validateVMClaimBinding(vm, claim, leaseID, slug); err != nil {
+			if err := b.validateVMClaimBinding(ctx, vm, claim, leaseID, slug); err != nil {
 				return LeaseTarget{}, err
 			}
 		} else if !req.IsReadOnlyStatus() {
@@ -138,7 +140,7 @@ func (b *exeDevLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseR
 		if err != nil {
 			return err
 		}
-		if err := b.validateVMClaimBinding(vm, claim, claim.LeaseID, claim.Slug); err != nil {
+		if err := b.validateVMClaimBinding(ctx, vm, claim, claim.LeaseID, claim.Slug); err != nil {
 			return err
 		}
 		return b.deleteVM(ctx, claim.CloudID)
@@ -288,7 +290,7 @@ func (b *exeDevLeaseBackend) deleteVM(ctx context.Context, name string) error {
 	return nil
 }
 
-func (b *exeDevLeaseBackend) claimResolvedVM(lease LeaseTarget, vm exeDevVM, leaseID, slug string, req ResolveRequest) (LeaseClaim, error) {
+func (b *exeDevLeaseBackend) claimResolvedVM(ctx context.Context, lease LeaseTarget, vm exeDevVM, leaseID, slug string, req ResolveRequest) (LeaseClaim, error) {
 	if err := b.validateResolvedLeaseTarget(lease, vm, leaseID, slug); err != nil {
 		return LeaseClaim{}, err
 	}
@@ -316,13 +318,13 @@ func (b *exeDevLeaseBackend) claimResolvedVM(lease LeaseTarget, vm exeDevVM, lea
 			return LeaseClaim{}, exit(2, "lease %s has a legacy unscoped claim; reuse with --reclaim to bind the exe.dev control route", leaseID)
 		}
 		if previous.ProviderScope != "" {
-			if err := b.validateExistingClaimRoute(previous); err != nil {
+			if err := b.validateExistingClaimRoute(ctx, previous); err != nil {
 				return LeaseClaim{}, err
 			}
 		}
 	}
 	cfg := b.configForRun()
-	providerScope, err := exeDevControlScope(cfg)
+	providerScope, err := b.controlScope(ctx)
 	if err != nil {
 		return LeaseClaim{}, err
 	}
@@ -358,7 +360,7 @@ func (b *exeDevLeaseBackend) validateResolvedLeaseTarget(lease LeaseTarget, vm e
 	return nil
 }
 
-func (b *exeDevLeaseBackend) claimForVMRelease(vm exeDevVM, leaseID, slug string) (LeaseClaim, error) {
+func (b *exeDevLeaseBackend) claimForVMRelease(ctx context.Context, vm exeDevVM, leaseID, slug string) (LeaseClaim, error) {
 	claim, exists, err := readLeaseClaimWithPresence(leaseID)
 	if err != nil {
 		return LeaseClaim{}, err
@@ -366,14 +368,14 @@ func (b *exeDevLeaseBackend) claimForVMRelease(vm exeDevVM, leaseID, slug string
 	if !exists {
 		return LeaseClaim{}, exit(2, "exe.dev VM %s has no exact local claim; refusing deletion", vm.Name())
 	}
-	if err := b.validateVMClaimBinding(vm, claim, leaseID, slug); err != nil {
+	if err := b.validateVMClaimBinding(ctx, vm, claim, leaseID, slug); err != nil {
 		return LeaseClaim{}, err
 	}
 	return claim, nil
 }
 
-func (b *exeDevLeaseBackend) validateExistingClaimRoute(claim LeaseClaim) error {
-	want, err := exeDevControlScope(b.configForRun())
+func (b *exeDevLeaseBackend) validateExistingClaimRoute(ctx context.Context, claim LeaseClaim) error {
+	want, err := b.controlScope(ctx)
 	if err != nil {
 		return err
 	}
@@ -383,7 +385,7 @@ func (b *exeDevLeaseBackend) validateExistingClaimRoute(claim LeaseClaim) error 
 	return nil
 }
 
-func (b *exeDevLeaseBackend) validateVMClaimBinding(vm exeDevVM, claim LeaseClaim, leaseID, slug string) error {
+func (b *exeDevLeaseBackend) validateVMClaimBinding(ctx context.Context, vm exeDevVM, claim LeaseClaim, leaseID, slug string) error {
 	if err := validateExeDevVMOwnership(vm, leaseID, slug, "deletion"); err != nil {
 		return err
 	}
@@ -391,7 +393,7 @@ func (b *exeDevLeaseBackend) validateVMClaimBinding(vm exeDevVM, claim LeaseClai
 	if claim.LeaseID != leaseID || claim.Provider != providerName || normalizeLeaseSlug(claim.Slug) != slug || claim.CloudID != vm.Name() {
 		return exit(2, "exe.dev VM %s is not bound to an exact provider/resource claim", vm.Name())
 	}
-	if err := b.validateExistingClaimRoute(claim); err != nil {
+	if err := b.validateExistingClaimRoute(ctx, claim); err != nil {
 		return err
 	}
 	if claim.Labels["provider"] != providerName || claim.Labels["lease"] != leaseID || normalizeLeaseSlug(claim.Labels["slug"]) != slug || claim.Labels["name"] != vm.Name() {
@@ -426,7 +428,10 @@ func (b *exeDevLeaseBackend) validateReleaseTarget(lease LeaseTarget, claim Leas
 	if lease.Server.Labels["lease"] != claim.LeaseID || normalizeLeaseSlug(lease.Server.Labels["slug"]) != normalizeLeaseSlug(claim.Slug) {
 		return exit(2, "provider=%s release labels do not match their claim snapshot", providerName)
 	}
-	return b.validateExistingClaimRoute(claim)
+	if strings.TrimSpace(claim.ProviderScope) == "" {
+		return exit(2, "lease %s has no exe.dev account-bound control scope", claim.LeaseID)
+	}
+	return nil
 }
 
 func (b *exeDevLeaseBackend) prepareLease(ctx context.Context, cfg Config, vm exeDevVM, leaseID, slug string, keep, wait bool) (LeaseTarget, error) {
@@ -536,20 +541,37 @@ func (b *exeDevLeaseBackend) listServers(ctx context.Context, all bool) ([]Lease
 	for _, vm := range vms {
 		if !all {
 			_, _, owned, err := exeDevOwnershipIdentity(vm)
-			if err != nil {
-				return nil, err
-			}
-			if !owned {
+			if err != nil || !owned {
 				continue
 			}
 		}
-		leaseID, slug, err := b.leaseIdentityForVM(vm)
+		leaseID, slug, err := b.leaseIdentityForInventoryVM(vm)
 		if err != nil {
 			return nil, err
 		}
 		servers = append(servers, exeDevServer(vm, leaseID, slug, cfg, true))
 	}
 	return servers, nil
+}
+
+func (b *exeDevLeaseBackend) leaseIdentityForInventoryVM(vm exeDevVM) (string, string, error) {
+	leaseID, slug, err := b.leaseIdentityForVM(vm)
+	if err == nil {
+		return leaseID, slug, nil
+	}
+	// Bulk inventory remains the recovery surface for malformed ownership tags.
+	// Exact reuse and deletion still use leaseIdentityForVM and fail closed.
+	leaseID, slug = fallbackExeDevIdentity(vm)
+	return leaseID, slug, nil
+}
+
+func fallbackExeDevIdentity(vm exeDevVM) (string, string) {
+	slug := normalizeLeaseSlug(vm.Name())
+	leaseID := "exe_" + slug
+	if strings.HasPrefix(slug, "crabbox-") {
+		leaseID = "exe_" + strings.TrimPrefix(slug, "crabbox-")
+	}
+	return leaseID, slug
 }
 
 func (b *exeDevLeaseBackend) listVMs(ctx context.Context, _ bool) ([]exeDevVM, error) {
@@ -717,12 +739,39 @@ func commandExitCode(result LocalCommandResult) int {
 	return 1
 }
 
-func exeDevControlScope(cfg Config) (string, error) {
+func (b *exeDevLeaseBackend) controlScope(ctx context.Context) (string, error) {
+	out, err := b.controlOutput(ctx, []string{"whoami", "--json"})
+	if err != nil {
+		return "", err
+	}
+	var identity struct {
+		Email string `json:"email"`
+	}
+	if err := json.Unmarshal([]byte(out), &identity); err != nil {
+		return "", exit(5, "exe.dev whoami returned invalid JSON: %v", err)
+	}
+	email := strings.ToLower(strings.TrimSpace(identity.Email))
+	if email == "" {
+		return "", exit(5, "exe.dev whoami returned no account identity")
+	}
+	return exeDevControlScope(b.configForRun(), exeDevAccountFingerprint(email))
+}
+
+func exeDevAccountFingerprint(email string) string {
+	sum := sha256.Sum256([]byte(strings.ToLower(strings.TrimSpace(email))))
+	return hex.EncodeToString(sum[:])
+}
+
+func exeDevControlScope(cfg Config, accountFingerprint string) (string, error) {
 	destination, port, err := exeDevControlDestination(cfg.ExeDev.ControlHost)
 	if err != nil {
 		return "", err
 	}
-	return "ssh:" + destination + "|port:" + blank(port, "default"), nil
+	accountFingerprint = strings.TrimSpace(accountFingerprint)
+	if accountFingerprint == "" {
+		return "", exit(2, "exe.dev account fingerprint is empty")
+	}
+	return "ssh:" + destination + "|port:" + blank(port, "default") + "|account:sha256:" + accountFingerprint, nil
 }
 
 func exeDevServer(vm exeDevVM, leaseID, slug string, cfg Config, keep bool) Server {
@@ -809,11 +858,7 @@ func (b *exeDevLeaseBackend) leaseIdentityForVM(vm exeDevVM) (string, string, er
 			}
 		}
 	}
-	slug := normalizeLeaseSlug(vm.Name())
-	leaseID := "exe_" + slug
-	if strings.HasPrefix(slug, "crabbox-") {
-		leaseID = "exe_" + strings.TrimPrefix(slug, "crabbox-")
-	}
+	leaseID, slug := fallbackExeDevIdentity(vm)
 	return leaseID, slug, nil
 }
 

--- a/internal/providers/exedev/backend_test.go
+++ b/internal/providers/exedev/backend_test.go
@@ -472,6 +472,8 @@ func TestExeDevReleaseSurvivesTouchedClaimRoundTrip(t *testing.T) {
 		LeaseID: leaseID,
 		Server:  exeDevServer(vm, leaseID, slug, cfg, true),
 	}
+	lease.Server.Labels[exeDevClaimGenerationLabel] = claim.Labels[exeDevClaimGenerationLabel]
+	setServerLeaseClaimSnapshot(&lease.Server, claim, true)
 	touched, err := backend.Touch(context.Background(), TouchRequest{Lease: lease, State: "ready"})
 	if err != nil {
 		t.Fatal(err)
@@ -483,7 +485,7 @@ func TestExeDevReleaseSurvivesTouchedClaimRoundTrip(t *testing.T) {
 	if claim.ProviderScope != mustExeDevControlScope(t, cfg) {
 		t.Fatalf("provider scope=%q", claim.ProviderScope)
 	}
-	resolved, err := backend.Resolve(context.Background(), ResolveRequest{ID: vm.Name(), ReleaseOnly: true})
+	resolved, err := backend.RefreshReleaseLeaseTarget(context.Background(), lease)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -493,6 +495,54 @@ func TestExeDevReleaseSurvivesTouchedClaimRoundTrip(t *testing.T) {
 	if !hasExeDevRM(runner) {
 		t.Fatalf("rm not called: %#v", runner.calls)
 	}
+}
+
+func TestExeDevReleaseRefreshRejectsConcurrentReclaim(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	leaseID := "cbx_abcdef123456"
+	slug := "blue"
+	vm := ownedExeDevVM(leaseID, slug)
+	runner := exeDevInventoryRunner(t, vm)
+	backend := newExeDevTestBackend(Config{}, runner)
+	cfg := backend.configForRun()
+	repoRoot := t.TempDir()
+	claim := persistExeDevClaim(t, cfg, vm, leaseID, slug, repoRoot)
+	lease := LeaseTarget{LeaseID: leaseID, Server: exeDevServer(vm, leaseID, slug, cfg, true)}
+	setServerLeaseClaimSnapshot(&lease.Server, claim, true)
+
+	reclaimed, err := backend.Resolve(context.Background(), ResolveRequest{ID: vm.Name(), Repo: Repo{Root: repoRoot}, Reclaim: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	reclaimedClaim, reclaimedExists, reclaimedSet := serverLeaseClaimSnapshot(reclaimed.Server)
+	if !reclaimedSet || !reclaimedExists || reclaimedClaim.Labels[exeDevClaimGenerationLabel] == claim.Labels[exeDevClaimGenerationLabel] {
+		t.Fatalf("reclaimed generation=%q, want rotation from %q", reclaimedClaim.Labels[exeDevClaimGenerationLabel], claim.Labels[exeDevClaimGenerationLabel])
+	}
+	if _, err := backend.RefreshReleaseLeaseTarget(context.Background(), lease); err == nil || !strings.Contains(err.Error(), "claim ownership changed") {
+		t.Fatalf("err=%v, want changed-ownership refusal", err)
+	}
+	assertNoExeDevRM(t, runner)
+}
+
+func TestExeDevReleaseRefreshTreatsMissingClaimAsOwnershipChange(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	leaseID := "cbx_abcdef123456"
+	slug := "blue"
+	vm := ownedExeDevVM(leaseID, slug)
+	runner := exeDevInventoryRunner(t, vm)
+	backend := newExeDevTestBackend(Config{}, runner)
+	claim := persistExeDevClaim(t, backend.configForRun(), vm, leaseID, slug, t.TempDir())
+	lease := LeaseTarget{LeaseID: leaseID, Server: exeDevServer(vm, leaseID, slug, backend.configForRun(), true)}
+	setServerLeaseClaimSnapshot(&lease.Server, claim, true)
+	if err := removeLeaseClaimIfUnchangedAfter(leaseID, claim, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := backend.RefreshReleaseLeaseTarget(context.Background(), lease)
+	if !errors.Is(err, errReleaseLeaseOwnershipChanged) {
+		t.Fatalf("err=%v, want ownership-change sentinel", err)
+	}
+	assertNoExeDevRM(t, runner)
 }
 
 func TestExeDevReleaseRetainsClaimWhenDeleteFails(t *testing.T) {
@@ -606,7 +656,9 @@ func newExeDevTestBackend(cfg Config, runner *exeDevRecordingRunner) *exeDevLeas
 
 func persistExeDevClaim(t *testing.T, cfg Config, vm exeDevVM, leaseID, slug, repoRoot string) LeaseClaim {
 	t.Helper()
-	claim, err := claimLeaseTargetForRepoConfigScopeIfUnchanged(leaseID, slug, cfg, mustExeDevControlScope(t, cfg), exeDevServer(vm, leaseID, slug, cfg, true), exeDevSSHTarget(cfg, vm), repoRoot, cfg.IdleTimeout, false, LeaseClaim{}, false)
+	server := exeDevServer(vm, leaseID, slug, cfg, true)
+	server.Labels[exeDevClaimGenerationLabel] = "cbx_testgeneration"
+	claim, err := claimLeaseTargetForRepoConfigScopeIfUnchanged(leaseID, slug, cfg, mustExeDevControlScope(t, cfg), server, exeDevSSHTarget(cfg, vm), repoRoot, cfg.IdleTimeout, false, LeaseClaim{}, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/providers/exedev/backend_test.go
+++ b/internal/providers/exedev/backend_test.go
@@ -2,6 +2,7 @@ package exedev
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"io"
@@ -27,11 +28,10 @@ func (r *exeDevRecordingRunner) Run(_ context.Context, req LocalCommandRequest) 
 func TestExeDevListFiltersCrabboxVMsByDefault(t *testing.T) {
 	runner := &exeDevRecordingRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
 		base := []string{"-o", "BatchMode=yes", "-o", "StrictHostKeyChecking=accept-new", "-o", "ConnectTimeout=10", "exe.dev", "ls --l --json"}
-		all := []string{"-o", "BatchMode=yes", "-o", "StrictHostKeyChecking=accept-new", "-o", "ConnectTimeout=10", "exe.dev", "ls --l --json --a"}
-		if !reflect.DeepEqual(req.Args, base) && !reflect.DeepEqual(req.Args, all) {
+		if !reflect.DeepEqual(req.Args, base) {
 			t.Fatalf("args=%v", req.Args)
 		}
-		return LocalCommandResult{Stdout: `{"vms":[{"vm_name":"crabbox-blue-12345678","ssh_dest":"crabbox-blue-12345678.exe.xyz","status":"running"},{"vm_name":"manual-box","ssh_dest":"manual-box.exe.xyz","status":"running"}]}`}, nil
+		return LocalCommandResult{Stdout: `{"vms":[{"vm_name":"crabbox-blue-12345678","ssh_dest":"crabbox-blue-12345678.exe.xyz","status":"running","tags":["crabbox","crabbox-lease-cbx_abcdef123456","crabbox-slug-blue"]},{"vm_name":"crabbox-manual-12345678","ssh_dest":"crabbox-manual-12345678.exe.xyz","status":"running"}]}`}, nil
 	}}
 	backend := &exeDevLeaseBackend{cfg: Config{}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
 	views, err := backend.List(context.Background(), ListRequest{})
@@ -59,7 +59,7 @@ func TestExeDevDoctorListsInventory(t *testing.T) {
 		if strings.Contains(got, " new ") || strings.Contains(got, " rm ") {
 			t.Fatalf("doctor used mutating command: %v", req.Args)
 		}
-		return LocalCommandResult{Stdout: `{"vms":[{"vm_name":"crabbox-blue-12345678","ssh_dest":"crabbox-blue-12345678.exe.xyz","status":"running"}]}`}, nil
+		return LocalCommandResult{Stdout: `{"vms":[{"vm_name":"crabbox-blue-12345678","ssh_dest":"crabbox-blue-12345678.exe.xyz","status":"running","tags":["crabbox","crabbox-lease-cbx_abcdef123456","crabbox-slug-blue"]}]}`}, nil
 	}}
 	doctor, err := Provider{}.ConfigureDoctor(Config{}, Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner})
 	if err != nil {
@@ -135,11 +135,11 @@ func TestExeDevAcquireReportsRollbackFailureAfterClaimFailure(t *testing.T) {
 		return nil
 	}
 	t.Cleanup(func() { waitForSSHReady = oldWait })
-	oldClaim := claimLeaseForRepoProvider
-	claimLeaseForRepoProvider = func(string, string, string, string, time.Duration, bool) error {
-		return primaryErr
+	oldClaim := claimLeaseTargetForRepoConfigIfUnchanged
+	claimLeaseTargetForRepoConfigIfUnchanged = func(string, string, Config, Server, SSHTarget, string, time.Duration, bool, LeaseClaim, bool) (LeaseClaim, error) {
+		return LeaseClaim{}, primaryErr
 	}
-	t.Cleanup(func() { claimLeaseForRepoProvider = oldClaim })
+	t.Cleanup(func() { claimLeaseTargetForRepoConfigIfUnchanged = oldClaim })
 	runner := newExeDevAcquireRollbackRunner()
 	backend := &exeDevLeaseBackend{cfg: Config{}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
 	_, err := backend.Acquire(context.Background(), AcquireRequest{Repo: Repo{Root: t.TempDir()}})
@@ -150,7 +150,7 @@ func newExeDevAcquireRollbackRunner() *exeDevRecordingRunner {
 	return &exeDevRecordingRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
 		cmd := strings.Join(req.Args, " ")
 		switch {
-		case strings.Contains(cmd, "ls --l --json --a"):
+		case strings.Contains(cmd, "ls --l --json"):
 			return LocalCommandResult{Stdout: `{"vms":[]}`}, nil
 		case strings.Contains(cmd, " new "):
 			return LocalCommandResult{Stdout: `{"vm_name":"created-vm","ssh_dest":"created-vm.exe.xyz","status":"running"}`}, nil
@@ -314,7 +314,10 @@ func TestExeDevResolveVMNameRecoversExistingClaim(t *testing.T) {
 	leaseID := "cbx_abcdef123456"
 	slug := "blue-lobster"
 	name := leaseProviderName(leaseID, slug)
-	if err := claimLeaseForRepoProvider(leaseID, slug, providerName, t.TempDir(), 0, false); err != nil {
+	cfg := Config{Provider: providerName}
+	applyExeDevDefaults(&cfg)
+	vm := exeDevVM{VMName: name, SSHDest: name + ".exe.xyz", Status: "running"}
+	if _, err := claimLeaseTargetForRepoConfigIfUnchanged(leaseID, slug, cfg, exeDevServer(vm, leaseID, slug, cfg, true), exeDevSSHTarget(cfg, vm), t.TempDir(), 0, false, LeaseClaim{}, false); err != nil {
 		t.Fatal(err)
 	}
 	runner := &exeDevRecordingRunner{fn: func(LocalCommandRequest) (LocalCommandResult, error) {
@@ -328,6 +331,265 @@ func TestExeDevResolveVMNameRecoversExistingClaim(t *testing.T) {
 	if gotLeaseID != leaseID || gotSlug != slug {
 		t.Fatalf("leaseID=%q slug=%q", gotLeaseID, gotSlug)
 	}
+}
+
+func TestExeDevReleaseRejectsUnclaimedRawIdentifiers(t *testing.T) {
+	vm := exeDevVM{VMName: "manual-box", SSHDest: "manual-box.exe.xyz", Status: "running"}
+	for _, identifier := range []string{vm.Name(), "manual box", vm.SSHHost()} {
+		t.Run(identifier, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			runner := exeDevInventoryRunner(t, vm)
+			backend := newExeDevTestBackend(Config{}, runner)
+			_, err := backend.Resolve(context.Background(), ResolveRequest{ID: identifier, ReleaseOnly: true})
+			if err == nil || !strings.Contains(err.Error(), "no exact local claim") {
+				t.Fatalf("err=%v, want exact local claim refusal", err)
+			}
+			assertNoExeDevRM(t, runner)
+		})
+	}
+}
+
+func TestExeDevReleaseRejectsTaggedVMWithoutLocalClaim(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	leaseID := "cbx_abcdef123456"
+	vm := ownedExeDevVM(leaseID, "blue")
+	runner := exeDevInventoryRunner(t, vm)
+	backend := newExeDevTestBackend(Config{}, runner)
+	_, err := backend.Resolve(context.Background(), ResolveRequest{ID: vm.Name(), ReleaseOnly: true})
+	if err == nil || !strings.Contains(err.Error(), "no exact local claim") {
+		t.Fatalf("err=%v, want exact local claim refusal", err)
+	}
+	assertNoExeDevRM(t, runner)
+}
+
+func TestExeDevReleaseRejectsClaimBoundToDifferentVM(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	leaseID := "cbx_abcdef123456"
+	vm := ownedExeDevVM(leaseID, "blue")
+	cfg := Config{Provider: providerName}
+	applyExeDevDefaults(&cfg)
+	other := vm
+	other.VMName = "crabbox-other-12345678"
+	persistExeDevClaim(t, cfg, other, leaseID, "blue", t.TempDir())
+	runner := exeDevInventoryRunner(t, vm)
+	backend := newExeDevTestBackend(cfg, runner)
+	_, err := backend.Resolve(context.Background(), ResolveRequest{ID: vm.Name(), ReleaseOnly: true})
+	if err == nil || !strings.Contains(err.Error(), "not bound to an exact provider/resource claim") {
+		t.Fatalf("err=%v, want exact resource binding refusal", err)
+	}
+	assertNoExeDevRM(t, runner)
+}
+
+func TestExeDevReleaseRequiresUnchangedClaimAndRemoteTags(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(t *testing.T, backend *exeDevLeaseBackend, runner *exeDevRecordingRunner, lease LeaseTarget, claim LeaseClaim, vm exeDevVM)
+		want   string
+	}{
+		{
+			name: "claim changed",
+			mutate: func(t *testing.T, backend *exeDevLeaseBackend, _ *exeDevRecordingRunner, lease LeaseTarget, claim LeaseClaim, vm exeDevVM) {
+				cfg := backend.configForRun()
+				if _, err := claimLeaseTargetForRepoConfigIfUnchanged(lease.LeaseID, claim.Slug, cfg, lease.Server, exeDevSSHTarget(cfg, vm), t.TempDir(), cfg.IdleTimeout, true, claim, true); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: "claim changed",
+		},
+		{
+			name: "control route changed",
+			mutate: func(_ *testing.T, backend *exeDevLeaseBackend, _ *exeDevRecordingRunner, _ LeaseTarget, _ LeaseClaim, _ exeDevVM) {
+				backend.cfg.ExeDev.ControlHost = "other.exe.dev"
+			},
+			want: "different exe.dev control route",
+		},
+		{
+			name: "remote tags removed",
+			mutate: func(t *testing.T, _ *exeDevLeaseBackend, runner *exeDevRecordingRunner, _ LeaseTarget, _ LeaseClaim, vm exeDevVM) {
+				vm.Tags = nil
+				runner.fn = exeDevInventoryResponse(t, vm)
+			},
+			want: "no complete Crabbox ownership tags",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			leaseID := "cbx_abcdef123456"
+			vm := ownedExeDevVM(leaseID, "blue")
+			runner := exeDevInventoryRunner(t, vm)
+			backend := newExeDevTestBackend(Config{}, runner)
+			claim := persistExeDevClaim(t, backend.configForRun(), vm, leaseID, "blue", t.TempDir())
+			lease, err := backend.Resolve(context.Background(), ResolveRequest{ID: vm.Name(), ReleaseOnly: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			test.mutate(t, backend, runner, lease, claim, vm)
+			err = backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease})
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("err=%v, want %q", err, test.want)
+			}
+			assertNoExeDevRM(t, runner)
+			if _, exists, readErr := readLeaseClaimWithPresence(leaseID); readErr != nil || !exists {
+				t.Fatalf("claim exists=%v err=%v, want retained", exists, readErr)
+			}
+		})
+	}
+}
+
+func TestExeDevReleaseDeletesExactlyClaimedVMAndRemovesClaim(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	leaseID := "cbx_abcdef123456"
+	vm := ownedExeDevVM(leaseID, "blue")
+	runner := exeDevInventoryRunner(t, vm)
+	backend := newExeDevTestBackend(Config{}, runner)
+	persistExeDevClaim(t, backend.configForRun(), vm, leaseID, "blue", t.TempDir())
+	lease, err := backend.Resolve(context.Background(), ResolveRequest{ID: vm.SSHHost(), ReleaseOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+	if !hasExeDevRM(runner) {
+		t.Fatalf("rm not called: %#v", runner.calls)
+	}
+	if _, exists, err := readLeaseClaimWithPresence(leaseID); err != nil || exists {
+		t.Fatalf("claim exists=%v err=%v, want removed", exists, err)
+	}
+}
+
+func TestExeDevReleaseRetainsClaimWhenDeleteFails(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	leaseID := "cbx_abcdef123456"
+	vm := ownedExeDevVM(leaseID, "blue")
+	runner := exeDevInventoryRunner(t, vm)
+	backend := newExeDevTestBackend(Config{}, runner)
+	persistExeDevClaim(t, backend.configForRun(), vm, leaseID, "blue", t.TempDir())
+	lease, err := backend.Resolve(context.Background(), ResolveRequest{ID: vm.Name(), ReleaseOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner.fn = func(req LocalCommandRequest) (LocalCommandResult, error) {
+		if strings.Contains(strings.Join(req.Args, " "), " rm ") {
+			return LocalCommandResult{ExitCode: 1}, errors.New("delete failed")
+		}
+		return exeDevInventoryResponse(t, vm)(req)
+	}
+	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err == nil || !strings.Contains(err.Error(), "delete failed") {
+		t.Fatalf("err=%v, want delete failure", err)
+	}
+	if _, exists, err := readLeaseClaimWithPresence(leaseID); err != nil || !exists {
+		t.Fatalf("claim exists=%v err=%v, want retained", exists, err)
+	}
+}
+
+func TestExeDevReuseRequiresExplicitAdoptionAndPersistsExactBinding(t *testing.T) {
+	leaseID := "cbx_abcdef123456"
+	vm := ownedExeDevVM(leaseID, "blue")
+	for _, reclaim := range []bool{false, true} {
+		t.Run(map[bool]string{false: "implicit refused", true: "explicit adopted"}[reclaim], func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			runner := exeDevInventoryRunner(t, vm)
+			backend := newExeDevTestBackend(Config{}, runner)
+			lease, err := backend.Resolve(context.Background(), ResolveRequest{ID: vm.Name(), Repo: Repo{Root: t.TempDir()}, Reclaim: reclaim})
+			if !reclaim {
+				if err == nil || !strings.Contains(err.Error(), "reuse with --reclaim") {
+					t.Fatalf("err=%v, want explicit reclaim refusal", err)
+				}
+				if _, exists, readErr := readLeaseClaimWithPresence(leaseID); readErr != nil || exists {
+					t.Fatalf("claim exists=%v err=%v, want absent", exists, readErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			claim, exists, readErr := readLeaseClaimWithPresence(leaseID)
+			if readErr != nil || !exists {
+				t.Fatalf("claim exists=%v err=%v", exists, readErr)
+			}
+			if claim.CloudID != vm.Name() || claim.Provider != providerName || claim.Labels[exeDevControlScopeLabel] == "" {
+				t.Fatalf("claim=%#v", claim)
+			}
+			if _, exists, snapshotSet := serverLeaseClaimSnapshot(lease.Server); !snapshotSet || !exists {
+				t.Fatalf("claim snapshot set=%v exists=%v", snapshotSet, exists)
+			}
+		})
+	}
+}
+
+func TestExeDevOwnershipRejectsConflictingTags(t *testing.T) {
+	vm := ownedExeDevVM("cbx_abcdef123456", "blue")
+	vm.Tags = append(vm.Tags, "crabbox-lease-cbx_other123456")
+	if _, _, _, err := exeDevOwnershipIdentity(vm); err == nil || !strings.Contains(err.Error(), "conflicting") {
+		t.Fatalf("err=%v, want conflicting tag refusal", err)
+	}
+}
+
+func TestExeDevOwnershipRejectsNoncanonicalLeaseTag(t *testing.T) {
+	vm := ownedExeDevVM("exe_abcdef123456", "blue")
+	if _, _, _, err := exeDevOwnershipIdentity(vm); err == nil || !strings.Contains(err.Error(), "invalid Crabbox lease tag") {
+		t.Fatalf("err=%v, want invalid lease tag refusal", err)
+	}
+}
+
+func ownedExeDevVM(leaseID, slug string) exeDevVM {
+	name := leaseProviderName(leaseID, slug)
+	return exeDevVM{
+		VMName:  name,
+		SSHDest: name + ".exe.xyz",
+		Status:  "running",
+		Tags:    []string{"crabbox", "crabbox-lease-" + leaseID, "crabbox-slug-" + slug},
+	}
+}
+
+func exeDevInventoryRunner(t *testing.T, vm exeDevVM) *exeDevRecordingRunner {
+	t.Helper()
+	return &exeDevRecordingRunner{fn: exeDevInventoryResponse(t, vm)}
+}
+
+func exeDevInventoryResponse(t *testing.T, vm exeDevVM) func(LocalCommandRequest) (LocalCommandResult, error) {
+	t.Helper()
+	payload, err := json.Marshal(exeDevListResponse{VMs: []exeDevVM{vm}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return func(req LocalCommandRequest) (LocalCommandResult, error) {
+		if strings.Contains(strings.Join(req.Args, " "), " rm ") {
+			return LocalCommandResult{Stdout: `{}`}, nil
+		}
+		return LocalCommandResult{Stdout: string(payload)}, nil
+	}
+}
+
+func newExeDevTestBackend(cfg Config, runner *exeDevRecordingRunner) *exeDevLeaseBackend {
+	applyExeDevDefaults(&cfg)
+	return &exeDevLeaseBackend{cfg: cfg, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
+}
+
+func persistExeDevClaim(t *testing.T, cfg Config, vm exeDevVM, leaseID, slug, repoRoot string) LeaseClaim {
+	t.Helper()
+	claim, err := claimLeaseTargetForRepoConfigIfUnchanged(leaseID, slug, cfg, exeDevServer(vm, leaseID, slug, cfg, true), exeDevSSHTarget(cfg, vm), repoRoot, cfg.IdleTimeout, false, LeaseClaim{}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return claim
+}
+
+func assertNoExeDevRM(t *testing.T, runner *exeDevRecordingRunner) {
+	t.Helper()
+	if hasExeDevRM(runner) {
+		t.Fatalf("unexpected rm call: %#v", runner.calls)
+	}
+}
+
+func hasExeDevRM(runner *exeDevRecordingRunner) bool {
+	for _, call := range runner.calls {
+		if strings.Contains(strings.Join(call.Args, " "), " rm ") {
+			return true
+		}
+	}
+	return false
 }
 
 func TestExeDevFlagsRejectGenericClassAndType(t *testing.T) {

--- a/internal/providers/exedev/backend_test.go
+++ b/internal/providers/exedev/backend_test.go
@@ -31,9 +31,6 @@ func TestExeDevListFiltersCrabboxVMsByDefault(t *testing.T) {
 	runner := &exeDevRecordingRunner{}
 	runner.fn = func(req LocalCommandRequest) (LocalCommandResult, error) {
 		base := []string{"-o", "BatchMode=yes", "-o", "StrictHostKeyChecking=accept-new", "-o", "ConnectTimeout=10", "exe.dev", "ls --l --json"}
-		if len(runner.calls) == 2 {
-			base[len(base)-1] += " -a"
-		}
 		if !reflect.DeepEqual(req.Args, base) {
 			t.Fatalf("args=%v", req.Args)
 		}

--- a/internal/providers/exedev/backend_test.go
+++ b/internal/providers/exedev/backend_test.go
@@ -28,13 +28,17 @@ func (r *exeDevRecordingRunner) Run(_ context.Context, req LocalCommandRequest) 
 }
 
 func TestExeDevListFiltersCrabboxVMsByDefault(t *testing.T) {
-	runner := &exeDevRecordingRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+	runner := &exeDevRecordingRunner{}
+	runner.fn = func(req LocalCommandRequest) (LocalCommandResult, error) {
 		base := []string{"-o", "BatchMode=yes", "-o", "StrictHostKeyChecking=accept-new", "-o", "ConnectTimeout=10", "exe.dev", "ls --l --json"}
+		if len(runner.calls) == 2 {
+			base[len(base)-1] += " -a"
+		}
 		if !reflect.DeepEqual(req.Args, base) {
 			t.Fatalf("args=%v", req.Args)
 		}
 		return LocalCommandResult{Stdout: `{"vms":[{"vm_name":"crabbox-blue-12345678","ssh_dest":"crabbox-blue-12345678.exe.xyz","status":"running","tags":["crabbox","crabbox-lease-cbx_abcdef123456","crabbox-slug-blue"]},{"vm_name":"crabbox-manual-12345678","ssh_dest":"crabbox-manual-12345678.exe.xyz","status":"running"}]}`}, nil
-	}}
+	}
 	backend := &exeDevLeaseBackend{cfg: Config{}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
 	views, err := backend.List(context.Background(), ListRequest{})
 	if err != nil {
@@ -417,6 +421,21 @@ func TestExeDevReleaseRejectsClaimBoundToDifferentVM(t *testing.T) {
 		t.Fatalf("err=%v, want exact resource binding refusal", err)
 	}
 	assertNoExeDevRM(t, runner)
+}
+
+func TestExeDevReleaseRejectsChangedSSHEndpoint(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	leaseID := "cbx_abcdef123456"
+	vm := ownedExeDevVM(leaseID, "blue")
+	backend := newExeDevTestBackend(Config{}, exeDevInventoryRunner(t, vm))
+	persistExeDevClaim(t, backend.configForRun(), vm, leaseID, "blue", t.TempDir())
+	vm.SSHDest = "replacement.exe.xyz:2222"
+	backend.rt.Exec = exeDevInventoryRunner(t, vm)
+
+	_, err := backend.Resolve(context.Background(), ResolveRequest{ID: vm.Name(), ReleaseOnly: true})
+	if err == nil || !strings.Contains(err.Error(), "SSH endpoint does not match") {
+		t.Fatalf("err=%v, want exact SSH endpoint refusal", err)
+	}
 }
 
 func TestExeDevReleaseRequiresUnchangedClaimAndRemoteTags(t *testing.T) {
@@ -877,6 +896,28 @@ func TestExeDevBulkInventoryTreatsMalformedTagsAsUnowned(t *testing.T) {
 	}
 }
 
+func TestExeDevLeaseLookupSkipsOnlyUnrelatedMalformedTags(t *testing.T) {
+	leaseID := "cbx_abcdef123456"
+	valid := ownedExeDevVM(leaseID, "blue")
+	malformed := ownedExeDevVM("cbx_other123456", "other")
+	malformed.Tags = append(malformed.Tags, "crabbox-lease-cbx_second123456")
+
+	backend := newExeDevTestBackend(Config{}, &exeDevRecordingRunner{fn: exeDevInventoryResponseMany(t, malformed, valid)})
+	vm, found, err := backend.findVMByLeaseID(context.Background(), leaseID)
+	if err != nil || !found || vm.Name() != valid.Name() {
+		t.Fatalf("vm=%#v found=%v err=%v", vm, found, err)
+	}
+	if command := strings.Join(backend.rt.Exec.(*exeDevRecordingRunner).calls[0].Args, " "); strings.Contains(command, " -a") {
+		t.Fatalf("lease lookup crossed into team-wide inventory: %s", command)
+	}
+
+	malformed.Tags = append(malformed.Tags, "crabbox-lease-"+leaseID)
+	backend = newExeDevTestBackend(Config{}, &exeDevRecordingRunner{fn: exeDevInventoryResponseMany(t, malformed, valid)})
+	if _, _, err := backend.findVMByLeaseID(context.Background(), leaseID); err == nil || !strings.Contains(err.Error(), "conflicting") {
+		t.Fatalf("err=%v, want malformed requested-lease refusal", err)
+	}
+}
+
 func TestExeDevOwnershipRejectsNoncanonicalLeaseTag(t *testing.T) {
 	vm := ownedExeDevVM("exe_abcdef123456", "blue")
 	if _, _, _, err := exeDevOwnershipIdentity(vm); err == nil || !strings.Contains(err.Error(), "invalid Crabbox lease tag") {
@@ -933,8 +974,12 @@ func exeDevInventoryRunner(t *testing.T, vm exeDevVM) *exeDevRecordingRunner {
 }
 
 func exeDevInventoryResponse(t *testing.T, vm exeDevVM) func(LocalCommandRequest) (LocalCommandResult, error) {
+	return exeDevInventoryResponseMany(t, vm)
+}
+
+func exeDevInventoryResponseMany(t *testing.T, vms ...exeDevVM) func(LocalCommandRequest) (LocalCommandResult, error) {
 	t.Helper()
-	payload, err := json.Marshal(exeDevListResponse{VMs: []exeDevVM{vm}})
+	payload, err := json.Marshal(exeDevListResponse{VMs: vms})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/providers/exedev/backend_test.go
+++ b/internal/providers/exedev/backend_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"flag"
 	"io"
+	"maps"
 	"reflect"
 	"slices"
 	"strings"
@@ -493,6 +494,52 @@ func TestExeDevReleaseDeletesExactlyClaimedVMAndRemovesClaim(t *testing.T) {
 	}
 	if _, exists, err := readLeaseClaimWithPresence(leaseID); err != nil || exists {
 		t.Fatalf("claim exists=%v err=%v, want removed", exists, err)
+	}
+}
+
+func TestExeDevReleaseRunsGuardedRemoteCleanupBeforeDelete(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	leaseID := "cbx_abcdef123456"
+	vm := ownedExeDevVM(leaseID, "blue")
+	runner := exeDevInventoryRunner(t, vm)
+	backend := newExeDevTestBackend(Config{}, runner)
+	claim := persistExeDevClaim(t, backend.configForRun(), vm, leaseID, "blue", t.TempDir())
+	labels := maps.Clone(claim.Labels)
+	labels["tailscale"] = "true"
+	claim, err := updateLeaseClaimLabelsIfUnchangedAfter(leaseID, claim, labels, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lease, err := backend.Resolve(context.Background(), ResolveRequest{ID: leaseID, ReleaseOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleaned := false
+	lease.SSH.Host = "stale-endpoint.example"
+	baseRun := runner.fn
+	runner.fn = func(req LocalCommandRequest) (LocalCommandResult, error) {
+		if strings.Contains(strings.Join(req.Args, " "), " rm ") && !cleaned {
+			return LocalCommandResult{}, errors.New("delete ran before guarded remote cleanup")
+		}
+		return baseRun(req)
+	}
+	err = backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{
+		Lease: lease,
+		GuardedRemoteCleanup: func(_ context.Context, target LeaseTarget) {
+			if target.SSH.Host != vm.SSHHost() {
+				t.Fatalf("cleanup SSH host=%q want %q", target.SSH.Host, vm.SSHHost())
+			}
+			if target.Server.Labels["tailscale"] != "true" {
+				t.Fatalf("cleanup labels=%v, want claimed Tailscale metadata", target.Server.Labels)
+			}
+			cleaned = true
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cleaned || !hasExeDevRM(runner) {
+		t.Fatalf("cleaned=%v rm=%v", cleaned, hasExeDevRM(runner))
 	}
 }
 

--- a/internal/providers/exedev/backend_test.go
+++ b/internal/providers/exedev/backend_test.go
@@ -150,6 +150,8 @@ func newExeDevAcquireRollbackRunner() *exeDevRecordingRunner {
 	return &exeDevRecordingRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
 		cmd := strings.Join(req.Args, " ")
 		switch {
+		case strings.Contains(cmd, "whoami --json"):
+			return LocalCommandResult{Stdout: `{"email":"test@example.com"}`}, nil
 		case strings.Contains(cmd, "ls --l --json"):
 			return LocalCommandResult{Stdout: `{"vms":[]}`}, nil
 		case strings.Contains(cmd, " new "):
@@ -458,6 +460,28 @@ func TestExeDevReleaseDeletesExactlyClaimedVMAndRemovesClaim(t *testing.T) {
 	}
 }
 
+func TestExeDevReleaseRejectsDifferentAuthenticatedAccount(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	leaseID := "cbx_abcdef123456"
+	slug := "blue"
+	vm := ownedExeDevVM(leaseID, slug)
+	baseResponse := exeDevInventoryResponse(t, vm)
+	runner := &exeDevRecordingRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+		if strings.Contains(strings.Join(req.Args, " "), "whoami --json") {
+			return LocalCommandResult{Stdout: `{"email":"other@example.com"}`}, nil
+		}
+		return baseResponse(req)
+	}}
+	backend := newExeDevTestBackend(Config{}, runner)
+	persistExeDevClaim(t, backend.configForRun(), vm, leaseID, slug, t.TempDir())
+
+	_, err := backend.Resolve(context.Background(), ResolveRequest{ID: vm.Name(), ReleaseOnly: true})
+	if err == nil || !strings.Contains(err.Error(), "different exe.dev control route") {
+		t.Fatalf("err=%v, want account-bound route refusal", err)
+	}
+	assertNoExeDevRM(t, runner)
+}
+
 func TestExeDevReleaseSurvivesTouchedClaimRoundTrip(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	leaseID := "cbx_abcdef123456"
@@ -613,6 +637,25 @@ func TestExeDevOwnershipRejectsConflictingTags(t *testing.T) {
 	}
 }
 
+func TestExeDevBulkInventoryTreatsMalformedTagsAsUnowned(t *testing.T) {
+	vm := ownedExeDevVM("cbx_abcdef123456", "blue")
+	vm.Tags = append(vm.Tags, "crabbox-lease-cbx_other123456")
+	runner := exeDevInventoryRunner(t, vm)
+	backend := newExeDevTestBackend(Config{}, runner)
+
+	views, err := backend.List(context.Background(), ListRequest{})
+	if err != nil || len(views) != 0 {
+		t.Fatalf("owned inventory views=%#v err=%v, want malformed VM omitted", views, err)
+	}
+	views, err = backend.List(context.Background(), ListRequest{All: true})
+	if err != nil || len(views) != 1 || views[0].Name != vm.Name() {
+		t.Fatalf("all inventory views=%#v err=%v, want malformed VM visible", views, err)
+	}
+	if _, err := backend.Resolve(context.Background(), ResolveRequest{ID: vm.Name(), ReleaseOnly: true}); err == nil || !strings.Contains(err.Error(), "conflicting") {
+		t.Fatalf("exact resolve err=%v, want hard malformed-tag refusal", err)
+	}
+}
+
 func TestExeDevOwnershipRejectsNoncanonicalLeaseTag(t *testing.T) {
 	vm := ownedExeDevVM("exe_abcdef123456", "blue")
 	if _, _, _, err := exeDevOwnershipIdentity(vm); err == nil || !strings.Contains(err.Error(), "invalid Crabbox lease tag") {
@@ -642,7 +685,11 @@ func exeDevInventoryResponse(t *testing.T, vm exeDevVM) func(LocalCommandRequest
 		t.Fatal(err)
 	}
 	return func(req LocalCommandRequest) (LocalCommandResult, error) {
-		if strings.Contains(strings.Join(req.Args, " "), " rm ") {
+		command := strings.Join(req.Args, " ")
+		if strings.Contains(command, "whoami --json") {
+			return LocalCommandResult{Stdout: `{"email":"test@example.com"}`}, nil
+		}
+		if strings.Contains(command, " rm ") {
 			return LocalCommandResult{Stdout: `{}`}, nil
 		}
 		return LocalCommandResult{Stdout: string(payload)}, nil
@@ -667,7 +714,7 @@ func persistExeDevClaim(t *testing.T, cfg Config, vm exeDevVM, leaseID, slug, re
 
 func mustExeDevControlScope(t *testing.T, cfg Config) string {
 	t.Helper()
-	scope, err := exeDevControlScope(cfg)
+	scope, err := exeDevControlScope(cfg, exeDevAccountFingerprint("test@example.com"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/providers/exedev/backend_test.go
+++ b/internal/providers/exedev/backend_test.go
@@ -171,7 +171,7 @@ func assertExeDevRollbackFailure(t *testing.T, err error, primary error, runner 
 	if !errors.As(err, &exitErr) || exitErr.Code != 1 {
 		t.Fatalf("err=%#v, want rendered ExitError code 1", err)
 	}
-	for _, want := range []string{"exe.dev cleanup failed for VM", "manual cleanup: crabbox stop --provider exe-dev --id", "exit status 1", primary.Error()} {
+	for _, want := range []string{"exe.dev cleanup failed for VM", "manual cleanup: ssh exe.dev rm crabbox-", "exit status 1", primary.Error()} {
 		if !strings.Contains(exitErr.Message, want) {
 			t.Fatalf("exit message=%q missing %q", exitErr.Message, want)
 		}

--- a/internal/providers/exedev/backend_test.go
+++ b/internal/providers/exedev/backend_test.go
@@ -646,13 +646,38 @@ func TestExeDevAbsentReleaseRechecksInventoryBeforeRemovingClaim(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	runner.fn = exeDevInventoryResponse(t, vm)
+	renamed := vm
+	renamed.VMName = "renamed-owned-vm"
+	renamed.SSHDest = "renamed-owned-vm.exe.xyz"
+	runner.fn = exeDevInventoryResponse(t, renamed)
 	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err == nil || !strings.Contains(err.Error(), "is present") {
 		t.Fatalf("err=%v, want present-VM refusal", err)
 	}
 	assertNoExeDevRM(t, runner)
 	if _, exists, err := readLeaseClaimWithPresence(leaseID); err != nil || !exists {
 		t.Fatalf("claim exists=%v err=%v, want retained", exists, err)
+	}
+}
+
+func TestExeDevAbsentReleaseRejectsRenamedOwnedVM(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	leaseID := "cbx_abcdef123456"
+	slug := "blue"
+	vm := ownedExeDevVM(leaseID, slug)
+	renamed := vm
+	renamed.VMName = "renamed-owned-vm"
+	renamed.SSHDest = "renamed-owned-vm.exe.xyz"
+	runner := exeDevInventoryRunner(t, renamed)
+	backend := newExeDevTestBackend(Config{}, runner)
+	persistExeDevClaim(t, backend.configForRun(), vm, leaseID, slug, t.TempDir())
+
+	_, err := backend.Resolve(context.Background(), ResolveRequest{ID: leaseID, ReleaseOnly: true})
+	if err == nil || !strings.Contains(err.Error(), "unexpected VM") {
+		t.Fatalf("err=%v, want renamed owned-VM refusal", err)
+	}
+	assertNoExeDevRM(t, runner)
+	if _, exists, readErr := readLeaseClaimWithPresence(leaseID); readErr != nil || !exists {
+		t.Fatalf("claim exists=%v err=%v, want retained", exists, readErr)
 	}
 }
 

--- a/internal/providers/exedev/backend_test.go
+++ b/internal/providers/exedev/backend_test.go
@@ -843,6 +843,7 @@ func TestExeDevReuseRequiresExplicitAdoptionAndPersistsExactBinding(t *testing.T
 			if !hasExeDevTagCommand(runner) {
 				t.Fatalf("explicit reclaim did not bind a remote claim generation: %#v", runner.calls)
 			}
+			assertExeDevTagOptionsPrecedeVM(t, runner)
 			if _, exists, snapshotSet := serverLeaseClaimSnapshot(lease.Server); !snapshotSet || !exists {
 				t.Fatalf("claim snapshot set=%v exists=%v", snapshotSet, exists)
 			}
@@ -907,15 +908,12 @@ func exeDevInventoryRunner(t *testing.T, vm exeDevVM) *exeDevRecordingRunner {
 		}
 		if strings.Contains(command, " tag ") {
 			fields := strings.Fields(req.Args[len(req.Args)-1])
-			deleteTags := len(fields) > 1 && fields[1] == "-d"
-			start := 2
+			deleteTags := len(fields) > 2 && fields[2] == "-d"
+			start := 3
 			if deleteTags {
-				start = 3
+				start = 4
 			}
 			for _, tag := range fields[start:] {
-				if tag == "--json" {
-					continue
-				}
 				if deleteTags {
 					current.Tags = slices.DeleteFunc(current.Tags, func(existing string) bool { return existing == tag })
 				} else if !slices.Contains(current.Tags, tag) {
@@ -998,6 +996,16 @@ func hasExeDevTagCommand(runner *exeDevRecordingRunner) bool {
 		}
 	}
 	return false
+}
+
+func assertExeDevTagOptionsPrecedeVM(t *testing.T, runner *exeDevRecordingRunner) {
+	t.Helper()
+	for _, call := range runner.calls {
+		fields := strings.Fields(call.Args[len(call.Args)-1])
+		if len(fields) > 0 && fields[0] == "tag" && (len(fields) < 2 || fields[1] != "--json") {
+			t.Fatalf("exe.dev tag options must precede VM name: %q", fields)
+		}
+	}
 }
 
 func TestExeDevFlagsRejectGenericClassAndType(t *testing.T) {

--- a/internal/providers/exedev/backend_test.go
+++ b/internal/providers/exedev/backend_test.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"io"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -84,6 +85,7 @@ func TestExeDevCreateVMUsesSSHControlAPI(t *testing.T) {
 			"--tag crabbox",
 			"--tag crabbox-lease-cbx_lease",
 			"--tag crabbox-slug-blue",
+			"--tag crabbox-claim-cbx_111111111111",
 			"--no-email",
 			"--image ubuntu:24.04",
 			"--cpu 4",
@@ -106,7 +108,7 @@ func TestExeDevCreateVMUsesSSHControlAPI(t *testing.T) {
 		NoEmail: true,
 	}}
 	backend := &exeDevLeaseBackend{cfg: cfg, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
-	vm, err := backend.createVM(context.Background(), backend.configForRun(), "crabbox-blue-12345678", "cbx_lease", "blue")
+	vm, err := backend.createVM(context.Background(), backend.configForRun(), "crabbox-blue-12345678", "cbx_lease", "blue", "cbx_111111111111")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -482,6 +484,30 @@ func TestExeDevReleaseRejectsDifferentAuthenticatedAccount(t *testing.T) {
 	assertNoExeDevRM(t, runner)
 }
 
+func TestExeDevReleaseRejectsReplacementClaimGeneration(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	leaseID := "cbx_abcdef123456"
+	slug := "blue"
+	vm := ownedExeDevVM(leaseID, slug)
+	runner := exeDevInventoryRunner(t, vm)
+	backend := newExeDevTestBackend(Config{}, runner)
+	persistExeDevClaim(t, backend.configForRun(), vm, leaseID, slug, t.TempDir())
+	vm.Tags = slices.DeleteFunc(vm.Tags, func(tag string) bool {
+		return strings.HasPrefix(tag, exeDevClaimGenerationTagPrefix)
+	})
+	vm.Tags = append(vm.Tags, exeDevClaimGenerationTagPrefix+"cbx_222222222222")
+	runner.fn = exeDevInventoryResponse(t, vm)
+
+	_, err := backend.Resolve(context.Background(), ResolveRequest{ID: leaseID, ReleaseOnly: true})
+	if err == nil || !strings.Contains(err.Error(), "generation does not match") {
+		t.Fatalf("err=%v, want replacement-generation refusal", err)
+	}
+	assertNoExeDevRM(t, runner)
+	if _, exists, readErr := readLeaseClaimWithPresence(leaseID); readErr != nil || !exists {
+		t.Fatalf("claim exists=%v err=%v, want retained", exists, readErr)
+	}
+}
+
 func TestExeDevReleaseSurvivesTouchedClaimRoundTrip(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	leaseID := "cbx_abcdef123456"
@@ -733,6 +759,9 @@ func TestExeDevReuseRequiresExplicitAdoptionAndPersistsExactBinding(t *testing.T
 			if claim.CloudID != vm.Name() || claim.Provider != providerName || claim.ProviderScope == "" {
 				t.Fatalf("claim=%#v", claim)
 			}
+			if !hasExeDevTagCommand(runner) {
+				t.Fatalf("explicit reclaim did not bind a remote claim generation: %#v", runner.calls)
+			}
 			if _, exists, snapshotSet := serverLeaseClaimSnapshot(lease.Server); !snapshotSet || !exists {
 				t.Fatalf("claim snapshot set=%v exists=%v", snapshotSet, exists)
 			}
@@ -780,13 +809,46 @@ func ownedExeDevVM(leaseID, slug string) exeDevVM {
 		VMName:  name,
 		SSHDest: name + ".exe.xyz",
 		Status:  "running",
-		Tags:    []string{"crabbox", "crabbox-lease-" + leaseID, "crabbox-slug-" + slug},
+		Tags:    []string{"crabbox", "crabbox-lease-" + leaseID, "crabbox-slug-" + slug, exeDevClaimGenerationTagPrefix + "cbx_111111111111"},
 	}
 }
 
 func exeDevInventoryRunner(t *testing.T, vm exeDevVM) *exeDevRecordingRunner {
 	t.Helper()
-	return &exeDevRecordingRunner{fn: exeDevInventoryResponse(t, vm)}
+	current := vm
+	return &exeDevRecordingRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+		command := strings.Join(req.Args, " ")
+		if strings.Contains(command, "whoami --json") {
+			return LocalCommandResult{Stdout: `{"email":"test@example.com"}`}, nil
+		}
+		if strings.Contains(command, " rm ") {
+			return LocalCommandResult{Stdout: `{}`}, nil
+		}
+		if strings.Contains(command, " tag ") {
+			fields := strings.Fields(req.Args[len(req.Args)-1])
+			deleteTags := len(fields) > 1 && fields[1] == "-d"
+			start := 2
+			if deleteTags {
+				start = 3
+			}
+			for _, tag := range fields[start:] {
+				if tag == "--json" {
+					continue
+				}
+				if deleteTags {
+					current.Tags = slices.DeleteFunc(current.Tags, func(existing string) bool { return existing == tag })
+				} else if !slices.Contains(current.Tags, tag) {
+					current.Tags = append(current.Tags, tag)
+				}
+			}
+			return LocalCommandResult{Stdout: `{}`}, nil
+		}
+		payload, err := json.Marshal(exeDevListResponse{VMs: []exeDevVM{current}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return LocalCommandResult{Stdout: string(payload)}, nil
+	}}
 }
 
 func exeDevInventoryResponse(t *testing.T, vm exeDevVM) func(LocalCommandRequest) (LocalCommandResult, error) {
@@ -815,7 +877,7 @@ func newExeDevTestBackend(cfg Config, runner *exeDevRecordingRunner) *exeDevLeas
 func persistExeDevClaim(t *testing.T, cfg Config, vm exeDevVM, leaseID, slug, repoRoot string) LeaseClaim {
 	t.Helper()
 	server := exeDevServer(vm, leaseID, slug, cfg, true)
-	server.Labels[exeDevClaimGenerationLabel] = "cbx_testgeneration"
+	server.Labels[exeDevClaimGenerationLabel] = "cbx_111111111111"
 	claim, err := claimLeaseTargetForRepoConfigScopeIfUnchanged(leaseID, slug, cfg, mustExeDevControlScope(t, cfg), server, exeDevSSHTarget(cfg, vm), repoRoot, cfg.IdleTimeout, false, LeaseClaim{}, false)
 	if err != nil {
 		t.Fatal(err)
@@ -842,6 +904,15 @@ func assertNoExeDevRM(t *testing.T, runner *exeDevRecordingRunner) {
 func hasExeDevRM(runner *exeDevRecordingRunner) bool {
 	for _, call := range runner.calls {
 		if strings.Contains(strings.Join(call.Args, " "), " rm ") {
+			return true
+		}
+	}
+	return false
+}
+
+func hasExeDevTagCommand(runner *exeDevRecordingRunner) bool {
+	for _, call := range runner.calls {
+		if strings.Contains(strings.Join(call.Args, " "), " tag ") {
 			return true
 		}
 	}

--- a/internal/providers/exedev/backend_test.go
+++ b/internal/providers/exedev/backend_test.go
@@ -148,16 +148,50 @@ func TestExeDevAcquireReportsRollbackFailureAfterClaimFailure(t *testing.T) {
 	assertExeDevRollbackFailure(t, err, primaryErr, runner)
 }
 
+func TestExeDevProvisioningRollbackRejectsReplacementGeneration(t *testing.T) {
+	leaseID := "cbx_abcdef123456"
+	slug := "blue"
+	vm := ownedExeDevVM(leaseID, slug)
+	runner := exeDevInventoryRunner(t, vm)
+	backend := newExeDevTestBackend(Config{}, runner)
+	primaryErr := errors.New("ssh not ready")
+
+	err := backend.rollbackCreatedVM(vm.Name(), leaseID, slug, "cbx_222222222222", primaryErr)
+	if err == nil || !strings.Contains(err.Error(), primaryErr.Error()) || !strings.Contains(err.Error(), "refused replacement VM") {
+		t.Fatalf("err=%v, want guarded rollback refusal", err)
+	}
+	assertNoExeDevRM(t, runner)
+}
+
 func newExeDevAcquireRollbackRunner() *exeDevRecordingRunner {
+	var created *exeDevVM
 	return &exeDevRecordingRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
 		cmd := strings.Join(req.Args, " ")
 		switch {
 		case strings.Contains(cmd, "whoami --json"):
 			return LocalCommandResult{Stdout: `{"email":"test@example.com"}`}, nil
 		case strings.Contains(cmd, "ls --l --json"):
-			return LocalCommandResult{Stdout: `{"vms":[]}`}, nil
+			vms := []exeDevVM{}
+			if created != nil {
+				vms = append(vms, *created)
+			}
+			payload, err := json.Marshal(exeDevListResponse{VMs: vms})
+			return LocalCommandResult{Stdout: string(payload)}, err
 		case strings.Contains(cmd, " new "):
-			return LocalCommandResult{Stdout: `{"vm_name":"created-vm","ssh_dest":"created-vm.exe.xyz","status":"running"}`}, nil
+			fields := strings.Fields(req.Args[len(req.Args)-1])
+			vm := exeDevVM{Status: "running"}
+			for i := 0; i < len(fields)-1; i++ {
+				switch fields[i] {
+				case "--name":
+					vm.VMName = fields[i+1]
+					vm.SSHDest = fields[i+1] + ".exe.xyz"
+				case "--tag":
+					vm.Tags = append(vm.Tags, fields[i+1])
+				}
+			}
+			created = &vm
+			payload, err := json.Marshal(vm)
+			return LocalCommandResult{Stdout: string(payload)}, err
 		case strings.Contains(cmd, " rm "):
 			return LocalCommandResult{ExitCode: 1}, errors.New("exit status 1")
 		default:

--- a/internal/providers/exedev/backend_test.go
+++ b/internal/providers/exedev/backend_test.go
@@ -594,6 +594,92 @@ func TestExeDevReleaseRetainsClaimWhenDeleteFails(t *testing.T) {
 	}
 }
 
+func TestExeDevReleaseRemovesUnchangedClaimWhenVMIsAlreadyAbsent(t *testing.T) {
+	leaseID := "cbx_abcdef123456"
+	slug := "blue"
+	vm := ownedExeDevVM(leaseID, slug)
+	for _, identifier := range []string{leaseID, vm.Name(), vm.SSHHost()} {
+		t.Run(identifier, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			runner := &exeDevRecordingRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+				if strings.Contains(strings.Join(req.Args, " "), "whoami --json") {
+					return LocalCommandResult{Stdout: `{"email":"test@example.com"}`}, nil
+				}
+				return LocalCommandResult{Stdout: `{"vms":[]}`}, nil
+			}}
+			backend := newExeDevTestBackend(Config{}, runner)
+			persistExeDevClaim(t, backend.configForRun(), vm, leaseID, slug, t.TempDir())
+
+			lease, err := backend.Resolve(context.Background(), ResolveRequest{ID: identifier, ReleaseOnly: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if lease.Server.Labels[exeDevConfirmedAbsentLabel] != "true" {
+				t.Fatalf("labels=%v, want confirmed-absence marker", lease.Server.Labels)
+			}
+			if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err != nil {
+				t.Fatal(err)
+			}
+			assertNoExeDevRM(t, runner)
+			if _, exists, err := readLeaseClaimWithPresence(leaseID); err != nil || exists {
+				t.Fatalf("claim exists=%v err=%v, want removed", exists, err)
+			}
+		})
+	}
+}
+
+func TestExeDevAbsentReleaseRechecksInventoryBeforeRemovingClaim(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	leaseID := "cbx_abcdef123456"
+	slug := "blue"
+	vm := ownedExeDevVM(leaseID, slug)
+	runner := &exeDevRecordingRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+		if strings.Contains(strings.Join(req.Args, " "), "whoami --json") {
+			return LocalCommandResult{Stdout: `{"email":"test@example.com"}`}, nil
+		}
+		return LocalCommandResult{Stdout: `{"vms":[]}`}, nil
+	}}
+	backend := newExeDevTestBackend(Config{}, runner)
+	persistExeDevClaim(t, backend.configForRun(), vm, leaseID, slug, t.TempDir())
+
+	lease, err := backend.Resolve(context.Background(), ResolveRequest{ID: leaseID, ReleaseOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner.fn = exeDevInventoryResponse(t, vm)
+	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err == nil || !strings.Contains(err.Error(), "is present") {
+		t.Fatalf("err=%v, want present-VM refusal", err)
+	}
+	assertNoExeDevRM(t, runner)
+	if _, exists, err := readLeaseClaimWithPresence(leaseID); err != nil || !exists {
+		t.Fatalf("claim exists=%v err=%v, want retained", exists, err)
+	}
+}
+
+func TestExeDevAbsentReleaseRejectsDifferentAuthenticatedAccount(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	leaseID := "cbx_abcdef123456"
+	slug := "blue"
+	vm := ownedExeDevVM(leaseID, slug)
+	runner := &exeDevRecordingRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+		if strings.Contains(strings.Join(req.Args, " "), "whoami --json") {
+			return LocalCommandResult{Stdout: `{"email":"other@example.com"}`}, nil
+		}
+		return LocalCommandResult{Stdout: `{"vms":[]}`}, nil
+	}}
+	backend := newExeDevTestBackend(Config{}, runner)
+	persistExeDevClaim(t, backend.configForRun(), vm, leaseID, slug, t.TempDir())
+
+	_, err := backend.Resolve(context.Background(), ResolveRequest{ID: leaseID, ReleaseOnly: true})
+	if err == nil || !strings.Contains(err.Error(), "different exe.dev control route") {
+		t.Fatalf("err=%v, want account-bound route refusal", err)
+	}
+	assertNoExeDevRM(t, runner)
+	if _, exists, readErr := readLeaseClaimWithPresence(leaseID); readErr != nil || !exists {
+		t.Fatalf("claim exists=%v err=%v, want retained", exists, readErr)
+	}
+}
+
 func TestExeDevReuseRequiresExplicitAdoptionAndPersistsExactBinding(t *testing.T) {
 	leaseID := "cbx_abcdef123456"
 	vm := ownedExeDevVM(leaseID, "blue")

--- a/internal/providers/exedev/backend_test.go
+++ b/internal/providers/exedev/backend_test.go
@@ -135,11 +135,11 @@ func TestExeDevAcquireReportsRollbackFailureAfterClaimFailure(t *testing.T) {
 		return nil
 	}
 	t.Cleanup(func() { waitForSSHReady = oldWait })
-	oldClaim := claimLeaseTargetForRepoConfigIfUnchanged
-	claimLeaseTargetForRepoConfigIfUnchanged = func(string, string, Config, Server, SSHTarget, string, time.Duration, bool, LeaseClaim, bool) (LeaseClaim, error) {
+	oldClaim := claimLeaseTargetForRepoConfigScopeIfUnchanged
+	claimLeaseTargetForRepoConfigScopeIfUnchanged = func(string, string, Config, string, Server, SSHTarget, string, time.Duration, bool, LeaseClaim, bool) (LeaseClaim, error) {
 		return LeaseClaim{}, primaryErr
 	}
-	t.Cleanup(func() { claimLeaseTargetForRepoConfigIfUnchanged = oldClaim })
+	t.Cleanup(func() { claimLeaseTargetForRepoConfigScopeIfUnchanged = oldClaim })
 	runner := newExeDevAcquireRollbackRunner()
 	backend := &exeDevLeaseBackend{cfg: Config{}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
 	_, err := backend.Acquire(context.Background(), AcquireRequest{Repo: Repo{Root: t.TempDir()}})
@@ -317,7 +317,7 @@ func TestExeDevResolveVMNameRecoversExistingClaim(t *testing.T) {
 	cfg := Config{Provider: providerName}
 	applyExeDevDefaults(&cfg)
 	vm := exeDevVM{VMName: name, SSHDest: name + ".exe.xyz", Status: "running"}
-	if _, err := claimLeaseTargetForRepoConfigIfUnchanged(leaseID, slug, cfg, exeDevServer(vm, leaseID, slug, cfg, true), exeDevSSHTarget(cfg, vm), t.TempDir(), 0, false, LeaseClaim{}, false); err != nil {
+	if _, err := claimLeaseTargetForRepoConfigScopeIfUnchanged(leaseID, slug, cfg, mustExeDevControlScope(t, cfg), exeDevServer(vm, leaseID, slug, cfg, true), exeDevSSHTarget(cfg, vm), t.TempDir(), 0, false, LeaseClaim{}, false); err != nil {
 		t.Fatal(err)
 	}
 	runner := &exeDevRecordingRunner{fn: func(LocalCommandRequest) (LocalCommandResult, error) {
@@ -390,7 +390,7 @@ func TestExeDevReleaseRequiresUnchangedClaimAndRemoteTags(t *testing.T) {
 			name: "claim changed",
 			mutate: func(t *testing.T, backend *exeDevLeaseBackend, _ *exeDevRecordingRunner, lease LeaseTarget, claim LeaseClaim, vm exeDevVM) {
 				cfg := backend.configForRun()
-				if _, err := claimLeaseTargetForRepoConfigIfUnchanged(lease.LeaseID, claim.Slug, cfg, lease.Server, exeDevSSHTarget(cfg, vm), t.TempDir(), cfg.IdleTimeout, true, claim, true); err != nil {
+				if _, err := claimLeaseTargetForRepoConfigScopeIfUnchanged(lease.LeaseID, claim.Slug, cfg, claim.ProviderScope, lease.Server, exeDevSSHTarget(cfg, vm), t.TempDir(), cfg.IdleTimeout, true, claim, true); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -458,6 +458,43 @@ func TestExeDevReleaseDeletesExactlyClaimedVMAndRemovesClaim(t *testing.T) {
 	}
 }
 
+func TestExeDevReleaseSurvivesTouchedClaimRoundTrip(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	leaseID := "cbx_abcdef123456"
+	slug := "blue"
+	vm := ownedExeDevVM(leaseID, slug)
+	runner := exeDevInventoryRunner(t, vm)
+	backend := newExeDevTestBackend(Config{}, runner)
+	cfg := backend.configForRun()
+	repoRoot := t.TempDir()
+	claim := persistExeDevClaim(t, cfg, vm, leaseID, slug, repoRoot)
+	lease := LeaseTarget{
+		LeaseID: leaseID,
+		Server:  exeDevServer(vm, leaseID, slug, cfg, true),
+	}
+	touched, err := backend.Touch(context.Background(), TouchRequest{Lease: lease, State: "ready"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim, err = claimLeaseTargetForRepoConfigScopeIfUnchanged(leaseID, slug, cfg, claim.ProviderScope, touched, exeDevSSHTarget(cfg, vm), repoRoot, cfg.IdleTimeout, true, claim, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claim.ProviderScope != mustExeDevControlScope(t, cfg) {
+		t.Fatalf("provider scope=%q", claim.ProviderScope)
+	}
+	resolved, err := backend.Resolve(context.Background(), ResolveRequest{ID: vm.Name(), ReleaseOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: resolved}); err != nil {
+		t.Fatal(err)
+	}
+	if !hasExeDevRM(runner) {
+		t.Fatalf("rm not called: %#v", runner.calls)
+	}
+}
+
 func TestExeDevReleaseRetainsClaimWhenDeleteFails(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	leaseID := "cbx_abcdef123456"
@@ -508,7 +545,7 @@ func TestExeDevReuseRequiresExplicitAdoptionAndPersistsExactBinding(t *testing.T
 			if readErr != nil || !exists {
 				t.Fatalf("claim exists=%v err=%v", exists, readErr)
 			}
-			if claim.CloudID != vm.Name() || claim.Provider != providerName || claim.Labels[exeDevControlScopeLabel] == "" {
+			if claim.CloudID != vm.Name() || claim.Provider != providerName || claim.ProviderScope == "" {
 				t.Fatalf("claim=%#v", claim)
 			}
 			if _, exists, snapshotSet := serverLeaseClaimSnapshot(lease.Server); !snapshotSet || !exists {
@@ -569,11 +606,20 @@ func newExeDevTestBackend(cfg Config, runner *exeDevRecordingRunner) *exeDevLeas
 
 func persistExeDevClaim(t *testing.T, cfg Config, vm exeDevVM, leaseID, slug, repoRoot string) LeaseClaim {
 	t.Helper()
-	claim, err := claimLeaseTargetForRepoConfigIfUnchanged(leaseID, slug, cfg, exeDevServer(vm, leaseID, slug, cfg, true), exeDevSSHTarget(cfg, vm), repoRoot, cfg.IdleTimeout, false, LeaseClaim{}, false)
+	claim, err := claimLeaseTargetForRepoConfigScopeIfUnchanged(leaseID, slug, cfg, mustExeDevControlScope(t, cfg), exeDevServer(vm, leaseID, slug, cfg, true), exeDevSSHTarget(cfg, vm), repoRoot, cfg.IdleTimeout, false, LeaseClaim{}, false)
 	if err != nil {
 		t.Fatal(err)
 	}
 	return claim
+}
+
+func mustExeDevControlScope(t *testing.T, cfg Config) string {
+	t.Helper()
+	scope, err := exeDevControlScope(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return scope
 }
 
 func assertNoExeDevRM(t *testing.T, runner *exeDevRecordingRunner) {

--- a/internal/providers/exedev/core.go
+++ b/internal/providers/exedev/core.go
@@ -33,6 +33,8 @@ type LocalCommandRequest = core.LocalCommandRequest
 type LocalCommandResult = core.LocalCommandResult
 type LeaseClaim = core.LeaseClaim
 
+var errReleaseLeaseOwnershipChanged = core.ErrReleaseLeaseOwnershipChanged
+
 const (
 	providerName  = "exe-dev"
 	targetLinux   = core.TargetLinux

--- a/internal/providers/exedev/core.go
+++ b/internal/providers/exedev/core.go
@@ -97,6 +97,10 @@ func removeLeaseClaimIfUnchangedAfter(leaseID string, expected core.LeaseClaim, 
 	return core.RemoveLeaseClaimIfUnchangedAfter(leaseID, expected, action)
 }
 
+func updateLeaseClaimLabelsIfUnchangedAfter(leaseID string, expected core.LeaseClaim, labels map[string]string, action func() error) (core.LeaseClaim, error) {
+	return core.UpdateLeaseClaimLabelsIfUnchangedAfter(leaseID, expected, labels, action)
+}
+
 func setServerLeaseClaimSnapshot(server *Server, claim core.LeaseClaim, exists bool) {
 	core.SetServerLeaseClaimSnapshot(server, claim, exists)
 }

--- a/internal/providers/exedev/core.go
+++ b/internal/providers/exedev/core.go
@@ -75,8 +75,8 @@ func allocateDirectLeaseSlug(leaseID, requested string, servers []Server) (strin
 	return core.AllocateDirectLeaseSlug(leaseID, requested, servers)
 }
 
-var claimLeaseTargetForRepoConfigIfUnchanged = func(leaseID, slug string, cfg Config, server Server, target SSHTarget, repoRoot string, idleTimeout time.Duration, reclaim bool, expected core.LeaseClaim, expectedExists bool) (core.LeaseClaim, error) {
-	return core.ClaimLeaseTargetForRepoConfigIfUnchanged(leaseID, slug, cfg, server, target, repoRoot, idleTimeout, reclaim, expected, expectedExists)
+var claimLeaseTargetForRepoConfigScopeIfUnchanged = func(leaseID, slug string, cfg Config, providerScope string, server Server, target SSHTarget, repoRoot string, idleTimeout time.Duration, reclaim bool, expected core.LeaseClaim, expectedExists bool) (core.LeaseClaim, error) {
+	return core.ClaimLeaseTargetForRepoConfigScopeIfUnchanged(leaseID, slug, cfg, providerScope, server, target, repoRoot, idleTimeout, reclaim, expected, expectedExists)
 }
 
 func resolveLeaseClaimForProvider(identifier, provider string) (core.LeaseClaim, bool, error) {

--- a/internal/providers/exedev/core.go
+++ b/internal/providers/exedev/core.go
@@ -85,6 +85,10 @@ func resolveLeaseClaimForProvider(identifier, provider string) (core.LeaseClaim,
 	return core.ResolveLeaseClaimForProvider(identifier, provider)
 }
 
+func resolveLeaseClaimForProviderCloudID(cloudID, provider string) (core.LeaseClaim, bool, error) {
+	return core.ResolveLeaseClaimForProviderCloudID(cloudID, provider)
+}
+
 func readLeaseClaimWithPresence(leaseID string) (core.LeaseClaim, bool, error) {
 	return core.ReadLeaseClaimWithPresence(leaseID)
 }

--- a/internal/providers/exedev/core.go
+++ b/internal/providers/exedev/core.go
@@ -31,6 +31,7 @@ type Repo = core.Repo
 type ExitError = core.ExitError
 type LocalCommandRequest = core.LocalCommandRequest
 type LocalCommandResult = core.LocalCommandResult
+type LeaseClaim = core.LeaseClaim
 
 const (
 	providerName  = "exe-dev"
@@ -62,6 +63,10 @@ func normalizeLeaseSlug(value string) string {
 	return core.NormalizeLeaseSlug(value)
 }
 
+func isCanonicalLeaseID(value string) bool {
+	return core.IsCanonicalLeaseID(value)
+}
+
 func leaseProviderName(leaseID, slug string) string {
 	return core.LeaseProviderName(leaseID, slug)
 }
@@ -70,16 +75,28 @@ func allocateDirectLeaseSlug(leaseID, requested string, servers []Server) (strin
 	return core.AllocateDirectLeaseSlug(leaseID, requested, servers)
 }
 
-var claimLeaseForRepoProvider = func(leaseID, slug, provider, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
-	return core.ClaimLeaseForRepoProvider(leaseID, slug, provider, repoRoot, idleTimeout, reclaim)
+var claimLeaseTargetForRepoConfigIfUnchanged = func(leaseID, slug string, cfg Config, server Server, target SSHTarget, repoRoot string, idleTimeout time.Duration, reclaim bool, expected core.LeaseClaim, expectedExists bool) (core.LeaseClaim, error) {
+	return core.ClaimLeaseTargetForRepoConfigIfUnchanged(leaseID, slug, cfg, server, target, repoRoot, idleTimeout, reclaim, expected, expectedExists)
 }
 
 func resolveLeaseClaimForProvider(identifier, provider string) (core.LeaseClaim, bool, error) {
 	return core.ResolveLeaseClaimForProvider(identifier, provider)
 }
 
-func removeLeaseClaim(leaseID string) {
-	core.RemoveLeaseClaim(leaseID)
+func readLeaseClaimWithPresence(leaseID string) (core.LeaseClaim, bool, error) {
+	return core.ReadLeaseClaimWithPresence(leaseID)
+}
+
+func removeLeaseClaimIfUnchangedAfter(leaseID string, expected core.LeaseClaim, action func() error) error {
+	return core.RemoveLeaseClaimIfUnchangedAfter(leaseID, expected, action)
+}
+
+func setServerLeaseClaimSnapshot(server *Server, claim core.LeaseClaim, exists bool) {
+	core.SetServerLeaseClaimSnapshot(server, claim, exists)
+}
+
+func serverLeaseClaimSnapshot(server Server) (core.LeaseClaim, bool, bool) {
+	return core.ServerLeaseClaimSnapshot(server)
 }
 
 func directLeaseLabels(cfg Config, leaseID, slug, provider, market string, keep bool, now time.Time) map[string]string {


### PR DESCRIPTION
## Summary

- require complete canonical exe.dev ownership tags, an account-bound control scope, an exact unchanged local claim, and a random provider-visible resource generation before reuse or deletion
- make claimless and legacy adoption explicit through `--reclaim`, rotating the remote generation under the unchanged claim lock without retargeting an existing claim
- re-read inventory and revalidate name, lease, slug, account, route, generation, and claim while holding the claim lock across guarded remote cleanup and deletion
- fence run, watch, warmup, prewarm, explicit stop, provisioning rollback, and already-absent retry cleanup; retain claims after failed or ambiguous operations
- keep malformed or foreign resources non-destructive while preserving `--all` inventory recovery

Fixes https://github.com/openclaw/crabbox/issues/926

## Verification

- `go build -trimpath -o /tmp/crabbox-exedev-926-final ./cmd/crabbox`
- `go vet ./...`
- `go test -race ./...`
- `go test -race ./internal/providers/exedev -count=1`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker`
- `npm run build --prefix worker`
- `node scripts/build-docs-site.mjs`
- AutoReview local and whole-branch modes: no accepted/actionable findings

## Live proof

- An earlier disposable funded-account canary created, used, explicitly reclaimed, and deleted `crabbox-pr946-live-89d4bf10`; foreign VMs remained and remote inventory returned to its original count.
- The disposable SSH key was removed and direct authentication with it failed afterward.
- Exact-head create/use/deny/destroy proof for `7099e142` is pending before merge because this candidate adds the remote generation and guarded-cleanup protocol.

## Provider contract

exe.dev exposes only name-based `rm`; it does not expose an immutable VM ID or conditional delete. This candidate uses the strongest available provider-visible identity: a random generation tag bound to the exact account, route, deterministic name, canonical lease/slug tags, and unchanged local claim, with a final recheck immediately before `rm`.
