### PR TITLE
fix(security): bind External config argv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Prevented repository-defined External lifecycle commands from placing inherited `external.config` values on process arguments without an exact, trusted non-secret argv contract. Thanks @coygeek.
 - Prevented repository-controlled External SSH endpoint templates and adapter output from silently using ambient or operator-managed SSH credentials, with source-bound opt-ins for environment-derived fields and provider-returned destinations. Thanks @coygeek.
 - Made Sealos DevBox preflight work with tenant-scoped RBAC, rendered the runtime class, storage request, scheduling constraints, and SSH port contract required by hosted Sealos clusters, updated the SSHGate default to port 2233, bootstrapped missing sync tools, and cleaned local claims safely when a DevBox is already absent. Thanks @coygeek.
 - Changed portal logout to an authenticated, same-origin `POST` with a read-only `GET` confirmation page, preventing cross-site top-level navigation from clearing portal cookies or revoking isolated Code viewer sessions. Thanks @coygeek.

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -788,7 +788,11 @@ not shell commands. Acquire steps can opt into release cleanup with
 `rollbackOnFailure: true`. Put credentials in an operation `env:` map, not in
 `argv` or `steps`; environment-derived argv values require the explicit
 `allowEnvArgv: true` compatibility opt-in, and environment-derived resource
-names require `connection.allowEnvResourceName: true`. See
+names require `connection.allowEnvResourceName: true`. Repository lifecycle
+commands cannot place inherited `external.config` values in argv without an
+exact lifecycle and config-derived connection-template contract carrying
+`allowConfigArgv: true` in trusted user config; repository-owned config values
+are unchanged. See
 [External Provider](../providers/external.md) for placeholders, output
 semantics, inventory formats, routing behavior, controller-safe raw
 `json-lease` identity attestation, and security guidance.

--- a/docs/providers/external.md
+++ b/docs/providers/external.md
@@ -192,6 +192,17 @@ later release still requires `allowEnvArgv` before placing `{{resourceName}}`
 back in argv. Do not use either opt-in for tokens, passwords, API keys, or
 other credential contents.
 
+Repository lifecycle commands also cannot place `{{config.*}}` values inherited
+from user config, an explicit config file, or `--external-config-json` in
+`argv` or `steps`. Pass credentials through the operation `env:` map. For an
+inherited non-secret value that must be an argument, set `allowConfigArgv: true`
+on that operation and repeat the exact full lifecycle plus `resourceName` and
+`cloudId` template contract in trusted user config. The repository cannot grant
+itself this opt-in, and changing any lifecycle command, argument, environment
+mapping, output mode, cleanup behavior, or config-derived connection template
+invalidates the approval. Repository-owned `external.config` values remain
+ordinary project automation.
+
 Environment-derived expansion in `connection.ssh` fields is rejected by
 default, including indirect use through an environment-backed `resourceName`,
 because values such as the SSH user, host, key path, ready check, or proxy

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -487,6 +487,7 @@ type ExternalLifecycleOperation struct {
 	Steps             [][]string        `yaml:"steps,omitempty" json:"steps,omitempty"`
 	Env               map[string]string `yaml:"env,omitempty" json:"env,omitempty"`
 	AllowEnvArgv      bool              `yaml:"allowEnvArgv,omitempty" json:"allowEnvArgv,omitempty"`
+	AllowConfigArgv   bool              `yaml:"allowConfigArgv,omitempty" json:"allowConfigArgv,omitempty"`
 	Output            string            `yaml:"output,omitempty" json:"output,omitempty"`
 	NamePrefix        string            `yaml:"namePrefix,omitempty" json:"namePrefix,omitempty"`
 	RollbackOnFailure bool              `yaml:"rollbackOnFailure,omitempty" json:"rollbackOnFailure,omitempty"`
@@ -5854,10 +5855,12 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 		}
 		if file.External.Lifecycle != nil {
 			cfg.External.Lifecycle = *file.External.Lifecycle
+			cfg.credentialProvenance.externalLifecycle = credentialSource
 		}
 		if file.External.Connection != nil {
 			cfg.External.Connection = *file.External.Connection
 			ssh := cfg.External.Connection.SSH
+			cfg.credentialProvenance.externalConnection = credentialSource
 			cfg.credentialProvenance.externalSSHConnection = credentialSource
 			if trusted {
 				outputContract, outputContractOK := externalProviderOutputContract(cfg.External)
@@ -5911,6 +5914,19 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 				if cfg.credentialProvenance.externalApproved.providerOutput &&
 					outputContractOK && outputContract == cfg.credentialProvenance.externalApproved.outputContract {
 					cfg.credentialProvenance.externalSSHOutput = credentialSourceTrustedFile
+				}
+			}
+		}
+		if trusted && (file.External.Lifecycle != nil || file.External.Connection != nil) {
+			cfg.credentialProvenance.externalArgvApproval = externalLifecycleCredentialApproval{}
+			if externalLifecycleAllowsConfigArgv(cfg.External.Lifecycle) {
+				contract, ok := externalLifecycleContract(cfg.External)
+				if !ok {
+					return exit(2, "external lifecycle config-argv contract must be JSON encodable")
+				}
+				cfg.credentialProvenance.externalArgvApproval = externalLifecycleCredentialApproval{
+					configArgv: true,
+					contract:   contract,
 				}
 			}
 		}

