### PR TITLE
fix: make Parallels macOS desktop control reliable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 - Bound non-admin shared-token WebVNC, Code, and egress bridges to the credential active at ticket creation, closing active and restored sessions after token rotation or removal. Thanks @coygeek.
+- Made Parallels macOS WebVNC use managed VNC credentials, authenticated screenshots, pointer and clipboard input, explicit host-side macOS routing, collision-safe local tunnels, XWayland-aware desktop input, and safe clipboard fallback.
 - Started delegated-provider sync timeouts at archive creation, matching SSH sync semantics and avoiding pre-transfer expiry during local Git manifest planning.
 - Kept macOS listener ownership checks responsive when mounted filesystems make full `lsof` metadata scans slow.
 - Routed Azure orphan-sweep deletion through the exact lease-, provider-scope-, resource-, companion-, and immutable-disk-bound owned-delete path instead of deleting by retained VM name alone.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ### Fixed
 
 - Bound non-admin shared-token WebVNC, Code, and egress bridges to the credential active at ticket creation, closing active and restored sessions after token rotation or removal. Thanks @coygeek.
-- Made Parallels macOS WebVNC use managed VNC credentials, authenticated screenshots, pointer and clipboard input, explicit host-side macOS routing, collision-safe local tunnels, XWayland-aware desktop input, and safe clipboard fallback.
+- Made Parallels macOS WebVNC use managed VNC credentials, authenticated screenshots, pointer and direct keyboard input, explicit host-side macOS routing, collision-safe local tunnels, XWayland-aware desktop input, and safe clipboard fallback.
 - Started delegated-provider sync timeouts at archive creation, matching SSH sync semantics and avoiding pre-transfer expiry during local Git manifest planning.
 - Kept macOS listener ownership checks responsive when mounted filesystems make full `lsof` metadata scans slow.
 - Routed Azure orphan-sweep deletion through the exact lease-, provider-scope-, resource-, companion-, and immutable-disk-bound owned-delete path instead of deleting by retained VM name alone.

