### PR TITLE
ci: retry anonymous Homebrew verifier reads

### DIFF
--- a/.github/workflows/verify-homebrew.yml
+++ b/.github/workflows/verify-homebrew.yml
@@ -122,15 +122,21 @@ jobs:
           go-version-file: go.mod
           cache: false
 
-      - name: Preserve pinned Go in the frozen verifier path
+      - name: Preserve pinned release tools in the frozen verifier path
         shell: bash
         run: |
           set -euo pipefail
           tools="$RUNNER_TEMP/release-tools"
           mkdir -m 700 "$tools"
           brew_path=$(command -v brew)
+          curl_path=$(command -v curl)
           printf '%s\n' '#!/bin/bash' "exec \"$brew_path\" \"\$@\"" >"$tools/brew"
-          chmod 700 "$tools/brew"
+          # Frozen verifier traffic is public GET-only. Retry shared-runner
+          # throttling without adding credentials or weakening either read.
+          printf '%s\n' '#!/bin/bash' \
+            "exec \"$curl_path\" \"\$@\" --retry-all-errors --retry 60 --retry-delay 15 --retry-max-time 900" \
+            >"$tools/curl"
+          chmod 700 "$tools/brew" "$tools/curl"
           ln -s "$(command -v go)" "$tools/go"
           printf '%s\n' "$tools" >>"$GITHUB_PATH"
 

--- a/.github/workflows/verify-homebrew.yml
+++ b/.github/workflows/verify-homebrew.yml
@@ -133,9 +133,23 @@ jobs:
           printf '%s\n' '#!/bin/bash' "exec \"$brew_path\" \"\$@\"" >"$tools/brew"
           # Frozen verifier traffic is public GET-only. Retry shared-runner
           # throttling without adding credentials or weakening either read.
-          printf '%s\n' '#!/bin/bash' \
-            "exec \"$curl_path\" \"\$@\" --retry-all-errors --retry 60 --retry-delay 15 --retry-max-time 900" \
-            >"$tools/curl"
+          # Stage stdout so a retry cannot append to redirected partial JSON.
+          {
+            printf '%s\n' '#!/bin/bash' 'set -euo pipefail'
+            printf 'curl_bin=%q\n' "$curl_path"
+            cat <<'CURL_WRAPPER'
+          retry=(--retry-all-errors --retry 60 --retry-delay 15 --retry-max-time 900)
+          for arg in "$@"; do
+            case "$arg" in
+              -o|--output|--output=*) exec "$curl_bin" "$@" "${retry[@]}" ;;
+            esac
+          done
+          output=$(mktemp "${TMPDIR:-/tmp}/crabbox-curl.XXXXXX")
+          trap 'rm -f "$output"' EXIT
+          "$curl_bin" "$@" "${retry[@]}" --output "$output"
+          cat "$output"
+          CURL_WRAPPER
+          } >"$tools/curl"
           chmod 700 "$tools/brew" "$tools/curl"
           ln -s "$(command -v go)" "$tools/go"
           printf '%s\n' "$tools" >>"$GITHUB_PATH"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -380,6 +380,11 @@ The launcher captures absolute Homebrew, Node, and Go executable paths before
 scrubbing the environment, then preserves only those tool directories plus the
 macOS system paths in the child `PATH`.
 
+Hosted native runners also place a credential-free `curl` retry wrapper in that
+trusted tool directory. It keeps the frozen verifier's public GitHub API reads
+bounded to 15 minutes while tolerating transient shared-runner 403/rate-limit
+responses; it never adds an authorization header or skips a pre/postflight read.
+
 ```sh
 
 scripts/verify-homebrew-release.sh \

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -383,7 +383,9 @@ macOS system paths in the child `PATH`.
 Hosted native runners also place a credential-free `curl` retry wrapper in that
 trusted tool directory. It keeps the frozen verifier's public GitHub API reads
 bounded to 15 minutes while tolerating transient shared-runner 403/rate-limit
-responses; it never adds an authorization header or skips a pre/postflight read.
+responses. Stdout responses are staged in a curl-owned temporary file and
+emitted only after success, so retries cannot append to partial JSON. The wrapper
+never adds an authorization header or skips a pre/postflight read.
 
 ```sh
 

