### PR TITLE
ci: add hermetic end-to-end connector smoke workflow

### DIFF
--- a/.github/workflows/connector-e2e-smokes.yml
+++ b/.github/workflows/connector-e2e-smokes.yml
@@ -1,0 +1,120 @@
+# Hermetic connector-lifecycle gate (tier 1 of
+# https://github.com/openclaw/crabbox/issues/944).
+#
+# Every row runs with zero repository or provider credentials on hosted
+# runners. Tier 2 (secret-backed cloud providers) is intentionally out of
+# scope pending a maintainer credential policy; nothing in this file may
+# reference repository or environment credentials.
+#
+# Rows considered but dropped:
+#   - docker-sandbox live smoke (scripts/live-docker-sandbox-smoke.sh):
+#     requires the proprietary Docker Sandboxes `sbx` CLI, which is not
+#     preinstalled on hosted runners and needs `sbx login` account
+#     authentication. The docker-sandbox connector is covered hermetically
+#     by the trust-boundary row below, which drives the real CLI against a
+#     fake `sbx` at the process boundary.
+name: Connector E2E Smokes
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: connector-e2e-smokes-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  GOFLAGS: -mod=readonly -trimpath
+  GOTOOLCHAIN: local
+
+jobs:
+  hermetic:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 15
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: docker-sandbox-trust-boundary
+            runner: ubuntu-latest
+            build-cli: false
+            smoke: scripts/docker-sandbox-trust-boundary-smoke.sh
+
+          - name: local-container
+            runner: ubuntu-latest
+            build-cli: true
+            smoke: |
+              CRABBOX_LIVE=1 \
+              CRABBOX_LIVE_PROVIDERS=local-container \
+              CRABBOX_BIN="$PWD/bin/crabbox" \
+                scripts/live-smoke.sh
+
+          # Read-only doctor readiness contract. Hosted runners do not ship
+          # Firecracker or CNI plugins, so the script's own
+          # `classification=environment_blocked` outcome is an expected pass:
+          # it proves the doctor JSON contract classifies missing
+          # KVM/Firecracker/CNI prerequisites instead of failing opaquely.
+          # `classification=validation_failed` (malformed doctor output)
+          # still fails the row.
+          - name: firecracker-readiness
+            runner: ubuntu-latest
+            build-cli: true
+            smoke: |
+              status=0
+              output="$(scripts/live-firecracker-smoke.sh 2>&1)" || status=$?
+              printf '%s\n' "$output"
+              if [ "$status" -eq 0 ]; then
+                exit 0
+              fi
+              if printf '%s\n' "$output" | grep -q 'classification=environment_blocked'; then
+                echo "readiness contract held: missing prerequisites classified as environment_blocked"
+                exit 0
+              fi
+              exit "$status"
+
+          - name: ssh-localhost
+            runner: ubuntu-latest
+            build-cli: true
+            smoke: CRABBOX_BIN="$PWD/bin/crabbox" scripts/live-ssh-localhost-smoke.sh
+
+          # Mirrors the apple-vm job in ci.yml: hermetic native helper and
+          # embedded VM daemon proof on Apple Silicon.
+          - name: apple-vm
+            runner: macos-15
+            build-cli: false
+            smoke: |
+              test "$(uname -m)" = arm64
+              go vet ./internal/applevmhelper ./cmd/crabbox-apple-vm-helper
+              go test -race ./internal/applevmhelper ./internal/providers/applevm
+              sh scripts/build-vmd.sh
+              go build -trimpath -tags vmdembed -o /tmp/crabbox-apple-vm-helper ./cmd/crabbox-apple-vm-helper
+              /tmp/crabbox-apple-vm-helper vmd-info | grep -q '"embedded":true'
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Install smoke dependencies
+        if: matrix.name == 'local-container'
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
+
+      - name: Build CLI
+        if: matrix.build-cli == true
+        run: go build -trimpath -o bin/crabbox ./cmd/crabbox
+
+      - name: Run connector lifecycle smoke
+        run: ${{ matrix.smoke }}

