### PR TITLE
fix(egress): keep replaced egress sessions dead across restarts and revocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- fix(egress): replaced egress sessions can no longer resurrect and clobber their replacement — the coordinator refuses tickets and connects for superseded session IDs, and the host/client daemon exits fatally when replaced.
 - Enforced explicitly declared zero-byte artifact sizes during pull while preserving legacy manifests that omit size.
 - Prevented apple-container orphan cleanup from deleting claims reclaimed during its resource snapshot, including same-value rewrites, while retaining stored SSH keys when ownership cannot be proven safe to remove. Thanks @anagnorisis2peripeteia.
 - Prevented local-container orphan cleanup from deleting claims reclaimed during its resource snapshot while retaining stored SSH keys when ownership cannot be proven safe to remove. Thanks @anagnorisis2peripeteia.

--- a/internal/cli/egress.go
+++ b/internal/cli/egress.go
@@ -140,7 +140,11 @@ func (a App) egressHostWithConnectHook(ctx context.Context, args []string, onCon
 	if onConnected != nil {
 		onConnected()
 	}
-	return bridge.serveHost(ctx, allow)
+	err = bridge.serveHost(ctx, allow)
+	if replacedEgressSessionClose(err) {
+		return exit(egressDaemonFatalCode, "egress session replaced: %v", err)
+	}
+	return err
 }
 
 func (a App) egressClient(ctx context.Context, args []string) error {
@@ -174,7 +178,11 @@ func (a App) egressClient(ctx context.Context, args []string) error {
 		return err
 	}
 	fmt.Fprintf(a.Stdout, "egress client: connected lease=%s session=%s listen=%s\n", leaseID, bridge.sessionID, *listen)
-	return bridge.serveClient(ctx, *listen)
+	err = bridge.serveClient(ctx, *listen)
+	if replacedEgressSessionClose(err) {
+		return exit(egressDaemonFatalCode, "egress session replaced: %v", err)
+	}
+	return err
 }
 
 func (a App) egressStart(ctx context.Context, args []string) error {
@@ -481,6 +489,14 @@ func fatalEgressBridgeSetupError(err error) bool {
 	default:
 		return false
 	}
+}
+
+func replacedEgressSessionClose(err error) bool {
+	if websocket.CloseStatus(err) != websocket.StatusServiceRestart {
+		return false
+	}
+	var closeErr websocket.CloseError
+	return errors.As(err, &closeErr) && strings.Contains(closeErr.Reason, "replaced by a newer egress")
 }
 
 func reusableEgressSessionID(ctx context.Context, coord *CoordinatorClient, leaseID, sessionID string) (string, error) {

--- a/internal/cli/egress_session_replaced_test.go
+++ b/internal/cli/egress_session_replaced_test.go
@@ -1,0 +1,133 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"nhooyr.io/websocket"
+)
+
+func TestEgressHostReplacementCloseIsFatal(t *testing.T) {
+	server := egressClosingCoordinator(
+		t,
+		"host",
+		websocket.StatusServiceRestart,
+		"replaced by a newer egress session",
+	)
+	defer server.Close()
+
+	err := runEgressHostAgainstCoordinator(t, server.URL)
+	assertEgressExitCode(t, err, egressDaemonFatalCode)
+}
+
+func TestEgressClientReplacementCloseIsFatal(t *testing.T) {
+	server := egressClosingCoordinator(
+		t,
+		"client",
+		websocket.StatusServiceRestart,
+		"replaced by a newer egress client",
+	)
+	defer server.Close()
+
+	err := runEgressClientAgainstCoordinator(t, server.URL)
+	assertEgressExitCode(t, err, egressDaemonFatalCode)
+}
+
+func TestEgressOtherServeLoopClosesAreNotFatal(t *testing.T) {
+	tests := []struct {
+		name   string
+		code   websocket.StatusCode
+		reason string
+	}{
+		{
+			name:   "different code",
+			code:   websocket.StatusInternalError,
+			reason: "replaced by a newer egress session",
+		},
+		{
+			name:   "different reason",
+			code:   websocket.StatusServiceRestart,
+			reason: "coordinator maintenance",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := egressClosingCoordinator(t, "host", tt.code, tt.reason)
+			defer server.Close()
+
+			err := runEgressHostAgainstCoordinator(t, server.URL)
+			if err == nil {
+				t.Fatal("expected serve-loop close error")
+			}
+			var exitErr ExitError
+			if errors.As(err, &exitErr) && exitErr.Code == egressDaemonFatalCode {
+				t.Fatalf("close unexpectedly mapped to fatal exit: %v", err)
+			}
+		})
+	}
+}
+
+func egressClosingCoordinator(
+	t *testing.T,
+	role string,
+	code websocket.StatusCode,
+	reason string,
+) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		wantPath := "/v1/leases/cbx_abcdef123456/egress/" + role
+		if r.URL.Path != wantPath {
+			http.NotFound(w, r)
+			return
+		}
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Errorf("websocket accept: %v", err)
+			return
+		}
+		_ = conn.Close(code, reason)
+	}))
+}
+
+func runEgressHostAgainstCoordinator(t *testing.T, coordinatorURL string) error {
+	t.Helper()
+	clearConfigEnv(t)
+	isolateRunTestUserDirs(t, t.TempDir())
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	return (App{Stdout: io.Discard, Stderr: io.Discard}).egressHost(ctx, []string{
+		"--id", "cbx_abcdef123456",
+		"--coordinator", coordinatorURL,
+		"--ticket", "egress_abcdef1234567890abcdef1234567890",
+		"--session", "egress_session",
+		"--allow", "example.com",
+	})
+}
+
+func runEgressClientAgainstCoordinator(t *testing.T, coordinatorURL string) error {
+	t.Helper()
+	clearConfigEnv(t)
+	isolateRunTestUserDirs(t, t.TempDir())
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	return (App{Stdout: io.Discard, Stderr: io.Discard}).egressClient(ctx, []string{
+		"--id", "cbx_abcdef123456",
+		"--coordinator", coordinatorURL,
+		"--ticket", "egress_abcdef1234567890abcdef1234567890",
+		"--session", "egress_session",
+		"--listen", "127.0.0.1:0",
+	})
+}
+
+func assertEgressExitCode(t *testing.T, err error, want int) {
+	t.Helper()
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != want {
+		t.Fatalf("exit error=%v want code %d", err, want)
+	}
+}

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -252,6 +252,7 @@ const codeTicketTTLSeconds = 120;
 const codeViewerTicketTTLSeconds = 120;
 const codeViewerSessionTTLSeconds = 8 * 60 * 60;
 const egressTicketTTLSeconds = 120;
+export const replacedEgressSessionsPerLease = 256;
 const runtimeAdapterTicketTTLSeconds = 120;
 const nativeVNCTicketTTLSeconds = 60;
 const runtimeAdapterProvisionalClaimTTLSeconds = 10 * 60;
