### PR TITLE
fix(cli): deliver server-first egress banner racing the CONNECT handshake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Delivered server-first mediated-egress bytes after the local proxy handshake without letting one slow stream block unrelated connections. Thanks @anagnorisis2peripeteia.
 - Serialized complete per-lease egress host-daemon starts and stops and atomically replaced the remote client, preventing concurrent lifecycle commands and ordinary restarts from leaving untracked or stale processes. Thanks @anagnorisis2peripeteia.
 - Closed code-server WebSockets whose upstream dial completes after bridge shutdown, preventing orphaned connections and reader goroutines. Thanks @anagnorisis2peripeteia.
 - Stopped failed runs' telemetry samplers promptly so long-lived CLI processes do not retain ticker goroutines or continue probing released leases. Thanks @anagnorisis2peripeteia.

--- a/internal/cli/egress.go
+++ b/internal/cli/egress.go
@@ -32,6 +32,7 @@ const (
 	egressRemoteLog         = "/tmp/crabbox-egress-client.log"
 	egressMaxMessageBytes   = 2 * 1024 * 1024
 	egressCopyChunkBytes    = 32 * 1024
+	egressClientQueueBytes  = 8 * egressCopyChunkBytes
 	egressOpenTimeout       = 20 * time.Second
 	egressDialTimeout       = 15 * time.Second
 	egressRemoteReadyWait   = 5 * time.Second
@@ -50,6 +51,15 @@ type egressProxyMessage struct {
 
 type egressOpenResult struct {
 	err error
+}
+
+type egressClientConn struct {
+	conn            net.Conn
+	ready           bool
+	queue           [][]byte
+	queuedBytes     int
+	draining        bool
+	closeAfterDrain bool
 }
 
 func (a App) egress(ctx context.Context, args []string) error {
@@ -387,12 +397,13 @@ func (a App) egressCoordinatorAndLease(ctx context.Context, provider, coordinato
 }
 
 type egressBridge struct {
-	ws        *websocket.Conn
-	sessionID string
-	writeMu   sync.Mutex
-	mu        sync.Mutex
-	conns     map[string]net.Conn
-	pending   map[string]chan egressOpenResult
+	ws          *websocket.Conn
+	sessionID   string
+	writeMu     sync.Mutex
+	mu          sync.Mutex
+	conns       map[string]net.Conn
+	clientConns map[string]*egressClientConn
+	pending     map[string]chan egressOpenResult
 }
 
 func connectEgressBridge(ctx context.Context, coord *CoordinatorClient, leaseID, role, ticket, sessionID, profile string, allow []string) (*egressBridge, error) {
@@ -428,10 +439,11 @@ func connectEgressBridge(ctx context.Context, coord *CoordinatorClient, leaseID,
 	}
 	ws.SetReadLimit(egressMaxMessageBytes)
 	return &egressBridge{
-		ws:        ws,
-		sessionID: sessionID,
-		conns:     map[string]net.Conn{},
-		pending:   map[string]chan egressOpenResult{},
+		ws:          ws,
+		sessionID:   sessionID,
+		conns:       map[string]net.Conn{},
+		clientConns: map[string]*egressClientConn{},
+		pending:     map[string]chan egressOpenResult{},
 	}, nil
 }
 
@@ -494,7 +506,7 @@ func (b *egressBridge) hostOpen(ctx context.Context, msg egressProxyMessage, all
 		_ = conn.Close()
 		return
 	}
-	go b.copyConnToBridge(ctx, msg.ID, conn)
+	go b.relayConnToBridge(ctx, msg.ID, conn)
 }
 
 func dialPublicEgressHost(ctx context.Context, host, port string) (net.Conn, error) {
@@ -649,12 +661,13 @@ func (b *egressBridge) clientReadLoop(ctx context.Context) error {
 				go b.closeHostConn(msg.ID)
 			}
 		case "error":
-			b.finishOpen(msg.ID, errors.New(msg.Error))
-			b.closeConn(msg.ID)
+			b.rejectOpen(msg.ID, errors.New(msg.Error))
 		case "data":
-			b.writeConn(msg)
+			b.enqueueClientConn(msg)
 		case "close":
-			b.closeConn(msg.ID)
+			if !b.closeClientConnAfterDrain(msg.ID) {
+				b.closeConn(msg.ID)
+			}
 		}
 	}
 }
