### PR TITLE
fix: keep crabbox runtime state out of sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixed
 
-- Prevented config and `.crabboxignore` negations from re-including Crabbox-owned env profiles, uploaded scripts, logs, captures, and run artifacts in sync manifests. Thanks @zozo123.
+- Prevented config and `.crabboxignore` negations, including case aliases, from re-including Crabbox-owned env profiles, uploaded scripts, logs, captures, and run artifacts in sync manifests. Thanks @zozo123.
 - Allowed ordered `!` re-includes in `.crabboxignore` and `sync.exclude`, with `\!` for literal leading-bang paths. Thanks @chsong1.
 - Completed coordinator diagnostic redaction for non-Bearer authorization schemes, GCP signed URLs, and every configured provider credential field. Thanks @coygeek.
 - Reconciled idle admin WebVNC, Code, egress, and control sockets during direct and Node scheduled maintenance after admin-token or GitHub-admin rotation. Thanks @coygeek.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Prevented config and `.crabboxignore` negations from re-including Crabbox-owned env profiles, uploaded scripts, logs, captures, and run artifacts in sync manifests. Thanks @zozo123.
 - Allowed ordered `!` re-includes in `.crabboxignore` and `sync.exclude`, with `\!` for literal leading-bang paths. Thanks @chsong1.
 - Completed coordinator diagnostic redaction for non-Bearer authorization schemes, GCP signed URLs, and every configured provider credential field. Thanks @coygeek.
 - Reconciled idle admin WebVNC, Code, egress, and control sockets during direct and Node scheduled maintenance after admin-token or GitHub-admin rotation. Thanks @coygeek.

--- a/docs/features/sync.md
+++ b/docs/features/sync.md
@@ -34,9 +34,10 @@ letting you test uncommitted local edits.
 The built-in excludes are intentionally conservative. They cover common churn
 such as `node_modules`, `.git`, `dist`, `coverage`, `playwright-report`,
 `test-results`, `.next`, `.vite`, `.turbo`, `target`, `.venv`, `__pycache__`,
-`.gradle`, and the local `.crabbox/logs`, `.crabbox/captures`, and
-`.crabbox/runs` directories. Crabbox does not globally drop tracked source files
-just because a path segment happens to be named `build` or `out`. Put
+`.gradle`, and Crabbox runtime state under `.crabbox/env`,
+`.crabbox/scripts`, `.crabbox/logs`, `.crabbox/captures`, and
+`.crabbox/runs`. Crabbox does not globally drop tracked source files just
+because a path segment happens to be named `build` or `out`. Put
 project-specific generated directories in `.crabboxignore` or `sync.exclude`.
 
 ## Excludes
@@ -59,6 +60,12 @@ read from the repository root. Blank lines and lines starting with `#` are
 ignored; the remaining lines are appended to `sync.exclude` and use the same
 matcher as config excludes. Crabbox supports only the exact `.crabboxignore`
 name; there is no short alias.
+
+Crabbox-owned runtime state under `.crabbox/env`, `.crabbox/scripts`,
+`.crabbox/logs`, `.crabbox/captures`, and `.crabbox/runs` is always excluded
+after repo rules are applied. Those paths can contain forwarded env profiles,
+uploaded scripts, local run artifacts, or failure bundles, so `.crabboxignore`
+cannot re-include them.
 
 Repo-local config should hold project-specific excludes and env allowlists.
 Secrets must never be passed as command-line arguments or via broad env globs.

--- a/docs/features/sync.md
+++ b/docs/features/sync.md
@@ -65,7 +65,8 @@ Crabbox-owned runtime state under `.crabbox/env`, `.crabbox/scripts`,
 `.crabbox/logs`, `.crabbox/captures`, and `.crabbox/runs` is always excluded
 after repo rules are applied. Those paths can contain forwarded env profiles,
 uploaded scripts, local run artifacts, or failure bundles, so `.crabboxignore`
-cannot re-include them.
+cannot re-include them. Case aliases of these reserved paths are protected too,
+including on case-insensitive filesystems.
 
 If a project stores source files in one of these reserved directories, move
 them elsewhere before upgrading; reserved runtime paths are no longer eligible

--- a/docs/features/sync.md
+++ b/docs/features/sync.md
@@ -67,6 +67,10 @@ after repo rules are applied. Those paths can contain forwarded env profiles,
 uploaded scripts, local run artifacts, or failure bundles, so `.crabboxignore`
 cannot re-include them.
 
+If a project stores source files in one of these reserved directories, move
+them elsewhere before upgrading; reserved runtime paths are no longer eligible
+for sync even when they are tracked or explicitly re-included.
+
 Repo-local config should hold project-specific excludes and env allowlists.
 Secrets must never be passed as command-line arguments or via broad env globs.
 

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -137,6 +137,17 @@ func protectedSyncExcludes() []string {
 	}
 }
 
