### PR TITLE
fix: restore Homebrew proof downloads

### DIFF
--- a/.github/workflows/verify-homebrew.yml
+++ b/.github/workflows/verify-homebrew.yml
@@ -160,7 +160,7 @@ jobs:
               [.artifacts[] | select(.name == $name)] |
               if length == 1 then .[0].id else error("ambiguous proof artifact") end
             ' "$metadata")
-            gh api --method GET --header 'Accept: application/octet-stream' \
+            gh api --method GET --header 'Accept: application/vnd.github+json' \
               "repos/$GITHUB_REPOSITORY/actions/artifacts/$artifact_id/zip" \
               >"$proofs_dir/verified-assets-$arch.zip"
           done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.38.4 - Unreleased
+
+### Fixed
+
+- Restored native Homebrew verification by using the supported GitHub Actions artifact archive media type.
+
 ## 0.38.3 - 2026-07-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## 0.38.4 - Unreleased
-
-### Fixed
-
-- Restored native Homebrew verification by using the supported GitHub Actions artifact archive media type.
-
 ## 0.38.3 - 2026-07-14
 
 ### Fixed

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -359,7 +359,7 @@ for arch in arm64 x86_64; do
     if length == 1 then .[0].id else error("ambiguous proof artifact") end
   ' "$PUBLIC_ARTIFACTS")
   gh api --method GET \
-    --header 'Accept: application/octet-stream' \
+    --header 'Accept: application/vnd.github+json' \
     "repos/openclaw/crabbox/actions/artifacts/$ARTIFACT_ID/zip" \
     >"$PUBLIC_PROOFS/verified-assets-$arch.zip"
 done

--- a/scripts/release-workflow.test.js
+++ b/scripts/release-workflow.test.js
@@ -59,12 +59,25 @@ test("release workflow is verifier-only, protected-default, dual-native, and tok
 
 test("Homebrew verifier keeps downloaded proof inputs outside the protected checkout", () => {
   const workflow = read(".github/workflows/verify-homebrew.yml");
+  const proofDownloadStart = workflow.indexOf("      - name: Download immutable native proof ZIPs");
+  const proofDownloadEnd = workflow.indexOf(
+    "      - name: Verify public Homebrew install without credentials",
+  );
+  assert.notEqual(proofDownloadStart, -1);
+  assert.notEqual(proofDownloadEnd, -1);
+  const proofDownloadStep = workflow.slice(
+    proofDownloadStart,
+    proofDownloadEnd,
+  );
   assert.match(workflow, /WORKFLOW_SHA: \$\{\{ github\.workflow_sha \}\}/);
   assert.match(workflow, /\[\[ "\$WORKFLOW_SHA" == "\$VERIFIER_COMMIT" \]\]/);
   assert.match(workflow, /assets_dir="\$RUNNER_TEMP\/release-assets"/);
   assert.match(workflow, /proofs_dir="\$RUNNER_TEMP\/public-proofs"/);
-  assert.match(workflow, /Accept: application\/vnd\.github\+json/);
-  assert.doesNotMatch(workflow, /actions\/artifacts[\s\S]{0,200}application\/octet-stream/);
+  assert.match(
+    proofDownloadStep,
+    /gh api --method GET --header 'Accept: application\/vnd\.github\+json' \\\s+"repos\/\$GITHUB_REPOSITORY\/actions\/artifacts\/\$artifact_id\/zip"/,
+  );
+  assert.doesNotMatch(proofDownloadStep, /application\/octet-stream/);
   assert.match(workflow, /"\$RUNNER_TEMP\/release-assets"/);
   assert.match(workflow, /"\$RUNNER_TEMP\/public-proofs"/);
   assert.doesNotMatch(workflow, /"\$PWD\/(?:release-assets|public-proofs)"/);
@@ -518,6 +531,10 @@ test("release documentation forbids automatic publication, deletion, and Homebre
   assert.match(release, /Never delete a partial draft or release/);
   assert.match(release, /Publish with one draft-state transition/);
   assert.match(release, /Update and prove Homebrew/);
+  assert.match(
+    release,
+    /gh api --method GET \\\s+--header 'Accept: application\/vnd\.github\+json' \\\s+"repos\/openclaw\/crabbox\/actions\/artifacts\/\$ARTIFACT_ID\/zip"/,
+  );
   assert.match(release, /Developer ID Application: OpenClaw Foundation \(FWJYW4S8P8\)/);
   assert.match(release, /PACKAGE_SCRIPT_SHA256/);
   assert.match(

--- a/scripts/release-workflow.test.js
+++ b/scripts/release-workflow.test.js
@@ -63,6 +63,8 @@ test("Homebrew verifier keeps downloaded proof inputs outside the protected chec
   assert.match(workflow, /\[\[ "\$WORKFLOW_SHA" == "\$VERIFIER_COMMIT" \]\]/);
   assert.match(workflow, /assets_dir="\$RUNNER_TEMP\/release-assets"/);
   assert.match(workflow, /proofs_dir="\$RUNNER_TEMP\/public-proofs"/);
+  assert.match(workflow, /Accept: application\/vnd\.github\+json/);
+  assert.doesNotMatch(workflow, /actions\/artifacts[\s\S]{0,200}application\/octet-stream/);
   assert.match(workflow, /"\$RUNNER_TEMP\/release-assets"/);
   assert.match(workflow, /"\$RUNNER_TEMP\/public-proofs"/);
   assert.doesNotMatch(workflow, /"\$PWD\/(?:release-assets|public-proofs)"/);


### PR DESCRIPTION
Fixes https://github.com/openclaw/crabbox/issues/1089

## Summary

- use the supported JSON media type when downloading Actions proof archives
- keep the release runbook command aligned with the protected workflow
- bind regression coverage to the exact artifact-download step and documented command
- record the repair under 0.38.4 Unreleased

## Verification

- `node --test scripts/release-workflow.test.js` (22 passed)
- source-blind live contract: both v0.38.3 native proof ZIPs resolved, downloaded, passed `unzip -t`, and contained `verified-assets.json`; an invalid artifact ID failed closed
- full combined branch autoreview: clean, confidence 0.97

## Security and configuration

No secret or configuration changes. The workflow still removes GitHub credentials before executing the downloaded candidate and Homebrew verifier.
