### PR TITLE
docs: add hermetic agent evidence pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Documented a provider-neutral hermetic-agent evidence pattern with separate writer contexts, QA arbitration, required proof artifacts, and sync-safe local downloads. Thanks @zozo123.
 - Added `sync-plan --json` with candidate and dirty-delta sizes, configured guardrail status, deleted-path counts, and ranked file and directory hotspots for automation. Thanks @zozo123.
 - Added a CubeSandbox delegated-run provider with E2B-compatible lifecycle and envd execution, archive sync, CubeProxy routing, exact API-endpoint/sandbox-bound ownership claims, conflict-safe explicit adoption, and guarded cleanup. Thanks @zozo123.
 - Added coordinator-managed Daytona Linux leases with a Worker-held API key, exact ownership cleanup, expiring SSH-token refresh, CLI secret redaction, and production Cloudflare configuration.

--- a/README.md
+++ b/README.md
@@ -313,7 +313,8 @@ and authoring guide.
 - **Agent workspace evidence.** History, logs, events, telemetry, JUnit
   summaries, screenshots, recordings, artifacts, and PR publishing make
   autonomous work reviewable instead of only ephemeral terminal output. See
-  [Artifacts](docs/features/artifacts.md) and
+  [Hermetic agent evidence](docs/features/hermetic-agent-evidence.md),
+  [Artifacts](docs/features/artifacts.md), and
   [Telemetry](docs/features/telemetry.md).
 - **Stable timing records.** `--timing-json` on `run`, `warmup`, `prewarm`, and
   `actions hydrate` gives scripts one machine-readable sync/command/total

--- a/docs/README.md
+++ b/docs/README.md
@@ -141,7 +141,8 @@ Pick whichever matches your intent:
   [Runtime adapter stack](features/runtime-adapter-stack.md),
   [Capabilities](features/capabilities.md),
   [Interactive desktop and VNC](features/interactive-desktop-vnc.md),
-  [Telemetry](features/telemetry.md), [Sync](features/sync.md).
+  [Telemetry](features/telemetry.md), [Sync](features/sync.md),
+  [Hermetic agent evidence](features/hermetic-agent-evidence.md).
 - **Pick or add a target:** [Provider reference](providers/README.md),
   [Providers feature overview](features/providers.md),
   [Provider selection](features/provider-selection.md),

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -90,9 +90,9 @@ Provider deep-dives that live here in `features/`:
 - [Station profiles](station-profiles.md): planned supervised workload records, agent profile, and model-access security gates.
 - [Agent runtime bridge](agent-runtime-bridge.md): contract for future
   harness-in-the-box HTTP/SSE bridge support under Station.
-- [Hermetic agent evidence](hermetic-agent-evidence.md): public demo showing
+- [Hermetic agent evidence](hermetic-agent-evidence.md): repo-local pattern for
   separate code/test writer contexts, QA arbitration, required artifacts, and
-  Crabbox/Islo remote proof collection.
+  Crabbox remote proof collection.
 - [Deterministic perf evidence](deterministic-perf-evidence.md): contract for
   future reproducible metric budgets and perf gate evidence.
 - [Actions hydration](actions-hydration.md): let GitHub Actions prepare a runner, then sync local work into that workspace.

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -90,6 +90,9 @@ Provider deep-dives that live here in `features/`:
 - [Station profiles](station-profiles.md): planned supervised workload records, agent profile, and model-access security gates.
 - [Agent runtime bridge](agent-runtime-bridge.md): contract for future
   harness-in-the-box HTTP/SSE bridge support under Station.
+- [Hermetic agent evidence](hermetic-agent-evidence.md): public demo showing
+  separate code/test writer contexts, QA arbitration, required artifacts, and
+  Crabbox/Islo remote proof collection.
 - [Deterministic perf evidence](deterministic-perf-evidence.md): contract for
   future reproducible metric budgets and perf gate evidence.
 - [Actions hydration](actions-hydration.md): let GitHub Actions prepare a runner, then sync local work into that workspace.

