### PR TITLE
fix: disable inherited SSH forwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Disabled inherited SSH agent and X11 forwarding across CLI-managed SSH, rsync, SCP, VNC, and port-forward transports, preserving per-lease credential boundaries. Thanks @coygeek.
 - Collected runtime-only provider credentials through provider-owned diagnostic hooks and redacted opaque OpenSandbox and W&B upstream errors before they reach CLI output. Thanks @coygeek.
 - Redacted complete punctuation-bearing authorization, API-key, and bearer values from CLI and coordinator diagnostics while preserving whitespace-separated routing context. Thanks @coygeek.
 - Limited framing of proxied Browser Code responses to the same isolated Code origin, preventing sibling same-site pages from clickjacking an authenticated session without breaking code-server webviews. Thanks @coygeek.

--- a/docs/features/ssh-keys.md
+++ b/docs/features/ssh-keys.md
@@ -36,7 +36,10 @@ A per-lease `known_hosts` file lives next to the key
 - `StrictHostKeyChecking=accept-new` — trust a host's key on first contact, then
   pin it;
 - `UserKnownHostsFile` pointed at the per-lease `known_hosts`;
-- `IdentitiesOnly=yes` with `-i <key>` so only the lease key is offered.
+- `IdentitiesOnly=yes` with `-i <key>` so only the lease key is offered;
+- `ForwardAgent=no`, `ForwardX11=no`, and `ForwardX11Trusted=no` so broad local
+  OpenSSH configuration cannot delegate ambient agent or X11 authority to a
+  lease.
 
 Because host keys are scoped to the lease's own file, a reused provider IP from
 a previous lease never poisons the user's global `~/.ssh/known_hosts`, and two

--- a/docs/security.md
+++ b/docs/security.md
@@ -461,6 +461,9 @@ never proxies SSH traffic. The posture:
   (`<user-config>/crabbox/testboxes/<lease-id>/id_ed25519`; RSA for AWS/Azure
   Windows). Matching cloud key pairs are removed when Crabbox deletes the box.
   See [SSH keys](features/ssh-keys.md).
+- CLI-managed SSH, rsync, SCP, VNC, and port-forward connections explicitly
+  disable agent and X11 forwarding, overriding broad settings inherited from
+  the operator's OpenSSH configuration.
 - SSH listens on the configured primary port (default `2222`) plus configured
   fallback ports (default `22`), because port 22 is not reliably reachable from
   every operator network.

