### PR TITLE
docs: clarify use cases, costs, and runtime boundaries

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,215 +1,100 @@
-# 🦀 Crabbox Docs
+# Crabbox
 
-**Warm a box, sync the diff, run the suite.**
+**Run any repository command in the right box.**
 
-## What Crabbox is
+## What Crabbox Is
 
-Crabbox is a generic remote software testing and execution control plane. It
-keeps the local developer story unchanged: edit, save, run. The difference is
-where the command executes. Crabbox moves tests, builds, browser checks,
-platform validation, and review evidence onto owned or provider-backed remote
-capacity, then streams the result back to the caller.
-
-It is for maintainers, contributors, and automation that need a repeatable way
-to run repository commands on a machine other than the local laptop. A
-`crabbox run` leases a brokered cloud machine, reuses a static SSH host, or
-delegates to a sandbox provider; syncs your tracked, non-ignored local files;
-executes the command remotely; streams stdout and stderr back; records evidence;
-and then releases or unclaims the target.
-
-Use Crabbox when local compute is too small or slow, when a workflow needs a
-fresh disposable runner, when the target platform is remote, or when an AI agent
-or reviewer needs auditable command output from the exact environment that ran.
-It is not a CI service, a package manager, a production deployment platform, a
-hostile multi-tenant sandbox, or a tool that automatically sanitizes secrets
-from command output and artifacts.
-
-An optional coordinator owns cloud provider credentials, lease state, cleanup,
-usage accounting, and cost guardrails so individual machines and CLIs never
-hold those. The coordinator runs either on Cloudflare Workers with a Durable
-Object or on Node.js with PostgreSQL.
-
-The Node runtime can also own a
-[dedicated private AWS workspace service](features/aws-private-workspaces.md):
-small allowlisted EC2 instances, no public address or SSH, task-role
-credentials, SSM bootstrap, and an authenticated create/status/delete API.
-
-## How it fits together
-
-```text
-your laptop                 coordinator runtime              cloud provider
--------------               -------------------              --------------
-crabbox CLI    -- HTTPS --> Cloudflare + Durable Object  --> Hetzner / AWS / Azure / GCP / Daytona
-   |                      or Node.js + PostgreSQL              |
-   |                                                           |
-   +------------- SSH + rsync to leased runner <---------------+
-```
-
-The CLI is a Go binary (`cmd/crabbox`, `internal/cli`). Shared coordinator
-behavior lives in `worker/src`; Cloudflare and Node/PostgreSQL provide runtime
-adapters. For normal CLI leases, lifecycle calls go through the coordinator
-over HTTPS, but the data plane — SSH, rsync, and command execution — goes
-**directly from the CLI to the runner host**. The dedicated private AWS
-workspace API is the documented SSM-only exception. Runners hold no coordinator
-credentials; they are leaf nodes.
-
-Crabbox selects one of three execution modes per provider:
-
-- **Brokered** — for `aws`, `azure`, `daytona`, `gcp`, and `hetzner` when a
-  broker URL is configured (`CRABBOX_COORDINATOR`). The coordinator provisions
-  and tracks leases; the CLI still drives sync and command execution over SSH.
-- **Direct SSH** — the same SSH-lease providers without a broker, plus static
-  hosts (`provider: ssh`) and self-hosted/local providers. The CLI talks to the
-  cloud or host API itself.
-- **Delegated** — sandbox/proof runners (for example dynamic-session and
-  Firecracker providers) that own sync and run end to end; there is no SSH lease.
-
-Brokered Linux runners are vanilla Ubuntu boxes prepared by cloud-init with SSH,
-Git, rsync, and `/work/crabbox`. AWS and Azure can also broker Windows
-(normal and WSL2) and, on AWS, EC2 Mac desktop targets. Project runtimes come
-from Actions hydration or repo-owned setup.
-
-## A run, end to end
-
-1. The CLI loads config from flags, env, repo, user, and defaults.
-2. The CLI mints a per-lease SSH key and slug, then `POST /v1/leases` on the
-   broker (brokered mode) or provisions directly (direct mode).
-3. The coordinator checks active-lease and monthly spend caps, reserves
-   worst-case TTL cost, provisions a server with region/market fallback, and
-   returns host / port / user / workdir / expiry / slug.
-4. The CLI waits for the `crabbox-ready` marker, seeds remote Git when possible,
-   rsyncs the Git file-list manifest, runs sync guardrails, and hydrates the
-   configured base ref.
-5. The CLI runs the command over SSH, streams output, records run events, and
-   sends heartbeats.
-6. The CLI releases the lease unless `--keep` is set. Kept leases still
-   auto-release after the idle timeout, and the broker frees reserved cost when
-   the lease closes.
-
-See [How Crabbox Works](how-it-works.md) for the full picture, including
-warm-box reuse and the brokered-vs-direct paths. See the
-[Source Map](source-map.md) to trace any documented behavior back to code.
-
-## Install
+Crabbox keeps the edit-and-run loop on your laptop while moving execution to a
+local sandbox, cloud VM, existing SSH host, managed developer environment, or
+hosted agent sandbox. Depending on the selected provider, it syncs the checkout
+or hands the workload to a provider-owned execution contract, returns available
+output and evidence, and releases owned capacity when cleanup is supported.
 
 ```sh
-brew install openclaw/tap/crabbox
-```
-
-Verify with `crabbox --version`.
-
-## Quick start
-
-```sh
-# log in once per machine — stores a broker token in user config
-crabbox login --url https://broker.example.com
-
-# one-shot run on a fresh leased box
 crabbox run -- pnpm test
-
-# keep a warm box around for repeated runs; output includes an id and a slug
-crabbox warmup
-crabbox run --id swift-crab -- pnpm test:changed
-crabbox ssh --id swift-crab
-crabbox stop swift-crab
 ```
 
-Each lease has a canonical id (`cbx_<12 hex>`) and a friendly slug
-(`<adjective>-<noun>`); most commands accept either via `--id`. Run
-`crabbox doctor` to validate local config, broker/provider reachability, and SSH
-key availability before a long workflow, and `crabbox usage` to summarize recent
-spend by user, org, provider, and server type.
+## One Loop, Many Kinds of Box
 
-## Where to read next
+Every run follows the same basic path:
 
-Pick whichever matches your intent:
+1. **Choose** a provider directly or ask Crabbox to recommend one for the job.
+2. **Lease or reuse** a short-lived box, sandbox, VM, or host.
+3. **Sync or hand off** the workload according to the provider's execution
+   contract.
+4. **Run** the command and stream its output.
+5. **Collect available proof and apply cleanup** according to the provider's
+   capabilities and the run policy.
 
-- **Start here:** [Getting started](getting-started.md),
-  [How Crabbox Works](how-it-works.md),
-  [Concepts and glossary](concepts.md).
-- **Get the mental model:** [Vision](vision.md),
-  [Architecture](architecture.md), [Orchestrator](orchestrator.md),
-  [Runtime adapter stack](features/runtime-adapter-stack.md),
-  [Broker auth and routing](features/broker-auth-routing.md),
-  [Coordinator](features/coordinator.md),
-  [Bring your own infrastructure](features/bring-your-own-infrastructure.md),
-  [Slurm academic sandboxes](features/slurm-academic-sandboxes.md).
-- **Deploy the coordinator:** [Infrastructure](infrastructure.md),
-  [Portable coordinator](features/portable-coordinator.md),
-  [Operations](operations.md), [Security](security.md).
-- **Use the CLI:** [CLI overview](cli.md),
-  [Command reference](commands/README.md),
-  [Feature reference](features/README.md),
-  [Configuration](features/configuration.md), [Jobs](features/jobs.md),
-  [Pond](features/pond.md),
-  [Actions hydration](features/actions-hydration.md),
-  [Capsules](features/capsules.md), [Checkpoints](features/checkpoints.md),
-  [Browser portal](features/portal.md),
-  [Runtime adapter stack](features/runtime-adapter-stack.md),
-  [Capabilities](features/capabilities.md),
-  [Interactive desktop and VNC](features/interactive-desktop-vnc.md),
-  [Telemetry](features/telemetry.md), [Sync](features/sync.md),
-  [Hermetic agent evidence](features/hermetic-agent-evidence.md).
-- **Integrate tools:** [Integration catalog](integrations/README.md),
-  [Editors and control surfaces](integrations/editors.md),
-  [AI agents and harnesses](integrations/agents.md),
-  [Integration authoring](integrations/authoring.md).
-- **Pick or add a target:** [Provider reference](providers/README.md),
-  [Provider selection](features/provider-selection.md),
-  [Provider landscape](features/provider-landscape.md),
-  [Provider live smoke](features/provider-live-smoke.md),
-  [Provider authoring](features/provider-authoring.md),
-  [Provider backends](provider-backends.md),
-  [Capacity fallback](features/capacity-fallback.md),
-  [Slurm academic sandboxes](features/slurm-academic-sandboxes.md),
-  [Network](features/network.md), [Tailscale](features/tailscale.md).
-  Per-provider: [AWS](providers/aws.md), [Azure](providers/azure.md),
-  [Azure Dynamic Sessions](providers/azure-dynamic-sessions.md),
-  [Google Cloud](providers/gcp.md), [Hetzner](providers/hetzner.md),
-  [DigitalOcean](providers/digitalocean.md), [Linode](providers/linode.md),
-  [Vultr](providers/vultr.md), [Proxmox](providers/proxmox.md),
-  [XCP-ng](providers/xcp-ng.md),
-  [Incus](providers/incus.md), [Parallels](providers/parallels.md),
-  [Local Container](providers/local-container.md),
-  [Multipass](providers/multipass.md),
-  [Static SSH](providers/ssh.md), [Railway](providers/railway.md),
-  [RunPod](providers/runpod.md),
-  [Blacksmith Testbox](providers/blacksmith-testbox.md),
-  [KubeVirt](providers/kubevirt.md), [External](providers/external.md),
-  [Namespace Devbox](providers/namespace-devbox.md),
-  [Namespace Compute Instance](providers/namespace-instance.md),
-  [Semaphore](providers/semaphore.md), [Sprites](providers/sprites.md),
-  [Tenki](providers/tenki.md),
-  [Coder](providers/coder.md),
-  [Daytona](providers/daytona.md), [Islo](providers/islo.md),
-  [E2B](providers/e2b.md), [Modal](providers/modal.md),
-  [Agent Sandbox](providers/agent-sandbox.md),
-  [OpenComputer](providers/opencomputer.md),
-  [Freestyle](providers/freestyle.md),
-  [Anthropic Sandbox Runtime](providers/anthropic-sandbox-runtime.md),
-  [Tensorlake](providers/tensorlake.md), [Upstash Box](providers/upstash-box.md),
-  [Weights & Biases](providers/wandb.md), [Cloudflare](providers/cloudflare.md).
-- **Operate it:** [Operations](operations.md),
-  [Observability](observability.md), [Troubleshooting](troubleshooting.md),
-  [Performance](performance.md), [Cost and usage](features/cost-usage.md),
-  [Lifecycle and cleanup](features/lifecycle-cleanup.md).
-- **Set it up or audit it:** [Infrastructure](infrastructure.md),
-  [Portable coordinator](features/portable-coordinator.md),
-  [Security](security.md), [Auth and admin](features/auth-admin.md),
-  [Repository onboarding](features/repository-onboarding.md),
-  [SSH keys](features/ssh-keys.md), [Source Map](source-map.md).
+The execution substrate can change without turning the workflow into a
+provider-specific script. Start with [Use Cases](use-cases.md) when you know the
+job but not the provider, or browse the [Provider Reference](providers/README.md)
+when you already know where the work should run.
 
-## About these docs
+## Start Here
 
-Markdown in this directory is the user-facing documentation source.
-Implementation truth stays in code; the [Source Map](source-map.md) lists the
-files behind each documented behavior. The documentation site at
-<https://crabbox.sh/> is generated from these Markdown files by
-`scripts/build-docs-site.mjs` and deployed by `.github/workflows/pages.yml`.
-Pages must be enabled on the repository or organization for the workflow to
-publish.
+- [Getting Started](getting-started.md) — install the CLI and complete a first
+  remote run.
+- [Use Cases](use-cases.md) — choose a workflow such as fast feedback, agent
+  execution, cross-platform validation, browser QA, fan-out, or GPU work.
+- [Pricing and Costs](pricing.md) — understand the current open-source,
+  bring-your-own-compute cost model and its guardrails.
+- [How Crabbox Works](how-it-works.md) — follow a run across the CLI,
+  coordinator, and runner.
 
