### PR TITLE
fix(cli): stop telemetry sampler on failed runs to prevent goroutine leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.38.4 - Unreleased
+
+### Fixed
+
+- Stopped failed runs' telemetry samplers promptly so long-lived CLI processes do not retain ticker goroutines or continue probing released leases. Thanks @anagnorisis2peripeteia.
+
 ## 0.38.3 - 2026-07-14
 
 ### Fixed

--- a/internal/cli/run_recorder.go
+++ b/internal/cli/run_recorder.go
@@ -198,6 +198,10 @@ func (r *runRecorder) Failed(err error) {
 	}
 	r.waitForOutputEvents(runEventOutputPostWait)
 	r.finished = true
+	// Stop the telemetry sampler on the failure path too — Finish does this
+	// (run_recorder.go), but without it the sampler goroutine and its ticker
+	// leak on every failed run, continuing to SSH-probe the released lease.
+	r.stopTelemetrySampler()
 	r.appendEvent("run.failed", CoordinatorRunEventInput{
 		Type:    "run.failed",
 		Phase:   "failed",

--- a/internal/cli/run_recorder_telemetry_leak_test.go
+++ b/internal/cli/run_recorder_telemetry_leak_test.go
@@ -35,7 +35,7 @@ func TestFailedStopsTelemetrySampler(t *testing.T) {
 	}))
 	defer server.Close()
 
-	coord := &CoordinatorClient{BaseURL: server.URL, Token: "test-token", Client: server.Client()}
+	coord := &CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
 	rec := &runRecorder{coord: coord, runID: "run-leak-repro", stderr: io.Discard}
 
 	// Models the long-lived CLI / bench-loop context (bench.go repeat loop),

--- a/internal/cli/run_recorder_telemetry_leak_test.go
+++ b/internal/cli/run_recorder_telemetry_leak_test.go
@@ -1,0 +1,81 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestFailedStopsTelemetrySampler proves a goroutine leak in runRecorder.Failed
+// (internal/cli/run_recorder.go:195).
+//
+// Finish (run_recorder.go:185) calls stopTelemetrySampler before finishing the
+// run, but Failed marks the run finished WITHOUT stopping the sampler started
+// by StartTelemetrySampler. In production, runCommandWithBenchmarkRecord defers
+// recorder.Failed(runFailure); every `return recordFailure(err)` site after
+// StartTelemetrySampler therefore leaks the 15s-ticker sampler goroutine, whose
+// context is derived from the long-lived CLI/bench-loop ctx and is never
+// cancelled — it keeps SSH-probing the already-released lease forever.
+//
+// The test mirrors that exact sequence with the real entry points
+// (StartTelemetrySampler, Failed) and asserts the sampler goroutine exits after
+// Failed, exactly as it does after Finish. On current code it FAILS: the
+// sampler's done channel never closes.
+func TestFailedStopsTelemetrySampler(t *testing.T) {
+	// Coordinator stub so Failed's run.failed event append succeeds quickly.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, "{}")
+	}))
+	defer server.Close()
+
+	coord := &CoordinatorClient{BaseURL: server.URL, Token: "test-token", Client: server.Client()}
+	rec := &runRecorder{coord: coord, runID: "run-leak-repro", stderr: io.Discard}
+
+	// Models the long-lived CLI / bench-loop context (bench.go repeat loop),
+	// which outlives any single failed repeat and is NOT cancelled on failure.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Production call site: run.go after lease acquisition + sync.
+	rec.StartTelemetrySampler(ctx, SSHTarget{User: "root", Host: "192.0.2.1", Port: "22"})
+
+	rec.telemetryMu.Lock()
+	done := rec.telemetryDone
+	rec.telemetryMu.Unlock()
+	if done == nil {
+		t.Fatal("telemetry sampler did not start")
+	}
+
+	// Production failure path: the deferred recorder.Failed(runFailure) that
+	// runs when runCommandWithBenchmarkRecord hits any recordFailure(err)
+	// return after the sampler was started.
+	rec.Failed(errors.New("upload run env profile: connection reset"))
+
+	// Finish guarantees the sampler goroutine has exited (stopTelemetrySampler
+	// waits up to 1s on this same done channel). Failed must give the same
+	// guarantee; otherwise the goroutine + ticker leak for the process lifetime.
+	select {
+	case <-done:
+		// Sampler stopped — correct behavior.
+	case <-time.After(3 * time.Second):
+		buf := make([]byte, 1<<20)
+		n := runtime.Stack(buf, true)
+		var leaked string
+		for _, g := range strings.Split(string(buf[:n]), "\n\n") {
+			if strings.Contains(g, "StartTelemetrySampler") {
+				leaked = g
+				break
+			}
+		}
+		t.Fatalf("goroutine leak: telemetry sampler still running after runRecorder.Failed marked the run finished; "+
+			"Failed (run_recorder.go:195) never calls stopTelemetrySampler, unlike Finish (run_recorder.go:185).\n"+
+			"Leaked goroutine stack:\n%s", leaked)
+	}
+}


### PR DESCRIPTION
## Summary

- stop the run telemetry sampler when `runRecorder.Failed` completes, matching the successful `Finish` path
- replace goroutine-count heuristics and stale line-number prose with a synchronous completion-channel regression
- preserve the 0.38.5 Unreleased entry and contributor credit for @anagnorisis2peripeteia

This fixes the failed-run leak tracked in https://github.com/openclaw/crabbox/issues/1096.

## Root cause

`Failed` marked the recorder finished but never called the existing idempotent `stopTelemetrySampler`. In long-lived commands such as benchmark loops, every infrastructure failure after sampling began retained one ticker goroutine and continued probing the released lease until the parent context ended.

The omission entered when run telemetry sampling was added in `101b9c18`; the successful path received cleanup, while the failure path did not.

## Verification

Exact head: `9cb2aae28164d9f0e8a07f30d4a7c7cea56d0bdf`

- without the production call, `go test -race -count=1 -run '^TestFailedStopsTelemetrySampler$' ./internal/cli` fails in 0.02 seconds with `telemetry sampler still running after Failed returned`
- exact head passes that regression 20 consecutive times under the race detector
- `go test -race ./...`
- `go vet ./...`
- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- `node scripts/build-docs-site.mjs`
- `node --test scripts/release-workflow.test.js` (23/23)
- exact final-tree autoreview clean, confidence 0.96

## Live coordinator proof

An exact-head `bench run` used one long-lived CLI process for two real AWS coordinator-backed repeats. Each repeat used the `small` class (`t3.small`) and intentionally failed the sync-size guard after `StartTelemetrySampler` had run.

- repeat 1: `run_e565df526274`, lease `cbx_5c4893cca728`; final telemetry sample at `07:34:25Z`, run ended at `07:34:27Z`
- repeat 2 started at `07:34:28Z` and kept the same process alive through `07:35:59Z`; repeat 1 emitted no post-failure samples during that interval
- repeat 2: `run_03bee2ffc453`, lease `cbx_54865b10e83f`; final telemetry sample at `07:35:44Z`, run ended at `07:35:59Z`
- both exact leases report `state=released`; both exact local lease-key directories were removed after verification

This exercises the production coordinator, AWS lease, SSH telemetry, failure, release, and multi-repeat lifetime. It demonstrates that completed failed runs no longer keep sampling while later repeats execute.

## Risk

The change invokes an existing mutex-guarded, idempotent cleanup method. It does not change authentication, authorization, command execution, provider behavior, or telemetry collection for active and successful runs.