--- a/internal/cli/connect_test.go
+++ b/internal/cli/connect_test.go
@@ -59,6 +59,9 @@ printf 'err\n' >&2
 	wantArgs := []string{
 		"-i", "/tmp/crabbox key",
 		"-o", "IdentitiesOnly=yes",
+		"-o", "ForwardAgent=no",
+		"-o", "ForwardX11=no",
+		"-o", "ForwardX11Trusted=no",
 		"-o", "BatchMode=yes",
 		"-o", "ConnectTimeout=10",
 		"-o", "ConnectionAttempts=3",

--- a/internal/cli/egress.go
+++ b/internal/cli/egress.go
@@ -936,7 +936,7 @@ func egressClientBinaryForTarget(ctx context.Context, target SSHTarget) (string,
 }
 
 func scpBaseArgs(target SSHTarget) []string {
-	args := make([]string, 0, 16)
+	args := sshForwardingDenyArgs()
 	if target.TargetOS == targetWindows && target.WindowsMode != windowsModeWSL2 {
 		args = append(args, "-O")
 	}

--- a/internal/cli/egress_test.go
+++ b/internal/cli/egress_test.go
@@ -261,6 +261,14 @@ func TestSCPBaseArgsUseLegacyProtocolForNativeWindows(t *testing.T) {
 	if slices.Contains(linux, "-O") {
 		t.Fatalf("Linux scp args should not force legacy protocol: %v", linux)
 	}
+	for name, args := range map[string][]string{"native Windows": native, "WSL2": wsl2, "Linux": linux} {
+		got := strings.Join(args, " ")
+		for _, want := range []string{"ForwardAgent=no", "ForwardX11=no", "ForwardX11Trusted=no"} {
+			if !strings.Contains(got, want) {
+				t.Fatalf("%s scp args missing %s: %v", name, want, args)
+			}
+		}
+	}
 }
 
 func TestManualEgressTicketCreationReusesActiveSession(t *testing.T) {

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -598,15 +598,23 @@ func sshBaseArgs(target SSHTarget) []string {
 	return sshBaseArgsWithOptions(target, "10", "3")
 }
 
+func sshForwardingDenyArgs() []string {
+	return []string{
+		"-o", "ForwardAgent=no",
+		"-o", "ForwardX11=no",
+		"-o", "ForwardX11Trusted=no",
+	}
+}
+
 func sshBaseArgsWithOptions(target SSHTarget, connectTimeout, connectionAttempts string) []string {
-	args := []string{
+	args := append(sshForwardingDenyArgs(),
 		"-o", "BatchMode=yes",
-		"-o", "ConnectTimeout=" + connectTimeout,
-		"-o", "ConnectionAttempts=" + connectionAttempts,
+		"-o", "ConnectTimeout="+connectTimeout,
+		"-o", "ConnectionAttempts="+connectionAttempts,
 		"-o", "ServerAliveInterval=15",
 		"-o", "ServerAliveCountMax=2",
 		"-p", target.Port,
-	}
+	)
 	if target.DisableHostKeyChecking {
 		args = append(args,
 			"-o", "StrictHostKeyChecking=no",

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -477,6 +477,9 @@ func TestSSHArgsIncludeReliabilityOptions(t *testing.T) {
 		"ConnectTimeout=10",
 		"ConnectionAttempts=3",
 		"IdentitiesOnly=yes",
+		"ForwardAgent=no",
+		"ForwardX11=no",
+		"ForwardX11Trusted=no",
 		"ServerAliveInterval=15",
 		"ServerAliveCountMax=2",
 		"ControlMaster=auto",
@@ -488,6 +491,34 @@ func TestSSHArgsIncludeReliabilityOptions(t *testing.T) {
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("sshArgs() missing %q in %q", want, got)
+		}
+	}
+}
+
+func TestSSHArgsOverrideAmbientForwardingConfig(t *testing.T) {
+	if _, err := exec.LookPath("ssh"); err != nil {
+		t.Skip("OpenSSH client is unavailable")
+	}
+	configPath := filepath.Join(t.TempDir(), "hostile_config")
+	if err := os.WriteFile(configPath, []byte("Host *\n  ForwardAgent yes\n  ForwardX11 yes\n  ForwardX11Trusted yes\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	target := SSHTarget{User: "crabbox", Host: "203.0.113.10", Port: "2222"}
+	args := append(sshBaseArgs(target), "-F", configPath, "-G", target.User+"@"+target.Host)
+	out, err := exec.Command("ssh", args...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("ssh -G: %v: %s", err, out)
+	}
+	resolved := make(map[string]string)
+	for _, line := range strings.Split(string(out), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 2 {
+			resolved[fields[0]] = fields[1]
+		}
+	}
+	for _, option := range []string{"forwardagent", "forwardx11", "forwardx11trusted"} {
+		if got := resolved[option]; got != "no" {
+			t.Fatalf("ssh -G resolved %s=%q, want no", option, got)
 		}
 	}
 }

--- a/internal/cli/vnc.go
+++ b/internal/cli/vnc.go
@@ -448,11 +448,11 @@ func startVNCTunnel(ctx context.Context, target SSHTarget, localPort, remoteHost
 }
 
 func vncTunnelArgs(target SSHTarget, localPort, remoteHost, remotePort string) []string {
-	args := []string{
+	args := append(sshForwardingDenyArgs(),
 		"-o", "BatchMode=yes",
 		"-o", "StrictHostKeyChecking=accept-new",
-		"-o", "UserKnownHostsFile=" + sshConfigFileValue(knownHostsFile(target)),
-		"-o", "ConnectTimeout=" + strconv.Itoa(int(vncTunnelSSHConnectTimeout/time.Second)),
+		"-o", "UserKnownHostsFile="+sshConfigFileValue(knownHostsFile(target)),
+		"-o", "ConnectTimeout="+strconv.Itoa(int(vncTunnelSSHConnectTimeout/time.Second)),
 		"-o", "ConnectionAttempts=1",
 		"-o", "ExitOnForwardFailure=yes",
 		"-o", "GatewayPorts=no",
@@ -463,7 +463,7 @@ func vncTunnelArgs(target SSHTarget, localPort, remoteHost, remotePort string) [
 		"-o", "ServerAliveInterval=15",
 		"-o", "ServerAliveCountMax=2",
 		"-p", target.Port,
-	}
+	)
 	if target.Key != "" {
 		args = append([]string{"-i", target.Key, "-o", "IdentitiesOnly=yes"}, args...)
 	}

--- a/internal/cli/vnc_test.go
+++ b/internal/cli/vnc_test.go
@@ -221,7 +221,7 @@ func TestVNCTunnelDisablesSSHMultiplexing(t *testing.T) {
 	args := strings.Join(vncTunnelArgs(SSHTarget{
 		Port: "22", User: "crabbox", Host: "192.0.2.10",
 	}, "5907", "127.0.0.1", "5900"), "\n")
-	for _, want := range []string{"ExitOnForwardFailure=yes", "ControlMaster=no", "ControlPath=none", "ControlPersist=no", "ForkAfterAuthentication=no"} {
+	for _, want := range []string{"ForwardAgent=no", "ForwardX11=no", "ForwardX11Trusted=no", "ExitOnForwardFailure=yes", "ControlMaster=no", "ControlPath=none", "ControlPersist=no", "ForkAfterAuthentication=no"} {
 		if !strings.Contains(args, want) {
 			t.Fatalf("dedicated tunnel missing %q: %s", want, args)
 		}


### PR DESCRIPTION
## Summary

- override ambient OpenSSH agent and X11 forwarding for every CLI-managed SSH connection
- reuse one default-deny option builder across interactive SSH, remote commands, rsync, SCP setup, VNC, WebVNC, and pond port forwards
- document the per-lease credential boundary and cover argument propagation plus real OpenSSH option resolution

Closes https://github.com/openclaw/crabbox/issues/963

## Live proof

- Executed the production SSH argument builder through local OpenSSH `ssh -G` with a disposable hostile `Host *` configuration setting `ForwardAgent yes`, `ForwardX11 yes`, and `ForwardX11Trusted yes`.
- OpenSSH resolved all three effective values to `no` without opening a network connection.

## Verification

- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- `go vet ./...`
- `go test -race ./...`
- focused SSH, interactive-connect, SCP, and VNC regression tests
- `SHARP_IGNORE_GLOBAL_LIBVIPS=1 npm ci --prefix worker`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker` (893 passed, 3 skipped)
- `npm run build --prefix worker`
- `node scripts/build-docs-site.mjs`
- AutoReview: no accepted/actionable findings; independent `go test ./internal/cli` passed
