### PR TITLE
fix: unify macOS WebVNC portal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- Unified direct macOS WebVNC with the authenticated portal: Tart and Parallels viewers now use the same chrome and controls as Linux and Windows when coordinator login is configured, with provider-lifetime registration and the local viewer retained as the offline fallback.
 - Replaced WebVNC password and username URL fragments with one-time credential handoff tickets, and made repeated `--open` calls reuse and focus the existing lease viewer tab when the browser supports cross-tab handoff.
 - Required E2B stop and automatic cleanup to hold an unchanged API-endpoint-, sandbox-, lease-, slug-, and provider-bound local claim across deletion; claimless recovery now requires explicit `--reclaim`. Thanks @coygeek.
 - Prevented config and `.crabboxignore` negations, including case aliases, from re-including Crabbox-owned env profiles, uploaded scripts, logs, captures, and run artifacts in sync manifests. Thanks @zozo123.

--- a/docs/commands/webvnc.md
+++ b/docs/commands/webvnc.md
@@ -1,10 +1,13 @@
 # webvnc
 
-`crabbox webvnc` opens a desktop lease in a browser tab. For coordinator-backed
-leases it bridges into the authenticated coordinator portal. The local container
-provider also supports WebVNC by serving noVNC locally over an SSH tunnel. An
-existing loopback VNC tunnel can use the provider-neutral `webvnc local` bridge
-on a macOS or Linux host.
+`crabbox webvnc` opens a desktop lease in a browser tab. Coordinator-backed
+leases bridge into the authenticated coordinator portal. Direct macOS providers
+such as Tart and Parallels use that same portal whenever coordinator login is
+configured; Crabbox registers the external lease until `crabbox stop` or normal
+coordinator expiry. Without coordinator auth, direct macOS keeps a
+localhost viewer as its offline fallback. The local container provider serves
+noVNC locally over an SSH tunnel. An existing loopback VNC tunnel can use the
+provider-neutral `webvnc local` bridge on a macOS or Linux host.
 
 ```sh
 crabbox warmup --desktop
@@ -66,6 +69,11 @@ browser noVNC
   <-> SSH tunnel
   <-> runner 127.0.0.1:5900
 ```
+
+This path also carries Tart and Parallels macOS Screen Sharing sessions when a
+coordinator login is configured. The portal chrome, sharing, controller,
+clipboard, status, reset, and daemon controls are the same as for Linux and
+Windows.
 
 For the local container provider, the data path is local:
 

--- a/docs/features/interactive-desktop-vnc.md
+++ b/docs/features/interactive-desktop-vnc.md
@@ -93,8 +93,8 @@ local-to-portal path.
   `crabbox webvnc` process keeps the SSH tunnel open, connects to the
   coordinator with a one-use bridge ticket, and the authenticated portal serves
   bundled noVNC. The portal never connects to the runner directly, so the local
-  bridge must keep running. `--open` preloads the VNC password into the local
-  browser fragment.
+  bridge must keep running. `--open` gives the browser a one-use credential
+  handoff ticket; usernames and passwords never enter the URL.
 - `crabbox vnc` is for a native VNC client: when WebVNC status or reset reports
   the portal path is unhealthy, or when you need a native client feature.
 
