### PR TITLE
ci: restore Homebrew release verification

### DIFF
--- a/.github/workflows/verify-homebrew.yml
+++ b/.github/workflows/verify-homebrew.yml
@@ -122,18 +122,6 @@ jobs:
           go-version-file: go.mod
           cache: false
 
-      - name: Preserve pinned Go in the clean verifier path
-        shell: bash
-        run: |
-          set -euo pipefail
-          tools="$RUNNER_TEMP/release-tools"
-          mkdir -m 700 "$tools"
-          brew_path=$(command -v brew)
-          printf '%s\n' '#!/bin/bash' "exec \"$brew_path\" \"\$@\"" >"$tools/brew"
-          chmod 700 "$tools/brew"
-          ln -s "$(command -v go)" "$tools/go"
-          printf '%s\n' "$tools" >>"$GITHUB_PATH"
-
       - name: Download frozen public release assets
         shell: bash
         env:

--- a/.github/workflows/verify-homebrew.yml
+++ b/.github/workflows/verify-homebrew.yml
@@ -122,6 +122,18 @@ jobs:
           go-version-file: go.mod
           cache: false
 
+      - name: Preserve pinned Go in the clean verifier path
+        shell: bash
+        run: |
+          set -euo pipefail
+          tools="$RUNNER_TEMP/release-tools"
+          mkdir -m 700 "$tools"
+          brew_path=$(command -v brew)
+          printf '%s\n' '#!/bin/bash' "exec \"$brew_path\" \"\$@\"" >"$tools/brew"
+          chmod 700 "$tools/brew"
+          ln -s "$(command -v go)" "$tools/go"
+          printf '%s\n' "$tools" >>"$GITHUB_PATH"
+
       - name: Download frozen public release assets
         shell: bash
         env:

--- a/.github/workflows/verify-homebrew.yml
+++ b/.github/workflows/verify-homebrew.yml
@@ -48,6 +48,7 @@ jobs:
           RELEASE_ID: ${{ inputs.release_id }}
           RELEASE_TAG: ${{ inputs.tag }}
           PUBLIC_VERIFIER_RUN_ID: ${{ inputs.public_verifier_run_id }}
+          RUN_SHA: ${{ github.sha }}
           VERIFIER_COMMIT: ${{ inputs.verifier_commit }}
           WORKFLOW_SHA: ${{ github.workflow_sha }}
         run: |
@@ -61,7 +62,7 @@ jobs:
           [[ "$REF_PROTECTED" == true ]]
           [[ "$GITHUB_REF" == "$expected_ref" ]]
           [[ "$GITHUB_WORKFLOW_REF" == "$expected_workflow_ref" ]]
-          [[ "$WORKFLOW_SHA" == "$VERIFIER_COMMIT" ]]
+          [[ "$WORKFLOW_SHA" == "$RUN_SHA" ]]
 
           work="$RUNNER_TEMP/homebrew-guard"
           mkdir -m 700 "$work"
@@ -114,6 +115,11 @@ jobs:
           ref: ${{ inputs.verifier_commit }}
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Set up Go for build-info inspection
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
 
       - name: Download frozen public release assets
         shell: bash

--- a/.github/workflows/verify-homebrew.yml
+++ b/.github/workflows/verify-homebrew.yml
@@ -122,6 +122,18 @@ jobs:
           go-version-file: go.mod
           cache: false
 
+      - name: Preserve pinned Go in the frozen verifier path
+        shell: bash
+        run: |
+          set -euo pipefail
+          tools="$RUNNER_TEMP/release-tools"
+          mkdir -m 700 "$tools"
+          brew_path=$(command -v brew)
+          printf '%s\n' '#!/bin/bash' "exec \"$brew_path\" \"\$@\"" >"$tools/brew"
+          chmod 700 "$tools/brew"
+          ln -s "$(command -v go)" "$tools/go"
+          printf '%s\n' "$tools" >>"$GITHUB_PATH"
+
       - name: Download frozen public release assets
         shell: bash
         env:

--- a/.github/workflows/verify-homebrew.yml
+++ b/.github/workflows/verify-homebrew.yml
@@ -120,6 +120,7 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: Download frozen public release assets
         shell: bash

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -369,6 +369,10 @@ Remove every GitHub, Actions, Homebrew, signing, notary, and secret-store
 credential from the environment. Then run the downstream verifier in a new
 credential-free shell:
 
