### PR TITLE
fix: harden diagnostic credential redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Redacted complete punctuation-bearing authorization, API-key, and bearer values from CLI and coordinator diagnostics while preserving whitespace-separated routing context. Thanks @coygeek.
 - Limited framing of proxied Browser Code responses to the same isolated Code origin, preventing sibling same-site pages from clickjacking an authenticated session without breaking code-server webviews. Thanks @coygeek.
 - Revalidated non-admin GitHub grants when WebVNC and Code agent tickets are consumed, matching the existing egress fail-closed boundary after logout, emergency revocation, membership loss, or membership-check failure. Thanks @coygeek.
 - Bound coordinator Azure managed-disk cleanup to a durable immutable disk claim captured from the live VM association, preventing stale adopted ownership tags from authorizing deletion. Thanks @coygeek.

--- a/docs/security.md
+++ b/docs/security.md
@@ -299,7 +299,9 @@ Sprites, and Upstash Box. The same final redaction covers `doctor` text and JSON
 messages/details. It removes exact configured secrets, authorization and API-key
 headers, credential-bearing URL query/userinfo components, common secret JSON
 fields, bearer values, and PEM private keys while retaining non-secret routing
-context. Generated stop and failure-routing commands retain provider
+context. Header and bearer fallbacks treat whitespace or an unescaped JSON quote
+as the credential boundary, so punctuation inside an otherwise unknown credential
+cannot expose a suffix. Generated stop and failure-routing commands retain provider
 endpoint routing but remove URL userinfo before they are printed or stored.
 GitHub Actions registration metadata and its short-lived runner token travel
 over SSH stdin rather than the remote command line. These guarantees apply to

--- a/internal/cli/diagnostic_redaction.go
+++ b/internal/cli/diagnostic_redaction.go
@@ -11,11 +11,11 @@ import (
 const diagnosticRedaction = "[redacted]"
 
 var (
-	diagnosticHeaderPattern = regexp.MustCompile(`(?i)\b(authorization|proxy-authorization|x-api-key|api-key|api_key|access-token|access_token|client-secret|client_secret|session-token|session_token|token|password)[ \t]*[:=][ \t]*(?:(?:bearer|basic)(?:[ \t]*:[ \t]*\r?\n[ \t]+|[ \t]*:[ \t]*|[ \t]*\r?\n[ \t]+|[ \t]+))?[^\s"',;\\}&#?]+`)
+	diagnosticHeaderPattern = regexp.MustCompile(`(?i)(^|[^?&[:alnum:]_-])(authorization|proxy-authorization|x-api-key|api-key|api_key|access-token|access_token|client-secret|client_secret|session-token|session_token|token|password)[ \t]*[:=][ \t]*(?:(?:bearer|basic)(?:[ \t]*:[ \t]*\r?\n[ \t]+|[ \t]*:[ \t]*|[ \t]*\r?\n[ \t]+|[ \t]+))?(?:\\.|[^\s"])+`)
 	diagnosticJSONPattern   = regexp.MustCompile(`(?i)"(authorization|proxy-authorization|x-api-key|apiKey|api-key|api_key|accessToken|access-token|access_token|clientSecret|client-secret|client_secret|credential|credentials|privateKey|private-key|private_key|secret|sessionToken|session-token|session_token|token|password)"\s*:\s*"(?:\\[\s\S]|[^"\\])*(?:"|$)`)
-	diagnosticQueryPattern  = regexp.MustCompile(`(?i)([?&](?:api[_-]?key|access[_-]?token|client[_-]?secret|password|token|signature|sig|x-amz-credential|x-amz-signature|x-amz-security-token|x-goog-credential|x-goog-signature|x-goog-security-token)=)[^&#\s]+`)
+	diagnosticQueryPattern  = regexp.MustCompile(`(?i)([?&](?:authorization|proxy-authorization|x-api-key|api[_-]?key|access[_-]?token|client[_-]?secret|session[_-]?token|password|token|signature|sig|x-amz-credential|x-amz-signature|x-amz-security-token|x-goog-credential|x-goog-signature|x-goog-security-token)=)[^&#\s]+`)
 	diagnosticURLPattern    = regexp.MustCompile(`(?i)\b(https?://)[^/@\s]+@`)
-	diagnosticBearerPattern = regexp.MustCompile(`(?i)\bbearer(?:[ \t]*:[ \t]*\r?\n[ \t]+|[ \t]*:[ \t]*|[ \t]*\r?\n[ \t]+|[ \t]+)[^\s"',;\\}]+`)
+	diagnosticBearerPattern = regexp.MustCompile(`(?i)\bbearer(?:[ \t]*:[ \t]*\r?\n[ \t]+|[ \t]*:[ \t]*|[ \t]*\r?\n[ \t]+|[ \t]+)(?:\\.|[^\s"])+`)
 	diagnosticPEMPattern    = regexp.MustCompile(`(?is)-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?(?:-----END [A-Z0-9 ]*PRIVATE KEY-----|$)`)
 )
 
@@ -62,10 +62,15 @@ func normalizedDiagnosticSecrets(values []string) []string {
 }
 
 func redactDiagnosticAssignment(match string) string {
-	separator := strings.IndexAny(match, ":=")
+	indexes := diagnosticHeaderPattern.FindStringSubmatchIndex(match)
+	if len(indexes) < 6 || indexes[5] < 0 {
+		return match
+	}
+	separator := strings.IndexAny(match[indexes[5]:], ":=")
 	if separator < 0 {
 		return match
 	}
+	separator += indexes[5]
 	return match[:separator+1] + " " + diagnosticRedaction
 }
 

--- a/internal/cli/diagnostic_redaction_test.go
+++ b/internal/cli/diagnostic_redaction_test.go
@@ -22,7 +22,7 @@ func TestRedactDiagnosticSecretsCoversCredentialEncodings(t *testing.T) {
 		"Standalone Bearer [redacted]",
 		"Proxy-Authorization=Basic proxy-value",
 		`{"clientSecret":"json-secret","privateKey":"json-key","message":"quota exceeded"}`,
-		"https://alice:password@example.test/path?access_token=query-token&x-amz-signature=signed-value&x-goog-credential=gcs-credential&x-goog-signature=gcs-signature&region=eu",
+		"https://alice:password@example.test/path?access_token=query-token&x-api-key=query-api-key&authorization=query-authorization&proxy-authorization=query-proxy-authorization&session_token=query-session-token&x-amz-signature=signed-value&x-goog-credential=gcs-credential&x-goog-signature=gcs-signature&region=eu",
 		"https://single-userinfo-token@other.example.test/path",
 		"-----BEGIN OPENSSH PRIVATE KEY-----\nprivate-material\n-----END OPENSSH PRIVATE KEY-----",
 	}, "\n")
