### PR TITLE
fix: protect portal cookies from sibling origins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.38.1 - Unreleased
 
+### Fixed
+
+- Protected portal and isolated Code sessions with browser-enforced host-only cookies, rejected duplicate session cookies, and retired legacy cookie names to prevent sibling-origin shadowing. Thanks @coygeek.
+
 ## 0.38.0 - 2026-07-11
 
 ### Added

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -135,7 +135,8 @@ the OAuth credential encrypted under the session secret so request authenticatio
 can periodically revalidate current org/team membership. An optional Cloudflare
 Access JWT (`cf-access-jwt-assertion`) can supply the owner identity. The
 coordinator injects `x-crabbox-auth`, `-admin`, `-owner`, `-org`, and `-github-login`
-headers. The portal converts a `crabbox_session` cookie into a Bearer token.
+headers. The portal converts one unique `__Host-crabbox_session` host-only
+cookie into a Bearer token and rejects duplicate session cookies.
 
 ## Fleet Coordinator And Runtime Adapters
 

--- a/docs/features/coordinator.md
+++ b/docs/features/coordinator.md
@@ -85,8 +85,9 @@ owner email for admin and shared-token requests.
 After auth, the coordinator strips inbound Access headers and injects a trusted
 context for the fleet implementation: `x-crabbox-auth`, `x-crabbox-admin`,
 `x-crabbox-owner`, `x-crabbox-org`, and `x-crabbox-github-login`. The portal
-converts a `crabbox_session` cookie into a Bearer token so browser sessions reuse
-the same auth path.
+converts one unique `__Host-crabbox_session` host-only cookie into a Bearer token
+so browser sessions reuse the same auth path. Duplicate session cookies fail
+closed.
 
 GitHub user tokens are scoped to their owner/org for lease, run, log, and usage
 routes. Admin scope (admin token, or shared token where allowed) is required for
@@ -219,9 +220,9 @@ GET    /v1/images/{id}/fast-snapshot-restore
 
 The portal is the authenticated browser UI served by the same coordinator
 (`worker/src/portal.ts`). Login is unauthenticated; everything else uses the
-`crabbox_session` cookie. Logout confirmation is read-only, while logout itself
-requires a same-origin `POST` and closes WebVNC, Code, and mediated-egress
-bridges bound to that portal session.
+host-only `__Host-crabbox_session` cookie. Logout confirmation is read-only,
+while logout itself requires a same-origin `POST` and closes WebVNC, Code, and
+mediated-egress bridges bound to that portal session.
 
 ```text
 GET    /portal

--- a/docs/features/portal.md
+++ b/docs/features/portal.md
@@ -63,9 +63,10 @@ content from the coordinator and from other leases by setting
 `/portal/leases/{id-or-slug}/code/` URL remains the entrypoint: after normal
 portal authorization it redirects through a one-use, short-lived viewer ticket
 to an opaque per-lease hostname. That hostname receives only an HttpOnly,
-path-scoped Code viewer session; it never receives `crabbox_session` and cannot
-use the Code session on other portal routes or lease origins. The ingress must
-provide wildcard TLS and WebSocket routing for the template.
+browser-enforced host-only `__Host-crabbox_code_session`; it never receives
+`__Host-crabbox_session` and cannot use the Code session on other portal routes
+or lease origins. The ingress must provide wildcard TLS and WebSocket routing
+for the template.
 Proxied responses may set only code-server's `vscode-tkn` cookie; Crabbox removes
 domain scope and confines it to that lease's Code path.
 Crabbox also replaces upstream Content Security Policy headers and limits
@@ -83,13 +84,18 @@ browser HTTP and WebSocket traffic fails closed with `409 Code origin required`.
 
 ## Authentication and scope
 
-Portal pages use a browser session cookie (`crabbox_session`) minted after a
-successful GitHub login through the same OAuth flow as `crabbox login`. The
-Worker converts the cookie to a `Bearer` token internally; an unauthenticated
-GET request to a portal page is redirected to `/portal/login` with a
-`returnTo` parameter. The session carries owner/org claims, and the Worker
-rejects altered or suffixed spellings of its signed session tokens. The session
-scopes every page to that identity.
+Portal pages use a browser-enforced host-only session cookie
+(`__Host-crabbox_session`) minted after a successful GitHub login through the
+same OAuth flow as `crabbox login`. The Worker converts the cookie to a `Bearer`
+token internally; an unauthenticated GET request to a portal page is redirected
+to `/portal/login` with a `returnTo` parameter. The session carries owner/org
+claims, and the Worker rejects altered or suffixed spellings of its signed
+session tokens. Duplicate session cookies fail closed. The session scopes every
+page to that identity.
+
+Upgrading retires the legacy `crabbox_session` and `crabbox_code_session`
+cookies. Existing portal sessions must sign in once; active browser Code
+sessions rebootstrap through their normal portal entrypoint.
 
 ```text
 session  authenticated GitHub user (owner / org embedded in the token)

