### PR TITLE
chore(release): authorize v0.40.0 source

### DIFF
--- a/release/records/v0.40.0.json
+++ b/release/records/v0.40.0.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "repository": "openclaw/crabbox",
+  "tag": "v0.40.0",
+  "tagObject": "83d090fd1456202012e73ecad606c81831219b54",
+  "sourceCommit": "47f8e45c9a13e50c40255e8312f16b1eed1b0003",
+  "publicationStatus": "ready"
+}


### PR DESCRIPTION
Authorize-source record for **v0.40.0**.

Binds the signed tag `v0.40.0` (tag object `83d090fd1456202012e73ecad606c81831219b54`) to source commit `47f8e45c9a13e50c40255e8312f16b1eed1b0003`, `publicationStatus: ready`. Required on `main` before the credential-free producer will build the release candidate.
