### PR TITLE
fix(release): preserve selected Xcode toolchain

### DIFF
--- a/scripts/build-release-candidate.sh
+++ b/scripts/build-release-candidate.sh
@@ -94,6 +94,14 @@ producer_arch=$(uname -m)
   echo "could not capture the Swift/Xcode producer toolchain" >&2
   exit 1
 }
+developer_env=()
+if [[ -n "${DEVELOPER_DIR:-}" ]]; then
+  [[ "$DEVELOPER_DIR" == /* && -d "$DEVELOPER_DIR" ]] || {
+    echo "DEVELOPER_DIR must be an absolute existing directory" >&2
+    exit 1
+  }
+  developer_env=(DEVELOPER_DIR="$DEVELOPER_DIR")
+fi
 git clone --quiet --no-local --no-checkout "$ROOT" "$SOURCE"
 git -C "$SOURCE" checkout --quiet --detach "$TAG_COMMIT"
 [[ "$(git -C "$SOURCE" rev-parse "refs/tags/$TAG")" == "$TAG_OBJECT" ]]
@@ -103,6 +111,7 @@ git -C "$SOURCE" checkout --quiet --detach "$TAG_COMMIT"
 (
   cd "$SOURCE"
   env -i \
+    "${developer_env[@]}" \
     GOCACHE="$WORK/gocache" \
     GOMODCACHE="$WORK/gomodcache" \
     GOPROXY=https://proxy.golang.org \

--- a/scripts/build-release-candidate.sh
+++ b/scripts/build-release-candidate.sh
@@ -94,13 +94,11 @@ producer_arch=$(uname -m)
   echo "could not capture the Swift/Xcode producer toolchain" >&2
   exit 1
 }
-developer_env=()
 if [[ -n "${DEVELOPER_DIR:-}" ]]; then
   [[ "$DEVELOPER_DIR" == /* && -d "$DEVELOPER_DIR" ]] || {
     echo "DEVELOPER_DIR must be an absolute existing directory" >&2
     exit 1
   }
-  developer_env=(DEVELOPER_DIR="$DEVELOPER_DIR")
 fi
 git clone --quiet --no-local --no-checkout "$ROOT" "$SOURCE"
 git -C "$SOURCE" checkout --quiet --detach "$TAG_COMMIT"
@@ -110,18 +108,24 @@ git -C "$SOURCE" checkout --quiet --detach "$TAG_COMMIT"
 
 (
   cd "$SOURCE"
-  env -i \
-    "${developer_env[@]}" \
-    GOCACHE="$WORK/gocache" \
-    GOMODCACHE="$WORK/gomodcache" \
-    GOPROXY=https://proxy.golang.org \
-    GOSUMDB=sum.golang.org \
-    GOTOOLCHAIN="$CRABBOX_RELEASE_GO_VERSION" \
-    GOWORK=off \
-    HOME="$BUILD_HOME" \
-    PATH="$PATH" \
-    TMPDIR="$BUILD_TMP" \
-    goreleaser release --clean --skip=publish --parallelism 1 --config "$ROOT/.goreleaser.yaml"
+  run_goreleaser() {
+    env -i "$@" \
+      GOCACHE="$WORK/gocache" \
+      GOMODCACHE="$WORK/gomodcache" \
+      GOPROXY=https://proxy.golang.org \
+      GOSUMDB=sum.golang.org \
+      GOTOOLCHAIN="$CRABBOX_RELEASE_GO_VERSION" \
+      GOWORK=off \
+      HOME="$BUILD_HOME" \
+      PATH="$PATH" \
+      TMPDIR="$BUILD_TMP" \
+      goreleaser release --clean --skip=publish --parallelism 1 --config "$ROOT/.goreleaser.yaml"
+  }
+  if [[ -n "${DEVELOPER_DIR:-}" ]]; then
+    run_goreleaser "DEVELOPER_DIR=$DEVELOPER_DIR"
+  else
+    run_goreleaser
+  fi
 )
 
 version=${TAG#v}

--- a/scripts/release-workflow.test.js
+++ b/scripts/release-workflow.test.js
@@ -76,8 +76,9 @@ test("GoReleaser is credential-free build-only with exact binary archives", () =
   assert.match(build, /env -i[\s\S]*goreleaser release --clean --skip=publish/);
   assert.match(build, /git clone --quiet --no-local --no-checkout/);
   assert.match(build, /git -C "\$SOURCE" checkout --quiet --detach "\$TAG_COMMIT"/);
-  assert.match(build, /developer_env=\(DEVELOPER_DIR="\$DEVELOPER_DIR"\)/);
-  assert.match(build, /env -i \\\n\s+"\$\{developer_env\[@\]\}"/);
+  assert.match(build, /run_goreleaser\(\) \{[\s\S]*env -i "\$@"/);
+  assert.match(build, /run_goreleaser "DEVELOPER_DIR=\$DEVELOPER_DIR"/);
+  assert.match(build, /else\s+run_goreleaser\s+fi/);
   assert.match(build, /chmod -R u\+w "\$path"[\s\S]*rm -rf "\$path"/);
   assert.doesNotMatch(build, /gh release|HOMEBREW_TAP_GITHUB_TOKEN=.*\$\{/);
 });

--- a/scripts/release-workflow.test.js
+++ b/scripts/release-workflow.test.js
@@ -76,6 +76,8 @@ test("GoReleaser is credential-free build-only with exact binary archives", () =
   assert.match(build, /env -i[\s\S]*goreleaser release --clean --skip=publish/);
   assert.match(build, /git clone --quiet --no-local --no-checkout/);
   assert.match(build, /git -C "\$SOURCE" checkout --quiet --detach "\$TAG_COMMIT"/);
+  assert.match(build, /developer_env=\(DEVELOPER_DIR="\$DEVELOPER_DIR"\)/);
+  assert.match(build, /env -i \\\n\s+"\$\{developer_env\[@\]\}"/);
   assert.match(build, /chmod -R u\+w "\$path"[\s\S]*rm -rf "\$path"/);
   assert.doesNotMatch(build, /gh release|HOMEBREW_TAP_GITHUB_TOKEN=.*\$\{/);
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where release operators selecting a specific Xcode installation with `DEVELOPER_DIR` would have that selection dropped during the isolated GoReleaser build, allowing Swift artifacts to use a different toolchain than the recorded producer facts.

## Why This Change Was Made

The credential-free producer now validates an optional absolute `DEVELOPER_DIR` and forwards it into the clean GoReleaser environment. An explicit wrapper preserves the default unset path without relying on empty-array expansion, which is unsafe under macOS Bash 3.2 with nounset enabled.

## User Impact

Release candidates use the same selected Xcode toolchain for captured provenance and Swift artifact production. Default builds without `DEVELOPER_DIR` continue working.

## Evidence

- Reproduced during the v0.38.1 credential-free candidate build
- `/bin/bash -n scripts/build-release-candidate.sh`
- Bash 3.2-safe unset and set wrapper probe
- `node --test scripts/release-workflow.test.js` (19 passed)
- Branch-wide mandatory autoreview: clean; no accepted/actionable findings

Config or secret implications: none. `DEVELOPER_DIR` remains optional and only enters the credential-free isolated producer environment.
