### PR TITLE
fix(cli): don't report ctx-killed pond-mesh forwards as failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Kept pond SSH forwards process-owned and grouped each member's ports into one connection, so terminal teardown reaps tunnels and helpers without hiding genuine failures or multiplying handshakes. Thanks @anagnorisis2peripeteia.
 - Preserved foreground container-runner output buffered behind slow HTTP clients when the detached-descendant drain cap expires.
 - Delivered server-first mediated-egress bytes after the local proxy handshake without letting one slow stream block unrelated connections. Thanks @anagnorisis2peripeteia.
 - Serialized complete per-lease egress host-daemon starts and stops and atomically replaced the remote client, preventing concurrent lifecycle commands and ordinary restarts from leaving untracked or stale processes. Thanks @anagnorisis2peripeteia.

--- a/docs/commands/pond.md
+++ b/docs/commands/pond.md
@@ -129,7 +129,7 @@ availability against `127.0.0.1`.
 
 Without `--export`, the command starts the forwards, prints the export lines and
 the paths of the rendered files, then blocks until interrupted (Ctrl-C), keeping
-all tunnels alive:
+all tunnels alive. Ports for the same member share one owned SSH process:
 
 ```text
 pond "alpha" SSH-mesh ready (2 forwards)
@@ -139,13 +139,17 @@ wrote /Users/alice/.crabbox/pond/alpha/hosts
 wrote /Users/alice/.crabbox/pond/alpha/env
 ```
 
+Ctrl-Z is treated as teardown rather than suspension, so a stopped CLI cannot
+leave active forwarding processes behind.
+
 ### Export (daemon) mode
 
