### PR TITLE
docs(security): provide a working private reporting path

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -89,13 +89,14 @@ break need an explicit product decision and migration path.
 
 Crabbox targets a single trusted user running on their own machine, so most
 findings are ordinary bugs rather than exploitable vulnerabilities against the
-boundaries above. This project does not run a separate private-disclosure
-process.
+boundaries above.
 
-If you find a security-relevant issue, the most useful thing you can do is send
-a pull request with the fix — that way the fix and the report arrive together
-and nothing sits publicly described but unpatched. For non-sensitive hardening,
-reliability, or expected-behavior questions, a normal GitHub issue is fine.
+Report suspected vulnerabilities privately to
+[security@openclaw.ai](mailto:security@openclaw.ai). Do not open a public issue
+or pull request that discloses an unpatched vulnerability, exploit path, secret,
+or security-sensitive proof of concept. For non-sensitive hardening,
+reliability, or expected-behavior questions, a normal GitHub issue or pull
+request is fine.
 
 A helpful report or PR identifies which supported boundary is crossed (see the
 sections above), the attacker access it requires, and the affected code path.


### PR DESCRIPTION
Related: https://github.com/openclaw/crabbox/issues/1095

## What Problem This Solves

Resolves a problem where suspected-vulnerability reporters had no working private disclosure path because GitHub private vulnerability reporting is disabled for this repository. The interim policy removed the dead link but directed reporters toward public fixes instead.

## Why This Change Was Made

The policy now uses the same monitored fallback address documented by the main OpenClaw repository: security@openclaw.ai. Public issues and pull requests remain appropriate for non-sensitive hardening and reliability work.

## User Impact

Security researchers can privately report sensitive findings without exposing an unpatched vulnerability, exploit path, secret, or proof of concept.

## Evidence

- Compared the reporting guidance with openclaw/openclaw `SECURITY.md` on current `main`.
- `git diff --check` — passed.
- Verified `SECURITY.md` contains `security@openclaw.ai` and no `security/advisories/new` link.
- Autoreview: clean; no accepted or actionable findings.