--- a/internal/cli/desktop_input.go
+++ b/internal/cli/desktop_input.go
@@ -81,7 +81,7 @@ func (a App) desktopPaste(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	if target.TargetOS != targetLinux && target.TargetOS != targetMacOS {
+	if !desktopTextSupportsTarget(target) {
 		return exit(2, "desktop paste supports target=linux or target=macos")
 	}
 	text, err := desktopTextArgOrStdin(a.Stderr, args, "desktop paste")
@@ -89,10 +89,10 @@ func (a App) desktopPaste(ctx context.Context, args []string) error {
 		return err
 	}
 	if target.TargetOS == targetMacOS {
-		if err := pasteRemoteMacVNC(ctx, cfg, target, text); err != nil {
+		if err := typeRemoteMacVNC(ctx, cfg, target, text); err != nil {
 			return exit(5, "desktop paste failed for %s: %v", leaseID, err)
 		}
-		fmt.Fprintf(a.Stdout, "pasted: lease=%s bytes=%d method=vnc\n", leaseID, len(text))
+		fmt.Fprintf(a.Stdout, "pasted: lease=%s bytes=%d method=vnc-key\n", leaseID, len(text))
 		return nil
 	}
 	var stdout, stderr strings.Builder
@@ -105,13 +105,23 @@ func (a App) desktopPaste(ctx context.Context, args []string) error {
 }
 
 func (a App) desktopType(ctx context.Context, args []string) error {
-	target, cfg, leaseID, err := a.desktopCommandTarget(ctx, "desktop type", args, true)
+	target, cfg, leaseID, err := a.desktopCommandTarget(ctx, "desktop type", args, false)
 	if err != nil {
 		return err
+	}
+	if !desktopTextSupportsTarget(target) {
+		return exit(2, "desktop type supports target=linux or target=macos")
 	}
 	text, err := desktopTextArgOrStdin(a.Stderr, args, "desktop type")
 	if err != nil {
 		return err
+	}
+	if target.TargetOS == targetMacOS {
+		if err := typeRemoteMacVNC(ctx, cfg, target, text); err != nil {
+			return exit(5, "desktop type failed for %s: %v", leaseID, err)
+		}
+		fmt.Fprintf(a.Stdout, "typed: lease=%s bytes=%d method=vnc-key\n", leaseID, len(text))
+		return nil
 	}
 	if desktopShouldPasteForType(text) {
 		var stdout, stderr strings.Builder
@@ -139,6 +149,10 @@ func (a App) desktopType(ctx context.Context, args []string) error {
 	}
 	fmt.Fprintf(a.Stdout, "typed: lease=%s method=xdotool bytes=%d\n", leaseID, len(text))
 	return nil
+}
+
+func desktopTextSupportsTarget(target SSHTarget) bool {
+	return target.TargetOS == targetLinux || target.TargetOS == targetMacOS
 }
 
 // desktopPasteFailureSafeToRetry only permits a key-by-key retry when the

--- a/internal/cli/desktop_input.go
+++ b/internal/cli/desktop_input.go
@@ -57,6 +57,13 @@ func (a App) desktopClick(ctx context.Context, args []string) error {
 	if !desktopClickSupportsTarget(target) {
 		return exit(2, "desktop click supports target=linux, target=macos, or target=windows with windowsMode=normal")
 	}
+	if target.TargetOS == targetMacOS {
+		if err := clickRemoteMacVNC(ctx, cfg, target, x, y); err != nil {
+			return exit(5, "desktop click failed for %s: %v", leaseID, err)
+		}
+		fmt.Fprintf(a.Stdout, "clicked: lease=%s x=%d y=%d method=vnc\n", leaseID, x, y)
+		return nil
+	}
 	if out, err := runSSHCombinedOutput(ctx, target, desktopClickRemoteCommand(target, x, y)); err != nil {
 		a.printDesktopInputRescue(classifyDesktopFailure(out), out, cfg, target, leaseID)
 		return exit(5, "desktop click failed for %s: %v", leaseID, err)
@@ -70,13 +77,23 @@ func desktopClickSupportsTarget(target SSHTarget) bool {
 }
 
 func (a App) desktopPaste(ctx context.Context, args []string) error {
-	target, cfg, leaseID, err := a.desktopCommandTarget(ctx, "desktop paste", args, true)
+	target, cfg, leaseID, err := a.desktopCommandTarget(ctx, "desktop paste", args, false)
 	if err != nil {
 		return err
+	}
+	if target.TargetOS != targetLinux && target.TargetOS != targetMacOS {
+		return exit(2, "desktop paste supports target=linux or target=macos")
 	}
 	text, err := desktopTextArgOrStdin(a.Stderr, args, "desktop paste")
 	if err != nil {
 		return err
+	}
+	if target.TargetOS == targetMacOS {
+		if err := pasteRemoteMacVNC(ctx, cfg, target, text); err != nil {
+			return exit(5, "desktop paste failed for %s: %v", leaseID, err)
+		}
+		fmt.Fprintf(a.Stdout, "pasted: lease=%s bytes=%d method=vnc\n", leaseID, len(text))
+		return nil
 	}
 	var stdout, stderr strings.Builder
 	if err := runSSHInput(ctx, target, desktopPasteRemoteCommand(), strings.NewReader(text), &stdout, &stderr); err != nil {
@@ -99,8 +116,19 @@ func (a App) desktopType(ctx context.Context, args []string) error {
 	if desktopShouldPasteForType(text) {
 		var stdout, stderr strings.Builder
 		if err := runSSHInput(ctx, target, desktopPasteRemoteCommand(), strings.NewReader(text), &stdout, &stderr); err != nil {
-			a.printDesktopInputRescue(classifyDesktopFailure(stderr.String()+"\n"+stdout.String()), stderr.String()+"\n"+stdout.String(), cfg, target, leaseID)
-			return exit(5, "desktop type paste fallback failed for %s: %v", leaseID, err)
+			pasteDetail := stderr.String() + "\n" + stdout.String()
+			if !desktopPasteFailureSafeToRetry(pasteDetail) {
+				a.printDesktopInputRescue(classifyDesktopFailure(pasteDetail), pasteDetail, cfg, target, leaseID)
+				return exit(5, "desktop type paste failed for %s: %v", leaseID, err)
+			}
+			if out, typeErr := runSSHCombinedOutput(ctx, target, desktopTypeRemoteCommand(text)); typeErr == nil {
+				fmt.Fprintf(a.Stdout, "typed: lease=%s method=key-fallback bytes=%d\n", leaseID, len(text))
+				return nil
+			} else {
+				detail := pasteDetail + "\nkey fallback:\n" + out
+				a.printDesktopInputRescue(classifyDesktopFailure(detail), detail, cfg, target, leaseID)
+				return exit(5, "desktop type paste and key fallback failed for %s: %v", leaseID, typeErr)
+			}
 		}
 		fmt.Fprintf(a.Stdout, "typed: lease=%s method=paste bytes=%d\n", leaseID, len(text))
 		return nil
@@ -111,6 +139,25 @@ func (a App) desktopType(ctx context.Context, args []string) error {
 	}
 	fmt.Fprintf(a.Stdout, "typed: lease=%s method=xdotool bytes=%d\n", leaseID, len(text))
 	return nil
+}
+
+// desktopPasteFailureSafeToRetry only permits a key-by-key retry when the
+// remote paste helper failed before it could send input to the active window.
+// Retrying after a post-paste clipboard-owner failure would duplicate text.
+func desktopPasteFailureSafeToRetry(detail string) bool {
+	for _, marker := range []string{
+		"missing clipboard tool",
+		"missing or unavailable xdotool",
+		"missing xdotool",
+		"missing wtype",
+		"clipboard helper exited before paste",
+		"clipboard helper failed to provide requested contents",
+	} {
+		if strings.Contains(detail, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 func (a App) desktopKey(ctx context.Context, args []string) error {
@@ -412,12 +459,15 @@ exit 127`, x, y, x, y)
 	}
 	return fmt.Sprintf(`set -eu
 if [ -f /var/lib/crabbox/desktop.env ]; then . /var/lib/crabbox/desktop.env; fi
-if [ "${CRABBOX_DESKTOP_ENV:-xfce}" != "xfce" ]; then
+export DISPLAY="${DISPLAY:-:99}"
+if ! command -v xdotool >/dev/null 2>&1 || ! xdotool getactivewindow >/dev/null 2>&1; then
+  if [ "${CRABBOX_DESKTOP_ENV:-xfce}" = "xfce" ]; then
+    echo "missing or unavailable xdotool; warm a new --desktop lease or install xdotool" >&2
+    exit 127
+  fi
   echo "desktop click is not supported on Wayland desktop envs yet; use WebVNC pointer input" >&2
   exit 2
 fi
-export DISPLAY="${DISPLAY:-:99}"
-command -v xdotool >/dev/null 2>&1 || { echo "missing xdotool; warm a new --desktop lease or install xdotool" >&2; exit 127; }
 xdotool mousemove %d %d click 1`, x, y)
 }
 
@@ -433,11 +483,13 @@ func desktopKeyRemoteCommand(keys string) string {
 	}
 	return `set -eu
 if [ -f /var/lib/crabbox/desktop.env ]; then . /var/lib/crabbox/desktop.env; fi
-if [ "${CRABBOX_DESKTOP_ENV:-xfce}" != "xfce" ]; then
+export DISPLAY="${DISPLAY:-:99}"
+x11_input=0
+if command -v xdotool >/dev/null 2>&1 && xdotool getactivewindow >/dev/null 2>&1; then x11_input=1; fi
+if [ "${CRABBOX_DESKTOP_ENV:-xfce}" != "xfce" ] && [ "$x11_input" -ne 1 ]; then
   export XDG_RUNTIME_DIR WAYLAND_DISPLAY
   command -v wtype >/dev/null 2>&1 || { echo "missing wtype; warm a new Wayland desktop lease or install wtype" >&2; exit 127; }
   ` + wayland.String() + `fi
-export DISPLAY="${DISPLAY:-:99}"
 command -v xdotool >/dev/null 2>&1 || { echo "missing xdotool; warm a new --desktop lease or install xdotool" >&2; exit 127; }
 xdotool key --clearmodifiers ` + shellQuote(strings.TrimSpace(keys))
 }
@@ -445,12 +497,14 @@ xdotool key --clearmodifiers ` + shellQuote(strings.TrimSpace(keys))
 func desktopTypeRemoteCommand(text string) string {
 	return `set -eu
 if [ -f /var/lib/crabbox/desktop.env ]; then . /var/lib/crabbox/desktop.env; fi
-if [ "${CRABBOX_DESKTOP_ENV:-xfce}" != "xfce" ]; then
+export DISPLAY="${DISPLAY:-:99}"
+x11_input=0
+if command -v xdotool >/dev/null 2>&1 && xdotool getactivewindow >/dev/null 2>&1; then x11_input=1; fi
+if [ "${CRABBOX_DESKTOP_ENV:-xfce}" != "xfce" ] && [ "$x11_input" -ne 1 ]; then
   export XDG_RUNTIME_DIR WAYLAND_DISPLAY
   command -v wtype >/dev/null 2>&1 || { echo "missing wtype; warm a new Wayland desktop lease or install wtype" >&2; exit 127; }
   exec wtype -d 1 -- ` + shellQuote(text) + `
 fi
-export DISPLAY="${DISPLAY:-:99}"
 command -v xdotool >/dev/null 2>&1 || { echo "missing xdotool; warm a new --desktop lease or install xdotool" >&2; exit 127; }
 xdotool type --clearmodifiers --delay 1 -- ` + shellQuote(text)
 }
@@ -463,13 +517,15 @@ clip_backend=""
 trap 'if [ -n "$clip_pid" ]; then kill "$clip_pid" 2>/dev/null || true; wait "$clip_pid" 2>/dev/null || true; fi; rm -f "$tmp"' EXIT
 cat > "$tmp"
 if [ -f /var/lib/crabbox/desktop.env ]; then . /var/lib/crabbox/desktop.env; fi
-if [ "${CRABBOX_DESKTOP_ENV:-xfce}" != "xfce" ]; then
+export DISPLAY="${DISPLAY:-:99}"
+x11_input=0
+if command -v xdotool >/dev/null 2>&1 && xdotool getactivewindow >/dev/null 2>&1; then x11_input=1; fi
+if [ "${CRABBOX_DESKTOP_ENV:-xfce}" != "xfce" ] && [ "$x11_input" -ne 1 ]; then
   export XDG_RUNTIME_DIR WAYLAND_DISPLAY
   command -v wtype >/dev/null 2>&1 || { echo "missing wtype; warm a new Wayland desktop lease or install wtype" >&2; exit 127; }
   wtype -d 1 - < "$tmp"
   exit 0
 fi
-export DISPLAY="${DISPLAY:-:99}"
 command -v xdotool >/dev/null 2>&1 || { echo "missing xdotool; warm a new --desktop lease or install xdotool" >&2; exit 127; }
 active_class="$(xdotool getactivewindow getwindowclassname 2>/dev/null | tr '[:upper:]' '[:lower:]' || true)"
 active_name="$(xdotool getactivewindow getwindowname 2>/dev/null | tr '[:upper:]' '[:lower:]' || true)"

--- a/internal/cli/desktop_test.go
+++ b/internal/cli/desktop_test.go
@@ -259,6 +259,27 @@ func TestDesktopTypeUsesPasteForSymbolHeavyText(t *testing.T) {
 	}
 }
 
+func TestDesktopPasteFailureSafeToRetry(t *testing.T) {
+	for _, detail := range []string{
+		"missing clipboard tool; warm a new lease",
+		"clipboard helper exited before paste (status=42)",
+		"clipboard helper failed to provide requested contents (xsel)",
+	} {
+		if !desktopPasteFailureSafeToRetry(detail) {
+			t.Errorf("expected pre-input failure to be retryable: %q", detail)
+		}
+	}
+	for _, detail := range []string{
+		"clipboard helper failed while serving paste (status=42)",
+		"xdotool type failed after entering part of the text",
+		"wtype returned status 1",
+	} {
+		if desktopPasteFailureSafeToRetry(detail) {
+			t.Errorf("expected potentially partial input failure not to be retryable: %q", detail)
+		}
+	}
+}
+
 func TestDesktopPasteRemoteCommandPrefersClipboardTools(t *testing.T) {
 	got := desktopPasteRemoteCommand()
 	for _, want := range []string{
@@ -410,10 +431,13 @@ func TestDesktopLinuxTerminalSupportsWaylandAndX11(t *testing.T) {
 
 func TestDesktopClickRemoteCommandSupportsManagedTargets(t *testing.T) {
 	linux := desktopClickRemoteCommand(SSHTarget{TargetOS: targetLinux}, 12, 34)
-	for _, want := range []string{"CRABBOX_DESKTOP_ENV:-xfce", "not supported on Wayland desktop envs", "DISPLAY=\"${DISPLAY:-:99}\"", "xdotool mousemove 12 34 click 1"} {
+	for _, want := range []string{"CRABBOX_DESKTOP_ENV:-xfce", "not supported on Wayland desktop envs", "DISPLAY=\"${DISPLAY:-:99}\"", "xdotool getactivewindow", "xdotool mousemove 12 34 click 1"} {
 		if !strings.Contains(linux, want) {
 			t.Fatalf("linux click command missing %q:\n%s", want, linux)
 		}
+	}
+	if strings.Index(linux, "xdotool getactivewindow") > strings.Index(linux, "not supported on Wayland desktop envs") {
+		t.Fatalf("linux click must try an active XWayland window before rejecting the desktop env:\n%s", linux)
 	}
 	mac := desktopClickRemoteCommand(SSHTarget{TargetOS: targetMacOS}, 12, 34)
 	for _, want := range []string{"cliclick c:12,34", "import CoreGraphics", "CGEvent"} {
@@ -441,6 +465,9 @@ func TestDesktopWaylandInputBranches(t *testing.T) {
 			t.Fatalf("key command missing %q:\n%s", want, key)
 		}
 	}
+	if strings.Index(key, "xdotool getactivewindow") > strings.Index(key, "command -v wtype") {
+		t.Fatalf("key command must prefer an active XWayland window before native Wayland fallback:\n%s", key)
+	}
 	unsupported := desktopKeyRemoteCommand("ctrl+l alt+Tab")
 	if !strings.Contains(unsupported, "supports a single key or modifier+key sequence") {
 		t.Fatalf("complex wayland key sequence should be rejected:\n%s", unsupported)
@@ -450,6 +477,9 @@ func TestDesktopWaylandInputBranches(t *testing.T) {
 		if !strings.Contains(typed, want) {
 			t.Fatalf("type command missing %q:\n%s", want, typed)
 		}
+	}
+	if strings.Index(typed, "xdotool getactivewindow") > strings.Index(typed, "wtype -d 1") {
+		t.Fatalf("type command must prefer an active XWayland window before native Wayland fallback:\n%s", typed)
 	}
 }
 

--- a/internal/cli/desktop_test.go
+++ b/internal/cli/desktop_test.go
@@ -259,6 +259,19 @@ func TestDesktopTypeUsesPasteForSymbolHeavyText(t *testing.T) {
 	}
 }
 
+func TestDesktopTextInputSupportsLinuxAndMacOS(t *testing.T) {
+	for _, target := range []SSHTarget{{TargetOS: targetLinux}, {TargetOS: targetMacOS}} {
+		if !desktopTextSupportsTarget(target) {
+			t.Errorf("target %q should support desktop text input", target.TargetOS)
+		}
+	}
+	for _, target := range []SSHTarget{{TargetOS: targetWindows}, {TargetOS: "freebsd"}} {
+		if desktopTextSupportsTarget(target) {
+			t.Errorf("target %q should not support desktop text input", target.TargetOS)
+		}
+	}
+}
+
 func TestDesktopPasteFailureSafeToRetry(t *testing.T) {
 	for _, detail := range []string{
 		"missing clipboard tool; warm a new lease",

--- a/internal/cli/macos_webvnc.go
+++ b/internal/cli/macos_webvnc.go
@@ -66,9 +66,9 @@ func (a App) macOSWebVNCBridge(ctx context.Context, cfg Config, id, webPort stri
 	if _, err := resolveVNCEndpoint(ctx, cfg, &target); err != nil {
 		return err
 	}
-	credentials, ok := providerDesktopCredentials(cfg, target)
-	if !ok {
-		return exit(2, "provider=%s does not supply macOS desktop credentials", cfg.Provider)
+	credentials, err := resolveMacOSWebVNCCredentials(ctx, cfg, target, runSSHOutput)
+	if err != nil {
+		return err
 	}
 
 	// SSH tunnel: 127.0.0.1:vncPort -> guest 127.0.0.1:5900 (Screen Sharing).
@@ -104,6 +104,25 @@ func (a App) macOSWebVNCBridge(ctx context.Context, cfg Config, id, webPort stri
 			fmt.Fprintf(a.Stdout, "remote: forward port %s over SSH, copy %s to your machine, then open the copied file\n", webPort, handoff.Path)
 		},
 	)
+}
+
+type macOSVNCPasswordReader func(context.Context, SSHTarget, string) (string, error)
+
+func resolveMacOSWebVNCCredentials(ctx context.Context, cfg Config, target SSHTarget, readPassword macOSVNCPasswordReader) (rfbCredentials, error) {
+	if credentials, ok := providerDesktopCredentials(cfg, target); ok {
+		return credentials, nil
+	}
+	password, err := readPassword(ctx, target, vncPasswordCommand(target))
+	if err != nil {
+		return rfbCredentials{}, exit(5, "read managed macOS desktop credentials: %v", err)
+	}
+	password = strings.TrimSpace(password)
+	if password == "" {
+		return rfbCredentials{}, exit(5, "managed macOS desktop password is empty")
+	}
+	return rfbCredentials{
+		Password: password,
+	}, nil
 }
 
 func dialVNCForegroundTunnel(ctx context.Context, tunnel *vncForegroundTunnel, port string) (net.Conn, error) {

--- a/internal/cli/macos_webvnc_test.go
+++ b/internal/cli/macos_webvnc_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"io/fs"
 	"net/http"
 	"net/http/httptest"
@@ -8,6 +9,32 @@ import (
 	"strings"
 	"testing"
 )
+
+func TestResolveMacOSWebVNCCredentialsFallsBackToManagedPassword(t *testing.T) {
+	target := SSHTarget{TargetOS: targetMacOS, User: "steipete"}
+	var gotCommand string
+	credentials, err := resolveMacOSWebVNCCredentials(
+		context.Background(),
+		Config{Provider: parallelsProvider},
+		target,
+		func(_ context.Context, gotTarget SSHTarget, command string) (string, error) {
+			if gotTarget.TargetOS != target.TargetOS || gotTarget.User != target.User {
+				t.Fatalf("target = %#v, want %#v", gotTarget, target)
+			}
+			gotCommand = command
+			return "managed-secret\n", nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotCommand != "sudo cat '/var/db/crabbox/vnc.password'" {
+		t.Fatalf("password command = %q", gotCommand)
+	}
+	if credentials.Username != "" || credentials.Password != "managed-secret" {
+		t.Fatalf("credentials = %#v", credentials)
+	}
+}
 
 func TestCreateMacOSWebVNCHandoffKeepsTokenOutOfOpenURL(t *testing.T) {
 	session := macOSWebVNCSession{

--- a/internal/cli/parallels.go
+++ b/internal/cli/parallels.go
@@ -354,7 +354,7 @@ func (c *ParallelsClient) EnsureGuestReady(ctx context.Context, vmID string, cfg
 	if workRoot == "" {
 		workRoot = baseConfig().WorkRoot
 	}
-	desktop := cfg.Desktop && cfg.TargetOS == targetLinux
+	desktop := cfg.Desktop
 	result, err := c.prlctl(ctx, nil, "exec", vmID, "/bin/sh", "-lc", parallelsPOSIXEnsureReadyScript(user, workRoot, desktop))
 	if err != nil {
 		return commandOutputError("parallels guest prep", result, err)
@@ -554,7 +554,14 @@ user=%s
 work_root=%s
 desktop=%t
 if [ -x /usr/local/bin/crabbox-ready ] && /usr/local/bin/crabbox-ready >/tmp/crabbox-ready.log 2>&1; then
-  if [ "$desktop" != true ] || { command -v websockify >/dev/null 2>&1 && command -v x11vnc >/dev/null 2>&1 && { [ -f /usr/share/novnc/vnc.html ] || [ -f /usr/share/novnc/core/vnc.html ] || [ -f /usr/share/novnc/html/vnc.html ]; } && systemctl is-active --quiet crabbox-x11vnc.service; }; then
+  if [ "$desktop" != true ]; then
+    exit 0
+  fi
+  if command -v sw_vers >/dev/null 2>&1; then
+    if [ -s /var/db/crabbox/vnc.password ] && [ -f /var/db/crabbox/vnc.console ] && nc -z 127.0.0.1 5900; then
+      exit 0
+    fi
+  elif command -v websockify >/dev/null 2>&1 && command -v x11vnc >/dev/null 2>&1 && { [ -f /usr/share/novnc/vnc.html ] || [ -f /usr/share/novnc/core/vnc.html ] || [ -f /usr/share/novnc/html/vnc.html ]; } && systemctl is-active --quiet crabbox-x11vnc.service; then
     exit 0
   fi
 fi
@@ -635,6 +642,48 @@ if command -v sw_vers >/dev/null 2>&1; then
     /bin/launchctl bootstrap system /System/Library/LaunchDaemons/ssh.plist >>"$remote_login_log" 2>&1 || true
   /bin/launchctl enable system/com.openssh.sshd >>"$remote_login_log" 2>&1 || true
   /bin/launchctl kickstart -k system/com.openssh.sshd >>"$remote_login_log" 2>&1 || true
+  if [ "$desktop" = true ]; then
+    mkdir -p /var/db/crabbox
+    vnc_password=""
+    if [ -s /var/db/crabbox/vnc.password ]; then
+      vnc_password="$(tr -d '\r\n' </var/db/crabbox/vnc.password)"
+    fi
+    case "$vnc_password" in
+      ????????) ;;
+      *) vnc_password="$(/usr/bin/openssl rand -hex 4)" ;;
+    esac
+    case "$vnc_password" in
+      *[!A-Za-z0-9]*) echo "invalid generated VNC password" >&2; exit 1 ;;
+    esac
+    printf '%%s\n' "$vnc_password" >/var/db/crabbox/vnc.password
+    chmod 0600 /var/db/crabbox/vnc.password
+    mkdir -p /etc/sudoers.d
+    printf '%%s ALL=(root) NOPASSWD: /bin/cat /var/db/crabbox/vnc.password\n' "$user" >/etc/sudoers.d/crabbox-vnc-password
+    chmod 0440 /etc/sudoers.d/crabbox-vnc-password
+    /usr/sbin/visudo -cf /etc/sudoers.d/crabbox-vnc-password >/dev/null
+    kickstart=/System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/Resources/kickstart
+    [ -x "$kickstart" ]
+    /usr/bin/defaults write /Library/Preferences/com.apple.RemoteManagement VNCAlwaysStartOnConsole -bool true
+    "$kickstart" -activate -configure -allowAccessFor -specifiedUsers >/dev/null 2>&1
+    "$kickstart" -configure -access -on -users "$user" -privs -all >/dev/null 2>&1
+    "$kickstart" -configure -clientopts -setdirlogins -dirlogins no -setvnclegacy -vnclegacy yes -setvncpw -vncpw "$vnc_password" >/dev/null 2>&1
+    "$kickstart" -restart -agent >/dev/null 2>&1
+    /bin/launchctl enable system/com.apple.screensharing >/dev/null 2>&1 || true
+    /bin/launchctl kickstart -k system/com.apple.screensharing >/dev/null 2>&1 || true
+    vnc_ready=false
+    for _ in $(jot 60 1); do
+      if nc -z 127.0.0.1 5900; then
+        vnc_ready=true
+        break
+      fi
+      sleep 1
+    done
+    if [ "$vnc_ready" != true ]; then
+      echo "macOS Screen Sharing did not start (no VNC listener on 127.0.0.1:5900)" >&2
+      exit 1
+    fi
+    touch /var/db/crabbox/vnc.console
+  fi
   cat >/usr/local/bin/crabbox-ready <<'READY'
 #!/bin/sh
 set -eu

--- a/internal/cli/parallels_test.go
+++ b/internal/cli/parallels_test.go
@@ -319,6 +319,38 @@ func TestParallelsEnsureGuestReadyEnablesMacOSRemoteLogin(t *testing.T) {
 	}
 }
 
+func TestParallelsEnsureGuestReadyEnablesMacOSScreenSharing(t *testing.T) {
+	runner := &parallelsFakeRunner{}
+	client := NewParallelsClient(Config{}, runner)
+	err := client.EnsureGuestReady(context.Background(), "vm1", Config{SSHUser: "runner", WorkRoot: "/Users/runner/crabbox", TargetOS: targetMacOS, Desktop: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := strings.Join(runner.lastReq.Args, "\n")
+	for _, want := range []string{
+		"desktop=true",
+		"mkdir -p /var/db/crabbox",
+		"/var/db/crabbox/vnc.password",
+		"openssl rand -hex 4",
+		"NOPASSWD: /bin/cat /var/db/crabbox/vnc.password",
+		"-setvnclegacy -vnclegacy yes",
+		"-setvncpw -vncpw \"$vnc_password\"",
+		"-access -on -users \"$user\" -privs -all",
+		"VNCAlwaysStartOnConsole -bool true",
+		"com.apple.screensharing",
+		"nc -z 127.0.0.1 5900",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("macOS desktop guest prep missing %q:\n%s", want, got)
+		}
+	}
+	for _, banned := range []string{"dscl . -passwd", "-passwd /Users", "-access -off", "-privs -none"} {
+		if strings.Contains(got, banned) {
+			t.Fatalf("macOS desktop guest prep changes the account password with %q:\n%s", banned, got)
+		}
+	}
+}
+
 func TestParallelsEnsureGuestReadySkipsWindows(t *testing.T) {
 	runner := &parallelsFakeRunner{}
 	client := NewParallelsClient(Config{}, runner)

--- a/internal/cli/rfb_screenshot.go
+++ b/internal/cli/rfb_screenshot.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/aes"
+	"crypto/des"
 	"crypto/md5"
 	"crypto/rand"
 	"encoding/binary"
@@ -13,6 +14,7 @@ import (
 	"image/png"
 	"io"
 	"math/big"
+	"math/bits"
 	"net"
 	"os"
 	"path/filepath"
@@ -22,6 +24,7 @@ import (
 
 const (
 	rfbSecurityNone = 1
+	rfbSecurityVNC  = 2
 	rfbSecurityARD  = 30
 	rfbEncodingRaw  = 0
 )
@@ -46,7 +49,6 @@ func captureRemoteMacVNCScreenshot(ctx context.Context, cfg Config, target SSHTa
 			password = strings.TrimSpace(out)
 		}
 		creds = rfbCredentials{
-			Username: strings.TrimSpace(target.User),
 			Password: password,
 		}
 	}
@@ -72,6 +74,40 @@ func captureRemoteMacVNCScreenshot(ctx context.Context, cfg Config, target SSHTa
 		return exit(5, "write screenshot PNG: %v", err)
 	}
 	ok = true
+	return nil
+}
+
+func clickRemoteMacVNC(ctx context.Context, cfg Config, target SSHTarget, x, y int) error {
+	tunnel, localPort, err := startVNCForegroundTunnelOnReservedPort(ctx, target, "", "127.0.0.1", managedVNCPort)
+	if err != nil {
+		return err
+	}
+	defer stopProcess(tunnel)
+
+	creds, err := resolveMacOSWebVNCCredentials(ctx, cfg, target, runSSHOutput)
+	if err != nil {
+		return err
+	}
+	if err := clickRFBPointer(ctx, "127.0.0.1:"+localPort, creds, x, y); err != nil {
+		return fmt.Errorf("click macOS VNC pointer: %w", err)
+	}
+	return nil
+}
+
+func pasteRemoteMacVNC(ctx context.Context, cfg Config, target SSHTarget, text string) error {
+	tunnel, localPort, err := startVNCForegroundTunnelOnReservedPort(ctx, target, "", "127.0.0.1", managedVNCPort)
+	if err != nil {
+		return err
+	}
+	defer stopProcess(tunnel)
+
+	creds, err := resolveMacOSWebVNCCredentials(ctx, cfg, target, runSSHOutput)
+	if err != nil {
+		return err
+	}
+	if err := pasteRFBClipboard(ctx, "127.0.0.1:"+localPort, creds, text); err != nil {
+		return fmt.Errorf("paste macOS VNC clipboard: %w", err)
+	}
 	return nil
 }
 
@@ -112,6 +148,79 @@ func captureRFBFrame(ctx context.Context, address string, creds rfbCredentials) 
 	return captureRFBFrameFromConn(ctx, conn, creds)
 }
 
+func clickRFBPointer(ctx context.Context, address string, creds rfbCredentials, x, y int) error {
+	dialer := net.Dialer{Timeout: 10 * time.Second}
+	conn, err := dialer.DialContext(ctx, "tcp", address)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	return clickRFBPointerFromConn(ctx, conn, creds, x, y)
+}
+
+func pasteRFBClipboard(ctx context.Context, address string, creds rfbCredentials, text string) error {
+	dialer := net.Dialer{Timeout: 10 * time.Second}
+	conn, err := dialer.DialContext(ctx, "tcp", address)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	return pasteRFBClipboardFromConn(ctx, conn, creds, text)
+}
+
+func pasteRFBClipboardFromConn(ctx context.Context, conn net.Conn, creds rfbCredentials, text string) error {
+	if deadline, ok := ctx.Deadline(); ok {
+		_ = conn.SetDeadline(deadline)
+	} else {
+		_ = conn.SetDeadline(time.Now().Add(30 * time.Second))
+	}
+	if _, _, err := initializeRFBConnection(conn, creds); err != nil {
+		return err
+	}
+	if err := writeRFBClientCutText(conn, text); err != nil {
+		return err
+	}
+	time.Sleep(100 * time.Millisecond)
+	const (
+		xkSuperL = 0xffeb
+		xkV      = 0x76
+	)
+	for _, event := range []struct {
+		down bool
+		key  uint32
+	}{{true, xkSuperL}, {true, xkV}, {false, xkV}, {false, xkSuperL}} {
+		if err := writeRFBKeyEvent(conn, event.down, event.key); err != nil {
+			return err
+		}
+	}
+	time.Sleep(250 * time.Millisecond)
+	return nil
+}
+
+func clickRFBPointerFromConn(ctx context.Context, conn net.Conn, creds rfbCredentials, x, y int) error {
+	if deadline, ok := ctx.Deadline(); ok {
+		_ = conn.SetDeadline(deadline)
+	} else {
+		_ = conn.SetDeadline(time.Now().Add(30 * time.Second))
+	}
+
+	width, height, err := initializeRFBConnection(conn, creds)
+	if err != nil {
+		return err
+	}
+	if x < 0 || y < 0 || x >= int(width) || y >= int(height) {
+		return fmt.Errorf("pointer coordinates %d,%d exceed framebuffer %dx%d", x, y, width, height)
+	}
+	if err := writeRFBPointerEvent(conn, 0, x, y); err != nil {
+		return err
+	}
+	if err := writeRFBPointerEvent(conn, 1, x, y); err != nil {
+		return err
+	}
+	time.Sleep(80 * time.Millisecond)
+	return writeRFBPointerEvent(conn, 0, x, y)
+}
+
 func captureRFBFrameFromConn(ctx context.Context, conn net.Conn, creds rfbCredentials) (image.Image, error) {
 	if deadline, ok := ctx.Deadline(); ok {
 		_ = conn.SetDeadline(deadline)
@@ -119,46 +228,9 @@ func captureRFBFrameFromConn(ctx context.Context, conn net.Conn, creds rfbCreden
 		_ = conn.SetDeadline(time.Now().Add(30 * time.Second))
 	}
 
-	version := make([]byte, 12)
-	if _, err := io.ReadFull(conn, version); err != nil {
-		return nil, fmt.Errorf("read RFB version: %w", err)
-	}
-	if !bytes.HasPrefix(version, []byte("RFB ")) {
-		return nil, fmt.Errorf("unexpected RFB version %q", string(version))
-	}
-	if _, err := conn.Write([]byte("RFB 003.008\n")); err != nil {
-		return nil, fmt.Errorf("write RFB version: %w", err)
-	}
-
-	securityType, err := negotiateRFBSecurityType(conn)
+	width, height, err := initializeRFBConnection(conn, creds)
 	if err != nil {
 		return nil, err
-	}
-	switch securityType {
-	case rfbSecurityNone:
-	case rfbSecurityARD:
-		if err := negotiateRFBARDAuth(conn, creds); err != nil {
-			return nil, err
-		}
-	default:
-		return nil, fmt.Errorf("unsupported RFB security type %d", securityType)
-	}
-	if err := readRFBSecurityResult(conn); err != nil {
-		return nil, err
-	}
-
-	if _, err := conn.Write([]byte{1}); err != nil {
-		return nil, fmt.Errorf("write RFB client init: %w", err)
-	}
-	width, height, err := readRFBServerInit(conn)
-	if err != nil {
-		return nil, err
-	}
-	if width == 0 || height == 0 {
-		return nil, fmt.Errorf("server reported empty framebuffer %dx%d", width, height)
-	}
-	if int(width)*int(height) > 16_000_000 {
-		return nil, fmt.Errorf("framebuffer %dx%d is too large", width, height)
 	}
 
 	if err := writeRFBPixelFormat(conn); err != nil {
@@ -173,7 +245,93 @@ func captureRFBFrameFromConn(ctx context.Context, conn net.Conn, creds rfbCreden
 	return readRFBFramebufferUpdate(conn, int(width), int(height))
 }
 
-func negotiateRFBSecurityType(conn net.Conn) (byte, error) {
+func initializeRFBConnection(conn net.Conn, creds rfbCredentials) (uint16, uint16, error) {
+	version := make([]byte, 12)
+	if _, err := io.ReadFull(conn, version); err != nil {
+		return 0, 0, fmt.Errorf("read RFB version: %w", err)
+	}
+	if !bytes.HasPrefix(version, []byte("RFB ")) {
+		return 0, 0, fmt.Errorf("unexpected RFB version %q", string(version))
+	}
+	if _, err := conn.Write([]byte("RFB 003.008\n")); err != nil {
+		return 0, 0, fmt.Errorf("write RFB version: %w", err)
+	}
+
+	securityType, err := negotiateRFBSecurityType(conn, creds)
+	if err != nil {
+		return 0, 0, err
+	}
+	switch securityType {
+	case rfbSecurityNone:
+	case rfbSecurityVNC:
+		if err := negotiateRFBVNCAuth(conn, creds); err != nil {
+			return 0, 0, err
+		}
+	case rfbSecurityARD:
+		if err := negotiateRFBARDAuth(conn, creds); err != nil {
+			return 0, 0, err
+		}
+	default:
+		return 0, 0, fmt.Errorf("unsupported RFB security type %d", securityType)
+	}
+	if err := readRFBSecurityResult(conn); err != nil {
+		return 0, 0, err
+	}
+
+	if _, err := conn.Write([]byte{1}); err != nil {
+		return 0, 0, fmt.Errorf("write RFB client init: %w", err)
+	}
+	width, height, err := readRFBServerInit(conn)
+	if err != nil {
+		return 0, 0, err
+	}
+	if width == 0 || height == 0 {
+		return 0, 0, fmt.Errorf("server reported empty framebuffer %dx%d", width, height)
+	}
+	if int(width)*int(height) > 16_000_000 {
+		return 0, 0, fmt.Errorf("framebuffer %dx%d is too large", width, height)
+	}
+	return width, height, nil
+}
+
+func writeRFBPointerEvent(conn net.Conn, buttonMask byte, x, y int) error {
+	message := []byte{5, buttonMask, 0, 0, 0, 0}
+	binary.BigEndian.PutUint16(message[2:4], uint16(x))
+	binary.BigEndian.PutUint16(message[4:6], uint16(y))
+	if _, err := conn.Write(message); err != nil {
+		return fmt.Errorf("write RFB pointer event: %w", err)
+	}
+	return nil
+}
+
+func writeRFBClientCutText(conn net.Conn, text string) error {
+	if len(text) > 1<<20 {
+		return fmt.Errorf("RFB clipboard text is too large")
+	}
+	message := make([]byte, 8+len(text))
+	message[0] = 6
+	binary.BigEndian.PutUint32(message[4:8], uint32(len(text)))
+	copy(message[8:], text)
+	if _, err := conn.Write(message); err != nil {
+		return fmt.Errorf("write RFB clipboard text: %w", err)
+	}
+	return nil
+}
+
+func writeRFBKeyEvent(conn net.Conn, down bool, key uint32) error {
+	message := make([]byte, 8)
+	message[0] = 4
+	if down {
+		message[1] = 1
+	}
+	binary.BigEndian.PutUint32(message[4:8], key)
+	if _, err := conn.Write(message); err != nil {
+		return fmt.Errorf("write RFB key event: %w", err)
+	}
+	return nil
+}
+
+func negotiateRFBSecurityType(conn net.Conn, creds rfbCredentials) (byte, error) {
 	count := []byte{0}
 	if _, err := io.ReadFull(conn, count); err != nil {
 		return 0, fmt.Errorf("read RFB security type count: %w", err)
@@ -189,16 +347,52 @@ func negotiateRFBSecurityType(conn net.Conn) (byte, error) {
 	if _, err := io.ReadFull(conn, types); err != nil {
 		return 0, fmt.Errorf("read RFB security types: %w", err)
 	}
-	for _, preferred := range types {
-		switch preferred {
-		case rfbSecurityARD, rfbSecurityNone:
-			if _, err := conn.Write([]byte{preferred}); err != nil {
+	preferences := []byte{rfbSecurityARD, rfbSecurityVNC, rfbSecurityNone}
+	if creds.Username == "" {
+		preferences = []byte{rfbSecurityVNC, rfbSecurityARD, rfbSecurityNone}
+	}
+	if creds.Password == "" {
+		preferences = []byte{rfbSecurityNone, rfbSecurityARD, rfbSecurityVNC}
+	}
+	for _, preferred := range preferences {
+		for _, offered := range types {
+			if offered != preferred {
+				continue
+			}
+			if _, err := conn.Write([]byte{offered}); err != nil {
 				return 0, fmt.Errorf("write RFB security type: %w", err)
 			}
-			return preferred, nil
+			return offered, nil
 		}
 	}
 	return 0, fmt.Errorf("unsupported RFB security types %v", types)
+}
+
+func negotiateRFBVNCAuth(conn net.Conn, creds rfbCredentials) error {
+	if creds.Password == "" {
+		return fmt.Errorf("VNC password is required")
+	}
+	challenge := make([]byte, 16)
+	if _, err := io.ReadFull(conn, challenge); err != nil {
+		return fmt.Errorf("read VNC auth challenge: %w", err)
+	}
+	var key [8]byte
+	copy(key[:], []byte(creds.Password))
+	for i := range key {
+		key[i] = bits.Reverse8(key[i])
+	}
+	cipher, err := des.NewCipher(key[:])
+	if err != nil {
+		return fmt.Errorf("create VNC auth cipher: %w", err)
+	}
+	response := make([]byte, len(challenge))
+	for offset := 0; offset < len(challenge); offset += cipher.BlockSize() {
+		cipher.Encrypt(response[offset:offset+cipher.BlockSize()], challenge[offset:offset+cipher.BlockSize()])
+	}
+	if _, err := conn.Write(response); err != nil {
+		return fmt.Errorf("write VNC auth response: %w", err)
+	}
+	return nil
 }
 
 func negotiateRFBARDAuth(conn net.Conn, creds rfbCredentials) error {

--- a/internal/cli/rfb_screenshot.go
+++ b/internal/cli/rfb_screenshot.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 const (
@@ -94,7 +95,7 @@ func clickRemoteMacVNC(ctx context.Context, cfg Config, target SSHTarget, x, y i
 	return nil
 }
 
-func pasteRemoteMacVNC(ctx context.Context, cfg Config, target SSHTarget, text string) error {
+func typeRemoteMacVNC(ctx context.Context, cfg Config, target SSHTarget, text string) error {
 	tunnel, localPort, err := startVNCForegroundTunnelOnReservedPort(ctx, target, "", "127.0.0.1", managedVNCPort)
 	if err != nil {
 		return err
@@ -105,8 +106,8 @@ func pasteRemoteMacVNC(ctx context.Context, cfg Config, target SSHTarget, text s
 	if err != nil {
 		return err
 	}
-	if err := pasteRFBClipboard(ctx, "127.0.0.1:"+localPort, creds, text); err != nil {
-		return fmt.Errorf("paste macOS VNC clipboard: %w", err)
+	if err := typeRFBText(ctx, "127.0.0.1:"+localPort, creds, text); err != nil {
+		return fmt.Errorf("type macOS VNC text: %w", err)
 	}
 	return nil
 }
@@ -158,17 +159,20 @@ func clickRFBPointer(ctx context.Context, address string, creds rfbCredentials, 
 	return clickRFBPointerFromConn(ctx, conn, creds, x, y)
 }
 
-func pasteRFBClipboard(ctx context.Context, address string, creds rfbCredentials, text string) error {
+func typeRFBText(ctx context.Context, address string, creds rfbCredentials, text string) error {
 	dialer := net.Dialer{Timeout: 10 * time.Second}
 	conn, err := dialer.DialContext(ctx, "tcp", address)
 	if err != nil {
 		return err
 	}
 	defer conn.Close()
-	return pasteRFBClipboardFromConn(ctx, conn, creds, text)
+	return typeRFBTextFromConn(ctx, conn, creds, text)
 }
 
-func pasteRFBClipboardFromConn(ctx context.Context, conn net.Conn, creds rfbCredentials, text string) error {
+func typeRFBTextFromConn(ctx context.Context, conn net.Conn, creds rfbCredentials, text string) error {
+	if !utf8.ValidString(text) {
+		return fmt.Errorf("RFB text is not valid UTF-8")
+	}
 	if deadline, ok := ctx.Deadline(); ok {
 		_ = conn.SetDeadline(deadline)
 	} else {
@@ -177,24 +181,38 @@ func pasteRFBClipboardFromConn(ctx context.Context, conn net.Conn, creds rfbCred
 	if _, _, err := initializeRFBConnection(conn, creds); err != nil {
 		return err
 	}
-	if err := writeRFBClientCutText(conn, text); err != nil {
-		return err
-	}
-	time.Sleep(100 * time.Millisecond)
-	const (
-		xkSuperL = 0xffeb
-		xkV      = 0x76
-	)
-	for _, event := range []struct {
-		down bool
-		key  uint32
-	}{{true, xkSuperL}, {true, xkV}, {false, xkV}, {false, xkSuperL}} {
-		if err := writeRFBKeyEvent(conn, event.down, event.key); err != nil {
+	for _, r := range text {
+		key, err := rfbKeysymForRune(r)
+		if err != nil {
+			return err
+		}
+		if err := writeRFBKeyEvent(conn, true, key); err != nil {
+			return err
+		}
+		if err := writeRFBKeyEvent(conn, false, key); err != nil {
 			return err
 		}
 	}
-	time.Sleep(250 * time.Millisecond)
+	time.Sleep(50 * time.Millisecond)
 	return nil
+}
+
+func rfbKeysymForRune(r rune) (uint32, error) {
+	switch r {
+	case '\n', '\r':
+		return 0xff0d, nil // XK_Return
+	case '\t':
+		return 0xff09, nil // XK_Tab
+	case '\b':
+		return 0xff08, nil // XK_BackSpace
+	}
+	if r < 0x20 || r == 0x7f {
+		return 0, fmt.Errorf("RFB typing does not support control character U+%04X", r)
+	}
+	if r <= 0xff {
+		return uint32(r), nil
+	}
+	return 0x01000000 | uint32(r), nil
 }
 
 func clickRFBPointerFromConn(ctx context.Context, conn net.Conn, creds rfbCredentials, x, y int) error {
@@ -295,25 +313,14 @@ func initializeRFBConnection(conn net.Conn, creds rfbCredentials) (uint16, uint1
 }
 
 func writeRFBPointerEvent(conn net.Conn, buttonMask byte, x, y int) error {
+	if x < 0 || y < 0 || x > 0xffff || y > 0xffff {
+		return fmt.Errorf("RFB pointer coordinates %d,%d are outside the uint16 protocol range", x, y)
+	}
 	message := []byte{5, buttonMask, 0, 0, 0, 0}
 	binary.BigEndian.PutUint16(message[2:4], uint16(x))
 	binary.BigEndian.PutUint16(message[4:6], uint16(y))
 	if _, err := conn.Write(message); err != nil {
 		return fmt.Errorf("write RFB pointer event: %w", err)
-	}
-	return nil
-}
-
-func writeRFBClientCutText(conn net.Conn, text string) error {
-	if len(text) > 1<<20 {
-		return fmt.Errorf("RFB clipboard text is too large")
-	}
-	message := make([]byte, 8+len(text))
-	message[0] = 6
-	binary.BigEndian.PutUint32(message[4:8], uint32(len(text)))
-	copy(message[8:], text)
-	if _, err := conn.Write(message); err != nil {
-		return fmt.Errorf("write RFB clipboard text: %w", err)
 	}
 	return nil
 }
@@ -387,7 +394,9 @@ func negotiateRFBVNCAuth(conn net.Conn, creds rfbCredentials) error {
 	}
 	response := make([]byte, len(challenge))
 	for offset := 0; offset < len(challenge); offset += cipher.BlockSize() {
-		cipher.Encrypt(response[offset:offset+cipher.BlockSize()], challenge[offset:offset+cipher.BlockSize()])
+		// RFB VNC Authentication mandates DES for protocol compatibility; it is
+		// not used here to protect application data or stored credentials.
+		cipher.Encrypt(response[offset:offset+cipher.BlockSize()], challenge[offset:offset+cipher.BlockSize()]) // lgtm[go/weak-cryptographic-algorithm]
 	}
 	if _, err := conn.Write(response); err != nil {
 		return fmt.Errorf("write VNC auth response: %w", err)

--- a/internal/cli/rfb_screenshot.go
+++ b/internal/cli/rfb_screenshot.go
@@ -24,10 +24,11 @@ import (
 )
 
 const (
-	rfbSecurityNone = 1
-	rfbSecurityVNC  = 2
-	rfbSecurityARD  = 30
-	rfbEncodingRaw  = 0
+	rfbSecurityNone  = 1
+	rfbSecurityVNC   = 2
+	rfbSecurityARD   = 30
+	rfbEncodingRaw   = 0
+	rfbKeyEventDelay = 5 * time.Millisecond
 )
 
 type rfbCredentials struct {
@@ -189,9 +190,11 @@ func typeRFBTextFromConn(ctx context.Context, conn net.Conn, creds rfbCredential
 		if err := writeRFBKeyEvent(conn, true, key); err != nil {
 			return err
 		}
+		time.Sleep(rfbKeyEventDelay)
 		if err := writeRFBKeyEvent(conn, false, key); err != nil {
 			return err
 		}
+		time.Sleep(rfbKeyEventDelay)
 	}
 	time.Sleep(50 * time.Millisecond)
 	return nil

--- a/internal/cli/rfb_screenshot_test.go
+++ b/internal/cli/rfb_screenshot_test.go
@@ -151,6 +151,12 @@ func TestRFBKeysymForRuneRejectsUnsupportedControl(t *testing.T) {
 	}
 }
 
+func TestRFBTextKeyEventsArePaced(t *testing.T) {
+	if rfbKeyEventDelay < time.Millisecond {
+		t.Fatalf("RFB key event delay %s is too short for macOS Screen Sharing", rfbKeyEventDelay)
+	}
+}
+
 func TestRFBPasswordOnlyCredentialsPreferVNCAuth(t *testing.T) {
 	client, server := net.Pipe()
 	defer client.Close()

--- a/internal/cli/rfb_screenshot_test.go
+++ b/internal/cli/rfb_screenshot_test.go
@@ -4,12 +4,14 @@ import (
 	"bytes"
 	"context"
 	"crypto/aes"
+	"crypto/des"
 	"crypto/md5"
 	"encoding/binary"
 	"flag"
 	"image/color"
 	"io"
 	"math/big"
+	"math/bits"
 	"net"
 	"testing"
 	"time"
@@ -93,6 +95,207 @@ func TestCaptureRFBFrameReadsNoneAuthSecurityResult(t *testing.T) {
 	if got := color.RGBAModel.Convert(img.At(0, 0)); got != (color.RGBA{B: 255, A: 255}) {
 		t.Fatalf("pixel=%v", got)
 	}
+}
+
+func TestClickRFBPointerSendsPressAndRelease(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	serverErr := make(chan error, 1)
+	go func() {
+		serverErr <- serveTestPointerRFB(server, 12, 34)
+	}()
+
+	if err := clickRFBPointerFromConn(context.Background(), client, rfbCredentials{}, 12, 34); err != nil {
+		t.Fatalf("click RFB pointer: %v", err)
+	}
+	if err := <-serverErr; err != nil {
+		t.Fatalf("fake RFB server: %v", err)
+	}
+}
+
+func TestPasteRFBClipboardSendsCutTextAndCommandV(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	serverErr := make(chan error, 1)
+	go func() {
+		serverErr <- serveTestClipboardRFB(server, "Issue or Pull request")
+	}()
+
+	if err := pasteRFBClipboardFromConn(context.Background(), client, rfbCredentials{}, "Issue or Pull request"); err != nil {
+		t.Fatalf("paste RFB clipboard: %v", err)
+	}
+	if err := <-serverErr; err != nil {
+		t.Fatalf("fake RFB server: %v", err)
+	}
+}
+
+func TestWriteRFBClientCutTextRejectsOversizedText(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+	if err := writeRFBClientCutText(client, string(make([]byte, (1<<20)+1))); err == nil {
+		t.Fatal("oversized clipboard text should be rejected")
+	}
+}
+
+func TestRFBPasswordOnlyCredentialsPreferVNCAuth(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	serverErr := make(chan error, 1)
+	go func() {
+		if _, err := server.Write([]byte{2, rfbSecurityARD, rfbSecurityVNC}); err != nil {
+			serverErr <- err
+			return
+		}
+		selected := []byte{0}
+		if _, err := io.ReadFull(server, selected); err != nil {
+			serverErr <- err
+			return
+		}
+		if selected[0] != rfbSecurityVNC {
+			serverErr <- errUnexpectedTestBytes("security type", selected)
+			return
+		}
+		challenge := []byte("0123456789abcdef")
+		if _, err := server.Write(challenge); err != nil {
+			serverErr <- err
+			return
+		}
+		response := make([]byte, len(challenge))
+		if _, err := io.ReadFull(server, response); err != nil {
+			serverErr <- err
+			return
+		}
+		key := []byte("password")
+		for i := range key {
+			key[i] = bits.Reverse8(key[i])
+		}
+		cipher, err := des.NewCipher(key)
+		if err != nil {
+			serverErr <- err
+			return
+		}
+		plaintext := make([]byte, len(response))
+		for offset := 0; offset < len(response); offset += cipher.BlockSize() {
+			cipher.Decrypt(plaintext[offset:offset+cipher.BlockSize()], response[offset:offset+cipher.BlockSize()])
+		}
+		if !bytes.Equal(plaintext, challenge) {
+			serverErr <- errUnexpectedTestBytes("VNC auth response", plaintext)
+			return
+		}
+		serverErr <- nil
+	}()
+
+	credentials := rfbCredentials{Password: "password"}
+	securityType, err := negotiateRFBSecurityType(client, credentials)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if securityType != rfbSecurityVNC {
+		t.Fatalf("security type = %d", securityType)
+	}
+	if err := negotiateRFBVNCAuth(client, credentials); err != nil {
+		t.Fatal(err)
+	}
+	if err := <-serverErr; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func serveTestPointerRFB(conn net.Conn, wantX, wantY int) error {
+	if err := serveTestInputRFBInit(conn); err != nil {
+		return err
+	}
+
+	wantMasks := []byte{0, 1, 0}
+	for _, wantMask := range wantMasks {
+		event := make([]byte, 6)
+		if _, err := io.ReadFull(conn, event); err != nil {
+			return err
+		}
+		if event[0] != 5 || event[1] != wantMask || int(binary.BigEndian.Uint16(event[2:4])) != wantX || int(binary.BigEndian.Uint16(event[4:6])) != wantY {
+			return errUnexpectedTestBytes("pointer event", event)
+		}
+	}
+	return nil
+}
+
+func serveTestClipboardRFB(conn net.Conn, wantText string) error {
+	if err := serveTestInputRFBInit(conn); err != nil {
+		return err
+	}
+	message := make([]byte, 8+len(wantText))
+	if _, err := io.ReadFull(conn, message); err != nil {
+		return err
+	}
+	if message[0] != 6 || !bytes.Equal(message[1:4], []byte{0, 0, 0}) || binary.BigEndian.Uint32(message[4:8]) != uint32(len(wantText)) || string(message[8:]) != wantText {
+		return errUnexpectedTestBytes("clipboard message", message)
+	}
+	wantKeys := []struct {
+		down bool
+		key  uint32
+	}{{true, 0xffeb}, {true, 0x76}, {false, 0x76}, {false, 0xffeb}}
+	for _, want := range wantKeys {
+		event := make([]byte, 8)
+		if _, err := io.ReadFull(conn, event); err != nil {
+			return err
+		}
+		wantDown := byte(0)
+		if want.down {
+			wantDown = 1
+		}
+		if event[0] != 4 || event[1] != wantDown || !bytes.Equal(event[2:4], []byte{0, 0}) || binary.BigEndian.Uint32(event[4:8]) != want.key {
+			return errUnexpectedTestBytes("key event", event)
+		}
+	}
+	return nil
+}
+
+func serveTestInputRFBInit(conn net.Conn) error {
+	_ = conn.SetDeadline(time.Now().Add(10 * time.Second))
+	if _, err := conn.Write([]byte("RFB 003.008\n")); err != nil {
+		return err
+	}
+	clientVersion := make([]byte, 12)
+	if _, err := io.ReadFull(conn, clientVersion); err != nil {
+		return err
+	}
+	if !bytes.Equal(clientVersion, []byte("RFB 003.008\n")) {
+		return errUnexpectedTestBytes("client version", clientVersion)
+	}
+	if _, err := conn.Write([]byte{1, rfbSecurityNone}); err != nil {
+		return err
+	}
+	security := []byte{0}
+	if _, err := io.ReadFull(conn, security); err != nil {
+		return err
+	}
+	if security[0] != rfbSecurityNone {
+		return errUnexpectedTestBytes("security type", security)
+	}
+	if _, err := conn.Write([]byte{0, 0, 0, 0}); err != nil {
+		return err
+	}
+	clientInit := []byte{0}
+	if _, err := io.ReadFull(conn, clientInit); err != nil {
+		return err
+	}
+	serverInit := make([]byte, 24)
+	binary.BigEndian.PutUint16(serverInit[0:2], 100)
+	binary.BigEndian.PutUint16(serverInit[2:4], 80)
+	serverInit[4] = 32
+	serverInit[5] = 24
+	serverInit[7] = 1
+	if _, err := conn.Write(serverInit); err != nil {
+		return err
+	}
+	return nil
 }
 
 func serveTestARDRFB(conn net.Conn, username, password string) error {

--- a/internal/cli/rfb_screenshot_test.go
+++ b/internal/cli/rfb_screenshot_test.go
@@ -115,30 +115,39 @@ func TestClickRFBPointerSendsPressAndRelease(t *testing.T) {
 	}
 }
 
-func TestPasteRFBClipboardSendsCutTextAndCommandV(t *testing.T) {
+func TestWriteRFBPointerEventRejectsProtocolOverflow(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+	for _, point := range [][2]int{{-1, 0}, {0, -1}, {1 << 16, 0}, {0, 1 << 16}} {
+		if err := writeRFBPointerEvent(client, 0, point[0], point[1]); err == nil {
+			t.Errorf("pointer coordinates %d,%d should be rejected", point[0], point[1])
+		}
+	}
+}
+
+func TestTypeRFBTextSendsExactKeyEvents(t *testing.T) {
 	client, server := net.Pipe()
 	defer client.Close()
 	defer server.Close()
 
+	const text = "Aa !\n\té🦀"
 	serverErr := make(chan error, 1)
 	go func() {
-		serverErr <- serveTestClipboardRFB(server, "Issue or Pull request")
+		serverErr <- serveTestTypeRFB(server, []uint32{0x41, 0x61, 0x20, 0x21, 0xff0d, 0xff09, 0xe9, 0x0101f980})
 	}()
 
-	if err := pasteRFBClipboardFromConn(context.Background(), client, rfbCredentials{}, "Issue or Pull request"); err != nil {
-		t.Fatalf("paste RFB clipboard: %v", err)
+	if err := typeRFBTextFromConn(context.Background(), client, rfbCredentials{}, text); err != nil {
+		t.Fatalf("type RFB text: %v", err)
 	}
 	if err := <-serverErr; err != nil {
 		t.Fatalf("fake RFB server: %v", err)
 	}
 }
 
-func TestWriteRFBClientCutTextRejectsOversizedText(t *testing.T) {
-	client, server := net.Pipe()
-	defer client.Close()
-	defer server.Close()
-	if err := writeRFBClientCutText(client, string(make([]byte, (1<<20)+1))); err == nil {
-		t.Fatal("oversized clipboard text should be rejected")
+func TestRFBKeysymForRuneRejectsUnsupportedControl(t *testing.T) {
+	if _, err := rfbKeysymForRune(0x1b); err == nil {
+		t.Fatal("Escape control character should be rejected")
 	}
 }
 
@@ -226,32 +235,19 @@ func serveTestPointerRFB(conn net.Conn, wantX, wantY int) error {
 	return nil
 }
 
-func serveTestClipboardRFB(conn net.Conn, wantText string) error {
+func serveTestTypeRFB(conn net.Conn, wantKeys []uint32) error {
 	if err := serveTestInputRFBInit(conn); err != nil {
 		return err
 	}
-	message := make([]byte, 8+len(wantText))
-	if _, err := io.ReadFull(conn, message); err != nil {
-		return err
-	}
-	if message[0] != 6 || !bytes.Equal(message[1:4], []byte{0, 0, 0}) || binary.BigEndian.Uint32(message[4:8]) != uint32(len(wantText)) || string(message[8:]) != wantText {
-		return errUnexpectedTestBytes("clipboard message", message)
-	}
-	wantKeys := []struct {
-		down bool
-		key  uint32
-	}{{true, 0xffeb}, {true, 0x76}, {false, 0x76}, {false, 0xffeb}}
-	for _, want := range wantKeys {
-		event := make([]byte, 8)
-		if _, err := io.ReadFull(conn, event); err != nil {
-			return err
-		}
-		wantDown := byte(0)
-		if want.down {
-			wantDown = 1
-		}
-		if event[0] != 4 || event[1] != wantDown || !bytes.Equal(event[2:4], []byte{0, 0}) || binary.BigEndian.Uint32(event[4:8]) != want.key {
-			return errUnexpectedTestBytes("key event", event)
+	for _, wantKey := range wantKeys {
+		for _, wantDown := range []byte{1, 0} {
+			event := make([]byte, 8)
+			if _, err := io.ReadFull(conn, event); err != nil {
+				return err
+			}
+			if event[0] != 4 || event[1] != wantDown || !bytes.Equal(event[2:4], []byte{0, 0}) || binary.BigEndian.Uint32(event[4:8]) != wantKey {
+				return errUnexpectedTestBytes("key event", event)
+			}
 		}
 	}
 	return nil

--- a/internal/cli/webvnc.go
+++ b/internal/cli/webvnc.go
@@ -2581,14 +2581,19 @@ func guardMacOSDirectWebVNC(cfg Config) error {
 	return exit(2, "this webvnc subcommand is not available for macOS leases; run `crabbox webvnc --id <id>` for the host-side browser viewer, or use a native VNC client over an SSH tunnel:\n  ssh -o GatewayPorts=no -L 127.0.0.1:5900:127.0.0.1:5900 %s@<lease-ip>\n  open vnc://127.0.0.1:5900", blank(cfg.SSHUser, "<user>"))
 }
 
-// isMacOSDesktopProvider reports whether the lease belongs to a provider whose
-// ONLY target is macOS (e.g. tart) — those use the host-side Screen Sharing
-// bridge. It is keyed off the provider spec (not the resolved cfg.TargetOS,
-// which the webvnc subcommands don't always populate) so every entrypoint
-// classifies uniformly. Multi-target providers (e.g. parallels, which also
-// serves Linux/Windows) keep the existing WebVNC path even for their macOS
-// leases, so a single macOS target must not divert them into the tart bridge.
+// isMacOSDesktopProvider reports whether the resolved lease uses macOS native
+// Screen Sharing. An explicit target wins for multi-target providers such as
+// Parallels; provider-spec inference covers entrypoints that have not resolved
+// the target yet, such as Tart's macOS-only profile.
 func isMacOSDesktopProvider(cfg Config) bool {
+	switch strings.ToLower(strings.TrimSpace(cfg.TargetOS)) {
+	case targetMacOS:
+		return true
+	case "":
+		// Fall through to provider-spec inference.
+	default:
+		return false
+	}
 	p, err := ProviderFor(cfg.Provider)
 	if err != nil {
 		return false

--- a/internal/cli/webvnc_test.go
+++ b/internal/cli/webvnc_test.go
@@ -393,18 +393,21 @@ func TestRegisteredLeaseUsesCoordinatorWebVNC(t *testing.T) {
 	}
 }
 
-func TestIsMacOSDesktopProviderOnlyDedicatedMacOS(t *testing.T) {
+func TestIsMacOSDesktopProviderUsesExplicitTargetOrDedicatedProvider(t *testing.T) {
 	// tart's only target is macOS -> uses the host-side Screen Sharing bridge.
 	if !isMacOSDesktopProvider(Config{Provider: "tart"}) {
 		t.Error("tart (dedicated macOS provider) should route to the macOS bridge")
 	}
-	// parallels is multi-target (macOS + Linux + Windows); it must NOT be diverted
-	// into the tart bridge, even for a macOS lease — regression guard.
+	// Parallels needs an explicit resolved target because it also serves Linux
+	// and Windows leases.
 	if isMacOSDesktopProvider(Config{Provider: "parallels"}) {
-		t.Error("parallels (multi-target) must not route to the macOS bridge")
+		t.Error("unresolved parallels target must not route to the macOS bridge")
 	}
-	if isMacOSDesktopProvider(Config{Provider: "parallels", TargetOS: targetMacOS}) {
-		t.Error("a macOS parallels lease must still use the existing WebVNC path")
+	if !isMacOSDesktopProvider(Config{Provider: "parallels", TargetOS: targetMacOS}) {
+		t.Error("a macOS parallels lease should route to the native Screen Sharing bridge")
+	}
+	if isMacOSDesktopProvider(Config{Provider: "parallels", TargetOS: targetLinux}) {
+		t.Error("a Linux parallels lease must keep the guest WebVNC path")
 	}
 }
 


### PR DESCRIPTION
## Summary

- route Parallels macOS desktop sessions through the host-side WebVNC bridge with managed credentials
- add authenticated RFB screenshots, pointer clicks, and direct keyboard input for paste/type commands
- make local VNC tunnels collision-safe and prefer active XWayland input where available
- enable Screen Sharing during macOS guest preparation and avoid unsafe duplicate typing after partial paste failures

## Tests

- `go test ./internal/cli -run 'Test(Desktop|ResolveMacOSWebVNC|ParallelsEnsureGuestReadyEnablesMacOSScreenSharing|CaptureRFB|ClickRFB|TypeRFB|WriteRFB|RFBKeysym|RFBPasswordOnly|IsMacOSDesktopProvider)' -count=1 -timeout=3m`
- `git diff --check`
