### PR TITLE
ci: add protected coordinator token rotation

### DIFF
--- a/.github/workflows/coordinator-admin-token-rotate.yml
+++ b/.github/workflows/coordinator-admin-token-rotate.yml
@@ -1,0 +1,77 @@
+name: Rotate Coordinator Admin Token
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: coordinator-admin-token-rotate
+  cancel-in-progress: false
+
+jobs:
+  guard:
+    name: Guard protected rotation
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require the protected default-branch workflow
+        shell: bash
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          REF_PROTECTED: ${{ github.ref_protected }}
+          RUN_SHA: ${{ github.sha }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+        run: |
+          set -euo pipefail
+          expected_ref="refs/heads/$DEFAULT_BRANCH"
+          expected_workflow_ref="$GITHUB_REPOSITORY/.github/workflows/coordinator-admin-token-rotate.yml@$expected_ref"
+          [[ "$GITHUB_EVENT_NAME" == workflow_dispatch ]]
+          [[ "$GITHUB_REF" == "$expected_ref" ]]
+          [[ "$GITHUB_WORKFLOW_REF" == "$expected_workflow_ref" ]]
+          [[ "$REF_PROTECTED" == true ]]
+          [[ "$WORKFLOW_SHA" == "$RUN_SHA" ]]
+
+  rotate:
+    name: Rotate crabbox-coordinator admin token
+    needs: guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: coordinator
+    steps:
+      - name: Check out protected source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: worker/package-lock.json
+
+      - name: Install
+        run: npm ci
+        working-directory: worker
+
+      - name: Rotate coordinator admin token
+        shell: bash
+        working-directory: worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: "91b59577e757131d68d55a471fe32aca"
+          CRABBOX_ADMIN_TOKEN_NEXT: ${{ secrets.CRABBOX_ADMIN_TOKEN_NEXT }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$CLOUDFLARE_API_TOKEN" ]]; then
+            echo "::error::Set CLOUDFLARE_API_TOKEN on the coordinator environment."
+            exit 1
+          fi
+          if [[ -z "$CRABBOX_ADMIN_TOKEN_NEXT" ]]; then
+            echo "::error::Set CRABBOX_ADMIN_TOKEN_NEXT on the coordinator environment."
+            exit 1
+          fi
+          printf '%s' "$CRABBOX_ADMIN_TOKEN_NEXT" | npx wrangler secret put CRABBOX_ADMIN_TOKEN

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Added a protected default-branch workflow for rotating the coordinator admin
+  token from a one-time environment secret without exposing it on argv.
 - Added exact brokered lease image identity and provider startup phase timings, plus Azure OS disk snapshot promotion and automatic scoped selection.
 - Added a project vision that defines Crabbox as a remote execution and evidence layer called by agents, with agent orchestration and model-credential delivery explicitly outside its scope.
 - Added coordinator-owned ready-pool desired capacity with atomic fill claims, provider-neutral compatibility keys, borrow heartbeats, abandoned-borrow quarantine, stale-record pruning, and pool counters.

--- a/scripts/coordinator-admin-token-rotation-workflow.test.js
+++ b/scripts/coordinator-admin-token-rotation-workflow.test.js
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const workflow = fs.readFileSync(
+  path.join(repoRoot, ".github", "workflows", "coordinator-admin-token-rotate.yml"),
+  "utf8",
+);
+
+test("coordinator admin-token rotation is protected and manual", () => {
+  assert.match(workflow, /^  workflow_dispatch:$/m);
+  assert.doesNotMatch(workflow, /^  (?:push|pull_request|schedule):/m);
+  assert.match(workflow, /environment: coordinator/);
+  assert.match(
+    workflow,
+    /expected_workflow_ref="\$GITHUB_REPOSITORY\/\.github\/workflows\/coordinator-admin-token-rotate\.yml@\$expected_ref"/,
+  );
+  assert.match(workflow, /\[\[ "\$GITHUB_REF" == "\$expected_ref" \]\]/);
+  assert.match(workflow, /\[\[ "\$REF_PROTECTED" == true \]\]/);
+  assert.match(workflow, /\[\[ "\$WORKFLOW_SHA" == "\$RUN_SHA" \]\]/);
+  assert.match(workflow, /ref: \$\{\{ github\.workflow_sha \}\}/);
+  assert.match(workflow, /persist-credentials: false/);
+  assert.match(workflow, /cancel-in-progress: false/);
+});
+
+test("rotation keeps both credentials environment-scoped and off argv", () => {
+  assert.equal((workflow.match(/secrets\.CLOUDFLARE_API_TOKEN/g) ?? []).length, 1);
+  assert.equal((workflow.match(/secrets\.CRABBOX_ADMIN_TOKEN_NEXT/g) ?? []).length, 1);
+  assert.match(
+    workflow,
+    /printf '%s' "\$CRABBOX_ADMIN_TOKEN_NEXT" \| npx wrangler secret put CRABBOX_ADMIN_TOKEN/,
+  );
+  assert.doesNotMatch(workflow, /echo "\$CRABBOX_ADMIN_TOKEN_NEXT"/);
+  assert.doesNotMatch(workflow, /--token|--secret/);
+});


### PR DESCRIPTION
Related: https://github.com/openclaw/crabbox/issues/1208

## What Problem This Solves

Resolves an operational problem where the coordinator admin token could not be rotated from the protected GitHub environment, leaving brokered image publication blocked when the existing token was unavailable locally.

## Why This Change Was Made

Adds a manual, protected-default-branch workflow that reads a one-time next token only inside the `coordinator` environment and sends it to Wrangler over stdin. The workflow requires exact protected-source identity, keeps credentials out of checkout and dependency-install steps, and never places the token on argv.

## User Impact

Maintainers can rotate the production coordinator admin token without local Cloudflare credentials or exposing the token in workflow inputs. The staging secret can be deleted immediately after rotation.

## Evidence

- `actionlint .github/workflows/coordinator-admin-token-rotate.yml`
- `node --test scripts/coordinator-admin-token-rotation-workflow.test.js scripts/workflow-action-pins.test.js` — 3 passed
- `git diff --check`
- autoreview was not run because its secret-path guard refuses credential-rotation workflow filenames; this change is workflow metadata plus its static contract test
