### PR TITLE
fix(apple-vm): guard Cleanup orphan sweep against a concurrent same-scope Acquire's claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Prevented apple-container orphan cleanup from deleting claims reclaimed during its resource snapshot, including same-value rewrites, while retaining stored SSH keys when ownership cannot be proven safe to remove. Thanks @anagnorisis2peripeteia.
 - Prevented local-container orphan cleanup from deleting claims reclaimed during its resource snapshot while retaining stored SSH keys when ownership cannot be proven safe to remove. Thanks @anagnorisis2peripeteia.
 - Prevented external-provider orphan cleanup from deleting claims reclaimed during its resource snapshot while retaining routing state when ownership cannot be proven safe to remove. Thanks @anagnorisis2peripeteia.
+- Prevented apple-vm orphan cleanup from deleting claims reclaimed during its resource snapshot while retaining stored SSH keys when ownership cannot be proven safe to remove. Thanks @anagnorisis2peripeteia.
 
 ## 0.39.0 - 2026-07-17
 

--- a/docs/features/provider-live-smoke.md
+++ b/docs/features/provider-live-smoke.md
@@ -155,7 +155,7 @@ hermetic lifecycle tests, `scripts/live-smoke.sh`, dedicated live runners, and
 `//go:build smoke` tests. Regenerate it with
 `node scripts/generate-provider-matrix.mjs`; docs CI rejects drift.
 
-Current coverage: 76 providers; 4 with convention-named hermetic lifecycle tests, 56 with a live runner, 7 with tagged Go smoke tests, and 19 with none of those lifecycle surfaces.
+Current coverage: 76 providers; 4 with convention-named hermetic lifecycle tests, 56 with a live runner, 8 with tagged Go smoke tests, and 19 with none of those lifecycle surfaces.
 
 | Provider | Hermetic lifecycle | Live runner | Tagged Go smoke |
 | --- | --- | --- | --- |
@@ -163,7 +163,7 @@ Current coverage: 76 providers; 4 with convention-named hermetic lifecycle tests
 | [anthropic-sandbox-runtime](../providers/anthropic-sandbox-runtime.md) | — | dedicated + matrix | — |
 | [apple-container](../providers/apple-container.md) | — | matrix | yes |
 | [apple-machine](../providers/apple-machine.md) | — | — | — |
-| [apple-vm](../providers/apple-vm.md) | — | matrix | — |
+| [apple-vm](../providers/apple-vm.md) | — | matrix | yes |
 | [ascii-box](../providers/ascii-box.md) | — | — | — |
 | [aws](../providers/aws.md) | — | matrix | — |
 | [aws-lambda-microvm](../providers/aws-lambda-microvm.md) | — | dedicated + matrix | — |

--- a/internal/providers/applevm/backend.go
+++ b/internal/providers/applevm/backend.go
@@ -385,6 +385,14 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 	if err := requireHost(); err != nil {
 		return err
 	}
+	// Snapshot orphan-candidate claims before listing instances so a claim
+	// registered by a concurrent Acquire cannot be compared against an older
+	// instance view and misclassified as a "missing instance" orphan. Only claims
+	// that predate our instance view can be genuine orphans.
+	orphanCandidates, err := core.ListLeaseClaims()
+	if err != nil {
+		return err
+	}
 	instances, err := b.listInstances(ctx, cfg)
 	if err != nil {
 		return err
@@ -437,8 +445,8 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 		removed++
 	}
 	claimsRemoved := 0
