### PR TITLE
fix(security): bind GCP deletion to exact claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Required direct GCP release and cleanup to hold an unchanged project-, zone-, name-, numeric-instance-, lease-, slug-, and provider-key-bound local claim across deletion. Thanks @coygeek.
 - Prevented repository-defined External lifecycle commands from placing inherited `external.config` values on process arguments without an exact, trusted non-secret argv contract. Thanks @coygeek.
 - Prevented repository-controlled External SSH endpoint templates and adapter output from silently using ambient or operator-managed SSH credentials, with source-bound opt-ins for environment-derived fields and provider-returned destinations. Thanks @coygeek.
 - Made Sealos DevBox preflight work with tenant-scoped RBAC, rendered the runtime class, storage request, scheduling constraints, and SSH port contract required by hosted Sealos clusters, updated the SSHGate default to port 2233, bootstrapped missing sync tools, and cleaned local claims safely when a DevBox is already absent. Thanks @coygeek.

--- a/docs/providers/gcp.md
+++ b/docs/providers/gcp.md
@@ -295,6 +295,14 @@ ttl_secs=<seconds>
 zone=<gcp_zone>
 ```
 
+Crabbox also records the immutable numeric Compute Engine instance ID in the
+local lease claim. Direct release and cleanup require that unchanged claim to
+match the exact project, zone, instance name and numeric ID, lease, slug, and
+provider key before deletion. Labels and deterministic names remain discovery
+hints, not destructive authority. Claimless or stale-claim resources are
+skipped; recover or remove them through an explicit operator-controlled GCP
+workflow instead of silently adopting cloud metadata.
+
 Direct cleanup:
 
 ```sh
@@ -324,7 +332,8 @@ duplicate exact-name matches fail as ambiguous. These checks are
 defense-in-depth against accidental or ambiguous resource adoption. GCP labels
 are operator metadata, not an authorization boundary against another principal
 that can already mutate instances in the same project. Brokered cleanup is
-coordinator-owned; direct cleanup is best-effort label cleanup.
+coordinator-owned; direct cleanup additionally requires the exact local claim
+described above.
 
 Three independent safety nets enforce expiry:
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -324,8 +324,10 @@ claim or explicit `stop --reclaim` adoption of the currently inspected
 deployment; a successful stop removes that one-deployment claim.
 Direct Hetzner release and cleanup similarly require canonical provider labels
 plus an unchanged local claim whose lease and cloud ID match the exact server.
-Cleanup skips weakly labeled, unclaimed, and stale-claim servers instead of
-turning provider inventory into ownership proof.
+Direct GCP release and cleanup require an unchanged local claim bound to the
+project, zone, instance name and immutable numeric ID, lease, slug, and provider
+key. Cleanup skips weakly labeled, unclaimed, and stale-claim servers instead
+of turning provider inventory into ownership proof.
 
 Artifact publishing rejects symlinks, directories at reserved generated-output
 paths, and other non-regular bundle entries before upload side effects. Required

