### PR TITLE
fix: bind Azure disk cleanup to durable claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Bound coordinator Azure managed-disk cleanup to a durable immutable disk claim captured from the live VM association, preventing stale adopted ownership tags from authorizing deletion. Thanks @coygeek.
 - Required direct Azure release and cleanup to hold an unchanged subscription-, resource-group-, VM-name-, immutable-VM-, lease-, slug-, and provider-key-bound local claim across deletion, with durable companion-resource identities for interruption-safe cleanup. Thanks @coygeek.
 - Required direct GCP release and cleanup to hold an unchanged project-, zone-, name-, numeric-instance-, lease-, slug-, and provider-key-bound local claim across deletion. Thanks @coygeek.
 - Prevented repository-defined External lifecycle commands from placing inherited `external.config` values on process arguments without an exact, trusted non-secret argv contract. Thanks @coygeek.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -572,6 +572,10 @@ bin/crabbox inspect --id blue-lobster --json
 bin/crabbox stop blue-lobster
 ```
 
+Azure release persists an immutable managed-disk cleanup claim before deleting
+the VM. Retries use that durable claim and recheck any live disk attachment;
+they never treat names or Crabbox-written ownership tags as sufficient proof.
+
 Trusted operators can use `crabbox admin release` or `crabbox admin delete --force` for stuck leases.
 
 After AWS credential or account rotation, scan old provider accounts directly for Crabbox-tagged EC2 instances that the current coordinator can no longer see:

--- a/docs/security.md
+++ b/docs/security.md
@@ -534,6 +534,11 @@ Provider tags discover candidates and explain why they look stale, but do not
 authorize a destructive action. Automatic AWS or Azure deletion requires an
 exact retained coordinator lease binding for the same provider resource and
 region; EC2 Mac host release likewise requires an exact retained host binding.
+Before coordinator Azure cleanup deletes a VM, it also persists the managed
+disk's immutable ID while the live `managedBy` association still matches that
+VM. Later disk deletion revalidates that identity and any current attachment;
+an interrupted cleanup may continue after the VM is gone without trusting
+self-written tags, while missing or mismatched claims fail closed.
 Tag-only and legacy candidates remain report-only. Sweeps skip `keep=true`
 resources and apply a grace window before reporting missing labels or stale
 lease mappings.

--- a/worker/src/azure.ts
+++ b/worker/src/azure.ts
@@ -48,6 +48,12 @@ const LEGACY_AZURE_NOBLE_GEN2_IMAGE =
 const DEFAULT_AZURE_WINDOWS_IMAGE =
   "MicrosoftWindowsServer:windowsserver2022:2022-datacenter-smalldisk-g2:latest";
 
+function azureOwnedDeleteClaimKey(providerScope: string, cloudID: string, leaseID: string): string {
+  return ["provider:azure:delete-claim", providerScope, cloudID, leaseID]
+    .map((part) => encodeURIComponent(part))
+    .join(":");
+}
+
 interface TokenCache {
   token: string;
   expiresAt: number;
@@ -107,6 +113,7 @@ interface AzureDisk {
   name?: string;
   managedBy?: string;
   tags?: Record<string, string>;
+  properties?: { uniqueId?: string };
 }
 
 interface AzureOwnedDeleteResources {
@@ -114,6 +121,30 @@ interface AzureOwnedDeleteResources {
   nic: boolean;
   pip: boolean;
   disk: boolean;
+}
+
+interface AzureOwnedDeleteInspection extends AzureOwnedDeleteResources {
+  diskResource?: AzureDisk;
+}
+
+interface AzureOwnedDeleteClaim {
+  version: 1;
+  provider: "azure";
+  leaseID: string;
+  slug: string;
+  owner: string;
+  cloudID: string;
+  providerScope: string;
+  disk?: {
+    resourceID: string;
+    uniqueID: string;
+  };
+}
+
+export interface AzureOwnedDeleteClaimStorage {
+  get<T>(key: string): Promise<T | undefined>;
+  put<T>(key: string, value: T): Promise<void>;
+  delete(key: string): Promise<unknown>;
 }
 
 interface AzureSecurityRule {
@@ -177,6 +208,7 @@ export class AzureClient {
   private readonly deferredCleanup:
     | ((request: AzureDeferredCleanupRequest) => Promise<void>)
     | undefined;
+  private readonly ownedDeleteClaimStorage: AzureOwnedDeleteClaimStorage | undefined;
   fetcher: typeof fetch = (input, init) => fetch(input, init);
 
   constructor(
@@ -188,6 +220,7 @@ export class AzureClient {
       subscription?: string;
       resourceGroup?: string;
       deferredCleanup?: (request: AzureDeferredCleanupRequest) => Promise<void>;
+      ownedDeleteClaimStorage?: AzureOwnedDeleteClaimStorage;
     } = {},
   ) {
     this.env = env;
@@ -213,6 +246,7 @@ export class AzureClient {
     if (this.sshCIDRs.length === 0) this.sshCIDRs.push("0.0.0.0/0");
     this.defaultLocation = options.location || env.CRABBOX_AZURE_LOCATION?.trim() || "eastus";
     this.deferredCleanup = options.deferredCleanup;
+    this.ownedDeleteClaimStorage = options.ownedDeleteClaimStorage;
   }
 
   async listCrabboxServers(): Promise<ProviderMachine[]> {
@@ -308,6 +342,7 @@ export class AzureClient {
       vnet: string;
       nsg: string;
       deferredCleanup?: (request: AzureDeferredCleanupRequest) => Promise<void>;
+      ownedDeleteClaimStorage?: AzureOwnedDeleteClaimStorage;
     } = {
       location,
       vnet: multiRegion ? azureRegionalName(this.vnet, location) : this.vnet,
@@ -315,6 +350,9 @@ export class AzureClient {
     };
     if (this.deferredCleanup) {
       options.deferredCleanup = this.deferredCleanup;
+    }
+    if (this.ownedDeleteClaimStorage) {
+      options.ownedDeleteClaimStorage = this.ownedDeleteClaimStorage;
     }
     return new AzureClient(this.env, options);
   }
@@ -447,14 +485,27 @@ export class AzureClient {
         `refusing to delete Azure lease ${lease.id}: stored provider scope does not match the cleanup client`,
       );
     }
+    const claimKey = azureOwnedDeleteClaimKey(this.providerScope(), lease.cloudID, lease.id);
+    let claim = await this.ownedDeleteClaimStorage?.get<AzureOwnedDeleteClaim>(claimKey);
+    if (!claim) {
+      const inspection = await this.ownedDeleteResources(lease, { prepareClaim: true });
+      claim = this.ownedDeleteClaim(lease, inspection.diskResource);
+      await this.ownedDeleteClaimStorage?.put(claimKey, claim);
+    }
+    this.requireOwnedDeleteClaim(lease, claim);
+
     const order: (keyof AzureOwnedDeleteResources)[] = ["vm", "nic", "pip", "disk"];
     for (const kind of order) {
       for (let attempt = 0; ; attempt += 1) {
         // Re-read every surviving resource before each destructive operation so
         // a same-name replacement cannot inherit authorization from an older read.
         // oxlint-disable-next-line eslint/no-await-in-loop -- every delete requires fresh ownership proof.
-        const resources = await this.ownedDeleteResources(lease);
-        if (!resources.vm && !resources.nic && !resources.pip && !resources.disk) return;
+        const resources = await this.ownedDeleteResources(lease, { claim });
+        if (!resources.vm && !resources.nic && !resources.pip && !resources.disk) {
+          // oxlint-disable-next-line eslint/no-await-in-loop -- clear only after the fresh inventory proves cleanup complete.
+          await this.ownedDeleteClaimStorage?.delete(claimKey);
+          return;
+        }
         if (!resources[kind]) break;
         const selected: AzureOwnedDeleteResources = {
           vm: false,
@@ -476,17 +527,19 @@ export class AzureClient {
         await sleep(DELETE_RETRY_DELAY_MS);
       }
     }
+    await this.ownedDeleteClaimStorage?.delete(claimKey);
   }
 
   private async ownedDeleteResources(
     lease: Pick<LeaseRecord, "id" | "slug" | "provider" | "cloudID" | "owner">,
-  ): Promise<AzureOwnedDeleteResources> {
+    options: { claim?: AzureOwnedDeleteClaim; prepareClaim?: boolean } = {},
+  ): Promise<AzureOwnedDeleteInspection> {
     const name = lease.cloudID;
     const vmResourcePath = vmPath(this.resourceGroup, name);
     const nicResourcePath = networkPath(this.resourceGroup, "networkInterfaces", `${name}-nic`);
     const pipResourcePath = networkPath(this.resourceGroup, "publicIPAddresses", `${name}-pip`);
     const diskResourcePath = `/resourceGroups/${this.resourceGroup}/providers/Microsoft.Compute/disks/${name}-osdisk`;
-    const [vm, nic, pip, disk] = await Promise.all([
+    const [vm, nic, pip, initialDisk] = await Promise.all([
       this.ownedResource<AzureVM>(vmResourcePath, API_VERSIONS.compute, "virtualMachines", name),
       this.ownedResource<AzureNIC>(
         nicResourcePath,
@@ -515,6 +568,7 @@ export class AzureClient {
     const expectedNICID = this.resourceID(nicResourcePath);
     const expectedPIPID = this.resourceID(pipResourcePath);
     const expectedDiskID = this.resourceID(diskResourcePath);
+    const vmDiskID = vm?.properties?.storageProfile?.osDisk?.managedDisk?.id;
     if (
       vm &&
       !vm.properties?.networkProfile?.networkInterfaces?.some((item) =>
@@ -536,9 +590,21 @@ export class AzureClient {
         `refusing to delete Azure resources for ${name}: NIC does not own ${name}-pip`,
       );
     }
+    if (options.prepareClaim && vmDiskID) {
+      if (!azureResourceIDEqual(vmDiskID, expectedDiskID)) {
+        throw new Error(
+          `refusing to delete Azure resources for ${name}: VM does not own ${name}-osdisk`,
+        );
+      }
+      if (!initialDisk) {
+        throw new Error(
+          `refusing to delete Azure resources for ${name}: managed OS disk identity is not yet available`,
+        );
+      }
+    }
 
+    let disk = initialDisk;
     if (disk) {
-      const vmDiskID = vm?.properties?.storageProfile?.osDisk?.managedDisk?.id;
       this.requireResourceIdentity("disk", disk, diskResourcePath, lease.id);
       if (vm && !azureResourceIDEqual(vmDiskID, expectedDiskID)) {
         throw new Error(
@@ -553,6 +619,7 @@ export class AzureClient {
           );
         }
         if (
+          !options.prepareClaim ||
           !vm ||
           !azureResourceIDEqual(vmDiskID, expectedDiskID) ||
           !azureResourceIDEqual(disk.managedBy, this.resourceID(vmResourcePath))
@@ -561,20 +628,128 @@ export class AzureClient {
             `refusing to delete Azure disk ${name}-osdisk: ownership does not match lease ${lease.id}`,
           );
         }
+        const uniqueID = this.requireDiskUniqueID(disk, lease.id);
         const ownershipTags = azureOwnershipTags(vm.tags ?? {}, lease);
         // Azure-created OS disks do not inherit VM tags. Bind the disk while
-        // the verified VM association is live so a later retry remains safe.
+        // the verified VM association is live. The immutable identity check
+        // prevents a concurrent same-name replacement from receiving the claim.
         await this.arm("PATCH", diskResourcePath, API_VERSIONS.disks, {
           tags: { ...disk.tags, ...ownershipTags },
         });
         const taggedDisk = await this.arm<AzureDisk>("GET", diskResourcePath, API_VERSIONS.disks);
         this.requireOwnedResource("disk", taggedDisk, diskResourcePath, lease);
+        if (
+          this.requireDiskUniqueID(taggedDisk, lease.id) !== uniqueID ||
+          !azureResourceIDEqual(taggedDisk.managedBy, this.resourceID(vmResourcePath))
+        ) {
+          throw new Error(
+            `refusing to delete Azure disk ${name}-osdisk: live association changed while binding lease ${lease.id}`,
+          );
+        }
+        disk = taggedDisk;
       } else {
         this.requireOwnedResource("disk", disk, diskResourcePath, lease);
       }
+
+      const uniqueID = this.requireDiskUniqueID(disk, lease.id);
+      if (options.prepareClaim) {
+        if (
+          !vm ||
+          !azureResourceIDEqual(vmDiskID, expectedDiskID) ||
+          !azureResourceIDEqual(disk.managedBy, this.resourceID(vmResourcePath))
+        ) {
+          throw new Error(
+            `refusing to delete Azure disk ${name}-osdisk: live association does not match lease ${lease.id}`,
+          );
+        }
+      } else {
+        const claimedDisk = options.claim?.disk;
+        if (
+          !claimedDisk ||
+          !azureResourceIDEqual(claimedDisk.resourceID, expectedDiskID) ||
+          claimedDisk.uniqueID !== uniqueID
+        ) {
+          throw new Error(
+            `refusing to delete Azure disk ${name}-osdisk: immutable identity does not match lease ${lease.id}`,
+          );
+        }
+        if (
+          (vm && !azureResourceIDEqual(disk.managedBy, this.resourceID(vmResourcePath))) ||
+          (!vm &&
+            disk.managedBy &&
+            !azureResourceIDEqual(disk.managedBy, this.resourceID(vmResourcePath)))
+        ) {
+          throw new Error(
+            `refusing to delete Azure disk ${name}-osdisk: live association does not match lease ${lease.id}`,
+          );
+        }
+      }
     }
 
-    return { vm: Boolean(vm), nic: Boolean(nic), pip: Boolean(pip), disk: Boolean(disk) };
+    return {
+      vm: Boolean(vm),
+      nic: Boolean(nic),
+      pip: Boolean(pip),
+      disk: Boolean(disk),
+      ...(disk ? { diskResource: disk } : {}),
+    };
+  }
+
+  private ownedDeleteClaim(
+    lease: Pick<LeaseRecord, "id" | "slug" | "provider" | "cloudID" | "owner">,
+    disk: AzureDisk | undefined,
+  ): AzureOwnedDeleteClaim {
+    const diskResourcePath = `/resourceGroups/${this.resourceGroup}/providers/Microsoft.Compute/disks/${lease.cloudID}-osdisk`;
+    return {
+      version: 1,
+      provider: "azure",
+      leaseID: lease.id,
+      slug: lease.slug ?? "",
+      owner: lease.owner,
+      cloudID: lease.cloudID,
+      providerScope: this.providerScope(),
+      ...(disk
+        ? {
+            disk: {
+              resourceID: this.resourceID(diskResourcePath),
+              uniqueID: this.requireDiskUniqueID(disk, lease.id),
+            },
+          }
+        : {}),
+    };
+  }
+
+  private requireOwnedDeleteClaim(
+    lease: Pick<LeaseRecord, "id" | "slug" | "provider" | "cloudID" | "owner">,
+    claim: AzureOwnedDeleteClaim,
+  ): void {
+    const expectedDiskID = this.resourceID(
+      `/resourceGroups/${this.resourceGroup}/providers/Microsoft.Compute/disks/${lease.cloudID}-osdisk`,
+    );
+    if (
+      claim.version !== 1 ||
+      claim.provider !== "azure" ||
+      claim.leaseID !== lease.id ||
+      claim.slug !== (lease.slug ?? "") ||
+      claim.owner !== lease.owner ||
+      claim.cloudID !== lease.cloudID ||
+      claim.providerScope !== this.providerScope() ||
+      (claim.disk &&
+        (!azureResourceIDEqual(claim.disk.resourceID, expectedDiskID) ||
+          !claim.disk.uniqueID.trim()))
+    ) {
+      throw new Error(`refusing to delete Azure lease ${lease.id}: durable cleanup claim mismatch`);
+    }
+  }
+
+  private requireDiskUniqueID(disk: AzureDisk, leaseID: string): string {
+    const uniqueID = disk.properties?.uniqueId?.trim();
+    if (!uniqueID) {
+      throw new Error(
+        `refusing to delete Azure disk ${disk.name ?? "unknown"}: immutable identity is missing for lease ${leaseID}`,
+      );
+    }
+    return uniqueID;
   }
 
   private async ownedResource<T>(

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -10960,6 +10960,7 @@ export class FleetCoordinator {
             location: record.location,
             subscription: scope.subscription,
             resourceGroup: scope.resourceGroup,
+            ownedDeleteClaimStorage: this.state.storage,
           }).deleteOwnedServer(lease);
         } catch (error) {
           await this.state.runExclusive(async () => {
@@ -16759,6 +16760,7 @@ interface ProviderStateStorage {
   get<T>(key: string): Promise<T | undefined>;
   put<T>(key: string, value: T): Promise<void>;
   list<T>(options?: { prefix?: string }): Promise<Map<string, T>>;
+  delete(key: string): Promise<unknown>;
 }
 
 interface ProviderAccessContext {
@@ -16943,6 +16945,7 @@ export class AzureProvider implements CloudProvider {
     this.clientValue ??= new AzureClient(this.env, {
       ...(this.location ? { location: this.location } : {}),
       ...(this.deferredCleanup ? { deferredCleanup: this.deferredCleanup } : {}),
+      ...(this.storage ? { ownedDeleteClaimStorage: this.storage } : {}),
     });
     return this.clientValue;
   }
@@ -17015,6 +17018,7 @@ export class AzureProvider implements CloudProvider {
       ...(this.deferredCleanup ? { deferredCleanup: this.deferredCleanup } : {}),
       subscription: scope.subscription,
       resourceGroup: scope.resourceGroup,
+      ...(this.storage ? { ownedDeleteClaimStorage: this.storage } : {}),
     }).deleteOwnedServer(lease);
   }
 

--- a/worker/test/azure.test.ts
+++ b/worker/test/azure.test.ts
@@ -16,6 +16,7 @@ import {
   isRetryableProvisioningError,
   preserveNonCrabboxRules,
   summarizeAzureErrorBody,
+  type AzureOwnedDeleteClaimStorage,
   type AzureDeferredCleanupRequest,
 } from "../src/azure";
 import type { LeaseConfig } from "../src/config";
@@ -61,6 +62,42 @@ function ownedAzureTags(overrides: Record<string, string> = {}): Record<string, 
     slug: "blue-lobster",
     ...overrides,
   };
+}
+
+function memoryAzureDeleteClaimStorage(): {
+  records: Map<string, unknown>;
+  putKeys: string[];
+  storage: AzureOwnedDeleteClaimStorage;
+} {
+  const records = new Map<string, unknown>();
+  const putKeys: string[] = [];
+  return {
+    records,
+    putKeys,
+    storage: {
+      get: async <T>(key: string) => records.get(key) as T | undefined,
+      put: async <T>(key: string, value: T) => {
+        putKeys.push(key);
+        records.set(key, value);
+      },
+      delete: async (key: string) => {
+        records.delete(key);
+      },
+    },
+  };
+}
+
+function azureResourceNotFoundResponse(url: URL): Response {
+  const resource = url.pathname.slice(url.pathname.indexOf("/providers/") + 11);
+  return new Response(
+    JSON.stringify({
+      error: {
+        code: "ResourceNotFound",
+        message: `The Resource '${resource}' was not found.`,
+      },
+    }),
+    { status: 404 },
+  );
 }
 
 function testLeaseConfig(overrides: Partial<LeaseConfig> = {}): LeaseConfig {
@@ -582,7 +619,10 @@ describe("azure provider", () => {
         return Response.json({
           id: url.pathname,
           name: "crabbox-blue-lobster-osdisk",
+          managedBy:
+            "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/virtualMachines/crabbox-blue-lobster",
           tags: ownedAzureTags(),
+          properties: { uniqueId: "disk-unique-id" },
         });
       }
       return new Response("unexpected request", { status: 500 });
@@ -592,7 +632,41 @@ describe("azure provider", () => {
     expect(deletes).toHaveLength(4);
   });
 
-  it("resumes verified Azure companion cleanup after the VM is gone", async () => {
+  it("scopes durable Azure cleanup claims to the exact VM attempt", async () => {
+    const { putKeys, storage } = memoryAzureDeleteClaimStorage();
+    for (const cloudID of ["crabbox-blue-lobster-attempt-1", "crabbox-blue-lobster-attempt-2"]) {
+      const client = new AzureClient(baseEnv, { ownedDeleteClaimStorage: storage });
+      (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
+        token: "test-token",
+        expiresAt: Date.now() + 3_600_000,
+      };
+      client.fetcher = async (input) => azureResourceNotFoundResponse(new URL(String(input)));
+      // oxlint-disable-next-line eslint/no-await-in-loop -- preserve deterministic claim-write order for the assertion.
+      await expect(
+        client.deleteOwnedServer({ ...ownedAzureLease(), cloudID }),
+      ).resolves.toBeUndefined();
+    }
+
+    expect(putKeys).toHaveLength(2);
+    expect(new Set(putKeys).size).toBe(2);
+  });
+
+  it("keeps durable cleanup claim storage on regional Azure fallback clients", () => {
+    const { storage } = memoryAzureDeleteClaimStorage();
+    const client = new AzureClient(baseEnv, { ownedDeleteClaimStorage: storage });
+    const regional = (
+      client as unknown as {
+        clientForLocation(location: string, multiRegion: boolean): AzureClient;
+      }
+    ).clientForLocation("westus3", true);
+
+    expect(
+      (regional as unknown as { ownedDeleteClaimStorage?: AzureOwnedDeleteClaimStorage })
+        .ownedDeleteClaimStorage,
+    ).toBe(storage);
+  });
+
+  it("does not delete an Azure VM before its referenced managed disk identity is visible", async () => {
     const client = new AzureClient(baseEnv);
     (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
       token: "test-token",
@@ -601,43 +675,141 @@ describe("azure provider", () => {
     const deletes: string[] = [];
     client.fetcher = async (input, init) => {
       const url = new URL(String(input));
-      const method = init?.method ?? "GET";
-      if (method === "DELETE") {
+      if (init?.method === "DELETE") {
         deletes.push(url.pathname);
         return new Response(null, { status: 204 });
       }
-      if (url.pathname.endsWith("/virtualMachines/crabbox-blue-lobster")) {
-        return new Response(
-          JSON.stringify({
-            error: {
-              code: "ResourceNotFound",
-              message:
-                "The Resource 'Microsoft.Compute/virtualMachines/crabbox-blue-lobster' was not found.",
+      if (url.pathname.includes("/virtualMachines/")) {
+        return Response.json({
+          id: url.pathname,
+          name: "crabbox-blue-lobster",
+          tags: ownedAzureTags(),
+          properties: {
+            networkProfile: {
+              networkInterfaces: [
+                {
+                  id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/networkInterfaces/crabbox-blue-lobster-nic",
+                },
+              ],
             },
-          }),
-          { status: 404 },
-        );
+            storageProfile: {
+              osDisk: {
+                managedDisk: {
+                  id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/disks/crabbox-blue-lobster-osdisk",
+                },
+              },
+            },
+          },
+        });
       }
-      const name = url.pathname.slice(url.pathname.lastIndexOf("/") + 1);
-      const properties = url.pathname.includes("/networkInterfaces/")
-        ? {
-            ipConfigurations: [
-              {
-                properties: {
-                  publicIPAddress: {
-                    id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/publicIPAddresses/crabbox-blue-lobster-pip",
+      return azureResourceNotFoundResponse(url);
+    };
+
+    await expect(client.deleteOwnedServer(ownedAzureLease())).rejects.toThrow(
+      "managed OS disk identity is not yet available",
+    );
+    expect(deletes).toEqual([]);
+  });
+
+  it("resumes verified Azure companion cleanup from a durable claim after the VM is gone", async () => {
+    const { records, storage } = memoryAzureDeleteClaimStorage();
+    const deleted = new Set<string>();
+    const deletes: string[] = [];
+    let failNICDelete = true;
+    const client = (): AzureClient => {
+      const value = new AzureClient(baseEnv, { ownedDeleteClaimStorage: storage });
+      (value as unknown as { cache: { token: string; expiresAt: number } }).cache = {
+        token: "test-token",
+        expiresAt: Date.now() + 3_600_000,
+      };
+      value.fetcher = async (input, init) => {
+        const url = new URL(String(input));
+        const method = init?.method ?? "GET";
+        if (method === "DELETE") {
+          deletes.push(url.pathname);
+          if (failNICDelete && url.pathname.includes("/networkInterfaces/")) {
+            return new Response("injected interruption", { status: 400 });
+          }
+          deleted.add(url.pathname);
+          return new Response(null, { status: 204 });
+        }
+        if (deleted.has(url.pathname)) {
+          const resource = url.pathname.slice(url.pathname.indexOf("/providers/") + 11);
+          return new Response(
+            JSON.stringify({
+              error: {
+                code: "ResourceNotFound",
+                message: `The Resource '${resource}' was not found.`,
+              },
+            }),
+            { status: 404 },
+          );
+        }
+        const name = url.pathname.slice(url.pathname.lastIndexOf("/") + 1);
+        const isVM = url.pathname.includes("/virtualMachines/");
+        const isNIC = url.pathname.includes("/networkInterfaces/");
+        const isDisk = url.pathname.includes("/disks/");
+        const properties = isVM
+          ? {
+              networkProfile: {
+                networkInterfaces: [
+                  {
+                    id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/networkInterfaces/crabbox-blue-lobster-nic",
+                  },
+                ],
+              },
+              storageProfile: {
+                osDisk: {
+                  managedDisk: {
+                    id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/disks/crabbox-blue-lobster-osdisk",
                   },
                 },
               },
-            ],
-          }
-        : {};
-      return Response.json({ id: url.pathname, name, tags: ownedAzureTags(), properties });
+            }
+          : isNIC
+            ? {
+                ipConfigurations: [
+                  {
+                    properties: {
+                      publicIPAddress: {
+                        id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/publicIPAddresses/crabbox-blue-lobster-pip",
+                      },
+                    },
+                  },
+                ],
+              }
+            : isDisk
+              ? { uniqueId: "disk-unique-id" }
+              : {};
+        return Response.json({
+          id: url.pathname,
+          name,
+          managedBy:
+            isDisk &&
+            !deleted.has(
+              url.pathname.replace("/disks/", "/virtualMachines/").replace("-osdisk", ""),
+            )
+              ? "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/virtualMachines/crabbox-blue-lobster"
+              : undefined,
+          tags: ownedAzureTags(),
+          properties,
+        });
+      };
+      return value;
     };
 
-    await expect(client.deleteOwnedServer(ownedAzureLease())).resolves.toBeUndefined();
-    expect(deletes).toHaveLength(3);
-    expect(deletes.some((path) => path.includes("/virtualMachines/"))).toBe(false);
+    await expect(client().deleteOwnedServer(ownedAzureLease())).rejects.toThrow(
+      "injected interruption",
+    );
+    expect(records.size).toBe(1);
+    expect(deleted.size).toBe(1);
+    expect([...deleted][0]).toContain("/virtualMachines/");
+
+    failNICDelete = false;
+    await expect(client().deleteOwnedServer(ownedAzureLease())).resolves.toBeUndefined();
+    expect(records.size).toBe(0);
+    expect(deletes.filter((path) => path.includes("/virtualMachines/"))).toHaveLength(1);
+    expect(deleted.size).toBe(4);
   });
 
   it("refuses all Azure deletion when a companion belongs to another lease", async () => {
@@ -686,7 +858,9 @@ describe("azure provider", () => {
                 },
               ],
             }
-          : {};
+          : url.pathname.includes("/disks/")
+            ? { uniqueId: "disk-unique-id" }
+            : {};
       return Response.json({ id: url.pathname, name, tags, properties });
     };
 
@@ -747,7 +921,9 @@ describe("azure provider", () => {
                 },
               ],
             }
-          : {};
+          : url.pathname.includes("/disks/")
+            ? { uniqueId: "disk-unique-id" }
+            : {};
       return Response.json({ id: url.pathname, name, managedBy, tags, properties });
     };
 
@@ -763,65 +939,74 @@ describe("azure provider", () => {
       {},
       "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/virtualMachines/crabbox-other",
     ],
-  ])("refuses to adopt an Azure disk with %s", async (_case, diskTags, diskManagedBy) => {
-    const client = new AzureClient(baseEnv);
-    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
-      token: "test-token",
-      expiresAt: Date.now() + 3_600_000,
-    };
-    const deletes: string[] = [];
-    client.fetcher = async (input, init) => {
-      const url = new URL(String(input));
-      if (init?.method === "DELETE") {
-        deletes.push(url.pathname);
-        return new Response(null, { status: 204 });
-      }
-      const name = url.pathname.slice(url.pathname.lastIndexOf("/") + 1);
-      const isDisk = url.pathname.includes("/disks/");
-      const properties = url.pathname.includes("/virtualMachines/")
-        ? {
-            networkProfile: {
-              networkInterfaces: [
-                {
-                  id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/networkInterfaces/crabbox-blue-lobster-nic",
-                },
-              ],
-            },
-            storageProfile: {
-              osDisk: {
-                managedDisk: {
-                  id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/disks/crabbox-blue-lobster-osdisk",
-                },
-              },
-            },
-          }
-        : url.pathname.includes("/networkInterfaces/")
+    [
+      "matching tags but wrong managedBy",
+      ownedAzureTags(),
+      "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/virtualMachines/crabbox-other",
+      "live association does not match",
+    ],
+  ])(
+    "refuses to adopt an Azure disk with %s",
+    async (_case, diskTags, diskManagedBy, expectedError = "ownership does not match") => {
+      const client = new AzureClient(baseEnv);
+      (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
+        token: "test-token",
+        expiresAt: Date.now() + 3_600_000,
+      };
+      const deletes: string[] = [];
+      client.fetcher = async (input, init) => {
+        const url = new URL(String(input));
+        if (init?.method === "DELETE") {
+          deletes.push(url.pathname);
+          return new Response(null, { status: 204 });
+        }
+        const name = url.pathname.slice(url.pathname.lastIndexOf("/") + 1);
+        const isDisk = url.pathname.includes("/disks/");
+        const properties = url.pathname.includes("/virtualMachines/")
           ? {
-              ipConfigurations: [
-                {
-                  properties: {
-                    publicIPAddress: {
-                      id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/publicIPAddresses/crabbox-blue-lobster-pip",
-                    },
+              networkProfile: {
+                networkInterfaces: [
+                  {
+                    id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/networkInterfaces/crabbox-blue-lobster-nic",
+                  },
+                ],
+              },
+              storageProfile: {
+                osDisk: {
+                  managedDisk: {
+                    id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/disks/crabbox-blue-lobster-osdisk",
                   },
                 },
-              ],
+              },
             }
-          : {};
-      return Response.json({
-        id: url.pathname,
-        name,
-        managedBy: isDisk ? diskManagedBy : undefined,
-        tags: isDisk ? diskTags : ownedAzureTags(),
-        properties,
-      });
-    };
+          : url.pathname.includes("/networkInterfaces/")
+            ? {
+                ipConfigurations: [
+                  {
+                    properties: {
+                      publicIPAddress: {
+                        id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/publicIPAddresses/crabbox-blue-lobster-pip",
+                      },
+                    },
+                  },
+                ],
+              }
+            : isDisk
+              ? { uniqueId: "disk-unique-id" }
+              : {};
+        return Response.json({
+          id: url.pathname,
+          name,
+          managedBy: isDisk ? diskManagedBy : undefined,
+          tags: isDisk ? diskTags : ownedAzureTags(),
+          properties,
+        });
+      };
 
-    await expect(client.deleteOwnedServer(ownedAzureLease())).rejects.toThrow(
-      "disk crabbox-blue-lobster-osdisk: ownership does not match",
-    );
-    expect(deletes).toEqual([]);
-  });
+      await expect(client.deleteOwnedServer(ownedAzureLease())).rejects.toThrow(expectedError);
+      expect(deletes).toEqual([]);
+    },
+  );
 
   it("revalidates Azure companions after deleting the VM", async () => {
     const client = new AzureClient(baseEnv);
@@ -855,6 +1040,7 @@ describe("azure provider", () => {
         vmDeleted && url.pathname.includes("/networkInterfaces/")
           ? ownedAzureTags({ lease: "cbx_000000000000" })
           : ownedAzureTags();
+      const isDisk = url.pathname.includes("/disks/");
       const properties = url.pathname.includes("/virtualMachines/")
         ? {
             networkProfile: {
@@ -884,8 +1070,18 @@ describe("azure provider", () => {
                 },
               ],
             }
-          : {};
-      return Response.json({ id: url.pathname, name, tags, properties });
+          : isDisk
+            ? { uniqueId: "disk-unique-id" }
+            : {};
+      return Response.json({
+        id: url.pathname,
+        name,
+        managedBy: isDisk
+          ? "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/virtualMachines/crabbox-blue-lobster"
+          : undefined,
+        tags,
+        properties,
+      });
     };
 
     await expect(client.deleteOwnedServer(ownedAzureLease())).rejects.toThrow(
@@ -915,6 +1111,7 @@ describe("azure provider", () => {
         );
       }
       const name = url.pathname.slice(url.pathname.lastIndexOf("/") + 1);
+      const isDisk = url.pathname.includes("/disks/");
       const properties = url.pathname.includes("/virtualMachines/")
         ? {
             networkProfile: {
@@ -944,8 +1141,18 @@ describe("azure provider", () => {
                 },
               ],
             }
-          : {};
-      return Response.json({ id: url.pathname, name, tags: ownedAzureTags(), properties });
+          : isDisk
+            ? { uniqueId: "disk-unique-id" }
+            : {};
+      return Response.json({
+        id: url.pathname,
+        name,
+        managedBy: isDisk
+          ? "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/virtualMachines/crabbox-blue-lobster"
+          : undefined,
+        tags: ownedAzureTags(),
+        properties,
+      });
     };
 
     await expect(client.deleteOwnedServer(ownedAzureLease())).rejects.toThrow(


### PR DESCRIPTION
## Summary

- bind Azure managed-disk cleanup to a durable ownership claim containing the exact provider scope, VM attempt, disk ARM ID, and immutable disk unique ID
- adopt missing disk tags only while a live VM-to-disk association can be revalidated; fail closed when disk identity or association cannot be proved
- preserve claims across interrupted cleanup and regional/deferred clients, clearing them only after fresh inventory proves zero residue
- document the durable cleanup boundary and add contributor credit to the changelog

Closes https://github.com/openclaw/crabbox/issues/966

## Verification

- AutoReview: clean after three passes; fixed claim-key collisions, missing-disk fail-open behavior, and dropped regional storage propagation
- focused Azure Worker tests: 54 passed
- full Worker suite: 870 passed, 3 skipped; typecheck, lint, format, and Wrangler dry-run build passed
- Go: `go vet ./...` and `go test -race ./...` passed
- docs command surface, provider matrix, 210-link validation, and site build passed
- live Azure ARM canary on exact commit `3f97e2cd05644c6d4f5d56f4419d1bc2668474bc`: provisioned lease `cbx_3d6dd2ef3470` in `eastus2`, completed SSH workload proof, removed disk tags to exercise adoption, injected a failure after VM deletion, resumed with a new client from the durable claim, and independently verified VM/NIC/public-IP/disk residue `0`, claim residue `0`, and baseline NSG rules restored