--- a/docs/features/provider-live-smoke.md
+++ b/docs/features/provider-live-smoke.md
@@ -19,7 +19,11 @@ still matches the offline contract.
    `lifecycle_test.go` or `*_lifecycle_test.go`; the source-derived Connector
    Lifecycles job discovers their packages and runs them with the race detector.
    Cover acquire, resolve/readiness, use, touch, list, release, cleanup failure,
-   and claim retention where the backend supports those stages.
+   and claim retention where the backend supports those stages. The
+   `.github/workflows/connector-e2e-smokes.yml` gate additionally drives
+   secret-free connector lifecycles end to end on hosted runners: local
+   containers, a localhost byo-SSH target, the Docker Sandbox trust-boundary
+   proof, and read-only readiness contracts.
 2. **Guarded live smoke** — opt-in developer or maintainer proof against the real
    provider. Use `CRABBOX_LIVE=1`, select the exact provider, cap spend and TTL,
    arm cleanup before the first mutation, and prove create/use/destroy with zero

--- a/scripts/connector-e2e-smokes-workflow.test.js
+++ b/scripts/connector-e2e-smokes-workflow.test.js
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const workflow = fs.readFileSync(
+  path.join(repoRoot, ".github", "workflows", "connector-e2e-smokes.yml"),
+  "utf8",
+);
+
+test("connector lifecycle gate runs on pull requests, main pushes, and manual dispatch only", () => {
+  const trigger = workflow.slice(workflow.indexOf("\non:"), workflow.indexOf("permissions:"));
+  assert.match(trigger, /pull_request:/);
+  assert.match(trigger, /push:\s*\n\s+branches:\s*\n\s+- main/);
+  assert.match(trigger, /workflow_dispatch:/);
+  assert.doesNotMatch(
+    workflow,
+    /schedule:/,
+    "the hermetic gate must not run on a schedule; tier 2 needs a maintainer credential policy first",
+  );
+});
+
+test("connector lifecycle gate stays hermetic: no secret references anywhere", () => {
+  assert.ok(
+    !workflow.includes("secrets."),
+    "workflow must not reference secrets; tier 1 of https://github.com/openclaw/crabbox/issues/944 is zero-credential",
+  );
+});
+
+test("matrix rows do not fail fast and are time-bounded", () => {
+  assert.match(workflow, /fail-fast:\s*false/);
+  assert.match(workflow, /timeout-minutes:\s*15/);
+});
+
+test("pull request runs cancel superseded attempts", () => {
+  assert.match(workflow, /concurrency:\s*\n\s+group:/);
+  assert.match(workflow, /cancel-in-progress:.*pull_request/);
+});

