### PR TITLE
feat: expose authoritative SSH host keys in inspect --json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added optional authoritative pre-boot SSH host public keys to coordinator-backed Linux lease inspection for fail-closed identity pinning.
 - Redesigned the documentation site around first-class provider discovery, with complete provider navigation, multi-category filtering, responsive tables and mobile navigation, and accessibility improvements. Thanks @zozo123.
 - Added explicit GCP metadata-server authentication for brokered coordinators, with hardened token validation, bounded retries, source-aware readiness diagnostics, and preserved service-account-key defaults. Thanks @dani29.
 

--- a/docs/commands/inspect.md
+++ b/docs/commands/inspect.md
@@ -59,6 +59,20 @@ key path, port, user, and host). Empty fields render as `-`.
 label map. Secrets such as broker tokens, provider keys, and VNC passwords are
 never included in either output mode.
 
+For coordinator leases whose provider can inject an SSH host key before first
+boot, JSON also includes `sshHostKey`. Its value is exactly the public host-key
+algorithm and base64 payload, without a hostname or comment:
+
+```json
+{
+  "sshHostKey": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA..."
+}
+```
+
+The key is the authoritative public half generated for provisioning, not a key
+learned later through `known_hosts` or `ssh-keyscan`. The field is omitted when
+the provider cannot inject a host key before boot.
+
 ## Flags
 
 ```text

--- a/docs/features/ssh-keys.md
+++ b/docs/features/ssh-keys.md
@@ -37,10 +37,11 @@ is sent only in the provider bootstrap payload. `crabbox inspect --json`
 exposes the public identity as `sshHostKey` in exact `algorithm base64` form for
 automation that pins the server identity before connecting.
 
-This pre-boot path is available for Hetzner, AWS, and GCP Linux leases, and for
-Azure Linux leases not created from a snapshot. The field is omitted for
-Windows, macOS, Daytona, Azure snapshot, registered, and direct-provider leases,
-where Crabbox cannot authoritatively inject a host key before boot.
+This pre-boot path is available for Hetzner, GCP, and non-private AWS Linux
+leases, and for Azure Linux leases not created from a snapshot. The field is
+omitted for private AWS workspaces, Windows, macOS, Daytona, Azure snapshot,
+registered, and direct-provider leases, where Crabbox cannot authoritatively
+inject a host key before boot.
 
 ## Host-key trust and connection reuse
 

--- a/docs/features/ssh-keys.md
+++ b/docs/features/ssh-keys.md
@@ -6,9 +6,9 @@ Read when:
 - debugging SSH authentication or host-key trust;
 - changing how provider key pairs are imported or cleaned up.
 
-Crabbox generates a fresh SSH key per lease by default. This keeps a long-lived
-personal key out of every runner and gives the provider layer a predictable,
-per-lease resource name it can import and later delete.
+Crabbox generates a fresh SSH client authentication key per lease by default.
+This keeps a long-lived personal key out of every runner and gives the provider
+layer a predictable, per-lease resource name it can import and later delete.
 
 ## Per-lease key generation
 
@@ -28,6 +28,20 @@ Linux:   ~/.config/crabbox/testboxes/<lease>/id_ed25519
 The matching `<lease>/id_ed25519.pub` sits beside it. The key directory is
 created with `0700` permissions.
 
+## Provisioned host identity
+
+For supported coordinator-backed Linux leases, the coordinator also generates
+a separate Ed25519 server host-key pair and injects it before the machine's
+first boot. It stores only the public half on the lease record; the private half
+is sent only in the provider bootstrap payload. `crabbox inspect --json`
+exposes the public identity as `sshHostKey` in exact `algorithm base64` form for
+automation that pins the server identity before connecting.
+
+This pre-boot path is available for Hetzner, AWS, and GCP Linux leases, and for
+Azure Linux leases not created from a snapshot. The field is omitted for
+Windows, macOS, Daytona, Azure snapshot, registered, and direct-provider leases,
+where Crabbox cannot authoritatively inject a host key before boot.
+
 ## Host-key trust and connection reuse
 
 A per-lease `known_hosts` file lives next to the key
@@ -44,6 +58,9 @@ A per-lease `known_hosts` file lives next to the key
 Because host keys are scoped to the lease's own file, a reused provider IP from
 a previous lease never poisons the user's global `~/.ssh/known_hosts`, and two
 leases sharing an address do not cross host-key state.
+
+The coordinator host-key metadata does not change this interactive trust path:
+`crabbox ssh` continues to use per-lease TOFU with `accept-new`.
 
 On macOS and Linux, connection multiplexing is enabled
 (`ControlMaster=auto`, `ControlPersist=10m`) with a `ControlPath` scoped by the

--- a/docs/security.md
+++ b/docs/security.md
@@ -693,8 +693,10 @@ The coordinator stores only operational metadata:
 - the command string, unless disabled.
 
 The coordinator does **not** store unbounded logs, environment values, file
-contents, or SSH keys. Run records keep bounded stdout/stderr captures (chunked,
-with a stored cap) and optional structured JUnit summaries for debugging.
+contents, or SSH private keys. For supported leases it stores the authoritative
+public SSH host key injected before first boot as operational identity metadata.
+Run records keep bounded stdout/stderr captures (chunked, with a stored cap) and
+optional structured JUnit summaries for debugging.
 
 For binary or sensitive-by-format output, use `crabbox run --capture-stdout
 <path>` or `--capture-stderr <path>` so the stream is written to a local file

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -83,6 +83,7 @@ type CoordinatorLease struct {
 	Host                  string                `json:"host"`
 	SSHUser               string                `json:"sshUser"`
 	SSHPort               string                `json:"sshPort"`
+	SSHHostKey            string                `json:"sshHostKey,omitempty"`
 	SSHFallbackPorts      []string              `json:"sshFallbackPorts,omitempty"`
 	WorkRoot              string                `json:"workRoot"`
 	Keep                  bool                  `json:"keep"`
@@ -2112,6 +2113,7 @@ func leaseToServerTarget(lease CoordinatorLease, cfg Config) (Server, SSHTarget,
 		cfg.WindowsMode = lease.WindowsMode
 	}
 	target := sshTargetForLease(cfg, lease.Host, lease.SSHUser, lease.SSHPort)
+	target.SSHHostKey = lease.SSHHostKey
 	if server.Provider == "daytona" {
 		target.Key = ""
 		target.ReadyCheck = "command -v git >/dev/null && command -v rsync >/dev/null && command -v tar >/dev/null"

--- a/internal/cli/provider_coordinator.go
+++ b/internal/cli/provider_coordinator.go
@@ -315,6 +315,7 @@ func (b *coordinatorLeaseBackend) Status(ctx context.Context, req StatusRequest)
 		Network:          resolved.Network,
 		Tailscale:        lease.Tailscale,
 		SSHHost:          target.Host,
+		SSHHostKey:       target.SSHHostKey,
 		SSHUser:          redactedSSHUser(b.cfg, server, target),
 		SSHPort:          target.Port,
 		SSHFallbackPorts: target.FallbackPorts,

--- a/internal/cli/provider_coordinator_test.go
+++ b/internal/cli/provider_coordinator_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -201,6 +202,59 @@ func TestCoordinatorStatusRedactsDaytonaSSHAccessToken(t *testing.T) {
 	}
 	if status.SSHUser != "<token>" {
 		t.Fatalf("sshUser=%q, want redacted token", status.SSHUser)
+	}
+}
+
+func TestCoordinatorInspectJSONIncludesOptionalSSHHostKey(t *testing.T) {
+	const sshHostKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILocalAuthoritativeHostKey"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.HasPrefix(r.URL.Path, "/v1/leases/") {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		lease := CoordinatorLease{
+			ID:       strings.TrimPrefix(r.URL.Path, "/v1/leases/"),
+			Provider: "aws",
+			TargetOS: targetLinux,
+			State:    "provisioning",
+		}
+		if lease.ID == "cbx_with_key" {
+			lease.SSHHostKey = sshHostKey
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease})
+	}))
+	defer server.Close()
+
+	clearConfigEnv(t)
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+	t.Setenv("CRABBOX_COORDINATOR", server.URL)
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "user-token")
+
+	for _, test := range []struct {
+		id      string
+		wantKey bool
+	}{
+		{id: "cbx_with_key", wantKey: true},
+		{id: "cbx_without_key", wantKey: false},
+	} {
+		t.Run(test.id, func(t *testing.T) {
+			var stdout bytes.Buffer
+			app := App{Stdout: &stdout, Stderr: &bytes.Buffer{}}
+			if err := app.inspect(context.Background(), []string{"--provider", "aws", "--id", test.id, "--json"}); err != nil {
+				t.Fatal(err)
+			}
+			var got map[string]any
+			if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+				t.Fatal(err)
+			}
+			value, ok := got["sshHostKey"]
+			if test.wantKey {
+				if !ok || value != sshHostKey {
+					t.Fatalf("sshHostKey=%#v present=%t, want %q", value, ok, sshHostKey)
+				}
+			} else if ok {
+				t.Fatalf("sshHostKey=%#v, want omitted", value)
+			}
+		})
 	}
 }
 
@@ -403,6 +457,7 @@ func TestLeaseToServerTargetPreservesCoordinatorWorkRoot(t *testing.T) {
 		SSHUser:    "ec2-user",
 		SSHPort:    "22",
 		Host:       "203.0.113.10",
+		SSHHostKey: "ssh-ed25519 AAAAauthoritative",
 		WorkRoot:   defaultMacOSWorkRoot,
 		ServerType: "mac2.metal",
 		State:      "active",
@@ -413,6 +468,9 @@ func TestLeaseToServerTargetPreservesCoordinatorWorkRoot(t *testing.T) {
 	}
 	if target.TargetOS != targetMacOS || target.User != "ec2-user" || target.Port != "22" {
 		t.Fatalf("target=%#v", target)
+	}
+	if target.SSHHostKey != "ssh-ed25519 AAAAauthoritative" {
+		t.Fatalf("ssh host key=%q", target.SSHHostKey)
 	}
 	if server.Labels["work_root"] != defaultMacOSWorkRoot {
 		t.Fatalf("work_root label=%q want %q", server.Labels["work_root"], defaultMacOSWorkRoot)

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -24,6 +24,7 @@ import (
 type SSHTarget struct {
 	User                   string
 	Host                   string
+	SSHHostKey             string
 	Key                    string
 	CertificateFile        string
 	KnownHostsFile         string

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -210,6 +210,7 @@ func statusViewFromLeaseTarget(ctx context.Context, cfg Config, lease LeaseTarge
 		Network:          resolved.Network,
 		Tailscale:        tailscale,
 		SSHHost:          target.Host,
+		SSHHostKey:       target.SSHHostKey,
 		SSHUser:          redactedSSHUser(cfg, server, target),
 		SSHPort:          target.Port,
 		SSHFallbackPorts: target.FallbackPorts,
@@ -245,6 +246,7 @@ type StatusView struct {
 	Network          NetworkMode        `json:"network"`
 	Tailscale        *TailscaleMetadata `json:"tailscale,omitempty"`
 	SSHHost          string             `json:"sshHost"`
+	SSHHostKey       string             `json:"sshHostKey,omitempty"`
 	SSHUser          string             `json:"sshUser"`
 	SSHPort          string             `json:"sshPort"`
 	SSHFallbackPorts []string           `json:"sshFallbackPorts,omitempty"`

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -2485,6 +2485,10 @@ export class FleetCoordinator {
       providerRegionForConfig(config),
       providerProjectForConfig(config),
     );
+    const injectsSSHHostKey = provider.supportsSSHHostKeyInjection(config);
+    if (injectsSSHHostKey) {
+      config = withSSHHostKey(config, `crabbox-${leaseID}`);
+    }
     const providerHourlyUSD = await provider
       .hourlyPriceUSD(config.serverType, config)
       .catch(() => undefined);
@@ -2670,6 +2674,7 @@ export class FleetCoordinator {
         sshUser: config.sshUser,
         sshPort: config.sshPort,
         sshFallbackPorts: config.sshFallbackPorts,
+        ...(injectsSSHHostKey ? { sshHostKey: sshPublicKeyIdentity(config.sshHostPublicKey) } : {}),
         workRoot: config.workRoot,
         keep: config.keep,
         ttlSeconds: config.ttlSeconds,
@@ -3709,9 +3714,7 @@ export class FleetCoordinator {
     const provisionClaim = crypto.randomUUID();
     const sshHostKeys = workspaceCapability
       ? undefined
-      : sshUtils.generateKeyPairSync("ed25519", {
-          comment: `crabbox-${workspace.id}`,
-        });
+      : generateSSHHostKeyPair(`crabbox-${workspace.id}`);
     const sshHostKeySha256 = sshHostKeys
       ? await workspaceSSHHostKeyFingerprint(sshHostKeys.public)
       : undefined;
@@ -16600,6 +16603,25 @@ function workspaceSSHHostKeysFromRequest(
   }
 }
 
+function generateSSHHostKeyPair(comment: string): { private: string; public: string } {
+  return sshUtils.generateKeyPairSync("ed25519", { comment });
+}
+
+function withSSHHostKey(config: LeaseConfig, comment: string): LeaseConfig {
+  if (config.sshHostPrivateKey || config.sshHostPublicKey) {
+    if (!config.sshHostPrivateKey || !config.sshHostPublicKey) {
+      throw new Error("SSH host key material must include both private and public halves");
+    }
+    return config;
+  }
+  const hostKeys = generateSSHHostKeyPair(comment);
+  return {
+    ...config,
+    sshHostPrivateKey: hostKeys.private,
+    sshHostPublicKey: hostKeys.public,
+  };
+}
+
 async function workspaceSSHHostKeyFingerprint(publicKey: string): Promise<string> {
   const [type, encoded] = publicKey.trim().split(/\s+/u, 3);
   if (type !== "ssh-ed25519" || !encoded) {
@@ -17971,6 +17993,7 @@ interface CloudProvider {
     lease?: LeaseRecord,
     purpose?: "operate" | "observe",
   ): ProviderWorkspaceCapability | undefined;
+  supportsSSHHostKeyInjection(config: ReturnType<typeof leaseConfig>): boolean;
   restrictedLeaseRequestFields?(input: LeaseRequest): string[];
   recoverServer?(lease: LeaseRecord): Promise<ProviderMachine | undefined>;
   resumeRecoveredServer?(
@@ -18140,6 +18163,10 @@ export class HetznerProvider implements CloudProvider {
     return servers.map((server) => this.client.toMachine(server));
   }
 
+  supportsSSHHostKeyInjection(config: ReturnType<typeof leaseConfig>): boolean {
+    return config.target === "linux";
+  }
+
   async findServerByLease(leaseID: string): Promise<ProviderMachine | undefined> {
     const server = await this.client.findServerByLease(leaseID);
     return server ? this.client.toMachine(server) : undefined;
@@ -18294,6 +18321,10 @@ export class AzureProvider implements CloudProvider {
 
   listCrabboxServers(): Promise<ProviderMachine[]> {
     return this.client.listCrabboxServers();
+  }
+
+  supportsSSHHostKeyInjection(config: ReturnType<typeof leaseConfig>): boolean {
+    return config.target === "linux" && !config.azureSnapshot;
   }
 
   getServer(id: string): Promise<ProviderMachine> {
@@ -18483,6 +18514,10 @@ export class GCPProvider implements CloudProvider {
     return this.client.listCrabboxServers();
   }
 
+  supportsSSHHostKeyInjection(config: ReturnType<typeof leaseConfig>): boolean {
+    return config.target === "linux";
+  }
+
   getServer(id: string): Promise<ProviderMachine> {
     return this.client.getServer(id);
   }
@@ -18648,6 +18683,10 @@ export class DaytonaProvider implements CloudProvider {
 
   listCrabboxServers(): Promise<ProviderMachine[]> {
     return this.client.listCrabboxServers();
+  }
+
+  supportsSSHHostKeyInjection(): boolean {
+    return false;
   }
 
   getServer(id: string): Promise<ProviderMachine> {
@@ -18908,6 +18947,10 @@ export class AWSProvider implements CloudProvider {
 
   listCrabboxServers(): Promise<ProviderMachine[]> {
     return this.client.listCrabboxServers();
+  }
+
+  supportsSSHHostKeyInjection(config: ReturnType<typeof leaseConfig>): boolean {
+    return config.target === "linux" && !config.awsPrivate;
   }
 
   getServer(id: string): Promise<ProviderMachine> {

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -2283,6 +2283,7 @@ export class FleetCoordinator {
     request: Request,
     reservationGuard?: () => Promise<Response | undefined>,
     workspaceID?: string,
+    workspaceCapability?: ProviderWorkspaceCapability,
   ): Promise<Response> {
     const owner = requestOwner(request);
     const org = requestOrg(request, this.env);
@@ -2319,7 +2320,7 @@ export class FleetCoordinator {
     }
     if (workspaceID) {
       config = { ...config, awsUseStockImage: config.provider === "aws" };
-      if (!config.awsPrivate) {
+      if (!workspaceCapability) {
         const hostKeys = workspaceSSHHostKeysFromRequest(request);
         if (!hostKeys) {
           return json(
@@ -2485,7 +2486,7 @@ export class FleetCoordinator {
       providerRegionForConfig(config),
       providerProjectForConfig(config),
     );
-    const injectsSSHHostKey = provider.supportsSSHHostKeyInjection(config);
+    const injectsSSHHostKey = !workspaceCapability && provider.supportsSSHHostKeyInjection(config);
     if (injectsSSHHostKey) {
       config = withSSHHostKey(config, `crabbox-${leaseID}`);
     }
@@ -3779,6 +3780,7 @@ export class FleetCoordinator {
           return undefined;
         },
         workspace.id,
+        workspaceCapability,
       );
     } catch (error) {
       const persistedLease = await this.getLease(workspace.leaseID);

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -439,6 +439,7 @@ export interface LeaseRecord {
   sshUser: string;
   sshPort: string;
   sshFallbackPorts?: string[];
+  sshHostKey?: string;
   providerAccessExpiresAt?: string;
   workRoot: string;
   keep: boolean;

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -17,6 +17,7 @@ import { CloudflareCoordinatorRuntime } from "../src/coordinator-runtime";
 import {
   AWSProvider,
   AzureProvider,
+  DaytonaProvider,
   FleetCoordinator,
   FleetDurableObject,
   GCPProvider,
@@ -6280,6 +6281,13 @@ describe("fleet lease identity and idle", () => {
     );
     expect(createdHostPrivateKey).toContain("BEGIN OPENSSH PRIVATE KEY");
     expect(createdHostPublicKey).toMatch(/^ssh-ed25519 /);
+    const createdHostKeyIdentity = createdHostPublicKey.trim().split(/\s+/u).slice(0, 2).join(" ");
+    expect(createdHostKeyIdentity.split(/\s+/u)).toHaveLength(2);
+    const persistedWorkspaceLease = storage.value<LeaseRecord>(
+      `lease:${created.providerResourceId}`,
+    );
+    expect(persistedWorkspaceLease?.sshHostKey).toBe(createdHostKeyIdentity);
+    expect(JSON.stringify(persistedWorkspaceLease)).not.toContain(createdHostPrivateKey);
     expect(
       storage.value<{ sshHostKeySha256?: string }>(workspaceFixtureKey("fleet-is-101"))
         ?.sshHostKeySha256,
@@ -13321,9 +13329,13 @@ describe("fleet lease identity and idle", () => {
   it("persists brokered leases as provisioning before provider create returns", async () => {
     const storage = new MemoryStorage();
     let storedDuringCreate: LeaseRecord | undefined;
+    let injectedHostPrivateKey = "";
+    let injectedHostPublicKey = "";
     const fleet = testFleet(storage, {
       azure: fakeProvider(
-        () => {
+        (config) => {
+          injectedHostPrivateKey = config.sshHostPrivateKey;
+          injectedHostPublicKey = config.sshHostPublicKey;
           storedDuringCreate = structuredClone(storage.value("lease:cbx_abcdef123456"));
         },
         { provider: "azure", cloudID: "vm-cbx-abcdef123456", region: "eastus" },
@@ -13353,14 +13365,134 @@ describe("fleet lease identity and idle", () => {
       state: "provisioning",
       cloudID: "",
     });
+    expect(injectedHostPrivateKey).toContain("BEGIN OPENSSH PRIVATE KEY");
+    const injectedHostKeyIdentity = injectedHostPublicKey
+      .trim()
+      .split(/\s+/u)
+      .slice(0, 2)
+      .join(" ");
+    expect(injectedHostKeyIdentity).toMatch(/^ssh-ed25519 [A-Za-z0-9+/]+={0,2}$/u);
+    expect(injectedHostKeyIdentity.split(/\s+/u)).toHaveLength(2);
+    expect(storedDuringCreate?.sshHostKey).toBe(injectedHostKeyIdentity);
+    expect(JSON.stringify(storedDuringCreate)).not.toContain(injectedHostPrivateKey);
     const { lease } = (await create.json()) as { lease: LeaseRecord };
     expect(lease).toMatchObject({
       id: "cbx_abcdef123456",
       provider: "azure",
       state: "active",
       cloudID: "vm-cbx-abcdef123456",
+      sshHostKey: injectedHostKeyIdentity,
     });
-    expect(storage.value<LeaseRecord>("lease:cbx_abcdef123456")?.state).toBe("active");
+    const storedLease = storage.value<LeaseRecord>("lease:cbx_abcdef123456");
+    expect(storedLease?.state).toBe("active");
+    expect(storedLease?.sshHostKey).toBe(injectedHostKeyIdentity);
+    expect(JSON.stringify(storedLease)).not.toContain(injectedHostPrivateKey);
+  });
+
+  it("omits SSH host keys when a provider cannot inject them before boot", async () => {
+    const storage = new MemoryStorage();
+    let createdConfig: LeaseConfig | undefined;
+    const fleet = testFleet(storage, {
+      azure: fakeProvider(
+        (config) => {
+          createdConfig = config;
+        },
+        { provider: "azure", cloudID: "vm-cbx-abcdef123456", region: "eastus" },
+      ),
+    });
+
+    const create = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers: {
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
+          "x-crabbox-admin": "true",
+        },
+        body: {
+          leaseID: "cbx_abcdef123456",
+          provider: "azure",
+          azureLocation: "eastus",
+          azureSnapshot: "snapshot-cbx-abcdef123456",
+          sshPublicKey: "ssh-ed25519 test",
+        },
+      }),
+    );
+
+    expect(create.status).toBe(201);
+    expect(createdConfig?.sshHostPrivateKey).toBe("");
+    expect(createdConfig?.sshHostPublicKey).toBe("");
+    const { lease } = (await create.json()) as { lease: LeaseRecord };
+    expect(lease.sshHostKey).toBeUndefined();
+    expect(lease).not.toHaveProperty("sshHostKey");
+    const storedLease = storage.value<LeaseRecord>("lease:cbx_abcdef123456");
+    expect(storedLease?.sshHostKey).toBeUndefined();
+    expect(storedLease).not.toHaveProperty("sshHostKey");
+  });
+
+  it("limits SSH host-key injection to authoritative provider paths", () => {
+    const env = {} as Env;
+    const storage = new MemoryStorage();
+
+    expect(
+      new HetznerProvider(env).supportsSSHHostKeyInjection(
+        leaseConfig({ provider: "hetzner", target: "linux", sshPublicKey: "ssh-ed25519 test" }),
+      ),
+    ).toBe(true);
+    expect(
+      new AWSProvider(env, "us-east-1", storage).supportsSSHHostKeyInjection(
+        leaseConfig({ provider: "aws", target: "linux", sshPublicKey: "ssh-ed25519 test" }),
+      ),
+    ).toBe(true);
+    expect(
+      new AWSProvider(env, "us-east-1", storage).supportsSSHHostKeyInjection(
+        leaseConfig({
+          provider: "aws",
+          target: "linux",
+          awsPrivate: true,
+          sshPublicKey: "",
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      new GCPProvider(env).supportsSSHHostKeyInjection(
+        leaseConfig({ provider: "gcp", target: "linux", sshPublicKey: "ssh-ed25519 test" }),
+      ),
+    ).toBe(true);
+    expect(
+      new AzureProvider(env).supportsSSHHostKeyInjection(
+        leaseConfig({ provider: "azure", target: "linux", sshPublicKey: "ssh-ed25519 test" }),
+      ),
+    ).toBe(true);
+    expect(
+      new AzureProvider(env).supportsSSHHostKeyInjection(
+        leaseConfig({
+          provider: "azure",
+          target: "linux",
+          azureSnapshot: "snapshot-cbx-abcdef123456",
+          sshPublicKey: "ssh-ed25519 test",
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      new AWSProvider(env, "us-east-1", storage).supportsSSHHostKeyInjection(
+        leaseConfig({ provider: "aws", target: "windows", sshPublicKey: "ssh-ed25519 test" }),
+      ),
+    ).toBe(false);
+    expect(
+      new AWSProvider(env, "us-east-1", storage).supportsSSHHostKeyInjection(
+        leaseConfig({
+          provider: "aws",
+          target: "macos",
+          capacity: { market: "on-demand" },
+          sshPublicKey: "ssh-ed25519 test",
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      new DaytonaProvider(env).supportsSSHHostKeyInjection(
+        leaseConfig({ provider: "daytona", target: "linux", sshPublicKey: "ssh-ed25519 test" }),
+      ),
+    ).toBe(false);
   });
 
   it("rejects a concurrent create with the same lease ID", async () => {
@@ -25858,6 +25990,15 @@ function fakeProvider(
         return await result.onList();
       }
       return result.servers ?? [];
+    },
+    supportsSSHHostKeyInjection(config: LeaseConfig) {
+      const provider = result.provider ?? config.provider;
+      return (
+        config.target === "linux" &&
+        provider !== "daytona" &&
+        !(provider === "aws" && config.awsPrivate) &&
+        !(provider === "azure" && config.azureSnapshot)
+      );
     },
     restrictedLeaseRequestFields(input: LeaseRequest) {
       return result.onRestrictedLeaseRequestFields?.(input) ?? [];

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -6287,7 +6287,7 @@ describe("fleet lease identity and idle", () => {
       `lease:${created.providerResourceId}`,
     );
     expect(persistedWorkspaceLease?.sshHostKey).toBe(createdHostKeyIdentity);
-    expect(JSON.stringify(persistedWorkspaceLease)).not.toContain(createdHostPrivateKey);
+    expect(JSON.stringify(persistedWorkspaceLease)).not.toContain("BEGIN OPENSSH PRIVATE KEY");
     expect(
       storage.value<{ sshHostKeySha256?: string }>(workspaceFixtureKey("fleet-is-101"))
         ?.sshHostKeySha256,
@@ -13374,7 +13374,7 @@ describe("fleet lease identity and idle", () => {
     expect(injectedHostKeyIdentity).toMatch(/^ssh-ed25519 [A-Za-z0-9+/]+={0,2}$/u);
     expect(injectedHostKeyIdentity.split(/\s+/u)).toHaveLength(2);
     expect(storedDuringCreate?.sshHostKey).toBe(injectedHostKeyIdentity);
-    expect(JSON.stringify(storedDuringCreate)).not.toContain(injectedHostPrivateKey);
+    expect(JSON.stringify(storedDuringCreate)).not.toContain("BEGIN OPENSSH PRIVATE KEY");
     const { lease } = (await create.json()) as { lease: LeaseRecord };
     expect(lease).toMatchObject({
       id: "cbx_abcdef123456",
@@ -13386,7 +13386,7 @@ describe("fleet lease identity and idle", () => {
     const storedLease = storage.value<LeaseRecord>("lease:cbx_abcdef123456");
     expect(storedLease?.state).toBe("active");
     expect(storedLease?.sshHostKey).toBe(injectedHostKeyIdentity);
-    expect(JSON.stringify(storedLease)).not.toContain(injectedHostPrivateKey);
+    expect(JSON.stringify(storedLease)).not.toContain("BEGIN OPENSSH PRIVATE KEY");
   });
 
   it("omits SSH host keys when a provider cannot inject them before boot", async () => {
@@ -13449,6 +13449,7 @@ describe("fleet lease identity and idle", () => {
           provider: "aws",
           target: "linux",
           awsPrivate: true,
+          awsRequireSSM: true,
           sshPublicKey: "",
         }),
       ),

--- a/worker/test/private-aws-workspace.test.ts
+++ b/worker/test/private-aws-workspace.test.ts
@@ -189,7 +189,8 @@ describe("private AWS workspaces", () => {
         return [];
       },
       supportsSSHHostKeyInjection(): boolean {
-        return false;
+        // Capability-owned workspaces must bypass generic provider host-key injection.
+        return true;
       },
       async findServerByLease(): Promise<ProviderMachine | undefined> {
         return undefined;
@@ -249,7 +250,8 @@ describe("private AWS workspaces", () => {
         return undefined;
       },
     };
-    const fleet = new FleetCoordinator(new MemoryRuntime(), privateAWSEnv(), {
+    const runtime = new MemoryRuntime();
+    const fleet = new FleetCoordinator(runtime, privateAWSEnv(), {
       aws: provider,
     } as never);
 
@@ -282,6 +284,10 @@ describe("private AWS workspaces", () => {
       capacityRegions: ["us-west-2"],
       capacityHints: false,
     });
+    const leases = await runtime.storage.list<LeaseRecord>({ prefix: "lease:" });
+    const lease = [...leases.values()][0];
+    expect(lease?.sshHostKey).toBeUndefined();
+    expect(JSON.stringify(lease)).not.toContain("OPENSSH PRIVATE KEY");
     expect(requested?.awsSSMBootstrapCommand).toContain("crabbox-workspace.service");
     expect(requested?.awsSSMBootstrapCommand).toContain("node server.js");
     expect(requested?.awsSSMBootstrapCommand).toContain(
@@ -561,6 +567,9 @@ function privateRecoveryProvider(state: RecoveryProviderState): Record<string, u
     workspaceCapability: privateWorkspaceCapability(),
     async listCrabboxServers(): Promise<ProviderMachine[]> {
       return [];
+    },
+    supportsSSHHostKeyInjection(): boolean {
+      return false;
     },
     async recoverServer(): Promise<ProviderMachine> {
       state.recovers += 1;

--- a/worker/test/private-aws-workspace.test.ts
+++ b/worker/test/private-aws-workspace.test.ts
@@ -188,6 +188,9 @@ describe("private AWS workspaces", () => {
       async listCrabboxServers(): Promise<ProviderMachine[]> {
         return [];
       },
+      supportsSSHHostKeyInjection(): boolean {
+        return false;
+      },
       async findServerByLease(): Promise<ProviderMachine | undefined> {
         return undefined;
       },


### PR DESCRIPTION
## Summary

Expose authoritative SSH host-key material through `crabbox inspect --json` so consumers can pin host keys instead of trusting on first use. Companion change for OpenClaw cloud workers (openclaw/openclaw#104294), whose bootstrap is fail-closed on host-key pinning and currently cannot admit crabbox-provisioned machines.

- The worker generates one Ed25519 host pair before lease reservation and injects it through the existing cloud-init `ssh_keys` mechanism (the same machinery workspace provisioning already uses); only the normalized public `algorithm base64` half is persisted on the lease record — the private half is never stored.
- `inspect --json` gains optional `sshHostKey` carrying exactly `algorithm base64` (no hostname, no comment). Providers/leases where pre-boot injection is not possible omit the field.
- Interactive `crabbox ssh` TOFU behavior is unchanged.

Provider coverage: supplies the key on Hetzner, AWS, and GCP Linux plus Azure non-snapshot Linux; omits for Azure snapshots, Windows, macOS, Daytona, and registered/direct/runtime-adapter leases.

## Validation

- `go vet ./...`, `go test -race ./...` green.
- Worker format/lint/typecheck/tests/builds green (947 tests, 3 skipped); Node typecheck/build green.
- `scripts/check-docs.sh` green; docs (inspect, ssh-keys, security) and changelog updated.
- Tests cover exact key format, pre-provision persistence, private-key exclusion, workspace reuse, provider omissions, and inspect presence/omission.
