### PR TITLE
fix(deploy): apply the selected Daytona snapshot

### DIFF
--- a/.github/workflows/coordinator-deploy.yml
+++ b/.github/workflows/coordinator-deploy.yml
@@ -60,6 +60,21 @@ jobs:
         run: npm ci
         working-directory: worker
 
+      - name: Configure Daytona snapshot
+        if: steps.token.outputs.ready == 'true'
+        run: |
+          if [ -z "${CRABBOX_DAYTONA_SNAPSHOT}" ]; then
+            echo "::error::CRABBOX_DAYTONA_SNAPSHOT is not set in the 'coordinator' environment."
+            exit 1
+          fi
+          printf '%s' "${CRABBOX_DAYTONA_SNAPSHOT}" |
+            npx wrangler secret put CRABBOX_DAYTONA_SNAPSHOT
+        working-directory: worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: "91b59577e757131d68d55a471fe32aca"
+          CRABBOX_DAYTONA_SNAPSHOT: ${{ secrets.CRABBOX_DAYTONA_SNAPSHOT }}
+
       - name: Deploy
         if: steps.token.outputs.ready == 'true'
         # `npm run deploy` runs the predeploy bundle (vendor-novnc) then

--- a/.github/workflows/coordinator-deploy.yml
+++ b/.github/workflows/coordinator-deploy.yml
@@ -12,6 +12,12 @@ on:
       - "worker/**"
       - ".github/workflows/coordinator-deploy.yml"
   workflow_dispatch:
+    inputs:
+      clearDaytonaSnapshot:
+        description: Clear the Worker snapshot binding and use the Daytona account default
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -63,17 +69,23 @@ jobs:
       - name: Configure Daytona snapshot
         if: steps.token.outputs.ready == 'true'
         run: |
-          if [ -z "${CRABBOX_DAYTONA_SNAPSHOT}" ]; then
-            echo "::error::CRABBOX_DAYTONA_SNAPSHOT is not set in the 'coordinator' environment."
-            exit 1
+          if [ "${CLEAR_DAYTONA_SNAPSHOT}" = "true" ]; then
+            printf '{"CRABBOX_DAYTONA_SNAPSHOT":null}\n' |
+              npx wrangler secret bulk
+          elif [ -n "${CRABBOX_DAYTONA_SNAPSHOT}" ]; then
+            # Snapshot selection is runtime config independent of Worker code.
+            # Sync first so both the current and newly deployed versions agree.
+            printf '%s' "${CRABBOX_DAYTONA_SNAPSHOT}" |
+              npx wrangler secret put CRABBOX_DAYTONA_SNAPSHOT
+          else
+            echo "::notice::CRABBOX_DAYTONA_SNAPSHOT is not set; keeping the Daytona account-default mode."
           fi
-          printf '%s' "${CRABBOX_DAYTONA_SNAPSHOT}" |
-            npx wrangler secret put CRABBOX_DAYTONA_SNAPSHOT
         working-directory: worker
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: "91b59577e757131d68d55a471fe32aca"
           CRABBOX_DAYTONA_SNAPSHOT: ${{ secrets.CRABBOX_DAYTONA_SNAPSHOT }}
+          CLEAR_DAYTONA_SNAPSHOT: ${{ inputs.clearDaytonaSnapshot }}
 
       - name: Deploy
         if: steps.token.outputs.ready == 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,8 @@
 
 ### Fixed
 
-- Kept the brokered Daytona fallback on its operator-managed snapshot by
-  applying the private snapshot binding during every coordinator deployment.
+- Kept brokered Daytona on its operator-managed snapshot across coordinator
+  deployments while preserving account-default mode and an explicit clear path.
 - Recovered exact-owned Azure public IPs, network interfaces, and tagged OS
   disks when a coordinator deployment interrupted provisioning before the VM
   existed, while rejecting ambiguous or mismatched resource sets.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 ### Fixed
 
