### PR TITLE
feat(cli): add SSH file and tunnel bridges

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -99,6 +99,7 @@ See [history](commands/history.md), [logs](commands/logs.md),
 ```text
 crabbox connect <id>                          open an interactive SSH session
 crabbox ssh --id <id>                          print the SSH command
+crabbox tunnel --id <id> --port <port>         forward a remote loopback port
 crabbox vnc --id <id> [--open]                 print/open SSH-tunneled VNC details
 crabbox webvnc --id <id> [--open]              bridge a desktop lease into the web portal
 crabbox code --id <id> [--open]                bridge a code lease into the web portal
@@ -108,7 +109,8 @@ crabbox screenshot --id <id> [--output <png>]  capture a PNG from a desktop leas
 crabbox desktop launch|terminal|record|proof|doctor|click|paste|type|key
 ```
 
-See [connect](commands/connect.md), [ssh](commands/ssh.md), [vnc](commands/vnc.md),
+See [connect](commands/connect.md), [ssh](commands/ssh.md),
+[tunnel](commands/tunnel.md), [vnc](commands/vnc.md),
 [webvnc](commands/webvnc.md), [code](commands/code.md),
 [egress](commands/egress.md), [ports](commands/ports.md),
 [screenshot](commands/screenshot.md), [desktop](commands/desktop.md).

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -45,6 +45,7 @@ same order as the CLI help.
 - [checkpoint](checkpoint.md)
 - [ssh](ssh.md)
 - [connect](connect.md)
+- [tunnel](tunnel.md)
 - [ports](ports.md)
 - [cp](cp.md)
 - [vnc](vnc.md)

--- a/docs/commands/cp.md
+++ b/docs/commands/cp.md
@@ -1,13 +1,15 @@
 # cp
 
-`crabbox cp` copies files or directories between the host and a delegated
-sandbox that Crabbox owns. It resolves the lease id or slug first, then maps the
-special `SANDBOX:PATH` side to the provider's native sandbox identifier.
+`crabbox cp` copies data between the host and a Crabbox lease. It resolves the
+lease id or slug first, then uses either the provider's native copy bridge or
+the lease's resolved SSH transport.
 
 ```sh
 crabbox cp --provider docker-sandbox --id blue-box ./coverage.xml SANDBOX:/tmp/coverage.xml
 crabbox cp --provider docker-sandbox --id blue-box SANDBOX:/tmp/output.log ./output.log
 crabbox cp --provider docker-sandbox --id blue-box -L ./src SANDBOX:/tmp/src
+crabbox cp --provider ssh --id buildbox.local ./input.json SANDBOX:/tmp/input.json
+crabbox cp --provider ssh --id buildbox.local SANDBOX:/tmp/output.json ./output.json
 ```
 
 ## Lease Resolution
@@ -25,7 +27,10 @@ Exactly one side must use `SANDBOX:PATH`.
 `crabbox cp` does not support sandbox-to-sandbox copies.
 
 For `provider=docker-sandbox`, Crabbox rewrites `SANDBOX:PATH` to
-`<sandbox-name>:PATH` and then calls `sbx cp`.
+`<sandbox-name>:PATH` and then calls `sbx cp`. For an SSH-reachable provider,
+Crabbox maps that path to the resolved SSH target and calls the local `scp`
+client with the same key, certificate, proxy command, and host-key policy used
+by `crabbox connect`.
 
 ## Flags
 
@@ -37,13 +42,16 @@ For `provider=docker-sandbox`, Crabbox rewrites `SANDBOX:PATH` to
 
 ## Provider Support
 
-This command is provider-opt-in. Providers without a native copy bridge fail
-clearly instead of guessing. In this slice, `docker-sandbox` is the supported
-provider.
+This command works with providers that expose either a native copy bridge or an
+SSH-reachable lease. The native bridge defines whether directory copies and
+`-L` are supported; the SSH path copies regular files. Crabbox rejects
+token-as-username SSH targets because passing that secret through `scp` is not
+portable.
 
 ## See also
 
 - [`ports`](ports.md) - publish, list, or unpublish provider-native ports.
