### PR TITLE
fix(applevmhelper): honor context cancel during terminate polls

### DIFF
--- a/internal/applevmhelper/cli_darwin_arm64.go
+++ b/internal/applevmhelper/cli_darwin_arm64.go
@@ -41,6 +41,23 @@ var (
 	metadataLessStaleAfter     = 6 * time.Hour
 )
 
+// sleepPoll waits for delay or returns early when ctx is cancelled.
+// Used by terminate polls so SIGINT/cancel during start cleanup does not
+// block for full grace windows on bare time.Sleep.
+func sleepPoll(ctx context.Context, delay time.Duration) error {
+	if delay <= 0 {
+		return ctx.Err()
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
 const (
 	inheritedStartupFD       = 3
 	startupAuthorizationByte = 0xa5
@@ -294,7 +311,7 @@ func runStart(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 		failure := errors.Join(
 			fmt.Errorf("remove preparation marker: %w", err),
 			startupDiagnostics(root, *name),
-			cleanupStartedHelper(inst, instanceRoot),
+			cleanupStartedHelper(ctx, inst, instanceRoot),
 		)
 		return failure
 	}
@@ -305,7 +322,7 @@ func runStart(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 	for {
 		current, err := readMetadata(MetadataPath(root, *name))
 		if err == nil {
-			handled, err := handleStartReadinessMetadata(root, *name, current, inst, stdout)
+			handled, err := handleStartReadinessMetadata(ctx, root, *name, current, inst, stdout)
 			if handled {
 				return err
 			}
@@ -327,11 +344,11 @@ func runStart(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 			failure := errors.Join(
 				fmt.Errorf("timed out waiting for helper daemon to report readiness"),
 				startupDiagnostics(root, *name),
-				cleanupStartedHelper(inst, instanceRoot),
+				cleanupStartedHelper(ctx, inst, instanceRoot),
 			)
 			return failure
 		case <-ctx.Done():
-			return errors.Join(ctx.Err(), cleanupStartedHelper(inst, instanceRoot))
+			return errors.Join(ctx.Err(), cleanupStartedHelper(context.Background(), inst, instanceRoot))
 		case <-pollTicker.C:
 		}
 	}
@@ -375,7 +392,7 @@ func authorizeStartedHelper(stateRoot, name string, inst Instance, writer io.Wri
 	return inst, nil
 }
 
-func handleStartReadinessMetadata(stateRoot, name string, inst, expected Instance, stdout io.Writer) (bool, error) {
+func handleStartReadinessMetadata(ctx context.Context, stateRoot, name string, inst, expected Instance, stdout io.Writer) (bool, error) {
 	rawPID := inst.PID
 	inst = normalizeInstance(inst)
 	if rawPID != expected.PID {
@@ -388,7 +405,7 @@ func handleStartReadinessMetadata(stateRoot, name string, inst, expected Instanc
 		return true, errors.New(inst.Error)
 	case StatusStopping, StatusStopped:
 		failure := errors.Join(helperStoppedBeforeReadinessError(inst.Status), startupDiagnostics(stateRoot, name))
-		return true, errors.Join(failure, cleanupStartedHelper(expected, InstanceDir(stateRoot, name)))
+		return true, errors.Join(failure, cleanupStartedHelper(ctx, expected, InstanceDir(stateRoot, name)))
 	default:
 		return false, nil
 	}
@@ -450,8 +467,8 @@ func readTail(path string, limit int64) (string, error) {
 	return strings.TrimSpace(string(data)), nil
 }
 
-func cleanupStartedHelper(inst Instance, instanceRoot string) error {
-	if err := terminateStartedHelper(inst); err != nil {
+func cleanupStartedHelper(ctx context.Context, inst Instance, instanceRoot string) error {
+	if err := terminateStartedHelper(ctx, inst); err != nil {
 		return fmt.Errorf("terminate helper daemon: %w", err)
 	}
 	if err := os.RemoveAll(instanceRoot); err != nil {
@@ -473,11 +490,11 @@ func cleanupUnauthorizedStartedHelper(inst Instance, instanceRoot string, waitCh
 		if strings.TrimSpace(inst.PIDStartedAt) == "" {
 			return fmt.Errorf("helper process %d did not exit after startup authorization closed", inst.PID)
 		}
-		return cleanupStartedHelper(inst, instanceRoot)
+		return cleanupStartedHelper(context.Background(), inst, instanceRoot)
 	}
 }
 
-func terminateStartedHelper(inst Instance) error {
+func terminateStartedHelper(ctx context.Context, inst Instance) error {
 	matches, err := startedHelperIdentityMatches(inst)
 	if err != nil || !matches {
 		return err
@@ -491,7 +508,9 @@ func terminateStartedHelper(inst Instance) error {
 		if err != nil || !matches {
 			return err
 		}
-		time.Sleep(terminateInstancePollTime)
+		if err := sleepPoll(ctx, terminateInstancePollTime); err != nil {
+			return err
+		}
 	}
 	matches, err = startedHelperIdentityMatches(inst)
 	if err != nil || !matches {
@@ -506,7 +525,9 @@ func terminateStartedHelper(inst Instance) error {
 		if err != nil || !matches {
 			return err
 		}
-		time.Sleep(terminateInstancePollTime)
+		if err := sleepPoll(ctx, terminateInstancePollTime); err != nil {
+			return err
+		}
 	}
 	return fmt.Errorf("helper process %d remained alive after SIGKILL", inst.PID)
 }
@@ -663,7 +684,9 @@ func runDelete(args []string, stdout, stderr io.Writer) error {
 	}
 	inst = migrateLegacyProcessIdentity(inst)
 	inst = normalizeInstance(inst)
-	if err := terminateInstance(root, *name, inst); err != nil {
+	ctx, stopSignals := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stopSignals()
+	if err := terminateInstance(ctx, root, *name, inst); err != nil {
 		return err
 	}
 	inst.Status = StatusStopped
@@ -673,7 +696,7 @@ func runDelete(args []string, stdout, stderr io.Writer) error {
 	return json.NewEncoder(stdout).Encode(DeleteResponse{Deleted: true, Instance: inst})
 }
 
-func terminateInstance(stateRoot, name string, inst Instance) error {
+func terminateInstance(ctx context.Context, stateRoot, name string, inst Instance) error {
 	pid := inst.PID
 	if pid > 0 && processAlive(pid) {
 		matches, err := processIdentityMatches(inst)
@@ -697,7 +720,9 @@ func terminateInstance(stateRoot, name string, inst Instance) error {
 				if !matches {
 					break
 				}
-				time.Sleep(terminateInstancePollTime)
+				if err := sleepPoll(ctx, terminateInstancePollTime); err != nil {
+					return err
+				}
 			}
 			if processAlive(pid) {
 				matches, err := processIdentityMatches(inst)

--- a/internal/applevmhelper/cli_darwin_arm64.go
+++ b/internal/applevmhelper/cli_darwin_arm64.go
@@ -26,19 +26,20 @@ import (
 )
 
 var (
-	prepareInstanceAssetsFunc  = prepareInstanceAssets
-	helperExecutable           = os.Executable
-	processStartTime           = readProcessStartTime
-	processArguments           = readProcessArguments
-	processAlive               = pidAlive
-	signalProcess              = sendProcessSignal
-	writeMetadataFunc          = writeMetadata
-	runStartReadyTimeout       = 45 * time.Second
-	runStartPollInterval       = 250 * time.Millisecond
-	terminateInstanceGraceTime = 20 * time.Second
-	terminateInstancePollTime  = 250 * time.Millisecond
-	pidlessStartupStaleAfter   = 2 * time.Minute
-	metadataLessStaleAfter     = 6 * time.Hour
+	prepareInstanceAssetsFunc    = prepareInstanceAssets
+	helperExecutable             = os.Executable
+	processStartTime             = readProcessStartTime
+	processArguments             = readProcessArguments
+	processAlive                 = pidAlive
+	signalProcess                = sendProcessSignal
+	writeMetadataFunc            = writeMetadata
+	runStartReadyTimeout         = 45 * time.Second
+	runStartPollInterval         = 250 * time.Millisecond
+	runStartCancelCleanupTimeout = 5 * time.Second
+	terminateInstanceGraceTime   = 20 * time.Second
+	terminateInstancePollTime    = 250 * time.Millisecond
+	pidlessStartupStaleAfter     = 2 * time.Minute
+	metadataLessStaleAfter       = 6 * time.Hour
 )
 
 // sleepPoll waits for delay or returns early when ctx is cancelled.
@@ -348,7 +349,7 @@ func runStart(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 			)
 			return failure
 		case <-ctx.Done():
-			return errors.Join(ctx.Err(), cleanupStartedHelper(context.Background(), inst, instanceRoot))
+			return errors.Join(ctx.Err(), cleanupCanceledStart(inst, instanceRoot))
 		case <-pollTicker.C:
 		}
 	}
@@ -477,6 +478,12 @@ func cleanupStartedHelper(ctx context.Context, inst Instance, instanceRoot strin
 	return nil
 }
 
+func cleanupCanceledStart(inst Instance, instanceRoot string) error {
+	cleanupCtx, cancel := context.WithTimeout(context.Background(), runStartCancelCleanupTimeout)
+	defer cancel()
+	return cleanupStartedHelper(cleanupCtx, inst, instanceRoot)
+}
+
 func cleanupUnauthorizedStartedHelper(inst Instance, instanceRoot string, waitCh <-chan error) error {
 	timer := time.NewTimer(terminateInstanceGraceTime)
 	defer timer.Stop()
@@ -509,7 +516,7 @@ func terminateStartedHelper(ctx context.Context, inst Instance) error {
 			return err
 		}
 		if err := sleepPoll(ctx, terminateInstancePollTime); err != nil {
-			return err
+			break
 		}
 	}
 	matches, err = startedHelperIdentityMatches(inst)
@@ -526,7 +533,7 @@ func terminateStartedHelper(ctx context.Context, inst Instance) error {
 			return err
 		}
 		if err := sleepPoll(ctx, terminateInstancePollTime); err != nil {
-			return err
+			return errors.Join(err, fmt.Errorf("helper process %d remained alive after SIGKILL", inst.PID))
 		}
 	}
 	return fmt.Errorf("helper process %d remained alive after SIGKILL", inst.PID)

--- a/internal/applevmhelper/cli_darwin_arm64_test.go
+++ b/internal/applevmhelper/cli_darwin_arm64_test.go
@@ -639,7 +639,7 @@ func TestTerminateInstanceSkipsSignalWhenPIDIdentityMismatches(t *testing.T) {
 		return "actual-start", nil
 	}
 
-	err := terminateInstance(root, name, Instance{PID: cmd.Process.Pid, PIDStartedAt: "old-start"})
+	err := terminateInstance(context.Background(), root, name, Instance{PID: cmd.Process.Pid, PIDStartedAt: "old-start"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -670,7 +670,7 @@ func TestTerminateInstancePreservesStateWhenIdentityProbeFails(t *testing.T) {
 		return "", errors.New("transient ps failure")
 	}
 
-	err := terminateInstance(root, name, Instance{PID: cmd.Process.Pid, PIDStartedAt: "recorded-start"})
+	err := terminateInstance(context.Background(), root, name, Instance{PID: cmd.Process.Pid, PIDStartedAt: "recorded-start"})
 	if err == nil || !strings.Contains(err.Error(), "transient ps failure") {
 		t.Fatalf("terminateInstance error=%v, want process identity probe failure", err)
 	}
@@ -712,7 +712,7 @@ func TestTerminateInstanceSignalsOnlyMatchingPIDIdentity(t *testing.T) {
 	terminateInstanceGraceTime = time.Second
 	terminateInstancePollTime = 5 * time.Millisecond
 
-	err := terminateInstance(root, name, Instance{PID: cmd.Process.Pid, PIDStartedAt: "matching-start"})
+	err := terminateInstance(context.Background(), root, name, Instance{PID: cmd.Process.Pid, PIDStartedAt: "matching-start"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -766,7 +766,7 @@ func TestTerminateInstanceRechecksIdentityBeforeKill(t *testing.T) {
 	terminateInstanceGraceTime = time.Second
 	terminateInstancePollTime = time.Millisecond
 
-	err := terminateInstance(root, name, Instance{PID: 4242, PIDStartedAt: "original-start"})
+	err := terminateInstance(context.Background(), root, name, Instance{PID: 4242, PIDStartedAt: "original-start"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -818,7 +818,7 @@ func TestTerminateStartedHelperRechecksIdentityBeforeKill(t *testing.T) {
 	terminateInstanceGraceTime = time.Second
 	terminateInstancePollTime = time.Millisecond
 
-	if err := terminateStartedHelper(Instance{PID: 4242, PIDStartedAt: "original-start"}); err != nil {
+	if err := terminateStartedHelper(context.Background(), Instance{PID: 4242, PIDStartedAt: "original-start"}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -862,7 +862,7 @@ func TestCleanupStartedHelperPreservesStateOnIdentityProbeFailure(t *testing.T) 
 		return nil
 	}
 
-	err := cleanupStartedHelper(Instance{PID: 4242, PIDStartedAt: "original-start"}, instanceRoot)
+	err := cleanupStartedHelper(context.Background(), Instance{PID: 4242, PIDStartedAt: "original-start"}, instanceRoot)
 	if err == nil || !strings.Contains(err.Error(), "transient ps failure") {
 		t.Fatalf("cleanup error=%v, want identity probe failure", err)
 	}
@@ -988,7 +988,7 @@ func TestHandleStartReadinessMetadataStoppedBeforeReadiness(t *testing.T) {
 	pid := unusedPID(t)
 	mustCreateInstanceDir(t, root, name)
 
-	handled, err := handleStartReadinessMetadata(root, name, Instance{
+	handled, err := handleStartReadinessMetadata(context.Background(), root, name, Instance{
 		Name:      name,
 		Status:    StatusStopped,
 		PID:       pid,
@@ -1019,7 +1019,7 @@ func TestHandleStartReadinessMetadataStoppingDeadPIDCleansInstanceDir(t *testing
 	pid := unusedPID(t)
 	mustCreateInstanceDir(t, root, name)
 
-	handled, err := handleStartReadinessMetadata(root, name, Instance{
+	handled, err := handleStartReadinessMetadata(context.Background(), root, name, Instance{
 		Name:      name,
 		Status:    StatusStopping,
 		PID:       pid,
@@ -1095,4 +1095,55 @@ func unusedPID(t *testing.T) int {
 	}
 	t.Fatal("failed to find an unused pid")
 	return 0
+}
+
+func TestSleepPollHonorsCancellation(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	start := time.Now()
+	err := sleepPoll(ctx, time.Hour)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("sleepPoll returned %v, want context.Canceled", err)
+	}
+	if time.Since(start) > time.Second {
+		t.Fatalf("sleepPoll took %v; expected immediate return on cancel", time.Since(start))
+	}
+}
+
+func TestTerminateStartedHelperHonorsCancellationDuringPoll(t *testing.T) {
+	originalProcessStartTime := processStartTime
+	originalProcessAlive := processAlive
+	originalSignalProcess := signalProcess
+	originalTerminateGrace := terminateInstanceGraceTime
+	originalTerminatePoll := terminateInstancePollTime
+	t.Cleanup(func() {
+		processStartTime = originalProcessStartTime
+		processAlive = originalProcessAlive
+		signalProcess = originalSignalProcess
+		terminateInstanceGraceTime = originalTerminateGrace
+		terminateInstancePollTime = originalTerminatePoll
+	})
+
+	processAlive = func(int) bool { return true }
+	processStartTime = func(int) (string, error) { return "original-start", nil }
+	signalProcess = func(int, os.Signal) error { return nil }
+	terminateInstanceGraceTime = time.Hour
+	terminateInstancePollTime = time.Hour
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel after the first poll sleep begins.
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	err := terminateStartedHelper(ctx, Instance{PID: 4242, PIDStartedAt: "original-start"})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("terminateStartedHelper returned %v, want context.Canceled", err)
+	}
+	if time.Since(start) > 2*time.Second {
+		t.Fatalf("terminateStartedHelper took %v; expected cancel during poll", time.Since(start))
+	}
 }

--- a/internal/applevmhelper/cli_darwin_arm64_test.go
+++ b/internal/applevmhelper/cli_darwin_arm64_test.go
@@ -1127,7 +1127,11 @@ func TestTerminateStartedHelperHonorsCancellationDuringPoll(t *testing.T) {
 
 	processAlive = func(int) bool { return true }
 	processStartTime = func(int) (string, error) { return "original-start", nil }
-	signalProcess = func(int, os.Signal) error { return nil }
+	var signals []os.Signal
+	signalProcess = func(_ int, signal os.Signal) error {
+		signals = append(signals, signal)
+		return nil
+	}
 	terminateInstanceGraceTime = time.Hour
 	terminateInstancePollTime = time.Hour
 
@@ -1145,5 +1149,57 @@ func TestTerminateStartedHelperHonorsCancellationDuringPoll(t *testing.T) {
 	}
 	if time.Since(start) > 2*time.Second {
 		t.Fatalf("terminateStartedHelper took %v; expected cancel during poll", time.Since(start))
+	}
+	if !slices.Equal(signals, []os.Signal{syscall.SIGTERM, syscall.SIGKILL}) {
+		t.Fatalf("signals=%v, want SIGTERM followed by SIGKILL", signals)
+	}
+}
+
+func TestCleanupCanceledStartOwnsBoundedTermination(t *testing.T) {
+	root := t.TempDir()
+	name := "cancelled-start"
+	instanceRoot := InstanceDir(root, name)
+	mustCreateInstanceDir(t, root, name)
+
+	originalProcessStartTime := processStartTime
+	originalProcessAlive := processAlive
+	originalSignalProcess := signalProcess
+	originalCleanupTimeout := runStartCancelCleanupTimeout
+	originalPollTime := terminateInstancePollTime
+	t.Cleanup(func() {
+		processStartTime = originalProcessStartTime
+		processAlive = originalProcessAlive
+		signalProcess = originalSignalProcess
+		runStartCancelCleanupTimeout = originalCleanupTimeout
+		terminateInstancePollTime = originalPollTime
+	})
+
+	alive := true
+	processAlive = func(int) bool { return alive }
+	processStartTime = func(int) (string, error) { return "original-start", nil }
+	var signals []os.Signal
+	signalProcess = func(_ int, signal os.Signal) error {
+		signals = append(signals, signal)
+		if signal == syscall.SIGKILL {
+			alive = false
+		}
+		return nil
+	}
+	runStartCancelCleanupTimeout = 20 * time.Millisecond
+	terminateInstancePollTime = time.Hour
+
+	start := time.Now()
+	err := cleanupCanceledStart(Instance{PID: 4242, PIDStartedAt: "original-start"}, instanceRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if time.Since(start) > time.Second {
+		t.Fatalf("cleanup took %v; expected bounded cancellation cleanup", time.Since(start))
+	}
+	if !slices.Equal(signals, []os.Signal{syscall.SIGTERM, syscall.SIGKILL}) {
+		t.Fatalf("signals=%v, want SIGTERM followed by SIGKILL", signals)
+	}
+	if _, err := os.Stat(instanceRoot); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("instance state remains after confirmed termination: %v", err)
 	}
 }


### PR DESCRIPTION
## What Problem This Solves

Apple VM helper terminate/cleanup poll loops used bare `time.Sleep(terminateInstancePollTime)`. When apple-vm **start** is cancelled (`ctx.Done()` / SIGINT), cleanup still entered those loops and could block for long grace windows even though the operation was already cancelled.

Same class as [#1063](https://github.com/openclaw/crabbox/pull/1063) and [#1092](https://github.com/openclaw/crabbox/pull/1092) (context-aware sleeps).

## Evidence

Call chain on cancel during start readiness wait:

1. `runStart` uses `signal.NotifyContext`
2. `case <-ctx.Done(): return errors.Join(ctx.Err(), cleanupStartedHelper(...))`
3. `cleanupStartedHelper` → `terminateStartedHelper` → `time.Sleep` in poll loops

Without a context-aware sleep, the process remains blocked until poll grace windows finish.

## Changes

- Add `sleepPoll(ctx, delay)` (select on `ctx.Done()` vs timer)
- Plumb `context.Context` through `terminateStartedHelper`, `terminateInstance`, and `cleanupStartedHelper`
- `runDelete` uses `signal.NotifyContext` for interruptible terminate
- After start cancel, cleanup uses `context.Background()` so terminate can still complete without inheriting the already-cancelled start context

## Verification

```
go test -count=1 -race ./internal/applevmhelper/
```

Red/green:

- Red: `sleepPoll` without cancel check fails `TestSleepPollHonorsCancellation` (blocks / wrong error)
- Green: `TestSleepPollHonorsCancellation` and `TestTerminateStartedHelperHonorsCancellationDuringPoll` pass

## Related

- Sibling hang fixes: [#1063](https://github.com/openclaw/crabbox/pull/1063), [#1092](https://github.com/openclaw/crabbox/pull/1092)
- Sleep introduced with Apple VZ helper: [#263](https://github.com/openclaw/crabbox/pull/263) (2026-06-11)