-Build and check the docs site locally:
+## Pick an Operating Model
+
+| Path | Best For | Ownership |
+| --- | --- | --- |
+| Local runtime | Fast, credential-free development checks | Your workstation and local runtime |
+| Direct cloud or SSH | Personal cloud accounts, private hosts, and self-hosted virtualization | Your provider account or infrastructure |
+| Team coordinator | Shared credentials, leases, cleanup, usage, and spend caps | Your Cloudflare or Node.js/PostgreSQL deployment |
+| Delegated execution | Provider-shaped agent, CI, browser, or GPU runs | The selected provider or self-hosted runtime operator |
+
+Crabbox software is MIT-licensed. It does not currently publish a hosted
+control-plane plan; provider compute and any coordinator infrastructure are
+billed by their respective operators. See [Pricing and Costs](pricing.md) for
+the exact boundary.
+
+## Trust Boundary
+
+Crabbox is a developer execution tool, not one uniform security sandbox.
+Isolation depends on the selected runtime. A local container with the host
+Docker socket, a managed microVM, a shared team VM, and a provider-owned sandbox
+have different boundaries.
+
+Use [Provider Selection](features/provider-selection.md) to route a workload,
+then read that provider's documentation before running unfamiliar or untrusted
+code. The recommendation command is workflow guidance, not a security
+certification.
+
+## Go Deeper
+
+- **CLI and configuration:** [CLI](cli.md),
+  [Command Reference](commands/README.md),
+  [Configuration](features/configuration.md), and
+  [Repository Onboarding](features/repository-onboarding.md).
+- **Fleet and operations:** [Architecture](architecture.md),
+  [Infrastructure](infrastructure.md), [Operations](operations.md),
+  [Observability](observability.md), and [Security](security.md).
+- **Runs and evidence:** [Jobs](features/jobs.md),
+  [Actions Hydration](features/actions-hydration.md),
+  [Artifacts](features/artifacts.md), [Checkpoints](features/checkpoints.md),
+  and [Interactive Desktop and VNC](features/interactive-desktop-vnc.md).
+- **Platform boundaries:** [Nested Execution](features/nested-execution.md)
+  distinguishes WSL2, container engines, prepared KVM hosts, and local
+  sandboxes.
+- **Extensibility:** [Integration Catalog](integrations/README.md),
+  [Provider Authoring](features/provider-authoring.md), and
+  [Source Map](source-map.md).
+
+## About These Docs
+
+The Markdown in `docs/` is the user-facing source for
+[crabbox.sh](https://crabbox.sh/). Implementation truth stays in code; the
+[Source Map](source-map.md) traces documented behavior back to its owner.
+
+Build and validate the site locally:
 
 ```sh
 scripts/check-docs.sh

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -46,6 +46,8 @@ live in the [Command Reference](../commands/README.md).
 - [Mediated egress](egress.md): browser/app egress through an operator machine
   using the coordinator mediator.
 - [Runner bootstrap](runner-bootstrap.md): cloud-init, installed tools, SSH port, and readiness.
+- [Nested execution](nested-execution.md): WSL2, container engines, prepared KVM
+  hosts, and their conditional boundaries.
 - [Prebaked runner images](prebaked-images.md): image storage and the image/cache/state boundary.
 - [Image bake runbook](image-bake-runbook.md): exact bake, candidate smoke, promotion, rollback, and cleanup flow.
 - [SSH keys](ssh-keys.md): per-lease keys, cleanup, and local storage.

--- a/docs/features/nested-execution.md
+++ b/docs/features/nested-execution.md
@@ -1,0 +1,159 @@
+# Nested Execution
+
+Read this when you need WSL2 or a container engine inside a Crabbox target, want
+to run microVMs on a prepared KVM host, or are comparing those shapes with a
+local sandbox.
+
+“Nested box” can describe several different systems. They do not have the same
+requirements or security boundary, so Crabbox should not expose them as one
+universal promise.
+
+## What Works Today
+
+| Shape | Current Crabbox Path | Boundary |
+| --- | --- | --- |
+| Linux tooling inside a Windows VM | Managed AWS or Azure with `--target windows --windows-mode wsl2` | WSL2 on compatible nested-virtualization capacity |
+| A container engine available inside the workload | Prepare it on an SSH/VM image, or opt into Local Container host socket pass-through | Depends on the engine; the socket controls the host engine and is often host-root-equivalent with a rootful daemon |
+| A full VM or microVM on a prepared KVM host | Run Crabbox on that host with `--provider firecracker`; reaching a remote outer host does not add inner-VM lifecycle | Provider, instance family, host kernel, and policy dependent |
+| A sandbox or VM on the developer machine | Use a local provider such as Local Container, Apple VM, Multipass, Hyper-V, Parallels, Windows Sandbox, or Docker Sandbox | Runs beside the CLI; not necessarily nested inside another Crabbox lease |
+
+There is no provider-neutral `--nested` flag today. WSL2 is a first-class target
+contract. Generic nested KVM, Hyper-V, or container-in-container capability is
+not yet represented as one guaranteed provider feature.
+
+Crabbox also does not expose a parent/child lease API. A runner cannot ask the
+coordinator for bounded child Crabbox leases; that would be control-plane
+delegation, not nested virtualization.
+
+## WSL2 Inside a Managed Windows Box
+
+AWS and Azure can provision Windows instances on VM families that expose the
+virtualization support WSL2 needs:
+
+```sh
+crabbox warmup --provider aws \
+  --target windows \
+  --windows-mode wsl2
+
+crabbox run --id blue-lobster -- uname -a
+```
+
+Crabbox enables the required Windows features, updates WSL, verifies the pinned
+Ubuntu root filesystem checksum, imports it, reboots as needed, and proves the
+POSIX contract by running the Linux-side readiness setup.
+
+This is not available on every instance type or architecture. Defaults use the
+documented WSL2 candidate lists, and AWS rejects unsupported explicit instance
+types. An operator-selected exact Azure VM size remains operator-validated;
+warmup fails if the selected size does not expose nested virtualization. The
+first warmup is slower than a normal Linux lease because Windows features,
+updates, and imports can require multiple reboots.
+
+See [Windows VNC and WSL2](vnc-windows.md), [AWS](../providers/aws.md), and
+[Azure](../providers/azure.md) for the supported families and current
+limitations.
+
+## Containers Inside a Box
+
+There are three common patterns:
+
+1. **Engine installed in a full VM.** Bake Docker, containerd, Podman, or another
+   engine into the image and use a normal SSH lease. The inner containers share
+   the leased VM's kernel.
+2. **Host socket pass-through.** Local Container can mount the host Docker
+   socket with `--local-container-docker-socket`. This is convenient for build
+   and integration tests, but access to the socket is effectively control of
+   the host engine. Do not present it as a hostile-code isolation boundary.
+3. **Container-in-container.** A privileged inner daemon may work on a prepared
+   host, but it needs kernel features, storage, network, and security policy that
+   Crabbox does not currently standardize across providers.
+
+Use a dedicated VM or microVM boundary when the inner workload must not control
+the host container engine.
+
+## KVM or MicroVMs Inside a Box
+
+A Linux guest can launch KVM, Firecracker, QEMU/KVM, or another hardware-backed
+runtime only when all outer layers expose the required virtualization
+extensions. At minimum, verify:
+
+```sh
+test -r /dev/kvm
+test -w /dev/kvm
+```
+
+The cloud instance family must support nested virtualization; the account and
+image must allow it; the guest kernel must expose `/dev/kvm`; and the workload
+still needs networking, images, storage, cleanup, and an isolation policy.
+
+Crabbox's `firecracker` provider is currently a direct provider for a Linux KVM
+host running the CLI. It does not automatically turn an arbitrary cloud lease
+into a nested Firecracker host. Run Crabbox itself on the prepared Linux KVM
+host with `--provider firecracker`. The `ssh` and `external` providers can reach
+a prepared outer host, but inner virtualization must then be invoked and
+managed by the workload; Crabbox has no generic remote nested-VM lifecycle.
+
+## Local VM and Sandbox Options
+
+Local providers solve a related problem without nesting everything inside a
+remote lease:
+
+- **Local Container** — Docker-compatible Linux containers with normal Crabbox
+  SSH and sync.
+- **Apple VM** — full ARM64 Linux VM through Apple's
+  `Virtualization.framework` on Apple Silicon.
+- **Multipass** — Canonical-managed local Ubuntu VM.
+- **Hyper-V** — local native Windows VM on a compatible Windows host.
+- **Parallels** — local Linux, macOS, native Windows, and preconfigured
+  Windows/WSL2 templates with checkpoint and fork support.
+- **Windows Sandbox, Docker Sandbox, Apple Container, and local policy
+  runtimes** — delegated local execution with provider-specific boundaries.
+
+Use:
+
+```sh
+crabbox providers recommend local
+crabbox providers recommend offline-validation
+```
+
+to inspect the current local choices.
+
+## Capability Boundary
+
+Nested support is conditional on the target OS, architecture, instance type,
+region, image, and outer-host policy. A provider-wide “nested virtualization”
+claim would overstate AWS, Azure, or GCP support.
+
+Today, request WSL2 explicitly and let warmup prove its POSIX readiness. For KVM
+or Firecracker, run Crabbox on the prepared host and verify `/dev/kvm` there.
+Crabbox has no generic nested-capability resolver or provider-neutral preflight.
+
+## Security Notes
+
+- Nesting does not automatically improve isolation. Every additional daemon,
+  hypervisor, socket, and management API adds a boundary that must be patched
+  and configured.
+- Passing a host container socket into a box weakens the boundary even when the
+  outer container looks disposable.
+- A VM family advertising nested virtualization says that the CPU feature is
+  exposed; it does not certify the inner runtime, network policy, or cleanup.
+- Do not place provider credentials inside a leaf runner when the coordinator
+  or an external lifecycle service can own them.
+
+## External References
+
+- [AWS EC2 nested virtualization](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/amazon-ec2-nested-virtualization.html)
+- [Google Compute Engine nested virtualization](https://cloud.google.com/compute/docs/instances/nested-virtualization/overview)
+- [Microsoft nested Hyper-V](https://learn.microsoft.com/en-us/windows-server/virtualization/hyper-v/nested-virtualization)
+- [Microsoft WSL FAQ](https://learn.microsoft.com/en-us/windows/wsl/faq)
+- [Docker rootless mode](https://docs.docker.com/engine/security/rootless/)
+- [Firecracker production host setup](https://github.com/firecracker-microvm/firecracker/blob/main/docs/prod-host-setup.md)
+
+## Related Docs
+
+- [Use Cases](../use-cases.md)
+- [Provider Selection](provider-selection.md)
+- [Windows VNC and WSL2](vnc-windows.md)
+- [Local Container](../providers/local-container.md)
+- [Firecracker](../providers/firecracker.md)
+- [Security](../security.md)

--- a/docs/pricing.md
+++ b/docs/pricing.md
@@ -1,0 +1,79 @@
+# Pricing and Costs
+
+Crabbox is open-source software and does not meter or resell compute today.
+There is no single Crabbox per-minute price: runtime costs remain with your
+workstation, infrastructure account, or selected provider.
+
+## Current Price Boundary
+
+| Component | Current Cost | Who Bills It |
+| --- | --- | --- |
+| Crabbox CLI and coordinator software | **$0 license fee** under MIT | Nobody |
+| Local containers, VMs, and sandboxes | Existing workstation and runtime cost | You or the local runtime vendor |
+| Direct cloud VMs and GPU capacity | Provider's current rate | Your cloud or compute provider |
+| Hosted sandboxes and dev environments | Provider's plan and usage rate | The selected sandbox provider |
+| Cloudflare coordinator | Your Worker, Durable Object, storage, and related usage | Cloudflare |
+| Node.js coordinator | Your service, PostgreSQL, queue, network, and storage | Your infrastructure provider |
+
+Crabbox does not currently publish a hosted coordinator plan or a separate
+Crabbox usage markup. If a provider requires a subscription, credits, or API
+usage, that agreement remains between the operator and that provider.
+
+`crabbox marketplace` is preview-only. Configured retail markups affect
+advisory quotes, but no payment is captured, credits are not reserved, and a
+quote does not provision a lease.
+
+## What Crabbox Tracks
+
+For coordinator-backed providers, Crabbox records lease counts, active leases,
+runtime, estimated elapsed cost, and worst-case reserved cost. It can enforce
+fleet, owner, and organization limits before a new lease is provisioned.
+
+```sh
+crabbox usage --scope user
+crabbox usage --scope org --org example-org
+```
+
+The estimate is an operational guardrail, not invoice reconciliation. Static IP
+charges, egress, snapshots, taxes, credits, negotiated discounts, and every
+provider-specific extra are not all modeled.
+
+Direct-from-CLI and delegated-provider spend does not pass through the
+coordinator, so `crabbox usage` cannot present it as one consolidated invoice.
+
+## How Rates Are Estimated
+
+Coordinator-backed estimates use this order:
+
+1. An operator-supplied `CRABBOX_COST_RATES_JSON` override.
+2. Live provider pricing where the adapter implements it.
+3. A checked-in provider and server-type fallback.
+4. A generic final fallback.
+
+Before provisioning, admission rejects a candidate when its reserved-cost
+estimate for the requested type and TTL would cross a configured limit. This is
+not a hard provider-invoice ceiling: the final provider or type price can be
+updated after provisioning, and provider-specific extras are not all included.
+
+See [Cost and Usage](features/cost-usage.md) for rate precedence, environment
+variables, identity rules, and the exact budget calculation.
+
+## Keep Spend Predictable
+
+- Start with `crabbox providers recommend cost-control` to favor local runtimes,
+  cleanup, cache reuse, reusable state, and coordinator governance.
+- Use one-shot `crabbox run` to apply the provider's normal post-run release
+  policy; check the provider page when release retains or pauses capacity.
+- Give retained boxes an explicit idle timeout and TTL.
+- Reuse a warm box or cache when setup time dominates the run.
+- Set fleet, per-owner, and per-organization active-lease and monthly limits on
+  the coordinator.
+- Verify the selected provider's current rate, quota, architecture, and region
+  before launching expensive or GPU-backed capacity.
+
+## Related Docs
+
+- [Cost and Usage](features/cost-usage.md)
+- [`usage` Command](commands/usage.md)
+- [Infrastructure](infrastructure.md)
+- [Use Cases](use-cases.md)

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -1,0 +1,195 @@
+# Use Cases
+
+Read this when you know what needs to happen but do not yet know which Crabbox
+provider or execution model fits.
+
+Start with the workload, not the vendor:
+
+```sh
+crabbox providers recommend
+crabbox providers recommend fast-feedback
+crabbox providers recommend agent-sandbox --json
+```
+
+With no use case, `crabbox providers recommend` prints every supported
+recommendation name. Recommendations use checked-in capability metadata. They
+do not contact providers, confirm credentials or quota, benchmark startup time,
+or certify a security boundary.
+
+## Speed Up Test and Build Loops
+
+Use this when a repository command is too slow, memory-hungry, or disruptive
+locally.
+
+```sh
+crabbox providers recommend fast-feedback
+crabbox providers recommend linux-vm
+crabbox run --provider hetzner -- pnpm test
+```
+
+Prefer `fast-feedback` for local runtimes, reusable caches, and quick edit-run
+loops. Prefer `linux-vm` when execution should move off the workstation or full
+VM and SSH semantics matter.
+
+## Give a Coding Agent a Disposable Environment
+
+Use a delegated or local sandbox when an agent needs to execute generated code,
+install dependencies, or inspect a repository away from the main checkout—or,
+with a remote provider, away from the workstation.
+
+```sh
+crabbox providers recommend agent-sandbox
+crabbox providers recommend disposable-execution
+crabbox providers recommend isolated-execution
+```
+
+These are three different questions:
+
+- `agent-sandbox` favors providers shaped for agent and devbox execution;
+- `disposable-execution` requires a cleanup-capable temporary runtime;
+- `isolated-execution` favors delegated and local sandbox boundaries.
+
+The last recommendation is routing guidance, not a provider security
+certification. Read the selected provider's trust and network model before
+running hostile code or attaching secrets.
+
+## Validate Linux, Windows, WSL2, or macOS
+
+Use platform recommendations when behavior depends on the target operating
+system:
+
+```sh
+crabbox providers recommend linux-vm
+crabbox providers recommend windows
+crabbox providers recommend macos
+
+crabbox run --provider aws --target windows --windows-mode wsl2 -- uname -a
+```
+
+Native Windows runs PowerShell and Windows tooling. WSL2 runs the POSIX contract
+inside a nested-capable Windows VM. macOS targets may be local Apple Silicon VMs
+or cloud Mac capacity, depending on the provider.
+
+## Test a Browser or Visible Desktop
+
+Use a desktop-capable SSH lease when a test needs a browser, screenshots, input,
+or a handoff to a teammate:
+
+```sh
+crabbox providers recommend desktop
+crabbox warmup --provider azure --target windows --desktop
+crabbox webvnc --id blue-lobster
+```
+
+Pair it with evidence routing when the result must survive after the box:
+
+```sh
+crabbox providers recommend run-evidence
+crabbox providers recommend failure-diagnostics
+```
+
+## Reuse Warm State
+
+Use a warm box when repeated setup costs more than keeping or restoring prepared
+state:
+
+```sh
+crabbox providers recommend warm-start
+crabbox providers recommend versioned-workspace
+
+crabbox warmup --slug warm-tests
+crabbox run --id warm-tests -- pnpm test:changed
+```
+
+`warm-start` uses signals such as local runtime, cache volumes, retained
+sessions, pause/resume, and workspace state. It does not promise the same
+snapshot or warm-pool primitive on every provider.
+
+## Fan Out Parallel Experiments
+
+Use fork-capable workspace providers for parallel branches, best-of-N agent
+attempts, or test shards that should start from prepared state:
+
+```sh
+crabbox providers recommend fanout-testing
+crabbox checkpoint fork <checkpoint-id> --count 4
+```
+
+This is provider-neutral checkpoint and fork routing. It is not a guarantee of
+live-memory microVM forking.
+
+## Run GPU Workloads
+
+Use the GPU recommendation for model tests, CUDA builds, rendering, or other
+accelerator-shaped work:
+
+```sh
+crabbox providers recommend gpu
+crabbox run --provider runpod -- nvidia-smi
+```
+
+SSH-lease GPU providers are usually better for interactive debugging. Delegated
+GPU providers are often a better fit when the provider should own execution
+and result collection.
+
+## Run Locally Without Cloud Credentials
+
+Use a local container, VM, or policy sandbox for a fast smoke test that stays on
+the workstation:
+
+```sh
+crabbox providers recommend local
+crabbox providers recommend offline-validation
+crabbox run --provider local-container -- pnpm test
+```
+
+Local does not mean one isolation model. A Docker-compatible container, Apple
+VM, Multipass VM, Windows Sandbox, and a local policy runtime have different
+host access, persistence, and cleanup contracts. Read the selected provider
+page before running unfamiliar code.
+
+## Use Infrastructure You Already Own
+
+Crabbox can use a durable SSH host, private virtualization stack, or direct
+cloud account without a shared coordinator:
+
+```sh
+crabbox providers recommend byo-ssh
+crabbox providers recommend self-hosted
+crabbox providers recommend linux-vm
+```
+
+Use `ssh` for a host whose lifecycle Crabbox must not own. Use a self-hosted
+provider such as Proxmox, XCP-ng, Incus, KubeVirt, or Firecracker when Crabbox
+should create and clean up the runtime.
+
+## Share a Governed Team Fleet
+
+Use the coordinator path when a team needs shared provider credentials, lease
+ownership, cleanup, usage records, active-lease limits, and monthly spend caps:
+
+```sh
+crabbox providers recommend team-cloud
+crabbox login --url https://broker.example.com
+crabbox usage --scope user
+```
+
+The coordinator is a control plane. The CLI still connects directly to normal
+SSH runners for sync and command execution.
+
+## Need a More Specific Route?
+
+The CLI also recommends providers for artifacts, CI proof, code interpreters,
+failure diagnostics, MCP attachment, network containment, pause/resume, preview
+URLs, reachability, remote development, resource observability, reusable run
+sessions, web-app smoke tests, and Worker/module execution.
+
+See [`crabbox providers recommend`](commands/providers.md#providers-recommend) for
+the complete current list, aliases, filters, scores, and caveats.
+
+## Related Docs
+
+- [Provider Selection](features/provider-selection.md)
+- [Provider Reference](providers/README.md)
+- [Nested Execution](features/nested-execution.md)
+- [Pricing and Costs](pricing.md)

--- a/scripts/build-docs-site.mjs
+++ b/scripts/build-docs-site.mjs
@@ -38,7 +38,19 @@ const legacyProviderFeatureNotes = new Set([
 ]);
 
 const sections = [
-  ["Start", ["README.md", "getting-started.md", "how-it-works.md", "architecture.md", "orchestrator.md", "cli.md"]],
+  [
+    "Start",
+    [
+      "README.md",
+      "getting-started.md",
+      "use-cases.md",
+      "pricing.md",
+      "how-it-works.md",
+      "architecture.md",
+      "orchestrator.md",
+      "cli.md",
+    ],
+  ],
   ["Integrations", rels("integrations")],
   ["Providers", rels("providers")],
   ["Features", rels("features")],
@@ -526,10 +538,23 @@ function layout({ page, html, toc, prev, next, sectionName }) {
   const editUrl = `${repoEditBase}/${page.rel}`;
   const isHome = page.rel === "README.md";
   const isProviderIndex = page.rel === "providers/README.md";
+  const documentTitle = isHome
+    ? "Crabbox — Run Any Repository Command in the Right Box"
+    : `${page.title} - Crabbox Docs`;
+  const metaDescription = isHome
+    ? "Run repository commands in local sandboxes, cloud VMs, SSH hosts, Windows and WSL2, macOS, or hosted agent sandboxes through one CLI."
+    : `${page.title} documentation for Crabbox remote execution.`;
+  const canonicalUrl = pageUrl(docsOrigin(), page.outRel);
   const prevNext = !isHome && (prev || next) ? pageNavHtml(prev, next, rootPrefix) : "";
   const heroBlock = isHome ? landingHero(rootPrefix) : standardHero(page, sectionName, editUrl);
-  const articleClass = isHome ? "doc doc-home" : isProviderIndex ? "doc doc-wide" : "doc";
-  const tocBlock = isHome || isProviderIndex ? "" : toc;
+  const articleClass = isProviderIndex ? "doc doc-wide" : "doc";
+  const tocBlock = isProviderIndex ? "" : toc;
+  const articleBlock = isHome
+    ? ""
+    : `<div class="doc-grid${isProviderIndex ? " doc-grid-wide" : ""}">
+        <article class="${articleClass}">${html}${prevNext}</article>
+        ${tocBlock}
+      </div>`;
   return `<!doctype html>
 <html lang="en">
 <head>
@@ -537,7 +562,14 @@ function layout({ page, html, toc, prev, next, sectionName }) {
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="color-scheme" content="light dark">
   <meta name="theme-color" id="theme-color" content="#f4f5f5">
-  <title>${escapeHtml(page.title)} - Crabbox Docs</title>
+  <title>${escapeHtml(documentTitle)}</title>
+  <meta name="description" content="${escapeAttr(metaDescription)}">
+  <link rel="canonical" href="${escapeAttr(canonicalUrl)}">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Crabbox">
+  <meta property="og:title" content="${escapeAttr(documentTitle)}">
+  <meta property="og:description" content="${escapeAttr(metaDescription)}">
+  <meta property="og:url" content="${escapeAttr(canonicalUrl)}">
   <link rel="icon" href="${rootPrefix}crabbox.svg">
   <link rel="ai-catalog" href="/.well-known/ai-catalog.json" type="application/ai-catalog+json">
   <script>(function(){var s;try{s=localStorage.getItem('crabbox-docs-theme')}catch(e){}var d=window.matchMedia&&matchMedia('(prefers-color-scheme: dark)').matches;var t=(s==='light'||s==='dark')?s:(d?'dark':'light');document.documentElement.dataset.theme=t;document.getElementById('theme-color').content=t==='dark'?'#17191b':'#f4f5f5'})();</script>
@@ -557,7 +589,7 @@ function layout({ page, html, toc, prev, next, sectionName }) {
       <div class="sidebar-head">
         <a class="brand" href="${rootPrefix}index.html" aria-label="Crabbox docs home">
           <img src="${rootPrefix}crabbox.svg" alt="" width="42" height="42">
-          <span><strong>Crabbox</strong><small>Remote testbox docs</small></span>
+          <span><strong>Crabbox</strong><small>Execution control plane</small></span>
         </a>
         ${themeToggleHtml()}
       </div>
@@ -568,10 +600,7 @@ function layout({ page, html, toc, prev, next, sectionName }) {
     </aside>
     <main id="main-content" tabindex="-1">
       ${heroBlock}
-      <div class="doc-grid${isHome ? " doc-grid-home" : ""}${isProviderIndex ? " doc-grid-wide" : ""}">
-        <article class="${articleClass}">${html}${prevNext}</article>
-        ${tocBlock}
-      </div>
+      ${articleBlock}
     </main>
   </div>
   <script>${js()}</script>
@@ -593,36 +622,212 @@ function standardHero(page, sectionName, editUrl) {
 }
 
 function landingHero(rootPrefix) {
-  const features = [
-    ["Local loop, remote box", "Keep your editor and git workflow. Crabbox rsyncs your dirty checkout to a leased remote box and streams the run back."],
-    ["Brokered, not BYO creds", "A Cloudflare Worker holds provider credentials and serializes lease state. Your CLI only carries a bearer token."],
-    ["Cost-aware leases", "TTL-bounded machines, monthly spend caps, and per-user / per-org / per-provider usage from the broker."],
-    ["Reuse what's warm", "<code>crabbox warmup</code> keeps a box hot. Reuse it with <code>--id</code> across runs, SSH, and CI hydration."],
-    ["Many providers, one loop", "Brokered Hetzner / AWS / Azure, delegated E2B / Daytona / Blacksmith / Semaphore, or static SSH targets - Linux, Windows, and macOS."],
-    ["Plays with Actions", "<code>actions hydrate</code> reuses your repository's GitHub Actions setup steps so local runs land in the same hydrated workspace."],
-    ["Desktop in your browser", "<code>crabbox webvnc</code> streams a Linux, macOS, or Windows desktop into the browser. Drive UI tests, capture screenshots, hand the live session to a teammate - no VPN."],
-    ["Proof for every run", "<code>crabbox artifacts collect</code> bundles screenshots, video, JUnit summaries, logs, and lease metadata. Drop it on a PR as before/after evidence instead of scraping log output."],
+  const useCases = [
+    {
+      id: "fast-feedback",
+      number: "01",
+      title: "Fast Test Loops",
+      summary: "Warm boxes and reusable caches",
+      resultTitle: "Shorten the edit–run loop.",
+      resultBody: "Start with providers that favor local execution, reusable caches, warm sessions, or other fast-feedback paths.",
+      commands: ["crabbox providers recommend fast-feedback", "crabbox doctor --provider <name>"],
+      href: "use-cases.html#speed-up-test-and-build-loops",
+      linkLabel: "Open the Fast Test Loop Guide",
+    },
+    {
+      id: "agent-sandbox",
+      number: "02",
+      title: "Coding Agents",
+      summary: "Agent workspaces and cleanup routes",
+      resultTitle: "Separate agent fit from cleanup guarantees.",
+      resultBody: "Compare agent- and devbox-shaped runtimes with the stricter disposable route, then inspect the selected provider’s isolation, network, secret, and cleanup boundary.",
+      commands: [
+        "crabbox providers recommend agent-sandbox",
+        "crabbox providers recommend disposable-execution",
+        "crabbox doctor --provider <name>",
+      ],
+      href: "use-cases.html#give-a-coding-agent-a-disposable-environment",
+      linkLabel: "Open the Coding Agent Guide",
+    },
+    {
+      id: "cross-platform",
+      number: "03",
+      title: "Cross-Platform",
+      summary: "Linux, Windows, WSL2, macOS",
+      resultTitle: "Match the operating system before the vendor.",
+      resultBody: "Compare the platform routes independently; Windows includes native and WSL2-capable paths, subject to the selected host.",
+      commands: [
+        "crabbox providers recommend linux-vm",
+        "crabbox providers recommend windows",
+        "crabbox providers recommend macos",
+      ],
+      href: "use-cases.html#validate-linux-windows-wsl2-or-macos",
+      linkLabel: "Open the Platform Validation Guide",
+    },
+    {
+      id: "desktop",
+      number: "04",
+      title: "Browser & Desktop QA",
+      summary: "Visible browser and desktop sessions",
+      resultTitle: "Start with a visible desktop-capable target.",
+      resultBody: "Compare browser and desktop paths first, then add evidence routing when screenshots, video, or diagnostics must survive the lease.",
+      commands: ["crabbox providers recommend desktop", "crabbox doctor --provider <name>"],
+      href: "use-cases.html#test-a-browser-or-visible-desktop",
+      linkLabel: "Open the Browser & Desktop Guide",
+    },
+    {
+      id: "fanout-testing",
+      number: "05",
+      title: "Parallel Experiments",
+      summary: "Parallel runs from prepared state",
+      resultTitle: "Fan prepared state out across multiple attempts.",
+      resultBody: "Start with checkpoint- and fork-capable workspace providers for test shards, branch comparisons, or best-of-N runs.",
+      commands: ["crabbox providers recommend fanout-testing", "crabbox doctor --provider <name>"],
+      href: "use-cases.html#fan-out-parallel-experiments",
+      linkLabel: "Open the Parallel Experiments Guide",
+    },
+    {
+      id: "gpu",
+      number: "06",
+      title: "GPU Workloads",
+      summary: "GPU machines and sandboxes",
+      resultTitle: "Require GPU capability before choosing capacity.",
+      resultBody: "Compare SSH-accessible and delegated accelerator paths for model tests, CUDA builds, rendering, or other GPU-shaped work.",
+      commands: ["crabbox providers recommend gpu", "crabbox doctor --provider <name>"],
+      href: "use-cases.html#run-gpu-workloads",
+      linkLabel: "Open the GPU Workload Guide",
+    },
   ];
-  const cards = features
-    .map(([title, body]) => `<article class="feature"><h3>${escapeHtml(title)}</h3><p>${body}</p></article>`)
+  const jobChoices = useCases
+    .map(
+      ({ id, number, title, summary }, index) =>
+        `<div class="home-job-option">
+          <input class="home-job-radio sr-only" type="radio" name="home-job" id="home-job-${escapeAttr(id)}" value="${escapeAttr(id)}" aria-controls="home-job-result-${escapeAttr(id)}" data-home-job-radio${index === 0 ? " checked" : ""}>
+          <label for="home-job-${escapeAttr(id)}"><span>${number}</span><strong>${escapeHtml(title)}</strong><small>${escapeHtml(summary)}</small></label>
+        </div>`,
+    )
     .join("");
+  const jobResults = useCases
+    .map(({ id, resultTitle, resultBody, commands, href, linkLabel }, index) => {
+      const recommendationCommands = commands.filter((command) => !command.startsWith("crabbox doctor "));
+      const copyLabel = recommendationCommands.length === 1 ? "Copy recommendation command" : "Copy recommendation commands";
+      return `<article class="home-job-result" id="home-job-result-${escapeAttr(id)}" data-home-job-result="${escapeAttr(id)}" aria-labelledby="home-job-result-title-${escapeAttr(id)}"${index === 0 ? ' data-home-job-default="true"' : ""}>
+          <div class="home-job-result-copy">
+            <p class="eyebrow">Recommended Starting Path</p>
+            <h3 id="home-job-result-title-${escapeAttr(id)}">${escapeHtml(resultTitle)}</h3>
+            <p>${escapeHtml(resultBody)}</p>
+          </div>
+          <div class="home-job-command">
+            <div><span>built-in recommendations</span><small>verify after selection</small></div>
+            <pre data-copyable data-copy-text="${escapeAttr(recommendationCommands.join("\n"))}" data-copy-label="${copyLabel}"><code>${commands.map((command) => `<span class="home-job-command-line"><i aria-hidden="true">$</i><b>${escapeHtml(command)}</b></span>`).join("")}</code></pre>
+            <a href="${rootPrefix}${href}">${escapeHtml(linkLabel)} <i aria-hidden="true">→</i></a>
+          </div>
+        </article>`;
+    })
+    .join("");
+  const paths = [
+    [
+      "Local",
+      "Stay on this machine",
+      "Containers, full VMs, and policy sandboxes for fast checks without cloud credentials.",
+      "use-cases.html#run-locally-without-cloud-credentials",
+      "See Local Paths",
+    ],
+    [
+      "Your Accounts and Infrastructure",
+      "Use capacity you control",
+      "Cloud accounts, SSH hosts, and self-hosted virtualization such as Proxmox or Firecracker.",
+      "use-cases.html#use-infrastructure-you-already-own",
+      "Use Your Infrastructure",
+    ],
+    [
+      "Provider-Managed",
+      "Delegate the runtime",
+      "Hosted sandboxes, devboxes, CI proof runners, browser sessions, and GPU jobs.",
+      "providers/index.html?q=provider-managed",
+      "Browse Managed Providers",
+    ],
+  ];
+  const pathCards = paths
+    .map(
+      ([eyebrow, title, body, href, label], index) =>
+        `<article class="home-path"><span>${String(index + 1).padStart(2, "0")}</span><p>${escapeHtml(eyebrow)}</p><h3>${escapeHtml(title)}</h3><div>${escapeHtml(body)}</div><a href="${rootPrefix}${href}">${escapeHtml(label)} <i aria-hidden="true">→</i></a></article>`,
+    )
+    .join("");
+  const providerCount = Object.keys(providerMetadata).length;
   return `<header class="hero hero-home">
-        <div class="home-title">
-          <img src="${rootPrefix}crabbox.svg" alt="" width="72" height="72">
-          <div><p class="eyebrow">Remote execution control plane</p><h1>Crabbox</h1></div>
+        <div class="home-hero-copy">
+          <div class="home-title">
+            <img src="${rootPrefix}crabbox.svg" alt="" width="56" height="56" fetchpriority="high">
+            <div><strong>Crabbox</strong><small>Remote Execution Control Plane</small></div>
+          </div>
+          <p class="eyebrow">One CLI. Many Runtimes.</p>
+          <h1>Run Your Code in <em>the Right Box.</em></h1>
+          <p class="lede">Keep editing locally. Crabbox runs the working tree you have on the machine it needs—a local runtime, cloud VM, SSH host, or managed sandbox—then streams the result back. No bespoke CI job for every iteration.</p>
+          <div class="cta">
+            <a class="cta-primary" href="${rootPrefix}getting-started.html">Run Your First Command</a>
+            <a class="cta-secondary" href="#home-use-cases-heading">Route Your Workload</a>
+          </div>
+          <ul class="home-facts" aria-label="Crabbox product facts">
+            <li>MIT licensed</li>
+            <li>Linux, Windows, and macOS</li>
+            <li>${providerCount} registered providers</li>
+          </ul>
         </div>
-        <p class="home-tagline">A short-lived box for every run.</p>
-        <p class="lede">Keep the local edit-and-run loop while Crabbox leases, syncs, executes, and releases work across shared cloud capacity.</p>
-        <div class="cta">
-          <a class="cta-primary" href="${rootPrefix}getting-started.html">Get started</a>
-          <a class="cta-secondary" href="${rootPrefix}providers/index.html">Browse ${Object.keys(providerMetadata).length} providers</a>
+        <div class="home-console" role="group" aria-label="Example Crabbox run">
+          <div class="home-console-bar"><span aria-hidden="true">● ● ●</span><strong>crabbox / run</strong><small>ready</small></div>
+          <pre><code><span>$</span> crabbox run --provider local-container -- pnpm test</code></pre>
+          <ol>
+            <li><b>01</b><div><strong>Lease</strong><small>blue-lobster · local-container</small></div><i aria-hidden="true">✓</i></li>
+            <li><b>02</b><div><strong>Sync</strong><small>tracked + nonignored files</small></div><i aria-hidden="true">✓</i></li>
+            <li><b>03</b><div><strong>Run</strong><small>pnpm test · live output</small></div><i aria-hidden="true">✓</i></li>
+            <li><b>04</b><div><strong>Release</strong><small>owned container removed</small></div><i aria-hidden="true">✓</i></li>
+          </ol>
+          <div class="home-console-result"><i aria-hidden="true">✓</i><div><strong>Result returned</strong><small>temporary container cleaned up</small></div></div>
         </div>
-        <pre class="hero-snippet" aria-label="Example Crabbox run"><code><span class="prompt">$</span> crabbox run -- pnpm test
-<span class="comment"># lease cbx_8f2 - hetzner cax21 - ready 11s</span>
-<span class="comment"># sync 184 files (1.2 MB)</span>
-<span class="comment"># tests passed in 47s - released</span></code></pre>
       </header>
-      <section class="features" aria-labelledby="highlights-heading"><h2 class="sr-only" id="highlights-heading">Highlights</h2>${cards}</section>`;
+      <section class="home-section home-use-cases" aria-labelledby="home-use-cases-heading">
+        <header><div><p class="eyebrow">Interactive Workload Router</p><h2 id="home-use-cases-heading">Pick the Job. Get the Starting Commands.</h2></div><p>Turn ${providerCount} registered providers into a focused comparison path. Choose a workload, run the matching built-in recommendations, then verify the provider you select with <code>crabbox doctor</code>.</p></header>
+        <form class="home-job-finder" data-home-job-finder>
+          <fieldset>
+            <legend class="sr-only">Choose the job Crabbox should help with</legend>
+            <div class="home-job-layout">
+              <div class="home-job-choices">${jobChoices}</div>
+              <div class="home-job-results">${jobResults}</div>
+            </div>
+          </fieldset>
+          <p class="home-job-disclaimer"><strong>Built-in guidance, not a live provider check.</strong> Availability, price, performance, credentials, quota, and security still depend on the provider. Verify readiness with <code>crabbox doctor</code>.</p>
+        </form>
+        <a class="home-section-link" href="${rootPrefix}use-cases.html">See All Recommendation Paths <span aria-hidden="true">→</span></a>
+      </section>
+      <section class="home-section home-paths" aria-labelledby="home-paths-heading">
+        <header><div><p class="eyebrow">Choose by Ownership</p><h2 id="home-paths-heading">Run Here, There, or Managed.</h2></div><p>The loop stays the same. Only the runtime owner, isolation boundary, and billing relationship change.</p></header>
+        <div class="home-path-grid">${pathCards}</div>
+      </section>
+      <section class="home-section home-pricing" aria-labelledby="home-pricing-heading">
+        <header><div><p class="eyebrow">Current Cost Model</p><h2 id="home-pricing-heading">Crabbox Software Is Free. Compute Isn’t.</h2></div><p>No opaque “box credit” is needed to understand today’s product. Crabbox separates its software from the infrastructure that runs the work.</p></header>
+        <div class="home-price-grid">
+          <article><span>Crabbox Software</span><strong>$0 license fee</strong><p>MIT-licensed CLI and coordinator.</p></article>
+          <article><span>Compute</span><strong>Provider rate</strong><p>Cloud, sandbox, GPU, or local runtime bills remain external.</p></article>
+          <article><span>Coordinator</span><strong>Your infrastructure</strong><p>Run it on Cloudflare or Node.js with PostgreSQL.</p></article>
+          <article><span>Coordinator Guardrails</span><strong>TTL and spend caps</strong><p>For brokered providers, estimate reserved cost and reject leases over configured limits.</p></article>
+        </div>
+        <a class="home-section-link" href="${rootPrefix}pricing.html">See Pricing and Cost Boundaries <span aria-hidden="true">→</span></a>
+      </section>
+      <aside class="home-capability-note" aria-labelledby="home-nested-heading">
+        <div><p class="eyebrow">Conditional Capability</p><h2 id="home-nested-heading">Need WSL2 or KVM?</h2></div>
+        <p>WSL2 works on compatible AWS and Azure Windows targets. Firecracker requires Crabbox to run on a prepared Linux <code>/dev/kvm</code> host. There is no generic nested mode. <a href="${rootPrefix}features/nested-execution.html">Read the exact boundaries <span aria-hidden="true">→</span></a></p>
+      </aside>
+      <section class="home-install" aria-labelledby="home-install-heading">
+        <div><p class="eyebrow">Install the CLI</p><h2 id="home-install-heading">One Command to Start.</h2><p>Install Crabbox, choose direct, local, delegated, or team-coordinator access, then run the command your repository already knows.</p><a href="${rootPrefix}getting-started.html">Open the 10-Minute Guide <span aria-hidden="true">→</span></a></div>
+        <pre><code><span>$</span> brew install openclaw/tap/crabbox
+<span>$</span> crabbox doctor
+<span>$</span> crabbox run -- pnpm test</code></pre>
+      </section>
+      <aside class="home-trust" aria-labelledby="home-trust-heading">
+        <div><p class="eyebrow">Trust Boundary</p><h2 id="home-trust-heading">Choose Isolation Deliberately.</h2></div>
+        <p>Crabbox is a developer execution tool, not one uniform hostile multi-tenant sandbox. Isolation, network policy, secrets, and host access depend on the selected runtime. <a href="${rootPrefix}security.html">Read the security model</a> before running unfamiliar code.</p>
+      </aside>`;
 }
 
 function pageNavHtml(prev, next, rootPrefix) {
@@ -665,7 +870,7 @@ function css() {
 :root[data-theme="dark"]{color-scheme:dark;--ink:#f4f0ea;--muted:#aeb5b6;--shell:#17191b;--paper:#202326;--reef:#62c7bd;--coral:#ff8a78;--ochre:#efc15b;--line:#353a3d;--line-soft:#2b2f32;--panel:#202326;--sidebar:#111315;--body-soft:#c7cccb;--code-bg:#0e1011;--code-fg:#f4f0ea;--code-border:#08090a;--code-comment:#8d9999;--code-scroll:#4e565a;--inline-bg:#2b3032;--inline-border:#3b4245;--nav-active-bg:#402722;--nav-active-fg:#ffb3a5;--quote-bg:#1b2d2c;--focus:#62c7bd}
 *{box-sizing:border-box}
 html{scroll-behavior:smooth;scroll-padding-top:24px}
-body{margin:0;background:var(--shell);color:var(--ink);font-family:"IBM Plex Sans",Avenir Next,sans-serif;line-height:1.65;overflow-x:hidden;-webkit-font-smoothing:antialiased;transition:background-color .18s,color .18s}
+body{margin:0;background:var(--shell);color:var(--ink);font-family:"IBM Plex Sans",Avenir Next,sans-serif;line-height:1.65;-webkit-font-smoothing:antialiased;transition:background-color .18s,color .18s}
 [hidden]{display:none!important}
 ::selection{background:var(--coral);color:var(--paper)}
 a{color:var(--reef);text-decoration-thickness:.07em;text-underline-offset:.18em;transition:color .15s}
@@ -727,41 +932,125 @@ main{min-width:0;padding:30px 48px 80px;max-width:1360px;margin:0 auto;width:100
 .edit{color:var(--muted)}
 
 /* landing hero */
-.hero-home{display:block;border-bottom:1px solid var(--line);padding:42px 0 34px}
+.home main{max-width:1500px}
+.hero-home{display:grid;grid-template-columns:minmax(0,1.08fr) minmax(380px,.92fr);align-items:center;gap:44px;padding:48px;border:1px solid var(--line);border-radius:24px;background:radial-gradient(circle at 6% 8%,color-mix(in srgb,var(--coral) 13%,transparent),transparent 28%),radial-gradient(circle at 93% 92%,color-mix(in srgb,var(--reef) 15%,transparent),transparent 31%),var(--paper);overflow:hidden}
 .hero-home:after{display:none}
-.home-title{display:flex;align-items:center;gap:18px;margin-bottom:22px}
-.home-title img{width:72px;height:72px;flex:0 0 72px}
-.home-title .eyebrow{margin-bottom:4px}
-.hero-home h1{font-size:4rem;line-height:.95;letter-spacing:0;font-weight:700;margin:0}
-.home-tagline{font-family:Fraunces,Georgia,serif;font-size:1.7rem;line-height:1.2;margin:0 0 10px;color:var(--ink);text-wrap:balance}
-.lede{margin:0 0 22px;color:var(--body-soft);font-size:1.08rem;line-height:1.55;max-width:62ch;text-wrap:pretty}
+.home-hero-copy{min-width:0}
+.home-title{display:flex;align-items:center;gap:12px;margin-bottom:34px}
+.home-title img{width:56px;height:56px;flex:0 0 56px}
+.home-title strong,.home-title small{display:block}
+.home-title strong{font:700 1.42rem/1 Fraunces,Georgia,serif}
+.home-title small{margin-top:5px;color:var(--muted);font-size:.68rem;font-weight:700;letter-spacing:.02em;text-transform:uppercase}
+.hero-home h1{max-width:760px;font-size:clamp(3.45rem,5.7vw,6.2rem);line-height:.88;letter-spacing:-.045em;font-weight:700;margin:0;text-wrap:balance}
+.hero-home h1 em{display:block;color:var(--coral);font-style:normal}
+.lede{margin:24px 0 26px;color:var(--body-soft);font-size:1.08rem;line-height:1.58;max-width:62ch;text-wrap:pretty}
 .cta{display:flex;gap:10px;flex-wrap:wrap}
 .cta-primary,.cta-secondary{display:inline-flex;align-items:center;border-radius:6px;padding:10px 16px;font-weight:600;font-size:.93rem;text-decoration:none;touch-action:manipulation;transition:transform .15s,box-shadow .15s,background-color .15s,border-color .15s,color .15s}
 .cta-primary{background:var(--ink);color:var(--paper);border:1px solid var(--ink)}
 .cta-primary:hover{background:var(--reef);border-color:var(--reef);color:var(--paper);transform:translateY(-1px);box-shadow:0 8px 20px color-mix(in srgb,var(--reef) 22%,transparent)}
 .cta-secondary{border:1px solid var(--ink);color:var(--ink);background:transparent}
 .cta-secondary:hover{border-color:var(--coral);color:var(--coral);transform:translateY(-1px)}
-.hero-snippet{max-width:880px;margin:30px 0 0;background:var(--code-bg);color:var(--code-fg);border-radius:8px;padding:20px 22px;font:500 .88rem/1.65 "IBM Plex Mono",ui-monospace,monospace;border:1px solid var(--code-border);box-shadow:0 16px 34px rgba(0,0,0,.18);overflow:auto}
-.hero-snippet code{background:transparent;border:0;padding:0;color:inherit;font:inherit;display:block;white-space:pre}
-.hero-snippet .prompt{color:var(--ochre)}
-.hero-snippet .comment{color:var(--code-comment)}
-
-/* feature grid */
-.features{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:12px;margin:26px 0 8px}
-.feature{background:var(--panel);border:1px solid var(--line-soft);border-radius:8px;padding:18px 18px 16px;transition:border-color .15s,transform .15s,box-shadow .15s}
-.feature:hover{border-color:var(--coral);transform:translateY(-2px);box-shadow:0 10px 24px rgba(0,0,0,.08)}
-.feature h3{font-family:Fraunces,Georgia,serif;font-size:1.05rem;margin:0 0 6px;font-weight:600;letter-spacing:0;line-height:1.2}
-.feature p{margin:0;color:var(--body-soft);font-size:.92rem;line-height:1.5}
-.feature code{font-size:.86em;background:var(--inline-bg);border:1px solid var(--inline-border);border-radius:5px;padding:.04em .3em}
+.home-facts{display:flex;flex-wrap:wrap;gap:8px 22px;padding:0;margin:24px 0 0;color:var(--muted);font-size:.76rem;font-weight:700;list-style:none}
+.home-facts li{position:relative;padding-left:14px}
+.home-facts li:before{content:"";position:absolute;left:0;top:.58em;width:5px;height:5px;border-radius:50%;background:var(--reef)}
+.home-console{min-width:0;padding:16px;border:1px solid var(--code-border);border-radius:18px;background:var(--code-bg);color:var(--code-fg);box-shadow:0 28px 72px rgba(0,0,0,.25)}
+.home-console-bar{display:grid;grid-template-columns:1fr auto 1fr;align-items:center;padding:3px 3px 14px;border-bottom:1px solid rgba(255,255,255,.1);font-size:.72rem}
+.home-console-bar span{color:var(--coral);letter-spacing:.12em}
+.home-console-bar small{text-align:right;color:#7dd3c7}
+.home-console pre{max-width:100%;margin:13px 0;padding:14px;overflow:auto;border:1px solid rgba(255,255,255,.09);border-radius:9px;background:#0d0f10;font:500 .76rem/1.55 "IBM Plex Mono",ui-monospace,monospace}
+.home-console pre code{white-space:pre}
+.home-console pre span{color:#efc15b}
+.home-console ol{display:grid;gap:8px;padding:0;margin:0;list-style:none}
+.home-console li{display:grid;grid-template-columns:42px minmax(0,1fr) 22px;align-items:center;gap:10px;padding:12px;border:1px solid rgba(255,255,255,.09);border-radius:10px;background:rgba(255,255,255,.035)}
+.home-console li b{display:grid;place-items:center;width:32px;height:32px;border-radius:50%;background:rgba(255,255,255,.1);font:700 .66rem/1 "IBM Plex Mono",monospace}
+.home-console li strong,.home-console li small,.home-console-result strong,.home-console-result small{display:block}
+.home-console li small,.home-console-result small{overflow-wrap:anywhere;color:var(--code-comment)}
+.home-console li i,.home-console-result>i{color:#7dd3c7;font-style:normal}
+.home-console-result{display:flex;gap:11px;align-items:center;margin-top:10px;padding:13px;border-radius:10px;background:color-mix(in srgb,var(--reef) 30%,#111)}
+.home-section{padding:82px 0;border-bottom:1px solid var(--line)}
+.home-section>header{display:grid;grid-template-columns:minmax(0,1fr) minmax(300px,.72fr);align-items:end;gap:40px;margin-bottom:28px}
+.home-section>header h2,.home-install h2{margin:0;color:var(--ink);font:700 clamp(2.3rem,4.1vw,4.4rem)/.98 Fraunces,Georgia,serif;letter-spacing:-.035em;text-wrap:balance}
+.home-section>header>p{max-width:58ch;margin:0 0 5px;color:var(--body-soft);font-size:1rem;text-wrap:pretty}
+.home-section>header code,.home-capability-note code{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:.86em}
+.home-job-finder{padding:18px;border:1px solid var(--code-border);border-radius:22px;background:radial-gradient(circle at 100% 0,color-mix(in srgb,var(--reef) 34%,transparent),transparent 38%),var(--code-bg);color:var(--code-fg);box-shadow:0 24px 60px rgba(0,0,0,.16)}
+.home-job-finder fieldset{min-width:0;padding:0;margin:0;border:0}
+.home-job-layout{display:grid;grid-template-columns:minmax(300px,.82fr) minmax(0,1.18fr);gap:18px;align-items:stretch}
+.home-job-choices{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:8px}
+.home-job-option{position:relative;min-width:0}
+.home-job-option label{display:flex;min-height:108px;height:100%;flex-direction:column;padding:15px;border:1px solid rgba(255,255,255,.12);border-radius:12px;background:rgba(255,255,255,.045);color:var(--code-fg);cursor:pointer;touch-action:manipulation;transition:transform .15s,border-color .15s,background-color .15s,box-shadow .15s}
+.home-job-option label:hover{transform:translateY(-2px);border-color:rgba(125,211,199,.65);background:rgba(255,255,255,.075)}
+.home-job-option input:focus-visible+label{outline:3px solid #7dd3c7;outline-offset:2px}
+.home-job-option input:checked+label{border-color:#7dd3c7;background:color-mix(in srgb,var(--reef) 34%,#171a1c);box-shadow:inset 3px 0 0 #7dd3c7}
+.home-job-option label>span{color:#7dd3c7;font:700 .64rem/1 "IBM Plex Mono",monospace}
+.home-job-option label>strong{margin-top:12px;font:600 1.06rem/1.15 Fraunces,Georgia,serif;text-wrap:balance}
+.home-job-option label>small{margin-top:auto;padding-top:8px;color:var(--code-comment);font-size:.69rem;line-height:1.35;overflow-wrap:anywhere}
+.home-job-result{display:none;min-width:0;height:100%;grid-template-columns:minmax(0,.85fr) minmax(0,1.15fr);gap:20px;padding:26px;border:1px solid rgba(255,255,255,.13);border-radius:15px;background:linear-gradient(145deg,rgba(255,255,255,.075),rgba(255,255,255,.025))}
+.home-job-result:first-child{display:grid}
+.home-job-finder:has(.home-job-radio:checked) .home-job-result{display:none}
+.home-job-finder:has(#home-job-fast-feedback:checked) [data-home-job-result="fast-feedback"],
+.home-job-finder:has(#home-job-agent-sandbox:checked) [data-home-job-result="agent-sandbox"],
+.home-job-finder:has(#home-job-cross-platform:checked) [data-home-job-result="cross-platform"],
+.home-job-finder:has(#home-job-desktop:checked) [data-home-job-result="desktop"],
+.home-job-finder:has(#home-job-fanout-testing:checked) [data-home-job-result="fanout-testing"],
+.home-job-finder:has(#home-job-gpu:checked) [data-home-job-result="gpu"]{display:grid}
+.home-job-result-copy{display:flex;min-width:0;flex-direction:column}
+.home-job-result-copy .eyebrow{margin-bottom:12px}
+.home-job-result h3{margin:0;color:var(--code-fg);font:600 2rem/1.05 Fraunces,Georgia,serif;text-wrap:balance}
+.home-job-result-copy>p:not(.eyebrow){margin:16px 0;color:var(--code-comment);font-size:.9rem;text-wrap:pretty}
+.home-job-command{display:flex;min-width:0;flex-direction:column;padding:14px;border:1px solid rgba(255,255,255,.1);border-radius:12px;background:#0d0f10}
+.home-job-command>div{display:flex;justify-content:space-between;gap:12px;padding:1px 2px 12px;border-bottom:1px solid rgba(255,255,255,.09);font-size:.66rem}
+.home-job-command>div span{color:#f0ebe2;font-weight:700}
+.home-job-command>div small{color:#7dd3c7}
+.home-job-command pre{position:relative;max-width:100%;margin:14px 0;padding:2px 58px 2px 0;overflow:auto;background:transparent;border:0;color:var(--code-fg);font:500 .72rem/1.75 "IBM Plex Mono",ui-monospace,monospace}
+.home-job-command pre code{display:grid;min-width:0;gap:3px;white-space:normal}
+.home-job-command-line{display:grid;min-width:0;grid-template-columns:auto minmax(0,1fr);gap:7px}
+.home-job-command-line i{color:#efc15b;font-style:normal}
+.home-job-command-line b{min-width:0;font:inherit;overflow-wrap:anywhere}
+.home-job-command a{display:inline-flex;align-items:center;gap:8px;margin-top:auto;color:#7dd3c7;font-size:.75rem;font-weight:700;text-decoration:none}
+.home-job-command a:hover{color:#ff8a78}
+.home-job-command a i{font-style:normal;transition:transform .16s}
+.home-job-command a:hover i{transform:translateX(3px)}
+.home-job-disclaimer{margin:14px 3px 2px;color:var(--code-comment);font-size:.73rem;text-wrap:pretty}
+.home-job-disclaimer strong{color:var(--code-fg)}
+.home-section-link{display:inline-flex;align-items:center;gap:10px;margin-top:22px;color:var(--ink);font-weight:700;text-decoration:none}
+.home-section-link span{transition:transform .16s}
+.home-section-link:hover span{transform:translateX(3px)}
+.home-path-grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));border:1px solid var(--line);border-radius:16px;background:var(--paper);overflow:hidden}
+.home-path{display:flex;min-height:280px;flex-direction:column;padding:26px}
+.home-path+.home-path{border-left:1px solid var(--line)}
+.home-path>span{color:var(--coral);font:700 .7rem/1 "IBM Plex Mono",monospace}
+.home-path>p{margin:38px 0 5px;color:var(--muted);font-size:.68rem;font-weight:700;text-transform:uppercase}
+.home-path h3{margin:0 0 12px;font:600 1.55rem/1.1 Fraunces,Georgia,serif;text-wrap:balance}
+.home-path>div{color:var(--body-soft);font-size:.91rem}
+.home-path a{display:inline-flex;gap:8px;align-items:center;margin-top:auto;padding-top:25px;font-weight:700;text-decoration:none}
+.home-path a i{font-style:normal;transition:transform .16s}
+.home-path a:hover i{transform:translateX(3px)}
+.home-price-grid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:10px}
+.home-price-grid article{min-width:0;padding:22px;border:1px solid var(--line);border-radius:12px;background:var(--paper)}
+.home-price-grid span,.home-price-grid strong{display:block}
+.home-price-grid span{color:var(--muted);font-size:.68rem;font-weight:700;text-transform:uppercase}
+.home-price-grid strong{margin:24px 0 9px;font:600 1.25rem/1.12 Fraunces,Georgia,serif;overflow-wrap:anywhere}
+.home-price-grid p{margin:0;color:var(--body-soft);font-size:.84rem;line-height:1.45}
+.home-capability-note{display:grid;grid-template-columns:minmax(230px,.55fr) minmax(0,1.45fr);align-items:center;gap:38px;margin-top:28px;padding:26px 28px;border:1px solid color-mix(in srgb,var(--reef) 32%,var(--line));border-radius:14px;background:color-mix(in srgb,var(--reef) 7%,var(--paper))}
+.home-capability-note .eyebrow{margin-bottom:5px}
+.home-capability-note h2{margin:0;font:600 1.75rem/1.08 Fraunces,Georgia,serif;text-wrap:balance}
+.home-capability-note>p{margin:0;color:var(--body-soft);text-wrap:pretty}
+.home-capability-note a{font-weight:700;white-space:nowrap}
+.home-install{display:grid;grid-template-columns:minmax(0,1fr) minmax(380px,.85fr);align-items:center;gap:48px;margin:82px 0 0;padding:38px 40px;border:1px solid var(--line);border-radius:18px;background:var(--paper)}
+.home-install h2{font-size:clamp(2.2rem,3.6vw,3.6rem)}
+.home-install>div>p:not(.eyebrow){max-width:58ch;margin:16px 0;color:var(--body-soft)}
+.home-install a{display:inline-flex;gap:8px;align-items:center;font-weight:700;text-decoration:none}
+.home-install pre{max-width:100%;margin:0;padding:20px;overflow:auto;border:1px solid var(--code-border);border-radius:12px;background:var(--code-bg);color:var(--code-fg);font:500 .78rem/1.8 "IBM Plex Mono",ui-monospace,monospace;box-shadow:0 14px 34px rgba(0,0,0,.18)}
+.home-install pre code{white-space:pre}
+.home-install pre span{color:#efc15b}
+.home-trust{display:grid;grid-template-columns:minmax(260px,.65fr) minmax(0,1.35fr);gap:48px;align-items:start;margin-top:64px;padding:34px 0 0;border-top:1px solid var(--line)}
+.home-trust h2{margin:0;font:600 1.7rem/1.1 Fraunces,Georgia,serif;text-wrap:balance}
+.home-trust>p{max-width:72ch;margin:0;color:var(--body-soft)}
 
 /* layout: doc + toc */
 .doc-grid{display:grid;grid-template-columns:minmax(0,1fr);gap:36px;margin-top:30px}
-.doc-grid-home{margin-top:18px}
-.doc-home{padding:8px 0 0;max-width:78ch;margin-inline:auto;width:100%}
-.doc-home>:first-child{margin-top:0}
-@media(min-width:1180px){.doc-grid{grid-template-columns:minmax(0,78ch) 210px;justify-content:start}.doc-grid-home,.doc-grid-wide{grid-template-columns:minmax(0,1fr)}}
+@media(min-width:1180px){.doc-grid{grid-template-columns:minmax(0,78ch) 210px;justify-content:start}.doc-grid-wide{grid-template-columns:minmax(0,1fr)}}
 .doc{min-width:0;max-width:78ch;overflow-wrap:break-word}
-.doc-home{max-width:none}
 .doc-wide{max-width:none}
 .doc h1{display:none}
 .doc h2{font-family:Fraunces,Georgia,serif;font-size:1.65rem;line-height:1.15;margin:1.9em 0 .5em;font-weight:600;letter-spacing:0;position:relative;text-wrap:balance;scroll-margin-top:24px}
@@ -781,10 +1070,11 @@ main{min-width:0;padding:30px 48px 80px;max-width:1360px;margin:0 auto;width:100
 .doc pre::-webkit-scrollbar{height:8px}
 .doc pre::-webkit-scrollbar-thumb{background:var(--code-scroll);border-radius:8px}
 .doc pre code{display:block;background:transparent;border:0;color:inherit;padding:0;font-size:1em;white-space:pre;overflow-wrap:normal;word-break:normal;tab-size:2}
-.doc pre .copy{position:absolute;top:8px;right:8px;background:rgba(255,251,244,.06);color:var(--code-fg);border:1px solid rgba(255,251,244,.18);border-radius:6px;padding:3px 9px;font:600 .7rem/1 "IBM Plex Sans",sans-serif;cursor:pointer;opacity:0;transition:opacity .15s,background .15s,border-color .15s}
-.doc pre:hover .copy,.doc pre .copy:focus{opacity:1}
-.doc pre .copy:hover{background:rgba(255,251,244,.14)}
-.doc pre .copy.copied{background:var(--coral);border-color:var(--coral);opacity:1}
+:is(.doc pre,[data-copyable]) .copy{position:absolute;top:8px;right:8px;background:rgba(255,251,244,.06);color:var(--code-fg);border:1px solid rgba(255,251,244,.18);border-radius:6px;padding:3px 9px;font:600 .7rem/1 "IBM Plex Sans",sans-serif;cursor:pointer;opacity:0;transition:opacity .15s,background-color .15s,border-color .15s}
+:is(.doc pre,[data-copyable]):hover .copy,:is(.doc pre,[data-copyable]) .copy:focus-visible{opacity:1}
+:is(.doc pre,[data-copyable]) .copy:hover{background:rgba(255,251,244,.14)}
+:is(.doc pre,[data-copyable]) .copy.copied{background:var(--coral);border-color:var(--coral);opacity:1}
+.home-job-command [data-copyable] .copy{min-width:44px;min-height:44px;opacity:1}
 .doc blockquote{margin:1.4em 0;padding:12px 16px;border-left:3px solid var(--coral);background:var(--quote-bg);border-radius:0 8px 8px 0;color:var(--ink)}
 .doc blockquote p:last-child{margin-bottom:0}
 .table-scroll{width:100%;max-width:100%;overflow-x:auto;overscroll-behavior-inline:contain;margin:1.2em 0;border-top:1px solid var(--line);border-bottom:1px solid var(--line);scrollbar-width:thin;scrollbar-color:var(--code-scroll) transparent}
@@ -844,6 +1134,11 @@ main{min-width:0;padding:30px 48px 80px;max-width:1360px;margin:0 auto;width:100
 .nav-backdrop{display:none;position:fixed;inset:0;z-index:20;width:100%;height:100%;border:0;background:rgba(0,0,0,.48);padding:0;cursor:pointer}
 
 /* mobile */
+@media(max-width:1280px){
+  .hero-home{grid-template-columns:1fr;padding:40px}
+  .home-console{max-width:760px}
+  .home-price-grid{grid-template-columns:repeat(2,minmax(0,1fr))}
+}
 @media(max-width:900px){
   .shell{display:block}
   body.nav-open{overflow:hidden}
@@ -855,20 +1150,53 @@ main{min-width:0;padding:30px 48px 80px;max-width:1360px;margin:0 auto;width:100
   .hero{padding-top:8px}
   .hero h1{font-size:2.2rem}
   .hero-meta{width:100%;justify-content:flex-start}
-  .hero-home{padding-top:18px}
-  .hero-home h1{font-size:3rem}
-  .home-tagline{font-size:1.45rem}
-  .hero-snippet{font-size:.78rem;padding:16px 16px}
-  .features{grid-template-columns:repeat(2,minmax(0,1fr));margin-top:22px}
+  .hero-home{padding:32px}
+  .hero-home h1{font-size:clamp(3.2rem,10vw,5rem)}
+  .home-section{padding:64px 0}
+  .home-section>header{grid-template-columns:1fr;gap:16px}
+  .home-job-layout{grid-template-columns:1fr}
+  .home-job-choices{grid-template-columns:repeat(3,minmax(0,1fr))}
+  .home-path-grid{grid-template-columns:1fr}
+  .home-path{min-height:230px}
+  .home-path+.home-path{border-top:1px solid var(--line);border-left:0}
+  .home-capability-note{grid-template-columns:1fr;gap:12px}
+  .home-install{grid-template-columns:1fr;margin-top:64px}
+  .home-trust{grid-template-columns:1fr;gap:16px}
   .doc-grid{margin-top:22px;gap:24px}
   .doc :is(h2,h3,h4) .anchor{display:none}
 }
 @media(max-width:520px){
   main{padding:64px 16px 48px}
-  .home-title{gap:13px}
-  .home-title img{width:58px;height:58px;flex-basis:58px}
-  .hero-home h1{font-size:2.65rem}
-  .features{grid-template-columns:1fr}
+  .hero-home{padding:24px 18px;border-radius:18px}
+  .home-title{gap:10px;margin-bottom:28px}
+  .home-title img{width:48px;height:48px;flex-basis:48px}
+  .home-title strong{font-size:1.24rem}
+  .home-title small{font-size:.58rem}
+  .hero-home h1{font-size:clamp(2.85rem,15vw,4rem)}
+  .lede{font-size:1rem}
+  .cta-primary,.cta-secondary{width:100%;justify-content:center}
+  .home-facts{display:grid;gap:7px}
+  .home-console{margin-top:4px;padding:11px;border-radius:13px}
+  .home-console-bar{grid-template-columns:1fr auto}
+  .home-console-bar strong{display:none}
+  .home-console pre{font-size:.68rem}
+  .home-console li{grid-template-columns:36px minmax(0,1fr) 18px;padding:10px}
+  .home-console li b{width:29px;height:29px}
+  .home-price-grid{grid-template-columns:1fr}
+  .home-section{padding:54px 0}
+  .home-section>header h2,.home-install h2{font-size:2.45rem}
+  .home-job-finder{margin:0 -2px;padding:10px;border-radius:16px}
+  .home-job-choices{grid-template-columns:repeat(2,minmax(0,1fr))}
+  .home-job-option label{min-height:76px;padding:11px}
+  .home-job-option label>strong{font-size:.98rem}
+  .home-job-option label>small{display:none}
+  .home-job-result{grid-template-columns:1fr;gap:18px;padding:19px}
+  .home-job-result h3{font-size:1.8rem}
+  .home-job-command pre{font-size:.66rem}
+  .home-capability-note{padding:22px 20px}
+  .home-capability-note a{white-space:normal}
+  .home-install{gap:28px;margin-top:54px;padding:28px 20px}
+  .home-install pre{margin:0 -6px;padding:16px;font-size:.7rem}
   .page-nav{grid-template-columns:1fr}
   .page-nav-next{grid-column:1}
   .doc pre{margin-left:-16px;margin-right:-16px;border-radius:0;border-left:0;border-right:0}
@@ -956,7 +1284,16 @@ const input=document.getElementById('doc-search');
 const navSections=[...document.querySelectorAll('[data-nav-section]')];
 const navEmpty=document.querySelector('.nav-empty');
 let navOpenState=null;
-input?.addEventListener('input',()=>{
+const navParams=new URLSearchParams(location.search);
+if(input)input.value=navParams.get('docs')||'';
+const syncNavURL=()=>{
+  if(location.protocol==='file:')return;
+  const next=new URL(location.href);
+  const value=input?.value.trim()||'';
+  value?next.searchParams.set('docs',value):next.searchParams.delete('docs');
+  history.replaceState(null,'',next);
+};
+const applyNavFilters=(updateURL=true)=>{
   const q=input.value.trim().toLowerCase();
   const terms=q.split(/\\s+/).filter(Boolean);
   if(q&&!navOpenState)navOpenState=new Map(navSections.map((section)=>[section,section.open]));
@@ -976,7 +1313,10 @@ input?.addEventListener('input',()=>{
   });
   if(!q)navOpenState=null;
   if(navEmpty)navEmpty.hidden=!q||matches>0;
-});
+  if(updateURL)syncNavURL();
+};
+input?.addEventListener('input',()=>applyNavFilters());
+if(input?.value)applyNavFilters(false);
 
 const providerFilter=document.querySelector('[data-provider-filter]');
 if(providerFilter){
@@ -985,8 +1325,20 @@ if(providerFilter){
   const providerRows=[...document.querySelectorAll('.provider-matrix tbody tr')];
   const providerCount=providerFilter.querySelector('[data-provider-count]');
   const providerEmpty=providerFilter.querySelector('[data-provider-empty]');
-  let providerGroup='all';
-  const applyProviderFilters=()=>{
+  const providerParams=new URLSearchParams(location.search);
+  let providerGroup=providerParams.get('group')||'all';
+  if(!providerButtons.some((button)=>button.dataset.providerGroupFilter===providerGroup))providerGroup='all';
+  if(providerInput)providerInput.value=providerParams.get('q')||'';
+  providerButtons.forEach((button)=>button.setAttribute('aria-pressed',button.dataset.providerGroupFilter===providerGroup?'true':'false'));
+  const syncProviderURL=()=>{
+    if(location.protocol==='file:')return;
+    const next=new URL(location.href);
+    const value=providerInput?.value.trim()||'';
+    value?next.searchParams.set('q',value):next.searchParams.delete('q');
+    providerGroup!=='all'?next.searchParams.set('group',providerGroup):next.searchParams.delete('group');
+    history.replaceState(null,'',next);
+  };
+  const applyProviderFilters=(updateURL=true)=>{
     const terms=(providerInput?.value.trim().toLowerCase()||'').split(/\\s+/).filter(Boolean);
     let count=0;
     providerRows.forEach((row)=>{
@@ -1000,6 +1352,7 @@ if(providerFilter){
     });
     if(providerCount)providerCount.textContent=count===1?'1 provider':count+' providers';
     if(providerEmpty)providerEmpty.hidden=count>0;
+    if(updateURL)syncProviderURL();
   };
   providerInput?.addEventListener('input',applyProviderFilters);
   providerButtons.forEach((button)=>button.addEventListener('click',()=>{
@@ -1007,9 +1360,39 @@ if(providerFilter){
     providerButtons.forEach((item)=>item.setAttribute('aria-pressed',item===button?'true':'false'));
     applyProviderFilters();
   }));
+  applyProviderFilters(false);
 }
 
-document.querySelectorAll('.doc pre').forEach(pre=>{const btn=document.createElement('button');btn.type='button';btn.className='copy';btn.setAttribute('aria-live','polite');btn.textContent='Copy';btn.addEventListener('click',async()=>{const code=pre.querySelector('code')?.textContent??'';try{await navigator.clipboard.writeText(code);btn.textContent='Copied';btn.classList.add('copied');setTimeout(()=>{btn.textContent='Copy';btn.classList.remove('copied')},1400)}catch{btn.textContent='Failed';setTimeout(()=>{btn.textContent='Copy'},1400)}});pre.appendChild(btn)});
+const homeJobFinder=document.querySelector('[data-home-job-finder]');
+if(homeJobFinder){
+  const homeJobRadios=[...homeJobFinder.querySelectorAll('[data-home-job-radio]')];
+  const selectHomeJob=(value)=>{
+    const radio=homeJobRadios.find((item)=>item.value===value)||homeJobRadios[0];
+    if(radio)radio.checked=true;
+    return radio?.value||'';
+  };
+  const homeJobParams=new URLSearchParams(location.search);
+  const syncHomeJobURL=(value)=>{
+    if(location.protocol==='file:')return;
+    const next=new URL(location.href);
+    if(value)next.searchParams.set('job',value);
+    else next.searchParams.delete('job');
+    history.replaceState(null,'',next);
+  };
+  const requestedHomeJob=homeJobParams.get('job');
+  const selectedHomeJob=selectHomeJob(requestedHomeJob);
+  if(requestedHomeJob&&requestedHomeJob!==selectedHomeJob)syncHomeJobURL('');
+  homeJobRadios.forEach((radio)=>radio.addEventListener('change',()=>{
+    if(radio.checked)syncHomeJobURL(radio.value);
+  }));
+  window.addEventListener('popstate',()=>{
+    const requested=new URLSearchParams(location.search).get('job');
+    const selected=selectHomeJob(requested);
+    if(requested&&requested!==selected)syncHomeJobURL('');
+  });
+}
+
+document.querySelectorAll('.doc pre,[data-copyable]').forEach(pre=>{const btn=document.createElement('button');const copyLabel=pre.dataset.copyLabel||'Copy code';btn.type='button';btn.className='copy';btn.setAttribute('aria-live','polite');btn.setAttribute('aria-label',copyLabel);btn.textContent='Copy';btn.addEventListener('click',async()=>{const code=pre.dataset.copyText??pre.querySelector('code')?.textContent??'';try{await navigator.clipboard.writeText(code);btn.textContent='Copied';btn.setAttribute('aria-label','Copied');btn.classList.add('copied');setTimeout(()=>{btn.textContent='Copy';btn.setAttribute('aria-label',copyLabel);btn.classList.remove('copied')},1400)}catch{btn.textContent='Failed';btn.setAttribute('aria-label','Copy failed');setTimeout(()=>{btn.textContent='Copy';btn.setAttribute('aria-label',copyLabel)},1400)}});pre.appendChild(btn)});
 
 const tocLinks=document.querySelectorAll('.toc a');
 if(tocLinks.length){const map=new Map();tocLinks.forEach(a=>{const id=a.getAttribute('href').slice(1);const el=document.getElementById(id);if(el)map.set(el,a)});const setActive=l=>{tocLinks.forEach(x=>x.classList.remove('active'));l.classList.add('active')};const obs=new IntersectionObserver(entries=>{const visible=entries.filter(e=>e.isIntersecting).sort((a,b)=>a.boundingClientRect.top-b.boundingClientRect.top);if(visible.length){const link=map.get(visible[0].target);if(link)setActive(link)}},{rootMargin:'-15% 0px -65% 0px',threshold:0});map.forEach((_,el)=>obs.observe(el))}

--- a/scripts/build-docs-site.test.js
+++ b/scripts/build-docs-site.test.js
@@ -9,6 +9,7 @@ import { markdownToHtml } from "./build-docs-site.mjs";
 const repoRoot = path.resolve(import.meta.dirname, "..");
 const providersDir = path.join(repoRoot, "docs", "providers");
 const integrationsDir = path.join(repoRoot, "docs", "integrations");
+const useCasesFile = path.join(repoRoot, "docs", "use-cases.md");
 const siteDir = path.join(repoRoot, "dist", "docs-site");
 const providerIndexFile = path.join(siteDir, "providers", "index.html");
 const generatedTest = fs.existsSync(providerIndexFile) ? test : test.skip;
@@ -161,15 +162,101 @@ generatedTest("generated AWS page is active in Providers navigation and pager", 
   assert.match(pager, new RegExp(`href="\.\./providers/${escapeRegExp(next)}"`));
 });
 
-generatedTest("homepage primary CTA targets an indexed Start page", () => {
+generatedTest("homepage presents use-case, pricing, and onboarding paths", () => {
   const home = readGenerated("index.html");
   const startNav = navSection(home, "Start");
   const gettingStarted = readGenerated("getting-started.html");
+  const useCases = readGenerated("use-cases.html");
+  const pricing = readGenerated("pricing.html");
 
-  assert.match(home, /<a class="cta-primary" href="getting-started\.html">Get started<\/a>/);
+  assert.match(
+    home,
+    /<title>Crabbox — Run Any Repository Command in the Right Box<\/title>/,
+  );
+  assert.match(home, /<meta name="description" content="[^"]+">/);
+  assert.match(home, /<link rel="canonical" href="https:\/\/crabbox\.sh\/">/);
+  assert.match(home, /<meta property="og:title" content="Crabbox — Run Any Repository Command in the Right Box">/);
+  assert.match(home, /navParams\.get\('docs'\)/);
+  assert.match(home, /next\.searchParams\.set\('docs',value\)/);
+  assert.match(
+    home,
+    /<a class="cta-primary" href="getting-started\.html">Run Your First Command<\/a>/,
+  );
+  assert.match(
+    home,
+    /<a class="cta-secondary" href="#home-use-cases-heading">Route Your Workload<\/a>/,
+  );
+  assert.match(home, /<form class="home-job-finder" data-home-job-finder>/);
+  assert.equal(occurrences(home, 'class="home-job-radio sr-only"'), 6, "homepage should expose six job choices");
+  assert.equal(occurrences(home, 'class="home-job-result"'), 6, "every job choice should have a result");
+  assert.equal(occurrences(home, 'data-home-job-radio checked'), 1, "job finder should have one default route");
+  assert.equal(occurrences(home, 'aria-controls="home-job-result-'), 6, "every job choice should identify its result");
+  assert.equal(occurrences(home, "data-copy-text="), 6, "every job result should expose a runnable copy target");
+  assert.doesNotMatch(home, /data-copy-text="[^"]*\$/);
+  assert.doesNotMatch(home, /data-copy-text="[^"]*&lt;name&gt;/);
+  assert.match(home, /homeJobParams\.get\('job'\)/);
+  assert.match(home, /next\.searchParams\.set\('job',value\)/);
+  const useCaseAnchors = [...home.matchAll(/<a href="use-cases\.html#([^"]+)">Open the /g)]
+    .map((match) => match[1]);
+  assert.equal(useCaseAnchors.length, 6);
+  for (const anchor of useCaseAnchors) {
+    assert.match(useCases, new RegExp(`id="${escapeRegExp(anchor)}"`), `homepage use-case anchor ${anchor} should exist`);
+  }
+  const providersSource = fs.readFileSync(path.join(repoRoot, "internal", "cli", "providers.go"), "utf8");
+  const registry = providersSource.match(
+    /func providerRecommendationUseCases\(\) \[\]string \{\s*return \[\]string\{([\s\S]*?)\n\t\}\n\}/,
+  );
+  assert.ok(registry, "provider recommendation registry should be readable");
+  const registered = new Set([...registry[1].matchAll(/"([a-z][a-z0-9-]*)"/g)].map((match) => match[1]));
+  const finderRecommendations = [...home.matchAll(/class="home-job-command-line"><i aria-hidden="true">\$<\/i><b>crabbox providers recommend ([a-z][a-z0-9-]*)/g)]
+    .map((match) => match[1]);
+  assert.equal(finderRecommendations.length, 9, "job finder should expose every intended starting route");
+  assert.deepEqual(
+    [...new Set(finderRecommendations.filter((name) => !registered.has(name)))],
+    [],
+    "job finder recommendations should stay on the canonical CLI surface",
+  );
+  const providerCount = Object.keys(
+    JSON.parse(fs.readFileSync(path.join(providersDir, "provider-metadata.json"), "utf8")),
+  ).length;
+  assert.match(home, new RegExp(`<li>${providerCount} registered providers</li>`));
+  assert.match(home, new RegExp(`Turn ${providerCount} registered providers into a focused comparison path\\.`));
+  assert.match(home, /href="pricing\.html">See Pricing and Cost Boundaries/);
+  assert.match(home, /There is no generic nested mode\./);
+  assert.match(home, /href="features\/nested-execution\.html">Read the exact boundaries/);
+  assert.match(home, /<aside class="home-trust"[^>]*aria-labelledby="home-trust-heading">/);
+  assert.doesNotMatch(
+    home,
+    /<div class="doc-grid/,
+    "homepage should end after its decision journey instead of embedding the full docs README",
+  );
   assert.match(startNav, /href="getting-started\.html"[^>]*>Getting Started<\/a>/);
+  assert.match(startNav, /href="use-cases\.html"[^>]*>Use Cases<\/a>/);
+  assert.match(startNav, /href="pricing\.html"[^>]*>Pricing and Costs<\/a>/);
   assert.match(gettingStarted, /<a class="nav-link active" href="getting-started\.html"[^>]*aria-current="page">Getting Started<\/a>/);
+  assert.match(useCases, /<a class="nav-link active" href="use-cases\.html"[^>]*aria-current="page">Use Cases<\/a>/);
+  assert.match(pricing, /<a class="nav-link active" href="pricing\.html"[^>]*aria-current="page">Pricing and Costs<\/a>/);
   assert.match(gettingStarted, /<nav class="page-nav"/);
+});
+
+test("use-case guide only invokes registered provider recommendations", () => {
+  const providersSource = fs.readFileSync(path.join(repoRoot, "internal", "cli", "providers.go"), "utf8");
+  const registry = providersSource.match(
+    /func providerRecommendationUseCases\(\) \[\]string \{\s*return \[\]string\{([\s\S]*?)\n\t\}\n\}/,
+  );
+  assert.ok(registry, "provider recommendation registry should be readable");
+  const registered = new Set([...registry[1].matchAll(/"([a-z][a-z0-9-]*)"/g)].map((match) => match[1]));
+  const guide = fs.readFileSync(useCasesFile, "utf8");
+  const invoked = [...guide.matchAll(/^crabbox providers recommend(?: ([a-z][a-z0-9-]*))?(?:\s|$)/gm)]
+    .map((match) => match[1])
+    .filter(Boolean);
+
+  assert.ok(invoked.length > 0, "use-case guide should include recommendation examples");
+  assert.deepEqual(
+    [...new Set(invoked.filter((name) => !registered.has(name)))],
+    [],
+    "use-case guide recommendations should stay on the canonical CLI surface",
+  );
 });
 
 generatedTest("provider index renders filterable rows in a scroll region", () => {
@@ -184,6 +271,9 @@ generatedTest("provider index renders filterable rows in a scroll region", () =>
   assert.match(filter, /data-provider-group-filter="all"[^>]*aria-pressed="true"/);
   assert.match(filter, /data-provider-empty/);
   assert.match(matrixRegion, /<table class="provider-matrix">/);
+  assert.match(html, /new URLSearchParams\(location\.search\)/);
+  assert.match(html, /providerParams\.get\('group'\)/);
+  assert.match(html, /providerParams\.get\('q'\)/);
   assert.equal(
     occurrences(html, "split(/\\s+/)"),
     3,
@@ -265,6 +355,7 @@ generatedTest("generated Features navigation stays capability-focused", () => {
   }
 
   assert.match(featuresNav, /href="\.\.\/features\/configuration\.html"/);
+  assert.match(featuresNav, /href="\.\.\/features\/nested-execution\.html"/);
   assert.match(featuresNav, /href="\.\.\/features\/sync\.html"/);
   assert.match(featuresNav, /href="\.\.\/features\/artifacts\.html"/);
 });

--- a/scripts/docs-ui-proof.mjs
+++ b/scripts/docs-ui-proof.mjs
@@ -19,6 +19,10 @@ const featuresPage = path.join(siteDir, "features", "index.html");
 if (!fs.existsSync(featuresPage)) {
   throw new Error(`generated Features page not found: ${featuresPage}`);
 }
+const homePage = path.join(siteDir, "index.html");
+if (!fs.existsSync(homePage)) {
+  throw new Error(`generated homepage not found: ${homePage}`);
+}
 
 fs.mkdirSync(outDir, { recursive: true });
 for (const artifact of [
@@ -28,6 +32,9 @@ for (const artifact of [
   "features-empty-desktop.png",
   "features-desktop-dark.png",
   "features-mobile.png",
+  "home-desktop-light.png",
+  "home-desktop-dark.png",
+  "home-mobile.png",
   "interaction-proof.json",
   "SHA256SUMS",
 ]) {
@@ -64,7 +71,7 @@ const server = http.createServer((request, response) => {
 
 const baseURL = await listen(server, preferredPort, explicitPort);
 const proof = {
-  subject: "Features explorer browser proof",
+  subject: "Docs browser proof",
   source: {
     commit: process.env.CRABBOX_DOCS_PROOF_COMMIT || process.env.GITHUB_SHA || null,
     workflowCommit: process.env.GITHUB_SHA || null,
@@ -73,6 +80,7 @@ const proof = {
     runId: process.env.GITHUB_RUN_ID || null,
   },
   url: `${baseURL}/features/`,
+  homeUrl: `${baseURL}/`,
   siteDir: path.relative(process.cwd(), siteDir) || ".",
   outDir: path.relative(process.cwd(), outDir) || ".",
   screenshots: [],
@@ -101,6 +109,12 @@ try {
   await proveEscapeClears(desktopLight.page);
   await proveEmptyResult(desktopLight.page);
   await screenshot(desktopLight.page, "features-empty-desktop.png");
+  await openHome(desktopLight.page);
+  await assertHomeShell(desktopLight.page, "desktop light");
+  await proveHomeJobFinder(desktopLight.page);
+  await openHome(desktopLight.page);
+  await assertHomeShell(desktopLight.page, "desktop light restored");
+  await screenshot(desktopLight.page, "home-desktop-light.png");
   await assertNoPageErrors(desktopLight);
   await desktopLight.context.close();
   activeProofPage = undefined;
@@ -114,6 +128,10 @@ try {
   await assertTheme(desktopDark.page, "dark");
   await assertFeatureShell(desktopDark.page);
   await screenshot(desktopDark.page, "features-desktop-dark.png");
+  await openHome(desktopDark.page);
+  await assertTheme(desktopDark.page, "dark");
+  await assertHomeShell(desktopDark.page, "desktop dark");
+  await screenshot(desktopDark.page, "home-desktop-dark.png");
   await assertNoPageErrors(desktopDark);
   await desktopDark.context.close();
   activeProofPage = undefined;
@@ -128,6 +146,10 @@ try {
   await assertTheme(mobile.page, "light");
   await assertMobileLayout(mobile.page);
   await screenshot(mobile.page, "features-mobile.png");
+  await openHome(mobile.page);
+  await assertTheme(mobile.page, "light");
+  await assertHomeShell(mobile.page, "mobile light");
+  await screenshot(mobile.page, "home-mobile.png");
   await assertNoPageErrors(mobile);
   await mobile.context.close();
   activeProofPage = undefined;
@@ -137,6 +159,12 @@ try {
   await proveFilePreview(filePreview.page);
   await assertNoPageErrors(filePreview);
   await filePreview.context.close();
+  activeProofPage = undefined;
+
+  const noScriptHome = await openNoScriptHome(browser);
+  activeProofPage = noScriptHome;
+  await proveNoScriptHome(noScriptHome.page);
+  await noScriptHome.context.close();
   activeProofPage = undefined;
 } catch (error) {
   failure = error;
@@ -257,12 +285,182 @@ async function openFilePreview(browser) {
   return { context, page, errors, name: "direct file preview" };
 }
 
+async function openNoScriptHome(browser) {
+  const context = await browser.newContext({
+    colorScheme: "light",
+    javaScriptEnabled: false,
+    reducedMotion: "reduce",
+    viewport: { width: 1280, height: 900 },
+  });
+  await context.route("**/*", (route) => {
+    const url = route.request().url();
+    if (url.startsWith(baseURL) || url.startsWith("data:")) return route.continue();
+    return route.abort("blockedbyclient");
+  });
+  const page = await context.newPage();
+  page.setDefaultTimeout(7000);
+  await page.goto(proof.homeUrl, { waitUntil: "domcontentloaded" });
+  await page.locator('[data-home-job-radio][value="fast-feedback"]').waitFor({ state: "attached" });
+  return { context, page, errors: [], name: "no-script homepage" };
+}
+
+async function openHome(page) {
+  await page.goto(proof.homeUrl, { waitUntil: "domcontentloaded" });
+  await page.addStyleTag({
+    content:
+      "*,*:before,*:after{animation:none!important;transition:none!important;caret-color:transparent!important}html{scroll-behavior:auto!important}",
+  });
+  await page.locator(".hero-home h1").waitFor({ state: "visible" });
+  await page.waitForFunction(() => document.querySelectorAll("[data-home-job-radio]").length === 6);
+  await page.evaluate(async () => {
+    if (document.fonts?.ready) await document.fonts.ready;
+  });
+  await page.waitForTimeout(50);
+}
+
+async function assertHomeShell(page, name) {
+  await assertText(page, ".hero-home h1", /Run Your Code in\s+the Right Box\./, `${name} homepage headline is intact`);
+  await assertVisible(page, ".home-capability-note", `${name} nested-capability boundary is visible`);
+  const layout = await page.evaluate(() => ({
+    innerWidth: window.innerWidth,
+    scrollWidth: Math.max(document.documentElement.scrollWidth, document.body.scrollWidth),
+    jobChoices: document.querySelectorAll("[data-home-job-radio]").length,
+    jobResults: document.querySelectorAll("[data-home-job-result]").length,
+    visibleJobResults: [...document.querySelectorAll("[data-home-job-result]")]
+      .filter((result) => getComputedStyle(result).display !== "none")
+      .map((result) => result.getAttribute("data-home-job-result")),
+    selectedJob: document.querySelector("[data-home-job-radio]:checked")?.value || "",
+    minimumJobChoiceHeight: Math.min(
+      ...[...document.querySelectorAll(".home-job-option label")].map((label) => label.getBoundingClientRect().height),
+    ),
+    visibleFinderCopyButtons: [...document.querySelectorAll(".home-job-command .copy")]
+      .filter((button) => button.getClientRects().length > 0 && getComputedStyle(button).opacity !== "0")
+      .map((button) => button.getBoundingClientRect().height),
+    controlledJobResults: [...document.querySelectorAll("[data-home-job-radio]")]
+      .filter((radio) => document.getElementById(radio.getAttribute("aria-controls"))).length,
+    finderDisclaimer: document.querySelector(".home-job-disclaimer")?.textContent.replace(/\s+/g, " ").trim() || "",
+    capabilityText: document.querySelector(".home-capability-note")?.textContent.replace(/\s+/g, " ").trim() || "",
+    example: document.querySelector(".home-console pre")?.textContent.trim() || "",
+    registeredProviders: document.querySelector(".home-facts li:last-child")?.textContent.trim() || "",
+  }));
+  proof.interactions.home ||= {};
+  proof.interactions.home[name] = layout;
+  assert(layout.scrollWidth <= layout.innerWidth + 1, `${name} homepage has no horizontal overflow`, layout);
+  assert(layout.jobChoices === 6, `${name} homepage exposes six curated job choices`, layout);
+  assert(layout.jobResults === 6, `${name} homepage provides one route per job`, layout);
+  assert(layout.visibleJobResults.length === 1, `${name} homepage exposes exactly one job result`, layout);
+  assert(layout.visibleJobResults[0] === layout.selectedJob, `${name} selected job controls the visible result`, layout);
+  assert(layout.minimumJobChoiceHeight >= 44, `${name} job choices meet the minimum touch target`, layout);
+  assert(
+    layout.visibleFinderCopyButtons.length === 1 && layout.visibleFinderCopyButtons[0] >= 44,
+    `${name} finder copy control remains discoverable and meets the minimum touch target`,
+    layout,
+  );
+  assert(layout.controlledJobResults === 6, `${name} job choices identify their result panels`, layout);
+  assert(layout.finderDisclaimer.includes("Built-in guidance, not a live provider check."), `${name} homepage states the recommendation boundary`, layout);
+  assert(layout.capabilityText.includes("There is no generic nested mode."), `${name} homepage states the nested boundary`, layout);
+  assert(layout.example.includes("--provider local-container"), `${name} homepage example names its provider`, layout);
+  assert(/^\d+ registered providers$/.test(layout.registeredProviders), `${name} homepage provider count is explicit`, layout);
+}
+
+async function proveHomeJobFinder(page) {
+  await page.goto(`${proof.homeUrl}?job=not-a-route`, { waitUntil: "domcontentloaded" });
+  await page.locator('[data-home-job-radio][value="fast-feedback"]').waitFor({ state: "attached" });
+  let state = await page.evaluate(() => ({
+    job: new URL(location.href).searchParams.get("job"),
+    checked: document.querySelector("[data-home-job-radio]:checked")?.value,
+  }));
+  assert(state.job === null, "job finder removes an invalid deep-link route", state);
+  assert(state.checked === "fast-feedback", "invalid job route falls back to the default", state);
+
+  await page.locator('label[for="home-job-gpu"]').click();
+  await page.waitForFunction(() => new URL(location.href).searchParams.get("job") === "gpu");
+  state = await page.evaluate(() => ({
+    job: new URL(location.href).searchParams.get("job"),
+    checked: document.querySelector("[data-home-job-radio]:checked")?.value,
+    visible: [...document.querySelectorAll("[data-home-job-result]")]
+      .filter((result) => getComputedStyle(result).display !== "none")
+      .map((result) => result.getAttribute("data-home-job-result")),
+    command: document.querySelector('[data-home-job-result="gpu"] code')?.textContent || "",
+    copyText: document.querySelector('[data-home-job-result="gpu"] [data-copy-text]')?.dataset.copyText || "",
+  }));
+  assert(state.job === "gpu", "job finder writes shareable URL state", state);
+  assert(state.checked === "gpu", "job finder selects the requested GPU route", state);
+  assert(state.visible.length === 1 && state.visible[0] === "gpu", "job finder shows only the GPU result", state);
+  assert(state.command.includes("crabbox providers recommend gpu"), "GPU route exposes the canonical recommendation", state);
+  assert(state.copyText === "crabbox providers recommend gpu", "GPU route copies only the runnable recommendation", state);
+  await page.context().grantPermissions(["clipboard-read", "clipboard-write"], { origin: new URL(baseURL).origin });
+  await page.locator('[data-home-job-result="gpu"] .copy').click();
+  await page.locator('[data-home-job-result="gpu"] .copy').getByText("Copied").waitFor();
+  const copiedCommand = await page.evaluate(() => navigator.clipboard.readText());
+  assert(copiedCommand === "crabbox providers recommend gpu", "finder clipboard contains the exact runnable recommendation", {
+    copiedCommand,
+  });
+
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await page.locator('[data-home-job-radio][value="gpu"]').waitFor({ state: "attached" });
+  state = await page.evaluate(() => ({
+    checked: document.querySelector("[data-home-job-radio]:checked")?.value,
+    visible: [...document.querySelectorAll("[data-home-job-result]")]
+      .filter((result) => getComputedStyle(result).display !== "none")
+      .map((result) => result.getAttribute("data-home-job-result")),
+  }));
+  assert(state.checked === "gpu", "job finder restores a deep-linked route", state);
+  assert(state.visible.length === 1 && state.visible[0] === "gpu", "deep-linked route restores the matching result", state);
+
+  const gpuRadio = page.locator('[data-home-job-radio][value="gpu"]');
+  await gpuRadio.focus();
+  await gpuRadio.press("ArrowLeft");
+  await page.waitForFunction(() => new URL(location.href).searchParams.get("job") === "fanout-testing");
+  state = await page.evaluate(() => ({
+    job: new URL(location.href).searchParams.get("job"),
+    checked: document.querySelector("[data-home-job-radio]:checked")?.value,
+  }));
+  assert(state.job === "fanout-testing" && state.checked === "fanout-testing", "native radio keyboard navigation updates the route", state);
+}
+
 async function proveFilePreview(page) {
   const initialURL = page.url();
   await page.locator("#fx-search").fill("desktop");
   const visibleCards = await page.locator("[data-fx-card]:visible").count();
   assert(visibleCards > 0, "direct file preview search remains interactive", { visibleCards });
   assert(page.url() === initialURL, "direct file preview avoids unsupported History API writes", { url: page.url() });
+
+  await page.goto(pathToFileURL(homePage).href, { waitUntil: "domcontentloaded" });
+  await page.locator('label[for="home-job-gpu"]').click();
+  const fileJobState = await page.evaluate(() => ({
+    url: location.href,
+    checked: document.querySelector("[data-home-job-radio]:checked")?.value,
+    visible: [...document.querySelectorAll("[data-home-job-result]")]
+      .filter((result) => getComputedStyle(result).display !== "none")
+      .map((result) => result.getAttribute("data-home-job-result")),
+  }));
+  assert(fileJobState.checked === "gpu", "direct file preview job finder remains interactive", fileJobState);
+  assert(fileJobState.visible.length === 1 && fileJobState.visible[0] === "gpu", "direct file preview updates the job result", fileJobState);
+  assert(!new URL(fileJobState.url).searchParams.has("job"), "direct file preview job finder avoids unsupported History API writes", fileJobState);
+}
+
+async function proveNoScriptHome(page) {
+  await page.locator('[data-home-job-radio][value="gpu"]').focus();
+  await page.keyboard.press("Space");
+  let state = await noScriptJobState(page);
+  assert(state.checked === "gpu", "no-script job finder selects a route with native controls", state);
+  assert(state.visible.length === 1 && state.visible[0] === "gpu", "no-script job finder shows the selected result", state);
+
+  await page.keyboard.press("ArrowLeft");
+  state = await noScriptJobState(page);
+  assert(state.checked === "fanout-testing", "no-script job finder supports native keyboard navigation", state);
+  assert(state.visible.length === 1 && state.visible[0] === "fanout-testing", "no-script keyboard navigation updates the result", state);
+  proof.interactions.noScriptHome = state;
+}
+
+async function noScriptJobState(page) {
+  return page.evaluate(() => ({
+    checked: document.querySelector("[data-home-job-radio]:checked")?.value || "",
+    visible: [...document.querySelectorAll("[data-home-job-result]")]
+      .filter((result) => getComputedStyle(result).display !== "none")
+      .map((result) => result.getAttribute("data-home-job-result")),
+  }));
 }
 
 async function assertFeatureShell(page) {


### PR DESCRIPTION
## Summary

- redesign the docs homepage around the decisions visitors actually make: job, ownership model, cost, then runtime boundary
- replace the static use-case grid with an accessible, URL-addressable workload router that emits canonical `providers recommend` commands and copies only runnable recommendations
- add use-case and pricing guides grounded in the existing provider-recommendation and cost surfaces
- document the current WSL2, container-engine, prepared-KVM, and local-sandbox paths without implying a universal nested mode or child-lease API
- improve generated-site metadata, URL-backed search and provider filters, responsiveness, accessibility, and regression coverage
- extend Docs UI Proof with homepage captures and assertions at desktop, dark-mode, mobile, direct-file, and JavaScript-disabled states

## Why

Crabbox exposes 79 registered providers, but an inventory-first site makes visitors decode the catalog before they can answer simpler questions: which workflow fits, where it can run, who owns the runtime, and what they will pay.

This PR makes that decision path explicit while preserving implementation truth. The workload router uses built-in capability metadata rather than inventing live rankings, prices, quota, benchmarks, or security claims. Crabbox software is MIT-licensed; compute remains billed by the workstation, infrastructure account, or selected provider. WSL2 and KVM are presented as conditional target capabilities, not as one generic nested-box promise.

## User impact

Visitors can start from fast test loops, coding agents, cross-platform validation, browser/desktop QA, parallel experiments, or GPU workloads. Each route produces the exact checked-in recommendation command, a follow-up `crabbox doctor` step, and a link to the detailed guide. Selections are keyboard-operable, survive reloads through `?job=`, and still work without JavaScript.

No CLI configuration, coordinator behavior, provider lifecycle, credentials, or secret handling changes.

## Validation

- `scripts/check-docs.sh`
  - 56 command docs checked
  - 79-provider matrix checked
  - 237 Markdown files and internal links checked
  - 14 generated-site tests passed
  - navigation normalized across 232 generated pages
- `node scripts/docs-ui-proof.mjs`
  - 159/159 browser assertions passed
  - exact clipboard payload verified
  - valid, invalid, and restored `?job=` states verified
  - native keyboard and true JavaScript-disabled interaction verified
  - no JavaScript errors or horizontal overflow
  - desktop light, desktop dark, and mobile homepage screenshots generated alongside the feature-explorer proof
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output`
  - TruffleHog scan clean
  - no accepted or actionable review findings

The Docs UI Proof workflow publishes the generated browser artifacts; screenshots are not checked into the source tree.