@@ -672,16 +685,23 @@ func (b *egressBridge) handleProxyConn(ctx context.Context, conn net.Conn) {
 		return
 	}
 	id := newLocalEgressConnID()
+	b.registerClientConn(id, conn)
 	if err := b.openRemote(ctx, id, host, port); err != nil {
+		b.discardClientConn(id)
 		_, _ = io.WriteString(conn, "HTTP/1.1 502 Bad Gateway\r\n\r\n")
 		return
 	}
-	b.mu.Lock()
-	b.conns[id] = conn
-	b.mu.Unlock()
-	defer b.closeConn(id)
+	cleanupBeforeRelay := true
+	defer func() {
+		if cleanupBeforeRelay {
+			b.closeConn(id)
+			go b.closeHostConn(id)
+		}
+	}()
 	if req.Method == http.MethodConnect {
-		_, _ = io.WriteString(conn, "HTTP/1.1 200 Connection Established\r\nProxy-Agent: crabbox\r\n\r\n")
+		if _, err := io.WriteString(conn, "HTTP/1.1 200 Connection Established\r\nProxy-Agent: crabbox\r\n\r\n"); err != nil {
+			return
+		}
 	} else {
 		var buf bytes.Buffer
 		req.RequestURI = ""
@@ -694,13 +714,15 @@ func (b *egressBridge) handleProxyConn(ctx context.Context, conn net.Conn) {
 			return
 		}
 	}
+	b.markClientConnReady(id)
 	if reader.Buffered() > 0 {
 		buffered, _ := reader.Peek(reader.Buffered())
 		if len(buffered) > 0 {
 			_ = b.writeJSON(ctx, egressProxyMessage{Type: "data", ID: id, Body: base64.StdEncoding.EncodeToString(buffered)})
 		}
 	}