@@ -109,12 +109,13 @@ crabbox vnc --id blue-lobster --open
 ```
 
 WebVNC is available on coordinator-managed desktop leases and on direct desktop
-providers. Direct providers normally use a localhost viewer. With
-`broker.mode: registered`, direct leases instead use the outbound coordinator
-bridge, so KubeVirt, external, static SSH, local Docker, and other SSH desktop
-leases can appear in and be shared from the portal. Blacksmith remains
-unsupported. Native `crabbox vnc` works against every managed and host-managed
-desktop in the support matrix.
+providers. Authenticated direct macOS providers such as Tart and Parallels are
+registered automatically for the provider lease lifetime, so they use the same portal
+chrome and controls as Linux and Windows. Other direct providers can opt into
+the outbound coordinator bridge with `broker.mode: registered`; without that
+mode they keep their localhost viewer. Blacksmith remains unsupported. Native
+`crabbox vnc` works against every managed and host-managed desktop in the
+support matrix.
 
 For kept registered desktop leases, `broker.autoWebVNC: true` starts the bridge
 daemon automatically. The daemon heartbeats the registration while connected;
@@ -177,9 +178,10 @@ crabbox desktop launch --id blue-lobster --browser --url https://example.com --w
 For human demos, launched browsers stay windowed so the desktop panel, title
 bar, and surrounding session remain visible. Use `--fullscreen` only when you
 want browser-only video or capture output. `--webvnc` (and its `--open` /
-`--take-control` companions) bridges the launched desktop into the portal and
-requires a coordinator-backed Hetzner, AWS, or Azure lease. The local container
-provider uses local noVNC over SSH. `--egress` routes the launched browser
+`--take-control` companions) bridges the launched desktop into the portal.
+Authenticated Tart and Parallels macOS leases use the same portal as
+coordinator-managed leases; the local container provider uses local noVNC over
+SSH. `--egress` routes the launched browser
 through the lease-local egress proxy (default
 `127.0.0.1:3128`) and currently requires `--browser`; see
 [mediated egress](egress.md).

--- a/docs/providers/tart.md
+++ b/docs/providers/tart.md
@@ -87,11 +87,11 @@ Lease with `--desktop` to get a visible macOS session:
 
 ```sh
 crabbox warmup --provider tart --desktop
-crabbox webvnc --provider tart --id <lease-id>   # browser viewer (host-side bridge)
+crabbox webvnc --provider tart --id <lease-id>   # shared portal, or local fallback without coordinator login
 crabbox screenshot --provider tart --id <lease-id> --output desktop.png
 ```
 
-`crabbox webvnc` runs a host-side bridge: it SSH-tunnels to the guest's Screen Sharing port, creates a self-contained mode-0600 noVNC viewer file, and opens that file in the browser — no noVNC/`websockify` tooling on the guest. The temporary viewer talks only to literal `127.0.0.1`, fetches the account credentials with an authenticated POST, and authenticates the WebSocket relay with a per-session subprotocol, keeping the bearer out of process arguments and browser URLs. The file contains only the ephemeral bridge token and is removed when the bridge exits. `crabbox screenshot` uses the same locally configured account credentials for noninteractive capture. noVNC authenticates via macOS Apple (ARD) auth with the lease account credentials (handed to the local viewer only). Prefer a native VNC client instead? Tunnel and connect directly:
+`crabbox webvnc` runs a host-side bridge to the guest's Screen Sharing port; the guest needs no noVNC/`websockify` tooling. With an authenticated coordinator login, Crabbox registers the Tart lease and presents it inside the same portal chrome and controls as Linux and Windows. The registration follows the Tart lease until `crabbox stop` or normal coordinator expiry and never grants the coordinator authority to delete the VM. Without coordinator auth, Crabbox keeps the self-contained mode-0600 localhost viewer as an offline fallback. `crabbox screenshot` uses the same locally configured account credentials for noninteractive capture. noVNC authenticates via macOS Apple (ARD) auth with the lease account credentials. Prefer a native VNC client instead? Tunnel and connect directly:
 
 ```sh
 ssh -i <lease-key> -o GatewayPorts=no -L 127.0.0.1:5900:127.0.0.1:5900 admin@<lease-ip>
@@ -110,7 +110,7 @@ open vnc://127.0.0.1:5900    # native VNC client on the controller
 
 **Exposure boundary:** macOS Screen Sharing binds all guest interfaces, so the VNC server is reachable at the guest's address on the tart host network (not localhost-only), gated by account authentication. tart's network is host-local (only the Mac can reach the guest), so the effective boundary is "account-authenticated VNC, reachable from the tart host." The SSH tunnels above keep the viewer side on `127.0.0.1`.
 
-> The browser viewer is a **host-side** bridge (the guest needs no noVNC/`websockify`). For the remote control-plane case, run `crabbox webvnc` on the Mac, tunnel the printed web port to your machine with `ssh -o GatewayPorts=no -L 127.0.0.1:<port>:127.0.0.1:<port> <user>@<mac>`, copy the printed handoff file to your machine with `scp`, and open the copied file while the bridge is running. The `webvnc status`/`reset`/`daemon` subcommands (the Linux noVNC-daemon model) remain unsupported for macOS and point you to `crabbox webvnc`.
+> The browser viewer is a **host-side** bridge (the guest needs no noVNC/`websockify`). With coordinator auth, `webvnc status`, `reset`, and `daemon` use the shared portal model. Without coordinator auth, remote operators can still forward the printed localhost web port and copy/open the mode-`0600` handoff file while the bridge is running.
 
 ## Not yet supported
 

