### PR TITLE
fix(blaxel): lifecycle policies, full-document label updates, absolute FS paths

### DIFF
--- a/internal/providers/blaxel/client.go
+++ b/internal/providers/blaxel/client.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"time"
 )
 
 type Client interface {
@@ -34,12 +35,12 @@ type Client interface {
 }
 
 type CreateSandboxRequest struct {
-	Name       string            `json:"name,omitempty"`
-	Image      string            `json:"image,omitempty"`
-	Region     string            `json:"region,omitempty"`
-	MemoryMB   int               `json:"memoryMb,omitempty"`
-	TTL        string            `json:"ttl,omitempty"`
-	IdleTTL    string            `json:"idleTtl,omitempty"`
+	Name     string `json:"name,omitempty"`
+	Image    string `json:"image,omitempty"`
+	Region   string `json:"region,omitempty"`
+	MemoryMB int    `json:"memoryMb,omitempty"`
+	TTL      string `json:"ttl,omitempty"`
+	IdleTTL  string `json:"idleTtl,omitempty"`
 	// TerminatedRetention is optional Blaxel lifecycle retention after stop/delete.
 	// When empty and any expiration policy is present, apiCreateSandboxRequest defaults it to "5m".
 	TerminatedRetention string            `json:"terminatedRetention,omitempty"`
@@ -356,13 +357,30 @@ func listLabelQuery(labels map[string]string) string {
 }
 
 func (c *restClient) UpdateSandboxLabels(ctx context.Context, id string, labels map[string]string) (Sandbox, error) {
-	current, err := c.GetSandbox(ctx, id)
+	// Blaxel PUT is a full replace: a labels-only body passes validation but
+	// DEACTIVATES the sandbox (spec is dropped). Round-trip the current
+	// document and merge labels into it so runtime/lifecycle survive.
+	raw, err := c.do(ctx, http.MethodGet, "/v0/sandboxes/"+url.PathEscape(id), nil, nil, nil)
 	if err != nil {
 		return Sandbox{}, err
 	}
-	req := apiUpdateSandboxRequest(current, labels)
+	var doc map[string]any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return Sandbox{}, fmt.Errorf("blaxel sandbox %s: decode for label update: %w", id, err)
+	}
+	metadata, _ := doc["metadata"].(map[string]any)
+	if metadata == nil {
+		metadata = map[string]any{}
+		doc["metadata"] = metadata
+	}
+	metadata["labels"] = labels
+	// Send only metadata + spec back: status/timestamps are server-owned.
+	body := map[string]any{"metadata": metadata}
+	if spec, ok := doc["spec"]; ok {
+		body["spec"] = spec
+	}
 	var out blaxelAPISandbox
-	_, err = c.do(ctx, http.MethodPut, "/v0/sandboxes/"+url.PathEscape(id), nil, req, &out)
+	_, err = c.do(ctx, http.MethodPut, "/v0/sandboxes/"+url.PathEscape(id), nil, body, &out)
 	if err != nil {
 		return Sandbox{}, err
 	}
@@ -376,19 +394,19 @@ func (c *restClient) DeleteSandbox(ctx context.Context, id string) error {
 
 func (c *restClient) ExecuteProcess(ctx context.Context, sandbox string, req ExecuteProcessRequest) (Process, error) {
 	var out blaxelAPIProcess
-	_, err := c.doSandbox(ctx, sandbox, http.MethodPost, "/process", nil, apiProcessRequest(req), &out)
+	_, err := c.doSandboxRetry(ctx, sandbox, http.MethodPost, "/process", nil, apiProcessRequest(req), &out)
 	return out.process(), err
 }
 
 func (c *restClient) GetProcess(ctx context.Context, sandbox, process string) (Process, error) {
 	var out blaxelAPIProcess
-	_, err := c.doSandbox(ctx, sandbox, http.MethodGet, "/process/"+url.PathEscape(process), nil, nil, &out)
+	_, err := c.doSandboxRetry(ctx, sandbox, http.MethodGet, "/process/"+url.PathEscape(process), nil, nil, &out)
 	return out.process(), err
 }
 
 func (c *restClient) GetProcessLogs(ctx context.Context, sandbox, process string) (ProcessLogs, error) {
 	var out ProcessLogs
-	_, err := c.doSandbox(ctx, sandbox, http.MethodGet, "/process/"+url.PathEscape(process)+"/logs", nil, nil, &out)
+	_, err := c.doSandboxRetry(ctx, sandbox, http.MethodGet, "/process/"+url.PathEscape(process)+"/logs", nil, nil, &out)
 	return out, err
 }
 
@@ -400,11 +418,39 @@ func (c *restClient) StopProcess(ctx context.Context, sandbox, process string) e
 func (c *restClient) WriteFile(ctx context.Context, sandbox string, req WriteFileRequest) error {
 	endpoint := "/filesystem/" + cleanSandboxPath(req.Path)
 	body := map[string]any{"content": req.Content, "isDirectory": req.Directory}
-	_, err := c.doSandbox(ctx, sandbox, http.MethodPut, endpoint, nil, body, nil)
+	_, err := c.doSandboxRetry(ctx, sandbox, http.MethodPut, endpoint, nil, body, nil)
 	return err
 }
 
 func (c *restClient) UploadFile(ctx context.Context, sandbox, remotePath string, reader io.Reader) error {
+	// Retry the whole multipart flow on WORKLOAD_UNAVAILABLE: the workload
+	// proxy can still be coming up after the control plane says ready.
+	// Safe because that error means the request never reached the workload.
+	for attempt := 0; ; attempt++ {
+		err := c.uploadFileOnce(ctx, sandbox, remotePath, reader)
+		if err == nil || !isWorkloadUnavailable(err) || attempt >= len(blaxelWorkloadRetryDelays) {
+			return err
+		}
+		// Rewind the source for the next attempt (sync passes an *os.File).
+		seeker, ok := reader.(io.Seeker)
+		if !ok {
+			return err
+		}
+		if _, seekErr := seeker.Seek(0, io.SeekStart); seekErr != nil {
+			return err
+		}
+		delay := blaxelWorkloadRetryDelays[attempt]
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func (c *restClient) uploadFileOnce(ctx context.Context, sandbox, remotePath string, reader io.Reader) error {
 	initiate := struct {
 		Permissions string `json:"permissions,omitempty"`
 	}{Permissions: "0644"}
@@ -430,7 +476,7 @@ func (c *restClient) UploadFile(ctx context.Context, sandbox, remotePath string,
 func (c *restClient) GetDirectoryTree(ctx context.Context, sandbox, remotePath string) (DirectoryTree, error) {
 	var out DirectoryTree
 	endpoint := "/filesystem/tree/" + cleanSandboxPath(remotePath)
-	_, err := c.doSandbox(ctx, sandbox, http.MethodGet, endpoint, nil, nil, &out)
+	_, err := c.doSandboxRetry(ctx, sandbox, http.MethodGet, endpoint, nil, nil, &out)
 	return out, err
 }
 
@@ -446,6 +492,49 @@ func (c *restClient) do(ctx context.Context, method, endpoint string, values url
 	return c.doAt(ctx, c.base, method, endpoint, values, request, response)
 }
 
+// blaxelWorkloadRetryDelays follows Blaxel's own WORKLOAD_UNAVAILABLE guidance:
+// exponential backoff starting at 500ms, capping at 30s, giving up after ~60s.
+var blaxelWorkloadRetryDelays = []time.Duration{
+	500 * time.Millisecond,
+	1 * time.Second,
+	2 * time.Second,
+	4 * time.Second,
+	8 * time.Second,
+	15 * time.Second,
+	30 * time.Second,
+}
+
+// isWorkloadUnavailable reports whether err is Blaxel's transient "workload
+// not yet serving" response. The control plane can mark a sandbox ready while
+// the workload proxy still 404s every data-plane request for tens of seconds.
+func isWorkloadUnavailable(err error) bool {
+	var apiErr apiError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	return strings.Contains(apiErr.Body, "WORKLOAD_UNAVAILABLE")
+}
+
+// doSandboxRetry wraps doSandbox with bounded retries for the sandbox data
+// plane (process exec, filesystem, multipart upload). WORKLOAD_UNAVAILABLE
+// means the request never reached the workload, so retrying is safe.
+// Management-plane calls keep using do/doSandbox directly.
+func (c *restClient) doSandboxRetry(ctx context.Context, sandbox, method, endpoint string, values url.Values, request any, response any) ([]byte, error) {
+	body, err := c.doSandbox(ctx, sandbox, method, endpoint, values, request, response)
+	for i := 0; err != nil && isWorkloadUnavailable(err) && i < len(blaxelWorkloadRetryDelays); i++ {
+		delay := blaxelWorkloadRetryDelays[i]
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+		body, err = c.doSandbox(ctx, sandbox, method, endpoint, values, request, response)
+	}
+	return body, err
+}
+
 func (c *restClient) doAt(ctx context.Context, baseURL, method, endpoint string, values url.Values, request any, response any) ([]byte, error) {
 	var body io.Reader
 	if request != nil {
@@ -459,7 +548,7 @@ func (c *restClient) doAt(ctx context.Context, baseURL, method, endpoint string,
 	if err != nil {
 		return nil, err
 	}
-	reqURL.Path = path.Join(reqURL.Path, endpoint)
+	reqURL.Path = joinEndpointPreservingDoubleSlash(reqURL.Path, endpoint)
 	if strings.HasSuffix(endpoint, "/") && !strings.HasSuffix(reqURL.Path, "/") {
 		reqURL.Path += "/"
 	}
@@ -550,7 +639,7 @@ func (c *restClient) doMultipartAt(ctx context.Context, baseURL, method, endpoin
 	if err != nil {
 		return nil, err
 	}
-	reqURL.Path = path.Join(reqURL.Path, endpoint)
+	reqURL.Path = joinEndpointPreservingDoubleSlash(reqURL.Path, endpoint)
 	reqURL.RawQuery = values.Encode()
 	httpReq, err := http.NewRequestWithContext(ctx, method, reqURL.String(), body)
 	if err != nil {
@@ -583,7 +672,18 @@ func (c *restClient) doMultipartAt(ctx context.Context, baseURL, method, endpoin
 }
 
 func cleanSandboxPath(value string) string {
-	return strings.TrimPrefix(path.Clean("/"+strings.TrimSpace(value)), "/")
+	// Keep the leading slash: Blaxel's filesystem APIs treat relative paths as
+	// living under their virtual /blaxel root (invisible to sandbox processes),
+	// while absolute paths map to the real guest filesystem.
+	return path.Clean("/" + strings.TrimSpace(value))
+}
+
+// joinEndpointPreservingDoubleSlash appends an endpoint to a base path without
+// collapsing "//": filesystem endpoints encode absolute guest paths as
+// "/filesystem/<verb>//abs/path" (leading "/" after the verb marks the path as
+// guest-absolute), and path.Join would silently flatten it to a relative path.
+func joinEndpointPreservingDoubleSlash(base, endpoint string) string {
+	return strings.TrimRight(base, "/") + endpoint
 }
 
 type blaxelExpirationPolicy struct {
@@ -676,26 +776,6 @@ func apiCreateSandboxRequest(req CreateSandboxRequest) blaxelAPISandbox {
 		retention = defaultTerminatedRetention
 	}
 	out.Spec.Lifecycle.TerminatedRetention = retention
-	return out
-}
-
-type blaxelAPISandboxLabelUpdate struct {
-	Metadata struct {
-		Name   string            `json:"name,omitempty"`
-		Labels map[string]string `json:"labels,omitempty"`
-	} `json:"metadata,omitempty"`
-}
-
-func apiUpdateSandboxRequest(current Sandbox, labels map[string]string) blaxelAPISandboxLabelUpdate {
-	// Label updates must not rewrite sandbox runtime/lifecycle. encoding/json
-	// never omits nested struct values, so a labels PUT built from blaxelAPISandbox
-	// would serialize empty "lifecycle":{} / "runtime":{} objects. Blaxel treats
-	// that as clearing policies and returns HTTP 400:
-	//   lifecycle configuration must contain at least one expiration policy
-	//   or a terminated retention duration
-	var out blaxelAPISandboxLabelUpdate
-	out.Metadata.Name = firstNonEmpty(current.Name, current.ID)
-	out.Metadata.Labels = labels
 	return out
 }
 

--- a/internal/providers/blaxel/client.go
+++ b/internal/providers/blaxel/client.go
@@ -40,8 +40,11 @@ type CreateSandboxRequest struct {
 	MemoryMB   int               `json:"memoryMb,omitempty"`
 	TTL        string            `json:"ttl,omitempty"`
 	IdleTTL    string            `json:"idleTtl,omitempty"`
-	WorkingDir string            `json:"workingDir,omitempty"`
-	Labels     map[string]string `json:"labels,omitempty"`
+	// TerminatedRetention is optional Blaxel lifecycle retention after stop/delete.
+	// When empty and any expiration policy is present, apiCreateSandboxRequest defaults it to "5m".
+	TerminatedRetention string            `json:"terminatedRetention,omitempty"`
+	WorkingDir          string            `json:"workingDir,omitempty"`
+	Labels              map[string]string `json:"labels,omitempty"`
 }
 
 type ListSandboxesRequest struct {
@@ -583,6 +586,12 @@ func cleanSandboxPath(value string) string {
 	return strings.TrimPrefix(path.Clean("/"+strings.TrimSpace(value)), "/")
 }
 
+type blaxelExpirationPolicy struct {
+	Action string `json:"action,omitempty"`
+	Type   string `json:"type,omitempty"`
+	Value  string `json:"value,omitempty"`
+}
+
 type blaxelAPISandbox struct {
 	Metadata struct {
 		Name      string            `json:"name,omitempty"`
@@ -596,19 +605,27 @@ type blaxelAPISandbox struct {
 		Runtime struct {
 			Image  string `json:"image,omitempty"`
 			Memory int    `json:"memory,omitempty"`
-			TTL    string `json:"ttl,omitempty"`
+			// TTL is retained for older Blaxel control planes that still read runtime.ttl.
+			// Modern APIs require spec.lifecycle.expirationPolicies (see apiCreateSandboxRequest).
+			TTL string `json:"ttl,omitempty"`
 		} `json:"runtime,omitempty"`
 		Lifecycle struct {
-			ExpirationPolicies []struct {
-				Action string `json:"action,omitempty"`
-				Type   string `json:"type,omitempty"`
-				Value  string `json:"value,omitempty"`
-			} `json:"expirationPolicies,omitempty"`
+			ExpirationPolicies  []blaxelExpirationPolicy `json:"expirationPolicies,omitempty"`
+			TerminatedRetention string                   `json:"terminatedRetention,omitempty"`
 		} `json:"lifecycle,omitempty"`
 	} `json:"spec,omitempty"`
 	State  string `json:"state,omitempty"`
 	Status string `json:"status,omitempty"`
 }
+
+// defaultTerminatedRetention is applied whenever Crabbox emits lifecycle
+// expiration policies. Blaxel rejects creates whose lifecycle object is empty.
+const defaultTerminatedRetention = "5m"
+
+// defaultSandboxMaxAgeTTL is used when neither --blaxel-ttl nor --blaxel-idle-ttl
+// is set. The live Blaxel API requires at least one expiration policy or a
+// terminatedRetention value; an empty lifecycle body returns HTTP 400.
+const defaultSandboxMaxAgeTTL = "2h"
 
 func apiCreateSandboxRequest(req CreateSandboxRequest) blaxelAPISandbox {
 	var out blaxelAPISandbox
@@ -617,27 +634,68 @@ func apiCreateSandboxRequest(req CreateSandboxRequest) blaxelAPISandbox {
 	out.Spec.Region = req.Region
 	out.Spec.Runtime.Image = req.Image
 	out.Spec.Runtime.Memory = req.MemoryMB
-	out.Spec.Runtime.TTL = req.TTL
-	if strings.TrimSpace(req.IdleTTL) != "" {
-		out.Spec.Lifecycle.ExpirationPolicies = []struct {
-			Action string `json:"action,omitempty"`
-			Type   string `json:"type,omitempty"`
-			Value  string `json:"value,omitempty"`
-		}{{
+
+	ttl := strings.TrimSpace(req.TTL)
+	idleTTL := strings.TrimSpace(req.IdleTTL)
+	// Keep legacy runtime.ttl for older backends when a max-age is configured.
+	out.Spec.Runtime.TTL = ttl
+
+	var policies []blaxelExpirationPolicy
+	if ttl != "" {
+		policies = append(policies, blaxelExpirationPolicy{
+			Action: "delete",
+			Type:   "ttl-max-age",
+			Value:  ttl,
+		})
+	}
+	if idleTTL != "" {
+		policies = append(policies, blaxelExpirationPolicy{
 			Action: "delete",
 			Type:   "ttl-idle",
-			Value:  req.IdleTTL,
-		}}
+			Value:  idleTTL,
+		})
 	}
+	// Ensure modern Blaxel always receives a non-empty lifecycle configuration.
+	// Without this, creates fail with:
+	//   "lifecycle configuration must contain at least one expiration policy
+	//    or a terminated retention duration"
+	if len(policies) == 0 {
+		policies = append(policies, blaxelExpirationPolicy{
+			Action: "delete",
+			Type:   "ttl-max-age",
+			Value:  defaultSandboxMaxAgeTTL,
+		})
+		if out.Spec.Runtime.TTL == "" {
+			out.Spec.Runtime.TTL = defaultSandboxMaxAgeTTL
+		}
+	}
+	out.Spec.Lifecycle.ExpirationPolicies = policies
+
+	retention := strings.TrimSpace(req.TerminatedRetention)
+	if retention == "" {
+		retention = defaultTerminatedRetention
+	}
+	out.Spec.Lifecycle.TerminatedRetention = retention
 	return out
 }
 
-func apiUpdateSandboxRequest(current Sandbox, labels map[string]string) blaxelAPISandbox {
-	var out blaxelAPISandbox
+type blaxelAPISandboxLabelUpdate struct {
+	Metadata struct {
+		Name   string            `json:"name,omitempty"`
+		Labels map[string]string `json:"labels,omitempty"`
+	} `json:"metadata,omitempty"`
+}
+
+func apiUpdateSandboxRequest(current Sandbox, labels map[string]string) blaxelAPISandboxLabelUpdate {
+	// Label updates must not rewrite sandbox runtime/lifecycle. encoding/json
+	// never omits nested struct values, so a labels PUT built from blaxelAPISandbox
+	// would serialize empty "lifecycle":{} / "runtime":{} objects. Blaxel treats
+	// that as clearing policies and returns HTTP 400:
+	//   lifecycle configuration must contain at least one expiration policy
+	//   or a terminated retention duration
+	var out blaxelAPISandboxLabelUpdate
 	out.Metadata.Name = firstNonEmpty(current.Name, current.ID)
 	out.Metadata.Labels = labels
-	out.Spec.Region = current.Region
-	out.Spec.Runtime.Image = current.Image
 	return out
 }
 

--- a/internal/providers/blaxel/client_test.go
+++ b/internal/providers/blaxel/client_test.go
@@ -343,3 +343,102 @@ func mustParseURL(t *testing.T, raw string) *url.URL {
 	}
 	return parsed
 }
+
+func TestAPICreateSandboxRequestMapsLifecyclePolicies(t *testing.T) {
+	t.Parallel()
+
+	got := apiCreateSandboxRequest(CreateSandboxRequest{
+		Name:     "sbx-test",
+		Image:    "blaxel/base-image:latest",
+		Region:   "us-was-1",
+		MemoryMB: 2048,
+		TTL:      "20m",
+		IdleTTL:  "10m",
+	})
+
+	if got.Spec.Runtime.TTL != "20m" {
+		t.Fatalf("runtime.ttl=%q", got.Spec.Runtime.TTL)
+	}
+	if got.Spec.Lifecycle.TerminatedRetention != defaultTerminatedRetention {
+		t.Fatalf("terminatedRetention=%q", got.Spec.Lifecycle.TerminatedRetention)
+	}
+	if len(got.Spec.Lifecycle.ExpirationPolicies) != 2 {
+		t.Fatalf("policies=%#v", got.Spec.Lifecycle.ExpirationPolicies)
+	}
+	if got.Spec.Lifecycle.ExpirationPolicies[0] != (blaxelExpirationPolicy{Action: "delete", Type: "ttl-max-age", Value: "20m"}) {
+		t.Fatalf("max-age policy=%#v", got.Spec.Lifecycle.ExpirationPolicies[0])
+	}
+	if got.Spec.Lifecycle.ExpirationPolicies[1] != (blaxelExpirationPolicy{Action: "delete", Type: "ttl-idle", Value: "10m"}) {
+		t.Fatalf("idle policy=%#v", got.Spec.Lifecycle.ExpirationPolicies[1])
+	}
+
+	raw, err := json.Marshal(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(raw)
+	for _, want := range []string{
+		`"expirationPolicies"`,
+		`"ttl-max-age"`,
+		`"ttl-idle"`,
+		`"terminatedRetention":"5m"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("create body missing %s: %s", want, body)
+		}
+	}
+}
+
+func TestAPICreateSandboxRequestDefaultsLifecycleWhenTTLUnset(t *testing.T) {
+	t.Parallel()
+
+	got := apiCreateSandboxRequest(CreateSandboxRequest{
+		Name:  "sbx-default",
+		Image: "blaxel/base-image:latest",
+	})
+	if len(got.Spec.Lifecycle.ExpirationPolicies) != 1 {
+		t.Fatalf("policies=%#v", got.Spec.Lifecycle.ExpirationPolicies)
+	}
+	if got.Spec.Lifecycle.ExpirationPolicies[0].Type != "ttl-max-age" || got.Spec.Lifecycle.ExpirationPolicies[0].Value != defaultSandboxMaxAgeTTL {
+		t.Fatalf("default policy=%#v", got.Spec.Lifecycle.ExpirationPolicies[0])
+	}
+	if got.Spec.Lifecycle.TerminatedRetention != defaultTerminatedRetention {
+		t.Fatalf("terminatedRetention=%q", got.Spec.Lifecycle.TerminatedRetention)
+	}
+	if got.Spec.Runtime.TTL != defaultSandboxMaxAgeTTL {
+		t.Fatalf("runtime.ttl=%q", got.Spec.Runtime.TTL)
+	}
+}
+
+func TestAPICreateSandboxRequestHonorsExplicitTerminatedRetention(t *testing.T) {
+	t.Parallel()
+
+	got := apiCreateSandboxRequest(CreateSandboxRequest{
+		Name:                "sbx-ret",
+		IdleTTL:             "3m",
+		TerminatedRetention: "15m",
+	})
+	if got.Spec.Lifecycle.TerminatedRetention != "15m" {
+		t.Fatalf("terminatedRetention=%q", got.Spec.Lifecycle.TerminatedRetention)
+	}
+	if len(got.Spec.Lifecycle.ExpirationPolicies) != 1 || got.Spec.Lifecycle.ExpirationPolicies[0].Type != "ttl-idle" {
+		t.Fatalf("policies=%#v", got.Spec.Lifecycle.ExpirationPolicies)
+	}
+}
+
+
+func TestAPIUpdateSandboxRequestOmitsEmptyLifecycle(t *testing.T) {
+	t.Parallel()
+	got := apiUpdateSandboxRequest(Sandbox{ID: "sbx-1", Name: "sbx-1", Region: "us-was-1", Image: "img"}, map[string]string{"crabbox.lease": "blx_sbx-1"})
+	raw, err := json.Marshal(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(raw)
+	if strings.Contains(body, "lifecycle") || strings.Contains(body, "runtime") || strings.Contains(body, "region") || strings.Contains(body, `"spec"`) {
+		t.Fatalf("update body should be labels-only, got %s", body)
+	}
+	if !strings.Contains(body, `"crabbox.lease":"blx_sbx-1"`) {
+		t.Fatalf("missing labels: %s", body)
+	}
+}

--- a/internal/providers/blaxel/client_test.go
+++ b/internal/providers/blaxel/client_test.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
@@ -179,7 +180,7 @@ func TestClientUsesManagementShapeAndSandboxDataPlane(t *testing.T) {
 				t.Fatalf("process body=%#v", body)
 			}
 			_ = json.NewEncoder(w).Encode(map[string]any{"pid": "1234", "status": "running"})
-		case r.Method == http.MethodPost && r.URL.Path == "/sandbox/sbx-1/filesystem-multipart/initiate/tmp/archive.tgz":
+		case r.Method == http.MethodPost && r.URL.Path == "/sandbox/sbx-1/filesystem-multipart/initiate//tmp/archive.tgz":
 			_ = json.NewEncoder(w).Encode(map[string]any{"uploadId": "upload-1", "path": "/tmp/archive.tgz"})
 		case r.Method == http.MethodPut && r.URL.Path == "/sandbox/sbx-1/filesystem-multipart/upload-1/part":
 			sawUpload = true
@@ -426,19 +427,157 @@ func TestAPICreateSandboxRequestHonorsExplicitTerminatedRetention(t *testing.T) 
 	}
 }
 
+func TestUpdateSandboxLabelsRoundTripsFullDocument(t *testing.T) {
+	// Blaxel PUT is a full replace: the update body must carry the current
+	// spec (runtime + lifecycle) or the sandbox gets DEACTIVATED.
+	var putBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/v0/sandboxes/sbx-1" {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"metadata": map[string]any{"name": "sbx-1", "labels": map[string]string{"old": "1"}},
+				"spec": map[string]any{
+					"region":  "us-pdx-1",
+					"runtime": map[string]any{"image": "img", "memory": 4096},
+					"lifecycle": map[string]any{
+						"expirationPolicies":  []map[string]string{{"type": "ttl-max-age", "value": "10m", "action": "delete"}},
+						"terminatedRetention": "1m",
+					},
+				},
+				"status": "DEPLOYED",
+			})
+			return
+		}
+		if r.Method == http.MethodPut && r.URL.Path == "/v0/sandboxes/sbx-1" {
+			buf := new(strings.Builder)
+			_, _ = io.Copy(buf, r.Body)
+			putBody = buf.String()
+			_ = json.NewEncoder(w).Encode(map[string]any{"metadata": map[string]any{"name": "sbx-1"}, "status": "DEPLOYED"})
+			return
+		}
+		w.WriteHeader(http.StatusTeapot)
+	}))
+	t.Cleanup(srv.Close)
 
-func TestAPIUpdateSandboxRequestOmitsEmptyLifecycle(t *testing.T) {
-	t.Parallel()
-	got := apiUpdateSandboxRequest(Sandbox{ID: "sbx-1", Name: "sbx-1", Region: "us-was-1", Image: "img"}, map[string]string{"crabbox.lease": "blx_sbx-1"})
-	raw, err := json.Marshal(got)
+	client, err := newBlaxelClient(core.Config{Blaxel: core.BlaxelConfig{
+		APIURL:    srv.URL,
+		APIKey:    "test-key",
+		Workspace: "workspace-test",
+	}}, core.Runtime{HTTP: srv.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
-	body := string(raw)
-	if strings.Contains(body, "lifecycle") || strings.Contains(body, "runtime") || strings.Contains(body, "region") || strings.Contains(body, `"spec"`) {
-		t.Fatalf("update body should be labels-only, got %s", body)
+	if _, err := client.UpdateSandboxLabels(context.Background(), "sbx-1", map[string]string{"crabbox.lease": "blx_sbx-1"}); err != nil {
+		t.Fatal(err)
 	}
-	if !strings.Contains(body, `"crabbox.lease":"blx_sbx-1"`) {
-		t.Fatalf("missing labels: %s", body)
+	for _, want := range []string{`"crabbox.lease":"blx_sbx-1"`, `"lifecycle"`, `"ttl-max-age"`, `"terminatedRetention":"1m"`, `"runtime"`, `"region"`} {
+		if !strings.Contains(putBody, want) {
+			t.Fatalf("PUT body missing %s: %s", want, putBody)
+		}
+	}
+	if strings.Contains(putBody, `"old":"1"`) {
+		t.Fatalf("PUT body should replace labels, got %s", putBody)
+	}
+}
+
+func TestDoSandboxRetryRecoversFromWorkloadUnavailable(t *testing.T) {
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Management-plane sandbox lookup for sandboxBaseURL.
+		if r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v0/sandboxes/") {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"metadata": map[string]any{"name": "sbx", "url": "http://" + r.Host + "/sandbox/sbx"},
+				"status":   "DEPLOYED",
+			})
+			return
+		}
+		if r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/process") {
+			calls++
+			if calls < 3 {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"code":"WORKLOAD_UNAVAILABLE","status":404}`))
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"pid":"123","status":"running"}`))
+			return
+		}
+		w.WriteHeader(http.StatusTeapot)
+	}))
+	t.Cleanup(srv.Close)
+
+	client, err := newBlaxelClient(core.Config{Blaxel: core.BlaxelConfig{
+		APIURL:    srv.URL,
+		APIKey:    "test-key",
+		Workspace: "workspace-test",
+	}}, core.Runtime{HTTP: srv.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rc, ok := client.(*restClient)
+	if !ok {
+		t.Fatalf("unexpected client type %T", client)
+	}
+
+	oldDelays := blaxelWorkloadRetryDelays
+	blaxelWorkloadRetryDelays = []time.Duration{time.Millisecond, time.Millisecond}
+	t.Cleanup(func() { blaxelWorkloadRetryDelays = oldDelays })
+
+	var out blaxelAPIProcess
+	_, err = rc.doSandboxRetry(context.Background(), "sbx", http.MethodPost, "/process", nil, map[string]any{}, &out)
+	if err != nil {
+		t.Fatalf("doSandboxRetry: %v", err)
+	}
+	if calls != 3 {
+		t.Fatalf("expected 3 calls, got %d", calls)
+	}
+	if out.PID != "123" {
+		t.Fatalf("unexpected pid %s", out.PID)
+	}
+}
+
+func TestDoSandboxRetryDoesNotRetryOtherErrors(t *testing.T) {
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v0/sandboxes/") {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"metadata": map[string]any{"name": "sbx", "url": "http://" + r.Host + "/sandbox/sbx"},
+				"status":   "DEPLOYED",
+			})
+			return
+		}
+		if r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/process") {
+			calls++
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"bad request"}`))
+			return
+		}
+		w.WriteHeader(http.StatusTeapot)
+	}))
+	t.Cleanup(srv.Close)
+
+	client, err := newBlaxelClient(core.Config{Blaxel: core.BlaxelConfig{
+		APIURL:    srv.URL,
+		APIKey:    "test-key",
+		Workspace: "workspace-test",
+	}}, core.Runtime{HTTP: srv.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rc, ok := client.(*restClient)
+	if !ok {
+		t.Fatalf("unexpected client type %T", client)
+	}
+
+	oldDelays := blaxelWorkloadRetryDelays
+	blaxelWorkloadRetryDelays = []time.Duration{time.Millisecond, time.Millisecond}
+	t.Cleanup(func() { blaxelWorkloadRetryDelays = oldDelays })
+
+	var out blaxelAPIProcess
+	_, err = rc.doSandboxRetry(context.Background(), "sbx", http.MethodPost, "/process", nil, map[string]any{}, &out)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 call for non-retryable error, got %d", calls)
 	}
 }


### PR DESCRIPTION
## Summary

The Blaxel provider was broken end-to-end on current Blaxel APIs. This PR fixes three distinct issues found by running `crabbox run --provider blaxel` against a live workspace:

1. **Lifecycle schema** (original scope): create sent `runtime.ttl` only; current API requires `spec.lifecycle.expirationPolicies` / `terminatedRetention` and rejects with `400 lifecycle configuration must contain at least one expiration policy or a terminated retention duration`. TTL/idle flags now map to `ttl-max-age` / `ttl-idle` policies (+ `terminatedRetention` default), with `runtime.ttl` kept for older control planes.

2. **Label updates deactivated the sandbox**: the original label PUT built a partial body with an empty `lifecycle:{}` (400 after my create fix). A labels-only body passes validation but Blaxel PUT is a **full replace** — the sandbox flips to `DEACTIVATED` and the workload never serves again. Verified live. Updates now GET the current document and PUT `metadata`+`spec` back with merged labels.

3. **Uploads landed in a void**: `cleanSandboxPath` stripped the leading slash. Relative FS paths resolve under Blaxel's virtual `/blaxel` root, invisible to sandbox processes — multipart complete returned 200 but `/tmp/x.tgz` did not exist at exec time. Paths stay absolute now, and URL joining preserves the `/filesystem/<verb>//abs/path` shape (`path.Join` was collapsing it).

Also: data-plane calls (process exec, filesystem, multipart) retry `WORKLOAD_UNAVAILABLE` with Blaxel's own prescribed backoff (500ms → 30s, ~60s budget) — the control plane reports `DEPLOYED` before the workload proxy serves.

## Verification (live workspace)

- Stock 0.40.0 repro: create 400 lifecycle error.
- With this PR: full run green — lease, label update, 25MB sync upload, remote command output, `exit=0` (~5s).
- `go test ./internal/providers/blaxel/` passes (lifecycle mapping, label round-trip, retry, absolute paths).

## Notes

- Earlier revision of this PR used a labels-only PUT; live testing proved that deactivates sandboxes, corrected here to a full-document round-trip.
- `WORKLOAD_UNAVAILABLE` after ~60s was observed on genuinely deactivated sandboxes (cause #2), not a platform issue.
