### PR TITLE
fix: use canonical sparse checkout rules

### DIFF
--- a/docs/providers/blacksmith-testbox.md
+++ b/docs/providers/blacksmith-testbox.md
@@ -52,6 +52,9 @@ sparse rules or `skip-worktree` index state leave tracked paths absent because
 those paths can otherwise be misread as deletions during a later full sync. A
 sparse configuration that materializes every tracked path remains supported.
 Materialize a temporary full checkout when the source workspace must stay sparse.
+Git 2.41 or newer is required only to distinguish an intentional deletion from
+a hidden path after sparse index metadata becomes ambiguous; older Git fails
+closed in that state with the same full-checkout remediation.
 
 Keep a Testbox between runs via a JSON session handle:
 

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -23,10 +23,19 @@ type Repo struct {
 	BaseRef   string
 }
 
+type gitTrackedPath struct {
+	name         string
+	skipWorktree bool
+}
+
 // GitCheckoutHasHiddenOmissions reports whether sparse rules or skip-worktree
 // index state leave tracked paths absent. Delegated sync tools must not treat
 // them as deletions from a complete checkout.
 func GitCheckoutHasHiddenOmissions(root string) (bool, error) {
+	return gitCheckoutHasHiddenOmissions(root, sparseCheckoutIncludedPaths)
+}
+
+func gitCheckoutHasHiddenOmissions(root string, resolveSparseRules func(string, []gitTrackedPath) (map[string]struct{}, error)) (bool, error) {
 	if strings.TrimSpace(root) == "" {
 		return false, nil
 	}
@@ -46,11 +55,7 @@ func GitCheckoutHasHiddenOmissions(root string) (bool, error) {
 	if len(tagged) == 0 {
 		return false, nil
 	}
-	type trackedPath struct {
-		name         string
-		skipWorktree bool
-	}
-	tracked := make([]trackedPath, 0, bytes.Count(tagged, []byte{0}))
+	tracked := make([]gitTrackedPath, 0, bytes.Count(tagged, []byte{0}))
 	for _, entry := range bytes.Split(tagged, []byte{0}) {
 		if len(entry) == 0 {
 			continue
@@ -59,23 +64,26 @@ func GitCheckoutHasHiddenOmissions(root string) (bool, error) {
 			return false, fmt.Errorf("parse tracked path metadata")
 		}
 		path := string(entry[2:])
-		tracked = append(tracked, trackedPath{name: path, skipWorktree: entry[0] == 'S'})
+		tracked = append(tracked, gitTrackedPath{name: path, skipWorktree: entry[0] == 'S'})
 	}
 	includedPaths := make(map[string]struct{})
+	var sparseRulesErr error
 	if sparseEnabled {
-		included, err := sparseCheckoutIncludedPaths(root)
-		if err != nil {
-			return false, err
-		}
-		for _, path := range bytes.Split(included, []byte{0}) {
-			if len(path) > 0 {
-				includedPaths[string(path)] = struct{}{}
-			}
-		}
+		includedPaths, sparseRulesErr = resolveSparseRules(root, tracked)
 	}
 	for _, path := range tracked {
+		if sparseEnabled && sparseRulesErr != nil && !path.skipWorktree {
+			exists, statErr := trackedPathExistsWithoutSymlinkAncestor(root, path.name)
+			if statErr != nil {
+				return false, fmt.Errorf("inspect tracked path %q: %w", path.name, statErr)
+			}
+			if !exists {
+				return false, fmt.Errorf("classify missing tracked path %q without git sparse-checkout check-rules (requires Git 2.41 or newer): %w", path.name, sparseRulesErr)
+			}
+			continue
+		}
 		hiddenCandidate := path.skipWorktree
-		if sparseEnabled {
+		if sparseEnabled && sparseRulesErr == nil {
 			_, ruleIncludesPath := includedPaths[path.name]
 			hiddenCandidate = hiddenCandidate || !ruleIncludesPath
 		}
@@ -113,23 +121,30 @@ func trackedPathExistsWithoutSymlinkAncestor(root, gitPath string) (bool, error)
 	return true, nil
 }
 
-func sparseCheckoutIncludedPaths(root string) ([]byte, error) {
-	rulesPath := gitOutput(root, "rev-parse", "--git-path", "info/sparse-checkout")
-	if rulesPath == "" {
-		return nil, fmt.Errorf("locate sparse-checkout rules")
+func sparseCheckoutIncludedPaths(root string, tracked []gitTrackedPath) (map[string]struct{}, error) {
+	var paths bytes.Buffer
+	for _, trackedPath := range tracked {
+		paths.WriteString(trackedPath.name)
+		paths.WriteByte(0)
 	}
-	if !filepath.IsAbs(rulesPath) {
-		rulesPath = filepath.Join(root, filepath.FromSlash(rulesPath))
-	}
-	// Sparse-checkout rules use Git's exclude-pattern engine with inverted
-	// product meaning: matching tracked paths are the materialized set.
-	cmd := exec.Command("git", "ls-files", "-ci", "-z", "--exclude-from="+rulesPath)
+	cmd := exec.Command("git", "sparse-checkout", "check-rules", "-z")
 	cmd.Dir = root
+	cmd.Stdin = bytes.NewReader(paths.Bytes())
 	out, err := cmd.Output()
 	if err != nil {
-		return nil, fmt.Errorf("evaluate sparse-checkout rules: %w", err)
+		return nil, fmt.Errorf("git sparse-checkout check-rules unavailable: %w", err)
 	}
-	return out, nil
+	return nulPathSet(out), nil
+}
+
+func nulPathSet(out []byte) map[string]struct{} {
+	paths := make(map[string]struct{})
+	for _, item := range bytes.Split(out, []byte{0}) {
+		if len(item) > 0 {
+			paths[string(item)] = struct{}{}
+		}
+	}
+	return paths
 }
 
 func findRepo() (Repo, error) {

--- a/internal/cli/repo_test.go
+++ b/internal/cli/repo_test.go
@@ -72,8 +72,14 @@ func TestGitCheckoutHasHiddenOmissions(t *testing.T) {
 	}
 
 	runGit(t, dir, "sparse-checkout", "set", "included")
+	rulesUnavailable := func(string, []gitTrackedPath) (map[string]struct{}, error) {
+		return nil, fmt.Errorf("check-rules unsupported")
+	}
 	if omitted, err := GitCheckoutHasHiddenOmissions(dir); err != nil || !omitted {
 		t.Fatal("sparse-checkout omission was not detected")
+	}
+	if omitted, err := gitCheckoutHasHiddenOmissions(dir, rulesUnavailable); err != nil || !omitted {
+		t.Fatal("old Git missed definite skip-worktree omission")
 	}
 	if _, err := os.Stat(filepath.Join(dir, "omitted", "drop.txt")); !os.IsNotExist(err) {
 		t.Fatalf("omitted path still materialized: %v", err)
@@ -81,7 +87,11 @@ func TestGitCheckoutHasHiddenOmissions(t *testing.T) {
 	// The sparse rules remain authoritative even if another Git operation
 	// loses the index's skip-worktree bit for an excluded path.
 	runGit(t, dir, "update-index", "--no-skip-worktree", "omitted/drop.txt")
-	if omitted, err := GitCheckoutHasHiddenOmissions(dir); err != nil || !omitted {
+	if omitted, err := GitCheckoutHasHiddenOmissions(dir); err != nil {
+		if !strings.Contains(err.Error(), "Git 2.41") {
+			t.Fatal(err)
+		}
+	} else if !omitted {
 		t.Fatal("sparse rule omission was missed after clearing skip-worktree")
 	}
 
@@ -93,13 +103,23 @@ func TestGitCheckoutHasHiddenOmissions(t *testing.T) {
 	if omitted, err := GitCheckoutHasHiddenOmissions(dir); err != nil || omitted {
 		t.Fatal("fully materialized sparse checkout reported omissions")
 	}
+	if omitted, err := gitCheckoutHasHiddenOmissions(dir, rulesUnavailable); err != nil || omitted {
+		t.Fatal("old Git rejected fully materialized sparse checkout")
+	}
 	// An ordinary deletion of an included path is intentional sync input, not
 	// a sparse omission.
 	if err := os.Remove(filepath.Join(dir, "omitted", "drop.txt")); err != nil {
 		t.Fatal(err)
 	}
-	if omitted, err := GitCheckoutHasHiddenOmissions(dir); err != nil || omitted {
+	if omitted, err := GitCheckoutHasHiddenOmissions(dir); err != nil {
+		if !strings.Contains(err.Error(), "Git 2.41") {
+			t.Fatal(err)
+		}
+	} else if omitted {
 		t.Fatal("intentional deletion in fully included sparse checkout was rejected")
+	}
+	if omitted, err := gitCheckoutHasHiddenOmissions(dir, rulesUnavailable); omitted || err == nil || !strings.Contains(err.Error(), "Git 2.41") {
+		t.Fatalf("old Git ambiguity omission=%v err=%v", omitted, err)
 	}
 	writeFile(t, filepath.Join(dir, "omitted", "drop.txt"), "drop\n")
 	// Actual absence remains unsafe even when the sparse rules include the path.
@@ -147,6 +167,33 @@ func TestGitCheckoutHasHiddenOmissionsInLinkedWorktree(t *testing.T) {
 
 	if omitted, err := GitCheckoutHasHiddenOmissions(worktree); err != nil || !omitted {
 		t.Fatalf("linked sparse worktree omission=%v err=%v", omitted, err)
+	}
+}
+
+func TestGitCheckoutHasHiddenOmissionsInNestedCone(t *testing.T) {
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.email", "test@example.com")
+	runGit(t, dir, "config", "user.name", "Test")
+	for path, contents := range map[string]string{
+		"root.txt":     "root\n",
+		"a/parent.txt": "parent\n",
+		"a/b/x.txt":    "included\n",
+		"a/c/y.txt":    "omitted\n",
+	} {
+		writeFile(t, filepath.Join(dir, path), contents)
+	}
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-m", "init")
+	runGit(t, dir, "sparse-checkout", "set", "a/b")
+	runGit(t, dir, "update-index", "--no-skip-worktree", "a/c/y.txt")
+
+	if omitted, err := GitCheckoutHasHiddenOmissions(dir); err != nil {
+		if !strings.Contains(err.Error(), "Git 2.41") {
+			t.Fatal(err)
+		}
+	} else if !omitted {
+		t.Fatal("nested cone omission was missed")
 	}
 }
 


### PR DESCRIPTION
## Summary

- replace the raw exclude-pattern approximation with Git's canonical `sparse-checkout check-rules -z` evaluator
- preserve intentional deletions while rejecting hidden tracked paths, including nested cone layouts
- fail closed on pre-2.41 Git only when index metadata cannot distinguish an intentional deletion from a sparse omission
- document the compatibility boundary and add nested-cone plus older-Git regression coverage

## Why

The implementation merged in https://github.com/openclaw/crabbox/pull/1105 used `git ls-files -ci --exclude-from=...`. Cone-mode ancestor traversal patterns can make that command classify excluded sibling paths as included. This could let a hidden path be synced as a remote deletion. This PR resolves the exact review finding at https://github.com/openclaw/crabbox/pull/1105#discussion_r3592750611.

## Verification

- exact head `75acb53d90ef617e10a745bd5245fb54ec3a1d1e`
- `go test -race -count=20 -run '^TestGitCheckoutHasHiddenOmissions' ./internal/cli`
- `go test -race -count=20 -run '^TestBlacksmithRunRejectsSparseCheckoutBeforeWarmup$' ./internal/providers/blacksmith`
- `node scripts/build-docs-site.mjs`
- `git diff --check origin/main...HEAD`
- exact-head autoreview clean, confidence 0.93
- Blacksmith create/use/stop lifecycle: https://github.com/openclaw/crabbox/actions/runs/29475484295
- remote proof marker: `crabbox-pr1107-canonical-sparse-live-ok`
- emitted Testbox `tbx_01kxmr7nb0ffx1b9bwf21m0n8p` stopped by the one-shot run; repeat stop returned 409 already stopped; no exact-ID local claim residue remained
