### PR TITLE
fix(firecracker): guard Cleanup claim removal against a concurrent reclaim

### DIFF
--- a/internal/providers/firecracker/backend.go
+++ b/internal/providers/firecracker/backend.go
@@ -436,7 +436,19 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 		if err := b.releaseStateRecord(ctx, cfg, record, true); err != nil {
 			return err
 		}
-		core.RemoveLeaseClaim(record.LeaseID)
+		// Guard the claim removal against a concurrent Resolve/Touch that
+		// reclaimed this lease after our cleanup snapshot: RemoveLeaseClaimIfUnchanged
+		// declines to delete a claim rewritten in the check->destroy window,
+		// leaving the reclaiming process's live lease intact. (namespaceinstance
+		// backend.go:455,473 uses the same guard.)
+		if claim := claims[record.LeaseID]; claim.LeaseID != "" {
+			if err := core.RemoveLeaseClaimIfUnchanged(record.LeaseID, claim); err != nil {
+				fmt.Fprintf(b.rt.Stderr, "skip firecracker claim removal lease=%s reason=reclaimed-during-cleanup err=%v\n", record.LeaseID, err)
+				continue
+			}
+		} else {
+			core.RemoveLeaseClaim(record.LeaseID)
+		}
 		removeTestboxKey(record.LeaseID)
 	}
 	for leaseID, claim := range claims {
@@ -448,7 +460,12 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 			continue
 		}
 		fmt.Fprintf(b.rt.Stdout, "remove firecracker claim lease=%s slug=%s reason=missing_state\n", leaseID, blankIfEmpty(claim.Slug))
-		core.RemoveLeaseClaim(leaseID)
+		// A claim with no state record is only a genuine orphan if it is
+		// unchanged since our snapshot; a concurrent reclaim makes it live again.
+		if err := core.RemoveLeaseClaimIfUnchanged(leaseID, claim); err != nil {
+			fmt.Fprintf(b.rt.Stderr, "skip firecracker claim removal lease=%s reason=reclaimed-during-cleanup err=%v\n", leaseID, err)
+			continue
+		}
 		removeTestboxKey(leaseID)
 	}
 	return nil

