### PR TITLE
build: reauthorize 0.38.1 release

### DIFF
--- a/release/records/v0.38.1.json
+++ b/release/records/v0.38.1.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "repository": "openclaw/crabbox",
   "tag": "v0.38.1",
-  "tagObject": "b9c14e1943ec4a2ca394689a63e8a9c5318ff48c",
-  "sourceCommit": "72cd4d60c99068b229550bbca9f5a1302663fa72",
+  "tagObject": "326b5fa1e4f9543b11bde0583635f37d00f13f0a",
+  "sourceCommit": "3f83f4c58a65d2546620a8b31257f53375fabab2",
   "publicationStatus": "ready"
 }

--- a/scripts/release-workflow.test.js
+++ b/scripts/release-workflow.test.js
@@ -553,11 +553,11 @@ test("v0.38.0 is pinned to the corrected signed source and ready for publication
   assert.equal(record.publicationStatus, "ready");
 });
 
-test("v0.38.1 is pinned to the signed admission-metadata source and ready for publication", () => {
+test("v0.38.1 is pinned to the signed ready-pool source and ready for publication", () => {
   const record = JSON.parse(read("release/records/v0.38.1.json"));
   assert.equal(record.tag, "v0.38.1");
-  assert.equal(record.tagObject, "b9c14e1943ec4a2ca394689a63e8a9c5318ff48c");
-  assert.equal(record.sourceCommit, "72cd4d60c99068b229550bbca9f5a1302663fa72");
+  assert.equal(record.tagObject, "326b5fa1e4f9543b11bde0583635f37d00f13f0a");
+  assert.equal(record.sourceCommit, "3f83f4c58a65d2546620a8b31257f53375fabab2");
   assert.equal(record.publicationStatus, "ready");
 });
 


### PR DESCRIPTION
## What Problem This Solves

Reauthorizes the unpublished v0.38.1 release after the maintainer-directed tag rebase that included #1077 and #1078.

## Why This Change Was Made

The prior v0.38.1 tag was removed before any draft or public release existed. The replacement signed tag now binds the complete 0.38.1 source, including ready-pool lease scrubbing and its final lifecycle hardening. This updates the protected release record and its exact regression assertion to that new immutable identity.

## User Impact

The eventual 0.38.1 release will contain the complete ready-pool safety work. No published release or uploaded asset changed.

## Evidence

- Signed tag object: `326b5fa1e4f9543b11bde0583635f37d00f13f0a`
- Peeled source commit: `3f83f4c58a65d2546620a8b31257f53375fabab2`
- `git verify-tag v0.38.1` against `.github/release-allowed-signers`
- `scripts/verify-release-source.sh` with publishability required
- `node --test scripts/release-workflow.test.js` (19 passed)
- Mandatory autoreview: clean; no accepted/actionable findings

Config or secret implications: none. Release assets are not built or published by this PR.
