### PR TITLE
fix: reconcile idle admin sockets during maintenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Reconciled idle admin WebVNC, Code, egress, and control sockets during direct and Node scheduled maintenance after admin-token or GitHub-admin rotation. Thanks @coygeek.
 - Bound accepted WebVNC and Code backend agents to the manager grant that created them, closing attributable agents after share or credential revocation while preserving pre-upgrade hibernated sockets. Thanks @coygeek.
 - Bound non-admin shared-token WebVNC, Code, and egress bridges to the credential active at ticket creation, closing active and restored sessions after token rotation or removal. Thanks @coygeek.
 - Made Parallels macOS WebVNC use managed VNC credentials, authenticated screenshots, pointer and direct keyboard input, explicit host-side macOS routing, collision-safe local tunnels, XWayland-aware desktop input, and safe clipboard fallback.

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -890,7 +890,7 @@ export class FleetCoordinator {
 
   async fetch(request: Request): Promise<Response> {
     try {
-      this.reconcileAdminGrantVersion(request);
+      await this.reconcileAdminGrantVersion(request);
       if (!(await this.restoredBridgesReady())) {
         return json(
           {
@@ -1472,12 +1472,24 @@ export class FleetCoordinator {
     return ready;
   }
 
-  private reconcileAdminGrantVersion(request: Request): void {
+  private async reconcileAdminGrantVersion(request: Request): Promise<void> {
     const version = trustedAdminGrantVersion(request);
-    if (!version || version === this.currentAdminGrantVersion) {
+    if (!version) {
       return;
     }
+    if (version === this.currentAdminGrantVersion) return;
+    await this.applyAdminGrantVersion(version);
+  }
+
+  private async applyAdminGrantVersion(version: string): Promise<void> {
     this.currentAdminGrantVersion = version;
+    const validation = await adminGrantValidation(this.env, version);
+    if (this.currentAdminGrantVersion === version) {
+      this.reconcileAdminBridgeSockets(validation);
+    }
+  }
+
+  private adminBridgeSockets(): Set<WebSocket> {
     const sockets = new Set<WebSocket>([
       ...this.controlSockets.values(),
       ...this.codeAgents.values(),
@@ -1495,14 +1507,18 @@ export class FleetCoordinator {
         sockets.add(viewer.socket);
       }
     }
+    return sockets;
+  }
+
+  private reconcileAdminBridgeSockets(validation: AdminGrantValidation): void {
     const revokedEgressSessions = new Set<string>();
-    for (const socket of sockets) {
+    for (const socket of this.adminBridgeSockets()) {
       const attachment = this.bridgeAttachment(socket);
       if (
         !attachment ||
         !("admin" in attachment) ||
         attachment.admin !== true ||
-        attachment.adminGrantVersion === version
+        cachedAdminGrantIsCurrent(attachment, validation)
       ) {
         continue;
       }
@@ -1523,6 +1539,22 @@ export class FleetCoordinator {
       this.handleBridgeClose(socket, 1008, "admin access revoked");
       closeSocket(socket, 1008, "admin access revoked");
     }
+  }
+
+  private async reconcileScheduledAdminGrants(
+    forwardedVersion?: string,
+    preserveForwardedVersion = false,
+  ): Promise<void> {
+    let version =
+      forwardedVersion ?? (preserveForwardedVersion ? this.currentAdminGrantVersion : undefined);
+    if (!version) {
+      const derivedVersion = await configuredAdminGrantVersion(this.env);
+      version =
+        preserveForwardedVersion && this.currentAdminGrantVersion
+          ? this.currentAdminGrantVersion
+          : derivedVersion;
+    }
+    await this.applyAdminGrantVersion(version);
   }
 
   private async currentAdminGrantValidation(): Promise<AdminGrantValidation> {
@@ -2133,9 +2165,21 @@ export class FleetCoordinator {
   }
 
   async alarm(): Promise<void> {
+    await this.runScheduledMaintenance();
+  }
+
+  protected async durableObjectAlarm(): Promise<void> {
+    await this.runScheduledMaintenance(undefined, true);
+  }
+
+  private async runScheduledMaintenance(
+    forwardedAdminGrantVersion?: string,
+    preserveForwardedVersion = false,
+  ): Promise<void> {
     if (!(await this.restoredBridgesReady())) {
       throw new Error("restored bridge lease state is temporarily unavailable");
     }
+    await this.reconcileScheduledAdminGrants(forwardedAdminGrantVersion, preserveForwardedVersion);
     await this.expireLeases();
     await this.webVNCCredentialHandoffs.cleanupExpired();
     await this.reconcileRuntimeAdapterDeletes();
@@ -2155,7 +2199,7 @@ export class FleetCoordinator {
     if (request.headers.get("x-crabbox-internal") !== "scheduled") {
       return json({ error: "unauthorized" }, { status: 401 });
     }
-    await this.alarm();
+    await this.runScheduledMaintenance(trustedAdminGrantVersion(request));
     return json({ ok: true });
   }
 
@@ -12687,7 +12731,7 @@ export class FleetDurableObject extends FleetCoordinator implements DurableObjec
   }
 
   override alarm(): Promise<void> {
-    return super.alarm();
+    return super.durableObjectAlarm();
   }
 
   override webSocketMessage(socket: WebSocket, message: string | ArrayBuffer): Promise<void> {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -13,9 +13,11 @@ import {
   type LeaseConfig,
 } from "../src/config";
 import { routeCoordinatorRequest } from "../src/coordinator-entry";
+import { CloudflareCoordinatorRuntime } from "../src/coordinator-runtime";
 import {
   AWSProvider,
   AzureProvider,
+  FleetCoordinator,
   FleetDurableObject,
   GCPProvider,
   HetznerProvider,
@@ -283,6 +285,209 @@ describe("runtime adapter relay", () => {
     expect(socket.closeCode).toBe(1008);
     expect(socket.closeReason).toBe("admin access revoked");
     expect(internal.controlSockets.has("control-old-deployment-admin")).toBe(false);
+  });
+
+  it("reconciles idle admin sockets during direct scheduled alarms", async () => {
+    const oldAdminToken = "old-admin-token";
+    const oldVersion = await adminGrantVersion({ CRABBOX_ADMIN_TOKEN: oldAdminToken });
+    const fleet = testCoordinator(
+      new MemoryStorage(),
+      {},
+      {
+        CRABBOX_ADMIN_TOKEN: oldAdminToken,
+      },
+    );
+    const leaseID = "cbx_000000000001";
+    const grant = {
+      auth: "bearer" as const,
+      owner: "admin@example.com",
+      org: "example-org",
+      admin: true,
+      adminTokenHash: await sha256Hex(oldAdminToken),
+      adminGrantVersion: oldVersion,
+    };
+    const control = new FakeWebSocket({
+      kind: "control",
+      clientID: "control-scheduled-admin",
+      ...grant,
+      subscriptions: {},
+    });
+    const codeAgent = new FakeWebSocket({ kind: "code-agent", leaseID });
+    const codeViewer = new FakeWebSocket({
+      kind: "code-viewer",
+      leaseID,
+      id: "code-scheduled-admin",
+      ...grant,
+    });
+    const webAgent = new FakeWebSocket({
+      kind: "webvnc-agent",
+      leaseID,
+      id: "agent_scheduled_admin",
+      capabilities: new Set<string>(),
+    });
+    const webViewer = new FakeWebSocket({
+      kind: "webvnc-viewer",
+      leaseID,
+      id: "viewer_scheduled_admin",
+      agentID: "agent_scheduled_admin",
+      ...grant,
+      label: "admin",
+    });
+    const egressHost = new FakeWebSocket({
+      kind: "egress-host",
+      leaseID,
+      sessionID: "egress_scheduled_admin",
+      ...grant,
+    });
+    const egressClient = new FakeWebSocket({
+      kind: "egress-client",
+      leaseID,
+      sessionID: "egress_scheduled_admin",
+      ...grant,
+    });
+    const internal = fleet as unknown as {
+      env: Env;
+      controlSockets: Map<string, WebSocket>;
+      codeAgents: Map<string, WebSocket>;
+      codeViewers: Map<string, WebSocket>;
+      webVNCAgents: Map<string, Map<string, WebSocket>>;
+      webVNCViewers: Map<string, Map<string, unknown>>;
+      egressHosts: Map<string, WebSocket>;
+      egressClients: Map<string, WebSocket>;
+    };
+    internal.controlSockets.set("control-scheduled-admin", control as unknown as WebSocket);
+    internal.codeAgents.set(leaseID, codeAgent as unknown as WebSocket);
+    internal.codeViewers.set("code-scheduled-admin", codeViewer as unknown as WebSocket);
+    internal.webVNCAgents.set(
+      leaseID,
+      new Map([["agent_scheduled_admin", webAgent as unknown as WebSocket]]),
+    );
+    internal.webVNCViewers.set(
+      leaseID,
+      new Map([
+        [
+          "viewer_scheduled_admin",
+          {
+            id: "viewer_scheduled_admin",
+            agentID: "agent_scheduled_admin",
+            socket: webViewer as unknown as WebSocket,
+            ...grant,
+            label: "admin",
+            connectedAt: new Date().toISOString(),
+          },
+        ],
+      ]),
+    );
+    const egressKey = `${leaseID}\u0000egress_scheduled_admin`;
+    internal.egressHosts.set(egressKey, egressHost as unknown as WebSocket);
+    internal.egressClients.set(egressKey, egressClient as unknown as WebSocket);
+    const primed = await fleet.fetch(
+      request("GET", "/v1/health", {
+        headers: { "x-crabbox-admin-grant-version": oldVersion },
+      }),
+    );
+    expect(primed.status).toBe(200);
+    internal.env.CRABBOX_ADMIN_TOKEN = "new-admin-token";
+
+    await fleet.alarm();
+
+    for (const socket of [control, codeViewer, webViewer, egressHost, egressClient]) {
+      expect(socket.closeCode).toBe(1008);
+      expect(socket.closeReason).toBe("admin access revoked");
+    }
+    expect(codeAgent.sentJSON()).toEqual([
+      {
+        type: "ws_close",
+        id: "code-scheduled-admin",
+        code: 1008,
+        reason: "admin access revoked",
+      },
+    ]);
+    expect(webAgent.closeCode).toBe(1011);
+    expect(internal.controlSockets.has("control-scheduled-admin")).toBe(false);
+    expect(internal.codeViewers.has("code-scheduled-admin")).toBe(false);
+    expect(internal.webVNCViewers.get(leaseID)?.has("viewer_scheduled_admin") ?? false).toBe(false);
+    expect(internal.egressHosts.has(egressKey)).toBe(false);
+    expect(internal.egressClients.has(egressKey)).toBe(false);
+  });
+
+  it("preserves the forwarded admin grant version during Worker scheduled maintenance", async () => {
+    const oldAdminToken = "old-admin-token";
+    const newAdminToken = "new-admin-token";
+    const newVersion = await adminGrantVersion({ CRABBOX_ADMIN_TOKEN: newAdminToken });
+    const fleet = testFleet(new MemoryStorage(), {}, { CRABBOX_ADMIN_TOKEN: oldAdminToken });
+    const socket = new FakeWebSocket({
+      kind: "control",
+      clientID: "control-current-deployment-admin",
+      owner: "admin@example.com",
+      org: "example-org",
+      admin: true,
+      auth: "bearer",
+      adminTokenHash: await sha256Hex(newAdminToken),
+      adminGrantVersion: newVersion,
+      subscriptions: {},
+    });
+    const internal = fleet as unknown as {
+      currentAdminGrantVersion?: string;
+      controlSockets: Map<string, WebSocket>;
+    };
+    internal.controlSockets.set("control-current-deployment-admin", socket as unknown as WebSocket);
+
+    const response = await fleet.fetch(
+      request("POST", "/v1/internal/scheduled", {
+        headers: {
+          "x-crabbox-internal": "scheduled",
+          "x-crabbox-admin-grant-version": newVersion,
+        },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(socket.closeCode).toBeUndefined();
+    expect(internal.controlSockets.has("control-current-deployment-admin")).toBe(true);
+    expect(internal.currentAdminGrantVersion).toBe(newVersion);
+
+    await fleet.alarm();
+
+    expect(socket.closeCode).toBeUndefined();
+    expect(internal.controlSockets.has("control-current-deployment-admin")).toBe(true);
+    expect(internal.currentAdminGrantVersion).toBe(newVersion);
+  });
+
+  it("does not let an alarm race roll back a newly forwarded admin grant version", async () => {
+    const oldAdminToken = "old-admin-token";
+    const newAdminToken = "new-admin-token";
+    const newVersion = await adminGrantVersion({ CRABBOX_ADMIN_TOKEN: newAdminToken });
+    const fleet = testFleet(new MemoryStorage(), {}, { CRABBOX_ADMIN_TOKEN: oldAdminToken });
+    const socket = new FakeWebSocket({
+      kind: "control",
+      clientID: "control-racing-deployment-admin",
+      owner: "admin@example.com",
+      org: "example-org",
+      admin: true,
+      auth: "bearer",
+      adminTokenHash: await sha256Hex(newAdminToken),
+      adminGrantVersion: newVersion,
+      subscriptions: {},
+    });
+    const internal = fleet as unknown as {
+      currentAdminGrantVersion?: string;
+      controlSockets: Map<string, WebSocket>;
+    };
+    internal.controlSockets.set("control-racing-deployment-admin", socket as unknown as WebSocket);
+
+    const alarm = fleet.alarm();
+    const response = await fleet.fetch(
+      request("GET", "/v1/health", {
+        headers: { "x-crabbox-admin-grant-version": newVersion },
+      }),
+    );
+    await alarm;
+
+    expect(response.status).toBe(200);
+    expect(socket.closeCode).toBeUndefined();
+    expect(internal.controlSockets.has("control-racing-deployment-admin")).toBe(true);
+    expect(internal.currentAdminGrantVersion).toBe(newVersion);
   });
 
   it("revalidates idle admin controls before broadcasting subscribed run events", async () => {
@@ -24091,6 +24296,25 @@ function testFleet(
   }
   return new FleetDurableObject(
     { storage } as unknown as DurableObjectState,
+    { CRABBOX_DEFAULT_ORG: "default-org", ...env } as Env,
+    providers,
+  );
+}
+
+function testCoordinator(
+  storage = new MemoryStorage(),
+  providers = {},
+  env: Partial<Env> = {},
+): FleetCoordinator {
+  for (const provider of Object.values(providers)) {
+    (
+      provider as {
+        attachStorage?: (storage: MemoryStorage) => void;
+      }
+    ).attachStorage?.(storage);
+  }
+  return new FleetCoordinator(
+    new CloudflareCoordinatorRuntime({ storage } as unknown as DurableObjectState),
     { CRABBOX_DEFAULT_ORG: "default-org", ...env } as Env,
     providers,
   );


### PR DESCRIPTION
## Summary

- sweep idle admin-authorized control, WebVNC, Code, and egress sockets during scheduled maintenance
- derive current admin grants directly for Node alarms while preserving Worker-forwarded grant versions across Durable Object alarms
- fence asynchronous grant validation so an older alarm cannot overwrite a newer deployment version
- add rotation, Worker preservation, and alarm/request race regressions

## Verification

- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker` (909 passed, 3 skipped)
- `npm run build --prefix worker`
- structured autoreview clean (0.94)

Closes https://github.com/openclaw/crabbox/issues/1010
