### PR TITLE
fix(tart): guard Cleanup orphan sweep against a concurrent Acquire's claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Prevented Tart cleanup from deleting lease claims and stored SSH keys created or rebound by concurrent acquisitions. Thanks @anagnorisis2peripeteia.
 - Failed Node coordinator startup on malformed trusted-proxy CIDRs, warned on untrusted forwarded client headers, and kept environment-backed provider failures out of top-level request logs.
 - Kept pond SSH forwards process-owned and grouped each member's ports into one connection, so terminal teardown reaps tunnels and helpers without hiding genuine failures or multiplying handshakes. Thanks @anagnorisis2peripeteia.
 - Preserved foreground container-runner output buffered behind slow HTTP clients when the detached-descendant drain cap expires.

--- a/internal/providers/tart/backend.go
+++ b/internal/providers/tart/backend.go
@@ -310,6 +310,17 @@ func (b *backend) ReleaseLeaseMessage(lease LeaseTarget) string {
 
 func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 	cfg := b.configForRun()
+	// Snapshot orphan-candidate claims BEFORE listing instances. A claim
+	// registered by a concurrent Acquire after this point (while Cleanup dwells
+	// in a slow stopVM/deleteVM below) is absent here and therefore protected
+	// from the orphan sweep, which would otherwise read the newer claim against
+	// this older instance view as a "missing instance" and destroy a healthy,
+	// running VM's lease. Only claims that predate our instance view can be
+	// genuine orphans.
+	orphanCandidates, err := listLeaseClaims()
+	if err != nil {
+		return err
+	}
 	instances, err := b.listInstances(ctx)
 	if err != nil {
 		return err
@@ -351,11 +362,7 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 		removed++
 	}
 	claimsRemoved := 0
-	allClaims, claimErr := listLeaseClaims()
-	if claimErr != nil {
-		return claimErr
-	}
-	for _, claim := range allClaims {
+	for _, claim := range orphanCandidates {
 		if claim.Provider != providerName || claim.LeaseID == "" {
 			continue
 		}
@@ -370,8 +377,15 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 			fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s slug=%s reason=%s\n", claim.LeaseID, blank(claim.Slug, "-"), reason)
 			continue
 		}
+		// Remove only if the claim is still exactly as snapshotted. A concurrent
+		// Acquire/Touch that (re)bound this lease between the snapshot and now
+		// makes it no longer an orphan, so RemoveLeaseClaimIfUnchanged declines
+		// the deletion and we leave the live lease intact.
+		if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
+			fmt.Fprintf(b.rt.Stderr, "skip claim lease=%s slug=%s reason=changed-during-cleanup err=%v\n", claim.LeaseID, blank(claim.Slug, "-"), err)
+			continue
+		}
 		fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s slug=%s reason=%s\n", claim.LeaseID, blank(claim.Slug, "-"), reason)
-		removeLeaseClaim(claim.LeaseID)
 		removeStoredTestboxKey(claim.LeaseID)
 		claimsRemoved++
 	}

--- a/internal/providers/tart/backend.go
+++ b/internal/providers/tart/backend.go
@@ -310,13 +310,8 @@ func (b *backend) ReleaseLeaseMessage(lease LeaseTarget) string {
 
 func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 	cfg := b.configForRun()
-	// Snapshot orphan-candidate claims BEFORE listing instances. A claim
-	// registered by a concurrent Acquire after this point (while Cleanup dwells
-	// in a slow stopVM/deleteVM below) is absent here and therefore protected
-	// from the orphan sweep, which would otherwise read the newer claim against
-	// this older instance view as a "missing instance" and destroy a healthy,
-	// running VM's lease. Only claims that predate our instance view can be
-	// genuine orphans.
+	// Snapshot candidates before instances so newer claims cannot be compared
+	// against an older instance view and misclassified as orphans.
 	orphanCandidates, err := listLeaseClaims()
 	if err != nil {
 		return err
@@ -377,16 +372,15 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 			fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s slug=%s reason=%s\n", claim.LeaseID, blank(claim.Slug, "-"), reason)
 			continue
 		}
-		// Remove only if the claim is still exactly as snapshotted. A concurrent
-		// Acquire/Touch that (re)bound this lease between the snapshot and now
-		// makes it no longer an orphan, so RemoveLeaseClaimIfUnchanged declines
-		// the deletion and we leave the live lease intact.
-		if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
+		// Keep the claim and its key when another process changed the candidate.
+		if err := core.RemoveLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, func() error {
+			removeStoredTestboxKey(claim.LeaseID)
+			return nil
+		}); err != nil {
 			fmt.Fprintf(b.rt.Stderr, "skip claim lease=%s slug=%s reason=changed-during-cleanup err=%v\n", claim.LeaseID, blank(claim.Slug, "-"), err)
 			continue
 		}
 		fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s slug=%s reason=%s\n", claim.LeaseID, blank(claim.Slug, "-"), reason)