--- a/internal/cli/claim.go
+++ b/internal/cli/claim.go
@@ -47,6 +47,7 @@ type leaseClaim struct {
 	SSHHost                             string            `json:"sshHost,omitempty"`
 	SSHPort                             int               `json:"sshPort,omitempty"`
 	BridgeURL                           string            `json:"bridgeURL,omitempty"`
+	CoordinatorRegistrationURL          string            `json:"coordinatorRegistrationURL,omitempty"`
 	RuntimeAdapterRegistrationID        string            `json:"runtimeAdapterRegistrationID,omitempty"`
 	RuntimeAdapterPendingRegistrationID string            `json:"runtimeAdapterPendingRegistrationID,omitempty"`
 	CacheVolumes                        []string          `json:"cacheVolumes,omitempty"`

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -49,6 +49,8 @@ type Config struct {
 	brokerProvider                string
 	BrokerLoginRedirectOrigins    []string
 	BrokerAutoWebVNC              bool
+	macOSPortalAuto               bool
+	macOSPortalCoordinator        string
 	CoordToken                    string
 	CoordTokenCommand             []string
 	CoordAdminToken               string

--- a/internal/cli/coordinator_registration.go
+++ b/internal/cli/coordinator_registration.go
@@ -172,6 +172,9 @@ func (a App) registerCoordinatorLeaseBestEffort(ctx context.Context, cfg Config,
 		if adapterMode {
 			return fmt.Errorf("register adapter workspace with coordinator: %w", err)
 		}
+		if cfg.macOSPortalAuto {
+			return fmt.Errorf("register macOS portal lease with coordinator: %w", err)
+		}
 		return nil
 	}
 	if adapterMode && (registered.RuntimeAdapterID != adapterID ||
@@ -198,7 +201,40 @@ func (a App) registerCoordinatorLeaseBestEffort(ctx context.Context, cfg Config,
 			return err
 		}
 	}
+	if cfg.macOSPortalAuto {
+		if err := persistAutomaticCoordinatorRegistrationBinding(lease.LeaseID, cfg, coord.BaseURL); err != nil {
+			callCtx, cancel := context.WithTimeout(context.Background(), coordinatorRegistrationTimeout)
+			_, releaseErr := coord.ReleaseLease(callCtx, lease.LeaseID, false)
+			cancel()
+			a.coordinatorRegistrationWarning(lease.LeaseID, errors.Join(err, releaseErr))
+			return err
+		}
+	}
 	return nil
+}
+
+func persistAutomaticCoordinatorRegistrationBinding(leaseID string, cfg Config, actualURL string) error {
+	expectedURL := strings.TrimSpace(cfg.macOSPortalCoordinator)
+	if expectedURL == "" || actualURL != expectedURL {
+		return fmt.Errorf("automatic macOS portal coordinator binding changed before persistence")
+	}
+	return mutateLeaseClaimGuarded(
+		leaseID,
+		func(claim leaseClaim, exists bool) error {
+			if !exists || claim.LeaseID != leaseID {
+				return fmt.Errorf("automatic macOS portal registration requires a persisted lease claim")
+			}
+			bound := strings.TrimSpace(claim.CoordinatorRegistrationURL)
+			if bound != "" && bound != expectedURL {
+				return fmt.Errorf("automatic macOS portal coordinator conflicts with persisted binding")
+			}
+			return nil
+		},
+		func(claim *leaseClaim) error {
+			claim.CoordinatorRegistrationURL = expectedURL
+			return nil
+		},
+	)
 }
 
 func coordinatorRegistrationSSHUser(target SSHTarget) string {
@@ -529,6 +565,12 @@ func (a App) releaseRegisteredCoordinatorLease(ctx context.Context, cfg Config, 
 			err = fmt.Errorf("coordinator is not configured")
 		}
 		return err
+	}
+	if cfg.macOSPortalAuto {
+		expectedURL := strings.TrimSpace(cfg.macOSPortalCoordinator)
+		if expectedURL == "" || coord.BaseURL != expectedURL {
+			return fmt.Errorf("macOS portal coordinator changed from persisted registration binding")
+		}
 	}
 	callCtx, cancel := context.WithTimeout(ctx, coordinatorRegistrationTimeout)
 	defer cancel()

--- a/internal/cli/macos_webvnc.go
+++ b/internal/cli/macos_webvnc.go
@@ -121,6 +121,7 @@ func resolveMacOSWebVNCCredentials(ctx context.Context, cfg Config, target SSHTa
 		return rfbCredentials{}, exit(5, "managed macOS desktop password is empty")
 	}
 	return rfbCredentials{
+		Username: strings.TrimSpace(target.User),
 		Password: password,
 	}, nil
 }

