### PR TITLE
test(cli): keep lease-release tests out of the real crabbox state dir

### DIFF
--- a/internal/cli/prewarm_test.go
+++ b/internal/cli/prewarm_test.go
@@ -64,6 +64,7 @@ func (b *prewarmCleanupTestBackend) Touch(context.Context, TouchRequest) (Server
 }
 
 func TestPrewarmPostWarmupFailuresReleaseSSHLease(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir()) // lease cleanup stops egress daemons; keep lock files out of the real state dir
 	for _, stage := range []string{"actions hydration", "probe", "pool registration"} {
 		t.Run(stage, func(t *testing.T) {
 			backend := &prewarmCleanupTestBackend{}
@@ -131,6 +132,7 @@ func TestPrewarmGuardedCleanupUsesAcquiredLeaseFence(t *testing.T) {
 }
 
 func TestPrewarmCleanupFailurePrintsStopCommand(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	for _, tc := range []struct {
 		name    string
 		backend *prewarmCleanupTestBackend
@@ -172,6 +174,7 @@ func TestPrewarmFailureDoesNotReleaseDelegatedProvider(t *testing.T) {
 }
 
 func TestPrewarmCoordinatorCleanupReleasesByIDWhenResolveFails(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	released := false
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -63,6 +63,7 @@ func (b *warmupFailureReleaseBackend) Touch(context.Context, TouchRequest) (Serv
 }
 
 func TestWarmupFailureLeavesAcknowledgedLeaseForControllerReleaseGate(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir()) // standalone cleanup stops egress daemons; keep lock files out of the real state dir
 	backend := &warmupFailureReleaseBackend{}
 	app := App{Stdout: io.Discard, Stderr: io.Discard}
 	lease := LeaseTarget{LeaseID: "cbx_abcdef123456"}
@@ -80,6 +81,7 @@ func TestWarmupFailureLeavesAcknowledgedLeaseForControllerReleaseGate(t *testing
 }
 
 func TestReleaseBackendLeaseStopsBeforeCleanupAfterOwnershipChange(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir()) // same release path; only the ownership-change early return keeps it off the state dir
 	base := &warmupFailureReleaseBackend{}
 	backend := &ownershipChangedReleaseBackend{warmupFailureReleaseBackend: base}
 	lease := LeaseTarget{LeaseID: "cbx_abcdef123456", SSH: SSHTarget{Host: "192.0.2.70"}}


### PR DESCRIPTION
## Summary

Four internal/cli tests drive lease-release cleanup (which stops per-lease egress host daemons and takes the per-lease daemon file lock) without isolating the state directory, so every `go test -race ./internal/cli/` run left a stray `cbx_abcdef123456.pid.lock` in the user's real `~/Library/Application Support/crabbox/state/egress/`. Confirmed leakers, each reproduced per-test by watching the real state dir: `TestWarmupFailureLeavesAcknowledgedLeaseForControllerReleaseGate` (run_test.go), and `TestPrewarmPostWarmupFailuresReleaseSSHLease`, `TestPrewarmCleanupFailurePrintsStopCommand`, `TestPrewarmCoordinatorCleanupReleasesByIDWhenResolveFails` (prewarm_test.go). `TestReleaseBackendLeaseStopsBeforeCleanupAfterOwnershipChange` gets the same isolation since only its ownership-change early return currently keeps it off the state dir.

Fix: `t.Setenv("XDG_STATE_HOME", t.TempDir())` per test, matching the suite's existing isolation convention (`crabboxStateDir` prefers `XDG_STATE_HOME`).

Known remaining sibling (separate follow-up): some test also creates/rotates real `state/claims/tbx_*.json` + `state/claim-locks/*.lock` entries per suite run.

## Verification

- `go vet ./internal/cli/`
- Per-test: state dir stays clean for all four former leakers.
- Full `go test -race ./internal/cli/`: pass, and a before/after `find` diff of the real state tree shows no egress lock-file leak.

Test-only change; no changelog entry, no config or secret implications.
