### PR TITLE
test(cli): make controller unready-inspection restart test deterministic

### DIFF
--- a/internal/cli/controller_service_test.go
+++ b/internal/cli/controller_service_test.go
@@ -2075,14 +2075,17 @@ func TestControllerRestartDoesNotTreatUnreadyInspectionAsReady(t *testing.T) {
 	defer cancel()
 	service, err := newControllerService(ctx, controllerServiceOptions{
 		StateFile: path, MaxConcurrent: 1, Profile: request.Profile,
-		CreateTimeout: time.Second, InspectTimeout: time.Second, StopTimeout: time.Second,
+		// CreateTimeout also bounds provisioning staleness (provisioningExpired);
+		// keep it far above race-detector scheduling latency so the unready
+		// inspection is judged inside the provisioning window.
+		CreateTimeout: time.Hour, InspectTimeout: time.Second, StopTimeout: time.Second,
 		ConnectionTimeout: time.Second,
 	}, runner, "token", &bytes.Buffer{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	service.startReconciliation()
-	time.Sleep(100 * time.Millisecond)
+	waitControllerWorkspaceStatusMessage(t, service, request.ID, "provisioning", "workspace provisioning; waiting for provider")
 	warmups, _, _ := runner.counts()
 	if warmups != 0 {
 		t.Fatalf("unready inspection started duplicate warmup; calls=%d", warmups)


### PR DESCRIPTION
## Summary

`TestControllerRestartDoesNotTreatUnreadyInspectionAsReady` was flaky under `go test -race ./internal/cli/` (observed 'status="stopping" want provisioning', roughly one failure in six full-suite runs on 2026-07-17; always passing alone).

Exact transition: the test seeds a provisioning record with `CreatedAt = time.Now()` and `CreateTimeout: time.Second`. `reconcileProvisioning` checks `status.Ready` first, and only unready inspections fall through to `provisioningExpired`, which fires once `now >= CreatedAt + CreateTimeout`. Under race-detector load, more than one second can elapse before the reconcile pass judges the unready inspection, so `finishProvisioningFailure` moves the workspace to "stopping". (The sibling ready-path test is immune because `Ready` wins before the expiry check.)

Fix, in the test only:
- `CreateTimeout: time.Hour` so the staleness window cannot elapse during the test; the other one-second timeouts only bound instant fake-runner calls and stay as they were.
- Replace the fixed 100ms sleep with `waitControllerWorkspaceStatusMessage(..., "provisioning", "workspace provisioning; waiting for provider")` — the message `markProvisioningWaiting` sets right after an unready inspection is processed. This both removes the timing assumption and strengthens the test: it now proves a reconcile pass actually judged the unready inspection, instead of potentially asserting on the untouched seeded state.

## Verification

- `go vet ./internal/cli/`
- `go test -race ./internal/cli/ -run 'TestControllerRestart' -count=20`: pass (164s, 20 consecutive runs of the restart tests)
- Full `go test -race ./internal/cli/`: pass (429s)

Test-only change; no changelog entry, no config or secret implications.
