### PR TITLE
fix: enforce declared zero artifact sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added bounded JSON Schema validation for required run artifacts across supported standard drafts, with local references and redacted failure diagnostics. Thanks @dwin-gharibi.
 
+### Fixed
+
+- Enforced explicitly declared zero-byte artifact sizes during pull while preserving legacy manifests that omit size.
+
 ## 0.39.0 - 2026-07-17
 
 ### Added

--- a/internal/cli/artifacts_manifest.go
+++ b/internal/cli/artifacts_manifest.go
@@ -51,6 +51,21 @@ type artifactManifestFile struct {
 	sizeDeclared bool
 }
 
+func (file artifactManifestFile) MarshalJSON() ([]byte, error) {
+	type manifestFile artifactManifestFile
+	var size *int64
+	if file.declaresSize() {
+		size = &file.Size
+	}
+	return json.Marshal(struct {
+		manifestFile
+		Size *int64 `json:"size,omitempty"`
+	}{
+		manifestFile: manifestFile(file),
+		Size:         size,
+	})
+}
+
 func (file *artifactManifestFile) UnmarshalJSON(data []byte) error {
 	type manifestFile artifactManifestFile
 	var decoded struct {
@@ -113,6 +128,7 @@ func writeArtifactManifest(root *os.Root, opts artifactPublishOptions, files []a
 			SHA256:       file.snapshotHash,
 			ExpiresAt:    artifactURLExpiresAt(file.URL),
 			AccessPolicy: artifactAccessPolicy(file.URL, opts.Storage),
+			sizeDeclared: true,
 		})
 	}
 	path := filepath.Join(opts.Directory, artifactManifestFilename)

