### PR TITLE
docs: fix coordinator API methods, backend-kind labels, and cli command map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Corrected the CLI command map, coordinator API methods, and provider architecture reference to match the implemented commands, routes, and backend capabilities. Thanks @zozo123.
 - Partitioned unauthenticated GitHub OAuth starts by caller with an atomic per-source limit and guarded global backstop, preventing one source from exhausting login for every user. Thanks @coygeek.
 - Disabled inherited SSH agent and X11 forwarding across CLI-managed SSH, rsync, SCP, VNC, and port-forward transports, preserving per-lease credential boundaries. Thanks @coygeek.
 - Collected runtime-only provider credentials through provider-owned diagnostic hooks and redacted opaque OpenSandbox and W&B upstream errors before they reach CLI output. Thanks @coygeek.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -223,10 +223,11 @@ GET  /v1/providers/{provider}/readiness
 GET  /v1/runners
 POST /v1/runners/sync
 POST /v1/images
-POST /v1/images/{id}/promote | fast-snapshot-restore
+POST /v1/images/{id}/promote
+GET  /v1/images/{id}/fast-snapshot-restore
 POST /v1/artifacts/uploads
 GET  /v1/admin/leases
-POST /v1/admin/lease-audit
+GET  /v1/admin/lease-audit
 POST /v1/admin/leases/{id-or-slug}/release | delete
 GET  /v1/admin/hosts
 POST /v1/admin/aws-orphan-sweep

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -39,6 +39,7 @@ Commands are grouped here for orientation. Each links to its detailed page under
 
 ```text
 crabbox warmup [lease flags]                 lease a box and wait until ready
+crabbox prewarm [lease flags]                lease and hydrate a reusable test-ready box
 crabbox run -- <command...>                  sync, run a remote command, stream output
 crabbox run --pool <key> -- <command...>     borrow a hydrated ready-pool lease
 crabbox run --timing-record=default -- <cmd> append timing to the local benchmark ledger
@@ -50,26 +51,32 @@ crabbox list                                  list machines (alias: crabbox pool
 crabbox share --id <id> [--user|--org]        grant access to a lease
 crabbox unshare --id <id> [--user|--org|--all]
 crabbox stop <id-or-slug>                     end a lease (alias: crabbox release)
-crabbox cleanup [--dry-run]                   sweep expired direct-provider machines
+crabbox pause <id-or-slug>                    pause a lease, keeping its state (provider-dependent)
+crabbox resume <id-or-slug>                   resume a previously paused lease
+crabbox cleanup [--dry-run]                   sweep expired direct-provider machines (alias: crabbox machine cleanup)
 crabbox pool ready [key]                      list hydrated broker ready-pool leases
 ```
 
-See [warmup](commands/warmup.md), [run](commands/run.md),
-[watch](commands/watch.md),
+See [warmup](commands/warmup.md), [prewarm](commands/prewarm.md),
+[run](commands/run.md), [watch](commands/watch.md),
 [status](commands/status.md), [inspect](commands/inspect.md),
 [list](commands/list.md), [share](commands/share.md),
 [unshare](commands/unshare.md), [stop](commands/stop.md),
+[pause](commands/pause.md), [resume](commands/resume.md),
 [cleanup](commands/cleanup.md), [pool](commands/pool.md).
 
 ### Run helpers and jobs
 
 ```text
 crabbox sync-plan [--limit <n>]              preview local sync manifest size hotspots
+crabbox shard --count <n> -- <command...>    fork a checkpoint into parallel test shards
+crabbox cp --id <id> <src> SANDBOX:<dst>     copy files between host and a delegated sandbox
 crabbox job list                              list repo-local configured jobs
 crabbox job run <name>                        run a configured job
 ```
 
-See [sync-plan](commands/sync-plan.md), [job](commands/job.md).
+See [sync-plan](commands/sync-plan.md), [shard](commands/shard.md),
+[cp](commands/cp.md), [job](commands/job.md).
 
 ### Observability
 
@@ -95,14 +102,15 @@ crabbox vnc --id <id> [--open]                 print/open SSH-tunneled VNC detai
 crabbox webvnc --id <id> [--open]              bridge a desktop lease into the web portal
 crabbox code --id <id> [--open]                bridge a code lease into the web portal
 crabbox egress start --id <id>                 bridge lease traffic through this machine
+crabbox ports --id <id> [--publish <port>]     list, publish, or unpublish provider-native ports
 crabbox screenshot --id <id> [--output <png>]  capture a PNG from a desktop lease
 crabbox desktop launch|terminal|record|proof|doctor|click|paste|type|key
 ```
 
 See [connect](commands/connect.md), [ssh](commands/ssh.md), [vnc](commands/vnc.md),
 [webvnc](commands/webvnc.md), [code](commands/code.md),
-[egress](commands/egress.md), [screenshot](commands/screenshot.md),
-[desktop](commands/desktop.md).
+[egress](commands/egress.md), [ports](commands/ports.md),
+[screenshot](commands/screenshot.md), [desktop](commands/desktop.md).
 
 ### Media and artifacts
 
@@ -152,12 +160,13 @@ See [pond](commands/pond.md) and the [pond feature](features/pond.md).
 ```text
 crabbox providers                             show provider capabilities
 crabbox usage [--scope user|org|all]          cost and usage estimates
