### PR TITLE
fix: preserve exact coordinator org identities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixed
 
+- Preserved exact coordinator organization identities in collision-free authorization keys, preventing distinct labels from sharing leases, runs, bridges, workspaces, runners, or usage limits after lossy normalization. Ambiguous legacy records now fail closed for non-admin access while remaining available for admin cleanup. Thanks @coygeek.
 - Confined Nomad API redirects to the configured scheme, hostname, and effective port before replaying ACL tokens or request bodies, while keeping rejected Location secrets out of diagnostics. Thanks @coygeek.
 - Launched native Windows desktop apps directly in the active interactive session without scheduled tasks, waiting for a visible window and reporting its process ID, session, and title.
 - Unified direct macOS WebVNC with the authenticated portal: Tart and Parallels viewers now use the same chrome and controls as Linux and Windows when coordinator login is configured, with provider-lifetime registration and the local viewer retained as the offline fallback.

--- a/docs/features/cost-usage.md
+++ b/docs/features/cost-usage.md
@@ -115,6 +115,8 @@ Leases are attributed to an owner and an org. The broker resolves them by token 
 - **Shared token** (`CRABBOX_SHARED_TOKEN`) — owner is a verified Access JWT email if present,
   else `CRABBOX_SHARED_OWNER`, else `unknown`; org is `CRABBOX_DEFAULT_ORG`, else `unknown`.
   The `X-Crabbox-Owner` / `X-Crabbox-Org` headers are not honored for shared-token requests.
+- A missing org displays as `unknown` but uses a distinct accounting identity from an org
+  explicitly configured with the label `unknown`.
 - Raw Cloudflare Access identity headers are ignored; only a verified Access JWT email
   (validated against `CRABBOX_ACCESS_TEAM_DOMAIN` / `CRABBOX_ACCESS_AUD`) can become the
   bearer-token owner.

--- a/docs/features/portable-coordinator.md
+++ b/docs/features/portable-coordinator.md
@@ -198,7 +198,9 @@ caller-supplied connection identity and derives the client address from the
 rightmost untrusted member of the forwarded chain. The ingress must strip any
 incoming copy of the trusted user header before setting its authenticated
 value. Set a stable trusted-user organization before creating records; without
-it, proxy-authenticated requests use the literal organization `unknown`.
+it, proxy-authenticated requests use a dedicated missing-org identity that is
+displayed as `unknown` but remains distinct from an org literally named
+`unknown`.
 
 Trust only the actual ingress addresses or a dedicated ingress subnet, and use
 network policy to block direct access from other workloads. Do not configure

--- a/docs/security.md
+++ b/docs/security.md
@@ -177,6 +177,25 @@ Admin scope comes from `CRABBOX_ADMIN_TOKEN`, or from a signed GitHub user token
 whose verified email or login matches `CRABBOX_GITHUB_ADMIN_OWNERS` or
 `CRABBOX_GITHUB_ADMIN_LOGINS`. Locally, admin commands can still send the admin
 bearer via `CRABBOX_COORDINATOR_ADMIN_TOKEN` or `broker.adminToken`.
+
+Organization labels are exact, case-sensitive identities: 1-63 printable ASCII
+characters with no leading or trailing spaces. The coordinator stores them in a
+reversible, versioned authorization namespace, so labels such as `science team`
+and `science_team` remain distinct. Missing organization identity is also
+distinct from a configured organization literally named `unknown`, although
+both display as `unknown` in user-facing status. Missing-org principals can
+still own resources and receive explicit user shares, but never receive an org
+share.
+
+Records created before this namespace was introduced contain only a lossy
+organization value, so their original identity cannot be recovered safely.
+Those leases, runs, workspaces, ready-pool entries, runners, bridge sessions,
+and tickets fail closed for non-admin access after upgrade. Admin lease cleanup
+and scheduled provider cleanup remain available; recreate active records under
+their exact organization label. Legacy workspace records are not reused or
+replenished as prewarms. Per-org admission limits conservatively count legacy
+records against every exact label they could have represented.
+
 Long-lived control, WebVNC, Code, and egress sessions bind cached admin authority
 to the exact GitHub identity or bearer token plus a deployment grant version.
 Changing any configured admin source revokes older active, restored, ticketed,

--- a/worker/src/auth.ts
+++ b/worker/src/auth.ts
@@ -98,7 +98,7 @@ export async function authenticateRequest(
         trustedIdentity?.owner ??
         request.headers.get("x-crabbox-owner") ??
         "unknown",
-      org: request.headers.get("x-crabbox-org") ?? env.CRABBOX_DEFAULT_ORG ?? "unknown",
+      org: request.headers.get("x-crabbox-org") ?? env.CRABBOX_DEFAULT_ORG ?? "",
     };
   }
   if (env.CRABBOX_SHARED_TOKEN && timingSafeEqual(token ?? "", env.CRABBOX_SHARED_TOKEN)) {
@@ -112,7 +112,7 @@ export async function authenticateRequest(
         trustedIdentity?.owner ??
         env.CRABBOX_SHARED_OWNER?.trim() ??
         "unknown",
-      org: env.CRABBOX_DEFAULT_ORG ?? "unknown",
+      org: env.CRABBOX_DEFAULT_ORG ?? "",
     };
   }
   if (token) {
@@ -476,7 +476,7 @@ function trustedProxyIdentity(
     admin: false,
     auth: "proxy",
     owner,
-    org: env.CRABBOX_TRUSTED_USER_ORG?.trim() || "unknown",
+    org: env.CRABBOX_TRUSTED_USER_ORG ?? "",
   };
 }
 

--- a/worker/src/coordinator-entry.ts
+++ b/worker/src/coordinator-entry.ts
@@ -10,6 +10,7 @@ import {
 import { codeProxyRequestBodyBytes, isIsolatedCodeRequest } from "./code-origin";
 import { cookieValue } from "./cookies";
 import { bearerToken, json, pathParts } from "./http";
+import { InvalidOrgLabelError, orgKeyForLabel } from "./org-identity";
 import { runtimeAdapterProxyPath, runtimeAdapterRelayMethodAllowed } from "./runtime-adapter-relay";
 import { timingSafeEqual } from "./timing-safe";
 import type { Env } from "./types";
@@ -89,13 +90,11 @@ export async function prepareCoordinatorRequest(
   }
   const runtimeAdapterAuth = runtimeAdapterServiceAuth(request, env, route);
   if (runtimeAdapterAuth) {
-    return {
-      request: await requestWithAdminGrantVersion(
-        requestWithAuthContext(requestWithoutTrustedHeaders(request), runtimeAdapterAuth),
-        env,
-      ),
-      authenticated: true,
-    };
+    return await authenticatedCoordinatorRequest(
+      requestWithoutTrustedHeaders(request),
+      runtimeAdapterAuth,
+      env,
+    );
   }
   const portal = url.pathname.startsWith("/portal");
   if (portal && !portalCookieRequestIntentAllowed(request, env, url)) {
@@ -132,8 +131,29 @@ export async function prepareCoordinatorRequest(
       authenticated: false,
     };
   }
+  return await authenticatedCoordinatorRequest(authRequest, auth, env);
+}
+
+async function authenticatedCoordinatorRequest(
+  request: Request,
+  auth: AuthContext,
+  env: Env,
+): Promise<PreparedCoordinatorRequest> {
+  try {
+    if (auth.org) {
+      orgKeyForLabel(auth.org);
+    }
+  } catch (error) {
+    if (!(error instanceof InvalidOrgLabelError)) {
+      throw error;
+    }
+    return {
+      response: json({ error: "invalid_org_identity", message: error.message }, { status: 503 }),
+      authenticated: false,
+    };
+  }
   return {
-    request: await requestWithAdminGrantVersion(requestWithAuthContext(authRequest, auth), env),
+    request: await requestWithAdminGrantVersion(requestWithAuthContext(request, auth), env),
     authenticated: true,
   };
 }

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -92,6 +92,26 @@ import {
   githubPortalLogout,
   githubPortalLogoutConfirmation,
 } from "./oauth";