+func protectedSyncExcludeMatches(rel, exclude string) bool {
+	rel = strings.ToLower(strings.Trim(filepath.ToSlash(rel), "/"))
+	exclude = strings.ToLower(strings.Trim(filepath.ToSlash(exclude), "/"))
+	for _, protected := range protectedSyncExcludes() {
+		if exclude == protected {
+			return rel == protected || strings.HasPrefix(rel, protected+"/")
+		}
+	}
+	return false
+}
+
 // syncIncludes returns the configured sync include (whitelist) patterns. When
 // empty the whole working tree is synced (minus excludes); when non-empty only
 // matching paths are synced.
@@ -628,7 +639,7 @@ func pathExcluded(rel string, excludes []string) bool {
 	excluded := false
 	for _, exclude := range excludes {
 		exclude, negated := excludeRule(exclude)
-		if excludeMatches(rel, exclude) {
+		if excludeMatches(rel, exclude) || protectedSyncExcludeMatches(rel, exclude) {
 			excluded = !negated
 		}
 	}

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -78,7 +78,7 @@ func cleanRemoteRepoName(name string) string {
 }
 
 func defaultExcludes() []string {
-	return []string{
+	excludes := []string{
 		".git",
 		"._*",
 		"node_modules",
@@ -96,11 +96,6 @@ func defaultExcludes() []string {
 		".cache",
 		".tmp",
 		".local",
-		".crabbox/env",
-		".crabbox/scripts",
-		".crabbox/logs",
-		".crabbox/captures",
-		".crabbox/runs",
 		".swiftpm",
 		".build",
 		"apps/*/.build",
@@ -115,6 +110,7 @@ func defaultExcludes() []string {
 		".gradle",
 		"target",
 	}
+	return append(excludes, protectedSyncExcludes()...)
 }
 
 func configuredExcludes(cfg Config) []string {

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -96,6 +96,8 @@ func defaultExcludes() []string {
 		".cache",
 		".tmp",
 		".local",
+		".crabbox/env",
+		".crabbox/scripts",
 		".crabbox/logs",
 		".crabbox/captures",
 		".crabbox/runs",
@@ -125,7 +127,18 @@ func syncExcludes(root string, cfg Config) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return appendOrderedStrings(excludes, ignore...), nil
+	excludes = appendOrderedStrings(excludes, ignore...)
+	return appendOrderedStrings(excludes, protectedSyncExcludes()...), nil
+}
+
+func protectedSyncExcludes() []string {
+	return []string{
+		".crabbox/env",
+		".crabbox/scripts",
+		".crabbox/logs",
+		".crabbox/captures",
+		".crabbox/runs",
+	}
 }
 
 // syncIncludes returns the configured sync include (whitelist) patterns. When

--- a/internal/cli/repo_test.go
+++ b/internal/cli/repo_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -355,10 +356,21 @@ func TestCrabboxRuntimeExcludesCannotBeReincluded(t *testing.T) {
 	runGit(t, dir, "init")
 	runGit(t, dir, "config", "user.email", "test@example.com")
 	runGit(t, dir, "config", "user.name", "Test")
-	writeFile(t, filepath.Join(dir, ".crabboxignore"), "!.crabbox/env\n!.crabbox/scripts\n!.crabbox/runs\n")
-	writeFile(t, filepath.Join(dir, ".crabbox", "env", "live.env"), "export API_TOKEN=secret\n")
-	writeFile(t, filepath.Join(dir, ".crabbox", "scripts", "smoke.sh"), "echo hi\n")
-	writeFile(t, filepath.Join(dir, ".crabbox", "runs", "run_123", "artifact.tgz"), "artifact")
+	runtimeFiles := []string{
+		".crabbox/env/live.env",
+		".crabbox/scripts/smoke.sh",
+		".crabbox/logs/run.log",
+		".crabbox/captures/failure.tgz",
+		".crabbox/runs/run_123/artifact.tgz",
+	}
+	var ignore strings.Builder
+	for _, exclude := range protectedSyncExcludes() {
+		fmt.Fprintf(&ignore, "!%s\n", exclude)
+	}
+	writeFile(t, filepath.Join(dir, ".crabboxignore"), ignore.String())
+	for _, rel := range runtimeFiles {
+		writeFile(t, filepath.Join(dir, filepath.FromSlash(rel)), "runtime state\n")
+	}
 	writeFile(t, filepath.Join(dir, ".crabbox", "srt-settings.json"), "{}\n")
 	writeFile(t, filepath.Join(dir, "src", "main.go"), "package main\n")
 	runGit(t, dir, "add", ".")
@@ -378,13 +390,13 @@ func TestCrabboxRuntimeExcludesCannotBeReincluded(t *testing.T) {
 			t.Fatalf("manifest %q missing %q", got, want)
 		}
 	}
-	for _, notWant := range []string{".crabbox/env/live.env", ".crabbox/scripts/smoke.sh", ".crabbox/runs/run_123/artifact.tgz"} {
+	for _, notWant := range runtimeFiles {
 		if strings.Contains(got, notWant) {
 			t.Fatalf("manifest %q should not include protected runtime path %q", got, notWant)
 		}
-	}
-	if !pathExcluded(".crabbox/env/live.env", excludes) || !pathExcluded(".crabbox/scripts/smoke.sh", excludes) || !pathExcluded(".crabbox/runs/run_123/artifact.tgz", excludes) {
-		t.Fatalf("protected runtime excludes were overridden: %v", excludes)
+		if !pathExcluded(notWant, excludes) {
+			t.Fatalf("protected runtime path %q was re-included: %v", notWant, excludes)
+		}
 	}
 }
 

--- a/internal/cli/repo_test.go
+++ b/internal/cli/repo_test.go
@@ -350,6 +350,44 @@ func TestCrabboxIgnoreCanReincludeDefaultExcludedSourcePath(t *testing.T) {
 	}
 }
 
+func TestCrabboxRuntimeExcludesCannotBeReincluded(t *testing.T) {
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.email", "test@example.com")
+	runGit(t, dir, "config", "user.name", "Test")
+	writeFile(t, filepath.Join(dir, ".crabboxignore"), "!.crabbox/env\n!.crabbox/scripts\n!.crabbox/runs\n")
+	writeFile(t, filepath.Join(dir, ".crabbox", "env", "live.env"), "export API_TOKEN=secret\n")
+	writeFile(t, filepath.Join(dir, ".crabbox", "scripts", "smoke.sh"), "echo hi\n")
+	writeFile(t, filepath.Join(dir, ".crabbox", "runs", "run_123", "artifact.tgz"), "artifact")
+	writeFile(t, filepath.Join(dir, ".crabbox", "srt-settings.json"), "{}\n")
+	writeFile(t, filepath.Join(dir, "src", "main.go"), "package main\n")
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-m", "init")
+
+	excludes, err := syncExcludes(dir, baseConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := syncManifest(dir, excludes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := strings.Join(manifest.Files, ",")
+	for _, want := range []string{".crabbox/srt-settings.json", "src/main.go"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("manifest %q missing %q", got, want)
+		}
+	}
+	for _, notWant := range []string{".crabbox/env/live.env", ".crabbox/scripts/smoke.sh", ".crabbox/runs/run_123/artifact.tgz"} {
+		if strings.Contains(got, notWant) {
+			t.Fatalf("manifest %q should not include protected runtime path %q", got, notWant)
+		}
+	}
+	if !pathExcluded(".crabbox/env/live.env", excludes) || !pathExcluded(".crabbox/scripts/smoke.sh", excludes) || !pathExcluded(".crabbox/runs/run_123/artifact.tgz", excludes) {
+		t.Fatalf("protected runtime excludes were overridden: %v", excludes)
+	}
+}
+
 func TestPathExcludedUsesOrderedNegation(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/cli/repo_test.go
+++ b/internal/cli/repo_test.go
@@ -398,6 +398,17 @@ func TestCrabboxRuntimeExcludesCannotBeReincluded(t *testing.T) {
 			t.Fatalf("protected runtime path %q was re-included: %v", notWant, excludes)
 		}
 	}
+	for _, alias := range []string{
+		".CRABBOX/env/live.env",
+		".crabbox/SCRIPTS/smoke.sh",
+		".Crabbox/Logs/run.log",
+		".crabbox/CAPTURES/failure.tgz",
+		".CRABBOX/RUNS/run_123/artifact.tgz",
+	} {
+		if !pathExcluded(alias, excludes) {
+			t.Fatalf("case alias of protected runtime path %q was re-included: %v", alias, excludes)
+		}
+	}
 }
 
 func TestPathExcludedUsesOrderedNegation(t *testing.T) {


### PR DESCRIPTION
## Summary
- Keep Crabbox-owned runtime state under `.crabbox/env`, `.crabbox/scripts`, `.crabbox/logs`, `.crabbox/captures`, and `.crabbox/runs` in a final protected sync exclude set.
- Protect case aliases of those paths on case-insensitive filesystems while leaving other repo-owned `.crabbox` files eligible for sync.
- Cover every reserved directory with regression tests, document the compatibility boundary, and add the release note.

## Root Cause
`.crabboxignore` and configured sync rules are ordered, last-match-wins lists. User rules were appended after built-in excludes, so a later `!` rule could re-include Crabbox-owned runtime files. Literal case-sensitive matching also left aliases such as `.CRABBOX/ENV` unprotected on case-insensitive filesystems.

## Compatibility
The five runtime directories are now reserved even when their files are tracked or explicitly re-included. Projects that stored source files there must move them elsewhere before upgrading. Other `.crabbox` files remain syncable.

## Validation
- `go test ./internal/cli`
- `scripts/check-docs.sh`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --parallel-tests 'go test ./internal/cli && scripts/check-docs.sh'` — clean, no accepted/actionable findings
- Built the CLI and ran `sync-plan` in a temporary Git repository containing tracked case-aliased runtime state plus a repo-owned settings file:

```text
$ crabbox sync-plan --limit 20
sync candidate: 3 files, 97 B
top files:
  81 B       .crabboxignore
  13 B       src/main.go
  3 B        .CRABBOX/srt-settings.json
top dirs:
  81 B       .
  13 B       src
  3 B        .CRABBOX
```

The tracked `.CRABBOX/ENV/live.env` fixture is absent while the repo-owned settings file remains present.
