### PR TITLE
chore(release): pin 0.38.2 source

### DIFF
--- a/release/records/v0.38.2.json
+++ b/release/records/v0.38.2.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "repository": "openclaw/crabbox",
+  "tag": "v0.38.2",
+  "tagObject": "b11d63f5a3353ed8117bbfbc92fca0bc2512d1f9",
+  "sourceCommit": "d009660c442c7f072d3058097d1c2a86067c47c1",
+  "publicationStatus": "ready"
+}

--- a/scripts/release-workflow.test.js
+++ b/scripts/release-workflow.test.js
@@ -577,6 +577,14 @@ test("v0.38.1 is pinned to the signed ready-pool source and ready for publicatio
   assert.equal(record.publicationStatus, "ready");
 });
 
+test("v0.38.2 is pinned to the cancellation-fix source and ready for publication", () => {
+  const record = JSON.parse(read("release/records/v0.38.2.json"));
+  assert.equal(record.tag, "v0.38.2");
+  assert.equal(record.tagObject, "b11d63f5a3353ed8117bbfbc92fca0bc2512d1f9");
+  assert.equal(record.sourceCommit, "d009660c442c7f072d3058097d1c2a86067c47c1");
+  assert.equal(record.publicationStatus, "ready");
+});
+
 test("managed Foundation signing and notary configuration is repository-owned and secret-free", () => {
   const manifest = read(".mac-release.env");
   const codeowners = read(".github/CODEOWNERS");


### PR DESCRIPTION
## Summary

- pin the signed `v0.38.2` tag object and source commit
- mark the release source ready for publication
- cover the immutable release record in the workflow contract test

## Verification

- `node --test scripts/release-workflow.test.js`
- `git diff --check`
