### PR TITLE
fix(apple-container): honor explicit guest architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Fixed
 
+- Forwarded explicit ARM64 and AMD64 guest architecture selections to Apple Container while preserving the implicit native ARM64 path.
 - Made `cp` over resolved SSH prefer rsync secluded arguments whenever the remote rsync supports them, so remote paths travel over the rsync protocol instead of the remote shell command line. This sidesteps an upstream rsync 3.4.4 `safe_arg()` bug that appends one uninitialized heap byte after a backslash-escaped wildcard (e.g. `\[`), which intermittently corrupted remote copy paths; remotes without secluded-args support (such as macOS openrsync) keep the previous shell-transported behavior. Thanks @zozo123.
 - Kept Cloud Run sandbox creation and cleanup fail-closed: indeterminate creates retain exact recovery claims while definitive conflicts drop provisional ownership, cleanup serializes against active work and concurrent reclaim, absolute lease TTLs are enforced, failed destroys remain tracked and reported for retry, direct payloads travel on stdin instead of argv, and remote gateways must confirm durable routing plus synchronous deletion. Thanks @zozo123.
 - Bound GitHub OAuth callbacks independently to each initiating browser flow and bound sessions, durable ownership, admin grants, and revocations to immutable GitHub account IDs instead of reassignable emails or logins, with a fail-closed operator recovery path for legacy records. Thanks @zozo123.

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -512,7 +512,7 @@ lease-acting commands):
 --provider <name>            See `crabbox providers` for the full list.
 --profile <name>
 --class <name>
---arch amd64|arm64           CPU architecture; arm64 supports Linux on AWS/Azure and native Windows on Azure.
+--arch amd64|arm64           CPU architecture; arm64 supports Linux on AWS/Azure/Apple Container and native Windows on Azure.
 --os <selector>              Portable Linux OS image, e.g. ubuntu:26.04
 --type <provider-type>
 --market spot|on-demand

--- a/docs/commands/warmup.md
+++ b/docs/commands/warmup.md
@@ -254,7 +254,7 @@ warmup, because it also dispatches the workflow and waits for the ready marker.
 --provider <name>                  provider (see crabbox providers); default hetzner
 --profile <name>                   configuration profile
 --class <name>                     machine class; default beast
---arch amd64|arm64                 CPU architecture; arm64 supports Linux on AWS/Azure and native Windows on Azure
+--arch amd64|arm64                 CPU architecture; arm64 supports Linux on AWS/Azure/Apple Container and native Windows on Azure
 --os ubuntu:26.04|ubuntu:24.04     portable Linux OS image selector
 --type <provider-type>             provider server/instance type
 --market spot|on-demand            capacity market (AWS)

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -98,7 +98,7 @@ broker:
 
 provider: aws            # default provider when --provider is unset
 target: linux            # default target OS: linux | macos | windows
-architecture: amd64      # amd64 | arm64; arm64 supports Linux on AWS/Azure and native Windows on Azure
+architecture: amd64      # amd64 | arm64; arm64 supports Linux on AWS/Azure/Apple Container and native Windows on Azure
 os: ubuntu:26.04         # OS image; resolved to per-provider images for linux
 windows:
   mode: normal           # normal | wsl2 when target=windows
@@ -1096,8 +1096,9 @@ ignored. The `serverType:` and `--type` paths intentionally do not fall back;
 they fail loud if the provider rejects the type.
 
 Set `architecture: arm64` (or `--arch arm64`) for Linux ARM capacity on AWS or
-Azure. Explicit ARM provider types also select matching ARM Linux images when
-no provider-specific image override is set.
+Azure. Apple Container defaults to native ARM64 and also accepts explicit ARM64
+or AMD64 guest selection. Explicit ARM cloud provider types select matching ARM
+Linux images when no provider-specific image override is set.
 
 ## Environment variables
 

--- a/docs/features/jobs.md
+++ b/docs/features/jobs.md
@@ -143,7 +143,7 @@ windows:
   mode: wsl2           # normal | wsl2; sets --windows-mode
 profile: project-check
 class: beast
