### PR TITLE
feat(worker): add read-only device pairing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Added coordinator-owned ready-pool desired capacity with atomic fill claims, provider-neutral compatibility keys, borrow heartbeats, abandoned-borrow quarantine, stale-record pruning, and pool counters.
 - Added reserved `CRABBOX_LEASE_ID`, `CRABBOX_RUN_ID`, and `CRABBOX_SLUG` metadata to every remote command, with Crabbox-owned values taking precedence over forwarded environment variables.
-- Added owner-bound, single-use coordinator pairing grants and revocable read-only device tokens for listing and inspecting visible leases.
+- Added browser-initiated, owner-bound coordinator pairing grants and revocable credential-free device tokens for read-only lease status.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added coordinator-owned ready-pool desired capacity with atomic fill claims, provider-neutral compatibility keys, borrow heartbeats, abandoned-borrow quarantine, stale-record pruning, and pool counters.
 - Added reserved `CRABBOX_LEASE_ID`, `CRABBOX_RUN_ID`, and `CRABBOX_SLUG` metadata to every remote command, with Crabbox-owned values taking precedence over forwarded environment variables.
+- Added owner-bound, single-use coordinator pairing grants and revocable read-only device tokens for listing and inspecting visible leases.
 
 ### Fixed
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -76,7 +76,8 @@ certification.
   [Repository Onboarding](features/repository-onboarding.md).
 - **Fleet and operations:** [Architecture](architecture.md),
   [Infrastructure](infrastructure.md), [Operations](operations.md),
-  [Observability](observability.md), and [Security](security.md).
+  [Observability](observability.md), [Read-Only Device Pairing](features/device-pairing.md),
+  and [Security](security.md).
 - **Runs and evidence:** [Jobs](features/jobs.md),
   [Actions Hydration](features/actions-hydration.md),
   [Artifacts](features/artifacts.md), [Checkpoints](features/checkpoints.md),

