### PR TITLE
ci: isolate Homebrew public witnesses

### DIFF
--- a/.github/workflows/verify-homebrew.yml
+++ b/.github/workflows/verify-homebrew.yml
@@ -94,9 +94,43 @@ jobs:
             .path == ".github/workflows/release-assets.yml" and .state == "active"
           ' "$work/workflow.json" >/dev/null
 
+  public-witness-preflight:
+    name: freeze-anonymous-public-witness
+    needs: guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out protected Homebrew workflow tooling
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+
+      - name: Freeze anonymous public metadata before native execution
+        shell: bash
+        env:
+          RELEASE_ID: ${{ inputs.release_id }}
+          PUBLIC_VERIFIER_RUN_ID: ${{ inputs.public_verifier_run_id }}
+        run: |
+          set -euo pipefail
+          unset ACTIONS_ID_TOKEN_REQUEST_TOKEN ACTIONS_RUNTIME_TOKEN GH_TOKEN GITHUB_TOKEN
+          unset HOMEBREW_GITHUB_API_TOKEN HOMEBREW_TAP_GITHUB_TOKEN
+          scripts/fetch-public-release-witness.sh \
+            "$GITHUB_REPOSITORY" "$RELEASE_ID" "$PUBLIC_VERIFIER_RUN_ID" \
+            "$RUNNER_TEMP/public-witness"
+
+      - name: Freeze public witness for native jobs
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: homebrew-public-witness-${{ github.run_id }}
+          path: ${{ runner.temp }}/public-witness
+          if-no-files-found: error
+          overwrite: true
+          retention-days: 30
+
   verify:
     name: verify-${{ matrix.arch }}
-    needs: guard
+    needs: public-witness-preflight
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     strategy:
@@ -122,6 +156,12 @@ jobs:
           go-version-file: go.mod
           cache: false
 
+      - name: Download frozen anonymous public witness
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: homebrew-public-witness-${{ github.run_id }}
+          path: ${{ runner.temp }}/public-witness
+
       - name: Preserve pinned release tools in the frozen verifier path
         shell: bash
         run: |
@@ -131,23 +171,37 @@ jobs:
           brew_path=$(command -v brew)
           curl_path=$(command -v curl)
           printf '%s\n' '#!/bin/bash' "exec \"$brew_path\" \"\$@\"" >"$tools/brew"
-          # Frozen verifier traffic is public GET-only. Retry shared-runner
-          # throttling without adding credentials or weakening either read.
-          # Stage stdout so a retry cannot append to redirected partial JSON.
+          # Native verification consumes this witness before any candidate
+          # execution. A separate clean job owns every post-candidate read.
           {
             printf '%s\n' '#!/bin/bash' 'set -euo pipefail'
             printf 'curl_bin=%q\n' "$curl_path"
             cat <<'CURL_WRAPPER'
-          retry=(--retry-all-errors --retry 60 --retry-delay 15 --retry-max-time 900)
+          public_url=
           for arg in "$@"; do
             case "$arg" in
-              -o|--output|--output=*) exec "$curl_bin" "$@" "${retry[@]}" ;;
+              https://api.github.com/*) public_url=$arg ;;
             esac
           done
-          output=$(mktemp "${TMPDIR:-/tmp}/crabbox-curl.XXXXXX")
-          trap 'rm -f "$output"' EXIT
-          "$curl_bin" "$@" "${retry[@]}" --output "$output"
-          cat "$output"
+          if [[ -n "$public_url" && -n "${CRABBOX_PUBLIC_WITNESS_DIR:-}" ]]; then
+            witness=$CRABBOX_PUBLIC_WITNESS_DIR
+            [[ -d "$witness" && ! -L "$witness" ]]
+            (cd "$witness" && shasum -a 256 -c manifest.sha256 >/dev/null)
+            workflow_id=$(jq -er '.workflow_id | select(type == "number" and . > 0)' \
+              "$witness/run.json")
+            base="https://api.github.com/repos/$GITHUB_REPOSITORY"
+            case "$public_url" in
+              "$base/releases/$RELEASE_ID") witness_file=release.json ;;
+              "$base/actions/runs/$PUBLIC_VERIFIER_RUN_ID") witness_file=run.json ;;
+              "$base/actions/workflows/$workflow_id") witness_file=workflow.json ;;
+              "$base/actions/runs/$PUBLIC_VERIFIER_RUN_ID/artifacts?per_page=100") \
+                witness_file=artifacts.json ;;
+              *) echo "unexpected public witness URL: $public_url" >&2; exit 1 ;;
+            esac
+            cat "$witness/$witness_file"
+            exit 0
+          fi
+          exec "$curl_bin" "$@"
           CURL_WRAPPER
           } >"$tools/curl"
           chmod 700 "$tools/brew" "$tools/curl"
