### PR TITLE
fix: require exact E2B cleanup claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Required E2B stop and automatic cleanup to hold an unchanged API-endpoint-, sandbox-, lease-, slug-, and provider-bound local claim across deletion; claimless recovery now requires explicit `--reclaim`. Thanks @coygeek.
 - Prevented config and `.crabboxignore` negations, including case aliases, from re-including Crabbox-owned env profiles, uploaded scripts, logs, captures, and run artifacts in sync manifests. Thanks @zozo123.
 - Allowed ordered `!` re-includes in `.crabboxignore` and `sync.exclude`, with `\!` for literal leading-bang paths. Thanks @chsong1.
 - Completed coordinator diagnostic redaction for non-Bearer authorization schemes, GCP signed URLs, and every configured provider credential field. Thanks @coygeek.

--- a/docs/commands/stop.md
+++ b/docs/commands/stop.md
@@ -64,8 +64,11 @@ Crabbox lease ID and local slug:
   exact local claim binds that RunPod id and provider-returned name. Unclaimed
   and legacy pods remain visible to status/list but require explicit
   `--reclaim` reuse before deletion.
-- `e2b` — accepts a Crabbox lease ID, a local slug, or a Crabbox-owned E2B
-  sandbox ID in raw or `e2b_<sandboxID>` form and deletes the E2B sandbox.
+- `e2b` — accepts a Crabbox lease ID, local slug, or E2B sandbox ID only when
+  an exact local claim binds the sandbox and configured API endpoint. Claimless
+  raw or `e2b_<sandboxID>` identifiers require explicit `--reclaim`; Crabbox
+  re-reads canonical remote ownership metadata and persists the exact claim
+  before deletion. Failed deletion retains the claim for an exact retry.
 - `railway` — refuses unclaimed service IDs. Use `--reclaim` only after
   inspecting the configured API endpoint, project, environment, service, and
   current deployment; Crabbox persists that exact one-deployment binding before

--- a/docs/providers/e2b.md
+++ b/docs/providers/e2b.md
@@ -99,7 +99,8 @@ files.
 
 1. Create or resolve a Crabbox-owned E2B sandbox from `e2b.template` (default
    `base`), with internet access enabled.
-2. Store Crabbox metadata on the sandbox and write a local repo claim.
+2. Store Crabbox metadata on the sandbox and write a local repo claim bound to
+   the exact API endpoint and sandbox ID.
 3. Build the Crabbox sync manifest, upload a gzipped archive into `/tmp`, and
    extract it into the resolved workdir.
 4. Execute the command through the E2B process stream in that workdir.
@@ -162,8 +163,11 @@ Expected results:
 ## Gotchas
 
 - `--id` accepts a Crabbox slug, a `cbx_...` lease ID, or an E2B sandbox ID in
-  raw or `e2b_<sandboxID>` form. Raw and synthetic sandbox IDs are honored only
-  when the sandbox metadata marks it as Crabbox-owned.
+  raw or `e2b_<sandboxID>` form. Destructive cleanup requires an exact local
+  endpoint-and-sandbox claim. To recover a Crabbox-owned sandbox whose claim is
+  missing or legacy, inspect the exact sandbox ID and pass `stop --reclaim`;
+  Crabbox revalidates its canonical lease metadata before adopting and deleting
+  it.
 - `--class` and `--type` are rejected; the E2B template owns sandbox resources.
 - `--checksum` is rejected because there is no Crabbox SSH/rsync target. Large-
   sync preflight guardrails still apply.

