### PR TITLE
fix(worker): harden device token revalidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- Bounded device membership revalidation to one GitHub revalidation per token per minute while preserving immediate token revocation, fail-closed errors, and a distinct re-pairing response for expired OAuth grants.
 - Kept ready-pool reconciliation rollout-compatible with older CLIs and coordinators, preserved unexpired in-flight claims across policy changes, and required actual ready capacity for `pool ensure` success.
 
 ## 0.40.1 - 2026-07-23

--- a/docs/features/device-pairing.md
+++ b/docs/features/device-pairing.md
@@ -56,7 +56,11 @@ grants cannot mint a token. The coordinator allows at most 10 active grants and
 pairing another when the device limit is reached.
 
 A device token expires after at most 90 days and stops earlier if its paired
-browser authorization grant expires or can no longer be revalidated.
+browser authorization grant expires or can no longer be revalidated. When the
+stored OAuth grant has expired, been revoked, or can no longer be opened, the
+coordinator returns `401 pairing_reauth_required` so the companion can ask the
+user to pair again. Device-token revocation remains distinct and returns `401
+device_token_invalid`.
 
 Pairing codes and device tokens belong only in request bodies, the
 `Authorization` header, and the device's protected credential store. Do not put
@@ -66,10 +70,18 @@ repository configuration.
 ## Owner revalidation
 
 The coordinator stores the paired browser session's sealed GitHub authorization
-grant beside the token hash. Every device request performs a fresh, uncached
-check of the immutable GitHub account and its current allowed organization/team
-membership. GitHub errors, account mismatch, removed membership, revoked users,
-or a no-longer-allowed organization fail closed with `401`.
+grant beside the token hash. Every device request reads the durable token
+verifier, checks the sealed grant's expiry and readability, and applies current
+local revoked-user and allowed-organization policy. Successful remote GitHub
+account and organization/team membership checks are cached for 60 seconds per
+exact device token. The cache is bounded and never shared by devices, owners, or
+organizations.
+
+After a cache miss or expiry, GitHub errors, account mismatch, removed
+membership, revoked users, or a no-longer-allowed organization fail closed with
+`401`; a stale positive is never used as an error fallback. An expired or
+revoked OAuth credential returns `pairing_reauth_required`, while other owner
+authorization failures return `device_owner_unauthorized`.
 
 The sealed grant never reaches the device. Only a hash of the device token is
 stored, and the public device response contains no credential material.
@@ -86,7 +98,8 @@ DELETE /v1/devices       revoke all devices for this owner/org
 
 Device and grant indexes are scoped to the exact owner/org and bounded by their
 caps; management does not scan other owners' records. Revocation removes the
-server-side verifier, so the next request with that token returns `401`. Lease
+server-side verifier and its in-memory membership entry, so the next request
+with that token returns `401` even when it had a warm membership result. Lease
 owner or sharing changes are evaluated from current lease state on every read,
 so removed visibility fails closed on the next request as well.
 
@@ -99,6 +112,22 @@ but still requires the exact configured request destination and rejects a
 different supplied Origin. The configured origin must be HTTPS. Loopback HTTP
 is accepted only for local development. These credential-bearing routes do not
 redirect to another origin.
+
+## Threat model
+
+The 60-second positive membership cache is an explicit availability and quota
+tradeoff. A user removed from GitHub organization or team membership can retain
+device read access only until that device token's current cache entry expires,
+so the accepted removal latency is at most about 60 seconds. GitHub lookup
+failures after that deadline deny access rather than extending the window.
+
+The window does not apply to the durable device-token verifier, device-token
+expiry, sealed-grant expiry or decryption, configured revoked-user policy,
+allowed-organization policy, or current lease visibility. Those checks run on
+every request. Individual or bulk device revocation deletes the verifier first
+and takes effect on the next request regardless of cache state. Cache entries
+are keyed by the exact device ID and token hash and are held only in bounded
+ephemeral Worker memory, preventing cross-token or cross-tenant reuse.
 
 ## Non-goals
 

--- a/docs/features/device-pairing.md
+++ b/docs/features/device-pairing.md
@@ -80,8 +80,10 @@ organizations.
 After a cache miss or expiry, GitHub errors, account mismatch, removed
 membership, revoked users, or a no-longer-allowed organization fail closed with
 `401`; a stale positive is never used as an error fallback. An expired or
-revoked OAuth credential returns `pairing_reauth_required`, while other owner
-authorization failures return `device_owner_unauthorized`.
+revoked OAuth credential, or a recognized GitHub SAML/OAuth authorization
+requirement, returns `pairing_reauth_required`. Other owner authorization
+failures, including unrecognized GitHub `403` responses, return
+`device_owner_unauthorized`.
 
 The sealed grant never reaches the device. Only a hash of the device token is
 stored, and the public device response contains no credential material.