--- a/docs/features/hermetic-agent-evidence.md
+++ b/docs/features/hermetic-agent-evidence.md
@@ -9,14 +9,14 @@ Read this when:
 Crabbox is a useful execution layer for hermetic-agent workflows because the
 repository owns the agent protocol while Crabbox owns the remote run and
 evidence plumbing: sync the checkout, run the command on a clean runner or
-delegated sandbox, require proof artifacts, download bounded evidence, and keep
+delegated sandbox, require proof artifacts, download selected evidence, and keep
 the exact command output reviewable.
 
 The best Crabbox fit is a **run-evidence pattern**, not a new agent framework:
 
 - `crabbox run` executes the repo-owned hermetic harness.
 - `--require-artifact` turns the proof JSON into a post-run gate.
-- `--download` pulls the bounded proof files back for review or agent handoff.
+- `--download` pulls selected proof files back for review or agent handoff.
 - Provider choice stays ordinary Crabbox policy: SSH-backed Linux providers when
   the operator wants Crabbox-managed SSH and rsync, or delegated providers when
   their adapter advertises bounded artifact/download support.
@@ -39,11 +39,11 @@ A hermetic-agent harness usually models three roles:
 | Test writer | `spec/problem.md`, `guides/test-writer.md` | Must not read implementation output |
 | QA arbiter | Spec, both outputs, hidden oracle | May send blame backward, but not forbidden artifacts |
 
-The seeded failure is intentionally a bad generated test expectation. The
-implementation follows the spec, the test expects the wrong case-folding result,
-and QA assigns the disagreement to `test_writer`. That matters because hidden or
-generated tests are not automatically truth; the reviewer must still decide
-which side violated the spec.
+A useful validation fixture intentionally seeds a bad generated test
+expectation. For example, the implementation follows the spec, the test expects
+the wrong case-folding result, and QA assigns the disagreement to `test_writer`.
+That matters because hidden or generated tests are not automatically truth; the
+reviewer must still decide which side violated the spec.
 
 ## Local Proof
 
@@ -76,15 +76,18 @@ crabbox job run hermetic-agents
 ```
 
 The job runs the local proof script, requires the JSON proof file after command
-success, and downloads JSON/Markdown evidence into `.crabbox/proofs/`.
+success, and downloads JSON/Markdown evidence into
+`.crabbox/runs/hermetic-agents/`. Crabbox always excludes `.crabbox/runs/` from
+later workspace syncs, so a prior proof is not uploaded as source on the next
+run.
 
 The same flow without the job wrapper is:
 
 ```sh
 crabbox run \
   --require-artifact docs/metrics/hermetic-agents-e2e.json \
