### PR TITLE
feat: add signed run receipts with crabbox run --attest and crabbox verify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added provider-neutral Ed25519-signed run receipts through `crabbox run --attest` and integrity verification through `crabbox verify`, with collision-safe signing-key handling and explicit self-signed trust reporting. Thanks @yetval.
 - Documented a provider-neutral hermetic-agent evidence pattern with separate writer contexts, QA arbitration, required proof artifacts, and sync-safe local downloads. Thanks @zozo123.
 - Added `sync-plan --json` with candidate and dirty-delta sizes, configured guardrail status, deleted-path counts, and ranked file and directory hotspots for automation. Thanks @zozo123.
 - Added a CubeSandbox delegated-run provider with E2B-compatible lifecycle and envd execution, archive sync, CubeProxy routing, exact API-endpoint/sandbox-bound ownership claims, conflict-safe explicit adoption, and guarded cleanup. Thanks @zozo123.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added `sync-plan --json` with candidate and dirty-delta sizes, configured guardrail status, deleted-path counts, and ranked file and directory hotspots for automation. Thanks @zozo123.
 - Added a CubeSandbox delegated-run provider with E2B-compatible lifecycle and envd execution, archive sync, CubeProxy routing, exact API-endpoint/sandbox-bound ownership claims, conflict-safe explicit adoption, and guarded cleanup. Thanks @zozo123.
 - Added coordinator-managed Daytona Linux leases with a Worker-held API key, exact ownership cleanup, expiring SSH-token refresh, CLI secret redaction, and production Cloudflare configuration.
+- Added signed run receipts: `crabbox run --attest <path>` writes an Ed25519-signed receipt of a successful run, and the new `crabbox verify` command checks receipt integrity and reports the signer fingerprint. Thanks @yetval.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
 - Added `sync-plan --json` with candidate and dirty-delta sizes, configured guardrail status, deleted-path counts, and ranked file and directory hotspots for automation. Thanks @zozo123.
 - Added a CubeSandbox delegated-run provider with E2B-compatible lifecycle and envd execution, archive sync, CubeProxy routing, exact API-endpoint/sandbox-bound ownership claims, conflict-safe explicit adoption, and guarded cleanup. Thanks @zozo123.
 - Added coordinator-managed Daytona Linux leases with a Worker-held API key, exact ownership cleanup, expiring SSH-token refresh, CLI secret redaction, and production Cloudflare configuration.
-- Added signed run receipts: `crabbox run --attest <path>` writes an Ed25519-signed receipt of a successful run, and the new `crabbox verify` command checks receipt integrity and reports the signer fingerprint. Thanks @yetval.
 
 ### Fixed
 

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -30,6 +30,7 @@ same order as the CLI help.
 - [events](events.md)
 - [attach](attach.md)
 - [results](results.md)
+- [verify](verify.md)
 - [cache](cache.md)
 - [status](status.md)
 - [list](list.md)

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -344,8 +344,9 @@ Use `--attest <path>` to write a signed run receipt after a successful run: a
 flat JSON record of the provider, lease, command, exit code, timing, and the
 SHA-256 of the combined live output stream, signed with a per-user Ed25519 key
 minted on first use under the user config dir. Check receipts later with
-[`crabbox verify`](verify.md). Pass `--attest-key <path>` to sign with an
-existing PKCS8 PEM Ed25519 key instead of the default one.
+[`crabbox verify`](verify.md), then compare the reported signer fingerprint
+through a trusted channel. Pass `--attest-key <path>` to sign with an existing
+PKCS8 PEM Ed25519 key instead of the default one.
 
 ## Artifacts and downloads
 

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -340,6 +340,13 @@ selected live console output, collected artifact paths, and the
 `--proof-template` or preset template. Keep proof templates in repo config so
 parser-sensitive PR wording stays project-owned.
 
+Use `--attest <path>` to write a signed run receipt after a successful run: a
+flat JSON record of the provider, lease, command, exit code, timing, and the
+SHA-256 of the combined live output stream, signed with a per-user Ed25519 key
+minted on first use under the user config dir. Check receipts later with
+[`crabbox verify`](verify.md). Pass `--attest-key <path>` to sign with an
+existing PKCS8 PEM Ed25519 key instead of the default one.
+
 ## Artifacts and downloads
 
 Use repeatable `--artifact-glob <glob>` to collect matching remote files after a
@@ -553,6 +560,8 @@ Run-specific flags:
 --preset-var name=value      Repeatable or comma-separated.
 --emit-proof <path>
 --proof-template <name>
+--attest <path>
+--attest-key <path>
 --preflight
 --preflight-tools <comma-separated tool names>
 --junit <comma-separated remote XML paths>

--- a/docs/commands/verify.md
+++ b/docs/commands/verify.md
@@ -3,7 +3,8 @@
 `crabbox verify` checks a signed run receipt produced by `crabbox run --attest`.
 It recomputes the receipt's canonical bytes, verifies the embedded Ed25519
 signature, and prints the signer's public key fingerprint, so a reviewer can
-confirm a pasted receipt has not been edited after the run.
+confirm a pasted receipt has not been edited after the run once they have
+matched the fingerprint through a trusted channel.
 
 ```sh
 crabbox run --attest receipt.json -- go test ./...
@@ -13,14 +14,14 @@ crabbox verify receipt.json
 On success it prints one line and exits 0:
 
 ```
-PASS receipt.json signer=sha256:6a5f...
+PASS receipt.json signer=sha256:6a5f... trust=self-signed
 ```
 
 If any signed field was modified after signing, it prints a failure line and
 exits 1:
 
 ```
-FAIL receipt.json signer=sha256:6a5f...: signature mismatch
+FAIL receipt.json signer=sha256:6a5f... trust=self-signed: signature mismatch
 ```
 
 A receipt that cannot be checked at all (unreadable file, invalid JSON,
@@ -35,7 +36,7 @@ The receipt is a flat JSON object. `schema_version`, `generated_at`,
 `provider`, `command`, `exit_code`, `command_ms`, and `public_key` are always
 present; `lease_id`, `slug`, `run_id`, `actions_url`, and `log_sha256` appear
 when the run produced them. `log_sha256` is the SHA-256 of the combined
-stdout and stderr stream as observed by the client during brokered SSH runs.
+stdout and stderr stream as observed by the client during SSH-backed runs.
 
 The signature covers the canonical encoding of every field except `signature`
 itself: the object is re-marshaled as compact JSON with lexicographically
@@ -52,7 +53,9 @@ PKCS8 PEM Ed25519 key instead; the override path is never auto-created.
 
 Verification trusts the key embedded in the receipt and reports its
 fingerprint. Binding that fingerprint to an identity is out of scope: compare
-it out of band with the signer.
+it out of band with the signer. The `trust=self-signed` marker is printed on
+every verification result so `PASS` cannot be mistaken for an identity or
+execution-provenance check.
 
 ## Non-goals
 

--- a/docs/commands/verify.md
+++ b/docs/commands/verify.md
@@ -1,0 +1,59 @@
+# verify
+
+`crabbox verify` checks a signed run receipt produced by `crabbox run --attest`.
+It recomputes the receipt's canonical bytes, verifies the embedded Ed25519
+signature, and prints the signer's public key fingerprint, so a reviewer can
+confirm a pasted receipt has not been edited after the run.
+
+```sh
+crabbox run --attest receipt.json -- go test ./...
+crabbox verify receipt.json
+```
+
+On success it prints one line and exits 0:
+
+```
+PASS receipt.json signer=sha256:6a5f...
+```
+
+If any signed field was modified after signing, it prints a failure line and
+exits 1:
+
+```
+FAIL receipt.json signer=sha256:6a5f...: signature mismatch
+```
+
+A receipt that cannot be checked at all (unreadable file, invalid JSON, a
+missing or malformed `public_key` or `signature`) exits 2 with an error on
+stderr.
+
+## Receipt format
+
+The receipt is a flat JSON object. `schema_version`, `generated_at`,
+`provider`, `lease_id`, `command`, `exit_code`, `command_ms`, and `public_key`
+are always present; `slug`, `run_id`, `actions_url`, and `log_sha256` appear
+when the run produced them. `log_sha256` is the SHA-256 of the combined
+stdout and stderr stream as observed by the client during brokered SSH runs.
+
+The signature covers the canonical encoding of every field except `signature`
+itself: the object is re-marshaled as compact JSON with lexicographically
+sorted keys, and the Ed25519 signature is computed over those bytes. Because
+`public_key` is inside the signed payload, swapping in a different key also
+fails verification.
+
+## Keys
+
+Signing uses a per-user Ed25519 key that `crabbox run --attest` mints on first
+use at `<user config dir>/crabbox/attest/id_ed25519.pem` (PKCS8 PEM, file mode
+0600). Pass `--attest-key <path>` to `crabbox run` to sign with an existing
+PKCS8 PEM Ed25519 key instead; the override path is never auto-created.
+
+Verification trusts the key embedded in the receipt and reports its
+fingerprint. Binding that fingerprint to an identity is out of scope: compare
+it out of band with the signer.
+
+## Non-goals
+
+`crabbox verify` proves integrity and possession of the signing key, not
+identity or execution provenance. There are no trust roots, no transparency
+log, and no coordinator-held keys in this version.

--- a/docs/commands/verify.md
+++ b/docs/commands/verify.md
@@ -32,8 +32,8 @@ show one value to a reader while the signature still verifies against another.
 ## Receipt format
 
 The receipt is a flat JSON object. `schema_version`, `generated_at`,
-`provider`, `lease_id`, `command`, `exit_code`, `command_ms`, and `public_key`
-are always present; `slug`, `run_id`, `actions_url`, and `log_sha256` appear
+`provider`, `command`, `exit_code`, `command_ms`, and `public_key` are always
+present; `lease_id`, `slug`, `run_id`, `actions_url`, and `log_sha256` appear
 when the run produced them. `log_sha256` is the SHA-256 of the combined
 stdout and stderr stream as observed by the client during brokered SSH runs.
 

--- a/docs/commands/verify.md
+++ b/docs/commands/verify.md
@@ -23,9 +23,11 @@ exits 1:
 FAIL receipt.json signer=sha256:6a5f...: signature mismatch
 ```
 
-A receipt that cannot be checked at all (unreadable file, invalid JSON, a
-missing or malformed `public_key` or `signature`) exits 2 with an error on
-stderr.
+A receipt that cannot be checked at all (unreadable file, invalid JSON,
+duplicate JSON keys, a missing or malformed `public_key` or `signature`) exits
+2 with an error on stderr. Duplicate keys are rejected outright because JSON
+parsers disagree on which duplicate wins, which would let an edited receipt
+show one value to a reader while the signature still verifies against another.
 
 ## Receipt format
 

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -143,6 +143,7 @@ Provider deep-dives that live here in `features/`:
 - [events](../commands/events.md) — show run events
 - [attach](../commands/attach.md) — attach to an active run
 - [results](../commands/results.md) — show test results
+- [verify](../commands/verify.md) — check a signed run receipt
 - [artifacts](../commands/artifacts.md) — manage run artifacts
 - [media](../commands/media.md) — capture screenshots/video
 

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -99,6 +99,8 @@ func (a App) directCommandHelp(ctx context.Context, args []string) (error, bool)
 		return a.attach(ctx, helpArgs), true
 	case "results":
 		return a.results(ctx, helpArgs), true
+	case "verify":
+		return a.verify(ctx, helpArgs), true
 	case "status":
 		return a.status(ctx, helpArgs), true
 	case "list":
@@ -194,6 +196,7 @@ Commands:
   events      Print recorded run events
   attach      Follow recorded events for an active run
   results     Show recorded test result summaries
+  verify      Verify a signed run receipt
   cache       Inspect, purge, warm, or list remote cache volumes
   status      Show lease state; add --wait to block until ready
   list        List Crabbox machines

