### PR TITLE
fix: recover provisioning interrupted by coordinator deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@
 ### Fixed
 
 - Reconciled brokered leases whose provider provisioning was interrupted by a
-  coordinator deployment or runtime restart, recovering any owned cloud
-  resource for cleanup and failing resource-free leases with a durable reason.
+  coordinator deployment, recovering any owned cloud resource for cleanup and
+  failing resource-free leases with a durable reason.
 - Made Blacksmith doctor report all-organization inventory scope and a
   nonterminal active Testbox count for capacity-aware callers.
 - Kept default-derived Azure images out of normal broker lease requests so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 
 ### Fixed
 
+- Reconciled brokered leases whose provider provisioning was interrupted by a
+  coordinator deployment or runtime restart, recovering any owned cloud
+  resource for cleanup and failing resource-free leases with a durable reason.
 - Made Blacksmith doctor report all-organization inventory scope and a
   nonterminal active Testbox count for capacity-aware callers.
 - Made brokered Daytona usable with Crabbox auth alone, added a read-only
@@ -533,6 +536,7 @@
 - Added direct SSH login helpers for kept Islo sandboxes through the official Islo CLI proxy. Thanks @zozo123.
 - Added a portable Node.js and PostgreSQL coordinator runtime with durable pg-boss maintenance jobs, WebSocket bridges, trusted reverse-proxy identity support, container packaging, and the existing Cloudflare Worker/Durable Object runtime preserved as an adapter over the same fleet implementation.
 - Added refreshable coordinator bearer authentication through a shell-free JSON argv token command, including HTTP and reconnecting WebSocket bridges behind expiring upstream identity proxies.
+
 ### Fixed
 
 - Fixed pond ACL bootstrap to preserve Tailscale HuJSON comments, ordering, trailing commas, and unrelated policy sections while failing closed on ambiguous shapes. Thanks @coygeek.

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -99,6 +99,10 @@ type CoordinatorLease struct {
 	ExpiresAt             string                         `json:"expiresAt"`
 	Telemetry             *LeaseTelemetry                `json:"telemetry,omitempty"`
 	TelemetryHistory      []*LeaseTelemetry              `json:"telemetryHistory,omitempty"`
+	CleanupAttempts       int                            `json:"cleanupAttempts,omitempty"`
+	CleanupError          string                         `json:"cleanupError,omitempty"`
+	CleanupRetryAt        string                         `json:"cleanupRetryAt,omitempty"`
+	FailureError          string                         `json:"failureError,omitempty"`
 	ProviderMetadata      map[string]any                 `json:"providerMetadata,omitempty"`
 }
 

--- a/internal/cli/provider_coordinator_test.go
+++ b/internal/cli/provider_coordinator_test.go
@@ -136,7 +136,16 @@ func TestCoordinatorListJSONUsesUserLeasesWhenAdminTokenMissing(t *testing.T) {
 			t.Fatalf("leases state=%q", got)
 		}
 		_ = json.NewEncoder(w).Encode(map[string]any{"leases": []CoordinatorLease{
-			{ID: "cbx_123", Provider: "daytona", State: "active", SSHUser: "daytona-live-token"},
+			{
+				ID:              "cbx_123",
+				Provider:        "daytona",
+				State:           "provisioning",
+				SSHUser:         "daytona-live-token",
+				CleanupAttempts: 2,
+				CleanupError:    "provider resource not yet visible",
+				CleanupRetryAt:  "2026-08-03T11:05:00Z",
+				FailureError:    "interrupted provisioning",
+			},
 		}})
 	}))
 	defer server.Close()
