### PR TITLE
ci: add hermetic connector lifecycle gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,24 @@ jobs:
       - name: Build
         run: go build -trimpath -o /tmp/crabbox ./cmd/crabbox
 
+  connector-lifecycles:
+    name: Connector Lifecycles
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Test source-derived hermetic lifecycle packages
+        run: scripts/test-provider-lifecycles.sh
+
   apple-vm:
     name: Apple VM
     runs-on: macos-15

--- a/docs/features/provider-live-smoke.md
+++ b/docs/features/provider-live-smoke.md
@@ -12,6 +12,41 @@ cover config, command construction, JSON parsing, lifecycle decisions, and error
 paths. A live smoke is the extra opt-in proof that the documented real substrate
 still matches the offline contract.
 
+## Validation tiers
+
+1. **Hermetic lifecycle** — required CI, no credentials, quota, network access,
+   or provider spend. Name full fake-backed lifecycle files
+   `lifecycle_test.go` or `*_lifecycle_test.go`; the source-derived Connector
+   Lifecycles job discovers their packages and runs them with the race detector.
+   Cover acquire, resolve/readiness, use, touch, list, release, cleanup failure,
+   and claim retention where the backend supports those stages.
+2. **Guarded live smoke** — opt-in developer or maintainer proof against the real
+   provider. Use `CRABBOX_LIVE=1`, select the exact provider, cap spend and TTL,
+   arm cleanup before the first mutation, and prove create/use/destroy with zero
+   residue. Funded or remote provider changes require this tier before merge.
+3. **Hosted live matrix** — not enabled. A future scheduled or manually
+   dispatched secret-backed workflow needs a separate repository policy for
+   trusted environments, provider credentials, spend limits, cancellation, and
+   orphan auditing. It must never expose secrets to pull-request code.
+
+The hermetic job is a visible merge gate, even though the broader Go job also
+runs the same packages. This deliberate overlap makes lifecycle coverage easy to
+find and keeps the gate source-derived instead of maintaining another provider
+allowlist.
+
+### Lifecycle contract
+
+| Stage | Backend contract | Typical CLI proof |
+| --- | --- | --- |
+| Acquire | `SSHLeaseBackend.Acquire` or delegated `Warmup` | `crabbox warmup` |
+| Resolve / readiness | `Resolve`, delegated `Status` | `crabbox status --wait` |
+| Use / sync | SSH execution or delegated `Run` | `crabbox run` |
+| Touch | `LeaseTouchBackend.Touch` | status or explicit backend test |
+| Inventory | `List`, `ListJSON`, `Inspect` | `crabbox list --json` |
+| Optional capabilities | copy, ports, checkpoint, pause/resume | provider-specific commands |
+| Release | `ReleaseLease` or delegated `Stop` | `crabbox stop` |
+| Orphan cleanup | `CleanupBackend.Cleanup` | `crabbox cleanup --dry-run` |
+
 ## Pick Candidates
 
 Start with the checked-in capability matrix:
@@ -84,3 +119,106 @@ Each provider that needs real credentials should document an opt-in smoke with:
 When live credentials are unavailable, land the offline tests and docs first.
 Mark the live smoke as opt-in instead of weakening the provider contract or
 pretending an untested live path is proven.
