### PR TITLE
feat: add Zed Remote Projects handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ crabbox prewarm                                      # lease + Actions hydration
 crabbox run --id blue-lobster -- pnpm test:changed
 crabbox connect blue-lobster                         # open an interactive SSH session
 crabbox ssh --id blue-lobster
+crabbox zed --id blue-lobster                       # prepare a Zed Remote Projects session
 crabbox stop blue-lobster
 ```
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -99,6 +99,7 @@ See [history](commands/history.md), [logs](commands/logs.md),
 ```text
 crabbox connect <id>                          open an interactive SSH session
 crabbox ssh --id <id>                          print the SSH command
+crabbox zed --id <id>                          prepare a lease for Zed Remote Projects
 crabbox vnc --id <id> [--open]                 print/open SSH-tunneled VNC details
 crabbox webvnc --id <id> [--open]              bridge a desktop lease into the web portal
 crabbox code --id <id> [--open]                bridge a code lease into the web portal
@@ -108,8 +109,9 @@ crabbox screenshot --id <id> [--output <png>]  capture a PNG from a desktop leas
 crabbox desktop launch|terminal|record|proof|doctor|click|paste|type|key
 ```
 
-See [connect](commands/connect.md), [ssh](commands/ssh.md), [vnc](commands/vnc.md),
-[webvnc](commands/webvnc.md), [code](commands/code.md),
+See [connect](commands/connect.md), [ssh](commands/ssh.md),
+[zed](commands/zed.md), [vnc](commands/vnc.md), [webvnc](commands/webvnc.md),
+[code](commands/code.md),
 [egress](commands/egress.md), [ports](commands/ports.md),
 [screenshot](commands/screenshot.md), [desktop](commands/desktop.md).
 

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -45,6 +45,7 @@ same order as the CLI help.
 - [checkpoint](checkpoint.md)
 - [ssh](ssh.md)
 - [connect](connect.md)
+- [zed](zed.md)
 - [ports](ports.md)
 - [cp](cp.md)
 - [vnc](vnc.md)

--- a/docs/commands/zed.md
+++ b/docs/commands/zed.md
@@ -1,0 +1,67 @@
+# zed
+
+`crabbox zed` prepares an existing SSH-capable lease for use with Zed Remote
+Projects. It prints the exact SSH command and remote folder to enter in Zed,
+then keeps the lease active until you press Ctrl-C.
+
+```sh
+crabbox run --id swift-crab --sync-only
+crabbox zed --id swift-crab
+```
+
+In Zed, open **Remote Projects**, select **Connect New Server**, paste the
+printed command, and open the printed folder. Keep `crabbox zed` running for
+the duration of the editor session.
+
+## Why the command stays running
+
+Zed opens its own SSH processes after the connection is added. Those processes
+do not send Crabbox lease heartbeats. While `crabbox zed` is running, Crabbox
+keeps coordinator-backed leases heartbeating and marks direct-provider leases
+running or ready where the provider supports lease touches.
+
+The lease's configured hard TTL still applies while the command is running.
+
+Stopping `crabbox zed` does not release the lease. Use
+`crabbox stop <id-or-slug>` when the workspace is no longer needed.
+
+## Workspace and synchronization
+
+The command opens the current repository's normal remote workspace and follows
+the current local subdirectory. It also honors a workspace hydrated through
+GitHub Actions. If the folder does not exist, the command asks you to run
+`crabbox run --id <lease> --sync-only` first.
+
+Crabbox synchronization is local to remote. Commit and push changes made in
+Zed, or copy them back explicitly, before releasing an ephemeral lease.
+
+## Security and platform boundaries
+
+`crabbox zed` does not edit `~/.ssh/config`, modify Zed settings, or launch an
+editor process. Zed's command-line URL syntax cannot carry arbitrary SSH
+options such as per-lease identity files and proxy commands, so the complete
+command is handed to Zed's supported **Connect New Server** flow instead.
+
+The command supports key-based SSH access to Linux and macOS targets. It rejects
+Windows remote targets, which Zed does not support as remote servers, and
+token-as-username SSH providers, whose credentials should not be persisted in
+editor settings.
+
+## Flags
+
+`crabbox zed` accepts the same lease, provider, target, routing, network, and
+`--reclaim` flags as [`crabbox connect`](connect.md). The first positional
+argument is also accepted as the lease id or slug:
+
+```sh
+crabbox zed swift-crab
+crabbox zed --id swift-crab --network tailscale
+crabbox zed --provider ssh --target macos --static-host mac-studio.local
+```
+
+## See also
+
+- [`crabbox run`](run.md) - synchronize the local checkout to the lease.
+- [`crabbox ssh`](ssh.md) - print a general-purpose SSH command without holding a heartbeat.
+- [`crabbox connect`](connect.md) - open an interactive terminal session.
+- [`crabbox stop`](stop.md) - release the lease when finished.

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -151,6 +151,7 @@ Provider deep-dives that live here in `features/`:
 
 ### Interactive access
 - [ssh](../commands/ssh.md) — SSH to a lease
+- [zed](../commands/zed.md) — prepare a lease for Zed Remote Projects
 - [desktop](../commands/desktop.md) — desktop/input commands
 - [vnc](../commands/vnc.md) — native VNC access
 - [webvnc](../commands/webvnc.md) — browser-based VNC

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -258,6 +258,16 @@ crabbox warmup --code
 crabbox code --id swift-crab --open
 ```
 
