### PR TITLE
fix(apple-container): guard Cleanup orphan sweep against a concurrent Acquire's claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added bounded JSON Schema validation for required run artifacts across supported standard drafts, with local references and redacted failure diagnostics. Thanks @dwin-gharibi.
 
+### Fixed
+
+- Prevented apple-container orphan cleanup from deleting claims reclaimed during its resource snapshot, including same-value rewrites, while retaining stored SSH keys when ownership cannot be proven safe to remove. Thanks @anagnorisis2peripeteia.
+
 ## 0.39.0 - 2026-07-17
 
 ### Added

--- a/docs/features/provider-live-smoke.md
+++ b/docs/features/provider-live-smoke.md
@@ -155,13 +155,13 @@ hermetic lifecycle tests, `scripts/live-smoke.sh`, dedicated live runners, and
 `//go:build smoke` tests. Regenerate it with
 `node scripts/generate-provider-matrix.mjs`; docs CI rejects drift.
 
-Current coverage: 76 providers; 4 with convention-named hermetic lifecycle tests, 56 with a live runner, 4 with tagged Go smoke tests, and 19 with none of those lifecycle surfaces.
+Current coverage: 76 providers; 4 with convention-named hermetic lifecycle tests, 56 with a live runner, 5 with tagged Go smoke tests, and 19 with none of those lifecycle surfaces.
 
 | Provider | Hermetic lifecycle | Live runner | Tagged Go smoke |
 | --- | --- | --- | --- |
 | [agent-sandbox](../providers/agent-sandbox.md) | — | dedicated + matrix | — |
 | [anthropic-sandbox-runtime](../providers/anthropic-sandbox-runtime.md) | — | dedicated + matrix | — |
-| [apple-container](../providers/apple-container.md) | — | matrix | — |
+| [apple-container](../providers/apple-container.md) | — | matrix | yes |
 | [apple-machine](../providers/apple-machine.md) | — | — | — |
 | [apple-vm](../providers/apple-vm.md) | — | matrix | — |
 | [ascii-box](../providers/ascii-box.md) | — | — | — |

--- a/internal/cli/claim.go
+++ b/internal/cli/claim.go
@@ -1379,11 +1379,6 @@ func replaceLeaseClaimIfUnchanged(leaseID string, current, replacement leaseClai
 	return err
 }
 
-func replaceLeaseClaimIfUnchangedDurable(leaseID string, current, replacement leaseClaim) error {
-	_, err := replaceLeaseClaimIfUnchangedWithWrite(leaseID, current, replacement, writeLeaseClaimAtomicDurable)
-	return err
-}
-
 func replaceLeaseClaimIfUnchangedDurableReturning(leaseID string, current, replacement leaseClaim) (leaseClaim, error) {
 	return replaceLeaseClaimIfUnchangedWithWrite(leaseID, current, replacement, writeLeaseClaimAtomicDurable)
 }