--- a/internal/cli/claim.go
+++ b/internal/cli/claim.go
@@ -810,6 +810,10 @@ func providerClaimScope(provider string, cfg Config) string {
 		if endpoint := normalizedCubeSandboxClaimEndpoint(cfg.CubeSandbox.APIURL); endpoint != "" {
 			return "endpoint:" + endpoint
 		}
+	case "e2b":
+		if endpoint := normalizedCubeSandboxClaimEndpoint(cfg.E2B.APIURL); endpoint != "" {
+			return "endpoint:" + endpoint
+		}
 	case "namespace-instance":
 		parts := make([]string, 0, 3)
 		if endpoint := normalizedNamespaceClaimEndpoint(cfg.NamespaceInstance.Endpoint); endpoint != "" {

--- a/internal/cli/claim_test.go
+++ b/internal/cli/claim_test.go
@@ -258,6 +258,17 @@ func TestCubeSandboxProviderClaimScopeBindsAPIEndpoint(t *testing.T) {
 	}
 }
 
+func TestE2BProviderClaimScopeBindsAPIEndpoint(t *testing.T) {
+	cfg := Config{E2B: E2BConfig{APIURL: "HTTPS://API.E2B.APP:443/v1/"}}
+	if got, want := providerClaimScope("e2b", cfg), "endpoint:https://api.e2b.app/v1"; got != want {
+		t.Fatalf("providerClaimScope(e2b)=%q, want %q", got, want)
+	}
+	cfg.E2B.APIURL = ""
+	if got := providerClaimScope("e2b", cfg); got != "" {
+		t.Fatalf("providerClaimScope(e2b)=%q, want empty", got)
+	}
+}
+
 func TestConditionalClaimMutationRejectsChangedState(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	cfg := baseConfig()

--- a/internal/providers/e2b/backend.go
+++ b/internal/providers/e2b/backend.go
@@ -143,11 +143,9 @@ func (b *e2bBackend) Run(ctx context.Context, req RunRequest) (RunResult, error)
 			if !shouldStop {
 				return
 			}
-			if err := b.deleteSandboxForCleanup(client, sandboxID); err != nil {
+			if err := b.deleteClaimedSandboxForCleanup(client, leaseID, sandboxID); err != nil {
 				fmt.Fprintf(b.rt.Stderr, "warning: e2b stop failed for %s: %v\n", sandboxID, err)
-				return
 			}
-			removeLeaseClaim(leaseID)
 		}()
 	}
 	result := RunResult{
@@ -319,15 +317,106 @@ func (b *e2bBackend) Stop(ctx context.Context, req StopRequest) error {
 	if err != nil {
 		return err
 	}
-	leaseID, sandboxID, _, err := b.resolveSandboxID(ctx, client, req.ID, "", false)
+	claim, sandbox, err := b.resolveStopTarget(ctx, client, req.ID)
+	if err != nil {
+		var missing *e2bClaimedSandboxMissingError
+		if errors.As(err, &missing) {
+			if removeErr := removeLeaseClaimIfUnchangedAfter(missing.claim.LeaseID, missing.claim, nil); removeErr != nil {
+				return removeErr
+			}
+			fmt.Fprintf(b.rt.Stderr, "released lease=%s sandbox=%s (already absent)\n", missing.claim.LeaseID, missing.claim.CloudID)
+			return nil
+		}
+		return err
+	}
+	if err := b.deleteClaimedSandbox(ctx, client, claim.LeaseID, sandbox.SandboxID); err != nil {
+		return err
+	}
+	fmt.Fprintf(b.rt.Stderr, "released lease=%s sandbox=%s\n", claim.LeaseID, sandbox.SandboxID)
+	return nil
+}
+
+func (b *e2bBackend) ReclaimAndStop(ctx context.Context, req StopRequest) error {
+	if req.ID == "" {
+		return exit(2, "provider=e2b stop --reclaim requires an exact E2B sandbox id")
+	}
+	sandboxID := req.ID
+	if isE2BSyntheticID(sandboxID) {
+		sandboxID = strings.TrimPrefix(sandboxID, "e2b_")
+	} else if strings.HasPrefix(sandboxID, "cbx_") {
+		return exit(2, "provider=e2b stop --reclaim requires an exact E2B sandbox id, not lease %q", req.ID)
+	}
+	client, err := newE2BClient(b.cfg, b.rt)
 	if err != nil {
 		return err
 	}
-	if err := client.DeleteSandbox(ctx, sandboxID); err != nil {
-		return e2bError("delete sandbox", err)
+	sandbox, err := client.GetSandbox(ctx, sandboxID)
+	if err != nil {
+		return e2bError("get sandbox", err)
 	}
-	removeLeaseClaim(leaseID)
-	fmt.Fprintf(b.rt.Stderr, "released lease=%s sandbox=%s\n", leaseID, sandboxID)
+	if sandbox.SandboxID != sandboxID {
+		return exit(4, "e2b sandbox lookup for %q returned a different sandbox %q", sandboxID, sandbox.SandboxID)
+	}
+	if !isCrabboxE2BSandbox(sandbox) {
+		return exit(4, "e2b sandbox %q is not claimed by Crabbox", req.ID)
+	}
+	leaseID := strings.TrimSpace(sandbox.Metadata["lease"])
+	if !isCanonicalLeaseID(leaseID) {
+		return exit(4, "e2b sandbox %q lacks a canonical Crabbox lease id", req.ID)
+	}
+	slug := strings.TrimSpace(sandbox.Metadata["slug"])
+	if slug == "" {
+		return exit(4, "e2b sandbox %q lacks a canonical Crabbox slug", req.ID)
+	}
+	cfg := e2bClaimConfig(b.cfg)
+	if existing, ok, err := resolveLeaseClaimForProviderCloudIDScope(sandbox.SandboxID, providerClaimScope(cfg)); err != nil {
+		return err
+	} else if ok && existing.LeaseID != leaseID {
+		return exit(4, "e2b sandbox %q is already bound to lease %q", sandbox.SandboxID, existing.LeaseID)
+	}
+	previous, previousExists, err := readLeaseClaimWithPresence(leaseID)
+	if err != nil {
+		return err
+	}
+	if err := validateE2BReclaimCollision(leaseID, sandbox.SandboxID, previous, previousExists); err != nil {
+		return err
+	}
+	var claim LeaseClaim
+	if previousExists && previous.RepoRoot != "" {
+		claim, err = claimLeaseTargetForRepoConfigIfUnchanged(
+			leaseID,
+			slug,
+			cfg,
+			e2bSandboxToServer(sandbox),
+			SSHTarget{},
+			previous.RepoRoot,
+			cfg.IdleTimeout,
+			true,
+			previous,
+			true,
+		)
+	} else {
+		claim, err = claimLeaseTargetForConfigIfUnchanged(
+			leaseID,
+			slug,
+			cfg,
+			e2bSandboxToServer(sandbox),
+			SSHTarget{},
+			cfg.IdleTimeout,
+			previous,
+			previousExists,
+		)
+	}
+	if err != nil {
+		return err
+	}
+	if err := validateE2BClaim(cfg, claim, sandbox); err != nil {
+		return err
+	}
+	if err := b.deleteClaimedSandbox(ctx, client, leaseID, sandbox.SandboxID); err != nil {
+		return err
+	}
+	fmt.Fprintf(b.rt.Stderr, "released lease=%s sandbox=%s\n", leaseID, sandbox.SandboxID)
 	return nil
 }
 
@@ -366,9 +455,10 @@ func (b *e2bBackend) createSandbox(ctx context.Context, client e2bAPI, repo Repo
 	if sandbox.SandboxID == "" {
 		return "", e2bSandbox{}, "", exit(5, "e2b create sandbox returned no sandbox id")
 	}
-	if err := claimLeaseForRepoProviderPond(leaseID, slug, e2bProvider, cfg.Pond, repo.Root, cfg.IdleTimeout, reclaim); err != nil {
+	cfg = e2bClaimConfig(cfg)
+	if err := claimLeaseTargetForRepoConfig(leaseID, slug, cfg, e2bSandboxToServer(sandbox), SSHTarget{}, repo.Root, cfg.IdleTimeout, reclaim); err != nil {
 		if cleanupErr := b.deleteSandboxForCleanup(client, sandbox.SandboxID); cleanupErr != nil {
-			leakErr := fmt.Errorf("cleanup e2b sandbox %s after claim failure: %w; run `crabbox stop --provider e2b --id %s` to retry cleanup", sandbox.SandboxID, cleanupErr, sandbox.SandboxID)
+			leakErr := fmt.Errorf("cleanup e2b sandbox %s after claim failure: %w; run `crabbox stop --provider e2b --id %s --reclaim` to retry cleanup", sandbox.SandboxID, cleanupErr, sandbox.SandboxID)
 			fmt.Fprintf(b.rt.Stderr, "warning: %v\n", leakErr)
 			return "", e2bSandbox{}, "", errors.Join(err, leakErr)
 		}
@@ -383,8 +473,139 @@ func (b *e2bBackend) deleteSandboxForCleanup(client e2bAPI, sandboxID string) er
 	return client.DeleteSandbox(ctx, sandboxID)
 }
 
+func (b *e2bBackend) deleteClaimedSandboxForCleanup(client e2bAPI, leaseID, sandboxID string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), e2bCleanupTimeout)
+	defer cancel()
+	return b.deleteClaimedSandbox(ctx, client, leaseID, sandboxID)
+}
+
 func e2bCleanupCommand(leaseID string) string {
 	return fmt.Sprintf("crabbox stop --provider %s --id %s", e2bProvider, shellQuote(leaseID))
+}
+
+func (b *e2bBackend) resolveStopTarget(ctx context.Context, client e2bAPI, id string) (LeaseClaim, e2bSandbox, error) {
+	if id == "" {
+		return LeaseClaim{}, e2bSandbox{}, exit(2, "provider=e2b requires a Crabbox lease id, slug, or E2B sandbox id")
+	}
+	cfg := e2bClaimConfig(b.cfg)
+	claim, ok, exact, err := resolveLeaseClaimForProviderScopeWithExact(id, providerClaimScope(cfg))
+	if err != nil {
+		return LeaseClaim{}, e2bSandbox{}, err
+	}
+	if exact && !ok {
+		if claim.Provider != e2bProvider {
+			return LeaseClaim{}, e2bSandbox{}, exit(4, "e2b identifier %q is claimed by a different provider", id)
+		}
+		return LeaseClaim{}, e2bSandbox{}, exit(4, "e2b identifier %q is claimed for a different API endpoint", id)
+	}
+	if !ok {
+		if strings.HasPrefix(id, "cbx_") {
+			return LeaseClaim{}, e2bSandbox{}, exit(4, "e2b lease %q has no exact local claim", id)
+		}
+		sandboxID := id
+		if isE2BSyntheticID(id) {
+			sandboxID = strings.TrimPrefix(id, "e2b_")
+		}
+		claim, ok, err = resolveLeaseClaimForProviderCloudIDScope(sandboxID, providerClaimScope(cfg))
+		if err != nil {
+			return LeaseClaim{}, e2bSandbox{}, err
+		}
+		if !ok {
+			return LeaseClaim{}, e2bSandbox{}, exit(4, "e2b sandbox %q has no exact local claim; use --reclaim to adopt it explicitly", id)
+		}
+	}
+	if claim.ProviderScope != providerClaimScope(cfg) {
+		return LeaseClaim{}, e2bSandbox{}, exit(4, "e2b lease %q belongs to a different API endpoint; use --reclaim with the exact sandbox id to adopt it", claim.LeaseID)
+	}
+	if strings.TrimSpace(claim.CloudID) == "" {
+		return LeaseClaim{}, e2bSandbox{}, exit(4, "e2b lease %q has a legacy claim not bound to an exact sandbox; use --reclaim with the exact sandbox id to adopt it", claim.LeaseID)
+	}
+	sandbox, err := client.GetSandbox(ctx, claim.CloudID)
+	if err != nil {
+		if isNotFoundError(err) {
+			return LeaseClaim{}, e2bSandbox{}, &e2bClaimedSandboxMissingError{claim: claim}
+		}
+		return LeaseClaim{}, e2bSandbox{}, e2bError("get sandbox", err)
+	}
+	if err := validateE2BClaim(cfg, claim, sandbox); err != nil {
+		return LeaseClaim{}, e2bSandbox{}, err
+	}
+	return claim, sandbox, nil
+}
+
+func (b *e2bBackend) deleteClaimedSandbox(ctx context.Context, client e2bAPI, leaseID, sandboxID string) error {
+	cfg := e2bClaimConfig(b.cfg)
+	claim, ok, exact, err := resolveLeaseClaimForProviderScopeWithExact(leaseID, providerClaimScope(cfg))
+	if err != nil {
+		return err
+	}
+	if !ok || !exact {
+		return exit(4, "e2b lease %q has no exact local claim; refusing deletion", leaseID)
+	}
+	if claim.ProviderScope != providerClaimScope(cfg) || claim.CloudID != sandboxID {
+		return exit(4, "e2b lease %q is not bound to sandbox %q on this API endpoint; refusing deletion", leaseID, sandboxID)
+	}
+	return removeLeaseClaimIfUnchangedAfter(leaseID, claim, func() error {
+		sandbox, err := client.GetSandbox(ctx, sandboxID)
+		if err != nil {
+			if isNotFoundError(err) {
+				return nil
+			}
+			return e2bError("get sandbox before delete", err)
+		}
+		if err := validateE2BClaim(cfg, claim, sandbox); err != nil {
+			return err
+		}
+		if err := client.DeleteSandbox(ctx, sandboxID); err != nil {
+			if isNotFoundError(err) {
+				return nil
+			}
+			return e2bError("delete sandbox", err)
+		}
+		return nil
+	})
+}
+
+func validateE2BReclaimCollision(leaseID, sandboxID string, previous LeaseClaim, previousExists bool) error {
+	if !previousExists {
+		return nil
+	}
+	if previous.Provider != e2bProvider {
+		return exit(4, "e2b lease %q is already claimed by provider %q; refusing reclaim", leaseID, previous.Provider)
+	}
+	if previous.CloudID != "" && previous.CloudID != sandboxID {
+		return exit(4, "e2b lease %q is already bound to sandbox %q; refusing retarget to %q", leaseID, previous.CloudID, sandboxID)
+	}
+	return nil
+}
+
+type e2bClaimedSandboxMissingError struct {
+	claim LeaseClaim
+}
+
+func (e *e2bClaimedSandboxMissingError) Error() string {
+	return fmt.Sprintf("e2b sandbox %q for lease %q no longer exists", e.claim.CloudID, e.claim.LeaseID)
+}
+
+func validateE2BClaim(cfg Config, claim LeaseClaim, sandbox e2bSandbox) error {
+	if claim.Provider != e2bProvider || claim.ProviderScope != providerClaimScope(e2bClaimConfig(cfg)) {
+		return exit(4, "e2b lease %q belongs to a different provider or API endpoint", claim.LeaseID)
+	}
+	if claim.CloudID == "" || claim.CloudID != sandbox.SandboxID {
+		return exit(4, "e2b lease %q is not bound to sandbox %q", claim.LeaseID, sandbox.SandboxID)
+	}
+	if !isCrabboxE2BSandbox(sandbox) || strings.TrimSpace(sandbox.Metadata["lease"]) != claim.LeaseID || strings.TrimSpace(sandbox.Metadata["slug"]) != claim.Slug {
+		return exit(4, "e2b sandbox %q no longer has canonical ownership metadata for lease %q", sandbox.SandboxID, claim.LeaseID)
+	}
+	return nil
+}
+
+func e2bClaimConfig(cfg Config) Config {
+	cfg.Provider = e2bProvider
+	if strings.TrimSpace(cfg.E2B.APIURL) == "" {
+		cfg.E2B.APIURL = "https://api.e2b.app"
+	}
+	return cfg
 }
 
 func (b *e2bBackend) resolveSandboxID(ctx context.Context, client e2bAPI, id, repoRoot string, reclaim bool) (string, string, string, error) {
@@ -394,6 +615,37 @@ func (b *e2bBackend) resolveSandboxID(ctx context.Context, client e2bAPI, id, re
 	if claim, ok, err := resolveLeaseClaim(id); err != nil {
 		return "", "", "", err
 	} else if ok && claim.Provider == e2bProvider {
+		if claim.CloudID != "" {
+			cfg := e2bClaimConfig(b.cfg)
+			if claim.ProviderScope != providerClaimScope(cfg) {
+				return "", "", "", exit(4, "e2b lease %q belongs to a different API endpoint", claim.LeaseID)
+			}
+			sandbox, err := client.GetSandbox(ctx, claim.CloudID)
+			if err != nil {
+				return "", "", "", e2bError("get sandbox", err)
+			}
+			if err := validateE2BClaim(cfg, claim, sandbox); err != nil {
+				return "", "", "", err
+			}
+			if repoRoot != "" {
+				claim, err = claimLeaseTargetForRepoConfigIfUnchanged(
+					claim.LeaseID,
+					claim.Slug,
+					cfg,
+					e2bSandboxToServer(sandbox),
+					SSHTarget{},
+					repoRoot,
+					time.Duration(claim.IdleTimeoutSeconds)*time.Second,
+					reclaim,
+					claim,
+					true,
+				)
+				if err != nil {
+					return "", "", "", err
+				}
+			}
+			return claim.LeaseID, sandbox.SandboxID, claim.Slug, nil
+		}
 		if repoRoot != "" {
 			if err := claimLeaseForRepoProvider(claim.LeaseID, claim.Slug, e2bProvider, repoRoot, time.Duration(claim.IdleTimeoutSeconds)*time.Second, reclaim); err != nil {
 				return "", "", "", err

--- a/internal/providers/e2b/backend_test.go
+++ b/internal/providers/e2b/backend_test.go
@@ -634,6 +634,7 @@ func TestE2BTimeoutCapsAtOneHour(t *testing.T) {
 }
 
 func TestE2BCreateSandboxCapsDefaultTTL(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	client := &fakeE2BSyncClient{}
 	backend := &e2bBackend{
 		cfg: Config{
@@ -656,11 +657,11 @@ func TestE2BCreateSandboxCapsDefaultTTL(t *testing.T) {
 }
 
 func TestE2BCreateSandboxReportsCleanupFailureAfterClaimFailure(t *testing.T) {
-	origClaim := claimLeaseForRepoProviderPond
-	claimLeaseForRepoProviderPond = func(_, _, _, _, _ string, _ time.Duration, _ bool) error {
+	origClaim := claimLeaseTargetForRepoConfig
+	claimLeaseTargetForRepoConfig = func(_, _ string, _ Config, _ Server, _ SSHTarget, _ string, _ time.Duration, _ bool) error {
 		return errors.New("claim write failed")
 	}
-	t.Cleanup(func() { claimLeaseForRepoProviderPond = origClaim })
+	t.Cleanup(func() { claimLeaseTargetForRepoConfig = origClaim })
 
 	client := &fakeE2BSyncClient{deleteErr: errors.New("delete failed")}
 	var stderr bytes.Buffer
@@ -676,7 +677,7 @@ func TestE2BCreateSandboxReportsCleanupFailureAfterClaimFailure(t *testing.T) {
 		"claim write failed",
 		"cleanup e2b sandbox sbx_1",
 		"delete failed",
-		"crabbox stop --provider e2b --id sbx_1",
+		"crabbox stop --provider e2b --id sbx_1 --reclaim",
 	} {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("err=%v, want %q", err, want)
@@ -778,6 +779,42 @@ func TestE2BRunReturnsSessionHandleWhenKeepOnFailureRetainsSandbox(t *testing.T)
 	}
 }
 
+func TestE2BRunCleanupUsesExactClaim(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	client := &fakeE2BSyncClient{}
+	restore := swapNewE2BClient(client)
+	defer restore()
+	backend := &e2bBackend{
+		cfg: Config{
+			IdleTimeout: 30 * time.Minute,
+			TTL:         2 * time.Minute,
+			E2B:         E2BConfig{APIKey: "test", Workdir: "repo"},
+		},
+		rt: Runtime{Stdout: io.Discard, Stderr: io.Discard},
+	}
+
+	result, err := backend.Run(context.Background(), RunRequest{
+		Repo:    Repo{Name: "repo", Root: t.TempDir()},
+		Command: []string{"true"},
+		NoSync:  true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Session == nil || result.Session.Kept {
+		t.Fatalf("session=%#v", result.Session)
+	}
+	if len(client.deleteIDs) != 1 || client.deleteIDs[0] != "sbx_1" {
+		t.Fatalf("deleteIDs=%#v", client.deleteIDs)
+	}
+	if !client.deleteDeadlineSet {
+		t.Fatal("run cleanup did not use a bounded context")
+	}
+	if _, exists, err := readLeaseClaimWithPresence(result.Session.LeaseID); err != nil || exists {
+		t.Fatalf("cleanup claim exists=%t err=%v", exists, err)
+	}
+}
+
 func TestE2BSandboxToServerUsesMetadata(t *testing.T) {
 	server := e2bSandboxToServer(e2bSandbox{
 		SandboxID:  "sbx_1",
@@ -826,12 +863,176 @@ func TestE2BResolveSyntheticIDRequiresCrabboxMetadata(t *testing.T) {
 	}
 }
 
+func TestE2BCreateBindsExactSandboxAndEndpoint(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	client := &fakeE2BSyncClient{}
+	backend := &e2bBackend{
+		cfg: Config{
+			IdleTimeout: 30 * time.Minute,
+			E2B: E2BConfig{
+				APIURL:   "https://api.example.test/root/",
+				Template: "base",
+			},
+		},
+		rt: Runtime{Stdout: io.Discard, Stderr: io.Discard},
+	}
+	leaseID, sandbox, _, err := backend.createSandbox(context.Background(), client, Repo{Root: t.TempDir()}, true, false, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim, ok, exact, err := resolveLeaseClaimForProviderScopeWithExact(leaseID, "endpoint:https://api.example.test/root")
+	if err != nil || !ok || !exact {
+		t.Fatalf("claim=%#v ok=%t exact=%t err=%v", claim, ok, exact, err)
+	}
+	if claim.CloudID != sandbox.SandboxID || claim.ProviderScope != "endpoint:https://api.example.test/root" {
+		t.Fatalf("claim=%#v sandbox=%#v", claim, sandbox)
+	}
+}
+
+func TestE2BStopRejectsLabelledButUnclaimedSandbox(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	client := &fakeE2BSyncClient{sandbox: e2bSandbox{
+		SandboxID: "sbx_unclaimed",
+		Metadata: map[string]string{
+			"provider": e2bProvider,
+			"crabbox":  "true",
+			"lease":    "cbx_123456789abc",
+			"slug":     "unclaimed",
+		},
+	}}
+	restore := swapNewE2BClient(client)
+	defer restore()
+	backend := &e2bBackend{cfg: e2bClaimConfig(Config{}), rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+	err := backend.Stop(context.Background(), StopRequest{ID: "sbx_unclaimed"})
+	if err == nil || !strings.Contains(err.Error(), "no exact local claim") {
+		t.Fatalf("Stop err=%v, want exact-claim rejection", err)
+	}
+	if len(client.getIDs) != 0 || len(client.deleteIDs) != 0 {
+		t.Fatalf("unclaimed Stop touched provider: gets=%#v deletes=%#v", client.getIDs, client.deleteIDs)
+	}
+}
+
+func TestE2BStopChecksLiveOwnershipAndRemovesClaimAtomically(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	client := &fakeE2BSyncClient{}
+	restore := swapNewE2BClient(client)
+	defer restore()
+	backend := &e2bBackend{
+		cfg: Config{E2B: E2BConfig{APIURL: "https://api.example.test", Template: "base"}},
+		rt:  Runtime{Stdout: io.Discard, Stderr: io.Discard},
+	}
+	leaseID, sandbox, _, err := backend.createSandbox(context.Background(), client, Repo{Root: t.TempDir()}, true, false, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.sandbox.Metadata["lease"] = "cbx_ffffffffffff"
+	err = backend.Stop(context.Background(), StopRequest{ID: leaseID})
+	if err == nil || !strings.Contains(err.Error(), "no longer has canonical ownership metadata") {
+		t.Fatalf("mismatched Stop err=%v", err)
+	}
+	if len(client.deleteIDs) != 0 {
+		t.Fatalf("mismatched Stop deleted %#v", client.deleteIDs)
+	}
+	if _, exists, err := readLeaseClaimWithPresence(leaseID); err != nil || !exists {
+		t.Fatalf("mismatched Stop lost recovery claim: exists=%t err=%v", exists, err)
+	}
+
+	client.sandbox.Metadata["lease"] = leaseID
+	if err := backend.Stop(context.Background(), StopRequest{ID: leaseID}); err != nil {
+		t.Fatalf("Stop exact claim: %v", err)
+	}
+	if len(client.deleteIDs) != 1 || client.deleteIDs[0] != sandbox.SandboxID {
+		t.Fatalf("deleteIDs=%#v", client.deleteIDs)
+	}
+	if _, exists, err := readLeaseClaimWithPresence(leaseID); err != nil || exists {
+		t.Fatalf("successful Stop claim exists=%t err=%v", exists, err)
+	}
+}
+
+func TestE2BStopRetainsClaimWhenDeleteFails(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	client := &fakeE2BSyncClient{deleteErr: errors.New("delete failed")}
+	restore := swapNewE2BClient(client)
+	defer restore()
+	backend := &e2bBackend{
+		cfg: Config{E2B: E2BConfig{APIURL: "https://api.example.test", Template: "base"}},
+		rt:  Runtime{Stdout: io.Discard, Stderr: io.Discard},
+	}
+	leaseID, sandbox, _, err := backend.createSandbox(context.Background(), client, Repo{Root: t.TempDir()}, true, false, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = backend.Stop(context.Background(), StopRequest{ID: leaseID})
+	if err == nil || !strings.Contains(err.Error(), "delete failed") {
+		t.Fatalf("Stop err=%v, want delete failure", err)
+	}
+	if len(client.deleteIDs) != 1 || client.deleteIDs[0] != sandbox.SandboxID {
+		t.Fatalf("deleteIDs=%#v", client.deleteIDs)
+	}
+	if _, exists, err := readLeaseClaimWithPresence(leaseID); err != nil || !exists {
+		t.Fatalf("failed Stop lost recovery claim: exists=%t err=%v", exists, err)
+	}
+}
+
+func TestE2BStopRejectsDifferentAPIEndpointBeforeRemoteRead(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	client := &fakeE2BSyncClient{}
+	creator := &e2bBackend{
+		cfg: Config{E2B: E2BConfig{APIURL: "https://api-a.example.test", Template: "base"}},
+		rt:  Runtime{Stdout: io.Discard, Stderr: io.Discard},
+	}
+	leaseID, _, _, err := creator.createSandbox(context.Background(), client, Repo{Root: t.TempDir()}, true, false, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.getIDs = nil
+	restore := swapNewE2BClient(client)
+	defer restore()
+	other := &e2bBackend{
+		cfg: Config{E2B: E2BConfig{APIURL: "https://api-b.example.test"}},
+		rt:  Runtime{Stdout: io.Discard, Stderr: io.Discard},
+	}
+	err = other.Stop(context.Background(), StopRequest{ID: leaseID})
+	if err == nil || !strings.Contains(err.Error(), "different API endpoint") {
+		t.Fatalf("Stop err=%v, want endpoint rejection", err)
+	}
+	if len(client.getIDs) != 0 || len(client.deleteIDs) != 0 {
+		t.Fatalf("endpoint mismatch touched provider: gets=%#v deletes=%#v", client.getIDs, client.deleteIDs)
+	}
+}
+
+func TestE2BReclaimAndStopAdoptsExactSandbox(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	client := &fakeE2BSyncClient{sandbox: e2bSandbox{
+		SandboxID: "sbx_reclaim",
+		Metadata: map[string]string{
+			"provider": e2bProvider,
+			"crabbox":  "true",
+			"lease":    "cbx_123456789abc",
+			"slug":     "reclaim-me",
+		},
+	}}
+	restore := swapNewE2BClient(client)
+	defer restore()
+	backend := &e2bBackend{cfg: e2bClaimConfig(Config{}), rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+	if err := backend.ReclaimAndStop(context.Background(), StopRequest{ID: "sbx_reclaim"}); err != nil {
+		t.Fatalf("ReclaimAndStop: %v", err)
+	}
+	if len(client.deleteIDs) != 1 || client.deleteIDs[0] != "sbx_reclaim" {
+		t.Fatalf("deleteIDs=%#v", client.deleteIDs)
+	}
+	if _, exists, err := readLeaseClaimWithPresence("cbx_123456789abc"); err != nil || exists {
+		t.Fatalf("successful reclaim claim exists=%t err=%v", exists, err)
+	}
+}
+
 type fakeE2BSyncClient struct {
 	commands          []string
 	users             []string
 	sandbox           e2bSandbox
 	createReq         e2bCreateSandboxRequest
 	createCalls       int
+	getIDs            []string
 	getErr            error
 	deleteIDs         []string
 	deleteErr         error
@@ -853,14 +1054,16 @@ func (f *fakeE2BSyncClient) CreateSandbox(_ context.Context, req e2bCreateSandbo
 	if f.sandbox.SandboxID != "" {
 		return f.sandbox, nil
 	}
-	return e2bSandbox{SandboxID: "sbx_1", Metadata: req.Metadata}, nil
+	f.sandbox = e2bSandbox{SandboxID: "sbx_1", Metadata: req.Metadata, State: "running"}
+	return f.sandbox, nil
 }
 
 func (f *fakeE2BSyncClient) ConnectSandbox(context.Context, string, int) (e2bSession, error) {
 	return e2bSession{}, nil
 }
 
-func (f *fakeE2BSyncClient) GetSandbox(context.Context, string) (e2bSandbox, error) {
+func (f *fakeE2BSyncClient) GetSandbox(_ context.Context, sandboxID string) (e2bSandbox, error) {
+	f.getIDs = append(f.getIDs, sandboxID)
 	if f.getErr != nil {
 		return e2bSandbox{}, f.getErr
 	}

--- a/internal/providers/e2b/core.go
+++ b/internal/providers/e2b/core.go
@@ -21,12 +21,14 @@ type WarmupRequest = core.WarmupRequest
 type RunRequest = core.RunRequest
 type RunResult = core.RunResult
 type RunSessionHandle = core.RunSessionHandle
+type LeaseClaim = core.LeaseClaim
 type ListRequest = core.ListRequest
 type LeaseView = core.LeaseView
 type StatusRequest = core.StatusRequest
 type StatusView = core.StatusView
 type StopRequest = core.StopRequest
 type Server = core.Server
+type SSHTarget = core.SSHTarget
 type Repo = core.Repo
 type SyncManifest = core.SyncManifest
 type ExitError = core.ExitError
@@ -72,14 +74,38 @@ func directLeaseLabels(cfg Config, leaseID, slug, provider, market string, keep 
 
 var claimLeaseForRepoProvider = core.ClaimLeaseForRepoProvider
 
-var claimLeaseForRepoProviderPond = core.ClaimLeaseForRepoProviderPond
+var claimLeaseTargetForRepoConfig = core.ClaimLeaseTargetForRepoConfig
+
+var claimLeaseTargetForRepoConfigIfUnchanged = core.ClaimLeaseTargetForRepoConfigIfUnchanged
+
+var claimLeaseTargetForConfigIfUnchanged = core.ClaimLeaseTargetForConfigIfUnchanged
+
+func resolveLeaseClaimForProviderScopeWithExact(identifier, providerScope string) (LeaseClaim, bool, bool, error) {
+	return core.ResolveLeaseClaimForProviderScopeWithExact(identifier, e2bProvider, providerScope)
+}
+
+func resolveLeaseClaimForProviderCloudIDScope(cloudID, providerScope string) (LeaseClaim, bool, error) {
+	return core.ResolveLeaseClaimForProviderCloudIDScope(cloudID, e2bProvider, providerScope)
+}
+
+func readLeaseClaimWithPresence(leaseID string) (LeaseClaim, bool, error) {
+	return core.ReadLeaseClaimWithPresence(leaseID)
+}
+
+func removeLeaseClaimIfUnchangedAfter(leaseID string, expected LeaseClaim, action func() error) error {
+	return core.RemoveLeaseClaimIfUnchangedAfter(leaseID, expected, action)
+}
+
+func providerClaimScope(cfg Config) string {
+	return core.ProviderClaimScope(e2bProvider, cfg)
+}
+
+func isCanonicalLeaseID(value string) bool {
+	return core.IsCanonicalLeaseID(value)
+}
 
 func resolveLeaseClaim(identifier string) (core.LeaseClaim, bool, error) {
 	return core.ResolveLeaseClaim(identifier)
-}
-
-func removeLeaseClaim(leaseID string) {
-	core.RemoveLeaseClaim(leaseID)
 }
 
 func writeTimingJSON(w io.Writer, report timingReport) error {


### PR DESCRIPTION
## Summary

- bind E2B claims to the exact API endpoint and sandbox returned at creation
- require an unchanged exact claim plus live lease, slug, and provider metadata across deletion
- make claimless cleanup an explicit reclaim operation and keep automatic run cleanup on the same guarded path

Fixes https://github.com/openclaw/crabbox/issues/1022

## Verification

- `go vet ./...`
- `go test -race ./...`
- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- `scripts/check-docs.sh`
- autoreview clean

Regression coverage proves that metadata-only unclaimed sandboxes are not read or deleted, endpoint mismatches fail before provider access, changed ownership and failed deletion retain recovery claims, automatic cleanup uses an exact bounded claim, and explicit reclaim adopts only the requested sandbox before deleting it.
