### PR TITLE
fix(worker): don't discard buffered foreground output when the drain cap expires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Preserved foreground container-runner output buffered behind slow HTTP clients when the detached-descendant drain cap expires.
 - Delivered server-first mediated-egress bytes after the local proxy handshake without letting one slow stream block unrelated connections. Thanks @anagnorisis2peripeteia.
 - Serialized complete per-lease egress host-daemon starts and stops and atomically replaced the remote client, preventing concurrent lifecycle commands and ordinary restarts from leaving untracked or stale processes. Thanks @anagnorisis2peripeteia.
 - Closed code-server WebSockets whose upstream dial completes after bridge shutdown, preventing orphaned connections and reader goroutines. Thanks @anagnorisis2peripeteia.

--- a/worker/azure-dynamic-sessions.Dockerfile
+++ b/worker/azure-dynamic-sessions.Dockerfile
@@ -3,7 +3,7 @@ FROM --platform=$BUILDPLATFORM mcr.microsoft.com/devcontainers/go:1.26-bookworm@
 ARG TARGETOS=linux
 ARG TARGETARCH
 WORKDIR /src
-COPY cloudflare-container-runner/go.mod cloudflare-container-runner/main.go ./
+COPY cloudflare-container-runner/go.mod cloudflare-container-runner/*.go ./
 RUN target_arch="${TARGETARCH:-$(go env GOARCH)}" \
   && CGO_ENABLED=0 GOOS=$TARGETOS GOARCH="$target_arch" go build -trimpath -ldflags="-s -w" -o /out/crabbox-container-runner .
 

--- a/worker/cloudflare-container-runner/main.go
+++ b/worker/cloudflare-container-runner/main.go
@@ -24,6 +24,7 @@ import (
 const minStreamLifetime = 75 * time.Millisecond
 const finalStreamFlushDelay = 100 * time.Millisecond
 const streamHeartbeatInterval = 15 * time.Second
+const pipeReadPoll = 10 * time.Millisecond
 
 // After the direct child is reaped, a background descendant may have
 // inherited a stdout/stderr write-end (e.g. `sleep 30 & echo done`) and still
@@ -38,12 +39,12 @@ const streamHeartbeatInterval = 15 * time.Second
 //     so genuine trailing output is never cut short.
 //   - pipeDrainPoll is the polling interval used to sample the shared `copied`
 //     byte counter and decide whether progress was made since the last check.
-//   - pipeDrainGrace is an ABSOLUTE CAP on the whole drain phase, in case a
+//   - pipeDrainGrace is an ABSOLUTE CAP on descendant output, in case a
 //     descendant writes continuously (e.g. `(while true; do echo x; done) &`)
-//     and so never goes idle: once this cap elapses (even mid-progress) we
-//     close the read-ends and return anyway. It is the same 5s constant the
-//     bounded-select design used, now acting as a backstop rather than the
-//     primary timer.
+//     and so never goes idle. Before starting the cap, each copier snapshots
+//     and delivers every byte already buffered when it observes the direct
+//     child's exit. The cap can therefore stop new descendant writes without
+//     discarding buffered foreground output.
 //
 // None of this bounds the foreground command's own runtime: runCommand owns
 // the pipe read-ends, so cmd.Wait never closes them, and a long-running
@@ -232,6 +233,22 @@ func runCommand(ctx context.Context, req execRequest, cwd string, writer *eventW
 		_ = wOut.Close()
 		return 0, err
 	}
+	rOutFD := int(rOut.Fd())
+	rErrFD := int(rErr.Fd())
+	if err := syscall.SetNonblock(rOutFD, true); err != nil {
+		_ = rOut.Close()
+		_ = wOut.Close()
+		_ = rErr.Close()
+		_ = wErr.Close()
+		return 0, err
+	}
+	if err := syscall.SetNonblock(rErrFD, true); err != nil {
+		_ = rOut.Close()
+		_ = wOut.Close()
+		_ = rErr.Close()
+		_ = wErr.Close()
+		return 0, err
+	}
 	cmd.Stdout = wOut
 	cmd.Stderr = wErr
 
@@ -275,9 +292,10 @@ func runCommand(ctx context.Context, req execRequest, cwd string, writer *eventW
 	// pipe and close the read-ends mid-write, truncating buffered output.
 	var writesInFlight atomic.Int64
 	var wg sync.WaitGroup
+	foregroundDone := make(chan struct{})
 	wg.Add(2)
-	go copyPipe(&wg, rOut, "stdout", writer, &copied, &writesInFlight)
-	go copyPipe(&wg, rErr, "stderr", writer, &copied, &writesInFlight)
+	go copyPipe(&wg, &interruptiblePipeReader{fd: rOutFD, stop: foregroundDone}, "stdout", writer, &copied, &writesInFlight)
+	go copyPipe(&wg, &interruptiblePipeReader{fd: rErrFD, stop: foregroundDone}, "stderr", writer, &copied, &writesInFlight)
 
 	// Reap the child first. Because we own rOut/rErr, cmd.Wait does NOT close
 	// them, so the copiers keep delivering the child's output for the ENTIRE
@@ -286,6 +304,29 @@ func runCommand(ctx context.Context, req execRequest, cwd string, writer *eventW
 	// bound the command's runtime, only what happens to a lingering descendant
 	// after the direct child has already exited.
 	waitErr := cmd.Wait()
+
+	// Stop the foreground copiers without closing the read-ends. Each copier
+	// finishes any in-flight HTTP write before observing the signal, leaving all
+	// unread bytes intact in the owned kernel pipe.
+	close(foregroundDone)
+	wg.Wait()
+
+	// Snapshot and deliver the bytes buffered at this foreground/descendant
+	// boundary before any absolute timer starts. New descendant writes may land
+	// behind the snapshot, but the finite prefix containing all foreground output
+	// is guaranteed to reach the client.
+	buf := make([]byte, 32*1024)
+	if err := drainBufferedPipe(rOutFD, buf, "stdout", writer, &copied, &writesInFlight); err != nil {
+		return 1, err
+	}
+	if err := drainBufferedPipe(rErrFD, buf, "stderr", writer, &copied, &writesInFlight); err != nil {
+		return 1, err
+	}
+
+	descendantDone := make(chan struct{})
+	wg.Add(2)
+	go copyPipe(&wg, &interruptiblePipeReader{fd: rOutFD, stop: descendantDone}, "stdout", writer, &copied, &writesInFlight)
+	go copyPipe(&wg, &interruptiblePipeReader{fd: rErrFD, stop: descendantDone}, "stderr", writer, &copied, &writesInFlight)
 
 	// The direct child is reaped, but a background descendant may have
 	// inherited a write-end (e.g. `sleep 30 & echo done`) and still hold the
@@ -296,9 +337,9 @@ func runCommand(ctx context.Context, req execRequest, cwd string, writer *eventW
 	// progress for pipeDrainIdle (a quiet/absent descendant — nothing left to
 	// lose), OR the absolute pipeDrainGrace cap elapses (a descendant writing
 	// continuously, e.g. `(while true; do echo x; done) &`, which would
-	// otherwise keep resetting the idle timer forever). Closing the read-ends
-	// forces the blocked copyPipe Reads to return (os.ErrClosed, treated as
-	// benign) so wg.Wait() completes.
+	// otherwise keep resetting the idle timer forever). The copiers use
+	// nonblocking reads, so signaling them first and joining them before closing
+	// the read-ends avoids any read racing a reused file descriptor.
 	drained := make(chan struct{})
 	go func() {
 		wg.Wait()
@@ -325,8 +366,9 @@ drainLoop:
 				idleDeadline = now.Add(pipeDrainIdle)
 			}
 			if now.After(idleDeadline) || now.After(deadline) {
-				closeReaders()
+				close(descendantDone)
 				<-drained
+				closeReaders()
 				break drainLoop
 			}
 		}
@@ -390,12 +432,7 @@ func copyPipe(wg *sync.WaitGroup, reader io.Reader, eventType string, writer *ev
 	for {
 		n, err := reader.Read(buf)
 		if n > 0 {
-			// Mark the write in flight for the whole (potentially blocking)
-			// write so the drain loop never treats a slow flush as an idle pipe.
-			writesInFlight.Add(1)
-			writer.write(streamEvent{Type: eventType, Data: string(buf[:n])})
-			writesInFlight.Add(-1)
-			copied.Add(int64(n))
+			writePipeChunk(buf[:n], eventType, writer, copied, writesInFlight)
 		}
 		if err != nil {
 			if !benignPipeReadError(err) {
@@ -406,8 +443,75 @@ func copyPipe(wg *sync.WaitGroup, reader io.Reader, eventType string, writer *ev
 	}
 }
 
+var errForegroundDrained = errors.New("foreground pipe drain boundary")
+
+type interruptiblePipeReader struct {
+	fd   int
+	stop <-chan struct{}
+}
+
+func (r *interruptiblePipeReader) Read(buf []byte) (int, error) {
+	for {
+		if r.stop != nil {
+			select {
+			case <-r.stop:
+				return 0, errForegroundDrained
+			default:
+			}
+		}
+
+		n, err := syscall.Read(r.fd, buf)
+		if n == 0 && err == nil {
+			return 0, io.EOF
+		}
+		if !errors.Is(err, syscall.EAGAIN) {
+			return n, err
+		}
+		if r.stop == nil {
+			time.Sleep(pipeReadPoll)
+			continue
+		}
+		select {
+		case <-r.stop:
+			return 0, errForegroundDrained
+		case <-time.After(pipeReadPoll):
+		}
+	}
+}
+
+func drainBufferedPipe(fd int, buf []byte, eventType string, writer *eventWriter, copied, writesInFlight *atomic.Int64) error {
+	remaining, err := pipeBufferedBytes(fd)
+	if err != nil {
+		return fmt.Errorf("inspect buffered %s: %w", eventType, err)
+	}
+	for remaining > 0 {
+		chunkSize := min(remaining, len(buf))
+		n, readErr := syscall.Read(fd, buf[:chunkSize])
+		if n > 0 {
+			writePipeChunk(buf[:n], eventType, writer, copied, writesInFlight)
+			remaining -= n
+		}
+		if readErr != nil {
+			return readErr
+		}
+		if n == 0 {
+			return io.ErrNoProgress
+		}
+	}
+	return nil
+}
+
+func writePipeChunk(chunk []byte, eventType string, writer *eventWriter, copied, writesInFlight *atomic.Int64) {
+	// Mark the write in flight for the whole (potentially blocking) write so
+	// the drain loop never treats a slow flush as an idle pipe.
+	writesInFlight.Add(1)
+	writer.write(streamEvent{Type: eventType, Data: string(chunk)})
+	writesInFlight.Add(-1)
+	copied.Add(int64(len(chunk)))
+}
+
 func benignPipeReadError(err error) bool {
-	return errors.Is(err, io.EOF) || errors.Is(err, os.ErrClosed)
+	return errors.Is(err, io.EOF) || errors.Is(err, os.ErrClosed) || errors.Is(err, errForegroundDrained)
 }
 
 type eventWriter struct {

--- a/worker/cloudflare-container-runner/pipe_buffered_darwin.go
+++ b/worker/cloudflare-container-runner/pipe_buffered_darwin.go
@@ -1,0 +1,18 @@
+//go:build darwin
+
+package main
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+func pipeBufferedBytes(fd int) (int, error) {
+	const fionread = 0x4004667f // _IOR('f', 127, int)
+	var available int32
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(fd), fionread, uintptr(unsafe.Pointer(&available)))
+	if errno != 0 {
+		return 0, errno
+	}
+	return int(available), nil
+}

--- a/worker/cloudflare-container-runner/pipe_buffered_linux.go
+++ b/worker/cloudflare-container-runner/pipe_buffered_linux.go
@@ -1,0 +1,17 @@
+//go:build linux
+
+package main
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+func pipeBufferedBytes(fd int) (int, error) {
+	var available int32
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(fd), syscall.TIOCINQ, uintptr(unsafe.Pointer(&available)))
+	if errno != 0 {
+		return 0, errno
+	}
+	return int(available), nil
+}

--- a/worker/cloudflare-container-runner/stdout_truncation_test.go
+++ b/worker/cloudflare-container-runner/stdout_truncation_test.go
@@ -540,3 +540,66 @@ func TestRunCommandNoTruncationUnderSlowResponseWrite(t *testing.T) {
 			got, totalBytes, totalBytes-got)
 	}
 }
+
+// TestRunCommandDrainCapPreservesBufferedForegroundOutput proves the absolute
+// descendant cap cannot discard foreground bytes that were already buffered
+// in the pipe when the direct child exited.
+func TestRunCommandDrainCapPreservesBufferedForegroundOutput(t *testing.T) {
+	origIdle := pipeDrainIdle
+	origPoll := pipeDrainPoll
+	origGrace := pipeDrainGrace
+	pipeDrainIdle = 50 * time.Millisecond
+	pipeDrainPoll = 5 * time.Millisecond
+	pipeDrainGrace = 75 * time.Millisecond
+	defer func() {
+		pipeDrainIdle = origIdle
+		pipeDrainPoll = origPoll
+		pipeDrainGrace = origGrace
+	}()
+
+	const totalBytes = 512 * 1024
+	rec := &slowResponseWriter{delay: 200 * time.Millisecond}
+	writer := &eventWriter{w: rec}
+	req := execRequest{
+		Command: fmt.Sprintf("head -c %d /dev/zero | tr '\\0' 'x'", totalBytes),
+	}
+
+	code, err := runCommand(context.Background(), req, t.TempDir(), writer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+
+	var got int
+	var errEvents []string
+	scanner := bufio.NewScanner(bytes.NewBufferString(rec.body()))
+	scanner.Buffer(make([]byte, 0, 1<<20), 1<<21)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var ev streamEvent
+		if err := json.Unmarshal(line, &ev); err != nil {
+			t.Fatalf("unmarshal event %q: %v", line, err)
+		}
+		switch ev.Type {
+		case "stdout":
+			got += len(ev.Data)
+		case "error":
+			errEvents = append(errEvents, ev.Error)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if len(errEvents) > 0 {
+		t.Fatalf("unexpected error events: %v", errEvents)
+	}
+	if got != totalBytes {
+		t.Fatalf("stdout bytes delivered = %d, want %d (lost %d bytes: drain cap closed the pipe while buffered foreground output remained)",
+			got, totalBytes, totalBytes-got)
+	}
+}

--- a/worker/cloudflare-container.Dockerfile
+++ b/worker/cloudflare-container.Dockerfile
@@ -3,7 +3,7 @@ FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26-bookworm@sha256:5f6
 ARG TARGETOS=linux
 ARG TARGETARCH
 WORKDIR /src
-COPY cloudflare-container-runner/go.mod cloudflare-container-runner/main.go ./
+COPY cloudflare-container-runner/go.mod cloudflare-container-runner/*.go ./
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -trimpath -ldflags="-s -w" -o /out/crabbox-cloudflare-container-runner .
 
 FROM docker.io/library/golang:1.26-bookworm@sha256:5f68ec6805843bd3981a951ffada82a26a0bd2631045c8f7dba483fa868f5ec5 AS go-runtime


### PR DESCRIPTION
## Summary

- preserve every foreground byte buffered when the direct child exits before starting the detached-descendant drain cap
- switch the owned pipe read ends to interruptible nonblocking reads, snapshot the kernel-buffered foreground prefix, then resume idle/capped descendant draining
- stop and join copiers before closing read ends, preventing raw-fd reads from racing descriptor reuse
- include all runner Go sources in the Cloudflare and Azure production image builds

Follow-up to the Codex autoreview P1 finding on merged https://github.com/openclaw/crabbox/pull/1097: the absolute cap could close the read ends while a foreground chunk was still being flushed to a slow HTTP client, silently discarding unread foreground bytes still buffered in the OS pipe.

## Regression proof

`TestRunCommandDrainCapPreservesBufferedForegroundOutput` uses a 75 ms cap, a 200 ms-per-write response writer, and 512 KiB of foreground output.

- before fix: failed; delivered 475,136 / 524,288 bytes, losing 49,152 bytes
- after fix: passed; delivered all 524,288 bytes
- flake proof: `go test . -run '^TestRunCommandDrainCapPreservesBufferedForegroundOutput$' -count=5` passed 5/5

## Verification

- `go build ./...`
- `go vet ./...`
- `go test . -count=1`
- focused prompt-return, idle, bursty, noisy absolute-cap, slow-writer, long-foreground, and truncation test matrix
- Cloudflare runner-stage Docker build
- Azure runner-stage Docker build
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted`: clean; no accepted/actionable findings, patch correct (0.93)