-architecture: amd64    # amd64 | arm64; arm64 supports Linux on AWS/Azure and native Windows on Azure
+architecture: amd64    # amd64 | arm64; arm64 supports Linux on AWS/Azure/Apple Container and native Windows on Azure
 type: m8i.4xlarge      # alias: serverType
 market: on-demand      # alias: capacity.market
 network: auto

--- a/docs/providers/apple-container.md
+++ b/docs/providers/apple-container.md
@@ -55,6 +55,9 @@ need stronger host separation, larger capacity, or shared team infrastructure.
 container system status
 crabbox run --provider apple-container -- pnpm test
 
+crabbox run --provider apple-container --arch arm64 -- uname -m
+crabbox run --provider apple-container --arch amd64 -- uname -m
+
 crabbox warmup --provider apple --slug apple-smoke
 crabbox run --provider apple --id apple-smoke -- pnpm test:changed
 crabbox ssh --provider apple --id apple-smoke
@@ -74,6 +77,7 @@ crabbox run --provider apple-container \
 ```yaml
 provider: apple-container
 target: linux
+architecture: arm64        # native default; set amd64 for an x86_64 guest
 appleContainer:
   cliPath: container        # path to Apple's container CLI
   image: ubuntu:26.04       # base image; defaults to the Crabbox OS image (--os)
@@ -89,6 +93,10 @@ default (follows `--os`; currently `ubuntu:26.04`), `user=crabbox`,
 `workRoot=/work/crabbox`, SSH port `22`. If provider code is constructed
 directly without the normal config layer, an empty `appleContainer.image` falls
 back to the same Crabbox OS image default.
+
+The implicit guest architecture is native `arm64`. Explicit `--arch arm64` and
+`--arch amd64` selections are forwarded to `container run --arch`, so the
+reported Crabbox architecture matches the guest runtime architecture.
 
 Provider flags:
 

--- a/internal/cli/os_image.go
+++ b/internal/cli/os_image.go
@@ -95,7 +95,7 @@ func effectiveArchitectureForConfig(cfg Config) string {
 	if cfg.architectureExplicit {
 		return cfg.Architecture
 	}
-	if cfg.Provider == "apple-vm" || cfg.Provider == "applevm" || cfg.Provider == "lume" || cfg.Provider == "local-lume" || cfg.Provider == "lume-macos" || cfg.Provider == "aws-lambda-microvm" {
+	if cfg.Provider == "apple-container" || cfg.Provider == "apple" || cfg.Provider == "applecontainer" || cfg.Provider == "apple-vm" || cfg.Provider == "applevm" || cfg.Provider == "lume" || cfg.Provider == "local-lume" || cfg.Provider == "lume-macos" || cfg.Provider == "aws-lambda-microvm" {
 		return ArchitectureARM64
 	}
 	if cfg.TargetOS == targetLinux || cfg.TargetOS == targetWindows {

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -163,8 +163,8 @@ func validateProviderTarget(cfg Config) error {
 		return exit(2, "provider=%s supports architecture=arm64 only", provider.Name())
 	}
 	if machineTarget && effectiveArchitectureForConfig(cfg) == ArchitectureARM64 {
-		if provider.Name() != "azure" && provider.Name() != "aws" && provider.Name() != "tart" && provider.Name() != "apple-vm" && provider.Name() != "lume" && provider.Name() != "aws-lambda-microvm" && provider.Name() != "external" {
-			return exit(2, "architecture=arm64 currently supports provider=azure, provider=aws, provider=tart, provider=apple-vm, provider=lume, provider=aws-lambda-microvm, or provider=external")
+		if !providerSupportsARM64(provider.Name()) {
+			return exit(2, "architecture=arm64 currently supports provider=azure, provider=aws, provider=tart, provider=apple-container, provider=apple-vm, provider=lume, provider=aws-lambda-microvm, or provider=external")
 		}
 		if cfg.TargetOS != targetLinux &&
 			!(provider.Name() == "azure" && cfg.TargetOS == targetWindows) &&
@@ -208,6 +208,15 @@ func validateProviderTarget(cfg Config) error {
 		return nil
 	}
 	return nil
+}
+
+func providerSupportsARM64(name string) bool {
+	switch name {
+	case "azure", "aws", "tart", "apple-container", "apple-vm", "lume", "aws-lambda-microvm", "external":
+		return true
+	default:
+		return false
+	}
 }
 
 func validateProviderTargetSupport(cfg Config) (Provider, error) {

--- a/internal/cli/target_test.go
+++ b/internal/cli/target_test.go
@@ -263,6 +263,26 @@ func TestValidateProviderTargetRejectsAppleVMExplicitAMD64(t *testing.T) {
 	}
 }
 
+func TestValidateProviderTargetDefaultsAppleContainerToARM64(t *testing.T) {
+	for _, provider := range []string{"apple-container", "apple", "applecontainer"} {
+		cfg := baseConfig()
+		cfg.Provider = provider
+		cfg.TargetOS = targetLinux
+		if got := effectiveArchitectureForConfig(cfg); got != ArchitectureARM64 {
+			t.Errorf("provider=%s effective architecture=%q want arm64", provider, got)
+		}
+	}
+}
+
+func TestProviderSupportsARM64IncludesAppleContainer(t *testing.T) {
+	if !providerSupportsARM64("apple-container") {
+		t.Fatal("apple-container should support ARM64")
+	}
+	if providerSupportsARM64("apple-machine") {
+		t.Fatal("apple-machine should remain conservative until upstream AMD64 support is proven")
+	}
+}
+
 func TestValidateProviderTargetDefaultsAWSLambdaMicroVMToARM64(t *testing.T) {
 	cfg := baseConfig()
 	cfg.Provider = "aws-lambda-microvm"

--- a/internal/providers/applecontainer/backend.go
+++ b/internal/providers/applecontainer/backend.go
@@ -454,6 +454,9 @@ func (b *backend) createContainer(ctx context.Context, cfg core.Config, name, le
 		"-e", "CRABBOX_WORK_ROOT=" + cfg.AppleContainer.WorkRoot,
 		"-e", "CRABBOX_SSH_PORT=" + sshPort,
 	}
+	if core.IsArchitectureExplicit(cfg) {
+		args = append(args, "--arch", cfg.Architecture)
+	}
 	for i, volume := range cfg.Cache.Volumes {
 		args = append(args, "-e", fmt.Sprintf("CRABBOX_CACHE_VOLUME_PATH_%d=%s", i, strings.TrimSpace(volume.Path)))
 	}
@@ -854,7 +857,8 @@ func (b *backend) serverFromContainer(c inspectContainer, cfg core.Config) core.
 }
 
 // checkRunSurface verifies the `container run` subcommand exists and advertises
-// the options the lease path depends on (`--user`, `--label`, `--dns`). It uses
+// the options the lease path depends on (`--user`, `--label`, `--dns`, and
+// `--arch` when architecture was explicit). It uses
 // `run --help`, which has no side effects, so doctor can detect an incompatible
 // CLI before any lease is attempted.
 func (b *backend) checkRunSurface(ctx context.Context) error {
@@ -863,7 +867,11 @@ func (b *backend) checkRunSurface(ctx context.Context) error {
 		return exit(2, "%s `container run` subcommand unavailable (incompatible container CLI?): %s", providerName, commandDetail(result, err))
 	}
 	help := result.Stdout + result.Stderr
-	for _, opt := range []string{"--user", "--label", "--dns"} {
+	required := []string{"--user", "--label", "--dns"}
+	if core.IsArchitectureExplicit(b.configForRun()) {
+		required = append(required, "--arch")
+	}
+	for _, opt := range required {
 		if !strings.Contains(help, opt) {
 			return exit(2, "%s `container run` is missing the required %s option; upgrade Apple's container CLI", providerName, opt)
 		}

--- a/internal/providers/applecontainer/backend_test.go
+++ b/internal/providers/applecontainer/backend_test.go
@@ -235,6 +235,43 @@ func TestCreateContainerBuildsRunArgs(t *testing.T) {
 	if strings.Count(args, "--dns") != 1 {
 		t.Fatalf("custom DNS should not be duplicated:\n%s", args)
 	}
+	if strings.Contains(args, "--arch") {
+		t.Fatalf("implicit native architecture should not add --arch:\n%s", args)
+	}
+}
+
+func TestCreateContainerForwardsExplicitArchitecture(t *testing.T) {
+	for _, architecture := range []string{core.ArchitectureARM64, core.ArchitectureAMD64} {
+		t.Run(architecture, func(t *testing.T) {
+			configPath := filepath.Join(t.TempDir(), "config.yaml")
+			contents := "provider: apple-container\ntarget: linux\narchitecture: " + architecture + "\n"
+			if err := os.WriteFile(configPath, []byte(contents), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("CRABBOX_CONFIG", configPath)
+			cfg, err := core.LoadConfig()
+			if err != nil {
+				t.Fatal(err)
+			}
+			cfg.AppleContainer = core.AppleContainerConfig{
+				CLIPath:  "container",
+				Image:    "debian:bookworm",
+				User:     "runner",
+				WorkRoot: "/work/crabbox",
+			}
+			runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+				commandKey([]string{"run"}): {Stdout: "crabbox-blue\n"},
+			}}
+			b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}).(*backend)
+			if _, err := b.createContainer(context.Background(), b.configForRun(), "crabbox-blue", "cbx_123", "blue-lobster", "ssh-ed25519 AAAA test", true); err != nil {
+				t.Fatal(err)
+			}
+			args := recordedArgsForCommand(t, runner, "run")
+			if !strings.Contains(args, "--arch\n"+architecture) {
+				t.Fatalf("explicit architecture missing from run args:\n%s", args)
+			}
+		})
+	}
 }
 
 func TestCreateContainerAddsHostDNS(t *testing.T) {
@@ -986,6 +1023,27 @@ func TestDoctorRejectsIncompatibleRunCLI(t *testing.T) {
 		}
 		if _, err := testBackend(runner).Doctor(context.Background(), core.DoctorRequest{}); err == nil {
 			t.Fatal("doctor passed despite run lacking --dns")
+		}
+	})
+	t.Run("explicit architecture needs arch option", func(t *testing.T) {
+		configPath := filepath.Join(t.TempDir(), "config.yaml")
+		if err := os.WriteFile(configPath, []byte("provider: apple-container\ntarget: linux\narchitecture: arm64\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("CRABBOX_CONFIG", configPath)
+		cfg, err := core.LoadConfig()
+		if err != nil {
+			t.Fatal(err)
+		}
+		runner := &recordingRunner{
+			responses: map[string]core.LocalCommandResult{
+				commandKey([]string{"system", "status"}): {Stdout: "running\n"},
+				commandKey([]string{"run", "--help"}):    {Stdout: "OPTIONS:\n  -u, --user <user>\n  --label <label>\n  --dns <server>\n"},
+			},
+		}
+		b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}).(*backend)
+		if _, err := b.Doctor(context.Background(), core.DoctorRequest{}); err == nil || !strings.Contains(err.Error(), "--arch") {
+			t.Fatalf("doctor error=%v, want missing --arch", err)
 		}
 	})
 }


### PR DESCRIPTION
Fixes #1182.

Apple Container now treats its implicit guest as native ARM64 and forwards explicit ARM64 and AMD64 selections to Apple container run. Doctor verifies the architecture option only when an architecture was explicitly requested; Apple Machine remains conservative.

Verification:

- go test -race ./internal/cli ./internal/providers/applecontainer
- go vet ./internal/cli ./internal/providers/applecontainer
- node scripts/build-docs-site.mjs
- .agents/skills/autoreview/scripts/autoreview --mode local
