### PR TITLE
fix(blacksmith): don't stop a concurrently-claimed testbox in failed-warmup cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- Limited failed Blacksmith warmup cleanup to Testbox IDs emitted by that invocation, preventing config-matched concurrent Testboxes from being stopped. Thanks @anagnorisis2peripeteia.
 - Prevented Tart cleanup from deleting lease claims and stored SSH keys created or rebound by concurrent acquisitions. Thanks @anagnorisis2peripeteia.
 - Failed Node coordinator startup on malformed trusted-proxy CIDRs, warned on untrusted forwarded client headers, and kept environment-backed provider failures out of top-level request logs.
 - Kept pond SSH forwards process-owned and grouped each member's ports into one connection, so terminal teardown reaps tunnels and helpers without hiding genuine failures or multiplying handshakes. Thanks @anagnorisis2peripeteia.

--- a/internal/providers/blacksmith/backend.go
+++ b/internal/providers/blacksmith/backend.go
@@ -1070,6 +1070,16 @@ func (b *blacksmithBackend) cleanupFailedWarmup(ctx context.Context, before map[
 			if before[item.ID] || !blacksmithMatchesConfig(item, b.cfg) {
 				continue
 			}
+			// Do not stop a testbox another crabbox process already owns. A
+			// concurrent warmup with the same repo/workflow/job/ref registers a
+			// lease claim (warmupLease -> claimLeaseForRepoProvider); the
+			// config-only matcher cannot tell that healthy, in-use box from our
+			// own orphan, so gate the stop on the absence of a live claim. Our
+			// own failed warmup never claimed, so a genuine orphan stays
+			// unclaimed and is still swept.
+			if _, claimed, err := core.ResolveLeaseClaimForProvider(item.ID, blacksmithTestboxProvider); err == nil && claimed {
+				continue
+			}
 			_ = b.Stop(ctx, StopRequest{ID: item.ID})
 			before[item.ID] = true
 			stopped = true

--- a/internal/providers/blacksmith/backend.go
+++ b/internal/providers/blacksmith/backend.go
@@ -803,11 +803,12 @@ func (b *blacksmithBackend) warmupLease(ctx context.Context, repo Repo, reclaim 
 	if err != nil {
 		return "", "", err
 	}
-	beforeWarmup := b.listIDsBestEffort(ctx)
 	result, err := b.runCommand(ctx, args, b.rt.Stdout, b.rt.Stderr)
 	output := result.Stdout + result.Stderr
 	if err != nil {
-		b.cleanupFailedWarmup(ctx, beforeWarmup, output)
+		if leaseID := parseBlacksmithID(output); leaseID != "" {
+			_ = b.Stop(ctx, StopRequest{ID: leaseID})
+		}
 		return "", "", exit(result.ExitCode, "blacksmith testbox warmup failed: %v; if the delegated queue is unavailable, rerun with a coordinator-backed provider such as --provider aws", err)
 	}
 	leaseID := parseBlacksmithID(output)
@@ -1031,71 +1032,6 @@ func minBlacksmithDuration(left, right time.Duration) time.Duration {
 		return left
 	}
 	return right
-}
-
-func (b *blacksmithBackend) listIDsBestEffort(ctx context.Context) map[string]bool {
-	out, err := b.commandOutput(ctx, blacksmithListAllArgs(b.cfg))
-	if err != nil {
-		return map[string]bool{}
-	}
-	ids := map[string]bool{}
-	for _, item := range parseBlacksmithList(out) {
-		ids[item.ID] = true
-	}
-	return ids
-}
-
-func (b *blacksmithBackend) cleanupFailedWarmup(ctx context.Context, before map[string]bool, output string) {
-	if leaseID := parseBlacksmithID(output); leaseID != "" {
-		if err := b.Stop(ctx, StopRequest{ID: leaseID}); err == nil {
-			before[leaseID] = true
-		}
-	}
-	stoppedAny := false
-	quietAttempts := 0
-	for attempt := 0; attempt < blacksmithCleanupAttempts; attempt++ {
-		if attempt > 0 {
-			select {
-			case <-ctx.Done():
-				return
-			case <-time.After(blacksmithCleanupDelay):
-			}
-		}
-		list, err := b.commandOutput(ctx, blacksmithListAllArgs(b.cfg))
-		if err != nil {
-			return
-		}
-		stopped := false
-		for _, item := range parseBlacksmithList(list) {
-			if before[item.ID] || !blacksmithMatchesConfig(item, b.cfg) {
-				continue
-			}
-			// Do not stop a testbox another crabbox process already owns. A
-			// concurrent warmup with the same repo/workflow/job/ref registers a
-			// lease claim (warmupLease -> claimLeaseForRepoProvider); the
-			// config-only matcher cannot tell that healthy, in-use box from our
-			// own orphan, so gate the stop on the absence of a live claim. Our
-			// own failed warmup never claimed, so a genuine orphan stays
-			// unclaimed and is still swept.
-			if _, claimed, err := core.ResolveLeaseClaimForProvider(item.ID, blacksmithTestboxProvider); err == nil && claimed {
-				continue
-			}
-			_ = b.Stop(ctx, StopRequest{ID: item.ID})
-			before[item.ID] = true
-			stopped = true
-		}
-		if stopped {
-			stoppedAny = true
-			quietAttempts = 0
-			continue
-		}
-		if stoppedAny {
-			quietAttempts++
-			if quietAttempts >= blacksmithCleanupQuiet {
-				return
-			}
-		}
-	}
 }
 
 func (b *blacksmithBackend) blacksmithStatusView(ctx context.Context, leaseID string) (statusView, error) {

--- a/internal/providers/blacksmith/backend_test.go
+++ b/internal/providers/blacksmith/backend_test.go
@@ -420,110 +420,6 @@ func TestBlacksmithWarmupFailureStopsPrintedTestbox(t *testing.T) {
 	}
 }
 
-func TestBlacksmithWarmupFailureStopsNewListedTestbox(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
-	originalDelay := blacksmithCleanupDelay
-	originalAttempts := blacksmithCleanupAttempts
-	originalQuiet := blacksmithCleanupQuiet
-	blacksmithCleanupDelay = time.Millisecond
-	blacksmithCleanupAttempts = 3
-	blacksmithCleanupQuiet = 1
-	var stopped string
-	listCalls := 0
-	runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
-		if len(req.Args) >= 3 && req.Args[0] == "testbox" && req.Args[1] == "list" {
-			listCalls++
-			if listCalls < 3 {
-				return LocalCommandResult{Stdout: "ID STATUS REPO WORKFLOW JOB REF CREATED\n"}, nil
-			}
-			return LocalCommandResult{Stdout: "tbx_async123 queued openclaw .github/workflows/testbox.yml check main 2026-05-04T21:23:47.000000Z\n"}, nil
-		}
-		if len(req.Args) >= 3 && req.Args[0] == "testbox" && req.Args[1] == "stop" {
-			for i, arg := range req.Args {
-				if arg == "--id" && i+1 < len(req.Args) {
-					stopped = req.Args[i+1]
-				}
-			}
-			return LocalCommandResult{}, nil
-		}
-		return LocalCommandResult{ExitCode: 1, Stdout: "workflow missing\n"}, errors.New("exit status 1")
-	}}
-	t.Cleanup(func() {
-		blacksmithCleanupDelay = originalDelay
-		blacksmithCleanupAttempts = originalAttempts
-		blacksmithCleanupQuiet = originalQuiet
-	})
-
-	cfg := baseConfig()
-	cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
-	cfg.Blacksmith.Job = "check"
-	cfg.Blacksmith.Ref = "main"
-	backend := newTestBlacksmithBackend(cfg, runner)
-	_, _, err := backend.warmupLease(context.Background(), Repo{Root: "/repo"}, false, "")
-	if err == nil {
-		t.Fatal("expected warmup failure")
-	}
-	if stopped != "tbx_async123" {
-		t.Fatalf("stopped=%q, want tbx_async123", stopped)
-	}
-}
-
-func TestBlacksmithWarmupFailureContinuesAfterFirstDelayedStop(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
-	originalDelay := blacksmithCleanupDelay
-	originalAttempts := blacksmithCleanupAttempts
-	originalQuiet := blacksmithCleanupQuiet
-	blacksmithCleanupDelay = time.Millisecond
-	blacksmithCleanupAttempts = 5
-	blacksmithCleanupQuiet = 1
-	stopped := []string{}
-	listCalls := 0
-	runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
-		if len(req.Args) >= 3 && req.Args[0] == "testbox" && req.Args[1] == "list" {
-			listCalls++
-			switch listCalls {
-			case 2:
-				return LocalCommandResult{Stdout: "tbx_delayed1 queued openclaw .github/workflows/testbox.yml check main 2026-05-04T21:23:47.000000Z\n"}, nil
-			case 3:
-				return LocalCommandResult{Stdout: "tbx_delayed2 queued openclaw .github/workflows/testbox.yml check main 2026-05-04T21:23:48.000000Z\n"}, nil
-			default:
-				return LocalCommandResult{Stdout: "ID STATUS REPO WORKFLOW JOB REF CREATED\n"}, nil
-			}
-		}
-		if len(req.Args) >= 3 && req.Args[0] == "testbox" && req.Args[1] == "stop" {
-			for i, arg := range req.Args {
-				if arg == "--id" && i+1 < len(req.Args) {
-					stopped = append(stopped, req.Args[i+1])
-				}
-			}
-			return LocalCommandResult{}, nil
-		}
-		return LocalCommandResult{ExitCode: 1, Stdout: "workflow missing\n"}, errors.New("exit status 1")
-	}}
-	t.Cleanup(func() {
-		blacksmithCleanupDelay = originalDelay
-		blacksmithCleanupAttempts = originalAttempts
-		blacksmithCleanupQuiet = originalQuiet
-	})
-
-	cfg := baseConfig()
-	cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
-	cfg.Blacksmith.Job = "check"
-	cfg.Blacksmith.Ref = "main"
-	backend := newTestBlacksmithBackend(cfg, runner)
-	_, _, err := backend.warmupLease(context.Background(), Repo{Root: "/repo"}, false, "")
-	if err == nil {
-		t.Fatal("expected warmup failure")
-	}
-	if !reflect.DeepEqual(stopped, []string{"tbx_delayed1", "tbx_delayed2"}) {
-		t.Fatalf("stopped=%v, want both delayed testboxes", stopped)
-	}
-}
-
 func TestBlacksmithOneShotRunRemovesClaimAfterStop(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -557,8 +453,8 @@ func TestBlacksmithOneShotRunRemovesClaimAfterStop(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(runner.calls) != 4 {
-		t.Fatalf("blacksmith calls=%d, want list/warmup/run/stop", len(runner.calls))
+	if len(runner.calls) != 3 {
+		t.Fatalf("blacksmith calls=%d, want warmup/run/stop", len(runner.calls))
 	}
 	if claim, err := readLeaseClaim("tbx_abc123"); err != nil {
 		t.Fatal(err)
@@ -610,8 +506,8 @@ func TestBlacksmithKeptRunWritesLeaseOutput(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(runner.calls) != 3 {
-		t.Fatalf("blacksmith calls=%d, want list/warmup/run without stop: %#v", len(runner.calls), runner.calls)
+	if len(runner.calls) != 2 {
+		t.Fatalf("blacksmith calls=%d, want warmup/run without stop: %#v", len(runner.calls), runner.calls)
 	}
 	if result.Session == nil {
 		t.Fatal("missing session handle")
@@ -964,14 +860,14 @@ func TestBlacksmithRunCollectsArtifactsBeforeOneShotCleanup(t *testing.T) {
 	if len(result.Artifacts) != 1 {
 		t.Fatalf("artifacts=%#v", result.Artifacts)
 	}
-	if len(runner.calls) != 5 {
+	if len(runner.calls) != 4 {
 		t.Fatalf("calls=%#v", runner.calls)
 	}
-	if runner.calls[0][1] != "list" || runner.calls[1][1] != "warmup" || runner.calls[2][1] != "run" || runner.calls[3][1] != "run" || runner.calls[4][1] != "stop" {
+	if runner.calls[0][1] != "warmup" || runner.calls[1][1] != "run" || runner.calls[2][1] != "run" || runner.calls[3][1] != "stop" {
 		t.Fatalf("unexpected call order: %#v", runner.calls)
 	}
-	if !strings.Contains(runner.calls[3][len(runner.calls[3])-1], core.DelegatedRunArtifactBeginMarker) {
-		t.Fatalf("second run was not artifact collection: %#v", runner.calls[3])
+	if !strings.Contains(runner.calls[2][len(runner.calls[2])-1], core.DelegatedRunArtifactBeginMarker) {
+		t.Fatalf("second run was not artifact collection: %#v", runner.calls[2])
 	}
 }
 
@@ -1021,8 +917,8 @@ func TestBlacksmithRunArtifactFailureKeepsOneShotOnKeepOnFailure(t *testing.T) {
 	if !errors.As(err, &exitErr) || exitErr.Code != 7 {
 		t.Fatalf("err=%v want artifact exit 7", err)
 	}
-	if len(runner.calls) != 4 {
-		t.Fatalf("blacksmith calls=%d want list/warmup/run/artifact-run without stop: %#v", len(runner.calls), runner.calls)
+	if len(runner.calls) != 3 {
+		t.Fatalf("blacksmith calls=%d want warmup/run/artifact-run without stop: %#v", len(runner.calls), runner.calls)
 	}
 	if result.Session == nil || !result.Session.Kept {
 		t.Fatalf("session=%#v, want kept after artifact failure", result.Session)
@@ -1145,8 +1041,8 @@ func TestBlacksmithKeepOnFailureKeepsTestboxAndWritesBundle(t *testing.T) {
 	if !errors.As(err, &exitErr) || exitErr.Code != 7 {
 		t.Fatalf("err=%v want exit 7", err)
 	}
-	if len(runner.calls) != 3 {
-		t.Fatalf("blacksmith calls=%d want list/warmup/run without stop: %#v", len(runner.calls), runner.calls)
+	if len(runner.calls) != 2 {
+		t.Fatalf("blacksmith calls=%d want warmup/run without stop: %#v", len(runner.calls), runner.calls)
 	}
 	if result.Session == nil || !result.Session.Kept {
 		t.Fatalf("session=%#v, want kept after keep-on-failure", result.Session)

--- a/internal/providers/blacksmith/cleanup_toctou_test.go
+++ b/internal/providers/blacksmith/cleanup_toctou_test.go
@@ -1,0 +1,191 @@
+package blacksmith
+
+// Repro for a cross-process TOCTOU in cleanupFailedWarmup (backend.go):
+// the failed-warmup cleanup decides which testboxes to stop from a list-diff
+// snapshot (listIDsBestEffort before the warmup command) plus a config-only
+// matcher (blacksmithMatchesConfig: workflow/job/ref, no per-invocation
+// ownership marker). A testbox created concurrently by ANOTHER crabbox
+// process with the same config (e.g. two CI jobs of the same repo) appears
+// after the snapshot, matches the config, and is stopped — severing that
+// other process's healthy, in-use lease.
+//
+// The test models two crabbox processes (backend A and backend B) sharing one
+// fake Blacksmith control plane. The interleaving is sequenced
+// deterministically:
+//   1. A's warmupLease takes its "before" snapshot (control plane empty).
+//   2. While A's `blacksmith testbox warmup` command is in flight, process B
+//      runs its own warmup for the same config; it succeeds, creating and
+//      claiming tbx_bee123 (simulated inside A's warmup command handler).
+//   3. A's warmup command fails WITHOUT printing a tbx_ id (queue error).
+//   4. A's cleanupFailedWarmup lists --all, sees tbx_bee123 (absent from A's
+//      before-map, matches workflow/job/ref) and stops it.
+//
+// Correct behavior: A must not stop a testbox it did not create, so
+// tbx_bee123 must survive with its lease claim intact. Current code stops it,
+// so this test FAILS — that failure is the bug proof.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// crossProcControlPlane is a shared fake Blacksmith control plane visible to
+// both simulated crabbox processes.
+type crossProcControlPlane struct {
+	mu      sync.Mutex
+	boxes   map[string]bool
+	stopped []string
+}
+
+func (cp *crossProcControlPlane) add(id string) {
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
+	cp.boxes[id] = true
+}
+
+func (cp *crossProcControlPlane) stop(id string) {
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
+	if cp.boxes[id] {
+		delete(cp.boxes, id)
+		cp.stopped = append(cp.stopped, id)
+	}
+}
+
+func (cp *crossProcControlPlane) has(id string) bool {
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
+	return cp.boxes[id]
+}
+
+func (cp *crossProcControlPlane) stoppedIDs() []string {
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
+	out := append([]string(nil), cp.stopped...)
+	sort.Strings(out)
+	return out
+}
+
+func (cp *crossProcControlPlane) listOutput() string {
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
+	var b strings.Builder
+	b.WriteString("ID STATUS REPO WORKFLOW JOB REF CREATED\n")
+	ids := make([]string, 0, len(cp.boxes))
+	for id := range cp.boxes {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	for _, id := range ids {
+		fmt.Fprintf(&b, "%s running openclaw .github/workflows/testbox.yml check main 2026-07-14T10:00:00.000000Z\n", id)
+	}
+	return b.String()
+}
+
+// crossProcRunner is a per-process fake `blacksmith` CLI backed by the shared
+// control plane.
+type crossProcRunner struct {
+	cp       *crossProcControlPlane
+	onWarmup func(LocalCommandRequest) (LocalCommandResult, error)
+}
+
+func (r *crossProcRunner) Run(_ context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+	args := req.Args
+	if len(args) >= 2 && args[0] == "testbox" {
+		switch args[1] {
+		case "list":
+			return LocalCommandResult{Stdout: r.cp.listOutput()}, nil
+		case "warmup":
+			return r.onWarmup(req)
+		case "stop":
+			for i, arg := range args {
+				if arg == "--id" && i+1 < len(args) {
+					r.cp.stop(args[i+1])
+				}
+			}
+			return LocalCommandResult{}, nil
+		}
+	}
+	return LocalCommandResult{}, nil
+}
+
+func TestCrossProcCleanupFailedWarmupStopsConcurrentProcessTestbox(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
+
+	originalDelay := blacksmithCleanupDelay
+	originalAttempts := blacksmithCleanupAttempts
+	originalQuiet := blacksmithCleanupQuiet
+	blacksmithCleanupDelay = time.Millisecond
+	blacksmithCleanupAttempts = 3
+	blacksmithCleanupQuiet = 1
+	t.Cleanup(func() {
+		blacksmithCleanupDelay = originalDelay
+		blacksmithCleanupAttempts = originalAttempts
+		blacksmithCleanupQuiet = originalQuiet
+	})
+
+	// Both processes run the same repo/config — two CI jobs of one project.
+	cfg := baseConfig()
+	cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
+	cfg.Blacksmith.Job = "check"
+	cfg.Blacksmith.Ref = "main"
+
+	cp := &crossProcControlPlane{boxes: map[string]bool{}}
+
+	// Process B: its warmup succeeds and creates tbx_bee123.
+	runnerB := &crossProcRunner{cp: cp, onWarmup: func(LocalCommandRequest) (LocalCommandResult, error) {
+		cp.add("tbx_bee123")
+		return LocalCommandResult{Stdout: "queued tbx_bee123\n"}, nil
+	}}
+	backendB := newTestBlacksmithBackend(cfg, runnerB)
+
+	// Process A: its warmup fails with a queue error that prints no tbx_ id.
+	// While A's warmup command is in flight (strictly AFTER A took its
+	// "before" list snapshot), process B completes its own warmup and claims
+	// its healthy testbox — the concurrent interleaving under test.
+	leaseB := ""
+	runnerA := &crossProcRunner{cp: cp}
+	runnerA.onWarmup = func(LocalCommandRequest) (LocalCommandResult, error) {
+		id, _, err := backendB.warmupLease(context.Background(), Repo{Root: "/repo-b"}, false, "")
+		if err != nil {
+			t.Fatalf("process B warmup failed: %v", err)
+		}
+		leaseB = id
+		return LocalCommandResult{ExitCode: 1, Stdout: "error: delegated queue unavailable\n"}, errors.New("exit status 1")
+	}
+	backendA := newTestBlacksmithBackend(cfg, runnerA)
+
+	_, _, err := backendA.warmupLease(context.Background(), Repo{Root: "/repo-a"}, false, "")
+	if err == nil {
+		t.Fatal("expected process A warmup failure")
+	}
+	if leaseB != "tbx_bee123" {
+		t.Fatalf("process B lease=%q, want tbx_bee123", leaseB)
+	}
+
+	// Process B's healthy in-use testbox must survive process A's
+	// failed-warmup cleanup: A never created it.
+	if stopped := cp.stoppedIDs(); len(stopped) != 0 {
+		t.Fatalf("process A's failed-warmup cleanup stopped testbox(es) it does not own: %v (process B's lease severed mid-run)", stopped)
+	}
+	if !cp.has("tbx_bee123") {
+		t.Fatal("process B's testbox tbx_bee123 was removed from the control plane by process A's cleanup")
+	}
+	claim, claimErr := readLeaseClaim("tbx_bee123")
+	if claimErr != nil {
+		t.Fatal(claimErr)
+	}
+	if claim.LeaseID != "tbx_bee123" {
+		t.Fatalf("process B's lease claim was removed by process A's cleanup: %#v", claim)
+	}
+}

--- a/internal/providers/blacksmith/cleanup_toctou_test.go
+++ b/internal/providers/blacksmith/cleanup_toctou_test.go
@@ -1,191 +1,61 @@
 package blacksmith
 
-// Repro for a cross-process TOCTOU in cleanupFailedWarmup (backend.go):
-// the failed-warmup cleanup decides which testboxes to stop from a list-diff
-// snapshot (listIDsBestEffort before the warmup command) plus a config-only
-// matcher (blacksmithMatchesConfig: workflow/job/ref, no per-invocation
-// ownership marker). A testbox created concurrently by ANOTHER crabbox
-// process with the same config (e.g. two CI jobs of the same repo) appears
-// after the snapshot, matches the config, and is stopped — severing that
-// other process's healthy, in-use lease.
-//
-// The test models two crabbox processes (backend A and backend B) sharing one
-// fake Blacksmith control plane. The interleaving is sequenced
-// deterministically:
-//   1. A's warmupLease takes its "before" snapshot (control plane empty).
-//   2. While A's `blacksmith testbox warmup` command is in flight, process B
-//      runs its own warmup for the same config; it succeeds, creating and
-//      claiming tbx_bee123 (simulated inside A's warmup command handler).
-//   3. A's warmup command fails WITHOUT printing a tbx_ id (queue error).
-//   4. A's cleanupFailedWarmup lists --all, sees tbx_bee123 (absent from A's
-//      before-map, matches workflow/job/ref) and stops it.
-//
-// Correct behavior: A must not stop a testbox it did not create, so
-// tbx_bee123 must survive with its lease claim intact. Current code stops it,
-// so this test FAILS — that failure is the bug proof.
-
 import (
 	"context"
 	"errors"
-	"fmt"
 	"path/filepath"
-	"sort"
-	"strings"
-	"sync"
 	"testing"
-	"time"
 )
 
-// crossProcControlPlane is a shared fake Blacksmith control plane visible to
-// both simulated crabbox processes.
-type crossProcControlPlane struct {
-	mu      sync.Mutex
-	boxes   map[string]bool
-	stopped []string
-}
-
-func (cp *crossProcControlPlane) add(id string) {
-	cp.mu.Lock()
-	defer cp.mu.Unlock()
-	cp.boxes[id] = true
-}
-
-func (cp *crossProcControlPlane) stop(id string) {
-	cp.mu.Lock()
-	defer cp.mu.Unlock()
-	if cp.boxes[id] {
-		delete(cp.boxes, id)
-		cp.stopped = append(cp.stopped, id)
-	}
-}
-
-func (cp *crossProcControlPlane) has(id string) bool {
-	cp.mu.Lock()
-	defer cp.mu.Unlock()
-	return cp.boxes[id]
-}
-
-func (cp *crossProcControlPlane) stoppedIDs() []string {
-	cp.mu.Lock()
-	defer cp.mu.Unlock()
-	out := append([]string(nil), cp.stopped...)
-	sort.Strings(out)
-	return out
-}
-
-func (cp *crossProcControlPlane) listOutput() string {
-	cp.mu.Lock()
-	defer cp.mu.Unlock()
-	var b strings.Builder
-	b.WriteString("ID STATUS REPO WORKFLOW JOB REF CREATED\n")
-	ids := make([]string, 0, len(cp.boxes))
-	for id := range cp.boxes {
-		ids = append(ids, id)
-	}
-	sort.Strings(ids)
-	for _, id := range ids {
-		fmt.Fprintf(&b, "%s running openclaw .github/workflows/testbox.yml check main 2026-07-14T10:00:00.000000Z\n", id)
-	}
-	return b.String()
-}
-
-// crossProcRunner is a per-process fake `blacksmith` CLI backed by the shared
-// control plane.
-type crossProcRunner struct {
-	cp       *crossProcControlPlane
-	onWarmup func(LocalCommandRequest) (LocalCommandResult, error)
-}
-
-func (r *crossProcRunner) Run(_ context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
-	args := req.Args
-	if len(args) >= 2 && args[0] == "testbox" {
-		switch args[1] {
-		case "list":
-			return LocalCommandResult{Stdout: r.cp.listOutput()}, nil
-		case "warmup":
-			return r.onWarmup(req)
-		case "stop":
-			for i, arg := range args {
-				if arg == "--id" && i+1 < len(args) {
-					r.cp.stop(args[i+1])
-				}
-			}
-			return LocalCommandResult{}, nil
-		}
-	}
-	return LocalCommandResult{}, nil
-}
-
-func TestCrossProcCleanupFailedWarmupStopsConcurrentProcessTestbox(t *testing.T) {
+func TestFailedWarmupDoesNotStopConcurrentUnclaimedTestbox(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
 
-	originalDelay := blacksmithCleanupDelay
-	originalAttempts := blacksmithCleanupAttempts
-	originalQuiet := blacksmithCleanupQuiet
-	blacksmithCleanupDelay = time.Millisecond
-	blacksmithCleanupAttempts = 3
-	blacksmithCleanupQuiet = 1
-	t.Cleanup(func() {
-		blacksmithCleanupDelay = originalDelay
-		blacksmithCleanupAttempts = originalAttempts
-		blacksmithCleanupQuiet = originalQuiet
-	})
+	boxExists := false
+	listCalls := 0
+	stopped := ""
+	runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+		if len(req.Args) < 2 || req.Args[0] != "testbox" {
+			return LocalCommandResult{}, nil
+		}
+		switch req.Args[1] {
+		case "list":
+			listCalls++
+			if boxExists {
+				return LocalCommandResult{Stdout: "tbx_bee123 running example-org .github/workflows/testbox.yml check main 2026-07-14T10:00:00.000000Z\n"}, nil
+			}
+			return LocalCommandResult{Stdout: "ID STATUS REPO WORKFLOW JOB REF CREATED\n"}, nil
+		case "warmup":
+			// Another invocation can create its testbox before warmup returns
+			// and before that invocation publishes a local lease claim.
+			boxExists = true
+			return LocalCommandResult{ExitCode: 1, Stdout: "error: delegated queue unavailable\n"}, errors.New("exit status 1")
+		case "stop":
+			for i, arg := range req.Args {
+				if arg == "--id" && i+1 < len(req.Args) {
+					stopped = req.Args[i+1]
+				}
+			}
+			boxExists = false
+		}
+		return LocalCommandResult{}, nil
+	}}
 
-	// Both processes run the same repo/config — two CI jobs of one project.
 	cfg := baseConfig()
 	cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
 	cfg.Blacksmith.Job = "check"
 	cfg.Blacksmith.Ref = "main"
+	backend := newTestBlacksmithBackend(cfg, runner)
 
-	cp := &crossProcControlPlane{boxes: map[string]bool{}}
-
-	// Process B: its warmup succeeds and creates tbx_bee123.
-	runnerB := &crossProcRunner{cp: cp, onWarmup: func(LocalCommandRequest) (LocalCommandResult, error) {
-		cp.add("tbx_bee123")
-		return LocalCommandResult{Stdout: "queued tbx_bee123\n"}, nil
-	}}
-	backendB := newTestBlacksmithBackend(cfg, runnerB)
-
-	// Process A: its warmup fails with a queue error that prints no tbx_ id.
-	// While A's warmup command is in flight (strictly AFTER A took its
-	// "before" list snapshot), process B completes its own warmup and claims
-	// its healthy testbox — the concurrent interleaving under test.
-	leaseB := ""
-	runnerA := &crossProcRunner{cp: cp}
-	runnerA.onWarmup = func(LocalCommandRequest) (LocalCommandResult, error) {
-		id, _, err := backendB.warmupLease(context.Background(), Repo{Root: "/repo-b"}, false, "")
-		if err != nil {
-			t.Fatalf("process B warmup failed: %v", err)
-		}
-		leaseB = id
-		return LocalCommandResult{ExitCode: 1, Stdout: "error: delegated queue unavailable\n"}, errors.New("exit status 1")
+	if _, _, err := backend.warmupLease(context.Background(), Repo{Root: "/repo-a"}, false, ""); err == nil {
+		t.Fatal("expected warmup failure")
 	}
-	backendA := newTestBlacksmithBackend(cfg, runnerA)
-
-	_, _, err := backendA.warmupLease(context.Background(), Repo{Root: "/repo-a"}, false, "")
-	if err == nil {
-		t.Fatal("expected process A warmup failure")
+	if stopped != "" || !boxExists {
+		t.Fatalf("failed warmup stopped concurrent testbox=%q exists=%v", stopped, boxExists)
 	}
-	if leaseB != "tbx_bee123" {
-		t.Fatalf("process B lease=%q, want tbx_bee123", leaseB)
-	}
-
-	// Process B's healthy in-use testbox must survive process A's
-	// failed-warmup cleanup: A never created it.
-	if stopped := cp.stoppedIDs(); len(stopped) != 0 {
-		t.Fatalf("process A's failed-warmup cleanup stopped testbox(es) it does not own: %v (process B's lease severed mid-run)", stopped)
-	}
-	if !cp.has("tbx_bee123") {
-		t.Fatal("process B's testbox tbx_bee123 was removed from the control plane by process A's cleanup")
-	}
-	claim, claimErr := readLeaseClaim("tbx_bee123")
-	if claimErr != nil {
-		t.Fatal(claimErr)
-	}
-	if claim.LeaseID != "tbx_bee123" {
-		t.Fatalf("process B's lease claim was removed by process A's cleanup: %#v", claim)
+	if listCalls != 0 {
+		t.Fatalf("failed warmup inferred ownership from %d inventory scan(s)", listCalls)
 	}
 }

--- a/internal/providers/blacksmith/helpers.go
+++ b/internal/providers/blacksmith/helpers.go
@@ -112,19 +112,6 @@ func blacksmithListAllArgs(cfg Config) []string {
 	return append(blacksmithListArgs(cfg), "--all")
 }
 
-func blacksmithMatchesConfig(item blacksmithListItem, cfg Config) bool {
-	if workflow := blacksmithWorkflow(cfg); workflow != "" && item.Workflow != workflow {
-		return false
-	}
-	if job := blacksmithJob(cfg); job != "" && item.Job != job {
-		return false
-	}
-	if ref := blacksmithRef(cfg); ref != "" && item.Ref != ref {
-		return false
-	}
-	return true
-}
-
 func parseBlacksmithList(output string) []blacksmithListItem {
 	items := []blacksmithListItem{}
 	for _, line := range strings.Split(output, "\n") {

--- a/internal/providers/blacksmith/helpers.go
+++ b/internal/providers/blacksmith/helpers.go
@@ -19,9 +19,6 @@ var (
 	blacksmithSyncStartPattern = regexp.MustCompile(`(?i)^\s*Syncing(?:\.\.\.| from repo root:)`)
 	blacksmithSyncDonePattern  = regexp.MustCompile(`(?i)^\s*(Changes synced in|No changes to sync|Sync complete)\b`)
 	blacksmithStatusPollDelay  = 5 * time.Second
-	blacksmithCleanupAttempts  = 36
-	blacksmithCleanupDelay     = 5 * time.Second
-	blacksmithCleanupQuiet     = 12
 )
 
 type blacksmithFlagValues struct {


### PR DESCRIPTION
## Summary

Failed Blacksmith warmups previously inferred ownership from a before/after organization inventory diff plus workflow/job/ref matching. A concurrent warmup with the same configuration could create a Testbox inside that window and be stopped by the failing invocation.

The maintainer rewrite removes the ambiguous inventory sweep. A failed warmup now stops a Testbox only when that exact command emitted its `tbx_` ID. Failures without an ID rely on the provider idle timeout instead of risking another invocation's Testbox.

This is stronger than the original local-claim guard: another invocation has an unavoidable window after Testbox creation and before claim publication, and another host's local claim is not visible at all.

Part of https://github.com/openclaw/crabbox/issues/1123.

## Verification

- `go test -race ./internal/providers/blacksmith -run 'TestFailedWarmupDoesNotStopConcurrentUnclaimedTestbox|TestBlacksmithWarmupFailureStopsPrintedTestbox' -count=50`
- `go test -race ./internal/providers/blacksmith`
- `go vet ./...`
- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- Source-blind built-CLI behavior validation: anonymous failure made zero inventory and stop calls; emitted-ID failure stopped exactly `tbx_owned123` and made zero inventory calls.
- Blacksmith CLI `0.4.48` help confirmed no per-invocation label or ownership flag. Live inventory reached the configured backend but timed out, so no unowned provider mutation was attempted.
- AutoReview: clean, no accepted/actionable findings, confidence 0.89.

Thanks @anagnorisis2peripeteia for the report and concurrency harness.
