### PR TITLE
fix(cli): drop in-flight code-server upstream opened after bridge Close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Closed code-server WebSockets whose upstream dial completes after bridge shutdown, preventing orphaned connections and reader goroutines. Thanks @anagnorisis2peripeteia.
 - Stopped failed runs' telemetry samplers promptly so long-lived CLI processes do not retain ticker goroutines or continue probing released leases. Thanks @anagnorisis2peripeteia.
 - Preserved WebVNC reconnect attempt state across consecutive connection failures so retry delays increase instead of repeatedly hammering the coordinator. Thanks @anagnorisis2peripeteia.
 

--- a/internal/cli/code.go
+++ b/internal/cli/code.go
@@ -224,6 +224,7 @@ type codeBridge struct {
 	upstream       map[string]*websocket.Conn
 	pending        map[string][]codeProxyMessage
 	incomingFrames map[string]codePendingWebSocketFrame
+	closed         bool
 	chunkSeq       atomic.Uint64
 }
 
@@ -307,6 +308,7 @@ func (b *codeBridge) Close(code websocket.StatusCode, reason string) {
 	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	b.closed = true
 	for id, conn := range b.upstream {
 		_ = conn.Close(websocket.StatusNormalClosure, "bridge stopped")
 		delete(b.upstream, id)
@@ -415,6 +417,14 @@ func (b *codeBridge) openUpstreamWebSocket(ctx context.Context, msg codeProxyMes
 	}
 	conn.SetReadLimit(maxCodeBridgeReadBytes)
 	b.mu.Lock()
+	if b.closed {
+		// Close ran while we were dialing: registering now would leak this conn
+		// and its reader goroutine, since Close has already swept b.upstream and
+		// will not run again. Drop it instead.
+		b.mu.Unlock()
+		_ = conn.Close(websocket.StatusGoingAway, "bridge closed")
+		return
+	}
 	b.upstream[msg.ID] = conn
 	pending := append([]codeProxyMessage(nil), b.pending[msg.ID]...)
 	delete(b.pending, msg.ID)

--- a/internal/cli/code_bridge_close_race_test.go
+++ b/internal/cli/code_bridge_close_race_test.go
@@ -1,0 +1,137 @@
+package cli
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"nhooyr.io/websocket"
+)
+
+// TestCodeBridgeCloseDropsLateUpstreamWebSocket forces an upstream dial to
+// complete after bridge shutdown. The late connection must close and must not
+// be registered on the dead bridge.
+func TestCodeBridgeCloseDropsLateUpstreamWebSocket(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	dialArrived := make(chan struct{})      // code-server saw the upstream dial
+	releaseUpstream := make(chan struct{})  // let the upstream dial complete
+	upstreamAccepted := make(chan struct{}) // upstream websocket established
+	upstreamClosed := make(chan struct{})   // upstream websocket was closed by bridge
+	testDone := make(chan struct{})
+
+	var dialArrivedOnce sync.Once
+
+	// Fake local code-server: hold the ws_open dial in flight until released,
+	// then accept and keep the websocket open (as the real code-server would).
+	codeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		dialArrivedOnce.Do(func() { close(dialArrived) })
+		select {
+		case <-releaseUpstream:
+		case <-testDone:
+			return
+		}
+		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
+		if err != nil {
+			return
+		}
+		defer close(upstreamClosed)
+		close(upstreamAccepted)
+		// Keep the conn open like a real code-server session; exit with test.
+		readCtx, readCancel := context.WithCancel(r.Context())
+		defer readCancel()
+		go func() {
+			<-testDone
+			readCancel()
+		}()
+		for {
+			if _, _, err := conn.Read(readCtx); err != nil {
+				return
+			}
+		}
+	}))
+
+	// Fake coordinator: send one ws_open, wait until the bridge's upstream
+	// dial is in flight, then drop the connection so Serve returns and Close runs.
+	coord := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		msg := `{"type":"ws_open","id":"leak-1","path":"/ws"}`
+		if err := conn.Write(r.Context(), websocket.MessageText, []byte(msg)); err != nil {
+			return
+		}
+		select {
+		case <-dialArrived:
+		case <-testDone:
+			return
+		}
+		conn.CloseNow() // coordinator websocket drops mid-session
+	}))
+	t.Cleanup(func() {
+		close(testDone)
+		coord.Close()
+		codeServer.Close()
+	})
+
+	ws, _, err := websocket.Dial(ctx, "ws"+coord.URL[len("http"):], nil)
+	if err != nil {
+		t.Fatalf("dial fake coordinator: %v", err)
+	}
+
+	// Mirror the production bridge construction without coordinator auth.
+	b := &codeBridge{
+		ws:             ws,
+		baseURL:        codeServer.URL,
+		client:         &http.Client{Timeout: 30 * time.Second},
+		upstream:       map[string]*websocket.Conn{},
+		pending:        map[string][]codeProxyMessage{},
+		incomingFrames: map[string]codePendingWebSocketFrame{},
+	}
+
+	serveDone := make(chan error, 1)
+	go func() { serveDone <- b.Serve(ctx) }() // deferred b.Close runs before this returns
+
+	select {
+	case <-serveDone:
+		// Serve returned => Close (deferred in Serve) has fully completed.
+	case <-time.After(10 * time.Second):
+		t.Fatal("Serve did not return after coordinator drop")
+	}
+
+	b.mu.Lock()
+	n := len(b.upstream)
+	b.mu.Unlock()
+	if n != 0 {
+		t.Fatalf("sanity: upstream map not empty immediately after Close: %d", n)
+	}
+
+	// Bridge is closed. Now let the in-flight ws_open dial complete, exactly
+	// as when the local code-server answers slowly during a bridge drop.
+	close(releaseUpstream)
+
+	select {
+	case <-upstreamAccepted:
+	case <-time.After(10 * time.Second):
+		t.Fatal("upstream dial never completed after release")
+	}
+
+	// Invariant: the completed in-flight dial must be closed instead of being
+	// registered on the already-closed bridge.
+	select {
+	case <-upstreamClosed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("closed codeBridge left the completed upstream websocket open")
+	}
+	b.mu.Lock()
+	n = len(b.upstream)
+	b.mu.Unlock()
+	if n != 0 {
+		t.Fatalf("closed codeBridge re-registered an upstream websocket: len(b.upstream)=%d after Close", n)
+	}
+}


