### PR TITLE
fix(worker): revoke rotated shared-token bridges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Bound non-admin shared-token WebVNC, Code, and egress bridges to the credential active at ticket creation, closing active and restored sessions after token rotation or removal. Thanks @coygeek.
 - Started delegated-provider sync timeouts at archive creation, matching SSH sync semantics and avoiding pre-transfer expiry during local Git manifest planning.
 - Kept macOS listener ownership checks responsive when mounted filesystems make full `lsof` metadata scans slow.
 - Routed Azure orphan-sweep deletion through the exact lease-, provider-scope-, resource-, companion-, and immutable-disk-bound owned-delete path instead of deleting by retained VM name alone.

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -298,6 +298,7 @@ interface CachedAdminGrant {
 interface CachedBridgeGrant extends CachedAdminGrant {
   auth?: AuthContext["auth"];
   login?: string;
+  sharedTokenHash?: string;
   portalSessionHash?: string;
   githubGrant?: GitHubUserGrant;
 }
@@ -1226,6 +1227,13 @@ export class FleetCoordinator {
         { kind: "webvnc-viewer" | "code-viewer" | "egress-host" | "egress-client" }
       >;
     }> = [];
+    const sharedBridgesToCheck: Array<{
+      socket: WebSocket;
+      attachment: Extract<
+        BridgeAttachment,
+        { kind: "webvnc-viewer" | "code-viewer" | "egress-host" | "egress-client" }
+      >;
+    }> = [];
     for (const socket of this.restoredBridgeSockets) {
       const attachment = this.bridgeAttachment(socket);
       if (!attachment) {
@@ -1285,17 +1293,33 @@ export class FleetCoordinator {
         }
         if (attachment.auth === "github" && attachment.admin !== true) {
           githubBridgesToCheck.push({ socket, attachment });
+        } else if (attachment.auth === "bearer" && attachment.admin !== true) {
+          sharedBridgesToCheck.push({ socket, attachment });
         }
       }
     }
-    const githubBridgeRevocations = await Promise.all(
-      githubBridgesToCheck.map(async ({ socket, attachment }) => ({
-        socket,
-        attachment,
-        reason: await this.githubBridgeGrantFailureReason(attachment),
-      })),
-    );
-    for (const { socket, attachment, reason } of githubBridgeRevocations) {
+    const [githubBridgeRevocations, sharedBridgeRevocations] = await Promise.all([
+      Promise.all(
+        githubBridgesToCheck.map(async ({ socket, attachment }) => ({
+          socket,
+          attachment,
+          reason: await this.githubBridgeGrantFailureReason(attachment),
+        })),
+      ),
+      Promise.all(
+        sharedBridgesToCheck.map(async ({ socket, attachment }) => ({
+          socket,
+          attachment,
+          reason: (await this.sharedBridgeGrantIsCurrent(attachment))
+            ? undefined
+            : "shared access revoked",
+        })),
+      ),
+    ]);
+    for (const { socket, attachment, reason } of [
+      ...githubBridgeRevocations,
+      ...sharedBridgeRevocations,
+    ]) {
       if (!reason) continue;
       if (attachment.kind === "egress-host" || attachment.kind === "egress-client") {
         revokedEgressSessions.set(egressSocketKey(attachment.leaseID, attachment.sessionID), {
@@ -1497,6 +1521,7 @@ export class FleetCoordinator {
           ...(attachment.admin !== undefined ? { admin: attachment.admin } : {}),
           ...(attachment.auth ? { auth: attachment.auth } : {}),
           ...(attachment.login ? { login: attachment.login } : {}),
+          ...(attachment.sharedTokenHash ? { sharedTokenHash: attachment.sharedTokenHash } : {}),
           ...(attachment.adminTokenHash ? { adminTokenHash: attachment.adminTokenHash } : {}),
           ...(attachment.adminGrantVersion
             ? { adminGrantVersion: attachment.adminGrantVersion }
@@ -1862,6 +1887,22 @@ export class FleetCoordinator {
   ): Promise<boolean> {
     if (
       revocableUserBridge(attachment) &&
+      attachment.auth === "bearer" &&
+      attachment.admin !== true
+    ) {
+      const now = Date.now();
+      const lastValidatedAt = this.userGrantValidationTimes.get(socket) ?? 0;
+      if (now - lastValidatedAt >= userGrantRevalidationIntervalMs) {
+        if (!(await this.sharedBridgeGrantIsCurrent(attachment))) {
+          this.userGrantValidationTimes.delete(socket);
+          this.closeRevokedUserBridge(socket, attachment, "shared access revoked");
+          return false;
+        }
+        this.userGrantValidationTimes.set(socket, now);
+      }
+    }
+    if (
+      revocableUserBridge(attachment) &&
       attachment.auth === "github" &&
       attachment.admin !== true
     ) {
@@ -1902,6 +1943,16 @@ export class FleetCoordinator {
     this.handleBridgeClose(socket, 1008, "admin access revoked");
     closeSocket(socket, 1008, "admin access revoked");
     return false;
+  }
+
+  private async sharedBridgeGrantIsCurrent(attachment: CachedBridgeGrant): Promise<boolean> {
+    const sharedToken = this.env.CRABBOX_SHARED_TOKEN;
+    return (
+      typeof sharedToken === "string" &&
+      sharedToken.length > 0 &&
+      /^[a-f0-9]{64}$/.test(attachment.sharedTokenHash ?? "") &&
+      attachment.sharedTokenHash === (await sha256Hex(sharedToken))
+    );
   }
 
   private async githubBridgeGrantFailureReason(
@@ -6721,7 +6772,7 @@ export class FleetCoordinator {
         { status: 400 },
       );
     }
-    const bridgeGrant = await bridgeGrantForRequest(request, admin);
+    const bridgeGrant = await bridgeGrantForRequest(request, admin, this.env.CRABBOX_SHARED_TOKEN);
     if (!bridgeGrant) {
       return json(
         { error: "user_session_invalid", message: "GitHub user session cannot be revalidated" },
@@ -7555,7 +7606,7 @@ export class FleetCoordinator {
     if (error) {
       return json({ error: "webvnc_unavailable", message: error }, { status: 409 });
     }
-    const bridgeGrant = await bridgeGrantForRequest(request, admin);
+    const bridgeGrant = await bridgeGrantForRequest(request, admin, this.env.CRABBOX_SHARED_TOKEN);
     if (!bridgeGrant) {
       return json(
         { error: "user_session_invalid", message: "GitHub user session cannot be revalidated" },
@@ -7850,7 +7901,7 @@ export class FleetCoordinator {
     if (error) {
       return json({ error: "code_unavailable", message: error }, { status: 409 });
     }
-    const bridgeGrant = await bridgeGrantForRequest(request, admin);
+    const bridgeGrant = await bridgeGrantForRequest(request, admin, this.env.CRABBOX_SHARED_TOKEN);
     if (!bridgeGrant) {
       return json(
         { error: "user_session_invalid", message: "GitHub user session cannot be revalidated" },
@@ -7982,7 +8033,11 @@ export class FleetCoordinator {
     if (request.headers.get("upgrade")?.toLowerCase() === "websocket") {
       const bridgeGrant = viewerSession
         ? copyBridgeGrant(viewerSession)
-        : await bridgeGrantForRequest(authorizedRequest, isAdminRequest(authorizedRequest));
+        : await bridgeGrantForRequest(
+            authorizedRequest,
+            isAdminRequest(authorizedRequest),
+            this.env.CRABBOX_SHARED_TOKEN,
+          );
       if (!bridgeGrant) {
         return json(
           { error: "code_viewer_session_revoked", message: "Code viewer session has ended" },
@@ -8003,7 +8058,7 @@ export class FleetCoordinator {
     const now = new Date();
     const auth = requestAuthType(request);
     const admin = isAdminRequest(request);
-    const bridgeGrant = await bridgeGrantForRequest(request, admin);
+    const bridgeGrant = await bridgeGrantForRequest(request, admin, this.env.CRABBOX_SHARED_TOKEN);
     if (!bridgeGrant) {
       return portalError("Code session ended", "Log in again to open Code.", 401);
     }
@@ -8121,7 +8176,10 @@ export class FleetCoordinator {
       (session.auth === "github" && !validPortalSessionHash(session.portalSessionHash)) ||
       (session.portalSessionHash &&
         (await this.portalSessionIsRevoked(session.portalSessionHash))) ||
-      (session.auth === "github" && (await this.githubBridgeGrantFailureReason(session)))
+      (session.auth === "github" && (await this.githubBridgeGrantFailureReason(session))) ||
+      (session.auth === "bearer" &&
+        session.admin !== true &&
+        !(await this.sharedBridgeGrantIsCurrent(session)))
     ) {
       if (session) {
         await this.state.storage.delete(codeViewerSessionKey(value));
@@ -8679,7 +8737,11 @@ export class FleetCoordinator {
         return json({ error: "webvnc_unavailable", message: error }, { status: 409 });
       }
       const admin = isAdminRequest(request);
-      const bridgeGrant = await bridgeGrantForRequest(request, admin);
+      const bridgeGrant = await bridgeGrantForRequest(
+        request,
+        admin,
+        this.env.CRABBOX_SHARED_TOKEN,
+      );
       if (!bridgeGrant) {
         return json(
           { error: "user_session_invalid", message: "GitHub user session cannot be revalidated" },
@@ -8996,6 +9058,13 @@ export class FleetCoordinator {
     if (
       currentTicket.auth === "github" &&
       (await this.githubBridgeGrantFailureReason(currentTicket))
+    ) {
+      return undefined;
+    }
+    if (
+      currentTicket.auth === "bearer" &&
+      currentTicket.admin !== true &&
+      !(await this.sharedBridgeGrantIsCurrent(currentTicket))
     ) {
       return undefined;
     }
@@ -14207,6 +14276,7 @@ async function adminGrantForRequest(request: Request, admin: boolean): Promise<C
 async function bridgeGrantForRequest(
   request: Request,
   admin: boolean,
+  sharedToken?: string,
 ): Promise<CachedBridgeGrant | undefined> {
   const auth = requestAuthType(request);
   const adminGrant = await adminGrantForRequest(request, admin);
@@ -14214,6 +14284,13 @@ async function bridgeGrantForRequest(
     return adminGrant;
   }
   if (auth !== "github") {
+    if (auth === "bearer" && !admin && sharedToken) {
+      const token = bearerToken(request);
+      if (!token) {
+        return undefined;
+      }
+      return { auth, sharedTokenHash: await sha256Hex(token), ...adminGrant };
+    }
     return { auth, ...adminGrant };
   }
   const token = bearerToken(request);
@@ -14248,6 +14325,7 @@ function copyBridgeGrant(principal: CachedBridgeGrant): CachedBridgeGrant {
   return {
     ...(principal.auth ? { auth: principal.auth } : {}),
     ...(principal.login ? { login: principal.login } : {}),
+    ...(principal.sharedTokenHash ? { sharedTokenHash: principal.sharedTokenHash } : {}),
     ...(principal.adminTokenHash ? { adminTokenHash: principal.adminTokenHash } : {}),
     ...(principal.adminGrantVersion ? { adminGrantVersion: principal.adminGrantVersion } : {}),
     ...(principal.portalSessionHash ? { portalSessionHash: principal.portalSessionHash } : {}),
@@ -15152,6 +15230,7 @@ function leaseBridgeTicketPrincipal(
     admin: ticket.admin === true,
     ...(ticket.auth ? { auth: ticket.auth } : {}),
     ...(ticket.login ? { login: ticket.login } : {}),
+    ...(ticket.sharedTokenHash ? { sharedTokenHash: ticket.sharedTokenHash } : {}),
     ...(ticket.adminTokenHash ? { adminTokenHash: ticket.adminTokenHash } : {}),
     ...(ticket.adminGrantVersion ? { adminGrantVersion: ticket.adminGrantVersion } : {}),
     ...(ticket.portalSessionHash ? { portalSessionHash: ticket.portalSessionHash } : {}),

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -360,6 +360,105 @@ describe("runtime adapter relay", () => {
     expect(internal.codeViewers.has("code-rotated-admin")).toBe(false);
   });
 
+  it("revokes active shared-token WebVNC, Code, and egress bridges after rotation", async () => {
+    const oldSharedToken = "old-shared-token";
+    const grant = {
+      auth: "bearer" as const,
+      owner: "shared@example.com",
+      org: "example-org",
+      admin: false,
+      sharedTokenHash: await sha256Hex(oldSharedToken),
+    };
+    const fleet = testFleet(new MemoryStorage(), {}, { CRABBOX_SHARED_TOKEN: oldSharedToken });
+    const leaseID = "cbx_000000000001";
+    const webAgent = new FakeWebSocket({
+      kind: "webvnc-agent",
+      leaseID,
+      id: "agent_shared_token",
+      capabilities: new Set<string>(),
+    });
+    const webViewer = new FakeWebSocket({
+      kind: "webvnc-viewer",
+      leaseID,
+      id: "viewer_shared_token",
+      agentID: "agent_shared_token",
+      ...grant,
+      label: "shared",
+    });
+    const codeAgent = new FakeWebSocket({ kind: "code-agent", leaseID });
+    const codeViewer = new FakeWebSocket({
+      kind: "code-viewer",
+      leaseID,
+      id: "code_shared_token",
+      ...grant,
+    });
+    const egressHost = new FakeWebSocket({
+      kind: "egress-host",
+      leaseID,
+      sessionID: "egress_shared_token",
+      ...grant,
+    });
+    const egressClient = new FakeWebSocket({
+      kind: "egress-client",
+      leaseID,
+      sessionID: "egress_shared_token",
+      ...grant,
+    });
+    const internal = fleet as unknown as {
+      env: Env;
+      webVNCAgents: Map<string, Map<string, WebSocket>>;
+      webVNCViewers: Map<string, Map<string, unknown>>;
+      codeAgents: Map<string, WebSocket>;
+      codeViewers: Map<string, WebSocket>;
+      egressHosts: Map<string, WebSocket>;
+      egressClients: Map<string, WebSocket>;
+    };
+    internal.webVNCAgents.set(
+      leaseID,
+      new Map([["agent_shared_token", webAgent as unknown as WebSocket]]),
+    );
+    internal.webVNCViewers.set(
+      leaseID,
+      new Map([
+        [
+          "viewer_shared_token",
+          {
+            id: "viewer_shared_token",
+            agentID: "agent_shared_token",
+            socket: webViewer as unknown as WebSocket,
+            ...grant,
+            label: "shared",
+            connectedAt: new Date().toISOString(),
+          },
+        ],
+      ]),
+    );
+    internal.codeAgents.set(leaseID, codeAgent as unknown as WebSocket);
+    internal.codeViewers.set("code_shared_token", codeViewer as unknown as WebSocket);
+    internal.egressHosts.set(
+      `${leaseID}\u0000egress_shared_token`,
+      egressHost as unknown as WebSocket,
+    );
+    internal.egressClients.set(
+      `${leaseID}\u0000egress_shared_token`,
+      egressClient as unknown as WebSocket,
+    );
+    internal.env.CRABBOX_SHARED_TOKEN = "new-shared-token";
+
+    await fleet.webSocketMessage(webViewer as unknown as WebSocket, "vnc-frame");
+    await fleet.webSocketMessage(codeViewer as unknown as WebSocket, "code-frame");
+    await fleet.webSocketMessage(egressHost as unknown as WebSocket, "egress-frame");
+
+    for (const socket of [webViewer, codeViewer, egressHost, egressClient]) {
+      expect(socket.closeCode).toBe(1008);
+      expect(socket.closeReason).toBe("shared access revoked");
+    }
+    expect(internal.webVNCViewers.get(leaseID)?.has("viewer_shared_token") ?? false).toBe(false);
+    expect(internal.codeViewers.has("code_shared_token")).toBe(false);
+    expect(internal.egressHosts.has(`${leaseID}\u0000egress_shared_token`)).toBe(false);
+    expect(internal.egressClients.has(`${leaseID}\u0000egress_shared_token`)).toBe(false);
+  });
+
   it("fails closed active non-admin GitHub WebVNC and egress bridges after revocation", async () => {
     const env = {
       CRABBOX_SESSION_SECRET: "session-secret",
@@ -961,6 +1060,84 @@ describe("runtime adapter relay", () => {
     expect(agent.sentJSON()).toHaveLength(2);
   });
 
+  it("rejects restored shared-token bridges after credential rotation", async () => {
+    const storage = new MemoryStorage();
+    const lease = testLease({
+      id: "cbx_000000000002",
+      provider: "external",
+      lifecycle: "registered",
+      state: "active",
+      owner: "shared@example.com",
+      org: "example-org",
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    storage.seed(`lease:${lease.id}`, lease);
+    const grant = {
+      auth: "bearer" as const,
+      owner: "shared@example.com",
+      org: "example-org",
+      admin: false,
+      sharedTokenHash: await sha256Hex("old-shared-token"),
+    };
+    const webAgent = new FakeWebSocket({
+      kind: "webvnc-agent",
+      leaseID: lease.id,
+      id: "agent_restored_shared",
+      capabilities: new Set<string>(),
+    });
+    const webViewer = new FakeWebSocket({
+      kind: "webvnc-viewer",
+      leaseID: lease.id,
+      id: "viewer_restored_shared",
+      agentID: "agent_restored_shared",
+      ...grant,
+      label: "shared",
+    });
+    const codeAgent = new FakeWebSocket({ kind: "code-agent", leaseID: lease.id });
+    const codeViewer = new FakeWebSocket({
+      kind: "code-viewer",
+      leaseID: lease.id,
+      id: "code_restored_shared",
+      ...grant,
+    });
+    const egressHost = new FakeWebSocket({
+      kind: "egress-host",
+      leaseID: lease.id,
+      sessionID: "egress_restored_shared",
+      ...grant,
+    });
+    const egressClient = new FakeWebSocket({
+      kind: "egress-client",
+      leaseID: lease.id,
+      sessionID: "egress_restored_shared",
+      ...grant,
+    });
+    const fleet = new FleetDurableObject(
+      {
+        storage,
+        getWebSockets: () =>
+          [
+            webAgent,
+            webViewer,
+            codeAgent,
+            codeViewer,
+            egressHost,
+            egressClient,
+          ] as unknown as WebSocket[],
+      } as unknown as DurableObjectState,
+      {
+        CRABBOX_DEFAULT_ORG: "example-org",
+        CRABBOX_SHARED_TOKEN: "new-shared-token",
+      } as Env,
+    );
+
+    expect((await fleet.fetch(request("GET", "/v1/health"))).status).toBe(200);
+    for (const socket of [webViewer, codeViewer, egressHost, egressClient]) {
+      expect(socket.closeCode).toBe(1008);
+      expect(socket.closeReason).toBe("shared access revoked");
+    }
+  });
+
   it("reconciles hibernated viewer principals against the current lease share", async () => {
     const storage = new MemoryStorage();
     const lease = testLease({
@@ -979,7 +1156,7 @@ describe("runtime adapter relay", () => {
       kind: "code-viewer",
       leaseID: lease.id,
       id: "code-revoked",
-      auth: "bearer",
+      auth: "proxy",
       owner: "revoked@example.com",
       org: "other-org",
       admin: false,
@@ -988,7 +1165,7 @@ describe("runtime adapter relay", () => {
       kind: "code-viewer",
       leaseID: lease.id,
       id: "code-owner",
-      auth: "bearer",
+      auth: "proxy",
       owner: "owner@example.com",
       org: "example-org",
       admin: false,
@@ -11086,7 +11263,7 @@ describe("fleet lease identity and idle", () => {
       kind: "code-viewer",
       leaseID,
       id: "code-revoked",
-      auth: "bearer",
+      auth: "proxy",
       owner: "revoked@example.com",
       org: "other-org",
       admin: false,
@@ -11095,7 +11272,7 @@ describe("fleet lease identity and idle", () => {
       kind: "code-viewer",
       leaseID,
       id: "code-retained",
-      auth: "bearer",
+      auth: "proxy",
       owner: "retained@example.com",
       org: "other-org",
       admin: false,
@@ -11104,7 +11281,7 @@ describe("fleet lease identity and idle", () => {
       kind: "code-viewer",
       leaseID,
       id: "code-owner",
-      auth: "bearer",
+      auth: "proxy",
       owner: "owner@example.com",
       org: "example-org",
       admin: false,
@@ -16730,17 +16907,17 @@ describe("fleet lease identity and idle", () => {
     expect(isolatedOrigin).toBeDefined();
     const viewers = [
       {
-        "x-crabbox-auth": "bearer",
+        "x-crabbox-auth": "proxy",
         "x-crabbox-owner": "owner@example.com",
         "x-crabbox-org": "example-org",
       },
       {
-        "x-crabbox-auth": "bearer",
+        "x-crabbox-auth": "proxy",
         "x-crabbox-owner": "manager@example.com",
         "x-crabbox-org": "other-org",
       },
       {
-        "x-crabbox-auth": "bearer",
+        "x-crabbox-auth": "proxy",
         "x-crabbox-owner": "admin@example.com",
         "x-crabbox-org": "other-org",
         "x-crabbox-admin": "true",
@@ -16763,6 +16940,7 @@ describe("fleet lease identity and idle", () => {
     const env = {
       CRABBOX_CODE_ORIGIN_TEMPLATE: "https://{lease}.code.example.test",
       CRABBOX_PUBLIC_URL: "https://crabbox.test",
+      CRABBOX_SHARED_TOKEN: "portal-session-token",
     };
     const fleet = testFleet(storage, {}, env);
     const leaseID = "cbx_000000000001";
@@ -16873,6 +17051,14 @@ describe("fleet lease identity and idle", () => {
       }),
     );
     expect(sameOriginPost.status).not.toBe(403);
+
+    (fleet as unknown as { env: Env }).env.CRABBOX_SHARED_TOKEN = "rotated-portal-token";
+    const rotatedSession = await fleet.fetch(
+      new Request(`${bootstrapURL.origin}${bootstrap.headers.get("location")}`, {
+        headers: { cookie: sessionCookie },
+      }),
+    );
+    expect(rotatedSession.status).toBe(302);
 
     const missingSession = await fleet.fetch(
       new Request(`${bootstrapURL.origin}/portal/leases/${leaseID}/code/health`),
@@ -17658,7 +17844,7 @@ describe("fleet lease identity and idle", () => {
     storage.seed(`code-viewer-session:${session}`, {
       session,
       leaseID,
-      auth: "bearer",
+      auth: "proxy",
       admin: false,
       owner: "alice@example.com",
       org: "example-org",
@@ -17796,6 +17982,86 @@ describe("fleet lease identity and idle", () => {
       }),
     );
     expect(githubFetch).not.toHaveBeenCalled();
+  });
+
+  it("binds shared-token bridge tickets to the credential active at creation", async () => {
+    const storage = new MemoryStorage();
+    const oldSharedToken = "old-shared-token";
+    const env = {
+      CRABBOX_SHARED_TOKEN: oldSharedToken,
+      CRABBOX_DEFAULT_ORG: "example-org",
+    } as Env;
+    const leaseID = "cbx_000000000001";
+    storage.seed(
+      `lease:${leaseID}`,
+      testLease({
+        id: leaseID,
+        slug: "blue-lobster",
+        owner: "shared@example.com",
+        org: "example-org",
+        desktop: true,
+        code: true,
+        state: "active",
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      }),
+    );
+    const fleet = testFleet(storage, {}, env);
+    const headers = {
+      authorization: `Bearer ${oldSharedToken}`,
+      "x-crabbox-auth": "bearer",
+      "x-crabbox-owner": "shared@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const cases = [
+      {
+        createPath: `/v1/leases/${leaseID}/webvnc/ticket`,
+        consumePath: `/v1/leases/${leaseID}/webvnc/agent`,
+        storagePrefix: "webvnc-ticket",
+        body: {},
+      },
+      {
+        createPath: `/v1/leases/${leaseID}/code/ticket`,
+        consumePath: `/v1/leases/${leaseID}/code/agent`,
+        storagePrefix: "code-ticket",
+        body: {},
+      },
+      {
+        createPath: `/v1/leases/${leaseID}/egress/ticket`,
+        consumePath: `/v1/leases/${leaseID}/egress/host`,
+        storagePrefix: "egress-ticket",
+        body: { role: "host" },
+      },
+    ];
+    const sharedTokenHash = await sha256Hex(oldSharedToken);
+    const tickets = await Promise.all(
+      cases.map(async (item): Promise<(typeof cases)[number] & { ticket: string }> => {
+        const response = await fleet.fetch(
+          request("POST", item.createPath, { headers, body: item.body }),
+        );
+        expect(response.status).toBe(200);
+        const result = (await response.json()) as { ticket?: string };
+        const ticket = result.ticket ?? "";
+        expect(ticket).not.toBe("");
+        expect(storage.value(`${item.storagePrefix}:${ticket}`)).toMatchObject({
+          auth: "bearer",
+          sharedTokenHash,
+        });
+        return { ...item, ticket };
+      }),
+    );
+
+    (fleet as unknown as { env: Env }).env.CRABBOX_SHARED_TOKEN = "new-shared-token";
+    await Promise.all(
+      tickets.map(async (item) => {
+        const response = await fleet.fetch(
+          request("GET", item.consumePath, {
+            headers: { authorization: `Bearer ${item.ticket}`, upgrade: "websocket" },
+          }),
+        );
+        expect(response.status).toBe(401);
+        expect(storage.value(`${item.storagePrefix}:${item.ticket}`)).toBeUndefined();
+      }),
+    );
   });
 
   it("rejects bridge tickets whose cached admin grant was revoked", async () => {


### PR DESCRIPTION
Closes https://github.com/openclaw/crabbox/issues/1001

## Summary

- bind non-admin bearer bridge grants to a SHA-256 identity for the configured shared token
- revalidate shared-token identity before consuming WebVNC, Code, and egress tickets
- close active and restored bridge sockets after the shared token rotates or disappears
- revoke durable isolated-Code viewer sessions after shared-token rotation
- fail closed for legacy bearer grants that predate the credential binding

## Root cause

Shared-token requests were cached only as `auth: bearer`. Active bridge validation rechecked GitHub user grants and admin grants, but treated every non-admin bearer attachment as current forever.

## Verification

- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker` — 901 passed, 3 skipped
- `npm run build --prefix worker`
- AutoReview — clean, no accepted/actionable findings (confidence 0.93)

Regression coverage includes ticket creation/consumption, active WebVNC/Code/egress traffic, restored sockets, legacy grants, and durable isolated-Code sessions.
