### PR TITLE
fix(sync): stop sparse checkouts from deleting scoped files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Stopped sparse-checkout and skip-worktree omissions from deleting in-scope remote files, and kept staged gitlink removals out of file-deletion manifests. Thanks @vincentkoc.
 - Deferred ordinary coordinator lease provider cleanup to durable alarm-owned retries while preserving synchronous force-admin deletion and visible retry state. Thanks @fuller-stack-dev.
 - Made future Linux developer-image preparation use root-owned Corepack state while source, candidate, and promoted smoke checks exercise Corepack and pnpm as the runtime user. Thanks @fuller-stack-dev.
 - Made local sync report actionable non-Git workdir diagnostics and fail before lease acquisition, resolution, preparation, or ready-pool borrowing. Thanks @bunlongheng.

--- a/docs/commands/sync-plan.md
+++ b/docs/commands/sync-plan.md
@@ -28,6 +28,11 @@ matches what an actual sync would ship:
 Ordered exclude rules are applied before size accounting; a later `!pattern`
 can re-include a path matched by an earlier rule.
 
+The same preflight rejects tracked non-gitlink paths hidden by sparse-checkout
+or `skip-worktree` state only when they remain in the effective manifest after
+`sync.include` and ordered excludes. On Git older than 2.41, an ambiguous
+missing in-scope path fails closed; out-of-scope paths do not affect the plan.
+
 ## Output
 
 The first line reports the candidate file count and total size. If the

--- a/docs/features/sync.md
+++ b/docs/features/sync.md
@@ -27,6 +27,17 @@ That list is then filtered by the active excludes:
 - repo-local `sync.exclude` (config) patterns;
 - root `.crabboxignore` patterns.
 
+Before transfer, Crabbox checks tracked paths that remain in the effective
+manifest scope. If sparse-checkout rules or `skip-worktree` state hide one of
+those paths, sync stops instead of treating the omission as a deletion. Hidden
+paths outside `sync.include` or removed by ordered excludes are ignored.
+Gitlinks are not manifest files or remote file deletions, while symlinks remain
+file-like.
+
+Git 2.41 or newer distinguishes an intentional in-scope deletion from a sparse
+omission after index metadata becomes ambiguous. Older Git fails closed only
+for an ambiguous missing path that remains in the effective manifest scope.
+
 Git-ignored output, dependency folders, `.git`, and common local caches stay out
 of the transfer. This keeps a first sync close to what CI would see while still
 letting you test uncommitted local edits.

--- a/internal/cli/delegated_archive_sync_test.go
+++ b/internal/cli/delegated_archive_sync_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"os"
 	"os/exec"
