### PR TITLE
test: isolate user state across platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
   windows-pond-mesh-cancellation:
     name: Windows Pond Mesh Cancellation
     runs-on: windows-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
 
     steps:
       - name: Check out
@@ -80,6 +80,9 @@ jobs:
         with:
           go-version-file: go.mod
           cache: false
+
+      - name: Test user directory isolation
+        run: go test ./internal/testutil ./internal/providers/aws ./internal/providers/daytona ./internal/providers/digitalocean ./internal/providers/hostinger ./internal/providers/hyperv ./internal/providers/morph ./internal/providers/namespace ./internal/providers/scaleway ./internal/providers/vast ./internal/providers/vultr -count=1
 
       - name: Test pond mesh cancellation
         run: go test ./internal/cli/ -run PondMeshCancel -count=1 -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
           cache: false
 
       - name: Test user directory isolation
-        run: go test ./internal/testutil ./internal/providers/aws ./internal/providers/daytona ./internal/providers/digitalocean ./internal/providers/hostinger ./internal/providers/hyperv ./internal/providers/morph ./internal/providers/namespace ./internal/providers/scaleway ./internal/providers/vast ./internal/providers/vultr -count=1
+        run: go test ./internal/testutil ./internal/providers/aws ./internal/providers/daytona ./internal/providers/digitalocean ./internal/providers/hyperv ./internal/providers/namespace ./internal/providers/scaleway ./internal/providers/vast ./internal/providers/vultr -count=1
 
       - name: Test pond mesh cancellation
         run: go test ./internal/cli/ -run PondMeshCancel -count=1 -v

--- a/internal/cli/auth_test.go
+++ b/internal/cli/auth_test.go
@@ -17,9 +17,7 @@ import (
 )
 
 func TestWriteBrokerLoginStoresTokenInUserConfig(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	isolateTestUserDirs(t)
 	t.Setenv("CRABBOX_CONFIG", "")
 	t.Setenv("CRABBOX_COORDINATOR", "")
 	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "")

