### PR TITLE
feat: expose AWS instance-profile state in inspect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.38.1 - Unreleased
 
+### Added
+
+- Exposed authoritative direct-AWS instance-profile attachment state in `inspect --json` provider metadata for admission-policy enforcement.
+
 ### Fixed
 
 - Protected portal and isolated Code sessions with browser-enforced host-only cookies, rejected duplicate session cookies, and retired legacy cookie names to prevent sibling-origin shadowing. Thanks @coygeek.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Exposed authoritative direct-AWS instance-profile attachment state in `inspect --json` provider metadata for admission-policy enforcement.
+- Exposed authoritative AWS instance-profile attachment state in `inspect --json` provider metadata for admission-policy enforcement across direct and brokered leases.
 
 ### Fixed
 

--- a/docs/commands/inspect.md
+++ b/docs/commands/inspect.md
@@ -73,8 +73,9 @@ The key is the authoritative public half generated for provisioning, not a key
 learned later through `known_hosts` or `ssh-keyscan`. The field is omitted when
 the provider cannot inject a host key before boot.
 
-Direct AWS leases also include authoritative provider metadata sourced from
-EC2 `DescribeInstances`:
+AWS leases also include authoritative provider metadata sourced from EC2
+`DescribeInstances`. Brokered inspection requests a fresh coordinator-side
+lookup; direct inspection uses the local AWS client:
 
 ```json
 {

--- a/docs/commands/inspect.md
+++ b/docs/commands/inspect.md
@@ -73,6 +73,21 @@ The key is the authoritative public half generated for provisioning, not a key
 learned later through `known_hosts` or `ssh-keyscan`. The field is omitted when
 the provider cannot inject a host key before boot.
 
+Direct AWS leases also include authoritative provider metadata sourced from
+EC2 `DescribeInstances`:
+
+```json
+{
+  "providerMetadata": {
+    "instanceProfileAttached": false
+  }
+}
+```
+
+Consumers can use this boolean to fail closed when a workload must not receive
+an IAM instance profile. The field is omitted when the backend cannot attest
+the association state.
+
 ## Flags
 
 ```text

--- a/internal/cli/aws.go
+++ b/internal/cli/aws.go
@@ -1228,6 +1228,9 @@ func awsInstanceToServer(instance types.Instance) Server {
 		Name:     name,
 		Status:   string(instance.State.Name),
 		Labels:   labels,
+		ProviderMetadata: map[string]any{
+			"instanceProfileAttached": instance.IamInstanceProfile != nil,
+		},
 	}
 	if instance.Placement != nil {
 		server.HostID = aws.ToString(instance.Placement.HostId)

--- a/internal/cli/aws_test.go
+++ b/internal/cli/aws_test.go
@@ -442,6 +442,37 @@ func TestAWSInstanceToServerPreservesHostID(t *testing.T) {
 	}
 }
 
