### PR TITLE
build: authorize Crabbox 0.38.1 release

### DIFF
--- a/release/records/v0.38.1.json
+++ b/release/records/v0.38.1.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "repository": "openclaw/crabbox",
+  "tag": "v0.38.1",
+  "tagObject": "b9c14e1943ec4a2ca394689a63e8a9c5318ff48c",
+  "sourceCommit": "72cd4d60c99068b229550bbca9f5a1302663fa72",
+  "publicationStatus": "ready"
+}

--- a/scripts/release-workflow.test.js
+++ b/scripts/release-workflow.test.js
@@ -553,6 +553,14 @@ test("v0.38.0 is pinned to the corrected signed source and ready for publication
   assert.equal(record.publicationStatus, "ready");
 });
 
+test("v0.38.1 is pinned to the signed admission-metadata source and ready for publication", () => {
+  const record = JSON.parse(read("release/records/v0.38.1.json"));
+  assert.equal(record.tag, "v0.38.1");
+  assert.equal(record.tagObject, "b9c14e1943ec4a2ca394689a63e8a9c5318ff48c");
+  assert.equal(record.sourceCommit, "72cd4d60c99068b229550bbca9f5a1302663fa72");
+  assert.equal(record.publicationStatus, "ready");
+});
+
 test("managed Foundation signing and notary configuration is repository-owned and secret-free", () => {
   const manifest = read(".mac-release.env");
   const codeowners = read(".github/CODEOWNERS");


### PR DESCRIPTION
## What Problem This Solves

Authorizes the immutable signed v0.38.1 source identity for Crabbox's protected release pipeline.

## Why This Change Was Made

Records the exact annotated tag object and peeled source commit, then pins both values in the release workflow regression suite. No release asset is created or published by this change.

## User Impact

Release operators can build and verify v0.38.1 without weakening signed-source or publication safeguards.

## Evidence

- Signed tag object: `b9c14e1943ec4a2ca394689a63e8a9c5318ff48c`
- Source commit: `72cd4d60c99068b229550bbca9f5a1302663fa72`
- `node --test scripts/release-workflow.test.js` (19 passed)
- `DEFAULT_BRANCH=main RELEASE_TAG=v0.38.1 EXPECTED_TAG_OBJECT=b9c14e1943ec4a2ca394689a63e8a9c5318ff48c EXPECTED_TAG_COMMIT=72cd4d60c99068b229550bbca9f5a1302663fa72 TRUSTED_HEAD=HEAD REQUIRE_PUBLISHABLE=1 scripts/verify-release-source.sh`
- Autoreview: clean; no accepted/actionable findings