--- a/internal/cli/claim_test.go
+++ b/internal/cli/claim_test.go
@@ -1980,16 +1980,14 @@ func TestResolveLeaseClaimFallbacks(t *testing.T) {
 }
 
 func TestClaimStateDirFallbackAndMissingClaim(t *testing.T) {
-	home := t.TempDir()
+	dirs := isolateTestUserDirs(t)
 	t.Setenv("XDG_STATE_HOME", "")
-	t.Setenv("HOME", home)
-	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 	dir, err := crabboxStateDir()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(dir, home) || filepath.Base(dir) != "state" {
-		t.Fatalf("state dir=%q should live under home %q and end in state", dir, home)
+	if !strings.Contains(dir, dirs.Root) || filepath.Base(dir) != "state" {
+		t.Fatalf("state dir=%q should live under test root %q and end in state", dir, dirs.Root)
 	}
 	claim, err := readLeaseClaim("cbx_missing")
 	if err != nil {

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -11,11 +11,18 @@ import (
 	"testing"
 	"time"
 
+	"github.com/openclaw/crabbox/internal/testutil"
 	"gopkg.in/yaml.v3"
 )
 
+func isolateTestUserDirs(t *testing.T) testutil.UserDirs {
+	t.Helper()
+	return testutil.IsolateUserDirs(t)
+}
+
 func clearConfigEnv(t *testing.T) {
 	t.Helper()
+	isolateTestUserDirs(t)
 	for _, key := range []string{
 		"CRABBOX_COORDINATOR",
 		"CRABBOX_COORDINATOR_MODE",

--- a/internal/cli/egress_daemon_double_provision_test.go
+++ b/internal/cli/egress_daemon_double_provision_test.go
@@ -18,6 +18,8 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/testutil"
 )
 
 // TestMain keeps re-invoked test binaries alive as daemon children instead of
@@ -27,7 +29,7 @@ func TestMain(m *testing.M) {
 		time.Sleep(10 * time.Minute)
 		os.Exit(egressDaemonFatalCode)
 	}
-	os.Exit(m.Run())
+	os.Exit(testutil.RunWithIsolatedUserDirs(m))
 }
 
 var egressDaemonPIDRe = regexp.MustCompile(`egress host daemon: pid=(\d+)`)

--- a/internal/cli/lease_test.go
+++ b/internal/cli/lease_test.go
@@ -21,8 +21,7 @@ func TestNewRunIDUsesCanonicalFormatAndIsUnique(t *testing.T) {
 }
 
 func TestTestboxKeyPathRejectsTraversalIDs(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	isolateTestUserDirs(t)
 
 	for _, leaseID := range []string{"../target", "nested/target", `nested\target`, " cbx_123 "} {
 		if path, err := testboxKeyPath(leaseID); err == nil {
@@ -32,8 +31,7 @@ func TestTestboxKeyPathRejectsTraversalIDs(t *testing.T) {
 }
 
 func TestTestboxKeyPathAllowsSafeCustomIDs(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	isolateTestUserDirs(t)
 
 	path, err := testboxKeyPath("morphvm_123")
 	if err != nil {
@@ -50,8 +48,7 @@ func TestTestboxKeyPathAllowsSafeCustomIDs(t *testing.T) {
 }
 
 func TestUseLeaseKnownHostsScopesAndEnforcesHostVerification(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	isolateTestUserDirs(t)
 
 	const leaseID = "cbx_abcdef123456"
 	target := SSHTarget{User: "root", Host: "provider-resource", Port: "22"}
@@ -86,8 +83,7 @@ func TestUseLeaseKnownHostsScopesAndEnforcesHostVerification(t *testing.T) {
 }
 
 func TestUseLeaseKnownHostsFailsClosedWhenDirectoryCannotBePrepared(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	isolateTestUserDirs(t)
 	configDir, err := os.UserConfigDir()
 	if err != nil {
 		t.Fatal(err)

--- a/internal/cli/pond_mesh_cancel_windows_test.go
+++ b/internal/cli/pond_mesh_cancel_windows_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/openclaw/crabbox/internal/testutil"
 	"golang.org/x/sys/windows"
 )
 
@@ -28,7 +29,7 @@ func TestMain(m *testing.M) {
 		time.Sleep(10 * time.Minute)
 		os.Exit(0)
 	}
-	os.Exit(m.Run())
+	os.Exit(testutil.RunWithIsolatedUserDirs(m))
 }
 
 func TestPondMeshCancelRunForwardsReturnsNoErrorOnWindows(t *testing.T) {

--- a/internal/cli/pond_mesh_test.go
+++ b/internal/cli/pond_mesh_test.go
@@ -834,6 +834,7 @@ func TestCollectPondMembersDoesNotRestoreStoppedClaim(t *testing.T) {
 }
 
 func TestCollectPondMembersDoesNotPreparePortlessMembers(t *testing.T) {
+	isolateTestUserDirs(t)
 	backend := &pondMeshResolveRecordingBackend{}
 	servers := []Server{
 		{Name: "client", Labels: map[string]string{pondLabelKey: "alpha", "slug": "client", "lease": "cbx_client"}},

--- a/internal/cli/provider_backend_test.go
+++ b/internal/cli/provider_backend_test.go
@@ -1070,6 +1070,7 @@ xcpNg:
 }
 
 func TestLoadLeaseTargetConfigAllowsExistingLeaseDespiteUnsupportedProvisioningTarget(t *testing.T) {
+	isolateTestUserDirs(t)
 	configPath := filepath.Join(t.TempDir(), "crabbox.yaml")
 	t.Setenv("CRABBOX_CONFIG", configPath)
 	if err := os.WriteFile(configPath, []byte(`provider: xcp-ng
@@ -1099,6 +1100,7 @@ xcpNg:
 }
 
 func TestLoadLeaseTargetConfigAllowsAWSMacOSWithoutProvisioningHost(t *testing.T) {
+	isolateTestUserDirs(t)
 	configPath := filepath.Join(t.TempDir(), "crabbox.yaml")
 	t.Setenv("CRABBOX_CONFIG", configPath)
 	t.Setenv("CRABBOX_HOST_ID", "")

--- a/internal/cli/provider_coordinator_test.go
+++ b/internal/cli/provider_coordinator_test.go
@@ -676,6 +676,7 @@ func TestCoordinatorResolveFallsBackToAdminToken(t *testing.T) {
 }
 
 func TestCoordinatorReleaseFallsBackToAdminToken(t *testing.T) {
+	isolateTestUserDirs(t)
 	adminReleased := false
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost || r.URL.Path != "/v1/admin/leases/cbx_admin/release" && r.URL.Path != "/v1/leases/cbx_admin/release" {

--- a/internal/cli/static_route_test.go
+++ b/internal/cli/static_route_test.go
@@ -249,6 +249,7 @@ func TestAutoRouteStaticLeaseSkipsClaimScanForExplicitNonStaticProvider(t *testi
 }
 
 func TestAutoRouteStaticLeaseRespectsExplicitStaticHost(t *testing.T) {
+	isolateTestUserDirs(t)
 	defaults := baseConfig()
 	fs := newFlagSet("test", io.Discard)
 	target := registerTargetFlags(fs, defaults)
@@ -271,6 +272,7 @@ func TestAutoRouteStaticLeaseRespectsExplicitStaticHost(t *testing.T) {
 }
 
 func TestAutoRouteStaticLeaseIgnoresNonStaticIDs(t *testing.T) {
+	isolateTestUserDirs(t)
 	defaults := baseConfig()
 	fs := newFlagSet("test", io.Discard)
 	registerTargetFlags(fs, defaults)
@@ -382,6 +384,7 @@ func TestStopDispatchesExplicitReclaimContract(t *testing.T) {
 }
 
 func TestStopRejectsReclaimForSSHLeaseProvider(t *testing.T) {
+	isolateTestUserDirs(t)
 	err := (App{Stdout: io.Discard, Stderr: io.Discard}).stop(context.Background(), []string{
 		"--provider", "ssh", "--static-host", "host.example.test", "--id", "static_host-example-test", "--reclaim",
 	})

--- a/internal/providers/aws/backend_test.go
+++ b/internal/providers/aws/backend_test.go
@@ -11,6 +11,7 @@ import (
 
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/testutil"
 )
 
 type fakeAWSClient struct {
@@ -139,8 +140,7 @@ func (c *fakeAWSClient) SpotPlacementScores(context.Context, Config) ([]ec2types
 }
 
 func TestAWSAcquireCleansUpCreatedServerAndKeyOnIPFailure(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	testutil.IsolateUserDirs(t)
 	ipErr := errors.New("ip unavailable")
 	fake := &fakeAWSClient{
 		created:   awsTestServer("i-created", "cbx_created", "created", "us-west-2"),
@@ -167,8 +167,7 @@ func TestAWSAcquireCleansUpCreatedServerAndKeyOnIPFailure(t *testing.T) {
 }
 
 func TestAWSAcquireBindsImmutableProviderKeyID(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	testutil.IsolateUserDirs(t)
 	fake := &fakeAWSClient{}
 	oldClient := newAWSClient
 	newAWSClient = func(context.Context, Config) (awsClient, error) { return fake, nil }
@@ -197,8 +196,7 @@ func TestAWSAcquireBindsImmutableProviderKeyID(t *testing.T) {
 }
 
 func TestAWSAcquireRollsBackWhenCleanupIdentityTagsFail(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	testutil.IsolateUserDirs(t)
 	tagErr := errors.New("tag write failed")
 	fake := &fakeAWSClient{setTagsErr: tagErr}
 	oldClient := newAWSClient
@@ -221,8 +219,7 @@ func TestAWSAcquireRollsBackWhenCleanupIdentityTagsFail(t *testing.T) {
 }
 
 func TestAWSAcquireDoesNotDeleteProviderKeyByNameOnCreateFailure(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	testutil.IsolateUserDirs(t)
 	createErr := errors.New("capacity unavailable")
 	east := &fakeAWSClient{createErr: createErr}
 	west := &fakeAWSClient{}
@@ -426,8 +423,7 @@ func TestAWSReleaseRejectsForgedOrMismatchedOwnership(t *testing.T) {
 }
 
 func TestAWSReleaseRemovesClaimWhenProviderKeyDeletionFails(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	testutil.IsolateUserDirs(t)
 	leaseID := "cbx_abcdef123456"
 	keyName := "crabbox-cbx-abcdef123456"
 	if err := core.ClaimLeaseForRepoProvider(leaseID, "partial-release", "aws", t.TempDir(), time.Minute, false); err != nil {
@@ -494,8 +490,7 @@ func TestAWSTouchUsesFallbackRegion(t *testing.T) {
 }
 
 func TestAWSCleanupRequiresExactClaimForFallbackRegionServer(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	testutil.IsolateUserDirs(t)
 	tagOnly := awsTestServer("i-tag-only", "cbx_111111111111", "tag-only", "us-west-2")
 	tagOnly.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
 	staleClaim := awsTestServer("i-stale", "cbx_333333333333", "stale", "us-west-2")
@@ -563,8 +558,7 @@ func TestAWSCleanupRequiresExactClaimForFallbackRegionServer(t *testing.T) {
 }
 
 func TestAWSCleanupDryRunRetainsExactClaim(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	testutil.IsolateUserDirs(t)
 	server := awsTestServer("i-dry-run", "cbx_555555555555", "dry-run", "us-west-2")
 	server.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
 	fake := &fakeAWSClient{servers: []Server{server}}
@@ -1002,8 +996,7 @@ func TestAWSCleanupTreatsInstanceMissingAtDeleteBoundaryAsRemoved(t *testing.T) 
 
 func isolateAWSClaimState(t *testing.T) {
 	t.Helper()
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	testutil.IsolateUserDirs(t)
 }
 
 func claimAWSCleanupServer(t *testing.T, cfg Config, server Server) {
@@ -1036,8 +1029,7 @@ func assertAWSClaimMissing(t *testing.T, leaseID string) {
 }
 
 func TestAWSAcquireSuffixesSlugCollisionsAcrossRegions(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	testutil.IsolateUserDirs(t)
 	stopErr := errors.New("stop after create")
 	east := &fakeAWSClient{waitErr: stopErr}
 	west := &fakeAWSClient{servers: []Server{awsTestServer("i-west", "cbx_west", "taken", "us-west-2")}}
@@ -1126,8 +1118,7 @@ func TestAWSAcquireUsesTailscaleHostnameOnlyForStrictMode(t *testing.T) {
 		{name: "tailscale", network: core.NetworkTailscale, want: "crabbox-bootstrap"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			t.Setenv("HOME", t.TempDir())
-			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+			testutil.IsolateUserDirs(t)
 			fake := &fakeAWSClient{}
 			oldClient := newAWSClient
 			newAWSClient = func(context.Context, Config) (awsClient, error) { return fake, nil }

--- a/internal/providers/daytona/backend_run_test.go
+++ b/internal/providers/daytona/backend_run_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	apidaytona "github.com/daytonaio/daytona/libs/api-client-go"
+	"github.com/openclaw/crabbox/internal/testutil"
 )
 
 func TestCreateDaytonaSyncArchiveWritesTempFile(t *testing.T) {
@@ -206,9 +207,7 @@ func TestDaytonaAuthRequiresOrganizationForJWT(t *testing.T) {
 }
 
 func TestDaytonaAuthFallsBackToCLIConfig(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	testutil.IsolateUserDirs(t)
 	configDir, err := os.UserConfigDir()
 	if err != nil {
 		t.Fatal(err)
@@ -255,9 +254,7 @@ func TestDaytonaAuthFallsBackToCLIConfig(t *testing.T) {
 }
 
 func TestDaytonaEnvAuthOverridesCLIConfig(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	testutil.IsolateUserDirs(t)
 	configDir, err := os.UserConfigDir()
 	if err != nil {
 		t.Fatal(err)

--- a/internal/providers/digitalocean/backend_test.go
+++ b/internal/providers/digitalocean/backend_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/testutil"
 )
 
 type fakeDigitalOceanAPI struct {
@@ -184,9 +185,7 @@ func removeDropletByID(items []droplet, id int64) []droplet {
 
 func newTestBackend(t *testing.T, api *fakeDigitalOceanAPI) *digitalOceanLeaseBackend {
 	t.Helper()
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("XDG_CONFIG_HOME", home)
+	testutil.IsolateUserDirs(t)
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
 	cfg.TargetOS = core.TargetLinux
@@ -2911,5 +2910,5 @@ type fixedClock struct{ t time.Time }
 func (c fixedClock) Now() time.Time { return c.t }
 
 func TestMain(m *testing.M) {
-	os.Exit(m.Run())
+	os.Exit(testutil.RunWithIsolatedUserDirs(m))
 }

--- a/internal/providers/hostinger/provider_test.go
+++ b/internal/providers/hostinger/provider_test.go
@@ -19,14 +19,12 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/testutil"
 )
 
 func isolateHostingerTestState(t *testing.T) {
 	t.Helper()
-	root := t.TempDir()
-	t.Setenv("HOME", root)
-	t.Setenv("XDG_CONFIG_HOME", filepath.Join(root, "config"))
-	t.Setenv("XDG_STATE_HOME", filepath.Join(root, "state"))
+	testutil.IsolateUserDirs(t)
 }
 
 func TestProviderSpecAndFlags(t *testing.T) {

--- a/internal/providers/hyperv/provider_test.go
+++ b/internal/providers/hyperv/provider_test.go
@@ -14,7 +14,12 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/testutil"
 )
+
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunWithIsolatedUserDirs(m))
+}
 
 type recordingRunner struct {
 	calls     []core.LocalCommandRequest
@@ -531,6 +536,7 @@ func TestServerFromInstanceOverridesStaleReadyState(t *testing.T) {
 }
 
 func TestCreateVMUsesDifferencingDisk(t *testing.T) {
+	testutil.IsolateUserDirs(t)
 	runner := &recordingRunner{
 		responses: map[string]core.LocalCommandResult{},
 		errors:    map[string]error{},
@@ -581,6 +587,7 @@ func TestCreateVMUsesDifferencingDisk(t *testing.T) {
 // Leases must not copy or resize the template: the differencing disk avoids the
 // multi-GB per-lease copy and inherits the template's virtual size.
 func TestCreateVMDoesNotCopyOrResizeTemplate(t *testing.T) {
+	testutil.IsolateUserDirs(t)
 	runner := &recordingRunner{
 		responses: map[string]core.LocalCommandResult{},
 		errors:    map[string]error{},
@@ -604,6 +611,7 @@ func TestCreateVMDoesNotCopyOrResizeTemplate(t *testing.T) {
 }
 
 func TestCreateVMPlacesVMFilesUnderHypervVMDir(t *testing.T) {
+	testutil.IsolateUserDirs(t)
 	runner := &recordingRunner{
 		responses: map[string]core.LocalCommandResult{},
 		errors:    map[string]error{},
@@ -633,6 +641,7 @@ func TestCreateVMPlacesVMFilesUnderHypervVMDir(t *testing.T) {
 // BEFORE the VM is created/booted, keep the password out of host command lines,
 // and leave the template (ParentPath) untouched.
 func TestCreateVMInitPasswordInjectsRunOnceBeforeBoot(t *testing.T) {
+	testutil.IsolateUserDirs(t)
 	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
 	b := testBackend(runner)
 	b.cfg.HyperV.InitPassword = true
@@ -701,6 +710,7 @@ func TestHyperVInitHiveNameIsUniqueAndSafe(t *testing.T) {
 }
 
 func TestCreateVMNoInitPasswordByDefault(t *testing.T) {
+	testutil.IsolateUserDirs(t)
 	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
 	b := testBackend(runner)
 	cfg := b.configForRun()
@@ -760,6 +770,7 @@ func TestAcquireRejectsUnsafeSSHUser(t *testing.T) {
 }
 
 func TestAcquireQuarantinesSSHBeforeConnectingNetwork(t *testing.T) {
+	testutil.IsolateUserDirs(t)
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	oldOS := hypervHostOS
@@ -829,6 +840,7 @@ func TestAcquireQuarantinesSSHBeforeConnectingNetwork(t *testing.T) {
 }
 
 func TestAcquireKeepPersistsClaimAndKeyBeforeBootstrap(t *testing.T) {
+	testutil.IsolateUserDirs(t)
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	oldOS := hypervHostOS
 	hypervHostOS = "windows"
@@ -872,6 +884,7 @@ func TestAcquireKeepPersistsClaimAndKeyBeforeBootstrap(t *testing.T) {
 }
 
 func TestAcquirePersistsProvisionalClaimThenRollsBackFailedLease(t *testing.T) {
+	testutil.IsolateUserDirs(t)
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	oldOS := hypervHostOS
 	hypervHostOS = "windows"
@@ -1566,6 +1579,7 @@ func TestEnsureOpenSSHPasswordNotInArgs(t *testing.T) {
 }
 
 func TestResolveInstancePropagatesQueryError(t *testing.T) {
+	testutil.IsolateUserDirs(t)
 	runner := &recordingRunner{
 		responses: map[string]core.LocalCommandResult{},
 		errors:    map[string]error{},
@@ -1618,6 +1632,7 @@ func TestRemoveVMQueriesActualVHDPaths(t *testing.T) {
 }
 
 func TestCreateVMDisablesAutomaticCheckpoints(t *testing.T) {
+	testutil.IsolateUserDirs(t)
 	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
 	b := testBackend(runner)
 	cfg := b.configForRun()
@@ -1998,6 +2013,7 @@ func TestInvokeInGuestAbortsOnContextCancel(t *testing.T) {
 
 // The readiness probe must precede the SSH lockdown.
 func TestAcquireWaitsForGuestReadyBeforeLockdown(t *testing.T) {
+	testutil.IsolateUserDirs(t)
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	oldOS := hypervHostOS

--- a/internal/providers/morph/backend_test.go
+++ b/internal/providers/morph/backend_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/openclaw/crabbox/internal/testutil"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -775,10 +776,11 @@ func TestMorphServerReportsGatewayAndProviderNetworking(t *testing.T) {
 }
 
 func TestMorphResolveRejectsUnsafeMetadataLeaseID(t *testing.T) {
-	home := t.TempDir()
-	configDir := filepath.Join(home, ".config")
-	t.Setenv("HOME", home)
-	t.Setenv("XDG_CONFIG_HOME", configDir)
+	testutil.IsolateUserDirs(t)
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		t.Fatal(err)
+	}
 	fake := &fakeMorphAPI{
 		getInstance: func(_ context.Context, instanceID string) (morphInstance, error) {
 			return morphInstance{
@@ -799,7 +801,7 @@ func TestMorphResolveRejectsUnsafeMetadataLeaseID(t *testing.T) {
 		now:    time.Now,
 	}
 
-	_, err := backend.Resolve(context.Background(), ResolveRequest{ID: "inst_unsafe"})
+	_, err = backend.Resolve(context.Background(), ResolveRequest{ID: "inst_unsafe"})
 	if err == nil || !strings.Contains(err.Error(), "invalid lease claim id") {
 		t.Fatalf("Resolve error=%v", err)
 	}
@@ -1302,7 +1304,5 @@ func testMorphConfig() Config {
 
 func configureMorphTestHome(t *testing.T) {
 	t.Helper()
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	testutil.IsolateUserDirs(t)
 }

--- a/internal/providers/namespace/backend_test.go
+++ b/internal/providers/namespace/backend_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/testutil"
 )
 
 func TestNamespaceSSHTargetParsesPrepareResult(t *testing.T) {
@@ -79,8 +81,7 @@ func TestListDevboxesIgnoresSuccessfulCommandStderr(t *testing.T) {
 }
 
 func TestNamespaceSSHTargetFromConfig(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := testutil.IsolateUserDirs(t).Home
 	dir := filepath.Join(home, ".namespace", "ssh")
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		t.Fatal(err)
@@ -242,8 +243,7 @@ func TestResolveRestoresRepoClaimWhenNamespacePrepareFails(t *testing.T) {
 }
 
 func TestCleanupNamespaceSSHFilesRemovesOnlyCrabboxNamespaceFiles(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := testutil.IsolateUserDirs(t).Home
 	dir := filepath.Join(home, ".namespace", "ssh")
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		t.Fatal(err)
@@ -280,8 +280,7 @@ func TestCleanupNamespaceSSHFilesRemovesOnlyCrabboxNamespaceFiles(t *testing.T) 
 }
 
 func TestReleaseLeaseCleansNamespaceSSHFiles(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := testutil.IsolateUserDirs(t).Home
 	dir := filepath.Join(home, ".namespace", "ssh")
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		t.Fatal(err)
@@ -313,8 +312,7 @@ func TestReleaseLeaseCleansNamespaceSSHFiles(t *testing.T) {
 }
 
 func TestReleaseLeaseRetainsStoppedNamespaceClaimAndSSHFiles(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := testutil.IsolateUserDirs(t).Home
 	leaseID := "cbx_deadbeef0000"
 	slug := "blue-lobster"
 	name := leaseProviderName(leaseID, slug)
@@ -460,7 +458,7 @@ func TestNamespaceLifecycleCommandFallbacks(t *testing.T) {
 }
 
 func TestNamespacePrepareReportsPrepareFailure(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	testutil.IsolateUserDirs(t)
 	runner := &namespaceRecordingRunner{failAll: true}
 	backend := &namespaceLeaseBackend{rt: Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
 
@@ -474,7 +472,7 @@ func TestNamespacePrepareReportsPrepareFailure(t *testing.T) {
 }
 
 func TestNamespacePrepareIgnoresSuccessfulCommandStderr(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	testutil.IsolateUserDirs(t)
 	runner := &namespaceQueuedRunner{
 		results: []LocalCommandResult{
 			{ExitCode: 2, Stderr: "configure unsupported"},

--- a/internal/providers/scaleway/backend_lifecycle_test.go
+++ b/internal/providers/scaleway/backend_lifecycle_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/scw"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/testutil"
 )
 
 func TestScalewayAcquireListResolveTouchReleaseLifecycle(t *testing.T) {
@@ -789,8 +790,7 @@ func TestScalewayDoctorReportsInventoryAndMissingAuth(t *testing.T) {
 
 func newTestBackend(t *testing.T) (*Backend, *fakeScalewayClient) {
 	t.Helper()
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	testutil.IsolateUserDirs(t)
 	fake := newFakeScalewayClient()
 	cfg := core.Config{
 		Provider: providerName,

--- a/internal/providers/scaleway/client_test.go
+++ b/internal/providers/scaleway/client_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/scw"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/testutil"
 )
 
 func TestScalewayClientRefusesCrossOriginRedirectBeforeTokenReplay(t *testing.T) {
@@ -279,8 +280,6 @@ func TestApplyScalewayLocationDefaultsOnlyFillsMissingSDKValues(t *testing.T) {
 
 func TestNewClientReportsMissingAuthWithoutSecrets(t *testing.T) {
 	clearScalewayEnv(t)
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	_, err := newClient(core.Config{}, core.Runtime{})
 	if err == nil || !strings.Contains(err.Error(), "SCW_ACCESS_KEY and SCW_SECRET_KEY") {
 		t.Fatalf("newClient err=%v", err)
@@ -289,8 +288,6 @@ func TestNewClientReportsMissingAuthWithoutSecrets(t *testing.T) {
 
 func TestNewClientReportsPartialAuthWithoutSecretValue(t *testing.T) {
 	clearScalewayEnv(t)
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("SCW_ACCESS_KEY", "SCW11111111111111111")
 	_, err := newClient(core.Config{}, core.Runtime{})
 	if err == nil || !strings.Contains(err.Error(), "SCW_SECRET_KEY") {
@@ -303,8 +300,6 @@ func TestNewClientReportsPartialAuthWithoutSecretValue(t *testing.T) {
 
 func TestNewClientSanitizesSDKValidationError(t *testing.T) {
 	clearScalewayEnv(t)
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("SCW_ACCESS_KEY", "invalid-access-key")
 	t.Setenv("SCW_SECRET_KEY", "invalid-secret-key")
 	t.Setenv("CRABBOX_SCALEWAY_PROJECT_ID", "project-1")
@@ -345,8 +340,6 @@ func (fn scalewayRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, er
 
 func TestScalewayListPropagatesContextToSDKRequest(t *testing.T) {
 	clearScalewayEnv(t)
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("SCW_ACCESS_KEY", "SCW11111111111111111")
 	t.Setenv("SCW_SECRET_KEY", "11111111-1111-1111-1111-111111111111")
 	t.Setenv("SCW_DEFAULT_PROJECT_ID", "11111111-1111-1111-1111-111111111111")
@@ -372,6 +365,7 @@ func TestScalewayListPropagatesContextToSDKRequest(t *testing.T) {
 
 func clearScalewayEnv(t *testing.T) {
 	t.Helper()
+	testutil.IsolateUserDirs(t)
 	unsetScalewayEnv(t, "SCW_API_URL")
 	unsetScalewayEnv(t, "SCW_INSECURE")
 	for _, key := range []string{
@@ -421,8 +415,6 @@ func newTestScalewaySDKClient(t *testing.T, apiURL string, httpClient *http.Clie
 func newTestScalewaySDKClientWithEnv(t *testing.T, apiURL string, httpClient *http.Client, env map[string]string) Client {
 	t.Helper()
 	clearScalewayEnv(t)
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("SCW_ACCESS_KEY", testScalewayAccessKey)
 	t.Setenv("SCW_SECRET_KEY", testScalewaySecretKey)
 	t.Setenv("SCW_API_URL", apiURL)

--- a/internal/providers/tart/provider_test.go
+++ b/internal/providers/tart/provider_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/testutil"
 )
 
 type recordingRunner struct {
@@ -289,10 +290,7 @@ func TestShouldCleanupSkipsMissingClaim(t *testing.T) {
 }
 
 func TestAcquireKeepIPFailureDeletesUnclaimedVMAndKey(t *testing.T) {
-	configHome := t.TempDir()
-	t.Setenv("HOME", configHome)
-	t.Setenv("XDG_CONFIG_HOME", configHome)
-	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	testutil.IsolateUserDirs(t)
 	binDir := t.TempDir()
 	fakeTart := filepath.Join(binDir, "tart")
 	if err := os.WriteFile(fakeTart, []byte("#!/bin/sh\nsleep 0.2\n"), 0o755); err != nil {

--- a/internal/providers/vast/backend_test.go
+++ b/internal/providers/vast/backend_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/testutil"
 )
 
 type fakeVastAPI struct {
@@ -187,9 +188,7 @@ func (f *fakeVastAPI) DetachInstanceSSHKey(_ context.Context, id int, keyID stri
 
 func newTestBackend(t *testing.T, api *fakeVastAPI) *backend {
 	t.Helper()
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("XDG_CONFIG_HOME", home)
+	testutil.IsolateUserDirs(t)
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
 	cfg.TargetOS = core.TargetLinux

--- a/internal/providers/vultr/backend_test.go
+++ b/internal/providers/vultr/backend_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/testutil"
 )
 
 type fakeVultrAPI struct {
@@ -171,9 +172,7 @@ func removeVultrInstance(items []vultrInstance, id string) []vultrInstance {
 
 func newTestBackend(t *testing.T, api *fakeVultrAPI) *backend {
 	t.Helper()
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("XDG_CONFIG_HOME", home)
+	testutil.IsolateUserDirs(t)
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
 	cfg.TargetOS = core.TargetLinux

--- a/internal/testutil/userdirs.go
+++ b/internal/testutil/userdirs.go
@@ -1,0 +1,161 @@
+package testutil
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// UserDirs contains the test-owned directories installed by IsolateUserDirs.
+type UserDirs struct {
+	Root       string
+	Home       string
+	ConfigHome string
+	StateHome  string
+	AppData    string
+}
+
+// IsolateUserDirs redirects every user-directory input used by Crabbox and the
+// Go standard library to a per-test temporary root.
+func IsolateUserDirs(t *testing.T) UserDirs {
+	t.Helper()
+	dirs := userDirs(t.TempDir())
+	if err := prepareUserDirs(dirs); err != nil {
+		t.Fatalf("prepare isolated test user directories: %v", err)
+	}
+	for key, value := range dirs.environment() {
+		t.Setenv(key, value)
+	}
+	assertUserConfigDir(t, dirs.Root)
+	return dirs
+}
+
+// RunWithIsolatedUserDirs provides a package-wide safety net for tests that
+// reach user state without installing per-test isolation first.
+func RunWithIsolatedUserDirs(m *testing.M) int {
+	if err := preserveGoCacheEnv(); err != nil {
+		fmt.Fprintf(os.Stderr, "preserve Go caches before isolating test user directories: %v\n", err)
+		return 2
+	}
+	root, err := os.MkdirTemp("", "crabbox-test-user-dirs-")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "create isolated test user directories: %v\n", err)
+		return 2
+	}
+	defer os.RemoveAll(root)
+
+	dirs := userDirs(root)
+	if err := prepareUserDirs(dirs); err != nil {
+		fmt.Fprintf(os.Stderr, "prepare isolated test user directories: %v\n", err)
+		return 2
+	}
+	for key, value := range dirs.environment() {
+		if err := os.Setenv(key, value); err != nil {
+			fmt.Fprintf(os.Stderr, "set isolated test user directory %s: %v\n", key, err)
+			return 2
+		}
+	}
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "resolve isolated test config directory: %v\n", err)
+		return 2
+	}
+	if err := requireWithinRoot(dirs.Root, configDir); err != nil {
+		fmt.Fprintf(os.Stderr, "isolated test config directory guard: %v\n", err)
+		return 2
+	}
+	return m.Run()
+}
+
+func preserveGoCacheEnv() error {
+	if os.Getenv("GOCACHE") == "" {
+		cacheDir, err := os.UserCacheDir()
+		if err != nil {
+			return fmt.Errorf("resolve Go build cache parent: %w", err)
+		}
+		if err := os.Setenv("GOCACHE", filepath.Join(cacheDir, "go-build")); err != nil {
+			return fmt.Errorf("set GOCACHE: %w", err)
+		}
+	}
+	if os.Getenv("GOMODCACHE") == "" {
+		goPath := os.Getenv("GOPATH")
+		if goPath == "" {
+			homeDir, err := os.UserHomeDir()
+			if err != nil {
+				return fmt.Errorf("resolve Go module cache parent: %w", err)
+			}
+			goPath = filepath.Join(homeDir, "go")
+		}
+		goPath = filepath.SplitList(goPath)[0]
+		if err := os.Setenv("GOMODCACHE", filepath.Join(goPath, "pkg", "mod")); err != nil {
+			return fmt.Errorf("set GOMODCACHE: %w", err)
+		}
+	}
+	return nil
+}
+
+func userDirs(root string) UserDirs {
+	return UserDirs{
+		Root:       root,
+		Home:       filepath.Join(root, "home"),
+		ConfigHome: filepath.Join(root, "config"),
+		StateHome:  filepath.Join(root, "state"),
+		AppData:    filepath.Join(root, "appdata"),
+	}
+}
+
+func prepareUserDirs(dirs UserDirs) error {
+	paths := []string{
+		dirs.Root,
+		dirs.Home,
+		dirs.ConfigHome,
+		dirs.StateHome,
+		dirs.AppData,
+		filepath.Join(dirs.Root, "local-appdata"),
+	}
+	for _, path := range paths {
+		if err := os.MkdirAll(path, 0o700); err != nil {
+			return fmt.Errorf("create %q: %w", path, err)
+		}
+		if err := os.Chmod(path, 0o700); err != nil {
+			return fmt.Errorf("secure %q: %w", path, err)
+		}
+	}
+	return nil
+}
+
+func (dirs UserDirs) environment() map[string]string {
+	return map[string]string{
+		"HOME":            dirs.Home,
+		"home":            dirs.Home,
+		"USERPROFILE":     dirs.Home,
+		"XDG_CONFIG_HOME": dirs.ConfigHome,
+		"XDG_STATE_HOME":  dirs.StateHome,
+		"APPDATA":         dirs.AppData,
+		"LOCALAPPDATA":    filepath.Join(dirs.Root, "local-appdata"),
+	}
+}
+
+func assertUserConfigDir(t *testing.T, root string) {
+	t.Helper()
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		t.Fatalf("resolve isolated test config directory: %v", err)
+	}
+	if err := requireWithinRoot(root, configDir); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func requireWithinRoot(root, path string) error {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return fmt.Errorf("compare test root %q with resolved path %q: %w", root, path, err)
+	}
+	if rel == ".." || filepath.IsAbs(rel) || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("resolved user directory %q escapes test root %q", path, root)
+	}
+	return nil
+}

--- a/internal/testutil/userdirs_test.go
+++ b/internal/testutil/userdirs_test.go
@@ -1,0 +1,44 @@
+package testutil
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestIsolateUserDirsContainsStateAndPlatformConfig(t *testing.T) {
+	dirs := IsolateUserDirs(t)
+
+	if got := os.Getenv("XDG_STATE_HOME"); got != dirs.StateHome {
+		t.Fatalf("XDG_STATE_HOME=%q want %q", got, dirs.StateHome)
+	}
+	if got := os.Getenv("APPDATA"); got != dirs.AppData {
+		t.Fatalf("APPDATA=%q want %q", got, dirs.AppData)
+	}
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := requireWithinRoot(dirs.Root, configDir); err != nil {
+		t.Fatal(err)
+	}
+	if runtime.GOOS == "windows" && configDir != dirs.AppData {
+		t.Fatalf("Windows user config directory=%q want APPDATA %q", configDir, dirs.AppData)
+	}
+	if runtime.GOOS != "windows" {
+		for _, path := range []string{dirs.Root, dirs.Home, dirs.ConfigHome, dirs.StateHome, dirs.AppData} {
+			info, err := os.Stat(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if info.Mode().Perm()&0o077 != 0 {
+				t.Fatalf("isolated user directory %q mode=%#o want private", path, info.Mode().Perm())
+			}
+		}
+	}
+	stateDir := filepath.Join(os.Getenv("XDG_STATE_HOME"), "crabbox")
+	if err := requireWithinRoot(dirs.Root, stateDir); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary

- add one shared `testutil.IsolateUserDirs` helper that redirects state, config, home, AppData, and local AppData into a private per-test tree on every supported OS
- migrate the affected CLI and provider tests, with package-wide safety nets for CLI, DigitalOcean, and Hyper-V tests that could otherwise reach persistent user state
- extend the existing Windows CI job to run the isolation helper and affected provider suites natively

The helper asserts that `os.UserConfigDir()` remains inside the test root and creates every synthetic user directory with private permissions. Package-wide isolation preserves the original Go build and module cache locations so nested CLI builds do not redownload dependencies.

Thanks to @paulcam206 for the detailed reports and cross-platform reproduction work.

## Reproduction and proof

On unmodified `main`, running one reported CLI test with a controlled fallback home passed but left this persistent lock behind:

```console
$ env -u XDG_STATE_HOME -u XDG_CONFIG_HOME HOME="$repro_root" go test -count=1 -run '^TestAutoRouteStaticLeaseIgnoresNonStaticIDs$' -v ./internal/cli
=== RUN   TestAutoRouteStaticLeaseIgnoresNonStaticIDs
--- PASS: TestAutoRouteStaticLeaseIgnoresNonStaticIDs (0.00s)
PASS
$ find "$repro_root" -path '*/crabbox/*'
/tmp/crabbox-state-repro.Z2zIbT/Library/Application Support/crabbox/state/claim-locks/cbx_abc123.json.lock
```

The same controlled-fallback check on this branch leaves no Crabbox path behind:

```console
$ env -u XDG_STATE_HOME -u XDG_CONFIG_HOME HOME="$repro_root" go test -count=1 -run '^TestAutoRouteStaticLeaseIgnoresNonStaticIDs$' -v ./internal/cli
=== RUN   TestAutoRouteStaticLeaseIgnoresNonStaticIDs
--- PASS: TestAutoRouteStaticLeaseIgnoresNonStaticIDs (0.00s)
PASS
ok  github.com/openclaw/crabbox/internal/cli  0.474s
$ find "$repro_root" -path '*/crabbox/*'
$ echo "PASS: no Crabbox files were written beneath the fallback home"
PASS: no Crabbox files were written beneath the fallback home
```

## Verification

```console
$ gofmt -w $(git ls-files '*.go')
$ go vet ./...
$ go test -race -p 1 ./...
ok  github.com/openclaw/crabbox/internal/cli  210.560s
ok  github.com/openclaw/crabbox/internal/providers/digitalocean  2.757s
ok  github.com/openclaw/crabbox/internal/providers/hyperv  1.716s
ok  github.com/openclaw/crabbox/internal/testutil  (cached)
```

The full local parallel race command was also attempted, but this machine had only 2.9 GiB free and parallel linking stopped with `no space left on device`; the identical suite passed with `-p 1`. The hosted Go job passed the exact `go test -race ./...` command at https://github.com/openclaw/crabbox/actions/runs/30673261639/job/91295228438.

Native Windows execution passed in the expanded existing Windows CI job at https://github.com/openclaw/crabbox/actions/runs/30673261639/job/91295228445. That job exercised the shared helper plus AWS, Daytona, DigitalOcean, Hyper-V, Namespace, Scaleway, Vast, and Vultr before rerunning the existing Pond Mesh cancellation proof. Locally, the Windows implementation was checked against Go's documented `os.UserConfigDir` behavior: `%AppData%` is redirected via `APPDATA`, while `USERPROFILE` and `LOCALAPPDATA` cover the other standard-library user-directory resolvers.

Closes https://github.com/openclaw/crabbox/issues/1212
Closes https://github.com/openclaw/crabbox/issues/1213
