### PR TITLE
fix: prevent cross-origin Code framing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Limited framing of proxied Browser Code responses to the same isolated Code origin, preventing sibling same-site pages from clickjacking an authenticated session without breaking code-server webviews. Thanks @coygeek.
 - Revalidated non-admin GitHub grants when WebVNC and Code agent tickets are consumed, matching the existing egress fail-closed boundary after logout, emergency revocation, membership loss, or membership-check failure. Thanks @coygeek.
 - Bound coordinator Azure managed-disk cleanup to a durable immutable disk claim captured from the live VM association, preventing stale adopted ownership tags from authorizing deletion. Thanks @coygeek.
 - Required direct Azure release and cleanup to hold an unchanged subscription-, resource-group-, VM-name-, immutable-VM-, lease-, slug-, and provider-key-bound local claim across deletion, with durable companion-resource identities for interruption-safe cleanup. Thanks @coygeek.

--- a/docs/features/portal.md
+++ b/docs/features/portal.md
@@ -68,6 +68,9 @@ use the Code session on other portal routes or lease origins. The ingress must
 provide wildcard TLS and WebSocket routing for the template.
 Proxied responses may set only code-server's `vscode-tkn` cookie; Crabbox removes
 domain scope and confines it to that lease's Code path.
+Crabbox also replaces upstream Content Security Policy headers and limits
+framing to the same isolated Code origin, so a sibling same-site origin cannot
+embed an authenticated Code session while code-server's own webviews still work.
 Portal logout revokes WebVNC, isolated Code, and mediated-egress bridge sessions
 server-side, so their sockets or separate host-scoped cookies cannot retain
 access after the portal cookie is cleared. Logout uses a same-origin `POST`; a

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -14867,6 +14867,7 @@ const codePortalContentSecurityPolicy = [
   "child-src 'self' blob:",
   "connect-src 'self' ws: wss: https:",
   "font-src 'self' data: blob:",
+  "frame-ancestors 'self'",
   "frame-src 'self' https://*.vscode-cdn.net data:",
   "img-src 'self' https: data: blob:",
   "manifest-src 'self'",

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -17358,6 +17358,7 @@ describe("fleet lease identity and idle", () => {
     expect(csp).toContain("script-src 'self' 'unsafe-inline' 'unsafe-eval' blob:");
     expect(csp).toContain("https://static.cloudflareinsights.com");
     expect(csp).toContain("worker-src 'self' data: blob:");
+    expect(csp).toContain("frame-ancestors 'self'");
     expect(headers.get("content-length")).toBeNull();
     expect(headers.get("content-type")).toBe("text/html");
     expect(headers.get("cache-control")).toBe("no-store, no-transform");


### PR DESCRIPTION
## Summary

- replace upstream Code proxy CSP with `frame-ancestors 'self'`
- block sibling same-site origins from framing authenticated isolated Code sessions
- preserve code-server's legitimate same-origin webviews, previews, and extension surfaces
- document the boundary and add a regression assertion

## Verification

- `go vet ./...`
- `go test -race ./...`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm run check:node --prefix worker`
- `npm test --prefix worker` (871 passed, 3 skipped)
- `npm run build --prefix worker`
- `bash scripts/check-docs.sh`
- AutoReview iteration: rejected the initial global `'none'` policy because it broke same-origin code-server frames; revised `'self'` policy reviewed clean with no actionable findings

## Live proof

Ran the actual local Worker and Durable Object over HTTPS with an isolated Wrangler state. A disposable registered lease attached a live Code agent WebSocket, bootstrapped an isolated viewer session, and proxied agent-supplied HTML whose hostile upstream CSP allowed an attacker origin. The delivered `200` response replaced that policy with `frame-ancestors 'self'`; the upstream attacker origin was absent. The lease registration then released successfully with no retained live resource.

Closes https://github.com/openclaw/crabbox/issues/960
