### PR TITLE
chore: open 0.40.1 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 0.40.1 - Unreleased
+
 ## 0.40.0 - 2026-07-19
 
 ### Added


### PR DESCRIPTION
Open the next unreleased changelog section (0.40.1) after publishing 0.40.0.
