### PR TITLE
fix(security): bind External SSH credential destinations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Prevented repository-controlled External SSH endpoint templates and adapter output from silently using ambient or operator-managed SSH credentials, with source-bound opt-ins for environment-derived fields and provider-returned destinations. Thanks @coygeek.
 - Made Sealos DevBox preflight work with tenant-scoped RBAC, rendered the runtime class, storage request, scheduling constraints, and SSH port contract required by hosted Sealos clusters, updated the SSHGate default to port 2233, bootstrapped missing sync tools, and cleaned local claims safely when a DevBox is already absent. Thanks @coygeek.
 - Changed portal logout to an authenticated, same-origin `POST` with a read-only `GET` confirmation page, preventing cross-site top-level navigation from clearing portal cookies or revoking isolated Code viewer sessions. Thanks @coygeek.
 - Bound non-admin GitHub WebVNC, Code, and egress bridges to their encrypted user grant and portal session, closing active or restored bridges after logout, emergency revocation, membership loss, or membership-check failure without persisting plaintext GitHub credentials. Thanks @coygeek.

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -726,9 +726,17 @@ external:
   config:
     backend: vm
     namespace: team-devboxes
+  connection:
+    ssh:
+      trustProviderOutput: true
   workRoot: /workspaces/crabbox
   routingFile: ""
 ```
+
+If the protocol response contains SSH coordinates, keep
+`trustProviderOutput: true` together with the exact command, arguments, and
+`external.config` plus its connection inputs in trusted user config. Repository
+config cannot inherit the approval after changing that adapter contract.
 
 The executable receives one versioned JSON request on stdin per lifecycle
 operation and returns one JSON response on stdout. This keeps internal control
@@ -762,11 +770,18 @@ external:
     ssh:
       user: "{{env.DEVBOX_USER}}"
       host: "{{resourceName}}"
+      allowEnv: true
+      trustProviderOutput: true
       sshConfigProxy: true
   config:
     size: cpu16
   workRoot: /home/developer/crabbox
 ```
+
+Put this destination-bearing example in trusted user config. Repository config
+may define the lifecycle, but its exact `resourceName`, SSH destination, and
+environment opt-in must be repeated in trusted user config before Crabbox uses
+operator-managed SSH credentials.
 
 Declarative lifecycle entries use one `argv` array or an ordered `steps` list,
 not shell commands. Acquire steps can opt into release cleanup with

--- a/docs/providers/external.md
+++ b/docs/providers/external.md
@@ -28,9 +28,18 @@ external:
     backend: vm
     namespace: team-devboxes
     size: cpu32
+  connection:
+    ssh:
+      trustProviderOutput: true
   workRoot: /workspaces/crabbox
   routingFile: ""
 ```
+
+When a protocol command returns SSH coordinates, put
+`connection.ssh.trustProviderOutput: true` in the same trusted user config as
+the exact command, arguments, `external.config`, and connection inputs.
+Repository config cannot self-enable this contract, and changing the
+output-producing adapter contract invalidates an inherited approval.
 
 `external.config` is arbitrary YAML passed as JSON to the executable. Keep
 secrets in the executable's normal credential store or environment rather than
@@ -119,12 +128,19 @@ external:
       user: "{{env.DEVBOX_USER}}"
       host: "{{resourceName}}"
       port: "22"
+      allowEnv: true
+      trustProviderOutput: true
       sshConfigProxy: true
       readyCheck: command -v git && command -v rsync && command -v tar
   config:
     size: cpu16
   workRoot: /home/developer/crabbox
 ```
+
+Place this destination-bearing example in trusted user config. If repository
+config owns the lifecycle, repeat the exact `resourceName`, SSH destination,
+and environment opt-in in trusted user config before using operator-managed
+SSH credentials.
 
 `acquire`, `list`, `release`, and `connection.ssh.user` are required.
 Lifecycle operations configure exactly one of `argv` or `steps`. Steps run in
@@ -176,6 +192,27 @@ later release still requires `allowEnvArgv` before placing `{{resourceName}}`
 back in argv. Do not use either opt-in for tokens, passwords, API keys, or
 other credential contents.
 
