### PR TITLE
fix(images): isolate Corepack cache ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Made future Linux developer-image preparation use root-owned Corepack state while source, candidate, and promoted smoke checks exercise Corepack and pnpm as the runtime user. Thanks @fuller-stack-dev.
 - Made local sync report actionable non-Git workdir diagnostics and fail before lease acquisition, resolution, preparation, or ready-pool borrowing. Thanks @bunlongheng.
 
 ## 0.41.3 - 2026-08-11

--- a/scripts/install-linux-developer-tools.sh
+++ b/scripts/install-linux-developer-tools.sh
@@ -17,6 +17,7 @@ browser_bin_dir="${CRABBOX_LINUX_BROWSER_BIN_DIR:-/usr/local/bin}"
 browser_state_dir="${CRABBOX_LINUX_BROWSER_STATE_DIR:-/var/lib/crabbox}"
 chrome_defaults_file="${CRABBOX_LINUX_CHROME_DEFAULTS_FILE:-/etc/default/google-chrome}"
 trufflehog_bin_dir="${CRABBOX_LINUX_TRUFFLEHOG_BIN_DIR:-/usr/local/bin}"
+sudo_preserve_env="CRABBOX_LINUX_PNPM_VERSION,CRABBOX_LINUX_NODE_MAJOR,CRABBOX_LINUX_DOCKER_IMAGES,CRABBOX_LINUX_DESKTOP_TOOLS,CRABBOX_LINUX_BROWSER,CRABBOX_LINUX_APT_KEYRINGS_DIR,CRABBOX_LINUX_APT_SOURCES_DIR,CRABBOX_LINUX_APT_CONF_DIR,CRABBOX_LINUX_OS_RELEASE_FILE,CRABBOX_LINUX_CHROME_POLICY_DIR,CRABBOX_LINUX_CHROMIUM_POLICY_DIR,CRABBOX_LINUX_BROWSER_BIN_DIR,CRABBOX_LINUX_BROWSER_STATE_DIR,CRABBOX_LINUX_CHROME_DEFAULTS_FILE,CRABBOX_LINUX_TRUFFLEHOG_BIN_DIR,HTTP_PROXY,HTTPS_PROXY,NO_PROXY,http_proxy,https_proxy,no_proxy,ALL_PROXY,all_proxy"
 nodesource_signing_key_fingerprint="6F71F525282841EEDAF851B42F59B5F99B1BE0B4"
 docker_signing_key_fingerprint="9DC858229FC7DD38854AE2D88D81803C0EBFCD88"
 google_linux_signing_key_fingerprint="EB4C1BFD4F042F6DDDCCEC917721F63BD38B4796"
@@ -28,7 +29,7 @@ log() {
 need_root() {
   if [[ "$(id -u)" -ne 0 ]]; then
     if command -v sudo >/dev/null 2>&1; then
-      exec sudo -E bash "$0" "$@"
+      exec sudo -H "--preserve-env=$sudo_preserve_env" bash "$0" "$@"
     fi
     log "sudo is required when not running as root"
     exit 2

--- a/scripts/install-linux-developer-tools.test.js
+++ b/scripts/install-linux-developer-tools.test.js
@@ -58,6 +58,112 @@ esac
 	);
 }
 
