### PR TITLE
feat(modal): support named Secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
 
 ## 0.38.3 - 2026-07-14
 
+### Added
+
+- Added Modal environment selection and named Secret injection without passing Secret values through Crabbox. Thanks @simonMoisselin.
+
 ### Fixed
 
 - Made provider IP and loopback VNC waits return promptly when their context is cancelled. Thanks @SebTardif.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.38.5 - Unreleased
 
+### Added
+
+- Added Modal environment selection and named Secret injection without passing Secret values through Crabbox. Thanks @simonMoisselin.
+
 ### Fixed
 
 - Closed code-server WebSockets whose upstream dial completes after bridge shutdown, preventing orphaned connections and reader goroutines. Thanks @anagnorisis2peripeteia.
@@ -17,10 +21,6 @@
 - Rejected Blacksmith delegated runs when Git hides omitted tracked paths, before those paths could be misread as remote deletions.
 
 ## 0.38.3 - 2026-07-14
-
-### Added
-
-- Added Modal environment selection and named Secret injection without passing Secret values through Crabbox. Thanks @simonMoisselin.
 
 ### Fixed
 

--- a/docs/providers/modal.md
+++ b/docs/providers/modal.md
@@ -74,9 +74,9 @@ modal:
   image: python:3.13-slim
   workdir: /workspace/crabbox/work
   python: python3
-  environment: dev
+  environment: my-app-dev
   secrets:
-    - mapaperasse-dev
+    - example
 ```
 
 Provider flags:
@@ -107,6 +107,8 @@ Defaults: app `crabbox`, image `python:3.13-slim`, workdir
 `modal.secrets` contains Modal Secret names, not secret values. Crabbox resolves
 those names inside Modal when creating the sandbox. Use `modal.environment` (or
 `--modal-environment`) when the secrets belong to a named Modal environment.
+Set these fields in the user config or pass the corresponding flags or environment
+variables; repository-local config cannot select a Modal environment or Secret.
 
 ## Lifecycle
 

--- a/docs/providers/modal.md
+++ b/docs/providers/modal.md
@@ -74,6 +74,9 @@ modal:
   image: python:3.13-slim
   workdir: /workspace/crabbox/work
   python: python3
+  environment: dev
+  secrets:
+    - mapaperasse-dev
 ```
 
 Provider flags:
@@ -83,6 +86,8 @@ Provider flags:
 --modal-image
 --modal-workdir
 --modal-python
+--modal-environment
+--modal-secret NAME  # repeatable or comma-separated
 ```
 
 Environment overrides:
@@ -92,10 +97,16 @@ CRABBOX_MODAL_APP
 CRABBOX_MODAL_IMAGE
 CRABBOX_MODAL_WORKDIR
 CRABBOX_MODAL_PYTHON
+CRABBOX_MODAL_ENVIRONMENT
+CRABBOX_MODAL_SECRETS     # comma-separated Modal Secret names
 ```
 
 Defaults: app `crabbox`, image `python:3.13-slim`, workdir
 `/workspace/crabbox`, Python binary `python3`.
+
+`modal.secrets` contains Modal Secret names, not secret values. Crabbox resolves
+those names inside Modal when creating the sandbox. Use `modal.environment` (or
+`--modal-environment`) when the secrets belong to a named Modal environment.
 
 ## Lifecycle
 

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -7020,10 +7020,10 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 		if file.Modal.Python != "" {
 			cfg.Modal.Python = file.Modal.Python
 		}
