### PR TITLE
fix(daytona): expose broker readiness and idempotent cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 
 ### Fixed
 
+- Made brokered Daytona usable with Crabbox auth alone, added a read-only
+  fallback readiness probe with truthful control/data-plane diagnostics, and
+  made repeated sandbox cleanup idempotent.
 - Bounded device membership revalidation to one GitHub revalidation per token per minute while preserving immediate token revocation, fail-closed errors, and a distinct re-pairing response for expired OAuth grants.
 - Kept ready-pool reconciliation rollout-compatible with older CLIs and coordinators, preserved unexpired in-flight claims across policy changes, and required actual ready capacity for `pool ensure` success.
 

--- a/docs/features/daytona.md
+++ b/docs/features/daytona.md
@@ -69,6 +69,13 @@ CRABBOX_DAYTONA_SSH_ACCESS_MINUTES # minimum token TTL; default 120
 ```
 
 The coordinator accepts no Daytona API credential from lease requests.
+Clients authenticate only to Crabbox; no Daytona CLI profile or Daytona API
+environment variable is required on the client.
+
+Use `crabbox doctor --provider daytona` to verify the broker fallback without
+creating a sandbox. The readiness endpoint performs a read-only inventory
+request and reports the client auth boundary, coordinator control plane,
+SSH/rsync data plane, snapshot source, and current inventory count.
 
 ## Config
 
@@ -146,8 +153,9 @@ long-lived, directly SSH-reachable runner host.
 
 In brokered mode the Worker creates and deletes the sandbox, verifies exact
 lease labels before destructive cleanup, refreshes the SSH token before expiry,
-and redacts that token from the portal. Workspaces and ready pools are disabled
-because they persist an SSH endpoint beyond the rotating credential.
+redacts that token from the portal, and treats an already absent owned sandbox
+as successful cleanup. Workspaces and ready pools are disabled because they
+persist an SSH endpoint beyond the rotating credential.
 
 See [providers.md](../commands/providers.md) for the full provider matrix and
 [capabilities.md](capabilities.md) for opt-in lease features.

--- a/docs/providers/daytona.md
+++ b/docs/providers/daytona.md
@@ -53,6 +53,18 @@ For a coordinator deployment, store `DAYTONA_CRABBOX_KEY` as a Worker secret.
 The optional `CRABBOX_DAYTONA_SNAPSHOT` Worker variable selects a shared
 snapshot; when it is empty, the Daytona account default is used.
 
+Clients need only normal Crabbox broker authentication. They do not need a
+Daytona CLI profile or Daytona API environment variables. Verify the fallback
+without creating a sandbox:
+
+```sh
+crabbox doctor --provider daytona
+```
+
+The broker readiness check performs a read-only sandbox inventory request and
+reports `daytona-fallback` with `client_auth=crabbox`,
+`control_plane=coordinator`, `data_plane=ssh-rsync`, and `mutation=false`.
+
 ## Auth
 
 Crabbox reads the active Daytona CLI profile when no Daytona auth values are set
@@ -138,11 +150,15 @@ The non-auth settings can also be set through environment variables:
 - Actions hydration: no.
 - Coordinator (broker): yes for Linux SSH/sync/run. The coordinator owns the
   API key and rotates the lease's SSH token.
+- Broker readiness: read-only Daytona inventory plus explicit coordinator and
+  SSH/rsync data-plane diagnostics; no sandbox is created.
 
 ## Gotchas
 
 - Direct mode requires `daytona.snapshot` (or `--daytona-snapshot`). Brokered
   mode uses the coordinator's optional `CRABBOX_DAYTONA_SNAPSHOT`.
+- Brokered release and rollback are idempotent when the owned sandbox was
+  already deleted or expired.
 - `--class` and `--type` are rejected; size the sandbox through the snapshot.
 - `--id <sandbox-id-or-slug>` is required to address an existing sandbox.
 - Daytona `run` is delegated to the toolbox APIs; it is not core-over-SSH

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -650,7 +650,21 @@ func TestDoctorChecksProviderReadinessForCoordinatorSupportedDaytona(t *testing.
 			_ = json.NewEncoder(w).Encode(CoordinatorWhoami{Auth: "token", Owner: "alice@example.test", Org: "example-org"})
 		case "/v1/providers/daytona/readiness":
 			readinessCalled = true
-			_ = json.NewEncoder(w).Encode(CoordinatorProviderReadiness{Provider: "daytona", Configured: true})
+			_ = json.NewEncoder(w).Encode(CoordinatorProviderReadiness{
+				Provider:   "daytona",
+				Configured: true,
+				Checks: []DoctorCheck{{
+					Status:  "ok",
+					Check:   "daytona-fallback",
+					Message: "auth=ready control_plane=ready inventory=ready leases=0 mutation=false",
+					Details: map[string]string{
+						"client_auth":   "crabbox",
+						"control_plane": "coordinator",
+						"data_plane":    "ssh-rsync",
+						"mutation":      "false",
+					},
+				}},
+			})
 		default:
 			http.Error(w, "unexpected "+r.URL.Path, http.StatusBadRequest)
 		}
@@ -669,6 +683,9 @@ func TestDoctorChecksProviderReadinessForCoordinatorSupportedDaytona(t *testing.
 	}
 	if !strings.Contains(stdout.String(), "ok      provider provider=daytona coordinator_secrets=ready") {
 		t.Fatalf("missing Daytona readiness: %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "ok      daytona-fallback auth=ready control_plane=ready inventory=ready leases=0 mutation=false") {
+		t.Fatalf("missing Daytona fallback readiness: %q", stdout.String())
 	}
 }
 

--- a/internal/cli/provider_backend_test.go
+++ b/internal/cli/provider_backend_test.go
@@ -323,6 +323,21 @@ func TestLoadBackendWrapsCoordinatorOnlyForSupportedSSHProviders(t *testing.T) {
 		t.Fatalf("backend=%T, want coordinatorLeaseBackend", backend)
 	}
 
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("DAYTONA_API_KEY", "")
+	t.Setenv("DAYTONA_JWT_TOKEN", "")
+	t.Setenv("CRABBOX_DAYTONA_API_KEY", "")
+	t.Setenv("CRABBOX_DAYTONA_JWT_TOKEN", "")
+	cfg.Provider = "daytona"
+	backend, err = loadBackend(cfg, testRuntimeWithRunner(&recordingCommandRunner{}))
+	if err != nil {
+		t.Fatalf("load Daytona coordinator backend without client Daytona auth: %v", err)
+	}
+	if _, ok := backend.(*coordinatorLeaseBackend); !ok {
+		t.Fatalf("backend=%T, want coordinatorLeaseBackend", backend)
+	}
+
 	cfg.Provider = "ssh"
 	backend, err = loadBackend(cfg, testRuntimeWithRunner(&recordingCommandRunner{}))
 	if err != nil {

--- a/internal/providers/daytona/provider_test.go
+++ b/internal/providers/daytona/provider_test.go
@@ -16,4 +16,18 @@ func TestProviderSupportsCoordinator(t *testing.T) {
 			t.Fatalf("features=%v missing %s", spec.Features, feature)
 		}
 	}
+	for _, unsupported := range []core.Feature{
+		core.FeatureDesktop,
+		core.FeatureBrowser,
+		core.FeatureCode,
+		core.FeatureTailscale,
+		core.FeatureCheckpoint,
+		core.FeatureFork,
+		core.FeatureRestore,
+		core.FeatureSnapshot,
+	} {
+		if spec.Features.Has(unsupported) {
+			t.Fatalf("features=%v unexpectedly includes %s", spec.Features, unsupported)
+		}
+	}
 }

--- a/worker/src/daytona.ts
+++ b/worker/src/daytona.ts
@@ -162,7 +162,13 @@ export class DaytonaClient {
   }
 
   async deleteServer(id: string): Promise<void> {
-    await this.request<unknown>("DELETE", `/sandbox/${encodeURIComponent(id)}`);
+    try {
+      await this.request<unknown>("DELETE", `/sandbox/${encodeURIComponent(id)}`);
+    } catch (error) {
+      // A prior cleanup or Daytona-side expiry already reached the desired state.
+      // Treating 404 as success keeps release and rollback retries idempotent.
+      if (!isDaytonaNotFound(error)) throw error;
+    }
   }
 
   async createSSHAccess(

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -6735,6 +6735,8 @@ export class FleetCoordinator {
     );
     if (provider === "aws" && readiness.configured && !this.testProviders.aws) {
       readiness.checks = await this.awsProviderCapacityChecks(url.searchParams);
+    } else if (provider === "daytona" && readiness.configured && !this.testProviders.daytona) {
+      readiness.checks = await new DaytonaProvider(this.env).readinessChecks();
     }
     return json(readiness);
   }
@@ -20841,6 +20843,37 @@ export class DaytonaProvider implements CloudProvider {
 
   listCrabboxServers(): Promise<ProviderMachine[]> {
     return this.client.listCrabboxServers();
+  }
+
+  async readinessChecks(): Promise<ProviderReadinessCheck[]> {
+    const details = {
+      api: "list",
+      mutation: "false",
+      client_auth: "crabbox",
+      control_plane: "coordinator",
+      data_plane: "ssh-rsync",
+      snapshot: this.env.CRABBOX_DAYTONA_SNAPSHOT?.trim() ? "configured" : "account-default",
+    };
+    try {
+      const servers = await this.client.listCrabboxServers();
+      return [
+        {
+          status: "ok",
+          check: "daytona-fallback",
+          message: `auth=ready control_plane=ready inventory=ready leases=${servers.length} mutation=false`,
+          details: { ...details, leases: String(servers.length) },
+        },
+      ];
+    } catch (error) {
+      return [
+        {
+          status: "failed",
+          check: "daytona-fallback",
+          message: `auth_or_control_plane=failed mutation=false ${coordinatorErrorMessage(this.env, error)}`,
+          details,
+        },
+      ];
+    }
   }
 
   supportsSSHHostKeyInjection(): boolean {

--- a/worker/test/daytona.test.ts
+++ b/worker/test/daytona.test.ts
@@ -169,6 +169,19 @@ describe("daytona coordinator client", () => {
     expect(diagnostic).toContain("route=iad");
   });
 
+  it("treats an already deleted sandbox as successful cleanup", async () => {
+    const client = new DaytonaClient(baseEnv);
+    client.fetcher = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(null, { status: 404 }))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+      .mockResolvedValueOnce(new Response("unavailable", { status: 503 }));
+
+    await expect(client.deleteServer("sandbox-one")).resolves.toBeUndefined();
+    await expect(client.deleteServer("sandbox-one")).resolves.toBeUndefined();
+    await expect(client.deleteServer("sandbox-one")).rejects.toThrow("http 503");
+  });
+
   it.each(["started", "running", "ready", "active", " Active "])(
     "accepts Daytona ready state %j",
     async (state) => {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -28023,13 +28023,59 @@ describe("fleet identity", () => {
       missing: ["DAYTONA_CRABBOX_KEY"],
     });
 
-    const daytonaFleet = testFleet(undefined, {}, { DAYTONA_CRABBOX_KEY: "live-key" });
+    const daytonaRequests: Request[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const daytonaRequest = input instanceof Request ? input : new Request(input, init);
+        daytonaRequests.push(daytonaRequest.clone());
+        return Response.json({
+          items: [
+            {
+              id: "sandbox-one",
+              name: "crabbox-one",
+              state: "started",
+              labels: { crabbox: "true" },
+            },
+          ],
+          nextCursor: null,
+        });
+      }),
+    );
+    const daytonaFleet = testFleet(
+      undefined,
+      {},
+      {
+        DAYTONA_CRABBOX_KEY: "live-key",
+        CRABBOX_DAYTONA_API_URL: "https://daytona.example/api",
+        CRABBOX_DAYTONA_SNAPSHOT: "crabbox-ready",
+      },
+    );
     const daytona = await daytonaFleet.fetch(request("GET", "/v1/providers/daytona/readiness"));
     await expect(daytona.json()).resolves.toMatchObject({
       provider: "daytona",
       configured: true,
       missing: [],
+      checks: [
+        {
+          status: "ok",
+          check: "daytona-fallback",
+          details: {
+            api: "list",
+            mutation: "false",
+            client_auth: "crabbox",
+            control_plane: "coordinator",
+            data_plane: "ssh-rsync",
+            snapshot: "configured",
+            leases: "1",
+          },
+        },
+      ],
     });
+    expect(daytonaRequests).toHaveLength(1);
+    expect(daytonaRequests[0]?.method).toBe("GET");
+    expect(daytonaRequests[0]?.headers.get("authorization")).toBe("Bearer live-key");
+    expect(new URL(daytonaRequests[0]!.url).pathname).toBe("/api/sandbox");
   });
 
   it("reports AWS capacity quota readiness before a lease is requested", async () => {
@@ -28080,6 +28126,54 @@ describe("fleet identity", () => {
         }),
       ]),
     );
+  });
+
+  it("reports a configured but unusable Daytona fallback without leaking its key", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              error: "unauthorized",
+              workerKey: "daytona-live-secret",
+            }),
+            { status: 401 },
+          ),
+      ),
+    );
+    const fleet = testFleet(
+      undefined,
+      {},
+      {
+        DAYTONA_CRABBOX_KEY: "daytona-live-secret",
+        CRABBOX_DAYTONA_API_URL: "https://daytona.example/api",
+      },
+    );
+
+    const response = await fleet.fetch(request("GET", "/v1/providers/daytona/readiness"));
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).not.toContain("daytona-live-secret");
+    expect(JSON.parse(body)).toMatchObject({
+      provider: "daytona",
+      configured: true,
+      missing: [],
+      checks: [
+        {
+          status: "failed",
+          check: "daytona-fallback",
+          details: {
+            api: "list",
+            mutation: "false",
+            client_auth: "crabbox",
+            control_plane: "coordinator",
+            data_plane: "ssh-rsync",
+            snapshot: "account-default",
+          },
+        },
+      ],
+    });
   });
 
   it("rejects path-bearing AWS regions before signed requests", async () => {


### PR DESCRIPTION
Related: https://github.com/openclaw/crabbox/issues/1208

## What Problem This Solves

Fixes an issue where callers could not verify brokered Daytona control-plane access before selecting it, and cleanup retried forever when Daytona had already removed a sandbox.

## Why This Change Was Made

Adds a read-only Daytona inventory check to Crabbox's provider readiness contract and treats provider `404` deletion as successful cleanup. Cross-provider fallback selection remains caller-owned: Crabbox reports `doctor` readiness for one provider, and the workload router decides whether to select it or continue. The OpenClaw consumer is https://github.com/openclaw/openclaw/pull/116841.

## User Impact

Operators can probe Daytona without creating a sandbox. Workload routers can skip Daytona when `crabbox doctor --provider daytona` exits nonzero, while already-missing Daytona resources no longer leave cleanup stuck.

## Evidence

- Live configured-broker doctor on July 31, 2026 returned `ok=false`, `broker` HTTP 401 with `hint=renew_crabbox_broker_login`, and a successful admin-side Daytona inventory check with `machines=0`; no sandbox was created.
- https://github.com/openclaw/openclaw/pull/116841 calls `crabbox doctor` for each candidate, selects only a zero-exit provider, and has focused tests for Daytona selection and Daytona-to-Azure/AWS fall-through.
- Targeted Go provider, doctor, and CLI tests passed.
- Worker Daytona/fleet tests passed 19 focused cases.
- Worker typecheck, oxlint, and format checks passed.
- `git diff --check origin/main...HEAD` passed.
- TruffleHog and final autoreview clean.