-		removeStoredTestboxKey(claim.LeaseID)
 		claimsRemoved++
 	}
 	if !req.DryRun {

--- a/internal/providers/tart/backend.go
+++ b/internal/providers/tart/backend.go
@@ -372,11 +372,9 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 			fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s slug=%s reason=%s\n", claim.LeaseID, blank(claim.Slug, "-"), reason)
 			continue
 		}
-		// Keep the claim and its key when another process changed the candidate.
-		if err := core.RemoveLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, func() error {
-			removeStoredTestboxKey(claim.LeaseID)
-			return nil
-		}); err != nil {
+		// Acquisition creates or reuses the key before publishing its claim, so
+		// missing-instance cleanup cannot safely delete that key without a wider fence.
+		if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
 			fmt.Fprintf(b.rt.Stderr, "skip claim lease=%s slug=%s reason=changed-during-cleanup err=%v\n", claim.LeaseID, blank(claim.Slug, "-"), err)
 			continue
 		}

--- a/internal/providers/tart/cleanup_toctou_test.go
+++ b/internal/providers/tart/cleanup_toctou_test.go
@@ -1,0 +1,213 @@
+package tart
+
+// Repro for a TOCTOU race in (*backend).Cleanup (backend.go:311-382):
+//
+// Cleanup snapshots instances once via listInstances() (:313) and builds the
+// `live` lease-ID set (:321-331) from that stale snapshot, but the orphan-claim
+// sweep (:354-377) reads a FRESH listLeaseClaims(). A claim registered by a
+// concurrent Acquire (backend.go:184, core.ClaimLeaseForRepoProviderScopePondEndpoint)
+// while Cleanup is stuck inside its deletion loop (stopVM/deleteVM can take a
+// full VM shutdown each) is therefore visible to the sweep but absent from
+// `live`, and gets deleted as "missing instance" — orphaning a healthy,
+// running VM and destroying its lease claim + stored SSH key.
+//
+// The test drives the race deterministically: the fake tart runner blocks in
+// `tart stop <stale-vm>` (exactly where a real Cleanup dwells) until a second
+// goroutine has registered a new claim through the same production entrypoint
+// Acquire uses. On correct code the freshly claimed lease must survive
+// Cleanup; on current code the sweep removes it and the test FAILS.
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type toctouRunner struct {
+	mu        sync.Mutex
+	responses map[string]core.LocalCommandResult
+	onceStop  sync.Once
+	// duringStop simulates work happening while `tart stop` is executing
+	// (a real VM shutdown takes seconds-to-minutes).
+	duringStop func()
+}
+
+func (r *toctouRunner) Run(_ context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+	if len(req.Args) >= 2 && req.Args[0] == "stop" && r.duringStop != nil {
+		r.onceStop.Do(r.duringStop)
+	}
+	r.mu.Lock()
+	resp := r.responses[commandKey(req.Args)]
+	r.mu.Unlock()
+	return resp, nil
+}
+
+func TestCleanupOrphanSweepDeletesConcurrentAcquireClaim(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	repoRoot := t.TempDir()
+
+	const (
+		staleVM  = "crabbox-stale-old1" // stopped, claimless: makes Cleanup enter its deletion loop
+		newVM    = "crabbox-new-fresh1" // cloned+booted by the concurrent Acquire AFTER Cleanup's snapshot
+		newLease = "cbx_racefresh12345"
+	)
+
+	// Cleanup's one-and-only instance snapshot: taken before the concurrent
+	// Acquire clones its VM, so it contains only the stale VM.
+	listJSON := `[{"Name":"` + staleVM + `","State":"stopped","Running":false,"Disk":50,"Size":12,"Source":"ghcr.io/test:latest"}]`
+
+	// The concurrent Acquire (process B). It registers its lease claim via the
+	// exact production call Acquire performs at backend.go:184, for a VM that
+	// is genuinely running by then — it just was not in Cleanup's snapshot.
+	acquireErr := make(chan error, 1)
+	registerConcurrentClaim := func() {
+		go func() {
+			server := core.Server{
+				CloudID:  newVM,
+				Provider: providerName,
+				Name:     newVM,
+				Status:   "ready",
+				Labels: map[string]string{
+					"crabbox":  "true",
+					"provider": providerName,
+					"instance": newVM,
+					"lease":    newLease,
+					"slug":     "fresh-slug",
+					"state":    "ready",
+				},
+			}
+			acquireErr <- core.ClaimLeaseForRepoProviderScopePondEndpoint(
+				newLease, "fresh-slug", providerName, instanceScope(newVM), "",
+				repoRoot, 30*time.Minute, false, server, core.SSHTarget{},
+			)
+		}()
+		// `tart stop` does not return until the concurrent Acquire has
+		// finished claiming — the realistic ordering (VM shutdowns are slow).
+		if err := <-acquireErr; err != nil {
+			t.Errorf("concurrent Acquire claim registration failed: %v", err)
+		}
+	}
+
+	runner := &toctouRunner{
+		responses: map[string]core.LocalCommandResult{
+			commandKey([]string{"list", "--source", "local", "--format", "json"}): {Stdout: listJSON},
+		},
+		duringStop: registerConcurrentClaim,
+	}
+
+	var out bytes.Buffer
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: &out, Stderr: io.Discard, Exec: runner}).(*backend)
+
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+
+	// The invariant: a claim registered for a live, running VM during Cleanup
+	// must survive Cleanup. Current code deletes it as "missing instance".
+	claim, ok, err := core.ResolveLeaseClaimForProvider(newLease, providerName)
+	if err != nil {
+		t.Fatalf("ResolveLeaseClaimForProvider(%s): %v", newLease, err)
+	}
+	if !ok || claim.LeaseID != newLease {
+		t.Fatalf("Cleanup's orphan sweep deleted the claim registered by a concurrent Acquire for running VM %s: claim present=%v (want present)\ncleanup output:\n%s",
+			newVM, ok, out.String())
+	}
+	if strings.Contains(out.String(), "remove claim lease="+newLease) {
+		t.Fatalf("Cleanup removed the healthy concurrent claim:\n%s", out.String())
+	}
+}
+
+// TestCleanupOrphanSweepGuardDeclinesReclaimedCandidate exercises the fix's
+// SECOND defense. The reorder above stops a brand-new claim from being swept;
+// this covers a claim that IS a legitimate orphan candidate (present in the
+// pre-instance snapshot, no live instance) but is reclaimed/rebound after the
+// snapshot while Cleanup dwells in its stop loop. RemoveLeaseClaimIfUnchanged
+// must observe the change and decline the removal, so the reclaiming process
+// keeps its lease. Inverting or short-circuiting that guard branch makes the
+// sweep report "remove claim" for the rebound lease, which this test rejects.
+func TestCleanupOrphanSweepGuardDeclinesReclaimedCandidate(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	repoRoot := t.TempDir()
+
+	const (
+		staleVM     = "crabbox-stale-old2" // claimless, stopped: makes Cleanup enter its stop loop
+		orphanVM    = "crabbox-orphan-cand2"
+		orphanLease = "cbx_orphancand67890"
+	)
+
+	// Only the stale VM is listed; the candidate's VM is absent, so its claim is
+	// a genuine sweep target on the snapshot.
+	listJSON := `[{"Name":"` + staleVM + `","State":"stopped","Running":false,"Disk":50,"Size":12,"Source":"ghcr.io/test:latest"}]`
+
+	origServer := core.Server{
+		CloudID: orphanVM, Provider: providerName, Name: orphanVM, Status: "idle",
+		Labels: map[string]string{
+			"crabbox": "true", "provider": providerName, "instance": orphanVM,
+			"lease": orphanLease, "slug": "orphan-slug", "state": "idle",
+		},
+	}
+	// Registered BEFORE Cleanup, so it is in the pre-instance orphan snapshot.
+	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(
+		orphanLease, "orphan-slug", providerName, instanceScope(orphanVM), "",
+		repoRoot, 30*time.Minute, false, origServer, core.SSHTarget{},
+	); err != nil {
+		t.Fatalf("setup orphan-candidate claim: %v", err)
+	}
+
+	// During the stale VM's stop (inside the loop, before the orphan sweep) a
+	// concurrent process reclaims the same lease, rewriting the claim so it no
+	// longer matches the snapshot the sweep holds.
+	reclaimErr := make(chan error, 1)
+	reclaim := func() {
+		go func() {
+			rebound := origServer
+			rebound.Status = "ready"
+			rebound.Labels = map[string]string{
+				"crabbox": "true", "provider": providerName, "instance": orphanVM,
+				"lease": orphanLease, "slug": "orphan-slug", "state": "ready",
+			}
+			reclaimErr <- core.ClaimLeaseForRepoProviderScopePondEndpoint(
+				orphanLease, "orphan-slug", providerName, instanceScope(orphanVM), "",
+				repoRoot, 30*time.Minute, false, rebound, core.SSHTarget{},
+			)
+		}()
+		if err := <-reclaimErr; err != nil {
+			t.Errorf("concurrent reclaim registration failed: %v", err)
+		}
+	}
+
+	runner := &toctouRunner{
+		responses: map[string]core.LocalCommandResult{
+			commandKey([]string{"list", "--source", "local", "--format", "json"}): {Stdout: listJSON},
+		},
+		duringStop: reclaim,
+	}
+
+	var out bytes.Buffer
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: &out, Stderr: io.Discard, Exec: runner}).(*backend)
+
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+
+	claim, ok, err := core.ResolveLeaseClaimForProvider(orphanLease, providerName)
+	if err != nil {
+		t.Fatalf("ResolveLeaseClaimForProvider(%s): %v", orphanLease, err)
+	}
+	if !ok || claim.LeaseID != orphanLease {
+		t.Fatalf("guard failed: a reclaimed orphan-candidate claim was deleted: present=%v\noutput:\n%s", ok, out.String())
+	}
+	if strings.Contains(out.String(), "remove claim lease="+orphanLease) {
+		t.Fatalf("guard branch bypassed: sweep reported removing a reclaimed claim:\n%s", out.String())
+	}
+}

