### PR TITLE
fix(aws): bootstrap SSH over Tailscale hostname when enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Bootstrapped strict Tailscale AWS leases through their rendered tailnet hostname while preserving public and automatic network selection, allowing same-account EC2 operators without public-IP reachability to create leases successfully. Thanks @SebTardif.
 - Bounded coordinator lease and workspace history scans and kept saturated cleanup retry batches scheduled promptly, preventing large retained histories from exhausting Durable Object memory or stranding cleanup.
 
 ## 0.37.1 - 2026-07-11

--- a/internal/providers/aws/backend.go
+++ b/internal/providers/aws/backend.go
@@ -121,7 +121,10 @@ func (b *awsLeaseBackend) acquireOnce(ctx context.Context, keep bool, requestedS
 		return LeaseTarget{}, fmt.Errorf("bind AWS caller account: %w", err)
 	}
 	server.Labels["aws_account_id"] = accountID
-	target := sshTargetFromConfig(cfg, server.PublicNet.IPv4.IP)
+	if cfg.Tailscale.Enabled && strings.TrimSpace(cfg.Tailscale.Hostname) == "" {
+		cfg.Tailscale.Hostname = core.RenderTailscaleHostname(cfg.Tailscale.HostnameTemplate, leaseID, slug, cfg.Provider)
+	}
+	target := sshTargetForBootstrap(cfg, server.PublicNet.IPv4.IP, leaseID, slug)
 	if err := bootstrapAWSWindowsDesktop(ctx, cfg, &target, publicKey, b.RT.Stderr); err != nil {
 		return LeaseTarget{}, err
 	}
@@ -154,7 +157,8 @@ func (b *awsLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (Leas
 				return LeaseTarget{}, exit(4, "lease/server not found: %s (instance exists but is not Crabbox-managed)", req.ID)
 			}
 			leaseID := blank(server.Labels["lease"], req.ID)
-			target := sshTargetFromConfig(cfg, server.PublicNet.IPv4.IP)
+			slug := strings.TrimSpace(server.Labels["slug"])
+			target := sshTargetForBootstrap(cfg, server.PublicNet.IPv4.IP, leaseID, slug)
 			useStoredTestboxKey(&target, leaseID)
 			return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 		}
