### PR TITLE
test(providers): keep sandbox claim tests out of the real crabbox state dir

### DIFF
--- a/internal/providers/applemachine/backend_test.go
+++ b/internal/providers/applemachine/backend_test.go
@@ -78,6 +78,7 @@ func TestInspectMachineDecodesAppleJSON(t *testing.T) {
 }
 
 func TestRunUsesHomeMountedRepoAndEnv(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir()) // claims (and their lock files) must stay out of the real state dir
 	originalGOOS, originalGOARCH := hostGOOS, hostGOARCH
 	hostGOOS, hostGOARCH = "darwin", "arm64"
 	t.Cleanup(func() { hostGOOS, hostGOARCH = originalGOOS, originalGOARCH })
@@ -132,6 +133,7 @@ func TestRunUsesHomeMountedRepoAndEnv(t *testing.T) {
 }
 
 func TestRunTimingJSONClassifiesCommandFailure(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	originalGOOS, originalGOARCH := hostGOOS, hostGOARCH
 	hostGOOS, hostGOARCH = "darwin", "arm64"
 	t.Cleanup(func() { hostGOOS, hostGOARCH = originalGOOS, originalGOARCH })
@@ -173,6 +175,7 @@ func TestRunTimingJSONClassifiesCommandFailure(t *testing.T) {
 }
 
 func TestRunDeletesOneShotMachineSession(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir()) // one-shot Run claims a generated lease id; keep the claim lock out of the real state dir
 	originalGOOS, originalGOARCH := hostGOOS, hostGOARCH
 	hostGOOS, hostGOARCH = "darwin", "arm64"
 	t.Cleanup(func() { hostGOOS, hostGOARCH = originalGOOS, originalGOARCH })

--- a/internal/providers/cubesandbox/backend_test.go
+++ b/internal/providers/cubesandbox/backend_test.go
@@ -768,6 +768,7 @@ func TestCubeSandboxTimeoutPreservesRequestedTTL(t *testing.T) {
 }
 
 func TestCubeSandboxCreateSandboxPreservesDefaultTTL(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir()) // keep=true writes a lease claim; keep it out of the real state dir
 	client := &fakeCubeSandboxSyncClient{}
 	backend := &cubesandboxBackend{
 		cfg: Config{

--- a/internal/providers/tensorlake/backend_test.go
+++ b/internal/providers/tensorlake/backend_test.go
@@ -740,6 +740,7 @@ func TestRunTimingJSONUsesClaimSlugForReusedSandbox(t *testing.T) {
 }
 
 func TestKeepOnFailureRetainsSandboxAndPrintsHint(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir()) // keep-on-failure writes a lease claim (and lock); keep both out of the real state dir
 	sandboxID := "failkeep" + randomSuffix() + randomSuffix()
 	defer removeLeaseClaim(leasePrefix + sandboxID)
 	runner := newRunner(
@@ -841,6 +842,7 @@ func TestRunSkipsSyncWithNoSync(t *testing.T) {
 }
 
 func TestKeepRetainsSandbox(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir()) // Keep writes a lease claim; keep it out of the real state dir
 	runner := newRunner(map[string]scriptedReply{
 		"sbx create": {stdout: "keepid01234567890ab\n"},
 		"sbx exec":   {stdout: "hi\n"},
@@ -952,6 +954,7 @@ func TestStopRejectsUnclaimedID(t *testing.T) {
 }
 
 func TestCreateInvocationCarriesSizingFlags(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir()) // Keep writes a lease claim; keep it out of the real state dir
 	runner := newRunner(map[string]scriptedReply{
 		"sbx create": {stdout: "sizingid01234567890\n"},
 		"sbx exec":   {stdout: "ok\n"},


### PR DESCRIPTION
## Summary

Seven provider tests wrote lease claims (and claim lock files) into the user's real state directory (`~/Library/Application Support/crabbox/state/`) because they exercise keep/one-shot claim paths without isolating `XDG_STATE_HOME`:

- tensorlake: `TestKeepRetainsSandbox`, `TestCreateInvocationCarriesSizingFlags`, `TestKeepOnFailureRetainsSandboxAndPrintsHint` (this one removed its claim but left the `.lock` behind)
- cubesandbox: `TestCubeSandboxCreateSandboxPreservesDefaultTTL`
- applemachine: `TestRunUsesHomeMountedRepoAndEnv`, `TestRunTimingJSONClassifiesCommandFailure`, `TestRunDeletesOneShotMachineSession` (one-shot Run claims a generated lease id per run, so it deposited a fresh orphan lock every run)

Each test now sets `t.Setenv("XDG_STATE_HOME", t.TempDir())`, matching the isolation the neighboring tests in the same files already use. Same bug class as https://github.com/openclaw/crabbox/pull/1129.

Attribution note: fresh `tbx_*` claim churn observed during suite runs turned out to be ambient (live sessions warming Blacksmith testboxes on the same machine), not test leakage — every remaining state-dir change during an 8-minute two-suite proof window traced to real repoRoots of active sessions.

## Verification

- `go vet` on the three packages; `go test -race -count=1` on the three packages: pass.
- Per-package state-tree diff sweep across all of `internal/providers/*`: clean after the fix (previously leaking packages verified clean on rerun).
- Full proof window: `go test -race ./internal/cli/` (pass, 300s) + `go test ./internal/providers/...` (pass) with a before/after `find` diff of the real state tree — only ambient live-session claims changed; zero test artifacts.

Test-only change; no changelog entry, no config or secret implications.

