### PR TITLE
fix: verify provider SSH host keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Kept sync manifest writes compatible with minimal BusyBox guests instead of requiring a GNU-only `dd` option, and preserved complete Phala gateway hostnames so later status and SSH reconnects keep working.
 - Restored lease-scoped SSH host-key pinning for Namespace Instance, Phala, and Islo proxy connections instead of accepting unverified server identities. Thanks @coygeek.
 - Corrected the CLI command map, coordinator API methods, and provider architecture reference to match the implemented commands, routes, and backend capabilities. Thanks @zozo123.
 - Partitioned unauthenticated GitHub OAuth starts by caller with an atomic per-source limit and guarded global backstop, preventing one source from exhausting login for every user. Thanks @coygeek.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Restored lease-scoped SSH host-key pinning for Namespace Instance, Phala, and Islo proxy connections instead of accepting unverified server identities. Thanks @coygeek.
 - Corrected the CLI command map, coordinator API methods, and provider architecture reference to match the implemented commands, routes, and backend capabilities. Thanks @zozo123.
 - Partitioned unauthenticated GitHub OAuth starts by caller with an atomic per-source limit and guarded global backstop, preventing one source from exhausting login for every user. Thanks @coygeek.
 - Disabled inherited SSH agent and X11 forwarding across CLI-managed SSH, rsync, SCP, VNC, and port-forward transports, preserving per-lease credential boundaries. Thanks @coygeek.

--- a/internal/cli/lease.go
+++ b/internal/cli/lease.go
@@ -108,6 +108,25 @@ func UseStoredTestboxKey(target *SSHTarget, leaseID string) {
 	useStoredTestboxKey(target, leaseID)
 }
 