+
+## Tagged Go live smokes
+
+Some adapters keep narrow live checks next to their backend. These remain
+excluded from normal CI by the `smoke` build tag:
+
+```sh
+ISLO_API_KEY=... go test -tags smoke -run TestLiveIsloStatusClassification -v ./internal/providers/islo
+CRABBOX_LIVE_ISLO_PAUSE_RESUME=1 ISLO_API_KEY=... CRABBOX_LIVE_ISLO_IMAGE=... go test -tags smoke -run TestLiveIsloPauseResumeLifecycle -v ./internal/providers/islo
+CRABBOX_MORPH_API_KEY=... CRABBOX_LIVE_MORPH_SNAPSHOT=... go test -tags smoke -run TestLiveMorphAcquireResolveTouchReleaseLease -v ./internal/providers/morph
+CRABBOX_WANDB_API_KEY=... WANDB_ENTITY_NAME=... go test -tags smoke -run TestSmokeVersionAndExec -v ./internal/providers/wandb
+```
+
+Use environment injection or an approved credential store; do not put secret
+values on command lines, in repository config, fixtures, proof logs, or shell
+history.
+
+<!-- BEGIN GENERATED PROVIDER LIFECYCLE COVERAGE -->
+
+## Source-derived coverage matrix
+
+This matrix is generated from the registered provider list, convention-named
+hermetic lifecycle tests, `scripts/live-smoke.sh`, dedicated live runners, and
+`//go:build smoke` tests. Regenerate it with
+`node scripts/generate-provider-matrix.mjs`; docs CI rejects drift.
+
+Current coverage: 71 providers; 4 with convention-named hermetic lifecycle tests, 51 with a live runner, 3 with tagged Go smoke tests, and 19 with none of those lifecycle surfaces.
+
+| Provider | Hermetic lifecycle | Live runner | Tagged Go smoke |
+| --- | --- | --- | --- |
+| [agent-sandbox](../providers/agent-sandbox.md) | — | dedicated + matrix | — |
+| [anthropic-sandbox-runtime](../providers/anthropic-sandbox-runtime.md) | — | dedicated + matrix | — |
+| [apple-container](../providers/apple-container.md) | — | matrix | — |
+| [apple-machine](../providers/apple-machine.md) | — | — | — |
+| [apple-vm](../providers/apple-vm.md) | — | matrix | — |
+| [ascii-box](../providers/ascii-box.md) | — | — | — |
+| [aws](../providers/aws.md) | — | matrix | — |
+| [aws-lambda-microvm](../providers/aws-lambda-microvm.md) | — | dedicated + matrix | — |
+| [azure](../providers/azure.md) | — | — | — |
+| [azure-dynamic-sessions](../providers/azure-dynamic-sessions.md) | — | — | — |
+| [blacksmith-testbox](../providers/blacksmith-testbox.md) | — | matrix | — |
+| [blaxel](../providers/blaxel.md) | — | dedicated | — |
+| [cloudflare](../providers/cloudflare.md) | — | dedicated | — |
+| [cloudflare-dynamic-workers](../providers/cloudflare-dynamic-workers.md) | — | dedicated | — |
+| [cloudflare-sandbox](../providers/cloudflare-sandbox.md) | — | — | — |
+| [coder](../providers/coder.md) | — | matrix | — |
+| [codesandbox](../providers/codesandbox.md) | — | dedicated | — |
+| [crownest](../providers/crownest.md) | — | dedicated | — |
+| [daytona](../providers/daytona.md) | — | matrix | — |
+| [digitalocean](../providers/digitalocean.md) | — | dedicated + matrix | — |
+| [docker-sandbox](../providers/docker-sandbox.md) | — | dedicated + matrix | — |
+| [e2b](../providers/e2b.md) | — | matrix | — |
+| [exe-dev](../providers/exe-dev.md) | — | — | — |
+| [external](../providers/external.md) | — | matrix | — |
+| [fastapi-cloud](../providers/fastapi-cloud.md) | — | — | — |
+| [firecracker](../providers/firecracker.md) | yes (`firecracker`) | dedicated | — |
+| [freestyle](../providers/freestyle.md) | — | — | — |
+| [gcp](../providers/gcp.md) | — | — | — |
+| [hetzner](../providers/hetzner.md) | — | matrix | — |
+| [hostinger](../providers/hostinger.md) | — | — | — |
+| [hyperv](../providers/hyperv.md) | — | — | — |
+| [incus](../providers/incus.md) | — | matrix | — |
+| [islo](../providers/islo.md) | — | — | yes |
+| [kubevirt](../providers/kubevirt.md) | — | matrix | — |
+| [lambda](../providers/lambda.md) | — | dedicated | — |
+| [linode](../providers/linode.md) | — | dedicated + matrix | — |
+| [local-container](../providers/local-container.md) | — | matrix | — |
+| [modal](../providers/modal.md) | — | matrix | — |
+| [morph](../providers/morph.md) | — | matrix | yes |
+| [multipass](../providers/multipass.md) | — | matrix | — |
+| [mxc](../providers/mxc.md) | — | — | — |
+| [namespace-devbox](../providers/namespace-devbox.md) | — | matrix | — |
+| [namespace-instance](../providers/namespace-instance.md) | — | matrix | — |
+| [nebius](../providers/nebius.md) | yes (`nebius`) | dedicated + matrix | — |
+| [nomad](../providers/nomad.md) | yes (`nomad`) | dedicated + matrix | — |
+| [nvidia-brev](../providers/nvidia-brev.md) | — | dedicated + matrix | — |
+| [opencomputer](../providers/opencomputer.md) | — | — | — |
+| [opensandbox](../providers/opensandbox.md) | — | dedicated + matrix | — |
+| [ovh](../providers/ovh.md) | — | dedicated + matrix | — |
+| [parallels](../providers/parallels.md) | — | — | — |
+| [phala](../providers/phala.md) | — | dedicated + matrix | — |
+| [proxmox](../providers/proxmox.md) | — | dedicated + matrix | — |
+| [railway](../providers/railway.md) | — | — | — |
+| [runpod](../providers/runpod.md) | — | dedicated + matrix | — |
+| [scaleway](../providers/scaleway.md) | yes (`scaleway`) | dedicated + matrix | — |
+| [semaphore](../providers/semaphore.md) | — | matrix | — |
+| [smolvm](../providers/smolvm.md) | — | dedicated + matrix | — |
+| [sprites](../providers/sprites.md) | — | matrix | — |
+| [ssh](../providers/ssh.md) | — | — | — |
+| [superserve](../providers/superserve.md) | — | dedicated + matrix | — |
+| [tart](../providers/tart.md) | — | matrix | — |
+| [tencentcloud](../providers/tencentcloud.md) | — | dedicated + matrix | — |
+| [tenki](../providers/tenki.md) | — | matrix | — |
+| [tensorlake](../providers/tensorlake.md) | — | — | — |
+| [upstash-box](../providers/upstash-box.md) | — | — | — |
+| [vast](../providers/vast.md) | — | dedicated | — |
+| [vercel-sandbox](../providers/vercel-sandbox.md) | — | dedicated + matrix | — |
+| [vultr](../providers/vultr.md) | — | dedicated + matrix | — |
+| [wandb](../providers/wandb.md) | — | matrix | yes |
+| [windows-sandbox](../providers/windows-sandbox.md) | — | — | — |
+| [xcp-ng](../providers/xcp-ng.md) | — | dedicated + matrix | — |
+
+<!-- END GENERATED PROVIDER LIFECYCLE COVERAGE -->

