### PR TITLE
fix(apple-container): require an exact claim before state-based cleanup (P0 data loss)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Fixed
 
+- Prevented Apple-container cleanup from force-deleting stopped containers without an exact resource-bound local claim. Thanks @coygeek.
 - Limited failed Blacksmith warmup cleanup to Testbox IDs emitted by that invocation, preventing config-matched concurrent Testboxes from being stopped. Thanks @anagnorisis2peripeteia.
 - Prevented Tart cleanup from deleting lease claims and stored SSH keys created or rebound by concurrent acquisitions. Thanks @anagnorisis2peripeteia.
 - Failed Node coordinator startup on malformed trusted-proxy CIDRs, warned on untrusted forwarded client headers, and kept environment-backed provider failures out of top-level request logs.

--- a/docs/providers/apple-container.md
+++ b/docs/providers/apple-container.md
@@ -137,9 +137,9 @@ variable consumed by the bootstrap script.
 6. `status`, `list`, and `stop` inspect or remove labeled containers via
    `container ls --all --format json`, `container inspect`, and
    `container delete --force`.
-7. `cleanup --provider apple-container` removes stopped containers and running
-   non-`keep` containers whose local claim is stale past the idle timeout plus a
-   safety grace period, and prunes orphaned claims.
+7. `cleanup --provider apple-container` removes exactly claimed stopped containers
+   and exactly claimed running non-`keep` containers whose local claim is stale
+   past the idle timeout plus a safety grace period, and prunes orphaned claims.
 
 ## Limits and caveats
 