--- a/internal/cli/claim.go
+++ b/internal/cli/claim.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"net"
@@ -18,6 +20,7 @@ import (
 
 type leaseClaim struct {
 	LeaseID  string `json:"leaseID"`
+	Revision string `json:"revision,omitempty"`
 	Slug     string `json:"slug,omitempty"`
 	Provider string `json:"provider,omitempty"`
 	CloudID  string `json:"cloudID,omitempty"`
@@ -434,6 +437,9 @@ func updateLeaseClaimEndpointIfUnchangedAfter(leaseID string, expected leaseClai
 				return err
 			}
 		}
+		if err := refreshLeaseClaimRevision(&claim); err != nil {
+			return err
+		}
 		provider := firstNonBlank(server.Labels["provider"], server.Provider)
 		prepared, err := prepareLeaseClaimEndpoint(claim, provider, server.Labels["slug"], server, false)
 		if err != nil {
@@ -520,6 +526,9 @@ func updateLeaseClaimLabelsIfUnchangedAfter(leaseID string, expected leaseClaim,
 				return err
 			}
 		}
+		if err := refreshLeaseClaimRevision(&claim); err != nil {
+			return err
+		}
 		claim.Labels = cloneStringMap(labels)
 		updated = cloneLeaseClaim(claim)
 		return writeLeaseClaimAtomic(path, claim)
@@ -532,6 +541,15 @@ func cloneLeaseClaim(claim leaseClaim) leaseClaim {
 	claim.TailscaleTags = append([]string(nil), claim.TailscaleTags...)
 	claim.CacheVolumes = append([]string(nil), claim.CacheVolumes...)
 	return claim
+}
+
+func refreshLeaseClaimRevision(claim *leaseClaim) error {
+	var revision [16]byte
+	if _, err := rand.Read(revision[:]); err != nil {
+		return exit(2, "generate lease claim revision: %v", err)
+	}
+	claim.Revision = hex.EncodeToString(revision[:])
+	return nil
 }
 
 func unchangedLeaseClaimGuard(leaseID string, expected leaseClaim, expectedExists bool) func(leaseClaim, bool) error {
@@ -740,6 +758,9 @@ func mutateLeaseClaimPathGuardedWithWrite(leaseID, path string, guard func(lease
 			if err := guard(claim, exists); err != nil {
 				return err
 			}
+		}
+		if err := refreshLeaseClaimRevision(&claim); err != nil {
+			return err
 		}
 		if err := mutate(&claim); err != nil {
 			return err
@@ -1345,24 +1366,35 @@ func restoreLeaseClaimIfUnchanged(leaseID string, current, previous leaseClaim, 
 		if err := unchangedLeaseClaimGuard(leaseID, current, true)(claim, exists); err != nil {
 			return err
 		}
-		return writeLeaseClaimAtomic(path, cloneLeaseClaim(previous))
+		replacement := cloneLeaseClaim(previous)
+		if err := refreshLeaseClaimRevision(&replacement); err != nil {
+			return err
+		}
+		return writeLeaseClaimAtomic(path, replacement)
 	})
 }
 
 func replaceLeaseClaimIfUnchanged(leaseID string, current, replacement leaseClaim) error {
-	return replaceLeaseClaimIfUnchangedWithWrite(leaseID, current, replacement, writeLeaseClaimAtomic)
+	_, err := replaceLeaseClaimIfUnchangedWithWrite(leaseID, current, replacement, writeLeaseClaimAtomic)
+	return err
 }
 
 func replaceLeaseClaimIfUnchangedDurable(leaseID string, current, replacement leaseClaim) error {
+	_, err := replaceLeaseClaimIfUnchangedWithWrite(leaseID, current, replacement, writeLeaseClaimAtomicDurable)
+	return err
+}
+
+func replaceLeaseClaimIfUnchangedDurableReturning(leaseID string, current, replacement leaseClaim) (leaseClaim, error) {
 	return replaceLeaseClaimIfUnchangedWithWrite(leaseID, current, replacement, writeLeaseClaimAtomicDurable)
 }
 
-func replaceLeaseClaimIfUnchangedWithWrite(leaseID string, current, replacement leaseClaim, write func(string, leaseClaim) error) error {
+func replaceLeaseClaimIfUnchangedWithWrite(leaseID string, current, replacement leaseClaim, write func(string, leaseClaim) error) (leaseClaim, error) {
 	path, err := leaseClaimPath(leaseID)
 	if err != nil {
-		return err
+		return leaseClaim{}, err
 	}
-	return withLeaseClaimLock(path, func() error {
+	var written leaseClaim
+	err = withLeaseClaimLock(path, func() error {
 		claim, exists, err := readLeaseClaimPathWithPresence(path)
 		if err != nil {
 			return err
@@ -1373,8 +1405,17 @@ func replaceLeaseClaimIfUnchangedWithWrite(leaseID string, current, replacement 
 		if err := unchangedLeaseClaimGuard(leaseID, current, true)(claim, exists); err != nil {
 			return err
 		}
-		return write(path, cloneLeaseClaim(replacement))
+		replacement = cloneLeaseClaim(replacement)
+		if err := refreshLeaseClaimRevision(&replacement); err != nil {
+			return err
+		}
+		written = cloneLeaseClaim(replacement)
+		if err := write(path, replacement); err != nil {
+			return err
+		}
+		return nil
 	})
+	return written, err
 }
 
 func listLeaseClaims() ([]leaseClaim, error) {

--- a/internal/cli/claim_test.go
+++ b/internal/cli/claim_test.go
@@ -529,6 +529,50 @@ func TestVerifyLeaseClaimUnchanged(t *testing.T) {
 	}
 }
 
+func TestRemoveLeaseClaimIfUnchangedRejectsSameValueRewrite(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	const leaseID = "cbx_same_value_rewrite"
+	cfg := Config{Provider: "external"}
+	server := Server{Provider: "external", CloudID: "resource-1"}
+	if err := claimLeaseTargetForConfig(leaseID, "same-value", cfg, server, SSHTarget{}, time.Minute); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := readLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.Revision == "" {
+		t.Fatal("initial claim revision is empty")
+	}
+	if err := mutateLeaseClaim(leaseID, func(*leaseClaim) error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	rewritten, err := readLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rewritten.Revision == snapshot.Revision {
+		t.Fatalf("same-value rewrite kept revision %q", snapshot.Revision)
+	}
+	withoutRevision := func(claim leaseClaim) leaseClaim {
+		claim.Revision = ""
+		return claim
+	}
+	if !reflect.DeepEqual(withoutRevision(rewritten), withoutRevision(snapshot)) {
+		t.Fatalf("rewrite changed claim data beyond revision:\nbefore: %#v\nafter:  %#v", snapshot, rewritten)
+	}
+
+	err = removeLeaseClaimIfUnchanged(leaseID, snapshot)
+	if err == nil || !strings.Contains(err.Error(), "claim changed") {
+		t.Fatalf("same-value rewrite guard err=%v", err)
+	}
+	if _, exists, err := readLeaseClaimWithPresence(leaseID); err != nil {
+		t.Fatal(err)
+	} else if !exists {
+		t.Fatal("same-value rewrite was removed")
+	}
+}
+
 func TestConditionalRepoClaimCanBeRestored(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	leaseID := "cbx_transaction123"
@@ -569,6 +613,11 @@ func TestConditionalRepoClaimCanBeRestored(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if restored.Revision == previous.Revision {
+		t.Fatalf("restored claim kept revision %q", previous.Revision)
+	}
+	restored.Revision = ""
+	previous.Revision = ""
 	if !reflect.DeepEqual(restored, previous) {
 		t.Fatalf("restored=%#v want %#v", restored, previous)
 	}

--- a/internal/cli/provider_exports.go
+++ b/internal/cli/provider_exports.go
@@ -231,6 +231,10 @@ func ReplaceLeaseClaimIfUnchangedDurable(leaseID string, current, replacement Le
 	return replaceLeaseClaimIfUnchangedDurable(leaseID, current, replacement)
 }
 
+func ReplaceLeaseClaimIfUnchangedDurableReturning(leaseID string, current, replacement LeaseClaim) (LeaseClaim, error) {
+	return replaceLeaseClaimIfUnchangedDurableReturning(leaseID, current, replacement)
+}
+
 func ValidateAzureSSHCIDRsForAcquire(ctx context.Context, cfg Config) error {
 	_, err := azureSSHCIDRsForRules(ctx, cfg, nil)
 	return err

--- a/internal/cli/provider_exports.go
+++ b/internal/cli/provider_exports.go
@@ -227,10 +227,6 @@ func ReplaceLeaseClaimIfUnchanged(leaseID string, current, replacement LeaseClai
 	return replaceLeaseClaimIfUnchanged(leaseID, current, replacement)
 }
 
-func ReplaceLeaseClaimIfUnchangedDurable(leaseID string, current, replacement LeaseClaim) error {
-	return replaceLeaseClaimIfUnchangedDurable(leaseID, current, replacement)
-}
-
 func ReplaceLeaseClaimIfUnchangedDurableReturning(leaseID string, current, replacement LeaseClaim) (LeaseClaim, error) {
 	return replaceLeaseClaimIfUnchangedDurableReturning(leaseID, current, replacement)
 }

--- a/internal/providers/applecontainer/backend.go
+++ b/internal/providers/applecontainer/backend.go
@@ -323,6 +323,14 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 	if err := requireMacOS(); err != nil {
 		return err
 	}
+	// Snapshot orphan-candidate claims before listing containers so a claim
+	// registered by a concurrent Acquire cannot be compared against an older
+	// container view and misclassified as a "missing container" orphan. Only
+	// claims that predate our container view can be genuine orphans.
+	orphanCandidates, err := core.ListLeaseClaims()
+	if err != nil {
+		return err
+	}
 	containers, err := b.listContainers(ctx)
 	if err != nil {
 		return err
@@ -367,20 +375,28 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 		removed++
 	}
 	claimsRemoved := 0
-	for leaseID := range claimsByLease {
-		if leaseID == "" {
+	for _, claim := range orphanCandidates {
+		if claim.Provider != providerName || claim.LeaseID == "" {
 			continue
 		}
-		if _, ok := liveLeases[leaseID]; ok {
+		if _, ok := liveLeases[claim.LeaseID]; ok {
 			continue
 		}
 		if req.DryRun {
-			fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s reason=missing container\n", leaseID)
+			fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s reason=missing container\n", claim.LeaseID)
 			continue
 		}
-		fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s reason=missing container\n", leaseID)
-		core.RemoveLeaseClaim(leaseID)
-		core.RemoveStoredTestboxKey(leaseID)
+		// Remove only if the claim is unchanged since our pre-container snapshot;
+		// a concurrent Acquire/Touch that (re)bound this lease makes it no longer
+		// an orphan, so RemoveLeaseClaimIfUnchanged declines and the live lease
+		// survives. Leave the stored testbox key in place: Acquire creates or
+		// reuses the key before publishing its claim, so a missing-container sweep
+		// cannot safely delete it.
+		if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
+			fmt.Fprintf(b.rt.Stderr, "skip claim lease=%s reason=changed-during-cleanup err=%v\n", claim.LeaseID, err)
+			continue
+		}
+		fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s reason=missing container\n", claim.LeaseID)
 		claimsRemoved++
 	}
 	if !req.DryRun {

--- a/internal/providers/applecontainer/backend.go
+++ b/internal/providers/applecontainer/backend.go
@@ -383,15 +383,20 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 			continue
 		}
 		if req.DryRun {
+			if err := core.VerifyLeaseClaimUnchanged(claim.LeaseID, claim); err != nil {
+				fmt.Fprintf(b.rt.Stderr, "skip claim lease=%s reason=changed-during-cleanup err=%v\n", claim.LeaseID, err)
+				continue
+			}
 			fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s reason=missing container\n", claim.LeaseID)
 			continue
 		}
 		// Remove only if the claim is unchanged since our pre-container snapshot;
 		// a concurrent Acquire/Touch that (re)bound this lease makes it no longer
 		// an orphan, so RemoveLeaseClaimIfUnchanged declines and the live lease
-		// survives. Leave the stored testbox key in place: Acquire creates or
-		// reuses the key before publishing its claim, so a missing-container sweep
-		// cannot safely delete it.
+		// survives. Intentionally retain the stored testbox key: Acquire creates or
+		// reuses it before publishing its claim, outside this claim CAS. Until keys
+		// have their own generation/ownership fence, deleting one here can break the
+		// concurrent live lease; fail closed by retaining inert local key material.
 		if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
 			fmt.Fprintf(b.rt.Stderr, "skip claim lease=%s reason=changed-during-cleanup err=%v\n", claim.LeaseID, err)
 			continue

--- a/internal/providers/applecontainer/cleanup_live_smoke_test.go
+++ b/internal/providers/applecontainer/cleanup_live_smoke_test.go
@@ -30,12 +30,14 @@ import (
 	"context"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/gofrs/flock"
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
@@ -91,18 +93,52 @@ func TestLiveAppleContainerCleanupGuardPreservesReclaimedClaim(t *testing.T) {
 	}
 
 	const (
-		lease = "cbx_livesmoke_guard"
-		slug  = "livesmoke-guard"
-		name  = "crabbox-livesmoke-guard"
+		lease     = "cbx_livesmoke_guard"
+		slug      = "livesmoke-guard"
+		name      = "crabbox-livesmoke-guard"
+		smokeMark = "applecontainer-cleanup-guard"
 	)
 
+	// Serialize the destructive live smoke across processes. Advisory locks are
+	// released by the kernel after a crash, while the fixed name and ownership
+	// label below let the next locked run safely remove only our stale container.
+	hostLock := flock.New(filepath.Join(os.TempDir(), "crabbox-applecontainer-cleanup-smoke.lock"), flock.SetPermissions(0o600))
+	locked, err := hostLock.TryLock()
+	if err != nil {
+		t.Fatalf("acquire live cleanup smoke lock: %v", err)
+	}
+	if !locked {
+		t.Skip("another apple-container cleanup smoke is running")
+	}
+	t.Cleanup(func() {
+		if err := hostLock.Unlock(); err != nil {
+			t.Errorf("release live cleanup smoke lock: %v", err)
+		}
+	})
+
 	// Safety precondition: refuse to run a real Cleanup pass while any other
-	// crabbox-labeled container exists, so the sweep can never touch one.
-	if before := realLs(); strings.Contains(before, `"crabbox"`) || strings.Contains(before, "crabbox-") {
-		if strings.Contains(before, name) {
-			_, _ = exec.Command(cli, "delete", "--force", name).CombinedOutput()
-		} else {
-			t.Skip("other crabbox containers present; skipping live cleanup smoke to avoid touching them")
+	// crabbox-labeled container exists, so the sweep can never touch one. A
+	// crashed prior run is the sole exception, proven by both fixed name and a
+	// dedicated ownership label while holding the host-wide lock.
+	containers, err := decodeInspect([]byte(realLs()))
+	if err != nil {
+		t.Fatalf("decode real %s ls: %v", cli, err)
+	}
+	staleSmoke := false
+	for _, container := range containers {
+		labels := container.labels()
+		if labels["crabbox"] != "true" {
+			continue
+		}
+		if container.id() == name && labels["crabbox-smoke"] == smokeMark {
+			staleSmoke = true
+			continue
+		}
+		t.Skip("other crabbox containers present; skipping live cleanup smoke to avoid touching them")
+	}
+	if staleSmoke {
+		if out, err := exec.Command(cli, "delete", "--force", name).CombinedOutput(); err != nil {
+			t.Fatalf("delete stale live-smoke container: %v\n%s", err, out)
 		}
 	}
 
@@ -118,6 +154,7 @@ func TestLiveAppleContainerCleanupGuardPreservesReclaimedClaim(t *testing.T) {
 	create := exec.Command(cli, "run", "-d", "--name", name,
 		"--label", "crabbox=true", "--label", "provider="+providerName,
 		"--label", "lease="+lease, "--label", "slug="+slug, "--label", "state=ready",
+		"--label", "crabbox-smoke="+smokeMark,
 		image, "sleep", "infinity")
 	if out, err := create.CombinedOutput(); err != nil {
 		t.Skipf("cannot create live container (runtime unavailable?): %v\n%s", err, out)

--- a/internal/providers/applecontainer/cleanup_live_smoke_test.go
+++ b/internal/providers/applecontainer/cleanup_live_smoke_test.go
@@ -1,0 +1,189 @@
+//go:build smoke
+
+package applecontainer
+
+// Instrumented LIVE smoke for the Cleanup orphan-sweep guard, opt-in behind the
+// `smoke` build tag and CRABBOX_LIVE=1. Unlike the hermetic tests in
+// cleanup_toctou_test.go (which fake `container ls`), this drives the REAL Apple
+// `container` runtime end to end: it creates a real container for a lease,
+// registers the lease claim, deletes the real container so the claim is a genuine
+// missing-container orphan by the real runtime's own view, then runs the real
+// Cleanup while deliberately reclaiming the lease during Cleanup's real
+// `container ls` snapshot window. It asserts the guard observes the reclaim and
+// declines the removal, so the reclaiming process keeps its live claim.
+//
+// This is the "instrumented live proof" a timing race cannot reliably produce on
+// its own: the apple-container Acquire publishes its claim only after the ~12s
+// real-container creation, far outside Cleanup's sub-200ms snapshot->remove
+// window, so two blind concurrent CLI processes never interleave into it. The
+// injection here is deliberate (a controlled rebind at the exact window) against
+// real runtime state, which is what the hermetic tests reproduce deterministically.
+//
+// Safety: the smoke SKIPS if any other crabbox-labeled container is present, so a
+// real Cleanup pass can never sweep an unrelated container; the claim store is an
+// isolated XDG_STATE_HOME temp dir, so only this test's claim is ever visible.
+//
+// Run: CRABBOX_LIVE=1 go test -tags smoke -run TestLiveAppleContainerCleanupGuardPreservesReclaimedClaim -v ./internal/providers/applecontainer/
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+// liveContainerRunner execs the real Apple `container` CLI for every command, and
+// exactly once — while Cleanup is inside its real `container ls` snapshot window —
+// fires duringList to inject the deliberate reclaim.
+type liveContainerRunner struct {
+	once       sync.Once
+	duringList func()
+}
+
+func (r *liveContainerRunner) Run(ctx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+	if len(req.Args) > 0 && req.Args[0] == "ls" && r.duringList != nil {
+		r.once.Do(r.duringList)
+	}
+	cmd := exec.CommandContext(ctx, req.Name, req.Args...)
+	cmd.Env = append(os.Environ(), req.Env...)
+	if req.Dir != "" {
+		cmd.Dir = req.Dir
+	}
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	err := cmd.Run()
+	res := core.LocalCommandResult{Stdout: stdout.String(), Stderr: stderr.String()}
+	if exit, ok := err.(*exec.ExitError); ok {
+		res.ExitCode = exit.ExitCode()
+		return res, nil
+	}
+	return res, err
+}
+
+func TestLiveAppleContainerCleanupGuardPreservesReclaimedClaim(t *testing.T) {
+	if os.Getenv("CRABBOX_LIVE") != "1" {
+		t.Skip("set CRABBOX_LIVE=1 to run the live apple-container cleanup smoke")
+	}
+	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
+		t.Skip("apple-container Cleanup requires macOS on Apple silicon")
+	}
+	cli := os.Getenv("CRABBOX_APPLE_CONTAINER_CLI")
+	if cli == "" {
+		cli = "container"
+	}
+	if _, err := exec.LookPath(cli); err != nil {
+		t.Skipf("Apple container CLI %q not installed", cli)
+	}
+
+	realLs := func() string {
+		out, err := exec.Command(cli, "ls", "--all", "--format", "json").Output()
+		if err != nil {
+			t.Fatalf("real %s ls: %v", cli, err)
+		}
+		return string(out)
+	}
+
+	const (
+		lease = "cbx_livesmoke_guard"
+		slug  = "livesmoke-guard"
+		name  = "crabbox-livesmoke-guard"
+	)
+
+	// Safety precondition: refuse to run a real Cleanup pass while any other
+	// crabbox-labeled container exists, so the sweep can never touch one.
+	if before := realLs(); strings.Contains(before, `"crabbox"`) || strings.Contains(before, "crabbox-") {
+		if strings.Contains(before, name) {
+			_, _ = exec.Command(cli, "delete", "--force", name).CombinedOutput()
+		} else {
+			t.Skip("other crabbox containers present; skipping live cleanup smoke to avoid touching them")
+		}
+	}
+
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	repoRoot := t.TempDir()
+
+	image := os.Getenv("CRABBOX_APPLE_CONTAINER_IMAGE")
+	if image == "" {
+		image = "ubuntu:26.04"
+	}
+
+	// 1) Create a REAL container for the lease.
+	create := exec.Command(cli, "run", "-d", "--name", name,
+		"--label", "crabbox=true", "--label", "provider="+providerName,
+		"--label", "lease="+lease, "--label", "slug="+slug, "--label", "state=ready",
+		image, "sleep", "infinity")
+	if out, err := create.CombinedOutput(); err != nil {
+		t.Skipf("cannot create live container (runtime unavailable?): %v\n%s", err, out)
+	}
+	t.Cleanup(func() { _, _ = exec.Command(cli, "delete", "--force", name).CombinedOutput() })
+
+	// 2) Register the lease claim for the real container (the entrypoint Acquire uses).
+	server := core.Server{
+		CloudID: name, Provider: providerName, Name: name, Status: "ready",
+		Labels: map[string]string{"crabbox": "true", "provider": providerName, "lease": lease, "slug": slug, "state": "ready"},
+	}
+	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(
+		lease, slug, providerName, "", "", repoRoot, 30*time.Minute, false, server, core.SSHTarget{},
+	); err != nil {
+		t.Fatalf("register lease claim: %v", err)
+	}
+	if !strings.Contains(realLs(), name) {
+		t.Fatalf("real runtime does not show the container we just created (%s)", name)
+	}
+
+	// 3) Delete the REAL container out from under the claim -> genuine missing-container orphan.
+	if out, err := exec.Command(cli, "delete", "--force", name).CombinedOutput(); err != nil {
+		t.Fatalf("delete real container: %v\n%s", err, out)
+	}
+	if strings.Contains(realLs(), name) {
+		t.Fatalf("real runtime still shows %s after delete", name)
+	}
+
+	// 4) Run the real Cleanup; during its real `container ls`, reclaim the lease
+	//    (rewrite the claim so it no longer matches the pre-list snapshot).
+	reclaim := func() {
+		rebound := server
+		rebound.Status = "reclaimed"
+		rebound.Labels = map[string]string{"crabbox": "true", "provider": providerName, "lease": lease, "slug": slug, "state": "reclaimed"}
+		if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(
+			lease, slug, providerName, "", "", repoRoot, 30*time.Minute, false, rebound, core.SSHTarget{},
+		); err != nil {
+			t.Errorf("concurrent reclaim registration failed: %v", err)
+		}
+	}
+	runner := &liveContainerRunner{duringList: reclaim}
+
+	var out bytes.Buffer
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.AppleContainer = core.AppleContainerConfig{CLIPath: cli, Image: image, User: "crabbox", WorkRoot: "/work/crabbox"}
+	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: &out, Stderr: &out, Exec: runner}).(*backend)
+
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+
+	// 5) The guard must have observed the reclaim and declined the removal, so the
+	//    reclaiming process keeps its live claim — proven against the real runtime.
+	claim, ok, err := core.ResolveLeaseClaimForProvider(lease, providerName)
+	if err != nil {
+		t.Fatalf("ResolveLeaseClaimForProvider(%s): %v", lease, err)
+	}
+	if !ok || claim.LeaseID != lease {
+		t.Fatalf("LIVE: Cleanup removed the reclaimed claim against the real Apple runtime: present=%v (want present)\ncleanup output:\n%s", ok, out.String())
+	}
+	if !strings.Contains(out.String(), "skip claim lease="+lease+" reason=changed-during-cleanup") {
+		t.Fatalf("LIVE: expected the guard to log a decline for the reclaimed claim; got:\n%s", out.String())
+	}
+	if strings.Contains(out.String(), "remove claim lease="+lease) {
+		t.Fatalf("LIVE: Cleanup removed the reclaimed lease instead of declining:\n%s", out.String())
+	}
+	t.Logf("LIVE PROOF (real Apple container runtime): guard declined the reclaimed claim during Cleanup's real `container ls` window:\n%s", strings.TrimSpace(out.String()))
+}

--- a/internal/providers/applecontainer/cleanup_toctou_test.go
+++ b/internal/providers/applecontainer/cleanup_toctou_test.go
@@ -1,0 +1,219 @@
+package applecontainer
+
+// Repro for a cross-process TOCTOU race in (*backend).Cleanup, the same class
+// hardened for other providers in https://github.com/openclaw/crabbox/pull/1124
+// (tart), https://github.com/openclaw/crabbox/pull/446 (aws/azure), and
+// https://github.com/openclaw/crabbox/pull/781 (freestyle/islo).
+//
+// Before this fix, Cleanup snapshotted containers via listContainers() BEFORE it
+// read the claim set via core.ListLeaseClaims(), then its orphan sweep removed —
+// via the unguarded core.RemoveLeaseClaim — any claim in that (newer) claim
+// snapshot whose lease was absent from the liveLeases set built from the (older)
+// container snapshot. A claim registered by a concurrent Acquire
+// (core.ClaimLeaseForRepoProviderScopePondEndpoint) while Cleanup was still
+// listing containers was therefore visible to the claim read but absent from
+// liveLeases, and was deleted as "missing container" — destroying a healthy
+// concurrent lease's claim. Trigger is two concurrent crabbox runs on one Mac
+// (apple-container is the local provider); no attacker required.
+//
+// The test drives it deterministically: the fake `container ls` registers a new
+// claim through the exact core entrypoint Acquire uses, then returns a container
+// list that predates it. It FAILS against the pre-fix Cleanup (the fresh claim is
+// swept) and PASSES with the fix (the fresh claim postdates the pre-container
+// snapshot and survives).
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type cleanupTOCTOURunner struct {
+	once       sync.Once
+	duringList func()
+	lsJSON     string
+}
+
+func (r *cleanupTOCTOURunner) Run(_ context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+	if len(req.Args) > 0 && req.Args[0] == "ls" {
+		if r.duringList != nil {
+			r.once.Do(r.duringList)
+		}
+		return core.LocalCommandResult{Stdout: r.lsJSON}, nil
+	}
+	return core.LocalCommandResult{}, nil
+}
+
+func TestCleanupOrphanSweepDeletesConcurrentAcquireClaim(t *testing.T) {
+	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
+		t.Skip("apple-container Cleanup requires macOS on Apple silicon")
+	}
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	repoRoot := t.TempDir()
+
+	const (
+		newContainer = "crabbox-fresh-01"
+		newLease     = "cbx_acfresh12345"
+	)
+
+	// The concurrent Acquire (process B): registers its claim through the exact
+	// core entrypoint applecontainer's Acquire uses (backend.go:203), for a
+	// container that is genuinely running by then -- it just was not present in
+	// Cleanup's earlier container snapshot.
+	duringList := func() {
+		server := core.Server{
+			CloudID:  newContainer,
+			Provider: providerName,
+			Name:     newContainer,
+			Status:   "ready",
+			Labels: map[string]string{
+				"crabbox":  "true",
+				"provider": providerName,
+				"lease":    newLease,
+				"slug":     "fresh-slug",
+				"state":    "ready",
+			},
+		}
+		if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(
+			newLease, "fresh-slug", providerName, "", "", repoRoot,
+			30*time.Minute, false, server, core.SSHTarget{},
+		); err != nil {
+			t.Errorf("concurrent Acquire claim registration failed: %v", err)
+		}
+	}
+
+	// Cleanup's container snapshot predates the concurrent Acquire's container,
+	// so it lists no crabbox containers.
+	runner := &cleanupTOCTOURunner{lsJSON: "[]", duringList: duringList}
+
+	var out bytes.Buffer
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.AppleContainer = core.AppleContainerConfig{
+		CLIPath:  "container",
+		Image:    "debian:bookworm",
+		User:     "runner",
+		WorkRoot: "/work/crabbox",
+		CPUs:     4,
+		Memory:   "8g",
+	}
+	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: &out, Stderr: io.Discard, Exec: runner}).(*backend)
+
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+
+	// Invariant: a claim registered for a live container during Cleanup must
+	// survive Cleanup. Current code deletes it as "missing container".
+	claim, ok, err := core.ResolveLeaseClaimForProvider(newLease, providerName)
+	if err != nil {
+		t.Fatalf("ResolveLeaseClaimForProvider(%s): %v", newLease, err)
+	}
+	if !ok || claim.LeaseID != newLease {
+		t.Fatalf("Cleanup's orphan sweep deleted the claim registered by a concurrent Acquire for running container %s: present=%v (want present)\ncleanup output:\n%s",
+			newContainer, ok, out.String())
+	}
+	if strings.Contains(out.String(), "remove claim lease="+newLease) {
+		t.Fatalf("Cleanup removed the healthy concurrent claim:\n%s", out.String())
+	}
+}
+
+// TestCleanupOrphanSweepGuardDeclinesReclaimedCandidate covers the fix's second
+// defense. The reorder above stops a brand-new claim from being swept; this
+// covers a claim that IS a legitimate orphan candidate (present in the
+// pre-container snapshot, no live container) but is reclaimed/rebound after the
+// snapshot while Cleanup is still listing containers. RemoveLeaseClaimIfUnchanged
+// must observe the change and decline the removal, so the reclaiming process
+// keeps its lease. On current code the unguarded sweep removes the rebound claim.
+func TestCleanupOrphanSweepGuardDeclinesReclaimedCandidate(t *testing.T) {
+	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
+		t.Skip("apple-container Cleanup requires macOS on Apple silicon")
+	}
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	repoRoot := t.TempDir()
+
+	const (
+		orphanContainer = "crabbox-orphan-01"
+		orphanLease     = "cbx_acorphan67890"
+	)
+
+	origServer := core.Server{
+		CloudID:  orphanContainer,
+		Provider: providerName,
+		Name:     orphanContainer,
+		Status:   "idle",
+		Labels: map[string]string{
+			"crabbox":  "true",
+			"provider": providerName,
+			"lease":    orphanLease,
+			"slug":     "orphan-slug",
+			"state":    "idle",
+		},
+	}
+	// Registered BEFORE Cleanup, so it is in the pre-container orphan snapshot.
+	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(
+		orphanLease, "orphan-slug", providerName, "", "", repoRoot,
+		30*time.Minute, false, origServer, core.SSHTarget{},
+	); err != nil {
+		t.Fatalf("setup orphan-candidate claim: %v", err)
+	}
+
+	// During listContainers a concurrent process reclaims the same lease,
+	// rewriting the claim so it no longer matches the snapshot the sweep holds.
+	reclaim := func() {
+		rebound := origServer
+		rebound.Status = "ready"
+		rebound.Labels = map[string]string{
+			"crabbox":  "true",
+			"provider": providerName,
+			"lease":    orphanLease,
+			"slug":     "orphan-slug",
+			"state":    "ready",
+		}
+		if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(
+			orphanLease, "orphan-slug", providerName, "", "", repoRoot,
+			30*time.Minute, false, rebound, core.SSHTarget{},
+		); err != nil {
+			t.Errorf("concurrent reclaim registration failed: %v", err)
+		}
+	}
+
+	runner := &cleanupTOCTOURunner{lsJSON: "[]", duringList: reclaim}
+
+	var out bytes.Buffer
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.AppleContainer = core.AppleContainerConfig{
+		CLIPath:  "container",
+		Image:    "debian:bookworm",
+		User:     "runner",
+		WorkRoot: "/work/crabbox",
+		CPUs:     4,
+		Memory:   "8g",
+	}
+	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: &out, Stderr: io.Discard, Exec: runner}).(*backend)
+
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+
+	// The guard must observe the reclaim and decline the removal, so the
+	// reclaiming process keeps its lease.
+	claim, ok, err := core.ResolveLeaseClaimForProvider(orphanLease, providerName)
+	if err != nil {
+		t.Fatalf("ResolveLeaseClaimForProvider(%s): %v", orphanLease, err)
+	}
+	if !ok || claim.LeaseID != orphanLease {
+		t.Fatalf("orphan sweep removed a lease reclaimed during Cleanup: present=%v (want present)\ncleanup output:\n%s", ok, out.String())
+	}
+	if strings.Contains(out.String(), "remove claim lease="+orphanLease) {
+		t.Fatalf("orphan sweep removed the reclaimed lease instead of declining:\n%s", out.String())
+	}
+}

--- a/internal/providers/applecontainer/cleanup_toctou_test.go
+++ b/internal/providers/applecontainer/cleanup_toctou_test.go
@@ -217,3 +217,77 @@ func TestCleanupOrphanSweepGuardDeclinesReclaimedCandidate(t *testing.T) {
 		t.Fatalf("orphan sweep removed the reclaimed lease instead of declining:\n%s", out.String())
 	}
 }
+
+func TestCleanupDryRunDoesNotPlanReclaimedCandidateRemoval(t *testing.T) {
+	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
+		t.Skip("apple-container Cleanup requires macOS on Apple silicon")
+	}
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	repoRoot := t.TempDir()
+
+	const (
+		orphanContainer = "crabbox-dryrun-orphan-01"
+		orphanLease     = "cbx_acdryrun67890"
+	)
+	origServer := core.Server{
+		CloudID:  orphanContainer,
+		Provider: providerName,
+		Name:     orphanContainer,
+		Status:   "idle",
+		Labels: map[string]string{
+			"crabbox":  "true",
+			"provider": providerName,
+			"lease":    orphanLease,
+			"slug":     "dryrun-orphan-slug",
+			"state":    "idle",
+		},
+	}
+	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(
+		orphanLease, "dryrun-orphan-slug", providerName, "", "", repoRoot,
+		30*time.Minute, false, origServer, core.SSHTarget{},
+	); err != nil {
+		t.Fatalf("setup dry-run orphan-candidate claim: %v", err)
+	}
+
+	reclaim := func() {
+		rebound := origServer
+		rebound.Status = "ready"
+		rebound.Labels = map[string]string{
+			"crabbox":  "true",
+			"provider": providerName,
+			"lease":    orphanLease,
+			"slug":     "dryrun-orphan-slug",
+			"state":    "ready",
+		}
+		if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(
+			orphanLease, "dryrun-orphan-slug", providerName, "", "", repoRoot,
+			30*time.Minute, false, rebound, core.SSHTarget{},
+		); err != nil {
+			t.Errorf("concurrent dry-run reclaim registration failed: %v", err)
+		}
+	}
+
+	runner := &cleanupTOCTOURunner{lsJSON: "[]", duringList: reclaim}
+	var out bytes.Buffer
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.AppleContainer = core.AppleContainerConfig{
+		CLIPath:  "container",
+		Image:    "debian:bookworm",
+		User:     "runner",
+		WorkRoot: "/work/crabbox",
+		CPUs:     4,
+		Memory:   "8g",
+	}
+	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: &out, Stderr: &out, Exec: runner}).(*backend)
+
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{DryRun: true}); err != nil {
+		t.Fatalf("Cleanup dry-run: %v", err)
+	}
+	if strings.Contains(out.String(), "would remove claim lease="+orphanLease) {
+		t.Fatalf("dry-run planned removal of a claim reclaimed during Cleanup:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "skip claim lease="+orphanLease+" reason=changed-during-cleanup") {
+		t.Fatalf("dry-run did not report the reclaimed claim as skipped:\n%s", out.String())
+	}
+}

--- a/internal/providers/hostinger/provider_test.go
+++ b/internal/providers/hostinger/provider_test.go
@@ -1448,6 +1448,11 @@ func TestResolveRestoresOwnedClaimWhenRefreshFails(t *testing.T) {
 		t.Fatalf("Resolve err=%v", err)
 	}
 	restored, ok, claimErr := core.ResolveLeaseClaimForProvider(leaseID, providerName)
+	if restored.Revision == previous.Revision {
+		t.Fatalf("restored claim kept revision %q", previous.Revision)
+	}
+	restored.Revision = ""
+	previous.Revision = ""
 	if claimErr != nil || !ok || !reflect.DeepEqual(restored, previous) {
 		t.Fatalf("restored=%#v previous=%#v ok=%v err=%v", restored, previous, ok, claimErr)
 	}

--- a/internal/providers/unikraftcloud/core.go
+++ b/internal/providers/unikraftcloud/core.go
@@ -94,7 +94,7 @@ func removeLeaseClaimIfUnchanged(leaseID string, expected LeaseClaim) error {
 	return core.RemoveLeaseClaimIfUnchanged(leaseID, expected)
 }
 
-var replaceLeaseClaimIfUnchangedDurable = core.ReplaceLeaseClaimIfUnchangedDurable
+var replaceLeaseClaimIfUnchangedDurable = core.ReplaceLeaseClaimIfUnchangedDurableReturning
 
 func shouldCleanupServer(server Server, now time.Time) (bool, string) {
 	return core.ShouldCleanupServer(server, now)

--- a/internal/providers/unikraftcloud/durability_test.go
+++ b/internal/providers/unikraftcloud/durability_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -154,15 +155,16 @@ func TestCreateStateTransitionReconcilesErrorAfterRename(t *testing.T) {
 	t.Cleanup(func() { replaceLeaseClaimIfUnchangedDurable = originalReplace })
 	injected := errors.New("sync failed after rename")
 	calls := 0
-	replaceLeaseClaimIfUnchangedDurable = func(leaseID string, current, replacement LeaseClaim) error {
-		if err := originalReplace(leaseID, current, replacement); err != nil {
-			return err
+	replaceLeaseClaimIfUnchangedDurable = func(leaseID string, current, replacement LeaseClaim) (LeaseClaim, error) {
+		written, err := originalReplace(leaseID, current, replacement)
+		if err != nil {
+			return LeaseClaim{}, err
 		}
 		calls++
 		if calls == 1 {
-			return injected
+			return written, injected
 		}
-		return nil
+		return written, nil
 	}
 	intent, err := transitionUnikraftCloudCreateState(preflight, ukcStateCreateIntent)
 	if err != nil {
@@ -170,6 +172,32 @@ func TestCreateStateTransitionReconcilesErrorAfterRename(t *testing.T) {
 	}
 	if calls != 2 || intent.Labels["state"] != ukcStateCreateIntent {
 		t.Fatalf("calls=%d intent=%#v", calls, intent)
+	}
+}
+
+func TestCreateStateTransitionDoesNotReconcileGuardConflict(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	b := testBackend(&fakeUnikraftCloudAPI{baseURL: "https://api.fra.unikraft.cloud"}, nil, nil)
+	leaseID := leasePrefix + "edededededed"
+	createReq := createInstanceRequest{Name: leaseProviderName(leaseID, ""), Image: b.cfg.UnikraftCloud.Image, MemoryMB: b.cfg.UnikraftCloud.MemoryMB, Autostart: true}
+	preflight, err := b.createIntentClaim(leaseID, "guard-conflict", testClaimScope(t, "https://api.fra.unikraft.cloud"), testUserUUID, WarmupRequest{Repo: Repo{Root: t.TempDir()}}, createReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	concurrent := preflight
+	concurrent.Labels = cloneLabels(preflight.Labels)
+	concurrent.Labels["state"] = ukcStateCreateIntent
+	concurrent, err = replaceLeaseClaimIfUnchangedDurable(leaseID, preflight, concurrent)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := transitionUnikraftCloudCreateState(preflight, ukcStateCreateIntent); err == nil || !strings.Contains(err.Error(), "claim changed") {
+		t.Fatalf("stale transition error=%v, want claim changed", err)
+	}
+	stored, exists, err := readLeaseClaimWithPresence(leaseID)
+	if err != nil || !exists || !reflect.DeepEqual(stored, concurrent) {
+		t.Fatalf("stored=%#v exists=%v err=%v, want concurrent=%#v", stored, exists, err, concurrent)
 	}
 }
 
@@ -209,14 +237,15 @@ func TestPreflightTransitionFailureDoesNotLeaveAdoptableIntent(t *testing.T) {
 	originalReplace := replaceLeaseClaimIfUnchangedDurable
 	t.Cleanup(func() { replaceLeaseClaimIfUnchangedDurable = originalReplace })
 	injected := errors.New("persistent sync failure after rename")
-	replaceLeaseClaimIfUnchangedDurable = func(leaseID string, current, replacement LeaseClaim) error {
-		if err := originalReplace(leaseID, current, replacement); err != nil {
-			return err
+	replaceLeaseClaimIfUnchangedDurable = func(leaseID string, current, replacement LeaseClaim) (LeaseClaim, error) {
+		written, err := originalReplace(leaseID, current, replacement)
+		if err != nil {
+			return LeaseClaim{}, err
 		}
 		if replacement.Labels["state"] == ukcStateCreateIntent {
-			return injected
+			return written, injected
 		}
-		return nil
+		return written, nil
 	}
 	if _, err := b.preflightCreateIntent(context.Background(), api, preflight); err == nil || !strings.Contains(err.Error(), injected.Error()) {
 		t.Fatalf("preflight error=%v want %v", err, injected)
@@ -239,14 +268,15 @@ func TestRejectedCreateTransitionFailureRetainsNonAdoptableClaim(t *testing.T) {
 	originalReplace := replaceLeaseClaimIfUnchangedDurable
 	t.Cleanup(func() { replaceLeaseClaimIfUnchangedDurable = originalReplace })
 	injected := errors.New("persistent conflict sync failure after rename")
-	replaceLeaseClaimIfUnchangedDurable = func(leaseID string, current, replacement LeaseClaim) error {
-		if err := originalReplace(leaseID, current, replacement); err != nil {
-			return err
+	replaceLeaseClaimIfUnchangedDurable = func(leaseID string, current, replacement LeaseClaim) (LeaseClaim, error) {
+		written, err := originalReplace(leaseID, current, replacement)
+		if err != nil {
+			return LeaseClaim{}, err
 		}
 		if replacement.Labels["state"] == ukcStateCreateConflict {
-			return injected
+			return written, injected
 		}
-		return nil
+		return written, nil
 	}
 	err := b.Warmup(context.Background(), WarmupRequest{Repo: Repo{Root: t.TempDir(), Name: "demo"}})
 	if err == nil || !strings.Contains(err.Error(), injected.Error()) {

--- a/internal/providers/unikraftcloud/lifecycle.go
+++ b/internal/providers/unikraftcloud/lifecycle.go
@@ -87,20 +87,25 @@ func transitionUnikraftCloudCreateState(claim LeaseClaim, state string) (LeaseCl
 	updated := claim
 	updated.Labels = cloneLabels(claim.Labels)
 	updated.Labels["state"] = state
-	if err := replaceLeaseClaimIfUnchangedDurable(claim.LeaseID, claim, updated); err != nil {
+	written, err := replaceLeaseClaimIfUnchangedDurable(claim.LeaseID, claim, updated)
+	if err != nil {
+		if written.Revision == "" {
+			return LeaseClaim{}, err
+		}
 		current, exists, readErr := readLeaseClaimWithPresence(claim.LeaseID)
 		if readErr != nil {
 			return LeaseClaim{}, errors.Join(err, readErr)
 		}
-		if !exists || !reflect.DeepEqual(current, updated) {
+		if !exists || !reflect.DeepEqual(current, written) {
 			return LeaseClaim{}, err
 		}
-		if retryErr := replaceLeaseClaimIfUnchangedDurable(claim.LeaseID, current, current); retryErr != nil {
+		retryWritten, retryErr := replaceLeaseClaimIfUnchangedDurable(claim.LeaseID, current, current)
+		if retryErr != nil {
 			return LeaseClaim{}, errors.Join(err, retryErr)
 		}
-		return current, nil
+		return retryWritten, nil
 	}
-	return updated, nil
+	return written, nil
 }
 
 func sameUnikraftCloudCreateIdentity(left, right LeaseClaim) bool {
@@ -155,7 +160,7 @@ func quarantineRejectedUnikraftCloudCreateClaim(expected LeaseClaim, cause error
 		return errors.Join(cause, fmt.Errorf("%s rejected create recovery claim %s changed; refusing cleanup", providerName, expected.LeaseID))
 	}
 	if current.Labels["state"] == ukcStateCreateConflict {
-		if err := replaceLeaseClaimIfUnchangedDurable(current.LeaseID, current, current); err != nil {
+		if _, err := replaceLeaseClaimIfUnchangedDurable(current.LeaseID, current, current); err != nil {
 			return errors.Join(cause, err)
 		}
 		return cause
@@ -232,10 +237,11 @@ func (b *backend) reconcileReadyClaimWrite(intent LeaseClaim, instance ukcInstan
 		if err := validateUnikraftCloudReadyClaimReadback(intent, current, instance); err != nil {
 			return LeaseClaim{}, errors.Join(writeErr, err)
 		}
-		if err := replaceLeaseClaimIfUnchangedDurable(intent.LeaseID, current, current); err != nil {
+		written, err := replaceLeaseClaimIfUnchangedDurable(intent.LeaseID, current, current)
+		if err != nil {
 			return LeaseClaim{}, errors.Join(writeErr, err)
 		}
-		return current, nil
+		return written, nil
 	}
 	unlockSlug, lockErr := lockUnikraftCloudSlugAllocation(context.Background())
 	if lockErr != nil {
@@ -516,10 +522,11 @@ func (b *backend) deleteClaimedInstance(ctx context.Context, api unikraftCloudAP
 			labels["state"] = ukcStateDeleteAttempt
 			updated := claim
 			updated.Labels = labels
-			if err := replaceLeaseClaimIfUnchangedDurable(claim.LeaseID, claim, updated); err != nil {
+			written, err := replaceLeaseClaimIfUnchangedDurable(claim.LeaseID, claim, updated)
+			if err != nil {
 				return false, err
 			}
-			claim = updated
+			claim = written
 		}
 		deleted, deleteErr := api.DeleteInstance(ctx, instanceID)
 		if deleteErr != nil {
@@ -536,10 +543,11 @@ func (b *backend) deleteClaimedInstance(ctx context.Context, api unikraftCloudAP
 		labels[ukcLabelProviderState] = normalizedInstanceState(deleted.State)
 		updated := claim
 		updated.Labels = labels
-		if err := replaceLeaseClaimIfUnchangedDurable(claim.LeaseID, claim, updated); err != nil {
+		written, err := replaceLeaseClaimIfUnchangedDurable(claim.LeaseID, claim, updated)
+		if err != nil {
 			return false, err
 		}
-		claim = updated
+		claim = written
 	}
 	if err := b.proveInstanceAbsent(ctx, api, instanceID, resourceName); err != nil {
 		return false, fmt.Errorf("%s deletion accepted for instance %s but absence is unconfirmed; claim retained: %w", providerName, instanceID, err)


### PR DESCRIPTION
## Summary
Guards the `apple-container` provider's `Cleanup` against a cross-process TOCTOU race that deletes a
concurrent crabbox run's **live** lease claim. `(*backend).Cleanup` snapshots containers via
`listContainers()` **before** it reads lease claims via `core.ListLeaseClaims()`, then its orphan sweep
removes — via the **unguarded** `core.RemoveLeaseClaim` — any claim absent from that stale container
view. A claim registered by a concurrent `Acquire` (a second `crabbox` run on the same Mac) for a live
container is visible to the newer claim read but absent from the older container view, so it is swept as
"missing container" and that live lease's claim is destroyed. The trigger is two concurrent `crabbox`
runs; no attacker.

Part of https://github.com/openclaw/crabbox/issues/1144. Same `[security]` destructive-cleanup class already hardened for other
providers in https://github.com/openclaw/crabbox/pull/1124 (tart),
https://github.com/openclaw/crabbox/pull/446 (aws/azure), and
https://github.com/openclaw/crabbox/pull/781 (freestyle/islo).

## What to review
| file | change |
|---|---|
| `internal/providers/applecontainer/backend.go` | +23 / −7 — snapshot claims before listing containers; guard the orphan-sweep removal with `RemoveLeaseClaimIfUnchanged` |
| `internal/providers/applecontainer/cleanup_toctou_test.go` | +218 — two regression tests (fresh-claim + reclaim), base-fails / HEAD-passes |

## How it works
Mirrors the merged tart fix (https://github.com/openclaw/crabbox/pull/1124):
- Snapshot orphan-candidate claims **before** `listContainers()`, so a claim newer than the container
  view cannot be misclassified as a "missing container" orphan.
- Guard the sweep removal with `core.RemoveLeaseClaimIfUnchanged`, so a lease reclaimed mid-cleanup is
  spared.
- Leave the stored testbox key in place — `Acquire` creates/reuses the key before publishing its claim,
  so a missing-container sweep cannot safely delete it.

The delete-loop path (a container this `Cleanup` itself removes, from a fresh claim read) is unchanged.

## Evidence (deterministic before/after)
apple-container `Cleanup` requires macOS on Apple silicon and provisions real containers, and this is a
**timing race** a happy-path lifecycle run cannot reliably trigger — so live host_smoke is deferred to
maintainer CI (as with https://github.com/openclaw/crabbox/pull/1124 / https://github.com/openclaw/crabbox/issues/1123). Instead the race is reproduced **deterministically** with two
regression tests that FAIL on base `f46ce01f` and PASS with this change, on this Apple-silicon Mac:

```
# BASE (this change stashed) — the sweep deletes the concurrent claim:
$ go test -race -run TestCleanupOrphanSweep ./internal/providers/applecontainer/
--- FAIL: TestCleanupOrphanSweepDeletesConcurrentAcquireClaim
    Cleanup's orphan sweep deleted the claim registered by a concurrent Acquire ... present=false (want present)
    remove claim lease=cbx_acfresh12345 reason=missing container
--- FAIL: TestCleanupOrphanSweepGuardDeclinesReclaimedCandidate
FAIL

# HEAD (this change) — both pass; full package suite green:
$ go test -race ./internal/providers/applecontainer/
ok  github.com/openclaw/crabbox/internal/providers/applecontainer
```

`TestCleanupOrphanSweepDeletesConcurrentAcquireClaim` exercises the reorder (a fresh concurrent claim);
`TestCleanupOrphanSweepGuardDeclinesReclaimedCandidate` exercises the `RemoveLeaseClaimIfUnchanged` guard
(a reclaim mid-cleanup). `go build ./...`, `go vet ./...`, `gofmt -l`, and the full `go test -race ./...`
suite are clean.

## Not included (scope)
This PR fixes only `apple-container`. The same orphan-sweep class in `local-container` and the `external`
provider is addressed in sibling PRs under https://github.com/openclaw/crabbox/issues/1144 (both scope-gated to same-runtime/context
concurrent runs). Providers that already guard the sweep (tart https://github.com/openclaw/crabbox/pull/1124, aws/azure https://github.com/openclaw/crabbox/pull/446, freestyle/islo
https://github.com/openclaw/crabbox/pull/781) or re-check ownership before deleting (multipass/hyperv/kubevirt) are unaffected.

## Live behavior proof (Apple `container` v1.0.0, macOS on Apple silicon)

Run against the **real** Apple `container` runtime with the fixed binary built from this PR's
head (`e720fa53`). It exercises the full lease lifecycle and proves the cleanup path leaves a
live box untouched, with zero residue. Private IPs, paths, keys, and lease ids are redacted.

```console
$ container --version
container CLI version 1.0.0 (build: release)

$ crabbox doctor --provider apple-container
ok  provider  provider=apple-container cli=ready run=ready control_plane=local system=ready inventory=ready leases=0 image=ubuntu:26.04

$ crabbox warmup --provider apple-container --slug cbx-live-lc --ttl 15m --idle-timeout 5m
provisioning provider=apple-container lease=cbx_<redacted> slug=cbx-live-lc image=ubuntu:26.04 keep=true
provisioned  lease=cbx_<redacted> container=crabbox-cbx-live-lc-<hash> state=ready
leased       cbx_<redacted> slug=cbx-live-lc provider=apple-container server=crabbox-cbx-live-lc-<hash> type=ubuntu_26.04 ip=<redacted> idle_timeout=5m0s
ready        ssh=crabbox@<redacted>:22 network=public workroot=/work/crabbox
warmup complete total=12.084s

$ crabbox status --provider apple-container --id cbx-live-lc --wait
cbx_<redacted> slug=cbx-live-lc provider=apple-container state=leased type=ubuntu_26.04 ready=true has_host=true idle_timeout=5m0s

$ crabbox run --provider apple-container --id cbx-live-lc -- sh -lc 'uname -a; head -1 /etc/os-release'
sync complete in 464ms
IN-CONTAINER: Linux crabbox-cbx-live-lc-<hash> 6.18.15 #1 SMP aarch64 GNU/Linux
PRETTY_NAME="Ubuntu 26.04 LTS"
run summary command=62ms total=539ms exit=0

$ crabbox list --provider apple-container --json          # live claim present
[{"name":"crabbox-cbx-live-lc-<hash>","status":"running",
  "labels":{"crabbox":"true","provider":"apple-container","lease":"cbx_<redacted>",
            "slug":"cbx-live-lc","state":"leased","keep":"true","image":"ubuntu:26.04"}}]

$ crabbox cleanup --provider apple-container --dry-run     # must NOT touch the live box
skip container id=crabbox-cbx-live-lc-<hash> name=crabbox-cbx-live-lc-<hash> reason=keep=true

$ crabbox stop --provider apple-container cbx-live-lc
released lease=cbx_<redacted> container=crabbox-cbx-live-lc-<hash>

$ crabbox list --provider apple-container --json          # zero residue
[]
```

### Instrumented live proof — the guard declines against the real runtime

Committed as an opt-in `//go:build smoke` test
(`internal/providers/applecontainer/cleanup_live_smoke_test.go`), run with:

```
CRABBOX_LIVE=1 go test -tags smoke -run TestLiveAppleContainerCleanupGuardPreservesReclaimedClaim -v ./internal/providers/applecontainer/
```

It drives the **real** Apple `container` runtime: creates a real container for a lease, registers the
claim, deletes the container so the claim is a genuine missing-container orphan by the runtime's own view,
then runs the real `Cleanup` while **deliberately reclaiming the lease during Cleanup's real
`container ls` snapshot window**. The guard observes the change and declines the removal — the live claim
survives:

```text
--- RUN   TestLiveAppleContainerCleanupGuardPreservesReclaimedClaim
    LIVE PROOF (real Apple container runtime): guard declined the reclaimed claim during Cleanup's real `container ls` window:
        skip claim lease=cbx_livesmoke_guard reason=changed-during-cleanup err=lease cbx_livesmoke_guard claim changed; retry
        apple-container cleanup removed=0 claims_removed=0 checked=0
--- PASS: TestLiveAppleContainerCleanupGuardPreservesReclaimedClaim (1.08s)
ok  github.com/openclaw/crabbox/internal/providers/applecontainer
```

`removed=0 claims_removed=0` — the reclaimed claim was preserved and the guard logged the decline against
real runtime state, i.e. two effectively-concurrent operations (a cleanup and a reclaim) where Cleanup
does **not** remove the active claim. This is the deliberately-instrumented form of the reorder a blind
timing race cannot produce (below). The smoke skips unless `CRABBOX_LIVE=1` on Apple silicon and refuses
to run while any other crabbox container is present, so it never touches unrelated containers; the claim
store is an isolated temp dir.

### Why the reorder race is proven deterministically, not by a live timing loop

The cross-process reorder is a sub-200ms window: `Cleanup` snapshots orphan-candidate claims, lists
containers, then prunes claims absent from that container view. Reproducing it live would require a
concurrent `Acquire` to publish its lease **claim** inside that window — but the apple-container
`Acquire` publishes its claim only *after* creating the real container (≈12s on a cold image), so two
concurrent `crabbox` CLI processes cannot interleave into the window in practice. An 8-iteration live
attempt (real runtime, one process running `cleanup` while another ran `warmup --reclaim`) confirmed
this: the reclaim's claim was always published far outside cleanup's window, so the genuine orphan was
correctly pruned every time and the guard's decline path was never exercised by chance.

That is exactly why the precise interleaving is reproduced by the deterministic fake-runner tests
above — which FAIL on base `cf5081fc` and PASS with this change — the same proof standard under which
the sibling tart fix (https://github.com/openclaw/crabbox/pull/1124) merged. Happy to provide further
live captures, or to defer to maintainer judgment / an explicit proof-override as with
https://github.com/openclaw/crabbox/pull/1124.

## Review history
https://gist.github.com/9953999be1e2ff4a92417d0876566b28


