### PR TITLE
fix: defer coordinator lease cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Deferred ordinary coordinator lease provider cleanup to durable alarm-owned retries while preserving synchronous force-admin deletion and visible retry state. Thanks @fuller-stack-dev.
 - Made future Linux developer-image preparation use root-owned Corepack state while source, candidate, and promoted smoke checks exercise Corepack and pnpm as the runtime user. Thanks @fuller-stack-dev.
 - Made local sync report actionable non-Git workdir diagnostics and fail before lease acquisition, resolution, preparation, or ready-pool borrowing. Thanks @bunlongheng.
 

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -13100,7 +13100,25 @@ export class FleetCoordinator {
     if (lease.runtimeAdapterDeleteRequestedAt) {
       return this.runtimeAdapterDeletePendingResponse(lease, request, true);
     }
-    const released = await this.releaseResolvedLease(lease, { deleteServer: true, keep: false });
+    let released: LeaseRecord;
+    try {
+      released = await this.releaseResolvedLease(lease, {
+        deleteServer: true,
+        keep: false,
+        awaitProviderCleanup: true,
+      });
+    } catch (error) {
+      if (error instanceof LeaseCleanupInProgressError) {
+        return json(
+          {
+            error: "cleanup_in_progress",
+            message: "lease cleanup is already owned by another operation",
+          },
+          { status: 409 },
+        );
+      }
+      throw error;
+    }
     return released.runtimeAdapterDeleteRequestedAt
       ? this.runtimeAdapterDeletePendingResponse(released, request, true)
       : json({ lease: publicLeaseRecord(released) });
@@ -16117,6 +16135,7 @@ export class FleetCoordinator {
     options: {
       deleteServer: boolean;
       keep?: boolean;
+      awaitProviderCleanup?: boolean;
       expectedCreateAttempt?: CreateAttemptRecord;
       expectedLease?: LeaseRecord;
     },
@@ -16187,6 +16206,7 @@ export class FleetCoordinator {
     options: {
       deleteServer: boolean;
       keep?: boolean;
+      awaitProviderCleanup?: boolean;
       expectedCreateAttempt?: CreateAttemptRecord;
       expectedLease?: LeaseRecord;
     },
@@ -16217,7 +16237,15 @@ export class FleetCoordinator {
         return { cleanup: false as const, blocked: true as const, lease: current };
       }
       if (current.cleanupStartedAt) {
-        return { cleanup: false as const, blocked: false as const, lease: current };
+        if (options.awaitProviderCleanup && cleanupClaimDeadline(current) <= Date.now()) {
+          // Reclaim the expired claim below. Its prior owner remains fenced by the
+          // cleanupStartedAt comparison in finishLeaseCleanupClaim.
+        } else {
+          if (options.awaitProviderCleanup) {
+            throw new LeaseCleanupInProgressError();
+          }
+          return { cleanup: false as const, blocked: false as const, lease: current };
+        }
       }
       const deleteServer = options.deleteServer && !isRegisteredLease(current);
       const shouldDelete = Boolean(
@@ -16235,6 +16263,19 @@ export class FleetCoordinator {
         await this.markAWSIngressReconcilePending(released);
         await this.scheduleAlarm();
         return { cleanup: false as const, blocked: false as const, lease: released };
+      }
+      if (!options.awaitProviderCleanup) {
+        const pending = finalizedReleasedLease(current, true, options.keep);
+        // A zero-duration cleanup claim keeps queued deletion visible to rollback readers
+        // while allowing either coordinator version to reclaim it immediately.
+        const queuedAt = new Date().toISOString();
+        pending.releaseDeletesServer = true;
+        pending.cleanupStartedAt = queuedAt;
+        pending.cleanupClaimExpiresAt = queuedAt;
+        await this.putLease(pending);
+        await this.markAWSIngressReconcilePending(pending);
+        await this.scheduleAlarm();
+        return { cleanup: false as const, blocked: false as const, lease: pending };
       }
       const now = new Date();
       const claimed = finalizedReleasedLease(current, true, options.keep);
@@ -16375,6 +16416,8 @@ interface CreateAttemptRecord {
 class CreateAttemptConflictError extends Error {}
 
 class LeaseReleaseResolutionConflictError extends Error {}
+
+class LeaseCleanupInProgressError extends Error {}
 
 class CreateAttemptCanceledError extends Error {}
 

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -6577,7 +6577,16 @@ describe("fleet lease identity and idle", () => {
       }),
     );
 
-    expect(response.status).toBe(500);
+    expect(response.status).toBe(200);
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)).toMatchObject({
+      state: "released",
+      cloudID: lease.cloudID,
+      releaseDeletesServer: true,
+      cleanupStartedAt: expect.any(String),
+    });
+
+    await fleet.alarm();
+
     expect(storage.value<LeaseRecord>(`lease:${lease.id}`)).toMatchObject({
       state: "released",
       cloudID: lease.cloudID,
@@ -7006,7 +7015,11 @@ describe("fleet lease identity and idle", () => {
     expect(other.providerResourceId).not.toBe(created.providerResourceId);
 
     const released = await fleet.fetch(request("DELETE", `/v1/workspaces/${body.id}`, { headers }));
-    await expect(released.json()).resolves.toMatchObject({ status: "stopped" });
+    await expect(released.json()).resolves.toMatchObject({ status: "stopping" });
+    expect(providerReleases).toBe(0);
+
+    await fleet.alarm();
+
     expect(providerReleases).toBe(1);
   });
 
@@ -7154,11 +7167,20 @@ describe("fleet lease identity and idle", () => {
       request("DELETE", "/v1/workspaces/fleet-prewarm-bob", { headers: bobHeaders }),
     );
     await fleet.alarm();
-    expect(providerReleases).toBe(3);
+    expect(providerReleases).toBe(2);
+    expect(storage.value<LeaseRecord>(`lease:${replenished[0]!.leaseID}`)).toMatchObject({
+      state: "released",
+      releaseDeletesServer: true,
+      cleanupStartedAt: expect.any(String),
+    });
     const activeSpares = [
       ...(await storage.list<StoredWorkspace>({ prefix: "workspace:" })).values(),
     ].filter((workspace) => workspace.prewarm && !workspace.releaseRequestedAt);
     expect(activeSpares).toHaveLength(0);
+
+    await fleet.alarm();
+
+    expect(providerReleases).toBe(3);
   });
 
   it("keeps separate workspace spares for active profiles in one organization", async () => {
@@ -7284,7 +7306,17 @@ describe("fleet lease identity and idle", () => {
           provider,
         );
         const released = await fleet.fetch(request("DELETE", `/v1/workspaces/${id}`, { headers }));
-        await expect(released.json()).resolves.toMatchObject({ status: "stopped" });
+        await expect(released.json()).resolves.toMatchObject({ status: "stopping" });
+        expect(storage.value<LeaseRecord>(`lease:${created.providerResourceId}`)).toMatchObject({
+          state: "released",
+          releaseDeletesServer: true,
+          cleanupStartedAt: expect.any(String),
+        });
+
+        await fleet.alarm();
+
+        const stopped = await fleet.fetch(request("GET", `/v1/workspaces/${id}`, { headers }));
+        await expect(stopped.json()).resolves.toMatchObject({ status: "stopped" });
       }),
     );
   });
@@ -7429,12 +7461,21 @@ describe("fleet lease identity and idle", () => {
 
     unblock.resolve();
     await provisioning;
+    const stopping = await fleet.fetch(request("GET", `/v1/workspaces/${body.id}`, { headers }));
+    await expect(stopping.json()).resolves.toMatchObject({
+      providerResourceId: pending.providerResourceId,
+      status: "stopping",
+    });
+    expect(providerCreates).toBe(1);
+    expect(providerReleases).toBe(0);
+
+    await fleet.alarm();
+
     const stopped = await fleet.fetch(request("GET", `/v1/workspaces/${body.id}`, { headers }));
     await expect(stopped.json()).resolves.toMatchObject({
       providerResourceId: pending.providerResourceId,
       status: "stopped",
     });
-    expect(providerCreates).toBe(1);
     expect(providerReleases).toBe(1);
   });
 
@@ -8511,6 +8552,16 @@ describe("fleet lease identity and idle", () => {
     } as LeaseRecord);
 
     await fleet.alarm();
+    expect(providerReleases).toBe(0);
+    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)).toMatchObject({
+      state: "released",
+      cloudID: "321",
+      releaseDeletesServer: true,
+      cleanupStartedAt: expect.any(String),
+    });
+
+    await fleet.alarm();
+
     expect(providerReleases).toBe(1);
     const stopped = await fleet.fetch(
       request("GET", "/v1/workspaces/fleet-is-106", {
@@ -8558,6 +8609,14 @@ describe("fleet lease identity and idle", () => {
     const pending = await fleet.fetch(request("DELETE", `/v1/workspaces/${body.id}`, { headers }));
     await expect(pending.json()).resolves.toMatchObject({
       status: "stopping",
+      message: "workspace stopping",
+    });
+    expect(providerReleases).toBe(0);
+
+    await fleet.alarm();
+    const failed = await fleet.fetch(request("GET", `/v1/workspaces/${body.id}`, { headers }));
+    await expect(failed.json()).resolves.toMatchObject({
+      status: "stopping",
       message: "provider cleanup throttled",
     });
     const nextBody = { ...body, id: "fleet-is-107" };
@@ -8569,7 +8628,14 @@ describe("fleet lease identity and idle", () => {
     await expect(nextReady.json()).resolves.toMatchObject({ status: "ready" });
     expect(providerReleases).toBe(1);
 
-    const stopped = await fleet.fetch(request("DELETE", `/v1/workspaces/${body.id}`, { headers }));
+    const retryPending = await fleet.fetch(
+      request("DELETE", `/v1/workspaces/${body.id}`, { headers }),
+    );
+    await expect(retryPending.json()).resolves.toMatchObject({ status: "stopping" });
+    expect(providerReleases).toBe(1);
+
+    await fleet.alarm();
+    const stopped = await fleet.fetch(request("GET", `/v1/workspaces/${body.id}`, { headers }));
     await expect(stopped.json()).resolves.toMatchObject({
       status: "stopped",
       message: "workspace stopped",
@@ -8664,6 +8730,15 @@ describe("fleet lease identity and idle", () => {
       ...retryingWorkspace,
       reconcileAfter: new Date(Date.now() - 1_000).toISOString(),
     });
+    await fleet.alarm();
+
+    expect(providerReleases).toBe(0);
+    expect(storage.value<LeaseRecord>(`lease:${pending.providerResourceId}`)).toMatchObject({
+      state: "released",
+      releaseDeletesServer: true,
+      cleanupStartedAt: expect.any(String),
+    });
+
     await fleet.alarm();
 
     const stopped = await fleet.fetch(request("GET", `/v1/workspaces/${body.id}`, { headers }));
@@ -8786,14 +8861,26 @@ describe("fleet lease identity and idle", () => {
 
     expect(creates).toBe(0);
     expect(recoveries).toBe(1);
-    expect(releases.toSorted()).toEqual([prewarmLeaseID, recoveredLeaseID].toSorted());
-    expect(storage.value<LeaseRecord>(`lease:${recoveredLeaseID}`)?.state).toBe("released");
-    expect(storage.value<LeaseRecord>(`lease:${prewarmLeaseID}`)?.state).toBe("released");
+    expect(releases).toEqual([]);
+    expect(storage.value<LeaseRecord>(`lease:${recoveredLeaseID}`)).toMatchObject({
+      state: "released",
+      releaseDeletesServer: true,
+      cleanupStartedAt: expect.any(String),
+    });
+    expect(storage.value<LeaseRecord>(`lease:${prewarmLeaseID}`)).toMatchObject({
+      state: "released",
+      releaseDeletesServer: true,
+      cleanupStartedAt: expect.any(String),
+    });
     expect(
       storage.value<{ releaseRequestedAt?: string }>(
         `workspace:${legacyOrg}:alice%40example.com:${recoveredWorkspace.id}`,
       )?.releaseRequestedAt,
     ).toBeDefined();
+
+    await fleet.alarm();
+
+    expect(releases.toSorted()).toEqual([prewarmLeaseID, recoveredLeaseID].toSorted());
   });
 
   it("uses provider-owned GCP recovery instead of project-wide label inventory", async () => {
@@ -9330,6 +9417,15 @@ describe("fleet lease identity and idle", () => {
         }),
       );
       expect(remove.status).toBe(200);
+      expect(cleanupLeases).toHaveLength(0);
+      expect(storage.value<LeaseRecord>(`lease:${lease.id}`)).toMatchObject({
+        state: "released",
+        releaseDeletesServer: true,
+        cleanupStartedAt: expect.any(String),
+      });
+
+      await fleet.alarm();
+
       expect(cleanupLeases).toHaveLength(1);
       expect(cleanupLeases[0]).toMatchObject({
         cloudID,
@@ -9789,7 +9885,13 @@ describe("fleet lease identity and idle", () => {
     storage.seed(leaseKey, retained);
 
     const stopped = await fleet.fetch(request("DELETE", `/v1/workspaces/${body.id}`, { headers }));
-    await expect(stopped.json()).resolves.toMatchObject({ status: "stopped" });
+    await expect(stopped.json()).resolves.toMatchObject({ status: "stopping" });
+    expect(providerReleases).toBe(0);
+
+    await fleet.alarm();
+
+    const completed = await fleet.fetch(request("GET", `/v1/workspaces/${body.id}`, { headers }));
+    await expect(completed.json()).resolves.toMatchObject({ status: "stopped" });
     expect(providerReleases).toBe(1);
   });
 
@@ -9822,7 +9924,14 @@ describe("fleet lease identity and idle", () => {
     const release = await fleet.fetch(
       request("POST", `/portal/leases/${pending.providerResourceId}/release`, { headers }),
     );
-    expect(release.status).toBe(500);
+    expect(release.status).toBe(303);
+    expect(storage.value<LeaseRecord>(`lease:${pending.providerResourceId}`)).toMatchObject({
+      state: "released",
+      releaseDeletesServer: true,
+      cleanupStartedAt: expect.any(String),
+    });
+
+    await fleet.alarm();
 
     const stopping = await fleet.fetch(request("GET", `/v1/workspaces/${body.id}`, { headers }));
     await expect(stopping.json()).resolves.toMatchObject({
@@ -13456,6 +13565,10 @@ describe("fleet lease identity and idle", () => {
     };
     expect(drained.entry.state).toBe("draining");
     expect(drained.lease.state).toBe("released");
+    expect(deleted).toBe("");
+
+    await fleet.alarm();
+
     expect(deleted).toBe("123");
   });
 
@@ -14731,10 +14844,14 @@ describe("fleet lease identity and idle", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(cleanupOrder).toEqual(["provider:4242"]);
+    expect(cleanupOrder).toEqual([]);
     const stored = storage.value<LeaseRecord>("lease:cbx_tailscale_cleanup");
     expect(stored?.tailscale?.deviceID).toBe("node-123");
     expect(fetch).not.toHaveBeenCalled();
+
+    await fleet.alarm();
+
+    expect(cleanupOrder).toEqual(["provider:4242"]);
   });
 
   it("does not hold the state transition lock while minting a Tailscale key", async () => {
@@ -15680,6 +15797,198 @@ describe("fleet lease identity and idle", () => {
     );
   });
 
+  it("reclaims an ordinary queued release for synchronous force-admin deletion", async () => {
+    const storage = new MemoryStorage();
+    const deleted: string[] = [];
+    const lease = testLease({
+      id: "cbx_000000000099",
+      owner: "alice@example.com",
+      org: "example-org",
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    storage.seed(`lease:${lease.id}`, lease);
+    const fleet = testFleet(storage, {
+      hetzner: fakeProvider(undefined, {}, async (id) => {
+        deleted.push(id);
+      }),
+    });
+    const headers = {
+      "x-crabbox-owner": lease.owner,
+      "x-crabbox-org": "example-org",
+    };
+
+    const ordinary = await fleet.fetch(
+      request("POST", `/v1/leases/${lease.id}/release`, {
+        headers,
+        body: { delete: true },
+      }),
+    );
+    expect(ordinary.status).toBe(200);
+    expect(deleted).toEqual([]);
+    const queued = storage.value<LeaseRecord>(`lease:${lease.id}`)!;
+    expect(queued).toMatchObject({
+      state: "released",
+      releaseDeletesServer: true,
+      cleanupStartedAt: expect.any(String),
+      cleanupClaimExpiresAt: expect.any(String),
+    });
+    expect(queued.cleanupClaimExpiresAt).toBe(queued.cleanupStartedAt);
+    expect(shippedCleanupReaderNeedsCleanup(queued)).toBe(true);
+
+    const repeated = await fleet.fetch(
+      request("POST", `/v1/leases/${lease.id}/release`, {
+        headers,
+        body: { delete: true },
+      }),
+    );
+    expect(repeated.status).toBe(200);
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)?.cleanupStartedAt).toBe(
+      queued.cleanupStartedAt,
+    );
+    expect(deleted).toEqual([]);
+
+    const forced = await fleet.fetch(
+      request("POST", `/v1/admin/leases/${lease.id}/delete`, {
+        headers: { ...headers, "x-crabbox-admin": "true" },
+      }),
+    );
+    expect(forced.status).toBe(200);
+    expect(deleted).toEqual([lease.cloudID]);
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)).toMatchObject({ state: "released" });
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)?.cleanupStartedAt).toBeUndefined();
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)?.releaseDeletesServer).toBeUndefined();
+  });
+
+  it("keeps an active cleanup owner fenced from force-admin deletion", async () => {
+    const storage = new MemoryStorage();
+    const cleanupStartedAt = new Date().toISOString();
+    const cleanupClaimExpiresAt = new Date(Date.now() + 60_000).toISOString();
+    const lease = testLease({
+      id: "cbx_000000000098",
+      state: "released",
+      owner: "alice@example.com",
+      org: "example-org",
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      releaseDeletesServer: true,
+      cleanupStartedAt,
+      cleanupClaimExpiresAt,
+    });
+    storage.seed(`lease:${lease.id}`, lease);
+    let providerReleases = 0;
+    const fleet = testFleet(storage, {
+      hetzner: fakeProvider(undefined, {}, async () => {
+        providerReleases += 1;
+      }),
+    });
+
+    const forced = await fleet.fetch(
+      request("POST", `/v1/admin/leases/${lease.id}/delete`, {
+        headers: {
+          "x-crabbox-owner": lease.owner,
+          "x-crabbox-org": "example-org",
+          "x-crabbox-admin": "true",
+        },
+      }),
+    );
+
+    expect(forced.status).toBe(409);
+    await expect(forced.json()).resolves.toMatchObject({ error: "cleanup_in_progress" });
+    expect(providerReleases).toBe(0);
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)).toMatchObject({
+      cleanupStartedAt,
+      cleanupClaimExpiresAt,
+    });
+  });
+
+  it("keeps deferred release cleanup retryable after provider failure", async () => {
+    const storage = new MemoryStorage();
+    const lease = testLease({
+      id: "cbx_000000000097",
+      owner: "alice@example.com",
+      org: "example-org",
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    storage.seed(`lease:${lease.id}`, lease);
+    let providerReleases = 0;
+    const fleet = testFleet(storage, {
+      hetzner: fakeProvider(undefined, {}, async () => {
+        providerReleases += 1;
+        if (providerReleases === 1) {
+          throw new Error("provider cleanup throttled");
+        }
+      }),
+    });
+    const headers = {
+      "x-crabbox-owner": lease.owner,
+      "x-crabbox-org": "example-org",
+    };
+
+    const ordinary = await fleet.fetch(
+      request("POST", `/v1/leases/${lease.id}/release`, {
+        headers,
+        body: { delete: true },
+      }),
+    );
+    expect(ordinary.status).toBe(200);
+    expect(providerReleases).toBe(0);
+
+    await fleet.alarm();
+    expect(providerReleases).toBe(1);
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)).toMatchObject({
+      state: "released",
+      releaseDeletesServer: true,
+      cleanupError: "provider cleanup throttled",
+      cleanupRetryAt: expect.any(String),
+    });
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)?.cleanupStartedAt).toBeUndefined();
+
+    const forcedRetry = await fleet.fetch(
+      request("POST", `/v1/admin/leases/${lease.id}/delete`, {
+        headers: { ...headers, "x-crabbox-admin": "true" },
+      }),
+    );
+    expect(forcedRetry.status).toBe(200);
+    expect(providerReleases).toBe(2);
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)?.cleanupError).toBeUndefined();
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)?.releaseDeletesServer).toBeUndefined();
+  });
+
+  it("does not queue provider cleanup for a no-delete release", async () => {
+    const storage = new MemoryStorage();
+    const lease = testLease({
+      id: "cbx_000000000096",
+      owner: "alice@example.com",
+      org: "example-org",
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    storage.seed(`lease:${lease.id}`, lease);
+    let providerReleases = 0;
+    const fleet = testFleet(storage, {
+      hetzner: fakeProvider(undefined, {}, async () => {
+        providerReleases += 1;
+      }),
+    });
+
+    const released = await fleet.fetch(
+      request("POST", `/v1/leases/${lease.id}/release`, {
+        headers: {
+          "x-crabbox-owner": lease.owner,
+          "x-crabbox-org": "example-org",
+        },
+        body: { delete: false },
+      }),
+    );
+
+    expect(released.status).toBe(200);
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)).toMatchObject({
+      state: "released",
+      releaseDeletesServer: false,
+    });
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)?.cleanupStartedAt).toBeUndefined();
+    await fleet.alarm();
+    expect(providerReleases).toBe(0);
+  });
+
   it("can release a provisioning lease before cloud resources are known", async () => {
     const storage = new MemoryStorage();
     const deleted: string[] = [];
@@ -16284,7 +16593,12 @@ describe("fleet lease identity and idle", () => {
       }),
     );
     expect(deleteKept.status).toBe(200);
-    expect(deleted).toEqual(["vm-cbx-abcdef123456"]);
+    expect(deleted).toEqual([]);
+    expect(storage.value<LeaseRecord>("lease:cbx_abcdef123456")).toMatchObject({
+      state: "released",
+      releaseDeletesServer: true,
+      cleanupStartedAt: expect.any(String),
+    });
 
     const retryDeleteKept = await fleet.fetch(
       request("POST", "/v1/leases/cbx_abcdef123456/release", {
@@ -16296,6 +16610,10 @@ describe("fleet lease identity and idle", () => {
       }),
     );
     expect(retryDeleteKept.status).toBe(200);
+    expect(deleted).toEqual([]);
+
+    await fleet.alarm();
+
     expect(deleted).toEqual(["vm-cbx-abcdef123456"]);
   });
 
@@ -16439,6 +16757,15 @@ describe("fleet lease identity and idle", () => {
       }),
     );
     expect(retryDelete.status).toBe(200);
