### PR TITLE
fix: bind Azure cleanup to exact durable claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Required direct Azure release and cleanup to hold an unchanged subscription-, resource-group-, VM-name-, immutable-VM-, lease-, slug-, and provider-key-bound local claim across deletion, with durable companion-resource identities for interruption-safe cleanup. Thanks @coygeek.
 - Required direct GCP release and cleanup to hold an unchanged project-, zone-, name-, numeric-instance-, lease-, slug-, and provider-key-bound local claim across deletion. Thanks @coygeek.
 - Prevented repository-defined External lifecycle commands from placing inherited `external.config` values on process arguments without an exact, trusted non-secret argv contract. Thanks @coygeek.
 - Prevented repository-controlled External SSH endpoint templates and adapter output from silently using ambient or operator-managed SSH credentials, with source-bound opt-ins for environment-derived fields and provider-returned destinations. Thanks @coygeek.

--- a/docs/features/provider-live-smoke.md
+++ b/docs/features/provider-live-smoke.md
@@ -151,7 +151,7 @@ hermetic lifecycle tests, `scripts/live-smoke.sh`, dedicated live runners, and
 `//go:build smoke` tests. Regenerate it with
 `node scripts/generate-provider-matrix.mjs`; docs CI rejects drift.
 
-Current coverage: 72 providers; 4 with convention-named hermetic lifecycle tests, 52 with a live runner, 3 with tagged Go smoke tests, and 19 with none of those lifecycle surfaces.
+Current coverage: 72 providers; 4 with convention-named hermetic lifecycle tests, 53 with a live runner, 3 with tagged Go smoke tests, and 18 with none of those lifecycle surfaces.
 
 | Provider | Hermetic lifecycle | Live runner | Tagged Go smoke |
 | --- | --- | --- | --- |
@@ -163,7 +163,7 @@ Current coverage: 72 providers; 4 with convention-named hermetic lifecycle tests
 | [ascii-box](../providers/ascii-box.md) | — | — | — |
 | [aws](../providers/aws.md) | — | matrix | — |
 | [aws-lambda-microvm](../providers/aws-lambda-microvm.md) | — | dedicated + matrix | — |
