### PR TITLE
fix: prevent sparse Testbox sync corruption

### DIFF
--- a/docs/providers/blacksmith-testbox.md
+++ b/docs/providers/blacksmith-testbox.md
@@ -47,6 +47,11 @@ crabbox status --provider blacksmith-testbox --id tbx_123
 crabbox stop --provider blacksmith-testbox tbx_123
 ```
 
+Run delegated sync from a full Git checkout. Crabbox rejects sparse checkouts
+before invoking Blacksmith because paths intentionally omitted by sparse checkout
+can otherwise be misread as deletions during a later full sync. Materialize a
+temporary full checkout when the source workspace must stay sparse.
+
 Keep a Testbox between runs via a JSON session handle:
 
 ```sh

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -23,6 +23,19 @@ type Repo struct {
 	BaseRef   string
 }
 
+// IsSparseGitCheckout reports whether Git intentionally omits tracked paths
+// from the working tree. Delegated sync tools must not treat those omissions as
+// deletions from a complete checkout.
+func IsSparseGitCheckout(root string) bool {
+	if strings.TrimSpace(root) == "" {
+		return false
+	}
+	return strings.EqualFold(
+		strings.TrimSpace(gitOutput(root, "config", "--bool", "core.sparseCheckout")),
+		"true",
+	)
+}
+
 func findRepo() (Repo, error) {
 	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
 	out, err := cmd.Output()

--- a/internal/cli/repo_test.go
+++ b/internal/cli/repo_test.go
@@ -57,6 +57,18 @@ func TestRepoNameFromRootAndRemoteFallsBackToRemoteBasename(t *testing.T) {
 	}
 }
 
+func TestIsSparseGitCheckout(t *testing.T) {
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	if IsSparseGitCheckout(dir) {
+		t.Fatal("normal checkout reported sparse")
+	}
+	runGit(t, dir, "config", "core.sparseCheckout", "true")
+	if !IsSparseGitCheckout(dir) {
+		t.Fatal("sparse checkout was not detected")
+	}
+}
+
 func TestSyncManifestUsesGitFilesAndIgnoresIgnoredJunk(t *testing.T) {
 	dir := t.TempDir()
 	runGit(t, dir, "init")

--- a/internal/providers/blacksmith/backend.go
+++ b/internal/providers/blacksmith/backend.go
@@ -108,6 +108,13 @@ func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 		fmt.Fprintf(b.rt.Stderr, "env forwarding note=blacksmith-testbox delegates execution to the Blacksmith CLI; configure secrets in the Testbox workflow instead\n")
 		return RunResult{}, core.Exit(2, "env forwarding is unsupported for provider=%s; configure secrets in the provider workflow or use an SSH-backed provider", blacksmithTestboxProvider)
 	}
+	if core.IsSparseGitCheckout(req.Repo.Root) {
+		return RunResult{}, core.Exit(
+			2,
+			"provider=%s cannot safely delegate sync from a sparse Git checkout; run from a materialized full checkout",
+			blacksmithTestboxProvider,
+		)
+	}
 	started := b.rt.Clock.Now()
 	leaseID := req.ID
 	slug := ""

--- a/internal/providers/blacksmith/backend_test.go
+++ b/internal/providers/blacksmith/backend_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -215,6 +216,36 @@ func TestBlacksmithRunRejectsEnvForwardingBeforeWarmup(t *testing.T) {
 	}
 	if strings.Contains(out, "secret-token-value") {
 		t.Fatalf("stderr leaked env value: %q", out)
+	}
+}
+
+func TestBlacksmithRunRejectsSparseCheckoutBeforeWarmup(t *testing.T) {
+	dir := t.TempDir()
+	git := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		if output, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, output)
+		}
+	}
+	git("init")
+	git("config", "core.sparseCheckout", "true")
+
+	runner := &blacksmithFuncRunner{}
+	backend := newTestBlacksmithBackend(baseConfig(), runner)
+	_, err := backend.Run(context.Background(), RunRequest{
+		Repo:    Repo{Root: dir},
+		Command: []string{"true"},
+	})
+	var exitErr ExitError
+	if !core.AsExitError(err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("Run error=%v, want exit 2", err)
+	}
+	if !strings.Contains(err.Error(), "materialized full checkout") {
+		t.Fatalf("Run error=%q missing remediation", err)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("runner was called before sparse-checkout validation: %#v", runner.calls)
 	}
 }
 


### PR DESCRIPTION
Closes https://github.com/openclaw/crabbox/issues/1093

Merge after https://github.com/openclaw/crabbox/pull/1091 so the 0.38.4 release remains serialized.

## What Problem This Solves

Fixes an issue where users running Blacksmith Testbox from a sparse Git checkout could receive a remotely corrupted workspace when a later delegated sync interpreted intentionally omitted tracked paths as deletions.

## Why This Change Was Made

Crabbox now detects Git's canonical sparse-checkout setting and fails before invoking Blacksmith's delegated sync. The provider documentation directs users to materialize a temporary full checkout, preserving the provider boundary while preventing an unsafe remote mutation.

## User Impact

Blacksmith Testbox runs from full checkouts are unchanged. Runs started from sparse checkouts now stop with an actionable error instead of risking thousands of phantom remote deletions.

## Evidence

- `go test -count=1 ./internal/cli ./internal/providers/blacksmith` — passed.
- `go test -count=1 -run TestIsSparseGitCheckout ./internal/cli` — passed.
- `go test -count=1 ./internal/providers/blacksmith` — passed.
- `git diff --check` — passed.
- Structured autoreview — clean twice; no accepted or actionable findings.
- Source-blind CLI validation — sparse fixture exited 2 with the full-checkout remediation and never invoked the provider stub; disabling sparse mode reached the stub and propagated its exit 99.
