### PR TITLE
fix(node): avoid logging provider errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixed
 
-- Failed Node coordinator startup on malformed trusted-proxy CIDRs and warned on untrusted forwarded client headers so reverse-proxy source-bucket collapse is visible without changing OAuth admission limits.
+- Failed Node coordinator startup on malformed trusted-proxy CIDRs, warned on untrusted forwarded client headers, and kept environment-backed provider failures out of top-level request logs.
 - Kept pond SSH forwards process-owned and grouped each member's ports into one connection, so terminal teardown reaps tunnels and helpers without hiding genuine failures or multiplying handshakes. Thanks @anagnorisis2peripeteia.
 - Preserved foreground container-runner output buffered behind slow HTTP clients when the detached-descendant drain cap expires.
 - Stopped a previously started egress host daemon during non-daemon egress starts so it cannot clobber the new foreground session, and held the per-lease lock until the foreground host joins so concurrent replacement starts cannot interleave.

--- a/worker/node/server.ts
+++ b/worker/node/server.ts
@@ -136,7 +136,8 @@ async function handleRequest(request: IncomingMessage, response: ServerResponse)
       request.destroy();
       return;
     }
-    console.error("coordinator request failed", error);
+    // Provider failures can contain environment-backed credentials; keep only safe context here.
+    console.error("coordinator request failed");
     await writeResponse(response, Response.json({ error: "internal_error" }, { status: 500 }));
   } finally {
     cancellation.dispose();
@@ -168,8 +169,8 @@ async function handleUpgrade(
     if (!context.upgraded) {
       await writeUpgradeResponse(socket, response);
     }
-  } catch (error) {
-    console.error("coordinator websocket upgrade failed", error);
+  } catch {
+    console.error("coordinator websocket upgrade failed");
     if (!context.upgraded) {
       await writeUpgradeResponse(
         socket,


### PR DESCRIPTION
## Summary

- stop passing arbitrary HTTP and WebSocket request errors to the Node coordinator's top-level logger
- preserve stable failure context and existing client error responses
- update the current release note to include the log-safety hardening

## Why

The aggregate CodeQL check on https://github.com/openclaw/crabbox/pull/1115 reported two high-severity clear-text logging paths after that PR merged. Both sinks could receive errors derived from the environment-backed coordinator configuration. This focused follow-up removes the credential-bearing value from those log calls rather than suppressing the scanner.

## Verification

- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check:node --prefix worker`
- `npm test --prefix worker -- node-build.test.ts server-support.test.ts` — 21 passed
- `npm test --prefix worker` — 34 files passed, 2 skipped; 1,059 tests passed, 3 skipped
- `npm run build:node --prefix worker`
- real Node coordinator against ephemeral PostgreSQL: health and readiness returned 200; two untrusted forwarded requests remained nonblocking and emitted one rate-limited warning
- AutoReview clean with no accepted/actionable findings (confidence 0.94)

## Risk

The two unexpected-request logs retain the failure location but omit exception details. Response status and request handling are unchanged.

Follow-up to https://github.com/openclaw/crabbox/pull/1115.
