### PR TITLE
fix(worker): count live reservations across months

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Counted live managed leases against monthly reserved-USD budgets after UTC month rollover until cleanup commits a terminal state, preventing overlapping reservations from bypassing configured cost caps. Thanks @coygeek.
 - Bounded coordinator lease and workspace history scans and kept saturated cleanup retry batches scheduled promptly, preventing large retained histories from exhausting Durable Object memory or stranding cleanup.
 
 ## 0.37.1 - 2026-07-11

--- a/docs/features/cost-usage.md
+++ b/docs/features/cost-usage.md
@@ -102,8 +102,9 @@ CRABBOX_DEFAULT_ORG                  org assigned when no org header is present
 ```
 
 Monthly budget checks add the candidate lease's `reservedUSD` to the month's existing
-reserved total for the relevant scope, so a lease that would push the scope over budget
-is refused before it provisions.
+reserved total for the relevant scope. Live managed leases keep reserving budget after
+a UTC month rollover until cleanup commits a terminal state. A lease that would push
+the scope over budget is refused before it provisions.
 
 ## Identity for usage accounting
 

--- a/worker/src/usage.ts
+++ b/worker/src/usage.ts
@@ -165,7 +165,9 @@ export function addLeaseToCostLimitUsage(
       usage.orgActiveLeases += 1;
     }
   }
-  if (monthKey(new Date(lease.createdAt)) !== usage.month) {
+  // A live lease still reserves provider spend in the active budget window,
+  // even when its creation month has rolled over.
+  if (!isLiveLease(lease) && monthKey(new Date(lease.createdAt)) !== usage.month) {
     return;
   }
   const reservedUSD = leaseUsage(lease, now).reservedUSD;

--- a/worker/test/usage.test.ts
+++ b/worker/test/usage.test.ts
@@ -262,6 +262,56 @@ describe("usage accounting", () => {
     expect(error).toContain("monthly budget for owner exceeded");
   });
 
+  it.each([
+    ["fleet", { maxMonthlyUSD: 10 }, "monthly budget exceeded"],
+    ["owner", { maxMonthlyUSDPerOwner: 10 }, "monthly budget for owner exceeded"],
+    ["org", { maxMonthlyUSDPerOrg: 10 }, "monthly budget for org exceeded"],
+  ] as const)(
+    "counts live prior-month reservations against the %s monthly budget",
+    (_, limit, message) => {
+      const now = new Date("2026-06-01T00:30:00Z");
+      const existing = testLease({
+        createdAt: "2026-05-31T23:30:00Z",
+        expiresAt: "2026-06-01T23:30:00Z",
+        maxEstimatedUSD: 9,
+      });
+      const candidate = testLease({
+        id: "cbx_month_boundary_candidate",
+        createdAt: now.toISOString(),
+        expiresAt: "2026-06-01T01:30:00Z",
+        maxEstimatedUSD: 2,
+      });
+
+      expect(
+        enforceCostLimits([existing], candidate, { ...costLimits({} as never), ...limit }, now),
+      ).toContain(message);
+    },
+  );
+
+  it("does not carry terminal prior-month reservations into the current budget", () => {
+    const now = new Date("2026-06-01T00:30:00Z");
+    const released = testLease({
+      createdAt: "2026-05-31T22:00:00Z",
+      endedAt: "2026-05-31T23:00:00Z",
+      state: "released",
+      maxEstimatedUSD: 9,
+    });
+    const candidate = testLease({
+      id: "cbx_month_boundary_released_candidate",
+      createdAt: now.toISOString(),
+      maxEstimatedUSD: 2,
+    });
+
+    expect(
+      enforceCostLimits(
+        [released],
+        candidate,
+        { ...costLimits({} as never), maxMonthlyUSD: 10 },
+        now,
+      ),
+    ).toBe("");
+  });
+
   it("allows configured capacity admins to use the admin owner active cap", () => {
     const now = new Date("2026-05-01T02:00:00Z");
     const activeLeases = Array.from({ length: 4 }, (_, index) =>


### PR DESCRIPTION
## Summary

- count live managed lease reservations in the active monthly budget window after UTC month rollover
- keep terminal prior-month reservations excluded from the current month
- cover fleet, owner, and organization caps at the month boundary
- document the enforcement semantics and credit the reporter

Fixes https://github.com/openclaw/crabbox/issues/1039

## Root cause

Cost-limit accounting filtered every reservation by its creation month. A lease still consuming provider capacity after rollover therefore stopped contributing to monthly reserved-USD caps until cleanup, permitting overlapping reservations above configured limits.

## Verification

- `npm test --prefix worker -- --run test/usage.test.ts`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- autoreview: clean, patch correctness 0.97