+func useLeaseKnownHosts(target *SSHTarget, leaseID string) error {
+	keyPath, err := testboxKeyPath(leaseID)
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(keyPath)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return exit(2, "prepare lease SSH host-key directory for %s: %v", leaseID, err)
+	}
+	// Keep the verified host identity beside Crabbox's lease credentials so
+	// cleanup removes both and identical provider hostnames cannot share trust.
+	target.KnownHostsFile = filepath.Join(dir, "known_hosts")
+	return nil
+}
+
+func UseLeaseKnownHosts(target *SSHTarget, leaseID string) error {
+	return useLeaseKnownHosts(target, leaseID)
+}
+
 func moveStoredTestboxKey(oldLeaseID, newLeaseID string) error {
 	if oldLeaseID == "" || newLeaseID == "" || oldLeaseID == newLeaseID {
 		return nil

--- a/internal/cli/lease_test.go
+++ b/internal/cli/lease_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -32,5 +33,64 @@ func TestTestboxKeyPathAllowsSafeCustomIDs(t *testing.T) {
 	want := filepath.Join(configDir, "crabbox", "testboxes", "morphvm_123", "id_ed25519")
 	if path != want {
 		t.Fatalf("testboxKeyPath()=%q want %q", path, want)
+	}
+}
+
+func TestUseLeaseKnownHostsScopesAndEnforcesHostVerification(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	const leaseID = "cbx_abcdef123456"
+	target := SSHTarget{User: "root", Host: "provider-resource", Port: "22"}
+	if err := useLeaseKnownHosts(&target, leaseID); err != nil {
+		t.Fatal(err)
+	}
+	keyPath, err := testboxKeyPath(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(filepath.Dir(keyPath), "known_hosts")
+	if target.KnownHostsFile != want {
+		t.Fatalf("KnownHostsFile=%q want %q", target.KnownHostsFile, want)
+	}
+	if info, err := os.Stat(filepath.Dir(want)); err != nil {
+		t.Fatalf("stat lease SSH directory: %v", err)
+	} else if info.Mode().Perm()&0o077 != 0 {
+		t.Fatalf("lease SSH directory mode=%#o want private", info.Mode().Perm())
+	}
+
+	args := strings.Join(sshBaseArgs(target), " ")
+	for _, wantArg := range []string{"StrictHostKeyChecking=accept-new", "UserKnownHostsFile=" + sshConfigFileValue(want)} {
+		if !strings.Contains(args, wantArg) {
+			t.Fatalf("ssh args missing %q: %s", wantArg, args)
+		}
+	}
+	for _, forbidden := range []string{"StrictHostKeyChecking=no", "UserKnownHostsFile=/dev/null"} {
+		if strings.Contains(args, forbidden) {
+			t.Fatalf("ssh args contain insecure option %q: %s", forbidden, args)
+		}
+	}
+}
+
+func TestUseLeaseKnownHostsFailsClosedWhenDirectoryCannotBePrepared(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	testboxesPath := filepath.Join(configDir, "crabbox", "testboxes")
+	if err := os.MkdirAll(filepath.Dir(testboxesPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(testboxesPath, []byte("not a directory"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	target := SSHTarget{KnownHostsFile: "unchanged"}
+	if err := useLeaseKnownHosts(&target, "cbx_abcdef123456"); err == nil {
+		t.Fatal("useLeaseKnownHosts succeeded with an unusable lease directory")
+	}
+	if target.KnownHostsFile != "unchanged" {
+		t.Fatalf("KnownHostsFile changed after preparation failure: %q", target.KnownHostsFile)
 	}
 }

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -1391,7 +1391,10 @@ IFS= read -r manifest_len
 case "$manifest_len" in
   ''|*[!0-9]*) echo "invalid sync manifest length" >&2; exit 1 ;;
 esac
-dd bs=1 count="$manifest_len" of="$meta_dir/sync-manifest.new" status=none
+# Keep this to POSIX dd operands: minimal guests commonly provide BusyBox dd,
+# which rejects GNU's progress-suppression extension. Suppress only the summary;
+# dd's exit status still makes the fail-closed script abort on a short write.
+dd bs=1 count="$manifest_len" of="$meta_dir/sync-manifest.new" 2>/dev/null
 cat > "$meta_dir/sync-deleted.new"
 `
 	return "bash -lc " + shellQuote(script)

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -1550,6 +1550,9 @@ func TestRemoteWriteSyncManifestsNewForTargetUsesInterpretedWriterForWSL2(t *tes
 	if !strings.Contains(plain, "dd bs=1") {
 		t.Fatalf("non-WSL2 manifest writer should keep portable dd fallback: %q", plain)
 	}
+	if strings.Contains(plain, "status=none") {
+		t.Fatalf("non-WSL2 manifest writer should not require GNU dd extensions: %q", plain)
+	}
 }
 
 func TestSyncManifestInputForTargetFramesDeletedLengthForWSL2(t *testing.T) {

--- a/internal/providers/islo/backend_test.go
+++ b/internal/providers/islo/backend_test.go
@@ -26,6 +26,13 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
+func isolateIsloTestHome(t *testing.T) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+}
+
 func TestParseIsloSSE(t *testing.T) {
 	body := strings.Join([]string{
 		"event: stdout",
@@ -249,9 +256,16 @@ func TestIsloMutationsRejectCanonicalSandboxWithoutExactClaim(t *testing.T) {
 
 func TestIsloStopDeletesExactlyClaimedSandbox(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	if err := claimLeaseForRepoProvider("isb_crabbox-repo-abcdef", "web", isloProvider, t.TempDir(), time.Hour, false); err != nil {
+	isolateIsloTestHome(t)
+	const leaseID = "isb_crabbox-repo-abcdef"
+	if err := claimLeaseForRepoProvider(leaseID, "web", isloProvider, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
+	target := core.SSHTarget{}
+	if err := core.UseLeaseKnownHosts(&target, leaseID); err != nil {
+		t.Fatal(err)
+	}
+	knownHostsDir := filepath.Dir(target.KnownHostsFile)
 	client := &fakeIsloSyncClient{}
 	restore := swapNewIsloClient(client)
 	t.Cleanup(restore)
@@ -265,6 +279,9 @@ func TestIsloStopDeletesExactlyClaimedSandbox(t *testing.T) {
 	}
 	if client.deleteCalls != 1 {
 		t.Fatalf("delete calls=%d, want 1", client.deleteCalls)
+	}
+	if _, err := os.Stat(knownHostsDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("lease SSH state remains after stop: %v", err)
 	}
 }
 
@@ -388,6 +405,7 @@ func TestIsloRunRejectsUnsafeWorkdirBeforeProviderClient(t *testing.T) {
 
 func TestIsloResolveSSHUsesSandboxHostnameDefaults(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	isolateIsloTestHome(t)
 	root := t.TempDir()
 	leaseID := "isb_crabbox-repo-abcdef"
 	if err := claimLeaseForRepoProvider(leaseID, "web", isloProvider, root, time.Hour, false); err != nil {
@@ -413,8 +431,16 @@ func TestIsloResolveSSHUsesSandboxHostnameDefaults(t *testing.T) {
 	if lease.SSH.Host != "crabbox-repo-abcdef.islo" || lease.SSH.User != isloWorkloadUser || lease.SSH.Port != "22" {
 		t.Fatalf("ssh target=%#v", lease.SSH)
 	}
-	if lease.SSH.Key != "" || len(lease.SSH.FallbackPorts) != 0 || !lease.SSH.SSHConfigProxy || !lease.SSH.DisableHostKeyChecking {
+	if lease.SSH.Key != "" || len(lease.SSH.FallbackPorts) != 0 || !lease.SSH.SSHConfigProxy || lease.SSH.DisableHostKeyChecking {
 		t.Fatalf("islo ssh should not force Crabbox's default key or fallback ports: %#v", lease.SSH)
+	}
+	keyPath, err := core.TestboxKeyPath(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantKnownHosts := filepath.Join(filepath.Dir(keyPath), "known_hosts")
+	if lease.SSH.KnownHostsFile != wantKnownHosts {
+		t.Fatalf("KnownHostsFile=%q want %q", lease.SSH.KnownHostsFile, wantKnownHosts)
 	}
 	if lease.Server.PublicNet.IPv4.IP != "crabbox-repo-abcdef.islo" || lease.Server.Labels["ssh_host"] != "crabbox-repo-abcdef.islo" {
 		t.Fatalf("server ssh labels=%#v public=%q", lease.Server.Labels, lease.Server.PublicNet.IPv4.IP)
@@ -423,6 +449,7 @@ func TestIsloResolveSSHUsesSandboxHostnameDefaults(t *testing.T) {
 
 func TestIsloResolveSSHHonorsExplicitSSHOverrides(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	isolateIsloTestHome(t)
 	leaseID := "isb_crabbox-repo-abcdef"
 	if err := claimLeaseForRepoProvider(leaseID, "web", isloProvider, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
@@ -449,6 +476,7 @@ func TestIsloResolveSSHHonorsExplicitSSHOverrides(t *testing.T) {
 
 func TestIsloResolveSSHResumesPausedSandbox(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	isolateIsloTestHome(t)
 	root := t.TempDir()
 	client := &fakeIsloSyncClient{
 		getSandbox: &gosdk.SandboxResponse{Name: "crabbox-repo-abcdef", Status: "paused"},
@@ -478,6 +506,7 @@ func TestIsloResolveSSHResumesPausedSandbox(t *testing.T) {
 
 func TestIsloResolveSSHRejectsUnclaimedSandboxBeforeResume(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	isolateIsloTestHome(t)
 	client := &fakeIsloSyncClient{
 		getSandbox: &gosdk.SandboxResponse{Name: "crabbox-repo-abcdef", Status: "paused"},
 	}
@@ -502,6 +531,7 @@ func TestIsloResolveSSHRejectsUnclaimedSandboxBeforeResume(t *testing.T) {
 
 func TestIsloResolveSSHRejectsForeignClaimBeforeResume(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	isolateIsloTestHome(t)
 	leaseID := "isb_crabbox-repo-abcdef"
 	if err := claimLeaseForRepoProvider(leaseID, "web", isloProvider, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
@@ -530,6 +560,7 @@ func TestIsloResolveSSHRejectsForeignClaimBeforeResume(t *testing.T) {
 
 func TestIsloResolveSSHWaitsForStartingSandbox(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	isolateIsloTestHome(t)
 	leaseID := "isb_crabbox-repo-abcdef"
 	if err := claimLeaseForRepoProvider(leaseID, "web", isloProvider, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)

--- a/internal/providers/islo/core.go
+++ b/internal/providers/islo/core.go
@@ -76,6 +76,7 @@ func resolveLeaseClaim(identifier string) (core.LeaseClaim, bool, error) {
 
 func removeLeaseClaim(leaseID string) {
 	core.RemoveLeaseClaim(leaseID)
+	core.RemoveStoredTestboxKey(leaseID)
 }
 
 func updateLeaseClaimTailscale(leaseID, ipv4, fqdn string) error {

--- a/internal/providers/islo/ssh.go
+++ b/internal/providers/islo/ssh.go
@@ -34,6 +34,9 @@ func (b *isloBackend) Resolve(ctx context.Context, req core.ResolveRequest) (cor
 	server := isloSandboxToServer(sandbox)
 	applyIsloSSHLabels(&server, leaseID, b.cfg)
 	target := b.sshTargetForSandbox(name)
+	if err := core.UseLeaseKnownHosts(&target, leaseID); err != nil {
+		return core.LeaseTarget{}, err
+	}
 	return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 }
 
@@ -113,14 +116,13 @@ func (b *isloBackend) sshTargetForSandbox(name string) core.SSHTarget {
 		key = b.cfg.SSHKey
 	}
 	return core.SSHTarget{
-		User:                   user,
-		Host:                   isloSSHHost(name),
-		Key:                    key,
-		Port:                   port,
-		FallbackPorts:          []string{},
-		TargetOS:               targetLinux,
-		SSHConfigProxy:         true,
-		DisableHostKeyChecking: true,
+		User:           user,
+		Host:           isloSSHHost(name),
+		Key:            key,
+		Port:           port,
+		FallbackPorts:  []string{},
+		TargetOS:       targetLinux,
+		SSHConfigProxy: true,
 	}
 }
 

--- a/internal/providers/namespaceinstance/backend.go
+++ b/internal/providers/namespaceinstance/backend.go
@@ -94,6 +94,9 @@ func machineTypeForClass(class string) string {
 func (b *backend) Spec() core.ProviderSpec { return b.spec }
 
 func (b *backend) RebindResolvedLeaseTarget(target *core.LeaseTarget, leaseID string) error {
+	if err := core.UseLeaseKnownHosts(&target.SSH, leaseID); err != nil {
+		return err
+	}
 	core.UseStoredTestboxKey(&target.SSH, leaseID)
 	return nil
 }
@@ -191,7 +194,10 @@ func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.Le
 		recoveryLabels["recovery"] = recovery
 		recoveryLabels["state"] = "provisioning"
 		item := instance{ClusterID: id, Labels: recoveryLabels}
-		lease := b.lease(item, cfg, leaseID)
+		lease, err := b.lease(item, cfg, leaseID)
+		if err != nil {
+			return err
+		}
 		if req.Repo.Root != "" {
 			return core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, lease.Server, lease.SSH, req.Repo.Root, cfg.IdleTimeout, req.Reclaim)
 		}
@@ -218,7 +224,10 @@ func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.Le
 	if err != nil {
 		return core.LeaseTarget{}, rollback(err)
 	}
-	lease := b.lease(item, cfg, leaseID)
+	lease, err := b.lease(item, cfg, leaseID)
+	if err != nil {
+		return core.LeaseTarget{}, rollback(err)
+	}
 	if err := b.prepareSSH(ctx, cfg, &lease.SSH); err != nil {
 		return core.LeaseTarget{}, rollback(err)
 	}
@@ -241,7 +250,10 @@ func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.Le
 	if err != nil {
 		return core.LeaseTarget{}, err
 	}
-	lease := b.lease(item, cfg, leaseID)
+	lease, err := b.lease(item, cfg, leaseID)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
 	if req.ReleaseOnly || req.StatusOnly && !req.ReadyProbe {
 		return lease, nil
 	}
@@ -707,28 +719,30 @@ func (b *backend) resolve(ctx context.Context, identifier string, cfg core.Confi
 	return instance{}, "", core.Exit(4, "Namespace instance lease not found: %s", identifier)
 }
 
-func (b *backend) lease(item instance, cfg core.Config, leaseID string) core.LeaseTarget {
+func (b *backend) lease(item instance, cfg core.Config, leaseID string) (core.LeaseTarget, error) {
 	target := core.SSHTarget{
-		User:                   "root",
-		Host:                   item.ClusterID,
-		Key:                    cfg.SSHKey,
-		Port:                   "22",
-		TargetOS:               core.TargetLinux,
-		ReadyCheck:             "command -v git >/dev/null && command -v rsync >/dev/null && command -v tar >/dev/null && command -v python3 >/dev/null",
-		NoControlMaster:        true,
-		DisableHostKeyChecking: true,
-		NetworkKind:            "public",
-		SSHConfigProxy:         true,
-		ProxyCommand:           proxyCommand(cfg, item.ClusterID),
+		User:            "root",
+		Host:            item.ClusterID,
+		Key:             cfg.SSHKey,
+		Port:            "22",
+		TargetOS:        core.TargetLinux,
+		ReadyCheck:      "command -v git >/dev/null && command -v rsync >/dev/null && command -v tar >/dev/null && command -v python3 >/dev/null",
+		NoControlMaster: true,
+		NetworkKind:     "public",
+		SSHConfigProxy:  true,
+		ProxyCommand:    proxyCommand(cfg, item.ClusterID),
 	}
 	if leaseID != "" {
+		if err := core.UseLeaseKnownHosts(&target, leaseID); err != nil {
+			return core.LeaseTarget{}, err
+		}
 		core.UseStoredTestboxKey(&target, leaseID)
 	}
 	server := b.server(item, cfg)
 	if claim, ok, _ := resolveNamespaceClaim(leaseID, cfg); ok {
 		mergeClaimLabels(&server, claim)
 	}
-	return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}
+	return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 }
 
 func (b *backend) prepareSSH(ctx context.Context, cfg core.Config, target *core.SSHTarget) error {

--- a/internal/providers/namespaceinstance/backend_test.go
+++ b/internal/providers/namespaceinstance/backend_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"io"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -49,6 +50,50 @@ func TestProviderContract(t *testing.T) {
 	if spec.Kind != core.ProviderKindSSHLease || spec.Coordinator != core.CoordinatorNever ||
 		!spec.Features.Has(core.FeatureSSH) || !spec.Features.Has(core.FeatureCrabboxSync) || !spec.Features.Has(core.FeatureCleanup) {
 		t.Fatalf("spec=%#v", spec)
+	}
+}
+
+func TestLeasePinsProxyHostKeyPerLease(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	const leaseID = "cbx_abcdef123456"
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	applyDefaults(&cfg)
+	lease, err := (&backend{}).lease(instance{ClusterID: "instance-id", Labels: map[string]string{"lease": leaseID}}, cfg, leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyPath, err := core.TestboxKeyPath(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantKnownHosts := filepath.Join(filepath.Dir(keyPath), "known_hosts")
+	if lease.SSH.DisableHostKeyChecking || lease.SSH.KnownHostsFile != wantKnownHosts {
+		t.Fatalf("namespace instance SSH target does not pin its lease host key: %#v", lease.SSH)
+	}
+	if !lease.SSH.SSHConfigProxy || lease.SSH.ProxyCommand == "" {
+		t.Fatalf("namespace instance SSH proxy routing was lost: %#v", lease.SSH)
+	}
+}
+
+func TestRebindResolvedLeaseTargetRebindsKnownHosts(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	const leaseID = "cbx_abcdef123456"
+	target := core.LeaseTarget{SSH: core.SSHTarget{KnownHostsFile: "alias/known_hosts"}}
+
+	if err := (&backend{}).RebindResolvedLeaseTarget(&target, leaseID); err != nil {
+		t.Fatal(err)
+	}
+	keyPath, err := core.TestboxKeyPath(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := filepath.Join(filepath.Dir(keyPath), "known_hosts"); target.SSH.KnownHostsFile != want {
+		t.Fatalf("KnownHostsFile=%q want %q", target.SSH.KnownHostsFile, want)
 	}
 }
 

--- a/internal/providers/phala/backend.go
+++ b/internal/providers/phala/backend.go
@@ -243,6 +243,9 @@ func instanceTypeForClass(class string) string {
 func (b *backend) Spec() core.ProviderSpec { return b.spec }
 
 func (b *backend) RebindResolvedLeaseTarget(target *core.LeaseTarget, leaseID string) error {
+	if err := core.UseLeaseKnownHosts(&target.SSH, leaseID); err != nil {
+		return err
+	}
 	core.UseStoredTestboxKey(&target.SSH, leaseID)
 	return nil
 }
@@ -324,7 +327,10 @@ func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.Le
 		recoveryLabels["recovery"] = recovery
 		recoveryLabels["state"] = "provisioning"
 		item := instance{ID: id, Name: phalaCVMName(leaseID), Labels: recoveryLabels}
-		lease := b.lease(item, cfg, leaseID)
+		lease, err := b.lease(item, cfg, leaseID)
+		if err != nil {
+			return err
+		}
 		if req.Repo.Root != "" {
 			return core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, lease.Server, lease.SSH, req.Repo.Root, cfg.IdleTimeout, req.Reclaim)
 		}
@@ -379,7 +385,10 @@ func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.Le
 	if slug != "" {
 		item.Labels["slug"] = slug
 	}
-	lease := b.lease(item, cfg, leaseID)
+	lease, err := b.lease(item, cfg, leaseID)
+	if err != nil {
+		return core.LeaseTarget{}, rollback(err)
+	}
 	if err := b.prepareSSH(ctx, cfg, &lease.SSH); err != nil {
 		return core.LeaseTarget{}, rollback(err)
 	}
@@ -433,7 +442,10 @@ func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.Le
 	if err != nil {
 		return core.LeaseTarget{}, err
 	}
-	lease := b.lease(item, cfg, leaseID)
+	lease, err := b.lease(item, cfg, leaseID)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
 	if req.ReleaseOnly || req.StatusOnly && !req.ReadyProbe {
 		return lease, nil
 	}
@@ -1044,28 +1056,30 @@ func (b *backend) resolve(ctx context.Context, identifier string, cfg core.Confi
 	return instance{}, "", core.Exit(4, "Phala CVM lease not found: %s", identifier)
 }
 
-func (b *backend) lease(item instance, cfg core.Config, leaseID string) core.LeaseTarget {
+func (b *backend) lease(item instance, cfg core.Config, leaseID string) (core.LeaseTarget, error) {
 	target := core.SSHTarget{
-		User:                   "root",
-		Host:                   item.cloudID(),
-		Key:                    cfg.SSHKey,
-		Port:                   "22",
-		TargetOS:               core.TargetLinux,
-		ReadyCheck:             "command -v rsync >/dev/null && command -v tar >/dev/null && command -v python3 >/dev/null",
-		NoControlMaster:        true,
-		DisableHostKeyChecking: true,
-		NetworkKind:            "public",
-		SSHConfigProxy:         true,
-		ProxyCommand:           proxyCommand(cfg, item.cloudID(), item.Labels["gateway_host"]),
+		User:            "root",
+		Host:            item.cloudID(),
+		Key:             cfg.SSHKey,
+		Port:            "22",
+		TargetOS:        core.TargetLinux,
+		ReadyCheck:      "command -v rsync >/dev/null && command -v tar >/dev/null && command -v python3 >/dev/null",
+		NoControlMaster: true,
+		NetworkKind:     "public",
+		SSHConfigProxy:  true,
+		ProxyCommand:    proxyCommand(cfg, item.cloudID(), item.Labels["gateway_host"]),
 	}
 	if leaseID != "" {
+		if err := core.UseLeaseKnownHosts(&target, leaseID); err != nil {
+			return core.LeaseTarget{}, err
+		}
 		core.UseStoredTestboxKey(&target, leaseID)
 	}
 	server := b.server(item, cfg)
 	if claim, ok, _ := resolvePhalaClaim(leaseID, cfg); ok {
 		mergeClaimLabels(&server, claim)
 	}
-	return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}
+	return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 }
 
 func (b *backend) prepareSSH(ctx context.Context, cfg core.Config, target *core.SSHTarget) error {

--- a/internal/providers/phala/backend.go
+++ b/internal/providers/phala/backend.go
@@ -442,6 +442,21 @@ func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.Le
 	if err != nil {
 		return core.LeaseTarget{}, err
 	}
+	// Older claims passed gateway_host through the provider-label sanitizer,
+	// which clipped long DNS names at its 63-byte label limit. Refresh those
+	// claims once so reconnects use the complete TLS SNI host. A failed refresh
+	// drops the suspect cache and leaves the proxy's live lookup fallback intact.
+	if !req.ReleaseOnly && cachedGatewayHostNeedsRefresh(item.Labels["gateway_host"]) {
+		delete(item.Labels, "gateway_host")
+		if gatewayHost, refreshErr := b.resolveGatewayHost(ctx, item.cloudID()); refreshErr != nil {
+			fmt.Fprintf(b.rt.Stderr, "warning: could not refresh phala gateway host for phala_cvm=%s: %v\n", item.cloudID(), refreshErr)
+		} else if gatewayHost != "" {
+			if item.Labels == nil {
+				item.Labels = map[string]string{}
+			}
+			item.Labels["gateway_host"] = gatewayHost
+		}
+	}
 	lease, err := b.lease(item, cfg, leaseID)
 	if err != nil {
 		return core.LeaseTarget{}, err
@@ -576,7 +591,13 @@ func (b *backend) Touch(ctx context.Context, req core.TouchRequest) (core.Server
 	cfg := b.configForRun()
 	now := b.now()
 	server := req.Lease.Server
+	gatewayHost := strings.TrimSpace(server.Labels["gateway_host"])
 	server.Labels = core.TouchDirectLeaseLabels(server.Labels, cfg, req.State, now)
+	// gateway_host is local connection metadata, not a provider label. Preserve
+	// its complete DNS value across the generic provider-label timestamp update.
+	if gatewayHost != "" {
+		server.Labels["gateway_host"] = gatewayHost
+	}
 	leaseID := strings.TrimSpace(req.Lease.LeaseID)
 	if leaseID != "" {
 		claim, ok, err := resolvePhalaClaim(leaseID, cfg)
@@ -1079,7 +1100,19 @@ func (b *backend) lease(item instance, cfg core.Config, leaseID string) (core.Le
 	if claim, ok, _ := resolvePhalaClaim(leaseID, cfg); ok {
 		mergeClaimLabels(&server, claim)
 	}
+	// A freshly resolved full gateway host must win over legacy claim labels,
+	// which may contain the old 63-byte-truncated value.
+	if gatewayHost := strings.TrimSpace(item.Labels["gateway_host"]); gatewayHost != "" {
+		server.Labels["gateway_host"] = gatewayHost
+	}
 	return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+}
+
+func cachedGatewayHostNeedsRefresh(host string) bool {
+	host = strings.TrimSpace(host)
+	// sanitizeProviderLabelValue caps values at exactly 63 bytes. Treat that
+	// boundary as suspect; refreshing a legitimately 63-byte hostname is safe.
+	return len(host) == 63
 }
 
 func (b *backend) prepareSSH(ctx context.Context, cfg core.Config, target *core.SSHTarget) error {

--- a/internal/providers/phala/backend_test.go
+++ b/internal/providers/phala/backend_test.go
@@ -1532,11 +1532,17 @@ func TestDefaultWorkRootIsWritableOnDevOsGuest(t *testing.T) {
 // SSH readiness probe must not block on git, which the dev-os guest cannot
 // provide.
 func TestPhalaLeaseReadyCheckDropsGit(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 	b := &backend{rt: core.Runtime{}}
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
 	applyDefaults(&cfg)
-	lease := b.lease(instance{ID: "appid123", Labels: map[string]string{"lease": "cbx_test"}}, cfg, "cbx_test")
+	lease, err := b.lease(instance{ID: "appid123", Labels: map[string]string{"lease": "cbx_test"}}, cfg, "cbx_test")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if strings.Contains(lease.SSH.ReadyCheck, "git") {
 		t.Fatalf("lease ReadyCheck must not require git:\n%s", lease.SSH.ReadyCheck)
 	}
@@ -1544,6 +1550,50 @@ func TestPhalaLeaseReadyCheckDropsGit(t *testing.T) {
 		if !strings.Contains(lease.SSH.ReadyCheck, "command -v "+tool) {
 			t.Fatalf("lease ReadyCheck missing %s:\n%s", tool, lease.SSH.ReadyCheck)
 		}
+	}
+}
+
+func TestPhalaLeasePinsProxyHostKeyPerLease(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	const leaseID = "cbx_abcdef123456"
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	applyDefaults(&cfg)
+	lease, err := (&backend{}).lease(instance{ID: "cvm-id", Labels: map[string]string{"lease": leaseID}}, cfg, leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyPath, err := core.TestboxKeyPath(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantKnownHosts := filepath.Join(filepath.Dir(keyPath), "known_hosts")
+	if lease.SSH.DisableHostKeyChecking || lease.SSH.KnownHostsFile != wantKnownHosts {
+		t.Fatalf("phala SSH target does not pin its lease host key: %#v", lease.SSH)
+	}
+	if !lease.SSH.SSHConfigProxy || lease.SSH.ProxyCommand == "" {
+		t.Fatalf("phala SSH proxy routing was lost: %#v", lease.SSH)
+	}
+}
+
+func TestRebindResolvedLeaseTargetRebindsKnownHosts(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	const leaseID = "cbx_abcdef123456"
+	target := core.LeaseTarget{SSH: core.SSHTarget{KnownHostsFile: "alias/known_hosts"}}
+
+	if err := (&backend{}).RebindResolvedLeaseTarget(&target, leaseID); err != nil {
+		t.Fatal(err)
+	}
+	keyPath, err := core.TestboxKeyPath(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := filepath.Join(filepath.Dir(keyPath), "known_hosts"); target.SSH.KnownHostsFile != want {
+		t.Fatalf("KnownHostsFile=%q want %q", target.SSH.KnownHostsFile, want)
 	}
 }
 
@@ -1962,6 +2012,9 @@ func TestResolveGatewayHostToleratesMissingAndIncomplete(t *testing.T) {
 // connection skips the per-connection cvms-get call.
 func TestGatewayHostRoundTripsThroughClaimToProxyCommand(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
 	cfg.IdleTimeout = 5 * time.Minute
@@ -1983,7 +2036,10 @@ func TestGatewayHostRoundTripsThroughClaimToProxyCommand(t *testing.T) {
 		t.Fatalf("gateway_host not surfaced from claim: labels=%v", item.Labels)
 	}
 	b := &backend{cfg: cfg, rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard}}
-	lease := b.lease(item, cfg, leaseID)
+	lease, err := b.lease(item, cfg, leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !strings.Contains(lease.SSH.ProxyCommand, "--gateway-host "+host) {
 		t.Fatalf("ProxyCommand=%q missing cached --gateway-host %q", lease.SSH.ProxyCommand, host)
 	}

--- a/internal/providers/phala/backend_test.go
+++ b/internal/providers/phala/backend_test.go
@@ -635,6 +635,8 @@ func TestTouchPersistsUpdatedLabelsToClaim(t *testing.T) {
 			time.Now().Add(-time.Minute),
 		),
 	}
+	const gatewayHost = "cvm-1-22.dstack-pha-production.phala.network"
+	server.Labels["gateway_host"] = gatewayHost
 	target := core.SSHTarget{Host: "cvm-1", User: "root", Port: "22"}
 	if err := core.ClaimLeaseTargetForConfig(leaseID, "blue-box", cfg, server, target, cfg.IdleTimeout); err != nil {
 		t.Fatal(err)
@@ -655,8 +657,57 @@ func TestTouchPersistsUpdatedLabelsToClaim(t *testing.T) {
 	}
 	if len(claims) != 1 ||
 		claims[0].Labels["last_touched_at"] != touched.Labels["last_touched_at"] ||
-		claims[0].Labels["expires_at"] != touched.Labels["expires_at"] {
+		claims[0].Labels["expires_at"] != touched.Labels["expires_at"] ||
+		claims[0].Labels["gateway_host"] != gatewayHost {
 		t.Fatalf("claims=%#v touched=%#v", claims, touched.Labels)
+	}
+}
+
+func TestResolveRepairsTruncatedGatewayHostClaim(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	applyDefaults(&cfg)
+	const (
+		leaseID  = "cbx_abcdef123456"
+		cloudID  = "0123456789abcdef0123456789abcdef01234567"
+		fullHost = cloudID + "-22.dstack-pha-prod5.phala.network"
+	)
+	truncatedHost := fullHost[:63]
+	labels := core.DirectLeaseLabels(cfg, leaseID, "blue-box", providerName, "", false, time.Now())
+	labels["phala_cvm"] = cloudID
+	labels["gateway_host"] = truncatedHost
+	server := core.Server{CloudID: cloudID, Provider: providerName, Name: "blue-box", Labels: labels}
+	if err := core.ClaimLeaseTargetForConfig(leaseID, "blue-box", cfg, server, core.SSHTarget{Host: cloudID, Port: "22"}, cfg.IdleTimeout); err != nil {
+		t.Fatal(err)
+	}
+	runner := &fakeRunner{results: []core.LocalCommandResult{
+		{Stdout: `{"success":true,"total":1,"items":[{"appId":"` + cloudID + `","cvmName":"crabbox-cbx-abcdef123456","status":"running"}]}`},
+		{Stdout: `{"success":true,"app_id":"` + cloudID + `","gateway":{"base_domain":"dstack-pha-prod5.phala.network"}}`},
+	}}
+	b := &backend{cfg: cfg, rt: core.Runtime{Exec: runner, Stdout: io.Discard, Stderr: io.Discard}}
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: leaseID, StatusOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := lease.Server.Labels["gateway_host"]; got != fullHost {
+		t.Fatalf("gateway_host=%q want %q", got, fullHost)
+	}
+	if !strings.Contains(lease.SSH.ProxyCommand, "--gateway-host "+fullHost) {
+		t.Fatalf("ProxyCommand=%q missing repaired gateway host", lease.SSH.ProxyCommand)
+	}
+	if _, err := b.Touch(context.Background(), core.TouchRequest{Lease: lease, State: "ready", IdleTimeout: cfg.IdleTimeout}); err != nil {
+		t.Fatal(err)
+	}
+	claims, err := core.ListLeaseClaims()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(claims) != 1 || claims[0].Labels["gateway_host"] != fullHost {
+		t.Fatalf("repaired gateway host not persisted: %#v", claims)
 	}
 }
 


### PR DESCRIPTION
## Summary

- restore first-contact SSH host-key pinning for Namespace Instance, Phala, and Islo instead of disabling server authentication
- scope each provider's `known_hosts` file to the canonical lease, preserve proxy routing, and fail closed when the lease SSH-state directory cannot be prepared
- rebind host-key state when aliases resolve to canonical leases and remove Islo's SSH state during lifecycle cleanup
- keep manifest sync portable to BusyBox guests and preserve complete Phala TLS gateway hostnames across claim updates, repairing legacy 63-byte-truncated claims before reconnect

Fixes https://github.com/openclaw/crabbox/issues/961

## Maintainer decision

Use verified host identity by default. These provider proxy paths now use Crabbox's existing `StrictHostKeyChecking=accept-new` trust-on-first-use model; there is no insecure compatibility flag.

## Verification

- `go test -race ./internal/cli ./internal/providers/namespaceinstance ./internal/providers/phala ./internal/providers/islo`
- `go test -race ./...`
- `go vet ./...`
- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- Worker format, lint, typecheck, 897 tests, and Wrangler dry-run build
- docs command/provider/link/site build checks
- disposable real `sshd` through `ProxyCommand`: first contact pinned, reconnect accepted, rotated host key rejected, zero residue
- authenticated Islo create/pause/resume/use/destroy lifecycle; zero matching residue
- authenticated Phala `tdx.small` create, TDX attestation, BusyBox sync, remote command, status, pinned reconnect, and destroy lifecycle on lease `cbx_4fbc81bf6463`; provider inventory and local claim/key/known-host state all reached zero residue
- authenticated Namespace Instance `4x8` create, status, inspect, pinned reconnect, cache discovery, sync, remote command, and destroy lifecycle on lease `cbx_7980ca1142c9`; Namespace inventory and local claim/key/known-host state all reached zero residue
- AutoReview cycle 1: three accepted findings fixed (fail-closed storage, canonical rebind, isolated test homes)
- AutoReview cycle 2: clean, no accepted/actionable findings (0.93)
- AutoReview after live-found Phala repairs: clean, no accepted/actionable findings (0.95)

## Live merge gate

All authenticated live gates are complete. Merge remains gated only on exact-head hosted checks.

## Secrets and config

No new secret, credential, or configuration surface. Provider credentials remain in their existing CLI/keychain or environment paths.
