### PR TITLE
feat: inject reserved execution metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added coordinator-owned ready-pool desired capacity with atomic fill claims, provider-neutral compatibility keys, borrow heartbeats, abandoned-borrow quarantine, stale-record pruning, and pool counters.
+- Added reserved `CRABBOX_LEASE_ID`, `CRABBOX_RUN_ID`, and `CRABBOX_SLUG` metadata to every remote command, with Crabbox-owned values taking precedence over forwarded environment variables.
 
 ### Fixed
 

--- a/docs/features/env-forwarding.md
+++ b/docs/features/env-forwarding.md
@@ -121,8 +121,30 @@ a per-run file at `.crabbox/env/<run-or-lease-id>.env` inside the workdir
 removed after the run, and a one-line probe reports which names landed:
 
 ```text
-env profile remote=.crabbox/env/cbx_ab12cd34ef56.env vars=PROJECT_FOO=set,PROJECT_BAR=set
+env profile remote=.crabbox/env/run_ab12cd34ef56.env vars=PROJECT_FOO=set,PROJECT_BAR=set
 ```
+
+## Reserved execution metadata
+
+Every remote command receives three Crabbox-owned environment variables:
+
+```text
+CRABBOX_LEASE_ID  Stable ID for the lease or workspace used by the command.
+CRABBOX_RUN_ID    Unique ID for this crabbox run invocation.
+CRABBOX_SLUG      Friendly lease slug when available; empty otherwise.
+```
+
+`CRABBOX_RUN_ID` uses the durable coordinator-issued run ID when the run is
+coordinator-backed. Without a coordinator, the CLI generates the same
+`run_<12 lowercase hex characters>` shape before dispatch. The value stays
+fixed across argv, shell, uploaded-script, job, and delegated execution within
+that invocation; a later `crabbox run` gets a new ID.
+
+These names are reserved and do not need to appear in `env.allow`. Crabbox
+applies them after ambient allowlist values, profile files, and profile or
+preset environment expansion, so user-supplied values cannot override the
+execution metadata. Matching names are removed from uploaded profile env before
+the remote file is sourced, then the Crabbox-owned values are injected inline.
 
 ## Reusable helpers: `--env-helper`
 

--- a/docs/features/env-forwarding.md
+++ b/docs/features/env-forwarding.md
@@ -134,6 +134,11 @@ CRABBOX_RUN_ID    Unique ID for this crabbox run invocation.
 CRABBOX_SLUG      Friendly lease slug when available; empty otherwise.
 ```
 
+`CRABBOX_LEASE_ID` and `CRABBOX_SLUG` can be empty when a delegated provider
+creates a fresh sandbox during the run itself, because the session does not
+exist yet when the command environment is assembled. Scripts that namespace
+external resources should fall back to `CRABBOX_RUN_ID`, which is always set.
+
 `CRABBOX_RUN_ID` uses the durable coordinator-issued run ID when the run is
 coordinator-backed. Without a coordinator, the CLI generates the same
 `run_<12 lowercase hex characters>` shape before dispatch. The value stays

--- a/docs/features/identifiers.md
+++ b/docs/features/identifiers.md
@@ -103,22 +103,23 @@ lease ID with `_` rewritten to `-`).
 
 ## Run ID
 
-Each `crabbox run` against a coordinator also gets a durable run handle:
+Each `crabbox run` gets a run ID:
 
 ```text
 run_abcdef123456
 ```
 
 Like lease IDs, run IDs are the `run_` prefix plus 12 lowercase hex characters
-(`newRunID` in the coordinator, from 6 random bytes). The coordinator mints the run
-record before the lease is acquired, so events can be appended for leasing
-failures, sync failures, and command output even when the run never reaches
-command-start. A run ID is stable across a single invocation; retrying the same
-command produces a new run.
+from 6 random bytes. A configured coordinator mints the durable run record; the
+CLI uses that issued ID for execution metadata. Coordinator-free runs mint the
+same shape locally before dispatch. A run ID is stable across a single
+invocation; retrying the same command produces a new run.
 
-`crabbox history`, `crabbox events`, `crabbox attach`, `crabbox logs`, and
-`crabbox results` all accept run IDs. Slugs do not resolve to runs — only to
-leases.
+Coordinator-issued IDs are durable handles accepted by `crabbox history`,
+`crabbox events`, `crabbox attach`, `crabbox logs`, and `crabbox results`.
+Locally minted IDs identify the invocation in command environments, timing,
+proof, and failure artifacts but do not create coordinator history. Slugs do
+not resolve to runs — only to leases.
 
 ## Local Claims
 
@@ -224,7 +225,7 @@ provisional lease ID  newLeaseID() before the broker call
 final lease ID        broker may return a different ID; key dir + claim re-keyed to it
 slug                  computed on first lease creation, stable for that lease
 provider name         derived from final lease ID + slug
-run ID                minted per crabbox run when a coordinator is configured
+run ID                minted per crabbox run by the coordinator or local CLI
 ```
 
 Slugs are not reserved after a lease ends. The next lease that happens to hash

--- a/internal/cli/attest_test.go
+++ b/internal/cli/attest_test.go
@@ -442,6 +442,29 @@ func TestDelegatedRunReceiptUsesSessionIdentityFallbacks(t *testing.T) {
 	}
 }
 
