### PR TITLE
chore(release): 0.40.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.39.1 - Unreleased
+## 0.40.0 - 2026-07-19
 
 ### Added
 

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -39,7 +39,7 @@ Status labels are deliberate:
   no user-facing command is shipped.
 
 Catalog status tracks repository state, not the latest release archive. The
-standards-compliant Agent Skill metadata is scheduled for 0.39.1; released
+standards-compliant Agent Skill metadata is scheduled for 0.40.0; released
 0.39.0 binaries still generate a body-only `SKILL.md`.
 
 ## Two extension planes

--- a/docs/integrations/agents.md
+++ b/docs/integrations/agents.md
@@ -90,7 +90,7 @@ instructions; they do not grant credentials or bypass the agent host's command
 approval and sandbox policy. See [`crabbox init`](../commands/init.md) and
 [Repository Onboarding](../features/repository-onboarding.md).
 
-The standards-compliant generated metadata is scheduled for Crabbox 0.39.1.
+The standards-compliant generated metadata is scheduled for Crabbox 0.40.0.
 Released 0.39.0 binaries still emit a body-only skill; until upgrading, add the
 required `name` and `description` frontmatter manually.
 
@@ -121,7 +121,7 @@ The checked-in `skills/crabbox` source and `.agents/skills/crabbox` projection
 are byte-identical and CI rejects drift. Use `crabbox init` when the repository
 also needs Crabbox configuration, Actions hydration, and detected project-job
 instructions; use a skill manager when only agent discovery is missing.
-`--pin refs/heads/main` selects this unreleased branch explicitly; after 0.39.1
+`--pin refs/heads/main` selects this unreleased branch explicitly; after 0.40.0
 is tagged, omit it to follow GitHub CLI's latest-release resolution.
 
 ### Discover from crabbox.sh

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/crabbox-worker",
-  "version": "0.39.0",
+  "version": "0.40.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/crabbox-worker",
-      "version": "0.39.0",
+      "version": "0.40.0",
       "dependencies": {
         "@aws-sdk/credential-providers": "^3.1084.0",
         "@cloudflare/containers": "^0.3.7",

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/crabbox-worker",
-  "version": "0.39.0",
+  "version": "0.40.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Cut the **0.40.0** release.

- Date the `0.40.0` changelog section (was `0.39.1 - Unreleased`); the minor bump reflects the new providers and commands added since 0.39.0.
- Bump the worker package version surface: `worker/package.json` and both root entries in `worker/package-lock.json` to `0.40.0`.

Metadata-only. The full Go suite (85 packages), the separate `cloudflare-container-runner` module, and a CLI smoke of the new provider/command surfaces were verified green on this tree before the bump. Worker + Release Check gates run in CI here.