+func TestAWSInstanceToServerReportsInstanceProfileAttachment(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		profile  *types.IamInstanceProfile
+		attached bool
+	}{
+		{name: "absent", attached: false},
+		{
+			name:     "attached",
+			profile:  &types.IamInstanceProfile{Arn: aws.String("arn:aws:iam::123456789012:instance-profile/worker")},
+			attached: true,
+		},
+		{
+			name:     "attached with incomplete metadata",
+			profile:  &types.IamInstanceProfile{},
+			attached: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server := awsInstanceToServer(types.Instance{
+				InstanceId:         aws.String("i-1234567890abcdef0"),
+				IamInstanceProfile: tc.profile,
+				State:              &types.InstanceState{Name: types.InstanceStateNameRunning},
+			})
+			if got := server.ProviderMetadata["instanceProfileAttached"]; got != tc.attached {
+				t.Fatalf("instanceProfileAttached=%v, want %v", got, tc.attached)
+			}
+		})
+	}
+}
+
 func TestRetryableAWSSnapshotDeleteError(t *testing.T) {
 	for _, message := range []string{
 		"InvalidSnapshot.InUse: snapshot is currently in use by ami-123",

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -96,6 +96,7 @@ type CoordinatorLease struct {
 	ExpiresAt             string                `json:"expiresAt"`
 	Telemetry             *LeaseTelemetry       `json:"telemetry,omitempty"`
 	TelemetryHistory      []*LeaseTelemetry     `json:"telemetryHistory,omitempty"`
+	ProviderMetadata      map[string]any        `json:"providerMetadata,omitempty"`
 }
 
 type CoordinatorLeaseRegistration struct {
@@ -949,10 +950,22 @@ func (c *CoordinatorClient) UpdateLeaseTailscale(ctx context.Context, id string,
 }
 
 func (c *CoordinatorClient) GetLease(ctx context.Context, id string) (CoordinatorLease, error) {
+	return c.getLease(ctx, id, false)
+}
+
+func (c *CoordinatorClient) GetLeaseWithAuthoritativeProviderMetadata(ctx context.Context, id string) (CoordinatorLease, error) {
+	return c.getLease(ctx, id, true)
+}
+
+func (c *CoordinatorClient) getLease(ctx context.Context, id string, providerMetadata bool) (CoordinatorLease, error) {
 	var res struct {
 		Lease CoordinatorLease `json:"lease"`
 	}
-	err := c.do(ctx, http.MethodGet, "/v1/leases/"+url.PathEscape(id), nil, &res)
+	path := "/v1/leases/" + url.PathEscape(id)
+	if providerMetadata {
+		path += "?providerMetadata=authoritative"
+	}
+	err := c.do(ctx, http.MethodGet, path, nil, &res)
 	return res.Lease, err
 }
 

--- a/internal/cli/hcloud.go
+++ b/internal/cli/hcloud.go
@@ -76,6 +76,7 @@ type Server struct {
 	Name                string            `json:"name"`
 	Status              string            `json:"status"`
 	Labels              map[string]string `json:"labels"`
+	ProviderMetadata    map[string]any    `json:"provider_metadata,omitempty"`
 	PublicNet           struct {
 		IPv4 struct {
 			IP string `json:"ip"`

--- a/internal/cli/inspect.go
+++ b/internal/cli/inspect.go
@@ -26,7 +26,11 @@ func (a App) inspect(ctx context.Context, args []string) error {
 	if err := requireLeaseID(*id, "crabbox inspect --id <lease-id-or-slug>", cfg); err != nil {
 		return err
 	}
-	state, err := a.leaseStatus(ctx, cfg, *id)
+	state, err := a.leaseStatusWithRequest(ctx, cfg, StatusRequest{
+		Options:                       leaseOptionsFromConfig(cfg),
+		ID:                            *id,
+		AuthoritativeProviderMetadata: *jsonOut,
+	})
 	if err != nil {
 		return err
 	}

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -817,10 +817,11 @@ type WarmupRequest struct {
 }
 
 type StatusRequest struct {
-	Options     LeaseOptions
-	ID          string
-	Wait        bool
-	WaitTimeout time.Duration
+	Options                       LeaseOptions
+	ID                            string
+	Wait                          bool
+	WaitTimeout                   time.Duration
+	AuthoritativeProviderMetadata bool
 }
 
 type StopRequest struct {

--- a/internal/cli/provider_coordinator.go
+++ b/internal/cli/provider_coordinator.go
@@ -290,7 +290,13 @@ func (b *coordinatorLeaseBackend) Resolve(ctx context.Context, req ResolveReques
 }
 
 func (b *coordinatorLeaseBackend) Status(ctx context.Context, req StatusRequest) (statusView, error) {
-	lease, err := b.coord.GetLease(ctx, req.ID)
+	var lease CoordinatorLease
+	var err error
+	if req.AuthoritativeProviderMetadata {
+		lease, err = b.coord.GetLeaseWithAuthoritativeProviderMetadata(ctx, req.ID)
+	} else {
+		lease, err = b.coord.GetLease(ctx, req.ID)
+	}
 	if err != nil {
 		return statusView{}, err
 	}
@@ -329,6 +335,10 @@ func (b *coordinatorLeaseBackend) Status(ctx context.Context, req StatusRequest)
 		Ready:            ready,
 		Telemetry:        lease.Telemetry,
 		TelemetryHistory: lease.TelemetryHistory,
+		ProviderMetadata: inspectProviderMetadata(
+			blank(lease.Provider, b.cfg.Provider),
+			lease.ProviderMetadata,
+		),
 	}, nil
 }
 

--- a/internal/cli/provider_coordinator_test.go
+++ b/internal/cli/provider_coordinator_test.go
@@ -173,6 +173,9 @@ func TestCoordinatorStatusRedactsDaytonaSSHAccessToken(t *testing.T) {
 		if r.Method != http.MethodGet || r.URL.Path != "/v1/leases/cbx_123" {
 			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
 		}
+		if r.URL.RawQuery != "" {
+			t.Fatalf("ordinary status unexpectedly requested provider metadata: %s", r.URL.RawQuery)
+		}
 		_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
 			ID:       "cbx_123",
 			Provider: "daytona",
@@ -211,11 +214,15 @@ func TestCoordinatorInspectJSONIncludesOptionalSSHHostKey(t *testing.T) {
 		if r.Method != http.MethodGet || !strings.HasPrefix(r.URL.Path, "/v1/leases/") {
 			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
 		}
+		if got := r.URL.Query().Get("providerMetadata"); got != "authoritative" {
+			t.Fatalf("providerMetadata=%q, want authoritative", got)
+		}
 		lease := CoordinatorLease{
-			ID:       strings.TrimPrefix(r.URL.Path, "/v1/leases/"),
-			Provider: "aws",
-			TargetOS: targetLinux,
-			State:    "provisioning",
+			ID:               strings.TrimPrefix(r.URL.Path, "/v1/leases/"),
+			Provider:         "aws",
+			TargetOS:         targetLinux,
+			State:            "provisioning",
+			ProviderMetadata: map[string]any{"instanceProfileAttached": false},
 		}
 		if lease.ID == "cbx_with_key" {
 			lease.SSHHostKey = sshHostKey
@@ -230,16 +237,17 @@ func TestCoordinatorInspectJSONIncludesOptionalSSHHostKey(t *testing.T) {
 	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "user-token")
 
 	for _, test := range []struct {
-		id      string
-		wantKey bool
+		id             string
+		configuredWith string
+		wantKey        bool
 	}{
-		{id: "cbx_with_key", wantKey: true},
-		{id: "cbx_without_key", wantKey: false},
+		{id: "cbx_with_key", configuredWith: "aws", wantKey: true},
+		{id: "cbx_without_key", configuredWith: "daytona", wantKey: false},
 	} {
 		t.Run(test.id, func(t *testing.T) {
 			var stdout bytes.Buffer
 			app := App{Stdout: &stdout, Stderr: &bytes.Buffer{}}
-			if err := app.inspect(context.Background(), []string{"--provider", "aws", "--id", test.id, "--json"}); err != nil {
+			if err := app.inspect(context.Background(), []string{"--provider", test.configuredWith, "--id", test.id, "--json"}); err != nil {
 				t.Fatal(err)
 			}
 			var got map[string]any
@@ -253,6 +261,10 @@ func TestCoordinatorInspectJSONIncludesOptionalSSHHostKey(t *testing.T) {
 				}
 			} else if ok {
 				t.Fatalf("sshHostKey=%#v, want omitted", value)
+			}
+			metadata, ok := got["providerMetadata"].(map[string]any)
+			if !ok || metadata["instanceProfileAttached"] != false {
+				t.Fatalf("providerMetadata=%#v, want authoritative false", got["providerMetadata"])
 			}
 		})
 	}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -279,6 +279,14 @@ type StatusView struct {
 type statusView = StatusView
 
 func (a App) leaseStatus(ctx context.Context, cfg Config, id string) (statusView, error) {
+	return a.leaseStatusWithRequest(ctx, cfg, StatusRequest{Options: leaseOptionsFromConfig(cfg), ID: id})
+}
+
+func (a App) leaseStatusWithRequest(
+	ctx context.Context,
+	cfg Config,
+	req StatusRequest,
+) (statusView, error) {
 	backend, err := loadBackend(cfg, runtimeForApp(a))
 	if err != nil {
 		return statusView{}, err
@@ -286,16 +294,16 @@ func (a App) leaseStatus(ctx context.Context, cfg Config, id string) (statusView
 	if statusBackend, ok := backend.(interface {
 		Status(context.Context, StatusRequest) (statusView, error)
 	}); ok {
-		return statusBackend.Status(ctx, StatusRequest{Options: leaseOptionsFromConfig(cfg), ID: id})
+		return statusBackend.Status(ctx, req)
 	}
 	if delegated, ok := backend.(DelegatedRunBackend); ok {
-		return delegated.Status(ctx, StatusRequest{Options: leaseOptionsFromConfig(cfg), ID: id})
+		return delegated.Status(ctx, req)
 	}
 	sshBackend, ok := backend.(SSHLeaseBackend)
 	if !ok {
 		return statusView{}, exit(2, "provider=%s does not support status", backend.Spec().Name)
 	}
-	lease, err := sshBackend.Resolve(ctx, ResolveRequest{Options: leaseOptionsFromConfig(cfg), ID: id, StatusOnly: true, NoLocalStateMutations: true})
+	lease, err := sshBackend.Resolve(ctx, ResolveRequest{Options: req.Options, ID: req.ID, StatusOnly: true, NoLocalStateMutations: true})
 	if err != nil {
 		return statusView{}, err
 	}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -196,10 +196,11 @@ func statusViewFromLeaseTarget(ctx context.Context, cfg Config, lease LeaseTarge
 	if meta.Enabled {
 		tailscale = &meta
 	}
+	provider := blank(server.Provider, cfg.Provider)
 	return statusView{
 		ID:               lease.LeaseID,
 		Slug:             serverSlug(server),
-		Provider:         blank(server.Provider, cfg.Provider),
+		Provider:         provider,
 		TargetOS:         blank(server.Labels["target"], cfg.TargetOS),
 		WindowsMode:      blank(server.Labels["windows_mode"], cfg.WindowsMode),
 		State:            state,
@@ -220,9 +221,21 @@ func statusViewFromLeaseTarget(ctx context.Context, cfg Config, lease LeaseTarge
 		IdleTimeout:      leaseLabelDurationDisplay(server.Labels["idle_timeout_secs"], server.Labels["idle_timeout"]),
 		ExpiresAt:        blank(leaseLabelTimeDisplay(server.Labels["expires_at"]), server.Labels["expires_at"]),
 		Labels:           server.Labels,
+		ProviderMetadata: inspectProviderMetadata(provider, server.ProviderMetadata),
 		HasHost:          hasHost,
 		Ready:            ready,
 	}, nil
+}
+
+func inspectProviderMetadata(provider string, metadata map[string]any) map[string]any {
+	if provider != "aws" {
+		return nil
+	}
+	attached, ok := metadata["instanceProfileAttached"].(bool)
+	if !ok {
+		return nil
+	}
+	return map[string]any{"instanceProfileAttached": attached}
 }
 
 func leaseStatusStateCanBeReady(lease LeaseTarget, state string) bool {
@@ -256,6 +269,7 @@ type StatusView struct {
 	IdleTimeout      string             `json:"idleTimeout,omitempty"`
 	ExpiresAt        string             `json:"expiresAt,omitempty"`
 	Labels           map[string]string  `json:"labels,omitempty"`
+	ProviderMetadata map[string]any     `json:"providerMetadata,omitempty"`
 	HasHost          bool               `json:"hasHost"`
 	Ready            bool               `json:"ready"`
 	Telemetry        *LeaseTelemetry    `json:"telemetry,omitempty"`

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -81,6 +81,50 @@ func TestLeaseStatusStateCanBeReadyRejectsTerminalStates(t *testing.T) {
 	}
 }
 
+func TestStatusViewIncludesProviderMetadata(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.Provider = "aws"
+	cfg.Network = NetworkPublic
+	metadata := map[string]any{
+		"instanceProfileAttached": false,
+		"internal":                "must-not-leak",
+	}
+	view, err := statusViewFromLeaseTarget(context.Background(), cfg, LeaseTarget{
+		LeaseID: "cbx_status",
+		Server: Server{
+			Provider:         "aws",
+			Status:           "running",
+			Labels:           map[string]string{},
+			ProviderMetadata: metadata,
+		},
+	})
+	if err != nil {
+		t.Fatalf("statusViewFromLeaseTarget returned error: %v", err)
+	}
+	if got := view.ProviderMetadata["instanceProfileAttached"]; got != false {
+		t.Fatalf("instanceProfileAttached=%v, want false", got)
+	}
+	if _, ok := view.ProviderMetadata["internal"]; ok {
+		t.Fatal("providerMetadata unexpectedly exposed an internal field")
+	}
+	metadata["instanceProfileAttached"] = "false"
+	view, err = statusViewFromLeaseTarget(context.Background(), cfg, LeaseTarget{
+		LeaseID: "cbx_status_invalid",
+		Server: Server{
+			Provider:         "aws",
+			Status:           "running",
+			Labels:           map[string]string{},
+			ProviderMetadata: metadata,
+		},
+	})
+	if err != nil {
+		t.Fatalf("statusViewFromLeaseTarget returned error: %v", err)
+	}
+	if view.ProviderMetadata != nil {
+		t.Fatalf("providerMetadata=%v, want omitted invalid metadata", view.ProviderMetadata)
+	}
+}
+
 func TestStatusWaitRequestsReadyProbe(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))

--- a/worker/src/aws.ts
+++ b/worker/src/aws.ts
@@ -2651,6 +2651,8 @@ function instanceToMachine(input: unknown): ProviderMachine {
     ...(asString(instance["keyName"]) ? { awsKeyName: asString(instance["keyName"]) } : {}),
     ...(asString(instance["subnetId"]) ? { awsSubnetID: asString(instance["subnetId"]) } : {}),
     ...(securityGroupIDs.length > 0 ? { awsSecurityGroupIDs: securityGroupIDs } : {}),
+    awsInstanceProfileAttached:
+      Object.hasOwn(instance, "iamInstanceProfile") && instance["iamInstanceProfile"] != null,
     ...(asString(record(instance["iamInstanceProfile"])["arn"])
       ? { awsInstanceProfileARN: asString(record(instance["iamInstanceProfile"])["arn"]) }
       : {}),

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -5098,9 +5098,17 @@ export class FleetCoordinator {
         lease && this.leaseProviderAccessVisibleToRequest(lease, request, admin)
           ? await this.refreshLeaseAccessForResolution(lease)
           : lease;
-      return refreshed
-        ? json({ lease: this.leaseForRequest(refreshed, request, admin) })
-        : notFound();
+      if (!refreshed) {
+        return notFound();
+      }
+      const visible = this.leaseForRequest(refreshed, request, admin);
+      if (new URL(request.url).searchParams.get("providerMetadata") !== "authoritative") {
+        return json({ lease: visible });
+      }
+      const providerMetadata = await this.authoritativeLeaseProviderMetadata(refreshed);
+      return json({
+        lease: providerMetadata ? { ...visible, providerMetadata } : visible,
+      });
     }
     if (method === "POST" && action === "heartbeat") {
       return this.heartbeatLease(request, leaseID);
@@ -12713,6 +12721,26 @@ export class FleetCoordinator {
       visible.sshUser = "<token>";
     }
     return visible;
+  }
+
+  private async authoritativeLeaseProviderMetadata(
+    lease: LeaseRecord,
+  ): Promise<{ instanceProfileAttached: boolean } | undefined> {
+    if (!leaseIsLive(lease) || managedLeaseProvider(lease) !== "aws" || !lease.cloudID) {
+      return undefined;
+    }
+    const provider = this.provider("aws", lease.region, lease.providerProject);
+    if (!provider.getServer) {
+      throw new Error("AWS provider cannot attest instance metadata");
+    }
+    const server = await provider.getServer(lease.cloudID);
+    if (!providerMachineOwnedByLease(server, lease, "aws")) {
+      throw new Error("AWS instance metadata does not match the lease owner");
+    }
+    if (typeof server.awsInstanceProfileAttached !== "boolean") {
+      throw new Error("AWS provider returned incomplete instance-profile metadata");
+    }
+    return { instanceProfileAttached: server.awsInstanceProfileAttached };
   }
 
   private runtimeAdapterDeletePendingResponse(

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -831,6 +831,7 @@ export interface ProviderMachine {
   awsKeyName?: string;
   awsSubnetID?: string;
   awsSecurityGroupIDs?: string[];
+  awsInstanceProfileAttached?: boolean;
   awsInstanceProfileARN?: string;
   awsMetadataHttpEndpoint?: string;
   awsMetadataHttpTokens?: string;

--- a/worker/test/aws.test.ts
+++ b/worker/test/aws.test.ts
@@ -517,6 +517,38 @@ describe("aws provider", () => {
     await expect(client.findServer("i-abcdef123456")).rejects.toThrow("AuthFailure");
   });
 
+  it.each([
+    { attached: false, profileXML: "" },
+    {
+      attached: true,
+      profileXML:
+        "<iamInstanceProfile><arn>arn:aws:iam::123456789012:instance-profile/worker</arn></iamInstanceProfile>",
+    },
+  ])(
+    "maps authoritative instance-profile presence: $attached",
+    async ({ attached, profileXML }) => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () =>
+          ec2XMLResponse(`<DescribeInstancesResponse><reservationSet><item><instancesSet><item>
+          <instanceId>i-abcdef123456</instanceId>
+          <instanceState><name>running</name></instanceState>
+          <instanceType>c7a.8xlarge</instanceType>
+          ${profileXML}
+        </item></instancesSet></item></reservationSet></DescribeInstancesResponse>`),
+        ),
+      );
+      const client = new EC2SpotClient(
+        { AWS_ACCESS_KEY_ID: "test", AWS_SECRET_ACCESS_KEY: "secret" } as never,
+        "us-east-1",
+      );
+
+      await expect(client.getServer("i-abcdef123456")).resolves.toMatchObject({
+        awsInstanceProfileAttached: attached,
+      });
+    },
+  );
+
   it("rejects invalid configured AWS SSH CIDRs before changing ingress", async () => {
     const calls: string[] = [];
     vi.stubGlobal(

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -25749,6 +25749,161 @@ describe("fleet identity", () => {
   });
 });
 
+describe("authoritative lease provider metadata", () => {
+  const headers = {
+    "x-crabbox-owner": "peter@example.com",
+    "x-crabbox-org": "openclaw",
+  };
+
+  it.each([
+    { attached: false, id: "cbx_0000000000a1" },
+    { attached: true, id: "cbx_0000000000a2" },
+  ])("freshly attests AWS instance-profile state: $attached", async ({ attached, id }) => {
+    const storage = new MemoryStorage();
+    const lease = testLease({
+      id,
+      provider: "aws",
+      cloudID: `i-${id.slice(4)}`,
+      region: "eu-west-1",
+      serverType: "c7a.8xlarge",
+    });
+    storage.seed(`lease:${id}`, lease);
+    const getServer = vi.fn<() => ProviderMachine>(() => ({
+      provider: "aws" as const,
+      id: 0,
+      cloudID: lease.cloudID,
+      name: lease.serverName,
+      status: "running",
+      serverType: lease.serverType,
+      host: lease.host,
+      awsInstanceProfileAttached: attached,
+      labels: {
+        crabbox: "true",
+        created_by: "crabbox",
+        lease: lease.id,
+        owner: "peter_example.com",
+        provider: "aws",
+        slug: lease.slug ?? "",
+      },
+    }));
+    const fleet = testFleet(
+      storage,
+      { aws: fakeProvider(undefined, { provider: "aws" }, undefined, getServer) },
+      { CRABBOX_DEFAULT_ORG: "openclaw" },
+    );
+
+    const ordinary = await fleet.fetch(request("GET", `/v1/leases/${id}`, { headers }));
+    await expect(ordinary.json()).resolves.not.toHaveProperty("lease.providerMetadata");
+    expect(getServer).not.toHaveBeenCalled();
+
+    const attested = await fleet.fetch(
+      request("GET", `/v1/leases/${id}?providerMetadata=authoritative`, { headers }),
+    );
+    await expect(attested.json()).resolves.toMatchObject({
+      lease: { providerMetadata: { instanceProfileAttached: attached } },
+    });
+    expect(getServer).toHaveBeenCalledOnce();
+  });
+
+  it("fails closed when the fresh AWS instance does not match lease ownership", async () => {
+    const storage = new MemoryStorage();
+    const lease = testLease({
+      id: "cbx_0000000000a3",
+      provider: "aws",
+      cloudID: "i-0000000000a3",
+      region: "eu-west-1",
+    });
+    storage.seed(`lease:${lease.id}`, lease);
+    const fleet = testFleet(
+      storage,
+      {
+        aws: fakeProvider(undefined, { provider: "aws" }, undefined, () => ({
+          provider: "aws",
+          id: 0,
+          cloudID: lease.cloudID,
+          name: lease.serverName,
+          status: "running",
+          serverType: lease.serverType,
+          host: lease.host,
+          awsInstanceProfileAttached: false,
+          labels: {},
+        })),
+      },
+      { CRABBOX_DEFAULT_ORG: "openclaw" },
+    );
+
+    const response = await fleet.fetch(
+      request("GET", `/v1/leases/${lease.id}?providerMetadata=authoritative`, { headers }),
+    );
+    expect(response.status).toBe(500);
+  });
+
+  it("fails closed when AWS omits authoritative instance-profile state", async () => {
+    const storage = new MemoryStorage();
+    const lease = testLease({
+      id: "cbx_0000000000a4",
+      provider: "aws",
+      cloudID: "i-0000000000a4",
+      region: "eu-west-1",
+    });
+    storage.seed(`lease:${lease.id}`, lease);
+    const fleet = testFleet(
+      storage,
+      {
+        aws: fakeProvider(undefined, { provider: "aws" }, undefined, () => ({
+          provider: "aws",
+          id: 0,
+          cloudID: lease.cloudID,
+          name: lease.serverName,
+          status: "running",
+          serverType: lease.serverType,
+          host: lease.host,
+          labels: {
+            crabbox: "true",
+            created_by: "crabbox",
+            lease: lease.id,
+            owner: "peter_example.com",
+            provider: "aws",
+            slug: lease.slug ?? "",
+          },
+        })),
+      },
+      { CRABBOX_DEFAULT_ORG: "openclaw" },
+    );
+
+    const response = await fleet.fetch(
+      request("GET", `/v1/leases/${lease.id}?providerMetadata=authoritative`, { headers }),
+    );
+    expect(response.status).toBe(500);
+  });
+
+  it("omits authoritative metadata for terminal AWS leases without a provider lookup", async () => {
+    const storage = new MemoryStorage();
+    const lease = testLease({
+      id: "cbx_0000000000a5",
+      provider: "aws",
+      cloudID: "i-0000000000a5",
+      region: "eu-west-1",
+      state: "released",
+    });
+    storage.seed(`lease:${lease.id}`, lease);
+    const getServer = vi.fn<() => ProviderMachine>(() => {
+      throw new Error("terminal lease must not query AWS");
+    });
+    const fleet = testFleet(
+      storage,
+      { aws: fakeProvider(undefined, { provider: "aws" }, undefined, getServer) },
+      { CRABBOX_DEFAULT_ORG: "openclaw" },
+    );
+
+    const response = await fleet.fetch(
+      request("GET", `/v1/leases/${lease.id}?providerMetadata=authoritative`, { headers }),
+    );
+    await expect(response.json()).resolves.not.toHaveProperty("lease.providerMetadata");
+    expect(getServer).not.toHaveBeenCalled();
+  });
+});
+
 async function startGitHubLogin(env: Partial<Env> = {}): Promise<{
   fleet: FleetDurableObject;
   loginID: string;


### PR DESCRIPTION
## What Problem This Solves

OpenClaw cloud-worker admission must prove that an AWS lease has no IAM instance profile. Local configuration and guest-side metadata probes do not authoritatively describe the EC2 control-plane attachment state, and the original direct-only implementation omitted coordinator-backed leases.

## Why This Change Was Made

AWS inspection now derives `providerMetadata.instanceProfileAttached` from a fresh `DescribeInstances` response for both direct and brokered leases. JSON inspection opts into the authoritative provider-neutral lookup; ordinary status and non-JSON inspection stay storage-only. The Worker no-ops for non-AWS or terminal leases, verifies exact lease ownership for live AWS leases, and fails closed on missing metadata. `inspect --json` exposes only the documented boolean.

## User Impact

Security-sensitive consumers can reject AWS workers unless Crabbox authoritatively reports that no instance profile is attached. Ordinary coordinator lease reads do not trigger the additional provider lookup.

## Evidence

- `go test ./internal/cli` (green; final exact run 136.490s)
- Worker `npm test` (1,054 passed, 3 skipped)
- Worker `npm run build` (Wrangler production dry-run green)
- Worker TypeScript check and targeted oxlint green
- Focused direct and brokered attachment/status tests, including provider-neutral lookup, exact ownership, missing metadata, true/false attachment state, and ordinary-read no-op
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --base origin/main` (clean; no accepted/actionable findings)