--- a/internal/providers/tart/cleanup_toctou_test.go
+++ b/internal/providers/tart/cleanup_toctou_test.go
@@ -1,22 +1,5 @@
 package tart
 
-// Repro for a TOCTOU race in (*backend).Cleanup (backend.go:311-382):
-//
-// Cleanup snapshots instances once via listInstances() (:313) and builds the
-// `live` lease-ID set (:321-331) from that stale snapshot, but the orphan-claim
-// sweep (:354-377) reads a FRESH listLeaseClaims(). A claim registered by a
-// concurrent Acquire (backend.go:184, core.ClaimLeaseForRepoProviderScopePondEndpoint)
-// while Cleanup is stuck inside its deletion loop (stopVM/deleteVM can take a
-// full VM shutdown each) is therefore visible to the sweep but absent from
-// `live`, and gets deleted as "missing instance" — orphaning a healthy,
-// running VM and destroying its lease claim + stored SSH key.
-//
-// The test drives the race deterministically: the fake tart runner blocks in
-// `tart stop <stale-vm>` (exactly where a real Cleanup dwells) until a second
-// goroutine has registered a new claim through the same production entrypoint
-// Acquire uses. On correct code the freshly claimed lease must survive
-// Cleanup; on current code the sweep removes it and the test FAILS.
-
 import (
 	"bytes"
 	"context"
@@ -29,185 +12,109 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-type toctouRunner struct {
-	mu        sync.Mutex
+type cleanupRaceRunner struct {
 	responses map[string]core.LocalCommandResult
 	onceStop  sync.Once
-	// duringStop simulates work happening while `tart stop` is executing
-	// (a real VM shutdown takes seconds-to-minutes).
-	duringStop func()
+	onStop    func()
 }
 
-func (r *toctouRunner) Run(_ context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
-	if len(req.Args) >= 2 && req.Args[0] == "stop" && r.duringStop != nil {
-		r.onceStop.Do(r.duringStop)
+func (r *cleanupRaceRunner) Run(_ context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+	if len(req.Args) >= 2 && req.Args[0] == "stop" && r.onStop != nil {
+		r.onceStop.Do(r.onStop)
 	}
-	r.mu.Lock()
-	resp := r.responses[commandKey(req.Args)]
-	r.mu.Unlock()
-	return resp, nil
+	return r.responses[commandKey(req.Args)], nil
 }
 
-func TestCleanupOrphanSweepDeletesConcurrentAcquireClaim(t *testing.T) {
+func TestCleanupPreservesClaimCreatedAfterInstanceSnapshot(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	repoRoot := t.TempDir()
-
 	const (
-		staleVM  = "crabbox-stale-old1" // stopped, claimless: makes Cleanup enter its deletion loop
-		newVM    = "crabbox-new-fresh1" // cloned+booted by the concurrent Acquire AFTER Cleanup's snapshot
+		staleVM  = "crabbox-stale-old1"
+		newVM    = "crabbox-new-fresh1"
 		newLease = "cbx_racefresh12345"
 	)
 
-	// Cleanup's one-and-only instance snapshot: taken before the concurrent
-	// Acquire clones its VM, so it contains only the stale VM.
-	listJSON := `[{"Name":"` + staleVM + `","State":"stopped","Running":false,"Disk":50,"Size":12,"Source":"ghcr.io/test:latest"}]`
-
-	// The concurrent Acquire (process B). It registers its lease claim via the
-	// exact production call Acquire performs at backend.go:184, for a VM that
-	// is genuinely running by then — it just was not in Cleanup's snapshot.
-	acquireErr := make(chan error, 1)
-	registerConcurrentClaim := func() {
-		go func() {
-			server := core.Server{
-				CloudID:  newVM,
-				Provider: providerName,
-				Name:     newVM,
-				Status:   "ready",
-				Labels: map[string]string{
-					"crabbox":  "true",
-					"provider": providerName,
-					"instance": newVM,
-					"lease":    newLease,
-					"slug":     "fresh-slug",
-					"state":    "ready",
-				},
-			}
-			acquireErr <- core.ClaimLeaseForRepoProviderScopePondEndpoint(
-				newLease, "fresh-slug", providerName, instanceScope(newVM), "",
-				repoRoot, 30*time.Minute, false, server, core.SSHTarget{},
-			)
-		}()
-		// `tart stop` does not return until the concurrent Acquire has
-		// finished claiming — the realistic ordering (VM shutdowns are slow).
-		if err := <-acquireErr; err != nil {
-			t.Errorf("concurrent Acquire claim registration failed: %v", err)
-		}
-	}
-
-	runner := &toctouRunner{
-		responses: map[string]core.LocalCommandResult{
-			commandKey([]string{"list", "--source", "local", "--format", "json"}): {Stdout: listJSON},
-		},
-		duringStop: registerConcurrentClaim,
-	}
-
-	var out bytes.Buffer
-	cfg := core.BaseConfig()
-	cfg.Provider = providerName
-	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: &out, Stderr: io.Discard, Exec: runner}).(*backend)
-
-	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
-		t.Fatalf("Cleanup: %v", err)
-	}
-
-	// The invariant: a claim registered for a live, running VM during Cleanup
-	// must survive Cleanup. Current code deletes it as "missing instance".
-	claim, ok, err := core.ResolveLeaseClaimForProvider(newLease, providerName)
-	if err != nil {
-		t.Fatalf("ResolveLeaseClaimForProvider(%s): %v", newLease, err)
-	}
-	if !ok || claim.LeaseID != newLease {
-		t.Fatalf("Cleanup's orphan sweep deleted the claim registered by a concurrent Acquire for running VM %s: claim present=%v (want present)\ncleanup output:\n%s",
-			newVM, ok, out.String())
-	}
-	if strings.Contains(out.String(), "remove claim lease="+newLease) {
-		t.Fatalf("Cleanup removed the healthy concurrent claim:\n%s", out.String())
+	out := runCleanupRace(t, staleVM, func() {
+		claimTartLease(t, repoRoot, newLease, newVM, "ready")
+	})
+	assertTartClaim(t, newLease, "ready")
+	if strings.Contains(out, "remove claim lease="+newLease) {
+		t.Fatalf("cleanup reported removing a claim created after its instance snapshot:\n%s", out)
 	}
 }
 
-// TestCleanupOrphanSweepGuardDeclinesReclaimedCandidate exercises the fix's
-// SECOND defense. The reorder above stops a brand-new claim from being swept;
-// this covers a claim that IS a legitimate orphan candidate (present in the
-// pre-instance snapshot, no live instance) but is reclaimed/rebound after the
-// snapshot while Cleanup dwells in its stop loop. RemoveLeaseClaimIfUnchanged
-// must observe the change and decline the removal, so the reclaiming process
-// keeps its lease. Inverting or short-circuiting that guard branch makes the
-// sweep report "remove claim" for the rebound lease, which this test rejects.
-func TestCleanupOrphanSweepGuardDeclinesReclaimedCandidate(t *testing.T) {
+func TestCleanupPreservesReclaimedOrphanCandidate(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	repoRoot := t.TempDir()
-
 	const (
-		staleVM     = "crabbox-stale-old2" // claimless, stopped: makes Cleanup enter its stop loop
+		staleVM     = "crabbox-stale-old2"
 		orphanVM    = "crabbox-orphan-cand2"
 		orphanLease = "cbx_orphancand67890"
 	)
 
-	// Only the stale VM is listed; the candidate's VM is absent, so its claim is
-	// a genuine sweep target on the snapshot.
+	claimTartLease(t, repoRoot, orphanLease, orphanVM, "idle")
+	out := runCleanupRace(t, staleVM, func() {
+		claimTartLease(t, repoRoot, orphanLease, orphanVM, "ready")
+	})
+	assertTartClaim(t, orphanLease, "ready")
+	if strings.Contains(out, "remove claim lease="+orphanLease) {
+		t.Fatalf("cleanup reported removing a concurrently reclaimed claim:\n%s", out)
+	}
+}
+
+func runCleanupRace(t *testing.T, staleVM string, onStop func()) string {
+	t.Helper()
 	listJSON := `[{"Name":"` + staleVM + `","State":"stopped","Running":false,"Disk":50,"Size":12,"Source":"ghcr.io/test:latest"}]`
-
-	origServer := core.Server{
-		CloudID: orphanVM, Provider: providerName, Name: orphanVM, Status: "idle",
-		Labels: map[string]string{
-			"crabbox": "true", "provider": providerName, "instance": orphanVM,
-			"lease": orphanLease, "slug": "orphan-slug", "state": "idle",
-		},
-	}
-	// Registered BEFORE Cleanup, so it is in the pre-instance orphan snapshot.
-	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(
-		orphanLease, "orphan-slug", providerName, instanceScope(orphanVM), "",
-		repoRoot, 30*time.Minute, false, origServer, core.SSHTarget{},
-	); err != nil {
-		t.Fatalf("setup orphan-candidate claim: %v", err)
-	}
-
-	// During the stale VM's stop (inside the loop, before the orphan sweep) a
-	// concurrent process reclaims the same lease, rewriting the claim so it no
-	// longer matches the snapshot the sweep holds.
-	reclaimErr := make(chan error, 1)
-	reclaim := func() {
-		go func() {
-			rebound := origServer
-			rebound.Status = "ready"
-			rebound.Labels = map[string]string{
-				"crabbox": "true", "provider": providerName, "instance": orphanVM,
-				"lease": orphanLease, "slug": "orphan-slug", "state": "ready",
-			}
-			reclaimErr <- core.ClaimLeaseForRepoProviderScopePondEndpoint(
-				orphanLease, "orphan-slug", providerName, instanceScope(orphanVM), "",
-				repoRoot, 30*time.Minute, false, rebound, core.SSHTarget{},
-			)
-		}()
-		if err := <-reclaimErr; err != nil {
-			t.Errorf("concurrent reclaim registration failed: %v", err)
-		}
-	}
-
-	runner := &toctouRunner{
+	runner := &cleanupRaceRunner{
 		responses: map[string]core.LocalCommandResult{
 			commandKey([]string{"list", "--source", "local", "--format", "json"}): {Stdout: listJSON},
 		},
-		duringStop: reclaim,
+		onStop: onStop,
 	}
-
 	var out bytes.Buffer
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
 	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: &out, Stderr: io.Discard, Exec: runner}).(*backend)
-
 	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatalf("Cleanup: %v", err)
 	}
+	return out.String()
+}
 
-	claim, ok, err := core.ResolveLeaseClaimForProvider(orphanLease, providerName)
+func claimTartLease(t *testing.T, repoRoot, leaseID, instance, state string) {
+	t.Helper()
+	server := core.Server{
+		CloudID:  instance,
+		Provider: providerName,
+		Name:     instance,
+		Status:   state,
+		Labels: map[string]string{
+			"crabbox":  "true",
+			"provider": providerName,
+			"instance": instance,
+			"lease":    leaseID,
+			"slug":     "race-slug",
+			"state":    state,
+		},
+	}
+	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(
+		leaseID, "race-slug", providerName, instanceScope(instance), "", repoRoot,
+		30*time.Minute, false, server, core.SSHTarget{},
+	); err != nil {
+		t.Fatalf("claim Tart lease %s: %v", leaseID, err)
+	}
+}
+
+func assertTartClaim(t *testing.T, leaseID, state string) {
+	t.Helper()
+	claim, ok, err := core.ResolveLeaseClaimForProvider(leaseID, providerName)
 	if err != nil {
-		t.Fatalf("ResolveLeaseClaimForProvider(%s): %v", orphanLease, err)
+		t.Fatalf("ResolveLeaseClaimForProvider(%s): %v", leaseID, err)
 	}
-	if !ok || claim.LeaseID != orphanLease {
-		t.Fatalf("guard failed: a reclaimed orphan-candidate claim was deleted: present=%v\noutput:\n%s", ok, out.String())
+	if !ok {
+		t.Fatalf("cleanup removed live claim %s", leaseID)
 	}
-	if strings.Contains(out.String(), "remove claim lease="+orphanLease) {
-		t.Fatalf("guard branch bypassed: sweep reported removing a reclaimed claim:\n%s", out.String())
+	if got := claim.Labels["state"]; got != state {
+		t.Fatalf("claim %s state = %q, want %q", leaseID, got, state)
 	}
 }

--- a/internal/providers/tart/provider_test.go
+++ b/internal/providers/tart/provider_test.go
@@ -1590,11 +1590,22 @@ func TestCleanupDeleteError(t *testing.T) {
 func TestCleanupRemovesOrphanedClaims(t *testing.T) {
 	stateDir := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", stateDir)
+	const leaseID = "cbx_orphan"
 	err := core.ClaimLeaseForRepoProviderScopePond(
-		"cbx_orphan", "orphan-slug", providerName, "instance:crabbox-gone-9999", "", t.TempDir(), 30*time.Minute, false,
+		leaseID, "orphan-slug", providerName, "instance:crabbox-gone-9999", "", t.TempDir(), 30*time.Minute, false,
 	)
 	if err != nil {
 		t.Fatalf("setup orphan claim: %v", err)
+	}
+	keyPath, err := testboxKeyPath(leaseID)
+	if err != nil {
+		t.Fatalf("testbox key path: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(keyPath), 0o700); err != nil {
+		t.Fatalf("create testbox key directory: %v", err)
+	}
+	if err := os.WriteFile(keyPath, []byte("test key"), 0o600); err != nil {
+		t.Fatalf("write testbox key: %v", err)
 	}
 	listJSON := `[]`
 	runner := &recordingRunner{
@@ -1617,6 +1628,14 @@ func TestCleanupRemovesOrphanedClaims(t *testing.T) {
 	}
 	if !strings.Contains(output, "claims_removed=1") {
 		t.Fatalf("should report claims_removed=1: %q", output)
+	}
+	if _, ok, err := core.ResolveLeaseClaimForProvider(leaseID, providerName); err != nil {
+		t.Fatalf("resolve removed claim: %v", err)
+	} else if ok {
+		t.Fatalf("orphan claim %s still exists", leaseID)
+	}
+	if _, err := os.Stat(keyPath); !os.IsNotExist(err) {
+		t.Fatalf("orphan key %s still exists: %v", keyPath, err)
 	}
 }
 

--- a/internal/providers/tart/provider_test.go
+++ b/internal/providers/tart/provider_test.go
@@ -1587,9 +1587,12 @@ func TestCleanupDeleteError(t *testing.T) {
 	}
 }
 
-func TestCleanupRemovesOrphanedClaims(t *testing.T) {
+func TestCleanupRemovesOrphanedClaimsWithoutDeletingStoredKey(t *testing.T) {
 	stateDir := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", stateDir)
+	configHome := t.TempDir()
+	t.Setenv("HOME", configHome)
+	t.Setenv("XDG_CONFIG_HOME", configHome)
 	const leaseID = "cbx_orphan"
 	err := core.ClaimLeaseForRepoProviderScopePond(
 		leaseID, "orphan-slug", providerName, "instance:crabbox-gone-9999", "", t.TempDir(), 30*time.Minute, false,
@@ -1634,8 +1637,8 @@ func TestCleanupRemovesOrphanedClaims(t *testing.T) {
 	} else if ok {
 		t.Fatalf("orphan claim %s still exists", leaseID)
 	}
-	if _, err := os.Stat(keyPath); !os.IsNotExist(err) {
-		t.Fatalf("orphan key %s still exists: %v", keyPath, err)
+	if _, err := os.Stat(keyPath); err != nil {
+		t.Fatalf("stored key removed without an acquisition fence: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- snapshot Tart orphan-claim candidates before listing instances so claims created after the instance view cannot be misclassified as missing
- remove a candidate only when its persisted claim still exactly matches the snapshot
- retain stored SSH keys during missing-instance claim cleanup because Tart creates or reuses the key before it publishes the replacement claim; safe key garbage collection needs a wider acquisition fence
- cover both post-snapshot claim creation and concurrent rebinding with compact deterministic regressions

Part of https://github.com/openclaw/crabbox/issues/1123.

## Maintainer improvements

- reduced the original 213-line regression file to focused shared fixtures
- strengthened assertions to verify rebound claim contents, successful orphan-claim deletion, and intentional key retention
- isolated both claim and key paths from the developer's real config directories
- added changelog credit for @anagnorisis2peripeteia

## Verification

- base proof: `TestCleanupPreservesClaimCreatedAfterInstanceSnapshot` fails on current `main` because cleanup removes the live claim
- `go test -race ./internal/providers/tart/ -run 'TestCleanup(Preserves|RemovesOrphanedClaimsWithoutDeletingStoredKey)' -count=50`
- `go test -race ./internal/providers/tart/ -count=1`
- `go vet ./...`
- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- final whole-branch AutoReview clean with no accepted/actionable findings (confidence 0.91)

The repository-wide race command also exposed pre-existing cross-package claim-store leakage when packages share one temporary home; the exact Tart package is isolated and green, and hosted exact-head CI remains the merge authority.