+func TestDelegatedRunReceiptPrefersExecutionRunID(t *testing.T) {
+	setAttestTestHome(t)
+	path := filepath.Join(t.TempDir(), "receipt.json")
+	result := RunResult{
+		Provider: "e2b",
+		Session:  &RunSessionHandle{RunID: "run_provider"},
+	}
+	if _, err := writeDelegatedRunReceipt(path, "", Config{Provider: "e2b"}, result, RunRequest{RunID: "run_execution"}); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var receipt map[string]any
+	if err := json.Unmarshal(data, &receipt); err != nil {
+		t.Fatal(err)
+	}
+	if receipt["run_id"] != "run_execution" {
+		t.Fatalf("run_id=%v, want execution metadata run ID", receipt["run_id"])
+	}
+}
+
 func TestAttestReceiptCreatesMissingParentDirectories(t *testing.T) {
 	setAttestTestHome(t)
 	path := filepath.Join(t.TempDir(), "nested", "deeper", "receipt.json")

--- a/internal/cli/bench.go
+++ b/internal/cli/bench.go
@@ -763,6 +763,7 @@ func timingReportFromDelegatedRunResult(req RunRequest, result RunResult, provid
 		Provider:      firstNonBlank(result.Provider, provider),
 		LeaseID:       result.LeaseID,
 		Slug:          result.Slug,
+		RunID:         delegatedRunID(req, result),
 		SyncDelegated: result.SyncDelegated,
 		CommandMs:     result.Command.Milliseconds(),
 		TotalMs:       result.Total.Milliseconds(),

--- a/internal/cli/bench_test.go
+++ b/internal/cli/bench_test.go
@@ -76,17 +76,21 @@ func (b benchmarkTimingTestBackend) Status(context.Context, StatusRequest) (Stat
 func (b benchmarkTimingTestBackend) Stop(context.Context, StopRequest) error { return nil }
 
 func TestTimingReportFromDelegatedRunResultClassifiesRunError(t *testing.T) {
-	report := timingReportFromDelegatedRunResult(RunRequest{}, RunResult{
+	report := timingReportFromDelegatedRunResult(RunRequest{RunID: "run_execution"}, RunResult{
 		Provider:      "sandbox-test",
 		SyncDelegated: true,
 		Command:       250 * time.Millisecond,
 		Total:         time.Second,
+		Session:       &RunSessionHandle{RunID: "run_provider"},
 	}, "fallback", context.DeadlineExceeded)
 	if report.ExitCode != 1 {
 		t.Fatalf("ExitCode=%d, want 1", report.ExitCode)
 	}
 	if report.RunStatus != RunStatusTimedOut || report.ErrorKind != RunErrorTimeout {
 		t.Fatalf("runStatus/errorKind=%q/%q", report.RunStatus, report.ErrorKind)
+	}
+	if report.RunID != "run_execution" {
+		t.Fatalf("RunID=%q, want execution metadata run ID", report.RunID)
 	}
 }
 

--- a/internal/cli/job_test.go
+++ b/internal/cli/job_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -137,6 +138,44 @@ func TestJobRunDryRunPropagatesArchitecture(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Fatalf("dry-run output missing %q:\n%s", want, got)
 		}
+	}
+}
+
+func TestJobRunInjectsReservedExecutionMetadata(t *testing.T) {
+	clearConfigEnv(t)
+	dir := t.TempDir()
+	isolateRunTestUserDirs(t, dir)
+	logPath := installRecordingSSH(t, dir)
+	t.Setenv("CRABBOX_FAKE_SSH_PORT", "22")
+	t.Setenv("CRABBOX_FAKE_SSH_PROXY", "1")
+	configPath := filepath.Join(dir, ".crabbox.yaml")
+	t.Setenv("CRABBOX_CONFIG", configPath)
+	if err := os.WriteFile(configPath, []byte(`jobs:
+  metadata:
+    provider: run-env-profile-test
+    noSync: true
+    command: env
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	app := App{Stdout: &stdout, Stderr: &stderr}
+	if err := app.Run(context.Background(), []string{"job", "run", "--id", "cbx_env_profile_test", "metadata"}); err != nil {
+		t.Fatalf("job run failed: %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	logText := string(data)
+	for _, want := range []string{"CRABBOX_LEASE_ID='cbx_env_profile_test'", "CRABBOX_SLUG=''"} {
+		if !strings.Contains(logText, want) {
+			t.Fatalf("job command missing %q:\n%s", want, logText)
+		}
+	}
+	if !regexp.MustCompile(`CRABBOX_RUN_ID='run_[a-f0-9]{12}'`).MatchString(logText) {
+		t.Fatalf("job command missing run metadata:\n%s", logText)
 	}
 }
 

--- a/internal/cli/lease.go
+++ b/internal/cli/lease.go
@@ -23,6 +23,10 @@ func NewLeaseID() string {
 	return newLeaseID()
 }
 
+func newRunID() string {
+	return "run_" + strings.TrimPrefix(newLeaseID(), "cbx_")
+}
+
 func publicKeyFor(privatePath string) (string, error) {
 	pub := privatePath + ".pub"
 	data, err := os.ReadFile(pub)

--- a/internal/cli/lease_test.go
+++ b/internal/cli/lease_test.go
@@ -3,9 +3,22 @@ package cli
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
+
+func TestNewRunIDUsesCanonicalFormatAndIsUnique(t *testing.T) {
+	first := newRunID()
+	second := newRunID()
+	pattern := regexp.MustCompile(`^run_[a-f0-9]{12}$`)
+	if !pattern.MatchString(first) || !pattern.MatchString(second) {
+		t.Fatalf("run IDs must use canonical format: first=%q second=%q", first, second)
+	}
+	if first == second {
+		t.Fatalf("run IDs must be unique per invocation: %q", first)
+	}
+}
 
 func TestTestboxKeyPathRejectsTraversalIDs(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())

--- a/internal/cli/profiles_test.go
+++ b/internal/cli/profiles_test.go
@@ -480,6 +480,26 @@ func TestRenderRunProofUsesTemplateAndLiveOutput(t *testing.T) {
 	}
 }
 
+func TestDelegatedRunProofUsesExecutionRunID(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "proof.md")
+	_, err := writeDelegatedRunProof(path, "", Config{Provider: "e2b"}, RunResult{
+		Provider:   "e2b",
+		LeaseID:    "cbx_123",
+		LogExcerpt: "passed",
+		Session:    &RunSessionHandle{RunID: "run_provider"},
+	}, RunRequest{RunID: "run_execution", Command: []string{"true"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "Crabbox `run_execution`") || strings.Contains(string(data), "run_provider") {
+		t.Fatalf("delegated proof did not correlate execution metadata run ID:\n%s", data)
+	}
+}
+
 func TestRenderRunProofUsesSafeMarkdownFence(t *testing.T) {
 	got, err := renderRunProof(proofRenderInput{
 		Provider:   "aws",

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -811,6 +811,7 @@ type ListRequest struct {
 type RunRequest struct {
 	Repo                  Repo
 	ID                    string
+	RunID                 string
 	Options               LeaseOptions
 	Keep                  bool
 	Reclaim               bool

--- a/internal/cli/providers_builtin_test.go
+++ b/internal/cli/providers_builtin_test.go
@@ -1033,7 +1033,24 @@ func (testStaticSSHProvider) ApplyFlags(*Config, *flag.FlagSet, any) error {
 	return nil
 }
 func (p testStaticSSHProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
-	return testSSHBackend{spec: p.Spec()}, nil
+	return testStaticSSHBackend{testSSHBackend: testSSHBackend{spec: p.Spec()}, cfg: cfg}, nil
+}
+
+type testStaticSSHBackend struct {
+	testSSHBackend
+	cfg Config
+}
+
+func (b testStaticSSHBackend) Acquire(context.Context, AcquireRequest) (LeaseTarget, error) {
+	server, target, leaseID, err := staticLease(b.cfg)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+}
+
+func (b testStaticSSHBackend) Resolve(context.Context, ResolveRequest) (LeaseTarget, error) {
+	return b.Acquire(context.Background(), AcquireRequest{})
 }
 
 type testExeDevProvider struct{}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -518,6 +518,8 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	envSelection.Inline = mergeEnv(envSelection.Inline, expansion.Env)
 	envSelection.Effective = mergeEnv(envSelection.Effective, expansion.Env)
 	stripExternalDesktopPasswordFromRunEnv(cfg, &envSelection)
+	executionRunID := newRunID()
+	applyRunExecutionMetadata(&envSelection, strings.TrimSpace(*leaseIDFlag), executionRunID, requestedSlug)
 	envHelperName := strings.TrimSpace(*envHelper)
 	if envHelperName != "" && len(envSelection.Profile) == 0 {
 		return exit(2, "--env-helper requires --env-from-profile values selected by --allow-env")
@@ -877,6 +879,11 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	if useCoordinator {
 		recorder.AttachLease(leaseID, serverSlug(server), cfg)
 	}
+	if recorder.runID != "" {
+		executionRunID = recorder.runID
+	}
+	applyRunExecutionMetadata(&envSelection, leaseID, executionRunID, serverSlug(server))
+	runReq.Env = envSelection.Effective
 	keepFailedLease := false
 	defer func() {
 		if !shouldReleaseRunLease(acquired, *keep, keepFailedLease, *stopAfter, runFailure) {
@@ -997,7 +1004,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		if contextPrinted {
 			return
 		}
-		printRunContextSummary(a.Stderr, coord, cfg, server, currentTarget, leaseID, workdir, hydratedByActions, actionsURL, recorder)
+		printRunContextSummary(a.Stderr, coord, cfg, server, currentTarget, leaseID, executionRunID, workdir, hydratedByActions, actionsURL)
 		contextPrinted = true
 	}
 	printPreflight := func(currentTarget SSHTarget) {
@@ -1150,6 +1157,11 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 			recorder.AttachLease(leaseID, serverSlug(server), cfg)
 			startRunHeartbeat(nil)
 		}
+		if recorder.runID != "" {
+			executionRunID = recorder.runID
+		}
+		applyRunExecutionMetadata(&envSelection, leaseID, executionRunID, serverSlug(server))
+		runReq.Env = envSelection.Effective
 		if err := a.claimLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, server, target, repo.Root, *reclaim); err != nil {
 			return true, err
 		}
@@ -1418,7 +1430,7 @@ afterSync:
 		if *timingJSON || timingRecordEnabled {
 			total := time.Since(timings.started)
 			report := timingReportFromRunWithActionsURL(cfg.Provider, leaseID, serverSlug(server), timings, total, 0, actionsURL)
-			populateRunTimingMetadata(&report, cfg, repo, server, leaseID, recorder.runID, workdir, nil)
+			populateRunTimingMetadata(&report, cfg, repo, server, leaseID, executionRunID, workdir, nil)
 			report.Label = runLabelValue
 			finalTimingReport = &report
 		}
@@ -1472,7 +1484,7 @@ afterSync:
 		return recordFailure(err)
 	}
 	if len(envSelection.Profile) > 0 {
-		profileEnvFile = runEnvProfilePath(firstNonBlank(recorder.runID, leaseID, "run"))
+		profileEnvFile = runEnvProfilePath(firstNonBlank(executionRunID, leaseID, "run"))
 		envHelperPath := ""
 		if envHelperName != "" {
 			safeName, _ := safeEnvHelperName(envHelperName)
@@ -1557,6 +1569,7 @@ afterSync:
 		maybePrintEnvForwardingSummary(a.Stderr, cfg.Provider, "forwarded", cfg.EnvAllow, envSelection.Effective)
 	}
 	runEnv := mergeEnv(envSelection.Inline, capabilityEnv)
+	runEnv = mergeEnv(runEnv, runExecutionMetadata(leaseID, executionRunID, serverSlug(server)))
 	envFiles := remoteRunEnvFiles(actionsEnvFile, profileEnvFile)
 	useShell := shouldUseShellWithLiteralArgs(command, expansion.LiteralArgs)
 	remote := remoteCommandWithEnvFiles(workdir, runEnv, envFiles, command)
@@ -1680,7 +1693,7 @@ afterSync:
 	}
 	var runArtifacts []runArtifact
 	if code == 0 && len(runArtifactGlobs) > 0 {
-		collected, artifactOutput, err := collectRunArtifactGlobs(ctx, target, workdir, repo.Root, recorder.runID, leaseID, runArtifactGlobs)
+		collected, artifactOutput, err := collectRunArtifactGlobs(ctx, target, workdir, repo.Root, executionRunID, leaseID, runArtifactGlobs)
 		if err != nil {
 			return recordFailure(err)
 		}
@@ -1714,7 +1727,7 @@ afterSync:
 		failureClassificationPrinted = true
 	}
 	report := timingReportFromRunWithActionsURL(cfg.Provider, leaseID, serverSlug(server), timings, total, code, actionsURL)
-	populateRunTimingMetadata(&report, cfg, repo, server, leaseID, recorder.runID, workdir, runArtifacts)
+	populateRunTimingMetadata(&report, cfg, repo, server, leaseID, executionRunID, workdir, runArtifacts)
 	report.Label = runLabelValue
 	report.SchemaValidations = schemaValidationResults
 	if strings.TrimSpace(*emitProof) != "" && code == 0 {
@@ -1724,7 +1737,7 @@ afterSync:
 			Provider:    cfg.Provider,
 			LeaseID:     leaseID,
 			Slug:        serverSlug(server),
-			RunID:       recorder.runID,
+			RunID:       executionRunID,
 			Command:     commandDisplay,
 			LogExcerpt:  selectProofLogExcerpt(logBuffer.String()),
 			ActionsURL:  actionsURL,
@@ -1746,7 +1759,7 @@ afterSync:
 			Provider:   cfg.Provider,
 			LeaseID:    leaseID,
 			Slug:       serverSlug(server),
-			RunID:      recorder.runID,
+			RunID:      executionRunID,
 			Command:    commandDisplay,
 			ExitCode:   code,
 			CommandMs:  report.CommandMs,
@@ -1764,7 +1777,7 @@ afterSync:
 	if a.runOutcome != nil {
 		a.runOutcome.Recorded = true
 		a.runOutcome.ExitCode = code
-		a.runOutcome.RunID = recorder.runID
+		a.runOutcome.RunID = executionRunID
 		a.runOutcome.Results = results
 	}
 	fmt.Fprintf(a.Stderr, "command complete in %s total=%s\n", timings.command.Round(time.Millisecond), total.Round(time.Millisecond))
@@ -1773,7 +1786,7 @@ afterSync:
 	if runLabelValue != "" {
 		labelField = fmt.Sprintf(" label=%q", runLabelValue)
 	}
-	fmt.Fprintf(a.Stderr, "run details provider=%s lease=%s slug=%s run=%s%s type=%s repo=%s workdir=%s actions=%s stop_command=%q idle_timeout=%s\n", cfg.Provider, leaseID, blank(serverSlug(server), "-"), blank(recorder.runID, "-"), labelField, blank(server.ServerType.Name, "-"), repo.Root, workdir, blank(actionsURL, "-"), report.StopCommand, cfg.IdleTimeout)
+	fmt.Fprintf(a.Stderr, "run details provider=%s lease=%s slug=%s run=%s%s type=%s repo=%s workdir=%s actions=%s stop_command=%q idle_timeout=%s\n", cfg.Provider, leaseID, blank(serverSlug(server), "-"), executionRunID, labelField, blank(server.ServerType.Name, "-"), repo.Root, workdir, blank(actionsURL, "-"), report.StopCommand, cfg.IdleTimeout)
 	if *timingJSON || timingRecordEnabled {
 		finalTimingReport = &report
 	}
@@ -1784,7 +1797,7 @@ afterSync:
 			WindowsMode:           cfg.WindowsMode,
 			LeaseID:               leaseID,
 			Slug:                  serverSlug(server),
-			RunID:                 recorder.runID,
+			RunID:                 executionRunID,
 			RunHistoryUnavailable: recorder.historyUnavailable,
 			CommandDisplay:        commandDisplay,
 			ShellMode:             *shellMode || useShell,
@@ -1800,7 +1813,7 @@ afterSync:
 			Provider:       cfg.Provider,
 			LeaseID:        leaseID,
 			Slug:           serverSlug(server),
-			RunID:          recorder.runID,
+			RunID:          executionRunID,
 			Workdir:        workdir,
 			ExitCode:       code,
 			ActionsRunURL:  actionsURL,
@@ -1812,7 +1825,7 @@ afterSync:
 			StderrPath:     streamCaptures.stderr.path(),
 			CaptureFlagSet: *captureOnFail,
 		}
-		if local, bytes, captureErr := captureFailureBundle(ctx, target, workdir, leaseID, recorder.runID, capture); captureErr != nil {
+		if local, bytes, captureErr := captureFailureBundle(ctx, target, workdir, leaseID, executionRunID, capture); captureErr != nil {
 			fmt.Fprintf(a.Stderr, "warning: failure bundle failed: %v\n", captureErr)
 			if local != "" {
 				fmt.Fprintf(a.Stderr, "failure-bundle local=%s bytes=%d secret_risk=caller-redacts-before-sharing\n", local, bytes)

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -640,6 +640,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	runReq := RunRequest{
 		Repo:                  repo,
 		ID:                    *leaseIDFlag,
+		RunID:                 executionRunID,
 		Options:               options,
 		Keep:                  *keep,
 		KeepOnFailure:         *keepOnFailure,
@@ -883,6 +884,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		executionRunID = recorder.runID
 	}
 	applyRunExecutionMetadata(&envSelection, leaseID, executionRunID, serverSlug(server))
+	runReq.RunID = executionRunID
 	runReq.Env = envSelection.Effective
 	keepFailedLease := false
 	defer func() {
@@ -1004,7 +1006,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		if contextPrinted {
 			return
 		}
-		printRunContextSummary(a.Stderr, coord, cfg, server, currentTarget, leaseID, executionRunID, workdir, hydratedByActions, actionsURL)
+		printRunContextSummary(a.Stderr, coord, cfg, server, currentTarget, leaseID, executionRunID, recorder.runID, workdir, hydratedByActions, actionsURL)
 		contextPrinted = true
 	}
 	printPreflight := func(currentTarget SSHTarget) {
@@ -1161,6 +1163,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 			executionRunID = recorder.runID
 		}
 		applyRunExecutionMetadata(&envSelection, leaseID, executionRunID, serverSlug(server))
+		runReq.RunID = executionRunID
 		runReq.Env = envSelection.Effective
 		if err := a.claimLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, server, target, repo.Root, *reclaim); err != nil {
 			return true, err
@@ -1798,7 +1801,7 @@ afterSync:
 			LeaseID:               leaseID,
 			Slug:                  serverSlug(server),
 			RunID:                 executionRunID,
-			RunHistoryUnavailable: recorder.historyUnavailable,
+			RunHistoryUnavailable: recorder.historyIsUnavailable(),
 			CommandDisplay:        commandDisplay,
 			ShellMode:             *shellMode || useShell,
 			ScriptMode:            script != nil,
@@ -1944,6 +1947,7 @@ func writeDelegatedRunProof(path, templateName string, cfg Config, result RunRes
 		Provider:    provider,
 		LeaseID:     leaseID,
 		Slug:        slug,
+		RunID:       delegatedRunID(req, result),
 		Command:     command,
 		LogExcerpt:  logExcerpt,
 		ActionsURL:  result.ActionsURL,
@@ -1964,6 +1968,7 @@ func writeDelegatedRunReceipt(path, keyPath string, cfg Config, result RunResult
 		Provider:   result.Provider,
 		LeaseID:    result.LeaseID,
 		Slug:       result.Slug,
+		RunID:      delegatedRunID(req, result),
 		Command:    command,
 		ExitCode:   result.ExitCode,
 		CommandMs:  result.Command.Milliseconds(),
@@ -1973,11 +1978,20 @@ func writeDelegatedRunReceipt(path, keyPath string, cfg Config, result RunResult
 		receipt.Provider = firstNonBlank(receipt.Provider, session.Provider)
 		receipt.LeaseID = firstNonBlank(receipt.LeaseID, session.LeaseID)
 		receipt.Slug = firstNonBlank(receipt.Slug, session.Slug)
-		receipt.RunID = session.RunID
 		receipt.ActionsURL = firstNonBlank(receipt.ActionsURL, session.ActionsURL)
 	}
 	receipt.Provider = firstNonBlank(receipt.Provider, cfg.Provider)
 	return writeRunReceipt(path, keyPath, receipt)
+}
+
+func delegatedRunID(req RunRequest, result RunResult) string {
+	if runID := strings.TrimSpace(req.RunID); runID != "" {
+		return runID
+	}
+	if result.Session != nil {
+		return strings.TrimSpace(result.Session.RunID)
+	}
+	return ""
 }
 
 func runCommandDisplay(command []string, shellMode bool) string {

--- a/internal/cli/run_env_profile.go
+++ b/internal/cli/run_env_profile.go
@@ -63,6 +63,34 @@ type runEnvSelection struct {
 	SummaryRequested bool
 }
 
+const (
+	runEnvLeaseID = "CRABBOX_LEASE_ID"
+	runEnvRunID   = "CRABBOX_RUN_ID"
+	runEnvSlug    = "CRABBOX_SLUG"
+)
+
+var reservedRunEnvNames = []string{runEnvLeaseID, runEnvRunID, runEnvSlug}
+
+func runExecutionMetadata(leaseID, runID, slug string) map[string]string {
+	return map[string]string{
+		runEnvLeaseID: strings.TrimSpace(leaseID),
+		runEnvRunID:   strings.TrimSpace(runID),
+		runEnvSlug:    strings.TrimSpace(slug),
+	}
+}
+
+func applyRunExecutionMetadata(selection *runEnvSelection, leaseID, runID, slug string) {
+	if selection == nil {
+		return
+	}
+	removeEnvironmentKeys(selection.Profile, reservedRunEnvNames...)
+	removeEnvironmentKeys(selection.Inline, reservedRunEnvNames...)
+	removeEnvironmentKeys(selection.Effective, reservedRunEnvNames...)
+	metadata := runExecutionMetadata(leaseID, runID, slug)
+	selection.Inline = mergeEnv(selection.Inline, metadata)
+	selection.Effective = mergeEnv(selection.Effective, metadata)
+}
+
 func removeEnvironmentKeys(values map[string]string, denied ...string) {
 	for key := range values {
 		for _, name := range denied {

--- a/internal/cli/run_env_profile_test.go
+++ b/internal/cli/run_env_profile_test.go
@@ -142,6 +142,58 @@ func TestAllowedEnvFromProfilesOnlyForAllowlist(t *testing.T) {
 	}
 }
 
+func TestRunExecutionMetadataOverridesForwardedValues(t *testing.T) {
+	selection := runEnvSelection{
+		Profile: map[string]string{
+			"CRABBOX_LEASE_ID": "profile-lease",
+			"crabbox_run_id":   "profile-run",
+			"CRABBOX_SLUG":     "profile-slug",
+			"PROFILE_VALUE":    "preserved",
+		},
+		Inline: map[string]string{
+			"CRABBOX_LEASE_ID": "inline-lease",
+			"crabbox_run_id":   "inline-run",
+			"CRABBOX_SLUG":     "inline-slug",
+			"INLINE_VALUE":     "preserved",
+		},
+		Effective: map[string]string{
+			"CRABBOX_LEASE_ID": "effective-lease",
+			"crabbox_run_id":   "effective-run",
+			"CRABBOX_SLUG":     "effective-slug",
+			"PROFILE_VALUE":    "preserved",
+			"INLINE_VALUE":     "preserved",
+		},
+	}
+
+	applyRunExecutionMetadata(&selection, " cbx_abcdef123456 ", " run_123456abcdef ", " blue-lobster ")
+
+	want := map[string]string{
+		runEnvLeaseID: "cbx_abcdef123456",
+		runEnvRunID:   "run_123456abcdef",
+		runEnvSlug:    "blue-lobster",
+	}
+	for name, value := range want {
+		if selection.Inline[name] != value || selection.Effective[name] != value {
+			t.Fatalf("reserved %s did not win: inline=%#v effective=%#v", name, selection.Inline, selection.Effective)
+		}
+	}
+	for name := range selection.Profile {
+		for _, reserved := range reservedRunEnvNames {
+			if strings.EqualFold(name, reserved) {
+				t.Fatalf("profile retained reserved name %q: %#v", name, selection.Profile)
+			}
+		}
+	}
+	for _, values := range []map[string]string{selection.Inline, selection.Effective} {
+		if _, found := values["crabbox_run_id"]; found {
+			t.Fatalf("case-insensitive override survived: %#v", values)
+		}
+	}
+	if selection.Profile["PROFILE_VALUE"] != "preserved" || selection.Inline["INLINE_VALUE"] != "preserved" {
+		t.Fatalf("unrelated environment changed: %#v", selection)
+	}
+}
+
 func TestExternalDesktopPasswordNeverEntersRunEnvironmentForAnyTarget(t *testing.T) {
 	t.Setenv("SCREEN_SHARING_PASSWORD", "operator-secret")
 	t.Setenv("SCREEN_SAFE_VALUE", "preserved")

--- a/internal/cli/run_observability.go
+++ b/internal/cli/run_observability.go
@@ -71,13 +71,9 @@ func envNameLooksSecret(name string) bool {
 	return false
 }
 
-func printRunContextSummary(w io.Writer, coord *CoordinatorClient, cfg Config, server Server, target SSHTarget, leaseID, workdir string, hydrated bool, actionsURL string, recorder *runRecorder) {
+func printRunContextSummary(w io.Writer, coord *CoordinatorClient, cfg Config, server Server, target SSHTarget, leaseID, runID, workdir string, hydrated bool, actionsURL string) {
 	if w == nil {
 		return
-	}
-	runID := ""
-	if recorder != nil {
-		runID = recorder.runID
 	}
 	workspace := "raw"
 	if hydrated {

--- a/internal/cli/run_observability.go
+++ b/internal/cli/run_observability.go
@@ -71,7 +71,7 @@ func envNameLooksSecret(name string) bool {
 	return false
 }
 
-func printRunContextSummary(w io.Writer, coord *CoordinatorClient, cfg Config, server Server, target SSHTarget, leaseID, runID, workdir string, hydrated bool, actionsURL string) {
+func printRunContextSummary(w io.Writer, coord *CoordinatorClient, cfg Config, server Server, target SSHTarget, leaseID, runID, historyRunID, workdir string, hydrated bool, actionsURL string) {
 	if w == nil {
 		return
 	}
@@ -80,7 +80,7 @@ func printRunContextSummary(w io.Writer, coord *CoordinatorClient, cfg Config, s
 		workspace = "actions-hydrated"
 	}
 	fmt.Fprintln(w, "run context:")
-	fmt.Fprintf(w, "  run=%s portal=%s logs=%s\n", blank(runID, "-"), runPortalURL(coord, runID), runLogsURL(coord, runID))
+	fmt.Fprintf(w, "  run=%s portal=%s logs=%s\n", blank(runID, "-"), runPortalURL(coord, historyRunID), runLogsURL(coord, historyRunID))
 	fmt.Fprintf(w, "  lease=%s slug=%s provider=%s target=%s type=%s\n", leaseID, blank(serverSlug(server), "-"), cfg.Provider, blank(target.TargetOS, cfg.TargetOS), server.ServerType.Name)
 	fmt.Fprintf(w, "  ssh=%s@%s:%s ip=%s\n", redactedSSHUser(cfg, server, target), target.Host, target.Port, blank(server.PublicNet.IPv4.IP, target.Host))
 	fmt.Fprintf(w, "  workdir=%s workspace=%s actions=%s\n", workdir, workspace, blank(actionsURL, "-"))

--- a/internal/cli/run_recorder.go
+++ b/internal/cli/run_recorder.go
@@ -65,6 +65,10 @@ func (r *runRecorder) UseCoordinator(coord *CoordinatorClient) {
 	r.coord = coord
 }
 
+func (r *runRecorder) historyIsUnavailable() bool {
+	return r == nil || r.runID == "" || r.historyUnavailable
+}
+
 func (r *runRecorder) Event(kind, phase, message string) {
 	if r == nil || r.runID == "" || (r.finished && kind != "lease.released") {
 		return

--- a/internal/cli/run_recorder_test.go
+++ b/internal/cli/run_recorder_test.go
@@ -153,6 +153,11 @@ func TestRunRecorderDefersCreateWhenCoordinatorRequiresLeaseID(t *testing.T) {
 	if text := stderr.String(); strings.Contains(text, "warning:") || !strings.Contains(text, "recording run run_123") {
 		t.Fatalf("stderr=%q", text)
 	}
+	selection := runEnvSelection{Inline: map[string]string{}, Effective: map[string]string{}}
+	applyRunExecutionMetadata(&selection, "cbx_abcdef123456", rec.runID, "blue-lobster")
+	if selection.Effective[runEnvRunID] != "run_123" {
+		t.Fatalf("execution metadata run ID=%q, want coordinator-issued run_123", selection.Effective[runEnvRunID])
+	}
 }
 
 func TestRunRecorderDefersCreateForExplicitLeaseRuns(t *testing.T) {

--- a/internal/cli/run_recorder_test.go
+++ b/internal/cli/run_recorder_test.go
@@ -160,6 +160,21 @@ func TestRunRecorderDefersCreateWhenCoordinatorRequiresLeaseID(t *testing.T) {
 	}
 }
 
+func TestRunRecorderHistoryAvailabilityRequiresRecordedRunID(t *testing.T) {
+	if !((*runRecorder)(nil)).historyIsUnavailable() {
+		t.Fatal("nil recorder reported history available")
+	}
+	if !(&runRecorder{}).historyIsUnavailable() {
+		t.Fatal("local-only recorder reported history available")
+	}
+	if (&runRecorder{runID: "run_123"}).historyIsUnavailable() {
+		t.Fatal("recorded coordinator run reported history unavailable")
+	}
+	if !(&runRecorder{runID: "run_123", historyUnavailable: true}).historyIsUnavailable() {
+		t.Fatal("failed coordinator history reported available")
+	}
+}
+
 func TestRunRecorderDefersCreateForExplicitLeaseRuns(t *testing.T) {
 	var stderr bytes.Buffer
 	var createBodies []map[string]any

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -982,11 +982,35 @@ func TestRunCommandInjectsReservedMetadataIntoDelegatedRequest(t *testing.T) {
 	if !regexp.MustCompile(`^run_[a-f0-9]{12}$`).MatchString(env[runEnvRunID]) {
 		t.Fatalf("delegated run ID=%q", env[runEnvRunID])
 	}
+	if runModuleRuntimeTestRequests[0].RunID != env[runEnvRunID] {
+		t.Fatalf("delegated request run ID=%q, env run ID=%q", runModuleRuntimeTestRequests[0].RunID, env[runEnvRunID])
+	}
 	for _, forbidden := range []string{"ambient-lease", "ambient-run", "ambient-slug"} {
 		for _, value := range env {
 			if value == forbidden {
 				t.Fatalf("reserved override %q reached delegated request: %#v", forbidden, env)
 			}
+		}
+	}
+}
+
+func TestPrintRunContextSummarySeparatesExecutionAndHistoryRunIDs(t *testing.T) {
+	coord := &CoordinatorClient{BaseURL: "https://coordinator.example.test"}
+	var local bytes.Buffer
+	printRunContextSummary(&local, coord, Config{Provider: "aws", TargetOS: targetLinux}, Server{}, SSHTarget{}, "cbx_123", "run_local", "", "/work/repo", false, "")
+	if got := local.String(); !strings.Contains(got, "run=run_local portal=- logs=-") || strings.Contains(got, "/runs/run_local") {
+		t.Fatalf("local run context exposed nonexistent history URLs:\n%s", got)
+	}
+
+	var recorded bytes.Buffer
+	printRunContextSummary(&recorded, coord, Config{Provider: "aws", TargetOS: targetLinux}, Server{}, SSHTarget{}, "cbx_123", "run_execution", "run_history", "/work/repo", false, "")
+	for _, want := range []string{
+		"run=run_execution",
+		"portal=https://coordinator.example.test/portal/runs/run_history",
+		"logs=https://coordinator.example.test/v1/runs/run_history/logs",
+	} {
+		if !strings.Contains(recorded.String(), want) {
+			t.Fatalf("recorded run context missing %q:\n%s", want, recorded.String())
 		}
 	}
 }

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -246,6 +247,74 @@ func assertSSHLogContains(t *testing.T, logPath, want string) {
 	}
 	if !strings.Contains(string(data), want) {
 		t.Fatalf("ssh log missing %q:\n%s", want, data)
+	}
+}
+
+func TestRunCommandInjectsReservedMetadataAcrossSSHCommandModes(t *testing.T) {
+	tests := []struct {
+		name string
+		args func(string) []string
+	}{
+		{name: "argv", args: func(string) []string { return []string{"--", "env"} }},
+		{name: "shell", args: func(string) []string { return []string{"--shell", "--", "env | sort"} }},
+		{name: "script", args: func(script string) []string { return []string{"--script", script} }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearConfigEnv(t)
+			dir := t.TempDir()
+			isolateRunTestUserDirs(t, dir)
+			logPath := installRecordingSSH(t, dir)
+			t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, "missing.yaml"))
+			t.Setenv("CRABBOX_FAKE_SSH_PORT", "22")
+			t.Setenv("CRABBOX_FAKE_SSH_PROXY", "1")
+			t.Setenv(runEnvLeaseID, "ambient-lease")
+			t.Setenv(runEnvRunID, "ambient-run")
+			t.Setenv(runEnvSlug, "ambient-slug")
+
+			profile := filepath.Join(dir, "env.profile")
+			if err := os.WriteFile(profile, []byte("CRABBOX_LEASE_ID=profile-lease\nCRABBOX_RUN_ID=profile-run\nCRABBOX_SLUG=profile-slug\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			script := filepath.Join(dir, "proof.sh")
+			if err := os.WriteFile(script, []byte("#!/bin/sh\nenv | sort\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			args := []string{
+				"--provider", "run-env-profile-test",
+				"--no-sync",
+				"--allow-env", strings.Join(reservedRunEnvNames, ","),
+				"--env-from-profile", profile,
+			}
+			args = append(args, tt.args(script)...)
+			var stdout, stderr bytes.Buffer
+			if err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), args); err != nil {
+				t.Fatalf("run error=%v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+			}
+			data, err := os.ReadFile(logPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			logText := string(data)
+			if !strings.Contains(logText, "CRABBOX_LEASE_ID='cbx_env_profile_test'") {
+				t.Fatalf("lease metadata missing from SSH command:\n%s", logText)
+			}
+			if !strings.Contains(logText, "CRABBOX_SLUG=''") {
+				t.Fatalf("empty slug metadata missing from SSH command:\n%s", logText)
+			}
+			runIDMatch := regexp.MustCompile(`CRABBOX_RUN_ID='(run_[a-f0-9]{12})'`).FindStringSubmatch(logText)
+			if len(runIDMatch) != 2 {
+				t.Fatalf("CLI-generated run metadata missing from SSH command:\n%s", logText)
+			}
+			if !strings.Contains(stderr.String(), "run="+runIDMatch[1]) {
+				t.Fatalf("reported run ID differs from command metadata: run=%s stderr=%s", runIDMatch[1], stderr.String())
+			}
+			for _, forbidden := range []string{"ambient-lease", "ambient-run", "ambient-slug", "profile-lease", "profile-run", "profile-slug"} {
+				if strings.Contains(logText, forbidden) {
+					t.Fatalf("reserved metadata override %q reached SSH command:\n%s", forbidden, logText)
+				}
+			}
+		})
 	}
 }
 
@@ -880,6 +949,80 @@ func TestRunCommandPassesScriptToModuleDelegatedProvider(t *testing.T) {
 	}
 	if len(req.Command) != 0 {
 		t.Fatalf("command=%v, want none", req.Command)
+	}
+}
+
+func TestRunCommandInjectsReservedMetadataIntoDelegatedRequest(t *testing.T) {
+	clearConfigEnv(t)
+	runModuleRuntimeTestRequests = nil
+	t.Setenv(runEnvLeaseID, "ambient-lease")
+	t.Setenv(runEnvRunID, "ambient-run")
+	t.Setenv(runEnvSlug, "ambient-slug")
+	script := filepath.Join(t.TempDir(), "worker.mjs")
+	if err := os.WriteFile(script, []byte("export default { fetch() { return new Response('ok') } }\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
+		"--provider", "module-runtime-test",
+		"--id", "cbx_delegated",
+		"--allow-env", strings.Join(reservedRunEnvNames, ","),
+		"--script", script,
+	})
+	if err != nil {
+		t.Fatalf("run error=%v stderr=%q", err, stderr.String())
+	}
+	if len(runModuleRuntimeTestRequests) != 1 {
+		t.Fatalf("run requests=%#v, want one", runModuleRuntimeTestRequests)
+	}
+	env := runModuleRuntimeTestRequests[0].Env
+	if env[runEnvLeaseID] != "cbx_delegated" || env[runEnvSlug] != "" {
+		t.Fatalf("delegated lease metadata=%#v", env)
+	}
+	if !regexp.MustCompile(`^run_[a-f0-9]{12}$`).MatchString(env[runEnvRunID]) {
+		t.Fatalf("delegated run ID=%q", env[runEnvRunID])
+	}
+	for _, forbidden := range []string{"ambient-lease", "ambient-run", "ambient-slug"} {
+		for _, value := range env {
+			if value == forbidden {
+				t.Fatalf("reserved override %q reached delegated request: %#v", forbidden, env)
+			}
+		}
+	}
+}
+
+func TestRunCommandInjectsReservedMetadataIntoStaticSSH(t *testing.T) {
+	clearConfigEnv(t)
+	dir := t.TempDir()
+	isolateRunTestUserDirs(t, dir)
+	logPath := installRecordingSSH(t, dir)
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, "missing.yaml"))
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
+		"--provider", "ssh",
+		"--static-host", "127.0.0.1",
+		"--static-user", "runner",
+		"--static-work-root", "/tmp/crabbox-static-test",
+		"--no-sync",
+		"--",
+		"env",
+	})
+	if err != nil {
+		t.Fatalf("static SSH run error=%v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	logText := string(data)
+	for _, pattern := range []string{
+		`CRABBOX_LEASE_ID='static_[^']+'`,
+		`CRABBOX_RUN_ID='run_[a-f0-9]{12}'`,
+		`CRABBOX_SLUG=''`,
+	} {
+		if !regexp.MustCompile(pattern).MatchString(logText) {
+			t.Fatalf("static SSH metadata %q missing:\n%s", pattern, logText)
+		}
 	}
 }
 
@@ -1613,7 +1756,7 @@ exit 0
 	if readErr != nil {
 		t.Fatal(readErr)
 	}
-	if !strings.Contains(string(logData), "rm -f --") || !strings.Contains(string(logData), ".crabbox/env/cbx_env_profile_test.env") {
+	if !strings.Contains(string(logData), "rm -f --") || !regexp.MustCompile(`\.crabbox/env/run_[a-f0-9]{12}\.env`).Match(logData) {
 		t.Fatalf("cleanup command missing from ssh log:\n%s", logData)
 	}
 }


### PR DESCRIPTION
## Summary

- inject `CRABBOX_LEASE_ID`, `CRABBOX_RUN_ID`, and `CRABBOX_SLUG` through the centralized run environment selection pipeline
- use the coordinator-issued run ID when available and mint a canonical CLI run ID for coordinator-free invocations
- keep reserved metadata authoritative over ambient, profile, preset, capability, and delegated-request environment values
- carry coordinator-free run IDs through context, timing, proof, artifact, and failure output
- document lifecycle and precedence semantics and add regression coverage for argv, shell, script, job, static SSH, coordinator, and delegated paths

Fixes https://github.com/openclaw/crabbox/issues/1161

## Verification

```text
$ gofmt -w $(git ls-files '*.go')
(clean)

$ go vet ./...
(pass)

$ go test -race ./...
ok  github.com/openclaw/crabbox/internal/cli  194.810s
ok  all remaining test packages

$ node scripts/build-docs-site.mjs
built docs site: dist/docs-site

$ .agents/skills/autoreview/scripts/autoreview --mode local
autoreview clean: no accepted/actionable findings reported
```

## Real behavior proof

Built the real CLI and ran a shell command inside a Docker-backed local-container lease while attempting to override all three reserved names from ambient and profile environment sources:

```text
$ go build -trimpath -o bin/crabbox ./cmd/crabbox
$ CRABBOX_LEASE_ID=ambient-lease CRABBOX_RUN_ID=ambient-run CRABBOX_SLUG=ambient-slug \
  ./bin/crabbox run --provider local-container \
  --local-container-image node:24-bookworm --no-sync \
  --allow-env CRABBOX_LEASE_ID,CRABBOX_RUN_ID,CRABBOX_SLUG \
  --env-from-profile override.env --shell -- \
  'env | grep "^CRABBOX_" | sort'

run context:
  run=run_52b21a66ebee portal=- logs=-
  lease=cbx_d3be3ca783ee slug=harbor-hermit-a9c5 provider=local-container target=linux type=node_24-bookworm
CRABBOX_LEASE_ID=cbx_d3be3ca783ee
CRABBOX_RUN_ID=run_52b21a66ebee
CRABBOX_SLUG=harbor-hermit-a9c5
run details provider=local-container lease=cbx_d3be3ca783ee slug=harbor-hermit-a9c5 run=run_52b21a66ebee type=node_24-bookworm
lease cleanup stopped=true policy=auto lease=cbx_d3be3ca783ee slug=harbor-hermit-a9c5
```

The source-blind behavior contract passed 5/5 clauses: injection, canonical values, override protection, matching reported/in-target run IDs, and unique IDs across invocations.