--- a/internal/cli/macos_webvnc_test.go
+++ b/internal/cli/macos_webvnc_test.go
@@ -31,7 +31,7 @@ func TestResolveMacOSWebVNCCredentialsFallsBackToManagedPassword(t *testing.T) {
 	if gotCommand != "sudo cat '/var/db/crabbox/vnc.password'" {
 		t.Fatalf("password command = %q", gotCommand)
 	}
-	if credentials.Username != "" || credentials.Password != "managed-secret" {
+	if credentials.Username != "steipete" || credentials.Password != "managed-secret" {
 		t.Fatalf("credentials = %#v", credentials)
 	}
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -3287,6 +3287,17 @@ func (a App) stop(ctx context.Context, args []string) error {
 	if err := ValidateLeaseTargetProviderIdentity(lease, expectedIdentity); err != nil {
 		return err
 	}
+	coordinatorCleanupCfg := cfg
+	coordinatorCleanupCfg.TargetOS = lease.SSH.TargetOS
+	coordinatorCleanupCfg.WindowsMode = lease.SSH.WindowsMode
+	// Stop accepts provider resource IDs, but portal registration state is
+	// indexed by the canonical lease ID resolved above.
+	cleanupLeaseID := firstNonBlank(lease.LeaseID, *id)
+	routedCleanupCfg, _, routeErr := macOSPortalWebVNCConfigForLease(coordinatorCleanupCfg, cleanupLeaseID)
+	coordinatorCleanupCfg = routedCleanupCfg
+	if routeErr != nil {
+		fmt.Fprintf(a.Stderr, "warning: could not prepare macOS portal deregistration for %s: %v\n", lease.LeaseID, routeErr)
+	}
 	connectionCleanupSafe := releaseLeaseConnectionCleanupSafe(sshBackend)
 	if connectionCleanupSafe {
 		if lease.SSH.Host != "" {
@@ -3309,7 +3320,14 @@ func (a App) stop(ctx context.Context, args []string) error {
 	if !connectionCleanupSafe {
 		a.cleanupBackendLeaseLocalConnectionsBestEffort(*id, lease.LeaseID)
 	}
-	a.releaseRegisteredCoordinatorLeaseBestEffort(ctx, cfg, lease.LeaseID)
+	if isMacOSDesktopProvider(coordinatorCleanupCfg) && supportsDirectSSHWebVNC(cfg.Provider) {
+		for _, daemonID := range uniqueNonBlankStrings(*id, lease.LeaseID, serverSlug(lease.Server)) {
+			if _, stopErr := a.stopWebVNCDaemonIfRunning(daemonID); stopErr != nil {
+				fmt.Fprintf(a.Stderr, "warning: could not stop macOS WebVNC daemon for %s: %v\n", daemonID, stopErr)
+			}
+		}
+	}
+	a.releaseRegisteredCoordinatorLeaseBestEffort(ctx, coordinatorCleanupCfg, lease.LeaseID)
 	if backendCoordinator(backend) != nil {
 		fmt.Fprintf(a.Stderr, "released lease=%s server=%s\n", lease.LeaseID, lease.Server.DisplayID())
 		return nil

--- a/internal/cli/webvnc.go
+++ b/internal/cli/webvnc.go
@@ -227,6 +227,10 @@ func (a App) webvnc(ctx context.Context, args []string) error {
 	if err := applyProviderFlags(&cfg, fs, providerFlags); err != nil {
 		return err
 	}
+	cfg, _, err = macOSPortalWebVNCConfigForLease(cfg, *id)
+	if err != nil {
+		return err
+	}
 	if useDirectSSHWebVNC(cfg) {
 		// macOS leases (e.g. tart) have no guest-side noVNC/websockify; serve the
 		// browser viewer from a host-side bridge over the guest's native Screen
@@ -275,14 +279,12 @@ func (a App) webvnc(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	password := ""
-	if endpoint.Managed {
-		password, _ = runSSHOutput(ctx, target, vncPasswordCommand(target))
+	credentials, err := resolveWebVNCPortalCredentials(ctx, cfg, target, endpoint, runSSHOutput)
+	if err != nil {
+		return err
 	}
-	username := ""
-	if endpoint.Managed && target.TargetOS == targetMacOS {
-		username = target.User
-	}
+	username := credentials.Username
+	password := credentials.Password
 
 	connHost := endpoint.Host
 	connPort := endpoint.Port
@@ -570,6 +572,10 @@ func (a App) webVNCDaemonStart(ctx context.Context, args []string) error {
 	if err := applyProviderFlags(&cfg, fs, providerFlags); err != nil {
 		return err
 	}
+	cfg, _, err = macOSPortalWebVNCConfigForLease(cfg, *id)
+	if err != nil {
+		return err
+	}
 	target := SSHTarget{TargetOS: cfg.TargetOS, WindowsMode: cfg.WindowsMode}
 	bridgeID := *id
 	identityValidated := false
@@ -828,6 +834,10 @@ func (a App) webVNCStatusCommand(ctx context.Context, args []string) error {
 	if err := applyProviderFlags(&cfg, fs, providerFlags); err != nil {
 		return err
 	}
+	cfg, _, err = macOSPortalWebVNCConfigForLease(cfg, *id)
+	if err != nil {
+		return err
+	}
 	if useDirectSSHWebVNC(cfg) {
 		if err := guardMacOSDirectWebVNC(cfg); err != nil {
 			return err
@@ -871,14 +881,15 @@ func (a App) webVNCStatusCommand(ctx context.Context, args []string) error {
 		*localPort = availableLocalVNCPort()
 	}
 	endpoint, endpointErr := resolveVNCEndpoint(ctx, cfg, &target)
-	password := ""
-	username := ""
-	if endpointErr == nil && endpoint.Managed {
-		password, _ = runSSHOutput(ctx, target, vncPasswordCommand(target))
-		if target.TargetOS == targetMacOS {
-			username = target.User
+	credentials := rfbCredentials{}
+	if endpointErr == nil && !*redactCredentials {
+		credentials, err = resolveWebVNCPortalCredentials(ctx, cfg, target, endpoint, runSSHOutput)
+		if err != nil {
+			return err
 		}
 	}
+	username := credentials.Username
+	password := credentials.Password
 	status, statusErr := coord.WebVNCStatus(ctx, leaseID)
 	daemon, daemonErr := localWebVNCDaemonStatus(leaseID)
 	if daemonErr == nil && leaseID != *id {
@@ -977,6 +988,10 @@ func (a App) webVNCResetCommand(ctx context.Context, args []string) error {
 	if err := applyProviderFlags(&cfg, fs, providerFlags); err != nil {
 		return err
 	}
+	cfg, automaticMacOSPortal, err := macOSPortalWebVNCConfigForLease(cfg, *id)
+	if err != nil {
+		return err
+	}
 	if useDirectSSHWebVNC(cfg) {
 		if err := guardMacOSDirectWebVNC(cfg); err != nil {
 			return err
@@ -1000,6 +1015,11 @@ func (a App) webVNCResetCommand(ctx context.Context, args []string) error {
 	if err := enforceManagedLeaseCapabilities(cfg, server, leaseID); err != nil {
 		return err
 	}
+	if automaticMacOSPortal {
+		if err := a.claimAndTouchLeaseTarget(ctx, cfg, server, target, leaseID, false); err != nil {
+			return err
+		}
+	}
 	if _, err := coord.ResetWebVNC(ctx, leaseID); err != nil {
 		fmt.Fprintf(a.Stdout, "portal reset: skipped (%v)\n", err)
 	}
@@ -1017,12 +1037,12 @@ func (a App) webVNCResetCommand(ctx context.Context, args []string) error {
 		printRescue(a.Stdout, classifyDesktopFailure(out), trimFailureDetail(out), desktopDoctorCommand(rescueCtx))
 		return exit(5, "reset target WebVNC/input stack: %v", err)
 	}
-	password := ""
-	username := ""
-	if target.TargetOS == targetMacOS {
-		username = target.User
+	credentials, err := resolveWebVNCPortalCredentials(ctx, cfg, target, vncEndpoint{Managed: true}, runSSHOutput)
+	if err != nil {
+		return err
 	}
-	password, _ = runSSHOutput(ctx, target, vncPasswordCommand(target))
+	username := credentials.Username
+	password := credentials.Password
 	portalUsername, portalPassword := "", ""
 	if *openPortal || !*redactCredentials {
 		portalUsername, portalPassword = username, password
@@ -2644,6 +2664,84 @@ func supportsDirectSSHWebVNC(provider string) bool {
 
 func useDirectSSHWebVNC(cfg Config) bool {
 	return supportsDirectSSHWebVNC(cfg.Provider) && !shouldRegisterCoordinatorLease(cfg)
+}
+
+// macOSPortalWebVNCConfig registers direct macOS leases when the operator
+// already has coordinator auth. The registration follows the provider lease,
+// so overlapping bridges can share it and stop owns the matching cleanup.
+func macOSPortalWebVNCConfig(cfg Config) (Config, bool, error) {
+	if !useDirectSSHWebVNC(cfg) || !isMacOSDesktopProvider(cfg) || strings.TrimSpace(cfg.Coordinator) == "" {
+		return cfg, false, nil
+	}
+	if strings.TrimSpace(cfg.CoordToken) == "" && len(cfg.CoordTokenCommand) == 0 {
+		return cfg, false, nil
+	}
+	coord, configured, err := newCoordinatorClient(cfg)
+	if err != nil {
+		return cfg, false, err
+	}
+	if !configured || coord == nil || !coord.hasConfiguredAuth() {
+		return cfg, false, nil
+	}
+	cfg.BrokerMode = BrokerModeRegistered
+	cfg.macOSPortalAuto = true
+	cfg.macOSPortalCoordinator = coord.BaseURL
+	return cfg, true, nil
+}
+
+func macOSPortalWebVNCConfigForLease(cfg Config, id string) (Config, bool, error) {
+	var claim leaseClaim
+	var claimExists bool
+	if supportsDirectSSHWebVNC(cfg.Provider) && strings.TrimSpace(id) != "" {
+		var err error
+		claim, claimExists, err = resolveLeaseClaimForProvider(id, canonicalClaimProvider(cfg.Provider))
+		if err != nil {
+			return cfg, false, err
+		}
+		claimedTarget := firstNonBlank(claim.TargetOS, claim.Labels["target"])
+		if claimExists && !cfg.targetFlagExplicit && claimedTarget == targetMacOS {
+			cfg.TargetOS = targetMacOS
+			cfg.WindowsMode = claim.WindowsMode
+		}
+	}
+	routed, automatic, err := macOSPortalWebVNCConfig(cfg)
+	if err != nil {
+		return routed, false, err
+	}
+	boundCoordinator := strings.TrimSpace(claim.CoordinatorRegistrationURL)
+	if !claimExists || boundCoordinator == "" {
+		return routed, automatic, nil
+	}
+	if !shouldRegisterCoordinatorLease(routed) {
+		return routed, automatic, nil
+	}
+	currentCoordinator, bindingErr := coordinatorRegistrationURLForConfig(routed)
+	if bindingErr != nil {
+		return routed, false, bindingErr
+	}
+	routed.macOSPortalAuto = true
+	routed.macOSPortalCoordinator = boundCoordinator
+	if currentCoordinator != boundCoordinator {
+		return routed, false, exit(4, "macOS portal coordinator changed from persisted registration binding")
+	}
+	return routed, true, nil
+}
+
+func resolveWebVNCPortalCredentials(
+	ctx context.Context,
+	cfg Config,
+	target SSHTarget,
+	endpoint vncEndpoint,
+	readPassword macOSVNCPasswordReader,
+) (rfbCredentials, error) {
+	if !endpoint.Managed {
+		return rfbCredentials{}, nil
+	}
+	if target.TargetOS == targetMacOS {
+		return resolveMacOSWebVNCCredentials(ctx, cfg, target, readPassword)
+	}
+	password, _ := readPassword(ctx, target, vncPasswordCommand(target))
+	return rfbCredentials{Password: strings.TrimSpace(password)}, nil
 }
 
 func directSSHWebVNCAllowsNone(server Server, endpoint vncEndpoint) bool {

--- a/internal/cli/webvnc_test.go
+++ b/internal/cli/webvnc_test.go
@@ -420,6 +420,134 @@ func TestRegisteredLeaseUsesCoordinatorWebVNC(t *testing.T) {
 	}
 }
 
+func TestMacOSWebVNCPortalConfigUsesAuthenticatedCoordinator(t *testing.T) {
+	cfg := Config{
+		Provider:    "direct-webvnc-test",
+		TargetOS:    targetMacOS,
+		Coordinator: "https://broker.example.test",
+		CoordToken:  "token",
+	}
+	got, temporary, err := macOSPortalWebVNCConfig(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !temporary || got.BrokerMode != BrokerModeRegistered || useDirectSSHWebVNC(got) {
+		t.Fatalf("portal config=%#v temporary=%t", got, temporary)
+	}
+
+	withoutAuth := cfg
+	withoutAuth.CoordToken = ""
+	withoutAuth.Coordinator = "not-a-url"
+	got, temporary, err = macOSPortalWebVNCConfig(withoutAuth)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if temporary || got.BrokerMode == BrokerModeRegistered || !useDirectSSHWebVNC(got) {
+		t.Fatalf("unauthenticated config=%#v temporary=%t", got, temporary)
+	}
+
+	registered := cfg
+	registered.BrokerMode = BrokerModeRegistered
+	got, temporary, err = macOSPortalWebVNCConfig(registered)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if temporary || got.BrokerMode != BrokerModeRegistered {
+		t.Fatalf("explicit registered config=%#v temporary=%t", got, temporary)
+	}
+
+	invalid := cfg
+	invalid.Coordinator = "not-a-url"
+	if _, _, err := macOSPortalWebVNCConfig(invalid); err == nil {
+		t.Fatal("invalid authenticated coordinator URL should fail instead of silently using the local viewer")
+	}
+}
+
+func TestMacOSWebVNCPortalConfigUsesStoredMultiTargetLease(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	leaseID := "cbx_macosportal123"
+	claimCfg := baseConfig()
+	claimCfg.Provider = "direct-webvnc-test"
+	claimCfg.TargetOS = targetMacOS
+	if err := claimLeaseTargetForRepoConfig(
+		leaseID,
+		"macos-portal",
+		claimCfg,
+		Server{Provider: "direct-webvnc-test", Labels: map[string]string{"state": "ready", "target": targetMacOS}},
+		SSHTarget{Host: "192.0.2.40", TargetOS: targetMacOS},
+		"/repo",
+		time.Hour,
+		true,
+	); err != nil {
+		t.Fatal(err)
+	}
+	stored, exists, err := readLeaseClaimWithPresence(leaseID)
+	if err != nil || !exists || stored.Labels["target"] != targetMacOS {
+		t.Fatalf("stored claim=%#v exists=%t err=%v", stored, exists, err)
+	}
+	foreignCfg := baseConfig()
+	foreignCfg.Provider = "local-container"
+	foreignCfg.TargetOS = targetLinux
+	if err := claimLeaseTargetForRepoConfig(
+		"cbx_aaa_foreign",
+		"macos-portal",
+		foreignCfg,
+		Server{Provider: "local-container", Labels: map[string]string{"state": "ready", "target": targetLinux}},
+		SSHTarget{Host: "192.0.2.41", TargetOS: targetLinux},
+		"/repo",
+		time.Hour,
+		true,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	got, automatic, err := macOSPortalWebVNCConfigForLease(Config{
+		Provider:    "direct-webvnc-test",
+		Coordinator: "https://broker.example.test",
+		CoordToken:  "token",
+	}, "macos-portal")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !automatic || got.TargetOS != targetMacOS || got.BrokerMode != BrokerModeRegistered {
+		t.Fatalf("stored target config=%#v automatic=%t", got, automatic)
+	}
+	if err := persistAutomaticCoordinatorRegistrationBinding(leaseID, got, "https://broker.example.test"); err != nil {
+		t.Fatal(err)
+	}
+	stored, exists, err = readLeaseClaimWithPresence(leaseID)
+	if err != nil || !exists || stored.CoordinatorRegistrationURL != "https://broker.example.test" {
+		t.Fatalf("persisted coordinator claim=%#v exists=%t err=%v", stored, exists, err)
+	}
+	if _, _, err := macOSPortalWebVNCConfigForLease(Config{
+		Provider:    "direct-webvnc-test",
+		Coordinator: "https://other-broker.example.test",
+		CoordToken:  "token",
+	}, "macos-portal"); err == nil || !strings.Contains(err.Error(), "persisted registration binding") {
+		t.Fatalf("coordinator drift error=%v", err)
+	}
+	if _, _, err := macOSPortalWebVNCConfigForLease(Config{
+		Provider:    "direct-webvnc-test",
+		Coordinator: "https://other-broker.example.test",
+		CoordToken:  "token",
+		BrokerMode:  BrokerModeRegistered,
+	}, "macos-portal"); err == nil || !strings.Contains(err.Error(), "persisted registration binding") {
+		t.Fatalf("explicit registered coordinator drift error=%v", err)
+	}
+
+	explicitLinux := got
+	explicitLinux.BrokerMode = BrokerModeManaged
+	explicitLinux.TargetOS = targetLinux
+	explicitLinux.targetFlagExplicit = true
+	got, automatic, err = macOSPortalWebVNCConfigForLease(explicitLinux, leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if automatic || got.TargetOS != targetLinux {
+		t.Fatalf("explicit target config=%#v automatic=%t", got, automatic)
+	}
+}
+
 func TestIsMacOSDesktopProviderUsesExplicitTargetOrDedicatedProvider(t *testing.T) {
 	// tart's only target is macOS -> uses the host-side Screen Sharing bridge.
 	if !isMacOSDesktopProvider(Config{Provider: "tart"}) {
@@ -472,8 +600,34 @@ func (directWebVNCTestProvider) ApplyFlags(*Config, *flag.FlagSet, any) error {
 	return nil
 }
 func (directWebVNCTestProvider) Configure(Config, Runtime) (Backend, error) { return nil, nil }
+func (directWebVNCTestProvider) DesktopCredentials(Config, SSHTarget) (DesktopCredentials, bool) {
+	return DesktopCredentials{Username: "admin", Password: "provider-secret"}, true
+}
 func (directWebVNCTestProvider) CommandRoutingArgs(_ Config, leaseID string) []string {
 	return []string{"--direct-webvnc-routing", "route-" + leaseID}
+}
+
+func TestWebVNCPortalCredentialsUseMacOSProviderAccount(t *testing.T) {
+	read := false
+	credentials, err := resolveWebVNCPortalCredentials(
+		context.Background(),
+		Config{Provider: "direct-webvnc-test"},
+		SSHTarget{TargetOS: targetMacOS, User: "lease-user"},
+		vncEndpoint{Managed: true},
+		func(context.Context, SSHTarget, string) (string, error) {
+			read = true
+			return "", errors.New("managed password file is absent")
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if read {
+		t.Fatal("provider account credentials should avoid the managed password file")
+	}
+	if credentials.Username != "admin" || credentials.Password != "provider-secret" {
+		t.Fatalf("credentials=%#v", credentials)
+	}
 }
 
 func TestWebVNCResetRemoteCommandHandlesWaylandAndX11(t *testing.T) {


### PR DESCRIPTION
## What Problem This Solves

Tart and Parallels macOS desktops opened in a separate local viewer instead of the authenticated Crabbox WebVNC portal used by Linux and Windows. Their coordinator lifecycle also lacked a durable binding between the provider lease and portal registration.

## Why This Change Was Made

Authenticated direct macOS leases now register with the configured coordinator and use the same portal handoff, chrome, controls, daemon, status, reset, and stop lifecycle as other desktops. The registration URL is persisted without credentials, provider-owned desktop credentials are respected, and cleanup follows the canonical lease ID even when stop is invoked by slug or provider resource ID. Offline use without coordinator auth retains the local viewer.

## User Impact

Users with coordinator auth see Tart and Parallels macOS Screen Sharing inside the unified Crabbox portal. Overlapping bridges reuse one provider-lifetime registration, and stopping the provider lease removes both the WebVNC daemon and coordinator row.

## Evidence

- `go test -race ./...`
- `go test ./...`
- `go vet ./...`
- Focused macOS portal, WebVNC, registration, credential, and stop tests
- Clean final autoreview after lifecycle and credential regressions were repaired
- Real Tart live proof: authenticated portal connection, native 1024x768 macOS frame, reset handoff, overlapping bridge lifecycle, provider credentials, persisted coordinator binding, slug/canonical stop cleanup, and provider deletion across fresh leases
