### PR TITLE
fix: require owned Azure orphan deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Routed Azure orphan-sweep deletion through the exact lease-, provider-scope-, resource-, companion-, and immutable-disk-bound owned-delete path instead of deleting by retained VM name alone.
 - Kept sync manifest writes compatible with minimal BusyBox guests instead of requiring a GNU-only `dd` option, and preserved complete Phala gateway hostnames so later status and SSH reconnects keep working.
 - Restored lease-scoped SSH host-key pinning for Namespace Instance, Phala, and Islo proxy connections instead of accepting unverified server identities. Thanks @coygeek.
 - Corrected the CLI command map, coordinator API methods, and provider architecture reference to match the implemented commands, routes, and backend capabilities. Thanks @zozo123.

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -11398,8 +11398,14 @@ export class FleetCoordinator {
       recordCloudOrphanSweepOwnership(candidate, ownershipLease);
       if (config.deleteEnabled && ownershipLease) {
         try {
+          const provider = this.provider("azure", region);
+          if (!provider.deleteOwnedServer) {
+            throw new ProviderCleanupManualResolutionError(
+              `refusing to delete Azure lease ${ownershipLease.id}: exact owned-delete support is unavailable`,
+            );
+          }
           // oxlint-disable-next-line eslint/no-await-in-loop -- delete failures must stay attached to the candidate.
-          await this.provider("azure", region).deleteServer(machine.cloudID || machine.name);
+          await provider.deleteOwnedServer(ownershipLease);
           candidate.action = "terminated";
         } catch (error) {
           candidate.action = "terminate_failed";
@@ -16798,6 +16804,7 @@ interface CloudProvider {
   ): Promise<ProviderLeaseCreateFinalization>;
   releaseLease(lease: LeaseRecord): Promise<void>;
   deleteServer(id: string): Promise<void>;
+  deleteOwnedServer?(lease: LeaseRecord): Promise<void>;
   supportsNativeImages(): boolean;
   nativeImagesUnsupportedMessage(): string;
   defaultImageStrategy(lease: LeaseRecord): "image" | "disk-snapshot";

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -9832,7 +9832,8 @@ describe("fleet lease identity and idle", () => {
   it("deletes only coordinator-owned Azure orphan sweep candidates", async () => {
     const storage = new MemoryStorage();
     const list = vi.spyOn(storage, "list");
-    const deleted: string[] = [];
+    const rawDeleted: string[] = [];
+    const ownedDeleted: LeaseRecord[] = [];
     const oldSeconds = String(Math.trunc((Date.now() - 60 * 60 * 1000) / 1000));
     storage.seed(
       "lease:cbx_000000000776",
@@ -9841,6 +9842,7 @@ describe("fleet lease identity and idle", () => {
         provider: "azure",
         cloudID: "vm-orphan",
         region: "westus2",
+        providerScope: "/subscriptions/subscription/resourceGroups/crabbox-leases",
         state: "expired",
         keep: false,
       }),
@@ -9917,7 +9919,11 @@ describe("fleet lease identity and idle", () => {
                 name: "vm-orphan",
                 labels: {
                   crabbox: "true",
-                  lease: "cbx_missing",
+                  created_by: "crabbox",
+                  provider: "azure",
+                  lease: "cbx_000000000776",
+                  slug: "blue-lobster",
+                  owner: "peter@example.com",
                   created_at: oldSeconds,
                   expires_at: oldSeconds,
                 },
@@ -9991,9 +9997,12 @@ describe("fleet lease identity and idle", () => {
                 },
               }),
             ],
+            onDeleteOwnedServer(lease) {
+              ownedDeleted.push(structuredClone(lease));
+            },
           },
           async (id) => {
-            deleted.push(id);
+            rawDeleted.push(id);
           },
         ),
       },
@@ -10015,7 +10024,16 @@ describe("fleet lease identity and idle", () => {
       terminated: number;
       candidates: Array<Record<string, unknown>>;
     }>("azure-orphan-sweep:last");
-    expect(deleted).toEqual(["vm-orphan"]);
+    expect(rawDeleted).toEqual([]);
+    expect(ownedDeleted).toEqual([
+      expect.objectContaining({
+        id: "cbx_000000000776",
+        provider: "azure",
+        cloudID: "vm-orphan",
+        region: "westus2",
+        providerScope: "/subscriptions/subscription/resourceGroups/crabbox-leases",
+      }),
+    ]);
     expect(
       list.mock.calls.filter(([options]) => options?.prefix === "lease:" && options.limit === 128),
     ).toHaveLength(2);
@@ -10024,7 +10042,7 @@ describe("fleet lease identity and idle", () => {
       expect.objectContaining({
         cloudID: "vm-orphan",
         region: "westus2",
-        leaseID: "cbx_missing",
+        leaseID: "cbx_000000000776",
         reason: "expired-provider-tag",
         ownership: "coordinator-lease",
         ownershipLeaseID: "cbx_000000000776",
@@ -10037,6 +10055,93 @@ describe("fleet lease identity and idle", () => {
         action: "reported",
       }),
     ]);
+  });
+
+  it("keeps Azure orphan sweep candidates when exact owned deletion rejects them", async () => {
+    const storage = new MemoryStorage();
+    const rawDeleted: string[] = [];
+    const ownedDeleted: LeaseRecord[] = [];
+    const oldSeconds = String(Math.trunc((Date.now() - 60 * 60 * 1000) / 1000));
+    storage.seed(
+      "lease:cbx_000000000776",
+      testLease({
+        id: "cbx_000000000776",
+        provider: "azure",
+        cloudID: "vm-replaced",
+        region: "westus2",
+        providerScope: "/subscriptions/subscription/resourceGroups/crabbox-leases",
+        state: "expired",
+        keep: false,
+      }),
+    );
+    const fleet = testFleet(
+      storage,
+      {
+        azure: fakeProvider(
+          undefined,
+          {
+            provider: "azure",
+            servers: [
+              testMachine({
+                provider: "azure",
+                cloudID: "vm-replaced",
+                region: "westus2",
+                name: "vm-replaced",
+                labels: {
+                  crabbox: "true",
+                  created_by: "crabbox",
+                  provider: "azure",
+                  lease: "cbx_replacement",
+                  slug: "replacement",
+                  owner: "other@example.com",
+                  created_at: oldSeconds,
+                  expires_at: oldSeconds,
+                },
+              }),
+            ],
+            onDeleteOwnedServer(lease) {
+              ownedDeleted.push(structuredClone(lease));
+              throw new Error(
+                `refusing to delete Azure VM vm-replaced: ownership does not match lease ${lease.id}`,
+              );
+            },
+          },
+          async (id) => {
+            rawDeleted.push(id);
+          },
+        ),
+      },
+      {
+        AZURE_TENANT_ID: "tenant",
+        AZURE_CLIENT_ID: "client",
+        AZURE_CLIENT_SECRET: "secret",
+        AZURE_SUBSCRIPTION_ID: "subscription",
+        CRABBOX_AZURE_LOCATION: "westus2",
+        CRABBOX_AZURE_ORPHAN_SWEEP_DELETE: "1",
+        CRABBOX_AZURE_ORPHAN_SWEEP_GRACE_SECONDS: "1",
+      },
+    );
+
+    await fleet.alarm();
+
+    expect(rawDeleted).toEqual([]);
+    expect(ownedDeleted).toEqual([
+      expect.objectContaining({ id: "cbx_000000000776", cloudID: "vm-replaced" }),
+    ]);
+    expect(storage.value("azure-orphan-sweep:last")).toMatchObject({
+      mode: "delete",
+      terminated: 0,
+      candidates: [
+        expect.objectContaining({
+          cloudID: "vm-replaced",
+          leaseID: "cbx_replacement",
+          ownership: "coordinator-lease",
+          ownershipLeaseID: "cbx_000000000776",
+          action: "terminate_failed",
+          error: expect.stringContaining("ownership does not match lease cbx_000000000776"),
+        }),
+      ],
+    });
   });
 
   it("releases stale pending EC2 Mac hosts during the AWS orphan sweep", async () => {
@@ -23433,6 +23538,7 @@ function fakeProvider(
         }
       | undefined;
     onReleaseLease?: (lease: LeaseRecord) => Promise<void> | void;
+    onDeleteOwnedServer?: (lease: LeaseRecord) => Promise<void> | void;
     onRecoverServer?: (
       lease: LeaseRecord,
     ) => Promise<ProviderMachine | undefined> | ProviderMachine | undefined;
@@ -23599,6 +23705,13 @@ function fakeProvider(
     async deleteServer(id: string) {
       await onDelete?.(id);
     },
+    ...(result.onDeleteOwnedServer
+      ? {
+          async deleteOwnedServer(lease: LeaseRecord) {
+            await result.onDeleteOwnedServer?.(lease);
+          },
+        }
+      : {}),
     async releaseLease(lease: LeaseRecord) {
       await result.onReleaseLease?.(lease);
       await onDelete?.(


### PR DESCRIPTION
## Summary

- route Azure orphan-sweep deletion through the existing exact owned-delete lifecycle
- fail closed when the provider does not expose exact owned deletion or current resource ownership does not match the retained lease
- preserve report/diagnostic state without falling back to raw VM-name deletion
- cover exact routing, same-name replacement refusal, paged retained-lease scans, and raw-delete non-use

Fixes https://github.com/openclaw/crabbox/issues/998

## Verification

- `npm test --prefix worker -- --run test/fleet.test.ts` (414 passed)
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker` (898 passed, 3 skipped)
- `npm run build --prefix worker`
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` (clean, 0.96)

## Live proof

- Exact candidate: `c030f223b06d4d938e95242c0cf32bff51745a4a`.
- Authenticated disposable Azure proof used a resource-group-scoped ephemeral service principal and real `Standard_D2s_v7` VM.
- Provisioned the VM through `AzureClient.createServerWithFallback`, then executed `AZURE_ORPHAN_LIVE_OK` over real SSH before triggering `FleetDurableObject.alarm()`.
- The repaired orphan sweep reported one exact retained-lease termination; VM, NIC, public IP, managed disk, and owned-delete claim were all absent afterward (`vitest`: 1 passed, 169.60s).
- A preceding `Standard_D2s_v5` capacity refusal also exercised rollback; its partial resources were removed before the successful retry.
- Zero residue: the disposable Azure resource group, ephemeral service principal, and application were deleted; the temporary 1Password item was archived.
- Hosted exact-head proof: all 15 CI, CodeQL, Socket, lifecycle, docs, Apple VM, Worker, Scripts, and release checks passed.
