### PR TITLE
docs(cli): document egress daemon cutover ordering constraint

### DIFF
--- a/internal/cli/egress.go
+++ b/internal/cli/egress.go
@@ -272,6 +272,14 @@ func (a App) prepareEgressClientCutover(ctx context.Context, coord *CoordinatorC
 		return CoordinatorEgressTicket{}, err
 	}
 	if daemon {
+		// Stop the old host daemon before the new session activates (the remote
+		// client start in egressStart). The coordinator keeps one active egress
+		// session per lease, and the old supervisor restarts its host on any
+		// non-fatal exit, so a still-running old daemon would reconnect its
+		// prior session and clobber the replacement mid-cutover. The brief
+		// no-daemon window until the new host starts is the accepted tradeoff;
+		// the stop stays after ticket minting so preflight failures preserve
+		// the working daemon.
 		if stopped, err := a.stopEgressHostDaemonLocked(leaseID); err != nil {
 			return CoordinatorEgressTicket{}, err
 		} else if stopped {


### PR DESCRIPTION
## Summary

Comment-only follow-up to https://github.com/openclaw/crabbox/pull/1103. The maintainer review comment (https://github.com/openclaw/crabbox/pull/1103#issuecomment-4995563050) asked whether the earlier host-daemon stop in `prepareEgressClientCutover` widens the no-daemon window intentionally. It does — the coordinator keeps one active egress session per lease and the old supervisor auto-restarts its host, so a still-running old daemon reconnects its prior session and clobbers the replacement mid-cutover (the live bug #1103 fixed). This documents that ordering constraint at the stop site so it does not get re-flagged.

No behavior change.

## Verification

- `go vet ./internal/cli/`
- `go test ./internal/cli/ -run 'TestPrepareEgressClientCutover|TestEgressDaemon' -count=1`
