### PR TITLE
feat: add capability-aware image selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added capability-aware AWS image promotion and lease selection by minimum OS, SDK/runtime versions, browser, WebView2, and desktop support, with fail-before-lease rejection when no promoted image satisfies every requirement.
 - Added provider-neutral Ed25519-signed run receipts through `crabbox run --attest` and integrity verification through `crabbox verify`, with collision-safe signing-key handling and explicit self-signed trust reporting. Thanks @yetval.
 - Documented a provider-neutral hermetic-agent evidence pattern with separate writer contexts, QA arbitration, required proof artifacts, and sync-safe local downloads. Thanks @zozo123.
 - Added `sync-plan --json` with candidate and dirty-delta sizes, configured guardrail status, deleted-path counts, and ranked file and directory hotspots for automation. Thanks @zozo123.

--- a/docs/commands/image.md
+++ b/docs/commands/image.md
@@ -110,6 +110,12 @@ Flags:
 --type <instance-type>   instance type the AMI boots on, for example mac2.metal
 --server-type <type>     alias for --type
 --architecture <arch>    AWS AMI architecture, for example x86_64_mac or arm64_mac
+--os-version <version>   numeric OS version present in the image
+--sdk <name=version>     SDK present in the image (repeatable)
+--runtime <name=version> runtime present in the image (repeatable)
+--browser                image includes browser support
+--webview2               image includes Microsoft WebView2
+--desktop                image includes desktop support
 --fast-snapshot-restore  enable AWS Fast Snapshot Restore for the backing snapshots
 --fsr-az <az>            availability zone for Fast Snapshot Restore (repeatable)
 --json                   print the promoted image record as JSON
@@ -121,6 +127,11 @@ metadata from their source lease. For external macOS AMIs, Crabbox reads the
 architecture from AWS but also accepts `--type` or `--architecture` to pin the
 promotion metadata explicitly. Use `--os` to record the portable Linux selector
 for a promoted Linux AMI.
+
+Capability declarations make the AMI eligible for capability-aware selection.
+Versions use numeric dot notation, for example `--os-version 15.5`,
+`--sdk xcode=16.4`, or `--runtime node=24.2`. Omitted capabilities remain
+unknown and do not satisfy an explicit image requirement.
 
 Add `--fast-snapshot-restore` plus one or more `--fsr-az` values when the
 promoted image backs hot lanes that need immediate EBS snapshot reads:
@@ -142,6 +153,9 @@ Future brokered AWS leases use the promoted image when the request does not set
 an explicit `awsAMI`/`CRABBOX_AWS_AMI` override. Promotion stores coordinator
 metadata only; it does not copy or modify the AMI. A macOS promotion is scoped
 to matching macOS leases and never becomes the Linux or Windows default.
+Crabbox retains a scoped catalog of promoted AMIs so a lease can select the
+newest image satisfying every requested image capability, not only the last
+promoted default.
 
 Promote, smoke-test, and roll back if needed:
 
@@ -162,9 +176,10 @@ crabbox stop <slug>
 ```
 
 If the smoke fails, promote the previous known-good AMI again. The coordinator
-stores only scoped selected AMI IDs, so rollback is just another `image promote`
-for the same target and region. Keep the previous AMI available until at least
-one brokered AWS smoke succeeds on the new image.
+updates the scoped default and retains each promotion in the capability catalog,
+so rollback is another `image promote` for the same target and region. Keep the
+previous AMI available until at least one brokered AWS smoke succeeds on the new
+image.
 
 ## fsr-status
 

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -511,6 +511,12 @@ lease-acting commands):
 --desktop-env xfce|wayland|gnome
 --browser
 --code
+--image-min-os <version>
+--image-sdk <name=version>     Repeatable.
+--image-runtime <name=version> Repeatable.
+--image-require-browser
+--image-require-webview2
+--image-require-desktop
 --target linux|macos|windows
 --windows-mode normal|wsl2
 --static-host <host>         provider=ssh

--- a/docs/commands/warmup.md
+++ b/docs/commands/warmup.md
@@ -268,6 +268,12 @@ warmup, because it also dispatches the workflow and waits for the ready marker.
 --desktop-env xfce|wayland|gnome   Linux desktop environment
 --browser                          provision/require a browser binary
 --code                             provision/require code-server
+--image-min-os <version>           require a minimum promoted-image OS version
+--image-sdk <name=version>         require a minimum SDK version; repeatable
+--image-runtime <name=version>     require a minimum runtime version; repeatable
+--image-require-browser            require browser support in the promoted image
+--image-require-webview2           require WebView2 support in the promoted image
+--image-require-desktop            require desktop support in the promoted image
 --target linux|macos|windows       target OS
 --windows-mode normal|wsl2         Windows mode
 --static-host <host>               static SSH host (provider=ssh)
@@ -293,6 +299,15 @@ Provider-specific flags (for example `--azure-backend`, `--e2b-template`,
 `--daytona-snapshot`) are contributed by the selected provider; run
 `crabbox warmup --provider <name> --help` to see the set for a given provider,
 and `crabbox providers` to list all providers and their capabilities.
+
+Image requirement flags currently select AWS promoted images. Crabbox verifies
+the full requirement set before reserving a lease or calling AWS. Explicit AMI,
+snapshot, and stock-image overrides cannot be verified against the promotion
+catalog and fail closed when combined with image requirements.
+The CLI sends capability-aware creates to a dedicated coordinator route, so an
+older coordinator returns not found instead of silently ignoring requirements.
+Image requirements cannot be combined with `run --pool` because current pool
+entries do not record or prove image capabilities.
 
 ## SSH keys
 

--- a/docs/features/prebaked-images.md
+++ b/docs/features/prebaked-images.md
@@ -27,6 +27,9 @@ Provider-owned image storage is always the source of truth for image bytes:
   `crabbox image promote` records the selected AMI as the default for matching
   brokered AWS leases. Promotion is scoped by target, architecture, and region,
   so a macOS AMI never replaces the Linux or Windows default.
+  Promotions may declare OS, SDK/runtime, browser, WebView2, and desktop
+  capabilities. Capability-aware leases select the newest matching AMI from the
+  scoped promotion catalog and fail before leasing when no image matches.
 - **Azure / GCP** — managed images and disk snapshots live in the cloud project.
   `crabbox image create` can capture them and `crabbox image delete` can remove
   them (`--provider azure|gcp`).
@@ -37,7 +40,7 @@ Provider-owned image storage is always the source of truth for image bytes:
 - **Delegated runners** (for example Blacksmith) — images are owned by the
   provider's runner infrastructure, not by Crabbox.
 
-The coordinator stores only the current provider image identifier, promotion
+The coordinator stores scoped provider image identifiers, promotion capability
 metadata, and enough tags to explain provenance. Do not store image bytes in
 git, release artifacts, or coordinator durable state.
 
@@ -117,6 +120,9 @@ guard scripts. At a high level, an AWS bake is:
    crabbox image promote ami-1234567890abcdef0 --json
    ```
 
+   Add declarations such as `--os-version 26.04 --runtime node=24.2
+   --browser --desktop` when future leases must select by baked capabilities.
+
 6. Run a normal brokered lease (no override) plus the relevant QA lane to confirm
    the promoted image is selected and healthy.
 7. Keep the previous known-good AMI until the new image has real QA proof.
@@ -134,7 +140,7 @@ provider-side artifacts.
   provider image from a lease (`--no-reboot` defaults to true on AWS).
 - `crabbox image promote <ami-id> [--target linux|macos|windows] [--region <r>]`
   — set the default brokered AWS image; supports `--fast-snapshot-restore` with
-  `--fsr-az <az>`.
+  `--fsr-az <az>` and capability declarations.
 - `crabbox image fsr-status <ami-id|snapshot-id>` — AWS Fast Snapshot Restore
   status.
 - `crabbox image delete <image-id> [--provider aws|azure|gcp]` — remove a

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	Desktop                       bool
 	DesktopEnv                    string
 	Browser                       bool
