### PR TITLE
feat: add sync-plan json output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added `sync-plan --json` with candidate and dirty-delta sizes, configured guardrail status, deleted-path counts, and ranked file and directory hotspots for automation. Thanks @zozo123.
 - Added a CubeSandbox delegated-run provider with E2B-compatible lifecycle and envd execution, archive sync, CubeProxy routing, exact API-endpoint/sandbox-bound ownership claims, conflict-safe explicit adoption, and guarded cleanup. Thanks @zozo123.
 - Added coordinator-managed Daytona Linux leases with a Worker-held API key, exact ownership cleanup, expiring SSH-token refresh, CLI secret redaction, and production Cloudflare configuration.
 

--- a/docs/commands/sync-plan.md
+++ b/docs/commands/sync-plan.md
@@ -8,6 +8,7 @@ the manifest after editing `.crabboxignore`.
 ```sh
 crabbox sync-plan
 crabbox sync-plan --limit 10
+crabbox sync-plan --json
 ```
 
 The command reads only your local Git checkout. It does not require a
@@ -52,14 +53,45 @@ Directories are grouped at one level deep for top-level paths and two
 levels deep for nested paths (for example `internal/cli`), so deeply
 nested hotspots still roll up to a meaningful prefix.
 
+With `--json`, the command emits the same information in a stable
+machine-readable shape for CI checks and agent preflights:
+
+```json
+{
+  "candidate": { "files": 1843, "bytes": 327680000, "humanBytes": "312.5 MiB" },
+  "dirtyDelta": { "files": 12, "bytes": 524288, "humanBytes": "512.0 KiB" },
+  "deletedTrackedPaths": 2,
+  "guardrail": {
+    "scope": "dirty_delta",
+    "files": 12,
+    "bytes": 524288,
+    "humanBytes": "512.0 KiB",
+    "limits": { "warnFiles": 0, "warnBytes": 0, "failFiles": 0, "failBytes": 0 },
+    "allowLarge": false,
+    "status": "ok"
+  },
+  "topFiles": [{ "path": "assets/demo.mp4", "bytes": 88604672, "humanBytes": "84.5 MiB" }],
+  "topDirs": [{ "path": "assets", "bytes": 147010355, "humanBytes": "140.2 MiB" }]
+}
+```
+
+`candidate` is the full manifest that would be present on the remote after
+sync. `dirtyDelta` is the locally changed/untracked/deleted path set that
+`crabbox run` uses for large-sync guardrails when it is non-empty.
+`guardrail.scope` is therefore either `dirty_delta` or `candidate`, matching
+the sync preflight path. `guardrail.status` is `ok`, `warning`, or `failed`;
+warnings and failures are listed in `guardrail.reasons` when configured
+`sync.warn*` or `sync.fail*` thresholds are reached.
+
 ## Flags
 
 ```text
 --limit <n>   number of top files and directories to print (default 20)
+--json        print machine-readable JSON
 ```
 
 `--limit` must be positive; `--limit 0` (or any non-positive value) is
-rejected with an error. There is no `--json` output for this command.
+rejected with an error.
 
 ## Use cases
 
@@ -67,6 +99,7 @@ rejected with an error. There is no `--json` output for this command.
 - find directories that quietly grew (`.cache/`, `dist/`, generated
   assets);
 - audit `.crabboxignore` and `sync.exclude` after adding new patterns.
