### PR TITLE
fix(runpod): make new pods accept the configured SSH key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 
 - Kept ready-pool reconciliation rollout-compatible with older CLIs and coordinators, preserved unexpired in-flight claims across policy changes, and required actual ready capacity for `pool ensure` success.
+- Authorized RunPod SSH access with the configured public key while rejecting missing, empty, or invalid key files before creating a paid pod. Thanks @morluto.
 
 ## 0.40.1 - 2026-07-23
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -341,7 +341,7 @@ func (a App) doctor(ctx context.Context, args []string) error {
 		if _, err := os.Stat(cfg.SSHKey); err != nil {
 			record("missing", "ssh-key", cfg.SSHKey, map[string]string{"path": cfg.SSHKey})
 			ok = false
-		} else if _, err := publicKeyFor(cfg.SSHKey); err != nil {
+		} else if _, err := PublicKeyFor(cfg.SSHKey); err != nil {
 			record("missing", "ssh-key", cfg.SSHKey+".pub", map[string]string{"path": cfg.SSHKey + ".pub"})
 			ok = false
 		} else {

--- a/internal/cli/lease.go
+++ b/internal/cli/lease.go
@@ -27,7 +27,10 @@ func newRunID() string {
 	return "run_" + strings.TrimPrefix(newLeaseID(), "cbx_")
 }
 
-func publicKeyFor(privatePath string) (string, error) {
+func PublicKeyFor(privatePath string) (string, error) {
+	if strings.TrimSpace(privatePath) == "" {
+		return "", exit(2, "ssh key path is not configured")
+	}
 	pub := privatePath + ".pub"
 	data, err := os.ReadFile(pub)
 	if err != nil {
@@ -37,7 +40,23 @@ func publicKeyFor(privatePath string) (string, error) {
 	if key == "" {
 		return "", exit(2, "ssh public key %s is empty", pub)
 	}
+	if !LooksLikeInlineSSHPublicKey(key) {
+		return "", exit(2, "ssh public key %s is not a supported OpenSSH public key", pub)
+	}
 	return key, nil
+}
+
+func LooksLikeInlineSSHPublicKey(value string) bool {
+	fields := strings.Fields(value)
+	if len(fields) < 2 {
+		return false
+	}
+	switch fields[0] {
+	case "ssh-ed25519", "ssh-rsa", "ecdsa-sha2-nistp256", "ecdsa-sha2-nistp384", "ecdsa-sha2-nistp521", "sk-ssh-ed25519@openssh.com", "sk-ecdsa-sha2-nistp256@openssh.com":
+		return true
+	default:
+		return false
+	}
 }
 
 func testboxKeyPath(leaseID string) (string, error) {
@@ -80,7 +99,7 @@ func ensureTestboxKeyWithType(leaseID, keyType string) (string, string, error) {
 		return "", "", err
 	}
 	if _, err := os.Stat(privatePath); err == nil {
-		publicKey, err := publicKeyFor(privatePath)
+		publicKey, err := PublicKeyFor(privatePath)
 		return privatePath, publicKey, err
 	}
 	if err := os.MkdirAll(filepath.Dir(privatePath), 0o700); err != nil {
@@ -94,7 +113,7 @@ func ensureTestboxKeyWithType(leaseID, keyType string) (string, string, error) {
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return "", "", exit(2, "generate ssh key for %s: %v: %s", leaseID, err, strings.TrimSpace(string(out)))
 	}
-	publicKey, err := publicKeyFor(privatePath)
+	publicKey, err := PublicKeyFor(privatePath)
 	return privatePath, publicKey, err
 }
 

--- a/internal/providers/kubevirt/backend.go
+++ b/internal/providers/kubevirt/backend.go
@@ -571,7 +571,7 @@ func (b *leaseBackend) sshKey(leaseID string) (string, string, error) {
 
 func kubeVirtPublicKeyValue(value string) (string, error) {
 	value = strings.TrimSpace(value)
-	if value == "" || looksLikeInlineSSHPublicKey(value) {
+	if value == "" || core.LooksLikeInlineSSHPublicKey(value) {
 		return value, nil
 	}
 	if publicKey, err := readKubeVirtPublicKeyFile(value); err == nil {
@@ -591,23 +591,10 @@ func readKubeVirtPublicKeyFile(path string) (string, error) {
 	if publicKey == "" {
 		return "", core.Exit(2, "KubeVirt SSH public key %s is empty", path)
 	}
-	if !looksLikeInlineSSHPublicKey(publicKey) {
+	if !core.LooksLikeInlineSSHPublicKey(publicKey) {
 		return "", core.Exit(2, "KubeVirt SSH public key %s is not a supported OpenSSH public key", path)
 	}
 	return publicKey, nil
-}
-
-func looksLikeInlineSSHPublicKey(value string) bool {
-	fields := strings.Fields(value)
-	if len(fields) < 2 {
-		return false
-	}
-	switch fields[0] {
-	case "ssh-ed25519", "ssh-rsa", "ecdsa-sha2-nistp256", "ecdsa-sha2-nistp384", "ecdsa-sha2-nistp521", "sk-ssh-ed25519@openssh.com", "sk-ecdsa-sha2-nistp256@openssh.com":
-		return true
-	default:
-		return false
-	}
 }
 
 func looksLikePublicKeyPath(value string) bool {

--- a/internal/providers/runpod/backend.go
+++ b/internal/providers/runpod/backend.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -89,6 +90,10 @@ func (b *runpodLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (L
 	fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s name=%s image=%s instance=%s disk=%dGB keep=%v\n",
 		providerName, leaseID, slug, name, cfg.Runpod.Image, cfg.Runpod.InstanceID, cfg.Runpod.DiskGB, req.Keep)
 
+	publicKey, err := runpodPublicKey(cfg.SSHKey)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
 	pod, err := client.DeployPod(ctx, runpodDeployInput{
 		Name:              name,
 		ImageName:         cfg.Runpod.Image,
@@ -97,7 +102,7 @@ func (b *runpodLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (L
 		TemplateID:        cfg.Runpod.TemplateID,
 		ContainerDiskInGb: cfg.Runpod.DiskGB,
 		Ports:             "22/tcp",
-		StartSSH:          true,
+		PublicKey:         publicKey,
 	})
 	if err != nil {
 		return LeaseTarget{}, exit(1, "runpod create pod failed: %v", err)
@@ -132,6 +137,19 @@ func (b *runpodLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (L
 	}
 	fmt.Fprintf(b.rt.Stderr, "provisioned lease=%s pod=%s state=ready\n", leaseID, pod.ID)
 	return lease, nil
+}
+
+func runpodPublicKey(privatePath string) (string, error) {
+	path := privatePath + ".pub"
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", exit(2, "read ssh public key %s: %v", path, err)
+	}
+	publicKey := strings.TrimSpace(string(data))
+	if publicKey == "" {
+		return "", exit(2, "ssh public key %s is empty", path)
+	}
+	return publicKey, nil
 }
 
 func (b *runpodLeaseBackend) cleanupFailedAcquire(client runpodAPI, podID string, cause error) error {

--- a/internal/providers/runpod/backend.go
+++ b/internal/providers/runpod/backend.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
-	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -90,7 +89,7 @@ func (b *runpodLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (L
 	fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s name=%s image=%s instance=%s disk=%dGB keep=%v\n",
 		providerName, leaseID, slug, name, cfg.Runpod.Image, cfg.Runpod.InstanceID, cfg.Runpod.DiskGB, req.Keep)
 
-	publicKey, err := runpodPublicKey(cfg.SSHKey)
+	publicKey, err := publicKeyFor(cfg.SSHKey)
 	if err != nil {
 		return LeaseTarget{}, err
 	}
@@ -137,19 +136,6 @@ func (b *runpodLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (L
 	}
 	fmt.Fprintf(b.rt.Stderr, "provisioned lease=%s pod=%s state=ready\n", leaseID, pod.ID)
 	return lease, nil
-}
-
-func runpodPublicKey(privatePath string) (string, error) {
-	path := privatePath + ".pub"
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return "", exit(2, "read ssh public key %s: %v", path, err)
-	}
-	publicKey := strings.TrimSpace(string(data))
-	if publicKey == "" {
-		return "", exit(2, "ssh public key %s is empty", path)
-	}
-	return publicKey, nil
 }
 
 func (b *runpodLeaseBackend) cleanupFailedAcquire(client runpodAPI, podID string, cause error) error {

--- a/internal/providers/runpod/backend_test.go
+++ b/internal/providers/runpod/backend_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -220,6 +221,26 @@ func TestRunpodDeployPayloadUsesGPUAvailabilityPriority(t *testing.T) {
 	}
 }
 
+func TestRunpodDeployPayloadSerializesSSHPublicKey(t *testing.T) {
+	payload := runpodDeployPayload(runpodDeployInput{
+		InstanceID: "NVIDIA L4",
+		PublicKey:  testRunpodPublicKey,
+	})
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded struct {
+		Env map[string]string `json:"env"`
+	}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Env["PUBLIC_KEY"] != testRunpodPublicKey {
+		t.Fatalf("serialized PUBLIC_KEY=%q, want configured key", decoded.Env["PUBLIC_KEY"])
+	}
+}
+
 func TestRunpodSSHTargetUsesPublicPortAndUser(t *testing.T) {
 	cfg := Config{Runpod: RunpodConfig{User: "root", WorkRoot: "/tmp/crabbox"}}
 	applyRunpodDefaults(&cfg)
@@ -331,6 +352,23 @@ type fakeRunpodAPI struct {
 	deployPod    runpodPod
 }
 
+const testRunpodPublicKey = "ssh-ed25519 AAAATEST crabbox-runpod-test"
+
+func testRunpodConfig(t *testing.T) Config {
+	t.Helper()
+	keyPath := t.TempDir() + "/id_ed25519"
+	if err := os.WriteFile(keyPath+".pub", []byte(testRunpodPublicKey+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return Config{
+		SSHKey: keyPath,
+		Runpod: RunpodConfig{
+			APIKey:     "test-key",
+			InstanceID: "NVIDIA L4",
+		},
+	}
+}
+
 func (f *fakeRunpodAPI) Whoami(_ context.Context) (runpodMyself, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -369,6 +407,27 @@ func (f *fakeRunpodAPI) TerminatePod(ctx context.Context, podID string) error {
 		return terminatePod(ctx, podID)
 	}
 	return nil
+}
+
+func TestRunpodAcquireUsesConfiguredSSHPublicKey(t *testing.T) {
+	fake := &fakeRunpodAPI{
+		deployPod: runpodPod{ID: "pod_created"},
+		getPod: func(string) (runpodPod, error) {
+			return runpodPod{}, errors.New("stop after deploy")
+		},
+	}
+	backend := &runpodLeaseBackend{
+		cfg:    testRunpodConfig(t),
+		rt:     Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		client: fake,
+	}
+
+	if _, err := backend.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: t.TempDir()}}); err == nil {
+		t.Fatal("Acquire succeeded after the fake readiness failure")
+	}
+	if len(fake.deployCalls) != 1 || fake.deployCalls[0].PublicKey != testRunpodPublicKey {
+		t.Fatalf("deploy calls=%#v, want configured public key", fake.deployCalls)
+	}
 }
 
 func TestRunpodListFiltersCrabboxPodsByDefault(t *testing.T) {
@@ -456,7 +515,7 @@ func TestRunpodAcquireRollbackUsesBoundedCleanup(t *testing.T) {
 		},
 	}
 	backend := &runpodLeaseBackend{
-		cfg:                    Config{Runpod: RunpodConfig{APIKey: "k"}},
+		cfg:                    testRunpodConfig(t),
 		rt:                     Runtime{Stdout: io.Discard, Stderr: io.Discard},
 		client:                 fake,
 		pollInitialOverride:    time.Millisecond,
@@ -485,7 +544,7 @@ func TestRunpodAcquireRollbackCannotBlockForever(t *testing.T) {
 		},
 	}
 	backend := &runpodLeaseBackend{
-		cfg:                    Config{Runpod: RunpodConfig{APIKey: "k"}},
+		cfg:                    testRunpodConfig(t),
 		rt:                     Runtime{Stdout: io.Discard, Stderr: io.Discard},
 		client:                 fake,
 		pollInitialOverride:    time.Millisecond,
@@ -516,7 +575,7 @@ func TestRunpodAcquireRejectsMismatchedReadyPodAndRollsBack(t *testing.T) {
 		},
 	}
 	backend := &runpodLeaseBackend{
-		cfg:    Config{Runpod: RunpodConfig{APIKey: "k"}},
+		cfg:    testRunpodConfig(t),
 		rt:     Runtime{Stdout: io.Discard, Stderr: io.Discard},
 		client: fake,
 	}

--- a/internal/providers/runpod/backend_test.go
+++ b/internal/providers/runpod/backend_test.go
@@ -430,6 +430,75 @@ func TestRunpodAcquireUsesConfiguredSSHPublicKey(t *testing.T) {
 	}
 }
 
+func TestRunpodAcquireRejectsInvalidSSHPublicKeyBeforeDeploy(t *testing.T) {
+	tests := []struct {
+		name      string
+		configure func(*testing.T, *Config)
+		wantError string
+	}{
+		{
+			name: "unconfigured key path",
+			configure: func(_ *testing.T, cfg *Config) {
+				cfg.SSHKey = ""
+			},
+			wantError: "ssh key path is not configured",
+		},
+		{
+			name: "missing public key",
+			configure: func(t *testing.T, cfg *Config) {
+				t.Helper()
+				if err := os.Remove(cfg.SSHKey + ".pub"); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantError: "read ssh public key",
+		},
+		{
+			name: "empty public key",
+			configure: func(t *testing.T, cfg *Config) {
+				t.Helper()
+				if err := os.WriteFile(cfg.SSHKey+".pub", nil, 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantError: "is empty",
+		},
+		{
+			name: "private key material",
+			configure: func(t *testing.T, cfg *Config) {
+				t.Helper()
+				privateKey := "-----BEGIN OPENSSH PRIVATE KEY-----\nnot-a-public-key\n-----END OPENSSH PRIVATE KEY-----\n"
+				if err := os.WriteFile(cfg.SSHKey+".pub", []byte(privateKey), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantError: "is not a supported OpenSSH public key",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := testRunpodConfig(t)
+			test.configure(t, &cfg)
+			fake := &fakeRunpodAPI{}
+			backend := &runpodLeaseBackend{
+				cfg:    cfg,
+				rt:     Runtime{Stdout: io.Discard, Stderr: io.Discard},
+				client: fake,
+			}
+
+			_, err := backend.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: t.TempDir()}})
+			var exitErr core.ExitError
+			if err == nil || !core.AsExitError(err, &exitErr) || exitErr.Code != 2 || !strings.Contains(err.Error(), test.wantError) {
+				t.Fatalf("Acquire error=%v, want exit 2 containing %q", err, test.wantError)
+			}
+			if len(fake.deployCalls) != 0 {
+				t.Fatalf("deploy calls=%#v, want zero paid resources created", fake.deployCalls)
+			}
+		})
+	}
+}
+
 func TestRunpodListFiltersCrabboxPodsByDefault(t *testing.T) {
 	fake := &fakeRunpodAPI{listPods: []runpodPod{
 		{ID: "pod_a", Name: "crabbox-blue-12345678", DesiredStatus: "RUNNING"},

--- a/internal/providers/runpod/client.go
+++ b/internal/providers/runpod/client.go
@@ -112,7 +112,7 @@ type runpodDeployInput struct {
 	TemplateID        string
 	ContainerDiskInGb int
 	Ports             string
-	StartSSH          bool
+	PublicKey         string
 }
 
 func newRunpodClient(cfg Config, rt Runtime) (runpodAPI, error) {
@@ -271,6 +271,9 @@ func runpodDeployPayload(input runpodDeployInput) map[string]any {
 	}
 	if input.TemplateID != "" {
 		payload["templateId"] = input.TemplateID
+	}
+	if publicKey := strings.TrimSpace(input.PublicKey); publicKey != "" {
+		payload["env"] = map[string]string{"PUBLIC_KEY": publicKey}
 	}
 	instanceIDs := runpodInstanceIDs(input.InstanceID)
 	if strings.HasPrefix(strings.ToLower(instanceIDs[0]), "cpu") {

--- a/internal/providers/runpod/core.go
+++ b/internal/providers/runpod/core.go
@@ -51,6 +51,10 @@ func newLeaseID() string {
 	return core.NewLeaseID()
 }
 
+func publicKeyFor(privatePath string) (string, error) {
+	return core.PublicKeyFor(privatePath)
+}
+
 func newLeaseSlug(leaseID string) string {
 	return core.NewLeaseSlug(leaseID)
 }


### PR DESCRIPTION
Closes https://github.com/openclaw/crabbox/issues/1202

## What Problem This Solves

Fixes an issue where users provisioning RunPod leases with a configured `ssh.key` would receive a running pod with an exposed SSH port but no matching authorized key. The pod could report `PUBLIC_KEY` as `null`, leaving Crabbox's SSH readiness check unable to authenticate.

## Why This Change Was Made

The RunPod provider now reads the configured key's adjacent `.pub` file before creating the pod and serializes that exact value as `env.PUBLIC_KEY` in the `POST /pods` request. Missing or empty public-key files fail before the paid resource is created.

This keeps key ownership unchanged: the private key remains local, and only its public half is included in the provider request.

```text
ssh.key.pub
    |
    v
RunPod POST /pods
  env.PUBLIC_KEY
    |
    v
official image startup -> ~/.ssh/authorized_keys -> sshd
```

## User Impact

RunPod pods created by Crabbox can authorize the same SSH identity that Crabbox uses for readiness, sync, and command execution. Invalid local key configuration now fails before pod creation instead of producing an unreachable running lease.

## Evidence

- Two Crabbox 0.38.0 provisioning attempts reached `RUNNING` with public port 22 but could not authenticate; the pod environment showed `PUBLIC_KEY` as `null`.
- The regression test proves the configured `.pub` value reaches the acquire request and JSON serialization preserves it as `env.PUBLIC_KEY`.
- `go test ./internal/providers/runpod -count=1` — pass.
- `go test -race ./internal/providers/runpod ./internal/providers/all -count=1` — pass.
- `go vet ./internal/providers/runpod ./internal/providers/all` — pass.
- `go build -trimpath -o /tmp/crabbox-runpod-key-check ./cmd/crabbox` — pass.


## Live provider proof

Validated commit `1a3b1aabb466ef48bcbf46b500de9e6d594e1037` with the patched Crabbox binary and a disposable SSH key created only for this test.

The one-shot RunPod lease completed SSH readiness, repository sync, and a remote command:

```text
provider=runpod
lease_id=cbx_929b8e20f493
remote_command=CRABBOX_PR1203_LIVE_OK
exit_status=0
run_status=succeeded
lease_stopped=true
post_run_pod_count=0
```

The missing-sidecar preflight was also exercised with the disposable public-key file temporarily absent:

```text
exit_status=2
error=read SSH public key <redacted-path>.pub: no such file or directory
post_attempt_pod_count=0
```

The private key remained local. The evidence above omits the disposable key value, API credentials, host/IP, port, local paths, and provider endpoints. RunPod reported no remaining pods after either check.
