### PR TITLE
fix: secure WebVNC browser handoffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- Replaced WebVNC password and username URL fragments with one-time credential handoff tickets, and made repeated `--open` calls reuse and focus the existing lease viewer tab when the browser supports cross-tab handoff.
 - Required E2B stop and automatic cleanup to hold an unchanged API-endpoint-, sandbox-, lease-, slug-, and provider-bound local claim across deletion; claimless recovery now requires explicit `--reclaim`. Thanks @coygeek.
 - Prevented config and `.crabboxignore` negations, including case aliases, from re-including Crabbox-owned env profiles, uploaded scripts, logs, captures, and run artifacts in sync manifests. Thanks @zozo123.
 - Allowed ordered `!` re-includes in `.crabboxignore` and `sync.exclude`, with `\!` for literal leading-bang paths. Thanks @chsong1.

--- a/docs/commands/webvnc.md
+++ b/docs/commands/webvnc.md
@@ -46,9 +46,10 @@ nonce, recorded in its identity, rather than the adapter owner token. After
 the SSH tunnel opens, Crabbox
 proves that the exact expected SSH process owns the local listener before
 retrieving a VNC credential, completes a noVNC WebSocket and VNC password
-challenge, and rechecks ownership before printing any credential-bearing
-viewer URL. A missing/zero expected PID, unrelated listener, or unauthenticated
-endpoint never receives a password probe or URL.
+challenge, and rechecks ownership before sending the credential to the
+coordinator through its authenticated one-time handoff API. A missing/zero
+expected PID, unrelated listener, or unauthenticated endpoint never receives a
+password probe or handoff.
 
 Deployments that expose the browser portal and bridge agent through different
 origins can set `CRABBOX_WEBVNC_AGENT_BASE_URL` to the agent's exact HTTPS
@@ -293,15 +294,16 @@ instead of granting general passwordless sudo.
 ## Portal and passwords
 
 `--open` opens the portal page after the bridge starts. When the VNC password is
-available, the command places it in the URL fragment handed to the local browser
-tab. URL fragments are not sent to the coordinator, and Crabbox preserves
-special characters such as `!` when building the fragment. Credential-bearing
-viewer URLs, usernames, and passwords remain redacted on stdout unless the
-operator explicitly sets `--redact-credentials=false`. Credential-free URLs and
-recovery commands remain visible. If the portal login flow redirects first,
-the page may still prompt for the VNC password; use the explicit reveal only in
-a private terminal. If an old tab is retrying with a stale fragment, close it
-before opening the new bridge URL.
+available, the command sends it over the authenticated coordinator API and puts
+only a short-lived, one-use handoff ticket in the browser URL fragment. The
+portal consumes the ticket, loads the credential into browser memory, and
+removes the ticket from the address bar before connecting. Passwords and
+usernames never enter CLI-generated portal URLs. Ticket-bearing viewer URLs,
+usernames, and passwords remain redacted on stdout unless the operator
+explicitly sets `--redact-credentials=false`; credential-free URLs and recovery
+commands remain visible. Repeated `--open` calls hand the fresh ticket to an
+existing viewer tab for that lease and focus it when the browser permits,
+rather than starting a second active viewer.
 
 The portal page may show `WebVNC daemon not running` or `waiting for VNC bridge`
 until the local command has connected. If you opened the portal first, start the
