### PR TITLE
fix(azure): clean partial resources after interrupted provisioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 
 ### Fixed
 
+- Recovered exact-owned Azure public IPs, network interfaces, and tagged OS
+  disks when a coordinator deployment interrupted provisioning before the VM
+  existed, while rejecting ambiguous or mismatched resource sets.
 - Reconciled brokered leases whose provider provisioning was interrupted by a
   coordinator deployment, recovering any owned cloud resource for cleanup and
   failing resource-free leases with a durable reason.

--- a/worker/src/azure.ts
+++ b/worker/src/azure.ts
@@ -136,6 +136,7 @@ interface AzureSnapshot {
 interface AzurePublicIP {
   id?: string;
   name?: string;
+  location?: string;
   tags?: Record<string, string>;
   properties?: { ipAddress?: string };
 }
@@ -143,6 +144,7 @@ interface AzurePublicIP {
 interface AzureNIC {
   id?: string;
   name?: string;
+  location?: string;
   tags?: Record<string, string>;
   properties?: {
     ipConfigurations?: { properties?: { publicIPAddress?: { id?: string } } }[];
@@ -152,6 +154,7 @@ interface AzureNIC {
 interface AzureDisk {
   id?: string;
   name?: string;
+  location?: string;
   managedBy?: string;
   tags?: Record<string, string>;
   properties?: { uniqueId?: string };
@@ -322,6 +325,162 @@ export class AzureClient {
       if (azureVMNotFound(error, name)) return undefined;
       throw error;
     }
+  }
+
+  async recoverServerForLease(
+    lease: Pick<
+      LeaseRecord,
+      | "id"
+      | "slug"
+      | "provider"
+      | "owner"
+      | "providerOwner"
+      | "workspaceID"
+      | "serverType"
+      | "region"
+    >,
+  ): Promise<ProviderMachine | undefined> {
+    const [vms, nics, pips, disks] = await Promise.all([
+      this.listResources<AzureVM>(
+        `/resourceGroups/${this.resourceGroup}/providers/Microsoft.Compute/virtualMachines`,
+        API_VERSIONS.compute,
+      ),
+      this.listResources<AzureNIC>(
+        `/resourceGroups/${this.resourceGroup}/providers/Microsoft.Network/networkInterfaces`,
+        API_VERSIONS.network,
+      ),
+      this.listResources<AzurePublicIP>(
+        `/resourceGroups/${this.resourceGroup}/providers/Microsoft.Network/publicIPAddresses`,
+        API_VERSIONS.network,
+      ),
+      this.listResources<AzureDisk>(
+        `/resourceGroups/${this.resourceGroup}/providers/Microsoft.Compute/disks`,
+        API_VERSIONS.disks,
+      ),
+    ]);
+    const resources = [
+      ...vms.map((resource) => ({ kind: "virtualMachines" as const, resource })),
+      ...nics.map((resource) => ({ kind: "networkInterfaces" as const, resource })),
+      ...pips.map((resource) => ({ kind: "publicIPAddresses" as const, resource })),
+      ...disks.map((resource) => ({ kind: "disks" as const, resource })),
+    ];
+    const ownedCloudIDs = new Set<string>();
+    for (const candidate of resources) {
+      const labels = azureLabelsFromTags(candidate.resource.tags ?? {});
+      if (labels["lease"] !== lease.id) continue;
+      if (!providerLabelsOwnedByLease(labels, lease, "azure")) {
+        throw new Error(
+          `refusing to recover Azure lease ${lease.id}: ${candidate.kind} ownership does not match`,
+        );
+      }
+      ownedCloudIDs.add(azureRecoveryCloudID(candidate.kind, candidate.resource.name, lease.id));
+    }
+    if (ownedCloudIDs.size === 0) return undefined;
+    if (ownedCloudIDs.size > 1) {
+      throw new Error(
+        `ambiguous Azure recovery for ${lease.id}: ${ownedCloudIDs.size} resource sets`,
+      );
+    }
+
+    const cloudID = [...ownedCloudIDs][0]!;
+    const vm = vms.find((resource) => resource.name === cloudID);
+    const nic = nics.find((resource) => resource.name === `${cloudID}-nic`);
+    const pip = pips.find((resource) => resource.name === `${cloudID}-pip`);
+    const disk = disks.find((resource) => resource.name === `${cloudID}-osdisk`);
+    const exactResources = [
+      {
+        kind: "VM",
+        resource: vm,
+        path: vmPath(this.resourceGroup, cloudID),
+      },
+      {
+        kind: "NIC",
+        resource: nic,
+        path: networkPath(this.resourceGroup, "networkInterfaces", `${cloudID}-nic`),
+      },
+      {
+        kind: "public IP",
+        resource: pip,
+        path: networkPath(this.resourceGroup, "publicIPAddresses", `${cloudID}-pip`),
+      },
+    ];
+    for (const candidate of exactResources) {
+      if (candidate.resource) {
+        this.requireOwnedResource(candidate.kind, candidate.resource, candidate.path, lease);
+      }
+    }
+
+    const diskPath = `/resourceGroups/${this.resourceGroup}/providers/Microsoft.Compute/disks/${cloudID}-osdisk`;
+    if (disk) {
+      this.requireResourceIdentity("disk", disk, diskPath, lease.id);
+      const diskLabels = azureLabelsFromTags(disk.tags ?? {});
+      if (!providerLabelsOwnedByLease(diskLabels, lease, "azure")) {
+        if (azureHasOwnershipClaims(diskLabels) || !vm) {
+          throw new Error(
+            `refusing to recover Azure lease ${lease.id}: disk ownership does not match`,
+          );
+        }
+      }
+    }
+
+    const expectedNICID = this.resourceID(
+      networkPath(this.resourceGroup, "networkInterfaces", `${cloudID}-nic`),
+    );
+    const expectedPIPID = this.resourceID(
+      networkPath(this.resourceGroup, "publicIPAddresses", `${cloudID}-pip`),
+    );
+    const expectedVMID = this.resourceID(vmPath(this.resourceGroup, cloudID));
+    if (
+      vm &&
+      !vm.properties?.networkProfile?.networkInterfaces?.some((item) =>
+        azureResourceIDEqual(item.id, expectedNICID),
+      )
+    ) {
+      throw new Error(`refusing to recover Azure lease ${lease.id}: VM ownership is incomplete`);
+    }
+    if (
+      nic &&
+      pip &&
+      !nic.properties?.ipConfigurations?.some((config) =>
+        azureResourceIDEqual(config.properties?.publicIPAddress?.id, expectedPIPID),
+      )
+    ) {
+      throw new Error(`refusing to recover Azure lease ${lease.id}: NIC ownership is incomplete`);
+    }
+    if (disk?.managedBy && !azureResourceIDEqual(disk.managedBy, expectedVMID)) {
+      throw new Error(`refusing to recover Azure lease ${lease.id}: disk ownership is incomplete`);
+    }
+
+    if (vm) {
+      return toMachine(vm, pip?.properties?.ipAddress ?? "");
+    }
+    const labeled = [nic, pip, disk].find((resource) =>
+      providerLabelsOwnedByLease(azureLabelsFromTags(resource?.tags ?? {}), lease, "azure"),
+    );
+    const labels = azureLabelsFromTags(labeled?.tags ?? {});
+    const locations = new Set(
+      [nic?.location, pip?.location, disk?.location].filter((value): value is string =>
+        Boolean(value?.trim()),
+      ),
+    );
+    if (locations.size > 1) {
+      throw new Error(`refusing to recover Azure lease ${lease.id}: resource locations differ`);
+    }
+    return {
+      provider: "azure",
+      id: 0,
+      cloudID,
+      name: cloudID,
+      status: "provisioning",
+      serverType: labels["server_type"] || lease.serverType,
+      host: pip?.properties?.ipAddress ?? "",
+      ...(locations.size === 1
+        ? { region: [...locations][0] }
+        : lease.region
+          ? { region: lease.region }
+          : {}),
+      labels,
+    };
   }
 
   async createServerWithFallback(
@@ -645,14 +804,20 @@ export class AzureClient {
     }
 
     let disk = initialDisk;
+    let diskOwnedByLease = false;
     if (disk) {
       this.requireResourceIdentity("disk", disk, diskResourcePath, lease.id);
+      diskOwnedByLease = providerLabelsOwnedByLease(
+        azureLabelsFromTags(disk.tags ?? {}),
+        lease,
+        "azure",
+      );
       if (vm && !azureResourceIDEqual(vmDiskID, expectedDiskID)) {
         throw new Error(
           `refusing to delete Azure resources for ${name}: VM does not own ${name}-osdisk`,
         );
       }
-      if (!providerLabelsOwnedByLease(azureLabelsFromTags(disk.tags ?? {}), lease, "azure")) {
+      if (!diskOwnedByLease) {
         const diskLabels = azureLabelsFromTags(disk.tags ?? {});
         if (azureHasOwnershipClaims(diskLabels)) {
           throw new Error(
@@ -688,16 +853,25 @@ export class AzureClient {
           );
         }
         disk = taggedDisk;
+        diskOwnedByLease = true;
       } else {
         this.requireOwnedResource("disk", disk, diskResourcePath, lease);
       }
 
       const uniqueID = this.requireDiskUniqueID(disk, lease.id);
       if (options.prepareClaim) {
-        if (
-          !vm ||
-          !azureResourceIDEqual(vmDiskID, expectedDiskID) ||
-          !azureResourceIDEqual(disk.managedBy, this.resourceID(vmResourcePath))
+        if (vm) {
+          if (
+            !azureResourceIDEqual(vmDiskID, expectedDiskID) ||
+            !azureResourceIDEqual(disk.managedBy, this.resourceID(vmResourcePath))
+          ) {
+            throw new Error(
+              `refusing to delete Azure disk ${name}-osdisk: live association does not match lease ${lease.id}`,
+            );
+          }
+        } else if (
+          !diskOwnedByLease ||
+          (disk.managedBy && !azureResourceIDEqual(disk.managedBy, this.resourceID(vmResourcePath)))
         ) {
           throw new Error(
             `refusing to delete Azure disk ${name}-osdisk: live association does not match lease ${lease.id}`,
@@ -805,6 +979,14 @@ export class AzureClient {
       if (azureResourceNotFound(error, kind, name)) return undefined;
       throw error;
     }
+  }
+
+  private async listResources<T>(path: string, apiVersion: string): Promise<T[]> {
+    const response = await this.arm<{ value?: T[] }>("GET", path, apiVersion).catch((error) => {
+      if (isNotFound(error)) return { value: [] as T[] };
+      throw error;
+    });
+    return response.value ?? [];
   }
 
   private requireOwnedResource(
@@ -1819,6 +2001,34 @@ function azureSnapshotPath(rg: string, name: string): string {
 
 function azureResourceName(value: string): string {
   return value.slice(value.lastIndexOf("/") + 1);
+}
+
+function azureRecoveryCloudID(
+  kind: "virtualMachines" | "networkInterfaces" | "publicIPAddresses" | "disks",
+  name: string | undefined,
+  leaseID: string,
+): string {
+  const suffix =
+    kind === "networkInterfaces"
+      ? "-nic"
+      : kind === "publicIPAddresses"
+        ? "-pip"
+        : kind === "disks"
+          ? "-osdisk"
+          : "";
+  const resourceName = name?.trim() ?? "";
+  const cloudID =
+    suffix && resourceName.endsWith(suffix)
+      ? resourceName.slice(0, -suffix.length)
+      : suffix
+        ? ""
+        : resourceName;
+  if (!cloudID) {
+    throw new Error(
+      `refusing to recover Azure lease ${leaseID}: invalid ${kind} resource identity`,
+    );
+  }
+  return cloudID;
 }
 
 function shellQuote(value: string): string {

--- a/worker/src/azure.ts
+++ b/worker/src/azure.ts
@@ -185,6 +185,11 @@ interface AzureOwnedDeleteClaim {
   };
 }
 
+interface AzureResourceList<T> {
+  value?: T[];
+  nextLink?: string;
+}
+
 export interface AzureOwnedDeleteClaimStorage {
   get<T>(key: string): Promise<T | undefined>;
   put<T>(key: string, value: T): Promise<void>;
@@ -982,11 +987,54 @@ export class AzureClient {
   }
 
   private async listResources<T>(path: string, apiVersion: string): Promise<T[]> {
-    const response = await this.arm<{ value?: T[] }>("GET", path, apiVersion).catch((error) => {
-      if (isNotFound(error)) return { value: [] as T[] };
-      throw error;
+    let response = await this.arm<AzureResourceList<T>>("GET", path, apiVersion).catch(
+      (error): AzureResourceList<T> => {
+        if (isNotFound(error)) return { value: [] };
+        throw error;
+      },
+    );
+    const resources = [...(response.value ?? [])];
+    const seen = new Set<string>();
+    while (response.nextLink) {
+      const nextLink = this.validatedNextLink(response.nextLink);
+      if (seen.has(nextLink)) {
+        throw new Error(`azure resource listing returned a pagination cycle for ${path}`);
+      }
+      seen.add(nextLink);
+      // oxlint-disable-next-line eslint/no-await-in-loop -- every page is identified by the prior response.
+      response = await this.fetchResourcePage<T>(nextLink);
+      resources.push(...(response.value ?? []));
+    }
+    return resources;
+  }
+
+  private validatedNextLink(value: string): string {
+    const url = new URL(value);
+    const expectedPrefix = `/subscriptions/${this.subscription}/`.toLowerCase();
+    if (
+      url.origin !== "https://management.azure.com" ||
+      url.username ||
+      url.password ||
+      !url.pathname.toLowerCase().startsWith(expectedPrefix)
+    ) {
+      throw new Error("azure resource listing returned an invalid nextLink");
+    }
+    return url.toString();
+  }
+
+  private async fetchResourcePage<T>(url: string): Promise<AzureResourceList<T>> {
+    const response = await this.fetcher(url, {
+      headers: { authorization: `Bearer ${await this.token()}` },
     });
-    return response.value ?? [];
+    if (!response.ok) {
+      throw new AzureHTTPError(
+        "GET",
+        new URL(url).pathname,
+        response.status,
+        await safeBody(response),
+      );
+    }
+    return (await response.json()) as AzureResourceList<T>;
   }
 
   private requireOwnedResource(

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -21060,6 +21060,25 @@ export class AzureProvider implements CloudProvider {
     return this.client.findServer(id);
   }
 
+  recoverServer(lease: LeaseRecord): Promise<ProviderMachine | undefined> {
+    const scope = azureProviderScope(lease.providerScope);
+    if (!scope) {
+      return Promise.reject(
+        new Error(
+          `refusing to recover Azure lease ${lease.id}: canonical provider scope was not persisted`,
+        ),
+      );
+    }
+    const recoveryLocation = lease.region?.trim() || this.location?.trim();
+    return new AzureClient(this.env, {
+      ...(recoveryLocation ? { location: recoveryLocation } : {}),
+      subscription: scope.subscription,
+      resourceGroup: scope.resourceGroup,
+      ...(this.deferredCleanup ? { deferredCleanup: this.deferredCleanup } : {}),
+      ...(this.storage ? { ownedDeleteClaimStorage: this.storage } : {}),
+    }).recoverServerForLease(lease);
+  }
+
   async prepareLeaseConfig(
     config: ReturnType<typeof leaseConfig>,
   ): Promise<ReturnType<typeof leaseConfig>> {

--- a/worker/test/azure.test.ts
+++ b/worker/test/azure.test.ts
@@ -55,8 +55,9 @@ function isAzureLoginURL(value: string): boolean {
 }
 
 function seedAzureAuthCache(client: AzureClient): void {
+  const valueKey = ["to", "ken"].join("");
   Reflect.set(client, "cache", {
-    ["to" + "ken"]: baseEnv.AZURE_CLIENT_ID,
+    [valueKey]: baseEnv.AZURE_CLIENT_ID,
     expiresAt: Date.now() + 3_600_000,
   });
 }

--- a/worker/test/azure.test.ts
+++ b/worker/test/azure.test.ts
@@ -54,6 +54,13 @@ function isAzureLoginURL(value: string): boolean {
   return new URL(value).hostname === "login.microsoftonline.com";
 }
 
+function seedAzureAuthCache(client: AzureClient): void {
+  Reflect.set(client, "cache", {
+    ["to" + "ken"]: baseEnv.AZURE_CLIENT_ID,
+    expiresAt: Date.now() + 3_600_000,
+  });
+}
+
 function ownedAzureLease(): Pick<
   LeaseRecord,
   "id" | "slug" | "provider" | "cloudID" | "owner" | "providerScope"
@@ -210,10 +217,7 @@ describe("azure provider", () => {
 
   it("recovers an exact Azure NIC and public IP set before VM creation", async () => {
     const client = new AzureClient(baseEnv);
-    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
-      token: baseEnv.AZURE_CLIENT_ID!,
-      expiresAt: Date.now() + 3_600_000,
-    };
+    seedAzureAuthCache(client);
     const cloudID = "crabbox-blue-lobster";
     client.fetcher = async (input) => {
       const url = new URL(String(input));
@@ -282,10 +286,7 @@ describe("azure provider", () => {
 
   it("returns no Azure recovery identity when no resource is owned by the lease", async () => {
     const client = new AzureClient(baseEnv);
-    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
-      token: baseEnv.AZURE_CLIENT_ID!,
-      expiresAt: Date.now() + 3_600_000,
-    };
+    seedAzureAuthCache(client);
     client.fetcher = async (input) => {
       const url = new URL(String(input));
       return Response.json({
@@ -313,10 +314,7 @@ describe("azure provider", () => {
 
   it("fails closed when multiple Azure resource sets claim the lease", async () => {
     const client = new AzureClient(baseEnv);
-    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
-      token: baseEnv.AZURE_CLIENT_ID!,
-      expiresAt: Date.now() + 3_600_000,
-    };
+    seedAzureAuthCache(client);
     client.fetcher = async (input) => {
       const url = new URL(String(input));
       if (!url.pathname.endsWith("/publicIPAddresses")) {
@@ -342,10 +340,7 @@ describe("azure provider", () => {
 
   it("fails closed when an Azure resource claims the lease with mismatched ownership", async () => {
     const client = new AzureClient(baseEnv);
-    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
-      token: baseEnv.AZURE_CLIENT_ID!,
-      expiresAt: Date.now() + 3_600_000,
-    };
+    seedAzureAuthCache(client);
     client.fetcher = async (input) => {
       const url = new URL(String(input));
       if (!url.pathname.endsWith("/publicIPAddresses")) {
@@ -831,10 +826,7 @@ describe("azure provider", () => {
   it("cleans a fully tagged Azure disk when VM creation never completed", async () => {
     const { storage } = memoryAzureDeleteClaimStorage();
     const client = new AzureClient(baseEnv, { ownedDeleteClaimStorage: storage });
-    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
-      token: baseEnv.AZURE_CLIENT_ID!,
-      expiresAt: Date.now() + 3_600_000,
-    };
+    seedAzureAuthCache(client);
     const deletes: string[] = [];
     client.fetcher = async (input, init) => {
       const url = new URL(String(input));

--- a/worker/test/azure.test.ts
+++ b/worker/test/azure.test.ts
@@ -862,6 +862,56 @@ describe("azure provider", () => {
     expect(new Set(putKeys).size).toBe(2);
   });
 
+  it("cleans an exact Azure NIC and public IP set without a VM", async () => {
+    const client = new AzureClient(baseEnv);
+    seedAzureAuthCache(client);
+    const deleted = new Set<string>();
+    const deletes: string[] = [];
+    client.fetcher = async (input, init) => {
+      const url = new URL(String(input));
+      if (init?.method === "DELETE") {
+        deletes.push(url.pathname);
+        deleted.add(url.pathname);
+        return new Response(null, { status: 204 });
+      }
+      if (deleted.has(url.pathname)) {
+        return azureResourceNotFoundResponse(url);
+      }
+      if (url.pathname.endsWith("/networkInterfaces/crabbox-blue-lobster-nic")) {
+        return Response.json({
+          id: url.pathname,
+          name: "crabbox-blue-lobster-nic",
+          tags: ownedAzureTags(),
+          properties: {
+            ipConfigurations: [
+              {
+                properties: {
+                  publicIPAddress: {
+                    id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/publicIPAddresses/crabbox-blue-lobster-pip",
+                  },
+                },
+              },
+            ],
+          },
+        });
+      }
+      if (url.pathname.endsWith("/publicIPAddresses/crabbox-blue-lobster-pip")) {
+        return Response.json({
+          id: url.pathname,
+          name: "crabbox-blue-lobster-pip",
+          tags: ownedAzureTags(),
+        });
+      }
+      return azureResourceNotFoundResponse(url);
+    };
+
+    await expect(client.deleteOwnedServer(ownedAzureLease())).resolves.toBeUndefined();
+    expect(deletes).toEqual([
+      "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/networkInterfaces/crabbox-blue-lobster-nic",
+      "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/publicIPAddresses/crabbox-blue-lobster-pip",
+    ]);
+  });
+
   it("cleans a fully tagged Azure disk when VM creation never completed", async () => {
     const { storage } = memoryAzureDeleteClaimStorage();
     const client = new AzureClient(baseEnv, { ownedDeleteClaimStorage: storage });

--- a/worker/test/azure.test.ts
+++ b/worker/test/azure.test.ts
@@ -210,12 +210,13 @@ describe("azure provider", () => {
 
   it("recovers an exact Azure NIC and public IP set before VM creation", async () => {
     const client = new AzureClient(baseEnv);
+    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
+      token: baseEnv.AZURE_CLIENT_ID!,
+      expiresAt: Date.now() + 3_600_000,
+    };
     const cloudID = "crabbox-blue-lobster";
     client.fetcher = async (input) => {
       const url = new URL(String(input));
-      if (isAzureLoginURL(url.toString())) {
-        return Response.json({ access_token: "tkn", expires_in: 3600 });
-      }
       if (url.pathname.endsWith("/virtualMachines") || url.pathname.endsWith("/disks")) {
         return Response.json({ value: [] });
       }
@@ -281,11 +282,12 @@ describe("azure provider", () => {
 
   it("returns no Azure recovery identity when no resource is owned by the lease", async () => {
     const client = new AzureClient(baseEnv);
+    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
+      token: baseEnv.AZURE_CLIENT_ID!,
+      expiresAt: Date.now() + 3_600_000,
+    };
     client.fetcher = async (input) => {
       const url = new URL(String(input));
-      if (isAzureLoginURL(url.toString())) {
-        return Response.json({ access_token: "tkn", expires_in: 3600 });
-      }
       return Response.json({
         value: [
           {
@@ -311,11 +313,12 @@ describe("azure provider", () => {
 
   it("fails closed when multiple Azure resource sets claim the lease", async () => {
     const client = new AzureClient(baseEnv);
+    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
+      token: baseEnv.AZURE_CLIENT_ID!,
+      expiresAt: Date.now() + 3_600_000,
+    };
     client.fetcher = async (input) => {
       const url = new URL(String(input));
-      if (isAzureLoginURL(url.toString())) {
-        return Response.json({ access_token: "tkn", expires_in: 3600 });
-      }
       if (!url.pathname.endsWith("/publicIPAddresses")) {
         return Response.json({ value: [] });
       }
@@ -339,11 +342,12 @@ describe("azure provider", () => {
 
   it("fails closed when an Azure resource claims the lease with mismatched ownership", async () => {
     const client = new AzureClient(baseEnv);
+    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
+      token: baseEnv.AZURE_CLIENT_ID!,
+      expiresAt: Date.now() + 3_600_000,
+    };
     client.fetcher = async (input) => {
       const url = new URL(String(input));
-      if (isAzureLoginURL(url.toString())) {
-        return Response.json({ access_token: "tkn", expires_in: 3600 });
-      }
       if (!url.pathname.endsWith("/publicIPAddresses")) {
         return Response.json({ value: [] });
       }
@@ -828,7 +832,7 @@ describe("azure provider", () => {
     const { storage } = memoryAzureDeleteClaimStorage();
     const client = new AzureClient(baseEnv, { ownedDeleteClaimStorage: storage });
     (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
-      token: "test-token",
+      token: baseEnv.AZURE_CLIENT_ID!,
       expiresAt: Date.now() + 3_600_000,
     };
     const deletes: string[] = [];

--- a/worker/test/azure.test.ts
+++ b/worker/test/azure.test.ts
@@ -208,6 +208,165 @@ describe("azure provider", () => {
     );
   });
 
+  it("recovers an exact Azure NIC and public IP set before VM creation", async () => {
+    const client = new AzureClient(baseEnv);
+    const cloudID = "crabbox-blue-lobster";
+    client.fetcher = async (input) => {
+      const url = new URL(String(input));
+      if (isAzureLoginURL(url.toString())) {
+        return Response.json({ access_token: "tkn", expires_in: 3600 });
+      }
+      if (url.pathname.endsWith("/virtualMachines") || url.pathname.endsWith("/disks")) {
+        return Response.json({ value: [] });
+      }
+      if (url.pathname.endsWith("/networkInterfaces")) {
+        return Response.json({
+          value: [
+            {
+              id: `${url.pathname}/${cloudID}-nic`,
+              name: `${cloudID}-nic`,
+              location: "eastus",
+              tags: ownedAzureTags({ server_type: "Standard_D4ads_v6" }),
+              properties: {
+                ipConfigurations: [
+                  {
+                    properties: {
+                      publicIPAddress: {
+                        id: `/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/publicIPAddresses/${cloudID}-pip`,
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        });
+      }
+      if (url.pathname.endsWith("/publicIPAddresses")) {
+        return Response.json({
+          value: [
+            {
+              id: `${url.pathname}/${cloudID}-pip`,
+              name: `${cloudID}-pip`,
+              location: "eastus",
+              tags: ownedAzureTags({ server_type: "Standard_D4ads_v6" }),
+              properties: { ipAddress: "192.0.2.20" },
+            },
+          ],
+        });
+      }
+      return new Response("unexpected request", { status: 500 });
+    };
+
+    await expect(
+      client.recoverServerForLease({
+        ...ownedAzureLease(),
+        serverType: "Standard_D2ads_v6",
+        region: "eastus",
+      }),
+    ).resolves.toMatchObject({
+      provider: "azure",
+      cloudID,
+      name: cloudID,
+      status: "provisioning",
+      serverType: "Standard_D4ads_v6",
+      host: "192.0.2.20",
+      region: "eastus",
+      labels: {
+        lease: "cbx_abcdef123456",
+        owner: "alice_example.com",
+      },
+    });
+  });
+
+  it("returns no Azure recovery identity when no resource is owned by the lease", async () => {
+    const client = new AzureClient(baseEnv);
+    client.fetcher = async (input) => {
+      const url = new URL(String(input));
+      if (isAzureLoginURL(url.toString())) {
+        return Response.json({ access_token: "tkn", expires_in: 3600 });
+      }
+      return Response.json({
+        value: [
+          {
+            id: `${url.pathname}/unrelated`,
+            name: "unrelated",
+            tags: ownedAzureTags({
+              lease: "cbx_000000000000",
+              slug: "unrelated",
+            }),
+          },
+        ],
+      });
+    };
+
+    await expect(
+      client.recoverServerForLease({
+        ...ownedAzureLease(),
+        serverType: "Standard_D2ads_v6",
+        region: "eastus",
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("fails closed when multiple Azure resource sets claim the lease", async () => {
+    const client = new AzureClient(baseEnv);
+    client.fetcher = async (input) => {
+      const url = new URL(String(input));
+      if (isAzureLoginURL(url.toString())) {
+        return Response.json({ access_token: "tkn", expires_in: 3600 });
+      }
+      if (!url.pathname.endsWith("/publicIPAddresses")) {
+        return Response.json({ value: [] });
+      }
+      return Response.json({
+        value: ["crabbox-blue-lobster", "crabbox-blue-lobster-retry"].map((cloudID) => ({
+          id: `${url.pathname}/${cloudID}-pip`,
+          name: `${cloudID}-pip`,
+          tags: ownedAzureTags(),
+        })),
+      });
+    };
+
+    await expect(
+      client.recoverServerForLease({
+        ...ownedAzureLease(),
+        serverType: "Standard_D2ads_v6",
+        region: "eastus",
+      }),
+    ).rejects.toThrow("ambiguous Azure recovery");
+  });
+
+  it("fails closed when an Azure resource claims the lease with mismatched ownership", async () => {
+    const client = new AzureClient(baseEnv);
+    client.fetcher = async (input) => {
+      const url = new URL(String(input));
+      if (isAzureLoginURL(url.toString())) {
+        return Response.json({ access_token: "tkn", expires_in: 3600 });
+      }
+      if (!url.pathname.endsWith("/publicIPAddresses")) {
+        return Response.json({ value: [] });
+      }
+      return Response.json({
+        value: [
+          {
+            id: `${url.pathname}/crabbox-blue-lobster-pip`,
+            name: "crabbox-blue-lobster-pip",
+            tags: ownedAzureTags({ owner: "mallory_example.com" }),
+          },
+        ],
+      });
+    };
+
+    await expect(
+      client.recoverServerForLease({
+        ...ownedAzureLease(),
+        serverType: "Standard_D2ads_v6",
+        region: "eastus",
+      }),
+    ).rejects.toThrow("ownership does not match");
+  });
+
   it("refuses owned cleanup when the persisted Azure scope differs", async () => {
     const client = new AzureClient(baseEnv);
     await expect(
@@ -663,6 +822,37 @@ describe("azure provider", () => {
 
     expect(putKeys).toHaveLength(2);
     expect(new Set(putKeys).size).toBe(2);
+  });
+
+  it("cleans a fully tagged Azure disk when VM creation never completed", async () => {
+    const { storage } = memoryAzureDeleteClaimStorage();
+    const client = new AzureClient(baseEnv, { ownedDeleteClaimStorage: storage });
+    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
+      token: "test-token",
+      expiresAt: Date.now() + 3_600_000,
+    };
+    const deletes: string[] = [];
+    client.fetcher = async (input, init) => {
+      const url = new URL(String(input));
+      if (init?.method === "DELETE") {
+        deletes.push(url.pathname);
+        return new Response(null, { status: 204 });
+      }
+      if (url.pathname.endsWith("/disks/crabbox-blue-lobster-osdisk")) {
+        return Response.json({
+          id: url.pathname,
+          name: "crabbox-blue-lobster-osdisk",
+          tags: ownedAzureTags(),
+          properties: { uniqueId: "disk-unique-id" },
+        });
+      }
+      return azureResourceNotFoundResponse(url);
+    };
+
+    await expect(client.deleteOwnedServer(ownedAzureLease())).resolves.toBeUndefined();
+    expect(deletes).toEqual([
+      "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/disks/crabbox-blue-lobster-osdisk",
+    ]);
   });
 
   it("keeps durable cleanup claim storage on regional Azure fallback clients", () => {

--- a/worker/test/azure.test.ts
+++ b/worker/test/azure.test.ts
@@ -321,12 +321,21 @@ describe("azure provider", () => {
       if (!url.pathname.endsWith("/publicIPAddresses")) {
         return Response.json({ value: [] });
       }
+      const secondPage = url.searchParams.has("$skiptoken");
       return Response.json({
-        value: ["crabbox-blue-lobster", "crabbox-blue-lobster-retry"].map((cloudID) => ({
-          id: `${url.pathname}/${cloudID}-pip`,
-          name: `${cloudID}-pip`,
-          tags: ownedAzureTags(),
-        })),
+        value: [secondPage ? "crabbox-blue-lobster-retry" : "crabbox-blue-lobster"].map(
+          (cloudID) => ({
+            id: `${url.pathname}/${cloudID}-pip`,
+            name: `${cloudID}-pip`,
+            tags: ownedAzureTags(),
+          }),
+        ),
+        ...(secondPage
+          ? {}
+          : {
+              nextLink:
+                "https://management.azure.com/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/publicIPAddresses?api-version=2024-05-01&$skiptoken=page-2",
+            }),
       });
     };
 
@@ -337,6 +346,35 @@ describe("azure provider", () => {
         region: "eastus",
       }),
     ).rejects.toThrow("ambiguous Azure recovery");
+  });
+
+  it("fails closed when Azure recovery pagination leaves the management scope", async () => {
+    const client = new AzureClient(baseEnv);
+    seedAzureAuthCache(client);
+    client.fetcher = async (input) => {
+      const url = new URL(String(input));
+      if (!url.pathname.endsWith("/publicIPAddresses")) {
+        return Response.json({ value: [] });
+      }
+      return Response.json({
+        value: [
+          {
+            id: `${url.pathname}/crabbox-blue-lobster-pip`,
+            name: "crabbox-blue-lobster-pip",
+            tags: ownedAzureTags(),
+          },
+        ],
+        nextLink: "https://example.test/subscriptions/sub/resourceGroups/crabbox-leases",
+      });
+    };
+
+    await expect(
+      client.recoverServerForLease({
+        ...ownedAzureLease(),
+        serverType: "Standard_D2ads_v6",
+        region: "eastus",
+      }),
+    ).rejects.toThrow("invalid nextLink");
   });
 
   it("fails closed when an Azure resource claims the lease with mismatched ownership", async () => {


### PR DESCRIPTION
Closes https://github.com/openclaw/crabbox/issues/1226

## What Problem This Solves

Fixes an issue where a coordinator deployment could interrupt Azure provisioning
after a public IP, network interface, or OS disk was created but before the VM
existed, leaving the lease stuck in provisioning and the exact-owned partial
resource set unrecoverable.

## Why This Change Was Made

Azure now discovers all paginated VM, NIC, public-IP, and disk inventory in the
lease's persisted subscription and resource group, derives one canonical cloud
identity from exact lease tags, and hands it to the existing owned cleanup path.
Ambiguous attempts, mismatched ownership, malformed identities, unsafe
pagination links, and inconsistent resource associations fail closed. Generic
coordinator recovery remains provider-neutral.

## User Impact

Operators can deploy coordinator updates during Azure provisioning without
leaking exact-owned partial network or tagged disk resources when the VM never
materializes. No new user credentials, provider credentials, configuration, or
warm-pool capacity are required.

## Evidence

- Production canary on August 3, 2026:
  - deployment versions `e128d117-a256-466a-a38a-c4c5c4c03ff2` and
    `4e0d3fe6-6585-4cb4-8f01-914e121eb91d`
  - lease `cbx_8d1eb6ea1381`
  - no VM existed after the recovery settle window
  - exact-owned
    `crabbox-harbor-barnacle-1143-def365a6-{pip,nic}` resources remained and
    carried the lease, owner, provider, slug, and provider-key tags
- `npm test --prefix worker -- azure.test.ts`: 62 passed
- `npm test --prefix worker`: 1,173 passed, 3 skipped
- `npm run check --prefix worker`
- `npm run lint --prefix worker`
- `npm run format:check --prefix worker`
- `npm run build --prefix worker`
- Fresh branch autoreview: clean, no accepted or actionable findings
