### PR TITLE
docs(security): fix broken reporting link, invite issues/PRs

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -87,12 +87,13 @@ break need an explicit product decision and migration path.
 
 ## Reporting
 
-Use [GitHub private vulnerability reporting](https://github.com/openclaw/crabbox/security/advisories/new)
-for a suspected vulnerability. Use a normal GitHub issue for non-sensitive
-hardening, reliability, documentation, or expected-behavior discussions.
+Crabbox targets a single trusted user running on their own machine, so most
+findings are ordinary bugs rather than exploitable vulnerabilities against the
+boundaries above. The most useful thing you can do is open a normal GitHub
+issue — or, better, send a pull request with the fix. This project does not run
+a separate private-disclosure process.
 
-Do not publish live credentials, private infrastructure details, or an
-exploit-ready report containing sensitive deployment information. Reports
-should identify the supported boundary crossed, required attacker access,
-affected code path, and a reproduction where practical. CVSS scoring is useful
-only after the report is accepted as a vulnerability.
+A helpful report identifies which supported boundary is crossed (see the
+sections above), the attacker access it requires, and the affected code path,
+with a reproduction where practical. Please don't paste live credentials or
+private infrastructure details into a public issue.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -89,11 +89,15 @@ break need an explicit product decision and migration path.
 
 Crabbox targets a single trusted user running on their own machine, so most
 findings are ordinary bugs rather than exploitable vulnerabilities against the
-boundaries above. The most useful thing you can do is open a normal GitHub
-issue — or, better, send a pull request with the fix. This project does not run
-a separate private-disclosure process.
+boundaries above. This project does not run a separate private-disclosure
+process.
 
-A helpful report identifies which supported boundary is crossed (see the
-sections above), the attacker access it requires, and the affected code path,
-with a reproduction where practical. Please don't paste live credentials or
-private infrastructure details into a public issue.
+If you find a security-relevant issue, the most useful thing you can do is send
+a pull request with the fix — that way the fix and the report arrive together
+and nothing sits publicly described but unpatched. For non-sensitive hardening,
+reliability, or expected-behavior questions, a normal GitHub issue is fine.
+
+A helpful report or PR identifies which supported boundary is crossed (see the
+sections above), the attacker access it requires, and the affected code path.
+Please don't paste live credentials or private infrastructure details into a
+public issue.


### PR DESCRIPTION
Closes #1095.

SECURITY.md pointed reporters at GitHub private vulnerability reporting, which is disabled on this repo — a dead end. Crabbox is a single-user local dev tool with a minimal threat model, and we don't want a separate private-disclosure process for it. This updates the Reporting section to invite normal issues and PRs (fixes especially welcome) and removes the broken advisories link. No change to the trust-model / in-scope / out-of-scope sections.
