### PR TITLE
chore(release): prepare 0.39.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.38.5 - Unreleased
+## 0.39.0 - 2026-07-17
 
 ### Added
 

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/crabbox-worker",
-  "version": "0.38.4",
+  "version": "0.39.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/crabbox-worker",
-      "version": "0.38.4",
+      "version": "0.39.0",
       "dependencies": {
         "@aws-sdk/credential-providers": "^3.1084.0",
         "@cloudflare/containers": "^0.3.7",

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/crabbox-worker",
-  "version": "0.38.4",
+  "version": "0.39.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Prepares the 0.39.0 release: converts the accumulated `0.38.5 - Unreleased` changelog section to `0.39.0 - 2026-07-17`. Minor bump (from v0.38.4) for the new external-provider desktop support (macOS/Windows/WSL2) plus the batch of features and fixes already logged.

No code change — changelog only. The signed tag, producer, signing, notarization, draft, publish, and Homebrew gates follow per docs/RELEASING.md.