-With `--export`, the command starts each forward as a daemon process that
-survives the CLI exit, verifies none exit immediately (wrong key, host
-unreachable, …), records the PIDs in `~/.crabbox/pond/<name>/daemon.json`, prints
-the `export` lines to stdout, and exits. Daemon mode runs on macOS and Linux
-operator hosts only; on Windows, run `pond connect` without `--export`.
+With `--export`, the command starts one daemon process per member containing all
+of that member's forwards. The processes survive the CLI exit; Crabbox verifies
+none exit immediately (wrong key, host unreachable, …), records the PIDs in
+`~/.crabbox/pond/<name>/daemon.json`, prints the `export` lines to stdout, and
+exits. Daemon mode runs on macOS and Linux operator hosts only; on Windows, run
+`pond connect` without `--export`.
 
 ```bash
 eval $(crabbox pond connect alpha --export)

--- a/internal/cli/pond_mesh.go
+++ b/internal/cli/pond_mesh.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -80,6 +81,20 @@ type pondMeshHandle interface {
 	Process() processSignaler
 	PID() int
 	String() string
+	// WasTerminatedByOurCancel reports whether THIS process's Wait error is
+	// attributable solely to our own teardown rather than a genuine failure.
+	// Teardown is exec.CommandContext's DEFAULT cancellation — SIGKILL on Unix,
+	// TerminateProcess on Windows — recorded per-forward by the ctx watchdog's
+	// Cancel hook. The connect loop never infers intent from the shared context,
+	// which under a race can misattribute one forward's genuine failure to
+	// another forward's cancellation. On Unix our SIGKILL is uncatchable, so our
+	// kill is always ProcessState.Signaled() while a peer that reached its own
+	// nonzero exit code is Exited() — unambiguous. On Windows there are no
+	// signals, so the provenance flag governs, except that a process our kill
+	// found already gone died on its own and is treated as a genuine exit. A
+	// genuine failure therefore returns false even when the shared context was
+	// cancelled first.
+	WasTerminatedByOurCancel() bool
 }
 
 // processSignaler is the subset of *os.Process that the connect loop touches
@@ -96,7 +111,21 @@ type processSignaler interface {
 type pondMeshExecRunner struct{}
 
 func (pondMeshExecRunner) Command(ctx context.Context, name string, args ...string) pondMeshHandle {
-	return &pondMeshExecHandle{cmd: exec.CommandContext(ctx, name, args...)}
+	h := &pondMeshExecHandle{cmd: exec.CommandContext(ctx, name, args...)}
+	// Keep exec.CommandContext's DEFAULT cancellation — SIGKILL on Unix,
+	// TerminateProcess on Windows — the long-standing Crabbox SSH teardown
+	// behaviour. We override Cancel ONLY to record provenance: mark that WE
+	// initiated this process's teardown (before the kill lands, so a concurrent
+	// Wait observes the flag) and, on Windows, note whether the kill found the
+	// process had already exited on its own. We deliberately do NOT send a
+	// graceful, catchable signal first: an ssh that trapped SIGINT and exited
+	// non-zero would report ProcessState.Exited(), indistinguishable from a
+	// genuine tunnel failure. SIGKILL cannot be caught, so on Unix our own
+	// teardown is always Signaled() — letting WasTerminatedByOurCancel suppress
+	// it without ever consulting the shared context, so a different forward's
+	// genuine failure is never misclassified as our cancellation.
+	h.cmd.Cancel = h.cancelAndKill
+	return h
 }
 
 // pondMeshDaemonRunner creates SSH tunnel processes that survive the parent
@@ -114,6 +143,17 @@ func (pondMeshDaemonRunner) Command(_ context.Context, name string, args ...stri
 
 type pondMeshExecHandle struct {
 	cmd *exec.Cmd
+	// cancelled records that our own teardown (the ctx watchdog's Cancel hook)
+	// is terminating this process. It is set before the kill is delivered so a
+	// concurrent Wait always observes it.
+	cancelled atomic.Bool
+	// killFoundExited records that our kill found the process had ALREADY exited
+	// on its own. It is only meaningful on Windows, where our TerminateProcess
+	// is otherwise indistinguishable from a genuine exit: a process that died
+	// before our kill landed is a genuine result, not our teardown. On Unix the
+	// terminal ProcessState (Signaled vs Exited) is authoritative and this flag
+	// is ignored.
+	killFoundExited atomic.Bool
 }
 
 func (h *pondMeshExecHandle) Start() error   { return h.cmd.Start() }
@@ -130,6 +170,39 @@ func (h *pondMeshExecHandle) Process() processSignaler {
 		return nil
 	}
 	return h.cmd.Process
+}
+
+// cancelAndKill is the exec.CommandContext Cancel hook. It records that OUR
+// teardown initiated this process's termination, then performs the platform
+// default kill (SIGKILL on Unix, TerminateProcess on Windows via os.Process.Kill).
+// An os.ErrProcessDone from the kill means the process finished on its own
+// before our kill landed; we note that so the Windows classifier can treat the
+// exit as genuine. The cancelled flag is stored before the kill so a concurrent
+// Wait observes it.
+func (h *pondMeshExecHandle) cancelAndKill() error {
+	h.cancelled.Store(true)
+	p := h.cmd.Process
+	if p == nil {
+		return nil
+	}
+	if err := p.Kill(); err != nil {
+		if errors.Is(err, os.ErrProcessDone) {
+			h.killFoundExited.Store(true)
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func (h *pondMeshExecHandle) WasTerminatedByOurCancel() bool {
+	if !h.cancelled.Load() {
+		// We never touched this process, so any Wait error is a genuine
+		// failure regardless of whether the shared context was cancelled by a
+		// sibling forward or the caller.
+		return false
+	}
+	return killAttributableToCancel(h.cmd.ProcessState, h.killFoundExited.Load())
 }
 
 // pondMeshDefaultRunner is overridden in tests via the package-level pointer
@@ -998,18 +1071,28 @@ func runPondMeshForwards(ctx context.Context, opts pondConnectOptions, members [
 		go func(rf runningForward) {
 			defer wg.Done()
 			err := rf.handle.Wait()
-			if err != nil && !errors.Is(err, context.Canceled) {
+			// Classify by PER-FORWARD provenance, never the shared context.
+			// Reading ctx.Err() here is unsafe under a race: if a sibling
+			// forward or the caller cancels first, ctx.Err() is non-nil by the
+			// time THIS forward's genuine failure is classified, and its error
+			// would be silently discarded. Instead we suppress a Wait error
+			// only when OUR teardown terminated THIS specific process (portable
+			// across SIGINT/SIGKILL on Unix and TerminateProcess on Windows).
+			// A genuine non-zero exit the peer reached on its own is still
+			// recorded even when the shared context was already cancelled.
+			if err != nil && !rf.handle.WasTerminatedByOurCancel() {
 				firstErrOnce.Do(func() { firstErr = err })
 			}
 			cancel()
 		}(rf)
 	}
 	<-ctx.Done()
-	for _, rf := range running {
-		if proc := rf.handle.Process(); proc != nil {
-			_ = proc.Signal(os.Interrupt)
-		}
-	}
+	// Teardown is exec.CommandContext's DEFAULT cancellation: cancelling the
+	// derived ctx above fires each handle's Cancel hook, which records
+	// provenance and delivers the platform kill (SIGKILL on Unix,
+	// TerminateProcess on Windows). We intentionally send no catchable signal
+	// of our own — an ssh that trapped SIGINT and exited non-zero would look
+	// like a genuine failure. Just wait for every waiter to finish reaping.
 	wg.Wait()
 	return firstErr
 }

--- a/internal/cli/pond_mesh.go
+++ b/internal/cli/pond_mesh.go
@@ -47,6 +47,10 @@ const pondMeshLocalPortStart = 51820
 // large ponds simultaneously without exhausting it.
 const pondMeshLocalPortEnd = 52819
 
+// pondMeshCancelWaitDelay bounds the exec.CommandContext fallback when a
+// platform teardown API reports an error before the SSH root has exited.
+const pondMeshCancelWaitDelay = 5 * time.Second
+
 // pondMeshHostsRoot is the per-user state directory under HOME where
 // `pond connect` writes the rendered hosts and env files. The structure
 // mirrors the existing ~/.crabbox layout other commands already use.
@@ -83,17 +87,16 @@ type pondMeshHandle interface {
 	String() string
 	// WasTerminatedByOurCancel reports whether THIS process's Wait error is
 	// attributable solely to our own teardown rather than a genuine failure.
-	// Teardown is exec.CommandContext's DEFAULT cancellation — SIGKILL on Unix,
-	// TerminateProcess on Windows — recorded per-forward by the ctx watchdog's
-	// Cancel hook. The connect loop never infers intent from the shared context,
-	// which under a race can misattribute one forward's genuine failure to
-	// another forward's cancellation. On Unix our SIGKILL is uncatchable, so our
+	// Teardown is a hard kill of the isolated process group/tree, recorded
+	// per-member process by the ctx watchdog's Cancel hook. The connect loop never
+	// infers intent from the shared context,
+	// which under a race can misattribute one member's genuine failure to
+	// another member's cancellation. On Unix our SIGKILL is uncatchable, so our
 	// kill is always ProcessState.Signaled() while a peer that reached its own
 	// nonzero exit code is Exited() — unambiguous. On Windows there are no
-	// signals, so the provenance flag governs, except that a process our kill
-	// found already gone died on its own and is treated as a genuine exit. A
-	// genuine failure therefore returns false even when the shared context was
-	// cancelled first.
+	// signals, so the Job Object's cancellation-only exit code provides the
+	// terminal provenance. A genuine failure therefore returns false even when
+	// the shared context was cancelled first.
 	WasTerminatedByOurCancel() bool
 }
 
@@ -111,18 +114,19 @@ type processSignaler interface {
 type pondMeshExecRunner struct{}
 
 func (pondMeshExecRunner) Command(ctx context.Context, name string, args ...string) pondMeshHandle {
-	h := &pondMeshExecHandle{cmd: exec.CommandContext(ctx, name, args...)}
-	// Keep exec.CommandContext's DEFAULT cancellation — SIGKILL on Unix,
-	// TerminateProcess on Windows — the long-standing Crabbox SSH teardown
-	// behaviour. We override Cancel ONLY to record provenance: mark that WE
-	// initiated this process's teardown (before the kill lands, so a concurrent
-	// Wait observes the flag) and, on Windows, note whether the kill found the
-	// process had already exited on its own. We deliberately do NOT send a
-	// graceful, catchable signal first: an ssh that trapped SIGINT and exited
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.WaitDelay = pondMeshCancelWaitDelay
+	h := &pondMeshExecHandle{cmd: cmd, managed: true}
+	// Keep exec.CommandContext's hard-cancel semantics, but terminate the full
+	// isolated process group/tree so ProxyCommand and wrapper descendants cannot
+	// survive their SSH leader. We override Cancel to record provenance: mark
+	// that WE initiated this process's teardown before the kill lands, so a
+	// concurrent Wait observes the flag. We deliberately do NOT send a graceful,
+	// catchable signal first: an ssh that trapped SIGINT and exited
 	// non-zero would report ProcessState.Exited(), indistinguishable from a
 	// genuine tunnel failure. SIGKILL cannot be caught, so on Unix our own
 	// teardown is always Signaled() — letting WasTerminatedByOurCancel suppress
-	// it without ever consulting the shared context, so a different forward's
+	// it without ever consulting the shared context, so a different member's
 	// genuine failure is never misclassified as our cancellation.
 	h.cmd.Cancel = h.cancelAndKill
 	return h
@@ -142,22 +146,20 @@ func (pondMeshDaemonRunner) Command(_ context.Context, name string, args ...stri
 }
 
 type pondMeshExecHandle struct {
-	cmd *exec.Cmd
+	cmd      *exec.Cmd
+	managed  bool
+	platform pondMeshPlatformState
 	// cancelled records that our own teardown (the ctx watchdog's Cancel hook)
 	// is terminating this process. It is set before the kill is delivered so a
 	// concurrent Wait always observes it.
 	cancelled atomic.Bool
-	// killFoundExited records that our kill found the process had ALREADY exited
-	// on its own. It is only meaningful on Windows, where our TerminateProcess
-	// is otherwise indistinguishable from a genuine exit: a process that died
-	// before our kill landed is a genuine result, not our teardown. On Unix the
-	// terminal ProcessState (Signaled vs Exited) is authoritative and this flag
-	// is ignored.
-	killFoundExited atomic.Bool
+	// cancelFailed makes cleanup/inventory failures observable instead of
+	// suppressing them as an ordinary operator cancellation.
+	cancelFailed atomic.Bool
+	cancelErrMu  sync.Mutex
+	cancelErr    error
 }
 
-func (h *pondMeshExecHandle) Start() error   { return h.cmd.Start() }
-func (h *pondMeshExecHandle) Wait() error    { return h.cmd.Wait() }
 func (h *pondMeshExecHandle) String() string { return h.cmd.String() }
 func (h *pondMeshExecHandle) PID() int {
 	if h.cmd.Process == nil {
@@ -173,36 +175,51 @@ func (h *pondMeshExecHandle) Process() processSignaler {
 }
 
 // cancelAndKill is the exec.CommandContext Cancel hook. It records that OUR
-// teardown initiated this process's termination, then performs the platform
-// default kill (SIGKILL on Unix, TerminateProcess on Windows via os.Process.Kill).
+// teardown initiated this process's termination, then hard-kills its complete
+// isolated process group/tree.
 // An os.ErrProcessDone from the kill means the process finished on its own
-// before our kill landed; we note that so the Windows classifier can treat the
-// exit as genuine. The cancelled flag is stored before the kill so a concurrent
-// Wait observes it.
+// before our kill landed. The cancelled flag is stored before the kill so a
+// concurrent Wait observes it.
 func (h *pondMeshExecHandle) cancelAndKill() error {
 	h.cancelled.Store(true)
-	p := h.cmd.Process
-	if p == nil {
+	if h.cmd.Process == nil {
 		return nil
 	}
-	if err := p.Kill(); err != nil {
+	if err := terminatePondMeshForwardProcess(h); err != nil {
 		if errors.Is(err, os.ErrProcessDone) {
-			h.killFoundExited.Store(true)
-			return nil
+			return os.ErrProcessDone
 		}
+		h.cancelFailed.Store(true)
+		h.cancelErrMu.Lock()
+		h.cancelErr = err
+		h.cancelErrMu.Unlock()
 		return err
 	}
 	return nil
+}
+
+func (h *pondMeshExecHandle) joinCancellationError(err error) error {
+	h.cancelErrMu.Lock()
+	defer h.cancelErrMu.Unlock()
+	if h.cancelErr == nil || errors.Is(err, h.cancelErr) {
+		return err
+	}
+	return errors.Join(err, h.cancelErr)
 }
 
 func (h *pondMeshExecHandle) WasTerminatedByOurCancel() bool {
 	if !h.cancelled.Load() {
 		// We never touched this process, so any Wait error is a genuine
 		// failure regardless of whether the shared context was cancelled by a
-		// sibling forward or the caller.
+		// sibling member or the caller.
 		return false
 	}
-	return killAttributableToCancel(h.cmd.ProcessState, h.killFoundExited.Load())
+	if h.cancelFailed.Load() {
+		// Cleanup itself failed. Surface that error instead of disguising a
+		// possible surviving process tree as clean cancellation.
+		return false
+	}
+	return killAttributableToCancel(h.cmd.ProcessState)
 }
 
 // pondMeshDefaultRunner is overridden in tests via the package-level pointer
@@ -420,35 +437,36 @@ func (a App) pondConnect(ctx context.Context, args []string) error {
 			return err
 		}
 		daemonRunner := pondMeshDaemonRunner{}
-		peerTarget := pondSSHTargetsByLease(members)
+		groups, err := pondMeshForwardGroups(members, summary.Forwards)
+		if err != nil {
+			return err
+		}
 		var started []pondMeshHandle
-		for _, fwd := range summary.Forwards {
-			target, ok := peerTarget[fwd.LeaseID]
-			if !ok {
-				stopDaemonHandles(started)
-				return exit(7, "no SSH target resolved for pond peer %q", fwd.Peer)
-			}
-			args := pondMeshSSHArgsForForward(target, fwd)
+		var startedGroups []pondMeshForwardGroup
+		for _, group := range groups {
+			args := pondMeshSSHArgsForForwards(group.Target, group.Forwards)
 			handle := daemonRunner.Command(context.Background(), "ssh", args...)
 			if err := handle.Start(); err != nil {
 				stopDaemonHandles(started)
-				return fmt.Errorf("start ssh -L %d:%d for %s: %w", fwd.LocalPort, fwd.RemotePort, fwd.Peer, err)
+				return fmt.Errorf("start ssh forwards for %s: %w", pondMeshForwardGroupLabel(group.Forwards), err)
 			}
 			started = append(started, handle)
-			fmt.Fprintf(opts.Stderr, "  -L 127.0.0.1:%d -> %s:%d\n", fwd.LocalPort, fwd.Peer, fwd.RemotePort)
+			startedGroups = append(startedGroups, group)
+			for _, fwd := range group.Forwards {
+				fmt.Fprintf(opts.Stderr, "  -L 127.0.0.1:%d -> %s:%d\n", fwd.LocalPort, fwd.Peer, fwd.RemotePort)
+			}
 		}
 		// Give tunnels a brief window to complete authentication and forward
 		// setup, then verify none exited immediately (wrong key, host unreachable, ...).
 		waitCh := make(chan error, len(started))
 		for i, h := range started {
-			go func(i int, h pondMeshHandle) {
+			go func(group pondMeshForwardGroup, h pondMeshHandle) {
 				err := h.Wait()
-				label := fmt.Sprintf("%s:%d", summary.Forwards[i].Peer, summary.Forwards[i].RemotePort)
 				select {
-				case waitCh <- fmt.Errorf("ssh -L for %s exited immediately: %w", label, err):
+				case waitCh <- fmt.Errorf("ssh forwards for %s exited immediately: %w", pondMeshForwardGroupLabel(group.Forwards), err):
 				default:
 				}
-			}(i, h)
+			}(startedGroups[i], h)
 		}
 		select {
 		case err := <-waitCh:
@@ -456,7 +474,7 @@ func (a App) pondConnect(ctx context.Context, args []string) error {
 			return err
 		case <-time.After(200 * time.Millisecond):
 		}
-		if err := writePondMeshDaemonState(opts.HomeDir, pond, summary, started); err != nil {
+		if err := writePondMeshDaemonState(opts.HomeDir, pond, summary, startedGroups, started); err != nil {
 			stopDaemonHandles(started)
 			return err
 		}
@@ -875,7 +893,7 @@ func stopDaemonHandles(handles []pondMeshHandle) {
 	}
 }
 
-func writePondMeshDaemonState(home, pond string, summary pondMeshSummary, handles []pondMeshHandle) error {
+func writePondMeshDaemonState(home, pond string, summary pondMeshSummary, groups []pondMeshForwardGroup, handles []pondMeshHandle) error {
 	path, err := pondMeshDaemonStatePath(home, pond, true)
 	if err != nil {
 		return err
@@ -886,8 +904,8 @@ func writePondMeshDaemonState(home, pond string, summary pondMeshSummary, handle
 		if pid := handle.PID(); pid > 0 {
 			pids = append(pids, pid)
 			process := pondMeshDaemonProcess{PID: pid, Command: handle.String()}
-			if i < len(summary.Forwards) {
-				process.Forward = summary.Forwards[i]
+			if i < len(groups) && len(groups[i].Forwards) > 0 {
+				process.Forward = groups[i].Forwards[0]
 			}
 			processes = append(processes, process)
 		}
@@ -1016,81 +1034,161 @@ func pondResolveIDForServer(server Server) string {
 	return serverSlug(server)
 }
 
-// pondMeshSSHArgsForForward builds the `ssh -L ...` argument vector for one
-// forward. It re-uses the same SSH options as the rest of the CLI.
-func pondMeshSSHArgsForForward(target SSHTarget, fwd pondMeshForward) []string {
+type pondMeshForwardGroup struct {
+	Target   SSHTarget
+	Forwards []pondMeshForward
+}
+
+func pondMeshForwardGroups(members []pondMember, forwards []pondMeshForward) ([]pondMeshForwardGroup, error) {
+	peerTarget := pondSSHTargetsByLease(members)
+	groupIndex := make(map[string]int, len(peerTarget))
+	groups := make([]pondMeshForwardGroup, 0, len(peerTarget))
+	for _, fwd := range forwards {
+		target, ok := peerTarget[fwd.LeaseID]
+		if !ok {
+			return nil, exit(7, "no SSH target resolved for pond peer %q", fwd.Peer)
+		}
+		index, ok := groupIndex[fwd.LeaseID]
+		if !ok {
+			index = len(groups)
+			groupIndex[fwd.LeaseID] = index
+			groups = append(groups, pondMeshForwardGroup{Target: target})
+		}
+		groups[index].Forwards = append(groups[index].Forwards, fwd)
+	}
+	return groups, nil
+}
+
+func pondMeshForwardGroupLabel(forwards []pondMeshForward) string {
+	if len(forwards) == 0 {
+		return "unknown peer"
+	}
+	ports := make([]string, 0, len(forwards))
+	for _, fwd := range forwards {
+		ports = append(ports, strconv.Itoa(fwd.RemotePort))
+	}
+	return fmt.Sprintf("%s:%s", forwards[0].Peer, strings.Join(ports, ","))
+}
+
+// pondMeshSSHArgsForForwards builds one owned `ssh` argument vector containing
+// every `-L` for a member. One connection per member avoids both multiplexed
+// background masters and concurrent per-port handshakes.
+func pondMeshSSHArgsForForwards(target SSHTarget, forwards []pondMeshForward) []string {
+	// A pond member tunnel must remain the process owned by its exec.Cmd. Reusing a
+	// persistent master lets the short-lived mux client exit while the master
+	// retains the listener, so cancellation cannot reap or classify the tunnel.
+	target.NoControlMaster = true
 	args := append([]string{}, sshBaseArgs(target)...)
-	forward := fmt.Sprintf("127.0.0.1:%d:127.0.0.1:%d", fwd.LocalPort, fwd.RemotePort)
 	args = append(args,
+		"-o", "ControlPath=none",
+		"-o", "ControlPersist=no",
 		"-N",
 		"-o", "ExitOnForwardFailure=yes",
-		"-L", forward,
-		target.User+"@"+target.Host,
 	)
+	for _, fwd := range forwards {
+		forward := fmt.Sprintf("127.0.0.1:%d:127.0.0.1:%d", fwd.LocalPort, fwd.RemotePort)
+		args = append(args, "-L", forward)
+	}
+	args = append(args, target.User+"@"+target.Host)
 	return args
 }
 
-// runPondMeshForwards spawns one ssh -L per forward in the summary, waits for
-// ctx cancellation or any process exit, and tears the rest down. The
-// orchestration is deliberately simple: ControlMaster + ControlPersist (from
-// sshBaseArgs) reuses a single underlying TCP connection per peer so the
-// fan-out is cheap.
+// runPondMeshForwards spawns one SSH process per member, with all that member's
+// -L specifications, then waits for ctx cancellation or any process exit and
+// tears the rest down. Each member owns one non-multiplexed SSH process so
+// cancellation owns its complete lifetime and process tree.
 func runPondMeshForwards(ctx context.Context, opts pondConnectOptions, members []pondMember, summary pondMeshSummary) error {
+	terminationCtx, stopTerminationSignals := pondMeshTerminationContext(ctx)
+	defer stopTerminationSignals()
 	runner := opts.Runner
 	if runner == nil {
 		runner = pondMeshDefaultRunner
 	}
-	peerTarget := pondSSHTargetsByLease(members)
-	type runningForward struct {
-		fwd    pondMeshForward
+	groups, err := pondMeshForwardGroups(members, summary.Forwards)
+	if err != nil {
+		return err
+	}
+	type runningForwardGroup struct {
+		group  pondMeshForwardGroup
 		handle pondMeshHandle
 	}
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithCancel(terminationCtx)
 	defer cancel()
-	running := []runningForward{}
-	for _, fwd := range summary.Forwards {
-		target, ok := peerTarget[fwd.LeaseID]
-		if !ok {
-			cancel()
-			return exit(7, "no SSH target resolved for pond peer %q", fwd.Peer)
+	running := []runningForwardGroup{}
+	reapStarted := func() error {
+		var wg sync.WaitGroup
+		waitErrs := make([]error, len(running))
+		terminatedByCancel := make([]bool, len(running))
+		for i, rf := range running {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				waitErrs[i] = rf.handle.Wait()
+				terminatedByCancel[i] = rf.handle.WasTerminatedByOurCancel()
+			}()
 		}
-		args := pondMeshSSHArgsForForward(target, fwd)
+		wg.Wait()
+		for i, rf := range running {
+			if waitErrs[i] == nil && !terminatedByCancel[i] {
+				return fmt.Errorf("ssh forwards for %s exited unexpectedly", pondMeshForwardGroupLabel(rf.group.Forwards))
+			}
+			if waitErrs[i] != nil && !terminatedByCancel[i] {
+				return waitErrs[i]
+			}
+		}
+		return nil
+	}
+	for _, group := range groups {
+		args := pondMeshSSHArgsForForwards(group.Target, group.Forwards)
 		handle := runner.Command(ctx, "ssh", args...)
 		if err := handle.Start(); err != nil {
+			parentErr := terminationCtx.Err()
 			cancel()
-			return fmt.Errorf("start ssh -L %d:%d for %s: %w", fwd.LocalPort, fwd.RemotePort, fwd.Peer, err)
+			if reapErr := reapStarted(); reapErr != nil {
+				return reapErr
+			}
+			if parentErr != nil && errors.Is(err, parentErr) {
+				return nil
+			}
+			return fmt.Errorf("start ssh forwards for %s: %w", pondMeshForwardGroupLabel(group.Forwards), err)
 		}
-		running = append(running, runningForward{fwd: fwd, handle: handle})
-		fmt.Fprintf(opts.Stderr, "  -L 127.0.0.1:%d -> %s:%d\n", fwd.LocalPort, fwd.Peer, fwd.RemotePort)
+		running = append(running, runningForwardGroup{group: group, handle: handle})
+		for _, fwd := range group.Forwards {
+			fmt.Fprintf(opts.Stderr, "  -L 127.0.0.1:%d -> %s:%d\n", fwd.LocalPort, fwd.Peer, fwd.RemotePort)
+		}
 	}
 	var wg sync.WaitGroup
 	var firstErr error
 	var firstErrOnce sync.Once
 	for _, rf := range running {
 		wg.Add(1)
-		go func(rf runningForward) {
+		go func(rf runningForwardGroup) {
 			defer wg.Done()
 			err := rf.handle.Wait()
-			// Classify by PER-FORWARD provenance, never the shared context.
+			// Classify by PER-MEMBER-PROCESS provenance, never the shared context.
 			// Reading ctx.Err() here is unsafe under a race: if a sibling
 			// forward or the caller cancels first, ctx.Err() is non-nil by the
 			// time THIS forward's genuine failure is classified, and its error
 			// would be silently discarded. Instead we suppress a Wait error
-			// only when OUR teardown terminated THIS specific process (portable
-			// across SIGINT/SIGKILL on Unix and TerminateProcess on Windows).
+			// only when OUR teardown terminated THIS specific process with the
+			// platform's hard process-group/tree kill.
 			// A genuine non-zero exit the peer reached on its own is still
 			// recorded even when the shared context was already cancelled.
-			if err != nil && !rf.handle.WasTerminatedByOurCancel() {
+			terminatedByCancel := rf.handle.WasTerminatedByOurCancel()
+			if err == nil && !terminatedByCancel {
+				firstErrOnce.Do(func() {
+					firstErr = fmt.Errorf("ssh forwards for %s exited unexpectedly", pondMeshForwardGroupLabel(rf.group.Forwards))
+				})
+			} else if err != nil && !terminatedByCancel {
 				firstErrOnce.Do(func() { firstErr = err })
 			}
 			cancel()
 		}(rf)
 	}
 	<-ctx.Done()
-	// Teardown is exec.CommandContext's DEFAULT cancellation: cancelling the
-	// derived ctx above fires each handle's Cancel hook, which records
-	// provenance and delivers the platform kill (SIGKILL on Unix,
-	// TerminateProcess on Windows). We intentionally send no catchable signal
+	// Cancelling the derived context fires each handle's Cancel hook, which
+	// records provenance and hard-kills the complete platform process group/tree.
+	// We intentionally send no catchable signal
 	// of our own — an ssh that trapped SIGINT and exited non-zero would look
 	// like a genuine failure. Just wait for every waiter to finish reaping.
 	wg.Wait()

--- a/internal/cli/pond_mesh_cancel_unix.go
+++ b/internal/cli/pond_mesh_cancel_unix.go
@@ -3,18 +3,153 @@
 package cli
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"os"
+	"os/exec"
+	"os/signal"
+	"sync"
 	"syscall"
 )
 
+const (
+	pondMeshAnchorArg = "--crabbox-internal-pond-mesh-anchor"
+	pondMeshAnchorEnv = "CRABBOX_INTERNAL_POND_MESH_ANCHOR"
+)
+
+type pondMeshPlatformState struct {
+	cleanupOnce sync.Once
+	anchor      *exec.Cmd
+	anchorWrite *os.File
+	cleanupErr  error
+}
+
+func init() {
+	if os.Getenv(pondMeshAnchorEnv) != "1" || len(os.Args) != 2 || os.Args[1] != pondMeshAnchorArg {
+		return
+	}
+	// Only a child created with Setpgid may act as an anchor. This prevents a
+	// manually forged internal invocation from signaling its caller's group.
+	if os.Getpid() != syscall.Getpgrp() {
+		os.Exit(126)
+	}
+	parentLifetime := os.NewFile(3, "pond-mesh-parent-lifetime")
+	if parentLifetime == nil {
+		os.Exit(126)
+	}
+	var buffer [1]byte
+	for {
+		if _, err := parentLifetime.Read(buffer[:]); err != nil {
+			break
+		}
+	}
+	// This process is still the live group leader, so its PGID cannot have been
+	// reused. Kill the anchor, SSH root, and every inherited helper atomically.
+	if err := syscall.Kill(-syscall.Getpgrp(), syscall.SIGKILL); err != nil {
+		os.Exit(126)
+	}
+	os.Exit(127)
+}
+
+func pondMeshTerminationContext(ctx context.Context) (context.Context, func()) {
+	// Forward children are outside the terminal group. Convert hangup, quit, and
+	// suspension into owned teardown; otherwise Ctrl-Z would stop Crabbox while
+	// leaving live tunnels behind.
+	return signal.NotifyContext(ctx, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTSTP)
+}
+
+func (h *pondMeshExecHandle) Start() error {
+	if !h.managed {
+		return h.cmd.Start()
+	}
+	executable, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolve pond mesh anchor executable: %w", err)
+	}
+	anchorRead, anchorWrite, err := os.Pipe()
+	if err != nil {
+		return fmt.Errorf("create pond mesh anchor pipe: %w", err)
+	}
+	anchor := exec.Command(executable, pondMeshAnchorArg)
+	anchor.Env = append(os.Environ(), pondMeshAnchorEnv+"=1")
+	anchor.ExtraFiles = []*os.File{anchorRead}
+	anchor.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := anchor.Start(); err != nil {
+		_ = anchorRead.Close()
+		_ = anchorWrite.Close()
+		return fmt.Errorf("start pond mesh group anchor: %w", err)
+	}
+	_ = anchorRead.Close()
+	h.platform.anchor = anchor
+	h.platform.anchorWrite = anchorWrite
+	h.cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true, Pgid: anchor.Process.Pid}
+	if err := h.cmd.Start(); err != nil {
+		cleanupErr := h.finishPondMeshPlatform()
+		if cleanupErr != nil {
+			return errors.Join(err, cleanupErr)
+		}
+		return err
+	}
+	return nil
+}
+
+func (h *pondMeshExecHandle) Wait() error {
+	err := h.cmd.Wait()
+	if !h.managed {
+		return err
+	}
+	cleanupErr := h.finishPondMeshPlatform()
+	return h.joinCancellationError(errors.Join(err, cleanupErr))
+}
+
+func (h *pondMeshExecHandle) finishPondMeshPlatform() error {
+	h.platform.cleanupOnce.Do(func() {
+		if h.platform.anchorWrite != nil {
+			if err := h.platform.anchorWrite.Close(); err != nil {
+				h.platform.cleanupErr = fmt.Errorf("close pond mesh anchor pipe: %w", err)
+			}
+		}
+		if h.platform.anchor == nil {
+			return
+		}
+		err := h.platform.anchor.Wait()
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			if status, ok := exitErr.Sys().(syscall.WaitStatus); ok && status.Signaled() && status.Signal() == syscall.SIGKILL {
+				return
+			}
+		}
+		if err != nil {
+			h.platform.cleanupErr = errors.Join(h.platform.cleanupErr, fmt.Errorf("wait for pond mesh group anchor: %w", err))
+		}
+	})
+	return h.platform.cleanupErr
+}
+
+func terminatePondMeshForwardProcess(h *pondMeshExecHandle) error {
+	rootErr := h.cmd.Process.Kill()
+	cleanupErr := h.finishPondMeshPlatform()
+	if rootErr != nil {
+		if errors.Is(rootErr, os.ErrProcessDone) {
+			if cleanupErr != nil {
+				return cleanupErr
+			}
+			return os.ErrProcessDone
+		}
+		return errors.Join(rootErr, cleanupErr)
+	}
+	return cleanupErr
+}
+
 // killAttributableToCancel reports, for a process WE cancelled, whether its
 // terminal state is our own teardown rather than a genuine failure. Our
-// cancellation uses exec.CommandContext's default SIGKILL, which is uncatchable
+// cancellation uses a process-group SIGKILL, which is uncatchable
 // and reported as WaitStatus.Signaled() (Exited()==false); a process that
 // reached its own exit code before our kill landed is reported as Exited() and
 // is a genuine result we must surface. A nil state (killed before it produced
-// one) is our teardown. killFoundExited is a Windows-only concern, ignored here.
-func killAttributableToCancel(ps *os.ProcessState, _ bool) bool {
+// one) is our teardown.
+func killAttributableToCancel(ps *os.ProcessState) bool {
 	if ps == nil {
 		return true
 	}

--- a/internal/cli/pond_mesh_cancel_unix.go
+++ b/internal/cli/pond_mesh_cancel_unix.go
@@ -1,0 +1,27 @@
+//go:build !windows
+
+package cli
+
+import (
+	"os"
+	"syscall"
+)
+
+// killAttributableToCancel reports, for a process WE cancelled, whether its
+// terminal state is our own teardown rather than a genuine failure. Our
+// cancellation uses exec.CommandContext's default SIGKILL, which is uncatchable
+// and reported as WaitStatus.Signaled() (Exited()==false); a process that
+// reached its own exit code before our kill landed is reported as Exited() and
+// is a genuine result we must surface. A nil state (killed before it produced
+// one) is our teardown. killFoundExited is a Windows-only concern, ignored here.
+func killAttributableToCancel(ps *os.ProcessState, _ bool) bool {
+	if ps == nil {
+		return true
+	}
+	if ws, ok := ps.Sys().(syscall.WaitStatus); ok {
+		return ws.Signaled()
+	}
+	// No WaitStatus available on this platform: any non-Exited terminal state
+	// is our signal-driven kill rather than a peer's own exit code.
+	return !ps.Exited()
+}

--- a/internal/cli/pond_mesh_cancel_windows.go
+++ b/internal/cli/pond_mesh_cancel_windows.go
@@ -2,16 +2,236 @@
 
 package cli
 
-import "os"
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// pondMeshWindowsCancelExitCode is written atomically by TerminateJobObject to
+// every still-running member. The root's final ProcessState therefore records
+// whether cancellation actually terminated it, without a status-check race.
+const pondMeshWindowsCancelExitCode uint32 = 0x43425801
+
+var pondMeshTerminateJobObject = windows.TerminateJobObject
+
+type pondMeshPlatformState struct {
+	mu            sync.Mutex
+	job           windows.Handle
+	process       windows.Handle
+	finished      bool
+	jobTerminated bool
+	cleanupErr    error
+}
+
+func pondMeshTerminationContext(ctx context.Context) (context.Context, func()) {
+	return ctx, func() {}
+}
+
+func (h *pondMeshExecHandle) Start() error {
+	if !h.managed {
+		return h.cmd.Start()
+	}
+	h.platform.mu.Lock()
+	defer h.platform.mu.Unlock()
+	h.cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP | windows.CREATE_SUSPENDED,
+	}
+	if err := h.cmd.Start(); err != nil {
+		return err
+	}
+	job, err := windows.CreateJobObject(nil, nil)
+	if err != nil {
+		return h.failPondMeshStartLocked(fmt.Errorf("create pond mesh job: %w", err))
+	}
+	var limits windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+	limits.BasicLimitInformation.LimitFlags = windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+	if _, err := windows.SetInformationJobObject(
+		job,
+		windows.JobObjectExtendedLimitInformation,
+		uintptr(unsafe.Pointer(&limits)),
+		uint32(unsafe.Sizeof(limits)),
+	); err != nil {
+		_ = windows.CloseHandle(job)
+		return h.failPondMeshStartLocked(fmt.Errorf("configure pond mesh job: %w", err))
+	}
+	process, err := windows.OpenProcess(
+		windows.PROCESS_SET_QUOTA|windows.PROCESS_TERMINATE|windows.PROCESS_QUERY_LIMITED_INFORMATION|windows.SYNCHRONIZE,
+		false,
+		uint32(h.cmd.Process.Pid),
+	)
+	if err != nil {
+		_ = windows.CloseHandle(job)
+		return h.failPondMeshStartLocked(fmt.Errorf("open suspended pond mesh process: %w", err))
+	}
+	if err := windows.AssignProcessToJobObject(job, process); err != nil {
+		_ = windows.CloseHandle(process)
+		_ = windows.CloseHandle(job)
+		return h.failPondMeshStartLocked(fmt.Errorf("assign pond mesh process to job: %w", err))
+	}
+	h.platform.job = job
+	h.platform.process = process
+	if err := resumePondMeshProcess(h.cmd.Process.Pid); err != nil {
+		return h.failPondMeshStartLocked(err)
+	}
+	return nil
+}
+
+func (h *pondMeshExecHandle) failPondMeshStartLocked(startErr error) error {
+	if h.platform.job != 0 {
+		_ = pondMeshTerminateJobObject(h.platform.job, pondMeshWindowsCancelExitCode)
+		h.platform.jobTerminated = true
+	}
+	_ = h.cmd.Process.Kill()
+	_ = h.closePondMeshHandlesLocked()
+	h.platform.finished = true
+	// Let a concurrently firing CommandContext watcher observe finished instead
+	// of deadlocking on the setup mutex while Wait receives its result.
+	h.platform.mu.Unlock()
+	_ = h.cmd.Wait()
+	h.platform.mu.Lock()
+	return startErr
+}
+
+func resumePondMeshProcess(pid int) error {
+	snapshot, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPTHREAD, 0)
+	if err != nil {
+		return fmt.Errorf("snapshot suspended pond mesh threads: %w", err)
+	}
+	defer windows.CloseHandle(snapshot)
+	var entry windows.ThreadEntry32
+	entry.Size = uint32(unsafe.Sizeof(entry))
+	if err := windows.Thread32First(snapshot, &entry); err != nil {
+		return fmt.Errorf("enumerate suspended pond mesh threads: %w", err)
+	}
+	for {
+		if entry.OwnerProcessID == uint32(pid) {
+			thread, err := windows.OpenThread(windows.THREAD_SUSPEND_RESUME, false, entry.ThreadID)
+			if err != nil {
+				return fmt.Errorf("open suspended pond mesh thread: %w", err)
+			}
+			_, resumeErr := windows.ResumeThread(thread)
+			_ = windows.CloseHandle(thread)
+			if resumeErr != nil {
+				return fmt.Errorf("resume pond mesh process: %w", resumeErr)
+			}
+			return nil
+		}
+		entry.Size = uint32(unsafe.Sizeof(entry))
+		if err := windows.Thread32Next(snapshot, &entry); err != nil {
+			if errors.Is(err, windows.ERROR_NO_MORE_FILES) {
+				return fmt.Errorf("suspended pond mesh process %d has no thread", pid)
+			}
+			return fmt.Errorf("enumerate suspended pond mesh threads: %w", err)
+		}
+	}
+}
+
+func (h *pondMeshExecHandle) Wait() error {
+	err := h.cmd.Wait()
+	if !h.managed {
+		return err
+	}
+	cleanupErr := h.finishPondMeshPlatform()
+	return h.joinCancellationError(errors.Join(err, cleanupErr))
+}
+
+func (h *pondMeshExecHandle) finishPondMeshPlatform() error {
+	h.platform.mu.Lock()
+	defer h.platform.mu.Unlock()
+	if h.platform.finished {
+		return h.platform.cleanupErr
+	}
+	if h.platform.job != 0 && !h.platform.jobTerminated {
+		if err := pondMeshTerminateJobObject(h.platform.job, pondMeshWindowsCancelExitCode); err != nil {
+			h.platform.cleanupErr = fmt.Errorf("terminate pond mesh job after root exit: %w", err)
+		} else {
+			h.platform.jobTerminated = true
+		}
+	}
+	h.platform.cleanupErr = errors.Join(h.platform.cleanupErr, h.closePondMeshHandlesLocked())
+	h.platform.finished = true
+	return h.platform.cleanupErr
+}
+
+func (h *pondMeshExecHandle) closePondMeshHandlesLocked() error {
+	var closeErr error
+	if h.platform.process != 0 {
+		if err := windows.CloseHandle(h.platform.process); err != nil {
+			closeErr = errors.Join(closeErr, fmt.Errorf("close pond mesh process handle: %w", err))
+		}
+		h.platform.process = 0
+	}
+	if h.platform.job != 0 {
+		if err := windows.CloseHandle(h.platform.job); err != nil {
+			closeErr = errors.Join(closeErr, fmt.Errorf("close pond mesh job handle: %w", err))
+		}
+		h.platform.job = 0
+	}
+	return closeErr
+}
+
+func terminatePondMeshForwardProcess(h *pondMeshExecHandle) error {
+	h.platform.mu.Lock()
+	defer h.platform.mu.Unlock()
+	if h.platform.finished || h.platform.job == 0 || h.platform.process == 0 {
+		return os.ErrProcessDone
+	}
+	if !h.platform.jobTerminated {
+		if err := pondMeshTerminateJobObject(h.platform.job, pondMeshWindowsCancelExitCode); err != nil {
+			// A failed job termination must not strand Wait on a live SSH root.
+			// Post-check the exact retained handle first: TerminateProcess may still
+			// succeed against an already-signaled process and overwrite its natural
+			// exit code. Only hard-kill a root that is still observably live.
+			waitResult, waitErr := windows.WaitForSingleObject(h.platform.process, 0)
+			rootExited := waitErr == nil && waitResult == windows.WAIT_OBJECT_0
+			var rootErr error
+			if !rootExited {
+				rootErr = windows.TerminateProcess(h.platform.process, pondMeshWindowsCancelExitCode)
+			}
+			// Closing the last kill-on-close Job handle is an independent full-tree
+			// fallback for descendants even when the root already exited naturally.
+			jobCloseErr := windows.CloseHandle(h.platform.job)
+			if jobCloseErr == nil {
+				h.platform.job = 0
+				h.platform.jobTerminated = true
+			}
+			if rootExited && jobCloseErr == nil {
+				return os.ErrProcessDone
+			}
+			return errors.Join(
+				fmt.Errorf("terminate pond mesh job: %w", err),
+				wrapPondMeshWindowsCleanupError("query pond mesh root fallback state", waitErr),
+				wrapPondMeshWindowsCleanupError("terminate pond mesh root fallback", rootErr),
+				wrapPondMeshWindowsCleanupError("close pond mesh job fallback", jobCloseErr),
+			)
+		}
+		h.platform.jobTerminated = true
+	}
+	return nil
+}
+
+func wrapPondMeshWindowsCleanupError(action string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%s: %w", action, err)
+}
 
 // killAttributableToCancel reports, for a process WE cancelled, whether its
-// terminal state is our own teardown. Windows has no signals: our
-// TerminateProcess is reported as Exited() with a non-zero code, which is
-// indistinguishable from a genuine failure by inspection, so the cancelled flag
-// the caller has already checked governs — EXCEPT when our kill found the
-// process had already exited on its own (killFoundExited). That process died
-// before our cancellation could touch it, so its exit is genuine and must be
-// surfaced.
-func killAttributableToCancel(_ *os.ProcessState, killFoundExited bool) bool {
-	return !killFoundExited
+// terminal state is our own teardown. A forced Windows tree termination is
+// reported as Exited() with a non-zero
+// code. That is indistinguishable from a genuine failure by inspection, so the
+// cancelled flag the caller has already checked is necessary but insufficient:
+// only the atomic job-termination sentinel proves the root was still running
+// when our cancellation terminated it. A root that exited naturally first
+// retains its genuine exit code.
+func killAttributableToCancel(ps *os.ProcessState) bool {
+	return ps == nil || ps.ExitCode() == int(pondMeshWindowsCancelExitCode)
 }

--- a/internal/cli/pond_mesh_cancel_windows.go
+++ b/internal/cli/pond_mesh_cancel_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package cli
+
+import "os"
+
+// killAttributableToCancel reports, for a process WE cancelled, whether its
+// terminal state is our own teardown. Windows has no signals: our
+// TerminateProcess is reported as Exited() with a non-zero code, which is
+// indistinguishable from a genuine failure by inspection, so the cancelled flag
+// the caller has already checked governs — EXCEPT when our kill found the
+// process had already exited on its own (killFoundExited). That process died
+// before our cancellation could touch it, so its exit is genuine and must be
+// surfaced.
+func killAttributableToCancel(_ *os.ProcessState, killFoundExited bool) bool {
+	return !killFoundExited
+}

--- a/internal/cli/pond_mesh_cancel_windows_test.go
+++ b/internal/cli/pond_mesh_cancel_windows_test.go
@@ -1,0 +1,306 @@
+//go:build windows
+
+package cli
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestPondMeshForwardStartsSuspendedInJob(t *testing.T) {
+	handle := pondMeshExecRunner{}.Command(context.Background(), "cmd.exe", "/c", "exit", "0")
+	execHandle := handle.(*pondMeshExecHandle)
+	if err := handle.Start(); err != nil {
+		t.Fatal(err)
+	}
+	if execHandle.cmd.SysProcAttr == nil || execHandle.cmd.SysProcAttr.CreationFlags&syscall.CREATE_NEW_PROCESS_GROUP == 0 {
+		t.Fatalf("forward missing CREATE_NEW_PROCESS_GROUP: %#v", execHandle.cmd.SysProcAttr)
+	}
+	if execHandle.cmd.SysProcAttr.CreationFlags&windows.CREATE_SUSPENDED == 0 {
+		t.Fatalf("forward missing CREATE_SUSPENDED: %#v", execHandle.cmd.SysProcAttr)
+	}
+	if execHandle.platform.job == 0 {
+		t.Fatal("forward started without a Job Object")
+	}
+	if err := handle.Wait(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPondMeshNaturalExitBeforeCancelSurvivesOnWindows(t *testing.T) {
+	err, terminated := runPondMeshNaturalExitBeforeCancelWindows(t, 7)
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 7 {
+		t.Fatalf("natural exit = %v, want exit code 7", err)
+	}
+	if terminated {
+		t.Fatal("natural exit racing cancellation was suppressed as our teardown")
+	}
+}
+
+func TestPondMeshNaturalSuccessBeforeCancelSurvivesOnWindows(t *testing.T) {
+	err, terminated := runPondMeshNaturalExitBeforeCancelWindows(t, 0)
+	if err != nil {
+		t.Fatalf("natural success became a cancellation error: %v", err)
+	}
+	if terminated {
+		t.Fatal("natural success racing cancellation was classified as our teardown")
+	}
+}
+
+func TestPondMeshNaturalExitDuringJobTerminationSurvivesOnWindows(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	handle := pondMeshExecRunner{}.Command(ctx, os.Args[0], "-test.run=^TestPondMeshWindowsExitHelper$")
+	execHandle := handle.(*pondMeshExecHandle)
+	stateDir := t.TempDir()
+	ready := filepath.Join(stateDir, "ready")
+	release := filepath.Join(stateDir, "release")
+	execHandle.cmd.Env = append(os.Environ(),
+		"CBX_POND_WINDOWS_EXIT_CODE=7",
+		"CBX_POND_WINDOWS_READY="+ready,
+		"CBX_POND_WINDOWS_WAIT="+release,
+	)
+	if err := handle.Start(); err != nil {
+		t.Fatal(err)
+	}
+	waitForPondMeshWindowsFile(t, ready, "exit helper did not start")
+
+	originalTerminateJob := pondMeshTerminateJobObject
+	pondMeshTerminateJobObject = func(job windows.Handle, exitCode uint32) error {
+		if err := os.WriteFile(release, []byte("exit"), 0o600); err != nil {
+			return err
+		}
+		result, err := windows.WaitForSingleObject(execHandle.platform.process, 5000)
+		if err != nil {
+			return err
+		}
+		if result != windows.WAIT_OBJECT_0 {
+			return errors.New("natural exit did not complete before job termination")
+		}
+		return originalTerminateJob(job, exitCode)
+	}
+	defer func() { pondMeshTerminateJobObject = originalTerminateJob }()
+
+	waitCh := make(chan error, 1)
+	go func() { waitCh <- handle.Wait() }()
+	cancel()
+	err := <-waitCh
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 7 {
+		t.Fatalf("natural exit during job termination = %v, want exit code 7", err)
+	}
+	if handle.WasTerminatedByOurCancel() {
+		t.Fatal("natural exit during job termination was suppressed as our teardown")
+	}
+}
+
+func TestPondMeshCancelKillsWindowsProcessTree(t *testing.T) {
+	if os.Getenv("CBX_POND_WINDOWS_TREE_HELPER") == "1" {
+		child := exec.Command("cmd.exe", "/c", "ping -t 127.0.0.1 >NUL")
+		if err := child.Start(); err != nil {
+			os.Exit(8)
+		}
+		if err := os.WriteFile(os.Getenv("CBX_POND_WINDOWS_CHILD_PID"), []byte(strconv.Itoa(child.Process.Pid)), 0o600); err != nil {
+			os.Exit(9)
+		}
+		_ = child.Wait()
+		return
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	handle := pondMeshExecRunner{}.Command(ctx, os.Args[0], "-test.run=^TestPondMeshCancelKillsWindowsProcessTree$")
+	execHandle := handle.(*pondMeshExecHandle)
+	childPIDFile := filepath.Join(t.TempDir(), "child-pid")
+	execHandle.cmd.Env = append(os.Environ(),
+		"CBX_POND_WINDOWS_TREE_HELPER=1",
+		"CBX_POND_WINDOWS_CHILD_PID="+childPIDFile,
+	)
+	if err := handle.Start(); err != nil {
+		t.Fatal(err)
+	}
+	waitCh := make(chan error, 1)
+	go func() { waitCh <- handle.Wait() }()
+	childPID := waitForPondMeshWindowsChildPID(t, childPIDFile)
+	t.Cleanup(func() {
+		_ = exec.Command("taskkill", "/PID", strconv.Itoa(childPID), "/T", "/F").Run()
+	})
+
+	cancel()
+	if err := <-waitCh; err == nil {
+		t.Fatal("cancelled process tree returned success")
+	}
+	if !handle.WasTerminatedByOurCancel() {
+		t.Fatal("cancelled process tree was not attributed to our teardown")
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if _, alive := webVNCDaemonProcessCommand(childPID); !alive {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("forward descendant %d survived cancellation", childPID)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestPondMeshJobTerminationFailureStillKillsWindowsProcessTree(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	handle := pondMeshExecRunner{}.Command(ctx, os.Args[0], "-test.run=^TestPondMeshCancelKillsWindowsProcessTree$")
+	execHandle := handle.(*pondMeshExecHandle)
+	childPIDFile := filepath.Join(t.TempDir(), "child-pid")
+	execHandle.cmd.Env = append(os.Environ(),
+		"CBX_POND_WINDOWS_TREE_HELPER=1",
+		"CBX_POND_WINDOWS_CHILD_PID="+childPIDFile,
+	)
+	if err := handle.Start(); err != nil {
+		t.Fatal(err)
+	}
+	childPID := waitForPondMeshWindowsChildPID(t, childPIDFile)
+	t.Cleanup(func() {
+		_ = exec.Command("taskkill", "/PID", strconv.Itoa(childPID), "/T", "/F").Run()
+	})
+
+	originalTerminateJob := pondMeshTerminateJobObject
+	forcedErr := errors.New("forced job termination failure")
+	pondMeshTerminateJobObject = func(windows.Handle, uint32) error { return forcedErr }
+	defer func() { pondMeshTerminateJobObject = originalTerminateJob }()
+
+	waitCh := make(chan error, 1)
+	go func() { waitCh <- handle.Wait() }()
+	cancel()
+	select {
+	case err := <-waitCh:
+		if err == nil || !strings.Contains(err.Error(), forcedErr.Error()) {
+			t.Fatalf("job termination failure = %v, want cleanup diagnostic", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Wait hung after job termination failure")
+	}
+	if handle.WasTerminatedByOurCancel() {
+		t.Fatal("failed job termination was suppressed as clean cancellation")
+	}
+	waitForPondMeshWindowsProcessExit(t, childPID)
+}
+
+func waitForPondMeshWindowsChildPID(t *testing.T, path string) int {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+			if err != nil {
+				t.Fatalf("parse child pid: %v", err)
+			}
+			return pid
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			t.Fatal(err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("tree helper did not publish its child pid")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func waitForPondMeshWindowsFile(t *testing.T, path, timeoutMessage string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal(timeoutMessage)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func waitForPondMeshWindowsProcessExit(t *testing.T, pid int) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if _, alive := webVNCDaemonProcessCommand(pid); !alive {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("forward descendant %d survived cancellation", pid)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestPondMeshWindowsExitHelper(t *testing.T) {
+	codeText := os.Getenv("CBX_POND_WINDOWS_EXIT_CODE")
+	if codeText == "" {
+		return
+	}
+	code, err := strconv.Atoi(codeText)
+	if err != nil {
+		os.Exit(9)
+	}
+	if err := os.WriteFile(os.Getenv("CBX_POND_WINDOWS_READY"), []byte("ready"), 0o600); err != nil {
+		os.Exit(8)
+	}
+	if waitFile := os.Getenv("CBX_POND_WINDOWS_WAIT"); waitFile != "" {
+		deadline := time.Now().Add(5 * time.Second)
+		for {
+			if _, err := os.Stat(waitFile); err == nil {
+				break
+			}
+			if time.Now().After(deadline) {
+				os.Exit(10)
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+	os.Exit(code)
+}
+
+func runPondMeshNaturalExitBeforeCancelWindows(t *testing.T, exitCode int) (error, bool) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	handle := pondMeshExecRunner{}.Command(ctx, os.Args[0], "-test.run=^TestPondMeshWindowsExitHelper$")
+	execHandle := handle.(*pondMeshExecHandle)
+	ready := filepath.Join(t.TempDir(), "ready")
+	execHandle.cmd.Env = append(os.Environ(),
+		"CBX_POND_WINDOWS_EXIT_CODE="+strconv.Itoa(exitCode),
+		"CBX_POND_WINDOWS_READY="+ready,
+	)
+	if err := handle.Start(); err != nil {
+		t.Fatal(err)
+	}
+	waitCh := make(chan error, 1)
+	go func() { waitCh <- handle.Wait() }()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if _, err := os.Stat(ready); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("helper did not start")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	// Let the child exit while Wait and the context watcher run concurrently.
+	// The exact Job/process handles must preserve the natural result either way.
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+	err := <-waitCh
+	return err, handle.WasTerminatedByOurCancel()
+}

--- a/internal/cli/pond_mesh_ctx_cancel_test.go
+++ b/internal/cli/pond_mesh_ctx_cancel_test.go
@@ -1,0 +1,85 @@
+package cli
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestRunPondMeshForwardsGracefulCancelReturnsNoError proves that a clean,
+// user-initiated shutdown (ctx cancellation, i.e. Ctrl-C on `crabbox pond
+// connect`) is NOT reported as a tunnel failure — even when the child is an
+// ssh that CATCHES SIGINT and exits with a non-zero status.
+//
+// This is the regression for hole (1): v2 tore forwards down with a graceful,
+// catchable SIGINT. Real ssh (and this fake) traps SIGINT and exits non-zero,
+// so its terminal state is ProcessState.Exited() with a real code — which v2's
+// classifier reads as a GENUINE failure (not Signaled()), and a clean Ctrl-C
+// therefore returns a spurious tunnel error. v3 removes the graceful signal and
+// relies on exec.CommandContext's DEFAULT cancellation (SIGKILL on Unix), which
+// is uncatchable: the child's trap never fires, its terminal state is always
+// Signaled(), and WasTerminatedByOurCancel suppresses it. So this test FAILS on
+// v2 (spurious exit-255 error) and PASSES on v3.
+//
+// It drives the REAL production entry point runPondMeshForwards with the real
+// pondMeshExecRunner (opts.Runner == nil falls back to pondMeshDefaultRunner)
+// so the actual ProcessState logic is exercised — no handle is mocked. The only
+// substitution is a fake `ssh` binary injected via PATH so no network is
+// touched.
+func TestRunPondMeshForwardsGracefulCancelReturnsNoError(t *testing.T) {
+	if os.PathSeparator != '/' {
+		t.Skip("fake ssh shell script requires a unix-like OS")
+	}
+
+	// Fake ssh that holds the "tunnel" open like a healthy `ssh -N -L`, but
+	// TRAPS SIGINT/SIGTERM and exits 255 — exactly what real ssh does on a
+	// catchable signal. Under v3's SIGKILL teardown the trap never fires.
+	binDir := t.TempDir()
+	fakeSSH := filepath.Join(binDir, "ssh")
+	script := "#!/bin/sh\ntrap 'exit 255' INT TERM\nwhile :; do sleep 0.05; done\n"
+	if err := os.WriteFile(fakeSSH, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	members := []pondMember{{
+		Name:  "peer-a",
+		Lease: "lease-a",
+		SSH: SSHTarget{
+			User:                   "crab",
+			Host:                   "127.0.0.1",
+			Port:                   "22",
+			DisableHostKeyChecking: true,
+			NoControlMaster:        true,
+		},
+	}}
+	summary := pondMeshSummary{Forwards: []pondMeshForward{{
+		Peer:       "peer-a",
+		RemotePort: 8080,
+		LocalPort:  18080,
+		LeaseID:    "lease-a",
+	}}}
+	// Runner deliberately nil: exercise the production pondMeshExecRunner.
+	opts := pondConnectOptions{Stdout: io.Discard, Stderr: io.Discard}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() { errCh <- runPondMeshForwards(ctx, opts, members, summary) }()
+
+	// Give the fake tunnel time to start, then simulate Ctrl-C.
+	time.Sleep(500 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("graceful ctx cancellation must not be reported as a tunnel failure, got: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("runPondMeshForwards did not return after ctx cancellation")
+	}
+}

--- a/internal/cli/pond_mesh_race_unix_test.go
+++ b/internal/cli/pond_mesh_race_unix_test.go
@@ -17,8 +17,8 @@ import (
 )
 
 // TestRunPondMeshForwardsGenuineExitSurvivesSiblingCancel is the regression for
-// the race steipete flagged as "not safe to land": a genuine per-forward
-// failure must be surfaced even while a SIBLING forward is being torn down —
+// the race steipete flagged as "not safe to land": a genuine per-member-process
+// failure must be surfaced even while a SIBLING member is being torn down —
 // classifying by anything shared (the ctx, or a "some cancel happened" flag)
 // discards it.
 //
@@ -38,7 +38,7 @@ import (
 // exiting on its own — which is exactly what makes the Exited-vs-Signaled
 // provenance split unambiguous. A classifier that suppressed every error once
 // any cancel occurred would drop A's exit 7 and return nil; the per-forward
-// provenance redesign returns the genuine *exec.ExitError.
+// process provenance redesign returns the genuine *exec.ExitError.
 func TestRunPondMeshForwardsGenuineExitSurvivesSiblingCancel(t *testing.T) {
 	if os.PathSeparator != '/' {
 		t.Skip("fake ssh shell script requires a unix-like OS")

--- a/internal/cli/pond_mesh_race_unix_test.go
+++ b/internal/cli/pond_mesh_race_unix_test.go
@@ -1,0 +1,160 @@
+//go:build !windows
+
+package cli
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestRunPondMeshForwardsGenuineExitSurvivesSiblingCancel is the regression for
+// the race steipete flagged as "not safe to land": a genuine per-forward
+// failure must be surfaced even while a SIBLING forward is being torn down —
+// classifying by anything shared (the ctx, or a "some cancel happened" flag)
+// discards it.
+//
+// Two forwards run concurrently against the REAL production runner:
+//   - forward A exits 7 ON ITS OWN — a genuine, peer-attributable non-zero
+//     status. The OS records ProcessState.Exited() (a real code), never
+//     Signaled(), and because A exited on its own the ctx watchdog never fires
+//     A's Cancel hook, so A's `cancelled` flag stays false. Both facts make
+//     WasTerminatedByOurCancel return false, so exit 7 is recorded.
+//   - forward B is a healthy long-running tunnel. A's exit triggers cancel(),
+//     the ctx watchdog SIGKILLs B, and B's terminal state is Signaled() with
+//     `cancelled` true — WasTerminatedByOurCancel returns true, so B's
+//     "signal: killed" is SUPPRESSED and never masks A's genuine exit 7.
+//
+// This is the v3 shape: v3 tears down with an UNCATCHABLE SIGKILL (not a
+// graceful SIGINT), so a forward can only reach a genuine Exited() code by
+// exiting on its own — which is exactly what makes the Exited-vs-Signaled
+// provenance split unambiguous. A classifier that suppressed every error once
+// any cancel occurred would drop A's exit 7 and return nil; the per-forward
+// provenance redesign returns the genuine *exec.ExitError.
+func TestRunPondMeshForwardsGenuineExitSurvivesSiblingCancel(t *testing.T) {
+	if os.PathSeparator != '/' {
+		t.Skip("fake ssh shell script requires a unix-like OS")
+	}
+
+	const (
+		portGenuine = 19001 // forward A: exits 7 on its own (Exited(7))
+		portCancel  = 19002 // forward B: healthy tunnel, SIGKILLed on teardown
+	)
+
+	binDir := t.TempDir()
+	pidDir := t.TempDir()
+	// One fake ssh binary that branches on the -L local port. Forward A exits 7
+	// on its own — a genuine non-zero code the OS reports as Exited(), not
+	// Signaled(). It first waits for Forward B to record its PID, so B is up
+	// (and its PID file written) before A's exit triggers the teardown SIGKILL;
+	// otherwise a slow runner can kill B before its shell writes the PID and the
+	// leak check below has nothing to read. Forward B holds a healthy tunnel open
+	// via `exec sleep` (so the tracked PID IS the sleep and our SIGKILL reaps it
+	// directly, leaving no orphan). Each records its PID so we can prove the
+	// children are reaped (no waiter/child leak).
+	script := "#!/bin/sh\n" +
+		"case \"$*\" in\n" +
+		"  *:" + strconv.Itoa(portGenuine) + ":*)\n" +
+		"    echo $$ > \"$CBX_TEST_PIDDIR/genuine\"\n" +
+		"    i=0; while [ ! -s \"$CBX_TEST_PIDDIR/cancel\" ] && [ $i -lt 500 ]; do i=$((i+1)); sleep 0.01; done\n" +
+		"    exit 7 ;;\n" +
+		"  *:" + strconv.Itoa(portCancel) + ":*)\n" +
+		"    echo $$ > \"$CBX_TEST_PIDDIR/cancel\"\n" +
+		"    exec sleep 60 ;;\n" +
+		"esac\n"
+	fakeSSH := filepath.Join(binDir, "ssh")
+	if err := os.WriteFile(fakeSSH, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CBX_TEST_PIDDIR", pidDir)
+
+	members := []pondMember{
+		{
+			Name:  "peer-genuine",
+			Lease: "lease-genuine",
+			SSH:   SSHTarget{User: "crab", Host: "127.0.0.1", Port: "22", DisableHostKeyChecking: true, NoControlMaster: true},
+		},
+		{
+			Name:  "peer-cancel",
+			Lease: "lease-cancel",
+			SSH:   SSHTarget{User: "crab", Host: "127.0.0.1", Port: "22", DisableHostKeyChecking: true, NoControlMaster: true},
+		},
+	}
+	summary := pondMeshSummary{Forwards: []pondMeshForward{
+		{Peer: "peer-genuine", RemotePort: 8081, LocalPort: portGenuine, LeaseID: "lease-genuine"},
+		{Peer: "peer-cancel", RemotePort: 8082, LocalPort: portCancel, LeaseID: "lease-cancel"},
+	}}
+	// Runner deliberately nil: exercise the production pondMeshExecRunner.
+	opts := pondConnectOptions{Stdout: io.Discard, Stderr: io.Discard}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() { errCh <- runPondMeshForwards(ctx, opts, members, summary) }()
+
+	var err error
+	select {
+	case err = <-errCh:
+	case <-time.After(15 * time.Second):
+		t.Fatal("runPondMeshForwards did not return")
+	}
+
+	if err == nil {
+		t.Fatal("genuine forward failure (exit 7) was swallowed after a sibling forward cancelled the context; want a non-nil error")
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected the genuine failure to surface as *exec.ExitError, got %T: %v", err, err)
+	}
+	if code := exitErr.ExitCode(); code != 7 {
+		t.Fatalf("expected genuine exit code 7 to survive the sibling cancel, got %d (%v)", code, err)
+	}
+
+	// Leak proof: both fake-ssh children must be reaped (their waiter
+	// goroutines ran Wait to completion — no goroutine or child process leaks
+	// survive teardown). runPondMeshForwards only returns after wg.Wait(), so
+	// by here every waiter has exited; assert the PIDs are gone.
+	for _, name := range []string{"genuine", "cancel"} {
+		pid := readPIDFile(t, filepath.Join(pidDir, name))
+		if alive := processAlive(pid); alive {
+			t.Fatalf("fake-ssh child for %q (pid %d) still alive after teardown: waiter/child leak", name, pid)
+		}
+	}
+}
+
+func readPIDFile(t *testing.T, path string) int {
+	t.Helper()
+	// The child writes its PID asynchronously; allow a brief window.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			if pid, perr := strconv.Atoi(strings.TrimSpace(string(data))); perr == nil && pid > 0 {
+				return pid
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("pid file %s never became readable", path)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// processAlive reports whether a process with the given PID is still running,
+// using signal 0 (existence probe). A reaped child returns ESRCH.
+func processAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(pid, 0)
+	return err == nil || errors.Is(err, syscall.EPERM)
+}

--- a/internal/cli/pond_mesh_signal_unix_test.go
+++ b/internal/cli/pond_mesh_signal_unix_test.go
@@ -1,0 +1,181 @@
+//go:build !windows
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestRunPondMeshForwardsUnexpectedSuccessKillsDescendants(t *testing.T) {
+	binDir := t.TempDir()
+	stateDir := t.TempDir()
+	descendantFile := filepath.Join(stateDir, "descendant")
+	fakeSSH := filepath.Join(binDir, "ssh")
+	script := "#!/bin/sh\nsleep 600 &\necho $! > \"$CBX_POND_DESCENDANT\"\nexit 0\n"
+	if err := os.WriteFile(fakeSSH, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CBX_POND_DESCENDANT", descendantFile)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	members := []pondMember{{
+		Name: "peer-a", Lease: "lease-a",
+		SSH: SSHTarget{User: "crab", Host: "127.0.0.1", Port: "22", DisableHostKeyChecking: true},
+	}}
+	summary := pondMeshSummary{Forwards: []pondMeshForward{{
+		Peer: "peer-a", RemotePort: 8080, LocalPort: 18080, LeaseID: "lease-a",
+	}}}
+	err := runPondMeshForwards(context.Background(), pondConnectOptions{Stdout: io.Discard, Stderr: io.Discard}, members, summary)
+	if err == nil || !strings.Contains(err.Error(), "ssh forwards for peer-a:8080 exited unexpectedly") {
+		t.Fatalf("unexpected clean forward exit = %v", err)
+	}
+	descendantPID := readPondMeshSignalPID(t, descendantFile)
+	defer func() { _ = syscall.Kill(descendantPID, syscall.SIGKILL) }()
+	waitForPondMeshSignalProcessExit(t, descendantPID)
+}
+
+func TestRunPondMeshForwardsTerminalInterruptIsClean(t *testing.T) {
+	if os.Getenv("CBX_POND_SIGNAL_HELPER") == "1" {
+		runPondMeshTerminalInterruptHelper(t)
+		return
+	}
+
+	for _, tc := range []struct {
+		name   string
+		signal syscall.Signal
+	}{
+		{name: "interrupt", signal: syscall.SIGINT},
+		{name: "hangup", signal: syscall.SIGHUP},
+		{name: "quit", signal: syscall.SIGQUIT},
+		{name: "suspend", signal: syscall.SIGTSTP},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			binDir := t.TempDir()
+			stateDir := t.TempDir()
+			readyFile := filepath.Join(stateDir, "ready")
+			childFile := filepath.Join(stateDir, "child")
+			descendantFile := filepath.Join(stateDir, "descendant")
+			fakeSSH := filepath.Join(binDir, "ssh")
+			script := "#!/bin/sh\necho $$ > \"$CBX_POND_SIGNAL_CHILD\"\nsleep 600 &\necho $! > \"$CBX_POND_SIGNAL_DESCENDANT\"\necho ready > \"$CBX_POND_SIGNAL_READY\"\ntrap 'exit 255' HUP INT QUIT TERM\nwhile :; do sleep 0.05; done\n"
+			if err := os.WriteFile(fakeSSH, []byte(script), 0o755); err != nil {
+				t.Fatal(err)
+			}
+
+			cmd := exec.Command(os.Args[0], "-test.run=^TestRunPondMeshForwardsTerminalInterruptIsClean$")
+			cmd.Env = append(os.Environ(),
+				"CBX_POND_SIGNAL_HELPER=1",
+				"CBX_POND_SIGNAL_KIND="+tc.name,
+				"CBX_POND_SIGNAL_READY="+readyFile,
+				"CBX_POND_SIGNAL_CHILD="+childFile,
+				"CBX_POND_SIGNAL_DESCENDANT="+descendantFile,
+				"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+			)
+			cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+			var output bytes.Buffer
+			cmd.Stdout = &output
+			cmd.Stderr = &output
+			if err := cmd.Start(); err != nil {
+				t.Fatal(err)
+			}
+			defer func() {
+				_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+				if data, err := os.ReadFile(childFile); err == nil {
+					if pid, err := strconv.Atoi(string(bytes.TrimSpace(data))); err == nil {
+						_ = syscall.Kill(-pid, syscall.SIGKILL)
+					}
+				}
+			}()
+
+			deadline := time.Now().Add(5 * time.Second)
+			for {
+				if _, err := os.Stat(readyFile); err == nil {
+					break
+				}
+				if time.Now().After(deadline) {
+					t.Fatalf("forward never became ready:\n%s", output.String())
+				}
+				time.Sleep(10 * time.Millisecond)
+			}
+			if err := syscall.Kill(-cmd.Process.Pid, tc.signal); err != nil {
+				t.Fatal(err)
+			}
+			if err := cmd.Wait(); err != nil {
+				t.Fatalf("terminal %s reported a tunnel failure: %v\n%s", tc.name, err, output.String())
+			}
+			descendantPID := readPondMeshSignalPID(t, descendantFile)
+			waitForPondMeshSignalProcessExit(t, descendantPID)
+		})
+	}
+}
+
+func readPondMeshSignalPID(t *testing.T, path string) int {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pid, err := strconv.Atoi(string(bytes.TrimSpace(data)))
+	if err != nil {
+		t.Fatalf("parse descendant pid: %v", err)
+	}
+	return pid
+}
+
+func waitForPondMeshSignalProcessExit(t *testing.T, pid int) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		err := syscall.Kill(pid, 0)
+		if errors.Is(err, syscall.ESRCH) {
+			return
+		}
+		if err != nil && !errors.Is(err, syscall.EPERM) {
+			t.Fatalf("probe descendant %d: %v", pid, err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("forward descendant %d survived cancellation", pid)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func runPondMeshTerminalInterruptHelper(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if os.Getenv("CBX_POND_SIGNAL_KIND") == "interrupt" {
+		signals := make(chan os.Signal, 1)
+		signal.Notify(signals, os.Interrupt)
+		defer signal.Stop(signals)
+		go func() {
+			<-signals
+			// A terminal delivers SIGINT to the full foreground process group.
+			// Delay parent cancellation so group isolation is exercised.
+			time.Sleep(200 * time.Millisecond)
+			cancel()
+		}()
+	}
+
+	members := []pondMember{{
+		Name:  "peer-a",
+		Lease: "lease-a",
+		SSH:   SSHTarget{User: "crab", Host: "127.0.0.1", Port: "22", DisableHostKeyChecking: true, NoControlMaster: true},
+	}}
+	summary := pondMeshSummary{Forwards: []pondMeshForward{{
+		Peer: "peer-a", RemotePort: 8080, LocalPort: 18080, LeaseID: "lease-a",
+	}}}
+	if err := runPondMeshForwards(ctx, pondConnectOptions{Stdout: io.Discard, Stderr: io.Discard}, members, summary); err != nil {
+		t.Fatalf("clean terminal interrupt: %v", err)
+	}
+}

--- a/internal/cli/pond_mesh_test.go
+++ b/internal/cli/pond_mesh_test.go
@@ -14,6 +14,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -22,12 +23,14 @@ import (
 // the argv at Start() and blocks Wait() on the signal channel so the orchestration
 // loop can be terminated deterministically without real ssh processes.
 type pondMeshRecordingHandle struct {
-	name    string
-	args    []string
-	pid     int
-	started bool
-	signal  chan struct{}
-	mu      sync.Mutex
+	name      string
+	args      []string
+	pid       int
+	started   bool
+	signal    chan struct{}
+	ctx       context.Context
+	cancelled atomic.Bool
+	mu        sync.Mutex
 }
 
 func (h *pondMeshRecordingHandle) Start() error {
@@ -38,7 +41,15 @@ func (h *pondMeshRecordingHandle) Start() error {
 }
 
 func (h *pondMeshRecordingHandle) Wait() error {
-	<-h.signal
+	// Mirror the production handle: a healthy tunnel blocks until it is either
+	// explicitly signalled or the ctx watchdog would kill it (ctx cancelled).
+	// On ctx cancellation we record provenance exactly as the real Cancel hook
+	// does, then return nil — a healthy tunnel torn down by our own teardown.
+	select {
+	case <-h.signal:
+	case <-h.ctx.Done():
+		h.cancelled.Store(true)
+	}
 	return nil
 }
 
@@ -49,6 +60,11 @@ func (h *pondMeshRecordingHandle) String() string {
 func (h *pondMeshRecordingHandle) PID() int { return h.pid }
 
 func (h *pondMeshRecordingHandle) Process() processSignaler { return testProcessSignaler{h.signal} }
+
+// WasTerminatedByOurCancel mirrors the production classifier for the recording
+// double: this stub's Wait() only returns nil (a healthy tunnel torn down by
+// the connect loop), so a set cancelled flag always denotes our teardown.
+func (h *pondMeshRecordingHandle) WasTerminatedByOurCancel() bool { return h.cancelled.Load() }
 
 // testProcessSignaler closes the underlying channel on the first signal so
 // the handle's Wait() returns.
@@ -78,11 +94,11 @@ type pondMeshRecordingRunner struct {
 	handles []*pondMeshRecordingHandle
 }
 
-func (r *pondMeshRecordingRunner) Command(_ context.Context, name string, args ...string) pondMeshHandle {
+func (r *pondMeshRecordingRunner) Command(ctx context.Context, name string, args ...string) pondMeshHandle {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.calls = append(r.calls, append([]string{name}, args...))
-	h := &pondMeshRecordingHandle{name: name, args: append([]string{}, args...), pid: 1000 + len(r.handles), signal: make(chan struct{})}
+	h := &pondMeshRecordingHandle{name: name, args: append([]string{}, args...), pid: 1000 + len(r.handles), signal: make(chan struct{}), ctx: ctx}
 	r.handles = append(r.handles, h)
 	return h
 }

--- a/internal/cli/pond_mesh_test.go
+++ b/internal/cli/pond_mesh_test.go
@@ -29,11 +29,18 @@ type pondMeshRecordingHandle struct {
 	started   bool
 	signal    chan struct{}
 	ctx       context.Context
+	startHook func() error
+	waitErr   error
 	cancelled atomic.Bool
 	mu        sync.Mutex
 }
 
 func (h *pondMeshRecordingHandle) Start() error {
+	if h.startHook != nil {
+		if err := h.startHook(); err != nil {
+			return err
+		}
+	}
 	h.mu.Lock()
 	h.started = true
 	h.mu.Unlock()
@@ -41,6 +48,9 @@ func (h *pondMeshRecordingHandle) Start() error {
 }
 
 func (h *pondMeshRecordingHandle) Wait() error {
+	if h.waitErr != nil {
+		return h.waitErr
+	}
 	// Mirror the production handle: a healthy tunnel blocks until it is either
 	// explicitly signalled or the ctx watchdog would kill it (ctx cancelled).
 	// On ctx cancellation we record provenance exactly as the real Cancel hook
@@ -89,16 +99,25 @@ func (p testProcessSignaler) Kill() error {
 // every (name, args) invocation it sees so tests can assert on the full SSH
 // argument vector without spawning processes.
 type pondMeshRecordingRunner struct {
-	mu      sync.Mutex
-	calls   [][]string
-	handles []*pondMeshRecordingHandle
+	mu        sync.Mutex
+	calls     [][]string
+	handles   []*pondMeshRecordingHandle
+	startHook func(index int, ctx context.Context) error
+	waitErrs  map[int]error
 }
 
 func (r *pondMeshRecordingRunner) Command(ctx context.Context, name string, args ...string) pondMeshHandle {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.calls = append(r.calls, append([]string{name}, args...))
-	h := &pondMeshRecordingHandle{name: name, args: append([]string{}, args...), pid: 1000 + len(r.handles), signal: make(chan struct{}), ctx: ctx}
+	index := len(r.handles)
+	h := &pondMeshRecordingHandle{name: name, args: append([]string{}, args...), pid: 1000 + index, signal: make(chan struct{}), ctx: ctx}
+	if r.startHook != nil {
+		h.startHook = func() error { return r.startHook(index, ctx) }
+	}
+	if r.waitErrs != nil {
+		h.waitErr = r.waitErrs[index]
+	}
 	r.handles = append(r.handles, h)
 	return h
 }
@@ -340,13 +359,21 @@ func TestPreparePondMeshSummarySkipsMembersWithoutPorts(t *testing.T) {
 	}
 }
 
-func TestPondMeshSSHArgsBuildsLocalForward(t *testing.T) {
+func TestPondMeshSSHArgsGroupsMemberForwards(t *testing.T) {
 	target := SSHTarget{User: "ubuntu", Host: "lease.example", Port: "22", Key: "/tmp/test-key"}
-	fwd := pondMeshForward{Peer: "web", RemotePort: 8080, LocalPort: 51900, LeaseID: "cbx_x"}
-	args := pondMeshSSHArgsForForward(target, fwd)
+	forwards := []pondMeshForward{
+		{Peer: "web", RemotePort: 8080, LocalPort: 51900, LeaseID: "cbx_x"},
+		{Peer: "web", RemotePort: 9090, LocalPort: 51901, LeaseID: "cbx_x"},
+	}
+	args := pondMeshSSHArgsForForwards(target, forwards)
 	joined := strings.Join(args, " ")
-	if !strings.Contains(joined, "-L 127.0.0.1:51900:127.0.0.1:8080") {
-		t.Fatalf("args missing -L spec: %v", args)
+	for _, spec := range []string{
+		"-L 127.0.0.1:51900:127.0.0.1:8080",
+		"-L 127.0.0.1:51901:127.0.0.1:9090",
+	} {
+		if !strings.Contains(joined, spec) {
+			t.Fatalf("args missing %q: %v", spec, args)
+		}
 	}
 	if !strings.Contains(joined, "ubuntu@lease.example") {
 		t.Fatalf("args missing user@host: %v", args)
@@ -357,12 +384,19 @@ func TestPondMeshSSHArgsBuildsLocalForward(t *testing.T) {
 	if !strings.Contains(joined, "ExitOnForwardFailure=yes") {
 		t.Fatalf("args missing ExitOnForwardFailure option: %v", args)
 	}
-	if !strings.Contains(joined, "ControlMaster=auto") && !strings.Contains(joined, "ControlMaster=no") {
-		t.Fatalf("args missing ControlMaster option: %v", args)
+	for _, required := range []string{"ControlMaster=no", "ControlPath=none", "ControlPersist=no"} {
+		if !strings.Contains(joined, required) {
+			t.Fatalf("args missing %q: %v", required, args)
+		}
+	}
+	for _, unwanted := range []string{"ControlMaster=auto"} {
+		if strings.Contains(joined, unwanted) {
+			t.Fatalf("args contain persistent multiplexing option %q: %v", unwanted, args)
+		}
 	}
 }
 
-func TestRunPondMeshForwardsLaunchesPerForwardAndTearsDown(t *testing.T) {
+func TestRunPondMeshForwardsLaunchesPerMemberAndTearsDown(t *testing.T) {
 	runner := &pondMeshRecordingRunner{}
 	members := []pondMember{
 		{Name: "web", Lease: "cbx_web", SSH: SSHTarget{User: "ubuntu", Host: "lease-web.example", Port: "22"}, Ports: []int{8080}},
@@ -383,7 +417,7 @@ func TestRunPondMeshForwardsLaunchesPerForwardAndTearsDown(t *testing.T) {
 		runner.mu.Lock()
 		count := len(runner.handles)
 		runner.mu.Unlock()
-		if count >= 3 {
+		if count >= 2 {
 			break
 		}
 		select {
@@ -401,10 +435,10 @@ func TestRunPondMeshForwardsLaunchesPerForwardAndTearsDown(t *testing.T) {
 			t.Fatalf("runPondMeshForwards: %v", err)
 		}
 	}
-	if got := len(runner.calls); got != 3 {
-		t.Fatalf("expected 3 ssh invocations, got %d (%v)", got, runner.calls)
+	if got := len(runner.calls); got != 2 {
+		t.Fatalf("expected 2 ssh invocations (one per member), got %d (%v)", got, runner.calls)
 	}
-	// Verify each ssh invocation carries the right -L spec.
+	// Verify the worker's two ports share one owned SSH invocation.
 	wantSpecs := []string{
 		"127.0.0.1:60000:127.0.0.1:8080",
 		"127.0.0.1:60001:127.0.0.1:3000",
@@ -433,6 +467,124 @@ func TestRunPondMeshForwardsLaunchesPerForwardAndTearsDown(t *testing.T) {
 	}
 	if gotTargetsBySpec["127.0.0.1:60001:127.0.0.1:3000"] != "ubuntu@lease-worker.example" {
 		t.Fatalf("worker forward target=%q", gotTargetsBySpec["127.0.0.1:60001:127.0.0.1:3000"])
+	}
+	workerCalls := 0
+	for _, call := range runner.calls {
+		if call[len(call)-1] == "ubuntu@lease-worker.example" {
+			workerCalls++
+			forwardCount := 0
+			for _, arg := range call {
+				if arg == "-L" {
+					forwardCount++
+				}
+			}
+			if forwardCount != 2 {
+				t.Fatalf("worker SSH invocation has %d forwards, want 2: %v", forwardCount, call)
+			}
+		}
+	}
+	if workerCalls != 1 {
+		t.Fatalf("worker SSH invocations=%d want 1", workerCalls)
+	}
+}
+
+func TestRunPondMeshForwardsReapsStartupFailures(t *testing.T) {
+	members := []pondMember{
+		{Name: "web", Lease: "cbx_web", SSH: SSHTarget{User: "ubuntu", Host: "lease-web.example", Port: "22"}},
+		{Name: "worker", Lease: "cbx_worker", SSH: SSHTarget{User: "ubuntu", Host: "lease-worker.example", Port: "22"}},
+	}
+	summary := pondMeshSummary{Forwards: []pondMeshForward{
+		{Peer: "web", RemotePort: 8080, LocalPort: 60000, LeaseID: "cbx_web"},
+		{Peer: "worker", RemotePort: 3000, LocalPort: 60001, LeaseID: "cbx_worker"},
+	}}
+
+	t.Run("operator cancellation is clean", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		runner := &pondMeshRecordingRunner{}
+		runner.startHook = func(index int, commandCtx context.Context) error {
+			if index != 1 {
+				return nil
+			}
+			cancel()
+			<-commandCtx.Done()
+			return commandCtx.Err()
+		}
+		err := runPondMeshForwards(ctx, pondConnectOptions{Stdout: io.Discard, Stderr: io.Discard, Runner: runner}, members, summary)
+		if err != nil {
+			t.Fatalf("operator cancellation during startup = %v", err)
+		}
+		if !runner.handles[0].cancelled.Load() {
+			t.Fatal("already-started member was not reaped after operator cancellation")
+		}
+	})
+
+	t.Run("genuine startup failure is reported", func(t *testing.T) {
+		runner := &pondMeshRecordingRunner{}
+		startErr := errors.New("ssh executable failed")
+		runner.startHook = func(index int, _ context.Context) error {
+			if index == 1 {
+				return startErr
+			}
+			return nil
+		}
+		err := runPondMeshForwards(context.Background(), pondConnectOptions{Stdout: io.Discard, Stderr: io.Discard, Runner: runner}, members, summary)
+		if !errors.Is(err, startErr) {
+			t.Fatalf("genuine startup failure = %v, want %v", err, startErr)
+		}
+		if !runner.handles[0].cancelled.Load() {
+			t.Fatal("already-started member was not reaped after genuine startup failure")
+		}
+	})
+
+	t.Run("cancellation does not hide earlier tunnel failure", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		forwardErr := errors.New("earlier ssh authentication failed")
+		runner := &pondMeshRecordingRunner{waitErrs: map[int]error{0: forwardErr}}
+		runner.startHook = func(index int, commandCtx context.Context) error {
+			if index != 1 {
+				return nil
+			}
+			cancel()
+			<-commandCtx.Done()
+			return commandCtx.Err()
+		}
+		err := runPondMeshForwards(ctx, pondConnectOptions{Stdout: io.Discard, Stderr: io.Discard, Runner: runner}, members, summary)
+		if !errors.Is(err, forwardErr) {
+			t.Fatalf("startup cancellation hid earlier tunnel failure: got %v, want %v", err, forwardErr)
+		}
+	})
+}
+
+func TestRunPondMeshForwardsReportsUnexpectedCleanExit(t *testing.T) {
+	runner := &pondMeshRecordingRunner{}
+	members := []pondMember{{
+		Name: "web", Lease: "cbx_web", SSH: SSHTarget{User: "ubuntu", Host: "lease-web.example", Port: "22"}, Ports: []int{8080},
+	}}
+	summary := pondMeshSummary{Forwards: []pondMeshForward{{
+		Peer: "web", RemotePort: 8080, LocalPort: 60000, LeaseID: "cbx_web",
+	}}}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- runPondMeshForwards(context.Background(), pondConnectOptions{Stdout: io.Discard, Stderr: io.Discard, Runner: runner}, members, summary)
+	}()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		runner.mu.Lock()
+		if len(runner.handles) == 1 {
+			handle := runner.handles[0]
+			runner.mu.Unlock()
+			_ = handle.Process().Signal(os.Interrupt)
+			break
+		}
+		runner.mu.Unlock()
+		if time.Now().After(deadline) {
+			t.Fatal("forward did not start")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	err := <-errCh
+	if err == nil || !strings.Contains(err.Error(), "ssh forwards for web:8080 exited unexpectedly") {
+		t.Fatalf("unexpected clean exit = %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fix pond SSH-forward shutdown classification without losing genuine tunnel failures. Each member now owns one non-multiplexed SSH process containing all of its `-L` forwards; Crabbox tears down that complete process tree and suppresses a wait error only when the same process proves Crabbox initiated its termination.

## Maintainer improvements

- Preserve per-process cancellation provenance instead of consulting shared context state.
- Group every exposed port for one member into one SSH connection, avoiding both persistent multiplexing daemons and per-port handshake fan-out.
- On Unix, reserve a stable process group with an internal anchor and reap the SSH root plus descendants on cancellation or unexpected root exit.
- On Windows, start SSH suspended, assign it to a kill-on-close Job Object before execution, retain exact process identity, and use a cancellation-only exit code to distinguish owned termination from natural exit races.
- Treat Ctrl-C, SIGHUP, SIGQUIT, and Ctrl-Z as owned teardown; report unexpected clean SSH exits and genuine sibling failures.
- Reap already-started members when cancellation races startup, while preserving any earlier genuine tunnel or cleanup failure.
- Document terminal semantics and add the release-note entry with thanks to @anagnorisis2peripeteia.

## Verification

- `go test -race ./...`
- `go vet ./...`
- native CLI build and Windows amd64 test cross-build
- pond-focused race suite, 10 repetitions
- Worker format, lint, TypeScript, and build checks
- Worker Vitest: 1,055 passed, 3 skipped
- docs-site build
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output`: clean, no actionable findings

## Live proof

- Disposable AWS Linux member with two exposed HTTP ports: `pond connect` launched exactly one SSH root carrying both `-L` specifications; both loopback endpoints returned distinct expected payloads; Ctrl-C exited 0; no listener, SSH process, or anchor remained.
- Disposable native AWS Windows host: the focused process/Job suite passed 20 consecutive repetitions, including natural-exit races, forced Job-termination failure fallback, and descendant cleanup. Proof: https://crabbox.openclaw.ai/portal/runs/run_2db91808743b
- Earlier two-member AWS proof covered Ctrl-C, Ctrl-Z, genuine child failure, sibling cleanup, and zero residual listeners/processes.
- All disposable leases were released and verified absent.

Tracks https://github.com/openclaw/crabbox/issues/1096.
