### PR TITLE
fix(hyperv): provisioning hangs while Windows guests boot

### DIFF
--- a/.agents/skills/crabbox/SKILL.md
+++ b/.agents/skills/crabbox/SKILL.md
@@ -195,17 +195,10 @@ PowerShell and `--script <file.ps1>` for longer scripts.
 
 ### Hyper-V Windows leases
 
-`hyperv` is a native-Windows SSH-lease provider. A template needs a Generation 2
-VHDX, DHCP networking, and a known local administrator credential supplied
-through trusted user config or `CRABBOX_HYPERV_GUEST_PASSWORD`.
-See `docs/providers/hyperv.md` for the complete bootstrap and lifecycle contract.
-
-OpenSSH Server and git do not need to be preinstalled. When absent, the provider
-uses PowerShell Direct to bootstrap a pinned, SHA-256-verified Win32-OpenSSH MSI
-and MinGit inside the guest; templates with existing `sshd` and `git` skip those
-downloads. Guest internet access to GitHub is therefore required only for
-missing bootstrap tools. OpenSSH installation does not depend on Windows Update
-or a Features on Demand source.
+`hyperv` needs a Generation 2 VHDX, DHCP, and a known local administrator
+password in trusted config or `CRABBOX_HYPERV_GUEST_PASSWORD`. It installs
+pinned, verified OpenSSH and MinGit packages when missing, using PowerShell
+Direct. See `docs/providers/hyperv.md` for template and lifecycle details.
 
 ```powershell
 crabbox run --provider hyperv --target windows `
@@ -214,12 +207,9 @@ crabbox run --provider hyperv --target windows `
   -- powershell -NoProfile -Command "whoami; hostname"
 ```
 
-For provider-development proof on an interactive Windows host, prefer an
-elevated headless/session-0 runner. Windows can display credential UI for failed
-early PowerShell Direct attempts even when the host command is non-interactive.
-Keep the guest password out of command arguments and logs, save the timing/run
-output, and verify that the lease reaches `state=ready`, executes over SSH, and
-releases cleanly.
+For provider testing, use an elevated headless/session-0 runner when possible.
+Keep the guest password out of arguments and logs, and verify the lease becomes
+ready, runs over SSH, and releases cleanly.
 
 ## Secrets And Environment Forwarding
 

--- a/.agents/skills/crabbox/SKILL.md
+++ b/.agents/skills/crabbox/SKILL.md
@@ -207,9 +207,10 @@ crabbox run --provider hyperv --target windows `
   -- powershell -NoProfile -Command "whoami; hostname"
 ```
 
-For provider testing, use an elevated headless/session-0 runner when possible.
-Keep the guest password out of arguments and logs, and verify the lease becomes
-ready, runs over SSH, and releases cleanly.
+For provider testing, use an elevated headless/session-0 runner when possible:
+early PowerShell Direct failures can show credential UI even for non-interactive
+commands. Keep the guest password out of arguments and logs, and verify the
+lease becomes ready, runs over SSH, and releases cleanly.
 
 ## Secrets And Environment Forwarding
 

--- a/.agents/skills/crabbox/SKILL.md
+++ b/.agents/skills/crabbox/SKILL.md
@@ -200,17 +200,9 @@ password in trusted config or `CRABBOX_HYPERV_GUEST_PASSWORD`. It installs
 pinned, verified OpenSSH and MinGit packages when missing, using PowerShell
 Direct. See `docs/providers/hyperv.md` for template and lifecycle details.
 
-```powershell
-crabbox run --provider hyperv --target windows `
-  --hyperv-image 'C:\Images\windows.vhdx' `
-  --timing-json --no-sync `
-  -- powershell -NoProfile -Command "whoami; hostname"
-```
-
-For provider testing, use an elevated headless/session-0 runner when possible:
-early PowerShell Direct failures can show credential UI even for non-interactive
-commands. Keep the guest password out of arguments and logs, and verify the
-lease becomes ready, runs over SSH, and releases cleanly.
+For provider testing, prefer an elevated headless runner; early PowerShell
+Direct failures can show credential UI. Keep passwords out of arguments and
+logs, and verify the lease becomes ready, runs over SSH, and releases.
 
 ## Secrets And Environment Forwarding
 

--- a/.agents/skills/crabbox/SKILL.md
+++ b/.agents/skills/crabbox/SKILL.md
@@ -193,6 +193,34 @@ Native Windows targets use PowerShell and tar-based manifest sync. Prefer plain
 argv for one executable such as `dotnet test`; use `--shell` for multi-statement
 PowerShell and `--script <file.ps1>` for longer scripts.
 
+### Hyper-V Windows leases
+
+`hyperv` is a native-Windows SSH-lease provider. A template needs a Generation 2
+VHDX, DHCP networking, and a known local administrator credential supplied
+through trusted user config or `CRABBOX_HYPERV_GUEST_PASSWORD`.
+See `docs/providers/hyperv.md` for the complete bootstrap and lifecycle contract.
+
+OpenSSH Server and git do not need to be preinstalled. When absent, the provider
+uses PowerShell Direct to bootstrap a pinned, SHA-256-verified Win32-OpenSSH MSI
+and MinGit inside the guest; templates with existing `sshd` and `git` skip those
+downloads. Guest internet access to GitHub is therefore required only for
+missing bootstrap tools. OpenSSH installation does not depend on Windows Update
+or a Features on Demand source.
+
+```powershell
+crabbox run --provider hyperv --target windows `
+  --hyperv-image 'C:\Images\windows.vhdx' `
+  --timing-json --no-sync `
+  -- powershell -NoProfile -Command "whoami; hostname"
+```
+
+For provider-development proof on an interactive Windows host, prefer an
+elevated headless/session-0 runner. Windows can display credential UI for failed
+early PowerShell Direct attempts even when the host command is non-interactive.
+Keep the guest password out of command arguments and logs, save the timing/run
+output, and verify that the lease reaches `state=ready`, executes over SSH, and
+releases cleanly.
+
 ## Secrets And Environment Forwarding
 
 Crabbox does not forward the whole local environment. Forwarding is name-based:

--- a/docs/providers/hyperv.md
+++ b/docs/providers/hyperv.md
@@ -28,15 +28,11 @@ reject configuration on non-Windows hosts.
     first use
 - The Hyper-V PowerShell module (included with the Hyper-V feature)
 
-OpenSSH and git do **not** need to be pre-installed. On first acquire the
-provider installs the pinned, SHA-256-verified Win32-OpenSSH MSI used by the
-`Microsoft.OpenSSH.Preview` winget package and, if absent, portable MinGit
-(also pinned and SHA-256-verified). Both installs are no-ops when already
-present, so a template that pre-bakes inbox/FoD OpenSSH, the MSI version, or git
-skips the matching per-lease download. OpenSSH bootstrap does not depend on
-Windows Update, WSUS, or a matching Features on Demand source. This keeps the
-template requirement to a plain Windows VHDX with a known admin password. ISO
-images are not supported — provide a fully installed VHDX.
+OpenSSH and git do **not** need to be pre-installed. When missing, the provider
+installs pinned, SHA-256-verified Win32-OpenSSH and MinGit packages. Existing
+installations are reused. The OpenSSH bootstrap does not require Windows Update
+or Features on Demand. ISO images are not supported; use an installed VHDX with
+a known administrator password.
 
 ### Preparing a template
 
@@ -134,9 +130,7 @@ During `Acquire`, the provider:
 2. With `--hyperv-init-password`, mounts the lease disk offline and writes a
    first-boot `RunOnce` that sets the guest password (password-less templates)
 3. Creates and starts the VM with its network adapter disconnected
-4. Waits for a trivial authenticated PowerShell Direct call to succeed. The
-   readiness loop has an overall boot budget and bounds each attempt so a guest
-   that is still booting cannot hang acquisition.
+4. Waits for PowerShell Direct readiness within a bounded boot timeout
 5. Uses PowerShell Direct to stop/disable sshd, add an inbound TCP/22 block
    rule, replace authorized keys, discard template `Match` authentication
    blocks, and restrict SSH to the selected user
@@ -147,11 +141,9 @@ During `Acquire`, the provider:
 8. Installs git (MinGit) if absent — required for Crabbox sync
 9. Waits for SSH readiness on the injected key
 
