### PR TITLE
fix(cli): confine JUnit result collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Confined explicit JUnit result collection to final paths inside the remote workdir on POSIX and Windows while preserving safe in-workdir symlinks and absolute paths. Thanks @coygeek.
 - Verified Node.js release archives against published SHA-256 checksums before local Actions hydration installs or reuses them, preventing unverified setup-node downloads from reaching the workflow PATH. Thanks @coygeek.
 - Limited shared egress status to coarse active visibility unless the caller has manage access, keeping per-side host and client connection state private. Thanks @coygeek.
 - Counted live managed leases against monthly reserved-USD budgets after UTC month rollover until cleanup commits a terminal state, preventing overlapping reservations from bypassing configured cost caps. Thanks @coygeek.

--- a/docs/features/test-results.md
+++ b/docs/features/test-results.md
@@ -51,8 +51,13 @@ Or through the environment: `CRABBOX_RESULTS_JUNIT` (comma-separated paths),
 `crabbox run` collects results only when `--results-auto` is set or at least one
 explicit `--junit` path is configured.
 
-For explicit `--junit` paths, the CLI reads each listed file from the workdir
-(Windows-native targets use a PowerShell variant) and parses it.
+For explicit `--junit` paths, the CLI resolves each listed file and reads it
+only when its final target remains inside the workdir, then parses it. Relative
+paths, absolute paths within the workdir, and symlinks that stay within the
+workdir remain supported. Windows-native targets apply the same rule while
+resolving directory junctions and symbolic links. Collection validates the
+opened file and reads from the same descriptor or stream, so a background
+process cannot swap a checked path before the read.
 
 Auto discovery (`--results-auto`) is freshness-aware so it never reports stale
 reports from an earlier run:

