### PR TITLE
docs: document accepted low-severity security trade-offs

### DIFF
--- a/docs/commands/artifacts.md
+++ b/docs/commands/artifacts.md
@@ -249,9 +249,17 @@ signing grants. When `--prefix` is omitted for hosted publishing, the CLI
 derives a unique prefix from the PR number, bundle directory, and current time
 so later QA comments do not overwrite earlier evidence.
 
-The coordinator scopes each new grant under opaque encodings of the exact
-authenticated organization and owner. Caller prefixes cannot cross or replace
-that authorization namespace.
+The coordinator scopes each new grant under versioned base64url encodings of
+the exact authenticated organization and owner. These values are reversible,
+not hashed or encrypted, and appear in object paths for both public and signed
+URLs. The owner can be a non-public GitHub verified email. Caller prefixes
+cannot cross or replace that authorization namespace.
+
+`artifacts publish --pr` can place these URLs in public pull-request comments.
+Operators should weigh that identity disclosure before enabling
+`CRABBOX_ARTIFACTS_PUBLIC_READS`; the random capability namespace on public
+grants prevents easy guessing but does not hide the encoded identity from a URL
+recipient. This identity disclosure is an accepted Low/P3 residual risk.
 
 ## Manifest, list, and pull
 

--- a/docs/features/ssh-keys.md
+++ b/docs/features/ssh-keys.md
@@ -43,6 +43,26 @@ omitted for private AWS workspaces, Windows, macOS, Daytona, Azure snapshot,
 registered, and direct-provider leases, where Crabbox cannot authoritatively
 inject a host key before boot.
 
+### Trust model
+
+To pin the exact SSH host identity before the first connection, including
+coordinator terminal and native-VNC connections, the coordinator generates the
+host key pair and delivers it to the instance through provider launch data: AWS
+and Hetzner user-data, Azure `customData`, or GCP metadata. This avoids a
+trust-on-first-use gap for those connections.
+
+The launch data contains the host private key. Principals with provider-side
+read access to that data, or root access on the instance, can read the private
+key and impersonate that host. On providers that expose launch data through an
+in-guest metadata service, any guest process able to query that service can also
+read the key without root access. Treat provider launch-data readers, guest
+workloads with metadata access, and root on the instance as trusted
+infrastructure. Tighten provider-side IAM permissions, such as
+`ec2:DescribeInstanceAttribute` and `compute.instances.get`, restrict in-guest
+metadata access where the provider supports it, and do not log launch-data
+request bodies. This Low/P3 residual risk is accepted to preserve pre-connection
+host-identity pinning.
+
 ## Host-key trust and connection reuse
 
 A per-lease `known_hosts` file lives next to the key

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -528,6 +528,15 @@ Omit `CRABBOX_ARTIFACTS_PUBLIC_READS` to return expiring signed read URLs even
 when a base URL is configured. Enable it only when the artifact origin is
 intentionally public; each public grant receives a random capability namespace.
 
+**Security consideration:** Artifact object paths embed the authenticated
+organization and owner as reversible base64url values, not hashes or encrypted
+values. This applies to both expiring signed URLs and public URLs. The owner can
+be a non-public GitHub verified email, and `crabbox artifacts publish --pr` can
+place the resulting URLs in public pull-request comments. The random capability
+namespace makes a public URL difficult to guess but does not conceal identity
+from someone who has the URL. Weigh that disclosure before enabling public
+reads. This identity disclosure is an accepted Low/P3 residual risk.
+
 Deploy the matching access key id and secret access key as coordinator secrets,
 not local CLI defaults. End users run `crabbox artifacts publish` without
 holding any S3/R2 credentials.

--- a/docs/providers/xcp-ng.md
+++ b/docs/providers/xcp-ng.md
@@ -116,9 +116,10 @@ crabbox cleanup --provider xcp-ng --dry-run
 
 Keep `CRABBOX_XCP_NG_API_URL` on an administrator-only management network or
 VPN, and prefer trusted certificates. Set `CRABBOX_XCP_NG_INSECURE_TLS=1` or
-pass `--xcp-ng-insecure-tls` only for private lab pools where you control the
-network and certificate issuance. That only disables certificate verification;
-the API URL must still use HTTPS.
+pass `--xcp-ng-insecure-tls` only on a trusted management network in a fully
+trusted private lab. Keep TLS verification enabled, as it is by default, in all
+other environments. Disabling verification does not permit plain HTTP; the API
+URL must still use HTTPS.
 
 ## Configuration
 
@@ -157,6 +158,16 @@ or VPN when possible. Prefer trusted certificates. `insecureTLS` is a
 private-lab escape hatch, not a general deployment mode. If `apiUrl` points at
 a pool member that returns XAPI `HOST_IS_SLAVE` during login, Crabbox retries
 login once against the master address reported by XAPI.
+
+**Security consideration:** Following the master address and re-authenticating
+there is required for legitimate pool-master failover. The re-authentication
+includes the configured XAPI password. When `--xcp-ng-insecure-tls` is enabled,
+an on-path attacker who can tamper with the XAPI response could replace the
+reported master address and redirect that password-bearing re-authentication to
+a host of their choosing. Keep TLS verification enabled in any environment that
+is not a fully trusted private lab, and use insecure TLS only on a trusted
+management network. This Low/P3 residual risk is accepted to preserve
+pool-master failover.
 
 Repository-local `crabbox.yaml` and `.crabbox.yaml` files cannot override
 `apiUrl` or `insecureTLS`, so a checkout cannot redirect inherited credentials.

--- a/docs/security.md
+++ b/docs/security.md
@@ -403,10 +403,12 @@ repo:
   and optional `CRABBOX_ARTIFACTS_SESSION_TOKEN` — brokered artifact publishing.
   Scope these to the artifact bucket/prefix and use them only to sign
   short-lived upload/read URLs. New grants encode the exact authenticated
-  owner/org identity in an opaque versioned namespace; existing object URLs are
-  not rewritten or resolved through a legacy lookup path. Reads remain signed
-  unless `CRABBOX_ARTIFACTS_PUBLIC_READS=1` explicitly opts into non-expiring
-  public links; public grants add an unguessable per-grant namespace.
+  owner/org identity as reversible base64url values, not hashes or encrypted
+  values; this is visible in both signed and public object URLs. Existing object
+  URLs are not rewritten or resolved through a legacy lookup path. Reads remain
+  signed unless `CRABBOX_ARTIFACTS_PUBLIC_READS=1` explicitly opts into
+  non-expiring public links; public grants add an unguessable per-grant
+  namespace.
 
 Set the non-secret `CRABBOX_RUNTIME_ADAPTER_OWNER` and
 `CRABBOX_RUNTIME_ADAPTER_ORG` to stable deployment identities when the


### PR DESCRIPTION
## Summary

- document the accepted Low/P3 XCP-ng pool-master redirect risk when insecure TLS is enabled
- document the accepted Low/P3 SSH host-key delivery trust model for provider launch data and guest metadata access
- document the accepted Low/P3 artifact URL identity disclosure for reversible owner/org path values
- preserve all existing features and behavior

## Issues

- https://github.com/openclaw/crabbox/issues/1031
- https://github.com/openclaw/crabbox/issues/1003
- https://github.com/openclaw/crabbox/issues/1060

## Verification

- `node scripts/check-docs-links.mjs`
- `scripts/check-docs.sh`
- `.agents/skills/autoreview/scripts/autoreview --mode local --parallel-tests 'node scripts/check-docs-links.mjs && scripts/check-docs.sh'`

Final autoreview: clean, no accepted or actionable findings.
