### PR TITLE
fix(cli): verify setup-node downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Verified Node.js release archives against published SHA-256 checksums before local Actions hydration installs or reuses them, preventing unverified setup-node downloads from reaching the workflow PATH. Thanks @coygeek.
 - Counted live managed leases against monthly reserved-USD budgets after UTC month rollover until cleanup commits a terminal state, preventing overlapping reservations from bypassing configured cost caps. Thanks @coygeek.
 - Bounded coordinator lease and workspace history scans and kept saturated cleanup retry batches scheduled promptly, preventing large retained histories from exhausting Durable Object memory or stranding cleanup.
 

--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -1819,7 +1819,7 @@ __crabbox_setup_node() {
       *) case "$actual" in "$want") corepack enable >/dev/null 2>&1 || true; return 0 ;; esac ;;
     esac
   fi
-  local arch version dir tmp selector
+  local arch version archive checksums expected actual dir marker tmp extract selector
   arch="$(__crabbox_arch)"
   case "$dots" in
     0) selector="v${major}." ;;
@@ -1831,17 +1831,48 @@ __crabbox_setup_node() {
     echo "unable to resolve Node $major" >&2
     return 2
   fi
-	  dir="$RUNNER_TOOL_CACHE/node-${version}-linux-${arch}"
-	  if [ ! -x "$dir/bin/node" ]; then
-	    tmp="$RUNNER_TEMP/node-${version}.tar.xz"
-	    mkdir -p "$RUNNER_TOOL_CACHE" "$RUNNER_TEMP"
-	    curl -fsSL -o "$tmp" "https://nodejs.org/dist/${version}/node-${version}-linux-${arch}.tar.xz"
-	    __crabbox_ensure_xz || { echo "xz is required to extract Node archives; install xz-utils or use a fuller local-container image" >&2; return 2; }
-	    tar -xJf "$tmp" -C "$RUNNER_TOOL_CACHE"
-	  fi
-	  rm -f "$RUNNER_TOOL_CACHE/node"
-	  ln -s "$dir" "$RUNNER_TOOL_CACHE/node"
-	  export PATH="$RUNNER_TOOL_CACHE/node/bin:$PATH"
+  archive="node-${version}-linux-${arch}.tar.xz"
+  dir="$RUNNER_TOOL_CACHE/node-${version}-linux-${arch}"
+  marker="$dir/.crabbox-node-sha256"
+  tmp="$RUNNER_TEMP/$archive"
+  checksums="$RUNNER_TEMP/node-${version}-SHASUMS256.txt"
+  mkdir -p "$RUNNER_TOOL_CACHE" "$RUNNER_TEMP"
+  curl -fsSL -o "$checksums" "https://nodejs.org/dist/${version}/SHASUMS256.txt"
+  expected="$(awk -v archive="$archive" '$2 == archive || $2 == "*" archive { print $1; exit }' "$checksums")"
+  case "$expected" in ''|*[!0-9a-fA-F]*) expected= ;; esac
+  if [ "${#expected}" -ne 64 ]; then
+    echo "Node release checksums did not contain a valid digest for $archive" >&2
+    return 2
+  fi
+  if [ ! -x "$dir/bin/node" ] || [ ! -f "$marker" ] || [ "$(cat "$marker" 2>/dev/null || true)" != "$expected" ]; then
+    curl -fsSL -o "$tmp" "https://nodejs.org/dist/${version}/${archive}"
+    if command -v sha256sum >/dev/null 2>&1; then
+      actual="$(sha256sum "$tmp" | awk '{ print $1 }')"
+    elif command -v shasum >/dev/null 2>&1; then
+      actual="$(shasum -a 256 "$tmp" | awk '{ print $1 }')"
+    else
+      echo "sha256sum or shasum is required to verify Node archives" >&2
+      return 2
+    fi
+    actual="$(printf '%s' "$actual" | tr 'A-F' 'a-f')"
+    if [ "$actual" != "$expected" ]; then
+      echo "Node archive checksum mismatch for $archive" >&2
+      return 2
+    fi
+    __crabbox_ensure_xz || { echo "xz is required to extract Node archives; install xz-utils or use a fuller local-container image" >&2; return 2; }
+    extract="$RUNNER_TEMP/node-${version}-extract"
+    rm -rf "$extract"
+    mkdir -p "$extract"
+    tar -xJf "$tmp" -C "$extract"
+    [ -x "$extract/node-${version}-linux-${arch}/bin/node" ] || { echo "Node archive has an unexpected layout" >&2; return 2; }
+    rm -rf "$dir"
+    mv "$extract/node-${version}-linux-${arch}" "$dir"
+    printf '%s\n' "$expected" >"$marker"
+    rm -rf "$extract"
+  fi
+  rm -f "$RUNNER_TOOL_CACHE/node"
+  ln -s "$dir" "$RUNNER_TOOL_CACHE/node"
+  export PATH="$RUNNER_TOOL_CACHE/node/bin:$PATH"
   corepack enable >/dev/null 2>&1 || true
 }
 __crabbox_setup_go() {

--- a/internal/cli/actions_test.go
+++ b/internal/cli/actions_test.go
@@ -926,6 +926,92 @@ func TestLocalActionsHydrateScriptAllowsSetupNodeCheckLatest(t *testing.T) {
 	}
 }
 
