### PR TITLE
feat(cli): add editor handoff via crabbox open --editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added a single `open --editor=<name>` lease handoff for external editors, starting with Zed Remote Projects and preserving lease activity while the editor is connected. Thanks @zozo123.
 - Added a searchable, filterable Features capability explorer with responsive light and dark layouts, deep-linked state, and browser interaction proof. Thanks @zozo123.
 - Added Modal environment selection and named Secret injection without passing Secret values through Crabbox. Thanks @simonMoisselin.
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ crabbox prewarm                                      # lease + Actions hydration
 crabbox run --id blue-lobster -- pnpm test:changed
 crabbox connect blue-lobster                         # open an interactive SSH session
 crabbox ssh --id blue-lobster
+crabbox open --editor=zed --id blue-lobster          # prepare a Zed Remote Projects session
 crabbox stop blue-lobster
 ```
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -99,6 +99,7 @@ See [history](commands/history.md), [logs](commands/logs.md),
 ```text
 crabbox connect <id>                          open an interactive SSH session
 crabbox ssh --id <id>                          print the SSH command
+crabbox open --editor=zed --id <id>             prepare an editor handoff
 crabbox vnc --id <id> [--open]                 print/open SSH-tunneled VNC details
 crabbox webvnc --id <id> [--open]              bridge a desktop lease into the web portal
 crabbox code --id <id> [--open]                bridge a code lease into the web portal
@@ -108,8 +109,8 @@ crabbox screenshot --id <id> [--output <png>]  capture a PNG from a desktop leas
 crabbox desktop launch|terminal|record|proof|doctor|click|paste|type|key
 ```
 
-See [connect](commands/connect.md), [ssh](commands/ssh.md), [vnc](commands/vnc.md),
-[webvnc](commands/webvnc.md), [code](commands/code.md),
+See [connect](commands/connect.md), [ssh](commands/ssh.md), [open](commands/open.md),
+[vnc](commands/vnc.md), [webvnc](commands/webvnc.md), [code](commands/code.md),
 [egress](commands/egress.md), [ports](commands/ports.md),
 [screenshot](commands/screenshot.md), [desktop](commands/desktop.md).
 

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -45,6 +45,7 @@ same order as the CLI help.
 - [checkpoint](checkpoint.md)
 - [ssh](ssh.md)
 - [connect](connect.md)
+- [open](open.md)
 - [ports](ports.md)
 - [cp](cp.md)
 - [vnc](vnc.md)

--- a/docs/commands/open.md
+++ b/docs/commands/open.md
@@ -1,0 +1,71 @@
+# open
+
+`crabbox open` prepares an existing SSH-capable lease for an external editor.
+Select the editor with `--editor`; Crabbox prints its connection instructions
+and remote folder, then keeps the lease active until you press Ctrl-C.
+
+Zed Remote Projects is the first supported editor:
+
+```sh
+crabbox run --id swift-crab --sync-only
+crabbox open --editor=zed --id swift-crab
+```
+
+In Zed, open **Remote Projects**, select **Connect New Server**, paste the
+printed command, and open the printed folder. Keep `crabbox open` running for
+the duration of the editor session.
+
+## Why the command stays running
+
+External editors open their own SSH processes after a connection is added.
+Those processes do not send Crabbox lease heartbeats. While `crabbox open` is
+running, Crabbox keeps coordinator-backed leases heartbeating and marks
+direct-provider leases running or ready where the provider supports lease
+touches.
+
+The lease's configured hard TTL still applies while the command is running.
+
+Stopping `crabbox open` does not release the lease. Use
+`crabbox stop <id-or-slug>` when the workspace is no longer needed.
+
+## Workspace and synchronization
+
+The command opens the current repository's normal remote workspace and follows
+the current local subdirectory. It also honors a workspace hydrated through
+GitHub Actions. If the folder does not exist, the command asks you to run
+`crabbox run --id <lease> --sync-only` first.
+
+Crabbox synchronization is local to remote. Commit and push changes made in
+the editor, or copy them back explicitly, before releasing an ephemeral lease.
+
+## Zed security and platform boundaries
+
+The Zed handoff does not edit `~/.ssh/config`, modify Zed settings, or launch an
+editor process. Zed's command-line URL syntax cannot carry arbitrary SSH
+options such as per-lease identity files and proxy commands, so the complete
+command is handed to Zed's supported **Connect New Server** flow instead.
+
+Zed supports key-based SSH access to Linux and macOS targets. The handoff
+rejects Windows remote targets, which Zed does not support as remote servers,
+and token-as-username SSH providers, whose credentials should not be persisted
+in editor settings.
+
+## Flags
+
+`crabbox open` requires `--editor=<name>` and accepts the same lease, provider,
+target, routing, network, and `--reclaim` flags as
+[`crabbox connect`](connect.md). The first positional argument is also accepted
+as the lease id or slug:
+
+```sh
+crabbox open --editor=zed swift-crab
+crabbox open --editor=zed --id swift-crab --network tailscale
+crabbox open --editor=zed --provider ssh --target macos --static-host mac-studio.local
+```
+
+## See also
+
+- [`crabbox run`](run.md) - synchronize the local checkout to the lease.
+- [`crabbox ssh`](ssh.md) - print a general-purpose SSH command without holding a heartbeat.
+- [`crabbox connect`](connect.md) - open an interactive terminal session.
+- [`crabbox stop`](stop.md) - release the lease when finished.

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -65,6 +65,7 @@ live in the [Command Reference](../commands/README.md).
 - [Actions hydration](actions-hydration.md): let GitHub Actions prepare a runner, then sync local work into that workspace.
 - [Capsules](capsules.md): local-first replay manifests for GitHub Actions failures.
 - [Checkpoints](checkpoints.md): save, restore, and fork reusable remote workspaces.
+- [Editor handoff](../commands/open.md): prepare a synced lease for an external editor and keep its activity alive.
 - [Interactive desktop and VNC](interactive-desktop-vnc.md): VNC hub, support matrix, tunnel model, and QA boundaries.
 - [Artifacts](artifacts.md): screenshots, video, trimmed GIFs, logs, metadata, templates, and PR publishing.
 - [Linux VNC](vnc-linux.md): Linux desktop setup and troubleshooting.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -258,6 +258,16 @@ crabbox warmup --code
 crabbox code --id swift-crab --open
 ```
 