--- a/worker/node/server-support.ts
+++ b/worker/node/server-support.ts
@@ -205,6 +205,20 @@ export async function writeNodeResponseBody(stream: Writable, body: Buffer): Pro
   await completion;
 }
 
+export function nodeResponseHeaders(headers: Headers): Array<[string, string | string[]]> {
+  const result: Array<[string, string | string[]]> = [];
+  for (const [name, value] of headers) {
+    if (name.toLowerCase() !== "set-cookie") {
+      result.push([name, value]);
+    }
+  }
+  const setCookies = headers.getSetCookie();
+  if (setCookies.length > 0) {
+    result.push(["set-cookie", setCookies]);
+  }
+  return result;
+}
+
 export function fleetRequestQueue(request: Request): FleetRequestQueue {
   return coordinatorRequestQueue(request);
 }

--- a/worker/node/server.ts
+++ b/worker/node/server.ts
@@ -21,6 +21,7 @@ import {
   fleetRequestQueue,
   isReadinessRequestMethod,
   isTrustedProxySource,
+  nodeResponseHeaders,
   nodeRequestAbortSignal,
   readNodeRequestBody,
   requestSourceIP,
@@ -284,7 +285,9 @@ async function writeResponse(
   closeConnection = false,
 ): Promise<void> {
   response.statusCode = result.status;
-  result.headers.forEach((value, name) => response.setHeader(name, value));
+  for (const [name, value] of nodeResponseHeaders(result.headers)) {
+    response.setHeader(name, value);
+  }
   if (closeConnection) {
     response.setHeader("connection", "close");
   }
@@ -302,7 +305,11 @@ async function writeUpgradeResponse(socket: Duplex, response: Response): Promise
   headers.set("content-length", String(body.byteLength));
   const statusText = STATUS_CODES[response.status] || "Error";
   const lines = [`HTTP/1.1 ${response.status} ${statusText}`];
-  headers.forEach((value, name) => lines.push(`${name}: ${value}`));
+  for (const [name, value] of nodeResponseHeaders(headers)) {
+    for (const item of Array.isArray(value) ? value : [value]) {
+      lines.push(`${name}: ${item}`);
+    }
+  }
   socket.end(`${lines.join("\r\n")}\r\n\r\n${body.toString()}`);
 }
 

--- a/worker/src/cookies.ts
+++ b/worker/src/cookies.ts
@@ -1,13 +1,22 @@
+export const portalSessionCookieName = "__Host-crabbox_session";
+export const legacyPortalSessionCookieName = "crabbox_session";
+export const codeViewerSessionCookieName = "__Host-crabbox_code_session";
+export const legacyCodeViewerSessionCookieName = "crabbox_code_session";
+
 export function cookieValue(header: string, name: string): string {
+  let result: string | undefined;
   for (const part of header.split(";")) {
     const [key, ...value] = part.trim().split("=");
     if (key === name) {
+      if (result !== undefined) {
+        return "";
+      }
       try {
-        return decodeURIComponent(value.join("="));
+        result = decodeURIComponent(value.join("="));
       } catch {
         return "";
       }
     }
   }
-  return "";
+  return result ?? "";
 }

--- a/worker/src/coordinator-entry.ts
+++ b/worker/src/coordinator-entry.ts
@@ -8,7 +8,7 @@ import {
   type AuthRequestContext,
 } from "./auth";
 import { codeProxyRequestBodyBytes, isIsolatedCodeRequest } from "./code-origin";
-import { cookieValue } from "./cookies";
+import { cookieValue, portalSessionCookieName } from "./cookies";
 import { bearerToken, json, pathParts } from "./http";
 import { InvalidOrgLabelError, orgKeyForLabel } from "./org-identity";
 import { runtimeAdapterProxyPath, runtimeAdapterRelayMethodAllowed } from "./runtime-adapter-relay";
@@ -120,7 +120,7 @@ export async function prepareCoordinatorRequest(
     request.method === "POST" &&
     url.pathname === "/portal/logout" &&
     !request.headers.has("authorization")
-      ? cookieValue(request.headers.get("cookie") ?? "", "crabbox_session")
+      ? cookieValue(request.headers.get("cookie") ?? "", portalSessionCookieName)
       : undefined;
   const auth = portalLogoutToken
     ? await authenticateUserTokenForRevocation(portalLogoutToken, env)
@@ -171,7 +171,7 @@ async function authenticatedCoordinatorRequest(
 
 function portalCookieRequestIntentAllowed(request: Request, env: Env, url: URL): boolean {
   if (request.headers.get("authorization")) return true;
-  if (!cookieValue(request.headers.get("cookie") ?? "", "crabbox_session")) return true;
+  if (!cookieValue(request.headers.get("cookie") ?? "", portalSessionCookieName)) return true;
   const method = request.method.toUpperCase();
   const websocket =
     method === "GET" && request.headers.get("upgrade")?.toLowerCase() === "websocket";
@@ -280,7 +280,7 @@ function requestWithPortalCookie(request: Request): Request {
   if (request.headers.get("authorization")) {
     return request;
   }
-  const token = cookieValue(request.headers.get("cookie") ?? "", "crabbox_session");
+  const token = cookieValue(request.headers.get("cookie") ?? "", portalSessionCookieName);
   if (!token) {
     return request;
   }

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -50,7 +50,12 @@ import {
   type LeaseConfig,
   type LeaseConfigDefaults,
 } from "./config";
-import { cookieValue } from "./cookies";
+import {
+  codeViewerSessionCookieName,
+  cookieValue,
+  legacyCodeViewerSessionCookieName,
+  portalSessionCookieName,
+} from "./cookies";
 import {
   CloudflareCoordinatorRuntime,
   bufferCoordinatorRequestBody,
@@ -8762,17 +8767,20 @@ export class FleetCoordinator {
       expiresAt: new Date(expiresAt).toISOString(),
     };
     await this.state.storage.put(codeViewerSessionKey(session.session), session);
+    const headers = new Headers({
+      "cache-control": "no-store",
+      location: ticket.returnTo,
+      "referrer-policy": "no-referrer",
+    });
+    for (const cookie of codeViewerSessionCookies(
+      session,
+      Math.max(0, Math.floor((expiresAt - now.getTime()) / 1000)),
+    )) {
+      headers.append("set-cookie", cookie);
+    }
     return new Response(null, {
       status: 303,
-      headers: {
-        "cache-control": "no-store",
-        location: ticket.returnTo,
-        "referrer-policy": "no-referrer",
-        "set-cookie": codeViewerSessionCookie(
-          session,
-          Math.max(0, Math.floor((expiresAt - now.getTime()) / 1000)),
-        ),
-      },
+      headers,
     });
   }
 
@@ -8780,7 +8788,7 @@ export class FleetCoordinator {
     request: Request,
     leaseID: string,
   ): Promise<CodeViewerSessionRecord | undefined> {
-    const value = cookieValue(request.headers.get("cookie") ?? "", "crabbox_code_session");
+    const value = cookieValue(request.headers.get("cookie") ?? "", codeViewerSessionCookieName);
     if (!validCodeViewerSession(value)) {
       return undefined;
     }
@@ -8889,7 +8897,7 @@ export class FleetCoordinator {
 
   private async portalLogout(request: Request): Promise<Response> {
     await this.cleanupExpiredCodeViewerAuth();
-    const token = cookieValue(request.headers.get("cookie") ?? "", "crabbox_session");
+    const token = cookieValue(request.headers.get("cookie") ?? "", portalSessionCookieName);
     if (token) {
       const verifiedTokenExpiresAt = await verifiedUserTokenExpiresAtForRevocation(token, this.env);
       if (verifiedTokenExpiresAt) {
@@ -15543,15 +15551,25 @@ function isolatedCodeRequestOriginAllowed(request: Request): boolean {
   );
 }
 
-function codeViewerSessionCookie(session: CodeViewerSessionRecord, maxAgeSeconds: number): string {
+function codeViewerSessionCookies(
+  session: CodeViewerSessionRecord,
+  maxAgeSeconds: number,
+): string[] {
+  const attributes = ["HttpOnly", "Secure", "SameSite=Lax"];
   return [
-    `crabbox_code_session=${encodeURIComponent(session.session)}`,
-    `Path=/portal/leases/${encodeURIComponent(session.leaseID)}/code/`,
-    "HttpOnly",
-    "Secure",
-    "SameSite=Lax",
-    `Max-Age=${Math.max(0, Math.trunc(maxAgeSeconds))}`,
-  ].join("; ");
+    [
+      `${codeViewerSessionCookieName}=${encodeURIComponent(session.session)}`,
+      "Path=/",
+      ...attributes,
+      `Max-Age=${Math.max(0, Math.trunc(maxAgeSeconds))}`,
+    ].join("; "),
+    [
+      `${legacyCodeViewerSessionCookieName}=`,
+      `Path=/portal/leases/${encodeURIComponent(session.leaseID)}/code/`,
+      ...attributes,
+      "Max-Age=0",
+    ].join("; "),
+  ];
 }
 
 export function bridgeTicketFromRequest(

--- a/worker/src/oauth.ts
+++ b/worker/src/oauth.ts
@@ -4,6 +4,7 @@ import {
   userTokenExpiresAt,
   userTokenSigningConfigurationError,
 } from "./auth";
+import { legacyPortalSessionCookieName, portalSessionCookieName } from "./cookies";
 import type { CoordinatorRuntime, CoordinatorStorage } from "./coordinator-runtime";
 import {
   githubUserIsRevoked,
@@ -103,7 +104,11 @@ export async function githubPortalLogin(
     return html("Crabbox login busy", "Too many pending GitHub logins. Try again shortly.", 429);
   }
 
-  return redirect(githubAuthorizeURLFor(clientID, pending.state, pending.redirectURI), 302);
+  return redirect(
+    githubAuthorizeURLFor(clientID, pending.state, pending.redirectURI),
+    302,
+    legacyPortalSessionCookieHeaders(),
+  );
 }
 
 export function githubPortalLogout(): Response {
@@ -111,9 +116,7 @@ export function githubPortalLogout(): Response {
     "Crabbox logged out",
     "Your Crabbox portal session has ended.",
     200,
-    {
-      "set-cookie": portalSessionCookie("", 0),
-    },
+    portalSessionCookieHeaders("", 0),
     `<p><a href="/portal/login">Log in again</a></p>`,
   );
 }
@@ -341,9 +344,11 @@ async function githubAuthCallback(
     }
     if (completed.mode === "portal") {
       await runtime.runExclusive(() => deletePendingOAuth(runtime.storage, completed));
-      return redirect(completed.returnTo || "/portal", 302, {
-        "set-cookie": portalSessionCookie(token, ttlSeconds),
-      });
+      return redirect(
+        completed.returnTo || "/portal",
+        302,
+        portalSessionCookieHeaders(token, ttlSeconds),
+      );
     }
     if (!completed.loopbackRedirectURI) {
       await runtime.runExclusive(() => deletePendingOAuth(runtime.storage, completed));
@@ -690,37 +695,49 @@ function html(
   title: string,
   message: string,
   status = 200,
-  headers: Record<string, string> = {},
+  headers: HeadersInit = {},
   extraBody = "",
 ): Response {
   const escapedTitle = escapeHTML(title);
   const escapedMessage = escapeHTML(message);
+  const responseHeaders = new Headers(headers);
+  responseHeaders.set("content-type", "text/html; charset=utf-8");
   return new Response(
     `<!doctype html><html><head><meta charset="utf-8"><title>${escapedTitle}</title><style>body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;max-width:42rem;margin:5rem auto;padding:0 1rem;line-height:1.5;color:#111}code{background:#f4f4f5;padding:.15rem .3rem;border-radius:4px}</style></head><body><h1>${escapedTitle}</h1><p>${escapedMessage}</p>${extraBody}</body></html>`,
-    { status, headers: { "content-type": "text/html; charset=utf-8", ...headers } },
+    { status, headers: responseHeaders },
   );
 }
 
-function redirect(location: string, status = 302, headers: Record<string, string> = {}): Response {
+function redirect(location: string, status = 302, headers: HeadersInit = {}): Response {
+  const responseHeaders = new Headers(headers);
+  responseHeaders.set("location", location);
   return new Response(null, {
     status,
-    headers: {
-      location,
-      ...headers,
-    },
+    headers: responseHeaders,
   });
 }
 
-function portalSessionCookie(value: string, maxAgeSeconds: number): string {
-  const attrs = [
-    `crabbox_session=${encodeURIComponent(value)}`,
+function portalSessionCookieHeaders(value: string, maxAgeSeconds: number): Headers {
+  const headers = legacyPortalSessionCookieHeaders();
+  headers.append("set-cookie", sessionCookie(portalSessionCookieName, value, maxAgeSeconds));
+  return headers;
+}
+
+function legacyPortalSessionCookieHeaders(): Headers {
+  const headers = new Headers();
+  headers.append("set-cookie", sessionCookie(legacyPortalSessionCookieName, "", 0));
+  return headers;
+}
+
+function sessionCookie(name: string, value: string, maxAgeSeconds: number): string {
+  return [
+    `${name}=${encodeURIComponent(value)}`,
     "Path=/",
     "HttpOnly",
     "Secure",
     "SameSite=Lax",
     `Max-Age=${Math.max(0, Math.trunc(maxAgeSeconds))}`,
-  ];
-  return attrs.join("; ");
+  ].join("; ");
 }
 
 function safePortalReturnTo(value: string | null): string {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -18593,10 +18593,14 @@ describe("fleet lease identity and idle", () => {
       `/portal/leases/${leaseID}/code/?folder=%2Fwork%2Frepo`,
     );
     const cookie = bootstrap.headers.get("set-cookie") || "";
-    expect(cookie).toContain("crabbox_code_session=code_session_");
+    expect(cookie).toContain("__Host-crabbox_code_session=code_session_");
+    expect(cookie).toContain("Path=/");
+    expect(cookie).toContain("crabbox_code_session=;");
     expect(cookie).toContain(`Path=/portal/leases/${leaseID}/code/`);
     expect(cookie).toContain("HttpOnly");
     expect(cookie).toContain("Secure");
+    expect(cookie).toContain("SameSite=Lax");
+    expect(cookie).not.toContain("Domain=");
     const maxAge = Number.parseInt(/Max-Age=(\d+)/.exec(cookie)?.[1] || "", 10);
     expect(maxAge).toBeGreaterThanOrEqual(295);
     expect(maxAge).toBeLessThanOrEqual(300);
@@ -18613,6 +18617,27 @@ describe("fleet lease identity and idle", () => {
     expect(await page.text()).toContain("crabbox code --id blue-lobster --open");
 
     const sessionCookie = cookie.split(";", 1)[0] || "";
+    const legacySession = await fleet.fetch(
+      new Request(`${bootstrapURL.origin}${bootstrap.headers.get("location")}`, {
+        headers: { cookie: sessionCookie.replace("__Host-", "") },
+      }),
+    );
+    expect(legacySession.status).toBe(302);
+
+    const duplicateSession = await fleet.fetch(
+      new Request(`${bootstrapURL.origin}${bootstrap.headers.get("location")}`, {
+        headers: { cookie: `${sessionCookie}; ${sessionCookie}` },
+      }),
+    );
+    expect(duplicateSession.status).toBe(302);
+
+    const shadowedSession = await fleet.fetch(
+      new Request(`${bootstrapURL.origin}${bootstrap.headers.get("location")}`, {
+        headers: { cookie: `crabbox_code_session=attacker; ${sessionCookie}` },
+      }),
+    );
+    expect(shadowedSession.status).toBe(200);
+
     const crossOriginPost = await fleet.fetch(
       new Request(`${bootstrapURL.origin}/portal/leases/${leaseID}/code/api/save`, {
         method: "POST",
@@ -18661,7 +18686,7 @@ describe("fleet lease identity and idle", () => {
 
     const malformedSession = await fleet.fetch(
       new Request(`${bootstrapURL.origin}/portal/leases/${leaseID}/code/health`, {
-        headers: { cookie: "crabbox_code_session=%ZZ" },
+        headers: { cookie: "__Host-crabbox_code_session=%ZZ" },
       }),
     );
     expect(malformedSession.status).toBe(302);
@@ -18707,7 +18732,7 @@ describe("fleet lease identity and idle", () => {
 
     const staleSession = await fleet.fetch(
       new Request(`${isolatedOrigin}/portal/leases/${leaseID}/code/health`, {
-        headers: { cookie: `crabbox_code_session=${session}` },
+        headers: { cookie: `__Host-crabbox_code_session=${session}` },
       }),
     );
     expect(staleSession.status).toBe(404);
@@ -18727,7 +18752,7 @@ describe("fleet lease identity and idle", () => {
       ),
     );
     expect(bootstrap.status).toBe(303);
-    const issuedSession = /crabbox_code_session=([^;]+)/.exec(
+    const issuedSession = /__Host-crabbox_code_session=([^;]+)/.exec(
       bootstrap.headers.get("set-cookie") ?? "",
     )?.[1];
     expect(issuedSession).toMatch(/^code_session_[a-f0-9]{32}$/);
@@ -18774,7 +18799,7 @@ describe("fleet lease identity and idle", () => {
         }),
     );
     vi.stubGlobal("fetch", githubFetch);
-    const portalCookie = `crabbox_session=${encodeURIComponent(token)}`;
+    const portalCookie = `__Host-crabbox_session=${encodeURIComponent(token)}`;
     const throughCoordinator = async (input: Request): Promise<Response> =>
       await routeCoordinatorRequest(input, env, async (prepared) => await fleet.fetch(prepared), {
         githubMembership: async (): Promise<void> => {},
@@ -18963,7 +18988,8 @@ describe("fleet lease identity and idle", () => {
       }),
     );
     expect(logout.status).toBe(200);
-    expect(logout.headers.get("set-cookie")).toContain("crabbox_session=");
+    expect(logout.headers.get("set-cookie")).toContain("__Host-crabbox_session=");
+    expect(logout.headers.get("set-cookie")).toContain("crabbox_session=;");
     expect(logout.headers.get("set-cookie")).toContain("Max-Age=0");
     expect(storage.value(expiredRevocationKey)).toBeUndefined();
     expect(activeViewer.closeCode).toBe(1008);
@@ -19014,7 +19040,7 @@ describe("fleet lease identity and idle", () => {
 
     const suffixedPortalSession = await throughCoordinator(
       new Request(codeEntry, {
-        headers: { cookie: `crabbox_session=${encodeURIComponent(`${token}.ignored`)}` },
+        headers: { cookie: `__Host-crabbox_session=${encodeURIComponent(`${token}.ignored`)}` },
       }),
     );
     expect(suffixedPortalSession.status).toBe(302);
@@ -19481,7 +19507,7 @@ describe("fleet lease identity and idle", () => {
     const response = await fleet.fetch(
       new Request(`${isolatedOrigin}/portal/leases/${leaseID}/code/api/status`, {
         headers: {
-          cookie: `crabbox_code_session=${session}`,
+          cookie: `__Host-crabbox_code_session=${session}`,
           "x-client-trace": "trace-1",
           origin: isolatedOrigin || "",
         },
@@ -19544,7 +19570,7 @@ describe("fleet lease identity and idle", () => {
     const response = await fleet.fetch(
       new Request(`${isolatedOrigin}/portal/leases/${leaseID}/code/api/status`, {
         headers: {
-          cookie: `crabbox_code_session=${session}`,
+          cookie: `__Host-crabbox_code_session=${session}`,
           origin: isolatedOrigin || "",
         },
       }),
@@ -25052,6 +25078,8 @@ describe("fleet identity", () => {
       request("GET", "/portal/login?returnTo=/portal/leases/cbx_000000000001/vnc"),
     );
     expect(start.status).toBe(302);
+    expect(start.headers.get("set-cookie")).toContain("crabbox_session=;");
+    expect(start.headers.get("set-cookie")).toContain("Max-Age=0");
     const location = start.headers.get("location") ?? "";
     const state = new URL(location).searchParams.get("state");
     expect(state).toBeTruthy();
@@ -25062,7 +25090,14 @@ describe("fleet identity", () => {
     );
     expect(callback.status).toBe(302);
     expect(callback.headers.get("location")).toBe("/portal/leases/cbx_000000000001/vnc");
-    expect(callback.headers.get("set-cookie")).toContain("crabbox_session=cbxu_");
+    const cookie = callback.headers.get("set-cookie") ?? "";
+    expect(cookie).toContain("__Host-crabbox_session=cbxu_");
+    expect(cookie).toContain("crabbox_session=;");
+    expect(cookie).toContain("Path=/");
+    expect(cookie).toContain("HttpOnly");
+    expect(cookie).toContain("Secure");
+    expect(cookie).toContain("SameSite=Lax");
+    expect(cookie).not.toContain("Domain=");
   });
 
   it.each([
@@ -25096,7 +25131,7 @@ describe("fleet identity", () => {
     );
     expect(callback.status).toBe(302);
     expect(callback.headers.get("location")).toBe("/portal");
-    expect(callback.headers.get("set-cookie")).toContain("crabbox_session=cbxu_");
+    expect(callback.headers.get("set-cookie")).toContain("__Host-crabbox_session=cbxu_");
   });
 
   it("requires a POST before clearing the portal session", async () => {
@@ -25114,7 +25149,8 @@ describe("fleet identity", () => {
     const logout = await fleet.fetch(request("POST", "/portal/logout"));
     expect(logout.status).toBe(200);
     expect(logout.headers.get("location")).toBeNull();
-    expect(logout.headers.get("set-cookie")).toContain("crabbox_session=");
+    expect(logout.headers.get("set-cookie")).toContain("__Host-crabbox_session=");
+    expect(logout.headers.get("set-cookie")).toContain("crabbox_session=;");
     expect(logout.headers.get("set-cookie")).toContain("Max-Age=0");
     const body = await logout.text();
     expect(body).toContain("Crabbox logged out");

--- a/worker/test/http.test.ts
+++ b/worker/test/http.test.ts
@@ -188,7 +188,7 @@ describe("coordinator auth", () => {
       login: "alice",
       githubAccessToken: "github-access-token",
     });
-    const cookie = `crabbox_session=${encodeURIComponent(token)}`;
+    const cookie = `__Host-crabbox_session=${encodeURIComponent(token)}`;
     const mutationURL = "https://broker.example.test/portal/leases/blue-lobster/share";
     const viewerURL = "https://broker.example.test/portal/leases/blue-lobster/vnc/viewer";
 
@@ -274,7 +274,7 @@ describe("coordinator auth", () => {
       githubAccessToken: "github-access-token",
     });
     const headers = {
-      cookie: `crabbox_session=${encodeURIComponent(token)}`,
+      cookie: `__Host-crabbox_session=${encodeURIComponent(token)}`,
       origin: "https://broker.example.test",
     };
     const membershipUnavailable = {
@@ -337,7 +337,7 @@ describe("coordinator auth", () => {
       CRABBOX_SESSION_SECRET: "session-secret",
       CRABBOX_PUBLIC_URL: "https://broker.example.test",
     } as Env;
-    const cookie = "crabbox_session=%ZZ";
+    const cookie = "__Host-crabbox_session=%ZZ";
 
     const portalGet = await prepareCoordinatorRequest(
       new Request("https://broker.example.test/portal?provider=aws", { headers: { cookie } }),
@@ -367,6 +367,43 @@ describe("coordinator auth", () => {
     );
   });
 
+  it("ignores legacy portal cookies and rejects duplicate host-prefixed sessions", async () => {
+    const env = {
+      CRABBOX_SESSION_SECRET: "session-secret",
+      CRABBOX_PUBLIC_URL: "https://broker.example.test",
+      CRABBOX_DEFAULT_ORG: "example-org",
+    } as Env;
+    const token = await issueUserToken(env, {
+      owner: "alice@example.com",
+      ownerSource: "github-verified-email",
+      org: "example-org",
+      login: "alice",
+      githubAccessToken: "github-access-token",
+    });
+    const url = "https://broker.example.test/portal/leases/blue-lobster";
+    const prepare = async (cookie: string) =>
+      await prepareCoordinatorRequest(
+        new Request(url, { headers: { cookie } }),
+        env,
+        allowGitHubMembership,
+      );
+
+    const hostOnly = await prepare(
+      `crabbox_session=attacker; __Host-crabbox_session=${encodeURIComponent(token)}`,
+    );
+    expect(hostOnly).toMatchObject({ authenticated: true });
+
+    const rejected = await Promise.all(
+      [
+        `crabbox_session=${encodeURIComponent(token)}`,
+        `__Host-crabbox_session=${encodeURIComponent(token)}; __Host-crabbox_session=${encodeURIComponent(token)}`,
+      ].map(prepare),
+    );
+    for (const prepared of rejected) {
+      expect(prepared).toMatchObject({ authenticated: false, response: { status: 302 } });
+    }
+  });
+
   it("routes only the exact per-lease Code origin without portal-cookie authority", async () => {
     const env = {
       CRABBOX_CODE_ORIGIN_TEMPLATE: "https://{lease}.code.example.test",
@@ -376,7 +413,7 @@ describe("coordinator auth", () => {
     const origin = await codeOriginForLease(env, leaseID);
     const isolated = await prepareCoordinatorRequest(
       new Request(`${origin}/portal/leases/${leaseID}/code/static/app.js`, {
-        headers: { cookie: "crabbox_session=must-not-authorize-code-origin" },
+        headers: { cookie: "__Host-crabbox_session=must-not-authorize-code-origin" },
       }),
       env,
     );

--- a/worker/test/server-support.test.ts
+++ b/worker/test/server-support.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "node:events";
-import type { IncomingMessage, ServerResponse } from "node:http";
+import { createServer, get, type IncomingMessage, type ServerResponse } from "node:http";
 import { Writable } from "node:stream";
 
 import { describe, expect, it, vi } from "vitest";
@@ -8,11 +8,13 @@ import {
   AsyncMutex,
   AsyncOperationTracker,
   RequestBodyTooLargeError,
+  closeServer,
   drainAndStop,
   authenticatedRequestBodyBytes,
   fleetRequestQueue,
   isReadinessRequestMethod,
   isTrustedProxySource,
+  nodeResponseHeaders,
   nodeRequestAbortSignal,
   readNodeRequestBody,
   requestBodyLimit,
@@ -224,6 +226,47 @@ describe("Node server support", () => {
     await expect(writeNodeResponseBody(response, Buffer.from("payload"))).rejects.toThrow(
       "Premature close",
     );
+  });
+
+  it("emits separate Set-Cookie fields through Node HTTP", async () => {
+    const headers = new Headers({ "x-test": "ok" });
+    headers.append("set-cookie", "legacy=; Path=/; Max-Age=0");
+    headers.append("set-cookie", "__Host-current=value; Path=/; Secure");
+    expect(nodeResponseHeaders(headers)).toContainEqual([
+      "set-cookie",
+      ["legacy=; Path=/; Max-Age=0", "__Host-current=value; Path=/; Secure"],
+    ]);
+
+    const server = createServer((_request, response) => {
+      for (const [name, value] of nodeResponseHeaders(headers)) {
+        response.setHeader(name, value);
+      }
+      response.end();
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") throw new Error("missing Node test address");
+      const setCookies = await new Promise<string[]>((resolve, reject) => {
+        const request = get(
+          { hostname: "127.0.0.1", port: address.port, path: "/" },
+          (response) => {
+            response.resume();
+            response.once("end", () => resolve(response.headers["set-cookie"] ?? []));
+          },
+        );
+        request.once("error", reject);
+      });
+      expect(setCookies).toEqual([
+        "legacy=; Path=/; Max-Age=0",
+        "__Host-current=value; Path=/; Secure",
+      ]);
+    } finally {
+      await closeServer(server);
+    }
   });
 
   it("bounds shutdown waits", async () => {


### PR DESCRIPTION
## Summary

- move portal and isolated Code sessions to browser-enforced `__Host-` cookie names
- reject duplicate active session cookies and ignore legacy names
- expire legacy cookies during login, logout, and Code bootstrap migration
- preserve separate `Set-Cookie` fields through the Node HTTP and upgrade bridges
- document the one-time browser session transition and add changelog credit for @coygeek

## Compatibility

- existing portal sessions sign in once after upgrade
- active browser Code sessions rebootstrap through the existing portal entrypoint
- CLI bearer authentication is unchanged

## Validation

- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm run check:node --prefix worker`
- `npm test --prefix worker` — 1,048 passed, 3 skipped
- `npm run build --prefix worker`
- `npm run build:node --prefix worker`
- `scripts/check-docs.sh` — 6 docs-site tests passed
- real Node socket proof received distinct legacy-deletion and host-prefixed `Set-Cookie` fields
- live Safari proof across three temporary HTTPS sibling origins: legacy-only portal and Code cookies arrived but failed authentication; legitimate host-prefixed sessions remained unique and valid after sibling attempts to set the same `__Host-` names with `Domain`
- temporary Workers, custom domains, and browser test cookies deleted after proof
- AutoReview clean after fixing its Node multi-cookie transport finding

Closes https://github.com/openclaw/crabbox/issues/1002