+The launcher captures absolute Homebrew, Node, and Go executable paths before
+scrubbing the environment, then preserves only those tool directories plus the
+macOS system paths in the child `PATH`.
+
 ```sh
 
 scripts/verify-homebrew-release.sh \

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -491,6 +491,11 @@ notarization checks. Apple Silicon also runs the helper's non-mutating info path
 This bounded verifier is the installed-binary smoke; it does not create a lease.
 Only both native proofs complete the Homebrew gate.
 
+The Homebrew workflow itself runs from the current protected `main` commit,
+while its verification checkout remains pinned to the release record's
+protected verifier commit. This keeps published provenance immutable while
+allowing a protected workflow-only repair to restore the downstream proof.
+
 ## Cancellation And Recovery
 
 Cancellation stops all publication and tap actions immediately. Inspect the

--- a/scripts/homebrew-release.test.js
+++ b/scripts/homebrew-release.test.js
@@ -393,6 +393,12 @@ test("Homebrew verifier is publishability-gated, native, token-free, and read-on
   assert.match(source, /homebrew_cache="\$work\/cache"/);
   assert.match(source, /HOME="\$homebrew_home"/);
   assert.match(source, /HOMEBREW_CACHE="\$homebrew_cache"/);
+  assert.match(source, /go_bin=\$\(command -v go\)/);
+  assert.match(
+    source,
+    /clean_path="\$\{brew_bin%\/\*\}:\$\{node_bin%\/\*\}:\$\{go_bin%\/\*\}:\/usr\/bin:\/bin:\/usr\/sbin:\/sbin"/,
+  );
+  assert.ok(main.indexOf("go_bin=$(command -v go)") < main.indexOf("/usr/bin/env -i"));
   assert.doesNotMatch(source, /^\s*HOME="\$HOME"/m);
   for (const credential of forbiddenCredentials) {
     assert.match(credentialGuards, new RegExp(`\\b${credential}\\b`));

--- a/scripts/release-workflow.test.js
+++ b/scripts/release-workflow.test.js
@@ -78,6 +78,13 @@ test("Homebrew verifier keeps downloaded proof inputs outside the protected chec
   );
   assert.match(workflow, /go-version-file: go\.mod/);
   assert.match(workflow, /go-version-file: go\.mod\n\s+cache: false/);
+  assert.match(workflow, /name: Preserve pinned Go in the frozen verifier path/);
+  assert.match(workflow, /tools="\$RUNNER_TEMP\/release-tools"/);
+  assert.match(workflow, /brew_path=\$\(command -v brew\)/);
+  assert.match(workflow, /exec \\\"\$brew_path\\\" \\\"\\\$@\\\"/);
+  assert.match(workflow, /chmod 700 "\$tools\/brew"/);
+  assert.match(workflow, /ln -s "\$\(command -v go\)" "\$tools\/go"/);
+  assert.match(workflow, /printf '%s\\n' "\$tools" >>"\$GITHUB_PATH"/);
   assert.match(workflow, /assets_dir="\$RUNNER_TEMP\/release-assets"/);
   assert.match(workflow, /proofs_dir="\$RUNNER_TEMP\/public-proofs"/);
   assert.match(

--- a/scripts/release-workflow.test.js
+++ b/scripts/release-workflow.test.js
@@ -78,13 +78,6 @@ test("Homebrew verifier keeps downloaded proof inputs outside the protected chec
   );
   assert.match(workflow, /go-version-file: go\.mod/);
   assert.match(workflow, /go-version-file: go\.mod\n\s+cache: false/);
-  assert.match(workflow, /name: Preserve pinned Go in the clean verifier path/);
-  assert.match(workflow, /tools="\$RUNNER_TEMP\/release-tools"/);
-  assert.match(workflow, /brew_path=\$\(command -v brew\)/);
-  assert.match(workflow, /exec \\\"\$brew_path\\\" \\\"\\\$@\\\"/);
-  assert.match(workflow, /chmod 700 "\$tools\/brew"/);
-  assert.match(workflow, /ln -s "\$\(command -v go\)" "\$tools\/go"/);
-  assert.match(workflow, /printf '%s\\n' "\$tools" >>"\$GITHUB_PATH"/);
   assert.match(workflow, /assets_dir="\$RUNNER_TEMP\/release-assets"/);
   assert.match(workflow, /proofs_dir="\$RUNNER_TEMP\/public-proofs"/);
   assert.match(

--- a/scripts/release-workflow.test.js
+++ b/scripts/release-workflow.test.js
@@ -77,6 +77,7 @@ test("Homebrew verifier keeps downloaded proof inputs outside the protected chec
     /name: Set up Go for build-info inspection\n\s+uses: actions\/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16/,
   );
   assert.match(workflow, /go-version-file: go\.mod/);
+  assert.match(workflow, /go-version-file: go\.mod\n\s+cache: false/);
   assert.match(workflow, /assets_dir="\$RUNNER_TEMP\/release-assets"/);
   assert.match(workflow, /proofs_dir="\$RUNNER_TEMP\/public-proofs"/);
   assert.match(

--- a/scripts/release-workflow.test.js
+++ b/scripts/release-workflow.test.js
@@ -78,6 +78,13 @@ test("Homebrew verifier keeps downloaded proof inputs outside the protected chec
   );
   assert.match(workflow, /go-version-file: go\.mod/);
   assert.match(workflow, /go-version-file: go\.mod\n\s+cache: false/);
+  assert.match(workflow, /name: Preserve pinned Go in the clean verifier path/);
+  assert.match(workflow, /tools="\$RUNNER_TEMP\/release-tools"/);
+  assert.match(workflow, /brew_path=\$\(command -v brew\)/);
+  assert.match(workflow, /exec \\\"\$brew_path\\\" \\\"\\\$@\\\"/);
+  assert.match(workflow, /chmod 700 "\$tools\/brew"/);
+  assert.match(workflow, /ln -s "\$\(command -v go\)" "\$tools\/go"/);
+  assert.match(workflow, /printf '%s\\n' "\$tools" >>"\$GITHUB_PATH"/);
   assert.match(workflow, /assets_dir="\$RUNNER_TEMP\/release-assets"/);
   assert.match(workflow, /proofs_dir="\$RUNNER_TEMP\/public-proofs"/);
   assert.match(

--- a/scripts/release-workflow.test.js
+++ b/scripts/release-workflow.test.js
@@ -70,7 +70,13 @@ test("Homebrew verifier keeps downloaded proof inputs outside the protected chec
     proofDownloadEnd,
   );
   assert.match(workflow, /WORKFLOW_SHA: \$\{\{ github\.workflow_sha \}\}/);
-  assert.match(workflow, /\[\[ "\$WORKFLOW_SHA" == "\$VERIFIER_COMMIT" \]\]/);
+  assert.match(workflow, /RUN_SHA: \$\{\{ github\.sha \}\}/);
+  assert.match(workflow, /\[\[ "\$WORKFLOW_SHA" == "\$RUN_SHA" \]\]/);
+  assert.match(
+    workflow,
+    /name: Set up Go for build-info inspection\n\s+uses: actions\/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16/,
+  );
+  assert.match(workflow, /go-version-file: go\.mod/);
   assert.match(workflow, /assets_dir="\$RUNNER_TEMP\/release-assets"/);
   assert.match(workflow, /proofs_dir="\$RUNNER_TEMP\/public-proofs"/);
   assert.match(

--- a/scripts/verify-homebrew-release.sh
+++ b/scripts/verify-homebrew-release.sh
@@ -594,7 +594,7 @@ main() {
   [[ $# -eq 8 ]] || usage
   local tag=$1 asset_dir=$2 tag_object=$3 source_commit=$4 verifier_commit=$5
   local release_id=$6 public_run_id=$7 proof_dir=$8
-  local native_arch brew_bin node_bin work clean_path user_name homebrew_home homebrew_cache source_asset_dir
+  local native_arch brew_bin node_bin go_bin work clean_path user_name homebrew_home homebrew_cache source_asset_dir
   validate_release_identity "$tag" "$tag_object" "$source_commit" "$verifier_commit"
   assert_no_downstream_credentials
   [[ "$(uname -s)" == Darwin ]] || {
@@ -622,8 +622,10 @@ main() {
 
   brew_bin=$(command -v brew)
   node_bin=$(command -v node)
-  [[ "$brew_bin" == /* && "$node_bin" == /* && -x "$brew_bin" && -x "$node_bin" ]] || {
-    echo "absolute Homebrew and Node executables are required" >&2
+  go_bin=$(command -v go)
+  [[ "$brew_bin" == /* && "$node_bin" == /* && "$go_bin" == /* &&
+    -x "$brew_bin" && -x "$node_bin" && -x "$go_bin" ]] || {
+    echo "absolute Homebrew, Node, and Go executables are required" >&2
     exit 1
   }
   work=$(mktemp -d "${TMPDIR:-/tmp}/crabbox-homebrew-verify.XXXXXX")
@@ -637,7 +639,7 @@ main() {
     "$tag" "$asset_dir" "$tag_object" "$source_commit" "$verifier_commit" \
     "$release_id" "$public_run_id" "$proof_dir" "$work/public-preflight" "$node_bin"
   asset_dir="$work/public-preflight/public-assets"
-  clean_path="${brew_bin%/*}:${node_bin%/*}:/usr/bin:/bin:/usr/sbin:/sbin"
+  clean_path="${brew_bin%/*}:${node_bin%/*}:${go_bin%/*}:/usr/bin:/bin:/usr/sbin:/sbin"
   user_name=$(id -un)
 
   # shellcheck disable=SC2016 # Expanded by the credential-free child shell.


### PR DESCRIPTION
## Summary

- install the pinned Go toolchain before downstream Homebrew verification
- keep the workflow commit pinned to protected main while checking out the immutable release verifier separately
- document and regression-test that trust split

## Proof

- `node --test scripts/release-workflow.test.js scripts/homebrew-release.test.js` — 37/37 passed
- autoreview clean, confidence 0.90
- failure reproduced on both native jobs in https://github.com/openclaw/crabbox/actions/runs/29511456703 (`missing required tool: go`)

## Release impact

Restores the blocked native Homebrew verification gate for the already-published immutable v0.38.4 release. No release assets, tag identity, or provenance bytes change.
