### PR TITLE
fix: revalidate GitHub bridge agent tickets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Revalidated non-admin GitHub grants when WebVNC and Code agent tickets are consumed, matching the existing egress fail-closed boundary after logout, emergency revocation, membership loss, or membership-check failure. Thanks @coygeek.
 - Bound coordinator Azure managed-disk cleanup to a durable immutable disk claim captured from the live VM association, preventing stale adopted ownership tags from authorizing deletion. Thanks @coygeek.
 - Required direct Azure release and cleanup to hold an unchanged subscription-, resource-group-, VM-name-, immutable-VM-, lease-, slug-, and provider-key-bound local claim across deletion, with durable companion-resource identities for interruption-safe cleanup. Thanks @coygeek.
 - Required direct GCP release and cleanup to hold an unchanged project-, zone-, name-, numeric-instance-, lease-, slug-, and provider-key-bound local claim across deletion. Thanks @coygeek.

--- a/docs/security.md
+++ b/docs/security.md
@@ -181,11 +181,12 @@ organization-bound principal also fail closed during restore and whenever lease
 sharing access shrinks.
 Non-admin GitHub WebVNC, Code, and egress sessions bind to the exact portal
 session and preserve only the encrypted GitHub credential from its signed user
-token. Active traffic rechecks portal logout and emergency user revocation, and
-revalidates GitHub membership under the configured membership-cache window.
-Membership errors fail closed. Restored legacy GitHub bridge attachments without
-a complete encrypted grant and portal-session binding close before carrying
-traffic; plaintext GitHub credentials are never stored in bridge state.
+token. Agent-ticket consumption and active traffic recheck portal logout and
+emergency user revocation, and revalidate GitHub membership under the configured
+membership-cache window. Membership errors fail closed. New or restored legacy
+GitHub bridge tickets and attachments without a complete encrypted grant and
+portal-session binding fail before carrying traffic; plaintext GitHub
+credentials are never stored in bridge state.
 Shared-operator requests do **not** trust caller-supplied `X-Crabbox-Owner` /
 `X-Crabbox-Org` headers — pin that automation's identity with
 `CRABBOX_SHARED_OWNER` (and `CRABBOX_DEFAULT_ORG`), or prefer per-user signed

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -295,7 +295,7 @@ interface CachedBridgeGrant extends CachedAdminGrant {
   githubGrant?: GitHubUserGrant;
 }
 
