### PR TITLE
fix(ci): bootstrap Homebrew tap verification

### DIFF
--- a/.github/workflows/verify-homebrew.yml
+++ b/.github/workflows/verify-homebrew.yml
@@ -122,14 +122,21 @@ jobs:
           go-version-file: go.mod
           cache: false
 
-      - name: Preserve pinned Go in the frozen verifier path
+      - name: Preserve pinned tools for the frozen verifier
         shell: bash
         run: |
           set -euo pipefail
           tools="$RUNNER_TEMP/release-tools"
           mkdir -m 700 "$tools"
           brew_path=$(command -v brew)
-          printf '%s\n' '#!/bin/bash' "exec \"$brew_path\" \"\$@\"" >"$tools/brew"
+          cat >"$tools/brew" <<EOF
+          #!/bin/bash
+          set -euo pipefail
+          if [[ "\${1:-}" == cat && "\${2:-}" == openclaw/tap/crabbox ]]; then
+            "$brew_path" tap openclaw/tap
+          fi
+          exec "$brew_path" "\$@"
+          EOF
           chmod 700 "$tools/brew"
           ln -s "$(command -v go)" "$tools/go"
           printf '%s\n' "$tools" >>"$GITHUB_PATH"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -385,11 +385,12 @@ The last command first re-fetches the current public release, workflow run,
 workflow, and artifact metadata without authentication. It binds the successful
 post-publication run, both digest-pinned native proof ZIPs, their current release
 and asset timestamps, and the supplied public bytes before it changes local
-Homebrew state. It then performs `brew update`, a fresh install or reinstall,
+Homebrew state. It then performs `brew update`, ensures the public
+`openclaw/tap` is present without credentials, performs a fresh install or reinstall,
 `brew test`, exact installed-byte and architecture comparison, Foundation
 signature and online notarization checks, exact version execution, and Apple
 Silicon `vmd-info`, then repeats the unauthenticated public-record and proof
-comparison to close the verification window. It does not update the tap. The
+comparison to close the verification window. It does not publish or write to the tap. The
 tap formula must be byte-for-byte output from the protected
 `scripts/render-homebrew-formula.mjs`; any additional Ruby, interpolation, or
 format drift is rejected before Homebrew evaluates it. Protected downstream

