### PR TITLE
fix(node): fail closed on invalid trusted-proxy CIDRs and warn on untrusted forwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Failed Node coordinator startup on malformed trusted-proxy CIDRs and warned on untrusted forwarded client headers so reverse-proxy source-bucket collapse is visible without changing OAuth admission limits.
 - Kept pond SSH forwards process-owned and grouped each member's ports into one connection, so terminal teardown reaps tunnels and helpers without hiding genuine failures or multiplying handshakes. Thanks @anagnorisis2peripeteia.
 - Preserved foreground container-runner output buffered behind slow HTTP clients when the detached-descendant drain cap expires.
 - Stopped a previously started egress host daemon during non-daemon egress starts so it cannot clobber the new foreground session, and held the per-lease lock until the foreground host joins so concurrent replacement starts cannot interleave.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -394,7 +394,9 @@ GitHub OAuth start routes remain unauthenticated so a new user can bootstrap log
 The coordinator limits active attempts to ten per caller source and 100 globally for
 both CLI and portal login, after removing expired attempts. Node deployments behind a
 reverse proxy must configure `CRABBOX_TRUSTED_PROXY_CIDRS`; otherwise caller limits use
-the direct peer address and ignore forwarded addresses.
+the direct peer address and ignore forwarded addresses. The Node runtime rejects malformed
+allowlist entries at startup and rate-limits warnings when an untrusted socket peer sends
+`X-Forwarded-For`, which usually means the reverse-proxy allowlist is missing or incomplete.
 
 For any portal that exposes browser Code, configure
 `CRABBOX_CODE_ORIGIN_TEMPLATE=https://{lease}.code.example.com` and route the

--- a/worker/node/server-support.ts
+++ b/worker/node/server-support.ts
@@ -11,6 +11,7 @@ export const authenticatedRequestBodyBytes = 16 * 1024 * 1024;
 export const runFinishRequestBodyBytes = 64 * 1024 * 1024;
 
 const noop = () => {};
+const untrustedForwardingWarningIntervalMs = 60_000;
 
 export class RequestBodyTooLargeError extends Error {}
 
