### PR TITLE
fix(cli): lock egress host-daemon starts to prevent double-provision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Serialized complete per-lease egress host-daemon starts and stops and atomically replaced the remote client, preventing concurrent lifecycle commands and ordinary restarts from leaving untracked or stale processes. Thanks @anagnorisis2peripeteia.
 - Closed code-server WebSockets whose upstream dial completes after bridge shutdown, preventing orphaned connections and reader goroutines. Thanks @anagnorisis2peripeteia.
 - Stopped failed runs' telemetry samplers promptly so long-lived CLI processes do not retain ticker goroutines or continue probing released leases. Thanks @anagnorisis2peripeteia.
 - Preserved WebVNC reconnect attempt state across consecutive connection failures so retry delays increase instead of repeatedly hammering the coordinator. Thanks @anagnorisis2peripeteia.

--- a/internal/cli/egress.go
+++ b/internal/cli/egress.go
@@ -17,6 +17,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -207,9 +208,24 @@ func (a App) egressStart(ctx context.Context, args []string) error {
 	if err := enforceManagedLeaseCapabilities(cfg, server, leaseID); err != nil {
 		return err
 	}
+	var unlockDaemon func()
+	if *daemon {
+		unlockDaemon, err = acquireEgressDaemonLock(leaseID)
+		if err != nil {
+			return exit(2, "acquire egress daemon lock: %v", err)
+		}
+		defer unlockDaemon()
+	}
 	sessionID := newLocalEgressSessionID()
 	if err := installRemoteEgressClient(ctx, target); err != nil {
 		return err
+	}
+	if *daemon {
+		if stopped, err := a.stopEgressHostDaemonLocked(leaseID); err != nil {
+			return err
+		} else if stopped {
+			fmt.Fprintln(a.Stdout, "egress host daemon: replacing previous daemon")
+		}
 	}
 	clientTicket, err := coord.CreateEgressTicket(ctx, leaseID, "client", sessionID, *profile, allow)
 	if err != nil {
@@ -237,7 +253,7 @@ func (a App) egressStart(ctx context.Context, args []string) error {
 		hostArgs = append(hostArgs, "--allow", strings.Join(allow, ","))
 	}
 	if *daemon {
-		return a.startEgressHostDaemon(leaseID, hostArgs)
+		return a.startEgressHostDaemonLocked(leaseID, hostArgs)
 	}
 	hostTicket, err := coord.CreateEgressTicket(ctx, leaseID, "host", sessionID, *profile, allow)
 	if err != nil {
@@ -293,19 +309,38 @@ func (a App) egressStop(ctx context.Context, args []string) error {
 	if *id == "" {
 		return exit(2, "usage: crabbox egress stop --id <lease-id-or-slug>")
 	}
-	stoppedLocal, err := a.stopEgressHostDaemon(*id)
-	if err != nil {
-		return err
-	}
 	cfg, cfgErr := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{LeaseID: *id})
+	leaseID := *id
+	var target SSHTarget
+	resolved := false
 	if cfgErr == nil {
-		if _, target, leaseID, resolveErr := a.resolveNetworkLeaseTarget(ctx, cfg, *id, false); resolveErr == nil {
-			_ = runSSHQuiet(ctx, target, remoteStopEgressClientCommand())
-			if leaseID != *id && !stoppedLocal {
-				stoppedLocal, _ = a.stopEgressHostDaemon(leaseID)
-			}
-			fmt.Fprintf(a.Stdout, "egress remote client: stopped lease=%s\n", leaseID)
+		if _, resolvedTarget, resolvedLeaseID, resolveErr := a.resolveNetworkLeaseTarget(ctx, cfg, *id, false); resolveErr == nil {
+			target = resolvedTarget
+			leaseID = resolvedLeaseID
+			resolved = true
 		}
+	}
+	unlock, err := acquireEgressDaemonLocks(*id, leaseID)
+	if err != nil {
+		return exit(2, "acquire egress daemon locks: %v", err)
+	}
+	defer unlock()
+	stoppedLocal := false
+	seen := map[string]bool{}
+	for _, daemonID := range []string{*id, leaseID} {
+		if seen[daemonID] {
+			continue
+		}
+		seen[daemonID] = true
+		stopped, stopErr := a.stopEgressHostDaemonLocked(daemonID)
+		if stopErr != nil {
+			return stopErr
+		}
+		stoppedLocal = stoppedLocal || stopped
+	}
+	if resolved {
+		_ = runSSHQuiet(ctx, target, remoteStopEgressClientCommand())
+		fmt.Fprintf(a.Stdout, "egress remote client: stopped lease=%s\n", leaseID)
 	}
 	if !stoppedLocal {
 		fmt.Fprintf(a.Stdout, "egress host daemon: no local daemon for %s\n", *id)
@@ -966,12 +1001,30 @@ func installRemoteEgressClient(ctx context.Context, target SSHTarget) error {
 		return err
 	}
 	defer cleanup()
-	args := append(scpBaseArgs(target), exe, target.User+"@"+target.Host+":"+egressRemoteBinary)
+	uploadNonce, err := randomHex(8)
+	if err != nil {
+		return exit(2, "create egress client upload path: %v", err)
+	}
+	uploadPath := egressRemoteBinary + ".tmp-" + uploadNonce
+	promoted := false
+	defer func() {
+		if promoted {
+			return
+		}
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_ = runSSHQuiet(cleanupCtx, target, "rm -f "+shellQuote(uploadPath))
+	}()
+	args := append(scpBaseArgs(target), exe, target.User+"@"+target.Host+":"+uploadPath)
 	cmd := exec.CommandContext(ctx, "scp", args...)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return exit(5, "copy egress client: %v: %s", err, strings.TrimSpace(string(out)))
 	}
-	return runSSHQuiet(ctx, target, "chmod 700 "+shellQuote(egressRemoteBinary))
+	if err := runSSHQuiet(ctx, target, "chmod 700 "+shellQuote(uploadPath)+" && mv -f "+shellQuote(uploadPath)+" "+shellQuote(egressRemoteBinary)); err != nil {
+		return exit(5, "install egress client: %v", err)
+	}
+	promoted = true
+	return nil
 }
 
 func egressClientBinaryForTarget(ctx context.Context, target SSHTarget) (string, func(), error) {
@@ -1068,12 +1121,69 @@ func egressRemoteProbeCommand(host, port string) string {
 	return "if command -v nc >/dev/null 2>&1; then nc -z " + shellQuote(host) + " " + shellQuote(port) + " >/dev/null 2>&1; else timeout 1 bash -lc " + shellQuote("</dev/tcp/"+host+"/"+port) + " >/dev/null 2>&1; fi"
 }
 
+// acquireEgressDaemonLock serializes every local egress daemon lifecycle
+// operation for a lease. It is keyed on the egress pid path, so it does not
+// contend with the WebVNC daemon lock for the same lease.
+func acquireEgressDaemonLock(leaseID string) (func(), error) {
+	_, pidPath, err := egressDaemonPaths(leaseID)
+	if err != nil {
+		return nil, err
+	}
+	dir := filepath.Dir(pidPath)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, err
+	}
+	if err := os.Chmod(dir, 0o700); err != nil {
+		return nil, err
+	}
+	return acquireDaemonFileLock(pidPath + ".lock")
+}
+
+func acquireEgressDaemonLocks(leaseIDs ...string) (func(), error) {
+	unique := map[string]bool{}
+	ids := make([]string, 0, len(leaseIDs))
+	for _, leaseID := range leaseIDs {
+		leaseID = strings.TrimSpace(leaseID)
+		if leaseID == "" || unique[leaseID] {
+			continue
+		}
+		unique[leaseID] = true
+		ids = append(ids, leaseID)
+	}
+	sort.Strings(ids)
+	unlocks := make([]func(), 0, len(ids))
+	for _, leaseID := range ids {
+		unlock, err := acquireEgressDaemonLock(leaseID)
+		if err != nil {
+			for i := len(unlocks) - 1; i >= 0; i-- {
+				unlocks[i]()
+			}
+			return nil, err
+		}
+		unlocks = append(unlocks, unlock)
+	}
+	return func() {
+		for i := len(unlocks) - 1; i >= 0; i-- {
+			unlocks[i]()
+		}
+	}, nil
+}
+
 func (a App) startEgressHostDaemon(leaseID string, args []string) error {
+	unlock, err := acquireEgressDaemonLock(leaseID)
+	if err != nil {
+		return exit(2, "acquire egress daemon lock: %v", err)
+	}
+	defer unlock()
+	return a.startEgressHostDaemonLocked(leaseID, args)
+}
+
+func (a App) startEgressHostDaemonLocked(leaseID string, args []string) error {
 	exe, err := os.Executable()
 	if err != nil {
 		return exit(2, "resolve crabbox executable: %v", err)
 	}
-	if stopped, err := a.stopEgressHostDaemon(leaseID); err != nil {
+	if stopped, err := a.stopEgressHostDaemonLocked(leaseID); err != nil {
 		return err
 	} else if stopped {
 		fmt.Fprintln(a.Stdout, "egress host daemon: replacing previous daemon")
@@ -1114,6 +1224,15 @@ func (a App) startEgressHostDaemon(leaseID string, args []string) error {
 }
 
 func (a App) stopEgressHostDaemon(leaseID string) (bool, error) {
+	unlock, err := acquireEgressDaemonLock(leaseID)
+	if err != nil {
+		return false, exit(2, "acquire egress daemon lock: %v", err)
+	}
+	defer unlock()
+	return a.stopEgressHostDaemonLocked(leaseID)
+}
+
+func (a App) stopEgressHostDaemonLocked(leaseID string) (bool, error) {
 	_, pidPath, err := egressDaemonPaths(leaseID)
 	if err != nil {
 		return false, err

--- a/internal/cli/egress.go
+++ b/internal/cli/egress.go
@@ -220,14 +220,7 @@ func (a App) egressStart(ctx context.Context, args []string) error {
 	if err := installRemoteEgressClient(ctx, target); err != nil {
 		return err
 	}
-	if *daemon {
-		if stopped, err := a.stopEgressHostDaemonLocked(leaseID); err != nil {
-			return err
-		} else if stopped {
-			fmt.Fprintln(a.Stdout, "egress host daemon: replacing previous daemon")
-		}
-	}
-	clientTicket, err := coord.CreateEgressTicket(ctx, leaseID, "client", sessionID, *profile, allow)
+	clientTicket, err := a.prepareEgressClientCutover(ctx, coord, leaseID, sessionID, *profile, allow, *daemon)
 	if err != nil {
 		return err
 	}
@@ -261,6 +254,21 @@ func (a App) egressStart(ctx context.Context, args []string) error {
 	}
 	hostArgs = append(hostArgs, "--ticket", hostTicket.Ticket)
 	return a.egressHost(ctx, hostArgs)
+}
+
+func (a App) prepareEgressClientCutover(ctx context.Context, coord *CoordinatorClient, leaseID, sessionID, profile string, allow []string, daemon bool) (CoordinatorEgressTicket, error) {
+	clientTicket, err := coord.CreateEgressTicket(ctx, leaseID, "client", sessionID, profile, allow)
+	if err != nil {
+		return CoordinatorEgressTicket{}, err
+	}
+	if daemon {
+		if stopped, err := a.stopEgressHostDaemonLocked(leaseID); err != nil {
+			return CoordinatorEgressTicket{}, err
+		} else if stopped {
+			fmt.Fprintln(a.Stdout, "egress host daemon: replacing previous daemon")
+		}
+	}
+	return clientTicket, nil
 }
 
 func (a App) egressStatus(ctx context.Context, args []string) error {

--- a/internal/cli/egress_daemon_double_provision_test.go
+++ b/internal/cli/egress_daemon_double_provision_test.go
@@ -1,0 +1,286 @@
+//go:build !windows
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestMain keeps re-invoked test binaries alive as daemon children instead of
+// recursively running the suite.
+func TestMain(m *testing.M) {
+	if os.Getenv("CRABBOX_EGRESS_DAEMON_TESTCHILD") == "1" {
+		time.Sleep(10 * time.Minute)
+		os.Exit(egressDaemonFatalCode)
+	}
+	os.Exit(m.Run())
+}
+
+var egressDaemonPIDRe = regexp.MustCompile(`egress host daemon: pid=(\d+)`)
+
+func egressDaemonTestPID(t *testing.T, output *bytes.Buffer) int {
+	t.Helper()
+	match := egressDaemonPIDRe.FindSubmatch(output.Bytes())
+	if match == nil {
+		t.Fatalf("egress daemon start did not report a pid (output: %s)", strings.TrimSpace(output.String()))
+	}
+	pid, err := strconv.Atoi(string(match[1]))
+	if err != nil {
+		t.Fatalf("parse egress daemon pid: %v", err)
+	}
+	return pid
+}
+
+func egressDaemonTestAlive(pid int) bool {
+	command, running := webVNCDaemonProcessCommand(pid)
+	return running && !strings.Contains(strings.ToLower(command), "<defunct>")
+}
+
+func killEgressDaemonTestGroup(pid int) {
+	_ = syscall.Kill(-pid, syscall.SIGKILL) // Setpgid: pgid == supervisor pid
+	_ = syscall.Kill(pid, syscall.SIGKILL)
+}
+
+// TestEgressDaemonConcurrentStartDoubleProvision covers the former
+// stop-check-start-write race with real supervisor processes.
+func TestEgressDaemonConcurrentStartDoubleProvision(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())          // isolate crabboxStateDir
+	t.Setenv("CRABBOX_EGRESS_DAEMON_TESTCHILD", "1") // inherited by spawned supervisors
+
+	const iterations = 20
+	for i := 0; i < iterations; i++ {
+		leaseID := fmt.Sprintf("-%d", i)
+		var outs [2]bytes.Buffer
+		var errs [2]error
+		release := make(chan struct{})
+		var wg sync.WaitGroup
+		for g := 0; g < 2; g++ {
+			wg.Add(1)
+			go func(g int) {
+				defer wg.Done()
+				app := App{Stdout: &outs[g], Stderr: &outs[g]}
+				<-release
+				errs[g] = app.startEgressHostDaemon(leaseID, []string{"host", "--id", leaseID, "crabbox-test-supervisor"})
+			}(g)
+		}
+		close(release)
+		wg.Wait()
+
+		var pids []int
+		for g := 0; g < 2; g++ {
+			if errs[g] != nil {
+				t.Fatalf("iteration %d: concurrent start %d failed: %v (output: %s)", i, g, errs[g], strings.TrimSpace(outs[g].String()))
+			}
+			pids = append(pids, egressDaemonTestPID(t, &outs[g]))
+		}
+		for _, pid := range pids {
+			p := pid
+			t.Cleanup(func() { killEgressDaemonTestGroup(p) })
+		}
+
+		time.Sleep(100 * time.Millisecond)
+		var livePids []int
+		for _, pid := range pids {
+			if egressDaemonTestAlive(pid) {
+				livePids = append(livePids, pid)
+			}
+		}
+		_, pidPath, pErr := egressDaemonPaths(leaseID)
+		if pErr != nil {
+			t.Fatalf("egressDaemonPaths: %v", pErr)
+		}
+		recorded, readErr := os.ReadFile(pidPath)
+		if readErr != nil {
+			t.Fatalf("iteration %d: read egress daemon pid: %v", i, readErr)
+		}
+		recordedPID, parseErr := strconv.Atoi(strings.TrimSpace(string(recorded)))
+		if parseErr != nil {
+			t.Fatalf("iteration %d: parse recorded egress daemon pid: %v", i, parseErr)
+		}
+		if len(livePids) != 1 || livePids[0] != recordedPID {
+			t.Fatalf("iteration %d: concurrent starts left live supervisors=%v but pid file records %d (start errors: %v / %v)", i, livePids, recordedPID, errs[0], errs[1])
+		}
+
+		var stopOutput bytes.Buffer
+		stopped, stopErr := (App{Stdout: &stopOutput, Stderr: &stopOutput}).stopEgressHostDaemon(leaseID)
+		if stopErr != nil || !stopped {
+			t.Fatalf("iteration %d: stop recorded supervisor: stopped=%t err=%v output=%s", i, stopped, stopErr, strings.TrimSpace(stopOutput.String()))
+		}
+		for _, pid := range pids {
+			if egressDaemonTestAlive(pid) {
+				t.Fatalf("iteration %d: supervisor pid %d remained alive after stop", i, pid)
+			}
+		}
+		if _, err := os.Stat(pidPath); !os.IsNotExist(err) {
+			t.Fatalf("iteration %d: pid file still exists after stop: %v", i, err)
+		}
+	}
+}
+
+func TestEgressDaemonStopUsesLeaseLock(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CRABBOX_EGRESS_DAEMON_TESTCHILD", "1")
+	leaseID := "stop-lock"
+	var output bytes.Buffer
+	app := App{Stdout: &output, Stderr: &output}
+	if err := app.startEgressHostDaemon(leaseID, []string{"host", "--id", leaseID, "crabbox-test-supervisor"}); err != nil {
+		t.Fatalf("start egress daemon: %v (output: %s)", err, strings.TrimSpace(output.String()))
+	}
+	pid := egressDaemonTestPID(t, &output)
+	t.Cleanup(func() { killEgressDaemonTestGroup(pid) })
+
+	unlock, err := acquireEgressDaemonLock(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if unlock != nil {
+			unlock()
+		}
+	}()
+	type stopResult struct {
+		stopped bool
+		err     error
+	}
+	result := make(chan stopResult, 1)
+	go func() {
+		stopped, err := app.stopEgressHostDaemon(leaseID)
+		result <- stopResult{stopped: stopped, err: err}
+	}()
+
+	select {
+	case got := <-result:
+		t.Fatalf("stop bypassed the held lease lock: stopped=%t err=%v", got.stopped, got.err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	if !egressDaemonTestAlive(pid) {
+		t.Fatalf("daemon pid %d stopped while its lease lock was held", pid)
+	}
+	_, pidPath, err := egressDaemonPaths(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	recorded, err := os.ReadFile(pidPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(string(recorded)); got != strconv.Itoa(pid) {
+		t.Fatalf("pid file changed while lease lock was held: got %q want %d", got, pid)
+	}
+
+	unlock()
+	unlock = nil
+	select {
+	case got := <-result:
+		if got.err != nil {
+			t.Fatal(got.err)
+		}
+		if !got.stopped {
+			t.Fatal("locked stop reported no daemon")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("stop did not complete after lease lock release")
+	}
+	if egressDaemonTestAlive(pid) {
+		t.Fatalf("daemon pid %d remained alive after locked stop", pid)
+	}
+	if _, err := os.Stat(pidPath); !os.IsNotExist(err) {
+		t.Fatalf("pid file still exists after locked stop: %v", err)
+	}
+}
+
+func TestEgressStopHoldsDaemonLockThroughRemoteCleanup(t *testing.T) {
+	clearConfigEnv(t)
+	dir := t.TempDir()
+	isolateRunTestUserDirs(t, dir)
+	marker := filepath.Join(dir, "ssh-started")
+	release := filepath.Join(dir, "ssh-release")
+	sshScript := `#!/bin/sh
+cmd=""
+for arg do cmd="$arg"; done
+case "$cmd" in
+  *egress-client*)
+    : > "$CRABBOX_FAKE_SSH_STARTED"
+    while [ ! -e "$CRABBOX_FAKE_SSH_RELEASE" ]; do /bin/sleep 0.01; done
+    ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(dir, "ssh"), []byte(sshScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+	t.Setenv("CRABBOX_FAKE_SSH_STARTED", marker)
+	t.Setenv("CRABBOX_FAKE_SSH_RELEASE", release)
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, ".crabbox.yaml"))
+	t.Setenv("CRABBOX_FAKE_SSH_PORT", "22")
+
+	var stdout, stderr bytes.Buffer
+	stopDone := make(chan error, 1)
+	go func() {
+		stopDone <- (App{Stdout: &stdout, Stderr: &stderr}).egressStop(context.Background(), []string{
+			"--provider", "run-env-profile-test",
+			"--id", "friendly-slug",
+		})
+	}()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if _, err := os.Stat(marker); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			_ = os.WriteFile(release, nil, 0o600)
+			stopErr := <-stopDone
+			t.Fatalf("egress stop did not reach remote cleanup: %v\nstdout=%s\nstderr=%s", stopErr, stdout.String(), stderr.String())
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	lockResult := make(chan error, 1)
+	lockRelease := make(chan struct{})
+	go func() {
+		unlock, err := acquireEgressDaemonLock("cbx_env_profile_test")
+		lockResult <- err
+		if err == nil {
+			<-lockRelease
+			unlock()
+		}
+	}()
+	select {
+	case err := <-lockResult:
+		close(lockRelease)
+		_ = os.WriteFile(release, nil, 0o600)
+		t.Fatalf("remote cleanup released the daemon lock early: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	if err := os.WriteFile(release, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-stopDone:
+		if err != nil {
+			t.Fatalf("egress stop: %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("egress stop did not finish after remote cleanup")
+	}
+	select {
+	case err := <-lockResult:
+		if err != nil {
+			t.Fatal(err)
+		}
+		close(lockRelease)
+	case <-time.After(2 * time.Second):
+		t.Fatal("daemon lock did not release after remote cleanup")
+	}
+}

--- a/internal/cli/egress_daemon_double_provision_test.go
+++ b/internal/cli/egress_daemon_double_provision_test.go
@@ -6,6 +6,8 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -197,6 +199,47 @@ func TestEgressDaemonStopUsesLeaseLock(t *testing.T) {
 	}
 	if _, err := os.Stat(pidPath); !os.IsNotExist(err) {
 		t.Fatalf("pid file still exists after locked stop: %v", err)
+	}
+}
+
+func TestPrepareEgressClientCutoverPreservesDaemonWhenTicketCreationFails(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CRABBOX_EGRESS_DAEMON_TESTCHILD", "1")
+	leaseID := "ticket-failure"
+	var output bytes.Buffer
+	app := App{Stdout: &output, Stderr: &output}
+	if err := app.startEgressHostDaemon(leaseID, []string{"host", "--id", leaseID, "crabbox-test-supervisor"}); err != nil {
+		t.Fatalf("start egress daemon: %v (output: %s)", err, strings.TrimSpace(output.String()))
+	}
+	pid := egressDaemonTestPID(t, &output)
+	t.Cleanup(func() { killEgressDaemonTestGroup(pid) })
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/leases/"+leaseID+"/egress/ticket" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		http.Error(w, "temporary coordinator failure", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+	coord := &CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
+
+	_, err := app.prepareEgressClientCutover(context.Background(), coord, leaseID, "egress_test", "", []string{"example.com"}, true)
+	if err == nil {
+		t.Fatal("expected ticket creation failure")
+	}
+	if !egressDaemonTestAlive(pid) {
+		t.Fatalf("daemon pid %d stopped before ticket creation succeeded", pid)
+	}
+	_, pidPath, err := egressDaemonPaths(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	recorded, err := os.ReadFile(pidPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(string(recorded)); got != strconv.Itoa(pid) {
+		t.Fatalf("pid file changed after ticket failure: got %q want %d", got, pid)
 	}
 }
 

--- a/internal/cli/egress_install_unix_test.go
+++ b/internal/cli/egress_install_unix_test.go
@@ -1,0 +1,75 @@
+//go:build !windows
+
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInstallRemoteEgressClientUsesAtomicPromotion(t *testing.T) {
+	dir := t.TempDir()
+	goScript := `#!/bin/sh
+out=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-o" ]; then shift; out="$1"; break; fi
+  shift
+done
+[ -n "$out" ] || exit 1
+printf '#!/bin/sh\nexit 0\n' > "$out"
+/bin/chmod 700 "$out"
+`
+	scpScript := `#!/bin/sh
+printf '%s\n' "$@" > "$CRABBOX_FAKE_SCP_LOG"
+`
+	sshScript := `#!/bin/sh
+cmd=""
+for arg do cmd="$arg"; done
+printf '%s\n' "$cmd" >> "$CRABBOX_FAKE_SSH_LOG"
+/bin/cat >/dev/null || true
+`
+	for name, script := range map[string]string{"go": goScript, "scp": scpScript, "ssh": sshScript} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(script), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	scpLog := filepath.Join(dir, "scp.log")
+	sshLog := filepath.Join(dir, "ssh.log")
+	t.Setenv("PATH", dir)
+	t.Setenv("CRABBOX_FAKE_SCP_LOG", scpLog)
+	t.Setenv("CRABBOX_FAKE_SSH_LOG", sshLog)
+	target := SSHTarget{User: "crabbox", Host: "runner.example", Port: "22", TargetOS: targetLinux}
+	if err := installRemoteEgressClient(context.Background(), target); err != nil {
+		t.Fatal(err)
+	}
+
+	scpData, err := os.ReadFile(scpLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var destination string
+	for _, line := range strings.Split(strings.TrimSpace(string(scpData)), "\n") {
+		if strings.HasPrefix(line, "crabbox@runner.example:") {
+			destination = strings.TrimPrefix(line, "crabbox@runner.example:")
+		}
+	}
+	if !strings.HasPrefix(destination, egressRemoteBinary+".tmp-") || len(strings.TrimPrefix(destination, egressRemoteBinary+".tmp-")) != 16 {
+		t.Fatalf("scp destination is not a unique temporary path: %q", destination)
+	}
+	sshData, err := os.ReadFile(sshLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	promotion := string(sshData)
+	for _, want := range []string{"chmod 700 " + shellQuote(destination), "mv -f " + shellQuote(destination) + " " + shellQuote(egressRemoteBinary)} {
+		if !strings.Contains(promotion, want) {
+			t.Fatalf("promotion command missing %q: %s", want, promotion)
+		}
+	}
+	if strings.Contains(promotion, "rm -f") {
+		t.Fatalf("successful promotion unexpectedly ran cleanup: %s", promotion)
+	}
+}

--- a/internal/cli/webvnc.go
+++ b/internal/cli/webvnc.go
@@ -1896,13 +1896,13 @@ func acquireWebVNCDaemonLock(leaseID string) (func(), error) {
 	if err := os.Chmod(dir, 0o700); err != nil {
 		return nil, err
 	}
-	return acquireWebVNCDaemonFileLock(pidPath + ".lock")
+	return acquireDaemonFileLock(pidPath + ".lock")
 }
 
-func acquireWebVNCDaemonFileLock(lockPath string) (func(), error) {
+func acquireDaemonFileLock(lockPath string) (func(), error) {
 	if info, err := os.Lstat(lockPath); err == nil {
 		if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
-			return nil, fmt.Errorf("WebVNC daemon lock must be a regular file")
+			return nil, fmt.Errorf("daemon lock must be a regular file")
 		}
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return nil, err
@@ -1920,7 +1920,7 @@ func acquireWebVNCDaemonFileLock(lockPath string) (func(), error) {
 		return closeWithError(err)
 	}
 	if !info.Mode().IsRegular() {
-		return closeWithError(fmt.Errorf("WebVNC daemon lock must be a regular file"))
+		return closeWithError(fmt.Errorf("daemon lock must be a regular file"))
 	}
 	if err := file.Chmod(0o600); err != nil {
 		return closeWithError(err)


### PR DESCRIPTION
## Summary

Serialize the complete daemonized egress lifecycle per lease so concurrent starts and stops cannot double-provision, remove a replacement PID, or kill a newly started remote client. Preserve a working daemon until the replacement client ticket has been minted.

## What changed

| File | Change |
|---|---|
| `internal/cli/egress.go` | Hold per-lease locks across the full daemonized start and stop workflows; mint the replacement ticket before cutting over the working host; lock alias and canonical IDs in stable order; atomically promote unique remote-client uploads; stop the old host before activating the replacement session. |
| `internal/cli/webvnc.go` | Generalize the existing private daemon file-lock helper for safe reuse by egress without changing WebVNC behavior. |
| `internal/cli/egress_daemon_double_provision_test.go` | Exercise real supervisor processes, PID-file identity, clean stop, ticket-failure preservation, stop-side lock participation, and lock retention through remote cleanup. |
| `internal/cli/egress_install_unix_test.go` | Verify unique temporary upload plus atomic remote promotion on POSIX platforms. |
| `CHANGELOG.md` | Document the lifecycle fix and thank @anagnorisis2peripeteia. |

## Verification

Exact reviewed head: `b6a2c3a6d1bccffab5038db8e3af155389c1f03e`

- Base-path red: removing the start-side production lock made the real-process regression fail on iteration 0 with two live supervisors and only one recorded PID.
- Stop-path red: removing stop-side locking made the stop regression fail immediately because stop bypassed the held lease lock.
- Availability red: restoring stop-before-ticket order made the new regression fail because the working daemon was killed when the ticket endpoint returned HTTP 503.
- Focused lifecycle, ticket-failure, and atomic-install regressions passed 20 consecutive iterations under the race detector.
- The same-file #1099 timeout/cancel regression passed 20 consecutive iterations, including its real 20-second timeout path (473 seconds total).
- Full local suite passed after rebasing over #1099: `go test -race ./...`.
- Static/build/docs gates passed: `go vet ./...`, trimmed CLI build, and docs-site generation.
- Native Windows test binary cross-compiled successfully; POSIX fake-tool coverage is isolated behind `!windows`.
- Autoreview first found remote stop cleanup outside the lock and a POSIX-only test without a build constraint; both were fixed. A later exact-head review found the stop-before-ticket availability regression; that was fixed with red/green proof. Final branch autoreview was clean with no accepted/actionable findings and correctness confidence 0.91.

## Live proof

Validated the branch binary against the production coordinator and a fresh AWS lease.

The live run materially improved the original candidate:

1. The original candidate's two concurrent user-facing daemon starts both failed before reaching its narrow host lock because they tried to overwrite the running remote executable.
2. Unique temporary upload plus atomic rename fixed that failure, then exposed a second restart bug: the old host supervisor could reconnect its prior session while the replacement client was starting.
3. Moving old-host shutdown inside the same lock, after upload and ticket mint but before new-session activation, fixed the cutover while preserving the working host across preflight failures.

Final replay:

- Two identical concurrent `egress start --daemon` invocations both completed successfully and serialized their replacements.
- The final PID file named exactly one live supervisor, with one host child; all replaced supervisor PIDs were absent or defunct.
- Coordinator status reported the same final session with `host=true` and `client=true`.
- A real request from the lease through the mediated proxy returned HTTP 200.
- No temporary upload files remained on the lease.
- `egress stop` removed the local PID file and supervisor, killed the remote client and listener, and coordinator status transitioned to `host=false` and `client=false`.
- The AWS lease reached `released`, and the exact generated local lease-key directory was removed.
