### PR TITLE
fix(worker): revoke backend agents with manager grants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Bound accepted WebVNC and Code backend agents to the manager grant that created them, closing attributable agents after share or credential revocation while preserving pre-upgrade hibernated sockets. Thanks @coygeek.
 - Bound non-admin shared-token WebVNC, Code, and egress bridges to the credential active at ticket creation, closing active and restored sessions after token rotation or removal. Thanks @coygeek.
 - Made Parallels macOS WebVNC use managed VNC credentials, authenticated screenshots, pointer and direct keyboard input, explicit host-side macOS routing, collision-safe local tunnels, XWayland-aware desktop input, and safe clipboard fallback.
 - Started delegated-provider sync timeouts at archive creation, matching SSH sync semantics and avoiding pre-transfer expiry during local Git manifest planning.

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -749,7 +749,15 @@ interface AzureOrphanSweepRecord {
 }
 
 type BridgeAttachment =
-  | { kind: "webvnc-agent"; leaseID: string; id: string; capabilities: Set<string> }
+  | (CachedBridgeGrant & {
+      kind: "webvnc-agent";
+      leaseID: string;
+      id: string;
+      capabilities: Set<string>;
+      owner?: string;
+      org?: string;
+      admin?: boolean;
+    })
   | (CachedBridgeGrant & {
       kind: "webvnc-viewer";
       leaseID: string;
@@ -760,7 +768,13 @@ type BridgeAttachment =
       admin?: boolean;
       label: string;
     })
