### PR TITLE
feat(images): provision TruffleHog across platforms

### DIFF
--- a/docs/features/azure.md
+++ b/docs/features/azure.md
@@ -19,6 +19,12 @@ and Windows WSL2 when your subscription has credits or available quota. It
 follows the same ordered region fallback as AWS for brokered leases, while
 keeping Windows classes smaller than the large Linux-focused classes.
 
+Linux VMs install checksum-pinned TruffleHog 3.95.9 once during cloud-init.
+Azure uses Marketplace images rather than Crabbox-promoted developer images, so
+there is no separate Azure image publication step. Brokered environments pick
+up bootstrap changes when the coordinator Worker is deployed; direct mode picks
+them up with the updated Crabbox CLI.
+
 This page covers the `azure` VM backend. Azure Container Apps dynamic sessions
 are a separate, delegated-run backend selected with `--azure-backend
 dynamic-sessions`; see the [Provider Reference](../providers/README.md).
@@ -27,7 +33,7 @@ dynamic-sessions`; see the [Provider Reference](../providers/README.md).
 
 | Target | Brokered | Notes |
 | --- | --- | --- |
-| Linux | Yes | Cloud-init bootstrap, SSH, rsync, optional desktop/browser/code. |
+| Linux | Yes | Cloud-init bootstrap, SSH, rsync, pinned TruffleHog, optional desktop/browser/code. |
 | Windows native | Yes | Native Windows SSH/sync/run and optional desktop/VNC. No browser/code. |
 | Windows WSL2 | Yes | Nested-virtualization VM sizes; POSIX sync/run/actions hydration through WSL. |
 | macOS | No | Azure offers no managed macOS; use AWS EC2 Mac or a static SSH host. |

--- a/docs/features/image-bake-runbook.md
+++ b/docs/features/image-bake-runbook.md
@@ -320,12 +320,12 @@ scripts/mint-aws-devtools-image.sh \
   verification stops image preparation; failed Google verification skips
   Chrome and tries the distro Chromium package.
 - **Windows** (`scripts/install-windows-developer-tools.ps1`): common CLI/build
-  tooling, GitHub CLI, Node 24, corepack/pnpm, and Windows Server container
-  support with Docker Engine. It deliberately avoids Docker Desktop because
-  headless image bakes should not depend on a user-session desktop app or
-  Docker Desktop licensing. The Chocolatey package, Node MSI, and Docker Engine
-  archive are pinned to reviewed SHA-256 digests and verified before privileged
-  installation or extraction.
+  tooling, GitHub CLI, Node 24, corepack/pnpm, TruffleHog 3.95.9, and Windows
+  Server container support with Docker Engine. It deliberately avoids Docker
+  Desktop because headless image bakes should not depend on a user-session
+  desktop app or Docker Desktop licensing. The Chocolatey package, Node MSI,
+  TruffleHog archive, and Docker Engine archive are pinned to reviewed SHA-256
+  digests and verified before privileged installation or extraction.
 
 Windows developer bakes are headless by default for faster boot and fewer
 desktop-bootstrap moving parts. Pass `--desktop` only when the image must back
@@ -509,11 +509,12 @@ image generic: it verifies Command Line Tools by default, or selects an
 installed `/Applications/Xcode*.app` developer directory when
 `CRABBOX_MACOS_REQUIRE_XCODE=1`. It installs Homebrew when missing, installs
 common developer packages (Git, GitHub CLI, jq/yq, ripgrep, fd, ShellCheck,
-shfmt, Python, Node 24, pnpm via corepack), and creates `/usr/local/bin` shims
-so non-login SSH commands find those tools after the AMI boots. It does not
-download Xcode — install Xcode in a private prep hook first if the base image
-lacks it. Do not put Apple credentials, download tokens, or private package
-mirrors in this repository or in baked images.
+shfmt, Python, Node 24, pnpm via corepack), installs TruffleHog 3.95.9 from a
+reviewed SHA-256-pinned archive, and creates `/usr/local/bin` shims so non-login
+SSH commands find those tools after the AMI boots. It does not download Xcode —
+install Xcode in a private prep hook first if the base image lacks it. Do not
+put Apple credentials, download tokens, or private package mirrors in this
+repository or in baked images.
 
 ### Generic developer-tools wrapper
 

--- a/internal/cli/azure.go
+++ b/internal/cli/azure.go
@@ -43,6 +43,9 @@ const (
 	legacyAzureJammyImage             = "Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest"
 	legacyAzureNobleGen2Image         = "Canonical:0001-com-ubuntu-server-noble:24_04-lts-gen2:latest"
 	defaultAzureWindowsImage          = "MicrosoftWindowsServer:windowsserver2022:2022-datacenter-smalldisk-g2:latest"
+	azureTruffleHogVersion            = "3.95.9"
+	azureTruffleHogAMD64SHA256        = "f6d1106b85107d79527ed7a5b98b592beadd8b770dc3c9e8c1ad99e1b2cf127e"
+	azureTruffleHogARM64SHA256        = "9d9c2ec4ea36a089a9c5aaafe1969d176013ddf9f44d68e8cd75291aed8c83ed"
 	azureDeleteRetryDelay             = 15 * time.Second
 	azureDeleteRetryAttempts          = 13
 	azureSnapshotQuarantineNSGSuffix  = "-q-nsg"
@@ -1355,7 +1358,7 @@ func (c *AzureClient) azureOSProfile(cfg Config, publicKey, name, leaseID string
 		return &armcompute.OSProfile{
 			ComputerName:  to.Ptr(name),
 			AdminUsername: to.Ptr(cfg.SSHUser),
-			CustomData:    to.Ptr(base64.StdEncoding.EncodeToString([]byte(cloudInit(cfg, publicKey)))),
+			CustomData:    to.Ptr(base64.StdEncoding.EncodeToString([]byte(azureLinuxCloudInit(cfg, publicKey)))),
 			LinuxConfiguration: &armcompute.LinuxConfiguration{
 				DisablePasswordAuthentication: to.Ptr(true),
 				SSH: &armcompute.SSHConfiguration{
@@ -1382,6 +1385,42 @@ func (c *AzureClient) azureOSProfile(cfg Config, publicKey, name, leaseID string
 			ProvisionVMAgent:       to.Ptr(true),
 		},
 	}, nil
+}
+
+func azureLinuxCloudInit(cfg Config, publicKey string) string {
+	return cloudInitWithAdditionalBootstrap(cfg, publicKey, azureLinuxTruffleHogBootstrap())
+}
+
+func azureLinuxTruffleHogBootstrap() string {
+	versionPattern := strings.ReplaceAll(azureTruffleHogVersion, ".", "[.]")
+	return fmt.Sprintf(`    if ! command -v trufflehog >/dev/null 2>&1 || ! trufflehog --no-update --version | grep -Eq '(^|[[:space:]])%[1]s($|[[:space:]])'; then
+      trufflehog_version=%[2]s
+      trufflehog_arch="$(dpkg --print-architecture)"
+      case "$trufflehog_arch" in
+        amd64) trufflehog_sha256=%[3]s ;;
+        arm64) trufflehog_sha256=%[4]s ;;
+        *) echo "unsupported TruffleHog architecture: $trufflehog_arch" >&2; exit 1 ;;
+      esac
+      trufflehog_archive="trufflehog_${trufflehog_version}_linux_${trufflehog_arch}.tar.gz"
+      trufflehog_url="https://github.com/trufflesecurity/trufflehog/releases/download/v${trufflehog_version}/${trufflehog_archive}"
+      trufflehog_tmp="$(mktemp -d)"
+      retry curl -fsSL --output "$trufflehog_tmp/$trufflehog_archive" "$trufflehog_url"
+      (
+        cd "$trufflehog_tmp"
+        printf '%%s  %%s\n' "$trufflehog_sha256" "$trufflehog_archive" | sha256sum -c -
+      )
+      tar --no-same-owner -xzf "$trufflehog_tmp/$trufflehog_archive" -C "$trufflehog_tmp" trufflehog
+      trufflehog_candidate="$(mktemp /usr/local/bin/trufflehog.tmp.XXXXXX)"
+      install -m 0755 "$trufflehog_tmp/trufflehog" "$trufflehog_candidate"
+      if ! "$trufflehog_candidate" --no-update --version | grep -Eq '(^|[[:space:]])%[1]s($|[[:space:]])'; then
+        rm -f "$trufflehog_candidate"
+        rm -rf "$trufflehog_tmp"
+        exit 1
+      fi
+      mv -f "$trufflehog_candidate" /usr/local/bin/trufflehog
+      rm -rf "$trufflehog_tmp"
+    fi
+    trufflehog --no-update --version`, versionPattern, azureTruffleHogVersion, azureTruffleHogAMD64SHA256, azureTruffleHogARM64SHA256)
 }
 
 type azureSnapshotPrerequisiteResult struct {

--- a/internal/cli/azure_test.go
+++ b/internal/cli/azure_test.go
@@ -16,6 +16,26 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
 )
 
+func TestAzureLinuxCloudInitInstallsPinnedTruffleHog(t *testing.T) {
+	got := azureLinuxCloudInit(baseConfig(), "ssh-ed25519 test")
+	for _, want := range []string{
+		"trufflehog_version=3.95.9",
+		"f6d1106b85107d79527ed7a5b98b592beadd8b770dc3c9e8c1ad99e1b2cf127e",
+		"9d9c2ec4ea36a089a9c5aaafe1969d176013ddf9f44d68e8cd75291aed8c83ed",
+		"trufflehog --no-update --version",
+		"sha256sum -c -",
+		"tar --no-same-owner",
+		`mv -f "$trufflehog_candidate" /usr/local/bin/trufflehog`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("Azure Linux cloud-init missing %q", want)
+		}
+	}
+	if strings.Index(got, "sha256sum -c -") > strings.Index(got, "tar --no-same-owner") {
+		t.Fatal("Azure Linux cloud-init must verify the archive before extraction")
+	}
+}
+
 func TestParseAzureImageRef(t *testing.T) {
 	t.Parallel()
 	cases := []struct {

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -38,6 +38,10 @@ func awsUserData(cfg Config, publicKey string) string {
 }
 
 func cloudInit(cfg Config, publicKey string) string {
+	return cloudInitWithAdditionalBootstrap(cfg, publicKey, "")
+}
+
+func cloudInitWithAdditionalBootstrap(cfg Config, publicKey, additionalBootstrap string) string {
 	portLines := ""
 	for _, port := range sshPortCandidates(cfg.SSHPort, cfg.SSHFallbackPorts) {
 		portLines += fmt.Sprintf("      Port %s\n", port)
@@ -45,6 +49,12 @@ func cloudInit(cfg Config, publicKey string) string {
 	readyChecks := cloudInitOptionalReadyChecks(cfg)
 	writeFiles := cloudInitOptionalWriteFiles(cfg)
 	bootstrap := cloudInitOptionalBootstrap(cfg)
+	if additionalBootstrap != "" {
+		if bootstrap != "" {
+			bootstrap += "\n"
+		}
+		bootstrap += additionalBootstrap
+	}
 	yamlSSHUser := yamlInlineString(cfg.SSHUser)
 	yamlPublicKey := yamlInlineString(publicKey)
 	shellSSHUser := shellQuote(cfg.SSHUser)

--- a/scripts/install-linux-developer-tools.sh
+++ b/scripts/install-linux-developer-tools.sh
@@ -252,7 +252,7 @@ trufflehog_sha256_for_arch() {
 trufflehog_binary_ready() {
   local binary="$1"
   [[ -x "$binary" ]] &&
-    "$binary" --version 2>/dev/null |
+    "$binary" --no-update --version 2>/dev/null |
       awk -v version="$trufflehog_version" '
         {
           for (field = 1; field <= NF; field++) {
@@ -344,7 +344,7 @@ print_versions() {
   npm --version
   corepack --version
   pnpm --version
-  "$trufflehog_bin_dir/trufflehog" --version
+  "$trufflehog_bin_dir/trufflehog" --no-update --version
   docker --version
   docker compose version
 }

--- a/scripts/install-linux-developer-tools.test.js
+++ b/scripts/install-linux-developer-tools.test.js
@@ -640,3 +640,9 @@ test("linux developer image reports TruffleHog from the configured install direc
 	assert.equal(result.status, 0, result.stderr || result.stdout);
 	assert.match(result.stdout, /trufflehog 3\.95\.9/);
 });
+
+test("linux developer image keeps pinned TruffleHog probes update-free", () => {
+	const script = fs.readFileSync(path.join(repoRoot, "scripts/install-linux-developer-tools.sh"), "utf8");
+	assert.match(script, /"\$binary" --no-update --version/);
+	assert.match(script, /"\$trufflehog_bin_dir\/trufflehog" --no-update --version/);
+});

--- a/scripts/install-macos-developer-tools.sh
+++ b/scripts/install-macos-developer-tools.sh
@@ -8,6 +8,8 @@ python_formula="${CRABBOX_MACOS_PYTHON_FORMULA:-python@3.13}"
 require_xcode="${CRABBOX_MACOS_REQUIRE_XCODE:-0}"
 xcode_developer_dir="${CRABBOX_MACOS_XCODE_DEVELOPER_DIR:-}"
 force_links="${CRABBOX_MACOS_FORCE_LINKS:-0}"
+trufflehog_version="3.95.9"
+trufflehog_bin_dir="${CRABBOX_MACOS_TRUFFLEHOG_BIN_DIR:-/usr/local/bin}"
 homebrew_install_commit="280cbc9adffcbdef15dd1c9d991ef2d1dd7cfc9c"
 homebrew_install_sha256="f3e91784ffeda32bc397de7acc1154724cc47522a459c9ac656cca176eeba457"
 homebrew_install_url="https://raw.githubusercontent.com/Homebrew/install/${homebrew_install_commit}/install.sh"
@@ -38,6 +40,15 @@ log() {
 die() {
   log "$*"
   exit 1
+}
+
+run_as_root() {
+  if [[ "$(id -u)" -eq 0 || -w "$trufflehog_bin_dir" ]] ||
+    { [[ ! -e "$trufflehog_bin_dir" ]] && [[ -w "$(dirname "$trufflehog_bin_dir")" ]]; }; then
+    "$@"
+    return
+  fi
+  sudo "$@"
 }
 
 shell_single_quote() {
@@ -281,6 +292,80 @@ install_node_and_pnpm() {
   link_tool pnpm "$node_bin" "$corepack_bin" "$npm_bin"
 }
 
+trufflehog_arch() {
+  case "$1" in
+    x86_64 | amd64) printf '%s\n' "amd64" ;;
+    arm64 | aarch64) printf '%s\n' "arm64" ;;
+    *)
+      log "unsupported TruffleHog architecture: $1"
+      return 1
+      ;;
+  esac
+}
+
+trufflehog_sha256_for_arch() {
+  case "$1" in
+    amd64) printf '%s\n' "4306a58d25b85aad7b5fb6f5732df77c50a9161db2746b56e196649072218691" ;;
+    arm64) printf '%s\n' "944c6ea3a2993a9f808d08107b40e03ba92bc75972876a1ee47d567bfd6fa1b5" ;;
+    *)
+      log "unsupported TruffleHog architecture: $1"
+      return 1
+      ;;
+  esac
+}
+
+trufflehog_binary_ready() {
+  local binary="$1"
+  [[ -x "$binary" ]] &&
+    "$binary" --no-update --version 2>/dev/null |
+      awk -v version="$trufflehog_version" '
+        {
+          for (field = 1; field <= NF; field++) {
+            if ($field == version) {
+              found = 1
+            }
+          }
+        }
+        END { exit found ? 0 : 1 }
+      '
+}
+
+install_trufflehog() {
+  local arch archive candidate checksum target tmp_dir url
+  arch="$(trufflehog_arch "$(uname -m)")"
+  checksum="$(trufflehog_sha256_for_arch "$arch")"
+  archive="trufflehog_${trufflehog_version}_darwin_${arch}.tar.gz"
+  url="https://github.com/trufflesecurity/trufflehog/releases/download/v${trufflehog_version}/${archive}"
+  target="$trufflehog_bin_dir/trufflehog"
+
+  if trufflehog_binary_ready "$target"; then
+    log "TruffleHog $trufflehog_version is already installed"
+    return
+  fi
+
+  tmp_dir="$(mktemp -d)"
+  if ! curl -fsSL --retry 3 --output "$tmp_dir/$archive" "$url" ||
+    ! (
+      cd "$tmp_dir"
+      printf '%s  %s\n' "$checksum" "$archive" | shasum -a 256 -c -
+    ) ||
+    ! tar -xzf "$tmp_dir/$archive" -C "$tmp_dir" trufflehog; then
+    rm -rf "$tmp_dir"
+    return 1
+  fi
+
+  run_as_root mkdir -p "$trufflehog_bin_dir"
+  candidate="$(run_as_root mktemp "${target}.tmp.XXXXXX")"
+  if ! run_as_root install -m 0755 "$tmp_dir/trufflehog" "$candidate" ||
+    ! trufflehog_binary_ready "$candidate" ||
+    ! run_as_root mv -f "$candidate" "$target"; then
+    run_as_root rm -f "$candidate" || true
+    rm -rf "$tmp_dir"
+    return 1
+  fi
+  rm -rf "$tmp_dir"
+}
+
 link_common_tools() {
   local brew_prefix python_bin zshenv_line
   brew_prefix="$(brew --prefix)"
@@ -335,6 +420,7 @@ print_versions() {
   npm --version
   corepack --version
   pnpm --version
+  "$trufflehog_bin_dir/trufflehog" --no-update --version
 }
 
 if [[ "${CRABBOX_MACOS_SOURCE_ONLY:-0}" == "1" ]]; then
@@ -347,5 +433,6 @@ install_homebrew
 install_formulas
 install_node_and_pnpm
 link_common_tools
+install_trufflehog
 prepare_cache_dirs
 print_versions

--- a/scripts/install-macos-developer-tools.test.js
+++ b/scripts/install-macos-developer-tools.test.js
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -88,4 +88,73 @@ test("Homebrew and SSH shell setup remain noninteractive and idempotent", async 
   assert.match(text, /zshenv_line='export PATH="\/usr\/local\/bin:\/opt\/homebrew\/bin:\/opt\/homebrew\/sbin:\$PATH"'/);
   assert.match(text, /grep -qxF "\$zshenv_line" "\$HOME\/\.zshenv"/);
   assert.match(text, /tail -c 1 "\$HOME\/\.zshenv"/);
+});
+
+test("TruffleHog archives are pinned, verified, and atomically installed", async () => {
+  const text = await source();
+  const start = text.indexOf("install_trufflehog() {");
+  const end = text.indexOf("link_common_tools() {");
+  const installTruffleHog = text.slice(start, end);
+
+  assert.match(text, /trufflehog_version="3\.95\.9"/);
+  assert.match(text, /4306a58d25b85aad7b5fb6f5732df77c50a9161db2746b56e196649072218691/);
+  assert.match(text, /944c6ea3a2993a9f808d08107b40e03ba92bc75972876a1ee47d567bfd6fa1b5/);
+  assert.match(text, /"\$binary" --no-update --version/);
+  const download = installTruffleHog.indexOf('curl -fsSL --retry 3 --output "$tmp_dir/$archive" "$url"');
+  const verify = installTruffleHog.indexOf("shasum -a 256 -c -");
+  const extract = installTruffleHog.indexOf('tar -xzf "$tmp_dir/$archive" -C "$tmp_dir" trufflehog');
+  const validate = installTruffleHog.indexOf('trufflehog_binary_ready "$candidate"');
+  const replace = installTruffleHog.indexOf('mv -f "$candidate" "$target"');
+  assert.ok(download >= 0, "TruffleHog download must be present");
+  assert.ok(verify > download, "checksum verification must follow the download");
+  assert.ok(extract > verify, "archive extraction must follow verification");
+  assert.ok(validate > extract, "candidate validation must follow extraction");
+  assert.ok(replace > validate, "atomic replacement must follow candidate validation");
+});
+
+test("TruffleHog checksum mapping covers Intel and Apple Silicon images", () => {
+  const result = spawnSync(
+    "bash",
+    [
+      "-lc",
+      [
+        `CRABBOX_MACOS_SOURCE_ONLY=1 source ${shellQuote(script)}`,
+        "trufflehog_sha256_for_arch amd64",
+        "trufflehog_sha256_for_arch arm64",
+      ].join("; "),
+    ],
+    { encoding: "utf8" },
+  );
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /4306a58d25b85aad7b5fb6f5732df77c50a9161db2746b56e196649072218691/);
+  assert.match(result.stdout, /944c6ea3a2993a9f808d08107b40e03ba92bc75972876a1ee47d567bfd6fa1b5/);
+});
+
+test("pinned TruffleHog is reused without another download", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "crabbox-macos-trufflehog-"));
+  const trufflehog = path.join(dir, "trufflehog");
+  const curl = path.join(dir, "curl");
+  await writeFile(trufflehog, "#!/bin/sh\nprintf 'trufflehog 3.95.9\\n'\n");
+  await writeFile(curl, "#!/bin/sh\nexit 99\n");
+  await chmod(trufflehog, 0o755);
+  await chmod(curl, 0o755);
+
+  const result = spawnSync(
+    "bash",
+    [
+      "-lc",
+      [
+        `CRABBOX_MACOS_SOURCE_ONLY=1 CRABBOX_MACOS_TRUFFLEHOG_BIN_DIR=${shellQuote(dir)} source ${shellQuote(script)}`,
+        "install_trufflehog",
+      ].join("; "),
+    ],
+    {
+      encoding: "utf8",
+      env: { ...process.env, PATH: `${dir}:${process.env.PATH ?? ""}` },
+    },
+  );
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stderr, /TruffleHog 3\.95\.9 is already installed/);
 });

--- a/scripts/install-windows-developer-tools.ps1
+++ b/scripts/install-windows-developer-tools.ps1
@@ -43,6 +43,11 @@ $ChocolateyPackageURL = $env:CRABBOX_WINDOWS_CHOCO_PACKAGE_URL
 if (-not $ChocolateyPackageURL) { $ChocolateyPackageURL = "https://community.chocolatey.org/api/v2/package/chocolatey/2.7.3" }
 $ChocolateyPackageSHA256 = $env:CRABBOX_WINDOWS_CHOCO_PACKAGE_SHA256
 if (-not $ChocolateyPackageSHA256) { $ChocolateyPackageSHA256 = "40778cc59245b3eb6ea5147aeef5bea5d577419e5abce22a224189740dc16db5" }
+$TruffleHogVersion = "3.95.9"
+$TruffleHogAMD64SHA256 = "25cc731f678922c870edba49f19c324aa6c8e7190b551c4fbe49d0c4e1c5446a"
+$TruffleHogARM64SHA256 = "df982afbf72d1c1a125e4871b624b7f959b2f62caa40e4d14bf861fb93c237bb"
+$TruffleHogInstallDir = $env:CRABBOX_WINDOWS_TRUFFLEHOG_INSTALL_DIR
+if (-not $TruffleHogInstallDir) { $TruffleHogInstallDir = "C:\Program Files\TruffleHog" }
 
 function Write-Log {
   param([string]$Message)
@@ -180,6 +185,60 @@ function Enable-CorepackPnpm {
   Write-Log "activating pnpm $PnpmVersion"
   & corepack enable
   & corepack prepare "pnpm@$PnpmVersion" --activate
+}
+
+function Resolve-TruffleHogAsset {
+  $architecture = [Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
+  switch ($architecture) {
+    "X64" { return @{ Name = "amd64"; SHA256 = $TruffleHogAMD64SHA256 } }
+    "Arm64" { return @{ Name = "arm64"; SHA256 = $TruffleHogARM64SHA256 } }
+    default { throw "unsupported TruffleHog architecture: $architecture" }
+  }
+}
+
+function Test-TruffleHogBinary {
+  param([string]$Path)
+  if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) { return $false }
+  try {
+    $output = (& $Path --no-update --version 2>$null | Out-String).Trim()
+    return $LASTEXITCODE -eq 0 -and ($output -split "\s+") -contains $TruffleHogVersion
+  } catch {
+    return $false
+  }
+}
+
+function Install-TruffleHog {
+  $target = Join-Path $TruffleHogInstallDir "trufflehog.exe"
+  if (Test-TruffleHogBinary -Path $target) {
+    Write-Log "TruffleHog $TruffleHogVersion is already installed"
+    Add-MachinePath $TruffleHogInstallDir
+    return
+  }
+
+  $asset = Resolve-TruffleHogAsset
+  $archiveName = "trufflehog_$($TruffleHogVersion)_windows_$($asset.Name).tar.gz"
+  $url = "https://github.com/trufflesecurity/trufflehog/releases/download/v$TruffleHogVersion/$archiveName"
+  $workDir = Join-Path $env:TEMP ("crabbox-trufflehog-" + [Guid]::NewGuid().ToString("N"))
+  $archive = Join-Path $workDir $archiveName
+  $extractDir = Join-Path $workDir "extract"
+  $candidate = Join-Path $TruffleHogInstallDir ("trufflehog.exe.new-" + [Guid]::NewGuid().ToString("N"))
+  Write-Log "installing TruffleHog $TruffleHogVersion"
+  try {
+    New-Item -ItemType Directory -Force -Path $workDir, $extractDir, $TruffleHogInstallDir | Out-Null
+    Retry { Invoke-WebRequest -Uri $url -OutFile $archive -UseBasicParsing }
+    Assert-FileSHA256 -Path $archive -Expected $asset.SHA256 -Name "TruffleHog archive"
+    & tar.exe -xzf $archive -C $extractDir trufflehog.exe
+    if ($LASTEXITCODE -ne 0) { throw "TruffleHog archive extraction failed with exit code $LASTEXITCODE" }
+    Copy-Item -LiteralPath (Join-Path $extractDir "trufflehog.exe") -Destination $candidate -Force
+    if (-not (Test-TruffleHogBinary -Path $candidate)) {
+      throw "downloaded TruffleHog binary did not report version $TruffleHogVersion"
+    }
+    Move-Item -LiteralPath $candidate -Destination $target -Force
+  } finally {
+    Remove-Item -Force -LiteralPath $candidate -ErrorAction SilentlyContinue
+    Remove-Item -Recurse -Force -LiteralPath $workDir -ErrorAction SilentlyContinue
+  }
+  Add-MachinePath $TruffleHogInstallDir
 }
 
 function Install-StaticDockerEngine {
@@ -320,6 +379,7 @@ Refresh-SessionPath
 Install-Node
 Refresh-SessionPath
 Enable-CorepackPnpm
+Install-TruffleHog
 Install-DockerEngine
 Prepare-Caches
 Disable-FirstBootNoise
@@ -344,6 +404,7 @@ node --version
 npm --version
 corepack --version
 pnpm --version
+trufflehog --no-update --version
 if (Get-Command docker.exe -ErrorAction SilentlyContinue) {
   docker --version
 }

--- a/scripts/install-windows-developer-tools.test.js
+++ b/scripts/install-windows-developer-tools.test.js
@@ -73,3 +73,30 @@ test("Windows developer tools prep verifies the Docker archive before extraction
   assert.ok(cleanup > extract, "Docker archive cleanup must follow extraction");
   assert.ok(register > cleanup, "Docker service registration must follow verified extraction");
 });
+
+test("Windows developer tools prep verifies and atomically installs pinned TruffleHog archives", () => {
+  assert.match(script, /\$TruffleHogVersion = "3\.95\.9"/);
+  assert.match(script, /25cc731f678922c870edba49f19c324aa6c8e7190b551c4fbe49d0c4e1c5446a/);
+  assert.match(script, /df982afbf72d1c1a125e4871b624b7f959b2f62caa40e4d14bf861fb93c237bb/);
+  assert.match(script, /Resolve-TruffleHogAsset/);
+  assert.match(script, /catch \{\s+return \$false\s+\}/);
+  assert.match(script, /& \$Path --no-update --version/);
+
+  const start = script.indexOf("function Install-TruffleHog");
+  const end = script.indexOf("function Install-StaticDockerEngine");
+  const installTruffleHog = script.slice(start, end);
+  assert.match(installTruffleHog, /if \(Test-TruffleHogBinary -Path \$target\) \{/);
+  assert.match(installTruffleHog, /TruffleHog \$TruffleHogVersion is already installed/);
+  const download = installTruffleHog.indexOf("Invoke-WebRequest -Uri $url -OutFile $archive");
+  const verify = installTruffleHog.indexOf(
+    'Assert-FileSHA256 -Path $archive -Expected $asset.SHA256 -Name "TruffleHog archive"',
+  );
+  const extract = installTruffleHog.indexOf("& tar.exe -xzf $archive");
+  const validate = installTruffleHog.indexOf("Test-TruffleHogBinary -Path $candidate");
+  const replace = installTruffleHog.indexOf("Move-Item -LiteralPath $candidate -Destination $target -Force");
+  assert.ok(download >= 0, "TruffleHog download must be present");
+  assert.ok(verify > download, "checksum verification must follow the download");
+  assert.ok(extract > verify, "archive extraction must follow verification");
+  assert.ok(validate > extract, "candidate validation must follow extraction");
+  assert.ok(replace > validate, "atomic replacement must follow candidate validation");
+});

--- a/scripts/macos-image-lifecycle-smoke.sh
+++ b/scripts/macos-image-lifecycle-smoke.sh
@@ -893,6 +893,8 @@ command -v corepack
 corepack --version
 command -v pnpm
 pnpm --version
+command -v trufflehog
+trufflehog --no-update --version
 command -v python3
 python3 --version
 test -d "$HOME/crabbox"

--- a/scripts/macos-image-lifecycle-smoke.test.js
+++ b/scripts/macos-image-lifecycle-smoke.test.js
@@ -641,6 +641,8 @@ test("macOS lifecycle smoke preserves full mock lifecycle evidence", async () =>
   assert.match(fakeLog, /command -v node/);
   assert.match(fakeLog, /command -v corepack/);
   assert.match(fakeLog, /command -v pnpm/);
+  assert.match(fakeLog, /command -v trufflehog/);
+  assert.match(fakeLog, /trufflehog --no-update --version/);
   assert.match(fakeLog, /^checkpoint create --id cbx_source --name full-checkpoint --mode native --strategy image --wait --wait-timeout 60m$/m);
   assert.match(fakeLog, /^checkpoint fork chk_macos --desktop$/m);
   assert.match(fakeLog, /^checkpoint delete chk_macos$/m);

--- a/scripts/mint-aws-devtools-image.sh
+++ b/scripts/mint-aws-devtools-image.sh
@@ -463,6 +463,7 @@ if ($nodeMajor -lt 24) { throw "Node.js 24 or newer is required, found major $no
 npm --version
 corepack --version
 pnpm --version
+trufflehog --no-update --version
 docker --version
 docker version
 docker image inspect mcr.microsoft.com/windows/servercore:ltsc2022 | Out-Null
@@ -482,6 +483,8 @@ command -v node
 command -v npm
 command -v corepack
 command -v pnpm
+command -v trufflehog
+trufflehog --no-update --version
 command -v docker
 node --version
 node -e 'if (Number(process.versions.node.split(".")[0]) < 24) throw new Error(`Node.js 24 or newer is required, found ${process.version}`)'

--- a/scripts/mint-aws-devtools-image.test.js
+++ b/scripts/mint-aws-devtools-image.test.js
@@ -223,7 +223,18 @@ test("AWS devtools mint wrapper uses sg for first docker group member", async ()
     await writeFile(file, body);
     await chmod(file, 0o755);
   };
-  for (const name of ["git", "gh", "jq", "rg", "fd", "python3", "npm", "corepack", "pnpm"]) {
+  for (const name of [
+    "git",
+    "gh",
+    "jq",
+    "rg",
+    "fd",
+    "python3",
+    "npm",
+    "corepack",
+    "pnpm",
+    "trufflehog",
+  ]) {
     await writeTool(name, "#!/usr/bin/env bash\nexit 0\n");
   }
   await writeTool("node", "#!/usr/bin/env bash\n[[ \"${1:-}\" == \"--version\" ]] && printf 'v24.0.0\\n'\nexit 0\n");

--- a/scripts/mint-aws-devtools-image.test.js
+++ b/scripts/mint-aws-devtools-image.test.js
@@ -131,6 +131,15 @@ test("AWS devtools mint wrapper defaults to dry plan", async () => {
   await assert.rejects(readFile(fake.log, "utf8"));
 });
 
+test("AWS developer image smoke requires TruffleHog on Linux and Windows", async () => {
+  const text = await readFile(script, "utf8");
+  assert.match(text, /pnpm --version\ntrufflehog --no-update --version\ndocker --version/);
+  assert.match(
+    text,
+    /command -v pnpm\ncommand -v trufflehog\ntrufflehog --no-update --version\ncommand -v docker/,
+  );
+});
+
 test("AWS devtools mint wrapper runs linux source candidate and promoted proof", async () => {
   const fake = await setupFakeCrabbox();
   const result = await runScript(

--- a/worker/src/azure.ts
+++ b/worker/src/azure.ts
@@ -47,6 +47,47 @@ const LEGACY_AZURE_NOBLE_GEN2_IMAGE =
   "Canonical:0001-com-ubuntu-server-noble:24_04-lts-gen2:latest";
 const DEFAULT_AZURE_WINDOWS_IMAGE =
   "MicrosoftWindowsServer:windowsserver2022:2022-datacenter-smalldisk-g2:latest";
+const AZURE_TRUFFLEHOG_VERSION = "3.95.9";
+const AZURE_TRUFFLEHOG_AMD64_SHA256 =
+  "f6d1106b85107d79527ed7a5b98b592beadd8b770dc3c9e8c1ad99e1b2cf127e";
+const AZURE_TRUFFLEHOG_ARM64_SHA256 =
+  "9d9c2ec4ea36a089a9c5aaafe1969d176013ddf9f44d68e8cd75291aed8c83ed";
+
+export function azureLinuxCloudInit(config: LeaseConfig): string {
+  return cloudInit(config, azureLinuxTruffleHogBootstrap());
+}
+
+function azureLinuxTruffleHogBootstrap(): string {
+  const versionPattern = AZURE_TRUFFLEHOG_VERSION.replaceAll(".", "[.]");
+  return `    if ! command -v trufflehog >/dev/null 2>&1 || ! trufflehog --no-update --version | grep -Eq '(^|[[:space:]])${versionPattern}($|[[:space:]])'; then
+      trufflehog_version=${AZURE_TRUFFLEHOG_VERSION}
+      trufflehog_arch="$(dpkg --print-architecture)"
+      case "$trufflehog_arch" in
+        amd64) trufflehog_sha256=${AZURE_TRUFFLEHOG_AMD64_SHA256} ;;
+        arm64) trufflehog_sha256=${AZURE_TRUFFLEHOG_ARM64_SHA256} ;;
+        *) echo "unsupported TruffleHog architecture: $trufflehog_arch" >&2; exit 1 ;;
+      esac
+      trufflehog_archive="trufflehog_\${trufflehog_version}_linux_\${trufflehog_arch}.tar.gz"
+      trufflehog_url="https://github.com/trufflesecurity/trufflehog/releases/download/v\${trufflehog_version}/\${trufflehog_archive}"
+      trufflehog_tmp="$(mktemp -d)"
+      retry curl -fsSL --output "$trufflehog_tmp/$trufflehog_archive" "$trufflehog_url"
+      (
+        cd "$trufflehog_tmp"
+        printf '%s  %s\\n' "$trufflehog_sha256" "$trufflehog_archive" | sha256sum -c -
+      )
+      tar --no-same-owner -xzf "$trufflehog_tmp/$trufflehog_archive" -C "$trufflehog_tmp" trufflehog
+      trufflehog_candidate="$(mktemp /usr/local/bin/trufflehog.tmp.XXXXXX)"
+      install -m 0755 "$trufflehog_tmp/trufflehog" "$trufflehog_candidate"
+      if ! "$trufflehog_candidate" --no-update --version | grep -Eq '(^|[[:space:]])${versionPattern}($|[[:space:]])'; then
+        rm -f "$trufflehog_candidate"
+        rm -rf "$trufflehog_tmp"
+        exit 1
+      fi
+      mv -f "$trufflehog_candidate" /usr/local/bin/trufflehog
+      rm -rf "$trufflehog_tmp"
+    fi
+    trufflehog --no-update --version`;
+}
 
 function azureOwnedDeleteClaimKey(providerScope: string, cloudID: string, leaseID: string): string {
   return ["provider:azure:delete-claim", providerScope, cloudID, leaseID]
@@ -1140,7 +1181,9 @@ export class AzureClient {
       { lroTimeoutMs: DEFAULT_AZURE_NETWORK_LRO_TIMEOUT_MS },
     );
     const customData = btoa(
-      config.target === "windows" ? azureWindowsBootstrapPowerShell(config) : cloudInit(config),
+      config.target === "windows"
+        ? azureWindowsBootstrapPowerShell(config)
+        : azureLinuxCloudInit(config),
     );
     const storageProfile: Record<string, unknown> = {};
     const vmProperties: Record<string, unknown> = {

--- a/worker/src/bootstrap.ts
+++ b/worker/src/bootstrap.ts
@@ -52,7 +52,7 @@ function base64Encode(bytes: Uint8Array): string {
   return btoa(chunks.join(""));
 }
 
-export function cloudInit(config: LeaseConfig): string {
+export function cloudInit(config: LeaseConfig, additionalBootstrap = ""): string {
   if (config.awsPrivate) {
     return privateAWSCloudInit(config);
   }
@@ -62,7 +62,7 @@ export function cloudInit(config: LeaseConfig): string {
   const readyChecks = optionalReadyChecks(config);
   const sshHostKeys = optionalSSHHostKeys(config);
   const writeFiles = optionalWriteFiles(config);
-  const bootstrap = optionalBootstrap(config);
+  const bootstrap = [optionalBootstrap(config), additionalBootstrap].filter(Boolean).join("\n");
   return `#cloud-config
 package_update: false
 package_upgrade: false

