### PR TITLE
fix(cli): honor context cancel during SSH readiness backoff

### DIFF
--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -163,7 +163,9 @@ func waitForSSHReady(ctx context.Context, target *SSHTarget, stderr io.Writer, p
 			lastPorts = strings.Join(probes, ",")
 			fmt.Fprintln(stderr, sshWaitProgressMessage(target, phase, reachablePort, transportPort, lastPorts, time.Since(start), time.Until(deadline)))
 		}
-		time.Sleep(10 * time.Second)
+		if err := sleepContext(ctx, 10*time.Second); err != nil {
+			return err
+		}
 	}
 }
 

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -164,7 +164,7 @@ func waitForSSHReady(ctx context.Context, target *SSHTarget, stderr io.Writer, p
 			fmt.Fprintln(stderr, sshWaitProgressMessage(target, phase, reachablePort, transportPort, lastPorts, time.Since(start), time.Until(deadline)))
 		}
 		if err := sleepContext(ctx, 10*time.Second); err != nil {
-			return err
+			return context.Cause(ctx)
 		}
 	}
 }

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 	"unicode/utf16"
@@ -738,7 +739,17 @@ exit 0
 	}
 }
 
-func TestWaitForSSHReadyHonorsCancellationDuringBackoff(t *testing.T) {
+type sshWaitProgressSignal struct {
+	once  sync.Once
+	ready chan struct{}
+}
+
+func (w *sshWaitProgressSignal) Write(p []byte) (int, error) {
+	w.once.Do(func() { close(w.ready) })
+	return len(p), nil
+}
+
+func TestWaitForSSHReadyPreservesCancellationCauseDuringBackoff(t *testing.T) {
 	// Prove cancel is observed during the inter-attempt backoff, not only at
 	// the top of the loop. Fake ssh always fails so wait enters the sleep.
 	dir := t.TempDir()
@@ -760,22 +771,30 @@ exit 255
 		ReadyCheck:     "true",
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	cause := errors.New("lease disappeared during SSH readiness")
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+	progress := &sshWaitProgressSignal{ready: make(chan struct{})}
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- waitForSSHReady(ctx, &target, io.Discard, "test", time.Minute)
+		errCh <- waitForSSHReady(ctx, &target, progress, "test", time.Minute)
 	}()
 
-	// Let the first failed probe complete and enter the 10s backoff.
-	time.Sleep(200 * time.Millisecond)
-	cancel()
+	select {
+	case <-progress.ready:
+		// Progress is written after the failed probe and immediately before backoff.
+	case err := <-errCh:
+		t.Fatalf("waitForSSHReady returned before backoff: %v", err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("waitForSSHReady did not reach the backoff")
+	}
+	cancel(cause)
 
 	select {
 	case err := <-errCh:
-		if !errors.Is(err, context.Canceled) {
-			t.Fatalf("waitForSSHReady returned %v, want context.Canceled", err)
+		if !errors.Is(err, cause) {
+			t.Fatalf("waitForSSHReady returned %v, want cancellation cause %v", err, cause)
 		}
 	case <-time.After(3 * time.Second):
 		t.Fatal("waitForSSHReady did not return within 3s after cancel; still blocked on bare sleep")

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -734,6 +735,50 @@ exit 0
 	}
 	if string(ports) != "2222\n22\n" {
 		t.Fatalf("ports=%q want fallback sequence", string(ports))
+	}
+}
+
+func TestWaitForSSHReadyHonorsCancellationDuringBackoff(t *testing.T) {
+	// Prove cancel is observed during the inter-attempt backoff, not only at
+	// the top of the loop. Fake ssh always fails so wait enters the sleep.
+	dir := t.TempDir()
+	sshPath := filepath.Join(dir, "ssh")
+	script := `#!/bin/sh
+exit 255
+`
+	if err := os.WriteFile(sshPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	target := SSHTarget{
+		User:           "crabbox",
+		Host:           "private.example",
+		Port:           "22",
+		SSHConfigProxy: true,
+		ProxyCommand:   "provider proxy %h %p",
+		ReadyCheck:     "true",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- waitForSSHReady(ctx, &target, io.Discard, "test", time.Minute)
+	}()
+
+	// Let the first failed probe complete and enter the 10s backoff.
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("waitForSSHReady returned %v, want context.Canceled", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("waitForSSHReady did not return within 3s after cancel; still blocked on bare sleep")
 	}
 }
 


### PR DESCRIPTION
## What problem this solves

`waitForSSHReady` is the shared SSH readiness loop for bootstrap, sync, and command paths. It checked cancellation at loop entry but used a bare ten-second sleep between failed probes, delaying cancellation by the full backoff.

## Improved fix

- replace the bare retry sleep with the existing context-aware helper
- preserve `context.Cause`, so lease-watch failures are not downgraded to generic `context.Canceled`
- synchronize the regression test on the real failed-probe progress boundary instead of sleeping for an assumed 200ms
- retain contributor credit in the 0.38.4 Unreleased changelog

## Verification

- `go test -race ./internal/cli -run 'TestWaitForSSHReadyPreservesCancellationCauseDuringBackoff' -count=20`
- `go test -race ./internal/cli -count=1` (193.850s)
- `go vet ./...`
- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- built-CLI, source-blind behavior contract: a real `provider=ssh` run reached SSH readiness backoff, remained alive before cancellation, then exited nonzero 0.114s after SIGINT; no readiness timeout and zero isolated-home files
- full combined-diff autoreview: clean, confidence 0.96

## Risk

Shared SSH readiness only. Probe, success, deadline, and provider routing behavior are unchanged. Cancellation now returns promptly while preserving the exact existing cancellation cause.

## Related

- Same defect class: https://github.com/openclaw/crabbox/pull/1063
- Original loop provenance: `a52b45d45` (2026-04-30)