--- a/docs/features/auth-admin.md
+++ b/docs/features/auth-admin.md
@@ -30,8 +30,11 @@ allowed GitHub org** (`CRABBOX_GITHUB_ALLOWED_ORGS`, or the singular
 of them. The account must also expose a verified email through GitHub's
 `user:email` scope as an eligibility check; ownership uses GitHub's immutable
 numeric account ID, never an email or login. On success the broker issues a
-signed user token (prefix `cbxu_`, HMAC-SHA256, default 180-day expiry) and the
-CLI stores it in the user config. The token carries the GitHub OAuth credential
+signed user token (prefix `cbxu_`, HMAC-SHA256, default 180-day expiry) for CLI
+login, while portal login receives a distinct `cbwp_` browser-session token in a
+host-only cookie. Normal API Bearer authentication accepts `cbxu_` but rejects
+`cbwp_`; browser-only authority is never inferred from a caller-supplied Cookie
+header. The token carries the GitHub OAuth credential
 encrypted under the independent session secret. The broker revalidates that
 credential's account ID and current org/team membership on requests, caching
 successful checks for five minutes and failing closed when GitHub can no longer

--- a/docs/features/coordinator.md
+++ b/docs/features/coordinator.md
@@ -85,14 +85,22 @@ owner email for admin and shared-token requests.
 After auth, the coordinator strips inbound Access headers and injects a trusted
 context for the fleet implementation: `x-crabbox-auth`, `x-crabbox-admin`,
 `x-crabbox-owner`, `x-crabbox-org`, and `x-crabbox-github-login`. The portal
-converts one unique `__Host-crabbox_session` host-only cookie into a Bearer token
-so browser sessions reuse the same auth path. Duplicate session cookies fail
-closed.
+stores a distinct `cbwp_` browser-session credential in the unique
+`__Host-crabbox_session` host-only cookie. The coordinator accepts that audience
+only from the cookie-authenticated portal path and marks it as a trusted portal
+session; normal API Bearer authentication rejects it. Legacy `cbxu_` portal
+cookies remain usable for ordinary portal pages but cannot initiate pairing.
+Duplicate session cookies fail closed.
 
 GitHub user tokens are scoped to their owner/org for lease, run, log, and usage
 routes. Admin scope (admin token, or shared token where allowed) is required for
 `GET /v1/pool`, all `/v1/admin/*` routes, `POST /v1/images`, and the image
 sub-routes.
+
+The [read-only device pairing](device-pairing.md) surface uses a separate
+`crabbox-device` principal. It can only list and inspect credential-free lease
+status, never inherits owner or admin authority, and revalidates the paired
+GitHub owner on every request.
 
 ## API surface
 

--- a/docs/features/device-pairing.md
+++ b/docs/features/device-pairing.md
@@ -1,0 +1,111 @@
+# Read-Only Device Pairing
+
+Read this when you are implementing or auditing a companion that displays
+coordinator lease status without receiving lease credentials or lifecycle
+authority.
+
+## Security boundary
+
+A device token is a distinct coordinator principal. It is not an alias for the
+user who paired it. The token has audience `crabbox-device` and exactly one
+scope, `leases:read`. It can call only:
+
+```text
+GET /v1/leases
+GET /v1/leases/{id-or-slug}
+```
+
+Those routes return the leases currently visible to the paired owner, including
+leases shared with that owner. Device responses always redact SSH host, user,
+port, fallback ports, host key, work root, provider-access expiry, and Tailscale
+access metadata. A device read never refreshes provider access, calls a provider,
+or writes coordinator state.
+
+All other routes are denied before normal routing with `403
+device_scope_forbidden`. This includes create, run, heartbeat, stop, release,
+share, authoritative provider metadata, bridge tickets, portal, and admin
+surfaces.
+
+## Pairing flow
+
+Pairing begins only from the coordinator-hosted browser session. A signed GitHub
+user token presented as an API Bearer token, a shared automation token, a trusted
+proxy identity, or an admin token cannot initiate pairing.
+
+Portal OAuth issues the browser a distinct `cbwp_` signed session credential.
+Normal API authentication does not accept that audience, and copying a `cbxu_`
+user Bearer token into a Cookie header does not create a pairing-capable browser
+session. This distinction is enforced cryptographically rather than inferred
+from client-controlled `Cookie` or `Origin` headers.
+
+```text
+POST /v1/pairing/grants
+  Auth: __Host-crabbox_session browser cookie
+  Body: { "name": "Alice's phone" }
+  Result: one-use cbxp_ grant, expires after 5 minutes
+
+POST /v1/pairing/exchange
+  Auth: one-use grant in the JSON body
+  Body: { "grant": "..." }
+  Result: cbxd_ device token plus public device metadata
+```
+
+The grant is owner-bound and atomically consumed. Expired grants and replayed
+grants cannot mint a token. The coordinator allows at most 10 active grants and
+10 active device tokens per owner and organization. Revoke an old device before
+pairing another when the device limit is reached.
+
+A device token expires after at most 90 days and stops earlier if its paired
+browser authorization grant expires or can no longer be revalidated.
+
+Pairing codes and device tokens belong only in request bodies, the
+`Authorization` header, and the device's protected credential store. Do not put
+them in URLs, command arguments, logs, analytics, crash reports, screenshots, or
+repository configuration.
+
+## Owner revalidation
+
+The coordinator stores the paired browser session's sealed GitHub authorization
+grant beside the token hash. Every device request performs a fresh, uncached
+check of the immutable GitHub account and its current allowed organization/team
+membership. GitHub errors, account mismatch, removed membership, revoked users,
+or a no-longer-allowed organization fail closed with `401`.
+
+The sealed grant never reaches the device. Only a hash of the device token is
+stored, and the public device response contains no credential material.
+
+## Device management and revocation
+
+Device management also requires the same coordinator-hosted browser session:
+
+```text
+GET    /v1/devices       list this owner/org's active devices
+DELETE /v1/devices/{id}  revoke one device
+DELETE /v1/devices       revoke all devices for this owner/org
+```
+
+Device and grant indexes are scoped to the exact owner/org and bounded by their
+caps; management does not scan other owners' records. Revocation removes the
+server-side verifier, so the next request with that token returns `401`. Lease
+owner or sharing changes are evaluated from current lease state on every read,
+so removed visibility fails closed on the next request as well.
+
+## Origin policy
+
+Pairing, exchange, device revocation, and device reads require both the request
+destination and the `Origin` header to exactly match `CRABBOX_PUBLIC_URL`.
+Read-only `GET /v1/devices` accepts the browser's normal missing `Origin` header,
+but still requires the exact configured request destination and rejects a
+different supplied Origin. The configured origin must be HTTPS. Loopback HTTP
+is accepted only for local development. These credential-bearing routes do not
+redirect to another origin.
+
+## Non-goals
+
+Device tokens do not grant provider API access, SSH access, portal cookies,
+WebVNC or code access, lifecycle mutations, admin authority, marketplace or
+payment access, or direct-provider behavior. Expanding the route or scope set
+requires a separate security decision.
+
+See [Coordinator](coordinator.md), [Auth and admin](auth-admin.md), and
+[Operational security](../security.md) for the surrounding trust model.

--- a/docs/security.md
+++ b/docs/security.md
@@ -81,6 +81,13 @@ in `worker/src/auth.ts` in this precedence:
    claim; admin is derived only from an immutable owner allowlist at request
    time. Legacy email-owned sessions are rejected and require a fresh login.
 
+Portal OAuth uses a separate `cbwp_` signed audience in the host-only
+`__Host-crabbox_session` cookie. It carries the same encrypted GitHub
+revalidation material but is accepted only by the portal-cookie path, never as
+a normal API Bearer. Browser-only pairing requires this trusted portal-session
+context, so replaying a `cbxu_` API token in a caller-supplied Cookie header does
+not grant browser authority.
+
 ### GitHub browser login
 
 `crabbox login --url <broker-url>` opens a GitHub OAuth flow and stores the

--- a/worker/src/auth.ts
+++ b/worker/src/auth.ts
@@ -8,7 +8,8 @@ import { bearerToken } from "./http";
 import { timingSafeEqual } from "./timing-safe";
 import type { Env } from "./types";
 
-const tokenPrefix = "cbxu_";
+const userTokenPrefix = "cbxu_";
+const portalTokenPrefix = "cbwp_";
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 const accessJwtHeaderMaxChars = 2048;
@@ -29,6 +30,7 @@ export interface AuthContext {
   owner: string;
   org: string;
   login?: string;
+  portalSession?: boolean;
   tokenExpiresAt?: string;
   githubGrant?: GitHubUserGrant;
 }
@@ -48,7 +50,7 @@ export interface AuthRequestContext {
 }
 
 interface UserTokenPayload {
-  typ: "crabbox-user";
+  typ: "crabbox-user" | "crabbox-portal";
   version: typeof userTokenVersion;
   ownerSource: "github-verified-email";
   jti: string;
@@ -157,6 +159,36 @@ export async function authenticateRequest(
   return trustedIdentity;
 }
 
+export async function authenticatePortalToken(
+  token: string,
+  env: Env,
+  context: AuthRequestContext = {},
+): Promise<AuthContext | undefined> {
+  const payload = await verifyPortalToken(token, env).catch(() => undefined);
+  if (!payload) return undefined;
+  const accessToken = await openGitHubCredential(
+    payload.githubCredential,
+    sessionSecret(env),
+  ).catch(() => undefined);
+  if (!accessToken) return undefined;
+  const membership = context.githubMembership ?? requireCurrentGitHubMembership;
+  try {
+    await membership(
+      {
+        accessToken,
+        tokenID: payload.jti,
+        owner: payload.owner,
+        org: payload.org,
+        login: payload.login,
+      },
+      env,
+    );
+  } catch {
+    return undefined;
+  }
+  return authContextForPayload(payload, env, true);
+}
+
 export function githubUserIsAdmin(
   payload: { owner: string },
   env: Pick<Env, "CRABBOX_GITHUB_ADMIN_OWNERS">,
@@ -165,6 +197,29 @@ export function githubUserIsAdmin(
   return (
     githubAccountID(owner) !== undefined && envList(env.CRABBOX_GITHUB_ADMIN_OWNERS).includes(owner)
   );
+}
+
+function authContextForPayload(
+  payload: UserTokenPayload,
+  env: Pick<Env, "CRABBOX_GITHUB_ADMIN_OWNERS">,
+  portalSession = false,
+): AuthContext {
+  const expiresAt = new Date(payload.exp * 1000).toISOString();
+  return {
+    authorized: true,
+    admin: githubUserIsAdmin(payload, env),
+    auth: "github",
+    owner: payload.owner,
+    org: payload.org,
+    login: payload.login,
+    ...(portalSession ? { portalSession: true } : {}),
+    tokenExpiresAt: expiresAt,
+    githubGrant: {
+      tokenID: payload.jti,
+      sealedCredential: payload.githubCredential,
+      expiresAt,
+    },
+  };
 }
 
 function envList(value: string | undefined): string[] {
@@ -188,6 +243,11 @@ export function requestWithAuthContext(request: Request, auth: AuthContext): Req
     headers.set("x-crabbox-github-login", auth.login);
   } else {
     headers.delete("x-crabbox-github-login");
+  }
+  if (auth.portalSession) {
+    headers.set("x-crabbox-portal-session", "true");
+  } else {
+    headers.delete("x-crabbox-portal-session");
   }
   if (auth.tokenExpiresAt) {
     headers.set("x-crabbox-token-expires-at", auth.tokenExpiresAt);
@@ -219,7 +279,8 @@ export function requestWithoutTrustedHeaders(request: Request): Request {
     !request.headers.has("x-crabbox-proxy-secret") &&
     !request.headers.has("x-crabbox-admin-grant-version") &&
     !request.headers.has("x-crabbox-github-token-id") &&
-    !request.headers.has("x-crabbox-github-sealed-credential")
+    !request.headers.has("x-crabbox-github-sealed-credential") &&
+    !request.headers.has("x-crabbox-portal-session")
   ) {
     return request;
   }
@@ -229,6 +290,7 @@ export function requestWithoutTrustedHeaders(request: Request): Request {
   headers.delete("x-crabbox-admin-grant-version");
   headers.delete("x-crabbox-github-token-id");
   headers.delete("x-crabbox-github-sealed-credential");
+  headers.delete("x-crabbox-portal-session");
   return new Request(request, { headers });
 }
 
@@ -236,24 +298,42 @@ export function isAdminRequest(request: Request): boolean {
   return request.headers.get("x-crabbox-admin") === "true";
 }
 
+interface SignedUserTokenInput {
+  owner: string;
+  ownerSource: "github-verified-email";
+  org: string;
+  login: string;
+  githubAccessToken: string;
+  name?: string;
+  ttlSeconds?: number;
+}
+
 export async function issueUserToken(
   env: Pick<Env, "CRABBOX_SHARED_TOKEN" | "CRABBOX_SESSION_SECRET">,
-  input: {
-    owner: string;
-    ownerSource: "github-verified-email";
-    org: string;
-    login: string;
-    githubAccessToken: string;
-    name?: string;
-    ttlSeconds?: number;
-  },
+  input: SignedUserTokenInput,
+): Promise<string> {
+  return issueSignedUserToken(env, input, "crabbox-user", userTokenPrefix);
+}
+
+export async function issuePortalToken(
+  env: Pick<Env, "CRABBOX_SHARED_TOKEN" | "CRABBOX_SESSION_SECRET">,
+  input: SignedUserTokenInput,
+): Promise<string> {
+  return issueSignedUserToken(env, input, "crabbox-portal", portalTokenPrefix);
+}
+
+async function issueSignedUserToken(
+  env: Pick<Env, "CRABBOX_SHARED_TOKEN" | "CRABBOX_SESSION_SECRET">,
+  input: SignedUserTokenInput,
+  typ: UserTokenPayload["typ"],
+  prefix: string,
 ): Promise<string> {
   const now = Math.floor(Date.now() / 1000);
   if (!input.githubAccessToken || input.githubAccessToken.length > githubAccessTokenMaxChars) {
     throw new Error("GitHub access token is required for signed user tokens");
   }
   const payload: UserTokenPayload = {
-    typ: "crabbox-user",
+    typ,
     version: userTokenVersion,
     ownerSource: input.ownerSource,
     jti: crypto.randomUUID(),
@@ -269,11 +349,19 @@ export async function issueUserToken(
   }
   const encodedPayload = base64URL(encoder.encode(JSON.stringify(payload)));
   const sig = await sign(encodedPayload, sessionSecret(env));
-  return `${tokenPrefix}${encodedPayload}.${sig}`;
+  return `${prefix}${encodedPayload}.${sig}`;
 }
 
 export function userTokenExpiresAt(token: string): string | undefined {
-  const payload = decodeUserTokenPayload(token);
+  const payload = decodeSignedUserTokenPayload(token, userTokenPrefix);
+  if (typeof payload?.exp !== "number") {
+    return undefined;
+  }
+  return new Date(payload.exp * 1000).toISOString();
+}
+
+export function portalTokenExpiresAt(token: string): string | undefined {
+  const payload = decodeSignedUserTokenPayload(token, portalTokenPrefix);
   if (typeof payload?.exp !== "number") {
     return undefined;
   }
@@ -286,6 +374,14 @@ export async function verifiedUserTokenExpiresAtForRevocation(
   env: Pick<Env, "CRABBOX_SHARED_TOKEN" | "CRABBOX_SESSION_SECRET">,
 ): Promise<string | undefined> {
   const payload = await verifyUserToken(token, env).catch(() => undefined);
+  return payload ? new Date(payload.exp * 1000).toISOString() : undefined;
+}
+
+export async function verifiedPortalTokenExpiresAtForRevocation(
+  token: string,
+  env: Pick<Env, "CRABBOX_SHARED_TOKEN" | "CRABBOX_SESSION_SECRET">,
+): Promise<string | undefined> {
+  const payload = await verifyPortalToken(token, env).catch(() => undefined);
   return payload ? new Date(payload.exp * 1000).toISOString() : undefined;
 }
 
@@ -310,6 +406,15 @@ export async function authenticateUserTokenForRevocation(
       expiresAt: new Date(payload.exp * 1000).toISOString(),
     },
   };
+}
+
+export async function authenticatePortalTokenForRevocation(
+  token: string,
+  env: Pick<Env, "CRABBOX_SHARED_TOKEN" | "CRABBOX_SESSION_SECRET" | "CRABBOX_GITHUB_ADMIN_OWNERS">,
+): Promise<AuthContext | undefined> {
+  const payload = await verifyPortalToken(token, env).catch(() => undefined);
+  if (!payload) return undefined;
+  return authContextForPayload(payload, env, true);
 }
 
 export async function githubUserGrantIsCurrent(
@@ -347,7 +452,23 @@ async function verifyUserToken(
   token: string,
   env: Pick<Env, "CRABBOX_SHARED_TOKEN" | "CRABBOX_SESSION_SECRET">,
 ): Promise<UserTokenPayload | undefined> {
-  const parts = userTokenParts(token);
+  return verifySignedUserToken(token, env, userTokenPrefix, "crabbox-user");
+}
+
+async function verifyPortalToken(
+  token: string,
+  env: Pick<Env, "CRABBOX_SHARED_TOKEN" | "CRABBOX_SESSION_SECRET">,
+): Promise<UserTokenPayload | undefined> {
+  return verifySignedUserToken(token, env, portalTokenPrefix, "crabbox-portal");
+}
+
+async function verifySignedUserToken(
+  token: string,
+  env: Pick<Env, "CRABBOX_SHARED_TOKEN" | "CRABBOX_SESSION_SECRET">,
+  prefix: string,
+  typ: UserTokenPayload["typ"],
+): Promise<UserTokenPayload | undefined> {
+  const parts = signedUserTokenParts(token, prefix);
   if (!parts) {
     return undefined;
   }
@@ -356,9 +477,9 @@ async function verifyUserToken(
   if (!timingSafeEqual(signature, expected)) {
     return undefined;
   }
-  const payload = decodeUserTokenPayload(token);
+  const payload = decodeSignedUserTokenPayload(token, prefix);
   if (
-    payload.typ !== "crabbox-user" ||
+    payload.typ !== typ ||
     payload.version !== userTokenVersion ||
     payload.ownerSource !== "github-verified-email" ||
     typeof payload.owner !== "string" ||
@@ -380,8 +501,8 @@ async function verifyUserToken(
   return payload as UserTokenPayload;
 }
 
-function decodeUserTokenPayload(token: string): Partial<UserTokenPayload> {
-  const parts = userTokenParts(token);
+function decodeSignedUserTokenPayload(token: string, prefix: string): Partial<UserTokenPayload> {
+  const parts = signedUserTokenParts(token, prefix);
   if (!parts) {
     return {};
   }
@@ -394,11 +515,14 @@ function decodeUserTokenPayload(token: string): Partial<UserTokenPayload> {
   }
 }
 
-function userTokenParts(token: string): { encodedPayload: string; signature: string } | undefined {
-  if (!token.startsWith(tokenPrefix)) {
+function signedUserTokenParts(
+  token: string,
+  prefix: string,
+): { encodedPayload: string; signature: string } | undefined {
+  if (!token.startsWith(prefix)) {
     return undefined;
   }
-  const parts = token.slice(tokenPrefix.length).split(".");
+  const parts = token.slice(prefix.length).split(".");
   if (parts.length !== 2 || !parts[0] || !parts[1]) {
     return undefined;
   }

--- a/worker/src/auth.ts
+++ b/worker/src/auth.ts
@@ -25,7 +25,7 @@ const accessKeySetLoads = new Map<string, Promise<AccessKeySetCacheEntry>>();
 export interface AuthContext {
   authorized: boolean;
   admin: boolean;
-  auth: "bearer" | "github" | "proxy";
+  auth: "bearer" | "device" | "github" | "proxy";
   owner: string;
   org: string;
   login?: string;

--- a/worker/src/coordinator-entry.ts
+++ b/worker/src/coordinator-entry.ts
@@ -1,4 +1,6 @@
 import {
+  authenticatePortalToken,
+  authenticatePortalTokenForRevocation,
   authenticateUserTokenForRevocation,
   authenticateRequest,
   requestWithAdminGrantVersion,
@@ -14,8 +16,10 @@ import { InvalidOrgLabelError, orgKeyForLabel } from "./org-identity";
 import {
   coordinatorOriginStatus,
   deviceTokenRouteAllowed,
+  isDeviceManagementRequest,
   isDeviceTokenRequest,
   isPairingExchangeRequest,
+  isPairingGrantRequest,
   pairingRequestBodyBytes,
 } from "./pairing";
 import { runtimeAdapterProxyPath, runtimeAdapterRelayMethodAllowed } from "./runtime-adapter-relay";
@@ -141,7 +145,9 @@ export async function prepareCoordinatorRequest(
     };
   }
   const portal = url.pathname.startsWith("/portal");
-  if (portal && !portalCookieRequestIntentAllowed(request, env, url)) {
+  const browserSessionRequest =
+    isPairingGrantRequest(request) || isDeviceManagementRequest(request);
+  if ((portal || browserSessionRequest) && !portalCookieRequestIntentAllowed(request, env, url)) {
     return {
       response: json({ error: "portal_request_origin_forbidden" }, { status: 403 }),
       authenticated: false,
@@ -156,17 +162,30 @@ export async function prepareCoordinatorRequest(
       authenticated: false,
     };
   }
-  const authRequest = portal ? requestWithPortalCookie(request) : request;
+  const authRequest = portal || browserSessionRequest ? requestWithPortalCookie(request) : request;
+  const portalCookieToken =
+    (portal || browserSessionRequest) && !request.headers.has("authorization")
+      ? cookieValue(request.headers.get("cookie") ?? "", portalSessionCookieName)
+      : undefined;
   const portalLogoutToken =
     portal &&
     request.method === "POST" &&
     url.pathname === "/portal/logout" &&
     !request.headers.has("authorization")
-      ? cookieValue(request.headers.get("cookie") ?? "", portalSessionCookieName)
+      ? portalCookieToken
       : undefined;
-  const auth = portalLogoutToken
-    ? await authenticateUserTokenForRevocation(portalLogoutToken, env)
-    : await authenticateRequest(authRequest, env, authContext);
+  let auth: AuthContext | undefined;
+  if (portalLogoutToken) {
+    auth =
+      (await authenticatePortalTokenForRevocation(portalLogoutToken, env)) ??
+      (await authenticateUserTokenForRevocation(portalLogoutToken, env));
+  } else if (portalCookieToken) {
+    auth =
+      (await authenticatePortalToken(portalCookieToken, env, authContext)) ??
+      (await authenticateRequest(authRequest, env, authContext));
+  } else {
+    auth = await authenticateRequest(authRequest, env, authContext);
+  }
   if (!auth?.authorized) {
     if (portal && request.method === "GET" && request.headers.get("upgrade") !== "websocket") {
       const login = new URL("/portal/login", url.origin);

--- a/worker/src/coordinator-entry.ts
+++ b/worker/src/coordinator-entry.ts
@@ -84,7 +84,9 @@ export async function prepareCoordinatorRequest(
       authenticated: false,
     };
   }
-  if (isPairingExchangeRequest(request) || isDeviceTokenRequest(request)) {
+  const deviceTokenRequest =
+    isDeviceTokenRequest(request) && !configuredCoordinatorBearer(request, env);
+  if (isPairingExchangeRequest(request) || deviceTokenRequest) {
     const origin = coordinatorOriginStatus(request, env, true);
     if (origin === "unavailable") {
       return {
@@ -98,7 +100,7 @@ export async function prepareCoordinatorRequest(
         authenticated: false,
       };
     }
-    if (isDeviceTokenRequest(request) && !deviceTokenRouteAllowed(request)) {
+    if (deviceTokenRequest && !deviceTokenRouteAllowed(request)) {
       return {
         response: json({ error: "device_scope_forbidden" }, { status: 403 }),
         authenticated: false,
@@ -349,6 +351,19 @@ function runtimeAdapterServiceAuth(
     owner: env.CRABBOX_RUNTIME_ADAPTER_OWNER || "service@openclaw.org",
     org: env.CRABBOX_RUNTIME_ADAPTER_ORG || env.CRABBOX_DEFAULT_ORG || "openclaw",
   };
+}
+
+function configuredCoordinatorBearer(
+  request: Request,
+  env: Pick<Env, "CRABBOX_ADMIN_TOKEN" | "CRABBOX_SHARED_TOKEN" | "CRABBOX_RUNTIME_ADAPTER_TOKEN">,
+): boolean {
+  const token = bearerToken(request);
+  return Boolean(
+    token &&
+    [env.CRABBOX_ADMIN_TOKEN, env.CRABBOX_SHARED_TOKEN, env.CRABBOX_RUNTIME_ADAPTER_TOKEN].some(
+      (configured) => configured && timingSafeEqual(token, configured),
+    ),
+  );
 }
 
 async function canonicalPortalRedirect(

--- a/worker/src/coordinator-entry.ts
+++ b/worker/src/coordinator-entry.ts
@@ -11,6 +11,13 @@ import { codeProxyRequestBodyBytes, isIsolatedCodeRequest } from "./code-origin"
 import { cookieValue, portalSessionCookieName } from "./cookies";
 import { bearerToken, json, pathParts } from "./http";
 import { InvalidOrgLabelError, orgKeyForLabel } from "./org-identity";
+import {
+  coordinatorOriginStatus,
+  deviceTokenRouteAllowed,
+  isDeviceTokenRequest,
+  isPairingExchangeRequest,
+  pairingRequestBodyBytes,
+} from "./pairing";
 import { runtimeAdapterProxyPath, runtimeAdapterRelayMethodAllowed } from "./runtime-adapter-relay";
 import { timingSafeEqual } from "./timing-safe";
 import type { Env } from "./types";
@@ -71,6 +78,32 @@ export async function prepareCoordinatorRequest(
     return {
       response: json({ error: "not_found" }, { status: 404 }),
       authenticated: false,
+    };
+  }
+  if (isPairingExchangeRequest(request) || isDeviceTokenRequest(request)) {
+    const origin = coordinatorOriginStatus(request, env, true);
+    if (origin === "unavailable") {
+      return {
+        response: json({ error: "pairing_unavailable" }, { status: 503 }),
+        authenticated: false,
+      };
+    }
+    if (origin === "forbidden") {
+      return {
+        response: json({ error: "coordinator_origin_forbidden" }, { status: 403 }),
+        authenticated: false,
+      };
+    }
+    if (isDeviceTokenRequest(request) && !deviceTokenRouteAllowed(request)) {
+      return {
+        response: json({ error: "device_scope_forbidden" }, { status: 403 }),
+        authenticated: false,
+      };
+    }
+    return {
+      request: requestWithoutCoordinatorAuthContext(request),
+      authenticated: false,
+      ...(isPairingExchangeRequest(request) ? { bodyLimit: pairingRequestBodyBytes } : {}),
     };
   }
   if (isolatedCode) {

--- a/worker/src/coordinator-runtime.ts
+++ b/worker/src/coordinator-runtime.ts
@@ -25,6 +25,13 @@ export function coordinatorRequestQueue(request: Request): CoordinatorRequestQue
   if (method === "GET" && path.join("/") === "v1/auth/github/callback") {
     return "direct";
   }
+  if (
+    path[0] === "v1" &&
+    ((path[1] === "pairing" && (path[2] === "grants" || path[2] === "exchange")) ||
+      path[1] === "devices")
+  ) {
+    return "direct";
+  }
   if (method === "POST" && path.join("/") === "v1/leases") {
     return "direct";
   }

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -1019,7 +1019,7 @@ export class FleetCoordinator {
 
   async fetch(request: Request): Promise<Response> {
     try {
-      if (isDeviceTokenRequest(request)) {
+      if (isDeviceTokenRequest(request) && !configuredFleetBearer(request, this.env)) {
         const authenticated = await this.authenticatedDeviceRequest(request);
         if (authenticated instanceof Response) return authenticated;
         request = authenticated;
@@ -1459,12 +1459,7 @@ export class FleetCoordinator {
     if (method === "DELETE" && !deviceID) {
       const devices = await this.state.runExclusive(async () => {
         const active = await this.activeOwnerDevices(owner, org);
-        await Promise.all(
-          active.flatMap((record) => [
-            this.state.storage.delete(deviceTokenKey(record.id)),
-            this.state.storage.delete(deviceOwnerIndexKey(owner, org, record.id)),
-          ]),
-        );
+        await Promise.all(active.map((record) => this.revokeDeviceRecord(record)));
         return active;
       });
       return pairingJSON({ revoked: devices.length });
@@ -1481,10 +1476,7 @@ export class FleetCoordinator {
         ) {
           return notFound();
         }
-        await Promise.all([
-          this.state.storage.delete(key),
-          this.state.storage.delete(deviceOwnerIndexKey(owner, org, deviceID)),
-        ]);
+        await this.revokeDeviceRecord(record);
         return new Response(null, { status: 204, headers: pairingResponseHeaders() });
       });
     }
@@ -1570,6 +1562,11 @@ export class FleetCoordinator {
       }),
     );
     return records.filter((record): record is DeviceTokenRecord => record !== undefined);
+  }
+
+  private async revokeDeviceRecord(record: DeviceTokenRecord): Promise<void> {
+    await this.state.storage.delete(deviceTokenKey(record.id));
+    await this.state.storage.delete(deviceOwnerIndexKey(record.owner, record.org, record.id));
   }
 
   private async activeOwnerPairingGrants(
@@ -17291,6 +17288,19 @@ function pairingOriginError(
   return status === "forbidden"
     ? json({ error: "coordinator_origin_forbidden" }, { status: 403 })
     : undefined;
+}
+
+function configuredFleetBearer(
+  request: Request,
+  env: Pick<Env, "CRABBOX_ADMIN_TOKEN" | "CRABBOX_SHARED_TOKEN" | "CRABBOX_RUNTIME_ADAPTER_TOKEN">,
+): boolean {
+  const token = bearerToken(request);
+  return Boolean(
+    token &&
+    [env.CRABBOX_ADMIN_TOKEN, env.CRABBOX_SHARED_TOKEN, env.CRABBOX_RUNTIME_ADAPTER_TOKEN].some(
+      (configured) => configured && timingSafeEqual(token, configured),
+    ),
+  );
 }
 
 async function pairingInput(

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -10,8 +10,10 @@ import {
   isAdminRequest,
   requestWithAuthContext,
   sha256Hex,
+  verifiedPortalTokenExpiresAtForRevocation,
   verifiedUserTokenExpiresAtForRevocation,
   type AuthContext,
+  type AuthRequestContext,
   type GitHubUserGrant,
 } from "./auth";
 import {
@@ -69,6 +71,7 @@ import {
   type DaytonaSSHEndpoint,
 } from "./daytona";
 import { GCPClient, gcpProviderLabelValue } from "./gcp";
+import { requireFreshGitHubMembership } from "./github-membership";
 import {
   HetznerClient,
   HetznerProvisioningError,
@@ -127,24 +130,33 @@ import {
 import { defaultOSImage, normalizeOSImage } from "./os-image";
 import {
   coordinatorOriginStatus,
+  deviceOwnerIndexKey,
+  deviceOwnerIndexPrefix,
   deviceTokenKey,
-  deviceTokenPrefixKey,
   deviceTokenRouteAllowed,
   deviceTokenTTLSeconds,
   isDeviceTokenRequest,
+  maxDeviceTokensPerOwner,
+  maxPairingGrantsPerOwner,
   newDeviceToken,
   newPairingGrant,
   pairingDeviceName,
   pairingGrantHash,
   pairingGrantKey,
-  pairingGrantPrefixKey,
+  pairingGrantOwnerIndexKey,
+  pairingGrantOwnerIndexPrefix,
   pairingGrantTTLSeconds,
   parsedDeviceToken,
   publicDeviceRecord,
   validDeviceID,
+  validDeviceOwnerIndexRecord,
+  validPairingGrantOwnerIndexRecord,
+  validStoredDeviceTokenRecord,
   validDeviceTokenRecord,
   validPairingGrantRecord,
+  type DeviceOwnerIndexRecord,
   type DeviceTokenRecord,
+  type PairingGrantOwnerIndexRecord,
   type PairingGrantRecord,
 } from "./pairing";
 import {
@@ -206,6 +218,7 @@ import {
   tailscaleTagOwnershipErrorMessage,
   validateTailscaleTags,
 } from "./tailscale";
+import { timingSafeEqual } from "./timing-safe";
 import type {
   CapacityHint,
   Env,
@@ -998,6 +1011,7 @@ export class FleetCoordinator {
     private readonly state: CoordinatorRuntime,
     private readonly env: Env,
     private readonly testProviders: Partial<Record<Provider, CloudProvider>> = {},
+    private readonly authContext: AuthRequestContext = {},
   ) {
     this.webVNCCredentialHandoffs = new WebVNCCredentialHandoffs(state);
     this.restoreBridgeWebSockets();
@@ -1311,7 +1325,9 @@ export class FleetCoordinator {
   private async createPairingGrant(request: Request): Promise<Response> {
     const originError = pairingOriginError(request, this.env);
     if (originError) return originError;
-    if (!pairingOwnerSession(request)) {
+    const ownerSession = pairingBrowserSession(request);
+    if (!ownerSession) {
+      await request.arrayBuffer().catch(() => undefined);
       return json({ error: "owner_session_required" }, { status: 403 });
     }
     const input = await pairingInput(request);
@@ -1319,27 +1335,40 @@ export class FleetCoordinator {
     const name = pairingDeviceName(input.name);
     if (!name) return json({ error: "invalid_device_name" }, { status: 400 });
     const now = new Date();
+    const owner = requestOwner(request);
+    const org = requestOrg(request, this.env);
     const credentials = await newPairingGrant();
     const record: PairingGrantRecord = {
       version: 1,
       audience: "crabbox-device-pairing",
       scope: "leases:read",
       grantHash: credentials.grantHash,
-      owner: requestOwner(request),
-      org: requestOrg(request, this.env),
+      owner,
+      org,
+      ownerLogin: ownerSession.login,
+      ownerGrant: ownerSession.grant,
       name,
       createdAt: now.toISOString(),
       expiresAt: new Date(now.getTime() + pairingGrantTTLSeconds * 1000).toISOString(),
     };
-    const grants = await this.state.storage.list<PairingGrantRecord>({
-      prefix: pairingGrantPrefixKey(),
+    const ownerIndex: PairingGrantOwnerIndexRecord = {
+      version: 1,
+      grantHash: record.grantHash,
+      expiresAt: record.expiresAt,
+    };
+    const stored = await this.state.runExclusive(async () => {
+      const activeGrants = await this.activeOwnerPairingGrants(owner, org, now.getTime());
+      if (activeGrants.length >= maxPairingGrantsPerOwner) return false;
+      await this.state.storage.put(
+        pairingGrantOwnerIndexKey(owner, org, record.grantHash),
+        ownerIndex,
+      );
+      await this.state.storage.put(pairingGrantKey(record.grantHash), record);
+      return true;
     });
-    await Promise.all(
-      [...grants.entries()]
-        .filter(([, grant]) => Date.parse(grant.expiresAt) <= now.getTime())
-        .map(([key]) => this.state.storage.delete(key)),
-    );
-    await this.state.storage.put(pairingGrantKey(record.grantHash), record);
+    if (!stored) {
+      return pairingJSON({ error: "pairing_grant_limit_reached" }, { status: 429 });
+    }
     return pairingJSON({
       grant: credentials.grant,
       audience: record.audience,
@@ -1361,8 +1390,14 @@ export class FleetCoordinator {
     if (!record || !validPairingGrantRecord(record, grantHash)) {
       return pairingUnauthorized("pairing_grant_invalid");
     }
+    await this.state.storage.delete(
+      pairingGrantOwnerIndexKey(record.owner, record.org, record.grantHash),
+    );
     if (Date.parse(record.expiresAt) <= Date.now()) {
       return pairingUnauthorized("pairing_grant_expired");
+    }
+    if (!(await this.pairingOwnerIsCurrent(record))) {
+      return pairingUnauthorized("pairing_owner_unauthorized");
     }
     const now = new Date();
     const credentials = await newDeviceToken();
@@ -1374,57 +1409,84 @@ export class FleetCoordinator {
       tokenHash: credentials.tokenHash,
       owner: record.owner,
       org: record.org,
+      ownerLogin: record.ownerLogin,
+      ownerGrant: record.ownerGrant,
       name: record.name,
       createdAt: now.toISOString(),
       expiresAt: new Date(now.getTime() + deviceTokenTTLSeconds * 1000).toISOString(),
     };
-    await this.state.storage.put(deviceTokenKey(device.id), device);
+    const ownerIndex: DeviceOwnerIndexRecord = {
+      version: 1,
+      deviceID: device.id,
+      expiresAt: device.expiresAt,
+    };
+    const stored = await this.state.runExclusive(async () => {
+      const activeDevices = await this.activeOwnerDevices(record.owner, record.org);
+      if (activeDevices.length >= maxDeviceTokensPerOwner) return false;
+      await this.state.storage.put(
+        deviceOwnerIndexKey(device.owner, device.org, device.id),
+        ownerIndex,
+      );
+      await this.state.storage.put(deviceTokenKey(device.id), device);
+      return true;
+    });
+    if (!stored) {
+      return pairingJSON(
+        { error: "device_limit_reached", limit: maxDeviceTokensPerOwner },
+        { status: 409 },
+      );
+    }
     return pairingJSON({ device: publicDeviceRecord(device), token: credentials.token });
   }
 
   private async deviceRoute(request: Request, deviceID?: string): Promise<Response> {
-    const originError = pairingOriginError(request, this.env);
+    const method = request.method.toUpperCase();
+    const originError = pairingOriginError(request, this.env, method !== "GET");
     if (originError) return originError;
-    if (!pairingOwnerSession(request)) {
+    if (!pairingBrowserSession(request)) {
       return json({ error: "owner_session_required" }, { status: 403 });
     }
-    const method = request.method.toUpperCase();
     const owner = requestOwner(request);
     const org = requestOrg(request, this.env);
     if (method === "GET" && !deviceID) {
-      const records = await this.state.storage.list<DeviceTokenRecord>({
-        prefix: deviceTokenPrefixKey(),
-      });
-      const expiredKeys: string[] = [];
-      const devices = [...records.entries()]
-        .filter(([key, record]) => {
-          if (Date.parse(record.expiresAt) <= Date.now()) {
-            expiredKeys.push(key);
-            return false;
-          }
-          return record.owner === owner && record.org === org;
-        })
-        .map(([, record]) => publicDeviceRecord(record))
-        .toSorted((left, right) => right.createdAt.localeCompare(left.createdAt));
-      await Promise.all(expiredKeys.map((key) => this.state.storage.delete(key)));
+      const devices = await this.state.runExclusive(async () =>
+        (await this.activeOwnerDevices(owner, org))
+          .map((record) => publicDeviceRecord(record))
+          .toSorted((left, right) => right.createdAt.localeCompare(left.createdAt)),
+      );
       return pairingJSON({ devices });
     }
     if (method === "DELETE" && !deviceID) {
-      const records = await this.state.storage.list<DeviceTokenRecord>({
-        prefix: deviceTokenPrefixKey(),
+      const devices = await this.state.runExclusive(async () => {
+        const active = await this.activeOwnerDevices(owner, org);
+        await Promise.all(
+          active.flatMap((record) => [
+            this.state.storage.delete(deviceTokenKey(record.id)),
+            this.state.storage.delete(deviceOwnerIndexKey(owner, org, record.id)),
+          ]),
+        );
+        return active;
       });
-      const keys = [...records.entries()]
-        .filter(([, record]) => record.owner === owner && record.org === org)
-        .map(([key]) => key);
-      await Promise.all(keys.map((key) => this.state.storage.delete(key)));
-      return pairingJSON({ revoked: keys.length });
+      return pairingJSON({ revoked: devices.length });
     }
     if (method === "DELETE" && deviceID && validDeviceID(deviceID)) {
-      const key = deviceTokenKey(deviceID);
-      const record = await this.state.storage.get<DeviceTokenRecord>(key, { noCache: true });
-      if (!record || record.owner !== owner || record.org !== org) return notFound();
-      await this.state.storage.delete(key);
-      return new Response(null, { status: 204, headers: pairingResponseHeaders() });
+      return await this.state.runExclusive(async () => {
+        const key = deviceTokenKey(deviceID);
+        const record = await this.state.storage.get<DeviceTokenRecord>(key, { noCache: true });
+        if (
+          !record ||
+          !validStoredDeviceTokenRecord(record, deviceID) ||
+          record.owner !== owner ||
+          record.org !== org
+        ) {
+          return notFound();
+        }
+        await Promise.all([
+          this.state.storage.delete(key),
+          this.state.storage.delete(deviceOwnerIndexKey(owner, org, deviceID)),
+        ]);
+        return new Response(null, { status: 204, headers: pairingResponseHeaders() });
+      });
     }
     return json({ error: "not_found" }, { status: 404 });
   }
@@ -1443,13 +1505,14 @@ export class FleetCoordinator {
       return pairingUnauthorized("device_token_invalid");
     }
     if (Date.parse(record.expiresAt) <= Date.now()) {
-      await this.state.storage.delete(key);
       return pairingUnauthorized("device_token_expired");
     }
     const org = orgAuthLabelFromKey(record.org);
     if (org === undefined) {
-      await this.state.storage.delete(key);
       return pairingUnauthorized("device_token_invalid");
+    }
+    if (!(await this.pairingOwnerIsCurrent(record))) {
+      return pairingUnauthorized("device_owner_unauthorized");
     }
     return requestWithAuthContext(request, {
       authorized: true,
@@ -1459,6 +1522,91 @@ export class FleetCoordinator {
       org,
       tokenExpiresAt: record.expiresAt,
     });
+  }
+
+  private async pairingOwnerIsCurrent(
+    record: Pick<DeviceTokenRecord, "owner" | "org" | "ownerLogin" | "ownerGrant">,
+  ): Promise<boolean> {
+    const org = orgAuthLabelFromKey(record.org);
+    if (org === undefined) return false;
+    return await githubUserGrantIsCurrent(
+      record.ownerGrant,
+      { owner: record.owner, org, login: record.ownerLogin },
+      this.env,
+      {
+        githubMembership: this.authContext.githubMembership ?? requireFreshGitHubMembership,
+      },
+    );
+  }
+
+  private async activeOwnerDevices(owner: string, org: string): Promise<DeviceTokenRecord[]> {
+    const indexes = await this.state.storage.list<DeviceOwnerIndexRecord>({
+      prefix: deviceOwnerIndexPrefix(owner, org),
+      limit: maxDeviceTokensPerOwner + 1,
+      noCache: true,
+    });
+    const records = await Promise.all(
+      [...indexes.entries()].map(async ([indexKey, index]) => {
+        if (!validDeviceOwnerIndexRecord(index, index.deviceID)) {
+          await this.state.storage.delete(indexKey);
+          return undefined;
+        }
+        const key = deviceTokenKey(index.deviceID);
+        const record = await this.state.storage.get<DeviceTokenRecord>(key, { noCache: true });
+        if (
+          !record ||
+          !validStoredDeviceTokenRecord(record, index.deviceID) ||
+          record.owner !== owner ||
+          record.org !== org
+        ) {
+          await this.state.storage.delete(indexKey);
+          return undefined;
+        }
+        if (Date.parse(record.expiresAt) <= Date.now()) {
+          await Promise.all([this.state.storage.delete(indexKey), this.state.storage.delete(key)]);
+          return undefined;
+        }
+        return record;
+      }),
+    );
+    return records.filter((record): record is DeviceTokenRecord => record !== undefined);
+  }
+
+  private async activeOwnerPairingGrants(
+    owner: string,
+    org: string,
+    now: number,
+  ): Promise<PairingGrantRecord[]> {
+    const indexes = await this.state.storage.list<PairingGrantOwnerIndexRecord>({
+      prefix: pairingGrantOwnerIndexPrefix(owner, org),
+      limit: maxPairingGrantsPerOwner + 1,
+      noCache: true,
+    });
+    const records = await Promise.all(
+      [...indexes.entries()].map(async ([indexKey, index]) => {
+        if (!validPairingGrantOwnerIndexRecord(index, index.grantHash)) {
+          await this.state.storage.delete(indexKey);
+          return undefined;
+        }
+        const key = pairingGrantKey(index.grantHash);
+        const record = await this.state.storage.get<PairingGrantRecord>(key, { noCache: true });
+        if (
+          !record ||
+          !validPairingGrantRecord(record, index.grantHash) ||
+          record.owner !== owner ||
+          record.org !== org
+        ) {
+          await this.state.storage.delete(indexKey);
+          return undefined;
+        }
+        if (Date.parse(record.expiresAt) <= now) {
+          await Promise.all([this.state.storage.delete(indexKey), this.state.storage.delete(key)]);
+          return undefined;
+        }
+        return record;
+      }),
+    );
+    return records.filter((record): record is PairingGrantRecord => record !== undefined);
   }
 
   async webSocketMessage(socket: WebSocket, message: string | ArrayBuffer): Promise<void> {
@@ -5548,6 +5696,9 @@ export class FleetCoordinator {
     if (method === "GET" && action === undefined) {
       const admin = isAdminRequest(request);
       const lease = await this.resolveLease(leaseID, request, false);
+      if (lease && requestAuthType(request) === "device") {
+        return json({ lease: this.deviceLeaseRecord(lease) });
+      }
       const refreshed =
         lease && this.leaseProviderAccessVisibleToRequest(lease, request, admin)
           ? await this.refreshLeaseAccessForResolution(lease)
@@ -9790,7 +9941,9 @@ export class FleetCoordinator {
     await this.cleanupExpiredCodeViewerAuth();
     const token = cookieValue(request.headers.get("cookie") ?? "", portalSessionCookieName);
     if (token) {
-      const verifiedTokenExpiresAt = await verifiedUserTokenExpiresAtForRevocation(token, this.env);
+      const verifiedTokenExpiresAt =
+        (await verifiedPortalTokenExpiresAtForRevocation(token, this.env)) ??
+        (await verifiedUserTokenExpiresAtForRevocation(token, this.env));
       if (verifiedTokenExpiresAt) {
         const portalSessionHash = await sha256Hex(token);
         const now = new Date();
@@ -11585,6 +11738,9 @@ export class FleetCoordinator {
     const leases = admin
       ? this.filterLeases(await this.leaseRecords(), request)
       : this.filterLeasesForRequest(await this.leaseRecords(), request);
+    if (requestAuthType(request) === "device") {
+      return json({ leases: leases.map((lease) => this.deviceLeaseRecord(lease)) });
+    }
     return json({ leases: leases.map((lease) => this.leaseForListRequest(lease, request, admin)) });
   }
 
@@ -14103,13 +14259,14 @@ export class FleetCoordinator {
 
   private leaseForRequest(lease: LeaseRecord, request: Request, admin: boolean): LeaseRecord {
     const visible = publicLeaseRecord(lease);
+    const role = this.leaseAccessRole(lease, request, admin);
     if (visible.cleanupError) {
       visible.cleanupError = coordinatorDiagnosticText(this.env, visible.cleanupError);
     }
     if (visible.failureError) {
       visible.failureError = coordinatorDiagnosticText(this.env, visible.failureError);
     }
-    if (visible.share && !this.leaseManageableByRequest(lease, request, admin)) {
+    if (visible.share && role !== "owner" && role !== "manage") {
       delete visible.share;
     }
     if (
@@ -14120,6 +14277,60 @@ export class FleetCoordinator {
       visible.sshUser = "<token>";
     }
     return visible;
+  }
+
+  private deviceLeaseRecord(lease: LeaseRecord): Record<string, unknown> {
+    return {
+      id: lease.id,
+      slug: lease.slug,
+      workspaceID: lease.workspaceID,
+      provider: lease.provider,
+      lifecycle: lease.lifecycle,
+      target: lease.target,
+      os: lease.os,
+      windowsMode: lease.windowsMode,
+      desktop: lease.desktop,
+      desktopEnv: lease.desktopEnv,
+      browser: lease.browser,
+      code: lease.code,
+      owner: lease.owner,
+      org: orgLabelForDisplay(lease.org),
+      profile: lease.profile,
+      class: lease.class,
+      serverType: lease.serverType,
+      requestedServerType: lease.requestedServerType,
+      pond: lease.pond,
+      exposedPorts: lease.exposedPorts,
+      market: lease.market,
+      keep: lease.keep,
+      ttlSeconds: lease.ttlSeconds,
+      idleTimeoutSeconds: lease.idleTimeoutSeconds,
+      estimatedHourlyUSD: lease.estimatedHourlyUSD,
+      maxEstimatedUSD: lease.maxEstimatedUSD,
+      state: lease.state,
+      createdAt: lease.createdAt,
+      updatedAt: lease.updatedAt,
+      lastTouchedAt: lease.lastTouchedAt,
+      expiresAt: lease.expiresAt,
+      releasedAt: lease.releasedAt,
+      endedAt: lease.endedAt,
+      registeredAt: lease.registeredAt,
+      telemetry: lease.telemetry,
+      telemetryHistory: lease.telemetryHistory,
+      cleanupAttempts: lease.cleanupAttempts,
+      cleanupFailedAt: lease.cleanupFailedAt,
+      cleanupRetryAt: lease.cleanupRetryAt,
+      cleanupError: lease.cleanupError
+        ? coordinatorDiagnosticText(this.env, lease.cleanupError)
+        : undefined,
+      failureError: lease.failureError
+        ? coordinatorDiagnosticText(this.env, lease.failureError)
+        : undefined,
+      host: "<redacted>",
+      sshUser: "<redacted>",
+      sshPort: "<redacted>",
+      workRoot: "<redacted>",
+    };
   }
 
   private async authoritativeLeaseProviderMetadata(
@@ -14169,12 +14380,13 @@ export class FleetCoordinator {
     lease: LeaseRecord,
     request: Request,
     admin: boolean,
-  ): "owner" | LeaseShareRole | undefined {
-    return this.leaseAccessRoleForPrincipal(lease, {
+  ): "owner" | LeaseShareRole | "device" | undefined {
+    const role = this.leaseAccessRoleForPrincipal(lease, {
       owner: requestOwner(request),
       org: requestOrg(request, this.env),
       admin,
     });
+    return role && requestAuthType(request) === "device" ? "device" : role;
   }
 
   private leaseAccessRoleForPrincipal(
@@ -17045,21 +17257,34 @@ function requestAuthType(request: Request): AuthContext["auth"] {
     : "github";
 }
 
-function pairingOwnerSession(request: Request): boolean {
-  if (!request.headers.has("x-crabbox-auth")) return false;
-  const auth = requestAuthType(request);
-  return (
-    auth === "github" ||
-    auth === "proxy" ||
-    (auth === "bearer" && !isAdminRequest(request) && requestOwner(request) !== "unknown")
-  );
+function pairingBrowserSession(
+  request: Request,
+): { login: string; grant: GitHubUserGrant } | undefined {
+  if (
+    requestAuthType(request) !== "github" ||
+    request.headers.get("x-crabbox-portal-session") !== "true"
+  ) {
+    return undefined;
+  }
+  const cookie = cookieValue(request.headers.get("cookie") ?? "", portalSessionCookieName);
+  const token = bearerToken(request);
+  if (!cookie || !token || !timingSafeEqual(cookie, token)) return undefined;
+  const login = request.headers.get("x-crabbox-github-login")?.trim() ?? "";
+  const tokenID = request.headers.get("x-crabbox-github-token-id")?.trim() ?? "";
+  const sealedCredential = request.headers.get("x-crabbox-github-sealed-credential")?.trim() ?? "";
+  const expiresAt = request.headers.get("x-crabbox-token-expires-at")?.trim() ?? "";
+  if (!login || !tokenID || !sealedCredential || Date.parse(expiresAt) <= Date.now()) {
+    return undefined;
+  }
+  return { login, grant: { tokenID, sealedCredential, expiresAt } };
 }
 
 function pairingOriginError(
   request: Request,
   env: Pick<Env, "CRABBOX_PUBLIC_URL">,
+  requireOriginHeader = true,
 ): Response | undefined {
-  const status = coordinatorOriginStatus(request, env, true);
+  const status = coordinatorOriginStatus(request, env, requireOriginHeader);
   if (status === "unavailable") {
     return json({ error: "pairing_unavailable" }, { status: 503 });
   }

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -126,6 +126,28 @@ import {
 } from "./org-records";
 import { defaultOSImage, normalizeOSImage } from "./os-image";
 import {
+  coordinatorOriginStatus,
+  deviceTokenKey,
+  deviceTokenPrefixKey,
+  deviceTokenRouteAllowed,
+  deviceTokenTTLSeconds,
+  isDeviceTokenRequest,
+  newDeviceToken,
+  newPairingGrant,
+  pairingDeviceName,
+  pairingGrantHash,
+  pairingGrantKey,
+  pairingGrantPrefixKey,
+  pairingGrantTTLSeconds,
+  parsedDeviceToken,
+  publicDeviceRecord,
+  validDeviceID,
+  validDeviceTokenRecord,
+  validPairingGrantRecord,
+  type DeviceTokenRecord,
+  type PairingGrantRecord,
+} from "./pairing";
+import {
   portalCode,
   portalCodeBootstrapHandoff,
   portalAdmin,
@@ -983,6 +1005,11 @@ export class FleetCoordinator {
 
   async fetch(request: Request): Promise<Response> {
     try {
+      if (isDeviceTokenRequest(request)) {
+        const authenticated = await this.authenticatedDeviceRequest(request);
+        if (authenticated instanceof Response) return authenticated;
+        request = authenticated;
+      }
       await this.reconcileAdminGrantVersion(request);
       if (!(await this.restoredBridgesReady())) {
         return json(
@@ -1037,6 +1064,19 @@ export class FleetCoordinator {
       }
       if (method === "GET" && parts.join("/") === "v1/whoami") {
         return this.whoami(request);
+      }
+      if (method === "POST" && parts.join("/") === "v1/pairing/grants") {
+        return await this.createPairingGrant(request);
+      }
+      if (method === "POST" && parts.join("/") === "v1/pairing/exchange") {
+        return await this.exchangePairingGrant(request);
+      }
+      if (
+        parts[0] === "v1" &&
+        parts[1] === "devices" &&
+        (parts.length === 2 || parts.length === 3)
+      ) {
+        return await this.deviceRoute(request, parts[2]);
       }
       if (
         method === "GET" &&
@@ -1266,6 +1306,159 @@ export class FleetCoordinator {
     } catch (error) {
       return json({ error: coordinatorErrorMessage(this.env, error) }, { status: 500 });
     }
+  }
+
+  private async createPairingGrant(request: Request): Promise<Response> {
+    const originError = pairingOriginError(request, this.env);
+    if (originError) return originError;
+    if (!pairingOwnerSession(request)) {
+      return json({ error: "owner_session_required" }, { status: 403 });
+    }
+    const input = await pairingInput(request);
+    if (!input) return json({ error: "invalid_pairing_request" }, { status: 400 });
+    const name = pairingDeviceName(input.name);
+    if (!name) return json({ error: "invalid_device_name" }, { status: 400 });
+    const now = new Date();
+    const credentials = await newPairingGrant();
+    const record: PairingGrantRecord = {
+      version: 1,
+      audience: "crabbox-device-pairing",
+      scope: "leases:read",
+      grantHash: credentials.grantHash,
+      owner: requestOwner(request),
+      org: requestOrg(request, this.env),
+      name,
+      createdAt: now.toISOString(),
+      expiresAt: new Date(now.getTime() + pairingGrantTTLSeconds * 1000).toISOString(),
+    };
+    const grants = await this.state.storage.list<PairingGrantRecord>({
+      prefix: pairingGrantPrefixKey(),
+    });
+    await Promise.all(
+      [...grants.entries()]
+        .filter(([, grant]) => Date.parse(grant.expiresAt) <= now.getTime())
+        .map(([key]) => this.state.storage.delete(key)),
+    );
+    await this.state.storage.put(pairingGrantKey(record.grantHash), record);
+    return pairingJSON({
+      grant: credentials.grant,
+      audience: record.audience,
+      scope: [record.scope],
+      expiresAt: record.expiresAt,
+    });
+  }
+
+  private async exchangePairingGrant(request: Request): Promise<Response> {
+    const originError = pairingOriginError(request, this.env);
+    if (originError) return originError;
+    const input = await pairingInput(request);
+    if (!input || typeof input.grant !== "string") {
+      return json({ error: "invalid_pairing_request" }, { status: 400 });
+    }
+    const grantHash = await pairingGrantHash(input.grant);
+    if (!grantHash) return pairingUnauthorized("pairing_grant_invalid");
+    const record = await this.state.take<PairingGrantRecord>(pairingGrantKey(grantHash));
+    if (!record || !validPairingGrantRecord(record, grantHash)) {
+      return pairingUnauthorized("pairing_grant_invalid");
+    }
+    if (Date.parse(record.expiresAt) <= Date.now()) {
+      return pairingUnauthorized("pairing_grant_expired");
+    }
+    const now = new Date();
+    const credentials = await newDeviceToken();
+    const device: DeviceTokenRecord = {
+      version: 1,
+      id: credentials.id,
+      audience: "crabbox-device",
+      scope: ["leases:read"],
+      tokenHash: credentials.tokenHash,
+      owner: record.owner,
+      org: record.org,
+      name: record.name,
+      createdAt: now.toISOString(),
+      expiresAt: new Date(now.getTime() + deviceTokenTTLSeconds * 1000).toISOString(),
+    };
+    await this.state.storage.put(deviceTokenKey(device.id), device);
+    return pairingJSON({ device: publicDeviceRecord(device), token: credentials.token });
+  }
+
+  private async deviceRoute(request: Request, deviceID?: string): Promise<Response> {
+    const originError = pairingOriginError(request, this.env);
+    if (originError) return originError;
+    if (!pairingOwnerSession(request)) {
+      return json({ error: "owner_session_required" }, { status: 403 });
+    }
+    const method = request.method.toUpperCase();
+    const owner = requestOwner(request);
+    const org = requestOrg(request, this.env);
+    if (method === "GET" && !deviceID) {
+      const records = await this.state.storage.list<DeviceTokenRecord>({
+        prefix: deviceTokenPrefixKey(),
+      });
+      const expiredKeys: string[] = [];
+      const devices = [...records.entries()]
+        .filter(([key, record]) => {
+          if (Date.parse(record.expiresAt) <= Date.now()) {
+            expiredKeys.push(key);
+            return false;
+          }
+          return record.owner === owner && record.org === org;
+        })
+        .map(([, record]) => publicDeviceRecord(record))
+        .toSorted((left, right) => right.createdAt.localeCompare(left.createdAt));
+      await Promise.all(expiredKeys.map((key) => this.state.storage.delete(key)));
+      return pairingJSON({ devices });
+    }
+    if (method === "DELETE" && !deviceID) {
+      const records = await this.state.storage.list<DeviceTokenRecord>({
+        prefix: deviceTokenPrefixKey(),
+      });
+      const keys = [...records.entries()]
+        .filter(([, record]) => record.owner === owner && record.org === org)
+        .map(([key]) => key);
+      await Promise.all(keys.map((key) => this.state.storage.delete(key)));
+      return pairingJSON({ revoked: keys.length });
+    }
+    if (method === "DELETE" && deviceID && validDeviceID(deviceID)) {
+      const key = deviceTokenKey(deviceID);
+      const record = await this.state.storage.get<DeviceTokenRecord>(key, { noCache: true });
+      if (!record || record.owner !== owner || record.org !== org) return notFound();
+      await this.state.storage.delete(key);
+      return new Response(null, { status: 204, headers: pairingResponseHeaders() });
+    }
+    return json({ error: "not_found" }, { status: 404 });
+  }
+
+  private async authenticatedDeviceRequest(request: Request): Promise<Request | Response> {
+    const originError = pairingOriginError(request, this.env);
+    if (originError) return originError;
+    if (!deviceTokenRouteAllowed(request)) {
+      return json({ error: "device_scope_forbidden" }, { status: 403 });
+    }
+    const parsed = await parsedDeviceToken(bearerToken(request));
+    if (!parsed) return pairingUnauthorized("device_token_invalid");
+    const key = deviceTokenKey(parsed.id);
+    const record = await this.state.storage.get<DeviceTokenRecord>(key, { noCache: true });
+    if (!record || !validDeviceTokenRecord(record, parsed.id, parsed.tokenHash)) {
+      return pairingUnauthorized("device_token_invalid");
+    }
+    if (Date.parse(record.expiresAt) <= Date.now()) {
+      await this.state.storage.delete(key);
+      return pairingUnauthorized("device_token_expired");
+    }
+    const org = orgAuthLabelFromKey(record.org);
+    if (org === undefined) {
+      await this.state.storage.delete(key);
+      return pairingUnauthorized("device_token_invalid");
+    }
+    return requestWithAuthContext(request, {
+      authorized: true,
+      admin: false,
+      auth: "device",
+      owner: record.owner,
+      org,
+      tokenExpiresAt: record.expiresAt,
+    });
   }
 
   async webSocketMessage(socket: WebSocket, message: string | ArrayBuffer): Promise<void> {
@@ -16847,7 +17040,66 @@ function canonicalCodeReturnTo(request: Request, leaseID: string): string {
 
 function requestAuthType(request: Request): AuthContext["auth"] {
   const auth = request.headers.get("x-crabbox-auth");
-  return auth === "bearer" || auth === "github" || auth === "proxy" ? auth : "github";
+  return auth === "bearer" || auth === "device" || auth === "github" || auth === "proxy"
+    ? auth
+    : "github";
+}
+
+function pairingOwnerSession(request: Request): boolean {
+  if (!request.headers.has("x-crabbox-auth")) return false;
+  const auth = requestAuthType(request);
+  return (
+    auth === "github" ||
+    auth === "proxy" ||
+    (auth === "bearer" && !isAdminRequest(request) && requestOwner(request) !== "unknown")
+  );
+}
+
+function pairingOriginError(
+  request: Request,
+  env: Pick<Env, "CRABBOX_PUBLIC_URL">,
+): Response | undefined {
+  const status = coordinatorOriginStatus(request, env, true);
+  if (status === "unavailable") {
+    return json({ error: "pairing_unavailable" }, { status: 503 });
+  }
+  return status === "forbidden"
+    ? json({ error: "coordinator_origin_forbidden" }, { status: 403 })
+    : undefined;
+}
+
+async function pairingInput(
+  request: Request,
+): Promise<{ grant?: unknown; name?: unknown } | undefined> {
+  if (!request.headers.get("content-type")?.toLowerCase().startsWith("application/json")) {
+    return undefined;
+  }
+  try {
+    const input = (await request.json()) as unknown;
+    return input && typeof input === "object" && !Array.isArray(input)
+      ? (input as { grant?: unknown; name?: unknown })
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function pairingResponseHeaders(): Headers {
+  return new Headers({
+    "cache-control": "no-store",
+    "referrer-policy": "no-referrer",
+    "x-content-type-options": "nosniff",
+  });
+}
+
+function pairingJSON(data: unknown, init: ResponseInit = {}): Response {
+  const headers = pairingResponseHeaders();
+  for (const [name, value] of new Headers(init.headers)) headers.set(name, value);
+  return json(data, { ...init, headers });
+}
+
+function pairingUnauthorized(error: string): Response {
+  return pairingJSON({ error }, { status: 401 });
 }
 
 function webVNCPortalViewerRequest(

--- a/worker/src/github-membership.ts
+++ b/worker/src/github-membership.ts
@@ -103,6 +103,21 @@ export async function requireCurrentGitHubMembership(
   return load;
 }
 
+export async function requireFreshGitHubMembership(
+  identity: GitHubMembershipIdentity,
+  env: GitHubMembershipEnv,
+): Promise<void> {
+  requireSafeGitHubRevocationConfig(env);
+  if (githubUserIsRevoked(identity, env)) {
+    throw new GitHubAuthorizationError(`GitHub user ${identity.login} has been revoked.`);
+  }
+  if (!allowedGitHubOrgs(env).includes(identity.org.trim().toLowerCase())) {
+    throw new GitHubAuthorizationError(`GitHub organization ${identity.org} is no longer allowed.`);
+  }
+  await requireExactGitHubAccount(identity.accessToken, identity.owner, identity.login);
+  await requireExactGitHubMembership(identity.accessToken, identity.login, identity.org, env);
+}
+
 function githubUserIsRevoked(
   identity: Pick<GitHubMembershipIdentity, "owner">,
   env: Pick<GitHubMembershipEnv, "CRABBOX_GITHUB_REVOKED_USERS">,

--- a/worker/src/oauth.ts
+++ b/worker/src/oauth.ts
@@ -1,5 +1,7 @@
 import {
+  issuePortalToken,
   issueUserToken,
+  portalTokenExpiresAt,
   sha256Hex,
   userTokenExpiresAt,
   userTokenSigningConfigurationError,
@@ -349,7 +351,10 @@ async function githubAuthCallback(
     if (identity.name) {
       tokenInput.name = identity.name;
     }
-    const token = await issueUserToken(env, tokenInput);
+    const token =
+      pending.mode === "portal"
+        ? await issuePortalToken(env, tokenInput)
+        : await issueUserToken(env, tokenInput);
     const completion: Pick<OAuthPending, "token" | "owner" | "org" | "login"> & {
       tokenExpiresAt?: string;
     } = {
@@ -358,7 +363,8 @@ async function githubAuthCallback(
       org,
       login: identity.login,
     };
-    const tokenExpiresAt = userTokenExpiresAt(token);
+    const tokenExpiresAt =
+      pending.mode === "portal" ? portalTokenExpiresAt(token) : userTokenExpiresAt(token);
     if (tokenExpiresAt) {
       completion.tokenExpiresAt = tokenExpiresAt;
     }

--- a/worker/src/pairing.ts
+++ b/worker/src/pairing.ts
@@ -1,0 +1,225 @@
+import { base64URL, sha256Hex } from "./auth";
+import { bearerToken, pathParts } from "./http";
+import { timingSafeEqual } from "./timing-safe";
+import type { Env } from "./types";
+
+export const pairingGrantTTLSeconds = 5 * 60;
+export const deviceTokenTTLSeconds = 90 * 24 * 60 * 60;
+export const pairingRequestBodyBytes = 4 * 1024;
+
+const pairingGrantPrefix = "cbxp_";
+export const deviceTokenPrefix = "cbxd_";
+const deviceAudience = "crabbox-device";
+const pairingAudience = "crabbox-device-pairing";
+const leaseReadScope = "leases:read";
+const deviceIDPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+export interface PairingGrantRecord {
+  version: 1;
+  audience: typeof pairingAudience;
+  scope: typeof leaseReadScope;
+  grantHash: string;
+  owner: string;
+  org: string;
+  name: string;
+  createdAt: string;
+  expiresAt: string;
+}
+
+export interface DeviceTokenRecord {
+  version: 1;
+  id: string;
+  audience: typeof deviceAudience;
+  scope: [typeof leaseReadScope];
+  tokenHash: string;
+  owner: string;
+  org: string;
+  name: string;
+  createdAt: string;
+  expiresAt: string;
+}
+
+export interface PublicDeviceRecord {
+  id: string;
+  audience: typeof deviceAudience;
+  scope: [typeof leaseReadScope];
+  name: string;
+  createdAt: string;
+  expiresAt: string;
+}
+
+export type CoordinatorOriginStatus = "allowed" | "forbidden" | "unavailable";
+
+export function coordinatorOriginStatus(
+  request: Request,
+  env: Pick<Env, "CRABBOX_PUBLIC_URL">,
+  requireOriginHeader: boolean,
+): CoordinatorOriginStatus {
+  const configured = canonicalCoordinatorOrigin(env.CRABBOX_PUBLIC_URL);
+  if (!configured) return "unavailable";
+  if (new URL(request.url).origin !== configured) return "forbidden";
+  const origin = request.headers.get("origin")?.trim();
+  if (!origin) return requireOriginHeader ? "forbidden" : "allowed";
+  try {
+    return new URL(origin).origin === configured && origin === configured ? "allowed" : "forbidden";
+  } catch {
+    return "forbidden";
+  }
+}
+
+export function isPairingExchangeRequest(request: Request): boolean {
+  return (
+    request.method.toUpperCase() === "POST" &&
+    pathParts(request).join("/") === "v1/pairing/exchange"
+  );
+}
+
+export function isDeviceTokenRequest(request: Request): boolean {
+  return bearerToken(request).startsWith(deviceTokenPrefix);
+}
+
+export function deviceTokenRouteAllowed(request: Request): boolean {
+  if (request.method.toUpperCase() !== "GET") return false;
+  const parts = pathParts(request);
+  if (parts.join("/") === "v1/leases") return true;
+  return (
+    parts.length === 3 &&
+    parts[0] === "v1" &&
+    parts[1] === "leases" &&
+    Boolean(parts[2]) &&
+    !new URL(request.url).searchParams.has("providerMetadata")
+  );
+}
+
+export async function newPairingGrant(): Promise<{ grant: string; grantHash: string }> {
+  const grant = `${pairingGrantPrefix}${randomSecret()}`;
+  return { grant, grantHash: await sha256Hex(grant) };
+}
+
+export async function pairingGrantHash(grant: string): Promise<string | undefined> {
+  return validPairingGrant(grant) ? await sha256Hex(grant) : undefined;
+}
+
+export function pairingGrantKey(grantHash: string): string {
+  return `pairing-grant:${grantHash}`;
+}
+
+export function pairingGrantPrefixKey(): string {
+  return "pairing-grant:";
+}
+
+export async function newDeviceToken(): Promise<{
+  id: string;
+  token: string;
+  tokenHash: string;
+}> {
+  const id = crypto.randomUUID().toLowerCase();
+  const token = `${deviceTokenPrefix}${id}.${randomSecret()}`;
+  return { id, token, tokenHash: await sha256Hex(token) };
+}
+
+export async function parsedDeviceToken(
+  token: string,
+): Promise<{ id: string; tokenHash: string } | undefined> {
+  const match = /^cbxd_([0-9a-f-]{36})\.([A-Za-z0-9_-]{43})$/.exec(token);
+  if (!match?.[1] || !deviceIDPattern.test(match[1])) return undefined;
+  return { id: match[1], tokenHash: await sha256Hex(token) };
+}
+
+export function deviceTokenKey(id: string): string {
+  return `device-token:${id}`;
+}
+
+export function deviceTokenPrefixKey(): string {
+  return "device-token:";
+}
+
+export function validDeviceID(id: string): boolean {
+  return deviceIDPattern.test(id);
+}
+
+export function validPairingGrantRecord(record: PairingGrantRecord, hash: string): boolean {
+  return (
+    record.version === 1 &&
+    record.audience === pairingAudience &&
+    record.scope === leaseReadScope &&
+    typeof record.owner === "string" &&
+    record.owner.length > 0 &&
+    typeof record.org === "string" &&
+    typeof record.name === "string" &&
+    Number.isFinite(Date.parse(record.createdAt)) &&
+    Number.isFinite(Date.parse(record.expiresAt)) &&
+    typeof record.grantHash === "string" &&
+    timingSafeEqual(record.grantHash, hash)
+  );
+}
+
+export function validDeviceTokenRecord(
+  record: DeviceTokenRecord,
+  id: string,
+  tokenHash: string,
+): boolean {
+  return (
+    record.version === 1 &&
+    record.id === id &&
+    record.audience === deviceAudience &&
+    Array.isArray(record.scope) &&
+    record.scope.length === 1 &&
+    record.scope[0] === leaseReadScope &&
+    typeof record.owner === "string" &&
+    record.owner.length > 0 &&
+    typeof record.org === "string" &&
+    typeof record.name === "string" &&
+    Number.isFinite(Date.parse(record.createdAt)) &&
+    Number.isFinite(Date.parse(record.expiresAt)) &&
+    typeof record.tokenHash === "string" &&
+    timingSafeEqual(record.tokenHash, tokenHash)
+  );
+}
+
+export function publicDeviceRecord(record: DeviceTokenRecord): PublicDeviceRecord {
+  return {
+    id: record.id,
+    audience: record.audience,
+    scope: record.scope,
+    name: record.name,
+    createdAt: record.createdAt,
+    expiresAt: record.expiresAt,
+  };
+}
+
+export function pairingDeviceName(value: unknown): string | undefined {
+  if (value === undefined || value === null || value === "") return "Mobile device";
+  if (typeof value !== "string") return undefined;
+  const name = value.trim();
+  if (!name || name.length > 80) return undefined;
+  for (const character of name) {
+    const code = character.charCodeAt(0);
+    if (code <= 31 || code === 127) return undefined;
+  }
+  return name;
+}
+
+function canonicalCoordinatorOrigin(value: string | undefined): string | undefined {
+  try {
+    const url = new URL(value?.trim() ?? "");
+    if (url.username || url.password) return undefined;
+    if (url.protocol === "https:") return url.origin;
+    if (url.protocol === "http:" && loopbackHostname(url.hostname)) return url.origin;
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
+function loopbackHostname(hostname: string): boolean {
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]";
+}
+
+function validPairingGrant(grant: string): boolean {
+  return new RegExp(`^${pairingGrantPrefix}[A-Za-z0-9_-]{43}$`).test(grant);
+}
+
+function randomSecret(): string {
+  return base64URL(crypto.getRandomValues(new Uint8Array(32)));
+}

--- a/worker/src/pairing.ts
+++ b/worker/src/pairing.ts
@@ -1,4 +1,4 @@
-import { base64URL, sha256Hex } from "./auth";
+import { base64URL, sha256Hex, type GitHubUserGrant } from "./auth";
 import { bearerToken, pathParts } from "./http";
 import { timingSafeEqual } from "./timing-safe";
 import type { Env } from "./types";
@@ -6,6 +6,8 @@ import type { Env } from "./types";
 export const pairingGrantTTLSeconds = 5 * 60;
 export const deviceTokenTTLSeconds = 90 * 24 * 60 * 60;
 export const pairingRequestBodyBytes = 4 * 1024;
+export const maxDeviceTokensPerOwner = 10;
+export const maxPairingGrantsPerOwner = 10;
 
 const pairingGrantPrefix = "cbxp_";
 export const deviceTokenPrefix = "cbxd_";
@@ -13,6 +15,8 @@ const deviceAudience = "crabbox-device";
 const pairingAudience = "crabbox-device-pairing";
 const leaseReadScope = "leases:read";
 const deviceIDPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const sha256Pattern = /^[a-f0-9]{64}$/;
+const encoder = new TextEncoder();
 
 export interface PairingGrantRecord {
   version: 1;
@@ -21,6 +25,8 @@ export interface PairingGrantRecord {
   grantHash: string;
   owner: string;
   org: string;
+  ownerLogin: string;
+  ownerGrant: GitHubUserGrant;
   name: string;
   createdAt: string;
   expiresAt: string;
@@ -34,6 +40,8 @@ export interface DeviceTokenRecord {
   tokenHash: string;
   owner: string;
   org: string;
+  ownerLogin: string;
+  ownerGrant: GitHubUserGrant;
   name: string;
   createdAt: string;
   expiresAt: string;
@@ -45,6 +53,18 @@ export interface PublicDeviceRecord {
   scope: [typeof leaseReadScope];
   name: string;
   createdAt: string;
+  expiresAt: string;
+}
+
+export interface PairingGrantOwnerIndexRecord {
+  version: 1;
+  grantHash: string;
+  expiresAt: string;
+}
+
+export interface DeviceOwnerIndexRecord {
+  version: 1;
+  deviceID: string;
   expiresAt: string;
 }
 
@@ -71,6 +91,22 @@ export function isPairingExchangeRequest(request: Request): boolean {
   return (
     request.method.toUpperCase() === "POST" &&
     pathParts(request).join("/") === "v1/pairing/exchange"
+  );
+}
+
+export function isPairingGrantRequest(request: Request): boolean {
+  return (
+    request.method.toUpperCase() === "POST" && pathParts(request).join("/") === "v1/pairing/grants"
+  );
+}
+
+export function isDeviceManagementRequest(request: Request): boolean {
+  const parts = pathParts(request);
+  return (
+    (request.method.toUpperCase() === "GET" || request.method.toUpperCase() === "DELETE") &&
+    parts[0] === "v1" &&
+    parts[1] === "devices" &&
+    (parts.length === 2 || parts.length === 3)
   );
 }
 
@@ -108,6 +144,14 @@ export function pairingGrantPrefixKey(): string {
   return "pairing-grant:";
 }
 
+export function pairingGrantOwnerIndexKey(owner: string, org: string, grantHash: string): string {
+  return `${pairingGrantOwnerIndexPrefix(owner, org)}${grantHash}`;
+}
+
+export function pairingGrantOwnerIndexPrefix(owner: string, org: string): string {
+  return `pairing-grant-owner:${ownerScope(owner, org)}:`;
+}
+
 export async function newDeviceToken(): Promise<{
   id: string;
   token: string;
@@ -134,6 +178,14 @@ export function deviceTokenPrefixKey(): string {
   return "device-token:";
 }
 
+export function deviceOwnerIndexKey(owner: string, org: string, deviceID: string): string {
+  return `${deviceOwnerIndexPrefix(owner, org)}${deviceID}`;
+}
+
+export function deviceOwnerIndexPrefix(owner: string, org: string): string {
+  return `device-owner:${ownerScope(owner, org)}:`;
+}
+
 export function validDeviceID(id: string): boolean {
   return deviceIDPattern.test(id);
 }
@@ -146,6 +198,9 @@ export function validPairingGrantRecord(record: PairingGrantRecord, hash: string
     typeof record.owner === "string" &&
     record.owner.length > 0 &&
     typeof record.org === "string" &&
+    typeof record.ownerLogin === "string" &&
+    record.ownerLogin.length > 0 &&
+    validGitHubUserGrant(record.ownerGrant) &&
     typeof record.name === "string" &&
     Number.isFinite(Date.parse(record.createdAt)) &&
     Number.isFinite(Date.parse(record.expiresAt)) &&
@@ -159,6 +214,10 @@ export function validDeviceTokenRecord(
   id: string,
   tokenHash: string,
 ): boolean {
+  return validStoredDeviceTokenRecord(record, id) && timingSafeEqual(record.tokenHash, tokenHash);
+}
+
+export function validStoredDeviceTokenRecord(record: DeviceTokenRecord, id: string): boolean {
   return (
     record.version === 1 &&
     record.id === id &&
@@ -169,11 +228,38 @@ export function validDeviceTokenRecord(
     typeof record.owner === "string" &&
     record.owner.length > 0 &&
     typeof record.org === "string" &&
+    typeof record.ownerLogin === "string" &&
+    record.ownerLogin.length > 0 &&
+    validGitHubUserGrant(record.ownerGrant) &&
     typeof record.name === "string" &&
     Number.isFinite(Date.parse(record.createdAt)) &&
     Number.isFinite(Date.parse(record.expiresAt)) &&
     typeof record.tokenHash === "string" &&
-    timingSafeEqual(record.tokenHash, tokenHash)
+    sha256Pattern.test(record.tokenHash)
+  );
+}
+
+export function validPairingGrantOwnerIndexRecord(
+  record: PairingGrantOwnerIndexRecord,
+  grantHash: string,
+): boolean {
+  return (
+    record.version === 1 &&
+    record.grantHash === grantHash &&
+    sha256Pattern.test(record.grantHash) &&
+    Number.isFinite(Date.parse(record.expiresAt))
+  );
+}
+
+export function validDeviceOwnerIndexRecord(
+  record: DeviceOwnerIndexRecord,
+  deviceID: string,
+): boolean {
+  return (
+    record.version === 1 &&
+    record.deviceID === deviceID &&
+    validDeviceID(record.deviceID) &&
+    Number.isFinite(Date.parse(record.expiresAt))
   );
 }
 
@@ -222,4 +308,21 @@ function validPairingGrant(grant: string): boolean {
 
 function randomSecret(): string {
   return base64URL(crypto.getRandomValues(new Uint8Array(32)));
+}
+
+function ownerScope(owner: string, org: string): string {
+  return base64URL(encoder.encode(JSON.stringify([owner, org])));
+}
+
+function validGitHubUserGrant(grant: GitHubUserGrant): boolean {
+  return (
+    grant !== null &&
+    typeof grant === "object" &&
+    typeof grant.tokenID === "string" &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(grant.tokenID) &&
+    typeof grant.sealedCredential === "string" &&
+    grant.sealedCredential.length > 0 &&
+    typeof grant.expiresAt === "string" &&
+    Number.isFinite(Date.parse(grant.expiresAt))
+  );
 }

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -27441,7 +27441,7 @@ describe("fleet identity", () => {
     expect(callback.status).toBe(302);
     expect(callback.headers.get("location")).toBe("/portal/leases/cbx_000000000001/vnc");
     const cookie = callback.headers.get("set-cookie") ?? "";
-    expect(cookie).toContain("__Host-crabbox_session=cbxu_");
+    expect(cookie).toContain("__Host-crabbox_session=cbwp_");
     expect(cookie).toContain("crabbox_session=;");
     expect(cookie).toContain("Path=/");
     expect(cookie).toContain("HttpOnly");
@@ -27470,12 +27470,12 @@ describe("fleet identity", () => {
       return cookiePairFromResponse(callback, "__Host-crabbox_session");
     };
     const throughCoordinator = async (
-      token: string,
+      sessionCookie: string,
       leaseID = "cbx_000000000001",
     ): Promise<Response> =>
       await routeCoordinatorRequest(
-        new Request(`https://crabbox.test/v1/leases/${leaseID}`, {
-          headers: { authorization: `Bearer ${token}` },
+        new Request(`https://crabbox.test/portal/leases/${leaseID}`, {
+          headers: { cookie: sessionCookie },
         }),
         env,
         async (prepared) => await fleet.fetch(prepared),
@@ -27493,7 +27493,7 @@ describe("fleet identity", () => {
         expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
       }),
     );
-    expect((await throughCoordinator(originalToken)).status).toBe(200);
+    expect((await throughCoordinator(originalCookie)).status).toBe(200);
     storage.seed(
       "lease:cbx_000000000002",
       testLease({
@@ -27507,8 +27507,8 @@ describe("fleet identity", () => {
     const reassignedCookie = await login(67890);
     const reassignedToken = decodeURIComponent(reassignedCookie.split("=", 2)[1] ?? "");
     expect(decodeUserTokenPayload(reassignedToken).owner).toBe("github:67890");
-    expect((await throughCoordinator(reassignedToken)).status).toBe(404);
-    expect((await throughCoordinator(reassignedToken, "cbx_000000000002")).status).toBe(404);
+    expect((await throughCoordinator(reassignedCookie)).status).toBe(404);
+    expect((await throughCoordinator(reassignedCookie, "cbx_000000000002")).status).toBe(404);
 
     const recovered = await fleet.fetch(
       request("PUT", "/v1/leases/cbx_000000000002/share", {
@@ -27517,7 +27517,7 @@ describe("fleet identity", () => {
       }),
     );
     expect(recovered.status).toBe(200);
-    expect((await throughCoordinator(reassignedToken, "cbx_000000000002")).status).toBe(200);
+    expect((await throughCoordinator(reassignedCookie, "cbx_000000000002")).status).toBe(200);
   });
 
   it.each([
@@ -27554,7 +27554,7 @@ describe("fleet identity", () => {
     );
     expect(callback.status).toBe(302);
     expect(callback.headers.get("location")).toBe("/portal");
-    expect(callback.headers.get("set-cookie")).toContain("__Host-crabbox_session=cbxu_");
+    expect(callback.headers.get("set-cookie")).toContain("__Host-crabbox_session=cbwp_");
   });
 
   it("requires a POST before clearing the portal session", async () => {
@@ -29649,14 +29649,17 @@ function decodeUserTokenPayload(token: string): {
   iat: number;
   jti: string;
   githubCredential: string;
+  owner: string;
 } {
-  expect(token).toMatch(/^cbxu_/);
-  const [payload] = token.slice("cbxu_".length).split(".");
+  expect(token).toMatch(/^cb(?:xu|wp)_/);
+  const prefix = token.startsWith("cbwp_") ? "cbwp_" : "cbxu_";
+  const [payload] = token.slice(prefix.length).split(".");
   const decoded = Buffer.from(payload, "base64url").toString("utf8");
   return JSON.parse(decoded) as {
     exp: number;
     iat: number;
     jti: string;
     githubCredential: string;
+    owner: string;
   };
 }

--- a/worker/test/github-membership.test.ts
+++ b/worker/test/github-membership.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { authenticateRequest, issueUserToken } from "../src/auth";
 import { prepareCoordinatorRequest } from "../src/coordinator-entry";
+import { requireFreshGitHubMembership } from "../src/github-membership";
 import type { Env } from "../src/types";
 
 const accessToken = "github-access-token-for-tests";
@@ -110,6 +111,24 @@ describe("GitHub user-token membership", () => {
       authorized: true,
     });
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("supports uncached membership checks for device principals", async () => {
+    const env = testEnv({ CRABBOX_GITHUB_MEMBERSHIP_CACHE_SECONDS: "300" });
+    const fetchMock = membershipFetch();
+    vi.stubGlobal("fetch", fetchMock);
+    const identity = {
+      accessToken,
+      tokenID: crypto.randomUUID(),
+      owner: `github:${accountID}`,
+      org: "example-org",
+      login: "alice",
+    };
+
+    await requireFreshGitHubMembership(identity, env);
+    await requireFreshGitHubMembership(identity, env);
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
   });
 
   it("rejects a credential whose GitHub account id no longer matches the session", async () => {

--- a/worker/test/pairing.test.ts
+++ b/worker/test/pairing.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { issuePortalToken, issueUserToken } from "../src/auth";
 import { routeCoordinatorRequest } from "../src/coordinator-entry";
 import {
   type CoordinatorRuntime,
@@ -9,44 +10,75 @@ import {
 } from "../src/coordinator-runtime";
 import { FleetCoordinator } from "../src/fleet";
 import { orgKeyForLabel } from "../src/org-identity";
-import { deviceTokenTTLSeconds, pairingGrantTTLSeconds } from "../src/pairing";
+import {
+  deviceTokenTTLSeconds,
+  maxDeviceTokensPerOwner,
+  maxPairingGrantsPerOwner,
+  pairingGrantTTLSeconds,
+} from "../src/pairing";
 import type { Env, LeaseRecord } from "../src/types";
 
 const origin = "https://coordinator.example.test";
-const owner = "alice@example.com";
+const owner = "github:12345";
+const ownerLogin = "alice";
+const otherOwner = "github:67890";
 const org = "example-org";
 
 class MemoryStorage implements CoordinatorStorage {
   private readonly values = new Map<string, unknown>();
+  writes = 0;
+  readonly listPrefixes: string[] = [];
 
   get<T>(key: string): Promise<T | undefined> {
     return Promise.resolve(this.values.get(key) as T | undefined);
   }
 
   put<T>(key: string, value: T): Promise<void> {
+    this.writes += 1;
     this.values.set(key, value);
     return Promise.resolve();
   }
 
   delete(key: string): Promise<void> {
+    this.writes += 1;
     this.values.delete(key);
     return Promise.resolve();
   }
 
-  list<T>({ prefix = "" }: { prefix?: string } = {}): Promise<Map<string, T>> {
+  list<T>({
+    prefix = "",
+    limit,
+    startAfter,
+  }: {
+    prefix?: string;
+    limit?: number;
+    startAfter?: string;
+    noCache?: boolean;
+  } = {}): Promise<Map<string, T>> {
+    this.listPrefixes.push(prefix);
+    const entries = [...this.values]
+      .toSorted(([left], [right]) => left.localeCompare(right))
+      .filter(([key]) => key.startsWith(prefix) && (!startAfter || key > startAfter));
     return Promise.resolve(
       new Map(
-        [...this.values]
-          .filter(([key]) => key.startsWith(prefix))
-          .map(([key, value]) => [key, value as T]),
+        (limit === undefined ? entries : entries.slice(0, limit)).map(([key, value]) => [
+          key,
+          value as T,
+        ]),
       ),
     );
   }
 
   take<T>(key: string): Promise<T | undefined> {
+    this.writes += 1;
     const value = this.values.get(key) as T | undefined;
     this.values.delete(key);
     return Promise.resolve(value);
+  }
+
+  resetObservations(): void {
+    this.writes = 0;
+    this.listPrefixes.length = 0;
   }
 
   serialized(): string {
@@ -116,6 +148,8 @@ class MemoryRuntime implements CoordinatorRuntime {
 interface PairingFixture {
   env: Env;
   runtime: MemoryRuntime;
+  membershipAllowed: { value: boolean };
+  membershipChecks: ReturnType<typeof vi.fn>;
   request(
     path: string,
     init?: RequestInit,
@@ -123,6 +157,10 @@ interface PairingFixture {
     destinationOrigin?: string,
   ): Promise<Response>;
   ownerRequest(path: string, init?: RequestInit, requestOrigin?: string): Promise<Response>;
+  bearerRequest(path: string, init?: RequestInit): Promise<Response>;
+  userBearerRequest(path: string, init?: RequestInit): Promise<Response>;
+  portalBearerRequest(path: string, init?: RequestInit): Promise<Response>;
+  userCookieRequest(path: string, init?: RequestInit): Promise<Response>;
   pair(name?: string): Promise<{ deviceID: string; grant: string; token: string }>;
 }
 
@@ -133,16 +171,17 @@ describe("coordinator device pairing", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
-  it("exchanges an owner grant for a read-only token and reuses lease visibility", async () => {
-    const fixture = pairingFixture();
+  it("exchanges a browser grant for a distinct credential-free device principal", async () => {
+    const fixture = await pairingFixture();
     await seedLease(fixture.runtime, lease("cbx_000000000001", owner));
     await seedLease(
       fixture.runtime,
-      lease("cbx_000000000002", "bob@example.com", { users: { [owner]: "use" } }),
+      lease("cbx_000000000002", otherOwner, { users: { [owner]: "use" } }),
     );
-    await seedLease(fixture.runtime, lease("cbx_000000000003", "carol@example.com"));
+    await seedLease(fixture.runtime, lease("cbx_000000000003", "github:99999"));
 
     const { deviceID, grant, token } = await fixture.pair("Alice's phone");
     expect(fixture.runtime.storage.serialized()).not.toContain(grant);
@@ -155,14 +194,31 @@ describe("coordinator device pairing", () => {
       "cbx_000000000001",
       "cbx_000000000002",
     ]);
+    for (const item of listBody.leases) {
+      expect(item).toMatchObject({
+        host: "<redacted>",
+        sshUser: "<redacted>",
+        sshPort: "<redacted>",
+        workRoot: "<redacted>",
+      });
+      expect(item).not.toHaveProperty("sshHostKey");
+      expect(item).not.toHaveProperty("providerAccessExpiresAt");
+      expect(item).not.toHaveProperty("tailscale");
+    }
 
     const inspect = await fixture.request("/v1/leases/cbx_000000000002", deviceRequest(token));
     expect(inspect.status).toBe(200);
     await expect(inspect.json()).resolves.toMatchObject({
-      lease: { id: "cbx_000000000002", owner: "bob@example.com" },
+      lease: {
+        id: "cbx_000000000002",
+        owner: otherOwner,
+        host: "<redacted>",
+        sshUser: "<redacted>",
+      },
     });
 
-    const devices = await fixture.ownerRequest("/v1/devices");
+    fixture.runtime.storage.resetObservations();
+    const devices = await fixture.ownerRequest("/v1/devices", {}, "");
     expect(devices.status).toBe(200);
     expect(devices.headers.get("cache-control")).toBe("no-store");
     const deviceText = await devices.text();
@@ -177,11 +233,49 @@ describe("coordinator device pairing", () => {
         }),
       ],
     });
+    expect(fixture.runtime.storage.listPrefixes).toContainEqual(
+      expect.stringMatching(/^device-owner:/),
+    );
+    expect(fixture.runtime.storage.listPrefixes).not.toContain("device-token:");
+  });
+
+  it("never refreshes provider access or writes storage during device detail reads", async () => {
+    const fixture = await pairingFixture();
+    const managed = lease("cbx_000000000004", owner);
+    managed.provider = "daytona";
+    managed.lifecycle = "managed";
+    managed.host = "ssh.app.daytona.io";
+    managed.sshUser = "live-provider-access-token";
+    managed.sshPort = "22";
+    managed.sshFallbackPorts = ["2222"];
+    managed.sshHostKey = "SHA256:host-key";
+    managed.providerAccessExpiresAt = new Date(Date.now() + 60_000).toISOString();
+    managed.tailscale = { enabled: true, ipv4: "100.64.0.1", state: "ready" };
+    await seedLease(fixture.runtime, managed);
+    const { token } = await fixture.pair();
+    const providerFetch = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValue(new Error("provider called"));
+    fixture.runtime.storage.resetObservations();
+
+    const response = await fixture.request(`/v1/leases/${managed.id}`, deviceRequest(token));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      lease: {
+        host: "<redacted>",
+        sshUser: "<redacted>",
+        sshPort: "<redacted>",
+        workRoot: "<redacted>",
+      },
+    });
+    expect(providerFetch).not.toHaveBeenCalled();
+    expect(fixture.runtime.storage.writes).toBe(0);
   });
 
   it("expires grants, consumes successful grants once, and rejects replay", async () => {
     vi.useFakeTimers({ now: new Date("2026-07-27T12:00:00Z") });
-    const fixture = pairingFixture();
+    const fixture = await pairingFixture();
     const expiredGrant = await issueGrant(fixture);
     await vi.advanceTimersByTimeAsync(pairingGrantTTLSeconds * 1000 + 1);
 
@@ -198,7 +292,7 @@ describe("coordinator device pairing", () => {
   });
 
   it("revokes individual devices and all owner devices immediately", async () => {
-    const fixture = pairingFixture();
+    const fixture = await pairingFixture();
     await seedLease(fixture.runtime, lease("cbx_000000000001", owner));
     const first = await fixture.pair("First phone");
     const second = await fixture.pair("Second phone");
@@ -216,16 +310,18 @@ describe("coordinator device pairing", () => {
     expect((await fixture.request("/v1/leases", deviceRequest(second.token))).status).toBe(401);
   });
 
-  it("expires device tokens and removes their stored verifier", async () => {
+  it("expires device tokens without mutating storage from the device request", async () => {
     vi.useFakeTimers({ now: new Date("2026-07-27T12:00:00Z") });
-    const fixture = pairingFixture();
+    const fixture = await pairingFixture();
     const { token } = await fixture.pair();
     await vi.advanceTimersByTimeAsync(deviceTokenTTLSeconds * 1000 + 1);
+    fixture.runtime.storage.resetObservations();
 
     const expired = await fixture.request("/v1/leases", deviceRequest(token));
     expect(expired.status).toBe(401);
     await expect(expired.json()).resolves.toEqual({ error: "device_token_expired" });
-    expect(fixture.runtime.storage.serialized()).not.toContain("device-token:");
+    expect(fixture.runtime.storage.writes).toBe(0);
+    expect(fixture.runtime.storage.serialized()).toContain("device-token:");
   });
 
   it.each([
@@ -240,7 +336,7 @@ describe("coordinator device pairing", () => {
       "GET",
     ],
   ])("returns 403 when a device token attempts to %s", async (_label, path, method) => {
-    const fixture = pairingFixture();
+    const fixture = await pairingFixture();
     const { token } = await fixture.pair();
     const response = await fixture.request(path, deviceRequest(token, method));
     expect(response.status).toBe(403);
@@ -248,7 +344,7 @@ describe("coordinator device pairing", () => {
   });
 
   it("rejects forged and non-canonical device credentials", async () => {
-    const fixture = pairingFixture();
+    const fixture = await pairingFixture();
     const { token } = await fixture.pair();
     const [prefix, secret] = token.split(".") as [string, string];
     const deviceID = prefix.slice("cbxd_".length);
@@ -271,14 +367,10 @@ describe("coordinator device pairing", () => {
   });
 
   it("requires the exact configured origin without redirecting credentials", async () => {
-    const fixture = pairingFixture();
+    const fixture = await pairingFixture();
     const missingOrigin = await fixture.ownerRequest(
       "/v1/pairing/grants",
-      {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: "{}",
-      },
+      { method: "POST", headers: { "content-type": "application/json" }, body: "{}" },
       "",
     );
     expect(missingOrigin.status).toBe(403);
@@ -289,15 +381,17 @@ describe("coordinator device pairing", () => {
       "https://evil.example.test",
     );
     expect(wrongBrowserOrigin.status).toBe(403);
+    const wrongDeviceListOrigin = await fixture.ownerRequest(
+      "/v1/devices",
+      {},
+      "https://evil.example.test",
+    );
+    expect(wrongDeviceListOrigin.status).toBe(403);
 
     const grant = await issueGrant(fixture);
     const wrongDestination = await fixture.request(
       "/v1/pairing/exchange",
-      {
-        method: "POST",
-        headers: { "content-type": "application/json", origin },
-        body: JSON.stringify({ grant }),
-      },
+      jsonPost({ grant }),
       origin,
       "https://alias.example.test",
     );
@@ -312,13 +406,11 @@ describe("coordinator device pairing", () => {
     expect(wrongAPIOrigin.status).toBe(403);
   });
 
-  it("fails closed after lease sharing changes and isolates device management by owner", async () => {
-    const fixture = pairingFixture();
-    const shared = lease("cbx_000000000001", "bob@example.com", {
-      users: { [owner]: "use" },
-    });
+  it("fails closed after membership or lease sharing changes", async () => {
+    const fixture = await pairingFixture();
+    const shared = lease("cbx_000000000001", otherOwner, { users: { [owner]: "use" } });
     await seedLease(fixture.runtime, shared);
-    const { deviceID, token } = await fixture.pair();
+    const { token } = await fixture.pair();
     expect((await fixture.request(`/v1/leases/${shared.id}`, deviceRequest(token))).status).toBe(
       200,
     );
@@ -329,7 +421,17 @@ describe("coordinator device pairing", () => {
       404,
     );
 
-    const bob = pairingFixture(fixture.runtime, "bob@example.com");
+    fixture.membershipAllowed.value = false;
+    const offboarded = await fixture.request("/v1/leases", deviceRequest(token));
+    expect(offboarded.status).toBe(401);
+    await expect(offboarded.json()).resolves.toEqual({ error: "device_owner_unauthorized" });
+  });
+
+  it("isolates device management indexes by owner", async () => {
+    const fixture = await pairingFixture();
+    const { deviceID, token } = await fixture.pair();
+    const bob = await pairingFixture(fixture.runtime, otherOwner, "bob");
+
     const bobDevices = await bob.ownerRequest("/v1/devices");
     await expect(bobDevices.json()).resolves.toEqual({ devices: [] });
     expect((await bob.ownerRequest(`/v1/devices/${deviceID}`, { method: "DELETE" })).status).toBe(
@@ -338,36 +440,109 @@ describe("coordinator device pairing", () => {
     expect((await fixture.request("/v1/leases", deviceRequest(token))).status).toBe(200);
   });
 
-  it("requires a non-admin owner session to issue pairing grants", async () => {
-    const fixture = pairingFixture();
+  it("requires a GitHub browser session rather than any API bearer", async () => {
+    const fixture = await pairingFixture();
     const anonymous = await fixture.request("/v1/pairing/grants", jsonPost({}));
     expect(anonymous.status).toBe(401);
 
+    const shared = await fixture.bearerRequest("/v1/pairing/grants", jsonPost({}));
+    expect(shared.status).toBe(403);
+    await expect(shared.json()).resolves.toEqual({ error: "owner_session_required" });
+
+    const signedBearer = await fixture.userBearerRequest("/v1/pairing/grants", jsonPost({}));
+    expect(signedBearer.status).toBe(403);
+    await expect(signedBearer.json()).resolves.toEqual({ error: "owner_session_required" });
+
+    const copiedCookie = await fixture.userCookieRequest("/v1/pairing/grants", jsonPost({}));
+    expect(copiedCookie.status).toBe(403);
+    await expect(copiedCookie.json()).resolves.toEqual({ error: "owner_session_required" });
+
+    const portalBearer = await fixture.portalBearerRequest("/v1/leases");
+    expect(portalBearer.status).toBe(401);
+
     const admin = await fixture.request("/v1/pairing/grants", {
       ...jsonPost({}),
-      headers: {
-        ...jsonPost({}).headers,
-        authorization: "Bearer admin-token",
-        origin,
-      },
+      headers: { "content-type": "application/json", authorization: "Bearer admin-token", origin },
     });
     expect(admin.status).toBe(403);
     await expect(admin.json()).resolves.toEqual({ error: "owner_session_required" });
   });
+
+  it("caps active devices per owner", async () => {
+    const fixture = await pairingFixture();
+    for (let index = 0; index < maxDeviceTokensPerOwner - 1; index += 1) {
+      // oxlint-disable-next-line eslint/no-await-in-loop -- each pairing consumes its one-use grant.
+      await fixture.pair(`Device ${index + 1}`);
+    }
+
+    const grants = await Promise.all([
+      issueGrant(fixture, "Concurrent device A"),
+      issueGrant(fixture, "Concurrent device B"),
+    ]);
+    const exchanges = await Promise.all(grants.map((grant) => exchangeGrant(fixture, grant)));
+    expect(exchanges.map((response) => response.status).toSorted()).toEqual([200, 409]);
+    const rejected = exchanges.find((response) => response.status === 409)!;
+    await expect(rejected.json()).resolves.toEqual({
+      error: "device_limit_reached",
+      limit: maxDeviceTokensPerOwner,
+    });
+    const devices = await fixture.ownerRequest("/v1/devices");
+    const body = (await devices.json()) as { devices: unknown[] };
+    expect(body.devices).toHaveLength(maxDeviceTokensPerOwner);
+  });
+
+  it("bounds active pairing grants per owner", async () => {
+    const fixture = await pairingFixture();
+    const responses = await Promise.all(
+      Array.from({ length: maxPairingGrantsPerOwner + 1 }, (_, index) =>
+        fixture.ownerRequest(
+          "/v1/pairing/grants",
+          jsonPost({ name: `Concurrent pending device ${index + 1}` }),
+        ),
+      ),
+    );
+    expect(responses.map((response) => response.status).toSorted()).toEqual([
+      ...Array.from({ length: maxPairingGrantsPerOwner }, () => 200),
+      429,
+    ]);
+    const rejected = responses.find((response) => response.status === 429)!;
+    expect(rejected.status).toBe(429);
+    await expect(rejected.json()).resolves.toEqual({ error: "pairing_grant_limit_reached" });
+  });
 });
 
-function pairingFixture(
+async function pairingFixture(
   existingRuntime = new MemoryRuntime(),
-  sharedOwner = owner,
-): PairingFixture {
+  sessionOwner = owner,
+  login = ownerLogin,
+): Promise<PairingFixture> {
   const env = {
     CRABBOX_PUBLIC_URL: origin,
-    CRABBOX_SHARED_TOKEN: "owner-token",
-    CRABBOX_SHARED_OWNER: sharedOwner,
+    CRABBOX_SHARED_TOKEN: "shared-token",
+    CRABBOX_SHARED_OWNER: "automation@example.com",
     CRABBOX_ADMIN_TOKEN: "admin-token",
+    CRABBOX_SESSION_SECRET: "session-secret",
     CRABBOX_DEFAULT_ORG: org,
+    CRABBOX_GITHUB_ALLOWED_ORG: org,
+    CRABBOX_GITHUB_MEMBERSHIP_CACHE_SECONDS: "0",
   } as Env;
-  const fleet = new FleetCoordinator(existingRuntime, env);
+  const membershipAllowed = { value: true };
+  const membershipChecks = vi.fn<() => Promise<void>>(async (): Promise<void> => {
+    if (!membershipAllowed.value) throw new Error("membership removed");
+  });
+  const authContext = { githubMembership: membershipChecks };
+  const tokenInput = {
+    owner: sessionOwner,
+    ownerSource: "github-verified-email" as const,
+    org,
+    login,
+    githubAccessToken: `github-access-token-${sessionOwner}`,
+  };
+  const [userToken, portalToken] = await Promise.all([
+    issueUserToken(env, tokenInput),
+    issuePortalToken(env, tokenInput),
+  ]);
+  const fleet = new FleetCoordinator(existingRuntime, env, {}, authContext);
   const request = async (
     path: string,
     init: RequestInit = {},
@@ -378,6 +553,7 @@ function pairingFixture(
       new Request(`${destinationOrigin}${path}`, init),
       env,
       async (prepared) => await fleet.fetch(prepared),
+      authContext,
     );
   const ownerRequest = async (
     path: string,
@@ -385,15 +561,32 @@ function pairingFixture(
     requestOrigin = origin,
   ): Promise<Response> => {
     const headers = new Headers(init.headers);
-    headers.set("authorization", "Bearer owner-token");
+    headers.set("cookie", `__Host-crabbox_session=${encodeURIComponent(portalToken)}`);
     if (requestOrigin) headers.set("origin", requestOrigin);
+    return await request(path, { ...init, headers });
+  };
+  const withBearer = async (token: string, path: string, init: RequestInit = {}) => {
+    const headers = new Headers(init.headers);
+    headers.set("authorization", `Bearer ${token}`);
+    headers.set("origin", origin);
     return await request(path, { ...init, headers });
   };
   const fixture: PairingFixture = {
     env,
     runtime: existingRuntime,
+    membershipAllowed,
+    membershipChecks,
     request,
     ownerRequest,
+    bearerRequest: async (path, init) => await withBearer("shared-token", path, init),
+    userBearerRequest: async (path, init) => await withBearer(userToken, path, init),
+    portalBearerRequest: async (path, init) => await withBearer(portalToken, path, init),
+    userCookieRequest: async (path, init = {}) => {
+      const headers = new Headers(init.headers);
+      headers.set("cookie", `__Host-crabbox_session=${encodeURIComponent(userToken)}`);
+      headers.set("origin", origin);
+      return await request(path, { ...init, headers });
+    },
     async pair(name?: string) {
       const grant = await issueGrant(fixture, name);
       const response = await exchangeGrant(fixture, grant);
@@ -456,6 +649,8 @@ function lease(id: string, leaseOwner: string, share?: LeaseRecord["share"]): Le
     host: "127.0.0.1",
     sshUser: "crabbox",
     sshPort: "22",
+    sshFallbackPorts: ["2222"],
+    sshHostKey: "SHA256:test-host-key",
     workRoot: "/work/crabbox",
     keep: true,
     ttlSeconds: 3600,

--- a/worker/test/pairing.test.ts
+++ b/worker/test/pairing.test.ts
@@ -1,0 +1,469 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { routeCoordinatorRequest } from "../src/coordinator-entry";
+import {
+  type CoordinatorRuntime,
+  type CoordinatorSocketHandlers,
+  type CoordinatorStorage,
+  type CoordinatorWebSocketUpgradeOptions,
+} from "../src/coordinator-runtime";
+import { FleetCoordinator } from "../src/fleet";
+import { orgKeyForLabel } from "../src/org-identity";
+import { deviceTokenTTLSeconds, pairingGrantTTLSeconds } from "../src/pairing";
+import type { Env, LeaseRecord } from "../src/types";
+
+const origin = "https://coordinator.example.test";
+const owner = "alice@example.com";
+const org = "example-org";
+
+class MemoryStorage implements CoordinatorStorage {
+  private readonly values = new Map<string, unknown>();
+
+  get<T>(key: string): Promise<T | undefined> {
+    return Promise.resolve(this.values.get(key) as T | undefined);
+  }
+
+  put<T>(key: string, value: T): Promise<void> {
+    this.values.set(key, value);
+    return Promise.resolve();
+  }
+
+  delete(key: string): Promise<void> {
+    this.values.delete(key);
+    return Promise.resolve();
+  }
+
+  list<T>({ prefix = "" }: { prefix?: string } = {}): Promise<Map<string, T>> {
+    return Promise.resolve(
+      new Map(
+        [...this.values]
+          .filter(([key]) => key.startsWith(prefix))
+          .map(([key, value]) => [key, value as T]),
+      ),
+    );
+  }
+
+  take<T>(key: string): Promise<T | undefined> {
+    const value = this.values.get(key) as T | undefined;
+    this.values.delete(key);
+    return Promise.resolve(value);
+  }
+
+  serialized(): string {
+    return JSON.stringify([...this.values]);
+  }
+}
+
+class MemoryRuntime implements CoordinatorRuntime {
+  readonly storage = new MemoryStorage();
+  readonly ephemeralWebSocketMaxPayloadBytes = 1024 * 1024;
+  private exclusive = Promise.resolve();
+
+  async runExclusive<T>(callback: () => Promise<T>): Promise<T> {
+    const previous = this.exclusive;
+    let release!: () => void;
+    this.exclusive = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    try {
+      return await callback();
+    } finally {
+      release();
+    }
+  }
+
+  createWebSocketUpgrade(_options?: CoordinatorWebSocketUpgradeOptions): never {
+    throw new Error("websocket upgrade is not expected");
+  }
+
+  getWebSockets(): Iterable<WebSocket> {
+    return [];
+  }
+
+  socketAttachment<T>(_socket: WebSocket): T | undefined {
+    return undefined;
+  }
+
+  setSocketAttachment(_socket: WebSocket, _attachment: unknown): void {}
+
+  acceptWebSocket(
+    _socket: WebSocket,
+    _attachment: unknown,
+    _tags: string[],
+    _handlers: CoordinatorSocketHandlers,
+  ): void {}
+
+  acceptEphemeralWebSocket(_socket: WebSocket, _handlers: CoordinatorSocketHandlers): void {}
+
+  take<T>(key: string): Promise<T | undefined> {
+    return this.storage.take<T>(key);
+  }
+
+  getAlarm(): Promise<number | undefined> {
+    return Promise.resolve(undefined);
+  }
+
+  scheduleAlarm(_time: number): Promise<void> {
+    return Promise.resolve();
+  }
+
+  clearAlarm(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+interface PairingFixture {
+  env: Env;
+  runtime: MemoryRuntime;
+  request(
+    path: string,
+    init?: RequestInit,
+    requestOrigin?: string,
+    destinationOrigin?: string,
+  ): Promise<Response>;
+  ownerRequest(path: string, init?: RequestInit, requestOrigin?: string): Promise<Response>;
+  pair(name?: string): Promise<{ deviceID: string; grant: string; token: string }>;
+}
+
+describe("coordinator device pairing", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("exchanges an owner grant for a read-only token and reuses lease visibility", async () => {
+    const fixture = pairingFixture();
+    await seedLease(fixture.runtime, lease("cbx_000000000001", owner));
+    await seedLease(
+      fixture.runtime,
+      lease("cbx_000000000002", "bob@example.com", { users: { [owner]: "use" } }),
+    );
+    await seedLease(fixture.runtime, lease("cbx_000000000003", "carol@example.com"));
+
+    const { deviceID, grant, token } = await fixture.pair("Alice's phone");
+    expect(fixture.runtime.storage.serialized()).not.toContain(grant);
+    expect(fixture.runtime.storage.serialized()).not.toContain(token);
+
+    const list = await fixture.request("/v1/leases", deviceRequest(token));
+    expect(list.status).toBe(200);
+    const listBody = (await list.json()) as { leases: LeaseRecord[] };
+    expect(listBody.leases.map((item) => item.id).toSorted()).toEqual([
+      "cbx_000000000001",
+      "cbx_000000000002",
+    ]);
+
+    const inspect = await fixture.request("/v1/leases/cbx_000000000002", deviceRequest(token));
+    expect(inspect.status).toBe(200);
+    await expect(inspect.json()).resolves.toMatchObject({
+      lease: { id: "cbx_000000000002", owner: "bob@example.com" },
+    });
+
+    const devices = await fixture.ownerRequest("/v1/devices");
+    expect(devices.status).toBe(200);
+    expect(devices.headers.get("cache-control")).toBe("no-store");
+    const deviceText = await devices.text();
+    expect(deviceText).not.toContain(token);
+    expect(JSON.parse(deviceText)).toEqual({
+      devices: [
+        expect.objectContaining({
+          id: deviceID,
+          audience: "crabbox-device",
+          scope: ["leases:read"],
+          name: "Alice's phone",
+        }),
+      ],
+    });
+  });
+
+  it("expires grants, consumes successful grants once, and rejects replay", async () => {
+    vi.useFakeTimers({ now: new Date("2026-07-27T12:00:00Z") });
+    const fixture = pairingFixture();
+    const expiredGrant = await issueGrant(fixture);
+    await vi.advanceTimersByTimeAsync(pairingGrantTTLSeconds * 1000 + 1);
+
+    const expired = await exchangeGrant(fixture, expiredGrant);
+    expect(expired.status).toBe(401);
+    await expect(expired.json()).resolves.toEqual({ error: "pairing_grant_expired" });
+
+    const liveGrant = await issueGrant(fixture);
+    const accepted = await exchangeGrant(fixture, liveGrant);
+    expect(accepted.status).toBe(200);
+    const replayed = await exchangeGrant(fixture, liveGrant);
+    expect(replayed.status).toBe(401);
+    await expect(replayed.json()).resolves.toEqual({ error: "pairing_grant_invalid" });
+  });
+
+  it("revokes individual devices and all owner devices immediately", async () => {
+    const fixture = pairingFixture();
+    await seedLease(fixture.runtime, lease("cbx_000000000001", owner));
+    const first = await fixture.pair("First phone");
+    const second = await fixture.pair("Second phone");
+
+    const revokeOne = await fixture.ownerRequest(`/v1/devices/${first.deviceID}`, {
+      method: "DELETE",
+    });
+    expect(revokeOne.status).toBe(204);
+    expect((await fixture.request("/v1/leases", deviceRequest(first.token))).status).toBe(401);
+    expect((await fixture.request("/v1/leases", deviceRequest(second.token))).status).toBe(200);
+
+    const revokeAll = await fixture.ownerRequest("/v1/devices", { method: "DELETE" });
+    expect(revokeAll.status).toBe(200);
+    await expect(revokeAll.json()).resolves.toEqual({ revoked: 1 });
+    expect((await fixture.request("/v1/leases", deviceRequest(second.token))).status).toBe(401);
+  });
+
+  it("expires device tokens and removes their stored verifier", async () => {
+    vi.useFakeTimers({ now: new Date("2026-07-27T12:00:00Z") });
+    const fixture = pairingFixture();
+    const { token } = await fixture.pair();
+    await vi.advanceTimersByTimeAsync(deviceTokenTTLSeconds * 1000 + 1);
+
+    const expired = await fixture.request("/v1/leases", deviceRequest(token));
+    expect(expired.status).toBe(401);
+    await expect(expired.json()).resolves.toEqual({ error: "device_token_expired" });
+    expect(fixture.runtime.storage.serialized()).not.toContain("device-token:");
+  });
+
+  it.each([
+    ["create lease", "/v1/leases", "POST"],
+    ["release lease", "/v1/leases/cbx_000000000001/release", "POST"],
+    ["change sharing", "/v1/leases/cbx_000000000001/share", "PUT"],
+    ["read admin data", "/v1/admin/leases", "GET"],
+    ["read other APIs", "/v1/whoami", "GET"],
+    [
+      "request authoritative metadata",
+      "/v1/leases/cbx_000000000001?providerMetadata=authoritative",
+      "GET",
+    ],
+  ])("returns 403 when a device token attempts to %s", async (_label, path, method) => {
+    const fixture = pairingFixture();
+    const { token } = await fixture.pair();
+    const response = await fixture.request(path, deviceRequest(token, method));
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({ error: "device_scope_forbidden" });
+  });
+
+  it("rejects forged and non-canonical device credentials", async () => {
+    const fixture = pairingFixture();
+    const { token } = await fixture.pair();
+    const [prefix, secret] = token.split(".") as [string, string];
+    const deviceID = prefix.slice("cbxd_".length);
+    const forgeries = [
+      `${prefix}.${secret.slice(0, -1)}${secret.endsWith("A") ? "B" : "A"}`,
+      `cbxd_${crypto.randomUUID()}.${secret}`,
+      `${token}.ignored`,
+      `cbxd_${deviceID.toUpperCase()}.${secret}`,
+    ];
+
+    const responses = await Promise.all(
+      forgeries.map((forgery) => fixture.request("/v1/leases", deviceRequest(forgery))),
+    );
+    await Promise.all(
+      responses.map(async (response) => {
+        expect(response.status).toBe(401);
+        await expect(response.json()).resolves.toEqual({ error: "device_token_invalid" });
+      }),
+    );
+  });
+
+  it("requires the exact configured origin without redirecting credentials", async () => {
+    const fixture = pairingFixture();
+    const missingOrigin = await fixture.ownerRequest(
+      "/v1/pairing/grants",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{}",
+      },
+      "",
+    );
+    expect(missingOrigin.status).toBe(403);
+
+    const wrongBrowserOrigin = await fixture.ownerRequest(
+      "/v1/pairing/grants",
+      { method: "POST", headers: { "content-type": "application/json" }, body: "{}" },
+      "https://evil.example.test",
+    );
+    expect(wrongBrowserOrigin.status).toBe(403);
+
+    const grant = await issueGrant(fixture);
+    const wrongDestination = await fixture.request(
+      "/v1/pairing/exchange",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json", origin },
+        body: JSON.stringify({ grant }),
+      },
+      origin,
+      "https://alias.example.test",
+    );
+    expect(wrongDestination.status).toBe(403);
+    expect(wrongDestination.headers.get("location")).toBeNull();
+
+    const { token } = await fixture.pair();
+    const wrongAPIOrigin = await fixture.request(
+      "/v1/leases",
+      deviceRequest(token, "GET", "https://evil.example.test"),
+    );
+    expect(wrongAPIOrigin.status).toBe(403);
+  });
+
+  it("fails closed after lease sharing changes and isolates device management by owner", async () => {
+    const fixture = pairingFixture();
+    const shared = lease("cbx_000000000001", "bob@example.com", {
+      users: { [owner]: "use" },
+    });
+    await seedLease(fixture.runtime, shared);
+    const { deviceID, token } = await fixture.pair();
+    expect((await fixture.request(`/v1/leases/${shared.id}`, deviceRequest(token))).status).toBe(
+      200,
+    );
+
+    shared.share = { users: {} };
+    await seedLease(fixture.runtime, shared);
+    expect((await fixture.request(`/v1/leases/${shared.id}`, deviceRequest(token))).status).toBe(
+      404,
+    );
+
+    const bob = pairingFixture(fixture.runtime, "bob@example.com");
+    const bobDevices = await bob.ownerRequest("/v1/devices");
+    await expect(bobDevices.json()).resolves.toEqual({ devices: [] });
+    expect((await bob.ownerRequest(`/v1/devices/${deviceID}`, { method: "DELETE" })).status).toBe(
+      404,
+    );
+    expect((await fixture.request("/v1/leases", deviceRequest(token))).status).toBe(200);
+  });
+
+  it("requires a non-admin owner session to issue pairing grants", async () => {
+    const fixture = pairingFixture();
+    const anonymous = await fixture.request("/v1/pairing/grants", jsonPost({}));
+    expect(anonymous.status).toBe(401);
+
+    const admin = await fixture.request("/v1/pairing/grants", {
+      ...jsonPost({}),
+      headers: {
+        ...jsonPost({}).headers,
+        authorization: "Bearer admin-token",
+        origin,
+      },
+    });
+    expect(admin.status).toBe(403);
+    await expect(admin.json()).resolves.toEqual({ error: "owner_session_required" });
+  });
+});
+
+function pairingFixture(
+  existingRuntime = new MemoryRuntime(),
+  sharedOwner = owner,
+): PairingFixture {
+  const env = {
+    CRABBOX_PUBLIC_URL: origin,
+    CRABBOX_SHARED_TOKEN: "owner-token",
+    CRABBOX_SHARED_OWNER: sharedOwner,
+    CRABBOX_ADMIN_TOKEN: "admin-token",
+    CRABBOX_DEFAULT_ORG: org,
+  } as Env;
+  const fleet = new FleetCoordinator(existingRuntime, env);
+  const request = async (
+    path: string,
+    init: RequestInit = {},
+    requestOrigin = origin,
+    destinationOrigin = origin,
+  ): Promise<Response> =>
+    await routeCoordinatorRequest(
+      new Request(`${destinationOrigin}${path}`, init),
+      env,
+      async (prepared) => await fleet.fetch(prepared),
+    );
+  const ownerRequest = async (
+    path: string,
+    init: RequestInit = {},
+    requestOrigin = origin,
+  ): Promise<Response> => {
+    const headers = new Headers(init.headers);
+    headers.set("authorization", "Bearer owner-token");
+    if (requestOrigin) headers.set("origin", requestOrigin);
+    return await request(path, { ...init, headers });
+  };
+  const fixture: PairingFixture = {
+    env,
+    runtime: existingRuntime,
+    request,
+    ownerRequest,
+    async pair(name?: string) {
+      const grant = await issueGrant(fixture, name);
+      const response = await exchangeGrant(fixture, grant);
+      expect(response.status).toBe(200);
+      expect(response.headers.get("cache-control")).toBe("no-store");
+      const body = (await response.json()) as { device: { id: string }; token: string };
+      expect(body.token).toMatch(/^cbxd_/);
+      return { deviceID: body.device.id, grant, token: body.token };
+    },
+  };
+  return fixture;
+}
+
+async function issueGrant(fixture: PairingFixture, name?: string): Promise<string> {
+  const response = await fixture.ownerRequest("/v1/pairing/grants", jsonPost({ name }));
+  expect(response.status).toBe(200);
+  expect(response.headers.get("cache-control")).toBe("no-store");
+  const body = (await response.json()) as { grant: string };
+  expect(body.grant).toMatch(/^cbxp_/);
+  return body.grant;
+}
+
+async function exchangeGrant(fixture: PairingFixture, grant: string): Promise<Response> {
+  return await fixture.request("/v1/pairing/exchange", jsonPost({ grant }));
+}
+
+function jsonPost(body: unknown): RequestInit {
+  return {
+    method: "POST",
+    headers: { "content-type": "application/json", origin },
+    body: JSON.stringify(body),
+  };
+}
+
+function deviceRequest(token: string, method = "GET", requestOrigin = origin): RequestInit {
+  return { method, headers: { authorization: `Bearer ${token}`, origin: requestOrigin } };
+}
+
+async function seedLease(runtime: MemoryRuntime, value: LeaseRecord): Promise<void> {
+  await runtime.storage.put(`lease:${value.id}`, value);
+}
+
+function lease(id: string, leaseOwner: string, share?: LeaseRecord["share"]): LeaseRecord {
+  const now = new Date().toISOString();
+  return {
+    id,
+    provider: "external",
+    lifecycle: "registered",
+    target: "linux",
+    cloudID: `external-${id}`,
+    owner: leaseOwner,
+    org: orgKeyForLabel(org),
+    ...(share ? { share } : {}),
+    profile: "default",
+    class: "default",
+    serverType: "external",
+    serverID: 0,
+    serverName: id,
+    providerKey: `external-${id}`,
+    host: "127.0.0.1",
+    sshUser: "crabbox",
+    sshPort: "22",
+    workRoot: "/work/crabbox",
+    keep: true,
+    ttlSeconds: 3600,
+    estimatedHourlyUSD: 0,
+    maxEstimatedUSD: 0,
+    state: "active",
+    createdAt: now,
+    updatedAt: now,
+    expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+  };
+}

--- a/worker/test/pairing.test.ts
+++ b/worker/test/pairing.test.ts
@@ -26,6 +26,7 @@ const org = "example-org";
 
 class MemoryStorage implements CoordinatorStorage {
   private readonly values = new Map<string, unknown>();
+  deleteFailureKey?: string;
   writes = 0;
   readonly listPrefixes: string[] = [];
 
@@ -41,6 +42,7 @@ class MemoryStorage implements CoordinatorStorage {
 
   delete(key: string): Promise<void> {
     this.writes += 1;
+    if (key === this.deleteFailureKey) return Promise.reject(new Error("injected delete failure"));
     this.values.delete(key);
     return Promise.resolve();
   }
@@ -310,6 +312,23 @@ describe("coordinator device pairing", () => {
     expect((await fixture.request("/v1/leases", deviceRequest(second.token))).status).toBe(401);
   });
 
+  it("keeps a device indexed when verifier deletion fails", async () => {
+    const fixture = await pairingFixture();
+    const { deviceID, token } = await fixture.pair();
+    fixture.runtime.storage.deleteFailureKey = `device-token:${deviceID}`;
+
+    const failed = await fixture.ownerRequest(`/v1/devices/${deviceID}`, { method: "DELETE" });
+    expect(failed.status).toBe(500);
+    expect(fixture.runtime.storage.serialized()).toContain(`device-token:${deviceID}`);
+    expect(fixture.runtime.storage.serialized()).toContain("device-owner:");
+
+    fixture.runtime.storage.deleteFailureKey = undefined;
+    expect(
+      (await fixture.ownerRequest(`/v1/devices/${deviceID}`, { method: "DELETE" })).status,
+    ).toBe(204);
+    expect((await fixture.request("/v1/leases", deviceRequest(token))).status).toBe(401);
+  });
+
   it("expires device tokens without mutating storage from the device request", async () => {
     vi.useFakeTimers({ now: new Date("2026-07-27T12:00:00Z") });
     const fixture = await pairingFixture();
@@ -466,6 +485,35 @@ describe("coordinator device pairing", () => {
     });
     expect(admin.status).toBe(403);
     await expect(admin.json()).resolves.toEqual({ error: "owner_session_required" });
+  });
+
+  it("preserves configured bearer precedence for device-shaped static tokens", async () => {
+    const fixture = await pairingFixture();
+    const configured = `cbxd_${crypto.randomUUID()}.${"A".repeat(43)}`;
+    fixture.env.CRABBOX_SHARED_TOKEN = configured;
+
+    const response = await fixture.request("/v1/leases", deviceRequest(configured));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ leases: [] });
+  });
+
+  it("ignores forged fleet-auth headers on device-shaped credentials", async () => {
+    const fixture = await pairingFixture();
+    const forged = `cbxd_${crypto.randomUUID()}.${"B".repeat(43)}`;
+
+    const response = await fixture.request("/v1/leases", {
+      headers: {
+        authorization: `Bearer ${forged}`,
+        origin,
+        "x-crabbox-auth": "bearer",
+        "x-crabbox-owner": owner,
+        "x-crabbox-org": org,
+      },
+    });
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: "device_token_invalid" });
   });
 
   it("caps active devices per owner", async () => {


### PR DESCRIPTION
## Summary

- add five-minute, owner-bound, single-use pairing grants initiated only by a cryptographically distinct `cbwp_` portal browser session
- issue hash-only, individually revocable device credentials with a distinct `crabbox-device` audience, `leases:read` scope, and maximum 90-day lifetime
- enforce a hard device principal throughout lease authorization: device reads use an explicit credential-free status projection and never refresh provider access, call a provider adapter, or write lease state
- revalidate the paired immutable GitHub owner and allowed org/team membership without the normal positive cache on every device request
- use atomic, owner/org-scoped grant/device indexes with limits of 10 active grants and 10 active devices; verifier-first revocation remains discoverable and retryable after partial storage failure
- document the endpoints, lifecycle, revocation, caps, origin policy, and threat model in [Read-Only Device Pairing](https://github.com/openclaw/crabbox/blob/codex/778-pairing/docs/features/device-pairing.md)

Closes no issue. Implements the server-side slice of https://github.com/openclaw/crabbox/issues/778.

## Threat model

A device token is never a synonym for its owner. The owner/org is used only as the subject for current lease visibility. Device authentication maps to a distinct `device` lease role that is never manageable, provider-access-visible, portal-capable, or admin-capable. Before normal routing, device credentials are limited to:

```text
GET /v1/leases
GET /v1/leases/{id-or-slug}
```

Both responses use an explicit status-only projection. SSH host/user/port/work-root values are marked `<redacted>`; fallback ports, host keys, provider-access expiry, Tailscale access, shares, and provider-internal access fields are omitted. Detail reads bypass provider access refresh entirely and perform no provider mutation or coordinator-state write. Every create/run/heartbeat/stop/release/share/bridge/admin/authoritative-metadata route returns `403 device_scope_forbidden` before dispatch.

Pairing initiation requires the `cbwp_` audience produced by the coordinator's bound portal OAuth flow. Normal API authentication rejects `cbwp_`; a `cbxu_` user bearer copied into a Cookie header remains non-pairing authority. Pairing grants are atomically consumed once after five minutes at most. The server stores credential hashes and a sealed GitHub revalidation grant, never raw device credentials. Every device request performs a fresh GitHub account/org/team check; removal or GitHub failure returns `401`.

Grant and device records have bounded owner/org indexes. Atomic critical sections enforce the caps under concurrent requests. Revocation deletes the verifier before its index, so a failed delete leaves the credential indexed for retry; successful individual/all-device revocation fails the next request closed. Current lease owner/share state is evaluated on every read. Configured admin/shared/runtime-adapter tokens retain precedence even when their text begins with `cbxd_`.

Pairing, exchange, device lease reads, and revocation require the exact configured destination and exact `Origin`; same-origin read-only `GET /v1/devices` permits the browser's normal missing Origin but rejects a different supplied Origin. Credential-bearing routes never redirect across origins. Pairing grants and device tokens remain out of URLs, argv, logs, analytics, crash text, repository config, and proof output.

## Verification

```text
npm ci --prefix worker
npm run format:check --prefix worker
npm run lint --prefix worker
npm run check --prefix worker
npm test --prefix worker
npm run build --prefix worker

Test Files  36 passed | 2 skipped (38)
Tests       1127 passed | 3 skipped (1130)
wrangler deploy --dry-run: success
```

```text
scripts/check-docs.sh

checked 238 markdown files: internal links ok
generated docs tests: 14 passed
```

The prior Go-only gate remains valid because this update changes only Worker and documentation code. Its cumulative Blacksmith proof is recorded in runs https://github.com/openclaw/crabbox/actions/runs/30328614203 and https://github.com/openclaw/crabbox/actions/runs/30329270415: vet passed, all race packages/tests passed after isolating the Testbox XDG permission fixture, and the real CLI build passed.

Local `wrangler dev` proof used a real active GitHub/org membership with one-hour proof sessions. All credential values were kept off argv and redacted:

```text
registration=201
signed API bearer pairing=403 {"error":"owner_session_required"}
portal browser grant=200
grant exchange=200
device list without Origin=200
device lease list=200
device detail=200 {"host":"<redacted>","sshUser":"<redacted>","sshPort":"<redacted>","workRoot":"<redacted>"}
device release attempt=403 {"error":"device_scope_forbidden"}
device revoke=204
revoked token access=401 {"error":"device_token_invalid"}
```

Failure-injection and concurrency tests additionally prove:

- detail performs zero provider fetches and zero storage writes;
- removed GitHub membership fails the next device request;
- 11 concurrent grants yield exactly 10 successes;
- two concurrent exchanges at nine devices yield one success and one `409`;
- verifier deletion failure retains the owner index for a successful retry;
- device-shaped configured static tokens preserve their existing authentication behavior;
- forged fleet-auth headers cannot bypass device verifier checks.

Autoreview: clean on the full exact branch diff, no accepted/actionable findings.
