### PR TITLE
chore(release): prepare v0.40.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## 0.40.1 - Unreleased
+## 0.40.1 - 2026-07-23
+
+### Added
+
+- Documented Tensorlake's public `tl-crabbox` image, its writable `/workspace`, and its pnpm-ready setup guide.
+
+### Fixed
+
+- Forwarded explicit ARM64 and AMD64 guest architecture selections to Apple Container while preserving the implicit native ARM64 path.
 
 ## 0.40.0 - 2026-07-19
 
@@ -18,7 +26,6 @@
 
 ### Fixed
 
-- Forwarded explicit ARM64 and AMD64 guest architecture selections to Apple Container while preserving the implicit native ARM64 path.
 - Made `cp` over resolved SSH prefer rsync secluded arguments whenever the remote rsync supports them, so remote paths travel over the rsync protocol instead of the remote shell command line. This sidesteps an upstream rsync 3.4.4 `safe_arg()` bug that appends one uninitialized heap byte after a backslash-escaped wildcard (e.g. `\[`), which intermittently corrupted remote copy paths; remotes without secluded-args support (such as macOS openrsync) keep the previous shell-transported behavior. Thanks @zozo123.
 - Kept Cloud Run sandbox creation and cleanup fail-closed: indeterminate creates retain exact recovery claims while definitive conflicts drop provisional ownership, cleanup serializes against active work and concurrent reclaim, absolute lease TTLs are enforced, failed destroys remain tracked and reported for retry, direct payloads travel on stdin instead of argv, and remote gateways must confirm durable routing plus synchronous deletion. Thanks @zozo123.
 - Bound GitHub OAuth callbacks independently to each initiating browser flow and bound sessions, durable ownership, admin grants, and revocations to immutable GitHub account IDs instead of reassignable emails or logins, with a fail-closed operator recovery path for legacy records. Thanks @zozo123.

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/crabbox-worker",
-  "version": "0.40.0",
+  "version": "0.40.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/crabbox-worker",
-      "version": "0.40.0",
+      "version": "0.40.1",
       "dependencies": {
         "@aws-sdk/credential-providers": "^3.1084.0",
         "@cloudflare/containers": "^0.3.7",

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/crabbox-worker",
-  "version": "0.40.0",
+  "version": "0.40.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Prepares the protected source commit for v0.40.1.

Release notes:

- Apple Container forwards explicit ARM64 and AMD64 guest architecture selections.
- Tensorlake documentation now covers the public tl-crabbox image and setup guide.

Verification completed locally:

- go vet ./...
- go test -race ./...
- scripts/test-go-modules.sh
- scripts/check-go-coverage.sh 90.0
- Worker format, lint, typecheck, tests, and dry-run build
- node --test scripts/*.test.js
- scripts/check-docs.sh
- real Blacksmith Testbox smoke tbx_01ky7jfsmdsamqtxt1e47n5e7s