-	for _, claim := range claims {
-		if claim.LeaseID == "" {
+	for _, claim := range orphanCandidates {
+		if !isAppleVMProviderName(claim.Provider) || claim.LeaseID == "" {
 			continue
 		}
 		if _, ok := live[claim.LeaseID]; ok {
@@ -449,12 +457,25 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 			continue
 		}
 		if req.DryRun {
+			if err := core.VerifyLeaseClaimUnchanged(claim.LeaseID, claim); err != nil {
+				fmt.Fprintf(b.rt.Stderr, "skip claim lease=%s reason=changed-during-cleanup err=%v\n", claim.LeaseID, err)
+				continue
+			}
 			fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s reason=missing instance\n", claim.LeaseID)
 			continue
 		}
+		// Remove only if the claim is unchanged since our pre-instance snapshot; a
+		// concurrent Acquire/Touch that (re)bound this lease makes it no longer an
+		// orphan, so RemoveLeaseClaimIfUnchanged declines and the live lease survives.
+		// Intentionally retain the stored testbox key: Acquire creates or reuses it
+		// before publishing its claim, outside this claim CAS. Until keys have their
+		// own generation/ownership fence, deleting one here can break the concurrent
+		// live lease; fail closed by retaining inert local key material.
+		if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
+			fmt.Fprintf(b.rt.Stderr, "skip claim lease=%s reason=changed-during-cleanup err=%v\n", claim.LeaseID, err)
+			continue
+		}
 		fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s reason=missing instance\n", claim.LeaseID)
-		core.RemoveLeaseClaim(claim.LeaseID)
-		core.RemoveStoredTestboxKey(claim.LeaseID)
 		claimsRemoved++
 	}
 	if !req.DryRun {

--- a/internal/providers/applevm/cleanup_live_smoke_test.go
+++ b/internal/providers/applevm/cleanup_live_smoke_test.go
@@ -1,0 +1,287 @@
+//go:build smoke
+
+package applevm
+
+// Instrumented LIVE smoke for the Cleanup orphan-sweep guard, opt-in behind the
+// `smoke` build tag and CRABBOX_LIVE=1. Unlike the hermetic tests in
+// cleanup_toctou_test.go (which fake the helper via recordingRunner), this builds
+// and drives the REAL apple-vm helper binary (cmd/crabbox-apple-vm-helper) that
+// Cleanup shells out to. Cleanup's only helper calls are `list` and `delete`, both
+// of which read/remove on-disk instance metadata under the state root — no
+// Virtualization.framework VM is booted, so the guarded orphan-sweep path runs end
+// to end against the real helper subprocess on any Apple-silicon Mac, entitlements
+// or base image absent.
+//
+// The genuine orphan is a claim whose lease has NO instance metadata in the real
+// state root, so the REAL `crabbox-apple-vm-helper list` reports {"instances":null}
+// — a real "missing instance" by the helper's own view, exactly the condition the
+// sweep is designed to detect. Two sub-proofs, both against the real helper:
+//
+//   Guard  — during Cleanup's real `list` window we deliberately reclaim the lease
+//            (rewriting the claim so it no longer matches the pre-list snapshot); the
+//            CAS guard must observe the change and DECLINE the removal, so the
+//            reclaiming process keeps its live claim.
+//   Retain — a genuine orphan that is NOT reclaimed is removed, but its stored SSH
+//            key (which Acquire prepares before publishing its claim) is RETAINED.
+//
+// This is the "instrumented live proof" a timing race cannot reliably produce on its
+// own: Acquire publishes its claim only after the multi-second VM creation, far
+// outside Cleanup's sub-200ms snapshot->remove window, so two blind concurrent CLI
+// processes never interleave into it. The reclaim injection here is a controlled
+// rebind at the exact window against real helper state, which the hermetic tests
+// reproduce deterministically.
+//
+// Safety: HOME, XDG_CONFIG_HOME, XDG_STATE_HOME and the state root are all isolated
+// temp dirs, so the real Cleanup can only ever see this test's own claim over an
+// empty state root — it can never touch host claims, keys, or VMs. A host-wide
+// advisory lock serializes concurrent smoke runs.
+//
+// Run: CRABBOX_LIVE=1 go test -tags smoke -run TestLiveAppleVMCleanup -v ./internal/providers/applevm/
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gofrs/flock"
+	"github.com/openclaw/crabbox/internal/applevmhelper"
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+// liveHelperRunner execs the real crabbox-apple-vm-helper binary for every command,
+// and exactly once — while Cleanup is inside its real `list` snapshot window — fires
+// duringList to inject the deliberate reclaim.
+type liveHelperRunner struct {
+	once       sync.Once
+	duringList func()
+}
+
+func (r *liveHelperRunner) Run(ctx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+	if len(req.Args) > 0 && req.Args[0] == "list" && r.duringList != nil {
+		r.once.Do(r.duringList)
+	}
+	cmd := exec.CommandContext(ctx, req.Name, req.Args...)
+	cmd.Env = append(os.Environ(), req.Env...)
+	if req.Dir != "" {
+		cmd.Dir = req.Dir
+	}
+	if req.Stdin != nil {
+		cmd.Stdin = req.Stdin
+	}
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	err := cmd.Run()
+	res := core.LocalCommandResult{Stdout: stdout.String(), Stderr: stderr.String()}
+	if exit, ok := err.(*exec.ExitError); ok {
+		res.ExitCode = exit.ExitCode()
+		return res, nil
+	}
+	return res, err
+}
+
+// buildRealAppleVMHelper builds the actual helper binary (list/delete are state-only,
+// no VF) and sanity-checks that it lists an empty state root; skips if the toolchain
+// or platform can't produce/run it.
+func buildRealAppleVMHelper(t *testing.T) string {
+	t.Helper()
+	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
+		t.Skip("apple-vm helper requires macOS on Apple silicon")
+	}
+	bin := filepath.Join(t.TempDir(), applevmhelper.ManagedHelperName)
+	build := exec.Command("go", "build", "-o", bin, "github.com/openclaw/crabbox/cmd/crabbox-apple-vm-helper")
+	build.Env = os.Environ()
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Skipf("cannot build apple-vm helper: %v\n%s", err, out)
+	}
+	// Sanity: the real helper lists an empty state root without VF.
+	probeRoot := t.TempDir()
+	out, err := exec.Command(bin, "list", "--state-root", probeRoot).Output()
+	if err != nil {
+		t.Skipf("real apple-vm helper cannot list (runtime unavailable?): %v", err)
+	}
+	var resp applevmhelper.ListResponse
+	if err := json.Unmarshal(out, &resp); err != nil {
+		t.Fatalf("real helper list returned invalid JSON: %v\n%s", err, out)
+	}
+	return bin
+}
+
+// newLiveAppleVMBackend wires a backend that shells out to the real helper binary
+// with runner, over an isolated state root, capturing Cleanup output into out.
+func newLiveAppleVMBackend(t *testing.T, out *bytes.Buffer, root, helperBin string, runner core.CommandRunner) *backend {
+	t.Helper()
+	oldGOOS, oldGOARCH := hostGOOS, hostGOARCH
+	oldMacOSVersion := hostMacOSVersion
+	hostGOOS, hostGOARCH = "darwin", "arm64"
+	hostMacOSVersion = func() (string, error) { return "26.5", nil }
+	t.Cleanup(func() {
+		hostGOOS, hostGOARCH = oldGOOS, oldGOARCH
+		hostMacOSVersion = oldMacOSVersion
+	})
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatalf("mkdir state root %s: %v", root, err)
+	}
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.AppleVM = core.AppleVMConfig{
+		HelperPath:  helperBin,
+		Image:       "https://cloud-images.ubuntu.com/releases/noble/release-20260518/ubuntu-24.04-server-cloudimg-arm64.img",
+		ImageSHA256: "6a61b967ba4a27dd1966f835a67643073ed55c2860ce3dc1cb0517282e6b8bec",
+		User:        "runner",
+		WorkRoot:    "/workspace/crabbox",
+		CPUs:        4,
+		MemoryMiB:   8192,
+		DiskGiB:     40,
+	}
+	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: out, Stderr: out, Exec: runner}).(*backend)
+	b.prepareHelper = func(context.Context, core.Config) (string, error) { return helperBin, nil }
+	b.stateRoot = func() (string, error) { return root, nil }
+	b.waitForSSH = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error { return nil }
+	return b
+}
+
+func lockLiveAppleVMSmoke(t *testing.T) {
+	t.Helper()
+	hostLock := flock.New(filepath.Join(os.TempDir(), "crabbox-applevm-cleanup-smoke.lock"), flock.SetPermissions(0o600))
+	locked, err := hostLock.TryLock()
+	if err != nil {
+		t.Fatalf("acquire live cleanup smoke lock: %v", err)
+	}
+	if !locked {
+		t.Skip("another apple-vm cleanup smoke is running")
+	}
+	t.Cleanup(func() {
+		if err := hostLock.Unlock(); err != nil {
+			t.Errorf("release live cleanup smoke lock: %v", err)
+		}
+	})
+}
+
+func requireLiveAppleVM(t *testing.T) {
+	t.Helper()
+	if os.Getenv("CRABBOX_LIVE") != "1" {
+		t.Skip("set CRABBOX_LIVE=1 to run the live apple-vm cleanup smoke")
+	}
+}
+
+// TestLiveAppleVMCleanupGuardPreservesReclaimedClaim proves the TOCTOU guard against
+// the real helper: a lease reclaimed during Cleanup's real `list` window keeps its
+// claim.
+func TestLiveAppleVMCleanupGuardPreservesReclaimedClaim(t *testing.T) {
+	requireLiveAppleVM(t)
+	lockLiveAppleVMSmoke(t)
+	helperBin := buildRealAppleVMHelper(t)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".state"))
+	root := filepath.Join(t.TempDir(), "state")
+
+	leaseID := "cbx_livesmoke_guard"
+	slug := "livesmoke-guard"
+	name := core.LeaseProviderName(leaseID, slug)
+	writeAgedAppleVMOrphanClaim(t, leaseID, slug, name)
+
+	// During Cleanup's real `list`, reclaim the lease so it no longer matches the
+	// pre-list snapshot (rewrites content + LastUsedAt=now, exactly as a concurrent
+	// Acquire would).
+	reclaim := func() {
+		existing, err := core.ReadLeaseClaim(leaseID)
+		if err != nil {
+			t.Errorf("read existing claim %s before reclaim: %v", leaseID, err)
+			return
+		}
+		server := core.Server{
+			CloudID: name, Provider: providerName, Name: name, Status: "ready",
+			Labels: map[string]string{"crabbox": "true", "provider": providerName, "lease": leaseID, "slug": slug, "state": "ready"},
+		}
+		if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(
+			leaseID, slug, providerName, instanceScope(name), "", existing.RepoRoot, 5*time.Minute, false, server, core.SSHTarget{},
+		); err != nil {
+			t.Errorf("concurrent reclaim registration failed: %v", err)
+		}
+	}
+	runner := &liveHelperRunner{duringList: reclaim}
+
+	var out bytes.Buffer
+	b := newLiveAppleVMBackend(t, &out, root, helperBin, runner)
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+
+	claim, ok, err := core.ResolveLeaseClaimForProvider(leaseID, providerName)
+	if err != nil {
+		t.Fatalf("ResolveLeaseClaimForProvider(%s): %v", leaseID, err)
+	}
+	if !ok || claim.LeaseID != leaseID {
+		t.Fatalf("LIVE: Cleanup removed the reclaimed claim against the real apple-vm helper: present=%v (want present)\ncleanup output:\n%s", ok, out.String())
+	}
+	if !strings.Contains(out.String(), "skip claim lease="+leaseID+" reason=changed-during-cleanup") {
+		t.Fatalf("LIVE: expected the guard to log a decline for the reclaimed claim; got:\n%s", out.String())
+	}
+	if strings.Contains(out.String(), "remove claim lease="+leaseID) {
+		t.Fatalf("LIVE: Cleanup removed the reclaimed lease instead of declining:\n%s", out.String())
+	}
+	t.Logf("LIVE PROOF (real crabbox-apple-vm-helper): guard declined the reclaimed claim during Cleanup's real `list` window:\n%s", strings.TrimSpace(out.String()))
+}
+
+// TestLiveAppleVMCleanupRetainsKeyOnGenuineOrphanRemoval proves the availability fix
+// against the real helper: a genuine orphan (no live instance, not reclaimed) is
+// removed, but its stored SSH key is retained.
+func TestLiveAppleVMCleanupRetainsKeyOnGenuineOrphanRemoval(t *testing.T) {
+	requireLiveAppleVM(t)
+	lockLiveAppleVMSmoke(t)
+	helperBin := buildRealAppleVMHelper(t)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".state"))
+	root := filepath.Join(t.TempDir(), "state")
+
+	leaseID := "cbx_livesmoke_retain"
+	slug := "livesmoke-retain"
+	name := core.LeaseProviderName(leaseID, slug)
+	writeAgedAppleVMOrphanClaim(t, leaseID, slug, name)
+
+	keyPath, err := core.TestboxKeyPath(leaseID)
+	if err != nil {
+		t.Fatalf("TestboxKeyPath(%s): %v", leaseID, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(keyPath), 0o700); err != nil {
+		t.Fatalf("mkdir key dir %s: %v", filepath.Dir(keyPath), err)
+	}
+	if err := os.WriteFile(keyPath, []byte("key-prepared-by-concurrent-acquire"), 0o600); err != nil {
+		t.Fatalf("write prepared key %s: %v", keyPath, err)
+	}
+
+	runner := &liveHelperRunner{} // no reclaim: the orphan is genuinely removed
+	var out bytes.Buffer
+	b := newLiveAppleVMBackend(t, &out, root, helperBin, runner)
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+
+	if _, ok, err := core.ResolveLeaseClaimForProvider(leaseID, providerName); err != nil {
+		t.Fatalf("ResolveLeaseClaimForProvider(%s): %v", leaseID, err)
+	} else if ok {
+		t.Fatalf("LIVE: cleanup should remove the genuine orphan claim %s\n%s", leaseID, out.String())
+	}
+	if _, err := os.Stat(keyPath); err != nil {
+		t.Fatalf("LIVE: prepared key was removed by cleanup against the real helper: %v\n%s", err, out.String())
+	}
+	if !strings.Contains(out.String(), "remove claim lease="+leaseID) {
+		t.Fatalf("LIVE: expected a genuine orphan removal to be logged; got:\n%s", out.String())
+	}
+	t.Logf("LIVE PROOF (real crabbox-apple-vm-helper): genuine orphan removed, prepared key retained:\n%s", strings.TrimSpace(out.String()))
+}