+function runNeedRootFixture(uid, args = [], env = {}) {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-linux-tools-sudo-"));
+	const bin = path.join(dir, "bin");
+	const sudoLog = path.join(dir, "sudo.log");
+	fs.mkdirSync(bin);
+	writeExecutable(
+		path.join(bin, "id"),
+		`#!/usr/bin/env bash
+[[ "$*" == "-u" ]] || exit 64
+printf '${uid}\n'
+`,
+	);
+	writeExecutable(
+		path.join(bin, "sudo"),
+		`#!/usr/bin/env bash
+set -euo pipefail
+printf 'arg=%s\n' "$@" >"$CRABBOX_FAKE_SUDO_LOG"
+preserve_arg=""
+for arg in "$@"; do
+  case "$arg" in
+    --preserve-env=*) preserve_arg="\${arg#--preserve-env=}" ;;
+  esac
+done
+IFS=',' read -ra preserved <<<"$preserve_arg"
+for name in "\${preserved[@]}"; do
+  printf 'env=%s=%s\n' "$name" "\${!name-}" >>"$CRABBOX_FAKE_SUDO_LOG"
+done
+`,
+	);
+
+	return {
+		result: spawnSync(
+			"bash",
+			["-c", `source scripts/install-linux-developer-tools.sh\nneed_root ${args.join(" ")}`],
+			{
+				cwd: repoRoot,
+				env: {
+					...process.env,
+					...env,
+					PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}`,
+					CRABBOX_FAKE_SUDO_LOG: sudoLog,
+				},
+				encoding: "utf8",
+			},
+		),
+		sudoLog,
+	};
+}
+
+test("linux developer tool setup isolates root HOME and preserves approved configuration", () => {
+	const script = fs.readFileSync(
+		path.join(repoRoot, "scripts/install-linux-developer-tools.sh"),
+		"utf8",
+	);
+	const configured = [
+		...script.matchAll(/\$\{(CRABBOX_LINUX_[A-Z0-9_]+):-/g),
+	].map((match) => match[1]);
+	const proxyEnv = [
+		"HTTP_PROXY",
+		"HTTPS_PROXY",
+		"NO_PROXY",
+		"http_proxy",
+		"https_proxy",
+		"no_proxy",
+		"ALL_PROXY",
+		"all_proxy",
+	];
+	const expectedEnv = Object.fromEntries(
+		[...configured, ...proxyEnv].map((name, index) => [
+			name,
+			`${name.toLowerCase()}-sentinel-${index}`,
+		]),
+	);
+	const unrelatedName = "CRABBOX_UNRELATED_SENTINEL";
+	const unrelatedValue = "must-not-cross-sudo";
+	const { result, sudoLog } = runNeedRootFixture(1000, ["sentinel"], {
+		...expectedEnv,
+		[unrelatedName]: unrelatedValue,
+	});
+	assert.equal(result.status, 0, result.stderr || result.stdout);
+	const lines = fs.readFileSync(sudoLog, "utf8").trim().split("\n");
+	const args = lines.filter((line) => line.startsWith("arg=")).map((line) => line.slice(4));
+	assert.equal(args[0], "-H");
+	assert.doesNotMatch(args.join("\n"), /^-E$/m);
+	const preserveArg = args.find((arg) => arg.startsWith("--preserve-env="));
+	assert.ok(preserveArg, "sudo re-exec must preserve approved installer configuration");
+	const preserved = preserveArg.slice("--preserve-env=".length).split(",");
+	assert.deepEqual([...preserved].sort(), [...configured, ...proxyEnv].sort());
+	assert.equal(preserved.includes("HOME"), false);
+	assert.equal(preserved.includes(unrelatedName), false);
+	const forwarded = Object.fromEntries(
+		lines.filter((line) => line.startsWith("env=")).map((line) => {
+			const separator = line.indexOf("=", 4);
+			return [line.slice(4, separator), line.slice(separator + 1)];
+		}),
+	);
+	assert.deepEqual(forwarded, expectedEnv);
+	assert.doesNotMatch(lines.join("\n"), new RegExp(`${unrelatedName}|${unrelatedValue}`));
+});
+
+test("linux developer tool setup does not invoke sudo when already root", () => {
+	const { result, sudoLog } = runNeedRootFixture(0);
+	assert.equal(result.status, 0, result.stderr || result.stdout);
+	assert.equal(fs.existsSync(sudoLog), false);
+});
+
 test("linux developer tool repository setup rewrites keyrings idempotently", () => {
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-linux-tools-"));
 	const bin = path.join(dir, "bin");

--- a/scripts/mint-aws-devtools-image.sh
+++ b/scripts/mint-aws-devtools-image.sh
@@ -509,6 +509,8 @@ trufflehog --no-update --version
 command -v docker
 node --version
 node -e 'if (Number(process.versions.node.split(".")[0]) < 24) throw new Error(`Node.js 24 or newer is required, found ${process.version}`)'
+corepack --version
+pnpm --version
 docker_group_member() {
   if id -nG 2>/dev/null | tr ' ' '\n' | grep -qx docker; then
     return 0

--- a/scripts/mint-aws-devtools-image.test.js
+++ b/scripts/mint-aws-devtools-image.test.js
@@ -137,12 +137,12 @@ test("AWS devtools mint wrapper defaults to dry plan", async () => {
   await assert.rejects(readFile(fake.log, "utf8"));
 });
 
-test("AWS developer image smoke requires TruffleHog on Linux and Windows", async () => {
+test("AWS developer image smoke executes package managers and requires TruffleHog", async () => {
   const text = await readFile(script, "utf8");
   assert.match(text, /pnpm --version\ntrufflehog --no-update --version\ndocker --version/);
   assert.match(
     text,
-    /command -v pnpm\ncommand -v trufflehog\ntrufflehog --no-update --version\ncommand -v docker/,
+    /command -v pnpm\ncommand -v trufflehog\ntrufflehog --no-update --version\ncommand -v docker\nnode --version\nnode -e .*\ncorepack --version\npnpm --version\n/,
   );
 });
 
@@ -183,6 +183,8 @@ test("AWS devtools mint wrapper runs linux source candidate and promoted proof",
   assert.doesNotMatch(log, /warmup .*--region us-west-2/);
   assert.match(log, /run --provider aws --target linux --id cbx_source --no-sync --script/);
   assert.match(log, /run --provider aws --target linux --id cbx_source --no-sync --shell -- set -euo pipefail/);
+  assert.equal((log.match(/corepack --version/g) ?? []).length, 3);
+  assert.equal((log.match(/pnpm --version/g) ?? []).length, 3);
   assert.match(log, /docker image inspect hello-world ubuntu:24\.04 node:24-bookworm/);
   assert.match(log, /env CRABBOX_AWS_REGION=us-west-2 AWS_REGION=us-west-2 CRABBOX_AWS_AMI= args checkpoint create --provider aws --target linux --id cbx_source --name crabbox-linux-devtools-/);
   assert.match(log, /--mode native --strategy image --no-reboot=false --wait --wait-timeout 60m/);


### PR DESCRIPTION
## Summary

- re-execute privileged Linux developer-tool preparation with `sudo -H`, so Corepack writes root-owned preparation state under root's HOME instead of creating root-owned cache state in the runtime SSH user's home
- replace broad `sudo -E` forwarding with an explicit allowlist covering every supported `CRABBOX_LINUX_*` installer setting plus `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`, their lowercase variants, and the repository-supported `ALL_PROXY`/`all_proxy` pair; HOME and unrelated variables do not cross the privilege boundary
- run Corepack and pnpm version checks in the Linux source, candidate, and promoted image smoke phases as the runtime user

## Root cause

Linux image preparation elevated the installer with `sudo -E`. That retained the runtime user's HOME while running Corepack as root, allowing root-owned Corepack cache state to be created in the runtime SSH user's home. The broad environment inheritance also crossed more process state than the installer needs.

## Verification

- `node --test scripts/install-linux-developer-tools.test.js scripts/mint-aws-devtools-image.test.js` (24/24 passed)
- `bash -n scripts/install-linux-developer-tools.sh scripts/mint-aws-devtools-image.sh`
- `shellcheck -e SC1090 scripts/install-linux-developer-tools.sh scripts/mint-aws-devtools-image.sh`
- `node --check scripts/install-linux-developer-tools.test.js`
- `node --check scripts/mint-aws-devtools-image.test.js`
- `node --test scripts/devtools-image-workflow.test.js scripts/workflow-action-pins.test.js` (4/4 passed)
- `node scripts/check-docs-links.mjs`
- `node scripts/check-command-docs.mjs`
- `git diff --check origin/main...HEAD`
- global autoreview through P1: clean

## Operations

No configuration or secret migration is required. This merge changes future image preparation and proof only; it does not repair an already-published Linux AMI. After merge, an authorized operator must separately run the protected **Publish Developer Image** workflow for Linux to republish the image. That protected publication is intentionally not performed by this PR or this landing task.