+Environment-derived expansion in `connection.ssh` fields is rejected by
+default, including indirect use through an environment-backed `resourceName`,
+because values such as the SSH user, host, key path, ready check, or proxy
+command can expose process environment data to a network destination or local
+process. For non-secret environment-backed SSH routing values, set
+`connection.ssh.allowEnv: true` in trusted user config. Repository config
+cannot grant itself this opt-in. The opt-in does not approve inherited SSH
+authentication for a repository-selected destination.
+
+A repository-selected External SSH `host`, default-host `resourceName`, or
+`proxyCommand` is rejected even when the repository supplies a key. OpenSSH
+can still add identities from operator user config, and a nested SSH proxy can
+authenticate independently of the outer key. To approve the destination,
+repeat the exact SSH endpoint templates (user, host, key, port, fallback ports,
+and proxy settings) plus any `resourceName` they reference in trusted user
+config (see
+[Configuration](../features/configuration.md#precedence)).
+Templates that reference `repo.*` inputs remain repository-selected. Templates
+that reference `config.*` are approved only when the effective
+`external.config` map also comes from trusted config.
+
 `leaseIdSlug` is the lease ID normalized as a lowercase slug, suitable for
 providers that require DNS-style names. `resourceName` is the expanded
 `connection.resourceName`.
@@ -216,7 +253,14 @@ external:
     resourceName: "{{leaseIdSlug}}"
     ssh:
       user: developer
+      trustProviderOutput: true
 ```
+
+Because `json-lease` and `json-lease-array` may supply SSH coordinates directly,
+their `trustProviderOutput` contract and the complete lifecycle/configuration
+that produces the output must be approved together in trusted user config.
+Without that explicit source-bound approval, Crabbox rejects returned SSH
+coordinates before connecting or persisting validated routing state.
 
 A declarative adapter qualifies for controller fixed-ID provisioning only when
 `idempotentLeaseId` is true, both acquire and resolve use `json-lease`, list
@@ -241,6 +285,8 @@ reserved `lease`, `slug`, `name`, `externalResourceName`, or
 For `json-name-array`, optional `list.namePrefix` discards inventory names
 outside the expanded prefix before Crabbox constructs leases. Use it when a
 provider CLI lists resources that are not all owned by this configuration.
+Both list formats select SSH destinations and therefore require the same
+source-bound `connection.ssh.trustProviderOutput` contract.
 
 Declarative configuration and resolved connection templates are included in
 the private per-lease routing file. This lets generated retry, daemon, SSH, and

--- a/docs/security.md
+++ b/docs/security.md
@@ -260,14 +260,25 @@ destination checks, including a symlink outside the checkout that resolves
 back into it. The canonical user config and explicit files outside the active
 repository remain operator-trusted sources.
 
-Repository-selected Static SSH, remote Parallels, and exe.dev control hosts
-cannot inherit a key, SSH agent, or local SSH configuration from a more trusted
-source. Put both a Static SSH or Parallels host and a relative, symlink-resolved
-key file contained by the repository in the same repository config, or
-explicitly approve the destination with the matching host flag or environment
-variable. Absolute, missing, and repository-escaping key paths do not count as
-same-source credentials. Because exe.dev control authentication is always
-ambient, a repository-defined custom control host requires an explicit
+Repository-selected Static SSH, remote Parallels, External SSH, and exe.dev
+control hosts cannot inherit a key, SSH agent, or local SSH configuration from
+a more trusted source. Static SSH and Parallels may pair the destination with
+a relative, symlink-resolved key file contained by the same repository;
+absolute, missing, and repository-escaping key paths do not count as
+same-source credentials. They can instead use the matching host flag or
+environment variable for approval. External SSH always requires the exact SSH
+endpoint (user, host, key, port, fallback ports, and proxy settings) plus any
+referenced `resourceName` to be repeated in trusted user config because
+operator SSH config and nested proxies can add
+authentication independently of an outer key. Repository-controlled template
+inputs keep the resulting destination in the repository trust domain, and the
+SSH environment-expansion opt-in is honored only from trusted user config.
+Protocol or declarative JSON output may supply SSH coordinates only when the
+exact output-producing adapter contract and `ssh.trustProviderOutput` are
+approved together in trusted user config; repository changes invalidate that
+approval.
+Because exe.dev control authentication is always ambient, a repository-defined
+custom control host requires an explicit
 `--exe-dev-control-host` or `CRABBOX_EXE_DEV_CONTROL_HOST` override.
 
 Cookie-authenticated portal mutations and portal viewer WebSocket upgrades

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -456,15 +456,16 @@ type AgentSandboxConfig struct {
 }
 
 type ExternalConfig struct {
-	Command       string
-	Args          []string
-	Config        map[string]any
-	Capabilities  ExternalCapabilitiesConfig
-	Lifecycle     ExternalLifecycleConfig
-	Connection    ExternalConnectionConfig
-	WorkRoot      string
-	RoutingFile   string
-	routingLoaded bool
+	Command                  string
+	Args                     []string
+	Config                   map[string]any
+	Capabilities             ExternalCapabilitiesConfig
+	Lifecycle                ExternalLifecycleConfig
+	Connection               ExternalConnectionConfig
+	WorkRoot                 string
+	RoutingFile              string
+	routingLoaded            bool
+	routingCredentialVersion int
 }
 
 type ExternalCapabilitiesConfig struct {
@@ -501,16 +502,18 @@ type ExternalConnectionConfig struct {
 }
 
 type ExternalSSHConnectionConfig struct {
-	User            string   `yaml:"user,omitempty" json:"user,omitempty"`
-	Host            string   `yaml:"host,omitempty" json:"host,omitempty"`
-	Key             string   `yaml:"key,omitempty" json:"key,omitempty"`
-	Port            string   `yaml:"port,omitempty" json:"port,omitempty"`
-	FallbackPorts   []string `yaml:"fallbackPorts,omitempty" json:"fallbackPorts,omitempty"`
-	ReadyCheck      string   `yaml:"readyCheck,omitempty" json:"readyCheck,omitempty"`
-	AuthSecret      bool     `yaml:"authSecret,omitempty" json:"authSecret,omitempty"`
-	NoControlMaster bool     `yaml:"noControlMaster,omitempty" json:"noControlMaster,omitempty"`
-	SSHConfigProxy  bool     `yaml:"sshConfigProxy,omitempty" json:"sshConfigProxy,omitempty"`
-	ProxyCommand    string   `yaml:"proxyCommand,omitempty" json:"proxyCommand,omitempty"`
+	User                string   `yaml:"user,omitempty" json:"user,omitempty"`
+	Host                string   `yaml:"host,omitempty" json:"host,omitempty"`
+	Key                 string   `yaml:"key,omitempty" json:"key,omitempty"`
+	Port                string   `yaml:"port,omitempty" json:"port,omitempty"`
+	FallbackPorts       []string `yaml:"fallbackPorts,omitempty" json:"fallbackPorts,omitempty"`
+	ReadyCheck          string   `yaml:"readyCheck,omitempty" json:"readyCheck,omitempty"`
+	AuthSecret          bool     `yaml:"authSecret,omitempty" json:"authSecret,omitempty"`
+	NoControlMaster     bool     `yaml:"noControlMaster,omitempty" json:"noControlMaster,omitempty"`
+	SSHConfigProxy      bool     `yaml:"sshConfigProxy,omitempty" json:"sshConfigProxy,omitempty"`
+	ProxyCommand        string   `yaml:"proxyCommand,omitempty" json:"proxyCommand,omitempty"`
+	AllowEnv            bool     `yaml:"allowEnv,omitempty" json:"allowEnv,omitempty"`
+	TrustProviderOutput bool     `yaml:"trustProviderOutput,omitempty" json:"trustProviderOutput,omitempty"`
 }
 
 type NamespaceConfig struct {
@@ -5844,6 +5847,7 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 		}
 		if file.External.Config != nil {
 			cfg.External.Config = file.External.Config
+			cfg.credentialProvenance.externalConfig = credentialSource
 		}
 		if file.External.Capabilities != nil {
 			cfg.External.Capabilities = *file.External.Capabilities
@@ -5853,12 +5857,62 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 		}
 		if file.External.Connection != nil {
 			cfg.External.Connection = *file.External.Connection
+			ssh := cfg.External.Connection.SSH
+			cfg.credentialProvenance.externalSSHConnection = credentialSource
+			if trusted {
+				outputContract, outputContractOK := externalProviderOutputContract(cfg.External)
+				if ssh.TrustProviderOutput && !outputContractOK {
+					return exit(2, "external provider-output contract must be JSON encodable")
+				}
+				cfg.credentialProvenance.externalApproved = externalCredentialApproval{
+					resource:       cfg.External.Connection.ResourceName,
+					host:           ssh.Host,
+					proxy:          ssh.ProxyCommand,
+					allowEnv:       ssh.AllowEnv,
+					envSSH:         ssh,
+					providerOutput: ssh.TrustProviderOutput,
+					outputContract: outputContract,
+				}
+				cfg.credentialProvenance.externalApproved.envSSH.FallbackPorts = append([]string(nil), ssh.FallbackPorts...)
+			}
+			cfg.credentialProvenance.externalResource = credentialDestinationSource(
+				cfg.External.Connection.ResourceName, cfg.credentialProvenance.externalApproved.resource, credentialSource,
+			)
+			cfg.credentialProvenance.externalSSHHost = credentialDestinationSource(
+				ssh.Host, cfg.credentialProvenance.externalApproved.host, credentialSource,
+			)
+			cfg.credentialProvenance.externalSSHProxy = credentialDestinationSource(
+				ssh.ProxyCommand, cfg.credentialProvenance.externalApproved.proxy, credentialSource,
+			)
+			cfg.credentialProvenance.externalSSHAllowEnv = credentialSourceForBool(ssh.AllowEnv, credentialSource)
+			if !trusted && ssh.AllowEnv && cfg.credentialProvenance.externalApproved.allowEnv &&
+				externalSSHEnvApprovalMatches(cfg.External.Connection, cfg.credentialProvenance.externalApproved) {
+				cfg.credentialProvenance.externalSSHAllowEnv = credentialSourceTrustedFile
+			}
 		}
 		if file.External.WorkRoot != "" {
 			cfg.External.WorkRoot = file.External.WorkRoot
 		}
 		if file.External.RoutingFile != "" {
 			cfg.External.RoutingFile = file.External.RoutingFile
+			cfg.credentialProvenance.externalRouting = credentialSource
+		}
+		if cfg.External.Connection.SSH.TrustProviderOutput {
+			outputContract, outputContractOK := externalProviderOutputContract(cfg.External)
+			if trusted {
+				if !outputContractOK {
+					return exit(2, "external provider-output contract must be JSON encodable")
+				}
+				cfg.credentialProvenance.externalApproved.providerOutput = true
+				cfg.credentialProvenance.externalApproved.outputContract = outputContract
+				cfg.credentialProvenance.externalSSHOutput = credentialSourceTrustedFile
+			} else {
+				cfg.credentialProvenance.externalSSHOutput = credentialSourceRepository
+				if cfg.credentialProvenance.externalApproved.providerOutput &&
+					outputContractOK && outputContract == cfg.credentialProvenance.externalApproved.outputContract {
+					cfg.credentialProvenance.externalSSHOutput = credentialSourceTrustedFile
+				}
+			}
 		}
 	}
 	if file.Namespace != nil {
@@ -8098,12 +8152,23 @@ func applyEnv(cfg *Config) error {
 	if value, ok := getenvBool("CRABBOX_AGENT_SANDBOX_FORGET_MISSING"); ok {
 		cfg.AgentSandbox.ForgetMissing = value
 	}
-	cfg.External.Command = getenv("CRABBOX_EXTERNAL_COMMAND", cfg.External.Command)
+	externalProviderOutputExplicit := false
+	if value := os.Getenv("CRABBOX_EXTERNAL_COMMAND"); value != "" {
+		cfg.External.Command = value
+		externalProviderOutputExplicit = true
+	}
 	if arg := os.Getenv("CRABBOX_EXTERNAL_ARG"); arg != "" {
 		cfg.External.Args = []string{arg}
+		externalProviderOutputExplicit = true
+	}
+	if externalProviderOutputExplicit {
+		markExternalProviderOutputExplicit(cfg, credentialSourceEnvironment)
 	}
 	cfg.External.WorkRoot = getenv("CRABBOX_EXTERNAL_WORK_ROOT", cfg.External.WorkRoot)
-	cfg.External.RoutingFile = getenv("CRABBOX_EXTERNAL_ROUTING_FILE", cfg.External.RoutingFile)
+	if value := os.Getenv("CRABBOX_EXTERNAL_ROUTING_FILE"); value != "" {
+		cfg.External.RoutingFile = value
+		cfg.credentialProvenance.externalRouting = credentialSourceEnvironment
+	}
 	if value, ok := getenvBool("CRABBOX_EXTERNAL_IDEMPOTENT_LEASE_ID"); ok {
 		cfg.External.Capabilities.IdempotentLeaseID = value
 	}

--- a/internal/cli/credential_provenance.go
+++ b/internal/cli/credential_provenance.go
@@ -1,9 +1,12 @@
 package cli
 
 import (
+	"crypto/sha256"
+	"encoding/json"
 	"flag"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 )
 
@@ -18,62 +21,81 @@ const (
 )
 
 type credentialDestinationProvenance struct {
-	coordinator         credentialValueSource
-	coordToken          credentialValueSource
-	coordTokenCommand   credentialValueSource
-	coordAdminToken     credentialValueSource
-	accessClientID      credentialValueSource
-	accessClientSecret  credentialValueSource
-	accessToken         credentialValueSource
-	azSessionsEndpoint  credentialValueSource
-	proxmoxAPIURL       credentialValueSource
-	proxmoxTokenID      credentialValueSource
-	proxmoxTokenSecret  credentialValueSource
-	proxmoxInsecureTLS  credentialValueSource
-	morphAPIURL         credentialValueSource
-	morphAPIKey         credentialValueSource
-	morphSSHGatewayHost credentialValueSource
-	daytonaAPIURL       credentialValueSource
-	daytonaAPIKey       credentialValueSource
-	daytonaJWTToken     credentialValueSource
-	daytonaSSHGateway   credentialValueSource
-	e2bAPIURL           credentialValueSource
-	e2bDomain           credentialValueSource
-	e2bAPIKey           credentialValueSource
-	railwayAPIURL       credentialValueSource
-	railwayAPIToken     credentialValueSource
-	fastAPICloudAPIURL  credentialValueSource
-	fastAPICloudToken   credentialValueSource
-	runpodAPIURL        credentialValueSource
-	runpodAPIKey        credentialValueSource
-	vastAPIURL          credentialValueSource
-	vastAPIKey          credentialValueSource
-	isloBaseURL         credentialValueSource
-	isloAPIKey          credentialValueSource
-	tenkiEndpoint       credentialValueSource
-	tenkiGateway        credentialValueSource
-	tensorlakeAPIURL    credentialValueSource
-	tensorlakeAPIKey    credentialValueSource
-	upstashBoxBaseURL   credentialValueSource
-	upstashBoxAPIKey    credentialValueSource
-	smolvmBaseURL       credentialValueSource
-	smolvmAPIKey        credentialValueSource
-	asciiBoxBaseURL     credentialValueSource
-	asciiBoxAPIKey      credentialValueSource
-	cloudflareAPIURL    credentialValueSource
-	cloudflareToken     credentialValueSource
-	nomadAddress        credentialValueSource
-	nomadTokenEnv       credentialValueSource
-	semaphoreHost       credentialValueSource
-	semaphoreToken      credentialValueSource
-	spritesAPIURL       credentialValueSource
-	spritesToken        credentialValueSource
-	parallelsHost       credentialValueSource
-	parallelsHostKey    credentialValueSource
-	staticHost          credentialValueSource
-	sshKey              credentialValueSource
-	exeDevControlHost   credentialValueSource
-	repositoryRoot      string
+	coordinator           credentialValueSource
+	coordToken            credentialValueSource
+	coordTokenCommand     credentialValueSource
+	coordAdminToken       credentialValueSource
+	accessClientID        credentialValueSource
+	accessClientSecret    credentialValueSource
+	accessToken           credentialValueSource
+	azSessionsEndpoint    credentialValueSource
+	proxmoxAPIURL         credentialValueSource
+	proxmoxTokenID        credentialValueSource
+	proxmoxTokenSecret    credentialValueSource
+	proxmoxInsecureTLS    credentialValueSource
+	morphAPIURL           credentialValueSource
+	morphAPIKey           credentialValueSource
+	morphSSHGatewayHost   credentialValueSource
+	daytonaAPIURL         credentialValueSource
+	daytonaAPIKey         credentialValueSource
+	daytonaJWTToken       credentialValueSource
+	daytonaSSHGateway     credentialValueSource
+	e2bAPIURL             credentialValueSource
+	e2bDomain             credentialValueSource
+	e2bAPIKey             credentialValueSource
+	railwayAPIURL         credentialValueSource
+	railwayAPIToken       credentialValueSource
+	fastAPICloudAPIURL    credentialValueSource
+	fastAPICloudToken     credentialValueSource
+	runpodAPIURL          credentialValueSource
+	runpodAPIKey          credentialValueSource
+	vastAPIURL            credentialValueSource
+	vastAPIKey            credentialValueSource
+	isloBaseURL           credentialValueSource
+	isloAPIKey            credentialValueSource
+	tenkiEndpoint         credentialValueSource
+	tenkiGateway          credentialValueSource
+	tensorlakeAPIURL      credentialValueSource
+	tensorlakeAPIKey      credentialValueSource
+	upstashBoxBaseURL     credentialValueSource
+	upstashBoxAPIKey      credentialValueSource
+	smolvmBaseURL         credentialValueSource
+	smolvmAPIKey          credentialValueSource
+	asciiBoxBaseURL       credentialValueSource
+	asciiBoxAPIKey        credentialValueSource
+	cloudflareAPIURL      credentialValueSource
+	cloudflareToken       credentialValueSource
+	nomadAddress          credentialValueSource
+	nomadTokenEnv         credentialValueSource
+	semaphoreHost         credentialValueSource
+	semaphoreToken        credentialValueSource
+	spritesAPIURL         credentialValueSource
+	spritesToken          credentialValueSource
+	parallelsHost         credentialValueSource
+	parallelsHostKey      credentialValueSource
+	staticHost            credentialValueSource
+	sshKey                credentialValueSource
+	exeDevControlHost     credentialValueSource
+	externalConfig        credentialValueSource
+	externalResource      credentialValueSource
+	externalSSHConnection credentialValueSource
+	externalSSHHost       credentialValueSource
+	externalSSHProxy      credentialValueSource
+	externalSSHAllowEnv   credentialValueSource
+	externalSSHOutput     credentialValueSource
+	externalRouting       credentialValueSource
+	externalApproved      externalCredentialApproval
+	repositoryRoot        string
+}
+
+type externalCredentialApproval struct {
+	resource       string
+	host           string
+	proxy          string
+	allowEnv       bool
+	envSSH         ExternalSSHConnectionConfig
+	providerOutput bool
+	outputContract [32]byte
 }
 
 type sourcedCredential struct {
@@ -86,6 +108,16 @@ func credentialSourceForFile(trusted bool) credentialValueSource {
 		return credentialSourceTrustedFile
 	}
 	return credentialSourceRepository
+}
+
+func credentialDestinationSource(value, approved string, source credentialValueSource) credentialValueSource {
+	if strings.TrimSpace(value) == "" {
+		return credentialSourceUnknown
+	}
+	if source == credentialSourceRepository && approved != "" && value == approved {
+		return credentialSourceTrustedFile
+	}
+	return source
 }
 
 func firstNonEmptyEnv(names ...string) (string, bool) {
@@ -192,6 +224,12 @@ func markCredentialDestinationFlagSources(cfg *Config, fs *flag.FlagSet) {
 	}
 	if flagWasSet(fs, "exe-dev-control-host") {
 		provenance.exeDevControlHost = credentialSourceFlag
+	}
+	if flagWasSet(fs, "external-routing-file") {
+		provenance.externalRouting = credentialSourceFlag
+	}
+	if flagWasSet(fs, "external-config-json") {
+		provenance.externalConfig = credentialSourceFlag
 	}
 }
 
@@ -346,8 +384,261 @@ func validateProviderCredentialDestination(cfg Config) error {
 		if provenance.exeDevControlHost == credentialSourceRepository {
 			return repositoryCredentialDestinationError("exe-dev", "exeDev.controlHost", "CRABBOX_EXE_DEV_CONTROL_HOST or --exe-dev-control-host")
 		}
+	case "external":
+		if cfg.External.Connection.SSH.TrustProviderOutput && provenance.externalSSHOutput == credentialSourceRepository {
+			return repositoryCredentialDestinationError("external", "external.connection.ssh.trustProviderOutput", "the same provider-output contract in trusted user config")
+		}
+		if !externalDeclarativeLifecycleConfigured(cfg.External) {
+			break
+		}
+		if cfg.External.Connection.SSH.AllowEnv && provenance.externalSSHAllowEnv == credentialSourceRepository {
+			return repositoryCredentialDestinationError("external", "external.connection.ssh.allowEnv", "the same opt-in in trusted user config")
+		}
+		resourceSource := externalTemplateCredentialSource(
+			cfg.External.Connection.ResourceName,
+			provenance.externalResource,
+			credentialSourceUnknown,
+			provenance.externalConfig,
+		)
+		hostSource := provenance.externalSSHHost
+		if strings.TrimSpace(cfg.External.Connection.SSH.Host) == "" {
+			hostSource = resourceSource
+		} else {
+			hostSource = externalTemplateCredentialSource(
+				cfg.External.Connection.SSH.Host, hostSource, resourceSource, provenance.externalConfig,
+			)
+		}
+		proxySource := externalTemplateCredentialSource(
+			cfg.External.Connection.SSH.ProxyCommand,
+			provenance.externalSSHProxy,
+			resourceSource,
+			provenance.externalConfig,
+		)
+		if proxySource == credentialSourceRepository {
+			return repositoryCredentialDestinationError("external", "external.connection.ssh.proxyCommand", "the same proxy command in trusted user config")
+		}
+		if hostSource == credentialSourceRepository {
+			return repositoryCredentialDestinationError("external", "external.connection.ssh.host", "the same destination in trusted user config")
+		}
+		if externalSSHEndpointUsesRepositoryInput(
+			cfg.External.Connection,
+			provenance.externalApproved,
+			provenance.externalSSHConnection,
+			resourceSource,
+			provenance.externalConfig,
+		) {
+			return repositoryCredentialDestinationError("external", "external.connection.ssh endpoint", "trusted endpoint templates and trusted template inputs")
+		}
+		if provenance.externalSSHConnection == credentialSourceRepository &&
+			!externalSSHEndpointApprovalMatches(cfg.External.Connection, provenance.externalApproved) {
+			return repositoryCredentialDestinationError("external", "external.connection.ssh endpoint", "the same user, host, key, port, fallback ports, and proxy settings in trusted user config")
+		}
 	}
 	return nil
+}
+
+// ValidateProviderCredentialDestination enforces source-bound credential
+// routing for provider entry points that can load configuration after the
+// normal CLI validation phase.
+func ValidateProviderCredentialDestination(cfg Config) error {
+	return validateProviderCredentialDestination(cfg)
+}
+
+// ValidateExternalProviderSSHOutput requires a trusted, source-bound contract
+// before adapter output may supply SSH coordinates directly.
+func ValidateExternalProviderSSHOutput(cfg Config) error {
+	if !cfg.External.Connection.SSH.TrustProviderOutput {
+		return exit(2, "external provider SSH output requires external.connection.ssh.trustProviderOutput in trusted user config")
+	}
+	if cfg.credentialProvenance.externalSSHOutput == credentialSourceRepository {
+		return repositoryCredentialDestinationError("external", "external.connection.ssh.trustProviderOutput", "the same provider-output contract in trusted user config")
+	}
+	return nil
+}
+
+func externalTemplateCredentialSource(value string, source, resourceSource, configSource credentialValueSource) credentialValueSource {
+	if strings.Contains(value, "{{repo.") {
+		return credentialSourceRepository
+	}
+	if configSource == credentialSourceRepository && strings.Contains(value, "{{config.") {
+		return credentialSourceRepository
+	}
+	if resourceSource == credentialSourceRepository && strings.Contains(value, "{{resourceName}}") {
+		return credentialSourceRepository
+	}
+	return source
+}
+
+func externalDeclarativeLifecycleConfigured(cfg ExternalConfig) bool {
+	return len(cfg.Lifecycle.Acquire.Argv) > 0 || len(cfg.Lifecycle.Acquire.Steps) > 0
+}
+
+// MarkExternalRoutingCredentialSources applies the routing file's trust source
+// to connection values after the External provider loads that private state.
+// An unknown source is reserved for claim-bound automatic routing.
+func MarkExternalRoutingCredentialSources(cfg *Config) {
+	source := cfg.credentialProvenance.externalRouting
+	if source == credentialSourceUnknown {
+		source = credentialSourceTrustedFile
+	}
+	connection := cfg.External.Connection
+	provenance := &cfg.credentialProvenance
+	provenance.externalConfig = source
+	provenance.externalResource = credentialDestinationSource(connection.ResourceName, provenance.externalApproved.resource, source)
+	provenance.externalSSHConnection = source
+	provenance.externalSSHHost = credentialDestinationSource(connection.SSH.Host, provenance.externalApproved.host, source)
+	provenance.externalSSHProxy = credentialDestinationSource(connection.SSH.ProxyCommand, provenance.externalApproved.proxy, source)
+	provenance.externalSSHAllowEnv = credentialSourceForBool(connection.SSH.AllowEnv, source)
+	if source == credentialSourceRepository && connection.SSH.AllowEnv && provenance.externalApproved.allowEnv &&
+		externalSSHEnvApprovalMatches(connection, provenance.externalApproved) {
+		provenance.externalSSHAllowEnv = credentialSourceTrustedFile
+	}
+	provenance.externalSSHOutput = credentialSourceForBool(connection.SSH.TrustProviderOutput, source)
+	outputContract, outputContractOK := externalProviderOutputContract(cfg.External)
+	if source == credentialSourceRepository && connection.SSH.TrustProviderOutput && provenance.externalApproved.providerOutput &&
+		outputContractOK && outputContract == provenance.externalApproved.outputContract {
+		provenance.externalSSHOutput = credentialSourceTrustedFile
+	}
+}
+
+// MarkExternalRoutingFileExplicit records an operator-selected routing path
+// before the External provider loads it during flag application.
+func MarkExternalRoutingFileExplicit(cfg *Config) {
+	cfg.credentialProvenance.externalRouting = credentialSourceFlag
+}
+
+// MarkExternalProviderOutputFlagExplicit records that an operator changed the
+// adapter contract through a trusted flag.
+func MarkExternalProviderOutputFlagExplicit(cfg *Config) {
+	markExternalProviderOutputExplicit(cfg, credentialSourceFlag)
+}
+
+func markExternalProviderOutputExplicit(cfg *Config, source credentialValueSource) {
+	if cfg.External.Connection.SSH.TrustProviderOutput && cfg.credentialProvenance.externalSSHOutput != credentialSourceRepository {
+		cfg.credentialProvenance.externalSSHOutput = source
+	}
+}
+
+func credentialSourceForBool(value bool, source credentialValueSource) credentialValueSource {
+	if !value {
+		return credentialSourceUnknown
+	}
+	return source
+}
+
+func externalSSHEnvTemplatesMatch(left, right ExternalSSHConnectionConfig) bool {
+	return left.User == right.User &&
+		left.Host == right.Host &&
+		left.Key == right.Key &&
+		left.Port == right.Port &&
+		slices.Equal(left.FallbackPorts, right.FallbackPorts) &&
+		left.ReadyCheck == right.ReadyCheck &&
+		left.ProxyCommand == right.ProxyCommand
+}
+
+func externalSSHEnvApprovalMatches(connection ExternalConnectionConfig, approval externalCredentialApproval) bool {
+	if !externalSSHEnvTemplatesMatch(connection.SSH, approval.envSSH) {
+		return false
+	}
+	if externalSSHReferencesResourceName(connection.SSH) && connection.ResourceName != approval.resource {
+		return false
+	}
+	return true
+}
+
+func externalSSHEndpointApprovalMatches(connection ExternalConnectionConfig, approval externalCredentialApproval) bool {
+	ssh := connection.SSH
+	approved := approval.envSSH
+	if ssh.User != approved.User ||
+		ssh.Host != approved.Host ||
+		ssh.Key != approved.Key ||
+		ssh.Port != approved.Port ||
+		!slices.Equal(ssh.FallbackPorts, approved.FallbackPorts) ||
+		ssh.AuthSecret != approved.AuthSecret ||
+		ssh.NoControlMaster != approved.NoControlMaster ||
+		ssh.SSHConfigProxy != approved.SSHConfigProxy ||
+		ssh.ProxyCommand != approved.ProxyCommand {
+		return false
+	}
+	if externalSSHEndpointReferencesResourceName(ssh) && connection.ResourceName != approval.resource {
+		return false
+	}
+	return true
+}
+
+func externalSSHEndpointUsesRepositoryInput(
+	connection ExternalConnectionConfig,
+	approval externalCredentialApproval,
+	connectionSource, resourceSource, configSource credentialValueSource,
+) bool {
+	ssh := connection.SSH
+	approved := approval.envSSH
+	for _, field := range []struct {
+		value    string
+		approved string
+	}{
+		{ssh.User, approved.User},
+		{ssh.Key, approved.Key},
+		{ssh.Port, approved.Port},
+	} {
+		source := credentialDestinationSource(field.value, field.approved, connectionSource)
+		if externalTemplateCredentialSource(field.value, source, resourceSource, configSource) == credentialSourceRepository {
+			return true
+		}
+	}
+	fallbackSource := connectionSource
+	if fallbackSource == credentialSourceRepository && slices.Equal(ssh.FallbackPorts, approved.FallbackPorts) {
+		fallbackSource = credentialSourceTrustedFile
+	}
+	for _, value := range ssh.FallbackPorts {
+		if externalTemplateCredentialSource(value, fallbackSource, resourceSource, configSource) == credentialSourceRepository {
+			return true
+		}
+	}
+	return false
+}
+
+func externalSSHEndpointReferencesResourceName(ssh ExternalSSHConnectionConfig) bool {
+	values := []string{ssh.User, ssh.Host, ssh.Key, ssh.Port, ssh.ProxyCommand}
+	values = append(values, ssh.FallbackPorts...)
+	for _, value := range values {
+		if strings.Contains(value, "{{resourceName}}") {
+			return true
+		}
+	}
+	return false
+}
+
+func externalSSHReferencesResourceName(ssh ExternalSSHConnectionConfig) bool {
+	values := []string{ssh.User, ssh.Host, ssh.Key, ssh.Port, ssh.ReadyCheck, ssh.ProxyCommand}
+	values = append(values, ssh.FallbackPorts...)
+	for _, value := range values {
+		if strings.Contains(value, "{{resourceName}}") {
+			return true
+		}
+	}
+	return false
+}
+
+func externalProviderOutputContract(cfg ExternalConfig) ([32]byte, bool) {
+	contract := struct {
+		Command    string                   `json:"command,omitempty"`
+		Args       []string                 `json:"args,omitempty"`
+		Config     map[string]any           `json:"config,omitempty"`
+		Lifecycle  ExternalLifecycleConfig  `json:"lifecycle,omitempty"`
+		Connection ExternalConnectionConfig `json:"connection,omitempty"`
+	}{
+		Command:    cfg.Command,
+		Args:       cfg.Args,
+		Config:     cfg.Config,
+		Lifecycle:  cfg.Lifecycle,
+		Connection: cfg.Connection,
+	}
+	data, err := json.Marshal(contract)
+	if err != nil {
+		return [32]byte{}, false
+	}
+	return sha256.Sum256(data), true
 }
 
 // ValidateNativeCredentialDestination is called only when a provider is about

--- a/internal/cli/credential_provenance_test.go
+++ b/internal/cli/credential_provenance_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -835,6 +836,129 @@ func TestRepositorySSHDestinationsRejectInheritedOrAmbientAuthentication(t *test
 			},
 			want: "exeDev.controlHost",
 		},
+		{
+			name: "external ambient auth",
+			cfg: Config{
+				Provider: "external",
+				External: ExternalConfig{Lifecycle: externalLifecycleConfigForTest(), Connection: ExternalConnectionConfig{SSH: ExternalSSHConnectionConfig{
+					Host: "repo.example.test",
+				}}},
+				credentialProvenance: credentialDestinationProvenance{
+					externalSSHHost: credentialSourceRepository,
+				},
+			},
+			want: "external.connection.ssh.host",
+		},
+		{
+			name: "external repository key does not isolate ambient config",
+			cfg: Config{
+				Provider: "external",
+				External: ExternalConfig{Lifecycle: externalLifecycleConfigForTest(), Connection: ExternalConnectionConfig{SSH: ExternalSSHConnectionConfig{
+					Host: "repo.example.test",
+					Key:  "repo-key",
+				}}},
+				credentialProvenance: credentialDestinationProvenance{
+					externalSSHHost: credentialSourceRepository,
+				},
+			},
+			want: "external.connection.ssh.host",
+		},
+		{
+			name: "external proxy ambient auth",
+			cfg: Config{
+				Provider: "external",
+				External: ExternalConfig{Lifecycle: externalLifecycleConfigForTest(), Connection: ExternalConnectionConfig{SSH: ExternalSSHConnectionConfig{
+					ProxyCommand: "repo-proxy %h %p",
+				}}},
+				credentialProvenance: credentialDestinationProvenance{
+					externalSSHProxy: credentialSourceRepository,
+				},
+			},
+			want: "proxyCommand",
+		},
+		{
+			name: "external resource name ambient auth",
+			cfg: Config{
+				Provider: "external",
+				External: ExternalConfig{Lifecycle: externalLifecycleConfigForTest(), Connection: ExternalConnectionConfig{
+					ResourceName: "repo.example.test",
+				}},
+				credentialProvenance: credentialDestinationProvenance{
+					externalResource: credentialSourceRepository,
+				},
+			},
+			want: "external.connection.ssh.host",
+		},
+		{
+			name: "external trusted host template with repository resource",
+			cfg: Config{
+				Provider: "external",
+				External: ExternalConfig{Lifecycle: externalLifecycleConfigForTest(), Connection: ExternalConnectionConfig{
+					ResourceName: "repo.example.test",
+					SSH:          ExternalSSHConnectionConfig{Host: "{{resourceName}}"},
+				}},
+				credentialProvenance: credentialDestinationProvenance{
+					externalResource: credentialSourceRepository,
+					externalSSHHost:  credentialSourceTrustedFile,
+				},
+			},
+			want: "external.connection.ssh.host",
+		},
+		{
+			name: "external trusted proxy template with repository resource",
+			cfg: Config{
+				Provider: "external",
+				External: ExternalConfig{Lifecycle: externalLifecycleConfigForTest(), Connection: ExternalConnectionConfig{
+					ResourceName: "repo.example.test",
+					SSH:          ExternalSSHConnectionConfig{ProxyCommand: "proxy {{resourceName}}"},
+				}},
+				credentialProvenance: credentialDestinationProvenance{
+					externalResource: credentialSourceRepository,
+					externalSSHProxy: credentialSourceTrustedFile,
+				},
+			},
+			want: "proxyCommand",
+		},
+		{
+			name: "external trusted host template with repository config",
+			cfg: Config{
+				Provider: "external",
+				External: ExternalConfig{Lifecycle: externalLifecycleConfigForTest(), Connection: ExternalConnectionConfig{SSH: ExternalSSHConnectionConfig{
+					Host: "{{config.host}}",
+				}}},
+				credentialProvenance: credentialDestinationProvenance{
+					externalConfig:  credentialSourceRepository,
+					externalSSHHost: credentialSourceTrustedFile,
+				},
+			},
+			want: "external.connection.ssh.host",
+		},
+		{
+			name: "external trusted proxy template with repository input",
+			cfg: Config{
+				Provider: "external",
+				External: ExternalConfig{Lifecycle: externalLifecycleConfigForTest(), Connection: ExternalConnectionConfig{SSH: ExternalSSHConnectionConfig{
+					ProxyCommand: "proxy {{repo.remoteUrl}}",
+				}}},
+				credentialProvenance: credentialDestinationProvenance{
+					externalSSHProxy: credentialSourceTrustedFile,
+				},
+			},
+			want: "proxyCommand",
+		},
+		{
+			name: "external repository environment opt-in",
+			cfg: Config{
+				Provider: "external",
+				External: ExternalConfig{Lifecycle: externalLifecycleConfigForTest(), Connection: ExternalConnectionConfig{SSH: ExternalSSHConnectionConfig{
+					AllowEnv: true,
+				}}},
+				credentialProvenance: credentialDestinationProvenance{
+					externalSSHAllowEnv: credentialSourceRepository,
+				},
+			},
+			want: "external.connection.ssh.allowEnv",
+		},
 	}
 
 	for _, test := range tests {
@@ -885,6 +1009,146 @@ func TestRepositorySSHDestinationsAllowSameSourceKeys(t *testing.T) {
 		if err := validateProviderCredentialDestination(cfg); err != nil {
 			t.Fatalf("provider=%s rejected same-source SSH config: %v", cfg.Provider, err)
 		}
+	}
+}
+
+func TestExternalCommandModeIgnoresUnusedConnectionProvenance(t *testing.T) {
+	cfg := Config{
+		Provider: "external",
+		External: ExternalConfig{
+			Command: "provider-adapter",
+			Connection: ExternalConnectionConfig{SSH: ExternalSSHConnectionConfig{
+				Host: "unused.example.test",
+			}},
+		},
+		credentialProvenance: credentialDestinationProvenance{externalSSHHost: credentialSourceRepository},
+	}
+	if err := validateProviderCredentialDestination(cfg); err != nil {
+		t.Fatalf("unused command-mode connection rejected: %v", err)
+	}
+}
+
+func externalLifecycleConfigForTest() ExternalLifecycleConfig {
+	return ExternalLifecycleConfig{Acquire: ExternalLifecycleOperation{Argv: []string{"provider-adapter"}}}
+}
+
+func TestExternalRoutingFileCarriesCredentialSource(t *testing.T) {
+	base := Config{
+		Provider: "external",
+		External: ExternalConfig{
+			Lifecycle: ExternalLifecycleConfig{Acquire: ExternalLifecycleOperation{Argv: []string{"provider-adapter"}}},
+			Connection: ExternalConnectionConfig{SSH: ExternalSSHConnectionConfig{
+				Host: "routed.example.test",
+			}},
+		},
+	}
+
+	repository := base
+	repository.credentialProvenance.externalRouting = credentialSourceRepository
+	MarkExternalRoutingCredentialSources(&repository)
+	if err := validateProviderCredentialDestination(repository); err == nil {
+		t.Fatal("repository routing file with ambient auth was accepted")
+	}
+
+	trusted := base
+	MarkExternalRoutingCredentialSources(&trusted)
+	if err := validateProviderCredentialDestination(trusted); err != nil {
+		t.Fatalf("claim-bound routing state rejected: %v", err)
+	}
+}
+
+func TestExternalRoutingLoaderPreservesConfiguredSource(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	external := ExternalConfig{
+		Lifecycle: externalLifecycleConfigForTest(),
+		Connection: ExternalConnectionConfig{SSH: ExternalSSHConnectionConfig{
+			Host: "routed.example.test",
+		}},
+	}
+	path, err := PersistExternalRouting("cbx_abcdef123456", external)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repository := Config{
+		Provider: "external",
+		External: ExternalConfig{RoutingFile: path},
+		credentialProvenance: credentialDestinationProvenance{
+			externalRouting: credentialSourceRepository,
+		},
+	}
+	if err := loadExternalRoutingConfig(&repository, path, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateProviderCredentialDestination(repository); err == nil {
+		t.Fatal("repository-configured routing state with ambient auth was accepted")
+	}
+
+	legacyClaim := Config{Provider: "external"}
+	if err := loadExternalRoutingConfig(&legacyClaim, path, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateProviderCredentialDestination(legacyClaim); err == nil {
+		t.Fatal("legacy claim-bound routing state inherited credential trust")
+	}
+
+	approvedLegacy := Config{Provider: "external"}
+	approvedConnection := external.Connection
+	if err := applyFileConfigWithTrust(&approvedLegacy, fileConfig{External: &fileExternalConfig{
+		Connection: &approvedConnection,
+	}}, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := loadExternalRoutingConfig(&approvedLegacy, path, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateProviderCredentialDestination(approvedLegacy); err != nil {
+		t.Fatalf("legacy routing with exact current approval rejected: %v", err)
+	}
+
+	validatedPath, err := PersistValidatedExternalRouting("cbx_abcdef123457", external)
+	if err != nil {
+		t.Fatal(err)
+	}
+	validatedClaim := Config{Provider: "external"}
+	if err := loadExternalRoutingConfig(&validatedClaim, validatedPath, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateProviderCredentialDestination(validatedClaim); err != nil {
+		t.Fatalf("validated claim-bound routing state rejected: %v", err)
+	}
+}
+
+func TestExternalRoutingAllowEnvApprovalBindsResourceName(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	approved := ExternalConnectionConfig{
+		ResourceName: "approved-resource",
+		SSH: ExternalSSHConnectionConfig{
+			User:     "{{resourceName}}",
+			Host:     "approved.example.test",
+			AllowEnv: true,
+		},
+	}
+	cfg := Config{Provider: "external"}
+	if err := applyFileConfigWithTrust(&cfg, fileConfig{External: &fileExternalConfig{Connection: &approved}}, true); err != nil {
+		t.Fatal(err)
+	}
+
+	routed := approved
+	routed.ResourceName = "{{env.GITHUB_TOKEN}}"
+	routed.AllowEnvResourceName = true
+	path, err := PersistExternalRouting("cbx_abcdef123456", ExternalConfig{
+		Lifecycle:  externalLifecycleConfigForTest(),
+		Connection: routed,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := loadExternalRoutingConfig(&cfg, path, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateProviderCredentialDestination(cfg); err == nil || !strings.Contains(err.Error(), "ssh.allowEnv") {
+		t.Fatalf("repository routing resource-name change error=%v", err)
 	}
 }
 
@@ -1023,6 +1287,325 @@ func TestConfigMergeTracksSSHDestinationSources(t *testing.T) {
 		}
 		if err := validateProviderCredentialDestination(cfg); err != nil {
 			t.Fatalf("explicit exe.dev control host rejected: %v", err)
+		}
+	})
+
+	t.Run("external repository host requires trusted approval", func(t *testing.T) {
+		repositoryRoot, key := repositorySSHKeyFixture(t)
+		cfg := baseConfig()
+		cfg.Provider = "external"
+		cfg.External.Lifecycle = externalLifecycleConfigForTest()
+		cfg.credentialProvenance.repositoryRoot = repositoryRoot
+		connection := ExternalConnectionConfig{SSH: ExternalSSHConnectionConfig{Host: "repo.example.test"}}
+		if err := applyFileConfigWithTrust(&cfg, fileConfig{External: &fileExternalConfig{Connection: &connection}}, false); err != nil {
+			t.Fatal(err)
+		}
+		if err := validateProviderCredentialDestination(cfg); err == nil {
+			t.Fatal("repository external host with ambient auth was accepted")
+		}
+
+		connection.SSH.Key = key
+		if err := applyFileConfigWithTrust(&cfg, fileConfig{External: &fileExternalConfig{Connection: &connection}}, false); err != nil {
+			t.Fatal(err)
+		}
+		if err := validateProviderCredentialDestination(cfg); err == nil {
+			t.Fatal("repository external host with a same-source key was accepted")
+		}
+	})
+
+	t.Run("trusted external approval survives intermediate repository layer", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Provider = "external"
+		cfg.External.Lifecycle = externalLifecycleConfigForTest()
+		connection := ExternalConnectionConfig{
+			ResourceName: "approved.example.test",
+			SSH: ExternalSSHConnectionConfig{
+				Host:         "{{resourceName}}",
+				ProxyCommand: "proxy approved.example.test",
+				AllowEnv:     true,
+			},
+		}
+		if err := applyFileConfigWithTrust(&cfg, fileConfig{External: &fileExternalConfig{Connection: &connection}}, true); err != nil {
+			t.Fatal(err)
+		}
+		intermediate := ExternalConnectionConfig{
+			ResourceName: "other.example.test",
+			SSH: ExternalSSHConnectionConfig{
+				Host:         "other.example.test",
+				ProxyCommand: "proxy other.example.test",
+			},
+		}
+		if err := applyFileConfigWithTrust(&cfg, fileConfig{External: &fileExternalConfig{Connection: &intermediate}}, false); err != nil {
+			t.Fatal(err)
+		}
+		if err := applyFileConfigWithTrust(&cfg, fileConfig{External: &fileExternalConfig{Connection: &connection}}, false); err != nil {
+			t.Fatal(err)
+		}
+		if err := validateProviderCredentialDestination(cfg); err != nil {
+			t.Fatalf("trusted External SSH destination rejected: %v", err)
+		}
+	})
+
+	t.Run("trusted external env approval is template-bound", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Provider = "external"
+		cfg.External.Lifecycle = externalLifecycleConfigForTest()
+		trusted := ExternalConnectionConfig{SSH: ExternalSSHConnectionConfig{
+			User:     "{{env.EXTERNAL_SSH_USER}}",
+			Host:     "approved.example.test",
+			AllowEnv: true,
+		}}
+		if err := applyFileConfigWithTrust(&cfg, fileConfig{External: &fileExternalConfig{Connection: &trusted}}, true); err != nil {
+			t.Fatal(err)
+		}
+		repository := trusted
+		repository.SSH.User = "{{env.AWS_SECRET_ACCESS_KEY}}"
+		if err := applyFileConfigWithTrust(&cfg, fileConfig{External: &fileExternalConfig{Connection: &repository}}, false); err != nil {
+			t.Fatal(err)
+		}
+		if err := validateProviderCredentialDestination(cfg); err == nil || !strings.Contains(err.Error(), "ssh.allowEnv") {
+			t.Fatalf("repository env template change error=%v", err)
+		}
+	})
+
+	t.Run("trusted external env approval binds referenced resource name", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Provider = "external"
+		cfg.External.Lifecycle = externalLifecycleConfigForTest()
+		trusted := ExternalConnectionConfig{
+			ResourceName: "approved-resource",
+			SSH: ExternalSSHConnectionConfig{
+				User:     "{{resourceName}}",
+				Host:     "approved.example.test",
+				AllowEnv: true,
+			},
+		}
+		if err := applyFileConfigWithTrust(&cfg, fileConfig{External: &fileExternalConfig{Connection: &trusted}}, true); err != nil {
+			t.Fatal(err)
+		}
+		repository := trusted
+		repository.ResourceName = "{{env.GITHUB_TOKEN}}"
+		repository.AllowEnvResourceName = true
+		if err := applyFileConfigWithTrust(&cfg, fileConfig{External: &fileExternalConfig{Connection: &repository}}, false); err != nil {
+			t.Fatal(err)
+		}
+		if err := validateProviderCredentialDestination(cfg); err == nil || !strings.Contains(err.Error(), "ssh.allowEnv") {
+			t.Fatalf("repository resource-name change error=%v", err)
+		}
+	})
+
+	t.Run("trusted external provider output approval binds adapter contract", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Provider = "external"
+		trusted := fileExternalConfig{
+			Command: "approved-provider",
+			Args:    []string{"--profile", "approved"},
+			Config:  map[string]any{"namespace": "approved"},
+			Connection: &ExternalConnectionConfig{SSH: ExternalSSHConnectionConfig{
+				TrustProviderOutput: true,
+			}},
+		}
+		if err := applyFileConfigWithTrust(&cfg, fileConfig{External: &trusted}, true); err != nil {
+			t.Fatal(err)
+		}
+		if err := ValidateExternalProviderSSHOutput(cfg); err != nil {
+			t.Fatalf("trusted provider-output contract rejected: %v", err)
+		}
+
+		repository := fileExternalConfig{Command: "repository-provider"}
+		if err := applyFileConfigWithTrust(&cfg, fileConfig{External: &repository}, false); err != nil {
+			t.Fatal(err)
+		}
+		if err := ValidateExternalProviderSSHOutput(cfg); err == nil || !strings.Contains(err.Error(), "trustProviderOutput") {
+			t.Fatalf("repository provider-output contract change error=%v", err)
+		}
+	})
+
+	t.Run("partial explicit override does not approve repository contract", func(t *testing.T) {
+		for name, markExplicit := range map[string]func(*Config){
+			"flag": MarkExternalProviderOutputFlagExplicit,
+			"environment": func(cfg *Config) {
+				markExternalProviderOutputExplicit(cfg, credentialSourceEnvironment)
+			},
+		} {
+			t.Run(name, func(t *testing.T) {
+				cfg := baseConfig()
+				cfg.Provider = "external"
+				trusted := fileExternalConfig{
+					Command: "approved-provider",
+					Args:    []string{"--approved"},
+					Connection: &ExternalConnectionConfig{SSH: ExternalSSHConnectionConfig{
+						TrustProviderOutput: true,
+					}},
+				}
+				if err := applyFileConfigWithTrust(&cfg, fileConfig{External: &trusted}, true); err != nil {
+					t.Fatal(err)
+				}
+				if err := applyFileConfigWithTrust(&cfg, fileConfig{External: &fileExternalConfig{
+					Args: []string{"--repository"},
+				}}, false); err != nil {
+					t.Fatal(err)
+				}
+				markExplicit(&cfg)
+				if err := ValidateExternalProviderSSHOutput(cfg); err == nil || !strings.Contains(err.Error(), "trustProviderOutput") {
+					t.Fatalf("partial %s override error=%v", name, err)
+				}
+			})
+		}
+	})
+
+	t.Run("trusted external provider output approval binds connection inputs", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Provider = "external"
+		trustedConnection := ExternalConnectionConfig{
+			ResourceName: "approved-resource",
+			SSH:          ExternalSSHConnectionConfig{TrustProviderOutput: true},
+		}
+		trusted := fileExternalConfig{
+			Command:    "approved-provider",
+			Connection: &trustedConnection,
+		}
+		if err := applyFileConfigWithTrust(&cfg, fileConfig{External: &trusted}, true); err != nil {
+			t.Fatal(err)
+		}
+		repositoryConnection := trustedConnection
+		repositoryConnection.ResourceName = "repository-resource"
+		if err := applyFileConfigWithTrust(&cfg, fileConfig{External: &fileExternalConfig{
+			Connection: &repositoryConnection,
+		}}, false); err != nil {
+			t.Fatal(err)
+		}
+		if err := ValidateExternalProviderSSHOutput(cfg); err == nil || !strings.Contains(err.Error(), "trustProviderOutput") {
+			t.Fatalf("repository provider-output connection change error=%v", err)
+		}
+	})
+
+	t.Run("repository cannot self-enable external provider output", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Provider = "external"
+		repository := fileExternalConfig{
+			Command: "repository-provider",
+			Connection: &ExternalConnectionConfig{SSH: ExternalSSHConnectionConfig{
+				TrustProviderOutput: true,
+			}},
+		}
+		if err := applyFileConfigWithTrust(&cfg, fileConfig{External: &repository}, false); err != nil {
+			t.Fatal(err)
+		}
+		if err := ValidateExternalProviderSSHOutput(cfg); err == nil || !strings.Contains(err.Error(), "trustProviderOutput") {
+			t.Fatalf("repository provider-output opt-in error=%v", err)
+		}
+		if err := validateProviderCredentialDestination(cfg); err == nil || !strings.Contains(err.Error(), "trustProviderOutput") {
+			t.Fatalf("repository provider-output preflight error=%v", err)
+		}
+	})
+
+	t.Run("trusted external provider output rejects unencodable contract", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Provider = "external"
+		trusted := fileExternalConfig{
+			Command: "approved-provider",
+			Config:  map[string]any{"invalid": math.Inf(1)},
+			Connection: &ExternalConnectionConfig{SSH: ExternalSSHConnectionConfig{
+				TrustProviderOutput: true,
+			}},
+		}
+		err := applyFileConfigWithTrust(&cfg, fileConfig{External: &trusted}, true)
+		if err == nil || !strings.Contains(err.Error(), "JSON encodable") {
+			t.Fatalf("error=%v", err)
+		}
+	})
+
+	t.Run("repository external proxy requires trusted approval", func(t *testing.T) {
+		repositoryRoot, key := repositorySSHKeyFixture(t)
+		cfg := baseConfig()
+		cfg.Provider = "external"
+		cfg.External.Lifecycle = externalLifecycleConfigForTest()
+		cfg.credentialProvenance.repositoryRoot = repositoryRoot
+		connection := ExternalConnectionConfig{SSH: ExternalSSHConnectionConfig{
+			Host:         "approved.example.test",
+			Key:          key,
+			ProxyCommand: "repo-proxy %h %p",
+		}}
+		if err := applyFileConfigWithTrust(&cfg, fileConfig{External: &fileExternalConfig{Connection: &connection}}, false); err != nil {
+			t.Fatal(err)
+		}
+		if err := validateProviderCredentialDestination(cfg); err == nil {
+			t.Fatal("repository external proxy with a same-source outer key was accepted")
+		}
+	})
+
+	t.Run("trusted external approval binds full SSH endpoint", func(t *testing.T) {
+		mutations := map[string]func(*ExternalSSHConnectionConfig){
+			"user":           func(ssh *ExternalSSHConnectionConfig) { ssh.User = "root" },
+			"key":            func(ssh *ExternalSSHConnectionConfig) { ssh.Key = "/tmp/other-key" },
+			"port":           func(ssh *ExternalSSHConnectionConfig) { ssh.Port = "2222" },
+			"fallback ports": func(ssh *ExternalSSHConnectionConfig) { ssh.FallbackPorts = []string{"2200"} },
+			"config proxy":   func(ssh *ExternalSSHConnectionConfig) { ssh.SSHConfigProxy = true },
+		}
+		for name, mutate := range mutations {
+			t.Run(name, func(t *testing.T) {
+				cfg := baseConfig()
+				cfg.Provider = "external"
+				cfg.External.Lifecycle = externalLifecycleConfigForTest()
+				trusted := ExternalConnectionConfig{SSH: ExternalSSHConnectionConfig{
+					User:          "developer",
+					Host:          "approved.example.test",
+					Port:          "22",
+					FallbackPorts: []string{"2201", "2202"},
+				}}
+				if err := applyFileConfigWithTrust(&cfg, fileConfig{External: &fileExternalConfig{Connection: &trusted}}, true); err != nil {
+					t.Fatal(err)
+				}
+				repository := trusted
+				repository.SSH.FallbackPorts = append([]string(nil), trusted.SSH.FallbackPorts...)
+				mutate(&repository.SSH)
+				if err := applyFileConfigWithTrust(&cfg, fileConfig{External: &fileExternalConfig{Connection: &repository}}, false); err != nil {
+					t.Fatal(err)
+				}
+				if err := validateProviderCredentialDestination(cfg); err == nil || !strings.Contains(err.Error(), "ssh endpoint") {
+					t.Fatalf("repository %s change error=%v", name, err)
+				}
+			})
+		}
+	})
+
+	t.Run("trusted external endpoint rejects repository template inputs", func(t *testing.T) {
+		mutations := map[string]func(*ExternalSSHConnectionConfig){
+			"user": func(ssh *ExternalSSHConnectionConfig) { ssh.User = "{{config.endpoint}}" },
+			"key":  func(ssh *ExternalSSHConnectionConfig) { ssh.Key = "{{config.endpoint}}" },
+			"port": func(ssh *ExternalSSHConnectionConfig) { ssh.Port = "{{config.endpoint}}" },
+			"fallback port": func(ssh *ExternalSSHConnectionConfig) {
+				ssh.FallbackPorts = []string{"{{config.endpoint}}"}
+			},
+		}
+		for name, mutate := range mutations {
+			t.Run(name, func(t *testing.T) {
+				cfg := baseConfig()
+				cfg.Provider = "external"
+				cfg.External.Lifecycle = externalLifecycleConfigForTest()
+				trustedConnection := ExternalConnectionConfig{SSH: ExternalSSHConnectionConfig{
+					User: "developer",
+					Host: "approved.example.test",
+					Port: "22",
+				}}
+				mutate(&trustedConnection.SSH)
+				trusted := fileExternalConfig{
+					Config:     map[string]any{"endpoint": "approved-value"},
+					Connection: &trustedConnection,
+				}
+				if err := applyFileConfigWithTrust(&cfg, fileConfig{External: &trusted}, true); err != nil {
+					t.Fatal(err)
+				}
+				if err := applyFileConfigWithTrust(&cfg, fileConfig{External: &fileExternalConfig{
+					Config: map[string]any{"endpoint": "repository-value"},
+				}}, false); err != nil {
+					t.Fatal(err)
+				}
+				if err := validateProviderCredentialDestination(cfg); err == nil || !strings.Contains(err.Error(), "ssh endpoint") {
+					t.Fatalf("repository %s template input error=%v", name, err)
+				}
+			})
 		}
 	})
 }

--- a/internal/cli/external_routing.go
+++ b/internal/cli/external_routing.go
@@ -18,24 +18,28 @@ import (
 var externalRoutingMutationMutexes sync.Map
 
 type externalRoutingState struct {
-	Command      string                     `json:"command,omitempty"`
-	Args         []string                   `json:"args,omitempty"`
-	Config       map[string]any             `json:"config,omitempty"`
-	Capabilities ExternalCapabilitiesConfig `json:"capabilities,omitempty"`
-	Lifecycle    ExternalLifecycleConfig    `json:"lifecycle,omitempty"`
-	Connection   ExternalConnectionConfig   `json:"connection,omitempty"`
-	WorkRoot     string                     `json:"workRoot,omitempty"`
+	Command                   string                     `json:"command,omitempty"`
+	Args                      []string                   `json:"args,omitempty"`
+	Config                    map[string]any             `json:"config,omitempty"`
+	Capabilities              ExternalCapabilitiesConfig `json:"capabilities,omitempty"`
+	Lifecycle                 ExternalLifecycleConfig    `json:"lifecycle,omitempty"`
+	Connection                ExternalConnectionConfig   `json:"connection,omitempty"`
+	WorkRoot                  string                     `json:"workRoot,omitempty"`
+	CredentialBoundaryVersion int                        `json:"credentialBoundaryVersion,omitempty"`
 }
 
-func externalRoutingStateForConfig(cfg ExternalConfig) externalRoutingState {
+const externalRoutingCredentialVersion = 1
+
+func externalRoutingStateForConfig(cfg ExternalConfig, credentialVersion int) externalRoutingState {
 	return externalRoutingState{
-		Command:      cfg.Command,
-		Args:         append([]string(nil), cfg.Args...),
-		Config:       cfg.Config,
-		Capabilities: cfg.Capabilities,
-		Lifecycle:    cfg.Lifecycle,
-		Connection:   cfg.Connection,
-		WorkRoot:     cfg.WorkRoot,
+		Command:                   cfg.Command,
+		Args:                      append([]string(nil), cfg.Args...),
+		Config:                    cfg.Config,
+		Capabilities:              cfg.Capabilities,
+		Lifecycle:                 cfg.Lifecycle,
+		Connection:                cfg.Connection,
+		WorkRoot:                  cfg.WorkRoot,
+		CredentialBoundaryVersion: credentialVersion,
 	}
 }
 
@@ -71,11 +75,21 @@ func externalRoutingConfigDir() (string, error) {
 }
 
 func PersistExternalRouting(leaseID string, cfg ExternalConfig) (string, error) {
+	return persistExternalRouting(leaseID, cfg, 0)
+}
+
+// PersistValidatedExternalRouting records that the credential destination was
+// validated before the routing state became authoritative for a lease.
+func PersistValidatedExternalRouting(leaseID string, cfg ExternalConfig) (string, error) {
+	return persistExternalRouting(leaseID, cfg, externalRoutingCredentialVersion)
+}
+
+func persistExternalRouting(leaseID string, cfg ExternalConfig, credentialVersion int) (string, error) {
 	path, err := ExternalRoutingPath(leaseID)
 	if err != nil {
 		return "", err
 	}
-	data, err := json.MarshalIndent(externalRoutingStateForConfig(cfg), "", "  ")
+	data, err := json.MarshalIndent(externalRoutingStateForConfig(cfg, credentialVersion), "", "  ")
 	if err != nil {
 		return "", fmt.Errorf("encode external routing: %w", err)
 	}
@@ -163,15 +177,16 @@ func LoadExternalRouting(path string) (ExternalConfig, error) {
 		return ExternalConfig{}, fmt.Errorf("parse external routing file: %w", err)
 	}
 	return ExternalConfig{
-		Command:       state.Command,
-		Args:          append([]string(nil), state.Args...),
-		Config:        state.Config,
-		Capabilities:  state.Capabilities,
-		Lifecycle:     state.Lifecycle,
-		Connection:    state.Connection,
-		WorkRoot:      state.WorkRoot,
-		RoutingFile:   path,
-		routingLoaded: true,
+		Command:                  state.Command,
+		Args:                     append([]string(nil), state.Args...),
+		Config:                   state.Config,
+		Capabilities:             state.Capabilities,
+		Lifecycle:                state.Lifecycle,
+		Connection:               state.Connection,
+		WorkRoot:                 state.WorkRoot,
+		RoutingFile:              path,
+		routingLoaded:            true,
+		routingCredentialVersion: state.CredentialBoundaryVersion,
 	}, nil
 }
 
@@ -220,11 +235,11 @@ func removeExternalRoutingIfUnchangedWithSync(leaseID string, expected ExternalC
 		if err != nil {
 			return err
 		}
-		actualData, err := json.Marshal(externalRoutingStateForConfig(actual))
+		actualData, err := json.Marshal(externalRoutingStateForConfig(actual, 0))
 		if err != nil {
 			return fmt.Errorf("encode current external routing state: %w", err)
 		}
-		expectedData, err := json.Marshal(externalRoutingStateForConfig(expected))
+		expectedData, err := json.Marshal(externalRoutingStateForConfig(expected, 0))
 		if err != nil {
 			return fmt.Errorf("encode expected external routing state: %w", err)
 		}

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -361,7 +361,7 @@ func autoRouteExternalLeaseWithHints(cfg *Config, id string, routingExplicit, ta
 	}
 	if providerSelected && strings.TrimSpace(cfg.External.RoutingFile) != "" {
 		if !cfg.External.routingLoaded {
-			if err := loadExternalRoutingConfig(cfg, cfg.External.RoutingFile); err != nil {
+			if err := loadExternalRoutingConfig(cfg, cfg.External.RoutingFile, false); err != nil {
 				return err
 			}
 		}
@@ -387,18 +387,25 @@ func autoRouteExternalLeaseWithHints(cfg *Config, id string, routingExplicit, ta
 	if !cfg.providerExplicit {
 		cfg.Provider = "external"
 	}
-	if err := loadExternalRoutingConfig(cfg, path); err != nil {
+	if err := loadExternalRoutingConfig(cfg, path, true); err != nil {
 		return err
 	}
 	return restoreExternalLeaseTarget(cfg, targetExplicit, windowsModeExplicit)
 }
 
-func loadExternalRoutingConfig(cfg *Config, path string) error {
+func loadExternalRoutingConfig(cfg *Config, path string, claimBound bool) error {
 	routing, err := LoadExternalRouting(path)
 	if err != nil {
 		return err
 	}
+	if claimBound {
+		cfg.credentialProvenance.externalRouting = credentialSourceRepository
+		if routing.routingCredentialVersion >= externalRoutingCredentialVersion {
+			cfg.credentialProvenance.externalRouting = credentialSourceTrustedFile
+		}
+	}
 	cfg.External = routing
+	MarkExternalRoutingCredentialSources(cfg)
 	if strings.TrimSpace(routing.WorkRoot) != "" {
 		cfg.WorkRoot = routing.WorkRoot
 	}

--- a/internal/providers/external/backend.go
+++ b/internal/providers/external/backend.go
@@ -34,6 +34,9 @@ func (b *leaseBackend) SupportsRequestedLeaseID() bool {
 }
 
 func (b *leaseBackend) Acquire(ctx context.Context, req core.AcquireRequest) (_ core.LeaseTarget, resultErr error) {
+	if err := b.validateAcquireProviderSSHOutput(); err != nil {
+		return core.LeaseTarget{}, err
+	}
 	leaseID := strings.TrimSpace(req.RequestedLeaseID)
 	fixedLeaseID := leaseID != ""
 	if leaseID == "" {
@@ -111,7 +114,7 @@ func (b *leaseBackend) Acquire(ctx context.Context, req core.AcquireRequest) (_ 
 		}
 		return core.LeaseTarget{}, err
 	}
-	if _, err := core.PersistExternalRouting(lease.LeaseID, b.cfg.External); err != nil {
+	if _, err := core.PersistValidatedExternalRouting(lease.LeaseID, b.cfg.External); err != nil {
 		var acquireErr error = core.Exit(2, "%v", err)
 		if !req.Keep {
 			acquireErr = appendAcquireCleanupError(acquireErr, b.rollbackAcquireRelease(ctx, leaseForProtocol(lease)))
@@ -181,6 +184,13 @@ func (b *leaseBackend) Acquire(ctx context.Context, req core.AcquireRequest) (_ 
 		return core.LeaseTarget{}, err
 	}
 	return lease, nil
+}
+
+func (b *leaseBackend) validateAcquireProviderSSHOutput() error {
+	if !lifecycleConfigured(b.cfg.External) || b.cfg.External.Lifecycle.Acquire.Output == lifecycleOutputJSONLease {
+		return core.ValidateExternalProviderSSHOutput(b.cfg)
+	}
+	return nil
 }
 
 func (b *leaseBackend) rollbackAcquireRelease(ctx context.Context, lease *protocolLease) error {
@@ -323,7 +333,7 @@ func (b *leaseBackend) Resolve(ctx context.Context, req core.ResolveRequest) (co
 		return lease, nil
 	}
 	if !req.NoLocalStateMutations {
-		if _, err := core.PersistExternalRouting(lease.LeaseID, b.cfg.External); err != nil {
+		if _, err := core.PersistValidatedExternalRouting(lease.LeaseID, b.cfg.External); err != nil {
 			return core.LeaseTarget{}, core.Exit(2, "%v", err)
 		}
 	}
@@ -528,7 +538,9 @@ func (b *leaseBackend) Cleanup(ctx context.Context, req core.CleanupRequest) err
 	if req.DryRun {
 		return nil
 	}
-	response, err := b.invoke(ctx, protocolRequest{Operation: "list", All: true, Refresh: true})
+	response, err := b.invoke(ctx, protocolRequest{
+		Operation: "list", All: true, Refresh: true, SkipSSHOutputValidation: true,
+	})
 	if err != nil {
 		return err
 	}
@@ -596,6 +608,9 @@ func (b *leaseBackend) invokeProtocol(ctx context.Context, request protocolReque
 	}
 	if response.ProtocolVersion != protocolVersion {
 		return protocolResponse{}, core.Exit(5, "external provider protocol version %d is unsupported", response.ProtocolVersion)
+	}
+	if err := b.validateProviderSSHOutput(request, response); err != nil {
+		return protocolResponse{}, err
 	}
 	if request.Operation == "list" && b.cfg.External.Capabilities.IdempotentLeaseID {
 		if response.Leases == nil {

--- a/internal/providers/external/flags.go
+++ b/internal/providers/external/flags.go
@@ -42,12 +42,14 @@ func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 		return nil
 	}
 	if core.FlagWasSet(fs, "external-routing-file") {
+		core.MarkExternalRoutingFileExplicit(cfg)
 		cfg.External.RoutingFile = *v.RoutingFile
 		routing, err := core.LoadExternalRouting(cfg.External.RoutingFile)
 		if err != nil {
 			return core.Exit(2, "%v", err)
 		}
 		cfg.External = routing
+		core.MarkExternalRoutingCredentialSources(cfg)
 		cfg.WorkRoot = externalWorkRoot(*cfg)
 	} else if path := strings.TrimSpace(cfg.External.RoutingFile); path != "" && !core.ExternalRoutingLoaded(cfg.External) {
 		routing, err := core.LoadExternalRouting(path)
@@ -55,6 +57,7 @@ func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 			return core.Exit(2, "%v", err)
 		}
 		cfg.External = routing
+		core.MarkExternalRoutingCredentialSources(cfg)
 		cfg.WorkRoot = externalWorkRoot(*cfg)
 	}
 	if core.FlagWasSet(fs, "external-command") {
@@ -76,6 +79,9 @@ func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	}
 	if core.FlagWasSet(fs, "external-idempotent-lease-id") {
 		cfg.External.Capabilities.IdempotentLeaseID = *v.IdempotentLeaseID
+	}
+	if core.FlagWasSet(fs, "external-command") || core.FlagWasSet(fs, "external-arg") || core.FlagWasSet(fs, "external-config-json") {
+		core.MarkExternalProviderOutputFlagExplicit(cfg)
 	}
 	return validateConfig(*cfg)
 }

--- a/internal/providers/external/lifecycle.go
+++ b/internal/providers/external/lifecycle.go
@@ -122,7 +122,11 @@ func (b *leaseBackend) invokeLifecycle(ctx context.Context, request protocolRequ
 		if err := validateRawExternalLeaseIdentity(request.Operation, lease); err != nil {
 			return protocolResponse{}, err
 		}
-		return protocolResponse{ProtocolVersion: protocolVersion, Lease: &lease, RawLifecycleIdentity: true}, nil
+		response := protocolResponse{ProtocolVersion: protocolVersion, Lease: &lease, RawLifecycleIdentity: true}
+		if err := b.validateProviderSSHOutput(request, response); err != nil {
+			return protocolResponse{}, err
+		}
+		return response, nil
 	case lifecycleOutputJSONNameArray:
 		namePrefix := ""
 		if operation.NamePrefix != "" {
@@ -153,7 +157,11 @@ func (b *leaseBackend) invokeLifecycle(ctx context.Context, request protocolRequ
 			}
 			leases = append(leases, lease)
 		}
-		return protocolResponse{ProtocolVersion: protocolVersion, Leases: leases}, nil
+		response := protocolResponse{ProtocolVersion: protocolVersion, Leases: leases}
+		if err := b.validateProviderSSHOutput(request, response); err != nil {
+			return protocolResponse{}, err
+		}
+		return response, nil
 	case lifecycleOutputJSONLeaseArray:
 		var leases []protocolLease
 		if err := json.Unmarshal([]byte(result.Stdout), &leases); err != nil {
@@ -169,10 +177,36 @@ func (b *leaseBackend) invokeLifecycle(ctx context.Context, request protocolRequ
 				}
 			}
 		}
-		return protocolResponse{ProtocolVersion: protocolVersion, Leases: leases}, nil
+		response := protocolResponse{ProtocolVersion: protocolVersion, Leases: leases}
+		if err := b.validateProviderSSHOutput(request, response); err != nil {
+			return protocolResponse{}, err
+		}
+		return response, nil
 	default:
 		return protocolResponse{}, core.Exit(2, "external lifecycle %s has unsupported output %q", request.Operation, operation.Output)
 	}
+}
+
+func (b *leaseBackend) validateProviderSSHOutput(request protocolRequest, response protocolResponse) error {
+	if request.SkipSSHOutputValidation ||
+		(request.Operation != "acquire" && request.Operation != "list" &&
+			(request.Operation != "resolve" || request.ReleaseOnly)) {
+		return nil
+	}
+	if response.Lease != nil && response.Lease.SSH != nil {
+		if err := core.ValidateExternalProviderSSHOutput(b.cfg); err != nil {
+			return err
+		}
+	}
+	for index := range response.Leases {
+		if response.Leases[index].SSH == nil {
+			continue
+		}
+		if err := core.ValidateExternalProviderSSHOutput(b.cfg); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func validateRawExternalLeaseIdentity(operation string, lease protocolLease) error {
@@ -447,11 +481,16 @@ func (b *leaseBackend) lifecycleLeaseForRequest(request protocolRequest, resourc
 
 func lifecycleSSH(cfg core.ExternalSSHConnectionConfig, templateCtx lifecycleTemplateContext) (protocolSSH, error) {
 	expand := func(label, value string) (string, error) {
-		expanded, err := expandLifecycleValue(value, templateCtx)
+		expansion, err := expandLifecycleValueTracked(value, templateCtx)
 		if err != nil {
 			return "", core.Exit(2, "external connection ssh.%s: %v", label, err)
 		}
-		return expanded, nil
+		// Resource-name provenance survives claims, so indirect placeholders are
+		// subject to the same narrow opt-in as direct environment expansion.
+		if expansion.sensitive && !cfg.AllowEnv {
+			return "", core.Exit(2, "external connection ssh.%s uses an environment-derived value; set external.connection.ssh.allowEnv in trusted user config only for non-secret values", label)
+		}
+		return expansion.value, nil
 	}
 	user, err := expand("user", cfg.User)
 	if err != nil {

--- a/internal/providers/external/protocol.go
+++ b/internal/providers/external/protocol.go
@@ -10,22 +10,23 @@ import (
 const protocolVersion = 1
 
 type protocolRequest struct {
-	ProtocolVersion int                               `json:"protocolVersion"`
-	Operation       string                            `json:"operation"`
-	Config          map[string]any                    `json:"config,omitempty"`
-	Desired         *desiredLease                     `json:"desired,omitempty"`
-	Lease           *protocolLease                    `json:"lease,omitempty"`
-	Expected        *protocolExpectedProviderIdentity `json:"expected,omitempty"`
-	ID              string                            `json:"id,omitempty"`
-	State           string                            `json:"state,omitempty"`
-	Keep            bool                              `json:"keep,omitempty"`
-	Reclaim         bool                              `json:"reclaim,omitempty"`
-	ReleaseOnly     bool                              `json:"releaseOnly,omitempty"`
-	Force           bool                              `json:"force,omitempty"`
-	All             bool                              `json:"all,omitempty"`
-	Refresh         bool                              `json:"refresh,omitempty"`
-	DryRun          bool                              `json:"dryRun,omitempty"`
-	Repo            *protocolRepo                     `json:"repo,omitempty"`
+	ProtocolVersion         int                               `json:"protocolVersion"`
+	Operation               string                            `json:"operation"`
+	Config                  map[string]any                    `json:"config,omitempty"`
+	Desired                 *desiredLease                     `json:"desired,omitempty"`
+	Lease                   *protocolLease                    `json:"lease,omitempty"`
+	Expected                *protocolExpectedProviderIdentity `json:"expected,omitempty"`
+	ID                      string                            `json:"id,omitempty"`
+	State                   string                            `json:"state,omitempty"`
+	Keep                    bool                              `json:"keep,omitempty"`
+	Reclaim                 bool                              `json:"reclaim,omitempty"`
+	ReleaseOnly             bool                              `json:"releaseOnly,omitempty"`
+	Force                   bool                              `json:"force,omitempty"`
+	All                     bool                              `json:"all,omitempty"`
+	Refresh                 bool                              `json:"refresh,omitempty"`
+	DryRun                  bool                              `json:"dryRun,omitempty"`
+	Repo                    *protocolRepo                     `json:"repo,omitempty"`
+	SkipSSHOutputValidation bool                              `json:"-"`
 }
 
 type protocolExpectedProviderIdentity struct {

--- a/internal/providers/external/provider.go
+++ b/internal/providers/external/provider.go
@@ -90,6 +90,7 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 	if cfg.TargetOS != "" && cfg.TargetOS != core.TargetLinux {
 		return nil, core.Exit(2, "provider=%s supports target=linux only", providerName)
 	}
+	cfg.Provider = providerName
 	loadedRouting := core.ExternalRoutingLoaded(cfg.External)
 	if path := strings.TrimSpace(cfg.External.RoutingFile); path != "" && !loadedRouting {
 		routing, err := core.LoadExternalRouting(path)
@@ -97,7 +98,11 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 			return nil, core.Exit(2, "%v", err)
 		}
 		cfg.External = routing
+		core.MarkExternalRoutingCredentialSources(&cfg)
 		loadedRouting = true
+	}
+	if err := core.ValidateProviderCredentialDestination(cfg); err != nil {
+		return nil, err
 	}
 	base := core.BaseConfig()
 	explicitTopLevelWorkRoot := !loadedRouting && strings.TrimSpace(cfg.WorkRoot) != "" && cfg.WorkRoot != base.WorkRoot
@@ -108,7 +113,6 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 	if err := validateConfig(cfg); err != nil {
 		return nil, err
 	}
-	cfg.Provider = providerName
 	cfg.TargetOS = core.TargetLinux
 	cfg.SSHFallbackPorts = nil
 	cfg.WorkRoot = externalWorkRoot(cfg)

--- a/internal/providers/external/provider_test.go
+++ b/internal/providers/external/provider_test.go
@@ -21,9 +21,12 @@ import (
 func testConfig() core.Config {
 	cfg := core.BaseConfig()
 	cfg.External = core.ExternalConfig{
-		Command:  "provider-command",
-		Args:     []string{"--profile", "test"},
-		Config:   map[string]any{"namespace": "dev", "cpu": 32},
+		Command: "provider-command",
+		Args:    []string{"--profile", "test"},
+		Config:  map[string]any{"namespace": "dev", "cpu": 32},
+		Connection: core.ExternalConnectionConfig{SSH: core.ExternalSSHConnectionConfig{
+			TrustProviderOutput: true,
+		}},
 		WorkRoot: "/home/tester/crabbox",
 	}
 	return cfg
@@ -800,6 +803,66 @@ func TestInvokeDeclarativeLifecycleValidatesConnectionBeforeAcquire(t *testing.T
 	}
 }
 
+func TestLifecycleSSHRejectsEnvironmentDerivedFieldsByDefault(t *testing.T) {
+	t.Setenv("EXTERNAL_SSH_VALUE", "sensitive-value")
+	templateCtx := lifecycleTemplateContext{values: map[string]string{}}
+	tests := []struct {
+		name   string
+		field  string
+		mutate func(*core.ExternalSSHConnectionConfig)
+	}{
+		{name: "user", field: "ssh.user", mutate: func(cfg *core.ExternalSSHConnectionConfig) { cfg.User = "{{env.EXTERNAL_SSH_VALUE}}" }},
+		{name: "host", field: "ssh.host", mutate: func(cfg *core.ExternalSSHConnectionConfig) { cfg.Host = "{{env.EXTERNAL_SSH_VALUE}}" }},
+		{name: "key", field: "ssh.key", mutate: func(cfg *core.ExternalSSHConnectionConfig) { cfg.Key = "{{env.EXTERNAL_SSH_VALUE}}" }},
+		{name: "port", field: "ssh.port", mutate: func(cfg *core.ExternalSSHConnectionConfig) { cfg.Port = "{{env.EXTERNAL_SSH_VALUE}}" }},
+		{name: "ready check", field: "ssh.readyCheck", mutate: func(cfg *core.ExternalSSHConnectionConfig) { cfg.ReadyCheck = "{{env.EXTERNAL_SSH_VALUE}}" }},
+		{name: "proxy command", field: "ssh.proxyCommand", mutate: func(cfg *core.ExternalSSHConnectionConfig) { cfg.ProxyCommand = "{{env.EXTERNAL_SSH_VALUE}}" }},
+		{name: "fallback port", field: "ssh.fallbackPorts", mutate: func(cfg *core.ExternalSSHConnectionConfig) {
+			cfg.FallbackPorts = []string{"{{env.EXTERNAL_SSH_VALUE}}"}
+		}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := core.ExternalSSHConnectionConfig{User: "developer", Host: "host.example.test"}
+			test.mutate(&cfg)
+			_, err := lifecycleSSH(cfg, templateCtx)
+			if err == nil || !strings.Contains(err.Error(), test.field) || !strings.Contains(err.Error(), "allowEnv") {
+				t.Fatalf("err=%v", err)
+			}
+		})
+	}
+}
+
+func TestLifecycleSSHAllowsExplicitNonSecretEnvironmentFields(t *testing.T) {
+	t.Setenv("EXTERNAL_SSH_HOST", "host.example.test")
+	ssh, err := lifecycleSSH(core.ExternalSSHConnectionConfig{
+		User:     "developer",
+		Host:     "{{env.EXTERNAL_SSH_HOST}}",
+		AllowEnv: true,
+	}, lifecycleTemplateContext{values: map[string]string{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ssh.Host != "host.example.test" {
+		t.Fatalf("host=%q", ssh.Host)
+	}
+}
+
+func TestLifecycleSSHRejectsIndirectEnvironmentDerivedFieldsByDefault(t *testing.T) {
+	templateCtx := lifecycleTemplateContext{
+		values:    map[string]string{"resourceName": "sensitive-value"},
+		sensitive: map[string]bool{"resourceName": true},
+	}
+	_, err := lifecycleSSH(core.ExternalSSHConnectionConfig{
+		User: "{{resourceName}}",
+		Host: "approved.example.test",
+	}, templateCtx)
+	if err == nil || !strings.Contains(err.Error(), "ssh.user") || !strings.Contains(err.Error(), "allowEnv") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
 func TestInvokeDeclarativeLifecycleConnectionTemplatesUseRequestContext(t *testing.T) {
 	cfg := core.BaseConfig()
 	cfg.External = core.ExternalConfig{
@@ -853,7 +916,7 @@ func TestInvokeDeclarativeLifecycleParsesNameInventory(t *testing.T) {
 			Release: core.ExternalLifecycleOperation{Argv: []string{"devboxctl", "rm", "{{name}}"}},
 		},
 		Connection: core.ExternalConnectionConfig{
-			SSH: core.ExternalSSHConnectionConfig{User: "developer", Host: "{{name}}", SSHConfigProxy: true},
+			SSH: core.ExternalSSHConnectionConfig{User: "developer", Host: "{{name}}", SSHConfigProxy: true, TrustProviderOutput: true},
 		},
 		WorkRoot: "/home/developer/crabbox",
 	}
@@ -886,6 +949,31 @@ func TestInvokeDeclarativeLifecycleParsesNameInventory(t *testing.T) {
 	}
 }
 
+func TestInvokeDeclarativeLifecycleRejectsUntrustedNameInventoryTarget(t *testing.T) {
+	isolateCrabboxState(t)
+	cfg := core.BaseConfig()
+	cfg.External = core.ExternalConfig{
+		Lifecycle: core.ExternalLifecycleConfig{
+			Acquire: core.ExternalLifecycleOperation{Argv: []string{"provider", "acquire"}},
+			List: core.ExternalLifecycleOperation{
+				Argv: []string{"provider", "list"}, Output: lifecycleOutputJSONNameArray,
+			},
+			Release: core.ExternalLifecycleOperation{Argv: []string{"provider", "release"}},
+		},
+		Connection: core.ExternalConnectionConfig{SSH: core.ExternalSSHConnectionConfig{
+			User: "developer", Host: "{{resourceName}}",
+		}},
+	}
+	backend := &leaseBackend{cfg: cfg, rt: core.Runtime{
+		Stderr: io.Discard,
+		Exec:   &recordingRunner{stdout: `["attacker.invalid"]`},
+	}}
+	_, err := backend.invokeLifecycle(context.Background(), protocolRequest{Operation: "list"})
+	if err == nil || !strings.Contains(err.Error(), "trustProviderOutput") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
 func TestInvokeDeclarativeLifecycleParsesRawLease(t *testing.T) {
 	cfg := core.BaseConfig()
 	cfg.External = core.ExternalConfig{
@@ -895,6 +983,7 @@ func TestInvokeDeclarativeLifecycleParsesRawLease(t *testing.T) {
 				Output: lifecycleOutputJSONLease,
 			},
 		},
+		Connection: core.ExternalConnectionConfig{SSH: core.ExternalSSHConnectionConfig{TrustProviderOutput: true}},
 	}
 	runner := &recordingRunner{stdout: `{
 		"leaseId":"cbx_abcdef123456",
@@ -919,6 +1008,32 @@ func TestInvokeDeclarativeLifecycleParsesRawLease(t *testing.T) {
 	if response.SynthesizedIdentity || response.Lease == nil || response.Lease.CloudID != "provider/resource-123" ||
 		response.Lease.SSH == nil || response.Lease.SSH.Host != "resource-123" {
 		t.Fatalf("response=%#v", response)
+	}
+}
+
+func TestInvokeDeclarativeLifecycleRejectsUntrustedRawSSHTarget(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.External.Lifecycle.Acquire = core.ExternalLifecycleOperation{
+		Argv: []string{"devboxctl", "new", "{{name}}"}, Output: lifecycleOutputJSONLease,
+	}
+	runner := &recordingRunner{stdout: `{
+		"leaseId":"cbx_abcdef123456",
+		"slug":"fast-coral",
+		"name":"crabbox-fast-coral-deadbeef",
+		"cloudId":"provider/resource-123",
+		"ssh":{"user":"developer","host":"attacker.invalid","port":"22"}
+	}`}
+	backend := &leaseBackend{cfg: cfg, rt: core.Runtime{Stderr: io.Discard, Exec: runner}}
+	_, err := backend.invokeLifecycle(context.Background(), protocolRequest{
+		Operation: "acquire",
+		Desired: &desiredLease{
+			LeaseID: "cbx_abcdef123456",
+			Slug:    "fast-coral",
+			Name:    "crabbox-fast-coral-deadbeef",
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "trustProviderOutput") {
+		t.Fatalf("error=%v", err)
 	}
 }
 
@@ -1096,7 +1211,7 @@ func TestDeclarativeLifecycleCleanupDryRunDoesNotRunCommand(t *testing.T) {
 			Cleanup: core.ExternalLifecycleOperation{Argv: []string{"devboxctl", "gc"}},
 		},
 		Connection: core.ExternalConnectionConfig{
-			SSH: core.ExternalSSHConnectionConfig{User: "developer", Host: "{{name}}"},
+			SSH: core.ExternalSSHConnectionConfig{User: "developer", Host: "{{name}}", TrustProviderOutput: true},
 		},
 	}
 	runner := &recordingRunner{}
@@ -1162,7 +1277,7 @@ func TestInvokeDeclarativeLifecycleFiltersNameInventory(t *testing.T) {
 			Release: core.ExternalLifecycleOperation{Argv: []string{"devboxctl", "rm", "{{name}}"}},
 		},
 		Connection: core.ExternalConnectionConfig{
-			SSH: core.ExternalSSHConnectionConfig{User: "developer", Host: "{{name}}"},
+			SSH: core.ExternalSSHConnectionConfig{User: "developer", Host: "{{name}}", TrustProviderOutput: true},
 		},
 		WorkRoot: "/home/developer/crabbox",
 	}
@@ -1477,7 +1592,7 @@ func TestDeclarativeInventoryUsesListedNameForLegacyClaim(t *testing.T) {
 		Connection: core.ExternalConnectionConfig{
 			ResourceName:         "{{env.DEVBOX_RESOURCE}}",
 			AllowEnvResourceName: true,
-			SSH:                  core.ExternalSSHConnectionConfig{User: "developer"},
+			SSH:                  core.ExternalSSHConnectionConfig{User: "developer", AllowEnv: true, TrustProviderOutput: true},
 		},
 		WorkRoot: "/home/developer/crabbox",
 	}
@@ -1520,7 +1635,7 @@ func TestDeclarativeInventoryPreservesEnvResourceNameProvenance(t *testing.T) {
 			Release: core.ExternalLifecycleOperation{Argv: []string{"devboxctl", "rm", "{{resourceName}}"}},
 		},
 		Connection: core.ExternalConnectionConfig{
-			SSH: core.ExternalSSHConnectionConfig{User: "developer", Host: "{{resourceName}}"},
+			SSH: core.ExternalSSHConnectionConfig{User: "developer", Host: "{{resourceName}}", AllowEnv: true, TrustProviderOutput: true},
 		},
 		WorkRoot: "/home/developer/crabbox",
 	}
@@ -1826,6 +1941,56 @@ func TestValidateConfigRejectsMixedOrIncompleteDeclarativeModes(t *testing.T) {
 	cfg.External.Lifecycle.List.Output = lifecycleOutputJSONLeaseArray
 	if err := validateConfig(cfg); err == nil || !strings.Contains(err.Error(), "namePrefix requires") {
 		t.Fatalf("list name prefix err=%v", err)
+	}
+}
+
+func TestAcquirePreflightRequiresTrustedProviderOutputBeforeCommandRuns(t *testing.T) {
+	cfg := testConfig()
+	cfg.External.Connection.SSH.TrustProviderOutput = false
+	if err := validateConfig(cfg); err != nil {
+		t.Fatalf("legacy command config rejected: %v", err)
+	}
+	backend := &leaseBackend{cfg: cfg}
+	if err := backend.validateAcquireProviderSSHOutput(); err == nil || !strings.Contains(err.Error(), "trustProviderOutput") {
+		t.Fatalf("command error=%v", err)
+	}
+
+	cfg.External.Command = ""
+	cfg.External.Lifecycle = core.ExternalLifecycleConfig{
+		Acquire: core.ExternalLifecycleOperation{Argv: []string{"provider", "acquire"}, Output: lifecycleOutputJSONLease},
+		List:    core.ExternalLifecycleOperation{Argv: []string{"provider", "list"}, Output: lifecycleOutputJSONLeaseArray},
+		Release: core.ExternalLifecycleOperation{Argv: []string{"provider", "release"}},
+	}
+	cfg.External.Connection.SSH.User = "developer"
+	backend.cfg = cfg
+	if err := backend.validateAcquireProviderSSHOutput(); err == nil || !strings.Contains(err.Error(), "trustProviderOutput") {
+		t.Fatalf("declarative error=%v", err)
+	}
+
+	cfg.External.Lifecycle.Acquire.Output = lifecycleOutputNone
+	cfg.External.Lifecycle.List.Output = lifecycleOutputJSONNameArray
+	backend.cfg = cfg
+	if err := backend.validateAcquireProviderSSHOutput(); err != nil {
+		t.Fatalf("configured acquire target rejected: %v", err)
+	}
+}
+
+func TestProtocolReleaseOnlyResolveAllowsLegacySSHOutputWithoutUsingIt(t *testing.T) {
+	cfg := testConfig()
+	cfg.External.Connection.SSH.TrustProviderOutput = false
+	runner := &recordingRunner{stdout: `{
+		"protocolVersion":1,
+		"lease":{"leaseId":"cbx_abcdef123456","slug":"fast-coral","name":"box","cloudId":"provider/resource","ssh":{"user":"developer","host":"legacy.example.test"}}
+	}`}
+	backend := &leaseBackend{cfg: cfg, rt: core.Runtime{Stderr: io.Discard, Exec: runner}}
+	if _, err := backend.invokeProtocol(context.Background(), protocolRequest{
+		Operation: "resolve", ReleaseOnly: true,
+	}); err != nil {
+		t.Fatalf("legacy release-only resolve rejected: %v", err)
+	}
+	if _, err := backend.invokeProtocol(context.Background(), protocolRequest{Operation: "resolve"}); err == nil ||
+		!strings.Contains(err.Error(), "trustProviderOutput") {
+		t.Fatalf("normal resolve error=%v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- bind External SSH endpoint templates and repository-backed template inputs to exact trusted-user-config approval
- require source-bound opt-ins for environment-derived SSH fields and provider-returned SSH destinations
- version validated routing state, fail legacy state closed for credential use, and preserve release-only/cleanup compatibility without connecting
- document the trusted configuration contract and changelog the security fix

Closes https://github.com/openclaw/crabbox/issues/953
Closes https://github.com/openclaw/crabbox/issues/956

## Verification

- `go vet ./...`
- `go test -race ./...`
- `go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker` (866 passed, 3 skipped)
- `npm run build --prefix worker`
- `node scripts/build-docs-site.mjs`
- AutoReview clean

## Live proof

Built the candidate CLI and exercised layered user/repository configuration through the real command path:

- repository-only External SSH destination: denied before provider use
- exact trusted endpoint plus exact provider-output contract: `doctor` and `list` succeeded
- repository-mutated environment-backed resource contract: denied before provider use

No persistent credentials or remote resources were created.
