### PR TITLE
fix(sync): recover finalization after transient SSH disconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,6 @@
 
 ### Fixed
 
-- Retried idempotent sync finalization and post-sync Actions hydration marker
-  cleanup once after a transient SSH transport failure, while preserving
-  redacted terminal diagnostics.
 - Made Blacksmith doctor report all-organization inventory scope and a
   nonterminal active Testbox count for capacity-aware callers.
 - Kept default-derived Azure images out of normal broker lease requests so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@
 
 ### Fixed
 
-- Retried idempotent post-sync Actions hydration marker cleanup once after a
-  transient SSH transport failure, while preserving redacted terminal diagnostics.
+- Retried idempotent sync finalization and post-sync Actions hydration marker
+  cleanup once after a transient SSH transport failure, while preserving
+  redacted terminal diagnostics.
 - Made Blacksmith doctor report all-organization inventory scope and a
   nonterminal active Testbox count for capacity-aware callers.
 - Kept default-derived Azure images out of normal broker lease requests so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 
 ### Fixed
 
+- Retried idempotent sync finalization and post-sync Actions hydration marker
+  cleanup once after a transient SSH transport failure, while preserving
+  redacted terminal diagnostics.
 - Made Blacksmith doctor report all-organization inventory scope and a
   nonterminal active Testbox count for capacity-aware callers.
 - Kept default-derived Azure images out of normal broker lease requests so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,10 @@
 
 ### Fixed
 
-- Retried idempotent remote workspace setup, sync finalization, and post-sync
-  Actions hydration marker cleanup once after a transient SSH transport
-  failure, while preserving redacted terminal diagnostics.
+- Retried idempotent remote workspace setup, Git and manifest sync preparation,
+  sync finalization, and post-sync Actions hydration marker cleanup once after
+  a transient SSH transport failure, while preserving redacted terminal
+  diagnostics.
 - Kept brokered Daytona on its operator-managed snapshot across coordinator
   deployments while preserving account-default mode and an explicit clear path.
 - Recovered exact-owned Azure public IPs, network interfaces, and tagged OS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 ### Fixed
 
+- Retried idempotent post-sync Actions hydration marker cleanup once after a
+  transient SSH transport failure, while preserving redacted terminal diagnostics.
 - Made Blacksmith doctor report all-organization inventory scope and a
   nonterminal active Testbox count for capacity-aware callers.
 - Made brokered Daytona usable with Crabbox auth alone, added a read-only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,9 @@
 
 ### Fixed
 
-- Retried idempotent sync finalization and post-sync Actions hydration marker
-  cleanup once after a transient SSH transport failure, while preserving
-  redacted terminal diagnostics.
+- Retried idempotent remote workspace setup, sync finalization, and post-sync
+  Actions hydration marker cleanup once after a transient SSH transport
+  failure, while preserving redacted terminal diagnostics.
 - Kept brokered Daytona on its operator-managed snapshot across coordinator
   deployments while preserving account-default mode and an explicit clear path.
 - Recovered exact-owned Azure public IPs, network interfaces, and tagged OS

--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -583,7 +583,7 @@ func (a App) syncLocalActionsWorkspace(ctx context.Context, cfg Config, repo Rep
 		BaseSHA:            gitHydrateBaseSHA(repo, cfg.Sync.BaseRef),
 		Fingerprint:        fingerprint,
 	})