--- a/internal/cli/results_parse_test.go
+++ b/internal/cli/results_parse_test.go
@@ -2,8 +2,13 @@ package cli
 
 import (
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestParseJUnitResults(t *testing.T) {
@@ -284,5 +289,103 @@ func TestNormalizeResultPath(t *testing.T) {
 		if got := normalizeResultPath(tc.workdir, tc.name); got != tc.want {
 			t.Fatalf("normalizeResultPath(%q, %q)=%q, want %q", tc.workdir, tc.name, got, tc.want)
 		}
+	}
+}
+
+func TestRemoteReadResultFilesConfinesResolvedPaths(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shell regression")
+	}
+	root := t.TempDir()
+	reports := filepath.Join(root, "reports")
+	outside := t.TempDir()
+	if err := os.Mkdir(reports, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write := func(path, content string) {
+		t.Helper()
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(filepath.Join(reports, "inside.xml"), "inside")
+	write(filepath.Join(outside, "outside.xml"), "outside")
+	links := map[string]string{
+		filepath.Join(root, "safe-leaf.xml"):   filepath.Join(reports, "inside.xml"),
+		filepath.Join(root, "safe-dir"):        reports,
+		filepath.Join(root, "escape-leaf.xml"): filepath.Join(outside, "outside.xml"),
+		filepath.Join(root, "escape-dir"):      outside,
+	}
+	for link, target := range links {
+		if err := os.Symlink(target, link); err != nil {
+			t.Fatal(err)
+		}
+	}
+	fifo := filepath.Join(root, "result.fifo")
+	if out, err := exec.Command("mkfifo", fifo).CombinedOutput(); err != nil {
+		t.Fatalf("mkfifo: %v\n%s", err, out)
+	}
+	paths := []string{
+		"reports/inside.xml",
+		filepath.Join(reports, "inside.xml"),
+		"safe-leaf.xml",
+		"safe-dir/inside.xml",
+		"escape-leaf.xml",
+		"escape-dir/outside.xml",
+		filepath.Join(outside, "outside.xml"),
+		"result.fifo",
+	}
+	command := remoteReadResultFiles(root, paths)
+	for _, want := range []string{`exec 3<"$candidate"`, `/proc/self/fd/3`, `echo $PPID > "$1"`, `lsof -a -p "$pid" -d 3`, `cat <&3`, `sleep 5; kill "$reader"`} {
+		if !strings.Contains(command, want) {
+			t.Fatalf("POSIX result reader missing descriptor-bound check %q:\n%s", want, command)
+		}
+	}
+	started := time.Now()
+	out, err := exec.Command("sh", "-c", command).CombinedOutput()
+	if err != nil {
+		t.Fatalf("remote result reader: %v\n%s", err, out)
+	}
+	if elapsed := time.Since(started); elapsed >= 5*time.Second {
+		t.Fatalf("non-regular result path blocked collection for %s", elapsed)
+	}
+	files := parseMarkedFiles(string(out))
+	for _, allowed := range paths[:4] {
+		if files[allowed] != "inside" {
+			t.Fatalf("allowed path %q missing: %#v", allowed, files)
+		}
+	}
+	for _, escaped := range paths[4:] {
+		if _, ok := files[escaped]; ok {
+			t.Fatalf("escaped path %q was collected: %#v", escaped, files)
+		}
+	}
+}
+
+func TestWindowsRemoteReadResultFilesUsesResolvedConfinement(t *testing.T) {
+	got := decodePowerShellCommand(t, windowsRemoteReadResultFiles(`C:\repo`, []string{`reports\junit.xml`}))
+	for _, want := range []string{
+		"GetFinalPathNameByHandle",
+		"CreateFile",
+		"$r=FinalPath $rh",
+		"$s.SafeFileHandle",
+		"$p.StartsWith($q,[StringComparison]::Ordinal)",
+		"$z.ReadToEnd()",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("windows result reader missing %q:\n%s", want, got)
+		}
+	}
+	command := windowsRemoteReadResultFiles(`C:\crabbox\cbx_123\crabbox`, []string{
+		`.crabbox\junit-proof\inside.xml`,
+		`C:\crabbox\cbx_123\crabbox\.crabbox\junit-proof\inside.xml`,
+		`.crabbox\junit-proof\safe-leaf.xml`,
+		`.crabbox\junit-proof\safe-dir\inside.xml`,
+		`.crabbox\junit-proof\escape-leaf.xml`,
+		`.crabbox\junit-proof\escape-dir\outside.xml`,
+		`C:\Windows\Temp\crabbox-junit-proof\outside.xml`,
+	})
+	if len(command) >= 7500 {
+		t.Fatalf("windows result reader exceeds cmd.exe command-line limit: %d bytes", len(command))
 	}
 }

--- a/internal/cli/results_remote.go
+++ b/internal/cli/results_remote.go
@@ -77,14 +77,16 @@ func remoteReadResultFiles(workdir string, paths []string) string {
 	b.WriteString("cd ")
 	b.WriteString(shellQuote(workdir))
 	b.WriteString(" && ")
+	b.WriteString(`root=$(pwd -P) || exit 0; crabbox_resolve_file() { p=$1; hops=0; while [ "$hops" -lt 40 ]; do dir=${p%/*}; base=${p##*/}; [ -n "$dir" ] || dir=/; dir=$(cd -P "$dir" 2>/dev/null && pwd -P) || return 1; p=$dir/$base; if [ -L "$p" ]; then target=$(readlink "$p") || return 1; case "$target" in /*) p=$target;; *) p=$dir/$target;; esac; hops=$((hops + 1)); continue; fi; [ -f "$p" ] || return 1; printf '%s\n' "$p"; return 0; done; return 1; }; `)
+	b.WriteString(`crabbox_read_file() { f=$1; case "$f" in /*) candidate=$f;; *) candidate=$root/$f;; esac; [ -f "$candidate" ] || return; exec 3<"$candidate" 2>/dev/null || return; resolved=$(crabbox_resolve_file "$candidate") || return; if [ "$root" != / ]; then case "$resolved" in "$root"/*) ;; *) return;; esac; fi; if [ -e /proc/self/fd/3 ]; then opened=$(readlink /proc/self/fd/3); elif command -v lsof >/dev/null 2>&1; then pidfile=$(mktemp) || return; sh -c 'echo $PPID > "$1"' sh "$pidfile" || { rm -f "$pidfile"; return; }; pid=$(cat "$pidfile"); rm -f "$pidfile"; opened=$(lsof -a -p "$pid" -d 3 -Fn 2>/dev/null | sed -n 's/^n//p'); else return; fi; [ "$opened" = "$resolved" ] || return; printf '\n`)
+	b.WriteString(resultFileMarker)
+	b.WriteString(`%s\n' "$f"; cat <&3; }; `)
 	b.WriteString("for f in")
 	for _, path := range paths {
 		b.WriteByte(' ')
 		b.WriteString(shellQuote(path))
 	}
-	b.WriteString("; do if [ -f \"$f\" ]; then printf '\\n")
-	b.WriteString(resultFileMarker)
-	b.WriteString("%s\\n' \"$f\"; cat \"$f\"; fi; done")
+	b.WriteString(`; do crabbox_read_file "$f" & reader=$!; ( sleep 5; kill "$reader" 2>/dev/null ) >/dev/null 2>&1 & guard=$!; wait "$reader" 2>/dev/null || :; kill "$guard" 2>/dev/null || :; wait "$guard" 2>/dev/null || :; done`)
 	return b.String()
 }
 

--- a/internal/cli/sync_windows_target.go
+++ b/internal/cli/sync_windows_target.go
@@ -267,12 +267,19 @@ New-Item -ItemType Directory -Force -Path $workdir | Out-Null
 
 func windowsRemoteReadResultFiles(workdir string, paths []string) string {
 	var b bytes.Buffer
-	b.WriteString(`$ErrorActionPreference = "SilentlyContinue"` + "\n")
+	b.WriteString(`$ErrorActionPreference = "Stop"` + "\n")
 	b.WriteString(`Set-Location -LiteralPath ` + psQuote(workdir) + "\n")
-	for _, path := range paths {
-		b.WriteString(`$f = ` + psQuote(path) + "\n")
-		b.WriteString(`if (Test-Path -LiteralPath $f) { Write-Output "` + resultFileMarker + `${f}"; Get-Content -Raw -LiteralPath $f }` + "\n")
+	b.WriteString(`Add-Type -Name N -Namespace Cbx -MemberDefinition '[DllImport("kernel32.dll",CharSet=CharSet.Unicode,SetLastError=true)]public static extern uint GetFinalPathNameByHandle(Microsoft.Win32.SafeHandles.SafeFileHandle h,System.Text.StringBuilder p,uint n,uint f);[DllImport("kernel32.dll",CharSet=CharSet.Unicode,SetLastError=true)]public static extern Microsoft.Win32.SafeHandles.SafeFileHandle CreateFile(string p,uint a,System.IO.FileShare s,System.IntPtr z,System.IO.FileMode m,uint f,System.IntPtr t);'
+function FinalPath($h){$b=New-Object Text.StringBuilder 32768;if(-not[Cbx.N]::GetFinalPathNameByHandle($h,$b,$b.Capacity,0)){throw 'final path failed'};$p=$b.ToString();if($p.StartsWith('\\?\UNC\')){return '\\'+$p.Substring(8)};if($p.StartsWith('\\?\')){return $p.Substring(4)};return $p}
+$rh=[Cbx.N]::CreateFile($pwd.Path,0,([IO.FileShare]::ReadWrite -bor [IO.FileShare]::Delete),[IntPtr]::Zero,[IO.FileMode]::Open,0x02000000,[IntPtr]::Zero);if($rh.IsInvalid){throw 'workdir open failed'};try{$r=FinalPath $rh}finally{$rh.Dispose()};$q=$r.TrimEnd('\')+'\'
+@(`)
+	for i, path := range paths {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(psQuote(path))
 	}
+	b.WriteString(`)|ForEach-Object{$f=$_;$s=$null;try{if([IO.Path]::IsPathRooted($f)){$o=$f}else{$o=Join-Path $pwd.Path $f};$s=[IO.File]::Open($o,[IO.FileMode]::Open,[IO.FileAccess]::Read,([IO.FileShare]::ReadWrite -bor [IO.FileShare]::Delete));$p=FinalPath $s.SafeFileHandle;if($p.StartsWith($q,[StringComparison]::Ordinal)){$z=New-Object IO.StreamReader($s,[Text.Encoding]::UTF8,$true,4096,$true);try{$v=$z.ReadToEnd()}finally{$z.Dispose()};Write-Output "` + resultFileMarker + `${f}";Write-Output $v}}catch{}finally{if($s){$s.Dispose()}}}`)
 	return powershellCommand(b.String())
 }
 


### PR DESCRIPTION
## Summary

- confine explicit JUnit collection to final paths inside the remote workdir on POSIX and native Windows
- read from the same validated descriptor/stream to close path-swap races
- preserve relative and absolute in-workdir reports, safe symlinks, and Windows directory junctions
- skip non-regular POSIX paths without blocking

Closes https://github.com/openclaw/crabbox/issues/1034

## Verification

- `go test ./internal/cli -run 'TestRemoteReadResultFiles|TestWindowsRemoteReadResultFiles|TestNormalizeResultPath' -count=1`
- `go test -race ./internal/cli -count=1`
- AutoReview clean: no accepted/actionable findings
- native Windows AWS canary: provider `aws`, lease `cbx_788b96ac0736`, run `run_9e937878bb97`
  - collected exactly four permitted reports: relative, absolute-in-workdir, safe leaf symlink, safe directory junction
  - excluded direct outside path, outside leaf symlink, and outside directory junction
  - result: `test results files=4 tests=4 failures=0 errors=0 skipped=0`
  - lease released and verified `state=released`