-The readiness probe, OpenSSH-install, and key-injection steps authenticate over
-PowerShell Direct using the guest administrator password. The readiness probe
-retries within a bounded boot budget; later guest operations retry transient
-failures with backoff and bound each individual host PowerShell process so a
-wedged call cannot hang the lease indefinitely.
+PowerShell Direct calls use the guest administrator password. Readiness and
+later guest operations have bounded retries, preventing a stalled call from
+hanging the lease.
 
 Set `CRABBOX_HYPERV_GUEST_PASSWORD` or `hyperv.guestPassword` in trusted user
 config to match the administrator password in your VHDX template. The provider

--- a/docs/providers/hyperv.md
+++ b/docs/providers/hyperv.md
@@ -10,8 +10,7 @@ Family: `local-vm`
 The Hyper-V provider creates and manages Windows virtual machines on a local
 Windows host using Microsoft Hyper-V. VMs are provisioned as Generation 2 VMs
 from a pre-configured VHDX template, connected to a configurable virtual switch
-(default: "Default Switch"), and accessed over SSH via the built-in Windows
-OpenSSH server.
+(default: "Default Switch"), and accessed over SSH via Windows OpenSSH.
 
 Hyper-V must be enabled on the host (`Enable-WindowsOptionalFeature -Online
 -FeatureName Microsoft-Hyper-V-All`). The provider is Windows-only and will
@@ -25,15 +24,17 @@ reject configuration on non-Windows hosts.
   - A local administrator account selected with `--hyperv-user`, with its
     password explicitly provided through `CRABBOX_HYPERV_GUEST_PASSWORD`
   - Network configured for DHCP on the Hyper-V virtual switch
-  - Guest internet access (or a Features-on-Demand source) so OpenSSH can be
-    installed on first use
+  - Guest internet access to GitHub when OpenSSH or git must be installed on
+    first use
 - The Hyper-V PowerShell module (included with the Hyper-V feature)
 
-OpenSSH and git do **not** need to be pre-installed: on first acquire the
-provider installs the Windows OpenSSH server (over PowerShell Direct) and, if
-absent, git (portable MinGit, pinned to a specific release and SHA-256-verified
-before extraction) — both are no-ops when already present, so a template that
-pre-bakes them just skips the per-lease download. This keeps the
+OpenSSH and git do **not** need to be pre-installed. On first acquire the
+provider installs the pinned, SHA-256-verified Win32-OpenSSH MSI used by the
+`Microsoft.OpenSSH.Preview` winget package and, if absent, portable MinGit
+(also pinned and SHA-256-verified). Both installs are no-ops when already
+present, so a template that pre-bakes inbox/FoD OpenSSH, the MSI version, or git
+skips the matching per-lease download. OpenSSH bootstrap does not depend on
+Windows Update, WSUS, or a matching Features on Demand source. This keeps the
 template requirement to a plain Windows VHDX with a known admin password. ISO
 images are not supported — provide a fully installed VHDX.
 
@@ -133,19 +134,24 @@ During `Acquire`, the provider:
 2. With `--hyperv-init-password`, mounts the lease disk offline and writes a
    first-boot `RunOnce` that sets the guest password (password-less templates)
 3. Creates and starts the VM with its network adapter disconnected
-4. Uses PowerShell Direct to stop/disable sshd, add an inbound TCP/22 block
+4. Waits for a trivial authenticated PowerShell Direct call to succeed. The
+   readiness loop has an overall boot budget and bounds each attempt so a guest
+   that is still booting cannot hang acquisition.
+5. Uses PowerShell Direct to stop/disable sshd, add an inbound TCP/22 block
    rule, replace authorized keys, discard template `Match` authentication
    blocks, and restrict SSH to the selected user
-5. Connects the network adapter, installs Windows OpenSSH if absent, and keeps
-   sshd stopped behind the quarantine rule
-6. Reapplies the final key-only config, validates `sshd_config`, regenerates
+6. Connects the network adapter, installs the pinned Win32-OpenSSH MSI from
+   GitHub if `sshd` is absent, and keeps sshd stopped behind the quarantine rule
+7. Reapplies the final key-only config, validates `sshd_config`, regenerates
    per-lease SSH host keys, starts sshd, and removes the quarantine rule last
-7. Installs git (MinGit) if absent — required for Crabbox sync
-8. Waits for SSH readiness on the injected key
+8. Installs git (MinGit) if absent — required for Crabbox sync
+9. Waits for SSH readiness on the injected key
 
-Both the OpenSSH-install and key-injection steps authenticate over PowerShell
-Direct using the guest administrator password and retry up to 5 times with
-backoff to allow the guest OS to boot.
+The readiness probe, OpenSSH-install, and key-injection steps authenticate over
+PowerShell Direct using the guest administrator password. The readiness probe
+retries within a bounded boot budget; later guest operations retry transient
+failures with backoff and bound each individual host PowerShell process so a
+wedged call cannot hang the lease indefinitely.
 
 Set `CRABBOX_HYPERV_GUEST_PASSWORD` or `hyperv.guestPassword` in trusted user
 config to match the administrator password in your VHDX template. The provider

--- a/docs/providers/hyperv.md
+++ b/docs/providers/hyperv.md
@@ -29,10 +29,10 @@ reject configuration on non-Windows hosts.
 - The Hyper-V PowerShell module (included with the Hyper-V feature)
 
 OpenSSH and git do **not** need to be pre-installed. When missing, the provider
-installs pinned, SHA-256-verified Win32-OpenSSH and MinGit packages. Existing
-installations are reused. The OpenSSH bootstrap does not require Windows Update
-or Features on Demand. ISO images are not supported; use an installed VHDX with
-a known administrator password.
+installs pinned, SHA-256-verified Win32-OpenSSH (matching the guest architecture)
+and MinGit packages. Existing installations are reused. The OpenSSH bootstrap
+does not require Windows Update or Features on Demand. ISO images are not
+supported; use an installed VHDX with a known administrator password.
 
 ### Preparing a template
 

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -21,6 +21,18 @@ type backend struct {
 	spec ProviderSpec
 	cfg  Config
 	rt   Runtime
+
+	// Guest boot/readiness timing. crabbox waits for PowerShell Direct itself to
+	// answer a trivial authenticated probe before the first real guest call,
+	// because PS Direct blocks (rather than fast-failing) while the guest is
+	// still booting. Each attempt is bounded by guestReadyProbeTimeout so a
+	// blocked probe is killed and retried (proven not to corrupt the guest
+	// session), and guestInvokeTimeout bounds each real guest call so a wedged
+	// mid-session call cannot hang the provision forever. Overridable in tests.
+	guestReadyProbeTimeout time.Duration
+	guestReadyBudget       time.Duration
+	guestInvokeTimeout     time.Duration
+	guestRetryBackoff      time.Duration
 }
 
 var hypervHostOS = runtime.GOOS
@@ -41,7 +53,15 @@ type hypervNetAdapter struct {
 
 func newBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
 	applyDefaults(&cfg)
-	return &backend{spec: spec, cfg: cfg, rt: rt}
+	return &backend{
+		spec:                   spec,
+		cfg:                    cfg,
+		rt:                     rt,
+		guestReadyProbeTimeout: 45 * time.Second,
+		guestReadyBudget:       5 * time.Minute,
+		guestInvokeTimeout:     10 * time.Minute,
+		guestRetryBackoff:      3 * time.Second,
+	}
 }
 
 func applyDefaults(cfg *Config) {
@@ -194,6 +214,9 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 		return nil
 	}
 
+	if err := b.waitGuestReady(ctx, name, cfg.HyperV.User); err != nil {
+		return LeaseTarget{}, errors.Join(fmt.Errorf("guest did not become reachable over PowerShell Direct: %w", err), cleanupFailedLease())
+	}
 	if err := b.stageSSHKey(ctx, name, cfg.HyperV.User, publicKey); err != nil {
 		return LeaseTarget{}, errors.Join(fmt.Errorf("pre-network SSH lockdown failed: %w", err), cleanupFailedLease())
 	}
@@ -596,11 +619,72 @@ func hypervInitHiveName(vhdPath string) string {
 	return fmt.Sprintf("crabbox-init-%x", sum[:8])
 }
 
