### PR TITLE
fix(cli): stop shadowing the WebVNC reconnect attempt counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.38.4 - Unreleased
+
+### Fixed
+
+- Preserved WebVNC reconnect attempt state across consecutive connection failures so retry delays increase instead of repeatedly hammering the coordinator. Thanks @anagnorisis2peripeteia.
+
 ## 0.38.3 - 2026-07-14
 
 ### Fixed

--- a/internal/cli/webvnc.go
+++ b/internal/cli/webvnc.go
@@ -467,10 +467,8 @@ func serveWebVNCBridgeSlot(ctx context.Context, cfg webVNCBridgePoolConfig, slot
 	for {
 		bridge, err := connectWebVNCBridge(ctx, cfg.Coord, cfg.LeaseID, cfg.Host, cfg.Port, cfg.RescueCtx.Target, cfg.Log)
 		if err != nil {
-			// Assign to the loop's attempt counter, not a new one: `:=` here
-			// shadowed it, so consecutive failures never incremented attempt and
-			// the reconnect backoff stayed pinned at its first-attempt value.
 			var kind string
+			// Keep attempt outside this block so consecutive failures increase the retry delay.
 			attempt, kind = nextWebVNCBridgeFailure(connectedOnce, attempt)
 			events <- webVNCBridgePoolEvent{Kind: kind, Slot: slot, Attempt: attempt, Err: err}
 			if err := waitWebVNCReconnect(ctx, webVNCReconnectDelay(attempt)); err != nil {

--- a/internal/cli/webvnc.go
+++ b/internal/cli/webvnc.go
@@ -467,7 +467,11 @@ func serveWebVNCBridgeSlot(ctx context.Context, cfg webVNCBridgePoolConfig, slot
 	for {
 		bridge, err := connectWebVNCBridge(ctx, cfg.Coord, cfg.LeaseID, cfg.Host, cfg.Port, cfg.RescueCtx.Target, cfg.Log)
 		if err != nil {
-			attempt, kind := nextWebVNCBridgeFailure(connectedOnce, attempt)
+			// Assign to the loop's attempt counter, not a new one: `:=` here
+			// shadowed it, so consecutive failures never incremented attempt and
+			// the reconnect backoff stayed pinned at its first-attempt value.
+			var kind string
+			attempt, kind = nextWebVNCBridgeFailure(connectedOnce, attempt)
 			events <- webVNCBridgePoolEvent{Kind: kind, Slot: slot, Attempt: attempt, Err: err}
 			if err := waitWebVNCReconnect(ctx, webVNCReconnectDelay(attempt)); err != nil {
 				events <- webVNCBridgePoolEvent{Kind: "fatal", Slot: slot, Err: err}

--- a/internal/cli/webvnc_backoff_shadow_test.go
+++ b/internal/cli/webvnc_backoff_shadow_test.go
@@ -7,28 +7,8 @@ import (
 	"time"
 )
 
-// TestWebVNCBridgeSlotBacksOffAcrossConnectFailures proves that
-// serveWebVNCBridgeSlot loses the attempt counter across consecutive connect
-// failures. At webvnc.go:470 the statement
-//
-//	attempt, kind := nextWebVNCBridgeFailure(connectedOnce, attempt)
-//
-// uses := inside the `if err != nil` block, declaring a NEW inner `attempt`
-// that shadows the loop's counter (declared at webvnc.go:466). The outer
-// counter therefore stays 0 forever, so every failed connect reports
-// Attempt=1 / Kind="initial-error" and the reconnect delay is pinned at
-// webVNCReconnectDelay(1)=500ms instead of backing off linearly to 5s.
-//
-// The intended contract is pinned by the existing unit test
-// TestNextWebVNCBridgeFailureBacksOffInitialFailures (webvnc_test.go): when
-// the returned attempt is threaded back in, the second failure must yield
-// attempt=2 / kind="retry" (1s delay). This test exercises the real loop and
-// asserts that same contract holds end-to-end.
-//
-// connectWebVNCBridge is made to fail instantly and deterministically (no
-// sockets) by setting CRABBOX_WEBVNC_AGENT_BASE_URL to a value with leading
-// whitespace, which webVNCAgentBaseURL rejects before any dial.
 func TestWebVNCBridgeSlotBacksOffAcrossConnectFailures(t *testing.T) {
+	// Leading whitespace fails split-agent URL validation before any network dial.
 	t.Setenv("CRABBOX_WEBVNC_AGENT_BASE_URL", " https://invalid.example:443")
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -38,16 +18,20 @@ func TestWebVNCBridgeSlotBacksOffAcrossConnectFailures(t *testing.T) {
 		Coord:   &CoordinatorClient{BaseURL: "https://coordinator.invalid"},
 		LeaseID: "lease-",
 		Host:    "127.0.0.1",
-		Port:    "1", // never dialed: connect fails at webVNCAgentBaseURL
+		Port:    "1",
 		Log:     io.Discard,
 	}
 
 	events := make(chan webVNCBridgePoolEvent, 16)
-	go serveWebVNCBridgeSlot(ctx, cfg, 0, events)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		serveWebVNCBridgeSlot(ctx, cfg, 0, events)
+	}()
 
-	// Collect the first three failure events from the real slot loop.
 	var got []webVNCBridgePoolEvent
-	deadline := time.After(15 * time.Second)
+	deadline := time.NewTimer(5 * time.Second)
+	defer deadline.Stop()
 	for len(got) < 3 {
 		select {
 		case ev := <-events:
@@ -55,19 +39,24 @@ func TestWebVNCBridgeSlotBacksOffAcrossConnectFailures(t *testing.T) {
 				t.Fatalf("unexpected fatal event: %v", ev.Err)
 			}
 			got = append(got, ev)
-		case <-deadline:
+		case <-deadline.C:
 			t.Fatalf("timed out waiting for failure events; got %d so far: %+v", len(got), got)
 		}
 	}
 	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("WebVNC bridge slot did not stop after cancellation")
+	}
 
 	wantAttempts := []int{1, 2, 3}
 	wantKinds := []string{"initial-error", "retry", "retry"}
 	for i, ev := range got {
 		if ev.Attempt != wantAttempts[i] {
-			t.Errorf("failure %d: Attempt=%d, want %d (attempt counter lost: shadowed by := at webvnc.go:470, backoff pinned at %s instead of %s)",
-				i+1, ev.Attempt, wantAttempts[i],
-				webVNCReconnectDelay(ev.Attempt), webVNCReconnectDelay(wantAttempts[i]))
+			t.Errorf("failure %d: attempt=%d delay=%s, want attempt=%d delay=%s",
+				i+1, ev.Attempt, webVNCReconnectDelay(ev.Attempt),
+				wantAttempts[i], webVNCReconnectDelay(wantAttempts[i]))
 		}
 		if ev.Kind != wantKinds[i] {
 			t.Errorf("failure %d: Kind=%q, want %q", i+1, ev.Kind, wantKinds[i])

--- a/internal/cli/webvnc_backoff_shadow_test.go
+++ b/internal/cli/webvnc_backoff_shadow_test.go
@@ -1,0 +1,76 @@
+package cli
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+)
+
+// TestWebVNCBridgeSlotBacksOffAcrossConnectFailures proves that
+// serveWebVNCBridgeSlot loses the attempt counter across consecutive connect
+// failures. At webvnc.go:470 the statement
+//
+//	attempt, kind := nextWebVNCBridgeFailure(connectedOnce, attempt)
+//
+// uses := inside the `if err != nil` block, declaring a NEW inner `attempt`
+// that shadows the loop's counter (declared at webvnc.go:466). The outer
+// counter therefore stays 0 forever, so every failed connect reports
+// Attempt=1 / Kind="initial-error" and the reconnect delay is pinned at
+// webVNCReconnectDelay(1)=500ms instead of backing off linearly to 5s.
+//
+// The intended contract is pinned by the existing unit test
+// TestNextWebVNCBridgeFailureBacksOffInitialFailures (webvnc_test.go): when
+// the returned attempt is threaded back in, the second failure must yield
+// attempt=2 / kind="retry" (1s delay). This test exercises the real loop and
+// asserts that same contract holds end-to-end.
+//
+// connectWebVNCBridge is made to fail instantly and deterministically (no
+// sockets) by setting CRABBOX_WEBVNC_AGENT_BASE_URL to a value with leading
+// whitespace, which webVNCAgentBaseURL rejects before any dial.
+func TestWebVNCBridgeSlotBacksOffAcrossConnectFailures(t *testing.T) {
+	t.Setenv("CRABBOX_WEBVNC_AGENT_BASE_URL", " https://invalid.example:443")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := webVNCBridgePoolConfig{
+		Coord:   &CoordinatorClient{BaseURL: "https://coordinator.invalid"},
+		LeaseID: "lease-",
+		Host:    "127.0.0.1",
+		Port:    "1", // never dialed: connect fails at webVNCAgentBaseURL
+		Log:     io.Discard,
+	}
+
+	events := make(chan webVNCBridgePoolEvent, 16)
+	go serveWebVNCBridgeSlot(ctx, cfg, 0, events)
+
+	// Collect the first three failure events from the real slot loop.
+	var got []webVNCBridgePoolEvent
+	deadline := time.After(15 * time.Second)
+	for len(got) < 3 {
+		select {
+		case ev := <-events:
+			if ev.Kind == "fatal" {
+				t.Fatalf("unexpected fatal event: %v", ev.Err)
+			}
+			got = append(got, ev)
+		case <-deadline:
+			t.Fatalf("timed out waiting for failure events; got %d so far: %+v", len(got), got)
+		}
+	}
+	cancel()
+
+	wantAttempts := []int{1, 2, 3}
+	wantKinds := []string{"initial-error", "retry", "retry"}
+	for i, ev := range got {
+		if ev.Attempt != wantAttempts[i] {
+			t.Errorf("failure %d: Attempt=%d, want %d (attempt counter lost: shadowed by := at webvnc.go:470, backoff pinned at %s instead of %s)",
+				i+1, ev.Attempt, wantAttempts[i],
+				webVNCReconnectDelay(ev.Attempt), webVNCReconnectDelay(wantAttempts[i]))
+		}
+		if ev.Kind != wantKinds[i] {
+			t.Errorf("failure %d: Kind=%q, want %q", i+1, ev.Kind, wantKinds[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Preserve the WebVNC bridge slot's reconnect attempt counter across consecutive connection failures.
- Let the existing retry schedule increase from 500 ms toward its 5 s cap instead of remaining pinned to the first-attempt delay.
- Add a production-loop regression test and a 0.38.5 unreleased changelog entry crediting @anagnorisis2peripeteia.

Part of https://github.com/openclaw/crabbox/issues/1096.

AI-assisted: yes. The contributor found the candidate through a concurrency audit, then the behavior was independently reproduced, reviewed, improved, and live-tested by a maintainer.

## Root cause

The connection-error branch used a short declaration for `attempt` and `kind`. That created a block-scoped `attempt`, discarded the incremented value, and left the loop's counter at zero. Every consecutive pre-connect failure was therefore reported as attempt 1 with the initial 500 ms delay.

## Implementation

- Declare only `kind` inside the error branch.
- Assign the helper result back into the loop-owned `attempt` counter.
- Drive the real bridge-slot loop through three deterministic connection failures.
- Cancel and join the test goroutine so the regression itself cannot leak work or outlive its environment override.

## Verification

Deterministic red/green proof:

- With the original short declaration temporarily restored, the focused race test failed: failures 2 and 3 both reported attempt 1, delay 500 ms, and `initial-error`.
- Restoring the fix made the focused race test pass 10 consecutive runs.
- `go test -race ./...` passed across the CLI and all providers.
- `go vet ./...` passed.
- The release guard passed 22/22 tests, the docs site built, and final branch autoreview reported no actionable findings with 0.98 confidence.

Live behavior proof on the exact branch head:

- Created a bounded AWS `t3.large` desktop lease with a 20-minute TTL and 10-minute idle timeout.
- Verified the desktop session, display, VNC service, input tooling, capture tooling, and a normal coordinator-backed WebVNC bridge connection.
- Used a local-loopback WebSocket fault agent that accepted one bridge connection and then returned HTTP 503 for reconnects. Real coordinator ticket creation and the real SSH/VNC tunnel remained in the path.
- The four live bridge slots advanced their printed retry delays through 1 s, 1.5 s, 2 s, 2.5 s, and 3 s instead of remaining at 500 ms.
- Released the lease and verified both its lease and provider instance were absent from inventory.

## Scope and risk

No helper schedule, pool architecture, authentication path, permission, dependency, or network trust boundary changed. A browser viewer interaction was not needed for this retry-state fix; the normal bridge handshake and coordinator/VNC data path were exercised directly.