--- a/internal/providers/applevm/cleanup_toctou_test.go
+++ b/internal/providers/applevm/cleanup_toctou_test.go
@@ -1,0 +1,497 @@
+package applevm
+
+// Repro for a cross-process TOCTOU race in (*backend).Cleanup, the same class
+// hardened for other providers in https://github.com/openclaw/crabbox/pull/1124
+// (tart), https://github.com/openclaw/crabbox/pull/446 (aws/azure), and
+// https://github.com/openclaw/crabbox/pull/781 (freestyle/islo).
+//
+// Before this fix, Cleanup snapshotted instances before it re-read claims via
+// core.ListLeaseClaims(), then its orphan sweep removed — via the unguarded
+// core.RemoveLeaseClaim — any claim in that (newer) claim snapshot
+// whose lease was absent from the live claim set built from the (older)
+// instance snapshot. A claim registered by a concurrent Acquire
+// (core.ClaimLeaseForRepoProviderScopePondEndpoint) while Cleanup was still
+// listing instances was therefore visible to the claim read but absent from live,
+// and was deleted as "missing instance" — destroying a healthy concurrent
+// lease's claim. Trigger is two concurrent crabbox runs on one Mac (apple-vm is
+// the local provider); no attacker required.
+//
+// The tests drive it deterministically. apple-vm additionally skips claims within
+// unclaimedInstanceGrace (3h) before reaching any guard, so the orphan candidates
+// are backdated past that grace; the fake `helper list` then reclaims one through
+// the exact core entrypoint Acquire uses (which rewrites LastUsedAt=now) and returns
+// an instance list that predates the reclaim.
+//
+// Against the pre-fix Cleanup the reclaimed claim is read only after listInstances —
+// by then LastUsedAt=now pulls it back inside the startup grace — so base grace-skips
+// it (prints "reason=startup grace period") and the claim survives; the destructive
+// base defect these tests actually pin is the stored-key deletion (see
+// TestCleanupRetainsKeyPreparedByConcurrentAcquire, whose orphan is not reclaimed).
+// With the fix, candidates are snapshotted before listInstances, so the still-aged
+// candidate reaches the CAS guard, which declines the changed claim
+// ("reason=changed-during-cleanup") and retains the key. All three FAIL on base and
+// PASS with the fix.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/openclaw/crabbox/internal/applevmhelper"
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func writeAgedAppleVMOrphanClaim(t *testing.T, leaseID, slug, name string) {
+	t.Helper()
+	writeAgedOrphanClaim(t, leaseID, slug, name, providerName, instanceScope(name))
+}
+
+// writeAgedOrphanClaim registers an orphan claim for an arbitrary provider/scope and
+// backdates it past the startup grace, so cleanup reaches its guarded removal path
+// rather than the grace skip. Used to plant both apple-vm orphans and foreign-provider
+// claims (the latter must be skipped by the sweep's provider filter).
+func writeAgedOrphanClaim(t *testing.T, leaseID, slug, name, provider, scope string) {
+	t.Helper()
+
+	server := core.Server{CloudID: name, Provider: provider, Name: name, Labels: map[string]string{
+		"instance": name,
+		"lease":    leaseID,
+		"provider": provider,
+		"slug":     slug,
+	}}
+	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, slug, provider, scope, "", t.TempDir(), 5*time.Minute, false, server, core.SSHTarget{}); err != nil {
+		t.Fatalf("setup orphan claim: %v", err)
+	}
+
+	before, err := core.ReadLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatalf("read claim %s before rewrite: %v", leaseID, err)
+	}
+
+	stateHome := os.Getenv("XDG_STATE_HOME")
+	if strings.TrimSpace(stateHome) == "" {
+		t.Fatal("XDG_STATE_HOME is not set")
+	}
+	path := filepath.Join(stateHome, "crabbox", "claims", leaseID+".json")
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read claim file %s: %v", path, err)
+	}
+
+	var claim map[string]any
+	if err := json.Unmarshal(data, &claim); err != nil {
+		t.Fatalf("parse claim file %s: %v", path, err)
+	}
+
+	backdate := time.Now().UTC().Add(-4 * time.Hour).Format(time.RFC3339)
+	claim["claimedAt"] = backdate
+	claim["lastUsedAt"] = backdate
+
+	rewritten, err := json.Marshal(claim)
+	if err != nil {
+		t.Fatalf("marshal claim file %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, rewritten, 0o600); err != nil {
+		t.Fatalf("rewrite claim file %s: %v", path, err)
+	}
+
+	readback, err := core.ReadLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatalf("read back claim %s: %v", leaseID, err)
+	}
+	if readback.ClaimedAt != backdate || readback.LastUsedAt != backdate {
+		t.Fatalf("failed to rewrite claim %s: claimedAt=%q lastUsedAt=%q want %q", leaseID, readback.ClaimedAt, readback.LastUsedAt, backdate)
+	}
+	if readback.ClaimedAt == before.ClaimedAt {
+		t.Fatalf("claim %s was not backdated", leaseID)
+	}
+	if claimWithinStartupGrace(readback, time.Now().UTC()) {
+		t.Fatalf("backdated claim %s is still within startup grace", leaseID)
+	}
+}
+
+func TestCleanupOrphanSweepGuardDeclinesReclaimedCandidate(t *testing.T) {
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	var out bytes.Buffer
+
+	oldGOOS, oldGOARCH := hostGOOS, hostGOARCH
+	oldMacOSVersion := hostMacOSVersion
+	hostGOOS, hostGOARCH = "darwin", "arm64"
+	hostMacOSVersion = func() (string, error) { return "26.5", nil }
+	t.Cleanup(func() {
+		hostGOOS, hostGOARCH = oldGOOS, oldGOARCH
+		hostMacOSVersion = oldMacOSVersion
+	})
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".state"))
+	root := t.TempDir()
+
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.AppleVM = core.AppleVMConfig{
+		HelperPath:  "/tmp/helper-source",
+		Image:       "https://cloud-images.ubuntu.com/releases/noble/release-20260518/ubuntu-24.04-server-cloudimg-arm64.img",
+		ImageSHA256: "6a61b967ba4a27dd1966f835a67643073ed55c2860ce3dc1cb0517282e6b8bec",
+		User:        "runner",
+		WorkRoot:    "/workspace/crabbox",
+		CPUs:        4,
+		MemoryMiB:   8192,
+		DiskGiB:     40,
+	}
+	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: &out, Stderr: &out, Exec: runner}).(*backend)
+	b.prepareHelper = func(context.Context, core.Config) (string, error) { return "helper", nil }
+	b.stateRoot = func() (string, error) { return root, nil }
+	b.waitForSSH = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error { return nil }
+
+	leaseID := "cbx_orphan67890"
+	slug := "orphan-slug"
+	name := core.LeaseProviderName(leaseID, slug)
+	writeAgedAppleVMOrphanClaim(t, leaseID, slug, name)
+
+	var once sync.Once
+	runner.hook = func(req core.LocalCommandRequest) (core.LocalCommandResult, error, bool) {
+		if len(req.Args) > 0 && req.Args[0] == "list" {
+			once.Do(func() {
+				existing, err := core.ReadLeaseClaim(leaseID)
+				if err != nil {
+					t.Errorf("read existing claim %s before reclaim: %v", leaseID, err)
+					return
+				}
+				server := core.Server{
+					CloudID:  name,
+					Provider: providerName,
+					Name:     name,
+					Status:   "ready",
+					Labels: map[string]string{
+						"crabbox":  "true",
+						"provider": providerName,
+						"lease":    leaseID,
+						"slug":     slug,
+						"state":    "ready",
+					},
+				}
+				if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, slug, providerName, instanceScope(name), "", existing.RepoRoot, 5*time.Minute, false, server, core.SSHTarget{}); err != nil {
+					t.Errorf("concurrent reclaim registration failed: %v", err)
+				}
+			})
+		}
+		return core.LocalCommandResult{}, nil, false
+	}
+
+	runner.responses[commandKey("helper", []string{"list", "--state-root", root})] = core.LocalCommandResult{Stdout: mustJSON(t, applevmhelper.ListResponse{})}
+
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+
+	claim, ok, err := core.ResolveLeaseClaimForProvider(leaseID, providerName)
+	if err != nil {
+		t.Fatalf("ResolveLeaseClaimForProvider(%s): %v", leaseID, err)
+	}
+	if !ok || claim.LeaseID != leaseID {
+		t.Fatalf("orphan sweep removed a claim reclaimed during Cleanup: present=%v (want present)\ncleanup output:\n%s", ok, out.String())
+	}
+	if !strings.Contains(out.String(), "skip claim lease="+leaseID) || !strings.Contains(out.String(), "changed-during-cleanup") {
+		t.Fatalf("expected reclaim skip output, got:\n%s", out.String())
+	}
+	if strings.Contains(out.String(), "remove claim lease="+leaseID) {
+		t.Fatalf("orphan sweep removed a reclaimed claim:\n%s", out.String())
+	}
+}
+
+func TestCleanupRetainsKeyPreparedByConcurrentAcquire(t *testing.T) {
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	var out bytes.Buffer
+
+	oldGOOS, oldGOARCH := hostGOOS, hostGOARCH
+	oldMacOSVersion := hostMacOSVersion
+	hostGOOS, hostGOARCH = "darwin", "arm64"
+	hostMacOSVersion = func() (string, error) { return "26.5", nil }
+	t.Cleanup(func() {
+		hostGOOS, hostGOARCH = oldGOOS, oldGOARCH
+		hostMacOSVersion = oldMacOSVersion
+	})
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".state"))
+	root := t.TempDir()
+
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.AppleVM = core.AppleVMConfig{
+		HelperPath:  "/tmp/helper-source",
+		Image:       "https://cloud-images.ubuntu.com/releases/noble/release-20260518/ubuntu-24.04-server-cloudimg-arm64.img",
+		ImageSHA256: "6a61b967ba4a27dd1966f835a67643073ed55c2860ce3dc1cb0517282e6b8bec",
+		User:        "runner",
+		WorkRoot:    "/workspace/crabbox",
+		CPUs:        4,
+		MemoryMiB:   8192,
+		DiskGiB:     40,
+	}
+	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: &out, Stderr: &out, Exec: runner}).(*backend)
+	b.prepareHelper = func(context.Context, core.Config) (string, error) { return "helper", nil }
+	b.stateRoot = func() (string, error) { return root, nil }
+	b.waitForSSH = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error { return nil }
+
+	leaseID := "cbx_keyretained67890"
+	slug := "key-retained-slug"
+	name := core.LeaseProviderName(leaseID, slug)
+	writeAgedAppleVMOrphanClaim(t, leaseID, slug, name)
+
+	keyPath, err := core.TestboxKeyPath(leaseID)
+	if err != nil {
+		t.Fatalf("TestboxKeyPath(%s): %v", leaseID, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(keyPath), 0o700); err != nil {
+		t.Fatalf("mkdir key dir %s: %v", filepath.Dir(keyPath), err)
+	}
+	if err := os.WriteFile(keyPath, []byte("key-prepared-by-concurrent-acquire"), 0o600); err != nil {
+		t.Fatalf("write prepared key %s: %v", keyPath, err)
+	}
+
+	runner.responses[commandKey("helper", []string{"list", "--state-root", root})] = core.LocalCommandResult{Stdout: mustJSON(t, applevmhelper.ListResponse{})}
+
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+
+	if _, ok, err := core.ResolveLeaseClaimForProvider(leaseID, providerName); err != nil {
+		t.Fatalf("ResolveLeaseClaimForProvider(%s): %v", leaseID, err)
+	} else if ok {
+		t.Fatalf("cleanup should remove orphan claim %s", leaseID)
+	}
+	if _, err := os.Stat(keyPath); err != nil {
+		t.Fatalf("prepared key was removed by cleanup: %v", err)
+	}
+	if !strings.Contains(out.String(), "remove claim lease="+leaseID) {
+		t.Fatalf("cleanup did not report claim removal:\n%s", out.String())
+	}
+}
+
+func TestCleanupDryRunDoesNotPlanReclaimedCandidateRemoval(t *testing.T) {
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	var out bytes.Buffer
+
+	oldGOOS, oldGOARCH := hostGOOS, hostGOARCH
+	oldMacOSVersion := hostMacOSVersion
+	hostGOOS, hostGOARCH = "darwin", "arm64"
+	hostMacOSVersion = func() (string, error) { return "26.5", nil }
+	t.Cleanup(func() {
+		hostGOOS, hostGOARCH = oldGOOS, oldGOARCH
+		hostMacOSVersion = oldMacOSVersion
+	})
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".state"))
+	root := t.TempDir()
+
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.AppleVM = core.AppleVMConfig{
+		HelperPath:  "/tmp/helper-source",
+		Image:       "https://cloud-images.ubuntu.com/releases/noble/release-20260518/ubuntu-24.04-server-cloudimg-arm64.img",
+		ImageSHA256: "6a61b967ba4a27dd1966f835a67643073ed55c2860ce3dc1cb0517282e6b8bec",
+		User:        "runner",
+		WorkRoot:    "/workspace/crabbox",
+		CPUs:        4,
+		MemoryMiB:   8192,
+		DiskGiB:     40,
+	}
+	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: &out, Stderr: &out, Exec: runner}).(*backend)
+	b.prepareHelper = func(context.Context, core.Config) (string, error) { return "helper", nil }
+	b.stateRoot = func() (string, error) { return root, nil }
+	b.waitForSSH = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error { return nil }
+
+	leaseID := "cbx_dryrun67890"
+	slug := "dryrun-orphan-slug"
+	name := core.LeaseProviderName(leaseID, slug)
+	writeAgedAppleVMOrphanClaim(t, leaseID, slug, name)
+
+	var once sync.Once
+	runner.hook = func(req core.LocalCommandRequest) (core.LocalCommandResult, error, bool) {
+		if len(req.Args) > 0 && req.Args[0] == "list" {
+			once.Do(func() {
+				existing, err := core.ReadLeaseClaim(leaseID)
+				if err != nil {
+					t.Errorf("read existing claim %s before reclaim: %v", leaseID, err)
+					return
+				}
+				server := core.Server{
+					CloudID:  name,
+					Provider: providerName,
+					Name:     name,
+					Status:   "ready",
+					Labels: map[string]string{
+						"crabbox":  "true",
+						"provider": providerName,
+						"lease":    leaseID,
+						"slug":     slug,
+						"state":    "ready",
+					},
+				}
+				if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, slug, providerName, instanceScope(name), "", existing.RepoRoot, 5*time.Minute, false, server, core.SSHTarget{}); err != nil {
+					t.Errorf("concurrent reclaim registration failed: %v", err)
+				}
+			})
+		}
+		return core.LocalCommandResult{}, nil, false
+	}
+
+	runner.responses[commandKey("helper", []string{"list", "--state-root", root})] = core.LocalCommandResult{Stdout: mustJSON(t, applevmhelper.ListResponse{})}
+
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{DryRun: true}); err != nil {
+		t.Fatalf("Cleanup dry-run: %v", err)
+	}
+
+	if strings.Contains(out.String(), "would remove claim lease="+leaseID) {
+		t.Fatalf("dry-run planned removal of a claim reclaimed during Cleanup:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "skip claim lease="+leaseID) || !strings.Contains(out.String(), "changed-during-cleanup") {
+		t.Fatalf("dry-run did not report reclaimed claim as skipped:\n%s", out.String())
+	}
+	claim, ok, err := core.ResolveLeaseClaimForProvider(leaseID, providerName)
+	if err != nil {
+		t.Fatalf("ResolveLeaseClaimForProvider(%s): %v", leaseID, err)
+	}
+	if !ok || claim.LeaseID != leaseID {
+		t.Fatalf("orphan sweep removed a claim reclaimed during dry-run: present=%v (want present)\ncleanup output:\n%s", ok, out.String())
+	}
+}
+
+// TestCleanupDryRunReportsGenuineOrphanRemoval covers the dry-run path for an
+// UNCHANGED genuine orphan (no concurrent reclaim): VerifyLeaseClaimUnchanged returns
+// nil, so cleanup must PLAN the removal ("would remove ...") rather than skip it, and
+// must not actually remove the claim. Complements the reclaim case, which only
+// exercises the skip branch of the same dry-run guard.
+func TestCleanupDryRunReportsGenuineOrphanRemoval(t *testing.T) {
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	var out bytes.Buffer
+
+	oldGOOS, oldGOARCH := hostGOOS, hostGOARCH
+	oldMacOSVersion := hostMacOSVersion
+	hostGOOS, hostGOARCH = "darwin", "arm64"
+	hostMacOSVersion = func() (string, error) { return "26.5", nil }
+	t.Cleanup(func() {
+		hostGOOS, hostGOARCH = oldGOOS, oldGOARCH
+		hostMacOSVersion = oldMacOSVersion
+	})
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".state"))
+	root := t.TempDir()
+
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.AppleVM = core.AppleVMConfig{
+		HelperPath:  "/tmp/helper-source",
+		Image:       "https://cloud-images.ubuntu.com/releases/noble/release-20260518/ubuntu-24.04-server-cloudimg-arm64.img",
+		ImageSHA256: "6a61b967ba4a27dd1966f835a67643073ed55c2860ce3dc1cb0517282e6b8bec",
+		User:        "runner",
+		WorkRoot:    "/workspace/crabbox",
+		CPUs:        4,
+		MemoryMiB:   8192,
+		DiskGiB:     40,
+	}
+	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: &out, Stderr: &out, Exec: runner}).(*backend)
+	b.prepareHelper = func(context.Context, core.Config) (string, error) { return "helper", nil }
+	b.stateRoot = func() (string, error) { return root, nil }
+	b.waitForSSH = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error { return nil }
+
+	leaseID := "cbx_dryrun_genuine"
+	slug := "dryrun-genuine-slug"
+	name := core.LeaseProviderName(leaseID, slug)
+	writeAgedAppleVMOrphanClaim(t, leaseID, slug, name)
+
+	runner.responses[commandKey("helper", []string{"list", "--state-root", root})] = core.LocalCommandResult{Stdout: mustJSON(t, applevmhelper.ListResponse{})}
+
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{DryRun: true}); err != nil {
+		t.Fatalf("Cleanup dry-run: %v", err)
+	}
+
+	if !strings.Contains(out.String(), "would remove claim lease="+leaseID+" reason=missing instance") {
+		t.Fatalf("dry-run must plan removal of an unchanged genuine orphan:\n%s", out.String())
+	}
+	if strings.Contains(out.String(), "skip claim lease="+leaseID) {
+		t.Fatalf("dry-run must not skip an unchanged genuine orphan:\n%s", out.String())
+	}
+	if _, ok, err := core.ResolveLeaseClaimForProvider(leaseID, providerName); err != nil {
+		t.Fatalf("ResolveLeaseClaimForProvider(%s): %v", leaseID, err)
+	} else if !ok {
+		t.Fatalf("dry-run must not actually remove the claim %s:\n%s", leaseID, out.String())
+	}
+}
+
+// TestCleanupSweepSkipsForeignProviderClaim covers the provider filter: a claim owned
+// by a DIFFERENT provider, aged past grace and absent from the apple-vm instance view,
+// must be skipped (not swept), so a broken filter cannot delete another provider's live
+// claim. Without the isAppleVMProviderName guard the sweep would treat it as a missing
+// apple-vm instance and remove it.
+func TestCleanupSweepSkipsForeignProviderClaim(t *testing.T) {
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	var out bytes.Buffer
+
+	oldGOOS, oldGOARCH := hostGOOS, hostGOARCH
+	oldMacOSVersion := hostMacOSVersion
+	hostGOOS, hostGOARCH = "darwin", "arm64"
+	hostMacOSVersion = func() (string, error) { return "26.5", nil }
+	t.Cleanup(func() {
+		hostGOOS, hostGOARCH = oldGOOS, oldGOARCH
+		hostMacOSVersion = oldMacOSVersion
+	})
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".state"))
+	root := t.TempDir()
+
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.AppleVM = core.AppleVMConfig{
+		HelperPath:  "/tmp/helper-source",
+		Image:       "https://cloud-images.ubuntu.com/releases/noble/release-20260518/ubuntu-24.04-server-cloudimg-arm64.img",
+		ImageSHA256: "6a61b967ba4a27dd1966f835a67643073ed55c2860ce3dc1cb0517282e6b8bec",
+		User:        "runner",
+		WorkRoot:    "/workspace/crabbox",
+		CPUs:        4,
+		MemoryMiB:   8192,
+		DiskGiB:     40,
+	}
+	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: &out, Stderr: &out, Exec: runner}).(*backend)
+	b.prepareHelper = func(context.Context, core.Config) (string, error) { return "helper", nil }
+	b.stateRoot = func() (string, error) { return root, nil }
+	b.waitForSSH = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error { return nil }
+
+	const foreignProvider = "aws"
+	leaseID := "cbx_foreign_provider"
+	slug := "foreign-slug"
+	name := core.LeaseProviderName(leaseID, slug)
+	writeAgedOrphanClaim(t, leaseID, slug, name, foreignProvider, "")
+
+	runner.responses[commandKey("helper", []string{"list", "--state-root", root})] = core.LocalCommandResult{Stdout: mustJSON(t, applevmhelper.ListResponse{})}
+
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+
+	if _, ok, err := core.ResolveLeaseClaimForProvider(leaseID, foreignProvider); err != nil {
+		t.Fatalf("ResolveLeaseClaimForProvider(%s, %s): %v", leaseID, foreignProvider, err)
+	} else if !ok {
+		t.Fatalf("apple-vm cleanup swept a FOREIGN-provider (%s) claim; the orphan sweep must be provider-scoped:\n%s", foreignProvider, out.String())
+	}
+	if strings.Contains(out.String(), "remove claim lease="+leaseID) {
+		t.Fatalf("apple-vm cleanup removed a foreign-provider claim:\n%s", out.String())
+	}
+}