+// invokeGuestScript runs one host powershell invocation bounded by perAttempt.
+// The bound matters for PowerShell Direct calls (Invoke-Command -VMName blocks
+// rather than fast-failing when a guest is unreachable, and execCommandRunner
+// kills the process on ctx cancel); without it a single wedged call would hang
+// forever. A per-attempt timeout surfaces as an error while the outer ctx stays
+// live, so callers retry it; an outer-ctx cancel surfaces via ctx.Err().
+func (b *backend) invokeGuestScript(ctx context.Context, script string, env []string, perAttempt time.Duration) (LocalCommandResult, error) {
+	attemptCtx, cancel := context.WithTimeout(ctx, perAttempt)
+	defer cancel()
+	return b.powershellWithEnv(attemptCtx, script, env)
+}
+
+// waitGuestReady blocks until PowerShell Direct answers a trivial authenticated
+// probe, or the boot budget elapses. This is the actual readiness signal the
+// first real guest call (stageSSHKey) needs: it succeeds only once the guest's
+// VM-session service and auth subsystem are up. Early in boot PS Direct blocks
+// (rather than fast-failing) and can return transient "credential is
+// invalid"/connection errors, so every failure is retried within the budget and
+// each attempt is bounded by guestReadyProbeTimeout. A blocked probe is killed
+// at that timeout; this does not corrupt the guest session (the next probe
+// succeeds), it only fails-fast so the loop can advance. Running this once up
+// front keeps the boot-window block out of every downstream step.
+func (b *backend) waitGuestReady(ctx context.Context, vmName, user string) error {
+	script := fmt.Sprintf(
+		`$cred = New-Object PSCredential('%s', (ConvertTo-SecureString $env:_CRABBOX_GP -AsPlainText -Force)); `+
+			`Invoke-Command -VMName '%s' -Credential $cred -ScriptBlock { $true } -ErrorAction Stop | Out-Null`,
+		escapePSString(user), escapePSString(vmName),
+	)
+	env := append(os.Environ(), "_CRABBOX_GP="+b.guestPassword())
+	// Bound the whole loop by the budget: backoff waits, the per-attempt probe
+	// timeout, and launching another probe at all are all capped to the remaining
+	// budget (invokeGuestScript derives its attempt deadline from budgetCtx). This
+	// keeps the total wait within guestReadyBudget instead of overshooting by one
+	// backoff plus one probe timeout.
+	budgetCtx, cancel := context.WithTimeout(ctx, b.guestReadyBudget)
+	defer cancel()
+	var lastErr error
+	for attempt := 0; ; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-budgetCtx.Done():
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
+				return fmt.Errorf("guest %s did not accept PowerShell Direct within %s: %w", vmName, b.guestReadyBudget, lastErr)
+			case <-time.After(b.guestRetryBackoff):
+			}
+		}
+		result, err := b.invokeGuestScript(budgetCtx, script, env, b.guestReadyProbeTimeout)
+		if err == nil {
+			return nil
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		lastErr = commandError("guest readiness probe", result, err)
+	}
+}
+
 // invokeInGuest runs a PowerShell script block inside the guest over PowerShell
 // Direct, authenticating as user with the configured guest password. It retries
-// with backoff while the guest finishes booting. scriptBlock is the body of an
-// Invoke-Command -ScriptBlock { ... }; the guest password is passed via the
-// _CRABBOX_GP env var, never on the command line.
+// with backoff, and bounds each attempt with guestInvokeTimeout (generous, so
+// long installs such as Add-WindowsCapability complete) so a wedged call can
+// never hang the provision. scriptBlock is the body of an Invoke-Command
+// -ScriptBlock { ... }; the guest password is passed via the _CRABBOX_GP env
+// var, never on the command line.
 func (b *backend) invokeInGuest(ctx context.Context, vmName, user, scriptBlock, label string) error {
 	script := fmt.Sprintf(
 		`$cred = New-Object PSCredential('%s', (ConvertTo-SecureString $env:_CRABBOX_GP -AsPlainText -Force)); `+
@@ -614,31 +698,62 @@ func (b *backend) invokeInGuest(ctx context.Context, vmName, user, scriptBlock, 
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
-			case <-time.After(time.Duration(attempt*5) * time.Second):
+			case <-time.After(time.Duration(attempt) * b.guestRetryBackoff):
 			}
 			fmt.Fprintf(b.rt.Stderr, "retrying %s (%d/5)...\n", label, attempt+1)
 		}
-		result, err := b.powershellWithEnv(ctx, script, env)
+		result, err := b.invokeGuestScript(ctx, script, env, b.guestInvokeTimeout)
 		if err == nil {
 			return nil
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
 		}
 		lastErr = commandError(label, result, err)
 	}
 	return lastErr
 }
 
+// Win32-OpenSSH release pinned for the guest OpenSSH server bootstrap. This is
+// the same payload winget installs as Microsoft.OpenSSH.Preview, fetched
+// directly from GitHub so the install does not depend on Windows Update /
+// Features-on-Demand (Add-WindowsCapability), which is blocked or offline on many
+// templates and fails with 0x800f0950. The MSI downloads inside the guest and
+// installs a privileged service, so it must not float with "latest": a changed
+// release response or substituted artifact would be privileged guest code
+// execution. Update the URL and SHA-256 together (SHA-256 is of the exact asset).
+// Note: the upstream release tag is "10.0.0.0p2-Preview" with no leading "v", so
+// the download path intentionally has no "v" before the tag (verified live: the
+// "v"-prefixed tag 404s).
+const (
+	win32OpenSSHURL    = "https://github.com/PowerShell/Win32-OpenSSH/releases/download/10.0.0.0p2-Preview/OpenSSH-Win64-v10.0.0.0.msi"
+	win32OpenSSHSHA256 = "ddec9c53864280759cf9f74791cefd387100e3946aa849a1c138a4ed1b96b7d9"
+)
+
 // ensureOpenSSH installs the Windows OpenSSH server inside the guest, but keeps
 // sshd stopped and its firewall rule disabled until injectSSHKey replaces the
 // template credentials and host keys. This lets a plain Windows template be
 // used as-is: it only needs a reachable administrator account
