### PR TITLE
fix(worker): harden provider reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Made brokered Daytona usable with Crabbox auth alone, added a read-only
   fallback readiness probe with truthful control/data-plane diagnostics, and
   made repeated sandbox cleanup idempotent.
+- Quarantined exact-owned AWS and Azure orphan candidates across consecutive successful inventories before deletion, and added bounded provider reconciliation backoff after inventory failures.
 - Bounded device membership revalidation to one GitHub revalidation per token per minute while preserving immediate token revocation, fail-closed errors, and a distinct re-pairing response for expired OAuth grants.
 - Kept ready-pool reconciliation rollout-compatible with older CLIs and coordinators, preserved unexpired in-flight claims across policy changes, and required actual ready capacity for `pool ensure` success.
 

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -199,7 +199,11 @@ import {
 } from "./provider-provisioning";
 import {
   observeProviderReconciliationCandidate,
+  providerReconciliationCircuitOpen,
   providerReconciliationFingerprint,
+  recordProviderReconciliationFailure,
+  recordProviderReconciliationSuccess,
+  type ProviderReconciliationCircuit,
   type ProviderReconciliationQuarantine,
 } from "./provider-reconciliation";
 import {
@@ -345,6 +349,7 @@ const awsOrphanSweepFirstAlarmKey = "aws-orphan-sweep:first-alarm";
 const azureOrphanSweepRecordKey = "azure-orphan-sweep:last";
 const azureOrphanSweepFirstAlarmKey = "azure-orphan-sweep:first-alarm";
 const providerReconciliationStatePrefix = "provider-reconciliation:";
+const providerReconciliationCircuitPrefix = "provider-reconciliation-circuit:";
 const awsIngressReconcileRecordKey = "aws-ingress-reconcile:pending";
 const azureDeferredCleanupPrefix = "azure-cleanup:";
 const readyPoolPrefix = "ready-pool:";
@@ -13485,6 +13490,16 @@ export class FleetCoordinator {
     let macHostsScanned = 0;
     for (const region of config.regions) {
       try {
+        const circuitKey = providerReconciliationCircuitKey("aws", region);
+        // oxlint-disable-next-line eslint/no-await-in-loop -- each provider scope has independent failure state.
+        const circuit = await this.state.storage.get<ProviderReconciliationCircuit>(circuitKey);
+        if (providerReconciliationCircuitOpen(circuit, Date.now())) {
+          errors.push({
+            region,
+            message: `reconciliation circuit open until ${circuit?.retryAt}`,
+          });
+          continue;
+        }
         // oxlint-disable-next-line eslint/no-await-in-loop -- reconciliation state is scoped to the provider region.
         const state = await this.state.storage.get<ProviderReconciliationScopeState>(
           providerReconciliationStateKey("aws", region),
@@ -13510,9 +13525,23 @@ export class FleetCoordinator {
           macHostsScanned += macHosts.length;
           macHostInventory.push(...macHosts.map((host) => ({ client, host, region })));
         }
+        // oxlint-disable-next-line eslint/no-await-in-loop -- clear the exact scope after a successful inventory.
+        await this.state.storage.put(circuitKey, recordProviderReconciliationSuccess());
       } catch (error) {
         const message = coordinatorErrorMessage(this.env, error);
         errors.push({ region, message });
+        const circuitKey = providerReconciliationCircuitKey("aws", region);
+        // oxlint-disable-next-line eslint/no-await-in-loop -- preserve failure state for the exact provider scope.
+        const previous = await this.state.storage.get<ProviderReconciliationCircuit>(circuitKey);
+        // oxlint-disable-next-line eslint/no-await-in-loop -- the next admin sweep must observe this failure.
+        await this.state.storage.put(
+          circuitKey,
+          recordProviderReconciliationFailure({
+            ...(previous ? { previous } : {}),
+            now: Date.now(),
+            error: message,
+          }),
+        );
         console.warn(`aws orphan sweep failed region=${region}: ${message}`);
       }
     }
@@ -13763,35 +13792,55 @@ export class FleetCoordinator {
     let scanned = 0;
     const inventoryRegion = config.regions[0] ?? this.env.CRABBOX_AZURE_LOCATION ?? "eastus";
     try {
-      // Azure inventory is resource-group scoped, not location scoped. One successful read is authoritative.
-      const machines = await this.provider("azure", inventoryRegion).listCrabboxServers();
-      const inventoryScopes = new Set(config.regions);
-      inventoryScopes.add(inventoryRegion);
-      for (const machine of machines) {
-        scanned += 1;
-        const candidateRegion = machine.region || inventoryRegion;
-        inventoryScopes.add(candidateRegion);
-        inventory.push({ machine, region: candidateRegion });
-      }
-      for (const scope of inventoryScopes) {
-        // oxlint-disable-next-line eslint/no-await-in-loop -- each scope has an independent Durable Object record.
-        const state = await this.state.storage.get<ProviderReconciliationScopeState>(
-          providerReconciliationStateKey("azure", scope),
-        );
-        reconciliationStates.set(
-          scope,
-          state ?? {
-            provider: "azure",
+      const circuitKey = providerReconciliationCircuitKey("azure", inventoryRegion);
+      const circuit = await this.state.storage.get<ProviderReconciliationCircuit>(circuitKey);
+      if (providerReconciliationCircuitOpen(circuit, Date.now())) {
+        errors.push({
+          region: inventoryRegion,
+          message: `reconciliation circuit open until ${circuit?.retryAt}`,
+        });
+      } else {
+        // Azure inventory is resource-group scoped, not location scoped. One successful read is authoritative.
+        const machines = await this.provider("azure", inventoryRegion).listCrabboxServers();
+        const inventoryScopes = new Set(config.regions);
+        inventoryScopes.add(inventoryRegion);
+        for (const machine of machines) {
+          scanned += 1;
+          const candidateRegion = machine.region || inventoryRegion;
+          inventoryScopes.add(candidateRegion);
+          inventory.push({ machine, region: candidateRegion });
+        }
+        for (const scope of inventoryScopes) {
+          // oxlint-disable-next-line eslint/no-await-in-loop -- each scope has an independent Durable Object record.
+          const state = await this.state.storage.get<ProviderReconciliationScopeState>(
+            providerReconciliationStateKey("azure", scope),
+          );
+          reconciliationStates.set(
             scope,
-            quarantines: {},
-            updatedAt: startedAt,
-          },
-        );
-        nextQuarantines.set(scope, {});
+            state ?? {
+              provider: "azure",
+              scope,
+              quarantines: {},
+              updatedAt: startedAt,
+            },
+          );
+          nextQuarantines.set(scope, {});
+        }
+        await this.state.storage.put(circuitKey, recordProviderReconciliationSuccess());
       }
     } catch (error) {
       const message = coordinatorErrorMessage(this.env, error);
       errors.push({ region: inventoryRegion, message });
+      const circuitKey = providerReconciliationCircuitKey("azure", inventoryRegion);
+      const previous = await this.state.storage.get<ProviderReconciliationCircuit>(circuitKey);
+      await this.state.storage.put(
+        circuitKey,
+        recordProviderReconciliationFailure({
+          ...(previous ? { previous } : {}),
+          now: Date.now(),
+          error: message,
+        }),
+      );
       console.warn(`azure orphan sweep failed region=${inventoryRegion}: ${message}`);
     }
     const inventoryKeys = new Set(
@@ -20173,6 +20222,10 @@ function cloudOrphanSweepResourceKey(cloudID: string, region: string): string {
 
 function providerReconciliationStateKey(provider: Provider, scope: string): string {
   return `${providerReconciliationStatePrefix}${provider}:${encodeURIComponent(scope)}`;
+}
+
+function providerReconciliationCircuitKey(provider: Provider, scope: string): string {
+  return `${providerReconciliationCircuitPrefix}${provider}:${encodeURIComponent(scope)}`;
 }
 
 function recordCloudOrphanSweepOwnership(

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -13495,13 +13495,19 @@ export class FleetCoordinator {
         }
         // oxlint-disable-next-line eslint/no-await-in-loop -- regions are swept independently.
         const machines = await this.provider("aws", region).listCrabboxServers();
+        let macHostClient: EC2SpotClient | undefined;
+        let macHosts: AWSMacHost[] = [];
+        if (config.macHostReleaseEnabled) {
+          macHostClient = new EC2SpotClient(this.env, region);
+          // oxlint-disable-next-line eslint/no-await-in-loop -- keep host cleanup attached to its region.
+          macHosts = await macHostClient.listMacHosts();
+        }
+        // Do not advance destructive reconciliation until every inventory for this region succeeds.
         reconciliationObservedKeys.set(region, new Set());
         scanned += machines.length;
         inventory.push(...machines.map((machine) => ({ machine, region })));
-        if (config.macHostReleaseEnabled) {
-          const client = new EC2SpotClient(this.env, region);
-          // oxlint-disable-next-line eslint/no-await-in-loop -- keep host cleanup attached to its region.
-          const macHosts = await client.listMacHosts();
+        if (macHostClient) {
+          const client = macHostClient;
           macHostsScanned += macHosts.length;
           macHostInventory.push(...macHosts.map((host) => ({ client, host, region })));
         }

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -198,6 +198,11 @@ import {
   validatedProviderProvisioningCleanupClaim,
 } from "./provider-provisioning";
 import {
+  observeProviderReconciliationCandidate,
+  providerReconciliationFingerprint,
+  type ProviderReconciliationQuarantine,
+} from "./provider-reconciliation";
+import {
   readRuntimeAdapterRelayBody,
   runtimeAdapterProxyPath,
   runtimeAdapterRelayBodyAllowed,
@@ -339,6 +344,7 @@ const awsOrphanSweepRecordKey = "aws-orphan-sweep:last";
 const awsOrphanSweepFirstAlarmKey = "aws-orphan-sweep:first-alarm";
 const azureOrphanSweepRecordKey = "azure-orphan-sweep:last";
 const azureOrphanSweepFirstAlarmKey = "azure-orphan-sweep:first-alarm";
+const providerReconciliationStatePrefix = "provider-reconciliation:";
 const awsIngressReconcileRecordKey = "aws-ingress-reconcile:pending";
 const azureDeferredCleanupPrefix = "azure-cleanup:";
 const readyPoolPrefix = "ready-pool:";
@@ -824,12 +830,19 @@ interface CloudOrphanSweepCandidate {
   activeCloudID?: string;
   ownership: "coordinator-lease" | "provider-tags-only";
   ownershipLeaseID?: string;
-  action: "reported" | "terminated" | "terminate_failed";
+  action: "reported" | "quarantined" | "terminated" | "terminate_failed";
   error?: string;
 }
 
 type AWSOrphanSweepCandidate = CloudOrphanSweepCandidate;
 type AzureOrphanSweepCandidate = CloudOrphanSweepCandidate;
+
+interface ProviderReconciliationScopeState {
+  provider: Provider;
+  scope: string;
+  quarantines: Record<string, ProviderReconciliationQuarantine>;
+  updatedAt: string;
+}
 
 interface AWSMacHostSweepCandidate {
   region: string;
@@ -13466,12 +13479,28 @@ export class FleetCoordinator {
     const errors: AWSOrphanSweepRecord["errors"] = [];
     const inventory: Array<{ machine: ProviderMachine; region: string }> = [];
     const macHostInventory: Array<{ client: EC2SpotClient; host: AWSMacHost; region: string }> = [];
+    const reconciliationStates = new Map<string, ProviderReconciliationScopeState>();
+    const nextQuarantines = new Map<string, Record<string, ProviderReconciliationQuarantine>>();
     let scanned = 0;
     let macHostsScanned = 0;
     for (const region of config.regions) {
       try {
+        // oxlint-disable-next-line eslint/no-await-in-loop -- reconciliation state is scoped to the provider region.
+        const state = await this.state.storage.get<ProviderReconciliationScopeState>(
+          providerReconciliationStateKey("aws", region),
+        );
         // oxlint-disable-next-line eslint/no-await-in-loop -- regions are swept independently.
         const machines = await this.provider("aws", region).listCrabboxServers();
+        reconciliationStates.set(
+          region,
+          state ?? {
+            provider: "aws",
+            scope: region,
+            quarantines: {},
+            updatedAt: startedAt,
+          },
+        );
+        nextQuarantines.set(region, {});
         scanned += machines.length;
         inventory.push(...machines.map((machine) => ({ machine, region })));
         if (config.macHostReleaseEnabled) {
@@ -13540,12 +13569,35 @@ export class FleetCoordinator {
       }
       const cloudID = machine.cloudID || machine.name || String(machine.id);
       const ownershipLease = ownershipLeases.get(cloudOrphanSweepResourceKey(cloudID, region));
-      recordCloudOrphanSweepOwnership(candidate, ownershipLease);
-      if (config.deleteEnabled && ownershipLease) {
+      const exactOwnershipLease =
+        ownershipLease && providerMachineOwnedByLease(machine, ownershipLease, "aws")
+          ? ownershipLease
+          : undefined;
+      recordCloudOrphanSweepOwnership(candidate, exactOwnershipLease);
+      const state = reconciliationStates.get(region);
+      const scopeQuarantines = nextQuarantines.get(region);
+      const observation =
+        exactOwnershipLease && state && scopeQuarantines
+          ? observeProviderReconciliationCandidate({
+              fingerprint: providerReconciliationFingerprint("aws", region, machine),
+              ...(state.quarantines[cloudID] ? { previous: state.quarantines[cloudID] } : {}),
+              now,
+              quarantineSeconds: config.graceSeconds,
+            })
+          : undefined;
+      if (observation && scopeQuarantines) {
+        scopeQuarantines[cloudID] = observation.quarantine;
+        candidate.action = "quarantined";
+      }
+      if (config.deleteEnabled && exactOwnershipLease && observation?.action === "release") {
         try {
-          // oxlint-disable-next-line eslint/no-await-in-loop -- delete failures must stay attached to the candidate.
-          await this.provider("aws", region).deleteServer(machine.cloudID || String(machine.id));
+          // AWS release re-reads canonical ownership and deletes the exact instance; success means absent or terminated.
+          // oxlint-disable-next-line eslint/no-await-in-loop -- release failures must stay attached to the candidate.
+          await this.provider("aws", region).releaseLease(exactOwnershipLease);
           candidate.action = "terminated";
+          if (scopeQuarantines) {
+            delete scopeQuarantines[cloudID];
+          }
         } catch (error) {
           candidate.action = "terminate_failed";
           candidate.error = coordinatorErrorMessage(this.env, error);
@@ -13556,6 +13608,17 @@ export class FleetCoordinator {
       }
       candidates.push(candidate);
     }
+    await this.state.runExclusive(async () => {
+      for (const [region, quarantines] of nextQuarantines) {
+        // oxlint-disable-next-line eslint/no-await-in-loop -- each scope is one bounded state record.
+        await this.state.storage.put(providerReconciliationStateKey("aws", region), {
+          provider: "aws",
+          scope: region,
+          quarantines,
+          updatedAt: new Date(now).toISOString(),
+        } satisfies ProviderReconciliationScopeState);
+      }
+    });
     for (const { client, host, region } of macHostInventory) {
       const candidate = awsMacHostSweepCandidate(
         host,
@@ -13694,28 +13757,42 @@ export class FleetCoordinator {
     const now = Date.now();
     const candidates: AzureOrphanSweepCandidate[] = [];
     const errors: AzureOrphanSweepRecord["errors"] = [];
-    const seenCloudIDs = new Set<string>();
     const inventory: Array<{ machine: ProviderMachine; region: string }> = [];
+    const reconciliationStates = new Map<string, ProviderReconciliationScopeState>();
+    const nextQuarantines = new Map<string, Record<string, ProviderReconciliationQuarantine>>();
     let scanned = 0;
-    for (const region of config.regions) {
-      try {
-        // oxlint-disable-next-line eslint/no-await-in-loop -- regions are swept independently.
-        const machines = await this.provider("azure", region).listCrabboxServers();
-        for (const machine of machines) {
-          const cloudID = machine.cloudID || machine.name || String(machine.id);
-          if (seenCloudIDs.has(cloudID)) {
-            continue;
-          }
-          seenCloudIDs.add(cloudID);
-          scanned += 1;
-          const candidateRegion = machine.region || region;
-          inventory.push({ machine, region: candidateRegion });
-        }
-      } catch (error) {
-        const message = coordinatorErrorMessage(this.env, error);
-        errors.push({ region, message });
-        console.warn(`azure orphan sweep failed region=${region}: ${message}`);
+    const inventoryRegion = config.regions[0] ?? this.env.CRABBOX_AZURE_LOCATION ?? "eastus";
+    try {
+      // Azure inventory is resource-group scoped, not location scoped. One successful read is authoritative.
+      const machines = await this.provider("azure", inventoryRegion).listCrabboxServers();
+      const inventoryScopes = new Set(config.regions);
+      inventoryScopes.add(inventoryRegion);
+      for (const machine of machines) {
+        scanned += 1;
+        const candidateRegion = machine.region || inventoryRegion;
+        inventoryScopes.add(candidateRegion);
+        inventory.push({ machine, region: candidateRegion });
       }
+      for (const scope of inventoryScopes) {
+        // oxlint-disable-next-line eslint/no-await-in-loop -- each scope has an independent Durable Object record.
+        const state = await this.state.storage.get<ProviderReconciliationScopeState>(
+          providerReconciliationStateKey("azure", scope),
+        );
+        reconciliationStates.set(
+          scope,
+          state ?? {
+            provider: "azure",
+            scope,
+            quarantines: {},
+            updatedAt: startedAt,
+          },
+        );
+        nextQuarantines.set(scope, {});
+      }
+    } catch (error) {
+      const message = coordinatorErrorMessage(this.env, error);
+      errors.push({ region: inventoryRegion, message });
+      console.warn(`azure orphan sweep failed region=${inventoryRegion}: ${message}`);
     }
     const inventoryKeys = new Set(
       inventory.map(({ machine, region }) =>
@@ -13759,18 +13836,35 @@ export class FleetCoordinator {
         continue;
       }
       const ownershipLease = ownershipLeases.get(cloudOrphanSweepResourceKey(cloudID, region));
-      recordCloudOrphanSweepOwnership(candidate, ownershipLease);
-      if (config.deleteEnabled && ownershipLease) {
+      const exactOwnershipLease =
+        ownershipLease && providerMachineOwnedByLease(machine, ownershipLease, "azure")
+          ? ownershipLease
+          : undefined;
+      recordCloudOrphanSweepOwnership(candidate, exactOwnershipLease);
+      const state = reconciliationStates.get(region);
+      const scopeQuarantines = nextQuarantines.get(region);
+      const observation =
+        exactOwnershipLease && state && scopeQuarantines
+          ? observeProviderReconciliationCandidate({
+              fingerprint: providerReconciliationFingerprint("azure", region, machine),
+              ...(state.quarantines[cloudID] ? { previous: state.quarantines[cloudID] } : {}),
+              now,
+              quarantineSeconds: config.graceSeconds,
+            })
+          : undefined;
+      if (observation && scopeQuarantines) {
+        scopeQuarantines[cloudID] = observation.quarantine;
+        candidate.action = "quarantined";
+      }
+      if (config.deleteEnabled && exactOwnershipLease && observation?.action === "release") {
         try {
-          const provider = this.provider("azure", region);
-          if (!provider.deleteOwnedServer) {
-            throw new ProviderCleanupManualResolutionError(
-              `refusing to delete Azure lease ${ownershipLease.id}: exact owned-delete support is unavailable`,
-            );
-          }
-          // oxlint-disable-next-line eslint/no-await-in-loop -- delete failures must stay attached to the candidate.
-          await provider.deleteOwnedServer(ownershipLease);
+          // Azure release uses the persisted provider scope and resumable owned-resource deletion.
+          // oxlint-disable-next-line eslint/no-await-in-loop -- release failures must stay attached to the candidate.
+          await this.provider("azure", region).releaseLease(exactOwnershipLease);
           candidate.action = "terminated";
+          if (scopeQuarantines) {
+            delete scopeQuarantines[cloudID];
+          }
         } catch (error) {
           candidate.action = "terminate_failed";
           candidate.error = coordinatorErrorMessage(this.env, error);
@@ -13781,6 +13875,17 @@ export class FleetCoordinator {
       }
       candidates.push(candidate);
     }
+    await this.state.runExclusive(async () => {
+      for (const [region, quarantines] of nextQuarantines) {
+        // oxlint-disable-next-line eslint/no-await-in-loop -- each scope is one bounded state record.
+        await this.state.storage.put(providerReconciliationStateKey("azure", region), {
+          provider: "azure",
+          scope: region,
+          quarantines,
+          updatedAt: new Date(now).toISOString(),
+        } satisfies ProviderReconciliationScopeState);
+      }
+    });
     const finishedAt = new Date().toISOString();
     const record: AzureOrphanSweepRecord = {
       startedAt,
@@ -20064,6 +20169,10 @@ function cloudOrphanSweepCandidate(
 
 function cloudOrphanSweepResourceKey(cloudID: string, region: string): string {
   return JSON.stringify([region, cloudID]);
+}
+
+function providerReconciliationStateKey(provider: Provider, scope: string): string {
+  return `${providerReconciliationStatePrefix}${provider}:${encodeURIComponent(scope)}`;
 }
 
 function recordCloudOrphanSweepOwnership(

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -13522,7 +13522,7 @@ export class FleetCoordinator {
             error: message,
           }),
         );
-        console.warn(`aws orphan sweep failed region=${region}: ${message}`);
+        console.warn("aws orphan sweep inventory failed; inspect the sweep record for details");
       }
     }
     const inventoryKeys = new Set(
@@ -13807,7 +13807,7 @@ export class FleetCoordinator {
           error: message,
         }),
       );
-      console.warn(`azure orphan sweep failed region=${inventoryRegion}: ${message}`);
+      console.warn("azure orphan sweep inventory failed; inspect the sweep record for details");
     }
     const inventoryKeys = new Set(
       inventory.map(({ machine, region }) =>

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -204,6 +204,7 @@ import {
   recordProviderReconciliationFailure,
   recordProviderReconciliationSuccess,
   type ProviderReconciliationCircuit,
+  type ProviderReconciliationObservation,
   type ProviderReconciliationQuarantine,
 } from "./provider-reconciliation";
 import {
@@ -348,7 +349,7 @@ const awsOrphanSweepRecordKey = "aws-orphan-sweep:last";
 const awsOrphanSweepFirstAlarmKey = "aws-orphan-sweep:first-alarm";
 const azureOrphanSweepRecordKey = "azure-orphan-sweep:last";
 const azureOrphanSweepFirstAlarmKey = "azure-orphan-sweep:first-alarm";
-const providerReconciliationStatePrefix = "provider-reconciliation:";
+const providerReconciliationCandidatePrefix = "provider-reconciliation:";
 const providerReconciliationCircuitPrefix = "provider-reconciliation-circuit:";
 const awsIngressReconcileRecordKey = "aws-ingress-reconcile:pending";
 const azureDeferredCleanupPrefix = "azure-cleanup:";
@@ -841,13 +842,6 @@ interface CloudOrphanSweepCandidate {
 
 type AWSOrphanSweepCandidate = CloudOrphanSweepCandidate;
 type AzureOrphanSweepCandidate = CloudOrphanSweepCandidate;
-
-interface ProviderReconciliationScopeState {
-  provider: Provider;
-  scope: string;
-  quarantines: Record<string, ProviderReconciliationQuarantine>;
-  updatedAt: string;
-}
 
 interface AWSMacHostSweepCandidate {
   region: string;
@@ -13484,8 +13478,7 @@ export class FleetCoordinator {
     const errors: AWSOrphanSweepRecord["errors"] = [];
     const inventory: Array<{ machine: ProviderMachine; region: string }> = [];
     const macHostInventory: Array<{ client: EC2SpotClient; host: AWSMacHost; region: string }> = [];
-    const reconciliationStates = new Map<string, ProviderReconciliationScopeState>();
-    const nextQuarantines = new Map<string, Record<string, ProviderReconciliationQuarantine>>();
+    const reconciliationObservedKeys = new Map<string, Set<string>>();
     let scanned = 0;
     let macHostsScanned = 0;
     for (const region of config.regions) {
@@ -13500,22 +13493,9 @@ export class FleetCoordinator {
           });
           continue;
         }
-        // oxlint-disable-next-line eslint/no-await-in-loop -- reconciliation state is scoped to the provider region.
-        const state = await this.state.storage.get<ProviderReconciliationScopeState>(
-          providerReconciliationStateKey("aws", region),
-        );
         // oxlint-disable-next-line eslint/no-await-in-loop -- regions are swept independently.
         const machines = await this.provider("aws", region).listCrabboxServers();
-        reconciliationStates.set(
-          region,
-          state ?? {
-            provider: "aws",
-            scope: region,
-            quarantines: {},
-            updatedAt: startedAt,
-          },
-        );
-        nextQuarantines.set(region, {});
+        reconciliationObservedKeys.set(region, new Set());
         scanned += machines.length;
         inventory.push(...machines.map((machine) => ({ machine, region })));
         if (config.macHostReleaseEnabled) {
@@ -13603,30 +13583,31 @@ export class FleetCoordinator {
           ? ownershipLease
           : undefined;
       recordCloudOrphanSweepOwnership(candidate, exactOwnershipLease);
-      const state = reconciliationStates.get(region);
-      const scopeQuarantines = nextQuarantines.get(region);
+      const scopeObservedKeys = reconciliationObservedKeys.get(region);
       const observation =
-        exactOwnershipLease && state && scopeQuarantines
-          ? observeProviderReconciliationCandidate({
+        exactOwnershipLease && scopeObservedKeys
+          ? // oxlint-disable-next-line eslint/no-await-in-loop -- candidate state is read before its provider release decision.
+            await this.observeStoredProviderReconciliationCandidate({
+              provider: "aws",
+              scope: region,
+              resourceID: cloudID,
               fingerprint: providerReconciliationFingerprint("aws", region, machine),
-              ...(state.quarantines[cloudID] ? { previous: state.quarantines[cloudID] } : {}),
               now,
               quarantineSeconds: config.graceSeconds,
             })
           : undefined;
-      if (observation && scopeQuarantines) {
-        scopeQuarantines[cloudID] = observation.quarantine;
+      if (observation && scopeObservedKeys) {
+        scopeObservedKeys.add(observation.key);
         candidate.action = "quarantined";
       }
+      let released = false;
       if (config.deleteEnabled && exactOwnershipLease && observation?.action === "release") {
         try {
           // AWS release re-reads canonical ownership and deletes the exact instance; success means absent or terminated.
           // oxlint-disable-next-line eslint/no-await-in-loop -- release failures must stay attached to the candidate.
           await this.provider("aws", region).releaseLease(exactOwnershipLease);
           candidate.action = "terminated";
-          if (scopeQuarantines) {
-            delete scopeQuarantines[cloudID];
-          }
+          released = true;
         } catch (error) {
           candidate.action = "terminate_failed";
           candidate.error = coordinatorErrorMessage(this.env, error);
@@ -13635,19 +13616,22 @@ export class FleetCoordinator {
           );
         }
       }
+      if (observation) {
+        if (released) {
+          // oxlint-disable-next-line eslint/no-await-in-loop -- persist each candidate's final state before advancing.
+          await this.state.storage.delete(observation.key);
+        } else {
+          // oxlint-disable-next-line eslint/no-await-in-loop -- persist each candidate's final state before advancing.
+          await this.state.storage.put(observation.key, observation.quarantine);
+        }
+      }
       candidates.push(candidate);
     }
-    await this.state.runExclusive(async () => {
-      for (const [region, quarantines] of nextQuarantines) {
-        // oxlint-disable-next-line eslint/no-await-in-loop -- each scope is one bounded state record.
-        await this.state.storage.put(providerReconciliationStateKey("aws", region), {
-          provider: "aws",
-          scope: region,
-          quarantines,
-          updatedAt: new Date(now).toISOString(),
-        } satisfies ProviderReconciliationScopeState);
-      }
-    });
+    for (const [region, observedKeys] of reconciliationObservedKeys) {
+      // A successful regional inventory is authoritative for every previously quarantined resource in that region.
+      // oxlint-disable-next-line eslint/no-await-in-loop -- each provider scope is cleared independently.
+      await this.clearUnobservedProviderReconciliationCandidates("aws", region, observedKeys);
+    }
     for (const { client, host, region } of macHostInventory) {
       const candidate = awsMacHostSweepCandidate(
         host,
@@ -13787,8 +13771,8 @@ export class FleetCoordinator {
     const candidates: AzureOrphanSweepCandidate[] = [];
     const errors: AzureOrphanSweepRecord["errors"] = [];
     const inventory: Array<{ machine: ProviderMachine; region: string }> = [];
-    const reconciliationStates = new Map<string, ProviderReconciliationScopeState>();
-    const nextQuarantines = new Map<string, Record<string, ProviderReconciliationQuarantine>>();
+    const reconciliationObservedKeys = new Set<string>();
+    let inventorySucceeded = false;
     let scanned = 0;
     const inventoryRegion = config.regions[0] ?? this.env.CRABBOX_AZURE_LOCATION ?? "eastus";
     try {
@@ -13802,30 +13786,12 @@ export class FleetCoordinator {
       } else {
         // Azure inventory is resource-group scoped, not location scoped. One successful read is authoritative.
         const machines = await this.provider("azure", inventoryRegion).listCrabboxServers();
-        const inventoryScopes = new Set(config.regions);
-        inventoryScopes.add(inventoryRegion);
         for (const machine of machines) {
           scanned += 1;
           const candidateRegion = machine.region || inventoryRegion;
-          inventoryScopes.add(candidateRegion);
           inventory.push({ machine, region: candidateRegion });
         }
-        for (const scope of inventoryScopes) {
-          // oxlint-disable-next-line eslint/no-await-in-loop -- each scope has an independent Durable Object record.
-          const state = await this.state.storage.get<ProviderReconciliationScopeState>(
-            providerReconciliationStateKey("azure", scope),
-          );
-          reconciliationStates.set(
-            scope,
-            state ?? {
-              provider: "azure",
-              scope,
-              quarantines: {},
-              updatedAt: startedAt,
-            },
-          );
-          nextQuarantines.set(scope, {});
-        }
+        inventorySucceeded = true;
         await this.state.storage.put(circuitKey, recordProviderReconciliationSuccess());
       }
     } catch (error) {
@@ -13890,30 +13856,30 @@ export class FleetCoordinator {
           ? ownershipLease
           : undefined;
       recordCloudOrphanSweepOwnership(candidate, exactOwnershipLease);
-      const state = reconciliationStates.get(region);
-      const scopeQuarantines = nextQuarantines.get(region);
       const observation =
-        exactOwnershipLease && state && scopeQuarantines
-          ? observeProviderReconciliationCandidate({
+        exactOwnershipLease && inventorySucceeded
+          ? // oxlint-disable-next-line eslint/no-await-in-loop -- candidate state is read before its provider release decision.
+            await this.observeStoredProviderReconciliationCandidate({
+              provider: "azure",
+              scope: region,
+              resourceID: cloudID,
               fingerprint: providerReconciliationFingerprint("azure", region, machine),
-              ...(state.quarantines[cloudID] ? { previous: state.quarantines[cloudID] } : {}),
               now,
               quarantineSeconds: config.graceSeconds,
             })
           : undefined;
-      if (observation && scopeQuarantines) {
-        scopeQuarantines[cloudID] = observation.quarantine;
+      if (observation) {
+        reconciliationObservedKeys.add(observation.key);
         candidate.action = "quarantined";
       }
+      let released = false;
       if (config.deleteEnabled && exactOwnershipLease && observation?.action === "release") {
         try {
           // Azure release uses the persisted provider scope and resumable owned-resource deletion.
           // oxlint-disable-next-line eslint/no-await-in-loop -- release failures must stay attached to the candidate.
           await this.provider("azure", region).releaseLease(exactOwnershipLease);
           candidate.action = "terminated";
-          if (scopeQuarantines) {
-            delete scopeQuarantines[cloudID];
-          }
+          released = true;
         } catch (error) {
           candidate.action = "terminate_failed";
           candidate.error = coordinatorErrorMessage(this.env, error);
@@ -13922,19 +13888,26 @@ export class FleetCoordinator {
           );
         }
       }
+      if (observation) {
+        if (released) {
+          // oxlint-disable-next-line eslint/no-await-in-loop -- persist each candidate's final state before advancing.
+          await this.state.storage.delete(observation.key);
+        } else {
+          // oxlint-disable-next-line eslint/no-await-in-loop -- persist each candidate's final state before advancing.
+          await this.state.storage.put(observation.key, observation.quarantine);
+        }
+      }
       candidates.push(candidate);
     }
-    await this.state.runExclusive(async () => {
-      for (const [region, quarantines] of nextQuarantines) {
-        // oxlint-disable-next-line eslint/no-await-in-loop -- each scope is one bounded state record.
-        await this.state.storage.put(providerReconciliationStateKey("azure", region), {
-          provider: "azure",
-          scope: region,
-          quarantines,
-          updatedAt: new Date(now).toISOString(),
-        } satisfies ProviderReconciliationScopeState);
-      }
-    });
+    if (inventorySucceeded) {
+      // Azure returns a resource-group-wide inventory. Clear stale candidates from every location,
+      // including locations omitted from an empty authoritative response.
+      await this.clearUnobservedProviderReconciliationCandidates(
+        "azure",
+        undefined,
+        reconciliationObservedKeys,
+      );
+    }
     const finishedAt = new Date().toISOString();
     const record: AzureOrphanSweepRecord = {
       startedAt,
@@ -14135,6 +14108,43 @@ export class FleetCoordinator {
     visitor: (lease: LeaseRecord) => Promise<boolean | void> | boolean | void,
   ): Promise<void> {
     await this.visitStorageRecords("lease:", visitor);
+  }
+
+  private async observeStoredProviderReconciliationCandidate(input: {
+    provider: Provider;
+    scope: string;
+    resourceID: string;
+    fingerprint: string;
+    now: number;
+    quarantineSeconds: number;
+  }): Promise<ProviderReconciliationObservation & { key: string }> {
+    const key = providerReconciliationCandidateKey(input.provider, input.scope, input.resourceID);
+    const previous = await this.state.storage.get<ProviderReconciliationQuarantine>(key);
+    return {
+      key,
+      ...observeProviderReconciliationCandidate({
+        fingerprint: input.fingerprint,
+        ...(previous ? { previous } : {}),
+        now: input.now,
+        quarantineSeconds: input.quarantineSeconds,
+      }),
+    };
+  }
+
+  private async clearUnobservedProviderReconciliationCandidates(
+    provider: Provider,
+    scope: string | undefined,
+    observedKeys: ReadonlySet<string>,
+  ): Promise<void> {
+    const prefix = providerReconciliationCandidatesPrefix(provider, scope);
+    await this.visitStorageRecords<ProviderReconciliationQuarantine>(
+      prefix,
+      async (_record, key) => {
+        if (!observedKeys.has(key)) {
+          await this.state.storage.delete(key);
+        }
+      },
+    );
   }
 
   private async visitStorageRecords<T>(
@@ -20220,8 +20230,17 @@ function cloudOrphanSweepResourceKey(cloudID: string, region: string): string {
   return JSON.stringify([region, cloudID]);
 }
 
-function providerReconciliationStateKey(provider: Provider, scope: string): string {
-  return `${providerReconciliationStatePrefix}${provider}:${encodeURIComponent(scope)}`;
+function providerReconciliationCandidatesPrefix(provider: Provider, scope?: string): string {
+  const providerPrefix = `${providerReconciliationCandidatePrefix}${provider}:`;
+  return scope === undefined ? providerPrefix : `${providerPrefix}${encodeURIComponent(scope)}:`;
+}
+
+function providerReconciliationCandidateKey(
+  provider: Provider,
+  scope: string,
+  resourceID: string,
+): string {
+  return `${providerReconciliationCandidatesPrefix(provider, scope)}${encodeURIComponent(resourceID)}`;
 }
 
 function providerReconciliationCircuitKey(provider: Provider, scope: string): string {

--- a/worker/src/provider-reconciliation.ts
+++ b/worker/src/provider-reconciliation.ts
@@ -29,11 +29,7 @@ export function providerReconciliationFingerprint(
   scope: string,
   machine: Pick<ProviderMachine, "cloudID" | "id" | "name" | "labels">,
 ): string {
-  const labels = Object.fromEntries(
-    Object.entries(machine.labels ?? {}).toSorted(([left], [right]) =>
-      left < right ? -1 : left > right ? 1 : 0,
-    ),
-  );
+  const labels = machine.labels ?? {};
   return JSON.stringify({
     provider,
     scope,
@@ -43,7 +39,9 @@ export function providerReconciliationFingerprint(
     owner: labels["owner"] ?? "",
     providerLabel: labels["provider"] ?? "",
     slug: labels["slug"] ?? "",
-    labels,
+    keep: labels["keep"] ?? "",
+    createdAt: labels["created_at"] ?? "",
+    expiresAt: labels["expires_at"] ?? "",
   });
 }
 

--- a/worker/src/provider-reconciliation.ts
+++ b/worker/src/provider-reconciliation.ts
@@ -1,0 +1,106 @@
+import type { Provider, ProviderMachine } from "./types";
+
+export interface ProviderReconciliationQuarantine {
+  fingerprint: string;
+  firstObservedAt: string;
+  lastObservedAt: string;
+  eligibleAt: string;
+  observations: number;
+}
+
+export interface ProviderReconciliationCircuit {
+  consecutiveFailures: number;
+  retryAt?: string;
+  lastError?: string;
+}
+
+export type ProviderReconciliationObservation =
+  | {
+      action: "quarantine";
+      quarantine: ProviderReconciliationQuarantine;
+    }
+  | {
+      action: "release";
+      quarantine: ProviderReconciliationQuarantine;
+    };
+
+export function providerReconciliationFingerprint(
+  provider: Provider,
+  scope: string,
+  machine: Pick<ProviderMachine, "cloudID" | "id" | "name" | "labels">,
+): string {
+  const labels = Object.fromEntries(
+    Object.entries(machine.labels ?? {}).sort(([left], [right]) =>
+      left < right ? -1 : left > right ? 1 : 0,
+    ),
+  );
+  return JSON.stringify({
+    provider,
+    scope,
+    cloudID: machine.cloudID || String(machine.id),
+    name: machine.name,
+    lease: labels["lease"] ?? "",
+    owner: labels["owner"] ?? "",
+    providerLabel: labels["provider"] ?? "",
+    slug: labels["slug"] ?? "",
+    labels,
+  });
+}
+
+export function observeProviderReconciliationCandidate(input: {
+  fingerprint: string;
+  previous?: ProviderReconciliationQuarantine;
+  now: number;
+  quarantineSeconds: number;
+}): ProviderReconciliationObservation {
+  const observedAt = new Date(input.now).toISOString();
+  const sameIdentity = input.previous?.fingerprint === input.fingerprint;
+  const previousEligibleAt = Date.parse(input.previous?.eligibleAt ?? "");
+  const observations = sameIdentity ? (input.previous?.observations ?? 0) + 1 : 1;
+  const eligibleAt = sameIdentity
+    ? input.previous!.eligibleAt
+    : new Date(input.now + Math.max(0, input.quarantineSeconds) * 1000).toISOString();
+  const quarantine: ProviderReconciliationQuarantine = {
+    fingerprint: input.fingerprint,
+    firstObservedAt: sameIdentity ? input.previous!.firstObservedAt : observedAt,
+    lastObservedAt: observedAt,
+    eligibleAt,
+    observations,
+  };
+  const release =
+    sameIdentity &&
+    observations >= 2 &&
+    Number.isFinite(previousEligibleAt) &&
+    input.now >= previousEligibleAt;
+  return {
+    action: release ? "release" : "quarantine",
+    quarantine,
+  };
+}
+
+export function recordProviderReconciliationSuccess(): ProviderReconciliationCircuit {
+  return { consecutiveFailures: 0 };
+}
+
+export function recordProviderReconciliationFailure(input: {
+  previous?: ProviderReconciliationCircuit;
+  now: number;
+  error: string;
+}): ProviderReconciliationCircuit {
+  const consecutiveFailures = (input.previous?.consecutiveFailures ?? 0) + 1;
+  const delayMs =
+    consecutiveFailures < 3 ? 0 : Math.min(60, 5 * 3 ** (consecutiveFailures - 3)) * 60 * 1000;
+  return {
+    consecutiveFailures,
+    ...(delayMs > 0 ? { retryAt: new Date(input.now + delayMs).toISOString() } : {}),
+    lastError: input.error,
+  };
+}
+
+export function providerReconciliationCircuitOpen(
+  circuit: ProviderReconciliationCircuit | undefined,
+  now: number,
+): boolean {
+  const retryAt = Date.parse(circuit?.retryAt ?? "");
+  return Number.isFinite(retryAt) && now < retryAt;
+}

--- a/worker/src/provider-reconciliation.ts
+++ b/worker/src/provider-reconciliation.ts
@@ -30,7 +30,7 @@ export function providerReconciliationFingerprint(
   machine: Pick<ProviderMachine, "cloudID" | "id" | "name" | "labels">,
 ): string {
   const labels = Object.fromEntries(
-    Object.entries(machine.labels ?? {}).sort(([left], [right]) =>
+    Object.entries(machine.labels ?? {}).toSorted(([left], [right]) =>
       left < right ? -1 : left > right ? 1 : 0,
     ),
   );

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -11651,6 +11651,75 @@ describe("fleet lease identity and idle", () => {
     });
   });
 
+  it("preserves AWS quarantine when EC2 Mac host inventory fails", async () => {
+    const storage = new MemoryStorage();
+    const deleted: string[] = [];
+    const oldSeconds = String(Math.trunc((Date.now() - 60 * 60 * 1000) / 1000));
+    const orphanMachine = testMachine({
+      cloudID: "i-orphan",
+      labels: {
+        crabbox: "true",
+        created_by: "crabbox",
+        provider: "aws",
+        lease: "cbx_000000000776",
+        slug: "blue-lobster",
+        owner: "peter_example.com",
+        created_at: oldSeconds,
+        expires_at: oldSeconds,
+      },
+    });
+    storage.seed(
+      "lease:cbx_000000000776",
+      testLease({
+        id: "cbx_000000000776",
+        provider: "aws",
+        cloudID: "i-orphan",
+        region: "eu-west-1",
+        state: "expired",
+        keep: false,
+      }),
+    );
+    seedProviderReconciliationEligible(storage, "aws", "eu-west-1", orphanMachine);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        ec2XMLResponse(
+          "<ErrorResponse><Error><Code>UnauthorizedOperation</Code></Error></ErrorResponse>",
+          403,
+        ),
+      ),
+    );
+    const fleet = testFleet(
+      storage,
+      {
+        aws: fakeProvider(undefined, { provider: "aws", servers: [orphanMachine] }, async (id) => {
+          deleted.push(id);
+        }),
+      },
+      {
+        AWS_ACCESS_KEY_ID: "test",
+        AWS_SECRET_ACCESS_KEY: "secret",
+        CRABBOX_AWS_ORPHAN_SWEEP_DELETE: "1",
+        CRABBOX_AWS_MAC_HOST_SWEEP_RELEASE: "1",
+        CRABBOX_AWS_ORPHAN_SWEEP_GRACE_SECONDS: "1",
+        CRABBOX_AWS_REGION: "eu-west-1",
+      },
+    );
+
+    await fleet.alarm();
+
+    expect(deleted).toEqual([]);
+    expect(storage.value("provider-reconciliation:aws:eu-west-1:i-orphan")).toMatchObject({
+      observations: 1,
+    });
+    expect(storage.value("aws-orphan-sweep:last")).toMatchObject({
+      scanned: 0,
+      terminated: 0,
+      candidates: [],
+      errors: [expect.objectContaining({ region: "eu-west-1" })],
+    });
+  });
+
   it("releases stale pending EC2 Mac hosts during the AWS orphan sweep", async () => {
     const storage = new MemoryStorage();
     const actions: string[] = [];

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -48,6 +48,7 @@ import {
   ProviderProvisioningCleanupError,
   providerProvisioningCleanupClaim,
 } from "../src/provider-provisioning";
+import { providerReconciliationFingerprint } from "../src/provider-reconciliation";
 import {
   runtimeAdapterDesktopRelayTimeoutMs,
   runtimeAdapterRelayFrameLimit,
@@ -11065,10 +11066,86 @@ describe("fleet lease identity and idle", () => {
     });
   });
 
+  it("quarantines an exactly owned AWS candidate before releasing it", async () => {
+    const storage = new MemoryStorage();
+    const deleted: string[] = [];
+    const oldSeconds = String(Math.trunc((Date.now() - 60 * 60 * 1000) / 1000));
+    const orphanMachine = testMachine({
+      cloudID: "i-orphan",
+      labels: {
+        crabbox: "true",
+        created_by: "crabbox",
+        provider: "aws",
+        lease: "cbx_000000000776",
+        slug: "blue-lobster",
+        owner: "peter_example.com",
+        created_at: oldSeconds,
+        expires_at: oldSeconds,
+      },
+    });
+    storage.seed(
+      "lease:cbx_000000000776",
+      testLease({
+        id: "cbx_000000000776",
+        provider: "aws",
+        cloudID: "i-orphan",
+        region: "eu-west-1",
+        state: "expired",
+        keep: false,
+      }),
+    );
+    const fleet = testFleet(
+      storage,
+      {
+        aws: fakeProvider(undefined, { provider: "aws", servers: [orphanMachine] }, async (id) => {
+          deleted.push(id);
+        }),
+      },
+      {
+        AWS_ACCESS_KEY_ID: "test",
+        AWS_SECRET_ACCESS_KEY: "secret",
+        CRABBOX_AWS_ORPHAN_SWEEP_DELETE: "1",
+        CRABBOX_AWS_ORPHAN_SWEEP_GRACE_SECONDS: "1",
+      },
+    );
+
+    await fleet.alarm();
+
+    expect(deleted).toEqual([]);
+    expect(storage.value("aws-orphan-sweep:last")).toMatchObject({
+      terminated: 0,
+      candidates: [
+        expect.objectContaining({
+          cloudID: "i-orphan",
+          ownership: "coordinator-lease",
+          action: "quarantined",
+        }),
+      ],
+    });
+    expect(
+      storage.value<{ quarantines: Record<string, unknown> }>(
+        "provider-reconciliation:aws:eu-west-1",
+      )?.quarantines,
+    ).toHaveProperty("i-orphan");
+  });
+
   it("terminates AWS orphan sweep candidates with exact coordinator ownership", async () => {
     const storage = new MemoryStorage();
     const deleted: string[] = [];
     const oldSeconds = String(Math.trunc((Date.now() - 60 * 60 * 1000) / 1000));
+    const orphanMachine = testMachine({
+      cloudID: "i-orphan",
+      labels: {
+        crabbox: "true",
+        created_by: "crabbox",
+        provider: "aws",
+        lease: "cbx_000000000776",
+        slug: "blue-lobster",
+        owner: "peter_example.com",
+        created_at: oldSeconds,
+        expires_at: oldSeconds,
+      },
+    });
     storage.seed(
       "lease:cbx_000000000776",
       testLease({
@@ -11091,6 +11168,7 @@ describe("fleet lease identity and idle", () => {
         keep: false,
       }),
     );
+    seedProviderReconciliationEligible(storage, "aws", "eu-west-1", orphanMachine);
     const fleet = testFleet(
       storage,
       {
@@ -11099,15 +11177,7 @@ describe("fleet lease identity and idle", () => {
           {
             provider: "aws",
             servers: [
-              testMachine({
-                cloudID: "i-orphan",
-                labels: {
-                  crabbox: "true",
-                  lease: "cbx_missing",
-                  created_at: oldSeconds,
-                  expires_at: oldSeconds,
-                },
-              }),
+              orphanMachine,
               testMachine({
                 cloudID: "i-wrong-region",
                 labels: {
@@ -11157,9 +11227,24 @@ describe("fleet lease identity and idle", () => {
   it("deletes only coordinator-owned Azure orphan sweep candidates", async () => {
     const storage = new MemoryStorage();
     const list = vi.spyOn(storage, "list");
-    const rawDeleted: string[] = [];
     const ownedDeleted: LeaseRecord[] = [];
     const oldSeconds = String(Math.trunc((Date.now() - 60 * 60 * 1000) / 1000));
+    const orphanMachine = testMachine({
+      provider: "azure",
+      cloudID: "vm-orphan",
+      region: "westus2",
+      name: "vm-orphan",
+      labels: {
+        crabbox: "true",
+        created_by: "crabbox",
+        provider: "azure",
+        lease: "cbx_000000000776",
+        slug: "blue-lobster",
+        owner: "peter_example.com",
+        created_at: oldSeconds,
+        expires_at: oldSeconds,
+      },
+    });
     storage.seed(
       "lease:cbx_000000000776",
       testLease({
@@ -11229,107 +11314,87 @@ describe("fleet lease identity and idle", () => {
         }),
       );
     }
+    seedProviderReconciliationEligible(storage, "azure", "westus2", orphanMachine);
     const fleet = testFleet(
       storage,
       {
-        azure: fakeProvider(
-          undefined,
-          {
-            provider: "azure",
-            servers: [
-              testMachine({
-                provider: "azure",
-                cloudID: "vm-orphan",
-                region: "westus2",
-                name: "vm-orphan",
-                labels: {
-                  crabbox: "true",
-                  created_by: "crabbox",
-                  provider: "azure",
-                  lease: "cbx_000000000776",
-                  slug: "blue-lobster",
-                  owner: "peter@example.com",
-                  created_at: oldSeconds,
-                  expires_at: oldSeconds,
-                },
-              }),
-              testMachine({
-                provider: "azure",
-                cloudID: "vm-kept",
-                name: "vm-kept",
-                labels: {
-                  crabbox: "true",
-                  keep: "true",
-                  lease: "cbx_missing",
-                  created_at: oldSeconds,
-                  expires_at: oldSeconds,
-                },
-              }),
-              testMachine({
-                provider: "azure",
-                cloudID: "vm-tag-only",
-                region: "westus2",
-                name: "vm-tag-only",
-                labels: {
-                  crabbox: "true",
-                  lease: "cbx_missing",
-                  created_at: oldSeconds,
-                  expires_at: oldSeconds,
-                },
-              }),
-              testMachine({
-                provider: "azure",
-                cloudID: "vm-provisioning",
-                name: "vm-provisioning",
-                labels: {
-                  crabbox: "true",
-                  lease: "cbx_000000000777",
-                  created_at: oldSeconds,
-                  expires_at: oldSeconds,
-                },
-              }),
-              testMachine({
-                provider: "azure",
-                cloudID: "vm-cleaning",
-                name: "vm-cleaning",
-                labels: {
-                  crabbox: "true",
-                  lease: "cbx_000000000778",
-                  created_at: oldSeconds,
-                  expires_at: oldSeconds,
-                },
-              }),
-              testMachine({
-                provider: "azure",
-                cloudID: "vm-retaining",
-                name: "vm-retaining",
-                labels: {
-                  crabbox: "true",
-                  lease: "cbx_000000000779",
-                  created_at: oldSeconds,
-                  expires_at: oldSeconds,
-                },
-              }),
-              testMachine({
-                provider: "azure",
-                cloudID: "vm-retained",
-                name: "vm-retained",
-                labels: {
-                  crabbox: "true",
-                  lease: "cbx_000000000780",
-                  created_at: oldSeconds,
-                  expires_at: oldSeconds,
-                },
-              }),
-            ],
-            onDeleteOwnedServer(lease) {
-              ownedDeleted.push(structuredClone(lease));
-            },
+        azure: fakeProvider(undefined, {
+          provider: "azure",
+          servers: [
+            orphanMachine,
+            testMachine({
+              provider: "azure",
+              cloudID: "vm-kept",
+              name: "vm-kept",
+              labels: {
+                crabbox: "true",
+                keep: "true",
+                lease: "cbx_missing",
+                created_at: oldSeconds,
+                expires_at: oldSeconds,
+              },
+            }),
+            testMachine({
+              provider: "azure",
+              cloudID: "vm-tag-only",
+              region: "westus2",
+              name: "vm-tag-only",
+              labels: {
+                crabbox: "true",
+                lease: "cbx_missing",
+                created_at: oldSeconds,
+                expires_at: oldSeconds,
+              },
+            }),
+            testMachine({
+              provider: "azure",
+              cloudID: "vm-provisioning",
+              name: "vm-provisioning",
+              labels: {
+                crabbox: "true",
+                lease: "cbx_000000000777",
+                created_at: oldSeconds,
+                expires_at: oldSeconds,
+              },
+            }),
+            testMachine({
+              provider: "azure",
+              cloudID: "vm-cleaning",
+              name: "vm-cleaning",
+              labels: {
+                crabbox: "true",
+                lease: "cbx_000000000778",
+                created_at: oldSeconds,
+                expires_at: oldSeconds,
+              },
+            }),
+            testMachine({
+              provider: "azure",
+              cloudID: "vm-retaining",
+              name: "vm-retaining",
+              labels: {
+                crabbox: "true",
+                lease: "cbx_000000000779",
+                created_at: oldSeconds,
+                expires_at: oldSeconds,
+              },
+            }),
+            testMachine({
+              provider: "azure",
+              cloudID: "vm-retained",
+              name: "vm-retained",
+              labels: {
+                crabbox: "true",
+                lease: "cbx_000000000780",
+                created_at: oldSeconds,
+                expires_at: oldSeconds,
+              },
+            }),
+          ],
+          onReleaseLease(lease) {
+            ownedDeleted.push(structuredClone(lease));
           },
-          async (id) => {
-            rawDeleted.push(id);
-          },
-        ),
+        }),
       },
       {
         AZURE_TENANT_ID: "tenant",
@@ -11349,7 +11414,6 @@ describe("fleet lease identity and idle", () => {
       terminated: number;
       candidates: Array<Record<string, unknown>>;
     }>("azure-orphan-sweep:last");
-    expect(rawDeleted).toEqual([]);
     expect(ownedDeleted).toEqual([
       expect.objectContaining({
         id: "cbx_000000000776",
@@ -11383,7 +11447,7 @@ describe("fleet lease identity and idle", () => {
     ]);
   });
 
-  it("keeps Azure orphan sweep candidates when exact owned deletion rejects them", async () => {
+  it("keeps Azure candidates report-only when provider labels do not match the lease", async () => {
     const storage = new MemoryStorage();
     const rawDeleted: string[] = [];
     const ownedDeleted: LeaseRecord[] = [];
@@ -11425,11 +11489,8 @@ describe("fleet lease identity and idle", () => {
                 },
               }),
             ],
-            onDeleteOwnedServer(lease) {
+            onReleaseLease(lease) {
               ownedDeleted.push(structuredClone(lease));
-              throw new Error(
-                `refusing to delete Azure VM vm-replaced: ownership does not match lease ${lease.id}`,
-              );
             },
           },
           async (id) => {
@@ -11451,9 +11512,7 @@ describe("fleet lease identity and idle", () => {
     await fleet.alarm();
 
     expect(rawDeleted).toEqual([]);
-    expect(ownedDeleted).toEqual([
-      expect.objectContaining({ id: "cbx_000000000776", cloudID: "vm-replaced" }),
-    ]);
+    expect(ownedDeleted).toEqual([]);
     expect(storage.value("azure-orphan-sweep:last")).toMatchObject({
       mode: "delete",
       terminated: 0,
@@ -11461,12 +11520,57 @@ describe("fleet lease identity and idle", () => {
         expect.objectContaining({
           cloudID: "vm-replaced",
           leaseID: "cbx_replacement",
-          ownership: "coordinator-lease",
-          ownershipLeaseID: "cbx_000000000776",
-          action: "terminate_failed",
-          error: expect.stringContaining("ownership does not match lease cbx_000000000776"),
+          ownership: "provider-tags-only",
+          action: "reported",
         }),
       ],
+    });
+  });
+
+  it("preserves Azure quarantine state when inventory fails", async () => {
+    const storage = new MemoryStorage();
+    const quarantine = {
+      fingerprint: "existing",
+      firstObservedAt: "2026-07-31T10:00:00.000Z",
+      lastObservedAt: "2026-07-31T10:00:00.000Z",
+      eligibleAt: "2026-07-31T10:15:00.000Z",
+      observations: 1,
+    };
+    storage.seed("provider-reconciliation:azure:eastus", {
+      provider: "azure",
+      scope: "eastus",
+      quarantines: { "vm-orphan": quarantine },
+      updatedAt: "2026-07-31T10:00:00.000Z",
+    });
+    const fleet = testFleet(
+      storage,
+      {
+        azure: fakeProvider(undefined, {
+          provider: "azure",
+          async onList() {
+            throw new Error("inventory unavailable");
+          },
+        }),
+      },
+      {
+        AZURE_TENANT_ID: "tenant",
+        AZURE_CLIENT_ID: "client",
+        AZURE_CLIENT_SECRET: "secret",
+        AZURE_SUBSCRIPTION_ID: "subscription",
+        CRABBOX_AZURE_LOCATION: "eastus",
+        CRABBOX_AZURE_ORPHAN_SWEEP_DELETE: "1",
+      },
+    );
+
+    await fleet.alarm();
+
+    expect(storage.value("provider-reconciliation:azure:eastus")).toMatchObject({
+      quarantines: { "vm-orphan": quarantine },
+    });
+    expect(storage.value("azure-orphan-sweep:last")).toMatchObject({
+      scanned: 0,
+      terminated: 0,
+      errors: [{ region: "eastus", message: "inventory unavailable" }],
     });
   });
 
@@ -29449,6 +29553,29 @@ function testMachine(overrides: Partial<ProviderMachine>): ProviderMachine {
     labels: { crabbox: "true" },
     ...overrides,
   };
+}
+
+function seedProviderReconciliationEligible(
+  storage: MemoryStorage,
+  provider: "aws" | "azure",
+  scope: string,
+  machine: ProviderMachine,
+): void {
+  const observedAt = new Date(Date.now() - 60_000).toISOString();
+  storage.seed(`provider-reconciliation:${provider}:${encodeURIComponent(scope)}`, {
+    provider,
+    scope,
+    quarantines: {
+      [machine.cloudID]: {
+        fingerprint: providerReconciliationFingerprint(provider, scope, machine),
+        firstObservedAt: observedAt,
+        lastObservedAt: observedAt,
+        eligibleAt: observedAt,
+        observations: 1,
+      },
+    },
+    updatedAt: observedAt,
+  });
 }
 
 function ownedTestMachine(provider: "aws" | "azure" | "gcp", cloudID: string): ProviderMachine {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -11122,11 +11122,16 @@ describe("fleet lease identity and idle", () => {
         }),
       ],
     });
-    expect(
-      storage.value<{ quarantines: Record<string, unknown> }>(
-        "provider-reconciliation:aws:eu-west-1",
-      )?.quarantines,
-    ).toHaveProperty("i-orphan");
+    expect(storage.value("provider-reconciliation:aws:eu-west-1:i-orphan")).toMatchObject({
+      observations: 1,
+    });
+    const storedCandidates = await storage.list({
+      prefix: "provider-reconciliation:aws:eu-west-1:",
+    });
+    expect([...storedCandidates.keys()]).toEqual([
+      "provider-reconciliation:aws:eu-west-1:i-orphan",
+    ]);
+    expect([...storedCandidates.values()][0]).not.toHaveProperty("quarantines");
   });
 
   it("terminates AWS orphan sweep candidates with exact coordinator ownership", async () => {
@@ -11536,12 +11541,7 @@ describe("fleet lease identity and idle", () => {
       eligibleAt: "2026-07-31T10:15:00.000Z",
       observations: 1,
     };
-    storage.seed("provider-reconciliation:azure:eastus", {
-      provider: "azure",
-      scope: "eastus",
-      quarantines: { "vm-orphan": quarantine },
-      updatedAt: "2026-07-31T10:00:00.000Z",
-    });
+    storage.seed("provider-reconciliation:azure:eastus:vm-orphan", quarantine);
     const fleet = testFleet(
       storage,
       {
@@ -11564,13 +11564,47 @@ describe("fleet lease identity and idle", () => {
 
     await fleet.alarm();
 
-    expect(storage.value("provider-reconciliation:azure:eastus")).toMatchObject({
-      quarantines: { "vm-orphan": quarantine },
-    });
+    expect(storage.value("provider-reconciliation:azure:eastus:vm-orphan")).toEqual(quarantine);
     expect(storage.value("azure-orphan-sweep:last")).toMatchObject({
       scanned: 0,
       terminated: 0,
       errors: [{ region: "eastus", message: "inventory unavailable" }],
+    });
+  });
+
+  it("clears Azure quarantine scopes absent from a successful inventory", async () => {
+    const storage = new MemoryStorage();
+    storage.seed("provider-reconciliation:azure:westus2:vm-orphan", {
+      fingerprint: "existing",
+      firstObservedAt: "2026-07-31T10:00:00.000Z",
+      lastObservedAt: "2026-07-31T10:00:00.000Z",
+      eligibleAt: "2026-07-31T10:15:00.000Z",
+      observations: 1,
+    });
+    const fleet = testFleet(
+      storage,
+      {
+        azure: fakeProvider(undefined, {
+          provider: "azure",
+          servers: [],
+        }),
+      },
+      {
+        AZURE_TENANT_ID: "tenant",
+        AZURE_CLIENT_ID: "client",
+        AZURE_CLIENT_SECRET: "secret",
+        AZURE_SUBSCRIPTION_ID: "subscription",
+        CRABBOX_AZURE_LOCATION: "eastus",
+      },
+    );
+
+    await fleet.alarm();
+
+    expect(storage.value("provider-reconciliation:azure:westus2:vm-orphan")).toBeUndefined();
+    expect(storage.value("azure-orphan-sweep:last")).toMatchObject({
+      scanned: 0,
+      terminated: 0,
+      errors: [],
     });
   });
 
@@ -29605,20 +29639,16 @@ function seedProviderReconciliationEligible(
   machine: ProviderMachine,
 ): void {
   const observedAt = new Date(Date.now() - 60_000).toISOString();
-  storage.seed(`provider-reconciliation:${provider}:${encodeURIComponent(scope)}`, {
-    provider,
-    scope,
-    quarantines: {
-      [machine.cloudID]: {
-        fingerprint: providerReconciliationFingerprint(provider, scope, machine),
-        firstObservedAt: observedAt,
-        lastObservedAt: observedAt,
-        eligibleAt: observedAt,
-        observations: 1,
-      },
+  storage.seed(
+    `provider-reconciliation:${provider}:${encodeURIComponent(scope)}:${encodeURIComponent(machine.cloudID)}`,
+    {
+      fingerprint: providerReconciliationFingerprint(provider, scope, machine),
+      firstObservedAt: observedAt,
+      lastObservedAt: observedAt,
+      eligibleAt: observedAt,
+      observations: 1,
     },
-    updatedAt: observedAt,
-  });
+  );
 }
 
 function ownedTestMachine(provider: "aws" | "azure" | "gcp", cloudID: string): ProviderMachine {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -11574,6 +11574,49 @@ describe("fleet lease identity and idle", () => {
     });
   });
 
+  it("backs off Azure inventory while its reconciliation circuit is open", async () => {
+    const storage = new MemoryStorage();
+    let inventoryCalls = 0;
+    const retryAt = new Date(Date.now() + 5 * 60_000).toISOString();
+    storage.seed("provider-reconciliation-circuit:azure:eastus", {
+      consecutiveFailures: 3,
+      retryAt,
+      lastError: "inventory unavailable",
+    });
+    const fleet = testFleet(
+      storage,
+      {
+        azure: fakeProvider(undefined, {
+          provider: "azure",
+          onList() {
+            inventoryCalls += 1;
+            return [];
+          },
+        }),
+      },
+      {
+        AZURE_TENANT_ID: "tenant",
+        AZURE_CLIENT_ID: "client",
+        AZURE_CLIENT_SECRET: "secret",
+        AZURE_SUBSCRIPTION_ID: "subscription",
+        CRABBOX_AZURE_LOCATION: "eastus",
+      },
+    );
+
+    await fleet.alarm();
+
+    expect(inventoryCalls).toBe(0);
+    expect(storage.value("azure-orphan-sweep:last")).toMatchObject({
+      scanned: 0,
+      errors: [
+        {
+          region: "eastus",
+          message: `reconciliation circuit open until ${retryAt}`,
+        },
+      ],
+    });
+  });
+
   it("releases stale pending EC2 Mac hosts during the AWS orphan sweep", async () => {
     const storage = new MemoryStorage();
     const actions: string[] = [];

--- a/worker/test/provider-reconciliation.test.ts
+++ b/worker/test/provider-reconciliation.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  observeProviderReconciliationCandidate,
+  providerReconciliationCircuitOpen,
+  providerReconciliationFingerprint,
+  recordProviderReconciliationFailure,
+  recordProviderReconciliationSuccess,
+} from "../src/provider-reconciliation";
+import type { ProviderMachine } from "../src/types";
+
+const machine: ProviderMachine = {
+  provider: "aws",
+  id: 1,
+  cloudID: "i-123",
+  name: "crabbox-cbx_123456789abc",
+  status: "running",
+  serverType: "c7a.large",
+  host: "192.0.2.10",
+  labels: {
+    crabbox: "true",
+    created_by: "crabbox",
+    lease: "cbx_123456789abc",
+    owner: "alice",
+    provider: "aws",
+    slug: "blue-box",
+  },
+};
+
+describe("provider reconciliation", () => {
+  it("builds a stable fingerprint independent of label insertion order", () => {
+    const reordered = {
+      ...machine,
+      labels: Object.fromEntries([
+        ["e\u0301", "decomposed"],
+        ["\u00e9", "precomposed"],
+        ...Object.entries(machine.labels).reverse(),
+      ]),
+    };
+    const original = {
+      ...machine,
+      labels: Object.fromEntries([
+        ...Object.entries(machine.labels),
+        ["\u00e9", "precomposed"],
+        ["e\u0301", "decomposed"],
+      ]),
+    };
+
+    expect(providerReconciliationFingerprint("aws", "eu-west-1", original)).toBe(
+      providerReconciliationFingerprint("aws", "eu-west-1", reordered),
+    );
+  });
+
+  it("changes the fingerprint when ownership identity changes", () => {
+    const changed = {
+      ...machine,
+      labels: { ...machine.labels, lease: "cbx_abcdefabcdef" },
+    };
+
+    expect(providerReconciliationFingerprint("aws", "eu-west-1", changed)).not.toBe(
+      providerReconciliationFingerprint("aws", "eu-west-1", machine),
+    );
+  });
+
+  it("requires the same candidate in two inventories after quarantine", () => {
+    const first = observeProviderReconciliationCandidate({
+      fingerprint: "abc",
+      now: Date.parse("2026-07-31T12:00:00Z"),
+      quarantineSeconds: 300,
+    });
+    expect(first.action).toBe("quarantine");
+
+    const tooEarly = observeProviderReconciliationCandidate({
+      fingerprint: "abc",
+      previous: first.quarantine,
+      now: Date.parse("2026-07-31T12:04:59Z"),
+      quarantineSeconds: 300,
+    });
+    expect(tooEarly.action).toBe("quarantine");
+
+    const eligible = observeProviderReconciliationCandidate({
+      fingerprint: "abc",
+      previous: tooEarly.quarantine,
+      now: Date.parse("2026-07-31T12:05:00Z"),
+      quarantineSeconds: 300,
+    });
+    expect(eligible.action).toBe("release");
+    expect(eligible.quarantine.observations).toBe(3);
+  });
+
+  it("resets quarantine when resource identity changes", () => {
+    const first = observeProviderReconciliationCandidate({
+      fingerprint: "old",
+      now: Date.parse("2026-07-31T12:00:00Z"),
+      quarantineSeconds: 300,
+    });
+    const changed = observeProviderReconciliationCandidate({
+      fingerprint: "new",
+      previous: first.quarantine,
+      now: Date.parse("2026-07-31T12:10:00Z"),
+      quarantineSeconds: 300,
+    });
+
+    expect(changed.action).toBe("quarantine");
+    expect(changed.quarantine.observations).toBe(1);
+    expect(changed.quarantine.eligibleAt).toBe("2026-07-31T12:15:00.000Z");
+  });
+
+  it("opens a bounded circuit after three consecutive failures", () => {
+    const now = Date.parse("2026-07-31T12:00:00Z");
+    const first = recordProviderReconciliationFailure({ now, error: "one" });
+    const second = recordProviderReconciliationFailure({ previous: first, now, error: "two" });
+    const third = recordProviderReconciliationFailure({ previous: second, now, error: "three" });
+    const fourth = recordProviderReconciliationFailure({ previous: third, now, error: "four" });
+    const sixth = recordProviderReconciliationFailure({
+      previous: recordProviderReconciliationFailure({
+        previous: fourth,
+        now,
+        error: "five",
+      }),
+      now,
+      error: "six",
+    });
+
+    expect(first.retryAt).toBeUndefined();
+    expect(second.retryAt).toBeUndefined();
+    expect(third.retryAt).toBe("2026-07-31T12:05:00.000Z");
+    expect(fourth.retryAt).toBe("2026-07-31T12:15:00.000Z");
+    expect(sixth.retryAt).toBe("2026-07-31T13:00:00.000Z");
+    expect(providerReconciliationCircuitOpen(third, now)).toBe(true);
+    expect(providerReconciliationCircuitOpen(third, Date.parse(third.retryAt!))).toBe(false);
+    expect(recordProviderReconciliationSuccess()).toEqual({ consecutiveFailures: 0 });
+  });
+});

--- a/worker/test/provider-reconciliation.test.ts
+++ b/worker/test/provider-reconciliation.test.ts
@@ -34,7 +34,7 @@ describe("provider reconciliation", () => {
       labels: Object.fromEntries([
         ["e\u0301", "decomposed"],
         ["\u00e9", "precomposed"],
-        ...Object.entries(machine.labels).reverse(),
+        ...Object.entries(machine.labels).toReversed(),
       ]),
     };
     const original = {

--- a/worker/test/provider-reconciliation.test.ts
+++ b/worker/test/provider-reconciliation.test.ts
@@ -62,6 +62,20 @@ describe("provider reconciliation", () => {
     );
   });
 
+  it("keeps arbitrary provider metadata out of the persisted fingerprint", () => {
+    const withLargeDiagnosticLabel = {
+      ...machine,
+      labels: {
+        ...machine.labels,
+        provider_diagnostic: "x".repeat(256 * 1024),
+      },
+    };
+
+    expect(providerReconciliationFingerprint("aws", "eu-west-1", withLargeDiagnosticLabel)).toBe(
+      providerReconciliationFingerprint("aws", "eu-west-1", machine),
+    );
+  });
+
   it("requires the same candidate in two inventories after quarantine", () => {
     const first = observeProviderReconciliationCandidate({
       fingerprint: "abc",


### PR DESCRIPTION
## Summary

- quarantine exact coordinator-owned AWS and Azure orphan candidates across consecutive successful inventories before deletion
- preserve provider-tag-only and `keep=true` resources as report-only
- add bounded per-provider-scope circuit backoff after inventory failures
- store quarantine state per resource and prune stale Azure locations after authoritative resource-group inventory

## User impact

Scheduled reconciliation can heal confirmed coordinator-owned cloud orphans without deleting ambiguous or protected resources. Inventory failures retain safety state and back off instead of repeatedly hammering a failing provider.

## Evidence

- `npm run check --prefix worker`
- `npm run lint --prefix worker`
- `npm run format:check --prefix worker`
- `npm test --prefix worker -- test/provider-reconciliation.test.ts test/fleet.test.ts` (498 tests)
- fresh autoreview clean after addressing stale Azure scope and Durable Object value-size findings
- `git diff --check origin/main...HEAD`

## Configuration and secrets

No new secrets. Existing AWS/Azure orphan sweep delete flags remain opt-in. Provider inventory must succeed before quarantine state can advance or stale state can be pruned.

Part of https://github.com/openclaw/crabbox/issues/1208
