### PR TITLE
fix: partition pending OAuth logins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Partitioned unauthenticated GitHub OAuth starts by caller with an atomic per-source limit and guarded global backstop, preventing one source from exhausting login for every user. Thanks @coygeek.
 - Disabled inherited SSH agent and X11 forwarding across CLI-managed SSH, rsync, SCP, VNC, and port-forward transports, preserving per-lease credential boundaries. Thanks @coygeek.
 - Collected runtime-only provider credentials through provider-owned diagnostic hooks and redacted opaque OpenSandbox and W&B upstream errors before they reach CLI output. Thanks @coygeek.
 - Redacted complete punctuation-bearing authorization, API-key, and bearer values from CLI and coordinator diagnostics while preserving whitespace-separated routing context. Thanks @coygeek.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -372,6 +372,12 @@ Provider choices are `HETZNER_TOKEN`, an AWS credential set, an Azure service
 principal, a GCP service account, or `DAYTONA_CRABBOX_KEY`. Node additionally
 requires `DATABASE_URL`.
 
+GitHub OAuth start routes remain unauthenticated so a new user can bootstrap login.
+The coordinator limits active attempts to ten per caller source and 100 globally for
+both CLI and portal login, after removing expired attempts. Node deployments behind a
+reverse proxy must configure `CRABBOX_TRUSTED_PROXY_CIDRS`; otherwise caller limits use
+the direct peer address and ignore forwarded addresses.
+
 For any portal that exposes browser Code, configure
 `CRABBOX_CODE_ORIGIN_TEMPLATE=https://{lease}.code.example.com` and route the
 matching wildcard hostname to the same coordinator with TLS and WebSocket

--- a/docs/security.md
+++ b/docs/security.md
@@ -102,6 +102,13 @@ the browser receives a random confirmation through that loopback URL. Polling
 requires both the CLI-held secret and the browser confirmation, so forwarding an
 authorization URL cannot deliver the resulting user token to the sender.
 
+Unauthenticated CLI and portal login starts share a ten-pending-attempt limit per
+caller source and a 100-attempt global backstop. Admission and storage are serialized,
+expired attempts are removed first, and only a session-secret-keyed source hash is
+stored with each attempt. Cloudflare supplies the caller address; the portable Node
+server derives it from the socket or an explicitly trusted proxy instead of trusting
+a client-provided forwarding header.
+
 User tokens can only mutate or read leases, runs, and usage for their own `owner`/`org`
 identity. Lease owners also have read-only audit access to run history, logs,
 events, telemetry, and live event subscriptions for work recorded against

--- a/worker/src/coordinator-runtime.ts
+++ b/worker/src/coordinator-runtime.ts
@@ -15,6 +15,12 @@ export function coordinatorRequestQueue(request: Request): CoordinatorRequestQue
   const url = new URL(request.url);
   const path = url.pathname.split("/").filter(Boolean);
   const method = request.method.toUpperCase();