-// (CRABBOX_HYPERV_GUEST_PASSWORD), not a pre-baked SSH setup. Idempotent;
-// installing the capability needs guest internet (or a configured
-// Features-on-Demand source).
+// (CRABBOX_HYPERV_GUEST_PASSWORD), not a pre-baked SSH setup. Idempotent: a
+// no-op install when the sshd service already exists (so a template that
+// pre-bakes OpenSSH skips the per-lease download). Installs the pinned
+// Win32-OpenSSH MSI from GitHub (SHA-256-verified) instead of the FoD capability
+// so it works on templates without Windows Update access; needs guest internet.
+// The MSI registers sshd StartType Automatic (and may start it and add its own
+// allow rule), so the stop/Manual step here still quarantines it; the actual
+// network block is the Crabbox-SSH-Quarantine rule stageSSHKey sets pre-network.
 func (b *backend) ensureOpenSSH(ctx context.Context, vmName, user string) error {
 	scriptBlock := `$ErrorActionPreference='Stop'; ` +
-		`$capName = 'OpenSSH.Server~~~~0.0.1.0'; ` +
-		`$cap = Get-WindowsCapability -Online -Name $capName; ` +
-		`if ($cap.State -ne 'Installed') { Add-WindowsCapability -Online -Name $capName | Out-Null }; ` +
+		`if (-not (Get-Service -Name sshd -ErrorAction SilentlyContinue)) { ` +
+		`[Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12; ` +
+		`$msi=Join-Path $env:TEMP 'crabbox-openssh.msi'; ` +
+		`Invoke-WebRequest -UseBasicParsing -Uri '` + win32OpenSSHURL + `' -OutFile $msi; ` +
+		`$hash=(Get-FileHash -Path $msi -Algorithm SHA256).Hash; ` +
+		`if ($hash -ne '` + win32OpenSSHSHA256 + `') { Remove-Item $msi -Force; throw ('OpenSSH SHA-256 mismatch: got ' + $hash) }; ` +
+		`$proc=Start-Process msiexec.exe -ArgumentList @('/i', ('"'+$msi+'"'), '/qn', '/norestart') -Wait -PassThru; ` +
+		`if ($proc.ExitCode -ne 0 -and $proc.ExitCode -ne 3010) { throw ('OpenSSH MSI install failed: exit ' + $proc.ExitCode) }; ` +
+		`Remove-Item $msi -Force -ErrorAction SilentlyContinue; ` +
+		`if (-not (Get-Service -Name sshd -ErrorAction SilentlyContinue)) { throw 'sshd service missing after OpenSSH MSI install' } }; ` +
 		`Stop-Service -Name sshd -Force -ErrorAction SilentlyContinue; ` +
 		`Set-Service -Name sshd -StartupType Manual; ` +
 		`if (Get-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -ErrorAction SilentlyContinue) { ` +
@@ -732,8 +847,11 @@ func sshAccessScript(user, publicKey string, activate bool) string {
 		return script
 	}
 	return script +
+		`$sshdExe = ((Get-CimInstance Win32_Service -Filter "Name='sshd'").PathName).Trim().Trim('"'); ` +
+		`if (-not $sshdExe) { throw 'sshd service not found for OpenSSH tool path resolution' }; ` +
+		`$sshBin = Split-Path -Parent $sshdExe; ` +
+		`$sshKeygen = Join-Path $sshBin 'ssh-keygen.exe'; ` +
 		`Get-ChildItem -Path $hostKeyDir -Filter 'ssh_host_*' -ErrorAction SilentlyContinue | Remove-Item -Force; ` +
-		`$sshKeygen = Join-Path $env:WINDIR 'System32\OpenSSH\ssh-keygen.exe'; ` +
 		`& $sshKeygen -A; ` +
 		`if ($LASTEXITCODE -ne 0) { throw 'SSH host key generation failed' }; ` +
 		`$systemSID = [System.Security.Principal.SecurityIdentifier]::new('S-1-5-18'); ` +
@@ -745,7 +863,6 @@ func sshAccessScript(user, publicKey string, activate bool) string {
 		`$hostKeyACL.AddAccessRule([System.Security.AccessControl.FileSystemAccessRule]::new($systemSID, [System.Security.AccessControl.FileSystemRights]::FullControl, [System.Security.AccessControl.AccessControlType]::Allow)); ` +
 		`$hostKeyACL.AddAccessRule([System.Security.AccessControl.FileSystemAccessRule]::new($adminsSID, [System.Security.AccessControl.FileSystemRights]::FullControl, [System.Security.AccessControl.AccessControlType]::Allow)); ` +
 		`Set-Acl -LiteralPath $_.FullName -AclObject $hostKeyACL }; ` +
-		`$sshdExe = Join-Path $env:WINDIR 'System32\OpenSSH\sshd.exe'; ` +
 		`& $sshdExe -t -f $sshdConfig; ` +
 		`if ($LASTEXITCODE -ne 0) { throw 'sshd_config validation failed' }; ` +
 		`Set-Service -Name sshd -StartupType Automatic; ` +

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -22,13 +22,7 @@ type backend struct {
 	cfg  Config
 	rt   Runtime
 
-	// Guest boot/readiness timing. crabbox waits for PowerShell Direct itself to
-	// answer a trivial authenticated probe before the first real guest call,
-	// because PS Direct blocks (rather than fast-failing) while the guest is
-	// still booting. Each attempt is bounded by guestReadyProbeTimeout so a
-	// blocked probe is killed and retried (proven not to corrupt the guest
-	// session), and guestInvokeTimeout bounds each real guest call so a wedged
-	// mid-session call cannot hang the provision forever. Overridable in tests.
+	// PowerShell Direct timeouts; overridden by tests.
 	guestReadyProbeTimeout time.Duration
 	guestReadyBudget       time.Duration
 	guestInvokeTimeout     time.Duration
@@ -619,28 +613,15 @@ func hypervInitHiveName(vhdPath string) string {
 	return fmt.Sprintf("crabbox-init-%x", sum[:8])
 }
 
-// invokeGuestScript runs one host powershell invocation bounded by perAttempt.
-// The bound matters for PowerShell Direct calls (Invoke-Command -VMName blocks
-// rather than fast-failing when a guest is unreachable, and execCommandRunner
-// kills the process on ctx cancel); without it a single wedged call would hang
-// forever. A per-attempt timeout surfaces as an error while the outer ctx stays
-// live, so callers retry it; an outer-ctx cancel surfaces via ctx.Err().
+// invokeGuestScript bounds a PowerShell Direct attempt so callers can retry it.
 func (b *backend) invokeGuestScript(ctx context.Context, script string, env []string, perAttempt time.Duration) (LocalCommandResult, error) {
 	attemptCtx, cancel := context.WithTimeout(ctx, perAttempt)
 	defer cancel()
 	return b.powershellWithEnv(attemptCtx, script, env)
 }
 
-// waitGuestReady blocks until PowerShell Direct answers a trivial authenticated
-// probe, or the boot budget elapses. This is the actual readiness signal the
-// first real guest call (stageSSHKey) needs: it succeeds only once the guest's
-// VM-session service and auth subsystem are up. Early in boot PS Direct blocks
-// (rather than fast-failing) and can return transient "credential is
-// invalid"/connection errors, so every failure is retried within the budget and
-// each attempt is bounded by guestReadyProbeTimeout. A blocked probe is killed
-// at that timeout; this does not corrupt the guest session (the next probe
-// succeeds), it only fails-fast so the loop can advance. Running this once up
-// front keeps the boot-window block out of every downstream step.
+// waitGuestReady retries an authenticated PowerShell Direct probe until the
+// guest responds or the boot budget expires.
 func (b *backend) waitGuestReady(ctx context.Context, vmName, user string) error {
 	script := fmt.Sprintf(
 		`$cred = New-Object PSCredential('%s', (ConvertTo-SecureString $env:_CRABBOX_GP -AsPlainText -Force)); `+
@@ -648,11 +629,7 @@ func (b *backend) waitGuestReady(ctx context.Context, vmName, user string) error
 		escapePSString(user), escapePSString(vmName),
 	)
 	env := append(os.Environ(), "_CRABBOX_GP="+b.guestPassword())
-	// Bound the whole loop by the budget: backoff waits, the per-attempt probe
-	// timeout, and launching another probe at all are all capped to the remaining
-	// budget (invokeGuestScript derives its attempt deadline from budgetCtx). This
-	// keeps the total wait within guestReadyBudget instead of overshooting by one
-	// backoff plus one probe timeout.
+	// Include attempts and backoff in the overall boot budget.
 	budgetCtx, cancel := context.WithTimeout(ctx, b.guestReadyBudget)
 	defer cancel()
 	var lastErr error
@@ -679,12 +656,8 @@ func (b *backend) waitGuestReady(ctx context.Context, vmName, user string) error
 }
 
 // invokeInGuest runs a PowerShell script block inside the guest over PowerShell
-// Direct, authenticating as user with the configured guest password. It retries
-// with backoff, and bounds each attempt with guestInvokeTimeout (generous, so
-// long installs such as Add-WindowsCapability complete) so a wedged call can
-// never hang the provision. scriptBlock is the body of an Invoke-Command
-// -ScriptBlock { ... }; the guest password is passed via the _CRABBOX_GP env
-// var, never on the command line.
+// Direct with bounded retries. The guest password is passed through
+// _CRABBOX_GP, never the command line.
 func (b *backend) invokeInGuest(ctx context.Context, vmName, user, scriptBlock, label string) error {
 	script := fmt.Sprintf(
 		`$cred = New-Object PSCredential('%s', (ConvertTo-SecureString $env:_CRABBOX_GP -AsPlainText -Force)); `+
@@ -714,17 +687,7 @@ func (b *backend) invokeInGuest(ctx context.Context, vmName, user, scriptBlock, 
 	return lastErr
 }
 
-// Win32-OpenSSH release pinned for the guest OpenSSH server bootstrap. This is
-// the same payload winget installs as Microsoft.OpenSSH.Preview, fetched
-// directly from GitHub so the install does not depend on Windows Update /
-// Features-on-Demand (Add-WindowsCapability), which is blocked or offline on many
-// templates and fails with 0x800f0950. The MSI downloads inside the guest and
-// installs a privileged service, so it must not float with "latest": a changed
-// release response or substituted artifact would be privileged guest code
-// execution. Update the URL and SHA-256 together (SHA-256 is of the exact asset).
-// Note: the upstream release tag is "10.0.0.0p2-Preview" with no leading "v", so
-// the download path intentionally has no "v" before the tag (verified live: the
-// "v"-prefixed tag 404s).
+// Pinned Win32-OpenSSH release. Update the URL and SHA-256 together.
 const (
 	win32OpenSSHURL    = "https://github.com/PowerShell/Win32-OpenSSH/releases/download/10.0.0.0p2-Preview/OpenSSH-Win64-v10.0.0.0.msi"
 	win32OpenSSHSHA256 = "ddec9c53864280759cf9f74791cefd387100e3946aa849a1c138a4ed1b96b7d9"
@@ -732,16 +695,9 @@ const (
 
 // ensureOpenSSH installs the Windows OpenSSH server inside the guest, but keeps
 // sshd stopped and its firewall rule disabled until injectSSHKey replaces the
-// template credentials and host keys. This lets a plain Windows template be
-// used as-is: it only needs a reachable administrator account
-// (CRABBOX_HYPERV_GUEST_PASSWORD), not a pre-baked SSH setup. Idempotent: a
-// no-op install when the sshd service already exists (so a template that
-// pre-bakes OpenSSH skips the per-lease download). Installs the pinned
-// Win32-OpenSSH MSI from GitHub (SHA-256-verified) instead of the FoD capability
-// so it works on templates without Windows Update access; needs guest internet.
-// The MSI registers sshd StartType Automatic (and may start it and add its own
-// allow rule), so the stop/Manual step here still quarantines it; the actual
-// network block is the Crabbox-SSH-Quarantine rule stageSSHKey sets pre-network.
+// template credentials and host keys. Existing installations are reused;
+// otherwise it installs the pinned, verified MSI without relying on Windows
+// Update. stageSSHKey's firewall rule keeps the service quarantined.
 func (b *backend) ensureOpenSSH(ctx context.Context, vmName, user string) error {
 	scriptBlock := `$ErrorActionPreference='Stop'; ` +
 		`if (-not (Get-Service -Name sshd -ErrorAction SilentlyContinue)) { ` +

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -22,7 +22,9 @@ type backend struct {
 	cfg  Config
 	rt   Runtime
 
-	// PowerShell Direct timeouts; overridden by tests.
+	// PowerShell Direct can block instead of failing while a guest boots, so
+	// readiness probes and later guest calls need per-attempt timeouts.
+	// Overridden by tests.
 	guestReadyProbeTimeout time.Duration
 	guestReadyBudget       time.Duration
 	guestInvokeTimeout     time.Duration
@@ -620,8 +622,8 @@ func (b *backend) invokeGuestScript(ctx context.Context, script string, env []st
 	return b.powershellWithEnv(attemptCtx, script, env)
 }
 
-// waitGuestReady retries an authenticated PowerShell Direct probe until the
-// guest responds or the boot budget expires.
+// waitGuestReady gates the first real guest call on authenticated PowerShell
+// Direct readiness. Each probe is bounded because early boot calls can block.
 func (b *backend) waitGuestReady(ctx context.Context, vmName, user string) error {
 	script := fmt.Sprintf(
 		`$cred = New-Object PSCredential('%s', (ConvertTo-SecureString $env:_CRABBOX_GP -AsPlainText -Force)); `+
@@ -687,17 +689,18 @@ func (b *backend) invokeInGuest(ctx context.Context, vmName, user, scriptBlock, 
 	return lastErr
 }
 
-// Pinned Win32-OpenSSH release. Update the URL and SHA-256 together.
+// Pinned Win32-OpenSSH payload used by Microsoft.OpenSSH.Preview. It runs as
+// privileged guest code, so update the URL and SHA-256 together and never use a
+// floating release. The upstream tag intentionally has no leading "v".
 const (
 	win32OpenSSHURL    = "https://github.com/PowerShell/Win32-OpenSSH/releases/download/10.0.0.0p2-Preview/OpenSSH-Win64-v10.0.0.0.msi"
 	win32OpenSSHSHA256 = "ddec9c53864280759cf9f74791cefd387100e3946aa849a1c138a4ed1b96b7d9"
 )
 
-// ensureOpenSSH installs the Windows OpenSSH server inside the guest, but keeps
-// sshd stopped and its firewall rule disabled until injectSSHKey replaces the
-// template credentials and host keys. Existing installations are reused;
-// otherwise it installs the pinned, verified MSI without relying on Windows
-// Update. stageSSHKey's firewall rule keeps the service quarantined.
+// ensureOpenSSH reuses an existing service or installs the pinned, verified MSI
+// without relying on Windows Update. The MSI may start sshd and add an allow
+// rule, so stageSSHKey's pre-network block and the stop/manual steps below keep
+// it closed until injectSSHKey installs the final key-only configuration.
 func (b *backend) ensureOpenSSH(ctx context.Context, vmName, user string) error {
 	scriptBlock := `$ErrorActionPreference='Stop'; ` +
 		`if (-not (Get-Service -Name sshd -ErrorAction SilentlyContinue)) { ` +

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -693,8 +693,10 @@ func (b *backend) invokeInGuest(ctx context.Context, vmName, user, scriptBlock, 
 // privileged guest code, so update the URL and SHA-256 together and never use a
 // floating release. The upstream tag intentionally has no leading "v".
 const (
-	win32OpenSSHURL    = "https://github.com/PowerShell/Win32-OpenSSH/releases/download/10.0.0.0p2-Preview/OpenSSH-Win64-v10.0.0.0.msi"
-	win32OpenSSHSHA256 = "ddec9c53864280759cf9f74791cefd387100e3946aa849a1c138a4ed1b96b7d9"
+	win32OpenSSHAMD64URL    = "https://github.com/PowerShell/Win32-OpenSSH/releases/download/10.0.0.0p2-Preview/OpenSSH-Win64-v10.0.0.0.msi"
+	win32OpenSSHAMD64SHA256 = "ddec9c53864280759cf9f74791cefd387100e3946aa849a1c138a4ed1b96b7d9"
+	win32OpenSSHARM64URL    = "https://github.com/PowerShell/Win32-OpenSSH/releases/download/10.0.0.0p2-Preview/OpenSSH-ARM64-v10.0.0.0.msi"
+	win32OpenSSHARM64SHA256 = "7a17d0e22d004fb47ca4bfd8fef926fa305de4ebf70a6f3c7a29c39aabef0023"
 )
 
 // ensureOpenSSH reuses an existing service or installs the pinned, verified MSI
@@ -702,13 +704,19 @@ const (
 // rule, so stageSSHKey's pre-network block and the stop/manual steps below keep
 // it closed until injectSSHKey installs the final key-only configuration.
 func (b *backend) ensureOpenSSH(ctx context.Context, vmName, user string) error {
+	// Win32_Processor.Architecture uses 9 for x64 and 12 for ARM64.
 	scriptBlock := `$ErrorActionPreference='Stop'; ` +
 		`if (-not (Get-Service -Name sshd -ErrorAction SilentlyContinue)) { ` +
 		`[Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12; ` +
+		`$nativeArch=(Get-CimInstance Win32_Processor | Select-Object -First 1 -ExpandProperty Architecture); ` +
+		`switch ([int]$nativeArch) { ` +
+		`9 { $msiUri='` + win32OpenSSHAMD64URL + `'; $expectedHash='` + win32OpenSSHAMD64SHA256 + `' } ` +
+		`12 { $msiUri='` + win32OpenSSHARM64URL + `'; $expectedHash='` + win32OpenSSHARM64SHA256 + `' } ` +
+		`default { throw ('unsupported Windows architecture for OpenSSH: ' + $nativeArch) } }; ` +
 		`$msi=Join-Path $env:TEMP 'crabbox-openssh.msi'; ` +
-		`Invoke-WebRequest -UseBasicParsing -Uri '` + win32OpenSSHURL + `' -OutFile $msi; ` +
+		`Invoke-WebRequest -UseBasicParsing -Uri $msiUri -OutFile $msi; ` +
 		`$hash=(Get-FileHash -Path $msi -Algorithm SHA256).Hash; ` +
-		`if ($hash -ne '` + win32OpenSSHSHA256 + `') { Remove-Item $msi -Force; throw ('OpenSSH SHA-256 mismatch: got ' + $hash) }; ` +
+		`if ($hash -ne $expectedHash) { Remove-Item $msi -Force; throw ('OpenSSH SHA-256 mismatch: got ' + $hash) }; ` +
 		`$proc=Start-Process msiexec.exe -ArgumentList @('/i', ('"'+$msi+'"'), '/qn', '/norestart') -Wait -PassThru; ` +
 		`if ($proc.ExitCode -ne 0 -and $proc.ExitCode -ne 3010) { throw ('OpenSSH MSI install failed: exit ' + $proc.ExitCode) }; ` +
 		`Remove-Item $msi -Force -ErrorAction SilentlyContinue; ` +

--- a/internal/providers/hyperv/provider_test.go
+++ b/internal/providers/hyperv/provider_test.go
@@ -22,9 +22,7 @@ type recordingRunner struct {
 	errors    map[string]error
 	onRun     func(core.LocalCommandRequest)
 	respond   func(core.LocalCommandRequest) (core.LocalCommandResult, error, bool)
-	// blockUntilCtx simulates a command that blocks (like a PowerShell Direct
-	// call wedged during guest boot) until its context is canceled, mirroring
-	// execCommandRunner's exec.CommandContext kill-on-cancel behavior.
+	// blockUntilCtx simulates a command that blocks until cancellation.
 	blockUntilCtx func(core.LocalCommandRequest) bool
 }
 
@@ -1879,9 +1877,7 @@ func readinessProbe(req core.LocalCommandRequest) bool {
 	return strings.Contains(req.Args[len(req.Args)-1], "{ $true }")
 }
 
-// A guest that blocks the first probes (PowerShell Direct wedged mid-boot) then
-// answers must be bounded per attempt and retried to success, not hung. Killing
-// a blocked probe does not corrupt the guest session, so the next attempt works.
+// A blocked readiness probe must time out and retry.
 func TestWaitGuestReadyRetriesThroughBlockingBoot(t *testing.T) {
 	runner := &recordingRunner{}
 	blocked := 0
@@ -1914,8 +1910,7 @@ func TestWaitGuestReadyRetriesThroughBlockingBoot(t *testing.T) {
 	}
 }
 
-// If the guest never answers PowerShell Direct, the wait must fail cleanly at the
-// budget instead of hanging on a single wedged probe.
+// An unresponsive guest must fail at the boot budget.
 func TestWaitGuestReadyFailsAfterBudget(t *testing.T) {
 	runner := &recordingRunner{}
 	runner.blockUntilCtx = func(req core.LocalCommandRequest) bool { return readinessProbe(req) }
@@ -1948,8 +1943,7 @@ func TestWaitGuestReadyAbortsOnContextCancel(t *testing.T) {
 	}
 }
 
-// A single wedged Invoke-Command attempt must be bounded by guestInvokeTimeout
-// and retried, not left to hang the provision forever.
+// A blocked guest call must time out and retry.
 func TestInvokeInGuestBoundsBlockingAttempt(t *testing.T) {
 	runner := &recordingRunner{}
 	first := true
@@ -1986,8 +1980,7 @@ func TestInvokeInGuestAbortsOnContextCancel(t *testing.T) {
 	}
 }
 
-// The readiness gate must run before the first real guest call (the pre-network
-// SSH lockdown), so PowerShell Direct is proven up before we depend on it.
+// The readiness probe must precede the SSH lockdown.
 func TestAcquireWaitsForGuestReadyBeforeLockdown(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
@@ -2001,8 +1994,7 @@ func TestAcquireWaitsForGuestReadyBeforeLockdown(t *testing.T) {
 		if len(req.Args) == 0 {
 			return
 		}
-		// Cancel as soon as the lockdown runs so Acquire stops early; we only
-		// care about the call ordering up to that point.
+		// Stop after the lockdown; only the call order matters.
 		if strings.Contains(req.Args[len(req.Args)-1], "Crabbox-SSH-Quarantine") {
 			cancel()
 		}

--- a/internal/providers/hyperv/provider_test.go
+++ b/internal/providers/hyperv/provider_test.go
@@ -1516,7 +1516,23 @@ func TestEnsureOpenSSHInstallsWithSshdClosed(t *testing.T) {
 	if script == "" {
 		t.Fatal("ensureOpenSSH should invoke an OpenSSH install over PowerShell Direct")
 	}
-	for _, want := range []string{win32OpenSSHURL, win32OpenSSHSHA256, "Get-FileHash", "msiexec.exe", "Get-Service -Name sshd", "Stop-Service", "StartupType Manual", "Disable-NetFirewallRule"} {
+	for _, want := range []string{
+		"Get-CimInstance Win32_Processor",
+		"switch ([int]$nativeArch)",
+		"9 {",
+		win32OpenSSHAMD64URL,
+		win32OpenSSHAMD64SHA256,
+		"12 {",
+		win32OpenSSHARM64URL,
+		win32OpenSSHARM64SHA256,
+		"unsupported Windows architecture for OpenSSH",
+		"Get-FileHash",
+		"msiexec.exe",
+		"Get-Service -Name sshd",
+		"Stop-Service",
+		"StartupType Manual",
+		"Disable-NetFirewallRule",
+	} {
 		if !strings.Contains(script, want) {
 			t.Errorf("ensureOpenSSH script missing %q", want)
 		}

--- a/internal/providers/hyperv/provider_test.go
+++ b/internal/providers/hyperv/provider_test.go
@@ -22,12 +22,20 @@ type recordingRunner struct {
 	errors    map[string]error
 	onRun     func(core.LocalCommandRequest)
 	respond   func(core.LocalCommandRequest) (core.LocalCommandResult, error, bool)
+	// blockUntilCtx simulates a command that blocks (like a PowerShell Direct
+	// call wedged during guest boot) until its context is canceled, mirroring
+	// execCommandRunner's exec.CommandContext kill-on-cancel behavior.
+	blockUntilCtx func(core.LocalCommandRequest) bool
 }
 
-func (r *recordingRunner) Run(_ context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+func (r *recordingRunner) Run(ctx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 	r.calls = append(r.calls, req)
 	if r.onRun != nil {
 		r.onRun(req)
+	}
+	if r.blockUntilCtx != nil && r.blockUntilCtx(req) {
+		<-ctx.Done()
+		return core.LocalCommandResult{}, ctx.Err()
 	}
 	if r.respond != nil {
 		if result, err, ok := r.respond(req); ok {
@@ -1503,21 +1511,21 @@ func TestEnsureOpenSSHInstallsWithSshdClosed(t *testing.T) {
 	var script string
 	for _, call := range runner.calls {
 		s := call.Args[len(call.Args)-1]
-		if strings.Contains(s, "Invoke-Command") && strings.Contains(s, "OpenSSH.Server") {
+		if strings.Contains(s, "Invoke-Command") && strings.Contains(s, "crabbox-openssh.msi") {
 			script = s
 		}
 	}
 	if script == "" {
 		t.Fatal("ensureOpenSSH should invoke an OpenSSH install over PowerShell Direct")
 	}
-	for _, want := range []string{"OpenSSH.Server~~~~0.0.1.0", "Add-WindowsCapability", "Stop-Service", "StartupType Manual", "Disable-NetFirewallRule"} {
+	for _, want := range []string{win32OpenSSHURL, win32OpenSSHSHA256, "Get-FileHash", "msiexec.exe", "Get-Service -Name sshd", "Stop-Service", "StartupType Manual", "Disable-NetFirewallRule"} {
 		if !strings.Contains(script, want) {
 			t.Errorf("ensureOpenSSH script missing %q", want)
 		}
 	}
-	for _, unwanted := range []string{"OpenSSH.Server*", "Add-WindowsCapability -Online -Name $cap.Name"} {
+	for _, unwanted := range []string{"Add-WindowsCapability", "OpenSSH.Server~~~~"} {
 		if strings.Contains(script, unwanted) {
-			t.Errorf("ensureOpenSSH uses ambiguous capability selection: %s", script)
+			t.Errorf("ensureOpenSSH should no longer use Features-on-Demand: %s", script)
 		}
 	}
 	for _, unwanted := range []string{"Start-Service sshd", "New-NetFirewallRule"} {
@@ -1861,5 +1869,164 @@ func TestApplyFlagsHyperVInitPassword(t *testing.T) {
 	}
 	if !cfg.HyperV.InitPassword {
 		t.Fatal("--hyperv-init-password not applied")
+	}
+}
+
+func readinessProbe(req core.LocalCommandRequest) bool {
+	if len(req.Args) == 0 {
+		return false
+	}
+	return strings.Contains(req.Args[len(req.Args)-1], "{ $true }")
+}
+
+// A guest that blocks the first probes (PowerShell Direct wedged mid-boot) then
+// answers must be bounded per attempt and retried to success, not hung. Killing
+// a blocked probe does not corrupt the guest session, so the next attempt works.
+func TestWaitGuestReadyRetriesThroughBlockingBoot(t *testing.T) {
+	runner := &recordingRunner{}
+	blocked := 0
+	runner.blockUntilCtx = func(req core.LocalCommandRequest) bool {
+		if readinessProbe(req) && blocked < 2 {
+			blocked++
+			return true
+		}
+		return false
+	}
+	b := testBackend(runner)
+	b.guestReadyProbeTimeout = 20 * time.Millisecond
+	b.guestReadyBudget = 5 * time.Second
+	b.guestRetryBackoff = time.Millisecond
+
+	if err := b.waitGuestReady(context.Background(), "crabbox-blue-1234", "crabbox"); err != nil {
+		t.Fatalf("waitGuestReady should succeed after transient boot blocking: %v", err)
+	}
+	if blocked != 2 {
+		t.Fatalf("expected 2 blocked probes before success, got %d", blocked)
+	}
+	probes := 0
+	for _, c := range runner.calls {
+		if readinessProbe(c) {
+			probes++
+		}
+	}
+	if probes < 3 {
+		t.Fatalf("expected >=3 readiness probes (2 blocked + 1 success), got %d", probes)
+	}
+}
+
+// If the guest never answers PowerShell Direct, the wait must fail cleanly at the
+// budget instead of hanging on a single wedged probe.
+func TestWaitGuestReadyFailsAfterBudget(t *testing.T) {
+	runner := &recordingRunner{}
+	runner.blockUntilCtx = func(req core.LocalCommandRequest) bool { return readinessProbe(req) }
+	b := testBackend(runner)
+	b.guestReadyProbeTimeout = 15 * time.Millisecond
+	b.guestReadyBudget = 60 * time.Millisecond
+	b.guestRetryBackoff = time.Millisecond
+
+	err := b.waitGuestReady(context.Background(), "crabbox-blue-1234", "crabbox")
+	if err == nil {
+		t.Fatal("waitGuestReady should fail once the boot budget is exceeded")
+	}
+	if !strings.Contains(err.Error(), "did not accept PowerShell Direct") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestWaitGuestReadyAbortsOnContextCancel(t *testing.T) {
+	runner := &recordingRunner{}
+	runner.blockUntilCtx = func(core.LocalCommandRequest) bool { return true }
+	b := testBackend(runner)
+	b.guestReadyProbeTimeout = time.Second
+	b.guestReadyBudget = time.Minute
+	b.guestRetryBackoff = time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := b.waitGuestReady(ctx, "crabbox-blue-1234", "crabbox"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("waitGuestReady should return context.Canceled, got: %v", err)
+	}
+}
+
+// A single wedged Invoke-Command attempt must be bounded by guestInvokeTimeout
+// and retried, not left to hang the provision forever.
+func TestInvokeInGuestBoundsBlockingAttempt(t *testing.T) {
+	runner := &recordingRunner{}
+	first := true
+	runner.blockUntilCtx = func(core.LocalCommandRequest) bool {
+		if first {
+			first = false
+			return true
+		}
+		return false
+	}
+	b := testBackend(runner)
+	b.guestInvokeTimeout = 20 * time.Millisecond
+	b.guestRetryBackoff = time.Millisecond
+
+	if err := b.invokeInGuest(context.Background(), "crabbox-blue-1234", "crabbox", "1", "probe"); err != nil {
+		t.Fatalf("invokeInGuest should retry past a wedged attempt: %v", err)
+	}
+	if len(runner.calls) < 2 {
+		t.Fatalf("expected a retry after the bounded attempt, got %d calls", len(runner.calls))
+	}
+}
+
+func TestInvokeInGuestAbortsOnContextCancel(t *testing.T) {
+	runner := &recordingRunner{}
+	runner.blockUntilCtx = func(core.LocalCommandRequest) bool { return true }
+	b := testBackend(runner)
+	b.guestInvokeTimeout = time.Second
+	b.guestRetryBackoff = time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := b.invokeInGuest(ctx, "crabbox-blue-1234", "crabbox", "1", "probe"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("invokeInGuest should return context.Canceled, got: %v", err)
+	}
+}
+
+// The readiness gate must run before the first real guest call (the pre-network
+// SSH lockdown), so PowerShell Direct is proven up before we depend on it.
+func TestAcquireWaitsForGuestReadyBeforeLockdown(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	oldOS := hypervHostOS
+	hypervHostOS = "windows"
+	t.Cleanup(func() { hypervHostOS = oldOS })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	runner.onRun = func(req core.LocalCommandRequest) {
+		if len(req.Args) == 0 {
+			return
+		}
+		// Cancel as soon as the lockdown runs so Acquire stops early; we only
+		// care about the call ordering up to that point.
+		if strings.Contains(req.Args[len(req.Args)-1], "Crabbox-SSH-Quarantine") {
+			cancel()
+		}
+	}
+	b := testBackend(runner)
+	_, _ = b.Acquire(ctx, core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "ready-order"})
+
+	readyIdx, stageIdx := -1, -1
+	for i, call := range runner.calls {
+		if len(call.Args) == 0 {
+			continue
+		}
+		script := call.Args[len(call.Args)-1]
+		switch {
+		case readyIdx < 0 && readinessProbe(call):
+			readyIdx = i
+		case stageIdx < 0 && strings.Contains(script, "Crabbox-SSH-Quarantine") && !strings.Contains(script, "Remove-NetFirewallRule"):
+			stageIdx = i
+		}
+	}
+	if readyIdx < 0 || stageIdx < 0 {
+		t.Fatalf("missing calls: readiness=%d lockdown=%d", readyIdx, stageIdx)
+	}
+	if readyIdx >= stageIdx {
+		t.Fatalf("readiness probe (%d) must precede pre-network lockdown (%d)", readyIdx, stageIdx)
 	}
 }

--- a/skills/crabbox/SKILL.md
+++ b/skills/crabbox/SKILL.md
@@ -193,6 +193,25 @@ Native Windows targets use PowerShell and tar-based manifest sync. Prefer plain
 argv for one executable such as `dotnet test`; use `--shell` for multi-statement
 PowerShell and `--script <file.ps1>` for longer scripts.
 
+### Hyper-V Windows leases
+
+`hyperv` needs a Generation 2 VHDX, DHCP, and a known local administrator
+password in trusted config or `CRABBOX_HYPERV_GUEST_PASSWORD`. It installs
+pinned, verified OpenSSH and MinGit packages when missing, using PowerShell
+Direct. See `docs/providers/hyperv.md` for template and lifecycle details.
+
+```powershell
+crabbox run --provider hyperv --target windows `
+  --hyperv-image 'C:\Images\windows.vhdx' `
+  --timing-json --no-sync `
+  -- powershell -NoProfile -Command "whoami; hostname"
+```
+
+For provider testing, use an elevated headless/session-0 runner when possible:
+early PowerShell Direct failures can show credential UI even for non-interactive
+commands. Keep the guest password out of arguments and logs, and verify the
+lease becomes ready, runs over SSH, and releases cleanly.
+
 ## Secrets And Environment Forwarding
 
 Crabbox does not forward the whole local environment. Forwarding is name-based:

--- a/skills/crabbox/SKILL.md
+++ b/skills/crabbox/SKILL.md
@@ -200,17 +200,9 @@ password in trusted config or `CRABBOX_HYPERV_GUEST_PASSWORD`. It installs
 pinned, verified OpenSSH and MinGit packages when missing, using PowerShell
 Direct. See `docs/providers/hyperv.md` for template and lifecycle details.
 
-```powershell
-crabbox run --provider hyperv --target windows `
-  --hyperv-image 'C:\Images\windows.vhdx' `
-  --timing-json --no-sync `
-  -- powershell -NoProfile -Command "whoami; hostname"
-```
-
-For provider testing, use an elevated headless/session-0 runner when possible:
-early PowerShell Direct failures can show credential UI even for non-interactive
-commands. Keep the guest password out of arguments and logs, and verify the
-lease becomes ready, runs over SSH, and releases cleanly.
+For provider testing, prefer an elevated headless runner; early PowerShell
+Direct failures can show credential UI. Keep passwords out of arguments and
+logs, and verify the lease becomes ready, runs over SSH, and releases.
 
 ## Secrets And Environment Forwarding
 


### PR DESCRIPTION
Related provenance: https://github.com/openclaw/crabbox/pull/212

## What Problem This Solves

Fixes an issue where `crabbox run --provider hyperv` could hang indefinitely
while a new Windows guest was still booting. The first PowerShell Direct call
could block instead of failing quickly, so the retry loop never advanced and
the lease never became ready or returned an actionable error.

Plain Windows templates also could not complete provisioning when OpenSSH
Server was absent and Windows Features on Demand could not acquire its payload.
In the reproduced environment, `Add-WindowsCapability` failed with
`0x800f0950` even though the guest had general internet access.

## Why This Change Was Made

The Hyper-V provider now waits on the capability it actually needs: a trivial,
authenticated PowerShell Direct call. Each readiness attempt has a timeout, the
whole readiness loop has a five-minute budget, and every later guest call has a
generous per-attempt timeout. This keeps cold-boot retries bounded without
cutting off legitimate longer-running install steps.

OpenSSH installation now uses the pinned Win32-OpenSSH x64 MSI that the
`Microsoft.OpenSSH.Preview` winget package installs, rather than acquiring the
Windows optional feature with `Add-WindowsCapability`.

The reason is dependency control, not a preference for one download host:

- `Add-WindowsCapability` is a Features on Demand operation. Microsoft
  documents that it depends on Windows Update, matching installation media, or
  a configured network FoD source, and that WSUS, intranet update management,
  Group Policy, and isolated environments can prevent OpenSSH installation.
  Crabbox cannot generically provision a matching FoD source for every guest OS
  build and enterprise update policy.
- The plain Enterprise template used for proof had GitHub connectivity
  (`https://github.com` returned HTTP 200) but FoD installation still failed
  with `0x800f0950`, isolating the failure to the Windows servicing source
  rather than general guest networking.
- `winget` itself was not available in the plain template because
  `Microsoft.DesktopAppInstaller` was not installed. Bootstrapping App Installer
  and its AppX dependencies would add another user-context/package-management
  stack before Crabbox could install SSH.
- The winget manifest for `Microsoft.OpenSSH.Preview` 10.0.0.0 points to the
  exact MSI and SHA-256 pinned here:
  `OpenSSH-Win64-v10.0.0.0.msi`,
  `DDEC9C53864280759CF9F74791CEFD387100E3946AA849A1C138A4ED1B96B7D9`.
  Downloading that immutable asset directly preserves the requested package
  choice without requiring winget to exist in the guest.
- This follows the provider's existing MinGit bootstrap pattern: download a
  fixed upstream artifact inside the guest, verify its SHA-256 before executing
  it, and update the version and digest together. There is no floating
  `latest` lookup.

The install remains idempotent: templates that already contain an `sshd`
service skip the MSI download, including templates that pre-bake the inbox/FoD
version. For bare templates, the MSI provides one deterministic install path
instead of an FoD-first fallback with two different binary locations, firewall
behaviors, and servicing dependencies.

The MSI starts services and adds an allow rule during installation, but the
provider's pre-network `Crabbox-SSH-Quarantine` block rule is already active.
The provider immediately stops `sshd`, sets it to Manual, resolves
`sshd.exe`/`ssh-keygen.exe` from the registered service path, installs and
validates key-only configuration, rotates host keys, and removes the quarantine
only after `sshd` starts successfully.

The repo-local Crabbox skill and `docs/providers/hyperv.md` are updated with the
new template requirements, bounded PowerShell Direct readiness contract,
OpenSSH MSI bootstrap, proof workflow, and cleanup expectations so agents and
human operators do not continue relying on the old FoD behavior.

References:

- Microsoft OpenSSH FoD troubleshooting:
  https://learn.microsoft.com/troubleshoot/windows-server/system-management-components/cant-install-openssh-features
- `Microsoft.OpenSSH.Preview` winget installer manifest:
  https://github.com/microsoft/winget-pkgs/blob/master/manifests/m/Microsoft/OpenSSH/Preview/10.0.0.0/Microsoft.OpenSSH.Preview.installer.yaml
- Pinned upstream release asset:
  https://github.com/PowerShell/Win32-OpenSSH/releases/download/10.0.0.0p2-Preview/OpenSSH-Win64-v10.0.0.0.msi

## User Impact

Hyper-V leases can now bootstrap from a plain Windows template with only a
known local administrator credential. Cold boots no longer hang indefinitely,
and OpenSSH setup no longer requires Windows Update, WSUS compatibility, or a
matching Features on Demand source.

Existing templates with OpenSSH already installed keep using their existing
installation.

There are no new configuration keys or secret-handling changes. The guest
password remains environment-only and is not placed on a command line.

## Evidence

### Automated checks

All checks passed on the rebased branch with Go 1.26.4:

```text
go build ./cmd/crabbox
go build -trimpath -o <temp-output> ./cmd/crabbox
go vet ./internal/providers/hyperv/...
go vet ./...
GOOS=linux GOARCH=amd64 go vet ./...
GOOS=linux GOARCH=amd64 go build -trimpath -o <temp-output> ./cmd/crabbox
go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...  # CI Linux target
go test ./internal/providers/hyperv/...
gofmt -l <all tracked Go files>
git diff --check
node scripts/build-docs-site.mjs
```

Focused regression coverage includes:

- `TestWaitGuestReadyRetriesThroughBlockingBoot`
- `TestWaitGuestReadyFailsAfterBudget`
- `TestWaitGuestReadyAbortsOnContextCancel`
- `TestInvokeInGuestBoundsBlockingAttempt`
- `TestInvokeInGuestAbortsOnContextCancel`
- `TestAcquireWaitsForGuestReadyBeforeLockdown`
- `TestEnsureOpenSSHInstallsWithSshdClosed`
- `TestEnsureOpenSSHPasswordNotInArgs`

The local Windows host can't run the CI race suite (`CGO_ENABLED=0`, no C
compiler). A full non-race `go test ./...` also reaches an unrelated
Windows-filesystem failure in
`internal/applevmhelper.TestEnsurePrivateDirTightensExistingPermissions`
(`0777`, expected `0700`). The changed Hyper-V package suite is green; Linux
race/full-module coverage remains CI-owned.

### Live Hyper-V proof

The final code was built and exercised against a real Generation 2 Hyper-V VM
created from a freshly primed Windows template. Provisioning installed the
pinned OpenSSH MSI, configured key-only SSH, installed git, reached
`state=ready`, ran a command over SSH inside the guest, and released the lease:

```text
provisioned lease=cbx_57a4211c20b0 instance=crabbox-swift-hermit-40cbaa25 state=ready
ssh=crabbox@172.26.97.133:22
running on 172.26.97.133 powershell -NoProfile -Command 'whoami; hostname; E2E-GUEST-OK'
win-iubdi9umh9d\crabbox
WIN-IUBDI9UMH9D
E2E-GUEST-OK
command complete in 3.947s total=4.754s
run summary ... exit=0
lease cleanup stopped=true
```

The exact final branch was rerun after review fixes and again completed with
`exit=0`, guest output `E2E-GUEST-OK`, and clean lease release.

### Targeted live observations

- Before the fix, an orphaned host `powershell.exe` remained blocked on a real
  Hyper-V guest `Invoke-Command` for more than five hours.
- A controlled two-VM experiment verified that force-terminating an early
  blocked readiness probe does not corrupt subsequent PowerShell Direct
  sessions: the control first authenticated at boot+36s; the VM whose early
  blocked probe was terminated authenticated at boot+13s.
- Direct MSI validation in the guest returned `msiexec exit=0`, registered
  `sshd` and `ssh-agent`, and installed `sshd.exe` at
  `C:\Program Files\OpenSSH\sshd.exe`.
- The pinned MSI URL returned HTTP 200 with a 6,586,368-byte asset; its SHA-256
  matched both the downloaded file and the winget manifest.
- The upstream tag is intentionally `10.0.0.0p2-Preview` without a leading
  `v`; the `v`-prefixed tag returns 404.

### Independent review

The uncommitted change was reviewed repeatedly with the repository autoreview
helper using Codex (`gpt-5.6-sol`, high reasoning). Accepted findings were fixed
and revalidated. The final run reported:

```text
autoreview clean: no accepted/actionable findings reported
overall: patch is correct
```

Screenshots are not applicable to this provider/CLI change; terminal output and
real guest execution are the relevant behavioral proof.