@@ -30,7 +30,7 @@ func TestRedactDiagnosticSecretsCoversCredentialEncodings(t *testing.T) {
 	got := RedactDiagnosticSecrets(value, exact)
 	for _, leaked := range []string{
 		exact, "header-token", "colon-header-token", "folded-header-token", "folded-colon-header-token", "spaced-folded-colon-header-token", "spaced-bearer-token", "colon-bearer-token", "folded-bearer-token", "folded-colon-bearer-token", "spaced-folded-colon-bearer-token", "proxy-value", "json-secret", "json-key", "alice", "password",
-		"query-token", "signed-value", "gcs-credential", "gcs-signature", "single-userinfo-token", "private-material",
+		"query-token", "query-api-key", "query-authorization", "query-proxy-authorization", "query-session-token", "signed-value", "gcs-credential", "gcs-signature", "single-userinfo-token", "private-material",
 	} {
 		if strings.Contains(got, leaked) {
 			t.Fatalf("diagnostic redaction leaked %q:\n%s", leaked, got)
@@ -43,6 +43,29 @@ func TestRedactDiagnosticSecretsCoversCredentialEncodings(t *testing.T) {
 	}
 	if strings.Count(got, diagnosticRedaction) < 8 {
 		t.Fatalf("missing redaction markers:\n%s", got)
+	}
+}
+
+func TestRedactDiagnosticSecretsConsumesPunctuationBearingCredentials(t *testing.T) {
+	for _, separator := range []string{",", ";", "'", "}", "&", "#", "?", `\"`} {
+		credential := "prefix" + separator + "secret-suffix"
+		for _, test := range []struct {
+			name  string
+			input string
+			want  string
+		}{
+			{name: "header", input: "Authorization: Bearer " + credential + " route=iad", want: "Authorization: [redacted] route=iad"},
+			{name: "bearer", input: "upstream Bearer " + credential + " request=retry", want: "upstream Bearer [redacted] request=retry"},
+		} {
+			t.Run(test.name+"/"+separator, func(t *testing.T) {
+				if got := RedactDiagnosticSecrets(test.input); got != test.want {
+					t.Fatalf("got %q, want %q", got, test.want)
+				}
+			})
+		}
+	}
+	if got := RedactDiagnosticSecrets("provider:Authorization: Bearer prefix}secret route=iad"); got != "provider:Authorization: [redacted] route=iad" {
+		t.Fatalf("prefixed header redaction lost its key: %q", got)
 	}
 }
 

--- a/worker/src/http.ts
+++ b/worker/src/http.ts
@@ -60,10 +60,10 @@ export function redactDiagnosticSecrets(
     redacted = redacted.replaceAll(secret, "[redacted]");
   }
   redacted = redacted.replaceAll(
-    /\b(authorization|proxy-authorization|x-api-key|api-key|api_key|access-token|access_token|client-secret|client_secret|session-token|session_token|token|password)[ \t]*[:=][ \t]*(?:(?:bearer|basic)(?:[ \t]*:[ \t]*\r?\n[ \t]+|[ \t]*:[ \t]*|[ \t]*\r?\n[ \t]+|[ \t]+))?[^\s"',;\\}]+/gi,
-    (match) => {
-      const colon = match.indexOf(":");
-      const equals = match.indexOf("=");
+    /(^|[^?&A-Za-z0-9_-])(authorization|proxy-authorization|x-api-key|api-key|api_key|access-token|access_token|client-secret|client_secret|session-token|session_token|token|password)[ \t]*[:=][ \t]*(?:(?:bearer|basic)(?:[ \t]*:[ \t]*\r?\n[ \t]+|[ \t]*:[ \t]*|[ \t]*\r?\n[ \t]+|[ \t]+))?(?:\\.|[^\s"])+/gi,
+    (match, prefix: string) => {
+      const colon = match.indexOf(":", prefix.length);
+      const equals = match.indexOf("=", prefix.length);
       const separator = colon < 0 ? equals : equals < 0 ? colon : Math.min(colon, equals);
       return separator >= 0 ? `${match.slice(0, separator + 1)} [redacted]` : match;
     },
@@ -76,12 +76,12 @@ export function redactDiagnosticSecrets(
     },
   );
   redacted = redacted.replaceAll(
-    /([?&](?:api[_-]?key|access[_-]?token|client[_-]?secret|password|token|signature|sig|x-amz-credential|x-amz-signature|x-amz-security-token)=)[^&#\s]+/gi,
+    /([?&](?:authorization|proxy-authorization|x-api-key|api[_-]?key|access[_-]?token|client[_-]?secret|session[_-]?token|password|token|signature|sig|x-amz-credential|x-amz-signature|x-amz-security-token)=)[^&#\s]+/gi,
     "$1[redacted]",
   );
   redacted = redacted.replaceAll(/\b(https?:\/\/)[^/\s:@]+:[^@\s/]+@/gi, "$1[redacted]@");
   redacted = redacted.replaceAll(
-    /\bbearer(?:[ \t]*:[ \t]*\r?\n[ \t]+|[ \t]*:[ \t]*|[ \t]*\r?\n[ \t]+|[ \t]+)[^\s"',;\\}]+/gi,
+    /\bbearer(?:[ \t]*:[ \t]*\r?\n[ \t]+|[ \t]*:[ \t]*|[ \t]*\r?\n[ \t]+|[ \t]+)(?:\\.|[^\s"])+/gi,
     "Bearer [redacted]",
   );
   return redacted.replaceAll(

--- a/worker/test/http.test.ts
+++ b/worker/test/http.test.ts
@@ -1236,7 +1236,7 @@ describe("http responses", () => {
       "X-API-Key=header-secret",
       "client_secret=plain-secret",
       '{"token":"json-secret\\\"escaped-tail-leak","clientSecret":"client-secret","x-api-key":"json-api-secret"}',
-      "https://alice:password@example.test/path?api_key=query-secret&X-Amz-Signature=signed-secret",
+      "https://alice:password@example.test/path?api_key=query-secret&x-api-key=query-api-key&authorization=query-authorization&proxy-authorization=query-proxy-authorization&session_token=query-session-token&X-Amz-Signature=signed-secret&region=eu",
       "-----BEGIN PRIVATE KEY-----\nprivate-key-body\n-----END PRIVATE KEY-----",
       "safe suffix",
     ].join("\n");
@@ -1266,6 +1266,10 @@ describe("http responses", () => {
       "alice",
       "password",
       "query-secret",
+      "query-api-key",
+      "query-authorization",
+      "query-proxy-authorization",
+      "query-session-token",
       "signed-secret",
       "PRIVATE KEY",
       "private-key-body",
@@ -1274,7 +1278,23 @@ describe("http responses", () => {
     }
     expect(redacted).toContain("[redacted]");
     expect(redacted).toContain("standalone Bearer [redacted]");
+    expect(redacted).toContain("region=eu");
     expect(redacted).toContain("safe suffix");
+  });
+
+  it("redacts punctuation-bearing credential suffixes while preserving context", () => {
+    for (const separator of [",", ";", "'", "}", "&", "#", "?", '\\"']) {
+      const credential = `prefix${separator}secret-suffix`;
+      expect(redactDiagnosticSecrets(`Authorization: Bearer ${credential} route=iad`)).toBe(
+        "Authorization: [redacted] route=iad",
+      );
+      expect(redactDiagnosticSecrets(`upstream Bearer ${credential} request=retry`)).toBe(
+        "upstream Bearer [redacted] request=retry",
+      );
+    }
+    expect(redactDiagnosticSecrets("provider:Authorization: Bearer prefix}secret route=iad")).toBe(
+      "provider:Authorization: [redacted] route=iad",
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- consume complete punctuation-bearing authorization, API-key, and bearer credentials in Go CLI/doctor and Worker diagnostics
- preserve unescaped JSON and whitespace routing boundaries, including URL query context
- align dedicated sensitive query aliases across both implementations and add regressions for every reported delimiter

Closes https://github.com/openclaw/crabbox/issues/968
Closes https://github.com/openclaw/crabbox/issues/974

## Verification

- `go vet ./...`
- `go test -race ./...`
- focused Go redaction tests
- Worker format, lint, Worker/Node typechecks, 872 tests, Worker/Dynamic Worker/Node builds
- docs checks and site build: 53 commands, 72 providers, 210 Markdown files
- executable production-function proof in both Go and bundled Worker JavaScript, including punctuation/escaped-quote credentials, sensitive query aliases, and preserved routing context
- AutoReview clean after one accepted query-alias finding was fixed