@@ -312,8 +314,9 @@ crabbox webvnc --id <lease-id-or-slug>
 ```
 
 For human demos, prefer WebVNC over native VNC because `crabbox webvnc --open`
-preloads the per-lease password in the local browser URL fragment. Use native
-VNC only as the fallback printed by `webvnc status` or `webvnc reset`.
+preloads the per-lease password through a one-use browser handoff without
+putting the password in the URL. Use native VNC only as the fallback printed by
+`webvnc status` or `webvnc reset`.
 
 The WebVNC toolbar includes clipboard controls. The paste control reads the
 local browser clipboard, sends it through noVNC, then sends the target paste
@@ -414,7 +417,8 @@ VNC authentication fails
 Retry with `--open` so Crabbox hands the credential directly to the browser. If
 manual entry is required, run the command in a private terminal with
 `--redact-credentials=false`; avoid copying that output into logs, issues, or
-chat. A portal login redirect can lose the URL fragment before noVNC sees it.
+chat. If a one-use handoff expires before the portal consumes it, rerun
+`crabbox webvnc --id <lease> --open` to mint a fresh ticket.
 
 ## Related docs
 

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -342,6 +342,11 @@ type CoordinatorWebVNCTicket struct {
 	ExpiresAt string `json:"expiresAt"`
 }
 
+type CoordinatorWebVNCCredentialHandoff struct {
+	Ticket    string `json:"ticket"`
+	ExpiresAt string `json:"expiresAt"`
+}
+
 type CoordinatorWebVNCEvent struct {
 	At     string `json:"at"`
 	Event  string `json:"event"`
@@ -1210,6 +1215,15 @@ func (c *CoordinatorClient) PollGitHubLogin(ctx context.Context, loginID, pollSe
 func (c *CoordinatorClient) CreateWebVNCTicket(ctx context.Context, leaseID string) (CoordinatorWebVNCTicket, error) {
 	var res CoordinatorWebVNCTicket
 	err := c.do(ctx, http.MethodPost, "/v1/leases/"+url.PathEscape(leaseID)+"/webvnc/ticket", map[string]any{}, &res)
+	return res, err
+}
+
+func (c *CoordinatorClient) CreateWebVNCCredentialHandoff(ctx context.Context, leaseID, username, password string) (CoordinatorWebVNCCredentialHandoff, error) {
+	var res CoordinatorWebVNCCredentialHandoff
+	err := c.do(ctx, http.MethodPost, "/v1/leases/"+url.PathEscape(leaseID)+"/webvnc/handoff", map[string]string{
+		"username": username,
+		"password": password,
+	}, &res)
 	return res, err
 }
 

--- a/internal/cli/webvnc.go
+++ b/internal/cli/webvnc.go
@@ -312,7 +312,6 @@ func (a App) webvnc(ctx context.Context, args []string) error {
 		}
 	}
 
-	portal := webVNCPortalURL(coord.BaseURL, leaseID, username, password, webVNCPortalOptions{TakeControl: *takeControl})
 	rescueCtx := rescueContext{Cfg: cfg, Target: target, LeaseID: leaseID}
 	opened := false
 	bridgeCtx := ctx
@@ -343,6 +342,14 @@ func (a App) webvnc(ctx context.Context, args []string) error {
 		NativeVNC:        nativeVNCOpenCommand(cfg, target, leaseID),
 		Log:              a.Stdout,
 		OnReady: func() error {
+			portalUsername, portalPassword := "", ""
+			if *openPortal || !*redactCredentials {
+				portalUsername, portalPassword = username, password
+			}
+			portal, err := createWebVNCPortalURL(ctx, coord, leaseID, portalUsername, portalPassword, webVNCPortalOptions{TakeControl: *takeControl})
+			if err != nil {
+				return err
+			}
 			fmt.Fprintln(a.Stdout, "bridge: connected; keep this process running while using WebVNC")
 			fmt.Fprintf(a.Stdout, "webvnc: %s\n", portal)
 			if strings.TrimSpace(password) != "" {
@@ -696,7 +703,7 @@ func (w webVNCRedactingWriter) Write(data []byte) (int, error) {
 }
 
 func webVNCOutputURLHasCredentials(value string) bool {
-	if strings.Contains(value, "password=") || strings.Contains(value, "username=") {
+	if strings.Contains(value, "password=") || strings.Contains(value, "username=") || strings.Contains(value, "handoff=") {
 		return true
 	}
 	parsed, err := url.Parse(value)
@@ -918,7 +925,14 @@ func (a App) webVNCStatusCommand(ctx context.Context, args []string) error {
 	for _, line := range recentWebVNCLogEvents(daemon.LogPath, 6) {
 		fmt.Fprintf(a.Stdout, "log event: %s\n", line)
 	}
-	portal := webVNCPortalURL(coord.BaseURL, leaseID, username, password)
+	portalUsername, portalPassword := "", ""
+	if !*redactCredentials {
+		portalUsername, portalPassword = username, password
+	}
+	portal, err := createWebVNCPortalURL(ctx, coord, leaseID, portalUsername, portalPassword)
+	if err != nil {
+		return err
+	}
 	fmt.Fprintf(a.Stdout, "webvnc: %s\n", portal)
 	if strings.TrimSpace(password) != "" {
 		fmt.Fprintf(a.Stdout, "password: %s\n", strings.TrimSpace(password))
@@ -1009,7 +1023,14 @@ func (a App) webVNCResetCommand(ctx context.Context, args []string) error {
 		username = target.User
 	}
 	password, _ = runSSHOutput(ctx, target, vncPasswordCommand(target))
-	portal := webVNCPortalURL(coord.BaseURL, leaseID, username, password, webVNCPortalOptions{TakeControl: *takeControl})
+	portalUsername, portalPassword := "", ""
+	if *openPortal || !*redactCredentials {
+		portalUsername, portalPassword = username, password
+	}
+	portal, err := createWebVNCPortalURL(ctx, coord, leaseID, portalUsername, portalPassword, webVNCPortalOptions{TakeControl: *takeControl})
+	if err != nil {
+		return err
+	}
 	daemonArgs := webVNCBridgeArgs(cfg, target, leaseID, *openPortal, *takeControl)
 	daemonName := *id
 	if strings.TrimSpace(daemonName) == "" {
@@ -4052,7 +4073,35 @@ type webVNCPortalOptions struct {
 	TakeControl bool
 }
 
-func webVNCPortalURL(base, leaseID, username, password string, opts ...webVNCPortalOptions) string {
+func createWebVNCPortalURL(ctx context.Context, coord *CoordinatorClient, leaseID, username, password string, opts ...webVNCPortalOptions) (string, error) {
+	handoff := ""
+	if strings.TrimSpace(username) != "" || strings.TrimSpace(password) != "" {
+		issued, err := coord.CreateWebVNCCredentialHandoff(ctx, leaseID, username, password)
+		if err != nil {
+			return "", fmt.Errorf("create WebVNC credential handoff: %w", err)
+		}
+		if !validWebVNCCredentialHandoffTicket(issued.Ticket) {
+			return "", fmt.Errorf("create WebVNC credential handoff: coordinator returned an invalid ticket")
+		}
+		handoff = issued.Ticket
+	}
+	return webVNCPortalURL(coord.BaseURL, leaseID, handoff, opts...), nil
+}
+
+func validWebVNCCredentialHandoffTicket(value string) bool {
+	const prefix = "vnc_handoff_"
+	if len(value) != len(prefix)+32 || !strings.HasPrefix(value, prefix) {
+		return false
+	}
+	for _, character := range value[len(prefix):] {
+		if (character < '0' || character > '9') && (character < 'a' || character > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+func webVNCPortalURL(base, leaseID, handoff string, opts ...webVNCPortalOptions) string {
 	u, err := url.Parse(base)
 	if err != nil {
 		return base
@@ -4065,13 +4114,10 @@ func webVNCPortalURL(base, leaseID, username, password string, opts ...webVNCPor
 	for _, opt := range opts {
 		takeControl = takeControl || opt.TakeControl
 	}
-	if strings.TrimSpace(username) != "" || strings.TrimSpace(password) != "" || takeControl {
+	if strings.TrimSpace(handoff) != "" || takeControl {
 		values := url.Values{}
-		if strings.TrimSpace(username) != "" {
-			values.Set("username", strings.TrimSpace(username))
-		}
-		if strings.TrimSpace(password) != "" {
-			values.Set("password", strings.TrimSpace(password))
+		if strings.TrimSpace(handoff) != "" {
+			values.Set("handoff", strings.TrimSpace(handoff))
 		}
 		if takeControl {
 			values.Set("control", "take")

--- a/internal/cli/webvnc_test.go
+++ b/internal/cli/webvnc_test.go
@@ -13,7 +13,6 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -37,38 +36,27 @@ func TestWebVNCURLs(t *testing.T) {
 	if got := webVNCAgentURLWithCapabilities("https://broker.example.com", "cbx_abcdef123456", "desktop_theme"); got != "wss://broker.example.com/v1/leases/cbx_abcdef123456/webvnc/agent?capabilities=desktop_theme" {
 		t.Fatalf("agent capability URL=%q", got)
 	}
-	if got := webVNCPortalURL("https://broker.example.com/", "cbx_abcdef123456", "", "secret value"); got != "https://broker.example.com/portal/leases/cbx_abcdef123456/vnc#password=secret+value" {
+	if got := webVNCPortalURL("https://broker.example.com/", "cbx_abcdef123456", "vnc_handoff_deadbeef"); got != "https://broker.example.com/portal/leases/cbx_abcdef123456/vnc#handoff=vnc_handoff_deadbeef" {
 		t.Fatalf("portal URL=%q", got)
 	}
-	if got := webVNCPortalURL("https://broker.example.com/", "cbx_abcdef123456", "ec2-user", "secret value"); got != "https://broker.example.com/portal/leases/cbx_abcdef123456/vnc#password=secret+value&username=ec2-user" {
+	if got := webVNCPortalURL("https://broker.example.com/#stale", "cbx_abcdef123456", ""); got != "https://broker.example.com/portal/leases/cbx_abcdef123456/vnc" {
 		t.Fatalf("portal URL=%q", got)
 	}
-	if got := webVNCPortalURL("https://broker.example.com/", "cbx_abcdef123456", "", "Cb1!abc"); got != "https://broker.example.com/portal/leases/cbx_abcdef123456/vnc#password=Cb1%21abc" {
-		t.Fatalf("portal URL=%q", got)
-	}
-	if got := webVNCPortalURL("https://broker.example.com/#stale", "cbx_abcdef123456", "", ""); got != "https://broker.example.com/portal/leases/cbx_abcdef123456/vnc" {
-		t.Fatalf("portal URL=%q", got)
-	}
-	if got := webVNCPortalURL("https://broker.example.com/", "cbx_abcdef123456", "", "", webVNCPortalOptions{TakeControl: true}); got != "https://broker.example.com/portal/leases/cbx_abcdef123456/vnc#control=take" {
+	if got := webVNCPortalURL("https://broker.example.com/", "cbx_abcdef123456", "", webVNCPortalOptions{TakeControl: true}); got != "https://broker.example.com/portal/leases/cbx_abcdef123456/vnc#control=take" {
 		t.Fatalf("portal URL with control=%q", got)
 	}
-	if got := webVNCPortalURL("https://broker.example.com/", "cbx_abcdef123456", "", "secret value", webVNCPortalOptions{TakeControl: true}); got != "https://broker.example.com/portal/leases/cbx_abcdef123456/vnc#control=take&password=secret+value" {
-		t.Fatalf("portal URL with password and control=%q", got)
+	if got := webVNCPortalURL("https://broker.example.com/", "cbx_abcdef123456", "vnc_handoff_deadbeef", webVNCPortalOptions{TakeControl: true}); got != "https://broker.example.com/portal/leases/cbx_abcdef123456/vnc#control=take&handoff=vnc_handoff_deadbeef" {
+		t.Fatalf("portal URL with handoff and control=%q", got)
 	}
-	got := webVNCPortalURL("https://broker.example.com/", "cbx_abcdef123456", "", "JVS/yMb%2B")
-	if got != "https://broker.example.com/portal/leases/cbx_abcdef123456/vnc#password=JVS%2FyMb%252B" {
-		t.Fatalf("portal URL with escaped password=%q", got)
-	}
-	fragment, ok := strings.CutPrefix(got, "https://broker.example.com/portal/leases/cbx_abcdef123456/vnc#")
-	if !ok {
-		t.Fatalf("portal URL missing expected fragment: %q", got)
-	}
-	values, err := url.ParseQuery(fragment)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if values.Get("password") != "JVS/yMb%2B" {
-		t.Fatalf("decoded portal password=%q", values.Get("password"))
+	for value, valid := range map[string]bool{
+		"vnc_handoff_0123456789abcdef0123456789abcdef": true,
+		"vnc_handoff_0123456789ABCDEF0123456789ABCDEF": false,
+		"vnc_handoff_short":                            false,
+		"password_0123456789abcdef0123456789abcdef":    false,
+	} {
+		if got := validWebVNCCredentialHandoffTicket(value); got != valid {
+			t.Fatalf("validWebVNCCredentialHandoffTicket(%q) = %t, want %t", value, got, valid)
+		}
 	}
 	if got := directSSHWebVNCURL("5901", "p+a ss"); got != "http://127.0.0.1:5901/vnc.html?autoconnect=1&compression=0&host=127.0.0.1&password=p%2Ba+ss&path=websockify&port=5901&quality=6&resize=scale" {
 		t.Fatalf("local container WebVNC URL=%q", got)
@@ -83,6 +71,45 @@ func TestWebVNCURLs(t *testing.T) {
 	}
 	if supportsDirectSSHWebVNC("static") || supportsDirectSSHWebVNC("aws") {
 		t.Fatal("static and coordinator-backed providers should not use direct SSH WebVNC")
+	}
+}
+
+func TestCreateWebVNCPortalURLUsesCredentialHandoff(t *testing.T) {
+	var received map[string]string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/leases/cbx_abcdef123456/webvnc/handoff" {
+			t.Fatalf("request = %s %s", r.Method, r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&received); err != nil {
+			t.Fatal(err)
+		}
+		_ = json.NewEncoder(w).Encode(CoordinatorWebVNCCredentialHandoff{
+			Ticket:    "vnc_handoff_0123456789abcdef0123456789abcdef",
+			ExpiresAt: "2026-07-09T12:00:00Z",
+		})
+	}))
+	defer server.Close()
+	coord := &CoordinatorClient{BaseURL: server.URL, Token: "test-token", Client: server.Client()}
+	got, err := createWebVNCPortalURL(
+		context.Background(),
+		coord,
+		"cbx_abcdef123456",
+		"vnc-user",
+		"generated-vnc-password",
+		webVNCPortalOptions{TakeControl: true},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if received["username"] != "vnc-user" || received["password"] != "generated-vnc-password" {
+		t.Fatalf("credential handoff body = %#v", received)
+	}
+	if strings.Contains(got, "vnc-user") || strings.Contains(got, "generated-vnc-password") || strings.Contains(got, "password=") || strings.Contains(got, "username=") {
+		t.Fatalf("portal URL exposed credentials: %s", got)
+	}
+	want := server.URL + "/portal/leases/cbx_abcdef123456/vnc#control=take&handoff=vnc_handoff_0123456789abcdef0123456789abcdef"
+	if got != want {
+		t.Fatalf("portal URL = %q, want %q", got, want)
 	}
 }
 
@@ -197,7 +224,7 @@ func TestWebVNCWebSocketDialRejectsCrossOriginDowngradeRedirect(t *testing.T) {
 func TestWebVNCRedactingWriterKeepsCredentialsOutOfDaemonLogs(t *testing.T) {
 	var output bytes.Buffer
 	writer := webVNCRedactingWriter{Writer: &output}
-	input := "bridge: connected\nwebvnc: https://portal.example/vnc#password=secret\npassword: secret\nusername: crabbox\nwebvnc: https://broker-user:broker-secret@portal.example/vnc\nopened: https://other-user:other-secret@portal.example/vnc\nwebvnc: run crabbox webvnc --id demo\nwebvnc: https://portal.example/vnc\n"
+	input := "bridge: connected\nwebvnc: https://portal.example/vnc#password=secret\npassword: secret\nusername: crabbox\nwebvnc: https://broker-user:broker-secret@portal.example/vnc\nopened: https://other-user:other-secret@portal.example/vnc\nopened: https://portal.example/vnc#handoff=vnc_handoff_secret\nwebvnc: run crabbox webvnc --id demo\nwebvnc: https://portal.example/vnc\n"
 	if _, err := writer.Write([]byte(input)); err != nil {
 		t.Fatal(err)
 	}
@@ -205,7 +232,7 @@ func TestWebVNCRedactingWriterKeepsCredentialsOutOfDaemonLogs(t *testing.T) {
 	if strings.Contains(got, "secret") || strings.Contains(got, "broker-user") || strings.Contains(got, "other-user") || strings.Contains(got, "#password=") {
 		t.Fatalf("credential leaked: %q", got)
 	}
-	if !strings.Contains(got, "bridge: connected") || strings.Count(got, "[redacted]") != 5 {
+	if !strings.Contains(got, "bridge: connected") || strings.Count(got, "[redacted]") != 6 {
 		t.Fatalf("unexpected redacted output: %q", got)
 	}
 	if !strings.Contains(got, "webvnc: run crabbox webvnc --id demo") || !strings.Contains(got, "webvnc: https://portal.example/vnc") {

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -1098,6 +1098,15 @@ export class FleetCoordinator {
         parts[1] === "leases" &&
         parts[2] &&
         parts[3] === "webvnc" &&
+        parts[4] === "handoff"
+      ) {
+        return await this.webVNCCredentialHandoff(request, parts[2]);
+      }
+      if (
+        parts[0] === "v1" &&
+        parts[1] === "leases" &&
+        parts[2] &&
+        parts[3] === "webvnc" &&
         parts[4] === "ticket"
       ) {
         return await this.createWebVNCTicket(request, parts[2]);
@@ -7859,7 +7868,14 @@ export class FleetCoordinator {
   }
 
   private async webVNCCredentialHandoff(request: Request, identifier: string): Promise<Response> {
-    const lease = await this.resolvePortalLease(identifier, request);
+    if (request.method.toUpperCase() !== "POST") {
+      return json({ error: "not_found" }, { status: 404 });
+    }
+    const portalRequest = new URL(request.url).pathname.startsWith("/portal/");
+    const admin = isAdminRequest(request);
+    const lease = portalRequest
+      ? await this.resolvePortalLease(identifier, request)
+      : await this.resolveLease(identifier, request, admin);
     if (!lease) {
       return notFound();
     }
@@ -7871,6 +7887,12 @@ export class FleetCoordinator {
       | { ticket?: unknown; username?: unknown; password?: unknown }
       | undefined;
     if (typeof body?.ticket === "string") {
+      if (!portalRequest) {
+        return json(
+          { error: "invalid_handoff", message: "portal handoff required" },
+          { status: 400 },
+        );
+      }
       const result = await this.webVNCCredentialHandoffs.consume(lease.id, body.ticket);
       if (result.status !== "accepted") {
         const expired = result.status === "expired";
@@ -7887,7 +7909,7 @@ export class FleetCoordinator {
         { headers: { "cache-control": "no-store" } },
       );
     }
-    if (!this.leaseManageableByRequest(lease, request, isAdminRequest(request))) {
+    if (!this.leaseManageableByRequest(lease, request, admin)) {
       return json({ error: "forbidden", message: "lease manage access required" }, { status: 403 });
     }
     const username = typeof body?.username === "string" ? body.username : "";

--- a/worker/src/portal.ts
+++ b/worker/src/portal.ts
@@ -1148,6 +1148,9 @@ export function portalVNC(lease: LeaseRecord, options: { canManage?: boolean } =
       const handoffTicket = fragment.get("handoff") || "";
       let credentialsReady = !handoffTicket;
       const takeControlOnConnect = fragment.get("control") === "take";
+      const reuseWindowName = "crabbox-webvnc-" + ${JSON.stringify(lease.id)};
+      const reuseChannel = typeof BroadcastChannel === "function" ? new BroadcastChannel(reuseWindowName) : null;
+      let portalReadyForReuse = false;
       const bridgeMissingMessage = ${JSON.stringify(bridgeMissingMessage)};
       const missingVNCCredentialMessage = "VNC credentials missing; open WebVNC from crabbox webvnc status";
       const failedVNCCredentialMessage = "VNC authentication failed; reopen WebVNC from crabbox webvnc status";
@@ -1178,6 +1181,97 @@ export function portalVNC(lease: LeaseRecord, options: { canManage?: boolean } =
       function setStatus(value, tone = "") {
         status.textContent = value;
         status.dataset.tone = tone;
+      }
+      function handoffFragment(value) {
+        const offered = new URLSearchParams(String(value || ""));
+        const ticket = offered.get("handoff") || "";
+        if (!/^vnc_handoff_[a-f0-9]{32}$/.test(ticket)) return "";
+        const safe = new URLSearchParams({ handoff: ticket });
+        if (offered.get("control") === "take") safe.set("control", "take");
+        return safe.toString();
+      }
+      reuseChannel?.addEventListener("message", (event) => {
+        const message = event.data;
+        if (!portalReadyForReuse || typeof message?.requestID !== "string") return;
+        if (message.type === "handoff-offer") {
+          reuseChannel.postMessage({
+            type: "handoff-candidate",
+            requestID: message.requestID,
+            recipientID: viewerID,
+            connected,
+            controller: isController,
+          });
+          return;
+        }
+        if (message.type !== "handoff-grant" || message.recipientID !== viewerID) return;
+        const nextFragment = handoffFragment(message.fragment);
+        if (!nextFragment) return;
+        reuseChannel.postMessage({
+          type: "handoff-accepted",
+          requestID: message.requestID,
+          recipientID: viewerID,
+        });
+        const nextURL = new URL(window.location.href);
+        nextURL.hash = nextFragment;
+        window.focus();
+        window.location.replace(nextURL);
+      });
+      window.addEventListener("hashchange", () => {
+        const nextTicket = new URLSearchParams(window.location.hash.slice(1)).get("handoff") || "";
+        if (nextTicket && nextTicket !== handoffTicket && handoffFragment("handoff=" + encodeURIComponent(nextTicket))) {
+          window.location.reload();
+        }
+      });
+      async function reuseExistingWebVNCTab() {
+        if (!handoffTicket || !reuseChannel) return false;
+        const requestID = viewerID;
+        const offered = new URLSearchParams({ handoff: handoffTicket });
+        if (takeControlOnConnect) offered.set("control", "take");
+        return await new Promise((resolve) => {
+          const candidates = new Map();
+          let recipientID = "";
+          let acceptedTimeout;
+          function finish(reused) {
+            window.clearTimeout(candidateTimeout);
+            window.clearTimeout(acceptedTimeout);
+            reuseChannel.removeEventListener("message", receive);
+            resolve(reused);
+          }
+          function receive(event) {
+            const message = event.data;
+            if (message?.requestID !== requestID) return;
+            if (message.type === "handoff-candidate" && typeof message.recipientID === "string") {
+              candidates.set(message.recipientID, {
+                recipientID: message.recipientID,
+                connected: message.connected === true,
+                controller: message.controller === true,
+              });
+              return;
+            }
+            if (message.type === "handoff-accepted" && message.recipientID === recipientID) {
+              finish(true);
+            }
+          }
+          reuseChannel.addEventListener("message", receive);
+          const candidateTimeout = window.setTimeout(() => {
+            const selected = [...candidates.values()].sort(
+              (left, right) => Number(right.controller) - Number(left.controller) || Number(right.connected) - Number(left.connected) || left.recipientID.localeCompare(right.recipientID),
+            )[0];
+            if (!selected) {
+              finish(false);
+              return;
+            }
+            recipientID = selected.recipientID;
+            reuseChannel.postMessage({
+              type: "handoff-grant",
+              requestID,
+              recipientID,
+              fragment: offered.toString(),
+            });
+            acceptedTimeout = window.setTimeout(() => finish(false), 180);
+          }, 80);
+          reuseChannel.postMessage({ type: "handoff-offer", requestID });
+        });
       }
       let rfb;
       let retryTimer;
@@ -1485,6 +1579,7 @@ export function portalVNC(lease: LeaseRecord, options: { canManage?: boolean } =
         window.clearTimeout(retryTimer);
         window.clearInterval(statusTimer);
         window.clearTimeout(desktopThemeTimer);
+        reuseChannel?.close();
         rfb?.disconnect();
       });
       const takeoverBtn = document.getElementById("vnc-takeover");
@@ -1818,7 +1913,22 @@ export function portalVNC(lease: LeaseRecord, options: { canManage?: boolean } =
         window.clearTimeout(copyResetTimer);
         copyResetTimer = window.setTimeout(() => { delete copyBtn.dataset.state; }, 1200);
       });
-      connect();
+      async function startViewer() {
+        if (await reuseExistingWebVNCTab()) {
+          const cleanURL = new URL(window.location.href);
+          cleanURL.hash = "";
+          window.history.replaceState(null, "", cleanURL);
+          setStatus("WebVNC continued in the existing tab", "ok");
+          try { window.open("", reuseWindowName)?.focus(); } catch (_) {}
+          reuseChannel?.close();
+          window.close();
+          return;
+        }
+        window.name = reuseWindowName;
+        portalReadyForReuse = true;
+        connect();
+      }
+      void startViewer();
     </script>`,
     200,
     nonce,

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -19050,6 +19050,21 @@ describe("fleet lease identity and idle", () => {
     expect(pageBody).toContain('linkFragment.set("handoff", body.ticket)');
     expect(pageBody).not.toContain('linkFragment.set("username", username)');
     expect(pageBody).not.toContain('linkFragment.set("password", password)');
+    expect(pageBody).toContain("new BroadcastChannel(reuseWindowName)");
+    expect(pageBody).toContain('type: "handoff-offer"');
+    expect(pageBody).toContain('type: "handoff-candidate"');
+    expect(pageBody).toContain('type: "handoff-grant"');
+    expect(pageBody).toContain('type: "handoff-accepted"');
+    expect(pageBody).toContain("message.recipientID === recipientID");
+    expect(pageBody).toContain("message.recipientID !== viewerID");
+    expect(pageBody).toContain('reuseChannel.postMessage({ type: "handoff-offer", requestID })');
+    expect(pageBody).not.toContain(
+      'reuseChannel.postMessage({ type: "handoff-offer", requestID, fragment:',
+    );
+    expect(pageBody).toContain("WebVNC continued in the existing tab");
+    expect(pageBody).toContain('window.open("", reuseWindowName)?.focus()');
+    expect(pageBody).toContain('window.addEventListener("hashchange"');
+    expect(pageBody).toContain("nextTicket !== handoffTicket");
     expect(pageBody).toContain("await refreshShareState()");
     expect(pageBody).toContain("writeClipboardText(await shareableWebVNCURL())");
     expect(pageBody).toContain('document.getElementById("vnc-share")');
@@ -19215,7 +19230,7 @@ describe("fleet lease identity and idle", () => {
     });
 
     const issuedHandoff = await fleet.fetch(
-      request("POST", "/portal/leases/blue-lobster/vnc/handoff", {
+      request("POST", "/v1/leases/blue-lobster/webvnc/handoff", {
         headers,
         body: { username: "vnc-user", password: "generated-vnc-password" },
       }),
@@ -19230,6 +19245,14 @@ describe("fleet lease identity and idle", () => {
     expect(storage.alarm()).toBe(Date.parse(issuedHandoffBody.expiresAt));
     expect(issuedHandoffBody).not.toHaveProperty("username");
     expect(issuedHandoffBody).not.toHaveProperty("password");
+
+    const apiCannotRedeem = await fleet.fetch(
+      request("POST", "/v1/leases/blue-lobster/webvnc/handoff", {
+        headers,
+        body: { ticket: issuedHandoffBody.ticket },
+      }),
+    );
+    expect(apiCannotRedeem.status).toBe(400);
 
     const friendCannotIssue = await fleet.fetch(
       request("POST", "/portal/leases/blue-lobster/vnc/handoff", {


### PR DESCRIPTION
## Summary

- replace CLI-generated WebVNC username/password URL fragments with authenticated one-use handoff tickets
- consume tickets only from authorized portal sessions and remove them from the address bar before connecting
- reuse and focus one existing lease viewer through a selected-recipient cross-tab handshake
- handle browsers that reuse the current tab through hash-only navigation

## Verification

- `go test -race ./...`
- `go vet ./...`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker`
- `npm run build --prefix worker`
- `npm run build:node --prefix worker`
- autoreview: clean, no accepted/actionable findings

## Live proof

- provider: `local-container`
- lease: `cbx_a8378a283279`
- isolated Node/PostgreSQL coordinator with registered desktop lease
- first `webvnc --open --take-control`: connected viewer; no username, password, or handoff remained in the Chrome URL
- repeated open: exactly one matching Chrome tab remained connected
- ticket probes: other lease `404`, first correct redemption `200`, replay `401`
- test lease, bridge processes, local coordinator, database, proxy, and credential-bearing temporary files were removed after proof