--- a/worker/test/azure.test.ts
+++ b/worker/test/azure.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   AzureClient,
+  azureLinuxCloudInit,
   azureLabelsFromTags,
   azureLROPollIntervalMS,
   azureProvisioningErrorCategory,
@@ -33,6 +34,21 @@ const baseEnv: Env = {
 };
 
 afterEach(() => vi.useRealTimers());
+
+it("installs pinned TruffleHog once in Azure Linux cloud-init", () => {
+  const got = azureLinuxCloudInit(testLeaseConfig());
+
+  expect(got).toContain(
+    "trufflehog/releases/download/v${trufflehog_version}/${trufflehog_archive}",
+  );
+  expect(got).toContain("f6d1106b85107d79527ed7a5b98b592beadd8b770dc3c9e8c1ad99e1b2cf127e");
+  expect(got).toContain("9d9c2ec4ea36a089a9c5aaafe1969d176013ddf9f44d68e8cd75291aed8c83ed");
+  expect(got).toContain("trufflehog --no-update --version");
+  expect(got.indexOf("sha256sum -c -")).toBeLessThan(got.indexOf("tar --no-same-owner"));
+  expect(got.indexOf('trufflehog_candidate="$(mktemp')).toBeLessThan(
+    got.indexOf('mv -f "$trufflehog_candidate" /usr/local/bin/trufflehog'),
+  );
+});
 
 function isAzureLoginURL(value: string): boolean {
   return new URL(value).hostname === "login.microsoftonline.com";


### PR DESCRIPTION
## What Problem This Solves

Crabbox's Linux developer image installs TruffleHog, but fresh macOS and Windows developer images and Azure Linux VMs do not. Those environments therefore cannot run the shared autoreview secret preflight without manual setup.

## Why This Change Was Made

- Adds checksum-pinned TruffleHog 3.95.9 installers for macOS and Windows amd64/arm64 image preparation.
- Adds the same pinned Linux bootstrap to Azure cloud-init in both direct CLI and broker Worker provisioning paths.
- Extends AWS Linux, Windows, and macOS candidate/promoted smoke checks to require TruffleHog.
- Disables TruffleHog self-update in validation and smoke probes so image contents remain pinned.
- Documents that Azure uses Marketplace images and receives this change through bootstrap source deployment rather than an image-promotion lifecycle.

## User Impact

Newly minted AWS developer images and newly provisioned Azure Linux VMs include TruffleHog before agent work begins. The installer is not part of autoreview invocation, and rerunning macOS preparation reuses an already-correct pinned binary.

Merging this PR updates source only. AWS image publication remains an explicit administrator operation, and the broker Worker must deploy before brokered Azure leases receive the new bootstrap.

## Evidence

- `node --test scripts/install-linux-developer-tools.test.js scripts/install-macos-developer-tools.test.js scripts/install-windows-developer-tools.test.js scripts/macos-image-lifecycle-smoke.test.js scripts/mint-aws-devtools-image.test.js`
  - 47 passed
- `go test ./internal/cli -run 'TestAzureLinuxCloudInitInstallsPinnedTruffleHog|TestAzure'`
- `npm test --prefix worker -- azure.test.ts`
  - 55 passed
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `go vet ./internal/cli`
- Real macOS arm64 archive proof: checksum verified, `trufflehog 3.95.9`, second invocation preserved binary hash and mtime.
- `.agents/skills/autoreview/scripts/autoreview --mode local`
  - no accepted/actionable findings; one reported Windows PATH concern was rejected because `Add-MachinePath` updates both machine PATH and the current process PATH before final validation.
