### PR TITLE
fix(actions): full resync rehydrates adopted workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Invalidated adopted Actions workspace readiness markers before full resync and rehydrated the canonical workspace before running commands. Thanks @vincentkoc.
 - Stopped sparse-checkout and skip-worktree omissions from deleting in-scope remote files, and kept staged gitlink removals out of file-deletion manifests. Thanks @vincentkoc.
 - Deferred ordinary coordinator lease provider cleanup to durable alarm-owned retries while preserving synchronous force-admin deletion and visible retry state. Thanks @fuller-stack-dev.
 - Made future Linux developer-image preparation use root-owned Corepack state while source, candidate, and promoted smoke checks exercise Corepack and pnpm as the runtime user. Thanks @fuller-stack-dev.

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -239,6 +239,14 @@ Standalone `crabbox actions hydrate --id ...` acquires the same remote workspace
 owner as ordinary reused runs, so hydration cannot overlap a sync, command,
 collection, or cleanup from another client.
 
+For an adopted Actions workspace, `--full-resync` invalidates the readiness
+marker before resetting the remote tree. A command-bearing run continues only
+when automatic local hydration can rebuild the canonical lease workspace; it
+otherwise fails before reset. Omit `--no-hydrate` and use the canonical
+workspace for the command path, or use `--sync-only` to reset and sync without
+rehydration or a user command. The full invalidation, reset, sync, hydration,
+and command sequence remains under the reusable workspace owner.
+
 If a JavaScript package-manager command (`pnpm`, `npm`, `node`, `corepack`)
 runs on a raw SSH workspace before a hydration marker exists and no automatic
 hydration is available, Crabbox probes the remote tool first and fails before

--- a/docs/features/actions-hydration.md
+++ b/docs/features/actions-hydration.md
@@ -56,6 +56,14 @@ You can also hydrate explicitly: `crabbox actions hydrate --id <id>` syncs the
 current checkout and then runs the hydrate workflow. Automatic hydration during
 `crabbox run` reuses the run's own sync rather than syncing twice.
 
+When `--full-resync` starts from an existing readiness marker, Crabbox
+invalidates that marker before resetting the workspace. Runs with a command must
+be able to hydrate the canonical lease workspace locally after sync; unsupported
+targets, `--no-hydrate`, and noncanonical adopted workspaces fail before reset.
+Use `--sync-only` when the intent is to replace the synced tree without
+rehydrating or running a command. Reused leases keep this sequence inside the
+workspace lifecycle owner.
+
 ## Local hydration details
 
 For local hydration Crabbox picks the workflow job to run in this order:

--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -497,35 +497,45 @@ func exitCodeForError(err error, fallback int) int {
 	return fallback
 }
 
