### PR TITLE
fix: scrub reusable ready-pool leases

### DIFF
--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -42,9 +42,19 @@ either the stable `cbx_...` ID or the active friendly slug (see
 
 With `--pool <key>`, Crabbox borrows one hydrated broker ready-pool lease,
 uses the pool-recorded SSH endpoint, runs the command, and returns the lease.
-The default `--pool-return auto` returns successful runs to the pool and drains
-failed runs so a bad machine is not reused. Use
-`--pool-return ready|drain|release` to override that policy for one run. See
+Before a reusable return, Crabbox resets the checkout to the pool's recorded
+branch, fetches its latest remote commit, removes run-local state, and verifies
+the normal Git worktree is clean. The default `--pool-return auto` returns the
+lease after that scrub even when the user command fails; lifecycle or scrub
+failures drain the lease so a bad machine is not reused. Ignored task state is
+removed; explicitly ignored dependency caches such as `node_modules` remain
+warm. Submodule worktrees drain instead of being reused. Reuse
+requires a canonical HTTPS origin that succeeds
+through a credential-free fetch preflight before the lease is borrowed. SSH,
+local/file, and private credential-backed origins are rejected; use a forced
+`drain` or `release` return policy for those repositories. Use
+`--pool-return ready|drain|release` to override the
+lifecycle policy for one run; `ready` still requires a successful scrub. See
 [Broker ready pools](../spec/broker.md).
 Pooled runs reject `--full-resync`/`--fresh-sync`. With `--no-sync`, pooled
 borrows require an exact commit match. Pooled runs also reject `--keep` and

--- a/docs/spec/broker.md
+++ b/docs/spec/broker.md
@@ -133,18 +133,37 @@ their current borrow or idle window.
 
 `crabbox run --pool` defaults to `--pool-return auto`:
 
-- command success: return `ready`
-- command failure, SSH failure, failed sync, failed hydration marker read, or
-  failed preflight: return `drain`
-- explicit `--pool-return ready`: force reuse
+- command success: scrub the checkout, then return `ready`
+- ordinary nonzero command exit: preserve the command failure, scrub the
+  checkout, then return `ready`
+- transport, cancellation, stream/capture, artifact, or other lifecycle
+  failure, failed scrub, SSH failure during scrub, or failed hydration marker
+  verification: return `drain`
+- explicit `--pool-return ready`: request reuse, still gated by the scrub
 - explicit `--pool-return drain`: release backing lease after the run
 - explicit `--pool-return release`: release backing lease immediately
 
-Successful returns keep the lease active and borrowable. Drained returns are no
+Before borrow, Crabbox captures a canonical origin from the local checkout and
+proves its HTTPS origin supports a credential-free fetch. Reusable pools reject
+SSH, local/file, and private credential-backed origins; forced `drain` and
+`release` policies do not need that contract. The scrub replaces task-mutable
+remote Git metadata from the trusted origin, fetches the pool entry's recorded
+branch, resets tracked and non-ignored untracked files, removes Crabbox
+run-local state, and clears stale sync metadata before verifying the prepared
+commit and clean worktree. Ignored task state is removed; only explicit cache
+paths that the repository itself ignores remain available. Submodule worktrees
+drain instead of being reused. Ready-pool reuse is for trusted workloads; this
+scrub prevents task-state confusion, not cross-tenant isolation or a hermetic
+host reset. Every entry advances to the latest remote branch
+commit. If that moves an exact-commit
+entry beyond its recorded commit, Crabbox drains the entry after the scrub so a
+later exact `--no-sync` borrow cannot use stale metadata.
+
+Reusable returns keep the lease active and borrowable. Drained returns are no
 longer borrowable and release the cloud machine to avoid poisoning the pool.
 Pooled runs reject full resync because that can replace the hydrated workspace.
-Pooled `--no-sync` runs require an exact commit match and do not borrow
-ref-only entries.
+Pooled `--no-sync` runs require an exact commit match and do not borrow ref-only
+entries.
 
 ## Provider contract
 

--- a/internal/cli/ready_pool.go
+++ b/internal/cli/ready_pool.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os/exec"
 	"strconv"
 	"strings"
 	"time"
@@ -411,12 +412,37 @@ func validateReadyPoolRunReturnPolicy(policy string) error {
 	}
 }
 
