### PR TITLE
ci: publish developer images through Actions

### DIFF
--- a/.github/workflows/devtools-image-publish.yml
+++ b/.github/workflows/devtools-image-publish.yml
@@ -1,0 +1,212 @@
+name: Publish Developer Image
+run-name: Publish ${{ inputs.target }} developer image in ${{ inputs.region }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Developer image platform
+        required: true
+        type: choice
+        options:
+          - linux
+          - windows
+          - macos
+      region:
+        description: AWS region
+        required: true
+        default: eu-west-1
+        type: string
+      linux_type:
+        description: Linux source instance type
+        required: true
+        default: m7i.large
+        type: string
+      windows_type:
+        description: Windows source instance type
+        required: true
+        default: m7i.large
+        type: string
+      macos_type:
+        description: macOS source instance type
+        required: true
+        default: mac-m4.metal
+        type: string
+      macos_host:
+        description: Use an available EC2 Mac host or allocate one
+        required: true
+        default: use-existing
+        type: choice
+        options:
+          - use-existing
+          - allocate
+
+permissions:
+  contents: read
+
+concurrency:
+  group: devtools-image-publish-${{ inputs.target }}
+  cancel-in-progress: false
+
+jobs:
+  guard:
+    name: Guard protected publication
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require the protected default-branch workflow
+        shell: bash
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          REF_PROTECTED: ${{ github.ref_protected }}
+          RUN_SHA: ${{ github.sha }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+        run: |
+          set -euo pipefail
+          expected_ref="refs/heads/$DEFAULT_BRANCH"
+          expected_workflow_ref="$GITHUB_REPOSITORY/.github/workflows/devtools-image-publish.yml@$expected_ref"
+          [[ "$GITHUB_EVENT_NAME" == workflow_dispatch ]]
+          [[ "$GITHUB_REF" == "$expected_ref" ]]
+          [[ "$GITHUB_WORKFLOW_REF" == "$expected_workflow_ref" ]]
+          [[ "$REF_PROTECTED" == true ]]
+          [[ "$WORKFLOW_SHA" == "$RUN_SHA" ]]
+
+      - name: Validate publication inputs
+        shell: bash
+        env:
+          TARGET: ${{ inputs.target }}
+          REGION: ${{ inputs.region }}
+          LINUX_TYPE: ${{ inputs.linux_type }}
+          WINDOWS_TYPE: ${{ inputs.windows_type }}
+          MACOS_TYPE: ${{ inputs.macos_type }}
+          MACOS_HOST: ${{ inputs.macos_host }}
+        run: |
+          set -euo pipefail
+          [[ "$TARGET" =~ ^(linux|windows|macos)$ ]]
+          [[ "$REGION" =~ ^[a-z]{2}(-gov)?-[a-z]+-[0-9]+$ ]]
+          [[ "$LINUX_TYPE" =~ ^[A-Za-z0-9.-]+$ ]]
+          [[ "$WINDOWS_TYPE" =~ ^[A-Za-z0-9.-]+$ ]]
+          [[ "$MACOS_TYPE" =~ ^[A-Za-z0-9.-]+$ ]]
+          [[ "$MACOS_HOST" =~ ^(use-existing|allocate)$ ]]
+
+  publish:
+    name: Build, smoke, and promote
+    needs: guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    environment: image-publisher
+    env:
+      CRABBOX_COORDINATOR: ${{ vars.CRABBOX_COORDINATOR }}
+      CRABBOX_COORDINATOR_TOKEN: ${{ secrets.CRABBOX_COORDINATOR_ADMIN_TOKEN }}
+      CRABBOX_COORDINATOR_ADMIN_TOKEN: ${{ secrets.CRABBOX_COORDINATOR_ADMIN_TOKEN }}
+      CRABBOX_OWNER: image-publisher@openclaw.invalid
+      CRABBOX_ORG: openclaw
+      CRABBOX_ACCESS_CLIENT_ID: ${{ secrets.CRABBOX_ACCESS_CLIENT_ID }}
+      CRABBOX_ACCESS_CLIENT_SECRET: ${{ secrets.CRABBOX_ACCESS_CLIENT_SECRET }}
+      TARGET: ${{ inputs.target }}
+      REGION: ${{ inputs.region }}
+      LINUX_TYPE: ${{ inputs.linux_type }}
+      WINDOWS_TYPE: ${{ inputs.windows_type }}
+      MACOS_TYPE: ${{ inputs.macos_type }}
+      MACOS_HOST: ${{ inputs.macos_host }}
+    steps:
+      - name: Verify publisher configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "$CRABBOX_COORDINATOR" ]]; then
+            echo "::error::Set the CRABBOX_COORDINATOR variable on the image-publisher environment."
+            exit 1
+          fi
+          if [[ -z "$CRABBOX_COORDINATOR_ADMIN_TOKEN" ]]; then
+            echo "::error::Set the CRABBOX_COORDINATOR_ADMIN_TOKEN secret on the image-publisher environment."
+            exit 1
+          fi
+
+      - name: Check out protected source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Build trusted Crabbox CLI
+        run: go build -trimpath -o bin/crabbox ./cmd/crabbox
+
+      - name: Publish and prove image
+        shell: bash
+        env:
+          CRABBOX_IMAGE_LOG_DIR: ${{ runner.temp }}/devtools-image-proof/aws
+          CRABBOX_MACOS_ARTIFACT_DIR: ${{ runner.temp }}/devtools-image-proof/macos
+        run: |
+          set -euo pipefail
+          proof_dir="$RUNNER_TEMP/devtools-image-proof"
+          mkdir -p "$proof_dir"
+          case "$TARGET" in
+            linux)
+              command=(
+                scripts/mint-aws-devtools-image.sh
+                --target linux
+                --region "$REGION"
+                --class standard
+                --type "$LINUX_TYPE"
+                --run
+              )
+              ;;
+            windows)
+              command=(
+                scripts/mint-aws-devtools-image.sh
+                --target windows
+                --region "$REGION"
+                --class standard
+                --type "$WINDOWS_TYPE"
+                --windows-mode normal
+                --run
+              )
+              ;;
+            macos)
+              command=(
+                scripts/mint-macos-devtools-image.sh
+                --region "$REGION"
+                --type "$MACOS_TYPE"
+                "--$MACOS_HOST"
+              )
+              ;;
+          esac
+          printf 'Publishing from protected commit %s\n' "$GITHUB_SHA"
+          printf 'Command:'
+          printf ' %q' "${command[@]}"
+          printf '\n'
+          "${command[@]}" 2>&1 | tee "$proof_dir/publish.log"
+
+      - name: Summarize publication
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Developer image publication"
+            echo
+            echo "- Target: \`$TARGET\`"
+            echo "- Region: \`$REGION\`"
+            echo "- Source commit: \`$GITHUB_SHA\`"
+            if [[ -f "$RUNNER_TEMP/devtools-image-proof/publish.log" ]]; then
+              echo
+              echo "### Result"
+              grep -E 'candidate AMI smoke passed|promoted (linux|windows) developer image passed|promoted macOS image lifecycle passed' \
+                "$RUNNER_TEMP/devtools-image-proof/publish.log" || true
+            fi
+          } >>"$GITHUB_STEP_SUMMARY"
+
+      - name: Upload publication proof
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: devtools-image-${{ inputs.target }}-${{ github.run_id }}
+          path: ${{ runner.temp }}/devtools-image-proof
+          if-no-files-found: error
+          retention-days: 30