+- [`tunnel`](tunnel.md) - forward a remote loopback port through SSH.
 - [`stop`](stop.md) - remove the lease when you are done.
 - [Docker Sandbox provider](../providers/docker-sandbox.md) - provider-specific
   notes and `sbx` command mapping.

--- a/docs/commands/tunnel.md
+++ b/docs/commands/tunnel.md
@@ -1,0 +1,66 @@
+# tunnel
+
+`crabbox tunnel` forwards one loopback port from an SSH-reachable lease to the
+local machine. The command prints the local address after the forward accepts
+connections, then stays attached until you stop it or its SSH process exits.
+
+```sh
+crabbox tunnel --id swift-crab --port 3000
+crabbox tunnel --id swift-crab --port 3000 --local-port 41000
+crabbox tunnel --id swift-crab --port 3000 --json
+```
+
+## Network boundary
+
+The forward binds to `127.0.0.1` on both sides. It does not publish the remote
+service to the local network or expose a service that listens on a non-loopback
+remote address.
+
+Crabbox resolves the same SSH target as `crabbox connect`, including its key,
+certificate, proxy command, network selection, and host-key policy. The command
+rejects token-as-username targets because passing that secret through the local
+SSH client is not portable.
+
+## Readiness output
+
+Without `--local-port`, Crabbox chooses an available local port. Text output
+contains the local address:
+
+```text
+127.0.0.1:41000
+```
+
+Pass `--json` when another process needs to keep the tunnel open and consume
+its coordinates:
+
+```json
+{"port":41000,"remotePort":3000}
+```
+
+The command writes this output only after the local forward accepts a
+connection. It exits with an error when SSH stops before readiness or the
+forward does not become ready within ten seconds.
+
+## Flags
+
+```text
+--id <lease-id-or-slug>     Lease to resolve. You may also pass it as the first argument.
+--provider <name>           Provider to resolve against.
+--port <remote-port>        Required remote loopback port.
+--local-port <local-port>   Local loopback port. The default chooses an available port.
+--json                      Print machine-readable tunnel coordinates.
+--network auto|tailscale|public
+--reclaim                   Claim the lease for the current repository before touching it.
+```
+
+## Provider support
+
+`crabbox tunnel` works with providers that expose an SSH-reachable lease. It
+does not replace provider-native public URLs or port publishing; use
+`crabbox ports` when a provider owns that bridge.
+
+## See also
+
+- [`connect`](connect.md) - open an interactive SSH session to a lease.
+- [`ports`](ports.md) - publish or inspect provider-native ports.
+- [`cp`](cp.md) - copy data between the host and a lease.

--- a/docs/providers/ssh.md
+++ b/docs/providers/ssh.md
@@ -30,6 +30,8 @@ delete the machine for you.
 ```sh
 crabbox run --provider ssh --static-host buildbox.local -- pnpm test
 crabbox ssh --provider ssh --id buildbox.local
+crabbox cp --provider ssh --id buildbox.local ./input.json SANDBOX:/tmp/input.json
+crabbox tunnel --provider ssh --id buildbox.local --port 3000
 crabbox run --provider static-ssh --target windows --static-host win-dev.local \
   -- pwsh -NoProfile -Command '$PSVersionTable'
 ```
@@ -181,6 +183,8 @@ path.
 | Capability | Support |
 | --- | --- |
 | SSH | yes |
+| File copy | regular files through `scp` |
+| Loopback tunnel | yes |
 | Crabbox sync | yes |
 | Desktop / browser / code | host-dependent (requires the tooling installed on the host) |
 | Actions hydration | Linux hosts only |
@@ -202,3 +206,5 @@ path.
 - [Provider backends](../provider-backends.md)
 - [Sync](../features/sync.md)
 - [SSH keys](../features/ssh-keys.md)