@@ -207,6 +261,8 @@ jobs:
       - name: Verify public Homebrew install without credentials
         shell: bash
         env:
+          CRABBOX_HOMEBREW_EXTERNAL_PUBLIC_POSTFLIGHT: "1"
+          CRABBOX_PUBLIC_WITNESS_DIR: ${{ runner.temp }}/public-witness
           RELEASE_ID: ${{ inputs.release_id }}
           RELEASE_TAG: ${{ inputs.tag }}
           SOURCE_COMMIT: ${{ inputs.source_commit }}
@@ -222,3 +278,38 @@ jobs:
             "$RELEASE_TAG" "$RUNNER_TEMP/release-assets" \
             "$TAG_OBJECT" "$SOURCE_COMMIT" "$VERIFIER_COMMIT" \
             "$RELEASE_ID" "$PUBLIC_VERIFIER_RUN_ID" "$RUNNER_TEMP/public-proofs"
+
+  public-witness-postflight:
+    name: confirm-anonymous-public-witness
+    needs: verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out protected Homebrew workflow tooling
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+
+      - name: Download preflight public witness
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: homebrew-public-witness-${{ github.run_id }}
+          path: ${{ runner.temp }}/public-witness-preflight
+
+      - name: Confirm anonymous public metadata after native execution
+        shell: bash
+        env:
+          RELEASE_ID: ${{ inputs.release_id }}
+          PUBLIC_VERIFIER_RUN_ID: ${{ inputs.public_verifier_run_id }}
+        run: |
+          set -euo pipefail
+          unset ACTIONS_ID_TOKEN_REQUEST_TOKEN ACTIONS_RUNTIME_TOKEN GH_TOKEN GITHUB_TOKEN
+          unset HOMEBREW_GITHUB_API_TOKEN HOMEBREW_TAP_GITHUB_TOKEN
+          scripts/fetch-public-release-witness.sh \
+            "$GITHUB_REPOSITORY" "$RELEASE_ID" "$PUBLIC_VERIFIER_RUN_ID" \
+            "$RUNNER_TEMP/public-witness-postflight"
+          for name in artifacts.json release.json run.json workflow.json manifest.sha256; do
+            cmp "$RUNNER_TEMP/public-witness-preflight/$name" \
+              "$RUNNER_TEMP/public-witness-postflight/$name"
+          done

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -415,6 +415,18 @@ lower-level `codesign-macos.sh`, `extract-release-notes.sh`,
 operator commands above and must not be reordered or invoked as substitute
 gates.
 
+The hosted `Verify Homebrew Release` workflow preserves the same anonymous
+public-record boundary without depending on a rate-limited native-runner IP. A
+credential-free Linux preflight freezes the public release, verifier run,
+workflow, and artifact metadata before either native job starts. Each native
+job validates that digest-pinned witness before any candidate execution, then
+performs no post-candidate read from its candidate-writable filesystem. A
+separate credential-free Linux postflight owns the post-candidate boundary: it
+repeats the anonymous reads after both native jobs and requires byte-for-byte
+equality of the security-relevant record with the preflight witness. Mutable
+download telemetry is excluded because verification itself downloads every
+asset.
+
 ## Serialized Gates
 
 ### 1. Create the private draft

