### PR TITLE
fix(azure): let broker defaults select the image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,6 @@
 
 ### Fixed
 
-- Kept default-derived Azure images out of normal broker lease requests so
-  coordinator-managed image policy no longer requires admin-token auth.
 - Made brokered Daytona usable with Crabbox auth alone, added a read-only
   fallback readiness probe with truthful control/data-plane diagnostics, and
   made repeated sandbox cleanup idempotent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 ### Fixed
 
+- Kept default-derived Azure images out of normal broker lease requests so
+  coordinator-managed image policy no longer requires admin-token auth.
 - Made brokered Daytona usable with Crabbox auth alone, added a read-only
   fallback readiness probe with truthful control/data-plane diagnostics, and
   made repeated sandbox cleanup idempotent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 
 - Made Blacksmith doctor report all-organization inventory scope and a
   nonterminal active Testbox count for capacity-aware callers.
+- Kept default-derived Azure images out of normal broker lease requests so
+  coordinator-managed image policy no longer requires admin-token auth.
 - Made brokered Daytona usable with Crabbox auth alone, added a read-only
   fallback readiness probe with truthful control/data-plane diagnostics, and
   made repeated sandbox cleanup idempotent.

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -920,7 +920,6 @@ func (c *CoordinatorClient) CreateLease(ctx context.Context, cfg Config, publicK
 		"awsSSHCIDRsPinned":               cfg.AWSSSHCIDRsPinned,
 		"awsMacHostID":                    cfg.AWSMacHostID,
 		"azureLocation":                   cfg.AzureLocation,
-		"azureImage":                      cfg.AzureImage,
 		"azureSnapshot":                   cfg.AzureSnapshot,
 		"sshUser":                         cfg.SSHUser,
 		"sshPort":                         cfg.SSHPort,
@@ -945,6 +944,9 @@ func (c *CoordinatorClient) CreateLease(ctx context.Context, cfg Config, publicK
 	}
 	if cfg.osImageExplicit {
 		req["os"] = cfg.OSImage
+	}
+	if cfg.azureImageExplicit {
+		req["azureImage"] = cfg.AzureImage
 	}
 	if cfg.AzureOSDiskExplicit {
 		req["azureOSDisk"] = cfg.AzureOSDisk

--- a/internal/cli/coordinator_test.go
+++ b/internal/cli/coordinator_test.go
@@ -1232,6 +1232,7 @@ func TestCoordinatorCreateLeaseSendsAWSSSHCIDRs(t *testing.T) {
 		AWSSSHCIDRs:         []string{"198.51.100.7/32"},
 		AzureLocation:       "eastus",
 		AzureImage:          "Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest",
+		azureImageExplicit:  true,
 		AzureSnapshot:       "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/snapshots/checkpoint",
 		AzureOSDisk:         "managed",
 		AzureOSDiskExplicit: true,
@@ -1423,6 +1424,50 @@ func TestCoordinatorRegisterLease(t *testing.T) {
 	}
 	if lease.Lifecycle != "registered" || got.Slug != "my-box" || got.Provider != "external" || got.Host != "192.0.2.10" || got.IdleTimeoutSeconds != 1800 {
 		t.Fatalf("lease=%#v request=%#v", lease, got)
+	}
+}
+
+func TestCoordinatorCreateLeaseForwardsOnlyExplicitAzureImage(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		explicit bool
+		want     bool
+	}{
+		{name: "default omitted"},
+		{name: "explicit forwarded", explicit: true, want: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var body map[string]any
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost || r.URL.Path != "/v1/leases" {
+					t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+				}
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Fatal(err)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"lease":{"id":"cbx_123","provider":"azure","state":"active","host":"192.0.2.10"}}`))
+			}))
+			defer server.Close()
+
+			client := CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
+			_, err := client.CreateLease(context.Background(), Config{
+				Provider:           "azure",
+				AzureLocation:      "eastus",
+				AzureImage:         defaultAzureLinuxImage,
+				azureImageExplicit: tc.explicit,
+				SSHFallbackPorts:   []string{"22"},
+				TTL:                time.Hour,
+				IdleTimeout:        30 * time.Minute,
+			}, "ssh-ed25519 test", false, "cbx_123", "blue-crab")
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, got := body["azureImage"]
+			if got != tc.want {
+				t.Fatalf("azureImage present=%t want %t: %#v", got, tc.want, body)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/116783

## What Problem This Solves

Fixes an issue where normal broker users selecting Azure would receive a 403
`admin_required` response before allocation because the CLI sent its
default-derived Azure image as an explicit resource selector.

## Why This Change Was Made

The CLI now sends `azureImage` only when the user explicitly configured the
Azure image. Default and portable OS selections remain coordinator-managed, so
the Worker keeps enforcing admin authentication for deliberate image
overrides without requiring direct Azure credentials on clients.

## User Impact

Normal broker users can fall back to Azure using Crabbox auth alone. Operators
retain control of the default Azure image, and explicit client-side image
overrides still require admin-token authentication.

## Evidence

- Live broker canary before the fix: normal user auth failed before allocation
  with HTTP 403 `admin_required`, identifying `azureImage` as the restricted
  field.
- Live broker canary on exact head
  `a9a48db6a0f2953d0359ba94247c6ab1fb7cc57e`: normal user auth was accepted
  without direct Azure credentials, and Azure began provisioning
  `Standard_D32ads_v6`. The machine remained unready through the five-minute
  spend cap, so the canary was cancelled. Run `run_8d0511b09c90` ended
  `state=failed` with no lease ID; provider listing showed no matching lease,
  and inspect/release by slug returned 404. This proves the auth fix, not SSH
  readiness or startup performance. Azure sizing is being addressed separately
  in OpenClaw routing policy.
- `go test ./internal/cli -run 'TestCoordinatorCreateLease(ForwardsOnlyExplicitAzureImage|SendsAWSSSHCIDRs|OmitsDefaultAzureOSDisk)$' -count=1`
- `go test ./internal/cli -count=1`
- Fresh structured autoreview: clean, no actionable findings.