+- Kept the brokered Daytona fallback on its operator-managed snapshot by
+  applying the private snapshot binding during every coordinator deployment.
 - Made Blacksmith doctor report all-organization inventory scope and a
   nonterminal active Testbox count for capacity-aware callers.
 - Made brokered Daytona usable with Crabbox auth alone, added a read-only

--- a/scripts/coordinator-deploy-workflow.test.js
+++ b/scripts/coordinator-deploy-workflow.test.js
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const workflow = fs.readFileSync(
+  path.join(repoRoot, ".github", "workflows", "coordinator-deploy.yml"),
+  "utf8",
+);
+
+test("coordinator deploy syncs a configured Daytona snapshot", () => {
+  assert.match(
+    workflow,
+    /CRABBOX_DAYTONA_SNAPSHOT: \$\{\{ secrets\.CRABBOX_DAYTONA_SNAPSHOT \}\}/,
+  );
+  assert.match(workflow, /\[ -n "\$\{CRABBOX_DAYTONA_SNAPSHOT\}" \]/);
+  assert.match(
+    workflow,
+    /printf '%s' "\$\{CRABBOX_DAYTONA_SNAPSHOT\}" \|\s+npx wrangler secret put CRABBOX_DAYTONA_SNAPSHOT/,
+  );
+});
+
+test("coordinator deploy preserves account-default mode when no snapshot is configured", () => {
+  assert.match(
+    workflow,
+    /CRABBOX_DAYTONA_SNAPSHOT is not set; keeping the Daytona account-default mode/,
+  );
+  assert.doesNotMatch(
+    workflow,
+    /CRABBOX_DAYTONA_SNAPSHOT is not set[^]*?exit 1/,
+  );
+});
+
+test("manual deploy can explicitly clear a stale Daytona snapshot binding", () => {
+  assert.match(workflow, /^      clearDaytonaSnapshot:$/m);
+  assert.match(workflow, /type: boolean/);
+  assert.match(
+    workflow,
+    /CLEAR_DAYTONA_SNAPSHOT: \$\{\{ inputs\.clearDaytonaSnapshot \}\}/,
+  );
+  assert.match(
+    workflow,
+    /printf '\{"CRABBOX_DAYTONA_SNAPSHOT":null\}\\n' \|\s+npx wrangler secret bulk/,
+  );
+});


### PR DESCRIPTION
Related: https://github.com/openclaw/crabbox/issues/1208

## What Problem This Solves

Resolves a deployment gap where operators could store a new Daytona fallback snapshot in the protected `coordinator` environment, but normal coordinator deploys never copied that value into the Cloudflare Worker. Production therefore remained on the previous snapshot after a successful snapshot build and redeploy.

## Why This Change Was Made

Every coordinator deployment now writes a configured protected `CRABBOX_DAYTONA_SNAPSHOT` environment secret to the Worker before publishing code. The value travels on stdin to Wrangler, never on argv. An absent secret preserves the documented Daytona account-default mode, and a protected manual dispatch can explicitly clear a stale Worker binding.

## User Impact

Brokered Daytona fallback leases use the operator-selected snapshot after the same protected deployment flow that publishes coordinator code. Operators can retain account-default behavior or explicitly clear a previous binding without an undocumented local Cloudflare mutation.

Landing note: use a merge commit rather than squash or rebase so the signed commit series is preserved.

## Evidence

- `actionlint .github/workflows/coordinator-deploy.yml`
- `git diff --check origin/main...HEAD`
- Live gap observed after snapshot bootstrap run https://github.com/openclaw/crabbox/actions/runs/30818171177: the GitHub environment secret existed, while coordinator deploy run https://github.com/openclaw/crabbox/actions/runs/30817923191 did not sync it into the Worker.
- The protected environment already contains `CRABBOX_DAYTONA_SNAPSHOT`; post-merge deployment is the live proof.