### PR DESCRIPTION
## Summary
Guards the `apple-vm` provider's `Cleanup` against a cross-process TOCTOU race that can delete a
concurrent crabbox run's **live** lease claim and strand its prepared SSH key. `(*backend).Cleanup` lists
VM instances via `listInstances()` **before** it reads lease claims, then its orphan sweep removes — via
the **unguarded** `core.RemoveLeaseClaim` plus a stored-key deletion — any apple-vm claim whose lease is
absent from that stale instance view. In the read-to-remove window, a claim/key that a concurrent
`Acquire` prepares before publishing (Acquire creates the instance and writes the SSH key before its claim
is visible) can be swept as "missing instance." The trigger is two concurrent same-scope `crabbox` runs on
one Mac (apple-vm is the local provider); no attacker.

Part of https://github.com/openclaw/crabbox/issues/1144 — apple-vm was missed in the original audit
because its `Cleanup` reads claims through a `providerClaims()` wrapper rather than a direct
`core.ListLeaseClaims()` call, so the list-symbol scan never flagged it (the correct audit key is the
unguarded `core.RemoveLeaseClaim`, not the list op). Same `[security]` destructive-cleanup class already
merged for tart (https://github.com/openclaw/crabbox/pull/1124), apple-container
(https://github.com/openclaw/crabbox/pull/1146), local-container
(https://github.com/openclaw/crabbox/pull/1147), and external
(https://github.com/openclaw/crabbox/pull/1148).

## What to review
| file | change |
|---|---|
| `internal/providers/applevm/backend.go` | +25 / −4 — snapshot orphan-candidate claims **before** `listInstances()`; guard the orphan-sweep **claim** removal with `RemoveLeaseClaimIfUnchanged` (and `VerifyLeaseClaimUnchanged` in dry-run), and **retain** the stored testbox key |
| `internal/providers/applevm/cleanup_toctou_test.go` | +497 — five regression tests (reclaim guard-decline, key-retention, dry-run no-plan, dry-run genuine-removal, foreign-provider skip), scope-forced |
| `internal/providers/applevm/cleanup_live_smoke_test.go` | +287 — `//go:build smoke` instrumented live proof driving the real `crabbox-apple-vm-helper` (see Live proof below) |
| `CHANGELOG.md` | +1 — apple-vm entry under `0.39.1 - Unreleased → Fixed`, matching the three siblings |

## How it works
Mirrors the merged apple-container fix (https://github.com/openclaw/crabbox/pull/1146):
- Snapshot orphan-candidate claims via `core.ListLeaseClaims()` **before** `listInstances()`, so a claim
  newer than the instance view cannot be misclassified as a "missing instance" orphan.
- Guard the sweep's claim removal with `core.RemoveLeaseClaimIfUnchanged` (and `VerifyLeaseClaimUnchanged`
  in `--dry-run`), so a lease reclaimed mid-cleanup is spared and dry-run does not plan its removal.
- **Retain** the stored testbox key rather than deleting it in the sweep: `Acquire` creates or reuses the
  key before publishing its claim, outside this claim CAS, so deleting it here can strand a concurrent
  live reacquisition. The instance-removal path (which deletes an instance that is actually present) still
  removes the key, unchanged.

**Startup-grace note:** apple-vm's sweep already skips claims within `unclaimedInstanceGrace` (3h). Because
a reclaim rewrites `LastUsedAt = now`, a claim reclaimed *after* the pre-fix code has already listed
instances lands back inside that grace and is skipped — so the live-claim-deletion window this closes is
the narrow one where a claim/key exists at listing time but its instance does not yet, which the CAS guard
+ key retention cover. The tests therefore backdate their orphan claims past the grace so the guarded path
is actually exercised.

## Evidence (deterministic before/after)
Three regression tests FAIL on base `5f6d7220` (with this test file applied) and PASS at HEAD, verified
under `-race`:

```
$ go test -race -run 'TestCleanupOrphanSweepGuardDeclinesReclaimedCandidate|TestCleanupRetainsKeyPreparedByConcurrentAcquire|TestCleanupDryRunDoesNotPlanReclaimedCandidateRemoval' ./internal/providers/applevm/

# BASE 5f6d7220:  --- FAIL (x3)
#   RetainsKey…                  base deletes the prepared key ("prepared key was removed by cleanup") — the destructive defect
#   GuardDeclinesReclaimed…      base grace-skips the reclaimed claim ("reason=startup grace period"); no changed-during-cleanup disposition
#   DryRunDoesNotPlanReclaimed…  same: dry-run does not emit the reclaimed-skip disposition
# HEAD:  ok  github.com/openclaw/crabbox/internal/providers/applevm
```

The destructive base failure the hermetic tests pin is the **stored-key deletion** (the reclaim-guard and
dry-run tests lock in the guard's `changed-during-cleanup` disposition, which base lacks). `go build ./...`,
`go vet` on both touched packages, and `gofmt -l` are clean; the full apple-vm package passes with the race
detector.

**Mutation coverage (gomu, diff-scoped):** 19 mutants on the changed lines. The two dry-run/foreign-provider
tests were added to close real survivors — they kill the sweep's provider-filter mutants (so a broken filter
can't sweep another provider's claim) and the dry-run guard's `would remove` path; each kill is confirmed by
direct mutant injection. The residual survivors are equivalent (`LeaseID == "" ` vs `<= ""`), unreachable
(empty-lease), or fail-safe (swallowing a `ListLeaseClaims` error sweeps nothing — no wrong removal).

## Live proof (instrumented, against the real helper)
`internal/providers/applevm/cleanup_live_smoke_test.go` (`//go:build smoke`, `CRABBOX_LIVE=1`) drives the
**real** `crabbox-apple-vm-helper` binary — built from `cmd/crabbox-apple-vm-helper` and exec'd exactly as
Cleanup shells out to it. Cleanup's only helper calls are `list` and `delete`, both of which read/remove
on-disk instance metadata, so **no Virtualization.framework VM is booted** and the guarded orphan-sweep runs
end-to-end against the real helper subprocess on any Apple-silicon Mac (entitlements/base image absent). The
genuine orphan is a claim whose lease has no instance metadata, so the real `list` reports
`{"instances":null}` — a real "missing instance" by the helper's own view. Two sub-proofs; the reclaim is a
controlled rebind injected during the real `list` window (a blind timing race can't hit the sub-200ms
window on its own). All temp-isolated HOME/XDG/state-root, so real Cleanup can only ever see this test's own
claim:

```
$ CRABBOX_LIVE=1 go test -tags smoke -run TestLiveAppleVMCleanup -v ./internal/providers/applevm/
--- PASS: TestLiveAppleVMCleanupGuardPreservesReclaimedClaim (0.50s)
    LIVE PROOF (real crabbox-apple-vm-helper): guard declined the reclaimed claim during Cleanup's real `list` window:
        skip claim lease=cbx_livesmoke_guard reason=changed-during-cleanup err=lease cbx_livesmoke_guard claim changed; retry
        apple-vm cleanup removed=0 claims_removed=0 checked=0
--- PASS: TestLiveAppleVMCleanupRetainsKeyOnGenuineOrphanRemoval (0.49s)
    LIVE PROOF (real crabbox-apple-vm-helper): genuine orphan removed, prepared key retained:
        remove claim lease=cbx_livesmoke_retain reason=missing instance
        apple-vm cleanup removed=0 claims_removed=1 checked=0
PASS
ok  	github.com/openclaw/crabbox/internal/providers/applevm	1.408s
```

## Not included (scope)
- No live proof exercises a booted VM: Cleanup never calls `start`, so the orphan-sweep path this PR touches
  has no VM dependency; the live proof drives the real helper's `list`/`delete` instead. A full VF boot lane
  stays with the maintainer's provisioned CI.
- The instance-removal path's unguarded `RemoveLeaseClaim` + key deletion is correct and unchanged (it
  deletes an instance that is actually present); it matches the merged siblings' scope.
- The other providers (tart, apple-container, local-container, external, aws/azure, freestyle/islo) are
  already fixed/merged. This PR is the apple-vm-specific repair under
  https://github.com/openclaw/crabbox/issues/1144.

## Review history
https://gist.github.com/9022e6f1fda2ba84c6bd7c07b184902c