-  --download docs/metrics/hermetic-agents-e2e.json=.crabbox/proofs/hermetic-agents-e2e.json \
-  --download docs/metrics/hermetic-agents-e2e.md=.crabbox/proofs/hermetic-agents-e2e.md \
+  --download docs/metrics/hermetic-agents-e2e.json=.crabbox/runs/hermetic-agents/hermetic-agents-e2e.json \
+  --download docs/metrics/hermetic-agents-e2e.md=.crabbox/runs/hermetic-agents/hermetic-agents-e2e.md \
   --shell './scripts/run_hermetic_agents_demo.sh'
 ```
 
@@ -105,7 +108,7 @@ Pick the provider the same way you would for any other Crabbox run:
 | Provider | The remote execution substrate; use normal provider selection instead of coupling the pattern to one backend. |
 | SSH-backed mode | Crabbox owns SSH, rsync, command execution, artifacts, history, and telemetry when a brokered provider is used. |
 | Delegated mode | The provider owns workspace upload and command transport; Crabbox owns CLI semantics, claims, required artifacts, downloads, and status when the adapter supports them. |
-| Artifacts | The proof JSON/Markdown are bounded run evidence, not raw transcripts or secrets. |
+| Artifacts | The proof JSON/Markdown are small run evidence, not raw transcripts or secrets. Delegated retrieval is byte-bounded by the adapter contract. |
 | Jobs | `.crabbox.yaml` names the repeatable remote proof as `hermetic-agents`. |
 | History/logs | Brokered SSH providers can add central run history; direct/delegated runs still provide live output and local proof downloads. |
 | Station | Future fit for long-running agent harnesses. This pattern is intentionally a one-shot run. |
@@ -179,8 +182,8 @@ jobs:
     requiredArtifacts:
       - docs/metrics/hermetic-agents-e2e.json
     downloads:
-      - docs/metrics/hermetic-agents-e2e.json=.crabbox/proofs/hermetic-agents-e2e.json
-      - docs/metrics/hermetic-agents-e2e.md=.crabbox/proofs/hermetic-agents-e2e.md
+      - docs/metrics/hermetic-agents-e2e.json=.crabbox/runs/hermetic-agents/hermetic-agents-e2e.json
+      - docs/metrics/hermetic-agents-e2e.md=.crabbox/runs/hermetic-agents/hermetic-agents-e2e.md
     stop: always
 ```
 

--- a/docs/features/hermetic-agent-evidence.md
+++ b/docs/features/hermetic-agent-evidence.md
@@ -12,6 +12,20 @@ evidence plumbing: sync the checkout, run the command on a clean runner or
 delegated sandbox, require proof artifacts, download bounded evidence, and keep
 the exact command output reviewable.
 
