### PR TITLE
chore(release): update v0.39.0 tag object after retag

### DIFF
--- a/release/records/v0.39.0.json
+++ b/release/records/v0.39.0.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "repository": "openclaw/crabbox",
   "tag": "v0.39.0",
-  "tagObject": "b515d60cfd0e744bcb0cd4823311fba58e3a87e4",
+  "tagObject": "cf459656a5cfb123a2a078ef11867e243e2cca72",
   "sourceCommit": "f46ce01f42e7bc2ff8491fafb3074ebd27b52c4e",
   "publicationStatus": "ready"
 }


### PR DESCRIPTION
The v0.39.0 tag was recreated with the correct bare-version annotation (`v0.39.0`) required by the release source verifier; the prior annotation caused a verification failure. Updates the release record's tagObject from the old `b515d60c` to the corrected signed tag `cf459656` (same source commit `f46ce01f`). Tag ruleset was temporarily relaxed to recreate the tag and restored to active immediately after.