### PR TITLE
fix: stabilize delegated sync and macOS listener checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- Started delegated-provider sync timeouts at archive creation, matching SSH sync semantics and avoiding pre-transfer expiry during local Git manifest planning.
+- Kept macOS listener ownership checks responsive when mounted filesystems make full `lsof` metadata scans slow.
 - Routed Azure orphan-sweep deletion through the exact lease-, provider-scope-, resource-, companion-, and immutable-disk-bound owned-delete path instead of deleting by retained VM name alone.
 - Kept sync manifest writes compatible with minimal BusyBox guests instead of requiring a GNU-only `dd` option, and preserved complete Phala gateway hostnames so later status and SSH reconnects keep working.
 - Restored lease-scoped SSH host-key pinning for Namespace Instance, Phala, and Islo proxy connections instead of accepting unverified server identities. Thanks @coygeek.

--- a/internal/cli/controller_listener_darwin.go
+++ b/internal/cli/controller_listener_darwin.go
@@ -64,7 +64,7 @@ func controllerDarwinLoopbackListenerOwnerPIDs(port string) ([]int, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 	path := "/usr/sbin/lsof"
-	output, err := exec.CommandContext(ctx, path, "-nP", "-a", "-iTCP:"+port, "-sTCP:LISTEN", "-Fpn").Output()
+	output, err := exec.CommandContext(ctx, path, controllerDarwinListenerLsofArgs(port)...).Output()
 	if err != nil {
 		return nil, fmt.Errorf("inspect macOS listener ownership: %w", err)
 	}
@@ -73,6 +73,13 @@ func controllerDarwinLoopbackListenerOwnerPIDs(port string) ([]int, error) {
 		return nil, fmt.Errorf("no process owns the IPv4 loopback listener")
 	}
 	return owners, nil
+}
+
+func controllerDarwinListenerLsofArgs(port string) []string {
+	// We only consume socket fields. Avoid filesystem metadata calls and lsof's
+	// helper-process overhead, which can exceed the fail-closed timeout when
+	// macOS has slow or unavailable simulator volumes mounted.
+	return []string{"-O", "-b", "-w", "-nP", "-a", "-iTCP:" + port, "-sTCP:LISTEN", "-Fpn"}
 }
 
 func controllerDarwinLoopbackListenerOwners(output, port string) []int {

--- a/internal/cli/controller_listener_darwin_test.go
+++ b/internal/cli/controller_listener_darwin_test.go
@@ -1,0 +1,18 @@
+//go:build darwin
+
+package cli
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestControllerDarwinListenerLsofAvoidsFilesystemMetadata(t *testing.T) {
+	want := []string{
+		"-O", "-b", "-w", "-nP", "-a",
+		"-iTCP:5901", "-sTCP:LISTEN", "-Fpn",
+	}
+	if got := controllerDarwinListenerLsofArgs("5901"); !reflect.DeepEqual(got, want) {
+		t.Fatalf("lsof args=%q want=%q", got, want)
+	}
+}

--- a/internal/cli/delegated_archive_sync.go
+++ b/internal/cli/delegated_archive_sync.go
@@ -63,13 +63,6 @@ func RunDelegatedArchiveSync(ctx context.Context, req DelegatedArchiveSyncReques
 	}
 
 	start := now()
-	syncCtx := ctx
-	cancel := func() {}
-	if req.Config.Sync.Timeout > 0 {
-		syncCtx, cancel = context.WithTimeout(ctx, req.Config.Sync.Timeout)
-	}
-	defer cancel()
-
 	excludes, err := syncExcludes(req.Repo.Root, req.Config)
 	if err != nil {
 		return nil, 0, err
@@ -89,6 +82,15 @@ func RunDelegatedArchiveSync(ctx context.Context, req DelegatedArchiveSyncReques
 		return nil, 0, err
 	}
 	preflightDuration := now().Sub(preflightStart)
+
+	// Match SSH sync semantics: local manifest planning is outside the transfer
+	// timeout. The timeout bounds archive creation and remote synchronization.
+	syncCtx := ctx
+	cancel := func() {}
+	if req.Config.Sync.Timeout > 0 {
+		syncCtx, cancel = context.WithTimeout(ctx, req.Config.Sync.Timeout)
+	}
+	defer cancel()
 
 	archiveStart := now()
 	archive, err := CreateSyncArchive(syncCtx, req.Repo, manifest, tempPattern)

--- a/internal/cli/webvnc_port_reservation_unix_test.go
+++ b/internal/cli/webvnc_port_reservation_unix_test.go
@@ -335,7 +335,9 @@ func TestDialVNCForegroundTunnelRequiresTrackedOwner(t *testing.T) {
 		done:   make(chan struct{}),
 		output: &strings.Builder{},
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	// macOS verifies ownership with lsof before and after dialing. Leave enough
+	// budget for both fail-closed probes under race-detector load.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	conn, err := dialVNCForegroundTunnel(ctx, tunnel, port)
 	if err != nil {

--- a/internal/providers/applevm/provider_test.go
+++ b/internal/providers/applevm/provider_test.go
@@ -428,7 +428,7 @@ func TestDoctorPassesSignedImageViaStdinAndRedactsDisplay(t *testing.T) {
 		if req.Name != "helper" || len(req.Args) == 0 || req.Args[0] != "doctor" {
 			return core.LocalCommandResult{}, nil, false
 		}
-		if args := strings.Join(req.Args, " "); strings.Contains(args, "secret") || strings.Contains(args, "private") {
+		if args := strings.Join(req.Args, " "); strings.Contains(args, signedImage) || strings.Contains(args, "bearer-secret") {
 			t.Fatalf("helper argv exposes signed image: %s", args)
 		}
 		for _, entry := range req.Env {
@@ -512,7 +512,7 @@ func TestAcquireRedactsSignedImageFromLogsAndLeaseMetadata(t *testing.T) {
 			if !ok || claim.ProviderScope != name {
 				t.Fatalf("claim before helper start: ok=%v claim=%+v", ok, claim)
 			}
-			if args := strings.Join(req.Args, " "); strings.Contains(args, "secret") || strings.Contains(args, "private") {
+			if args := strings.Join(req.Args, " "); strings.Contains(args, signedImage) || strings.Contains(args, "bearer-secret") {
 				t.Fatalf("helper argv exposes signed image: %s", args)
 			}
 			data, err := io.ReadAll(req.Stdin)


### PR DESCRIPTION
## Summary

- keep macOS listener ownership checks responsive on systems with slow mounted filesystems
- start delegated-provider sync timeouts after local Git manifest planning
- remove load-sensitive test assumptions around listener probes and private path names

## Root cause

macOS `lsof` was performing unnecessary filesystem metadata work and could exceed the fail-closed listener timeout. Delegated archive sync also started its configured timeout before six local Git manifest subprocesses, allowing the deadline to expire before upload began under load.

## Validation

- targeted macOS listener and delegated archive tests under the race detector
- OpenComputer timeout regression 20 consecutive runs under the race detector
- Apple VM redaction regressions under the race detector
- full local and disposable OpenAI devbox race suites during development