-	b.copyConnToBridge(ctx, id, conn)
+	cleanupBeforeRelay = false
+	b.relayConnToBridge(ctx, id, conn)
 }
 
 func (b *egressBridge) openRemote(ctx context.Context, id, host, port string) error {
@@ -752,6 +774,9 @@ func (b *egressBridge) settleAbandonedOpen(id string, ch chan egressOpenResult) 
 // a synchronous write, so callers that must not block (the single clientReadLoop
 // goroutine, or a canceling openRemote) invoke it via `go`.
 func (b *egressBridge) closeHostConn(id string) {
+	if b.ws == nil {
+		return
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), egressDialTimeout)
 	defer cancel()
 	_ = b.writeJSON(ctx, egressProxyMessage{Type: "close", ID: id})
@@ -783,7 +808,16 @@ func (b *egressBridge) finishOpen(id string, err error) bool {
 	return false
 }
 
-func (b *egressBridge) copyConnToBridge(ctx context.Context, id string, conn net.Conn) {
+// rejectOpen leaves the local proxy socket owned by handleProxyConn long
+// enough to return its HTTP 502 response.
+func (b *egressBridge) rejectOpen(id string, err error) {
+	b.discardClientConn(id)
+	b.finishOpen(id, err)
+}
+
+func (b *egressBridge) relayConnToBridge(ctx context.Context, id string, conn net.Conn) {
+	defer b.closeConn(id)
+	defer b.closeHostConn(id)
 	buf := make([]byte, egressCopyChunkBytes)
 	for {
 		n, err := conn.Read(buf)
@@ -797,8 +831,6 @@ func (b *egressBridge) copyConnToBridge(ctx context.Context, id string, conn net
 			}
 		}
 		if err != nil {
-			_ = b.writeJSON(ctx, egressProxyMessage{Type: "close", ID: id})
-			b.closeConn(id)
 			return
 		}
 	}
@@ -817,14 +849,175 @@ func (b *egressBridge) writeConn(msg egressProxyMessage) {
 	}
 }
 
+func (b *egressBridge) registerClientConn(id string, conn net.Conn) {
+	b.mu.Lock()
+	if b.clientConns == nil {
+		b.clientConns = map[string]*egressClientConn{}
+	}
+	b.clientConns[id] = &egressClientConn{conn: conn}
+	b.mu.Unlock()
+}
+
+// enqueueClientConn keeps the shared WebSocket reader independent of local
+// socket speed. Each client stream gets an ordered, bounded queue; a stream
+// that cannot keep up is closed without stalling unrelated streams.
+func (b *egressBridge) enqueueClientConn(msg egressProxyMessage) {
+	data, err := base64.StdEncoding.DecodeString(msg.Body)
+	if err != nil {
+		return
+	}
+	b.mu.Lock()
+	client := b.clientConns[msg.ID]
+	if client == nil {
+		b.mu.Unlock()
+		return
+	}
+	if len(data) > egressClientQueueBytes-client.queuedBytes {
+		delete(b.clientConns, msg.ID)
+		b.mu.Unlock()
+		_ = client.conn.Close()
+		go b.closeHostConn(msg.ID)
+		return
+	}
+	client.queue = append(client.queue, data)
+	client.queuedBytes += len(data)
+	startDrain := client.ready && !client.draining
+	if startDrain {
+		client.draining = true
+	}
+	b.mu.Unlock()
+	if startDrain {
+		go b.drainClientConn(msg.ID, client)
+	}
+}
+
+func (b *egressBridge) markClientConnReady(id string) {
+	b.mu.Lock()
+	client := b.clientConns[id]
+	if client == nil {
+		b.mu.Unlock()
+		return
+	}
+	client.ready = true
+	startDrain := len(client.queue) > 0 && !client.draining
+	closeNow := client.closeAfterDrain && len(client.queue) == 0 && !client.draining
+	if closeNow {
+		delete(b.clientConns, id)
+	}
+	if startDrain {
+		client.draining = true
+	}
+	b.mu.Unlock()
+	if closeNow {
+		_ = client.conn.Close()
+		return
+	}
+	if startDrain {
+		go b.drainClientConn(id, client)
+	}
+}
+
+func (b *egressBridge) drainClientConn(id string, client *egressClientConn) {
+	for {
+		b.mu.Lock()
+		if b.clientConns[id] != client || len(client.queue) == 0 {
+			closeNow := false
+			if b.clientConns[id] == client {
+				client.draining = false
+				if client.closeAfterDrain {
+					delete(b.clientConns, id)
+					closeNow = true
+				}
+			}
+			b.mu.Unlock()
+			if closeNow {
+				_ = client.conn.Close()
+			}
+			return
+		}
+		data := client.queue[0]
+		client.queue[0] = nil
+		client.queue = client.queue[1:]
+		client.queuedBytes -= len(data)
+		b.mu.Unlock()
+
+		if err := writeFull(client.conn, data); err != nil {
+			b.failClientConn(id, client)
+			return
+		}
+	}
+}
+
+// closeClientConnAfterDrain preserves WebSocket frame order: a terminal close
+// is applied only after all preceding data frames reach the local socket.
+func (b *egressBridge) closeClientConnAfterDrain(id string) bool {
+	b.mu.Lock()
+	client := b.clientConns[id]
+	if client == nil {
+		b.mu.Unlock()
+		return false
+	}
+	client.closeAfterDrain = true
+	closeNow := client.ready && len(client.queue) == 0 && !client.draining
+	if closeNow {
+		delete(b.clientConns, id)
+	}
+	b.mu.Unlock()
+	if closeNow {
+		_ = client.conn.Close()
+	}
+	return true
+}
+
+func writeFull(conn net.Conn, data []byte) error {
+	for len(data) > 0 {
+		n, err := conn.Write(data)
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			return io.ErrNoProgress
+		}
+		data = data[n:]
+	}
+	return nil
+}
+
+func (b *egressBridge) failClientConn(id string, client *egressClientConn) {
+	b.mu.Lock()
+	if b.clientConns[id] != client {
+		b.mu.Unlock()
+		return
+	}
+	delete(b.clientConns, id)
+	b.mu.Unlock()
+	_ = client.conn.Close()
+	go b.closeHostConn(id)
+}
+
+func (b *egressBridge) discardClientConn(id string) {
+	b.mu.Lock()
+	delete(b.clientConns, id)
+	b.mu.Unlock()
+}
+
 func (b *egressBridge) closeConn(id string) {
 	b.mu.Lock()
 	conn := b.conns[id]
+	client := b.clientConns[id]
+	pending := b.pending[id]
 	delete(b.conns, id)
+	delete(b.clientConns, id)
 	delete(b.pending, id)
 	b.mu.Unlock()
 	if conn != nil {
 		_ = conn.Close()
+	}
+	if client != nil {
+		_ = client.conn.Close()
+	}
+	if pending != nil {
+		pending <- egressOpenResult{err: errors.New("egress connection closed")}
 	}
 }
 