+- gate CI or an agent workflow on sync size before provisioning a remote box.
 
 The numbers `sync-plan` prints are upper bounds. The actual rsync transfer
 depends on what already exists on the remote runner: a repeat sync after a

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -490,36 +490,94 @@ func safeRepoRel(rel string) bool {
 
 func checkSyncPreflight(manifest SyncManifest, cfg Config, force bool, stderr io.Writer) error {
 	fileCount := len(manifest.Files)
-	guardCount, guardBytes, guardScope, guardPaths := syncGuardrailScope(manifest)
+	guard := evaluateSyncGuardrail(manifest, cfg, force)
 	if len(manifest.Changed) > 0 {
 		fmt.Fprintf(stderr, "sync candidate: %d files, %s dirty_delta=%d files, %s\n", fileCount, humanBytes(manifest.Bytes), len(manifest.Changed), humanBytes(manifest.ChangedBytes))
 	} else {
 		fmt.Fprintf(stderr, "sync candidate: %d files, %s\n", fileCount, humanBytes(manifest.Bytes))
 	}
-	allowLarge := force || cfg.Sync.AllowLarge || os.Getenv("CRABBOX_SYNC_ALLOW_LARGE") == "1"
-	if !allowLarge {
-		if cfg.Sync.FailFiles > 0 && guardCount >= cfg.Sync.FailFiles {
-			printSyncTopDirs(stderr, guardPaths)
-			return exit(6, "sync %s too large: %d files >= limit %d; use --force-sync-large or CRABBOX_SYNC_ALLOW_LARGE=1", guardScope, guardCount, cfg.Sync.FailFiles)
+	for _, reason := range guard.Reasons {
+		if reason.Status != "failed" {
+			continue
 		}
-		if cfg.Sync.FailBytes > 0 && guardBytes >= cfg.Sync.FailBytes {
-			printSyncTopDirs(stderr, guardPaths)
-			return exit(6, "sync %s too large: %s >= limit %s; use --force-sync-large or CRABBOX_SYNC_ALLOW_LARGE=1", guardScope, humanBytes(guardBytes), humanBytes(cfg.Sync.FailBytes))
+		printSyncTopDirs(stderr, guard.Paths)
+		if reason.Metric == "files" {
+			return exit(6, "sync %s too large: %d files >= limit %d; use --force-sync-large or CRABBOX_SYNC_ALLOW_LARGE=1", guard.Scope, reason.Actual, reason.Limit)
 		}
+		return exit(6, "sync %s too large: %s >= limit %s; use --force-sync-large or CRABBOX_SYNC_ALLOW_LARGE=1", guard.Scope, humanBytes(reason.Actual), humanBytes(reason.Limit))
 	}
 	warned := false
-	if cfg.Sync.WarnFiles > 0 && guardCount >= cfg.Sync.WarnFiles {
-		fmt.Fprintf(stderr, "warning: large sync %s: %d files >= warning threshold %d\n", guardScope, guardCount, cfg.Sync.WarnFiles)
-		warned = true
-	}
-	if cfg.Sync.WarnBytes > 0 && guardBytes >= cfg.Sync.WarnBytes {
-		fmt.Fprintf(stderr, "warning: large sync %s: %s >= warning threshold %s\n", guardScope, humanBytes(guardBytes), humanBytes(cfg.Sync.WarnBytes))
+	for _, reason := range guard.Reasons {
+		if reason.Status != "warning" {
+			continue
+		}
+		if reason.Metric == "files" {
+			fmt.Fprintf(stderr, "warning: large sync %s: %d files >= warning threshold %d\n", guard.Scope, reason.Actual, reason.Limit)
+		} else {
+			fmt.Fprintf(stderr, "warning: large sync %s: %s >= warning threshold %s\n", guard.Scope, humanBytes(reason.Actual), humanBytes(reason.Limit))
+		}
 		warned = true
 	}
 	if warned {
-		printSyncTopDirs(stderr, guardPaths)
+		printSyncTopDirs(stderr, guard.Paths)
 	}
 	return nil
+}
+
+type syncGuardrailEvaluation struct {
+	Count      int
+	Bytes      int64
+	Scope      string
+	Paths      []string
+	AllowLarge bool
+	Status     string
+	Reasons    []syncGuardrailReason
+}
+
+type syncGuardrailReason struct {
+	Status string
+	Metric string
+	Actual int64
+	Limit  int64
+}
+
+func evaluateSyncGuardrail(manifest SyncManifest, cfg Config, force bool) syncGuardrailEvaluation {
+	count, bytes, scope, paths := syncGuardrailScope(manifest)
+	out := syncGuardrailEvaluation{
+		Count:      count,
+		Bytes:      bytes,
+		Scope:      scope,
+		Paths:      paths,
+		AllowLarge: force || cfg.Sync.AllowLarge || os.Getenv("CRABBOX_SYNC_ALLOW_LARGE") == "1",
+		Status:     "ok",
+	}
+	if !out.AllowLarge {
+		if cfg.Sync.FailFiles > 0 && count >= cfg.Sync.FailFiles {
+			out.addReason("failed", "files", int64(count), int64(cfg.Sync.FailFiles))
+		}
+		if cfg.Sync.FailBytes > 0 && bytes >= cfg.Sync.FailBytes {
+			out.addReason("failed", "bytes", bytes, cfg.Sync.FailBytes)
+		}
+	}
+	if cfg.Sync.WarnFiles > 0 && count >= cfg.Sync.WarnFiles {
+		out.addReason("warning", "files", int64(count), int64(cfg.Sync.WarnFiles))
+	}
+	if cfg.Sync.WarnBytes > 0 && bytes >= cfg.Sync.WarnBytes {
+		out.addReason("warning", "bytes", bytes, cfg.Sync.WarnBytes)
+	}
+	return out
+}
+
+func (g *syncGuardrailEvaluation) addReason(status, metric string, actual, limit int64) {
+	if status == "failed" || g.Status == "ok" {
+		g.Status = status
+	}
+	g.Reasons = append(g.Reasons, syncGuardrailReason{
+		Status: status,
+		Metric: metric,
+		Actual: actual,
+		Limit:  limit,
+	})
 }
 
 func syncGuardrailScope(manifest SyncManifest) (count int, bytes int64, scope string, paths []string) {

--- a/internal/cli/sync_plan.go
+++ b/internal/cli/sync_plan.go
@@ -135,48 +135,30 @@ func syncPlanJSONRows(rows []syncPlanRow) []syncPlanJSONRow {
 }
 
 func syncPlanJSONGuardrailFor(manifest SyncManifest, cfg Config) syncPlanJSONGuardrail {
-	count, bytes, scope, _ := syncGuardrailScope(manifest)
+	evaluation := evaluateSyncGuardrail(manifest, cfg, false)
 	out := syncPlanJSONGuardrail{
-		Scope:      scope,
-		Files:      count,
-		Bytes:      bytes,
-		HumanBytes: humanBytes(bytes),
+		Scope:      evaluation.Scope,
+		Files:      evaluation.Count,
+		Bytes:      evaluation.Bytes,
+		HumanBytes: humanBytes(evaluation.Bytes),
 		Limits: syncPlanJSONGuardrailLimits{
 			WarnFiles: cfg.Sync.WarnFiles,
 			WarnBytes: cfg.Sync.WarnBytes,
 			FailFiles: cfg.Sync.FailFiles,
 			FailBytes: cfg.Sync.FailBytes,
 		},
-		AllowLarge: cfg.Sync.AllowLarge || os.Getenv("CRABBOX_SYNC_ALLOW_LARGE") == "1",
-		Status:     "ok",
+		AllowLarge: evaluation.AllowLarge,
+		Status:     evaluation.Status,
 	}
-	if !out.AllowLarge {
-		if cfg.Sync.FailFiles > 0 && count >= cfg.Sync.FailFiles {
-			out.addReason("failed", "files", int64(count), int64(cfg.Sync.FailFiles))
-		}
-		if cfg.Sync.FailBytes > 0 && bytes >= cfg.Sync.FailBytes {
-			out.addReason("failed", "bytes", bytes, cfg.Sync.FailBytes)
-		}
-	}
-	if cfg.Sync.WarnFiles > 0 && count >= cfg.Sync.WarnFiles {
-		out.addReason("warning", "files", int64(count), int64(cfg.Sync.WarnFiles))
-	}
-	if cfg.Sync.WarnBytes > 0 && bytes >= cfg.Sync.WarnBytes {
-		out.addReason("warning", "bytes", bytes, cfg.Sync.WarnBytes)
+	for _, reason := range evaluation.Reasons {
+		out.Reasons = append(out.Reasons, syncPlanJSONGuardrailReason{
+			Status: reason.Status,
+			Metric: reason.Metric,
+			Actual: reason.Actual,
+			Limit:  reason.Limit,
+		})
 	}
 	return out
-}
-
-func (g *syncPlanJSONGuardrail) addReason(status, metric string, actual, limit int64) {
-	if status == "failed" || g.Status == "ok" {
-		g.Status = status
-	}
-	g.Reasons = append(g.Reasons, syncPlanJSONGuardrailReason{
-		Status: status,
-		Metric: metric,
-		Actual: actual,
-		Limit:  limit,
-	})
 }
 
 func syncPlanRows(root string, manifest SyncManifest, limit int) ([]syncPlanRow, []syncPlanRow) {

--- a/internal/cli/sync_plan.go
+++ b/internal/cli/sync_plan.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -14,10 +15,57 @@ type syncPlanRow struct {
 	Bytes int64
 }
 
+type syncPlanJSONOutput struct {
+	Candidate           syncPlanJSONSize      `json:"candidate"`
+	DirtyDelta          syncPlanJSONSize      `json:"dirtyDelta"`
+	DeletedTrackedPaths int                   `json:"deletedTrackedPaths"`
+	Guardrail           syncPlanJSONGuardrail `json:"guardrail"`
+	TopFiles            []syncPlanJSONRow     `json:"topFiles"`
+	TopDirs             []syncPlanJSONRow     `json:"topDirs"`
+}
+
+type syncPlanJSONSize struct {
+	Files      int    `json:"files"`
+	Bytes      int64  `json:"bytes"`
+	HumanBytes string `json:"humanBytes"`
+}
+
+type syncPlanJSONRow struct {
+	Path       string `json:"path"`
+	Bytes      int64  `json:"bytes"`
+	HumanBytes string `json:"humanBytes"`
+}
+
+type syncPlanJSONGuardrail struct {
+	Scope      string                        `json:"scope"`
+	Files      int                           `json:"files"`
+	Bytes      int64                         `json:"bytes"`
+	HumanBytes string                        `json:"humanBytes"`
+	Limits     syncPlanJSONGuardrailLimits   `json:"limits"`
+	AllowLarge bool                          `json:"allowLarge"`
+	Status     string                        `json:"status"`
+	Reasons    []syncPlanJSONGuardrailReason `json:"reasons,omitempty"`
+}
+
+type syncPlanJSONGuardrailLimits struct {
+	WarnFiles int   `json:"warnFiles"`
+	WarnBytes int64 `json:"warnBytes"`
+	FailFiles int   `json:"failFiles"`
+	FailBytes int64 `json:"failBytes"`
+}
+
+type syncPlanJSONGuardrailReason struct {
+	Status string `json:"status"`
+	Metric string `json:"metric"`
+	Actual int64  `json:"actual"`
+	Limit  int64  `json:"limit"`
+}
+
 func (a App) syncPlan(ctx context.Context, args []string) error {
 	_ = ctx
 	fs := newFlagSet("sync-plan", a.Stderr)
 	limit := fs.Int("limit", 20, "number of top files and directories to print")
+	jsonOut := fs.Bool("json", false, "print JSON")
 	if err := parseFlags(fs, args); err != nil {
 		return err
 	}
@@ -41,6 +89,13 @@ func (a App) syncPlan(ctx context.Context, args []string) error {
 		return exit(6, "build sync file list: %v", err)
 	}
 	files, dirs := syncPlanRows(repo.Root, manifest, *limit)
+	if *jsonOut {
+		out := syncPlanJSON(manifest, files, dirs, cfg)
+		if err := json.NewEncoder(a.Stdout).Encode(out); err != nil {
+			return err
+		}
+		return nil
+	}
 	fmt.Fprintf(a.Stdout, "sync candidate: %d files, %s\n", len(manifest.Files), humanBytes(manifest.Bytes))
 	if len(manifest.Deleted) > 0 {
 		fmt.Fprintf(a.Stdout, "deleted tracked paths: %d\n", len(manifest.Deleted))
@@ -54,6 +109,74 @@ func (a App) syncPlan(ctx context.Context, args []string) error {
 		fmt.Fprintf(a.Stdout, "  %-10s %s\n", humanBytes(row.Bytes), row.Path)
 	}
 	return nil
+}
+
+func syncPlanJSON(manifest SyncManifest, files, dirs []syncPlanRow, cfg Config) syncPlanJSONOutput {
+	return syncPlanJSONOutput{
+		Candidate:           syncPlanJSONSizeFor(len(manifest.Files), manifest.Bytes),
+		DirtyDelta:          syncPlanJSONSizeFor(len(manifest.Changed), manifest.ChangedBytes),
+		DeletedTrackedPaths: len(manifest.Deleted),
+		Guardrail:           syncPlanJSONGuardrailFor(manifest, cfg),
+		TopFiles:            syncPlanJSONRows(files),
+		TopDirs:             syncPlanJSONRows(dirs),
+	}
+}
+
+func syncPlanJSONSizeFor(files int, bytes int64) syncPlanJSONSize {
+	return syncPlanJSONSize{Files: files, Bytes: bytes, HumanBytes: humanBytes(bytes)}
+}
+
+func syncPlanJSONRows(rows []syncPlanRow) []syncPlanJSONRow {
+	out := make([]syncPlanJSONRow, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, syncPlanJSONRow{Path: row.Path, Bytes: row.Bytes, HumanBytes: humanBytes(row.Bytes)})
+	}
+	return out
+}
+
+func syncPlanJSONGuardrailFor(manifest SyncManifest, cfg Config) syncPlanJSONGuardrail {
+	count, bytes, scope, _ := syncGuardrailScope(manifest)
+	out := syncPlanJSONGuardrail{
+		Scope:      scope,
+		Files:      count,
+		Bytes:      bytes,
+		HumanBytes: humanBytes(bytes),
+		Limits: syncPlanJSONGuardrailLimits{
+			WarnFiles: cfg.Sync.WarnFiles,
+			WarnBytes: cfg.Sync.WarnBytes,
+			FailFiles: cfg.Sync.FailFiles,
+			FailBytes: cfg.Sync.FailBytes,
+		},
+		AllowLarge: cfg.Sync.AllowLarge || os.Getenv("CRABBOX_SYNC_ALLOW_LARGE") == "1",
+		Status:     "ok",
+	}
+	if !out.AllowLarge {
+		if cfg.Sync.FailFiles > 0 && count >= cfg.Sync.FailFiles {
+			out.addReason("failed", "files", int64(count), int64(cfg.Sync.FailFiles))
+		}
+		if cfg.Sync.FailBytes > 0 && bytes >= cfg.Sync.FailBytes {
+			out.addReason("failed", "bytes", bytes, cfg.Sync.FailBytes)
+		}
+	}
+	if cfg.Sync.WarnFiles > 0 && count >= cfg.Sync.WarnFiles {
+		out.addReason("warning", "files", int64(count), int64(cfg.Sync.WarnFiles))
+	}
+	if cfg.Sync.WarnBytes > 0 && bytes >= cfg.Sync.WarnBytes {
+		out.addReason("warning", "bytes", bytes, cfg.Sync.WarnBytes)
+	}
+	return out
+}
+
+func (g *syncPlanJSONGuardrail) addReason(status, metric string, actual, limit int64) {
+	if status == "failed" || g.Status == "ok" {
+		g.Status = status
+	}
+	g.Reasons = append(g.Reasons, syncPlanJSONGuardrailReason{
+		Status: status,
+		Metric: metric,
+		Actual: actual,
+		Limit:  limit,
+	})
 }
 
 func syncPlanRows(root string, manifest SyncManifest, limit int) ([]syncPlanRow, []syncPlanRow) {

--- a/internal/cli/sync_plan_test.go
+++ b/internal/cli/sync_plan_test.go
@@ -1,6 +1,14 @@
 package cli
 
-import "testing"
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
 func TestSyncPlanDir(t *testing.T) {
 	tests := map[string]string{
@@ -24,4 +32,78 @@ func TestSortSyncPlanRows(t *testing.T) {
 	if got != "cab" {
 		t.Fatalf("sorted rows=%v", rows)
 	}
+}
+
+func TestSyncPlanJSONOutput(t *testing.T) {
+	clearConfigEnv(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("CRABBOX_PROVIDER", "")
+	t.Setenv("CRABBOX_DEFAULT_CLASS", "")
+	t.Setenv("CRABBOX_SYNC_ALLOW_LARGE", "")
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	writeFile(t, cfgPath, "sync:\n  warnFiles: 1\n  warnBytes: 4\n  failFiles: 2\n  failBytes: 30\n")
+	t.Setenv("CRABBOX_CONFIG", cfgPath)
+
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.email", "test@example.com")
+	runGit(t, dir, "config", "user.name", "Test")
+	writeFile(t, filepath.Join(dir, "README.md"), "readme")
+	writeFile(t, filepath.Join(dir, "assets", "demo.bin"), strings.Repeat("x", 16))
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-m", "init")
+	if err := os.Remove(filepath.Join(dir, "README.md")); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(dir, "notes.txt"), "note-data")
+	t.Chdir(dir)
+
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).Run(context.Background(), []string{"sync-plan", "--limit", "1", "--json"})
+	if err != nil {
+		t.Fatalf("sync-plan --json error=%v stderr=%q", err, stderr.String())
+	}
+	var got syncPlanJSONOutput
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("decode sync-plan JSON: %v\n%s", err, stdout.String())
+	}
+
+	if got.Candidate.Files != 2 || got.Candidate.Bytes != 25 || got.Candidate.HumanBytes != "25 B" {
+		t.Fatalf("candidate=%+v", got.Candidate)
+	}
+	if got.DirtyDelta.Files != 2 || got.DirtyDelta.Bytes != 9 || got.DeletedTrackedPaths != 1 {
+		t.Fatalf("dirty=%+v deleted=%d", got.DirtyDelta, got.DeletedTrackedPaths)
+	}
+	if got.Guardrail.Scope != "dirty_delta" || got.Guardrail.Files != 2 || got.Guardrail.Bytes != 9 || got.Guardrail.Status != "failed" {
+		t.Fatalf("guardrail=%+v", got.Guardrail)
+	}
+	if got.Guardrail.Limits.FailFiles != 2 || got.Guardrail.Limits.WarnBytes != 4 || got.Guardrail.AllowLarge {
+		t.Fatalf("guardrail limits=%+v allowLarge=%t", got.Guardrail.Limits, got.Guardrail.AllowLarge)
+	}
+	for _, want := range []syncPlanJSONGuardrailReason{
+		{Status: "failed", Metric: "files", Actual: 2, Limit: 2},
+		{Status: "warning", Metric: "files", Actual: 2, Limit: 1},
+		{Status: "warning", Metric: "bytes", Actual: 9, Limit: 4},
+	} {
+		if !syncPlanHasReason(got.Guardrail.Reasons, want) {
+			t.Fatalf("guardrail reasons=%+v missing=%+v", got.Guardrail.Reasons, want)
+		}
+	}
+	if len(got.TopFiles) != 1 || got.TopFiles[0].Path != "assets/demo.bin" || got.TopFiles[0].Bytes != 16 || got.TopFiles[0].HumanBytes != "16 B" {
+		t.Fatalf("topFiles=%+v", got.TopFiles)
+	}
+	if len(got.TopDirs) != 1 || got.TopDirs[0].Path != "assets" || got.TopDirs[0].Bytes != 16 {
+		t.Fatalf("topDirs=%+v", got.TopDirs)
+	}
+}
+
+func syncPlanHasReason(got []syncPlanJSONGuardrailReason, want syncPlanJSONGuardrailReason) bool {
+	for _, reason := range got {
+		if reason == want {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary

- add `crabbox sync-plan --json` for machine-readable sync preflight output
- include candidate totals, dirty-delta totals, deleted tracked paths, guardrail status and reasons, and ranked file and directory rows
- share one guardrail evaluator between normal run preflight and JSON output so the contracts cannot drift
- document the JSON contract and add command-level regression coverage

## Why

`sync-plan` already computes the manifest used by `run`, but text-only output is awkward for CI and automation that budget sync size before provisioning a remote box.

## Verification

- `go vet ./...`
- `go test -race ./...`
- `scripts/check-docs.sh`
- real `go run ./cmd/crabbox sync-plan --limit 2 --json` output decoded and inspected with `jq`
- autoreview clean

One unrelated controller retry timing test failed once in the autoreview parallel test run, then passed 5/5 in isolation; the subsequent full race suite passed.