@@ -170,7 +174,8 @@ func (b *awsLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (Leas
 		return LeaseTarget{}, err
 	} else if leaseID != "" {
 		cfg := awsConfigForServer(b.Cfg, server)
-		target := sshTargetFromConfig(cfg, server.PublicNet.IPv4.IP)
+		slug := strings.TrimSpace(server.Labels["slug"])
+		target := sshTargetForBootstrap(cfg, server.PublicNet.IPv4.IP, leaseID, slug)
 		useStoredTestboxKey(&target, leaseID)
 		return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 	}
@@ -408,6 +413,28 @@ func providerKeyForLease(leaseID string) string          { return core.ProviderK
 func ensureAWSSSHCIDRs(ctx context.Context, cfg *Config) { core.EnsureAWSSSHCIDRs(ctx, cfg) }
 func sshTargetFromConfig(cfg Config, host string) SSHTarget {
 	return core.SSHTargetFromConfig(cfg, host)
+}
+
+// bootstrapSSHHost returns the address used for bootstrap readiness probes and
+// subsequent SSH dials. When Tailscale is enabled the box self-enrolls via
+// cloud-init; EC2 operators cannot reach same-account public IPs, so probe the
+// rendered tailnet hostname instead of PublicNet IPv4 (#1049).
+func bootstrapSSHHost(cfg Config, publicIP, leaseID, slug string) string {
+	if !cfg.Tailscale.Enabled {
+		return publicIP
+	}
+	hostname := strings.TrimSpace(cfg.Tailscale.Hostname)
+	if hostname == "" {
+		hostname = core.RenderTailscaleHostname(cfg.Tailscale.HostnameTemplate, leaseID, slug, cfg.Provider)
+	}
+	if hostname == "" {
+		return publicIP
+	}
+	return hostname
+}
+
+func sshTargetForBootstrap(cfg Config, publicIP, leaseID, slug string) SSHTarget {
+	return sshTargetFromConfig(cfg, bootstrapSSHHost(cfg, publicIP, leaseID, slug))
 }
 
 var bootstrapAWSWindowsDesktop = core.BootstrapAWSWindowsDesktop

--- a/internal/providers/aws/backend.go
+++ b/internal/providers/aws/backend.go
@@ -121,7 +121,7 @@ func (b *awsLeaseBackend) acquireOnce(ctx context.Context, keep bool, requestedS
 		return LeaseTarget{}, fmt.Errorf("bind AWS caller account: %w", err)
 	}
 	server.Labels["aws_account_id"] = accountID
-	if cfg.Tailscale.Enabled && strings.TrimSpace(cfg.Tailscale.Hostname) == "" {
+	if cfg.Network == core.NetworkTailscale && cfg.Tailscale.Enabled && strings.TrimSpace(cfg.Tailscale.Hostname) == "" {
 		cfg.Tailscale.Hostname = core.RenderTailscaleHostname(cfg.Tailscale.HostnameTemplate, leaseID, slug, cfg.Provider)
 	}
 	target := sshTargetForBootstrap(cfg, server.PublicNet.IPv4.IP, leaseID, slug)
@@ -157,8 +157,7 @@ func (b *awsLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (Leas
 				return LeaseTarget{}, exit(4, "lease/server not found: %s (instance exists but is not Crabbox-managed)", req.ID)
 			}
 			leaseID := blank(server.Labels["lease"], req.ID)
-			slug := strings.TrimSpace(server.Labels["slug"])
-			target := sshTargetForBootstrap(cfg, server.PublicNet.IPv4.IP, leaseID, slug)
+			target := sshTargetFromConfig(cfg, server.PublicNet.IPv4.IP)
 			useStoredTestboxKey(&target, leaseID)
 			return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 		}
@@ -174,8 +173,7 @@ func (b *awsLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (Leas
 		return LeaseTarget{}, err
 	} else if leaseID != "" {
 		cfg := awsConfigForServer(b.Cfg, server)
-		slug := strings.TrimSpace(server.Labels["slug"])
-		target := sshTargetForBootstrap(cfg, server.PublicNet.IPv4.IP, leaseID, slug)
+		target := sshTargetFromConfig(cfg, server.PublicNet.IPv4.IP)
 		useStoredTestboxKey(&target, leaseID)
 		return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 	}
@@ -415,12 +413,11 @@ func sshTargetFromConfig(cfg Config, host string) SSHTarget {
 	return core.SSHTargetFromConfig(cfg, host)
 }
 
-// bootstrapSSHHost returns the address used for bootstrap readiness probes and
-// subsequent SSH dials. When Tailscale is enabled the box self-enrolls via
-// cloud-init; EC2 operators cannot reach same-account public IPs, so probe the
-// rendered tailnet hostname instead of PublicNet IPv4 (#1049).
+// bootstrapSSHHost returns the address used for the acquisition readiness probe.
+// Strict Tailscale mode cannot fall back to the public address, which can be
+// unreachable from same-account EC2 operators even after cloud-init succeeds.
 func bootstrapSSHHost(cfg Config, publicIP, leaseID, slug string) string {
-	if !cfg.Tailscale.Enabled {
+	if cfg.Network != core.NetworkTailscale || !cfg.Tailscale.Enabled {
 		return publicIP
 	}
 	hostname := strings.TrimSpace(cfg.Tailscale.Hostname)

--- a/internal/providers/aws/backend_test.go
+++ b/internal/providers/aws/backend_test.go
@@ -1088,27 +1088,71 @@ func awsTestServer(id, leaseID, slug, region string) Server {
 	return server
 }
 
-func TestBootstrapSSHHostUsesTailscaleHostnameWhenEnabled(t *testing.T) {
+func TestBootstrapSSHHostRespectsNetworkMode(t *testing.T) {
 	t.Parallel()
-	cfg := Config{}
-	cfg.Provider = "aws"
-	cfg.Tailscale.Enabled = true
-	cfg.Tailscale.HostnameTemplate = "crabbox-{slug}"
-	host := bootstrapSSHHost(cfg, "203.0.113.10", "cbx_testlease", "blue")
-	if host == "203.0.113.10" {
-		t.Fatalf("expected tailscale hostname, got public IP %q", host)
+	base := Config{Provider: "aws"}
+	base.Tailscale.Enabled = true
+	base.Tailscale.HostnameTemplate = "crabbox-{slug}"
+	for _, test := range []struct {
+		name    string
+		network core.NetworkMode
+		enabled bool
+		want    string
+	}{
+		{name: "auto", network: core.NetworkAuto, enabled: true, want: "203.0.113.10"},
+		{name: "public", network: core.NetworkPublic, enabled: true, want: "203.0.113.10"},
+		{name: "strict tailscale", network: core.NetworkTailscale, enabled: true, want: "crabbox-blue"},
+		{name: "tailscale not provisioned", network: core.NetworkTailscale, enabled: false, want: "203.0.113.10"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := base
+			cfg.Network = test.network
+			cfg.Tailscale.Enabled = test.enabled
+			if got := bootstrapSSHHost(cfg, "203.0.113.10", "cbx_testlease", "blue"); got != test.want {
+				t.Fatalf("got %q want %q", got, test.want)
+			}
+		})
 	}
-	if host == "" {
-		t.Fatal("expected non-empty host")
-	}
-	// Explicit hostname wins over template.
-	cfg.Tailscale.Hostname = "explicit-host"
-	if got := bootstrapSSHHost(cfg, "203.0.113.10", "cbx_testlease", "blue"); got != "explicit-host" {
-		t.Fatalf("got %q want explicit-host", got)
-	}
-	// Disabled tailscale keeps public IP.
-	cfg.Tailscale.Enabled = false
-	if got := bootstrapSSHHost(cfg, "203.0.113.10", "cbx_testlease", "blue"); got != "203.0.113.10" {
-		t.Fatalf("got %q want public IP", got)
+}
+
+func TestAWSAcquireUsesTailscaleHostnameOnlyForStrictMode(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		network core.NetworkMode
+		want    string
+	}{
+		{name: "auto", network: core.NetworkAuto, want: "203.0.113.20"},
+		{name: "public", network: core.NetworkPublic, want: "203.0.113.20"},
+		{name: "tailscale", network: core.NetworkTailscale, want: "crabbox-bootstrap"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+			fake := &fakeAWSClient{}
+			oldClient := newAWSClient
+			newAWSClient = func(context.Context, Config) (awsClient, error) { return fake, nil }
+			oldBootstrap := bootstrapAWSWindowsDesktop
+			var bootstrapHost string
+			bootstrapAWSWindowsDesktop = func(_ context.Context, _ Config, target *SSHTarget, _ string, _ io.Writer) error {
+				bootstrapHost = target.Host
+				return nil
+			}
+			t.Cleanup(func() {
+				newAWSClient = oldClient
+				bootstrapAWSWindowsDesktop = oldBootstrap
+			})
+
+			cfg := Config{Provider: "aws", TargetOS: "linux", AWSRegion: "us-east-1", Network: test.network}
+			cfg.Tailscale.Enabled = true
+			cfg.Tailscale.AuthKey = "test-auth-key"
+			cfg.Tailscale.HostnameTemplate = "crabbox-{slug}"
+			backend := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+			if _, err := backend.acquireOnce(context.Background(), false, "bootstrap"); err != nil {
+				t.Fatal(err)
+			}
+			if bootstrapHost != test.want {
+				t.Fatalf("bootstrap host=%q, want %q", bootstrapHost, test.want)
+			}
+		})
 	}
 }

--- a/internal/providers/aws/backend_test.go
+++ b/internal/providers/aws/backend_test.go
@@ -1087,3 +1087,28 @@ func awsTestServer(id, leaseID, slug, region string) Server {
 	server.PublicNet.IPv4.IP = "203.0.113.20"
 	return server
 }
+
+func TestBootstrapSSHHostUsesTailscaleHostnameWhenEnabled(t *testing.T) {
+	t.Parallel()
+	cfg := Config{}
+	cfg.Provider = "aws"
+	cfg.Tailscale.Enabled = true
+	cfg.Tailscale.HostnameTemplate = "crabbox-{slug}"
+	host := bootstrapSSHHost(cfg, "203.0.113.10", "cbx_testlease", "blue")
+	if host == "203.0.113.10" {
+		t.Fatalf("expected tailscale hostname, got public IP %q", host)
+	}
+	if host == "" {
+		t.Fatal("expected non-empty host")
+	}
+	// Explicit hostname wins over template.
+	cfg.Tailscale.Hostname = "explicit-host"
+	if got := bootstrapSSHHost(cfg, "203.0.113.10", "cbx_testlease", "blue"); got != "explicit-host" {
+		t.Fatalf("got %q want explicit-host", got)
+	}
+	// Disabled tailscale keeps public IP.
+	cfg.Tailscale.Enabled = false
+	if got := bootstrapSSHHost(cfg, "203.0.113.10", "cbx_testlease", "blue"); got != "203.0.113.10" {
+		t.Fatalf("got %q want public IP", got)
+	}
+}


### PR DESCRIPTION
## What problem this solves

With `--tailscale --network tailscale` on AWS, acquisition readiness always probed the instance public IPv4 address. An EC2 operator can lack public-IP reachability to another EC2 instance even after cloud-init has joined the lease to Tailscale, so `warmup` timed out instead of using the requested strict tailnet path.

## Change

- Render the lease Tailscale hostname before AWS acquisition readiness.
- Use that hostname only for strict `network=tailscale` acquisition.
- Preserve the existing public address for `network=auto`, `network=public`, and leases not provisioned with Tailscale.
- Leave normal Resolve behavior unchanged so the shared network selector continues to choose public or tailnet connectivity.
- Add helper and acquisition-path regression coverage for all three network modes.
- Add the maintainer changelog entry with contributor credit.

## Verification

```console
go test ./internal/providers/aws -count=1 -run 'TestBootstrapSSHHostRespectsNetworkMode|TestAWSAcquireUsesTailscaleHostnameOnlyForStrictMode'
go test -race ./internal/providers/aws ./internal/cli -count=1
go vet ./...
git diff --check origin/main...HEAD
```

All local checks pass.

## Live proof status

Attempted from a Tailscale-connected macOS operator:

```console
crabbox warmup --provider aws --target linux --os ubuntu:26.04 \
  --type t3.large --market on-demand --tailscale --network tailscale \
  --tailscale-tags tag:crabbox --idle-timeout 45m --ttl 1h \
  --slug aws-ts-1053 --timing-json
```

The request failed before AWS provisioning because the coordinator's configured Tailscale OAuth credential returned HTTP 401 (`tailscale_unavailable`). No AWS resource was created. Local direct-provider AWS credentials are also invalid, so exact create/use/delete proof remains gated on working AWS and Tailscale credentials. This PR should not merge until that provider proof or an explicit maintainer waiver is available.

Closes https://github.com/openclaw/crabbox/issues/1049