+Open the synced checkout in Zed Remote Projects:
+
+```sh
+crabbox run --id swift-crab --sync-only
+crabbox open --editor=zed --id swift-crab
+```
+
+Paste the printed SSH command into Zed's **Connect New Server** dialog, open the
+printed folder, and keep `crabbox open` running while you work.
+
 Use a Mac you already own (static SSH, no provisioning):
 
 ```yaml

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -111,6 +111,8 @@ func (a App) directCommandHelp(ctx context.Context, args []string) (error, bool)
 		return a.ssh(ctx, helpArgs), true
 	case "connect":
 		return a.connect(ctx, helpArgs), true
+	case "open":
+		return a.open(ctx, helpArgs), true
 	case "ports":
 		return a.ports(ctx, helpArgs), true
 	case "cp":
@@ -211,6 +213,7 @@ Commands:
   checkpoint  Create, restore, and fork workspace checkpoints
   ssh         Print the SSH command for a lease
   connect     Open an interactive SSH session to a lease
+  open        Prepare an editor handoff for a lease
   ports       Publish, list, or unpublish provider-native ports
   cp          Copy files between host and a delegated sandbox
   vnc         Print or open VNC connection details for a desktop lease
@@ -240,6 +243,7 @@ Common Flows:
   crabbox bench report --since 7d
   crabbox connect blue-lobster
   crabbox ssh --id blue-lobster
+  crabbox open --editor=zed --id blue-lobster
   crabbox ports --id blue-lobster --publish 8080
   crabbox cp --id blue-lobster ./coverage.xml SANDBOX:/tmp/coverage.xml
   crabbox vnc --id blue-lobster --open

--- a/internal/cli/cli_kong.go
+++ b/internal/cli/cli_kong.go
@@ -51,6 +51,7 @@ type crabboxKongCLI struct {
 	Checkpoint  checkpointKongCmd  `cmd:"" help:"Create, restore, and fork VM or workspace checkpoints."`
 	Ssh         sshKongCmd         `cmd:"" name:"ssh" passthrough:"" help:"Print the SSH command for a lease."`
 	Connect     connectKongCmd     `cmd:"" passthrough:"" help:"Open an interactive SSH session to a lease."`
+	Open        openKongCmd        `cmd:"" passthrough:"" help:"Prepare an editor handoff for a lease."`
 	Vnc         vncKongCmd         `cmd:"" name:"vnc" passthrough:"" help:"Print or open VNC connection details for a desktop lease."`
 	Webvnc      webvncKongCmd      `cmd:"" name:"webvnc" passthrough:"" help:"Open a desktop lease or local VNC tunnel in a browser."`
 	Code        codeKongCmd        `cmd:"" passthrough:"" help:"Bridge a code lease into the authenticated web portal."`
@@ -250,6 +251,9 @@ type sshKongCmd struct {
 	Args []string `arg:"" optional:""`
 }
 type connectKongCmd struct {
+	Args []string `arg:"" optional:""`
+}
+type openKongCmd struct {
 	Args []string `arg:"" optional:""`
 }
 type vncKongCmd struct {
@@ -650,6 +654,7 @@ func (c *marketplaceQuoteKongCmd) Run(ctx context.Context, app App) error {
 }
 func (c *sshKongCmd) Run(ctx context.Context, app App) error     { return app.ssh(ctx, c.Args) }
 func (c *connectKongCmd) Run(ctx context.Context, app App) error { return app.connect(ctx, c.Args) }
+func (c *openKongCmd) Run(ctx context.Context, app App) error    { return app.open(ctx, c.Args) }
 func (c *vncKongCmd) Run(ctx context.Context, app App) error     { return app.vnc(ctx, c.Args) }
 func (c *webvncKongCmd) Run(ctx context.Context, app App) error  { return app.webvnc(ctx, c.Args) }
 func (c *codeKongCmd) Run(ctx context.Context, app App) error    { return app.webCode(ctx, c.Args) }

--- a/internal/cli/open.go
+++ b/internal/cli/open.go
@@ -1,0 +1,114 @@
+package cli
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+)
+
+type editorTargetCapabilities struct {
+	supportsWindows       bool
+	supportsTokenUsername bool
+}
+
+type editorHandoffSpec struct {
+	displayName         string
+	connectInstructions string
+	targets             editorTargetCapabilities
+}
+
+var editorHandoffSpecs = map[string]editorHandoffSpec{
+	"zed": {
+		displayName: "Zed Remote Projects",
+		connectInstructions: "1. Open Remote Projects and select Connect New Server.\n" +
+			"2. Paste: %s\n" +
+			"3. Open: %s\n" +
+			"Keep this process running to maintain lease activity; press Ctrl-C when the Zed session is finished.\n",
+		targets: editorTargetCapabilities{
+			supportsWindows:       false,
+			supportsTokenUsername: false,
+		},
+	},
+}
+
+func (a App) open(ctx context.Context, args []string) error {
+	var editorName string
+	var editor editorHandoffSpec
+	resolved, err := a.resolveSSHCommandTargetWithOptions(ctx, "open", args, false, sshCommandResolveOptions{
+		registerFlags: func(fs *flag.FlagSet) {
+			fs.StringVar(&editorName, "editor", "", "editor: "+strings.Join(editorHandoffNames(), ", "))
+		},
+		validateFlags: func() error {
+			editorName = strings.ToLower(strings.TrimSpace(editorName))
+			if editorName == "" {
+				return exit(2, "usage: crabbox open --editor=<name> --id <lease-id-or-slug>")
+			}
+			var ok bool
+			editor, ok = editorHandoffSpecs[editorName]
+			if !ok {
+				return exit(2, "unknown editor %q; available editors: %s", editorName, strings.Join(editorHandoffNames(), ", "))
+			}
+			return nil
+		},
+	})
+	if err != nil {
+		return err
+	}
+	return a.runEditorHandoff(ctx, editorName, editor, resolved)
+}
+
+func editorHandoffNames() []string {
+	names := make([]string, 0, len(editorHandoffSpecs))
+	for name := range editorHandoffSpecs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func (a App) runEditorHandoff(ctx context.Context, editorName string, editor editorHandoffSpec, resolved resolvedSSHCommandTarget) error {
+	if err := validateEditorTarget(editorName, editor, resolved.Config, resolved.Lease.SSH); err != nil {
+		return err
+	}
+	repo, err := findRepo()
+	if err != nil {
+		return err
+	}
+	_, folder, hydratedByActions := codeWorkspace(ctx, resolved.Lease.SSH, resolved.Config, resolved.Lease.LeaseID, repo)
+	if err := runSSHQuiet(ctx, resolved.Lease.SSH, "test -d "+shellQuote(folder)); err != nil {
+		return exit(5, "remote folder %q is not ready; sync it first with: crabbox run --id %s --sync-only", folder, resolved.Lease.LeaseID)
+	}
+	if hydratedByActions {
+		fmt.Fprintf(a.Stderr, "using GitHub Actions workspace for %s\n", resolved.Lease.LeaseID)
+	}
+
+	stopLeaseActivity := a.startInteractiveSSHLeaseActivity(ctx, resolved.Config, resolved.Lease)
+	defer stopLeaseActivity()
+	writeEditorInstructions(a.Stdout, editor, resolved.Lease.SSH, folder)
+
+	<-ctx.Done()
+	return nil
+}
+
+func validateEditorTarget(editorName string, editor editorHandoffSpec, cfg Config, target SSHTarget) error {
+	if target.AuthSecret && !editor.targets.supportsTokenUsername {
+		return exit(2, "%s does not support token-as-username SSH credentials; use a key-based SSH provider", editorName)
+	}
+	if firstNonBlank(target.TargetOS, cfg.TargetOS) == targetWindows && !editor.targets.supportsWindows {
+		return exit(2, "%s remote projects require a Linux or macOS target", editorName)
+	}
+	return nil
+}
+
+func editorSSHCommandLine(target SSHTarget) string {
+	args := append(sshBaseArgs(target), target.User+"@"+target.Host)
+	return "ssh " + strings.Join(shellWords(args), " ")
+}
+
+func writeEditorInstructions(out io.Writer, editor editorHandoffSpec, target SSHTarget, folder string) {
+	fmt.Fprintln(out, editor.displayName)
+	fmt.Fprintf(out, editor.connectInstructions, editorSSHCommandLine(target), folder)
+}

--- a/internal/cli/open_test.go
+++ b/internal/cli/open_test.go
@@ -1,0 +1,157 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestOpenEditorZedTargetConstraints(t *testing.T) {
+	zed := editorHandoffSpecs["zed"]
+	tests := []struct {
+		name    string
+		cfg     Config
+		target  SSHTarget
+		wantErr string
+	}{
+		{name: "linux", target: SSHTarget{TargetOS: targetLinux}},
+		{name: "macos", target: SSHTarget{TargetOS: targetMacOS}},
+		{name: "config target", cfg: Config{TargetOS: targetLinux}},
+		{name: "windows", target: SSHTarget{TargetOS: targetWindows}, wantErr: "Linux or macOS"},
+		{name: "token username", target: SSHTarget{TargetOS: targetLinux, AuthSecret: true}, wantErr: "key-based SSH provider"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateEditorTarget("zed", zed, test.cfg, test.target)
+			if test.wantErr == "" {
+				if err != nil {
+					t.Fatal(err)
+				}
+				return
+			}
+			var exitErr ExitError
+			if !AsExitError(err, &exitErr) || exitErr.Code != 2 || !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("error=%v want exit 2 containing %q", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestOpenEditorZedSSHCommandLineKeepsExecutableUnquoted(t *testing.T) {
+	got := editorSSHCommandLine(SSHTarget{
+		User: "alice",
+		Host: "203.0.113.10",
+		Port: "2222",
+		Key:  "/tmp/key with spaces",
+	})
+	if !strings.HasPrefix(got, "ssh ") {
+		t.Fatalf("command=%q should start with an unquoted ssh executable", got)
+	}
+	for _, want := range []string{"'-i' '/tmp/key with spaces'", "'-p' '2222'", "'alice@203.0.113.10'"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("command=%q missing %q", got, want)
+		}
+	}
+}
+
+func TestOpenEditorZedHappyPathPrintsInstructions(t *testing.T) {
+	fakeEditorSSH(t, 0)
+	ctx, cancel := context.WithCancel(context.Background())
+	out := &cancelBuffer{cancel: cancel}
+	cfg := Config{WorkRoot: "/work", TargetOS: targetLinux}
+	target := SSHTarget{User: "alice", Host: "example.com", Port: "22", TargetOS: targetLinux}
+	resolved := resolvedSSHCommandTarget{Config: cfg, Lease: LeaseTarget{SSH: target}}
+
+	err := (App{Stdout: out, Stderr: &bytes.Buffer{}}).runEditorHandoff(ctx, "zed", editorHandoffSpecs["zed"], resolved)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo, err := findRepo()
+	if err != nil {
+		t.Fatal(err)
+	}
+	folder := mappedRemoteCodeFolder(remoteJoin(cfg, repo.Name), repo)
+	for _, want := range []string{
+		"Zed Remote Projects",
+		"Connect New Server",
+		"Paste: ssh ",
+		"'alice@example.com'",
+		"Open: " + folder,
+		"Keep this process running to maintain lease activity",
+		"press Ctrl-C",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("instructions missing %q:\n%s", want, out.String())
+		}
+	}
+}
+
+func TestOpenEditorZedMissingSyncedFolder(t *testing.T) {
+	fakeEditorSSH(t, 1)
+	resolved := resolvedSSHCommandTarget{
+		Config: Config{WorkRoot: "/work", TargetOS: targetLinux},
+		Lease: LeaseTarget{
+			LeaseID: "swift-crab",
+			SSH:     SSHTarget{User: "alice", Host: "example.com", Port: "22", TargetOS: targetLinux},
+		},
+	}
+	err := (App{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}).runEditorHandoff(
+		context.Background(), "zed", editorHandoffSpecs["zed"], resolved,
+	)
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 5 {
+		t.Fatalf("error=%v want exit 5", err)
+	}
+	if !strings.Contains(err.Error(), "crabbox run --id swift-crab --sync-only") {
+		t.Fatalf("error=%v missing sync-only hint", err)
+	}
+}
+
+func TestOpenEditorRejectsUnknownEditor(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).open(context.Background(), []string{
+		"--editor=vim",
+		"--id", "swift-crab",
+	})
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("error=%v want exit 2", err)
+	}
+	if !strings.Contains(err.Error(), `unknown editor "vim"`) || !strings.Contains(err.Error(), "available editors: zed") {
+		t.Fatalf("error=%v missing editor choices", err)
+	}
+}
+
+type cancelBuffer struct {
+	bytes.Buffer
+	cancel context.CancelFunc
+}
+
+func (w *cancelBuffer) Write(p []byte) (int, error) {
+	w.cancel()
+	return w.Buffer.Write(p)
+}
+
+func fakeEditorSSH(t *testing.T, folderExit int) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("test helper uses a POSIX shell script")
+	}
+	dir := t.TempDir()
+	script := `#!/bin/sh
+case "$*" in
+  *"test -d "*) exit "$CRABBOX_FAKE_FOLDER_EXIT" ;;
+  *) exit 1 ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(dir, "ssh"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CRABBOX_FAKE_FOLDER_EXIT", strconv.Itoa(folderExit))
+}

