### PR TITLE
chore(release): pin 0.38.3 source

### DIFF
--- a/release/records/v0.38.3.json
+++ b/release/records/v0.38.3.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "repository": "openclaw/crabbox",
+  "tag": "v0.38.3",
+  "tagObject": "2c4bee30c6af3039bae986c1a6784d9a2f4ee15c",
+  "sourceCommit": "9c3df396c94fef304975e221d5f0dc26e65d9860",
+  "publicationStatus": "ready"
+}

--- a/scripts/release-workflow.test.js
+++ b/scripts/release-workflow.test.js
@@ -586,6 +586,14 @@ test("v0.38.2 is pinned and publication-blocked after its immutable tag failed p
   assert.match(record.blocker, /tag annotation does not exactly equal v0\.38\.2/);
 });
 
+test("v0.38.3 is pinned to the cancellation-fix source and ready for publication", () => {
+  const record = JSON.parse(read("release/records/v0.38.3.json"));
+  assert.equal(record.tag, "v0.38.3");
+  assert.equal(record.tagObject, "2c4bee30c6af3039bae986c1a6784d9a2f4ee15c");
+  assert.equal(record.sourceCommit, "9c3df396c94fef304975e221d5f0dc26e65d9860");
+  assert.equal(record.publicationStatus, "ready");
+});
+
 test("managed Foundation signing and notary configuration is repository-owned and secret-free", () => {
   const manifest = read(".mac-release.env");
   const codeowners = read(".github/CODEOWNERS");


### PR DESCRIPTION
## Summary

- pin the signed `v0.38.3` tag object and source commit
- mark the corrected patch release source ready for publication
- cover the immutable record in the release workflow contract

## Verification

- `node --test scripts/release-workflow.test.js`
- `git diff --check`