### PR DESCRIPTION
## Summary

Close a code-server WebSocket whose upstream dial completes after its bridge has shut down, so the finished connection and its reader goroutine are not orphaned.

## What changed

| File | Change |
|---|---|
| `internal/cli/code.go` | Mark the bridge closed under its existing mutex; reject and close any upstream connection whose dial finishes after the final close sweep. |
| `internal/cli/code_bridge_close_race_test.go` | Deterministically force the in-flight-dial-during-close interleaving over real WebSocket sockets. |
| `CHANGELOG.md` | Document the user-visible lifecycle fix and thank @anagnorisis2peripeteia. |

The guard is deliberately post-dial and mutex-protected. Connections registered before shutdown remain covered by the existing `Close` sweep; a connection that lands afterward is closed before map registration or reader startup.

## Verification

Exact reviewed head: `48d69f7a99fdf7c2fcc8e310403ae369b49288a2`

- Deterministic red proof on the unfixed production path: `go test -race -count=1 -run '^TestCodeBridgeCloseDropsLateUpstreamWebSocket$' ./internal/cli` failed after the forced dial completed because the closed bridge left the upstream socket open.
- Fixed-path stress: the same race test passed 20 consecutive iterations under the race detector.
- Full local suite: `go test -race ./...` passed.
- Static/build/docs gates: `go vet ./...`, `go build -trimpath -o bin/crabbox ./cmd/crabbox`, and `node scripts/build-docs-site.mjs` passed.
- Pre-commit autoreview: clean; no accepted or actionable findings; correctness confidence 0.97.

## Live proof

Validated the exact branch binary against the production coordinator and a fresh code-enabled AWS lease:

1. Provisioned the lease and started `crabbox code`; the coordinator health endpoint reported `agentConnected=true` with zero pending requests.
2. Confirmed the spawned SSH tunnel was established and its local listener reached the real remote code-server (`/healthz` responded and the editor root returned an HTTP redirect).
3. Interrupted the bridge cleanly; the coordinator then reported `agentConnected=false`, and both the local bridge process and tunnel listener were absent.
4. Released the AWS lease, confirmed coordinator state `released`, and removed the exact generated local lease-key directory.

The deterministic regression is the exact late-dial interleaving. The live pass validates the surrounding production coordinator, SSH tunnel, code-server, shutdown, and cleanup path. Browser visual interaction was not claimed: the local Chrome DevTools bridge was unavailable, so the portal UI itself was not exercised.
