### PR TITLE
fix: confine Nomad API redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixed
 
+- Confined Nomad API redirects to the configured scheme, hostname, and effective port before replaying ACL tokens or request bodies, while keeping rejected Location secrets out of diagnostics. Thanks @coygeek.
 - Launched native Windows desktop apps directly in the active interactive session without scheduled tasks, waiting for a visible window and reporting its process ID, session, and title.
 - Unified direct macOS WebVNC with the authenticated portal: Tart and Parallels viewers now use the same chrome and controls as Linux and Windows when coordinator login is configured, with provider-lifetime registration and the local viewer retained as the offline fallback.
 - Replaced WebVNC password and username URL fragments with one-time credential handoff tickets, and made repeated `--open` calls reuse and focus the existing lease viewer tab when the browser supports cross-tab handoff.

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/firecracker-microvm/firecracker-go-sdk v1.0.0
 	github.com/gofrs/flock v0.13.0
 	github.com/google/go-tdx-guest v0.3.1
+	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/nomad/api v0.0.0-20260624190804-2007237ae08c
 	github.com/islo-labs/go-sdk v0.0.0-20260528125833-04a38f6f507c
 	github.com/lima-vm/go-qcow2reader v0.7.1
@@ -112,7 +113,6 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/hashicorp/cronexpr v1.1.3 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
-	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/internal/providers/nomad/client.go
+++ b/internal/providers/nomad/client.go
@@ -2,10 +2,18 @@ package nomad
 
 import (
 	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
 	"io"
+	"net"
+	"net/http"
+	"net/url"
 	"os"
 	"strings"
+	"time"
 
+	"github.com/hashicorp/go-cleanhttp"
 	nomadapi "github.com/hashicorp/nomad/api"
 )
 
@@ -26,19 +34,121 @@ type liveClient struct {
 	cfg    Config
 }
 