+	imageRequirements             imageRequirements
 	Code                          bool
 	Network                       NetworkMode
 	Class                         string

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -247,6 +247,7 @@ type CoordinatorImage struct {
 	Architecture         string                           `json:"architecture,omitempty"`
 	PromotedAt           string                           `json:"promotedAt,omitempty"`
 	FastSnapshotRestores []CoordinatorFastSnapshotRestore `json:"fastSnapshotRestores,omitempty"`
+	Capabilities         *imageCapabilities               `json:"capabilities,omitempty"`
 }
 
 type CoordinatorFastSnapshotRestore struct {
@@ -317,6 +318,7 @@ type CoordinatorImageRef struct {
 	Architecture           string
 	FastSnapshotRestore    bool
 	FastSnapshotRestoreAZs []string
+	Capabilities           imageCapabilities
 }
 
 type CoordinatorGitHubLoginStart struct {
@@ -857,6 +859,9 @@ func (c *CoordinatorClient) CreateLease(ctx context.Context, cfg Config, publicK
 	if len(capacity) > 0 {
 		req["capacity"] = capacity
 	}
+	if !imageRequirementsEmpty(cfg.imageRequirements) {
+		req["imageRequirements"] = cfg.imageRequirements
+	}
 	if cfg.osImageExplicit {
 		req["os"] = cfg.OSImage
 	}
@@ -864,7 +869,12 @@ func (c *CoordinatorClient) CreateLease(ctx context.Context, cfg Config, publicK
 		req["azureOSDisk"] = cfg.AzureOSDisk
 	}
 	addCoordinatorGCPFields(req, cfg)
-	err = c.do(ctx, http.MethodPost, "/v1/leases", req, &res)
+	path := "/v1/leases"
+	if !imageRequirementsEmpty(cfg.imageRequirements) {
+		// Older coordinators do not have this route, so mixed-version use fails closed.
+		path = "/v1/leases/capability-aware"
+	}
+	err = c.do(ctx, http.MethodPost, path, req, &res)
 	return res.Lease, err
 }
 
@@ -1602,6 +1612,20 @@ func imagePath(imageID, action string, refs ...CoordinatorImageRef) string {
 			if strings.TrimSpace(zone) != "" {
 				values.Add("fsrAz", strings.TrimSpace(zone))
 			}
+		}
+		if ref.Capabilities.OSVersion != "" {
+			values.Set("osVersion", ref.Capabilities.OSVersion)
+		}
+		addSortedImageVersions(func(value string) { values.Add("sdk", value) }, ref.Capabilities.SDKs)
+		addSortedImageVersions(func(value string) { values.Add("runtime", value) }, ref.Capabilities.Runtimes)
+		if ref.Capabilities.Browser {
+			values.Set("browser", "true")
+		}
+		if ref.Capabilities.WebView2 {
+			values.Set("webview2", "true")
+		}
+		if ref.Capabilities.Desktop {
+			values.Set("desktop", "true")
 		}
 	}
 	if encoded := values.Encode(); encoded != "" {

--- a/internal/cli/coordinator_test.go
+++ b/internal/cli/coordinator_test.go
@@ -1099,6 +1099,62 @@ func TestCoordinatorCreateLeaseSendsAWSSSHCIDRs(t *testing.T) {
 	}
 }
 
+func TestCoordinatorCreateLeaseSendsImageRequirementsOnFailClosedRoute(t *testing.T) {
+	var body struct {
+		ImageRequirements imageRequirements `json:"imageRequirements"`
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/leases/capability-aware" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		_, _ = w.Write([]byte(`{"lease":{"id":"cbx_123","provider":"aws","state":"active","host":"192.0.2.10"}}`))
+	}))
+	defer server.Close()
+
+	client := CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
+	requirements := imageRequirements{
+		MinOS:    "26.04",
+		Runtimes: map[string]string{"node": "24"},
+		Browser:  true,
+	}
+	_, err := client.CreateLease(context.Background(), Config{
+		Provider:          "aws",
+		ServerType:        "t3.small",
+		imageRequirements: requirements,
+	}, "ssh-ed25519 test", false, "cbx_123", "blue-crab")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(body.ImageRequirements, requirements) {
+		t.Fatalf("imageRequirements=%#v", body.ImageRequirements)
+	}
+}
+
+func TestCoordinatorImageRequirementsFailClosedOnOlderCoordinator(t *testing.T) {
+	var paths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	client := CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
+	_, err := client.CreateLease(context.Background(), Config{
+		Provider:          "aws",
+		ServerType:        "t3.small",
+		imageRequirements: imageRequirements{Runtimes: map[string]string{"node": "24"}},
+	}, "ssh-ed25519 test", false, "cbx_123", "blue-crab")
+	if err == nil {
+		t.Fatal("older coordinator unexpectedly accepted image requirements")
+	}
+	if !reflect.DeepEqual(paths, []string{"/v1/leases/capability-aware"}) {
+		t.Fatalf("paths=%v", paths)
+	}
+}
+
 func TestCoordinatorCreateLeaseOmitsImplicitDaytonaArchitecture(t *testing.T) {
 	var bodies []map[string]any
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1526,6 +1582,18 @@ func TestCoordinatorImageCreateAndPromote(t *testing.T) {
 			if got := r.URL.Query()["fsrAz"]; !reflect.DeepEqual(got, []string{"us-east-1a", "us-east-1b"}) {
 				t.Fatalf("promote fsrAz=%#v", got)
 			}
+			if got := r.URL.Query().Get("osVersion"); got != "15.5" {
+				t.Fatalf("promote osVersion=%q", got)
+			}
+			if got := r.URL.Query()["sdk"]; !reflect.DeepEqual(got, []string{"xcode=16.4"}) {
+				t.Fatalf("promote sdk=%#v", got)
+			}
+			if got := r.URL.Query()["runtime"]; !reflect.DeepEqual(got, []string{"go=1.25", "node=24.2"}) {
+				t.Fatalf("promote runtime=%#v", got)
+			}
+			if r.URL.Query().Get("browser") != "true" || r.URL.Query().Get("desktop") != "true" {
+				t.Fatalf("promote capabilities=%s", r.URL.RawQuery)
+			}
 			_, _ = w.Write([]byte(`{"image":{"id":"ami-12345678","name":"openclaw-crabbox-test","state":"available","region":"eu-west-1","promotedAt":"2026-05-01T12:46:00Z"}}`))
 		case "/v1/images/ami-12345678/fast-snapshot-restore":
 			if r.Method != http.MethodGet {
@@ -1558,7 +1626,7 @@ func TestCoordinatorImageCreateAndPromote(t *testing.T) {
 	if image, err := client.Image(context.Background(), "ami-12345678"); err != nil || image.State != "available" {
 		t.Fatalf("image=%#v err=%v", image, err)
 	}
-	if promoted, err := client.PromoteImage(context.Background(), "ami-12345678", CoordinatorImageRef{Provider: "aws", Region: "us-east-1", Target: "macos", OSImage: defaultOSImage, ServerType: "mac1.metal", Architecture: "x86_64_mac", FastSnapshotRestore: true, FastSnapshotRestoreAZs: []string{"us-east-1a", "us-east-1b"}}); err != nil || promoted.PromotedAt == "" {
+	if promoted, err := client.PromoteImage(context.Background(), "ami-12345678", CoordinatorImageRef{Provider: "aws", Region: "us-east-1", Target: "macos", OSImage: defaultOSImage, ServerType: "mac1.metal", Architecture: "x86_64_mac", FastSnapshotRestore: true, FastSnapshotRestoreAZs: []string{"us-east-1a", "us-east-1b"}, Capabilities: imageCapabilities{OSVersion: "15.5", SDKs: map[string]string{"xcode": "16.4"}, Runtimes: map[string]string{"node": "24.2", "go": "1.25"}, Browser: true, Desktop: true}}); err != nil || promoted.PromotedAt == "" {
 		t.Fatalf("promoted=%#v err=%v", promoted, err)
 	}
 	if status, err := client.FastSnapshotRestoreStatus(context.Background(), "ami-12345678", CoordinatorImageRef{Provider: "aws", Region: "us-east-1", FastSnapshotRestoreAZs: []string{"us-east-1a"}}); err != nil || len(status.FastSnapshotRestores) != 1 || status.FastSnapshotRestores[0].State != "enabled" {

--- a/internal/cli/image.go
+++ b/internal/cli/image.go
@@ -52,6 +52,14 @@ func (a App) imagePromote(ctx context.Context, args []string) error {
 	serverType := fs.String("type", "", "AWS instance type the AMI boots on, for example mac1.metal")
 	serverTypeAlias := fs.String("server-type", "", "alias for --type")
 	architecture := fs.String("architecture", "", "AWS AMI architecture, for example x86_64_mac or arm64_mac")
+	osVersion := fs.String("os-version", "", "OS version present in the image")
+	var sdkVersions stringListFlag
+	var runtimeVersions stringListFlag
+	fs.Var(&sdkVersions, "sdk", "SDK present in name=version form; repeatable")
+	fs.Var(&runtimeVersions, "runtime", "runtime present in name=version form; repeatable")
+	browser := fs.Bool("browser", false, "image includes a browser")
+	webView2 := fs.Bool("webview2", false, "image includes Microsoft WebView2")
+	desktop := fs.Bool("desktop", false, "image includes desktop support")
 	fastSnapshotRestore := fs.Bool("fast-snapshot-restore", false, "enable AWS Fast Snapshot Restore for the promoted AMI snapshots")
 	var fastSnapshotRestoreAZs stringListFlag
 	fs.Var(&fastSnapshotRestoreAZs, "fsr-az", "availability zone for Fast Snapshot Restore; repeatable")
@@ -60,10 +68,21 @@ func (a App) imagePromote(ctx context.Context, args []string) error {
 		return err
 	}
 	if fs.NArg() != 1 {
-		return exit(2, "usage: crabbox image promote <ami-id> [--target linux|macos|windows] [--os ubuntu:26.04|ubuntu:24.04] [--region <aws-region>] [--type <instance-type>] [--architecture <arch>] [--fast-snapshot-restore --fsr-az <az>]")
+		return exit(2, "usage: crabbox image promote <ami-id> [--target linux|macos|windows] [--os ubuntu:26.04|ubuntu:24.04] [--region <aws-region>] [--type <instance-type>] [--architecture <arch>] [--os-version <version>] [--sdk <name=version>] [--runtime <name=version>] [--browser] [--webview2] [--desktop] [--fast-snapshot-restore --fsr-az <az>]")
 	}
 	if *serverType == "" {
 		*serverType = *serverTypeAlias
+	}
+	if err := validateImageVersion(strings.TrimSpace(*osVersion), "os-version"); err != nil {
+		return err
+	}
+	sdks, err := parseImageVersions(sdkVersions, "sdk")
+	if err != nil {
+		return err
+	}
+	runtimes, err := parseImageVersions(runtimeVersions, "runtime")
+	if err != nil {
+		return err
 	}
 	if flagWasSet(fs, "os") {
 		normalized, err := normalizeOSImage(*osImage)
@@ -85,6 +104,14 @@ func (a App) imagePromote(ctx context.Context, args []string) error {
 		Architecture:           *architecture,
 		FastSnapshotRestore:    *fastSnapshotRestore,
 		FastSnapshotRestoreAZs: fastSnapshotRestoreAZs,
+		Capabilities: imageCapabilities{
+			OSVersion: strings.TrimSpace(*osVersion),
+			SDKs:      sdks,
+			Runtimes:  runtimes,
+			Browser:   *browser,
+			WebView2:  *webView2,
+			Desktop:   *desktop,
+		},
 	})
 	if err != nil {
 		return err

--- a/internal/cli/image_capabilities.go
+++ b/internal/cli/image_capabilities.go
@@ -1,0 +1,103 @@
+package cli
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type imageCapabilities struct {
+	OSVersion string            `json:"osVersion,omitempty"`
+	SDKs      map[string]string `json:"sdks,omitempty"`
+	Runtimes  map[string]string `json:"runtimes,omitempty"`
+	Browser   bool              `json:"browser,omitempty"`
+	WebView2  bool              `json:"webview2,omitempty"`
+	Desktop   bool              `json:"desktop,omitempty"`
+}
+
+type imageRequirements struct {
+	MinOS    string            `json:"minOS,omitempty"`
+	SDKs     map[string]string `json:"sdks,omitempty"`
+	Runtimes map[string]string `json:"runtimes,omitempty"`
+	Browser  bool              `json:"browser,omitempty"`
+	WebView2 bool              `json:"webview2,omitempty"`
+	Desktop  bool              `json:"desktop,omitempty"`
+}
+
+func parseImageVersions(values []string, flagName string) (map[string]string, error) {
+	if len(values) > 32 {
+		return nil, exit(2, "--%s supports at most 32 entries", flagName)
+	}
+	parsed := map[string]string{}
+	for _, value := range values {
+		name, version, ok := strings.Cut(value, "=")
+		name = strings.ToLower(strings.TrimSpace(name))
+		version = strings.TrimSpace(version)
+		if !ok || !validImageCapabilityName(name) || !validImageVersion(version) {
+			return nil, exit(2, "--%s must use name=dot.separated.numeric.version", flagName)
+		}
+		parsed[name] = version
+	}
+	if len(parsed) == 0 {
+		return nil, nil
+	}
+	return parsed, nil
+}
+
+func validImageCapabilityName(value string) bool {
+	if len(value) == 0 || len(value) > 64 {
+		return false
+	}
+	for index, char := range value {
+		if (char >= 'a' && char <= 'z') || (char >= '0' && char <= '9') {
+			continue
+		}
+		if index > 0 && (char == '.' || char == '_' || char == '-') {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func validImageVersion(value string) bool {
+	if value == "" || len(value) > 128 || strings.HasPrefix(value, ".") || strings.HasSuffix(value, ".") {
+		return false
+	}
+	for _, char := range value {
+		if (char < '0' || char > '9') && char != '.' {
+			return false
+		}
+	}
+	return !strings.Contains(value, "..")
+}
+
+func validateImageVersion(value, flagName string) error {
+	if value != "" && !validImageVersion(value) {
+		return exit(2, "--%s must be a dot-separated numeric version", flagName)
+	}
+	return nil
+}
+
+func imageRequirementsEmpty(value imageRequirements) bool {
+	return value.MinOS == "" && len(value.SDKs) == 0 && len(value.Runtimes) == 0 &&
+		!value.Browser && !value.WebView2 && !value.Desktop
+}
+
+func validateReadyPoolImageRequirements(value imageRequirements, pool string) error {
+	if strings.TrimSpace(pool) != "" && !imageRequirementsEmpty(value) {
+		return exit(2, "--pool cannot verify image capability requirements; omit --pool or the --image-* flags")
+	}
+	return nil
+}
+
+func addSortedImageVersions(add func(string), values map[string]string) {
+	names := make([]string, 0, len(values))
+	for name := range values {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		add(fmt.Sprintf("%s=%s", name, values[name]))
+	}
+}

--- a/internal/cli/image_capabilities_test.go
+++ b/internal/cli/image_capabilities_test.go
@@ -1,0 +1,86 @@
+package cli
+
+import (
+	"io"
+	"reflect"
+	"testing"
+)
+
+func TestLeaseImageCapabilityFlags(t *testing.T) {
+	cfg := baseConfig()
+	cfg.Provider = "aws"
+	cfg.Coordinator = "https://crabbox.example.test"
+	fs := newFlagSet("test", io.Discard)
+	values := registerLeaseCreateFlags(fs, cfg)
+	if err := parseFlags(fs, []string{
+		"--image-min-os", "15.4",
+		"--image-sdk", "Xcode=16.3",
+		"--image-runtime", "node=24.2",
+		"--image-runtime", "go=1.25",
+		"--image-require-browser",
+		"--image-require-webview2",
+		"--image-require-desktop",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := applyLeaseCreateFlags(&cfg, fs, values); err != nil {
+		t.Fatal(err)
+	}
+	want := imageRequirements{
+		MinOS:    "15.4",
+		SDKs:     map[string]string{"xcode": "16.3"},
+		Runtimes: map[string]string{"node": "24.2", "go": "1.25"},
+		Browser:  true,
+		WebView2: true,
+		Desktop:  true,
+	}
+	if !reflect.DeepEqual(cfg.imageRequirements, want) {
+		t.Fatalf("image requirements=%#v want %#v", cfg.imageRequirements, want)
+	}
+}
+
+func TestImageCapabilityFlagsRejectMalformedVersions(t *testing.T) {
+	cfg := baseConfig()
+	fs := newFlagSet("test", io.Discard)
+	values := registerLeaseCreateFlags(fs, cfg)
+	if err := parseFlags(fs, []string{"--image-runtime", "node=current"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := applyLeaseCreateFlags(&cfg, fs, values); err == nil {
+		t.Fatal("expected malformed image runtime version to fail")
+	}
+}
+
+func TestLeaseImageCapabilityFlagsRejectDirectProviders(t *testing.T) {
+	for name, configure := range map[string]func(*Config){
+		"direct": func(*Config) {},
+		"registered": func(cfg *Config) {
+			cfg.Provider = "aws"
+			cfg.Coordinator = "https://crabbox.example.test"
+			cfg.BrokerMode = BrokerModeRegistered
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			cfg := baseConfig()
+			configure(&cfg)
+			fs := newFlagSet("test", io.Discard)
+			values := registerLeaseCreateFlags(fs, cfg)
+			if err := parseFlags(fs, []string{"--image-min-os", "26.04"}); err != nil {
+				t.Fatal(err)
+			}
+			if err := applyLeaseCreateFlags(&cfg, fs, values); err == nil {
+				t.Fatal("expected unmanaged image requirements to fail")
+			}
+		})
+	}
+}
+
+func TestReadyPoolRejectsImageRequirements(t *testing.T) {
+	err := validateReadyPoolImageRequirements(imageRequirements{Browser: true}, "browser-pool")
+	if err == nil {
+		t.Fatal("expected ready-pool image requirements to fail")
+	}
+	if err := validateReadyPoolImageRequirements(imageRequirements{}, "browser-pool"); err != nil {
+		t.Fatalf("empty image requirements: %v", err)
+	}
+}

--- a/internal/cli/lease_flags.go
+++ b/internal/cli/lease_flags.go
@@ -28,6 +28,12 @@ type leaseCreateFlagValues struct {
 	Desktop       *bool
 	DesktopEnv    *string
 	Browser       *bool
+	ImageMinOS    *string
+	ImageSDK      *stringListFlag
+	ImageRuntime  *stringListFlag
+	ImageBrowser  *bool
+	ImageWebView2 *bool
+	ImageDesktop  *bool
 	Code          *bool
 	ProviderFlags providerFlagValues
 	Target        targetFlagValues
@@ -37,8 +43,12 @@ type leaseCreateFlagValues struct {
 func registerLeaseCreateFlags(fs *flag.FlagSet, defaults Config) leaseCreateFlagValues {
 	expose := stringListFlag{}
 	cacheVolumes := stringListFlag{}
+	imageSDK := stringListFlag{}
+	imageRuntime := stringListFlag{}
 	fs.Var(&expose, "expose", "declare a TCP port this lease wants reachable over the SSH-mesh plane; repeatable")
 	fs.Var(&cacheVolumes, "cache-volume", "provider-backed cache volume [name=]key:path; repeatable")
+	fs.Var(&imageSDK, "image-sdk", "minimum SDK in name=version form; repeatable")
+	fs.Var(&imageRuntime, "image-runtime", "minimum runtime in name=version form; repeatable")
 	return leaseCreateFlagValues{
 		Provider:      fs.String("provider", defaults.Provider, providerHelpAll()),
 		Profile:       fs.String("profile", defaults.Profile, "profile"),
@@ -57,6 +67,12 @@ func registerLeaseCreateFlags(fs *flag.FlagSet, defaults Config) leaseCreateFlag
 		Desktop:       fs.Bool("desktop", defaults.Desktop, "provision or require a visible desktop/VNC session"),
 		DesktopEnv:    fs.String("desktop-env", defaults.DesktopEnv, "Linux desktop environment: xfce, wayland, or gnome"),
 		Browser:       fs.Bool("browser", defaults.Browser, "provision or require a browser binary"),
+		ImageMinOS:    fs.String("image-min-os", "", "minimum promoted-image OS version"),
+		ImageSDK:      &imageSDK,
+		ImageRuntime:  &imageRuntime,
+		ImageBrowser:  fs.Bool("image-require-browser", false, "require browser support in the promoted image"),
+		ImageWebView2: fs.Bool("image-require-webview2", false, "require WebView2 support in the promoted image"),
+		ImageDesktop:  fs.Bool("image-require-desktop", false, "require desktop support in the promoted image"),
 		Code:          fs.Bool("code", defaults.Code, "provision or require web code-server capability"),
 		ProviderFlags: registerProviderFlags(fs, defaults),
 		Target:        registerTargetFlags(fs, defaults),
@@ -109,6 +125,25 @@ func applyLeaseCreateFlagsForLeaseMode(cfg *Config, fs *flag.FlagSet, values lea
 		cfg.Pond = pond
 	}
 	applyCapabilityFlags(cfg, *values.Desktop, *values.Browser, *values.Code)
+	if err := validateImageVersion(strings.TrimSpace(*values.ImageMinOS), "image-min-os"); err != nil {
+		return err
+	}
+	imageSDKs, err := parseImageVersions(*values.ImageSDK, "image-sdk")
+	if err != nil {
+		return err
+	}
+	imageRuntimes, err := parseImageVersions(*values.ImageRuntime, "image-runtime")
+	if err != nil {
+		return err
+	}
+	cfg.imageRequirements = imageRequirements{
+		MinOS:    strings.TrimSpace(*values.ImageMinOS),
+		SDKs:     imageSDKs,
+		Runtimes: imageRuntimes,
+		Browser:  *values.ImageBrowser,
+		WebView2: *values.ImageWebView2,
+		Desktop:  *values.ImageDesktop,
+	}
 	cfg.DesktopEnv = *values.DesktopEnv
 	if err := applyTargetFlagOverrides(cfg, fs, values.Target); err != nil {
 		return err
@@ -178,6 +213,9 @@ func applyLeaseCreateFlagsForLeaseMode(cfg *Config, fs *flag.FlagSet, values lea
 	if err := validateProviderTarget(*cfg); err != nil {
 		return err
 	}
+	if err := validateImageRequirementsForLease(*cfg, existingLeaseID); err != nil {
+		return err
+	}
 	if err := validateRequestedCapabilities(*cfg); err != nil {
 		return err
 	}
@@ -200,6 +238,21 @@ func applyLeaseCreateFlagsForLeaseMode(cfg *Config, fs *flag.FlagSet, values lea
 				return err
 			}
 		}
+	}
+	return nil
+}
+
+func validateImageRequirementsForLease(cfg Config, existingLeaseID string) error {
+	if imageRequirementsEmpty(cfg.imageRequirements) {
+		return nil
+	}
+	if existingLeaseID != "" {
+		return exit(2, "image capability requirements apply only when creating a new lease")
+	}
+	if cfg.Provider != "aws" ||
+		strings.TrimSpace(cfg.Coordinator) == "" ||
+		cfg.BrokerMode == BrokerModeRegistered {
+		return exit(2, "image capability requirements require a coordinator-managed AWS lease")
 	}
 	return nil
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -351,6 +351,9 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	if err := applyLeaseCreateFlagsForLease(&cfg, fs, leaseFlags, *leaseIDFlag); err != nil {
 		return err
 	}
+	if err := validateReadyPoolImageRequirements(cfg.imageRequirements, *readyPool); err != nil {
+		return err
+	}
 	expansion, err := expandRunProfile(cfg, *presetName, *scenario, presetVars, command, *shellMode, *preflight, artifactGlobs, *proofTemplate)
 	if err != nil {
 		return err

--- a/worker/src/aws.ts
+++ b/worker/src/aws.ts
@@ -11,6 +11,7 @@ import {
   workspaceProviderKeyPrefix,
   type LeaseConfig,
 } from "./config";
+import { hasImageRequirements } from "./image-capabilities";
 import { osImageSpec } from "./os-image";
 import {
   leaseIDForProviderKey,
@@ -326,12 +327,13 @@ export class EC2SpotClient {
     await this.ensureSSHKey(config.providerKey, config.sshPublicKey, leaseID);
     let transientImageID = "";
     try {
+      const capabilityImageRequired = hasImageRequirements(config.imageRequirements);
       const defaultImageID = config.awsSnapshot
         ? await (async () => {
             transientImageID = await this.registerSnapshotImage(config.awsSnapshot, leaseID);
             return this.waitForImageAvailable(transientImageID);
           })()
-        : config.target === "macos"
+        : config.target === "macos" || capabilityImageRequired
           ? ""
           : await this.resolveAMI(config);
       const securityGroupID = await this.ensureSecurityGroup(config, options);
@@ -361,15 +363,20 @@ export class EC2SpotClient {
         if (defaultImageID) {
           return defaultImageID;
         }
-        if (candidateConfig.target !== "macos") {
-          return this.resolveAMI(candidateConfig);
-        }
         const promotedImageID =
           config.awsPromotedAMIs[
             awsPromotedAMIConfigKey(this.region, candidateConfig.serverType)
           ] ?? "";
         if (promotedImageID) {
           return promotedImageID;
+        }
+        if (capabilityImageRequired) {
+          throw new Error(
+            `no AWS AMI found in ${this.region} for ${candidateConfig.serverType} satisfying the requested image capabilities`,
+          );
+        }
+        if (candidateConfig.target !== "macos") {
+          return this.resolveAMI(candidateConfig);
         }
         if (pinnedMacOSImageID && candidateConfig.serverType === config.serverType) {
           return pinnedMacOSImageID;

--- a/worker/src/config.ts
+++ b/worker/src/config.ts
@@ -1,6 +1,7 @@
 import { requireAWSRegion } from "./aws-region";
+import { normalizeImageRequirements } from "./image-capabilities";
 import { normalizeOSImage, osImageSpec } from "./os-image";
-import type { LeaseRequest, Provider, TargetOS, WindowsMode } from "./types";
+import type { ImageRequirements, LeaseRequest, Provider, TargetOS, WindowsMode } from "./types";
 
 export const awsMacOSInstanceTypeCandidates = [
   "mac2.metal",
@@ -25,6 +26,7 @@ export interface LeaseConfig {
   desktop: boolean;
   desktopEnv: "xfce" | "wayland" | "gnome";
   browser: boolean;
+  imageRequirements: ImageRequirements;
   code: boolean;
   tailscale: boolean;
   tailscaleTags: string[];
@@ -291,6 +293,7 @@ export function leaseConfig(input: LeaseRequest, defaults: LeaseConfigDefaults =
     desktop: input.desktop ?? false,
     desktopEnv,
     browser: input.browser ?? false,
+    imageRequirements: normalizeImageRequirements(input.imageRequirements),
     code: input.code ?? false,
     tailscale: input.tailscale ?? false,
     tailscaleTags: normalizeTailscaleTags(input.tailscaleTags ?? ["tag:crabbox"]),

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -75,6 +75,12 @@ import {
   requestOwner,
 } from "./http";
 import {
+  hasImageRequirements,
+  imageSatisfiesRequirements,
+  InvalidImageCapabilitiesError,
+  normalizeImageCapabilities,
+} from "./image-capabilities";
+import {
   MarketplaceInputError,
   marketplaceQuote,
   marketplaceStatus,
@@ -155,6 +161,7 @@ import type {
   LeaseShare,
   LeaseShareRole,
   LeaseTelemetry,
+  ImageCapabilities,
   Provider,
   ProviderFastSnapshotRestore,
   ProviderImage,
@@ -1023,6 +1030,9 @@ export class FleetCoordinator {
         return await this.listLeases(request);
       }
       if (method === "POST" && parts.join("/") === "v1/leases") {
+        return await this.createLease(request);
+      }
+      if (method === "POST" && parts.join("/") === "v1/leases/capability-aware") {
         return await this.createLease(request);
       }
       if (method === "POST" && parts.join("/") === "v1/workspaces") {
@@ -2235,7 +2245,22 @@ export class FleetCoordinator {
       if (error instanceof InvalidAWSRegionError) {
         return json({ error: "invalid_region", message: error.message }, { status: 400 });
       }
+      if (error instanceof InvalidImageCapabilitiesError) {
+        return json(
+          { error: "invalid_image_requirements", message: error.message },
+          { status: 400 },
+        );
+      }
       throw error;
+    }
+    if (hasImageRequirements(config.imageRequirements) && config.provider !== "aws") {
+      return json(
+        {
+          error: "image_capability_unsupported",
+          message: "image capability selection currently requires provider=aws",
+        },
+        { status: 409 },
+      );
     }
     if (workspaceID) {
       const hostKeys = workspaceSSHHostKeysFromRequest(request);
@@ -2320,6 +2345,15 @@ export class FleetCoordinator {
       );
     }
     if (retainedMacHostLease) {
+      if (hasImageRequirements(config.imageRequirements)) {
+        return json(
+          {
+            error: "image_capability_mismatch",
+            message: "image capability requirements cannot be verified when reusing an instance",
+          },
+          { status: 409 },
+        );
+      }
       const missingCapabilities = [
         config.desktop && !retainedMacHostLease.desktop ? "desktop" : "",
         config.browser && !retainedMacHostLease.browser ? "browser" : "",
@@ -2386,7 +2420,17 @@ export class FleetCoordinator {
         { status: 424 },
       );
     }
-    config = (await configProvider.prepareLeaseConfig?.(config)) ?? config;
+    try {
+      config = (await configProvider.prepareLeaseConfig?.(config)) ?? config;
+    } catch (error) {
+      if (error instanceof ImageCapabilityMismatchError) {
+        return json(
+          { error: "image_capability_mismatch", message: error.message },
+          { status: 409 },
+        );
+      }
+      throw error;
+    }
     const provider = this.provider(
       config.provider,
       providerRegionForConfig(config),
@@ -13032,6 +13076,34 @@ function promotedAWSImagePrefix(): string {
   return "image:aws:promoted";
 }
 
+function promotedAWSImageCatalogPrefix(
+  image: Pick<ProviderImage, "target" | "architecture" | "region" | "serverType"> & {
+    os?: string;
+  },
+): string {
+  const scope = promotedAWSImageKey(image).slice(`${promotedAWSImagePrefix()}:`.length);
+  return `image:aws:catalog:${scope}:`;
+}
+
+function promotedAWSImageCatalogKey(image: PromotedImageRecord): string {
+  return `${promotedAWSImageCatalogPrefix(image)}${encodeURIComponent(image.id)}`;
+}
+
+class ImageCapabilityMismatchError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ImageCapabilityMismatchError";
+  }
+}
+
+function promotionVersionMap(values: string[]): Record<string, string> | undefined {
+  const entries = values.map((value) => {
+    const separator = value.indexOf("=");
+    return separator > 0 ? [value.slice(0, separator), value.slice(separator + 1)] : [value, ""];
+  });
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
 function promotedAWSImageKey(
   image: Pick<ProviderImage, "target" | "architecture" | "region" | "serverType"> & {
     os?: string;
@@ -17961,14 +18033,38 @@ export class AWSProvider implements CloudProvider {
   ): Promise<ReturnType<typeof leaseConfig>> {
     if (
       config.awsAMI ||
+      this.env.CRABBOX_AWS_AMI?.trim() ||
       config.awsSnapshot ||
       config.awsUseStockImage ||
       config.providerKey.startsWith(workspaceProviderKeyPrefix)
     ) {
+      if (hasImageRequirements(config.imageRequirements)) {
+        throw new ImageCapabilityMismatchError(
+          "image capability requirements cannot be verified for an explicit or stock image source",
+        );
+      }
       return config;
     }
     if (config.target === "macos") {
-      return { ...config, awsPromotedAMIs: await this.promotedImagesForFallback(config) };
+      const awsPromotedAMIs = await this.promotedImagesForFallback(config);
+      if (
+        hasImageRequirements(config.imageRequirements) &&
+        Object.keys(awsPromotedAMIs).length === 0
+      ) {
+        throw new ImageCapabilityMismatchError(
+          "no promoted AWS macOS image satisfies the requested image capabilities",
+        );
+      }
+      return { ...config, awsPromotedAMIs };
+    }
+    if (hasImageRequirements(config.imageRequirements)) {
+      const awsPromotedAMIs = await this.promotedImagesForFallback(config);
+      if (Object.keys(awsPromotedAMIs).length === 0) {
+        throw new ImageCapabilityMismatchError(
+          `no promoted AWS ${config.target} image satisfies the requested image capabilities`,
+        );
+      }
+      return { ...config, awsAMI: "", awsPromotedAMIs };
     }
     const promoted = await this.promotedImage(config);
     return {
@@ -18332,8 +18428,14 @@ export class AWSProvider implements CloudProvider {
     return this.client.fastSnapshotRestoreStatus(snapshotIDs, availabilityZones);
   }
 
-  deleteImage(imageID: string): Promise<void> {
-    return this.client.deleteImage(imageID);
+  async deleteImage(imageID: string): Promise<void> {
+    await this.client.deleteImage(imageID);
+    const catalog = await this.storage.list<PromotedImageRecord>({ prefix: "image:aws:catalog:" });
+    await Promise.all(
+      [...catalog.entries()]
+        .filter(([, image]) => image.id === imageID)
+        .map(([key]) => this.storage.delete(key)),
+    );
   }
 
   async storedImageMetadata(imageID: string): Promise<ProviderImage | undefined> {
@@ -18417,6 +18519,7 @@ export class AWSProvider implements CloudProvider {
       region?: string;
       serverType?: string;
       architecture?: string;
+      capabilities?: ImageCapabilities;
       fastSnapshotRestore?: unknown;
       fastSnapshotRestoreAvailabilityZones?: string[];
     } = await readJson<{
@@ -18425,11 +18528,23 @@ export class AWSProvider implements CloudProvider {
       region?: string;
       serverType?: string;
       architecture?: string;
+      capabilities?: ImageCapabilities;
       fastSnapshotRestore?: unknown;
       fastSnapshotRestoreAvailabilityZones?: string[];
     }>(request).catch(() => ({}));
+    const requestedRegion = input.region ?? url.searchParams.get("region") ?? "";
+    const cataloged = await this.promotedCatalogImageByID(imageID, requestedRegion);
+    const priorCapabilities = known?.capabilities ?? cataloged?.capabilities;
+    const prior =
+      known || cataloged
+        ? {
+            ...cataloged,
+            ...known,
+            ...(priorCapabilities ? { capabilities: priorCapabilities } : {}),
+          }
+        : undefined;
     const target = normalizeAWSImageTarget(
-      input.target ?? url.searchParams.get("target") ?? known?.target ?? "linux",
+      input.target ?? url.searchParams.get("target") ?? prior?.target ?? "linux",
     );
     if (!target) {
       return json(
@@ -18440,7 +18555,7 @@ export class AWSProvider implements CloudProvider {
     let imageOS: string | undefined;
     if (target === "linux") {
       const requestedOS = input.os ?? url.searchParams.get("os");
-      const fallbackOS = known ? (known.os ?? "ubuntu:24.04") : defaultOSImage;
+      const fallbackOS = prior ? (prior.os ?? "ubuntu:24.04") : defaultOSImage;
       try {
         imageOS = normalizeOSImage(requestedOS ?? fallbackOS);
       } catch (error) {
@@ -18450,7 +18565,7 @@ export class AWSProvider implements CloudProvider {
         );
       }
     }
-    const rawRegion = input.region ?? url.searchParams.get("region") ?? known?.region ?? "";
+    const rawRegion = requestedRegion || prior?.region || "";
     const imageRegion = sanitizeAWSRegion(rawRegion);
     if (rawRegion && !imageRegion) {
       return json(
@@ -18458,15 +18573,57 @@ export class AWSProvider implements CloudProvider {
         { status: 400 },
       );
     }
-    const metadata: Partial<ProviderImage> = { ...known, target, region: imageRegion };
-    const serverType = input.serverType ?? url.searchParams.get("serverType") ?? known?.serverType;
+    const metadata: Partial<ProviderImage> = { ...prior, target, region: imageRegion };
+    const serverType = input.serverType ?? url.searchParams.get("serverType") ?? prior?.serverType;
     if (serverType) {
       metadata.serverType = serverType;
     }
     const architecture =
-      input.architecture ?? url.searchParams.get("architecture") ?? known?.architecture;
+      input.architecture ?? url.searchParams.get("architecture") ?? prior?.architecture;
     if (architecture) {
       metadata.architecture = architecture;
+    }
+    let capabilities: ImageCapabilities | undefined;
+    try {
+      capabilities = normalizeImageCapabilities({
+        ...prior?.capabilities,
+        ...input.capabilities,
+        osVersion:
+          input.capabilities?.osVersion ??
+          url.searchParams.get("osVersion") ??
+          prior?.capabilities?.osVersion,
+        sdks:
+          input.capabilities?.sdks ??
+          promotionVersionMap(url.searchParams.getAll("sdk")) ??
+          prior?.capabilities?.sdks,
+        runtimes:
+          input.capabilities?.runtimes ??
+          promotionVersionMap(url.searchParams.getAll("runtime")) ??
+          prior?.capabilities?.runtimes,
+        browser:
+          input.capabilities?.browser ??
+          (url.searchParams.has("browser")
+            ? boolFromUnknown(url.searchParams.get("browser"))
+            : undefined) ??
+          prior?.capabilities?.browser,
+        webview2:
+          input.capabilities?.webview2 ??
+          (url.searchParams.has("webview2")
+            ? boolFromUnknown(url.searchParams.get("webview2"))
+            : undefined) ??
+          prior?.capabilities?.webview2,
+        desktop:
+          input.capabilities?.desktop ??
+          (url.searchParams.has("desktop")
+            ? boolFromUnknown(url.searchParams.get("desktop"))
+            : undefined) ??
+          prior?.capabilities?.desktop,
+      });
+    } catch (error) {
+      return json(
+        { error: "invalid_image_capabilities", message: coordinatorErrorMessage(this.env, error) },
+        { status: 400 },
+      );
     }
     const fastSnapshotRestore = boolFromUnknown(
       input.fastSnapshotRestore ?? url.searchParams.get("fastSnapshotRestore"),
@@ -18530,8 +18687,10 @@ export class AWSProvider implements CloudProvider {
       architecture:
         image.architecture ?? awsImageArchitectureForTarget(target, image.serverType ?? ""),
       promotedAt: new Date().toISOString(),
+      ...(capabilities ? { capabilities } : {}),
     };
     await this.storage.put(promotedAWSImageKey(promoted), promoted);
+    await this.storage.put(promotedAWSImageCatalogKey(promoted), promoted);
     if (target === "linux" && promoted.os) {
       await this.storage.put(promotedAWSLinuxOSImageKey(promoted), promoted);
     }
@@ -18564,12 +18723,39 @@ export class AWSProvider implements CloudProvider {
     os?: string;
     serverType: string;
     awsRegion: string;
+    imageRequirements: LeaseConfig["imageRequirements"];
   }): Promise<PromotedImageRecord | undefined> {
     const architecture = awsImageArchitectureForLease(
       config.target,
       config.serverType,
       config.architecture,
     );
+    if (hasImageRequirements(config.imageRequirements)) {
+      const imageScope = {
+        target: config.target,
+        ...(config.os ? { os: config.os } : {}),
+        architecture,
+        serverType: config.serverType,
+        region: config.awsRegion,
+      };
+      const [selected, catalog] = await Promise.all([
+        this.storage.get<PromotedImageRecord>(promotedAWSImageKey(imageScope)),
+        this.storage.list<PromotedImageRecord>({
+          prefix: promotedAWSImageCatalogPrefix(imageScope),
+        }),
+      ]);
+      const candidates = new Map(
+        [selected, ...catalog.values()]
+          .filter((image): image is PromotedImageRecord => Boolean(image))
+          .map((image) => [image.id, image]),
+      );
+      return [...candidates.values()]
+        .filter((image) => imageSatisfiesRequirements(image.capabilities, config.imageRequirements))
+        .toSorted(
+          (left, right) =>
+            right.promotedAt.localeCompare(left.promotedAt) || left.id.localeCompare(right.id),
+        )[0];
+    }
     const scoped = await this.storage.get<PromotedImageRecord>(
       promotedAWSImageKey({
         target: config.target,
@@ -18625,6 +18811,7 @@ export class AWSProvider implements CloudProvider {
           os: config.os,
           serverType,
           awsRegion: region,
+          imageRequirements: config.imageRequirements,
         });
         if (promoted?.id) {
           out[awsPromotedAMIConfigKey(region, serverType)] = promoted.id;
@@ -18639,6 +18826,15 @@ export class AWSProvider implements CloudProvider {
       prefix: promotedAWSImagePrefix(),
     });
     return [...promoted.values()].find((image) => image.id === imageID);
+  }
+
+  private async promotedCatalogImageByID(
+    imageID: string,
+    preferredRegion: string,
+  ): Promise<PromotedImageRecord | undefined> {
+    const catalog = await this.storage.list<PromotedImageRecord>({ prefix: "image:aws:catalog:" });
+    const matches = [...catalog.values()].filter((image) => image.id === imageID);
+    return matches.find((image) => image.region === preferredRegion) ?? matches[0];
   }
 }
 

--- a/worker/src/image-capabilities.ts
+++ b/worker/src/image-capabilities.ts
@@ -1,0 +1,187 @@
+import type { ImageCapabilities, ImageRequirements } from "./types";
+
+const maxVersionEntries = 32;
+const maxVersionLength = 128;
+const namePattern = /^[a-z0-9][a-z0-9._-]{0,63}$/;
+const versionPattern = /^\d+(?:\.\d+)*$/;
+
+export class InvalidImageCapabilitiesError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidImageCapabilitiesError";
+  }
+}
+
+function normalizedVersion(value: unknown, label: string): string | undefined {
+  if (value === undefined || value === null || value === "") return undefined;
+  if (
+    typeof value !== "string" ||
+    value.trim().length > maxVersionLength ||
+    !versionPattern.test(value.trim())
+  ) {
+    throw new InvalidImageCapabilitiesError(`${label} must be a dot-separated numeric version`);
+  }
+  return value.trim();
+}
+
+function normalizedVersions(value: unknown, label: string): Record<string, string> | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== "object" || Array.isArray(value)) {
+    throw new InvalidImageCapabilitiesError(
+      `${label} must be an object of name-to-version entries`,
+    );
+  }
+  const entries = Object.entries(value as Record<string, unknown>);
+  if (entries.length > maxVersionEntries) {
+    throw new InvalidImageCapabilitiesError(
+      `${label} supports at most ${maxVersionEntries} entries`,
+    );
+  }
+  const normalized: Record<string, string> = {};
+  for (const [rawName, rawVersion] of entries) {
+    const name = rawName.trim().toLowerCase();
+    if (!namePattern.test(name)) {
+      throw new InvalidImageCapabilitiesError(
+        `${label} name ${JSON.stringify(rawName)} is invalid`,
+      );
+    }
+    const version = normalizedVersion(rawVersion, `${label}.${name}`);
+    if (!version) {
+      throw new InvalidImageCapabilitiesError(`${label}.${name} requires a version`);
+    }
+    normalized[name] = version;
+  }
+  return entries.length > 0 ? normalized : undefined;
+}
+
+function normalizedBoolean(value: unknown, label: string): boolean | undefined {
+  if (value === undefined || value === null || value === false) return undefined;
+  if (value !== true) throw new InvalidImageCapabilitiesError(`${label} must be a boolean`);
+  return true;
+}
+
+export function normalizeImageCapabilities(value: unknown): ImageCapabilities | undefined {
+  if (value === undefined || value === null) return undefined;
+  const input = imageCapabilityObject(value, "capabilities", [
+    "osVersion",
+    "sdks",
+    "runtimes",
+    "browser",
+    "webview2",
+    "desktop",
+  ]);
+  const osVersion = normalizedVersion(input["osVersion"], "capabilities.osVersion");
+  const sdks = normalizedVersions(input["sdks"], "capabilities.sdks");
+  const runtimes = normalizedVersions(input["runtimes"], "capabilities.runtimes");
+  const browser = normalizedBoolean(input["browser"], "capabilities.browser");
+  const webview2 = normalizedBoolean(input["webview2"], "capabilities.webview2");
+  const desktop = normalizedBoolean(input["desktop"], "capabilities.desktop");
+  const normalized: ImageCapabilities = {
+    ...(osVersion ? { osVersion } : {}),
+    ...(sdks ? { sdks } : {}),
+    ...(runtimes ? { runtimes } : {}),
+    ...(browser ? { browser } : {}),
+    ...(webview2 ? { webview2 } : {}),
+    ...(desktop ? { desktop } : {}),
+  };
+  return hasValues(normalized) ? normalized : undefined;
+}
+
+export function normalizeImageRequirements(value: unknown): ImageRequirements {
+  if (value === undefined || value === null) return {};
+  const input = imageCapabilityObject(value, "imageRequirements", [
+    "minOS",
+    "sdks",
+    "runtimes",
+    "browser",
+    "webview2",
+    "desktop",
+  ]);
+  const minOS = normalizedVersion(input["minOS"], "imageRequirements.minOS");
+  const sdks = normalizedVersions(input["sdks"], "imageRequirements.sdks");
+  const runtimes = normalizedVersions(input["runtimes"], "imageRequirements.runtimes");
+  const browser = normalizedBoolean(input["browser"], "imageRequirements.browser");
+  const webview2 = normalizedBoolean(input["webview2"], "imageRequirements.webview2");
+  const desktop = normalizedBoolean(input["desktop"], "imageRequirements.desktop");
+  return {
+    ...(minOS ? { minOS } : {}),
+    ...(sdks ? { sdks } : {}),
+    ...(runtimes ? { runtimes } : {}),
+    ...(browser ? { browser } : {}),
+    ...(webview2 ? { webview2 } : {}),
+    ...(desktop ? { desktop } : {}),
+  };
+}
+
+function imageCapabilityObject(
+  value: unknown,
+  label: string,
+  allowedKeys: string[],
+): Record<string, unknown> {
+  if (typeof value !== "object" || Array.isArray(value)) {
+    throw new InvalidImageCapabilitiesError(`${label} must be an object`);
+  }
+  const input = value as Record<string, unknown>;
+  const unknownKey = Object.keys(input).find((key) => !allowedKeys.includes(key));
+  if (unknownKey) {
+    throw new InvalidImageCapabilitiesError(`${label}.${unknownKey} is not supported`);
+  }
+  return input;
+}
+
+export function hasImageRequirements(value: ImageRequirements): boolean {
+  return hasValues(value);
+}
+
+export function missingImageCapabilities(
+  capabilities: ImageCapabilities | undefined,
+  requirements: ImageRequirements,
+): string[] {
+  const missing: string[] = [];
+  if (requirements.minOS && !versionAtLeast(capabilities?.osVersion, requirements.minOS)) {
+    missing.push(`OS >= ${requirements.minOS}`);
+  }
+  for (const [name, version] of Object.entries(requirements.sdks ?? {})) {
+    if (!versionAtLeast(capabilities?.sdks?.[name], version))
+      missing.push(`SDK ${name} >= ${version}`);
+  }
+  for (const [name, version] of Object.entries(requirements.runtimes ?? {})) {
+    if (!versionAtLeast(capabilities?.runtimes?.[name], version)) {
+      missing.push(`runtime ${name} >= ${version}`);
+    }
+  }
+  if (requirements.browser && !capabilities?.browser) missing.push("browser");
+  if (requirements.webview2 && !capabilities?.webview2) missing.push("WebView2");
+  if (requirements.desktop && !capabilities?.desktop) missing.push("desktop");
+  return missing;
+}
+
+export function imageSatisfiesRequirements(
+  capabilities: ImageCapabilities | undefined,
+  requirements: ImageRequirements,
+): boolean {
+  return missingImageCapabilities(capabilities, requirements).length === 0;
+}
+
+function versionAtLeast(actual: string | undefined, required: string): boolean {
+  if (!actual || !versionPattern.test(actual)) return false;
+  const actualParts = actual.split(".");
+  const requiredParts = required.split(".");
+  for (let index = 0; index < Math.max(actualParts.length, requiredParts.length); index += 1) {
+    const actualPart = normalizedNumericPart(actualParts[index] ?? "0");
+    const requiredPart = normalizedNumericPart(requiredParts[index] ?? "0");
+    if (actualPart.length !== requiredPart.length) return actualPart.length > requiredPart.length;
+    if (actualPart !== requiredPart) return actualPart > requiredPart;
+  }
+  return true;
+}
+
+function normalizedNumericPart(value: string): string {
+  return value.replace(/^0+(?=\d)/, "");
+}
+
+function hasValues(value: ImageCapabilities | ImageRequirements): boolean {
+  return Object.values(value).some((entry) =>
+    typeof entry === "object" ? Object.keys(entry ?? {}).length > 0 : entry !== undefined,
+  );
+}

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -148,6 +148,7 @@ export interface LeaseRequest {
   desktop?: boolean;
   desktopEnv?: string;
   browser?: boolean;
+  imageRequirements?: ImageRequirements;
   code?: boolean;
   tailscale?: boolean;
   tailscaleTags?: string[];
@@ -206,6 +207,24 @@ export interface LeaseRequest {
   sshPublicKey?: string;
   pond?: string;
   exposedPorts?: string[];
+}
+
+export interface ImageCapabilities {
+  osVersion?: string;
+  sdks?: Record<string, string>;
+  runtimes?: Record<string, string>;
+  browser?: boolean;
+  webview2?: boolean;
+  desktop?: boolean;
+}
+
+export interface ImageRequirements {
+  minOS?: string;
+  sdks?: Record<string, string>;
+  runtimes?: Record<string, string>;
+  browser?: boolean;
+  webview2?: boolean;
+  desktop?: boolean;
 }
 
 export interface LeaseRegistrationRequest {
@@ -535,6 +554,7 @@ export interface ProviderImage {
   resourceID?: string;
   snapshots?: string[];
   fastSnapshotRestores?: ProviderFastSnapshotRestore[];
+  capabilities?: ImageCapabilities;
 }
 
 export interface ProviderFastSnapshotRestore {

--- a/worker/test/aws.test.ts
+++ b/worker/test/aws.test.ts
@@ -1530,6 +1530,75 @@ describe("aws provider", () => {
     expect(await gunzipBase64(userData)).toContain("crabbox-configure-desktop-theme");
   });
 
+  it("uses the capability-selected AMI for a Linux region", async () => {
+    let imageQueries = 0;
+    let runImage = "";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        if (new URL(request.url).hostname.startsWith("servicequotas.")) {
+          return new Response(JSON.stringify({ Quota: { Value: 999 } }), {
+            headers: { "content-type": "application/json" },
+          });
+        }
+        const params = new URLSearchParams(await request.clone().text());
+        const action = params.get("Action") ?? "";
+        const securityGroupResponse = ec2ConfiguredSecurityGroupResponse(action, params);
+        if (securityGroupResponse) return securityGroupResponse;
+        if (action === "DescribeKeyPairs") {
+          return ec2XMLResponse(
+            "<DescribeKeyPairsResponse><keySet><item><keyName>crabbox-cbx</keyName><publicKey>ssh-ed25519 test</publicKey></item></keySet></DescribeKeyPairsResponse>",
+          );
+        }
+        if (action === "DescribeImages") {
+          imageQueries += 1;
+          return ec2XMLResponse("<DescribeImagesResponse><imagesSet /></DescribeImagesResponse>");
+        }
+        if (action === "RunInstances") {
+          runImage = params.get("ImageId") ?? "";
+          return ec2XMLResponse(`<?xml version="1.0" encoding="UTF-8"?>
+<RunInstancesResponse><instancesSet><item>
+  <instanceId>i-linux</instanceId><instanceType>t3.small</instanceType>
+  <ipAddress>203.0.113.44</ipAddress><instanceState><name>pending</name></instanceState>
+</item></instancesSet></RunInstancesResponse>`);
+        }
+        return ec2XMLResponse(
+          `<Response><Errors><Error><Code>Unexpected</Code><Message>${action}</Message></Error></Errors></Response>`,
+          500,
+        );
+      }),
+    );
+    const client = new EC2SpotClient(
+      {
+        AWS_ACCESS_KEY_ID: "test",
+        AWS_SECRET_ACCESS_KEY: "secret",
+        CRABBOX_AWS_SECURITY_GROUP_ID: "sg-123",
+        CRABBOX_AWS_SSH_CIDRS: "203.0.113.7/32",
+      } as never,
+      "eu-west-1",
+    );
+    const config = leaseConfig({
+      provider: "aws",
+      target: "linux",
+      serverType: "t3.small",
+      serverTypeExplicit: true,
+      sshPublicKey: "ssh-ed25519 test",
+      imageRequirements: { runtimes: { node: "24" } },
+    });
+    config.awsPromotedAMIs[awsPromotedAMIConfigKey("eu-west-1", "t3.small")] = "ami-capable";
+
+    await client.createServerWithFallback(
+      config,
+      "cbx_abcdef123456",
+      "violet-prawn",
+      "alice@example.com",
+    );
+
+    expect(runImage).toBe("ami-capable");
+    expect(imageQueries).toBe(0);
+  });
+
   it("resolves macOS AMIs per fallback instance type", async () => {
     const imageQueries: string[] = [];
     const hostTypes: string[] = [];
@@ -2057,6 +2126,7 @@ describe("aws provider", () => {
 
   it("uses scoped promoted macOS AMIs for fallback host families", async () => {
     const runImages: string[] = [];
+    let imageQueries = 0;
     vi.stubGlobal(
       "fetch",
       vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -2079,6 +2149,7 @@ describe("aws provider", () => {
           );
         }
         if (action === "DescribeImages") {
+          imageQueries += 1;
           return ec2XMLResponse(`<?xml version="1.0" encoding="UTF-8"?>
 <DescribeImagesResponse>
   <imagesSet>
@@ -2143,6 +2214,7 @@ describe("aws provider", () => {
       capacity: { market: "on-demand" },
       serverType: "mac2.metal",
       sshPublicKey: "ssh-ed25519 test",
+      imageRequirements: { desktop: true },
     });
     config.awsPromotedAMIs[awsPromotedAMIConfigKey("eu-west-1", "mac1.metal")] =
       "ami-promoted-mac1";
@@ -2154,6 +2226,7 @@ describe("aws provider", () => {
     );
 
     expect(runImages).toEqual(["ami-promoted-mac1"]);
+    expect(imageQueries).toBe(0);
     expect(result.serverType).toBe("mac1.metal");
   });
 

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -20458,6 +20458,225 @@ describe("fleet lease identity and idle", () => {
     expect(storage.value("image:aws:promoted")).toBeUndefined();
   });
 
+  it("stores declared image capabilities in the selectable AWS image catalog", async () => {
+    const storage = new MemoryStorage();
+    const provider = new AWSProvider({} as Env, "eu-west-1", storage);
+    vi.spyOn(provider, "getImage").mockResolvedValue({
+      id: "ami-tools",
+      name: "windows-tools",
+      state: "available",
+      provider: "aws",
+      region: "eu-west-1",
+      architecture: "x86_64",
+    });
+    const url = new URL(
+      "https://crabbox.test/v1/images/ami-tools/promote?target=windows&region=eu-west-1&osVersion=11.0.26100&runtime=node%3D24.2&browser=true&webview2=true&desktop=true",
+    );
+    const response = await provider.promoteImage(
+      "ami-tools",
+      undefined,
+      new Request(url, { method: "POST", body: "{}" }),
+      url,
+    );
+
+    expect(response).toMatchObject({
+      image: {
+        id: "ami-tools",
+        capabilities: {
+          osVersion: "11.0.26100",
+          runtimes: { node: "24.2" },
+          browser: true,
+          webview2: true,
+          desktop: true,
+        },
+      },
+    });
+    expect(storage.value("image:aws:catalog:windows:x86_64:eu-west-1:ami-tools")).toEqual(
+      expect.objectContaining({ id: "ami-tools" }),
+    );
+  });
+
+  it("preserves catalog capabilities when re-promoting an older image", async () => {
+    const storage = new MemoryStorage();
+    const provider = new AWSProvider({} as Env, "eu-west-1", storage);
+    vi.spyOn(provider, "getImage").mockImplementation(async (imageID) => ({
+      id: imageID,
+      name: imageID,
+      state: "available",
+      provider: "aws",
+      region: "eu-west-1",
+      architecture: "x86_64",
+    }));
+    const promote = async (imageID: string, runtime?: string) => {
+      const url = new URL(
+        `https://crabbox.test/v1/images/${imageID}/promote?target=linux&region=eu-west-1${runtime ? `&runtime=node%3D${runtime}` : ""}`,
+      );
+      return provider.promoteImage(
+        imageID,
+        undefined,
+        new Request(url, { method: "POST", body: "{}" }),
+        url,
+      );
+    };
+
+    await promote("ami-a", "24.2");
+    await promote("ami-b", "22.17");
+    const rollback = await promote("ami-a");
+
+    expect(rollback).toMatchObject({
+      image: { id: "ami-a", capabilities: { runtimes: { node: "24.2" } } },
+    });
+    expect(storage.value("image:aws:catalog:linux:x86_64:ubuntu26.04:eu-west-1:ami-a")).toEqual(
+      expect.objectContaining({ capabilities: { runtimes: { node: "24.2" } } }),
+    );
+  });
+
+  it("selects the newest promoted AWS image satisfying every requirement", async () => {
+    const storage = new MemoryStorage();
+    storage.seed("image:aws:catalog:linux:x86_64:ubuntu26.04:eu-west-1:ami-node22", {
+      id: "ami-node22",
+      name: "node-22",
+      state: "available",
+      target: "linux",
+      os: "ubuntu:26.04",
+      region: "eu-west-1",
+      architecture: "x86_64",
+      promotedAt: "2026-07-01T00:00:00Z",
+      capabilities: { osVersion: "26.04", runtimes: { node: "22.17" }, browser: true },
+    });
+    storage.seed("image:aws:catalog:linux:x86_64:ubuntu26.04:eu-west-1:ami-node24", {
+      id: "ami-node24",
+      name: "node-24",
+      state: "available",
+      target: "linux",
+      os: "ubuntu:26.04",
+      region: "eu-west-1",
+      architecture: "x86_64",
+      promotedAt: "2026-07-02T00:00:00Z",
+      capabilities: {
+        osVersion: "26.04",
+        sdks: { go: "1.25" },
+        runtimes: { node: "24.2" },
+        browser: true,
+        desktop: true,
+      },
+    });
+    storage.seed("image:aws:catalog:linux:x86_64:ubuntu26.04:eu-west-1:ami-node24-old", {
+      id: "ami-node24-old",
+      name: "node-24-old",
+      state: "available",
+      target: "linux",
+      os: "ubuntu:26.04",
+      region: "eu-west-1",
+      architecture: "x86_64",
+      promotedAt: "2026-06-30T00:00:00Z",
+      capabilities: {
+        osVersion: "26.04",
+        sdks: { go: "1.25" },
+        runtimes: { node: "24.1" },
+        browser: true,
+        desktop: true,
+      },
+    });
+    storage.seed("image:aws:catalog:linux:x86_64:ubuntu26.04:us-east-2:ami-node24-new", {
+      id: "ami-node24-new",
+      name: "node-24-new",
+      state: "available",
+      target: "linux",
+      os: "ubuntu:26.04",
+      region: "us-east-2",
+      architecture: "x86_64",
+      promotedAt: "2026-07-03T00:00:00Z",
+      capabilities: {
+        osVersion: "26.04",
+        sdks: { go: "1.25" },
+        runtimes: { node: "24.3" },
+        browser: true,
+        desktop: true,
+      },
+    });
+    const provider = new AWSProvider({} as Env, "eu-west-1", storage);
+    const config = leaseConfig({
+      provider: "aws",
+      os: "ubuntu:26.04",
+      capacity: { regions: ["us-east-2"] },
+      sshPublicKey: "ssh-ed25519 test",
+      imageRequirements: {
+        minOS: "26.04",
+        sdks: { go: "1.24" },
+        runtimes: { node: "24" },
+        browser: true,
+        desktop: true,
+      },
+    });
+
+    await expect(provider.prepareLeaseConfig(config)).resolves.toMatchObject({
+      awsAMI: "",
+      awsPromotedAMIs: expect.objectContaining({
+        [awsPromotedAMIConfigKey("eu-west-1", config.serverType)]: "ami-node24",
+        [awsPromotedAMIConfigKey("us-east-2", config.serverType)]: "ami-node24-new",
+      }),
+    });
+  });
+
+  it("rejects unsatisfied image requirements before reserving or creating a lease", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(
+      storage,
+      {},
+      {
+        AWS_ACCESS_KEY_ID: "test",
+        AWS_SECRET_ACCESS_KEY: "test",
+        CRABBOX_AWS_REGION: "eu-west-1",
+      },
+    );
+
+    const response = await fleet.fetch(
+      request("POST", "/v1/leases/capability-aware", {
+        body: {
+          provider: "aws",
+          sshPublicKey: "ssh-ed25519 test",
+          imageRequirements: { runtimes: { node: "99" }, desktop: true },
+        },
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "image_capability_mismatch",
+    });
+    expect(await storage.list({ prefix: "lease:" })).toHaveLength(0);
+  });
+
+  it("rejects capability selection when an operator AMI override is configured", async () => {
+    const storage = new MemoryStorage();
+    storage.seed("image:aws:catalog:linux:x86_64:ubuntu26.04:eu-west-1:ami-capable", {
+      id: "ami-capable",
+      name: "capable",
+      state: "available",
+      target: "linux",
+      os: "ubuntu:26.04",
+      region: "eu-west-1",
+      architecture: "x86_64",
+      promotedAt: "2026-07-03T00:00:00Z",
+      capabilities: { runtimes: { node: "24" } },
+    });
+    const provider = new AWSProvider(
+      { CRABBOX_AWS_AMI: "ami-operator" } as Env,
+      "eu-west-1",
+      storage,
+    );
+    const config = leaseConfig({
+      provider: "aws",
+      sshPublicKey: "ssh-ed25519 test",
+      imageRequirements: { runtimes: { node: "24" } },
+    });
+
+    await expect(provider.prepareLeaseConfig(config)).rejects.toThrow(
+      "cannot be verified for an explicit or stock image source",
+    );
+  });
+
   it("scopes promoted AWS macOS images by target, architecture, and server type", async () => {
     const storage = new MemoryStorage();
     const fleet = testFleet(storage, {

--- a/worker/test/image-capabilities.test.ts
+++ b/worker/test/image-capabilities.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  imageSatisfiesRequirements,
+  missingImageCapabilities,
+  normalizeImageCapabilities,
+  normalizeImageRequirements,
+} from "../src/image-capabilities";
+
+describe("image capabilities", () => {
+  it("compares numeric OS, SDK, and runtime versions", () => {
+    const capabilities = normalizeImageCapabilities({
+      osVersion: "15.5",
+      sdks: { xcode: "16.4" },
+      runtimes: { node: "24.2.0" },
+      browser: true,
+      desktop: true,
+    });
+
+    expect(
+      imageSatisfiesRequirements(
+        capabilities,
+        normalizeImageRequirements({
+          minOS: "15.4",
+          sdks: { XCODE: "16.3" },
+          runtimes: { node: "24.2" },
+          browser: true,
+          desktop: true,
+        }),
+      ),
+    ).toBe(true);
+    expect(missingImageCapabilities(capabilities, { webview2: true })).toEqual(["WebView2"]);
+  });
+
+  it("rejects malformed versions and capability names", () => {
+    expect(() => normalizeImageRequirements({ minOS: "macOS 15" })).toThrow(
+      "dot-separated numeric version",
+    );
+    expect(() => normalizeImageCapabilities({ runtimes: { "node/npm": "24" } })).toThrow("name");
+    expect(() => normalizeImageCapabilities({ runtimes: { node: "" } })).toThrow(
+      "requires a version",
+    );
+    for (const value of [false, "node=24", [], 24]) {
+      expect(() => normalizeImageRequirements(value)).toThrow("must be an object");
+    }
+    expect(() => normalizeImageRequirements({ runtime: { node: "24" } })).toThrow(
+      "is not supported",
+    );
+  });
+
+  it("compares versions without numeric precision loss", () => {
+    expect(
+      imageSatisfiesRequirements(
+        { runtimes: { node: "999999999999999999999999.1" } },
+        { runtimes: { node: "999999999999999999999998.9" } },
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- let AWS image promotions declare OS, SDK/runtime, browser, WebView2, and desktop capabilities
- retain a scoped promotion catalog and choose the newest matching AMI per region and instance-type fallback
- add CLI image requirement flags with fail-closed handling for direct, registered, ready-pool, explicit-image, stock-image, and mixed-version coordinator paths
- preserve capability metadata across image rollback/re-promotion

## Verification

- `go vet ./...`
- `go test -race ./...`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker` (918 passed, 3 skipped)
- `npm run build --prefix worker`
- `npm run build:node --prefix worker`
- local Wrangler HTTP proof: impossible capability request returned `409 image_capability_mismatch`; malformed requirement returned `400 invalid_image_requirements`; repeated lease inventory remained empty
- source-blind CLI proof: malformed versions, direct/registered mode, and ready-pool combinations fail before provider or pool work

## Configuration and secrets

No new secrets or environment variables. Capability selection is explicit through CLI/API fields. Existing `CRABBOX_AWS_AMI`, explicit AMI/snapshot, and stock-image overrides reject capability requirements because their contents cannot be verified against the promotion catalog.