--- a/internal/cli/artifacts_manifest.go
+++ b/internal/cli/artifacts_manifest.go
@@ -48,6 +48,28 @@ type artifactManifestFile struct {
 	SHA256       string `json:"sha256,omitempty"`
 	ExpiresAt    string `json:"expiresAt,omitempty"`
 	AccessPolicy string `json:"accessPolicy,omitempty"`
+	sizeDeclared bool
+}
+
+func (file *artifactManifestFile) UnmarshalJSON(data []byte) error {
+	type manifestFile artifactManifestFile
+	var decoded struct {
+		manifestFile
+		Size *int64 `json:"size"`
+	}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	*file = artifactManifestFile(decoded.manifestFile)
+	if decoded.Size != nil {
+		file.Size = *decoded.Size
+		file.sizeDeclared = true
+	}
+	return nil
+}
+
+func (file artifactManifestFile) declaresSize() bool {
+	return file.sizeDeclared || file.Size != 0
 }
 
 type artifactPullResult struct {
@@ -197,7 +219,7 @@ func pullArtifactManifest(ctx context.Context, ref, output string, overwrite boo
 			_ = os.Remove(tempPath)
 			return artifactPullResult{}, exit(2, "artifact hash mismatch for %s: got %s, want %s", file.Name, hash, file.SHA256)
 		}
-		if file.Size > 0 && file.Size != size {
+		if file.declaresSize() && file.Size != size {
 			_ = os.Remove(tempPath)
 			return artifactPullResult{}, exit(2, "artifact size mismatch for %s: got %d, want %d", file.Name, size, file.Size)
 		}
@@ -375,7 +397,7 @@ func artifactRequestError(err error) error {
 }
 
 func artifactDownloadLimit(file artifactManifestFile) int64 {
-	if file.Size > 0 && file.Size < maxPulledArtifactBytes {
+	if file.declaresSize() && file.Size >= 0 && file.Size < maxPulledArtifactBytes {
 		return file.Size
 	}
 	return maxPulledArtifactBytes

--- a/internal/cli/artifacts_test.go
+++ b/internal/cli/artifacts_test.go
@@ -2089,6 +2089,105 @@ func TestArtifactsPullRejectsNegativeManifestSize(t *testing.T) {
 	}
 }
 
+func TestArtifactsPullDistinguishesZeroFromOmittedManifestSize(t *testing.T) {
+	tests := []struct {
+		name      string
+		payload   string
+		sizeField string
+		wantError string
+	}{
+		{
+			name:      "declared zero accepts empty artifact",
+			sizeField: `,"size":0`,
+		},
+		{
+			name:      "declared zero rejects non-empty artifact",
+			payload:   "not empty",
+			sizeField: `,"size":0`,
+			wantError: "artifact size mismatch for artifact.txt: got 9, want 0",
+		},
+		{
+			name:    "omitted size remains optional",
+			payload: "legacy artifact",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			mustWriteFile(t, filepath.Join(dir, "artifact.txt"), test.payload)
+			manifest := fmt.Sprintf(`{"schemaVersion":1,"generatedAt":"2026-07-17T00:00:00Z","storage":{"backend":"local"},"files":[{"name":"artifact.txt","path":"artifact.txt"%s}]}`, test.sizeField)
+			manifestPath := filepath.Join(dir, artifactManifestFilename)
+			if err := os.WriteFile(manifestPath, []byte(manifest), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			output := filepath.Join(dir, "pull")
+			_, err := pullArtifactManifest(context.Background(), manifestPath, output, false)
+			if test.wantError != "" {
+				if err == nil || !strings.Contains(err.Error(), test.wantError) {
+					t.Fatalf("err=%v, want %q", err, test.wantError)
+				}
+				if _, statErr := os.Stat(filepath.Join(output, "artifact.txt")); !os.IsNotExist(statErr) {
+					t.Fatalf("mismatched artifact was installed: %v", statErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := os.ReadFile(filepath.Join(output, "artifact.txt"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != test.payload {
+				t.Fatalf("payload=%q, want %q", got, test.payload)
+			}
+		})
+	}
+}
+
+func TestDownloadArtifactURLHonorsDeclaredZeroSize(t *testing.T) {
+	for _, flushHeaders := range []bool{false, true} {
+		t.Run(fmt.Sprintf("flushHeaders=%t", flushHeaders), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if flushHeaders {
+					w.WriteHeader(http.StatusOK)
+					w.(http.Flusher).Flush()
+				}
+				_, _ = io.WriteString(w, "unexpected")
+			}))
+			defer server.Close()
+
+			data, err := json.Marshal(map[string]any{
+				"schemaVersion": 1,
+				"files": []map[string]any{{
+					"name": "artifact.txt",
+					"url":  server.URL,
+					"size": 0,
+				}},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			manifest, err := decodeArtifactManifest(data, "test manifest")
+			if err != nil {
+				t.Fatal(err)
+			}
+			outPath := filepath.Join(t.TempDir(), "artifact.txt")
+			_, _, _, err = downloadArtifactURL(context.Background(), manifest.Files[0], outPath)
+			if err == nil || !strings.Contains(err.Error(), "exceeds limit 0") {
+				t.Fatalf("err=%v, want zero-size limit rejection", err)
+			}
+			if info, statErr := os.Stat(outPath); statErr == nil && info.Size() != 0 {
+				t.Fatalf("downloaded artifact size=%d, want no bytes", info.Size())
+			} else if statErr != nil && !os.IsNotExist(statErr) {
+				t.Fatal(statErr)
+			}
+		})
+	}
+}
+
 func TestArtifactsPullAllowsOutputAfterManifestRef(t *testing.T) {
 	dir := t.TempDir()
 	payload := []byte("png-data")

--- a/internal/cli/artifacts_test.go
+++ b/internal/cli/artifacts_test.go
@@ -2147,6 +2147,89 @@ func TestArtifactsPullDistinguishesZeroFromOmittedManifestSize(t *testing.T) {
 	}
 }
 
+func TestArtifactsListJSONPreservesManifestSizePresence(t *testing.T) {
+	tests := []struct {
+		name          string
+		sizeField     string
+		wantSize      bool
+		wantSizeValue float64
+		wantPullError string
+	}{
+		{
+			name: "omitted",
+		},
+		{
+			name:          "explicit zero",
+			sizeField:     `,"size":0`,
+			wantSize:      true,
+			wantPullError: "artifact size mismatch for artifact.txt: got 15, want 0",
+		},
+		{
+			name:          "positive",
+			sizeField:     `,"size":15`,
+			wantSize:      true,
+			wantSizeValue: 15,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			mustWriteFile(t, filepath.Join(dir, "artifact.txt"), "legacy artifact")
+			manifest := fmt.Sprintf(`{"schemaVersion":1,"generatedAt":"2026-07-17T00:00:00Z","storage":{"backend":"local"},"files":[{"name":"artifact.txt","path":"artifact.txt"%s}]}`, test.sizeField)
+			manifestPath := filepath.Join(dir, artifactManifestFilename)
+			if err := os.WriteFile(manifestPath, []byte(manifest), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			var normalized bytes.Buffer
+			app := App{Stdout: &normalized, Stderr: io.Discard}
+			if err := app.artifactsList(context.Background(), []string{"--json", manifestPath}); err != nil {
+				t.Fatal(err)
+			}
+			var encoded struct {
+				Files []map[string]any `json:"files"`
+			}
+			if err := json.Unmarshal(normalized.Bytes(), &encoded); err != nil {
+				t.Fatal(err)
+			}
+			if len(encoded.Files) != 1 {
+				t.Fatalf("files=%#v, want one entry", encoded.Files)
+			}
+			gotSize, hasSize := encoded.Files[0]["size"]
+			if hasSize != test.wantSize {
+				t.Fatalf("normalized size presence=%t value=%v, want presence=%t\n%s", hasSize, gotSize, test.wantSize, normalized.String())
+			}
+			if hasSize && gotSize != test.wantSizeValue {
+				t.Fatalf("normalized size=%v, want %v", gotSize, test.wantSizeValue)
+			}
+
+			normalizedPath := filepath.Join(dir, "normalized.json")
+			if err := os.WriteFile(normalizedPath, normalized.Bytes(), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			output := filepath.Join(dir, "pull")
+			_, err := pullArtifactManifest(context.Background(), normalizedPath, output, false)
+			if test.wantPullError != "" {
+				if err == nil || !strings.Contains(err.Error(), test.wantPullError) {
+					t.Fatalf("err=%v, want %q", err, test.wantPullError)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := os.ReadFile(filepath.Join(output, "artifact.txt"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != "legacy artifact" {
+				t.Fatalf("payload=%q, want legacy artifact", got)
+			}
+		})
+	}
+}
+
 func TestDownloadArtifactURLHonorsDeclaredZeroSize(t *testing.T) {
 	for _, flushHeaders := range []bool{false, true} {
 		t.Run(fmt.Sprintf("flushHeaders=%t", flushHeaders), func(t *testing.T) {

--- a/internal/cli/artifacts_test.go
+++ b/internal/cli/artifacts_test.go
@@ -2293,6 +2293,7 @@ func TestArtifactsPullRejectsHashMismatch(t *testing.T) {
 		Files: []artifactManifestFile{{
 			Name:   "screenshot.png",
 			URL:    server.URL,
+			Size:   int64(len("changed")),
 			SHA256: strings.Repeat("0", 64),
 		}},
 	}


### PR DESCRIPTION
## Summary

- preserve whether an artifact manifest explicitly declares its size, including through JSON re-serialization
- enforce declared zero-byte sizes during local copies and remote downloads
- retain compatibility for legacy manifests that omit size
- add local, HTTP, and list-normalize-pull regression coverage plus an Unreleased changelog entry

## Root cause

The manifest decoded size into a plain integer, so both an omitted field and an explicit zero became the same value. Pull verification and remote download limiting then guarded on positive sizes only, treating an explicit zero as absent. The first fix tracked presence only in memory; custom JSON marshaling now preserves that distinction through `artifacts list --json` normalization.

## Validation

- Red regression proof before the fix: the local non-empty artifact and both buffered and streaming HTTP response cases returned success for a declared zero size.
- Focused regression suite: `go test ./internal/cli -run 'TestArtifactsPullDistinguishesZeroFromOmittedManifestSize|TestDownloadArtifactURLHonorsDeclaredZeroSize|TestArtifactsPullRejectsHashMismatch' -count=1`
- Required gate: `go build ./... && go vet ./... && go test ./internal/cli -run 'Artifact|Manifest|Schema' -count=1`
- Codex autoreview: `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` reported no accepted or actionable findings.

### Black-box CLI proof

Run from a fresh temporary directory with the CLI built from `1af659f875ec652a813f51d86fe0a2158e5e6a1f`. The source files were 0 bytes and 16 bytes respectively.

```text
$ crabbox artifacts pull explicit-zero-empty.json --output pull-empty
pulled: $PROOF_DIR/pull-empty/empty.txt bytes=0 sha256=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855

$ crabbox artifacts pull explicit-zero-nonempty.json --output pull-zero-nonempty
artifact size mismatch for artifact.txt: got 16, want 0
exit=2
installed=false

$ crabbox artifacts list --json omitted-size.json > normalized.json
$ jq -c '.files[0]' normalized.json
{"kind":"","name":"artifact.txt","path":"artifact.txt"}
size-key-absent=true

$ crabbox artifacts pull normalized.json --output pull-omitted
pulled: $PROOF_DIR/pull-omitted/artifact.txt bytes=16 sha256=34f7aed3bc21db8ad882cdc561813afe29bea539f2f951568c38d2c98c2c75ca
payload-match=true
```

Fixes #1133
