### PR TITLE
fix: harden coordinator diagnostics and inherited listeners

### DIFF
--- a/internal/cli/webvnc_lock_unix.go
+++ b/internal/cli/webvnc_lock_unix.go
@@ -34,11 +34,11 @@ func forwardInheritedWebVNCDaemonPortReservation(cmd *exec.Cmd) (func(), error) 
 	if port == "" && descriptor == "" {
 		return func() {}, nil
 	}
-	fd, err := strconv.ParseUint(descriptor, 10, strconv.IntSize)
+	fd, err := strconv.Atoi(descriptor)
 	if err != nil || fd <= 2 {
 		return nil, fmt.Errorf("inherited WebVNC daemon TCP listener descriptor is invalid")
 	}
-	duplicate, err := unix.Dup(int(fd))
+	duplicate, err := unix.Dup(fd)
 	if err != nil {
 		return nil, fmt.Errorf("duplicate inherited WebVNC daemon TCP listener: %w", err)
 	}

--- a/scripts/build-docs-site.test.js
+++ b/scripts/build-docs-site.test.js
@@ -158,8 +158,8 @@ generatedTest("generated AWS page is active in Providers navigation and pager", 
   const next = providerOutput(providerMarkdown[awsIndex + 1]);
   const pager = element(html, "nav", /class="page-nav"/);
 
-  assert.match(pager, new RegExp(`href="\.\./providers/${escapeRegExp(previous)}"`));
-  assert.match(pager, new RegExp(`href="\.\./providers/${escapeRegExp(next)}"`));
+  assert.match(pager, new RegExp(escapeRegExp(`href="../providers/${previous}"`)));
+  assert.match(pager, new RegExp(escapeRegExp(`href="../providers/${next}"`)));
 });
 
 generatedTest("homepage presents use-case, pricing, and onboarding paths", () => {

--- a/worker/node/server.ts
+++ b/worker/node/server.ts
@@ -147,8 +147,8 @@ async function handleRequest(request: IncomingMessage, response: ServerResponse)
 server.on("upgrade", (request, socket, head) => {
   void activeRequests
     .run(() => handleUpgrade(request, socket, head))
-    .catch((error) => {
-      console.error("coordinator websocket upgrade handler failed", error);
+    .catch(() => {
+      console.error("coordinator websocket upgrade handler failed");
       socket.destroy();
     });
 });


### PR DESCRIPTION
## What Problem This Solves

Resolves issues where coordinator WebSocket upgrade failures could emit provider-backed error details, inherited WebVNC descriptors crossed an unnecessary narrowing conversion, and docs pager tests treated literal dots as regex wildcards.

## Why This Change Was Made

The coordinator now logs only stable context for outer upgrade failures, inherited descriptors are parsed directly as native integers before duplication, and pager assertions escape the complete expected link. Test-only shell findings were separately dismissed because their values are passed as quoted positional arguments rather than interpolated shell source.

## User Impact

Operators get safer coordinator logs and inherited WebVNC listener forwarding retains the same behavior without conversion ambiguity. There is no docs UI change.

## Evidence

- `go test ./internal/cli -run 'TestWebVNCDaemon(SupervisorForwardsFreshListenerDuplicatePerRestart|InheritedTCPListenerAcceptsConnection)$' -count=1`\n- `node --test scripts/build-docs-site.test.js` (11 passed)\n- `npm run check:node`\n- `npm run format:check -- node/server.ts`\n- `git diff --check`\n- autoreview: clean, no accepted/actionable findings