--- a/scripts/generate-provider-matrix.mjs
+++ b/scripts/generate-provider-matrix.mjs
@@ -8,9 +8,12 @@ import { fileURLToPath } from "node:url";
 const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 const metadataPath = path.join(root, "docs", "providers", "provider-metadata.json");
 const readmePath = path.join(root, "docs", "providers", "README.md");
+const lifecycleGuidePath = path.join(root, "docs", "features", "provider-live-smoke.md");
 const benchmarkCategoriesPath = path.join(root, "internal", "cli", "provider_categories_generated.go");
 const beginMarker = "<!-- BEGIN GENERATED PROVIDER MATRIX -->";
 const endMarker = "<!-- END GENERATED PROVIDER MATRIX -->";
+const lifecycleBeginMarker = "<!-- BEGIN GENERATED PROVIDER LIFECYCLE COVERAGE -->";
+const lifecycleEndMarker = "<!-- END GENERATED PROVIDER LIFECYCLE COVERAGE -->";
 const check = process.argv.includes("--check");
 const allowed = {
   status: new Set(["built-in", "specialized"]),
@@ -56,15 +59,28 @@ function main() {
   validate(providers, metadata);
   const generated = render(providers, metadata);
   const readme = fs.readFileSync(readmePath, "utf8");
-  const next = replaceGenerated(readme, generated);
+  const next = replaceGenerated(readme, generated, beginMarker, endMarker, readmePath);
+  const lifecycleGuide = fs.readFileSync(lifecycleGuidePath, "utf8");
+  const coverage = lifecycleCoverage(providers, metadata);
+  const nextLifecycleGuide = replaceGenerated(
+    lifecycleGuide,
+    renderLifecycleCoverage(coverage),
+    lifecycleBeginMarker,
+    lifecycleEndMarker,
+    lifecycleGuidePath
+  );
 
   if (check) {
     if (next !== readme) {
       fail("provider decision matrix is stale; run node scripts/generate-provider-matrix.mjs");
     }
+    if (nextLifecycleGuide !== lifecycleGuide) {
+      fail("provider lifecycle coverage is stale; run node scripts/generate-provider-matrix.mjs");
+    }
     console.log(`checked provider matrix: ${providers.length} providers`);
   } else {
     fs.writeFileSync(readmePath, next, "utf8");
+    fs.writeFileSync(lifecycleGuidePath, nextLifecycleGuide, "utf8");
     console.log(`generated provider matrix: ${providers.length} providers`);
   }
 }
@@ -174,13 +190,84 @@ function render(providers, metadata) {
   return lines.join("\n");
 }
 
-function replaceGenerated(input, generated) {
-  const start = input.indexOf(beginMarker);
+function replaceGenerated(input, generated, startMarker, endMarker, targetPath) {
+  const start = input.indexOf(startMarker);
   const end = input.indexOf(endMarker);
   if (start < 0 || end < 0 || end < start) {
-    fail(`missing provider matrix markers in ${path.relative(root, readmePath)}`);
+    fail(`missing generated markers in ${path.relative(root, targetPath)}`);
   }
   return `${input.slice(0, start)}${generated}${input.slice(end + endMarker.length)}`;
+}
+
+function lifecycleCoverage(providers, metadata) {
+  const liveMatrixSource = fs.readFileSync(path.join(root, "scripts", "live-smoke.sh"), "utf8");
+  const matrixProviders = new Set(
+    [...liveMatrixSource.matchAll(/\bhas_provider\s+([a-z0-9-]+)/g)].map((match) => match[1])
+  );
+  return providers.map((provider) => {
+    const name = provider.provider;
+    const packageName = name === "blacksmith-testbox" ? "blacksmith" : name.replaceAll("-", "");
+    const packageDir = path.join(root, "internal", "providers", packageName);
+    const files = fs.existsSync(packageDir) ? fs.readdirSync(packageDir) : [];
+    const hermeticLifecycle = files.some((file) => /lifecycle.*_test\.go$/.test(file) && !hasSmokeBuildTag(path.join(packageDir, file)));
+    const goSmoke = files.some((file) => /(?:_live|smoke)_test\.go$/.test(file) && hasSmokeBuildTag(path.join(packageDir, file)));
+    const dedicatedSmoke = dedicatedLiveSmoke(name);
+    const matrixSmoke = matrixProviders.has(name);
+    return {
+      name,
+      docs: metadata[name].docs,
+      packageName,
+      hermeticLifecycle,
+      goSmoke,
+      dedicatedSmoke,
+      matrixSmoke
+    };
+  });
+}
+
+function hasSmokeBuildTag(file) {
+  return fs.readFileSync(file, "utf8").split("\n", 8).some((line) => line.trim() === "//go:build smoke");
+}
+
+function dedicatedLiveSmoke(provider) {
+  const candidates = [path.join(root, "scripts", `live-${provider}-smoke.sh`)];
+  if (provider === "cloudflare") candidates.push(path.join(root, "scripts", "deploy-cloudflare-smoke.sh"));
+  if (provider === "cloudflare-dynamic-workers") candidates.push(path.join(root, "scripts", "deploy-cloudflare-dynamic-workers-smoke.sh"));
+  if (provider === "codesandbox") candidates.push(path.join(root, "scripts", "live-codesandbox-smoke.test.js"));
+  if (provider === "proxmox") candidates.push(path.join(root, "scripts", "proxmox-live-smoke.sh"));
+  if (provider === "xcp-ng") candidates.push(path.join(root, "scripts", "xcpng-live-smoke.sh"));
+  return candidates.some((file) => fs.existsSync(file));
+}
+
+function renderLifecycleCoverage(coverage) {
+  const hermeticCount = coverage.filter((provider) => provider.hermeticLifecycle).length;
+  const liveCount = coverage.filter((provider) => provider.dedicatedSmoke || provider.matrixSmoke).length;
+  const goSmokeCount = coverage.filter((provider) => provider.goSmoke).length;
+  const uncoveredCount = coverage.filter(
+    (provider) => !provider.hermeticLifecycle && !provider.dedicatedSmoke && !provider.matrixSmoke && !provider.goSmoke
+  ).length;
+  const lines = [
+    lifecycleBeginMarker,
+    "",
+    "## Source-derived coverage matrix",
+    "",
+    "This matrix is generated from the registered provider list, convention-named",
+    "hermetic lifecycle tests, `scripts/live-smoke.sh`, dedicated live runners, and",
+    "`//go:build smoke` tests. Regenerate it with",
+    "`node scripts/generate-provider-matrix.mjs`; docs CI rejects drift.",
+    "",
+    `Current coverage: ${coverage.length} providers; ${hermeticCount} with convention-named hermetic lifecycle tests, ${liveCount} with a live runner, ${goSmokeCount} with tagged Go smoke tests, and ${uncoveredCount} with none of those lifecycle surfaces.`,
+    "",
+    "| Provider | Hermetic lifecycle | Live runner | Tagged Go smoke |",
+    "| --- | --- | --- | --- |"
+  ];
+  for (const provider of coverage) {
+    const hermetic = provider.hermeticLifecycle ? `yes (\`${provider.packageName}\`)` : "—";
+    const live = provider.dedicatedSmoke && provider.matrixSmoke ? "dedicated + matrix" : provider.dedicatedSmoke ? "dedicated" : provider.matrixSmoke ? "matrix" : "—";
+    lines.push(`| [${provider.name}](../providers/${provider.docs}) | ${hermetic} | ${live} | ${provider.goSmoke ? "yes" : "—"} |`);
+  }
+  lines.push("", lifecycleEndMarker);
+  return lines.join("\n");
 }
 
 function renderBenchmarkCategories(metadata) {

--- a/scripts/test-provider-lifecycles.sh
+++ b/scripts/test-provider-lifecycles.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root"
+
+packages=()
+while IFS= read -r file; do
+  if sed -n '1,8p' "$file" | grep -q '^//go:build smoke$'; then
+    continue
+  fi
+  package="./$(dirname "$file")"
+  found=0
+  for existing in "${packages[@]-}"; do
+    if [[ "$existing" == "$package" ]]; then
+      found=1
+      break
+    fi
+  done
+  if [[ "$found" == "0" ]]; then
+    packages+=("$package")
+  fi
+done < <(git ls-files 'internal/providers/*/*lifecycle*_test.go')
+
+if [[ "${#packages[@]}" == "0" ]]; then
+  echo "no convention-named provider lifecycle tests found" >&2
+  exit 1
+fi
+
+printf 'testing %d provider lifecycle packages\n' "${#packages[@]}"
+go test -race "${packages[@]}"


### PR DESCRIPTION
## Summary

- add a no-secret `Connector Lifecycles` CI job that discovers convention-named provider lifecycle test packages directly from the repository and runs them with the race detector
- document the hermetic, guarded-live, and policy-gated hosted-live validation tiers plus the shared lifecycle contract
- generate a complete 71-provider coverage matrix from provider registration, lifecycle tests, live runners, and tagged Go smoke tests
- keep secret-backed scheduled provider CI out of scope until repository credential, spend, cancellation, and orphan-audit policy is explicit

This is the safe tier-1 slice of https://github.com/openclaw/crabbox/issues/944. The umbrella issue remains open for broader lifecycle coverage and the separately governed hosted-live tier.

## Verification

- `scripts/test-provider-lifecycles.sh`
- `node scripts/generate-provider-matrix.mjs --check`
- `scripts/check-docs.sh`
- `bash -n scripts/test-provider-lifecycles.sh`
- `node --test scripts/*.test.js` (385 passed)
- `go test ./scripts`
- AutoReview local and branch modes: no accepted/actionable findings

## Security / secrets

- the new job has read-only repository permissions and receives no secrets
- no `pull_request` path can reach provider credentials or funded capacity
- live provider execution remains explicit, opt-in, and outside this workflow