--- a/internal/cli/ssh_cmd.go
+++ b/internal/cli/ssh_cmd.go
@@ -27,6 +27,15 @@ type resolvedSSHCommandTarget struct {
 }
 
 func (a App) resolveSSHCommandTarget(ctx context.Context, command string, args []string, allowShowSecret bool) (resolvedSSHCommandTarget, error) {
+	return a.resolveSSHCommandTargetWithOptions(ctx, command, args, allowShowSecret, sshCommandResolveOptions{})
+}
+
+type sshCommandResolveOptions struct {
+	registerFlags func(*flag.FlagSet)
+	validateFlags func() error
+}
+
+func (a App) resolveSSHCommandTargetWithOptions(ctx context.Context, command string, args []string, allowShowSecret bool, opts sshCommandResolveOptions) (resolvedSSHCommandTarget, error) {
 	defaults := defaultConfig()
 	fs := newFlagSet(command, a.Stderr)
 	provider := fs.String("provider", defaults.Provider, providerHelpSSH())
@@ -39,8 +48,16 @@ func (a App) resolveSSHCommandTarget(ctx context.Context, command string, args [
 	providerFlags := registerProviderFlags(fs, defaults)
 	targetFlags := registerTargetFlags(fs, defaults)
 	networkFlags := registerNetworkModeFlag(fs, defaults)
+	if opts.registerFlags != nil {
+		opts.registerFlags(fs)
+	}
 	if err := parseInterspersedFlags(fs, args); err != nil {
 		return resolvedSSHCommandTarget{}, err
+	}
+	if opts.validateFlags != nil {
+		if err := opts.validateFlags(); err != nil {
+			return resolvedSSHCommandTarget{}, err
+		}
 	}
 	idFlagSet := flagWasSet(fs, "id")
 	setIDFromFirstArg(fs, id)


### PR DESCRIPTION
## Summary

- add one top-level `crabbox open --editor=<name>` handoff instead of one command per editor
- keep editor display text, connection instructions, and target capabilities in a small editor table, so VS Code or Cursor support is another table entry
- implement Zed Remote Projects with the existing SSH target resolution, synced-workspace check, pasteable SSH command, and lease heartbeat held until Ctrl-C
- document the generalized editor workflow and credit the original contributor

## Supersedes

This supersedes https://github.com/openclaw/crabbox/pull/1109 without modifying its branch. Thanks @zozo123 for the original Zed Remote Projects work and behavior.

## Validation

- `go build ./...`
- `go vet ./...`
- `go test ./internal/cli/ -run 'Open|Editor|Zed' -count=1`
- `node scripts/check-command-docs.mjs`
- `scripts/check-docs.sh`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` (clean)

The focused tests cover Zed instructions, Windows rejection, token-as-username rejection, the missing synced-folder exit 5 hint, unknown editor rejection, and unquoted `ssh` with shell-quoted arguments.
