### PR TITLE
fix: prevent unsafe ready-pool lease reuse

### DIFF
--- a/.github/workflows/hydrate.yml
+++ b/.github/workflows/hydrate.yml
@@ -75,6 +75,7 @@ jobs:
           } > "$env_file"
           {
             echo "WORKSPACE=${GITHUB_WORKSPACE}"
+            echo "COMMIT=$(git -C "$GITHUB_WORKSPACE" rev-parse HEAD)"
             echo "RUN_ID=${GITHUB_RUN_ID}"
             echo "JOB=${CRABBOX_JOB}"
             echo "ENV_FILE=${env_file}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - Protected portal and isolated Code sessions with browser-enforced host-only cookies, rejected duplicate session cookies, and retired legacy cookie names to prevent sibling-origin shadowing. Thanks @coygeek.
 
+### Fixed
+
+- Scrubbed successful ready-pool workspaces through credential-free branch recovery and commit-bound Actions hydration, while draining failed or unverifiable leases before return.
+
 ## 0.38.0 - 2026-07-11
 
 ### Added

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -44,20 +44,26 @@ With `--pool <key>`, Crabbox borrows one hydrated broker ready-pool lease,
 uses the pool-recorded SSH endpoint, runs the command, and returns the lease.
 Before a reusable return, Crabbox resets the checkout to the pool's recorded
 branch, fetches its latest remote commit, removes run-local state, and verifies
-the normal Git worktree is clean. The default `--pool-return auto` returns the
-lease after that scrub even when the user command fails; lifecycle or scrub
-failures drain the lease so a bad machine is not reused. Ignored task state is
-removed; explicitly ignored dependency caches such as `node_modules` remain
-warm. Submodule worktrees drain instead of being reused. Reuse
+the normal Git worktree is clean. The default `--pool-return auto` scrubs and
+returns successful runs; command, lifecycle, or scrub failures drain the lease
+so a bad or de-hydrated machine is not reused. Ignored task state is removed.
+Successful runs may retain explicitly ignored dependency install trees.
+Actions-hydrated leases drain if
+their recorded hydration commit no longer matches the prepared branch commit.
+Submodule worktrees drain instead of being reused. Reuse
 requires a canonical HTTPS origin that succeeds
 through a credential-free fetch preflight before the lease is borrowed. SSH,
-local/file, and private credential-backed origins are rejected; use a forced
+local/file, query/fragment-bearing, and private credential-backed origins are rejected; use a forced
 `drain` or `release` return policy for those repositories. Use
 `--pool-return ready|drain|release` to override the
 lifecycle policy for one run; `ready` still requires a successful scrub. See
 [Broker ready pools](../spec/broker.md).
-Pooled runs reject `--full-resync`/`--fresh-sync`. With `--no-sync`, pooled
-borrows require an exact commit match. Pooled runs also reject `--keep` and
+Pooled runs reject `--full-resync`/`--fresh-sync`. Reusable pooled runs require
+a branch ref. With `--no-sync`, pooled borrows also require an exact commit
+match. Use a forced `drain` or `release` policy for exact SHA or tag refs.
+Reusable pooled runs also reject `--fresh-pr`; use a forced drain or release
+for one-shot PR work.
+Pooled runs also reject `--keep` and
 `--keep-on-failure`; use `--pool-return ready|drain|release` for lifecycle.
 
 On coordinator-backed one-shot runs, if SSH becomes unavailable after a

--- a/docs/spec/broker.md
+++ b/docs/spec/broker.md
@@ -123,6 +123,11 @@ Images are the base layer: operating system, runner user, SSH, language
 toolchains, package managers, Docker, and heavy system packages. Actions
 hydration is the repo layer: checkout, dependency install, generated caches,
 and project-specific setup from the same workflow that CI uses.
+The hydration marker records the checked-out commit so return-time scrub can
+drain a lease whose branch advanced beyond its prepared dependency state.
+Legacy or custom markers without the commit field drain on return; regenerate
+the workflow with `crabbox init --force` or add the checked-out `COMMIT` field
+before replenishing the pool.
 
 When the repository's main ref moves, new pool entries should hydrate the new
 commit. Existing ready entries with older commits can serve only requests that
@@ -134,8 +139,8 @@ their current borrow or idle window.
 `crabbox run --pool` defaults to `--pool-return auto`:
 
 - command success: scrub the checkout, then return `ready`
-- ordinary nonzero command exit: preserve the command failure, scrub the
-  checkout, then return `ready`
+- ordinary nonzero command exit: preserve the command failure and return
+  `drain`
 - transport, cancellation, stream/capture, artifact, or other lifecycle
   failure, failed scrub, SSH failure during scrub, or failed hydration marker
   verification: return `drain`
@@ -145,14 +150,16 @@ their current borrow or idle window.
 
 Before borrow, Crabbox captures a canonical origin from the local checkout and
 proves its HTTPS origin supports a credential-free fetch. Reusable pools reject
-SSH, local/file, and private credential-backed origins; forced `drain` and
+SSH, local/file, query/fragment-bearing, and private credential-backed origins; forced `drain` and
 `release` policies do not need that contract. The scrub replaces task-mutable
 remote Git metadata from the trusted origin, fetches the pool entry's recorded
 branch, resets tracked and non-ignored untracked files, removes Crabbox
 run-local state, and clears stale sync metadata before verifying the prepared
-commit and clean worktree. Ignored task state is removed; only explicit cache
-paths that the repository itself ignores remain available. Submodule worktrees
-drain instead of being reused. Ready-pool reuse is for trusted workloads; this
+commit and clean worktree. Ignored task state is removed, while successful
+commands may retain explicitly ignored dependency install trees. An
+Actions-hydrated entry remains reusable only while its recorded hydration
+commit matches the prepared branch commit. Submodule worktrees drain instead
+of being reused. Ready-pool reuse is for trusted workloads; this
 scrub prevents task-state confusion, not cross-tenant isolation or a hermetic
 host reset. Every entry advances to the latest remote branch
 commit. If that moves an exact-commit
@@ -162,8 +169,9 @@ later exact `--no-sync` borrow cannot use stale metadata.
 Reusable returns keep the lease active and borrowable. Drained returns are no
 longer borrowable and release the cloud machine to avoid poisoning the pool.
 Pooled runs reject full resync because that can replace the hydrated workspace.
-Pooled `--no-sync` runs require an exact commit match and do not borrow ref-only
-entries.
+Reusable pooled runs require a branch ref. Pooled `--no-sync` runs also require
+an exact commit match and do not borrow ref-only entries. Exact SHA and tag refs
+require a forced `drain` or `release` policy.
 
 ## Provider contract
 

--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -2163,6 +2163,7 @@ func githubActionsLeaseLabel(leaseID string) string {
 
 type actionsHydrationState struct {
 	Workspace    string
+	Commit       string
 	RunID        string
 	ReadyAt      string
 	Job          string
@@ -2290,6 +2291,8 @@ func parseActionsHydrationState(value string) actionsHydrationState {
 		switch key {
 		case "WORKSPACE":
 			state.Workspace = strings.TrimSpace(val)
+		case "COMMIT":
+			state.Commit = strings.TrimSpace(val)
 		case "RUN_ID":
 			state.RunID = strings.TrimSpace(val)
 		case "READY_AT":

--- a/internal/cli/actions_test.go
+++ b/internal/cli/actions_test.go
@@ -1266,8 +1266,8 @@ func TestLocalActionsRuntimeValidatesGoAndPythonVersions(t *testing.T) {
 }
 
 func TestParseActionsHydrationState(t *testing.T) {
-	got := parseActionsHydrationState("WORKSPACE=/home/runner/work/repo/repo\nRUN_ID=123\nJOB=hydrate\nENV_FILE=/home/runner/.crabbox/actions/cbx-123.env.sh\nSERVICES_FILE=/home/runner/.crabbox/actions/cbx-123.services\nREADY_AT=2026-05-01T00:00:00Z\n")
-	if got.Workspace != "/home/runner/work/repo/repo" || got.RunID != "123" || got.Job != "hydrate" || got.EnvFile == "" || got.ServicesFile == "" || got.ReadyAt == "" {
+	got := parseActionsHydrationState("WORKSPACE=/home/runner/work/repo/repo\nCOMMIT=0123456789abcdef0123456789abcdef01234567\nRUN_ID=123\nJOB=hydrate\nENV_FILE=/home/runner/.crabbox/actions/cbx-123.env.sh\nSERVICES_FILE=/home/runner/.crabbox/actions/cbx-123.services\nREADY_AT=2026-05-01T00:00:00Z\n")
+	if got.Workspace != "/home/runner/work/repo/repo" || got.Commit != "0123456789abcdef0123456789abcdef01234567" || got.RunID != "123" || got.Job != "hydrate" || got.EnvFile == "" || got.ServicesFile == "" || got.ReadyAt == "" {
 		t.Fatalf("unexpected hydration state: %#v", got)
 	}
 }

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -244,8 +244,10 @@ jobs:
           } > "${services_file}.tmp"
           mv "${services_file}.tmp" "$services_file"
           tmp="${state}.tmp"
+          commit="$(git -C "$GITHUB_WORKSPACE" rev-parse HEAD)"
           {
             echo "WORKSPACE=${GITHUB_WORKSPACE}"
+            echo "COMMIT=${commit}"
             echo "RUN_ID=${GITHUB_RUN_ID}"
             echo "JOB=${job}"
             echo "ENV_FILE=${env_file}"

--- a/internal/cli/ready_pool.go
+++ b/internal/cli/ready_pool.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os/exec"
 	"strconv"
 	"strings"
 	"time"
@@ -421,48 +420,47 @@ func readyPoolRunNeedsTrustedRemote(policy string) bool {
 	}
 }
 
-func readyPoolRunShouldScrub(policy string, runFailure error, ordinaryCommandFailure bool) bool {
+func readyPoolRunShouldScrub(policy string, runFailure error) bool {
 	switch strings.TrimSpace(policy) {
 	case "drain", "release":
 		return false
 	case "ready", "", "auto":
-		return runFailure == nil || ordinaryCommandFailure
+		return runFailure == nil
 	default:
 		return false
 	}
 }
 
-func readyPoolRunReturnResult(policy string, runFailure error, ordinaryCommandFailure bool, scrubErr error, metadataCompatible bool) string {
+func readyPoolRunReturnResult(policy string, runFailure error, scrubErr error, metadataCompatible bool) string {
 	switch strings.TrimSpace(policy) {
 	case "drain", "release":
 		return strings.TrimSpace(policy)
 	case "ready":
-		if readyPoolRunShouldScrub(policy, runFailure, ordinaryCommandFailure) && scrubErr == nil && metadataCompatible {
+		if readyPoolRunShouldScrub(policy, runFailure) && scrubErr == nil && metadataCompatible {
 			return "ready"
 		}
 		return "drain"
 	case "", "auto":
-		if readyPoolRunShouldScrub(policy, runFailure, ordinaryCommandFailure) && scrubErr == nil && metadataCompatible {
+		if readyPoolRunShouldScrub(policy, runFailure) && scrubErr == nil && metadataCompatible {
 			return "ready"
 		}
 		return "drain"
 	default:
 		return "drain"
 	}
-}
-
-func readyPoolOrdinaryRemoteCommandFailure(code int, streamErr, contextErr error) bool {
-	var exitErr *exec.ExitError
-	return contextErr == nil &&
-		asExitError(streamErr, &exitErr) &&
-		exitErr.ProcessState != nil &&
-		exitErr.ProcessState.ExitCode() >= 0 &&
-		code > 0 && code < 255
 }
 
 func readyPoolPreparedCommitMatches(recordedCommit, preparedCommit string) bool {
 	recordedCommit = strings.TrimSpace(recordedCommit)
 	return recordedCommit == "" || strings.EqualFold(recordedCommit, strings.TrimSpace(preparedCommit))
+}
+
+func readyPoolEntryRequiresHydration(entry CoordinatorReadyPoolEntry) bool {
+	return strings.TrimSpace(entry.Commit) == ""
+}
+
+func readyPoolRunRequiresHydrationProof(entry CoordinatorReadyPoolEntry, hydratedByActions bool) bool {
+	return hydratedByActions || readyPoolEntryRequiresHydration(entry)
 }
 
 func readyPoolReturnNeedsHydrationStop(result string) bool {
@@ -484,7 +482,7 @@ func readyPoolRunReturnReason(runFailure error, result, preparedCommit string, s
 		return "pool scrub failed"
 	}
 	if !metadataCompatible {
-		return "pool branch advanced beyond recorded commit"
+		return "pool hydration or recorded commit is stale"
 	}
 	if runFailure != nil {
 		return "run lifecycle failed"

--- a/internal/cli/ready_pool_scrub.go
+++ b/internal/cli/ready_pool_scrub.go
@@ -27,13 +27,13 @@ func trustedReadyPoolRemoteURL(remoteURL string) (string, error) {
 		return "", exit(7, "ready-pool reuse could not normalize the local Git origin")
 	}
 	parsed, err := url.Parse(canonical)
-	if err != nil || parsed.User != nil || parsed.Scheme != "https" || parsed.Host == "" {
+	if err != nil || parsed.User != nil || parsed.Scheme != "https" || parsed.Host == "" || parsed.RawQuery != "" || parsed.Fragment != "" || parsed.Opaque != "" {
 		return "", exit(7, "ready-pool reuse requires an anonymously fetchable HTTPS Git origin")
 	}
 	return canonical, nil
 }
 
-func preflightReadyPoolRemote(ctx context.Context, remoteURL string) error {
+func preflightReadyPoolRemote(ctx context.Context, remoteURL, branch string) error {
 	preflightCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 	workdir, err := os.MkdirTemp("", "crabbox-ready-pool-preflight-")
@@ -45,7 +45,7 @@ func preflightReadyPoolRemote(ctx context.Context, remoteURL string) error {
 	if runtime.GOOS == "windows" {
 		configNull = "NUL"
 	}
-	cmd := exec.CommandContext(preflightCtx, "git", "-c", "credential.helper=", "ls-remote", remoteURL)
+	cmd := exec.CommandContext(preflightCtx, "git", "-c", "credential.helper=", "ls-remote", "--exit-code", remoteURL, "refs/heads/"+branch)
 	cmd.Dir = workdir
 	cmd.Env = []string{
 		"HOME=" + workdir,
@@ -63,16 +63,16 @@ func preflightReadyPoolRemote(ctx context.Context, remoteURL string) error {
 	return nil
 }
 
-func (a App) scrubReadyPoolLease(ctx context.Context, target SSHTarget, entry CoordinatorReadyPoolEntry, workdir, trustedRemoteURL string, requireActionsHydration bool) (string, error) {
+func (a App) scrubReadyPoolLease(ctx context.Context, target SSHTarget, entry CoordinatorReadyPoolEntry, workdir, trustedRemoteURL string, requireActionsHydration bool) (string, bool, error) {
 	if strings.TrimSpace(workdir) == "" {
-		return "", exit(7, "ready-pool scrub has no remote workdir")
+		return "", false, exit(7, "ready-pool scrub has no remote workdir")
 	}
 	branch, err := readyPoolScrubBranch(entry.Ref)
 	if err != nil {
-		return "", exit(7, "ready-pool scrub requires a branch ref")
+		return "", false, exit(7, "ready-pool scrub requires a branch ref")
 	}
 	if strings.TrimSpace(trustedRemoteURL) == "" {
-		return "", exit(7, "ready-pool scrub has no trusted Git origin")
+		return "", false, exit(7, "ready-pool scrub has no trusted Git origin")
 	}
 	command := remoteReadyPoolScrub(workdir, branch, trustedRemoteURL)
 	if isWindowsNativeTarget(target) {
@@ -80,22 +80,26 @@ func (a App) scrubReadyPoolLease(ctx context.Context, target SSHTarget, entry Co
 	}
 	out, err := runSSHOutput(ctx, target, command)
 	if err != nil {
-		return "", exit(7, "ready-pool scrub failed on %s: %v", target.Host, err)
+		return "", false, exit(7, "ready-pool scrub failed on %s: %v", target.Host, err)
 	}
 	preparedCommit := strings.TrimSpace(out)
 	if !isGitCommitSHA(preparedCommit) {
-		return "", exit(7, "ready-pool scrub did not report one valid prepared commit")
+		return "", false, exit(7, "ready-pool scrub did not report one valid prepared commit")
 	}
-	if requireActionsHydration {
-		state, err := readActionsHydrationState(ctx, target, entry.LeaseID)
-		if err != nil {
-			return "", exit(7, "read ready-pool Actions hydration marker: %v", err)
-		}
-		if strings.TrimSpace(state.Workspace) == "" || strings.TrimSpace(state.Workspace) != strings.TrimSpace(workdir) {
-			return "", exit(7, "ready-pool Actions hydration marker no longer owns the prepared workspace")
-		}
+	hydrationCompatible := true
+	state, err := readActionsHydrationState(ctx, target, entry.LeaseID)
+	if err != nil {
+		return "", false, exit(7, "read ready-pool Actions hydration marker: %v", err)
 	}
-	return preparedCommit, nil
+	if strings.TrimSpace(state.Workspace) != "" {
+		if strings.TrimSpace(state.Workspace) != strings.TrimSpace(workdir) {
+			return "", false, exit(7, "ready-pool Actions hydration marker no longer owns the prepared workspace")
+		}
+		hydrationCompatible = isGitCommitSHA(state.Commit) && strings.EqualFold(state.Commit, preparedCommit)
+	} else if requireActionsHydration {
+		return "", false, exit(7, "ready-pool entry requires an Actions hydration marker")
+	}
+	return preparedCommit, hydrationCompatible, nil
 }
 
 func readyPoolScrubBranch(ref string) (string, error) {

--- a/internal/cli/ready_pool_scrub.go
+++ b/internal/cli/ready_pool_scrub.go
@@ -168,28 +168,42 @@ if safe_git ls-files --stage | awk '$1 == "160000" { found=1 } END { exit !found
   exit 1
 fi
 clean_args=(-ffdx --quiet)
-for cache_path in node_modules .pnpm-store .yarn/cache .yarn/unplugged; do
-  if [ -e "$cache_path" ]; then
-    if safe_git check-ignore -q -- "$cache_path"; then
-      if [ -L "$cache_path" ] || [ ! -d "$cache_path" ]; then
-        echo "ready-pool cache root must be a real directory" >&2
-        exit 1
-      fi
-      resolved_cache="$(cd -P -- "$cache_path" && pwd -P)"
-      case "$resolved_cache/" in
-        "$workdir"/*) ;;
-        *)
-          echo "ready-pool cache root escapes the workspace" >&2
-          exit 1
-          ;;
-      esac
-      clean_args+=(-e "$cache_path/")
-    elif [ "$?" -ne 1 ]; then
-      echo "ready-pool cache ignore check failed" >&2
+cache_paths=".git/crabbox-cache-paths.$$"
+trap 'rm -f -- "$cache_paths"' EXIT
+if ! /usr/bin/find -P . \( -ipath './.git' -o -ipath './.crabbox' \) -prune -o \( -type d -o -type l \) \( -iname node_modules -o -iname .pnpm-store -o -ipath '*/.yarn/cache' -o -ipath '*/.yarn/unplugged' \) -print0 -prune > "$cache_paths"; then
+  echo "ready-pool cache discovery failed" >&2
+  exit 1
+fi
+while IFS= read -r -d '' cache_path; do
+  cache_path="${cache_path#./}"
+  if safe_git check-ignore -q -- "$cache_path"; then
+    if [ -L "$cache_path" ] || [ ! -d "$cache_path" ]; then
+      echo "ready-pool cache root must be a real directory" >&2
       exit 1
     fi
+    resolved_cache="$(cd -P -- "$cache_path" && pwd -P)"
+    case "$resolved_cache/" in
+      "$workdir"/*) ;;
+      *)
+        echo "ready-pool cache root escapes the workspace" >&2
+        exit 1
+        ;;
+    esac
+    cache_pattern="${cache_path//\\/\\\\}"
+    cache_pattern="${cache_pattern//\*/\\*}"
+    cache_pattern="${cache_pattern//\?/\\?}"
+    cache_pattern="${cache_pattern//\[/\\[}"
+    cache_pattern="${cache_pattern//\]/\\]}"
+    cache_pattern="${cache_pattern//!/\\!}"
+    cache_pattern="${cache_pattern//#/\\#}"
+    clean_args+=(-e "$cache_pattern/")
+  elif [ "$?" -ne 1 ]; then
+    echo "ready-pool cache ignore check failed" >&2
+    exit 1
   fi
-done
+done < "$cache_paths"
+rm -f -- "$cache_paths"
+trap - EXIT
 safe_git clean "${clean_args[@]}"
 if [ -L .crabbox ]; then
   echo "ready-pool .crabbox root must not be a symlink" >&2
@@ -305,23 +319,44 @@ $gitlinks = @(& $git ls-files --stage | Where-Object { $_ -match '^160000 ' })
 if ($LASTEXITCODE -ne 0) { throw "ready-pool gitlink inspection failed" }
 if ($gitlinks.Count -ne 0) { throw "ready-pool scrub does not reuse submodule worktrees" }
 $cleanArgs = @('clean', '-ffdx', '--quiet')
-foreach ($cachePath in @('node_modules', '.pnpm-store', '.yarn/cache', '.yarn/unplugged')) {
-  if (Test-Path -LiteralPath $cachePath) {
-    & $git check-ignore -q -- $cachePath
-    if ($LASTEXITCODE -eq 0) {
-      $cacheCursor = $workdir
-      foreach ($segment in ($cachePath -split '/')) {
-        $cacheCursor = Join-Path $cacheCursor $segment
-        $cacheItem = Get-Item -LiteralPath $cacheCursor -Force
-        if ($cacheItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) {
-          throw "ready-pool cache root must not contain reparse points"
-        }
-      }
-      if (-not $cacheItem.PSIsContainer) { throw "ready-pool cache root must be a real directory" }
-      $cleanArgs += @('-e', "$cachePath/")
-    } elseif ($LASTEXITCODE -ne 1) {
-      throw "ready-pool cache ignore check failed"
+$pendingDirectories = New-Object 'System.Collections.Generic.Stack[System.IO.DirectoryInfo]'
+$cacheCandidates = New-Object 'System.Collections.Generic.List[string]'
+$pendingDirectories.Push((Get-Item -LiteralPath $workdir -Force))
+while ($pendingDirectories.Count -ne 0) {
+  $directory = $pendingDirectories.Pop()
+  foreach ($item in $directory.EnumerateFileSystemInfos()) {
+    $relative = $item.FullName.Substring($workdir.Length).TrimStart([char[]]@('\', '/'))
+    $normalized = $relative.Replace('\', '/')
+    if ($normalized -ieq '.git' -or $normalized -ieq '.crabbox') { continue }
+    $isCache = ($normalized -ieq 'node_modules' -or $normalized.EndsWith('/node_modules', [System.StringComparison]::OrdinalIgnoreCase) -or
+      $normalized -ieq '.pnpm-store' -or $normalized.EndsWith('/.pnpm-store', [System.StringComparison]::OrdinalIgnoreCase) -or
+      $normalized -ieq '.yarn/cache' -or $normalized.EndsWith('/.yarn/cache', [System.StringComparison]::OrdinalIgnoreCase) -or
+      $normalized -ieq '.yarn/unplugged' -or $normalized.EndsWith('/.yarn/unplugged', [System.StringComparison]::OrdinalIgnoreCase))
+    if ($isCache) {
+      $cacheCandidates.Add($normalized)
+      continue
     }
+    if ($item -is [System.IO.DirectoryInfo] -and -not ($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint)) {
+      $pendingDirectories.Push($item)
+    }
+  }
+}
+foreach ($cachePath in $cacheCandidates) {
+  & $git check-ignore -q -- $cachePath
+  if ($LASTEXITCODE -eq 0) {
+    $cacheCursor = $workdir
+    foreach ($segment in ($cachePath -split '/')) {
+      $cacheCursor = Join-Path $cacheCursor $segment
+      $cacheItem = Get-Item -LiteralPath $cacheCursor -Force
+      if ($cacheItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) {
+        throw "ready-pool cache root must not contain reparse points"
+      }
+    }
+    if (-not $cacheItem.PSIsContainer) { throw "ready-pool cache root must be a real directory" }
+    $cachePattern = $cachePath.Replace('\', '\\').Replace('*', '\*').Replace('?', '\?').Replace('[', '\[').Replace(']', '\]').Replace('!', '\!').Replace('#', '\#')
+    $cleanArgs += @('-e', "$cachePattern/")
+  } elseif ($LASTEXITCODE -ne 1) {
+    throw "ready-pool cache ignore check failed"
   }
 }
 & $git @cleanArgs

--- a/internal/cli/ready_pool_scrub_test.go
+++ b/internal/cli/ready_pool_scrub_test.go
@@ -244,7 +244,7 @@ func TestRemoteReadyPoolScrubUsesIsolatedTrustedGitMetadata(t *testing.T) {
 }
 
 func TestTrustedReadyPoolRemoteURL(t *testing.T) {
-	for _, value := range []string{"", "https://user@example.com/org/repo.git", "ssh://git@example.com/org/repo.git"} {
+	for _, value := range []string{"", "https://user@example.com/org/repo.git", "https://example.com/org/repo.git?access_token=secret", "https://example.com/org/repo.git#token", "ssh://git@example.com/org/repo.git"} {
 		if _, err := trustedReadyPoolRemoteURL(value); err == nil {
 			t.Fatalf("unsafe origin %q was accepted", value)
 		}
@@ -433,14 +433,19 @@ func TestPreflightReadyPoolRemoteRequiresAnonymousFetch(t *testing.T) {
 	if out, err := clone.CombinedOutput(); err != nil {
 		t.Fatalf("create bare origin: %v\n%s", err, out)
 	}
-	if err := preflightReadyPoolRemote(context.Background(), origin); err != nil {
+	if err := preflightReadyPoolRemote(context.Background(), origin, "main"); err != nil {
 		t.Fatalf("anonymous local origin rejected: %v", err)
 	}
 	runGit(t, origin, "symbolic-ref", "HEAD", "refs/heads/missing")
-	if err := preflightReadyPoolRemote(context.Background(), origin); err != nil {
+	if err := preflightReadyPoolRemote(context.Background(), origin, "main"); err != nil {
 		t.Fatalf("anonymous origin without advertised HEAD rejected: %v", err)
 	}
-	if err := preflightReadyPoolRemote(context.Background(), filepath.Join(root, "missing.git")); err == nil {
+	runGit(t, source, "tag", "--no-sign", "v1.0.0")
+	runGit(t, source, "push", origin, "refs/tags/v1.0.0")
+	if err := preflightReadyPoolRemote(context.Background(), origin, "v1.0.0"); err == nil {
+		t.Fatal("tag-only ref passed reusable branch preflight")
+	}
+	if err := preflightReadyPoolRemote(context.Background(), filepath.Join(root, "missing.git"), "main"); err == nil {
 		t.Fatal("missing origin passed anonymous fetch preflight")
 	}
 }

--- a/internal/cli/ready_pool_scrub_test.go
+++ b/internal/cli/ready_pool_scrub_test.go
@@ -25,6 +25,8 @@ func TestRemoteReadyPoolScrubResetsLatestBranchAndPreservesIgnoredCaches(t *test
 	runGit(t, source, "branch", "-M", "main")
 	mustWriteTestFile(t, filepath.Join(source, ".gitignore"), "node_modules/\n*.ignored\n")
 	mustWriteTestFile(t, filepath.Join(source, "proof.txt"), "base\n")
+	mustWriteTestFile(t, filepath.Join(source, "worker", "README.md"), "worker\n")
+	mustWriteTestFile(t, filepath.Join(source, "packages", "app[1]", "README.md"), "app\n")
 	runGit(t, source, "add", ".")
 	runGit(t, source, "commit", "-m", "base")
 	baseCommit := gitOutput(source, "rev-parse", "HEAD")
@@ -49,6 +51,8 @@ func TestRemoteReadyPoolScrubResetsLatestBranchAndPreservesIgnoredCaches(t *test
 	mustWriteTestFile(t, filepath.Join(workdir, "proof.txt"), "dirty feature\n")
 	mustWriteTestFile(t, filepath.Join(workdir, "untracked.txt"), "remove me\n")
 	mustWriteTestFile(t, filepath.Join(workdir, "node_modules", "cache.txt"), "keep me\n")
+	mustWriteTestFile(t, filepath.Join(workdir, "worker", "node_modules", "cache.txt"), "keep nested\n")
+	mustWriteTestFile(t, filepath.Join(workdir, "packages", "app[1]", "node_modules", "cache.txt"), "keep metachar\n")
 	mustWriteTestFile(t, filepath.Join(workdir, ".pnpm-store", "cache.txt"), "remove unless ignored\n")
 	mustWriteTestFile(t, filepath.Join(workdir, "task-state.ignored"), "remove me\n")
 	for _, name := range []string{"sync-fingerprint", "sync-manifest", "sync-manifest.new", "sync-deleted.new"} {
@@ -135,6 +139,14 @@ func TestRemoteReadyPoolScrubResetsLatestBranchAndPreservesIgnoredCaches(t *test
 	if string(cache) != "keep me\n" {
 		t.Fatalf("cache=%q", cache)
 	}
+	nestedCache, err := os.ReadFile(filepath.Join(workdir, "worker", "node_modules", "cache.txt"))
+	if err != nil || string(nestedCache) != "keep nested\n" {
+		t.Fatalf("nested ignored dependency cache was not preserved: data=%q err=%v", nestedCache, err)
+	}
+	metacharCache, err := os.ReadFile(filepath.Join(workdir, "packages", "app[1]", "node_modules", "cache.txt"))
+	if err != nil || string(metacharCache) != "keep metachar\n" {
+		t.Fatalf("metachar ignored dependency cache was not preserved: data=%q err=%v", metacharCache, err)
+	}
 	if _, err := os.Stat(filepath.Join(workdir, "task-state.ignored")); !os.IsNotExist(err) {
 		t.Fatalf("ignored task state remains: %v", err)
 	}
@@ -179,6 +191,9 @@ func TestWindowsRemoteReadyPoolScrubBuildsVerifiedReset(t *testing.T) {
 		"ready-pool scrub does not reuse submodule worktrees",
 		"$cleanArgs = @('clean', '-ffdx', '--quiet')",
 		"& $git check-ignore -q -- $cachePath",
+		"System.Collections.Generic.Stack[System.IO.DirectoryInfo]",
+		"$normalized.EndsWith('/node_modules', [System.StringComparison]::OrdinalIgnoreCase)",
+		"$cachePath.Replace('\\', '\\\\').Replace('*', '\\*')",
 		"$cachePath -split '/'",
 		"ready-pool cache root must not contain reparse points",
 		"[System.IO.FileAttributes]::ReparsePoint",
@@ -229,6 +244,11 @@ func TestRemoteReadyPoolScrubUsesIsolatedTrustedGitMetadata(t *testing.T) {
 		"safe_git branch --set-upstream-to=\"$remote_ref\" \"$ref\"",
 		"ready-pool scrub does not reuse submodule worktrees",
 		"safe_git check-ignore -q -- \"$cache_path\"",
+		"/usr/bin/find -P .",
+		"-iname node_modules",
+		"ready-pool cache discovery failed",
+		"*/.yarn/cache",
+		"cache_pattern=\"${cache_path//\\\\/\\\\\\\\}\"",
 		"ready-pool cache root must be a real directory",
 		"ready-pool cache root escapes the workspace",
 		"safe_git clean \"${clean_args[@]}\"",

--- a/internal/cli/ready_pool_test.go
+++ b/internal/cli/ready_pool_test.go
@@ -2,8 +2,6 @@ package cli
 
 import (
 	"errors"
-	"os/exec"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -100,58 +98,30 @@ func TestReadyPoolRunReturnDispositionRequiresScrubProof(t *testing.T) {
 		name            string
 		policy          string
 		runFailure      error
-		ordinaryFailure bool
 		scrubErr        error
 		wantScrub       bool
 		wantResult      string
 		metadataMatches bool
 	}{
 		{name: "success returns after scrub", policy: "auto", wantScrub: true, wantResult: "ready", metadataMatches: true},
-		{name: "command failure returns after scrub", policy: "auto", runFailure: runErr, ordinaryFailure: true, wantScrub: true, wantResult: "ready", metadataMatches: true},
-		{name: "command failure drains when scrub fails", policy: "auto", runFailure: runErr, ordinaryFailure: true, scrubErr: scrubErr, wantScrub: true, wantResult: "drain", metadataMatches: true},
-		{name: "advanced exact entry drains", policy: "auto", ordinaryFailure: true, wantScrub: true, wantResult: "drain"},
+		{name: "command failure drains without scrub", policy: "auto", runFailure: runErr, wantResult: "drain", metadataMatches: true},
+		{name: "advanced exact entry drains", policy: "auto", wantScrub: true, wantResult: "drain"},
 		{name: "transport failure drains", policy: "auto", runFailure: runErr, wantResult: "drain", metadataMatches: true},
 		{name: "lifecycle failure drains", policy: "auto", runFailure: runErr, wantResult: "drain", metadataMatches: true},
 		{name: "forced ready cannot override lifecycle failure", policy: "ready", runFailure: runErr, wantResult: "drain", metadataMatches: true},
-		{name: "forced ready still requires scrub", policy: "ready", runFailure: runErr, ordinaryFailure: true, scrubErr: scrubErr, wantScrub: true, wantResult: "drain", metadataMatches: true},
+		{name: "forced ready cannot reuse failed command", policy: "ready", runFailure: runErr, scrubErr: scrubErr, wantResult: "drain", metadataMatches: true},
 		{name: "explicit drain skips scrub", policy: "drain", wantResult: "drain", metadataMatches: true},
 		{name: "explicit release skips scrub", policy: "release", wantResult: "release", metadataMatches: true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := readyPoolRunShouldScrub(tc.policy, tc.runFailure, tc.ordinaryFailure); got != tc.wantScrub {
+			if got := readyPoolRunShouldScrub(tc.policy, tc.runFailure); got != tc.wantScrub {
 				t.Fatalf("readyPoolRunShouldScrub()=%v, want %v", got, tc.wantScrub)
 			}
-			if got := readyPoolRunReturnResult(tc.policy, tc.runFailure, tc.ordinaryFailure, tc.scrubErr, tc.metadataMatches); got != tc.wantResult {
+			if got := readyPoolRunReturnResult(tc.policy, tc.runFailure, tc.scrubErr, tc.metadataMatches); got != tc.wantResult {
 				t.Fatalf("readyPoolRunReturnResult()=%q, want %q", got, tc.wantResult)
 			}
 		})
-	}
-}
-
-func TestReadyPoolOrdinaryRemoteCommandFailure(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Unix process exit semantics")
-	}
-	exitErr := exec.Command("sh", "-c", "exit 1").Run()
-	if !readyPoolOrdinaryRemoteCommandFailure(1, exitErr, nil) {
-		t.Fatal("ordinary remote exit was treated as lifecycle failure")
-	}
-	if readyPoolOrdinaryRemoteCommandFailure(255, exitErr, nil) {
-		t.Fatal("SSH transport exit was treated as ordinary command failure")
-	}
-	if readyPoolOrdinaryRemoteCommandFailure(1, exitErr, errors.New("context canceled")) {
-		t.Fatal("canceled command was treated as ordinary command failure")
-	}
-	if readyPoolOrdinaryRemoteCommandFailure(0, nil, nil) {
-		t.Fatal("successful command was treated as ordinary command failure")
-	}
-	if readyPoolOrdinaryRemoteCommandFailure(1, errors.New("ssh executable missing"), nil) {
-		t.Fatal("SSH process failure was treated as ordinary command failure")
-	}
-	signaledErr := exec.Command("sh", "-c", "kill -TERM $$").Run()
-	if readyPoolOrdinaryRemoteCommandFailure(1, signaledErr, nil) {
-		t.Fatal("signaled SSH process was treated as ordinary command failure")
 	}
 }
 
@@ -163,7 +133,7 @@ func TestReadyPoolRunReturnReasonPreservesCommandOutcome(t *testing.T) {
 	if got := readyPoolRunReturnReason(nil, "drain", "", errors.New("scrub failed"), true); got != "pool scrub failed" {
 		t.Fatalf("scrub failure reason=%q", got)
 	}
-	if got := readyPoolRunReturnReason(nil, "drain", "", nil, false); got != "pool branch advanced beyond recorded commit" {
+	if got := readyPoolRunReturnReason(nil, "drain", "", nil, false); got != "pool hydration or recorded commit is stale" {
 		t.Fatalf("advanced commit reason=%q", got)
 	}
 }
@@ -177,5 +147,17 @@ func TestReadyPoolPreparedCommitMatches(t *testing.T) {
 	}
 	if readyPoolPreparedCommitMatches("old", "new") {
 		t.Fatal("advanced exact-commit entry remained reusable")
+	}
+}
+
+func TestReadyPoolEntryRequiresHydrationForRefOnlyEntries(t *testing.T) {
+	if !readyPoolEntryRequiresHydration(CoordinatorReadyPoolEntry{Ref: "main"}) {
+		t.Fatal("ref-only entry skipped hydration proof")
+	}
+	if readyPoolEntryRequiresHydration(CoordinatorReadyPoolEntry{Ref: "main", Commit: strings.Repeat("a", 40)}) {
+		t.Fatal("exact-commit entry unexpectedly required Actions hydration")
+	}
+	if !readyPoolRunRequiresHydrationProof(CoordinatorReadyPoolEntry{Ref: "main", Commit: strings.Repeat("a", 40)}, true) {
+		t.Fatal("exact-commit Actions run skipped hydration proof")
 	}
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -458,11 +458,15 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	}
 	trustedPoolRemoteURL := ""
 	if strings.TrimSpace(*readyPool) != "" && readyPoolRunNeedsTrustedRemote(*readyPoolReturn) {
+		poolBranch, branchErr := readyPoolScrubBranch(firstNonBlank(cfg.Actions.Ref, repo.BaseRef))
+		if branchErr != nil {
+			return exit(2, "reusable ready-pool runs require a branch ref; use --pool-return drain or release for exact SHA and tag refs")
+		}
 		trustedPoolRemoteURL, err = trustedReadyPoolRemoteURL(repo.RemoteURL)
 		if err != nil {
 			return err
 		}
-		if err := preflightReadyPoolRemote(ctx, trustedPoolRemoteURL); err != nil {
+		if err := preflightReadyPoolRemote(ctx, trustedPoolRemoteURL, poolBranch); err != nil {
 			return err
 		}
 	}
@@ -472,6 +476,9 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		return err
 	}
 	if !freshPR.Empty() {
+		if strings.TrimSpace(*readyPool) != "" && readyPoolRunNeedsTrustedRemote(*readyPoolReturn) {
+			return exit(2, "reusable ready-pool runs cannot use --fresh-pr; use --pool-return drain or release")
+		}
 		if *noSync {
 			return exit(2, "--fresh-pr cannot be combined with --no-sync")
 		}
@@ -540,7 +547,6 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	var runFailure error
 	var workdir string
 	var hydratedByActions bool
-	var poolOrdinaryCommandFailure bool
 	defer func() {
 		if borrowedPool == nil {
 			return
@@ -552,9 +558,10 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		var preparedCommit string
 		var scrubErr error
 		metadataCompatible := true
-		if readyPoolRunShouldScrub(*readyPoolReturn, failure, poolOrdinaryCommandFailure) {
+		if readyPoolRunShouldScrub(*readyPoolReturn, failure) {
 			scrubCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Minute)
-			preparedCommit, scrubErr = a.scrubReadyPoolLease(scrubCtx, target, borrowedPool.Entry, workdir, trustedPoolRemoteURL, hydratedByActions)
+			var hydrationCompatible bool
+			preparedCommit, hydrationCompatible, scrubErr = a.scrubReadyPoolLease(scrubCtx, target, borrowedPool.Entry, workdir, trustedPoolRemoteURL, readyPoolRunRequiresHydrationProof(borrowedPool.Entry, hydratedByActions))
 			cancel()
 			if scrubErr != nil {
 				fmt.Fprintf(a.Stderr, "warning: ready-pool scrub failed for %s: %v\n", borrowedPool.Entry.LeaseID, scrubErr)
@@ -562,14 +569,14 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 					err = readyPoolScrubLifecycleError(borrowedPool.Entry.LeaseID, scrubErr)
 				}
 			} else {
-				metadataCompatible = readyPoolPreparedCommitMatches(borrowedPool.Entry.Commit, preparedCommit)
+				metadataCompatible = hydrationCompatible && readyPoolPreparedCommitMatches(borrowedPool.Entry.Commit, preparedCommit)
 				fmt.Fprintf(a.Stderr, "scrubbed pool=%s lease=%s ref=%s commit=%s\n", borrowedPool.Entry.Key, borrowedPool.Entry.LeaseID, borrowedPool.Entry.Ref, preparedCommit)
 				if !metadataCompatible {
-					fmt.Fprintf(a.Stderr, "pool=%s lease=%s recorded_commit=%s advanced; draining stale exact-commit entry\n", borrowedPool.Entry.Key, borrowedPool.Entry.LeaseID, borrowedPool.Entry.Commit)
+					fmt.Fprintf(a.Stderr, "pool=%s lease=%s recorded_commit=%s hydration or commit metadata stale; draining entry\n", borrowedPool.Entry.Key, borrowedPool.Entry.LeaseID, borrowedPool.Entry.Commit)
 				}
 			}
 		}
-		result := readyPoolRunReturnResult(*readyPoolReturn, failure, poolOrdinaryCommandFailure, scrubErr, metadataCompatible)
+		result := readyPoolRunReturnResult(*readyPoolReturn, failure, scrubErr, metadataCompatible)
 		reason := readyPoolRunReturnReason(failure, result, preparedCommit, scrubErr, metadataCompatible)
 		coord, coordErr := readyPoolCoordinatorFromConfig(cfg)
 		if coordErr != nil {
@@ -932,18 +939,24 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	autoHydrateActions := shouldAutoHydrateActions(cfg, *noHydrate, *noSync, freshPR, *syncOnly)
 	if !freshPR.Empty() {
 		workdir = remoteJoin(cfg, leaseID, freshPR.WorkdirName())
-	} else if state, err := readActionsHydrationState(ctx, target, leaseID); err == nil && state.Workspace != "" {
-		workdir = state.Workspace
-		actionsEnvFile = state.EnvFile
-		if state.RunID != "" {
-			if ghRepo, err := resolveGitHubRepo(repo, cfg.Actions.Repo); err == nil {
-				actionsURL = actionsRunURL(ghRepo, state.RunID)
-			}
+	} else {
+		state, stateErr := readActionsHydrationState(ctx, target, leaseID)
+		if stateErr != nil && borrowedPool != nil && readyPoolRunNeedsTrustedRemote(*readyPoolReturn) {
+			return recordFailure(exit(7, "verify ready-pool Actions hydration marker: %v", stateErr))
 		}
-		hydratedByActions = true
-		fmt.Fprintf(a.Stderr, "using Actions workspace %s\n", workdir)
-	} else if commandNeedsHydrationHint(command, *shellMode) && cfg.Actions.Workflow != "" && !autoHydrateActions {
-		fmt.Fprintf(a.Stderr, "warning: no Actions hydration marker found for %s; JS package commands may fail on a raw box. Run \"crabbox actions hydrate --id %s\" first, omit --no-hydrate, or include runtime setup in the command.\n", leaseID, leaseID)
+		if stateErr == nil && state.Workspace != "" {
+			workdir = state.Workspace
+			actionsEnvFile = state.EnvFile
+			if state.RunID != "" {
+				if ghRepo, err := resolveGitHubRepo(repo, cfg.Actions.Repo); err == nil {
+					actionsURL = actionsRunURL(ghRepo, state.RunID)
+				}
+			}
+			hydratedByActions = true
+			fmt.Fprintf(a.Stderr, "using Actions workspace %s\n", workdir)
+		} else if commandNeedsHydrationHint(command, *shellMode) && cfg.Actions.Workflow != "" && !autoHydrateActions {
+			fmt.Fprintf(a.Stderr, "warning: no Actions hydration marker found for %s; JS package commands may fail on a raw box. Run \"crabbox actions hydrate --id %s\" first, omit --no-hydrate, or include runtime setup in the command.\n", leaseID, leaseID)
+		}
 	}
 	contextPrinted := false
 	preflightPrinted := false
@@ -1577,7 +1590,6 @@ afterSync:
 		}
 	}
 	code, streamErr := runSSHStreamResult(ctx, target, remote, stdout, stderr)
-	ordinaryRemoteCommandFailure := readyPoolOrdinaryRemoteCommandFailure(code, streamErr, ctx.Err())
 	if err := streamCaptures.closeAfterStream(streamErr, code, a.Stderr); err != nil {
 		return recordFailure(err)
 	}
@@ -1776,10 +1788,8 @@ afterSync:
 			return recordFailure(artifactFailure)
 		}
 		if testResultsFailure != nil {
-			poolOrdinaryCommandFailure = ordinaryRemoteCommandFailure
 			return recordFailure(testResultsFailure)
 		}
-		poolOrdinaryCommandFailure = ordinaryRemoteCommandFailure
 		return recordFailure(ExitError{Code: code, Message: fmt.Sprintf("remote command exited %d", code)})
 	}
 	return nil


### PR DESCRIPTION
Related: https://github.com/openclaw/crabbox/issues/1074

Follow-up to #1077, which merged while its final maintainer review was still running.

## What Problem This Solves

Fixes remaining cases where a reusable ready-pool lease could be returned after a failed run, reused for an exact commit without branch-liveness proof, or scrubbed while preserving unsafe or incomplete repository state.

## Why This Change Was Made

Reuse is now success-only and branch-bound. Failures drain the lease. Exact-commit and fresh-PR runs cannot reuse the pool. Hydration markers bind the workspace to the prepared commit. Scrubbing preserves complete Git history and validated dependency caches while rejecting filter-managed worktrees, symlink escapes, malformed origins, and stale branch state.

## User Impact

Operators can safely reuse ready-pool leases after successful branch runs. Failed, stale, or unverifiable leases are drained instead of silently re-entering the pool.

## Evidence

- `go test ./...`
- Branch-wide autoreview with `go test ./...`: clean, no actionable findings
- Focused scrub and ready-pool regression coverage for POSIX and Windows behavior, nested caches, marker binding, branch deletion, exact refs, Git filters, symlink/reparse escapes, and failure draining

