### PR TITLE
fix(daytona): secure reusable snapshot bootstrap

### DIFF
--- a/.github/workflows/daytona-snapshot-bootstrap.yml
+++ b/.github/workflows/daytona-snapshot-bootstrap.yml
@@ -1,0 +1,241 @@
+name: Bootstrap Daytona Snapshot
+run-name: Bootstrap Daytona snapshot ${{ inputs.name }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      name:
+        description: Daytona snapshot name
+        required: true
+        type: string
+      cpu:
+        description: Snapshot CPU cores
+        required: true
+        default: "2"
+        type: choice
+        options:
+          - "1"
+          - "2"
+          - "3"
+          - "4"
+      memoryGiB:
+        description: Snapshot memory in GiB
+        required: true
+        default: "4"
+        type: choice
+        options:
+          - "1"
+          - "2"
+          - "3"
+          - "4"
+          - "5"
+          - "6"
+          - "7"
+          - "8"
+      diskGiB:
+        description: Snapshot disk in GiB
+        required: true
+        default: "10"
+        type: choice
+        options:
+          - "3"
+          - "4"
+          - "5"
+          - "6"
+          - "7"
+          - "8"
+          - "9"
+          - "10"
+      baseImage:
+        description: OCI base image pinned by sha256 digest
+        required: true
+        type: string
+      confirm:
+        description: Type create to confirm this paid provider operation
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: daytona-snapshot-bootstrap
+  cancel-in-progress: false
+
+jobs:
+  guard:
+    name: Guard protected snapshot bootstrap
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require the protected default-branch workflow
+        shell: bash
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          REF_PROTECTED: ${{ github.ref_protected }}
+          RUN_SHA: ${{ github.sha }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+        run: |
+          set -euo pipefail
+          expected_ref="refs/heads/$DEFAULT_BRANCH"
+          expected_workflow_ref="$GITHUB_REPOSITORY/.github/workflows/daytona-snapshot-bootstrap.yml@$expected_ref"
+          [[ "$GITHUB_EVENT_NAME" == workflow_dispatch ]]
+          [[ "$GITHUB_REF" == "$expected_ref" ]]
+          [[ "$GITHUB_WORKFLOW_REF" == "$expected_workflow_ref" ]]
+          [[ "$REF_PROTECTED" == true ]]
+          [[ "$WORKFLOW_SHA" == "$RUN_SHA" ]]
+
+      - name: Validate snapshot inputs
+        shell: bash
+        env:
+          SNAPSHOT_NAME: ${{ inputs.name }}
+          CPU: ${{ inputs.cpu }}
+          MEMORY_GIB: ${{ inputs.memoryGiB }}
+          DISK_GIB: ${{ inputs.diskGiB }}
+          BASE_IMAGE: ${{ inputs.baseImage }}
+          CONFIRM: ${{ inputs.confirm }}
+        run: |
+          set -euo pipefail
+          [[ "$CONFIRM" == create ]]
+          [[ "$SNAPSHOT_NAME" =~ ^[a-zA-Z0-9][a-zA-Z0-9._-]{0,62}$ ]]
+          [[ "$CPU" =~ ^[1-4]$ ]]
+          [[ "$MEMORY_GIB" =~ ^[1-8]$ ]]
+          [[ "$DISK_GIB" =~ ^([3-9]|10)$ ]]
+          [[ "$BASE_IMAGE" =~ @sha256:[a-f0-9]{64}$ ]]
+          [[ "$BASE_IMAGE" != *[[:space:]]* ]]
+
+  bootstrap:
+    name: Create and verify snapshot
+    needs: guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: image-publisher
+    env:
+      CRABBOX_COORDINATOR: ${{ vars.CRABBOX_COORDINATOR }}
+      CRABBOX_COORDINATOR_ADMIN_TOKEN: ${{ secrets.CRABBOX_COORDINATOR_ADMIN_TOKEN }}
+      CRABBOX_ACCESS_CLIENT_ID: ${{ secrets.CRABBOX_ACCESS_CLIENT_ID }}
+      CRABBOX_ACCESS_CLIENT_SECRET: ${{ secrets.CRABBOX_ACCESS_CLIENT_SECRET }}
+      SNAPSHOT_NAME: ${{ inputs.name }}
+      CPU: ${{ inputs.cpu }}
+      MEMORY_GIB: ${{ inputs.memoryGiB }}
+      DISK_GIB: ${{ inputs.diskGiB }}
+      BASE_IMAGE: ${{ inputs.baseImage }}
+    steps:
+      - name: Verify broker configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! "$CRABBOX_COORDINATOR" =~ ^https:// ]]; then
+            echo "::error::Set the HTTPS CRABBOX_COORDINATOR variable on the image-publisher environment."
+            exit 1
+          fi
+          if [[ -z "$CRABBOX_COORDINATOR_ADMIN_TOKEN" ]]; then
+            echo "::error::Set the CRABBOX_COORDINATOR_ADMIN_TOKEN secret on the image-publisher environment."
+            exit 1
+          fi
+          if [[ -n "$CRABBOX_ACCESS_CLIENT_ID" || -n "$CRABBOX_ACCESS_CLIENT_SECRET" ]]; then
+            if [[ -z "$CRABBOX_ACCESS_CLIENT_ID" || -z "$CRABBOX_ACCESS_CLIENT_SECRET" ]]; then
+              echo "::error::Set both Cloudflare Access client secrets or neither."
+              exit 1
+            fi
+          fi
+
+      - name: Check out protected source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+
+      - name: Bootstrap and verify Daytona snapshot
+        shell: bash
+        run: |
+          set -euo pipefail
+          payload="$RUNNER_TEMP/daytona-snapshot-request.json"
+          response="$RUNNER_TEMP/daytona-snapshot-response.json"
+          proof_dir="$RUNNER_TEMP/daytona-snapshot-proof"
+          mkdir -p "$proof_dir"
+
+          jq -n \
+            --arg name "$SNAPSHOT_NAME" \
+            --arg baseImage "$BASE_IMAGE" \
+            --argjson cpu "$CPU" \
+            --argjson memoryGiB "$MEMORY_GIB" \
+            --argjson diskGiB "$DISK_GIB" \
+            '{
+              name: $name,
+              cpu: $cpu,
+              memoryGiB: $memoryGiB,
+              diskGiB: $diskGiB,
+              baseImage: $baseImage,
+              confirm: true
+            }' >"$payload"
+
+          request_headers() {
+            printf 'Authorization: Bearer '
+            printf '%s' "$CRABBOX_COORDINATOR_ADMIN_TOKEN"
+            printf '\n'
+            if [[ -n "$CRABBOX_ACCESS_CLIENT_ID" ]]; then
+              printf 'CF-Access-Client-Id: %s\n' "$CRABBOX_ACCESS_CLIENT_ID"
+              printf 'CF-Access-Client-Secret: %s\n' "$CRABBOX_ACCESS_CLIENT_SECRET"
+            fi
+          }
+
+          request_headers | curl --fail-with-body --silent --show-error \
+            --connect-timeout 10 \
+            --max-time 1200 \
+            -X POST \
+            -H @- \
+            -H 'Content-Type: application/json' \
+            --data-binary @"$payload" \
+            -o "$response" \
+            "${CRABBOX_COORDINATOR%/}/v1/admin/providers/daytona/snapshot-bootstrap"
+
+          jq -e \
+            --arg name "$SNAPSHOT_NAME" \
+            --arg baseImage "$BASE_IMAGE" \
+            --argjson cpu "$CPU" \
+            --argjson memoryGiB "$MEMORY_GIB" \
+            --argjson diskGiB "$DISK_GIB" \
+            '
+              .snapshot.snapshot == $name
+              and .snapshot.sourceSnapshot == $baseImage
+              and .snapshot.cpu == $cpu
+              and .snapshot.memoryGiB == $memoryGiB
+              and .snapshot.diskGiB == $diskGiB
+              and .snapshot.sourceCPU == $cpu
+              and .snapshot.sourceMemoryGiB == $memoryGiB
+              and .snapshot.sourceDiskGiB == $diskGiB
+              and .snapshot.cleanup == "deleted"
+            ' "$response" >/dev/null
+
+          jq '{
+            capturedAt: (now | todateiso8601),
+            snapshot: {
+              name: .snapshot.snapshot,
+              cpu: .snapshot.cpu,
+              memoryGiB: .snapshot.memoryGiB,
+              diskGiB: .snapshot.diskGiB,
+              sourceCPU: .snapshot.sourceCPU,
+              sourceMemoryGiB: .snapshot.sourceMemoryGiB,
+              sourceDiskGiB: .snapshot.sourceDiskGiB,
+              cleanup: .snapshot.cleanup
+            }
+          }' "$response" >"$proof_dir/result.json"
+
+          {
+            echo "## Daytona snapshot bootstrap"
+            echo
+            jq -r '
+              "- Snapshot: `\(.snapshot.name)`",
+              "- Resources: `\(.snapshot.cpu) CPU / \(.snapshot.memoryGiB) GiB / \(.snapshot.diskGiB) GiB`",
+              "- Builder cleanup: `\(.snapshot.cleanup)`"
+            ' "$proof_dir/result.json"
+          } >>"$GITHUB_STEP_SUMMARY"
+
+      - name: Upload sanitized snapshot proof
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: daytona-snapshot-${{ github.run_id }}
+          path: ${{ runner.temp }}/daytona-snapshot-proof
+          if-no-files-found: error
+          retention-days: 30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Added an admin-only Daytona snapshot bootstrap route with bounded resources,
   immutable base images, applied-capacity verification, and fail-safe builder
-  cleanup.
+  cleanup safeguards.
 - Added a protected broker soak workflow that records sanitized AWS/Azure
   maintenance evidence and runs one bounded, cleanup-verified Daytona canary
   without direct provider credentials or a warm pool.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- Added an admin-only Daytona snapshot bootstrap route with bounded resources,
+  immutable base images, applied-capacity verification, and fail-safe builder
+  cleanup.
 - Added a protected broker soak workflow that records sanitized AWS/Azure
   maintenance evidence and runs one bounded, cleanup-verified Daytona canary
   without direct provider credentials or a warm pool.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@
 
 ### Added
 
-- Added an admin-only Daytona snapshot bootstrap route with bounded resources,
-  immutable base images, applied-capacity verification, and fail-safe builder
-  cleanup safeguards.
+- Added an admin-only Daytona snapshot bootstrap route and protected
+  default-branch workflow with bounded resources, immutable base images,
+  applied-capacity verification, sanitized proof, and builder cleanup
+  safeguards.
 - Added a protected broker soak workflow that records sanitized AWS/Azure
   maintenance evidence and runs one bounded, cleanup-verified Daytona canary
   without direct provider credentials or a warm pool.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 - Added an admin-only Daytona snapshot bootstrap route and protected
   default-branch workflow with bounded resources, immutable base images,
-  applied-capacity verification, sanitized proof, and builder cleanup
-  safeguards.
+  applied-capacity and active-snapshot verification, sanitized proof, and
+  completion-verified builder cleanup.
 - Added a protected broker soak workflow that records sanitized AWS/Azure
   maintenance evidence and runs one bounded, cleanup-verified Daytona canary
   without direct provider credentials or a warm pool.

--- a/docs/features/daytona.md
+++ b/docs/features/daytona.md
@@ -176,11 +176,13 @@ explicit `confirm: true` because it creates paid provider resources.
 ```
 
 CPU is limited to 1-4, memory to 1-8 GiB, and disk to 3-10 GiB. `baseImage`
-must use an immutable SHA-256 digest. The coordinator verifies the resources
-Daytona actually applied before snapshotting, deletes the temporary builder on
-success or failure, and configures Daytona to stop an idle builder after 30
-minutes and delete it after it remains stopped for another 60 minutes if the
-Worker cleanup request is lost.
+must use an immutable SHA-256 digest. The coordinator rejects an existing
+snapshot name, verifies the resources Daytona actually applied, waits for the
+new snapshot to become active for up to 20 minutes, and waits for the temporary
+builder to be destroyed or absent before reporting successful cleanup. It also
+configures Daytona to stop an idle builder after 30 minutes and delete it after
+it remains stopped for another 60 minutes if the Worker cleanup request is
+lost.
 
 After this route is deployed, mint a snapshot through the protected
 default-branch workflow. The `image-publisher` environment supplies coordinator

--- a/docs/features/daytona.md
+++ b/docs/features/daytona.md
@@ -50,12 +50,12 @@ Each variable also has a `CRABBOX_`-prefixed form that takes precedence over the
 bare Daytona name (useful when other tooling already owns the unprefixed
 variable):
 
-| Crabbox-prefixed                  | Daytona name               | Config key                |
-| --------------------------------- | -------------------------- | ------------------------- |
-| `CRABBOX_DAYTONA_API_KEY`         | `DAYTONA_API_KEY`          | `daytona.apiKey`          |
-| `CRABBOX_DAYTONA_JWT_TOKEN`       | `DAYTONA_JWT_TOKEN`        | `daytona.jwtToken`        |
-| `CRABBOX_DAYTONA_ORGANIZATION_ID` | `DAYTONA_ORGANIZATION_ID`  | `daytona.organizationId`  |
-| `CRABBOX_DAYTONA_API_URL`         | `DAYTONA_API_URL`          | `daytona.apiUrl`          |
+| Crabbox-prefixed                  | Daytona name              | Config key               |
+| --------------------------------- | ------------------------- | ------------------------ |
+| `CRABBOX_DAYTONA_API_KEY`         | `DAYTONA_API_KEY`         | `daytona.apiKey`         |
+| `CRABBOX_DAYTONA_JWT_TOKEN`       | `DAYTONA_JWT_TOKEN`       | `daytona.jwtToken`       |
+| `CRABBOX_DAYTONA_ORGANIZATION_ID` | `DAYTONA_ORGANIZATION_ID` | `daytona.organizationId` |
+| `CRABBOX_DAYTONA_API_URL`         | `DAYTONA_API_URL`         | `daytona.apiUrl`         |
 
 The API URL defaults to `https://app.daytona.io/api`.
 