--- a/worker/src/auth.ts
+++ b/worker/src/auth.ts
@@ -1,4 +1,5 @@
 import {
+  GitHubCredentialError,
   githubAccountID,
   requireCurrentGitHubMembership,
   type GitHubMembershipEnv,
@@ -40,6 +41,8 @@ export interface GitHubUserGrant {
   sealedCredential: string;
   expiresAt: string;
 }
+
+export type GitHubUserGrantStatus = "current" | "reauth_required" | "unauthorized";
 
 export interface AuthRequestContext {
   trustedProxy?: boolean;
@@ -423,28 +426,37 @@ export async function githubUserGrantIsCurrent(
   env: Pick<Env, "CRABBOX_SHARED_TOKEN" | "CRABBOX_SESSION_SECRET"> & GitHubMembershipEnv,
   context: AuthRequestContext = {},
 ): Promise<boolean> {
+  return (await githubUserGrantStatus(grant, identity, env, context)) === "current";
+}
+
+export async function githubUserGrantStatus(
+  grant: GitHubUserGrant,
+  identity: Pick<GitHubMembershipIdentity, "owner" | "org" | "login">,
+  env: Pick<Env, "CRABBOX_SHARED_TOKEN" | "CRABBOX_SESSION_SECRET"> & GitHubMembershipEnv,
+  context: AuthRequestContext = {},
+): Promise<GitHubUserGrantStatus> {
   if (
     !/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(grant.tokenID) ||
     !grant.sealedCredential ||
-    !Number.isFinite(Date.parse(grant.expiresAt)) ||
-    Date.parse(grant.expiresAt) <= Date.now()
+    !Number.isFinite(Date.parse(grant.expiresAt))
   ) {
-    return false;
+    return "unauthorized";
   }
+  if (Date.parse(grant.expiresAt) <= Date.now()) return "reauth_required";
   let accessToken: string;
   try {
     const opened = await openGitHubCredential(grant.sealedCredential, sessionSecret(env));
-    if (!opened) return false;
+    if (!opened) return "reauth_required";
     accessToken = opened;
   } catch {
-    return false;
+    return "reauth_required";
   }
   const membership = context.githubMembership ?? requireCurrentGitHubMembership;
   try {
     await membership({ accessToken, tokenID: grant.tokenID, ...identity }, env);
-    return true;
-  } catch {
-    return false;
+    return "current";
+  } catch (error) {
+    return error instanceof GitHubCredentialError ? "reauth_required" : "unauthorized";
   }
 }
 

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -5,6 +5,7 @@ const { Client: SSHClientConstructor, utils: sshUtils } = ssh2;
 import { artifactUploadResponse, type ArtifactUploadRequest } from "./artifacts";
 import {
   adminGrantVersion as configuredAdminGrantVersion,
+  githubUserGrantStatus,
   githubUserGrantIsCurrent,
   githubUserIsAdmin,
   isAdminRequest,
@@ -71,7 +72,12 @@ import {
   type DaytonaSSHEndpoint,
 } from "./daytona";
 import { GCPClient, gcpProviderLabelValue } from "./gcp";
-import { requireFreshGitHubMembership } from "./github-membership";
+import {
+  requireFreshGitHubMembership,
+  requireGitHubMembershipPolicy,
+  type GitHubMembershipEnv,
+  type GitHubMembershipIdentity,
+} from "./github-membership";
 import {
   HetznerClient,
   HetznerProvisioningError,
@@ -342,6 +348,8 @@ const readyPoolCountersPrefix = "ready-pool-counters:";
 const readyPoolBorrowTimeoutMs = 2 * 60_000;
 const readyPoolFillClaimTimeoutMs = 15 * 60_000;
 const readyPoolTerminalRetentionMs = 24 * 60 * 60_000;
+export const deviceMembershipCacheTTLMS = 60_000;
+const deviceMembershipCacheMaxEntries = 1024;
 const workspaceReconcileIntervalMs = 10_000;
 const workspaceReconcileMaxIntervalMs = 5 * 60_000;
 const workspaceProvisionClaimMs = 15 * 60_000;
@@ -560,6 +568,11 @@ interface RuntimeAdapterDeleteCompletion {
   workspaceID: string;
   registrationID: string;
   status: "absent";
+}
+
+interface DeviceMembershipCacheEntry {
+  expiresAt: number;
+  load?: Promise<void>;
 }
 
 interface RuntimeAdapterLegacyDeleteCompletion {
@@ -998,6 +1011,7 @@ export class FleetCoordinator {
   private readonly adminGrantValidationTimes = new WeakMap<WebSocket, number>();
   private readonly userGrantValidationTimes = new WeakMap<WebSocket, number>();
   private readonly viewerSessionValidationTimes = new WeakMap<WebSocket, number>();
+  private readonly deviceMembershipCache = new Map<string, DeviceMembershipCacheEntry>();
   private currentAdminGrantVersion: string | undefined;
   private bridgeRestoreReady: Promise<boolean> | undefined;
   private readyPoolBorrowQueue: Promise<void> = Promise.resolve();
@@ -1503,7 +1517,11 @@ export class FleetCoordinator {
     if (org === undefined) {
       return pairingUnauthorized("device_token_invalid");
     }
-    if (!(await this.pairingOwnerIsCurrent(record))) {
+    const ownerStatus = await this.deviceOwnerStatus(record);
+    if (ownerStatus === "reauth_required") {
+      return pairingUnauthorized("pairing_reauth_required");
+    }
+    if (ownerStatus !== "current") {
       return pairingUnauthorized("device_owner_unauthorized");
     }
     return requestWithAuthContext(request, {
@@ -1529,6 +1547,61 @@ export class FleetCoordinator {
         githubMembership: this.authContext.githubMembership ?? requireFreshGitHubMembership,
       },
     );
+  }
+
+  private async deviceOwnerStatus(record: DeviceTokenRecord) {
+    const org = orgAuthLabelFromKey(record.org);
+    if (org === undefined) return "unauthorized" as const;
+    return await githubUserGrantStatus(
+      record.ownerGrant,
+      { owner: record.owner, org, login: record.ownerLogin },
+      this.env,
+      {
+        githubMembership: async (identity, env) =>
+          await this.requireCachedDeviceMembership(record, identity, env),
+      },
+    );
+  }
+
+  private async requireCachedDeviceMembership(
+    record: Pick<DeviceTokenRecord, "id" | "tokenHash">,
+    identity: GitHubMembershipIdentity,
+    env: GitHubMembershipEnv,
+  ): Promise<void> {
+    requireGitHubMembershipPolicy(identity, env);
+    const key = deviceMembershipCacheKey(record);
+    const now = Date.now();
+    const cached = this.deviceMembershipCache.get(key);
+    if (cached?.expiresAt && cached.expiresAt > now) {
+      this.deviceMembershipCache.delete(key);
+      this.deviceMembershipCache.set(key, cached);
+      return;
+    }
+    if (cached?.load) return await cached.load;
+    this.deviceMembershipCache.delete(key);
+
+    const entry: DeviceMembershipCacheEntry = { expiresAt: 0 };
+    const membership = this.authContext.githubMembership ?? requireFreshGitHubMembership;
+    entry.load = membership(identity, env).then(
+      () => {
+        if (this.deviceMembershipCache.get(key) === entry) {
+          entry.expiresAt = Date.now() + deviceMembershipCacheTTLMS;
+          delete entry.load;
+          this.deviceMembershipCache.delete(key);
+          this.deviceMembershipCache.set(key, entry);
+        }
+        return undefined;
+      },
+      (error: unknown) => {
+        if (this.deviceMembershipCache.get(key) === entry) {
+          this.deviceMembershipCache.delete(key);
+        }
+        throw error;
+      },
+    );
+    this.deviceMembershipCache.set(key, entry);
+    trimDeviceMembershipCache(this.deviceMembershipCache);
+    return await entry.load;
   }
 
   private async activeOwnerDevices(owner: string, org: string): Promise<DeviceTokenRecord[]> {
@@ -1566,6 +1639,7 @@ export class FleetCoordinator {
 
   private async revokeDeviceRecord(record: DeviceTokenRecord): Promise<void> {
     await this.state.storage.delete(deviceTokenKey(record.id));
+    this.deviceMembershipCache.delete(deviceMembershipCacheKey(record));
     await this.state.storage.delete(deviceOwnerIndexKey(record.owner, record.org, record.id));
   }
 
@@ -17274,6 +17348,22 @@ function pairingBrowserSession(
     return undefined;
   }
   return { login, grant: { tokenID, sealedCredential, expiresAt } };
+}
+
+function deviceMembershipCacheKey(record: Pick<DeviceTokenRecord, "id" | "tokenHash">): string {
+  return `${record.id}:${record.tokenHash}`;
+}
+
+function trimDeviceMembershipCache(cache: Map<string, DeviceMembershipCacheEntry>): void {
+  const now = Date.now();
+  for (const [key, entry] of cache) {
+    if (!entry.load && entry.expiresAt <= now) cache.delete(key);
+  }
+  while (cache.size > deviceMembershipCacheMaxEntries) {
+    const oldest = cache.keys().next().value;
+    if (oldest === undefined) break;
+    cache.delete(oldest);
+  }
 }
 
 function pairingOriginError(

--- a/worker/src/github-membership.ts
+++ b/worker/src/github-membership.ts
@@ -68,13 +68,7 @@ export async function requireCurrentGitHubMembership(
   identity: GitHubMembershipIdentity,
   env: GitHubMembershipEnv,
 ): Promise<void> {
-  requireSafeGitHubRevocationConfig(env);
-  if (githubUserIsRevoked(identity, env)) {
-    throw new GitHubAuthorizationError(`GitHub user ${identity.login} has been revoked.`);
-  }
-  if (!allowedGitHubOrgs(env).includes(identity.org.trim().toLowerCase())) {
-    throw new GitHubAuthorizationError(`GitHub organization ${identity.org} is no longer allowed.`);
-  }
+  requireGitHubMembershipPolicy(identity, env);
   const key = membershipCacheKey(identity, env);
   const now = Date.now();
   const cachedUntil = membershipCache.get(key) ?? 0;
@@ -107,6 +101,15 @@ export async function requireFreshGitHubMembership(
   identity: GitHubMembershipIdentity,
   env: GitHubMembershipEnv,
 ): Promise<void> {
+  requireGitHubMembershipPolicy(identity, env);
+  await requireExactGitHubAccount(identity.accessToken, identity.owner, identity.login);
+  await requireExactGitHubMembership(identity.accessToken, identity.login, identity.org, env);
+}
+
+export function requireGitHubMembershipPolicy(
+  identity: Pick<GitHubMembershipIdentity, "owner" | "org" | "login">,
+  env: GitHubMembershipEnv,
+): void {
   requireSafeGitHubRevocationConfig(env);
   if (githubUserIsRevoked(identity, env)) {
     throw new GitHubAuthorizationError(`GitHub user ${identity.login} has been revoked.`);
@@ -114,8 +117,6 @@ export async function requireFreshGitHubMembership(
   if (!allowedGitHubOrgs(env).includes(identity.org.trim().toLowerCase())) {
     throw new GitHubAuthorizationError(`GitHub organization ${identity.org} is no longer allowed.`);
   }
-  await requireExactGitHubAccount(identity.accessToken, identity.owner, identity.login);
-  await requireExactGitHubMembership(identity.accessToken, identity.login, identity.org, env);
 }
 
 function githubUserIsRevoked(
@@ -158,7 +159,8 @@ async function requireExactGitHubAccount(
   }
   const response = await fetch(`${githubAPIURL}/user`, { headers: githubHeaders(accessToken) });
   if (!response.ok) {
-    throw new GitHubAuthorizationError(
+    throw githubResponseError(
+      response,
       `Could not verify GitHub user ${login}: GitHub returned ${response.status}.`,
     );
   }
@@ -190,7 +192,8 @@ async function requireExactGitHubMembership(
     { headers: githubHeaders(accessToken) },
   );
   if (!response.ok) {
-    throw new GitHubAuthorizationError(
+    throw githubResponseError(
+      response,
       `GitHub user ${login} is not an active member of ${exactOrg}.`,
     );
   }
@@ -254,7 +257,8 @@ async function userGitHubTeams(accessToken: string): Promise<GitHubTeam[]> {
       headers: githubHeaders(accessToken),
     });
     if (!response.ok) {
-      throw new GitHubAuthorizationError(
+      throw githubResponseError(
+        response,
         `Could not verify GitHub team membership: GitHub returned ${response.status}.`,
       );
     }
@@ -320,4 +324,12 @@ function githubHeaders(accessToken: string): Record<string, string> {
   };
 }
 
+function githubResponseError(response: Response, message: string): GitHubAuthorizationError {
+  return response.status === 401
+    ? new GitHubCredentialError(message)
+    : new GitHubAuthorizationError(message);
+}
+
 export class GitHubAuthorizationError extends Error {}
+
+export class GitHubCredentialError extends GitHubAuthorizationError {}

--- a/worker/src/github-membership.ts
+++ b/worker/src/github-membership.ts
@@ -159,7 +159,7 @@ async function requireExactGitHubAccount(
   }
   const response = await fetch(`${githubAPIURL}/user`, { headers: githubHeaders(accessToken) });
   if (!response.ok) {
-    throw githubResponseError(
+    throw await githubResponseError(
       response,
       `Could not verify GitHub user ${login}: GitHub returned ${response.status}.`,
     );
@@ -192,7 +192,7 @@ async function requireExactGitHubMembership(
     { headers: githubHeaders(accessToken) },
   );
   if (!response.ok) {
-    throw githubResponseError(
+    throw await githubResponseError(
       response,
       `GitHub user ${login} is not an active member of ${exactOrg}.`,
     );
@@ -257,7 +257,8 @@ async function userGitHubTeams(accessToken: string): Promise<GitHubTeam[]> {
       headers: githubHeaders(accessToken),
     });
     if (!response.ok) {
-      throw githubResponseError(
+      // oxlint-disable-next-line eslint/no-await-in-loop -- classify the current page response before advancing.
+      throw await githubResponseError(
         response,
         `Could not verify GitHub team membership: GitHub returned ${response.status}.`,
       );
@@ -324,10 +325,59 @@ function githubHeaders(accessToken: string): Record<string, string> {
   };
 }
 
-function githubResponseError(response: Response, message: string): GitHubAuthorizationError {
-  return response.status === 401
+async function githubResponseError(
+  response: Response,
+  message: string,
+): Promise<GitHubAuthorizationError> {
+  if (response.status === 401) return new GitHubCredentialError(message);
+  if (response.status !== 403) return new GitHubAuthorizationError(message);
+
+  const sso = response.headers.get("x-github-sso")?.trim().toLowerCase() ?? "";
+  if (/^required(?:;|$)/.test(sso)) return new GitHubCredentialError(message);
+
+  const details = await githubErrorDetails(response);
+  return github403RequiresReauthentication(details)
     ? new GitHubCredentialError(message)
     : new GitHubAuthorizationError(message);
+}
+
+async function githubErrorDetails(
+  response: Response,
+): Promise<{ message: string; documentationURL: string }> {
+  try {
+    const body = (await response.json()) as { message?: unknown; documentation_url?: unknown };
+    return {
+      message: typeof body.message === "string" ? body.message.trim().toLowerCase() : "",
+      documentationURL:
+        typeof body.documentation_url === "string"
+          ? body.documentation_url.trim().toLowerCase()
+          : "",
+    };
+  } catch {
+    return { message: "", documentationURL: "" };
+  }
+}
+
+function github403RequiresReauthentication(details: {
+  message: string;
+  documentationURL: string;
+}): boolean {
+  if (
+    details.message === "bad credentials" ||
+    details.message.includes("resource protected by organization saml enforcement") ||
+    details.message.includes("oauth app access restrictions") ||
+    /\b(?:token|credentials?) (?:has |have |is |are )?(?:expired|revoked|invalid)\b/.test(
+      details.message,
+    ) ||
+    /\b(?:expired|revoked|invalid) (?:token|credentials?)\b/.test(details.message)
+  ) {
+    return true;
+  }
+  return (
+    details.documentationURL.startsWith("https://docs.github.com/") &&
+    (details.documentationURL.includes("/token-expiration-and-revocation") ||
+      details.documentationURL.includes("#saml-sso-authentication"))
+  );
 }
 
 export class GitHubAuthorizationError extends Error {}

--- a/worker/test/pairing.test.ts
+++ b/worker/test/pairing.test.ts
@@ -8,13 +8,16 @@ import {
   type CoordinatorStorage,
   type CoordinatorWebSocketUpgradeOptions,
 } from "../src/coordinator-runtime";
-import { FleetCoordinator } from "../src/fleet";
+import { deviceMembershipCacheTTLMS, FleetCoordinator } from "../src/fleet";
+import { GitHubCredentialError } from "../src/github-membership";
 import { orgKeyForLabel } from "../src/org-identity";
 import {
   deviceTokenTTLSeconds,
+  deviceTokenKey,
   maxDeviceTokensPerOwner,
   maxPairingGrantsPerOwner,
   pairingGrantTTLSeconds,
+  type DeviceTokenRecord,
 } from "../src/pairing";
 import type { Env, LeaseRecord } from "../src/types";
 
@@ -151,6 +154,7 @@ interface PairingFixture {
   env: Env;
   runtime: MemoryRuntime;
   membershipAllowed: { value: boolean };
+  membershipFailure: { value?: Error };
   membershipChecks: ReturnType<typeof vi.fn>;
   request(
     path: string,
@@ -298,12 +302,15 @@ describe("coordinator device pairing", () => {
     await seedLease(fixture.runtime, lease("cbx_000000000001", owner));
     const first = await fixture.pair("First phone");
     const second = await fixture.pair("Second phone");
+    expect((await fixture.request("/v1/leases", deviceRequest(first.token))).status).toBe(200);
 
     const revokeOne = await fixture.ownerRequest(`/v1/devices/${first.deviceID}`, {
       method: "DELETE",
     });
     expect(revokeOne.status).toBe(204);
-    expect((await fixture.request("/v1/leases", deviceRequest(first.token))).status).toBe(401);
+    const revoked = await fixture.request("/v1/leases", deviceRequest(first.token));
+    expect(revoked.status).toBe(401);
+    await expect(revoked.json()).resolves.toEqual({ error: "device_token_invalid" });
     expect((await fixture.request("/v1/leases", deviceRequest(second.token))).status).toBe(200);
 
     const revokeAll = await fixture.ownerRequest("/v1/devices", { method: "DELETE" });
@@ -426,6 +433,7 @@ describe("coordinator device pairing", () => {
   });
 
   it("fails closed after membership or lease sharing changes", async () => {
+    vi.useFakeTimers({ now: new Date("2026-07-27T12:00:00Z") });
     const fixture = await pairingFixture();
     const shared = lease("cbx_000000000001", otherOwner, { users: { [owner]: "use" } });
     await seedLease(fixture.runtime, shared);
@@ -441,9 +449,91 @@ describe("coordinator device pairing", () => {
     );
 
     fixture.membershipAllowed.value = false;
+    expect((await fixture.request("/v1/leases", deviceRequest(token))).status).toBe(200);
+    await vi.advanceTimersByTimeAsync(deviceMembershipCacheTTLMS + 1);
     const offboarded = await fixture.request("/v1/leases", deviceRequest(token));
     expect(offboarded.status).toBe(401);
     await expect(offboarded.json()).resolves.toEqual({ error: "device_owner_unauthorized" });
+  });
+
+  it("caches successful membership checks for 60 seconds per device token", async () => {
+    vi.useFakeTimers({ now: new Date("2026-07-27T12:00:00Z") });
+    const fixture = await pairingFixture();
+    const { token } = await fixture.pair();
+    fixture.membershipChecks.mockClear();
+
+    expect((await fixture.request("/v1/leases", deviceRequest(token))).status).toBe(200);
+    expect((await fixture.request("/v1/leases", deviceRequest(token))).status).toBe(200);
+    expect(fixture.membershipChecks).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(deviceMembershipCacheTTLMS + 1);
+    expect((await fixture.request("/v1/leases", deviceRequest(token))).status).toBe(200);
+    expect(fixture.membershipChecks).toHaveBeenCalledTimes(2);
+  });
+
+  it("fails closed on a lookup error after a warm membership entry expires", async () => {
+    vi.useFakeTimers({ now: new Date("2026-07-27T12:00:00Z") });
+    const fixture = await pairingFixture();
+    const { token } = await fixture.pair();
+    fixture.membershipChecks.mockClear();
+    expect((await fixture.request("/v1/leases", deviceRequest(token))).status).toBe(200);
+
+    fixture.membershipFailure.value = new Error("GitHub unavailable");
+    await vi.advanceTimersByTimeAsync(deviceMembershipCacheTTLMS + 1);
+    const failed = await fixture.request("/v1/leases", deviceRequest(token));
+
+    expect(failed.status).toBe(401);
+    await expect(failed.json()).resolves.toEqual({ error: "device_owner_unauthorized" });
+    expect(fixture.membershipChecks).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns a distinct reauthentication error for expired or revoked OAuth grants", async () => {
+    const expiredFixture = await pairingFixture();
+    const expired = await expiredFixture.pair();
+    const stored = await expiredFixture.runtime.storage.get<DeviceTokenRecord>(
+      deviceTokenKey(expired.deviceID),
+    );
+    if (!stored) throw new Error("device record was not stored");
+    await expiredFixture.runtime.storage.put(deviceTokenKey(expired.deviceID), {
+      ...stored,
+      ownerGrant: { ...stored.ownerGrant, expiresAt: new Date(Date.now() - 1).toISOString() },
+    });
+
+    const expiredResponse = await expiredFixture.request(
+      "/v1/leases",
+      deviceRequest(expired.token),
+    );
+    expect(expiredResponse.status).toBe(401);
+    await expect(expiredResponse.json()).resolves.toEqual({
+      error: "pairing_reauth_required",
+    });
+
+    const revokedFixture = await pairingFixture();
+    const revoked = await revokedFixture.pair();
+    revokedFixture.membershipFailure.value = new GitHubCredentialError("Bad credentials");
+    const revokedResponse = await revokedFixture.request(
+      "/v1/leases",
+      deviceRequest(revoked.token),
+    );
+    expect(revokedResponse.status).toBe(401);
+    await expect(revokedResponse.json()).resolves.toEqual({
+      error: "pairing_reauth_required",
+    });
+  });
+
+  it("does not share cached membership between device tokens", async () => {
+    const fixture = await pairingFixture();
+    const first = await fixture.pair("First phone");
+    const second = await fixture.pair("Second phone");
+    fixture.membershipChecks.mockClear();
+
+    expect((await fixture.request("/v1/leases", deviceRequest(first.token))).status).toBe(200);
+    fixture.membershipAllowed.value = false;
+    const secondResponse = await fixture.request("/v1/leases", deviceRequest(second.token));
+
+    expect(secondResponse.status).toBe(401);
+    await expect(secondResponse.json()).resolves.toEqual({ error: "device_owner_unauthorized" });
+    expect(fixture.membershipChecks).toHaveBeenCalledTimes(2);
   });
 
   it("isolates device management indexes by owner", async () => {
@@ -575,7 +665,9 @@ async function pairingFixture(
     CRABBOX_GITHUB_MEMBERSHIP_CACHE_SECONDS: "0",
   } as Env;
   const membershipAllowed = { value: true };
+  const membershipFailure: { value?: Error } = {};
   const membershipChecks = vi.fn<() => Promise<void>>(async (): Promise<void> => {
+    if (membershipFailure.value) throw membershipFailure.value;
     if (!membershipAllowed.value) throw new Error("membership removed");
   });
   const authContext = { githubMembership: membershipChecks };
@@ -623,6 +715,7 @@ async function pairingFixture(
     env,
     runtime: existingRuntime,
     membershipAllowed,
+    membershipFailure,
     membershipChecks,
     request,
     ownerRequest,

--- a/worker/test/pairing.test.ts
+++ b/worker/test/pairing.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { issuePortalToken, issueUserToken } from "../src/auth";
+import { issuePortalToken, issueUserToken, type AuthRequestContext } from "../src/auth";
 import { routeCoordinatorRequest } from "../src/coordinator-entry";
 import {
   type CoordinatorRuntime,
@@ -178,6 +178,7 @@ describe("coordinator device pairing", () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it("exchanges a browser grant for a distinct credential-free device principal", async () => {
@@ -521,6 +522,104 @@ describe("coordinator device pairing", () => {
     });
   });
 
+  it.each([
+    {
+      label: "SAML authorization required",
+      endpoint: "membership" as const,
+      githubResponse: () =>
+        Response.json(
+          {
+            message:
+              "Resource protected by organization SAML enforcement. You must grant your OAuth token access to this organization.",
+            documentation_url:
+              "https://docs.github.com/rest/authentication/authenticating-to-the-rest-api#saml-sso-authentication",
+          },
+          {
+            status: 403,
+            headers: { "x-github-sso": "required; url=https://github.com/orgs/example-org/sso" },
+          },
+        ),
+      expectedError: "pairing_reauth_required",
+    },
+    {
+      label: "revoked credential",
+      endpoint: "user" as const,
+      githubResponse: () =>
+        Response.json(
+          {
+            message: "Bad credentials",
+            documentation_url:
+              "https://docs.github.com/rest/authentication/authenticating-to-the-rest-api",
+          },
+          { status: 403 },
+        ),
+      expectedError: "pairing_reauth_required",
+    },
+    {
+      label: "genuine non-member",
+      endpoint: "membership" as const,
+      githubResponse: () =>
+        Response.json(
+          {
+            message: "You are not an active member of this organization.",
+            documentation_url:
+              "https://docs.github.com/rest/orgs/members#get-organization-membership-for-a-user",
+          },
+          { status: 403 },
+        ),
+      expectedError: "device_owner_unauthorized",
+    },
+    {
+      label: "unrecognized forbidden response",
+      endpoint: "user" as const,
+      githubResponse: () =>
+        Response.json(
+          { message: "Forbidden", documentation_url: "https://docs.github.com/rest" },
+          {
+            status: 403,
+            headers: { "x-github-sso": "partial-results; organizations=12345" },
+          },
+        ),
+      expectedError: "device_owner_unauthorized",
+    },
+  ])("classifies a GitHub 403 for $label", async ({ endpoint, githubResponse, expectedError }) => {
+    const failure: {
+      endpoint?: "user" | "membership";
+      response?: () => Response;
+    } = {};
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<(input: RequestInfo | URL) => Promise<Response>>(async (input) => {
+        const url = String(input);
+        if (failure.endpoint === "user" && url === "https://api.github.com/user") {
+          return failure.response!();
+        }
+        if (
+          failure.endpoint === "membership" &&
+          url === "https://api.github.com/user/memberships/orgs/example-org"
+        ) {
+          return failure.response!();
+        }
+        if (url === "https://api.github.com/user") {
+          return Response.json({ id: 12345, login: ownerLogin });
+        }
+        if (url === "https://api.github.com/user/memberships/orgs/example-org") {
+          return Response.json({ state: "active", organization: { login: org } });
+        }
+        throw new Error(`unexpected GitHub request ${url}`);
+      }),
+    );
+    const fixture = await pairingFixture(new MemoryRuntime(), owner, ownerLogin, {});
+    const { token } = await fixture.pair();
+    failure.endpoint = endpoint;
+    failure.response = githubResponse;
+
+    const response = await fixture.request("/v1/leases", deviceRequest(token));
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: expectedError });
+  });
+
   it("does not share cached membership between device tokens", async () => {
     const fixture = await pairingFixture();
     const first = await fixture.pair("First phone");
@@ -653,6 +752,7 @@ async function pairingFixture(
   existingRuntime = new MemoryRuntime(),
   sessionOwner = owner,
   login = ownerLogin,
+  authContextOverride?: AuthRequestContext,
 ): Promise<PairingFixture> {
   const env = {
     CRABBOX_PUBLIC_URL: origin,
@@ -670,7 +770,7 @@ async function pairingFixture(
     if (membershipFailure.value) throw membershipFailure.value;
     if (!membershipAllowed.value) throw new Error("membership removed");
   });
-  const authContext = { githubMembership: membershipChecks };
+  const authContext = authContextOverride ?? { githubMembership: membershipChecks };
   const tokenInput = {
     owner: sessionOwner,
     ownerSource: "github-verified-email" as const,


### PR DESCRIPTION
## Summary

- cache successful GitHub account and org/team revalidation for 60 seconds per exact device ID and verifier hash, with a 1,024-entry in-memory bound
- keep durable device-token lookup, token/grant expiry, sealed-grant opening, revoked-user policy, allowed-org policy, and lease visibility checks on every request; successful revocation also evicts the matching cache entry
- return `pairing_reauth_required` when the stored grant expires, cannot be opened, or GitHub rejects its credential, while device revocation remains `device_token_invalid`
- document the accepted membership-removal window and threat model, and add regression coverage for cache hits/expiry, fail-closed refresh, revocation precedence, reauth, and cross-token isolation

Implements https://github.com/openclaw/crabbox/issues/1200.

## Verification

```text
npm ci --prefix worker
npm run format:check --prefix worker
npm run lint --prefix worker
npm run check --prefix worker
npm test --prefix worker
npm run build --prefix worker

Test Files  36 passed | 2 skipped (38)
Tests       1131 passed | 3 skipped (1134)
wrangler deploy --dry-run: success
```

```text
gofmt -w $(git ls-files '*.go')
go vet ./...
scripts/check-docs.sh

go vet: pass
checked 238 markdown files: internal links ok
generated docs tests: 14 passed
```

The full Go race fan-out ran on Blacksmith Testbox. Every package outside the Testbox shared-filesystem permission fixture passed. The two affected packages were then rerun locally on the same commit with native filesystem semantics:

```text
GOFLAGS=-p=2 go test -race ./internal/cli ./internal/providers/external

ok  github.com/openclaw/crabbox/internal/cli                 227.218s
ok  github.com/openclaw/crabbox/internal/providers/external   8.000s
```

The real CLI also built and ran:

```text
go build -trimpath -o bin/crabbox ./cmd/crabbox
bin/crabbox --version

0.15.0
```

## Local Wrangler HTTP proof

The Worker ran under local Wrangler and used a real active GitHub/org membership. All credentials remained off argv and were redacted from output.

```text
github_identity=verified_active_org_member
pairing_exchange=200
device_request_1=200 observed_github_delta=1
device_request_2=200 observed_github_delta=0
device_revoke=204
revoked_device_request=401 error=device_token_invalid
expired_grant_device_request=401 error=pairing_reauth_required
```

Source-blind behavior validation passed all four contract clauses: repeated-request caching, immediate warm-token revocation, distinct expired-grant reauthentication, and credential-redacted evidence. Autoreview was clean with no accepted/actionable findings.

## Security and configuration

The stored sealed OAuth credential model from device pairing is unchanged. No new secrets or configuration are required. The explicit tradeoff is that removed GitHub org/team membership can remain readable for at most about 60 seconds; lookup failures after cache expiry fail closed, and explicit device-token revocation remains immediate.