@@ -850,16 +1043,26 @@ func (b *egressBridge) close() {
 	if b == nil {
 		return
 	}
-	_ = b.ws.Close(websocket.StatusNormalClosure, "egress stopped")
+	if b.ws != nil {
+		_ = b.ws.Close(websocket.StatusNormalClosure, "egress stopped")
+	}
 	b.mu.Lock()
-	defer b.mu.Unlock()
+	var closeConns []net.Conn
 	for id, conn := range b.conns {
-		_ = conn.Close()
+		closeConns = append(closeConns, conn)
 		delete(b.conns, id)
+	}
+	for id, client := range b.clientConns {
+		closeConns = append(closeConns, client.conn)
+		delete(b.clientConns, id)
 	}
 	for id, ch := range b.pending {
 		ch <- egressOpenResult{err: errors.New("egress bridge stopped")}
 		delete(b.pending, id)
+	}
+	b.mu.Unlock()
+	for _, conn := range closeConns {
+		_ = conn.Close()
 	}
 }
 

--- a/internal/cli/egress_banner_buffer_test.go
+++ b/internal/cli/egress_banner_buffer_test.go
@@ -1,0 +1,396 @@
+package cli
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"nhooyr.io/websocket"
+)
+
+func newTestEgressClientBridge() *egressBridge {
+	return &egressBridge{
+		conns:       map[string]net.Conn{},
+		clientConns: map[string]*egressClientConn{},
+		pending:     map[string]chan egressOpenResult{},
+	}
+}
+
+func egressDataFrame(id string, data []byte) egressProxyMessage {
+	return egressProxyMessage{Type: "data", ID: id, Body: base64.StdEncoding.EncodeToString(data)}
+}
+
+func readEgressBytes(t *testing.T, conn net.Conn, size int) []byte {
+	t.Helper()
+	if err := conn.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	data := make([]byte, size)
+	if _, err := io.ReadFull(conn, data); err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+func TestEgressServerFirstBannerFollowsProxyHandshake(t *testing.T) {
+	const id = "conn_banner"
+	const response = "HTTP/1.1 200 Connection Established\r\nProxy-Agent: crabbox\r\n\r\n"
+	const banner = "SSH-2.0-OpenSSH_9.6\r\n"
+	b := newTestEgressClientBridge()
+	client, proxy := net.Pipe()
+	defer client.Close()
+	b.registerClientConn(id, proxy)
+
+	b.enqueueClientConn(egressDataFrame(id, []byte(banner)))
+	if err := client.SetReadDeadline(time.Now().Add(50 * time.Millisecond)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Read(make([]byte, 1)); err == nil {
+		t.Fatal("server-first banner arrived before proxy handshake")
+	}
+
+	handshakeDone := make(chan error, 1)
+	go func() {
+		_, err := io.WriteString(proxy, response)
+		if err == nil {
+			b.markClientConnReady(id)
+		}
+		handshakeDone <- err
+	}()
+	if got := string(readEgressBytes(t, client, len(response)+len(banner))); got != response+banner {
+		t.Fatalf("proxy bytes = %q, want handshake then banner", got)
+	}
+	if err := <-handshakeDone; err != nil {
+		t.Fatal(err)
+	}
+	b.closeConn(id)
+}
+
+func TestEgressSlowClientStreamDoesNotBlockSharedReadLoop(t *testing.T) {
+	serverConn := make(chan *websocket.Conn, 1)
+	serverDone := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Errorf("accept websocket: %v", err)
+			return
+		}
+		serverConn <- conn
+		<-serverDone
+	}))
+	defer func() {
+		close(serverDone)
+		server.Close()
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ws, _, err := websocket.Dial(ctx, server.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := newTestEgressClientBridge()
+	b.ws = ws
+	defer b.close()
+
+	slowClient, slowProxy := net.Pipe()
+	defer slowClient.Close()
+	b.registerClientConn("slow", slowProxy)
+	b.markClientConnReady("slow")
+	fastClient, fastProxy := net.Pipe()
+	defer fastClient.Close()
+	b.registerClientConn("fast", fastProxy)
+	b.markClientConnReady("fast")
+
+	loopDone := make(chan error, 1)
+	go func() { loopDone <- b.clientReadLoop(ctx) }()
+	host := <-serverConn
+	writeFrame := func(msg egressProxyMessage) {
+		data, marshalErr := json.Marshal(msg)
+		if marshalErr != nil {
+			t.Fatal(marshalErr)
+		}
+		if writeErr := host.Write(ctx, websocket.MessageText, data); writeErr != nil {
+			t.Fatal(writeErr)
+		}
+	}
+	writeFrame(egressDataFrame("slow", []byte("blocked")))
+	writeFrame(egressDataFrame("fast", []byte("delivered")))
+	if got := string(readEgressBytes(t, fastClient, len("delivered"))); got != "delivered" {
+		t.Fatalf("fast stream = %q", got)
+	}
+
+	_ = host.CloseNow()
+	b.close()
+	select {
+	case <-loopDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("client read loop did not stop")
+	}
+}
+
+func TestEgressClientQueuePreservesFrameOrder(t *testing.T) {
+	const id = "conn_order"
+	b := newTestEgressClientBridge()
+	client, proxy := net.Pipe()
+	defer client.Close()
+	b.registerClientConn(id, proxy)
+	for _, part := range []string{"first", "-second", "-third"} {
+		b.enqueueClientConn(egressDataFrame(id, []byte(part)))
+	}
+	b.markClientConnReady(id)
+	if got := string(readEgressBytes(t, client, len("first-second-third"))); got != "first-second-third" {
+		t.Fatalf("ordered stream = %q", got)
+	}
+	b.closeConn(id)
+}
+
+func TestEgressClientCloseDrainsEarlierFrames(t *testing.T) {
+	const id = "conn_terminal_order"
+	b := newTestEgressClientBridge()
+	client, proxy := net.Pipe()
+	defer client.Close()
+	b.registerClientConn(id, proxy)
+	b.markClientConnReady(id)
+	b.enqueueClientConn(egressDataFrame(id, []byte("final-")))
+	b.enqueueClientConn(egressDataFrame(id, []byte("bytes")))
+	if !b.closeClientConnAfterDrain(id) {
+		t.Fatal("client stream was not registered")
+	}
+	if got := string(readEgressBytes(t, client, len("final-bytes"))); got != "final-bytes" {
+		t.Fatalf("terminal stream = %q", got)
+	}
+	if _, err := client.Read(make([]byte, 1)); !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrClosedPipe) {
+		t.Fatalf("terminal read error = %v, want closed stream", err)
+	}
+}
+
+func TestEgressClientQueueOverflowClosesOnlyThatStream(t *testing.T) {
+	b := newTestEgressClientBridge()
+	overflowClient, overflowProxy := net.Pipe()
+	defer overflowClient.Close()
+	b.registerClientConn("overflow", overflowProxy)
+	otherClient, otherProxy := net.Pipe()
+	defer otherClient.Close()
+	b.registerClientConn("other", otherProxy)
+
+	chunk := make([]byte, egressCopyChunkBytes)
+	for range egressClientQueueBytes/len(chunk) + 1 {
+		b.enqueueClientConn(egressDataFrame("overflow", chunk))
+	}
+	b.mu.Lock()
+	_, overflowExists := b.clientConns["overflow"]
+	_, otherExists := b.clientConns["other"]
+	b.mu.Unlock()
+	if overflowExists || !otherExists {
+		t.Fatalf("queue states overflow=%t other=%t", overflowExists, otherExists)
+	}
+	if _, err := overflowClient.Read(make([]byte, 1)); !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrClosedPipe) {
+		t.Fatalf("overflow stream read error = %v, want closed stream", err)
+	}
+	b.closeConn("other")
+}
+
+func TestEgressRejectedOpenPreservesProxyResponseSocket(t *testing.T) {
+	const id = "conn_rejected"
+	b := newTestEgressClientBridge()
+	client, proxy := net.Pipe()
+	defer client.Close()
+	defer proxy.Close()
+	b.registerClientConn(id, proxy)
+	result := make(chan egressOpenResult, 1)
+	b.mu.Lock()
+	b.pending[id] = result
+	b.mu.Unlock()
+
+	b.rejectOpen(id, errors.New("host not allowed"))
+	if got := <-result; got.err == nil || got.err.Error() != "host not allowed" {
+		t.Fatalf("open result = %v", got.err)
+	}
+	const response = "HTTP/1.1 502 Bad Gateway\r\n\r\n"
+	writeDone := make(chan error, 1)
+	go func() {
+		_, err := io.WriteString(proxy, response)
+		writeDone <- err
+	}()
+	if got := string(readEgressBytes(t, client, len(response))); got != response {
+		t.Fatalf("proxy response = %q", got)
+	}
+	if err := <-writeDone; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEgressRejectedOpenReturnsBadGatewayThroughReadLoop(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Errorf("accept websocket: %v", err)
+			return
+		}
+		defer conn.CloseNow()
+		_, data, err := conn.Read(context.Background())
+		if err != nil {
+			t.Errorf("read open: %v", err)
+			return
+		}
+		var open egressProxyMessage
+		if err := json.Unmarshal(data, &open); err != nil {
+			t.Errorf("decode open: %v", err)
+			return
+		}
+		if open.Type != "open" {
+			t.Errorf("message type = %q, want open", open.Type)
+			return
+		}
+		encoded, err := json.Marshal(egressProxyMessage{Type: "error", ID: open.ID, Error: "host not allowed"})
+		if err != nil {
+			t.Errorf("encode error: %v", err)
+			return
+		}
+		if err := conn.Write(context.Background(), websocket.MessageText, encoded); err != nil {
+			t.Errorf("write error: %v", err)
+			return
+		}
+		_, _, _ = conn.Read(context.Background())
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ws, _, err := websocket.Dial(ctx, server.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := newTestEgressClientBridge()
+	b.ws = ws
+	loopDone := make(chan error, 1)
+	go func() { loopDone <- b.clientReadLoop(ctx) }()
+
+	client, proxy := net.Pipe()
+	defer client.Close()
+	proxyDone := make(chan struct{})
+	go func() {
+		b.handleProxyConn(ctx, proxy)
+		close(proxyDone)
+	}()
+	const request = "CONNECT denied.example:443 HTTP/1.1\r\nHost: denied.example:443\r\n\r\n"
+	writeDone := make(chan error, 1)
+	go func() {
+		_, err := io.WriteString(client, request)
+		writeDone <- err
+	}()
+	const response = "HTTP/1.1 502 Bad Gateway\r\n\r\n"
+	if got := string(readEgressBytes(t, client, len(response))); got != response {
+		t.Fatalf("proxy response = %q", got)
+	}
+	if err := <-writeDone; err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-proxyDone:
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+	b.close()
+	select {
+	case <-loopDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("client read loop did not stop")
+	}
+}
+
+func TestEgressHandshakeWriteFailureClosesHostConnection(t *testing.T) {
+	hostMessages := make(chan egressProxyMessage, 8)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Errorf("accept websocket: %v", err)
+			return
+		}
+		defer conn.CloseNow()
+		for {
+			_, data, err := conn.Read(context.Background())
+			if err != nil {
+				return
+			}
+			var msg egressProxyMessage
+			if err := json.Unmarshal(data, &msg); err != nil {
+				t.Errorf("decode message: %v", err)
+				return
+			}
+			hostMessages <- msg
+			if msg.Type == "open" {
+				encoded, err := json.Marshal(egressProxyMessage{Type: "open_ok", ID: msg.ID})
+				if err != nil {
+					t.Errorf("encode open_ok: %v", err)
+					return
+				}
+				if err := conn.Write(context.Background(), websocket.MessageText, encoded); err != nil {
+					t.Errorf("write open_ok: %v", err)
+					return
+				}
+			}
+		}
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ws, _, err := websocket.Dial(ctx, server.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := newTestEgressClientBridge()
+	b.ws = ws
+	loopDone := make(chan error, 1)
+	go func() { loopDone <- b.clientReadLoop(ctx) }()
+
+	client, proxy := net.Pipe()
+	proxyDone := make(chan struct{})
+	go func() {
+		b.handleProxyConn(ctx, proxy)
+		close(proxyDone)
+	}()
+	requestDone := make(chan error, 1)
+	go func() {
+		_, err := io.WriteString(client, "CONNECT banner.example:22 HTTP/1.1\r\nHost: banner.example:22\r\n\r\n")
+		_ = client.Close()
+		requestDone <- err
+	}()
+	if err := <-requestDone; err != nil {
+		t.Fatal(err)
+	}
+
+	open := <-hostMessages
+	if open.Type != "open" {
+		t.Fatalf("first host message = %q, want open", open.Type)
+	}
+	select {
+	case msg := <-hostMessages:
+		if msg.Type != "close" || msg.ID != open.ID {
+			t.Fatalf("cleanup message = %+v, want close for %s", msg, open.ID)
+		}
+	case <-ctx.Done():
+		t.Fatal("host connection was not closed after handshake write failure")
+	}
+	select {
+	case <-proxyDone:
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+	_ = b.ws.CloseNow()
+	b.close()
+	select {
+	case <-loopDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("client read loop did not stop")
+	}
+}


### PR DESCRIPTION
## Summary

Fix the server-first mediated-egress race tracked in https://github.com/openclaw/crabbox/issues/1096 without blocking the shared WebSocket reader.

The local proxy stream is registered before the remote open can emit data. Inbound frames then use a bounded, ordered queue per stream until the local CONNECT handshake is complete. A slow or abandoned stream therefore cannot stall unrelated multiplexed connections.

## Maintainer improvements

- Replaced the contributor's shared `sync.Cond` wait with asynchronous per-stream delivery.
- Bounded each client queue to 256 KiB; overflow closes only that stream and its peer.
- Preserved frame order, including draining final data before a terminal close.
- Preserved the rejected-open `502 Bad Gateway` response.
- Closed the established host connection when the local proxy handshake fails.
- Added changelog credit and preserved Cameron Beeley's authorship and co-author trailer.

## Regression coverage

- CONNECT response strictly precedes an intact server-first banner.
- A blocked stream cannot stop the real shared WebSocket read loop from delivering another stream.
- Multiple frames preserve order.
- Terminal close drains earlier frames.
- Queue overflow is isolated to the offending stream.
- Rejected opens return `502` through the real read loop.
- Handshake write failure notifies and closes the host peer.

Focused race tests passed 50 consecutive runs during development and 20 consecutive runs on the rebased exact head. Full `go test -race ./...`, `go vet ./...`, native build, Windows cross-compile, Worker format/lint/typecheck/Vitest/build, and docs build passed locally.

Structured autoreview accepted two early findings (terminal-frame ordering and host cleanup on handshake failure). Both were fixed with regressions. Final exact-head branch review: clean, no actionable findings, confidence 0.94.

## Live behavior proof

Validated the built branch binary through the production coordinator path with a disposable AWS lease and `github.com` as the sole allowlist entry:

```text
egress: host=true client=true allow=github.com
allowed_status=HTTP/1.1 200 Connection Established
allowed_banner=SSH-2.0-3477046
concurrent_status=HTTP/1.1 200 Connection Established
concurrent_banner=SSH-2.0-3477046
rejected_status=HTTP/1.1 502 Bad Gateway
```

For the concurrency probe, the first allowed CONNECT socket remained unread while the second completed through the same bridge. Cleanup was also verified: local host daemon stopped, remote client stopped, coordinator reported `host=false client=false`, the remote process probe found no client, and the disposable lease was released.