-		if file.Modal.Environment != "" {
+		if trusted && file.Modal.Environment != "" {
 			cfg.Modal.Environment = file.Modal.Environment
 		}
-		if file.Modal.Secrets != nil {
+		if trusted && file.Modal.Secrets != nil {
 			cfg.Modal.Secrets = append([]string(nil), file.Modal.Secrets...)
 		}
 	}

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -994,10 +994,12 @@ type AnthropicSRTConfig struct {
 }
 
 type ModalConfig struct {
-	App     string
-	Image   string
-	Workdir string
-	Python  string
+	App         string
+	Image       string
+	Workdir     string
+	Python      string
+	Environment string
+	Secrets     []string
 }
 
 type UpstashBoxConfig struct {
@@ -4121,10 +4123,12 @@ type fileAnthropicSRTConfig struct {
 }
 
 type fileModalConfig struct {
-	App     string `yaml:"app,omitempty"`
-	Image   string `yaml:"image,omitempty"`
-	Workdir string `yaml:"workdir,omitempty"`
-	Python  string `yaml:"python,omitempty"`
+	App         string   `yaml:"app,omitempty"`
+	Image       string   `yaml:"image,omitempty"`
+	Workdir     string   `yaml:"workdir,omitempty"`
+	Python      string   `yaml:"python,omitempty"`
+	Environment string   `yaml:"environment,omitempty"`
+	Secrets     []string `yaml:"secrets,omitempty"`
 }
 
 type fileUpstashBoxConfig struct {
@@ -7016,6 +7020,12 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 		if file.Modal.Python != "" {
 			cfg.Modal.Python = file.Modal.Python
 		}
+		if file.Modal.Environment != "" {
+			cfg.Modal.Environment = file.Modal.Environment
+		}
+		if file.Modal.Secrets != nil {
+			cfg.Modal.Secrets = append([]string(nil), file.Modal.Secrets...)
+		}
 	}
 	if file.UpstashBox != nil {
 		if file.UpstashBox.BaseURL != "" {
@@ -8932,6 +8942,10 @@ func applyEnv(cfg *Config) error {
 	cfg.Modal.Image = getenv("CRABBOX_MODAL_IMAGE", cfg.Modal.Image)
 	cfg.Modal.Workdir = getenv("CRABBOX_MODAL_WORKDIR", cfg.Modal.Workdir)
 	cfg.Modal.Python = getenv("CRABBOX_MODAL_PYTHON", cfg.Modal.Python)
+	cfg.Modal.Environment = getenv("CRABBOX_MODAL_ENVIRONMENT", cfg.Modal.Environment)
+	if values, ok := getenvList("CRABBOX_MODAL_SECRETS"); ok {
+		cfg.Modal.Secrets = values
+	}
 	if value, ok := firstNonEmptyEnv("CRABBOX_UPSTASH_BOX_API_KEY", "UPSTASH_BOX_API_KEY"); ok {
 		cfg.UpstashBox.APIKey = value
 		cfg.credentialProvenance.upstashBoxAPIKey = credentialSourceEnvironment

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -7393,3 +7393,27 @@ func TestApplyFileJobConfigCoversJobOptions(t *testing.T) {
 		t.Fatalf("command/sync fields not applied: %#v", job)
 	}
 }
+
+func TestModalSecretConfigRequiresTrustedFile(t *testing.T) {
+	cfg := baseConfig()
+	cfg.Modal.Environment = "trusted-env"
+	cfg.Modal.Secrets = []string{"sample"}
+	file := fileConfig{Modal: &fileModalConfig{
+		Environment: "repo-env",
+		Secrets:     []string{"example"},
+	}}
+
+	if err := applyFileConfigWithTrust(&cfg, file, false); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Modal.Environment != "trusted-env" || !reflect.DeepEqual(cfg.Modal.Secrets, []string{"sample"}) {
+		t.Fatalf("untrusted Modal secret selection applied: %#v", cfg.Modal)
+	}
+
+	if err := applyFileConfigWithTrust(&cfg, file, true); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Modal.Environment != "repo-env" || !reflect.DeepEqual(cfg.Modal.Secrets, []string{"example"}) {
+		t.Fatalf("trusted Modal secret selection not applied: %#v", cfg.Modal)
+	}
+}

--- a/internal/providers/modal/backend.go
+++ b/internal/providers/modal/backend.go
@@ -302,6 +302,8 @@ func (b *modalBackend) createSandbox(ctx context.Context, client modalAPI, repo 
 		Workdir:        workspace,
 		TimeoutSeconds: timeoutSeconds,
 		Tags:           labels,
+		Environment:    cfg.Modal.Environment,
+		Secrets:        append([]string(nil), cfg.Modal.Secrets...),
 	})
 	if err != nil {
 		return "", modalSandbox{}, "", modalError("create sandbox", err)

--- a/internal/providers/modal/backend_test.go
+++ b/internal/providers/modal/backend_test.go
@@ -135,8 +135,8 @@ func TestRunCreatesExecsAndTerminatesEphemeralSandbox(t *testing.T) {
 	fake := &fakeModalAPI{}
 	withFakeModalAPI(t, fake)
 	cfg := newTestConfig()
-	cfg.Modal.Environment = "dev"
-	cfg.Modal.Secrets = []string{"mapaperasse-dev", "shared-dev"}
+	cfg.Modal.Environment = "my-app-dev"
+	cfg.Modal.Secrets = []string{"example", "sample"}
 	backend := NewModalBackend(Provider{}.Spec(), cfg, testRuntime()).(*modalBackend)
 	req := RunRequest{
 		Repo:    Repo{Name: "repo", Root: t.TempDir()},
@@ -153,7 +153,7 @@ func TestRunCreatesExecsAndTerminatesEphemeralSandbox(t *testing.T) {
 	if fake.createReq.App != "crabbox" || fake.createReq.Image != "python:3.13-slim" {
 		t.Fatalf("create req=%#v", fake.createReq)
 	}
-	if fake.createReq.Environment != "dev" || !reflect.DeepEqual(fake.createReq.Secrets, []string{"mapaperasse-dev", "shared-dev"}) {
+	if fake.createReq.Environment != "my-app-dev" || !reflect.DeepEqual(fake.createReq.Secrets, []string{"example", "sample"}) {
 		t.Fatalf("modal environment/secrets=%#v/%#v", fake.createReq.Environment, fake.createReq.Secrets)
 	}
 	if fake.createReq.Tags["provider"] != "modal" || fake.createReq.Tags["crabbox"] != "true" || fake.createReq.Tags["repo"] != "repo" {

--- a/internal/providers/modal/backend_test.go
+++ b/internal/providers/modal/backend_test.go
@@ -134,7 +134,10 @@ func TestRunCreatesExecsAndTerminatesEphemeralSandbox(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := &fakeModalAPI{}
 	withFakeModalAPI(t, fake)
-	backend := NewModalBackend(Provider{}.Spec(), newTestConfig(), testRuntime()).(*modalBackend)
+	cfg := newTestConfig()
+	cfg.Modal.Environment = "dev"
+	cfg.Modal.Secrets = []string{"mapaperasse-dev", "shared-dev"}
+	backend := NewModalBackend(Provider{}.Spec(), cfg, testRuntime()).(*modalBackend)
 	req := RunRequest{
 		Repo:    Repo{Name: "repo", Root: t.TempDir()},
 		Command: []string{"echo", "hello"},
@@ -149,6 +152,9 @@ func TestRunCreatesExecsAndTerminatesEphemeralSandbox(t *testing.T) {
 	}
 	if fake.createReq.App != "crabbox" || fake.createReq.Image != "python:3.13-slim" {
 		t.Fatalf("create req=%#v", fake.createReq)
+	}
+	if fake.createReq.Environment != "dev" || !reflect.DeepEqual(fake.createReq.Secrets, []string{"mapaperasse-dev", "shared-dev"}) {
+		t.Fatalf("modal environment/secrets=%#v/%#v", fake.createReq.Environment, fake.createReq.Secrets)
 	}
 	if fake.createReq.Tags["provider"] != "modal" || fake.createReq.Tags["crabbox"] != "true" || fake.createReq.Tags["repo"] != "repo" {
 		t.Fatalf("tags=%#v", fake.createReq.Tags)

--- a/internal/providers/modal/client.go
+++ b/internal/providers/modal/client.go
@@ -27,6 +27,8 @@ type modalCreateSandboxRequest struct {
 	Name           string            `json:"name,omitempty"`
 	TimeoutSeconds int               `json:"timeout_seconds"`
 	Tags           map[string]string `json:"tags"`
+	Environment    string            `json:"environment,omitempty"`
+	Secrets        []string          `json:"secrets,omitempty"`
 }
 
 type modalExecRequest struct {
@@ -310,7 +312,10 @@ const modalCreateScript = modalPythonPrelude + `
 try:
     req = load_payload()
     import modal
-    app = modal.App.lookup(req["app"], create_if_missing=True)
+    app_kwargs = {"create_if_missing": True}
+    if req.get("environment"):
+        app_kwargs["environment_name"] = req["environment"]
+    app = modal.App.lookup(req["app"], **app_kwargs)
     image_name = req.get("image") or "python:3.13-slim"
     image = modal.Image.from_registry(image_name)
     kwargs = {
@@ -322,6 +327,13 @@ try:
         kwargs["workdir"] = req["workdir"]
     if req.get("name"):
         kwargs["name"] = req["name"]
+    if req.get("environment"):
+        kwargs["environment_name"] = req["environment"]
+    if req.get("secrets"):
+        kwargs["secrets"] = [
+            modal.Secret.from_name(name, environment_name=req.get("environment") or None)
+            for name in req["secrets"]
+        ]
     sb = modal.Sandbox.create(**kwargs)
     tags = req.get("tags") or {}
     if tags:

--- a/internal/providers/modal/client.go
+++ b/internal/providers/modal/client.go
@@ -138,8 +138,9 @@ func (c *modalPythonClient) GetSandbox(ctx context.Context, sandboxID string) (m
 
 func (c *modalPythonClient) ListSandboxes(ctx context.Context, tags map[string]string) ([]modalSandbox, error) {
 	payload := map[string]any{
-		"app":  c.app(),
-		"tags": tags,
+		"app":         c.app(),
+		"environment": strings.TrimSpace(c.cfg.Modal.Environment),
+		"tags":        tags,
 	}
 	var sandboxes []modalSandbox
 	if err := c.runJSON(ctx, modalListScript, payload, &sandboxes); err != nil {
@@ -327,8 +328,6 @@ try:
         kwargs["workdir"] = req["workdir"]
     if req.get("name"):
         kwargs["name"] = req["name"]
-    if req.get("environment"):
-        kwargs["environment_name"] = req["environment"]
     if req.get("secrets"):
         kwargs["secrets"] = [
             modal.Secret.from_name(name, environment_name=req.get("environment") or None)
@@ -410,7 +409,10 @@ const modalListScript = modalPythonPrelude + `
 try:
     req = load_payload()
     import modal
-    app = modal.App.lookup(req["app"], create_if_missing=True)
+    app_kwargs = {"create_if_missing": True}
+    if req.get("environment"):
+        app_kwargs["environment_name"] = req["environment"]
+    app = modal.App.lookup(req["app"], **app_kwargs)
     items = []
     for sb in modal.Sandbox.list(app_id=app.app_id, tags=req.get("tags") or {}):
         items.append(sandbox_json(sb))

--- a/internal/providers/modal/client_test.go
+++ b/internal/providers/modal/client_test.go
@@ -35,6 +35,14 @@ func TestModalExecPreservesRemoteExit125(t *testing.T) {
 	}
 }
 
+func TestModalCreateScriptUsesNamedSecrets(t *testing.T) {
+	for _, want := range []string{"environment_name", "modal.Secret.from_name", `"secrets"`} {
+		if !strings.Contains(modalCreateScript, want) {
+			t.Fatalf("modal create script missing %q", want)
+		}
+	}
+}
+
 func TestModalExecReportsTransportExit125(t *testing.T) {
 	runner := &modalClientRunner{result: core.LocalCommandResult{ExitCode: modalTransportExitCode}}
 	client := &modalPythonClient{cfg: newTestConfig(), rt: Runtime{Exec: runner, Stdout: io.Discard, Stderr: io.Discard}}

--- a/internal/providers/modal/client_test.go
+++ b/internal/providers/modal/client_test.go
@@ -35,11 +35,135 @@ func TestModalExecPreservesRemoteExit125(t *testing.T) {
 	}
 }
 
-func TestModalCreateScriptUsesNamedSecrets(t *testing.T) {
-	for _, want := range []string{"environment_name", "modal.Secret.from_name", `"secrets"`} {
-		if !strings.Contains(modalCreateScript, want) {
-			t.Fatalf("modal create script missing %q", want)
-		}
+func TestModalCreateScriptScopesNamedSecretsThroughParentApp(t *testing.T) {
+	python, err := osexec.LookPath("python3")
+	if err != nil {
+		t.Skipf("python3 not found: %v", err)
+	}
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "modal.py"), []byte(`
+class App:
+    @staticmethod
+    def lookup(name, **kwargs):
+        assert name == "crabbox-canary"
+        assert kwargs == {"create_if_missing": True, "environment_name": "my-app-dev"}
+        return "app-handle"
+
+class Image:
+    @staticmethod
+    def from_registry(name):
+        assert name == "python:3.13-slim"
+        return "image-handle"
+
+class Secret:
+    @staticmethod
+    def from_name(name, **kwargs):
+        assert kwargs == {"environment_name": "my-app-dev"}
+        return name
+
+class CreatedSandbox:
+    object_id = "sb-canary"
+    name = ""
+    def poll(self):
+        return None
+    def get_tags(self):
+        return {}
+    def set_tags(self, tags):
+        pass
+    def detach(self):
+        pass
+
+class Sandbox:
+    @staticmethod
+    def create(**kwargs):
+        assert "environment_name" not in kwargs
+        assert kwargs["app"] == "app-handle"
+        assert kwargs["image"] == "image-handle"
+        assert kwargs["secrets"] == ["example", "sample"]
+        return CreatedSandbox()
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	payload, err := json.Marshal(modalCreateSandboxRequest{
+		App:            "crabbox-canary",
+		Image:          "python:3.13-slim",
+		TimeoutSeconds: 300,
+		Environment:    "my-app-dev",
+		Secrets:        []string{"example", "sample"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := osexec.Command(python, "-c", modalCreateScript, string(payload))
+	cmd.Env = append(os.Environ(), "PYTHONPATH="+dir, "PYTHONDONTWRITEBYTECODE=1")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("create script failed: %v; output=%s", err, out)
+	}
+	var sandbox modalSandbox
+	if err := json.Unmarshal(out, &sandbox); err != nil {
+		t.Fatalf("decode output %q: %v", out, err)
+	}
+	if sandbox.ID != "sb-canary" || sandbox.Status != "running" {
+		t.Fatalf("sandbox=%#v", sandbox)
+	}
+}
+
+func TestModalListCarriesConfiguredEnvironment(t *testing.T) {
+	runner := &modalClientRunner{stdout: "[]\n"}
+	cfg := newTestConfig()
+	cfg.Modal.Environment = "my-app-dev"
+	client := &modalPythonClient{cfg: cfg, rt: Runtime{Exec: runner, Stdout: io.Discard, Stderr: io.Discard}}
+
+	if _, err := client.ListSandboxes(context.Background(), map[string]string{"crabbox": "true"}); err != nil {
+		t.Fatal(err)
+	}
+	if runner.payload["environment"] != "my-app-dev" {
+		t.Fatalf("list payload=%#v", runner.payload)
+	}
+}
+
+func TestModalListScriptScopesAppLookupToEnvironment(t *testing.T) {
+	python, err := osexec.LookPath("python3")
+	if err != nil {
+		t.Skipf("python3 not found: %v", err)
+	}
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "modal.py"), []byte(`
+class AppHandle:
+    app_id = "app-canary"
+
+class App:
+    @staticmethod
+    def lookup(name, **kwargs):
+        assert name == "crabbox-canary"
+        assert kwargs == {"create_if_missing": True, "environment_name": "my-app-dev"}
+        return AppHandle()
+
+class Sandbox:
+    @staticmethod
+    def list(**kwargs):
+        assert kwargs == {"app_id": "app-canary", "tags": {"crabbox": "true"}}
+        return []
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	payload, err := json.Marshal(map[string]any{
+		"app":         "crabbox-canary",
+		"environment": "my-app-dev",
+		"tags":        map[string]string{"crabbox": "true"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := osexec.Command(python, "-c", modalListScript, string(payload))
+	cmd.Env = append(os.Environ(), "PYTHONPATH="+dir, "PYTHONDONTWRITEBYTECODE=1")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("list script failed: %v; output=%s", err, out)
+	}
+	if strings.TrimSpace(string(out)) != "[]" {
+		t.Fatalf("list output=%q", out)
 	}
 }
 
@@ -125,6 +249,7 @@ type modalClientRunner struct {
 	payload     map[string]any
 	resultPath  string
 	writeResult string
+	stdout      string
 	result      core.LocalCommandResult
 	err         error
 }
@@ -137,6 +262,9 @@ func (r *modalClientRunner) Run(_ context.Context, req LocalCommandRequest) (cor
 				_ = os.WriteFile(r.resultPath, []byte(r.writeResult), 0o600)
 			}
 		}
+	}
+	if r.stdout != "" && req.Stdout != nil {
+		_, _ = io.WriteString(req.Stdout, r.stdout)
 	}
 	return r.result, r.err
 }

--- a/internal/providers/modal/flags.go
+++ b/internal/providers/modal/flags.go
@@ -1,20 +1,43 @@
 package modal
 
-import "flag"
+import (
+	"flag"
+	"strings"
+)
 
 type modalFlagValues struct {
-	App     *string
-	Image   *string
-	Workdir *string
-	Python  *string
+	App         *string
+	Image       *string
+	Workdir     *string
+	Python      *string
+	Environment *string
+	Secrets     *modalSecretList
+}
+
+type modalSecretList []string
+
+func (s *modalSecretList) String() string { return strings.Join(*s, ",") }
+
+func (s *modalSecretList) Set(value string) error {
+	for _, item := range strings.Split(value, ",") {
+		item = strings.TrimSpace(item)
+		if item != "" {
+			*s = append(*s, item)
+		}
+	}
+	return nil
 }
 
 func RegisterModalProviderFlags(fs *flag.FlagSet, defaults Config) any {
+	secrets := modalSecretList(append([]string(nil), defaults.Modal.Secrets...))
+	fs.Var(&secrets, "modal-secret", "named Modal Secret to inject into the sandbox; repeatable or comma-separated")
 	return modalFlagValues{
-		App:     fs.String("modal-app", defaults.Modal.App, "Modal app name for Crabbox sandboxes"),
-		Image:   fs.String("modal-image", defaults.Modal.Image, "Modal sandbox image, as a registry reference"),
-		Workdir: fs.String("modal-workdir", defaults.Modal.Workdir, "Absolute working directory inside the Modal sandbox"),
-		Python:  fs.String("modal-python", defaults.Modal.Python, "Python binary used to run the local Modal client"),
+		App:         fs.String("modal-app", defaults.Modal.App, "Modal app name for Crabbox sandboxes"),
+		Image:       fs.String("modal-image", defaults.Modal.Image, "Modal sandbox image, as a registry reference"),
+		Workdir:     fs.String("modal-workdir", defaults.Modal.Workdir, "Absolute working directory inside the Modal sandbox"),
+		Python:      fs.String("modal-python", defaults.Modal.Python, "Python binary used to run the local Modal client"),
+		Environment: fs.String("modal-environment", defaults.Modal.Environment, "Modal environment for the sandbox and named Secrets"),
+		Secrets:     &secrets,
 	}
 }
 
@@ -42,6 +65,12 @@ func ApplyModalProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 	}
 	if flagWasSet(fs, "modal-python") {
 		cfg.Modal.Python = *v.Python
+	}
+	if flagWasSet(fs, "modal-environment") {
+		cfg.Modal.Environment = *v.Environment
+	}
+	if flagWasSet(fs, "modal-secret") {
+		cfg.Modal.Secrets = append([]string(nil), (*v.Secrets)...)
 	}
 	return nil
 }

--- a/internal/providers/modal/flags.go
+++ b/internal/providers/modal/flags.go
@@ -14,22 +14,29 @@ type modalFlagValues struct {
 	Secrets     *modalSecretList
 }
 
-type modalSecretList []string
+type modalSecretList struct {
+	values []string
+	set    bool
+}
 
-func (s *modalSecretList) String() string { return strings.Join(*s, ",") }
+func (s *modalSecretList) String() string { return strings.Join(s.values, ",") }
 
 func (s *modalSecretList) Set(value string) error {
+	if !s.set {
+		s.values = nil
+		s.set = true
+	}
 	for _, item := range strings.Split(value, ",") {
 		item = strings.TrimSpace(item)
 		if item != "" {
-			*s = append(*s, item)
+			s.values = append(s.values, item)
 		}
 	}
 	return nil
 }
 
 func RegisterModalProviderFlags(fs *flag.FlagSet, defaults Config) any {
-	secrets := modalSecretList(append([]string(nil), defaults.Modal.Secrets...))
+	secrets := modalSecretList{values: append([]string(nil), defaults.Modal.Secrets...)}
 	fs.Var(&secrets, "modal-secret", "named Modal Secret to inject into the sandbox; repeatable or comma-separated")
 	return modalFlagValues{
 		App:         fs.String("modal-app", defaults.Modal.App, "Modal app name for Crabbox sandboxes"),
@@ -70,7 +77,7 @@ func ApplyModalProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 		cfg.Modal.Environment = *v.Environment
 	}
 	if flagWasSet(fs, "modal-secret") {
-		cfg.Modal.Secrets = append([]string(nil), (*v.Secrets)...)
+		cfg.Modal.Secrets = append([]string(nil), v.Secrets.values...)
 	}
 	return nil
 }

--- a/internal/providers/modal/flags_test.go
+++ b/internal/providers/modal/flags_test.go
@@ -1,0 +1,36 @@
+package modal
+
+import (
+	"flag"
+	"reflect"
+	"testing"
+)
+
+func TestModalSecretFlagsReplaceConfiguredDefaults(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{name: "replace and repeat", args: []string{"--modal-secret", "example,sample", "--modal-secret", "dummy"}, want: []string{"example", "sample", "dummy"}},
+		{name: "clear", args: []string{"--modal-secret="}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := newTestConfig()
+			cfg.Provider = providerName
+			cfg.Modal.Secrets = []string{"sample"}
+			fs := flag.NewFlagSet("modal", flag.ContinueOnError)
+			values := RegisterModalProviderFlags(fs, cfg)
+			if err := fs.Parse(tt.args); err != nil {
+				t.Fatal(err)
+			}
+			if err := ApplyModalProviderFlags(&cfg, fs, values); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(cfg.Modal.Secrets, tt.want) {
+				t.Fatalf("Modal secrets=%v want %v", cfg.Modal.Secrets, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- add optional Modal environment and named Secret references to trusted user configuration, flags, and environment variables
- resolve Secret names inside Modal without passing Secret values through Crabbox
- derive sandbox environment from the parent App; do not pass Modal's deprecated `environment_name` argument to `Sandbox.create`
- scope inventory to the configured environment
- keep repository-local configuration from selecting environments or Secrets
- document the YAML, CLI, and environment-variable configuration

## Validation

- `go test -race ./internal/providers/modal`
- `go test ./internal/cli`
- `go vet ./...`
- `scripts/check-docs.sh`
- AutoReview: no accepted or actionable findings

## Live Modal proof

Exact-head binary canary against Modal client 1.5.1:

- created a temporary Modal environment and named Secret containing a non-sensitive sentinel
- injected the Secret through Crabbox's generated execution path
- confirmed the sandbox observed the sentinel
- waited for running containers to reach zero
- deleted the Secret and environment
- confirmed no Secret or environment residue remained

No Secret value passed through Crabbox configuration, command arguments, logs, or this pull request.

Exact head: `42c98faa8056fcccf4c5a017426a4e8ed975e091`