+    expect(deleted).toEqual(["vm-cbx-abcdef123456"]);
+    expect(storage.value<LeaseRecord>("lease:cbx_abcdef123456")).toMatchObject({
+      state: "released",
+      releaseDeletesServer: true,
+      cleanupStartedAt: expect.any(String),
+    });
+
+    await fleet.alarm();
+
     expect(deleted).toEqual(["vm-cbx-abcdef123456", "vm-cbx-abcdef123456"]);
     const retried = storage.value<LeaseRecord>("lease:cbx_abcdef123456");
     expect(retried?.state).toBe("released");
@@ -33016,6 +33343,21 @@ function testLease(overrides: Partial<LeaseRecord>): LeaseRecord {
     expiresAt: "2026-05-01T01:30:00.000Z",
     ...overrides,
   });
+}
+
+function shippedCleanupReaderNeedsCleanup(lease: LeaseRecord, now = Date.now()): boolean {
+  const live = lease.state === "active" || lease.state === "provisioning";
+  if (live && Date.parse(lease.expiresAt) <= now) {
+    return true;
+  }
+  if (lease.state === "released" && lease.releaseDeletesServer === false) {
+    return false;
+  }
+  return Boolean(
+    !live &&
+    ((lease.cloudID && (lease.cleanupError || lease.cleanupStartedAt)) ||
+      lease.providerKeyCleanupPending),
+  );
 }
 
 async function macOSPortalPage(): Promise<string> {

--- a/worker/test/private-aws-workspace.test.ts
+++ b/worker/test/private-aws-workspace.test.ts
@@ -344,7 +344,25 @@ describe("private AWS workspaces", () => {
       }),
     );
     expect(stopped.status).toBe(200);
