### PR TITLE
chore(release): authorize v0.38.4 source

### DIFF
--- a/release/records/v0.38.4.json
+++ b/release/records/v0.38.4.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "repository": "openclaw/crabbox",
+  "tag": "v0.38.4",
+  "tagObject": "dd6aa78ed373393c1e9887e9354dd24b449b2f8b",
+  "sourceCommit": "b288e613bd8267ea365c0098da7494b143242d8e",
+  "publicationStatus": "ready"
+}

--- a/scripts/release-workflow.test.js
+++ b/scripts/release-workflow.test.js
@@ -613,6 +613,14 @@ test("v0.38.3 is pinned to the cancellation-fix source and ready for publication
   assert.equal(record.publicationStatus, "ready");
 });
 
+test("v0.38.4 is pinned to the sparse-sync source and ready for publication", () => {
+  const record = JSON.parse(read("release/records/v0.38.4.json"));
+  assert.equal(record.tag, "v0.38.4");
+  assert.equal(record.tagObject, "dd6aa78ed373393c1e9887e9354dd24b449b2f8b");
+  assert.equal(record.sourceCommit, "b288e613bd8267ea365c0098da7494b143242d8e");
+  assert.equal(record.publicationStatus, "ready");
+});
+
 test("managed Foundation signing and notary configuration is repository-owned and secret-free", () => {
   const manifest = read(".mac-release.env");
   const codeowners = read(".github/CODEOWNERS");


### PR DESCRIPTION
## What Problem This Solves

Crabbox publication must fail closed unless a protected release record binds the immutable signed tag object and its exact source commit.

## Why This Change Was Made

Adds the ready record for v0.38.4, binding signed tag object dd6aa78ed373393c1e9887e9354dd24b449b2f8b to source commit b288e613bd8267ea365c0098da7494b143242d8e, plus a regression assertion.

## User Impact

No runtime behavior change. This authorizes publication of exactly the reviewed v0.38.4 source and no other tag or commit.

## Evidence

- Signed annotated tag verified locally.
- Release workflow suite: 23 of 23 passing.
- Mandatory autoreview clean at 0.94.
- Branch is one verified commit with only the protected record and matching assertion.