--- a/scripts/fetch-public-release-witness.sh
+++ b/scripts/fetch-public-release-witness.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 <owner/repository> <release-id> <public-verifier-run-id> <output-dir>" >&2
+  exit 2
+}
+
+[[ $# -eq 4 ]] || usage
+repository=$1
+release_id=$2
+run_id=$3
+output_dir=$4
+
+[[ "$repository" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || usage
+[[ "$release_id" =~ ^[1-9][0-9]*$ && "$run_id" =~ ^[1-9][0-9]*$ ]] || usage
+[[ ! -e "$output_dir" && ! -L "$output_dir" ]] || {
+  echo "public witness output must not already exist" >&2
+  exit 1
+}
+
+for credential in GH_TOKEN GITHUB_TOKEN HOMEBREW_GITHUB_API_TOKEN HOMEBREW_TAP_GITHUB_TOKEN; do
+  [[ -z "${!credential:-}" ]] || {
+    echo "public witness fetch must not receive $credential" >&2
+    exit 1
+  }
+done
+
+umask 077
+mkdir -m 700 "$output_dir"
+complete=0
+cleanup() {
+  if [[ "$complete" != 1 ]]; then
+    rm -rf "$output_dir"
+  fi
+}
+trap cleanup EXIT
+
+fetch_json() {
+  local path=$1 name=$2 raw
+  raw="$output_dir/.$name.raw"
+  curl --fail --silent --show-error --location \
+    --retry-all-errors --retry 6 --retry-delay 10 --retry-max-time 120 \
+    --header 'Accept: application/vnd.github+json' \
+    --header 'X-GitHub-Api-Version: 2026-03-10' \
+    --output "$raw" "https://api.github.com/$path"
+  case "$name" in
+    release.json)
+      jq -eS '
+        select(type == "object") |
+        {
+          id, tag_name, target_commitish, name, draft, immutable, prerelease,
+          created_at, updated_at, published_at, body,
+          assets: ([.assets[] | {
+            id, name, size, state, digest, updated_at, url
+          }] | sort_by(.name))
+        }
+      ' "$raw" >"$output_dir/$name"
+      ;;
+    run.json)
+      jq -eS '
+        select(type == "object") |
+        {
+          id, name, display_title, path, event, status, conclusion,
+          head_branch, head_sha, workflow_id, workflow_url, run_attempt,
+          created_at, run_started_at,
+          repository: {full_name: .repository.full_name},
+          head_repository: {full_name: .head_repository.full_name},
+          head_commit: {id: .head_commit.id}
+        }
+      ' "$raw" >"$output_dir/$name"
+      ;;
+    workflow.json)
+      jq -eS '
+        select(type == "object") | {id, name, path, state, url}
+      ' "$raw" >"$output_dir/$name"
+      ;;
+    artifacts.json)
+      jq -eS '
+        select(type == "object") |
+        {
+          total_count,
+          artifacts: ([.artifacts[] | {
+            id, name, size_in_bytes, expired, digest, created_at, updated_at,
+            workflow_run: {
+              id: .workflow_run.id,
+              head_branch: .workflow_run.head_branch,
+              head_sha: .workflow_run.head_sha
+            }
+          }] | sort_by(.name))
+        }
+      ' "$raw" >"$output_dir/$name"
+      ;;
+    *)
+      echo "unexpected public witness file: $name" >&2
+      return 1
+      ;;
+  esac
+  rm -f "$raw"
+}
+
+fetch_json "repos/$repository/releases/$release_id" release.json
+fetch_json "repos/$repository/actions/runs/$run_id" run.json
+workflow_id=$(jq -er '.workflow_id | select(type == "number" and . > 0)' "$output_dir/run.json")
+fetch_json "repos/$repository/actions/workflows/$workflow_id" workflow.json
+fetch_json "repos/$repository/actions/runs/$run_id/artifacts?per_page=100" artifacts.json
+
+(
+  cd "$output_dir"
+  for name in artifacts.json release.json run.json workflow.json; do
+    shasum -a 256 "$name"
+  done >manifest.sha256
+)
+
+complete=1
+trap - EXIT

