### PR TITLE
fix: harden Blacksmith hidden-omission detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Restored native Homebrew verification by using the supported GitHub Actions artifact archive media type.
+- Rejected Blacksmith delegated runs when Git hides omitted tracked paths, before those paths could be misread as remote deletions.
 
 ## 0.38.3 - 2026-07-14
 

--- a/docs/providers/blacksmith-testbox.md
+++ b/docs/providers/blacksmith-testbox.md
@@ -47,10 +47,11 @@ crabbox status --provider blacksmith-testbox --id tbx_123
 crabbox stop --provider blacksmith-testbox tbx_123
 ```
 
-Run delegated sync from a full Git checkout. Crabbox rejects sparse checkouts
-before invoking Blacksmith because paths intentionally omitted by sparse checkout
-can otherwise be misread as deletions during a later full sync. Materialize a
-temporary full checkout when the source workspace must stay sparse.
+Run delegated sync from a full Git checkout. Crabbox rejects a checkout when
+sparse rules or `skip-worktree` index state leave tracked paths absent because
+those paths can otherwise be misread as deletions during a later full sync. A
+sparse configuration that materializes every tracked path remains supported.
+Materialize a temporary full checkout when the source workspace must stay sparse.
 
 Keep a Testbox between runs via a JSON session handle:
 

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -23,17 +23,113 @@ type Repo struct {
 	BaseRef   string
 }
 
-// IsSparseGitCheckout reports whether Git intentionally omits tracked paths
-// from the working tree. Delegated sync tools must not treat those omissions as
-// deletions from a complete checkout.
-func IsSparseGitCheckout(root string) bool {
+// GitCheckoutHasHiddenOmissions reports whether sparse rules or skip-worktree
+// index state leave tracked paths absent. Delegated sync tools must not treat
+// them as deletions from a complete checkout.
+func GitCheckoutHasHiddenOmissions(root string) (bool, error) {
 	if strings.TrimSpace(root) == "" {
-		return false
+		return false, nil
 	}
-	return strings.EqualFold(
+	sparseEnabled := strings.EqualFold(
 		strings.TrimSpace(gitOutput(root, "config", "--bool", "core.sparseCheckout")),
 		"true",
 	)
+	if !sparseEnabled && gitOutput(root, "rev-parse", "--is-inside-work-tree") != "true" {
+		return false, nil
+	}
+	trackedCmd := exec.Command("git", "ls-files", "-t", "-z")
+	trackedCmd.Dir = root
+	tagged, err := trackedCmd.Output()
+	if err != nil {
+		return false, fmt.Errorf("list tracked paths: %w", err)
+	}
+	if len(tagged) == 0 {
+		return false, nil
+	}
+	type trackedPath struct {
+		name         string
+		skipWorktree bool
+	}
+	tracked := make([]trackedPath, 0, bytes.Count(tagged, []byte{0}))
+	for _, entry := range bytes.Split(tagged, []byte{0}) {
+		if len(entry) == 0 {
+			continue
+		}
+		if len(entry) < 3 || entry[1] != ' ' {
+			return false, fmt.Errorf("parse tracked path metadata")
+		}
+		path := string(entry[2:])
+		tracked = append(tracked, trackedPath{name: path, skipWorktree: entry[0] == 'S'})
+	}
+	includedPaths := make(map[string]struct{})
+	if sparseEnabled {
+		included, err := sparseCheckoutIncludedPaths(root)
+		if err != nil {
+			return false, err
+		}
+		for _, path := range bytes.Split(included, []byte{0}) {
+			if len(path) > 0 {
+				includedPaths[string(path)] = struct{}{}
+			}
+		}
+	}
+	for _, path := range tracked {
+		hiddenCandidate := path.skipWorktree
+		if sparseEnabled {
+			_, ruleIncludesPath := includedPaths[path.name]
+			hiddenCandidate = hiddenCandidate || !ruleIncludesPath
+		}
+		if !hiddenCandidate {
+			continue
+		}
+		exists, statErr := trackedPathExistsWithoutSymlinkAncestor(root, path.name)
+		if statErr != nil {
+			return false, fmt.Errorf("inspect tracked path %q: %w", path.name, statErr)
+		}
+		if exists {
+			continue
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
+func trackedPathExistsWithoutSymlinkAncestor(root, gitPath string) (bool, error) {
+	parts := strings.Split(filepath.FromSlash(gitPath), string(filepath.Separator))
+	current := root
+	for i, part := range parts {
+		current = filepath.Join(current, part)
+		info, err := os.Lstat(current)
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		if i < len(parts)-1 && (!info.IsDir() || info.Mode()&os.ModeSymlink != 0) {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func sparseCheckoutIncludedPaths(root string) ([]byte, error) {
+	rulesPath := gitOutput(root, "rev-parse", "--git-path", "info/sparse-checkout")
+	if rulesPath == "" {
+		return nil, fmt.Errorf("locate sparse-checkout rules")
+	}
+	if !filepath.IsAbs(rulesPath) {
+		rulesPath = filepath.Join(root, filepath.FromSlash(rulesPath))
+	}
+	// Sparse-checkout rules use Git's exclude-pattern engine with inverted
+	// product meaning: matching tracked paths are the materialized set.
+	cmd := exec.Command("git", "ls-files", "-ci", "-z", "--exclude-from="+rulesPath)
+	cmd.Dir = root
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("evaluate sparse-checkout rules: %w", err)
+	}
+	return out, nil
 }
 
 func findRepo() (Repo, error) {

--- a/internal/cli/repo_test.go
+++ b/internal/cli/repo_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -57,15 +58,119 @@ func TestRepoNameFromRootAndRemoteFallsBackToRemoteBasename(t *testing.T) {
 	}
 }
 
-func TestIsSparseGitCheckout(t *testing.T) {
+func TestGitCheckoutHasHiddenOmissions(t *testing.T) {
 	dir := t.TempDir()
 	runGit(t, dir, "init")
-	if IsSparseGitCheckout(dir) {
-		t.Fatal("normal checkout reported sparse")
+	runGit(t, dir, "config", "user.email", "test@example.com")
+	runGit(t, dir, "config", "user.name", "Test")
+	writeFile(t, filepath.Join(dir, "included", "keep.txt"), "keep\n")
+	writeFile(t, filepath.Join(dir, "omitted", "drop.txt"), "drop\n")
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-m", "init")
+	if omitted, err := GitCheckoutHasHiddenOmissions(dir); err != nil || omitted {
+		t.Fatal("full checkout reported omitted tracked paths")
 	}
-	runGit(t, dir, "config", "core.sparseCheckout", "true")
-	if !IsSparseGitCheckout(dir) {
-		t.Fatal("sparse checkout was not detected")
+
+	runGit(t, dir, "sparse-checkout", "set", "included")
+	if omitted, err := GitCheckoutHasHiddenOmissions(dir); err != nil || !omitted {
+		t.Fatal("sparse-checkout omission was not detected")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "omitted", "drop.txt")); !os.IsNotExist(err) {
+		t.Fatalf("omitted path still materialized: %v", err)
+	}
+	// The sparse rules remain authoritative even if another Git operation
+	// loses the index's skip-worktree bit for an excluded path.
+	runGit(t, dir, "update-index", "--no-skip-worktree", "omitted/drop.txt")
+	if omitted, err := GitCheckoutHasHiddenOmissions(dir); err != nil || !omitted {
+		t.Fatal("sparse rule omission was missed after clearing skip-worktree")
+	}
+
+	// Sparse mode itself is harmless when the current spec materializes every
+	// tracked path. Avoid blocking that valid Blacksmith workflow.
+	runGit(t, dir, "sparse-checkout", "set", "--no-cone", "/*")
+	writeFile(t, filepath.Join(dir, "omitted", "drop.txt"), "drop\n")
+	runGit(t, dir, "update-index", "--no-skip-worktree", "omitted/drop.txt")
+	if omitted, err := GitCheckoutHasHiddenOmissions(dir); err != nil || omitted {
+		t.Fatal("fully materialized sparse checkout reported omissions")
+	}
+	// An ordinary deletion of an included path is intentional sync input, not
+	// a sparse omission.
+	if err := os.Remove(filepath.Join(dir, "omitted", "drop.txt")); err != nil {
+		t.Fatal(err)
+	}
+	if omitted, err := GitCheckoutHasHiddenOmissions(dir); err != nil || omitted {
+		t.Fatal("intentional deletion in fully included sparse checkout was rejected")
+	}
+	writeFile(t, filepath.Join(dir, "omitted", "drop.txt"), "drop\n")
+	// Actual absence remains unsafe even when the sparse rules include the path.
+	runGit(t, dir, "update-index", "--skip-worktree", "included/keep.txt")
+	if err := os.Remove(filepath.Join(dir, "included", "keep.txt")); err != nil {
+		t.Fatal(err)
+	}
+	if omitted, err := GitCheckoutHasHiddenOmissions(dir); err != nil || !omitted {
+		t.Fatal("absent skip-worktree path matching sparse rules was missed")
+	}
+	writeFile(t, filepath.Join(dir, "included", "keep.txt"), "keep\n")
+	runGit(t, dir, "update-index", "--no-skip-worktree", "included/keep.txt")
+
+	// A manually marked but still-present path in an ordinary checkout is not
+	// a sparse omission and must not block delegated sync.
+	runGit(t, dir, "sparse-checkout", "disable")
+	runGit(t, dir, "update-index", "--skip-worktree", "included/keep.txt")
+	if omitted, err := GitCheckoutHasHiddenOmissions(dir); err != nil || omitted {
+		t.Fatal("dense checkout with present skip-worktree path reported omissions")
+	}
+	if err := os.Remove(filepath.Join(dir, "included", "keep.txt")); err != nil {
+		t.Fatal(err)
+	}
+	if omitted, err := GitCheckoutHasHiddenOmissions(dir); err != nil || !omitted {
+		t.Fatal("dense checkout missed absent skip-worktree path")
+	}
+}
+
+func TestGitCheckoutHasHiddenOmissionsInLinkedWorktree(t *testing.T) {
+	parent := t.TempDir()
+	source := filepath.Join(parent, "source")
+	worktree := filepath.Join(parent, "sparse-worktree")
+	if err := os.MkdirAll(source, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, source, "init")
+	runGit(t, source, "config", "user.email", "test@example.com")
+	runGit(t, source, "config", "user.name", "Test")
+	writeFile(t, filepath.Join(source, "included", "keep.txt"), "keep\n")
+	writeFile(t, filepath.Join(source, "omitted", "drop.txt"), "drop\n")
+	runGit(t, source, "add", ".")
+	runGit(t, source, "commit", "-m", "init")
+	runGit(t, source, "worktree", "add", "--detach", worktree)
+	runGit(t, worktree, "sparse-checkout", "set", "included")
+
+	if omitted, err := GitCheckoutHasHiddenOmissions(worktree); err != nil || !omitted {
+		t.Fatalf("linked sparse worktree omission=%v err=%v", omitted, err)
+	}
+}
+
+func TestGitCheckoutHasHiddenOmissionsThroughSymlinkAncestor(t *testing.T) {
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.email", "test@example.com")
+	runGit(t, dir, "config", "user.name", "Test")
+	writeFile(t, filepath.Join(dir, "included", "keep.txt"), "keep\n")
+	writeFile(t, filepath.Join(dir, "omitted", "drop.txt"), "drop\n")
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-m", "init")
+	runGit(t, dir, "sparse-checkout", "set", "included")
+
+	target := t.TempDir()
+	writeFile(t, filepath.Join(target, "drop.txt"), "shadow\n")
+	if err := os.Symlink(target, filepath.Join(dir, "omitted")); err != nil {
+		if runtime.GOOS == "windows" {
+			t.Skipf("symlink unavailable: %v", err)
+		}
+		t.Fatal(err)
+	}
+	if omitted, err := GitCheckoutHasHiddenOmissions(dir); err != nil || !omitted {
+		t.Fatalf("symlink-shadowed omission=%v err=%v", omitted, err)
 	}
 }
 

--- a/internal/providers/blacksmith/backend.go
+++ b/internal/providers/blacksmith/backend.go
@@ -108,10 +108,19 @@ func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 		fmt.Fprintf(b.rt.Stderr, "env forwarding note=blacksmith-testbox delegates execution to the Blacksmith CLI; configure secrets in the Testbox workflow instead\n")
 		return RunResult{}, core.Exit(2, "env forwarding is unsupported for provider=%s; configure secrets in the provider workflow or use an SSH-backed provider", blacksmithTestboxProvider)
 	}
-	if core.IsSparseGitCheckout(req.Repo.Root) {
+	hiddenOmissions, sparseErr := core.GitCheckoutHasHiddenOmissions(req.Repo.Root)
+	if sparseErr != nil {
 		return RunResult{}, core.Exit(
 			2,
-			"provider=%s cannot safely delegate sync from a sparse Git checkout; run from a materialized full checkout",
+			"provider=%s cannot verify sparse-checkout safety: %v; run from a materialized full checkout",
+			blacksmithTestboxProvider,
+			sparseErr,
+		)
+	}
+	if hiddenOmissions {
+		return RunResult{}, core.Exit(
+			2,
+			"provider=%s cannot safely delegate sync while Git omits tracked paths from the working tree; run from a materialized full checkout",
 			blacksmithTestboxProvider,
 		)
 	}

--- a/internal/providers/blacksmith/backend_test.go
+++ b/internal/providers/blacksmith/backend_test.go
@@ -229,7 +229,23 @@ func TestBlacksmithRunRejectsSparseCheckoutBeforeWarmup(t *testing.T) {
 		}
 	}
 	git("init")
-	git("config", "core.sparseCheckout", "true")
+	git("config", "user.email", "test@example.com")
+	git("config", "user.name", "Test")
+	for path, contents := range map[string]string{
+		"included/keep.txt": "keep\n",
+		"omitted/drop.txt":  "drop\n",
+	} {
+		fullPath := filepath.Join(dir, path)
+		if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(fullPath, []byte(contents), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	git("add", ".")
+	git("commit", "-m", "init")
+	git("sparse-checkout", "set", "included")
 
 	runner := &blacksmithFuncRunner{}
 	backend := newTestBlacksmithBackend(baseConfig(), runner)


### PR DESCRIPTION
Follow-up hardening for https://github.com/openclaw/crabbox/pull/1094 and https://github.com/openclaw/crabbox/issues/1093. The original fail-closed guard auto-merged while deeper review and live proof were still running.

## What changed

- Distinguish paths genuinely hidden by sparse rules or `skip-worktree` state from intentional tracked-file deletions.
- Evaluate worktree-specific sparse rules with Git's long-standing exclude-pattern plumbing, including Git versions before `sparse-checkout check-rules`.
- Reject hidden omissions before Blacksmith warmup or delegated sync, including linked worktrees, dense checkouts with absent `skip-worktree` paths, and symlink-shadowed ancestors.
- Preserve valid workflows: normal checkouts, fully materialized sparse configurations, intentional deletions, and present manually marked paths continue to the provider.
- Keep the 0.38.4 changelog and provider remediation current.

## Proof

- `go test -race -count=20 -run 'TestGitCheckoutHasHiddenOmissions' ./internal/cli`
- `go test -race -count=20 -run TestBlacksmithRunRejectsSparseCheckoutBeforeWarmup ./internal/providers/blacksmith`
- `go test -count=1 ./internal/cli ./internal/providers/blacksmith`
- `go vet ./...`
- `node scripts/build-docs-site.mjs`
- Source-blind CLI contract: an actual sparse checkout exited 2 before the provider executable; a fully materialized sparse configuration reached the provider shim and propagated its exit.
- Exact-head Blacksmith lifecycle: real Testbox create/use/stop succeeded, remote-fetch sync verified `GitCheckoutHasHiddenOmissions`, and printed `crabbox-hidden-omissions-live-ok`: https://github.com/openclaw/crabbox/actions/runs/29472440713
- Cleanup: the exact Testbox reports `already stopped`; no local claim or generated key remains.
- Structured autoreview: clean; patch correct, confidence 0.93.
