### PR TITLE
chore: align pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,65 @@
+<!--
+Optional linked context:
+Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
+below this comment.
+
+Required PR title:
+type: user-facing description
+Use a parenthesized scope only when it adds clarity:
+fix(auth): login redirect loops when session cookie is expired
+
+Types: feat, fix, improve, refactor, docs, chore.
+For fixes, describe the user-visible symptom and trigger:
+fix: task list fails to load when user has no environments
+Avoid implementation details such as:
+fix: add null check to task query
+-->
+
+<details>
+<summary>Additional instructions</summary>
+
+**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
+can help update the branch when needed.
+
+</details>
+
+## What Problem This Solves
+
+<!--
+Describe the concrete user, product, or operational problem.
+For fixes, begin with:
+"Fixes an issue where users <do X> would <experience Y> when <condition>."
+or:
+"Resolves a problem where..."
+
+Name the affected UI surface or workflow. Do not describe the code-level cause here.
+-->
+
+## Why This Change Was Made
+
+<!--
+In one or two sentences, explain the complete shipped solution, key design
+decisions, and relevant boundaries or non-goals. Include implementation detail
+only when it helps reviewers understand user-visible behavior or risk.
+Avoid file-by-file narration.
+-->
+
+## User Impact
+
+<!--
+State what users, operators, or developers can now do or expect. Lead with the
+concrete benefit and use user-facing language. If there is no user-visible
+impact, say so plainly.
+-->
+
+## Evidence
+
+<!--
+Show the most useful proof that this change works. Screenshots, screencasts,
+terminal output, focused tests, CI results, live observations, redacted logs,
+and artifact links are all useful. Include before/after evidence for visual
+changes when it clarifies the result.
+
+Reviewers will inspect the code, tests, and CI. Use this section to make the
+validation easy to understand, not to restate the diff.
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,9 @@
 <!--
 Optional linked context:
-Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
-below this comment.
+Add a visible
+`Closes https://github.com/openclaw/crabbox/issues/<issue-number>` or
+`Related: https://github.com/openclaw/crabbox/issues/<issue-number>` line below
+this comment.
 
 Required PR title:
 type: user-facing description


### PR DESCRIPTION
## What Problem This Solves

Resolves inconsistent pull request descriptions across OpenClaw-owned repositories, which makes cross-repository review and evidence collection less predictable.

## Why This Change Was Made

Adopts the canonical PR body structure from `openclaw/openclaw` at pinned commit `2ac723282c84286ad3f38aabbd2e70699aafb3c3`, while using full `openclaw/crabbox` issue URLs as required by this repository's contribution policy.

## User Impact

Contributors and maintainers get the shared PR submission structure with Crabbox-compliant issue references; no runtime behavior changes.

## Evidence

- Canonical source: https://github.com/openclaw/openclaw/blob/2ac723282c84286ad3f38aabbd2e70699aafb3c3/.github/pull_request_template.md
- Canonical blob: `e902c4789b21765ea16dfb75e436db5801b6450b`
- Canonical SHA-256: `38845d7f2cfc96402062408ac8a87b1e3f5f81dd80924785b0547b64a0c914b6`
- Repository-specific delta is limited to replacing shorthand issue references with full GitHub URLs.
- `git diff --check` passed.
- Metadata-only change; runtime tests are not applicable.
- AI-assisted batch maintenance change.