--- a/scripts/release-workflow.test.js
+++ b/scripts/release-workflow.test.js
@@ -96,8 +96,12 @@ test("Homebrew verifier keeps downloaded proof inputs outside the protected chec
   assert.match(workflow, /exec \\\"\$brew_path\\\" \\\"\\\$@\\\"/);
   assert.match(
     workflow,
-    /exec \\\"\$curl_path\\\" \\\"\\\$@\\\" --retry-all-errors --retry 60 --retry-delay 15 --retry-max-time 900/,
+    /retry=\(--retry-all-errors --retry 60 --retry-delay 15 --retry-max-time 900\)/,
   );
+  assert.match(workflow, /-o\|--output\|--output=\*\) exec "\$curl_bin" "\$@" "\$\{retry\[@\]\}"/);
+  assert.match(workflow, /output=\$\(mktemp "\$\{TMPDIR:-\/tmp\}\/crabbox-curl\.XXXXXX"\)/);
+  assert.match(workflow, /"\$curl_bin" "\$@" "\$\{retry\[@\]\}" --output "\$output"/);
+  assert.match(workflow, /cat "\$output"/);
   assert.doesNotMatch(toolsStep, /Authorization|GH_TOKEN|GITHUB_TOKEN/);
   assert.match(workflow, /chmod 700 "\$tools\/brew" "\$tools\/curl"/);
   assert.match(workflow, /ln -s "\$\(command -v go\)" "\$tools\/go"/);

--- a/scripts/release-workflow.test.js
+++ b/scripts/release-workflow.test.js
@@ -63,12 +63,19 @@ test("Homebrew verifier keeps downloaded proof inputs outside the protected chec
   const proofDownloadEnd = workflow.indexOf(
     "      - name: Verify public Homebrew install without credentials",
   );
+  const toolsStepStart = workflow.indexOf(
+    "      - name: Preserve pinned release tools in the frozen verifier path",
+  );
+  const toolsStepEnd = workflow.indexOf("      - name: Download frozen public release assets");
   assert.notEqual(proofDownloadStart, -1);
   assert.notEqual(proofDownloadEnd, -1);
+  assert.notEqual(toolsStepStart, -1);
+  assert.notEqual(toolsStepEnd, -1);
   const proofDownloadStep = workflow.slice(
     proofDownloadStart,
     proofDownloadEnd,
   );
+  const toolsStep = workflow.slice(toolsStepStart, toolsStepEnd);
   const verifyStart = workflow.indexOf(
     "      - name: Verify public Homebrew install without credentials",
   );
@@ -82,11 +89,17 @@ test("Homebrew verifier keeps downloaded proof inputs outside the protected chec
   );
   assert.match(workflow, /go-version-file: go\.mod/);
   assert.match(workflow, /go-version-file: go\.mod\n\s+cache: false/);
-  assert.match(workflow, /name: Preserve pinned Go in the frozen verifier path/);
+  assert.match(workflow, /name: Preserve pinned release tools in the frozen verifier path/);
   assert.match(workflow, /tools="\$RUNNER_TEMP\/release-tools"/);
   assert.match(workflow, /brew_path=\$\(command -v brew\)/);
+  assert.match(workflow, /curl_path=\$\(command -v curl\)/);
   assert.match(workflow, /exec \\\"\$brew_path\\\" \\\"\\\$@\\\"/);
-  assert.match(workflow, /chmod 700 "\$tools\/brew"/);
+  assert.match(
+    workflow,
+    /exec \\\"\$curl_path\\\" \\\"\\\$@\\\" --retry-all-errors --retry 60 --retry-delay 15 --retry-max-time 900/,
+  );
+  assert.doesNotMatch(toolsStep, /Authorization|GH_TOKEN|GITHUB_TOKEN/);
+  assert.match(workflow, /chmod 700 "\$tools\/brew" "\$tools\/curl"/);
   assert.match(workflow, /ln -s "\$\(command -v go\)" "\$tools\/go"/);
   assert.match(workflow, /printf '%s\\n' "\$tools" >>"\$GITHUB_PATH"/);
   assert.match(workflow, /assets_dir="\$RUNNER_TEMP\/release-assets"/);


### PR DESCRIPTION
## Summary

- add a credential-free curl bridge for the frozen Homebrew verifier
- retry transient anonymous GitHub API failures for at most 15 minutes
- preserve mandatory public preflight and postflight reads without adding authorization

## Failure proof

- https://github.com/openclaw/crabbox/actions/runs/29520675269
- Intel completed fully green.
- Apple Silicon completed install, signature, Homebrew test, and version proof, then received a shared-runner anonymous API 403 during postflight. Its failed-only retry received the same 403 during preflight.

## Verification

- `node --test scripts/release-workflow.test.js scripts/homebrew-release.test.js` (37/37)
- `node scripts/build-docs-site.mjs`
- `git diff --check`
- local curl option-order smoke confirmed appended retry options override an earlier retry count

No product artifact, release identity, signed tag, provenance, or verifier commit changes.