@@ -96,15 +96,15 @@ daytona:
   sshAccessMinutes: 30 # SSH access token TTL
 ```
 
-| Config key             | Flag                          | Default                     |
-| ---------------------- | ----------------------------- | --------------------------- |
-| `daytona.snapshot`     | `--daytona-snapshot`          | _(required)_                |
-| `daytona.target`       | `--daytona-target`            | _(empty)_                   |
-| `daytona.user`         | `--daytona-user`              | `daytona`                   |
-| `daytona.workRoot`     | `--daytona-work-root`         | `/home/daytona/crabbox`     |
-| `daytona.sshGatewayHost` | `--daytona-ssh-gateway-host` | `ssh.app.daytona.io`       |
-| `daytona.sshAccessMinutes` | `--daytona-ssh-access-minutes` | `30`                  |
-| `daytona.apiUrl`       | `--daytona-api-url`           | `https://app.daytona.io/api` |
+| Config key                 | Flag                           | Default                      |
+| -------------------------- | ------------------------------ | ---------------------------- |
+| `daytona.snapshot`         | `--daytona-snapshot`           | _(required)_                 |
+| `daytona.target`           | `--daytona-target`             | _(empty)_                    |
+| `daytona.user`             | `--daytona-user`               | `daytona`                    |
+| `daytona.workRoot`         | `--daytona-work-root`          | `/home/daytona/crabbox`      |
+| `daytona.sshGatewayHost`   | `--daytona-ssh-gateway-host`   | `ssh.app.daytona.io`         |
+| `daytona.sshAccessMinutes` | `--daytona-ssh-access-minutes` | `30`                         |
+| `daytona.apiUrl`           | `--daytona-api-url`            | `https://app.daytona.io/api` |
 
 A snapshot is required; `warmup`/`run` fail without `--daytona-snapshot` or
 `daytona.snapshot`.
@@ -156,6 +156,30 @@ lease labels before destructive cleanup, refreshes the SSH token before expiry,
 redacts that token from the portal, and treats an already absent owned sandbox
 as successful cleanup. Workspaces and ready pools are disabled because they
 persist an SSH endpoint beyond the rotating credential.
+
+## Snapshot bootstrap administration
+
+The coordinator exposes `POST /v1/admin/providers/daytona/snapshot-bootstrap`
+for creating a reusable Daytona snapshot without giving clients Daytona
+credentials. The request requires coordinator admin authentication and an
+explicit `confirm: true` because it creates paid provider resources.
+
+```json
+{
+	"name": "crabbox-ready",
+	"cpu": 2,
+	"memoryGiB": 4,
+	"diskGiB": 10,
+	"baseImage": "registry.example/crabbox@sha256:<64 lowercase hex characters>",
+	"confirm": true
+}
+```
+
+CPU is limited to 1-4, memory to 1-8 GiB, and disk to 3-10 GiB. `baseImage`
+must use an immutable SHA-256 digest. The coordinator verifies the resources
+Daytona actually applied before snapshotting, deletes the temporary builder on
+success or failure, and configures an unconditional 30-minute wall-clock TTL
+plus provider-side stop and deletion timers if the Worker request is lost.
 
 See [providers.md](../commands/providers.md) for the full provider matrix and
 [capabilities.md](capabilities.md) for opt-in lease features.

--- a/docs/features/daytona.md
+++ b/docs/features/daytona.md
@@ -178,8 +178,9 @@ explicit `confirm: true` because it creates paid provider resources.
 CPU is limited to 1-4, memory to 1-8 GiB, and disk to 3-10 GiB. `baseImage`
 must use an immutable SHA-256 digest. The coordinator verifies the resources
 Daytona actually applied before snapshotting, deletes the temporary builder on
-success or failure, and configures an unconditional 30-minute wall-clock TTL
-plus provider-side stop and deletion timers if the Worker request is lost.
+success or failure, and configures Daytona to stop an idle builder after 30
+minutes and delete it after it remains stopped for another 60 minutes if the
+Worker cleanup request is lost.
 
 See [providers.md](../commands/providers.md) for the full provider matrix and
 [capabilities.md](capabilities.md) for opt-in lease features.

--- a/docs/features/daytona.md
+++ b/docs/features/daytona.md
@@ -182,5 +182,25 @@ success or failure, and configures Daytona to stop an idle builder after 30
 minutes and delete it after it remains stopped for another 60 minutes if the
 Worker cleanup request is lost.
 
+After this route is deployed, mint a snapshot through the protected
+default-branch workflow. The `image-publisher` environment supplies coordinator
+admin auth, so the operator needs no Daytona credential:
+
+```sh
+gh workflow run daytona-snapshot-bootstrap.yml \
+  --ref main \
+  -f name=crabbox-ready \
+  -f cpu=2 \
+  -f memoryGiB=4 \
+  -f diskGiB=10 \
+  -f "baseImage=registry.example/crabbox@sha256:<digest>" \
+  -f confirm=create
+```
+
+The workflow requires the protected default-branch definition and environment
+approval, serializes snapshot creation, verifies the exact applied resources
+and `cleanup=deleted`, and uploads only sanitized proof without the builder ID
+or coordinator response.
+
 See [providers.md](../commands/providers.md) for the full provider matrix and
 [capabilities.md](capabilities.md) for opt-in lease features.

--- a/scripts/daytona-snapshot-bootstrap-workflow.test.js
+++ b/scripts/daytona-snapshot-bootstrap-workflow.test.js
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const workflow = fs.readFileSync(
+  path.join(repoRoot, ".github", "workflows", "daytona-snapshot-bootstrap.yml"),
+  "utf8",
+);
+
+test("Daytona snapshot bootstrap is protected, manual, and serialized", () => {
+  assert.match(workflow, /^  workflow_dispatch:$/m);
+  assert.doesNotMatch(workflow, /^  (?:push|pull_request|schedule):/m);
+  assert.match(workflow, /environment: image-publisher/);
+  assert.match(workflow, /group: daytona-snapshot-bootstrap/);
+  assert.match(workflow, /cancel-in-progress: false/);
+  assert.match(
+    workflow,
+    /expected_workflow_ref="\$GITHUB_REPOSITORY\/\.github\/workflows\/daytona-snapshot-bootstrap\.yml@\$expected_ref"/,
+  );
+  assert.match(workflow, /\[\[ "\$GITHUB_REF" == "\$expected_ref" \]\]/);
+  assert.match(workflow, /\[\[ "\$REF_PROTECTED" == true \]\]/);
+  assert.match(workflow, /\[\[ "\$WORKFLOW_SHA" == "\$RUN_SHA" \]\]/);
+  assert.match(workflow, /ref: \$\{\{ github\.workflow_sha \}\}/);
+  assert.match(workflow, /persist-credentials: false/);
+});
+
+test("workflow accepts bounded inputs and requires explicit confirmation", () => {
+  for (const input of ["name", "cpu", "memoryGiB", "diskGiB", "baseImage", "confirm"]) {
+    assert.match(workflow, new RegExp(`^      ${input}:$`, "m"));
+  }
+  assert.match(workflow, /\[\[ "\$CONFIRM" == create \]\]/);
+  assert.match(workflow, /\[\[ "\$CPU" =~ \^\[1-4\]\$ \]\]/);
+  assert.match(workflow, /\[\[ "\$MEMORY_GIB" =~ \^\[1-8\]\$ \]\]/);
+  assert.match(workflow, /\[\[ "\$DISK_GIB" =~ \^\(\[3-9\]\|10\)\$ \]\]/);
+  assert.match(workflow, /@sha256:\[a-f0-9\]\{64\}\$/);
+});
+
+test("workflow uses broker admin auth without exposing provider credentials", () => {
+  assert.match(workflow, /CRABBOX_COORDINATOR: \$\{\{ vars\.CRABBOX_COORDINATOR \}\}/);
+  assert.match(
+    workflow,
+    /CRABBOX_COORDINATOR_ADMIN_TOKEN: \$\{\{ secrets\.CRABBOX_COORDINATOR_ADMIN_TOKEN \}\}/,
+  );
+  assert.match(workflow, /printf 'Authorization: Bearer '/);
+  assert.match(workflow, /-H @-/);
+  assert.match(workflow, /--data-binary @"\$payload"/);
+  assert.match(workflow, /\/v1\/admin\/providers\/daytona\/snapshot-bootstrap/);
+  assert.doesNotMatch(
+    workflow,
+    /DAYTONA_API_KEY|DAYTONA_CRABBOX_KEY|AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY/,
+  );
+});
+
+test("workflow verifies exact resources and uploads only sanitized proof", () => {
+  assert.match(workflow, /\.snapshot\.sourceSnapshot == \$baseImage/);
+  assert.match(workflow, /\.snapshot\.sourceCPU == \$cpu/);
+  assert.match(workflow, /\.snapshot\.sourceMemoryGiB == \$memoryGiB/);
+  assert.match(workflow, /\.snapshot\.sourceDiskGiB == \$diskGiB/);
+  assert.match(workflow, /\.snapshot\.cleanup == "deleted"/);
+  assert.match(workflow, /Upload sanitized snapshot proof/);
+  assert.match(workflow, /path: \$\{\{ runner\.temp \}\}\/daytona-snapshot-proof/);
+  assert.doesNotMatch(workflow, /path: \$\{\{ runner\.temp \}\}\/daytona-snapshot-response\.json/);
+  assert.doesNotMatch(workflow, /sandboxID/);
+});

