### PR TITLE
fix: redact runtime provider credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Collected runtime-only provider credentials through provider-owned diagnostic hooks and redacted opaque OpenSandbox and W&B upstream errors before they reach CLI output. Thanks @coygeek.
 - Redacted complete punctuation-bearing authorization, API-key, and bearer values from CLI and coordinator diagnostics while preserving whitespace-separated routing context. Thanks @coygeek.
 - Limited framing of proxied Browser Code responses to the same isolated Code origin, preventing sibling same-site pages from clickjacking an authenticated session without breaking code-server webviews. Thanks @coygeek.
 - Revalidated non-admin GitHub grants when WebVNC and Code agent tickets are consumed, matching the existing egress fail-closed boundary after logout, emergency revocation, membership loss, or membership-check failure. Thanks @coygeek.

--- a/docs/security.md
+++ b/docs/security.md
@@ -299,10 +299,13 @@ Sprites, and Upstash Box. The same final redaction covers `doctor` text and JSON
 messages/details. It removes exact configured secrets, authorization and API-key
 headers, credential-bearing URL query/userinfo components, common secret JSON
 fields, bearer values, and PEM private keys while retaining non-secret routing
-context. Header and bearer fallbacks treat whitespace or an unescaped JSON quote
-as the credential boundary, so punctuation inside an otherwise unknown credential
-cannot expose a suffix. Generated stop and failure-routing commands retain provider
-endpoint routing but remove URL userinfo before they are printed or stored.
+context. Providers contribute runtime-only environment and local CLI-store
+credentials to that exact-value pass, keeping credential discovery beside the
+provider that owns it. Header and bearer fallbacks treat whitespace or an
+unescaped JSON quote as the credential boundary, so punctuation inside an
+otherwise unknown credential cannot expose a suffix. Generated stop and
+failure-routing commands retain provider endpoint routing but remove URL userinfo
+before they are printed or stored.
 GitHub Actions registration metadata and its short-lived runner token travel
 over SSH stdin rather than the remote command line. These guarantees apply to
 Crabbox-generated diagnostics and process arguments, not to arbitrary command

--- a/internal/cli/diagnostic_redaction.go
+++ b/internal/cli/diagnostic_redaction.go
@@ -114,11 +114,28 @@ func configuredDiagnosticSecrets(cfg Config) []string {
 			seen[value] = true
 		}
 	}
+	sources := make([]ProviderDiagnosticSecretSource, 0)
+	for _, provider := range registeredProviders() {
+		if source, ok := provider.(ProviderDiagnosticSecretSource); ok {
+			sources = append(sources, source)
+		}
+	}
+	collectProviderDiagnosticSecrets(cfg, sources, seen)
 	secrets := make([]string, 0, len(seen))
 	for secret := range seen {
 		secrets = append(secrets, secret)
 	}
 	return secrets