+The best Crabbox fit is a **run-evidence pattern**, not a new agent framework:
+
+- `crabbox run` executes the repo-owned hermetic harness.
+- `--require-artifact` turns the proof JSON into a post-run gate.
+- `--download` pulls the bounded proof files back for review or agent handoff.
+- Provider choice stays ordinary Crabbox policy: Islo for delegated sandbox
+  execution, or an SSH-backed Linux provider when the operator wants
+  Crabbox-managed SSH and rsync.
+
+Crabbox should not judge model output, store reasoning traces, decide whether a
+test is correct, or deliver model credentials for this pattern. Those decisions
+belong to the repo-owned harness and, later, to separately reviewed Station and
+agent-runtime bridge work.
+
 This page documents the public demo tracked by
 [openclaw/crabbox#1020](https://github.com/openclaw/crabbox/issues/1020):
 
@@ -81,6 +95,55 @@ Use any SSH-backed Linux provider instead of Islo when you want Crabbox-managed
 SSH and rsync rather than a delegated sandbox. The same `--require-artifact` and
 `--download` gates apply on supported Linux targets.
 
+## Concept Map
+
+| Crabbox concept | Fit in this demo |
+| --- | --- |
+| Run | One remote execution of the repo-owned hermetic harness. |
+| Workspace | The synced checkout containing specs, guides, harness code, and output paths. |
+| Provider | The remote execution substrate; the demo defaults to `islo` but does not require it. |
+| Delegated mode | With Islo, the provider owns archive upload and command transport; Crabbox owns CLI semantics, claims, required artifacts, downloads, and status. |
+| Artifacts | The proof JSON/Markdown are bounded run evidence, not raw transcripts or secrets. |
+| Jobs | `.crabbox.yaml` names the repeatable remote proof as `hermetic-agents`. |
+| History/logs | Brokered SSH providers can add central run history; direct/delegated runs still provide live output and local proof downloads. |
+| Station | Future fit for long-running agent harnesses. This demo is intentionally a one-shot run. |
+
+## Trust Boundary
+
+This pattern does not turn Crabbox into a hostile multi-tenant sandbox. Treat the
+repository config and harness as executable project automation, just like a
+Makefile or CI workflow.
+
+Keep these boundaries explicit:
+
+- The code/test writer separation is enforced by the harness manifests, not by
+  Crabbox itself.
+- Crabbox can require that the proof file exists; it does not validate the proof
+  schema unless the repo command does so.
+- Provider API keys and model/tool credentials must stay out of repo YAML and
+  command arguments.
+- Proof artifacts should be small, bounded, and redacted before sharing.
+- If a real model-backed version needs credentials, do not forward ambient
+  secrets through `env.allow`; wait for a reviewed workload-specific credential
+  path.
+
+## Station Later
+
+Long-running hermetic-agent systems may eventually fit Station better than
+one-shot `run`: a station could supervise coder/tester/QA processes, record
+attempt lifecycle, bridge a repo-owned harness API, and revoke model access on
+stop. That is not what this demo uses.
+
+Today, keep the path simple:
+
+```text
+repo harness -> crabbox run -> required proof artifact -> downloaded evidence
+```
+
+When Station and the agent-runtime bridge mature, the same proof schema can
+become station evidence without moving prompt loops or test interpretation into
+Crabbox core.
+
 ## Why This Belongs In Repo Config
 
 The agent protocol should stay in the application repo:
@@ -98,6 +161,35 @@ Crabbox should stay generic:
 
 This boundary keeps Crabbox from becoming an agent framework while still making
 agent output auditable.
+
+## Good Repo Config
+
+Keep the Crabbox YAML focused on execution policy:
+
+```yaml
+jobs:
+  hermetic-agents:
+    provider: islo
+    target: linux
+    shell: true
+    command: ./scripts/run_hermetic_agents_demo.sh
+    requiredArtifacts:
+      - docs/metrics/hermetic-agents-e2e.json
+    downloads:
+      - docs/metrics/hermetic-agents-e2e.json=.crabbox/proofs/hermetic-agents-e2e.json
+      - docs/metrics/hermetic-agents-e2e.md=.crabbox/proofs/hermetic-agents-e2e.md
+    stop: always
+```
+
+Keep the agent policy in repo-owned files such as:
+
+```text
+spec/problem.md
+guides/code-writer.md
+guides/test-writer.md
+guides/qa-arbiter.md
+scripts/hermetic_agents_demo.py
+```
 
 ## Review Checklist
 

--- a/docs/features/hermetic-agent-evidence.md
+++ b/docs/features/hermetic-agent-evidence.md
@@ -47,7 +47,8 @@ which side violated the spec.
 
 ## Local Proof
 
-A repository should keep a local proof command that works without Crabbox:
+A repository should keep a local proof command that works without Crabbox. For
+example:
 
 ```sh
 ./scripts/run_hermetic_agents_demo.sh
@@ -67,8 +68,8 @@ verdict, and the exact disagreement assigned to the test writer.
 
 ## Crabbox Run
 
-A repository can expose the same proof as a `.crabbox.yaml` job. With a normal
-SSH-backed Linux provider, the job shape is:
+A repository can expose the same proof as a `.crabbox.yaml` job. With an
+SSH-backed Linux provider, the user-facing command stays ordinary Crabbox:
 
 ```sh
 crabbox job run hermetic-agents
@@ -171,6 +172,7 @@ Keep the Crabbox YAML focused on execution policy:
 ```yaml
 jobs:
   hermetic-agents:
+    # Choose any provider that fits the repo: aws, hetzner, gcp, azure, ssh, etc.
     provider: aws
     target: linux
     shell: true

--- a/docs/features/hermetic-agent-evidence.md
+++ b/docs/features/hermetic-agent-evidence.md
@@ -4,7 +4,7 @@ Read this when:
 
 - running AI-generated code and tests from the same specification;
 - keeping the code writer, test writer, and QA reviewer in separate contexts;
-- using Crabbox to collect a durable proof file from the remote run.
+- using Crabbox to require and download durable proof files from the remote run.
 
 Crabbox is a useful execution layer for hermetic-agent workflows because the
 repository owns the agent protocol while Crabbox owns the remote run and
@@ -17,24 +17,21 @@ The best Crabbox fit is a **run-evidence pattern**, not a new agent framework:
 - `crabbox run` executes the repo-owned hermetic harness.
 - `--require-artifact` turns the proof JSON into a post-run gate.
 - `--download` pulls the bounded proof files back for review or agent handoff.
-- Provider choice stays ordinary Crabbox policy: Islo for delegated sandbox
-  execution, or an SSH-backed Linux provider when the operator wants
-  Crabbox-managed SSH and rsync.
+- Provider choice stays ordinary Crabbox policy: SSH-backed Linux providers when
+  the operator wants Crabbox-managed SSH and rsync, or delegated providers when
+  their adapter advertises bounded artifact/download support.
 
 Crabbox should not judge model output, store reasoning traces, decide whether a
 test is correct, or deliver model credentials for this pattern. Those decisions
 belong to the repo-owned harness and, later, to separately reviewed Station and
 agent-runtime bridge work.
 
-This page documents the public demo tracked by
-[openclaw/crabbox#1020](https://github.com/openclaw/crabbox/issues/1020):
+This page records the repo-local pattern tracked by
+[openclaw/crabbox#1020](https://github.com/openclaw/crabbox/issues/1020).
 
-- Demo repo: <https://github.com/zozo123/hermetic-agents-demo>
-- Live page: <https://zozo123.github.io/hermetic-agents-demo/>
+## Pattern Shape
 
-## Demo Shape
-
-The demo models three roles:
+A hermetic-agent harness usually models three roles:
 
 | Role | Allowed context | Forbidden context |
 | --- | --- | --- |
@@ -50,7 +47,7 @@ which side violated the spec.
 
 ## Local Proof
 
-The demo can run without Crabbox:
+A repository should keep a local proof command that works without Crabbox:
 
 ```sh
 ./scripts/run_hermetic_agents_demo.sh
@@ -70,43 +67,48 @@ verdict, and the exact disagreement assigned to the test writer.
 
 ## Crabbox Run
 
-The demo repo includes a `.crabbox.yaml` job:
+A repository can expose the same proof as a `.crabbox.yaml` job. With a normal
+SSH-backed Linux provider, the job shape is:
 
 ```sh
-export CRABBOX_ISLO_API_KEY=ak_...
 crabbox job run hermetic-agents
 ```
 
-That job uses `provider: islo`, runs the local proof script, requires the JSON
-proof file after command success, and downloads the JSON/Markdown evidence into
-`.crabbox/proofs/`.
+The job runs the local proof script, requires the JSON proof file after command
+success, and downloads JSON/Markdown evidence into `.crabbox/proofs/`.
 
 The same flow without the job wrapper is:
 
 ```sh
-crabbox run --provider islo \
+crabbox run \
   --require-artifact docs/metrics/hermetic-agents-e2e.json \
   --download docs/metrics/hermetic-agents-e2e.json=.crabbox/proofs/hermetic-agents-e2e.json \
   --download docs/metrics/hermetic-agents-e2e.md=.crabbox/proofs/hermetic-agents-e2e.md \
   --shell './scripts/run_hermetic_agents_demo.sh'
 ```
 
-Use any SSH-backed Linux provider instead of Islo when you want Crabbox-managed
-SSH and rsync rather than a delegated sandbox. The same `--require-artifact` and
-`--download` gates apply on supported Linux targets.
+Pick the provider the same way you would for any other Crabbox run:
+
+- Use brokered or direct SSH-backed Linux providers (`aws`, `azure`, `gcp`,
+  `hetzner`, `ssh`, and similar) when you want Crabbox-managed SSH, rsync,
+  broker history, telemetry, or warm-box reuse.
+- Use a delegated provider only when its adapter supports the required evidence
+  features. Islo, for example, supports bounded single-file `--require-artifact`
+  and `--download`.
 
 ## Concept Map
 
-| Crabbox concept | Fit in this demo |
+| Crabbox concept | Fit in this pattern |
 | --- | --- |
 | Run | One remote execution of the repo-owned hermetic harness. |
 | Workspace | The synced checkout containing specs, guides, harness code, and output paths. |
-| Provider | The remote execution substrate; the demo defaults to `islo` but does not require it. |
-| Delegated mode | With Islo, the provider owns archive upload and command transport; Crabbox owns CLI semantics, claims, required artifacts, downloads, and status. |
+| Provider | The remote execution substrate; use normal provider selection instead of coupling the pattern to one backend. |
+| SSH-backed mode | Crabbox owns SSH, rsync, command execution, artifacts, history, and telemetry when a brokered provider is used. |
+| Delegated mode | The provider owns workspace upload and command transport; Crabbox owns CLI semantics, claims, required artifacts, downloads, and status when the adapter supports them. |
 | Artifacts | The proof JSON/Markdown are bounded run evidence, not raw transcripts or secrets. |
 | Jobs | `.crabbox.yaml` names the repeatable remote proof as `hermetic-agents`. |
 | History/logs | Brokered SSH providers can add central run history; direct/delegated runs still provide live output and local proof downloads. |
-| Station | Future fit for long-running agent harnesses. This demo is intentionally a one-shot run. |
+| Station | Future fit for long-running agent harnesses. This pattern is intentionally a one-shot run. |
 
 ## Trust Boundary
 
@@ -132,7 +134,7 @@ Keep these boundaries explicit:
 Long-running hermetic-agent systems may eventually fit Station better than
 one-shot `run`: a station could supervise coder/tester/QA processes, record
 attempt lifecycle, bridge a repo-owned harness API, and revoke model access on
-stop. That is not what this demo uses.
+stop. That is not what this pattern uses.
 
 Today, keep the path simple:
 
@@ -169,7 +171,7 @@ Keep the Crabbox YAML focused on execution policy:
 ```yaml
 jobs:
   hermetic-agents:
-    provider: islo
+    provider: aws
     target: linux
     shell: true
     command: ./scripts/run_hermetic_agents_demo.sh
@@ -191,6 +193,10 @@ guides/qa-arbiter.md
 scripts/hermetic_agents_demo.py
 ```
 
+Switch `provider` to `islo` or another delegated backend only after confirming
+that backend supports the required artifact/download capabilities used by the
+job.
+
 ## Review Checklist
 
 Before sharing a hermetic-agent run, verify:
@@ -202,4 +208,6 @@ Before sharing a hermetic-agent run, verify:
 - Downloaded proof files contain no secrets or raw customer data.
 
 For artifact semantics and storage limits, see [Artifacts](artifacts.md). For
-delegated Islo behavior, see [Islo Provider](../providers/islo.md).
+provider capability details, see [Providers](providers.md),
+[Provider backends](../provider-backends.md), and any selected per-provider
+page.

--- a/docs/features/hermetic-agent-evidence.md
+++ b/docs/features/hermetic-agent-evidence.md
@@ -33,11 +33,11 @@ This page records the repo-local pattern tracked by
 
 A hermetic-agent harness usually models three roles:
 
-| Role | Allowed context | Forbidden context |
+| Role | Allowed context | Boundary |
 | --- | --- | --- |
-| Code writer | `spec/problem.md`, `guides/code-writer.md` | Generated tests |
-| Test writer | `spec/problem.md`, `guides/test-writer.md` | Implementation output |
-| QA arbiter | Spec, both outputs, hidden oracle | May send blame, not forbidden artifacts |
+| Code writer | `spec/problem.md`, `guides/code-writer.md` | Must not read generated tests |
+| Test writer | `spec/problem.md`, `guides/test-writer.md` | Must not read implementation output |
+| QA arbiter | Spec, both outputs, hidden oracle | May send blame backward, but not forbidden artifacts |
 
 The seeded failure is intentionally a bad generated test expectation. The
 implementation follows the spec, the test expects the wrong case-folding result,
@@ -47,8 +47,8 @@ which side violated the spec.
 
 ## Local Proof
 
-A repository should keep a local proof command that works without Crabbox. For
-example:
+An application repo should keep a local proof command that works without
+Crabbox. For example:
 
 ```sh
 ./scripts/run_hermetic_agents_demo.sh
@@ -94,8 +94,7 @@ Pick the provider the same way you would for any other Crabbox run:
   `hetzner`, `ssh`, and similar) when you want Crabbox-managed SSH, rsync,
   broker history, telemetry, or warm-box reuse.
 - Use a delegated provider only when its adapter supports the required evidence
-  features. Islo, for example, supports bounded single-file `--require-artifact`
-  and `--download`.
+  features, such as bounded single-file `--require-artifact` and `--download`.
 
 ## Concept Map
 
@@ -172,8 +171,8 @@ Keep the Crabbox YAML focused on execution policy:
 ```yaml
 jobs:
   hermetic-agents:
-    # Choose any provider that fits the repo: aws, hetzner, gcp, azure, ssh, etc.
-    provider: aws
+    # Omit provider to inherit user/team defaults, or set aws/hetzner/gcp/azure/ssh/etc.
+    # provider: aws
     target: linux
     shell: true
     command: ./scripts/run_hermetic_agents_demo.sh

--- a/docs/features/hermetic-agent-evidence.md
+++ b/docs/features/hermetic-agent-evidence.md
@@ -1,0 +1,113 @@
+# Hermetic Agent Evidence
+
+Read this when:
+
+- running AI-generated code and tests from the same specification;
+- keeping the code writer, test writer, and QA reviewer in separate contexts;
+- using Crabbox to collect a durable proof file from the remote run.
+
+Crabbox is a useful execution layer for hermetic-agent workflows because the
+repository owns the agent protocol while Crabbox owns the remote run and
+evidence plumbing: sync the checkout, run the command on a clean runner or
+delegated sandbox, require proof artifacts, download bounded evidence, and keep
+the exact command output reviewable.
+
+This page documents the public demo tracked by
+[openclaw/crabbox#1020](https://github.com/openclaw/crabbox/issues/1020):
+
+- Demo repo: <https://github.com/zozo123/hermetic-agents-demo>
+- Live page: <https://zozo123.github.io/hermetic-agents-demo/>
+
+## Demo Shape
+
+The demo models three roles:
+
+| Role | Allowed context | Forbidden context |
+| --- | --- | --- |
+| Code writer | `spec/problem.md`, `guides/code-writer.md` | Generated tests |
+| Test writer | `spec/problem.md`, `guides/test-writer.md` | Implementation output |
+| QA arbiter | Spec, both outputs, hidden oracle | May send blame, not forbidden artifacts |
+
+The seeded failure is intentionally a bad generated test expectation. The
+implementation follows the spec, the test expects the wrong case-folding result,
+and QA assigns the disagreement to `test_writer`. That matters because hidden or
+generated tests are not automatically truth; the reviewer must still decide
+which side violated the spec.
+
+## Local Proof
+
+The demo can run without Crabbox:
+
+```sh
+./scripts/run_hermetic_agents_demo.sh
+python3 scripts/hermetic_agents_demo.py --self-test
+bazelisk test //:hermetic_agents_e2e_test
+```
+
+Those commands write:
+
+```text
+docs/metrics/hermetic-agents-e2e.json
+docs/metrics/hermetic-agents-e2e.md
+```
+
+The JSON includes the role manifests, leak-check results, artifact digests, QA
+verdict, and the exact disagreement assigned to the test writer.
+
+## Crabbox Run
+
+The demo repo includes a `.crabbox.yaml` job:
+
+```sh
+export CRABBOX_ISLO_API_KEY=ak_...
+crabbox job run hermetic-agents
+```
+
+That job uses `provider: islo`, runs the local proof script, requires the JSON
+proof file after command success, and downloads the JSON/Markdown evidence into
+`.crabbox/proofs/`.
+
+The same flow without the job wrapper is:
+
+```sh
+crabbox run --provider islo \
+  --require-artifact docs/metrics/hermetic-agents-e2e.json \
+  --download docs/metrics/hermetic-agents-e2e.json=.crabbox/proofs/hermetic-agents-e2e.json \
+  --download docs/metrics/hermetic-agents-e2e.md=.crabbox/proofs/hermetic-agents-e2e.md \
+  --shell './scripts/run_hermetic_agents_demo.sh'
+```
+
+Use any SSH-backed Linux provider instead of Islo when you want Crabbox-managed
+SSH and rsync rather than a delegated sandbox. The same `--require-artifact` and
+`--download` gates apply on supported Linux targets.
+
+## Why This Belongs In Repo Config
+
+The agent protocol should stay in the application repo:
+
+- the distilled spec and role guides are project-specific;
+- the oracle and blame policy are part of the review contract;
+- the proof schema can evolve with the demo or product under test.
+
+Crabbox should stay generic:
+
+- sync the exact checkout being reviewed;
+- execute the declared command remotely;
+- require bounded proof artifacts before reporting success;
+- download evidence for reviewers, agents, or CI handoff.
+
+This boundary keeps Crabbox from becoming an agent framework while still making
+agent output auditable.
+
+## Review Checklist
+
+Before sharing a hermetic-agent run, verify:
+
+- The proof JSON contains separate `code_writer` and `test_writer` manifests.
+- Leak checks passed for both writer roles.
+- QA verdict and blame assignment are present.
+- Required artifacts were enforced by Crabbox, not only generated locally.
+- Downloaded proof files contain no secrets or raw customer data.
+
+For artifact semantics and storage limits, see [Artifacts](artifacts.md). For
+delegated Islo behavior, see [Islo Provider](../providers/islo.md).

--- a/docs/providers/islo.md
+++ b/docs/providers/islo.md
@@ -25,6 +25,10 @@ need Crabbox-managed SSH access to the box.
 Islo is Linux-only. Desktop, browser, code, Actions hydration, and SSH-based run
 options are not available.
 
+For a small end-to-end example that uses Islo to run a hermetic-agent proof and
+download the required JSON evidence, see
+[Hermetic agent evidence](../features/hermetic-agent-evidence.md).
+
 ## Commands
 
 ```sh

--- a/docs/providers/islo.md
+++ b/docs/providers/islo.md
@@ -25,10 +25,6 @@ need Crabbox-managed SSH access to the box.
 Islo is Linux-only. Desktop, browser, code, Actions hydration, and SSH-based run
 options are not available.
 
-For a small end-to-end example that uses Islo to run a hermetic-agent proof and
-download the required JSON evidence, see
-[Hermetic agent evidence](../features/hermetic-agent-evidence.md).
-
 ## Commands
 
 ```sh


### PR DESCRIPTION
## Summary

- Documents a provider-neutral, repo-local pattern for running a hermetic agent harness through Crabbox.
- Keeps agent protocol and judgment in the application repository while Crabbox owns remote execution, required artifacts, and selected evidence downloads.
- Stores downloaded proof under the sync-protected `.crabbox/runs/` tree so evidence from an earlier run is not uploaded as source on the next run.
- Adds README and feature-index discovery links plus maintainer-side changelog credit.

Closes https://github.com/openclaw/crabbox/issues/1020.

## Verification

- `./scripts/check-docs.sh`
- `go test ./internal/cli -run 'Test(Parse|Load|Merge).*Job|TestJob' -count=1`
- Autoreview: clean, no accepted or actionable findings
