### PR TITLE
chore(release): prepare 0.38.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
-## 0.38.4 - Unreleased
+## 0.38.4 - 2026-07-16
 
 ### Fixed
 
 - Restored native Homebrew verification by using the supported GitHub Actions artifact archive media type.
+- Made SSH readiness retries return promptly when cancelled while preserving the original cancellation cause.
 - Rejected Blacksmith delegated runs when Git hides omitted tracked paths, before those paths could be misread as remote deletions.
 
 ## 0.38.3 - 2026-07-14

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/crabbox-worker",
-  "version": "0.38.3",
+  "version": "0.38.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/crabbox-worker",
-      "version": "0.38.3",
+      "version": "0.38.4",
       "dependencies": {
         "@aws-sdk/credential-providers": "^3.1084.0",
         "@cloudflare/containers": "^0.3.7",

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/crabbox-worker",
-  "version": "0.38.3",
+  "version": "0.38.4",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- date the complete 0.38.4 changelog section for 2026-07-16
- include the landed SSH readiness cancellation fix in the release notes
- align the Worker package and lockfile versions at 0.38.4

## Verification

- `git diff --check`
- `node --test scripts/release-workflow.test.js scripts/release-verifier-isolation.test.js scripts/publish-release.test.js scripts/homebrew-release.test.js` (58 passed)
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- isolated Worker production-bundle regression passed with a 30-second timeout after one concurrent 5-second timeout
- autoreview clean, confidence 0.99

This PR only prepares the protected source commit. Signed tagging, immutable source pinning, draft creation, native verification, publication, public verification, and Homebrew proof remain separate release gates.
