### PR TITLE
feat(tart): support random clone serials

### DIFF
--- a/docs/providers/tart.md
+++ b/docs/providers/tart.md
@@ -55,11 +55,18 @@ tart:
   cpus: 4
   memory: 8192
   # disk: 80  # only set to resize beyond the base image default
+  # usbPassthrough: true  # macOS 27+ host; requires a signed Tart build
 ```
 
 Environment variables: `CRABBOX_TART_IMAGE`, `CRABBOX_TART_USER`,
 `CRABBOX_TART_PASSWORD`, `CRABBOX_TART_WORK_ROOT`, `CRABBOX_TART_CPUS`,
-`CRABBOX_TART_MEMORY`, `CRABBOX_TART_DISK`.
+`CRABBOX_TART_MEMORY`, `CRABBOX_TART_DISK`, `CRABBOX_TART_RANDOM_SERIAL`,
+`CRABBOX_TART_USB_PASSTHROUGH`.
+
+USB passthrough is opt-in. On a macOS 27 or newer host it adds Tart's
+`--usb-passthrough` run flag. The Tart executable must be Dock-visible and
+signed with Apple's `com.apple.developer.accessory-access.usb` entitlement.
+The host user selects the physical accessory from macOS's accessory menu.
 
 `CRABBOX_TART_PASSWORD` (or `tart.password` in the mode-0600 user config printed
 by `crabbox config path`) is the guest account password the local WebVNC viewer

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -1323,13 +1323,14 @@ type MultipassConfig struct {
 }
 
 type TartConfig struct {
-	Image    string
-	User     string
-	Password string
-	WorkRoot string
-	CPUs     int
-	Memory   int
-	Disk     int
+	Image        string
+	User         string
+	Password     string
+	WorkRoot     string
+	CPUs         int
+	Memory       int
+	Disk         int
+	RandomSerial bool
 }
 
 type LumeConfig struct {
@@ -4606,13 +4607,14 @@ type fileMultipassConfig struct {
 }
 
 type fileTartConfig struct {
-	Image    string `yaml:"image,omitempty"`
-	User     string `yaml:"user,omitempty"`
-	Password string `yaml:"password,omitempty"`
-	WorkRoot string `yaml:"workRoot,omitempty"`
-	CPUs     *int   `yaml:"cpus,omitempty"`
-	Memory   *int   `yaml:"memory,omitempty"`
-	Disk     *int   `yaml:"disk,omitempty"`
+	Image        string `yaml:"image,omitempty"`
+	User         string `yaml:"user,omitempty"`
+	Password     string `yaml:"password,omitempty"`
+	WorkRoot     string `yaml:"workRoot,omitempty"`
+	CPUs         *int   `yaml:"cpus,omitempty"`
+	Memory       *int   `yaml:"memory,omitempty"`
+	Disk         *int   `yaml:"disk,omitempty"`
+	RandomSerial *bool  `yaml:"randomSerial,omitempty"`
 }
 
 type fileLumeConfig struct {
@@ -7637,6 +7639,9 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 			cfg.Tart.Disk = *file.Tart.Disk
 			cfg.tartDiskExplicit = true
 		}
+		if file.Tart.RandomSerial != nil {
+			cfg.Tart.RandomSerial = *file.Tart.RandomSerial
+		}
 	}
 	if file.Lume != nil {
 		if trusted {
@@ -9608,6 +9613,9 @@ func applyEnv(cfg *Config) error {
 	if v := os.Getenv("CRABBOX_TART_DISK"); v != "" {
 		cfg.Tart.Disk = getenvInt("CRABBOX_TART_DISK", cfg.Tart.Disk)
 		cfg.tartDiskExplicit = cfg.Tart.Disk > 0
+	}
+	if v, ok := getenvBool("CRABBOX_TART_RANDOM_SERIAL"); ok {
+		cfg.Tart.RandomSerial = v
 	}
 	cfg.Lume.CLIPath = getenv("CRABBOX_LUME_CLI", cfg.Lume.CLIPath)
 	cfg.Lume.Base = getenv("CRABBOX_LUME_BASE", cfg.Lume.Base)

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -1323,14 +1323,15 @@ type MultipassConfig struct {
 }
 
 type TartConfig struct {
-	Image        string
-	User         string
-	Password     string
-	WorkRoot     string
-	CPUs         int
-	Memory       int
-	Disk         int
-	RandomSerial bool
+	Image          string
+	User           string
+	Password       string
+	WorkRoot       string
+	CPUs           int
+	Memory         int
+	Disk           int
+	RandomSerial   bool
+	USBPassthrough bool
 }
 
 type LumeConfig struct {
@@ -4607,14 +4608,15 @@ type fileMultipassConfig struct {
 }
 
 type fileTartConfig struct {
-	Image        string `yaml:"image,omitempty"`
-	User         string `yaml:"user,omitempty"`
-	Password     string `yaml:"password,omitempty"`
-	WorkRoot     string `yaml:"workRoot,omitempty"`
-	CPUs         *int   `yaml:"cpus,omitempty"`
-	Memory       *int   `yaml:"memory,omitempty"`
-	Disk         *int   `yaml:"disk,omitempty"`
-	RandomSerial *bool  `yaml:"randomSerial,omitempty"`
+	Image          string `yaml:"image,omitempty"`
+	User           string `yaml:"user,omitempty"`
+	Password       string `yaml:"password,omitempty"`
+	WorkRoot       string `yaml:"workRoot,omitempty"`
+	CPUs           *int   `yaml:"cpus,omitempty"`
+	Memory         *int   `yaml:"memory,omitempty"`
+	Disk           *int   `yaml:"disk,omitempty"`
+	RandomSerial   *bool  `yaml:"randomSerial,omitempty"`
+	USBPassthrough *bool  `yaml:"usbPassthrough,omitempty"`
 }
 
 type fileLumeConfig struct {
@@ -7642,6 +7644,9 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 		if file.Tart.RandomSerial != nil {
 			cfg.Tart.RandomSerial = *file.Tart.RandomSerial
 		}
+		if file.Tart.USBPassthrough != nil {
+			cfg.Tart.USBPassthrough = *file.Tart.USBPassthrough
+		}
 	}
 	if file.Lume != nil {
 		if trusted {
@@ -9616,6 +9621,9 @@ func applyEnv(cfg *Config) error {
 	}
 	if v, ok := getenvBool("CRABBOX_TART_RANDOM_SERIAL"); ok {
 		cfg.Tart.RandomSerial = v
+	}
+	if v, ok := getenvBool("CRABBOX_TART_USB_PASSTHROUGH"); ok {
+		cfg.Tart.USBPassthrough = v
 	}
 	cfg.Lume.CLIPath = getenv("CRABBOX_LUME_CLI", cfg.Lume.CLIPath)
 	cfg.Lume.Base = getenv("CRABBOX_LUME_BASE", cfg.Lume.Base)

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -3399,12 +3399,16 @@ func TestTartConfigDefaultsFileAndEnv(t *testing.T) {
 	t.Setenv("CRABBOX_TART_CPUS", "8")
 	t.Setenv("CRABBOX_TART_MEMORY", "16384")
 	t.Setenv("CRABBOX_TART_DISK", "100")
+	t.Setenv("CRABBOX_TART_RANDOM_SERIAL", "true")
 	applyEnv(&cfg)
 	if cfg.Tart.Image != "ghcr.io/env:latest" || cfg.Tart.User != "env-user" || cfg.Tart.WorkRoot != "/work/env" || cfg.Tart.CPUs != 8 || cfg.Tart.Memory != 16384 || cfg.Tart.Disk != 100 {
 		t.Fatalf("env tart config not applied: %+v", cfg.Tart)
 	}
 	if !cfg.tartDiskExplicit {
 		t.Fatal("positive CRABBOX_TART_DISK should mark tart disk explicit")
+	}
+	if !cfg.Tart.RandomSerial {
+		t.Fatal("CRABBOX_TART_RANDOM_SERIAL did not enable random serial")
 	}
 	t.Setenv("CRABBOX_TART_DISK", "0")
 	applyEnv(&cfg)
@@ -3793,10 +3797,12 @@ func TestTartConfigYAMLExplicitZeroPreserved(t *testing.T) {
 	file := fileConfig{}
 	zero := 0
 	negative := -1
+	randomSerial := true
 	file.Tart = &fileTartConfig{
-		CPUs:   &zero,
-		Memory: &zero,
-		Disk:   &negative,
+		CPUs:         &zero,
+		Memory:       &zero,
+		Disk:         &negative,
+		RandomSerial: &randomSerial,
 	}
 	if err := applyFileConfig(&cfg, file); err != nil {
 		t.Fatal(err)
@@ -3809,6 +3815,9 @@ func TestTartConfigYAMLExplicitZeroPreserved(t *testing.T) {
 	}
 	if cfg.Tart.Disk != -1 {
 		t.Fatalf("Tart.Disk=%d, want -1 (explicit YAML negative must be preserved)", cfg.Tart.Disk)
+	}
+	if !cfg.Tart.RandomSerial {
+		t.Fatal("Tart.RandomSerial=false, want true from YAML")
 	}
 	if !IsTartCPUsExplicit(&cfg) {
 		t.Fatal("tartCPUsExplicit must be true after YAML sets cpus")

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -3400,6 +3400,7 @@ func TestTartConfigDefaultsFileAndEnv(t *testing.T) {
 	t.Setenv("CRABBOX_TART_MEMORY", "16384")
 	t.Setenv("CRABBOX_TART_DISK", "100")
 	t.Setenv("CRABBOX_TART_RANDOM_SERIAL", "true")
+	t.Setenv("CRABBOX_TART_USB_PASSTHROUGH", "true")
 	applyEnv(&cfg)
 	if cfg.Tart.Image != "ghcr.io/env:latest" || cfg.Tart.User != "env-user" || cfg.Tart.WorkRoot != "/work/env" || cfg.Tart.CPUs != 8 || cfg.Tart.Memory != 16384 || cfg.Tart.Disk != 100 {
 		t.Fatalf("env tart config not applied: %+v", cfg.Tart)
@@ -3409,6 +3410,9 @@ func TestTartConfigDefaultsFileAndEnv(t *testing.T) {
 	}
 	if !cfg.Tart.RandomSerial {
 		t.Fatal("CRABBOX_TART_RANDOM_SERIAL did not enable random serial")
+	}
+	if !cfg.Tart.USBPassthrough {
+		t.Fatal("CRABBOX_TART_USB_PASSTHROUGH did not enable USB passthrough")
 	}
 	t.Setenv("CRABBOX_TART_DISK", "0")
 	applyEnv(&cfg)
@@ -3798,11 +3802,13 @@ func TestTartConfigYAMLExplicitZeroPreserved(t *testing.T) {
 	zero := 0
 	negative := -1
 	randomSerial := true
+	usbPassthrough := true
 	file.Tart = &fileTartConfig{
-		CPUs:         &zero,
-		Memory:       &zero,
-		Disk:         &negative,
-		RandomSerial: &randomSerial,
+		CPUs:           &zero,
+		Memory:         &zero,
+		Disk:           &negative,
+		RandomSerial:   &randomSerial,
+		USBPassthrough: &usbPassthrough,
 	}
 	if err := applyFileConfig(&cfg, file); err != nil {
 		t.Fatal(err)
@@ -3818,6 +3824,9 @@ func TestTartConfigYAMLExplicitZeroPreserved(t *testing.T) {
 	}
 	if !cfg.Tart.RandomSerial {
 		t.Fatal("Tart.RandomSerial=false, want true from YAML")
+	}
+	if !cfg.Tart.USBPassthrough {
+		t.Fatal("Tart.USBPassthrough=false, want true from YAML")
 	}
 	if !IsTartCPUsExplicit(&cfg) {
 		t.Fatal("tartCPUsExplicit must be true after YAML sets cpus")

--- a/internal/cli/desktop_input.go
+++ b/internal/cli/desktop_input.go
@@ -51,18 +51,25 @@ func (a App) desktopClick(ctx context.Context, args []string) error {
 	}
 	x, xOK := intFlagValue(args, "x")
 	y, yOK := intFlagValue(args, "y")
-	if !xOK || !yOK || x < 0 || y < 0 {
-		return exit(2, "usage: crabbox desktop click --id <lease-id-or-slug> --x <n> --y <n>")
+	count, countOK := intFlagValue(args, "count")
+	if !countOK {
+		count = 1
+	}
+	if !xOK || !yOK || x < 0 || y < 0 || count < 1 || count > 2 {
+		return exit(2, "usage: crabbox desktop click --id <lease-id-or-slug> --x <n> --y <n> [--count 1|2]")
 	}
 	if !desktopClickSupportsTarget(target) {
 		return exit(2, "desktop click supports target=linux, target=macos, or target=windows with windowsMode=normal")
 	}
 	if target.TargetOS == targetMacOS {
-		if err := clickRemoteMacVNC(ctx, cfg, target, x, y); err != nil {
+		if err := clickRemoteMacVNC(ctx, cfg, target, x, y, count); err != nil {
 			return exit(5, "desktop click failed for %s: %v", leaseID, err)
 		}
-		fmt.Fprintf(a.Stdout, "clicked: lease=%s x=%d y=%d method=vnc\n", leaseID, x, y)
+		fmt.Fprintf(a.Stdout, "clicked: lease=%s x=%d y=%d count=%d method=vnc\n", leaseID, x, y, count)
 		return nil
+	}
+	if count != 1 {
+		return exit(2, "desktop click --count is currently supported only for target=macos")
 	}
 	if out, err := runSSHCombinedOutput(ctx, target, desktopClickRemoteCommand(target, x, y)); err != nil {
 		a.printDesktopInputRescue(classifyDesktopFailure(out), out, cfg, target, leaseID)
@@ -210,6 +217,7 @@ func (a App) desktopCommandTarget(ctx context.Context, name string, args []strin
 	if strings.HasSuffix(name, "click") {
 		fs.Int("x", -1, "x coordinate")
 		fs.Int("y", -1, "y coordinate")
+		fs.Int("count", 1, "click count (macOS only: 1 or 2)")
 	}
 	if strings.HasSuffix(name, "paste") || strings.HasSuffix(name, "type") {
 		fs.String("text", "", "text to enter")

--- a/internal/cli/rfb_screenshot.go
+++ b/internal/cli/rfb_screenshot.go
@@ -81,7 +81,7 @@ func captureRemoteMacVNCScreenshot(ctx context.Context, cfg Config, target SSHTa
 	return nil
 }
 
-func clickRemoteMacVNC(ctx context.Context, cfg Config, target SSHTarget, x, y int) error {
+func clickRemoteMacVNC(ctx context.Context, cfg Config, target SSHTarget, x, y, count int) error {
 	tunnel, localPort, err := startVNCForegroundTunnelOnReservedPort(ctx, target, "", "127.0.0.1", managedVNCPort)
 	if err != nil {
 		return err
@@ -97,7 +97,7 @@ func clickRemoteMacVNC(ctx context.Context, cfg Config, target SSHTarget, x, y i
 		return fmt.Errorf("connect to verified macOS VNC tunnel: %w", err)
 	}
 	defer conn.Close()
-	if err := clickRFBPointerFromConn(ctx, conn, creds, authMode, x, y); err != nil {
+	if err := clickRFBPointerFromConnCount(ctx, conn, creds, authMode, x, y, count); err != nil {
 		return fmt.Errorf("click macOS VNC pointer: %w", err)
 	}
 	return nil
@@ -260,6 +260,10 @@ func rfbKeysymForRune(r rune) (uint32, error) {
 }
 
 func clickRFBPointerFromConn(ctx context.Context, conn net.Conn, creds rfbCredentials, authMode localWebVNCAuthenticationMode, x, y int) error {
+	return clickRFBPointerFromConnCount(ctx, conn, creds, authMode, x, y, 1)
+}
+
+func clickRFBPointerFromConnCount(ctx context.Context, conn net.Conn, creds rfbCredentials, authMode localWebVNCAuthenticationMode, x, y, count int) error {
 	if deadline, ok := ctx.Deadline(); ok {
 		_ = conn.SetDeadline(deadline)
 	} else {
@@ -273,14 +277,25 @@ func clickRFBPointerFromConn(ctx context.Context, conn net.Conn, creds rfbCreden
 	if x < 0 || y < 0 || x >= int(width) || y >= int(height) {
 		return fmt.Errorf("pointer coordinates %d,%d exceed framebuffer %dx%d", x, y, width, height)
 	}
+	if count < 1 || count > 2 {
+		return fmt.Errorf("pointer click count must be 1 or 2, found %d", count)
+	}
 	if err := writeRFBPointerEvent(conn, 0, x, y); err != nil {
 		return err
 	}
-	if err := writeRFBPointerEvent(conn, 1, x, y); err != nil {
-		return err
+	for click := 0; click < count; click++ {
+		if err := writeRFBPointerEvent(conn, 1, x, y); err != nil {
+			return err
+		}
+		time.Sleep(80 * time.Millisecond)
+		if err := writeRFBPointerEvent(conn, 0, x, y); err != nil {
+			return err
+		}
+		if click+1 < count {
+			time.Sleep(80 * time.Millisecond)
+		}
 	}
-	time.Sleep(80 * time.Millisecond)
-	return writeRFBPointerEvent(conn, 0, x, y)
+	return nil
 }
 
 func captureRFBFrameFromConn(ctx context.Context, conn net.Conn, creds rfbCredentials, authMode localWebVNCAuthenticationMode) (image.Image, error) {

--- a/internal/cli/rfb_screenshot_test.go
+++ b/internal/cli/rfb_screenshot_test.go
@@ -391,6 +391,24 @@ func TestClickRFBPointerSendsPressAndRelease(t *testing.T) {
 	}
 }
 
+func TestDoubleClickRFBPointerSendsTwoPressAndReleasePairs(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	serverErr := make(chan error, 1)
+	go func() {
+		serverErr <- serveTestPointerRFBWithCount(server, 12, 34, 2)
+	}()
+
+	if err := clickRFBPointerFromConnCount(context.Background(), client, rfbCredentials{}, localWebVNCAuthAuto, 12, 34, 2); err != nil {
+		t.Fatalf("double click RFB pointer: %v", err)
+	}
+	if err := <-serverErr; err != nil {
+		t.Fatalf("fake RFB server: %v", err)
+	}
+}
+
 func TestClickRFBPointerHonorsVNCModeWhenServerOffersARD(t *testing.T) {
 	client, server := net.Pipe()
 	defer client.Close()
@@ -577,11 +595,18 @@ func TestRFBPasswordOnlyCredentialsPreferVNCAuth(t *testing.T) {
 }
 
 func serveTestPointerRFB(conn net.Conn, wantX, wantY int) error {
+	return serveTestPointerRFBWithCount(conn, wantX, wantY, 1)
+}
+
+func serveTestPointerRFBWithCount(conn net.Conn, wantX, wantY, count int) error {
 	if err := serveTestInputRFBInit(conn); err != nil {
 		return err
 	}
 
-	wantMasks := []byte{0, 1, 0}
+	wantMasks := []byte{0}
+	for click := 0; click < count; click++ {
+		wantMasks = append(wantMasks, 1, 0)
+	}
 	for _, wantMask := range wantMasks {
 		event := make([]byte, 6)
 		if _, err := io.ReadFull(conn, event); err != nil {

--- a/internal/providers/tart/backend.go
+++ b/internal/providers/tart/backend.go
@@ -133,7 +133,7 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 	if core.IsTartDiskExplicit(&cfg) {
 		diskLabel = fmt.Sprintf("%dGB", cfg.Tart.Disk)
 	}
-	fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s image=%s cpus=%d memory=%dMB disk=%s keep=%v\n", providerName, leaseID, slug, cfg.Tart.Image, cfg.Tart.CPUs, cfg.Tart.Memory, diskLabel, req.Keep)
+	fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s image=%s cpus=%d memory=%dMB disk=%s random_serial=%v keep=%v\n", providerName, leaseID, slug, cfg.Tart.Image, cfg.Tart.CPUs, cfg.Tart.Memory, diskLabel, cfg.Tart.RandomSerial, req.Keep)
 
 	if err := b.cloneVM(ctx, cfg, name); err != nil {
 		_ = b.deleteVM(context.Background(), name)
@@ -414,6 +414,11 @@ func (b *backend) cloneVM(ctx context.Context, cfg Config, name string) error {
 
 // configureVM applies CPU, memory, and disk settings to the cloned VM before boot.
 func (b *backend) configureVM(ctx context.Context, cfg Config, name string) error {
+	if cfg.Tart.RandomSerial {
+		if _, err := b.tart(ctx, []string{"set", name, "--random-serial"}, nil, b.rt.Stderr); err != nil {
+			return fmt.Errorf("tart set --random-serial: %w", err)
+		}
+	}
 	if cfg.Tart.CPUs > 0 {
 		if _, err := b.tart(ctx, []string{"set", name, "--cpu", strconv.Itoa(cfg.Tart.CPUs)}, nil, b.rt.Stderr); err != nil {
 			return fmt.Errorf("tart set --cpu: %w", err)

--- a/internal/providers/tart/backend.go
+++ b/internal/providers/tart/backend.go
@@ -133,7 +133,7 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 	if core.IsTartDiskExplicit(&cfg) {
 		diskLabel = fmt.Sprintf("%dGB", cfg.Tart.Disk)
 	}
-	fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s image=%s cpus=%d memory=%dMB disk=%s random_serial=%v keep=%v\n", providerName, leaseID, slug, cfg.Tart.Image, cfg.Tart.CPUs, cfg.Tart.Memory, diskLabel, cfg.Tart.RandomSerial, req.Keep)
+	fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s image=%s cpus=%d memory=%dMB disk=%s random_serial=%v usb_passthrough=%v keep=%v\n", providerName, leaseID, slug, cfg.Tart.Image, cfg.Tart.CPUs, cfg.Tart.Memory, diskLabel, cfg.Tart.RandomSerial, cfg.Tart.USBPassthrough, req.Keep)
 
 	if err := b.cloneVM(ctx, cfg, name); err != nil {
 		_ = b.deleteVM(context.Background(), name)
@@ -438,15 +438,19 @@ func (b *backend) configureVM(ctx context.Context, cfg Config, name string) erro
 }
 
 // startVMArgs returns the tart run arguments for starting a VM headless.
-func startVMArgs(name string) []string {
-	return []string{"run", name, "--no-graphics"}
+func startVMArgs(name string, usbPassthrough bool) []string {
+	args := []string{"run", name, "--no-graphics"}
+	if usbPassthrough {
+		args = append(args, "--usb-passthrough")
+	}
+	return args
 }
 
 // startVM starts the VM headless in the background.
 // When keep is true the tart process is fully detached so it survives
 // crabbox exit, matching how docker run -d keeps containers alive.
 func (b *backend) startVM(ctx context.Context, cfg Config, name string, keep bool) error {
-	args := startVMArgs(name)
+	args := startVMArgs(name, cfg.Tart.USBPassthrough)
 	var stderrBuf bytes.Buffer
 	var detachedStderr *os.File
 	var devNull *os.File

--- a/internal/providers/tart/flags.go
+++ b/internal/providers/tart/flags.go
@@ -10,11 +10,12 @@ import (
 )
 
 type flagValues struct {
-	Image  *string
-	User   *string
-	CPUs   *int
-	Memory *int
-	Disk   *int
+	Image        *string
+	User         *string
+	CPUs         *int
+	Memory       *int
+	Disk         *int
+	RandomSerial *bool
 }
 
 func registerFlags(fs *flag.FlagSet, defaults core.Config) any {
@@ -24,6 +25,11 @@ func registerFlags(fs *flag.FlagSet, defaults core.Config) any {
 		CPUs:   fs.Int("tart-cpu", defaults.Tart.CPUs, "CPU count for tart VMs"),
 		Memory: fs.Int("tart-memory", defaults.Tart.Memory, "memory in MB for tart VMs"),
 		Disk:   fs.Int("tart-disk", defaults.Tart.Disk, "disk size in GB for tart VMs (0 = use clone default)"),
+		RandomSerial: fs.Bool(
+			"tart-random-serial",
+			defaults.Tart.RandomSerial,
+			"generate a new macOS machine identifier for each cloned VM",
+		),
 	}
 }
 
@@ -59,6 +65,9 @@ func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 		if *v.Disk > 0 {
 			core.MarkTartDiskExplicit(cfg)
 		}
+	}
+	if flagWasSet(fs, "tart-random-serial") {
+		cfg.Tart.RandomSerial = *v.RandomSerial
 	}
 	if isTartProviderName(cfg.Provider) {
 		if core.IsTargetExplicit(cfg) && cfg.TargetOS != targetMacOS {

--- a/internal/providers/tart/flags.go
+++ b/internal/providers/tart/flags.go
@@ -10,12 +10,13 @@ import (
 )
 
 type flagValues struct {
-	Image        *string
-	User         *string
-	CPUs         *int
-	Memory       *int
-	Disk         *int
-	RandomSerial *bool
+	Image          *string
+	User           *string
+	CPUs           *int
+	Memory         *int
+	Disk           *int
+	RandomSerial   *bool
+	USBPassthrough *bool
 }
 
 func registerFlags(fs *flag.FlagSet, defaults core.Config) any {
@@ -29,6 +30,11 @@ func registerFlags(fs *flag.FlagSet, defaults core.Config) any {
 			"tart-random-serial",
 			defaults.Tart.RandomSerial,
 			"generate a new macOS machine identifier for each cloned VM",
+		),
+		USBPassthrough: fs.Bool(
+			"tart-usb-passthrough",
+			defaults.Tart.USBPassthrough,
+			"allow selected physical USB accessories to attach to the VM (macOS 27+ host)",
 		),
 	}
 }
@@ -68,6 +74,9 @@ func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	}
 	if flagWasSet(fs, "tart-random-serial") {
 		cfg.Tart.RandomSerial = *v.RandomSerial
+	}
+	if flagWasSet(fs, "tart-usb-passthrough") {
+		cfg.Tart.USBPassthrough = *v.USBPassthrough
 	}
 	if isTartProviderName(cfg.Provider) {
 		if core.IsTargetExplicit(cfg) && cfg.TargetOS != targetMacOS {

--- a/internal/providers/tart/provider_test.go
+++ b/internal/providers/tart/provider_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -1008,6 +1009,25 @@ func TestConfigureVMSkipsZeroCPUAndMemory(t *testing.T) {
 	}
 }
 
+func TestConfigureVMAppliesRandomSerialBeforeOtherSettings(t *testing.T) {
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.Tart.RandomSerial = true
+	cfg.Tart.CPUs = 4
+	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}).(*backend)
+
+	if err := b.configureVM(context.Background(), cfg, "crabbox-test"); err != nil {
+		t.Fatalf("configureVM: %v", err)
+	}
+	if len(runner.calls) < 2 {
+		t.Fatalf("configureVM calls = %v, want random serial and CPU", runner.calls)
+	}
+	if got := runner.calls[0].Args; !slices.Equal(got, []string{"set", "crabbox-test", "--random-serial"}) {
+		t.Fatalf("first configureVM call = %v, want random serial", got)
+	}
+}
+
 func TestShouldCleanupStoppedInstance(t *testing.T) {
 	server := Server{Status: "stopped", Labels: map[string]string{}}
 	ok, reason := shouldCleanup(server, core.LeaseClaim{}, true, time.Now())
@@ -1233,6 +1253,22 @@ func TestApplyFlagsAcceptsPositiveResources(t *testing.T) {
 	}
 	if cfg.Tart.Disk != 100 {
 		t.Fatalf("Disk = %d, want 100", cfg.Tart.Disk)
+	}
+}
+
+func TestApplyFlagsEnablesRandomSerial(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	vals := registerFlags(fs, cfg)
+	if err := fs.Parse([]string{"--tart-random-serial"}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if err := applyFlags(&cfg, fs, vals); err != nil {
+		t.Fatalf("applyFlags: %v", err)
+	}
+	if !cfg.Tart.RandomSerial {
+		t.Fatal("RandomSerial = false, want true")
 	}
 }
 

--- a/internal/providers/tart/provider_test.go
+++ b/internal/providers/tart/provider_test.go
@@ -343,9 +343,16 @@ func TestAcquireKeepIPFailureDeletesUnclaimedVMAndKey(t *testing.T) {
 }
 
 func TestStartVMArgsHeadless(t *testing.T) {
-	args := startVMArgs("crabbox-blue-1234abcd")
+	args := startVMArgs("crabbox-blue-1234abcd", false)
 	if len(args) != 3 || args[0] != "run" || args[2] != "--no-graphics" {
 		t.Fatalf("startVMArgs=%v want [run <name> --no-graphics]", args)
+	}
+}
+
+func TestStartVMArgsUSBPassthrough(t *testing.T) {
+	args := startVMArgs("crabbox-blue-1234abcd", true)
+	if len(args) != 4 || args[3] != "--usb-passthrough" {
+		t.Fatalf("startVMArgs=%v want USB passthrough opt-in", args)
 	}
 }
 
@@ -1269,6 +1276,22 @@ func TestApplyFlagsEnablesRandomSerial(t *testing.T) {
 	}
 	if !cfg.Tart.RandomSerial {
 		t.Fatal("RandomSerial = false, want true")
+	}
+}
+
+func TestApplyFlagsEnablesUSBPassthrough(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	vals := registerFlags(fs, cfg)
+	if err := fs.Parse([]string{"--tart-usb-passthrough"}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if err := applyFlags(&cfg, fs, vals); err != nil {
+		t.Fatalf("applyFlags: %v", err)
+	}
+	if !cfg.Tart.USBPassthrough {
+		t.Fatal("USBPassthrough = false, want true")
 	}
 }
 
@@ -4202,7 +4225,7 @@ func TestServerFromInstanceSourcePreferred(t *testing.T) {
 }
 
 func TestStartVMArgsFormat(t *testing.T) {
-	args := startVMArgs("test-vm-name")
+	args := startVMArgs("test-vm-name", false)
 	if len(args) != 3 {
 		t.Fatalf("startVMArgs len = %d, want 3", len(args))
 	}


### PR DESCRIPTION
Adds an opt-in `--tart-random-serial` setting (plus YAML and environment configuration) that runs `tart set <vm> --random-serial` before other clone configuration.

This lets managed macOS clones receive unique hardware identities instead of inheriting the base VM identity.

Tests:
- `go test ./internal/providers/tart`
- focused Tart config file/environment tests

Note: the full `internal/cli` package test run was interrupted after 147s because an unrelated long-running test did not complete; the two config tests affected by this change pass directly.