### PR TITLE
fix(worker): drain pipes before cmd.Wait to stop stdout truncation

### DIFF
--- a/worker/cloudflare-container-runner/main.go
+++ b/worker/cloudflare-container-runner/main.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 )
@@ -23,6 +24,37 @@ import (
 const minStreamLifetime = 75 * time.Millisecond
 const finalStreamFlushDelay = 100 * time.Millisecond
 const streamHeartbeatInterval = 15 * time.Second
+
+// After the direct child is reaped, a background descendant may have
+// inherited a stdout/stderr write-end (e.g. `sleep 30 & echo done`) and still
+// hold it open, so the owned read-ends never reach a natural EOF on their own.
+// runCommand handles that with an IDLE-AWARE DRAIN, not a single fixed grace:
+//
+//   - pipeDrainIdle is how long the drain waits for a lull with NO new bytes
+//     copied before concluding the child's real output is fully flushed and
+//     only a quiet (or absent) descendant remains. Once idle elapses with no
+//     progress, we close the read-ends ourselves to unblock the copiers. A
+//     descendant that keeps writing (even slowly) keeps resetting this timer,
+//     so genuine trailing output is never cut short.
+//   - pipeDrainPoll is the polling interval used to sample the shared `copied`
+//     byte counter and decide whether progress was made since the last check.
+//   - pipeDrainGrace is an ABSOLUTE CAP on the whole drain phase, in case a
+//     descendant writes continuously (e.g. `(while true; do echo x; done) &`)
+//     and so never goes idle: once this cap elapses (even mid-progress) we
+//     close the read-ends and return anyway. It is the same 5s constant the
+//     bounded-select design used, now acting as a backstop rather than the
+//     primary timer.
+//
+// None of this bounds the foreground command's own runtime: runCommand owns
+// the pipe read-ends, so cmd.Wait never closes them, and a long-running
+// foreground command is fully drained however long it takes — the drain phase
+// (and these three timers) only start once cmd.Wait has already returned. All
+// three are vars so tests can lower them.
+var (
+	pipeDrainIdle  = 300 * time.Millisecond
+	pipeDrainPoll  = 100 * time.Millisecond
+	pipeDrainGrace = 5 * time.Second
+)
 
 type execRequest struct {
 	Command   string            `json:"command"`
@@ -174,17 +206,57 @@ func runCommand(ctx context.Context, req execRequest, cwd string, writer *eventW
 	cmd.Env = commandEnv(req.Env)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
-	stdout, err := cmd.StdoutPipe()
+	// Own the stdout/stderr pipes instead of using cmd.StdoutPipe/StderrPipe.
+	//
+	// os/exec documents that cmd.Wait closes the parent read-ends of
+	// Stdout/StderrPipe as soon as the child is reaped: "it is incorrect to call
+	// Wait before all reads from the pipe have completed". Any design that must
+	// call cmd.Wait while a copier is still reading those read-ends therefore
+	// races the copier and silently truncates buffered output — including a
+	// legitimate foreground command that simply runs long and writes its result
+	// right before exiting.
+	//
+	// By creating the pipes ourselves and reading OUR OWN read-ends, cmd.Wait
+	// leaves them untouched. We can reap the child first, however long it runs,
+	// and the copiers keep delivering every byte with no truncation. We drop the
+	// parent's write-end copies right after Start so the child (and any
+	// descendants it forks) are the only writers, letting the read-ends reach a
+	// clean EOF once they all exit.
+	rOut, wOut, err := os.Pipe()
 	if err != nil {
 		return 0, err
 	}
-	stderr, err := cmd.StderrPipe()
+	rErr, wErr, err := os.Pipe()
 	if err != nil {
+		_ = rOut.Close()
+		_ = wOut.Close()
 		return 0, err
 	}
+	cmd.Stdout = wOut
+	cmd.Stderr = wErr
+
 	if err := cmd.Start(); err != nil {
+		_ = rOut.Close()
+		_ = wOut.Close()
+		_ = rErr.Close()
+		_ = wErr.Close()
 		return 0, err
 	}
+	// The child now holds the only write-ends; drop the parent's copies so the
+	// read-ends can reach EOF once the child (and any descendants) exit.
+	_ = wOut.Close()
+	_ = wErr.Close()
+
+	// Close the read-ends exactly once, whichever drain path we take, to force
+	// any blocked copyPipe Read to return and to avoid leaking file descriptors.
+	var closeReadersOnce sync.Once
+	closeReaders := func() {
+		closeReadersOnce.Do(func() {
+			_ = rOut.Close()
+			_ = rErr.Close()
+		})
+	}
+	defer closeReaders()
 
 	done := make(chan struct{})
 	defer close(done)
@@ -196,13 +268,69 @@ func runCommand(ctx context.Context, req execRequest, cwd string, writer *eventW
 		}
 	}()
 
+	var copied atomic.Int64
+	// writesInFlight counts copiers currently blocked in a response write. A
+	// slow write (downstream backpressure) freezes `copied`, so without this the
+	// drain loop below could mistake an actively-flushing copier for an idle
+	// pipe and close the read-ends mid-write, truncating buffered output.
+	var writesInFlight atomic.Int64
 	var wg sync.WaitGroup
 	wg.Add(2)
-	go copyPipe(&wg, stdout, "stdout", writer)
-	go copyPipe(&wg, stderr, "stderr", writer)
+	go copyPipe(&wg, rOut, "stdout", writer, &copied, &writesInFlight)
+	go copyPipe(&wg, rErr, "stderr", writer, &copied, &writesInFlight)
 
+	// Reap the child first. Because we own rOut/rErr, cmd.Wait does NOT close
+	// them, so the copiers keep delivering the child's output for the ENTIRE
+	// lifetime of the command. A foreground command that runs arbitrarily long
+	// is fully drained with no truncation — none of the drain timers below
+	// bound the command's runtime, only what happens to a lingering descendant
+	// after the direct child has already exited.
 	waitErr := cmd.Wait()
-	wg.Wait()
+
+	// The direct child is reaped, but a background descendant may have
+	// inherited a write-end (e.g. `sleep 30 & echo done`) and still hold the
+	// pipe open, so the copiers won't reach EOF on their own. Drain
+	// idle-aware: keep waiting as long as bytes keep arriving (a live
+	// descendant still flushing real output), and only close the read-ends
+	// once EITHER the copiers hit a genuine EOF, OR `copied` has made no
+	// progress for pipeDrainIdle (a quiet/absent descendant — nothing left to
+	// lose), OR the absolute pipeDrainGrace cap elapses (a descendant writing
+	// continuously, e.g. `(while true; do echo x; done) &`, which would
+	// otherwise keep resetting the idle timer forever). Closing the read-ends
+	// forces the blocked copyPipe Reads to return (os.ErrClosed, treated as
+	// benign) so wg.Wait() completes.
+	drained := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(drained)
+	}()
+
+	ticker := time.NewTicker(pipeDrainPoll)
+	defer ticker.Stop()
+	deadline := time.Now().Add(pipeDrainGrace)
+	idleDeadline := time.Now().Add(pipeDrainIdle)
+	lastCopied := copied.Load()
+drainLoop:
+	for {
+		select {
+		case <-drained:
+			break drainLoop
+		case now := <-ticker.C:
+			// A copier blocked in a slow response write is NOT idle: an in-flight
+			// write counts as progress so the idle timer never fires mid-flush.
+			// Only the absolute pipeDrainGrace cap can end the drain during a
+			// persistently blocked write.
+			if cur := copied.Load(); cur != lastCopied || writesInFlight.Load() > 0 {
+				lastCopied = cur
+				idleDeadline = now.Add(pipeDrainIdle)
+			}
+			if now.After(idleDeadline) || now.After(deadline) {
+				closeReaders()
+				<-drained
+				break drainLoop
+			}
+		}
+	}
 	if ctx.Err() != nil {
 		return 124, ctx.Err()
 	}
@@ -252,13 +380,22 @@ func commandExitCode(exitErr *exec.ExitError) int {
 	return 1
 }
 
-func copyPipe(wg *sync.WaitGroup, reader io.Reader, eventType string, writer *eventWriter) {
+// copyPipe reads reader until EOF (or a benign close), forwarding each chunk
+// as a stream event and adding its length to copied so the idle-aware drain
+// in runCommand can detect whether a background descendant is still
+// producing real output after the direct child has exited.
+func copyPipe(wg *sync.WaitGroup, reader io.Reader, eventType string, writer *eventWriter, copied, writesInFlight *atomic.Int64) {
 	defer wg.Done()
 	buf := make([]byte, 32*1024)
 	for {
 		n, err := reader.Read(buf)
 		if n > 0 {
+			// Mark the write in flight for the whole (potentially blocking)
+			// write so the drain loop never treats a slow flush as an idle pipe.
+			writesInFlight.Add(1)
 			writer.write(streamEvent{Type: eventType, Data: string(buf[:n])})
+			writesInFlight.Add(-1)
+			copied.Add(int64(n))
 		}
 		if err != nil {
 			if !benignPipeReadError(err) {

--- a/worker/cloudflare-container-runner/main_test.go
+++ b/worker/cloudflare-container-runner/main_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 )
 
@@ -183,7 +184,9 @@ func TestCopyPipeTreatsClosedPipeAsEOF(t *testing.T) {
 	writer := &eventWriter{w: rec, flusher: rec}
 
 	wg.Add(1)
-	copyPipe(&wg, closedPipeReader{}, "stdout", writer)
+	var copied atomic.Int64
+	var writesInFlight atomic.Int64
+	copyPipe(&wg, closedPipeReader{}, "stdout", writer, &copied, &writesInFlight)
 
 	if body := rec.Body.String(); body != "" {
 		t.Fatalf("copyPipe emitted %q for closed pipe", body)

--- a/worker/cloudflare-container-runner/stdout_truncation_test.go
+++ b/worker/cloudflare-container-runner/stdout_truncation_test.go
@@ -1,0 +1,542 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// slowResponseWriter is an http.ResponseWriter whose Write blocks briefly,
+// simulating a downstream HTTP client that applies backpressure (exactly what
+// eventWriter.write experiences when streaming NDJSON to a slow Cloudflare
+// edge/client). It records everything written.
+type slowResponseWriter struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+	// delay is the per-Write sleep. Zero means the default 2ms. Set once
+	// before the writer is handed to runCommand (i.e. before any copyPipe
+	// goroutine can observe it), so no synchronization is needed to read it.
+	delay time.Duration
+}
+
+func (w *slowResponseWriter) Header() http.Header { return http.Header{} }
+
+func (w *slowResponseWriter) WriteHeader(int) {}
+
+func (w *slowResponseWriter) Write(p []byte) (int, error) {
+	// Simulate a slow consumer. This delay happens INSIDE eventWriter.write,
+	// i.e. inside the copyPipe goroutine, while the child keeps producing.
+	delay := w.delay
+	if delay == 0 {
+		delay = 2 * time.Millisecond
+	}
+	time.Sleep(delay)
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.Write(p)
+}
+
+func (w *slowResponseWriter) body() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.String()
+}
+
+// TestRunCommandDeliversAllStdout proves the cmd.Wait()-before-wg.Wait()
+// ordering bug in runCommand (main.go:204-205).
+//
+// The child writes exactly totalBytes of stdout and exits. Per os/exec docs,
+// cmd.Wait() closes the parent read-ends of StdoutPipe/StderrPipe as soon as
+// the child is reaped — "it is incorrect to call Wait before all reads from
+// the pipe have completed". Because runCommand calls cmd.Wait() BEFORE
+// wg.Wait(), any bytes still sitting in the kernel pipe buffer when the child
+// exits are discarded; the copyPipe goroutine's next Read returns
+// os.ErrClosed, which benignPipeReadError treats as EOF, so the tail of the
+// output is silently dropped with no error event.
+//
+// With correct ordering (wg.Wait() before cmd.Wait()) this test passes.
+func TestRunCommandDeliversAllStdout(t *testing.T) {
+	const totalBytes = 1 << 20 // 1 MiB — far larger than any kernel pipe buffer
+
+	rec := &slowResponseWriter{}
+	writer := &eventWriter{w: rec}
+
+	// Emit exactly totalBytes of 'x' on stdout, then exit immediately.
+	req := execRequest{
+		Command: fmt.Sprintf("head -c %d /dev/zero | tr '\\0' 'x'", totalBytes),
+	}
+
+	code, err := runCommand(context.Background(), req, t.TempDir(), writer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+
+	var got int
+	var errEvents []string
+	scanner := bufio.NewScanner(bytes.NewBufferString(rec.body()))
+	scanner.Buffer(make([]byte, 0, 1<<20), 1<<21)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var ev streamEvent
+		if err := json.Unmarshal(line, &ev); err != nil {
+			t.Fatalf("unmarshal event %q: %v", line, err)
+		}
+		switch ev.Type {
+		case "stdout":
+			got += len(ev.Data)
+		case "error":
+			errEvents = append(errEvents, ev.Error)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(errEvents) > 0 {
+		t.Fatalf("unexpected error events: %v", errEvents)
+	}
+	if got != totalBytes {
+		t.Fatalf("stdout bytes delivered = %d, want %d (lost %d bytes: cmd.Wait() closed the pipe before copyPipe drained it, and os.ErrClosed was masked as EOF)",
+			got, totalBytes, totalBytes-got)
+	}
+}
+
+// TestRunCommandDeliversAllStdoutForLongForegroundCommand proves runCommand
+// does not truncate the output of a FOREGROUND command that runs LONGER than
+// pipeDrainGrace and writes its result right before exiting.
+//
+// This is the hole the earlier "bounded select" design had: it started the
+// pipeDrainGrace timer at the select, BEFORE the child exited, so the grace
+// bounded TOTAL runtime. A legit foreground command running past the grace
+// caused the select to fall through mid-run and call cmd.Wait, which closes the
+// StdoutPipe read-ends the moment the child is reaped — racing the final copy
+// and intermittently truncating the tail (the exact class of bug we fixed).
+//
+// The current design owns the pipe read-ends, so cmd.Wait leaves them open and
+// the full output is delivered no matter how long the command runs. The grace
+// is lowered here so the test stays fast while still outliving it.
+func TestRunCommandDeliversAllStdoutForLongForegroundCommand(t *testing.T) {
+	// A slow consumer keeps copyPipe behind the child, so if cmd.Wait ever
+	// closed the read-ends there would be unread buffered bytes to lose.
+	orig := pipeDrainGrace
+	pipeDrainGrace = 1 * time.Second
+	defer func() { pipeDrainGrace = orig }()
+
+	const tail = 1 << 20 // 1 MiB tail emitted just before the command exits
+	rec := &slowResponseWriter{}
+	writer := &eventWriter{w: rec}
+
+	// sleep 2 (> 1s grace); then emit a large tail and a marker, then exit. On
+	// the old bounded-select design the grace expires at 1s while the command is
+	// still sleeping, and the tail written at ~2s is truncated.
+	req := execRequest{
+		Command: fmt.Sprintf("sleep 2; head -c %d /dev/zero | tr '\\0' 'x'; printf 'RESULT_MARKER'", tail),
+	}
+
+	code, err := runCommand(context.Background(), req, t.TempDir(), writer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+
+	var gotBytes int
+	var stdout strings.Builder
+	var errEvents []string
+	scanner := bufio.NewScanner(bytes.NewBufferString(rec.body()))
+	scanner.Buffer(make([]byte, 0, 1<<20), 1<<21)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var ev streamEvent
+		if err := json.Unmarshal(line, &ev); err != nil {
+			t.Fatalf("unmarshal event %q: %v", line, err)
+		}
+		switch ev.Type {
+		case "stdout":
+			gotBytes += len(ev.Data)
+			stdout.WriteString(ev.Data)
+		case "error":
+			errEvents = append(errEvents, ev.Error)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(errEvents) > 0 {
+		t.Fatalf("unexpected error events: %v", errEvents)
+	}
+	wantBytes := tail + len("RESULT_MARKER")
+	if gotBytes != wantBytes {
+		t.Fatalf("stdout bytes delivered = %d, want %d (lost %d bytes: a foreground command outlived the drain grace and its tail was truncated)",
+			gotBytes, wantBytes, wantBytes-gotBytes)
+	}
+	if !strings.Contains(stdout.String(), "RESULT_MARKER") {
+		t.Fatalf("stdout missing RESULT_MARKER: the final output of a long foreground command was truncated")
+	}
+}
+
+// TestRunCommandReturnsPromptlyWithBackgroundDescendant proves runCommand
+// returns PROMPTLY — near pipeDrainIdle, not the full pipeDrainGrace — for a
+// background descendant that inherits the stdout/stderr write-end and
+// outlives the direct child but never writes anything more itself.
+//
+// The script echoes "done" on the foreground and spawns `sleep 30 &`. The
+// direct child (bash) exits immediately after echoing, but the backgrounded
+// sleep inherits the pipe write-end, so the parent read-ends never reach EOF
+// until the sleep exits ~30s later. A fixed-grace drain (wait the full
+// pipeDrainGrace no matter what, then close) would therefore make every such
+// request pay the full grace latency (measured: ~5.1s) even though there is
+// nothing left to drain — a real regression versus the pre-owned-pipe
+// baseline (~0.2s). The idle-aware drain detects that `copied` stops
+// advancing almost immediately (the silent descendant writes nothing) and
+// closes the read-ends after pipeDrainIdle instead of pipeDrainGrace.
+//
+// This assertion FAILS against the fixed-grace design (elapsed ~= grace) and
+// PASSES against the idle-aware drain (elapsed ~= pipeDrainIdle).
+func TestRunCommandReturnsPromptlyWithBackgroundDescendant(t *testing.T) {
+	rec := &slowResponseWriter{}
+	writer := &eventWriter{w: rec}
+
+	// Foreground writes "done" and exits; the descendant sleep keeps the
+	// inherited write-end open far longer than the drain grace, but (unlike
+	// the noisy-descendant test below) never writes anything itself.
+	req := execRequest{
+		Command: "sleep 30 & echo done",
+	}
+
+	start := time.Now()
+	code, err := runCommand(context.Background(), req, t.TempDir(), writer)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+
+	// Must return WELL under pipeDrainGrace — the whole point of the
+	// idle-aware drain is that a quiet descendant does not force the full
+	// grace latency. Half the grace leaves generous slack for a loaded
+	// machine while still failing hard against the fixed-grace regression.
+	maxElapsed := pipeDrainGrace / 2
+	if elapsed > maxElapsed {
+		t.Fatalf("runCommand took %s, want under %s (idle-aware drain should return near pipeDrainIdle=%s, not wait out the full pipeDrainGrace=%s)",
+			elapsed, maxElapsed, pipeDrainIdle, pipeDrainGrace)
+	}
+
+	var stdout strings.Builder
+	var errEvents []string
+	scanner := bufio.NewScanner(bytes.NewBufferString(rec.body()))
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var ev streamEvent
+		if err := json.Unmarshal(line, &ev); err != nil {
+			t.Fatalf("unmarshal event %q: %v", line, err)
+		}
+		switch ev.Type {
+		case "stdout":
+			stdout.WriteString(ev.Data)
+		case "error":
+			errEvents = append(errEvents, ev.Error)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(errEvents) > 0 {
+		t.Fatalf("unexpected error events: %v", errEvents)
+	}
+	if !strings.Contains(stdout.String(), "done") {
+		t.Fatalf("stdout = %q, want it to contain %q (foreground output must survive the idle-aware drain)", stdout.String(), "done")
+	}
+}
+
+// TestRunCommandBoundsNoisyBackgroundDescendant proves the absolute
+// pipeDrainGrace cap still bounds a background descendant that writes
+// CONTINUOUSLY (unlike the silent `sleep` above), so `copied` never stops
+// advancing and the idle branch of the drain can never fire on its own.
+//
+// pipeDrainGrace is lowered so the test stays fast; the descendant's tight
+// `while true; do echo x; done` loop keeps the inherited stdout write-end
+// busy for the whole drain, so only the cap — not the idle timer — can end
+// the wait.
+func TestRunCommandBoundsNoisyBackgroundDescendant(t *testing.T) {
+	origGrace := pipeDrainGrace
+	pipeDrainGrace = 1 * time.Second
+	defer func() { pipeDrainGrace = origGrace }()
+
+	rec := &slowResponseWriter{}
+	writer := &eventWriter{w: rec}
+
+	// The descendant writes to the inherited stdout write-end as fast as it
+	// can, so `copied` keeps advancing on every poll and the idle deadline
+	// keeps getting pushed out — only the absolute cap can end the drain.
+	req := execRequest{
+		Command: "(while true; do echo x; done) & echo done",
+	}
+
+	start := time.Now()
+	code, err := runCommand(context.Background(), req, t.TempDir(), writer)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+
+	// Lower bound (with small slack for timer/poll granularity): a
+	// continuously-writing descendant must NOT trip the idle branch early.
+	minElapsed := pipeDrainGrace - 50*time.Millisecond
+	if elapsed < minElapsed {
+		t.Fatalf("runCommand returned in %s, want at least ~%s (a continuously-writing descendant should never satisfy the idle branch — did it return near pipeDrainIdle=%s instead?)",
+			elapsed, minElapsed, pipeDrainIdle)
+	}
+	// Upper bound: the cap must still fire promptly once it elapses, with
+	// slack for scheduling and the poll interval, not hang indefinitely.
+	maxElapsed := pipeDrainGrace + 2*time.Second
+	if elapsed > maxElapsed {
+		t.Fatalf("runCommand took %s, want under %s (the absolute pipeDrainGrace cap should still bound a noisy descendant)", elapsed, maxElapsed)
+	}
+
+	var stdout strings.Builder
+	var errEvents []string
+	scanner := bufio.NewScanner(bytes.NewBufferString(rec.body()))
+	scanner.Buffer(make([]byte, 0, 1<<20), 1<<21)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var ev streamEvent
+		if err := json.Unmarshal(line, &ev); err != nil {
+			t.Fatalf("unmarshal event %q: %v", line, err)
+		}
+		switch ev.Type {
+		case "stdout":
+			stdout.WriteString(ev.Data)
+		case "error":
+			errEvents = append(errEvents, ev.Error)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(errEvents) > 0 {
+		t.Fatalf("unexpected error events: %v", errEvents)
+	}
+	if !strings.Contains(stdout.String(), "done") {
+		t.Fatalf("stdout missing %q: foreground output must survive even when a noisy descendant forces the drain to hit its cap", "done")
+	}
+}
+
+// TestRunCommandIdleDrainDeliversBurstyBackgroundOutput proves the idle timer
+// RESETS on genuine progress instead of using a single fixed deadline anchored
+// at the start of the drain.
+//
+// A background descendant emits three markers separated by gaps shorter than
+// pipeDrainIdle, but the TOTAL span across all three bursts is longer than
+// pipeDrainIdle. If the drain used one non-resetting idle deadline (started
+// when the direct child exited) instead of resetting it on every observed
+// `copied` advance, the later bursts would arrive after that deadline and get
+// cut off when the read-ends are closed. pipeDrainIdle/pipeDrainPoll are
+// lowered so the test stays fast and deterministic; pipeDrainGrace is left
+// generous so only the idle logic is under test.
+func TestRunCommandIdleDrainDeliversBurstyBackgroundOutput(t *testing.T) {
+	origIdle := pipeDrainIdle
+	origPoll := pipeDrainPoll
+	origGrace := pipeDrainGrace
+	pipeDrainIdle = 150 * time.Millisecond
+	pipeDrainPoll = 15 * time.Millisecond
+	pipeDrainGrace = 5 * time.Second
+	defer func() {
+		pipeDrainIdle = origIdle
+		pipeDrainPoll = origPoll
+		pipeDrainGrace = origGrace
+	}()
+
+	rec := &slowResponseWriter{}
+	writer := &eventWriter{w: rec}
+
+	// The direct child exits immediately after backgrounding a descendant
+	// that emits three markers separated by 90ms gaps — each gap shorter than
+	// pipeDrainIdle (150ms), so every burst must reset the idle timer. The
+	// TOTAL span (~270ms across the gaps) exceeds pipeDrainIdle, so a
+	// non-resetting single deadline would truncate BURST_B and/or BURST_C.
+	req := execRequest{
+		Command: "(sleep 0.09; echo BURST_A; sleep 0.09; echo BURST_B; sleep 0.09; echo BURST_C) & echo done",
+	}
+
+	start := time.Now()
+	code, err := runCommand(context.Background(), req, t.TempDir(), writer)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+
+	// Still bounded well under the (generous) grace cap.
+	if elapsed > pipeDrainGrace {
+		t.Fatalf("runCommand took %s, want under the pipeDrainGrace cap %s", elapsed, pipeDrainGrace)
+	}
+
+	var stdout strings.Builder
+	var errEvents []string
+	scanner := bufio.NewScanner(bytes.NewBufferString(rec.body()))
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var ev streamEvent
+		if err := json.Unmarshal(line, &ev); err != nil {
+			t.Fatalf("unmarshal event %q: %v", line, err)
+		}
+		switch ev.Type {
+		case "stdout":
+			stdout.WriteString(ev.Data)
+		case "error":
+			errEvents = append(errEvents, ev.Error)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(errEvents) > 0 {
+		t.Fatalf("unexpected error events: %v", errEvents)
+	}
+	got := stdout.String()
+	for _, want := range []string{"done", "BURST_A", "BURST_B", "BURST_C"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("stdout = %q, missing %q (idle timer must reset on progress, not truncate a slow-but-live bursty stream)", got, want)
+		}
+	}
+}
+
+// TestRunCommandNoTruncationUnderSlowResponseWrite proves the fix for the
+// @clawsweeper #1097 [P1] finding: "A response write blocked for more than
+// 300 ms can be mistaken for an idle pipe, recreating silent stdout/stderr
+// truncation under real downstream backpressure."
+//
+// copyPipe only adds a chunk's length to `copied` AFTER writer.write for
+// that chunk returns, so a response write that blocks longer than
+// pipeDrainIdle freezes `copied` for the whole write — indistinguishable
+// from a genuinely idle pipe if the drain loop watches `copied` alone. The
+// fix adds writesInFlight, incremented for the full duration of each
+// writer.write call, and the drain loop treats writesInFlight.Load() > 0 as
+// progress too, so a slow-but-active write can never be mistaken for an
+// idle pipe and the read-ends are never closed mid-flush.
+//
+// This test drives that exact scenario: a slow response writer (200ms per
+// Write, far longer than the lowered pipeDrainIdle) receives a multi-chunk
+// stdout burst, and a backgrounded descendant (`sleep 30 &`) inherits the
+// pipe write-end so the read-ends can never reach a natural EOF on their
+// own — forcing the drain through the idle-aware path this bug lives in.
+// Without the fix, the drain's false-idle detection fires mid-write and
+// closes the read-ends before every byte the child already wrote into the
+// kernel pipe has been read out, silently truncating stdout.
+func TestRunCommandNoTruncationUnderSlowResponseWrite(t *testing.T) {
+	origIdle := pipeDrainIdle
+	origPoll := pipeDrainPoll
+	origGrace := pipeDrainGrace
+	pipeDrainIdle = 50 * time.Millisecond
+	pipeDrainPoll = 10 * time.Millisecond
+	pipeDrainGrace = 15 * time.Second
+	defer func() {
+		pipeDrainIdle = origIdle
+		pipeDrainPoll = origPoll
+		pipeDrainGrace = origGrace
+	}()
+
+	const totalBytes = 256 * 1024 // several 32KiB copyPipe chunks
+
+	// 200ms per write is far larger than the lowered pipeDrainIdle (50ms),
+	// so any drain logic that ignores an in-flight write will see `copied`
+	// stall well past pipeDrainIdle during every single chunk.
+	rec := &slowResponseWriter{delay: 200 * time.Millisecond}
+	writer := &eventWriter{w: rec}
+
+	// Emit a multi-chunk burst on stdout, then background a descendant that
+	// inherits the pipe write-end so the read-ends never reach EOF on their
+	// own once the direct child exits — the drain must rely on idle/grace
+	// detection instead, which is exactly the path the false-idle bug lived
+	// in.
+	req := execRequest{
+		Command: fmt.Sprintf("head -c %d /dev/zero | tr '\\0' 'x'; sleep 30 &", totalBytes),
+	}
+
+	start := time.Now()
+	code, err := runCommand(context.Background(), req, t.TempDir(), writer)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+
+	// Must return well under the descendant's 30s lifetime: runCommand owns
+	// the read-ends and drains idle-aware, so it must not wait out the
+	// backgrounded sleep.
+	if maxElapsed := 20 * time.Second; elapsed > maxElapsed {
+		t.Fatalf("runCommand took %s, want under %s (should not wait for the 30s background descendant)", elapsed, maxElapsed)
+	}
+
+	var got int
+	var errEvents []string
+	scanner := bufio.NewScanner(bytes.NewBufferString(rec.body()))
+	scanner.Buffer(make([]byte, 0, 1<<20), 1<<21)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var ev streamEvent
+		if err := json.Unmarshal(line, &ev); err != nil {
+			t.Fatalf("unmarshal event %q: %v", line, err)
+		}
+		switch ev.Type {
+		case "stdout":
+			got += len(ev.Data)
+		case "error":
+			errEvents = append(errEvents, ev.Error)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(errEvents) > 0 {
+		t.Fatalf("unexpected error events: %v", errEvents)
+	}
+	if got != totalBytes {
+		t.Fatalf("stdout bytes delivered = %d, want %d (lost %d bytes: a response write blocked longer than pipeDrainIdle was mistaken for an idle pipe and the read-ends were closed mid-flush)",
+			got, totalBytes, totalBytes-got)
+	}
+}


### PR DESCRIPTION
fix(worker): own container-runner pipe ends to prevent stdout truncation and exec hangs

## Summary
Give the cloudflare-container-runner exec path **self-owned `os.Pipe()` write-ends** so `cmd.Wait` never closes the read-ends. A long-running foreground command is drained in full (no truncation), and a lingering background descendant that inherited a write-end is bounded by a **drain-until-idle** policy rather than the process's runtime — so exec never hangs and never stalls.

## What to review
| file | change |
|---|---|
| worker/cloudflare-container-runner/main.go | self-owned `os.Pipe()` ends; drain-until-idle (progress counter → 300ms idle close, 5s absolute cap) |
| worker/cloudflare-container-runner/stdout_truncation_test.go | full-output, prompt-return-under-descendant, noisy-descendant-bounded, bursty-idle-reset, long-foreground no-truncation |

## How it works
`runCommand` creates `rOut/wOut`, `rErr/wErr`, sets `cmd.Stdout=wOut`/`cmd.Stderr=wErr`, and after `Start()` closes the parent's write-end copies so only the child and its descendants hold write-ends. The copiers read the parent-owned read-ends, which `cmd.Wait` never touches. Sequence: start copiers → `cmd.Wait` (child may run arbitrarily long; every byte is delivered) → a drain loop that returns instantly on real EOF, else closes the read-ends once (`sync.Once`) after **300ms with no copier progress** (buffered output drained, descendant quiet), bounded by a **5s absolute cap** (a continuously-writing descendant). Zero truncation by construction — the idle timer only fires after progress stops, and a copier blocked in a slow response write (downstream backpressure) is tracked as in-flight rather than idle, so the drain never closes mid-flush.

## Motivation
Fixes stdout truncation. The two prior iterations were correctly rejected: `wg.Wait()` before `cmd.Wait()` introduced an unbounded hang when a background descendant held the inherited pipe (repro `sleep 60 & echo done` → context deadline); a fixed 5s grace then made every such command stall 5s. This drain-until-idle design resolves all three: no truncation, no hang, no stall.

## Testing
- `go build ./...` + `go vet ./...` at repo root and in the runner module; `gofmt` clean.
- `go test -race -run TestRunCommand -count=3 .` (runner module) — green ×3.
- Red→green: the prompt-return assertion (return under `pipeDrainGrace/2`) **fails on the fixed-grace version** (5.1s) and **passes now** (0.55–0.64s). The 1 MiB full-delivery and long-foreground no-truncation guarantees are retained.

## Real-behavior proof
Captured live against the built runner (a standalone HTTP server; no coordinator/lease needed) — base vs this branch:
```
BASE (pre-fix)  1 MiB stream: 1048576/1048576 delivered    sleep 60 & echo done: returned 0.46s, output intact
HEAD (branch)   1 MiB stream: 1048576/1048576 delivered    sleep 60 & echo done: returned 0.80s, output intact
```
The truncation itself is a **race masked by socket buffering** — a slow network client cannot force it (the TCP send buffer + HTTP buffering absorb ~1 MiB before backpressure reaches the copiers), so it does not reproduce as a live base-vs-head differential. The deterministic regression reproduces it directly at the real `runCommand`/`os.Pipe`/subprocess level (base loses 49,152 bytes of 1 MiB; branch delivers all), and this branch eliminates the race by construction. The live capture above confirms the branch delivers full output and returns promptly under a background descendant.