-| [azure](../providers/azure.md) | — | — | — |
+| [azure](../providers/azure.md) | — | matrix | — |
 | [azure-dynamic-sessions](../providers/azure-dynamic-sessions.md) | — | — | — |
 | [blacksmith-testbox](../providers/blacksmith-testbox.md) | — | matrix | — |
 | [blaxel](../providers/blaxel.md) | — | dedicated | — |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -49,6 +49,7 @@ CRABBOX_LIVE=1 CRABBOX_LIVE_REPO=/path/to/my-app scripts/live-smoke.sh
 ```sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=aws               CRABBOX_LIVE_REPO=/path/to/my-app scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=hetzner           CRABBOX_LIVE_REPO=/path/to/my-app scripts/live-smoke.sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=azure CRABBOX_LIVE_COORDINATOR=0 CRABBOX_LIVE_AZURE_TYPE=Standard_D2s_v5 CRABBOX_LIVE_REPO=/path/to/my-app scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=blacksmith-testbox CRABBOX_LIVE_REPO=/path/to/my-app scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=e2b               CRABBOX_LIVE_REPO=/path/to/my-app scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=modal             CRABBOX_LIVE_REPO=/path/to/my-app scripts/live-smoke.sh

--- a/docs/security.md
+++ b/docs/security.md
@@ -326,8 +326,13 @@ Direct Hetzner release and cleanup similarly require canonical provider labels
 plus an unchanged local claim whose lease and cloud ID match the exact server.
 Direct GCP release and cleanup require an unchanged local claim bound to the
 project, zone, instance name and immutable numeric ID, lease, slug, and provider
-key. Cleanup skips weakly labeled, unclaimed, and stale-claim servers instead
-of turning provider inventory into ownership proof.
+key. Direct Azure release and cleanup likewise require an unchanged local claim
+bound to the subscription, resource group, VM name and immutable VM ID, lease,
+slug, and provider key. Before deleting a VM, Crabbox also persists immutable
+NIC, public IP, disk, and quarantine-NSG identities so an interrupted cleanup
+can resume without trusting reused names. Cleanup skips weakly labeled,
+unclaimed, and stale-claim servers instead of turning provider inventory into
+ownership proof.
 
 Artifact publishing rejects symlinks, directories at reserved generated-output
 paths, and other non-regular bundle entries before upload side effects. Required

--- a/internal/cli/azure.go
+++ b/internal/cli/azure.go
@@ -28,24 +28,30 @@ import (
 )
 
 const (
-	azureAddressSpace                = "10.42.0.0/16"
-	azureSubnetCIDR                  = "10.42.0.0/24"
-	azureProviderTag                 = "crabbox"
-	AzureOSDiskAuto                  = "auto"
-	AzureOSDiskEphemeral             = "ephemeral"
-	AzureOSDiskEphemeralPreview      = "ephemeral-preview"
-	AzureOSDiskManaged               = "managed"
-	azureComputePreviewAPIVersion    = "2025-04-01"
-	defaultAzureLinuxImage           = "Canonical:ubuntu-26_04-lts:server:latest"
-	defaultAzureLinuxARM64Image      = "Canonical:ubuntu-26_04-lts:server-arm64:latest"
-	azureNobleLinuxImage             = "Canonical:ubuntu-24_04-lts:server:latest"
-	azureNobleLinuxARM64Image        = "Canonical:ubuntu-24_04-lts:server-arm64:latest"
-	legacyAzureJammyImage            = "Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest"
-	legacyAzureNobleGen2Image        = "Canonical:0001-com-ubuntu-server-noble:24_04-lts-gen2:latest"
-	defaultAzureWindowsImage         = "MicrosoftWindowsServer:windowsserver2022:2022-datacenter-smalldisk-g2:latest"
-	azureDeleteRetryDelay            = 15 * time.Second
-	azureDeleteRetryAttempts         = 13
-	azureSnapshotQuarantineNSGSuffix = "-q-nsg"
+	azureAddressSpace                 = "10.42.0.0/16"
+	azureSubnetCIDR                   = "10.42.0.0/24"
+	azureProviderTag                  = "crabbox"
+	AzureOSDiskAuto                   = "auto"
+	AzureOSDiskEphemeral              = "ephemeral"
+	AzureOSDiskEphemeralPreview       = "ephemeral-preview"
+	AzureOSDiskManaged                = "managed"
+	azureComputePreviewAPIVersion     = "2025-04-01"
+	defaultAzureLinuxImage            = "Canonical:ubuntu-26_04-lts:server:latest"
+	defaultAzureLinuxARM64Image       = "Canonical:ubuntu-26_04-lts:server-arm64:latest"
+	azureNobleLinuxImage              = "Canonical:ubuntu-24_04-lts:server:latest"
+	azureNobleLinuxARM64Image         = "Canonical:ubuntu-24_04-lts:server-arm64:latest"
+	legacyAzureJammyImage             = "Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest"
+	legacyAzureNobleGen2Image         = "Canonical:0001-com-ubuntu-server-noble:24_04-lts-gen2:latest"
+	defaultAzureWindowsImage          = "MicrosoftWindowsServer:windowsserver2022:2022-datacenter-smalldisk-g2:latest"
+	azureDeleteRetryDelay             = 15 * time.Second
+	azureDeleteRetryAttempts          = 13
+	azureSnapshotQuarantineNSGSuffix  = "-q-nsg"
+	AzureCleanupBindingLabel          = "_crabbox_azure_cleanup_binding"
+	azureCleanupBindingVersion        = "v1"
+	azureCleanupNICIdentityLabel      = "_crabbox_azure_cleanup_nic_id"
+	azureCleanupPublicIPIdentityLabel = "_crabbox_azure_cleanup_public_ip_id"
+	azureCleanupDiskIdentityLabel     = "_crabbox_azure_cleanup_disk_id"
+	azureCleanupNSGIdentityLabel      = "_crabbox_azure_cleanup_nsg_id"
 )
 
 type AzureClient struct {
@@ -776,6 +782,10 @@ func nextAzureNSGPriority(used map[int32]bool) (int32, error) {
 }
 
 func (c *AzureClient) CreateServerWithFallback(ctx context.Context, cfg Config, publicKey, leaseID, slug string, keep bool, logf func(string, ...any)) (Server, Config, error) {
+	// Return the resolved account scope so the provider can persist an exact
+	// claim even when authentication was discovered through `az login`.
+	cfg.AzureSubscription = c.SubscriptionID
+	cfg.AzureResourceGroup = c.ResourceGroup
 	regions := azureRegionCandidates(cfg, c.Location)
 	var errs []error
 	for _, region := range regions {
@@ -801,6 +811,11 @@ func (c *AzureClient) CreateServerWithFallback(ctx context.Context, cfg Config, 
 		}
 	}
 	return Server{}, cfg, joinErrors(errs)
+}
+
+// LeaseClaimScope identifies the Azure account boundary used by this client.
+func (c *AzureClient) LeaseClaimScope() string {
+	return azureLeaseClaimScope(c.SubscriptionID, c.ResourceGroup)
 }
 
 func (c *AzureClient) createServerWithFallbackInLocation(ctx context.Context, cfg Config, publicKey, leaseID, slug string, keep bool, logf func(string, ...any)) (Server, Config, error) {
@@ -1817,6 +1832,72 @@ func (c *AzureClient) DeleteServer(ctx context.Context, name string) error {
 	return c.deleteVMResources(ctx, name)
 }
 
+// PrepareOwnedServer captures immutable companion identities before the VM can
+// be deleted. The caller persists the returned labels in the exact lease claim.
+func (c *AzureClient) PrepareOwnedServer(ctx context.Context, expected Server) (Server, error) {
+	return c.prepareAzureDeleteServer(ctx, expected, func(expected, live Server) error {
+		return validateAzureOwnedVM(expected, live)
+	})
+}
+
+// PrepareCleanupServer is the expiry-aware variant used by automatic cleanup.
+func (c *AzureClient) PrepareCleanupServer(ctx context.Context, expected Server, now time.Time) (Server, error) {
+	return c.prepareAzureDeleteServer(ctx, expected, func(expected, live Server) error {
+		return validateAzureCleanupVM(expected, live, now)
+	})
+}
+
+func (c *AzureClient) prepareAzureDeleteServer(ctx context.Context, expected Server, validateVM func(Server, Server) error) (Server, error) {
+	name := strings.TrimSpace(expected.CloudID)
+	if name == "" {
+		return Server{}, errors.New("azure delete candidate has no cloud id")
+	}
+	vmResponse, err := c.vmc.Get(ctx, c.ResourceGroup, name, nil)
+	if err != nil {
+		if isAzureNotFoundError(err) {
+			if _, bindingErr := azureDeleteResourcesFromLabels(expected); bindingErr != nil {
+				return Server{}, fmt.Errorf("Azure VM %s is absent and its durable cleanup binding is unavailable: %w", name, bindingErr)
+			}
+			return expected, nil
+		}
+		return Server{}, fmt.Errorf("re-read Azure delete VM %s: %w", name, err)
+	}
+	live := azureVMToServer(vmResponse.VirtualMachine, "", "")
+	if err := validateVM(expected, live); err != nil {
+		return Server{}, &azureCleanupSkipError{err: err}
+	}
+	resources, err := c.azureCleanupDeleteResources(ctx, name, vmResponse.VirtualMachine, live.Labels, expected.ImmutableID)
+	if err != nil {
+		var readErr *azureCleanupResourceReadError
+		if errors.As(err, &readErr) && !isAzureNotFoundError(readErr.err) {
+			return Server{}, err
+		}
+		return Server{}, &azureCleanupSkipError{err: err}
+	}
+	if HasAzureCleanupBinding(expected.Labels) {
+		persisted, err := azureDeleteResourcesFromLabels(expected)
+		if err != nil {
+			return Server{}, err
+		}
+		if err := requireMatchingAzureDeleteResources(persisted, resources); err != nil {
+			return Server{}, &azureCleanupSkipError{err: err}
+		}
+	}
+	prepared := expected
+	prepared.Labels = azureDeleteResourcesToLabels(expected.Labels, resources)
+	return prepared, nil
+}
+
+// DeleteOwnedServer revalidates an exact owned VM and every associated resource
+// at the release mutation boundary. Lease expiry is intentionally irrelevant.
+func (c *AzureClient) DeleteOwnedServer(ctx context.Context, expected Server) error {
+	resources, err := azureDeleteResourcesFromLabels(expected)
+	if err != nil {
+		return err
+	}
+	return c.deleteAzureValidatedResourcesWithRetry(ctx, expected, resources, validateAzureOwnedVM)
+}
+
 type azureCleanupSkipError struct{ err error }
 
 func (e *azureCleanupSkipError) Error() string { return e.err.Error() }
@@ -1837,25 +1918,9 @@ func IsAzureCleanupSkipError(err error) bool {
 // DeleteCleanupServer revalidates a cleanup candidate and every associated
 // resource consumed by deletion at the Azure mutation boundary.
 func (c *AzureClient) DeleteCleanupServer(ctx context.Context, expected Server, now time.Time) error {
-	name := strings.TrimSpace(expected.CloudID)
-	if name == "" {
-		return errors.New("azure cleanup candidate has no cloud id")
-	}
-	vmResponse, err := c.vmc.Get(ctx, c.ResourceGroup, name, nil)
+	resources, err := azureDeleteResourcesFromLabels(expected)
 	if err != nil {
-		return fmt.Errorf("re-read Azure cleanup VM %s: %w", name, err)
-	}
-	live := azureVMToServer(vmResponse.VirtualMachine, "", "")
-	if err := validateAzureCleanupVM(expected, live, now); err != nil {
-		return &azureCleanupSkipError{err: err}
-	}
-	resources, err := c.azureCleanupDeleteResources(ctx, name, vmResponse.VirtualMachine, live.Labels, expected.ImmutableID)
-	if err != nil {
-		var readErr *azureCleanupResourceReadError
-		if errors.As(err, &readErr) && !isAzureNotFoundError(readErr.err) {
-			return err
-		}
-		return &azureCleanupSkipError{err: err}
+		return err
 	}
 	return c.deleteAzureCleanupResourcesWithRetry(ctx, expected, resources, now)
 }
@@ -1998,7 +2063,82 @@ type azureVMDeleteResources struct {
 	quarantineID  string
 }
 
+// HasAzureCleanupBinding reports whether a local claim contains a complete,
+// versioned companion-resource snapshot captured before Azure VM deletion.
+func HasAzureCleanupBinding(labels map[string]string) bool {
+	return strings.TrimSpace(labels[AzureCleanupBindingLabel]) == azureCleanupBindingVersion
+}
+
+func azureDeleteResourcesToLabels(labels map[string]string, resources azureVMDeleteResources) map[string]string {
+	out := cloneStringMap(labels)
+	if out == nil {
+		out = make(map[string]string)
+	}
+	out[AzureCleanupBindingLabel] = azureCleanupBindingVersion
+	out[azureCleanupNICIdentityLabel] = strings.TrimSpace(resources.nicID)
+	out[azureCleanupPublicIPIdentityLabel] = strings.TrimSpace(resources.publicIPID)
+	if resources.diskID != "" {
+		out[azureCleanupDiskIdentityLabel] = strings.TrimSpace(resources.diskID)
+	} else {
+		delete(out, azureCleanupDiskIdentityLabel)
+	}
+	if resources.quarantineID != "" {
+		out[azureCleanupNSGIdentityLabel] = strings.TrimSpace(resources.quarantineID)
+	} else {
+		delete(out, azureCleanupNSGIdentityLabel)
+	}
+	return out
+}
+
+func azureDeleteResourcesFromLabels(expected Server) (azureVMDeleteResources, error) {
+	name := strings.TrimSpace(expected.CloudID)
+	if name == "" {
+		return azureVMDeleteResources{}, errors.New("azure delete candidate has no cloud id")
+	}
+	if !HasAzureCleanupBinding(expected.Labels) {
+		return azureVMDeleteResources{}, errors.New("durable Azure cleanup binding is missing")
+	}
+	resources := azureVMDeleteResources{
+		vm:         true,
+		vmID:       strings.TrimSpace(expected.ImmutableID),
+		nic:        name + "-nic",
+		nicID:      strings.TrimSpace(expected.Labels[azureCleanupNICIdentityLabel]),
+		publicIP:   name + "-pip",
+		publicIPID: strings.TrimSpace(expected.Labels[azureCleanupPublicIPIdentityLabel]),
+	}
+	if resources.vmID == "" || resources.nicID == "" || resources.publicIPID == "" {
+		return azureVMDeleteResources{}, errors.New("durable Azure cleanup binding is incomplete")
+	}
+	if resources.diskID = strings.TrimSpace(expected.Labels[azureCleanupDiskIdentityLabel]); resources.diskID != "" {
+		resources.disk = name + "-osdisk"
+	}
+	if resources.quarantineID = strings.TrimSpace(expected.Labels[azureCleanupNSGIdentityLabel]); resources.quarantineID != "" {
+		resources.quarantineNSG = name + azureSnapshotQuarantineNSGSuffix
+	}
+	return resources, nil
+}
+
+func requireMatchingAzureDeleteResources(expected, live azureVMDeleteResources) error {
+	if expected.vmID != live.vmID || expected.nic != live.nic || expected.nicID != live.nicID ||
+		expected.publicIP != live.publicIP || expected.publicIPID != live.publicIPID ||
+		expected.disk != live.disk || expected.diskID != live.diskID ||
+		expected.quarantineNSG != live.quarantineNSG || expected.quarantineID != live.quarantineID {
+		return errors.New("live Azure companion resources do not match the durable cleanup binding")
+	}
+	return nil
+}
+
 func validateAzureCleanupVM(expected, live Server, now time.Time) error {
+	if err := validateAzureOwnedVM(expected, live); err != nil {
+		return err
+	}
+	if shouldDelete, reason := shouldCleanupServer(live, now); !shouldDelete {
+		return fmt.Errorf("live Azure VM is no longer cleanup eligible: %s", reason)
+	}
+	return nil
+}
+
+func validateAzureOwnedVM(expected, live Server) error {
 	expectedID := strings.TrimSpace(expected.CloudID)
 	if expectedID == "" || strings.TrimSpace(live.CloudID) != expectedID {
 		return fmt.Errorf("live Azure cloud id %q does not match cleanup candidate %q", live.CloudID, expected.CloudID)
@@ -2017,8 +2157,8 @@ func validateAzureCleanupVM(expected, live Server, now time.Time) error {
 	if liveSlug, expectedSlug := strings.TrimSpace(labels["slug"]), strings.TrimSpace(expected.Labels["slug"]); liveSlug != expectedSlug {
 		return fmt.Errorf("live Azure VM slug %q does not match cleanup candidate slug %q", liveSlug, expectedSlug)
 	}
-	if shouldDelete, reason := shouldCleanupServer(live, now); !shouldDelete {
-		return fmt.Errorf("live Azure VM is no longer cleanup eligible: %s", reason)
+	if liveProviderKey, expectedProviderKey := strings.TrimSpace(labels["provider_key"]), strings.TrimSpace(expected.Labels["provider_key"]); liveProviderKey == "" || liveProviderKey != expectedProviderKey {
+		return fmt.Errorf("live Azure VM provider key does not match cleanup candidate")
 	}
 	return nil
 }

--- a/internal/cli/azure_cleanup_retry.go
+++ b/internal/cli/azure_cleanup_retry.go
@@ -9,9 +9,15 @@ import (
 )
 
 func (c *AzureClient) deleteAzureCleanupResourcesWithRetry(ctx context.Context, expected Server, resources azureVMDeleteResources, now time.Time) error {
+	return c.deleteAzureValidatedResourcesWithRetry(ctx, expected, resources, func(expected, live Server) error {
+		return validateAzureCleanupVM(expected, live, now)
+	})
+}
+
+func (c *AzureClient) deleteAzureValidatedResourcesWithRetry(ctx context.Context, expected Server, resources azureVMDeleteResources, validateVM func(Server, Server) error) error {
 	name := strings.TrimSpace(expected.CloudID)
 	var err error
-	resources, err = c.revalidateAzureCleanupDeleteResourcesWithRetry(ctx, expected, resources, now)
+	resources, err = c.revalidateAzureDeleteResourcesWithRetry(ctx, expected, resources, validateVM)
 	if err != nil {
 		return err
 	}
@@ -27,7 +33,7 @@ func (c *AzureClient) deleteAzureCleanupResourcesWithRetry(ctx context.Context, 
 					return err
 				}
 				var err error
-				resources, err = c.revalidateAzureCleanupDeleteResourcesWithRetry(ctx, expected, resources, now)
+				resources, err = c.revalidateAzureDeleteResourcesWithRetry(ctx, expected, resources, validateVM)
 				if err != nil {
 					return err
 				}
@@ -35,7 +41,7 @@ func (c *AzureClient) deleteAzureCleanupResourcesWithRetry(ctx context.Context, 
 			}
 			resources.vm = false
 			var err error
-			resources, err = c.revalidateAzureCleanupDeleteResourcesWithRetry(ctx, expected, resources, now)
+			resources, err = c.revalidateAzureDeleteResourcesWithRetry(ctx, expected, resources, validateVM)
 			if err != nil {
 				return err
 			}
@@ -55,7 +61,7 @@ func (c *AzureClient) deleteAzureCleanupResourcesWithRetry(ctx context.Context, 
 			return err
 		}
 		var err error
-		resources, err = c.revalidateAzureCleanupDeleteResourcesWithRetry(ctx, expected, resources, now)
+		resources, err = c.revalidateAzureDeleteResourcesWithRetry(ctx, expected, resources, validateVM)
 		if err != nil {
 			return err
 		}
@@ -65,9 +71,9 @@ func (c *AzureClient) deleteAzureCleanupResourcesWithRetry(ctx context.Context, 
 	}
 }
 
-func (c *AzureClient) revalidateAzureCleanupDeleteResourcesWithRetry(ctx context.Context, expected Server, resources azureVMDeleteResources, now time.Time) (azureVMDeleteResources, error) {
+func (c *AzureClient) revalidateAzureDeleteResourcesWithRetry(ctx context.Context, expected Server, resources azureVMDeleteResources, validateVM func(Server, Server) error) (azureVMDeleteResources, error) {
 	return retryAzureCleanupResourceReads(ctx, resources, func(current azureVMDeleteResources) (azureVMDeleteResources, error) {
-		return c.revalidateAzureCleanupDeleteResources(ctx, expected, current, now)
+		return c.revalidateAzureDeleteResources(ctx, expected, current, validateVM)
 	})
 }
 
@@ -104,7 +110,7 @@ func azureCleanupResourcesEmpty(resources azureVMDeleteResources) bool {
 	return !resources.vm && resources.nic == "" && resources.publicIP == "" && resources.disk == "" && resources.quarantineNSG == ""
 }
 
-func (c *AzureClient) revalidateAzureCleanupDeleteResources(ctx context.Context, expected Server, resources azureVMDeleteResources, now time.Time) (azureVMDeleteResources, error) {
+func (c *AzureClient) revalidateAzureDeleteResources(ctx context.Context, expected Server, resources azureVMDeleteResources, validateVM func(Server, Server) error) (azureVMDeleteResources, error) {
 	name := strings.TrimSpace(expected.CloudID)
 	labels := expected.Labels
 	if resources.nic != "" {
@@ -200,7 +206,7 @@ func (c *AzureClient) revalidateAzureCleanupDeleteResources(ctx context.Context,
 			}
 		} else {
 			live := azureVMToServer(response.VirtualMachine, "", "")
-			if err := validateAzureCleanupVM(expected, live, now); err != nil {
+			if err := validateVM(expected, live); err != nil {
 				return resources, &azureCleanupSkipError{err: err}
 			}
 			if response.VirtualMachine.Properties == nil {

--- a/internal/cli/azure_test.go
+++ b/internal/cli/azure_test.go
@@ -77,12 +77,13 @@ func TestValidateAzureCleanupVM(t *testing.T) {
 		CloudID:     "crabbox-live",
 		ImmutableID: "vmid-live",
 		Labels: map[string]string{
-			"crabbox":    "true",
-			"created_by": "crabbox",
-			"provider":   "azure",
-			"lease":      "cbx_123456abcdef",
-			"slug":       "live",
-			"expires_at": leaseLabelTime(now.Add(-time.Hour)),
+			"crabbox":      "true",
+			"created_by":   "crabbox",
+			"provider":     "azure",
+			"lease":        "cbx_123456abcdef",
+			"slug":         "live",
+			"provider_key": providerKeyForLease("cbx_123456abcdef"),
+			"expires_at":   leaseLabelTime(now.Add(-time.Hour)),
 		},
 	}
 	if err := validateAzureCleanupVM(expected, expected, now); err != nil {
@@ -106,6 +107,77 @@ func TestValidateAzureCleanupVM(t *testing.T) {
 	renewed.Labels["expires_at"] = leaseLabelTime(now.Add(time.Hour))
 	if err := validateAzureCleanupVM(expected, renewed, now); err == nil || !strings.Contains(err.Error(), "no longer cleanup eligible") {
 		t.Fatalf("renewed VM error=%v", err)
+	}
+}
+
+func TestValidateAzureOwnedVMDoesNotRequireExpiry(t *testing.T) {
+	expected := Server{
+		CloudID:     "crabbox-release",
+		ImmutableID: "vmid-release",
+		Labels: map[string]string{
+			"crabbox":      "true",
+			"created_by":   "crabbox",
+			"provider":     "azure",
+			"lease":        "cbx_123456abcdef",
+			"slug":         "release",
+			"provider_key": providerKeyForLease("cbx_123456abcdef"),
+		},
+	}
+	if err := validateAzureOwnedVM(expected, expected); err != nil {
+		t.Fatalf("valid release VM rejected: %v", err)
+	}
+	replacement := expected
+	replacement.ImmutableID = "vmid-replacement"
+	if err := validateAzureOwnedVM(expected, replacement); err == nil || !strings.Contains(err.Error(), "identity") {
+		t.Fatalf("replacement VM error=%v", err)
+	}
+	changedKey := expected
+	changedKey.Labels = maps.Clone(expected.Labels)
+	changedKey.Labels["provider_key"] = "replacement"
+	if err := validateAzureOwnedVM(expected, changedKey); err == nil || !strings.Contains(err.Error(), "provider key") {
+		t.Fatalf("changed provider key error=%v", err)
+	}
+}
+
+func TestAzureDeleteResourcesRoundTripDurableClaimLabels(t *testing.T) {
+	expected := Server{
+		CloudID:     "crabbox-owned",
+		ImmutableID: "vmid-owned",
+		Labels:      map[string]string{"lease": "cbx_123456abcdef", "slug": "owned"},
+	}
+	resources := azureVMDeleteResources{
+		vm:            true,
+		vmID:          "vmid-owned",
+		nic:           "crabbox-owned-nic",
+		nicID:         "nic-guid",
+		publicIP:      "crabbox-owned-pip",
+		publicIPID:    "pip-guid",
+		disk:          "crabbox-owned-osdisk",
+		diskID:        "disk-guid",
+		quarantineNSG: "crabbox-owned-q-nsg",
+		quarantineID:  "nsg-guid",
+	}
+	expected.Labels = azureDeleteResourcesToLabels(expected.Labels, resources)
+	if !HasAzureCleanupBinding(expected.Labels) {
+		t.Fatal("durable cleanup binding marker missing")
+	}
+	got, err := azureDeleteResourcesFromLabels(expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := requireMatchingAzureDeleteResources(got, resources); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAzureDeleteResourcesRejectIncompleteDurableClaim(t *testing.T) {
+	expected := Server{
+		CloudID:     "crabbox-owned",
+		ImmutableID: "vmid-owned",
+		Labels:      map[string]string{AzureCleanupBindingLabel: azureCleanupBindingVersion},
+	}
+	if _, err := azureDeleteResourcesFromLabels(expected); err == nil || !strings.Contains(err.Error(), "incomplete") {
+		t.Fatalf("err=%v, want incomplete binding rejection", err)
 	}
 }
 

--- a/internal/cli/claim.go
+++ b/internal/cli/claim.go
@@ -21,7 +21,9 @@ type leaseClaim struct {
 	Provider string `json:"provider,omitempty"`
 	CloudID  string `json:"cloudID,omitempty"`
 	// CloudNumericID binds providers whose CloudID is a reusable resource name.
-	CloudNumericID                      int64             `json:"cloudNumericID,omitempty"`
+	CloudNumericID int64 `json:"cloudNumericID,omitempty"`
+	// CloudImmutableID binds providers whose immutable identity is a string.
+	CloudImmutableID                    string            `json:"cloudImmutableID,omitempty"`
 	ProviderScope                       string            `json:"providerScope,omitempty"`
 	StaticHost                          string            `json:"staticHost,omitempty"`
 	StaticUser                          string            `json:"staticUser,omitempty"`
@@ -548,6 +550,9 @@ func applyLeaseClaimEndpoint(claim *leaseClaim, server Server, target SSHTarget)
 	if server.ID != 0 {
 		claim.CloudNumericID = server.ID
 	}
+	if server.ImmutableID != "" {
+		claim.CloudImmutableID = server.ImmutableID
+	}
 	if len(server.Labels) > 0 {
 		claim.Labels = cloneStringMap(server.Labels)
 	}
@@ -794,6 +799,8 @@ func canonicalClaimProvider(provider string) string {
 
 func providerClaimScope(provider string, cfg Config) string {
 	switch provider {
+	case "azure":
+		return azureLeaseClaimScope(cfg.AzureSubscription, cfg.AzureResourceGroup)
 	case "gcp":
 		if cfg.GCPProject != "" {
 			return "project:" + cfg.GCPProject
@@ -829,6 +836,15 @@ func providerClaimScope(provider string, cfg Config) string {
 		}
 	}
 	return ""
+}
+
+func azureLeaseClaimScope(subscriptionID, resourceGroup string) string {
+	subscriptionID = strings.ToLower(strings.TrimSpace(subscriptionID))
+	resourceGroup = strings.ToLower(strings.TrimSpace(resourceGroup))
+	if subscriptionID == "" || resourceGroup == "" {
+		return ""
+	}
+	return "subscription:" + subscriptionID + "|resource-group:" + resourceGroup
 }
 
 func normalizedNamespaceClaimEndpoint(raw string) string {

--- a/internal/cli/claim_test.go
+++ b/internal/cli/claim_test.go
@@ -144,9 +144,10 @@ func TestClaimLeaseTargetForConfigStoresUnattachedProviderResource(t *testing.T)
 	cfg := baseConfig()
 	cfg.Provider = "aws"
 	server := Server{
-		Provider: "aws",
-		CloudID:  "i-1750645",
-		ID:       42,
+		Provider:    "aws",
+		CloudID:     "i-1750645",
+		ID:          42,
+		ImmutableID: "vmid-1750645",
 		Labels: map[string]string{
 			"provider": "aws",
 			"slug":     "warm",
@@ -160,7 +161,7 @@ func TestClaimLeaseTargetForConfigStoresUnattachedProviderResource(t *testing.T)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if claim.Provider != "aws" || claim.CloudID != "i-1750645" || claim.CloudNumericID != 42 || claim.RepoRoot != "" {
+	if claim.Provider != "aws" || claim.CloudID != "i-1750645" || claim.CloudNumericID != 42 || claim.CloudImmutableID != "vmid-1750645" || claim.RepoRoot != "" {
 		t.Fatalf("unexpected unattached provider claim: %#v", claim)
 	}
 
@@ -174,6 +175,19 @@ func TestClaimLeaseTargetForConfigStoresUnattachedProviderResource(t *testing.T)
 	}
 	if claim.RepoRoot != repoRoot {
 		t.Fatalf("provider claim was not attached to repo: %#v", claim)
+	}
+}
+
+func TestAzureProviderClaimScopeRequiresCompleteRoute(t *testing.T) {
+	cfg := baseConfig()
+	cfg.AzureSubscription = " TEST-SUB "
+	cfg.AzureResourceGroup = " Production-RG "
+	if got, want := providerClaimScope("azure", cfg), "subscription:test-sub|resource-group:production-rg"; got != want {
+		t.Fatalf("providerClaimScope(azure)=%q, want %q", got, want)
+	}
+	cfg.AzureResourceGroup = ""
+	if got := providerClaimScope("azure", cfg); got != "" {
+		t.Fatalf("incomplete azure scope=%q, want empty", got)
 	}
 }
 

--- a/internal/providers/azure/backend.go
+++ b/internal/providers/azure/backend.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"strings"
 	"time"
@@ -33,11 +34,15 @@ type azureLeaseBackend struct{ shared.DirectSSHBackend }
 const azureAcquireRollbackTimeout = 20 * time.Minute
 
 type azureClient interface {
+	LeaseClaimScope() string
 	ListCrabboxServers(context.Context) ([]Server, error)
 	CreateServerWithFallback(context.Context, Config, string, string, string, bool, func(string, ...any)) (Server, Config, error)
 	WaitForServerIP(context.Context, string) (Server, error)
 	GetServer(context.Context, string) (Server, error)
 	DeleteServer(context.Context, string) error
+	PrepareOwnedServer(context.Context, Server) (Server, error)
+	PrepareCleanupServer(context.Context, Server, time.Time) (Server, error)
+	DeleteOwnedServer(context.Context, Server) error
 	DeleteCleanupServer(context.Context, Server, time.Time) error
 	SetTags(context.Context, string, map[string]string) error
 }
@@ -110,10 +115,15 @@ func (b *azureLeaseBackend) acquireOnce(ctx context.Context, keep bool, requeste
 		return LeaseTarget{}, err
 	}
 	server.Labels["state"] = "ready"
-	rollback = false
 	if err := client.SetTags(ctx, server.CloudID, server.Labels); err != nil {
 		fmt.Fprintf(b.RT.Stderr, "warning: set tags: %v\n", err)
 	}
+	if err := core.ClaimLeaseTargetForConfig(leaseID, slug, cfg, server, target, cfg.IdleTimeout); err != nil {
+		return LeaseTarget{}, err
+	}
+	b.Cfg.AzureSubscription = cfg.AzureSubscription
+	b.Cfg.AzureResourceGroup = cfg.AzureResourceGroup
+	rollback = false
 	return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 }
 
@@ -125,6 +135,9 @@ func (b *azureLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (Le
 	if strings.HasPrefix(req.ID, "crabbox-") {
 		server, err := client.GetServer(ctx, req.ID)
 		if err != nil {
+			if req.ReleaseOnly && isAzureCleanupNotFound(err) {
+				return resolveMissingAzureReleaseClaim(req.ID, client.LeaseClaimScope())
+			}
 			return LeaseTarget{}, err
 		}
 		if !isCrabboxAzureLease(server) {
@@ -146,7 +159,31 @@ func (b *azureLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (Le
 		useStoredTestboxKey(&target, leaseID)
 		return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 	}
+	if req.ReleaseOnly {
+		return resolveMissingAzureReleaseClaim(req.ID, client.LeaseClaimScope())
+	}
 	return LeaseTarget{}, exit(4, "lease/server not found: %s", req.ID)
+}
+
+func resolveMissingAzureReleaseClaim(identifier, providerScope string) (LeaseTarget, error) {
+	claim, exists, err := core.ResolveLeaseClaimForProvider(identifier, "azure")
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	if !exists {
+		claim, exists, err = core.ResolveLeaseClaimForProviderCloudID(identifier, "azure")
+		if err != nil {
+			return LeaseTarget{}, err
+		}
+	}
+	if !exists || !core.LeaseClaimMatchesIdentifier(claim, identifier) {
+		return LeaseTarget{}, exit(4, "lease/server not found: %s", identifier)
+	}
+	server := azureServerFromClaim(claim)
+	if err := validateExactAzureClaim(claim, server, claim.LeaseID, providerScope); err != nil {
+		return LeaseTarget{}, err
+	}
+	return LeaseTarget{Server: server, LeaseID: claim.LeaseID}, nil
 }
 
 func isCrabboxAzureLease(server Server) bool {
@@ -179,13 +216,30 @@ func (b *azureLeaseBackend) Doctor(ctx context.Context, _ core.DoctorRequest) (c
 }
 
 func (b *azureLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
-	if !isCrabboxAzureLease(req.Lease.Server) || req.Lease.LeaseID != req.Lease.Server.Labels["lease"] {
-		return exit(4, "refusing to release Azure VM %s without matching canonical Crabbox ownership tags", req.Lease.Server.DisplayID())
-	}
-	if err := deleteServer(ctx, b.Cfg, req.Lease.Server); err != nil {
+	client, err := newAzureClient(ctx, b.Cfg)
+	if err != nil {
 		return err
 	}
-	removeLeaseClaim(req.Lease.LeaseID)
+	claim, err := requireExactAzureClaim(req.Lease.Server, req.Lease.LeaseID, client.LeaseClaimScope())
+	if err != nil {
+		return err
+	}
+	prepared, err := client.PrepareOwnedServer(ctx, req.Lease.Server)
+	if err != nil {
+		return err
+	}
+	if err := validateExactAzureClaim(claim, prepared, req.Lease.LeaseID, client.LeaseClaimScope()); err != nil {
+		return err
+	}
+	claim, err = core.UpdateLeaseClaimLabelsIfUnchanged(claim.LeaseID, claim, prepared.Labels)
+	if err != nil {
+		return err
+	}
+	if err := core.RemoveLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, func() error {
+		return client.DeleteOwnedServer(ctx, prepared)
+	}); err != nil {
+		return err
+	}
 	core.RemoveStoredTestboxKey(req.Lease.LeaseID)
 	return nil
 }
@@ -211,7 +265,9 @@ func (b *azureLeaseBackend) Cleanup(ctx context.Context, req CleanupRequest) err
 	if b.RT.Clock != nil {
 		now = b.RT.Clock.Now().UTC()
 	}
+	seen := make(map[string]bool, len(servers))
 	for _, server := range servers {
+		seen[server.CloudID] = true
 		if !isCrabboxAzureLease(server) {
 			fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=canonical Crabbox ownership tags missing\n", server.DisplayID(), server.Name)
 			continue
@@ -221,8 +277,9 @@ func (b *azureLeaseBackend) Cleanup(ctx context.Context, req CleanupRequest) err
 			fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=%s\n", server.DisplayID(), server.Name, reason)
 			continue
 		}
-		if req.DryRun {
-			fmt.Fprintf(b.RT.Stderr, "delete server id=%s name=%s\n", server.DisplayID(), server.Name)
+		claim, claimErr := requireExactAzureClaim(server, server.Labels["lease"], client.LeaseClaimScope())
+		if claimErr != nil {
+			fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=exact local claim missing or stale\n", server.DisplayID(), server.Name)
 			continue
 		}
 		live, err := client.GetServer(ctx, server.CloudID)
@@ -238,11 +295,33 @@ func (b *azureLeaseBackend) Cleanup(ctx context.Context, req CleanupRequest) err
 			fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=%v\n", server.DisplayID(), server.Name, err)
 			continue
 		}
+		if err := validateExactAzureClaim(claim, live, server.Labels["lease"], client.LeaseClaimScope()); err != nil {
+			fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=exact local claim missing or stale\n", server.DisplayID(), server.Name)
+			continue
+		}
 		if shouldDelete, reason := core.ShouldCleanupServer(live, now); !shouldDelete {
 			fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=live VM %s\n", server.DisplayID(), server.Name, reason)
 			continue
 		}
-		if err := client.DeleteCleanupServer(ctx, server, now); err != nil {
+		fmt.Fprintf(b.RT.Stderr, "delete server id=%s name=%s\n", live.DisplayID(), live.Name)
+		if req.DryRun {
+			continue
+		}
+		prepared, err := client.PrepareCleanupServer(ctx, live, now)
+		if err != nil {
+			if core.IsAzureCleanupSkipError(err) {
+				fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=%v\n", live.DisplayID(), live.Name, err)
+				continue
+			}
+			return err
+		}
+		claim, err = core.UpdateLeaseClaimLabelsIfUnchanged(claim.LeaseID, claim, prepared.Labels)
+		if err != nil {
+			return err
+		}
+		if err := core.RemoveLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, func() error {
+			return client.DeleteCleanupServer(ctx, prepared, now)
+		}); err != nil {
 			if core.IsAzureCleanupSkipError(err) {
 				fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=%v\n", live.DisplayID(), live.Name, err)
 				continue
@@ -253,12 +332,63 @@ func (b *azureLeaseBackend) Cleanup(ctx context.Context, req CleanupRequest) err
 			}
 			return err
 		}
-		fmt.Fprintf(b.RT.Stderr, "delete server id=%s name=%s\n", live.DisplayID(), live.Name)
-		leaseID := server.Labels["lease"]
-		removeLeaseClaim(leaseID)
-		core.RemoveStoredTestboxKey(leaseID)
+		core.RemoveStoredTestboxKey(claim.LeaseID)
+	}
+	return b.resumeAzureCleanupClaims(ctx, client, seen, now, req.DryRun)
+}
+
+func (b *azureLeaseBackend) resumeAzureCleanupClaims(ctx context.Context, client azureClient, seen map[string]bool, now time.Time, dryRun bool) error {
+	claims, err := core.ListLeaseClaims()
+	if err != nil {
+		return err
+	}
+	for _, claim := range claims {
+		if claim.Provider != "azure" || claim.ProviderScope != client.LeaseClaimScope() || seen[claim.CloudID] || !core.HasAzureCleanupBinding(claim.Labels) {
+			continue
+		}
+		server := azureServerFromClaim(claim)
+		if err := validateExactAzureClaim(claim, server, claim.LeaseID, client.LeaseClaimScope()); err != nil {
+			fmt.Fprintf(b.RT.Stderr, "skip recovery server id=%s reason=exact local claim missing or stale\n", claim.CloudID)
+			continue
+		}
+		fmt.Fprintf(b.RT.Stderr, "resume cleanup server id=%s name=%s\n", server.DisplayID(), server.Name)
+		if dryRun {
+			continue
+		}
+		prepared, err := client.PrepareCleanupServer(ctx, server, now)
+		if err != nil {
+			if core.IsAzureCleanupSkipError(err) {
+				fmt.Fprintf(b.RT.Stderr, "skip recovery server id=%s reason=%v\n", server.DisplayID(), err)
+				continue
+			}
+			return err
+		}
+		claim, err = core.UpdateLeaseClaimLabelsIfUnchanged(claim.LeaseID, claim, prepared.Labels)
+		if err != nil {
+			return err
+		}
+		if err := core.RemoveLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, func() error {
+			return client.DeleteCleanupServer(ctx, prepared, now)
+		}); err != nil {
+			if core.IsAzureCleanupSkipError(err) {
+				fmt.Fprintf(b.RT.Stderr, "skip recovery server id=%s reason=%v\n", server.DisplayID(), err)
+				continue
+			}
+			return err
+		}
+		core.RemoveStoredTestboxKey(claim.LeaseID)
 	}
 	return nil
+}
+
+func azureServerFromClaim(claim core.LeaseClaim) Server {
+	return Server{
+		CloudID:     claim.CloudID,
+		Name:        claim.CloudID,
+		Provider:    "azure",
+		ImmutableID: claim.CloudImmutableID,
+		Labels:      maps.Clone(claim.Labels),
+	}
 }
 
 func listOwnedAzureServers(ctx context.Context, client azureClient) ([]Server, error) {
@@ -322,6 +452,45 @@ func deleteAzureServerWithClient(ctx context.Context, client azureClient, server
 	return client.DeleteServer(ctx, name)
 }
 
+func requireExactAzureClaim(server Server, expectedLeaseID, providerScope string) (core.LeaseClaim, error) {
+	claim, exists, err := core.ReadLeaseClaimWithPresence(expectedLeaseID)
+	if err != nil {
+		return core.LeaseClaim{}, err
+	}
+	if !exists {
+		return core.LeaseClaim{}, exit(2, "azure lease=%s has no exact local claim; refusing destructive operation", expectedLeaseID)
+	}
+	if err := validateExactAzureClaim(claim, server, expectedLeaseID, providerScope); err != nil {
+		return core.LeaseClaim{}, err
+	}
+	return claim, nil
+}
+
+func validateExactAzureClaim(claim core.LeaseClaim, server Server, expectedLeaseID, providerScope string) error {
+	serverSlug := strings.TrimSpace(server.Labels["slug"])
+	serverProviderKey := strings.TrimSpace(server.Labels["provider_key"])
+	if strings.TrimSpace(providerScope) == "" ||
+		!isCrabboxAzureLease(server) ||
+		claim.LeaseID != expectedLeaseID ||
+		claim.Provider != "azure" ||
+		claim.ProviderScope != providerScope ||
+		claim.CloudID == "" ||
+		claim.CloudID != strings.TrimSpace(server.CloudID) ||
+		claim.CloudImmutableID == "" ||
+		claim.CloudImmutableID != strings.TrimSpace(server.ImmutableID) ||
+		claim.Slug == "" ||
+		claim.Slug != serverSlug ||
+		server.Labels["lease"] != expectedLeaseID ||
+		strings.TrimSpace(claim.Labels["lease"]) != expectedLeaseID ||
+		strings.TrimSpace(claim.Labels["slug"]) != serverSlug ||
+		strings.TrimSpace(claim.Labels["provider"]) != "azure" ||
+		serverProviderKey == "" ||
+		strings.TrimSpace(claim.Labels["provider_key"]) != serverProviderKey {
+		return exit(2, "refusing to operate on Azure VM %s from a missing or stale exact local claim", server.DisplayID())
+	}
+	return nil
+}
+
 func validateAzureCleanupLiveServer(expected, live Server) error {
 	cloudID := strings.TrimSpace(expected.CloudID)
 	if cloudID == "" || strings.TrimSpace(live.CloudID) != cloudID {
@@ -363,7 +532,6 @@ func useStoredTestboxKey(target *SSHTarget, leaseID string) {
 func findServerByAlias(servers []Server, id string) (Server, string, error) {
 	return core.FindServerByAlias(servers, id)
 }
-func removeLeaseClaim(leaseID string) { core.RemoveLeaseClaim(leaseID) }
 func azureServerHost(server Server, network string) string {
 	return core.AzureServerHost(server, network)
 }

--- a/internal/providers/azure/backend_test.go
+++ b/internal/providers/azure/backend_test.go
@@ -15,19 +15,37 @@ import (
 )
 
 type fakeAzureClient struct {
-	deleted         []string
-	cleanupExpected []Server
-	tagged          []string
-	servers         []Server
-	listErr         error
-	created         Server
-	createCfg       Config
-	createErr       error
-	waitErr         error
-	getErr          error
-	get             map[string]Server
-	getErrs         map[string]error
-	getIDs          []string
+	claimScope        string
+	deleted           []string
+	cleanupExpected   []Server
+	ownedExpected     []Server
+	prepareCleanup    []Server
+	prepareOwned      []Server
+	prepareFunc       func(Server) Server
+	prepareErr        error
+	deleteOwnedFunc   func(Server) error
+	deleteCleanupFunc func(Server) error
+	tagged            []string
+	servers           []Server
+	listErr           error
+	created           Server
+	createCfg         Config
+	createErr         error
+	waitErr           error
+	getErr            error
+	get               map[string]Server
+	getErrs           map[string]error
+	getIDs            []string
+	setTagsFunc       func()
+}
+
+const azureTestClaimScope = "subscription:test-sub|resource-group:rg"
+
+func (c *fakeAzureClient) LeaseClaimScope() string {
+	if c.claimScope != "" {
+		return c.claimScope
+	}
+	return azureTestClaimScope
 }
 
 func (c *fakeAzureClient) ListCrabboxServers(context.Context) ([]Server, error) {
@@ -80,14 +98,55 @@ func (c *fakeAzureClient) DeleteServer(_ context.Context, name string) error {
 	return nil
 }
 
+func (c *fakeAzureClient) PrepareOwnedServer(_ context.Context, server Server) (Server, error) {
+	c.prepareOwned = append(c.prepareOwned, server)
+	if c.prepareErr != nil {
+		return Server{}, c.prepareErr
+	}
+	if c.prepareFunc != nil {
+		server = c.prepareFunc(server)
+	}
+	return server, nil
+}
+
+func (c *fakeAzureClient) PrepareCleanupServer(_ context.Context, server Server, _ time.Time) (Server, error) {
+	c.prepareCleanup = append(c.prepareCleanup, server)
+	if c.prepareErr != nil {
+		return Server{}, c.prepareErr
+	}
+	if c.prepareFunc != nil {
+		server = c.prepareFunc(server)
+	}
+	return server, nil
+}
+
+func (c *fakeAzureClient) DeleteOwnedServer(_ context.Context, server Server) error {
+	c.ownedExpected = append(c.ownedExpected, server)
+	if c.deleteOwnedFunc != nil {
+		if err := c.deleteOwnedFunc(server); err != nil {
+			return err
+		}
+	}
+	c.deleted = append(c.deleted, server.CloudID)
+	return nil
+}
+
 func (c *fakeAzureClient) DeleteCleanupServer(_ context.Context, server Server, _ time.Time) error {
 	c.cleanupExpected = append(c.cleanupExpected, server)
+	if c.deleteCleanupFunc != nil {
+		if err := c.deleteCleanupFunc(server); err != nil {
+			return err
+		}
+	}
 	c.deleted = append(c.deleted, server.CloudID)
 	return nil
 }
 
 func (c *fakeAzureClient) SetTags(_ context.Context, name string, _ map[string]string) error {
 	c.tagged = append(c.tagged, name)
+	if c.setTagsFunc != nil {
+		c.setTagsFunc()
+	}
 	return nil
 }
 
@@ -175,11 +234,8 @@ func TestAzureAcquireFailsClosedWhenSSHCIDRDetectionFails(t *testing.T) {
 func TestAzureAcquireDoesNotRollbackReadyServer(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
-	created := Server{
-		CloudID: "crabbox-ready",
-		Name:    "crabbox-ready",
-		Labels:  map[string]string{"lease": "cbx_ready"},
-	}
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	created := azureTestServer("crabbox-ready", "cbx_123456abcdef", "ready")
 	created.PublicNet.IPv4.IP = "203.0.113.10"
 	fake := &fakeAzureClient{
 		created:   created,
@@ -210,11 +266,54 @@ func TestAzureAcquireDoesNotRollbackReadyServer(t *testing.T) {
 	if len(fake.tagged) != 1 || fake.tagged[0] != "crabbox-ready" {
 		t.Fatalf("tagged=%v, want ready tag update", fake.tagged)
 	}
+	claim, exists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+	if err != nil || !exists {
+		t.Fatalf("claim exists=%v err=%v", exists, err)
+	}
+	if claim.ProviderScope != azureTestClaimScope || claim.CloudImmutableID != created.ImmutableID {
+		t.Fatalf("claim=%+v, want resolved Azure scope and immutable VM identity", claim)
+	}
+}
+
+func TestAzureAcquireRollsBackWhenExactClaimCannotPersist(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	blockedStateHome := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(blockedStateHome, []byte("blocked"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	created := azureTestServer("crabbox-claim-failure", "cbx_123456abcdef", "claim-failure")
+	created.PublicNet.IPv4.IP = "203.0.113.10"
+	fake := &fakeAzureClient{
+		created:   created,
+		createCfg: azureAcquireTestConfig(),
+		setTagsFunc: func() {
+			if err := os.Setenv("XDG_STATE_HOME", blockedStateHome); err != nil {
+				t.Fatal(err)
+			}
+		},
+	}
+	oldClient := newAzureClient
+	newAzureClient = func(context.Context, Config) (azureClient, error) { return fake, nil }
+	t.Cleanup(func() { newAzureClient = oldClient })
+	oldBootstrap := bootstrapManagedWindowsDesktop
+	bootstrapManagedWindowsDesktop = func(context.Context, Config, *SSHTarget, string, io.Writer) error { return nil }
+	t.Cleanup(func() { bootstrapManagedWindowsDesktop = oldBootstrap })
+
+	backend := NewAzureLeaseBackend(ProviderSpec{}, azureAcquireTestConfig(), Runtime{Stderr: io.Discard}).(*azureLeaseBackend)
+	if _, err := backend.acquireOnce(context.Background(), false, ""); err == nil {
+		t.Fatal("expected exact-claim persistence failure")
+	}
+	if len(fake.deleted) != 1 || fake.deleted[0] != created.CloudID {
+		t.Fatalf("deleted=%v, want funded VM rollback after claim failure", fake.deleted)
+	}
 }
 
 func azureAcquireTestConfig() Config {
 	return Config{
 		Provider:           "azure",
+		AzureSubscription:  "test-sub",
 		AzureLocation:      "eastus",
 		AzureResourceGroup: "rg",
 		AzureSSHCIDRs:      []string{"198.51.100.7/32"},
@@ -277,16 +376,19 @@ func TestAzureReleaseRejectsForgedOrMismatchedOwnership(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			fake := &fakeAzureClient{}
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			server := azureTestServer("crabbox-owned", "cbx_123456abcdef", "owned")
+			storeAzureTestClaim(t, server)
+			fake := &fakeAzureClient{servers: []Server{server}}
 			oldClient := newAzureClient
 			newAzureClient = func(context.Context, Config) (azureClient, error) { return fake, nil }
 			t.Cleanup(func() { newAzureClient = oldClient })
 
-			lease := LeaseTarget{Server: azureTestServer("crabbox-owned", "cbx_123456abcdef", "owned"), LeaseID: "cbx_123456abcdef"}
+			lease := LeaseTarget{Server: server, LeaseID: "cbx_123456abcdef"}
 			test.mutate(&lease)
 			backend := NewAzureLeaseBackend(ProviderSpec{}, azureAcquireTestConfig(), Runtime{Stderr: io.Discard}).(*azureLeaseBackend)
 			err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease})
-			if err == nil || !strings.Contains(err.Error(), "matching canonical Crabbox ownership tags") {
+			if err == nil || !strings.Contains(err.Error(), "exact local claim") {
 				t.Fatalf("err=%v, want ownership rejection", err)
 			}
 			if len(fake.deleted) != 0 {
@@ -299,17 +401,20 @@ func TestAzureReleaseRejectsForgedOrMismatchedOwnership(t *testing.T) {
 func TestAzureReleaseRemovesStoredLeaseKey(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	leaseID := "cbx_123456abcdef"
 	keyPath, _, err := core.EnsureTestboxKeyForConfig(Config{}, leaseID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	fake := &fakeAzureClient{}
+	server := azureTestServer("crabbox-owned", leaseID, "owned")
+	storeAzureTestClaim(t, server)
+	fake := &fakeAzureClient{servers: []Server{server}}
 	oldClient := newAzureClient
 	newAzureClient = func(context.Context, Config) (azureClient, error) { return fake, nil }
 	t.Cleanup(func() { newAzureClient = oldClient })
 
-	lease := LeaseTarget{Server: azureTestServer("crabbox-owned", leaseID, "owned"), LeaseID: leaseID}
+	lease := LeaseTarget{Server: server, LeaseID: leaseID}
 	backend := NewAzureLeaseBackend(ProviderSpec{}, azureAcquireTestConfig(), Runtime{Stderr: io.Discard}).(*azureLeaseBackend)
 	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err != nil {
 		t.Fatal(err)
@@ -317,13 +422,98 @@ func TestAzureReleaseRemovesStoredLeaseKey(t *testing.T) {
 	if _, err := os.Stat(filepath.Dir(keyPath)); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("stored lease key directory still exists: %v", err)
 	}
+	if _, exists, err := core.ReadLeaseClaimWithPresence(leaseID); err != nil || exists {
+		t.Fatalf("claim exists=%v err=%v, want removed after deletion", exists, err)
+	}
+	if len(fake.ownedExpected) != 1 || fake.ownedExpected[0].ImmutableID != server.ImmutableID {
+		t.Fatalf("release boundary=%+v, want exact live Azure identity", fake.ownedExpected)
+	}
+}
+
+func TestAzureReleasePersistsCleanupBindingBeforeDelete(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	server := azureTestServer("crabbox-owned", "cbx_123456abcdef", "owned")
+	storeAzureTestClaim(t, server)
+	deleteErr := errors.New("simulated interruption after durable binding")
+	fake := &fakeAzureClient{
+		servers: []Server{server},
+		prepareFunc: func(prepared Server) Server {
+			prepared.Labels = maps.Clone(prepared.Labels)
+			prepared.Labels[core.AzureCleanupBindingLabel] = "v1"
+			return prepared
+		},
+		deleteOwnedFunc: func(Server) error { return deleteErr },
+	}
+	oldClient := newAzureClient
+	newAzureClient = func(context.Context, Config) (azureClient, error) { return fake, nil }
+	t.Cleanup(func() { newAzureClient = oldClient })
+
+	backend := NewAzureLeaseBackend(ProviderSpec{}, azureAcquireTestConfig(), Runtime{Stderr: io.Discard}).(*azureLeaseBackend)
+	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{Server: server, LeaseID: server.Labels["lease"]}}); !errors.Is(err, deleteErr) {
+		t.Fatalf("err=%v, want simulated interruption", err)
+	}
+	claim, exists, err := core.ReadLeaseClaimWithPresence(server.Labels["lease"])
+	if err != nil || !exists {
+		t.Fatalf("claim exists=%v err=%v after interrupted delete", exists, err)
+	}
+	if claim.Labels[core.AzureCleanupBindingLabel] != "v1" {
+		t.Fatalf("claim labels=%v, want durable cleanup binding", claim.Labels)
+	}
+}
+
+func TestAzureResolveAndReleaseResumeAfterVMDeletion(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	server := azureTestServer("crabbox-interrupted", "cbx_123456abcdef", "interrupted")
+	server.Labels[core.AzureCleanupBindingLabel] = "v1"
+	storeAzureTestClaim(t, server)
+	fake := &fakeAzureClient{
+		getErrs: map[string]error{server.CloudID: core.Exit(4, "azure vm not found: %s", server.CloudID)},
+	}
+	oldClient := newAzureClient
+	newAzureClient = func(context.Context, Config) (azureClient, error) { return fake, nil }
+	t.Cleanup(func() { newAzureClient = oldClient })
+
+	backend := NewAzureLeaseBackend(ProviderSpec{}, azureAcquireTestConfig(), Runtime{Stderr: io.Discard}).(*azureLeaseBackend)
+	lease, err := backend.Resolve(context.Background(), ResolveRequest{ID: server.CloudID, ReleaseOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.LeaseID != server.Labels["lease"] || lease.Server.ImmutableID != server.ImmutableID {
+		t.Fatalf("lease=%+v, want claim-backed exact identity", lease)
+	}
+	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.deleted) != 1 || fake.deleted[0] != server.CloudID {
+		t.Fatalf("deleted=%v, want resumed deletion", fake.deleted)
+	}
+}
+
+func TestAzureReleaseRequiresExactClaim(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	server := azureTestServer("crabbox-owned", "cbx_123456abcdef", "owned")
+	fake := &fakeAzureClient{servers: []Server{server}}
+	oldClient := newAzureClient
+	newAzureClient = func(context.Context, Config) (azureClient, error) { return fake, nil }
+	t.Cleanup(func() { newAzureClient = oldClient })
+
+	backend := NewAzureLeaseBackend(ProviderSpec{}, azureAcquireTestConfig(), Runtime{Stderr: io.Discard}).(*azureLeaseBackend)
+	err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{Server: server, LeaseID: server.Labels["lease"]}})
+	if err == nil || !strings.Contains(err.Error(), "no exact local claim") {
+		t.Fatalf("err=%v, want exact-claim rejection", err)
+	}
+	if len(fake.getIDs) != 0 || len(fake.deleted) != 0 {
+		t.Fatalf("get=%v deleted=%v, want no provider read or delete", fake.getIDs, fake.deleted)
+	}
 }
 
 func TestAzureCleanupSkipsWeakTagsAndDeletesCanonicalExpiredVM(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	owned := azureTestServer("crabbox-owned", "cbx_123456abcdef", "owned")
 	owned.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
+	storeAzureTestClaim(t, owned)
 	keyPath, _, err := core.EnsureTestboxKeyForConfig(Config{}, owned.Labels["lease"])
 	if err != nil {
 		t.Fatal(err)
@@ -350,11 +540,61 @@ func TestAzureCleanupSkipsWeakTagsAndDeletesCanonicalExpiredVM(t *testing.T) {
 	if _, err := os.Stat(filepath.Dir(keyPath)); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("stored lease key directory still exists: %v", err)
 	}
+	if _, exists, err := core.ReadLeaseClaimWithPresence(owned.Labels["lease"]); err != nil || exists {
+		t.Fatalf("claim exists=%v err=%v, want removed after deletion", exists, err)
+	}
+}
+
+func TestAzureCleanupRequiresExactClaim(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	server := azureTestServer("crabbox-unclaimed", "cbx_123456abcdef", "unclaimed")
+	server.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
+	fake := &fakeAzureClient{servers: []Server{server}}
+	oldClient := newAzureClient
+	newAzureClient = func(context.Context, Config) (azureClient, error) { return fake, nil }
+	t.Cleanup(func() { newAzureClient = oldClient })
+
+	var stderr strings.Builder
+	backend := NewAzureLeaseBackend(ProviderSpec{}, azureAcquireTestConfig(), Runtime{Stderr: &stderr}).(*azureLeaseBackend)
+	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.getIDs) != 0 || len(fake.deleted) != 0 {
+		t.Fatalf("get=%v deleted=%v, want no provider read or delete", fake.getIDs, fake.deleted)
+	}
+	if !strings.Contains(stderr.String(), "exact local claim missing or stale") {
+		t.Fatalf("stderr=%q, want exact-claim diagnostic", stderr.String())
+	}
+}
+
+func TestAzureCleanupDryRunRevalidatesExactClaim(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	server := azureTestServer("crabbox-dry-run", "cbx_123456abcdef", "dry-run")
+	server.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
+	storeAzureTestClaim(t, server)
+	fake := &fakeAzureClient{servers: []Server{server}}
+	oldClient := newAzureClient
+	newAzureClient = func(context.Context, Config) (azureClient, error) { return fake, nil }
+	t.Cleanup(func() { newAzureClient = oldClient })
+
+	var stderr strings.Builder
+	backend := NewAzureLeaseBackend(ProviderSpec{}, azureAcquireTestConfig(), Runtime{Stderr: &stderr}).(*azureLeaseBackend)
+	if err := backend.Cleanup(context.Background(), CleanupRequest{DryRun: true}); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.getIDs) != 1 || len(fake.deleted) != 0 {
+		t.Fatalf("get=%v deleted=%v, want one revalidation and no delete", fake.getIDs, fake.deleted)
+	}
+	if !strings.Contains(stderr.String(), "delete server id=crabbox-dry-run") {
+		t.Fatalf("stderr=%q, want dry-run deletion plan", stderr.String())
+	}
 }
 
 func TestAzureCleanupRevalidatesLiveOwnershipBeforeDelete(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	snapshot := azureTestServer("crabbox-stale", "cbx_123456abcdef", "stale")
 	snapshot.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
+	storeAzureTestClaim(t, snapshot)
 	live := snapshot
 	live.Labels = maps.Clone(snapshot.Labels)
 	live.Labels["lease"] = "cbx_fedcba654321"
@@ -383,8 +623,10 @@ func TestAzureCleanupRevalidatesLiveOwnershipBeforeDelete(t *testing.T) {
 }
 
 func TestAzureCleanupRevalidatesLiveEligibilityBeforeDelete(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	snapshot := azureTestServer("crabbox-renewed", "cbx_123456abcdef", "renewed")
 	snapshot.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
+	storeAzureTestClaim(t, snapshot)
 	live := snapshot
 	live.Labels = maps.Clone(snapshot.Labels)
 	live.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(time.Hour))
@@ -407,8 +649,10 @@ func TestAzureCleanupRevalidatesLiveEligibilityBeforeDelete(t *testing.T) {
 }
 
 func TestAzureCleanupRejectsSameNameReplacementVM(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	snapshot := azureTestServer("crabbox-replaced", "cbx_123456abcdef", "replaced")
 	snapshot.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
+	storeAzureTestClaim(t, snapshot)
 	live := snapshot
 	live.ImmutableID = "vmid-replacement"
 	fake := &fakeAzureClient{servers: []Server{snapshot}, get: map[string]Server{snapshot.CloudID: live}}
@@ -429,9 +673,11 @@ func TestAzureCleanupRejectsSameNameReplacementVM(t *testing.T) {
 	}
 }
 
-func TestAzureCleanupDeleteBoundaryUsesOriginalCandidate(t *testing.T) {
+func TestAzureCleanupRejectsChangedLiveSlug(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	snapshot := azureTestServer("candidate", "cbx_111111111111", "original")
 	snapshot.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
+	storeAzureTestClaim(t, snapshot)
 	live := snapshot
 	live.Labels = maps.Clone(snapshot.Labels)
 	live.Labels["slug"] = "changed"
@@ -440,22 +686,28 @@ func TestAzureCleanupDeleteBoundaryUsesOriginalCandidate(t *testing.T) {
 	newAzureClient = func(context.Context, Config) (azureClient, error) { return fake, nil }
 	t.Cleanup(func() { newAzureClient = oldClient })
 
-	backend := NewAzureLeaseBackend(ProviderSpec{}, azureAcquireTestConfig(), Runtime{Stderr: io.Discard}).(*azureLeaseBackend)
+	var stderr strings.Builder
+	backend := NewAzureLeaseBackend(ProviderSpec{}, azureAcquireTestConfig(), Runtime{Stderr: &stderr}).(*azureLeaseBackend)
 	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
-	if len(fake.cleanupExpected) != 1 || fake.cleanupExpected[0].Labels["slug"] != "original" {
-		t.Fatalf("cleanup boundary candidates=%v, want original list candidate", fake.cleanupExpected)
+	if len(fake.cleanupExpected) != 0 || len(fake.deleted) != 0 {
+		t.Fatalf("cleanup crossed changed slug: expected=%v deleted=%v", fake.cleanupExpected, fake.deleted)
+	}
+	if !strings.Contains(stderr.String(), "exact local claim missing or stale") {
+		t.Fatalf("stderr=%q, want exact-claim diagnostic", stderr.String())
 	}
 }
 
 func TestAzureCleanupContinuesWhenLiveCandidateAlreadyGone(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	missing := azureTestServer("missing", "cbx_111111111111", "missing")
 	remaining := azureTestServer("remaining", "cbx_222222222222", "remaining")
 	for _, server := range []*Server{&missing, &remaining} {
 		server.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
+		storeAzureTestClaim(t, *server)
 	}
 	keyPath, _, err := core.EnsureTestboxKeyForConfig(Config{}, missing.Labels["lease"])
 	if err != nil {
@@ -486,6 +738,35 @@ func TestAzureCleanupContinuesWhenLiveCandidateAlreadyGone(t *testing.T) {
 	}
 }
 
+func TestAzureCleanupResumesDurablyBoundCompanionsAfterVMDeletion(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	server := azureTestServer("crabbox-interrupted", "cbx_123456abcdef", "interrupted")
+	server.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
+	server.Labels[core.AzureCleanupBindingLabel] = "v1"
+	storeAzureTestClaim(t, server)
+	fake := &fakeAzureClient{}
+	oldClient := newAzureClient
+	newAzureClient = func(context.Context, Config) (azureClient, error) { return fake, nil }
+	t.Cleanup(func() { newAzureClient = oldClient })
+
+	var stderr strings.Builder
+	backend := NewAzureLeaseBackend(ProviderSpec{}, azureAcquireTestConfig(), Runtime{Stderr: &stderr}).(*azureLeaseBackend)
+	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.cleanupExpected) != 1 || fake.cleanupExpected[0].CloudID != server.CloudID {
+		t.Fatalf("cleanup=%v, want interrupted exact claim recovery", fake.cleanupExpected)
+	}
+	if !strings.Contains(stderr.String(), "resume cleanup server") {
+		t.Fatalf("stderr=%q, want recovery diagnostic", stderr.String())
+	}
+	if _, exists, err := core.ReadLeaseClaimWithPresence(server.Labels["lease"]); err != nil || exists {
+		t.Fatalf("claim exists=%v err=%v, want removed after recovery", exists, err)
+	}
+}
+
 func azureTestServer(id, leaseID, slug string) Server {
 	return Server{
 		CloudID:     id,
@@ -493,11 +774,54 @@ func azureTestServer(id, leaseID, slug string) Server {
 		Provider:    "azure",
 		ImmutableID: "vmid-" + id,
 		Labels: map[string]string{
-			"crabbox":    "true",
-			"created_by": "crabbox",
-			"provider":   "azure",
-			"lease":      leaseID,
-			"slug":       slug,
+			"crabbox":      "true",
+			"created_by":   "crabbox",
+			"provider":     "azure",
+			"lease":        leaseID,
+			"slug":         slug,
+			"provider_key": core.ProviderKeyForLease(leaseID),
 		},
 	}
+}
+
+func TestValidateExactAzureClaimRejectsScopeAndResourceMismatch(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	server := azureTestServer("crabbox-owned", "cbx_123456abcdef", "owned")
+	claim := storeAzureTestClaim(t, server)
+	for _, test := range []struct {
+		name   string
+		mutate func(*core.LeaseClaim, *Server, *string)
+	}{
+		{name: "scope", mutate: func(_ *core.LeaseClaim, _ *Server, scope *string) { *scope = "subscription:other|resource-group:rg" }},
+		{name: "name", mutate: func(_ *core.LeaseClaim, server *Server, _ *string) { server.CloudID = "replacement" }},
+		{name: "immutable id", mutate: func(_ *core.LeaseClaim, server *Server, _ *string) { server.ImmutableID = "vmid-replacement" }},
+		{name: "slug", mutate: func(_ *core.LeaseClaim, server *Server, _ *string) { server.Labels["slug"] = "replacement" }},
+		{name: "provider key", mutate: func(_ *core.LeaseClaim, server *Server, _ *string) { server.Labels["provider_key"] = "replacement" }},
+		{name: "legacy claim", mutate: func(claim *core.LeaseClaim, _ *Server, _ *string) { claim.CloudImmutableID = "" }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			testClaim := claim
+			testClaim.Labels = maps.Clone(claim.Labels)
+			testServer := server
+			testServer.Labels = maps.Clone(server.Labels)
+			scope := azureTestClaimScope
+			test.mutate(&testClaim, &testServer, &scope)
+			if err := validateExactAzureClaim(testClaim, testServer, server.Labels["lease"], scope); err == nil {
+				t.Fatal("expected exact Azure claim mismatch")
+			}
+		})
+	}
+}
+
+func storeAzureTestClaim(t *testing.T, server Server) core.LeaseClaim {
+	t.Helper()
+	cfg := azureAcquireTestConfig()
+	if err := core.ClaimLeaseTargetForConfig(server.Labels["lease"], server.Labels["slug"], cfg, server, SSHTarget{}, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	claim, exists, err := core.ReadLeaseClaimWithPresence(server.Labels["lease"])
+	if err != nil || !exists {
+		t.Fatalf("claim exists=%v err=%v", exists, err)
+	}
+	return claim
 }

--- a/internal/providers/azure/provider.go
+++ b/internal/providers/azure/provider.go
@@ -114,6 +114,39 @@ func (p Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) err
 	return nil
 }
 
+func (Provider) PrepareLeaseClaimEndpoint(existing core.LeaseClaim, provider, slug string, server core.Server, allowProviderMetadata bool) (core.Server, error) {
+	_ = allowProviderMetadata
+	if provider != "azure" {
+		return core.Server{}, core.Exit(2, "refusing to rewrite Azure lease=%s as provider=%s", existing.LeaseID, provider)
+	}
+	if slug != existing.Slug || server.Labels["lease"] != existing.LeaseID || server.Labels["slug"] != existing.Slug {
+		return core.Server{}, core.Exit(2, "refusing to rewrite Azure lease=%s with mismatched label identity", existing.LeaseID)
+	}
+	if existing.CloudID != "" && server.CloudID != "" && existing.CloudID != server.CloudID {
+		return core.Server{}, core.Exit(2, "refusing to rewrite Azure lease=%s with stale VM name", existing.LeaseID)
+	}
+	if existing.CloudImmutableID != "" && server.ImmutableID != "" && existing.CloudImmutableID != server.ImmutableID {
+		return core.Server{}, core.Exit(2, "refusing to rewrite Azure lease=%s with stale immutable VM identity", existing.LeaseID)
+	}
+	if existing.CloudImmutableID == "" {
+		server.ImmutableID = ""
+	}
+	labels := make(map[string]string, len(server.Labels))
+	for key, value := range server.Labels {
+		labels[key] = value
+	}
+	if existingValue := existing.Labels["provider_key"]; existingValue != "" {
+		if cloudValue := labels["provider_key"]; cloudValue != "" && cloudValue != existingValue {
+			return core.Server{}, core.Exit(2, "refusing to rewrite Azure lease=%s with mismatched provider_key", existing.LeaseID)
+		}
+		labels["provider_key"] = existingValue
+	} else {
+		delete(labels, "provider_key")
+	}
+	server.Labels = labels
+	return server, nil
+}
+
 func (Provider) ServerTypeForConfig(cfg core.Config) string {
 	return core.AzureVMSizeCandidatesForConfig(cfg)[0]
 }

--- a/internal/providers/azure/provider_test.go
+++ b/internal/providers/azure/provider_test.go
@@ -2,10 +2,103 @@ package azure
 
 import (
 	"flag"
+	"strings"
 	"testing"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
+
+func TestPrepareLeaseClaimEndpointPreservesExactAzureIdentity(t *testing.T) {
+	provider := Provider{}
+	existing := core.LeaseClaim{
+		LeaseID:          "cbx_123456abcdef",
+		Slug:             "owned",
+		CloudID:          "crabbox-owned",
+		CloudImmutableID: "vmid-owned",
+		Labels: map[string]string{
+			"provider_key": core.ProviderKeyForLease("cbx_123456abcdef"),
+		},
+	}
+	server := core.Server{
+		CloudID:     "crabbox-owned",
+		ImmutableID: "vmid-owned",
+		Labels: map[string]string{
+			"lease":        existing.LeaseID,
+			"slug":         existing.Slug,
+			"provider_key": existing.Labels["provider_key"],
+		},
+	}
+	got, err := provider.PrepareLeaseClaimEndpoint(existing, "azure", existing.Slug, server, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.CloudID != existing.CloudID || got.ImmutableID != existing.CloudImmutableID {
+		t.Fatalf("server=%+v, want exact existing Azure identity", got)
+	}
+}
+
+func TestPrepareLeaseClaimEndpointRejectsIdentityRetargeting(t *testing.T) {
+	provider := Provider{}
+	existing := core.LeaseClaim{
+		LeaseID:          "cbx_123456abcdef",
+		Slug:             "owned",
+		CloudID:          "crabbox-owned",
+		CloudImmutableID: "vmid-owned",
+		Labels: map[string]string{
+			"provider_key": core.ProviderKeyForLease("cbx_123456abcdef"),
+		},
+	}
+	base := core.Server{
+		CloudID:     existing.CloudID,
+		ImmutableID: existing.CloudImmutableID,
+		Labels: map[string]string{
+			"lease":        existing.LeaseID,
+			"slug":         existing.Slug,
+			"provider_key": existing.Labels["provider_key"],
+		},
+	}
+	for _, test := range []struct {
+		name   string
+		mutate func(*core.Server)
+	}{
+		{name: "name", mutate: func(server *core.Server) { server.CloudID = "replacement" }},
+		{name: "immutable id", mutate: func(server *core.Server) { server.ImmutableID = "vmid-replacement" }},
+		{name: "provider key", mutate: func(server *core.Server) { server.Labels["provider_key"] = "wrong" }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			server := base
+			server.Labels = map[string]string{}
+			for key, value := range base.Labels {
+				server.Labels[key] = value
+			}
+			test.mutate(&server)
+			_, err := provider.PrepareLeaseClaimEndpoint(existing, "azure", existing.Slug, server, true)
+			if err == nil || !strings.Contains(err.Error(), "refusing to rewrite Azure") {
+				t.Fatalf("err=%v, want identity retarget rejection", err)
+			}
+		})
+	}
+}
+
+func TestPrepareLeaseClaimEndpointDoesNotPromoteLegacyClaim(t *testing.T) {
+	existing := core.LeaseClaim{LeaseID: "cbx_123456abcdef", Slug: "legacy", CloudID: "crabbox-legacy"}
+	server := core.Server{
+		CloudID:     existing.CloudID,
+		ImmutableID: "vmid-later",
+		Labels: map[string]string{
+			"lease":        existing.LeaseID,
+			"slug":         existing.Slug,
+			"provider_key": core.ProviderKeyForLease(existing.LeaseID),
+		},
+	}
+	got, err := (Provider{}).PrepareLeaseClaimEndpoint(existing, "azure", existing.Slug, server, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ImmutableID != "" || got.Labels["provider_key"] != "" {
+		t.Fatalf("server=%+v, want legacy claim metadata left unpromoted", got)
+	}
+}
 
 func TestIsCrabboxAzureLeaseRequiresCanonicalTags(t *testing.T) {
 	t.Parallel()

--- a/scripts/live-smoke.sh
+++ b/scripts/live-smoke.sh
@@ -1195,6 +1195,10 @@ if has_provider hetzner; then
   provider_smoke hetzner --class "${CRABBOX_LIVE_HETZNER_CLASS:-standard}" --ttl 15m --idle-timeout 2m
 fi
 
+if has_provider azure; then
+  provider_smoke azure --type "${CRABBOX_LIVE_AZURE_TYPE:-Standard_D2s_v5}" --ttl 20m --idle-timeout 5m
+fi
+
 if has_provider scaleway; then
   "$root/scripts/live-scaleway-smoke.sh"
 fi

--- a/scripts/live-smoke.test.js
+++ b/scripts/live-smoke.test.js
@@ -1803,6 +1803,25 @@ esac
   assert.doesNotMatch(crabboxCalls, /--provider morph/);
   assert.doesNotMatch(result.stderr, /CRABBOX_MORPH_API_KEY|MORPH_API_KEY|morph\.apiKey/);
 
+  const azureResult = spawnSync("bash", ["scripts/live-smoke.sh"], {
+    cwd: repoRoot,
+    env: {
+      ...env,
+      PATH: `${bin}${path.delimiter}${env.PATH ?? ""}`,
+      CRABBOX_BIN: fakeCrabbox,
+      CRABBOX_FAKE_LOG: crabboxLog,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_COORDINATOR: "0",
+      CRABBOX_LIVE_PROVIDERS: "azure",
+      CRABBOX_LIVE_AZURE_TYPE: "Standard_D4ads_v6",
+      CRABBOX_LIVE_REPO: repoRoot,
+    },
+    encoding: "utf8",
+  });
+  assert.equal(azureResult.status, 0, azureResult.stdout + azureResult.stderr);
+  const azureCalls = fs.readFileSync(crabboxLog, "utf8");
+  assert.match(azureCalls, /warmup --provider azure --type Standard_D4ads_v6 --ttl 20m --idle-timeout 5m/);
+
   const failedAudit = spawnSync("bash", ["scripts/live-smoke.sh"], {
     cwd: repoRoot,
     env: {


### PR DESCRIPTION
Closes https://github.com/openclaw/crabbox/issues/975

## Summary

- require direct Azure release and cleanup to hold an exact unchanged local claim bound to subscription, resource group, VM name, immutable VM ID, lease, slug, and provider key
- capture immutable NIC, public IP, managed disk, and quarantine NSG identities in that claim before deleting the VM
- resume interrupted manual release or automatic cleanup after the VM disappears, while rejecting same-name replacements and stale/legacy claims
- add Azure to the top-level live-smoke matrix and document the ownership boundary

## Verification

- `go vet ./...`
- `go test -race ./...`
- `node --test scripts/*.test.js`
- `scripts/test-provider-lifecycles.sh`
- `scripts/check-docs.sh`
- `node scripts/build-docs-site.mjs`
- Worker: format, lint, typecheck, 869 tests, and Wrangler dry-run build under Node 24
- AutoReview: clean, no accepted/actionable findings

## Authenticated Azure proof

Exact commit: `fa8bb412c1d724eb1ea5d8463e65116d34e85647`

- subscription-scoped create in `eastus2`, resource group `crabbox-leases`
- lease `cbx_40e92c3f2ce5`, VM `crabbox-tidal-krill-ee61-056dc804`, type `Standard_D4ads_v6`
- synced the 1,383-file Crabbox repository and ran the requested command successfully on Linux x86_64
- normal stop exercised the exact-claim deletion path
- verified zero exact-name Azure resource residue, zero local claim residue, and zero local key residue
- verified the shared NSG managed rule names and CIDRs were unchanged after cleanup