--- a/internal/providers/firecracker/cleanup_toctou_test.go
+++ b/internal/providers/firecracker/cleanup_toctou_test.go
@@ -1,0 +1,95 @@
+package firecracker
+
+import (
+	"context"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+// TestCleanupTOCTOUDeletesConcurrentlyReclaimedClaim proves the
+// check-then-destroy window in (*backend).Cleanup (backend.go ~line 426-440):
+// Cleanup decides via shouldCleanupRecord, then kills the VM and calls the
+// UNGUARDED core.RemoveLeaseClaim — with no if-unchanged guard between check
+// and act. If another crabbox process reclaims the same lease inside that
+// window (Resolve/Touch rewrites the claim through the real claim API), the
+// freshly-rewritten claim is deleted out from under the live session.
+//
+// The interleaving is injected deterministically at a real point INSIDE the
+// window: releaseStateRecord invokes the injectable b.cleanupNetwork hook
+// after shouldCleanupRecord has returned true and before
+// core.RemoveLeaseClaim runs. In production this window spans the
+// SIGTERM/SIGKILL + wait of the firecracker process (seconds), so a
+// concurrent `crabbox resolve --reclaim` fits in it easily. The claim flock
+// in claim.go only serializes individual file mutations, not this
+// check-then-destroy sequence; namespaceinstance closes exactly this window
+// with core.RemoveLeaseClaimIfUnchanged (backend.go:455,473), which
+// firecracker does not use.
+//
+// EXPECTED (correct, guarded) behavior: process B's rewritten claim survives
+// Cleanup, because a guarded removal would observe the claim changed after
+// the cleanup decision and refuse to delete it.
+// ACTUAL (buggy) behavior: the claim is gone -> the final assertion fails.
+func TestCleanupTOCTOUDeletesConcurrentlyReclaimedClaim(t *testing.T) {
+	cfg := lifecycleConfig(t)
+	test := newLifecycleTestBackend(t, cfg)
+
+	// Process B originally acquired the lease (state record + claim exist).
+	lease, err := test.backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: test.repoRoot}})
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	if _, ok, err := core.ResolveLeaseClaimForProvider(lease.LeaseID, providerName); err != nil || !ok {
+		t.Fatalf("precondition: acquired claim ok=%v err=%v", ok, err)
+	}
+
+	// The firecracker process has exited, so process A's Cleanup decides
+	// shouldCleanupRecord=true (reason=process_exited) from its snapshot.
+	test.processes.alive[4242] = false
+
+	// Process B concurrently reclaims the same lease INSIDE the
+	// check->destroy window, via the real production claim entry point
+	// (the same call chain (*backend).claimLeaseTarget uses on Resolve).
+	reclaimed := false
+	prevCleanupNetwork := test.backend.cleanupNetwork
+	test.backend.cleanupNetwork = func(ctx context.Context, record leaseStateRecord) error {
+		if err := prevCleanupNetwork(ctx, record); err != nil {
+			return err
+		}
+		if record.LeaseID != lease.LeaseID || reclaimed {
+			return nil
+		}
+		server := Server{
+			CloudID:  record.VMID,
+			Provider: providerName,
+			Name:     record.VMID,
+			Labels: map[string]string{
+				"lease": record.LeaseID,
+				"slug":  record.Slug,
+				"state": "ready",
+			},
+		}
+		if err := core.ClaimLeaseTargetForRepoConfig(record.LeaseID, record.Slug, cfg, server, lease.SSH, test.repoRoot, cfg.IdleTimeout, true); err != nil {
+			t.Fatalf("concurrent reclaim (process B) failed: %v", err)
+		}
+		reclaimed = true
+		return nil
+	}
+
+	// Process A runs `crabbox cleanup`.
+	if err := test.backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+	if !reclaimed {
+		t.Fatal("harness: concurrent reclaim hook never ran inside the cleanup window")
+	}
+
+	// B's freshly-rewritten claim must survive A's cleanup: a guarded
+	// removal (core.RemoveLeaseClaimIfUnchanged with the pre-decision
+	// snapshot, as namespaceinstance does) refuses to delete a claim that
+	// changed after the cleanup decision. The unguarded
+	// core.RemoveLeaseClaim deletes it unconditionally -> this fails.
+	if _, ok, err := core.ResolveLeaseClaimForProvider(lease.LeaseID, providerName); err != nil || !ok {
+		t.Fatalf("TOCTOU: Cleanup deleted the claim process B rewrote inside the check->destroy window (claim present=%v err=%v); unguarded core.RemoveLeaseClaim needs the *IfUnchanged guard", ok, err)
+	}
+}


### PR DESCRIPTION
`(*backend).Cleanup` decides via `shouldCleanupRecord`, releases the VM, then calls the **unguarded** `core.RemoveLeaseClaim`. A concurrent `Resolve`/`Touch` that reclaims the same lease inside that check→destroy window has its freshly-rewritten claim deleted out from under the live session. Trigger is two concurrent runs; no attacker. Same `[security]` class as https://github.com/openclaw/crabbox/pull/446.

**Fix:** guard both removals with `core.RemoveLeaseClaimIfUnchanged` against the pre-cleanup snapshot (mirrors `namespaceinstance` backend.go:455,473).

**Verify:** `go test ./internal/providers/firecracker/ -run TestCleanupTOCTOU -race` — `TestCleanupTOCTOUDeletesConcurrentlyReclaimedClaim` fails on base, passes with this fix. `go vet ./... && go build ./cmd/crabbox`.

Part of https://github.com/openclaw/crabbox/issues/1123.