--- a/internal/providers/applecontainer/backend.go
+++ b/internal/providers/applecontainer/backend.go
@@ -865,24 +865,29 @@ func shouldCleanup(server core.Server, claim core.LeaseClaim, hasClaim bool, now
 	if strings.EqualFold(labels["keep"], "true") {
 		return false, "keep=true"
 	}
+	if !hasClaim {
+		return false, "missing claim"
+	}
+	leaseID := strings.TrimSpace(labels["lease"])
+	containerID := strings.TrimSpace(server.CloudID)
+	if claim.Provider != providerName || claim.LeaseID != leaseID || leaseID == "" || strings.TrimSpace(claim.CloudID) != containerID || containerID == "" {
+		return false, "claim mismatch"
+	}
 	if !strings.EqualFold(server.Status, "running") && server.Status != "ready" {
 		return true, "container state=" + blank(server.Status, "unknown")
 	}
-	if hasClaim {
-		lastUsed, err := time.Parse(time.RFC3339, claim.LastUsedAt)
-		if err != nil || lastUsed.IsZero() {
-			return false, "claim active"
-		}
-		idle := time.Duration(claim.IdleTimeoutSeconds) * time.Second
-		if idle <= 0 {
-			return false, "claim active"
-		}
-		if now.After(lastUsed.Add(idle).Add(12 * time.Hour)) {
-			return true, "claim expired"
-		}
+	lastUsed, err := time.Parse(time.RFC3339, claim.LastUsedAt)
+	if err != nil || lastUsed.IsZero() {
 		return false, "claim active"
 	}
-	return false, "missing claim"
+	idle := time.Duration(claim.IdleTimeoutSeconds) * time.Second
+	if idle <= 0 {
+		return false, "claim active"
+	}
+	if now.After(lastUsed.Add(idle).Add(12 * time.Hour)) {
+		return true, "claim expired"
+	}
+	return false, "claim active"
 }
 
 func readyCheck(cfg core.Config) string {

--- a/internal/providers/applecontainer/backend_test.go
+++ b/internal/providers/applecontainer/backend_test.go
@@ -583,6 +583,9 @@ func TestRemoveContainerUsesDeleteForce(t *testing.T) {
 }
 
 func TestCleanupPreservesUnclaimedStoppedAppleContainer(t *testing.T) {
+	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
+		t.Skip("apple-container cleanup only runs on macOS/Apple silicon")
+	}
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
 		commandKey([]string{"ls", "--all", "--format", "json"}): {Stdout: `[{
@@ -604,6 +607,9 @@ func TestCleanupPreservesUnclaimedStoppedAppleContainer(t *testing.T) {
 }
 
 func TestCleanupDeletesStoppedAppleContainerWithExactClaim(t *testing.T) {
+	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
+		t.Skip("apple-container cleanup only runs on macOS/Apple silicon")
+	}
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	const leaseID = "cbx_claimed_cleanup"
 	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(

--- a/internal/providers/applecontainer/backend_test.go
+++ b/internal/providers/applecontainer/backend_test.go
@@ -582,6 +582,93 @@ func TestRemoveContainerUsesDeleteForce(t *testing.T) {
 	}
 }
 
+func TestCleanupPreservesUnclaimedStoppedAppleContainer(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+		commandKey([]string{"ls", "--all", "--format", "json"}): {Stdout: `[{
+			"status":"stopped",
+			"configuration":{
+				"id":"unclaimed-container",
+				"image":{"reference":"debian:bookworm"},
+				"labels":{"crabbox":"true","provider":"apple-container"}
+			}
+		}]`},
+	}}
+
+	if err := testBackend(runner).Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if commandWasCalled(runner.calls, "delete") {
+		t.Fatalf("Cleanup deleted unclaimed stopped container: %#v", runner.calls)
+	}
+}
+
+func TestCleanupDeletesStoppedAppleContainerWithExactClaim(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	const leaseID = "cbx_claimed_cleanup"
+	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(
+		leaseID,
+		"claimed-cleanup",
+		providerName,
+		"",
+		"",
+		t.TempDir(),
+		time.Minute,
+		false,
+		core.Server{CloudID: "claimed-container", Provider: providerName},
+		core.SSHTarget{},
+	); err != nil {
+		t.Fatal(err)
+	}
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+		commandKey([]string{"ls", "--all", "--format", "json"}): {Stdout: `[{
+			"status":"stopped",
+			"configuration":{
+				"id":"claimed-container",
+				"image":{"reference":"debian:bookworm"},
+				"labels":{"crabbox":"true","provider":"apple-container","lease":"cbx_claimed_cleanup"}
+			}
+		}]`},
+	}}
+
+	if err := testBackend(runner).Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if !commandWasCalled(runner.calls, "delete") {
+		t.Fatalf("Cleanup preserved exactly claimed stopped container: %#v", runner.calls)
+	}
+}
+
+func TestShouldCleanupRequiresExactClaimBeforeStateDeletion(t *testing.T) {
+	now := time.Now().UTC()
+	server := core.Server{
+		CloudID: "claimed-container",
+		Status:  "stopped",
+		Labels: map[string]string{
+			"crabbox":  "true",
+			"provider": providerName,
+			"lease":    "cbx_claimed_container",
+		},
+	}
+	exactClaim := core.LeaseClaim{
+		LeaseID:  "cbx_claimed_container",
+		Provider: providerName,
+		CloudID:  "claimed-container",
+	}
+
+	if cleanup, reason := shouldCleanup(server, core.LeaseClaim{}, false, now); cleanup || reason != "missing claim" {
+		t.Fatalf("unclaimed cleanup=%v reason=%q, want false/missing claim", cleanup, reason)
+	}
+	conflictingClaim := exactClaim
+	conflictingClaim.CloudID = "other-container"
+	if cleanup, reason := shouldCleanup(server, conflictingClaim, true, now); cleanup || reason != "claim mismatch" {
+		t.Fatalf("conflicting cleanup=%v reason=%q, want false/claim mismatch", cleanup, reason)
+	}
+	if cleanup, reason := shouldCleanup(server, exactClaim, true, now); !cleanup || reason != "container state=stopped" {
+		t.Fatalf("exact cleanup=%v reason=%q, want true/container state=stopped", cleanup, reason)
+	}
+}
+
 func TestRequireExactAppleContainerClaim(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	leaseID := "cbx_claimed_apple_container"


### PR DESCRIPTION
## Summary

- require an exact local claim matching provider, lease ID, and container ID before Apple-container cleanup considers container state
- preserve unclaimed or conflicting stopped containers while retaining cleanup of exactly claimed stopped containers
- document the fail-closed cleanup behavior and add the security fix to the changelog

## Security impact

The `crabbox=true` and `provider=apple-container` labels remain discovery hints, but no longer authorize `container delete --force`. Cleanup now fails closed before state-based deletion unless the local claim is resource-bound to the current container.

No config, secret, or migration changes.

This fix is intentionally separate from https://github.com/openclaw/crabbox/issues/1144 and https://github.com/openclaw/crabbox/issues/1146.

Fixes https://github.com/openclaw/crabbox/issues/1132

## Regression proof

Before the fix, `TestCleanupPreservesUnclaimedStoppedAppleContainer` failed after recording:

```text
container delete --force unclaimed-container
```

After the fix, the regression test passes. Additional coverage verifies that a conflicting resource-bound claim is skipped and an exact matching claim still permits stopped-container cleanup.

## Verification

```text
go build ./...
go vet ./...
go test -race ./internal/providers/applecontainer/... -count=1
```

Codex autoreview:

```text
.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
autoreview clean: no accepted/actionable findings reported
```
