### PR TITLE
fix(cli): serialize non-daemon egress start cutover and fix foreground host argv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 ### Fixed
 
 - Preserved foreground container-runner output buffered behind slow HTTP clients when the detached-descendant drain cap expires.
+- Stopped a previously started egress host daemon during non-daemon egress starts so it cannot clobber the new foreground session, and held the per-lease lock until the foreground host joins so concurrent replacement starts cannot interleave.
+- Fixed non-daemon egress start to actually run the foreground host bridge; it previously exited with a usage error right after starting the remote client.
 - Delivered server-first mediated-egress bytes after the local proxy handshake without letting one slow stream block unrelated connections. Thanks @anagnorisis2peripeteia.
 - Serialized complete per-lease egress host-daemon starts and stops and atomically replaced the remote client, preventing concurrent lifecycle commands and ordinary restarts from leaving untracked or stale processes. Thanks @anagnorisis2peripeteia.
 - Closed code-server WebSockets whose upstream dial completes after bridge shutdown, preventing orphaned connections and reader goroutines. Thanks @anagnorisis2peripeteia.

--- a/internal/cli/egress.go
+++ b/internal/cli/egress.go
@@ -101,6 +101,10 @@ bridges; the host agent opens the real outbound TCP connections.`)
 }
 
 func (a App) egressHost(ctx context.Context, args []string) error {
+	return a.egressHostWithConnectHook(ctx, args, nil)
+}
+
+func (a App) egressHostWithConnectHook(ctx context.Context, args []string, onConnected func()) error {
 	defaults := defaultConfig()
 	fs := newFlagSet("egress host", a.Stderr)
 	provider := fs.String("provider", defaults.Provider, "provider: hetzner or aws")
@@ -133,6 +137,9 @@ func (a App) egressHost(ctx context.Context, args []string) error {
 		return err
 	}
 	fmt.Fprintf(a.Stdout, "egress host: connected lease=%s session=%s profile=%s allow=%s\n", leaseID, bridge.sessionID, blank(*profile, "-"), strings.Join(allow, ","))
+	if onConnected != nil {
+		onConnected()
+	}
 	return bridge.serveHost(ctx, allow)
 }
 
@@ -218,19 +225,23 @@ func (a App) egressStart(ctx context.Context, args []string) error {
 	if err := enforceManagedLeaseCapabilities(cfg, server, leaseID); err != nil {
 		return err
 	}
-	var unlockDaemon func()
-	if *daemon {
-		unlockDaemon, err = acquireEgressDaemonLock(leaseID)
-		if err != nil {
-			return exit(2, "acquire egress daemon lock: %v", err)
-		}
-		defer unlockDaemon()
+	unlockDaemon, err := acquireEgressDaemonLock(leaseID)
+	if err != nil {
+		return exit(2, "acquire egress daemon lock: %v", err)
 	}
+	daemonLockHeld := true
+	releaseDaemonLock := func() {
+		if daemonLockHeld {
+			daemonLockHeld = false
+			unlockDaemon()
+		}
+	}
+	defer releaseDaemonLock()
 	sessionID := newLocalEgressSessionID()
 	if err := installRemoteEgressClient(ctx, target); err != nil {
 		return err
 	}
-	clientTicket, err := a.prepareEgressClientCutover(ctx, coord, leaseID, sessionID, *profile, allow, *daemon)
+	clientTicket, err := a.prepareEgressClientCutover(ctx, coord, leaseID, sessionID, *profile, allow)
 	if err != nil {
 		return err
 	}
@@ -243,7 +254,6 @@ func (a App) egressStart(ctx context.Context, args []string) error {
 	}
 	fmt.Fprintf(a.Stdout, "egress client: lease=%s listen=%s log=%s\n", leaseID, *listen, egressRemoteLog)
 	hostArgs := []string{
-		"host",
 		"--provider", cfg.Provider,
 		"--id", leaseID,
 		"--coordinator", coord.BaseURL,
@@ -256,35 +266,40 @@ func (a App) egressStart(ctx context.Context, args []string) error {
 		hostArgs = append(hostArgs, "--allow", strings.Join(allow, ","))
 	}
 	if *daemon {
-		return a.startEgressHostDaemonLocked(leaseID, hostArgs)
+		// The supervisor re-invokes `crabbox egress <args>`, so it needs the
+		// subcommand token; the in-process foreground call below must not get
+		// it because flag parsing stops at the first non-flag argument.
+		return a.startEgressHostDaemonLocked(leaseID, append([]string{"host"}, hostArgs...))
 	}
 	hostTicket, err := coord.CreateEgressTicket(ctx, leaseID, "host", sessionID, *profile, allow)
 	if err != nil {
 		return err
 	}
 	hostArgs = append(hostArgs, "--ticket", hostTicket.Ticket)
-	return a.egressHost(ctx, hostArgs)
+	// Hold the daemon lock until the foreground host has joined the session so a
+	// concurrent replacement start cannot interleave with its pending connect.
+	// Release it before the long-running serve loop so egress stop and replacement
+	// starts do not block until the session ends.
+	return a.egressHostWithConnectHook(ctx, hostArgs, releaseDaemonLock)
 }
 
-func (a App) prepareEgressClientCutover(ctx context.Context, coord *CoordinatorClient, leaseID, sessionID, profile string, allow []string, daemon bool) (CoordinatorEgressTicket, error) {
+func (a App) prepareEgressClientCutover(ctx context.Context, coord *CoordinatorClient, leaseID, sessionID, profile string, allow []string) (CoordinatorEgressTicket, error) {
 	clientTicket, err := coord.CreateEgressTicket(ctx, leaseID, "client", sessionID, profile, allow)
 	if err != nil {
 		return CoordinatorEgressTicket{}, err
 	}
-	if daemon {
-		// Stop the old host daemon before the new session activates (the remote
-		// client start in egressStart). The coordinator keeps one active egress
-		// session per lease, and the old supervisor restarts its host on any
-		// non-fatal exit, so a still-running old daemon would reconnect its
-		// prior session and clobber the replacement mid-cutover. The brief
-		// no-daemon window until the new host starts is the accepted tradeoff;
-		// the stop stays after ticket minting so preflight failures preserve
-		// the working daemon.
-		if stopped, err := a.stopEgressHostDaemonLocked(leaseID); err != nil {
-			return CoordinatorEgressTicket{}, err
-		} else if stopped {
-			fmt.Fprintln(a.Stdout, "egress host daemon: replacing previous daemon")
-		}
+	// Stop the old host daemon before the new daemon or foreground session
+	// activates (the remote client start in egressStart). The coordinator keeps
+	// one active egress session per lease, and the old supervisor restarts its
+	// host on any non-fatal exit, so a still-running old daemon would reconnect
+	// its prior session and clobber the replacement mid-cutover. The brief
+	// no-daemon window until the new host starts is the accepted tradeoff; the
+	// stop stays after ticket minting so preflight failures preserve the working
+	// daemon.
+	if stopped, err := a.stopEgressHostDaemonLocked(leaseID); err != nil {
+		return CoordinatorEgressTicket{}, err
+	} else if stopped {
+		fmt.Fprintln(a.Stdout, "egress host daemon: replacing previous daemon")
 	}
 	return clientTicket, nil
 }

--- a/internal/cli/egress_daemon_double_provision_test.go
+++ b/internal/cli/egress_daemon_double_provision_test.go
@@ -5,6 +5,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -223,7 +224,7 @@ func TestPrepareEgressClientCutoverPreservesDaemonWhenTicketCreationFails(t *tes
 	defer server.Close()
 	coord := &CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
 
-	_, err := app.prepareEgressClientCutover(context.Background(), coord, leaseID, "egress_test", "", []string{"example.com"}, true)
+	_, err := app.prepareEgressClientCutover(context.Background(), coord, leaseID, "egress_test", "", []string{"example.com"})
 	if err == nil {
 		t.Fatal("expected ticket creation failure")
 	}
@@ -240,6 +241,54 @@ func TestPrepareEgressClientCutoverPreservesDaemonWhenTicketCreationFails(t *tes
 	}
 	if got := strings.TrimSpace(string(recorded)); got != strconv.Itoa(pid) {
 		t.Fatalf("pid file changed after ticket failure: got %q want %d", got, pid)
+	}
+}
+
+func TestPrepareEgressClientCutoverStopsDaemonForForegroundStart(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CRABBOX_EGRESS_DAEMON_TESTCHILD", "1")
+	leaseID := "foreground-cutover"
+	var output bytes.Buffer
+	app := App{Stdout: &output, Stderr: &output}
+	if err := app.startEgressHostDaemon(leaseID, []string{"host", "--id", leaseID, "crabbox-test-supervisor"}); err != nil {
+		t.Fatalf("start egress daemon: %v (output: %s)", err, strings.TrimSpace(output.String()))
+	}
+	pid := egressDaemonTestPID(t, &output)
+	t.Cleanup(func() { killEgressDaemonTestGroup(pid) })
+	_, pidPath, err := egressDaemonPaths(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	output.Reset()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/leases/"+leaseID+"/egress/ticket" {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(CoordinatorEgressTicket{
+			Ticket:    "egress_ticket",
+			LeaseID:   leaseID,
+			Role:      "client",
+			SessionID: "egress_foreground",
+			ExpiresAt: "2026-07-16T00:00:00Z",
+		})
+	}))
+	defer server.Close()
+	coord := &CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
+
+	if _, err := app.prepareEgressClientCutover(context.Background(), coord, leaseID, "egress_foreground", "", []string{"example.com"}); err != nil {
+		t.Fatal(err)
+	}
+	if egressDaemonTestAlive(pid) {
+		t.Fatalf("daemon pid %d remained alive after foreground cutover", pid)
+	}
+	if _, err := os.Stat(pidPath); !os.IsNotExist(err) {
+		t.Fatalf("pid file still exists after foreground cutover: %v", err)
+	}
+	if !strings.Contains(output.String(), "egress host daemon: replacing previous daemon") {
+		t.Fatalf("foreground cutover did not report daemon replacement (output: %s)", strings.TrimSpace(output.String()))
 	}
 }
 

--- a/internal/cli/egress_test.go
+++ b/internal/cli/egress_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -456,6 +457,83 @@ func TestConnectEgressBridgeSendsTicketInDedicatedHeader(t *testing.T) {
 	case <-agentConnected:
 	case <-ctx.Done():
 		t.Fatal(ctx.Err())
+	}
+}
+
+func TestEgressHostConnectHookRunsAfterHandshake(t *testing.T) {
+	clearConfigEnv(t)
+	isolateRunTestUserDirs(t, t.TempDir())
+	accepted := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/leases/cbx_abcdef123456/egress/host" {
+			http.NotFound(w, r)
+			return
+		}
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Errorf("websocket accept: %v", err)
+			return
+		}
+		close(accepted)
+		_, _, _ = conn.Read(context.Background())
+		_ = conn.Close(websocket.StatusNormalClosure, "test done")
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	hookFired := make(chan struct{})
+	result := make(chan error, 1)
+	app := App{Stdout: io.Discard, Stderr: io.Discard}
+	go func() {
+		result <- app.egressHostWithConnectHook(ctx, []string{
+			"--id", "cbx_abcdef123456",
+			"--coordinator", server.URL,
+			"--ticket", "egress_abcdef1234567890abcdef1234567890",
+			"--session", "egress_session",
+			"--allow", "example.com",
+		}, func() { close(hookFired) })
+	}()
+
+	select {
+	case <-accepted:
+	case err := <-result:
+		t.Fatalf("egress host returned before handshake: %v", err)
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+	select {
+	case <-hookFired:
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+	cancel()
+	select {
+	case <-result:
+	case <-time.After(5 * time.Second):
+		t.Fatal("egress host did not return after shutdown")
+	}
+}
+
+func TestEgressHostConnectHookSkippedOnConnectFailure(t *testing.T) {
+	clearConfigEnv(t)
+	isolateRunTestUserDirs(t, t.TempDir())
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+
+	hookFired := false
+	err := (App{Stdout: io.Discard, Stderr: io.Discard}).egressHostWithConnectHook(context.Background(), []string{
+		"--id", "cbx_abcdef123456",
+		"--coordinator", server.URL,
+		"--ticket", "egress_abcdef1234567890abcdef1234567890",
+		"--session", "egress_session",
+		"--allow", "example.com",
+	}, func() { hookFired = true })
+	if err == nil {
+		t.Fatal("expected egress host connect failure")
+	}
+	if hookFired {
+		t.Fatal("connect hook fired after failed handshake")
 	}
 }
 


### PR DESCRIPTION
## Summary

Running `crabbox egress start` without `--daemon` while a host daemon from a previous `egress start --daemon` was still running never stopped that daemon: the per-lease daemon lock and the old-daemon stop in the cutover were both gated on the `--daemon` flag. The old daemon's supervisor would restart its host after the new foreground session activated, and connect-order last-wins session activation let the old session clobber the new foreground session. This is the same failure mode https://github.com/openclaw/crabbox/pull/1103 fixed for daemon-to-daemon replacement; the non-daemon path was left uncovered.

Changes:

- `egressStart` acquires the per-lease egress daemon lock unconditionally, and `prepareEgressClientCutover` stops a running host daemon unconditionally (its `daemon` parameter is gone). Ordering is unchanged: cutover after remote-client install and client-ticket mint, before the remote client starts, so preflight failures preserve a working daemon.
- The foreground path holds the lock until the host bridge handshake completes (new `egressHostWithConnectHook`), so a concurrent serialized replacement start cannot interleave with a pending foreground host connect, then releases it before the long-running serve loop so `egress stop` and replacement starts do not block until the session ends.
- Fixed a latent bug that made non-daemon `egress start` unusable: it passed the `host` subcommand token to the in-process `egressHost` call, flag parsing stopped at that first non-flag token, and the command exited with "egress host requires --profile or --allow" right after starting the remote client (present since the mediated egress bridge landed in b40d3645). The subcommand token is now prepended only for the daemon supervisor's re-invocation.

## Verification

- `go vet ./internal/cli/`
- `go test -race ./internal/cli/` (full suite, pass)
- New regression tests: `TestPrepareEgressClientCutoverStopsDaemonForForegroundStart` (running daemon is stopped during a non-daemon start cutover), `TestEgressHostConnectHookRunsAfterHandshake` and `TestEgressHostConnectHookSkippedOnConnectFailure` (lock-release hook timing and foreground argv parsing).

No config or secret implications.