-func (a App) hydrateActionsLocally(ctx context.Context, cfg Config, repo Repo, target SSHTarget, leaseID, expectedJob string, fields []string, waitTimeout time.Duration, streamOutput bool, syncBefore bool, owner *workspaceOwner) (actionsHydrationState, error) {
+type localActionsHydrationPlan struct {
+	leaseID, workdir, jobName, expectedJob, script, warnings string
+}
+
+func prepareLocalActionsHydration(cfg Config, repo Repo, target SSHTarget, leaseID, expectedJob string, fields []string) (localActionsHydrationPlan, error) {
+	target = targetWithConfigDefaults(target, cfg)
 	if !supportsLocalActionsHydrateTarget(target) {
-		return actionsHydrationState{}, exit(2, "local Actions hydration currently supports Linux and Windows WSL2 targets only")
+		return localActionsHydrationPlan{}, exit(2, "local Actions hydration currently supports Linux and Windows WSL2 targets only")
 	}
 	if err := validateWorkflowInputFields(fields); err != nil {
-		return actionsHydrationState{}, err
+		return localActionsHydrationPlan{}, err
 	}
 	workflowPath, err := localActionsWorkflowPath(repo.Root, cfg.Actions.Workflow)
 	if err != nil {
-		return actionsHydrationState{}, err
+		return localActionsHydrationPlan{}, err
 	}
-	workflow, err := readLocalHydrateWorkflow(workflowPath)
+	data, err := os.ReadFile(workflowPath)
 	if err != nil {
-		return actionsHydrationState{}, err
+		return localActionsHydrationPlan{}, err
+	}
+	workflow, err := parseLocalHydrateWorkflow(data, workflowPath)
+	if err != nil {
+		return localActionsHydrationPlan{}, err
 	}
 	jobName, job, err := selectLocalHydrateJob(workflow, cfg.Actions.Job)
 	if err != nil {
-		return actionsHydrationState{}, exit(2, "workflow %s %v", cfg.Actions.Workflow, err)
+		return localActionsHydrationPlan{}, exit(2, "workflow %s %v", cfg.Actions.Workflow, err)
 	}
-	if inputs, defaults, required, ok, err := parseWorkflowDispatchInputSpecFromFile(workflowPath); err != nil {
-		return actionsHydrationState{}, err
+	var warnings strings.Builder
+	if inputs, defaults, required, ok, err := parseWorkflowDispatchInputSpec(data); err != nil {
+		return localActionsHydrationPlan{}, err
 	} else if ok {
 		fields = applyWorkflowInputDefaults(fields, defaults)
 		if missing := missingRequiredWorkflowInputs(fields, required); len(missing) > 0 {
-			return actionsHydrationState{}, exit(2, "workflow %s requires hydrate input(s) %s; pass them with -f key=value or define defaults", cfg.Actions.Workflow, strings.Join(missing, ","))
+			return localActionsHydrationPlan{}, exit(2, "workflow %s requires hydrate input(s) %s; pass them with -f key=value or define defaults", cfg.Actions.Workflow, strings.Join(missing, ","))
 		}
 		filtered, dropped := filterWorkflowInputs(fields, inputs)
 		for _, field := range dropped {
-			fmt.Fprintf(a.Stderr, "warning: workflow %s does not declare input %s; omitting it\n", cfg.Actions.Workflow, fieldName(field))
+			fmt.Fprintf(&warnings, "warning: workflow %s does not declare input %s; omitting it\n", cfg.Actions.Workflow, fieldName(field))
 		}
 		fields = filtered
 		if !workflowFieldsContain(fields, "crabbox_job") {
@@ -533,31 +543,45 @@ func (a App) hydrateActionsLocally(ctx context.Context, cfg Config, repo Repo, t
 		}
 		for _, required := range []string{"crabbox_id", "crabbox_runner_label", "crabbox_keep_alive_minutes"} {
 			if !inputs[required] {
-				return actionsHydrationState{}, exit(2, "workflow %s does not declare required hydrate input %s", cfg.Actions.Workflow, required)
+				return localActionsHydrationPlan{}, exit(2, "workflow %s does not declare required hydrate input %s", cfg.Actions.Workflow, required)
 			}
 		}
 	}
 	workdir := remoteJoin(cfg, leaseID, repo.Name)
-	if streamOutput {
-		fmt.Fprintf(a.Stdout, "local actions hydrate workflow=%s job=%s workspace=%s\n", cfg.Actions.Workflow, jobName, workdir)
+	script, err := localActionsHydrateScript(cfg, repo, workflow, job, jobName, leaseID, fields, workdir)
+	if err != nil {
+		return localActionsHydrationPlan{}, err
 	}
-	if err := invalidateActionsHydrationWorkspaces(ctx, cfg, repo, target, leaseID); err != nil {
+	return localActionsHydrationPlan{leaseID: leaseID, workdir: workdir, jobName: jobName, expectedJob: expectedJob, script: script, warnings: warnings.String()}, nil
+}
+
+func (a App) hydrateActionsLocally(ctx context.Context, cfg Config, repo Repo, target SSHTarget, leaseID, expectedJob string, fields []string, waitTimeout time.Duration, streamOutput bool, syncBefore bool, owner *workspaceOwner) (actionsHydrationState, error) {
+	plan, err := prepareLocalActionsHydration(cfg, repo, target, leaseID, expectedJob, fields)
+	if err != nil {
 		return actionsHydrationState{}, err
 	}
-	if err := clearActionsHydrationState(ctx, target, leaseID); err != nil {
+	return a.executeLocalActionsHydration(ctx, cfg, repo, target, plan, waitTimeout, streamOutput, syncBefore, owner)
+}
+
+func (a App) executeLocalActionsHydration(ctx context.Context, cfg Config, repo Repo, target SSHTarget, plan localActionsHydrationPlan, waitTimeout time.Duration, streamOutput bool, syncBefore bool, owner *workspaceOwner) (actionsHydrationState, error) {
+	target = targetWithConfigDefaults(target, cfg)
+	fmt.Fprint(a.Stderr, plan.warnings)
+	if streamOutput {
+		fmt.Fprintf(a.Stdout, "local actions hydrate workflow=%s job=%s workspace=%s\n", cfg.Actions.Workflow, plan.jobName, plan.workdir)
+	}
+	if err := invalidateActionsHydrationWorkspaces(ctx, cfg, repo, target, plan.leaseID); err != nil {
+		return actionsHydrationState{}, err
+	}
+	if err := clearActionsHydrationState(ctx, target, plan.leaseID); err != nil {
 		return actionsHydrationState{}, err
 	}
 	if syncBefore {
-		if err := a.syncLocalActionsWorkspace(ctx, cfg, repo, target, workdir); err != nil {
+		if err := a.syncLocalActionsWorkspace(ctx, cfg, repo, target, plan.workdir); err != nil {
 			return actionsHydrationState{}, err
 		}
 	}
-	if _, err := runIdempotentSSHCombinedOutput(ctx, target, remoteInvalidateSyncFingerprintForTarget(target, workdir), idempotentSSHRetryDelay); err != nil {
+	if _, err := runIdempotentSSHCombinedOutput(ctx, target, remoteInvalidateSyncFingerprintForTarget(target, plan.workdir), idempotentSSHRetryDelay); err != nil {
 		return actionsHydrationState{}, exit(7, "invalidate reusable sync fingerprint before Actions hydration: %v", err)
-	}
-	script, err := localActionsHydrateScript(cfg, repo, workflow, job, jobName, leaseID, fields, workdir)
-	if err != nil {
-		return actionsHydrationState{}, err
 	}
 	stdout := io.Discard
 	stderr := io.Discard
@@ -565,11 +589,11 @@ func (a App) hydrateActionsLocally(ctx context.Context, cfg Config, repo Repo, t
 		stdout = a.Stdout
 		stderr = a.Stderr
 	}
-	if err := runSSHInput(ctx, target, remoteInstallLocalActionsHydrateScript(leaseID), strings.NewReader(script), stdout, stderr); err != nil {
+	if err := runSSHInput(ctx, target, remoteInstallLocalActionsHydrateScript(plan.leaseID), strings.NewReader(plan.script), stdout, stderr); err != nil {
 		return actionsHydrationState{}, exit(7, "install local Actions hydration script on %s: %v", target.Host, err)
 	}
 	if isWindowsWSL2Target(target) {
-		remote := remoteRunLocalActionsHydrateScriptForeground(leaseID, waitTimeout)
+		remote := remoteRunLocalActionsHydrateScriptForeground(plan.leaseID, waitTimeout)
 		if err := runSSHInput(ctx, target, remote, nil, stdout, stderr); err != nil {
 			return actionsHydrationState{}, exit(7, "run local Actions hydration on %s: %v", target.Host, err)
 		}
@@ -577,24 +601,24 @@ func (a App) hydrateActionsLocally(ctx context.Context, cfg Config, repo Repo, t
 		if owner != nil {
 			stateCtx = contextWithoutWorkspaceOwner(ctx)
 		}
-		state, err := readActionsHydrationState(stateCtx, target, leaseID)
+		state, err := readActionsHydrationState(stateCtx, target, plan.leaseID)
 		if err != nil || state.Workspace == "" {
 			if err != nil {
-				return actionsHydrationState{}, exit(7, "read local Actions hydration marker for %s: %v", leaseID, err)
+				return actionsHydrationState{}, exit(7, "read local Actions hydration marker for %s: %v", plan.leaseID, err)
 			}
-			return actionsHydrationState{}, exit(7, "local Actions hydration completed without marker for %s", leaseID)
+			return actionsHydrationState{}, exit(7, "local Actions hydration completed without marker for %s", plan.leaseID)
 		}
-		if expectedJob != "" && state.Job != "" && state.Job != expectedJob {
-			return actionsHydrationState{}, exit(5, "local Actions hydration marker for %s came from job %q, expected %q", leaseID, state.Job, expectedJob)
+		if plan.expectedJob != "" && state.Job != "" && state.Job != plan.expectedJob {
+			return actionsHydrationState{}, exit(5, "local Actions hydration marker for %s came from job %q, expected %q", plan.leaseID, state.Job, plan.expectedJob)
 		}
-		if err := ensureLocalActionsRunEnv(ctx, target, leaseID, state); err != nil {
+		if err := ensureLocalActionsRunEnv(ctx, target, plan.leaseID, state); err != nil {
 			return actionsHydrationState{}, err
 		}
 		return state, nil
 	}
-	startRemote := remoteStartLocalActionsHydrateScript(leaseID)
+	startRemote := remoteStartLocalActionsHydrateScript(plan.leaseID)
 	if owner != nil {
-		startRemote = owner.WrapBackgroundCommand(remoteLocalActionsHydrateBackgroundPayload(leaseID))
+		startRemote = owner.WrapBackgroundCommand(remoteLocalActionsHydrateBackgroundPayload(plan.leaseID))
 	}
 	startCtx := ctx
 	if owner != nil {
@@ -608,7 +632,7 @@ func (a App) hydrateActionsLocally(ctx context.Context, cfg Config, repo Repo, t
 	if owner != nil {
 		waitCtx = contextWithoutWorkspaceOwner(ctx)
 	}
-	state, err := waitForLocalActionsHydration(waitCtx, target, leaseID, expectedJob, strings.TrimSpace(pid), waitTimeout, stderr)
+	state, err := waitForLocalActionsHydration(waitCtx, target, plan.leaseID, plan.expectedJob, strings.TrimSpace(pid), waitTimeout, stderr)
 	if err != nil {
 		return actionsHydrationState{}, err
 	}
@@ -710,14 +734,6 @@ func (a App) syncLocalActionsWorkspace(ctx context.Context, cfg Config, repo Rep
 	return nil
 }
 
-func parseWorkflowDispatchInputSpecFromFile(path string) (map[string]bool, map[string]string, map[string]bool, bool, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, nil, nil, false, err
-	}
-	return parseWorkflowDispatchInputSpec(data)
-}
-
 func localActionsWorkflowPath(root, workflow string) (string, error) {
 	workflow = strings.TrimSpace(strings.TrimPrefix(workflow, "/"))
 	if workflow == "" {
@@ -817,12 +833,8 @@ type localCompositeRuns struct {
 	Steps []localHydrateStep `yaml:"steps"`
 }
 
-func readLocalHydrateWorkflow(path string) (localHydrateWorkflow, error) {
+func parseLocalHydrateWorkflow(data []byte, path string) (localHydrateWorkflow, error) {
 	var workflow localHydrateWorkflow
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return workflow, err
-	}
 	if err := yaml.Unmarshal(data, &workflow); err != nil {
 		return workflow, err
 	}
@@ -2402,6 +2414,22 @@ func clearActionsHydrationState(ctx context.Context, target SSHTarget, leaseID s
 	return exit(7, "clear GitHub Actions hydration marker on %s: %v", target.Host, lastErr)
 }
 
+func invalidateActionsHydrationMarker(ctx context.Context, target SSHTarget, leaseID string) error {
+	remote := remoteInvalidateActionsHydrationMarkerForTarget(target, leaseID)
+	lastOutput, lastErr := runIdempotentSSHCombinedOutput(ctx, target, remote, idempotentSSHRetryDelay)
+	if lastErr == nil {
+		return nil
+	}
+	details := strings.TrimSpace(lastOutput)
+	if target.AuthSecret {
+		details = RedactDiagnosticSecrets(details, target.User)
+	}
+	if details != "" {
+		return exit(7, "invalidate GitHub Actions hydration marker on %s: %v: %s", target.Host, lastErr, details)
+	}
+	return exit(7, "invalidate GitHub Actions hydration marker on %s: %v", target.Host, lastErr)
+}
+
 func writeActionsHydrationStop(ctx context.Context, target SSHTarget, leaseID string) error {
 	if err := runSSHQuiet(ctx, target, remoteWriteActionsHydrationStopForTarget(target, leaseID)); err != nil {
 		return exit(7, "write GitHub Actions hydration stop marker on %s: %v", target.Host, err)
@@ -2469,6 +2497,23 @@ exit 0
 `)
 	}
 	return remoteReadActionsHydrationState(leaseID)
+}
+
+func remoteInvalidateActionsHydrationMarker(leaseID string) string {
+	return "rm -f \"$HOME\"/" + shellQuote(actionsHydrationStatePath(leaseID))
+}
+
+func remoteInvalidateActionsHydrationMarkerForTarget(target SSHTarget, leaseID string) string {
+	if isWindowsNativeTarget(target) {
+		return powershellCommand(`$ErrorActionPreference = "Stop"
+$path = ` + psQuote(windowsActionsHydrationPath(actionsHydrationStatePath(leaseID))) + `
+if (Test-Path -LiteralPath $path) {
+  Remove-Item -LiteralPath $path -Force -ErrorAction Stop
+}
+exit 0
+`)
+	}
+	return remoteInvalidateActionsHydrationMarker(leaseID)
 }
 
 func remoteInstallLocalActionsHydrateScript(leaseID string) string {

--- a/internal/cli/actions_test.go
+++ b/internal/cli/actions_test.go
@@ -1270,6 +1270,173 @@ func TestMissingRequiredWorkflowInputs(t *testing.T) {
 	}
 }
 
+func TestPrepareLocalActionsHydrationFreezesDispatchInputsAndScript(t *testing.T) {
+	root := t.TempDir()
+	workflowPath := filepath.Join(root, ".github", "workflows", "hydrate.yml")
+	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	workflow := `name: Hydrate
+on:
+  workflow_dispatch:
+    inputs:
+      crabbox_id:
+        required: true
+      crabbox_runner_label:
+        required: true
+      crabbox_keep_alive_minutes:
+        required: true
+      suite:
+        default: smoke
+jobs:
+  build:
+    steps:
+      - run: echo "${{ inputs.suite }}"
+`
+	if err := os.WriteFile(workflowPath, []byte(workflow), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := defaultConfig()
+	cfg.Actions.Workflow = ".github/workflows/hydrate.yml"
+	repo := Repo{Root: root, Name: "repo", Head: strings.Repeat("a", 40)}
+	fields := actionsHydrateFields("cbx_123", "crabbox-cbx-123", "legacy", 0, []string{"extra=value"})
+	plan, err := prepareLocalActionsHydration(cfg, repo, SSHTarget{}, "cbx_123", "legacy", fields)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.leaseID != "cbx_123" || plan.jobName != "build" || plan.expectedJob != "" {
+		t.Fatalf("unexpected plan identity: %#v", plan)
+	}
+	if want := remoteJoin(cfg, "cbx_123", "repo"); plan.workdir != want {
+		t.Fatalf("workdir=%q want %q", plan.workdir, want)
+	}
+	for _, want := range []string{"export INPUT_SUITE='smoke'", "does not declare input crabbox_job", "does not declare input extra"} {
+		if !strings.Contains(plan.script+plan.warnings, want) {
+			t.Fatalf("prepared plan missing %q:\nscript=%s\nwarnings=%s", want, plan.script, plan.warnings)
+		}
+	}
+	if strings.Contains(plan.script, "${{") {
+		t.Fatalf("prepared script retained expression:\n%s", plan.script)
+	}
+}
+
+func TestPrepareLocalActionsHydrationRejectsUnsupportedRenderedWorkflow(t *testing.T) {
+	tests := []struct {
+		name      string
+		step      string
+		actionYML string
+		want      string
+	}{
+		{name: "expression", step: `run: echo "${{ matrix.node }}"`, want: "does not support expression"},
+		{name: "non-composite local action", step: "uses: ./action", actionYML: "runs:\n  using: node20\n", want: "only supports repo-local composite actions"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			workflowPath := filepath.Join(root, ".github", "workflows", "hydrate.yml")
+			if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			workflow := "jobs:\n  hydrate:\n    steps:\n      - " + tt.step + "\n"
+			if err := os.WriteFile(workflowPath, []byte(workflow), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if tt.actionYML != "" {
+				actionPath := filepath.Join(root, "action", "action.yml")
+				if err := os.MkdirAll(filepath.Dir(actionPath), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(actionPath, []byte(tt.actionYML), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			cfg := defaultConfig()
+			cfg.Actions.Workflow = ".github/workflows/hydrate.yml"
+			_, err := prepareLocalActionsHydration(cfg, Repo{Root: root, Name: "repo"}, SSHTarget{}, "cbx_123", "", nil)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error=%v want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestExecuteLocalActionsHydrationNormalizesConfigDerivedWSL2Target(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell ssh fixture")
+	}
+	dir := t.TempDir()
+	sshPath := filepath.Join(dir, "ssh")
+	logPath := filepath.Join(dir, "ssh.log")
+	hydratedPath := filepath.Join(dir, "hydrated")
+	sshScript := `#!/bin/sh
+remote=""
+for arg do remote="$arg"; done
+decoded="$remote"
+decode_base64() {
+  if [ "$(/usr/bin/uname -s)" = Darwin ]; then
+    /usr/bin/base64 -D
+  else
+    /usr/bin/base64 -d
+  fi
+}
+case "$remote" in
+  *" -EncodedCommand "*)
+    encoded=${remote##* }
+    outer=$(printf '%s' "$encoded" | decode_base64 | /usr/bin/iconv -f UTF-16LE -t UTF-8)
+    nested=$(printf '%s\n' "$outer" | /usr/bin/sed -n 's/.*FromBase64String("\([^"]*\)").*/\1/p' | /usr/bin/head -1)
+    if [ -n "$nested" ]; then
+      decoded=$(printf '%s' "$nested" | decode_base64)
+    else
+      decoded="$outer"
+    fi
+    ;;
+esac
+printf '%s\n---\n' "$decoded" >> "$CRABBOX_FAKE_SSH_LOG"
+case "$decoded" in
+  *"nohup"*) exit 42 ;;
+  *"timeout --signal=TERM"*) : > "$CRABBOX_FAKE_HYDRATED"; exit 0 ;;
+  *"cat"*".crabbox/actions/cbx_123.env"*)
+    if [ -e "$CRABBOX_FAKE_HYDRATED" ]; then
+      printf '%s\n' \
+        'WORKSPACE=/work/cbx_123/repo' \
+        'ENV_FILE=/home/crabbox/.crabbox/actions/cbx_123.env.sh'
+    fi
+    ;;
+esac
+/bin/cat >/dev/null || true
+exit 0
+`
+	if err := os.WriteFile(sshPath, []byte(sshScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CRABBOX_FAKE_SSH_LOG", logPath)
+	t.Setenv("CRABBOX_FAKE_HYDRATED", hydratedPath)
+	cfg := defaultConfig()
+	cfg.TargetOS = targetWindows
+	cfg.WindowsMode = windowsModeWSL2
+	plan := localActionsHydrationPlan{
+		leaseID: "cbx_123",
+		workdir: "/work/cbx_123/repo",
+		jobName: "hydrate",
+		script:  "echo ok\n",
+	}
+	target := SSHTarget{User: "crabbox", Host: "127.0.0.1", Port: "22"}
+	app := App{Stdout: io.Discard, Stderr: io.Discard}
+	if _, err := app.executeLocalActionsHydration(context.Background(), cfg, Repo{Name: "repo"}, target, plan, time.Minute, false, false, nil); err != nil {
+		logData, _ := os.ReadFile(logPath)
+		t.Fatalf("%v\n%s", err, logData)
+	}
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	logText := string(logData)
+	if !strings.Contains(logText, "timeout --signal=TERM") || strings.Contains(logText, "nohup") {
+		t.Fatalf("config-derived WSL2 target used the wrong hydration path:\n%s", logText)
+	}
+}
+
 func TestLocalActionsHydrateScriptRejectsUnsupportedUses(t *testing.T) {
 	_, err := localActionsHydrateScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, localHydrateJob{
 		Steps: []localHydrateStep{{Uses: "docker/login-action@v3"}},
@@ -1441,6 +1608,46 @@ func TestRemoteClearActionsHydrationStateRemovesReadyAndStop(t *testing.T) {
 	}
 }
 
+func TestRemoteInvalidateActionsHydrationMarkerPreservesBookkeeping(t *testing.T) {
+	leaseID := "cbx_123"
+	bookkeepingPaths := []string{
+		actionsHydrationEnvPath(leaseID),
+		actionsHydrationServicesPath(leaseID),
+		actionsHydrationStopPath(leaseID),
+		actionsHydrationLocalScriptPath(leaseID),
+		actionsHydrationLocalLogPath(leaseID),
+		actionsHydrationLocalExitPath(leaseID),
+	}
+	t.Run("posix", func(t *testing.T) {
+		got := remoteInvalidateActionsHydrationMarkerForTarget(SSHTarget{TargetOS: targetLinux}, leaseID)
+		if !strings.Contains(got, actionsHydrationStatePath(leaseID)) {
+			t.Fatalf("invalidate command missing readiness marker:\n%s", got)
+		}
+		for _, path := range bookkeepingPaths {
+			if strings.Contains(got, path) {
+				t.Fatalf("invalidate command removes bookkeeping path %q:\n%s", path, got)
+			}
+		}
+	})
+	t.Run("windows", func(t *testing.T) {
+		target := SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeNormal}
+		got := decodePowerShellCommand(t, remoteInvalidateActionsHydrationMarkerForTarget(target, leaseID))
+		if !strings.Contains(got, windowsActionsHydrationPath(actionsHydrationStatePath(leaseID))) {
+			t.Fatalf("invalidate command missing readiness marker:\n%s", got)
+		}
+		for _, want := range []string{`$ErrorActionPreference = "Stop"`, "Test-Path -LiteralPath $path", "Remove-Item -LiteralPath $path -Force -ErrorAction Stop"} {
+			if !strings.Contains(got, want) {
+				t.Fatalf("invalidate command missing fail-closed operation %q:\n%s", want, got)
+			}
+		}
+		for _, path := range bookkeepingPaths {
+			if strings.Contains(got, windowsActionsHydrationPath(path)) {
+				t.Fatalf("invalidate command removes bookkeeping path %q:\n%s", path, got)
+			}
+		}
+	})
+}
+
 func TestRemoteWriteActionsHydrationStopMatchesWorkflowInput(t *testing.T) {
 	got := remoteWriteActionsHydrationStop("cbx_123")
 	for _, want := range []string{
@@ -1454,11 +1661,12 @@ func TestRemoteWriteActionsHydrationStopMatchesWorkflowInput(t *testing.T) {
 }
 
 func TestWindowsActionsHydrationMarkerCommandsUseProgramData(t *testing.T) {
-	target := SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeNormal}
+	target := targetWithConfigDefaults(SSHTarget{}, Config{TargetOS: targetWindows, WindowsMode: windowsModeNormal})
 	for name, command := range map[string]string{
-		"read":  remoteReadActionsHydrationStateForTarget(target, "cbx_123"),
-		"clear": remoteClearActionsHydrationStateForTarget(target, "cbx_123"),
-		"stop":  remoteWriteActionsHydrationStopForTarget(target, "cbx_123"),
+		"read":       remoteReadActionsHydrationStateForTarget(target, "cbx_123"),
+		"invalidate": remoteInvalidateActionsHydrationMarkerForTarget(target, "cbx_123"),
+		"clear":      remoteClearActionsHydrationStateForTarget(target, "cbx_123"),
+		"stop":       remoteWriteActionsHydrationStopForTarget(target, "cbx_123"),
 	} {
 		decoded := decodePowerShellCommand(t, command)
 		for _, want := range []string{`C:\ProgramData\crabbox\actions`, `cbx_123`} {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1068,6 +1068,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	actionsURL := ""
 	hydratedByActions = false
 	autoHydrateActions := shouldAutoHydrateActions(cfg, *noHydrate, *noSync, freshPR, *syncOnly)
+	var preparedActionsHydration *localActionsHydrationPlan
 	if !freshPR.Empty() {
 		workdir = remoteJoin(cfg, leaseID, freshPR.WorkdirName())
 	} else {
@@ -1159,6 +1160,15 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		suggestion := rawJSRuntimeHydrateSuggestion(cfg, hydrateTarget, leaseID, acquired, *keep, *keepOnFailure)
 		return rawJSRuntimeMissingError(cfg, missing, command, *shellMode, suggestion)
 	}
+	handleActionsHydrationFailure := func(currentTarget SSHTarget, failure error) error {
+		if *keepOnFailure {
+			if acquired && !*keep {
+				keepFailedLease = true
+			}
+			printKeepOnFailureSSHHint(a.Stderr, cfg, leaseID, server, currentTarget)
+		}
+		return failure
+	}
 	autoHydrateActionsIfNeeded := func(currentTarget SSHTarget) error {
 		if !autoHydrateActions || hydratedByActions {
 			return nil
@@ -1175,16 +1185,25 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		}
 		fields := actionsHydrateFields(leaseID, githubActionsLeaseLabel(leaseID), cfg.Actions.Job, 0, cfg.Actions.Fields)
 		recorder.Event("actions.hydrate.started", "hydrate", cfg.Actions.Workflow)
-		state, err := a.hydrateActionsLocally(ctx, cfg, repo, currentTarget, leaseID, cfg.Actions.Job, fields, 20*time.Minute, false, false, lifecycleOwner)
+		plan := preparedActionsHydration
+		preparedActionsHydration = nil
+		var state actionsHydrationState
+		var err error
+		if plan == nil {
+			var prepared localActionsHydrationPlan
+			prepared, err = prepareLocalActionsHydration(cfg, repo, currentTarget, leaseID, cfg.Actions.Job, fields)
+			if err == nil {
+				plan = &prepared
+			}
+		} else if plan.leaseID != leaseID || plan.workdir != workdir {
+			err = exit(7, "prepared local Actions hydration no longer matches lease=%s workspace=%s", leaseID, workdir)
+		}
+		if err == nil {
+			state, err = a.executeLocalActionsHydration(ctx, cfg, repo, currentTarget, *plan, 20*time.Minute, false, false, lifecycleOwner)
+		}
 		if err != nil {
 			recorder.Event("actions.hydrate.failed", "hydrate", err.Error())
-			if *keepOnFailure {
-				if acquired && !*keep {
-					keepFailedLease = true
-				}
-				printKeepOnFailureSSHHint(a.Stderr, cfg, leaseID, server, currentTarget)
-			}
-			return err
+			return handleActionsHydrationFailure(currentTarget, err)
 		}
 		workdir = state.Workspace
 		actionsEnvFile = state.EnvFile
@@ -1264,6 +1283,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		if !freshPR.Empty() {
 			workdir = remoteJoin(cfg, leaseID, freshPR.WorkdirName())
 		}
+		preparedActionsHydration = nil
 		actionsEnvFile = ""
 		profileEnvFile = ""
 		actionsURL = ""
@@ -1280,6 +1300,21 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		return true, nil
 	}
 retrySync:
+	if fullResyncRequested && hydratedByActions && !*syncOnly {
+		if !autoHydrateActions {
+			return recordFailure(exit(2, "--full-resync would invalidate the adopted Actions workspace for %s, but this run cannot rehydrate it; configure actions.workflow and omit --no-hydrate, or use --sync-only", leaseID))
+		}
+		localHydrateWorkdir := remoteJoin(cfg, leaseID, repo.Name)
+		if workdir != localHydrateWorkdir {
+			return recordFailure(exit(2, "--full-resync cannot rehydrate adopted Actions workspace %s because local hydration uses %s; use --sync-only or hydrate the canonical workspace first", workdir, localHydrateWorkdir))
+		}
+		fields := actionsHydrateFields(leaseID, githubActionsLeaseLabel(leaseID), cfg.Actions.Job, 0, cfg.Actions.Fields)
+		plan, err := prepareLocalActionsHydration(cfg, repo, target, leaseID, cfg.Actions.Job, fields)
+		if err != nil {
+			return recordFailure(handleActionsHydrationFailure(target, err))
+		}
+		preparedActionsHydration = &plan
+	}
 	if !*noSync {
 		syncStart := time.Now()
 		if freshPR.Empty() {
@@ -1403,6 +1438,17 @@ retrySync:
 					goto afterSync
 				}
 			}
+		}
+		if fullResyncRequested && hydratedByActions {
+			// Readiness belongs to the adopted tree. Invalidate it before reset so
+			// afterSync must establish readiness on the replacement tree.
+			hydrateTarget := targetWithConfigDefaults(target, cfg)
+			if err := invalidateActionsHydrationMarker(ctx, hydrateTarget, leaseID); err != nil {
+				return recordFailure(err)
+			}
+			hydratedByActions = false
+			actionsEnvFile = ""
+			actionsURL = ""
 		}
 		if fullResyncRequested {
 			stepStart = time.Now()

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -2427,6 +2427,328 @@ func TestFullResyncSeedsPruneManifestFromGit(t *testing.T) {
 	}
 }
 
+type fullResyncActionsTestOptions struct {
+	noHydrate        bool
+	syncOnly         bool
+	failInvalidation bool
+	adoptedWorkspace string
+	workflow         string
+	mutateWorkflow   bool
+}
+
+type fullResyncActionsTestResult struct {
+	err             error
+	stdout          string
+	stderr          string
+	events          []string
+	resetCommand    string
+	syncTarget      string
+	hydrationScript string
+}
+
+func runFullResyncActionsTest(t *testing.T, opts fullResyncActionsTestOptions) fullResyncActionsTestResult {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell ssh fixture")
+	}
+	clearConfigEnv(t)
+	dir := t.TempDir()
+	isolateRunTestUserDirs(t, dir)
+	repoRoot := filepath.Join(dir, "crabbox")
+	workflowPath := filepath.Join(repoRoot, ".github", "workflows", "hydrate.yml")
+	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	workflow := opts.workflow
+	if workflow == "" {
+		workflow = `name: Hydrate
+on:
+  workflow_dispatch:
+    inputs:
+      crabbox_id:
+        required: true
+      crabbox_runner_label:
+        required: true
+      crabbox_keep_alive_minutes:
+        required: true
+jobs:
+  hydrate:
+    steps:
+      - run: echo prepared-snapshot
+`
+	}
+	if err := os.WriteFile(workflowPath, []byte(workflow), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"init", "-q"},
+		{"config", "user.email", "test@example.com"},
+		{"config", "user.name", "Crabbox Test"},
+		{"add", "."},
+		{"commit", "-qm", "fixture"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repoRoot
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	t.Chdir(repoRoot)
+	sshPath := filepath.Join(dir, "ssh")
+	rsyncPath := filepath.Join(dir, "rsync")
+	eventsPath := filepath.Join(dir, "events")
+	hydratedPath := filepath.Join(dir, "hydrated")
+	resetCommandPath := filepath.Join(dir, "reset-command")
+	syncTargetPath := filepath.Join(dir, "sync-target")
+	hydrationScriptPath := filepath.Join(dir, "hydration-script")
+	configPath := filepath.Join(dir, ".crabbox.yaml")
+	sshScript := `#!/bin/sh
+remote=""
+for arg do remote="$arg"; done
+case "$remote" in
+  *"protocol_action='acquire'"*) printf 'owner-acquire\n' >> "$CRABBOX_FAKE_EVENTS"; printf ACQUIRED; exit 0 ;;
+  *"protocol_action='renew'"*) printf RENEWED; exit 0 ;;
+  *"protocol_action='inspect'"*)
+    if [ -e "$CRABBOX_FAKE_OWNER_CHILD" ]; then printf CHILD; else printf OWNED; fi
+    exit 0
+    ;;
+  *"protocol_action='release'"*) printf 'owner-release\n' >> "$CRABBOX_FAKE_EVENTS"; printf RELEASED; exit 0 ;;
+  *"rsync-stop."*"phase_live="*)
+    : > "$CRABBOX_FAKE_OWNER_CHILD"
+    printf '123\n'
+    exit 0
+    ;;
+  *'touch "$HOME/.crabbox/workspace-owners/'*"rsync-stop."*)
+    rm -f "$CRABBOX_FAKE_OWNER_CHILD"
+    exit 0
+    ;;
+  *"rm -f"*".crabbox/actions/cbx_env_profile_test.env.sh"*)
+    printf 'clear\n' >> "$CRABBOX_FAKE_EVENTS"
+    ;;
+  *"rm -f"*".crabbox/actions/cbx_env_profile_test.env"*)
+    printf 'invalidate\n' >> "$CRABBOX_FAKE_EVENTS"
+    if [ "${CRABBOX_FAKE_INVALIDATE_FAIL:-0}" = "1" ]; then
+      printf 'marker invalidation denied\n' >&2
+      exit 1
+    fi
+    if [ "${CRABBOX_FAKE_MUTATE_WORKFLOW:-0}" = "1" ]; then
+      cat > "$CRABBOX_FAKE_WORKFLOW_PATH" <<'EOF'
+jobs:
+  hydrate:
+    steps:
+      - run: echo "${{ matrix.node }}"
+EOF
+    fi
+    ;;
+  *"rm -rf --"*)
+    printf 'reset\n' >> "$CRABBOX_FAKE_EVENTS"
+    printf '%s\n' "$remote" > "$CRABBOX_FAKE_RESET_COMMAND"
+    ;;
+  *"cat >"*"cbx_env_profile_test.local.sh"*)
+    /bin/cat > "$CRABBOX_FAKE_HYDRATION_SCRIPT"
+    exit 0
+    ;;
+  *"nohup"*"cbx_env_profile_test.local.sh"*)
+    printf 'hydrate\n' >> "$CRABBOX_FAKE_EVENTS"
+    : > "$CRABBOX_FAKE_HYDRATED"
+    printf '123\n'
+    ;;
+  *"cat "*".crabbox/actions/cbx_env_profile_test.env"*)
+    if [ -e "$CRABBOX_FAKE_HYDRATED" ]; then
+      printf 'WORKSPACE=%s\n' "$CRABBOX_FAKE_CANONICAL_WORKSPACE"
+      printf '%s\n' \
+        'RUN_ID=local-cbx_env_profile_test' \
+        'ENV_FILE=/home/crabbox/.crabbox/actions/cbx_env_profile_test.env.sh'
+    else
+      printf 'WORKSPACE=%s\n' "$CRABBOX_FAKE_ADOPTED_WORKSPACE"
+      printf '%s\n' \
+        'RUN_ID=123' \
+        'ENV_FILE=/home/crabbox/.crabbox/actions/cbx_env_profile_test.env.sh'
+    fi
+    ;;
+  *"pnpm"*"test"*)
+    printf 'command\n' >> "$CRABBOX_FAKE_EVENTS"
+    ;;
+esac
+/bin/cat >/dev/null || true
+exit 0
+`
+	rsyncScript := `#!/bin/sh
+printf 'sync\n' >> "$CRABBOX_FAKE_EVENTS"
+last=""
+for arg do last="$arg"; done
+printf '%s\n' "$last" > "$CRABBOX_FAKE_SYNC_TARGET"
+exit 0
+`
+	if err := os.WriteFile(sshPath, []byte(sshScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(rsyncPath, []byte(rsyncScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, []byte("actions:\n  workflow: .github/workflows/hydrate.yml\nsync:\n  fingerprint: false\n  gitSeed: false\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CRABBOX_CONFIG", configPath)
+	t.Setenv("CRABBOX_FAKE_SSH_PORT", "22")
+	t.Setenv("CRABBOX_FAKE_SSH_PROXY", "1")
+	t.Setenv("CRABBOX_FAKE_EVENTS", eventsPath)
+	t.Setenv("CRABBOX_FAKE_HYDRATED", hydratedPath)
+	t.Setenv("CRABBOX_FAKE_RESET_COMMAND", resetCommandPath)
+	t.Setenv("CRABBOX_FAKE_SYNC_TARGET", syncTargetPath)
+	t.Setenv("CRABBOX_FAKE_HYDRATION_SCRIPT", hydrationScriptPath)
+	t.Setenv("CRABBOX_FAKE_WORKFLOW_PATH", workflowPath)
+	t.Setenv("CRABBOX_FAKE_OWNER_CHILD", filepath.Join(dir, "owner-child"))
+	canonicalWorkspace := remoteJoin(defaultConfig(), "cbx_env_profile_test", "crabbox")
+	adoptedWorkspace := opts.adoptedWorkspace
+	if adoptedWorkspace == "" {
+		adoptedWorkspace = canonicalWorkspace
+	}
+	t.Setenv("CRABBOX_FAKE_CANONICAL_WORKSPACE", canonicalWorkspace)
+	t.Setenv("CRABBOX_FAKE_ADOPTED_WORKSPACE", adoptedWorkspace)
+	if opts.failInvalidation {
+		t.Setenv("CRABBOX_FAKE_INVALIDATE_FAIL", "1")
+	}
+	if opts.mutateWorkflow {
+		t.Setenv("CRABBOX_FAKE_MUTATE_WORKFLOW", "1")
+	}
+	args := []string{
+		"--provider", "run-env-profile-test",
+		"--id", "cbx_env_profile_test",
+		"--full-resync",
+	}
+	if opts.noHydrate {
+		args = append(args, "--no-hydrate")
+	}
+	if opts.syncOnly {
+		args = append(args, "--sync-only")
+	} else {
+		args = append(args, "--", "pnpm", "test")
+	}
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), args)
+	eventsData, readErr := os.ReadFile(eventsPath)
+	if readErr != nil && !os.IsNotExist(readErr) {
+		t.Fatal(readErr)
+	}
+	readOptional := func(path string) string {
+		data, err := os.ReadFile(path)
+		if err != nil && !os.IsNotExist(err) {
+			t.Fatal(err)
+		}
+		return string(data)
+	}
+	return fullResyncActionsTestResult{
+		err:             err,
+		stdout:          stdout.String(),
+		stderr:          stderr.String(),
+		events:          strings.Fields(string(eventsData)),
+		resetCommand:    readOptional(resetCommandPath),
+		syncTarget:      readOptional(syncTargetPath),
+		hydrationScript: readOptional(hydrationScriptPath),
+	}
+}
+
+func assertRunEvents(t *testing.T, got, want []string) {
+	t.Helper()
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("events=%v want %v", got, want)
+	}
+}
+
+func TestRunCommandFullResyncRehydratesAdoptedActionsWorkspaceInOrderUnderOwner(t *testing.T) {
+	result := runFullResyncActionsTest(t, fullResyncActionsTestOptions{})
+	if result.err != nil {
+		t.Fatalf("run error=%v\nstdout=%s\nstderr=%s", result.err, result.stdout, result.stderr)
+	}
+	assertRunEvents(t, result.events, []string{"owner-acquire", "invalidate", "reset", "sync", "clear", "hydrate", "command", "owner-release"})
+	canonicalWorkspace := remoteJoin(defaultConfig(), "cbx_env_profile_test", "crabbox")
+	for name, value := range map[string]string{
+		"reset command":    result.resetCommand,
+		"sync target":      result.syncTarget,
+		"hydration script": result.hydrationScript,
+	} {
+		if !strings.Contains(value, canonicalWorkspace) {
+			t.Fatalf("%s does not use canonical workspace %q:\n%s", name, canonicalWorkspace, value)
+		}
+	}
+}
+
+func TestRunCommandFullResyncRejectsUnsupportedWorkflowBeforeRemoteMutation(t *testing.T) {
+	result := runFullResyncActionsTest(t, fullResyncActionsTestOptions{workflow: `jobs:
+  hydrate:
+    steps:
+      - run: echo "${{ matrix.node }}"
+`})
+	var exitErr ExitError
+	if !AsExitError(result.err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("error=%v, want exit 2\nstdout=%s\nstderr=%s", result.err, result.stdout, result.stderr)
+	}
+	assertRunEvents(t, result.events, []string{"owner-acquire", "owner-release"})
+}
+
+func TestRunCommandFullResyncUsesPreparedWorkflowSnapshot(t *testing.T) {
+	result := runFullResyncActionsTest(t, fullResyncActionsTestOptions{mutateWorkflow: true})
+	if result.err != nil {
+		t.Fatalf("run error=%v\nstdout=%s\nstderr=%s", result.err, result.stdout, result.stderr)
+	}
+	if !strings.Contains(result.hydrationScript, "prepared-snapshot") || strings.Contains(result.hydrationScript, "matrix.node") {
+		t.Fatalf("hydration did not use prepared workflow snapshot:\n%s", result.hydrationScript)
+	}
+}
+
+func TestRunCommandFullResyncRejectsNonCanonicalAdoptedActionsWorkspace(t *testing.T) {
+	result := runFullResyncActionsTest(t, fullResyncActionsTestOptions{adoptedWorkspace: "/work/actions/crabbox"})
+	var exitErr ExitError
+	if !AsExitError(result.err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("error=%v, want exit 2\nstdout=%s\nstderr=%s", result.err, result.stdout, result.stderr)
+	}
+	if !strings.Contains(exitErr.Message, "local hydration uses") {
+		t.Fatalf("message=%q", exitErr.Message)
+	}
+	assertRunEvents(t, result.events, []string{"owner-acquire", "owner-release"})
+}
+
+func TestRunCommandFullResyncNoHydrateFailsBeforeResetOrCommand(t *testing.T) {
+	result := runFullResyncActionsTest(t, fullResyncActionsTestOptions{noHydrate: true})
+	var exitErr ExitError
+	if !AsExitError(result.err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("error=%v, want exit 2\nstdout=%s\nstderr=%s", result.err, result.stdout, result.stderr)
+	}
+	if !strings.Contains(exitErr.Message, "cannot rehydrate") {
+		t.Fatalf("message=%q", exitErr.Message)
+	}
+	assertRunEvents(t, result.events, []string{"owner-acquire", "owner-release"})
+}
+
+func TestRunCommandFullResyncInvalidationFailureStopsBeforeResetOrCommand(t *testing.T) {
+	result := runFullResyncActionsTest(t, fullResyncActionsTestOptions{failInvalidation: true})
+	var exitErr ExitError
+	if !AsExitError(result.err, &exitErr) || exitErr.Code != 7 {
+		t.Fatalf("error=%v, want exit 7\nstdout=%s\nstderr=%s", result.err, result.stdout, result.stderr)
+	}
+	if !strings.Contains(exitErr.Message, "invalidate GitHub Actions hydration marker") {
+		t.Fatalf("message=%q", exitErr.Message)
+	}
+	assertRunEvents(t, result.events, []string{"owner-acquire", "invalidate", "owner-release"})
+}
+
+func TestRunCommandFullResyncSyncOnlyInvalidatesWithoutRehydrate(t *testing.T) {
+	const adoptedWorkspace = "/work/actions/crabbox"
+	result := runFullResyncActionsTest(t, fullResyncActionsTestOptions{syncOnly: true, adoptedWorkspace: adoptedWorkspace})
+	if result.err != nil {
+		t.Fatalf("run error=%v\nstdout=%s\nstderr=%s", result.err, result.stdout, result.stderr)
+	}
+	assertRunEvents(t, result.events, []string{"owner-acquire", "invalidate", "reset", "sync", "owner-release"})
+	if !strings.Contains(result.resetCommand, adoptedWorkspace) || !strings.Contains(result.syncTarget, adoptedWorkspace) {
+		t.Fatalf("sync-only did not preserve adopted workspace reset/sync:\nreset=%s\nsync=%s", result.resetCommand, result.syncTarget)
+	}
+	if result.hydrationScript != "" {
+		t.Fatalf("sync-only unexpectedly installed hydration script:\n%s", result.hydrationScript)
+	}
+}
+
 func TestAllowRemoteSyncMassDeletionsForIncludeWhitelist(t *testing.T) {
 	cfg := baseConfig()
 	t.Setenv("CRABBOX_ALLOW_MASS_DELETIONS", "")


### PR DESCRIPTION
## What Problem This Solves

An adopted GitHub Actions workspace could retain a readiness marker across
`--full-resync`. Crabbox would destructively replace the remote tree while the
old marker still described the workspace as hydrated, allowing a user command
to start against a newly recreated but unhydrated checkout.

## Root Cause and Fix

The full-resync path treated the hydration marker as authoritative through the
reset and did not guarantee that local hydration could reconstruct the
canonical lease workspace afterward. Crabbox now prepares the workflow inputs
and hydration script before remote mutation, invalidates only the readiness
marker, resets and syncs the workspace, clears stale hydration state, rehydrates
the canonical workspace, and only then executes the user command.

The prepared workflow snapshot is deliberately reused after reset. If the
workflow does not declare `crabbox_job`, the filtered plan clears the expected
job so execution does not require marker data the workflow could not receive.

## Compatibility and Ownership

The accepted compatibility contract is fail-closed: a command-bearing adopted
workspace run stops before reset when hydration is disabled, the workflow is
unsupported, or the adopted workdir is not the canonical local-hydration
workspace. `--sync-only` remains available to invalidate, reset, and sync an
adopted workdir without hydration or a user command.

The complete invalidation → reset → sync → clear → hydrate → command lifecycle
runs under the reusable-workspace owner lock introduced by
https://github.com/openclaw/crabbox/pull/1246. Marker invalidation uses the
existing idempotent SSH retry behavior. Target defaults are normalized before
command selection, so POSIX and WSL2 use the POSIX marker path while native
Windows uses the ProgramData PowerShell path.

## Verification

- Focused ordering, fail-closed, sync-only, prepared-snapshot, POSIX, WSL2,
  native-Windows, and owner-lock tests
- `go test -race ./internal/cli ./internal/providers/daytona ./internal/providers/blacksmith`
- `go test -p 1 ./...`
- `go vet ./...`
- `scripts/test-go-modules.sh`
- `scripts/check-go-coverage.sh 90.0` (`90.0%`)
- `scripts/check-docs.sh`
- Source-blind CLI validation of canonical rehydration, failure-before-mutation,
  repeated sync-only behavior, and WSL2 target handling
- Linux Testbox proof for the WSL2 normalization fixture
- TruffleHog and final P1 autoreview: clean

There is no configuration migration, secret migration, or credential handling
change.