+var (
+	errNomadCrossOriginRedirect = errors.New("nomad refused cross-origin redirect")
+	errNomadInvalidRedirect     = errors.New("nomad refused invalid redirect")
+	errNomadRedirectLimit       = errors.New("nomad redirect stopped after 10 redirects")
+)
+
 func newNomadClient(cfg Config, rt Runtime) (Client, error) {
 	apiConfig, err := newNomadAPIConfig(cfg, os.Getenv)
 	if err != nil {
 		return nil, err
 	}
-	if rt.HTTP != nil {
-		apiConfig.HttpClient = rt.HTTP
+	if err := configureNomadHTTPClient(apiConfig, rt.HTTP); err != nil {
+		return nil, err
 	}
 	client, err := nomadapi.NewClient(apiConfig)
 	if err != nil {
 		return nil, err
 	}
 	return liveClient{client: client, cfg: cfg}, nil
+}
+
+func configureNomadHTTPClient(apiConfig *nomadapi.Config, source *http.Client) error {
+	trusted, err := url.Parse(apiConfig.Address)
+	if err != nil {
+		return err
+	}
+	if source == nil {
+		var transport *http.Transport
+		if trusted.Scheme == "unix" {
+			socketPath := trusted.EscapedPath()
+			dialer := &net.Dialer{}
+			transport = &http.Transport{
+				DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+					return dialer.DialContext(ctx, "unix", socketPath)
+				},
+			}
+			source = &http.Client{Transport: transport}
+		} else {
+			source = cleanhttp.DefaultPooledClient()
+			transport = source.Transport.(*http.Transport)
+		}
+		transport.TLSHandshakeTimeout = 10 * time.Second
+		transport.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12}
+		transport.ForceAttemptHTTP2 = false
+		if trusted.Scheme != "unix" {
+			if err := nomadapi.ConfigureTLS(source, apiConfig.TLSConfig); err != nil {
+				return err
+			}
+		}
+	}
+	if trusted.Scheme == "unix" {
+		// The SDK rewrites Unix-socket request URLs to this origin while the
+		// transport continues to dial only the configured socket.
+		trusted = &url.URL{Scheme: "http", Host: "127.0.0.1"}
+	}
+	apiConfig.HttpClient = secureNomadHTTPClient(source, trusted)
+	return nil
+}
+
+func secureNomadHTTPClient(source *http.Client, trusted *url.URL) *http.Client {
+	client := *source
+	originalCheckRedirect := source.CheckRedirect
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if !sameNomadOrigin(trusted, req.URL) {
+			return errNomadCrossOriginRedirect
+		}
+		if originalCheckRedirect != nil {
+			return originalCheckRedirect(req, via)
+		}
+		if len(via) >= 10 {
+			return errNomadRedirectLimit
+		}
+		return nil
+	}
+	return &client
+}
+
+func sameNomadOrigin(a, b *url.URL) bool {
+	return a != nil && b != nil &&
+		strings.EqualFold(a.Scheme, b.Scheme) &&
+		strings.EqualFold(a.Hostname(), b.Hostname()) &&
+		effectiveNomadPort(a) == effectiveNomadPort(b)
+}
+
+func effectiveNomadPort(value *url.URL) string {
+	if port := value.Port(); port != "" {
+		return port
+	}
+	switch strings.ToLower(value.Scheme) {
+	case "https":
+		return "443"
+	case "http":
+		return "80"
+	default:
+		return ""
+	}
+}
+
+func sanitizeNomadClientError(err error) error {
+	// net/http wraps redirect errors with the untrusted Location URL. Return
+	// only the stable sentinel so provider diagnostics cannot retain it.
+	if errors.Is(err, errNomadCrossOriginRedirect) {
+		return errNomadCrossOriginRedirect
+	}
+	if errors.Is(err, errNomadRedirectLimit) {
+		return errNomadRedirectLimit
+	}
+	var requestErr *url.Error
+	if errors.As(err, &requestErr) && strings.Contains(requestErr.Err.Error(), "failed to parse Location header") {
+		return errNomadInvalidRedirect
+	}
+	if err != nil && strings.Contains(err.Error(), "invalid redirect location") {
+		return errNomadInvalidRedirect
+	}
+	return err
 }
 
 func newNomadAPIConfig(cfg Config, lookup func(string) string) (*nomadapi.Config, error) {
@@ -65,17 +175,23 @@ func newNomadAPIConfig(cfg Config, lookup func(string) string) (*nomadapi.Config
 	}, nil
 }
 