--- a/internal/cli/attest.go
+++ b/internal/cli/attest.go
@@ -210,7 +210,6 @@ var attestRequiredReceiptFields = []string{
 	"schema_version",
 	"generated_at",
 	"provider",
-	"lease_id",
 	"command",
 	"exit_code",
 	"command_ms",
@@ -273,12 +272,12 @@ func validateRunReceipt(receipt map[string]any) error {
 	if _, err := time.Parse(time.RFC3339, generatedAt); err != nil {
 		return fmt.Errorf("invalid generated_at")
 	}
-	for _, key := range []string{"provider", "lease_id", "command", "public_key", "signature"} {
+	for _, key := range []string{"provider", "command", "public_key", "signature"} {
 		if _, err := receiptString(receipt, key); err != nil {
 			return err
 		}
 	}
-	for _, key := range []string{"slug", "run_id", "actions_url"} {
+	for _, key := range []string{"lease_id", "slug", "run_id", "actions_url"} {
 		if _, ok := receipt[key]; ok {
 			if _, err := receiptString(receipt, key); err != nil {
 				return err
@@ -349,11 +348,13 @@ func writeRunReceipt(path, keyPath string, in runReceiptInput) (runArtifact, err
 		"schema_version": attestReceiptSchemaVersion,
 		"generated_at":   time.Now().UTC().Format(time.RFC3339),
 		"provider":       in.Provider,
-		"lease_id":       in.LeaseID,
 		"command":        in.Command,
 		"exit_code":      in.ExitCode,
 		"command_ms":     in.CommandMs,
 		"public_key":     base64.StdEncoding.EncodeToString(pub),
+	}
+	if in.LeaseID != "" {
+		receipt["lease_id"] = in.LeaseID
 	}
 	if in.Slug != "" {
 		receipt["slug"] = in.Slug

--- a/internal/cli/attest.go
+++ b/internal/cli/attest.go
@@ -11,15 +11,21 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"hash"
+	"io"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 )
 
 const attestReceiptSchemaVersion = 1
+
+var errDuplicateReceiptKey = errors.New("duplicate key")
 
 type runReceiptInput struct {
 	Provider   string
@@ -48,6 +54,8 @@ func ensureAttestKey() (ed25519.PrivateKey, error) {
 	}
 	if _, err := os.Stat(path); err == nil {
 		return loadAttestKey(path)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, err
 	}
 	if err := createPrivateRunOutputDir(filepath.Dir(path)); err != nil {
 		return nil, err
@@ -72,9 +80,15 @@ func loadAttestKey(path string) (ed25519.PrivateKey, error) {
 	if err != nil {
 		return nil, err
 	}
-	block, _ := pem.Decode(data)
+	block, rest := pem.Decode(data)
 	if block == nil {
 		return nil, fmt.Errorf("attest key %s is not PEM encoded", path)
+	}
+	if block.Type != "PRIVATE KEY" {
+		return nil, fmt.Errorf("attest key %s is not a PKCS8 private key", path)
+	}
+	if len(bytes.TrimSpace(rest)) != 0 {
+		return nil, fmt.Errorf("attest key %s has trailing data", path)
 	}
 	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
 	if err != nil {
@@ -176,6 +190,155 @@ func canonicalReceiptBytes(receipt map[string]any) ([]byte, error) {
 	return json.Marshal(unsigned)
 }
 
+var attestReceiptFields = map[string]bool{
+	"schema_version": true,
+	"generated_at":   true,
+	"provider":       true,
+	"lease_id":       true,
+	"slug":           true,
+	"run_id":         true,
+	"command":        true,
+	"exit_code":      true,
+	"command_ms":     true,
+	"actions_url":    true,
+	"log_sha256":     true,
+	"public_key":     true,
+	"signature":      true,
+}
+
+var attestRequiredReceiptFields = []string{
+	"schema_version",
+	"generated_at",
+	"provider",
+	"lease_id",
+	"command",
+	"exit_code",
+	"command_ms",
+	"public_key",
+	"signature",
+}
+
+func decodeRunReceipt(data []byte) (map[string]any, error) {
+	duplicate, err := jsonHasDuplicateKeys(json.NewDecoder(bytes.NewReader(data)))
+	if err != nil {
+		return nil, err
+	}
+	if duplicate {
+		return nil, errDuplicateReceiptKey
+	}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	var receipt map[string]any
+	if err := dec.Decode(&receipt); err != nil {
+		return nil, err
+	}
+	var extra any
+	if err := dec.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return nil, fmt.Errorf("multiple JSON values")
+		}
+		return nil, err
+	}
+	if err := validateRunReceipt(receipt); err != nil {
+		return nil, err
+	}
+	return receipt, nil
+}
+
+func validateRunReceipt(receipt map[string]any) error {
+	if len(receipt) == 0 {
+		return fmt.Errorf("empty receipt")
+	}
+	for key := range receipt {
+		if !attestReceiptFields[key] {
+			return fmt.Errorf("unknown field %q", key)
+		}
+	}
+	for _, key := range attestRequiredReceiptFields {
+		if _, ok := receipt[key]; !ok {
+			return fmt.Errorf("missing %s", key)
+		}
+	}
+	schemaVersion, err := receiptInt64(receipt, "schema_version")
+	if err != nil {
+		return err
+	}
+	if schemaVersion != attestReceiptSchemaVersion {
+		return fmt.Errorf("unsupported schema_version %d", schemaVersion)
+	}
+	generatedAt, err := receiptString(receipt, "generated_at")
+	if err != nil {
+		return err
+	}
+	if _, err := time.Parse(time.RFC3339, generatedAt); err != nil {
+		return fmt.Errorf("invalid generated_at")
+	}
+	for _, key := range []string{"provider", "lease_id", "command", "public_key", "signature"} {
+		if _, err := receiptString(receipt, key); err != nil {
+			return err
+		}
+	}
+	for _, key := range []string{"slug", "run_id", "actions_url"} {
+		if _, ok := receipt[key]; ok {
+			if _, err := receiptString(receipt, key); err != nil {
+				return err
+			}
+		}
+	}
+	exitCode, err := receiptInt64(receipt, "exit_code")
+	if err != nil {
+		return err
+	}
+	if exitCode < 0 {
+		return fmt.Errorf("invalid exit_code")
+	}
+	commandMs, err := receiptInt64(receipt, "command_ms")
+	if err != nil {
+		return err
+	}
+	if commandMs < 0 {
+		return fmt.Errorf("invalid command_ms")
+	}
+	if _, ok := receipt["log_sha256"]; ok {
+		logDigest, err := receiptString(receipt, "log_sha256")
+		if err != nil {
+			return err
+		}
+		if !validSHA256Digest(logDigest) {
+			return fmt.Errorf("invalid log_sha256")
+		}
+	}
+	return nil
+}
+
+func receiptString(receipt map[string]any, key string) (string, error) {
+	value, ok := receipt[key].(string)
+	if !ok || strings.TrimSpace(value) == "" {
+		return "", fmt.Errorf("invalid %s", key)
+	}
+	return value, nil
+}
+
+func receiptInt64(receipt map[string]any, key string) (int64, error) {
+	number, ok := receipt[key].(json.Number)
+	if !ok {
+		return 0, fmt.Errorf("invalid %s", key)
+	}
+	value, err := strconv.ParseInt(number.String(), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s", key)
+	}
+	return value, nil
+}
+
+func validSHA256Digest(value string) bool {
+	if !strings.HasPrefix(value, "sha256:") {
+		return false
+	}
+	decoded, err := hex.DecodeString(strings.TrimPrefix(value, "sha256:"))
+	return err == nil && len(decoded) == sha256.Size
+}
+
 func writeRunReceipt(path, keyPath string, in runReceiptInput) (runArtifact, error) {
 	key, err := resolveAttestKey(keyPath)
 	if err != nil {
@@ -233,16 +396,12 @@ func (a App) verify(ctx context.Context, args []string) error {
 	if err != nil {
 		return exit(2, "read receipt: %v", err)
 	}
-	var receipt map[string]any
-	if err := json.Unmarshal(data, &receipt); err != nil {
-		return exit(2, "parse receipt: %v", err)
-	}
-	duplicate, err := jsonHasDuplicateKeys(json.NewDecoder(bytes.NewReader(data)))
-	if err != nil {
-		return exit(2, "parse receipt: %v", err)
-	}
-	if duplicate {
+	receipt, err := decodeRunReceipt(data)
+	if errors.Is(err, errDuplicateReceiptKey) {
 		return exit(2, "malformed receipt: duplicate key")
+	}
+	if err != nil {
+		return exit(2, "malformed receipt: %v", err)
 	}
 	pubText, ok := receipt["public_key"].(string)
 	if !ok {

--- a/internal/cli/attest.go
+++ b/internal/cli/attest.go
@@ -377,8 +377,13 @@ func writeRunReceipt(path, keyPath string, in runReceiptInput) (runArtifact, err
 		return runArtifact{}, err
 	}
 	encoded = append(encoded, '\n')
+	if dir := filepath.Dir(path); dir != "." && dir != "" {
+		if err := createPrivateRunOutputDir(dir); err != nil {
+			return runArtifact{}, exit(2, "create receipt directory: %v", err)
+		}
+	}
 	if err := writePrivateRunOutputFile(path, encoded); err != nil {
-		return runArtifact{}, err
+		return runArtifact{}, exit(2, "write receipt %s: %v", path, err)
 	}
 	return runArtifact{Kind: "receipt", Path: path, Bytes: len(encoded)}, nil
 }

--- a/internal/cli/attest.go
+++ b/internal/cli/attest.go
@@ -57,7 +57,7 @@ func ensureAttestKey() (ed25519.PrivateKey, error) {
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return nil, err
 	}
-	if err := createPrivateRunOutputDir(filepath.Dir(path)); err != nil {
+	if err := ensurePrivateRunOutputDir(filepath.Dir(path)); err != nil {
 		return nil, err
 	}
 	_, key, err := ed25519.GenerateKey(rand.Reader)
@@ -69,10 +69,96 @@ func ensureAttestKey() (ed25519.PrivateKey, error) {
 		return nil, err
 	}
 	encoded := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
-	if err := writePrivateRunOutputFile(path, encoded); err != nil {
+	created, err := writePrivateRunOutputFileIfAbsent(path, encoded)
+	if err != nil {
 		return nil, err
 	}
+	if !created {
+		return loadAttestKey(path)
+	}
 	return key, nil
+}
+
+type attestPathPreflight struct {
+	Receipt             string
+	KeyOverride         string
+	LeaseOutput         string
+	EmitProof           string
+	CaptureStdout       string
+	CaptureStderr       string
+	TimingRecord        string
+	TimingRecordEnabled bool
+	Downloads           []string
+}
+
+type attestLocalPath struct {
+	label string
+	path  string
+}
+
+func preflightAttestPaths(opts attestPathPreflight) error {
+	receiptPath := strings.TrimSpace(opts.Receipt)
+	keyOverride := strings.TrimSpace(opts.KeyOverride)
+	if receiptPath == "" {
+		if keyOverride != "" {
+			return exit(2, "--attest-key requires --attest")
+		}
+		return nil
+	}
+	keyPath := keyOverride
+	if keyPath == "" {
+		var err error
+		keyPath, err = attestKeyPath()
+		if err != nil {
+			return exit(2, "attest key path: %v", err)
+		}
+	}
+	outputs := []attestLocalPath{
+		{label: "lease output", path: strings.TrimSpace(opts.LeaseOutput)},
+		{label: "emit proof", path: strings.TrimSpace(opts.EmitProof)},
+		{label: "capture stdout", path: strings.TrimSpace(opts.CaptureStdout)},
+		{label: "capture stderr", path: strings.TrimSpace(opts.CaptureStderr)},
+	}
+	if opts.TimingRecordEnabled {
+		outputs = append(outputs, attestLocalPath{label: "timing record", path: strings.TrimSpace(opts.TimingRecord)})
+	}
+	for _, spec := range opts.Downloads {
+		download, err := parseRunDownloadSpec(spec)
+		if err != nil {
+			return err
+		}
+		outputs = append(outputs, attestLocalPath{label: "download " + download.Remote, path: download.Local})
+	}
+	for _, left := range []attestLocalPath{
+		{label: "attest receipt", path: receiptPath},
+		{label: "attest key", path: keyPath},
+	} {
+		for _, right := range outputs {
+			if right.path == "" {
+				continue
+			}
+			same, err := sameLocalOutputPath(left.path, right.path)
+			if err != nil {
+				return err
+			}
+			if same {
+				return exit(2, "%s and %s paths must be different", left.label, right.label)
+			}
+		}
+	}
+	same, err := sameLocalOutputPath(receiptPath, keyPath)
+	if err != nil {
+		return err
+	}
+	if same {
+		return exit(2, "attest receipt and attest key paths must be different")
+	}
+	if keyOverride != "" {
+		if _, err := loadAttestKey(keyOverride); err != nil {
+			return exit(2, "attest key: %v", err)
+		}
+	}
+	return nil
 }
 
 func loadAttestKey(path string) (ed25519.PrivateKey, error) {
@@ -431,9 +517,9 @@ func (a App) verify(ctx context.Context, args []string) error {
 	}
 	fingerprint := attestFingerprint(ed25519.PublicKey(pub))
 	if !ed25519.Verify(ed25519.PublicKey(pub), canonical, sig) {
-		fmt.Fprintf(a.Stdout, "FAIL %s signer=%s: signature mismatch\n", path, fingerprint)
+		fmt.Fprintf(a.Stdout, "FAIL %s signer=%s trust=self-signed: signature mismatch\n", path, fingerprint)
 		return ExitError{Code: 1}
 	}
-	fmt.Fprintf(a.Stdout, "PASS %s signer=%s\n", path, fingerprint)
+	fmt.Fprintf(a.Stdout, "PASS %s signer=%s trust=self-signed\n", path, fingerprint)
 	return nil
 }

--- a/internal/cli/attest.go
+++ b/internal/cli/attest.go
@@ -12,8 +12,10 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"hash"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 )
 
@@ -95,6 +97,27 @@ func resolveAttestKey(override string) (ed25519.PrivateKey, error) {
 func attestFingerprint(pub ed25519.PublicKey) string {
 	digest := sha256.Sum256(pub)
 	return "sha256:" + hex.EncodeToString(digest[:])
+}
+
+type attestDigestWriter struct {
+	mu     sync.Mutex
+	digest hash.Hash
+}
+
+func newAttestDigestWriter() *attestDigestWriter {
+	return &attestDigestWriter{digest: sha256.New()}
+}
+
+func (w *attestDigestWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.digest.Write(p)
+}
+
+func (w *attestDigestWriter) sum() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return "sha256:" + hex.EncodeToString(w.digest.Sum(nil))
 }
 
 func jsonHasDuplicateKeys(dec *json.Decoder) (bool, error) {

--- a/internal/cli/attest.go
+++ b/internal/cli/attest.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
@@ -96,6 +97,51 @@ func attestFingerprint(pub ed25519.PublicKey) string {
 	return "sha256:" + hex.EncodeToString(digest[:])
 }
 
+func jsonHasDuplicateKeys(dec *json.Decoder) (bool, error) {
+	token, err := dec.Token()
+	if err != nil {
+		return false, err
+	}
+	delim, ok := token.(json.Delim)
+	if !ok {
+		return false, nil
+	}
+	switch delim {
+	case '{':
+		seen := map[string]bool{}
+		for dec.More() {
+			keyToken, err := dec.Token()
+			if err != nil {
+				return false, err
+			}
+			key, ok := keyToken.(string)
+			if !ok {
+				return false, fmt.Errorf("invalid object key")
+			}
+			if seen[key] {
+				return true, nil
+			}
+			seen[key] = true
+			duplicate, err := jsonHasDuplicateKeys(dec)
+			if duplicate || err != nil {
+				return duplicate, err
+			}
+		}
+		_, err = dec.Token()
+		return false, err
+	case '[':
+		for dec.More() {
+			duplicate, err := jsonHasDuplicateKeys(dec)
+			if duplicate || err != nil {
+				return duplicate, err
+			}
+		}
+		_, err = dec.Token()
+		return false, err
+	}
+	return false, nil
+}
+
 func canonicalReceiptBytes(receipt map[string]any) ([]byte, error) {
 	unsigned := make(map[string]any, len(receipt))
 	for key, value := range receipt {
@@ -167,6 +213,13 @@ func (a App) verify(ctx context.Context, args []string) error {
 	var receipt map[string]any
 	if err := json.Unmarshal(data, &receipt); err != nil {
 		return exit(2, "parse receipt: %v", err)
+	}
+	duplicate, err := jsonHasDuplicateKeys(json.NewDecoder(bytes.NewReader(data)))
+	if err != nil {
+		return exit(2, "parse receipt: %v", err)
+	}
+	if duplicate {
+		return exit(2, "malformed receipt: duplicate key")
 	}
 	pubText, ok := receipt["public_key"].(string)
 	if !ok {

--- a/internal/cli/attest.go
+++ b/internal/cli/attest.go
@@ -1,0 +1,198 @@
+package cli
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const attestReceiptSchemaVersion = 1
+
+type runReceiptInput struct {
+	Provider   string
+	LeaseID    string
+	Slug       string
+	RunID      string
+	Command    string
+	ExitCode   int
+	CommandMs  int64
+	ActionsURL string
+	LogSHA256  string
+}
+
+func attestKeyPath() (string, error) {
+	base, err := os.UserConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, "crabbox", "attest", "id_ed25519.pem"), nil
+}
+
+func ensureAttestKey() (ed25519.PrivateKey, error) {
+	path, err := attestKeyPath()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := os.Stat(path); err == nil {
+		return loadAttestKey(path)
+	}
+	if err := createPrivateRunOutputDir(filepath.Dir(path)); err != nil {
+		return nil, err
+	}
+	_, key, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		return nil, err
+	}
+	encoded := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+	if err := writePrivateRunOutputFile(path, encoded); err != nil {
+		return nil, err
+	}
+	return key, nil
+}
+
+func loadAttestKey(path string) (ed25519.PrivateKey, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, fmt.Errorf("attest key %s is not PEM encoded", path)
+	}
+	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	key, ok := parsed.(ed25519.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("attest key %s is not an ed25519 key", path)
+	}
+	return key, nil
+}
+
+func resolveAttestKey(override string) (ed25519.PrivateKey, error) {
+	if override != "" {
+		return loadAttestKey(override)
+	}
+	return ensureAttestKey()
+}
+
+func attestFingerprint(pub ed25519.PublicKey) string {
+	digest := sha256.Sum256(pub)
+	return "sha256:" + hex.EncodeToString(digest[:])
+}
+
+func canonicalReceiptBytes(receipt map[string]any) ([]byte, error) {
+	unsigned := make(map[string]any, len(receipt))
+	for key, value := range receipt {
+		if key == "signature" {
+			continue
+		}
+		unsigned[key] = value
+	}
+	return json.Marshal(unsigned)
+}
+
+func writeRunReceipt(path, keyPath string, in runReceiptInput) (runArtifact, error) {
+	key, err := resolveAttestKey(keyPath)
+	if err != nil {
+		return runArtifact{}, exit(2, "attest key: %v", err)
+	}
+	pub := key.Public().(ed25519.PublicKey)
+	receipt := map[string]any{
+		"schema_version": attestReceiptSchemaVersion,
+		"generated_at":   time.Now().UTC().Format(time.RFC3339),
+		"provider":       in.Provider,
+		"lease_id":       in.LeaseID,
+		"command":        in.Command,
+		"exit_code":      in.ExitCode,
+		"command_ms":     in.CommandMs,
+		"public_key":     base64.StdEncoding.EncodeToString(pub),
+	}
+	if in.Slug != "" {
+		receipt["slug"] = in.Slug
+	}
+	if in.RunID != "" {
+		receipt["run_id"] = in.RunID
+	}
+	if in.ActionsURL != "" {
+		receipt["actions_url"] = in.ActionsURL
+	}
+	if in.LogSHA256 != "" {
+		receipt["log_sha256"] = in.LogSHA256
+	}
+	canonical, err := canonicalReceiptBytes(receipt)
+	if err != nil {
+		return runArtifact{}, err
+	}
+	receipt["signature"] = base64.StdEncoding.EncodeToString(ed25519.Sign(key, canonical))
+	encoded, err := json.MarshalIndent(receipt, "", "  ")
+	if err != nil {
+		return runArtifact{}, err
+	}
+	encoded = append(encoded, '\n')
+	if err := writePrivateRunOutputFile(path, encoded); err != nil {
+		return runArtifact{}, err
+	}
+	return runArtifact{Kind: "receipt", Path: path, Bytes: len(encoded)}, nil
+}
+
+func (a App) verify(ctx context.Context, args []string) error {
+	fs := newFlagSet("verify", a.Stderr)
+	if err := parseFlags(fs, args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return exit(2, "usage: crabbox verify <receipt.json>")
+	}
+	path := fs.Arg(0)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return exit(2, "read receipt: %v", err)
+	}
+	var receipt map[string]any
+	if err := json.Unmarshal(data, &receipt); err != nil {
+		return exit(2, "parse receipt: %v", err)
+	}
+	pubText, ok := receipt["public_key"].(string)
+	if !ok {
+		return exit(2, "malformed receipt: missing public_key")
+	}
+	pub, err := base64.StdEncoding.DecodeString(pubText)
+	if err != nil || len(pub) != ed25519.PublicKeySize {
+		return exit(2, "malformed receipt: invalid public_key")
+	}
+	sigText, ok := receipt["signature"].(string)
+	if !ok {
+		return exit(2, "malformed receipt: missing signature")
+	}
+	sig, err := base64.StdEncoding.DecodeString(sigText)
+	if err != nil || len(sig) != ed25519.SignatureSize {
+		return exit(2, "malformed receipt: invalid signature")
+	}
+	canonical, err := canonicalReceiptBytes(receipt)
+	if err != nil {
+		return exit(2, "canonicalize receipt: %v", err)
+	}
+	fingerprint := attestFingerprint(ed25519.PublicKey(pub))
+	if !ed25519.Verify(ed25519.PublicKey(pub), canonical, sig) {
+		fmt.Fprintf(a.Stdout, "FAIL %s signer=%s: signature mismatch\n", path, fingerprint)
+		return ExitError{Code: 1}
+	}
+	fmt.Fprintf(a.Stdout, "PASS %s signer=%s\n", path, fingerprint)
+	return nil
+}

--- a/internal/cli/attest_test.go
+++ b/internal/cli/attest_test.go
@@ -7,14 +7,18 @@ import (
 	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -238,6 +242,50 @@ func TestVerifyRejectsTamperedReceipts(t *testing.T) {
 			t.Fatalf("expected exit 2, got %v", err)
 		}
 	})
+}
+
+func TestAttestDigestWriterSerializesConcurrentStreams(t *testing.T) {
+	writer := newAttestDigestWriter()
+	stdout := io.MultiWriter(io.Discard, writer)
+	stderr := io.MultiWriter(io.Discard, writer)
+	chunk := bytes.Repeat([]byte("a"), 1024)
+	rounds := 64
+	var wg sync.WaitGroup
+	for _, stream := range []io.Writer{stdout, stderr} {
+		wg.Add(1)
+		go func(stream io.Writer) {
+			defer wg.Done()
+			for i := 0; i < rounds; i++ {
+				if _, err := stream.Write(chunk); err != nil {
+					t.Error(err)
+				}
+			}
+		}(stream)
+	}
+	wg.Wait()
+	expected := sha256.Sum256(bytes.Repeat([]byte("a"), 2*rounds*1024))
+	if got := writer.sum(); got != "sha256:"+hex.EncodeToString(expected[:]) {
+		t.Fatalf("unexpected digest %s", got)
+	}
+}
+
+func TestAttestDigestWriterHashesMixedStreamsInArrivalOrder(t *testing.T) {
+	writer := newAttestDigestWriter()
+	stdout := io.MultiWriter(io.Discard, writer)
+	stderr := io.MultiWriter(io.Discard, writer)
+	if _, err := stdout.Write([]byte("out line\n")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := stderr.Write([]byte("err line\n")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := stdout.Write([]byte("done\n")); err != nil {
+		t.Fatal(err)
+	}
+	expected := sha256.Sum256([]byte("out line\nerr line\ndone\n"))
+	if got := writer.sum(); got != "sha256:"+hex.EncodeToString(expected[:]) {
+		t.Fatalf("unexpected digest %s", got)
+	}
 }
 
 func TestAttestReceiptPathCollisions(t *testing.T) {

--- a/internal/cli/attest_test.go
+++ b/internal/cli/attest_test.go
@@ -349,6 +349,30 @@ func TestAttestDigestWriterHashesMixedStreamsInArrivalOrder(t *testing.T) {
 	}
 }
 
+func TestAttestReceiptCreatesMissingParentDirectories(t *testing.T) {
+	setAttestTestHome(t)
+	path := filepath.Join(t.TempDir(), "nested", "deeper", "receipt.json")
+	if _, err := writeRunReceipt(path, "", fullReceiptInput()); err != nil {
+		t.Fatalf("write receipt: %v", err)
+	}
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(filepath.Dir(path))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode().Perm() != 0o700 {
+			t.Fatalf("expected receipt dir mode 0700, got %v", info.Mode().Perm())
+		}
+	}
+	out, err := runVerify(t, path)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if !strings.HasPrefix(out, "PASS ") {
+		t.Fatalf("unexpected verify output: %q", out)
+	}
+}
+
 func TestAttestReceiptPathCollisions(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "receipt.json")
 	if err := preflightRunOutputCollisions("attest receipt", path, path, "", nil); err == nil {

--- a/internal/cli/attest_test.go
+++ b/internal/cli/attest_test.go
@@ -173,6 +173,41 @@ func TestVerifyRejectsTamperedReceipts(t *testing.T) {
 			wantCode: 2,
 		},
 		{
+			name: "unsupported schema version",
+			mutate: func(t *testing.T, path string, receipt map[string]any) []byte {
+				receipt["schema_version"] = 2
+				return marshalReceipt(t, receipt)
+			},
+			wantCode: 2,
+		},
+		{
+			name: "unknown field",
+			mutate: func(t *testing.T, path string, receipt map[string]any) []byte {
+				receipt["review_note"] = "not part of the receipt schema"
+				return marshalReceipt(t, receipt)
+			},
+			wantCode: 2,
+		},
+		{
+			name: "decimal exit code spelling",
+			mutate: func(t *testing.T, path string, receipt map[string]any) []byte {
+				data, err := os.ReadFile(path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return bytes.Replace(data, []byte(`"exit_code": 0`), []byte(`"exit_code": 0.0`), 1)
+			},
+			wantCode: 2,
+		},
+		{
+			name: "invalid log digest",
+			mutate: func(t *testing.T, path string, receipt map[string]any) []byte {
+				receipt["log_sha256"] = "sha256:not-hex"
+				return marshalReceipt(t, receipt)
+			},
+			wantCode: 2,
+		},
+		{
 			name: "duplicate exit code key keeps signed value last",
 			mutate: func(t *testing.T, path string, receipt map[string]any) []byte {
 				data, err := os.ReadFile(path)
@@ -242,6 +277,32 @@ func TestVerifyRejectsTamperedReceipts(t *testing.T) {
 			t.Fatalf("expected exit 2, got %v", err)
 		}
 	})
+}
+
+func TestVerifyRejectsSignedNonReceipt(t *testing.T) {
+	_, key, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pub := key.Public().(ed25519.PublicKey)
+	receipt := map[string]any{
+		"payload":    "not a crabbox receipt",
+		"public_key": base64.StdEncoding.EncodeToString(pub),
+	}
+	canonical, err := canonicalReceiptBytes(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt["signature"] = base64.StdEncoding.EncodeToString(ed25519.Sign(key, canonical))
+	path := filepath.Join(t.TempDir(), "receipt.json")
+	if err := os.WriteFile(path, marshalReceipt(t, receipt), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err = runVerify(t, path)
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("expected exit 2 for signed non-receipt, got %v", err)
+	}
 }
 
 func TestAttestDigestWriterSerializesConcurrentStreams(t *testing.T) {

--- a/internal/cli/attest_test.go
+++ b/internal/cli/attest_test.go
@@ -72,6 +72,9 @@ func TestAttestReceiptRoundTrip(t *testing.T) {
 	if !strings.HasPrefix(out, "PASS "+path+" signer=sha256:") {
 		t.Fatalf("unexpected verify output: %q", out)
 	}
+	if !strings.Contains(out, " trust=self-signed") {
+		t.Fatalf("verify output should expose the trust model: %q", out)
+	}
 	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
@@ -470,6 +473,141 @@ func TestEnsureAttestKeyMintsOncePrivately(t *testing.T) {
 		if dirInfo.Mode().Perm() != 0o700 {
 			t.Fatalf("expected key dir mode 0700, got %v", dirInfo.Mode().Perm())
 		}
+	}
+}
+
+func TestEnsureAttestKeyMintsOnceAcrossConcurrentCallers(t *testing.T) {
+	setAttestTestHome(t)
+	const callers = 32
+	start := make(chan struct{})
+	keys := make(chan ed25519.PrivateKey, callers)
+	errs := make(chan error, callers)
+	var wg sync.WaitGroup
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			key, err := ensureAttestKey()
+			if err != nil {
+				errs <- err
+				return
+			}
+			keys <- key
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(keys)
+	close(errs)
+	for err := range errs {
+		t.Fatalf("ensure attest key: %v", err)
+	}
+	var first ed25519.PrivateKey
+	count := 0
+	for key := range keys {
+		if first == nil {
+			first = key
+		} else if !first.Equal(key) {
+			t.Fatal("concurrent callers returned different signing keys")
+		}
+		count++
+	}
+	if count != callers {
+		t.Fatalf("received %d keys, want %d", count, callers)
+	}
+}
+
+func TestPreflightAttestPathsProtectsReceiptAndSigningKey(t *testing.T) {
+	setAttestTestHome(t)
+	dir := t.TempDir()
+	receiptPath := filepath.Join(dir, "receipt.json")
+	keyPath := filepath.Join(dir, "signer.pem")
+	_, key, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	defaultKeyPath, err := attestKeyPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name string
+		opts attestPathPreflight
+		want string
+	}{
+		{
+			name: "key requires receipt",
+			opts: attestPathPreflight{KeyOverride: keyPath},
+			want: "--attest-key requires --attest",
+		},
+		{
+			name: "receipt cannot replace default key",
+			opts: attestPathPreflight{Receipt: defaultKeyPath},
+			want: "attest receipt and attest key paths must be different",
+		},
+		{
+			name: "receipt cannot replace override key",
+			opts: attestPathPreflight{Receipt: keyPath, KeyOverride: keyPath},
+			want: "attest receipt and attest key paths must be different",
+		},
+		{
+			name: "receipt cannot share timing store",
+			opts: attestPathPreflight{Receipt: receiptPath, KeyOverride: keyPath, TimingRecord: receiptPath, TimingRecordEnabled: true},
+			want: "attest receipt and timing record paths must be different",
+		},
+		{
+			name: "capture cannot replace key",
+			opts: attestPathPreflight{Receipt: receiptPath, KeyOverride: keyPath, CaptureStdout: keyPath},
+			want: "attest key and capture stdout paths must be different",
+		},
+		{
+			name: "download cannot replace key",
+			opts: attestPathPreflight{Receipt: receiptPath, KeyOverride: keyPath, Downloads: []string{"build.log=" + keyPath}},
+			want: "attest key and download build.log paths must be different",
+		},
+		{
+			name: "invalid override fails before run",
+			opts: attestPathPreflight{Receipt: receiptPath, KeyOverride: filepath.Join(dir, "missing.pem")},
+			want: "attest key:",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := preflightAttestPaths(tc.opts)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error=%v, want %q", err, tc.want)
+			}
+		})
+	}
+	if err := preflightAttestPaths(attestPathPreflight{
+		Receipt:             receiptPath,
+		KeyOverride:         keyPath,
+		LeaseOutput:         filepath.Join(dir, "lease.json"),
+		EmitProof:           filepath.Join(dir, "proof.md"),
+		CaptureStdout:       filepath.Join(dir, "stdout.log"),
+		CaptureStderr:       filepath.Join(dir, "stderr.log"),
+		TimingRecord:        filepath.Join(dir, "timings.jsonl"),
+		TimingRecordEnabled: true,
+		Downloads:           []string{"build.log=" + filepath.Join(dir, "build.log")},
+	}); err != nil {
+		t.Fatalf("distinct attest paths: %v", err)
+	}
+}
+
+func TestRunRejectsAttestKeyWithoutAttest(t *testing.T) {
+	app := App{Stdout: io.Discard, Stderr: io.Discard, Stdin: strings.NewReader("")}
+	err := app.runCommand(context.Background(), []string{"--attest-key", "signer.pem", "--sync-only"})
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 2 || !strings.Contains(exitErr.Message, "--attest-key requires --attest") {
+		t.Fatalf("expected --attest-key dependency error, got %v", err)
 	}
 }
 

--- a/internal/cli/attest_test.go
+++ b/internal/cli/attest_test.go
@@ -597,6 +597,14 @@ func TestPreflightAttestPathsProtectsReceiptAndSigningKey(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	danglingParentAlias := filepath.Join(dir, "future-key-dir")
+	danglingAliasAvailable := true
+	if err := os.Symlink(filepath.Dir(defaultKeyPath), danglingParentAlias); err != nil {
+		danglingAliasAvailable = false
+		if runtime.GOOS != "windows" {
+			t.Fatal(err)
+		}
+	}
 	type pathCase struct {
 		name string
 		opts attestPathPreflight
@@ -651,16 +659,11 @@ func TestPreflightAttestPathsProtectsReceiptAndSigningKey(t *testing.T) {
 			want: "attest key and lease output paths must be different",
 		})
 	}
-	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
+	if danglingAliasAvailable {
 		cases = append(cases, pathCase{
-			name: "case variant receipt and timing paths",
-			opts: attestPathPreflight{
-				Receipt:             filepath.Join(dir, "Receipt.json"),
-				KeyOverride:         keyPath,
-				TimingRecord:        filepath.Join(dir, "receipt.JSON"),
-				TimingRecordEnabled: true,
-			},
-			want: "attest receipt and timing record paths must be different",
+			name: "dangling symlink parent cannot alias future default key",
+			opts: attestPathPreflight{Receipt: filepath.Join(danglingParentAlias, filepath.Base(defaultKeyPath))},
+			want: "attest receipt and attest key paths must be different",
 		})
 	}
 	for _, tc := range cases {
@@ -683,6 +686,21 @@ func TestPreflightAttestPathsProtectsReceiptAndSigningKey(t *testing.T) {
 		Downloads:           []string{"build.log=" + filepath.Join(dir, "build.log")},
 	}); err != nil {
 		t.Fatalf("distinct attest paths: %v", err)
+	}
+}
+
+func TestSameLocalOutputPathUsesFilesystemCaseSemantics(t *testing.T) {
+	dir := t.TempDir()
+	caseInsensitive, err := localPathCaseInsensitive(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	same, err := sameLocalOutputPath(filepath.Join(dir, "Receipt.json"), filepath.Join(dir, "receipt.JSON"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if same != caseInsensitive {
+		t.Fatalf("same=%t, filesystem case-insensitive=%t", same, caseInsensitive)
 	}
 }
 

--- a/internal/cli/attest_test.go
+++ b/internal/cli/attest_test.go
@@ -1,0 +1,321 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func setAttestTestHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	return home
+}
+
+func writeTestReceipt(t *testing.T, keyPath string, in runReceiptInput) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "receipt.json")
+	if _, err := writeRunReceipt(path, keyPath, in); err != nil {
+		t.Fatalf("write receipt: %v", err)
+	}
+	return path
+}
+
+func runVerify(t *testing.T, path string) (string, error) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	app := App{Stdout: &stdout, Stderr: &stderr, Stdin: strings.NewReader("")}
+	err := app.Run(context.Background(), []string{"verify", path})
+	return stdout.String(), err
+}
+
+func fullReceiptInput() runReceiptInput {
+	return runReceiptInput{
+		Provider:   "hetzner",
+		LeaseID:    "cbx_abc123",
+		Slug:       "blue-lobster",
+		RunID:      "run_42",
+		Command:    "go test ./...",
+		ExitCode:   0,
+		CommandMs:  1234,
+		ActionsURL: "https://github.com/example-org/my-app/actions/runs/7",
+		LogSHA256:  "sha256:" + strings.Repeat("ab", 32),
+	}
+}
+
+func TestAttestReceiptRoundTrip(t *testing.T) {
+	setAttestTestHome(t)
+	path := writeTestReceipt(t, "", fullReceiptInput())
+	out, err := runVerify(t, path)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if !strings.HasPrefix(out, "PASS "+path+" signer=sha256:") {
+		t.Fatalf("unexpected verify output: %q", out)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var receipt map[string]any
+	if err := json.Unmarshal(data, &receipt); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"schema_version", "generated_at", "provider", "lease_id", "slug", "run_id", "command", "exit_code", "command_ms", "actions_url", "log_sha256", "public_key", "signature"} {
+		if _, ok := receipt[key]; !ok {
+			t.Fatalf("receipt missing %s", key)
+		}
+	}
+}
+
+func TestAttestReceiptOmitsEmptyOptionalFields(t *testing.T) {
+	setAttestTestHome(t)
+	path := writeTestReceipt(t, "", runReceiptInput{
+		Provider:  "aws",
+		LeaseID:   "cbx_def456",
+		Command:   "true",
+		ExitCode:  0,
+		CommandMs: 5,
+	})
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var receipt map[string]any
+	if err := json.Unmarshal(data, &receipt); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"slug", "run_id", "actions_url", "log_sha256"} {
+		if _, ok := receipt[key]; ok {
+			t.Fatalf("receipt should omit empty %s", key)
+		}
+	}
+	out, err := runVerify(t, path)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if !strings.HasPrefix(out, "PASS ") {
+		t.Fatalf("unexpected verify output: %q", out)
+	}
+}
+
+func TestVerifyRejectsTamperedReceipts(t *testing.T) {
+	setAttestTestHome(t)
+	cases := []struct {
+		name     string
+		mutate   func(t *testing.T, path string, receipt map[string]any) []byte
+		wantCode int
+		wantFail bool
+	}{
+		{
+			name: "mutated exit code",
+			mutate: func(t *testing.T, path string, receipt map[string]any) []byte {
+				receipt["exit_code"] = 1
+				return marshalReceipt(t, receipt)
+			},
+			wantCode: 1,
+			wantFail: true,
+		},
+		{
+			name: "mutated command",
+			mutate: func(t *testing.T, path string, receipt map[string]any) []byte {
+				receipt["command"] = "rm -rf ./dist"
+				return marshalReceipt(t, receipt)
+			},
+			wantCode: 1,
+			wantFail: true,
+		},
+		{
+			name: "foreign public key",
+			mutate: func(t *testing.T, path string, receipt map[string]any) []byte {
+				pub, _, err := ed25519.GenerateKey(rand.Reader)
+				if err != nil {
+					t.Fatal(err)
+				}
+				receipt["public_key"] = base64.StdEncoding.EncodeToString(pub)
+				return marshalReceipt(t, receipt)
+			},
+			wantCode: 1,
+			wantFail: true,
+		},
+		{
+			name: "corrupt signature encoding",
+			mutate: func(t *testing.T, path string, receipt map[string]any) []byte {
+				receipt["signature"] = "!!!not-base64!!!"
+				return marshalReceipt(t, receipt)
+			},
+			wantCode: 2,
+		},
+		{
+			name: "missing signature",
+			mutate: func(t *testing.T, path string, receipt map[string]any) []byte {
+				delete(receipt, "signature")
+				return marshalReceipt(t, receipt)
+			},
+			wantCode: 2,
+		},
+		{
+			name: "truncated json",
+			mutate: func(t *testing.T, path string, receipt map[string]any) []byte {
+				data, err := os.ReadFile(path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return data[:len(data)/2]
+			},
+			wantCode: 2,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeTestReceipt(t, "", fullReceiptInput())
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var receipt map[string]any
+			if err := json.Unmarshal(data, &receipt); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path, tc.mutate(t, path, receipt), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			out, err := runVerify(t, path)
+			var exitErr ExitError
+			if !AsExitError(err, &exitErr) {
+				t.Fatalf("expected ExitError, got %v", err)
+			}
+			if exitErr.Code != tc.wantCode {
+				t.Fatalf("expected exit %d, got %d (%v)", tc.wantCode, exitErr.Code, err)
+			}
+			if tc.wantFail && !strings.Contains(out, "signature mismatch") {
+				t.Fatalf("expected FAIL output, got %q", out)
+			}
+		})
+	}
+	t.Run("missing file", func(t *testing.T) {
+		_, err := runVerify(t, filepath.Join(t.TempDir(), "absent.json"))
+		var exitErr ExitError
+		if !AsExitError(err, &exitErr) || exitErr.Code != 2 {
+			t.Fatalf("expected exit 2, got %v", err)
+		}
+	})
+}
+
+func marshalReceipt(t *testing.T, receipt map[string]any) []byte {
+	t.Helper()
+	data, err := json.MarshalIndent(receipt, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+func TestEnsureAttestKeyMintsOncePrivately(t *testing.T) {
+	setAttestTestHome(t)
+	first, err := ensureAttestKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := ensureAttestKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !first.Equal(second) {
+		t.Fatal("expected the same key on repeated mint")
+	}
+	path, err := attestKeyPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode().Perm() != 0o600 {
+			t.Fatalf("expected key mode 0600, got %v", info.Mode().Perm())
+		}
+		dirInfo, err := os.Stat(filepath.Dir(path))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if dirInfo.Mode().Perm() != 0o700 {
+			t.Fatalf("expected key dir mode 0700, got %v", dirInfo.Mode().Perm())
+		}
+	}
+}
+
+func TestAttestKeyOverride(t *testing.T) {
+	setAttestTestHome(t)
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyPath := filepath.Join(t.TempDir(), "signer.pem")
+	if err := os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	path := writeTestReceipt(t, keyPath, fullReceiptInput())
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var receipt map[string]any
+	if err := json.Unmarshal(data, &receipt); err != nil {
+		t.Fatal(err)
+	}
+	if receipt["public_key"] != base64.StdEncoding.EncodeToString(pub) {
+		t.Fatal("receipt should embed the override public key")
+	}
+	out, err := runVerify(t, path)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if !strings.Contains(out, attestFingerprint(pub)) {
+		t.Fatalf("expected fingerprint of override key, got %q", out)
+	}
+	defaultPath, err := attestKeyPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(defaultPath); !os.IsNotExist(err) {
+		t.Fatal("override signing should not mint the default key")
+	}
+	if _, err := writeRunReceipt(filepath.Join(t.TempDir(), "r.json"), filepath.Join(t.TempDir(), "absent.pem"), fullReceiptInput()); err == nil {
+		t.Fatal("expected error for missing override key")
+	}
+	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ecDER, err := x509.MarshalPKCS8PrivateKey(ecKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ecPath := filepath.Join(t.TempDir(), "ec.pem")
+	if err := os.WriteFile(ecPath, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: ecDER}), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := writeRunReceipt(filepath.Join(t.TempDir(), "r2.json"), ecPath, fullReceiptInput()); err == nil {
+		t.Fatal("expected error for non ed25519 key")
+	}
+}

--- a/internal/cli/attest_test.go
+++ b/internal/cli/attest_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 func setAttestTestHome(t *testing.T) string {
@@ -346,6 +347,48 @@ func TestAttestDigestWriterHashesMixedStreamsInArrivalOrder(t *testing.T) {
 	expected := sha256.Sum256([]byte("out line\nerr line\ndone\n"))
 	if got := writer.sum(); got != "sha256:"+hex.EncodeToString(expected[:]) {
 		t.Fatalf("unexpected digest %s", got)
+	}
+}
+
+func TestDelegatedRunReceiptOmitsMissingLeaseID(t *testing.T) {
+	setAttestTestHome(t)
+	path := filepath.Join(t.TempDir(), "receipt.json")
+	result := RunResult{
+		Provider:    "e2b",
+		CommandText: "pnpm test",
+		ExitCode:    0,
+		Command:     1500 * time.Millisecond,
+	}
+	req := RunRequest{Command: []string{"pnpm", "test"}}
+	artifact, err := writeDelegatedRunReceipt(path, "", Config{Provider: "e2b"}, result, req)
+	if err != nil {
+		t.Fatalf("write delegated receipt: %v", err)
+	}
+	if artifact.Kind != "receipt" {
+		t.Fatalf("unexpected artifact kind %q", artifact.Kind)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var receipt map[string]any
+	if err := json.Unmarshal(data, &receipt); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"lease_id", "slug", "run_id", "actions_url", "log_sha256"} {
+		if _, ok := receipt[key]; ok {
+			t.Fatalf("delegated receipt should omit empty %s", key)
+		}
+	}
+	if receipt["command"] != "pnpm test" {
+		t.Fatalf("unexpected command %v", receipt["command"])
+	}
+	out, err := runVerify(t, path)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if !strings.HasPrefix(out, "PASS ") {
+		t.Fatalf("unexpected verify output: %q", out)
 	}
 }
 

--- a/internal/cli/attest_test.go
+++ b/internal/cli/attest_test.go
@@ -169,6 +169,30 @@ func TestVerifyRejectsTamperedReceipts(t *testing.T) {
 			wantCode: 2,
 		},
 		{
+			name: "duplicate exit code key keeps signed value last",
+			mutate: func(t *testing.T, path string, receipt map[string]any) []byte {
+				data, err := os.ReadFile(path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return bytes.Replace(data, []byte(`"exit_code": 0`), []byte(`"exit_code": 1,
+  "exit_code": 0`), 1)
+			},
+			wantCode: 2,
+		},
+		{
+			name: "duplicate command key keeps signed value last",
+			mutate: func(t *testing.T, path string, receipt map[string]any) []byte {
+				data, err := os.ReadFile(path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return bytes.Replace(data, []byte(`"command": "go test ./..."`), []byte(`"command": "rm -rf ./dist",
+  "command": "go test ./..."`), 1)
+			},
+			wantCode: 2,
+		},
+		{
 			name: "truncated json",
 			mutate: func(t *testing.T, path string, receipt map[string]any) []byte {
 				data, err := os.ReadFile(path)
@@ -214,6 +238,19 @@ func TestVerifyRejectsTamperedReceipts(t *testing.T) {
 			t.Fatalf("expected exit 2, got %v", err)
 		}
 	})
+}
+
+func TestAttestReceiptPathCollisions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "receipt.json")
+	if err := preflightRunOutputCollisions("attest receipt", path, path, "", nil); err == nil {
+		t.Fatal("expected capture stdout collision error")
+	}
+	if err := preflightRunOutputCollisions("attest receipt", path, "", path, nil); err == nil {
+		t.Fatal("expected capture stderr collision error")
+	}
+	if err := preflightRunOutputCollisions("attest receipt", path, "", "", []string{"remote.log=" + path}); err == nil {
+		t.Fatal("expected download collision error")
+	}
 }
 
 func marshalReceipt(t *testing.T, receipt map[string]any) []byte {

--- a/internal/cli/attest_test.go
+++ b/internal/cli/attest_test.go
@@ -395,6 +395,53 @@ func TestDelegatedRunReceiptOmitsMissingLeaseID(t *testing.T) {
 	}
 }
 
+func TestDelegatedRunReceiptUsesSessionIdentityFallbacks(t *testing.T) {
+	setAttestTestHome(t)
+	path := filepath.Join(t.TempDir(), "receipt.json")
+	result := RunResult{
+		ExitCode:    0,
+		CommandText: "pnpm test",
+		Command:     1500 * time.Millisecond,
+		Session: &RunSessionHandle{
+			Provider:   "e2b",
+			LeaseID:    "cbx_session",
+			Slug:       "session-slug",
+			RunID:      "run_session",
+			ActionsURL: "https://github.com/example-org/my-app/actions/runs/7",
+		},
+	}
+	artifact, err := writeDelegatedRunReceipt(path, "", Config{Provider: "fallback"}, result, RunRequest{})
+	if err != nil {
+		t.Fatalf("write delegated receipt: %v", err)
+	}
+	if artifact.Kind != "receipt" {
+		t.Fatalf("unexpected artifact kind %q", artifact.Kind)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var receipt map[string]any
+	if err := json.Unmarshal(data, &receipt); err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]string{
+		"provider":    "e2b",
+		"lease_id":    "cbx_session",
+		"slug":        "session-slug",
+		"run_id":      "run_session",
+		"actions_url": "https://github.com/example-org/my-app/actions/runs/7",
+	}
+	for key, value := range want {
+		if receipt[key] != value {
+			t.Fatalf("receipt[%q]=%v, want %q", key, receipt[key], value)
+		}
+	}
+	if out, err := runVerify(t, path); err != nil || !strings.HasPrefix(out, "PASS ") {
+		t.Fatalf("verify output=%q error=%v", out, err)
+	}
+}
+
 func TestAttestReceiptCreatesMissingParentDirectories(t *testing.T) {
 	setAttestTestHome(t)
 	path := filepath.Join(t.TempDir(), "nested", "deeper", "receipt.json")
@@ -534,15 +581,28 @@ func TestPreflightAttestPathsProtectsReceiptAndSigningKey(t *testing.T) {
 	if err := os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}), 0o600); err != nil {
 		t.Fatal(err)
 	}
+	keySymlink := filepath.Join(dir, "signer-symlink.pem")
+	symlinkAvailable := true
+	if err := os.Symlink(keyPath, keySymlink); err != nil {
+		symlinkAvailable = false
+		if runtime.GOOS != "windows" {
+			t.Fatal(err)
+		}
+	}
+	keyHardlink := filepath.Join(dir, "signer-hardlink.pem")
+	if err := os.Link(keyPath, keyHardlink); err != nil {
+		t.Fatal(err)
+	}
 	defaultKeyPath, err := attestKeyPath()
 	if err != nil {
 		t.Fatal(err)
 	}
-	cases := []struct {
+	type pathCase struct {
 		name string
 		opts attestPathPreflight
 		want string
-	}{
+	}
+	cases := []pathCase{
 		{
 			name: "key requires receipt",
 			opts: attestPathPreflight{KeyOverride: keyPath},
@@ -574,10 +634,34 @@ func TestPreflightAttestPathsProtectsReceiptAndSigningKey(t *testing.T) {
 			want: "attest key and download build.log paths must be different",
 		},
 		{
+			name: "hard link cannot alias key",
+			opts: attestPathPreflight{Receipt: receiptPath, KeyOverride: keyPath, TimingRecord: keyHardlink, TimingRecordEnabled: true},
+			want: "attest key and timing record paths must be different",
+		},
+		{
 			name: "invalid override fails before run",
 			opts: attestPathPreflight{Receipt: receiptPath, KeyOverride: filepath.Join(dir, "missing.pem")},
 			want: "attest key:",
 		},
+	}
+	if symlinkAvailable {
+		cases = append(cases, pathCase{
+			name: "symlink cannot alias key",
+			opts: attestPathPreflight{Receipt: receiptPath, KeyOverride: keyPath, LeaseOutput: keySymlink},
+			want: "attest key and lease output paths must be different",
+		})
+	}
+	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
+		cases = append(cases, pathCase{
+			name: "case variant receipt and timing paths",
+			opts: attestPathPreflight{
+				Receipt:             filepath.Join(dir, "Receipt.json"),
+				KeyOverride:         keyPath,
+				TimingRecord:        filepath.Join(dir, "receipt.JSON"),
+				TimingRecordEnabled: true,
+			},
+			want: "attest receipt and timing record paths must be different",
+		})
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/cli/cli_kong.go
+++ b/internal/cli/cli_kong.go
@@ -34,6 +34,7 @@ type crabboxKongCLI struct {
 	Events      eventsKongCmd      `cmd:"" passthrough:"" help:"Print recorded run events."`
 	Attach      attachKongCmd      `cmd:"" passthrough:"" help:"Follow recorded events for an active run."`
 	Results     resultsKongCmd     `cmd:"" passthrough:"" help:"Show recorded test result summaries."`
+	Verify      verifyKongCmd      `cmd:"" passthrough:"" help:"Verify a signed run receipt."`
 	Cache       cacheKongCmd       `cmd:"" help:"Inspect, purge, or warm remote caches."`
 	Status      statusKongCmd      `cmd:"" passthrough:"" help:"Show lease state; add --wait to block until ready."`
 	List        listKongCmd        `cmd:"" passthrough:"" help:"List Crabbox machines."`
@@ -209,6 +210,9 @@ type attachKongCmd struct {
 	Args []string `arg:"" optional:""`
 }
 type resultsKongCmd struct {
+	Args []string `arg:"" optional:""`
+}
+type verifyKongCmd struct {
 	Args []string `arg:"" optional:""`
 }
 type portsKongCmd struct {
@@ -630,6 +634,7 @@ func (c *logsKongCmd) Run(ctx context.Context, app App) error      { return app.
 func (c *eventsKongCmd) Run(ctx context.Context, app App) error    { return app.events(ctx, c.Args) }
 func (c *attachKongCmd) Run(ctx context.Context, app App) error    { return app.attach(ctx, c.Args) }
 func (c *resultsKongCmd) Run(ctx context.Context, app App) error   { return app.results(ctx, c.Args) }
+func (c *verifyKongCmd) Run(ctx context.Context, app App) error    { return app.verify(ctx, c.Args) }
 func (c *portsKongCmd) Run(ctx context.Context, app App) error     { return app.ports(ctx, c.Args) }
 func (c *cpKongCmd) Run(ctx context.Context, app App) error        { return app.copyCommand(ctx, c.Args) }
 func (c *statusKongCmd) Run(ctx context.Context, app App) error    { return app.status(ctx, c.Args) }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -2,8 +2,6 @@ package cli
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"flag"
 	"fmt"
@@ -1542,7 +1540,7 @@ afterSync:
 	if stderrCaptured {
 		stderrEvents = nil
 	}
-	attestDigest := sha256.New()
+	attestDigest := newAttestDigestWriter()
 	if strings.TrimSpace(*attestOut) != "" {
 		stdout = io.MultiWriter(stdout, attestDigest)
 		stderr = io.MultiWriter(stderr, attestDigest)
@@ -1674,7 +1672,7 @@ afterSync:
 			ExitCode:   code,
 			CommandMs:  report.CommandMs,
 			ActionsURL: actionsURL,
-			LogSHA256:  "sha256:" + hex.EncodeToString(attestDigest.Sum(nil)),
+			LogSHA256:  attestDigest.sum(),
 		})
 		if err != nil {
 			return recordFailure(err)

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -653,19 +653,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 			fmt.Fprintf(a.Stderr, "artifact kind=proof path=%s bytes=%d template=%s\n", proof.Path, proof.Bytes, blank(proof.Template, "default"))
 		}
 		if runErr == nil && strings.TrimSpace(*attestOut) != "" {
-			command := strings.TrimSpace(result.CommandText)
-			if command == "" {
-				command = runCommandDisplay(runReq.Command, runReq.ShellMode)
-			}
-			receipt, err := writeRunReceipt(strings.TrimSpace(*attestOut), strings.TrimSpace(*attestKeyOverride), runReceiptInput{
-				Provider:   firstNonBlank(result.Provider, cfg.Provider),
-				LeaseID:    result.LeaseID,
-				Slug:       result.Slug,
-				Command:    command,
-				ExitCode:   result.ExitCode,
-				CommandMs:  result.Command.Milliseconds(),
-				ActionsURL: result.ActionsURL,
-			})
+			receipt, err := writeDelegatedRunReceipt(strings.TrimSpace(*attestOut), strings.TrimSpace(*attestKeyOverride), cfg, result, runReq)
 			if err != nil {
 				return err
 			}
@@ -1860,6 +1848,22 @@ func writeDelegatedRunProof(path, templateName string, cfg Config, result RunRes
 		CommandMs:   result.Command.Milliseconds(),
 		ExitCode:    result.ExitCode,
 		GeneratedAt: time.Now(),
+	})
+}
+
+func writeDelegatedRunReceipt(path, keyPath string, cfg Config, result RunResult, req RunRequest) (runArtifact, error) {
+	command := strings.TrimSpace(result.CommandText)
+	if command == "" {
+		command = runCommandDisplay(req.Command, req.ShellMode)
+	}
+	return writeRunReceipt(path, keyPath, runReceiptInput{
+		Provider:   firstNonBlank(result.Provider, cfg.Provider),
+		LeaseID:    result.LeaseID,
+		Slug:       result.Slug,
+		Command:    command,
+		ExitCode:   result.ExitCode,
+		CommandMs:  result.Command.Milliseconds(),
+		ActionsURL: result.ActionsURL,
 	})
 }
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1848,15 +1848,24 @@ func writeDelegatedRunReceipt(path, keyPath string, cfg Config, result RunResult
 	if command == "" {
 		command = runCommandDisplay(req.Command, req.ShellMode)
 	}
-	return writeRunReceipt(path, keyPath, runReceiptInput{
-		Provider:   firstNonBlank(result.Provider, cfg.Provider),
+	receipt := runReceiptInput{
+		Provider:   result.Provider,
 		LeaseID:    result.LeaseID,
 		Slug:       result.Slug,
 		Command:    command,
 		ExitCode:   result.ExitCode,
 		CommandMs:  result.Command.Milliseconds(),
 		ActionsURL: result.ActionsURL,
-	})
+	}
+	if session := result.Session; session != nil {
+		receipt.Provider = firstNonBlank(receipt.Provider, session.Provider)
+		receipt.LeaseID = firstNonBlank(receipt.LeaseID, session.LeaseID)
+		receipt.Slug = firstNonBlank(receipt.Slug, session.Slug)
+		receipt.RunID = session.RunID
+		receipt.ActionsURL = firstNonBlank(receipt.ActionsURL, session.ActionsURL)
+	}
+	receipt.Provider = firstNonBlank(receipt.Provider, cfg.Provider)
+	return writeRunReceipt(path, keyPath, receipt)
 }
 
 func runCommandDisplay(command []string, shellMode bool) string {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"flag"
 	"fmt"
@@ -232,6 +234,8 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	scenario := fs.String("scenario", "", "preset variable shorthand for --preset-var scenario=<value>")
 	emitProof := fs.String("emit-proof", "", "write a generated proof block after a successful run")
 	proofTemplate := fs.String("proof-template", "", "proof template name from the selected profile")
+	attestOut := fs.String("attest", "", "write a signed run receipt after a successful run")
+	attestKeyOverride := fs.String("attest-key", "", "path to an existing PKCS8 PEM ed25519 private key for --attest")
 	stopAfter := fs.String("stop-after", "", "stop policy for the lease: success, always, failure, or never")
 	leaseOutput := fs.String("lease-output", "", "write a small JSON lease handle for orchestrators")
 	readyPool := fs.String("pool", "", "borrow a broker ready-pool lease")
@@ -373,6 +377,9 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		if strings.TrimSpace(*emitProof) != "" {
 			return exit(2, "--emit-proof cannot be combined with --sync-only")
 		}
+		if strings.TrimSpace(*attestOut) != "" {
+			return exit(2, "--attest cannot be combined with --sync-only")
+		}
 	}
 	if err := preflightRunLocalOutputs(*captureStdout, *captureStderr, downloads); err != nil {
 		return err
@@ -401,6 +408,11 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 			}
 		}
 		if err := preflightLocalOutputPath("emit proof", strings.TrimSpace(*emitProof), true, true); err != nil {
+			return err
+		}
+	}
+	if strings.TrimSpace(*attestOut) != "" {
+		if err := preflightLocalOutputPath("attest receipt", strings.TrimSpace(*attestOut), true, true); err != nil {
 			return err
 		}
 	}
@@ -619,6 +631,26 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 			}
 			result.Artifacts = append(result.Artifacts, proof)
 			fmt.Fprintf(a.Stderr, "artifact kind=proof path=%s bytes=%d template=%s\n", proof.Path, proof.Bytes, blank(proof.Template, "default"))
+		}
+		if runErr == nil && strings.TrimSpace(*attestOut) != "" {
+			command := strings.TrimSpace(result.CommandText)
+			if command == "" {
+				command = runCommandDisplay(runReq.Command, runReq.ShellMode)
+			}
+			receipt, err := writeRunReceipt(strings.TrimSpace(*attestOut), strings.TrimSpace(*attestKeyOverride), runReceiptInput{
+				Provider:   firstNonBlank(result.Provider, cfg.Provider),
+				LeaseID:    result.LeaseID,
+				Slug:       result.Slug,
+				Command:    command,
+				ExitCode:   result.ExitCode,
+				CommandMs:  result.Command.Milliseconds(),
+				ActionsURL: result.ActionsURL,
+			})
+			if err != nil {
+				return err
+			}
+			result.Artifacts = append(result.Artifacts, receipt)
+			fmt.Fprintf(a.Stderr, "artifact kind=receipt path=%s bytes=%d\n", receipt.Path, receipt.Bytes)
 		}
 		if result.Session != nil {
 			coldRun := !result.Session.Reused
@@ -1488,6 +1520,11 @@ afterSync:
 	if stderrCaptured {
 		stderrEvents = nil
 	}
+	attestDigest := sha256.New()
+	if strings.TrimSpace(*attestOut) != "" {
+		stdout = io.MultiWriter(stdout, attestDigest)
+		stderr = io.MultiWriter(stderr, attestDigest)
+	}
 	resultsMarker := ""
 	if cfg.Results.Auto {
 		resultsMarker = remoteResultsMarker
@@ -1604,6 +1641,25 @@ afterSync:
 		runArtifacts = append(runArtifacts, proof)
 		report.Artifacts = runArtifacts
 		fmt.Fprintf(a.Stderr, "artifact kind=proof path=%s bytes=%d template=%s\n", proof.Path, proof.Bytes, blank(proof.Template, "default"))
+	}
+	if strings.TrimSpace(*attestOut) != "" && code == 0 {
+		receipt, err := writeRunReceipt(strings.TrimSpace(*attestOut), strings.TrimSpace(*attestKeyOverride), runReceiptInput{
+			Provider:   cfg.Provider,
+			LeaseID:    leaseID,
+			Slug:       serverSlug(server),
+			RunID:      recorder.runID,
+			Command:    commandDisplay,
+			ExitCode:   code,
+			CommandMs:  report.CommandMs,
+			ActionsURL: actionsURL,
+			LogSHA256:  "sha256:" + hex.EncodeToString(attestDigest.Sum(nil)),
+		})
+		if err != nil {
+			return recordFailure(err)
+		}
+		runArtifacts = append(runArtifacts, receipt)
+		report.Artifacts = runArtifacts
+		fmt.Fprintf(a.Stderr, "artifact kind=receipt path=%s bytes=%d\n", receipt.Path, receipt.Bytes)
 	}
 	recorder.Finish(ctx, target, code, timings.sync, timings.command, logBuffer.String(), logBuffer.Truncated(), results, classification)
 	if a.runOutcome != nil {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -260,6 +260,19 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	if err != nil {
 		return err
 	}
+	if err := preflightAttestPaths(attestPathPreflight{
+		Receipt:             *attestOut,
+		KeyOverride:         *attestKeyOverride,
+		LeaseOutput:         *leaseOutput,
+		EmitProof:           *emitProof,
+		CaptureStdout:       *captureStdout,
+		CaptureStderr:       *captureStderr,
+		TimingRecord:        timingRecordPath,
+		TimingRecordEnabled: timingRecordEnabled,
+		Downloads:           downloads,
+	}); err != nil {
+		return err
+	}
 	var cleanup leaseCleanupResult
 	var finalTimingReport *timingReport
 	var timingRecordRepo Repo
@@ -411,27 +424,6 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	}
 	if strings.TrimSpace(*attestOut) != "" {
 		attestPath := strings.TrimSpace(*attestOut)
-		if strings.TrimSpace(*leaseOutput) != "" {
-			samePath, err := sameLocalOutputPath(strings.TrimSpace(*leaseOutput), attestPath)
-			if err != nil {
-				return err
-			}
-			if samePath {
-				return exit(2, "lease output and attest receipt paths must be different")
-			}
-		}
-		if strings.TrimSpace(*emitProof) != "" {
-			samePath, err := sameLocalOutputPath(strings.TrimSpace(*emitProof), attestPath)
-			if err != nil {
-				return err
-			}
-			if samePath {
-				return exit(2, "emit proof and attest receipt paths must be different")
-			}
-		}
-		if err := preflightRunOutputCollisions("attest receipt", attestPath, *captureStdout, *captureStderr, downloads); err != nil {
-			return err
-		}
 		if err := preflightLocalOutputPath("attest receipt", attestPath, true, true); err != nil {
 			return err
 		}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -412,7 +412,29 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		}
 	}
 	if strings.TrimSpace(*attestOut) != "" {
-		if err := preflightLocalOutputPath("attest receipt", strings.TrimSpace(*attestOut), true, true); err != nil {
+		attestPath := strings.TrimSpace(*attestOut)
+		if strings.TrimSpace(*leaseOutput) != "" {
+			samePath, err := sameLocalOutputPath(strings.TrimSpace(*leaseOutput), attestPath)
+			if err != nil {
+				return err
+			}
+			if samePath {
+				return exit(2, "lease output and attest receipt paths must be different")
+			}
+		}
+		if strings.TrimSpace(*emitProof) != "" {
+			samePath, err := sameLocalOutputPath(strings.TrimSpace(*emitProof), attestPath)
+			if err != nil {
+				return err
+			}
+			if samePath {
+				return exit(2, "emit proof and attest receipt paths must be different")
+			}
+		}
+		if err := preflightRunOutputCollisions("attest receipt", attestPath, *captureStdout, *captureStderr, downloads); err != nil {
+			return err
+		}
+		if err := preflightLocalOutputPath("attest receipt", attestPath, true, true); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/run_download.go
+++ b/internal/cli/run_download.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 )
 
@@ -138,19 +137,19 @@ func preflightRunOutputCollisions(label, path, captureStdout, captureStderr stri
 }
 
 func sameLocalOutputPath(left, right string) (bool, error) {
-	leftAbs, err := filepath.Abs(filepath.Clean(left))
+	leftCanonical, err := canonicalLocalOutputPath(left)
 	if err != nil {
 		return false, exit(2, "local output path: %v", err)
 	}
-	rightAbs, err := filepath.Abs(filepath.Clean(right))
+	rightCanonical, err := canonicalLocalOutputPath(right)
 	if err != nil {
 		return false, exit(2, "local output path: %v", err)
 	}
-	if leftAbs == rightAbs || ((runtime.GOOS == "darwin" || runtime.GOOS == "windows") && strings.EqualFold(leftAbs, rightAbs)) {
+	if leftCanonical == rightCanonical {
 		return true, nil
 	}
-	leftInfo, leftErr := os.Stat(leftAbs)
-	rightInfo, rightErr := os.Stat(rightAbs)
+	leftInfo, leftErr := os.Stat(leftCanonical)
+	rightInfo, rightErr := os.Stat(rightCanonical)
 	if leftErr == nil && rightErr == nil {
 		return os.SameFile(leftInfo, rightInfo), nil
 	}
@@ -159,7 +158,123 @@ func sameLocalOutputPath(left, right string) (bool, error) {
 			return false, exit(2, "local output path: %v", statErr)
 		}
 	}
+	if strings.EqualFold(leftCanonical, rightCanonical) {
+		caseInsensitive, err := localPathCaseInsensitive(leftCanonical)
+		if err != nil {
+			return false, exit(2, "local output path case probe: %v", err)
+		}
+		if caseInsensitive {
+			return true, nil
+		}
+	}
 	return false, nil
+}
+
+func canonicalLocalOutputPath(path string) (string, error) {
+	abs, err := filepath.Abs(filepath.Clean(path))
+	if err != nil {
+		return "", err
+	}
+	return resolveLocalOutputSymlinks(abs, 0)
+}
+
+func resolveLocalOutputSymlinks(path string, depth int) (string, error) {
+	// Resolve each existing link even when its target or a later component is not created yet.
+	if depth > 64 {
+		return "", fmt.Errorf("too many symlinks in %s", path)
+	}
+	volume := filepath.VolumeName(path)
+	rest := strings.TrimPrefix(path, volume)
+	rest = strings.TrimLeft(rest, string(filepath.Separator))
+	current := volume + string(filepath.Separator)
+	if volume == "" {
+		current = string(filepath.Separator)
+	}
+	parts := strings.FieldsFunc(rest, func(r rune) bool { return r == rune(filepath.Separator) })
+	for i, part := range parts {
+		candidate := filepath.Join(current, part)
+		info, err := os.Lstat(candidate)
+		if errors.Is(err, os.ErrNotExist) {
+			return filepath.Join(append([]string{candidate}, parts[i+1:]...)...), nil
+		}
+		if err != nil {
+			return "", err
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			current = candidate
+			continue
+		}
+		target, err := os.Readlink(candidate)
+		if err != nil {
+			return "", err
+		}
+		if !filepath.IsAbs(target) {
+			target = filepath.Join(filepath.Dir(candidate), target)
+		}
+		if i+1 < len(parts) {
+			target = filepath.Join(append([]string{target}, parts[i+1:]...)...)
+		}
+		return resolveLocalOutputSymlinks(filepath.Clean(target), depth+1)
+	}
+	return current, nil
+}
+
+func localPathCaseInsensitive(path string) (bool, error) {
+	dir := path
+	for {
+		info, err := os.Stat(dir)
+		if err == nil {
+			if !info.IsDir() {
+				dir = filepath.Dir(dir)
+			}
+			break
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return false, err
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return false, err
+		}
+		dir = parent
+	}
+	// Probe the directory because supported platforms can host both case modes.
+	probe, err := os.CreateTemp(dir, ".crabbox-case-Aa-*")
+	if err != nil {
+		return false, err
+	}
+	probePath := probe.Name()
+	probeInfo, statErr := probe.Stat()
+	closeErr := probe.Close()
+	defer os.Remove(probePath)
+	if statErr != nil {
+		return false, statErr
+	}
+	if closeErr != nil {
+		return false, closeErr
+	}
+	foldedPath := filepath.Join(dir, flipASCIICase(filepath.Base(probePath)))
+	foldedInfo, err := os.Stat(foldedPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return os.SameFile(probeInfo, foldedInfo), nil
+}
+
+func flipASCIICase(value string) string {
+	flipped := []byte(value)
+	for i, char := range flipped {
+		switch {
+		case char >= 'a' && char <= 'z':
+			flipped[i] = char - ('a' - 'A')
+		case char >= 'A' && char <= 'Z':
+			flipped[i] = char + ('a' - 'A')
+		}
+	}
+	return string(flipped)
 }
 
 func preflightLocalOutputPath(label, path string, allowMissingDirs, replaceExisting bool) error {

--- a/internal/cli/run_download.go
+++ b/internal/cli/run_download.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
@@ -139,13 +140,26 @@ func preflightRunOutputCollisions(label, path, captureStdout, captureStderr stri
 func sameLocalOutputPath(left, right string) (bool, error) {
 	leftAbs, err := filepath.Abs(filepath.Clean(left))
 	if err != nil {
-		return false, exit(2, "capture stdout/stderr: %v", err)
+		return false, exit(2, "local output path: %v", err)
 	}
 	rightAbs, err := filepath.Abs(filepath.Clean(right))
 	if err != nil {
-		return false, exit(2, "capture stdout/stderr: %v", err)
+		return false, exit(2, "local output path: %v", err)
 	}
-	return leftAbs == rightAbs, nil
+	if leftAbs == rightAbs || ((runtime.GOOS == "darwin" || runtime.GOOS == "windows") && strings.EqualFold(leftAbs, rightAbs)) {
+		return true, nil
+	}
+	leftInfo, leftErr := os.Stat(leftAbs)
+	rightInfo, rightErr := os.Stat(rightAbs)
+	if leftErr == nil && rightErr == nil {
+		return os.SameFile(leftInfo, rightInfo), nil
+	}
+	for _, statErr := range []error{leftErr, rightErr} {
+		if statErr != nil && !errors.Is(statErr, os.ErrNotExist) {
+			return false, exit(2, "local output path: %v", statErr)
+		}
+	}
+	return false, nil
 }
 
 func preflightLocalOutputPath(label, path string, allowMissingDirs, replaceExisting bool) error {

--- a/internal/cli/run_download.go
+++ b/internal/cli/run_download.go
@@ -95,25 +95,29 @@ func rejectCaptureDownloadCollision(label, capturePath string, download runDownl
 }
 
 func preflightProofOutputPath(proofPath, captureStdout, captureStderr string, downloads []string) error {
-	if proofPath == "" {
+	return preflightRunOutputCollisions("emit proof", proofPath, captureStdout, captureStderr, downloads)
+}
+
+func preflightRunOutputCollisions(label, path, captureStdout, captureStderr string, downloads []string) error {
+	if path == "" {
 		return nil
 	}
 	if captureStdout != "" {
-		same, err := sameLocalOutputPath(proofPath, captureStdout)
+		same, err := sameLocalOutputPath(path, captureStdout)
 		if err != nil {
 			return err
 		}
 		if same {
-			return exit(2, "emit proof/capture stdout: paths must be different")
+			return exit(2, "%s/capture stdout: paths must be different", label)
 		}
 	}
 	if captureStderr != "" {
-		same, err := sameLocalOutputPath(proofPath, captureStderr)
+		same, err := sameLocalOutputPath(path, captureStderr)
 		if err != nil {
 			return err
 		}
 		if same {
-			return exit(2, "emit proof/capture stderr: paths must be different")
+			return exit(2, "%s/capture stderr: paths must be different", label)
 		}
 	}
 	for _, spec := range downloads {
@@ -121,12 +125,12 @@ func preflightProofOutputPath(proofPath, captureStdout, captureStderr string, do
 		if err != nil {
 			return err
 		}
-		same, err := sameLocalOutputPath(proofPath, download.Local)
+		same, err := sameLocalOutputPath(path, download.Local)
 		if err != nil {
 			return err
 		}
 		if same {
-			return exit(2, "emit proof/download %s: paths must be different", download.Remote)
+			return exit(2, "%s/download %s: paths must be different", label, download.Remote)
 		}
 	}
 	return nil

--- a/internal/cli/run_local_output.go
+++ b/internal/cli/run_local_output.go
@@ -1,6 +1,12 @@
 package cli
 
-import "os"
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+)
 
 const (
 	privateRunOutputDirMode  = 0o700
@@ -9,4 +15,41 @@ const (
 
 func createPrivateRunOutputDir(path string) error {
 	return os.MkdirAll(path, privateRunOutputDirMode)
+}
+
+func writePrivateRunOutputFileIfAbsent(path string, data []byte) (bool, error) {
+	dir := filepath.Dir(path)
+	file, err := os.CreateTemp(dir, "."+filepath.Base(path)+".crabbox-*")
+	if err != nil {
+		return false, err
+	}
+	tempPath := file.Name()
+	cleanup := func() {
+		_ = file.Close()
+		_ = os.Remove(tempPath)
+	}
+	if err := file.Chmod(privateRunOutputFileMode); err != nil {
+		cleanup()
+		return false, err
+	}
+	if _, err := io.Copy(file, bytes.NewReader(data)); err != nil {
+		cleanup()
+		return false, err
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(tempPath)
+		return false, err
+	}
+	// Publish a fully written key without replacing one won by a concurrent process.
+	if err := os.Link(tempPath, path); err != nil {
+		_ = os.Remove(tempPath)
+		if errors.Is(err, os.ErrExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	if err := os.Remove(tempPath); err != nil {
+		return true, err
+	}
+	return true, nil
 }

--- a/internal/cli/shard.go
+++ b/internal/cli/shard.go
@@ -38,6 +38,8 @@ var shardForbiddenRunFlags = map[string]bool{
 	"download":          true,
 	"emit-proof":        true,
 	"proof-template":    true,
+	"attest":            true,
+	"attest-key":        true,
 	"label":             true,
 	"id":                true,
 	"timing-json":       true,

--- a/internal/cli/shard_test.go
+++ b/internal/cli/shard_test.go
@@ -410,6 +410,8 @@ func TestPartitionShardRunArgs(t *testing.T) {
 		{name: "timing-record is forbidden", args: []string{"--timing-record", "default"}, wantErr: "--timing-record cannot be used with shard"},
 		{name: "capture-stdout is forbidden", args: []string{"--capture-stdout", "out.log"}, wantErr: "--capture-stdout cannot be used with shard"},
 		{name: "label is forbidden", args: []string{"--label", "mine"}, wantErr: "--label cannot be used with shard"},
+		{name: "attest is forbidden", args: []string{"--attest", "receipt.json"}, wantErr: "--attest cannot be used with shard"},
+		{name: "attest-key is forbidden", args: []string{"--attest-key", "key.pem"}, wantErr: "--attest-key cannot be used with shard"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/cli/watch.go
+++ b/internal/cli/watch.go
@@ -37,6 +37,8 @@ var watchForbiddenRunFlags = map[string]bool{
 	"download":          true,
 	"emit-proof":        true,
 	"proof-template":    true,
+	"attest":            true,
+	"attest-key":        true,
 	"label":             true,
 }
 

--- a/internal/cli/watch_test.go
+++ b/internal/cli/watch_test.go
@@ -1012,6 +1012,8 @@ func TestWatchRejectsConflictingRunFlags(t *testing.T) {
 		{"--download", "remote=local", "--", "echo", "ok"},
 		{"--emit-proof", "proof.md", "--", "echo", "ok"},
 		{"--proof-template", "default", "--", "echo", "ok"},
+		{"--attest", "receipt.json", "--", "echo", "ok"},
+		{"--attest-key", "key.pem", "--", "echo", "ok"},
 		{"-label", "custom", "--", "echo", "ok"},
 	} {
 		t.Run(args[0], func(t *testing.T) {


### PR DESCRIPTION
## Maintainer review update

Exact reviewed head: `c28da3ce2718b03c6cdbceb0e698e1e12250e154`, rebased onto current `main`.

- Protected both the receipt and effective signing key from collisions with lease/proof/capture/download/timing outputs, including symlink, hard-link, dangling-parent, and filesystem case aliases.
- Made first-use key minting atomic across concurrent processes; losing callers load the winning key instead of returning transient identities.
- Rejected `--attest-key` without `--attest` and validated override keys before any remote execution.
- Preserved delegated provider, lease, slug, run, and actions identity from session handles.
- Made the trust boundary visible in every result with `trust=self-signed`; a `PASS` is meaningful only after matching the fingerprint through a trusted channel.
- Added the maintainer-owned `Unreleased` changelog entry with contributor credit.

Exact-head verification: `go test -race ./...`, `go vet ./...`, `go build -trimpath -o /tmp/crabbox-pr996-current ./cmd/crabbox`, and `node scripts/check-command-docs.mjs` all pass. Four autoreview rounds addressed every accepted finding; the final review is clean with no actionable findings.

The maintainer exact-head proof below exercises the final trust marker and path hardening over real loopback SSH. The longer proof later in the body was captured by the contributor at head `7ec4e381` and covers tamper/schema rejection.

## Summary

Crabbox is built around run evidence: proof blocks (`--emit-proof`), content-addressed capsule manifests, timing JSON, JUnit summaries, artifact manifests with SHA-256 digests. None of that evidence is cryptographically signed, and there is no command to check any of it after the fact. A reviewer or an agent overseer has to trust pasted output.

This change adds the minimal provider-neutral primitive on top of what runs already collect:

- `crabbox run --attest <path>` writes `receipt.json` after a successful run: a flat JSON record of provider, lease, command, exit code, timing, and the SHA-256 of the combined stdout and stderr stream as observed by the client, signed with a per-user Ed25519 key.
- `crabbox verify <receipt.json>` recomputes the canonical bytes, checks the signature, and prints PASS or FAIL with the signer public key fingerprint and `trust=self-signed`. Exit 0 on PASS, 1 on signature mismatch, 2 for receipts that cannot be checked at all.
- The signing key is minted on first use at `<user config dir>/crabbox/attest/id_ed25519.pem` (PKCS8 PEM, 0600, same mint-once pattern as the per-lease SSH keys). `--attest-key <path>` signs with an existing PKCS8 PEM Ed25519 key and fails closed; it never creates a key at an override path.

Everything uses the Go standard library (`crypto/ed25519`, `crypto/x509`, `encoding/pem`); no new dependencies.

## Design notes

- The signature covers the canonical encoding of every receipt field except `signature` itself: the object minus `signature` is re-marshaled as compact JSON, which sorts map keys lexicographically. Because `public_key` is inside the signed payload, swapping in a different key also fails verification. Empty optional fields are omitted, never emitted as empty strings, so signer and verifier agree without per-field logic.
- The output digest is a fresh SHA-256 writer teed into the stream fan-out after the capture wrapping, so it sees the same bytes the console does, including under `--capture-stdout`. It deliberately does not hash the internal log ring buffer, which truncates at 8 MiB. Because the stdout and stderr streams write from separate goroutines, the digest is wrapped in a mutex-guarded writer, matching the synchronized run log buffer those streams already share, so `log_sha256` is always the hash of the bytes in arrival order and can never be corrupted by concurrent writes.
- Both run paths write receipts: the direct SSH path includes `run_id` and `log_sha256`; the delegated path preserves available session identity fields but omits `log_sha256` because a delegated `RunResult` carries only a bounded log excerpt, and hashing an excerpt would be misleading evidence. Dispatch stays by feature, not provider name, per `docs/vision.md`.
- `--attest` mirrors `--emit-proof`: path-valued, success-only, rejected with `--sync-only`, and preflighted with the same local output path checks.
- Hardening from the review rounds: `verify` rejects receipts whose JSON contains duplicate object keys anywhere (exit 2), because JSON parsers disagree on which duplicate wins and an edited receipt could show one value to a reader while the signature still verifies against another; beyond that, receipts are strictly schema validated before any signature decision: unknown fields, missing required fields, wrong types, non-integer number spellings, unsupported schema versions, invalid timestamps, and malformed digests are all rejected as malformed (exit 2), so `PASS` can only ever be printed for a well-formed, integrity-checked record. The receipt and effective signing-key paths are preflighted against every writable local output with filesystem-aware alias detection; `--attest`/`--attest-key` are forbidden in `watch` and `shard` forwarding, matching `--emit-proof`; missing parent directories use private modes; concurrent first use publishes exactly one stable key; and delegated receipts preserve every available session identity while omitting unavailable fields. The contributor changelog edit was dropped and a maintainer-owned entry was added during landing review.

## Config and secret implications

- New key file at `<user config dir>/crabbox/attest/id_ed25519.pem`, created 0600 in a 0700 directory through atomic no-replace publication. It is a signing identity, not a provider credential, and never leaves the machine.
- No secrets on argv: `--attest-key` takes a file path, never key material.
- No config schema changes and no coordinator or Worker changes.

## Verification

- `gofmt -l $(git ls-files '*.go')` clean
- `go vet ./...` clean
- `go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...` empty
- `go test -race ./...` all packages pass
- `go build -trimpath -o bin/crabbox ./cmd/crabbox` builds
- `node scripts/check-command-docs.mjs` passes (54 command docs, includes the new `verify` page and `crabbox verify --help` exit 0)
- `scripts/check-go-coverage.sh 90.0` passes
- New regression tests in `internal/cli/attest_test.go`: receipt round trip through the real `verify` command dispatch, empty-optional-field omission, a tamper table (mutated exit code, mutated command, foreign public key, corrupt signature encoding, deleted signature, duplicate `exit_code` key with the signed value last, duplicate `command` key with the signed value last, truncated JSON, missing file) asserting exit codes 1 vs 2, receipt path collision preflights against capture and download destinations, key mint idempotence with 0600/0700 permission checks, and `--attest-key` override semantics including fail-closed on a missing path and rejection of non-Ed25519 keys. `watch` and `shard` forbidden-flag suites cover `--attest` and `--attest-key` rejection. Digest-writer regressions run under the race detector: concurrent mixed stdout/stderr writes through the shared digest produce the exact expected hash with no data race (an unsynchronized hash in the same shape fails `-race` immediately), and a sequential mixed-stream case pins arrival-order hashing. Schema-validation regressions cover unsupported schema versions, unknown fields, decimal integer spellings, and invalid digests; a nested `--attest` path regression checks created directory modes; and a delegated-receipt regression covers a provider returning successful run metadata with no LeaseID, asserting the empty fields are omitted and the receipt still verifies.

## Exact-head real behavior proof

Built and exercised `c28da3ce2718b03c6cdbceb0e698e1e12250e154` with an isolated home directory, the static `ssh` provider explicitly pinned, a real local sshd, and temporary work/output paths. Temporary paths and the local username are redacted below; no cloud lease was created.

```text
$ git rev-parse HEAD
c28da3ce2718b03c6cdbceb0e698e1e12250e154

$ HOME=<isolated-home> /tmp/crabbox-pr996-current run --provider ssh --target macos \
    --static-host 127.0.0.1 --static-user <local-user> \
    --static-work-root <temporary-work-root> --no-sync \
    --attest <temporary-output>/receipt.json -- \
    /bin/sh -c 'printf "attest current-head\n"; uname -s'
using static target lease=static_127-0-0-1 slug=127-0-0-1 target=macos host=127.0.0.1 keep=false
running on 127.0.0.1 /bin/sh -c 'printf "attest current-head\n"; uname -s'
attest current-head
Darwin
artifact kind=receipt path=<temporary-output>/receipt.json bytes=520
lease cleanup stopped=true policy=auto lease=static_127-0-0-1 slug=127-0-0-1

$ HOME=<isolated-home> /tmp/crabbox-pr996-current verify <temporary-output>/receipt.json
PASS <temporary-output>/receipt.json signer=sha256:4ab06eb561fa17ba12b50bbe71d4c4d3a8abc4eb35b171e7c4263ef5be4a0b1c trust=self-signed

$ printf 'attest current-head\nDarwin\n' | shasum -a 256
0942612941e6d955b36963ac8de357e867e947d0db57e6c1f19070472a66aa52  -
$ jq -r '.log_sha256, .provider, .exit_code' <temporary-output>/receipt.json
sha256:0942612941e6d955b36963ac8de357e867e947d0db57e6c1f19070472a66aa52
ssh
0

$ HOME=<isolated-home> /tmp/crabbox-pr996-current run ... \
    --attest '<isolated-home>/Library/Application Support/crabbox/attest/id_ed25519.pem' -- /usr/bin/true
attest receipt and attest key paths must be different
exit status: 2
```

The collision attempt exits during local preflight: there is no target acquisition or remote command output. The independently computed hash exactly matches the receipt, and the verifier makes the self-signed trust boundary explicit.

## Contributor real behavior proof

Behavior addressed: run evidence in Crabbox cannot be verified after the fact; there is no signed receipt and no verify command, so any pasted run result is trust-me.
Real environment tested: the real `crabbox` binary built from pristine main d2ad413b101148400232c4f048da1227f9541ce0 and from this branch at head 7ec4e381, driving a real `crabbox run` over loopback SSH with the static ssh provider (real sshd, real sync, real remote command execution) on macOS; nothing simulated.
Exact steps or command run after this patch: `crabbox run --static-host 127.0.0.1 --static-user yuvald --attest receipts/nested/receipt.json -- /bin/sh -c 'echo attest demo; uname -s'` (a nested receipt path whose directories do not exist yet), then `crabbox verify` on the untouched receipt, after a one-field tamper, after a duplicate-key tamper that keeps the signed value last, and after injecting an unknown field.
Evidence after fix at contributor head `7ec4e381` (current output additionally includes `trust=self-signed`):
```
# BEFORE (pristine main d2ad413b101148400232c4f048da1227f9541ce0)
$ crabbox verify receipt.json
unexpected argument verify
exit status: 2
$ crabbox run --help | grep -E "^  -attest"
(no output; exit status 1: no such flags)

# AFTER (this branch, real run over loopback SSH with the static ssh provider)
$ crabbox run --static-host 127.0.0.1 --static-user yuvald --attest receipts/nested/receipt.json -- /bin/sh -c 'echo attest demo; uname -s'
running on 127.0.0.1 /bin/sh -c 'echo attest demo; uname -s'
attest demo
Darwin
artifact kind=receipt path=receipts/nested/receipt.json bytes=503
$ ls -la receipts/nested/receipt.json   (parent directories created by --attest)
-rw-------@ receipts/nested/receipt.json
$ cat receipts/nested/receipt.json
{
  "command": "/bin/sh -c 'echo attest demo; uname -s'",
  "command_ms": 640,
  "exit_code": 0,
  "generated_at": "2026-07-07T00:01:44Z",
  "lease_id": "static_127-0-0-1",
  "log_sha256": "sha256:32470cf9166f8353de6d7ffebf19d66a16ab9a0d34c2cad840ac30dda4865c21",
  "provider": "ssh",
  "public_key": "npCheZsJNUrNHucD7VmntRwVYel4vpiuprF6uRn6T9g=",
  "schema_version": 1,
  "signature": "fsbj5E/O1yi4H1QhxyKDzeKCsvq8Nj7oVLtOHeVhNHctaf2fKBfidiOJVvq3SSKJgrKacUkuKQeAK8YL/nhABA==",
  "slug": "127-0-0-1"
}
$ crabbox verify receipts/nested/receipt.json
PASS receipts/nested/receipt.json signer=sha256:c30e2ae902253e3191a54aa8b78da9170e9a3630820c0b97c6142f475fe81295
exit status: 0
$ printf 'attest demo
Darwin
' | shasum -a 256
32470cf9166f8353de6d7ffebf19d66a16ab9a0d34c2cad840ac30dda4865c21  -
$ sed -i '' 's/"exit_code": 0/"exit_code": 1/' receipts/nested/receipt.json && crabbox verify receipts/nested/receipt.json
FAIL receipts/nested/receipt.json signer=sha256:c30e2ae902253e3191a54aa8b78da9170e9a3630820c0b97c6142f475fe81295: signature mismatch
exit status: 1
$ duplicate exit_code key inserted with the signed value last, then crabbox verify
malformed receipt: duplicate key
exit status: 2
$ unknown field review_note injected, then crabbox verify
malformed receipt: unknown field "review_note"
exit status: 2
```
Observed result after fix: a real run over loopback SSH created the missing receipt directories with private modes and produced a signed receipt whose output digest independently matches the observed live output; verifying the untouched receipt prints PASS with the signer fingerprint and exit 0, flipping a single field flips the same command to FAIL signature mismatch with exit 1, and both a duplicate-key edit that keeps the signed value last and an injected unknown field are rejected outright as malformed with exit 2 instead of printing PASS, where pristine main rejects the verify command entirely and has no attest flags.
What was not tested: no delegated-provider live run (the delegated receipt path is exercised in the Go suite only); no Windows host; key rotation and multi-user trust decisions are out of scope for v1.

## Not in this change (deliberate v2 boundary)

A v1 receipt is client-side, self-signed evidence: it proves the record is unmodified since signing and was signed by the embedded key, whose fingerprint `verify` prints for out-of-band comparison. It does not prove who holds that key (no trust roots or identity binding), that the run occurred as described (the signer is the party that ran it), or that a receipt was not withheld and regenerated (no transparency log). Coordinator key custody, DSSE or in-toto envelope formats, trust roots, and a remote receipt registry are deliberately out of scope for this slice.
