### PR TITLE
chore: prepare Crabbox 0.38.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.38.1 - Unreleased
+## 0.38.1 - 2026-07-13
 
 ### Added
 

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/crabbox-worker",
-  "version": "0.38.0",
+  "version": "0.38.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/crabbox-worker",
-      "version": "0.38.0",
+      "version": "0.38.1",
       "dependencies": {
         "@aws-sdk/credential-providers": "^3.1084.0",
         "@cloudflare/containers": "^0.3.7",

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/crabbox-worker",
-  "version": "0.38.0",
+  "version": "0.38.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## What Problem This Solves

Prepares the reviewed Crabbox changes since v0.38.0 for the v0.38.1 release required by OpenClaw cloud-worker admission.

## Why This Change Was Made

Freezes the v0.38.1 changelog date and keeps the Worker package metadata aligned with the release version before the signed release tag is created.

## User Impact

Operators can install a single version containing authoritative AWS instance-profile attachment metadata and the portal cookie hardening shipped since v0.38.0.

## Evidence

- `git diff --check`
- `node --test scripts/release-workflow.test.js scripts/publish-release.test.js scripts/homebrew-release.test.js` (47 passed)
- Autoreview: clean; no accepted/actionable findings