-	if out, err := runSSHCombinedOutput(ctx, target, finalizeCommand); err != nil {
+	if out, err := runIdempotentSSHCombinedOutput(ctx, target, finalizeCommand, idempotentSSHRetryDelay); err != nil {
 		if out != "" {
 			return exit(6, "remote sync finalize failed: %s: %v", out, err)
 		}
@@ -2268,25 +2268,11 @@ func runActionsHydrationQuiet(ctx context.Context, target SSHTarget, remote stri
 	return err
 }
 
-var actionsHydrationMarkerRetryDelay = 2 * time.Second
-
 func clearActionsHydrationState(ctx context.Context, target SSHTarget, leaseID string) error {
 	remote := remoteClearActionsHydrationStateForTarget(target, leaseID)
-	var lastErr error
-	var lastOutput string
-	for attempt := 0; attempt < 2; attempt++ {
-		lastOutput, lastErr = runSSHCombinedOutput(ctx, target, remote)
-		if lastErr == nil {
-			return nil
-		}
-		if !shouldRetrySSHPort(lastErr) || attempt == 1 {
-			break
-		}
-		// Marker removal is idempotent, so a bounded retry can absorb a gateway
-		// transport refusal without risking duplicate user or workflow commands.
-		if err := sleepContext(ctx, actionsHydrationMarkerRetryDelay); err != nil {
-			return exit(7, "clear GitHub Actions hydration marker on %s: %v", target.Host, err)
-		}
+	lastOutput, lastErr := runIdempotentSSHCombinedOutput(ctx, target, remote, idempotentSSHRetryDelay)
+	if lastErr == nil {
+		return nil
 	}
 	details := strings.TrimSpace(lastOutput)
 	if target.AuthSecret {

--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -552,8 +552,12 @@ func (a App) syncLocalActionsWorkspace(ctx context.Context, cfg Config, repo Rep
 	}
 	manifestData := manifest.NUL()
 	deletedData := manifest.DeletedNUL()
+	finalizeToken, err := randomHex(16)
+	if err != nil {
+		return exit(6, "create sync finalize token: %v", err)
+	}
 	manifestInput := syncManifestInputForTarget(target, manifestData, deletedData)
-	if err := runSSHInput(ctx, target, remoteWriteSyncManifestsNewForTarget(target, workdir), strings.NewReader(manifestInput), io.Discard, a.Stderr); err != nil {
+	if err := runSSHInput(ctx, target, remoteWriteSyncManifestsNewForTarget(target, workdir, finalizeToken), strings.NewReader(manifestInput), io.Discard, a.Stderr); err != nil {
 		return exit(7, "write sync manifests: %v", err)
 	}
 	if shouldPruneRemoteSync(cfg.Sync.Delete, false) {
@@ -582,6 +586,7 @@ func (a App) syncLocalActionsWorkspace(ctx context.Context, cfg Config, repo Rep
 		BaseRef:            cfg.Sync.BaseRef,
 		BaseSHA:            gitHydrateBaseSHA(repo, cfg.Sync.BaseRef),
 		Fingerprint:        fingerprint,
+		Token:              finalizeToken,
 	})
 	if out, err := runIdempotentSSHCombinedOutput(ctx, target, finalizeCommand, idempotentSSHRetryDelay); err != nil {
 		if out != "" {

--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -2268,11 +2268,34 @@ func runActionsHydrationQuiet(ctx context.Context, target SSHTarget, remote stri
 	return err
 }
 
+var actionsHydrationMarkerRetryDelay = 2 * time.Second
+
 func clearActionsHydrationState(ctx context.Context, target SSHTarget, leaseID string) error {
-	if err := runSSHQuiet(ctx, target, remoteClearActionsHydrationStateForTarget(target, leaseID)); err != nil {
-		return exit(7, "clear GitHub Actions hydration marker on %s: %v", target.Host, err)
+	remote := remoteClearActionsHydrationStateForTarget(target, leaseID)
+	var lastErr error
+	var lastOutput string
+	for attempt := 0; attempt < 2; attempt++ {
+		lastOutput, lastErr = runSSHCombinedOutput(ctx, target, remote)
+		if lastErr == nil {
+			return nil
+		}
+		if !shouldRetrySSHPort(lastErr) || attempt == 1 {
+			break
+		}
+		// Marker removal is idempotent, so a bounded retry can absorb a gateway
+		// transport refusal without risking duplicate user or workflow commands.
+		if err := sleepContext(ctx, actionsHydrationMarkerRetryDelay); err != nil {
+			return exit(7, "clear GitHub Actions hydration marker on %s: %v", target.Host, err)
+		}
 	}
-	return nil
+	details := strings.TrimSpace(lastOutput)
+	if target.AuthSecret {
+		details = RedactDiagnosticSecrets(details, target.User)
+	}
+	if details != "" {
+		return exit(7, "clear GitHub Actions hydration marker on %s: %v: %s", target.Host, lastErr, details)
+	}
+	return exit(7, "clear GitHub Actions hydration marker on %s: %v", target.Host, lastErr)
 }
 
 func writeActionsHydrationStop(ctx context.Context, target SSHTarget, leaseID string) error {

--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -546,7 +546,7 @@ func (a App) syncLocalActionsWorkspace(ctx context.Context, cfg Config, repo Rep
 		warnCredentialBearingGitSeed(a.Stderr)
 	}
 	if gitSeed {
-		if err := runSSHQuiet(ctx, target, remoteGitSeed(workdir, repo.RemoteURL, repo.Head)); err != nil {
+		if _, err := runIdempotentSSHCombinedOutput(ctx, target, remoteGitSeed(workdir, repo.RemoteURL, repo.Head), idempotentSSHRetryDelay); err != nil {
 			fmt.Fprintf(a.Stderr, "warning: remote git seed failed: %v\n", err)
 		}
 	}
@@ -561,10 +561,10 @@ func (a App) syncLocalActionsWorkspace(ctx context.Context, cfg Config, repo Rep
 		return exit(7, "write sync manifests: %v", err)
 	}
 	if shouldPruneRemoteSync(cfg.Sync.Delete, false) {
-		if err := runSSHQuiet(ctx, target, remoteSeedSyncManifestFromGit(workdir)); err != nil {
+		if _, err := runIdempotentSSHCombinedOutput(ctx, target, remoteSeedSyncManifestFromGit(workdir), idempotentSSHRetryDelay); err != nil {
 			return exit(6, "remote sync seed manifest failed: %v", err)
 		}
-		if err := runSSHQuiet(ctx, target, remotePruneSyncManifestForTarget(target, workdir, finalizeToken)); err != nil {
+		if _, err := runIdempotentSSHCombinedOutput(ctx, target, remotePruneSyncManifestForTarget(target, workdir, finalizeToken), idempotentSSHRetryDelay); err != nil {
 			return exit(6, "remote sync prune failed: %v", err)
 		}
 	}

--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -564,7 +564,7 @@ func (a App) syncLocalActionsWorkspace(ctx context.Context, cfg Config, repo Rep
 		if err := runSSHQuiet(ctx, target, remoteSeedSyncManifestFromGit(workdir)); err != nil {
 			return exit(6, "remote sync seed manifest failed: %v", err)
 		}
-		if err := runSSHQuiet(ctx, target, remotePruneSyncManifestForTarget(target, workdir)); err != nil {
+		if err := runSSHQuiet(ctx, target, remotePruneSyncManifestForTarget(target, workdir, finalizeToken)); err != nil {
 			return exit(6, "remote sync prune failed: %v", err)
 		}
 	}

--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -538,7 +538,7 @@ func (a App) syncLocalActionsWorkspace(ctx context.Context, cfg Config, repo Rep
 	if err := checkSyncPreflight(manifest, cfg, false, a.Stderr); err != nil {
 		return err
 	}
-	if err := runSSHQuiet(ctx, target, remoteMkdir(workdir)); err != nil {
+	if _, err := runIdempotentSSHCombinedOutput(ctx, target, remoteMkdir(workdir), idempotentSSHRetryDelay); err != nil {
 		return exit(7, "create remote workdir: %v", err)
 	}
 	gitSeed, credentialBlocked := syncGitSeedDecision(cfg, repo)

--- a/internal/cli/actions_test.go
+++ b/internal/cli/actions_test.go
@@ -1498,3 +1498,88 @@ func TestActionsRunURLIgnoresLocalRunIDs(t *testing.T) {
 		t.Fatalf("actionsRunURL=%q", got)
 	}
 }
+
+func TestClearActionsHydrationStateRetriesTransientSSHTransportFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell ssh fixture")
+	}
+	dir := t.TempDir()
+	sshPath := filepath.Join(dir, "ssh")
+	callsPath := filepath.Join(dir, "calls")
+	script := `#!/bin/sh
+printf 'call\n' >> "$CRABBOX_FAKE_SSH_CALLS"
+if [ "$(wc -l < "$CRABBOX_FAKE_SSH_CALLS")" -eq 1 ]; then
+  printf 'gateway temporarily unavailable\n' >&2
+  exit 255
+fi
+exit 0
+`
+	if err := os.WriteFile(sshPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CRABBOX_FAKE_SSH_CALLS", callsPath)
+	originalDelay := actionsHydrationMarkerRetryDelay
+	actionsHydrationMarkerRetryDelay = 0
+	t.Cleanup(func() { actionsHydrationMarkerRetryDelay = originalDelay })
+
+	err := clearActionsHydrationState(context.Background(), SSHTarget{
+		User: "crabbox",
+		Host: "gateway.example",
+		Port: "22",
+	}, "cbx_123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	calls, err := os.ReadFile(callsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(string(calls), "call\n"); got != 2 {
+		t.Fatalf("ssh calls=%d want 2", got)
+	}
+}
+
+func TestClearActionsHydrationStateBoundsRetryAndRedactsDiagnostics(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell ssh fixture")
+	}
+	dir := t.TempDir()
+	sshPath := filepath.Join(dir, "ssh")
+	callsPath := filepath.Join(dir, "calls")
+	script := `#!/bin/sh
+printf 'call\n' >> "$CRABBOX_FAKE_SSH_CALLS"
+printf 'permission denied for opaque-access-token@gateway.example\n' >&2
+exit 255
+`
+	if err := os.WriteFile(sshPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CRABBOX_FAKE_SSH_CALLS", callsPath)
+	originalDelay := actionsHydrationMarkerRetryDelay
+	actionsHydrationMarkerRetryDelay = 0
+	t.Cleanup(func() { actionsHydrationMarkerRetryDelay = originalDelay })
+
+	err := clearActionsHydrationState(context.Background(), SSHTarget{
+		User:       "opaque-access-token",
+		Host:       "gateway.example",
+		Port:       "22",
+		AuthSecret: true,
+	}, "cbx_123")
+	if err == nil {
+		t.Fatal("expected persistent transport failure")
+	}
+	if got := err.Error(); strings.Contains(got, "opaque-access-token") ||
+		!strings.Contains(got, "[redacted]@gateway.example") ||
+		!strings.Contains(got, "exit status 255") {
+		t.Fatalf("error=%q", got)
+	}
+	calls, readErr := os.ReadFile(callsPath)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if got := strings.Count(string(calls), "call\n"); got != 2 {
+		t.Fatalf("ssh calls=%d want 2", got)
+	}
+}

--- a/internal/cli/actions_test.go
+++ b/internal/cli/actions_test.go
@@ -1519,9 +1519,9 @@ exit 0
 	}
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	t.Setenv("CRABBOX_FAKE_SSH_CALLS", callsPath)
-	originalDelay := actionsHydrationMarkerRetryDelay
-	actionsHydrationMarkerRetryDelay = 0
-	t.Cleanup(func() { actionsHydrationMarkerRetryDelay = originalDelay })
+	originalDelay := idempotentSSHRetryDelay
+	idempotentSSHRetryDelay = 0
+	t.Cleanup(func() { idempotentSSHRetryDelay = originalDelay })
 
 	err := clearActionsHydrationState(context.Background(), SSHTarget{
 		User: "crabbox",
@@ -1557,9 +1557,9 @@ exit 255
 	}
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	t.Setenv("CRABBOX_FAKE_SSH_CALLS", callsPath)
-	originalDelay := actionsHydrationMarkerRetryDelay
-	actionsHydrationMarkerRetryDelay = 0
-	t.Cleanup(func() { actionsHydrationMarkerRetryDelay = originalDelay })
+	originalDelay := idempotentSSHRetryDelay
+	idempotentSSHRetryDelay = 0
+	t.Cleanup(func() { idempotentSSHRetryDelay = originalDelay })
 
 	err := clearActionsHydrationState(context.Background(), SSHTarget{
 		User:       "opaque-access-token",

--- a/internal/cli/ready_pool_scrub.go
+++ b/internal/cli/ready_pool_scrub.go
@@ -218,7 +218,8 @@ git_dir="$(safe_git rev-parse --git-dir)"
 meta_dir="$git_dir/crabbox"
 mkdir -p "$meta_dir"
 rm -f -- "$meta_dir/sync-fingerprint" "$meta_dir/sync-manifest" "$meta_dir/sync-finalize-token" "$meta_dir/sync-finalize-complete-token" "$meta_dir/sync-finalize-lock"
-rm -f -- "$meta_dir"/sync-manifest.*.new "$meta_dir"/sync-deleted.*.new "$meta_dir"/sync-finalize-lock.stale.*
+rm -f -- "$meta_dir"/sync-manifest.*.new "$meta_dir"/sync-deleted.*.new "$meta_dir"/sync-manifest.*.sorted
+rm -f -- "$meta_dir"/sync-finalize-token.tmp.* "$meta_dir"/sync-finalize-complete-token.tmp.* "$meta_dir"/sync-finalize-lock.stale.*
 printf '%s %s\n' "$ref" "$target_commit" > "$meta_dir/git-hydrate-base"
 test "$(safe_git branch --show-current)" = "$ref"
 test "$(safe_git rev-parse HEAD)" = "$target_commit"
@@ -384,7 +385,7 @@ foreach ($name in @('sync-fingerprint', 'sync-manifest', 'sync-finalize-token', 
     if (Test-Path -LiteralPath $metadataPath) { throw "ready-pool stale Git metadata was not removed" }
   }
 }
-foreach ($pattern in @('sync-manifest.*.new', 'sync-deleted.*.new', 'sync-finalize-lock.stale.*')) {
+foreach ($pattern in @('sync-manifest.*.new', 'sync-deleted.*.new', 'sync-manifest.*.sorted', 'sync-finalize-token.tmp.*', 'sync-finalize-complete-token.tmp.*', 'sync-finalize-lock.stale.*')) {
   Get-ChildItem -LiteralPath $metaDir -Filter $pattern -Force -ErrorAction Stop | ForEach-Object {
     Remove-Item -LiteralPath $_.FullName -Force -ErrorAction Stop
   }

--- a/internal/cli/ready_pool_scrub.go
+++ b/internal/cli/ready_pool_scrub.go
@@ -217,7 +217,8 @@ rm -rf -- .crabbox/env .crabbox/scripts .crabbox/logs .crabbox/captures .crabbox
 git_dir="$(safe_git rev-parse --git-dir)"
 meta_dir="$git_dir/crabbox"
 mkdir -p "$meta_dir"
-rm -f -- "$meta_dir/sync-fingerprint" "$meta_dir/sync-manifest" "$meta_dir/sync-manifest.new" "$meta_dir/sync-deleted.new"
+rm -f -- "$meta_dir/sync-fingerprint" "$meta_dir/sync-manifest" "$meta_dir/sync-finalize-token" "$meta_dir/sync-finalize-complete-token" "$meta_dir/sync-finalize-lock"
+rm -f -- "$meta_dir"/sync-manifest.*.new "$meta_dir"/sync-deleted.*.new "$meta_dir"/sync-finalize-lock.stale.*
 printf '%s %s\n' "$ref" "$target_commit" > "$meta_dir/git-hydrate-base"
 test "$(safe_git branch --show-current)" = "$ref"
 test "$(safe_git rev-parse HEAD)" = "$target_commit"
@@ -376,11 +377,16 @@ $gitDir = (& $git rev-parse --git-dir).Trim()
 if ($LASTEXITCODE -ne 0 -or -not $gitDir) { throw "ready-pool Git metadata is missing" }
 $metaDir = Join-Path $gitDir 'crabbox'
 New-Item -ItemType Directory -Force -Path $metaDir | Out-Null
-foreach ($name in @('sync-fingerprint', 'sync-manifest', 'sync-manifest.new', 'sync-deleted.new')) {
+foreach ($name in @('sync-fingerprint', 'sync-manifest', 'sync-finalize-token', 'sync-finalize-complete-token', 'sync-finalize-lock')) {
   $metadataPath = Join-Path $metaDir $name
   if (Test-Path -LiteralPath $metadataPath) {
     Remove-Item -LiteralPath $metadataPath -Force -ErrorAction Stop
     if (Test-Path -LiteralPath $metadataPath) { throw "ready-pool stale Git metadata was not removed" }
+  }
+}
+foreach ($pattern in @('sync-manifest.*.new', 'sync-deleted.*.new', 'sync-finalize-lock.stale.*')) {
+  Get-ChildItem -LiteralPath $metaDir -Filter $pattern -Force -ErrorAction Stop | ForEach-Object {
+    Remove-Item -LiteralPath $_.FullName -Force -ErrorAction Stop
   }
 }
 Set-Content -LiteralPath (Join-Path $metaDir 'git-hydrate-base') -Value "$ref $targetCommit"

--- a/internal/cli/ready_pool_scrub.go
+++ b/internal/cli/ready_pool_scrub.go
@@ -217,7 +217,8 @@ rm -rf -- .crabbox/env .crabbox/scripts .crabbox/logs .crabbox/captures .crabbox
 git_dir="$(safe_git rev-parse --git-dir)"
 meta_dir="$git_dir/crabbox"
 mkdir -p "$meta_dir"
-rm -f -- "$meta_dir/sync-fingerprint" "$meta_dir/sync-manifest" "$meta_dir/sync-finalize-token" "$meta_dir/sync-finalize-complete-token" "$meta_dir/sync-finalize-lock"
+rm -f -- "$meta_dir/sync-fingerprint" "$meta_dir/sync-manifest" "$meta_dir/sync-manifest.new" "$meta_dir/sync-deleted.new"
+rm -f -- "$meta_dir/sync-finalize-token" "$meta_dir/sync-finalize-complete-token" "$meta_dir/sync-finalize-lock"
 rm -f -- "$meta_dir"/sync-manifest.*.new "$meta_dir"/sync-deleted.*.new "$meta_dir"/sync-manifest.*.sorted
 rm -f -- "$meta_dir"/sync-finalize-token.tmp.* "$meta_dir"/sync-finalize-complete-token.tmp.* "$meta_dir"/sync-finalize-lock.stale.*
 printf '%s %s\n' "$ref" "$target_commit" > "$meta_dir/git-hydrate-base"
@@ -378,7 +379,7 @@ $gitDir = (& $git rev-parse --git-dir).Trim()
 if ($LASTEXITCODE -ne 0 -or -not $gitDir) { throw "ready-pool Git metadata is missing" }
 $metaDir = Join-Path $gitDir 'crabbox'
 New-Item -ItemType Directory -Force -Path $metaDir | Out-Null
-foreach ($name in @('sync-fingerprint', 'sync-manifest', 'sync-finalize-token', 'sync-finalize-complete-token', 'sync-finalize-lock')) {
+foreach ($name in @('sync-fingerprint', 'sync-manifest', 'sync-manifest.new', 'sync-deleted.new', 'sync-finalize-token', 'sync-finalize-complete-token', 'sync-finalize-lock')) {
   $metadataPath = Join-Path $metaDir $name
   if (Test-Path -LiteralPath $metadataPath) {
     Remove-Item -LiteralPath $metadataPath -Force -ErrorAction Stop

--- a/internal/cli/ready_pool_scrub_test.go
+++ b/internal/cli/ready_pool_scrub_test.go
@@ -55,7 +55,7 @@ func TestRemoteReadyPoolScrubResetsLatestBranchAndPreservesIgnoredCaches(t *test
 	mustWriteTestFile(t, filepath.Join(workdir, "packages", "app[1]", "node_modules", "cache.txt"), "keep metachar\n")
 	mustWriteTestFile(t, filepath.Join(workdir, ".pnpm-store", "cache.txt"), "remove unless ignored\n")
 	mustWriteTestFile(t, filepath.Join(workdir, "task-state.ignored"), "remove me\n")
-	for _, name := range []string{"sync-fingerprint", "sync-manifest", "sync-finalize-token", "sync-finalize-complete-token", "sync-manifest.0123456789abcdef.new", "sync-deleted.0123456789abcdef.new"} {
+	for _, name := range []string{"sync-fingerprint", "sync-manifest", "sync-finalize-token", "sync-finalize-complete-token", "sync-manifest.0123456789abcdef.new", "sync-deleted.0123456789abcdef.new", "sync-manifest.0123456789abcdef.old.sorted", "sync-manifest.0123456789abcdef.new.sorted", "sync-finalize-token.tmp.123", "sync-finalize-complete-token.tmp.123"} {
 		mustWriteTestFile(t, filepath.Join(workdir, ".git", "crabbox", name), "stale\n")
 	}
 	for _, name := range []string{"env", "scripts", "logs", "captures", "runs"} {
@@ -153,7 +153,7 @@ func TestRemoteReadyPoolScrubResetsLatestBranchAndPreservesIgnoredCaches(t *test
 	if _, err := os.Stat(filepath.Join(workdir, ".pnpm-store")); !os.IsNotExist(err) {
 		t.Fatalf("non-ignored cache remains: %v", err)
 	}
-	for _, name := range []string{"sync-fingerprint", "sync-manifest", "sync-finalize-token", "sync-finalize-complete-token", "sync-manifest.0123456789abcdef.new", "sync-deleted.0123456789abcdef.new"} {
+	for _, name := range []string{"sync-fingerprint", "sync-manifest", "sync-finalize-token", "sync-finalize-complete-token", "sync-manifest.0123456789abcdef.new", "sync-deleted.0123456789abcdef.new", "sync-manifest.0123456789abcdef.old.sorted", "sync-manifest.0123456789abcdef.new.sorted", "sync-finalize-token.tmp.123", "sync-finalize-complete-token.tmp.123"} {
 		if _, err := os.Stat(filepath.Join(workdir, ".git", "crabbox", name)); !os.IsNotExist(err) {
 			t.Fatalf("stale metadata %s remains: %v", name, err)
 		}

--- a/internal/cli/ready_pool_scrub_test.go
+++ b/internal/cli/ready_pool_scrub_test.go
@@ -55,7 +55,7 @@ func TestRemoteReadyPoolScrubResetsLatestBranchAndPreservesIgnoredCaches(t *test
 	mustWriteTestFile(t, filepath.Join(workdir, "packages", "app[1]", "node_modules", "cache.txt"), "keep metachar\n")
 	mustWriteTestFile(t, filepath.Join(workdir, ".pnpm-store", "cache.txt"), "remove unless ignored\n")
 	mustWriteTestFile(t, filepath.Join(workdir, "task-state.ignored"), "remove me\n")
-	for _, name := range []string{"sync-fingerprint", "sync-manifest", "sync-finalize-token", "sync-finalize-complete-token", "sync-manifest.0123456789abcdef.new", "sync-deleted.0123456789abcdef.new", "sync-manifest.0123456789abcdef.old.sorted", "sync-manifest.0123456789abcdef.new.sorted", "sync-finalize-token.tmp.123", "sync-finalize-complete-token.tmp.123"} {
+	for _, name := range []string{"sync-fingerprint", "sync-manifest", "sync-manifest.new", "sync-deleted.new", "sync-finalize-token", "sync-finalize-complete-token", "sync-manifest.0123456789abcdef.new", "sync-deleted.0123456789abcdef.new", "sync-manifest.0123456789abcdef.old.sorted", "sync-manifest.0123456789abcdef.new.sorted", "sync-finalize-token.tmp.123", "sync-finalize-complete-token.tmp.123"} {
 		mustWriteTestFile(t, filepath.Join(workdir, ".git", "crabbox", name), "stale\n")
 	}
 	for _, name := range []string{"env", "scripts", "logs", "captures", "runs"} {
@@ -153,7 +153,7 @@ func TestRemoteReadyPoolScrubResetsLatestBranchAndPreservesIgnoredCaches(t *test
 	if _, err := os.Stat(filepath.Join(workdir, ".pnpm-store")); !os.IsNotExist(err) {
 		t.Fatalf("non-ignored cache remains: %v", err)
 	}
-	for _, name := range []string{"sync-fingerprint", "sync-manifest", "sync-finalize-token", "sync-finalize-complete-token", "sync-manifest.0123456789abcdef.new", "sync-deleted.0123456789abcdef.new", "sync-manifest.0123456789abcdef.old.sorted", "sync-manifest.0123456789abcdef.new.sorted", "sync-finalize-token.tmp.123", "sync-finalize-complete-token.tmp.123"} {
+	for _, name := range []string{"sync-fingerprint", "sync-manifest", "sync-manifest.new", "sync-deleted.new", "sync-finalize-token", "sync-finalize-complete-token", "sync-manifest.0123456789abcdef.new", "sync-deleted.0123456789abcdef.new", "sync-manifest.0123456789abcdef.old.sorted", "sync-manifest.0123456789abcdef.new.sorted", "sync-finalize-token.tmp.123", "sync-finalize-complete-token.tmp.123"} {
 		if _, err := os.Stat(filepath.Join(workdir, ".git", "crabbox", name)); !os.IsNotExist(err) {
 			t.Fatalf("stale metadata %s remains: %v", name, err)
 		}

--- a/internal/cli/ready_pool_scrub_test.go
+++ b/internal/cli/ready_pool_scrub_test.go
@@ -55,7 +55,7 @@ func TestRemoteReadyPoolScrubResetsLatestBranchAndPreservesIgnoredCaches(t *test
 	mustWriteTestFile(t, filepath.Join(workdir, "packages", "app[1]", "node_modules", "cache.txt"), "keep metachar\n")
 	mustWriteTestFile(t, filepath.Join(workdir, ".pnpm-store", "cache.txt"), "remove unless ignored\n")
 	mustWriteTestFile(t, filepath.Join(workdir, "task-state.ignored"), "remove me\n")
-	for _, name := range []string{"sync-fingerprint", "sync-manifest", "sync-manifest.new", "sync-deleted.new"} {
+	for _, name := range []string{"sync-fingerprint", "sync-manifest", "sync-finalize-token", "sync-finalize-complete-token", "sync-manifest.0123456789abcdef.new", "sync-deleted.0123456789abcdef.new"} {
 		mustWriteTestFile(t, filepath.Join(workdir, ".git", "crabbox", name), "stale\n")
 	}
 	for _, name := range []string{"env", "scripts", "logs", "captures", "runs"} {
@@ -153,7 +153,7 @@ func TestRemoteReadyPoolScrubResetsLatestBranchAndPreservesIgnoredCaches(t *test
 	if _, err := os.Stat(filepath.Join(workdir, ".pnpm-store")); !os.IsNotExist(err) {
 		t.Fatalf("non-ignored cache remains: %v", err)
 	}
-	for _, name := range []string{"sync-fingerprint", "sync-manifest", "sync-manifest.new", "sync-deleted.new"} {
+	for _, name := range []string{"sync-fingerprint", "sync-manifest", "sync-finalize-token", "sync-finalize-complete-token", "sync-manifest.0123456789abcdef.new", "sync-deleted.0123456789abcdef.new"} {
 		if _, err := os.Stat(filepath.Join(workdir, ".git", "crabbox", name)); !os.IsNotExist(err) {
 			t.Fatalf("stale metadata %s remains: %v", name, err)
 		}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1330,7 +1330,7 @@ retrySync:
 			timings.syncSteps.reset = time.Since(stepStart)
 		} else if isWindowsNativeTarget(target) {
 			stepStart = time.Now()
-			if err := runSSHQuiet(ctx, target, windowsRemoteMkdir(workdir)); err != nil {
+			if _, err := runIdempotentSSHCombinedOutput(ctx, target, windowsRemoteMkdir(workdir), idempotentSSHRetryDelay); err != nil {
 				return recordFailure(exit(7, "create remote workdir: %v", err))
 			}
 			timings.syncSteps.mkdir = time.Since(stepStart)
@@ -1498,7 +1498,7 @@ afterSync:
 		if isWindowsNativeTarget(target) {
 			mkdirCommand = windowsRemoteMkdir(workdir)
 		}
-		if err := runSSHQuiet(ctx, target, mkdirCommand); err != nil {
+		if _, err := runIdempotentSSHCombinedOutput(ctx, target, mkdirCommand, idempotentSSHRetryDelay); err != nil {
 			return recordFailure(exit(7, "create remote workdir: %v", err))
 		}
 	}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1417,7 +1417,7 @@ retrySync:
 			BaseSHA:            baseSHA,
 			Fingerprint:        fingerprint,
 		})
-		if out, err := runSSHCombinedOutput(ctx, target, finalizeCommand); err != nil {
+		if out, err := runIdempotentSSHCombinedOutput(ctx, target, finalizeCommand, idempotentSSHRetryDelay); err != nil {
 			if out != "" {
 				return recordFailure(exit(6, "remote sync finalize failed: %s: %v", out, err))
 			}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1352,7 +1352,7 @@ retrySync:
 		}
 		if gitSeed {
 			stepStart = time.Now()
-			if err := runSSHQuiet(ctx, target, remoteGitSeed(workdir, repo.RemoteURL, repo.Head)); err != nil {
+			if _, err := runIdempotentSSHCombinedOutput(ctx, target, remoteGitSeed(workdir, repo.RemoteURL, repo.Head), idempotentSSHRetryDelay); err != nil {
 				fmt.Fprintf(a.Stderr, "warning: remote git seed failed: %v\n", err)
 			}
 			timings.syncSteps.gitSeed = time.Since(stepStart)
@@ -1387,12 +1387,12 @@ retrySync:
 			// Full resync can git-seed files that are absent from the local manifest.
 			// Seed the old manifest from git so prune removes those resurrected paths.
 			if shouldSeedRemotePruneManifest(hydratedByActions, fullResyncRequested) {
-				if err := runSSHQuiet(ctx, target, remoteSeedSyncManifestFromGit(workdir)); err != nil {
+				if _, err := runIdempotentSSHCombinedOutput(ctx, target, remoteSeedSyncManifestFromGit(workdir), idempotentSSHRetryDelay); err != nil {
 					return recordFailure(exit(6, "remote sync seed manifest failed: %v", err))
 				}
 			}
 			stepStart = time.Now()
-			if err := runSSHQuiet(ctx, target, remotePruneSyncManifestForTarget(target, workdir, finalizeToken)); err != nil {
+			if _, err := runIdempotentSSHCombinedOutput(ctx, target, remotePruneSyncManifestForTarget(target, workdir, finalizeToken), idempotentSSHRetryDelay); err != nil {
 				return recordFailure(exit(6, "remote sync prune failed: %v", err))
 			}
 			timings.syncSteps.prune = time.Since(stepStart)

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1392,7 +1392,7 @@ retrySync:
 				}
 			}
 			stepStart = time.Now()
-			if err := runSSHQuiet(ctx, target, remotePruneSyncManifestForTarget(target, workdir)); err != nil {
+			if err := runSSHQuiet(ctx, target, remotePruneSyncManifestForTarget(target, workdir, finalizeToken)); err != nil {
 				return recordFailure(exit(6, "remote sync prune failed: %v", err))
 			}
 			timings.syncSteps.prune = time.Since(stepStart)

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1359,6 +1359,10 @@ retrySync:
 		}
 		manifestData := manifest.NUL()
 		deletedData := manifest.DeletedNUL()
+		finalizeToken, err := randomHex(16)
+		if err != nil {
+			return recordFailure(exit(6, "create sync finalize token: %v", err))
+		}
 		stepStart = time.Now()
 		manifestInput := syncManifestInputForTarget(target, manifestData, deletedData)
 		manifestCtx := ctx
@@ -1367,7 +1371,7 @@ retrySync:
 			manifestCtx, cancelManifest = context.WithTimeout(ctx, cfg.Sync.Timeout)
 		}
 		stopManifestHeartbeat := startSyncHeartbeat(a.Stderr, stepStart, 15*time.Second)
-		manifestErr := runSSHInput(manifestCtx, target, remoteWriteSyncManifestsNewForTarget(target, workdir), strings.NewReader(manifestInput), io.Discard, a.Stderr)
+		manifestErr := runSSHInput(manifestCtx, target, remoteWriteSyncManifestsNewForTarget(target, workdir, finalizeToken), strings.NewReader(manifestInput), io.Discard, a.Stderr)
 		stopManifestHeartbeat()
 		if cancelManifest != nil {
 			cancelManifest()
@@ -1416,6 +1420,7 @@ retrySync:
 			BaseRef:            cfg.Sync.BaseRef,
 			BaseSHA:            baseSHA,
 			Fingerprint:        fingerprint,
+			Token:              finalizeToken,
 		})
 		if out, err := runIdempotentSSHCombinedOutput(ctx, target, finalizeCommand, idempotentSSHRetryDelay); err != nil {
 			if out != "" {

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -15,6 +15,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -315,6 +316,68 @@ func TestRunCommandInjectsReservedMetadataAcrossSSHCommandModes(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestRunCommandRetriesIdempotentRemoteWorkdirCreation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell ssh fixture")
+	}
+	clearConfigEnv(t)
+	dir := t.TempDir()
+	isolateRunTestUserDirs(t, dir)
+	sshPath := filepath.Join(dir, "ssh")
+	mkdirCallsPath := filepath.Join(dir, "mkdir-calls")
+	firstMkdirPath := filepath.Join(dir, "first-mkdir")
+	mkdirCommandPath := filepath.Join(dir, "mkdir-command")
+	script := `#!/bin/sh
+remote=""
+for arg do remote="$arg"; done
+case "$remote" in
+  "mkdir -p "*)
+    if [ ! -e "$CRABBOX_FAKE_SSH_MKDIR_COMMAND" ]; then
+      printf '%s\n' "$remote" > "$CRABBOX_FAKE_SSH_MKDIR_COMMAND"
+    fi
+    IFS= read -r mkdir_command < "$CRABBOX_FAKE_SSH_MKDIR_COMMAND"
+    if [ "$remote" = "$mkdir_command" ]; then
+      printf 'call\n' >> "$CRABBOX_FAKE_SSH_MKDIR_CALLS"
+      if [ ! -e "$CRABBOX_FAKE_SSH_FIRST_MKDIR" ]; then
+        : > "$CRABBOX_FAKE_SSH_FIRST_MKDIR"
+        exit 255
+      fi
+    fi
+    ;;
+esac
+/bin/cat >/dev/null || true
+exit 0
+`
+	if err := os.WriteFile(sshPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, "missing.yaml"))
+	t.Setenv("CRABBOX_FAKE_SSH_MKDIR_CALLS", mkdirCallsPath)
+	t.Setenv("CRABBOX_FAKE_SSH_FIRST_MKDIR", firstMkdirPath)
+	t.Setenv("CRABBOX_FAKE_SSH_MKDIR_COMMAND", mkdirCommandPath)
+	t.Setenv("CRABBOX_FAKE_SSH_PORT", "22")
+	t.Setenv("CRABBOX_FAKE_SSH_PROXY", "1")
+
+	var stdout, stderr bytes.Buffer
+	if err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
+		"--provider", "run-env-profile-test",
+		"--no-sync",
+		"--no-hydrate",
+		"--",
+		"true",
+	}); err != nil {
+		t.Fatalf("run error=%v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	calls, err := os.ReadFile(mkdirCallsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(string(calls), "call\n"); got != 2 {
+		t.Fatalf("remote mkdir calls=%d want 2", got)
 	}
 }
 

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -1536,6 +1536,7 @@ type remoteSyncFinalizeOptions struct {
 	BaseRef            string
 	BaseSHA            string
 	Fingerprint        string
+	Token              string
 }
 
 func remoteWriteSyncManifestNew(workdir string) string {
@@ -1558,7 +1559,7 @@ func remoteSyncInterpreterCommand(python, perl, args string) string {
 		"; else echo " + shellQuote("missing required sync interpreter: need python3, python, or perl") + " >&2; exit 127; fi"
 }
 
-func remoteWriteSyncManifestsNew(workdir string) string {
+func remoteWriteSyncManifestsNew(workdir, finalizeToken string) string {
 	script := "set -e\nmkdir -p " + shellQuote(workdir) + "\ncd " + shellQuote(workdir) + "\n" + remoteSyncMetaDirScript() + `mkdir -p "$meta_dir"
 IFS= read -r manifest_len
 case "$manifest_len" in
@@ -1569,6 +1570,7 @@ esac
 # dd's exit status still makes the fail-closed script abort on a short write.
 dd bs=1 count="$manifest_len" of="$meta_dir/sync-manifest.new" 2>/dev/null
 cat > "$meta_dir/sync-deleted.new"
+printf %s ` + shellQuote(finalizeToken) + ` > "$meta_dir/sync-finalize-token.new"
 `
 	return "bash -lc " + shellQuote(script)
 }
@@ -1582,14 +1584,14 @@ func syncManifestInputForTarget(target SSHTarget, manifestData, deletedData []by
 	return fmt.Sprintf("%d\n", len(manifestData)) + string(manifestData) + string(deletedData)
 }
 
-func remoteWriteSyncManifestsNewForTarget(target SSHTarget, workdir string) string {
+func remoteWriteSyncManifestsNewForTarget(target SSHTarget, workdir, finalizeToken string) string {
 	if isWindowsWSL2Target(target) {
-		return remoteWriteSyncManifestsNewPython(workdir)
+		return remoteWriteSyncManifestsNewPython(workdir, finalizeToken)
 	}
-	return remoteWriteSyncManifestsNew(workdir)
+	return remoteWriteSyncManifestsNew(workdir, finalizeToken)
 }
 
-func remoteWriteSyncManifestsNewPython(workdir string) string {
+func remoteWriteSyncManifestsNewPython(workdir, finalizeToken string) string {
 	python := `import base64
 import sys
 
@@ -1617,7 +1619,8 @@ with open(sys.argv[2], "wb") as handle:
     handle.write(deleted)
 `
 	script := "set -e\nmkdir -p " + shellQuote(workdir) + "\ncd " + shellQuote(workdir) + "\n" + remoteSyncMetaDirScript() + "mkdir -p \"$meta_dir\"\n" +
-		"python3 -c " + shellQuote(python) + " \"$meta_dir/sync-manifest.new\" \"$meta_dir/sync-deleted.new\"\n"
+		"python3 -c " + shellQuote(python) + " \"$meta_dir/sync-manifest.new\" \"$meta_dir/sync-deleted.new\"\n" +
+		"printf %s " + shellQuote(finalizeToken) + " > \"$meta_dir/sync-finalize-token.new\"\n"
 	return "bash -lc " + shellQuote(script)
 }
 
@@ -1745,10 +1748,27 @@ new="$meta_dir/sync-manifest.new"
 deleted="$meta_dir/sync-deleted.new"
 rm -f "$deleted"
 manifest="$meta_dir/sync-manifest"
+pending_token="$meta_dir/sync-finalize-token.new"
+committed_token="$meta_dir/sync-finalize-token"
+expected_token=` + shellQuote(opts.Token) + `
+if [ -z "$expected_token" ]; then
+  echo "remote sync finalize failed: missing sync token" >&2
+  exit 67
+fi
 if [ -f "$new" ]; then
+  if [ -f "$pending_token" ]; then
+    if [ "$(cat "$pending_token")" != "$expected_token" ]; then
+      echo "remote sync finalize failed: pending token does not match this sync" >&2
+      exit 67
+    fi
+    mv "$pending_token" "$committed_token"
+  elif [ ! -f "$committed_token" ] || [ "$(cat "$committed_token")" != "$expected_token" ]; then
+    echo "remote sync finalize failed: pending token does not match this sync" >&2
+    exit 67
+  fi
   mv "$new" "$manifest"
-elif [ ! -f "$manifest" ]; then
-  echo "remote sync finalize failed: pending and committed manifests are missing" >&2
+elif [ ! -f "$manifest" ] || [ ! -f "$committed_token" ] || [ "$(cat "$committed_token")" != "$expected_token" ]; then
+  echo "remote sync finalize failed: no committed manifest for this sync" >&2
   exit 67
 fi
 if test -d .git && git status --short >/tmp/crabbox-git-status 2>/dev/null; then

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -1637,7 +1637,7 @@ with open(sys.argv[2], "wb") as handle:
 }
 
 func remoteSyncAbandonedMetadataCleanup() string {
-	return `find "$meta_dir" -type f \( -name 'sync-manifest.*.new' -o -name 'sync-deleted.*.new' -o -name 'sync-manifest.*.sorted' -o -name 'sync-finalize-token.tmp.*' -o -name 'sync-finalize-complete-token.tmp.*' \) -mtime +7 -exec rm -f -- {} \; 2>/dev/null || true`
+	return `find "$meta_dir" -type f \( -name 'sync-manifest.new' -o -name 'sync-deleted.new' -o -name 'sync-manifest.*.new' -o -name 'sync-deleted.*.new' -o -name 'sync-manifest.*.sorted' -o -name 'sync-finalize-token.tmp.*' -o -name 'sync-finalize-complete-token.tmp.*' \) -mtime +7 -exec rm -f -- {} \; 2>/dev/null || true`
 }
 
 func remoteSeedSyncManifestFromGit(workdir string) string {

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -1750,10 +1750,18 @@ rm -f "$deleted"
 manifest="$meta_dir/sync-manifest"
 pending_token="$meta_dir/sync-finalize-token.new"
 committed_token="$meta_dir/sync-finalize-token"
+complete_token="$meta_dir/sync-finalize-complete-token"
 expected_token=` + shellQuote(opts.Token) + `
-if [ -z "$expected_token" ]; then
-  echo "remote sync finalize failed: missing sync token" >&2
-  exit 67
+case "$expected_token" in
+  ''|*[!0-9a-f]*) echo "remote sync finalize failed: invalid sync token" >&2; exit 67 ;;
+esac
+` + remoteSyncFinalizeLockScript() + `
+if [ -f "$manifest" ] &&
+   [ -f "$committed_token" ] &&
+   [ "$(cat "$committed_token")" = "$expected_token" ] &&
+   [ -f "$complete_token" ] &&
+   [ "$(cat "$complete_token")" = "$expected_token" ]; then
+  exit 0
 fi
 if [ -f "$new" ]; then
   if [ -f "$pending_token" ]; then
@@ -1795,7 +1803,67 @@ fi
 		script += `printf %s ` + shellQuote(opts.Fingerprint) + ` > "$meta_dir/sync-fingerprint" || true
 `
 	}
+	script += `complete_tmp="$complete_token.tmp.$$"
+printf %s "$expected_token" > "$complete_tmp"
+mv "$complete_tmp" "$complete_token"
+`
 	return "bash -lc " + shellQuote(script)
+}
+
+func remoteSyncFinalizeLockScript() string {
+	return `lock_path="$meta_dir/sync-finalize-lock"
+lock_waits=0
+while ! ln -s "$$" "$lock_path" 2>/dev/null; do
+  lock_owner=$(readlink "$lock_path" 2>/dev/null || true)
+  lock_owner_live=
+  case "$lock_owner" in
+    ''|*[!0-9]*) ;;
+    *) if kill -0 "$lock_owner" 2>/dev/null; then lock_owner_live=1; fi ;;
+  esac
+  if [ -n "$lock_owner_live" ]; then
+    sleep 1
+  else
+    sleep 1
+    confirmed_owner=$(readlink "$lock_path" 2>/dev/null || true)
+    if [ "$confirmed_owner" = "$lock_owner" ]; then
+      owner_dead=
+      case "$confirmed_owner" in
+        ''|*[!0-9]*) owner_dead=1 ;;
+        *) if ! kill -0 "$confirmed_owner" 2>/dev/null; then owner_dead=1; fi ;;
+      esac
+      if [ -n "$owner_dead" ]; then
+        stale_lock="$lock_path.stale.$$"
+        if mv "$lock_path" "$stale_lock" 2>/dev/null; then
+          moved_owner=$(readlink "$stale_lock" 2>/dev/null || true)
+          if [ "$moved_owner" != "$confirmed_owner" ]; then
+            if [ ! -e "$lock_path" ] && [ ! -L "$lock_path" ]; then
+              mv "$stale_lock" "$lock_path" 2>/dev/null || true
+            fi
+            echo "remote sync finalize failed: lock ownership changed during recovery" >&2
+            exit 67
+          fi
+          rm -f "$stale_lock"
+          continue
+        fi
+      fi
+    fi
+  fi
+  lock_waits=$((lock_waits + 1))
+  if [ "$lock_waits" -ge 120 ]; then
+    echo "remote sync finalize failed: timed out waiting for active finalize" >&2
+    exit 67
+  fi
+done
+cleanup_finalize_lock() {
+  if [ "$(readlink "$lock_path" 2>/dev/null || true)" = "$$" ]; then
+    rm -f "$lock_path"
+  fi
+}
+trap cleanup_finalize_lock EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+`
 }
 
 func remoteSyncMetaDirScript() string {

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -551,6 +551,25 @@ func runSSHCombinedOutput(ctx context.Context, target SSHTarget, remote string) 
 	return strings.TrimSpace(string(lastOut)), lastErr
 }
 
+var idempotentSSHRetryDelay = 2 * time.Second
+
+func runIdempotentSSHCombinedOutput(ctx context.Context, target SSHTarget, remote string, retryDelay time.Duration) (string, error) {
+	var lastOut string
+	var lastErr error
+	for attempt := 0; attempt < 2; attempt++ {
+		lastOut, lastErr = runSSHCombinedOutput(ctx, target, remote)
+		if lastErr == nil || !shouldRetrySSHPort(lastErr) || attempt == 1 {
+			return lastOut, lastErr
+		}
+		// Only callers whose entire remote command is safe to repeat may use
+		// this helper. Transfer, hydration, and user commands stay outside it.
+		if err := sleepContext(ctx, retryDelay); err != nil {
+			return lastOut, err
+		}
+	}
+	return lastOut, lastErr
+}
+
 func runWSL2ControlScriptCombinedOutput(ctx context.Context, target SSHTarget, remote string, waitTimeout time.Duration, connectTimeout, connectionAttempts string) (string, error) {
 	command := wsl2StdinScriptCommandWithWaitTimeout(waitTimeout)
 	var lastOut []byte
@@ -1725,7 +1744,13 @@ mkdir -p "$meta_dir"
 new="$meta_dir/sync-manifest.new"
 deleted="$meta_dir/sync-deleted.new"
 rm -f "$deleted"
-mv "$new" "$meta_dir/sync-manifest"
+manifest="$meta_dir/sync-manifest"
+if [ -f "$new" ]; then
+  mv "$new" "$manifest"
+elif [ ! -f "$manifest" ]; then
+  echo "remote sync finalize failed: pending and committed manifests are missing" >&2
+  exit 67
+fi
 if test -d .git && git status --short >/tmp/crabbox-git-status 2>/dev/null; then
   deletions=$(awk '/^ D|^D / { n++ } END { print n+0 }' /tmp/crabbox-git-status)
   if [ ` + shellQuote(allowValue) + ` != '1' ] && [ "$deletions" -ge 200 ]; then

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -1539,6 +1539,14 @@ type remoteSyncFinalizeOptions struct {
 	Token              string
 }
 
+func remoteSyncPendingManifestName(token string) string {
+	return "sync-manifest." + token + ".new"
+}
+
+func remoteSyncPendingDeletedName(token string) string {
+	return "sync-deleted." + token + ".new"
+}
+
 func remoteWriteSyncManifestNew(workdir string) string {
 	script := "cd " + shellQuote(workdir) + " && " + remoteSyncMetaDirScript() + "mkdir -p \"$meta_dir\" && cat > \"$meta_dir/sync-manifest.new\""
 	return "bash -lc " + shellQuote(script)
@@ -1560,6 +1568,8 @@ func remoteSyncInterpreterCommand(python, perl, args string) string {
 }
 
 func remoteWriteSyncManifestsNew(workdir, finalizeToken string) string {
+	manifestName := remoteSyncPendingManifestName(finalizeToken)
+	deletedName := remoteSyncPendingDeletedName(finalizeToken)
 	script := "set -e\nmkdir -p " + shellQuote(workdir) + "\ncd " + shellQuote(workdir) + "\n" + remoteSyncMetaDirScript() + `mkdir -p "$meta_dir"
 IFS= read -r manifest_len
 case "$manifest_len" in
@@ -1568,9 +1578,8 @@ esac
 # Keep this to POSIX dd operands: minimal guests commonly provide BusyBox dd,
 # which rejects GNU's progress-suppression extension. Suppress only the summary;
 # dd's exit status still makes the fail-closed script abort on a short write.
-dd bs=1 count="$manifest_len" of="$meta_dir/sync-manifest.new" 2>/dev/null
-cat > "$meta_dir/sync-deleted.new"
-printf %s ` + shellQuote(finalizeToken) + ` > "$meta_dir/sync-finalize-token.new"
+dd bs=1 count="$manifest_len" of="$meta_dir/` + manifestName + `" 2>/dev/null
+cat > "$meta_dir/` + deletedName + `"
 `
 	return "bash -lc " + shellQuote(script)
 }
@@ -1592,6 +1601,8 @@ func remoteWriteSyncManifestsNewForTarget(target SSHTarget, workdir, finalizeTok
 }
 
 func remoteWriteSyncManifestsNewPython(workdir, finalizeToken string) string {
+	manifestName := remoteSyncPendingManifestName(finalizeToken)
+	deletedName := remoteSyncPendingDeletedName(finalizeToken)
 	python := `import base64
 import sys
 
@@ -1619,8 +1630,7 @@ with open(sys.argv[2], "wb") as handle:
     handle.write(deleted)
 `
 	script := "set -e\nmkdir -p " + shellQuote(workdir) + "\ncd " + shellQuote(workdir) + "\n" + remoteSyncMetaDirScript() + "mkdir -p \"$meta_dir\"\n" +
-		"python3 -c " + shellQuote(python) + " \"$meta_dir/sync-manifest.new\" \"$meta_dir/sync-deleted.new\"\n" +
-		"printf %s " + shellQuote(finalizeToken) + " > \"$meta_dir/sync-finalize-token.new\"\n"
+		"python3 -c " + shellQuote(python) + " \"$meta_dir/" + manifestName + "\" \"$meta_dir/" + deletedName + "\"\n"
 	return "bash -lc " + shellQuote(script)
 }
 
@@ -1636,7 +1646,9 @@ fi
 	return "bash -lc " + shellQuote(script)
 }
 
-func remotePruneSyncManifest(workdir string) string {
+func remotePruneSyncManifest(workdir, finalizeToken string) string {
+	manifestName := remoteSyncPendingManifestName(finalizeToken)
+	deletedName := remoteSyncPendingDeletedName(finalizeToken)
 	python := `import sys
 
 def read_manifest(path):
@@ -1671,8 +1683,8 @@ print STDOUT map { $_ . "\0" } grep { !$new{$_} } @old;
 	script := "set -e -o pipefail\ncd " + shellQuote(workdir) + `
 ` + remoteSyncMetaDirScript() + `
 old="$meta_dir/sync-manifest"
-new="$meta_dir/sync-manifest.new"
-deleted="$meta_dir/sync-deleted.new"
+new="$meta_dir/` + manifestName + `"
+deleted="$meta_dir/` + deletedName + `"
 delete_paths() {
   while IFS= read -r -d '' rel; do
     case "$rel" in ''|/*|../*|*/../*) continue ;; esac
@@ -1693,19 +1705,21 @@ if [ -f "$old" ] && [ -f "$new" ]; then manifest_removed_paths | delete_paths; f
 	return "bash -lc " + shellQuote(script)
 }
 
-func remotePruneSyncManifestForTarget(target SSHTarget, workdir string) string {
+func remotePruneSyncManifestForTarget(target SSHTarget, workdir, finalizeToken string) string {
 	if isWindowsWSL2Target(target) {
-		return remotePruneSyncManifestCoreutils(workdir)
+		return remotePruneSyncManifestCoreutils(workdir, finalizeToken)
 	}
-	return remotePruneSyncManifest(workdir)
+	return remotePruneSyncManifest(workdir, finalizeToken)
 }
 
-func remotePruneSyncManifestCoreutils(workdir string) string {
+func remotePruneSyncManifestCoreutils(workdir, finalizeToken string) string {
+	manifestName := remoteSyncPendingManifestName(finalizeToken)
+	deletedName := remoteSyncPendingDeletedName(finalizeToken)
 	script := "set -e -o pipefail\ncd " + shellQuote(workdir) + `
 ` + remoteSyncMetaDirScript() + `
 old="$meta_dir/sync-manifest"
-new="$meta_dir/sync-manifest.new"
-deleted="$meta_dir/sync-deleted.new"
+new="$meta_dir/` + manifestName + `"
+deleted="$meta_dir/` + deletedName + `"
 delete_paths() {
   while IFS= read -r -d '' rel; do
     case "$rel" in ''|/*|../*|*/../*) continue ;; esac
@@ -1719,8 +1733,8 @@ delete_paths() {
 }
 if [ -f "$deleted" ]; then delete_paths < "$deleted"; fi
 if [ -f "$old" ] && [ -f "$new" ]; then
-  old_sorted="$meta_dir/sync-manifest.old.sorted"
-  new_sorted="$meta_dir/sync-manifest.new.sorted"
+  old_sorted="$meta_dir/sync-manifest.` + finalizeToken + `.old.sorted"
+  new_sorted="$meta_dir/sync-manifest.` + finalizeToken + `.new.sorted"
   LC_ALL=C sort -z "$old" > "$old_sorted"
   LC_ALL=C sort -z "$new" > "$new_sorted"
   comm -z -23 "$old_sorted" "$new_sorted" | delete_paths
@@ -1740,15 +1754,15 @@ func remoteFinalizeSync(workdir string, opts remoteSyncFinalizeOptions) string {
 	if opts.AllowMassDeletions {
 		allowValue = "1"
 	}
+	manifestName := remoteSyncPendingManifestName(opts.Token)
+	deletedName := remoteSyncPendingDeletedName(opts.Token)
 	script := `set -e
 cd ` + shellQuote(workdir) + `
 ` + remoteSyncMetaDirScript() + `
 mkdir -p "$meta_dir"
-new="$meta_dir/sync-manifest.new"
-deleted="$meta_dir/sync-deleted.new"
-rm -f "$deleted"
+new="$meta_dir/` + manifestName + `"
+deleted="$meta_dir/` + deletedName + `"
 manifest="$meta_dir/sync-manifest"
-pending_token="$meta_dir/sync-finalize-token.new"
 committed_token="$meta_dir/sync-finalize-token"
 complete_token="$meta_dir/sync-finalize-complete-token"
 expected_token=` + shellQuote(opts.Token) + `
@@ -1764,16 +1778,10 @@ if [ -f "$manifest" ] &&
   exit 0
 fi
 if [ -f "$new" ]; then
-  if [ -f "$pending_token" ]; then
-    if [ "$(cat "$pending_token")" != "$expected_token" ]; then
-      echo "remote sync finalize failed: pending token does not match this sync" >&2
-      exit 67
-    fi
-    mv "$pending_token" "$committed_token"
-  elif [ ! -f "$committed_token" ] || [ "$(cat "$committed_token")" != "$expected_token" ]; then
-    echo "remote sync finalize failed: pending token does not match this sync" >&2
-    exit 67
-  fi
+  committed_tmp="$committed_token.tmp.$$"
+  printf %s "$expected_token" > "$committed_tmp"
+  mv "$committed_tmp" "$committed_token"
+  rm -f "$deleted"
   mv "$new" "$manifest"
 elif [ ! -f "$manifest" ] || [ ! -f "$committed_token" ] || [ "$(cat "$committed_token")" != "$expected_token" ]; then
   echo "remote sync finalize failed: no committed manifest for this sync" >&2

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -1571,6 +1571,7 @@ func remoteWriteSyncManifestsNew(workdir, finalizeToken string) string {
 	manifestName := remoteSyncPendingManifestName(finalizeToken)
 	deletedName := remoteSyncPendingDeletedName(finalizeToken)
 	script := "set -e\nmkdir -p " + shellQuote(workdir) + "\ncd " + shellQuote(workdir) + "\n" + remoteSyncMetaDirScript() + `mkdir -p "$meta_dir"
+` + remoteSyncAbandonedMetadataCleanup() + `
 IFS= read -r manifest_len
 case "$manifest_len" in
   ''|*[!0-9]*) echo "invalid sync manifest length" >&2; exit 1 ;;
@@ -1630,8 +1631,13 @@ with open(sys.argv[2], "wb") as handle:
     handle.write(deleted)
 `
 	script := "set -e\nmkdir -p " + shellQuote(workdir) + "\ncd " + shellQuote(workdir) + "\n" + remoteSyncMetaDirScript() + "mkdir -p \"$meta_dir\"\n" +
+		remoteSyncAbandonedMetadataCleanup() + "\n" +
 		"python3 -c " + shellQuote(python) + " \"$meta_dir/" + manifestName + "\" \"$meta_dir/" + deletedName + "\"\n"
 	return "bash -lc " + shellQuote(script)
+}
+
+func remoteSyncAbandonedMetadataCleanup() string {
+	return `find "$meta_dir" -type f \( -name 'sync-manifest.*.new' -o -name 'sync-deleted.*.new' -o -name 'sync-manifest.*.sorted' -o -name 'sync-finalize-token.tmp.*' -o -name 'sync-finalize-complete-token.tmp.*' \) -mtime +7 -exec rm -f -- {} \; 2>/dev/null || true`
 }
 
 func remoteSeedSyncManifestFromGit(workdir string) string {
@@ -1735,10 +1741,15 @@ if [ -f "$deleted" ]; then delete_paths < "$deleted"; fi
 if [ -f "$old" ] && [ -f "$new" ]; then
   old_sorted="$meta_dir/sync-manifest.` + finalizeToken + `.old.sorted"
   new_sorted="$meta_dir/sync-manifest.` + finalizeToken + `.new.sorted"
+  cleanup_sorted_manifests() {
+    rm -f "$old_sorted" "$new_sorted"
+  }
+  trap cleanup_sorted_manifests EXIT
   LC_ALL=C sort -z "$old" > "$old_sorted"
   LC_ALL=C sort -z "$new" > "$new_sorted"
   comm -z -23 "$old_sorted" "$new_sorted" | delete_paths
-  rm -f "$old_sorted" "$new_sorted"
+  cleanup_sorted_manifests
+  trap - EXIT
 fi
 `
 	return "bash -lc " + shellQuote(script)

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -1618,6 +1618,13 @@ func testRemotePruneSyncManifestPrunesManagedFiles(t *testing.T, command func(st
 	if _, err := os.Stat(outside); err != nil {
 		t.Fatalf("unsafe deleted path should not escape workdir: %v", err)
 	}
+	sorted, err := filepath.Glob(filepath.Join(workdir, ".crabbox", "sync-manifest.*.sorted"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sorted) != 0 {
+		t.Fatalf("sorted manifest scratch files remain: %v", sorted)
+	}
 }
 
 func TestRemotePruneSyncManifestFallsBackToPerlWithoutPython(t *testing.T) {
@@ -2214,6 +2221,15 @@ func TestRemoteWriteSyncManifestsNew(t *testing.T) {
 	}
 	if string(gotDeleted) != deleted {
 		t.Fatalf("unexpected deleted manifest: %q", gotDeleted)
+	}
+}
+
+func TestRemoteWriteSyncManifestsNewCollectsOnlyOldTokenArtifacts(t *testing.T) {
+	got := remoteWriteSyncManifestsNew("/work/repo", "0123456789abcdef0123456789abcdef")
+	for _, want := range []string{"find \"$meta_dir\"", "-mtime +7", "sync-manifest.*.new", "sync-finalize-complete-token.tmp.*"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("manifest writer missing abandoned metadata cleanup %q: %s", want, got)
+		}
 	}
 }
 

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -864,6 +864,41 @@ func TestShouldRetrySSHPortOnlyForTransportExit(t *testing.T) {
 	}
 }
 
+func TestRunIdempotentSSHCombinedOutputDoesNotRetryRemoteFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell ssh fixture")
+	}
+	dir := t.TempDir()
+	sshPath := filepath.Join(dir, "ssh")
+	callsPath := filepath.Join(dir, "calls")
+	script := `#!/bin/sh
+printf 'call\n' >> "$CRABBOX_FAKE_SSH_CALLS"
+printf 'remote failed\n' >&2
+exit 7
+`
+	if err := os.WriteFile(sshPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CRABBOX_FAKE_SSH_CALLS", callsPath)
+
+	out, err := runIdempotentSSHCombinedOutput(context.Background(), SSHTarget{
+		User: "crabbox",
+		Host: "gateway.example",
+		Port: "22",
+	}, "true", 0)
+	if err == nil || !strings.Contains(out, "remote failed") {
+		t.Fatalf("out=%q err=%v", out, err)
+	}
+	calls, readErr := os.ReadFile(callsPath)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if got := strings.Count(string(calls), "call\n"); got != 1 {
+		t.Fatalf("ssh calls=%d want 1", got)
+	}
+}
+
 func TestRunSSHStreamRetriesFallbackPorts(t *testing.T) {
 	dir := t.TempDir()
 	sshPath := filepath.Join(dir, "ssh")
@@ -1684,13 +1719,15 @@ func TestRemoteFinalizeSyncCommitsMetadataInOneCommand(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cmd := exec.Command("bash", "-lc", remoteFinalizeSync(workdir, remoteSyncFinalizeOptions{
+	remote := remoteFinalizeSync(workdir, remoteSyncFinalizeOptions{
 		BaseRef:     "main",
 		BaseSHA:     "abc123",
 		Fingerprint: "fp123",
-	}))
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("remote finalize failed: %v\n%s", err, out)
+	})
+	for attempt := 1; attempt <= 2; attempt++ {
+		if out, err := exec.Command("bash", "-lc", remote).CombinedOutput(); err != nil {
+			t.Fatalf("remote finalize attempt %d failed: %v\n%s", attempt, err, out)
+		}
 	}
 	if _, err := os.Stat(filepath.Join(metaDir, "sync-deleted.new")); !os.IsNotExist(err) {
 		t.Fatalf("deleted manifest should be removed, stat err=%v", err)
@@ -1715,6 +1752,73 @@ func TestRemoteFinalizeSyncCommitsMetadataInOneCommand(t *testing.T) {
 	}
 	if string(fingerprint) != "fp123" {
 		t.Fatalf("unexpected fingerprint: %q", fingerprint)
+	}
+}
+
+func TestRemoteFinalizeSyncRetriesAfterAmbiguousTransportFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell ssh fixture")
+	}
+	workdir := t.TempDir()
+	metaDir := filepath.Join(workdir, ".crabbox")
+	if err := os.MkdirAll(metaDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(metaDir, "sync-manifest.new"), []byte("tracked.txt\x00"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dir := t.TempDir()
+	sshPath := filepath.Join(dir, "ssh")
+	callsPath := filepath.Join(dir, "calls")
+	script := `#!/bin/sh
+remote=""
+for arg do remote="$arg"; done
+sh -c "$remote"
+status=$?
+if [ "$status" -ne 0 ]; then exit "$status"; fi
+printf 'call\n' >> "$CRABBOX_FAKE_SSH_CALLS"
+if [ "$(wc -l < "$CRABBOX_FAKE_SSH_CALLS")" -eq 1 ]; then exit 255; fi
+`
+	if err := os.WriteFile(sshPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CRABBOX_FAKE_SSH_CALLS", callsPath)
+
+	out, err := runIdempotentSSHCombinedOutput(context.Background(), SSHTarget{
+		User: "crabbox",
+		Host: "gateway.example",
+		Port: "22",
+	}, remoteFinalizeSync(workdir, remoteSyncFinalizeOptions{Fingerprint: "fp123"}), 0)
+	if err != nil {
+		t.Fatalf("out=%q err=%v", out, err)
+	}
+	calls, readErr := os.ReadFile(callsPath)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if got := strings.Count(string(calls), "call\n"); got != 2 {
+		t.Fatalf("ssh calls=%d want 2", got)
+	}
+	manifest, readErr := os.ReadFile(filepath.Join(metaDir, "sync-manifest"))
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(manifest) != "tracked.txt\x00" {
+		t.Fatalf("unexpected manifest: %q", manifest)
+	}
+}
+
+func TestRemoteFinalizeSyncRejectsMissingManifests(t *testing.T) {
+	workdir := t.TempDir()
+	cmd := exec.Command("bash", "-lc", remoteFinalizeSync(workdir, remoteSyncFinalizeOptions{}))
+	out, err := cmd.CombinedOutput()
+	if err == nil || exitCode(err) != 67 {
+		t.Fatalf("out=%q err=%v", out, err)
+	}
+	if !strings.Contains(string(out), "pending and committed manifests are missing") {
+		t.Fatalf("unexpected output: %q", out)
 	}
 }
 

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -1704,6 +1704,7 @@ func TestRemoteApplySyncManifestOnlyCommitsManifest(t *testing.T) {
 }
 
 func TestRemoteFinalizeSyncCommitsMetadataInOneCommand(t *testing.T) {
+	const finalizeToken = "sync-token-123"
 	workdir := t.TempDir()
 	if err := os.Mkdir(filepath.Join(workdir, ".git"), 0o755); err != nil {
 		t.Fatal(err)
@@ -1718,11 +1719,15 @@ func TestRemoteFinalizeSyncCommitsMetadataInOneCommand(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(metaDir, "sync-deleted.new"), []byte("deleted.txt\x00"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(metaDir, "sync-finalize-token.new"), []byte(finalizeToken), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	remote := remoteFinalizeSync(workdir, remoteSyncFinalizeOptions{
 		BaseRef:     "main",
 		BaseSHA:     "abc123",
 		Fingerprint: "fp123",
+		Token:       finalizeToken,
 	})
 	for attempt := 1; attempt <= 2; attempt++ {
 		if out, err := exec.Command("bash", "-lc", remote).CombinedOutput(); err != nil {
@@ -1753,18 +1758,29 @@ func TestRemoteFinalizeSyncCommitsMetadataInOneCommand(t *testing.T) {
 	if string(fingerprint) != "fp123" {
 		t.Fatalf("unexpected fingerprint: %q", fingerprint)
 	}
+	token, err := os.ReadFile(filepath.Join(metaDir, "sync-finalize-token"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(token) != finalizeToken {
+		t.Fatalf("unexpected finalize token: %q", token)
+	}
 }
 
 func TestRemoteFinalizeSyncRetriesAfterAmbiguousTransportFailure(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell ssh fixture")
 	}
+	const finalizeToken = "sync-token-123"
 	workdir := t.TempDir()
 	metaDir := filepath.Join(workdir, ".crabbox")
 	if err := os.MkdirAll(metaDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(metaDir, "sync-manifest.new"), []byte("tracked.txt\x00"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(metaDir, "sync-finalize-token.new"), []byte(finalizeToken), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1790,7 +1806,7 @@ if [ "$(wc -l < "$CRABBOX_FAKE_SSH_CALLS")" -eq 1 ]; then exit 255; fi
 		User: "crabbox",
 		Host: "gateway.example",
 		Port: "22",
-	}, remoteFinalizeSync(workdir, remoteSyncFinalizeOptions{Fingerprint: "fp123"}), 0)
+	}, remoteFinalizeSync(workdir, remoteSyncFinalizeOptions{Fingerprint: "fp123", Token: finalizeToken}), 0)
 	if err != nil {
 		t.Fatalf("out=%q err=%v", out, err)
 	}
@@ -1812,12 +1828,22 @@ if [ "$(wc -l < "$CRABBOX_FAKE_SSH_CALLS")" -eq 1 ]; then exit 255; fi
 
 func TestRemoteFinalizeSyncRejectsMissingManifests(t *testing.T) {
 	workdir := t.TempDir()
-	cmd := exec.Command("bash", "-lc", remoteFinalizeSync(workdir, remoteSyncFinalizeOptions{}))
+	metaDir := filepath.Join(workdir, ".crabbox")
+	if err := os.MkdirAll(metaDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(metaDir, "sync-manifest"), []byte("stale.txt\x00"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(metaDir, "sync-finalize-token"), []byte("previous-sync"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("bash", "-lc", remoteFinalizeSync(workdir, remoteSyncFinalizeOptions{Token: "current-sync"}))
 	out, err := cmd.CombinedOutput()
 	if err == nil || exitCode(err) != 67 {
 		t.Fatalf("out=%q err=%v", out, err)
 	}
-	if !strings.Contains(string(out), "pending and committed manifests are missing") {
+	if !strings.Contains(string(out), "no committed manifest for this sync") {
 		t.Fatalf("unexpected output: %q", out)
 	}
 }
@@ -1940,11 +1966,12 @@ func TestRemoteWriteSyncDeletedNew(t *testing.T) {
 }
 
 func TestRemoteWriteSyncManifestsNew(t *testing.T) {
+	const finalizeToken = "sync-token-123"
 	workdir := t.TempDir()
 	manifest := "keep.txt\x00"
 	deleted := "old.txt\x00"
 	input := fmt.Sprintf("%d\n", len(manifest)) + manifest + deleted
-	cmd := exec.Command("bash", "-lc", remoteWriteSyncManifestsNew(workdir))
+	cmd := exec.Command("bash", "-lc", remoteWriteSyncManifestsNew(workdir, finalizeToken))
 	cmd.Stdin = strings.NewReader(input)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("write manifests failed: %v\n%s", err, out)
@@ -1964,10 +1991,17 @@ func TestRemoteWriteSyncManifestsNew(t *testing.T) {
 	if string(gotDeleted) != deleted {
 		t.Fatalf("unexpected deleted manifest: %q", gotDeleted)
 	}
+	gotToken, err := os.ReadFile(filepath.Join(metaDir, "sync-finalize-token.new"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(gotToken) != finalizeToken {
+		t.Fatalf("unexpected finalize token: %q", gotToken)
+	}
 }
 
 func TestRemoteWriteSyncManifestsNewForTargetUsesInterpretedWriterForWSL2(t *testing.T) {
-	got := remoteWriteSyncManifestsNewForTarget(SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeWSL2}, "/work/repo")
+	got := remoteWriteSyncManifestsNewForTarget(SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeWSL2}, "/work/repo", "sync-token-123")
 	if !strings.Contains(got, "python3 -c") {
 		t.Fatalf("WSL2 manifest writer should use Python exact reads: %q", got)
 	}
@@ -1978,7 +2012,7 @@ func TestRemoteWriteSyncManifestsNewForTargetUsesInterpretedWriterForWSL2(t *tes
 		t.Fatalf("WSL2 manifest writer should keep the command short and avoid fallback scripts: %q", got)
 	}
 
-	plain := remoteWriteSyncManifestsNewForTarget(SSHTarget{TargetOS: targetLinux}, "/work/repo")
+	plain := remoteWriteSyncManifestsNewForTarget(SSHTarget{TargetOS: targetLinux}, "/work/repo", "sync-token-123")
 	if !strings.Contains(plain, "dd bs=1") {
 		t.Fatalf("non-WSL2 manifest writer should keep portable dd fallback: %q", plain)
 	}
@@ -2006,11 +2040,12 @@ func TestSyncManifestInputForTargetFramesDeletedLengthForWSL2(t *testing.T) {
 }
 
 func TestRemoteWriteSyncManifestsNewPython(t *testing.T) {
+	const finalizeToken = "sync-token-123"
 	workdir := t.TempDir()
 	manifest := strings.Repeat("manifest-entry\x00", 4096)
 	deleted := "old.txt\x00"
 	input := syncManifestInputForTarget(SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeWSL2}, []byte(manifest), []byte(deleted))
-	cmd := exec.Command("bash", "-lc", remoteWriteSyncManifestsNewPython(workdir))
+	cmd := exec.Command("bash", "-lc", remoteWriteSyncManifestsNewPython(workdir, finalizeToken))
 	cmd.Stdin = strings.NewReader(input)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("write interpreted manifests failed: %v\n%s", err, out)
@@ -2030,6 +2065,13 @@ func TestRemoteWriteSyncManifestsNewPython(t *testing.T) {
 	if string(gotDeleted) != deleted {
 		t.Fatalf("unexpected deleted manifest: %q", gotDeleted)
 	}
+	gotToken, err := os.ReadFile(filepath.Join(metaDir, "sync-finalize-token.new"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(gotToken) != finalizeToken {
+		t.Fatalf("unexpected finalize token: %q", gotToken)
+	}
 }
 
 func TestRemoteWriteSyncManifestsNewReadsChunkedInput(t *testing.T) {
@@ -2041,7 +2083,7 @@ func TestRemoteWriteSyncManifestsNewReadsChunkedInput(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	cmd := exec.Command(bashPath, "--noprofile", "--norc", "-c", remoteWriteSyncManifestsNew(workdir))
+	cmd := exec.Command(bashPath, "--noprofile", "--norc", "-c", remoteWriteSyncManifestsNew(workdir, "sync-token-123"))
 	var output bytes.Buffer
 	cmd.Stdout = &output
 	cmd.Stderr = &output

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -1494,15 +1494,15 @@ func TestWindowsToWSLPathSupportsHostMountRoot(t *testing.T) {
 }
 
 func TestRemotePruneSyncManifestDeletesOnlyManagedPaths(t *testing.T) {
-	got := remotePruneSyncManifest("/work/repo")
+	got := remotePruneSyncManifest("/work/repo", "0123456789abcdef0123456789abcdef")
 	for _, want := range []string{
-		"sync-deleted.new",
+		"sync-deleted.0123456789abcdef0123456789abcdef.new",
 		"manifest_removed_paths",
 		"command -v python3",
 		"command -v perl",
 		"rm -f --",
 		"rmdir --",
-		"sync-manifest.new",
+		"sync-manifest.0123456789abcdef0123456789abcdef.new",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("remotePruneSyncManifest missing %q in %q", want, got)
@@ -1511,7 +1511,7 @@ func TestRemotePruneSyncManifestDeletesOnlyManagedPaths(t *testing.T) {
 }
 
 func TestRemotePruneSyncManifestUsesDeletedListBeforeOldManifestDiff(t *testing.T) {
-	got := remotePruneSyncManifest("/work/repo")
+	got := remotePruneSyncManifest("/work/repo", "0123456789abcdef0123456789abcdef")
 	deletedIndex := strings.Index(got, `delete_paths < "$deleted"`)
 	oldIndex := strings.Index(got, "manifest_removed_paths | delete_paths")
 	if deletedIndex < 0 || oldIndex < 0 || deletedIndex > oldIndex {
@@ -1520,7 +1520,7 @@ func TestRemotePruneSyncManifestUsesDeletedListBeforeOldManifestDiff(t *testing.
 }
 
 func TestRemotePruneSyncManifestForWSL2UsesShortCoreutils(t *testing.T) {
-	got := remotePruneSyncManifestForTarget(SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeWSL2}, "/work/repo")
+	got := remotePruneSyncManifestForTarget(SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeWSL2}, "/work/repo", "0123456789abcdef0123456789abcdef")
 	for _, want := range []string{"sort -z", "comm -z -23", "delete_paths"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("WSL2 prune command missing %q in %q", want, got)
@@ -1573,12 +1573,12 @@ func TestRemotePruneSyncManifestCoreutilsPrunesManagedFiles(t *testing.T) {
 	testRemotePruneSyncManifestPrunesManagedFiles(t, remotePruneSyncManifestCoreutils)
 }
 
-func testRemotePruneSyncManifestPrunesManagedFiles(t *testing.T, command func(string) string) {
+func testRemotePruneSyncManifestPrunesManagedFiles(t *testing.T, command func(string, string) string) {
 	t.Helper()
 	workdir := t.TempDir()
 	mustWriteTestFile(t, filepath.Join(workdir, ".crabbox", "sync-manifest"), "keep.txt\x00kept-dir/keep.txt\x00stale.txt\x00old-empty/remove.txt\x00non-empty/remove.txt\x00")
-	mustWriteTestFile(t, filepath.Join(workdir, ".crabbox", "sync-manifest.new"), "keep.txt\x00kept-dir/keep.txt\x00")
-	mustWriteTestFile(t, filepath.Join(workdir, ".crabbox", "sync-deleted.new"), "explicit-delete.txt\x00../outside.txt\x00/absolute.txt\x00")
+	mustWriteTestFile(t, filepath.Join(workdir, ".crabbox", remoteSyncPendingManifestName("0123456789abcdef0123456789abcdef")), "keep.txt\x00kept-dir/keep.txt\x00")
+	mustWriteTestFile(t, filepath.Join(workdir, ".crabbox", remoteSyncPendingDeletedName("0123456789abcdef0123456789abcdef")), "explicit-delete.txt\x00../outside.txt\x00/absolute.txt\x00")
 	for _, rel := range []string{
 		"keep.txt",
 		"kept-dir/keep.txt",
@@ -1594,7 +1594,7 @@ func testRemotePruneSyncManifestPrunesManagedFiles(t *testing.T, command func(st
 	outside := filepath.Join(filepath.Dir(workdir), "outside.txt")
 	mustWriteTestFile(t, outside, "outside")
 
-	cmd := exec.Command("bash", "-lc", command(workdir))
+	cmd := exec.Command("bash", "-lc", command(workdir, "0123456789abcdef0123456789abcdef"))
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("remote prune failed: %v\n%s", err, out)
 	}
@@ -1623,8 +1623,8 @@ func testRemotePruneSyncManifestPrunesManagedFiles(t *testing.T, command func(st
 func TestRemotePruneSyncManifestFallsBackToPerlWithoutPython(t *testing.T) {
 	workdir := t.TempDir()
 	mustWriteTestFile(t, filepath.Join(workdir, ".crabbox", "sync-manifest"), "keep.txt\x00stale.txt\x00")
-	mustWriteTestFile(t, filepath.Join(workdir, ".crabbox", "sync-manifest.new"), "keep.txt\x00")
-	mustWriteTestFile(t, filepath.Join(workdir, ".crabbox", "sync-deleted.new"), "")
+	mustWriteTestFile(t, filepath.Join(workdir, ".crabbox", remoteSyncPendingManifestName("0123456789abcdef0123456789abcdef")), "keep.txt\x00")
+	mustWriteTestFile(t, filepath.Join(workdir, ".crabbox", remoteSyncPendingDeletedName("0123456789abcdef0123456789abcdef")), "")
 	mustWriteTestFile(t, filepath.Join(workdir, "keep.txt"), "keep")
 	mustWriteTestFile(t, filepath.Join(workdir, "stale.txt"), "stale")
 
@@ -1639,7 +1639,7 @@ func TestRemotePruneSyncManifestFallsBackToPerlWithoutPython(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	cmd := exec.Command(bashPath, "--noprofile", "--norc", "-c", remotePruneSyncManifest(workdir))
+	cmd := exec.Command(bashPath, "--noprofile", "--norc", "-c", remotePruneSyncManifest(workdir, "0123456789abcdef0123456789abcdef"))
 	cmd.Env = append(os.Environ(), "PATH="+toolDir)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("remote prune perl fallback failed: %v\n%s", err, out)
@@ -1658,8 +1658,8 @@ func TestRemotePruneSyncManifestFallsBackToPerlWithoutPython(t *testing.T) {
 func TestRemotePruneSyncManifestFailsClosedWhenInterpreterFails(t *testing.T) {
 	workdir := t.TempDir()
 	mustWriteTestFile(t, filepath.Join(workdir, ".crabbox", "sync-manifest"), "stale.txt\x00")
-	mustWriteTestFile(t, filepath.Join(workdir, ".crabbox", "sync-manifest.new"), "")
-	mustWriteTestFile(t, filepath.Join(workdir, ".crabbox", "sync-deleted.new"), "")
+	mustWriteTestFile(t, filepath.Join(workdir, ".crabbox", remoteSyncPendingManifestName("0123456789abcdef0123456789abcdef")), "")
+	mustWriteTestFile(t, filepath.Join(workdir, ".crabbox", remoteSyncPendingDeletedName("0123456789abcdef0123456789abcdef")), "")
 	mustWriteTestFile(t, filepath.Join(workdir, "stale.txt"), "stale")
 
 	toolDir := t.TempDir()
@@ -1672,7 +1672,7 @@ func TestRemotePruneSyncManifestFailsClosedWhenInterpreterFails(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	cmd := exec.Command(bashPath, "--noprofile", "--norc", "-c", remotePruneSyncManifest(workdir))
+	cmd := exec.Command(bashPath, "--noprofile", "--norc", "-c", remotePruneSyncManifest(workdir, "0123456789abcdef0123456789abcdef"))
 	cmd.Env = append(os.Environ(), "PATH="+toolDir)
 	if out, err := cmd.CombinedOutput(); err == nil {
 		t.Fatalf("remote prune unexpectedly succeeded\n%s", out)
@@ -1683,7 +1683,7 @@ func TestRemotePruneSyncManifestFailsClosedWhenInterpreterFails(t *testing.T) {
 }
 
 func TestRemotePruneSyncManifestDoesNotSwallowReadErrors(t *testing.T) {
-	got := remotePruneSyncManifest("/work/repo")
+	got := remotePruneSyncManifest("/work/repo", "0123456789abcdef0123456789abcdef")
 	for _, unsafe := range []string{"except IOError", "return () unless -"} {
 		if strings.Contains(got, unsafe) {
 			t.Fatalf("remote prune still treats manifest read errors as missing: %q", unsafe)
@@ -1714,13 +1714,10 @@ func TestRemoteFinalizeSyncCommitsMetadataInOneCommand(t *testing.T) {
 	if err := os.MkdirAll(metaDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(metaDir, "sync-manifest.new"), []byte("tracked.txt\x00"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(metaDir, remoteSyncPendingManifestName(finalizeToken)), []byte("tracked.txt\x00"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(metaDir, "sync-deleted.new"), []byte("deleted.txt\x00"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(metaDir, "sync-finalize-token.new"), []byte(finalizeToken), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(metaDir, remoteSyncPendingDeletedName(finalizeToken)), []byte("deleted.txt\x00"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1735,7 +1732,7 @@ func TestRemoteFinalizeSyncCommitsMetadataInOneCommand(t *testing.T) {
 			t.Fatalf("remote finalize attempt %d failed: %v\n%s", attempt, err, out)
 		}
 	}
-	if _, err := os.Stat(filepath.Join(metaDir, "sync-deleted.new")); !os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Join(metaDir, remoteSyncPendingDeletedName(finalizeToken))); !os.IsNotExist(err) {
 		t.Fatalf("deleted manifest should be removed, stat err=%v", err)
 	}
 	manifest, err := os.ReadFile(filepath.Join(metaDir, "sync-manifest"))
@@ -1785,10 +1782,7 @@ func TestRemoteFinalizeSyncRetriesAfterAmbiguousTransportFailure(t *testing.T) {
 	if err := os.MkdirAll(metaDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(metaDir, "sync-manifest.new"), []byte("tracked.txt\x00"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(metaDir, "sync-finalize-token.new"), []byte(finalizeToken), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(metaDir, remoteSyncPendingManifestName(finalizeToken)), []byte("tracked.txt\x00"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1834,6 +1828,48 @@ if [ "$(wc -l < "$CRABBOX_FAKE_SSH_CALLS")" -eq 1 ]; then exit 255; fi
 	}
 }
 
+func TestRemoteFinalizeSyncCompletedRetryPreservesNewerPendingState(t *testing.T) {
+	const completedToken = "0123456789abcdef0123456789abcdef"
+	const newerToken = "fedcba9876543210fedcba9876543210"
+	workdir := t.TempDir()
+	metaDir := filepath.Join(workdir, ".crabbox")
+	if err := os.MkdirAll(metaDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(metaDir, remoteSyncPendingManifestName(completedToken)), []byte("completed.txt\x00"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(metaDir, remoteSyncPendingDeletedName(completedToken)), []byte("completed-old.txt\x00"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	completedRemote := remoteFinalizeSync(workdir, remoteSyncFinalizeOptions{Token: completedToken})
+	if out, err := exec.Command("bash", "-lc", completedRemote).CombinedOutput(); err != nil {
+		t.Fatalf("initial finalize: %v\n%s", err, out)
+	}
+
+	newerFiles := map[string]string{
+		remoteSyncPendingManifestName(newerToken): "newer.txt\x00",
+		remoteSyncPendingDeletedName(newerToken):  "newer-old.txt\x00",
+	}
+	for name, contents := range newerFiles {
+		if err := os.WriteFile(filepath.Join(metaDir, name), []byte(contents), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if out, err := exec.Command("bash", "-lc", completedRemote).CombinedOutput(); err != nil {
+		t.Fatalf("completed retry: %v\n%s", err, out)
+	}
+	for name, want := range newerFiles {
+		got, err := os.ReadFile(filepath.Join(metaDir, name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != want {
+			t.Fatalf("%s=%q want %q", name, got, want)
+		}
+	}
+}
+
 func TestRemoteFinalizeSyncRejectsMissingManifests(t *testing.T) {
 	workdir := t.TempDir()
 	metaDir := filepath.Join(workdir, ".crabbox")
@@ -1867,10 +1903,7 @@ func TestRemoteFinalizeSyncWaitsForLiveOwner(t *testing.T) {
 	if err := os.Symlink(strconv.Itoa(os.Getpid()), lockPath); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(metaDir, "sync-manifest.new"), []byte("tracked.txt\x00"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(metaDir, "sync-finalize-token.new"), []byte(finalizeToken), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(metaDir, remoteSyncPendingManifestName(finalizeToken)), []byte("tracked.txt\x00"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1913,10 +1946,7 @@ func TestRemoteFinalizeSyncRecoversDeadOwner(t *testing.T) {
 	if err := crasher.Run(); err == nil {
 		t.Fatal("expected lock owner to terminate")
 	}
-	if err := os.WriteFile(filepath.Join(metaDir, "sync-manifest.new"), []byte("tracked.txt\x00"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(metaDir, "sync-finalize-token.new"), []byte(finalizeToken), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(metaDir, remoteSyncPendingManifestName(finalizeToken)), []byte("tracked.txt\x00"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2014,7 +2044,7 @@ func TestRemoteSyncFinalizeLockSerializesLiveOwner(t *testing.T) {
 	}
 }
 
-func TestRemoteFinalizeSyncRejectsMismatchedPendingToken(t *testing.T) {
+func TestRemoteFinalizeSyncDoesNotConsumeNewerPendingManifest(t *testing.T) {
 	const currentToken = "0123456789abcdef0123456789abcdef"
 	const newerToken = "fedcba9876543210fedcba9876543210"
 	workdir := t.TempDir()
@@ -2022,10 +2052,7 @@ func TestRemoteFinalizeSyncRejectsMismatchedPendingToken(t *testing.T) {
 	if err := os.MkdirAll(metaDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(metaDir, "sync-manifest.new"), []byte("newer.txt\x00"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(metaDir, "sync-finalize-token.new"), []byte(newerToken), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(metaDir, remoteSyncPendingManifestName(newerToken)), []byte("newer.txt\x00"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2033,15 +2060,15 @@ func TestRemoteFinalizeSyncRejectsMismatchedPendingToken(t *testing.T) {
 	if err == nil || exitCode(err) != 67 {
 		t.Fatalf("out=%q err=%v", out, err)
 	}
-	if !strings.Contains(string(out), "pending token does not match this sync") {
+	if !strings.Contains(string(out), "no committed manifest for this sync") {
 		t.Fatalf("unexpected output: %q", out)
 	}
-	token, readErr := os.ReadFile(filepath.Join(metaDir, "sync-finalize-token.new"))
+	token, readErr := os.ReadFile(filepath.Join(metaDir, remoteSyncPendingManifestName(newerToken)))
 	if readErr != nil {
 		t.Fatal(readErr)
 	}
-	if string(token) != newerToken {
-		t.Fatalf("newer pending token changed: %q", token)
+	if string(token) != "newer.txt\x00" {
+		t.Fatalf("newer pending manifest changed: %q", token)
 	}
 }
 
@@ -2174,26 +2201,19 @@ func TestRemoteWriteSyncManifestsNew(t *testing.T) {
 		t.Fatalf("write manifests failed: %v\n%s", err, out)
 	}
 	metaDir := filepath.Join(workdir, ".crabbox")
-	gotManifest, err := os.ReadFile(filepath.Join(metaDir, "sync-manifest.new"))
+	gotManifest, err := os.ReadFile(filepath.Join(metaDir, remoteSyncPendingManifestName(finalizeToken)))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if string(gotManifest) != manifest {
 		t.Fatalf("unexpected manifest: %q", gotManifest)
 	}
-	gotDeleted, err := os.ReadFile(filepath.Join(metaDir, "sync-deleted.new"))
+	gotDeleted, err := os.ReadFile(filepath.Join(metaDir, remoteSyncPendingDeletedName(finalizeToken)))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if string(gotDeleted) != deleted {
 		t.Fatalf("unexpected deleted manifest: %q", gotDeleted)
-	}
-	gotToken, err := os.ReadFile(filepath.Join(metaDir, "sync-finalize-token.new"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(gotToken) != finalizeToken {
-		t.Fatalf("unexpected finalize token: %q", gotToken)
 	}
 }
 
@@ -2248,30 +2268,24 @@ func TestRemoteWriteSyncManifestsNewPython(t *testing.T) {
 		t.Fatalf("write interpreted manifests failed: %v\n%s", err, out)
 	}
 	metaDir := filepath.Join(workdir, ".crabbox")
-	gotManifest, err := os.ReadFile(filepath.Join(metaDir, "sync-manifest.new"))
+	gotManifest, err := os.ReadFile(filepath.Join(metaDir, remoteSyncPendingManifestName(finalizeToken)))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if string(gotManifest) != manifest {
 		t.Fatalf("manifest bytes=%d want %d", len(gotManifest), len(manifest))
 	}
-	gotDeleted, err := os.ReadFile(filepath.Join(metaDir, "sync-deleted.new"))
+	gotDeleted, err := os.ReadFile(filepath.Join(metaDir, remoteSyncPendingDeletedName(finalizeToken)))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if string(gotDeleted) != deleted {
 		t.Fatalf("unexpected deleted manifest: %q", gotDeleted)
 	}
-	gotToken, err := os.ReadFile(filepath.Join(metaDir, "sync-finalize-token.new"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(gotToken) != finalizeToken {
-		t.Fatalf("unexpected finalize token: %q", gotToken)
-	}
 }
 
 func TestRemoteWriteSyncManifestsNewReadsChunkedInput(t *testing.T) {
+	const finalizeToken = "0123456789abcdef0123456789abcdef"
 	workdir := t.TempDir()
 	manifest := strings.Repeat("manifest-entry\x00", 4096)
 	deleted := "old.txt\x00"
@@ -2280,7 +2294,7 @@ func TestRemoteWriteSyncManifestsNewReadsChunkedInput(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	cmd := exec.Command(bashPath, "--noprofile", "--norc", "-c", remoteWriteSyncManifestsNew(workdir, "0123456789abcdef0123456789abcdef"))
+	cmd := exec.Command(bashPath, "--noprofile", "--norc", "-c", remoteWriteSyncManifestsNew(workdir, finalizeToken))
 	var output bytes.Buffer
 	cmd.Stdout = &output
 	cmd.Stderr = &output
@@ -2305,14 +2319,14 @@ func TestRemoteWriteSyncManifestsNewReadsChunkedInput(t *testing.T) {
 		t.Fatalf("write chunked manifests failed: %v\n%s", err, output.String())
 	}
 	metaDir := filepath.Join(workdir, ".crabbox")
-	gotManifest, err := os.ReadFile(filepath.Join(metaDir, "sync-manifest.new"))
+	gotManifest, err := os.ReadFile(filepath.Join(metaDir, remoteSyncPendingManifestName(finalizeToken)))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if string(gotManifest) != manifest {
 		t.Fatalf("manifest bytes=%d want %d", len(gotManifest), len(manifest))
 	}
-	gotDeleted, err := os.ReadFile(filepath.Join(metaDir, "sync-deleted.new"))
+	gotDeleted, err := os.ReadFile(filepath.Join(metaDir, remoteSyncPendingDeletedName(finalizeToken)))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -1704,7 +1705,7 @@ func TestRemoteApplySyncManifestOnlyCommitsManifest(t *testing.T) {
 }
 
 func TestRemoteFinalizeSyncCommitsMetadataInOneCommand(t *testing.T) {
-	const finalizeToken = "sync-token-123"
+	const finalizeToken = "0123456789abcdef0123456789abcdef"
 	workdir := t.TempDir()
 	if err := os.Mkdir(filepath.Join(workdir, ".git"), 0o755); err != nil {
 		t.Fatal(err)
@@ -1765,13 +1766,20 @@ func TestRemoteFinalizeSyncCommitsMetadataInOneCommand(t *testing.T) {
 	if string(token) != finalizeToken {
 		t.Fatalf("unexpected finalize token: %q", token)
 	}
+	completeToken, err := os.ReadFile(filepath.Join(metaDir, "sync-finalize-complete-token"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(completeToken) != finalizeToken {
+		t.Fatalf("unexpected complete token: %q", completeToken)
+	}
 }
 
 func TestRemoteFinalizeSyncRetriesAfterAmbiguousTransportFailure(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell ssh fixture")
 	}
-	const finalizeToken = "sync-token-123"
+	const finalizeToken = "0123456789abcdef0123456789abcdef"
 	workdir := t.TempDir()
 	metaDir := filepath.Join(workdir, ".crabbox")
 	if err := os.MkdirAll(metaDir, 0o755); err != nil {
@@ -1838,13 +1846,202 @@ func TestRemoteFinalizeSyncRejectsMissingManifests(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(metaDir, "sync-finalize-token"), []byte("previous-sync"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	cmd := exec.Command("bash", "-lc", remoteFinalizeSync(workdir, remoteSyncFinalizeOptions{Token: "current-sync"}))
+	cmd := exec.Command("bash", "-lc", remoteFinalizeSync(workdir, remoteSyncFinalizeOptions{Token: "fedcba9876543210fedcba9876543210"}))
 	out, err := cmd.CombinedOutput()
 	if err == nil || exitCode(err) != 67 {
 		t.Fatalf("out=%q err=%v", out, err)
 	}
 	if !strings.Contains(string(out), "no committed manifest for this sync") {
 		t.Fatalf("unexpected output: %q", out)
+	}
+}
+
+func TestRemoteFinalizeSyncWaitsForLiveOwner(t *testing.T) {
+	const finalizeToken = "0123456789abcdef0123456789abcdef"
+	workdir := t.TempDir()
+	metaDir := filepath.Join(workdir, ".crabbox")
+	if err := os.MkdirAll(metaDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	lockPath := filepath.Join(metaDir, "sync-finalize-lock")
+	if err := os.Symlink(strconv.Itoa(os.Getpid()), lockPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(metaDir, "sync-manifest.new"), []byte("tracked.txt\x00"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(metaDir, "sync-finalize-token.new"), []byte(finalizeToken), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command("bash", "-lc", remoteFinalizeSync(workdir, remoteSyncFinalizeOptions{Token: finalizeToken}))
+	done := make(chan error, 1)
+	go func() {
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			err = fmt.Errorf("%w: %s", err, out)
+		}
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		t.Fatalf("finalize did not wait for live owner: %v", err)
+	case <-time.After(150 * time.Millisecond):
+	}
+	if err := os.Remove(lockPath); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("finalize did not continue after live owner released lock")
+	}
+}
+
+func TestRemoteFinalizeSyncRecoversDeadOwner(t *testing.T) {
+	const finalizeToken = "0123456789abcdef0123456789abcdef"
+	workdir := t.TempDir()
+	metaDir := filepath.Join(workdir, ".crabbox")
+	if err := os.MkdirAll(metaDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	crashScript := "set -e\nmeta_dir=" + shellQuote(metaDir) + "\n" + remoteSyncFinalizeLockScript() + "\nkill -9 $$"
+	crasher := exec.Command("bash", "-c", crashScript)
+	if err := crasher.Run(); err == nil {
+		t.Fatal("expected lock owner to terminate")
+	}
+	if err := os.WriteFile(filepath.Join(metaDir, "sync-manifest.new"), []byte("tracked.txt\x00"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(metaDir, "sync-finalize-token.new"), []byte(finalizeToken), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := exec.Command("bash", "-lc", remoteFinalizeSync(workdir, remoteSyncFinalizeOptions{Token: finalizeToken})).CombinedOutput()
+	if err != nil {
+		t.Fatalf("recover dead owner: %v\n%s", err, out)
+	}
+	if _, err := os.Lstat(filepath.Join(metaDir, "sync-finalize-lock")); !os.IsNotExist(err) {
+		t.Fatalf("finalize lock should be removed, stat err=%v", err)
+	}
+}
+
+func TestRemoteFinalizeSyncWaitIsContextBounded(t *testing.T) {
+	const finalizeToken = "0123456789abcdef0123456789abcdef"
+	workdir := t.TempDir()
+	metaDir := filepath.Join(workdir, ".crabbox")
+	if err := os.MkdirAll(metaDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(strconv.Itoa(os.Getpid()), filepath.Join(metaDir, "sync-finalize-lock")); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+	err := exec.CommandContext(ctx, "bash", "-lc", remoteFinalizeSync(workdir, remoteSyncFinalizeOptions{Token: finalizeToken})).Run()
+	if err == nil || ctx.Err() != context.DeadlineExceeded {
+		t.Fatalf("err=%v context=%v", err, ctx.Err())
+	}
+}
+
+func TestRemoteSyncFinalizeLockSerializesLiveOwner(t *testing.T) {
+	metaDir := t.TempDir()
+	acquiredPath := filepath.Join(metaDir, "first-acquired")
+	releasePath := filepath.Join(metaDir, "release-first")
+	secondPath := filepath.Join(metaDir, "second-entered")
+	firstScript := "set -e\nmeta_dir=" + shellQuote(metaDir) + "\n" + remoteSyncFinalizeLockScript() +
+		"\nprintf first > " + shellQuote(acquiredPath) +
+		"\nwhile [ ! -f " + shellQuote(releasePath) + " ]; do sleep 1; done\n"
+	secondScript := "set -e\nmeta_dir=" + shellQuote(metaDir) + "\n" + remoteSyncFinalizeLockScript() +
+		"\nprintf second > " + shellQuote(secondPath) + "\n"
+
+	first := exec.Command("bash", "-c", firstScript)
+	if err := first.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if first.Process != nil {
+			_ = first.Process.Kill()
+		}
+	})
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		if _, err := os.Stat(acquiredPath); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("first finalize owner did not acquire lock")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	second := exec.Command("bash", "-c", secondScript)
+	secondDone := make(chan error, 1)
+	if err := second.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if second.Process != nil {
+			_ = second.Process.Kill()
+		}
+	})
+	go func() { secondDone <- second.Wait() }()
+	select {
+	case err := <-secondDone:
+		t.Fatalf("second finalize entered while first was live: %v", err)
+	case <-time.After(150 * time.Millisecond):
+	}
+	if _, err := os.Stat(secondPath); !os.IsNotExist(err) {
+		t.Fatalf("second finalize entered critical section early, stat err=%v", err)
+	}
+	if err := os.WriteFile(releasePath, []byte("release"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := first.Wait(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-secondDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("second finalize did not acquire released lock")
+	}
+}
+
+func TestRemoteFinalizeSyncRejectsMismatchedPendingToken(t *testing.T) {
+	const currentToken = "0123456789abcdef0123456789abcdef"
+	const newerToken = "fedcba9876543210fedcba9876543210"
+	workdir := t.TempDir()
+	metaDir := filepath.Join(workdir, ".crabbox")
+	if err := os.MkdirAll(metaDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(metaDir, "sync-manifest.new"), []byte("newer.txt\x00"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(metaDir, "sync-finalize-token.new"), []byte(newerToken), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := exec.Command("bash", "-lc", remoteFinalizeSync(workdir, remoteSyncFinalizeOptions{Token: currentToken})).CombinedOutput()
+	if err == nil || exitCode(err) != 67 {
+		t.Fatalf("out=%q err=%v", out, err)
+	}
+	if !strings.Contains(string(out), "pending token does not match this sync") {
+		t.Fatalf("unexpected output: %q", out)
+	}
+	token, readErr := os.ReadFile(filepath.Join(metaDir, "sync-finalize-token.new"))
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(token) != newerToken {
+		t.Fatalf("newer pending token changed: %q", token)
 	}
 }
 
@@ -1966,7 +2163,7 @@ func TestRemoteWriteSyncDeletedNew(t *testing.T) {
 }
 
 func TestRemoteWriteSyncManifestsNew(t *testing.T) {
-	const finalizeToken = "sync-token-123"
+	const finalizeToken = "0123456789abcdef0123456789abcdef"
 	workdir := t.TempDir()
 	manifest := "keep.txt\x00"
 	deleted := "old.txt\x00"
@@ -2001,7 +2198,7 @@ func TestRemoteWriteSyncManifestsNew(t *testing.T) {
 }
 
 func TestRemoteWriteSyncManifestsNewForTargetUsesInterpretedWriterForWSL2(t *testing.T) {
-	got := remoteWriteSyncManifestsNewForTarget(SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeWSL2}, "/work/repo", "sync-token-123")
+	got := remoteWriteSyncManifestsNewForTarget(SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeWSL2}, "/work/repo", "0123456789abcdef0123456789abcdef")
 	if !strings.Contains(got, "python3 -c") {
 		t.Fatalf("WSL2 manifest writer should use Python exact reads: %q", got)
 	}
@@ -2012,7 +2209,7 @@ func TestRemoteWriteSyncManifestsNewForTargetUsesInterpretedWriterForWSL2(t *tes
 		t.Fatalf("WSL2 manifest writer should keep the command short and avoid fallback scripts: %q", got)
 	}
 
-	plain := remoteWriteSyncManifestsNewForTarget(SSHTarget{TargetOS: targetLinux}, "/work/repo", "sync-token-123")
+	plain := remoteWriteSyncManifestsNewForTarget(SSHTarget{TargetOS: targetLinux}, "/work/repo", "0123456789abcdef0123456789abcdef")
 	if !strings.Contains(plain, "dd bs=1") {
 		t.Fatalf("non-WSL2 manifest writer should keep portable dd fallback: %q", plain)
 	}
@@ -2040,7 +2237,7 @@ func TestSyncManifestInputForTargetFramesDeletedLengthForWSL2(t *testing.T) {
 }
 
 func TestRemoteWriteSyncManifestsNewPython(t *testing.T) {
-	const finalizeToken = "sync-token-123"
+	const finalizeToken = "0123456789abcdef0123456789abcdef"
 	workdir := t.TempDir()
 	manifest := strings.Repeat("manifest-entry\x00", 4096)
 	deleted := "old.txt\x00"
@@ -2083,7 +2280,7 @@ func TestRemoteWriteSyncManifestsNewReadsChunkedInput(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	cmd := exec.Command(bashPath, "--noprofile", "--norc", "-c", remoteWriteSyncManifestsNew(workdir, "sync-token-123"))
+	cmd := exec.Command(bashPath, "--noprofile", "--norc", "-c", remoteWriteSyncManifestsNew(workdir, "0123456789abcdef0123456789abcdef"))
 	var output bytes.Buffer
 	cmd.Stdout = &output
 	cmd.Stderr = &output


### PR DESCRIPTION
Closes https://github.com/openclaw/crabbox/issues/1222

## What Problem This Solves

Fixes a post-transfer failure mode where a transient SSH exit 255 could abort safe remote preparation or finalization after expensive work had already completed.

## Why This Change Was Made

The retry boundary now retries exactly once only for explicitly idempotent SSH bookkeeping:

- remote workdir creation,
- git and sync-manifest seed operations,
- manifest pruning,
- token-scoped sync finalization, and
- hydration-marker cleanup.

Remote sync finalization uses token-scoped pending metadata, serialized lock ownership, bounded stale-lock recovery, and an exact completion token so an ambiguous disconnect can be retried without deleting newer state.

Transfer, provisioning, hydration scripts, and user commands remain non-retried.

## User Impact

Long syncs can recover from a brief SSH gateway refusal during safe bookkeeping instead of discarding completed work or failing before hydration starts. The retry remains bounded and cannot replay user commands.

## Evidence

- Exact Crabbox head: `7a8a8d41e0dcbfdab3ea31794c3bd799d2b8224c`
- Blacksmith Testbox `tbx_01kz42r1ach451hfcpgd9496b3`, Actions run https://github.com/openclaw/openclaw/actions/runs/30826142174:
  - `TestRunCommandRetriesIdempotentRemoteWorkdirCreation`
  - `TestRunIdempotentSSHCombinedOutputDoesNotRetryRemoteFailure`
  - `TestRemoteFinalizeSyncRetriesAfterAmbiguousTransportFailure`
  - `TestClearActionsHydrationState`
  - all passed under `go test -race`
- Exact-head Crabbox CI run https://github.com/openclaw/crabbox/actions/runs/30826419035 passed Go, Worker, Scripts, Docs, Release Check, Windows cancellation, connector lifecycle, and Apple VM jobs.
- CodeQL and connector smoke jobs passed on the exact head.
- Live Daytona sequence first reproduced a natural exit 255 in an idempotent git/manifest preparation step, proving the original retry boundary was too narrow.
- Final exact-head Daytona canary:
  - OpenClaw head `ac9380b9dfbed51c9fd15f93eeae8f7a5fc706d6`
  - run `run_fe8ee1c33b82`, lease `cbx_f3a45fabb3ed`
  - initial hydration completed in 6m17.236s
  - follow-up run `run_0f9183eb1731` completed in 28.120s end-to-end
  - explicit stop released the lease; no warm allocation remained
- Fresh autoreview: clean, no accepted or actionable findings.