@@ -162,6 +171,12 @@ func TestCoordinatorListJSONUsesUserLeasesWhenAdminTokenMissing(t *testing.T) {
 	}
 	if leases[0].SSHUser != "<token>" {
 		t.Fatalf("sshUser=%q, want redacted token", leases[0].SSHUser)
+	}
+	if leases[0].CleanupAttempts != 2 ||
+		leases[0].CleanupError != "provider resource not yet visible" ||
+		leases[0].CleanupRetryAt != "2026-08-03T11:05:00Z" ||
+		leases[0].FailureError != "interrupted provisioning" {
+		t.Fatalf("recovery diagnostics were not preserved: %#v", leases[0])
 	}
 	if stderr.Len() != 0 {
 		t.Fatalf("unexpected warning: %q", stderr.String())

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -12973,6 +12973,11 @@ export class FleetCoordinator {
         ) {
           const observed = structuredClone(lease);
           observed.provisioningRecoveryObservedAt = new Date(now).toISOString();
+          const retryAt = Date.parse(observed.cleanupRetryAt ?? "");
+          const settleAt = now + interruptedProvisioningDeploySettleMs;
+          if (Number.isFinite(retryAt) && retryAt < settleAt) {
+            observed.cleanupRetryAt = new Date(settleAt).toISOString();
+          }
           observed.updatedAt = observed.provisioningRecoveryObservedAt;
           await this.putLease(observed);
           return;

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -333,7 +333,6 @@ const runtimeAdapterMaxBufferedBytes = runtimeAdapterRelayFrameLimit * 2;
 const leaseCleanupRetryDelayMs = 5 * 60 * 1000;
 const leaseCleanupClaimStaleMs = 30 * 60 * 1000;
 const leaseCleanupBatchSize = 16;
-const interruptedProvisioningStaleMs = 30 * 60 * 1000;
 const interruptedProvisioningDeploySettleMs = 5 * 60 * 1000;
 const interruptedProvisioningAbsenceConfirmationMs = 30 * 60 * 1000;
 const interruptedProvisioningRecoveryBatchSize = 16;
@@ -4561,17 +4560,7 @@ export class FleetCoordinator {
     const provider = this.provider(workspace.provider, lease.region, lease.providerProject);
     let server: ProviderMachine | undefined;
     try {
-      if (provider.recoverServer) {
-        server = await provider.recoverServer(lease);
-      } else if (lease.cloudID && provider.getServer) {
-        server = await provider.getServer(lease.cloudID);
-      } else if (provider.findServerByLease) {
-        server = await provider.findServerByLease(lease.id);
-      } else {
-        server = (await provider.listCrabboxServers()).find(
-          (machine) => machine.labels?.["lease"] === lease.id,
-        );
-      }
+      server = await this.recoverProviderServer(workspace.provider, provider, lease);
     } catch (error) {
       if (!providerResourceNotFound(error)) {
         await this.recordWorkspaceRecoveryMiss(workspace, Number.POSITIVE_INFINITY);
@@ -5240,6 +5229,58 @@ export class FleetCoordinator {
       close(1011, coordinatorErrorMessage(this.env, error));
       throw error;
     }
+  }
+
+  private async recoverProviderServer(
+    providerName: Provider,
+    provider: CloudProvider,
+    lease: LeaseRecord,
+  ): Promise<ProviderMachine | undefined> {
+    const lookup = async (
+      find: (() => Promise<ProviderMachine | undefined>) | undefined,
+    ): Promise<ProviderMachine | undefined> => {
+      if (!find) return undefined;
+      try {
+        return await find();
+      } catch (error) {
+        if (providerResourceNotFound(error)) return undefined;
+        throw error;
+      }
+    };
+    let server = await lookup(
+      provider.recoverServer ? async () => await provider.recoverServer?.(lease) : undefined,
+    );
+    server ??= await lookup(
+      lease.cloudID && provider.getServer
+        ? async () => await provider.getServer?.(lease.cloudID)
+        : undefined,
+    );
+    server ??= await lookup(
+      provider.findServerByLease
+        ? async () => await provider.findServerByLease?.(lease.id)
+        : undefined,
+    );
+    if (!server && !provider.findServerByLease) {
+      const matches = (await provider.listCrabboxServers()).filter(
+        (candidate) => candidate.labels?.["lease"] === lease.id,
+      );
+      if (matches.length > 1) {
+        throw new Error(`multiple provider resources matched lease ${lease.id}`);
+      }
+      server = matches[0];
+    }
+    if (
+      server &&
+      !providerLabelsOwnedByLease(
+        server.labels ?? {},
+        lease,
+        providerName,
+        provider.ownershipLabelValue,
+      )
+    ) {
+      throw new Error(`provider resource ownership does not match lease ${lease.id}`);
+    }
+    return server;
   }
 
   private async cleanupExpiredNativeVNCTickets(now = Date.now()): Promise<void> {
@@ -12967,10 +13008,11 @@ export class FleetCoordinator {
         if (due.length >= interruptedProvisioningRecoveryBatchSize) {
           return;
         }
-        if (
-          interruptedProvisioningVersionMismatch(lease, this.env) &&
-          !Number.isFinite(Date.parse(lease.provisioningRecoveryObservedAt ?? ""))
-        ) {
+        const recoveryAt = interruptedProvisioningRecoveryAt(lease, this.env, now);
+        if (recoveryAt === undefined) {
+          return;
+        }
+        if (!Number.isFinite(Date.parse(lease.provisioningRecoveryObservedAt ?? ""))) {
           const observed = structuredClone(lease);
           observed.provisioningRecoveryObservedAt = new Date(now).toISOString();
           const retryAt = Date.parse(observed.cleanupRetryAt ?? "");
@@ -12982,8 +13024,7 @@ export class FleetCoordinator {
           await this.putLease(observed);
           return;
         }
-        const recoveryAt = interruptedProvisioningRecoveryAt(lease, this.env, now);
-        if (recoveryAt !== undefined && recoveryAt <= now) {
+        if (recoveryAt <= now) {
           due.push(structuredClone(lease));
         }
       });
@@ -13000,7 +13041,7 @@ export class FleetCoordinator {
     const provider = this.provider(providerName, lease.region, lease.providerProject);
     let server: ProviderMachine | undefined;
     try {
-      server = await this.findInterruptedProvisioningServer(providerName, provider, lease);
+      server = await this.recoverProviderServer(providerName, provider, lease);
     } catch (error) {
       const failure = `interrupted provisioning recovery failed: ${coordinatorErrorMessage(this.env, error)}`;
       await this.state.runExclusive(async () => {
@@ -13027,8 +13068,7 @@ export class FleetCoordinator {
       }
       const failedAtDate = new Date();
       const failedAt = failedAtDate.toISOString();
-      const interruption =
-        "coordinator deployment or runtime restart interrupted provider provisioning";
+      const interruption = "coordinator deployment interrupted provider provisioning";
       current.updatedAt = failedAt;
       if (server) {
         current.state = "failed";
@@ -13086,28 +13126,6 @@ export class FleetCoordinator {
       }
       await this.putLease(current);
     });
-  }
-
-  private async findInterruptedProvisioningServer(
-    providerName: Provider,
-    provider: CloudProvider,
-    lease: LeaseRecord,
-  ): Promise<ProviderMachine | undefined> {
-    let server = await provider.recoverServer?.(lease);
-    server ??= await provider.findServerByLease?.(lease.id);
-    if (!server && !provider.findServerByLease) {
-      const matches = (await provider.listCrabboxServers()).filter(
-        (candidate) => candidate.labels?.["lease"] === lease.id,
-      );
-      if (matches.length > 1) {
-        throw new Error(`multiple provider resources matched interrupted lease ${lease.id}`);
-      }
-      server = matches[0];
-    }
-    if (server && !providerLabelsOwnedByLease(server.labels ?? {}, lease, providerName)) {
-      throw new Error(`provider resource ownership does not match interrupted lease ${lease.id}`);
-    }
-    return server;
   }
 
   private async expireLeases(): Promise<void> {
@@ -19980,13 +19998,16 @@ function interruptedProvisioningRecoveryAt(
   if (!Number.isFinite(startedAt)) {
     return undefined;
   }
-  let recoveryAt = startedAt + interruptedProvisioningStaleMs;
-  if (interruptedProvisioningVersionMismatch(lease, env)) {
-    const observedAt = Date.parse(lease.provisioningRecoveryObservedAt ?? "");
-    recoveryAt = Number.isFinite(observedAt)
-      ? observedAt + interruptedProvisioningDeploySettleMs
-      : now;
+  if (!interruptedProvisioningVersionMismatch(lease, env)) {
+    // Provider creates have no shared upper bound, so age alone cannot distinguish an
+    // abandoned request from live provisioning. Only a deployment version change proves
+    // this Durable Object no longer owns the in-flight create.
+    return undefined;
   }
+  const observedAt = Date.parse(lease.provisioningRecoveryObservedAt ?? "");
+  const recoveryAt = Number.isFinite(observedAt)
+    ? observedAt + interruptedProvisioningDeploySettleMs
+    : now;
   const retryAt = Date.parse(lease.cleanupRetryAt ?? "");
   return Number.isFinite(retryAt) && retryAt > recoveryAt ? retryAt : recoveryAt;
 }
@@ -20696,6 +20717,7 @@ interface CloudProvider {
   ): ProviderWorkspaceCapability | undefined;
   supportsSSHHostKeyInjection(config: ReturnType<typeof leaseConfig>): boolean;
   restrictedLeaseRequestFields?(input: LeaseRequest): string[];
+  ownershipLabelValue?(value: string): string;
   recoverServer?(lease: LeaseRecord): Promise<ProviderMachine | undefined>;
   resumeRecoveredServer?(
     config: ReturnType<typeof leaseConfig>,
@@ -21442,6 +21464,10 @@ export class GCPProvider implements CloudProvider {
       input.gcpTags?.length ? "gcpTags" : "",
       input.gcpServiceAccount ? "gcpServiceAccount" : "",
     ].filter(Boolean);
+  }
+
+  ownershipLabelValue(value: string): string {
+    return gcpProviderLabelValue(value);
   }
 
   listCrabboxServers(): Promise<ProviderMachine[]> {

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -333,6 +333,10 @@ const runtimeAdapterMaxBufferedBytes = runtimeAdapterRelayFrameLimit * 2;
 const leaseCleanupRetryDelayMs = 5 * 60 * 1000;
 const leaseCleanupClaimStaleMs = 30 * 60 * 1000;
 const leaseCleanupBatchSize = 16;
+const interruptedProvisioningStaleMs = 30 * 60 * 1000;
+const interruptedProvisioningDeploySettleMs = 5 * 60 * 1000;
+const interruptedProvisioningAbsenceConfirmationMs = 30 * 60 * 1000;
+const interruptedProvisioningRecoveryBatchSize = 16;
 const awsOrphanSweepInitialDelayMs = 60 * 1000;
 const azureOrphanSweepInitialDelayMs = 60 * 1000;
 const defaultAWSOrphanSweepIntervalSeconds = 60 * 60;
@@ -2947,6 +2951,7 @@ export class FleetCoordinator {
     }
     await this.reconcileScheduledAdminGrants(forwardedAdminGrantVersion, preserveForwardedVersion);
     await this.quarantineLegacyWorkspaces();
+    await this.reconcileInterruptedLeaseProvisioning();
     await this.expireLeases();
     await this.webVNCCredentialHandoffs.cleanupExpired();
     await this.cleanupExpiredWebVNCPortalViewerAuth();
@@ -3266,6 +3271,9 @@ export class FleetCoordinator {
         delete reactivated.releaseDeletesServer;
         delete reactivated.failureError;
         delete reactivated.provisioningRequestStartedAt;
+        delete reactivated.provisioningCoordinatorVersion;
+        delete reactivated.provisioningRecoveryObservedAt;
+        delete reactivated.provisioningRecoveryMissingSince;
         clearLeaseCleanupMetadata(reactivated);
         const limitError = enforceCostLimitUsage(
           admission.costUsage,
@@ -3534,6 +3542,10 @@ export class FleetCoordinator {
         }
       }
       current.provisioningRequestStartedAt = new Date().toISOString();
+      const coordinatorVersion = this.env.CF_VERSION_METADATA?.id.trim();
+      if (coordinatorVersion) {
+        current.provisioningCoordinatorVersion = coordinatorVersion;
+      }
       current.updatedAt = current.provisioningRequestStartedAt;
       await this.putLease(current);
       return { started: true as const, current };
@@ -3627,6 +3639,9 @@ export class FleetCoordinator {
           record.state = "failed";
           record.updatedAt = failedAt;
           record.endedAt = failedAt;
+          delete record.provisioningCoordinatorVersion;
+          delete record.provisioningRecoveryObservedAt;
+          delete record.provisioningRecoveryMissingSince;
           record.cleanupFailedAt = failedAt;
           record.cleanupError = coordinatorErrorMessage(this.env, error);
           const awsOutcomeUncertain =
@@ -3693,6 +3708,9 @@ export class FleetCoordinator {
     record = structuredClone(current);
     record.state = "active";
     delete record.provisioningRequestStartedAt;
+    delete record.provisioningCoordinatorVersion;
+    delete record.provisioningRecoveryObservedAt;
+    delete record.provisioningRecoveryMissingSince;
     record.cloudID = server.cloudID;
     record.serverType = serverType;
     if (server.hostID) {
@@ -4747,6 +4765,9 @@ export class FleetCoordinator {
         delete current.provisioningResourceMayExist;
         delete current.provisioningFailureRetryable;
         delete current.provisioningRequestStartedAt;
+        delete current.provisioningCoordinatorVersion;
+        delete current.provisioningRecoveryObservedAt;
+        delete current.provisioningRecoveryMissingSince;
         delete current.endedAt;
         delete current.releasedAt;
         clearLeaseCleanupMetadata(current);
@@ -4815,6 +4836,9 @@ export class FleetCoordinator {
       current.provisioningResourceMayExist = false;
       current.provisioningFailureRetryable = true;
       delete current.provisioningRequestStartedAt;
+      delete current.provisioningCoordinatorVersion;
+      delete current.provisioningRecoveryObservedAt;
+      delete current.provisioningRecoveryMissingSince;
       current.updatedAt = new Date().toISOString();
       await this.putLease(current);
       return current;
@@ -5733,6 +5757,9 @@ export class FleetCoordinator {
       current.provisioningResourceMayExist = false;
       current.provisioningFailureRetryable = false;
       delete current.provisioningRequestStartedAt;
+      delete current.provisioningCoordinatorVersion;
+      delete current.provisioningRecoveryObservedAt;
+      delete current.provisioningRecoveryMissingSince;
       if (releaseRequested) {
         current.releasedAt = failedAt;
         delete current.releaseDeletesServer;
@@ -12932,6 +12959,152 @@ export class FleetCoordinator {
     return json({ error: "not_found" }, { status: 404 });
   }
 
+  private async reconcileInterruptedLeaseProvisioning(): Promise<void> {
+    const now = Date.now();
+    const candidates = await this.state.runExclusive(async () => {
+      const due: LeaseRecord[] = [];
+      await this.visitLeaseRecords(async (lease) => {
+        if (due.length >= interruptedProvisioningRecoveryBatchSize) {
+          return;
+        }
+        if (
+          interruptedProvisioningVersionMismatch(lease, this.env) &&
+          !Number.isFinite(Date.parse(lease.provisioningRecoveryObservedAt ?? ""))
+        ) {
+          const observed = structuredClone(lease);
+          observed.provisioningRecoveryObservedAt = new Date(now).toISOString();
+          observed.updatedAt = observed.provisioningRecoveryObservedAt;
+          await this.putLease(observed);
+          return;
+        }
+        const recoveryAt = interruptedProvisioningRecoveryAt(lease, this.env, now);
+        if (recoveryAt !== undefined && recoveryAt <= now) {
+          due.push(structuredClone(lease));
+        }
+      });
+      return due;
+    });
+    await Promise.all(candidates.map((lease) => this.reconcileInterruptedLease(lease)));
+  }
+
+  private async reconcileInterruptedLease(lease: LeaseRecord): Promise<void> {
+    const providerName = managedLeaseProvider(lease);
+    if (!providerName) {
+      return;
+    }
+    const provider = this.provider(providerName, lease.region, lease.providerProject);
+    let server: ProviderMachine | undefined;
+    try {
+      server = await this.findInterruptedProvisioningServer(providerName, provider, lease);
+    } catch (error) {
+      const failure = `interrupted provisioning recovery failed: ${coordinatorErrorMessage(this.env, error)}`;
+      await this.state.runExclusive(async () => {
+        const current = await this.getLease(lease.id);
+        if (!sameProvisioningAttempt(current, lease)) {
+          return;
+        }
+        const failedAt = new Date();
+        current.cleanupAttempts = (current.cleanupAttempts ?? 0) + 1;
+        current.cleanupError = failure;
+        current.cleanupFailedAt = failedAt.toISOString();
+        current.cleanupRetryAt = new Date(
+          failedAt.getTime() + leaseCleanupRetryDelayMs,
+        ).toISOString();
+        current.updatedAt = failedAt.toISOString();
+        await this.putLease(current);
+      });
+      return;
+    }
+    await this.state.runExclusive(async () => {
+      const current = await this.getLease(lease.id);
+      if (!sameProvisioningAttempt(current, lease)) {
+        return;
+      }
+      const failedAtDate = new Date();
+      const failedAt = failedAtDate.toISOString();
+      const interruption =
+        "coordinator deployment or runtime restart interrupted provider provisioning";
+      current.updatedAt = failedAt;
+      if (server) {
+        current.state = "failed";
+        current.endedAt = failedAt;
+        delete current.provisioningRequestStartedAt;
+        delete current.provisioningCoordinatorVersion;
+        delete current.provisioningRecoveryObservedAt;
+        delete current.provisioningRecoveryMissingSince;
+        applyRecoveredServerIdentity(current, server);
+        current.releaseDeletesServer = true;
+        current.provisioningResourceMayExist = true;
+        current.provisioningFailureRetryable = false;
+        current.cleanupError = `${interruption}; recovered provider resource for cleanup`;
+        current.cleanupFailedAt = failedAt;
+        delete current.cleanupRetryAt;
+        delete current.failureError;
+      } else {
+        const missingSince = Date.parse(current.provisioningRecoveryMissingSince ?? "");
+        if (
+          !Number.isFinite(missingSince) ||
+          failedAtDate.getTime() < missingSince + interruptedProvisioningAbsenceConfirmationMs
+        ) {
+          // A negative inventory read can race an accepted asynchronous create. Keep checking
+          // until the provider has remained empty for the full confirmation window.
+          if (!Number.isFinite(missingSince)) {
+            current.provisioningRecoveryMissingSince = failedAt;
+          }
+          current.provisioningResourceMayExist = true;
+          current.provisioningFailureRetryable = true;
+          current.cleanupError = `${interruption}; provider resource not yet visible`;
+          current.cleanupFailedAt = failedAt;
+          current.cleanupRetryAt = new Date(
+            failedAtDate.getTime() + leaseCleanupRetryDelayMs,
+          ).toISOString();
+          delete current.failureError;
+          delete current.releaseDeletesServer;
+          await this.putLease(current);
+          return;
+        }
+        current.state = "failed";
+        current.endedAt = failedAt;
+        delete current.provisioningRequestStartedAt;
+        delete current.provisioningCoordinatorVersion;
+        delete current.provisioningRecoveryObservedAt;
+        delete current.provisioningRecoveryMissingSince;
+        current.cloudID = "";
+        current.serverID = 0;
+        current.serverName = "";
+        current.host = "";
+        current.failureError = `${interruption}; no provider resource found`;
+        current.provisioningResourceMayExist = false;
+        current.provisioningFailureRetryable = false;
+        delete current.releaseDeletesServer;
+        clearLeaseCleanupMetadata(current);
+      }
+      await this.putLease(current);
+    });
+  }
+
+  private async findInterruptedProvisioningServer(
+    providerName: Provider,
+    provider: CloudProvider,
+    lease: LeaseRecord,
+  ): Promise<ProviderMachine | undefined> {
+    let server = await provider.recoverServer?.(lease);
+    server ??= await provider.findServerByLease?.(lease.id);
+    if (!server && !provider.findServerByLease) {
+      const matches = (await provider.listCrabboxServers()).filter(
+        (candidate) => candidate.labels?.["lease"] === lease.id,
+      );
+      if (matches.length > 1) {
+        throw new Error(`multiple provider resources matched interrupted lease ${lease.id}`);
+      }
+      server = matches[0];
+    }
+    if (server && !providerLabelsOwnedByLease(server.labels ?? {}, lease, providerName)) {
+      throw new Error(`provider resource ownership does not match interrupted lease ${lease.id}`);
+    }
+    return server;
+  }
+
   private async expireLeases(): Promise<void> {
     const claims = await this.state.runExclusive(async () => {
       const now = Date.now();
@@ -12986,6 +13159,9 @@ export class FleetCoordinator {
           lease.state = "failed";
           lease.updatedAt = nowISO;
           lease.endedAt = nowISO;
+          delete lease.provisioningCoordinatorVersion;
+          delete lease.provisioningRecoveryObservedAt;
+          delete lease.provisioningRecoveryMissingSince;
           lease.cleanupFailedAt = nowISO;
           lease.cleanupError = "lease expired before provider returned a cloud resource";
           await this.putLease(lease, { noCache: true });
@@ -13145,7 +13321,7 @@ export class FleetCoordinator {
         lease.runtimeAdapterDeleteRequestedAt ||
         leaseNeedsCleanup(lease, now)
       ) {
-        retainAlarm(nextLeaseAlarmTime(lease));
+        retainAlarm(nextLeaseAlarmTime(lease, this.env));
       }
     });
     for (const handoffAlarm of await this.webVNCCredentialHandoffs.alarmTimes(now)) {
@@ -19782,9 +19958,69 @@ function retainProvisioningCleanupClaim(
   lease.cleanupRetryAt = new Date(Date.parse(failedAt) + leaseCleanupRetryDelayMs).toISOString();
 }
 
-function nextLeaseAlarmTime(lease: LeaseRecord): number {
+function interruptedProvisioningRecoveryAt(
+  lease: LeaseRecord,
+  env: Pick<Env, "CF_VERSION_METADATA">,
+  now = Date.now(),
+): number | undefined {
+  if (
+    lease.workspaceID ||
+    lease.state !== "provisioning" ||
+    lease.cloudID ||
+    !managedLeaseProvider(lease)
+  ) {
+    return undefined;
+  }
+  const startedAt = Date.parse(lease.provisioningRequestStartedAt ?? "");
+  if (!Number.isFinite(startedAt)) {
+    return undefined;
+  }
+  let recoveryAt = startedAt + interruptedProvisioningStaleMs;
+  if (interruptedProvisioningVersionMismatch(lease, env)) {
+    const observedAt = Date.parse(lease.provisioningRecoveryObservedAt ?? "");
+    recoveryAt = Number.isFinite(observedAt)
+      ? observedAt + interruptedProvisioningDeploySettleMs
+      : now;
+  }
+  const retryAt = Date.parse(lease.cleanupRetryAt ?? "");
+  return Number.isFinite(retryAt) && retryAt > recoveryAt ? retryAt : recoveryAt;
+}
+
+function interruptedProvisioningVersionMismatch(
+  lease: LeaseRecord,
+  env: Pick<Env, "CF_VERSION_METADATA">,
+): boolean {
+  const currentVersion = env.CF_VERSION_METADATA?.id.trim();
+  return Boolean(
+    currentVersion &&
+    lease.provisioningCoordinatorVersion &&
+    lease.provisioningCoordinatorVersion !== currentVersion,
+  );
+}
+
+function sameProvisioningAttempt(
+  current: LeaseRecord | undefined,
+  expected: LeaseRecord,
+): current is LeaseRecord {
+  return Boolean(
+    current &&
+    current.state === "provisioning" &&
+    !current.cloudID &&
+    current.provisioningRequestStartedAt === expected.provisioningRequestStartedAt &&
+    current.provisioningCoordinatorVersion === expected.provisioningCoordinatorVersion &&
+    current.provisioningRecoveryObservedAt === expected.provisioningRecoveryObservedAt &&
+    current.provisioningRecoveryMissingSince === expected.provisioningRecoveryMissingSince,
+  );
+}
+
+function nextLeaseAlarmTime(lease: LeaseRecord, env: Pick<Env, "CF_VERSION_METADATA">): number {
   const now = Date.now();
   const expiresAt = Date.parse(lease.expiresAt);
+  const interruptedProvisioningAt = interruptedProvisioningRecoveryAt(lease, env);
+  const includeInterruptedProvisioning = (candidate: number): number =>
+    interruptedProvisioningAt === undefined
+      ? candidate
+      : Math.min(candidate, interruptedProvisioningAt);
   const runtimeAdapterDeleteRetryAt = Date.parse(lease.runtimeAdapterDeleteRetryAt ?? "");
   const runtimeAdapterDeleteDispatchUntil = Date.parse(
     lease.runtimeAdapterDeleteDispatchUntil ?? "",
@@ -19799,29 +20035,33 @@ function nextLeaseAlarmTime(lease: LeaseRecord): number {
     ) {
       deleteAlarm = Math.max(deleteAlarm, runtimeAdapterDeleteDispatchUntil);
     }
-    return leaseIsLive(lease) && Number.isFinite(expiresAt)
-      ? Math.min(expiresAt, deleteAlarm)
-      : deleteAlarm;
+    return includeInterruptedProvisioning(
+      leaseIsLive(lease) && Number.isFinite(expiresAt)
+        ? Math.min(expiresAt, deleteAlarm)
+        : deleteAlarm,
+    );
   }
   if (lease.providerKeyCleanupPending && !lease.cleanupStartedAt) {
     const retryAt = Date.parse(lease.cleanupRetryAt ?? "");
-    return Number.isFinite(retryAt) && retryAt > now ? retryAt : now + 1;
+    return includeInterruptedProvisioning(
+      Number.isFinite(retryAt) && retryAt > now ? retryAt : now + 1,
+    );
   }
   const claimDeadline = cleanupClaimDeadline(lease);
   if (lease.cleanupStartedAt && Number.isFinite(claimDeadline)) {
-    return claimDeadline;
+    return includeInterruptedProvisioning(claimDeadline);
   }
   const cleanupRetryAt = Date.parse(lease.cleanupRetryAt ?? "");
   if (Number.isFinite(cleanupRetryAt) && cleanupRetryAt <= now) {
-    return now + 1;
+    return includeInterruptedProvisioning(now + 1);
   }
   if (Number.isFinite(cleanupRetryAt)) {
     if (Number.isFinite(expiresAt) && expiresAt <= now) {
-      return cleanupRetryAt;
+      return includeInterruptedProvisioning(cleanupRetryAt);
     }
-    return Math.min(expiresAt, cleanupRetryAt);
+    return includeInterruptedProvisioning(Math.min(expiresAt, cleanupRetryAt));
   }
-  return expiresAt;
+  return includeInterruptedProvisioning(expiresAt);
 }
 
 function cleanupClaimDeadline(lease: LeaseRecord): number {
@@ -19858,6 +20098,9 @@ function terminalizeManualProviderCleanup(
   delete lease.cleanupClaimExpiresAt;
   delete lease.provisioningResourceMayExist;
   delete lease.provisioningFailureRetryable;
+  delete lease.provisioningCoordinatorVersion;
+  delete lease.provisioningRecoveryObservedAt;
+  delete lease.provisioningRecoveryMissingSince;
 }
 
 function clearRuntimeAdapterDeleteMetadata(lease: LeaseRecord): void {
@@ -19908,6 +20151,9 @@ function finalizedReleasedLease(
   lease.updatedAt = now;
   lease.releasedAt = now;
   lease.endedAt = now;
+  delete lease.provisioningCoordinatorVersion;
+  delete lease.provisioningRecoveryObservedAt;
+  delete lease.provisioningRecoveryMissingSince;
   if (wasUnprovisionedRelease) {
     lease.releaseDeletesServer = deleteServer;
   } else if (

--- a/worker/src/org-records.ts
+++ b/worker/src/org-records.ts
@@ -13,10 +13,14 @@ export type PortalExternalRunnerRecord = ExternalRunnerRecord & {
 };
 
 export function publicLeaseRecord(record: LeaseRecord): LeaseRecord {
-  return {
+  const publicRecord = {
     ...record,
     org: orgLabelForDisplay(record.org),
   };
+  delete publicRecord.provisioningCoordinatorVersion;
+  delete publicRecord.provisioningRecoveryObservedAt;
+  delete publicRecord.provisioningRecoveryMissingSince;
+  return publicRecord;
 }
 
 export function publicRunRecord(record: RunRecord): RunRecord {
@@ -52,10 +56,7 @@ export function publicExternalRunnerRecord(record: ExternalRunnerRecord): Extern
 
 /** Portal rows carry a non-secret identity kind so display labels never drive authorization links. */
 export function portalLeaseRecord(record: LeaseRecord): PortalLeaseRecord {
-  const publicRecord = {
-    ...record,
-    org: orgLabelForDisplay(record.org),
-  };
+  const publicRecord = publicLeaseRecord(record);
   const portalOrgKind = portalOrgKindForKey(record.org);
   return portalOrgKind ? { ...publicRecord, portalOrgKind } : publicRecord;
 }

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -9,6 +9,11 @@ export type AWSCredentialProvider = () => Promise<AWSCredentials>;
 
 export interface Env {
   FLEET: DurableObjectNamespace;
+  CF_VERSION_METADATA?: {
+    id: string;
+    tag?: string;
+    timestamp: string;
+  };
   HETZNER_TOKEN: string;
   awsCredentialProvider?: AWSCredentialProvider;
   AWS_ACCESS_KEY_ID?: string;
@@ -465,6 +470,9 @@ export interface LeaseRecord {
   provisioningResourceMayExist?: boolean;
   provisioningFailureRetryable?: boolean;
   provisioningRequestStartedAt?: string;
+  provisioningCoordinatorVersion?: string;
+  provisioningRecoveryObservedAt?: string;
+  provisioningRecoveryMissingSince?: string;
   releaseDeletesServer?: boolean;
   releasedAt?: string;
   endedAt?: string;

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -44,6 +44,7 @@ import {
 import { HetznerClient, HetznerProvisioningError } from "../src/hetzner";
 import { MISSING_ORG_KEY, isCurrentOrgKey, orgKeyForLabel } from "../src/org-identity";
 import { portalCode, portalVNC, webVNCCredentialsFromHistoryState } from "../src/portal";
+import { providerLabelValue } from "../src/provider-labels";
 import {
   ProviderProvisioningCleanupError,
   providerProvisioningCleanupClaim,
@@ -8435,7 +8436,14 @@ describe("fleet lease identity and idle", () => {
                 status: "running",
                 serverType: "cpx62",
                 host: "192.0.2.106",
-                labels: { lease: leaseID },
+                labels: {
+                  crabbox: "true",
+                  created_by: "crabbox",
+                  lease: leaseID,
+                  owner: "alice_example.com",
+                  provider: "hetzner",
+                  slug: "fleet-is-106",
+                },
               },
             ],
           },
@@ -8592,7 +8600,14 @@ describe("fleet lease identity and idle", () => {
                       status: "running",
                       serverType: "cpx62",
                       host: "192.0.2.112",
-                      labels: { lease: leaseID },
+                      labels: {
+                        crabbox: "true",
+                        created_by: "crabbox",
+                        lease: leaseID,
+                        owner: "alice_example.com",
+                        provider: "hetzner",
+                        slug: "fleet-is-112",
+                      },
                     },
                   ];
             },
@@ -8685,7 +8700,14 @@ describe("fleet lease identity and idle", () => {
                 status: "running",
                 serverType: "cpx62",
                 host: "192.0.2.112",
-                labels: { lease: lease.id },
+                labels: {
+                  crabbox: "true",
+                  created_by: "crabbox",
+                  lease: lease.id,
+                  owner: providerLabelValue(lease.owner),
+                  provider: "hetzner",
+                  slug: providerLabelValue(lease.slug ?? ""),
+                },
               };
             },
             onReleaseLease(lease) {
@@ -8812,6 +8834,8 @@ describe("fleet lease identity and idle", () => {
               created_by: "crabbox",
               provider: "gcp",
               lease: leaseID,
+              owner: "alice_example_com",
+              slug: "fleet-is-gcp-recovery",
             },
           };
         },
@@ -9884,12 +9908,22 @@ describe("fleet lease identity and idle", () => {
               status: "initializing",
               serverType: "cpx62",
               host: "",
-              labels: { lease: leaseID },
+              labels: {
+                crabbox: "true",
+                created_by: "crabbox",
+                lease: leaseID,
+                owner: "alice_example.com",
+                provider: "hetzner",
+                slug: "fleet-is-109",
+              },
             },
           ],
         },
         async () => {
           providerReleases += 1;
+        },
+        async () => {
+          throw new Error("hetzner GET /servers/missing-cloud-id: http 404: not_found");
         },
       ),
     });
@@ -9920,7 +9954,7 @@ describe("fleet lease identity and idle", () => {
       desktop: false,
       browser: false,
       code: false,
-      cloudID: "",
+      cloudID: "missing-cloud-id",
       owner: "alice@example.com",
       org: "example-org",
       profile: "default",
@@ -9993,7 +10027,14 @@ describe("fleet lease identity and idle", () => {
             status: "initializing",
             serverType: "cx53",
             host: "192.0.2.129",
-            labels: { lease: leaseID },
+            labels: {
+              crabbox: "true",
+              created_by: "crabbox",
+              lease: leaseID,
+              owner: "alice_example.com",
+              provider: "hetzner",
+              slug: "fleet-is-129",
+            },
           },
         ],
       }),
@@ -10339,7 +10380,7 @@ describe("fleet lease identity and idle", () => {
       state: "failed",
       cloudID: "",
       failureError:
-        "coordinator deployment or runtime restart interrupted provider provisioning; no provider resource found",
+        "coordinator deployment interrupted provider provisioning; no provider resource found",
       provisioningResourceMayExist: false,
       provisioningFailureRetryable: false,
     });
@@ -10413,6 +10454,56 @@ describe("fleet lease identity and idle", () => {
     expect(visibleLease.lease.provisioningRecoveryMissingSince).toBeUndefined();
   });
 
+  it("does not reconcile same-version long-running AWS Mac provisioning", async () => {
+    const storage = new MemoryStorage();
+    let providerLookups = 0;
+    const now = Date.now();
+    const fleet = testFleet(
+      storage,
+      {
+        aws: fakeProvider(undefined, {
+          provider: "aws",
+          onList() {
+            providerLookups += 1;
+            return [];
+          },
+        }),
+      },
+      {
+        CF_VERSION_METADATA: {
+          id: "current-version",
+          timestamp: new Date(now - 60 * 60_000).toISOString(),
+        },
+      },
+    );
+    storage.seed(
+      "lease:cbx_000000000096",
+      testLease({
+        id: "cbx_000000000096",
+        slug: "long-running-mac",
+        provider: "aws",
+        target: "macos",
+        serverType: "mac2.metal",
+        cloudID: "",
+        serverID: 0,
+        serverName: "",
+        host: "",
+        state: "provisioning",
+        provisioningRequestStartedAt: new Date(now - 31 * 60_000).toISOString(),
+        provisioningCoordinatorVersion: "current-version",
+        expiresAt: new Date(now + 60 * 60_000).toISOString(),
+      }),
+    );
+
+    await fleet.alarm();
+
+    expect(providerLookups).toBe(0);
+    expect(storage.value<LeaseRecord>("lease:cbx_000000000096")).toMatchObject({
+      state: "provisioning",
+      provisioningCoordinatorVersion: "current-version",
+    });
+  });
+
   it("keeps checking after an empty interrupted provisioning lookup", async () => {
     const storage = new MemoryStorage();
     const now = Date.now();
@@ -10436,18 +10527,27 @@ describe("fleet lease identity and idle", () => {
         slug: "delayed",
       },
     };
-    const fleet = testFleet(storage, {
-      azure: fakeProvider(undefined, {
-        provider: "azure",
-        onList() {
-          providerLookups += 1;
-          return providerLookups === 1 ? [] : [server];
+    const fleet = testFleet(
+      storage,
+      {
+        azure: fakeProvider(undefined, {
+          provider: "azure",
+          onList() {
+            providerLookups += 1;
+            return providerLookups === 1 ? [] : [server];
+          },
+          onReleaseLease() {
+            providerReleases += 1;
+          },
+        }),
+      },
+      {
+        CF_VERSION_METADATA: {
+          id: "new-version",
+          timestamp: new Date(now - 10 * 60_000).toISOString(),
         },
-        onReleaseLease() {
-          providerReleases += 1;
-        },
-      }),
-    });
+      },
+    );
     storage.seed(
       `lease:${leaseID}`,
       testLease({
@@ -10461,7 +10561,9 @@ describe("fleet lease identity and idle", () => {
         serverName: "",
         host: "",
         state: "provisioning",
-        provisioningRequestStartedAt: new Date(now - 31 * 60_000).toISOString(),
+        provisioningRequestStartedAt: new Date(now - 60_000).toISOString(),
+        provisioningCoordinatorVersion: "old-version",
+        provisioningRecoveryObservedAt: new Date(now - 10 * 60_000).toISOString(),
         expiresAt: new Date(now + 60 * 60_000).toISOString(),
       }),
     );
@@ -10474,7 +10576,7 @@ describe("fleet lease identity and idle", () => {
       provisioningResourceMayExist: true,
       provisioningFailureRetryable: true,
       cleanupError:
-        "coordinator deployment or runtime restart interrupted provider provisioning; provider resource not yet visible",
+        "coordinator deployment interrupted provider provisioning; provider resource not yet visible",
     });
     expect(Date.parse(uncertain?.provisioningRecoveryMissingSince ?? "")).toBeGreaterThanOrEqual(
       now,
@@ -10537,38 +10639,50 @@ describe("fleet lease identity and idle", () => {
     ).toBeUndefined();
   });
 
-  it("recovers and cleans an owned resource after stale provisioning", async () => {
+  it("recovers and cleans an owned resource after interrupted deployment", async () => {
     const storage = new MemoryStorage();
     const now = Date.now();
     let providerReleases = 0;
     const leaseID = "cbx_000000000093";
-    const fleet = testFleet(storage, {
-      azure: fakeProvider(undefined, {
-        provider: "azure",
-        servers: [
-          {
-            provider: "azure",
-            id: 0,
-            cloudID: "crabbox-interrupted",
-            name: "crabbox-interrupted",
-            status: "running",
-            serverType: "Standard_D4ads_v6",
-            host: "192.0.2.93",
-            labels: {
-              crabbox: "true",
-              created_by: "crabbox",
-              lease: leaseID,
-              owner: "alice_example.com",
-              provider: "azure",
-              slug: "interrupted",
-            },
+    const fleet = testFleet(
+      storage,
+      {
+        azure: fakeProvider(undefined, {
+          provider: "azure",
+          onRecoverServer() {
+            return undefined;
           },
-        ],
-        onReleaseLease() {
-          providerReleases += 1;
+          servers: [
+            {
+              provider: "azure",
+              id: 0,
+              cloudID: "crabbox-interrupted",
+              name: "crabbox-interrupted",
+              status: "running",
+              serverType: "Standard_D4ads_v6",
+              host: "192.0.2.93",
+              labels: {
+                crabbox: "true",
+                created_by: "crabbox",
+                lease: leaseID,
+                owner: "alice_example.com",
+                provider: "azure",
+                slug: "interrupted",
+              },
+            },
+          ],
+          onReleaseLease() {
+            providerReleases += 1;
+          },
+        }),
+      },
+      {
+        CF_VERSION_METADATA: {
+          id: "new-version",
+          timestamp: new Date(now - 10 * 60_000).toISOString(),
         },
-      }),
-    });
+      },
+    );
     storage.seed(
       `lease:${leaseID}`,
       testLease({
@@ -10582,7 +10696,9 @@ describe("fleet lease identity and idle", () => {
         serverName: "",
         host: "",
         state: "provisioning",
-        provisioningRequestStartedAt: new Date(now - 31 * 60_000).toISOString(),
+        provisioningRequestStartedAt: new Date(now - 60_000).toISOString(),
+        provisioningCoordinatorVersion: "old-version",
+        provisioningRecoveryObservedAt: new Date(now - 10 * 60_000).toISOString(),
         expiresAt: new Date(now + 60 * 60_000).toISOString(),
       }),
     );
@@ -10594,7 +10710,7 @@ describe("fleet lease identity and idle", () => {
       state: "failed",
       cloudID: "crabbox-interrupted",
       failureError:
-        "coordinator deployment or runtime restart interrupted provider provisioning; recovered provider resource for cleanup",
+        "coordinator deployment interrupted provider provisioning; recovered provider resource for cleanup",
       provisioningResourceMayExist: false,
       provisioningFailureRetryable: false,
     });
@@ -10604,14 +10720,23 @@ describe("fleet lease identity and idle", () => {
   it("backs off interrupted provisioning recovery when provider inventory fails", async () => {
     const storage = new MemoryStorage();
     const now = Date.now();
-    const fleet = testFleet(storage, {
-      azure: fakeProvider(undefined, {
-        provider: "azure",
-        onList() {
-          throw new Error("azure inventory unavailable");
+    const fleet = testFleet(
+      storage,
+      {
+        azure: fakeProvider(undefined, {
+          provider: "azure",
+          onList() {
+            throw new Error("azure inventory unavailable");
+          },
+        }),
+      },
+      {
+        CF_VERSION_METADATA: {
+          id: "new-version",
+          timestamp: new Date(now - 10 * 60_000).toISOString(),
         },
-      }),
-    });
+      },
+    );
     storage.seed(
       "lease:cbx_000000000094",
       testLease({
@@ -10625,7 +10750,9 @@ describe("fleet lease identity and idle", () => {
         serverName: "",
         host: "",
         state: "provisioning",
-        provisioningRequestStartedAt: new Date(now - 31 * 60_000).toISOString(),
+        provisioningRequestStartedAt: new Date(now - 60_000).toISOString(),
+        provisioningCoordinatorVersion: "old-version",
+        provisioningRecoveryObservedAt: new Date(now - 10 * 60_000).toISOString(),
         expiresAt: new Date(now + 60 * 60_000).toISOString(),
       }),
     );

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -41,6 +41,7 @@ import {
   workspaceTerminalOriginAllowed,
   type WebVNCBuffer,
 } from "../src/fleet";
+import { gcpProviderLabelValue } from "../src/gcp";
 import { HetznerClient, HetznerProvisioningError } from "../src/hetzner";
 import { MISSING_ORG_KEY, isCurrentOrgKey, orgKeyForLabel } from "../src/org-identity";
 import { portalCode, portalVNC, webVNCCredentialsFromHistoryState } from "../src/portal";
@@ -29947,6 +29948,13 @@ function fakeProvider(
     restrictedLeaseRequestFields(input: LeaseRequest) {
       return result.onRestrictedLeaseRequestFields?.(input) ?? [];
     },
+    ...(result.provider === "gcp"
+      ? {
+          ownershipLabelValue(value: string) {
+            return gcpProviderLabelValue(value);
+          },
+        }
+      : {}),
     ...(result.onRecoverServer
       ? {
           async recoverServer(lease: LeaseRecord) {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -10385,6 +10385,7 @@ describe("fleet lease identity and idle", () => {
         state: "provisioning",
         provisioningRequestStartedAt: new Date(now - 60_000).toISOString(),
         provisioningCoordinatorVersion: "old-version",
+        cleanupRetryAt: new Date(now + 60_000).toISOString(),
         expiresAt: new Date(now + 60 * 60_000).toISOString(),
       }),
     );

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -10289,6 +10289,358 @@ describe("fleet lease identity and idle", () => {
     expect(storage.value<LeaseRecord>("lease:cbx_000000000098")?.state).toBe("expired");
   });
 
+  it("fails interrupted deployment provisioning when no provider resource exists", async () => {
+    const storage = new MemoryStorage();
+    let providerLookups = 0;
+    const now = Date.now();
+    const fleet = testFleet(
+      storage,
+      {
+        azure: fakeProvider(undefined, {
+          provider: "azure",
+          onList() {
+            providerLookups += 1;
+            return [];
+          },
+        }),
+      },
+      {
+        CF_VERSION_METADATA: {
+          id: "new-version",
+          timestamp: new Date(now - 10 * 60_000).toISOString(),
+        },
+      },
+    );
+    storage.seed(
+      "lease:cbx_000000000091",
+      testLease({
+        id: "cbx_000000000091",
+        slug: "interrupted",
+        provider: "azure",
+        owner: "alice@example.com",
+        org: "example-org",
+        cloudID: "",
+        serverID: 0,
+        serverName: "",
+        host: "",
+        state: "provisioning",
+        provisioningRequestStartedAt: new Date(now - 60_000).toISOString(),
+        provisioningCoordinatorVersion: "old-version",
+        provisioningRecoveryObservedAt: new Date(now - 10 * 60_000).toISOString(),
+        provisioningRecoveryMissingSince: new Date(now - 31 * 60_000).toISOString(),
+        expiresAt: new Date(now + 60 * 60_000).toISOString(),
+      }),
+    );
+
+    await fleet.alarm();
+
+    expect(providerLookups).toBe(1);
+    expect(storage.value<LeaseRecord>("lease:cbx_000000000091")).toMatchObject({
+      state: "failed",
+      cloudID: "",
+      failureError:
+        "coordinator deployment or runtime restart interrupted provider provisioning; no provider resource found",
+      provisioningResourceMayExist: false,
+      provisioningFailureRetryable: false,
+    });
+    expect(
+      storage.value<LeaseRecord>("lease:cbx_000000000091")?.provisioningCoordinatorVersion,
+    ).toBeUndefined();
+  });
+
+  it("waits for the deployment settle window before reconciling interrupted provisioning", async () => {
+    const storage = new MemoryStorage();
+    let providerLookups = 0;
+    const now = Date.now();
+    const fleet = testFleet(
+      storage,
+      {
+        azure: fakeProvider(undefined, {
+          provider: "azure",
+          onList() {
+            providerLookups += 1;
+            return [];
+          },
+        }),
+      },
+      {
+        CF_VERSION_METADATA: {
+          id: "new-version",
+          timestamp: new Date(now - 60 * 60_000).toISOString(),
+        },
+      },
+    );
+    storage.seed(
+      "lease:cbx_000000000092",
+      testLease({
+        id: "cbx_000000000092",
+        slug: "settling",
+        provider: "azure",
+        owner: "alice@example.com",
+        org: "example-org",
+        cloudID: "",
+        serverID: 0,
+        serverName: "",
+        host: "",
+        state: "provisioning",
+        provisioningRequestStartedAt: new Date(now - 60_000).toISOString(),
+        provisioningCoordinatorVersion: "old-version",
+        expiresAt: new Date(now + 60 * 60_000).toISOString(),
+      }),
+    );
+
+    await fleet.alarm();
+
+    expect(providerLookups).toBe(0);
+    const stored = storage.value<LeaseRecord>("lease:cbx_000000000092");
+    expect(stored?.state).toBe("provisioning");
+    expect(Date.parse(stored?.provisioningRecoveryObservedAt ?? "")).toBeGreaterThanOrEqual(now);
+    expect(storage.alarm()).toBe(
+      Date.parse(stored?.provisioningRecoveryObservedAt ?? "") + 5 * 60_000,
+    );
+    const visible = await fleet.fetch(
+      request("GET", "/v1/leases/cbx_000000000092", {
+        headers: {
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
+        },
+      }),
+    );
+    const visibleLease = (await visible.json()) as { lease: LeaseRecord };
+    expect(visibleLease.lease.provisioningCoordinatorVersion).toBeUndefined();
+    expect(visibleLease.lease.provisioningRecoveryObservedAt).toBeUndefined();
+    expect(visibleLease.lease.provisioningRecoveryMissingSince).toBeUndefined();
+  });
+
+  it("keeps checking after an empty interrupted provisioning lookup", async () => {
+    const storage = new MemoryStorage();
+    const now = Date.now();
+    let providerLookups = 0;
+    let providerReleases = 0;
+    const leaseID = "cbx_000000000096";
+    const server: ProviderMachine = {
+      provider: "azure",
+      id: 0,
+      cloudID: "crabbox-delayed",
+      name: "crabbox-delayed",
+      status: "running",
+      serverType: "Standard_D4ads_v6",
+      host: "192.0.2.96",
+      labels: {
+        crabbox: "true",
+        created_by: "crabbox",
+        lease: leaseID,
+        owner: "alice_example.com",
+        provider: "azure",
+        slug: "delayed",
+      },
+    };
+    const fleet = testFleet(storage, {
+      azure: fakeProvider(undefined, {
+        provider: "azure",
+        onList() {
+          providerLookups += 1;
+          return providerLookups === 1 ? [] : [server];
+        },
+        onReleaseLease() {
+          providerReleases += 1;
+        },
+      }),
+    });
+    storage.seed(
+      `lease:${leaseID}`,
+      testLease({
+        id: leaseID,
+        slug: "delayed",
+        provider: "azure",
+        owner: "alice@example.com",
+        org: "example-org",
+        cloudID: "",
+        serverID: 0,
+        serverName: "",
+        host: "",
+        state: "provisioning",
+        provisioningRequestStartedAt: new Date(now - 31 * 60_000).toISOString(),
+        expiresAt: new Date(now + 60 * 60_000).toISOString(),
+      }),
+    );
+
+    await fleet.alarm();
+
+    const uncertain = storage.value<LeaseRecord>(`lease:${leaseID}`);
+    expect(uncertain).toMatchObject({
+      state: "provisioning",
+      provisioningResourceMayExist: true,
+      provisioningFailureRetryable: true,
+      cleanupError:
+        "coordinator deployment or runtime restart interrupted provider provisioning; provider resource not yet visible",
+    });
+    expect(Date.parse(uncertain?.provisioningRecoveryMissingSince ?? "")).toBeGreaterThanOrEqual(
+      now,
+    );
+    expect(Date.parse(uncertain?.cleanupRetryAt ?? "")).toBeGreaterThan(now);
+
+    storage.seed(`lease:${leaseID}`, {
+      ...uncertain,
+      cleanupRetryAt: new Date(now - 1).toISOString(),
+    });
+    await fleet.alarm();
+
+    expect(providerLookups).toBe(2);
+    expect(providerReleases).toBe(1);
+    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)).toMatchObject({
+      state: "failed",
+      cloudID: "crabbox-delayed",
+      provisioningResourceMayExist: false,
+      provisioningFailureRetryable: false,
+    });
+  });
+
+  it("records the coordinator version only while provider provisioning is active", async () => {
+    const storage = new MemoryStorage();
+    let activeVersion: string | undefined;
+    const fleet = testFleet(
+      storage,
+      {
+        hetzner: fakeProvider(() => {
+          activeVersion =
+            storage.value<LeaseRecord>("lease:cbx_000000000095")?.provisioningCoordinatorVersion;
+        }),
+      },
+      {
+        CF_VERSION_METADATA: {
+          id: "current-version",
+          timestamp: new Date().toISOString(),
+        },
+      },
+    );
+
+    const response = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers: {
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
+        },
+        body: {
+          leaseID: "cbx_000000000095",
+          provider: "hetzner",
+          sshPublicKey: "ssh-ed25519 version-test",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(activeVersion).toBe("current-version");
+    expect(
+      storage.value<LeaseRecord>("lease:cbx_000000000095")?.provisioningCoordinatorVersion,
+    ).toBeUndefined();
+  });
+
+  it("recovers and cleans an owned resource after stale provisioning", async () => {
+    const storage = new MemoryStorage();
+    const now = Date.now();
+    let providerReleases = 0;
+    const leaseID = "cbx_000000000093";
+    const fleet = testFleet(storage, {
+      azure: fakeProvider(undefined, {
+        provider: "azure",
+        servers: [
+          {
+            provider: "azure",
+            id: 0,
+            cloudID: "crabbox-interrupted",
+            name: "crabbox-interrupted",
+            status: "running",
+            serverType: "Standard_D4ads_v6",
+            host: "192.0.2.93",
+            labels: {
+              crabbox: "true",
+              created_by: "crabbox",
+              lease: leaseID,
+              owner: "alice_example.com",
+              provider: "azure",
+              slug: "interrupted",
+            },
+          },
+        ],
+        onReleaseLease() {
+          providerReleases += 1;
+        },
+      }),
+    });
+    storage.seed(
+      `lease:${leaseID}`,
+      testLease({
+        id: leaseID,
+        slug: "interrupted",
+        provider: "azure",
+        owner: "alice@example.com",
+        org: "example-org",
+        cloudID: "",
+        serverID: 0,
+        serverName: "",
+        host: "",
+        state: "provisioning",
+        provisioningRequestStartedAt: new Date(now - 31 * 60_000).toISOString(),
+        expiresAt: new Date(now + 60 * 60_000).toISOString(),
+      }),
+    );
+
+    await fleet.alarm();
+
+    expect(providerReleases).toBe(1);
+    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)).toMatchObject({
+      state: "failed",
+      cloudID: "crabbox-interrupted",
+      failureError:
+        "coordinator deployment or runtime restart interrupted provider provisioning; recovered provider resource for cleanup",
+      provisioningResourceMayExist: false,
+      provisioningFailureRetryable: false,
+    });
+    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)?.cleanupError).toBeUndefined();
+  });
+
+  it("backs off interrupted provisioning recovery when provider inventory fails", async () => {
+    const storage = new MemoryStorage();
+    const now = Date.now();
+    const fleet = testFleet(storage, {
+      azure: fakeProvider(undefined, {
+        provider: "azure",
+        onList() {
+          throw new Error("azure inventory unavailable");
+        },
+      }),
+    });
+    storage.seed(
+      "lease:cbx_000000000094",
+      testLease({
+        id: "cbx_000000000094",
+        slug: "inventory",
+        provider: "azure",
+        owner: "alice@example.com",
+        org: "example-org",
+        cloudID: "",
+        serverID: 0,
+        serverName: "",
+        host: "",
+        state: "provisioning",
+        provisioningRequestStartedAt: new Date(now - 31 * 60_000).toISOString(),
+        expiresAt: new Date(now + 60 * 60_000).toISOString(),
+      }),
+    );
+
+    await fleet.alarm();
+
+    const lease = storage.value<LeaseRecord>("lease:cbx_000000000094");
+    expect(lease).toMatchObject({
+      state: "provisioning",
+      cleanupAttempts: 1,
+      cleanupError: "interrupted provisioning recovery failed: azure inventory unavailable",
+    });
+    expect(Date.parse(lease?.cleanupRetryAt ?? "")).toBeGreaterThan(now);
+    expect(storage.alarm()).toBe(Date.parse(lease?.cleanupRetryAt ?? ""));
+  });
+
   it("does not let registration overwrite another owner or managed lease", async () => {
     const storage = new MemoryStorage();
     const fleet = testFleet(storage);

--- a/worker/test/private-aws-workspace.test.ts
+++ b/worker/test/private-aws-workspace.test.ts
@@ -9,6 +9,7 @@ import type {
   CoordinatorWebSocketUpgradeOptions,
 } from "../src/coordinator-runtime";
 import { AWSProvider, FleetCoordinator } from "../src/fleet";
+import { providerLabelValue } from "../src/provider-labels";
 import type { Env, LeaseRecord, ProviderMachine } from "../src/types";
 
 afterEach(() => {
@@ -539,7 +540,7 @@ describe("private AWS workspaces", () => {
   });
 });
 
-function privateMachine(id: string): ProviderMachine {
+function privateMachine(id: string, lease?: LeaseRecord): ProviderMachine {
   return {
     provider: "aws",
     id: 123,
@@ -549,7 +550,16 @@ function privateMachine(id: string): ProviderMachine {
     serverType: "t3a.small",
     host: "",
     region: "us-west-2",
-    labels: {},
+    labels: lease
+      ? {
+          crabbox: "true",
+          created_by: "crabbox",
+          lease: lease.id,
+          owner: providerLabelValue(lease.providerOwner ?? lease.owner),
+          provider: "aws",
+          slug: providerLabelValue(lease.slug ?? ""),
+        }
+      : {},
     awsSSMCommandID: "command-abc123",
     awsSSMCommandStatus: "Success",
   };
@@ -571,9 +581,9 @@ function privateRecoveryProvider(state: RecoveryProviderState): Record<string, u
     supportsSSHHostKeyInjection(): boolean {
       return false;
     },
-    async recoverServer(): Promise<ProviderMachine> {
+    async recoverServer(lease: LeaseRecord): Promise<ProviderMachine> {
       state.recovers += 1;
-      return { ...privateMachine("i-recovered123"), status: "running" };
+      return { ...privateMachine("i-recovered123", lease), status: "running" };
     },
     async getServer(id: string): Promise<ProviderMachine> {
       return privateMachine(id);

--- a/worker/test/wrangler-config.test.ts
+++ b/worker/test/wrangler-config.test.ts
@@ -36,6 +36,11 @@ describe("wrangler config", () => {
     expect(configStringValues("CRABBOX_AWS_SSH_CIDRS")).toEqual([]);
     expect(configStringValues("CRABBOX_PUBLIC_URL")).toEqual(["https://crabbox.openclaw.ai"]);
   });
+
+  it("binds deployment version metadata for interrupted provisioning recovery", () => {
+    expect(wranglerConfig).toContain('"version_metadata"');
+    expect(wranglerConfig).toContain('"binding": "CF_VERSION_METADATA"');
+  });
 });
 
 function configValues(name: string): number[] {

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -12,6 +12,9 @@
   },
   "workers_dev": true,
   "preview_urls": true,
+  "version_metadata": {
+    "binding": "CF_VERSION_METADATA",
+  },
   "triggers": {
     "crons": ["*/15 * * * *"],
   },


### PR DESCRIPTION
Closes https://github.com/openclaw/crabbox/issues/1224

## What Problem This Solves

Fixes an issue where users provisioning a brokered managed-provider lease could leave an untracked, billable cloud resource when a coordinator deployment replaced the Durable Object before the cloud identity was persisted.

## Why This Change Was Made

Scheduled fleet maintenance now detects interrupted provisioning from coordinator-version changes, waits through a deployment settle period, and uses one provider-neutral recovery helper shared with workspace recovery. The helper follows provider recovery, exact-ID, lease lookup, and inventory capabilities while treating provider not-found responses as misses and enforcing exact ownership labels, including GCP's label normalization.

A missing resource remains uncertain and is rechecked for 30 minutes before the lease is terminalized; recovered resources enter the existing cleanup path. Same-version lease age is deliberately not a recovery signal because AWS, Azure, and GCP create paths can legitimately exceed 30 minutes or have no proven upper bound.

The recovery state is internal, provider-neutral, and alarm-driven. There are no new user environment variables, broker settings, credentials, or warm-pool requirements. The Worker gains the standard Cloudflare Version Metadata binding, and existing lease diagnostics now pass through the Go JSON model for operators.

## User Impact

Broker provisioning interrupted by a coordinator deployment now heals automatically instead of leaving a permanently provisioning lease or an undiscovered cloud resource. Long-running same-version creates are not terminated by an arbitrary age threshold. Operators can see the durable cleanup or failure reason through existing lease JSON output.

## Evidence

Signed head: `43723ff447d691b50702791623681a958a320118`

Observed trigger on August 3, 2026:

- Azure canary `run_14493bd00e79` reached normal broker auth and selected `Standard_D4ads_v6`.
- Concurrent coordinator deploy https://github.com/openclaw/crabbox/actions/runs/30804794658 replaced the Worker while provisioning was in flight, producing Cloudflare `1101` before the cloud identity reached the lease record.

Validation:

- focused Worker recovery proof: 2 files passed, 517 tests passed
- `go test ./internal/cli -count=1`: passed on the preceding behavior head
- full Worker suite on the preceding behavior head: 37 files passed, 2 skipped; 1165 tests passed, 3 skipped
- Worker format, TypeScript, lint, and Wrangler dry-run build passed on the preceding behavior head
- fresh fixture-only autoreview: clean
- TruffleHog: clean on the preceding behavior head

Exact-head checks:

- CI: https://github.com/openclaw/crabbox/actions/runs/30807623781
- ClawSweeper dispatch: https://github.com/openclaw/crabbox/actions/runs/30807622400
- CodeQL: https://github.com/openclaw/crabbox/actions/runs/30807621070

The behavior autoreview fixed empty-hook fallback and provider 404 handling. Its remaining request for same-version restart recovery requires a new durable runtime-incarnation contract and is intentionally outside this deployment-version-only repair.

No deployment or recovery canary was run from this branch.
