### PR TITLE
chore(release): authorize v0.39.0 source

### DIFF
--- a/release/records/v0.39.0.json
+++ b/release/records/v0.39.0.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "repository": "openclaw/crabbox",
+  "tag": "v0.39.0",
+  "tagObject": "b515d60cfd0e744bcb0cd4823311fba58e3a87e4",
+  "sourceCommit": "f46ce01f42e7bc2ff8491fafb3074ebd27b52c4e",
+  "publicationStatus": "ready"
+}


### PR DESCRIPTION
Adds the protected release record binding the signed `v0.39.0` tag object `b515d60c` to source commit `f46ce01f`, publicationStatus ready. Required by the release producer's source-verification gate (docs/RELEASING.md).