+import {
+  MISSING_ORG_KEY,
+  isCurrentOrgKey,
+  isLegacyOrgKey,
+  orgAuthLabelFromKey,
+  orgKeyForLabel,
+  orgLabelForDisplay,
+  orgLabelFromKey,
+  orgMatchesForFilter,
+  requestOrgLabel,
+  sameOrgIdentityKey,
+} from "./org-identity";
+import {
+  publicExternalRunnerRecord,
+  publicLeaseRecord,
+  publicReadyPoolEntry,
+  publicRunRecord,
+  portalExternalRunnerRecord,
+  portalLeaseRecord,
+} from "./org-records";
 import { defaultOSImage, normalizeOSImage } from "./os-image";
 import {
   portalCode,
@@ -2102,9 +2122,10 @@ export class FleetCoordinator {
     ) {
       return "portal session ended";
     }
+    const org = typeof attachment.org === "string" ? orgLabelFromKey(attachment.org) : undefined;
     if (
       typeof attachment.owner !== "string" ||
-      typeof attachment.org !== "string" ||
+      !org ||
       typeof attachment.admin !== "boolean" ||
       typeof attachment.login !== "string" ||
       !validPortalSessionHash(attachment.portalSessionHash) ||
@@ -2116,7 +2137,7 @@ export class FleetCoordinator {
       attachment.githubGrant,
       {
         owner: attachment.owner,
-        org: attachment.org,
+        org,
         login: attachment.login,
       },
       this.env,
@@ -2201,6 +2222,7 @@ export class FleetCoordinator {
       throw new Error("restored bridge lease state is temporarily unavailable");
     }
     await this.reconcileScheduledAdminGrants(forwardedAdminGrantVersion, preserveForwardedVersion);
+    await this.quarantineLegacyWorkspaces();
     await this.expireLeases();
     await this.webVNCCredentialHandoffs.cleanupExpired();
     await this.reconcileRuntimeAdapterDeletes();
@@ -2566,7 +2588,7 @@ export class FleetCoordinator {
           });
           throw error;
         }
-        return json({ lease: reactivation.reactivated }, { status: 201 });
+        return json({ lease: publicLeaseRecord(reactivation.reactivated) }, { status: 201 });
       }
       return json(
         {
@@ -2752,7 +2774,7 @@ export class FleetCoordinator {
         {
           error: "lease_state_changed",
           message: "lease changed state while provider preparation was in progress",
-          lease: current,
+          lease: current ? publicLeaseRecord(current) : undefined,
         },
         { status: 409 },
       );
@@ -2794,7 +2816,7 @@ export class FleetCoordinator {
         const workspace = await this.state.storage.get<WorkspaceRecord>(
           workspaceKey(current.owner, current.org, current.workspaceID),
         );
-        if (workspace?.releaseRequestedAt && workspaceOwnsLease(workspace, current)) {
+        if (workspace?.releaseRequestedAt && workspaceLeaseMatchesCleanup(workspace, current)) {
           if (prepared?.provisioning?.publishAccessBeforeProvisioning) {
             await this.deleteProviderAccess(current.id);
           }
@@ -2817,7 +2839,7 @@ export class FleetCoordinator {
         {
           error: "lease_state_changed",
           message: "lease changed state before provider provisioning began",
-          lease: current,
+          lease: current ? publicLeaseRecord(current) : undefined,
         },
         { status: 409 },
       );
@@ -3014,7 +3036,7 @@ export class FleetCoordinator {
       );
     }
     record = finalization.record;
-    return json({ lease: record }, { status: 201 });
+    return json({ lease: publicLeaseRecord(record) }, { status: 201 });
   }
 
   private async createWorkspace(request: Request): Promise<Response> {
@@ -3324,7 +3346,7 @@ export class FleetCoordinator {
       const now = Date.now();
       const templates = new Map<string, WorkspaceRecord>();
       for (const workspace of workspaces.values()) {
-        if (workspace.prewarm) continue;
+        if (workspace.prewarm || !isCurrentOrgKey(workspace.org)) continue;
         const status = workspaceStatus(workspace, leases.get(leaseKey(workspace.leaseID)));
         if (status !== "provisioning" && status !== "ready") continue;
         const shape = workspacePrewarmShape(workspace);
@@ -3338,7 +3360,7 @@ export class FleetCoordinator {
       const failedByShape = new Map<string, WorkspaceRecord[]>();
       const releaseUpdates: Array<[string, WorkspaceRecord]> = [];
       for (const [key, workspace] of workspaces) {
-        if (!workspace.prewarm) continue;
+        if (!workspace.prewarm || !isCurrentOrgKey(workspace.org)) continue;
         const lease = leases.get(leaseKey(workspace.leaseID));
         const shape = workspacePrewarmShape(workspace);
         const template = templates.get(shape);
@@ -3424,6 +3446,21 @@ export class FleetCoordinator {
     });
   }
 
+  private async quarantineLegacyWorkspaces(): Promise<void> {
+    await this.state.runExclusive(async () => {
+      const workspaces = await this.state.storage.list<WorkspaceRecord>({ prefix: "workspace:" });
+      const now = new Date().toISOString();
+      const updates = [...workspaces.entries()]
+        .filter(([, workspace]) => isLegacyOrgKey(workspace.org) && !workspace.releaseRequestedAt)
+        .map(([key, workspace]) => {
+          const quarantined = { ...workspace, releaseRequestedAt: now, updatedAt: now };
+          delete quarantined.reconcileAfter;
+          return this.state.storage.put(key, quarantined);
+        });
+      await Promise.all(updates);
+    });
+  }
+
   private async allocateWorkspaceLeaseID(): Promise<string> {
     const leaseID = newLeaseID();
     if (
@@ -3478,7 +3515,7 @@ export class FleetCoordinator {
           if (terminalAt === undefined || terminalAt > cutoff) {
             return;
           }
-          if (lease && workspaceOwnsLease(current, lease)) {
+          if (lease && workspaceLeaseMatchesCleanup(current, lease)) {
             const detachedLease = structuredClone(lease);
             delete detachedLease.workspaceID;
             await this.putLease(detachedLease);
@@ -3499,7 +3536,7 @@ export class FleetCoordinator {
     initialLease?: LeaseRecord,
   ): Promise<void> {
     let lease = initialLease;
-    if (lease && !workspaceOwnsLease(workspace, lease)) {
+    if (lease && !workspaceLeaseMatchesCleanup(workspace, lease)) {
       await this.recordWorkspaceError(
         workspace,
         "workspace lease reservation conflicts with another lifecycle",
@@ -3796,9 +3833,9 @@ export class FleetCoordinator {
         await this.scheduleAlarm();
         return current;
       });
-      if (recovered.state === "active") {
+      if (recovered.state === "active" && !workspace.releaseRequestedAt) {
         await this.completeWorkspaceCreate(workspace, workspace.provisionClaim);
-      } else {
+      } else if (!workspace.releaseRequestedAt) {
         await this.deferWorkspaceReconciliation(workspace);
       }
       return recovered;
@@ -3991,14 +4028,23 @@ export class FleetCoordinator {
       const key = nativeVNCTicketKey(token);
       const ticket = await this.state.storage.get<NativeVNCTicketRecord>(key);
       await this.state.storage.delete(key);
-      if (!ticket || ticket.ticket !== token || Date.parse(ticket.expiresAt) <= Date.now()) {
+      if (
+        !ticket ||
+        ticket.ticket !== token ||
+        !isCurrentOrgKey(ticket.org) ||
+        Date.parse(ticket.expiresAt) <= Date.now()
+      ) {
         return undefined;
       }
       const workspace = await this.state.storage.get<WorkspaceRecord>(
         workspaceKey(ticket.owner, ticket.org, ticket.workspaceID),
       );
       const current = workspace ? await this.getLease(ticket.leaseID) : undefined;
-      return workspace && current && workspaceOwnsLease(workspace, current)
+      return workspace &&
+        current &&
+        isCurrentOrgKey(workspace.org) &&
+        isCurrentOrgKey(current.org) &&
+        workspaceOwnsLease(workspace, current)
         ? { workspace, lease: current }
         : undefined;
     });
@@ -4748,7 +4794,7 @@ export class FleetCoordinator {
     const workspace = await this.state.storage.get<WorkspaceRecord>(key);
     if (
       !workspace ||
-      !workspaceOwnsLease(workspace, lease) ||
+      !workspaceLeaseMatchesCleanup(workspace, lease) ||
       !workspace.releaseRequestedAt ||
       !workspace.error
     ) {
@@ -4763,7 +4809,7 @@ export class FleetCoordinator {
     workspace: WorkspaceRecord,
   ): Promise<LeaseRecord | undefined> {
     const lease = await this.getLease(workspace.leaseID);
-    if (!lease || !workspaceOwnsLease(workspace, lease)) {
+    if (!lease || !workspaceLeaseMatchesCleanup(workspace, lease)) {
       return lease;
     }
     return await this.releaseResolvedLease(lease, { deleteServer: true, keep: false });
@@ -4801,7 +4847,7 @@ export class FleetCoordinator {
       lease.tailscale = mergeTailscaleMetadata(lease.tailscale, input);
       lease.updatedAt = new Date().toISOString();
       await this.putLease(lease);
-      return json({ lease });
+      return json({ lease: publicLeaseRecord(lease) });
     }
     if (method === "POST" && action === "release") {
       return this.releaseLease(request, leaseID, false);
@@ -5083,7 +5129,7 @@ export class FleetCoordinator {
       await this.confirmRuntimeAdapterIdentity(runtimeAdapterIdentity, nowISO);
     }
     await this.scheduleAlarm();
-    return json({ lease: record }, { status: existing ? 200 : 201 });
+    return json({ lease: publicLeaseRecord(record) }, { status: existing ? 200 : 201 });
   }
 
   private async heartbeatLease(request: Request, leaseID: string): Promise<Response> {
@@ -5120,7 +5166,7 @@ export class FleetCoordinator {
     }
     const managedProvider = managedLeaseProvider(committed);
     if (requestCIDRs.length === 0 || !managedProvider) {
-      return json({ lease: committed });
+      return json({ lease: publicLeaseRecord(committed) });
     }
 
     const refresh = async (): Promise<LeaseRecord> => {
@@ -5170,7 +5216,7 @@ export class FleetCoordinator {
     };
     const lease =
       managedProvider === "aws" ? await this.withAWSIngressOperationLock(refresh) : await refresh();
-    return json({ lease });
+    return json({ lease: publicLeaseRecord(lease) });
   }
 
   private async refreshLeaseAccessForResolution(lease: LeaseRecord): Promise<LeaseRecord> {
@@ -5406,13 +5452,13 @@ export class FleetCoordinator {
           {
             error: "cleanup_in_progress",
             message: "lease cleanup has already started",
-            lease,
+            lease: publicLeaseRecord(lease),
           },
           { status: 409 },
         );
       }
       await this.scheduleAlarm();
-      return json({ lease });
+      return json({ lease: publicLeaseRecord(lease) });
     }
     const released = await this.releaseResolvedLease(lease, { deleteServer: shouldDelete });
     if (released.runtimeAdapterDeleteRequestedAt) {
@@ -5423,12 +5469,12 @@ export class FleetCoordinator {
         {
           error: "cleanup_in_progress",
           message: "lease cleanup has already started",
-          lease: released,
+          lease: publicLeaseRecord(released),
         },
         { status: 409 },
       );
     }
-    return json({ lease: released });
+    return json({ lease: publicLeaseRecord(released) });
   }
 
   private async completeRuntimeAdapterDelete(
@@ -5470,16 +5516,17 @@ export class FleetCoordinator {
         return runtimeAdapterDeleteInFlightResponse(result.retryAt);
       }
       if (result.status === "mismatch") {
+        const current = await this.getLease(lease.id);
         return json(
           {
             error: "lease_state_changed",
             message: "lease changed while completing its runtime adapter delete",
-            lease: await this.getLease(lease.id),
+            lease: current ? publicLeaseRecord(current) : undefined,
           },
           { status: 409 },
         );
       }
-      return json({ lease: result.lease });
+      return json({ lease: publicLeaseRecord(result.lease) });
     });
   }
 
@@ -5522,16 +5569,17 @@ export class FleetCoordinator {
         return runtimeAdapterDeleteInFlightResponse(result.retryAt);
       }
       if (result.status === "mismatch") {
+        const current = await this.getLease(lease.id);
         return json(
           {
             error: "lease_state_changed",
             message: "lease changed while completing its legacy runtime adapter delete",
-            lease: await this.getLease(lease.id),
+            lease: current ? publicLeaseRecord(current) : undefined,
           },
           { status: 409 },
         );
       }
-      return json({ lease: result.lease });
+      return json({ lease: publicLeaseRecord(result.lease) });
     });
   }
 
@@ -5684,7 +5732,7 @@ export class FleetCoordinator {
       tokenExpiresAt?: string;
     } = {
       owner: requestOwner(request),
-      org: requestOrg(request, this.env),
+      org: requestOrgLabel(request, this.env),
       auth: request.headers.get("x-crabbox-auth") || "bearer",
       admin: isAdminRequest(request),
     };
@@ -5788,13 +5836,13 @@ export class FleetCoordinator {
           .map((lease) => lease.id),
       );
       return portalHome(
-        leases,
-        runners,
+        leases.map(portalLeaseRecord),
+        runners.map(portalExternalRunnerRecord),
         request,
         this.attachPortalMacHostLeases(
           this.portalMacHostsVisibleToRequest(macHosts, hostLeases, request),
           hostLeases,
-        ),
+        ).map((host) => (host.lease ? { ...host, lease: portalLeaseRecord(host.lease) } : host)),
         manageableLeaseIDs,
       );
     }
@@ -5894,7 +5942,7 @@ export class FleetCoordinator {
       if (error) {
         return portalError("WebVNC unavailable", error, 409);
       }
-      return portalVNC(lease, {
+      return portalVNC(publicLeaseRecord(lease), {
         canManage: this.leaseManageableByRequest(lease, request, isAdminRequest(request)),
       });
     }
@@ -6136,7 +6184,7 @@ export class FleetCoordinator {
         state: lease.state,
         target: lease.target || "linux",
         owner: lease.owner,
-        org: lease.org,
+        org: orgLabelForDisplay(lease.org),
         class: lease.class,
         serverType: lease.serverType,
         ...(lease.host ? { host: lease.host } : {}),
@@ -6201,9 +6249,12 @@ export class FleetCoordinator {
     const canManage = Boolean(
       host.lease && this.leaseManageableByRequest(host.lease, request, isAdminRequest(request)),
     );
-    return portalMacHostDetail(host, host.lease ? this.leaseBridgeStatus(host.lease) : undefined, {
-      canManage,
-    });
+    const publicHost = host.lease ? { ...host, lease: publicLeaseRecord(host.lease) } : host;
+    return portalMacHostDetail(
+      publicHost,
+      host.lease ? this.leaseBridgeStatus(host.lease) : undefined,
+      { canManage },
+    );
   }
 
   private async portalMacHostLeaseRedirect(
@@ -6221,9 +6272,10 @@ export class FleetCoordinator {
         404,
       );
     }
+    const publicHost = host.lease ? { ...host, lease: publicLeaseRecord(host.lease) } : host;
     if (!lease) {
       if (action === "vnc") {
-        return portalMacHostDetail(host, undefined);
+        return portalMacHostDetail(publicHost, undefined);
       }
       return portalError(
         "Code unavailable",
@@ -6233,7 +6285,7 @@ export class FleetCoordinator {
     }
     const error = action === "vnc" ? webVNCLeaseError(lease) : codeLeaseError(lease);
     if (action === "vnc" && error === "lease was not created with desktop=true") {
-      return portalMacHostDetail(host, this.leaseBridgeStatus(lease), {
+      return portalMacHostDetail(publicHost, this.leaseBridgeStatus(lease), {
         canManage: this.leaseManageableByRequest(lease, request, isAdminRequest(request)),
       });
     }
@@ -6325,9 +6377,14 @@ export class FleetCoordinator {
         this.runReferencesLease(run, lease.id) && this.runReadableToRequest(run, request, lease)
       );
     });
-    return portalLeaseDetail(lease, visibleRuns, this.leaseBridgeStatus(lease), {
-      canManage: this.leaseManageableByRequest(lease, request, isAdminRequest(request)),
-    });
+    return portalLeaseDetail(
+      publicLeaseRecord(lease),
+      visibleRuns.map(publicRunRecord),
+      this.leaseBridgeStatus(lease),
+      {
+        canManage: this.leaseManageableByRequest(lease, request, isAdminRequest(request)),
+      },
+    );
   }
 
   private leaseBridgeStatus(lease: LeaseRecord): PortalLeaseBridgeStatus {
@@ -6535,7 +6592,7 @@ export class FleetCoordinator {
           latest.runtimeAdapterWorkspaceID === workspaceID &&
           latest.runtimeAdapterRegistrationID === lease.runtimeAdapterRegistrationID
         ) {
-          return json({ lease: latest, status: "deleted" });
+          return json({ lease: publicLeaseRecord(latest), status: "deleted" });
         }
         return runtimeAdapterWorkspaceDeleteError(
           "runtime_adapter_lease_changed",
@@ -6546,7 +6603,7 @@ export class FleetCoordinator {
       }
       return json(
         {
-          lease: (await this.getLease(lease.id)) ?? current,
+          lease: publicLeaseRecord((await this.getLease(lease.id)) ?? current),
           status: "deleting",
         },
         { status: 202 },
@@ -6810,12 +6867,12 @@ export class FleetCoordinator {
         leaseID: lease.id,
         slug: lease.slug || lease.id,
         owner: lease.owner,
-        org: lease.org,
+        org: orgLabelForDisplay(lease.org),
         share: normalizedLeaseShare(lease.share),
       });
     }
     const embedded = url.searchParams.get("embed") === "1";
-    return portalShareLease(lease, { embedded });
+    return portalShareLease(publicLeaseRecord(lease), { embedded });
   }
 
   private async portalShareLeaseAction(request: Request, identifier: string): Promise<Response> {
@@ -6841,7 +6898,7 @@ export class FleetCoordinator {
         leaseID: lease.id,
         slug: lease.slug || lease.id,
         owner: lease.owner,
-        org: lease.org,
+        org: orgLabelForDisplay(lease.org),
         share: normalizedLeaseShare(lease.share),
       });
     }
@@ -6913,7 +6970,7 @@ export class FleetCoordinator {
         this.runEvents(runID, 0, 100),
         this.readRunLog(runID),
       ]);
-      return portalRunDetail(run, events, tailString(log, 12 * 1024));
+      return portalRunDetail(publicRunRecord(run), events, tailString(log, 12 * 1024));
     }
     return json({ error: "not_found" }, { status: 404 });
   }
@@ -7352,6 +7409,7 @@ export class FleetCoordinator {
     );
     if (
       !identity ||
+      !isCurrentOrgKey(identity.org) ||
       identity.adapterID !== adapterID ||
       identity.owner !== ticket.owner ||
       identity.org !== ticket.org
@@ -7398,6 +7456,7 @@ export class FleetCoordinator {
     const attachment = agent ? this.bridgeAttachment(agent) : undefined;
     if (
       !identity ||
+      !isCurrentOrgKey(identity.org) ||
       identity.adapterID !== adapterID ||
       !agent ||
       agent.readyState !== WebSocket.OPEN ||
@@ -7475,6 +7534,20 @@ export class FleetCoordinator {
           {
             error: "runtime_adapter_unclaimed",
             message: "runtime adapter id has not been claimed",
+          },
+          { status: 409 },
+        ),
+      };
+    }
+    const legacyIdentity = isLegacyOrgKey(identity.org);
+    if (!isCurrentOrgKey(identity.org) && (method !== "DELETE" || !legacyIdentity)) {
+      return {
+        origin: "relay",
+        dispatched: false,
+        response: json(
+          {
+            error: "runtime_adapter_identity_legacy",
+            message: "runtime adapter identity must be reclaimed before use",
           },
           { status: 409 },
         ),
@@ -8220,12 +8293,16 @@ export class FleetCoordinator {
         );
       }
       viewerSession = session;
+      const org = orgAuthLabelFromKey(session.org);
+      if (org === undefined) {
+        return this.codeViewerAuthenticationRequired(request, identifier);
+      }
       authorizedRequest = requestWithAuthContext(request, {
         authorized: true,
         admin: session.admin,
         auth: session.auth,
         owner: session.owner,
-        org: session.org,
+        org,
         ...(session.login ? { login: session.login } : {}),
         ...(session.githubGrant
           ? {
@@ -8408,6 +8485,7 @@ export class FleetCoordinator {
       session.session !== value ||
       session.leaseID !== leaseID ||
       Date.parse(session.expiresAt) <= Date.now() ||
+      !isCurrentOrgKey(session.org) ||
       (session.auth === "github" && !validPortalSessionHash(session.portalSessionHash)) ||
       (session.portalSessionHash &&
         (await this.portalSessionIsRevoked(session.portalSessionHash))) ||
@@ -8466,6 +8544,7 @@ export class FleetCoordinator {
         !ticket ||
         ticket.ticket !== value ||
         ticket.leaseID !== leaseID ||
+        !isCurrentOrgKey(ticket.org) ||
         Date.parse(ticket.expiresAt) <= Date.now() ||
         (ticket.viewerExpiresAt !== undefined && Date.parse(ticket.viewerExpiresAt) <= Date.now())
       ) {
@@ -9215,7 +9294,7 @@ export class FleetCoordinator {
     return this.withBridgeTicketLock(async () => {
       const key = runtimeAdapterTicketKey(value);
       const ticket = await this.state.storage.get<RuntimeAdapterTicketRecord>(key);
-      if (!ticket || ticket.ticket !== value) {
+      if (!ticket || ticket.ticket !== value || !isCurrentOrgKey(ticket.org)) {
         return { status: "invalid" };
       }
       if (Date.parse(ticket.expiresAt) <= Date.now()) {
@@ -9249,6 +9328,7 @@ export class FleetCoordinator {
   ): Promise<boolean> {
     if (
       identity.adapterID !== adapterID ||
+      (!isCurrentOrgKey(identity.org) && !isLegacyOrgKey(identity.org)) ||
       identity.claimVersion !== 1 ||
       identity.claimState !== "provisional" ||
       identity.confirmedAt !== undefined ||
@@ -9309,6 +9389,9 @@ export class FleetCoordinator {
   private async currentLeaseBridgeTicket<
     T extends CachedBridgeGrant & { owner: string; org: string; admin?: boolean },
   >(ticket: T, lease: LeaseRecord): Promise<T | undefined> {
+    if (!isCurrentOrgKey(ticket.org) || !isCurrentOrgKey(lease.org)) {
+      return undefined;
+    }
     const currentTicket =
       ticket.admin === true
         ? withCurrentAdminGrant(ticket, await this.currentAdminGrantValidation())
@@ -9510,7 +9593,9 @@ export class FleetCoordinator {
   ): Promise<Response> {
     const method = request.method.toUpperCase();
     if (method === "GET" && !rawKey) {
-      return json({ pools: await this.allReadyPoolStatus(request) });
+      return json({
+        pools: (await this.allReadyPoolStatus(request)).map(publicReadyPoolEntry),
+      });
     }
     const decodedKey = decodeReadyPoolRouteKey(rawKey ?? "");
     const key = decodedKey === undefined ? "" : normalizeReadyPoolKey(decodedKey);
@@ -9518,7 +9603,7 @@ export class FleetCoordinator {
       return json({ error: "invalid_pool_key" }, { status: 400 });
     }
     if (method === "GET" && !action) {
-      return json({ pool: await this.readyPoolStatus(key, request) });
+      return json({ pool: (await this.readyPoolStatus(key, request)).map(publicReadyPoolEntry) });
     }
     if (method === "POST" && action === "register") {
       return await this.registerReadyPoolLease(request, key);
@@ -9644,7 +9729,7 @@ export class FleetCoordinator {
           .map((existing) => this.deleteReadyPoolEntry(existing)),
       );
       await this.putReadyPoolEntry(entry);
-      return json({ entry, lease });
+      return json({ entry: publicReadyPoolEntry(entry), lease: publicLeaseRecord(lease) });
     });
   }
 
@@ -9705,7 +9790,10 @@ export class FleetCoordinator {
           expiresAt: lease.expiresAt,
         };
         await this.putReadyPoolEntry(borrowed);
-        return json({ entry: borrowed, lease });
+        return json({
+          entry: publicReadyPoolEntry(borrowed),
+          lease: publicLeaseRecord(lease),
+        });
       });
     });
   }
@@ -9768,20 +9856,31 @@ export class FleetCoordinator {
         await this.putReadyPoolEntry(drained);
         if (lease && lease.state === "active") {
           return json({
-            entry: drained,
-            lease: await this.releaseResolvedLease(lease, { deleteServer: true, keep: false }),
+            entry: publicReadyPoolEntry(drained),
+            lease: publicLeaseRecord(
+              await this.releaseResolvedLease(lease, { deleteServer: true, keep: false }),
+            ),
           });
         }
-        return json({ entry: drained, lease });
+        return json({
+          entry: publicReadyPoolEntry(drained),
+          lease: lease ? publicLeaseRecord(lease) : undefined,
+        });
       }
       if (!lease || lease.state !== "active" || Date.parse(lease.expiresAt) <= Date.now()) {
         const stale = this.nextReturnedReadyPoolEntry(current, lease, "stale", input.reason);
         await this.putReadyPoolEntry(stale);
-        return json({ entry: stale, lease });
+        return json({
+          entry: publicReadyPoolEntry(stale),
+          lease: lease ? publicLeaseRecord(lease) : undefined,
+        });
       }
       const returned = this.nextReturnedReadyPoolEntry(current, lease, "ready", input.reason);
       await this.putReadyPoolEntry(returned);
-      return json({ entry: returned, lease });
+      return json({
+        entry: publicReadyPoolEntry(returned),
+        lease: publicLeaseRecord(lease),
+      });
     });
   }
 
@@ -9870,13 +9969,16 @@ export class FleetCoordinator {
     }
     const state = url.searchParams.get("state") ?? "expired";
     const owner = url.searchParams.get("owner") ?? "";
-    const org = url.searchParams.get("org") ?? "";
+    const org = orgFilterKey(url);
+    if (org === null) {
+      return json({ error: "invalid_org_identity" }, { status: 400 });
+    }
     const limit = clampLimit(url.searchParams.get("limit"), 100);
     const leases = (await this.leaseRecords())
       .filter((lease) => lease.provider === provider && !isRegisteredLease(lease))
       .filter((lease) => !state || lease.state === state)
       .filter((lease) => !owner || lease.owner === owner)
-      .filter((lease) => !org || lease.org === org)
+      .filter((lease) => !org || orgMatchesForFilter(lease.org, org))
       .filter((lease) => Boolean(lease.cloudID))
       .toSorted((a, b) => b.createdAt.localeCompare(a.createdAt))
       .slice(0, limit);
@@ -10159,7 +10261,7 @@ export class FleetCoordinator {
       state: lease.state,
       target: lease.target,
       owner: lease.owner,
-      org: lease.org,
+      org: orgLabelForDisplay(lease.org),
       cloudID: lease.cloudID,
       host: lease.host,
       serverType: lease.serverType,
@@ -10229,7 +10331,7 @@ export class FleetCoordinator {
       state: lease.state,
       target: lease.target,
       owner: lease.owner,
-      org: lease.org,
+      org: orgLabelForDisplay(lease.org),
       cloudID: lease.cloudID,
       host: lease.host,
       serverType: lease.serverType,
@@ -10310,7 +10412,7 @@ export class FleetCoordinator {
     const released = await this.releaseResolvedLease(lease, { deleteServer: true, keep: false });
     return released.runtimeAdapterDeleteRequestedAt
       ? runtimeAdapterDeletePendingResponse(released)
-      : json({ lease: released });
+      : json({ lease: publicLeaseRecord(released) });
   }
 
   private filterLeases(leases: LeaseRecord[], request: Request): LeaseRecord[] {
@@ -10324,12 +10426,13 @@ export class FleetCoordinator {
     const state = url.searchParams.get("state") ?? "";
     const provider = url.searchParams.get("provider") ?? "";
     const owner = url.searchParams.get("owner") ?? "";
-    const org = url.searchParams.get("org") ?? "";
+    const org = orgFilterKey(url);
+    if (org === null) return [];
     return leases
       .filter((lease) => !state || lease.state === state)
       .filter((lease) => !provider || lease.provider === provider)
       .filter((lease) => !owner || lease.owner === owner)
-      .filter((lease) => !org || lease.org === org)
+      .filter((lease) => !org || orgMatchesForFilter(lease.org, org))
       .toSorted((a, b) => b.createdAt.localeCompare(a.createdAt));
   }
 
@@ -10382,17 +10485,22 @@ export class FleetCoordinator {
     }
     await this.putRun(run);
     await this.appendRunEventRecord(run, { type: "run.started", phase: "starting" });
-    return json({ run }, { status: 201 });
+    return json({ run: publicRunRecord(run) }, { status: 201 });
   }
 
   private async createArtifactUploads(request: Request): Promise<Response> {
     try {
       const input = await readJson<ArtifactUploadRequest>(request);
+      // NUL cannot occur in a validated org label, so it preserves the missing-org tenant
+      // without colliding with the literal "unknown" label or exposing coordinator keys.
+      const artifactOrg =
+        requestOrg(request, this.env) === MISSING_ORG_KEY
+          ? "\0"
+          : requestOrgLabel(request, this.env);
       return json(
         await artifactUploadResponse(this.env, input, {
           owner: requestOwner(request),
-          // Artifact keys encode auth identity bytes exactly; usage org normalization is lossy.
-          org: request.headers.get("x-crabbox-org") ?? this.env.CRABBOX_DEFAULT_ORG ?? "",
+          org: artifactOrg,
         }),
         { status: 201 },
       );
@@ -10412,7 +10520,9 @@ export class FleetCoordinator {
     if (method === "GET" && action === undefined) {
       const run = await this.getRun(runID);
       const lease = run ? await this.ensureRunLeaseAttribution(run) : undefined;
-      return run && this.runReadableToRequest(run, request, lease) ? json({ run }) : notFound();
+      return run && this.runReadableToRequest(run, request, lease)
+        ? json({ run: publicRunRecord(run) })
+        : notFound();
     }
     if (method === "GET" && action === "logs") {
       const run = await this.getRun(runID);
@@ -10472,7 +10582,7 @@ export class FleetCoordinator {
     }
     run.telemetry = appendRunTelemetrySample(run.telemetry, telemetry);
     await this.putRun(run);
-    return json({ run });
+    return json({ run: publicRunRecord(run) });
   }
 
   private async finishRun(request: Request, runID: string): Promise<Response> {
@@ -10523,7 +10633,7 @@ export class FleetCoordinator {
       phase: run.state,
       exitCode: run.exitCode,
     });
-    return json({ run });
+    return json({ run: publicRunRecord(run) });
   }
 
   private async readRunLog(runID: string): Promise<string> {
@@ -10559,14 +10669,17 @@ export class FleetCoordinator {
     const url = new URL(request.url);
     const leaseID = url.searchParams.get("leaseID") ?? "";
     const owner = url.searchParams.get("owner") ?? "";
-    const org = url.searchParams.get("org") ?? "";
+    const org = orgFilterKey(url);
+    if (org === null) {
+      return json({ error: "invalid_org_identity" }, { status: 400 });
+    }
     const state = url.searchParams.get("state") ?? "";
     const limit = clampLimit(url.searchParams.get("limit"), 50);
     const admin = isAdminRequest(request);
     const runs = await this.recentRuns(limit, async (run) => {
       if (
         (owner && run.owner !== owner) ||
-        (org && run.org !== org) ||
+        (org && !orgMatchesForFilter(run.org, org)) ||
         (state && run.state !== state) ||
         (leaseID && run.leaseIDs !== undefined && !this.runReferencesLease(run, leaseID))
       ) {
@@ -10584,7 +10697,7 @@ export class FleetCoordinator {
       }
       return admin || this.runReadableToRequest(run, request, currentLease);
     });
-    return json({ runs });
+    return json({ runs: runs.map(publicRunRecord) });
   }
 
   private async listExternalRunners(request: Request): Promise<Response> {
@@ -10607,7 +10720,8 @@ export class FleetCoordinator {
           return true;
         })
         .toSorted((a, b) => runnerSortTime(b).localeCompare(runnerSortTime(a)))
-        .slice(0, limit),
+        .slice(0, limit)
+        .map(publicExternalRunnerRecord),
     });
   }
 
@@ -10619,7 +10733,10 @@ export class FleetCoordinator {
     const admin = isAdminRequest(request);
     const url = new URL(request.url);
     const owner = admin ? url.searchParams.get("owner") : requestOwner(request);
-    const org = admin ? url.searchParams.get("org") : requestOrg(request, this.env);
+    const org = admin ? orgFilterKey(url) : requestOrg(request, this.env);
+    if (org === null) {
+      return portalError("Invalid organization", "That organization identifier is invalid.", 400);
+    }
     const runner = (await this.visibleExternalRunners(request)).find(
       (candidate) =>
         candidate.provider === provider &&
@@ -10634,7 +10751,7 @@ export class FleetCoordinator {
         404,
       );
     }
-    return portalExternalRunnerDetail(runner, { admin });
+    return portalExternalRunnerDetail(publicExternalRunnerRecord(runner), { admin });
   }
 
   private async syncExternalRunners(request: Request): Promise<Response> {
@@ -10703,7 +10820,10 @@ export class FleetCoordinator {
       stale.push(next);
     }
     await Promise.all(writes);
-    return json({ runners: synced, stale });
+    return json({
+      runners: synced.map(publicExternalRunnerRecord),
+      stale: stale.map(publicExternalRunnerRecord),
+    });
   }
 
   private async usage(request: Request): Promise<Response> {
@@ -10718,7 +10838,10 @@ export class FleetCoordinator {
     const owner = admin
       ? (url.searchParams.get("owner") ?? requestOwner(request))
       : requestOwner(request);
-    const requestedOrg = url.searchParams.get("org") ?? undefined;
+    const requestedOrg = orgFilterKey(url);
+    if (requestedOrg === null) {
+      return json({ error: "invalid_org_identity" }, { status: 400 });
+    }
     const org = admin
       ? (requestedOrg ?? (scope === "org" ? requestOrg(request, this.env) : undefined))
       : requestOrg(request, this.env);
@@ -10734,7 +10857,7 @@ export class FleetCoordinator {
     return json({
       marketplace: marketplaceStatus(this.env),
       owner: requestOwner(request),
-      org: requestOrg(request, this.env),
+      org: requestOrgLabel(request, this.env),
     });
   }
 
@@ -10756,7 +10879,7 @@ export class FleetCoordinator {
         quote: marketplaceQuote(this.env, input),
         marketplace: status,
         owner: requestOwner(request),
-        org: requestOrg(request, this.env),
+        org: requestOrgLabel(request, this.env),
       });
     } catch (error) {
       if (error instanceof MarketplaceInputError) {
@@ -10929,7 +11052,7 @@ export class FleetCoordinator {
         const workspace = workspacesByLeaseID.get(stored.id);
         if (
           workspace &&
-          workspaceOwnsLease(workspace, stored) &&
+          workspaceLeaseMatchesCleanup(workspace, stored) &&
           workspaceProvisioningNeedsRecovery(workspace, stored, now)
         ) {
           continue;
@@ -11067,7 +11190,7 @@ export class FleetCoordinator {
         return (
           !(
             workspace &&
-            workspaceOwnsLease(workspace, lease) &&
+            workspaceLeaseMatchesCleanup(workspace, lease) &&
             workspaceProvisioningNeedsRecovery(workspace, lease, now)
           ) &&
           (leaseIsLive(lease) ||
@@ -12157,7 +12280,7 @@ export class FleetCoordinator {
   }
 
   private leaseForRequest(lease: LeaseRecord, request: Request, admin: boolean): LeaseRecord {
-    const visible = { ...lease };
+    const visible = publicLeaseRecord(lease);
     if (visible.cleanupError) {
       visible.cleanupError = coordinatorDiagnosticText(this.env, visible.cleanupError);
     }
@@ -12194,12 +12317,19 @@ export class FleetCoordinator {
     lease: LeaseRecord,
     principal: { owner: string; org: string; admin: boolean },
   ): "owner" | LeaseShareRole | undefined {
-    if (principal.admin || (lease.owner === principal.owner && lease.org === principal.org)) {
+    if (principal.admin) {
       return "owner";
     }
+    // Legacy org values are lossy and cannot safely prove any non-admin relationship,
+    // including an otherwise explicit user share carried by an ambiguous record.
+    if (!isCurrentOrgKey(lease.org) || !isCurrentOrgKey(principal.org)) {
+      return undefined;
+    }
+    const sameOrg = sameOrgIdentityKey(lease.org, principal.org);
+    if (lease.owner === principal.owner && sameOrg) return "owner";
     const share = normalizedLeaseShare(lease.share);
     const userRole = share.users[normalizeShareUser(principal.owner)];
-    const orgRole = lease.org === principal.org ? share.org : undefined;
+    const orgRole = sameOrg && lease.org !== MISSING_ORG_KEY ? share.org : undefined;
     if (userRole === "manage" || orgRole === "manage") {
       return "manage";
     }
@@ -12235,16 +12365,20 @@ export class FleetCoordinator {
     attachment: Extract<BridgeAttachment, { kind: "control" }>,
     lease?: LeaseRecord,
   ): boolean {
+    if (!attachment.admin && !isCurrentOrgKey(attachment.org)) {
+      return false;
+    }
     return Boolean(
       attachment.admin ||
-      (run.owner === attachment.owner && run.org === attachment.org) ||
+      (run.owner === attachment.owner && sameOrgIdentityKey(run.org, attachment.org)) ||
       run.leaseOwners?.some(
         (attribution) =>
-          attribution.owner === attachment.owner && attribution.org === attachment.org,
+          attribution.owner === attachment.owner &&
+          sameOrgIdentityKey(attribution.org, attachment.org),
       ) ||
       (!run.leaseOwners?.length &&
         lease?.owner === attachment.owner &&
-        lease.org === attachment.org),
+        sameOrgIdentityKey(lease.org, attachment.org)),
     );
   }
 
@@ -12309,7 +12443,8 @@ export class FleetCoordinator {
     attachment: Extract<BridgeAttachment, { kind: "control" }>,
   ): boolean {
     return Boolean(
-      attachment.admin || (lease.owner === attachment.owner && lease.org === attachment.org),
+      attachment.admin ||
+      (lease.owner === attachment.owner && sameOrgIdentityKey(lease.org, attachment.org)),
     );
   }
 
@@ -12534,7 +12669,7 @@ export class FleetCoordinator {
         {
           error: "lease_state_changed",
           message: "lease changed state while provider provisioning was in progress",
-          lease: preparation.lease,
+          lease: publicLeaseRecord(preparation.lease),
         },
         { status: 409 },
       );
@@ -12587,7 +12722,7 @@ export class FleetCoordinator {
           {
             error: "lease_state_changed",
             message: "lease changed state while provider provisioning was in progress",
-            lease: failure.lease,
+            lease: publicLeaseRecord(failure.lease),
           },
           { status: 409 },
         );
@@ -12621,7 +12756,7 @@ export class FleetCoordinator {
       {
         error: "lease_state_changed",
         message: "lease changed state while provider provisioning was in progress",
-        lease: latest,
+        lease: latest ? publicLeaseRecord(latest) : undefined,
       },
       { status: 409 },
     );
@@ -12661,7 +12796,7 @@ export class FleetCoordinator {
     const key = workspaceKey(lease.owner, lease.org, workspaceID);
     await this.state.runExclusive(async () => {
       const workspace = await this.state.storage.get<WorkspaceRecord>(key);
-      if (!workspace || !workspaceOwnsLease(workspace, lease)) {
+      if (!workspace || !workspaceLeaseMatchesCleanup(workspace, lease)) {
         throw new Error("workspace lease reservation conflicts with another lifecycle");
       }
       if (!workspace.releaseRequestedAt) {
@@ -12999,7 +13134,9 @@ function externalRunnerPrefix(): string {
 }
 
 function externalRunnerKey(provider: string, runnerID: string, owner: string, org: string): string {
-  return `${externalRunnerPrefix()}${provider}:${runnerID}:${org}:${owner}`;
+  return `${externalRunnerPrefix()}${[provider, runnerID, org, owner]
+    .map((value) => encodeURIComponent(value))
+    .join(":")}`;
 }
 
 function runLogKey(runID: string): string {
@@ -13492,7 +13629,7 @@ function runtimeAdapterDeletePendingResponse(lease: LeaseRecord): Response {
     {
       error: "runtime_adapter_delete_pending",
       message: "lease release is blocked while its runtime adapter delete is pending",
-      lease,
+      lease: publicLeaseRecord(lease),
     },
     { status: 409 },
   );
@@ -13611,7 +13748,7 @@ function workspacePrewarmMatches(
   target: Pick<WorkspaceRecord, "org" | "profile" | "provider" | "class" | "desktop">,
 ): boolean {
   return (
-    workspace.org === target.org &&
+    sameOrgIdentityKey(workspace.org, target.org) &&
     workspace.profile === target.profile &&
     workspace.provider === target.provider &&
     workspace.class === target.class &&
@@ -13686,10 +13823,14 @@ async function workspaceLeaseRequest(
 }
 
 function workspaceRecordHeaders(workspace: WorkspaceRecord): Headers {
+  const org = orgAuthLabelFromKey(workspace.org);
+  if (org === undefined) {
+    throw new Error("workspace organization identity must be recreated before provisioning");
+  }
   return new Headers({
     "content-type": "application/json",
     "x-crabbox-owner": workspace.owner,
-    "x-crabbox-org": workspace.org,
+    "x-crabbox-org": org,
   });
 }
 
@@ -13778,7 +13919,10 @@ function workspaceNextReconcileAt(
   lease?: LeaseRecord,
   now = Date.now(),
 ): number | undefined {
-  if (lease && !workspaceOwnsLease(workspace, lease)) return workspace.error ? undefined : now;
+  if (!isCurrentOrgKey(workspace.org) && !workspace.releaseRequestedAt) return undefined;
+  if (lease && !workspaceLeaseMatchesCleanup(workspace, lease)) {
+    return workspace.error ? undefined : now;
+  }
   if (lease?.state === "released" && lease.releaseDeletesServer === false) {
     return undefined;
   }
@@ -13898,6 +14042,20 @@ function workspaceTerminalTimestamp(
 
 function workspaceOwnsLease(workspace: WorkspaceRecord, lease: LeaseRecord): boolean {
   return (
+    lease.workspaceID === workspace.id &&
+    lease.id === workspace.leaseID &&
+    lease.owner === workspace.owner &&
+    sameOrgIdentityKey(lease.org, workspace.org)
+  );
+}
+
+/** Legacy orgs can prove only cleanup lifecycle linkage, never user access or adoption. */
+function workspaceLeaseMatchesCleanup(workspace: WorkspaceRecord, lease: LeaseRecord): boolean {
+  if (workspaceOwnsLease(workspace, lease)) return true;
+  return (
+    Boolean(workspace.releaseRequestedAt) &&
+    isLegacyOrgKey(workspace.org) &&
+    isLegacyOrgKey(lease.org) &&
     lease.workspaceID === workspace.id &&
     lease.id === workspace.leaseID &&
     lease.owner === workspace.owner &&
@@ -15002,6 +15160,24 @@ function clampLimit(value: string | null, fallback: number): number {
   return Math.min(Math.trunc(parsed), 500);
 }
 
+function orgFilterKey(url: URL): string | null | undefined {
+  const value = url.searchParams.get("org");
+  const kind = url.searchParams.get("orgKind");
+  if (kind === "missing") {
+    return value === null ? MISSING_ORG_KEY : null;
+  }
+  if (kind === "legacy") {
+    return value !== null && isLegacyOrgKey(value) ? value : null;
+  }
+  if (kind !== null) return null;
+  if (!value) return undefined;
+  try {
+    return orgKeyForLabel(value);
+  } catch {
+    return null;
+  }
+}
+
 function tailString(value: string, maxChars: number): string {
   if (value.length <= maxChars) {
     return value;
@@ -15389,7 +15565,7 @@ function bridgeAttachment(value: unknown): BridgeAttachment | undefined {
         validWebVNCSessionID(attachment.id) &&
         validWebVNCSessionID(attachment.agentID) &&
         typeof attachment.owner === "string" &&
-        validOptionalBridgePrincipal(attachment) &&
+        completeBridgePrincipal(attachment) &&
         typeof attachment.label === "string"
         ? attachment
         : undefined;
@@ -15420,7 +15596,8 @@ function bridgeAttachment(value: unknown): BridgeAttachment | undefined {
       if (serializedCodeViewer.auth === undefined) {
         // Old attachments had no auth binding. Treat them as GitHub sessions so the existing
         // portal-session revocation path closes them before any restored traffic is accepted.
-        return { ...serializedCodeViewer, auth: "github" };
+        const restored = { ...serializedCodeViewer, auth: "github" as const };
+        return completeBridgePrincipal(restored) ? restored : undefined;
       }
       return (serializedCodeViewer.auth === "bearer" ||
         serializedCodeViewer.auth === "github" ||
@@ -15434,13 +15611,14 @@ function bridgeAttachment(value: unknown): BridgeAttachment | undefined {
     case "egress-client":
       return typeof attachment.leaseID === "string" &&
         typeof attachment.sessionID === "string" &&
-        validOptionalEgressBridgePrincipal(attachment)
+        completeBridgePrincipal(attachment)
         ? attachment
         : undefined;
     case "runtime-adapter-agent":
       return validRuntimeAdapterID(attachment.adapterID) &&
         typeof attachment.owner === "string" &&
         typeof attachment.org === "string" &&
+        isCurrentOrgKey(attachment.org) &&
         (attachment.desktopTimeoutMs === undefined ||
           validRuntimeAdapterDesktopRelayTimeout(attachment.desktopTimeoutMs))
         ? attachment
@@ -15448,7 +15626,8 @@ function bridgeAttachment(value: unknown): BridgeAttachment | undefined {
     case "control":
       return typeof attachment.clientID === "string" &&
         typeof attachment.owner === "string" &&
-        typeof attachment.org === "string"
+        typeof attachment.org === "string" &&
+        (attachment.admin === true || isCurrentOrgKey(attachment.org))
         ? {
             ...attachment,
             subscriptions:
@@ -15471,7 +15650,8 @@ function validOptionalBridgePrincipal(value: {
   const complete =
     typeof value.owner === "string" &&
     typeof value.org === "string" &&
-    typeof value.admin === "boolean";
+    typeof value.admin === "boolean" &&
+    (value.admin || isCurrentOrgKey(value.org));
   return absent || complete;
 }
 
@@ -15483,7 +15663,8 @@ function completeBridgePrincipal(value: {
   return (
     typeof value.owner === "string" &&
     typeof value.org === "string" &&
-    typeof value.admin === "boolean"
+    typeof value.admin === "boolean" &&
+    (value.admin || isCurrentOrgKey(value.org))
   );
 }
 
@@ -15507,15 +15688,6 @@ function revocableUserBridge(attachment: BridgeAttachment): attachment is Extrac
     attachment.kind === "egress-host" ||
     attachment.kind === "egress-client"
   );
-}
-
-function validOptionalEgressBridgePrincipal(value: {
-  owner?: unknown;
-  org?: unknown;
-  admin?: unknown;
-}): boolean {
-  const legacy = value.owner === undefined && value.org === undefined && value.admin === undefined;
-  return legacy || completeBridgePrincipal(value);
 }
 
 function leaseBridgeTicketPrincipal(

--- a/worker/src/oauth.ts
+++ b/worker/src/oauth.ts
@@ -11,8 +11,8 @@ import {
   requireGitHubLoginMembership,
 } from "./github-membership";
 import { errorMessage, json, readJson } from "./http";
+import { requestOrgLabel } from "./org-identity";
 import type { Env, Provider } from "./types";
-import { requestOrg } from "./usage";
 
 const githubAuthorizeURL = "https://github.com/login/oauth/authorize";
 const githubTokenURL = "https://github.com/login/oauth/access_token";
@@ -293,12 +293,7 @@ async function githubAuthCallback(
   try {
     const accessToken = await exchangeGitHubCode(code, pending.redirectURI, env);
     const identity = await githubIdentity(accessToken);
-    const requestedOrg = requestOrg(
-      new Request(request.url, {
-        headers: { "x-crabbox-org": env.CRABBOX_DEFAULT_ORG ?? "" },
-      }),
-      env,
-    );
+    const requestedOrg = requestOrgLabel(new Request(request.url), env);
     if (githubUserIsRevoked(identity, env)) {
       throw new GitHubAuthorizationError(`GitHub user ${identity.login} has been revoked.`);
     }

--- a/worker/src/org-identity.ts
+++ b/worker/src/org-identity.ts
@@ -1,0 +1,155 @@
+import type { Env } from "./types";
+
+const currentOrgKeyPrefix = "~1.";
+const legacyOrgKeyPattern = /^[a-zA-Z0-9_.@-]{1,63}$/;
+
+export const MISSING_ORG_LABEL = "unknown";
+export const MISSING_ORG_KEY = "~0";
+
+export class InvalidOrgLabelError extends Error {
+  constructor(source = "organization") {
+    super(`${source} must be 1-63 printable ASCII characters without leading or trailing spaces`);
+    this.name = "InvalidOrgLabelError";
+  }
+}
+
+export function requestOrgLabel(request: Request, env: Pick<Env, "CRABBOX_DEFAULT_ORG">): string {
+  const source = requestOrgSource(request, env);
+  return source?.value ? validatedOrgLabel(source.value, source.name) : MISSING_ORG_LABEL;
+}
+
+export function requestOrgKey(request: Request, env: Pick<Env, "CRABBOX_DEFAULT_ORG">): string {
+  const source = requestOrgSource(request, env);
+  return source?.value
+    ? orgKeyForLabel(validatedOrgLabel(source.value, source.name))
+    : MISSING_ORG_KEY;
+}
+
+/** Stored and compared authorization identity. Use requestOrgLabel only at public boundaries. */
+export function requestOrg(request: Request, env: Pick<Env, "CRABBOX_DEFAULT_ORG">): string {
+  return requestOrgKey(request, env);
+}
+
+export function orgKeyForLabel(label: string): string {
+  const validLabel = validatedOrgLabel(label);
+  return `${currentOrgKeyPrefix}${encodeBase64URL(validLabel)}`;
+}
+
+/** Decode only canonical current keys. Legacy and malformed values return undefined. */
+export function orgLabelFromKey(key: unknown): string | undefined {
+  if (typeof key !== "string" || !key.startsWith(currentOrgKeyPrefix)) {
+    return undefined;
+  }
+  const encoded = key.slice(currentOrgKeyPrefix.length);
+  if (!encoded || !/^[a-zA-Z0-9_-]+$/.test(encoded) || encoded.length % 4 === 1) {
+    return undefined;
+  }
+  try {
+    const label = decodeBase64URL(encoded);
+    return orgKeyForLabel(label) === key ? label : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Exact label for a trusted request header; missing identity is represented by an empty value. */
+export function orgAuthLabelFromKey(key: unknown): string | undefined {
+  return key === MISSING_ORG_KEY ? "" : orgLabelFromKey(key);
+}
+
+export function orgLabelForDisplay(key: unknown): string {
+  if (key === MISSING_ORG_KEY) {
+    return MISSING_ORG_LABEL;
+  }
+  return (
+    orgLabelFromKey(key) ??
+    (typeof key === "string" && isLegacyOrgKey(key) ? key : MISSING_ORG_LABEL)
+  );
+}
+
+export function isCurrentOrgKey(key: unknown): key is string {
+  return key === MISSING_ORG_KEY || orgLabelFromKey(key) !== undefined;
+}
+
+/** Legacy identities never authorize, including against an identical legacy value. */
+export function sameOrgIdentityKey(left: string, right: string): boolean {
+  return left === right && isCurrentOrgKey(left);
+}
+
+/** Query/report filters may select an exact legacy bucket; never use this for authorization. */
+export function orgMatchesForFilter(left: string, right: string): boolean {
+  return (
+    sameOrgIdentityKey(left, right) ||
+    (isLegacyOrgKey(left) && isLegacyOrgKey(right) && left === right)
+  );
+}
+
+/**
+ * Cost limits include a legacy bucket in every identity it could have represented.
+ * This can over-count after an upgrade, but cannot let an ambiguous legacy record bypass a cap.
+ */
+export function orgMatchesForAccounting(left: string, right: string): boolean {
+  if (sameOrgIdentityKey(left, right)) {
+    return true;
+  }
+  const leftLegacy = isLegacyOrgKey(left);
+  const rightLegacy = isLegacyOrgKey(right);
+  if (leftLegacy && rightLegacy) {
+    return left === right;
+  }
+  if (!leftLegacy && !rightLegacy) {
+    return false;
+  }
+  const legacy = leftLegacy ? left : right;
+  const current = leftLegacy ? right : left;
+  const label = current === MISSING_ORG_KEY ? MISSING_ORG_LABEL : orgLabelFromKey(current);
+  return label !== undefined && legacyOrgKey(label) === legacy;
+}
+
+function requestOrgSource(
+  request: Request,
+  env: Pick<Env, "CRABBOX_DEFAULT_ORG">,
+): { value: string; name: string } | undefined {
+  const header = request.headers.get("x-crabbox-org");
+  if (header !== null) {
+    return { value: header, name: "x-crabbox-org" };
+  }
+  if (env.CRABBOX_DEFAULT_ORG) {
+    return { value: env.CRABBOX_DEFAULT_ORG, name: "CRABBOX_DEFAULT_ORG" };
+  }
+  return undefined;
+}
+
+function validatedOrgLabel(value: string, source?: string): string {
+  const printableASCII = [...value].every((character) => {
+    const code = character.charCodeAt(0);
+    return code >= 0x20 && code <= 0x7e;
+  });
+  if (
+    value.length < 1 ||
+    value.length > 63 ||
+    value.startsWith(" ") ||
+    value.endsWith(" ") ||
+    !printableASCII
+  ) {
+    throw new InvalidOrgLabelError(source);
+  }
+  return value;
+}
+
+export function isLegacyOrgKey(value: string): boolean {
+  return legacyOrgKeyPattern.test(value);
+}
+
+function legacyOrgKey(value: string): string {
+  return value.replaceAll(/[^a-zA-Z0-9_.@-]/g, "_").slice(0, 63) || MISSING_ORG_LABEL;
+}
+
+function encodeBase64URL(value: string): string {
+  return btoa(value).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
+}
+
+function decodeBase64URL(value: string): string {
+  const base64 = value.replaceAll("-", "+").replaceAll("_", "/");
+  return atob(base64.padEnd(Math.ceil(base64.length / 4) * 4, "="));
+}

--- a/worker/src/org-records.ts
+++ b/worker/src/org-records.ts
@@ -1,0 +1,78 @@
+import {
+  MISSING_ORG_KEY,
+  isCurrentOrgKey,
+  isLegacyOrgKey,
+  orgLabelForDisplay,
+} from "./org-identity";
+import type { ExternalRunnerRecord, LeaseRecord, ReadyPoolEntry, RunRecord } from "./types";
+
+export type PortalOrgKind = "missing" | "legacy" | "unsupported";
+export type PortalLeaseRecord = LeaseRecord & { portalOrgKind?: PortalOrgKind };
+export type PortalExternalRunnerRecord = ExternalRunnerRecord & {
+  portalOrgKind?: PortalOrgKind;
+};
+
+export function publicLeaseRecord(record: LeaseRecord): LeaseRecord {
+  return {
+    ...record,
+    org: orgLabelForDisplay(record.org),
+  };
+}
+
+export function publicRunRecord(record: RunRecord): RunRecord {
+  const publicRecord = {
+    ...record,
+    org: orgLabelForDisplay(record.org),
+  };
+  if (!record.leaseOwners) {
+    return publicRecord;
+  }
+  return {
+    ...publicRecord,
+    leaseOwners: record.leaseOwners.map((owner) => ({
+      ...owner,
+      org: orgLabelForDisplay(owner.org),
+    })),
+  };
+}
+
+export function publicReadyPoolEntry(entry: ReadyPoolEntry): ReadyPoolEntry {
+  return {
+    ...entry,
+    org: orgLabelForDisplay(entry.org),
+  };
+}
+
+export function publicExternalRunnerRecord(record: ExternalRunnerRecord): ExternalRunnerRecord {
+  return {
+    ...record,
+    org: orgLabelForDisplay(record.org),
+  };
+}
+
+/** Portal rows carry a non-secret identity kind so display labels never drive authorization links. */
+export function portalLeaseRecord(record: LeaseRecord): PortalLeaseRecord {
+  const publicRecord = {
+    ...record,
+    org: orgLabelForDisplay(record.org),
+  };
+  const portalOrgKind = portalOrgKindForKey(record.org);
+  return portalOrgKind ? { ...publicRecord, portalOrgKind } : publicRecord;
+}
+
+export function portalExternalRunnerRecord(
+  record: ExternalRunnerRecord,
+): PortalExternalRunnerRecord {
+  const publicRecord = {
+    ...record,
+    org: orgLabelForDisplay(record.org),
+  };
+  const portalOrgKind = portalOrgKindForKey(record.org);
+  return portalOrgKind ? { ...publicRecord, portalOrgKind } : publicRecord;
+}
+
+function portalOrgKindForKey(key: string): PortalOrgKind | undefined {
+  if (key === MISSING_ORG_KEY) return "missing";
+  if (isCurrentOrgKey(key)) return undefined;
+  return isLegacyOrgKey(key) ? "legacy" : "unsupported";
+}

--- a/worker/src/portal.ts
+++ b/worker/src/portal.ts
@@ -1,3 +1,4 @@
+import type { PortalExternalRunnerRecord, PortalLeaseRecord } from "./org-records";
 import type {
   ExternalRunnerRecord,
   LeaseRecord,
@@ -64,7 +65,7 @@ export interface PortalMacHostRecord {
   instanceType: string;
   autoPlacement: string;
   allocationTime?: string;
-  lease?: LeaseRecord;
+  lease?: PortalLeaseRecord;
 }
 
 export interface PortalAdminProviderStatus {
@@ -119,8 +120,8 @@ export interface PortalAdminView {
 export type PortalAdminTab = "health" | "leases" | "users";
 
 export function portalHome(
-  leases: LeaseRecord[],
-  runners: ExternalRunnerRecord[],
+  leases: PortalLeaseRecord[],
+  runners: PortalExternalRunnerRecord[],
   request: Request,
   macHosts: PortalMacHostRecord[] = [],
   manageableLeaseIDs: ReadonlySet<string> = new Set(),
@@ -2145,7 +2146,7 @@ function shellArg(value: string): string {
 }
 
 function leaseRow(
-  lease: LeaseRecord,
+  lease: PortalLeaseRecord,
   context: { admin: boolean; owner: string; org: string; canManage: boolean },
 ): string {
   const label = lease.slug || lease.id;
@@ -2442,7 +2443,7 @@ function macHostStateTone(value: string): "ok" | "warn" | "bad" {
 }
 
 function externalRunnerLeaseRow(
-  runner: ExternalRunnerRecord,
+  runner: PortalExternalRunnerRecord,
   context: { admin: boolean; owner: string; org: string },
 ): string {
   const ownership = context.admin ? runnerOwnership(runner, context.owner, context.org) : "mine";
@@ -2489,7 +2490,7 @@ function externalRunnerLeaseRow(
 }
 
 function externalRunnerDetailPath(
-  runner: ExternalRunnerRecord,
+  runner: PortalExternalRunnerRecord,
   context?: { admin: boolean; owner: string; org: string },
 ): string {
   const path = `/portal/runners/${encodeURIComponent(runner.provider)}/${encodeURIComponent(runner.id)}`;
@@ -2498,7 +2499,14 @@ function externalRunnerDetailPath(
   }
   const params = new URLSearchParams();
   params.set("owner", runner.owner);
-  params.set("org", runner.org);
+  if (runner.portalOrgKind === "missing" || runner.portalOrgKind === "unsupported") {
+    params.set("orgKind", runner.portalOrgKind);
+  } else {
+    params.set("org", runner.org);
+    if (runner.portalOrgKind === "legacy") {
+      params.set("orgKind", runner.portalOrgKind);
+    }
+  }
   return `${path}?${params.toString()}`;
 }
 
@@ -2651,16 +2659,28 @@ function portalLogoutButton(): string {
   return `<form method="post" action="/portal/logout"><button class="button secondary" type="submit">log out</button></form>`;
 }
 
-function leaseOwnership(lease: LeaseRecord, owner: string, org: string): "mine" | "system" {
-  return lease.owner === owner && lease.org === org ? "mine" : "system";
+function leaseOwnership(lease: PortalLeaseRecord, owner: string, org: string): "mine" | "system" {
+  const orgMatches = lease.portalOrgKind === "missing" ? org === "" : lease.org === org;
+  return lease.portalOrgKind !== "legacy" &&
+    lease.portalOrgKind !== "unsupported" &&
+    lease.owner === owner &&
+    orgMatches
+    ? "mine"
+    : "system";
 }
 
 function runnerOwnership(
-  runner: ExternalRunnerRecord,
+  runner: PortalExternalRunnerRecord,
   owner: string,
   org: string,
 ): "mine" | "system" {
-  return runner.owner === owner && runner.org === org ? "mine" : "system";
+  const orgMatches = runner.portalOrgKind === "missing" ? org === "" : runner.org === org;
+  return runner.portalOrgKind !== "legacy" &&
+    runner.portalOrgKind !== "unsupported" &&
+    runner.owner === owner &&
+    orgMatches
+    ? "mine"
+    : "system";
 }
 
 function runnerSortTime(runner: ExternalRunnerRecord): string {

--- a/worker/src/usage.ts
+++ b/worker/src/usage.ts
@@ -1,4 +1,7 @@
+import { orgLabelForDisplay, orgMatchesForAccounting, orgMatchesForFilter } from "./org-identity";
 import type { Env, LeaseRecord, Provider } from "./types";
+
+export { requestOrg, requestOrgKey, requestOrgLabel } from "./org-identity";
 
 export interface LeaseCost {
   hourlyUSD: number;
@@ -72,17 +75,6 @@ const defaultHourlyUSD: Record<string, number> = {
   "aws:c7a.48xlarge": 9.0,
 };
 
-export function requestOrg(request: Request, env: Pick<Env, "CRABBOX_DEFAULT_ORG">): string {
-  const header = request.headers.get("x-crabbox-org")?.trim();
-  if (header) {
-    return sanitizeOrg(header);
-  }
-  if (env.CRABBOX_DEFAULT_ORG) {
-    return sanitizeOrg(env.CRABBOX_DEFAULT_ORG);
-  }
-  return "unknown";
-}
-
 export function leaseCost(
   env: Pick<Env, "CRABBOX_COST_RATES_JSON">,
   provider: Provider,
@@ -121,7 +113,7 @@ export function enforceCostLimits(
   const managedLeases = leases.filter(isManagedLease);
   const active = managedLeases.filter((lease) => isActiveLease(lease, now));
   const ownerActive = active.filter((lease) => lease.owner === candidate.owner);
-  const orgActive = active.filter((lease) => lease.org === candidate.org);
+  const orgActive = active.filter((lease) => orgMatchesForAccounting(lease.org, candidate.org));
   if (limits.maxActiveLeases > 0 && active.length + 1 > limits.maxActiveLeases) {
     return `active lease limit exceeded: ${active.length + 1}/${limits.maxActiveLeases}`;
   }
@@ -140,7 +132,7 @@ export function enforceCostLimits(
     { scope: "user", owner: candidate.owner, month },
     now,
   );
-  const orgUsage = usageSummary(managedLeases, { scope: "org", org: candidate.org, month }, now);
+  const orgUsage = orgUsageForAccounting(managedLeases, candidate.org, month, now);
   if (overBudget(allUsage.reservedUSD + candidate.maxEstimatedUSD, limits.maxMonthlyUSD)) {
     return `monthly budget exceeded: ${formatUSD(allUsage.reservedUSD + candidate.maxEstimatedUSD)}/${formatUSD(limits.maxMonthlyUSD)}`;
   }
@@ -177,7 +169,10 @@ export function usageSummary(leases: LeaseRecord[], filter: UsageFilter, now: Da
     scope: filter.scope,
     ...finalize(total),
     byOwner: finalizeGroups(byOwner),
-    byOrg: finalizeGroups(byOrg),
+    byOrg: finalizeGroups(byOrg).map((group) => ({
+      ...group,
+      key: orgLabelForDisplay(group.key),
+    })),
     byProvider: finalizeGroups(byProvider),
     byServerType: finalizeGroups(byServerType),
   };
@@ -185,7 +180,7 @@ export function usageSummary(leases: LeaseRecord[], filter: UsageFilter, now: Da
     summary.owner = filter.owner;
   }
   if (filter.org) {
-    summary.org = filter.org;
+    summary.org = orgLabelForDisplay(filter.org);
   }
   return summary;
 }
@@ -233,13 +228,29 @@ function leaseMatchesUsageFilter(lease: LeaseRecord, filter: UsageFilter): boole
   }
   if (filter.scope === "user") {
     return (
-      (!filter.owner || lease.owner === filter.owner) && (!filter.org || lease.org === filter.org)
+      (!filter.owner || lease.owner === filter.owner) &&
+      (!filter.org || orgMatchesForFilter(lease.org, filter.org))
     );
   }
   if (filter.scope === "org") {
-    return !filter.org || lease.org === filter.org;
+    return !filter.org || orgMatchesForFilter(lease.org, filter.org);
   }
   return true;
+}
+
+function orgUsageForAccounting(
+  leases: LeaseRecord[],
+  org: string,
+  month: string,
+  now: Date,
+): UsageAccumulator {
+  const usage = newAccumulator();
+  for (const lease of leases) {
+    if (monthKey(new Date(lease.createdAt)) === month && orgMatchesForAccounting(lease.org, org)) {
+      addUsage(usage, leaseUsage(lease, now));
+    }
+  }
+  return usage;
 }
 
 function leaseUsage(lease: LeaseRecord, now: Date): UsageAccumulator {
@@ -353,10 +364,6 @@ function parseTime(value: string, fallback: Date): Date {
 
 function monthKey(date: Date): string {
   return date.toISOString().slice(0, 7);
-}
-
-function sanitizeOrg(value: string): string {
-  return value.replaceAll(/[^a-zA-Z0-9_.@-]/g, "_").slice(0, 63) || "unknown";
 }
 
 function roundUSD(value: number): number {

--- a/worker/test/coordinator-runtime.test.ts
+++ b/worker/test/coordinator-runtime.test.ts
@@ -11,8 +11,11 @@ import {
 } from "../src/coordinator-runtime";
 import { FleetCoordinator } from "../src/fleet";
 import { githubAuthRoute } from "../src/oauth";
+import { orgKeyForLabel } from "../src/org-identity";
 import { runtimeAdapterRelayFrameLimit } from "../src/runtime-adapter-relay";
 import type { Env, LeaseRecord } from "../src/types";
+
+const exampleOrgKey = orgKeyForLabel("example-org");
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -204,7 +207,7 @@ describe("coordinator runtimes", () => {
       target: "linux",
       cloudID: "external-shared-egress",
       owner: "owner@example.com",
-      org: "example-org",
+      org: exampleOrgKey,
       share: { users: { "manager@example.com": "manage" } },
       profile: "default",
       class: "default",
@@ -261,7 +264,7 @@ describe("coordinator runtimes", () => {
       leaseID: lease.id,
       sessionID: "egress_accepted",
       owner: "manager@example.com",
-      org: "example-org",
+      org: exampleOrgKey,
       admin: false,
     });
 
@@ -351,7 +354,7 @@ describe("coordinator runtimes", () => {
       target: "linux",
       cloudID: "external-shared-bridges",
       owner: "owner@example.com",
-      org: "example-org",
+      org: exampleOrgKey,
       share: { users: { "manager@example.com": "manage" } },
       profile: "default",
       class: "default",
@@ -420,7 +423,7 @@ describe("coordinator runtimes", () => {
       kind: "webvnc-agent",
       leaseID: lease.id,
       owner: "manager@example.com",
-      org: "example-org",
+      org: exampleOrgKey,
       admin: false,
     });
 
@@ -430,7 +433,7 @@ describe("coordinator runtimes", () => {
       kind: "code-agent",
       leaseID: lease.id,
       owner: "manager@example.com",
-      org: "example-org",
+      org: exampleOrgKey,
       admin: false,
     });
 
@@ -439,7 +442,7 @@ describe("coordinator runtimes", () => {
       kind: "webvnc-agent",
       leaseID: lease.id,
       owner: "admin@example.com",
-      org: "example-org",
+      org: exampleOrgKey,
       admin: true,
       auth: "bearer",
       adminGrantVersion: currentGrantVersion,
@@ -449,7 +452,7 @@ describe("coordinator runtimes", () => {
       kind: "code-agent",
       leaseID: lease.id,
       owner: "admin@example.com",
-      org: "example-org",
+      org: exampleOrgKey,
       admin: true,
       auth: "bearer",
       adminGrantVersion: currentGrantVersion,

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -35,6 +35,7 @@ import {
   type WebVNCBuffer,
 } from "../src/fleet";
 import { HetznerClient, HetznerProvisioningError } from "../src/hetzner";
+import { MISSING_ORG_KEY, isCurrentOrgKey, orgKeyForLabel } from "../src/org-identity";
 import { portalCode } from "../src/portal";
 import {
   ProviderProvisioningCleanupError,
@@ -61,6 +62,36 @@ import type {
 afterEach(() => {
   vi.unstubAllGlobals();
 });
+
+function currentOrgFixture<T>(value: T): T {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return value;
+  const record = value as Record<string, unknown>;
+  const org = record.org;
+  const leaseOwners = record.leaseOwners;
+  const currentOrg =
+    typeof org === "string" && !isCurrentOrgKey(org)
+      ? org
+        ? orgKeyForLabel(org)
+        : MISSING_ORG_KEY
+      : org;
+  const currentLeaseOwners = Array.isArray(leaseOwners)
+    ? leaseOwners.map((owner) => currentOrgFixture(owner))
+    : leaseOwners;
+  if (currentOrg === org && currentLeaseOwners === leaseOwners) return value;
+  return {
+    ...record,
+    ...(currentOrg === undefined ? {} : { org: currentOrg }),
+    ...(currentLeaseOwners === undefined ? {} : { leaseOwners: currentLeaseOwners }),
+  } as T;
+}
+
+function workspaceFixtureKey(
+  workspaceID: string,
+  owner = "alice@example.com",
+  org = "example-org",
+): string {
+  return `workspace:${orgKeyForLabel(org)}:${encodeURIComponent(owner)}:${workspaceID}`;
+}
 
 class MemoryStorage {
   private readonly values = new Map<string, unknown>();
@@ -120,7 +151,7 @@ class MemoryStorage {
   }
 
   seed<T>(key: string, value: T): void {
-    this.values.set(key, value);
+    this.values.set(key, currentOrgFixture(value));
   }
 
   value<T>(key: string): T | undefined {
@@ -192,8 +223,8 @@ class FakeWebSocket {
   private readonly sent: string[] = [];
   onSend?: (data: string) => void;
 
-  constructor(attachment?: unknown) {
-    this.attachment = attachment;
+  constructor(attachment?: unknown, options: { legacyOrg?: boolean } = {}) {
+    this.attachment = options.legacyOrg ? attachment : currentOrgFixture(attachment);
   }
 
   send(data: string): void {
@@ -1187,9 +1218,13 @@ describe("runtime adapter relay", () => {
     );
 
     expect((await fleet.fetch(request("GET", "/v1/health"))).status).toBe(200);
-    for (const socket of [...revoked, ...legacy]) {
+    for (const socket of revoked) {
       expect(socket.closeCode).toBe(1008);
       expect(socket.closeReason).toBe("lease access revoked");
+    }
+    for (const socket of legacy) {
+      expect(socket.closeCode).toBe(1012);
+      expect(socket.closeReason).toBe("coordinator restarted");
     }
     for (const socket of admin) {
       expect(socket.closeCode).toBeUndefined();
@@ -1397,8 +1432,8 @@ describe("runtime adapter relay", () => {
     expect((await fleet.fetch(request("GET", "/v1/health"))).status).toBe(200);
     expect(viewer.closeCode).toBe(1008);
     expect(viewer.closeReason).toBe("portal session ended");
-    expect(legacyViewer.closeCode).toBe(1008);
-    expect(legacyViewer.closeReason).toBe("lease access revoked");
+    expect(legacyViewer.closeCode).toBe(1012);
+    expect(legacyViewer.closeReason).toBe("coordinator restarted");
     expect(agent.sentJSON()).toEqual([
       {
         type: "ws_close",
@@ -1406,18 +1441,12 @@ describe("runtime adapter relay", () => {
         code: 1008,
         reason: "portal session ended",
       },
-      {
-        type: "ws_close",
-        id: "viewer-legacy",
-        code: 1008,
-        reason: "lease access revoked",
-      },
     ]);
     const relay = fleet as unknown as { codeViewers: Map<string, WebSocket> };
     expect(relay.codeViewers.size).toBe(0);
 
     await fleet.webSocketMessage(viewer as unknown as WebSocket, "post-logout-frame");
-    expect(agent.sentJSON()).toHaveLength(2);
+    expect(agent.sentJSON()).toHaveLength(1);
   });
 
   it("rejects restored shared-token bridges after credential rotation", async () => {
@@ -1607,6 +1636,8 @@ describe("runtime adapter relay", () => {
       id: "viewer_revoked",
       agentID: "agent_revoked",
       owner: "revoked@example.com",
+      org: "other-org",
+      admin: false,
       label: "revoked@example.com",
     });
     const retainedWebAgent = new FakeWebSocket({
@@ -1671,9 +1702,9 @@ describe("runtime adapter relay", () => {
     expect(retainedWebViewer.closeCode).toBe(1008);
     expect(retainedWebViewer.closeReason).toBe("bridge authentication expired");
     expect(retainedWebAgent.closeCode).toBe(1011);
-    expect(legacyOwnerWebViewer.closeCode).toBe(1008);
-    expect(legacyOwnerWebViewer.closeReason).toBe("lease access revoked");
-    expect(legacyOwnerWebAgent.closeCode).toBe(1011);
+    expect(legacyOwnerWebViewer.closeCode).toBe(1012);
+    expect(legacyOwnerWebViewer.closeReason).toBe("coordinator restarted");
+    expect(legacyOwnerWebAgent.closeCode).toBeUndefined();
     expect(codeAgent.sentJSON()).toEqual([
       {
         type: "ws_close",
@@ -1853,7 +1884,7 @@ describe("runtime adapter relay", () => {
     expect(storage.value("runtime-adapter-identity:example-adapter")).toMatchObject({
       adapterID: "example-adapter",
       owner: "alice@example.com",
-      org: "example-org",
+      org: orgKeyForLabel("example-org"),
       claimVersion: 1,
       claimState: "provisional",
       claimExpiresAt: expect.any(String),
@@ -2186,7 +2217,7 @@ describe("runtime adapter relay", () => {
     expect(recovered.status).toBe(200);
     expect(recoverableStorage.value("runtime-adapter-identity:recoverable-adapter")).toMatchObject({
       owner: "mallory@example.com",
-      org: "example-org",
+      org: orgKeyForLabel("example-org"),
       claimVersion: 1,
       claimState: "provisional",
       claimExpiresAt: expect.any(String),
@@ -2208,10 +2239,15 @@ describe("runtime adapter relay", () => {
       ...expiredRuntimeAdapterClaim("fresh-adapter"),
       claimExpiresAt: new Date(Date.now() + 60_000).toISOString(),
     });
+    await durableStorage.put("runtime-adapter-identity:future-adapter", {
+      ...expiredRuntimeAdapterClaim("future-adapter"),
+      org: "~2.future-key",
+    });
     const durableFleet = testFleet(durableStorage);
     await expectConflict(durableFleet, "legacy-adapter");
     await expectConflict(durableFleet, "confirmed-adapter");
     await expectConflict(durableFleet, "fresh-adapter");
+    await expectConflict(durableFleet, "future-adapter");
 
     const ticketStorage = new MemoryStorage();
     ticketStorage.seed(
@@ -3618,6 +3654,9 @@ describe("runtime adapter relay", () => {
       kind: "egress-host",
       leaseID: lease.id,
       sessionID: "restored-expired-session",
+      owner: lease.owner,
+      org: "example-org",
+      admin: false,
     });
     const fleet = new FleetDurableObject(
       {
@@ -5765,7 +5804,7 @@ describe("fleet lease identity and idle", () => {
     expect(storage.alarm()).toBeUndefined();
   });
 
-  it("skips broker selector restrictions for internal workspace provisioning", async () => {
+  it("provisions missing-org workspaces without applying broker selector restrictions", async () => {
     let created = false;
     let restrictionChecks = 0;
     const fleet = testFleet(
@@ -5785,6 +5824,7 @@ describe("fleet lease identity and idle", () => {
         ),
       },
       {
+        CRABBOX_DEFAULT_ORG: "",
         CRABBOX_WORKSPACE_PROVIDER: "aws",
         CRABBOX_WORKSPACE_SSH_PUBLIC_KEY: "ssh-ed25519 workspace-selector-test",
         CRABBOX_WORKSPACE_SSH_PRIVATE_KEY: "workspace-private-key",
@@ -5795,7 +5835,7 @@ describe("fleet lease identity and idle", () => {
       request("POST", "/v1/workspaces", {
         headers: {
           "x-crabbox-owner": "alice@example.com",
-          "x-crabbox-org": "example-org",
+          "x-crabbox-org": "",
         },
         body: {
           id: "selector-policy-workspace",
@@ -6008,7 +6048,7 @@ describe("fleet lease identity and idle", () => {
       request("POST", `/v1/leases/${lease.id}/release`, {
         headers: {
           "x-crabbox-owner": lease.owner,
-          "x-crabbox-org": lease.org,
+          "x-crabbox-org": "example-org",
         },
         body: { delete: true },
       }),
@@ -6206,9 +6246,8 @@ describe("fleet lease identity and idle", () => {
     expect(createdHostPrivateKey).toContain("BEGIN OPENSSH PRIVATE KEY");
     expect(createdHostPublicKey).toMatch(/^ssh-ed25519 /);
     expect(
-      storage.value<{ sshHostKeySha256?: string }>(
-        "workspace:example-org:alice%40example.com:fleet-is-101",
-      )?.sshHostKeySha256,
+      storage.value<{ sshHostKeySha256?: string }>(workspaceFixtureKey("fleet-is-101"))
+        ?.sshHostKeySha256,
     ).toMatch(/^[a-f0-9]{64}$/);
     const ready = await fleet.fetch(request("GET", `/v1/workspaces/${body.id}`, { headers }));
     const readyBody = (await ready.json()) as {
@@ -6323,7 +6362,7 @@ describe("fleet lease identity and idle", () => {
       workspaceID: body.id,
       leaseID: created.providerResourceId,
     });
-    const nativeVNCConnectionKey = "workspace:example-org:alice%40example.com:fleet-is-101";
+    const nativeVNCConnectionKey = workspaceFixtureKey("fleet-is-101");
     const nativeVNCInternals = fleet as unknown as {
       workspaceTerminals: Map<string, Set<WebSocket>>;
     };
@@ -6400,16 +6439,13 @@ describe("fleet lease identity and idle", () => {
       status: "ready",
     });
     expect(
-      storage.value<{ desktopCapabilityVersion?: number }>(
-        "workspace:example-org:alice%40example.com:fleet-is-101",
-      )?.desktopCapabilityVersion,
+      storage.value<{ desktopCapabilityVersion?: number }>(workspaceFixtureKey("fleet-is-101"))
+        ?.desktopCapabilityVersion,
     ).toBe(1);
 
     const legacyID = "fleet-legacy-desktop";
-    storage.seed(`workspace:example-org:alice%40example.com:${legacyID}`, {
-      ...storage.value<Record<string, unknown>>(
-        "workspace:example-org:alice%40example.com:fleet-is-101",
-      ),
+    storage.seed(workspaceFixtureKey(legacyID), {
+      ...storage.value<Record<string, unknown>>(workspaceFixtureKey("fleet-is-101")),
       id: legacyID,
       leaseID: "cbx_legacydesktop",
       desktop: false,
@@ -6481,9 +6517,7 @@ describe("fleet lease identity and idle", () => {
       id: "fleet-maintenance-failure",
       status: "provisioning",
     });
-    expect(
-      storage.value("workspace:example-org:alice%40example.com:fleet-maintenance-failure"),
-    ).toBeDefined();
+    expect(storage.value(workspaceFixtureKey("fleet-maintenance-failure"))).toBeDefined();
   });
 
   it("keeps an organization-wide workspace spare while demand is active", async () => {
@@ -6572,7 +6606,7 @@ describe("fleet lease identity and idle", () => {
     expect(storage.value<LeaseRecord>(`lease:${warmLeaseID}`)).toMatchObject({
       owner: "bob@example.com",
       providerOwner: "crabbox-internal-prewarm",
-      org: "example-org",
+      org: orgKeyForLabel("example-org"),
       workspaceID: "fleet-prewarm-bob",
     });
 
@@ -6940,11 +6974,11 @@ describe("fleet lease identity and idle", () => {
       "x-crabbox-org": "example-org",
     };
     const now = new Date().toISOString();
-    storage.seed("workspace:example-org:alice%40example.com:fleet-is-103", {
+    storage.seed(workspaceFixtureKey("fleet-is-103"), {
       id: "fleet-is-103",
       leaseID: "cbx_abcdef123456",
       owner: "alice@example.com",
-      org: "example-org",
+      org: orgKeyForLabel("example-org"),
       profile: "default",
       provider: "hetzner",
       class: "standard",
@@ -6985,7 +7019,7 @@ describe("fleet lease identity and idle", () => {
     const configuredSecret = "configured-workspace-secret";
     const reflectedSecret = "legacy-workspace-secret";
     const now = new Date().toISOString();
-    storage.seed("workspace:example-org:alice%40example.com:fleet-is-redacted", {
+    storage.seed(workspaceFixtureKey("fleet-is-redacted"), {
       id: "fleet-is-redacted",
       leaseID: "cbx_abcdef123456",
       owner: "alice@example.com",
@@ -7043,7 +7077,7 @@ describe("fleet lease identity and idle", () => {
       { CRABBOX_WORKSPACE_SSH_PUBLIC_KEY: "ssh-ed25519 workspace-test" },
     );
     const claimExpiresAt = new Date(Date.now() + 60_000).toISOString();
-    storage.seed("workspace:example-org:alice%40example.com:fleet-is-121", {
+    storage.seed(workspaceFixtureKey("fleet-is-121"), {
       id: "fleet-is-121",
       leaseID: "cbx_abcdef123456",
       owner: "alice@example.com",
@@ -7079,7 +7113,7 @@ describe("fleet lease identity and idle", () => {
       { CRABBOX_WORKSPACE_SSH_PUBLIC_KEY: "ssh-ed25519 workspace-test" },
     );
     const now = new Date().toISOString();
-    const workspaceKey = "workspace:example-org:alice%40example.com:fleet-is-123";
+    const workspaceKey = workspaceFixtureKey("fleet-is-123");
     storage.seed(workspaceKey, {
       id: "fleet-is-123",
       leaseID: "cbx_abcdef123456",
@@ -7152,7 +7186,7 @@ describe("fleet lease identity and idle", () => {
       }),
     });
     const old = new Date(Date.now() - 20 * 60_000).toISOString();
-    const workspaceKey = "workspace:example-org:alice%40example.com:fleet-is-124";
+    const workspaceKey = workspaceFixtureKey("fleet-is-124");
     storage.seed(workspaceKey, {
       id: "fleet-is-124",
       leaseID: "cbx_abcdef123456",
@@ -7212,7 +7246,7 @@ describe("fleet lease identity and idle", () => {
       { CRABBOX_WORKSPACE_SSH_PUBLIC_KEY: "ssh-ed25519 workspace-test" },
     );
     const old = new Date(Date.now() - 20 * 60_000).toISOString();
-    const workspaceKey = `workspace:example-org:alice%40example.com:${testCase.id}`;
+    const workspaceKey = workspaceFixtureKey(testCase.id);
     storage.seed(workspaceKey, {
       id: testCase.id,
       leaseID: "cbx_abcdef123456",
@@ -7288,7 +7322,7 @@ describe("fleet lease identity and idle", () => {
     });
     const now = new Date().toISOString();
     const claimExpiresAt = new Date(Date.now() + 60_000).toISOString();
-    storage.seed("workspace:example-org:alice%40example.com:fleet-is-125", {
+    storage.seed(workspaceFixtureKey("fleet-is-125"), {
       id: "fleet-is-125",
       leaseID: "cbx_abcdef123456",
       owner: "alice@example.com",
@@ -7336,7 +7370,7 @@ describe("fleet lease identity and idle", () => {
   it("does not start provider provisioning after workspace release wins", async () => {
     const storage = new MemoryStorage();
     let providerCreates = 0;
-    const workspaceKey = "workspace:example-org:alice%40example.com:fleet-is-126";
+    const workspaceKey = workspaceFixtureKey("fleet-is-126");
     const fleet = testFleet(
       storage,
       {
@@ -7387,7 +7421,7 @@ describe("fleet lease identity and idle", () => {
   it("revokes workspace terminals from the shared release transition", async () => {
     const storage = new MemoryStorage();
     const fleet = testFleet(storage);
-    const key = "workspace:example-org:alice%40example.com:fleet-is-127";
+    const key = workspaceFixtureKey("fleet-is-127");
     const now = new Date().toISOString();
     const lease = testLease({
       id: "cbx_abcdef123457",
@@ -7442,7 +7476,7 @@ describe("fleet lease identity and idle", () => {
         CRABBOX_WORKSPACE_SSH_PRIVATE_KEY: "workspace-private-key",
       },
     );
-    const key = "workspace:example-org:alice%40example.com:fleet-is-128";
+    const key = workspaceFixtureKey("fleet-is-128");
     const now = new Date().toISOString();
     const lease = testLease({
       id: "cbx_abcdef123458",
@@ -7492,7 +7526,7 @@ describe("fleet lease identity and idle", () => {
           connection: "upgrade",
           upgrade: "websocket",
           "x-crabbox-owner": lease.owner,
-          "x-crabbox-org": lease.org,
+          "x-crabbox-org": "example-org",
         },
       }),
     );
@@ -7643,9 +7677,7 @@ describe("fleet lease identity and idle", () => {
 
     const pending = await fleet.fetch(request("GET", `/v1/workspaces/${body.id}`, { headers }));
     await expect(pending.json()).resolves.toMatchObject({ status: "provisioning" });
-    const workspace = storage.value<Record<string, unknown>>(
-      "workspace:example-org:alice%40example.com:fleet-is-116",
-    )!;
+    const workspace = storage.value<Record<string, unknown>>(workspaceFixtureKey("fleet-is-116"))!;
     expect(workspace["error"]).toBeUndefined();
     expect(Date.parse(String(workspace["reconcileAfter"]))).toBeGreaterThan(Date.now());
     expect(storage.alarm()).toBe(Date.parse(String(workspace["reconcileAfter"])));
@@ -7664,7 +7696,7 @@ describe("fleet lease identity and idle", () => {
       { CRABBOX_WORKSPACE_SSH_PUBLIC_KEY: "ssh-ed25519 workspace-test" },
     );
     const createdAt = new Date(Date.now() - 16 * 60_000).toISOString();
-    storage.seed("workspace:example-org:alice%40example.com:fleet-is-130", {
+    storage.seed(workspaceFixtureKey("fleet-is-130"), {
       id: "fleet-is-130",
       leaseID: "cbx_abcdef123456",
       owner: "alice@example.com",
@@ -7890,7 +7922,7 @@ describe("fleet lease identity and idle", () => {
     );
     const now = new Date().toISOString();
     const expiresAt = new Date(Date.now() - 1_000).toISOString();
-    storage.seed("workspace:example-org:alice%40example.com:fleet-is-106", {
+    storage.seed(workspaceFixtureKey("fleet-is-106"), {
       id: "fleet-is-106",
       leaseID,
       owner: "alice@example.com",
@@ -8062,7 +8094,7 @@ describe("fleet lease identity and idle", () => {
     leaseID = pending.providerResourceId;
 
     await fleet.alarm();
-    const workspaceKey = "workspace:example-org:alice%40example.com:fleet-is-112";
+    const workspaceKey = workspaceFixtureKey("fleet-is-112");
     const recovering = await fleet.fetch(request("GET", `/v1/workspaces/${body.id}`, { headers }));
     await expect(recovering.json()).resolves.toMatchObject({
       status: "provisioning",
@@ -8096,6 +8128,121 @@ describe("fleet lease identity and idle", () => {
       status: "stopped",
     });
     expect(providerReleases).toBe(1);
+  });
+
+  it("quarantines legacy workspaces and cleans recoverable and prewarmed resources", async () => {
+    const storage = new MemoryStorage();
+    const now = new Date().toISOString();
+    const legacyOrg = "science_team";
+    const recoveredLeaseID = "cbx_abcdef000001";
+    const prewarmLeaseID = "cbx_abcdef000002";
+    let creates = 0;
+    let recoveries = 0;
+    const releases: string[] = [];
+    const fleet = testFleet(
+      storage,
+      {
+        hetzner: fakeProvider(
+          () => {
+            creates += 1;
+          },
+          {
+            provider: "hetzner",
+            onRecoverServer(lease) {
+              recoveries += 1;
+              expect(lease.id).toBe(recoveredLeaseID);
+              return {
+                provider: "hetzner",
+                id: 777,
+                cloudID: "777",
+                name: "crabbox-legacy-recovery",
+                status: "running",
+                serverType: "cpx62",
+                host: "192.0.2.112",
+                labels: { lease: lease.id },
+              };
+            },
+            onReleaseLease(lease) {
+              releases.push(lease.id);
+            },
+          },
+        ),
+      },
+      {
+        CRABBOX_WORKSPACE_PREWARM_COUNT: "1",
+        CRABBOX_WORKSPACE_SSH_PUBLIC_KEY: "ssh-ed25519 workspace-test",
+      },
+    );
+    const workspace = (id: string, leaseID: string, owner: string, prewarm = false) => ({
+      id,
+      leaseID,
+      owner,
+      org: legacyOrg,
+      profile: "default",
+      provider: "hetzner" as const,
+      class: "standard",
+      desktop: false,
+      ttlSeconds: 1800,
+      idleTimeoutSeconds: 360,
+      createdAt: now,
+      updatedAt: now,
+      ...(prewarm ? { prewarm: true } : {}),
+    });
+    const recoveredWorkspace = workspace("legacy-recovery", recoveredLeaseID, "alice@example.com");
+    const prewarmWorkspace = workspace(
+      "legacy-prewarm",
+      prewarmLeaseID,
+      "prewarm@example.com",
+      true,
+    );
+    const legacyLease = (id: string, workspaceID: string, owner: string) => ({
+      ...testLease({
+        id,
+        workspaceID,
+        owner,
+        state: "active",
+        cloudID: "888",
+        serverID: 888,
+        expiresAt: new Date(Date.now() + 30 * 60 * 1000).toISOString(),
+      }),
+      org: legacyOrg,
+    });
+    await Promise.all([
+      storage.put(
+        `workspace:${legacyOrg}:alice%40example.com:${recoveredWorkspace.id}`,
+        recoveredWorkspace,
+      ),
+      storage.put(
+        `workspace:${legacyOrg}:prewarm%40example.com:${prewarmWorkspace.id}`,
+        prewarmWorkspace,
+      ),
+      storage.put(`lease:${recoveredLeaseID}`, {
+        ...legacyLease(recoveredLeaseID, recoveredWorkspace.id, recoveredWorkspace.owner),
+        state: "failed",
+        cloudID: "",
+        serverID: 0,
+        provisioningResourceMayExist: true,
+        provisioningRequestStartedAt: now,
+        cleanupError: "provider response timed out",
+      }),
+      storage.put(
+        `lease:${prewarmLeaseID}`,
+        legacyLease(prewarmLeaseID, prewarmWorkspace.id, prewarmWorkspace.owner),
+      ),
+    ]);
+
+    await fleet.alarm();
+
+    expect(creates).toBe(0);
+    expect(recoveries).toBe(1);
+    expect(releases.toSorted()).toEqual([prewarmLeaseID, recoveredLeaseID].toSorted());
+    expect(storage.value<LeaseRecord>(`lease:${recoveredLeaseID}`)?.state).toBe("released");
+    expect(storage.value<LeaseRecord>(`lease:${prewarmLeaseID}`)?.state).toBe("released");
+    expect(
+      storage.value<{ releaseRequestedAt?: string }>(
+        `workspace:${legacyOrg}:alice%40example.com:${recoveredWorkspace.id}`,
+      )?.releaseRequestedAt,
+    ).toBeDefined();
   });
 
   it("uses provider-owned GCP recovery instead of project-wide label inventory", async () => {
@@ -8145,7 +8292,7 @@ describe("fleet lease identity and idle", () => {
       }),
     });
     const now = new Date().toISOString();
-    storage.seed("workspace:example-org:alice%40example.com:fleet-is-gcp-recovery", {
+    storage.seed(workspaceFixtureKey("fleet-is-gcp-recovery"), {
       id: "fleet-is-gcp-recovery",
       leaseID,
       owner: "alice@example.com",
@@ -8598,7 +8745,7 @@ describe("fleet lease identity and idle", () => {
       storage.seed(`lease:${lease.id}`, lease);
       const headers = {
         "x-crabbox-owner": lease.owner,
-        "x-crabbox-org": lease.org,
+        "x-crabbox-org": "example-org",
       };
 
       const retain = await fleet.fetch(
@@ -8654,7 +8801,7 @@ describe("fleet lease identity and idle", () => {
       id: "cbx_abcdef123456",
       workspaceID: "fleet-is-retained",
       owner: "alice@example.com",
-      org: "example-org",
+      org: orgKeyForLabel("example-org"),
       state: "released",
       releaseDeletesServer: false,
       providerKeyCleanupPending: true,
@@ -8664,7 +8811,7 @@ describe("fleet lease identity and idle", () => {
       updatedAt: now,
     });
     storage.seed(`lease:${lease.id}`, lease);
-    storage.seed("workspace:example-org:alice%40example.com:fleet-is-retained", {
+    storage.seed(workspaceFixtureKey("fleet-is-retained"), {
       id: "fleet-is-retained",
       leaseID: lease.id,
       owner: lease.owner,
@@ -8846,7 +8993,7 @@ describe("fleet lease identity and idle", () => {
       capabilities: { desktop: false },
     };
     await fleet.fetch(request("POST", "/v1/workspaces", { headers, body }));
-    const workspaceKey = "workspace:example-org:alice%40example.com:fleet-is-119";
+    const workspaceKey = workspaceFixtureKey("fleet-is-119");
 
     await fleet.alarm();
     const recovering = await fleet.fetch(request("GET", `/v1/workspaces/${body.id}`, { headers }));
@@ -8904,9 +9051,7 @@ describe("fleet lease identity and idle", () => {
       status: "failed",
       message: expect.stringContaining("active lease limit exceeded"),
     });
-    const workspace = storage.value<Record<string, unknown>>(
-      "workspace:example-org:alice%40example.com:fleet-is-118",
-    );
+    const workspace = storage.value<Record<string, unknown>>(workspaceFixtureKey("fleet-is-118"));
     expect(workspace?.["reconcileAfter"]).toBeUndefined();
   });
 
@@ -8916,7 +9061,7 @@ describe("fleet lease identity and idle", () => {
     for (let index = 0; index < 100; index += 1) {
       const id = `fleet-cap-${index}`;
       const leaseID = `cbx_${index.toString(16).padStart(12, "0")}`;
-      storage.seed(`workspace:example-org:alice%40example.com:${id}`, {
+      storage.seed(workspaceFixtureKey(id), {
         id,
         leaseID,
         owner: "alice@example.com",
@@ -8968,11 +9113,11 @@ describe("fleet lease identity and idle", () => {
   it("schedules terminal workspace retention cleanup", async () => {
     const storage = new MemoryStorage();
     const terminalAt = new Date().toISOString();
-    storage.seed("workspace:example-org:alice%40example.com:fleet-is-122", {
+    storage.seed(workspaceFixtureKey("fleet-is-122"), {
       id: "fleet-is-122",
       leaseID: "cbx_abcdef123456",
       owner: "alice@example.com",
-      org: "example-org",
+      org: orgKeyForLabel("example-org"),
       profile: "default",
       provider: "hetzner",
       class: "standard",
@@ -8993,7 +9138,7 @@ describe("fleet lease identity and idle", () => {
   it("detaches a retained lease when its terminal workspace record is pruned", async () => {
     const storage = new MemoryStorage();
     const terminalAt = new Date(Date.now() - 25 * 60 * 60_000).toISOString();
-    const workspaceKey = "workspace:example-org:alice%40example.com:fleet-is-131";
+    const workspaceKey = workspaceFixtureKey("fleet-is-131");
     storage.seed(workspaceKey, {
       id: "fleet-is-131",
       leaseID: "cbx_abcdef123456",
@@ -9140,7 +9285,7 @@ describe("fleet lease identity and idle", () => {
     const now = new Date().toISOString();
     const claimExpiresAt = new Date(Date.now() + 60_000).toISOString();
     const expiresAt = new Date(Date.now() + 5_000).toISOString();
-    storage.seed("workspace:example-org:alice%40example.com:fleet-is-108", {
+    storage.seed(workspaceFixtureKey("fleet-is-108"), {
       id: "fleet-is-108",
       leaseID,
       owner: "alice@example.com",
@@ -9223,7 +9368,7 @@ describe("fleet lease identity and idle", () => {
       ),
     });
     const now = new Date().toISOString();
-    const workspaceKey = "workspace:example-org:alice%40example.com:fleet-is-109";
+    const workspaceKey = workspaceFixtureKey("fleet-is-109");
     storage.seed(workspaceKey, {
       id: "fleet-is-109",
       leaseID,
@@ -9328,7 +9473,7 @@ describe("fleet lease identity and idle", () => {
       }),
     });
     const old = new Date(Date.now() - 20 * 60_000).toISOString();
-    storage.seed("workspace:example-org:alice%40example.com:fleet-is-129", {
+    storage.seed(workspaceFixtureKey("fleet-is-129"), {
       id: "fleet-is-129",
       leaseID,
       owner: "alice@example.com",
@@ -9395,7 +9540,7 @@ describe("fleet lease identity and idle", () => {
       }),
     });
     const now = new Date().toISOString();
-    const workspaceKey = "workspace:example-org:alice%40example.com:fleet-is-114";
+    const workspaceKey = workspaceFixtureKey("fleet-is-114");
     storage.seed(workspaceKey, {
       id: "fleet-is-114",
       leaseID,
@@ -11396,6 +11541,148 @@ describe("fleet lease identity and idle", () => {
     expect(deleted).toBe("123");
   });
 
+  it("keeps colliding exact org labels isolated across shares, runs, and filters", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const leaseID = "cbx_000000000088";
+    storage.seed(
+      `lease:${leaseID}`,
+      testLease({
+        id: leaseID,
+        owner: "owner@example.com",
+        org: "science team",
+        share: { org: "use", users: {} },
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      }),
+    );
+    const exactOrgHeaders = {
+      "x-crabbox-owner": "member@example.com",
+      "x-crabbox-org": "science team",
+    };
+    const collidingOrgHeaders = {
+      "x-crabbox-owner": "attacker@example.com",
+      "x-crabbox-org": "science_team",
+    };
+
+    const hidden = await fleet.fetch(
+      request("GET", `/v1/leases/${leaseID}`, { headers: collidingOrgHeaders }),
+    );
+    expect(hidden.status).toBe(404);
+    const blockedRun = await fleet.fetch(
+      request("POST", "/v1/runs", {
+        headers: collidingOrgHeaders,
+        body: { leaseID, command: ["true"] },
+      }),
+    );
+    expect(blockedRun.status).toBe(404);
+
+    const visible = await fleet.fetch(
+      request("GET", `/v1/leases/${leaseID}`, { headers: exactOrgHeaders }),
+    );
+    expect(visible.status).toBe(200);
+    await expect(visible.json()).resolves.toMatchObject({ lease: { org: "science team" } });
+    const run = await fleet.fetch(
+      request("POST", "/v1/runs", {
+        headers: exactOrgHeaders,
+        body: { leaseID, command: ["true"] },
+      }),
+    );
+    expect(run.status).toBe(201);
+    await expect(run.json()).resolves.toMatchObject({
+      run: {
+        org: "science team",
+        leaseOwners: [{ owner: "owner@example.com", org: "science team" }],
+      },
+    });
+
+    const exactFilter = await fleet.fetch(
+      request("GET", "/v1/leases?org=science%20team", {
+        headers: { ...exactOrgHeaders, "x-crabbox-admin": "true" },
+      }),
+    );
+    await expect(exactFilter.json()).resolves.toMatchObject({ leases: [{ id: leaseID }] });
+    const collidingFilter = await fleet.fetch(
+      request("GET", "/v1/leases?org=science_team", {
+        headers: { ...exactOrgHeaders, "x-crabbox-admin": "true" },
+      }),
+    );
+    await expect(collidingFilter.json()).resolves.toEqual({ leases: [] });
+  });
+
+  it("quarantines legacy org records but preserves admin cleanup", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const leaseID = "cbx_000000000087";
+    const legacy = testLease({
+      id: leaseID,
+      owner: "owner@example.com",
+      share: { org: "use", users: { "friend@example.com": "manage" } },
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+    });
+    legacy.org = "science_team";
+    await storage.put(`lease:${leaseID}`, legacy);
+    const friendHeaders = {
+      "x-crabbox-owner": "friend@example.com",
+      "x-crabbox-org": "science_team",
+    };
+
+    expect(
+      (await fleet.fetch(request("GET", `/v1/leases/${leaseID}`, { headers: friendHeaders })))
+        .status,
+    ).toBe(404);
+    const adminHeaders = { ...friendHeaders, "x-crabbox-admin": "true" };
+    const visible = await fleet.fetch(
+      request("GET", "/v1/admin/leases", { headers: adminHeaders }),
+    );
+    expect(visible.status).toBe(200);
+    await expect(visible.json()).resolves.toMatchObject({
+      leases: [{ id: leaseID, org: "science_team" }],
+    });
+    const filtered = await fleet.fetch(
+      request("GET", "/v1/admin/leases?org=science_team&orgKind=legacy", {
+        headers: adminHeaders,
+      }),
+    );
+    await expect(filtered.json()).resolves.toMatchObject({
+      leases: [{ id: leaseID, org: "science_team" }],
+    });
+    const released = await fleet.fetch(
+      request("POST", `/v1/admin/leases/${leaseID}/release`, {
+        headers: adminHeaders,
+        body: { delete: false },
+      }),
+    );
+    expect(released.status).toBe(200);
+    await expect(released.json()).resolves.toMatchObject({ lease: { state: "released" } });
+  });
+
+  it("does not treat missing org identity as an org share", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const leaseID = "cbx_000000000086";
+    storage.seed(
+      `lease:${leaseID}`,
+      testLease({
+        id: leaseID,
+        owner: "owner@example.com",
+        org: MISSING_ORG_KEY,
+        share: { org: "use", users: { "friend@example.com": "use" } },
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      }),
+    );
+    const missingHeaders = { "x-crabbox-owner": "other@example.com", "x-crabbox-org": "" };
+    const explicitHeaders = { "x-crabbox-owner": "friend@example.com", "x-crabbox-org": "" };
+
+    expect(
+      (await fleet.fetch(request("GET", `/v1/leases/${leaseID}`, { headers: missingHeaders })))
+        .status,
+    ).toBe(404);
+    expect(
+      (await fleet.fetch(request("GET", `/v1/leases/${leaseID}`, { headers: explicitHeaders })))
+        .status,
+    ).toBe(200);
+  });
+
   it("shares leases with explicit users or the owning org", async () => {
     const storage = new MemoryStorage();
     const fleet = testFleet(storage);
@@ -11777,7 +12064,7 @@ describe("fleet lease identity and idle", () => {
             agentID: "agent_revoked",
             socket: revokedWebViewer as unknown as WebSocket,
             owner: "revoked@example.com",
-            org: "other-org",
+            org: orgKeyForLabel("other-org"),
             admin: false,
             label: "revoked@example.com",
             connectedAt: new Date().toISOString(),
@@ -11790,7 +12077,7 @@ describe("fleet lease identity and idle", () => {
             agentID: "agent_retained",
             socket: retainedWebViewer as unknown as WebSocket,
             owner: "retained@example.com",
-            org: "other-org",
+            org: orgKeyForLabel("other-org"),
             admin: false,
             label: "retained@example.com",
             connectedAt: new Date().toISOString(),
@@ -11803,7 +12090,7 @@ describe("fleet lease identity and idle", () => {
             agentID: "agent_owner",
             socket: ownerWebViewer as unknown as WebSocket,
             owner: "owner@example.com",
-            org: "example-org",
+            org: orgKeyForLabel("example-org"),
             admin: false,
             label: "owner@example.com",
             connectedAt: new Date().toISOString(),
@@ -12842,7 +13129,7 @@ describe("fleet lease identity and idle", () => {
     await expect(conflictingCreate.json()).resolves.toMatchObject({ error: "lease_id_conflict" });
     expect(storage.value<LeaseRecord>("lease:cbx_abcdef123456")).toMatchObject({
       owner: "alice@example.com",
-      org: "example-org",
+      org: orgKeyForLabel("example-org"),
       state: "provisioning",
     });
 
@@ -12851,7 +13138,7 @@ describe("fleet lease identity and idle", () => {
     expect(firstResult.status).toBe(201);
     expect(storage.value<LeaseRecord>("lease:cbx_abcdef123456")).toMatchObject({
       owner: "alice@example.com",
-      org: "example-org",
+      org: orgKeyForLabel("example-org"),
       state: "active",
     });
   });
@@ -13414,7 +13701,9 @@ describe("fleet lease identity and idle", () => {
       lastTouchedAt: heartbeatLease.lastTouchedAt,
       expiresAt: heartbeatLease.expiresAt,
     });
-    expect(storage.value<LeaseRecord>("lease:cbx_abcdef123456")).toEqual(createdLease);
+    expect(storage.value<LeaseRecord>("lease:cbx_abcdef123456")).toEqual(
+      currentOrgFixture(createdLease),
+    );
   });
 
   it("buffers Cloudflare heartbeat bodies before serializing state transitions", async () => {
@@ -16830,6 +17119,76 @@ describe("fleet lease identity and idle", () => {
     expect(hidden.status).toBe(404);
   });
 
+  it("round-trips missing, literal, and legacy org runner links without collisions", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const now = new Date().toISOString();
+    const owner = "alice@example.com";
+    const runner = (org: string, repo: string): ExternalRunnerRecord => ({
+      id: "tbx_same_identity",
+      provider: "blacksmith-testbox",
+      owner,
+      org,
+      status: "ready",
+      repo,
+      firstSeenAt: now,
+      lastSeenAt: now,
+      updatedAt: now,
+    });
+    const records = [
+      runner(MISSING_ORG_KEY, "missing-repo"),
+      runner(orgKeyForLabel("unknown"), "literal-unknown-repo"),
+      runner("science_team", "legacy-repo"),
+      runner(orgKeyForLabel("science_team"), "exact-repo"),
+    ];
+    await Promise.all(
+      records.map((record, index) => storage.put(`runner:identity-${index}`, record)),
+    );
+    const headers = {
+      "x-crabbox-admin": "true",
+      "x-crabbox-owner": owner,
+      "x-crabbox-org": "",
+    };
+
+    const home = await fleet.fetch(request("GET", "/portal", { headers }));
+    expect(home.status).toBe(200);
+    const body = await home.text();
+    expect(body.match(/owner:mine/g)).toHaveLength(1);
+    const links = [...body.matchAll(/href="([^"]*\/tbx_same_identity\?[^"]+)"/g)].map((match) =>
+      match[1].replaceAll("&amp;", "&"),
+    );
+    expect(links).toHaveLength(4);
+
+    const expectedRepos = new Map([
+      ["owner=alice%40example.com&orgKind=missing", "missing-repo"],
+      ["owner=alice%40example.com&org=unknown", "literal-unknown-repo"],
+      ["owner=alice%40example.com&org=science_team&orgKind=legacy", "legacy-repo"],
+      ["owner=alice%40example.com&org=science_team", "exact-repo"],
+    ]);
+    const resolvedLinks = await Promise.all(
+      links.map(async (link) => {
+        const url = new URL(link, "https://crabbox.test");
+        const query = url.searchParams.toString();
+        const expectedRepo = expectedRepos.get(query);
+        if (!expectedRepo) throw new Error(`unexpected runner detail link: ${link}`);
+        const detail = await fleet.fetch(
+          request("GET", `${url.pathname}${url.search}`, { headers }),
+        );
+        expect(detail.status).toBe(200);
+        expect(await detail.text()).toContain(expectedRepo);
+        return query;
+      }),
+    );
+    expect(resolvedLinks.toSorted()).toEqual([...expectedRepos.keys()].toSorted());
+
+    const exactHome = await fleet.fetch(
+      request("GET", "/portal", {
+        headers: { ...headers, "x-crabbox-org": "science_team" },
+      }),
+    );
+    expect((await exactHome.text()).match(/owner:mine/g)).toHaveLength(1);
+  });
+
   it("shows non-owned runner leases only in the admin portal", async () => {
     const storage = new MemoryStorage();
     const fleet = testFleet(storage);
@@ -17459,6 +17818,7 @@ describe("fleet lease identity and idle", () => {
       CRABBOX_CODE_ORIGIN_TEMPLATE: "https://{lease}.code.example.test",
       CRABBOX_PUBLIC_URL: "https://crabbox.test",
       CRABBOX_SHARED_TOKEN: "portal-session-token",
+      CRABBOX_DEFAULT_ORG: "",
     };
     const fleet = testFleet(storage, {}, env);
     const leaseID = "cbx_000000000001";
@@ -17467,7 +17827,7 @@ describe("fleet lease identity and idle", () => {
       authorization: "Bearer portal-session-token",
       "x-crabbox-auth": "bearer",
       "x-crabbox-owner": "alice@example.com",
-      "x-crabbox-org": "example-org",
+      "x-crabbox-org": "",
       "x-crabbox-github-login": "alice",
       "x-crabbox-token-expires-at": tokenExpiresAt,
     };
@@ -17477,7 +17837,7 @@ describe("fleet lease identity and idle", () => {
         id: leaseID,
         slug: "blue-lobster",
         owner: "alice@example.com",
-        org: "example-org",
+        org: MISSING_ORG_KEY,
         code: true,
         expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
       }),
@@ -21873,7 +22233,7 @@ describe("fleet lease identity and idle", () => {
     );
   });
 
-  it("rejects empty artifact authorization identities", async () => {
+  it("keeps missing-org artifact grants distinct from the literal unknown org", async () => {
     const fleet = testFleet(
       new MemoryStorage(),
       {},
@@ -21886,23 +22246,53 @@ describe("fleet lease identity and idle", () => {
         CRABBOX_ARTIFACTS_SECRET_ACCESS_KEY: "super-secret",
       },
     );
-    const grant = async (headers: Record<string, string>) => {
+    const grant = async (org: string) => {
       const response = await fleet.fetch(
         request("POST", "/v1/artifacts/uploads", {
-          headers,
+          headers: { "x-crabbox-owner": "alice", "x-crabbox-org": org },
           body: { files: [{ name: "proof.txt", size: 1 }] },
         }),
       );
-      expect(response.status).toBe(400);
-      return (await response.json()) as { message: string };
+      expect(response.status).toBe(201);
+      return (await response.json()) as { prefix: string };
     };
 
-    await expect(grant({ "x-crabbox-owner": "alice", "x-crabbox-org": "" })).resolves.toMatchObject(
-      { message: "artifact upload organization identity is required" },
+    const missing = await grant("");
+    const literalUnknown = await grant("unknown");
+    expect(missing.prefix).not.toBe(literalUnknown.prefix);
+    expect(missing.prefix).toContain("/org/AA/");
+    expect(literalUnknown.prefix).toContain(
+      `/org/${Buffer.from("unknown").toString("base64url")}/`,
     );
-    await expect(
-      grant({ "x-crabbox-owner": "", "x-crabbox-org": "example-org" }),
-    ).resolves.toMatchObject({ message: "artifact upload owner identity is required" });
+    const missingIdentity = missing.prefix.split("/org/")[1].split("/")[0];
+    const literalIdentity = literalUnknown.prefix.split("/org/")[1].split("/")[0];
+    expect(Buffer.from(missingIdentity, "base64url").toString()).toBe("\0");
+    expect(Buffer.from(literalIdentity, "base64url").toString()).toBe("unknown");
+  });
+
+  it("rejects an empty artifact owner identity", async () => {
+    const fleet = testFleet(
+      new MemoryStorage(),
+      {},
+      {
+        CRABBOX_ARTIFACTS_BACKEND: "r2",
+        CRABBOX_ARTIFACTS_BUCKET: "qa-artifacts",
+        CRABBOX_ARTIFACTS_ENDPOINT_URL: "https://account.r2.cloudflarestorage.com",
+        CRABBOX_ARTIFACTS_ACCESS_KEY_ID: "access-key",
+        CRABBOX_ARTIFACTS_SECRET_ACCESS_KEY: "super-secret",
+      },
+    );
+    const response = await fleet.fetch(
+      request("POST", "/v1/artifacts/uploads", {
+        headers: { "x-crabbox-owner": "", "x-crabbox-org": "example-org" },
+        body: { files: [{ name: "proof.txt", size: 1 }] },
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      message: "artifact upload owner identity is required",
+    });
   });
 
   it("reports artifact broker setup errors without provider-specific local credentials", async () => {
@@ -22612,8 +23002,8 @@ describe("fleet run history", () => {
     expect(storage.value<RunRecord>("run:run_000000000001")).toMatchObject({
       leaseIDs: ["cbx_000000000001", "cbx_000000000002"],
       leaseOwners: [
-        { owner: "alice@example.com", org: "example-org" },
-        { owner: "bob@example.com", org: "elsewhere" },
+        { owner: "alice@example.com", org: orgKeyForLabel("example-org") },
+        { owner: "bob@example.com", org: orgKeyForLabel("elsewhere") },
       ],
     });
   });
@@ -22651,7 +23041,7 @@ describe("fleet run history", () => {
     expect(storage.value<RunRecord>("run:run_000000000001")).toMatchObject({
       leaseID: "cbx_000000000001",
       leaseIDs: ["cbx_000000000001"],
-      leaseOwners: [{ owner: "alice@example.com", org: "example-org" }],
+      leaseOwners: [{ owner: "alice@example.com", org: orgKeyForLabel("example-org") }],
     });
   });
 
@@ -25400,7 +25790,7 @@ function workerCloudReleaseCases() {
 }
 
 function testLease(overrides: Partial<LeaseRecord>): LeaseRecord {
-  return {
+  return currentOrgFixture({
     id: "cbx_000000000000",
     slug: "blue-lobster",
     provider: "hetzner",
@@ -25427,7 +25817,7 @@ function testLease(overrides: Partial<LeaseRecord>): LeaseRecord {
     updatedAt: "2026-05-01T00:00:00.000Z",
     expiresAt: "2026-05-01T01:30:00.000Z",
     ...overrides,
-  };
+  });
 }
 
 type CodePortalRuntime = {
@@ -25523,7 +25913,7 @@ function inlineScript(page: string, marker: string): string {
 }
 
 function testRun(overrides: Partial<RunRecord>): RunRecord {
-  return {
+  return currentOrgFixture({
     id: "run_000000000000",
     leaseID: "cbx_000000000000",
     owner: "peter@example.com",
@@ -25537,7 +25927,7 @@ function testRun(overrides: Partial<RunRecord>): RunRecord {
     logTruncated: false,
     startedAt: "2026-05-01T00:00:00.000Z",
     ...overrides,
-  };
+  });
 }
 
 function request(

--- a/worker/test/http.test.ts
+++ b/worker/test/http.test.ts
@@ -12,6 +12,7 @@ import {
 import { codeOriginForLease } from "../src/code-origin";
 import { prepareCoordinatorRequest } from "../src/coordinator-entry";
 import { errorMessage, json, redactDiagnosticSecrets, requestOwner } from "../src/http";
+import { MISSING_ORG_KEY, requestOrg, requestOrgLabel } from "../src/org-identity";
 import type { Env } from "../src/types";
 
 function proxyIdentityRequest(secret?: string): Request {
@@ -28,6 +29,152 @@ const allowGitHubMembership = {
 };
 
 describe("coordinator auth", () => {
+  it("keeps colliding org labels distinct after coordinator authentication", async () => {
+    const sharedEnv = {
+      CRABBOX_SHARED_TOKEN: "shared",
+      CRABBOX_SHARED_OWNER: "automation@example.com",
+      CRABBOX_DEFAULT_ORG: "science team",
+    } as Env;
+    const proxyEnv = {
+      CRABBOX_TRUSTED_USER_HEADER: "X-Authenticated-User",
+      CRABBOX_TRUSTED_USER_ORG: "science_team",
+    } as Env;
+    const shared = await prepareCoordinatorRequest(
+      new Request("https://example.test/v1/whoami", {
+        headers: { authorization: "Bearer shared" },
+      }),
+      sharedEnv,
+    );
+    const proxy = await prepareCoordinatorRequest(
+      new Request("https://example.test/v1/whoami", {
+        headers: { "x-authenticated-user": "alice@example.com" },
+      }),
+      proxyEnv,
+      { trustedProxy: true },
+    );
+    if ("response" in shared || "response" in proxy) {
+      throw new Error("expected authenticated coordinator requests");
+    }
+
+    expect(requestOrgLabel(shared.request, sharedEnv)).toBe("science team");
+    expect(requestOrgLabel(proxy.request, proxyEnv)).toBe("science_team");
+    expect(requestOrg(shared.request, sharedEnv)).not.toBe(requestOrg(proxy.request, proxyEnv));
+  });
+
+  it("keeps a missing authenticated org distinct from the literal unknown org", async () => {
+    const missingEnv = {
+      CRABBOX_SHARED_TOKEN: "shared",
+      CRABBOX_SHARED_OWNER: "automation@example.com",
+    } as Env;
+    const unknownEnv = { ...missingEnv, CRABBOX_DEFAULT_ORG: "unknown" } as Env;
+    const githubEnv = { CRABBOX_SESSION_SECRET: "session-secret" } as Env;
+    const githubToken = await issueUserToken(githubEnv, {
+      owner: "alice@example.com",
+      ownerSource: "github-verified-email",
+      org: "unknown",
+      login: "alice",
+      githubAccessToken: "github-access-token",
+    });
+    const [missingShared, missingProxy, configuredUnknown, signedUnknown] = await Promise.all([
+      prepareCoordinatorRequest(
+        new Request("https://example.test/v1/whoami", {
+          headers: { authorization: "Bearer shared" },
+        }),
+        missingEnv,
+      ),
+      prepareCoordinatorRequest(
+        proxyIdentityRequest(),
+        { CRABBOX_TRUSTED_USER_HEADER: "X-Authenticated-User" } as Env,
+        { trustedProxy: true },
+      ),
+      prepareCoordinatorRequest(
+        new Request("https://example.test/v1/whoami", {
+          headers: { authorization: "Bearer shared" },
+        }),
+        unknownEnv,
+      ),
+      prepareCoordinatorRequest(
+        new Request("https://example.test/v1/whoami", {
+          headers: { authorization: `Bearer ${githubToken}` },
+        }),
+        githubEnv,
+        allowGitHubMembership,
+      ),
+    ]);
+    if (
+      "response" in missingShared ||
+      "response" in missingProxy ||
+      "response" in configuredUnknown ||
+      "response" in signedUnknown
+    ) {
+      throw new Error("expected authenticated coordinator requests");
+    }
+
+    expect(missingShared.request.headers.get("x-crabbox-org")).toBe("");
+    expect(missingProxy.request.headers.get("x-crabbox-org")).toBe("");
+    expect(configuredUnknown.request.headers.get("x-crabbox-org")).toBe("unknown");
+    expect(signedUnknown.request.headers.get("x-crabbox-org")).toBe("unknown");
+    expect(requestOrg(missingShared.request, unknownEnv)).toBe(MISSING_ORG_KEY);
+    expect(requestOrg(missingProxy.request, unknownEnv)).toBe(MISSING_ORG_KEY);
+    const configuredUnknownKey = requestOrg(configuredUnknown.request, unknownEnv);
+    expect(configuredUnknownKey).not.toBe(MISSING_ORG_KEY);
+    expect(requestOrg(signedUnknown.request, unknownEnv)).toBe(configuredUnknownKey);
+    expect(
+      [missingShared, missingProxy, configuredUnknown, signedUnknown].map((prepared) =>
+        requestOrgLabel(prepared.request, unknownEnv),
+      ),
+    ).toEqual(["unknown", "unknown", "unknown", "unknown"]);
+  });
+
+  it("rejects invalid authenticated org configuration before coordinator forwarding", async () => {
+    const invalidOrg = " science_team";
+    const [shared, runtimeAdapter, trustedProxy] = await Promise.all([
+      prepareCoordinatorRequest(
+        new Request("https://example.test/v1/whoami", {
+          headers: { authorization: "Bearer shared" },
+        }),
+        {
+          CRABBOX_SHARED_TOKEN: "shared",
+          CRABBOX_DEFAULT_ORG: invalidOrg,
+        } as Env,
+      ),
+      prepareCoordinatorRequest(
+        new Request("https://example.test/v1/workspaces", {
+          method: "POST",
+          headers: { authorization: "Bearer runtime-adapter" },
+        }),
+        {
+          CRABBOX_RUNTIME_ADAPTER_TOKEN: "runtime-adapter",
+          CRABBOX_DEFAULT_ORG: invalidOrg,
+        } as Env,
+      ),
+      prepareCoordinatorRequest(
+        proxyIdentityRequest(),
+        {
+          CRABBOX_TRUSTED_USER_HEADER: "X-Authenticated-User",
+          CRABBOX_TRUSTED_USER_ORG: invalidOrg,
+        } as Env,
+        { trustedProxy: true },
+      ),
+    ]);
+
+    const responses = [shared, runtimeAdapter, trustedProxy].map((prepared) => {
+      expect(prepared).toMatchObject({ authenticated: false, response: { status: 503 } });
+      if (!("response" in prepared)) throw new Error("invalid org reached the coordinator");
+      return prepared.response;
+    });
+    const expectedError = {
+      error: "invalid_org_identity",
+      message:
+        "organization must be 1-63 printable ASCII characters without leading or trailing spaces",
+    };
+    await expect(Promise.all(responses.map((response) => response.json()))).resolves.toEqual([
+      expectedError,
+      expectedError,
+      expectedError,
+    ]);
+  });
+
   it("requires same-origin intent for portal-cookie mutations and viewer sockets", async () => {
     const env = {
       CRABBOX_SESSION_SECRET: "session-secret",

--- a/worker/test/usage.test.ts
+++ b/worker/test/usage.test.ts
@@ -1,7 +1,77 @@
 import { describe, expect, it } from "vitest";
 
+import {
+  InvalidOrgLabelError,
+  MISSING_ORG_KEY,
+  orgAuthLabelFromKey,
+  orgKeyForLabel,
+  orgLabelForDisplay,
+  orgLabelFromKey,
+  orgMatchesForAccounting,
+  orgMatchesForFilter,
+  requestOrg,
+  requestOrgLabel,
+  sameOrgIdentityKey,
+} from "../src/org-identity";
 import type { LeaseRecord } from "../src/types";
 import { costLimits, enforceCostLimits, leaseCost, usageSummary } from "../src/usage";
+
+describe("organization identity", () => {
+  it("keeps colliding legacy labels distinct in authorization keys", () => {
+    const spaced = orgKeyForLabel("science team");
+    const underscored = orgKeyForLabel("science_team");
+
+    expect(spaced).not.toBe(underscored);
+    expect(spaced).toMatch(/^~1\./);
+    expect(orgLabelFromKey(spaced)).toBe("science team");
+    expect(orgLabelFromKey(underscored)).toBe("science_team");
+    expect(sameOrgIdentityKey(spaced, underscored)).toBe(false);
+  });
+
+  it("rejects malformed labels and non-canonical keys", () => {
+    expect(() => orgKeyForLabel(" science team")).toThrow(InvalidOrgLabelError);
+    expect(() => orgKeyForLabel("science team ")).toThrow(InvalidOrgLabelError);
+    expect(() => orgKeyForLabel("science	t eam")).toThrow(InvalidOrgLabelError);
+    expect(() => orgKeyForLabel("science\n")).toThrow(InvalidOrgLabelError);
+    expect(() => orgKeyForLabel("science\r\n")).toThrow(InvalidOrgLabelError);
+    expect(() => orgKeyForLabel("sciencé")).toThrow(InvalidOrgLabelError);
+    expect(() => orgKeyForLabel("a".repeat(64))).toThrow(InvalidOrgLabelError);
+
+    const key = orgKeyForLabel("science team");
+    expect(orgLabelFromKey(`${key}=`)).toBeUndefined();
+    expect(orgLabelFromKey("~1.!!")).toBeUndefined();
+    expect(orgLabelFromKey("science_team")).toBeUndefined();
+    expect(orgLabelForDisplay("~1.!!")).toBe("unknown");
+    expect(orgLabelForDisplay("~2.future-key")).toBe("unknown");
+  });
+
+  it("keeps a missing identity distinct from the literal unknown label", () => {
+    const request = new Request("https://coordinator.example/v1/leases");
+
+    expect(requestOrg(request, {})).toBe(MISSING_ORG_KEY);
+    expect(requestOrgLabel(request, {})).toBe("unknown");
+    expect(requestOrg(request, { CRABBOX_DEFAULT_ORG: "unknown" })).not.toBe(MISSING_ORG_KEY);
+    expect(orgAuthLabelFromKey(MISSING_ORG_KEY)).toBe("");
+    expect(orgLabelForDisplay(MISSING_ORG_KEY)).toBe("unknown");
+  });
+
+  it("never authorizes legacy identities but conservatively accounts for them", () => {
+    const spaced = orgKeyForLabel("science team");
+    const underscored = orgKeyForLabel("science_team");
+    const unrelated = orgKeyForLabel("unrelated");
+
+    expect(sameOrgIdentityKey("science_team", "science_team")).toBe(false);
+    expect(orgMatchesForFilter("science_team", "science_team")).toBe(true);
+    expect(orgMatchesForFilter("science_team", underscored)).toBe(false);
+    expect(orgMatchesForAccounting("science_team", spaced)).toBe(true);
+    expect(orgMatchesForAccounting("science_team", underscored)).toBe(true);
+    expect(orgMatchesForAccounting("science_team", unrelated)).toBe(false);
+    expect(orgMatchesForAccounting("unknown", MISSING_ORG_KEY)).toBe(true);
+    expect(orgMatchesForAccounting("unknown", orgKeyForLabel("unknown"))).toBe(true);
+    expect(orgMatchesForAccounting("unknown", unrelated)).toBe(false);
+    expect(orgMatchesForAccounting("unknown", "unrelated")).toBe(false);
+  });
+});
 
 describe("azure cost overrides", () => {
   it("honors CRABBOX_COST_RATES_JSON for Azure SKUs", () => {
@@ -21,16 +91,17 @@ describe("azure cost overrides", () => {
 describe("usage accounting", () => {
   it("estimates cost and aggregates by owner and org", () => {
     const now = new Date("2026-05-01T02:00:00Z");
+    const org = orgKeyForLabel("openclaw");
     const lease = testLease({
       owner: "peter@example.com",
-      org: "openclaw",
+      org,
       createdAt: "2026-05-01T01:00:00Z",
       endedAt: "2026-05-01T02:00:00Z",
       state: "released",
       estimatedHourlyUSD: 2,
       maxEstimatedUSD: 3,
     });
-    const usage = usageSummary([lease], { scope: "org", org: "openclaw", month: "2026-05" }, now);
+    const usage = usageSummary([lease], { scope: "org", org, month: "2026-05" }, now);
     expect(usage.leases).toBe(1);
     expect(usage.runtimeSeconds).toBe(3600);
     expect(usage.estimatedUSD).toBe(2);
@@ -41,21 +112,86 @@ describe("usage accounting", () => {
 
   it("keeps user-visible usage inside the requested owner and org", () => {
     const now = new Date("2026-05-01T02:00:00Z");
-    const matching = testLease({ owner: "alice@example.com", org: "org-a" });
+    const org = orgKeyForLabel("org-a");
+    const matching = testLease({ owner: "alice@example.com", org });
     const otherOrg = testLease({
       id: "cbx_other_org",
       owner: "alice@example.com",
-      org: "org-b",
+      org: orgKeyForLabel("org-b"),
     });
 
     const usage = usageSummary(
       [matching, otherOrg],
-      { scope: "user", owner: "alice@example.com", org: "org-a", month: "2026-05" },
+      { scope: "user", owner: "alice@example.com", org, month: "2026-05" },
       now,
     );
 
     expect(usage.leases).toBe(1);
     expect(usage.byOrg.map((group) => group.key)).toEqual(["org-a"]);
+  });
+
+  it("keeps collision-resistant org budgets independent", () => {
+    const now = new Date("2026-05-01T00:30:00Z");
+    const existing = testLease({
+      org: orgKeyForLabel("science team"),
+      expiresAt: "2026-05-01T03:00:00Z",
+    });
+    const candidate = testLease({
+      id: "cbx_collision_candidate",
+      org: orgKeyForLabel("science_team"),
+      expiresAt: "2026-05-01T03:00:00Z",
+    });
+    const limits = {
+      ...costLimits({} as never),
+      maxActiveLeasesPerOrg: 1,
+    };
+
+    expect(enforceCostLimits([existing], candidate, limits, now)).toBe("");
+  });
+
+  it("counts ambiguous legacy org records against every matching current budget", () => {
+    const now = new Date("2026-05-01T00:30:00Z");
+    const legacy = testLease({
+      org: "science_team",
+      expiresAt: "2026-05-01T03:00:00Z",
+    });
+    const candidate = testLease({
+      id: "cbx_legacy_candidate",
+      org: orgKeyForLabel("science team"),
+      expiresAt: "2026-05-01T03:00:00Z",
+    });
+    const limits = {
+      ...costLimits({} as never),
+      maxActiveLeasesPerOrg: 1,
+    };
+
+    expect(enforceCostLimits([legacy], candidate, limits, now)).toContain(
+      "active lease limit for org exceeded: 2/1",
+    );
+  });
+
+  it("keeps legacy reservations in matching monthly org budgets", () => {
+    const now = new Date("2026-05-01T02:00:00Z");
+    const legacy = testLease({
+      org: "science_team",
+      state: "released",
+      endedAt: "2026-05-01T01:00:00Z",
+      maxEstimatedUSD: 9,
+    });
+    const candidate = testLease({
+      id: "cbx_legacy_monthly_candidate",
+      org: orgKeyForLabel("science team"),
+      createdAt: "2026-05-01T02:00:00Z",
+      maxEstimatedUSD: 2,
+    });
+    const limits = {
+      ...costLimits({} as never),
+      maxMonthlyUSDPerOrg: 10,
+    };
+
+    expect(enforceCostLimits([legacy], candidate, limits, now)).toContain(
+      "monthly budget for org exceeded",
+    );
   });
 
   it("blocks new leases when owner monthly budget would be exceeded", () => {
@@ -214,7 +350,7 @@ function testLease(overrides: Partial<LeaseRecord>): LeaseRecord {
     cloudID: "i-123",
     region: "eu-west-1",
     owner: "owner@example.com",
-    org: "example.com",
+    org: orgKeyForLabel("example.com"),
     profile: "project-check",
     class: "beast",
     serverType: "c7a.48xlarge",


### PR DESCRIPTION
## What Problem This Solves

Distinct authenticated organization labels such as `science team` and `science_team` were normalized to the same stored value. An org-shared lease could therefore become visible and usable by a principal from a different configured org, and the same collision mixed run attribution and org accounting.

Closes #1011.

## Why This Change Was Made

- Store and compare exact org labels through reversible, versioned authorization keys.
- Keep raw labels at OAuth, GitHub membership, artifact, portal, CLI, and JSON presentation boundaries.
- Give missing org identity a separate key from the literal label `unknown`; missing principals cannot inherit org-wide shares.
- Fail ambiguous pre-upgrade records closed for non-admin access while retaining narrowly scoped admin and scheduled cleanup paths.
- Count legacy records conservatively for admission limits, but keep report filtering separate from authorization.
- Reject invalid configured labels before forwarding or leasing.

## User Impact

- Colliding labels no longer share leases, runs, bridges, workspaces, runners, or usage limits.
- Organization labels are exact and case-sensitive, with a documented 1-63 printable-ASCII contract and no leading or trailing spaces.
- Legacy records remain visible to admins for cleanup but must be recreated before non-admin use.
- Existing artifact namespace semantics remain unchanged; missing org and literal `unknown` now receive distinct artifact namespaces.

## Evidence

- `npm test --prefix worker` — 934 passed, 3 skipped.
- Focused collision/auth/portal/artifact suite — 521 passed.
- Worker format, lint, browser and Node typechecks, Worker and Node builds — passed.
- Docs command surface, provider matrix, internal links, and site build — passed.
- Two-pass fresh autoreview — first pass found and drove a legacy-filter fix; second pass reported no actionable findings.
- Persistent local Worker replay:
  - `science team` owner registered and org-shared a lease.
  - `science_team` attacker received 404 for both lease read and run creation.
  - A different `science team` member received 200 and created a run with 201; returned lease, run, and attribution labels remained `science team`.