--- a/docs/features/image-bake-runbook.md
+++ b/docs/features/image-bake-runbook.md
@@ -257,6 +257,47 @@ crabbox image fsr-status ami-1234567890abcdef0 --region us-west-2 --json
 FSR is AWS-only. Treat snapshot warmup as a separate provider-cost decision; do
 not enable it casually for every candidate.
 
+## GitHub Actions publication
+
+Merging an installer or image-wrapper change updates the source recipe only. It
+does not create or promote an AWS image. Actual publication is a successful
+`Publish Developer Image` workflow run, which executes the same source smoke,
+candidate smoke, promotion, and promoted-image smoke described below.
+
+Configure the `image-publisher` GitHub environment with:
+
+- the `CRABBOX_COORDINATOR` environment variable;
+- the `CRABBOX_COORDINATOR_ADMIN_TOKEN` environment secret;
+- `CRABBOX_ACCESS_CLIENT_ID` and `CRABBOX_ACCESS_CLIENT_SECRET` environment
+  secrets when the coordinator is behind Cloudflare Access.
+
+Add required reviewers to that environment so paid image creation and
+fleet-wide promotion need explicit administrator approval. Dispatch one
+platform at a time from the protected default branch:
+
+```bash
+gh workflow run devtools-image-publish.yml \
+  --ref main \
+  -f target=linux \
+  -f region=eu-west-1
+
+gh workflow run devtools-image-publish.yml \
+  --ref main \
+  -f target=windows \
+  -f region=eu-west-1
+
+gh workflow run devtools-image-publish.yml \
+  --ref main \
+  -f target=macos \
+  -f region=eu-west-1 \
+  -f macos_host=use-existing
+```
+
+Use `macos_host=allocate` only when no suitable EC2 Mac Dedicated Host is
+available. The workflow uploads its complete mint logs and macOS lifecycle
+evidence as a 30-day Actions artifact. A failed candidate or promoted-image
+smoke fails the workflow and leaves the previous promoted image selected.
+
 ## Developer-image wrappers
 
 For generic AWS Linux and Windows developer AMIs, use the guarded wrapper