+  if (
+    (method === "POST" && path.join("/") === "v1/auth/github/start") ||
+    (method === "GET" && path.join("/") === "portal/login")
+  ) {
+    return "direct";
+  }
   if (method === "GET" && path.join("/") === "v1/auth/github/callback") {
     return "direct";
   }

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -901,7 +901,7 @@ export class FleetCoordinator {
         return await githubAuthRoute(request, parts[3], this.state, this.env);
       }
       if (method === "GET" && parts.join("/") === "portal/login") {
-        return await githubPortalLogin(request, this.state.storage, this.env);
+        return await githubPortalLogin(request, this.state, this.env);
       }
       if (method === "GET" && parts.join("/") === "portal/logout") {
         return githubPortalLogoutConfirmation();

--- a/worker/src/oauth.ts
+++ b/worker/src/oauth.ts
@@ -18,6 +18,7 @@ const githubAuthorizeURL = "https://github.com/login/oauth/authorize";
 const githubTokenURL = "https://github.com/login/oauth/access_token";
 const githubAPIURL = "https://api.github.com";
 const maxPendingOAuthLogins = 100;
+const maxPendingOAuthLoginsPerSource = 10;
 const defaultUserTokenTTLSeconds = 180 * 24 * 60 * 60;
 const minUserTokenTTLSeconds = 60 * 60;
 const maxUserTokenTTLSeconds = 365 * 24 * 60 * 60;
@@ -41,6 +42,7 @@ interface OAuthPending {
   login?: string;
   error?: string;
   callbackClaim?: string;
+  sourceHash?: string;
 }
 
 interface GitHubUser {
@@ -62,7 +64,7 @@ export async function githubAuthRoute(
 ): Promise<Response> {
   const method = request.method.toUpperCase();
   if (method === "POST" && action === "start") {
-    return await githubAuthStart(request, runtime.storage, env);
+    return await githubAuthStart(request, runtime, env);
   }
   if (method === "GET" && action === "callback") {
     return await githubAuthCallback(request, runtime, env);
@@ -75,7 +77,7 @@ export async function githubAuthRoute(
 
 export async function githubPortalLogin(
   request: Request,
-  storage: CoordinatorStorage,
+  runtime: Pick<CoordinatorRuntime, "storage" | "runExclusive">,
   env: Env,
 ): Promise<Response> {
   const clientID = env.CRABBOX_GITHUB_CLIENT_ID;
@@ -90,17 +92,16 @@ export async function githubPortalLogin(
   if (signingError) {
     return html("Crabbox login unavailable", signingError, 503);
   }
-  const pendingCount = await cleanupExpiredPendingOAuth(storage);
-  if (pendingCount >= maxPendingOAuthLogins) {
-    return html("Crabbox login busy", "Too many pending GitHub logins. Try again shortly.", 429);
-  }
   const url = new URL(request.url);
   const pending = newPendingOAuth({
     mode: "portal",
     returnTo: safePortalReturnTo(url.searchParams.get("returnTo")),
     redirectURI: oauthConfig.redirectURI,
+    sourceHash: await pendingOAuthSourceHash(request, env.CRABBOX_SESSION_SECRET!),
   });
-  await storePendingOAuth(storage, pending);
+  if (!(await admitPendingOAuth(runtime, pending))) {
+    return html("Crabbox login busy", "Too many pending GitHub logins. Try again shortly.", 429);
+  }
 
   return redirect(githubAuthorizeURLFor(clientID, pending.state, pending.redirectURI), 302);
 }
@@ -133,7 +134,7 @@ export function githubPortalLogoutConfirmation(): Response {
 
 async function githubAuthStart(
   request: Request,
-  storage: CoordinatorStorage,
+  runtime: Pick<CoordinatorRuntime, "storage" | "runExclusive">,
   env: Env,
 ): Promise<Response> {
   const clientID = env.CRABBOX_GITHUB_CLIENT_ID;
@@ -169,8 +170,17 @@ async function githubAuthStart(
       { status: 400 },
     );
   }
-  const pendingCount = await cleanupExpiredPendingOAuth(storage);
-  if (pendingCount >= maxPendingOAuthLogins) {
+  const pending = newPendingOAuth({
+    mode: "cli",
+    pollSecretHash: input.pollSecretHash,
+    loopbackRedirectURI,
+    redirectURI: oauthConfig.redirectURI,
+    sourceHash: await pendingOAuthSourceHash(request, env.CRABBOX_SESSION_SECRET!),
+  });
+  if (input.provider === "aws" || input.provider === "hetzner" || input.provider === "gcp") {
+    pending.provider = input.provider;
+  }
+  if (!(await admitPendingOAuth(runtime, pending))) {
     return json(
       {
         error: "login_rate_limited",
@@ -179,16 +189,6 @@ async function githubAuthStart(
       { status: 429 },
     );
   }
-  const pending = newPendingOAuth({
-    mode: "cli",
-    pollSecretHash: input.pollSecretHash,
-    loopbackRedirectURI,
-    redirectURI: oauthConfig.redirectURI,
-  });
-  if (input.provider === "aws" || input.provider === "hetzner" || input.provider === "gcp") {
-    pending.provider = input.provider;
-  }
-  await storePendingOAuth(storage, pending);
 
   return json({
     loginID: pending.id,
@@ -216,6 +216,28 @@ async function storePendingOAuth(
 ): Promise<void> {
   await storage.put(oauthKey(pending.id), pending);
   await storage.put(oauthStateKey(pending.state), pending.id);
+}
+
+async function pendingOAuthSourceHash(request: Request, sessionSecret: string): Promise<string> {
+  const source = request.headers.get("cf-connecting-ip")?.trim() || "unknown";
+  return sha256Hex(`crabbox-oauth-source-v1\0${sessionSecret}\0${source}`);
+}
+
+async function admitPendingOAuth(
+  runtime: Pick<CoordinatorRuntime, "storage" | "runExclusive">,
+  pending: OAuthPending,
+): Promise<boolean> {
+  return runtime.runExclusive(async () => {
+    const counts = await cleanupExpiredPendingOAuth(runtime.storage, pending.sourceHash);
+    if (
+      counts.total >= maxPendingOAuthLogins ||
+      counts.forSource >= maxPendingOAuthLoginsPerSource
+    ) {
+      return false;
+    }
+    await storePendingOAuth(runtime.storage, pending);
+    return true;
+  });
 }
 
 function githubAuthorizeURLFor(clientID: string, state: string, redirectURI: string): string {
@@ -632,20 +654,27 @@ async function deletePendingOAuth(
   await storage.delete(oauthStateKey(pending.state));
 }
 
-async function cleanupExpiredPendingOAuth(storage: CoordinatorStorage): Promise<number> {
+async function cleanupExpiredPendingOAuth(
+  storage: CoordinatorStorage,
+  sourceHash?: string,
+): Promise<{ total: number; forSource: number }> {
   const entries = await storage.list<OAuthPending>({ prefix: "oauth:" });
-  let active = 0;
+  let total = 0;
+  let forSource = 0;
   const now = Date.now();
-  await Promise.all(
-    [...entries.values()].map(async (pending) => {
-      if (Date.parse(pending.expiresAt) <= now) {
-        await deletePendingOAuth(storage, pending);
-        return;
-      }
-      active += 1;
-    }),
-  );
-  return active;
+  const expired: OAuthPending[] = [];
+  for (const pending of entries.values()) {
+    if (Date.parse(pending.expiresAt) <= now) {
+      expired.push(pending);
+      continue;
+    }
+    total += 1;
+    if (sourceHash && pending.sourceHash === sourceHash) {
+      forSource += 1;
+    }
+  }
+  await Promise.all(expired.map((pending) => deletePendingOAuth(storage, pending)));
+  return { total, forSource };
 }
 
 function oauthKey(id: string): string {

--- a/worker/test/coordinator-runtime.test.ts
+++ b/worker/test/coordinator-runtime.test.ts
@@ -533,7 +533,7 @@ describe("coordinator runtimes", () => {
       ).toBe("direct");
     }
     expect(coordinatorRequestQueue(new Request("https://coordinator.test/portal/login"))).toBe(
-      "lifecycle",
+      "direct",
     );
     expect(
       coordinatorRequestQueue(
@@ -544,7 +544,7 @@ describe("coordinator runtimes", () => {
       coordinatorRequestQueue(
         new Request("https://coordinator.test/v1/auth/github/start", { method: "POST" }),
       ),
-    ).toBe("lifecycle");
+    ).toBe("direct");
     expect(
       coordinatorRequestQueue(
         new Request("https://coordinator.test/v1/adapters/applied-alice/ticket", {
@@ -564,20 +564,18 @@ describe("coordinator runtimes", () => {
       CRABBOX_SHARED_TOKEN: "shared",
       CRABBOX_SESSION_SECRET: "session-secret",
     } as Env;
-    const start = await runtime.runExclusive(() =>
-      githubAuthRoute(
-        new Request("https://coordinator.test/v1/auth/github/start", {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({
-            pollSecretHash: "0".repeat(64),
-            loopbackRedirectURI: `http://127.0.0.1:54321/crabbox/oauth/${"a".repeat(64)}`,
-          }),
+    const start = await githubAuthRoute(
+      new Request("https://coordinator.test/v1/auth/github/start", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          pollSecretHash: "0".repeat(64),
+          loopbackRedirectURI: `http://127.0.0.1:54321/crabbox/oauth/${"a".repeat(64)}`,
         }),
-        "start",
-        runtime,
-        env,
-      ),
+      }),
+      "start",
+      runtime,
+      env,
     );
     const startBody = (await start.json()) as { url: string };
     const state = new URL(startBody.url).searchParams.get("state");

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -22356,6 +22356,106 @@ describe("fleet identity", () => {
     await expect(poll.json()).resolves.toMatchObject({ status: "pending" });
   });
 
+  it("atomically limits pending GitHub logins per caller", async () => {
+    const storage = new MemoryStorage();
+    const fleet = githubLoginTestFleet(storage);
+    const sourceIP = "198.51.100.40";
+
+    const responses = await Promise.all(
+      Array.from({ length: 20 }, () => fleet.fetch(githubLoginStartRequest(sourceIP))),
+    );
+    expect(responses.map(({ status }) => status).toSorted()).toEqual([
+      ...Array.from({ length: 10 }, () => 200),
+      ...Array.from({ length: 10 }, () => 429),
+    ]);
+    expect((await storage.list({ prefix: "oauth:" })).size).toBe(10);
+
+    const stored = [
+      ...(await storage.list<Record<string, unknown>>({ prefix: "oauth:" })).values(),
+    ];
+    expect(stored.every(({ sourceHash }) => typeof sourceHash === "string")).toBe(true);
+    expect(JSON.stringify(stored)).not.toContain(sourceIP);
+  });
+
+  it("shares the caller limit across CLI and portal GitHub login", async () => {
+    const fleet = githubLoginTestFleet();
+    const sourceIP = "198.51.100.41";
+
+    const cliStarts = await Promise.all(
+      Array.from({ length: 9 }, () => fleet.fetch(githubLoginStartRequest(sourceIP))),
+    );
+    expect(cliStarts.every(({ status }) => status === 200)).toBe(true);
+    expect(
+      (
+        await fleet.fetch(
+          request("GET", "/portal/login", {
+            headers: { "cf-connecting-ip": sourceIP },
+          }),
+        )
+      ).status,
+    ).toBe(302);
+
+    const blockedCLI = await fleet.fetch(githubLoginStartRequest(sourceIP));
+    expect(blockedCLI.status).toBe(429);
+    await expect(blockedCLI.json()).resolves.toMatchObject({ error: "login_rate_limited" });
+    expect(
+      (
+        await fleet.fetch(
+          request("GET", "/portal/login", {
+            headers: { "cf-connecting-ip": sourceIP },
+          }),
+        )
+      ).status,
+    ).toBe(429);
+    expect((await fleet.fetch(githubLoginStartRequest("198.51.100.42"))).status).toBe(200);
+  });
+
+  it("reclaims expired attempts from the caller limit", async () => {
+    const storage = new MemoryStorage();
+    const fleet = githubLoginTestFleet(storage);
+    const sourceIP = "198.51.100.43";
+
+    const starts = await Promise.all(
+      Array.from({ length: 10 }, () => fleet.fetch(githubLoginStartRequest(sourceIP))),
+    );
+    expect(starts.every(({ status }) => status === 200)).toBe(true);
+    expect((await fleet.fetch(githubLoginStartRequest(sourceIP))).status).toBe(429);
+
+    const attempts = await storage.list<Record<string, unknown>>({ prefix: "oauth:" });
+    await Promise.all(
+      [...attempts].map(([key, pending]) =>
+        storage.put(key, { ...pending, expiresAt: "2026-05-01T00:00:00.000Z" }),
+      ),
+    );
+
+    expect((await fleet.fetch(githubLoginStartRequest(sourceIP))).status).toBe(200);
+    expect((await storage.list({ prefix: "oauth:" })).size).toBe(1);
+  });
+
+  it("keeps a global pending GitHub login backstop across callers", async () => {
+    const fleet = githubLoginTestFleet();
+
+    const responses = await Promise.all(
+      Array.from({ length: 10 }, (_, source) =>
+        Array.from({ length: 10 }, () =>
+          fleet.fetch(githubLoginStartRequest(`198.51.100.${source + 1}`)),
+        ),
+      ).flat(),
+    );
+    expect(responses.every(({ status }) => status === 200)).toBe(true);
+
+    expect((await fleet.fetch(githubLoginStartRequest("198.51.100.200"))).status).toBe(429);
+    expect(
+      (
+        await fleet.fetch(
+          request("GET", "/portal/login", {
+            headers: { "cf-connecting-ip": "198.51.100.201" },
+          }),
+        )
+      ).status,
+    ).toBe(429);
+  });
+
   it.each([
     ["missing", undefined],
     ["remote host", `http://example.test:54321/crabbox/oauth/${"a".repeat(64)}`],
@@ -23106,6 +23206,31 @@ async function startGitHubLogin(env: Partial<Env> = {}): Promise<{
   const state = url.searchParams.get("state");
   expect(state).toBeTruthy();
   return { fleet, loginID: body.loginID, pollSecret, state: state || "" };
+}
+
+function githubLoginTestFleet(storage = new MemoryStorage()): FleetDurableObject {
+  return testFleet(
+    storage,
+    {},
+    {
+      CRABBOX_DEFAULT_ORG: "openclaw",
+      CRABBOX_PUBLIC_URL: "https://crabbox.test",
+      CRABBOX_GITHUB_CLIENT_ID: "github-client",
+      CRABBOX_GITHUB_CLIENT_SECRET: "github-secret",
+      CRABBOX_SHARED_TOKEN: "shared",
+      CRABBOX_SESSION_SECRET: "session-secret",
+    },
+  );
+}
+
+function githubLoginStartRequest(sourceIP: string): Request {
+  return request("POST", "/v1/auth/github/start", {
+    headers: { "cf-connecting-ip": sourceIP },
+    body: {
+      pollSecretHash: "0".repeat(64),
+      loopbackRedirectURI: testLoopbackRedirectURI,
+    },
+  });
 }
 
 const testLoopbackRedirectURI = `http://127.0.0.1:54321/crabbox/oauth/${"a".repeat(64)}`;


### PR DESCRIPTION
Fixes https://github.com/openclaw/crabbox/issues/973

## Summary

- limit unauthenticated GitHub OAuth starts to ten active attempts per caller source while retaining the 100-attempt global backstop
- serialize expiry cleanup, both admission checks, and pending-record storage so concurrent starts cannot overrun either cap
- share the caller budget across CLI and portal login, store only a session-secret-keyed source hash, and preserve trusted source derivation for Cloudflare and portable Node deployments
- document the security/operations contract and thank the reporter in the changelog

## Verification

- focused OAuth concurrency, cross-flow, global-cap, and expiry tests
- live local Wrangler HTTP proof: ten same-source CLI starts returned 200; the next CLI start and portal login returned 429; different sources still returned 200 and 302
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker` (897 passed, 3 skipped)
- `npm run build --prefix worker`
- `go vet ./...`
- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- `go test -race ./...`
- `node scripts/build-docs-site.mjs`
- AutoReview clean; no accepted/actionable findings

The live proof used disposable fake OAuth configuration and did not exchange a GitHub code, use production credentials, or create a provider resource.