--- a/internal/cli/credential_provenance.go
+++ b/internal/cli/credential_provenance.go
@@ -77,6 +77,8 @@ type credentialDestinationProvenance struct {
 	sshKey                credentialValueSource
 	exeDevControlHost     credentialValueSource
 	externalConfig        credentialValueSource
+	externalLifecycle     credentialValueSource
+	externalConnection    credentialValueSource
 	externalResource      credentialValueSource
 	externalSSHConnection credentialValueSource
 	externalSSHHost       credentialValueSource
@@ -85,6 +87,7 @@ type credentialDestinationProvenance struct {
 	externalSSHOutput     credentialValueSource
 	externalRouting       credentialValueSource
 	externalApproved      externalCredentialApproval
+	externalArgvApproval  externalLifecycleCredentialApproval
 	repositoryRoot        string
 }
 
@@ -96,6 +99,11 @@ type externalCredentialApproval struct {
 	envSSH         ExternalSSHConnectionConfig
 	providerOutput bool
 	outputContract [32]byte
+}
+
+type externalLifecycleCredentialApproval struct {
+	configArgv bool
+	contract   [32]byte
 }
 
 type sourcedCredential struct {
@@ -391,6 +399,26 @@ func validateProviderCredentialDestination(cfg Config) error {
 		if !externalDeclarativeLifecycleConfigured(cfg.External) {
 			break
 		}
+		if externalConfigIsInherited(cfg.External, provenance.externalConfig) {
+			repositoryLifecycle := provenance.externalLifecycle == credentialSourceRepository
+			repositoryResource := provenance.externalResource == credentialSourceRepository
+			repositoryCloudID := provenance.externalConnection == credentialSourceRepository
+			for _, configArgv := range externalLifecycleConfigArgvSurfaces(
+				cfg.External,
+				repositoryLifecycle,
+				repositoryLifecycle || repositoryResource,
+				repositoryLifecycle || repositoryCloudID,
+			) {
+				field := "external.lifecycle." + configArgv.operation + "." + configArgv.surface
+				if !repositoryLifecycle {
+					field = "external.connection template feeding " + field
+				}
+				override := "external.lifecycle." + configArgv.operation + ".allowConfigArgv in the same lifecycle contract in trusted user config"
+				if !configArgv.allowed || !externalLifecycleConfigArgvApproved(cfg.External, provenance.externalArgvApproval) {
+					return repositoryCredentialDestinationError("external", field, override)
+				}
+			}
+		}
 		if cfg.External.Connection.SSH.AllowEnv && provenance.externalSSHAllowEnv == credentialSourceRepository {
 			return repositoryCredentialDestinationError("external", "external.connection.ssh.allowEnv", "the same opt-in in trusted user config")
 		}
@@ -473,6 +501,115 @@ func externalDeclarativeLifecycleConfigured(cfg ExternalConfig) bool {
 	return len(cfg.Lifecycle.Acquire.Argv) > 0 || len(cfg.Lifecycle.Acquire.Steps) > 0
 }
 
+func externalConfigIsInherited(cfg ExternalConfig, source credentialValueSource) bool {
+	if len(cfg.Config) == 0 {
+		return false
+	}
+	if source != credentialSourceUnknown && source != credentialSourceRepository {
+		return true
+	}
+	return cfg.routingLoaded && source == credentialSourceRepository
+}
+
+func externalLifecycleAllowsConfigArgv(cfg ExternalLifecycleConfig) bool {
+	for _, operation := range externalLifecycleOperations(cfg) {
+		if operation.operation.AllowConfigArgv {
+			return true
+		}
+	}
+	return false
+}
+
+func externalLifecycleContract(cfg ExternalConfig) ([32]byte, bool) {
+	contract := struct {
+		Lifecycle    ExternalLifecycleConfig `json:"lifecycle"`
+		ResourceName string                  `json:"resourceName"`
+		CloudID      string                  `json:"cloudId"`
+	}{
+		Lifecycle:    cfg.Lifecycle,
+		ResourceName: cfg.Connection.ResourceName,
+		CloudID:      cfg.Connection.CloudID,
+	}
+	data, err := json.Marshal(contract)
+	if err != nil {
+		return [32]byte{}, false
+	}
+	return sha256.Sum256(data), true
+}
+
+func externalLifecycleConfigArgvApproved(cfg ExternalConfig, approval externalLifecycleCredentialApproval) bool {
+	if !approval.configArgv {
+		return false
+	}
+	contract, ok := externalLifecycleContract(cfg)
+	return ok && contract == approval.contract
+}
+
+type namedExternalLifecycleOperation struct {
+	name      string
+	operation ExternalLifecycleOperation
+}
+
+func externalLifecycleOperations(cfg ExternalLifecycleConfig) []namedExternalLifecycleOperation {
+	return []namedExternalLifecycleOperation{
+		{name: "doctor", operation: cfg.Doctor},
+		{name: "acquire", operation: cfg.Acquire},
+		{name: "resolve", operation: cfg.Resolve},
+		{name: "list", operation: cfg.List},
+		{name: "release", operation: cfg.Release},
+		{name: "touch", operation: cfg.Touch},
+		{name: "cleanup", operation: cfg.Cleanup},
+	}
+}
+
+type externalLifecycleConfigArgvSurface struct {
+	operation string
+	surface   string
+	allowed   bool
+}
+
+func externalLifecycleConfigArgvSurfaces(
+	cfg ExternalConfig,
+	directConfig bool,
+	resourceNameConfig bool,
+	cloudIDConfig bool,
+) []externalLifecycleConfigArgvSurface {
+	resourceNameUsesConfig := resourceNameConfig && strings.Contains(cfg.Connection.ResourceName, "{{config.")
+	cloudIDUsesConfig := cloudIDConfig && strings.Contains(cfg.Connection.CloudID, "{{config.")
+	var surfaces []externalLifecycleConfigArgvSurface
+	for _, named := range externalLifecycleOperations(cfg.Lifecycle) {
+		if externalLifecycleArgsUseConfig(named.operation.Argv, directConfig, resourceNameUsesConfig, cloudIDUsesConfig) {
+			surfaces = append(surfaces, externalLifecycleConfigArgvSurface{
+				operation: named.name,
+				surface:   "argv",
+				allowed:   named.operation.AllowConfigArgv,
+			})
+		}
+		for _, step := range named.operation.Steps {
+			if externalLifecycleArgsUseConfig(step, directConfig, resourceNameUsesConfig, cloudIDUsesConfig) {
+				surfaces = append(surfaces, externalLifecycleConfigArgvSurface{
+					operation: named.name,
+					surface:   "steps",
+					allowed:   named.operation.AllowConfigArgv,
+				})
+				break
+			}
+		}
+	}
+	return surfaces
+}
+
+func externalLifecycleArgsUseConfig(argv []string, directConfig, resourceNameUsesConfig, cloudIDUsesConfig bool) bool {
+	for _, value := range argv {
+		if directConfig && strings.Contains(value, "{{config.") ||
+			resourceNameUsesConfig && strings.Contains(value, "{{resourceName}}") ||
+			cloudIDUsesConfig && strings.Contains(value, "{{cloudId}}") {
+			return true
+		}
+	}
+	return false
+}
+
 // MarkExternalRoutingCredentialSources applies the routing file's trust source
 // to connection values after the External provider loads that private state.
 // An unknown source is reserved for claim-bound automatic routing.
@@ -484,6 +621,8 @@ func MarkExternalRoutingCredentialSources(cfg *Config) {
 	connection := cfg.External.Connection
 	provenance := &cfg.credentialProvenance
 	provenance.externalConfig = source
+	provenance.externalLifecycle = source
+	provenance.externalConnection = source
 	provenance.externalResource = credentialDestinationSource(connection.ResourceName, provenance.externalApproved.resource, source)
 	provenance.externalSSHConnection = source
 	provenance.externalSSHHost = credentialDestinationSource(connection.SSH.Host, provenance.externalApproved.host, source)

--- a/internal/cli/credential_provenance_test.go
+++ b/internal/cli/credential_provenance_test.go
@@ -1119,6 +1119,71 @@ func TestExternalRoutingLoaderPreservesConfiguredSource(t *testing.T) {
 	}
 }
 
+func TestExternalRoutingCredentialVersionProtectsConfigArgv(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	lifecycle := ExternalLifecycleConfig{
+		Acquire: ExternalLifecycleOperation{
+			Argv:            []string{"adapter", "create", "{{config.region}}"},
+			AllowConfigArgv: true,
+		},
+	}
+	external := ExternalConfig{
+		Config:    map[string]any{"region": "test-region"},
+		Lifecycle: lifecycle,
+	}
+	legacyPath, err := persistExternalRouting("cbx_abcdef123456", external, externalRoutingCredentialVersion-1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	legacyClaim := Config{Provider: "external"}
+	if err := loadExternalRoutingConfig(&legacyClaim, legacyPath, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateProviderCredentialDestination(legacyClaim); err == nil || !strings.Contains(err.Error(), "allowConfigArgv") {
+		t.Fatalf("legacy routing config argv error=%v", err)
+	}
+
+	approvedLegacy := Config{Provider: "external"}
+	if err := applyFileConfigWithTrust(&approvedLegacy, fileConfig{External: &fileExternalConfig{
+		Config:    external.Config,
+		Lifecycle: &lifecycle,
+	}}, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := loadExternalRoutingConfig(&approvedLegacy, legacyPath, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateProviderCredentialDestination(approvedLegacy); err != nil {
+		t.Fatalf("legacy routing with exact current approval rejected: %v", err)
+	}
+
+	validatedPath, err := PersistValidatedExternalRouting("cbx_abcdef123457", external)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repositorySelected := Config{
+		Provider: "external",
+		credentialProvenance: credentialDestinationProvenance{
+			externalRouting: credentialSourceRepository,
+		},
+	}
+	if err := loadExternalRoutingConfig(&repositorySelected, validatedPath, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateProviderCredentialDestination(repositorySelected); err == nil || !strings.Contains(err.Error(), "allowConfigArgv") {
+		t.Fatalf("repository-selected current routing config argv error=%v", err)
+	}
+
+	validatedClaim := Config{Provider: "external"}
+	if err := loadExternalRoutingConfig(&validatedClaim, validatedPath, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateProviderCredentialDestination(validatedClaim); err != nil {
+		t.Fatalf("current validated routing state rejected: %v", err)
+	}
+}
+
 func TestExternalRoutingAllowEnvApprovalBindsResourceName(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	approved := ExternalConnectionConfig{
@@ -1150,6 +1215,292 @@ func TestExternalRoutingAllowEnvApprovalBindsResourceName(t *testing.T) {
 	if err := validateProviderCredentialDestination(cfg); err == nil || !strings.Contains(err.Error(), "ssh.allowEnv") {
 		t.Fatalf("repository routing resource-name change error=%v", err)
 	}
+}
+
+func TestExternalLifecycleConfigArgvApproval(t *testing.T) {
+	trustedConfig := fileExternalConfig{Config: map[string]any{"token": "trusted-token"}}
+	applyTrustedConfig := func(t *testing.T, cfg *Config) {
+		t.Helper()
+		if err := applyFileConfigWithTrust(cfg, fileConfig{External: &trustedConfig}, true); err != nil {
+			t.Fatal(err)
+		}
+	}
+	applyRepositoryLifecycle := func(t *testing.T, cfg *Config, lifecycle ExternalLifecycleConfig, connection *ExternalConnectionConfig) {
+		t.Helper()
+		if err := applyFileConfigWithTrust(cfg, fileConfig{External: &fileExternalConfig{
+			Lifecycle:  &lifecycle,
+			Connection: connection,
+		}}, false); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Run("rejects inherited config in repository argv", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Provider = "external"
+		applyTrustedConfig(t, &cfg)
+		applyRepositoryLifecycle(t, &cfg, ExternalLifecycleConfig{
+			Acquire: ExternalLifecycleOperation{Argv: []string{"adapter", "--token", "{{config.token}}"}},
+		}, nil)
+
+		err := validateProviderCredentialDestination(cfg)
+		if err == nil || !strings.Contains(err.Error(), "external.lifecycle.acquire.argv") {
+			t.Fatalf("error=%v", err)
+		}
+		if strings.Contains(err.Error(), "trusted-token") {
+			t.Fatalf("error exposed config value: %v", err)
+		}
+	})
+
+	t.Run("rejects inherited config in repository steps", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Provider = "external"
+		applyTrustedConfig(t, &cfg)
+		applyRepositoryLifecycle(t, &cfg, ExternalLifecycleConfig{
+			Acquire: ExternalLifecycleOperation{Steps: [][]string{{"adapter", "prepare"}, {"adapter", "use", "{{config.token}}"}}},
+		}, nil)
+
+		err := validateProviderCredentialDestination(cfg)
+		if err == nil || !strings.Contains(err.Error(), "external.lifecycle.acquire.steps") {
+			t.Fatalf("error=%v", err)
+		}
+	})
+
+	t.Run("rejects inherited config through repository resource name", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Provider = "external"
+		applyTrustedConfig(t, &cfg)
+		connection := &ExternalConnectionConfig{ResourceName: "{{config.token}}"}
+		applyRepositoryLifecycle(t, &cfg, ExternalLifecycleConfig{
+			Acquire: ExternalLifecycleOperation{Argv: []string{"adapter", "create", "{{resourceName}}"}},
+		}, connection)
+
+		err := validateProviderCredentialDestination(cfg)
+		if err == nil || !strings.Contains(err.Error(), "external.lifecycle.acquire.argv") {
+			t.Fatalf("error=%v", err)
+		}
+	})
+
+	t.Run("rejects repository resource template feeding trusted lifecycle", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Provider = "external"
+		lifecycle := ExternalLifecycleConfig{
+			Acquire: ExternalLifecycleOperation{Argv: []string{"adapter", "create", "{{resourceName}}"}},
+		}
+		if err := applyFileConfigWithTrust(&cfg, fileConfig{External: &fileExternalConfig{
+			Config:    map[string]any{"token": "trusted-token"},
+			Lifecycle: &lifecycle,
+		}}, true); err != nil {
+			t.Fatal(err)
+		}
+		connection := ExternalConnectionConfig{ResourceName: "{{config.token}}"}
+		if err := applyFileConfigWithTrust(&cfg, fileConfig{External: &fileExternalConfig{Connection: &connection}}, false); err != nil {
+			t.Fatal(err)
+		}
+
+		err := validateProviderCredentialDestination(cfg)
+		if err == nil || !strings.Contains(err.Error(), "external.connection template feeding external.lifecycle.acquire.argv") {
+			t.Fatalf("error=%v", err)
+		}
+	})
+
+	t.Run("rejects repository cloud id template feeding trusted lifecycle", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Provider = "external"
+		lifecycle := ExternalLifecycleConfig{
+			Acquire: ExternalLifecycleOperation{Argv: []string{"adapter", "create"}},
+			Release: ExternalLifecycleOperation{Argv: []string{"adapter", "release", "{{cloudId}}"}},
+		}
+		if err := applyFileConfigWithTrust(&cfg, fileConfig{External: &fileExternalConfig{
+			Config:    map[string]any{"token": "trusted-token"},
+			Lifecycle: &lifecycle,
+		}}, true); err != nil {
+			t.Fatal(err)
+		}
+		connection := ExternalConnectionConfig{CloudID: "{{config.token}}"}
+		if err := applyFileConfigWithTrust(&cfg, fileConfig{External: &fileExternalConfig{Connection: &connection}}, false); err != nil {
+			t.Fatal(err)
+		}
+
+		err := validateProviderCredentialDestination(cfg)
+		if err == nil || !strings.Contains(err.Error(), "external.connection template feeding external.lifecycle.release.argv") {
+			t.Fatalf("error=%v", err)
+		}
+	})
+
+	t.Run("allows repository-owned config", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Provider = "external"
+		lifecycle := ExternalLifecycleConfig{
+			Acquire: ExternalLifecycleOperation{Argv: []string{"adapter", "--region", "{{config.region}}"}},
+		}
+		if err := applyFileConfigWithTrust(&cfg, fileConfig{External: &fileExternalConfig{
+			Config:    map[string]any{"region": "test-region"},
+			Lifecycle: &lifecycle,
+		}}, false); err != nil {
+			t.Fatal(err)
+		}
+		if err := validateProviderCredentialDestination(cfg); err != nil {
+			t.Fatalf("repository-owned config rejected: %v", err)
+		}
+	})
+
+	t.Run("allows trusted lifecycle", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Provider = "external"
+		lifecycle := ExternalLifecycleConfig{
+			Acquire: ExternalLifecycleOperation{Argv: []string{"adapter", "--region", "{{config.region}}"}},
+		}
+		if err := applyFileConfigWithTrust(&cfg, fileConfig{External: &fileExternalConfig{
+			Config:    map[string]any{"region": "test-region"},
+			Lifecycle: &lifecycle,
+		}}, true); err != nil {
+			t.Fatal(err)
+		}
+		if err := validateProviderCredentialDestination(cfg); err != nil {
+			t.Fatalf("trusted lifecycle rejected: %v", err)
+		}
+	})
+
+	t.Run("allows exact trusted non-secret contract", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Provider = "external"
+		lifecycle := ExternalLifecycleConfig{
+			Acquire: ExternalLifecycleOperation{
+				Argv:            []string{"adapter", "--region", "{{config.region}}"},
+				AllowConfigArgv: true,
+			},
+		}
+		if err := applyFileConfigWithTrust(&cfg, fileConfig{External: &fileExternalConfig{
+			Config:    map[string]any{"region": "test-region"},
+			Lifecycle: &lifecycle,
+		}}, true); err != nil {
+			t.Fatal(err)
+		}
+		applyRepositoryLifecycle(t, &cfg, lifecycle, nil)
+		if err := validateProviderCredentialDestination(cfg); err != nil {
+			t.Fatalf("exact trusted lifecycle contract rejected: %v", err)
+		}
+	})
+
+	t.Run("repository cannot self approve", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Provider = "external"
+		applyTrustedConfig(t, &cfg)
+		applyRepositoryLifecycle(t, &cfg, ExternalLifecycleConfig{
+			Acquire: ExternalLifecycleOperation{
+				Argv:            []string{"adapter", "{{config.token}}"},
+				AllowConfigArgv: true,
+			},
+		}, nil)
+
+		err := validateProviderCredentialDestination(cfg)
+		if err == nil || !strings.Contains(err.Error(), "same lifecycle contract in trusted user config") {
+			t.Fatalf("error=%v", err)
+		}
+	})
+
+	t.Run("trusted approval binds connection templates", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Provider = "external"
+		lifecycle := ExternalLifecycleConfig{
+			Acquire: ExternalLifecycleOperation{
+				Argv:            []string{"adapter", "create", "{{resourceName}}"},
+				AllowConfigArgv: true,
+			},
+		}
+		trustedConnection := ExternalConnectionConfig{ResourceName: "{{config.region}}"}
+		if err := applyFileConfigWithTrust(&cfg, fileConfig{External: &fileExternalConfig{
+			Config:     map[string]any{"region": "test-region", "token": "trusted-token"},
+			Lifecycle:  &lifecycle,
+			Connection: &trustedConnection,
+		}}, true); err != nil {
+			t.Fatal(err)
+		}
+		repositoryConnection := ExternalConnectionConfig{ResourceName: "{{config.token}}"}
+		applyRepositoryLifecycle(t, &cfg, lifecycle, &repositoryConnection)
+
+		if err := validateProviderCredentialDestination(cfg); err == nil {
+			t.Fatal("mutated connection template inherited trusted config")
+		}
+	})
+
+	t.Run("trusted approval is exact and operation bound", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Provider = "external"
+		trusted := ExternalLifecycleConfig{
+			Acquire: ExternalLifecycleOperation{
+				Argv:            []string{"approved-adapter", "{{config.token}}"},
+				AllowConfigArgv: true,
+			},
+		}
+		if err := applyFileConfigWithTrust(&cfg, fileConfig{External: &fileExternalConfig{
+			Config:    map[string]any{"token": "trusted-token"},
+			Lifecycle: &trusted,
+		}}, true); err != nil {
+			t.Fatal(err)
+		}
+
+		changed := trusted
+		changed.Acquire.Argv = []string{"repository-adapter", "{{config.token}}"}
+		applyRepositoryLifecycle(t, &cfg, changed, nil)
+		if err := validateProviderCredentialDestination(cfg); err == nil {
+			t.Fatal("mutated lifecycle inherited trusted config")
+		}
+
+		wrongOperation := ExternalLifecycleConfig{
+			Acquire: ExternalLifecycleOperation{Argv: []string{"approved-adapter", "{{config.token}}"}},
+			Release: ExternalLifecycleOperation{Argv: []string{"approved-adapter", "release"}, AllowConfigArgv: true},
+		}
+		if err := applyFileConfigWithTrust(&cfg, fileConfig{External: &fileExternalConfig{Lifecycle: &wrongOperation}}, true); err != nil {
+			t.Fatal(err)
+		}
+		applyRepositoryLifecycle(t, &cfg, wrongOperation, nil)
+		if err := validateProviderCredentialDestination(cfg); err == nil {
+			t.Fatal("approval on another operation authorized config argv")
+		}
+	})
+
+	t.Run("checks every config argv operation", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Provider = "external"
+		lifecycle := ExternalLifecycleConfig{
+			Acquire: ExternalLifecycleOperation{
+				Argv:            []string{"adapter", "create", "{{config.region}}"},
+				AllowConfigArgv: true,
+			},
+			Release: ExternalLifecycleOperation{
+				Argv: []string{"adapter", "release", "{{config.token}}"},
+			},
+		}
+		if err := applyFileConfigWithTrust(&cfg, fileConfig{External: &fileExternalConfig{
+			Config:    map[string]any{"region": "test-region", "token": "trusted-token"},
+			Lifecycle: &lifecycle,
+		}}, true); err != nil {
+			t.Fatal(err)
+		}
+		applyRepositoryLifecycle(t, &cfg, lifecycle, nil)
+
+		err := validateProviderCredentialDestination(cfg)
+		if err == nil || !strings.Contains(err.Error(), "external.lifecycle.release.argv") {
+			t.Fatalf("error=%v", err)
+		}
+	})
+
+	t.Run("allows inherited config in lifecycle env", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Provider = "external"
+		applyTrustedConfig(t, &cfg)
+		applyRepositoryLifecycle(t, &cfg, ExternalLifecycleConfig{
+			Acquire: ExternalLifecycleOperation{
+				Argv: []string{"adapter", "create"},
+				Env:  map[string]string{"ADAPTER_TOKEN": "{{config.token}}"},
+			},
+		}, nil)
+		if err := validateProviderCredentialDestination(cfg); err != nil {
+			t.Fatalf("lifecycle env rejected: %v", err)
+		}
+	})
 }
 
 func TestRepositorySSHDestinationsRejectExternalSameSourceKeyPaths(t *testing.T) {

--- a/internal/cli/external_routing.go
+++ b/internal/cli/external_routing.go
@@ -28,7 +28,7 @@ type externalRoutingState struct {
 	CredentialBoundaryVersion int                        `json:"credentialBoundaryVersion,omitempty"`
 }
 
-const externalRoutingCredentialVersion = 1
+const externalRoutingCredentialVersion = 2
 
 func externalRoutingStateForConfig(cfg ExternalConfig, credentialVersion int) externalRoutingState {
 	return externalRoutingState{


### PR DESCRIPTION
## Summary

- track the trust source of External lifecycle and connection templates
- reject inherited `external.config` values in repository-selected argv/steps, including indirect `resourceName` and `cloudId` flows
- add an operation-scoped `allowConfigArgv` opt-in that requires an exact trusted lifecycle and connection-template contract
- advance persisted routing credential-boundary validation so legacy and repository-selected routes cannot bypass the new rule
- document the safe environment channel and compatibility contract

Closes https://github.com/openclaw/crabbox/issues/950

## Verification

- `gofmt -w $(git ls-files '*.go')`
- `git diff --check`
- `go vet ./...`
- `go test -race ./...`
- `go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker`
- `npm run build --prefix worker`
- `node scripts/build-docs-site.mjs`
- AutoReview clean after fixing three accepted routing/approval findings

## Live CLI proof

Built the exact candidate and exercised real layered user/repository configuration through `crabbox list`:

- inherited user-config value plus repository lifecycle argv: rejected before the helper ran
- exact trusted lifecycle/connection contract with `allowConfigArgv`: allowed and passed the non-secret sentinel to the helper
- repository-owned `external.config` plus repository lifecycle: allowed unchanged

The canary used local non-secret sentinels and created no remote resource or persistent credential.