--- a/scripts/devtools-image-workflow.test.js
+++ b/scripts/devtools-image-workflow.test.js
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const workflow = fs.readFileSync(
+  path.join(repoRoot, ".github", "workflows", "devtools-image-publish.yml"),
+  "utf8",
+);
+
+test("developer image publication is a protected manual admin workflow", () => {
+  assert.match(workflow, /^  workflow_dispatch:$/m);
+  assert.doesNotMatch(workflow, /^  (?:push|pull_request|schedule):/m);
+  assert.match(workflow, /environment: image-publisher/);
+  assert.match(
+    workflow,
+    /expected_workflow_ref="\$GITHUB_REPOSITORY\/\.github\/workflows\/devtools-image-publish\.yml@\$expected_ref"/,
+  );
+  assert.match(workflow, /\[\[ "\$GITHUB_REF" == "\$expected_ref" \]\]/);
+  assert.match(workflow, /\[\[ "\$REF_PROTECTED" == true \]\]/);
+  assert.match(workflow, /\[\[ "\$WORKFLOW_SHA" == "\$RUN_SHA" \]\]/);
+  assert.match(workflow, /ref: \$\{\{ github\.workflow_sha \}\}/);
+  assert.match(workflow, /persist-credentials: false/);
+  assert.match(workflow, /cancel-in-progress: false/);
+});
+
+test("publication uses the existing source candidate promotion proof wrappers", () => {
+  assert.match(workflow, /scripts\/mint-aws-devtools-image\.sh[\s\S]*--target linux[\s\S]*--run/);
+  assert.match(workflow, /scripts\/mint-aws-devtools-image\.sh[\s\S]*--target windows[\s\S]*--windows-mode normal[\s\S]*--run/);
+  assert.match(workflow, /scripts\/mint-macos-devtools-image\.sh[\s\S]*"--\$MACOS_HOST"/);
+  assert.doesNotMatch(workflow, /--no-promote/);
+  assert.match(workflow, /go build -trimpath -o bin\/crabbox \.\/cmd\/crabbox/);
+});
+
+test("publication keeps credentials environment-scoped and retains proof", () => {
+  assert.match(workflow, /CRABBOX_COORDINATOR: \$\{\{ vars\.CRABBOX_COORDINATOR \}\}/);
+  assert.equal(
+    (workflow.match(/secrets\.CRABBOX_COORDINATOR_ADMIN_TOKEN/g) ?? []).length,
+    2,
+  );
+  assert.doesNotMatch(workflow, /AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY/);
+  assert.match(workflow, /name: Upload publication proof[\s\S]*if: always\(\)/);
+  assert.match(workflow, /if-no-files-found: error/);
+  assert.match(workflow, /retention-days: 30/);
+});


### PR DESCRIPTION
## What Problem This Solves

Merging developer-tool installer changes updates the image recipe but does not rebuild or promote the AWS images used by Crabbox. Publication currently depends on an administrator running local one-off commands, so source and promoted images can drift without a durable Actions proof trail.

## Why This Change Was Made

Add a protected, administrator-gated `Publish Developer Image` workflow that:

- publishes one selected Linux, Windows, or macOS image from protected `main`;
- builds the trusted Crabbox CLI from the workflow commit;
- runs the existing source smoke, candidate smoke, promotion, and promoted-image smoke wrappers;
- scopes coordinator credentials to an `image-publisher` environment;
- uploads the complete publication proof for 30 days.

The runbook now states explicitly that source merge is not image publication and documents the required environment configuration and dispatch commands.

## User Impact

Administrators can publish and verify developer images from GitHub Actions instead of an untracked local shell session. Nothing is promoted merely because source merged; promotion happens only after environment approval and successful candidate proof.

## Evidence

- `actionlint .github/workflows/devtools-image-publish.yml`
- `node --test scripts/devtools-image-workflow.test.js scripts/mint-aws-devtools-image.test.js scripts/macos-image-lifecycle-smoke.test.js` (26 passed)
- `scripts/check-docs.sh`
- `git diff --check`
- autoreview: clean, no accepted/actionable findings