@@ -67,6 +68,69 @@ func TestRunDelegatedArchiveSyncOwnsArchiveReplaceLifecycle(t *testing.T) {
 	}
 	if got := phases[len(phases)-1].Name; got != "core_sync" {
 		t.Fatalf("last phase=%q", got)
+	}
+}
+
+func TestRunDelegatedArchiveSyncRejectsInScopeSparseOmissionBeforeUpload(t *testing.T) {
+	root := newDelegatedArchiveSyncRepo(t)
+	runGit(t, root, "sparse-checkout", "set", "--no-cone", "/one.txt")
+	uploaded := false
+	executed := false
+
+	_, _, err := RunDelegatedArchiveSync(context.Background(), DelegatedArchiveSyncRequest{
+		Config:  baseConfig(),
+		Repo:    Repo{Root: root},
+		Workdir: "/workspace",
+		Upload: func(context.Context, string, io.Reader) error {
+			uploaded = true
+			return nil
+		},
+		Exec: func(context.Context, string) error {
+			executed = true
+			return nil
+		},
+	})
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 6 {
+		t.Fatalf("err=%v, want exit 6", err)
+	}
+	if !strings.Contains(err.Error(), `tracked path "two.txt"`) {
+		t.Fatalf("err=%v", err)
+	}
+	if uploaded || executed {
+		t.Fatalf("upload=%t exec=%t, want no transfer callbacks", uploaded, executed)
+	}
+}
+
+func TestRunDelegatedArchiveSyncRejectsMixedGitlinkConflictBeforeUpload(t *testing.T) {
+	root := newDelegatedArchiveSyncRepo(t)
+	setUnmergedIndexModes(t, root, "one.txt", "100644", "160000", "100644")
+	uploaded := false
+	executed := false
+
+	_, _, err := RunDelegatedArchiveSync(context.Background(), DelegatedArchiveSyncRequest{
+		Config:  baseConfig(),
+		Repo:    Repo{Root: root},
+		Workdir: "/workspace",
+		Upload: func(context.Context, string, io.Reader) error {
+			uploaded = true
+			return nil
+		},
+		Exec: func(context.Context, string) error {
+			executed = true
+			return nil
+		},
+	})
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 6 {
+		t.Fatalf("err=%v, want exit 6", err)
+	}
+	if !strings.Contains(err.Error(), `tracked path "one.txt"`) ||
+		!strings.Contains(err.Error(), "mixed file mode 100644 at stage 1") {
+		t.Fatalf("err=%v", err)
+	}
+	if uploaded || executed {
+		t.Fatalf("upload=%t exec=%t, want no transfer callbacks", uploaded, executed)
 	}
 }
 

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -13,6 +13,7 @@ import (
 	"path"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -50,6 +51,8 @@ func repositoryGitEnvironment() []string {
 
 type gitTrackedPath struct {
 	name         string
+	mode         string
+	stage        int
 	skipWorktree bool
 }
 
@@ -61,70 +64,134 @@ func GitCheckoutHasHiddenOmissions(root string) (bool, error) {
 }
 
 func gitCheckoutHasHiddenOmissions(root string, resolveSparseRules func(string, []gitTrackedPath) (map[string]struct{}, error)) (bool, error) {
+	path, err := gitCheckoutHiddenOmission(root, nil, resolveSparseRules)
+	return path != "", err
+}
+
+func gitCheckoutHiddenOmission(
+	root string,
+	inScope func(gitTrackedPath) bool,
+	resolveSparseRules func(string, []gitTrackedPath) (map[string]struct{}, error),
+) (string, error) {
 	if strings.TrimSpace(root) == "" {
-		return false, nil
+		return "", nil
 	}
-	sparseEnabled := strings.EqualFold(
+	sparseEnabled := gitCheckoutSparseEnabled(root)
+	if !sparseEnabled && gitOutput(root, "rev-parse", "--is-inside-work-tree") != "true" {
+		return "", nil
+	}
+	tracked, err := loadGitTrackedPaths(root)
+	if err != nil {
+		return "", err
+	}
+	return gitCheckoutHiddenOmissionForTracked(root, tracked, sparseEnabled, inScope, resolveSparseRules)
+}
+
+func gitCheckoutSparseEnabled(root string) bool {
+	return strings.EqualFold(
 		strings.TrimSpace(gitOutput(root, "config", "--bool", "core.sparseCheckout")),
 		"true",
 	)
-	if !sparseEnabled && gitOutput(root, "rev-parse", "--is-inside-work-tree") != "true" {
-		return false, nil
-	}
-	trackedCmd := exec.Command("git", "ls-files", "-t", "-z")
+}
+
+func loadGitTrackedPaths(root string) ([]gitTrackedPath, error) {
+	trackedCmd := exec.Command("git", "ls-files", "-t", "--stage", "-z")
 	trackedCmd.Dir = root
+	trackedCmd.Env = repositoryGitEnvironment()
 	tagged, err := trackedCmd.Output()
 	if err != nil {
-		return false, fmt.Errorf("list tracked paths: %w", err)
+		return nil, fmt.Errorf("list tracked paths: %w", err)
 	}
-	if len(tagged) == 0 {
-		return false, nil
+	tracked, err := parseGitTrackedPaths(tagged)
+	if err != nil {
+		return nil, err
 	}
-	tracked := make([]gitTrackedPath, 0, bytes.Count(tagged, []byte{0}))
-	for _, entry := range bytes.Split(tagged, []byte{0}) {
-		if len(entry) == 0 {
+	return tracked, nil
+}
+
+func gitCheckoutHiddenOmissionForTracked(
+	root string,
+	tracked []gitTrackedPath,
+	sparseEnabled bool,
+	inScope func(gitTrackedPath) bool,
+	resolveSparseRules func(string, []gitTrackedPath) (map[string]struct{}, error),
+) (string, error) {
+	scoped := make([]gitTrackedPath, 0, len(tracked))
+	for _, entry := range tracked {
+		if inScope != nil && !inScope(entry) {
 			continue
 		}
-		if len(entry) < 3 || entry[1] != ' ' {
-			return false, fmt.Errorf("parse tracked path metadata")
-		}
-		path := string(entry[2:])
-		tracked = append(tracked, gitTrackedPath{name: path, skipWorktree: entry[0] == 'S'})
+		scoped = append(scoped, entry)
+	}
+	if len(scoped) == 0 {
+		return "", nil
 	}
 	includedPaths := make(map[string]struct{})
 	var sparseRulesErr error
 	if sparseEnabled {
-		includedPaths, sparseRulesErr = resolveSparseRules(root, tracked)
+		includedPaths, sparseRulesErr = resolveSparseRules(root, scoped)
 	}
-	for _, path := range tracked {
-		if sparseEnabled && sparseRulesErr != nil && !path.skipWorktree {
-			exists, statErr := trackedPathExistsWithoutSymlinkAncestor(root, path.name)
+	for _, entry := range scoped {
+		if sparseEnabled && sparseRulesErr != nil && !entry.skipWorktree {
+			exists, statErr := trackedPathExistsWithoutSymlinkAncestor(root, entry.name)
 			if statErr != nil {
-				return false, fmt.Errorf("inspect tracked path %q: %w", path.name, statErr)
+				return "", fmt.Errorf("inspect tracked path %q: %w", entry.name, statErr)
 			}
 			if !exists {
-				return false, fmt.Errorf("classify missing tracked path %q without git sparse-checkout check-rules (requires Git 2.41 or newer): %w", path.name, sparseRulesErr)
+				return "", fmt.Errorf("classify missing tracked path %q without git sparse-checkout check-rules (requires Git 2.41 or newer): %w", entry.name, sparseRulesErr)
 			}
 			continue
 		}
-		hiddenCandidate := path.skipWorktree
+		hiddenCandidate := entry.skipWorktree
 		if sparseEnabled && sparseRulesErr == nil {
-			_, ruleIncludesPath := includedPaths[path.name]
+			_, ruleIncludesPath := includedPaths[entry.name]
 			hiddenCandidate = hiddenCandidate || !ruleIncludesPath
 		}
 		if !hiddenCandidate {
 			continue
 		}
-		exists, statErr := trackedPathExistsWithoutSymlinkAncestor(root, path.name)
+		exists, statErr := trackedPathExistsWithoutSymlinkAncestor(root, entry.name)
 		if statErr != nil {
-			return false, fmt.Errorf("inspect tracked path %q: %w", path.name, statErr)
+			return "", fmt.Errorf("inspect tracked path %q: %w", entry.name, statErr)
 		}
 		if exists {
 			continue
 		}
-		return true, nil
+		return entry.name, nil
 	}
-	return false, nil
+	return "", nil
+}
+
+func parseGitTrackedPaths(tagged []byte) ([]gitTrackedPath, error) {
+	tracked := make([]gitTrackedPath, 0, bytes.Count(tagged, []byte{0}))
+	for _, record := range bytes.Split(tagged, []byte{0}) {
+		if len(record) == 0 {
+			continue
+		}
+		if len(record) < 3 || record[1] != ' ' {
+			return nil, fmt.Errorf("parse tracked path metadata")
+		}
+		metadata, name, ok := bytes.Cut(record[2:], []byte{'\t'})
+		fields := bytes.Fields(metadata)
+		if !ok || len(name) == 0 || len(fields) != 3 {
+			return nil, fmt.Errorf("parse tracked path metadata")
+		}
+		mode := string(fields[0])
+		if _, err := strconv.ParseUint(mode, 8, 32); err != nil {
+			return nil, fmt.Errorf("parse tracked path mode %q", mode)
+		}
+		stage, err := strconv.Atoi(string(fields[2]))
+		if err != nil || stage < 0 || stage > 3 {
+			return nil, fmt.Errorf("parse tracked path stage %q", fields[2])
+		}
+		tracked = append(tracked, gitTrackedPath{
+			name:         string(name),
+			mode:         mode,
+			stage:        stage,
+			skipWorktree: record[0] == 'S',
+		})
+	}
+	return tracked, nil
 }
 
 func trackedPathExistsWithoutSymlinkAncestor(root, gitPath string) (bool, error) {
@@ -154,6 +221,7 @@ func sparseCheckoutIncludedPaths(root string, tracked []gitTrackedPath) (map[str
 	}
 	cmd := exec.Command("git", "sparse-checkout", "check-rules", "-z")
 	cmd.Dir = root
+	cmd.Env = repositoryGitEnvironment()
 	cmd.Stdin = bytes.NewReader(paths.Bytes())
 	out, err := cmd.Output()
 	if err != nil {
@@ -641,11 +709,34 @@ func syncManifestFiltered(root string, excludes, includes []string) (SyncManifes
 	if err != nil {
 		return SyncManifest{}, err
 	}
+	tracked, err := loadGitTrackedPaths(root)
+	if err != nil {
+		return SyncManifest{}, fmt.Errorf("verify sync manifest scope: %w", err)
+	}
+	inManifestScope := func(entry gitTrackedPath) bool {
+		rel := filepath.ToSlash(entry.name)
+		return safeRepoRel(rel) &&
+			!pathExcluded(rel, excludes) &&
+			pathIncluded(rel, includes)
+	}
+	gitlinkPaths, err := trackedGitlinkPaths(tracked, inManifestScope)
+	if err != nil {
+		return SyncManifest{}, fmt.Errorf("verify sync manifest scope: %w", err)
+	}
+	hidden, err := gitCheckoutHiddenOmissionForTracked(root, tracked, gitCheckoutSparseEnabled(root), func(entry gitTrackedPath) bool {
+		return entry.mode != "160000" && inManifestScope(entry)
+	}, sparseCheckoutIncludedPaths)
+	if err != nil {
+		return SyncManifest{}, fmt.Errorf("verify sync manifest scope: %w", err)
+	}
+	if hidden != "" {
+		return SyncManifest{}, fmt.Errorf("tracked path %q is hidden by sparse checkout or skip-worktree state but remains in sync manifest scope", hidden)
+	}
 	seen := map[string]bool{}
 	manifest := SyncManifest{}
 	for _, rel := range splitNul(out) {
 		rel = filepath.ToSlash(rel)
-		if !safeRepoRel(rel) || pathExcluded(rel, excludes) || !pathIncluded(rel, includes) || seen[rel] {
+		if _, isGitlink := gitlinkPaths[rel]; isGitlink || !safeRepoRel(rel) || pathExcluded(rel, excludes) || !pathIncluded(rel, includes) || seen[rel] {
 			continue
 		}
 		full := filepath.Join(root, filepath.FromSlash(rel))
@@ -658,17 +749,54 @@ func syncManifestFiltered(root string, excludes, includes []string) (SyncManifes
 		manifest.Bytes += info.Size()
 	}
 	sort.Strings(manifest.Files)
-	deleted, err := syncDeletedPaths(root, excludes, includes)
+	deleted, deletedGitlinks, err := syncDeletedPaths(root, excludes, includes)
 	if err != nil {
 		return SyncManifest{}, err
 	}
-	manifest.Deleted = filterDeletedPaths(deleted, seen)
+	for rel := range deletedGitlinks {
+		gitlinkPaths[rel] = struct{}{}
+	}
+	manifest.Deleted = filterDeletedPaths(deleted, seen, gitlinkPaths)
 	changed, err := changedSyncPaths(root, excludes, includes)
 	if err != nil {
 		return SyncManifest{}, err
 	}
 	manifest.Changed, manifest.ChangedBytes = changedPathSetBytes(root, changed)
 	return manifest, nil
+}
+
+func trackedGitlinkPaths(tracked []gitTrackedPath, inScope func(gitTrackedPath) bool) (map[string]struct{}, error) {
+	paths := make(map[string]struct{})
+	firstByPath := make(map[string]gitTrackedPath)
+	for _, entry := range tracked {
+		if inScope != nil && !inScope(entry) {
+			continue
+		}
+		rel := filepath.ToSlash(entry.name)
+		first, seen := firstByPath[rel]
+		if !seen {
+			firstByPath[rel] = entry
+			if entry.mode == "160000" {
+				paths[rel] = struct{}{}
+			}
+			continue
+		}
+		if (first.mode == "160000") == (entry.mode == "160000") {
+			continue
+		}
+		file, gitlink := first, entry
+		if first.mode == "160000" {
+			file, gitlink = entry, first
+		}
+		return nil, fmt.Errorf(
+			"tracked path %q has mixed file mode %s at stage %d and gitlink mode 160000 at stage %d in sync manifest scope",
+			rel,
+			file.mode,
+			file.stage,
+			gitlink.stage,
+		)
+	}
+	return paths, nil
 }
 
 func BuildSyncManifestFiltered(root string, excludes, includes []string) (SyncManifest, error) {
@@ -693,29 +821,49 @@ func (m SyncManifest) DeletedNUL() []byte {
 	return b.Bytes()
 }
 
-func syncDeletedPaths(root string, excludes, includes []string) ([]string, error) {
-	sets := [][]string{}
-	for _, args := range [][]string{
-		{"ls-files", "--deleted", "-z"},
-		{"diff", "--cached", "--name-only", "--diff-filter=D", "-z"},
-	} {
-		cmd := exec.Command("git", args...)
-		cmd.Dir = root
-		cmd.Env = repositoryGitEnvironment()
-		out, err := cmd.Output()
-		if err != nil {
-			return nil, err
-		}
-		sets = append(sets, splitNul(out))
+type gitCachedDeletion struct {
+	name         string
+	preimageMode string
+}
+
+func syncDeletedPaths(root string, excludes, includes []string) ([]string, map[string]struct{}, error) {
+	cmd := exec.Command("git", "ls-files", "--deleted", "-z")
+	cmd.Dir = root
+	cmd.Env = repositoryGitEnvironment()
+	worktreeOut, err := cmd.Output()
+	if err != nil {
+		return nil, nil, err
+	}
+	cmd = exec.Command("git", "diff", "--cached", "--raw", "--format=", "-z", "--diff-filter=D", "--no-renames")
+	cmd.Dir = root
+	cmd.Env = repositoryGitEnvironment()
+	cachedOut, err := cmd.Output()
+	if err != nil {
+		return nil, nil, err
+	}
+	cached, err := parseGitCachedDeletions(cachedOut)
+	if err != nil {
+		return nil, nil, err
 	}
 	seen := map[string]bool{}
-	for _, set := range sets {
-		for _, rel := range set {
-			rel = filepath.ToSlash(rel)
-			if !safeRepoRel(rel) || pathExcluded(rel, excludes) || !pathIncluded(rel, includes) {
-				continue
-			}
+	gitlinks := map[string]struct{}{}
+	inScope := func(rel string) bool {
+		return safeRepoRel(rel) && !pathExcluded(rel, excludes) && pathIncluded(rel, includes)
+	}
+	for _, rel := range splitNul(worktreeOut) {
+		rel = filepath.ToSlash(rel)
+		if inScope(rel) {
 			seen[rel] = true
+		}
+	}
+	for _, deletion := range cached {
+		rel := filepath.ToSlash(deletion.name)
+		if !inScope(rel) {
+			continue
+		}
+		seen[rel] = true
+		if deletion.preimageMode == "160000" {
+			gitlinks[rel] = struct{}{}
 		}
 	}
 	out := make([]string, 0, len(seen))
@@ -723,13 +871,42 @@ func syncDeletedPaths(root string, excludes, includes []string) ([]string, error
 		out = append(out, rel)
 	}
 	sort.Strings(out)
-	return out, nil
+	return out, gitlinks, nil
 }
 
-func filterDeletedPaths(deleted []string, files map[string]bool) []string {
+func parseGitCachedDeletions(raw []byte) ([]gitCachedDeletion, error) {
+	if len(raw) > 0 && raw[len(raw)-1] != 0 {
+		return nil, fmt.Errorf("parse staged deletion metadata")
+	}
+	records := bytes.Split(raw, []byte{0})
+	if len(records) > 0 && len(records[len(records)-1]) == 0 {
+		records = records[:len(records)-1]
+	}
+	if len(records)%2 != 0 {
+		return nil, fmt.Errorf("parse staged deletion metadata")
+	}
+	deletions := make([]gitCachedDeletion, 0, len(records)/2)
+	for i := 0; i < len(records); i += 2 {
+		fields := bytes.Fields(records[i])
+		if len(fields) != 5 || len(fields[0]) < 2 || fields[0][0] != ':' || string(fields[4]) != "D" || len(records[i+1]) == 0 {
+			return nil, fmt.Errorf("parse staged deletion metadata")
+		}
+		mode := string(fields[0][1:])
+		if _, err := strconv.ParseUint(mode, 8, 32); err != nil {
+			return nil, fmt.Errorf("parse staged deletion mode %q", mode)
+		}
+		deletions = append(deletions, gitCachedDeletion{
+			name:         string(records[i+1]),
+			preimageMode: mode,
+		})
+	}
+	return deletions, nil
+}
+
+func filterDeletedPaths(deleted []string, files map[string]bool, gitlinks map[string]struct{}) []string {
 	out := deleted[:0]
 	for _, rel := range deleted {
-		if !files[rel] {
+		if _, isGitlink := gitlinks[rel]; !isGitlink && !files[rel] {
 			out = append(out, rel)
 		}
 	}

--- a/internal/cli/repo_test.go
+++ b/internal/cli/repo_test.go
@@ -74,6 +74,75 @@ func TestRepoNameFromRootAndRemoteFallsBackToRemoteBasename(t *testing.T) {
 	}
 }
 
+func TestParseGitTrackedPaths(t *testing.T) {
+	raw := []byte(
+		"H 100644 aaaa 0\tspace name.txt\x00" +
+			"S 120000 bbbb 0\ttab\tname\n.txt\x00" +
+			"M 100644 cccc 1\tconflict.txt\x00" +
+			"M 100755 dddd 2\tconflict.txt\x00" +
+			"H 160000 eeee 0\tvendor/submodule\x00",
+	)
+	got, err := parseGitTrackedPaths(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 5 {
+		t.Fatalf("tracked=%#v", got)
+	}
+	if got[0].name != "space name.txt" || got[0].mode != "100644" || got[0].stage != 0 || got[0].skipWorktree {
+		t.Fatalf("regular=%#v", got[0])
+	}
+	if got[1].name != "tab\tname\n.txt" || got[1].mode != "120000" || got[1].stage != 0 || !got[1].skipWorktree {
+		t.Fatalf("symlink=%#v", got[1])
+	}
+	if got[2].name != "conflict.txt" || got[2].stage != 1 ||
+		got[3].name != "conflict.txt" || got[3].mode != "100755" || got[3].stage != 2 {
+		t.Fatalf("unmerged=%#v", got[2:4])
+	}
+	if got[4].mode != "160000" || got[4].stage != 0 {
+		t.Fatalf("gitlink=%#v", got[4])
+	}
+}
+
+func TestParseGitTrackedPathsRejectsMalformedMetadata(t *testing.T) {
+	for _, raw := range []string{
+		"H 100644 aaaa 0 missing-tab\x00",
+		"H invalid aaaa 0\tfile.txt\x00",
+		"H 100644 aaaa 4\tfile.txt\x00",
+		"H 100644 aaaa 0\t\x00",
+	} {
+		t.Run(fmt.Sprintf("%q", raw), func(t *testing.T) {
+			if _, err := parseGitTrackedPaths([]byte(raw)); err == nil {
+				t.Fatal("malformed metadata was accepted")
+			}
+		})
+	}
+}
+
+func TestParseGitCachedDeletions(t *testing.T) {
+	raw := []byte(
+		":100644 000000 aaaa 0000 D\x00space name.txt\x00" +
+			":160000 000000 bbbb 0000 D\x00vendor/tab\tname\nmodule\x00",
+	)
+	got, err := parseGitCachedDeletions(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || got[0].name != "space name.txt" || got[0].preimageMode != "100644" ||
+		got[1].name != "vendor/tab\tname\nmodule" || got[1].preimageMode != "160000" {
+		t.Fatalf("deletions=%#v", got)
+	}
+	for _, raw := range [][]byte{
+		[]byte(":160000 000000 aaaa 0000 D\x00missing-name"),
+		[]byte(":invalid 000000 aaaa 0000 D\x00module\x00"),
+		[]byte(":160000 000000 aaaa 0000 M\x00module\x00"),
+	} {
+		if _, err := parseGitCachedDeletions(raw); err == nil {
+			t.Fatalf("malformed staged deletion metadata accepted: %q", raw)
+		}
+	}
+}
+
 func TestGitCheckoutHasHiddenOmissions(t *testing.T) {
 	dir := t.TempDir()
 	runGit(t, dir, "init")
@@ -164,6 +233,38 @@ func TestGitCheckoutHasHiddenOmissions(t *testing.T) {
 	}
 }
 
+func TestGitCheckoutHiddenOmissionAppliesScopeBeforeClassification(t *testing.T) {
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.email", "test@example.com")
+	runGit(t, dir, "config", "user.name", "Test")
+	writeFile(t, filepath.Join(dir, "scoped.txt"), "scoped\n")
+	writeFile(t, filepath.Join(dir, "outside.txt"), "outside\n")
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-m", "init")
+	runGit(t, dir, "sparse-checkout", "set", "--no-cone", "/*")
+	if err := os.Remove(filepath.Join(dir, "scoped.txt")); err != nil {
+		t.Fatal(err)
+	}
+
+	resolverCalls := 0
+	rulesUnavailable := func(string, []gitTrackedPath) (map[string]struct{}, error) {
+		resolverCalls++
+		return nil, fmt.Errorf("check-rules unsupported")
+	}
+	if path, err := gitCheckoutHiddenOmission(dir, func(gitTrackedPath) bool { return false }, rulesUnavailable); err != nil || path != "" {
+		t.Fatalf("empty scope path=%q err=%v", path, err)
+	}
+	if resolverCalls != 0 {
+		t.Fatalf("resolver calls=%d, want 0", resolverCalls)
+	}
+	if path, err := gitCheckoutHiddenOmission(dir, func(entry gitTrackedPath) bool {
+		return entry.name == "scoped.txt"
+	}, rulesUnavailable); path != "" || err == nil || !strings.Contains(err.Error(), "Git 2.41") {
+		t.Fatalf("old Git ambiguity path=%q err=%v", path, err)
+	}
+}
+
 func TestGitCheckoutHasHiddenOmissionsInLinkedWorktree(t *testing.T) {
 	parent := t.TempDir()
 	source := filepath.Join(parent, "source")
@@ -234,6 +335,198 @@ func TestGitCheckoutHasHiddenOmissionsThroughSymlinkAncestor(t *testing.T) {
 	}
 	if omitted, err := GitCheckoutHasHiddenOmissions(dir); err != nil || !omitted {
 		t.Fatalf("symlink-shadowed omission=%v err=%v", omitted, err)
+	}
+}
+
+func TestSyncManifestRejectsOnlyHiddenPathsInEffectiveScope(t *testing.T) {
+	tests := []struct {
+		name      string
+		excludes  []string
+		includes  []string
+		wantError bool
+	}{
+		{name: "in scope", wantError: true},
+		{name: "outside include", includes: []string{"visible"}},
+		{name: "excluded", excludes: []string{"hidden"}},
+		{name: "ordered reinclude", excludes: []string{"hidden", "!hidden/drop.txt"}, wantError: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			runGit(t, dir, "init")
+			runGit(t, dir, "config", "user.email", "test@example.com")
+			runGit(t, dir, "config", "user.name", "Test")
+			writeFile(t, filepath.Join(dir, "visible", "keep.txt"), "keep\n")
+			writeFile(t, filepath.Join(dir, "hidden", "drop.txt"), "drop\n")
+			runGit(t, dir, "add", ".")
+			runGit(t, dir, "commit", "-m", "init")
+			runGit(t, dir, "sparse-checkout", "set", "visible")
+
+			manifest, err := syncManifestFiltered(dir, test.excludes, test.includes)
+			if test.wantError {
+				if err == nil || !strings.Contains(err.Error(), `tracked path "hidden/drop.txt"`) {
+					t.Fatalf("manifest=%#v err=%v", manifest, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Join(manifest.Files, ",") != "visible/keep.txt" {
+				t.Fatalf("manifest files=%v", manifest.Files)
+			}
+		})
+	}
+}
+
+func TestSyncManifestAllowsIntentionalDeletionInMaterializedSparseCheckout(t *testing.T) {
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.email", "test@example.com")
+	runGit(t, dir, "config", "user.name", "Test")
+	writeFile(t, filepath.Join(dir, "keep.txt"), "keep\n")
+	writeFile(t, filepath.Join(dir, "deleted.txt"), "delete\n")
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-m", "init")
+	runGit(t, dir, "sparse-checkout", "set", "--no-cone", "/*")
+
+	if _, err := syncManifestFiltered(dir, nil, nil); err != nil {
+		t.Fatalf("fully materialized sparse checkout: %v", err)
+	}
+	if err := os.Remove(filepath.Join(dir, "deleted.txt")); err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := syncManifestFiltered(dir, nil, nil)
+	if err != nil {
+		if strings.Contains(err.Error(), "Git 2.41") {
+			t.Skipf("intentional deletion classification requires Git 2.41+: %v", err)
+		}
+		t.Fatal(err)
+	}
+	if strings.Join(manifest.Deleted, ",") != "deleted.txt" {
+		t.Fatalf("deleted=%v", manifest.Deleted)
+	}
+}
+
+func TestSyncManifestTreatsSymlinksAsFiles(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink fixture requires Unix semantics")
+	}
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.email", "test@example.com")
+	runGit(t, dir, "config", "user.name", "Test")
+	writeFile(t, filepath.Join(dir, "visible", "keep.txt"), "keep\n")
+	if err := os.MkdirAll(filepath.Join(dir, "hidden"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("missing-target", filepath.Join(dir, "hidden", "link.txt")); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-m", "init")
+	runGit(t, dir, "sparse-checkout", "set", "--no-cone", "/*")
+	runGit(t, dir, "update-index", "--skip-worktree", "hidden/link.txt")
+
+	manifest, err := syncManifestFiltered(dir, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(strings.Join(manifest.Files, ","), "hidden/link.txt") {
+		t.Fatalf("manifest files=%v", manifest.Files)
+	}
+
+	runGit(t, dir, "update-index", "--no-skip-worktree", "hidden/link.txt")
+	runGit(t, dir, "sparse-checkout", "set", "visible")
+	if _, err := syncManifestFiltered(dir, nil, nil); err == nil || !strings.Contains(err.Error(), "hidden/link.txt") {
+		t.Fatalf("absent sparse symlink err=%v", err)
+	}
+}
+
+func TestSyncManifestIgnoresGitlinksButWholeCheckoutGuardDoesNot(t *testing.T) {
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.email", "test@example.com")
+	runGit(t, dir, "config", "user.name", "Test")
+	writeFile(t, filepath.Join(dir, "visible", "keep.txt"), "keep\n")
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-m", "base")
+	head := gitOutput(dir, "rev-parse", "HEAD")
+	runGit(t, dir, "update-index", "--add", "--cacheinfo", "160000,"+head+",vendor/submodule")
+	runGit(t, dir, "commit", "-m", "gitlink")
+	runGit(t, dir, "sparse-checkout", "set", "visible")
+
+	manifest, err := syncManifestFiltered(dir, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Join(manifest.Files, ",") != "visible/keep.txt" || len(manifest.Deleted) != 0 {
+		t.Fatalf("manifest=%#v", manifest)
+	}
+	if omitted, err := GitCheckoutHasHiddenOmissions(dir); err != nil || !omitted {
+		t.Fatalf("whole checkout omission=%v err=%v", omitted, err)
+	}
+}
+
+func TestSyncManifestRejectsMixedFileGitlinkConflictInEffectiveScope(t *testing.T) {
+	tests := []struct {
+		name      string
+		excludes  []string
+		includes  []string
+		wantError bool
+	}{
+		{name: "in scope", wantError: true},
+		{name: "outside include", includes: []string{"visible.txt"}},
+		{name: "excluded", excludes: []string{"conflict.txt"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			runGit(t, dir, "init")
+			runGit(t, dir, "config", "user.email", "test@example.com")
+			runGit(t, dir, "config", "user.name", "Test")
+			writeFile(t, filepath.Join(dir, "visible.txt"), "visible\n")
+			writeFile(t, filepath.Join(dir, "conflict.txt"), "conflict\n")
+			runGit(t, dir, "add", ".")
+			runGit(t, dir, "commit", "-m", "base")
+			setUnmergedIndexModes(t, dir, "conflict.txt", "100644", "160000", "100644")
+
+			manifest, err := syncManifestFiltered(dir, test.excludes, test.includes)
+			if test.wantError {
+				if err == nil ||
+					!strings.Contains(err.Error(), `tracked path "conflict.txt"`) ||
+					!strings.Contains(err.Error(), "file mode 100644 at stage 1") ||
+					!strings.Contains(err.Error(), "gitlink mode 160000 at stage 2") {
+					t.Fatalf("manifest=%#v err=%v", manifest, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Join(manifest.Files, ",") != "visible.txt" {
+				t.Fatalf("manifest files=%v", manifest.Files)
+			}
+		})
+	}
+}
+
+func TestSyncManifestKeepsFileLikeConflict(t *testing.T) {
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.email", "test@example.com")
+	runGit(t, dir, "config", "user.name", "Test")
+	writeFile(t, filepath.Join(dir, "conflict.txt"), "conflict\n")
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-m", "base")
+	setUnmergedIndexModes(t, dir, "conflict.txt", "100644", "100755", "100644")
+
+	manifest, err := syncManifestFiltered(dir, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Join(manifest.Files, ",") != "conflict.txt" {
+		t.Fatalf("manifest files=%v", manifest.Files)
 	}
 }
 
@@ -784,6 +1077,57 @@ func TestSyncManifestDoesNotDeleteRecreatedStagedDelete(t *testing.T) {
 	}
 }
 
+func TestSyncManifestDoesNotDeleteStagedGitlink(t *testing.T) {
+	tests := []struct {
+		name     string
+		excludes []string
+		includes []string
+		want     string
+	}{
+		{name: "effective scope", want: "deleted.txt"},
+		{name: "gitlink only", includes: []string{"vendor/submodule"}},
+		{name: "outside include", includes: []string{"visible.txt"}},
+		{name: "ordinary deletion only", includes: []string{"deleted.txt"}, want: "deleted.txt"},
+		{name: "excluded", excludes: []string{"vendor/submodule"}, want: "deleted.txt"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			runGit(t, dir, "init")
+			runGit(t, dir, "config", "user.email", "test@example.com")
+			runGit(t, dir, "config", "user.name", "Test")
+			writeFile(t, filepath.Join(dir, "visible.txt"), "visible\n")
+			writeFile(t, filepath.Join(dir, "deleted.txt"), "delete\n")
+			runGit(t, dir, "add", ".")
+			runGit(t, dir, "commit", "-m", "base")
+			head := gitOutput(dir, "rev-parse", "HEAD")
+			runGit(t, dir, "update-index", "--add", "--cacheinfo", "160000,"+head+",vendor/submodule")
+			runGit(t, dir, "commit", "-m", "gitlink")
+			runGit(t, dir, "rm", "--cached", "vendor/submodule")
+			if err := os.Remove(filepath.Join(dir, "deleted.txt")); err != nil {
+				t.Fatal(err)
+			}
+
+			tracked, err := loadGitTrackedPaths(dir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, entry := range tracked {
+				if entry.name == "vendor/submodule" {
+					t.Fatalf("staged gitlink deletion retained current index entry: %#v", entry)
+				}
+			}
+			manifest, err := syncManifestFiltered(dir, test.excludes, test.includes)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := strings.Join(manifest.Deleted, ","); got != test.want {
+				t.Fatalf("deleted=%q want %q", got, test.want)
+			}
+		})
+	}
+}
+
 func TestRemoteGitSeedCandidateRequiresRemoteTrackingRef(t *testing.T) {
 	dir := t.TempDir()
 	runGit(t, dir, "init")
@@ -956,6 +1300,27 @@ func runGit(t *testing.T, dir string, args ...string) {
 	cmd.Dir = dir
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+func setUnmergedIndexModes(t *testing.T, dir, rel string, modes ...string) {
+	t.Helper()
+	runGit(t, dir, "update-index", "--force-remove", "--", rel)
+	blob := gitOutput(dir, "hash-object", "--", rel)
+	commit := gitOutput(dir, "rev-parse", "HEAD")
+	var input strings.Builder
+	for i, mode := range modes {
+		object := blob
+		if mode == "160000" {
+			object = commit
+		}
+		fmt.Fprintf(&input, "%s %s %d\t%s\n", mode, object, i+1, rel)
+	}
+	cmd := exec.Command("git", "update-index", "--index-info")
+	cmd.Dir = dir
+	cmd.Stdin = strings.NewReader(input.String())
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("create unmerged index for %q: %v\n%s", rel, err, out)
 	}
 }
 


### PR DESCRIPTION
## Summary

This repairs sparse and skip-worktree sync manifests so a partial local checkout cannot make an in-scope tracked file look like a remote deletion.

The root cause was that manifest construction started from paths visible in the working tree and index output. A tracked path omitted by sparse-checkout rules or skip-worktree state could therefore disappear from the upload without being distinguished from an intentional deletion. Staged submodule removal had a related type-loss problem: after `git rm --cached`, the stage-zero gitlink entry is gone even though the cached deletion still needs to be recognized as a gitlink rather than a remote file deletion.

## Behavior

- Fail closed before upload only for hidden tracked non-gitlink paths that survive `sync.include` and ordered excludes.
- Keep out-of-scope hidden paths ignored, preserve ordered re-inclusion, and leave the existing exclude semantics unchanged.
- Keep symlinks file-like, omit gitlinks from file uploads and deletions, and reject mixed file/gitlink unmerged modes in effective scope.
- Classify staged deletions from cached raw-diff preimage modes, so mode `160000` removals are not emitted as remote file deletions while ordinary staged file deletions remain deletions.
- Preserve the existing whole-checkout guard used by Blacksmith-style workflows.

Git 2.41 and newer uses `git sparse-checkout check-rules` to distinguish sparse omissions from intentional deletions. On older Git, an ambiguous missing path fails closed only when it remains in effective manifest scope; fully materialized paths and paths outside scope continue normally.

The actionable non-Git preflight remains the first Git-source check: synced runs outside a Git repository still stop with the existing `git init` / `--no-sync` guidance.

## Verification

- `gofmt` on the touched Go files
- focused sparse, skip-worktree, gitlink, mixed-mode, deletion, and delegated-upload regression tests
- focused race-detector run
- full `go test ./internal/cli -count=1`
- `go vet ./...`
- `scripts/check-docs.sh`
- `node scripts/build-docs-site.mjs`
- `git diff --check`
- exact-bundle TruffleHog scan and maintainer review
- source-blind standalone CLI contract covering scope changes, staged gitlink deletion, mixed modes, symlinks, and non-Git diagnostic precedence

No configuration, secret, credential, data, or version migration is required.

Historical context: https://github.com/openclaw/crabbox/issues/1093

Non-goal: this does not change the exclude semantics discussed in https://github.com/openclaw/crabbox/issues/1231