-func readyPoolRunReturnResult(policy string, runFailure error) string {
+func readyPoolRunNeedsTrustedRemote(policy string) bool {
+	switch strings.ToLower(strings.TrimSpace(policy)) {
+	case "drain", "release":
+		return false
+	default:
+		return true
+	}
+}
+
+func readyPoolRunShouldScrub(policy string, runFailure error, ordinaryCommandFailure bool) bool {
 	switch strings.TrimSpace(policy) {
-	case "ready", "drain", "release":
+	case "drain", "release":
+		return false
+	case "ready", "", "auto":
+		return runFailure == nil || ordinaryCommandFailure
+	default:
+		return false
+	}
+}
+
+func readyPoolRunReturnResult(policy string, runFailure error, ordinaryCommandFailure bool, scrubErr error, metadataCompatible bool) string {
+	switch strings.TrimSpace(policy) {
+	case "drain", "release":
 		return strings.TrimSpace(policy)
+	case "ready":
+		if readyPoolRunShouldScrub(policy, runFailure, ordinaryCommandFailure) && scrubErr == nil && metadataCompatible {
+			return "ready"
+		}
+		return "drain"
 	case "", "auto":
-		if runFailure == nil {
+		if readyPoolRunShouldScrub(policy, runFailure, ordinaryCommandFailure) && scrubErr == nil && metadataCompatible {
 			return "ready"
 		}
 		return "drain"
@@ -425,15 +451,45 @@ func readyPoolRunReturnResult(policy string, runFailure error) string {
 	}
 }
 
+func readyPoolOrdinaryRemoteCommandFailure(code int, streamErr, contextErr error) bool {
+	var exitErr *exec.ExitError
+	return contextErr == nil &&
+		asExitError(streamErr, &exitErr) &&
+		exitErr.ProcessState != nil &&
+		exitErr.ProcessState.ExitCode() >= 0 &&
+		code > 0 && code < 255
+}
+
+func readyPoolPreparedCommitMatches(recordedCommit, preparedCommit string) bool {
+	recordedCommit = strings.TrimSpace(recordedCommit)
+	return recordedCommit == "" || strings.EqualFold(recordedCommit, strings.TrimSpace(preparedCommit))
+}
+
 func readyPoolReturnNeedsHydrationStop(result string) bool {
 	return result == "drain" || result == "release"
 }
 
-func readyPoolRunReturnReason(runFailure error) string {
-	if runFailure == nil {
-		return "run succeeded"
+func readyPoolRunReturnReason(runFailure error, result, preparedCommit string, scrubErr error, metadataCompatible bool) string {
+	if result == "ready" {
+		outcome := "run succeeded"
+		if runFailure != nil {
+			outcome = "run failed"
+		}
+		if preparedCommit != "" {
+			return outcome + "; scrubbed for reuse at " + preparedCommit
+		}
+		return outcome + "; scrubbed for reuse"
 	}
-	return "run failed"
+	if scrubErr != nil {
+		return "pool scrub failed"
+	}
+	if !metadataCompatible {
+		return "pool branch advanced beyond recorded commit"
+	}
+	if runFailure != nil {
+		return "run lifecycle failed"
+	}
+	return "pool drain requested"
 }
 
 func applyReadyPoolEndpoint(target SSHTarget, entry CoordinatorReadyPoolEntry) SSHTarget {

--- a/internal/cli/ready_pool_scrub.go
+++ b/internal/cli/ready_pool_scrub.go
@@ -45,7 +45,7 @@ func preflightReadyPoolRemote(ctx context.Context, remoteURL string) error {
 	if runtime.GOOS == "windows" {
 		configNull = "NUL"
 	}
-	cmd := exec.CommandContext(preflightCtx, "git", "-c", "credential.helper=", "ls-remote", "--exit-code", remoteURL, "HEAD")
+	cmd := exec.CommandContext(preflightCtx, "git", "-c", "credential.helper=", "ls-remote", remoteURL)
 	cmd.Dir = workdir
 	cmd.Env = []string{
 		"HOME=" + workdir,
@@ -217,21 +217,16 @@ func windowsRemoteReadyPoolScrub(workdir, ref, trustedRemoteURL string) string {
 $workdir = ` + psQuote(workdir) + `
 $ref = ` + psQuote(strings.TrimSpace(ref)) + `
 $trustedRemote = ` + psQuote(strings.TrimSpace(trustedRemoteURL)) + `
-# Borrowed commands may persist user-scoped Git variables. Clear the complete
-# inherited Git surface before installing the scrub's small trusted set.
-Get-ChildItem Env:GIT_* -ErrorAction SilentlyContinue | Remove-Item -ErrorAction Stop
-$env:GIT_CONFIG_NOSYSTEM = '1'
-$env:GIT_CONFIG_GLOBAL = 'NUL'
-$env:GIT_CONFIG_SYSTEM = 'NUL'
-$env:GIT_TERMINAL_PROMPT = '0'
 $gitCandidates = @()
-if ($env:ProgramFiles) {
-  $gitCandidates += (Join-Path $env:ProgramFiles 'Git\cmd\git.exe')
-  $gitCandidates += (Join-Path $env:ProgramFiles 'Git\bin\git.exe')
+$programFiles = [Environment]::GetFolderPath([Environment+SpecialFolder]::ProgramFiles)
+$programFilesX86 = [Environment]::GetFolderPath([Environment+SpecialFolder]::ProgramFilesX86)
+if ($programFiles) {
+  $gitCandidates += (Join-Path $programFiles 'Git\cmd\git.exe')
+  $gitCandidates += (Join-Path $programFiles 'Git\bin\git.exe')
 }
-if (${env:ProgramFiles(x86)}) {
-  $gitCandidates += (Join-Path ${env:ProgramFiles(x86)} 'Git\cmd\git.exe')
-  $gitCandidates += (Join-Path ${env:ProgramFiles(x86)} 'Git\bin\git.exe')
+if ($programFilesX86) {
+  $gitCandidates += (Join-Path $programFilesX86 'Git\cmd\git.exe')
+  $gitCandidates += (Join-Path $programFilesX86 'Git\bin\git.exe')
 }
 $gitCandidates = $gitCandidates | Where-Object { Test-Path -LiteralPath $_ -PathType Leaf }
 $git = $gitCandidates | Select-Object -First 1
@@ -244,15 +239,34 @@ $resolvedWorkdir = $workdirItem.FullName
 $workdir = $resolvedWorkdir
 Set-Location -LiteralPath $resolvedWorkdir
 if (-not (Test-Path -LiteralPath (Join-Path $workdir '.git') -PathType Container)) { throw "ready-pool workspace has no replaceable Git metadata" }
-& $git check-ref-format --branch $ref | Out-Null
-if ($LASTEXITCODE -ne 0) { throw "invalid ready-pool branch ref" }
 $parent = Split-Path -Parent $workdir
 $tmp = Join-Path $parent ('.crabbox-scrub-' + [System.Guid]::NewGuid().ToString('N'))
 New-Item -ItemType Directory -Force -Path $tmp | Out-Null
 $safeHome = Join-Path $tmp 'home'
 New-Item -ItemType Directory -Force -Path $safeHome | Out-Null
+$windowsRoot = [Environment]::GetFolderPath([Environment+SpecialFolder]::Windows)
+$systemDirectory = [Environment]::SystemDirectory
+$comSpec = Join-Path $systemDirectory 'cmd.exe'
+# Borrowed commands can persist user-level transport and config variables.
+# Replace the whole inherited environment before the first Git invocation.
+Get-ChildItem Env: | ForEach-Object { Remove-Item -LiteralPath ("Env:" + $_.Name) -ErrorAction Stop }
+$env:SystemRoot = $windowsRoot
+$env:WINDIR = $windowsRoot
+$env:ComSpec = $comSpec
+$env:PATH = ((Split-Path -Parent $git), $systemDirectory) -join ';'
+$env:PATHEXT = '.COM;.EXE;.BAT;.CMD'
+$env:TEMP = $safeHome
+$env:TMP = $safeHome
 $env:HOME = $safeHome
 $env:USERPROFILE = $safeHome
+$env:XDG_CONFIG_HOME = $safeHome
+$env:GIT_CONFIG_NOSYSTEM = '1'
+$env:GIT_CONFIG_GLOBAL = 'NUL'
+$env:GIT_CONFIG_SYSTEM = 'NUL'
+$env:GIT_TERMINAL_PROMPT = '0'
+$env:GCM_INTERACTIVE = 'Never'
+& $git check-ref-format --branch $ref | Out-Null
+if ($LASTEXITCODE -ne 0) { throw "invalid ready-pool branch ref" }
 & $git init --quiet $tmp
 if ($LASTEXITCODE -ne 0) { throw "ready-pool temporary Git init failed" }
 & $git -C $tmp remote add origin $trustedRemote

--- a/internal/cli/ready_pool_scrub.go
+++ b/internal/cli/ready_pool_scrub.go
@@ -137,11 +137,18 @@ test -x /usr/bin/git
 safe_git check-ref-format --branch "$ref" >/dev/null
 safe_git init --quiet "$tmp"
 safe_git -C "$tmp" remote add origin "$trusted_remote"
-refspec="+refs/heads/$ref:refs/remotes/origin/$ref"
-safe_git -C "$tmp" fetch --quiet --depth=1 origin "$refspec"
+safe_git -C "$tmp" fetch --quiet --prune --tags origin '+refs/heads/*:refs/remotes/origin/*'
 remote_ref="refs/remotes/origin/$ref"
 remote_commit="$(safe_git -C "$tmp" rev-parse --verify "$remote_ref^{commit}")"
 target_commit="$remote_commit"
+safe_git -C "$tmp" read-tree "$target_commit"
+filter_paths="$tmp/filter-paths"
+safe_git -C "$tmp" ls-files -z -- ':(top)**' ':(top,exclude,attr:!filter)**' ':(top,exclude,attr:-filter)**' > "$filter_paths"
+if [ -s "$filter_paths" ]; then
+  echo "ready-pool scrub does not reuse Git filter-managed worktrees" >&2
+  exit 1
+fi
+rm -f -- "$filter_paths"
 rm -rf -- .git
 mv -- "$tmp/.git" .git
 rm -rf -- "$safe_home"
@@ -151,6 +158,7 @@ safe_git remote set-url origin "$trusted_remote"
 test "$(safe_git remote get-url origin)" = "$trusted_remote"
 safe_git checkout --quiet -f -B "$ref" "$target_commit"
 safe_git reset --hard --quiet "$target_commit"
+safe_git branch --set-upstream-to="$remote_ref" "$ref" >/dev/null
 if safe_git ls-files --stage | awk '$1 == "160000" { found=1 } END { exit !found }'; then
   echo "ready-pool scrub does not reuse submodule worktrees" >&2
   exit 1
@@ -249,13 +257,17 @@ $env:USERPROFILE = $safeHome
 if ($LASTEXITCODE -ne 0) { throw "ready-pool temporary Git init failed" }
 & $git -C $tmp remote add origin $trustedRemote
 if ($LASTEXITCODE -ne 0) { throw "ready-pool trusted origin setup failed" }
-$refspec = "+refs/heads/${ref}:refs/remotes/origin/${ref}"
-& $git -C $tmp fetch --quiet --depth=1 origin $refspec
+& $git -C $tmp fetch --quiet --prune --tags origin '+refs/heads/*:refs/remotes/origin/*'
 if ($LASTEXITCODE -ne 0) { throw "ready-pool branch fetch failed" }
 $remoteRef = "refs/remotes/origin/$ref"
 $remoteCommit = (& $git -C $tmp rev-parse --verify "${remoteRef}^{commit}").Trim()
 if ($LASTEXITCODE -ne 0 -or -not $remoteCommit) { throw "ready-pool remote branch is missing" }
 $targetCommit = $remoteCommit
+& $git -C $tmp read-tree $targetCommit
+if ($LASTEXITCODE -ne 0) { throw "ready-pool target tree inspection failed" }
+$filterPaths = @(& $git -C $tmp ls-files -- ':(top)**' ':(top,exclude,attr:!filter)**' ':(top,exclude,attr:-filter)**')
+if ($LASTEXITCODE -ne 0) { throw "ready-pool Git filter inspection failed" }
+if ($filterPaths.Count -ne 0) { throw "ready-pool scrub does not reuse Git filter-managed worktrees" }
 $oldGit = Join-Path $workdir '.git'
 Remove-Item -LiteralPath $oldGit -Recurse -Force -ErrorAction Stop
 if (Test-Path -LiteralPath $oldGit) { throw "ready-pool old Git metadata was not removed" }
@@ -269,6 +281,8 @@ if ($LASTEXITCODE -ne 0 -or $actualRemote -ne $trustedRemote) { throw "ready-poo
 if ($LASTEXITCODE -ne 0) { throw "ready-pool branch checkout failed" }
 & $git reset --hard --quiet $targetCommit
 if ($LASTEXITCODE -ne 0) { throw "ready-pool branch reset failed" }
+& $git branch --set-upstream-to=$remoteRef $ref | Out-Null
+if ($LASTEXITCODE -ne 0) { throw "ready-pool branch upstream setup failed" }
 $gitlinks = @(& $git ls-files --stage | Where-Object { $_ -match '^160000 ' })
 if ($LASTEXITCODE -ne 0) { throw "ready-pool gitlink inspection failed" }
 if ($gitlinks.Count -ne 0) { throw "ready-pool scrub does not reuse submodule worktrees" }

--- a/internal/cli/ready_pool_scrub.go
+++ b/internal/cli/ready_pool_scrub.go
@@ -67,15 +67,16 @@ func (a App) scrubReadyPoolLease(ctx context.Context, target SSHTarget, entry Co
 	if strings.TrimSpace(workdir) == "" {
 		return "", exit(7, "ready-pool scrub has no remote workdir")
 	}
-	if strings.TrimSpace(entry.Ref) == "" {
+	branch, err := readyPoolScrubBranch(entry.Ref)
+	if err != nil {
 		return "", exit(7, "ready-pool scrub requires a branch ref")
 	}
 	if strings.TrimSpace(trustedRemoteURL) == "" {
 		return "", exit(7, "ready-pool scrub has no trusted Git origin")
 	}
-	command := remoteReadyPoolScrub(workdir, entry.Ref, trustedRemoteURL)
+	command := remoteReadyPoolScrub(workdir, branch, trustedRemoteURL)
 	if isWindowsNativeTarget(target) {
-		command = windowsRemoteReadyPoolScrub(workdir, entry.Ref, trustedRemoteURL)
+		command = windowsRemoteReadyPoolScrub(workdir, branch, trustedRemoteURL)
 	}
 	out, err := runSSHOutput(ctx, target, command)
 	if err != nil {
@@ -95,6 +96,20 @@ func (a App) scrubReadyPoolLease(ctx context.Context, target SSHTarget, entry Co
 		}
 	}
 	return preparedCommit, nil
+}
+
+func readyPoolScrubBranch(ref string) (string, error) {
+	ref = strings.TrimSpace(ref)
+	if strings.HasPrefix(ref, "refs/heads/") {
+		ref = strings.TrimPrefix(ref, "refs/heads/")
+		if ref != "" {
+			return ref, nil
+		}
+	}
+	if ref == "" || strings.HasPrefix(ref, "refs/") || isGitCommitSHA(ref) {
+		return "", fmt.Errorf("ready-pool scrub requires a branch ref")
+	}
+	return ref, nil
 }
 
 func remoteReadyPoolScrub(workdir, ref, trustedRemoteURL string) string {
@@ -144,6 +159,18 @@ clean_args=(-ffdx --quiet)
 for cache_path in node_modules .pnpm-store .yarn/cache .yarn/unplugged; do
   if [ -e "$cache_path" ]; then
     if safe_git check-ignore -q -- "$cache_path"; then
+      if [ -L "$cache_path" ] || [ ! -d "$cache_path" ]; then
+        echo "ready-pool cache root must be a real directory" >&2
+        exit 1
+      fi
+      resolved_cache="$(cd -P -- "$cache_path" && pwd -P)"
+      case "$resolved_cache/" in
+        "$workdir"/*) ;;
+        *)
+          echo "ready-pool cache root escapes the workspace" >&2
+          exit 1
+          ;;
+      esac
       clean_args+=(-e "$cache_path/")
     elif [ "$?" -ne 1 ]; then
       echo "ready-pool cache ignore check failed" >&2
@@ -250,6 +277,15 @@ foreach ($cachePath in @('node_modules', '.pnpm-store', '.yarn/cache', '.yarn/un
   if (Test-Path -LiteralPath $cachePath) {
     & $git check-ignore -q -- $cachePath
     if ($LASTEXITCODE -eq 0) {
+      $cacheCursor = $workdir
+      foreach ($segment in ($cachePath -split '/')) {
+        $cacheCursor = Join-Path $cacheCursor $segment
+        $cacheItem = Get-Item -LiteralPath $cacheCursor -Force
+        if ($cacheItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) {
+          throw "ready-pool cache root must not contain reparse points"
+        }
+      }
+      if (-not $cacheItem.PSIsContainer) { throw "ready-pool cache root must be a real directory" }
       $cleanArgs += @('-e', "$cachePath/")
     } elseif ($LASTEXITCODE -ne 1) {
       throw "ready-pool cache ignore check failed"

--- a/internal/cli/ready_pool_scrub.go
+++ b/internal/cli/ready_pool_scrub.go
@@ -1,0 +1,296 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func trustedReadyPoolRemoteURL(remoteURL string) (string, error) {
+	remoteURL = strings.TrimSpace(remoteURL)
+	if remoteURL == "" {
+		return "", exit(7, "ready-pool reuse requires a canonical local Git origin")
+	}
+	if gitRemoteURLHasCredentials(remoteURL) {
+		return "", exit(7, "ready-pool reuse refuses a credential-bearing local Git origin")
+	}
+	if strings.HasPrefix(remoteURL, "ssh://") || (!strings.Contains(remoteURL, "://") && strings.Contains(remoteURL, "@")) {
+		return "", exit(7, "ready-pool reuse requires an anonymously fetchable non-SSH Git origin")
+	}
+	canonical := normalizeGitRemoteURL(remoteURL)
+	if canonical == "" {
+		return "", exit(7, "ready-pool reuse could not normalize the local Git origin")
+	}
+	parsed, err := url.Parse(canonical)
+	if err != nil || parsed.User != nil || parsed.Scheme != "https" || parsed.Host == "" {
+		return "", exit(7, "ready-pool reuse requires an anonymously fetchable HTTPS Git origin")
+	}
+	return canonical, nil
+}
+
+func preflightReadyPoolRemote(ctx context.Context, remoteURL string) error {
+	preflightCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	workdir, err := os.MkdirTemp("", "crabbox-ready-pool-preflight-")
+	if err != nil {
+		return exit(7, "create ready-pool origin preflight directory")
+	}
+	defer os.RemoveAll(workdir)
+	configNull := "/dev/null"
+	if runtime.GOOS == "windows" {
+		configNull = "NUL"
+	}
+	cmd := exec.CommandContext(preflightCtx, "git", "-c", "credential.helper=", "ls-remote", "--exit-code", remoteURL, "HEAD")
+	cmd.Dir = workdir
+	cmd.Env = []string{
+		"HOME=" + workdir,
+		"USERPROFILE=" + workdir,
+		"PATH=" + os.Getenv("PATH"),
+		"GIT_CONFIG_NOSYSTEM=1",
+		"GIT_CONFIG_GLOBAL=" + configNull,
+		"GIT_CONFIG_SYSTEM=" + configNull,
+		"GIT_TERMINAL_PROMPT=0",
+		"GCM_INTERACTIVE=Never",
+	}
+	if err := cmd.Run(); err != nil {
+		return exit(7, "ready-pool reuse requires an anonymously fetchable Git origin before borrowing")
+	}
+	return nil
+}
+
+func (a App) scrubReadyPoolLease(ctx context.Context, target SSHTarget, entry CoordinatorReadyPoolEntry, workdir, trustedRemoteURL string, requireActionsHydration bool) (string, error) {
+	if strings.TrimSpace(workdir) == "" {
+		return "", exit(7, "ready-pool scrub has no remote workdir")
+	}
+	if strings.TrimSpace(entry.Ref) == "" {
+		return "", exit(7, "ready-pool scrub requires a branch ref")
+	}
+	if strings.TrimSpace(trustedRemoteURL) == "" {
+		return "", exit(7, "ready-pool scrub has no trusted Git origin")
+	}
+	command := remoteReadyPoolScrub(workdir, entry.Ref, trustedRemoteURL)
+	if isWindowsNativeTarget(target) {
+		command = windowsRemoteReadyPoolScrub(workdir, entry.Ref, trustedRemoteURL)
+	}
+	out, err := runSSHOutput(ctx, target, command)
+	if err != nil {
+		return "", exit(7, "ready-pool scrub failed on %s: %v", target.Host, err)
+	}
+	preparedCommit := strings.TrimSpace(out)
+	if !isGitCommitSHA(preparedCommit) {
+		return "", exit(7, "ready-pool scrub did not report one valid prepared commit")
+	}
+	if requireActionsHydration {
+		state, err := readActionsHydrationState(ctx, target, entry.LeaseID)
+		if err != nil {
+			return "", exit(7, "read ready-pool Actions hydration marker: %v", err)
+		}
+		if strings.TrimSpace(state.Workspace) == "" || strings.TrimSpace(state.Workspace) != strings.TrimSpace(workdir) {
+			return "", exit(7, "ready-pool Actions hydration marker no longer owns the prepared workspace")
+		}
+	}
+	return preparedCommit, nil
+}
+
+func remoteReadyPoolScrub(workdir, ref, trustedRemoteURL string) string {
+	script := `set -euo pipefail
+workdir=` + shellQuote(workdir) + `
+ref=` + shellQuote(strings.TrimSpace(ref)) + `
+trusted_remote=` + shellQuote(strings.TrimSpace(trustedRemoteURL)) + `
+if [ -L "$workdir" ] || [ ! -d "$workdir" ]; then
+  echo "ready-pool workspace root must be a real directory" >&2
+  exit 1
+fi
+resolved_workdir="$(cd -P -- "$workdir" && pwd -P)"
+workdir="$resolved_workdir"
+cd "$resolved_workdir"
+test -d .git
+parent="$(dirname -- "$workdir")"
+tmp="$(mktemp -d "$parent/.crabbox-scrub.XXXXXX")"
+safe_home="$tmp/home"
+mkdir -p "$safe_home"
+trap 'rm -rf -- "$tmp"' EXIT
+safe_git() {
+  /usr/bin/env -i HOME="$safe_home" PATH="/usr/bin:/bin" GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null GIT_TERMINAL_PROMPT=0 /usr/bin/git "$@"
+}
+test -x /usr/bin/git
+safe_git check-ref-format --branch "$ref" >/dev/null
+safe_git init --quiet "$tmp"
+safe_git -C "$tmp" remote add origin "$trusted_remote"
+refspec="+refs/heads/$ref:refs/remotes/origin/$ref"
+safe_git -C "$tmp" fetch --quiet --depth=1 origin "$refspec"
+remote_ref="refs/remotes/origin/$ref"
+remote_commit="$(safe_git -C "$tmp" rev-parse --verify "$remote_ref^{commit}")"
+target_commit="$remote_commit"
+rm -rf -- .git
+mv -- "$tmp/.git" .git
+rm -rf -- "$safe_home"
+rmdir -- "$tmp"
+trap - EXIT
+safe_git remote set-url origin "$trusted_remote"
+test "$(safe_git remote get-url origin)" = "$trusted_remote"
+safe_git checkout --quiet -f -B "$ref" "$target_commit"
+safe_git reset --hard --quiet "$target_commit"
+if safe_git ls-files --stage | awk '$1 == "160000" { found=1 } END { exit !found }'; then
+  echo "ready-pool scrub does not reuse submodule worktrees" >&2
+  exit 1
+fi
+clean_args=(-ffdx --quiet)
+for cache_path in node_modules .pnpm-store .yarn/cache .yarn/unplugged; do
+  if [ -e "$cache_path" ]; then
+    if safe_git check-ignore -q -- "$cache_path"; then
+      clean_args+=(-e "$cache_path/")
+    elif [ "$?" -ne 1 ]; then
+      echo "ready-pool cache ignore check failed" >&2
+      exit 1
+    fi
+  fi
+done
+safe_git clean "${clean_args[@]}"
+if [ -L .crabbox ]; then
+  echo "ready-pool .crabbox root must not be a symlink" >&2
+  exit 1
+fi
+if [ -e .crabbox ] && [ ! -d .crabbox ]; then
+  echo "ready-pool .crabbox root must be a directory" >&2
+  exit 1
+fi
+rm -rf -- .crabbox/env .crabbox/scripts .crabbox/logs .crabbox/captures .crabbox/runs
+git_dir="$(safe_git rev-parse --git-dir)"
+meta_dir="$git_dir/crabbox"
+mkdir -p "$meta_dir"
+rm -f -- "$meta_dir/sync-fingerprint" "$meta_dir/sync-manifest" "$meta_dir/sync-manifest.new" "$meta_dir/sync-deleted.new"
+printf '%s %s\n' "$ref" "$target_commit" > "$meta_dir/git-hydrate-base"
+test "$(safe_git branch --show-current)" = "$ref"
+test "$(safe_git rev-parse HEAD)" = "$target_commit"
+if ! status="$(safe_git status --porcelain --untracked-files=normal)"; then
+  echo "ready-pool Git status failed" >&2
+  exit 1
+fi
+test -z "$status"
+printf '%s\n' "$target_commit"`
+	return "/bin/bash --noprofile --norc -c " + shellQuote(script)
+}
+
+func windowsRemoteReadyPoolScrub(workdir, ref, trustedRemoteURL string) string {
+	return powershellCommand(`$ErrorActionPreference = "Stop"
+$workdir = ` + psQuote(workdir) + `
+$ref = ` + psQuote(strings.TrimSpace(ref)) + `
+$trustedRemote = ` + psQuote(strings.TrimSpace(trustedRemoteURL)) + `
+# Borrowed commands may persist user-scoped Git variables. Clear the complete
+# inherited Git surface before installing the scrub's small trusted set.
+Get-ChildItem Env:GIT_* -ErrorAction SilentlyContinue | Remove-Item -ErrorAction Stop
+$env:GIT_CONFIG_NOSYSTEM = '1'
+$env:GIT_CONFIG_GLOBAL = 'NUL'
+$env:GIT_CONFIG_SYSTEM = 'NUL'
+$env:GIT_TERMINAL_PROMPT = '0'
+$gitCandidates = @()
+if ($env:ProgramFiles) {
+  $gitCandidates += (Join-Path $env:ProgramFiles 'Git\cmd\git.exe')
+  $gitCandidates += (Join-Path $env:ProgramFiles 'Git\bin\git.exe')
+}
+if (${env:ProgramFiles(x86)}) {
+  $gitCandidates += (Join-Path ${env:ProgramFiles(x86)} 'Git\cmd\git.exe')
+  $gitCandidates += (Join-Path ${env:ProgramFiles(x86)} 'Git\bin\git.exe')
+}
+$gitCandidates = $gitCandidates | Where-Object { Test-Path -LiteralPath $_ -PathType Leaf }
+$git = $gitCandidates | Select-Object -First 1
+if (-not $git) { throw "ready-pool scrub could not locate trusted Git under Program Files" }
+$workdirItem = Get-Item -LiteralPath $workdir -Force
+if (-not $workdirItem.PSIsContainer -or ($workdirItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint)) {
+  throw "ready-pool workspace root must be a real directory"
+}
+$resolvedWorkdir = $workdirItem.FullName
+$workdir = $resolvedWorkdir
+Set-Location -LiteralPath $resolvedWorkdir
+if (-not (Test-Path -LiteralPath (Join-Path $workdir '.git') -PathType Container)) { throw "ready-pool workspace has no replaceable Git metadata" }
+& $git check-ref-format --branch $ref | Out-Null
+if ($LASTEXITCODE -ne 0) { throw "invalid ready-pool branch ref" }
+$parent = Split-Path -Parent $workdir
+$tmp = Join-Path $parent ('.crabbox-scrub-' + [System.Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Force -Path $tmp | Out-Null
+$safeHome = Join-Path $tmp 'home'
+New-Item -ItemType Directory -Force -Path $safeHome | Out-Null
+$env:HOME = $safeHome
+$env:USERPROFILE = $safeHome
+& $git init --quiet $tmp
+if ($LASTEXITCODE -ne 0) { throw "ready-pool temporary Git init failed" }
+& $git -C $tmp remote add origin $trustedRemote
+if ($LASTEXITCODE -ne 0) { throw "ready-pool trusted origin setup failed" }
+$refspec = "+refs/heads/${ref}:refs/remotes/origin/${ref}"
+& $git -C $tmp fetch --quiet --depth=1 origin $refspec
+if ($LASTEXITCODE -ne 0) { throw "ready-pool branch fetch failed" }
+$remoteRef = "refs/remotes/origin/$ref"
+$remoteCommit = (& $git -C $tmp rev-parse --verify "${remoteRef}^{commit}").Trim()
+if ($LASTEXITCODE -ne 0 -or -not $remoteCommit) { throw "ready-pool remote branch is missing" }
+$targetCommit = $remoteCommit
+$oldGit = Join-Path $workdir '.git'
+Remove-Item -LiteralPath $oldGit -Recurse -Force -ErrorAction Stop
+if (Test-Path -LiteralPath $oldGit) { throw "ready-pool old Git metadata was not removed" }
+Move-Item -LiteralPath (Join-Path $tmp '.git') -Destination $oldGit -ErrorAction Stop
+Remove-Item -LiteralPath $tmp -Recurse -Force -ErrorAction Stop
+& $git remote set-url origin $trustedRemote
+if ($LASTEXITCODE -ne 0) { throw "ready-pool trusted origin reset failed" }
+$actualRemote = (& $git remote get-url origin).Trim()
+if ($LASTEXITCODE -ne 0 -or $actualRemote -ne $trustedRemote) { throw "ready-pool trusted origin verification failed" }
+& $git checkout --quiet -f -B $ref $targetCommit
+if ($LASTEXITCODE -ne 0) { throw "ready-pool branch checkout failed" }
+& $git reset --hard --quiet $targetCommit
+if ($LASTEXITCODE -ne 0) { throw "ready-pool branch reset failed" }
+$gitlinks = @(& $git ls-files --stage | Where-Object { $_ -match '^160000 ' })
+if ($LASTEXITCODE -ne 0) { throw "ready-pool gitlink inspection failed" }
+if ($gitlinks.Count -ne 0) { throw "ready-pool scrub does not reuse submodule worktrees" }
+$cleanArgs = @('clean', '-ffdx', '--quiet')
+foreach ($cachePath in @('node_modules', '.pnpm-store', '.yarn/cache', '.yarn/unplugged')) {
+  if (Test-Path -LiteralPath $cachePath) {
+    & $git check-ignore -q -- $cachePath
+    if ($LASTEXITCODE -eq 0) {
+      $cleanArgs += @('-e', "$cachePath/")
+    } elseif ($LASTEXITCODE -ne 1) {
+      throw "ready-pool cache ignore check failed"
+    }
+  }
+}
+& $git @cleanArgs
+if ($LASTEXITCODE -ne 0) { throw "ready-pool branch clean failed" }
+$crabboxRoot = Join-Path $workdir '.crabbox'
+if (Test-Path -LiteralPath $crabboxRoot) {
+  $crabboxRootItem = Get-Item -LiteralPath $crabboxRoot -Force
+  if (-not $crabboxRootItem.PSIsContainer -or ($crabboxRootItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint)) {
+    throw "ready-pool .crabbox root must be a real directory"
+  }
+}
+foreach ($relative in @('.crabbox/env', '.crabbox/scripts', '.crabbox/logs', '.crabbox/captures', '.crabbox/runs')) {
+  $candidate = Join-Path $workdir $relative
+  if (Test-Path -LiteralPath $candidate) { Remove-Item -LiteralPath $candidate -Recurse -Force }
+}
+$gitDir = (& $git rev-parse --git-dir).Trim()
+if ($LASTEXITCODE -ne 0 -or -not $gitDir) { throw "ready-pool Git metadata is missing" }
+$metaDir = Join-Path $gitDir 'crabbox'
+New-Item -ItemType Directory -Force -Path $metaDir | Out-Null
+foreach ($name in @('sync-fingerprint', 'sync-manifest', 'sync-manifest.new', 'sync-deleted.new')) {
+  $metadataPath = Join-Path $metaDir $name
+  if (Test-Path -LiteralPath $metadataPath) {
+    Remove-Item -LiteralPath $metadataPath -Force -ErrorAction Stop
+    if (Test-Path -LiteralPath $metadataPath) { throw "ready-pool stale Git metadata was not removed" }
+  }
+}
+Set-Content -LiteralPath (Join-Path $metaDir 'git-hydrate-base') -Value "$ref $targetCommit"
+$branch = (& $git branch --show-current).Trim()
+if ($LASTEXITCODE -ne 0 -or $branch -ne $ref) { throw "ready-pool branch verification failed" }
+$head = (& $git rev-parse HEAD).Trim()
+if ($LASTEXITCODE -ne 0 -or $head -ne $targetCommit) { throw "ready-pool commit verification failed" }
+$status = @(& $git status --porcelain --untracked-files=normal)
+if ($LASTEXITCODE -ne 0 -or $status.Count -ne 0) { throw "ready-pool worktree is not clean" }
+Write-Output $targetCommit
+`)
+}
+
+func readyPoolScrubLifecycleError(leaseID string, scrubErr error) error {
+	return fmt.Errorf("ready-pool scrub failed for %s: %w", leaseID, scrubErr)
+}

--- a/internal/cli/ready_pool_scrub_test.go
+++ b/internal/cli/ready_pool_scrub_test.go
@@ -1,0 +1,288 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestRemoteReadyPoolScrubResetsLatestBranchAndPreservesIgnoredCaches(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX scrub integration")
+	}
+	root := t.TempDir()
+	source := filepath.Join(root, "source")
+	if err := os.Mkdir(source, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, source, "init")
+	runGit(t, source, "config", "user.email", "test@example.com")
+	runGit(t, source, "config", "user.name", "Test")
+	runGit(t, source, "branch", "-M", "main")
+	mustWriteTestFile(t, filepath.Join(source, ".gitignore"), "node_modules/\n*.ignored\n")
+	mustWriteTestFile(t, filepath.Join(source, "proof.txt"), "base\n")
+	runGit(t, source, "add", ".")
+	runGit(t, source, "commit", "-m", "base")
+
+	origin := filepath.Join(root, "origin.git")
+	cloneBare := exec.Command("git", "clone", "--bare", source, origin)
+	if out, err := cloneBare.CombinedOutput(); err != nil {
+		t.Fatalf("create bare origin: %v\n%s", err, out)
+	}
+	runGit(t, source, "remote", "add", "origin", origin)
+
+	workdir := filepath.Join(root, "workdir")
+	clone := exec.Command("git", "clone", origin, workdir)
+	if out, err := clone.CombinedOutput(); err != nil {
+		t.Fatalf("clone workdir: %v\n%s", err, out)
+	}
+	runGit(t, workdir, "config", "user.email", "test@example.com")
+	runGit(t, workdir, "config", "user.name", "Test")
+	runGit(t, workdir, "checkout", "-b", "feature")
+	mustWriteTestFile(t, filepath.Join(workdir, "proof.txt"), "dirty feature\n")
+	mustWriteTestFile(t, filepath.Join(workdir, "untracked.txt"), "remove me\n")
+	mustWriteTestFile(t, filepath.Join(workdir, "node_modules", "cache.txt"), "keep me\n")
+	mustWriteTestFile(t, filepath.Join(workdir, ".pnpm-store", "cache.txt"), "remove unless ignored\n")
+	mustWriteTestFile(t, filepath.Join(workdir, "task-state.ignored"), "remove me\n")
+	for _, name := range []string{"sync-fingerprint", "sync-manifest", "sync-manifest.new", "sync-deleted.new"} {
+		mustWriteTestFile(t, filepath.Join(workdir, ".git", "crabbox", name), "stale\n")
+	}
+	for _, name := range []string{"env", "scripts", "logs", "captures", "runs"} {
+		mustWriteTestFile(t, filepath.Join(workdir, ".crabbox", name, "stale.txt"), "stale\n")
+	}
+	attackerSource := filepath.Join(root, "attacker-source")
+	if err := os.Mkdir(attackerSource, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, attackerSource, "init")
+	runGit(t, attackerSource, "config", "user.email", "test@example.com")
+	runGit(t, attackerSource, "config", "user.name", "Test")
+	runGit(t, attackerSource, "branch", "-M", "main")
+	mustWriteTestFile(t, filepath.Join(attackerSource, "proof.txt"), "attacker\n")
+	runGit(t, attackerSource, "add", ".")
+	runGit(t, attackerSource, "commit", "-m", "attacker")
+	attackerOrigin := filepath.Join(root, "attacker.git")
+	cloneAttacker := exec.Command("git", "clone", "--bare", attackerSource, attackerOrigin)
+	if out, err := cloneAttacker.CombinedOutput(); err != nil {
+		t.Fatalf("create attacker origin: %v\n%s", err, out)
+	}
+	runGit(t, workdir, "remote", "set-url", "origin", attackerOrigin)
+	runGit(t, workdir, "config", "remote.origin.uploadpack", "false")
+	runGit(t, workdir, "config", "url."+attackerOrigin+".insteadOf", origin)
+
+	mustWriteTestFile(t, filepath.Join(source, "proof.txt"), "latest main\n")
+	runGit(t, source, "add", "proof.txt")
+	runGit(t, source, "commit", "-m", "advance main")
+	runGit(t, source, "push", "origin", "main")
+	wantCommit := gitOutput(source, "rev-parse", "HEAD")
+
+	cmd := exec.Command("bash", "-lc", remoteReadyPoolScrub(workdir, "main", origin))
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("scrub failed: %v\n%s", err, out)
+	}
+	if got := strings.TrimSpace(string(out)); got != wantCommit {
+		t.Fatalf("prepared commit=%q, want %q", got, wantCommit)
+	}
+	if got := gitOutput(workdir, "branch", "--show-current"); got != "main" {
+		t.Fatalf("branch=%q, want main", got)
+	}
+	if got := gitOutput(workdir, "rev-parse", "HEAD"); got != wantCommit {
+		t.Fatalf("HEAD=%q, want %q", got, wantCommit)
+	}
+	if got := gitOutput(workdir, "remote", "get-url", "origin"); got != origin {
+		t.Fatalf("origin=%q, want trusted %q", got, origin)
+	}
+	if got := gitOutput(workdir, "status", "--porcelain", "--untracked-files=normal"); got != "" {
+		t.Fatalf("worktree not clean: %q", got)
+	}
+	proof, err := os.ReadFile(filepath.Join(workdir, "proof.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(proof) != "latest main\n" {
+		t.Fatalf("proof=%q", proof)
+	}
+	cache, err := os.ReadFile(filepath.Join(workdir, "node_modules", "cache.txt"))
+	if err != nil {
+		t.Fatalf("ignored dependency cache was removed: %v", err)
+	}
+	if string(cache) != "keep me\n" {
+		t.Fatalf("cache=%q", cache)
+	}
+	if _, err := os.Stat(filepath.Join(workdir, "task-state.ignored")); !os.IsNotExist(err) {
+		t.Fatalf("ignored task state remains: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(workdir, ".pnpm-store")); !os.IsNotExist(err) {
+		t.Fatalf("non-ignored cache remains: %v", err)
+	}
+	for _, name := range []string{"sync-fingerprint", "sync-manifest", "sync-manifest.new", "sync-deleted.new"} {
+		if _, err := os.Stat(filepath.Join(workdir, ".git", "crabbox", name)); !os.IsNotExist(err) {
+			t.Fatalf("stale metadata %s remains: %v", name, err)
+		}
+	}
+	marker, err := os.ReadFile(filepath.Join(workdir, ".git", "crabbox", "git-hydrate-base"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := string(marker), "main "+wantCommit+"\n"; got != want {
+		t.Fatalf("hydrate marker=%q, want %q", got, want)
+	}
+	for _, name := range []string{"env", "scripts", "logs", "captures", "runs"} {
+		if _, err := os.Stat(filepath.Join(workdir, ".crabbox", name)); !os.IsNotExist(err) {
+			t.Fatalf("run transient %s remains: %v", name, err)
+		}
+	}
+}
+
+func TestWindowsRemoteReadyPoolScrubBuildsVerifiedReset(t *testing.T) {
+	decoded := decodePowerShellCommand(t, windowsRemoteReadyPoolScrub(`C:\crabbox\repo`, "main", "https://example.com/org/repo.git"))
+	for _, want := range []string{
+		"Get-ChildItem Env:GIT_*",
+		"Remove-Item -ErrorAction Stop",
+		"Join-Path $env:ProgramFiles 'Git\\cmd\\git.exe'",
+		"& $git -C $tmp fetch --quiet --depth=1 origin",
+		"& $git checkout --quiet -f -B $ref $targetCommit",
+		"ready-pool scrub does not reuse submodule worktrees",
+		"$cleanArgs = @('clean', '-ffdx', '--quiet')",
+		"& $git check-ignore -q -- $cachePath",
+		"[System.IO.FileAttributes]::ReparsePoint",
+		"ready-pool .crabbox root must be a real directory",
+		"ready-pool workspace root must be a real directory",
+		"$env:HOME = $safeHome",
+		"ready-pool trusted origin verification failed",
+		"Remove-Item -LiteralPath $metadataPath -Force -ErrorAction Stop",
+		"if (Test-Path -LiteralPath $metadataPath) { throw",
+		"sync-fingerprint",
+		"git-hydrate-base",
+		"& $git status --porcelain --untracked-files=normal",
+	} {
+		if !strings.Contains(decoded, want) {
+			t.Fatalf("Windows scrub missing %q in %q", want, decoded)
+		}
+	}
+}
+
+func TestReadyPoolRunNeedsTrustedRemote(t *testing.T) {
+	for _, policy := range []string{"auto", "ready", ""} {
+		if !readyPoolRunNeedsTrustedRemote(policy) {
+			t.Fatalf("policy %q must validate the trusted origin", policy)
+		}
+	}
+	for _, policy := range []string{"drain", "release", " DRAIN "} {
+		if readyPoolRunNeedsTrustedRemote(policy) {
+			t.Fatalf("policy %q must permit unconditional disposal", policy)
+		}
+	}
+}
+
+func TestRemoteReadyPoolScrubUsesIsolatedTrustedGitMetadata(t *testing.T) {
+	got := remoteReadyPoolScrub("/work/repo", "main", "https://example.com/org/repo.git")
+	for _, want := range []string{
+		"GIT_CONFIG_NOSYSTEM=1",
+		"GIT_CONFIG_GLOBAL=/dev/null",
+		"/usr/bin/git",
+		"/bin/bash --noprofile --norc -c",
+		"if [ -L \"$workdir\" ]",
+		"HOME=\"$safe_home\"",
+		"safe_git -C \"$tmp\" fetch",
+		"ready-pool scrub does not reuse submodule worktrees",
+		"safe_git check-ignore -q -- \"$cache_path\"",
+		"safe_git clean \"${clean_args[@]}\"",
+		"rm -rf -- .git",
+		"safe_git remote set-url origin",
+		"if ! status=",
+		"if [ -L .crabbox ]",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("POSIX scrub missing %q in %q", want, got)
+		}
+	}
+}
+
+func TestTrustedReadyPoolRemoteURL(t *testing.T) {
+	for _, value := range []string{"", "https://user@example.com/org/repo.git", "ssh://git@example.com/org/repo.git"} {
+		if _, err := trustedReadyPoolRemoteURL(value); err == nil {
+			t.Fatalf("unsafe origin %q was accepted", value)
+		}
+	}
+	if _, err := trustedReadyPoolRemoteURL("git@github.com:example-org/repo.git"); err == nil {
+		t.Fatal("SSH origin was accepted without a reusable authentication contract")
+	}
+	local := filepath.Join(t.TempDir(), "origin.git")
+	if _, err := trustedReadyPoolRemoteURL(local); err == nil {
+		t.Fatal("client-local origin was accepted for remote-host reuse")
+	}
+}
+
+func TestRemoteReadyPoolScrubRejectsCrabboxSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX symlink integration")
+	}
+	root := t.TempDir()
+	source := filepath.Join(root, "source")
+	if err := os.Mkdir(source, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, source, "init")
+	runGit(t, source, "config", "user.email", "test@example.com")
+	runGit(t, source, "config", "user.name", "Test")
+	runGit(t, source, "branch", "-M", "main")
+	if err := os.Symlink("../outside", filepath.Join(source, ".crabbox")); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, source, "add", ".crabbox")
+	runGit(t, source, "commit", "-m", "tracked crabbox symlink")
+
+	origin := filepath.Join(root, "origin.git")
+	cloneBare := exec.Command("git", "clone", "--bare", source, origin)
+	if out, err := cloneBare.CombinedOutput(); err != nil {
+		t.Fatalf("create bare origin: %v\n%s", err, out)
+	}
+	workdir := filepath.Join(root, "workdir")
+	clone := exec.Command("git", "clone", origin, workdir)
+	if out, err := clone.CombinedOutput(); err != nil {
+		t.Fatalf("clone workdir: %v\n%s", err, out)
+	}
+	sentinel := filepath.Join(root, "outside", "env", "sentinel.txt")
+	mustWriteTestFile(t, sentinel, "keep\n")
+
+	cmd := exec.Command("bash", "-lc", remoteReadyPoolScrub(workdir, "main", origin))
+	if out, err := cmd.CombinedOutput(); err == nil {
+		t.Fatalf("symlinked .crabbox root was accepted: %s", out)
+	}
+	if data, err := os.ReadFile(sentinel); err != nil || string(data) != "keep\n" {
+		t.Fatalf("outside sentinel changed: data=%q err=%v", data, err)
+	}
+}
+
+func TestPreflightReadyPoolRemoteRequiresAnonymousFetch(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "source")
+	if err := os.Mkdir(source, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, source, "init")
+	runGit(t, source, "config", "user.email", "test@example.com")
+	runGit(t, source, "config", "user.name", "Test")
+	runGit(t, source, "branch", "-M", "main")
+	mustWriteTestFile(t, filepath.Join(source, "proof.txt"), "proof\n")
+	runGit(t, source, "add", ".")
+	runGit(t, source, "commit", "-m", "base")
+
+	origin := filepath.Join(root, "origin.git")
+	clone := exec.Command("git", "clone", "--bare", source, origin)
+	if out, err := clone.CombinedOutput(); err != nil {
+		t.Fatalf("create bare origin: %v\n%s", err, out)
+	}
+	if err := preflightReadyPoolRemote(context.Background(), origin); err != nil {
+		t.Fatalf("anonymous local origin rejected: %v", err)
+	}
+	if err := preflightReadyPoolRemote(context.Background(), filepath.Join(root, "missing.git")); err == nil {
+		t.Fatal("missing origin passed anonymous fetch preflight")
+	}
+}

--- a/internal/cli/ready_pool_scrub_test.go
+++ b/internal/cli/ready_pool_scrub_test.go
@@ -150,6 +150,8 @@ func TestWindowsRemoteReadyPoolScrubBuildsVerifiedReset(t *testing.T) {
 		"ready-pool scrub does not reuse submodule worktrees",
 		"$cleanArgs = @('clean', '-ffdx', '--quiet')",
 		"& $git check-ignore -q -- $cachePath",
+		"$cachePath -split '/'",
+		"ready-pool cache root must not contain reparse points",
 		"[System.IO.FileAttributes]::ReparsePoint",
 		"ready-pool .crabbox root must be a real directory",
 		"ready-pool workspace root must be a real directory",
@@ -192,6 +194,8 @@ func TestRemoteReadyPoolScrubUsesIsolatedTrustedGitMetadata(t *testing.T) {
 		"safe_git -C \"$tmp\" fetch",
 		"ready-pool scrub does not reuse submodule worktrees",
 		"safe_git check-ignore -q -- \"$cache_path\"",
+		"ready-pool cache root must be a real directory",
+		"ready-pool cache root escapes the workspace",
 		"safe_git clean \"${clean_args[@]}\"",
 		"rm -rf -- .git",
 		"safe_git remote set-url origin",
@@ -257,6 +261,64 @@ func TestRemoteReadyPoolScrubRejectsCrabboxSymlink(t *testing.T) {
 	}
 	if data, err := os.ReadFile(sentinel); err != nil || string(data) != "keep\n" {
 		t.Fatalf("outside sentinel changed: data=%q err=%v", data, err)
+	}
+}
+
+func TestRemoteReadyPoolScrubRejectsIgnoredCacheSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX symlink integration")
+	}
+	root := t.TempDir()
+	source := filepath.Join(root, "source")
+	if err := os.Mkdir(source, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, source, "init")
+	runGit(t, source, "config", "user.email", "test@example.com")
+	runGit(t, source, "config", "user.name", "Test")
+	runGit(t, source, "branch", "-M", "main")
+	mustWriteTestFile(t, filepath.Join(source, ".gitignore"), "node_modules\n")
+	mustWriteTestFile(t, filepath.Join(source, "proof.txt"), "base\n")
+	runGit(t, source, "add", ".")
+	runGit(t, source, "commit", "-m", "base")
+
+	origin := filepath.Join(root, "origin.git")
+	cloneBare := exec.Command("git", "clone", "--bare", source, origin)
+	if out, err := cloneBare.CombinedOutput(); err != nil {
+		t.Fatalf("create bare origin: %v\n%s", err, out)
+	}
+	workdir := filepath.Join(root, "workdir")
+	clone := exec.Command("git", "clone", origin, workdir)
+	if out, err := clone.CombinedOutput(); err != nil {
+		t.Fatalf("clone workdir: %v\n%s", err, out)
+	}
+	outside := filepath.Join(root, "outside")
+	mustWriteTestFile(t, filepath.Join(outside, "sentinel.txt"), "keep\n")
+	if err := os.Symlink(outside, filepath.Join(workdir, "node_modules")); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command("bash", "-lc", remoteReadyPoolScrub(workdir, "main", origin))
+	if out, err := cmd.CombinedOutput(); err == nil {
+		t.Fatalf("symlinked ignored cache was accepted: %s", out)
+	}
+	if data, err := os.ReadFile(filepath.Join(outside, "sentinel.txt")); err != nil || string(data) != "keep\n" {
+		t.Fatalf("outside sentinel changed: data=%q err=%v", data, err)
+	}
+}
+
+func TestReadyPoolScrubBranchNormalizesFullHeadRef(t *testing.T) {
+	if got, err := readyPoolScrubBranch("refs/heads/main"); err != nil || got != "main" {
+		t.Fatalf("full branch ref normalized to %q, err=%v", got, err)
+	}
+	shaLikeBranch := strings.Repeat("a", 40)
+	if got, err := readyPoolScrubBranch("refs/heads/" + shaLikeBranch); err != nil || got != shaLikeBranch {
+		t.Fatalf("explicit SHA-like branch normalized to %q, err=%v", got, err)
+	}
+	for _, ref := range []string{"", "refs/tags/v1.0.0", strings.Repeat("a", 40)} {
+		if got, err := readyPoolScrubBranch(ref); err == nil {
+			t.Fatalf("non-branch ref %q normalized to %q", ref, got)
+		}
 	}
 }
 

--- a/internal/cli/ready_pool_scrub_test.go
+++ b/internal/cli/ready_pool_scrub_test.go
@@ -163,9 +163,13 @@ func TestRemoteReadyPoolScrubResetsLatestBranchAndPreservesIgnoredCaches(t *test
 func TestWindowsRemoteReadyPoolScrubBuildsVerifiedReset(t *testing.T) {
 	decoded := decodePowerShellCommand(t, windowsRemoteReadyPoolScrub(`C:\crabbox\repo`, "main", "https://example.com/org/repo.git"))
 	for _, want := range []string{
-		"Get-ChildItem Env:GIT_*",
-		"Remove-Item -ErrorAction Stop",
-		"Join-Path $env:ProgramFiles 'Git\\cmd\\git.exe'",
+		"[Environment]::GetFolderPath([Environment+SpecialFolder]::ProgramFiles)",
+		"[Environment]::GetFolderPath([Environment+SpecialFolder]::Windows)",
+		"Get-ChildItem Env:",
+		"Remove-Item -LiteralPath (\"Env:\" + $_.Name) -ErrorAction Stop",
+		"$env:PATH = ((Split-Path -Parent $git), $systemDirectory) -join ';'",
+		"$env:XDG_CONFIG_HOME = $safeHome",
+		"$env:GCM_INTERACTIVE = 'Never'",
 		"& $git -C $tmp fetch --quiet --prune --tags origin",
 		"& $git -C $tmp read-tree $targetCommit",
 		"& $git -C $tmp ls-files -- ':(top)**' ':(top,exclude,attr:!filter)**' ':(top,exclude,attr:-filter)**'",
@@ -431,6 +435,10 @@ func TestPreflightReadyPoolRemoteRequiresAnonymousFetch(t *testing.T) {
 	}
 	if err := preflightReadyPoolRemote(context.Background(), origin); err != nil {
 		t.Fatalf("anonymous local origin rejected: %v", err)
+	}
+	runGit(t, origin, "symbolic-ref", "HEAD", "refs/heads/missing")
+	if err := preflightReadyPoolRemote(context.Background(), origin); err != nil {
+		t.Fatalf("anonymous origin without advertised HEAD rejected: %v", err)
 	}
 	if err := preflightReadyPoolRemote(context.Background(), filepath.Join(root, "missing.git")); err == nil {
 		t.Fatal("missing origin passed anonymous fetch preflight")

--- a/internal/cli/ready_pool_scrub_test.go
+++ b/internal/cli/ready_pool_scrub_test.go
@@ -27,6 +27,9 @@ func TestRemoteReadyPoolScrubResetsLatestBranchAndPreservesIgnoredCaches(t *test
 	mustWriteTestFile(t, filepath.Join(source, "proof.txt"), "base\n")
 	runGit(t, source, "add", ".")
 	runGit(t, source, "commit", "-m", "base")
+	baseCommit := gitOutput(source, "rev-parse", "HEAD")
+	runGit(t, source, "branch", "maintenance")
+	runGit(t, source, "-c", "tag.gpgSign=false", "tag", "v-test")
 
 	origin := filepath.Join(root, "origin.git")
 	cloneBare := exec.Command("git", "clone", "--bare", source, origin)
@@ -97,6 +100,24 @@ func TestRemoteReadyPoolScrubResetsLatestBranchAndPreservesIgnoredCaches(t *test
 	if got := gitOutput(workdir, "remote", "get-url", "origin"); got != origin {
 		t.Fatalf("origin=%q, want trusted %q", got, origin)
 	}
+	if got := gitOutput(workdir, "rev-parse", "HEAD^"); got != baseCommit {
+		t.Fatalf("HEAD parent=%q, want full-history parent %q", got, baseCommit)
+	}
+	if got := gitOutput(workdir, "rev-parse", "--is-shallow-repository"); got != "false" {
+		t.Fatalf("is-shallow-repository=%q, want false", got)
+	}
+	if got := gitOutput(workdir, "rev-parse", "refs/remotes/origin/maintenance"); got != baseCommit {
+		t.Fatalf("maintenance ref=%q, want %q", got, baseCommit)
+	}
+	if got := gitOutput(workdir, "rev-parse", "refs/tags/v-test"); got != baseCommit {
+		t.Fatalf("tag=%q, want %q", got, baseCommit)
+	}
+	if got := gitOutput(workdir, "config", "--get", "branch.main.remote"); got != "origin" {
+		t.Fatalf("branch remote=%q, want origin", got)
+	}
+	if got := gitOutput(workdir, "config", "--get", "branch.main.merge"); got != "refs/heads/main" {
+		t.Fatalf("branch merge ref=%q, want refs/heads/main", got)
+	}
 	if got := gitOutput(workdir, "status", "--porcelain", "--untracked-files=normal"); got != "" {
 		t.Fatalf("worktree not clean: %q", got)
 	}
@@ -145,8 +166,12 @@ func TestWindowsRemoteReadyPoolScrubBuildsVerifiedReset(t *testing.T) {
 		"Get-ChildItem Env:GIT_*",
 		"Remove-Item -ErrorAction Stop",
 		"Join-Path $env:ProgramFiles 'Git\\cmd\\git.exe'",
-		"& $git -C $tmp fetch --quiet --depth=1 origin",
+		"& $git -C $tmp fetch --quiet --prune --tags origin",
+		"& $git -C $tmp read-tree $targetCommit",
+		"& $git -C $tmp ls-files -- ':(top)**' ':(top,exclude,attr:!filter)**' ':(top,exclude,attr:-filter)**'",
+		"ready-pool scrub does not reuse Git filter-managed worktrees",
 		"& $git checkout --quiet -f -B $ref $targetCommit",
+		"& $git branch --set-upstream-to=$remoteRef $ref",
 		"ready-pool scrub does not reuse submodule worktrees",
 		"$cleanArgs = @('clean', '-ffdx', '--quiet')",
 		"& $git check-ignore -q -- $cachePath",
@@ -192,6 +217,12 @@ func TestRemoteReadyPoolScrubUsesIsolatedTrustedGitMetadata(t *testing.T) {
 		"if [ -L \"$workdir\" ]",
 		"HOME=\"$safe_home\"",
 		"safe_git -C \"$tmp\" fetch",
+		"safe_git -C \"$tmp\" read-tree",
+		"safe_git -C \"$tmp\" ls-files -z --",
+		":(top,exclude,attr:!filter)**",
+		":(top,exclude,attr:-filter)**",
+		"ready-pool scrub does not reuse Git filter-managed worktrees",
+		"safe_git branch --set-upstream-to=\"$remote_ref\" \"$ref\"",
 		"ready-pool scrub does not reuse submodule worktrees",
 		"safe_git check-ignore -q -- \"$cache_path\"",
 		"ready-pool cache root must be a real directory",
@@ -319,6 +350,63 @@ func TestReadyPoolScrubBranchNormalizesFullHeadRef(t *testing.T) {
 		if got, err := readyPoolScrubBranch(ref); err == nil {
 			t.Fatalf("non-branch ref %q normalized to %q", ref, got)
 		}
+	}
+}
+
+func TestRemoteReadyPoolScrubRejectsGitFilterManagedWorktree(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX scrub integration")
+	}
+	for _, filterValue := range []string{"lfs", "unset", "unspecified"} {
+		t.Run(filterValue, func(t *testing.T) {
+			testRemoteReadyPoolScrubRejectsGitFilter(t, filterValue)
+		})
+	}
+}
+
+func testRemoteReadyPoolScrubRejectsGitFilter(t *testing.T, filterValue string) {
+	t.Helper()
+	root := t.TempDir()
+	source := filepath.Join(root, "source")
+	if err := os.Mkdir(source, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, source, "init")
+	runGit(t, source, "config", "user.email", "test@example.com")
+	runGit(t, source, "config", "user.name", "Test")
+	runGit(t, source, "branch", "-M", "main")
+	mustWriteTestFile(t, filepath.Join(source, "proof.txt"), "base\n")
+	runGit(t, source, "add", ".")
+	runGit(t, source, "commit", "-m", "base")
+
+	origin := filepath.Join(root, "origin.git")
+	cloneBare := exec.Command("git", "clone", "--bare", source, origin)
+	if out, err := cloneBare.CombinedOutput(); err != nil {
+		t.Fatalf("create bare origin: %v\n%s", err, out)
+	}
+	runGit(t, source, "remote", "add", "origin", origin)
+	workdir := filepath.Join(root, "workdir")
+	clone := exec.Command("git", "clone", origin, workdir)
+	if out, err := clone.CombinedOutput(); err != nil {
+		t.Fatalf("clone workdir: %v\n%s", err, out)
+	}
+
+	mustWriteTestFile(t, filepath.Join(source, ".gitattributes"), "*.bin filter="+filterValue+" -text\n")
+	mustWriteTestFile(t, filepath.Join(source, "asset.bin"), "payload\n")
+	runGit(t, source, "-c", "filter."+filterValue+".process=", "-c", "filter."+filterValue+".clean=cat", "-c", "filter."+filterValue+".required=false", "add", ".")
+	runGit(t, source, "commit", "-m", "add filtered asset")
+	runGit(t, source, "push", "origin", "main")
+
+	cmd := exec.Command("bash", "-lc", remoteReadyPoolScrub(workdir, "main", origin))
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("Git filter-managed worktree was accepted: %s", out)
+	}
+	if !strings.Contains(string(out), "does not reuse Git filter-managed worktrees") {
+		t.Fatalf("unexpected scrub error: %v\n%s", err, out)
+	}
+	if got := gitOutput(workdir, "rev-parse", "HEAD"); got != gitOutput(workdir, "rev-parse", "refs/remotes/origin/main") {
+		t.Fatalf("rejected scrub changed existing checkout HEAD=%q", got)
 	}
 }
 

--- a/internal/cli/ready_pool_test.go
+++ b/internal/cli/ready_pool_test.go
@@ -1,6 +1,9 @@
 package cli
 
 import (
+	"errors"
+	"os/exec"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -87,5 +90,92 @@ func TestReadyPoolRegisterCommitOmitsMismatchedImplicitCommit(t *testing.T) {
 	}
 	if got := readyPoolRegisterCommit(Config{}, repo, other, other); got != other {
 		t.Fatalf("explicit commit=%q, want other", got)
+	}
+}
+
+func TestReadyPoolRunReturnDispositionRequiresScrubProof(t *testing.T) {
+	runErr := errors.New("remote command exited 1")
+	scrubErr := errors.New("scrub failed")
+	tests := []struct {
+		name            string
+		policy          string
+		runFailure      error
+		ordinaryFailure bool
+		scrubErr        error
+		wantScrub       bool
+		wantResult      string
+		metadataMatches bool
+	}{
+		{name: "success returns after scrub", policy: "auto", wantScrub: true, wantResult: "ready", metadataMatches: true},
+		{name: "command failure returns after scrub", policy: "auto", runFailure: runErr, ordinaryFailure: true, wantScrub: true, wantResult: "ready", metadataMatches: true},
+		{name: "command failure drains when scrub fails", policy: "auto", runFailure: runErr, ordinaryFailure: true, scrubErr: scrubErr, wantScrub: true, wantResult: "drain", metadataMatches: true},
+		{name: "advanced exact entry drains", policy: "auto", ordinaryFailure: true, wantScrub: true, wantResult: "drain"},
+		{name: "transport failure drains", policy: "auto", runFailure: runErr, wantResult: "drain", metadataMatches: true},
+		{name: "lifecycle failure drains", policy: "auto", runFailure: runErr, wantResult: "drain", metadataMatches: true},
+		{name: "forced ready cannot override lifecycle failure", policy: "ready", runFailure: runErr, wantResult: "drain", metadataMatches: true},
+		{name: "forced ready still requires scrub", policy: "ready", runFailure: runErr, ordinaryFailure: true, scrubErr: scrubErr, wantScrub: true, wantResult: "drain", metadataMatches: true},
+		{name: "explicit drain skips scrub", policy: "drain", wantResult: "drain", metadataMatches: true},
+		{name: "explicit release skips scrub", policy: "release", wantResult: "release", metadataMatches: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := readyPoolRunShouldScrub(tc.policy, tc.runFailure, tc.ordinaryFailure); got != tc.wantScrub {
+				t.Fatalf("readyPoolRunShouldScrub()=%v, want %v", got, tc.wantScrub)
+			}
+			if got := readyPoolRunReturnResult(tc.policy, tc.runFailure, tc.ordinaryFailure, tc.scrubErr, tc.metadataMatches); got != tc.wantResult {
+				t.Fatalf("readyPoolRunReturnResult()=%q, want %q", got, tc.wantResult)
+			}
+		})
+	}
+}
+
+func TestReadyPoolOrdinaryRemoteCommandFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix process exit semantics")
+	}
+	exitErr := exec.Command("sh", "-c", "exit 1").Run()
+	if !readyPoolOrdinaryRemoteCommandFailure(1, exitErr, nil) {
+		t.Fatal("ordinary remote exit was treated as lifecycle failure")
+	}
+	if readyPoolOrdinaryRemoteCommandFailure(255, exitErr, nil) {
+		t.Fatal("SSH transport exit was treated as ordinary command failure")
+	}
+	if readyPoolOrdinaryRemoteCommandFailure(1, exitErr, errors.New("context canceled")) {
+		t.Fatal("canceled command was treated as ordinary command failure")
+	}
+	if readyPoolOrdinaryRemoteCommandFailure(0, nil, nil) {
+		t.Fatal("successful command was treated as ordinary command failure")
+	}
+	if readyPoolOrdinaryRemoteCommandFailure(1, errors.New("ssh executable missing"), nil) {
+		t.Fatal("SSH process failure was treated as ordinary command failure")
+	}
+	signaledErr := exec.Command("sh", "-c", "kill -TERM $$").Run()
+	if readyPoolOrdinaryRemoteCommandFailure(1, signaledErr, nil) {
+		t.Fatal("signaled SSH process was treated as ordinary command failure")
+	}
+}
+
+func TestReadyPoolRunReturnReasonPreservesCommandOutcome(t *testing.T) {
+	runErr := errors.New("remote command exited 1")
+	if got := readyPoolRunReturnReason(runErr, "ready", "abc123", nil, true); got != "run failed; scrubbed for reuse at abc123" {
+		t.Fatalf("ready return reason=%q", got)
+	}
+	if got := readyPoolRunReturnReason(nil, "drain", "", errors.New("scrub failed"), true); got != "pool scrub failed" {
+		t.Fatalf("scrub failure reason=%q", got)
+	}
+	if got := readyPoolRunReturnReason(nil, "drain", "", nil, false); got != "pool branch advanced beyond recorded commit" {
+		t.Fatalf("advanced commit reason=%q", got)
+	}
+}
+
+func TestReadyPoolPreparedCommitMatches(t *testing.T) {
+	if !readyPoolPreparedCommitMatches("", "new") {
+		t.Fatal("ref-only pool entry rejected prepared commit")
+	}
+	if !readyPoolPreparedCommitMatches("ABC123", "abc123") {
+		t.Fatal("same exact commit rejected")
+	}
+	if readyPoolPreparedCommitMatches("old", "new") {
+		t.Fatal("advanced exact-commit entry remained reusable")
 	}
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -456,6 +456,16 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	if err != nil {
 		return err
 	}
+	trustedPoolRemoteURL := ""
+	if strings.TrimSpace(*readyPool) != "" && readyPoolRunNeedsTrustedRemote(*readyPoolReturn) {
+		trustedPoolRemoteURL, err = trustedReadyPoolRemoteURL(repo.RemoteURL)
+		if err != nil {
+			return err
+		}
+		if err := preflightReadyPoolRemote(ctx, trustedPoolRemoteURL); err != nil {
+			return err
+		}
+	}
 	timingRecordRepo = repo
 	freshPR, err := parseFreshPRSpec(*freshPRValue, repo)
 	if err != nil {
@@ -528,6 +538,9 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	var leaseID string
 	var borrowedPool *CoordinatorReadyPoolResponse
 	var runFailure error
+	var workdir string
+	var hydratedByActions bool
+	var poolOrdinaryCommandFailure bool
 	defer func() {
 		if borrowedPool == nil {
 			return
@@ -536,21 +549,45 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		if failure == nil {
 			failure = err
 		}
-		result := readyPoolRunReturnResult(*readyPoolReturn, failure)
+		var preparedCommit string
+		var scrubErr error
+		metadataCompatible := true
+		if readyPoolRunShouldScrub(*readyPoolReturn, failure, poolOrdinaryCommandFailure) {
+			scrubCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Minute)
+			preparedCommit, scrubErr = a.scrubReadyPoolLease(scrubCtx, target, borrowedPool.Entry, workdir, trustedPoolRemoteURL, hydratedByActions)
+			cancel()
+			if scrubErr != nil {
+				fmt.Fprintf(a.Stderr, "warning: ready-pool scrub failed for %s: %v\n", borrowedPool.Entry.LeaseID, scrubErr)
+				if failure == nil {
+					err = readyPoolScrubLifecycleError(borrowedPool.Entry.LeaseID, scrubErr)
+				}
+			} else {
+				metadataCompatible = readyPoolPreparedCommitMatches(borrowedPool.Entry.Commit, preparedCommit)
+				fmt.Fprintf(a.Stderr, "scrubbed pool=%s lease=%s ref=%s commit=%s\n", borrowedPool.Entry.Key, borrowedPool.Entry.LeaseID, borrowedPool.Entry.Ref, preparedCommit)
+				if !metadataCompatible {
+					fmt.Fprintf(a.Stderr, "pool=%s lease=%s recorded_commit=%s advanced; draining stale exact-commit entry\n", borrowedPool.Entry.Key, borrowedPool.Entry.LeaseID, borrowedPool.Entry.Commit)
+				}
+			}
+		}
+		result := readyPoolRunReturnResult(*readyPoolReturn, failure, poolOrdinaryCommandFailure, scrubErr, metadataCompatible)
+		reason := readyPoolRunReturnReason(failure, result, preparedCommit, scrubErr, metadataCompatible)
 		coord, coordErr := readyPoolCoordinatorFromConfig(cfg)
 		if coordErr != nil {
 			fmt.Fprintf(a.Stderr, "warning: ready-pool return skipped for %s: %v\n", borrowedPool.Entry.LeaseID, coordErr)
-			if failure == nil {
+			if failure == nil && scrubErr == nil {
 				err = coordErr
 			}
 			return
 		}
 		if readyPoolReturnNeedsHydrationStop(result) {
-			a.writeActionsHydrationStopBestEffort(context.Background(), target, borrowedPool.Entry.LeaseID)
+			a.writeActionsHydrationStopBestEffort(context.WithoutCancel(ctx), target, borrowedPool.Entry.LeaseID)
 		}
-		if _, returnErr := coord.ReturnReadyPoolLease(context.Background(), borrowedPool.Entry.Key, borrowedPool.Entry.LeaseID, result, readyPoolRunReturnReason(failure), borrowedPool.Entry.BorrowToken); returnErr != nil {
+		returnCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		_, returnErr := coord.ReturnReadyPoolLease(returnCtx, borrowedPool.Entry.Key, borrowedPool.Entry.LeaseID, result, reason, borrowedPool.Entry.BorrowToken)
+		cancel()
+		if returnErr != nil {
 			fmt.Fprintf(a.Stderr, "warning: ready-pool return failed for %s: %v\n", borrowedPool.Entry.LeaseID, returnErr)
-			if failure == nil {
+			if failure == nil && scrubErr == nil {
 				err = returnErr
 			}
 			return
@@ -887,11 +924,11 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	}
 	timings := runTimings{started: time.Now()}
 	exitNodeEgressChecked := false
-	workdir := remoteJoin(cfg, leaseID, repo.Name)
+	workdir = remoteJoin(cfg, leaseID, repo.Name)
 	actionsEnvFile := ""
 	profileEnvFile := ""
 	actionsURL := ""
-	hydratedByActions := false
+	hydratedByActions = false
 	autoHydrateActions := shouldAutoHydrateActions(cfg, *noHydrate, *noSync, freshPR, *syncOnly)
 	if !freshPR.Empty() {
 		workdir = remoteJoin(cfg, leaseID, freshPR.WorkdirName())
@@ -1540,6 +1577,7 @@ afterSync:
 		}
 	}
 	code, streamErr := runSSHStreamResult(ctx, target, remote, stdout, stderr)
+	ordinaryRemoteCommandFailure := readyPoolOrdinaryRemoteCommandFailure(code, streamErr, ctx.Err())
 	if err := streamCaptures.closeAfterStream(streamErr, code, a.Stderr); err != nil {
 		return recordFailure(err)
 	}
@@ -1738,8 +1776,10 @@ afterSync:
 			return recordFailure(artifactFailure)
 		}
 		if testResultsFailure != nil {
+			poolOrdinaryCommandFailure = ordinaryRemoteCommandFailure
 			return recordFailure(testResultsFailure)
 		}
+		poolOrdinaryCommandFailure = ordinaryRemoteCommandFailure
 		return recordFailure(ExitError{Code: code, Message: fmt.Sprintf("remote command exited %d", code)})
 	}
 	return nil


### PR DESCRIPTION
Related: https://github.com/openclaw/crabbox/issues/1074

## Summary

- scrub reusable ready-pool leases back to the latest recorded branch before returning them ready
- preserve ordinary remote command exit codes while draining leases on transport, lifecycle, cleanup, or metadata failures
- restore the caller's credential-free canonical origin through isolated Git metadata, remove task artifacts, preserve ignored dependency caches, and verify the final checkout
- document the return and exact-commit behavior

## Why

A pooled task could leave its feature branch, dirty files, or poisoned Git configuration behind while the coordinator still advertised the lease as a clean `main` box. The next borrower could therefore receive stale or attacker-controlled task state.

## Verification

- `go test ./...`
- focused ready-pool/scrub regression suite
- `git diff --check`
- source-blind live AWS `m7i.4xlarge` canary, twice: poisoned origin/config and dirty task state removed; latest `main` restored; explicit ignored dependency cache preserved; lease returned ready, inspected without sync, then released with zero active canary leases
- `go vet ./...`
- fresh autoreview after accepted security/lifecycle fixes: clean, no findings

The AWS SSH path normalized a direct remote `exit 23` to process exit `1`; the command still remained failed and the reusable-return classification stayed correct. Exact nonstandard exit-code propagation is pre-existing provider behavior and outside this scrub change.

No configuration or secret changes. No coordinator protocol change.

AI-assisted: yes. Maintainer-directed design, implementation, tests, live validation, and review.
