### PR TITLE
fix(docs): make all sidebar counts reflect content pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -8,6 +8,7 @@ on:
       - "docs/**"
       - "scripts/build-docs-site.mjs"
       - "scripts/enhance-docs-site.mjs"
+      - "scripts/normalize-provider-counts.mjs"
       - ".github/workflows/pages.yml"
   workflow_dispatch:
 
@@ -38,6 +39,7 @@ jobs:
         run: |
           node scripts/build-docs-site.mjs
           node scripts/enhance-docs-site.mjs
+          node scripts/normalize-provider-counts.mjs
 
       - name: Configure Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -7,3 +7,4 @@ node scripts/check-docs-links.mjs
 node scripts/build-docs-site.mjs
 node --test scripts/build-docs-site.test.js scripts/enhance-docs-site.test.mjs
 node scripts/enhance-docs-site.mjs
+node scripts/normalize-provider-counts.mjs

--- a/scripts/normalize-provider-counts.mjs
+++ b/scripts/normalize-provider-counts.mjs
@@ -8,6 +8,8 @@ export function normalizeProviderCounts(source, providerCount) {
     throw new TypeError("providerCount must be a non-negative integer");
   }
 
+  // Provider metadata is the canonical registry; the navigation also contains
+  // providers/README.md, which is an index page rather than another provider.
   return source
     .replace(/Browse \d+ providers/g, `Browse ${providerCount} providers`)
     .replace(

--- a/scripts/normalize-provider-counts.mjs
+++ b/scripts/normalize-provider-counts.mjs
@@ -3,19 +3,31 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-export function normalizeProviderCounts(source, providerCount) {
+export function normalizeNavigationCounts(source, providerCount) {
   if (!Number.isInteger(providerCount) || providerCount < 0) {
     throw new TypeError("providerCount must be a non-negative integer");
   }
 
-  // Provider metadata is the canonical registry; the navigation also contains
-  // providers/README.md, which is an index page rather than another provider.
-  return source
-    .replace(/Browse \d+ providers/g, `Browse ${providerCount} providers`)
-    .replace(
-      /(<summary><h2>Providers<\/h2><span class="nav-count">)\d+(<\/span>)/g,
-      `$1${providerCount}$2`,
-    );
+  const withCanonicalProviderCta = source.replace(
+    /Browse \d+ providers/g,
+    `Browse ${providerCount} providers`,
+  );
+
+  return withCanonicalProviderCta.replace(
+    /<details class="nav-section"[^>]*>[\s\S]*?<\/details>/g,
+    (section) => {
+      const links = [...section.matchAll(/<a class="nav-link(?: active)?" href="([^"]+)"/g)];
+      const itemCount = links.filter(([, href]) => {
+        const pathname = href.split(/[?#]/, 1)[0];
+        return path.posix.basename(pathname) !== "index.html";
+      }).length;
+
+      return section.replace(
+        /(<span class="nav-count">)\d+(<\/span>)/,
+        `$1${itemCount}$2`,
+      );
+    },
+  );
 }
 
 export function normalizeProviderCountFiles({
@@ -29,7 +41,7 @@ export function normalizeProviderCountFiles({
 
   for (const file of htmlFiles(siteDir)) {
     const source = fs.readFileSync(file, "utf8");
-    const normalized = normalizeProviderCounts(source, providerCount);
+    const normalized = normalizeNavigationCounts(source, providerCount);
     if (normalized === source) continue;
     fs.writeFileSync(file, normalized, "utf8");
     changed += 1;
@@ -51,5 +63,5 @@ function htmlFiles(dir) {
 const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
 if (isMain) {
   const result = normalizeProviderCountFiles();
-  console.log(`normalized provider count to ${result.providerCount} across ${result.changed} pages`);
+  console.log(`normalized navigation counts across ${result.changed} pages; ${result.providerCount} providers`);
 }

--- a/scripts/normalize-provider-counts.mjs
+++ b/scripts/normalize-provider-counts.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export function normalizeProviderCounts(source, providerCount) {
+  if (!Number.isInteger(providerCount) || providerCount < 0) {
+    throw new TypeError("providerCount must be a non-negative integer");
+  }
+
+  return source
+    .replace(/Browse \d+ providers/g, `Browse ${providerCount} providers`)
+    .replace(
+      /(<summary><h2>Providers<\/h2><span class="nav-count">)\d+(<\/span>)/g,
+      `$1${providerCount}$2`,
+    );
+}
+
+export function normalizeProviderCountFiles({
+  root = process.cwd(),
+  siteDir = path.join(root, "dist", "docs-site"),
+  metadataFile = path.join(root, "docs", "providers", "provider-metadata.json"),
+} = {}) {
+  const metadata = JSON.parse(fs.readFileSync(metadataFile, "utf8"));
+  const providerCount = Object.keys(metadata).length;
+  let changed = 0;
+
+  for (const file of htmlFiles(siteDir)) {
+    const source = fs.readFileSync(file, "utf8");
+    const normalized = normalizeProviderCounts(source, providerCount);
+    if (normalized === source) continue;
+    fs.writeFileSync(file, normalized, "utf8");
+    changed += 1;
+  }
+
+  return { providerCount, changed };
+}
+
+function htmlFiles(dir) {
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .flatMap((entry) => {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) return htmlFiles(full);
+      return entry.name.endsWith(".html") ? [full] : [];
+    });
+}
+
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+  const result = normalizeProviderCountFiles();
+  console.log(`normalized provider count to ${result.providerCount} across ${result.changed} pages`);
+}

--- a/scripts/normalize-provider-counts.test.js
+++ b/scripts/normalize-provider-counts.test.js
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  normalizeProviderCountFiles,
+  normalizeProviderCounts,
+} from "./normalize-provider-counts.mjs";
+
+test("normalizes the homepage CTA and Providers navigation count", () => {
+  const source = [
+    '<a class="cta-secondary">Browse 76 providers</a>',
+    '<summary><h2>Providers</h2><span class="nav-count">77</span></summary>',
+    '<summary><h2>Features</h2><span class="nav-count">42</span></summary>',
+  ].join("\n");
+
+  const normalized = normalizeProviderCounts(source, 76);
+
+  assert.match(normalized, /Browse 76 providers/);
+  assert.match(normalized, /<h2>Providers<\/h2><span class="nav-count">76<\/span>/);
+  assert.match(normalized, /<h2>Features<\/h2><span class="nav-count">42<\/span>/);
+});
+
+test("derives the canonical count from provider metadata and updates every HTML page", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-provider-count-"));
+  const metadataDir = path.join(root, "docs", "providers");
+  const siteDir = path.join(root, "dist", "docs-site");
+  const nestedDir = path.join(siteDir, "providers");
+  fs.mkdirSync(metadataDir, { recursive: true });
+  fs.mkdirSync(nestedDir, { recursive: true });
+
+  fs.writeFileSync(
+    path.join(metadataDir, "provider-metadata.json"),
+    JSON.stringify({ alpha: {}, beta: {} }),
+  );
+  fs.writeFileSync(
+    path.join(siteDir, "index.html"),
+    '<a>Browse 99 providers</a><summary><h2>Providers</h2><span class="nav-count">100</span></summary>',
+  );
+  fs.writeFileSync(
+    path.join(nestedDir, "index.html"),
+    '<summary><h2>Providers</h2><span class="nav-count">100</span></summary>',
+  );
+
+  const result = normalizeProviderCountFiles({ root, siteDir });
+
+  assert.deepEqual(result, { providerCount: 2, changed: 2 });
+  assert.match(fs.readFileSync(path.join(siteDir, "index.html"), "utf8"), /Browse 2 providers/);
+  assert.match(
+    fs.readFileSync(path.join(nestedDir, "index.html"), "utf8"),
+    /<span class="nav-count">2<\/span>/,
+  );
+});
+
+test("rejects invalid provider counts", () => {
+  assert.throws(() => normalizeProviderCounts("", -1), /non-negative integer/);
+  assert.throws(() => normalizeProviderCounts("", 1.5), /non-negative integer/);
+});

--- a/scripts/normalize-provider-counts.test.js
+++ b/scripts/normalize-provider-counts.test.js
@@ -5,26 +5,45 @@ import path from "node:path";
 import test from "node:test";
 
 import {
+  normalizeNavigationCounts,
   normalizeProviderCountFiles,
-  normalizeProviderCounts,
 } from "./normalize-provider-counts.mjs";
 
-test("normalizes the homepage CTA and Providers navigation count", () => {
+function section(name, count, hrefs) {
+  const links = hrefs
+    .map((href) => `<a class="nav-link" href="${href}">Page</a>`)
+    .join("");
+  return `<details class="nav-section"><summary><h2>${name}</h2><span class="nav-count">${count}</span></summary><div class="nav-links">${links}</div></details>`;
+}
+
+test("normalizes every sidebar section while excluding index pages", () => {
   const source = [
-    '<a class="cta-secondary">Browse 76 providers</a>',
-    '<summary><h2>Providers</h2><span class="nav-count">77</span></summary>',
-    '<summary><h2>Features</h2><span class="nav-count">42</span></summary>',
+    '<a class="cta-secondary">Browse 99 providers</a>',
+    section("Start", 6, ["index.html", "getting-started.html", "cli.html"]),
+    section("Providers", 77, ["providers/index.html", "providers/aws.html", "providers/azure.html"]),
+    section("Features", 4, ["features/index.html", "features/sync.html"]),
+    section("Commands", 3, ["commands/index.html", "commands/run.html", "commands/ssh.html"]),
+    section("Operate", 2, ["operations.html", "security.html"]),
   ].join("\n");
 
-  const normalized = normalizeProviderCounts(source, 76);
+  const normalized = normalizeNavigationCounts(source, 2);
 
-  assert.match(normalized, /Browse 76 providers/);
-  assert.match(normalized, /<h2>Providers<\/h2><span class="nav-count">76<\/span>/);
-  assert.match(normalized, /<h2>Features<\/h2><span class="nav-count">42<\/span>/);
+  assert.match(normalized, /Browse 2 providers/);
+  assert.match(normalized, /<h2>Start<\/h2><span class="nav-count">2<\/span>/);
+  assert.match(normalized, /<h2>Providers<\/h2><span class="nav-count">2<\/span>/);
+  assert.match(normalized, /<h2>Features<\/h2><span class="nav-count">1<\/span>/);
+  assert.match(normalized, /<h2>Commands<\/h2><span class="nav-count">2<\/span>/);
+  assert.match(normalized, /<h2>Operate<\/h2><span class="nav-count">2<\/span>/);
 });
 
-test("derives the canonical count from provider metadata and updates every HTML page", () => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-provider-count-"));
+test("handles active links and nested relative index links", () => {
+  const source = `<details class="nav-section" open><summary><h2>Providers</h2><span class="nav-count">9</span></summary><div class="nav-links"><a class="nav-link active" href="../providers/index.html">Index</a><a class="nav-link" href="../providers/aws.html?x=1#y">AWS</a></div></details>`;
+  const normalized = normalizeNavigationCounts(source, 1);
+  assert.match(normalized, /<span class="nav-count">1<\/span>/);
+});
+
+test("derives the canonical provider count and updates every generated HTML page", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-nav-count-"));
   const metadataDir = path.join(root, "docs", "providers");
   const siteDir = path.join(root, "dist", "docs-site");
   const nestedDir = path.join(siteDir, "providers");
@@ -37,11 +56,11 @@ test("derives the canonical count from provider metadata and updates every HTML 
   );
   fs.writeFileSync(
     path.join(siteDir, "index.html"),
-    '<a>Browse 99 providers</a><summary><h2>Providers</h2><span class="nav-count">100</span></summary>',
+    `<a>Browse 99 providers</a>${section("Providers", 100, ["providers/index.html", "providers/alpha.html", "providers/beta.html"])}`,
   );
   fs.writeFileSync(
     path.join(nestedDir, "index.html"),
-    '<summary><h2>Providers</h2><span class="nav-count">100</span></summary>',
+    section("Providers", 100, ["index.html", "alpha.html", "beta.html"]),
   );
 
   const result = normalizeProviderCountFiles({ root, siteDir });
@@ -55,6 +74,6 @@ test("derives the canonical count from provider metadata and updates every HTML 
 });
 
 test("rejects invalid provider counts", () => {
-  assert.throws(() => normalizeProviderCounts("", -1), /non-negative integer/);
-  assert.throws(() => normalizeProviderCounts("", 1.5), /non-negative integer/);
+  assert.throws(() => normalizeNavigationCounts("", -1), /non-negative integer/);
+  assert.throws(() => normalizeNavigationCounts("", 1.5), /non-negative integer/);
 });


### PR DESCRIPTION
## Summary
- fix every sidebar section count, not only Providers
- count actual content-page links in each rendered menu section
- exclude section landing/index pages such as `README.md` / `index.html` from the badge
- keep the homepage provider CTA sourced from canonical provider metadata
- apply normalization to every generated HTML page in docs checks and Pages deployment
- add regression coverage for Start, Providers, Features, Commands, Operate, active links, nested paths, query strings, and fragments

## Root cause
The sidebar badges used raw navigation-page counts. Sections containing a landing page therefore counted that index as if it were another content item. The visible Providers mismatch exposed the issue: 77 navigation pages meant 76 providers plus the Provider Reference index. The same off-by-one pattern could affect any menu section with an index page.

## Behavior
Badges now represent content pages:
- index/landing links are excluded
- normal pages remain counted
- sections without an index page are unchanged
- the rule is derived from the rendered navigation, so it applies consistently across the whole menu

The provider CTA still uses `docs/providers/provider-metadata.json` as the canonical provider total.