### PR TITLE
fix: keep AWS image minting compatible with Bash 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,14 @@ jobs:
       - name: Verify Apple Silicon runner
         run: test "$(uname -m)" = arm64
 
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+
+      - name: Test macOS script compatibility
+        run: PATH="/usr/bin:/bin:$PATH" node --test scripts/mint-aws-devtools-image.test.js
+
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixed
 
+- Kept AWS developer-image minting compatible with macOS system Bash when AWS region selection is automatic.
 - Preserved exact coordinator organization identities in collision-free authorization keys, preventing distinct labels from sharing leases, runs, bridges, workspaces, runners, or usage limits after lossy normalization. Ambiguous legacy records now fail closed for non-admin access while remaining available for admin cleanup. Thanks @coygeek.
 - Confined Nomad API redirects to the configured scheme, hostname, and effective port before replaying ACL tokens or request bodies, while keeping rejected Location secrets out of diagnostics. Thanks @coygeek.
 - Launched native Windows desktop apps directly in the active interactive session without scheduled tasks, waiting for a visible window and reporting its process ID, session, and title.

--- a/scripts/mint-aws-devtools-image.sh
+++ b/scripts/mint-aws-devtools-image.sh
@@ -619,9 +619,9 @@ run_prep "$source_lease"
 reboot_windows_source_if_needed "$source_lease"
 smoke "$source_lease"
 
-image_env=()
+image_env=(env)
 [[ -n "$region" ]] && image_env+=(CRABBOX_AWS_REGION="$region" AWS_REGION="$region")
-image_output="$(env "${image_env[@]}" "$CRABBOX_BIN" checkpoint create \
+image_output="$("${image_env[@]}" "$CRABBOX_BIN" checkpoint create \
   --provider aws --target "$target" --id "$source_lease" --name "$image_name" \
   --mode native --strategy image --no-reboot=false --wait --wait-timeout "$wait_timeout")"
 printf '%s\n' "$image_output"


### PR DESCRIPTION
## Summary

- keep the AWS developer-image mint wrapper compatible with macOS system Bash 3.2 when region selection is automatic
- preserve the existing `env` wrapper and explicit-region assignments without expanding an empty array under `set -u`
- run the existing mint-wrapper regression suite in the macOS Apple VM CI job using the system Bash
- document the user-visible fix in the changelog

## Verification

Exact head: `31205010340b4c79a4be83b7b0e4a1acfc5a26c0`

- `bash -n scripts/mint-aws-devtools-image.sh`
- `PATH="/usr/bin:/bin:$PATH" node --test scripts/mint-aws-devtools-image.test.js` — 8/8 passed on macOS system Bash
- `node --test scripts/*.test.js` — 391/391 passed
- AutoReview with `gpt-5.5` high reasoning — clean, no accepted/actionable findings
- exact-head hosted CI: 18/18 checks passed — [CI](https://github.com/openclaw/crabbox/actions/runs/29062179723), [connector smokes](https://github.com/openclaw/crabbox/actions/runs/29062179803), [CodeQL](https://github.com/openclaw/crabbox/actions/runs/29062178992)
- the exact-head macOS Apple VM job ran the regression through system Bash and passed

No paid AWS lifecycle is required for this regression: it occurs while constructing the checkpoint command, and the existing fake Crabbox tests cover both automatic and explicit region paths.