@@ -126,29 +127,52 @@ export function isTrustedProxySource(
   const family = isIP(normalizedAddress);
   if (family === 0 || !configuredCIDRs?.trim()) return false;
 
-  const blockList = new BlockList();
   try {
-    for (const rawEntry of configuredCIDRs.split(",")) {
-      const entry = rawEntry.trim();
-      if (!entry) continue;
-      const separator = entry.lastIndexOf("/");
-      const subnet = normalizeIPAddress(separator === -1 ? entry : entry.slice(0, separator));
-      const subnetFamily = isIP(subnet);
-      if (subnetFamily === 0) return false;
-      const type = subnetFamily === 4 ? "ipv4" : "ipv6";
-      if (separator === -1) {
-        blockList.addAddress(subnet, type);
-        continue;
-      }
-      const prefix = Number(entry.slice(separator + 1));
-      const maxPrefix = subnetFamily === 4 ? 32 : 128;
-      if (!Number.isInteger(prefix) || prefix < 0 || prefix > maxPrefix) return false;
-      blockList.addSubnet(subnet, prefix, type);
-    }
+    const blockList = trustedProxyBlockList(configuredCIDRs);
+    return blockList.check(normalizedAddress, family === 4 ? "ipv4" : "ipv6");
   } catch {
     return false;
   }
-  return blockList.check(normalizedAddress, family === 4 ? "ipv4" : "ipv6");
+}
+
+export function validateTrustedProxyCIDRs(configuredCIDRs: string | undefined): void {
+  if (!configuredCIDRs?.trim()) return;
+  trustedProxyBlockList(configuredCIDRs);
+}
+
+export interface UntrustedForwardingDiagnosticOptions {
+  now?: () => number;
+  warningIntervalMs?: number;
+  warn?: (message: string) => void;
+}
+
+export function createUntrustedForwardingDiagnostic(
+  options: UntrustedForwardingDiagnosticOptions = {},
+): (
+  peerAddress: string | undefined,
+  forwardedFor: string | undefined,
+  trustedProxy: boolean,
+) => boolean {
+  const now = options.now ?? Date.now;
+  const warningIntervalMs = options.warningIntervalMs ?? untrustedForwardingWarningIntervalMs;
+  const warn = options.warn ?? console.warn;
+  let nextWarningAt = Number.NEGATIVE_INFINITY;
+
+  return (peerAddress, forwardedFor, trustedProxy) => {
+    const peer = normalizeIPAddress(peerAddress);
+    if (trustedProxy || !forwardedFor?.trim() || isIP(peer) === 0) return false;
+    const currentTime = now();
+    if (currentTime < nextWarningAt) return false;
+    nextWarningAt = currentTime + warningIntervalMs;
+    try {
+      warn(
+        `crabbox coordinator received X-Forwarded-For from untrusted peer ${peer}; reverse proxy trust may be misconfigured; configure CRABBOX_TRUSTED_PROXY_CIDRS`,
+      );
+    } catch {
+      // Diagnostics must never affect request handling.
+    }
+    return true;
+  };
 }
 
 export function requestSourceIP(
@@ -175,6 +199,38 @@ function normalizeIPAddress(address: string | undefined): string {
   const value = address?.trim() ?? "";
   const mappedIPv4 = /^::ffff:(\d+\.\d+\.\d+\.\d+)$/i.exec(value);
   return mappedIPv4?.[1] ?? value;
+}
+
+function trustedProxyBlockList(configuredCIDRs: string): BlockList {
+  const blockList = new BlockList();
+  for (const rawEntry of configuredCIDRs.split(",")) {
+    const entry = rawEntry.trim();
+    try {
+      if (!entry) throw new Error("empty entry");
+      const separator = entry.lastIndexOf("/");
+      const subnet = normalizeIPAddress(separator === -1 ? entry : entry.slice(0, separator));
+      const subnetFamily = isIP(subnet);
+      if (subnetFamily === 0) throw new Error("invalid address");
+      const type = subnetFamily === 4 ? "ipv4" : "ipv6";
+      if (separator === -1) {
+        blockList.addAddress(subnet, type);
+        continue;
+      }
+      const rawPrefix = entry.slice(separator + 1);
+      if (!/^\d+$/u.test(rawPrefix)) throw new Error("invalid prefix");
+      const prefix = Number(rawPrefix);
+      const maxPrefix = subnetFamily === 4 ? 32 : 128;
+      if (!Number.isInteger(prefix) || prefix < 0 || prefix > maxPrefix) {
+        throw new Error("invalid prefix");
+      }
+      blockList.addSubnet(subnet, prefix, type);
+    } catch {
+      throw new Error(
+        `CRABBOX_TRUSTED_PROXY_CIDRS contains invalid entry ${JSON.stringify(entry || "<empty>")}`,
+      );
+    }
+  }
+  return blockList;
 }
 
 export async function readNodeRequestBody(

--- a/worker/node/server.ts
+++ b/worker/node/server.ts
@@ -17,6 +17,7 @@ import {
   AsyncOperationTracker,
   RequestBodyTooLargeError,
   closeServer,
+  createUntrustedForwardingDiagnostic,
   drainAndStop,
   fleetRequestQueue,
   isReadinessRequestMethod,
@@ -29,13 +30,15 @@ import {
   settlesWithin,
   shouldReadUnauthenticatedRequestBody,
   unauthenticatedRequestBodyBytes,
+  validateTrustedProxyCIDRs,
   writeNodeResponseBody,
 } from "./server-support";
 
+const env = nodeCoordinatorEnv(process.env);
+validateTrustedProxyCIDRs(env.CRABBOX_TRUSTED_PROXY_CIDRS);
 const databaseURL = requiredEnv("DATABASE_URL");
 const port = positiveInt(process.env["PORT"], 8080);
 const shutdownTimeoutMs = positiveInt(process.env["CRABBOX_SHUTDOWN_TIMEOUT_MS"], 120_000);
-const env = nodeCoordinatorEnv(process.env);
 const awsDeployment = createAWSDeploymentGuard(env);
 const runtime = new NodeCoordinatorRuntime(databaseURL);
 const coordinator = new FleetCoordinator(runtime, env);
@@ -43,6 +46,7 @@ const lifecycleMutex = new AsyncMutex();
 const activeRequests = new AsyncOperationTracker();
 const publicDirectory = resolve(fileURLToPath(new NodeURL("../public", import.meta.url)));
 let shutdownPromise: Promise<void> | undefined;
+const diagnoseUntrustedForwarding = createUntrustedForwardingDiagnostic();
 
 runtime.setOperationRunner((callback) => lifecycleMutex.run(callback));
 await awsDeployment.start();
@@ -231,13 +235,12 @@ interface NodeRequestContext {
 function nodeRequestContext(request: IncomingMessage): NodeRequestContext {
   const configuredCIDRs = env.CRABBOX_TRUSTED_PROXY_CIDRS;
   const peerAddress = request.socket.remoteAddress;
+  const forwardedFor = joinedHeader(request.headers["x-forwarded-for"]);
+  const trustedProxy = isTrustedProxySource(peerAddress, configuredCIDRs);
+  diagnoseUntrustedForwarding(peerAddress, forwardedFor, trustedProxy);
   return {
-    sourceIP: requestSourceIP(
-      peerAddress,
-      joinedHeader(request.headers["x-forwarded-for"]),
-      configuredCIDRs,
-    ),
-    trustedProxy: isTrustedProxySource(peerAddress, configuredCIDRs),
+    sourceIP: requestSourceIP(peerAddress, forwardedFor, configuredCIDRs),
+    trustedProxy,
   };
 }
 

--- a/worker/test/node-build.test.ts
+++ b/worker/test/node-build.test.ts
@@ -30,18 +30,32 @@ describe("Node production bundle", () => {
       expect(result.code).not.toBe(0);
       expect(result.stderr).toContain("DATABASE_URL is required");
       expect(result.stderr).not.toContain("Named export");
+
+      const invalidProxy = await runNode(outfile, {
+        CRABBOX_TRUSTED_PROXY_CIDRS: "127.0.0.1,bad-cidr,10.0.0.0/8",
+        DATABASE_URL: "postgres://coordinator.test/crabbox",
+      });
+      expect(invalidProxy.code).not.toBe(0);
+      expect(invalidProxy.stderr).toContain(
+        'CRABBOX_TRUSTED_PROXY_CIDRS contains invalid entry "bad-cidr"',
+      );
     } finally {
       await rm(outputDirectory, { recursive: true, force: true });
     }
   });
 });
 
-async function runNode(entrypoint: string): Promise<{
+async function runNode(
+  entrypoint: string,
+  overrides: Record<string, string> = {},
+): Promise<{
   code: number | null;
   stderr: string;
 }> {
   const env = { ...process.env };
   delete env.DATABASE_URL;
+  delete env.CRABBOX_TRUSTED_PROXY_CIDRS;
+  Object.assign(env, overrides);
 
   return await new Promise((resolve, reject) => {
     const child = spawn(process.execPath, [entrypoint], { env });

--- a/worker/test/server-support.test.ts
+++ b/worker/test/server-support.test.ts
@@ -9,6 +9,7 @@ import {
   AsyncOperationTracker,
   RequestBodyTooLargeError,
   closeServer,
+  createUntrustedForwardingDiagnostic,
   drainAndStop,
   authenticatedRequestBodyBytes,
   fleetRequestQueue,
@@ -23,6 +24,7 @@ import {
   settlesWithin,
   shouldReadUnauthenticatedRequestBody,
   unauthenticatedRequestBodyBytes,
+  validateTrustedProxyCIDRs,
   writeNodeResponseBody,
 } from "../node/server-support";
 import { runtimeAdapterRelayBodyLimit } from "../src/runtime-adapter-relay";
@@ -192,6 +194,60 @@ describe("Node server support", () => {
     expect(isTrustedProxySource("192.0.2.10", ranges)).toBe(false);
     expect(isTrustedProxySource("10.4.5.6", undefined)).toBe(false);
     expect(isTrustedProxySource("10.4.5.6", "invalid,10.0.0.0/8")).toBe(false);
+  });
+
+  it("fails startup validation on the exact invalid trusted-proxy entry", () => {
+    expect(() => validateTrustedProxyCIDRs("127.0.0.1,broken,10.0.0.0/8")).toThrow(
+      'CRABBOX_TRUSTED_PROXY_CIDRS contains invalid entry "broken"',
+    );
+    expect(() => validateTrustedProxyCIDRs("10.0.0.0/33")).toThrow(
+      'CRABBOX_TRUSTED_PROXY_CIDRS contains invalid entry "10.0.0.0/33"',
+    );
+    expect(() => validateTrustedProxyCIDRs("127.0.0.1,,10.0.0.0/8")).toThrow(
+      'CRABBOX_TRUSTED_PROXY_CIDRS contains invalid entry "<empty>"',
+    );
+    for (const entry of ["10.0.0.1/", "10.0.0.1/0x0", "2001:db8::1/"]) {
+      expect(() => validateTrustedProxyCIDRs(entry)).toThrow(
+        `CRABBOX_TRUSTED_PROXY_CIDRS contains invalid entry ${JSON.stringify(entry)}`,
+      );
+    }
+  });
+
+  it("accepts valid trusted-proxy addresses and CIDRs at startup", () => {
+    expect(() => validateTrustedProxyCIDRs("127.0.0.1,10.0.0.0/8,2001:db8::/32")).not.toThrow();
+    expect(() => validateTrustedProxyCIDRs(undefined)).not.toThrow();
+    expect(() => validateTrustedProxyCIDRs("")).not.toThrow();
+    expect(() => validateTrustedProxyCIDRs("   ")).not.toThrow();
+  });
+
+  it("rate-limits untrusted forwarded-header diagnostics", () => {
+    let now = 1_000;
+    const warn = vi.fn<(message: string) => void>();
+    const diagnose = createUntrustedForwardingDiagnostic({
+      now: () => now,
+      warningIntervalMs: 60_000,
+      warn,
+    });
+
+    expect(diagnose("192.0.2.10", "198.51.100.8", false)).toBe(true);
+    expect(diagnose("192.0.2.10", "198.51.100.9", false)).toBe(false);
+    now += 59_999;
+    expect(diagnose("192.0.2.11", "198.51.100.10", false)).toBe(false);
+    now += 1;
+    expect(diagnose("192.0.2.11", "198.51.100.10", false)).toBe(true);
+    expect(warn).toHaveBeenCalledTimes(2);
+    expect(warn).toHaveBeenCalledWith(
+      "crabbox coordinator received X-Forwarded-For from untrusted peer 192.0.2.10; reverse proxy trust may be misconfigured; configure CRABBOX_TRUSTED_PROXY_CIDRS",
+    );
+  });
+
+  it("keeps trusted peers and requests without forwarding evidence silent", () => {
+    const warn = vi.fn<(message: string) => void>();
+    const diagnose = createUntrustedForwardingDiagnostic({ warn });
+
+    expect(diagnose("10.0.0.2", "198.51.100.8", true)).toBe(false);
+    expect(diagnose("192.0.2.10", undefined, false)).toBe(false);
+    expect(warn).not.toHaveBeenCalled();
   });
 
   it("derives caller IPs from sockets and trusted proxy chains", () => {


### PR DESCRIPTION
## Summary

- validate every configured Node trusted-proxy address or CIDR before runtime startup and fail with the exact invalid entry
- emit one global rate-limited warning when an untrusted socket peer sends `X-Forwarded-For`, without blocking or changing the request
- document the Node reverse-proxy startup and diagnostic behavior

## Scope and severity

The existing OAuth admission caps remain intentionally unchanged: `maxPendingOAuthLogins=100` and `maxPendingOAuthLoginsPerSource=10`. The pending-source hashing path is also unchanged. These controls continue to prevent pending-state exhaustion as designed in https://github.com/openclaw/crabbox/pull/997.

This patch only makes a silent Node reverse-proxy trust misconfiguration visible and rejects malformed allowlists instead of silently treating them as untrusted. Correctly configured Node deployments and the Cloudflare Worker runtime retain their existing behavior.

Severity: **Medium / availability**, not P1. No confidentiality or integrity impact is introduced or claimed.

Fixes https://github.com/openclaw/crabbox/issues/1008

## Verification

- `npm run check --prefix worker`
- `npm run check:node --prefix worker`
- `npm run lint --prefix worker`
- `npm test --prefix worker` — 34 files passed, 2 skipped; 1,059 tests passed, 3 skipped
- `npm run format:check --prefix worker`
- autoreview clean with no accepted or actionable findings