+crabbox marketplace status|quote              preview the credits gateway and smart-routing quotes
 crabbox admin leases|lease-audit|providers|hosts|release|delete
 crabbox admin aws-identity|aws-policy|mac-hosts
 ```
 
 See [providers](commands/providers.md), [usage](commands/usage.md),
-[admin](commands/admin.md).
+[marketplace](commands/marketplace.md), [admin](commands/admin.md).
 
 ### Config and auth
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -69,7 +69,8 @@ See [warmup](commands/warmup.md), [prewarm](commands/prewarm.md),
 
 ```text
 crabbox sync-plan [--limit <n>]              preview local sync manifest size hotspots
-crabbox shard --count <n> -- <command...>    fork a checkpoint into parallel test shards
+crabbox shard --from <checkpoint-id> --count <n> -- <command...>
+                                                fork a checkpoint into parallel test shards
 crabbox cp --id <id> <src> SANDBOX:<dst>     copy files between host and a delegated sandbox
 crabbox job list                              list repo-local configured jobs
 crabbox job run <name>                        run a configured job

--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -239,7 +239,7 @@ internal/providers/sprites              # Sprites SSH backend
 internal/providers/exedev               # exe.dev SSH backend
 internal/providers/runpod               # RunPod GPU pod SSH backend
 internal/providers/nvidiabrev           # NVIDIA Brev GPU workspace SSH backend
-internal/providers/railway              # Railway.app delegated backend
+internal/providers/railway              # Railway.app service-control backend
 internal/providers/blacksmith           # Blacksmith Testbox delegated backend
 internal/providers/e2b                  # E2B delegated backend
 internal/providers/islo                 # Islo delegated backend
@@ -370,6 +370,9 @@ type ProviderSpec struct {
 	Targets     []TargetSpec
 	Features    FeatureSet
 	Coordinator CoordinatorMode
+	// TailscaleEgressOnly marks FeatureTailscale as outbound userspace access,
+	// not a bidirectional peer endpoint.
+	TailscaleEgressOnly bool
 }
 ```
 
@@ -382,6 +385,9 @@ Pick `Kind` carefully:
 
 - `ProviderKindSSHLease`: provider returns SSH targets and Crabbox owns sync/run.
 - `ProviderKindDelegatedRun`: provider owns execution and output streaming.
+- `ProviderKindServiceControl`: provider inspects or controls an existing
+  hosted service instead of leasing a run surface (for example `railway` and
+  `fastapi-cloud`).
 
 `Targets` should describe what the provider can actually satisfy. Use `linux`,
 `macos`, or `windows` only for real operating-system targets. Use
@@ -412,6 +418,7 @@ cli.FeatureRunSession   // "run-session"
 cli.FeatureModuleRun    // "module-run"
 cli.FeatureRunArtifacts // "run-artifacts"
 cli.FeatureRunDownloads // "run-downloads"
+cli.FeaturePauseResume  // "pause-resume"
 cli.FeatureMCP          // "mcp-attachments"
 ```
 


### PR DESCRIPTION
## Summary
- `docs/architecture.md`: correct the coordinator API method list — `/v1/admin/lease-audit` is a GET (server routes it only for GET in `worker/src/fleet.ts`; the CLI client calls it with `http.MethodGet`), and split `/v1/images/{id}/promote | fast-snapshot-restore` so promote stays POST while the `fast-snapshot-restore` status endpoint is documented as GET.
- `docs/provider-backends.md`: relabel `internal/providers/railway` as a service-control backend (it registers `core.ProviderKindServiceControl`, not a delegated-run kind); document `ProviderKindServiceControl` in the "Pick `Kind` carefully" list; add the missing `TailscaleEgressOnly bool` field to the `ProviderSpec` listing; add the missing `cli.FeaturePauseResume // "pause-resume"` constant to the feature list.
- `docs/cli.md`: add the registered commands that were missing from the command map — `prewarm`, `shard`, `cp`, `ports`, `marketplace`, `pause`, and `resume` — each linked to its page under `docs/commands/`, and note the `crabbox machine cleanup` alias on the existing `cleanup` entry.
- `CHANGELOG.md`: credit @zozo123 for the corrected command and architecture references.

Part of the documentation-drift cleanup tracked in https://github.com/openclaw/crabbox/issues/944.

## Notes
- `fastapicloud` also registers `ProviderKindServiceControl`, but it does not appear in the provider directory listing in `docs/provider-backends.md`, so only the `railway` label needed fixing there.
- `docs/commands/machine.md` does not exist and `machine` is not part of the `app.go` help surface that `scripts/check-command-docs.mjs` enforces; since `machine cleanup` is a pure alias for `cleanup`, it is documented as an alias on the `cleanup` entry (matching the existing `stop`/`release` and `list`/`pool list` style) rather than as a linked row.

## Verification
- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- Built CLI help checked for `prewarm`, `shard`, `cp`, `ports`, `marketplace`, `pause`, `resume`, and `machine cleanup`.
- `scripts/check-docs.sh` — 53 command docs, 72 providers, 210 Markdown files, and docs-site build all pass.
- Generated `cli.html`, `architecture.html`, and `provider-backends.html` served over local HTTP and checked for the corrected rendered content; site icon also returned successfully.
- AutoReview: clean, no accepted/actionable findings (`0.99`).
