### PR TITLE
fix: make published releases immutable

### DIFF
--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -183,6 +183,7 @@ jobs:
             release.tag_name === process.env.RELEASE_TAG &&
             release.name === process.env.RELEASE_TAG &&
             release.draft === (process.env.EXPECTED_DRAFT === 'true') &&
+            release.immutable === (process.env.EXPECTED_DRAFT !== 'true') &&
             release.prerelease === false &&
             (release.draft ? release.published_at === null : typeof release.published_at === 'string') &&
             notes.length === Number(process.env.EXPECTED_NOTES_BYTES) &&

--- a/.github/workflows/verify-homebrew.yml
+++ b/.github/workflows/verify-homebrew.yml
@@ -1,0 +1,180 @@
+name: Verify Homebrew Release
+run-name: Verify Homebrew ${{ inputs.tag }} from published run ${{ inputs.public_verifier_run_id }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Signed stable release tag
+        required: true
+        type: string
+      tag_object:
+        description: Signed annotated tag object SHA
+        required: true
+        type: string
+      source_commit:
+        description: Peeled release source commit SHA
+        required: true
+        type: string
+      verifier_commit:
+        description: Protected release verifier commit SHA
+        required: true
+        type: string
+      release_id:
+        description: Published GitHub release ID
+        required: true
+        type: string
+      public_verifier_run_id:
+        description: Successful published-asset verifier run ID
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  guard:
+    name: guard-protected-release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Guard published release and protected verifier run
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          REF_PROTECTED: ${{ github.ref_protected }}
+          RELEASE_ID: ${{ inputs.release_id }}
+          RELEASE_TAG: ${{ inputs.tag }}
+          PUBLIC_VERIFIER_RUN_ID: ${{ inputs.public_verifier_run_id }}
+          VERIFIER_COMMIT: ${{ inputs.verifier_commit }}
+        run: |
+          set -euo pipefail
+          [[ "$RELEASE_TAG" =~ ^v[0-9]+[.][0-9]+[.][0-9]+$ ]]
+          [[ "$VERIFIER_COMMIT" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$RELEASE_ID" =~ ^[1-9][0-9]*$ ]]
+          [[ "$PUBLIC_VERIFIER_RUN_ID" =~ ^[1-9][0-9]*$ ]]
+          expected_ref="refs/heads/$DEFAULT_BRANCH"
+          expected_workflow_ref="$GITHUB_REPOSITORY/.github/workflows/verify-homebrew.yml@$expected_ref"
+          [[ "$REF_PROTECTED" == true ]]
+          [[ "$GITHUB_REF" == "$expected_ref" ]]
+          [[ "$GITHUB_WORKFLOW_REF" == "$expected_workflow_ref" ]]
+
+          work="$RUNNER_TEMP/homebrew-guard"
+          mkdir -m 700 "$work"
+          gh api --method GET "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" >"$work/release.json"
+          gh api --method GET "repos/$GITHUB_REPOSITORY/actions/runs/$PUBLIC_VERIFIER_RUN_ID" \
+            >"$work/run.json"
+          workflow_id=$(jq -er '.workflow_id | select(type == "number" and . > 0)' "$work/run.json")
+          gh api --method GET "repos/$GITHUB_REPOSITORY/actions/workflows/$workflow_id" \
+            >"$work/workflow.json"
+          jq -e \
+            --argjson id "$RELEASE_ID" \
+            --arg tag "$RELEASE_TAG" '
+              .id == $id and .tag_name == $tag and .name == $tag and
+              .draft == false and .prerelease == false and
+              .immutable == true and
+              (.published_at | type == "string")
+            ' "$work/release.json" >/dev/null
+          jq -e \
+            --argjson id "$PUBLIC_VERIFIER_RUN_ID" \
+            --arg branch "$DEFAULT_BRANCH" \
+            --arg sha "$VERIFIER_COMMIT" '
+              .id == $id and .event == "workflow_dispatch" and
+              .status == "completed" and .conclusion == "success" and
+              .head_branch == $branch and .head_sha == $sha and
+              .repository.full_name == env.GITHUB_REPOSITORY and
+              .head_repository.full_name == env.GITHUB_REPOSITORY
+            ' "$work/run.json" >/dev/null
+          jq -e '
+            .path == ".github/workflows/release-assets.yml" and .state == "active"
+          ' "$work/workflow.json" >/dev/null
+
+  verify:
+    name: verify-${{ matrix.arch }}
+    needs: guard
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-15
+            arch: arm64
+          - runner: macos-15-intel
+            arch: x86_64
+    steps:
+
+      - name: Check out protected release verifier
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.verifier_commit }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Download frozen public release assets
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+          VERIFIER_COMMIT: ${{ inputs.verifier_commit }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$VERIFIER_COMMIT"
+          version=${RELEASE_TAG#v}
+          assets=(
+            checksums.txt
+            provenance.json
+            "crabbox_${version}_darwin_amd64.tar.gz"
+            "crabbox_${version}_darwin_arm64.tar.gz"
+            "crabbox_${version}_linux_amd64.tar.gz"
+            "crabbox_${version}_linux_arm64.tar.gz"
+            "crabbox_${version}_windows_amd64.zip"
+            "crabbox_${version}_windows_arm64.zip"
+          )
+          mkdir -m 700 release-assets
+          for asset in "${assets[@]}"; do
+            curl --fail --location --retry 3 --silent --show-error \
+              --output "release-assets/$asset" \
+              "https://github.com/$GITHUB_REPOSITORY/releases/download/$RELEASE_TAG/$asset"
+          done
+
+      - name: Download immutable native proof ZIPs
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PUBLIC_VERIFIER_RUN_ID: ${{ inputs.public_verifier_run_id }}
+        run: |
+          set -euo pipefail
+          mkdir -m 700 public-proofs
+          metadata="$RUNNER_TEMP/public-proof-artifacts.json"
+          gh api --method GET \
+            "repos/$GITHUB_REPOSITORY/actions/runs/$PUBLIC_VERIFIER_RUN_ID/artifacts?per_page=100" \
+            >"$metadata"
+          for arch in arm64 x86_64; do
+            artifact_id=$(jq -er --arg name "verified-assets-$arch" '
+              [.artifacts[] | select(.name == $name)] |
+              if length == 1 then .[0].id else error("ambiguous proof artifact") end
+            ' "$metadata")
+            gh api --method GET --header 'Accept: application/octet-stream' \
+              "repos/$GITHUB_REPOSITORY/actions/artifacts/$artifact_id/zip" \
+              >"public-proofs/verified-assets-$arch.zip"
+          done
+
+      - name: Verify public Homebrew install without credentials
+        shell: bash
+        env:
+          RELEASE_ID: ${{ inputs.release_id }}
+          RELEASE_TAG: ${{ inputs.tag }}
+          SOURCE_COMMIT: ${{ inputs.source_commit }}
+          TAG_OBJECT: ${{ inputs.tag_object }}
+          PUBLIC_VERIFIER_RUN_ID: ${{ inputs.public_verifier_run_id }}
+          VERIFIER_COMMIT: ${{ inputs.verifier_commit }}
+        run: |
+          set -euo pipefail
+          unset ACTIONS_ID_TOKEN_REQUEST_TOKEN ACTIONS_RUNTIME_TOKEN GH_TOKEN GITHUB_TOKEN
+          unset HOMEBREW_GITHUB_API_TOKEN HOMEBREW_TAP_GITHUB_TOKEN
+          scripts/verify-homebrew-release.sh \
+            "$RELEASE_TAG" "$PWD/release-assets" \
+            "$TAG_OBJECT" "$SOURCE_COMMIT" "$VERIFIER_COMMIT" \
+            "$RELEASE_ID" "$PUBLIC_VERIFIER_RUN_ID" "$PWD/public-proofs"

--- a/.github/workflows/verify-homebrew.yml
+++ b/.github/workflows/verify-homebrew.yml
@@ -132,10 +132,11 @@ jobs:
             "crabbox_${version}_windows_amd64.zip"
             "crabbox_${version}_windows_arm64.zip"
           )
-          mkdir -m 700 release-assets
+          assets_dir="$RUNNER_TEMP/release-assets"
+          mkdir -m 700 "$assets_dir"
           for asset in "${assets[@]}"; do
             curl --fail --location --retry 3 --silent --show-error \
-              --output "release-assets/$asset" \
+              --output "$assets_dir/$asset" \
               "https://github.com/$GITHUB_REPOSITORY/releases/download/$RELEASE_TAG/$asset"
           done
 
@@ -146,7 +147,8 @@ jobs:
           PUBLIC_VERIFIER_RUN_ID: ${{ inputs.public_verifier_run_id }}
         run: |
           set -euo pipefail
-          mkdir -m 700 public-proofs
+          proofs_dir="$RUNNER_TEMP/public-proofs"
+          mkdir -m 700 "$proofs_dir"
           metadata="$RUNNER_TEMP/public-proof-artifacts.json"
           gh api --method GET \
             "repos/$GITHUB_REPOSITORY/actions/runs/$PUBLIC_VERIFIER_RUN_ID/artifacts?per_page=100" \
@@ -158,7 +160,7 @@ jobs:
             ' "$metadata")
             gh api --method GET --header 'Accept: application/octet-stream' \
               "repos/$GITHUB_REPOSITORY/actions/artifacts/$artifact_id/zip" \
-              >"public-proofs/verified-assets-$arch.zip"
+              >"$proofs_dir/verified-assets-$arch.zip"
           done
 
       - name: Verify public Homebrew install without credentials
@@ -175,6 +177,6 @@ jobs:
           unset ACTIONS_ID_TOKEN_REQUEST_TOKEN ACTIONS_RUNTIME_TOKEN GH_TOKEN GITHUB_TOKEN
           unset HOMEBREW_GITHUB_API_TOKEN HOMEBREW_TAP_GITHUB_TOKEN
           scripts/verify-homebrew-release.sh \
-            "$RELEASE_TAG" "$PWD/release-assets" \
+            "$RELEASE_TAG" "$RUNNER_TEMP/release-assets" \
             "$TAG_OBJECT" "$SOURCE_COMMIT" "$VERIFIER_COMMIT" \
-            "$RELEASE_ID" "$PUBLIC_VERIFIER_RUN_ID" "$PWD/public-proofs"
+            "$RELEASE_ID" "$PUBLIC_VERIFIER_RUN_ID" "$RUNNER_TEMP/public-proofs"

--- a/.github/workflows/verify-homebrew.yml
+++ b/.github/workflows/verify-homebrew.yml
@@ -49,6 +49,7 @@ jobs:
           RELEASE_TAG: ${{ inputs.tag }}
           PUBLIC_VERIFIER_RUN_ID: ${{ inputs.public_verifier_run_id }}
           VERIFIER_COMMIT: ${{ inputs.verifier_commit }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
         run: |
           set -euo pipefail
           [[ "$RELEASE_TAG" =~ ^v[0-9]+[.][0-9]+[.][0-9]+$ ]]
@@ -60,6 +61,7 @@ jobs:
           [[ "$REF_PROTECTED" == true ]]
           [[ "$GITHUB_REF" == "$expected_ref" ]]
           [[ "$GITHUB_WORKFLOW_REF" == "$expected_workflow_ref" ]]
+          [[ "$WORKFLOW_SHA" == "$VERIFIER_COMMIT" ]]
 
           work="$RUNNER_TEMP/homebrew-guard"
           mkdir -m 700 "$work"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -440,6 +440,12 @@ draft metadata, notes, and every asset record again. Require byte-for-byte
 equality with the frozen proof and require the successful native markers to
 refer to that exact state.
 
+Enable organization-enforced release immutability for this repository before
+the publication gate. The publisher checks the live setting before its sole
+PATCH, and the publication response plus every public verifier must report
+`immutable=true`. A repository-only or disabled setting blocks publication
+before mutation.
+
 The protected native verifier uses a non-cancelling concurrency key scoped to
 the immutable numeric release. GitHub Actions retains at most one pending run
 per key, so the serialized operator dispatches exactly once; different releases

--- a/scripts/create-release-draft.sh
+++ b/scripts/create-release-draft.sh
@@ -144,6 +144,7 @@ if (
   release.name !== process.env.RELEASE_TAG ||
   release.body !== notes ||
   release.draft !== true ||
+  release.immutable !== false ||
   release.prerelease !== false ||
   release.published_at !== null ||
   JSON.stringify(actualAssets) !== JSON.stringify(expectedAssets) ||

--- a/scripts/homebrew-release.test.js
+++ b/scripts/homebrew-release.test.js
@@ -462,6 +462,7 @@ test("public Homebrew proof binds the current release, successful run, both nati
     name: "v1.2.3",
     body: notes,
     draft: false,
+    immutable: true,
     prerelease: false,
     created_at: "2026-07-10T09:00:00Z",
     updated_at: "2026-07-10T10:05:00Z",

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -294,6 +294,12 @@ cmp "$WORK/predownload-state.json" "$WORK/postdownload-state.json"
 # freeze is the serialization boundary; no local command intervenes after the
 # final comparison except the exact draft=false PATCH.
 printf '{"draft":false}\n' >"$WORK/publish.json"
+api_get "repos/$REPOSITORY/immutable-releases" >"$WORK/immutable-releases.json"
+jq -e '.enabled == true and .enforced_by_owner == true' \
+  "$WORK/immutable-releases.json" >/dev/null || {
+  echo "organization-enforced release immutability is required before publication" >&2
+  exit 1
+}
 verify_protected_source final
 api_get "repos/$REPOSITORY/releases/$RELEASE_ID" >"$WORK/final-draft.json"
 publication_environment node "$ROOT/scripts/validate-release-publication.mjs" state \

--- a/scripts/publish-release.test.js
+++ b/scripts/publish-release.test.js
@@ -131,6 +131,7 @@ function prepareFixture({ publishable = true, dynamicRunName = true } = {}) {
     name: tag,
     body: notes,
     draft: true,
+    immutable: false,
     prerelease: false,
     created_at: "2026-07-10T09:50:00Z",
     updated_at: releaseUpdatedAt,
@@ -395,6 +396,7 @@ if (method === "PATCH") {
   fs.writeFileSync(path.join(api, "published"), "yes\\n");
   const value = json("release.json");
   value.draft = false;
+  value.immutable = true;
   value.updated_at = "2026-07-10T10:10:00Z";
   value.published_at = "2026-07-10T10:10:00Z";
   outputJson(value);
@@ -419,6 +421,12 @@ else if (endpoint === "repos/${repository}/rulesets/702") {
 else if (endpoint === "repos/${repository}/git/ref/tags/${tag}") outputFile("tag-ref.json");
 else if (endpoint === "repos/${repository}/git/tags/${tagObject}") outputFile("tag-object.json");
 else if (endpoint === "repos/${repository}/actions/runs/${runId}") outputFile("run.json");
+else if (endpoint === "repos/${repository}/immutable-releases") {
+  outputJson({
+    enabled: process.env.MOCK_MODE !== "immutable-disabled",
+    enforced_by_owner: process.env.MOCK_MODE !== "immutable-repository-only",
+  });
+}
 else if (endpoint === "repos/${repository}/actions/workflows/${workflowId}") outputFile("workflow.json");
 else if (endpoint === "repos/${repository}/actions/runs/${runId}/artifacts?per_page=100") {
   outputFile(
@@ -447,6 +455,7 @@ else if (endpoint === "repos/${repository}/releases/${releaseId}") {
   const value = json("release.json");
   if (published) {
     value.draft = false;
+    value.immutable = true;
     value.updated_at = "2026-07-10T10:10:00Z";
     value.published_at = "2026-07-10T10:10:00Z";
   } else if (process.env.MOCK_MODE === "drift" && count >= 2) {
@@ -586,6 +595,24 @@ test("final immediately pre-PATCH draft drift fails before any mutation", () => 
     const result = run("prepatch-drift");
     assert.notEqual(result.status, 0);
     assert.match(result.stderr, /asset identity drifted|digest/);
+    assert.deepEqual(mutations(), []);
+  });
+});
+
+test("disabled release immutability fails before publication", () => {
+  withFixture({}, ({ run, mutations }) => {
+    const result = run("immutable-disabled");
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /organization-enforced release immutability is required/);
+    assert.deepEqual(mutations(), []);
+  });
+});
+
+test("repository-only release immutability fails before publication", () => {
+  withFixture({}, ({ run, mutations }) => {
+    const result = run("immutable-repository-only");
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /organization-enforced release immutability is required/);
     assert.deepEqual(mutations(), []);
   });
 });

--- a/scripts/release-workflow.test.js
+++ b/scripts/release-workflow.test.js
@@ -57,6 +57,16 @@ test("release workflow is verifier-only, protected-default, dual-native, and tok
   );
 });
 
+test("Homebrew verifier keeps downloaded proof inputs outside the protected checkout", () => {
+  const workflow = read(".github/workflows/verify-homebrew.yml");
+  assert.match(workflow, /assets_dir="\$RUNNER_TEMP\/release-assets"/);
+  assert.match(workflow, /proofs_dir="\$RUNNER_TEMP\/public-proofs"/);
+  assert.match(workflow, /"\$RUNNER_TEMP\/release-assets"/);
+  assert.match(workflow, /"\$RUNNER_TEMP\/public-proofs"/);
+  assert.doesNotMatch(workflow, /"\$PWD\/(?:release-assets|public-proofs)"/);
+  assert.doesNotMatch(workflow, /mkdir -m 700 (?:release-assets|public-proofs)/);
+});
+
 test("script CI fetches signed release tags for publication fixtures", () => {
   const ci = read(".github/workflows/ci.yml");
   const scriptsJob = ci.slice(ci.indexOf("  scripts:"), ci.indexOf("  docs:"));

--- a/scripts/release-workflow.test.js
+++ b/scripts/release-workflow.test.js
@@ -59,6 +59,8 @@ test("release workflow is verifier-only, protected-default, dual-native, and tok
 
 test("Homebrew verifier keeps downloaded proof inputs outside the protected checkout", () => {
   const workflow = read(".github/workflows/verify-homebrew.yml");
+  assert.match(workflow, /WORKFLOW_SHA: \$\{\{ github\.workflow_sha \}\}/);
+  assert.match(workflow, /\[\[ "\$WORKFLOW_SHA" == "\$VERIFIER_COMMIT" \]\]/);
   assert.match(workflow, /assets_dir="\$RUNNER_TEMP\/release-assets"/);
   assert.match(workflow, /proofs_dir="\$RUNNER_TEMP\/public-proofs"/);
   assert.match(workflow, /"\$RUNNER_TEMP\/release-assets"/);

--- a/scripts/validate-release-publication.mjs
+++ b/scripts/validate-release-publication.mjs
@@ -122,12 +122,13 @@ function validateReleaseIdentity(release, expectedNames, expectedNotes, expected
   if (snapshot && createdAt !== snapshot.createdAt) fail("release creation timestamp drifted");
 
   if (expectedState === "draft") {
-    if (release.draft !== true || release.published_at !== null)
+    if (release.draft !== true || release.immutable !== false || release.published_at !== null)
       fail("release is not the exact unpublished draft");
     if (snapshot && updatedAt !== snapshot.releaseUpdatedAt)
       fail("draft release timestamp drifted after verification");
   } else if (expectedState === "published") {
-    if (release.draft !== false) fail("release publication response is still a draft");
+    if (release.draft !== false || release.immutable !== true)
+      fail("release publication response is not immutable");
     timestamp(release.published_at, "release published_at");
     if (snapshot && Date.parse(updatedAt) < Date.parse(snapshot.releaseUpdatedAt)) {
       fail("published release timestamp predates the verified draft");
@@ -146,6 +147,7 @@ function validateReleaseIdentity(release, expectedNames, expectedNotes, expected
     title: release.name,
     bodySha256: sha256(Buffer.from(release.body, "utf8")),
     draft: release.draft,
+    immutable: release.immutable,
     prerelease: release.prerelease,
     createdAt,
     updatedAt,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where published release assets remained mutable and release operators could not prove the Homebrew formula on both native Apple Silicon and Intel hosts from one protected, repeatable workflow.

## Why This Change Was Made

Requires organization-enforced release immutability before the publication mutation, rejects mutable public records in every verifier, and adds a protected-default-branch workflow that binds the immutable release to its exact successful public verifier run. The workflow checks out only that verifier commit and runs the credential-free Homebrew verifier on native arm64 and x86_64 runners; invalid refs fail instead of appearing skipped-successful.

## User Impact

No CLI behavior changes. Release operators get tamper-resistant public assets and a reproducible two-architecture Homebrew closeout gate.

## Evidence

- `actionlint .github/workflows/verify-homebrew.yml`
- Fresh Codex autoreview: clean after fixing invalid-ref skip behavior and requiring GitHub release immutability.
- `node --test scripts/publish-release.test.js`: 17/17 passing, including disabled and repository-only immutability failures before mutation.
- Crabbox v0.38.1 public verifier run `29327262104` is the pinned proof source used to exercise the workflow after landing; v0.38.2 will be the first immutable release accepted by the gate.