-    await expect(stopped.json()).resolves.toMatchObject({ status: "stopped" });
+    await expect(stopped.json()).resolves.toMatchObject({ status: "stopping" });
+    expect(releases).toBe(0);
+    expect(await runtime.storage.get<LeaseRecord>(`lease:${lease!.id}`)).toMatchObject({
+      state: "released",
+      releaseDeletesServer: true,
+      cleanupStartedAt: expect.any(String),
+    });
+
+    await fleet.alarm();
+
+    const completed = await fleet.fetch(
+      new Request("https://coordinator.test/v1/workspaces/private-gateway", {
+        headers: {
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
+        },
+      }),
+    );
+    await expect(completed.json()).resolves.toMatchObject({ status: "stopped" });
     expect(releases).toBe(1);
 
     const repeated = await fleet.fetch(
@@ -442,11 +460,26 @@ describe("private AWS workspaces", () => {
 
     expect(state.recovers).toBe(1);
     expect(state.resumes).toBe(0);
-    expect(state.releases).toBe(1);
+    expect(state.releases).toBe(0);
+    const queuedLeases = await runtime.storage.list<LeaseRecord>({ prefix: "lease:" });
+    expect([...queuedLeases.values()][0]).toMatchObject({
+      state: "released",
+      cloudID: "i-recovered123",
+      releaseDeletesServer: true,
+      cleanupStartedAt: expect.any(String),
+    });
     const status = await fleet.fetch(
       new Request("https://coordinator.test/v1/workspaces/private-gateway", { headers }),
     );
-    await expect(status.json()).resolves.toMatchObject({ status: "stopped" });
+    await expect(status.json()).resolves.toMatchObject({ status: "stopping" });
+
+    await fleet.alarm();
+
+    expect(state.releases).toBe(1);
+    const completed = await fleet.fetch(
+      new Request("https://coordinator.test/v1/workspaces/private-gateway", { headers }),
+    );
+    await expect(completed.json()).resolves.toMatchObject({ status: "stopped" });
   });
 
   it("does not reactivate when delete arrives during recovered bootstrap", async () => {
@@ -504,13 +537,29 @@ describe("private AWS workspaces", () => {
     await recovery;
 
     expect(state.resumes).toBe(1);
-    expect(state.releases).toBe(1);
+    expect(state.releases).toBe(0);
+    const queuedLeases = await runtime.storage.list<LeaseRecord>({ prefix: "lease:" });
+    expect([...queuedLeases.values()][0]).toMatchObject({
+      state: "released",
+      cloudID: "i-recovered123",
+      releaseDeletesServer: true,
+      cleanupStartedAt: expect.any(String),
+    });
     const status = await fleet.fetch(
       new Request("https://coordinator.test/v1/workspaces/private-gateway", { headers }),
     );
-    await expect(status.json()).resolves.toMatchObject({ status: "stopped" });
-    const leases = await runtime.storage.list<LeaseRecord>({ prefix: "lease:" });
-    expect([...leases.values()].some((lease) => lease.state === "active")).toBe(false);
+    await expect(status.json()).resolves.toMatchObject({ status: "stopping" });
+    expect([...queuedLeases.values()].some((lease) => lease.state === "active")).toBe(false);
+
+    await fleet.alarm();
+
+    expect(state.releases).toBe(1);
+    const completed = await fleet.fetch(
+      new Request("https://coordinator.test/v1/workspaces/private-gateway", { headers }),
+    );
+    await expect(completed.json()).resolves.toMatchObject({ status: "stopped" });
+    const completedLeases = await runtime.storage.list<LeaseRecord>({ prefix: "lease:" });
+    expect([...completedLeases.values()].some((lease) => lease.state === "active")).toBe(false);
   });
 
   it("uses configured runtime-adapter ownership without changing legacy defaults", async () => {


### PR DESCRIPTION
## Summary

Ordinary managed-provider release previously performed provider deletion inside the request, coupling client latency and request lifetime to provider I/O. This change makes the release transition durable first and leaves deletion, retry, and finalization to the coordinator alarm.

- Persist ordinary releases as `state=released` with `releaseDeletesServer=true` and an immediately expired `cleanupStartedAt` claim before returning.
- Keep the existing cleanup fields and claim timestamp so rollback readers discover the queued work and stale completions remain fenced.
- Preserve synchronous force-admin deletion: it reclaims an expired ordinary-release claim, while a genuinely active cleanup owner still receives `409 cleanup_in_progress`.
- Route JSON release, workspace and private-AWS release, portal release, and ready-pool drain/release through the same release operation.
- Keep `delete:false` non-destructive and repeated delete idempotent, with provider failures retained as visible retry state.

## Compatibility

This uses the existing lease cleanup fields and alarm reconciliation path. It requires no storage migration, protocol change, package-version change, or CLI workaround.

## Verification

- Worker formatting, lint, and TypeScript checks passed.
- Fleet tests: 551/551 passed.
- Private AWS workspace tests: 8/8 passed.
- Full Worker suite: 1,231 passed, 3 skipped.
- Worker dry-run build passed.
- Source-blind release contract: 8/8 clauses passed, backed by 559/559 lifecycle probes.
- `git diff --check`, exact-diff TruffleHog scan, and final structured P1 review passed with no actionable findings.

## Residual risk

No live provider was contacted in this repair pass. Real-provider deletion latency and eventual-consistency timing remain provider-dependent, but they now run behind the durable alarm retry path instead of the release request.