-interface WebVNCTicketRecord extends CachedAdminGrant {
+interface WebVNCTicketRecord extends CachedBridgeGrant {
   ticket: string;
   leaseID: string;
   owner: string;
@@ -315,7 +315,7 @@ interface NativeVNCTicketRecord {
   expiresAt: string;
 }
 
-interface CodeTicketRecord extends CachedAdminGrant {
+interface CodeTicketRecord extends CachedBridgeGrant {
   ticket: string;
   leaseID: string;
   owner: string;
@@ -7511,6 +7511,13 @@ export class FleetCoordinator {
     if (error) {
       return json({ error: "webvnc_unavailable", message: error }, { status: 409 });
     }
+    const bridgeGrant = await bridgeGrantForRequest(request, admin);
+    if (!bridgeGrant) {
+      return json(
+        { error: "user_session_invalid", message: "GitHub user session cannot be revalidated" },
+        { status: 401 },
+      );
+    }
     await this.cleanupExpiredWebVNCTickets();
     const now = new Date();
     const ticket: WebVNCTicketRecord = {
@@ -7519,7 +7526,7 @@ export class FleetCoordinator {
       owner: requestOwner(request),
       org: requestOrg(request, this.env),
       admin,
-      ...(await adminGrantForRequest(request, admin)),
+      ...bridgeGrant,
       createdAt: now.toISOString(),
       expiresAt: new Date(now.getTime() + webVNCTicketTTLSeconds * 1000).toISOString(),
     };
@@ -7799,6 +7806,13 @@ export class FleetCoordinator {
     if (error) {
       return json({ error: "code_unavailable", message: error }, { status: 409 });
     }
+    const bridgeGrant = await bridgeGrantForRequest(request, admin);
+    if (!bridgeGrant) {
+      return json(
+        { error: "user_session_invalid", message: "GitHub user session cannot be revalidated" },
+        { status: 401 },
+      );
+    }
     await this.cleanupExpiredCodeTickets();
     const now = new Date();
     const ticket: CodeTicketRecord = {
@@ -7807,7 +7821,7 @@ export class FleetCoordinator {
       owner: requestOwner(request),
       org: requestOrg(request, this.env),
       admin,
-      ...(await adminGrantForRequest(request, admin)),
+      ...bridgeGrant,
       createdAt: now.toISOString(),
       expiresAt: new Date(now.getTime() + codeTicketTTLSeconds * 1000).toISOString(),
     };
@@ -8925,6 +8939,25 @@ export class FleetCoordinator {
     return this.withBridgeTicketLock(() => this.consumeWebVNCTicketUnderLock(request, identifier));
   }
 
+  private async currentLeaseBridgeTicket<
+    T extends CachedBridgeGrant & { owner: string; org: string; admin?: boolean },
+  >(ticket: T, lease: LeaseRecord): Promise<T | undefined> {
+    const currentTicket =
+      ticket.admin === true
+        ? withCurrentAdminGrant(ticket, await this.currentAdminGrantValidation())
+        : ticket;
+    if (!this.leaseManagerAuthorized(lease, leaseBridgeTicketPrincipal(currentTicket))) {
+      return undefined;
+    }
+    if (
+      currentTicket.auth === "github" &&
+      (await this.githubBridgeGrantFailureReason(currentTicket))
+    ) {
+      return undefined;
+    }
+    return currentTicket;
+  }
+
   private async consumeWebVNCTicketUnderLock(
     request: Request,
     identifier: string,
@@ -8946,11 +8979,8 @@ export class FleetCoordinator {
     if (!lease || !identifierMatchesLease(identifier, lease)) {
       return { status: "not_found" };
     }
-    const currentTicket =
-      ticket.admin === true
-        ? withCurrentAdminGrant(ticket, await this.currentAdminGrantValidation())
-        : ticket;
-    if (!this.leaseManagerAuthorized(lease, leaseBridgeTicketPrincipal(currentTicket))) {
+    const currentTicket = await this.currentLeaseBridgeTicket(ticket, lease);
+    if (!currentTicket) {
       await this.state.storage.delete(key);
       return { status: "invalid" };
     }
@@ -8998,11 +9028,8 @@ export class FleetCoordinator {
     if (!lease || !identifierMatchesLease(identifier, lease)) {
       return { status: "not_found" };
     }
-    const currentTicket =
-      ticket.admin === true
-        ? withCurrentAdminGrant(ticket, await this.currentAdminGrantValidation())
-        : ticket;
-    if (!this.leaseManagerAuthorized(lease, leaseBridgeTicketPrincipal(currentTicket))) {
+    const currentTicket = await this.currentLeaseBridgeTicket(ticket, lease);
+    if (!currentTicket) {
       await this.state.storage.delete(key);
       return { status: "invalid" };
     }
@@ -9057,18 +9084,8 @@ export class FleetCoordinator {
     if (!lease || !identifierMatchesLease(identifier, lease)) {
       return { status: "not_found" };
     }
-    const currentTicket =
-      ticket.admin === true
-        ? withCurrentAdminGrant(ticket, await this.currentAdminGrantValidation())
-        : ticket;
-    if (!this.leaseManagerAuthorized(lease, leaseBridgeTicketPrincipal(currentTicket))) {
-      await this.state.storage.delete(key);
-      return { status: "invalid" };
-    }
-    if (
-      currentTicket.auth === "github" &&
-      (await this.githubBridgeGrantFailureReason(currentTicket))
-    ) {
+    const currentTicket = await this.currentLeaseBridgeTicket(ticket, lease);
+    if (!currentTicket) {
       await this.state.storage.delete(key);
       return { status: "invalid" };
     }

--- a/worker/test/coordinator-runtime.test.ts
+++ b/worker/test/coordinator-runtime.test.ts
@@ -339,7 +339,7 @@ describe("coordinator runtimes", () => {
     const runtime = new MemoryRuntime();
     const env = {
       CRABBOX_DEFAULT_ORG: "example-org",
-      CRABBOX_GITHUB_ADMIN_LOGINS: "admin",
+      CRABBOX_ADMIN_TOKEN: "admin-token",
     } as Env;
     const coordinator = new FleetCoordinator(runtime, env);
     const currentGrantVersion = await adminGrantVersion(env);
@@ -387,9 +387,9 @@ describe("coordinator runtimes", () => {
       "x-crabbox-owner": "admin@example.com",
       "x-crabbox-org": "example-org",
       "x-crabbox-admin": "true",
-      "x-crabbox-auth": "github",
-      "x-crabbox-github-login": "admin",
+      "x-crabbox-auth": "bearer",
       "x-crabbox-admin-grant-version": currentGrantVersion,
+      authorization: "Bearer admin-token",
     };
     const createTicket = async (
       kind: "webvnc" | "code",

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -17470,6 +17470,108 @@ describe("fleet lease identity and idle", () => {
     ).toEqual([]);
   });
 
+  it("revalidates non-admin GitHub grants when agent bridge tickets are consumed", async () => {
+    const storage = new MemoryStorage();
+    const env = {
+      CRABBOX_SESSION_SECRET: "session-secret",
+      CRABBOX_DEFAULT_ORG: "example-org",
+    } as Env;
+    const token = await issueUserToken(env, {
+      owner: "alice@example.com",
+      ownerSource: "github-verified-email",
+      org: "example-org",
+      login: "alice",
+      githubAccessToken: "github-access-token",
+    });
+    const payload = decodeUserTokenPayload(token);
+    const portalSessionHash = await sha256Hex(token);
+    const leaseID = "cbx_000000000001";
+    storage.seed(
+      `lease:${leaseID}`,
+      testLease({
+        id: leaseID,
+        slug: "blue-lobster",
+        owner: "alice@example.com",
+        org: "example-org",
+        desktop: true,
+        code: true,
+        state: "active",
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      }),
+    );
+    const fleet = testFleet(storage, {}, env);
+    const headers = {
+      authorization: `Bearer ${token}`,
+      "x-crabbox-auth": "github",
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+      "x-crabbox-github-login": "alice",
+      "x-crabbox-github-token-id": payload.jti,
+      "x-crabbox-github-sealed-credential": payload.githubCredential,
+      "x-crabbox-token-expires-at": new Date(payload.exp * 1000).toISOString(),
+    };
+    const cases = [
+      {
+        createPath: `/v1/leases/${leaseID}/webvnc/ticket`,
+        consumePath: `/v1/leases/${leaseID}/webvnc/agent`,
+        storagePrefix: "webvnc-ticket",
+        body: {},
+      },
+      {
+        createPath: `/v1/leases/${leaseID}/code/ticket`,
+        consumePath: `/v1/leases/${leaseID}/code/agent`,
+        storagePrefix: "code-ticket",
+        body: {},
+      },
+      {
+        createPath: `/v1/leases/${leaseID}/egress/ticket`,
+        consumePath: `/v1/leases/${leaseID}/egress/host`,
+        storagePrefix: "egress-ticket",
+        body: { role: "host" },
+      },
+    ];
+    const tickets = await Promise.all(
+      cases.map(async (item): Promise<(typeof cases)[number] & { ticket: string }> => {
+        const response = await fleet.fetch(
+          request("POST", item.createPath, { headers, body: item.body }),
+        );
+        expect(response.status).toBe(200);
+        const result = (await response.json()) as { ticket?: string };
+        expect(result.ticket).toBeTypeOf("string");
+        const ticket = result.ticket ?? "";
+        expect(storage.value(`${item.storagePrefix}:${ticket}`)).toMatchObject({
+          auth: "github",
+          login: "alice",
+          portalSessionHash,
+          githubGrant: {
+            tokenID: payload.jti,
+            sealedCredential: payload.githubCredential,
+          },
+        });
+        return { ...item, ticket };
+      }),
+    );
+
+    (fleet as unknown as { env: Env }).env.CRABBOX_GITHUB_REVOKED_USERS = "login:alice";
+    const githubFetch = vi.fn<() => Promise<Response>>(async () => {
+      throw new Error("emergency revocation must fail before GitHub API access");
+    });
+    vi.stubGlobal("fetch", githubFetch);
+
+    await Promise.all(
+      tickets.map(async (item) => {
+        const response = await fleet.fetch(
+          request("GET", item.consumePath, {
+            headers: { authorization: `Bearer ${item.ticket}`, upgrade: "websocket" },
+          }),
+        );
+        expect(response.status).toBe(401);
+        expect(storage.value(`${item.storagePrefix}:${item.ticket}`)).toBeUndefined();
+      }),
+    );
+    expect(githubFetch).not.toHaveBeenCalled();
+  });
+
   it("rejects bridge tickets whose cached admin grant was revoked", async () => {
     const storage = new MemoryStorage();
     const fleet = testFleet(storage, {}, { CRABBOX_GITHUB_ADMIN_LOGINS: "current-admin" });


### PR DESCRIPTION
## Summary

- persist the encrypted GitHub user grant and portal-session binding in WebVNC and Code agent tickets
- apply one shared fail-closed grant revalidation path to WebVNC, Code, and egress ticket consumption
- reject and consume tickets after logout, emergency revocation, membership loss, or membership-check failure
- document the agent-ticket revalidation boundary and add the user-facing changelog entry

## Verification

- `go vet ./...`
- `go test -race ./...`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker` (871 passed, 3 skipped)
- `npm run build --prefix worker`
- Worker Node typecheck and full docs generation/link gate
- AutoReview: clean, no actionable findings

## Live proof

Ran the actual Worker and Durable Object locally with an isolated Wrangler state and a real GitHub organization-membership check. A disposable external lease created both WebVNC and Code agent tickets, the authenticated portal session was logged out through `/portal/logout`, both subsequent WebSocket upgrade attempts failed closed with HTTP 401, and the lease released successfully with no retained live resource.

Closes https://github.com/openclaw/crabbox/issues/982
Closes https://github.com/openclaw/crabbox/issues/958