@@ -934,6 +935,13 @@ export class FleetCoordinator {
   private readonly egressHosts = new Map<string, WebSocket>();
   private readonly egressClients = new Map<string, WebSocket>();
   private readonly egressSessions = new Map<string, EgressSessionStatus>();
+  // Per-lease tombstones survive session revocation and DO restarts, and are dropped only when the
+  // lease's egress state is torn down. FIFO overflow after 256 replacements while one zombie stays
+  // offline is accepted residual risk. Full closure would require server-bound session identity
+  // (protocol change, out of scope).
+  private readonly replacedEgressSessions = new Map<string, string[]>();
+  private readonly hydratedEgressSessionState = new Set<string>();
+  private readonly egressSessionStateHydrations = new Map<string, Promise<void>>();
   private readonly runtimeAdapterAgents = new Map<string, WebSocket>();
   private readonly runtimeAdapterPending = new Map<string, RuntimeAdapterPendingRequest>();
   private readonly runtimeAdapterDeleteQueues = new Map<string, Promise<void>>();
@@ -1272,7 +1280,6 @@ export class FleetCoordinator {
       endpoint: string;
     }> = [];
     const endpointCounts = new Map<string, number>();
-    const egressSessions = new Map<string, Set<string>>();
     for (const socket of this.state.getWebSockets()) {
       const attachment = this.bridgeAttachment(socket);
       if (!attachment) {
@@ -1285,17 +1292,9 @@ export class FleetCoordinator {
       const endpoint = restoredBridgeEndpoint(attachment);
       candidates.push({ socket, attachment, endpoint });
       endpointCounts.set(endpoint, (endpointCounts.get(endpoint) ?? 0) + 1);
-      if (attachment.kind === "egress-host" || attachment.kind === "egress-client") {
-        const sessions = egressSessions.get(attachment.leaseID) ?? new Set<string>();
-        sessions.add(attachment.sessionID);
-        egressSessions.set(attachment.leaseID, sessions);
-      }
     }
     for (const { socket, attachment, endpoint } of candidates) {
-      const ambiguousEgressLease =
-        (attachment.kind === "egress-host" || attachment.kind === "egress-client") &&
-        (egressSessions.get(attachment.leaseID)?.size ?? 0) > 1;
-      if ((endpointCounts.get(endpoint) ?? 0) > 1 || ambiguousEgressLease) {
+      if ((endpointCounts.get(endpoint) ?? 0) > 1) {
         this.rejectRestoredBridgeSocket(socket, attachment);
         continue;
       }
@@ -1306,10 +1305,14 @@ export class FleetCoordinator {
 
   private async reconcileRestoredBridgeSockets(): Promise<void> {
     const leaseIDs = new Set<string>();
+    const egressLeaseIDs = new Set<string>();
     for (const socket of this.restoredBridgeSockets) {
       const attachment = this.bridgeAttachment(socket);
       if (attachment && "leaseID" in attachment) {
         leaseIDs.add(attachment.leaseID);
+        if (attachment.kind === "egress-host" || attachment.kind === "egress-client") {
+          egressLeaseIDs.add(attachment.leaseID);
+        }
       }
     }
     const [leaseEntries, adminGrants] = await Promise.all([
@@ -1318,6 +1321,88 @@ export class FleetCoordinator {
       ),
       this.currentAdminGrantValidation(),
     ]);
+    await Promise.all(
+      [...egressLeaseIDs].map((leaseID) => this.hydrateEgressSessionState(leaseID)),
+    );
+    const restoredEgressSessions = new Map<
+      string,
+      Map<string, Extract<BridgeAttachment, { kind: "egress-host" | "egress-client" }>>
+    >();
+    for (const socket of this.restoredBridgeSockets) {
+      const attachment = this.bridgeAttachment(socket);
+      if (attachment?.kind !== "egress-host" && attachment?.kind !== "egress-client") {
+        continue;
+      }
+      const sessions = restoredEgressSessions.get(attachment.leaseID) ?? new Map();
+      sessions.set(attachment.sessionID, attachment);
+      restoredEgressSessions.set(attachment.leaseID, sessions);
+    }
+    const forgetRestoredEgressSession = (leaseID: string, sessionID: string) => {
+      for (const candidate of this.restoredBridgeSockets) {
+        const attachment = this.bridgeAttachment(candidate);
+        if (
+          (attachment?.kind === "egress-host" || attachment?.kind === "egress-client") &&
+          attachment.leaseID === leaseID &&
+          attachment.sessionID === sessionID
+        ) {
+          this.restoredBridgeSockets.delete(candidate);
+        }
+      }
+    };
+    for (const leaseID of [...restoredEgressSessions.keys()].toSorted()) {
+      const sessions = restoredEgressSessions.get(leaseID)!;
+      let active = this.egressSessions.get(leaseID);
+      if (active && this.egressSessionWasReplaced(leaseID, active.sessionID)) {
+        // oxlint-disable-next-line eslint/no-await-in-loop -- restored session transitions must commit in winner order.
+        await this.clearEgressSession(
+          leaseID,
+          active.sessionID,
+          1012,
+          "replaced by a newer egress session",
+        );
+        active = undefined;
+      }
+      const sessionIDs = [...sessions.keys()].toSorted();
+      if (!active && sessionIDs.length > 1) {
+        for (const sessionID of sessionIDs) {
+          // oxlint-disable-next-line eslint/no-await-in-loop -- all ambiguous restored sessions must close before reconciliation continues.
+          await this.clearEgressSession(
+            leaseID,
+            sessionID,
+            1011,
+            "egress session state lost; reconnect",
+          );
+          forgetRestoredEgressSession(leaseID, sessionID);
+        }
+        continue;
+      }
+      const candidateWinnerSessionID = active?.sessionID ?? sessionIDs[0];
+      const winnerSessionID =
+        candidateWinnerSessionID &&
+        !this.egressSessionWasReplaced(leaseID, candidateWinnerSessionID)
+          ? candidateWinnerSessionID
+          : undefined;
+      const winner = winnerSessionID ? sessions.get(winnerSessionID) : undefined;
+      if (winner) {
+        // oxlint-disable-next-line eslint/no-await-in-loop -- persist the winner before rejecting other restored sessions.
+        await this.trackEgressSession(winner);
+      }
+      for (const sessionID of sessionIDs) {
+        if (sessionID === winnerSessionID) {
+          continue;
+        }
+        // oxlint-disable-next-line eslint/no-await-in-loop -- persist each tombstone before clearing its restored session.
+        await this.recordReplacedEgressSession(leaseID, sessionID);
+        // oxlint-disable-next-line eslint/no-await-in-loop -- preserve tombstone-before-clear ordering per session.
+        await this.clearEgressSession(
+          leaseID,
+          sessionID,
+          1012,
+          "replaced by a newer egress session",
+        );
+        forgetRestoredEgressSession(leaseID, sessionID);
+      }
+    }
     const leases = new Map(leaseEntries);
     const now = Date.now();
     const revoked = new Map<string, string>();
@@ -1533,15 +1618,17 @@ export class FleetCoordinator {
       this.handleBridgeClose(socket, 1008, "admin access revoked");
       closeSocket(socket, 1008, "admin access revoked");
     }
-    for (const { leaseID, sessionID } of revokedAdminEgressSessions.values()) {
-      this.clearEgressSession(leaseID, sessionID, 1008, "admin access revoked");
-    }
-    for (const [leaseID, reason] of revoked) {
-      this.closeLeaseBridges(leaseID, 1008, reason);
-    }
-    for (const { leaseID, sessionID, reason } of revokedEgressSessions.values()) {
-      this.clearEgressSession(leaseID, sessionID, 1008, reason);
-    }
+    await Promise.all([
+      ...[...revokedAdminEgressSessions.values()].map(({ leaseID, sessionID }) =>
+        this.clearEgressSession(leaseID, sessionID, 1008, "admin access revoked"),
+      ),
+      ...[...revoked.entries()].map(([leaseID, reason]) =>
+        this.closeLeaseBridges(leaseID, 1008, reason),
+      ),
+      ...[...revokedEgressSessions.values()].map(({ leaseID, sessionID, reason }) =>
+        this.clearEgressSession(leaseID, sessionID, 1008, reason),
+      ),
+    ]);
     for (const socket of this.restoredBridgeSockets) {
       const attachment = this.bridgeAttachment(socket);
       const reason =
@@ -1559,12 +1646,13 @@ export class FleetCoordinator {
         rightAttachment?.kind === "webvnc-agent" || rightAttachment?.kind === "code-agent";
       return Number(leftIsAgent) - Number(rightIsAgent);
     });
-    for (const [socket, reason] of revokedUserBridges) {
+    await revokedUserBridges.reduce<Promise<void>>(async (pending, [socket, reason]) => {
+      await pending;
       const attachment = this.bridgeAttachment(socket);
       if (attachment && revocableUserBridge(attachment)) {
-        this.closeRevokedUserBridge(socket, attachment, reason);
+        await this.closeRevokedUserBridge(socket, attachment, reason);
       }
-    }
+    }, Promise.resolve());
     this.restoredBridgeSockets.clear();
   }
 
@@ -1605,7 +1693,7 @@ export class FleetCoordinator {
     this.currentAdminGrantVersion = version;
     const validation = await adminGrantValidation(this.env, version);
     if (this.currentAdminGrantVersion === version) {
-      this.reconcileAdminBridgeSockets(validation);
+      await this.reconcileAdminBridgeSockets(validation);
     }
   }
 
@@ -1630,8 +1718,8 @@ export class FleetCoordinator {
     return sockets;
   }
 
-  private reconcileAdminBridgeSockets(validation: AdminGrantValidation): void {
-    const revokedEgressSessions = new Set<string>();
+  private async reconcileAdminBridgeSockets(validation: AdminGrantValidation): Promise<void> {
+    const revokedEgressSessions = new Map<string, { leaseID: string; sessionID: string }>();
     for (const socket of this.adminBridgeSockets()) {
       const attachment = this.bridgeAttachment(socket);
       if (
@@ -1646,19 +1734,21 @@ export class FleetCoordinator {
       if (attachment.kind === "egress-host" || attachment.kind === "egress-client") {
         const key = egressSocketKey(attachment.leaseID, attachment.sessionID);
         if (!revokedEgressSessions.has(key)) {
-          revokedEgressSessions.add(key);
-          this.clearEgressSession(
-            attachment.leaseID,
-            attachment.sessionID,
-            1008,
-            "admin access revoked",
-          );
+          revokedEgressSessions.set(key, {
+            leaseID: attachment.leaseID,
+            sessionID: attachment.sessionID,
+          });
         }
         continue;
       }
       this.handleBridgeClose(socket, 1008, "admin access revoked");
       closeSocket(socket, 1008, "admin access revoked");
     }
+    await Promise.all(
+      [...revokedEgressSessions.values()].map(({ leaseID, sessionID }) =>
+        this.clearEgressSession(leaseID, sessionID, 1008, "admin access revoked"),
+      ),
+    );
   }
 
   private async reconcileScheduledAdminGrants(
@@ -1779,11 +1869,9 @@ export class FleetCoordinator {
         break;
       case "egress-host":
         this.egressHosts.set(egressSocketKey(attachment.leaseID, attachment.sessionID), socket);
-        this.trackEgressSession(attachment);
         break;
       case "egress-client":
         this.egressClients.set(egressSocketKey(attachment.leaseID, attachment.sessionID), socket);
-        this.trackEgressSession(attachment);
         break;
       case "runtime-adapter-agent":
         closeSocket(
@@ -1819,8 +1907,10 @@ export class FleetCoordinator {
     this.webVNCViewers.set(leaseID, viewers);
   }
 
-  private trackEgressSession(attachment: Extract<BridgeAttachment, { sessionID: string }>): void {
-    this.activateEgressSession(
+  private async trackEgressSession(
+    attachment: Extract<BridgeAttachment, { sessionID: string }>,
+  ): Promise<void> {
+    await this.activateEgressSession(
       attachment.leaseID,
       attachment.sessionID,
       undefined,
@@ -1829,19 +1919,23 @@ export class FleetCoordinator {
     );
   }
 
-  private activateEgressSession(
+  private async activateEgressSession(
     leaseID: string,
     sessionID: string,
     profile: string | undefined,
     allow: string[] | undefined,
     nowDate: Date,
-  ): void {
+  ): Promise<void> {
     const previous = this.egressSessions.get(leaseID);
+    if (this.egressSessionWasReplaced(leaseID, sessionID)) {
+      return;
+    }
     if (!shouldActivateEgressSession(previous, sessionID, nowDate.toISOString())) {
       return;
     }
     if (previous && previous.sessionID !== sessionID) {
-      this.clearEgressSession(
+      await this.recordReplacedEgressSession(leaseID, previous.sessionID);
+      await this.clearEgressSession(
         leaseID,
         previous.sessionID,
         1012,
@@ -1860,7 +1954,63 @@ export class FleetCoordinator {
     if (sessionProfile) {
       sessionStatus.profile = sessionProfile;
     }
+    await this.state.storage.put(activeEgressSessionKey(leaseID), sessionStatus);
     this.egressSessions.set(leaseID, sessionStatus);
+  }
+
+  private egressSessionWasReplaced(leaseID: string, sessionID: string): boolean {
+    return this.replacedEgressSessions.get(leaseID)?.includes(sessionID) ?? false;
+  }
+
+  private async recordReplacedEgressSession(leaseID: string, sessionID: string): Promise<void> {
+    const replaced = [...(this.replacedEgressSessions.get(leaseID) ?? [])];
+    if (replaced.includes(sessionID)) {
+      return;
+    }
+    replaced.push(sessionID);
+    if (replaced.length > replacedEgressSessionsPerLease) {
+      replaced.shift();
+    }
+    await this.state.storage.put(replacedEgressSessionsKey(leaseID), replaced);
+    this.replacedEgressSessions.set(leaseID, replaced);
+  }
+
+  private async hydrateEgressSessionState(leaseID: string): Promise<void> {
+    if (this.hydratedEgressSessionState.has(leaseID)) {
+      return;
+    }
+    const existing = this.egressSessionStateHydrations.get(leaseID);
+    if (existing) {
+      await existing;
+      return;
+    }
+    const pending = (async () => {
+      const [storedActive, storedReplaced] = await Promise.all([
+        this.state.storage.get<unknown>(activeEgressSessionKey(leaseID)),
+        this.state.storage.get<unknown>(replacedEgressSessionsKey(leaseID)),
+      ]);
+      const replaced = boundedReplacedEgressSessions(storedReplaced);
+      if (replaced.length > 0) {
+        this.replacedEgressSessions.set(leaseID, replaced);
+      } else {
+        this.replacedEgressSessions.delete(leaseID);
+      }
+      const active = storedEgressSessionStatus(storedActive, leaseID);
+      if (active && replaced.includes(active.sessionID)) {
+        await this.state.storage.delete(activeEgressSessionKey(leaseID));
+      } else if (active && !this.egressSessions.has(leaseID)) {
+        this.egressSessions.set(leaseID, active);
+      }
+      this.hydratedEgressSessionState.add(leaseID);
+    })();
+    this.egressSessionStateHydrations.set(leaseID, pending);
+    try {
+      await pending;
+    } finally {
+      if (this.egressSessionStateHydrations.get(leaseID) === pending) {
+        this.egressSessionStateHydrations.delete(leaseID);
+      }
+    }
   }
 
   private async controlSocket(request: Request): Promise<Response> {
@@ -2032,6 +2182,9 @@ export class FleetCoordinator {
     attachment: BridgeAttachment,
     message: string | ArrayBuffer | Blob,
   ): Promise<void> {
+    if (attachment.kind === "egress-host" || attachment.kind === "egress-client") {
+      await this.hydrateEgressSessionState(attachment.leaseID);
+    }
     if (socket.readyState !== WebSocket.OPEN || !this.bridgeSocketIsCurrent(socket, attachment)) {
       this.rejectRestoredBridgeSocket(socket, attachment);
       return;
@@ -2138,7 +2291,7 @@ export class FleetCoordinator {
       const now = Date.now();
       if (Date.parse(attachment.viewerSessionExpiresAt) <= now) {
         this.viewerSessionValidationTimes.delete(socket);
-        this.closeRevokedUserBridge(socket, attachment, "viewer session expired");
+        await this.closeRevokedUserBridge(socket, attachment, "viewer session expired");
         return false;
       }
       const lastValidatedAt = this.viewerSessionValidationTimes.get(socket) ?? 0;
@@ -2146,7 +2299,7 @@ export class FleetCoordinator {
         const failureReason = await this.webVNCPortalViewerAttachmentFailureReason(attachment);
         if (failureReason) {
           this.viewerSessionValidationTimes.delete(socket);
-          this.closeRevokedUserBridge(socket, attachment, failureReason);
+          await this.closeRevokedUserBridge(socket, attachment, failureReason);
           return false;
         }
         this.viewerSessionValidationTimes.set(socket, now);
@@ -2162,7 +2315,7 @@ export class FleetCoordinator {
       if (now - lastValidatedAt >= userGrantRevalidationIntervalMs) {
         if (!(await this.sharedBridgeGrantIsCurrent(attachment))) {
           this.userGrantValidationTimes.delete(socket);
-          this.closeRevokedUserBridge(socket, attachment, "shared access revoked");
+          await this.closeRevokedUserBridge(socket, attachment, "shared access revoked");
           return false;
         }
         this.userGrantValidationTimes.set(socket, now);
@@ -2181,7 +2334,7 @@ export class FleetCoordinator {
         const failureReason = await this.githubBridgeGrantFailureReason(attachment);
         if (failureReason) {
           this.userGrantValidationTimes.delete(socket);
-          this.closeRevokedUserBridge(socket, attachment, failureReason);
+          await this.closeRevokedUserBridge(socket, attachment, failureReason);
           return false;
         }
         this.userGrantValidationTimes.set(socket, now);
@@ -2201,7 +2354,7 @@ export class FleetCoordinator {
     }
     this.adminGrantValidationTimes.delete(socket);
     if (attachment.kind === "egress-host" || attachment.kind === "egress-client") {
-      this.clearEgressSession(
+      await this.clearEgressSession(
         attachment.leaseID,
         attachment.sessionID,
         1008,
@@ -2274,7 +2427,7 @@ export class FleetCoordinator {
       : "user access revoked";
   }
 
-  private closeRevokedUserBridge(
+  private async closeRevokedUserBridge(
     socket: WebSocket,
     attachment: Extract<
       BridgeAttachment,
@@ -2289,10 +2442,10 @@ export class FleetCoordinator {
       }
     >,
     reason: string,
-  ): void {
+  ): Promise<void> {
     this.viewerSessionValidationTimes.delete(socket);
     if (attachment.kind === "egress-host" || attachment.kind === "egress-client") {
-      this.clearEgressSession(attachment.leaseID, attachment.sessionID, 1008, reason);
+      await this.clearEgressSession(attachment.leaseID, attachment.sessionID, 1008, reason);
       return;
     }
     this.handleBridgeClose(socket, 1008, reason);
@@ -6083,9 +6236,11 @@ export class FleetCoordinator {
       }
       revokedEgressSessions.add(attachment.sessionID);
     }
-    for (const sessionID of revokedEgressSessions) {
-      this.clearEgressSession(lease.id, sessionID, code, reason);
-    }
+    await Promise.all(
+      [...revokedEgressSessions].map((sessionID) =>
+        this.clearEgressSession(lease.id, sessionID, code, reason),
+      ),
+    );
   }
 
   private leaseManagerAuthorized(
@@ -6805,6 +6960,7 @@ export class FleetCoordinator {
         404,
       );
     }
+    await this.hydrateEgressSessionState(lease.id);
     const visibleRuns = await this.recentRuns(12, async (run) => {
       if (run.leaseIDs !== undefined && !this.runReferencesLease(run, lease.id)) {
         return false;
@@ -7221,7 +7377,7 @@ export class FleetCoordinator {
       },
     );
     if (result.status === "completed") {
-      this.closeLeaseBridges(lease.id, 1008, "lease ended");
+      await this.closeLeaseBridges(lease.id, 1008, "lease ended");
     }
     return result;
   }
@@ -7265,7 +7421,7 @@ export class FleetCoordinator {
       },
     );
     if (result.status === "completed") {
-      this.closeLeaseBridges(lease.id, 1008, "lease ended");
+      await this.closeLeaseBridges(lease.id, 1008, "lease ended");
     }
     return result;
   }
@@ -7499,6 +7655,13 @@ export class FleetCoordinator {
     await this.cleanupExpiredEgressTickets();
     const now = new Date();
     const requestedSessionID = input.sessionID ?? input.sessionId;
+    await this.hydrateEgressSessionState(lease.id);
+    if (
+      validEgressSessionID(requestedSessionID) &&
+      this.egressSessionWasReplaced(lease.id, requestedSessionID)
+    ) {
+      return egressSessionReplacedResponse();
+    }
     const sessionID = validEgressSessionID(requestedSessionID)
       ? requestedSessionID
       : newEgressSessionID();
@@ -7520,7 +7683,7 @@ export class FleetCoordinator {
       ticket.profile = profile;
     }
     await this.state.storage.put(egressTicketKey(ticket.ticket), ticket);
-    this.activateEgressSession(lease.id, ticket.sessionID, profile, ticket.allow ?? [], now);
+    await this.activateEgressSession(lease.id, ticket.sessionID, profile, ticket.allow ?? [], now);
     return json({
       ticket: ticket.ticket,
       leaseID: ticket.leaseID,
@@ -7553,6 +7716,10 @@ export class FleetCoordinator {
         return notFound();
       }
       const { lease, ticket } = consumed;
+      await this.hydrateEgressSessionState(lease.id);
+      if (this.egressSessionWasReplaced(lease.id, ticket.sessionID)) {
+        return egressSessionReplacedResponse();
+      }
       if (lease.state !== "active") {
         return json(
           { error: "egress_unavailable", message: "lease is not active" },
@@ -7569,7 +7736,7 @@ export class FleetCoordinator {
         ...principal,
       };
       const ticketCreatedAt = new Date(ticket.createdAt);
-      this.activateEgressSession(
+      await this.activateEgressSession(
         lease.id,
         ticket.sessionID,
         ticket.profile,
@@ -7594,6 +7761,7 @@ export class FleetCoordinator {
     if (!lease) {
       return notFound();
     }
+    await this.hydrateEgressSessionState(lease.id);
     const canManage = this.leaseManageableByRequest(lease, request, isAdminRequest(request));
     const session = this.egressSessions.get(lease.id);
     const key = session ? egressSocketKey(lease.id, session.sessionID) : undefined;
@@ -9352,14 +9520,15 @@ export class FleetCoordinator {
   }
 
   private async cleanupExpiredWebVNCPortalViewerAuth(now = Date.now()): Promise<void> {
-    this.closeExpiredWebVNCPortalViewerSockets(now);
+    await this.closeExpiredWebVNCPortalViewerSockets(now);
     await this.cleanupExpiredPortalViewerRecords(
       [webVNCPortalViewerTicketPrefix(), webVNCPortalViewerSessionPrefix()],
       now,
     );
   }
 
-  private closeExpiredWebVNCPortalViewerSockets(now: number): void {
+  private async closeExpiredWebVNCPortalViewerSockets(now: number): Promise<void> {
+    const closings: Promise<void>[] = [];
     for (const viewers of this.webVNCViewers.values()) {
       for (const viewer of viewers.values()) {
         const attachment = this.bridgeAttachment(viewer.socket);
@@ -9368,10 +9537,13 @@ export class FleetCoordinator {
           webVNCViewerSessionAttachment(attachment) &&
           Date.parse(attachment.viewerSessionExpiresAt) <= now
         ) {
-          this.closeRevokedUserBridge(viewer.socket, attachment, "viewer session expired");
+          closings.push(
+            this.closeRevokedUserBridge(viewer.socket, attachment, "viewer session expired"),
+          );
         }
       }
     }
+    await Promise.all(closings);
   }
 
   private async cleanupExpiredPortalViewerRecords(
@@ -9428,7 +9600,7 @@ export class FleetCoordinator {
               expiresAt: new Date(expiresAt).toISOString(),
             },
           );
-          this.closeBridgesForPortalSession(portalSessionHash);
+          await this.closeBridgesForPortalSession(portalSessionHash);
         });
       }
     }
@@ -9723,7 +9895,7 @@ export class FleetCoordinator {
     }
   }
 
-  private closeBridgesForPortalSession(portalSessionHash: string): void {
+  private async closeBridgesForPortalSession(portalSessionHash: string): Promise<void> {
     for (const [leaseID, viewers] of this.webVNCViewers) {
       for (const [id, viewer] of viewers) {
         const attachment = this.bridgeAttachment(viewer.socket);
@@ -9783,9 +9955,11 @@ export class FleetCoordinator {
         sessionID: attachment.sessionID,
       });
     }
-    for (const { leaseID, sessionID } of egressSessions.values()) {
-      this.clearEgressSession(leaseID, sessionID, 1008, "portal session ended");
-    }
+    await Promise.all(
+      [...egressSessions.values()].map(({ leaseID, sessionID }) =>
+        this.clearEgressSession(leaseID, sessionID, 1008, "portal session ended"),
+      ),
+    );
   }
 
   private clearCodeLease(leaseID: string, code = 1011, reason = "code bridge disconnected"): void {
@@ -9832,7 +10006,11 @@ export class FleetCoordinator {
     this.egressHosts.delete(key);
   }
 
-  private clearEgressLease(leaseID: string, code = 1011, reason = "lease ended"): void {
+  private async clearEgressLease(
+    leaseID: string,
+    code = 1011,
+    reason = "lease ended",
+  ): Promise<void> {
     for (const [key, socket] of this.egressHosts) {
       if (egressSocketLeaseID(key) === leaseID) {
         closeSocket(socket, code, reason);
@@ -9846,9 +10024,15 @@ export class FleetCoordinator {
       }
     }
     this.egressSessions.delete(leaseID);
+    await Promise.all([
+      this.state.storage.delete(activeEgressSessionKey(leaseID)),
+      this.state.storage.delete(replacedEgressSessionsKey(leaseID)),
+    ]);
+    this.replacedEgressSessions.delete(leaseID);
+    this.hydratedEgressSessionState.add(leaseID);
   }
 
-  private closeLeaseBridges(leaseID: string, code: number, reason: string): void {
+  private async closeLeaseBridges(leaseID: string, code: number, reason: string): Promise<void> {
     const webVNCAgents = this.webVNCAgents.get(leaseID);
     for (const [agentID, socket] of webVNCAgents ?? []) {
       closeSocket(socket, code, reason);
@@ -9862,22 +10046,25 @@ export class FleetCoordinator {
     this.codeAgents.delete(leaseID);
     closeSocket(codeAgent, code, reason);
     this.clearCodeLease(leaseID, code, reason);
-    this.clearEgressLease(leaseID, code, reason);
+    await this.clearEgressLease(leaseID, code, reason);
   }
 
-  private clearEgressSession(
+  private async clearEgressSession(
     leaseID: string,
     sessionID: string,
     code: number,
     reason: string,
-  ): void {
+  ): Promise<void> {
     const key = egressSocketKey(leaseID, sessionID);
     closeSocket(this.egressHosts.get(key), code, reason);
     closeSocket(this.egressClients.get(key), code, reason);
     this.egressHosts.delete(key);
     this.egressClients.delete(key);
-    if (this.egressSessions.get(leaseID)?.sessionID === sessionID) {
+    const clearedActiveSession = this.egressSessions.get(leaseID)?.sessionID === sessionID;
+    if (clearedActiveSession) {
+      await this.recordReplacedEgressSession(leaseID, sessionID);
       this.egressSessions.delete(leaseID);
+      await this.state.storage.delete(activeEgressSessionKey(leaseID));
     }
   }
 
@@ -11878,7 +12065,7 @@ export class FleetCoordinator {
       const claimed: Array<{ claim: string; lease: LeaseRecord }> = [];
       await this.visitLeaseRecords(async (stored) => {
         if (!leaseIsLive(stored)) {
-          this.closeLeaseBridges(stored.id, 1008, "lease ended");
+          await this.closeLeaseBridges(stored.id, 1008, "lease ended");
         }
         const workspace = stored.workspaceID
           ? await this.state.storage.get<WorkspaceRecord>(
@@ -11919,7 +12106,7 @@ export class FleetCoordinator {
           delete lease.cleanupStartedAt;
           delete lease.cleanupClaimExpiresAt;
           await this.putLease(lease, { noCache: true });
-          this.closeLeaseBridges(lease.id, 1008, "lease expired");
+          await this.closeLeaseBridges(lease.id, 1008, "lease expired");
           return;
         }
         if (lease.state === "provisioning" && !lease.cloudID) {
@@ -13842,7 +14029,7 @@ export class FleetCoordinator {
     if (preparation.blocked) {
       return preparation.lease;
     }
-    this.closeLeaseBridges(lease.id, 1008, "lease ended");
+    await this.closeLeaseBridges(lease.id, 1008, "lease ended");
     if (!preparation.cleanup) {
       return preparation.lease;
     }
@@ -14498,6 +14685,14 @@ function egressTicketPrefix(): string {
 
 function egressTicketKey(ticket: string): string {
   return `${egressTicketPrefix()}${ticket}`;
+}
+
+function activeEgressSessionKey(leaseID: string): string {
+  return `active-egress-session:${leaseID}`;
+}
+
+function replacedEgressSessionsKey(leaseID: string): string {
+  return `replaced-egress-sessions:${leaseID}`;
 }
 
 function runtimeAdapterTicketPrefix(): string {
@@ -15855,6 +16050,65 @@ function egressSocketKey(leaseID: string, sessionID: string): string {
 
 function egressSocketLeaseID(key: string): string {
   return key.split("\u0000", 1)[0] ?? key;
+}
+
+function egressSessionReplacedResponse(): Response {
+  return json(
+    {
+      error: "egress_session_replaced",
+      message: "egress session was replaced by a newer session",
+    },
+    { status: 409 },
+  );
+}
+
+function boundedReplacedEgressSessions(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const replaced: string[] = [];
+  for (const sessionID of value) {
+    if (
+      typeof sessionID === "string" &&
+      validEgressSessionID(sessionID) &&
+      !replaced.includes(sessionID)
+    ) {
+      replaced.push(sessionID);
+    }
+  }
+  return replaced.slice(-replacedEgressSessionsPerLease);
+}
+
+function storedEgressSessionStatus(
+  value: unknown,
+  leaseID: string,
+): EgressSessionStatus | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const stored = value as Partial<EgressSessionStatus>;
+  if (
+    stored.leaseID !== leaseID ||
+    !validEgressSessionID(stored.sessionID) ||
+    !Array.isArray(stored.allow) ||
+    !stored.allow.every((entry) => typeof entry === "string") ||
+    typeof stored.createdAt !== "string" ||
+    !Number.isFinite(Date.parse(stored.createdAt)) ||
+    typeof stored.updatedAt !== "string" ||
+    !Number.isFinite(Date.parse(stored.updatedAt)) ||
+    (stored.profile !== undefined && typeof stored.profile !== "string")
+  ) {
+    return undefined;
+  }
+  const profile = boundedEgressString(stored.profile);
+  return {
+    leaseID,
+    sessionID: stored.sessionID,
+    allow: boundedEgressAllowlist(stored.allow),
+    createdAt: stored.createdAt,
+    updatedAt: stored.updatedAt,
+    ...(profile ? { profile } : {}),
+  };
 }
 
 export function shouldActivateEgressSession(

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -36,6 +36,7 @@ import {
   forwardOrBufferWebVNC,
   resetWebVNCBridge,
   recordAzureDeferredCleanup,
+  replacedEgressSessionsPerLease,
   shouldActivateEgressSession,
   workspaceTerminalOriginAllowed,
   type WebVNCBuffer,
@@ -20504,6 +20505,697 @@ describe("fleet lease identity and idle", () => {
     expect(staleTicketBody.ticket).toMatch(/^egress_[a-f0-9]{32}$/);
   });
 
+  it("rejects replaced egress sessions while allowing active-session reconnects", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testWebSocketCoordinator(storage);
+    const leaseID = "cbx_000000000001";
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    storage.seed(
+      `lease:${leaseID}`,
+      testLease({
+        id: leaseID,
+        slug: "monotonic-egress",
+        owner: "alice@example.com",
+        org: "example-org",
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      }),
+    );
+
+    const createTicket = async (role: "host" | "client", sessionID: string) => {
+      const response = await fleet.fetch(
+        request("POST", "/v1/leases/monotonic-egress/egress/ticket", {
+          headers,
+          body: { role, sessionID, allow: ["example.com"] },
+        }),
+      );
+      const body = (await response.clone().json()) as { ticket?: string; error?: string };
+      return { response, body };
+    };
+    const connect = (role: "host" | "client", ticket: string) =>
+      fleet.fetch(
+        request("GET", `/v1/leases/monotonic-egress/egress/${role}`, {
+          headers: {
+            "x-crabbox-bridge-ticket": ticket,
+            upgrade: "websocket",
+          },
+        }),
+      );
+
+    const sessionA = "egress_session_a";
+    const sessionB = "egress_session_b";
+    const beforeReplacement = await createTicket("host", sessionA);
+    expect(beforeReplacement.response.status).toBe(200);
+    const replacement = await createTicket("client", sessionB);
+    expect(replacement.response.status).toBe(200);
+
+    const staleRemint = await createTicket("host", sessionA);
+    expect(staleRemint.response.status).toBe(409);
+    expect(staleRemint.body).toEqual({
+      error: "egress_session_replaced",
+      message: "egress session was replaced by a newer session",
+    });
+
+    const staleConnect = await connect("host", beforeReplacement.body.ticket ?? "");
+    expect(staleConnect.status).toBe(409);
+    await expect(staleConnect.json()).resolves.toEqual({
+      error: "egress_session_replaced",
+      message: "egress session was replaced by a newer session",
+    });
+
+    const replacementConnect = await connect("client", replacement.body.ticket ?? "");
+    expect(replacementConnect.status).toBe(200);
+    const sameSessionHost = await createTicket("host", sessionB);
+    expect(sameSessionHost.response.status).toBe(200);
+    expect((await connect("host", sameSessionHost.body.ticket ?? "")).status).toBe(200);
+    const sameSessionReconnect = await createTicket("host", sessionB);
+    expect(sameSessionReconnect.response.status).toBe(200);
+    expect((await connect("host", sameSessionReconnect.body.ticket ?? "")).status).toBe(200);
+
+    const status = await fleet.fetch(
+      request("GET", "/v1/leases/monotonic-egress/egress/status", { headers }),
+    );
+    await expect(status.json()).resolves.toMatchObject({
+      active: true,
+      sessionID: sessionB,
+      hostConnected: true,
+      clientConnected: true,
+    });
+  });
+
+  it("keeps replaced egress session tombstones across coordinator restarts", async () => {
+    const storage = new MemoryStorage();
+    const leaseID = "cbx_000000000001";
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    storage.seed(
+      `lease:${leaseID}`,
+      testLease({
+        id: leaseID,
+        slug: "restarted-egress",
+        owner: "alice@example.com",
+        org: "example-org",
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      }),
+    );
+    const ticketRequest = (fleet: FleetCoordinator, sessionID: string) =>
+      fleet.fetch(
+        request("POST", "/v1/leases/restarted-egress/egress/ticket", {
+          headers,
+          body: { role: "host", sessionID, allow: ["example.com"] },
+        }),
+      );
+
+    const firstCoordinator = testWebSocketCoordinator(storage);
+    expect((await ticketRequest(firstCoordinator, "egress_restart_a")).status).toBe(200);
+    expect((await ticketRequest(firstCoordinator, "egress_restart_b")).status).toBe(200);
+    expect(storage.value(`replaced-egress-sessions:${leaseID}`)).toEqual(["egress_restart_a"]);
+
+    const restartedCoordinator = testWebSocketCoordinator(storage);
+    const stale = await ticketRequest(restartedCoordinator, "egress_restart_a");
+    expect(stale.status).toBe(409);
+    await expect(stale.json()).resolves.toEqual({
+      error: "egress_session_replaced",
+      message: "egress session was replaced by a newer session",
+    });
+  });
+
+  it("persists a disconnected active egress session across coordinator restarts", async () => {
+    const storage = new MemoryStorage();
+    const leaseID = "cbx_000000000001";
+    const sessionA = "egress_active_a";
+    const sessionB = "egress_active_b";
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    storage.seed(
+      `lease:${leaseID}`,
+      testLease({
+        id: leaseID,
+        slug: "active-restarted-egress",
+        owner: "alice@example.com",
+        org: "example-org",
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      }),
+    );
+    const ticketRequest = (fleet: FleetCoordinator, sessionID: string) =>
+      fleet.fetch(
+        request("POST", "/v1/leases/active-restarted-egress/egress/ticket", {
+          headers,
+          body: { role: "host", sessionID, allow: ["example.com"] },
+        }),
+      );
+
+    const firstCoordinator = testWebSocketCoordinator(storage);
+    expect((await ticketRequest(firstCoordinator, sessionA)).status).toBe(200);
+    expect(storage.value(`active-egress-session:${leaseID}`)).toEqual({
+      leaseID,
+      sessionID: sessionA,
+      allow: ["example.com"],
+      createdAt: expect.any(String),
+      updatedAt: expect.any(String),
+    });
+
+    const restartedCoordinator = testWebSocketCoordinator(storage);
+    expect((await ticketRequest(restartedCoordinator, sessionB)).status).toBe(200);
+    expect(storage.value(`replaced-egress-sessions:${leaseID}`)).toEqual([sessionA]);
+    expect(storage.value(`active-egress-session:${leaseID}`)).toEqual({
+      leaseID,
+      sessionID: sessionB,
+      allow: ["example.com"],
+      createdAt: expect.any(String),
+      updatedAt: expect.any(String),
+    });
+
+    const secondRestart = testWebSocketCoordinator(storage);
+    const status = await secondRestart.fetch(
+      request("GET", "/v1/leases/active-restarted-egress/egress/status", { headers }),
+    );
+    await expect(status.json()).resolves.toMatchObject({
+      active: true,
+      sessionID: sessionB,
+      hostConnected: false,
+      clientConnected: false,
+    });
+    const stale = await ticketRequest(secondRestart, sessionA);
+    expect(stale.status).toBe(409);
+    await expect(stale.json()).resolves.toEqual({
+      error: "egress_session_replaced",
+      message: "egress session was replaced by a newer session",
+    });
+  });
+
+  it("honors a tombstone over an inconsistent stored active egress session", async () => {
+    const storage = new MemoryStorage();
+    const leaseID = "cbx_000000000001";
+    const sessionID = "egress_crash_stale";
+    const now = new Date().toISOString();
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    storage.seed(
+      `lease:${leaseID}`,
+      testLease({
+        id: leaseID,
+        slug: "crash-stale-egress",
+        owner: "alice@example.com",
+        org: "example-org",
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      }),
+    );
+    storage.seed(`active-egress-session:${leaseID}`, {
+      leaseID,
+      sessionID,
+      allow: ["example.com"],
+      createdAt: now,
+      updatedAt: now,
+    });
+    storage.seed(`replaced-egress-sessions:${leaseID}`, [sessionID]);
+
+    const fleet = testWebSocketCoordinator(storage);
+    const status = await fleet.fetch(
+      request("GET", "/v1/leases/crash-stale-egress/egress/status", { headers }),
+    );
+    await expect(status.json()).resolves.toMatchObject({
+      active: false,
+      sessionID: "",
+      hostConnected: false,
+      clientConnected: false,
+    });
+    expect(storage.value(`active-egress-session:${leaseID}`)).toBeUndefined();
+
+    const stale = await fleet.fetch(
+      request("POST", "/v1/leases/crash-stale-egress/egress/ticket", {
+        headers,
+        body: { role: "host", sessionID, allow: ["example.com"] },
+      }),
+    );
+    expect(stale.status).toBe(409);
+    await expect(stale.json()).resolves.toEqual({
+      error: "egress_session_replaced",
+      message: "egress session was replaced by a newer session",
+    });
+  });
+
+  it("keeps the persisted active egress session during restart reconciliation", async () => {
+    const storage = new MemoryStorage();
+    const leaseID = "cbx_000000000001";
+    const winnerSessionID = "egress_hibernated_b";
+    const replacedSessionID = "egress_hibernated_a";
+    const now = new Date().toISOString();
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    storage.seed(
+      `lease:${leaseID}`,
+      testLease({
+        id: leaseID,
+        slug: "hibernated-egress",
+        provider: "external",
+        lifecycle: "registered",
+        owner: "alice@example.com",
+        org: "example-org",
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      }),
+    );
+    storage.seed(`active-egress-session:${leaseID}`, {
+      leaseID,
+      sessionID: winnerSessionID,
+      allow: ["example.com"],
+      createdAt: now,
+      updatedAt: now,
+    });
+    const restored = [winnerSessionID, replacedSessionID].flatMap((sessionID) =>
+      ["egress-host", "egress-client"].map(
+        (kind) =>
+          new FakeWebSocket({
+            kind,
+            leaseID,
+            sessionID,
+            owner: "alice@example.com",
+            org: "example-org",
+            admin: false,
+            auth: "proxy",
+          }),
+      ),
+    );
+    const winnerSockets = restored.filter(
+      (socket) =>
+        (socket.deserializeAttachment() as { sessionID?: string } | undefined)?.sessionID ===
+        winnerSessionID,
+    );
+    const replacedSockets = restored.filter(
+      (socket) =>
+        (socket.deserializeAttachment() as { sessionID?: string } | undefined)?.sessionID ===
+        replacedSessionID,
+    );
+    const fleet = new FleetDurableObject(
+      {
+        storage,
+        getWebSockets: () => restored as unknown as WebSocket[],
+      } as unknown as DurableObjectState,
+      { CRABBOX_DEFAULT_ORG: "default-org" } as Env,
+    );
+
+    expect((await fleet.fetch(request("GET", "/v1/health"))).status).toBe(200);
+    for (const socket of winnerSockets) {
+      expect(socket.closeCode).toBeUndefined();
+    }
+    for (const socket of replacedSockets) {
+      expect(socket.closeCode).toBe(1012);
+      expect(socket.closeReason).toBe("replaced by a newer egress session");
+    }
+    const relay = fleet as unknown as {
+      egressSessions: Map<string, { sessionID: string }>;
+      replacedEgressSessions: Map<string, string[]>;
+    };
+    expect(relay.egressSessions.get(leaseID)?.sessionID).toBe(winnerSessionID);
+    expect(relay.replacedEgressSessions.get(leaseID)).toEqual([replacedSessionID]);
+    expect(storage.value(`active-egress-session:${leaseID}`)).toMatchObject({
+      leaseID,
+      sessionID: winnerSessionID,
+    });
+    expect(storage.value(`replaced-egress-sessions:${leaseID}`)).toEqual([replacedSessionID]);
+
+    const stale = await fleet.fetch(
+      request("POST", "/v1/leases/hibernated-egress/egress/ticket", {
+        headers,
+        body: { role: "host", sessionID: replacedSessionID, allow: ["example.com"] },
+      }),
+    );
+    expect(stale.status).toBe(409);
+    await expect(stale.json()).resolves.toMatchObject({ error: "egress_session_replaced" });
+  });
+
+  it("nonfatally resets ambiguous restored egress sessions without tombstoning them", async () => {
+    const storage = new MemoryStorage();
+    const leaseID = "cbx_000000000001";
+    const sessionIDs = ["egress_ambiguous_a", "egress_ambiguous_b"];
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    storage.seed(
+      `lease:${leaseID}`,
+      testLease({
+        id: leaseID,
+        slug: "ambiguous-egress",
+        provider: "external",
+        lifecycle: "registered",
+        owner: "alice@example.com",
+        org: "example-org",
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      }),
+    );
+    const restored = sessionIDs.flatMap((sessionID) =>
+      ["egress-host", "egress-client"].map(
+        (kind) =>
+          new FakeWebSocket({
+            kind,
+            leaseID,
+            sessionID,
+            owner: "alice@example.com",
+            org: "example-org",
+            admin: false,
+            auth: "proxy",
+          }),
+      ),
+    );
+    const fleet = new FleetDurableObject(
+      {
+        storage,
+        getWebSockets: () => restored as unknown as WebSocket[],
+      } as unknown as DurableObjectState,
+      { CRABBOX_DEFAULT_ORG: "default-org" } as Env,
+    );
+
+    expect((await fleet.fetch(request("GET", "/v1/health"))).status).toBe(200);
+    for (const socket of restored) {
+      expect(socket.closeCode).toBe(1011);
+      expect(socket.closeReason).toBe("egress session state lost; reconnect");
+    }
+    const relay = fleet as unknown as {
+      egressSessions: Map<string, { sessionID: string }>;
+      replacedEgressSessions: Map<string, string[]>;
+    };
+    expect(relay.egressSessions.has(leaseID)).toBe(false);
+    expect(relay.replacedEgressSessions.has(leaseID)).toBe(false);
+    expect(storage.value(`active-egress-session:${leaseID}`)).toBeUndefined();
+    expect(storage.value(`replaced-egress-sessions:${leaseID}`)).toBeUndefined();
+
+    const mint = (sessionID: string) =>
+      fleet.fetch(
+        request("POST", "/v1/leases/ambiguous-egress/egress/ticket", {
+          headers,
+          body: { role: "host", sessionID, allow: ["example.com"] },
+        }),
+      );
+    expect((await mint(sessionIDs[0] ?? "")).status).toBe(200);
+    expect((await mint(sessionIDs[1] ?? "")).status).toBe(200);
+  });
+
+  it("tracks one restored egress session when no active record exists", async () => {
+    const storage = new MemoryStorage();
+    const leaseID = "cbx_000000000001";
+    const sessionID = "egress_single_restored";
+    storage.seed(
+      `lease:${leaseID}`,
+      testLease({
+        id: leaseID,
+        slug: "single-restored-egress",
+        provider: "external",
+        lifecycle: "registered",
+        owner: "alice@example.com",
+        org: "example-org",
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      }),
+    );
+    const restored = ["egress-host", "egress-client"].map(
+      (kind) =>
+        new FakeWebSocket({
+          kind,
+          leaseID,
+          sessionID,
+          owner: "alice@example.com",
+          org: "example-org",
+          admin: false,
+          auth: "proxy",
+        }),
+    );
+    const fleet = new FleetDurableObject(
+      {
+        storage,
+        getWebSockets: () => restored as unknown as WebSocket[],
+      } as unknown as DurableObjectState,
+      { CRABBOX_DEFAULT_ORG: "default-org" } as Env,
+    );
+
+    expect((await fleet.fetch(request("GET", "/v1/health"))).status).toBe(200);
+    for (const socket of restored) {
+      expect(socket.closeCode).toBeUndefined();
+    }
+    const relay = fleet as unknown as {
+      egressSessions: Map<string, { sessionID: string }>;
+      replacedEgressSessions: Map<string, string[]>;
+    };
+    expect(relay.egressSessions.get(leaseID)?.sessionID).toBe(sessionID);
+    expect(relay.replacedEgressSessions.has(leaseID)).toBe(false);
+    expect(storage.value(`active-egress-session:${leaseID}`)).toMatchObject({
+      leaseID,
+      sessionID,
+    });
+    expect(storage.value(`replaced-egress-sessions:${leaseID}`)).toBeUndefined();
+  });
+
+  it("rejects a tombstoned hibernated egress socket during restart reconciliation", async () => {
+    const storage = new MemoryStorage();
+    const leaseID = "cbx_000000000001";
+    const sessionID = "egress_hibernated";
+    storage.seed(
+      `lease:${leaseID}`,
+      testLease({
+        id: leaseID,
+        slug: "hibernated-egress",
+        provider: "external",
+        lifecycle: "registered",
+        owner: "alice@example.com",
+        org: "example-org",
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      }),
+    );
+    storage.seed(`replaced-egress-sessions:${leaseID}`, [sessionID]);
+    const restored = [
+      new FakeWebSocket({
+        kind: "egress-host",
+        leaseID,
+        sessionID,
+        owner: "alice@example.com",
+        org: "example-org",
+        admin: false,
+      }),
+    ];
+    const fleet = new FleetDurableObject(
+      {
+        storage,
+        getWebSockets: () => restored as unknown as WebSocket[],
+      } as unknown as DurableObjectState,
+      { CRABBOX_DEFAULT_ORG: "default-org" } as Env,
+    );
+
+    expect((await fleet.fetch(request("GET", "/v1/health"))).status).toBe(200);
+    for (const socket of restored) {
+      expect(socket.closeCode).toBe(1012);
+      expect(socket.closeReason).toBe("replaced by a newer egress session");
+    }
+    const relay = fleet as unknown as {
+      egressSessions: Map<string, { sessionID: string }>;
+      replacedEgressSessions: Map<string, string[]>;
+    };
+    expect(relay.egressSessions.has(leaseID)).toBe(false);
+    expect(relay.replacedEgressSessions.get(leaseID)).toEqual([sessionID]);
+  });
+
+  it("bounds replaced egress session tombstones per lease", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testWebSocketCoordinator(storage);
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    storage.seed(
+      "lease:cbx_000000000001",
+      testLease({
+        id: "cbx_000000000001",
+        slug: "bounded-egress",
+        owner: "alice@example.com",
+        org: "example-org",
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      }),
+    );
+
+    const createTicket = (sessionID: string) =>
+      fleet.fetch(
+        request("POST", "/v1/leases/bounded-egress/egress/ticket", {
+          headers,
+          body: { role: "host", sessionID, allow: ["example.com"] },
+        }),
+      );
+    const sessions = Array.from(
+      { length: replacedEgressSessionsPerLease + 2 },
+      (_, index) => `egress_bound_${index}`,
+    );
+    const responses = await sessions.reduce<Promise<Response[]>>(async (pending, sessionID) => {
+      const collected = await pending;
+      collected.push(await createTicket(sessionID));
+      return collected;
+    }, Promise.resolve([]));
+    expect(responses.every((response) => response.status === 200)).toBe(true);
+    const relay = fleet as unknown as { replacedEgressSessions: Map<string, string[]> };
+    const expectedTombstones = sessions.slice(1, replacedEgressSessionsPerLease + 1);
+    expect(relay.replacedEgressSessions.get("cbx_000000000001")).toEqual(expectedTombstones);
+    expect(storage.value("replaced-egress-sessions:cbx_000000000001")).toEqual(expectedTombstones);
+
+    expect((await createTicket(sessions[0] ?? "")).status).toBe(200);
+    const newestTombstone = await createTicket(sessions[replacedEgressSessionsPerLease] ?? "");
+    expect(newestTombstone.status).toBe(409);
+    await expect(newestTombstone.json()).resolves.toMatchObject({
+      error: "egress_session_replaced",
+    });
+  });
+
+  it("clears replaced egress session tombstones on lease release", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testWebSocketCoordinator(storage);
+    const leaseID = "cbx_000000000001";
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    storage.seed(
+      `lease:${leaseID}`,
+      testLease({
+        id: leaseID,
+        slug: "released-egress",
+        provider: "external",
+        lifecycle: "registered",
+        owner: "alice@example.com",
+        org: "example-org",
+        keep: true,
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      }),
+    );
+    const createTicket = (sessionID: string) =>
+      fleet.fetch(
+        request("POST", "/v1/leases/released-egress/egress/ticket", {
+          headers,
+          body: { role: "host", sessionID, allow: ["example.com"] },
+        }),
+      );
+    expect((await createTicket("egress_release_a")).status).toBe(200);
+    expect((await createTicket("egress_release_b")).status).toBe(200);
+    const relay = fleet as unknown as { replacedEgressSessions: Map<string, string[]> };
+    expect(relay.replacedEgressSessions.get(leaseID)).toEqual(["egress_release_a"]);
+    expect(storage.value(`replaced-egress-sessions:${leaseID}`)).toEqual(["egress_release_a"]);
+    expect(storage.value(`active-egress-session:${leaseID}`)).toMatchObject({
+      leaseID,
+      sessionID: "egress_release_b",
+    });
+
+    const released = await fleet.fetch(
+      request("POST", "/v1/leases/released-egress/release", {
+        headers,
+        body: { delete: false },
+      }),
+    );
+    expect(released.status).toBe(200);
+    await expect(released.json()).resolves.toMatchObject({ lease: { state: "released" } });
+    expect(relay.replacedEgressSessions.has(leaseID)).toBe(false);
+    expect(storage.value(`active-egress-session:${leaseID}`)).toBeUndefined();
+    expect(storage.value(`replaced-egress-sessions:${leaseID}`)).toBeUndefined();
+  });
+
+  it("keeps replaced egress session tombstones on bridge authorization revocation", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testWebSocketCoordinator(storage);
+    const leaseID = "cbx_000000000001";
+    const ownerHeaders = {
+      "x-crabbox-owner": "owner@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const managerHeaders = {
+      "x-crabbox-owner": "manager@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    storage.seed(
+      `lease:${leaseID}`,
+      testLease({
+        id: leaseID,
+        slug: "revoked-egress",
+        owner: "owner@example.com",
+        org: "example-org",
+        share: { users: { "manager@example.com": "manage" } },
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      }),
+    );
+
+    const createTicket = (sessionID: string) =>
+      fleet.fetch(
+        request("POST", "/v1/leases/revoked-egress/egress/ticket", {
+          headers: managerHeaders,
+          body: { role: "host", sessionID, allow: ["example.com"] },
+        }),
+      );
+    expect((await createTicket("egress_revoke_a")).status).toBe(200);
+    const current = await createTicket("egress_revoke_b");
+    expect(current.status).toBe(200);
+    const currentTicket = ((await current.json()) as { ticket: string }).ticket;
+    const connected = await fleet.fetch(
+      request("GET", "/v1/leases/revoked-egress/egress/host", {
+        headers: { "x-crabbox-bridge-ticket": currentTicket, upgrade: "websocket" },
+      }),
+    );
+    expect(connected.status).toBe(200);
+    const relay = fleet as unknown as {
+      egressSessions: Map<string, { sessionID: string }>;
+      replacedEgressSessions: Map<string, string[]>;
+    };
+    expect(relay.replacedEgressSessions.get(leaseID)).toEqual(["egress_revoke_a"]);
+    expect(storage.value(`replaced-egress-sessions:${leaseID}`)).toEqual(["egress_revoke_a"]);
+    expect(storage.value(`active-egress-session:${leaseID}`)).toMatchObject({
+      leaseID,
+      sessionID: "egress_revoke_b",
+    });
+
+    const revoked = await fleet.fetch(
+      request("PUT", "/v1/leases/revoked-egress/share", {
+        headers: ownerHeaders,
+        body: { users: { "manager@example.com": "use" } },
+      }),
+    );
+    expect(revoked.status).toBe(200);
+    expect(relay.egressSessions.has(leaseID)).toBe(false);
+    expect(relay.replacedEgressSessions.get(leaseID)).toEqual([
+      "egress_revoke_a",
+      "egress_revoke_b",
+    ]);
+    expect(storage.value(`active-egress-session:${leaseID}`)).toBeUndefined();
+    expect(storage.value(`replaced-egress-sessions:${leaseID}`)).toEqual([
+      "egress_revoke_a",
+      "egress_revoke_b",
+    ]);
+
+    const ownerTicket = (sessionID: string) =>
+      fleet.fetch(
+        request("POST", "/v1/leases/revoked-egress/egress/ticket", {
+          headers: ownerHeaders,
+          body: { role: "host", sessionID, allow: ["example.com"] },
+        }),
+      );
+    const stale = await ownerTicket("egress_revoke_a");
+    expect(stale.status).toBe(409);
+    await expect(stale.json()).resolves.toMatchObject({ error: "egress_session_replaced" });
+
+    const revokedCurrent = await ownerTicket("egress_revoke_b");
+    expect(revokedCurrent.status).toBe(409);
+    await expect(revokedCurrent.json()).resolves.toMatchObject({
+      error: "egress_session_replaced",
+    });
+
+    const fresh = await ownerTicket("egress_revoke_c");
+    expect(fresh.status).toBe(200);
+    expect(storage.value(`active-egress-session:${leaseID}`)).toMatchObject({
+      leaseID,
+      sessionID: "egress_revoke_c",
+    });
+  });
+
   it("does not let an older egress session replace a newer current session", () => {
     expect(
       shouldActivateEgressSession(
@@ -27322,6 +28014,16 @@ function testCoordinator(
     { CRABBOX_DEFAULT_ORG: "default-org", ...env } as Env,
     providers,
   );
+}
+
+function testWebSocketCoordinator(
+  storage = new MemoryStorage(),
+  env: Partial<Env> = {},
+): FleetCoordinator {
+  return new FleetCoordinator(new FakeCoordinatorRuntime(storage), {
+    CRABBOX_DEFAULT_ORG: "default-org",
+    ...env,
+  } as Env);
 }
 
 function expiredRuntimeAdapterClaim(adapterID: string) {


### PR DESCRIPTION
## Summary

Makes egress session replacement safe by mechanism instead of by call-site ordering. Today a replaced host daemon can resurrect its dead session: the supervisor restarts the kicked host, it mints a fresh ticket for its old session ID, and the coordinator's last-writer-wins activation lets the zombie usurp the legitimate replacement. PRs https://github.com/openclaw/crabbox/pull/1103 and https://github.com/openclaw/crabbox/pull/1120 prevent this by stopping the old daemon before the new session activates — correct, but every future caller must remember the ordering (the non-daemon path already forgot once), and no local ordering can reach a stale daemon on another machine. This PR closes the class:

- **Coordinator** (`worker/src/fleet.ts`): replaced session IDs are tombstoned per lease and persisted in Durable Object storage together with the active session record, so both survive hibernation and restarts (including an active session that happens to be disconnected when the DO hibernates). Ticket mints and agent connects for a tombstoned session get `409 egress_session_replaced`; activation of a tombstoned session is refused. Revoking the current session also tombstones it (cleared-current = permanently dead; a re-granted user starts a fresh session). The replacement transition commits tombstone → clear-old → new-active in that order so a crash can only leave safe states, and hydration gives tombstones precedence over a stale active record. Restored-socket reconciliation keeps the persisted active session and rejects tombstoned ones; if no record exists and several hibernated sessions are ambiguous (first rollout), all are closed non-fatally ("egress session state lost; reconnect") and normal activation settles the winner — nothing is guessed, nothing legitimate is permanently killed. Tombstones clear only on lease-lifecycle teardown. 409 is deliberate: deployed CLIs already exit fatally on 409 at setup via `fatalEgressBridgeSetupError`, so old daemons in the field stop cleanly once this deploys.
- **CLI** (`internal/cli/egress.go`): a serve-loop close with code 1012 and reason containing "replaced by a newer egress" now exits with `egressDaemonFatalCode` (4), so the daemon supervisor stops instead of resurrecting — mirroring the existing WebVNC handling.

Persisting this state made the egress activate/clear paths async (storage I/O), following the file's existing always-await convention; ordering-sensitive close sequences stay sequential. The kill-old-daemon-first ordering in `egressStart` stays as defense in depth. Same-session reconnects after network blips are unaffected (plain socket closes route through `clearEgressHost`/`clearEgressClient`, not session teardown).

**Documented residual (conscious tradeoff):** tombstone history is a per-lease FIFO capped at 256. A daemon that stays offline through 256+ subsequent replacements of one lease and only then returns could still resurrect; any zombie that reconnects earlier dies fatally while tombstoned. Full closure requires server-bound session identity (protocol change) — noted in code and tracked as a follow-up design task.

## Verification

- `gofmt`, `go vet ./...`, `go build`, `go test -race ./...` — green.
- `npm run format:check|lint|check|test|build --prefix worker` — green (1084 passed).
- New worker tests: replacement → stale re-mint 409, stale pre-minted ticket connect 409, replacement connect 200; active-session reconnects unaffected; tombstones survive coordinator restarts; a disconnected active session survives restarts and is tombstoned by its replacement; tombstoned hibernated sockets rejected during reconciliation; ambiguous multi-session restore closes all non-fatally without tombstoning; hydration conflict (ID in both records) → not reported, mint 409, stale record deleted; revoked current session cannot re-mint; FIFO bound via exported constant; tombstones cleared on lease release only.
- New Go tests (`internal/cli/egress_session_replaced_test.go`): real websocket coordinator closes host/client bridges with 1012 "replaced…" → exit code 4; different close code or reason → not fatal.
- Structured review (Codex, gpt-5.6-sol, xhigh): five rounds. Accepted and fixed across rounds: in-memory-only tombstones (→ persisted), FIFO-8 (→ 256), forgotten disconnected-active session (→ persisted active record), revocation erasing history (→ revoked-current tombstoned), crash-ordering gap (→ tombstone-first commit order), lexicographic rollout winner (→ non-fatal ambiguity reset), stale-active hydration conflict (→ tombstone precedence). Final remaining finding = the documented FIFO residual above, consciously rejected as protocol-redesign territory.

## Live proof (production coordinator, real Hetzner lease)

Lease `cbx_b3279744c7f4` (hetzner, server 152262860), branch binary, coordinator `https://crabbox.openclaw.ai`:

1. `egress start --daemon` → daemon session A connected, status `host=true client=true`.
2. Foreground `egress host --session <fresh B>` → coordinator activated B and kicked A with exactly `1012 / "replaced by a newer egress session"`.
3. Daemon log (new binary):

```text
egress daemon supervisor: starting
egress host: connected lease=cbx_b3279744c7f4 session=egress_dk1f9dxhoth4 ...
egress session replaced: failed to get reader: received close frame: status = StatusServiceRestart and reason = "replaced by a newer egress session"
egress daemon supervisor: child exited fatal code=4; stopping
```

Supervisor stopped, zero egress processes remained, status flipped to session B; previous behavior was "restarting in 1s" + session A re-activating. This also confirms the deployed coordinator emits the exact close code/reason the CLI matcher expects. Lease released after the test.

The coordinator half takes effect on the next worker deploy; until then the CLI fatal-close mapping alone already prevents resurrection for updated CLIs.

## Config / secrets

None. No new config surface; no secrets touched.
