### PR TITLE
feat(blacksmith): report active fleet capacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 ### Fixed
 
+- Made Blacksmith doctor report all-organization inventory scope and a
+  nonterminal active Testbox count for capacity-aware callers.
 - Made brokered Daytona usable with Crabbox auth alone, added a read-only
   fallback readiness probe with truthful control/data-plane diagnostics, and
   made repeated sandbox cleanup idempotent.

--- a/internal/providers/blacksmith/backend.go
+++ b/internal/providers/blacksmith/backend.go
@@ -702,13 +702,27 @@ func (b *blacksmithBackend) ListJSON(ctx context.Context, req ListRequest) (any,
 }
 
 func (b *blacksmithBackend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
-	servers, err := b.List(ctx, ListRequest{})
+	servers, err := b.List(ctx, ListRequest{All: true})
 	if err != nil {
 		return core.DoctorResult{}, err
 	}
+	activeLeases := 0
+	for _, server := range servers {
+		// Blacksmith's all-org inventory may include terminal rows. Unknown states
+		// count as active so admission fails conservatively when the CLI evolves.
+		switch strings.ToLower(strings.TrimSpace(server.Status)) {
+		case "completed", "cancelled", "canceled", "failed", "released", "stopped":
+		default:
+			activeLeases++
+		}
+	}
 	return core.DoctorResult{
 		Provider: blacksmithTestboxProvider,
-		Message:  fmt.Sprintf("cli=ready control_plane=ready inventory=ready api=list mutation=false leases=%d runtime=ci_hydrated_by_provider", len(servers)),
+		Message: fmt.Sprintf(
+			"cli=ready control_plane=ready inventory=ready inventory_scope=all api=list mutation=false leases=%d active_leases=%d runtime=ci_hydrated_by_provider",
+			len(servers),
+			activeLeases,
+		),
 	}, nil
 }
 

--- a/internal/providers/blacksmith/backend.go
+++ b/internal/providers/blacksmith/backend.go
@@ -719,9 +719,10 @@ func (b *blacksmithBackend) Doctor(ctx context.Context, _ core.DoctorRequest) (c
 	return core.DoctorResult{
 		Provider: blacksmithTestboxProvider,
 		Message: fmt.Sprintf(
-			"cli=ready control_plane=ready inventory=ready inventory_scope=all api=list mutation=false leases=%d active_leases=%d runtime=ci_hydrated_by_provider",
-			len(servers),
+			"cli=ready control_plane=ready inventory=ready inventory_scope=all api=list mutation=false leases=%d active_leases=%d inventory_rows=%d runtime=ci_hydrated_by_provider",
 			activeLeases,
+			activeLeases,
+			len(servers),
 		),
 	}, nil
 }

--- a/internal/providers/blacksmith/backend_test.go
+++ b/internal/providers/blacksmith/backend_test.go
@@ -1323,7 +1323,7 @@ func TestBlacksmithDoctorListsInventoryOnly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result.Provider != blacksmithTestboxProvider || !strings.Contains(result.Message, "inventory_scope=all") || !strings.Contains(result.Message, "leases=3 active_leases=2") {
+	if result.Provider != blacksmithTestboxProvider || !strings.Contains(result.Message, "inventory_scope=all") || !strings.Contains(result.Message, "leases=2 active_leases=2 inventory_rows=3") {
 		t.Fatalf("result=%#v", result)
 	}
 	if len(runner.calls) != 1 {

--- a/internal/providers/blacksmith/backend_test.go
+++ b/internal/providers/blacksmith/backend_test.go
@@ -1310,7 +1310,12 @@ func TestBlacksmithBackendListJSONCanIncludeAllStates(t *testing.T) {
 func TestBlacksmithDoctorListsInventoryOnly(t *testing.T) {
 	runner := &blacksmithFuncRunner{fn: func(LocalCommandRequest) (LocalCommandResult, error) {
 		return LocalCommandResult{
-			Stdout: "tbx_123 ready my-app .github/workflows/testbox.yml test main 2026-05-06T00:00:00Z\n",
+			Stdout: strings.Join([]string{
+				"tbx_123 ready my-app .github/workflows/testbox.yml test main 2026-05-06T00:00:00Z",
+				"tbx_456 hydrating my-app .github/workflows/testbox.yml test main 2026-05-06T00:01:00Z",
+				"tbx_789 completed my-app .github/workflows/testbox.yml test main 2026-05-06T00:02:00Z",
+				"",
+			}, "\n"),
 		}, nil
 	}}
 	backend := newTestBlacksmithBackend(baseConfig(), runner)
@@ -1318,13 +1323,13 @@ func TestBlacksmithDoctorListsInventoryOnly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result.Provider != blacksmithTestboxProvider || !strings.Contains(result.Message, "cli=ready control_plane=ready inventory=ready api=list mutation=false leases=1 runtime=ci_hydrated_by_provider") {
+	if result.Provider != blacksmithTestboxProvider || !strings.Contains(result.Message, "inventory_scope=all") || !strings.Contains(result.Message, "leases=3 active_leases=2") {
 		t.Fatalf("result=%#v", result)
 	}
 	if len(runner.calls) != 1 {
 		t.Fatalf("calls=%#v, want one list", runner.calls)
 	}
-	want := []string{"testbox", "list"}
+	want := []string{"testbox", "list", "--all"}
 	if !reflect.DeepEqual(runner.calls[0], want) {
 		t.Fatalf("call=%#v, want %#v", runner.calls[0], want)
 	}


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/116783

## What Problem This Solves

Resolves a problem where capacity-aware callers could see only the current
operator's Blacksmith Testboxes even when the organization had several active
leases, making fleet admission decisions from incomplete inventory.

## Why This Change Was Made

Blacksmith doctor now reads the non-mutating all-organization Testbox inventory,
reports its scope explicitly, and separates total rows from nonterminal active
leases. Known terminal states do not consume admission capacity; unknown states
count as active so newer CLI states fail conservatively.

## User Impact

Operators and routing tools can make bounded Blacksmith admission decisions from
structured, organization-wide active capacity without creating or stopping a
Testbox.

## Evidence

- Before: `blacksmith testbox list --all` showed four active Testboxes while
  `crabbox doctor --provider blacksmith-testbox --json` reported `leases=1`.
- `go test ./internal/providers/blacksmith`
- Fresh Codex autoreview: clean, no accepted/actionable findings.
