### PR TITLE
chore(release): prepare 0.38.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
-## 0.38.2 - 2026-07-14
+## 0.38.3 - 2026-07-14
 
 ### Fixed
 
 - Made provider IP and loopback VNC waits return promptly when their context is cancelled. Thanks @SebTardif.
+
+## 0.38.2 - Unpublished
+
+- Publication blocked because the protected signed tag annotation did not satisfy release policy.
 
 ## 0.38.1 - 2026-07-13
 

--- a/release/records/v0.38.2.json
+++ b/release/records/v0.38.2.json
@@ -4,5 +4,6 @@
   "tag": "v0.38.2",
   "tagObject": "b11d63f5a3353ed8117bbfbc92fca0bc2512d1f9",
   "sourceCommit": "d009660c442c7f072d3058097d1c2a86067c47c1",
-  "publicationStatus": "ready"
+  "publicationStatus": "blocked",
+  "blocker": "Signed tag annotation does not exactly equal v0.38.2; protected tag is immutable and cannot be published."
 }

--- a/scripts/release-workflow.test.js
+++ b/scripts/release-workflow.test.js
@@ -577,12 +577,13 @@ test("v0.38.1 is pinned to the signed ready-pool source and ready for publicatio
   assert.equal(record.publicationStatus, "ready");
 });
 
-test("v0.38.2 is pinned to the cancellation-fix source and ready for publication", () => {
+test("v0.38.2 is pinned and publication-blocked after its immutable tag failed policy", () => {
   const record = JSON.parse(read("release/records/v0.38.2.json"));
   assert.equal(record.tag, "v0.38.2");
   assert.equal(record.tagObject, "b11d63f5a3353ed8117bbfbc92fca0bc2512d1f9");
   assert.equal(record.sourceCommit, "d009660c442c7f072d3058097d1c2a86067c47c1");
-  assert.equal(record.publicationStatus, "ready");
+  assert.equal(record.publicationStatus, "blocked");
+  assert.match(record.blocker, /tag annotation does not exactly equal v0\.38\.2/);
 });
 
 test("managed Foundation signing and notary configuration is repository-owned and secret-free", () => {

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/crabbox-worker",
-  "version": "0.38.2",
+  "version": "0.38.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/crabbox-worker",
-      "version": "0.38.2",
+      "version": "0.38.3",
       "dependencies": {
         "@aws-sdk/credential-providers": "^3.1084.0",
         "@cloudflare/containers": "^0.3.7",

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/crabbox-worker",
-  "version": "0.38.2",
+  "version": "0.38.3",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- prepare Crabbox 0.38.3 with the cancellation responsiveness fix
- record 0.38.2 as unpublished because its protected immutable tag failed annotation policy
- advance Worker package metadata to 0.38.3

## Verification

- `node --test scripts/release-workflow.test.js`
- `git diff --check`