--- a/scripts/release-workflow.test.js
+++ b/scripts/release-workflow.test.js
@@ -94,14 +94,18 @@ test("Homebrew verifier keeps downloaded proof inputs outside the protected chec
   assert.match(workflow, /brew_path=\$\(command -v brew\)/);
   assert.match(workflow, /curl_path=\$\(command -v curl\)/);
   assert.match(workflow, /exec \\\"\$brew_path\\\" \\\"\\\$@\\\"/);
-  assert.match(
-    workflow,
-    /retry=\(--retry-all-errors --retry 60 --retry-delay 15 --retry-max-time 900\)/,
-  );
-  assert.match(workflow, /-o\|--output\|--output=\*\) exec "\$curl_bin" "\$@" "\$\{retry\[@\]\}"/);
-  assert.match(workflow, /output=\$\(mktemp "\$\{TMPDIR:-\/tmp\}\/crabbox-curl\.XXXXXX"\)/);
-  assert.match(workflow, /"\$curl_bin" "\$@" "\$\{retry\[@\]\}" --output "\$output"/);
-  assert.match(workflow, /cat "\$output"/);
+  assert.match(workflow, /name: freeze-anonymous-public-witness/);
+  assert.match(workflow, /name: confirm-anonymous-public-witness/);
+  assert.match(workflow, /public-witness-preflight:[\s\S]*needs: guard/);
+  assert.match(workflow, /verify:[\s\S]*needs: public-witness-preflight/);
+  assert.match(workflow, /public-witness-postflight:[\s\S]*needs: verify/);
+  assert.match(workflow, /scripts\/fetch-public-release-witness\.sh/g);
+  assert.match(workflow, /homebrew-public-witness-\$\{\{ github\.run_id \}\}/);
+  assert.match(workflow, /CRABBOX_PUBLIC_WITNESS_DIR: \$\{\{ runner\.temp \}\}\/public-witness/);
+  assert.match(workflow, /CRABBOX_HOMEBREW_EXTERNAL_PUBLIC_POSTFLIGHT: "1"/);
+  assert.match(workflow, /shasum -a 256 -c manifest\.sha256/);
+  assert.match(workflow, /unexpected public witness URL/);
+  assert.match(workflow, /exec "\$curl_bin" "\$@"/);
   assert.doesNotMatch(toolsStep, /Authorization|GH_TOKEN|GITHUB_TOKEN/);
   assert.match(workflow, /chmod 700 "\$tools\/brew" "\$tools\/curl"/);
   assert.match(workflow, /ln -s "\$\(command -v go\)" "\$tools\/go"/);
@@ -119,6 +123,32 @@ test("Homebrew verifier keeps downloaded proof inputs outside the protected chec
   assert.doesNotMatch(workflow, /mkdir -m 700 (?:release-assets|public-proofs)/);
   assert.match(verifyStep, /unset ACTIONS_ID_TOKEN_REQUEST_TOKEN ACTIONS_RUNTIME_TOKEN GH_TOKEN GITHUB_TOKEN/);
   assert.match(verifyStep, /unset HOMEBREW_GITHUB_API_TOKEN HOMEBREW_TAP_GITHUB_TOKEN/);
+  assert.equal(
+    (workflow.match(/unset ACTIONS_ID_TOKEN_REQUEST_TOKEN ACTIONS_RUNTIME_TOKEN GH_TOKEN GITHUB_TOKEN/g) ?? [])
+      .length,
+    3,
+  );
+  assert.match(
+    workflow,
+    /for name in artifacts\.json release\.json run\.json workflow\.json manifest\.sha256; do[\s\S]*cmp/,
+  );
+  const homebrewVerifier = read("scripts/verify-homebrew-release.sh");
+  assert.match(homebrewVerifier, /external public postflight requires the protected Homebrew workflow/);
+  assert.equal(
+    (homebrewVerifier.match(/freeze_public_release \\\n/g) ?? []).length,
+    2,
+    "local verification must retain independent public preflight and postflight reads",
+  );
+  assert.match(
+    homebrewVerifier,
+    /if \[\[ "\$\{CRABBOX_HOMEBREW_EXTERNAL_PUBLIC_POSTFLIGHT:-\}" == 1 \]\]; then[\s\S]*Never re-read candidate-writable witness files after candidate execution[\s\S]*return 0/,
+  );
+  assert.doesNotMatch(read("scripts/fetch-public-release-witness.sh"), /Authorization|GH_TOKEN=/);
+  assert.notEqual(
+    fs.statSync(path.join(repoRoot, "scripts/fetch-public-release-witness.sh")).mode & 0o111,
+    0,
+    "public witness fetcher must be executable",
+  );
   assert.match(verifyStep, /HOMEBREW_NO_AUTO_UPDATE=1 brew tap openclaw\/tap/);
   assert.ok(
     verifyStep.indexOf("unset HOMEBREW_GITHUB_API_TOKEN HOMEBREW_TAP_GITHUB_TOKEN") <
@@ -128,6 +158,108 @@ test("Homebrew verifier keeps downloaded proof inputs outside the protected chec
     verifyStep.indexOf("HOMEBREW_NO_AUTO_UPDATE=1 brew tap openclaw/tap") <
       verifyStep.indexOf("scripts/verify-homebrew-release.sh"),
   );
+});
+
+test("public witness fetcher freezes canonical metadata without API credentials", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-public-witness-"));
+  try {
+    const bin = path.join(root, "bin");
+    const witness = path.join(root, "witness");
+    fs.mkdirSync(bin);
+    const curl = path.join(bin, "curl");
+    fs.writeFileSync(
+      curl,
+      `#!/usr/bin/env bash
+set -euo pipefail
+output=
+url=
+while ((\$#)); do
+  case \$1 in
+    --output) output=\$2; shift 2 ;;
+    https://*) url=\$1; shift ;;
+    *) shift ;;
+  esac
+done
+case \$url in
+  */releases/355) body='{"tag_name":"v0.38.4","id":355,"reactions":{"total_count":2},"assets":[{"id":1,"name":"checksums.txt","download_count":9}]}' ;;
+  */actions/runs/44) body='{"workflow_id":77,"id":44}' ;;
+  */actions/workflows/77) body='{"path":".github/workflows/release-assets.yml","id":77}' ;;
+  */actions/runs/44/artifacts?per_page=100) body='{"total_count":0,"artifacts":[]}' ;;
+  *) exit 64 ;;
+esac
+printf '%s\\n' "\$body" >"\$output"
+`,
+    );
+    fs.chmodSync(curl, 0o755);
+    const env = { ...process.env, PATH: `${bin}:${process.env.PATH}` };
+    for (const name of [
+      "GH_TOKEN",
+      "GITHUB_TOKEN",
+      "HOMEBREW_GITHUB_API_TOKEN",
+      "HOMEBREW_TAP_GITHUB_TOKEN",
+    ]) {
+      delete env[name];
+    }
+    const script = path.join(repoRoot, "scripts/fetch-public-release-witness.sh");
+    const result = spawnSync(
+      "bash",
+      [script, "openclaw/crabbox", "355", "44", witness],
+      { cwd: repoRoot, env, encoding: "utf8" },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    const release = JSON.parse(fs.readFileSync(path.join(witness, "release.json")));
+    assert.equal(release.id, 355);
+    assert.equal(release.tag_name, "v0.38.4");
+    assert.equal(release.assets[0].id, 1);
+    assert.equal(release.assets[0].name, "checksums.txt");
+    assert.equal("download_count" in release.assets[0], false);
+    assert.equal("reactions" in release, false);
+    const run = JSON.parse(fs.readFileSync(path.join(witness, "run.json")));
+    assert.equal(run.id, 44);
+    assert.equal(run.workflow_id, 77);
+    execFileSync("shasum", ["-a", "256", "-c", "manifest.sha256"], {
+      cwd: witness,
+      stdio: "ignore",
+    });
+
+    const credentialed = spawnSync(
+      "bash",
+      [script, "openclaw/crabbox", "355", "44", path.join(root, "credentialed")],
+      { cwd: repoRoot, env: { ...env, GITHUB_TOKEN: "present" }, encoding: "utf8" },
+    );
+    assert.notEqual(credentialed.status, 0);
+    assert.match(credentialed.stderr, /must not receive GITHUB_TOKEN/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("external Homebrew postflight mode is bound to the protected workflow", () => {
+  const result = spawnSync(
+    "bash",
+    [
+      path.join(repoRoot, "scripts/verify-homebrew-release.sh"),
+      "v1.2.3",
+      os.tmpdir(),
+      "a".repeat(40),
+      "b".repeat(40),
+      "c".repeat(40),
+      "1",
+      "2",
+      os.tmpdir(),
+    ],
+    {
+      cwd: repoRoot,
+      env: {
+        HOME: process.env.HOME,
+        PATH: process.env.PATH,
+        CRABBOX_HOMEBREW_EXTERNAL_PUBLIC_POSTFLIGHT: "1",
+      },
+      encoding: "utf8",
+    },
+  );
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /external public postflight requires the protected Homebrew workflow/);
 });
 
 test("script CI fetches signed release tags for publication fixtures", () => {

--- a/scripts/verify-homebrew-release.sh
+++ b/scripts/verify-homebrew-release.sh
@@ -597,6 +597,20 @@ main() {
   local native_arch brew_bin node_bin go_bin work clean_path user_name homebrew_home homebrew_cache source_asset_dir
   validate_release_identity "$tag" "$tag_object" "$source_commit" "$verifier_commit"
   assert_no_downstream_credentials
+  case "${CRABBOX_HOMEBREW_EXTERNAL_PUBLIC_POSTFLIGHT:-}" in
+    "") ;;
+    1)
+      [[ "${GITHUB_ACTIONS:-}" == true &&
+        "${GITHUB_WORKFLOW_REF:-}" == "$CRABBOX_RELEASE_REPOSITORY/.github/workflows/verify-homebrew.yml@refs/heads/$CRABBOX_RELEASE_DEFAULT_BRANCH" ]] || {
+        echo "external public postflight requires the protected Homebrew workflow" >&2
+        exit 1
+      }
+      ;;
+    *)
+      echo "invalid external public postflight mode" >&2
+      exit 1
+      ;;
+  esac
   [[ "$(uname -s)" == Darwin ]] || {
     echo "downstream Homebrew verification must run natively on macOS" >&2
     exit 1
@@ -662,10 +676,16 @@ main() {
       "$tag" "$asset_dir" "$tag_object" "$source_commit" "$verifier_commit" \
       "$native_arch" "$brew_bin" "$node_bin" "$work"
 
+  require_protected_homebrew_tooling "$verifier_commit" "$tag"
+  if [[ "${CRABBOX_HOMEBREW_EXTERNAL_PUBLIC_POSTFLIGHT:-}" == 1 ]]; then
+    # The protected hosted workflow closes this boundary in a clean Linux job.
+    # Never re-read candidate-writable witness files after candidate execution.
+    return 0
+  fi
+
   # Close the downstream verification window with a fresh unauthenticated read.
   # A concurrent release, run, artifact, proof, or public-byte change is an
   # incident and must invalidate this host's proof rather than silently pass.
-  require_protected_homebrew_tooling "$verifier_commit" "$tag"
   mkdir -m 700 "$work/public-postflight"
   freeze_public_release \
     "$tag" "$source_asset_dir" "$tag_object" "$source_commit" "$verifier_commit" \


### PR DESCRIPTION
## Summary

- freeze a canonical credential-free public release witness in a clean Linux preflight
- validate the frozen witness before either native candidate executes
- move every post-candidate public read into a separate clean Linux postflight
- compare the security-relevant public record before and after both native runs while excluding mutable download telemetry

## Why

The 0.38.4 Homebrew verifier proved Intel successfully, but the arm64 shared runner exhausted its anonymous GitHub API quota even after the bounded retry: https://github.com/openclaw/crabbox/actions/runs/29526548887. A fresh arm64 rerun received the same public 403 immediately. Native verification must stay credential-free, so this moves the rate-limited public metadata reads to isolated Linux jobs without weakening the candidate boundary.

## Verification

- `node --test scripts/release-workflow.test.js scripts/homebrew-release.test.js` (39/39)
- `actionlint .github/workflows/verify-homebrew.yml`
- `shellcheck scripts/fetch-public-release-witness.sh`
- `shellcheck -x scripts/verify-homebrew-release.sh`
- `node scripts/build-docs-site.mjs`
- live anonymous witness fetch for release `355178161` and verifier run `29511083328`; manifest and exact eight-asset inventory verified
- autoreview clean at exact branch head (0.91)
