### PR TITLE
fix(worker): redact shared egress connection detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 - Verified Node.js release archives against published SHA-256 checksums before local Actions hydration installs or reuses them, preventing unverified setup-node downloads from reaching the workflow PATH. Thanks @coygeek.
+- Limited shared egress status to coarse active visibility unless the caller has manage access, keeping per-side host and client connection state private. Thanks @coygeek.
 - Counted live managed leases against monthly reserved-USD budgets after UTC month rollover until cleanup commits a terminal state, preventing overlapping reservations from bypassing configured cost caps. Thanks @coygeek.
 - Bounded coordinator lease and workspace history scans and kept saturated cleanup retry batches scheduled promptly, preventing large retained histories from exhausting Durable Object memory or stranding cleanup.
 

--- a/docs/features/egress.md
+++ b/docs/features/egress.md
@@ -225,12 +225,14 @@ authorization.
 `GET /egress/status` reports the tracked session:
 
 ```text
-leaseID, sessionID, profile, allow, hostConnected, clientConnected,
+leaseID, active, sessionID, profile, allow, hostConnected, clientConnected,
 createdAt, updatedAt
 ```
 
-`hostConnected`/`clientConnected` reflect whether each side's WebSocket is
-currently open.
+All visible callers receive the coarse `active` session state. The detailed
+`hostConnected`/`clientConnected` fields reflect whether each side's WebSocket
+is currently open and are returned only to owners and callers with `manage`
+access.
 
 ## Bridge protocol
 

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -389,11 +389,12 @@ type CoordinatorEgressTicket struct {
 type CoordinatorEgressStatus struct {
 	LeaseID         string   `json:"leaseID"`
 	Slug            string   `json:"slug,omitempty"`
+	Active          bool     `json:"active"`
 	SessionID       string   `json:"sessionID,omitempty"`
 	Profile         string   `json:"profile,omitempty"`
 	Allow           []string `json:"allow,omitempty"`
-	HostConnected   bool     `json:"hostConnected"`
-	ClientConnected bool     `json:"clientConnected"`
+	HostConnected   *bool    `json:"hostConnected,omitempty"`
+	ClientConnected *bool    `json:"clientConnected,omitempty"`
 	CreatedAt       string   `json:"createdAt,omitempty"`
 	UpdatedAt       string   `json:"updatedAt,omitempty"`
 }

--- a/internal/cli/egress.go
+++ b/internal/cli/egress.go
@@ -268,8 +268,15 @@ func (a App) egressStatus(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(a.Stdout, "egress: lease=%s session=%s profile=%s host=%t client=%t allow=%s\n", status.LeaseID, blank(status.SessionID, "-"), blank(status.Profile, "-"), status.HostConnected, status.ClientConnected, strings.Join(status.Allow, ","))
+	fmt.Fprintln(a.Stdout, formatEgressStatus(status))
 	return nil
+}
+
+func formatEgressStatus(status CoordinatorEgressStatus) string {
+	if status.HostConnected == nil || status.ClientConnected == nil {
+		return fmt.Sprintf("egress: lease=%s active=%t", status.LeaseID, status.Active)
+	}
+	return fmt.Sprintf("egress: lease=%s session=%s profile=%s host=%t client=%t allow=%s", status.LeaseID, blank(status.SessionID, "-"), blank(status.Profile, "-"), *status.HostConnected, *status.ClientConnected, strings.Join(status.Allow, ","))
 }
 
 func (a App) egressStop(ctx context.Context, args []string) error {

--- a/internal/cli/egress_test.go
+++ b/internal/cli/egress_test.go
@@ -17,6 +17,42 @@ import (
 	"nhooyr.io/websocket"
 )
 
+func TestFormatEgressStatusPreservesDetailedAndCoarseState(t *testing.T) {
+	connected := true
+	disconnected := false
+	tests := []struct {
+		name   string
+		status CoordinatorEgressStatus
+		want   string
+	}{
+		{
+			name: "manager detail",
+			status: CoordinatorEgressStatus{
+				LeaseID:         "cbx_123",
+				Active:          true,
+				SessionID:       "egress_123",
+				Profile:         "custom",
+				Allow:           []string{"example.com"},
+				HostConnected:   &connected,
+				ClientConnected: &disconnected,
+			},
+			want: "egress: lease=cbx_123 session=egress_123 profile=custom host=true client=false allow=example.com",
+		},
+		{
+			name:   "shared coarse state",
+			status: CoordinatorEgressStatus{LeaseID: "cbx_123", Active: true},
+			want:   "egress: lease=cbx_123 active=true",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := formatEgressStatus(test.status); got != test.want {
+				t.Fatalf("formatEgressStatus()=%q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
 func TestEgressHostAllowedMatchesExactAndWildcards(t *testing.T) {
 	allow := []string{"discord.com", "*.discordcdn.com"}
 	for _, host := range []string{"discord.com", "cdn.discordcdn.com", "media.cdn.discordcdn.com"} {

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -7448,11 +7448,16 @@ export class FleetCoordinator {
     return json({
       leaseID: lease.id,
       slug: lease.slug,
+      active: session !== undefined,
       sessionID: canManage ? (session?.sessionID ?? "") : "",
       profile: canManage ? (session?.profile ?? "") : "",
       allow: canManage ? (session?.allow ?? []) : [],
-      hostConnected: host?.readyState === WebSocket.OPEN,
-      clientConnected: client?.readyState === WebSocket.OPEN,
+      ...(canManage
+        ? {
+            hostConnected: host?.readyState === WebSocket.OPEN,
+            clientConnected: client?.readyState === WebSocket.OPEN,
+          }
+        : {}),
       createdAt: canManage ? (session?.createdAt ?? "") : "",
       updatedAt: canManage ? (session?.updatedAt ?? "") : "",
     });

--- a/worker/src/portal.ts
+++ b/worker/src/portal.ts
@@ -588,7 +588,7 @@ export function portalLeaseDetail(
           <div class="bridge-grid">
             ${bridgeRow("WebVNC", active && lease.desktop === true, bridgeStatus.webVNCBridgeConnected, bridgeStatus.webVNCViewerConnected, vncAction)}
             ${bridgeRow("code", active && lease.code === true, bridgeStatus.codeBridgeConnected, false, codeAction)}
-            ${bridgeRow("egress", active && Boolean(bridgeStatus.egress), bridgeStatus.egress?.hostConnected ?? false, bridgeStatus.egress?.clientConnected ?? false, egressAction, "host", "client")}
+            ${bridgeRow("egress", active && Boolean(bridgeStatus.egress), bridgeStatus.egress?.hostConnected ?? false, bridgeStatus.egress?.clientConnected ?? false, egressAction, "host", "client", !canManage)}
           </div>
           <div class="access-commands">${commands}</div>
         </div>
@@ -3098,18 +3098,23 @@ function bridgeRow(
   action: string,
   bridgeLabel = "bridge",
   viewerLabel = "viewer",
+  coarse = false,
 ): string {
-  const status = enabled
-    ? bridgeConnected
-      ? viewerConnected
-        ? `${viewerLabel} active`
-        : `${bridgeLabel} ready`
-      : `waiting for ${bridgeLabel}`
-    : "unavailable";
-  const tone = enabled ? (bridgeConnected ? "ok" : "warn") : "";
+  const status = coarse
+    ? enabled
+      ? "active"
+      : "unavailable"
+    : enabled
+      ? bridgeConnected
+        ? viewerConnected
+          ? `${viewerLabel} active`
+          : `${bridgeLabel} ready`
+        : `waiting for ${bridgeLabel}`
+      : "unavailable";
+  const tone = enabled ? (coarse || bridgeConnected ? "ok" : "warn") : "";
   return `<div class="bridge-row">
     <div><strong>${escapeHTML(label)}</strong><small>${escapeHTML(status)}</small></div>
-    <span class="pill" data-tone="${tone}">${escapeHTML(enabled ? (bridgeConnected ? "connected" : "waiting") : "off")}</span>
+    <span class="pill" data-tone="${tone}">${escapeHTML(enabled ? (coarse ? "active" : bridgeConnected ? "connected" : "waiting") : "off")}</span>
     ${action}
   </div>`;
 }

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -19723,6 +19723,7 @@ describe("fleet lease identity and idle", () => {
     expect(status.status).toBe(200);
     await expect(status.json()).resolves.toMatchObject({
       leaseID: "cbx_000000000001",
+      active: true,
       sessionID: "egress_camel123",
       profile: "discord",
       allow: ["discord.com"],
@@ -19750,24 +19751,27 @@ describe("fleet lease identity and idle", () => {
       }),
     );
     expect(viewerStatus.status).toBe(200);
-    await expect(viewerStatus.json()).resolves.toMatchObject({
+    const viewerStatusBody = (await viewerStatus.json()) as Record<string, unknown>;
+    expect(viewerStatusBody).toMatchObject({
       leaseID: "cbx_000000000001",
+      active: true,
       sessionID: "",
       profile: "",
       allow: [],
-      hostConnected: false,
-      clientConnected: false,
       createdAt: "",
       updatedAt: "",
     });
+    expect(viewerStatusBody).not.toHaveProperty("hostConnected");
+    expect(viewerStatusBody).not.toHaveProperty("clientConnected");
 
     const viewerPortal = await fleet.fetch(
       request("GET", "/portal/leases/blue-lobster", { headers: viewerHeaders }),
     );
     expect(viewerPortal.status).toBe(200);
     const viewerPortalBody = await viewerPortal.text();
-    expect(viewerPortalBody).toContain("<strong>egress</strong><small>waiting for host</small>");
+    expect(viewerPortalBody).toContain("<strong>egress</strong><small>active</small>");
     expect(viewerPortalBody).toContain('<span class="muted">active</span>');
+    expect(viewerPortalBody).toContain('<span class="pill" data-tone="ok">active</span>');
     expect(viewerPortalBody).not.toContain("discord · discord.com");
     expect(viewerPortalBody).not.toContain("*.discordcdn.com");
     expect(viewerPortalBody).not.toContain("crabbox egress status --id blue-lobster");
@@ -19782,10 +19786,27 @@ describe("fleet lease identity and idle", () => {
       }),
     );
     await expect(managerStatus.json()).resolves.toMatchObject({
+      active: true,
       sessionID: "egress_camel123",
       profile: "discord",
       allow: ["discord.com"],
+      hostConnected: false,
+      clientConnected: false,
     });
+
+    const orgViewerStatus = await fleet.fetch(
+      request("GET", "/v1/leases/blue-lobster/egress/status", {
+        headers: {
+          "x-crabbox-owner": "org-viewer@example.com",
+          "x-crabbox-org": "example-org",
+        },
+      }),
+    );
+    expect(orgViewerStatus.status).toBe(200);
+    const orgViewerStatusBody = (await orgViewerStatus.json()) as Record<string, unknown>;
+    expect(orgViewerStatusBody).toMatchObject({ active: true });
+    expect(orgViewerStatusBody).not.toHaveProperty("hostConnected");
+    expect(orgViewerStatusBody).not.toHaveProperty("clientConnected");
 
     const missingTicket = await fleet.fetch(
       request("GET", "/v1/leases/blue-lobster/egress/host", {


### PR DESCRIPTION
## Summary

- preserve coarse egress `active` state for all visible lease callers
- restrict per-side host/client connection state to owners and manage shares
- keep the shared portal row useful without exposing side-specific diagnostics
- teach the CLI to render redacted coarse status without reporting false disconnections

Closes https://github.com/openclaw/crabbox/issues/949

## Verification

- `go test ./internal/cli -run 'TestFormatEgressStatus|TestEgress' -count=1`
- `npm test --prefix worker` (1,044 passed)
- `npm run check --prefix worker`
- `npm run lint --prefix worker`
- AutoReview clean (0.96 confidence)

## Compatibility

Owner and manage responses retain their existing detailed fields. Use-share callers retain the status endpoint and visible portal bridge row, now backed by the explicit coarse `active` field.