--- a/scripts/live-ssh-localhost-smoke.sh
+++ b/scripts/live-ssh-localhost-smoke.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Hermetic byo-ssh (provider=ssh) lifecycle smoke against 127.0.0.1.
+#
+# Generates a disposable ed25519 key, authorizes it for the current user,
+# ensures a local sshd is running, then drives the static SSH provider
+# through warmup -> status -> run -> list -> stop. No cloud resources, no
+# credentials beyond the throwaway keypair; the authorized_keys entry is
+# removed again on exit.
+#
+# Environment:
+#   CRABBOX_BIN                  Crabbox binary (default: ./bin/crabbox)
+#   CRABBOX_SSH_LOCALHOST_USER   SSH user (default: current user)
+#   CRABBOX_SSH_LOCALHOST_PORT   SSH port (default: 22)
+
+slug="ssh-localhost-smoke-$(date +%Y%m%d%H%M%S)-$$"
+bin="${CRABBOX_BIN:-./bin/crabbox}"
+ssh_user="${CRABBOX_SSH_LOCALHOST_USER:-$(id -un)}"
+ssh_port="${CRABBOX_SSH_LOCALHOST_PORT:-22}"
+work_dir="$(mktemp -d "${TMPDIR:-/tmp}/crabbox-ssh-localhost-XXXXXX")"
+key_file="$work_dir/id_ed25519"
+work_root="$work_dir/workroot"
+authorized_keys="$HOME/.ssh/authorized_keys"
+authorized_entry=""
+cleanup_armed=0
+
+classify_blocker() {
+  local command="$1"
+  local status="$2"
+  local output="$3"
+  local classification="environment_blocked"
+  local lower
+  lower="$(printf '%s' "$output" | tr '[:upper:]' '[:lower:]')"
+  if [[ "$lower" == *quota* || "$lower" == *"rate limit"* || "$lower" == *capacity* ]]; then
+    classification="quota_blocked"
+  fi
+  printf 'classification=%s command=%q exit=%s\n' "$classification" "$command" "$status" >&2
+  printf '%s\n' "$output" >&2
+}
+
+classify_validation_failure() {
+  local command="$1"
+  local status="$2"
+  local output="$3"
+  printf 'classification=validation_failed command=%q exit=%s\n' "$command" "$status" >&2
+  printf '%s\n' "$output" >&2
+}
+
+run_capture() {
+  local command="$1"
+  shift
+  local output
+  set +e
+  output="$("$@" 2>&1)"
+  local status=$?
+  set -e
+  if [ "$status" -ne 0 ]; then
+    classify_blocker "$command" "$status" "$output"
+    exit "$status"
+  fi
+  printf '%s\n' "$output"
+}
+
+remove_authorized_entry() {
+  if [ -n "$authorized_entry" ] && [ -f "$authorized_keys" ]; then
+    grep -vF -- "$authorized_entry" "$authorized_keys" >"$authorized_keys.crabbox-smoke" || true
+    mv "$authorized_keys.crabbox-smoke" "$authorized_keys"
+    chmod 600 "$authorized_keys"
+    authorized_entry=""
+  fi
+}
+
+cleanup() {
+  if [ "$cleanup_armed" -eq 1 ]; then
+    "$bin" stop --provider ssh "$slug" >/dev/null 2>&1 || true
+  fi
+  remove_authorized_entry
+  rm -rf "$work_dir"
+}
+trap cleanup EXIT
+
+if [ ! -x "$bin" ]; then
+  echo "missing crabbox binary: $bin" >&2
+  echo "build first: go build -trimpath -o bin/crabbox ./cmd/crabbox" >&2
+  exit 2
+fi
+
+mkdir -p "$work_root"
+ssh-keygen -t ed25519 -N "" -q -f "$key_file" -C "crabbox-ssh-localhost-smoke"
+mkdir -p "$HOME/.ssh"
+chmod 700 "$HOME/.ssh"
+authorized_entry="$(cat "$key_file.pub")"
+printf '%s\n' "$authorized_entry" >>"$authorized_keys"
+chmod 600 "$authorized_keys"
+
+sshd_reachable() {
+  ssh-keyscan -T 5 -p "$ssh_port" 127.0.0.1 >/dev/null 2>&1
+}
+
+if ! sshd_reachable; then
+  if command -v sudo >/dev/null 2>&1; then
+    sudo systemctl start ssh 2>/dev/null ||
+      sudo service ssh start 2>/dev/null ||
+      sudo systemctl start sshd 2>/dev/null || true
+  fi
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    if sshd_reachable; then
+      break
+    fi
+    sleep 1
+  done
+fi
+if ! sshd_reachable; then
+  classify_blocker "ssh-keyscan -p $ssh_port 127.0.0.1" 1 "no sshd reachable on 127.0.0.1:$ssh_port; start the local SSH service first"
+  exit 1
+fi
+
+export CRABBOX_STATIC_HOST=127.0.0.1
+export CRABBOX_STATIC_USER="$ssh_user"
+export CRABBOX_STATIC_PORT="$ssh_port"
+export CRABBOX_STATIC_WORK_ROOT="$work_root"
+export CRABBOX_SSH_KEY="$key_file"
+
+doctor_output="$(run_capture "$bin doctor --provider ssh" "$bin" doctor --provider ssh)"
+printf '%s\n' "$doctor_output"
+
+cleanup_armed=1
+run_capture "$bin warmup --provider ssh --slug $slug --keep" "$bin" warmup --provider ssh --slug "$slug" --keep >/dev/null
+run_capture "$bin status --provider ssh --id $slug --wait --wait-timeout 60s" "$bin" status --provider ssh --id "$slug" --wait --wait-timeout 60s >/dev/null
+
+run_output="$(run_capture "$bin run --provider ssh --id $slug --no-sync -- echo crabbox-ssh-localhost-ok" "$bin" run --provider ssh --id "$slug" --no-sync -- echo crabbox-ssh-localhost-ok)"
+printf '%s\n' "$run_output"
+if [[ "$run_output" != *crabbox-ssh-localhost-ok* ]]; then
+  classify_validation_failure "$bin run --provider ssh --id $slug" 1 "run output did not include crabbox-ssh-localhost-ok"
+  exit 1
+fi
+
+list_output="$(run_capture "$bin list --provider ssh --json" "$bin" list --provider ssh --json)"
+printf '%s\n' "$list_output"
+validation_status=0
+validation_output=""
+set +e
+if command -v python3 >/dev/null 2>&1; then
+  validation_output="$(CRABBOX_SMOKE_SLUG="$slug" python3 -c '
+import json
+import os
+import sys
+
+slug = os.environ["CRABBOX_SMOKE_SLUG"]
+try:
+    payload = json.load(sys.stdin)
+except Exception as exc:
+    print(f"invalid JSON: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+def has_slug(value):
+    if isinstance(value, dict):
+        labels = value.get("labels")
+        if isinstance(labels, dict) and labels.get("slug") == slug:
+            return True
+        if value.get("slug") == slug or value.get("name") == slug:
+            return True
+        return any(has_slug(child) for child in value.values())
+    if isinstance(value, list):
+        return any(has_slug(child) for child in value)
+    return False
+
+if not has_slug(payload):
+    print(f"list JSON did not include slug {slug}", file=sys.stderr)
+    sys.exit(1)
+' <<<"$list_output" 2>&1)"
+  validation_status=$?
+elif command -v jq >/dev/null 2>&1; then
+  validation_output="$(jq -e --arg slug "$slug" \
+    '.. | objects | select((.slug? == $slug) or (.name? == $slug) or (((.labels? // {}) | .slug?) == $slug))' \
+    >/dev/null <<<"$list_output" 2>&1)"
+  validation_status=$?
+  if [ "$validation_status" -ne 0 ] && [ -z "$validation_output" ]; then
+    validation_output="list JSON did not include slug $slug"
+  fi
+else
+  validation_output="no JSON parser available for list --json validation; install python3 or jq"
+  validation_status=1
+fi
+set -e
+if [ "$validation_status" -ne 0 ]; then
+  classify_validation_failure "$bin list --provider ssh --json" "$validation_status" "$validation_output"
+  exit "$validation_status"
+fi
+
+run_capture "$bin stop --provider ssh $slug" "$bin" stop --provider ssh "$slug" >/dev/null
+cleanup_armed=0
+printf 'classification=live_ssh_localhost_smoke_passed slug=%s host=127.0.0.1 cleanup=complete\n' "$slug"


### PR DESCRIPTION
## Summary

- Add `.github/workflows/connector-e2e-smokes.yml`, a zero-secrets end-to-end connector smoke tier that complements the source-derived lifecycle unit gate merged in https://github.com/openclaw/crabbox/pull/948: where that gate runs convention-named lifecycle test packages with the race detector, this workflow drives the real `crabbox` binary through warmup → status → run → stop against local substrates on hosted runners. Runs on `pull_request`, push to `main`, and `workflow_dispatch` — no `schedule`, no `secrets.` references, no cloud providers.
- One `hermetic` matrix job (`fail-fast: false`, `timeout-minutes: 15`, PR-scoped concurrency cancellation) with five rows:
  - **docker-sandbox-trust-boundary** (ubuntu-latest): `scripts/docker-sandbox-trust-boundary-smoke.sh` proves the workspace/command/env-file handoff against a fake `sbx` at the process boundary.
  - **local-container** (ubuntu-latest): `CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=local-container scripts/live-smoke.sh` drives a full lifecycle against the runner's Docker daemon.
  - **firecracker-readiness** (ubuntu-latest): read-only `crabbox doctor --provider firecracker --json` contract; `readiness_passed` and `environment_blocked` (expected on hosted runners without Firecracker/CNI) pass, anything else fails.
  - **ssh-localhost** (ubuntu-latest): new `scripts/live-ssh-localhost-smoke.sh` generates a disposable ed25519 key, authorizes it for the runner user, starts sshd, and drives the byo-ssh static provider (warmup → status → run → list → stop) against 127.0.0.1, then removes the authorized_keys entry.
  - **apple-vm** (macos-15): native helper vet/test, Swift VM daemon build, and embedded-daemon proof, mirroring the `apple-vm` job in `ci.yml`.
- Add `scripts/connector-e2e-smokes-workflow.test.js` asserting the trigger set (no `schedule:`), the literal absence of `secrets.`, `fail-fast: false`, bounded timeouts, and PR concurrency cancellation.
- Point the hermetic tier description in `docs/features/provider-live-smoke.md` at the new workflow.

## Notes

- **Dropped row:** the `docker-sandbox` live smoke (`scripts/live-docker-sandbox-smoke.sh`) needs the proprietary `sbx` CLI, `sbx login`, and host policy setup — not satisfiable on hosted runners without secrets. The trust-boundary row keeps that connector covered hermetically.
- **Locally proven** on a Docker-equipped host: docker-sandbox-trust-boundary (`classification=trust_boundary_proof_passed`) and local-container (full lifecycle, exit 0, lease deleted); firecracker-readiness produced the expected `classification=environment_blocked` on a non-KVM host, exercising the tolerated path.
- **Statically checked only:** `scripts/live-ssh-localhost-smoke.sh` (`bash -n`; local sshd intentionally not enabled on the authoring machine) and the apple-vm row (copied from the already-green `ci.yml` job). A `workflow_dispatch` run is the intended live proof for the full matrix before merge — happy to attach a run link from this fork on request.
- Naming deliberately avoids the `Connector Lifecycles` job introduced by https://github.com/openclaw/crabbox/pull/948; the two tiers are distinct required-check candidates.
- Tier 2 (secret-backed cloud providers, scheduled runs) remains out of scope pending maintainer credential/spend/orphan-audit policy, per https://github.com/openclaw/crabbox/issues/944.
- No config or secret implications: the workflow reads no secrets and mutates nothing outside the runner.

## Verification

- `node --test scripts/connector-e2e-smokes-workflow.test.js` (4/4)
- `node --test scripts/workflow-action-pins.test.js` (all `uses:` SHA-pinned, copied from `ci.yml`)
- `bash -n scripts/live-ssh-localhost-smoke.sh`
- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- `scripts/docker-sandbox-trust-boundary-smoke.sh` → `trust_boundary_proof_passed`
- `CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=local-container CRABBOX_BIN="$PWD/bin/crabbox" scripts/live-smoke.sh` → exit 0, lease deleted
- `CRABBOX_BIN="$PWD/bin/crabbox" scripts/live-firecracker-smoke.sh` → `environment_blocked` tolerated path
- `node scripts/generate-provider-matrix.mjs --check` (no generated-docs drift)

Refs: https://github.com/openclaw/crabbox/issues/944

🤖 Generated with [Claude Code](https://claude.com/claude-code)
