### PR TITLE
fix(ci): materialize public tap for release proof

### DIFF
--- a/.github/workflows/verify-homebrew.yml
+++ b/.github/workflows/verify-homebrew.yml
@@ -197,6 +197,7 @@ jobs:
           set -euo pipefail
           unset ACTIONS_ID_TOKEN_REQUEST_TOKEN ACTIONS_RUNTIME_TOKEN GH_TOKEN GITHUB_TOKEN
           unset HOMEBREW_GITHUB_API_TOKEN HOMEBREW_TAP_GITHUB_TOKEN
+          HOMEBREW_NO_AUTO_UPDATE=1 brew tap openclaw/tap
           scripts/verify-homebrew-release.sh \
             "$RELEASE_TAG" "$RUNNER_TEMP/release-assets" \
             "$TAG_OBJECT" "$SOURCE_COMMIT" "$VERIFIER_COMMIT" \

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -369,6 +369,13 @@ Remove every GitHub, Actions, Homebrew, signing, notary, and secret-store
 credential from the environment. Then run the downstream verifier in a new
 credential-free shell:
 
+On an ephemeral runner, materialize the public tap after removing credentials
+and before starting the verifier:
+
+```sh
+HOMEBREW_NO_AUTO_UPDATE=1 brew tap openclaw/tap
+```
+
 The launcher captures absolute Homebrew, Node, and Go executable paths before
 scrubbing the environment, then preserves only those tool directories plus the
 macOS system paths in the child `PATH`.

--- a/scripts/release-workflow.test.js
+++ b/scripts/release-workflow.test.js
@@ -69,6 +69,10 @@ test("Homebrew verifier keeps downloaded proof inputs outside the protected chec
     proofDownloadStart,
     proofDownloadEnd,
   );
+  const verifyStart = workflow.indexOf(
+    "      - name: Verify public Homebrew install without credentials",
+  );
+  const verifyStep = workflow.slice(verifyStart);
   assert.match(workflow, /WORKFLOW_SHA: \$\{\{ github\.workflow_sha \}\}/);
   assert.match(workflow, /RUN_SHA: \$\{\{ github\.sha \}\}/);
   assert.match(workflow, /\[\[ "\$WORKFLOW_SHA" == "\$RUN_SHA" \]\]/);
@@ -96,6 +100,17 @@ test("Homebrew verifier keeps downloaded proof inputs outside the protected chec
   assert.match(workflow, /"\$RUNNER_TEMP\/public-proofs"/);
   assert.doesNotMatch(workflow, /"\$PWD\/(?:release-assets|public-proofs)"/);
   assert.doesNotMatch(workflow, /mkdir -m 700 (?:release-assets|public-proofs)/);
+  assert.match(verifyStep, /unset ACTIONS_ID_TOKEN_REQUEST_TOKEN ACTIONS_RUNTIME_TOKEN GH_TOKEN GITHUB_TOKEN/);
+  assert.match(verifyStep, /unset HOMEBREW_GITHUB_API_TOKEN HOMEBREW_TAP_GITHUB_TOKEN/);
+  assert.match(verifyStep, /HOMEBREW_NO_AUTO_UPDATE=1 brew tap openclaw\/tap/);
+  assert.ok(
+    verifyStep.indexOf("unset HOMEBREW_GITHUB_API_TOKEN HOMEBREW_TAP_GITHUB_TOKEN") <
+      verifyStep.indexOf("HOMEBREW_NO_AUTO_UPDATE=1 brew tap openclaw/tap"),
+  );
+  assert.ok(
+    verifyStep.indexOf("HOMEBREW_NO_AUTO_UPDATE=1 brew tap openclaw/tap") <
+      verifyStep.indexOf("scripts/verify-homebrew-release.sh"),
+  );
 });
 
 test("script CI fetches signed release tags for publication fixtures", () => {


### PR DESCRIPTION
## Summary

- materialize the public `openclaw/tap` checkout after removing every GitHub and Homebrew token
- keep the frozen v0.38.4 verifier unchanged while allowing its canonical `brew cat` proof on clean runners
- document the ephemeral-runner prerequisite and lock credential/tap/verifier ordering in regression coverage

## Release blocker

The first protected dual-native run reached and passed public asset, provenance, signature, notarization, and Go-toolchain validation on both architectures, then failed because clean runners had no local public tap source for `brew cat`: https://github.com/openclaw/crabbox/actions/runs/29518467928

## Verification

- `node --test scripts/release-workflow.test.js scripts/homebrew-release.test.js` — 37/37 pass
- `node scripts/build-docs-site.mjs`
- `bash -n scripts/verify-homebrew-release.sh`
- `git diff --check`
- autoreview clean, patch confidence 0.93