--- a/internal/cli/claim.go
+++ b/internal/cli/claim.go
@@ -16,10 +16,12 @@ import (
 )
 
 type leaseClaim struct {
-	LeaseID                             string            `json:"leaseID"`
-	Slug                                string            `json:"slug,omitempty"`
-	Provider                            string            `json:"provider,omitempty"`
-	CloudID                             string            `json:"cloudID,omitempty"`
+	LeaseID  string `json:"leaseID"`
+	Slug     string `json:"slug,omitempty"`
+	Provider string `json:"provider,omitempty"`
+	CloudID  string `json:"cloudID,omitempty"`
+	// CloudNumericID binds providers whose CloudID is a reusable resource name.
+	CloudNumericID                      int64             `json:"cloudNumericID,omitempty"`
 	ProviderScope                       string            `json:"providerScope,omitempty"`
 	StaticHost                          string            `json:"staticHost,omitempty"`
 	StaticUser                          string            `json:"staticUser,omitempty"`
@@ -542,6 +544,9 @@ func endpointClaimGuard(leaseID string, next func(leaseClaim, bool) error) func(
 func applyLeaseClaimEndpoint(claim *leaseClaim, server Server, target SSHTarget) {
 	if server.CloudID != "" {
 		claim.CloudID = server.CloudID
+	}
+	if server.ID != 0 {
+		claim.CloudNumericID = server.ID
 	}
 	if len(server.Labels) > 0 {
 		claim.Labels = cloneStringMap(server.Labels)

--- a/internal/cli/claim_test.go
+++ b/internal/cli/claim_test.go
@@ -146,6 +146,7 @@ func TestClaimLeaseTargetForConfigStoresUnattachedProviderResource(t *testing.T)
 	server := Server{
 		Provider: "aws",
 		CloudID:  "i-1750645",
+		ID:       42,
 		Labels: map[string]string{
 			"provider": "aws",
 			"slug":     "warm",
@@ -159,7 +160,7 @@ func TestClaimLeaseTargetForConfigStoresUnattachedProviderResource(t *testing.T)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if claim.Provider != "aws" || claim.CloudID != "i-1750645" || claim.RepoRoot != "" {
+	if claim.Provider != "aws" || claim.CloudID != "i-1750645" || claim.CloudNumericID != 42 || claim.RepoRoot != "" {
 		t.Fatalf("unexpected unattached provider claim: %#v", claim)
 	}
 

--- a/internal/providers/gcp/backend.go
+++ b/internal/providers/gcp/backend.go
@@ -191,15 +191,16 @@ func (b *gcpLeaseBackend) Doctor(ctx context.Context, _ core.DoctorRequest) (cor
 }
 
 func (b *gcpLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
+	claim, err := requireExactGCPClaim(req.Lease.Server, req.Lease.LeaseID, b.Cfg)
+	if err != nil {
+		return err
+	}
 	client, err := newGCPClient(ctx, b.Cfg)
 	if err != nil {
 		return err
 	}
 	cloudID := strings.TrimSpace(req.Lease.Server.CloudID)
-	if cloudID == "" {
-		return exit(4, "refusing to delete gcp lease=%s: missing cloud id", req.Lease.LeaseID)
-	}
-	if zone := req.Lease.Server.Labels["zone"]; zone != "" {
+	if zone := strings.TrimSpace(claim.Labels["zone"]); zone != "" {
 		cfg := b.Cfg
 		cfg.GCPZone = zone
 		client, err = newGCPClient(ctx, cfg)
@@ -210,8 +211,7 @@ func (b *gcpLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequ
 	live, err := client.GetServer(ctx, cloudID)
 	if err != nil {
 		if core.IsGCPNotFound(err) {
-			removeLeaseClaim(req.Lease.LeaseID)
-			return nil
+			return core.RemoveLeaseClaimIfUnchanged(req.Lease.LeaseID, claim)
 		}
 		return err
 	}
@@ -224,11 +224,10 @@ func (b *gcpLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequ
 	if liveLeaseID := strings.TrimSpace(live.Labels["lease"]); liveLeaseID != req.Lease.LeaseID {
 		return exit(4, "refusing to delete gcp instance %q for lease=%s: live instance belongs to lease=%s", cloudID, req.Lease.LeaseID, blank(liveLeaseID, "-"))
 	}
-	if err := client.DeleteServer(ctx, cloudID); err != nil {
+	if err := validateExactGCPClaim(claim, live, req.Lease.LeaseID, b.Cfg); err != nil {
 		return err
 	}
-	removeLeaseClaim(req.Lease.LeaseID)
-	return nil
+	return deleteClaimedGCPServer(ctx, client, live, claim)
 }
 
 func (b *gcpLeaseBackend) ReleaseLeaseMessage(lease LeaseTarget) string {
@@ -285,12 +284,13 @@ func (b *gcpLeaseBackend) Cleanup(ctx context.Context, req CleanupRequest) error
 			fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=%s\n", server.DisplayID(), server.Name, reason)
 			continue
 		}
-		if req.DryRun {
-			fmt.Fprintf(b.RT.Stderr, "delete server id=%s name=%s\n", server.DisplayID(), server.Name)
+		claim, claimErr := requireExactGCPClaim(server, server.Labels["lease"], b.Cfg)
+		if claimErr != nil {
+			fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=exact local claim missing or stale\n", server.DisplayID(), server.Name)
 			continue
 		}
 		cfg := b.Cfg
-		if zone := server.Labels["zone"]; zone != "" {
+		if zone := strings.TrimSpace(claim.Labels["zone"]); zone != "" {
 			cfg.GCPZone = zone
 		}
 		client, err := newGCPClient(ctx, cfg)
@@ -301,8 +301,8 @@ func (b *gcpLeaseBackend) Cleanup(ctx context.Context, req CleanupRequest) error
 		if err != nil {
 			if core.IsGCPNotFound(err) {
 				fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=live instance no longer exists\n", server.DisplayID(), server.Name)
-				if leaseID := strings.TrimSpace(server.Labels["lease"]); leaseID != "" {
-					removeLeaseClaim(leaseID)
+				if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
+					return err
 				}
 				continue
 			}
@@ -312,22 +312,75 @@ func (b *gcpLeaseBackend) Cleanup(ctx context.Context, req CleanupRequest) error
 			fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=%v\n", server.DisplayID(), server.Name, err)
 			continue
 		}
+		if err := validateExactGCPClaim(claim, live, server.Labels["lease"], b.Cfg); err != nil {
+			fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=exact local claim missing or stale\n", server.DisplayID(), server.Name)
+			continue
+		}
 		if shouldDelete, reason := core.ShouldCleanupServer(live, now); !shouldDelete {
 			fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=live instance %s\n", server.DisplayID(), server.Name, reason)
 			continue
 		}
 		fmt.Fprintf(b.RT.Stderr, "delete server id=%s name=%s\n", live.DisplayID(), live.Name)
-		if err := client.DeleteServer(ctx, live.CloudID); err != nil {
-			return err
+		if req.DryRun {
+			continue
 		}
-		if leaseID := strings.TrimSpace(server.Labels["lease"]); leaseID != "" {
-			removeLeaseClaim(leaseID)
+		if err := deleteClaimedGCPServer(ctx, client, live, claim); err != nil {
+			return err
 		}
 	}
 	if err := b.pruneStaleClaims(ctx, liveLeaseIDs, req.DryRun); err != nil {
 		return err
 	}
 	return nil
+}
+
+func requireExactGCPClaim(server Server, expectedLeaseID string, cfg Config) (core.LeaseClaim, error) {
+	claim, exists, err := core.ReadLeaseClaimWithPresence(expectedLeaseID)
+	if err != nil {
+		return core.LeaseClaim{}, err
+	}
+	if !exists {
+		return core.LeaseClaim{}, exit(2, "gcp lease=%s has no exact local claim; refusing destructive operation", expectedLeaseID)
+	}
+	if err := validateExactGCPClaim(claim, server, expectedLeaseID, cfg); err != nil {
+		return core.LeaseClaim{}, err
+	}
+	return claim, nil
+}
+
+func validateExactGCPClaim(claim core.LeaseClaim, server Server, expectedLeaseID string, cfg Config) error {
+	providerScope := gcpClaimScope(cfg)
+	serverSlug := strings.TrimSpace(server.Labels["slug"])
+	serverZone := strings.TrimSpace(server.Labels["zone"])
+	serverProviderKey := strings.TrimSpace(server.Labels["provider_key"])
+	if providerScope == "" ||
+		!isCrabboxGCPLease(server) ||
+		claim.LeaseID != expectedLeaseID ||
+		claim.Provider != "gcp" ||
+		claim.ProviderScope != providerScope ||
+		claim.CloudID == "" ||
+		claim.CloudID != strings.TrimSpace(server.CloudID) ||
+		claim.CloudNumericID == 0 ||
+		claim.CloudNumericID != server.ID ||
+		claim.Slug == "" ||
+		claim.Slug != serverSlug ||
+		server.Labels["lease"] != expectedLeaseID ||
+		serverZone == "" ||
+		strings.TrimSpace(claim.Labels["zone"]) != serverZone ||
+		strings.TrimSpace(claim.Labels["lease"]) != expectedLeaseID ||
+		strings.TrimSpace(claim.Labels["slug"]) != serverSlug ||
+		strings.TrimSpace(claim.Labels["provider"]) != "gcp" ||
+		serverProviderKey == "" ||
+		strings.TrimSpace(claim.Labels["provider_key"]) != serverProviderKey {
+		return exit(2, "refusing to operate on GCP instance %s from a missing or stale exact local claim", server.DisplayID())
+	}
+	return nil
+}
+
+func deleteClaimedGCPServer(ctx context.Context, client gcpClient, server Server, claim core.LeaseClaim) error {
+	return core.RemoveLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, func() error {
+		return client.DeleteServer(ctx, server.CloudID)
+	})
 }
 
 func validateGCPCleanupLiveServer(expected, live Server) error {

--- a/internal/providers/gcp/backend_doctor_test.go
+++ b/internal/providers/gcp/backend_doctor_test.go
@@ -91,13 +91,79 @@ func canonicalGCPTestServer(leaseID, slug string) Server {
 		ID:       42,
 		Name:     name,
 		Labels: map[string]string{
-			"crabbox":    "true",
-			"created_by": "crabbox",
-			"provider":   "gcp",
-			"lease":      leaseID,
-			"slug":       slug,
-			"zone":       "us-central1-b",
+			"crabbox":      "true",
+			"created_by":   "crabbox",
+			"provider":     "gcp",
+			"provider_key": "crabbox-test",
+			"lease":        leaseID,
+			"slug":         slug,
+			"zone":         "us-central1-b",
 		},
+	}
+}
+
+func claimGCPTestServer(t *testing.T, cfg Config, server Server) {
+	t.Helper()
+	if err := core.ClaimLeaseTargetForConfig(server.Labels["lease"], server.Labels["slug"], cfg, server, core.SSHTarget{}, time.Minute); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidateExactGCPClaimBindsProviderResourceAndLease(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	cfg := Config{Provider: "gcp", GCPProject: "project-a", GCPZone: "us-central1-b"}
+	server := canonicalGCPTestServer("cbx_111111111111", "owned")
+	claimGCPTestServer(t, cfg, server)
+	claim, err := core.ReadLeaseClaim(server.Labels["lease"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validateExactGCPClaim(claim, server, server.Labels["lease"], cfg); err != nil {
+		t.Fatalf("valid exact claim rejected: %v", err)
+	}
+
+	tests := map[string]func(*core.LeaseClaim, *Server, *Config){
+		"project scope": func(_ *core.LeaseClaim, _ *Server, cfg *Config) { cfg.GCPProject = "project-b" },
+		"cloud name":    func(_ *core.LeaseClaim, server *Server, _ *Config) { server.CloudID += "-other" },
+		"numeric id":    func(_ *core.LeaseClaim, server *Server, _ *Config) { server.ID++ },
+		"slug": func(_ *core.LeaseClaim, server *Server, _ *Config) {
+			server.Labels["slug"] = "other"
+			server.Name = core.LeaseProviderName(server.Labels["lease"], "other")
+		},
+		"zone":         func(_ *core.LeaseClaim, server *Server, _ *Config) { server.Labels["zone"] = "us-central1-c" },
+		"provider key": func(_ *core.LeaseClaim, server *Server, _ *Config) { server.Labels["provider_key"] = "crabbox-other" },
+		"claim labels": func(claim *core.LeaseClaim, _ *Server, _ *Config) { delete(claim.Labels, "zone") },
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			changedClaim := claim
+			changedClaim.Labels = maps.Clone(claim.Labels)
+			changedServer := server
+			changedServer.Labels = maps.Clone(server.Labels)
+			changedCfg := cfg
+			mutate(&changedClaim, &changedServer, &changedCfg)
+			if err := validateExactGCPClaim(changedClaim, changedServer, server.Labels["lease"], changedCfg); err == nil {
+				t.Fatal("mismatched claim was accepted")
+			}
+		})
+	}
+}
+
+func TestGCPReleaseLeaseRejectsMissingExactClaimBeforeDelete(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	server := canonicalGCPTestServer("cbx_222222222222", "claimless")
+	fake := &fakeGCPDoctorClient{get: map[string]Server{server.CloudID: server}}
+	old := newGCPClient
+	newGCPClient = func(context.Context, Config) (gcpClient, error) { return fake, nil }
+	t.Cleanup(func() { newGCPClient = old })
+
+	backend := NewGCPLeaseBackend(core.ProviderSpec{}, Config{Provider: "gcp", GCPProject: "project-a", GCPZone: "us-central1-b"}, Runtime{Stderr: io.Discard}).(*gcpLeaseBackend)
+	err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: server.Labels["lease"], Server: server}})
+	if err == nil || !strings.Contains(err.Error(), "no exact local claim") {
+		t.Fatalf("ReleaseLease() error=%v, want missing-claim refusal", err)
+	}
+	if len(fake.deleted) != 0 {
+		t.Fatalf("deleted=%v, want no destructive call", fake.deleted)
 	}
 }
 
@@ -173,9 +239,6 @@ func TestGCPCleanupRemovesDeletedAndStaleClaims(t *testing.T) {
 	expiredLeaseID := "cbx_111111111111"
 	staleLeaseID := "cbx_222222222222"
 	otherProjectLeaseID := "cbx_333333333333"
-	if err := core.ClaimLeaseForRepoProviderScope(expiredLeaseID, "expired-box", "gcp", "project:project-a", repo, time.Minute, false); err != nil {
-		t.Fatal(err)
-	}
 	if err := core.ClaimLeaseForRepoProviderScope(staleLeaseID, "stale-box", "gcp", "project:project-a", repo, time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
@@ -188,10 +251,11 @@ func TestGCPCleanupRemovesDeletedAndStaleClaims(t *testing.T) {
 		ID:      42,
 		Labels: map[string]string{
 			"crabbox": "true", "created_by": "crabbox", "provider": "gcp",
-			"lease": expiredLeaseID, "slug": "expired-box",
+			"provider_key": "crabbox-test", "lease": expiredLeaseID, "slug": "expired-box", "zone": "us-central1-b",
 			"state": "ready", "expires_at": core.LeaseLabelTime(time.Now().Add(-time.Hour)),
 		},
 	}
+	claimGCPTestServer(t, Config{Provider: "gcp", GCPProject: "project-a", GCPZone: "us-central1-b"}, expired)
 	fake := &fakeGCPDoctorClient{
 		servers: []Server{expired,
 			{
@@ -218,6 +282,16 @@ func TestGCPCleanupRemovesDeletedAndStaleClaims(t *testing.T) {
 	if !ok {
 		t.Fatal("gcp backend missing cleanup")
 	}
+	if err := cleaner.Cleanup(context.Background(), core.CleanupRequest{DryRun: true}); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.deleted) != 0 {
+		t.Fatalf("dry-run deleted=%v, want no mutation", fake.deleted)
+	}
+	if claim, err := core.ReadLeaseClaim(expiredLeaseID); err != nil || claim.LeaseID == "" {
+		t.Fatalf("dry-run exact claim=%+v err=%v, want retained claim", claim, err)
+	}
+	stderr.Reset()
 	if err := cleaner.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
@@ -248,8 +322,11 @@ func TestGCPCleanupRemovesDeletedAndStaleClaims(t *testing.T) {
 }
 
 func TestGCPCleanupRevalidatesLiveOwnershipBeforeDelete(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	snapshot := canonicalGCPTestServer("cbx_111111111111", "stale")
 	snapshot.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
+	cfg := Config{Provider: "gcp", GCPProject: "project-a", GCPZone: snapshot.Labels["zone"]}
+	claimGCPTestServer(t, cfg, snapshot)
 	live := snapshot
 	live.Labels = maps.Clone(snapshot.Labels)
 	delete(live.Labels, "created_by")
@@ -263,7 +340,7 @@ func TestGCPCleanupRevalidatesLiveOwnershipBeforeDelete(t *testing.T) {
 	t.Cleanup(func() { newGCPClient = old })
 
 	var stderr bytes.Buffer
-	backend := NewGCPLeaseBackend(core.ProviderSpec{}, Config{Provider: "gcp", GCPProject: "project-a"}, Runtime{Stderr: &stderr}).(*gcpLeaseBackend)
+	backend := NewGCPLeaseBackend(core.ProviderSpec{}, cfg, Runtime{Stderr: &stderr}).(*gcpLeaseBackend)
 	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
@@ -272,6 +349,36 @@ func TestGCPCleanupRevalidatesLiveOwnershipBeforeDelete(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "live instance no longer has canonical Crabbox ownership labels") {
 		t.Fatalf("stderr=%q, want changed-ownership skip", stderr.String())
+	}
+}
+
+func TestGCPCleanupSkipsClaimlessAndStaleExactClaims(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	cfg := Config{Provider: "gcp", GCPProject: "project-a", GCPZone: "us-central1-b"}
+	claimless := canonicalGCPTestServer("cbx_333333333333", "claimless")
+	claimless.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
+	stale := canonicalGCPTestServer("cbx_444444444444", "stale")
+	stale.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
+	claimGCPTestServer(t, cfg, stale)
+	stale.ID++
+	fake := &fakeGCPDoctorClient{
+		servers: []Server{claimless, stale},
+		get:     map[string]Server{claimless.CloudID: claimless, stale.CloudID: stale},
+	}
+	old := newGCPClient
+	newGCPClient = func(context.Context, Config) (gcpClient, error) { return fake, nil }
+	t.Cleanup(func() { newGCPClient = old })
+
+	var stderr bytes.Buffer
+	backend := NewGCPLeaseBackend(core.ProviderSpec{}, cfg, Runtime{Stderr: &stderr}).(*gcpLeaseBackend)
+	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.deleted) != 0 {
+		t.Fatalf("cleanup deleted without exact authority: %v", fake.deleted)
+	}
+	if got := strings.Count(stderr.String(), "reason=exact local claim missing or stale"); got != 2 {
+		t.Fatalf("stderr=%q, missing/stale skips=%d want 2", stderr.String(), got)
 	}
 }
 
@@ -310,8 +417,11 @@ func TestGCPCleanupRetainsClaimWhenOwnershipLabelsDrift(t *testing.T) {
 }
 
 func TestGCPCleanupRevalidatesLiveEligibilityBeforeDelete(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	snapshot := canonicalGCPTestServer("cbx_111111111111", "renewed")
 	snapshot.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
+	cfg := Config{Provider: "gcp", GCPProject: "project-a", GCPZone: snapshot.Labels["zone"]}
+	claimGCPTestServer(t, cfg, snapshot)
 	live := snapshot
 	live.Labels = maps.Clone(snapshot.Labels)
 	live.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(time.Hour))
@@ -321,7 +431,7 @@ func TestGCPCleanupRevalidatesLiveEligibilityBeforeDelete(t *testing.T) {
 	t.Cleanup(func() { newGCPClient = old })
 
 	var stderr bytes.Buffer
-	backend := NewGCPLeaseBackend(core.ProviderSpec{}, Config{Provider: "gcp", GCPProject: "project-a"}, Runtime{Stderr: &stderr}).(*gcpLeaseBackend)
+	backend := NewGCPLeaseBackend(core.ProviderSpec{}, cfg, Runtime{Stderr: &stderr}).(*gcpLeaseBackend)
 	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
@@ -335,14 +445,12 @@ func TestGCPCleanupRevalidatesLiveEligibilityBeforeDelete(t *testing.T) {
 
 func TestGCPCleanupTreatsMissingLiveInstanceAsAlreadyDeleted(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	repo := t.TempDir()
 	leaseID := "cbx_111111111111"
 	slug := "gone"
-	if err := core.ClaimLeaseForRepoProviderScope(leaseID, slug, "gcp", "project:project-a", repo, time.Minute, false); err != nil {
-		t.Fatal(err)
-	}
 	snapshot := canonicalGCPTestServer(leaseID, slug)
 	snapshot.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
+	cfg := Config{Provider: "gcp", GCPProject: "project-a", GCPZone: snapshot.Labels["zone"]}
+	claimGCPTestServer(t, cfg, snapshot)
 	fake := &fakeGCPDoctorClient{
 		servers: []Server{snapshot},
 		getErr:  &googleapi.Error{Code: http.StatusNotFound, Message: "instance gone"},
@@ -352,7 +460,7 @@ func TestGCPCleanupTreatsMissingLiveInstanceAsAlreadyDeleted(t *testing.T) {
 	t.Cleanup(func() { newGCPClient = old })
 
 	var stderr bytes.Buffer
-	backend := NewGCPLeaseBackend(core.ProviderSpec{}, Config{Provider: "gcp", GCPProject: "project-a"}, Runtime{Stderr: &stderr}).(*gcpLeaseBackend)
+	backend := NewGCPLeaseBackend(core.ProviderSpec{}, cfg, Runtime{Stderr: &stderr}).(*gcpLeaseBackend)
 	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
@@ -373,13 +481,10 @@ func TestGCPCleanupTreatsMissingLiveInstanceAsAlreadyDeleted(t *testing.T) {
 
 func TestGCPReleaseLeaseRequiresCanonicalLiveOwnership(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	repo := t.TempDir()
 	leaseID := "cbx_777777777777"
 	slug := "release-box"
-	if err := core.ClaimLeaseForRepoProviderScope(leaseID, slug, "gcp", "project:project-a", repo, time.Minute, false); err != nil {
-		t.Fatal(err)
-	}
 	live := canonicalGCPTestServer(leaseID, slug)
+	claimGCPTestServer(t, Config{Provider: "gcp", GCPProject: "project-a", GCPZone: "us-central1-b"}, live)
 	fake := &fakeGCPDoctorClient{get: map[string]Server{live.CloudID: live}}
 	old := newGCPClient
 	newGCPClient = func(context.Context, Config) (gcpClient, error) {
@@ -391,7 +496,7 @@ func TestGCPReleaseLeaseRequiresCanonicalLiveOwnership(t *testing.T) {
 	err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{
 		Lease: LeaseTarget{
 			LeaseID: leaseID,
-			Server:  Server{CloudID: live.CloudID, Name: live.Name, Labels: map[string]string{"zone": "us-central1-b"}},
+			Server:  live,
 		},
 	})
 	if err != nil {
@@ -411,13 +516,15 @@ func TestGCPReleaseLeaseRequiresCanonicalLiveOwnership(t *testing.T) {
 
 func TestGCPReleaseLeaseRefusesWrongLiveLease(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	repo := t.TempDir()
 	leaseID := "cbx_888888888888"
-	if err := core.ClaimLeaseForRepoProviderScope(leaseID, "release-box", "gcp", "project:project-a", repo, time.Minute, false); err != nil {
-		t.Fatal(err)
-	}
-	live := canonicalGCPTestServer("cbx_999999999999", "other-box")
-	fake := &fakeGCPDoctorClient{get: map[string]Server{live.CloudID: live}}
+	claimed := canonicalGCPTestServer(leaseID, "release-box")
+	claimGCPTestServer(t, Config{Provider: "gcp", GCPProject: "project-a", GCPZone: "us-central1-b"}, claimed)
+	live := claimed
+	live.Labels = maps.Clone(claimed.Labels)
+	live.Labels["lease"] = "cbx_999999999999"
+	live.Labels["slug"] = "other-box"
+	live.Name = core.LeaseProviderName(live.Labels["lease"], live.Labels["slug"])
+	fake := &fakeGCPDoctorClient{get: map[string]Server{claimed.CloudID: live}}
 	old := newGCPClient
 	newGCPClient = func(context.Context, Config) (gcpClient, error) {
 		return fake, nil
@@ -428,7 +535,7 @@ func TestGCPReleaseLeaseRefusesWrongLiveLease(t *testing.T) {
 	err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{
 		Lease: LeaseTarget{
 			LeaseID: leaseID,
-			Server:  Server{CloudID: live.CloudID, Name: live.Name, Labels: map[string]string{"zone": "us-central1-b"}},
+			Server:  claimed,
 		},
 	})
 	if err == nil || !strings.Contains(err.Error(), "live instance belongs to lease=cbx_999999999999") {
@@ -448,24 +555,14 @@ func TestGCPReleaseLeaseRefusesWrongLiveLease(t *testing.T) {
 
 func TestGCPReleaseLeaseRefusesNonCanonicalLiveInstance(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	repo := t.TempDir()
 	leaseID := "cbx_aaaaaaaaaaaa"
-	cloudID := "crabbox-forged"
-	if err := core.ClaimLeaseForRepoProviderScope(leaseID, "release-box", "gcp", "project:project-a", repo, time.Minute, false); err != nil {
-		t.Fatal(err)
-	}
-	fake := &fakeGCPDoctorClient{get: map[string]Server{
-		cloudID: {
-			Provider: "gcp",
-			CloudID:  cloudID,
-			Name:     cloudID,
-			Labels: map[string]string{
-				"crabbox": "true",
-				"lease":   leaseID,
-				"zone":    "us-central1-b",
-			},
-		},
-	}}
+	claimed := canonicalGCPTestServer(leaseID, "release-box")
+	cloudID := claimed.CloudID
+	claimGCPTestServer(t, Config{Provider: "gcp", GCPProject: "project-a", GCPZone: "us-central1-b"}, claimed)
+	live := claimed
+	live.Labels = maps.Clone(claimed.Labels)
+	delete(live.Labels, "created_by")
+	fake := &fakeGCPDoctorClient{get: map[string]Server{cloudID: live}}
 	old := newGCPClient
 	newGCPClient = func(context.Context, Config) (gcpClient, error) {
 		return fake, nil
@@ -476,7 +573,7 @@ func TestGCPReleaseLeaseRefusesNonCanonicalLiveInstance(t *testing.T) {
 	err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{
 		Lease: LeaseTarget{
 			LeaseID: leaseID,
-			Server:  Server{CloudID: cloudID, Name: cloudID, Labels: map[string]string{"zone": "us-central1-b"}},
+			Server:  claimed,
 		},
 	})
 	if err == nil || !strings.Contains(err.Error(), "not canonical Crabbox-owned") {

--- a/internal/providers/gcp/provider.go
+++ b/internal/providers/gcp/provider.go
@@ -33,6 +33,42 @@ func (Provider) ApplyFlags(*core.Config, *flag.FlagSet, any) error {
 	return nil
 }
 
+func (Provider) PrepareLeaseClaimEndpoint(existing core.LeaseClaim, provider, slug string, server core.Server, allowProviderMetadata bool) (core.Server, error) {
+	_ = allowProviderMetadata
+	if provider != "gcp" {
+		return core.Server{}, core.Exit(2, "refusing to rewrite GCP lease=%s as provider=%s", existing.LeaseID, provider)
+	}
+	if slug != existing.Slug || server.Labels["lease"] != existing.LeaseID || server.Labels["slug"] != existing.Slug {
+		return core.Server{}, core.Exit(2, "refusing to rewrite GCP lease=%s with mismatched label identity", existing.LeaseID)
+	}
+	if existing.CloudID != "" && server.CloudID != "" && existing.CloudID != server.CloudID {
+		return core.Server{}, core.Exit(2, "refusing to rewrite GCP lease=%s with stale instance name", existing.LeaseID)
+	}
+	if existing.CloudNumericID != 0 && server.ID != 0 && existing.CloudNumericID != server.ID {
+		return core.Server{}, core.Exit(2, "refusing to rewrite GCP lease=%s with stale numeric instance identity", existing.LeaseID)
+	}
+	if existing.CloudNumericID == 0 {
+		server.ID = 0
+	}
+	labels := make(map[string]string, len(server.Labels))
+	for key, value := range server.Labels {
+		labels[key] = value
+	}
+	for _, key := range []string{"zone", "provider_key"} {
+		existingValue := existing.Labels[key]
+		if cloudValue := labels[key]; existingValue != "" && cloudValue != "" && cloudValue != existingValue {
+			return core.Server{}, core.Exit(2, "refusing to rewrite GCP lease=%s with mismatched %s", existing.LeaseID, key)
+		}
+		if existingValue != "" {
+			labels[key] = existingValue
+		} else {
+			delete(labels, key)
+		}
+	}
+	server.Labels = labels
+	return server, nil
+}
+
 func (Provider) ServerTypeForConfig(cfg core.Config) string {
 	return core.GCPMachineTypeCandidatesForClass(cfg.Class)[0]
 }

--- a/internal/providers/gcp/provider_test.go
+++ b/internal/providers/gcp/provider_test.go
@@ -1,0 +1,93 @@
+package gcp
+
+import (
+	"strings"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestPrepareLeaseClaimEndpointPreservesExactGCPIdentity(t *testing.T) {
+	existing := core.LeaseClaim{
+		LeaseID:        "cbx_123456789abc",
+		CloudID:        "crabbox-owned-cbx_123456789abc",
+		CloudNumericID: 42,
+		Slug:           "owned",
+		Labels: map[string]string{
+			"lease":        "cbx_123456789abc",
+			"slug":         "owned",
+			"zone":         "us-central1-b",
+			"provider_key": "crabbox-owner",
+		},
+	}
+	server := core.Server{
+		Provider: "gcp",
+		CloudID:  existing.CloudID,
+		ID:       existing.CloudNumericID,
+		Labels: map[string]string{
+			"provider":     "gcp",
+			"lease":        existing.LeaseID,
+			"slug":         existing.Slug,
+			"zone":         "us-central1-b",
+			"provider_key": "crabbox-owner",
+			"state":        "ready",
+		},
+	}
+
+	prepared, err := (Provider{}).PrepareLeaseClaimEndpoint(existing, "gcp", existing.Slug, server, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if prepared.ID != existing.CloudNumericID || prepared.Labels["zone"] != "us-central1-b" || prepared.Labels["provider_key"] != "crabbox-owner" {
+		t.Fatalf("prepared=%+v, want preserved exact identity", prepared)
+	}
+
+	for name, mutate := range map[string]func(*core.Server){
+		"name":         func(server *core.Server) { server.CloudID += "-other" },
+		"numeric id":   func(server *core.Server) { server.ID++ },
+		"zone":         func(server *core.Server) { server.Labels["zone"] = "us-central1-c" },
+		"provider key": func(server *core.Server) { server.Labels["provider_key"] = "crabbox-other" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			changed := server
+			changed.Labels = cloneTestLabels(server.Labels)
+			mutate(&changed)
+			if _, err := (Provider{}).PrepareLeaseClaimEndpoint(existing, "gcp", existing.Slug, changed, false); err == nil || !strings.Contains(err.Error(), "refusing to rewrite GCP") {
+				t.Fatalf("error=%v, want exact-identity refusal", err)
+			}
+		})
+	}
+}
+
+func TestPrepareLeaseClaimEndpointDoesNotPromoteLegacyGCPIdentity(t *testing.T) {
+	existing := core.LeaseClaim{
+		LeaseID: "cbx_legacy123456",
+		CloudID: "crabbox-legacy-cbx_legacy123456",
+		Slug:    "legacy",
+		Labels:  map[string]string{"lease": "cbx_legacy123456", "slug": "legacy"},
+	}
+	server := core.Server{
+		Provider: "gcp",
+		CloudID:  existing.CloudID,
+		ID:       99,
+		Labels: map[string]string{
+			"provider": "gcp", "lease": existing.LeaseID, "slug": existing.Slug,
+			"zone": "us-central1-b", "provider_key": "crabbox-cloud",
+		},
+	}
+	prepared, err := (Provider{}).PrepareLeaseClaimEndpoint(existing, "gcp", existing.Slug, server, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if prepared.ID != 0 || prepared.Labels["zone"] != "" || prepared.Labels["provider_key"] != "" {
+		t.Fatalf("prepared=%+v, must not promote mutable cloud identity into a legacy claim", prepared)
+	}
+}
+
+func cloneTestLabels(labels map[string]string) map[string]string {
+	cloned := make(map[string]string, len(labels))
+	for key, value := range labels {
+		cloned[key] = value
+	}
+	return cloned
+}


### PR DESCRIPTION
## Summary

- require an exact local GCP ownership claim before release or stale cleanup may delete an instance
- bind that claim to project, instance name, immutable numeric instance ID, zone, provider key, lease metadata, and canonical labels
- hold the unchanged claim lock through deletion and fail closed on missing, stale, or retargeted ownership evidence
- document the stronger GCP cleanup boundary and add regression coverage for release, cleanup, dry-run, drift, legacy claims, and endpoint rewrites

Closes https://github.com/openclaw/crabbox/issues/977

## Verification

- `go vet ./...`
- `go test -race ./...`
- `go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker` (866 passed, 3 skipped)
- `npm run build --prefix worker`
- `node scripts/build-docs-site.mjs`
- AutoReview: clean, no accepted/actionable findings

## Live proof

Exact candidate `9707b41f153d08846ec92197f485d4d7f886b51a` completed an authenticated GCP create/use/destroy canary:

- lease `cbx_687923eaa6c8`
- instance `crabbox-crimson-lobster-3ea3e7da`
- remote command returned `crabbox-gcp-exact-claim-ok`
- automatic release reported `stopped=true`
- independent post-release inventory found zero instances by exact name, zero instances by exact lease label, and zero boot disks by exact name

No credentials are added to Crabbox configuration or retained by the proof harness.
