### PR TITLE
fix(release): use managed keychain for notarization

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -102,6 +102,11 @@ timestamp. Submit each raw binary with `notarytool --wait`, require an
 `Accepted` result and distinct valid submission ID, then perform the online
 raw-binary check before creating the archive:
 
+The notary profile must live in the same managed, passwordless release
+keychain as the Foundation signing identity. The signer passes that keychain
+explicitly so headless release hosts never fall back to a locked login
+keychain.
+
 ```sh
 codesign --verify --strict --check-notarization -R=notarized <binary>
 ```

--- a/scripts/codesign-macos.sh
+++ b/scripts/codesign-macos.sh
@@ -35,6 +35,10 @@ CODESIGN_IDENTITY=${CODESIGN_IDENTITY:-${MAC_RELEASE_CODESIGN_IDENTITY:-}}
   echo "NOTARYTOOL_KEYCHAIN_PROFILE is required for official macOS releases" >&2
   exit 1
 }
+[[ -n "${MAC_RELEASE_CODESIGN_KEYCHAIN:-}" ]] || {
+  echo "MAC_RELEASE_CODESIGN_KEYCHAIN is required for official macOS releases" >&2
+  exit 1
+}
 
 for tool in codesign csreq ditto lipo node plutil xcrun; do
   command -v "$tool" >/dev/null || {
@@ -120,6 +124,7 @@ fi
 ditto -c -k --keepParent "$BINARY" "$NOTARY_ARCHIVE"
 if ! xcrun notarytool submit "$NOTARY_ARCHIVE" \
   --keychain-profile "$NOTARYTOOL_KEYCHAIN_PROFILE" \
+  --keychain "$MAC_RELEASE_CODESIGN_KEYCHAIN" \
   --no-s3-acceleration \
   --wait \
   --output-format json >"$NOTARY_RESULT"; then

--- a/scripts/release-workflow.test.js
+++ b/scripts/release-workflow.test.js
@@ -480,6 +480,7 @@ test("signing and verification enforce Foundation identity, runtime, timestamp, 
   assert.match(signer, /--options runtime/);
   assert.match(signer, /--timestamp/);
   assert.match(signer, /notarytool submit/);
+  assert.match(signer, /--keychain "\$MAC_RELEASE_CODESIGN_KEYCHAIN"/);
   assert.match(signer, /NOTARY_STATUS.*Accepted/);
   for (const script of [signer, verifier]) {
     assert.match(script, /--verify --strict --check-notarization -R=notarized/);


### PR DESCRIPTION
## Summary

- pass the managed release keychain explicitly to notarytool
- fail closed when the managed keychain path is absent
- document the headless-release requirement and lock it with regression coverage

## Why

The protected Crabbox packager prepares a dedicated passwordless Foundation signing keychain. The signer previously asked notarytool to read only the default keychain, so a headless release host failed when its login keychain was locked even though the approved release keychain and notarization profile were ready.

## Verification

- `bash -n scripts/codesign-macos.sh`
- `node --test scripts/release-workflow.test.js` (19 passed)
- autoreview clean

## Secrets/config

No new secret. The existing notarization profile must be stored in the same managed release keychain already required for Foundation signing.