+Open the synced checkout in Zed Remote Projects:
+
+```sh
+crabbox run --id swift-crab --sync-only
+crabbox zed --id swift-crab
+```
+
+Paste the printed SSH command into Zed's **Connect New Server** dialog, open the
+printed folder, and keep `crabbox zed` running while you work.
+
 Use a Mac you already own (static SSH, no provisioning):
 
 ```yaml

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -111,6 +111,8 @@ func (a App) directCommandHelp(ctx context.Context, args []string) (error, bool)
 		return a.ssh(ctx, helpArgs), true
 	case "connect":
 		return a.connect(ctx, helpArgs), true
+	case "zed":
+		return a.zed(ctx, helpArgs), true
 	case "ports":
 		return a.ports(ctx, helpArgs), true
 	case "cp":
@@ -211,6 +213,7 @@ Commands:
   checkpoint  Create, restore, and fork workspace checkpoints
   ssh         Print the SSH command for a lease
   connect     Open an interactive SSH session to a lease
+  zed         Prepare a lease for Zed Remote Projects
   ports       Publish, list, or unpublish provider-native ports
   cp          Copy files between host and a delegated sandbox
   vnc         Print or open VNC connection details for a desktop lease
@@ -240,6 +243,7 @@ Common Flows:
   crabbox bench report --since 7d
   crabbox connect blue-lobster
   crabbox ssh --id blue-lobster
+  crabbox zed --id blue-lobster
   crabbox ports --id blue-lobster --publish 8080
   crabbox cp --id blue-lobster ./coverage.xml SANDBOX:/tmp/coverage.xml
   crabbox vnc --id blue-lobster --open

--- a/internal/cli/cli_kong.go
+++ b/internal/cli/cli_kong.go
@@ -51,6 +51,7 @@ type crabboxKongCLI struct {
 	Checkpoint  checkpointKongCmd  `cmd:"" help:"Create, restore, and fork VM or workspace checkpoints."`
 	Ssh         sshKongCmd         `cmd:"" name:"ssh" passthrough:"" help:"Print the SSH command for a lease."`
 	Connect     connectKongCmd     `cmd:"" passthrough:"" help:"Open an interactive SSH session to a lease."`
+	Zed         zedKongCmd         `cmd:"" passthrough:"" help:"Prepare a lease for Zed Remote Projects."`
 	Vnc         vncKongCmd         `cmd:"" name:"vnc" passthrough:"" help:"Print or open VNC connection details for a desktop lease."`
 	Webvnc      webvncKongCmd      `cmd:"" name:"webvnc" passthrough:"" help:"Open a desktop lease or local VNC tunnel in a browser."`
 	Code        codeKongCmd        `cmd:"" passthrough:"" help:"Bridge a code lease into the authenticated web portal."`
@@ -250,6 +251,9 @@ type sshKongCmd struct {
 	Args []string `arg:"" optional:""`
 }
 type connectKongCmd struct {
+	Args []string `arg:"" optional:""`
+}
+type zedKongCmd struct {
 	Args []string `arg:"" optional:""`
 }
 type vncKongCmd struct {
@@ -650,6 +654,7 @@ func (c *marketplaceQuoteKongCmd) Run(ctx context.Context, app App) error {
 }
 func (c *sshKongCmd) Run(ctx context.Context, app App) error     { return app.ssh(ctx, c.Args) }
 func (c *connectKongCmd) Run(ctx context.Context, app App) error { return app.connect(ctx, c.Args) }
+func (c *zedKongCmd) Run(ctx context.Context, app App) error     { return app.zed(ctx, c.Args) }
 func (c *vncKongCmd) Run(ctx context.Context, app App) error     { return app.vnc(ctx, c.Args) }
 func (c *webvncKongCmd) Run(ctx context.Context, app App) error  { return app.webvnc(ctx, c.Args) }
 func (c *codeKongCmd) Run(ctx context.Context, app App) error    { return app.webCode(ctx, c.Args) }

--- a/internal/cli/zed.go
+++ b/internal/cli/zed.go
@@ -1,0 +1,59 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+)
+
+func (a App) zed(ctx context.Context, args []string) error {
+	resolved, err := a.resolveSSHCommandTarget(ctx, "zed", args, false)
+	if err != nil {
+		return err
+	}
+	if err := validateZedTarget(resolved.Config, resolved.Lease.SSH); err != nil {
+		return err
+	}
+	repo, err := findRepo()
+	if err != nil {
+		return err
+	}
+	_, folder, hydratedByActions := codeWorkspace(ctx, resolved.Lease.SSH, resolved.Config, resolved.Lease.LeaseID, repo)
+	if err := runSSHQuiet(ctx, resolved.Lease.SSH, "test -d "+shellQuote(folder)); err != nil {
+		return exit(5, "remote folder %q is not ready; sync it first with: crabbox run --id %s --sync-only", folder, resolved.Lease.LeaseID)
+	}
+	if hydratedByActions {
+		fmt.Fprintf(a.Stderr, "using GitHub Actions workspace for %s\n", resolved.Lease.LeaseID)
+	}
+
+	stopLeaseActivity := a.startInteractiveSSHLeaseActivity(ctx, resolved.Config, resolved.Lease)
+	defer stopLeaseActivity()
+	writeZedInstructions(a.Stdout, resolved.Lease.SSH, folder)
+
+	<-ctx.Done()
+	return nil
+}
+
+func validateZedTarget(cfg Config, target SSHTarget) error {
+	if target.AuthSecret {
+		return exit(2, "zed does not support token-as-username SSH credentials; use a key-based SSH provider")
+	}
+	if firstNonBlank(target.TargetOS, cfg.TargetOS) == targetWindows {
+		return exit(2, "zed remote projects require a Linux or macOS target")
+	}
+	return nil
+}
+
+func zedSSHCommandLine(target SSHTarget) string {
+	args := append(sshBaseArgs(target), target.User+"@"+target.Host)
+	return "ssh " + strings.Join(shellWords(args), " ")
+}
+
+func writeZedInstructions(out io.Writer, target SSHTarget, folder string) {
+	fmt.Fprintln(out, "Zed Remote Projects")
+	fmt.Fprintln(out, "1. Open Remote Projects and select Connect New Server.")
+	fmt.Fprintf(out, "2. Paste: %s\n", zedSSHCommandLine(target))
+	fmt.Fprintf(out, "3. Open: %s\n", folder)
+	fmt.Fprintln(out, "Keep this process running to maintain lease activity; press Ctrl-C when the Zed session is finished.")
+}

--- a/internal/cli/zed_test.go
+++ b/internal/cli/zed_test.go
@@ -1,0 +1,74 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestValidateZedTarget(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     Config
+		target  SSHTarget
+		wantErr string
+	}{
+		{name: "linux", target: SSHTarget{TargetOS: targetLinux}},
+		{name: "macos", target: SSHTarget{TargetOS: targetMacOS}},
+		{name: "config target", cfg: Config{TargetOS: targetLinux}},
+		{name: "windows", target: SSHTarget{TargetOS: targetWindows}, wantErr: "Linux or macOS"},
+		{name: "secret auth", target: SSHTarget{TargetOS: targetLinux, AuthSecret: true}, wantErr: "key-based SSH provider"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateZedTarget(test.cfg, test.target)
+			if test.wantErr == "" {
+				if err != nil {
+					t.Fatal(err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("error=%v want substring %q", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestZedSSHCommandLineKeepsExecutableUnquoted(t *testing.T) {
+	got := zedSSHCommandLine(SSHTarget{
+		User: "alice",
+		Host: "203.0.113.10",
+		Port: "2222",
+		Key:  "/tmp/key with spaces",
+	})
+	if !strings.HasPrefix(got, "ssh ") {
+		t.Fatalf("command=%q should start with an unquoted ssh executable", got)
+	}
+	for _, want := range []string{"'-i' '/tmp/key with spaces'", "'-p' '2222'", "'alice@203.0.113.10'"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("command=%q missing %q", got, want)
+		}
+	}
+}
+
+func TestWriteZedInstructionsIncludesConnectionFolderAndKeepalive(t *testing.T) {
+	var out bytes.Buffer
+	writeZedInstructions(&out, SSHTarget{
+		User: "alice",
+		Host: "example.com",
+		Port: "22",
+	}, "/work/crabbox/my-app")
+	got := out.String()
+	for _, want := range []string{
+		"Connect New Server",
+		"Paste: ssh ",
+		"Open: /work/crabbox/my-app",
+		"Keep this process running to maintain lease activity",
+		"press Ctrl-C",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("instructions missing %q:\n%s", want, got)
+		}
+	}
+}


### PR DESCRIPTION
Related: https://github.com/zed-industries/zed/pull/61102

## What Problem This Solves

Resolves a problem where users opening a Crabbox workspace in Zed Remote Projects had to assemble the connection workflow themselves: resolve the lease, synchronize the checkout, paste the SSH command, discover the remote folder, and keep the lease active while Zed runs its own SSH processes.

## Why This Change Was Made

Adds a provider-neutral `crabbox zed` command that reuses the existing SSH target resolution and lease-activity paths. It verifies the current repository's synced remote folder, prints a Zed-compatible SSH command plus the exact folder, and holds the lease activity until Ctrl-C.

The command does not modify `~/.ssh/config` or Zed settings. It rejects Windows remote targets and token-as-username credentials because Zed remote servers support Linux/macOS and editor settings should not persist provider secrets. The emitted executable is unquoted for compatibility with current Zed releases while every SSH argument remains shell-quoted.

## User Impact

Users can now run:

```sh
crabbox run --id <lease> --sync-only
crabbox zed --id <lease>
```

Then paste the printed command into Zed's **Connect New Server** flow, open the printed folder, and keep the command running for lease activity. The configured hard TTL still applies, and stopping the command does not release the lease.

## Evidence

- `go test -race -p 1 ./...`
- `go test ./internal/cli -count=1`
- `go vet ./...`
- `./scripts/check-docs.sh`
- Live local-container acceptance: provisioned a Linux lease, synced 1,510 files (22.9 MiB), emitted a command containing a spaced identity path and the exact remote folder, held the session, exited cleanly on Ctrl-C, and released the lease/container.
- Security/config implications: no credential output for token-auth providers and no persistent SSH or editor configuration changes.