+- [Copy command](../commands/cp.md)
+- [Tunnel command](../commands/tunnel.md)

--- a/internal/cli/cli_kong.go
+++ b/internal/cli/cli_kong.go
@@ -51,6 +51,7 @@ type crabboxKongCLI struct {
 	Checkpoint  checkpointKongCmd  `cmd:"" help:"Create, restore, and fork VM or workspace checkpoints."`
 	Ssh         sshKongCmd         `cmd:"" name:"ssh" passthrough:"" help:"Print the SSH command for a lease."`
 	Connect     connectKongCmd     `cmd:"" passthrough:"" help:"Open an interactive SSH session to a lease."`
+	Tunnel      tunnelKongCmd      `cmd:"" passthrough:"" help:"Forward a remote loopback port from a lease."`
 	Vnc         vncKongCmd         `cmd:"" name:"vnc" passthrough:"" help:"Print or open VNC connection details for a desktop lease."`
 	Webvnc      webvncKongCmd      `cmd:"" name:"webvnc" passthrough:"" help:"Open a desktop lease or local VNC tunnel in a browser."`
 	Code        codeKongCmd        `cmd:"" passthrough:"" help:"Bridge a code lease into the authenticated web portal."`
@@ -250,6 +251,9 @@ type sshKongCmd struct {
 	Args []string `arg:"" optional:""`
 }
 type connectKongCmd struct {
+	Args []string `arg:"" optional:""`
+}
+type tunnelKongCmd struct {
 	Args []string `arg:"" optional:""`
 }
 type vncKongCmd struct {
@@ -650,6 +654,7 @@ func (c *marketplaceQuoteKongCmd) Run(ctx context.Context, app App) error {
 }
 func (c *sshKongCmd) Run(ctx context.Context, app App) error     { return app.ssh(ctx, c.Args) }
 func (c *connectKongCmd) Run(ctx context.Context, app App) error { return app.connect(ctx, c.Args) }
+func (c *tunnelKongCmd) Run(ctx context.Context, app App) error  { return app.tunnel(ctx, c.Args) }
 func (c *vncKongCmd) Run(ctx context.Context, app App) error     { return app.vnc(ctx, c.Args) }
 func (c *webvncKongCmd) Run(ctx context.Context, app App) error  { return app.webvnc(ctx, c.Args) }
 func (c *codeKongCmd) Run(ctx context.Context, app App) error    { return app.webCode(ctx, c.Args) }

--- a/internal/cli/cp.go
+++ b/internal/cli/cp.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"os/exec"
 	"strings"
 )
 
@@ -31,16 +32,57 @@ func (a App) copyCommand(ctx context.Context, args []string) error {
 		return err
 	}
 	copyBackend, ok := backend.(CopyBackend)
-	if !ok {
-		return exit(2, "provider=%s does not support cp; use a provider with native file copy", backend.Spec().Name)
+	if ok {
+		return copyBackend.Copy(ctx, CopyRequest{
+			Options:     leaseOptionsFromConfig(cfg),
+			ID:          *id,
+			Source:      fs.Arg(0),
+			Destination: fs.Arg(1),
+			FollowLink:  *followLink,
+		})
 	}
-	return copyBackend.Copy(ctx, CopyRequest{
-		Options:     leaseOptionsFromConfig(cfg),
-		ID:          *id,
-		Source:      fs.Arg(0),
-		Destination: fs.Arg(1),
-		FollowLink:  *followLink,
-	})
+	if _, ok := backend.(SSHLoginBackend); !ok {
+		return exit(2, "provider=%s does not support cp; use a provider with native file copy or SSH access", backend.Spec().Name)
+	}
+	lease, err := a.resolveNetworkLoginLeaseTargetForRepo(ctx, &cfg, *id, false, false, true)
+	if err != nil {
+		return err
+	}
+	if lease.SSH.AuthSecret {
+		return exit(2, "provider=%s does not support SSH cp with token-as-username authentication", backend.Spec().Name)
+	}
+	if err := a.claimAndTouchLeaseTarget(ctx, cfg, lease.Server, lease.SSH, lease.LeaseID, false); err != nil {
+		return err
+	}
+	copyArgs, err := sshCopyArgs(lease.SSH, fs.Arg(0), fs.Arg(1))
+	if err != nil {
+		return err
+	}
+	cmd := exec.CommandContext(ctx, "scp", copyArgs...)
+	cmd.Stdout = a.Stdout
+	cmd.Stderr = a.Stderr
+	if err := cmd.Run(); err != nil {
+		if code := exitCode(err); code > 0 {
+			return ExitError{Code: code}
+		}
+		return err
+	}
+	return nil
+}
+
+func sshCopyArgs(target SSHTarget, source, destination string) ([]string, error) {
+	if err := validateCopyArgs(source, destination); err != nil {
+		return nil, err
+	}
+	remote := func(path string) string {
+		return target.User + "@" + target.Host + ":" + strings.SplitN(path, ":", 2)[1]
+	}
+	if isSandboxCopyArg(source) {
+		source = remote(source)
+	} else {
+		destination = remote(destination)
+	}
+	return append(scpBaseArgs(target), source, destination), nil
 }
 
 func validateCopyArgs(src, dst string) error {

--- a/internal/cli/egress.go
+++ b/internal/cli/egress.go
@@ -943,20 +943,15 @@ func egressClientBinaryForTarget(ctx context.Context, target SSHTarget) (string,
 }
 
 func scpBaseArgs(target SSHTarget) []string {
-	args := sshForwardingDenyArgs()
+	args := sshBaseArgs(target)
 	if target.TargetOS == targetWindows && target.WindowsMode != windowsModeWSL2 {
-		args = append(args, "-O")
+		args = append([]string{"-O"}, args...)
 	}
-	args = append(args,
-		"-o", "BatchMode=yes",
-		"-o", "StrictHostKeyChecking=accept-new",
-		"-o", "UserKnownHostsFile="+sshConfigFileValue(knownHostsFile(target)),
-		"-o", "ConnectTimeout=10",
-		"-o", "ConnectionAttempts=3",
-		"-P", target.Port,
-	)
-	if target.Key != "" {
-		args = append([]string{"-i", target.Key, "-o", "IdentitiesOnly=yes"}, args...)
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] == "-p" {
+			args[i] = "-P"
+			break
+		}
 	}
 	return args
 }

--- a/internal/cli/ports_cp_test.go
+++ b/internal/cli/ports_cp_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -70,8 +71,59 @@ func TestPortsRejectsUnsupportedProvider(t *testing.T) {
 }
 
 func TestCopyRejectsUnsupportedProvider(t *testing.T) {
-	err := (App{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}).copyCommand(context.Background(), []string{"--provider", "aws", "--id", "cbx_123", "./file.txt", "SANDBOX:/tmp/file.txt"})
+	err := (App{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}).copyCommand(context.Background(), []string{"--provider", "service-control-test", "--id", "service_123", "./file.txt", "SANDBOX:/tmp/file.txt"})
 	if err == nil || !strings.Contains(err.Error(), "does not support cp") {
 		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestSSHCopyArgsPreserveResolvedTransport(t *testing.T) {
+	target := SSHTarget{
+		User:                   "agent",
+		Host:                   "box.example.test",
+		Port:                   "2222",
+		Key:                    "/tmp/agent key",
+		CertificateFile:        "/tmp/agent-cert.pub",
+		ProxyCommand:           "provider proxy %h %p",
+		DisableHostKeyChecking: true,
+		NoControlMaster:        true,
+	}
+
+	wantPrefix := []string{
+		"-i", "/tmp/agent key",
+		"-o", "IdentitiesOnly=yes",
+		"-o", "ForwardAgent=no",
+		"-o", "ForwardX11=no",
+		"-o", "ForwardX11Trusted=no",
+		"-o", "BatchMode=yes",
+		"-o", "ConnectTimeout=10",
+		"-o", "ConnectionAttempts=3",
+		"-o", "ServerAliveInterval=15",
+		"-o", "ServerAliveCountMax=2",
+		"-P", "2222",
+		"-o", "StrictHostKeyChecking=no",
+		"-o", "UserKnownHostsFile=/dev/null",
+		"-o", "LogLevel=ERROR",
+		"-o", "ControlMaster=no",
+		"-o", "CertificateFile=/tmp/agent-cert.pub",
+		"-o", "ProxyCommand=provider proxy %h %p",
+	}
+
+	toSandbox, err := sshCopyArgs(target, "./input.txt", "SANDBOX:/workspace/input.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantToSandbox := append(append([]string{}, wantPrefix...), "./input.txt", "agent@box.example.test:/workspace/input.txt")
+	if !reflect.DeepEqual(toSandbox, wantToSandbox) {
+		t.Fatalf("to sandbox args=%q\nwant=%q", toSandbox, wantToSandbox)
+	}
+
+	fromSandbox, err := sshCopyArgs(target, "SANDBOX:/workspace/output.txt", "./output.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantFromSandbox := append(append([]string{}, wantPrefix...), "agent@box.example.test:/workspace/output.txt", "./output.txt")
+	if !reflect.DeepEqual(fromSandbox, wantFromSandbox) {
+		t.Fatalf("from sandbox args=%q\nwant=%q", fromSandbox, wantFromSandbox)
 	}
 }

--- a/internal/cli/tunnel.go
+++ b/internal/cli/tunnel.go
@@ -1,0 +1,135 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const tunnelLoopbackHost = "127.0.0.1"
+
+func (a App) tunnel(ctx context.Context, args []string) error {
+	defaults := defaultConfig()
+	fs := newFlagSet("tunnel", a.Stderr)
+	provider := fs.String("provider", defaults.Provider, providerHelpSSH())
+	id := fs.String("id", "", "lease id or slug")
+	port := fs.Int("port", 0, "remote loopback port")
+	localPort := fs.Int("local-port", 0, "local loopback port (default: automatic)")
+	jsonOut := fs.Bool("json", false, "print tunnel coordinates as JSON")
+	reclaim := fs.Bool("reclaim", false, "claim this lease for the current repo")
+	providerFlags := registerProviderFlags(fs, defaults)
+	targetFlags := registerTargetFlags(fs, defaults)
+	networkFlags := registerNetworkModeFlag(fs, defaults)
+	if err := parseInterspersedFlags(fs, args); err != nil {
+		return err
+	}
+	idFlagSet := flagWasSet(fs, "id")
+	setIDFromFirstArg(fs, id)
+	if fs.NArg() > 1 || (idFlagSet && fs.NArg() > 0) || *port < 1 || *port > 65535 || *localPort < 0 || *localPort > 65535 {
+		return exit(2, "usage: crabbox tunnel --id <lease-id-or-slug> --port <remote-port> [--local-port <local-port>] [--json]")
+	}
+	cfg, err := loadSSHCommandConfig(fs, *provider, providerFlags, targetFlags, networkFlags, leaseTargetConfigOptions{LeaseID: *id})
+	if err != nil {
+		return err
+	}
+	if err := requireLeaseID(*id, "crabbox tunnel --id <lease-id-or-slug> --port <remote-port>", cfg); err != nil {
+		return err
+	}
+	lease, err := a.resolveNetworkLoginLeaseTargetForRepo(ctx, &cfg, *id, false, *reclaim, true)
+	if err != nil {
+		return err
+	}
+	if lease.SSH.AuthSecret {
+		return exit(2, "crabbox tunnel does not support token-as-username SSH targets")
+	}
+	if err := a.claimAndTouchLeaseTarget(ctx, cfg, lease.Server, lease.SSH, lease.LeaseID, *reclaim); err != nil {
+		return err
+	}
+	selectedLocalPort := *localPort
+	if selectedLocalPort == 0 {
+		selectedLocalPort, err = availableTunnelPort()
+		if err != nil {
+			return err
+		}
+	}
+	stopLeaseActivity := a.startInteractiveSSHLeaseActivity(ctx, cfg, lease)
+	defer stopLeaseActivity()
+	return runSSHTunnel(ctx, lease.SSH, selectedLocalPort, *port, *jsonOut, a.Stdout, a.Stderr)
+}
+
+func availableTunnelPort() (int, error) {
+	listener, err := net.Listen("tcp4", tunnelLoopbackHost+":0")
+	if err != nil {
+		return 0, exit(5, "reserve local tunnel port: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+	return listener.Addr().(*net.TCPAddr).Port, nil
+}
+
+func sshTunnelArgs(target SSHTarget, localPort, remotePort int) []string {
+	args := append(sshBaseArgs(target),
+		"-N",
+		"-o", "ExitOnForwardFailure=yes",
+		"-o", "GatewayPorts=no",
+		"-o", "ControlMaster=no",
+		"-o", "ControlPath=none",
+		"-o", "ControlPersist=no",
+		"-L", fmt.Sprintf("%s:%d:%s:%d", tunnelLoopbackHost, localPort, tunnelLoopbackHost, remotePort),
+		target.User+"@"+target.Host,
+	)
+	return args
+}
+
+func runSSHTunnel(ctx context.Context, target SSHTarget, localPort, remotePort int, jsonOut bool, stdout, stderr io.Writer) error {
+	cmd := exec.CommandContext(ctx, "ssh", sshTunnelArgs(target, localPort, remotePort)...)
+	var details synchronizedBuffer
+	cmd.Stdout = stderr
+	cmd.Stderr = io.MultiWriter(stderr, &details)
+	if err := cmd.Start(); err != nil {
+		return exit(5, "start SSH tunnel: %v", err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	deadline := time.NewTimer(10 * time.Second)
+	defer deadline.Stop()
+	poll := time.NewTicker(50 * time.Millisecond)
+	defer poll.Stop()
+	for {
+		select {
+		case err := <-done:
+			if text := strings.TrimSpace(details.String()); text != "" {
+				return exit(5, "SSH tunnel exited before readiness: %s", text)
+			}
+			return exit(5, "SSH tunnel exited before readiness: %v", err)
+		case <-deadline.C:
+			_ = cmd.Process.Kill()
+			<-done
+			return exit(5, "timed out waiting for SSH tunnel on %s:%d", tunnelLoopbackHost, localPort)
+		case <-poll.C:
+			conn, err := net.DialTimeout("tcp4", net.JoinHostPort(tunnelLoopbackHost, strconv.Itoa(localPort)), 100*time.Millisecond)
+			if err != nil {
+				continue
+			}
+			_ = conn.Close()
+			if jsonOut {
+				if err := json.NewEncoder(stdout).Encode(map[string]int{"port": localPort, "remotePort": remotePort}); err != nil {
+					_ = cmd.Process.Kill()
+					<-done
+					return err
+				}
+			} else {
+				fmt.Fprintf(stdout, "%s:%d\n", tunnelLoopbackHost, localPort)
+			}
+			if err := <-done; err != nil && ctx.Err() == nil {
+				return err
+			}
+			return context.Cause(ctx)
+		}
+	}
+}

--- a/internal/cli/tunnel_test.go
+++ b/internal/cli/tunnel_test.go
@@ -1,0 +1,132 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSSHTunnelArgsUseLoopbackAndResolvedTransport(t *testing.T) {
+	target := SSHTarget{
+		User:            "agent",
+		Host:            "box.example.test",
+		Port:            "2222",
+		Key:             "/tmp/agent key",
+		CertificateFile: "/tmp/agent-cert.pub",
+		ProxyCommand:    "provider proxy %h %p",
+		NoControlMaster: true,
+	}
+
+	got := sshTunnelArgs(target, 41000, 3000)
+	want := append(sshBaseArgs(target),
+		"-N",
+		"-o", "ExitOnForwardFailure=yes",
+		"-o", "GatewayPorts=no",
+		"-o", "ControlMaster=no",
+		"-o", "ControlPath=none",
+		"-o", "ControlPersist=no",
+		"-L", "127.0.0.1:41000:127.0.0.1:3000",
+		"agent@box.example.test",
+	)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("args=%q\nwant=%q", got, want)
+	}
+}
+
+func TestTunnelCommandHelp(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).Run(context.Background(), []string{"tunnel", "--help"})
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 0 {
+		t.Fatalf("tunnel --help err=%v", err)
+	}
+	for _, want := range []string{"-id string", "-port int", "-local-port int", "-json"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("tunnel help missing %q:\n%s", want, stderr.String())
+		}
+	}
+}
+
+func TestRunSSHTunnelReportsReadinessAndStopsWithContext(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX fake ssh helper is only reliable on Unix hosts")
+	}
+	dir := t.TempDir()
+	sshPath := filepath.Join(dir, "ssh")
+	if err := os.WriteFile(sshPath, []byte("#!/bin/sh\nexec \"$CRABBOX_TEST_BINARY\" -test.run=TestSSHTunnelHelperProcess -- \"$@\"\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CRABBOX_TEST_BINARY", executable)
+	t.Setenv("CRABBOX_TUNNEL_HELPER", "1")
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	localPort, err := availableTunnelPort()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var stdout, stderr synchronizedBuffer
+	done := make(chan error, 1)
+	go func() {
+		done <- runSSHTunnel(ctx, SSHTarget{Host: "example.invalid", User: "tester"}, localPort, 3000, true, &stdout, &stderr)
+	}()
+
+	deadline := time.After(3 * time.Second)
+	for !strings.Contains(stdout.String(), fmt.Sprintf(`"port":%d`, localPort)) {
+		select {
+		case err := <-done:
+			t.Fatalf("tunnel stopped before readiness: %v\nstderr=%s", err, stderr.String())
+		case <-deadline:
+			t.Fatalf("tunnel did not report readiness: %s", stderr.String())
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("tunnel stop error=%v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("tunnel did not stop with its context")
+	}
+}
+
+func TestSSHTunnelHelperProcess(t *testing.T) {
+	if os.Getenv("CRABBOX_TUNNEL_HELPER") != "1" {
+		return
+	}
+	forward := ""
+	for i, arg := range os.Args {
+		if arg == "-L" && i+1 < len(os.Args) {
+			forward = os.Args[i+1]
+			break
+		}
+	}
+	parts := strings.Split(forward, ":")
+	if len(parts) != 4 {
+		fmt.Fprintln(os.Stderr, "missing SSH forwarding argument")
+		os.Exit(22)
+	}
+	listener, err := net.Listen("tcp4", net.JoinHostPort(parts[0], parts[1]))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(22)
+	}
+	defer listener.Close()
+	time.Sleep(time.Hour)
+}


### PR DESCRIPTION
## Summary

- let `crabbox cp` use the resolved SSH transport when a provider has no native copy backend
- add `crabbox tunnel` for a loopback-only SSH forward with machine-readable readiness output
- preserve the resolved key, certificate, proxy, network, and host-key policy across both bridges
- document the SSH capability and command boundaries

## Verification

- `go vet ./internal/cli`
- `go test ./internal/cli -count=1` (passed in the full suite, 479.729s)
- `go test ./internal/providers/tart -run TestStartVMKeepPreservesStartupStderr -count=1`
- `go test ./... -count=1` passed every package except one unrelated Tart timing attempt; the exact Tart test passed immediately in isolation
- `git diff --check`

## Compatibility

Providers with a native `CopyBackend` keep their existing behavior. SSH copy supports regular files and rejects token-as-username targets; tunnels bind `127.0.0.1` on both sides and remain attached to the caller process.