+func TestLocalActionsSetupNodeVerifiesArchiveBeforeExtraction(t *testing.T) {
+	got := localActionsRuntimeShell()
+	for _, want := range []string{
+		`SHASUMS256.txt`,
+		`Node release checksums did not contain a valid digest`,
+		`Node archive checksum mismatch`,
+		`.crabbox-node-sha256`,
+		`tar -xJf "$tmp" -C "$extract"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("setup-node runtime missing %q", want)
+		}
+	}
+	checksum := strings.Index(got, `actual="$(sha256sum "$tmp"`)
+	extract := strings.Index(got, `tar -xJf "$tmp"`)
+	if checksum < 0 || extract < checksum {
+		t.Fatalf("setup-node must verify the archive before extraction: checksum=%d extract=%d", checksum, extract)
+	}
+}
+
+func TestLocalActionsSetupNodeRejectsMissingOrMismatchedChecksum(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		checksums string
+		want      string
+	}{
+		{name: "missing", checksums: "", want: "did not contain a valid digest"},
+		{name: "mismatch", checksums: strings.Repeat("a", 64) + "  node-v88.0.0-linux-x64.tar.xz\n", want: "checksum mismatch"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			binDir := filepath.Join(root, "bin")
+			if err := os.MkdirAll(binDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			commands := map[string]string{
+				"curl": `#!/bin/sh
+out=
+url=
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-o" ]; then shift; out="$1"; else url="$1"; fi
+  shift
+done
+case "$url" in
+  */index.tab) printf 'version\n%s\n' 'v88.0.0' ;;
+  */SHASUMS256.txt) printf '%s' "$TEST_CHECKSUMS" >"$out" ;;
+  *) printf archive >"$out" ;;
+esac
+`,
+				"sha256sum": `#!/bin/sh
+printf '%s  %s\n' 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' "$1"
+`,
+				"tar": `#!/bin/sh
+touch "$TAR_CALLED"
+exit 99
+`,
+				"node":  "#!/bin/sh\nprintf '22.0.0\\n'\n",
+				"uname": "#!/bin/sh\nprintf 'x86_64\\n'\n",
+			}
+			for name, script := range commands {
+				if err := os.WriteFile(filepath.Join(binDir, name), []byte(script), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			}
+			tarCalled := filepath.Join(root, "tar-called")
+			script := localActionsRuntimeShell() + "\n__crabbox_setup_node 88\n"
+			cmd := exec.Command("bash", "-c", script)
+			cmd.Env = append(os.Environ(),
+				"GITHUB_WORKSPACE="+root,
+				"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+				"RUNNER_TEMP="+filepath.Join(root, "tmp"),
+				"RUNNER_TOOL_CACHE="+filepath.Join(root, "tools"),
+				"TAR_CALLED="+tarCalled,
+				"TEST_CHECKSUMS="+tc.checksums,
+			)
+			output, err := cmd.CombinedOutput()
+			if err == nil || !strings.Contains(string(output), tc.want) {
+				t.Fatalf("setup-node err=%v output=%q, want %q", err, output, tc.want)
+			}
+			if _, err := os.Stat(tarCalled); !os.IsNotExist(err) {
+				t.Fatalf("archive extraction ran before checksum rejection: %v", err)
+			}
+		})
+	}
+}
+
 func TestLocalActionsHydrateScriptKeepsToolCacheOffWorkRoot(t *testing.T) {
 	job := localHydrateJob{Steps: []localHydrateStep{{Uses: "actions/setup-node@v4", With: map[string]string{"node-version": "22"}}}}
 	workdir := "/work/cbx_123/repo"


### PR DESCRIPTION
## Summary

- verify the selected Node.js release archive against its published `SHASUMS256.txt` digest before extraction
- install through a private staging directory and bind cache reuse to the verified digest
- fail closed when integrity metadata is missing or mismatched

Closes https://github.com/openclaw/crabbox/issues/1037

## Verification

- `go test ./internal/cli -run 'TestLocalActionsSetupNode|TestLocalActionsHydrateScriptAllowsSetupNodeCheckLatest|TestLocalActionsRuntimeValidatesGoAndPythonVersions' -count=1`
- `go test -race ./internal/cli -count=1`
- `.agents/skills/autoreview/scripts/autoreview --mode local --parallel-tests "go test -race ./internal/cli -count=1" --stream-engine-output` — clean, correctness confidence 0.94

## Compatibility

The documented local `actions/setup-node` workflow remains automatic. Existing installations are reused only when their private tool-cache directory carries the digest published for the selected archive; missing or invalid release integrity metadata now fails closed before extraction.