--- a/worker/src/daytona.ts
+++ b/worker/src/daytona.ts
@@ -198,9 +198,13 @@ export class DaytonaClient {
       labels: {
         created_by: "crabbox",
         purpose: "snapshot-bootstrap",
+        snapshot_name: name,
       },
-      autoStopInterval: 0,
-      autoDeleteInterval: -1,
+      // The normal cleanup path deletes immediately. Provider-side expiry keeps a
+      // lost Worker request from leaving a paid bootstrap sandbox indefinitely.
+      autoStopInterval: 30,
+      autoDeleteInterval: 60,
+      ttlMinutes: 30,
       buildInfo: {
         dockerfileContent: `FROM ${baseImage}`,
       },
@@ -215,20 +219,23 @@ export class DaytonaClient {
     let operationError: unknown;
     try {
       const created = await this.request<DaytonaSandbox>("POST", "/sandbox", body);
-      sandboxID = created.id;
+      sandboxID = created.id?.trim() ?? "";
+      if (!sandboxID) {
+        throw new Error("daytona snapshot bootstrap returned no sandbox id");
+      }
       await this.waitForState(sandboxID, ["started", "running", "ready", "active"]);
       const built = await this.getSandbox(sandboxID);
-      if (built.cpu === undefined || built.cpu < cpu) {
+      if (built.cpu !== cpu) {
         throw new Error(
           `daytona sandbox ${sandboxID} has ${built.cpu ?? "unknown"} CPU after ${cpu} CPU image build`,
         );
       }
-      if (built.memory === undefined || built.memory < memoryGiB) {
+      if (built.memory !== memoryGiB) {
         throw new Error(
           `daytona sandbox ${sandboxID} has ${built.memory ?? "unknown"} GiB memory after ${memoryGiB} GiB image build`,
         );
       }
-      if (built.disk === undefined || built.disk < diskGiB) {
+      if (built.disk !== diskGiB) {
         throw new Error(
           `daytona sandbox ${sandboxID} disk is ${built.disk ?? "unknown"} GiB after ${diskGiB} GiB image build`,
         );

--- a/worker/src/daytona.ts
+++ b/worker/src/daytona.ts
@@ -22,6 +22,13 @@ interface DaytonaSandbox {
   disk?: number;
 }
 
+interface DaytonaSnapshot {
+  id: string;
+  name: string;
+  state?: string;
+  errorReason?: string | null;
+}
+
 interface DaytonaSandboxListResponse {
   items?: DaytonaSandbox[];
   nextCursor?: string | null;
@@ -75,6 +82,8 @@ export class DaytonaClient {
   fetcher: typeof fetch = (input, init) => fetch(input, init);
   pollDelayMs = 2_000;
   maxWaitMs = 5 * 60_000;
+  snapshotWaitMs = 20 * 60_000;
+  snapshotAcceptanceWaitMs = 10_000;
 
   private readonly apiURL: string;
   private readonly token: string;
@@ -192,6 +201,8 @@ export class DaytonaClient {
     diskGiB: number,
     baseImage: string,
   ): Promise<DaytonaSnapshotBootstrap> {
+    await this.assertSnapshotAbsent(name);
+
     const body: Record<string, unknown> = {
       name: `crabbox-snapshot-bootstrap-${crypto.randomUUID().slice(0, 8)}`,
       user: this.user,
@@ -215,6 +226,8 @@ export class DaytonaClient {
     if (this.target) body["target"] = this.target;
 
     let sandboxID = "";
+    let snapshotRequested = false;
+    let snapshotRequestConfirmed = false;
     let result: Omit<DaytonaSnapshotBootstrap, "cleanup"> | undefined;
     let operationError: unknown;
     try {
@@ -242,14 +255,16 @@ export class DaytonaClient {
       }
       await this.request<DaytonaSandbox>("POST", `/sandbox/${encodeURIComponent(sandboxID)}/stop`);
       await this.waitForState(sandboxID, ["stopped"]);
-      const snapshotting = await this.request<DaytonaSandbox>(
+      snapshotRequested = true;
+      await this.request<DaytonaSandbox>(
         "POST",
         `/sandbox/${encodeURIComponent(sandboxID)}/snapshot`,
         { name },
       );
-      if (normalizeDaytonaState(snapshotting.state ?? "") === "snapshotting") {
-        await this.waitForState(sandboxID, ["stopped"]);
-      }
+      snapshotRequestConfirmed = true;
+      // Daytona persists snapshot resources from this already verified source
+      // sandbox, so the active snapshot state is the authoritative completion signal.
+      await this.waitForSnapshotActive(name);
       result = {
         sourceSnapshot: baseImage,
         sourceCPU: built.cpu,
@@ -266,7 +281,29 @@ export class DaytonaClient {
     }
 
     try {
-      if (sandboxID) await this.deleteServer(sandboxID);
+      if (sandboxID) {
+        let transitionError: unknown;
+        if (snapshotRequested) {
+          try {
+            await this.waitForSnapshotTransition(sandboxID, !snapshotRequestConfirmed);
+          } catch (error) {
+            transitionError = error;
+          }
+        }
+        try {
+          await this.deleteSandboxAndWait(sandboxID);
+        } catch (deleteError) {
+          if (!transitionError) throw deleteError;
+          const transitionMessage =
+            transitionError instanceof Error ? transitionError.message : String(transitionError);
+          const deleteMessage =
+            deleteError instanceof Error ? deleteError.message : String(deleteError);
+          throw new Error(
+            `daytona sandbox ${sandboxID} snapshot transition observation failed: ${transitionMessage}; deletion also failed: ${deleteMessage}`,
+            { cause: deleteError },
+          );
+        }
+      }
     } catch (cleanupError) {
       if (operationError) {
         const operationMessage =
@@ -335,6 +372,133 @@ export class DaytonaClient {
     );
   }
 
+  private async getSnapshot(idOrName: string): Promise<DaytonaSnapshot> {
+    return await this.request<DaytonaSnapshot>("GET", `/snapshots/${encodeURIComponent(idOrName)}`);
+  }
+
+  private async assertSnapshotAbsent(name: string): Promise<void> {
+    try {
+      const snapshot = await this.getSnapshot(name);
+      throw new Error(
+        `daytona snapshot ${name} already exists (state=${snapshot.state ?? "unknown"})`,
+      );
+    } catch (error) {
+      if (!isDaytonaNotFound(error)) throw error;
+    }
+  }
+
+  private async waitForSnapshotActive(name: string): Promise<DaytonaSnapshot> {
+    const deadline = Date.now() + this.snapshotWaitMs;
+    let lastState = "not_found";
+    while (Date.now() <= deadline) {
+      try {
+        // Snapshot-from-sandbox is asynchronous; the row appears only after the
+        // runner has persisted the image, so 404 remains a pending state here.
+        // oxlint-disable-next-line eslint/no-await-in-loop -- each poll observes the latest provider state.
+        const snapshot = await this.getSnapshot(name);
+        lastState = snapshot.state ?? "";
+        const normalized = normalizeDaytonaState(lastState);
+        if (normalized === "active") return snapshot;
+        if (daytonaSnapshotTerminalState(normalized)) {
+          const reason = snapshot.errorReason?.trim();
+          throw new Error(
+            `daytona snapshot ${name} entered terminal state=${lastState || "unknown"}${reason ? `: ${reason}` : ""}`,
+          );
+        }
+      } catch (error) {
+        if (isDaytonaNotFound(error)) {
+          lastState = "not_found";
+        } else if (isDaytonaTransient(error)) {
+          lastState =
+            error instanceof DaytonaHTTPError ? `http_${error.status}` : "network_unavailable";
+        } else {
+          throw error;
+        }
+      }
+      // oxlint-disable-next-line eslint/no-await-in-loop -- delay between sequential state probes.
+      await new Promise((resolve) => setTimeout(resolve, this.pollDelayMs));
+    }
+    throw new Error(
+      `timed out waiting for daytona snapshot ${name} to become active (state=${lastState || "unknown"})`,
+    );
+  }
+
+  private async deleteSandboxAndWait(id: string): Promise<void> {
+    const deadline = Date.now() + this.maxWaitMs;
+    let deleteRequested = false;
+    let lastState = "";
+    while (Date.now() <= deadline) {
+      if (!deleteRequested) {
+        try {
+          // DELETE returns 409 while snapshotting or another state change is
+          // pending. Retry that authoritative conflict instead of abandoning cleanup.
+          // deleteServer already normalizes an already-absent sandbox to success.
+          // oxlint-disable-next-line eslint/no-await-in-loop -- each retry observes provider state.
+          await this.deleteServer(id);
+          deleteRequested = true;
+        } catch (error) {
+          if (!isDaytonaConflict(error)) throw error;
+          lastState = "state_change_in_progress";
+          // oxlint-disable-next-line eslint/no-await-in-loop -- delay between sequential cleanup retries.
+          await new Promise((resolve) => setTimeout(resolve, this.pollDelayMs));
+          continue;
+        }
+      }
+      try {
+        // DELETE only requests Daytona's asynchronous soft-delete transition.
+        // Do not report cleanup until provider teardown reaches its terminal state.
+        // oxlint-disable-next-line eslint/no-await-in-loop -- each poll observes the latest provider state.
+        const sandbox = await this.getSandbox(id);
+        lastState = sandbox.state ?? "";
+        const normalized = normalizeDaytonaState(lastState);
+        if (normalized === "destroyed" || normalized === "deleted") return;
+      } catch (error) {
+        if (isDaytonaNotFound(error)) return;
+        if (isDaytonaTransient(error)) {
+          lastState =
+            error instanceof DaytonaHTTPError ? `http_${error.status}` : "network_unavailable";
+        } else {
+          throw error;
+        }
+      }
+      // oxlint-disable-next-line eslint/no-await-in-loop -- delay between sequential cleanup probes.
+      await new Promise((resolve) => setTimeout(resolve, this.pollDelayMs));
+    }
+    throw new Error(
+      `timed out waiting for daytona sandbox ${id} cleanup (state=${lastState || "unknown"})`,
+    );
+  }
+
+  private async waitForSnapshotTransition(id: string, uncertainAcceptance: boolean): Promise<void> {
+    const startedAt = Date.now();
+    const deadline = startedAt + (uncertainAcceptance ? this.snapshotWaitMs : this.maxWaitMs);
+    const acceptanceDeadline = startedAt + Math.min(this.snapshotAcceptanceWaitMs, this.maxWaitMs);
+    let sawSnapshotting = false;
+    let lastState = "";
+    while (Date.now() <= deadline) {
+      try {
+        // Daytona persists the active snapshot before clearing the sandbox's
+        // pending snapshot transition. DELETE is rejected until this state clears.
+        // oxlint-disable-next-line eslint/no-await-in-loop -- each poll observes the latest provider state.
+        const sandbox = await this.getSandbox(id);
+        lastState = sandbox.state ?? "";
+        if (normalizeDaytonaState(lastState) === "snapshotting") {
+          sawSnapshotting = true;
+        } else if (sawSnapshotting || !uncertainAcceptance || Date.now() >= acceptanceDeadline) {
+          return;
+        }
+      } catch (error) {
+        if (isDaytonaNotFound(error)) return;
+        throw error;
+      }
+      // oxlint-disable-next-line eslint/no-await-in-loop -- delay between sequential state probes.
+      await new Promise((resolve) => setTimeout(resolve, this.pollDelayMs));
+    }
+    throw new Error(
+      `timed out waiting for daytona sandbox ${id} snapshot transition (state=${lastState || "unknown"})`,
+    );
+  }
+
   private async waitForState(id: string, expectedStates: string[]): Promise<DaytonaSandbox> {
     const expected = new Set(expectedStates.map(normalizeDaytonaState));
     const deadline = Date.now() + this.maxWaitMs;
@@ -399,6 +563,17 @@ export function isDaytonaNotFound(error: unknown): boolean {
   return error instanceof DaytonaHTTPError && error.status === 404;
 }
 
+function isDaytonaConflict(error: unknown): boolean {
+  return error instanceof DaytonaHTTPError && error.status === 409;
+}
+
+function isDaytonaTransient(error: unknown): boolean {
+  return (
+    error instanceof TypeError ||
+    (error instanceof DaytonaHTTPError && (error.status === 429 || error.status >= 500))
+  );
+}
+
 function daytonaMachine(sandbox: DaytonaSandbox): ProviderMachine {
   return {
     provider: "daytona",
@@ -432,6 +607,10 @@ function daytonaTerminalState(state: string): boolean {
     "destroying",
     "deleted",
   ].includes(normalizeDaytonaState(state));
+}
+
+function daytonaSnapshotTerminalState(state: string): boolean {
+  return ["inactive", "error", "build_failed", "removing"].includes(normalizeDaytonaState(state));
 }
 
 function daytonaReadyState(state: string): boolean {

--- a/worker/src/daytona.ts
+++ b/worker/src/daytona.ts
@@ -181,7 +181,11 @@ export class DaytonaClient {
     }
   }
 
-  async bootstrapSnapshot(name: string, diskGiB: number): Promise<DaytonaSnapshotBootstrap> {
+  async bootstrapSnapshot(
+    name: string,
+    diskGiB: number,
+    baseImage: string,
+  ): Promise<DaytonaSnapshotBootstrap> {
     const body: Record<string, unknown> = {
       name: `crabbox-snapshot-bootstrap-${crypto.randomUUID().slice(0, 8)}`,
       user: this.user,
@@ -191,8 +195,11 @@ export class DaytonaClient {
       },
       autoStopInterval: 0,
       autoDeleteInterval: -1,
+      buildInfo: {
+        dockerfileContent: `FROM ${baseImage}`,
+      },
+      disk: diskGiB,
     };
-    if (this.snapshot) body["snapshot"] = this.snapshot;
     if (this.target) body["target"] = this.target;
 
     let sandboxID = "";
@@ -202,21 +209,14 @@ export class DaytonaClient {
       const created = await this.request<DaytonaSandbox>("POST", "/sandbox", body);
       sandboxID = created.id;
       await this.waitForState(sandboxID, ["started", "running", "ready", "active"]);
-      const source = await this.getSandbox(sandboxID);
-
-      await this.request<DaytonaSandbox>("POST", `/sandbox/${encodeURIComponent(sandboxID)}/stop`);
-      await this.waitForState(sandboxID, ["stopped"]);
-      await this.request<DaytonaSandbox>(
-        "POST",
-        `/sandbox/${encodeURIComponent(sandboxID)}/resize`,
-        { disk: diskGiB },
-      );
-      const resized = await this.waitForState(sandboxID, ["stopped"]);
-      if (resized.disk !== undefined && resized.disk < diskGiB) {
+      const built = await this.getSandbox(sandboxID);
+      if (built.disk !== undefined && built.disk < diskGiB) {
         throw new Error(
-          `daytona sandbox ${sandboxID} disk remained ${resized.disk} GiB after ${diskGiB} GiB resize`,
+          `daytona sandbox ${sandboxID} disk is ${built.disk} GiB after ${diskGiB} GiB image build`,
         );
       }
+      await this.request<DaytonaSandbox>("POST", `/sandbox/${encodeURIComponent(sandboxID)}/stop`);
+      await this.waitForState(sandboxID, ["stopped"]);
       const snapshotting = await this.request<DaytonaSandbox>(
         "POST",
         `/sandbox/${encodeURIComponent(sandboxID)}/snapshot`,
@@ -226,10 +226,10 @@ export class DaytonaClient {
         await this.waitForState(sandboxID, ["stopped"]);
       }
       result = {
-        sourceSnapshot: source.snapshot?.trim() || "account-default",
-        ...(source.disk === undefined ? {} : { sourceDiskGiB: source.disk }),
+        sourceSnapshot: baseImage,
+        ...(built.disk === undefined ? {} : { sourceDiskGiB: built.disk }),
         snapshot: name,
-        diskGiB: resized.disk ?? diskGiB,
+        diskGiB: built.disk ?? diskGiB,
         sandboxID,
       };
     } catch (error) {

--- a/worker/src/daytona.ts
+++ b/worker/src/daytona.ts
@@ -200,11 +200,11 @@ export class DaytonaClient {
         purpose: "snapshot-bootstrap",
         snapshot_name: name,
       },
-      // The normal cleanup path deletes immediately. Provider-side expiry keeps a
-      // lost Worker request from leaving a paid bootstrap sandbox indefinitely.
+      // The normal cleanup path deletes immediately. If that request is lost,
+      // Daytona stops an idle builder after 30 minutes and deletes it after it
+      // remains stopped for another 60 minutes.
       autoStopInterval: 30,
       autoDeleteInterval: 60,
-      ttlMinutes: 30,
       buildInfo: {
         dockerfileContent: `FROM ${baseImage}`,
       },

--- a/worker/src/daytona.ts
+++ b/worker/src/daytona.ts
@@ -17,6 +17,9 @@ interface DaytonaSandbox {
   labels?: Record<string, string>;
   target?: string;
   state?: string;
+  cpu?: number;
+  memory?: number;
+  disk?: number;
 }
 
 interface DaytonaSandboxListResponse {
@@ -35,6 +38,15 @@ export interface DaytonaSSHEndpoint {
   host: string;
   port: string;
   expiresAt: string;
+}
+
+export interface DaytonaSnapshotBootstrap {
+  sourceSnapshot: string;
+  sourceDiskGiB?: number;
+  snapshot: string;
+  diskGiB: number;
+  sandboxID: string;
+  cleanup: "deleted";
 }
 
 export class DaytonaHTTPError extends Error {
@@ -113,9 +125,7 @@ export class DaytonaClient {
   }
 
   async getServer(id: string): Promise<ProviderMachine> {
-    return daytonaMachine(
-      await this.request<DaytonaSandbox>("GET", `/sandbox/${encodeURIComponent(id)}?verbose=true`),
-    );
+    return daytonaMachine(await this.getSandbox(id));
   }
 
   async createServer(
@@ -171,6 +181,81 @@ export class DaytonaClient {
     }
   }
 
+  async bootstrapSnapshot(name: string, diskGiB: number): Promise<DaytonaSnapshotBootstrap> {
+    const body: Record<string, unknown> = {
+      name: `crabbox-snapshot-bootstrap-${crypto.randomUUID().slice(0, 8)}`,
+      user: this.user,
+      labels: {
+        created_by: "crabbox",
+        purpose: "snapshot-bootstrap",
+      },
+      autoStopInterval: 0,
+      autoDeleteInterval: -1,
+    };
+    if (this.snapshot) body["snapshot"] = this.snapshot;
+    if (this.target) body["target"] = this.target;
+
+    let sandboxID = "";
+    let result: Omit<DaytonaSnapshotBootstrap, "cleanup"> | undefined;
+    let operationError: unknown;
+    try {
+      const created = await this.request<DaytonaSandbox>("POST", "/sandbox", body);
+      sandboxID = created.id;
+      await this.waitForState(sandboxID, ["started", "running", "ready", "active"]);
+      const source = await this.getSandbox(sandboxID);
+
+      await this.request<DaytonaSandbox>("POST", `/sandbox/${encodeURIComponent(sandboxID)}/stop`);
+      await this.waitForState(sandboxID, ["stopped"]);
+      await this.request<DaytonaSandbox>(
+        "POST",
+        `/sandbox/${encodeURIComponent(sandboxID)}/resize`,
+        { disk: diskGiB },
+      );
+      const resized = await this.waitForState(sandboxID, ["stopped"]);
+      if (resized.disk !== undefined && resized.disk < diskGiB) {
+        throw new Error(
+          `daytona sandbox ${sandboxID} disk remained ${resized.disk} GiB after ${diskGiB} GiB resize`,
+        );
+      }
+      const snapshotting = await this.request<DaytonaSandbox>(
+        "POST",
+        `/sandbox/${encodeURIComponent(sandboxID)}/snapshot`,
+        { name },
+      );
+      if (normalizeDaytonaState(snapshotting.state ?? "") === "snapshotting") {
+        await this.waitForState(sandboxID, ["stopped"]);
+      }
+      result = {
+        sourceSnapshot: source.snapshot?.trim() || "account-default",
+        ...(source.disk === undefined ? {} : { sourceDiskGiB: source.disk }),
+        snapshot: name,
+        diskGiB: resized.disk ?? diskGiB,
+        sandboxID,
+      };
+    } catch (error) {
+      operationError = error;
+    }
+
+    try {
+      if (sandboxID) await this.deleteServer(sandboxID);
+    } catch (cleanupError) {
+      if (operationError) {
+        const operationMessage =
+          operationError instanceof Error ? operationError.message : String(operationError);
+        const cleanupMessage =
+          cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
+        throw new Error(
+          `daytona snapshot bootstrap failed: ${operationMessage}; sandbox ${sandboxID} cleanup also failed: ${cleanupMessage}`,
+          { cause: cleanupError },
+        );
+      }
+      throw cleanupError;
+    }
+    if (operationError) throw operationError;
+    if (!result) throw new Error("daytona snapshot bootstrap completed without a result");
+    return { ...result, cleanup: "deleted" };
+  }
+
   async createSSHAccess(
     id: string,
     lease?: Pick<LeaseRecord, "expiresAt">,
@@ -212,6 +297,33 @@ export class DaytonaClient {
     }
     const responseBody = await response.text();
     return responseBody.trim() ? (JSON.parse(responseBody) as T) : (undefined as T);
+  }
+
+  private async getSandbox(id: string): Promise<DaytonaSandbox> {
+    return await this.request<DaytonaSandbox>(
+      "GET",
+      `/sandbox/${encodeURIComponent(id)}?verbose=true`,
+    );
+  }
+
+  private async waitForState(id: string, expectedStates: string[]): Promise<DaytonaSandbox> {
+    const expected = new Set(expectedStates.map(normalizeDaytonaState));
+    const deadline = Date.now() + this.maxWaitMs;
+    let lastState = "";
+    while (Date.now() <= deadline) {
+      // oxlint-disable-next-line eslint/no-await-in-loop -- each poll observes the latest provider state.
+      const sandbox = await this.getSandbox(id);
+      lastState = sandbox.state ?? "";
+      if (expected.has(normalizeDaytonaState(lastState))) return sandbox;
+      if (daytonaTerminalState(lastState)) {
+        throw new Error(`daytona sandbox ${id} entered terminal state=${lastState}`);
+      }
+      // oxlint-disable-next-line eslint/no-await-in-loop -- delay between sequential state probes.
+      await new Promise((resolve) => setTimeout(resolve, this.pollDelayMs));
+    }
+    throw new Error(
+      `timed out waiting for daytona sandbox ${id} state=${expectedStates.join("|")} (state=${lastState || "unknown"})`,
+    );
   }
 }
 

--- a/worker/src/daytona.ts
+++ b/worker/src/daytona.ts
@@ -42,8 +42,12 @@ export interface DaytonaSSHEndpoint {
 
 export interface DaytonaSnapshotBootstrap {
   sourceSnapshot: string;
-  sourceDiskGiB?: number;
+  sourceCPU: number;
+  sourceMemoryGiB: number;
+  sourceDiskGiB: number;
   snapshot: string;
+  cpu: number;
+  memoryGiB: number;
   diskGiB: number;
   sandboxID: string;
   cleanup: "deleted";
@@ -183,6 +187,8 @@ export class DaytonaClient {
 
   async bootstrapSnapshot(
     name: string,
+    cpu: number,
+    memoryGiB: number,
     diskGiB: number,
     baseImage: string,
   ): Promise<DaytonaSnapshotBootstrap> {
@@ -198,6 +204,8 @@ export class DaytonaClient {
       buildInfo: {
         dockerfileContent: `FROM ${baseImage}`,
       },
+      cpu,
+      memory: memoryGiB,
       disk: diskGiB,
     };
     if (this.target) body["target"] = this.target;
@@ -210,9 +218,19 @@ export class DaytonaClient {
       sandboxID = created.id;
       await this.waitForState(sandboxID, ["started", "running", "ready", "active"]);
       const built = await this.getSandbox(sandboxID);
-      if (built.disk !== undefined && built.disk < diskGiB) {
+      if (built.cpu === undefined || built.cpu < cpu) {
         throw new Error(
-          `daytona sandbox ${sandboxID} disk is ${built.disk} GiB after ${diskGiB} GiB image build`,
+          `daytona sandbox ${sandboxID} has ${built.cpu ?? "unknown"} CPU after ${cpu} CPU image build`,
+        );
+      }
+      if (built.memory === undefined || built.memory < memoryGiB) {
+        throw new Error(
+          `daytona sandbox ${sandboxID} has ${built.memory ?? "unknown"} GiB memory after ${memoryGiB} GiB image build`,
+        );
+      }
+      if (built.disk === undefined || built.disk < diskGiB) {
+        throw new Error(
+          `daytona sandbox ${sandboxID} disk is ${built.disk ?? "unknown"} GiB after ${diskGiB} GiB image build`,
         );
       }
       await this.request<DaytonaSandbox>("POST", `/sandbox/${encodeURIComponent(sandboxID)}/stop`);
@@ -227,9 +245,13 @@ export class DaytonaClient {
       }
       result = {
         sourceSnapshot: baseImage,
-        ...(built.disk === undefined ? {} : { sourceDiskGiB: built.disk }),
+        sourceCPU: built.cpu,
+        sourceMemoryGiB: built.memory,
+        sourceDiskGiB: built.disk,
         snapshot: name,
-        diskGiB: built.disk ?? diskGiB,
+        cpu: built.cpu,
+        memoryGiB: built.memory,
+        diskGiB: built.disk,
         sandboxID,
       };
     } catch (error) {

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -1025,6 +1025,7 @@ export class FleetCoordinator {
   private readonly runtimeAdapterAgents = new Map<string, WebSocket>();
   private readonly runtimeAdapterPending = new Map<string, RuntimeAdapterPendingRequest>();
   private readonly runtimeAdapterDeleteQueues = new Map<string, Promise<void>>();
+  private readonly daytonaSnapshotBootstrapQueues = new Map<string, Promise<void>>();
   private readonly controlSockets = new Map<string, WebSocket>();
   private readonly workspaceTerminals = new Map<string, Set<WebSocket>>();
   private readonly restoredBridgeSockets = new Set<WebSocket>();
@@ -12042,6 +12043,9 @@ export class FleetCoordinator {
         { status: 400 },
       );
     }
+    const cpu = input.cpu;
+    const memoryGiB = input.memoryGiB;
+    const diskGiB = input.diskGiB;
     const baseImage = typeof input.baseImage === "string" ? input.baseImage.trim() : "";
     if (!isImmutableOCIImageReference(baseImage)) {
       return json(
@@ -12052,14 +12056,16 @@ export class FleetCoordinator {
         { status: 400 },
       );
     }
-    const result = await new DaytonaClient(this.env).bootstrapSnapshot(
-      name,
-      input.cpu,
-      input.memoryGiB,
-      input.diskGiB,
-      baseImage,
-    );
-    return json({ snapshot: result });
+    return await this.withDaytonaSnapshotBootstrapLock(name, async () => {
+      const result = await new DaytonaClient(this.env).bootstrapSnapshot(
+        name,
+        cpu,
+        memoryGiB,
+        diskGiB,
+        baseImage,
+      );
+      return json({ snapshot: result });
+    });
   }
 
   private async adminTailscalePreflight(): Promise<Response> {
@@ -14651,6 +14657,31 @@ export class FleetCoordinator {
       return await operation();
     } finally {
       release();
+    }
+  }
+
+  private async withDaytonaSnapshotBootstrapLock<T>(
+    name: string,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    let release!: () => void;
+    const previous =
+      this.daytonaSnapshotBootstrapQueues.get(name)?.catch(() => {}) ?? Promise.resolve();
+    const next = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const tail = previous.then(() => next);
+    this.daytonaSnapshotBootstrapQueues.set(name, tail);
+    await previous;
+    try {
+      // Daytona exposes async snapshot completion by name, so same-name
+      // bootstraps must not overlap and observe another request's active row.
+      return await operation();
+    } finally {
+      release();
+      if (this.daytonaSnapshotBootstrapQueues.get(name) === tail) {
+        this.daytonaSnapshotBootstrapQueues.delete(name);
+      }
     }
   }
 

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -11987,15 +11987,37 @@ export class FleetCoordinator {
   }
 
   private async adminDaytonaSnapshotBootstrap(request: Request): Promise<Response> {
-    const input = await readJson<{ name?: unknown; diskGiB?: unknown; baseImage?: unknown }>(
-      request,
-    );
+    const input = await readJson<{
+      name?: unknown;
+      cpu?: unknown;
+      memoryGiB?: unknown;
+      diskGiB?: unknown;
+      baseImage?: unknown;
+    }>(request);
     const name = typeof input.name === "string" ? input.name.trim() : "";
     if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]{0,62}$/.test(name)) {
       return json(
         {
           error: "invalid_snapshot_name",
           message: "name must be 1-63 letters, numbers, dots, underscores, or hyphens",
+        },
+        { status: 400 },
+      );
+    }
+    if (input.cpu !== 2) {
+      return json(
+        {
+          error: "invalid_snapshot_cpu",
+          message: "temporary Daytona snapshot bootstrap requires cpu=2",
+        },
+        { status: 400 },
+      );
+    }
+    if (input.memoryGiB !== 4) {
+      return json(
+        {
+          error: "invalid_snapshot_memory",
+          message: "temporary Daytona snapshot bootstrap requires memoryGiB=4",
         },
         { status: 400 },
       );
@@ -12021,6 +12043,8 @@ export class FleetCoordinator {
     }
     const result = await new DaytonaClient(this.env).bootstrapSnapshot(
       name,
+      input.cpu,
+      input.memoryGiB,
       input.diskGiB,
       baseImage,
     );

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -1150,6 +1150,12 @@ export class FleetCoordinator {
       if (method === "GET" && parts.join("/") === "v1/admin/providers/identity") {
         return await this.adminProviderIdentity(request);
       }
+      if (
+        method === "POST" &&
+        parts.join("/") === "v1/admin/providers/daytona/snapshot-bootstrap"
+      ) {
+        return await this.adminDaytonaSnapshotBootstrap(request);
+      }
       if (method === "POST" && parts.join("/") === "v1/admin/tailscale-preflight") {
         return await this.adminTailscalePreflight();
       }
@@ -11980,6 +11986,31 @@ export class FleetCoordinator {
     return await this.adminAWSIdentity(request);
   }
 
+  private async adminDaytonaSnapshotBootstrap(request: Request): Promise<Response> {
+    const input = await readJson<{ name?: unknown; diskGiB?: unknown }>(request);
+    const name = typeof input.name === "string" ? input.name.trim() : "";
+    if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]{0,62}$/.test(name)) {
+      return json(
+        {
+          error: "invalid_snapshot_name",
+          message: "name must be 1-63 letters, numbers, dots, underscores, or hyphens",
+        },
+        { status: 400 },
+      );
+    }
+    if (input.diskGiB !== 10) {
+      return json(
+        {
+          error: "invalid_snapshot_disk",
+          message: "temporary Daytona snapshot bootstrap requires diskGiB=10",
+        },
+        { status: 400 },
+      );
+    }
+    const result = await new DaytonaClient(this.env).bootstrapSnapshot(name, input.diskGiB);
+    return json({ snapshot: result });
+  }
+
   private async adminTailscalePreflight(): Promise<Response> {
     return json({ tailscale: await tailscalePreflight(this.env) });
   }
@@ -18492,6 +18523,9 @@ function isAdminRoute(method: string, parts: string[]): boolean {
     return true;
   }
   if (method === "GET" && parts.join("/") === "v1/admin/providers/identity") {
+    return true;
+  }
+  if (method === "POST" && parts.join("/") === "v1/admin/providers/daytona/snapshot-bootstrap") {
     return true;
   }
   if (method === "POST" && parts.join("/") === "v1/admin/tailscale-preflight") {

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -11987,7 +11987,9 @@ export class FleetCoordinator {
   }
 
   private async adminDaytonaSnapshotBootstrap(request: Request): Promise<Response> {
-    const input = await readJson<{ name?: unknown; diskGiB?: unknown }>(request);
+    const input = await readJson<{ name?: unknown; diskGiB?: unknown; baseImage?: unknown }>(
+      request,
+    );
     const name = typeof input.name === "string" ? input.name.trim() : "";
     if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]{0,62}$/.test(name)) {
       return json(
@@ -12007,7 +12009,21 @@ export class FleetCoordinator {
         { status: 400 },
       );
     }
-    const result = await new DaytonaClient(this.env).bootstrapSnapshot(name, input.diskGiB);
+    const baseImage = typeof input.baseImage === "string" ? input.baseImage.trim() : "";
+    if (!/^[a-zA-Z0-9][a-zA-Z0-9._/:@-]{0,254}$/.test(baseImage)) {
+      return json(
+        {
+          error: "invalid_base_image",
+          message: "baseImage must be a single OCI image reference",
+        },
+        { status: 400 },
+      );
+    }
+    const result = await new DaytonaClient(this.env).bootstrapSnapshot(
+      name,
+      input.diskGiB,
+      baseImage,
+    );
     return json({ snapshot: result });
   }
 

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -11993,7 +11993,18 @@ export class FleetCoordinator {
       memoryGiB?: unknown;
       diskGiB?: unknown;
       baseImage?: unknown;
+      confirm?: unknown;
     }>(request);
+    if (input.confirm !== true) {
+      return json(
+        {
+          error: "snapshot_bootstrap_confirmation_required",
+          message:
+            "confirm=true is required because this operation creates paid provider resources",
+        },
+        { status: 400 },
+      );
+    }
     const name = typeof input.name === "string" ? input.name.trim() : "";
     if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]{0,62}$/.test(name)) {
       return json(
@@ -12004,39 +12015,39 @@ export class FleetCoordinator {
         { status: 400 },
       );
     }
-    if (input.cpu !== 2) {
+    if (!integerInRange(input.cpu, 1, 4)) {
       return json(
         {
           error: "invalid_snapshot_cpu",
-          message: "temporary Daytona snapshot bootstrap requires cpu=2",
+          message: "cpu must be an integer from 1 through 4",
         },
         { status: 400 },
       );
     }
-    if (input.memoryGiB !== 4) {
+    if (!integerInRange(input.memoryGiB, 1, 8)) {
       return json(
         {
           error: "invalid_snapshot_memory",
-          message: "temporary Daytona snapshot bootstrap requires memoryGiB=4",
+          message: "memoryGiB must be an integer from 1 through 8",
         },
         { status: 400 },
       );
     }
-    if (input.diskGiB !== 10) {
+    if (!integerInRange(input.diskGiB, 3, 10)) {
       return json(
         {
           error: "invalid_snapshot_disk",
-          message: "temporary Daytona snapshot bootstrap requires diskGiB=10",
+          message: "diskGiB must be an integer from 3 through 10",
         },
         { status: 400 },
       );
     }
     const baseImage = typeof input.baseImage === "string" ? input.baseImage.trim() : "";
-    if (!/^[a-zA-Z0-9][a-zA-Z0-9._/:@-]{0,254}$/.test(baseImage)) {
+    if (!isImmutableOCIImageReference(baseImage)) {
       return json(
         {
           error: "invalid_base_image",
-          message: "baseImage must be a single OCI image reference",
+          message: "baseImage must be an OCI image reference pinned by sha256 digest",
         },
         { status: 400 },
       );
@@ -18498,6 +18509,64 @@ function clampLimit(value: string | null, fallback: number): number {
     return fallback;
   }
   return Math.min(Math.trunc(parsed), 500);
+}
+
+function integerInRange(value: unknown, minimum: number, maximum: number): value is number {
+  return Number.isInteger(value) && Number(value) >= minimum && Number(value) <= maximum;
+}
+
+function isImmutableOCIImageReference(value: string): boolean {
+  const match = /^(.*)@sha256:([a-f0-9]{64})$/.exec(value);
+  if (!match) return false;
+  let name = match[1] ?? "";
+  const lastSlash = name.lastIndexOf("/");
+  const lastColon = name.lastIndexOf(":");
+  if (lastColon > lastSlash) {
+    const tag = name.slice(lastColon + 1);
+    if (!/^[\w][\w.-]{0,127}$/.test(tag)) return false;
+    name = name.slice(0, lastColon);
+  }
+  if (!name || name.length > 255) return false;
+
+  const components = name.split("/");
+  if (components.some((component) => !component)) return false;
+  const first = components[0] ?? "";
+  const hasRegistryAuthority =
+    components.length > 1 &&
+    (first === "localhost" || first.includes(".") || first.includes(":") || first.startsWith("["));
+  if (hasRegistryAuthority && !isOCIRegistryAuthority(first)) return false;
+
+  const repositoryComponents = hasRegistryAuthority ? components.slice(1) : components;
+  return repositoryComponents.every((component) =>
+    /^[a-z0-9]+(?:(?:[._]|__|-+)[a-z0-9]+)*$/.test(component),
+  );
+}
+
+function isOCIRegistryAuthority(value: string): boolean {
+  if (value.startsWith("[")) {
+    try {
+      const parsed = new URL(`https://${value}`);
+      return (
+        parsed.hostname.startsWith("[") &&
+        parsed.pathname === "/" &&
+        !parsed.username &&
+        !parsed.password &&
+        !parsed.search &&
+        !parsed.hash
+      );
+    } catch {
+      return false;
+    }
+  }
+  const domainComponent = "[a-z0-9](?:[a-z0-9-]*[a-z0-9])?";
+  const domain = `(?:${domainComponent})(?:\\.${domainComponent})*`;
+  if (!new RegExp(`^${domain}(?::[0-9]+)?$`, "i").test(value)) return false;
+  try {
+    const parsed = new URL(`https://${value}`);
+    return parsed.pathname === "/" && !parsed.username && !parsed.password && !parsed.search;
+  } catch {
+    return false;
+  }
 }
 
 function orgFilterKey(url: URL): string | null | undefined {

--- a/worker/test/daytona.test.ts
+++ b/worker/test/daytona.test.ts
@@ -182,6 +182,114 @@ describe("daytona coordinator client", () => {
     await expect(client.deleteServer("sandbox-one")).rejects.toThrow("http 503");
   });
 
+  it("creates a larger snapshot from the configured base and deletes its builder", async () => {
+    const calls: Array<{ method: string; path: string; body?: unknown }> = [];
+    let state = "creating";
+    let disk = 3;
+    const client = new DaytonaClient(baseEnv);
+    client.pollDelayMs = 0;
+    client.fetcher = vi.fn<typeof fetch>(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = new Request(input, init);
+      const url = new URL(request.url);
+      const body = request.body ? await request.clone().json() : undefined;
+      calls.push({ method: request.method, path: url.pathname, ...(body ? { body } : {}) });
+      if (request.method === "POST" && url.pathname === "/api/sandbox") {
+        state = "started";
+        return Response.json({
+          id: "snapshot-builder",
+          name: "crabbox-snapshot-bootstrap-test",
+          snapshot: "crabbox-ready",
+          state: "creating",
+          disk,
+        });
+      }
+      if (request.method === "GET" && url.pathname === "/api/sandbox/snapshot-builder") {
+        return Response.json({
+          id: "snapshot-builder",
+          name: "crabbox-snapshot-bootstrap-test",
+          snapshot: "crabbox-ready",
+          state,
+          disk,
+        });
+      }
+      if (request.method === "POST" && url.pathname.endsWith("/stop")) {
+        state = "stopped";
+        return Response.json({ id: "snapshot-builder", state });
+      }
+      if (request.method === "POST" && url.pathname.endsWith("/resize")) {
+        disk = (body as { disk: number }).disk;
+        return Response.json({ id: "snapshot-builder", state, disk });
+      }
+      if (request.method === "POST" && url.pathname.endsWith("/snapshot")) {
+        return Response.json({ id: "snapshot-builder", state: "snapshotting", disk });
+      }
+      if (request.method === "DELETE" && url.pathname.endsWith("/snapshot-builder")) {
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`unexpected request ${request.method} ${request.url}`);
+    });
+
+    await expect(client.bootstrapSnapshot("crabbox-ready-10g", 10)).resolves.toEqual({
+      sourceSnapshot: "crabbox-ready",
+      sourceDiskGiB: 3,
+      snapshot: "crabbox-ready-10g",
+      diskGiB: 10,
+      sandboxID: "snapshot-builder",
+      cleanup: "deleted",
+    });
+    expect(calls.map(({ method, path }) => `${method} ${path}`)).toEqual([
+      "POST /api/sandbox",
+      "GET /api/sandbox/snapshot-builder",
+      "GET /api/sandbox/snapshot-builder",
+      "POST /api/sandbox/snapshot-builder/stop",
+      "GET /api/sandbox/snapshot-builder",
+      "POST /api/sandbox/snapshot-builder/resize",
+      "GET /api/sandbox/snapshot-builder",
+      "POST /api/sandbox/snapshot-builder/snapshot",
+      "GET /api/sandbox/snapshot-builder",
+      "DELETE /api/sandbox/snapshot-builder",
+    ]);
+    expect(calls[0]?.body).toMatchObject({
+      snapshot: "crabbox-ready",
+      labels: {
+        created_by: "crabbox",
+        purpose: "snapshot-bootstrap",
+      },
+    });
+    expect(calls[0]?.body).not.toMatchObject({
+      labels: { crabbox: "true" },
+    });
+    expect(calls[5]?.body).toEqual({ disk: 10 });
+    expect(calls[7]?.body).toEqual({ name: "crabbox-ready-10g" });
+  });
+
+  it("deletes the builder when Daytona snapshot bootstrap fails", async () => {
+    const methods: string[] = [];
+    const client = new DaytonaClient(baseEnv);
+    client.pollDelayMs = 0;
+    client.fetcher = vi.fn<typeof fetch>(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = new Request(input, init);
+      const url = new URL(request.url);
+      methods.push(`${request.method} ${url.pathname}`);
+      if (request.method === "POST" && url.pathname === "/api/sandbox") {
+        return Response.json({ id: "snapshot-builder", state: "creating" });
+      }
+      if (request.method === "GET") {
+        return Response.json({ id: "snapshot-builder", state: "started", disk: 3 });
+      }
+      if (request.method === "POST" && url.pathname.endsWith("/stop")) {
+        return new Response("provider unavailable", { status: 503 });
+      }
+      if (request.method === "DELETE") {
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`unexpected request ${request.method} ${request.url}`);
+    });
+
+    await expect(client.bootstrapSnapshot("crabbox-ready-10g", 10)).rejects.toThrow("http 503");
+    expect(methods.at(-1)).toBe("DELETE /api/sandbox/snapshot-builder");
+  });
+
   it.each(["started", "running", "ready", "active", " Active "])(
     "accepts Daytona ready state %j",
     async (state) => {

--- a/worker/test/daytona.test.ts
+++ b/worker/test/daytona.test.ts
@@ -186,6 +186,9 @@ describe("daytona coordinator client", () => {
   it("creates a larger snapshot from the configured base and deletes its builder", async () => {
     const calls: Array<{ method: string; path: string; body?: unknown }> = [];
     let state = "creating";
+    let cleanupPolls = 0;
+    let snapshotPolls = 0;
+    let snapshotTransitionPolls = 0;
     let cpu = 1;
     let memory = 1;
     let disk = 3;
@@ -196,6 +199,21 @@ describe("daytona coordinator client", () => {
       const url = new URL(request.url);
       const body = request.body ? await request.clone().json() : undefined;
       calls.push({ method: request.method, path: url.pathname, ...(body ? { body } : {}) });
+      if (request.method === "GET" && url.pathname === "/api/snapshots/crabbox-ready-2x4x10") {
+        if (calls.length === 1) return new Response(null, { status: 404 });
+        snapshotPolls += 1;
+        if (snapshotPolls === 1) {
+          return new Response("temporary provider failure", { status: 503 });
+        }
+        return Response.json({
+          id: "snapshot-one",
+          name: "crabbox-ready-2x4x10",
+          state: "active",
+          cpu,
+          mem: memory,
+          disk,
+        });
+      }
       if (request.method === "POST" && url.pathname === "/api/sandbox") {
         state = "started";
         ({ cpu, memory, disk } = body as { cpu: number; memory: number; disk: number });
@@ -209,6 +227,31 @@ describe("daytona coordinator client", () => {
         });
       }
       if (request.method === "GET" && url.pathname === "/api/sandbox/snapshot-builder") {
+        if (state === "snapshotting") {
+          snapshotTransitionPolls += 1;
+          if (snapshotTransitionPolls === 1) {
+            return Response.json({
+              id: "snapshot-builder",
+              name: "crabbox-snapshot-bootstrap-test",
+              state,
+              cpu,
+              memory,
+              disk,
+            });
+          }
+          state = "stopped";
+        }
+        if (state === "destroying") {
+          cleanupPolls += 1;
+          if (cleanupPolls === 1) {
+            return new Response("temporary provider failure", { status: 503 });
+          }
+          return Response.json({
+            id: "snapshot-builder",
+            name: "crabbox-snapshot-bootstrap-test",
+            state: cleanupPolls === 2 ? "build_failed" : "destroyed",
+          });
+        }
         return Response.json({
           id: "snapshot-builder",
           name: "crabbox-snapshot-bootstrap-test",
@@ -223,9 +266,11 @@ describe("daytona coordinator client", () => {
         return Response.json({ id: "snapshot-builder", state });
       }
       if (request.method === "POST" && url.pathname.endsWith("/snapshot")) {
+        state = "snapshotting";
         return Response.json({ id: "snapshot-builder", state: "snapshotting", disk });
       }
       if (request.method === "DELETE" && url.pathname.endsWith("/snapshot-builder")) {
+        state = "destroying";
         return new Response(null, { status: 204 });
       }
       throw new Error(`unexpected request ${request.method} ${request.url}`);
@@ -246,16 +291,23 @@ describe("daytona coordinator client", () => {
       cleanup: "deleted",
     });
     expect(calls.map(({ method, path }) => `${method} ${path}`)).toEqual([
+      "GET /api/snapshots/crabbox-ready-2x4x10",
       "POST /api/sandbox",
       "GET /api/sandbox/snapshot-builder",
       "GET /api/sandbox/snapshot-builder",
       "POST /api/sandbox/snapshot-builder/stop",
       "GET /api/sandbox/snapshot-builder",
       "POST /api/sandbox/snapshot-builder/snapshot",
+      "GET /api/snapshots/crabbox-ready-2x4x10",
+      "GET /api/snapshots/crabbox-ready-2x4x10",
+      "GET /api/sandbox/snapshot-builder",
       "GET /api/sandbox/snapshot-builder",
       "DELETE /api/sandbox/snapshot-builder",
+      "GET /api/sandbox/snapshot-builder",
+      "GET /api/sandbox/snapshot-builder",
+      "GET /api/sandbox/snapshot-builder",
     ]);
-    expect(calls[0]?.body).toMatchObject({
+    expect(calls[1]?.body).toMatchObject({
       buildInfo: {
         dockerfileContent: `FROM ${baseImage}`,
       },
@@ -270,24 +322,29 @@ describe("daytona coordinator client", () => {
         snapshot_name: "crabbox-ready-2x4x10",
       },
     });
-    expect(calls[0]?.body).not.toMatchObject({
+    expect(calls[1]?.body).not.toMatchObject({
       labels: { crabbox: "true" },
     });
-    expect(calls[5]?.body).toEqual({ name: "crabbox-ready-2x4x10" });
+    expect(calls[6]?.body).toEqual({ name: "crabbox-ready-2x4x10" });
   });
 
   it("deletes the builder when Daytona snapshot bootstrap fails", async () => {
     const methods: string[] = [];
+    let deleted = false;
     const client = new DaytonaClient(baseEnv);
     client.pollDelayMs = 0;
     client.fetcher = vi.fn<typeof fetch>(async (input: RequestInfo | URL, init?: RequestInit) => {
       const request = new Request(input, init);
       const url = new URL(request.url);
       methods.push(`${request.method} ${url.pathname}`);
+      if (request.method === "GET" && url.pathname.startsWith("/api/snapshots/")) {
+        return new Response(null, { status: 404 });
+      }
       if (request.method === "POST" && url.pathname === "/api/sandbox") {
         return Response.json({ id: "snapshot-builder", state: "creating" });
       }
       if (request.method === "GET") {
+        if (deleted) return new Response(null, { status: 404 });
         return Response.json({
           id: "snapshot-builder",
           state: "started",
@@ -300,6 +357,7 @@ describe("daytona coordinator client", () => {
         return new Response("provider unavailable", { status: 503 });
       }
       if (request.method === "DELETE") {
+        deleted = true;
         return new Response(null, { status: 204 });
       }
       throw new Error(`unexpected request ${request.method} ${request.url}`);
@@ -308,23 +366,302 @@ describe("daytona coordinator client", () => {
     await expect(
       client.bootstrapSnapshot("crabbox-ready-2x4x10", 2, 4, 10, baseImage),
     ).rejects.toThrow("http 503");
-    expect(methods.at(-1)).toBe("DELETE /api/sandbox/snapshot-builder");
+    expect(methods.slice(-2)).toEqual([
+      "DELETE /api/sandbox/snapshot-builder",
+      "GET /api/sandbox/snapshot-builder",
+    ]);
+  });
+
+  it("rejects a failed snapshot and still waits for builder cleanup", async () => {
+    const methods: string[] = [];
+    let preflight = true;
+    let state = "started";
+    let snapshotRequested = false;
+    let transitionReadFailed = false;
+    const client = new DaytonaClient(baseEnv);
+    client.pollDelayMs = 0;
+    client.fetcher = vi.fn<typeof fetch>(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = new Request(input, init);
+      const url = new URL(request.url);
+      methods.push(`${request.method} ${url.pathname}`);
+      if (request.method === "GET" && url.pathname.startsWith("/api/snapshots/")) {
+        if (preflight) {
+          preflight = false;
+          return new Response(null, { status: 404 });
+        }
+        return Response.json({
+          id: "snapshot-one",
+          name: "crabbox-ready-2x4x10",
+          state: "build_failed",
+          errorReason: "registry push failed",
+        });
+      }
+      if (request.method === "POST" && url.pathname === "/api/sandbox") {
+        return Response.json({ id: "snapshot-builder", state: "creating" });
+      }
+      if (request.method === "GET" && url.pathname.endsWith("/snapshot-builder")) {
+        if (state === "destroying") return new Response(null, { status: 404 });
+        if (snapshotRequested && !transitionReadFailed) {
+          transitionReadFailed = true;
+          return new Response("temporary provider failure", { status: 503 });
+        }
+        return Response.json({
+          id: "snapshot-builder",
+          state,
+          cpu: 2,
+          memory: 4,
+          disk: 10,
+        });
+      }
+      if (request.method === "POST" && url.pathname.endsWith("/stop")) {
+        state = "stopped";
+        return Response.json({ id: "snapshot-builder", state });
+      }
+      if (request.method === "POST" && url.pathname.endsWith("/snapshot")) {
+        snapshotRequested = true;
+        return Response.json({ id: "snapshot-builder", state: "snapshotting" });
+      }
+      if (request.method === "DELETE") {
+        state = "destroying";
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`unexpected request ${request.method} ${request.url}`);
+    });
+
+    await expect(
+      client.bootstrapSnapshot("crabbox-ready-2x4x10", 2, 4, 10, baseImage),
+    ).rejects.toThrow(
+      "daytona snapshot crabbox-ready-2x4x10 entered terminal state=build_failed: registry push failed",
+    );
+    expect(transitionReadFailed).toBe(true);
+    expect(methods.slice(-2)).toEqual([
+      "DELETE /api/sandbox/snapshot-builder",
+      "GET /api/sandbox/snapshot-builder",
+    ]);
+  });
+
+  it("waits out snapshotting when the accepted snapshot response is lost", async () => {
+    const methods: string[] = [];
+    let state = "started";
+    let transitionPolls = 0;
+    let snapshotAttempted = false;
+    let deleteAttempts = 0;
+    let deleted = false;
+    const client = new DaytonaClient(baseEnv);
+    client.maxWaitMs = 25;
+    client.snapshotWaitMs = 100;
+    client.pollDelayMs = 10;
+    client.snapshotAcceptanceWaitMs = 20;
+    client.fetcher = vi.fn<typeof fetch>(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = new Request(input, init);
+      const url = new URL(request.url);
+      methods.push(`${request.method} ${url.pathname}`);
+      if (request.method === "GET" && url.pathname.startsWith("/api/snapshots/")) {
+        return new Response(null, { status: 404 });
+      }
+      if (request.method === "POST" && url.pathname === "/api/sandbox") {
+        return Response.json({ id: "snapshot-builder", state: "creating" });
+      }
+      if (request.method === "GET" && url.pathname.endsWith("/snapshot-builder")) {
+        if (deleted) return new Response(null, { status: 404 });
+        if (snapshotAttempted) {
+          transitionPolls += 1;
+          state =
+            transitionPolls === 1 ? "stopped" : transitionPolls <= 3 ? "snapshotting" : "stopped";
+        }
+        return Response.json({
+          id: "snapshot-builder",
+          state,
+          cpu: 2,
+          memory: 4,
+          disk: 10,
+        });
+      }
+      if (request.method === "POST" && url.pathname.endsWith("/stop")) {
+        state = "stopped";
+        return Response.json({ id: "snapshot-builder", state });
+      }
+      if (request.method === "POST" && url.pathname.endsWith("/snapshot")) {
+        snapshotAttempted = true;
+        throw new TypeError("network reset after snapshot acceptance");
+      }
+      if (request.method === "DELETE") {
+        deleteAttempts += 1;
+        if (deleteAttempts === 1) {
+          return new Response("Sandbox state change in progress", { status: 409 });
+        }
+        deleted = true;
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`unexpected request ${request.method} ${request.url}`);
+    });
+
+    await expect(
+      client.bootstrapSnapshot("crabbox-ready-2x4x10", 2, 4, 10, baseImage),
+    ).rejects.toThrow("network reset after snapshot acceptance");
+    expect(methods.slice(-6)).toEqual([
+      "GET /api/sandbox/snapshot-builder",
+      "GET /api/sandbox/snapshot-builder",
+      "GET /api/sandbox/snapshot-builder",
+      "DELETE /api/sandbox/snapshot-builder",
+      "DELETE /api/sandbox/snapshot-builder",
+      "GET /api/sandbox/snapshot-builder",
+    ]);
+  });
+
+  it("fails cleanup when Daytona accepts delete but never destroys the builder", async () => {
+    let preflight = true;
+    let state = "started";
+    const client = new DaytonaClient(baseEnv);
+    client.pollDelayMs = 25;
+    client.maxWaitMs = 20;
+    client.fetcher = vi.fn<typeof fetch>(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = new Request(input, init);
+      const url = new URL(request.url);
+      if (request.method === "GET" && url.pathname.startsWith("/api/snapshots/")) {
+        if (preflight) {
+          preflight = false;
+          return new Response(null, { status: 404 });
+        }
+        return Response.json({
+          id: "snapshot-one",
+          name: "crabbox-ready-2x4x10",
+          state: "active",
+          cpu: 2,
+          mem: 4,
+          disk: 10,
+        });
+      }
+      if (request.method === "POST" && url.pathname === "/api/sandbox") {
+        return Response.json({ id: "snapshot-builder", state: "creating" });
+      }
+      if (request.method === "GET" && url.pathname.endsWith("/snapshot-builder")) {
+        return Response.json({
+          id: "snapshot-builder",
+          state,
+          cpu: 2,
+          memory: 4,
+          disk: 10,
+        });
+      }
+      if (request.method === "POST" && url.pathname.endsWith("/stop")) {
+        state = "stopped";
+        return Response.json({ id: "snapshot-builder", state });
+      }
+      if (request.method === "POST" && url.pathname.endsWith("/snapshot")) {
+        return Response.json({ id: "snapshot-builder", state: "snapshotting" });
+      }
+      if (request.method === "DELETE") {
+        state = "destroying";
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`unexpected request ${request.method} ${request.url}`);
+    });
+
+    await expect(
+      client.bootstrapSnapshot("crabbox-ready-2x4x10", 2, 4, 10, baseImage),
+    ).rejects.toThrow(
+      "timed out waiting for daytona sandbox snapshot-builder cleanup (state=destroying)",
+    );
+  });
+
+  it("rejects an existing snapshot name before creating a paid builder", async () => {
+    const client = new DaytonaClient(baseEnv);
+    const fetchMock = vi.fn<typeof fetch>(async () =>
+      Response.json({
+        id: "snapshot-existing",
+        name: "crabbox-ready-2x4x10",
+        state: "active",
+      }),
+    );
+    client.fetcher = fetchMock;
+
+    await expect(
+      client.bootstrapSnapshot("crabbox-ready-2x4x10", 2, 4, 10, baseImage),
+    ).rejects.toThrow("daytona snapshot crabbox-ready-2x4x10 already exists (state=active)");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses a dedicated bounded snapshot wait longer than sandbox lifecycle waits", async () => {
+    let snapshotPolls = 0;
+    let state = "started";
+    let deleted = false;
+    const client = new DaytonaClient(baseEnv);
+    client.maxWaitMs = 50;
+    client.snapshotWaitMs = 200;
+    client.pollDelayMs = 60;
+    client.fetcher = vi.fn<typeof fetch>(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = new Request(input, init);
+      const url = new URL(request.url);
+      if (request.method === "GET" && url.pathname.startsWith("/api/snapshots/")) {
+        snapshotPolls += 1;
+        if (snapshotPolls < 3) return new Response(null, { status: 404 });
+        return Response.json({
+          id: "snapshot-one",
+          name: "crabbox-ready-2x4x10",
+          state: "active",
+          cpu: 2,
+          mem: 4,
+          disk: 10,
+        });
+      }
+      if (request.method === "POST" && url.pathname === "/api/sandbox") {
+        return Response.json({ id: "snapshot-builder", state: "creating" });
+      }
+      if (request.method === "GET" && url.pathname.endsWith("/snapshot-builder")) {
+        if (deleted) return new Response(null, { status: 404 });
+        return Response.json({
+          id: "snapshot-builder",
+          state,
+          cpu: 2,
+          memory: 4,
+          disk: 10,
+        });
+      }
+      if (request.method === "POST" && url.pathname.endsWith("/stop")) {
+        state = "stopped";
+        return Response.json({ id: "snapshot-builder", state });
+      }
+      if (request.method === "POST" && url.pathname.endsWith("/snapshot")) {
+        return Response.json({ id: "snapshot-builder", state: "snapshotting" });
+      }
+      if (request.method === "DELETE") {
+        deleted = true;
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`unexpected request ${request.method} ${request.url}`);
+    });
+
+    await expect(
+      client.bootstrapSnapshot("crabbox-ready-2x4x10", 2, 4, 10, baseImage),
+    ).resolves.toMatchObject({
+      snapshot: "crabbox-ready-2x4x10",
+      cleanup: "deleted",
+    });
+    expect(client.snapshotWaitMs).toBeGreaterThan(client.maxWaitMs);
+    expect(client.snapshotWaitMs).toBeLessThan(30 * 60_000);
+    expect(snapshotPolls).toBe(3);
   });
 
   it.each([2, 6])(
     "deletes the builder when Daytona applies %d GiB instead of the requested memory",
     async (appliedMemoryGiB) => {
       const methods: string[] = [];
+      let deleted = false;
       const client = new DaytonaClient(baseEnv);
       client.pollDelayMs = 0;
       client.fetcher = vi.fn<typeof fetch>(async (input: RequestInfo | URL, init?: RequestInit) => {
         const request = new Request(input, init);
         const url = new URL(request.url);
         methods.push(`${request.method} ${url.pathname}`);
+        if (request.method === "GET" && url.pathname.startsWith("/api/snapshots/")) {
+          return new Response(null, { status: 404 });
+        }
         if (request.method === "POST" && url.pathname === "/api/sandbox") {
           return Response.json({ id: "undersized-builder", state: "creating" });
         }
         if (request.method === "GET") {
+          if (deleted) return new Response(null, { status: 404 });
           return Response.json({
             id: "undersized-builder",
             state: "started",
@@ -334,6 +671,7 @@ describe("daytona coordinator client", () => {
           });
         }
         if (request.method === "DELETE") {
+          deleted = true;
           return new Response(null, { status: 204 });
         }
         throw new Error(`unexpected request ${request.method} ${request.url}`);
@@ -342,7 +680,10 @@ describe("daytona coordinator client", () => {
       await expect(
         client.bootstrapSnapshot("crabbox-ready-2x4x10", 2, 4, 10, baseImage),
       ).rejects.toThrow(`has ${appliedMemoryGiB} GiB memory after 4 GiB image build`);
-      expect(methods.at(-1)).toBe("DELETE /api/sandbox/undersized-builder");
+      expect(methods.slice(-2)).toEqual([
+        "DELETE /api/sandbox/undersized-builder",
+        "GET /api/sandbox/undersized-builder",
+      ]);
     },
   );
 

--- a/worker/test/daytona.test.ts
+++ b/worker/test/daytona.test.ts
@@ -195,10 +195,10 @@ describe("daytona coordinator client", () => {
       calls.push({ method: request.method, path: url.pathname, ...(body ? { body } : {}) });
       if (request.method === "POST" && url.pathname === "/api/sandbox") {
         state = "started";
+        disk = (body as { disk: number }).disk;
         return Response.json({
           id: "snapshot-builder",
           name: "crabbox-snapshot-bootstrap-test",
-          snapshot: "crabbox-ready",
           state: "creating",
           disk,
         });
@@ -207,7 +207,6 @@ describe("daytona coordinator client", () => {
         return Response.json({
           id: "snapshot-builder",
           name: "crabbox-snapshot-bootstrap-test",
-          snapshot: "crabbox-ready",
           state,
           disk,
         });
@@ -215,10 +214,6 @@ describe("daytona coordinator client", () => {
       if (request.method === "POST" && url.pathname.endsWith("/stop")) {
         state = "stopped";
         return Response.json({ id: "snapshot-builder", state });
-      }
-      if (request.method === "POST" && url.pathname.endsWith("/resize")) {
-        disk = (body as { disk: number }).disk;
-        return Response.json({ id: "snapshot-builder", state, disk });
       }
       if (request.method === "POST" && url.pathname.endsWith("/snapshot")) {
         return Response.json({ id: "snapshot-builder", state: "snapshotting", disk });
@@ -229,9 +224,11 @@ describe("daytona coordinator client", () => {
       throw new Error(`unexpected request ${request.method} ${request.url}`);
     });
 
-    await expect(client.bootstrapSnapshot("crabbox-ready-10g", 10)).resolves.toEqual({
-      sourceSnapshot: "crabbox-ready",
-      sourceDiskGiB: 3,
+    await expect(
+      client.bootstrapSnapshot("crabbox-ready-10g", 10, "daytonaio/sandbox:0.8.0"),
+    ).resolves.toEqual({
+      sourceSnapshot: "daytonaio/sandbox:0.8.0",
+      sourceDiskGiB: 10,
       snapshot: "crabbox-ready-10g",
       diskGiB: 10,
       sandboxID: "snapshot-builder",
@@ -243,14 +240,15 @@ describe("daytona coordinator client", () => {
       "GET /api/sandbox/snapshot-builder",
       "POST /api/sandbox/snapshot-builder/stop",
       "GET /api/sandbox/snapshot-builder",
-      "POST /api/sandbox/snapshot-builder/resize",
-      "GET /api/sandbox/snapshot-builder",
       "POST /api/sandbox/snapshot-builder/snapshot",
       "GET /api/sandbox/snapshot-builder",
       "DELETE /api/sandbox/snapshot-builder",
     ]);
     expect(calls[0]?.body).toMatchObject({
-      snapshot: "crabbox-ready",
+      buildInfo: {
+        dockerfileContent: "FROM daytonaio/sandbox:0.8.0",
+      },
+      disk: 10,
       labels: {
         created_by: "crabbox",
         purpose: "snapshot-bootstrap",
@@ -259,8 +257,7 @@ describe("daytona coordinator client", () => {
     expect(calls[0]?.body).not.toMatchObject({
       labels: { crabbox: "true" },
     });
-    expect(calls[5]?.body).toEqual({ disk: 10 });
-    expect(calls[7]?.body).toEqual({ name: "crabbox-ready-10g" });
+    expect(calls[5]?.body).toEqual({ name: "crabbox-ready-10g" });
   });
 
   it("deletes the builder when Daytona snapshot bootstrap fails", async () => {
@@ -275,7 +272,7 @@ describe("daytona coordinator client", () => {
         return Response.json({ id: "snapshot-builder", state: "creating" });
       }
       if (request.method === "GET") {
-        return Response.json({ id: "snapshot-builder", state: "started", disk: 3 });
+        return Response.json({ id: "snapshot-builder", state: "started", disk: 10 });
       }
       if (request.method === "POST" && url.pathname.endsWith("/stop")) {
         return new Response("provider unavailable", { status: 503 });
@@ -286,7 +283,9 @@ describe("daytona coordinator client", () => {
       throw new Error(`unexpected request ${request.method} ${request.url}`);
     });
 
-    await expect(client.bootstrapSnapshot("crabbox-ready-10g", 10)).rejects.toThrow("http 503");
+    await expect(
+      client.bootstrapSnapshot("crabbox-ready-10g", 10, "daytonaio/sandbox:0.8.0"),
+    ).rejects.toThrow("http 503");
     expect(methods.at(-1)).toBe("DELETE /api/sandbox/snapshot-builder");
   });
 

--- a/worker/test/daytona.test.ts
+++ b/worker/test/daytona.test.ts
@@ -185,6 +185,8 @@ describe("daytona coordinator client", () => {
   it("creates a larger snapshot from the configured base and deletes its builder", async () => {
     const calls: Array<{ method: string; path: string; body?: unknown }> = [];
     let state = "creating";
+    let cpu = 1;
+    let memory = 1;
     let disk = 3;
     const client = new DaytonaClient(baseEnv);
     client.pollDelayMs = 0;
@@ -195,11 +197,13 @@ describe("daytona coordinator client", () => {
       calls.push({ method: request.method, path: url.pathname, ...(body ? { body } : {}) });
       if (request.method === "POST" && url.pathname === "/api/sandbox") {
         state = "started";
-        disk = (body as { disk: number }).disk;
+        ({ cpu, memory, disk } = body as { cpu: number; memory: number; disk: number });
         return Response.json({
           id: "snapshot-builder",
           name: "crabbox-snapshot-bootstrap-test",
           state: "creating",
+          cpu,
+          memory,
           disk,
         });
       }
@@ -208,6 +212,8 @@ describe("daytona coordinator client", () => {
           id: "snapshot-builder",
           name: "crabbox-snapshot-bootstrap-test",
           state,
+          cpu,
+          memory,
           disk,
         });
       }
@@ -225,11 +231,15 @@ describe("daytona coordinator client", () => {
     });
 
     await expect(
-      client.bootstrapSnapshot("crabbox-ready-10g", 10, "daytonaio/sandbox:0.8.0"),
+      client.bootstrapSnapshot("crabbox-ready-2x4x10", 2, 4, 10, "daytonaio/sandbox:0.8.0"),
     ).resolves.toEqual({
       sourceSnapshot: "daytonaio/sandbox:0.8.0",
+      sourceCPU: 2,
+      sourceMemoryGiB: 4,
       sourceDiskGiB: 10,
-      snapshot: "crabbox-ready-10g",
+      snapshot: "crabbox-ready-2x4x10",
+      cpu: 2,
+      memoryGiB: 4,
       diskGiB: 10,
       sandboxID: "snapshot-builder",
       cleanup: "deleted",
@@ -248,6 +258,8 @@ describe("daytona coordinator client", () => {
       buildInfo: {
         dockerfileContent: "FROM daytonaio/sandbox:0.8.0",
       },
+      cpu: 2,
+      memory: 4,
       disk: 10,
       labels: {
         created_by: "crabbox",
@@ -257,7 +269,7 @@ describe("daytona coordinator client", () => {
     expect(calls[0]?.body).not.toMatchObject({
       labels: { crabbox: "true" },
     });
-    expect(calls[5]?.body).toEqual({ name: "crabbox-ready-10g" });
+    expect(calls[5]?.body).toEqual({ name: "crabbox-ready-2x4x10" });
   });
 
   it("deletes the builder when Daytona snapshot bootstrap fails", async () => {
@@ -272,7 +284,13 @@ describe("daytona coordinator client", () => {
         return Response.json({ id: "snapshot-builder", state: "creating" });
       }
       if (request.method === "GET") {
-        return Response.json({ id: "snapshot-builder", state: "started", disk: 10 });
+        return Response.json({
+          id: "snapshot-builder",
+          state: "started",
+          cpu: 2,
+          memory: 4,
+          disk: 10,
+        });
       }
       if (request.method === "POST" && url.pathname.endsWith("/stop")) {
         return new Response("provider unavailable", { status: 503 });
@@ -284,7 +302,7 @@ describe("daytona coordinator client", () => {
     });
 
     await expect(
-      client.bootstrapSnapshot("crabbox-ready-10g", 10, "daytonaio/sandbox:0.8.0"),
+      client.bootstrapSnapshot("crabbox-ready-2x4x10", 2, 4, 10, "daytonaio/sandbox:0.8.0"),
     ).rejects.toThrow("http 503");
     expect(methods.at(-1)).toBe("DELETE /api/sandbox/snapshot-builder");
   });

--- a/worker/test/daytona.test.ts
+++ b/worker/test/daytona.test.ts
@@ -261,7 +261,6 @@ describe("daytona coordinator client", () => {
       },
       autoStopInterval: 30,
       autoDeleteInterval: 60,
-      ttlMinutes: 30,
       cpu: 2,
       memory: 4,
       disk: 10,

--- a/worker/test/daytona.test.ts
+++ b/worker/test/daytona.test.ts
@@ -11,6 +11,7 @@ const baseEnv: Env = {
   CRABBOX_DAYTONA_API_URL: "https://daytona.example/api",
   CRABBOX_DAYTONA_SNAPSHOT: "crabbox-ready",
 };
+const baseImage = `daytonaio/sandbox@sha256:${"a".repeat(64)}`;
 
 describe("daytona coordinator client", () => {
   it("requires a dedicated Worker secret and a safe API URL", () => {
@@ -231,9 +232,9 @@ describe("daytona coordinator client", () => {
     });
 
     await expect(
-      client.bootstrapSnapshot("crabbox-ready-2x4x10", 2, 4, 10, "daytonaio/sandbox:0.8.0"),
+      client.bootstrapSnapshot("crabbox-ready-2x4x10", 2, 4, 10, baseImage),
     ).resolves.toEqual({
-      sourceSnapshot: "daytonaio/sandbox:0.8.0",
+      sourceSnapshot: baseImage,
       sourceCPU: 2,
       sourceMemoryGiB: 4,
       sourceDiskGiB: 10,
@@ -256,14 +257,18 @@ describe("daytona coordinator client", () => {
     ]);
     expect(calls[0]?.body).toMatchObject({
       buildInfo: {
-        dockerfileContent: "FROM daytonaio/sandbox:0.8.0",
+        dockerfileContent: `FROM ${baseImage}`,
       },
+      autoStopInterval: 30,
+      autoDeleteInterval: 60,
+      ttlMinutes: 30,
       cpu: 2,
       memory: 4,
       disk: 10,
       labels: {
         created_by: "crabbox",
         purpose: "snapshot-bootstrap",
+        snapshot_name: "crabbox-ready-2x4x10",
       },
     });
     expect(calls[0]?.body).not.toMatchObject({
@@ -302,10 +307,45 @@ describe("daytona coordinator client", () => {
     });
 
     await expect(
-      client.bootstrapSnapshot("crabbox-ready-2x4x10", 2, 4, 10, "daytonaio/sandbox:0.8.0"),
+      client.bootstrapSnapshot("crabbox-ready-2x4x10", 2, 4, 10, baseImage),
     ).rejects.toThrow("http 503");
     expect(methods.at(-1)).toBe("DELETE /api/sandbox/snapshot-builder");
   });
+
+  it.each([2, 6])(
+    "deletes the builder when Daytona applies %d GiB instead of the requested memory",
+    async (appliedMemoryGiB) => {
+      const methods: string[] = [];
+      const client = new DaytonaClient(baseEnv);
+      client.pollDelayMs = 0;
+      client.fetcher = vi.fn<typeof fetch>(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = new Request(input, init);
+        const url = new URL(request.url);
+        methods.push(`${request.method} ${url.pathname}`);
+        if (request.method === "POST" && url.pathname === "/api/sandbox") {
+          return Response.json({ id: "undersized-builder", state: "creating" });
+        }
+        if (request.method === "GET") {
+          return Response.json({
+            id: "undersized-builder",
+            state: "started",
+            cpu: 2,
+            memory: appliedMemoryGiB,
+            disk: 10,
+          });
+        }
+        if (request.method === "DELETE") {
+          return new Response(null, { status: 204 });
+        }
+        throw new Error(`unexpected request ${request.method} ${request.url}`);
+      });
+
+      await expect(
+        client.bootstrapSnapshot("crabbox-ready-2x4x10", 2, 4, 10, baseImage),
+      ).rejects.toThrow(`has ${appliedMemoryGiB} GiB memory after 4 GiB image build`);
+      expect(methods.at(-1)).toBe("DELETE /api/sandbox/undersized-builder");
+    },
+  );
 
   it.each(["started", "running", "ready", "active", " Active "])(
     "accepts Daytona ready state %j",

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -14579,7 +14579,11 @@ describe("fleet lease identity and idle", () => {
 
     const forbidden = await fleet.fetch(
       request("POST", "/v1/admin/providers/daytona/snapshot-bootstrap", {
-        body: { name: "crabbox-ready-10g", diskGiB: 10 },
+        body: {
+          name: "crabbox-ready-10g",
+          diskGiB: 10,
+          baseImage: "daytonaio/sandbox:0.8.0",
+        },
       }),
     );
     expect(forbidden.status).toBe(403);
@@ -14587,7 +14591,11 @@ describe("fleet lease identity and idle", () => {
     const invalid = await fleet.fetch(
       request("POST", "/v1/admin/providers/daytona/snapshot-bootstrap", {
         headers: { "x-crabbox-admin": "true" },
-        body: { name: "crabbox-ready-10g", diskGiB: 8 },
+        body: {
+          name: "crabbox-ready-10g",
+          diskGiB: 8,
+          baseImage: "daytonaio/sandbox:0.8.0",
+        },
       }),
     );
     expect(invalid.status).toBe(400);

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -14566,9 +14566,15 @@ describe("fleet lease identity and idle", () => {
   });
 
   it("restricts Daytona snapshot bootstrap to confirmed, bounded admin requests", async () => {
-    const fetchMock = vi.fn<typeof fetch>(
-      async () => new Response("provider unavailable", { status: 503 }),
-    );
+    let activeProviderRequests = 0;
+    let maxActiveProviderRequests = 0;
+    const fetchMock = vi.fn<typeof fetch>(async () => {
+      activeProviderRequests += 1;
+      maxActiveProviderRequests = Math.max(maxActiveProviderRequests, activeProviderRequests);
+      await Promise.resolve();
+      activeProviderRequests -= 1;
+      return new Response("provider unavailable", { status: 503 });
+    });
     vi.stubGlobal("fetch", fetchMock);
     const baseImage = `daytonaio/sandbox@sha256:${"a".repeat(64)}`;
     const fleet = testFleet(
@@ -14618,6 +14624,7 @@ describe("fleet lease identity and idle", () => {
     );
     expect(acceptedResponses.map((response) => response.status)).toEqual([500, 500, 500, 500]);
     expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(maxActiveProviderRequests).toBe(1);
     fetchMock.mockClear();
 
     const invalidResults = await Promise.all(

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -14565,9 +14565,12 @@ describe("fleet lease identity and idle", () => {
     expect(text).not.toContain("tskey-preflight-secret");
   });
 
-  it("restricts Daytona snapshot bootstrap to admin requests and a 2/4/10 target", async () => {
-    const fetchMock = vi.fn<typeof fetch>();
+  it("restricts Daytona snapshot bootstrap to confirmed, bounded admin requests", async () => {
+    const fetchMock = vi.fn<typeof fetch>(
+      async () => new Response("provider unavailable", { status: 503 }),
+    );
     vi.stubGlobal("fetch", fetchMock);
+    const baseImage = `daytonaio/sandbox@sha256:${"a".repeat(64)}`;
     const fleet = testFleet(
       new MemoryStorage(),
       {},
@@ -14584,26 +14587,93 @@ describe("fleet lease identity and idle", () => {
           cpu: 2,
           memoryGiB: 4,
           diskGiB: 10,
-          baseImage: "daytonaio/sandbox:0.8.0",
+          baseImage,
+          confirm: true,
         },
       }),
     );
     expect(forbidden.status).toBe(403);
 
-    const invalid = await fleet.fetch(
-      request("POST", "/v1/admin/providers/daytona/snapshot-bootstrap", {
-        headers: { "x-crabbox-admin": "true" },
-        body: {
-          name: "crabbox-ready-2x4x10",
-          cpu: 2,
-          memoryGiB: 4,
-          diskGiB: 8,
-          baseImage: "daytonaio/sandbox:0.8.0",
-        },
+    const acceptedResponses = await Promise.all(
+      [
+        baseImage,
+        `registry.example:5000/team/my--image@sha256:${"b".repeat(64)}`,
+        `registry.example/team/my__image:stable@sha256:${"c".repeat(64)}`,
+        `[2001:db8::1]:5000/team/image@sha256:${"d".repeat(64)}`,
+      ].map((validBaseImage) =>
+        fleet.fetch(
+          request("POST", "/v1/admin/providers/daytona/snapshot-bootstrap", {
+            headers: { "x-crabbox-admin": "true" },
+            body: {
+              name: "snapshot",
+              cpu: 2,
+              memoryGiB: 4,
+              diskGiB: 10,
+              baseImage: validBaseImage,
+              confirm: true,
+            },
+          }),
+        ),
+      ),
+    );
+    expect(acceptedResponses.map((response) => response.status)).toEqual([500, 500, 500, 500]);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    fetchMock.mockClear();
+
+    const invalidResults = await Promise.all(
+      [
+        [
+          { name: "snapshot", cpu: 2, memoryGiB: 4, diskGiB: 10, baseImage },
+          "snapshot_bootstrap_confirmation_required",
+        ],
+        [
+          { name: "snapshot", cpu: 5, memoryGiB: 4, diskGiB: 10, baseImage, confirm: true },
+          "invalid_snapshot_cpu",
+        ],
+        [
+          { name: "snapshot", cpu: 2, memoryGiB: 9, diskGiB: 10, baseImage, confirm: true },
+          "invalid_snapshot_memory",
+        ],
+        [
+          { name: "snapshot", cpu: 2, memoryGiB: 4, diskGiB: 11, baseImage, confirm: true },
+          "invalid_snapshot_disk",
+        ],
+        [
+          {
+            name: "snapshot",
+            cpu: 2,
+            memoryGiB: 4,
+            diskGiB: 10,
+            baseImage: "daytonaio/sandbox:latest",
+            confirm: true,
+          },
+          "invalid_base_image",
+        ],
+        [
+          {
+            name: "snapshot",
+            cpu: 2,
+            memoryGiB: 4,
+            diskGiB: 10,
+            baseImage: `registry/repository:5000/image@sha256:${"a".repeat(64)}`,
+            confirm: true,
+          },
+          "invalid_base_image",
+        ],
+      ].map(async ([body, error]) => {
+        const invalid = await fleet.fetch(
+          request("POST", "/v1/admin/providers/daytona/snapshot-bootstrap", {
+            headers: { "x-crabbox-admin": "true" },
+            body,
+          }),
+        );
+        return { status: invalid.status, body: await invalid.json(), error };
       }),
     );
-    expect(invalid.status).toBe(400);
-    await expect(invalid.json()).resolves.toMatchObject({ error: "invalid_snapshot_disk" });
+    for (const result of invalidResults) {
+      expect(result.status).toBe(400);
+      expect(result.body).toMatchObject({ error: result.error });
+    }
     expect(fetchMock).not.toHaveBeenCalled();
   });
 

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -14565,6 +14565,36 @@ describe("fleet lease identity and idle", () => {
     expect(text).not.toContain("tskey-preflight-secret");
   });
 
+  it("restricts Daytona snapshot bootstrap to admin requests and a 10 GiB target", async () => {
+    const fetchMock = vi.fn<typeof fetch>();
+    vi.stubGlobal("fetch", fetchMock);
+    const fleet = testFleet(
+      new MemoryStorage(),
+      {},
+      {
+        DAYTONA_CRABBOX_KEY: "daytona-live-secret",
+        CRABBOX_DAYTONA_API_URL: "https://daytona.example/api",
+      },
+    );
+
+    const forbidden = await fleet.fetch(
+      request("POST", "/v1/admin/providers/daytona/snapshot-bootstrap", {
+        body: { name: "crabbox-ready-10g", diskGiB: 10 },
+      }),
+    );
+    expect(forbidden.status).toBe(403);
+
+    const invalid = await fleet.fetch(
+      request("POST", "/v1/admin/providers/daytona/snapshot-bootstrap", {
+        headers: { "x-crabbox-admin": "true" },
+        body: { name: "crabbox-ready-10g", diskGiB: 8 },
+      }),
+    );
+    expect(invalid.status).toBe(400);
+    await expect(invalid.json()).resolves.toMatchObject({ error: "invalid_snapshot_disk" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("does not trust client-posted Tailscale device IDs for privileged cleanup", async () => {
     const storage = new MemoryStorage();
     const cleanupOrder: string[] = [];

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -14565,7 +14565,7 @@ describe("fleet lease identity and idle", () => {
     expect(text).not.toContain("tskey-preflight-secret");
   });
 
-  it("restricts Daytona snapshot bootstrap to admin requests and a 10 GiB target", async () => {
+  it("restricts Daytona snapshot bootstrap to admin requests and a 2/4/10 target", async () => {
     const fetchMock = vi.fn<typeof fetch>();
     vi.stubGlobal("fetch", fetchMock);
     const fleet = testFleet(
@@ -14580,7 +14580,9 @@ describe("fleet lease identity and idle", () => {
     const forbidden = await fleet.fetch(
       request("POST", "/v1/admin/providers/daytona/snapshot-bootstrap", {
         body: {
-          name: "crabbox-ready-10g",
+          name: "crabbox-ready-2x4x10",
+          cpu: 2,
+          memoryGiB: 4,
           diskGiB: 10,
           baseImage: "daytonaio/sandbox:0.8.0",
         },
@@ -14592,7 +14594,9 @@ describe("fleet lease identity and idle", () => {
       request("POST", "/v1/admin/providers/daytona/snapshot-bootstrap", {
         headers: { "x-crabbox-admin": "true" },
         body: {
-          name: "crabbox-ready-10g",
+          name: "crabbox-ready-2x4x10",
+          cpu: 2,
+          memoryGiB: 4,
           diskGiB: 8,
           baseImage: "daytonaio/sandbox:0.8.0",
         },


### PR DESCRIPTION
Related: https://github.com/openclaw/crabbox/issues/1208
Related: https://github.com/openclaw/crabbox/pull/1211

## What Problem This Solves

Resolves the missing safe operator path for creating a reusable Daytona snapshot through the coordinator. The prior one-off route accepted mutable image inputs, only supported one resource shape, and lacked a durable broker-only invocation path.

## Why This Change Was Made

Crabbox now exposes an admin-only, explicitly confirmed snapshot bootstrap operation with bounded resources and digest-pinned OCI images. It verifies the exact resources Daytona applied, serializes concurrent requests for the same snapshot name, waits up to 20 minutes for the requested snapshot to become active, and retries transient provider reads.

Temporary builder cleanup now follows Daytona's asynchronous lifecycle instead of treating an accepted delete as completion. It waits for snapshotting to clear, retries delete conflicts, polls through transient and stale pre-delete states, and returns `cleanup=deleted` only after Daytona reports the builder destroyed or absent. Daytona still stops an idle builder after 30 minutes and deletes it after 60 continuously stopped minutes if direct cleanup is lost.

A protected default-branch workflow runs this mutation through the `image-publisher` environment using the existing coordinator admin token. It requires environment approval, serializes workflow creation, passes auth through curl header stdin, verifies the source image, exact resources, and `cleanup=deleted`, and uploads only sanitized proof.

This remains an operator mutation, not part of normal lease routing. No Daytona sandbox, snapshot, secret, canary, or production deployment was created while preparing this PR.

## User Impact

Operators can prepare correctly sized Daytona fallback snapshots without distributing Daytona credentials or configuring local admin auth. Invalid or mutable image references fail before provider work, resource drift fails closed, same-name requests cannot observe another bootstrap's snapshot, and successful responses prove both snapshot availability and builder teardown.

Landing note: use a merge commit rather than squash or rebase so the signed seven-commit series is preserved.

## Evidence

- Final Blacksmith Testbox: `tbx_01kz3tyv8k4mfwek10tbsnpb0x`
- Actions run: https://github.com/openclaw/crabbox/actions/runs/30815439949
- Node `v24.13.0`: Worker format, lint, and typecheck clean
- Focused Daytona/Fleet suite: 536 passed
- Earlier full Worker suite: 1,181 passed, 3 skipped
- Earlier Worker and Node typechecks, Cloudflare Worker and dynamic-worker dry-run builds
- Earlier Node runtime build, runtime base-image pin check, and Docker image build
- Protected workflow: `actionlint` clean; Node 24 workflow contract tests 4 passed
- Fresh final autoreview: clean, no accepted/actionable findings
- `git diff --check`