-  | { kind: "code-agent"; leaseID: string }
+  | (CachedBridgeGrant & {
+      kind: "code-agent";
+      leaseID: string;
+      owner?: string;
+      org?: string;
+      admin?: boolean;
+    })
   | (CachedBridgeGrant & {
       kind: "code-viewer";
       leaseID: string;
@@ -1224,15 +1238,36 @@ export class FleetCoordinator {
       socket: WebSocket;
       attachment: Extract<
         BridgeAttachment,
-        { kind: "webvnc-viewer" | "code-viewer" | "egress-host" | "egress-client" }
+        {
+          kind:
+            | "webvnc-agent"
+            | "webvnc-viewer"
+            | "code-agent"
+            | "code-viewer"
+            | "egress-host"
+            | "egress-client";
+        }
       >;
     }> = [];
     const sharedBridgesToCheck: Array<{
       socket: WebSocket;
       attachment: Extract<
         BridgeAttachment,
-        { kind: "webvnc-viewer" | "code-viewer" | "egress-host" | "egress-client" }
+        {
+          kind:
+            | "webvnc-agent"
+            | "webvnc-viewer"
+            | "code-agent"
+            | "code-viewer"
+            | "egress-host"
+            | "egress-client";
+        }
       >;
+    }> = [];
+    const adminPortalAgentsToCheck: Array<{
+      socket: WebSocket;
+      attachment: Extract<BridgeAttachment, { kind: "webvnc-agent" | "code-agent" }>;
+      portalSessionHash: string;
     }> = [];
     for (const socket of this.restoredBridgeSockets) {
       const attachment = this.bridgeAttachment(socket);
@@ -1255,10 +1290,29 @@ export class FleetCoordinator {
         continue;
       }
       if (
+        (attachment.kind === "webvnc-agent" || attachment.kind === "code-agent") &&
+        attachment.admin === true &&
+        validPortalSessionHash(attachment.portalSessionHash)
+      ) {
+        adminPortalAgentsToCheck.push({
+          socket,
+          attachment,
+          portalSessionHash: attachment.portalSessionHash,
+        });
+      }
+      if (
         (attachment.kind === "webvnc-viewer" || attachment.kind === "code-viewer") &&
         !this.leaseViewerAuthorized(lease, attachment)
       ) {
         revokedViewers.set(socket, "lease access revoked");
+      }
+      if (
+        (attachment.kind === "webvnc-agent" || attachment.kind === "code-agent") &&
+        completeBridgePrincipal(attachment) &&
+        !this.leaseManagerAuthorized(lease, attachment)
+      ) {
+        revokedViewers.set(socket, "lease access revoked");
+        continue;
       }
       if (
         (attachment.kind === "egress-host" || attachment.kind === "egress-client") &&
@@ -1291,34 +1345,50 @@ export class FleetCoordinator {
           }
           continue;
         }
-        if (attachment.auth === "github" && attachment.admin !== true) {
+        if (
+          attachment.auth === "github" &&
+          (attachment.admin !== true ||
+            attachment.kind === "webvnc-agent" ||
+            attachment.kind === "code-agent")
+        ) {
           githubBridgesToCheck.push({ socket, attachment });
         } else if (attachment.auth === "bearer" && attachment.admin !== true) {
           sharedBridgesToCheck.push({ socket, attachment });
         }
       }
     }
-    const [githubBridgeRevocations, sharedBridgeRevocations] = await Promise.all([
-      Promise.all(
-        githubBridgesToCheck.map(async ({ socket, attachment }) => ({
-          socket,
-          attachment,
-          reason: await this.githubBridgeGrantFailureReason(attachment),
-        })),
-      ),
-      Promise.all(
-        sharedBridgesToCheck.map(async ({ socket, attachment }) => ({
-          socket,
-          attachment,
-          reason: (await this.sharedBridgeGrantIsCurrent(attachment))
-            ? undefined
-            : "shared access revoked",
-        })),
-      ),
-    ]);
+    const [githubBridgeRevocations, sharedBridgeRevocations, adminPortalAgentRevocations] =
+      await Promise.all([
+        Promise.all(
+          githubBridgesToCheck.map(async ({ socket, attachment }) => ({
+            socket,
+            attachment,
+            reason: await this.githubBridgeGrantFailureReason(attachment),
+          })),
+        ),
+        Promise.all(
+          sharedBridgesToCheck.map(async ({ socket, attachment }) => ({
+            socket,
+            attachment,
+            reason: (await this.sharedBridgeGrantIsCurrent(attachment))
+              ? undefined
+              : "shared access revoked",
+          })),
+        ),
+        Promise.all(
+          adminPortalAgentsToCheck.map(async ({ socket, attachment, portalSessionHash }) => ({
+            socket,
+            attachment,
+            reason: (await this.portalSessionIsRevoked(portalSessionHash))
+              ? "portal session ended"
+              : undefined,
+          })),
+        ),
+      ]);
     for (const { socket, attachment, reason } of [
       ...githubBridgeRevocations,
       ...sharedBridgeRevocations,
+      ...adminPortalAgentRevocations,
     ]) {
       if (!reason) continue;
       if (attachment.kind === "egress-host" || attachment.kind === "egress-client") {
@@ -1360,14 +1430,19 @@ export class FleetCoordinator {
         closeSocket(socket, 1008, reason);
       }
     }
-    for (const [socket, reason] of revokedViewers) {
+    const revokedUserBridges = [...revokedViewers].toSorted(([left], [right]) => {
+      const leftAttachment = this.bridgeAttachment(left);
+      const rightAttachment = this.bridgeAttachment(right);
+      const leftIsAgent =
+        leftAttachment?.kind === "webvnc-agent" || leftAttachment?.kind === "code-agent";
+      const rightIsAgent =
+        rightAttachment?.kind === "webvnc-agent" || rightAttachment?.kind === "code-agent";
+      return Number(leftIsAgent) - Number(rightIsAgent);
+    });
+    for (const [socket, reason] of revokedUserBridges) {
       const attachment = this.bridgeAttachment(socket);
-      if (attachment?.kind === "webvnc-viewer") {
-        this.clearWebVNCViewer(attachment.leaseID, attachment.id, socket);
-        closeSocket(socket, 1008, reason);
-      } else if (attachment?.kind === "code-viewer") {
-        this.clearCodeViewer(attachment.leaseID, attachment.id, socket, 1008, reason);
-        closeSocket(socket, 1008, reason);
+      if (attachment && revocableUserBridge(attachment)) {
+        this.closeRevokedUserBridge(socket, attachment, reason);
       }
     }
     this.restoredBridgeSockets.clear();
@@ -1405,10 +1480,16 @@ export class FleetCoordinator {
     this.currentAdminGrantVersion = version;
     const sockets = new Set<WebSocket>([
       ...this.controlSockets.values(),
+      ...this.codeAgents.values(),
       ...this.codeViewers.values(),
       ...this.egressHosts.values(),
       ...this.egressClients.values(),
     ]);
+    for (const agents of this.webVNCAgents.values()) {
+      for (const socket of agents.values()) {
+        sockets.add(socket);
+      }
+    }
     for (const viewers of this.webVNCViewers.values()) {
       for (const viewer of viewers.values()) {
         sockets.add(viewer.socket);
@@ -1817,15 +1898,17 @@ export class FleetCoordinator {
         }
         await forwardWebVNC(
           message,
-          this.webVNCAgents.get(attachment.leaseID)?.get(attachment.agentID),
+          await this.currentBridgeRecipient(
+            this.webVNCAgents.get(attachment.leaseID)?.get(attachment.agentID),
+          ),
         );
         break;
       case "code-agent":
         await this.handleCodeAgentMessage(attachment.leaseID, message);
         break;
       case "code-viewer": {
-        const agent = this.codeAgents.get(attachment.leaseID);
-        if (agent?.readyState !== WebSocket.OPEN) {
+        const agent = await this.currentBridgeRecipient(this.codeAgents.get(attachment.leaseID));
+        if (!agent) {
           return;
         }
         const data = await normalizeWebVNCData(message);
@@ -1904,7 +1987,9 @@ export class FleetCoordinator {
     if (
       revocableUserBridge(attachment) &&
       attachment.auth === "github" &&
-      attachment.admin !== true
+      (attachment.admin !== true ||
+        attachment.kind === "webvnc-agent" ||
+        attachment.kind === "code-agent")
     ) {
       const now = Date.now();
       const lastValidatedAt = this.userGrantValidationTimes.get(socket) ?? 0;
@@ -1991,7 +2076,15 @@ export class FleetCoordinator {
     socket: WebSocket,
     attachment: Extract<
       BridgeAttachment,
-      { kind: "webvnc-viewer" | "code-viewer" | "egress-host" | "egress-client" }
+      {
+        kind:
+          | "webvnc-agent"
+          | "webvnc-viewer"
+          | "code-agent"
+          | "code-viewer"
+          | "egress-host"
+          | "egress-client";
+      }
     >,
     reason: string,
   ): void {
@@ -5403,6 +5496,29 @@ export class FleetCoordinator {
     const code = 1008;
     const reason = "lease access revoked";
     const adminGrants = await this.currentAdminGrantValidation();
+    for (const agent of this.webVNCAgents.get(lease.id)?.values() ?? []) {
+      const attachment = this.bridgeAttachment(agent);
+      if (
+        attachment?.kind !== "webvnc-agent" ||
+        !completeBridgePrincipal(attachment) ||
+        this.leaseManagerAuthorized(lease, withCurrentAdminGrant(attachment, adminGrants))
+      ) {
+        continue;
+      }
+      this.clearWebVNCAgent(lease.id, attachment.id, agent);
+      closeSocket(agent, code, reason);
+    }
+    const codeAgent = this.codeAgents.get(lease.id);
+    const codeAgentAttachment = codeAgent ? this.bridgeAttachment(codeAgent) : undefined;
+    if (
+      codeAgent &&
+      codeAgentAttachment?.kind === "code-agent" &&
+      completeBridgePrincipal(codeAgentAttachment) &&
+      !this.leaseManagerAuthorized(lease, withCurrentAdminGrant(codeAgentAttachment, adminGrants))
+    ) {
+      this.clearCodeAgent(lease.id, codeAgent);
+      closeSocket(codeAgent, code, reason);
+    }
     for (const viewer of this.openWebVNCViewers(lease.id)) {
       if (this.leaseViewerAuthorized(lease, withCurrentAdminGrant(viewer, adminGrants))) {
         continue;
@@ -6721,7 +6837,7 @@ export class FleetCoordinator {
       if (consumed.status === "not_found") {
         return notFound();
       }
-      const { lease } = consumed;
+      const { lease, ticket } = consumed;
       const error = webVNCLeaseError(lease);
       if (error) {
         return json({ error: "webvnc_unavailable", message: error }, { status: 409 });
@@ -6734,6 +6850,7 @@ export class FleetCoordinator {
       this.trackWebVNCAgent(lease.id, agentID, agent, capabilities);
       this.recordWebVNCEvent(lease.id, "bridge_connected");
       this.acceptBridgeWebSocket(agent, {
+        ...leaseBridgeTicketPrincipal(ticket),
         kind: "webvnc-agent",
         leaseID: lease.id,
         id: agentID,
@@ -7863,8 +7980,10 @@ export class FleetCoordinator {
         { status: 403 },
       );
     }
-    const agentSocket = this.webVNCAgents.get(lease.id)?.get(viewer.agentID);
-    if (!agentSocket || agentSocket.readyState !== WebSocket.OPEN) {
+    const agentSocket = await this.currentBridgeRecipient(
+      this.webVNCAgents.get(lease.id)?.get(viewer.agentID),
+    );
+    if (!agentSocket) {
       return json(
         { error: "webvnc_bridge_missing", message: "No WebVNC backend is available yet." },
         { status: 409 },
@@ -7946,7 +8065,7 @@ export class FleetCoordinator {
       if (consumed.status === "not_found") {
         return notFound();
       }
-      const { lease } = consumed;
+      const { lease, ticket } = consumed;
       const error = codeLeaseError(lease);
       if (error) {
         return json({ error: "code_unavailable", message: error }, { status: 409 });
@@ -7957,7 +8076,11 @@ export class FleetCoordinator {
       closeSocket(this.codeAgents.get(lease.id), 1012, "replaced by a newer code bridge");
       this.clearCodeLease(lease.id);
       this.codeAgents.set(lease.id, agent);
-      this.acceptBridgeWebSocket(agent, { kind: "code-agent", leaseID: lease.id });
+      this.acceptBridgeWebSocket(agent, {
+        ...leaseBridgeTicketPrincipal(ticket),
+        kind: "code-agent",
+        leaseID: lease.id,
+      });
       return upgrade.response;
     });
   }
@@ -8012,7 +8135,7 @@ export class FleetCoordinator {
     if (error) {
       return portalError("Code unavailable", error, 409);
     }
-    const agent = this.codeAgents.get(lease.id);
+    const agent = await this.currentBridgeRecipient(this.codeAgents.get(lease.id));
     if (request.method.toUpperCase() === "GET" && _rest.length === 1 && _rest[0] === "health") {
       return this.codePortalHealth(lease, agent);
     }
@@ -8608,6 +8731,27 @@ export class FleetCoordinator {
       this.clearCodeViewer(attachment.leaseID, id, viewer, 1008, "portal session ended");
       closeSocket(viewer, 1008, "portal session ended");
     }
+    for (const [leaseID, agents] of this.webVNCAgents) {
+      for (const [id, agent] of agents) {
+        const attachment = this.bridgeAttachment(agent);
+        if (
+          attachment?.kind !== "webvnc-agent" ||
+          attachment.portalSessionHash !== portalSessionHash
+        ) {
+          continue;
+        }
+        this.clearWebVNCAgent(leaseID, id, agent);
+        closeSocket(agent, 1008, "portal session ended");
+      }
+    }
+    for (const [leaseID, agent] of this.codeAgents) {
+      const attachment = this.bridgeAttachment(agent);
+      if (attachment?.kind !== "code-agent" || attachment.portalSessionHash !== portalSessionHash) {
+        continue;
+      }
+      this.clearCodeAgent(leaseID, agent);
+      closeSocket(agent, 1008, "portal session ended");
+    }
     const egressSessions = new Map<string, { leaseID: string; sessionID: string }>();
     for (const socket of [...this.egressHosts.values(), ...this.egressClients.values()]) {
       const attachment = this.bridgeAttachment(socket);
@@ -8759,7 +8903,7 @@ export class FleetCoordinator {
           { status: 401 },
         );
       }
-      const agent = this.claimIdleWebVNCAgent(lease.id);
+      const agent = await this.claimIdleWebVNCAgent(lease.id);
       if (!agent) {
         const canManage = this.leaseManageableByRequest(lease, request, isAdminRequest(request));
         const command = canManage ? webVNCBridgeCommand(lease) : "";
@@ -8892,14 +9036,19 @@ export class FleetCoordinator {
     return this.openWebVNCViewers(leaseID).find((viewer) => viewer.agentID === agentID);
   }
 
-  private claimIdleWebVNCAgent(leaseID: string): { id: string; socket: WebSocket } | undefined {
+  private async claimIdleWebVNCAgent(
+    leaseID: string,
+  ): Promise<{ id: string; socket: WebSocket } | undefined> {
     const viewers = this.openWebVNCViewers(leaseID);
-    for (const [id, socket] of this.openWebVNCAgents(leaseID)) {
-      if (!viewers.some((viewer) => viewer.agentID === id)) {
-        return { id, socket };
-      }
-    }
-    return undefined;
+    const candidates = this.openWebVNCAgents(leaseID).filter(
+      ([id]) => !viewers.some((viewer) => viewer.agentID === id),
+    );
+    const current = await Promise.all(
+      candidates.map(async ([id, socket]) =>
+        (await this.currentBridgeRecipient(socket)) ? { id, socket } : undefined,
+      ),
+    );
+    return current.find((agent) => agent !== undefined);
   }
 
   private activeWebVNCControllerID(leaseID: string): string {
@@ -15105,7 +15254,9 @@ function bridgeAttachment(value: unknown): BridgeAttachment | undefined {
         ? attachment
         : undefined;
     case "webvnc-agent":
-      return typeof attachment.leaseID === "string" && validWebVNCSessionID(attachment.id)
+      return typeof attachment.leaseID === "string" &&
+        validWebVNCSessionID(attachment.id) &&
+        validOptionalBridgePrincipal(attachment)
         ? {
             ...attachment,
             capabilities:
@@ -15113,7 +15264,9 @@ function bridgeAttachment(value: unknown): BridgeAttachment | undefined {
           }
         : undefined;
     case "code-agent":
-      return typeof attachment.leaseID === "string" ? attachment : undefined;
+      return typeof attachment.leaseID === "string" && validOptionalBridgePrincipal(attachment)
+        ? attachment
+        : undefined;
     case "code-viewer":
       const serializedCodeViewer = attachment as Omit<typeof attachment, "auth"> & {
         auth?: AuthContext["auth"];
@@ -15194,13 +15347,21 @@ function completeBridgePrincipal(value: {
   );
 }
 
-function revocableUserBridge(
-  attachment: BridgeAttachment,
-): attachment is Extract<
+function revocableUserBridge(attachment: BridgeAttachment): attachment is Extract<
   BridgeAttachment,
-  { kind: "webvnc-viewer" | "code-viewer" | "egress-host" | "egress-client" }
+  {
+    kind:
+      | "webvnc-agent"
+      | "webvnc-viewer"
+      | "code-agent"
+      | "code-viewer"
+      | "egress-host"
+      | "egress-client";
+  }
 > {
   return (
+    ((attachment.kind === "webvnc-agent" || attachment.kind === "code-agent") &&
+      completeBridgePrincipal(attachment)) ||
     attachment.kind === "webvnc-viewer" ||
     attachment.kind === "code-viewer" ||
     attachment.kind === "egress-host" ||

--- a/worker/test/coordinator-runtime.test.ts
+++ b/worker/test/coordinator-runtime.test.ts
@@ -419,14 +419,41 @@ describe("coordinator runtimes", () => {
     expect(runtime.acceptedAttachment).toMatchObject({
       kind: "webvnc-agent",
       leaseID: lease.id,
+      owner: "manager@example.com",
+      org: "example-org",
+      admin: false,
     });
 
     const acceptedCodeTicket = await createTicket("code");
     expect((await connect("code", acceptedCodeTicket)).status).toBe(200);
-    expect(runtime.acceptedAttachment).toEqual({ kind: "code-agent", leaseID: lease.id });
+    expect(runtime.acceptedAttachment).toEqual({
+      kind: "code-agent",
+      leaseID: lease.id,
+      owner: "manager@example.com",
+      org: "example-org",
+      admin: false,
+    });
 
     expect((await connect("webvnc", await createTicket("webvnc", adminHeaders))).status).toBe(200);
+    expect(runtime.acceptedAttachment).toMatchObject({
+      kind: "webvnc-agent",
+      leaseID: lease.id,
+      owner: "admin@example.com",
+      org: "example-org",
+      admin: true,
+      auth: "bearer",
+      adminGrantVersion: currentGrantVersion,
+    });
     expect((await connect("code", await createTicket("code", adminHeaders))).status).toBe(200);
+    expect(runtime.acceptedAttachment).toMatchObject({
+      kind: "code-agent",
+      leaseID: lease.id,
+      owner: "admin@example.com",
+      org: "example-org",
+      admin: true,
+      auth: "bearer",
+      adminGrantVersion: currentGrantVersion,
+    });
 
     const revokedWebVNCTicket = await createTicket("webvnc");
     const revokedCodeTicket = await createTicket("code");

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -376,6 +376,14 @@ describe("runtime adapter relay", () => {
       leaseID,
       id: "agent_shared_token",
       capabilities: new Set<string>(),
+      ...grant,
+    });
+    const idleWebAgent = new FakeWebSocket({
+      kind: "webvnc-agent",
+      leaseID,
+      id: "agent_idle_shared_token",
+      capabilities: new Set<string>(),
+      ...grant,
     });
     const webViewer = new FakeWebSocket({
       kind: "webvnc-viewer",
@@ -385,7 +393,7 @@ describe("runtime adapter relay", () => {
       ...grant,
       label: "shared",
     });
-    const codeAgent = new FakeWebSocket({ kind: "code-agent", leaseID });
+    const codeAgent = new FakeWebSocket({ kind: "code-agent", leaseID, ...grant });
     const codeViewer = new FakeWebSocket({
       kind: "code-viewer",
       leaseID,
@@ -415,7 +423,10 @@ describe("runtime adapter relay", () => {
     };
     internal.webVNCAgents.set(
       leaseID,
-      new Map([["agent_shared_token", webAgent as unknown as WebSocket]]),
+      new Map([
+        ["agent_shared_token", webAgent as unknown as WebSocket],
+        ["agent_idle_shared_token", idleWebAgent as unknown as WebSocket],
+      ]),
     );
     internal.webVNCViewers.set(
       leaseID,
@@ -446,17 +457,161 @@ describe("runtime adapter relay", () => {
     internal.env.CRABBOX_SHARED_TOKEN = "new-shared-token";
 
     await fleet.webSocketMessage(webViewer as unknown as WebSocket, "vnc-frame");
-    await fleet.webSocketMessage(codeViewer as unknown as WebSocket, "code-frame");
+    await fleet.webSocketMessage(idleWebAgent as unknown as WebSocket, "idle-vnc-frame");
+    await fleet.webSocketMessage(codeViewer as unknown as WebSocket, "code-viewer-frame");
+    await fleet.webSocketMessage(codeAgent as unknown as WebSocket, "code-frame");
     await fleet.webSocketMessage(egressHost as unknown as WebSocket, "egress-frame");
 
-    for (const socket of [webViewer, codeViewer, egressHost, egressClient]) {
+    for (const socket of [
+      idleWebAgent,
+      webViewer,
+      codeAgent,
+      codeViewer,
+      egressHost,
+      egressClient,
+    ]) {
       expect(socket.closeCode).toBe(1008);
       expect(socket.closeReason).toBe("shared access revoked");
     }
+    expect(webAgent.closeCode).toBe(1011);
+    expect(internal.webVNCAgents.get(leaseID)?.size ?? 0).toBe(0);
     expect(internal.webVNCViewers.get(leaseID)?.has("viewer_shared_token") ?? false).toBe(false);
+    expect(internal.codeAgents.has(leaseID)).toBe(false);
     expect(internal.codeViewers.has("code_shared_token")).toBe(false);
     expect(internal.egressHosts.has(`${leaseID}\u0000egress_shared_token`)).toBe(false);
     expect(internal.egressClients.has(`${leaseID}\u0000egress_shared_token`)).toBe(false);
+  });
+
+  it("revalidates backend agents before forwarding viewer traffic", async () => {
+    const oldSharedToken = "old-shared-token";
+    const newSharedToken = "new-shared-token";
+    const agentGrant = {
+      auth: "bearer" as const,
+      owner: "shared@example.com",
+      org: "example-org",
+      admin: false,
+      sharedTokenHash: await sha256Hex(oldSharedToken),
+    };
+    const viewerGrant = {
+      ...agentGrant,
+      sharedTokenHash: await sha256Hex(newSharedToken),
+    };
+    const fleet = testFleet(new MemoryStorage(), {}, { CRABBOX_SHARED_TOKEN: newSharedToken });
+    const leaseID = "cbx_000000000001";
+    const webAgent = new FakeWebSocket({
+      kind: "webvnc-agent",
+      leaseID,
+      id: "agent_revoked_recipient",
+      capabilities: new Set<string>(),
+      ...agentGrant,
+    });
+    const webViewer = new FakeWebSocket({
+      kind: "webvnc-viewer",
+      leaseID,
+      id: "viewer_current_sender",
+      agentID: "agent_revoked_recipient",
+      ...viewerGrant,
+      label: "shared",
+    });
+    const codeAgent = new FakeWebSocket({ kind: "code-agent", leaseID, ...agentGrant });
+    const codeViewer = new FakeWebSocket({
+      kind: "code-viewer",
+      leaseID,
+      id: "code_current_sender",
+      ...viewerGrant,
+    });
+    const internal = fleet as unknown as {
+      webVNCAgents: Map<string, Map<string, WebSocket>>;
+      webVNCViewers: Map<string, Map<string, unknown>>;
+      codeAgents: Map<string, WebSocket>;
+      codeViewers: Map<string, WebSocket>;
+    };
+    internal.webVNCAgents.set(
+      leaseID,
+      new Map([["agent_revoked_recipient", webAgent as unknown as WebSocket]]),
+    );
+    internal.webVNCViewers.set(
+      leaseID,
+      new Map([
+        [
+          "viewer_current_sender",
+          {
+            id: "viewer_current_sender",
+            agentID: "agent_revoked_recipient",
+            socket: webViewer as unknown as WebSocket,
+            ...viewerGrant,
+            label: "shared",
+            connectedAt: new Date().toISOString(),
+          },
+        ],
+      ]),
+    );
+    internal.codeAgents.set(leaseID, codeAgent as unknown as WebSocket);
+    internal.codeViewers.set("code_current_sender", codeViewer as unknown as WebSocket);
+
+    await fleet.webSocketMessage(webViewer as unknown as WebSocket, "vnc-frame");
+    await fleet.webSocketMessage(codeViewer as unknown as WebSocket, "code-frame");
+
+    for (const socket of [webAgent, codeAgent]) {
+      expect(socket.closeCode).toBe(1008);
+      expect(socket.closeReason).toBe("shared access revoked");
+      expect(socket.sentJSON()).toEqual([]);
+    }
+    expect(webViewer.closeCode).toBe(1011);
+    expect(codeViewer.closeCode).toBe(1011);
+    expect(internal.webVNCAgents.has(leaseID)).toBe(false);
+    expect(internal.codeAgents.has(leaseID)).toBe(false);
+  });
+
+  it("revalidates active GitHub-admin backend agents against the user grant", async () => {
+    const env = {
+      CRABBOX_GITHUB_ADMIN_LOGINS: "alice",
+      CRABBOX_GITHUB_REVOKED_USERS: "login:alice",
+    } as Env;
+    const currentGrantVersion = await adminGrantVersion(env);
+    const grant = {
+      auth: "github" as const,
+      owner: "alice@example.com",
+      org: "example-org",
+      admin: true,
+      login: "alice",
+      adminGrantVersion: currentGrantVersion,
+      portalSessionHash: "a".repeat(64),
+      githubGrant: {
+        tokenID: "github-admin-token",
+        sealedCredential: "sealed-credential",
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      },
+    };
+    const fleet = testFleet(new MemoryStorage(), {}, env);
+    const leaseID = "cbx_000000000001";
+    const webAgent = new FakeWebSocket({
+      kind: "webvnc-agent",
+      leaseID,
+      id: "agent_revoked_github_admin",
+      capabilities: new Set<string>(),
+      ...grant,
+    });
+    const codeAgent = new FakeWebSocket({ kind: "code-agent", leaseID, ...grant });
+    const internal = fleet as unknown as {
+      webVNCAgents: Map<string, Map<string, WebSocket>>;
+      codeAgents: Map<string, WebSocket>;
+    };
+    internal.webVNCAgents.set(
+      leaseID,
+      new Map([["agent_revoked_github_admin", webAgent as unknown as WebSocket]]),
+    );
+    internal.codeAgents.set(leaseID, codeAgent as unknown as WebSocket);
+
+    await fleet.webSocketMessage(webAgent as unknown as WebSocket, "vnc-frame");
+    await fleet.webSocketMessage(codeAgent as unknown as WebSocket, "code-frame");
+
+    for (const socket of [webAgent, codeAgent]) {
+      expect(socket.closeCode).toBe(1008);
+      expect(socket.closeReason).toBe("user access revoked");
+    }
+    expect(internal.webVNCAgents.has(leaseID)).toBe(false);
+    expect(internal.codeAgents.has(leaseID)).toBe(false);
   });
 
   it("fails closed active non-admin GitHub WebVNC and egress bridges after revocation", async () => {
@@ -1084,6 +1239,7 @@ describe("runtime adapter relay", () => {
       leaseID: lease.id,
       id: "agent_restored_shared",
       capabilities: new Set<string>(),
+      ...grant,
     });
     const webViewer = new FakeWebSocket({
       kind: "webvnc-viewer",
@@ -1093,7 +1249,7 @@ describe("runtime adapter relay", () => {
       ...grant,
       label: "shared",
     });
-    const codeAgent = new FakeWebSocket({ kind: "code-agent", leaseID: lease.id });
+    const codeAgent = new FakeWebSocket({ kind: "code-agent", leaseID: lease.id, ...grant });
     const codeViewer = new FakeWebSocket({
       kind: "code-viewer",
       leaseID: lease.id,
@@ -1132,9 +1288,66 @@ describe("runtime adapter relay", () => {
     );
 
     expect((await fleet.fetch(request("GET", "/v1/health"))).status).toBe(200);
-    for (const socket of [webViewer, codeViewer, egressHost, egressClient]) {
+    expect(webAgent.closeCode).toBe(1011);
+    expect(webAgent.closeReason).toBe("WebVNC viewer disconnected");
+    for (const socket of [webViewer, codeAgent, codeViewer, egressHost, egressClient]) {
       expect(socket.closeCode).toBe(1008);
       expect(socket.closeReason).toBe("shared access revoked");
+    }
+  });
+
+  it("rejects restored GitHub-admin backend agents after user-grant revocation", async () => {
+    const storage = new MemoryStorage();
+    const lease = testLease({
+      id: "cbx_000000000003",
+      provider: "external",
+      lifecycle: "registered",
+      state: "active",
+      owner: "alice@example.com",
+      org: "example-org",
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    storage.seed(`lease:${lease.id}`, lease);
+    const env = {
+      CRABBOX_DEFAULT_ORG: "example-org",
+      CRABBOX_GITHUB_ADMIN_LOGINS: "alice",
+      CRABBOX_GITHUB_REVOKED_USERS: "login:alice",
+    } as Env;
+    const currentGrantVersion = await adminGrantVersion(env);
+    const grant = {
+      auth: "github" as const,
+      owner: "alice@example.com",
+      org: "example-org",
+      admin: true,
+      login: "alice",
+      adminGrantVersion: currentGrantVersion,
+      portalSessionHash: "b".repeat(64),
+      githubGrant: {
+        tokenID: "github-admin-token",
+        sealedCredential: "sealed-credential",
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      },
+    };
+    const webAgent = new FakeWebSocket({
+      kind: "webvnc-agent",
+      leaseID: lease.id,
+      id: "agent_restored_github_admin",
+      capabilities: new Set<string>(),
+      ...grant,
+    });
+    const codeAgent = new FakeWebSocket({ kind: "code-agent", leaseID: lease.id, ...grant });
+    const fleet = new FleetDurableObject(
+      {
+        storage,
+        getWebSockets: () => [webAgent, codeAgent] as unknown as WebSocket[],
+      } as unknown as DurableObjectState,
+      env,
+    );
+
+    expect((await fleet.fetch(request("GET", "/v1/health"))).status).toBe(200);
+    for (const socket of [webAgent, codeAgent]) {
+      expect(socket.closeCode).toBe(1008);
+      expect(socket.closeReason).toBe("user access revoked");
     }
   });
 
@@ -11226,9 +11439,24 @@ describe("fleet lease identity and idle", () => {
       }),
     );
 
-    const revokedWebAgent = new FakeWebSocket();
-    const retainedWebAgent = new FakeWebSocket();
-    const ownerWebAgent = new FakeWebSocket();
+    const revokedWebAgent = new FakeWebSocket({
+      kind: "webvnc-agent",
+      leaseID,
+      id: "agent_revoked",
+      capabilities: new Set<string>(),
+    });
+    const retainedWebAgent = new FakeWebSocket({
+      kind: "webvnc-agent",
+      leaseID,
+      id: "agent_retained",
+      capabilities: new Set<string>(),
+    });
+    const ownerWebAgent = new FakeWebSocket({
+      kind: "webvnc-agent",
+      leaseID,
+      id: "agent_owner",
+      capabilities: new Set<string>(),
+    });
     const revokedWebViewer = new FakeWebSocket({
       kind: "webvnc-viewer",
       leaseID,
@@ -11439,6 +11667,78 @@ describe("fleet lease identity and idle", () => {
       JSON.stringify({ retained: true }),
     );
     expect(retainedWebAgent.sentJSON()).toEqual([{ retained: true }]);
+  });
+
+  it("revokes idle backend agents when their manager loses manage access", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const leaseID = "cbx_000000000001";
+    const ownerHeaders = {
+      "x-crabbox-owner": "owner@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    storage.seed(
+      `lease:${leaseID}`,
+      testLease({
+        id: leaseID,
+        slug: "shared-backend-agents",
+        owner: "owner@example.com",
+        org: "example-org",
+        desktop: true,
+        code: true,
+        share: {
+          users: {
+            "manager@example.com": "manage",
+            "other-manager@example.com": "manage",
+          },
+        },
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      }),
+    );
+    const grant = {
+      auth: "proxy" as const,
+      owner: "manager@example.com",
+      org: "other-org",
+      admin: false,
+    };
+    const webAgent = new FakeWebSocket({
+      kind: "webvnc-agent",
+      leaseID,
+      id: "agent_manager",
+      capabilities: new Set<string>(),
+      ...grant,
+    });
+    const codeAgent = new FakeWebSocket({ kind: "code-agent", leaseID, ...grant });
+    const relay = fleet as unknown as {
+      webVNCAgents: Map<string, Map<string, WebSocket>>;
+      codeAgents: Map<string, WebSocket>;
+    };
+    relay.webVNCAgents.set(leaseID, new Map([["agent_manager", webAgent as unknown as WebSocket]]));
+    relay.codeAgents.set(leaseID, codeAgent as unknown as WebSocket);
+
+    const unrelatedRemoval = await fleet.fetch(
+      request("DELETE", "/v1/leases/shared-backend-agents/share", {
+        headers: ownerHeaders,
+        body: { user: "other-manager@example.com" },
+      }),
+    );
+    expect(unrelatedRemoval.status).toBe(200);
+    expect(webAgent.closeCode).toBeUndefined();
+    expect(codeAgent.closeCode).toBeUndefined();
+
+    const downgraded = await fleet.fetch(
+      request("PUT", "/v1/leases/shared-backend-agents/share", {
+        headers: ownerHeaders,
+        body: { users: { "manager@example.com": "use" } },
+      }),
+    );
+    expect(downgraded.status).toBe(200);
+    for (const socket of [webAgent, codeAgent]) {
+      expect(socket.closeCode).toBe(1008);
+      expect(socket.closeReason).toBe("lease access revoked");
+    }
+    expect(relay.webVNCAgents.has(leaseID)).toBe(false);
+    expect(relay.codeAgents.has(leaseID)).toBe(false);
   });
 
   it("revokes a live egress session when manage access is downgraded", async () => {
@@ -17219,7 +17519,15 @@ describe("fleet lease identity and idle", () => {
 
     const activeViewerID = "active-code-viewer";
     const portalSessionHash = await sha256Hex(token);
-    const activeAgent = new FakeWebSocket({ kind: "code-agent", leaseID });
+    const agentGrant = {
+      auth: "github" as const,
+      owner: "alice@example.com",
+      org: "example-org",
+      admin: false,
+      login: "alice",
+      portalSessionHash,
+    };
+    const activeAgent = new FakeWebSocket({ kind: "code-agent", leaseID, ...agentGrant });
     const activeViewer = new FakeWebSocket({
       kind: "code-viewer",
       leaseID,
@@ -17232,6 +17540,14 @@ describe("fleet lease identity and idle", () => {
       leaseID,
       id: "agent_active",
       capabilities: new Set<string>(),
+      ...agentGrant,
+    });
+    const idleWebAgent = new FakeWebSocket({
+      kind: "webvnc-agent",
+      leaseID,
+      id: "agent_idle_logout",
+      capabilities: new Set<string>(),
+      ...agentGrant,
     });
     const activeWebViewer = new FakeWebSocket({
       kind: "webvnc-viewer",
@@ -17298,7 +17614,10 @@ describe("fleet lease identity and idle", () => {
     codeBridgeState.codeViewers.set(activeViewerID, activeViewer as unknown as WebSocket);
     codeBridgeState.webVNCAgents.set(
       leaseID,
-      new Map([["agent_active", activeWebAgent as unknown as WebSocket]]),
+      new Map([
+        ["agent_active", activeWebAgent as unknown as WebSocket],
+        ["agent_idle_logout", idleWebAgent as unknown as WebSocket],
+      ]),
     );
     codeBridgeState.webVNCViewers.set(
       leaseID,
@@ -17341,6 +17660,8 @@ describe("fleet lease identity and idle", () => {
     expect(await crossSiteNavigation.text()).toContain('method="post"');
     expect(activeViewer.closeCode).toBeUndefined();
     expect(activeWebViewer.closeCode).toBeUndefined();
+    expect(idleWebAgent.closeCode).toBeUndefined();
+    expect(activeAgent.closeCode).toBeUndefined();
     expect(activeEgressHost.closeCode).toBeUndefined();
     expect(activeEgressClient.closeCode).toBeUndefined();
 
@@ -17359,6 +17680,10 @@ describe("fleet lease identity and idle", () => {
     expect(activeWebViewer.closeCode).toBe(1008);
     expect(activeWebViewer.closeReason).toBe("portal session ended");
     expect(activeWebAgent.closeCode).toBe(1011);
+    expect(idleWebAgent.closeCode).toBe(1008);
+    expect(idleWebAgent.closeReason).toBe("portal session ended");
+    expect(activeAgent.closeCode).toBe(1008);
+    expect(activeAgent.closeReason).toBe("portal session ended");
     expect(activeEgressHost.closeCode).toBe(1008);
     expect(activeEgressHost.closeReason).toBe("portal session ended");
     expect(activeEgressClient.closeCode).toBe(1008);
@@ -17880,6 +18205,65 @@ describe("fleet lease identity and idle", () => {
     expect(
       Object.keys(forwarded?.headers ?? {}).filter((key) => key.startsWith("x-crabbox-")),
     ).toEqual([]);
+  });
+
+  it("rejects a revoked backend agent before Code HTTP forwarding", async () => {
+    const storage = new MemoryStorage();
+    const env = {
+      CRABBOX_CODE_ORIGIN_TEMPLATE: "https://{lease}.code.example.test",
+      CRABBOX_SHARED_TOKEN: "new-shared-token",
+    };
+    const fleet = testFleet(storage, {}, env);
+    const leaseID = "cbx_000000000001";
+    storage.seed(
+      `lease:${leaseID}`,
+      testLease({
+        id: leaseID,
+        slug: "blue-lobster",
+        owner: "alice@example.com",
+        org: "example-org",
+        code: true,
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      }),
+    );
+    const agent = new FakeWebSocket({
+      kind: "code-agent",
+      leaseID,
+      auth: "bearer",
+      owner: "shared@example.com",
+      org: "example-org",
+      admin: false,
+      sharedTokenHash: await sha256Hex("old-shared-token"),
+    });
+    const relay = fleet as unknown as { codeAgents: Map<string, WebSocket> };
+    relay.codeAgents.set(leaseID, agent as unknown as WebSocket);
+    const session = `code_session_${"b".repeat(32)}`;
+    storage.seed(`code-viewer-session:${session}`, {
+      session,
+      leaseID,
+      auth: "proxy",
+      admin: false,
+      owner: "alice@example.com",
+      org: "example-org",
+      createdAt: new Date().toISOString(),
+      expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+    });
+    const isolatedOrigin = await codeOriginForLease(env, leaseID);
+
+    const response = await fleet.fetch(
+      new Request(`${isolatedOrigin}/portal/leases/${leaseID}/code/api/status`, {
+        headers: {
+          cookie: `crabbox_code_session=${session}`,
+          origin: isolatedOrigin || "",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(agent.sentJSON()).toEqual([]);
+    expect(agent.closeCode).toBe(1008);
+    expect(agent.closeReason).toBe("shared access revoked");
+    expect(relay.codeAgents.has(leaseID)).toBe(false);
   });
 
   it("revalidates non-admin GitHub grants when agent bridge tickets are consumed", async () => {
@@ -18707,13 +19091,13 @@ describe("fleet lease identity and idle", () => {
     });
 
     const agentFrames: string[] = [];
-    const agentSocket = {
-      readyState: WebSocket.OPEN,
-      send(data: string) {
-        agentFrames.push(data);
-      },
-      close() {},
-    } as WebSocket;
+    const agentSocket = new FakeWebSocket({
+      kind: "webvnc-agent",
+      leaseID: "cbx_000000000001",
+      id: "agent_theme1",
+      capabilities: new Set<string>(),
+    });
+    agentSocket.onSend = (data) => agentFrames.push(data);
     const viewerSocket = { readyState: WebSocket.OPEN, close() {} } as WebSocket;
     const observerSocket = { readyState: WebSocket.OPEN, close() {} } as WebSocket;
     const webVNCState = fleet as unknown as {
@@ -18735,7 +19119,10 @@ describe("fleet lease identity and idle", () => {
         >
       >;
     };
-    webVNCState.webVNCAgents.set("cbx_000000000001", new Map([["agent_theme1", agentSocket]]));
+    webVNCState.webVNCAgents.set(
+      "cbx_000000000001",
+      new Map([["agent_theme1", agentSocket as unknown as WebSocket]]),
+    );
     webVNCState.webVNCViewers.set(
       "cbx_000000000001",
       new Map([


### PR DESCRIPTION
## Summary

- bind accepted WebVNC and Code backend agents to the exact manager principal and revocable grant that authorized their bridge ticket
- revalidate backend agents on sender and recipient traffic, Code HTTP/health dispatch, WebVNC theme changes, restored-socket reconciliation, share reduction, portal logout, and admin grant rotation
- preserve pre-upgrade hibernated attachments that lack principal metadata while making every newly accepted agent attributable and fail closed

## Root cause

Agent tickets retained manager grant provenance through creation and consumption, but socket acceptance discarded it. Accepted backend agents therefore became lease-level infrastructure that could outlive the manager share, shared token, GitHub user grant, portal session, or admin grant that created them. Several recipient-only paths also used raw agent sockets without running the existing active-grant check.

## Validation

- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker` — 906 passed, 3 skipped
- `npm run build --prefix worker`
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean, confidence 0.91

Closes https://github.com/openclaw/crabbox/issues/1009