-func (c liveClient) AgentSelf(context.Context) (*nomadapi.AgentSelf, error) {
-	return c.client.Agent().Self()
+func (c liveClient) AgentSelf(ctx context.Context) (*nomadapi.AgentSelf, error) {
+	var value nomadapi.AgentSelf
+	query := (&nomadapi.QueryOptions{}).WithContext(ctx)
+	if _, err := c.client.Raw().Query("/v1/agent/self", &value, query); err != nil {
+		return nil, fmt.Errorf("failed querying self endpoint: %w", sanitizeNomadClientError(err))
+	}
+	return &value, nil
 }
 
 func (c liveClient) Regions(context.Context) ([]string, error) {
-	return c.client.Regions().List()
+	value, err := c.client.Regions().List()
+	return value, sanitizeNomadClientError(err)
 }
 
 func (c liveClient) NamespaceInfo(ctx context.Context, namespace string) (*nomadapi.Namespace, error) {
 	ns, _, err := c.client.Namespaces().Info(namespace, c.queryOptions(ctx))
-	return ns, err
+	return ns, sanitizeNomadClientError(err)
 }
 
 func (c liveClient) RegisterJob(ctx context.Context, job *nomadapi.Job) (string, error) {
@@ -84,7 +200,7 @@ func (c liveClient) RegisterJob(ctx context.Context, job *nomadapi.Job) (string,
 		ModifyIndex:  0,
 	}, c.writeOptions(ctx))
 	if err != nil {
-		return "", err
+		return "", sanitizeNomadClientError(err)
 	}
 	if resp == nil {
 		return "", nil
@@ -94,22 +210,22 @@ func (c liveClient) RegisterJob(ctx context.Context, job *nomadapi.Job) (string,
 
 func (c liveClient) JobInfo(ctx context.Context, jobID string) (*nomadapi.Job, error) {
 	job, _, err := c.client.Jobs().Info(jobID, c.queryOptions(ctx))
-	return job, err
+	return job, sanitizeNomadClientError(err)
 }
 
 func (c liveClient) JobAllocations(ctx context.Context, jobID string, all bool) ([]*nomadapi.AllocationListStub, error) {
 	allocs, _, err := c.client.Jobs().Allocations(jobID, all, c.queryOptions(ctx))
-	return allocs, err
+	return allocs, sanitizeNomadClientError(err)
 }
 
 func (c liveClient) EvaluationInfo(ctx context.Context, evalID string) (*nomadapi.Evaluation, error) {
 	eval, _, err := c.client.Evaluations().Info(evalID, c.queryOptions(ctx))
-	return eval, err
+	return eval, sanitizeNomadClientError(err)
 }
 
 func (c liveClient) DeregisterJob(ctx context.Context, jobID string, purge bool) (string, error) {
 	evalID, _, err := c.client.Jobs().Deregister(jobID, purge, c.writeOptions(ctx))
-	return evalID, err
+	return evalID, sanitizeNomadClientError(err)
 }
 
 func (c liveClient) AllocationExec(ctx context.Context, req nomadExecRequest) (int, error) {
@@ -132,7 +248,8 @@ func (c liveClient) AllocationExec(ctx context.Context, req nomadExecRequest) (i
 		JobID:     req.JobID,
 		Namespace: normalizeNamespace(c.cfg.Nomad.Namespace),
 	}
-	return c.client.Allocations().Exec(ctx, alloc, req.Task, false, req.Command, stdin, stdout, stderr, nil, c.queryOptions(ctx))
+	exitCode, err := c.client.Allocations().Exec(ctx, alloc, req.Task, false, req.Command, stdin, stdout, stderr, nil, c.queryOptions(ctx))
+	return exitCode, sanitizeNomadClientError(err)
 }
 
 func (c liveClient) queryOptions(ctx context.Context) *nomadapi.QueryOptions {

--- a/internal/providers/nomad/client_test.go
+++ b/internal/providers/nomad/client_test.go
@@ -2,14 +2,263 @@ package nomad
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	nomadapi "github.com/hashicorp/nomad/api"
 	core "github.com/openclaw/crabbox/internal/cli"
 )
+
+func TestNomadClientRefusesCrossOriginRedirectBeforeTokenReplay(t *testing.T) {
+	const token = "nomad-test-token"
+	var sinkRequests atomic.Int32
+	sink := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		sinkRequests.Add(1)
+	}))
+	defer sink.Close()
+
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-Nomad-Token"); got != token {
+			t.Errorf("origin token=%q want configured token", got)
+		}
+		http.Redirect(w, r, sink.URL+"/stolen?location-secret=value", http.StatusTemporaryRedirect)
+	}))
+	defer origin.Close()
+
+	t.Setenv("NOMAD_TOKEN", token)
+	client, err := newNomadClient(nomadTestConfig(origin.URL), Runtime{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.AgentSelf(context.Background())
+	if !errors.Is(err, errNomadCrossOriginRedirect) {
+		t.Fatalf("error=%v want cross-origin redirect refusal", err)
+	}
+	if got := sinkRequests.Load(); got != 0 {
+		t.Fatalf("redirect sink received %d requests", got)
+	}
+	for _, leaked := range []string{token, "location-secret", "/stolen"} {
+		if strings.Contains(err.Error(), leaked) {
+			t.Fatalf("redirect error leaked %q: %v", leaked, err)
+		}
+	}
+}
+
+func TestNomadClientFollowsSameOriginRedirect(t *testing.T) {
+	const token = "nomad-test-token"
+	var redirected atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/regions":
+			http.Redirect(w, r, "/redirected", http.StatusTemporaryRedirect)
+		case "/redirected":
+			redirected.Store(true)
+			if got := r.Header.Get("X-Nomad-Token"); got != token {
+				t.Errorf("redirected token=%q want configured token", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`["global"]`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("NOMAD_TOKEN", token)
+	client, err := newNomadClient(nomadTestConfig(server.URL), Runtime{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	regions, err := client.Regions(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !redirected.Load() || len(regions) != 1 || regions[0] != "global" {
+		t.Fatalf("redirected=%t regions=%v", redirected.Load(), regions)
+	}
+}
+
+func TestNomadClientPreservesCallerRedirectPolicy(t *testing.T) {
+	wantErr := errors.New("caller stopped redirect")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/redirected", http.StatusTemporaryRedirect)
+	}))
+	defer server.Close()
+	source := server.Client()
+	source.CheckRedirect = func(*http.Request, []*http.Request) error { return wantErr }
+
+	client, err := newNomadClient(nomadTestConfig(server.URL), Runtime{HTTP: source})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.Regions(context.Background())
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("error=%v want caller redirect policy", err)
+	}
+}
+
+func TestNomadClientSanitizesRedirectLimit(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hop := requests.Add(1)
+		http.Redirect(w, r, fmt.Sprintf("/redirect/%d?limit-secret=value", hop), http.StatusTemporaryRedirect)
+	}))
+	defer server.Close()
+
+	client, err := newNomadClient(nomadTestConfig(server.URL), Runtime{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.Regions(context.Background())
+	if !errors.Is(err, errNomadRedirectLimit) {
+		t.Fatalf("error=%v want redirect limit", err)
+	}
+	if strings.Contains(err.Error(), "limit-secret") || strings.Contains(err.Error(), "/redirect/") {
+		t.Fatalf("redirect limit error leaked Location details: %v", err)
+	}
+}
+
+func TestNomadClientSanitizesMalformedRedirect(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", "http://redirect.example.test/%zz?location-secret=value")
+		w.WriteHeader(http.StatusTemporaryRedirect)
+	}))
+	defer server.Close()
+
+	client, err := newNomadClient(nomadTestConfig(server.URL), Runtime{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.AgentSelf(context.Background())
+	if !errors.Is(err, errNomadInvalidRedirect) {
+		t.Fatalf("error=%v want invalid redirect refusal", err)
+	}
+	if strings.Contains(err.Error(), "location-secret") || strings.Contains(err.Error(), "%zz") {
+		t.Fatalf("invalid redirect error leaked Location details: %v", err)
+	}
+}
+
+func TestNomadClientSanitizesMalformedExecRedirect(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", "http://redirect.example.test/%zz?location-secret=value")
+		w.WriteHeader(http.StatusTemporaryRedirect)
+	}))
+	defer server.Close()
+
+	client, err := newNomadClient(nomadTestConfig(server.URL), Runtime{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.AllocationExec(context.Background(), nomadExecRequest{
+		AllocationID: "alloc-test",
+		NodeID:       "node-test",
+		NodeName:     "node-test",
+		JobID:        "job-test",
+		Task:         "task-test",
+		Command:      []string{"true"},
+	})
+	if !errors.Is(err, errNomadInvalidRedirect) {
+		t.Fatalf("error=%v want invalid redirect refusal", err)
+	}
+	if strings.Contains(err.Error(), "location-secret") || strings.Contains(err.Error(), "%zz") {
+		t.Fatalf("invalid exec redirect error leaked Location details: %v", err)
+	}
+}
+
+func TestConfigureNomadHTTPClientMatchesSDKTLSDefaults(t *testing.T) {
+	cfg := nomadTestConfig("https://nomad.example.test:4646")
+	cfg.Nomad.SkipVerify = true
+	apiConfig, err := newNomadAPIConfig(cfg, func(string) string { return "" })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := configureNomadHTTPClient(apiConfig, nil); err != nil {
+		t.Fatal(err)
+	}
+	transport, ok := apiConfig.HttpClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport=%T want *http.Transport", apiConfig.HttpClient.Transport)
+	}
+	if transport.TLSClientConfig == nil || transport.TLSClientConfig.MinVersion != tls.VersionTLS12 || !transport.TLSClientConfig.InsecureSkipVerify {
+		t.Fatalf("TLS config=%#v", transport.TLSClientConfig)
+	}
+	if transport.ForceAttemptHTTP2 {
+		t.Fatal("Nomad SDK compatibility requires HTTP/2 disabled")
+	}
+}
+
+func TestNomadClientGuardsUnixSocketRedirects(t *testing.T) {
+	var sinkRequests atomic.Int32
+	sink := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		sinkRequests.Add(1)
+	}))
+	defer sink.Close()
+
+	socketFile, err := os.CreateTemp("", "crabbox-nomad-*.sock")
+	if err != nil {
+		t.Fatal(err)
+	}
+	socketPath := socketFile.Name()
+	if err := socketFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(socketPath); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Remove(socketPath) })
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, sink.URL+"/stolen?location-secret=value", http.StatusTemporaryRedirect)
+	})}
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(func() { _ = server.Close() })
+
+	address := (&url.URL{Scheme: "unix", Path: socketPath}).String()
+	client, err := newNomadClient(nomadTestConfig(address), Runtime{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.Regions(context.Background())
+	if !errors.Is(err, errNomadCrossOriginRedirect) {
+		t.Fatalf("error=%v want Unix redirect refusal", err)
+	}
+	if got := sinkRequests.Load(); got != 0 {
+		t.Fatalf("redirect sink received %d Unix requests", got)
+	}
+}
+
+func TestSameNomadOriginUsesEffectivePorts(t *testing.T) {
+	a, _ := url.Parse("https://nomad.example.test")
+	b, _ := url.Parse("https://nomad.example.test:443/redirected")
+	c, _ := url.Parse("http://nomad.example.test:443/redirected")
+	if !sameNomadOrigin(a, b) {
+		t.Fatal("default HTTPS port should share origin")
+	}
+	if sameNomadOrigin(a, c) {
+		t.Fatal("scheme change should not share origin")
+	}
+}
+
+func nomadTestConfig(address string) Config {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.TargetOS = core.TargetLinux
+	cfg.Nomad.Address = address
+	return cfg
+}
 
 func TestRegisterJobUsesCreateOnlyModifyIndexGuard(t *testing.T) {
 	var request nomadapi.JobRegisterRequest


### PR DESCRIPTION
## What Problem This Solves

Nomad API requests carried `X-Nomad-Token` through Go's default redirect handling. A configured endpoint could redirect a normal doctor or lifecycle request to another origin and receive the ACL token.

Closes https://github.com/openclaw/crabbox/issues/1038

## Why This Change Was Made

- confine HTTP redirects to the configured scheme, hostname, and effective port
- preserve same-origin redirects, caller redirect policy, Nomad's 10-hop limit, TLS settings, pooled HTTP/1 transport, and Unix-socket support
- keep rejected and malformed `Location` data out of provider diagnostics
- cover ordinary HTTP, Unix-socket, and allocation WebSocket redirect paths

## User Impact

Normal same-origin Nomad redirects continue to work. Cross-origin redirects now fail closed before an ACL token or replayable request body reaches the destination. No new configuration or secret handling is required; deployments must keep the configured Nomad address on its canonical origin.

## Evidence

Exact head: `1ab53d167fb43a7a499c5c615cc26a8a4d61159b`

- `go vet ./...`
- `go test -race ./...`
- `./scripts/check-docs.sh`
- `.agents/skills/autoreview/scripts/autoreview --mode local --engine codex --model gpt-5.5 --thinking high --parallel-tests "go test -race ./internal/providers/nomad" ...`
  - clean: no accepted/actionable findings
- compiled CLI live proof against separate loopback Nomad and redirect-sink servers
  - `crabbox doctor` returned `nomad refused cross-origin redirect`
  - redirect sink received zero requests and no token
  - diagnostics contained neither the token nor hostile redirect path/query data

## Security and Configuration

The ACL token remains environment-only. The change adds no config fields, environment variables, persisted secrets, or command-line secret values.