--- a/scripts/homebrew-release.test.js
+++ b/scripts/homebrew-release.test.js
@@ -282,9 +282,12 @@ function runMockedHomebrewPhase({
     path.join(mockBin, "brew"),
     `#!/bin/sh
 printf 'brew:%s\\n' "$*" >>${shellQuote(log)}
-case "\${1:-}" in
+	case "\${1:-}" in
   update)
     [ "\${2:-}" = --force ] || exit 81
+    ;;
+  tap)
+    [ "\${2:-}" = openclaw/tap ] || exit 91
     ;;
   cat)
     [ "\${2:-}" = openclaw/tap/crabbox ] || exit 82
@@ -379,7 +382,8 @@ test("Homebrew verifier is publishability-gated, native, token-free, and read-on
   const main = source.slice(source.indexOf("main() {"));
   const phase = source.slice(source.indexOf("homebrew_phase() {"), source.indexOf("main() {"));
 
-  assert.match(source, /^FORMULA=openclaw\/tap\/crabbox$/m);
+  assert.match(source, /^TAP=openclaw\/tap$/m);
+  assert.match(source, /^FORMULA="\$TAP\/crabbox"$/m);
   assert.match(source, /REQUIRE_PUBLISHABLE=1/);
   assert.match(source, /validate-release-publication\.mjs" public-proof/);
   assert.match(source, /public-verifier-run-id/);
@@ -403,13 +407,15 @@ test("Homebrew verifier is publishability-gated, native, token-free, and read-on
   for (const credential of forbiddenCredentials) {
     assert.match(credentialGuards, new RegExp(`\\b${credential}\\b`));
   }
-  assert.doesNotMatch(source, /\bgh(?:\s|$)|brew tap|workflow run|update-formula|git push/);
+  assert.doesNotMatch(source, /\bgh(?:\s|$)|workflow run|update-formula|git push/);
   assert.doesNotMatch(source, /== --homebrew-phase/);
 
   assert.ok(main.indexOf("require_publishable_source") < main.indexOf("/usr/bin/env -i"));
   assert.ok(phase.indexOf("require_publishable_source") < phase.indexOf('"$brew_bin" update'));
   assert.ok(phase.indexOf("scripts/verify-release.sh") < phase.indexOf('"$brew_bin" update'));
   assert.ok(phase.indexOf('"$brew_bin" update --force') < phase.indexOf('"$brew_bin" cat'));
+  assert.ok(phase.indexOf('"$brew_bin" update --force') < phase.indexOf('"$brew_bin" tap'));
+  assert.ok(phase.indexOf('"$brew_bin" tap "$TAP"') < phase.indexOf('"$brew_bin" cat'));
   assert.ok(phase.indexOf("verify_homebrew_formula") < phase.indexOf('"$brew_bin" reinstall'));
   assert.ok(phase.indexOf("verify_homebrew_formula") < phase.indexOf('"$brew_bin" fetch'));
   assert.ok(phase.indexOf('"$brew_bin" fetch --force --formula') < phase.indexOf('"$brew_bin" install'));
@@ -593,6 +599,7 @@ test("mocked Homebrew phase proves fresh fetch, frozen bytes, trust, and final e
   assert.match(result.calls, /^verify-source:v1\.2\.3 /m);
   assert.match(result.calls, /^verify-release:v1\.2\.3 /m);
   assert.match(result.calls, /^brew:update --force$/m);
+  assert.match(result.calls, /^brew:tap openclaw\/tap$/m);
   assert.match(result.calls, /^brew:fetch --force --formula openclaw\/tap\/crabbox$/m);
   assert.match(result.calls, /^brew:install openclaw\/tap\/crabbox$/m);
   assert.match(result.calls, /^verify-macos:org\.openclaw\.crabbox arm64 /m);
@@ -601,6 +608,8 @@ test("mocked Homebrew phase proves fresh fetch, frozen bytes, trust, and final e
     /^verify-macos:org\.openclaw\.crabbox\.apple-vm-helper arm64 /m,
   );
   assert.match(result.calls, /^brew:test openclaw\/tap\/crabbox$/m);
+  assert.ok(result.calls.indexOf("brew:update") < result.calls.indexOf("brew:tap"));
+  assert.ok(result.calls.indexOf("brew:tap") < result.calls.indexOf("brew:fetch"));
   assert.ok(result.calls.indexOf("brew:fetch") < result.calls.indexOf("brew:install"));
   assert.ok(result.calls.indexOf("verify-macos:") < result.calls.indexOf("brew:test"));
 });

--- a/scripts/release-workflow.test.js
+++ b/scripts/release-workflow.test.js
@@ -78,10 +78,15 @@ test("Homebrew verifier keeps downloaded proof inputs outside the protected chec
   );
   assert.match(workflow, /go-version-file: go\.mod/);
   assert.match(workflow, /go-version-file: go\.mod\n\s+cache: false/);
-  assert.match(workflow, /name: Preserve pinned Go in the frozen verifier path/);
+  assert.match(workflow, /name: Preserve pinned tools for the frozen verifier/);
   assert.match(workflow, /tools="\$RUNNER_TEMP\/release-tools"/);
   assert.match(workflow, /brew_path=\$\(command -v brew\)/);
-  assert.match(workflow, /exec \\\"\$brew_path\\\" \\\"\\\$@\\\"/);
+  assert.match(
+    workflow,
+    /if \[\[ "\\\$\{1:-\}" == cat && "\\\$\{2:-\}" == openclaw\/tap\/crabbox \]\]; then/,
+  );
+  assert.match(workflow, /"\$brew_path" tap openclaw\/tap/);
+  assert.match(workflow, /exec "\$brew_path" "\\\$@"/);
   assert.match(workflow, /chmod 700 "\$tools\/brew"/);
   assert.match(workflow, /ln -s "\$\(command -v go\)" "\$tools\/go"/);
   assert.match(workflow, /printf '%s\\n' "\$tools" >>"\$GITHUB_PATH"/);

--- a/scripts/verify-homebrew-release.sh
+++ b/scripts/verify-homebrew-release.sh
@@ -5,7 +5,8 @@ ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 # shellcheck source=scripts/release-config.sh
 source "$ROOT/scripts/release-config.sh"
 
-FORMULA=openclaw/tap/crabbox
+TAP=openclaw/tap
+FORMULA="$TAP/crabbox"
 SCRIPT_PATH="$ROOT/scripts/verify-homebrew-release.sh"
 PROTECTED_HOMEBREW_TOOLING=(
   .github/release-allowed-signers
@@ -479,6 +480,7 @@ homebrew_phase() {
 
   local formula_file="$work/crabbox.rb"
   "$brew_bin" update --force
+  "$brew_bin" tap "$TAP"
   "$brew_bin" cat "$FORMULA" >"$formula_file"
   verify_homebrew_formula \
     "$node_bin" "$formula_file" "$tag" \


### PR DESCRIPTION
## Summary

- bootstrap the public `openclaw/tap` inside the credential-free Homebrew verifier before formula resolution
- bridge the same behavior into the frozen v0.38.4 verifier workflow without moving the immutable release tag or verifier commit
- cover ordering and the generated wrapper; clarify the read-only tap contract

## Failure proof

- post-merge Homebrew run: https://github.com/openclaw/crabbox/actions/runs/29518467928
- guard and immutable asset/native verification passed on both architectures
- both jobs failed only because `brew cat openclaw/tap/crabbox` ran before the public tap existed locally

## Verification

- `bash -n scripts/verify-homebrew-release.sh`
- `node --test scripts/homebrew-release.test.js scripts/release-workflow.test.js` — 37/37 passed
- `git diff --check`
- autoreview clean; no accepted/actionable findings, confidence 0.94

No release asset, tag, release object, formula byte, or credential handling changed.