+}
+
+func collectProviderDiagnosticSecrets(cfg Config, sources []ProviderDiagnosticSecretSource, seen map[string]bool) {
+	for _, source := range sources {
+		for _, value := range source.DiagnosticSecrets(cfg) {
+			if value = strings.TrimSpace(value); len(value) >= 4 {
+				seen[value] = true
+			}
+		}
+	}
 }
 
 func collectConfiguredDiagnosticSecrets(value reflect.Value, name string, seen map[string]bool) {

--- a/internal/cli/diagnostic_redaction_test.go
+++ b/internal/cli/diagnostic_redaction_test.go
@@ -5,6 +5,10 @@ import (
 	"testing"
 )
 
+type staticDiagnosticSecretSource []string
+
+func (s staticDiagnosticSecretSource) DiagnosticSecrets(Config) []string { return s }
+
 func TestRedactDiagnosticSecretsCoversCredentialEncodings(t *testing.T) {
 	exact := "configured-provider-secret"
 	value := strings.Join([]string{
@@ -94,4 +98,28 @@ func TestConfiguredDiagnosticSecretsFindsConfigAndSelectedEnvironment(t *testing
 	if strings.Contains(redacted, "secret") || strings.Count(redacted, diagnosticRedaction) != 5 {
 		t.Fatalf("configured secrets were not collected: %s", redacted)
 	}
+}
+
+func TestCollectProviderDiagnosticSecretsFindsRuntimeOnlyValues(t *testing.T) {
+	const runtimeSecret = "runtime-only-provider-secret"
+	seen := map[string]bool{}
+	collectProviderDiagnosticSecrets(Config{}, []ProviderDiagnosticSecretSource{
+		staticDiagnosticSecretSource{" ", "abc", " " + runtimeSecret + " ", runtimeSecret},
+	}, seen)
+
+	got := RedactDiagnosticSecrets("opaque diagnostic value "+runtimeSecret+" region=eu", secretsFromSet(seen)...)
+	if strings.Contains(got, runtimeSecret) || !strings.Contains(got, "region=eu") {
+		t.Fatalf("provider diagnostic secret collection failed: %q", got)
+	}
+	if len(seen) != 1 {
+		t.Fatalf("seen=%v want one normalized secret", seen)
+	}
+}
+
+func secretsFromSet(values map[string]bool) []string {
+	secrets := make([]string, 0, len(values))
+	for value := range values {
+		secrets = append(secrets, value)
+	}
+	return secrets
 }

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -430,6 +430,31 @@ func TestDoctorRedactsCoordinatorAndProviderDiagnostics(t *testing.T) {
 	}
 }
 
+func TestDoctorRedactsRuntimeOnlyProviderSecret(t *testing.T) {
+	for _, tool := range []string{"git", "tar"} {
+		if _, err := exec.LookPath(tool); err != nil {
+			t.Skipf("missing local doctor tool %s: %v", tool, err)
+		}
+	}
+	clearConfigEnv(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("CRABBOX_CONFIG", "")
+	const secret = "opaque-runtime-only-wandb-secret"
+	t.Setenv("WANDB_API_KEY", secret)
+
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).doctor(context.Background(), []string{"--provider", "wandb", "--json"})
+	if err != nil {
+		t.Fatalf("doctor error=%v stderr=%q", err, stderr.String())
+	}
+	output := stdout.String()
+	if strings.Contains(output, secret) || !strings.Contains(output, "[redacted]") || !strings.Contains(output, "region=eu") {
+		t.Fatalf("doctor returned unsafe diagnostic: %s", output)
+	}
+}
+
 func TestDoctorJSONCoordinatorOutputIncludesCapacityWarnings(t *testing.T) {
 	for _, tool := range []string{"git", "ssh", "ssh-keygen", "rsync"} {
 		if _, err := exec.LookPath(tool); err != nil {

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -32,6 +32,13 @@ type ProviderConfigValidator interface {
 	ValidateConfig(cfg Config) error
 }
 
+// ProviderDiagnosticSecretSource contributes runtime-only credentials to the
+// final diagnostic redaction pass. Providers should include every credential
+// source that is intentionally absent from Config, including local CLI stores.
+type ProviderDiagnosticSecretSource interface {
+	DiagnosticSecrets(cfg Config) []string
+}
+
 // ControllerProviderContract binds controller lifecycle retries to one opaque
 // provider configuration scope and an explicitly idempotent fixed-ID adapter.
 type ControllerProviderContract interface {

--- a/internal/cli/providers_builtin_test.go
+++ b/internal/cli/providers_builtin_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"os"
 	"strings"
 )
 
@@ -322,8 +323,29 @@ func (testWandbProvider) RegisterFlags(*flag.FlagSet, Config) any { return noPro
 func (testWandbProvider) ApplyFlags(*Config, *flag.FlagSet, any) error {
 	return nil
 }
+func (testWandbProvider) DiagnosticSecrets(Config) []string {
+	return []string{os.Getenv("WANDB_API_KEY")}
+}
 func (p testWandbProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
 	return testDelegatedBackend{spec: p.Spec()}, nil
+}
+func (p testWandbProvider) ConfigureDoctor(Config, Runtime) (DoctorBackend, error) {
+	return testWandbDoctorBackend{testDelegatedBackend: testDelegatedBackend{spec: p.Spec()}}, nil
+}
+
+type testWandbDoctorBackend struct {
+	testDelegatedBackend
+}
+
+func (b testWandbDoctorBackend) Doctor(context.Context, DoctorRequest) (DoctorResult, error) {
+	return DoctorResult{
+		Provider: b.spec.Name,
+		Checks: []DoctorCheck{{
+			Status:  "warning",
+			Check:   "diagnostic",
+			Message: "provider rejected opaque=" + os.Getenv("WANDB_API_KEY") + " region=eu",
+		}},
+	}, nil
 }
 
 type testWindowsSandboxProvider struct{}

--- a/internal/providers/all/diagnostic_secrets_test.go
+++ b/internal/providers/all/diagnostic_secrets_test.go
@@ -1,0 +1,73 @@
+package all
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestRuntimeOnlyProviderDiagnosticSecrets(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := os.Mkdir(filepath.Join(home, ".oc"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".oc", "config.json"), []byte(`{"api_key":"opencomputer-file-secret"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".netrc"), []byte("machine api.wandb.ai login test password wandb-netrc-secret\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	environment := map[string]string{
+		"CRABBOX_OPENCOMPUTER_API_KEY": "opencomputer-primary-secret",
+		"OPENCOMPUTER_API_KEY":         "opencomputer-fallback-secret",
+		"CRABBOX_CODESANDBOX_API_KEY":  "codesandbox-primary-secret",
+		"CSB_API_KEY":                  "codesandbox-fallback-secret",
+		"CRABBOX_OPENSANDBOX_API_KEY":  "opensandbox-primary-secret",
+		"OPEN_SANDBOX_API_KEY":         "opensandbox-fallback-secret",
+		"CRABBOX_SUPERSERVE_API_KEY":   "superserve-primary-secret",
+		"SUPERSERVE_API_KEY":           "superserve-fallback-secret",
+		"CRABBOX_CROWNEST_API_KEY":     "crownest-primary-secret",
+		"CROWNEST_API_KEY":             "crownest-fallback-secret",
+		"CRABBOX_WANDB_API_KEY":        "wandb-primary-secret",
+		"WANDB_API_KEY":                "wandb-fallback-secret",
+	}
+	for name, value := range environment {
+		t.Setenv(name, value)
+	}
+
+	tests := []struct {
+		provider string
+		want     []string
+	}{
+		{"opencomputer", []string{environment["CRABBOX_OPENCOMPUTER_API_KEY"], environment["OPENCOMPUTER_API_KEY"], "opencomputer-file-secret"}},
+		{"codesandbox", []string{environment["CRABBOX_CODESANDBOX_API_KEY"], environment["CSB_API_KEY"]}},
+		{"opensandbox", []string{environment["CRABBOX_OPENSANDBOX_API_KEY"], environment["OPEN_SANDBOX_API_KEY"]}},
+		{"superserve", []string{environment["CRABBOX_SUPERSERVE_API_KEY"], environment["SUPERSERVE_API_KEY"]}},
+		{"crownest", []string{environment["CRABBOX_CROWNEST_API_KEY"], environment["CROWNEST_API_KEY"]}},
+		{"wandb", []string{environment["CRABBOX_WANDB_API_KEY"], "wandb-config-secret", environment["WANDB_API_KEY"], "wandb-netrc-secret"}},
+	}
+	cfg := core.Config{Wandb: core.WandbConfig{APIKey: "wandb-config-secret"}}
+	for _, test := range tests {
+		t.Run(test.provider, func(t *testing.T) {
+			provider, err := core.ProviderFor(test.provider)
+			if err != nil {
+				t.Fatal(err)
+			}
+			source, ok := provider.(core.ProviderDiagnosticSecretSource)
+			if !ok {
+				t.Fatalf("provider %s does not contribute runtime diagnostic secrets", test.provider)
+			}
+			got := source.DiagnosticSecrets(cfg)
+			for _, want := range test.want {
+				if !slices.Contains(got, want) {
+					t.Fatalf("DiagnosticSecrets()=%q missing expected value", got)
+				}
+			}
+		})
+	}
+}

--- a/internal/providers/codesandbox/provider.go
+++ b/internal/providers/codesandbox/provider.go
@@ -2,6 +2,7 @@ package codesandbox
 
 import (
 	"flag"
+	"os"
 	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
@@ -15,6 +16,13 @@ type Provider struct{}
 
 func (Provider) Name() string      { return providerName }
 func (Provider) Aliases() []string { return []string{"csb", "code-sandbox"} }
+
+func (Provider) DiagnosticSecrets(core.Config) []string {
+	return []string{
+		os.Getenv(codesandboxPrimaryAPIKeyEnv),
+		os.Getenv(codesandboxFallbackAPIKeyEnv),
+	}
+}
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{

--- a/internal/providers/crownest/provider.go
+++ b/internal/providers/crownest/provider.go
@@ -2,6 +2,7 @@ package crownest
 
 import (
 	"flag"
+	"os"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
@@ -14,6 +15,13 @@ type Provider struct{}
 
 func (Provider) Name() string      { return providerName }
 func (Provider) Aliases() []string { return nil }
+
+func (Provider) DiagnosticSecrets(core.Config) []string {
+	return []string{
+		os.Getenv("CRABBOX_CROWNEST_API_KEY"),
+		os.Getenv("CROWNEST_API_KEY"),
+	}
+}
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{

--- a/internal/providers/opencomputer/provider.go
+++ b/internal/providers/opencomputer/provider.go
@@ -2,6 +2,7 @@ package opencomputer
 
 import (
 	"flag"
+	"os"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
@@ -14,6 +15,15 @@ type Provider struct{}
 
 func (Provider) Name() string      { return providerName }
 func (Provider) Aliases() []string { return []string{"oc", "open-computer"} }
+
+func (Provider) DiagnosticSecrets(core.Config) []string {
+	fileConfig := readOCFileConfig()
+	return []string{
+		os.Getenv("CRABBOX_OPENCOMPUTER_API_KEY"),
+		os.Getenv("OPENCOMPUTER_API_KEY"),
+		fileConfig.APIKey,
+	}
+}
 
 func (Provider) ServerTypeForConfig(core.Config) string { return "" }
 func (Provider) ServerTypeForClass(string) string       { return "" }

--- a/internal/providers/opensandbox/client.go
+++ b/internal/providers/opensandbox/client.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	sdk "github.com/alibaba/OpenSandbox/sdks/sandbox/go"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type openSandboxClient interface {
@@ -38,6 +39,14 @@ type ambiguousOpenSandboxCreateError struct {
 
 func (e *ambiguousOpenSandboxCreateError) Error() string { return e.cause.Error() }
 func (e *ambiguousOpenSandboxCreateError) Unwrap() error { return e.cause }
+
+type redactedOpenSandboxError struct {
+	cause   error
+	message string
+}
+
+func (e *redactedOpenSandboxError) Error() string { return e.message }
+func (e *redactedOpenSandboxError) Unwrap() error { return e.cause }
 
 type createSandboxOptions struct {
 	Image          string
@@ -260,6 +269,24 @@ func (c *sdkOpenSandboxClient) lifecycle() *sdk.LifecycleClient {
 	return sdk.NewLifecycleClient(c.base+"/v1", c.key, sdk.WithHTTPClient(&httpClient))
 }
 
+func (c *sdkOpenSandboxClient) redactProviderText(value string, extraSecrets ...string) string {
+	secrets := make([]string, 1, len(extraSecrets)+1)
+	secrets[0] = c.key
+	secrets = append(secrets, extraSecrets...)
+	return shared.RedactErrorSecrets(value, secrets...)
+}
+
+func (c *sdkOpenSandboxClient) redactProviderError(err error, extraSecrets ...string) error {
+	if err == nil {
+		return nil
+	}
+	message := c.redactProviderText(err.Error(), extraSecrets...)
+	if message == err.Error() {
+		return err
+	}
+	return &redactedOpenSandboxError{cause: err, message: message}
+}
+
 func (c *sdkOpenSandboxClient) config() sdk.ConnectionConfig {
 	protocol := ""
 	if parsed, err := url.Parse(c.base); err == nil {
@@ -314,7 +341,7 @@ func (c *sdkOpenSandboxClient) CreateSandbox(ctx context.Context, opts createSan
 	}
 	info, err := c.lifecycle().CreateSandbox(ctx, req)
 	if err != nil {
-		createErr := fmt.Errorf("opensandbox create sandbox: %w", err)
+		createErr := fmt.Errorf("opensandbox create sandbox: %w", c.redactProviderError(err))
 		if isOpenSandboxAmbiguousCreateError(err) {
 			return sandboxInfo{}, &ambiguousOpenSandboxCreateError{cause: createErr}
 		}
@@ -337,7 +364,7 @@ func (c *sdkOpenSandboxClient) CreateSandbox(ctx context.Context, opts createSan
 	if info.ExpiresAt == nil || info.ExpiresAt.IsZero() {
 		info, err = c.lifecycle().GetSandbox(readyCtx, sandboxID)
 		if err != nil {
-			return sandboxInfo{}, c.cleanupCreateFailure(ctx, sandboxID, fmt.Errorf("opensandbox refresh sandbox expiration: %w", err))
+			return sandboxInfo{}, c.cleanupCreateFailure(ctx, sandboxID, fmt.Errorf("opensandbox refresh sandbox expiration: %w", c.redactProviderError(err)))
 		}
 		if info.Status.State != sdk.StateRunning {
 			refreshedCtx, refreshedCancel := c.readinessContext(readyCtx, info.ExpiresAt)
@@ -363,14 +390,14 @@ func (c *sdkOpenSandboxClient) cleanupCreateFailure(ctx context.Context, sandbox
 	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), openSandboxCleanupTimeout)
 	defer cancel()
 	if err := c.lifecycle().DeleteSandbox(cleanupCtx, sandboxID); err != nil && !isOpenSandboxNotFound(err) {
-		return fmt.Errorf("%w; cleanup opensandbox sandbox %s failed: %v", cause, sandboxID, err)
+		return fmt.Errorf("%w; cleanup opensandbox sandbox %s failed: %v", cause, sandboxID, c.redactProviderError(err))
 	}
 	return cause
 }
 
 func (c *sdkOpenSandboxClient) ResumeSandbox(ctx context.Context, sandboxID string) error {
 	if err := c.lifecycle().ResumeSandbox(ctx, sandboxID); err != nil {
-		return fmt.Errorf("opensandbox resume sandbox: %w", err)
+		return fmt.Errorf("opensandbox resume sandbox: %w", c.redactProviderError(err))
 	}
 	readyCtx, cancel := c.readinessContext(ctx, nil)
 	defer cancel()
@@ -387,11 +414,11 @@ func (c *sdkOpenSandboxClient) ResumeSandbox(ctx context.Context, sandboxID stri
 }
 
 func (c *sdkOpenSandboxClient) PingSandbox(ctx context.Context, sandboxID string) error {
-	execd, err := c.execd(ctx, sandboxID)
+	conn, err := c.resolveExecd(ctx, sandboxID)
 	if err != nil {
 		return err
 	}
-	return execd.Ping(ctx)
+	return c.redactProviderError(c.execdForConnection(conn).Ping(ctx), openSandboxExecdSecrets(conn)...)
 }
 
 func (c *sdkOpenSandboxClient) readyTimeout() time.Duration {
@@ -446,7 +473,7 @@ func (c *sdkOpenSandboxClient) waitForRunning(ctx context.Context, sandboxID str
 			if expiresAt != nil && requestContextErr != nil && ctx.Err() == nil {
 				return nil, fmt.Errorf("sandbox %s expired before reaching Running state", sandboxID)
 			}
-			return nil, fmt.Errorf("get sandbox status: %w", err)
+			return nil, fmt.Errorf("get sandbox status: %w", c.redactProviderError(err))
 		}
 		if info.ExpiresAt != nil && !info.ExpiresAt.IsZero() {
 			expiresAt = info.ExpiresAt
@@ -478,13 +505,17 @@ func (c *sdkOpenSandboxClient) waitUntilReady(ctx context.Context, sandboxID str
 	start := time.Now()
 	var lastErr error
 	for {
-		execd, err := c.execd(ctx, sandboxID)
+		conn, err := c.resolveExecd(ctx, sandboxID)
 		if err == nil {
-			err = execd.Ping(ctx)
+			err = c.execdForConnection(conn).Ping(ctx)
+			if err != nil {
+				err = c.redactProviderError(err, openSandboxExecdSecrets(conn)...)
+			}
 		}
 		if err == nil {
 			return nil
 		}
+		err = c.redactProviderError(err)
 		if !isOpenSandboxReadinessPending(err) {
 			return fmt.Errorf("sandbox %s readiness failed: %w", sandboxID, err)
 		}
@@ -505,7 +536,7 @@ func (c *sdkOpenSandboxClient) waitUntilReady(ctx context.Context, sandboxID str
 func (c *sdkOpenSandboxClient) ListSandboxes(ctx context.Context, metadata map[string]string) ([]sandboxInfo, error) {
 	resp, err := c.lifecycle().ListSandboxes(ctx, sdk.ListOptions{Metadata: metadata, PageSize: 100})
 	if err != nil {
-		return nil, fmt.Errorf("opensandbox list sandboxes: %w", err)
+		return nil, fmt.Errorf("opensandbox list sandboxes: %w", c.redactProviderError(err))
 	}
 	out := make([]sandboxInfo, 0, len(resp.Items))
 	for i := range resp.Items {
@@ -517,25 +548,25 @@ func (c *sdkOpenSandboxClient) ListSandboxes(ctx context.Context, metadata map[s
 func (c *sdkOpenSandboxClient) GetSandbox(ctx context.Context, sandboxID string) (sandboxInfo, error) {
 	info, err := c.lifecycle().GetSandbox(ctx, sandboxID)
 	if err != nil {
-		return sandboxInfo{}, fmt.Errorf("opensandbox get sandbox: %w", err)
+		return sandboxInfo{}, fmt.Errorf("opensandbox get sandbox: %w", c.redactProviderError(err))
 	}
 	return sdkSandboxInfo(info), nil
 }
 
 func (c *sdkOpenSandboxClient) DeleteSandbox(ctx context.Context, sandboxID string) error {
 	if err := c.lifecycle().DeleteSandbox(ctx, sandboxID); err != nil {
-		return fmt.Errorf("opensandbox delete sandbox: %w", err)
+		return fmt.Errorf("opensandbox delete sandbox: %w", c.redactProviderError(err))
 	}
 	return nil
 }
 
 func (c *sdkOpenSandboxClient) UploadFile(ctx context.Context, sandboxID, remotePath string, body io.Reader) error {
-	execd, err := c.execd(ctx, sandboxID)
+	conn, err := c.resolveExecd(ctx, sandboxID)
 	if err != nil {
 		return err
 	}
-	if err := execd.UploadFile(ctx, body, sdk.UploadFileOptions{Metadata: sdk.FileMetadata{Path: remotePath}}); err != nil {
-		return fmt.Errorf("opensandbox upload %s: %w", remotePath, err)
+	if err := c.execdForConnection(conn).UploadFile(ctx, body, sdk.UploadFileOptions{Metadata: sdk.FileMetadata{Path: remotePath}}); err != nil {
+		return fmt.Errorf("opensandbox upload %s: %w", remotePath, c.redactProviderError(err, openSandboxExecdSecrets(conn)...))
 	}
 	return nil
 }
@@ -604,12 +635,13 @@ func (c *sdkOpenSandboxClient) runCommandStream(ctx context.Context, conn execdC
 	}
 	response, err := c.execdHTTPClient(conn).Do(request)
 	if err != nil {
-		return fmt.Errorf("opensandbox send command request: %w", err)
+		return fmt.Errorf("opensandbox send command request: %w", c.redactProviderError(err, openSandboxExecdSecrets(conn)...))
 	}
 	defer response.Body.Close()
 	if response.StatusCode >= http.StatusBadRequest {
 		message, _ := io.ReadAll(io.LimitReader(response.Body, 64*1024))
-		return fmt.Errorf("opensandbox command request failed status=%d body=%s", response.StatusCode, strings.TrimSpace(string(message)))
+		body := c.redactProviderText(strings.TrimSpace(string(message)), openSandboxExecdSecrets(conn)...)
+		return fmt.Errorf("opensandbox command request failed status=%d body=%s", response.StatusCode, body)
 	}
 	return streamOpenSandboxCommand(ctx, response.Body, handler)
 }
@@ -847,17 +879,9 @@ func commandOutput(text, data string) string {
 
 func (c *sdkOpenSandboxClient) Probe(ctx context.Context) error {
 	if _, err := c.lifecycle().ListSandboxes(ctx, sdk.ListOptions{PageSize: 1}); err != nil {
-		return fmt.Errorf("opensandbox probe: %w", err)
+		return fmt.Errorf("opensandbox probe: %w", c.redactProviderError(err))
 	}
 	return nil
-}
-
-func (c *sdkOpenSandboxClient) execd(ctx context.Context, sandboxID string) (*sdk.ExecdClient, error) {
-	conn, err := c.resolveExecd(ctx, sandboxID)
-	if err != nil {
-		return nil, err
-	}
-	return c.execdForConnection(conn), nil
 }
 
 func (c *sdkOpenSandboxClient) execdForConnection(conn execdConnection) *sdk.ExecdClient {
@@ -871,7 +895,7 @@ func (c *sdkOpenSandboxClient) interruptOpenSandboxCommand(ctx context.Context, 
 	interruptCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), openSandboxInterruptTimeout)
 	defer cancel()
 	if err := c.execdForConnection(conn).InterruptCommand(interruptCtx, executionID); err != nil {
-		return fmt.Errorf("%w; interrupt opensandbox command %s failed: %v", cause, executionID, err)
+		return fmt.Errorf("%w; interrupt opensandbox command %s failed: %v", cause, executionID, c.redactProviderError(err, openSandboxExecdSecrets(conn)...))
 	}
 	return cause
 }
@@ -880,7 +904,7 @@ func (c *sdkOpenSandboxClient) resolveExecd(ctx context.Context, sandboxID strin
 	useProxy := c.cfg.OpenSandbox.UseServerProxy
 	endpoint, err := c.lifecycle().GetEndpoint(ctx, sandboxID, sdk.DefaultExecdPort, &useProxy)
 	if err != nil {
-		return execdConnection{}, fmt.Errorf("opensandbox resolve execd endpoint: %w", err)
+		return execdConnection{}, fmt.Errorf("opensandbox resolve execd endpoint: %w", c.redactProviderError(err))
 	}
 	conn := c.config()
 	endpointURL := conn.RewriteEndpointURL(endpoint.Endpoint)
@@ -900,6 +924,28 @@ func (c *sdkOpenSandboxClient) resolveExecd(ctx context.Context, sandboxID strin
 		headers[execdAuthHeader] = c.key
 	}
 	return execdConnection{baseURL: endpointURL, rawQuery: rawQuery, headers: headers}, nil
+}
+
+func openSandboxExecdSecrets(conn execdConnection) []string {
+	secrets := make([]string, 0, len(conn.headers)+4)
+	for _, value := range conn.headers {
+		if value = strings.TrimSpace(value); len(value) >= 4 {
+			secrets = append(secrets, value)
+		}
+	}
+	for _, field := range strings.Split(conn.rawQuery, "&") {
+		_, value, found := strings.Cut(field, "=")
+		if !found {
+			value = field
+		}
+		if value = strings.TrimSpace(value); len(value) >= 4 {
+			secrets = append(secrets, value)
+		}
+		if decoded, err := url.QueryUnescape(value); err == nil && decoded != value && len(strings.TrimSpace(decoded)) >= 4 {
+			secrets = append(secrets, decoded)
+		}
+	}
+	return secrets
 }
 
 func normalizeOpenSandboxEndpointHeaders(values map[string]string) (map[string]string, error) {

--- a/internal/providers/opensandbox/client_redaction_test.go
+++ b/internal/providers/opensandbox/client_redaction_test.go
@@ -1,0 +1,86 @@
+package opensandbox
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	sdk "github.com/alibaba/OpenSandbox/sdks/sandbox/go"
+)
+
+func TestRunCommandStreamRedactsOpaqueAPIKeyInErrorBody(t *testing.T) {
+	const lifecycleSecret = "opaque-opensandbox-lifecycle-secret"
+	const headerSecret = "opaque-opensandbox-header-secret"
+	const querySecret = "opaque-opensandbox-query+secret"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-EXECD-ACCESS-TOKEN") != headerSecret || r.URL.Query().Get("signature") != querySecret {
+			t.Errorf("request missing endpoint credentials: headers=%v query=%v", r.Header, r.URL.Query())
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte("provider rejected lifecycle=" + lifecycleSecret + " header=" + headerSecret + " query=" + querySecret + " region=eu"))
+	}))
+	defer server.Close()
+
+	client := &sdkOpenSandboxClient{key: lifecycleSecret, client: server.Client()}
+	err := client.runCommandStream(context.Background(), execdConnection{
+		baseURL:  server.URL,
+		rawQuery: "signature=" + url.QueryEscape(querySecret),
+		headers:  map[string]string{"X-EXECD-ACCESS-TOKEN": headerSecret},
+	}, sdk.RunCommandRequest{}, func(commandStreamEvent) error {
+		return nil
+	})
+	if err == nil {
+		t.Fatal("runCommandStream() error=nil")
+	}
+	for _, secret := range []string{lifecycleSecret, headerSecret, querySecret, url.QueryEscape(querySecret)} {
+		if strings.Contains(err.Error(), secret) {
+			t.Fatalf("runCommandStream() leaked endpoint credential: %q", err)
+		}
+	}
+	if !strings.Contains(err.Error(), "region=eu") || strings.Count(err.Error(), "[redacted]") != 3 {
+		t.Fatalf("runCommandStream() returned unsafe diagnostic: %q", err)
+	}
+}
+
+func TestProbeRedactsOpaqueAPIKeyFromLiveSDKResponse(t *testing.T) {
+	const secret = "opaque-opensandbox-sdk-secret"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"code":"unauthorized","message":"provider rejected opaque=` + secret + ` region=eu"}`))
+	}))
+	defer server.Close()
+
+	client := &sdkOpenSandboxClient{
+		base:   server.URL,
+		key:    secret,
+		client: secureOpenSandboxHTTPClient(server.Client()),
+	}
+	err := client.Probe(context.Background())
+	if err == nil {
+		t.Fatal("Probe() error=nil")
+	}
+	if strings.Contains(err.Error(), secret) || !strings.Contains(err.Error(), "region=eu") || !strings.Contains(err.Error(), "[redacted]") {
+		t.Fatalf("Probe() returned unsafe diagnostic: %q", err)
+	}
+	var apiErr *sdk.APIError
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("Probe() lost SDK error identity: %v", err)
+	}
+}
+
+func TestRedactProviderErrorPreservesErrorChain(t *testing.T) {
+	const secret = "opaque-opensandbox-secret"
+	cause := errors.New("provider rejected opaque=" + secret + " region=eu")
+	got := (&sdkOpenSandboxClient{key: secret}).redactProviderError(cause)
+	if strings.Contains(got.Error(), secret) || !strings.Contains(got.Error(), "region=eu") || !strings.Contains(got.Error(), "[redacted]") {
+		t.Fatalf("redactProviderError() returned unsafe diagnostic: %q", got)
+	}
+	if !errors.Is(got, cause) {
+		t.Fatal("redactProviderError() did not preserve the original error chain")
+	}
+}

--- a/internal/providers/opensandbox/provider.go
+++ b/internal/providers/opensandbox/provider.go
@@ -2,6 +2,7 @@ package opensandbox
 
 import (
 	"flag"
+	"os"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
@@ -15,6 +16,13 @@ type Provider struct{}
 
 func (Provider) Name() string      { return providerName }
 func (Provider) Aliases() []string { return nil }
+
+func (Provider) DiagnosticSecrets(core.Config) []string {
+	return []string{
+		os.Getenv("CRABBOX_OPENSANDBOX_API_KEY"),
+		os.Getenv("OPEN_SANDBOX_API_KEY"),
+	}
+}
 
 func (Provider) ServerTypeForConfig(core.Config) string { return "" }
 func (Provider) ServerTypeForClass(string) string       { return "" }

--- a/internal/providers/superserve/provider.go
+++ b/internal/providers/superserve/provider.go
@@ -2,6 +2,7 @@ package superserve
 
 import (
 	"flag"
+	"os"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
@@ -14,6 +15,13 @@ type Provider struct{}
 
 func (Provider) Name() string      { return providerName }
 func (Provider) Aliases() []string { return nil }
+
+func (Provider) DiagnosticSecrets(core.Config) []string {
+	return []string{
+		os.Getenv("CRABBOX_SUPERSERVE_API_KEY"),
+		os.Getenv("SUPERSERVE_API_KEY"),
+	}
+}
 
 func (Provider) ServerTypeForConfig(core.Config) string { return "" }
 func (Provider) ServerTypeForClass(string) string       { return "" }

--- a/internal/providers/wandb/client.go
+++ b/internal/providers/wandb/client.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/openclaw/crabbox/internal/providers/shared"
 	sandboxv1 "github.com/openclaw/crabbox/internal/providers/wandb/gen/coreweave/sandbox/v1beta2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -121,8 +122,9 @@ type Auth struct {
 // inside that operation, and the backend closes the connection before returning
 // to avoid leaking sockets in long-lived Crabbox processes.
 type wandbClient struct {
-	conn *grpc.ClientConn
-	gw   sandboxv1.GatewayServiceClient
+	conn   *grpc.ClientConn
+	gw     sandboxv1.GatewayServiceClient
+	apiKey string
 }
 
 func newWandbClient(cfg Config, _ Runtime) (wandbAPI, error) {
@@ -156,7 +158,7 @@ func newWandbClient(cfg Config, _ Runtime) (wandbAPI, error) {
 	if err != nil {
 		return nil, fmt.Errorf("dial cwsandbox gateway %s: %w", endpoint, err)
 	}
-	return &wandbClient{conn: conn, gw: sandboxv1.NewGatewayServiceClient(conn)}, nil
+	return &wandbClient{conn: conn, gw: sandboxv1.NewGatewayServiceClient(conn), apiKey: auth.APIKey}, nil
 }
 
 // wandbProviderScope binds a local claim to the exact remote namespace without
@@ -313,7 +315,7 @@ func isLoopbackHost(host string) bool {
 // version the client is wired against.
 func (c *wandbClient) Version(ctx context.Context) (string, error) {
 	if _, err := c.gw.List(ctx, &sandboxv1.ListSandboxesRequest{PageSize: 1}); err != nil {
-		return "", mapRPCError(err, "version probe")
+		return "", mapRPCError(err, "version probe", c.apiKey)
 	}
 	return "coreweave.sandbox.v1beta2", nil
 }
@@ -335,7 +337,7 @@ func (c *wandbClient) Acquire(ctx context.Context, req wandbAcquireRequest) (wan
 		MaxLifetimeSeconds:   int32(req.MaxLifetimeSecs),
 	})
 	if err != nil {
-		return wandbSandbox{}, mapRPCError(err, "Start")
+		return wandbSandbox{}, mapRPCError(err, "Start", c.apiKey)
 	}
 	startupCtx, cancel := context.WithTimeout(ctx, startupTimeout(req.MaxLifetimeSecs))
 	defer cancel()
@@ -360,7 +362,7 @@ func (c *wandbClient) pollUntilRunning(ctx context.Context, id string) (wandbSan
 		}
 		resp, err := c.gw.Get(ctx, &sandboxv1.GetSandboxRequest{SandboxId: id})
 		if err != nil {
-			return wandbSandbox{}, mapRPCError(err, "Get(poll)")
+			return wandbSandbox{}, mapRPCError(err, "Get(poll)", c.apiKey)
 		}
 		switch resp.SandboxStatus {
 		case sandboxv1.SandboxStatus_SANDBOX_STATUS_RUNNING:
@@ -422,7 +424,7 @@ func (c *wandbClient) Exec(ctx context.Context, req wandbExecRequest) (int, erro
 	}
 	resp, err := c.gw.Exec(ctx, grpcReq)
 	if err != nil {
-		return 0, mapRPCError(err, "Exec")
+		return 0, mapRPCError(err, "Exec", c.apiKey)
 	}
 	if resp.Result == nil {
 		return 0, fmt.Errorf("wandb exec: empty response")
@@ -452,7 +454,7 @@ func (c *wandbClient) Stop(ctx context.Context, id string, gracefulSeconds int, 
 		if missingOK && status.Code(err) == codes.NotFound {
 			return nil
 		}
-		return mapRPCError(err, "Stop")
+		return mapRPCError(err, "Stop", c.apiKey)
 	}
 	if resp == nil {
 		return fmt.Errorf("wandb stop %s: empty response", id)
@@ -462,7 +464,7 @@ func (c *wandbClient) Stop(ctx context.Context, id string, gracefulSeconds int, 
 		if msg == "" {
 			msg = "stop failed"
 		}
-		return fmt.Errorf("wandb stop %s: %s", id, msg)
+		return fmt.Errorf("wandb stop %s: %s", id, shared.RedactErrorSecrets(msg, c.apiKey))
 	}
 	return nil
 }
@@ -480,7 +482,7 @@ func (c *wandbClient) List(ctx context.Context, tags []string, statusFilter stri
 	for {
 		resp, err := c.gw.List(ctx, grpcReq)
 		if err != nil {
-			return nil, mapRPCError(err, "List")
+			return nil, mapRPCError(err, "List", c.apiKey)
 		}
 		for _, sb := range resp.Sandboxes {
 			out = append(out, wandbSandbox{
@@ -500,7 +502,7 @@ func (c *wandbClient) List(ctx context.Context, tags []string, statusFilter stri
 func (c *wandbClient) Status(ctx context.Context, id string) (wandbSandbox, error) {
 	resp, err := c.gw.Get(ctx, &sandboxv1.GetSandboxRequest{SandboxId: id})
 	if err != nil {
-		return wandbSandbox{}, mapRPCError(err, "Get")
+		return wandbSandbox{}, mapRPCError(err, "Get", c.apiKey)
 	}
 	return wandbSandbox{
 		ID:        id,
@@ -522,13 +524,14 @@ func formatTimestamp(ts *timestamppb.Timestamp) string {
 // mapRPCError converts a gRPC status into the wandbAPIError surface that
 // callers (and tests) already expect. ExitCode mapping follows sysexits.h:
 // 77 EX_NOPERM, 69 EX_UNAVAILABLE, 124 GNU timeout.
-func mapRPCError(err error, op string) error {
+func mapRPCError(err error, op string, secrets ...string) error {
 	if err == nil {
 		return nil
 	}
 	s, ok := status.FromError(err)
 	if !ok {
-		return &wandbAPIError{ExitCode: 1, Stderr: fmt.Sprintf("%s: %v", op, err)}
+		message := shared.RedactErrorSecrets(err.Error(), secrets...)
+		return &wandbAPIError{ExitCode: 1, Stderr: fmt.Sprintf("%s: %s", op, message)}
 	}
 	exit := 1
 	switch s.Code() {
@@ -545,7 +548,7 @@ func mapRPCError(err error, op string) error {
 	}
 	return &wandbAPIError{
 		ExitCode: exit,
-		Stderr:   fmt.Sprintf("%s: %s", op, s.Message()),
+		Stderr:   fmt.Sprintf("%s: %s", op, shared.RedactErrorSecrets(s.Message(), secrets...)),
 		Code:     s.Code(),
 	}
 }

--- a/internal/providers/wandb/client_test.go
+++ b/internal/providers/wandb/client_test.go
@@ -69,6 +69,19 @@ func TestMapRPCErrorExitCodes(t *testing.T) {
 	}
 }
 
+func TestMapRPCErrorRedactsOpaqueAPIKey(t *testing.T) {
+	const secret = "opaque-wandb-secret"
+	for _, err := range []error{
+		status.Error(codes.Internal, "provider rejected opaque="+secret+" region=eu"),
+		errors.New("transport rejected opaque=" + secret + " region=eu"),
+	} {
+		got := mapRPCError(err, "probe", secret).Error()
+		if strings.Contains(got, secret) || !strings.Contains(got, "region=eu") || !strings.Contains(got, "[redacted]") {
+			t.Fatalf("mapRPCError() returned unsafe diagnostic: %q", got)
+		}
+	}
+}
+
 func TestWandbAPIErrorAsExitError(t *testing.T) {
 	err := &wandbAPIError{ExitCode: 77, Stderr: "auth failed", Code: codes.Unauthenticated}
 	var ee ExitError

--- a/internal/providers/wandb/provider.go
+++ b/internal/providers/wandb/provider.go
@@ -2,6 +2,7 @@ package wandb
 
 import (
 	"flag"
+	"os"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
@@ -14,6 +15,15 @@ type Provider struct{}
 
 func (Provider) Name() string      { return providerName }
 func (Provider) Aliases() []string { return []string{"weights-and-biases"} }
+
+func (Provider) DiagnosticSecrets(cfg core.Config) []string {
+	return []string{
+		os.Getenv("CRABBOX_WANDB_API_KEY"),
+		cfg.Wandb.APIKey,
+		os.Getenv("WANDB_API_KEY"),
+		readNetrcWandbKey(),
+	}
+}
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{


### PR DESCRIPTION
Closes https://github.com/openclaw/crabbox/issues/954
Closes https://github.com/openclaw/crabbox/issues/967
Closes https://github.com/openclaw/crabbox/issues/970

## Summary

- add a provider-owned diagnostic-secret capability for runtime-only environment and local CLI credential stores
- register OpenComputer, CodeSandbox, OpenSandbox, Superserve, Crownest, and W&B credential sources
- redact OpenSandbox lifecycle, execd header, and signed-query credentials across HTTP and SDK errors while preserving error identity
- redact W&B gRPC status, transport, and stop-result diagnostics with the exact active API key
- document the provider-owned credential-discovery boundary and add the Unreleased changelog entry

## Live proof

- exercised the production OpenSandbox command-stream client against a local HTTP endpoint that reflected distinct lifecycle, endpoint-header, and signed-query credentials in an opaque error body; all three were removed while routing context remained
- exercised the production OpenSandbox SDK lifecycle client against a local HTTP endpoint that reflected an opaque credential; the value was removed and the SDK API-error identity/status remained available through the wrapped error
- exercised the full doctor text/JSON recording path with a runtime-only provider credential in an opaque diagnostic

## Validation

- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- `go vet ./...`
- `go test -race ./...`
- `SHARP_IGNORE_GLOBAL_LIBVIPS=1 npm ci --prefix worker`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker` (893 passed, 3 skipped)
- `npm run build --prefix worker`
- `node scripts/build-docs-site.mjs`
- AutoReview clean: no accepted/actionable findings
