### PR TITLE
fix: serialize reused workspace lifecycles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,9 @@ jobs:
       - name: Test pond mesh cancellation
         run: go test ./internal/cli/ -run PondMeshCancel -count=1 -v
 
+      - name: Test Git workspace coherence
+        run: go test ./internal/cli/ -run '^(TestWindowsGitRootIdentityAcceptsShortAliasAndRejectsDistinctRoot|TestWindowsGitCoherenceRollbackRestoresIndexAfterSymbolicHeadFailure|TestWindowsGitSeedReplacesUnusableExactRootsAfterVerifiedClone|TestWindowsGitCoherenceSupportsDetachedSparseSplitAndLinkedIndexes|TestWorkspaceOwnerWindowsProtocolBehavior)$' -count=1 -v
+
   connector-lifecycles:
     name: Connector Lifecycles
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Serialized each reused SSH lease's complete workspace lifecycle across clients and watch iterations, from hydration-state and fingerprint inspection through sync, execution, evidence collection, failure capture, and pool scrub/return, with fenced stale-owner recovery on POSIX, WSL2, and native Windows. Reused Git workspaces now also keep `HEAD`, the index, the requested tree, and sync fingerprints coherent without advancing symbolic branches. Thanks @vincentkoc.
 - Stopped market-independent AWS Spot launch request errors from being retried as On-Demand while preserving fallback for Spot-recoverable capacity, quota, and unsupported-market failures. Thanks @vincentkoc.
 - Made plain source builds report `dev` instead of the stale `0.15.0` release identity while preserving injected release versions and tagged Go module build information. Thanks @coygeek.
 - Preserved custom local-container image `PATH` entries across managed SSH logins, including when users add or switch login-profile files after bootstrap. Thanks @coygeek.

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -170,6 +170,22 @@ full source upload. Crabbox also records a local/remote sync fingerprint and
 skips rsync when the tracked commit, manifest, and dirty metadata have not
 changed.
 
+Existing SSH leases use one remote, lease-scoped workspace owner before Crabbox
+reads hydration state, Git metadata, or the sync fingerprint. The owner remains
+held through sync or fresh checkout, Actions hydration, the command, result and
+artifact collection, failure capture, and ready-pool scrub/return. Separate
+clients and `watch` iterations therefore cannot mutate or execute the same
+reused workspace concurrently. A contending client waits for a bounded interval
+and prints periodic progress. Newly acquired one-shot leases are already
+exclusive and bypass this owner.
+
+Ownership is fenced with a random token and renewed while the lifecycle is
+active. If the local client disappears, Crabbox recovers an expired owner only
+after verifying that its witnessed remote child is no longer alive. Ambiguous
+renewal, release, token, or child state fails closed instead of risking a
+concurrent checkout. POSIX, WSL2, and native Windows targets implement the same
+protocol; the small sync-finalization lock remains nested inside it.
+
 Use `--full-resync` (alias `--fresh-sync`) when a warm lease smells stale:
 Crabbox deletes the remote workdir, skips the fingerprint fast path, reseeds Git
 when possible, and uploads the checkout from scratch. Use `--checksum` for a
@@ -218,6 +234,10 @@ or `--no-sync` is set. This preserves the setup the workflow performed:
 checkout path, installed dependencies, caches, runner temp/toolcache paths, and
 any project-specific preparation. See
 [Actions hydration](../features/actions-hydration.md).
+
+Standalone `crabbox actions hydrate --id ...` acquires the same remote workspace
+owner as ordinary reused runs, so hydration cannot overlap a sync, command,
+collection, or cleanup from another client.
 
 If a JavaScript package-manager command (`pnpm`, `npm`, `node`, `corepack`)
 runs on a raw SSH workspace before a hydration marker exists and no automatic

--- a/docs/features/sync.md
+++ b/docs/features/sync.md
@@ -77,7 +77,22 @@ Secrets must never be passed as command-line arguments or via broad env globs.
 
 ## Sync flow
 
-For an SSH-lease run, sync runs these steps:
+For an existing SSH lease, Crabbox first acquires a remote lease-scoped
+workspace owner. It does this before reading hydration state, Git metadata, or
+the sync fingerprint, and retains ownership through command execution, evidence
+collection, failure capture, and ready-pool cleanup. Separate clients and watch
+iterations contend on the same owner. Newly acquired one-shot leases bypass it
+because the acquisition itself is exclusive.
+
+The owner state lives under the remote user's Crabbox state directory, outside
+the replaceable checkout. Its filename is derived from a non-reversible lease
+digest, and its bounded contents contain only protocol version, expiry, random
+fencing token, and an optional witnessed child PID/start identity. Token-bound
+renewal and release fail closed. After a client crash, an expired owner is
+recoverable only when the exact witnessed child is no longer alive. POSIX,
+WSL2, and native Windows targets share these semantics.
+
+Once ownership is established, sync runs these steps:
 
 1. Resolve the local repository root.
 2. Build the sync manifest (the NUL-delimited file list) and a parallel list of

--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -14,6 +15,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -32,7 +34,7 @@ func (r GitHubRepo) Slug() string {
 	return r.Owner + "/" + r.Name
 }
 
-func (a App) actionsHydrate(ctx context.Context, args []string) error {
+func (a App) actionsHydrate(ctx context.Context, args []string) (err error) {
 	started := time.Now()
 	defaults := defaultConfig()
 	fs := newFlagSet("actions hydrate", a.Stderr)
@@ -137,6 +139,23 @@ func (a App) actionsHydrate(ctx context.Context, args []string) error {
 	if err := waitForSSHReady(ctx, &target, a.Stderr, "actions hydrate", 2*time.Minute); err != nil {
 		return err
 	}
+	ownerParentCtx := ctx
+	owner, err := acquireWorkspaceOwner(ctx, target, leaseID, a.Stderr)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		releaseCtx, cancel := context.WithTimeout(context.WithoutCancel(ownerParentCtx), 30*time.Second)
+		closeErr := owner.Close(releaseCtx)
+		cancel()
+		if closeErr != nil {
+			err = errors.Join(err, closeErr)
+			fmt.Fprintf(a.Stderr, "warning: workspace owner release failed: %v\n", closeErr)
+			return
+		}
+		fmt.Fprintln(a.Stderr, "workspace owner released")
+	}()
+	ctx = contextWithWorkspaceOwner(owner.Context(), owner)
 	if _, err := updateLeaseClaimEndpointIfUnchanged(leaseID, ownedClaim, server, target); err != nil {
 		return err
 	}
@@ -160,7 +179,7 @@ func (a App) actionsHydrate(ctx context.Context, args []string) error {
 	fields := actionsHydrateFields(leaseID, label, cfg.Actions.Job, *keepAliveMinutes, extraFields)
 	if !*githubRunner {
 		localFields := actionsHydrateFields(leaseID, label, cfg.Actions.Job, 0, extraFields)
-		if state, err := a.hydrateActionsLocally(ctx, cfg, repo, target, leaseID, cfg.Actions.Job, localFields, *waitTimeout, true, true); err == nil {
+		if state, err := a.hydrateActionsLocally(ctx, cfg, repo, target, leaseID, cfg.Actions.Job, localFields, *waitTimeout, true, true, owner); err == nil {
 			fmt.Fprintf(a.Stdout, "actions hydrated local id=%s slug=%s workspace=%s run_id=%s\n", leaseID, blank(slug, "-"), state.Workspace, blank(state.RunID, "-"))
 			fmt.Fprintf(a.Stdout, "actions hydrate complete total=%s\n", time.Since(started).Round(time.Millisecond))
 			if *timingJSON {
@@ -184,7 +203,7 @@ func (a App) actionsHydrate(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	state, err := a.hydrateActionsWithGitHubRunner(ctx, cfg, repo, target, leaseID, slug, ghRepo, label, ref, fields, *waitTimeout)
+	state, err := a.hydrateActionsWithGitHubRunner(ctx, cfg, repo, target, leaseID, slug, ghRepo, label, ref, fields, *waitTimeout, owner)
 	if err != nil {
 		return err
 	}
@@ -206,8 +225,11 @@ func (a App) actionsHydrate(ctx context.Context, args []string) error {
 	return nil
 }
 
-func (a App) hydrateActionsWithGitHubRunner(ctx context.Context, cfg Config, repo Repo, target SSHTarget, leaseID, slug string, ghRepo GitHubRepo, label, ref string, fields []string, waitTimeout time.Duration) (actionsHydrationState, error) {
-	if err := a.registerGitHubActionsRunner(ctx, cfg, target, leaseID, slug, ghRepo, "", nil); err != nil {
+func (a App) hydrateActionsWithGitHubRunner(ctx context.Context, cfg Config, repo Repo, target SSHTarget, leaseID, slug string, ghRepo GitHubRepo, label, ref string, fields []string, waitTimeout time.Duration, owner *workspaceOwner) (actionsHydrationState, error) {
+	if err := a.registerGitHubActionsRunnerOwned(ctx, cfg, target, leaseID, slug, ghRepo, "", nil, owner); err != nil {
+		return actionsHydrationState{}, err
+	}
+	if err := invalidateActionsHydrationWorkspaces(ctx, cfg, repo, target, leaseID); err != nil {
 		return actionsHydrationState{}, err
 	}
 	if err := clearActionsHydrationState(ctx, target, leaseID); err != nil {
@@ -231,20 +253,54 @@ func (a App) hydrateActionsWithGitHubRunner(ctx context.Context, cfg Config, rep
 	if !workflowFieldsContain(fields, "crabbox_job") {
 		expectedJob = ""
 	}
+	monitorStarted := false
+	if owner != nil {
+		if err := runSSHQuiet(ctx, target, remotePrepareActionsHydrationMonitorForTarget(target, leaseID)); err != nil {
+			return actionsHydrationState{}, exit(7, "prepare Actions hydration child witness on %s: %v", target.Host, err)
+		}
+		monitor := remoteActionsHydrationMonitorForTarget(target, leaseID, waitTimeout, owner)
+		if _, err := runSSHOutput(contextWithoutWorkspaceOwner(ctx), target, owner.WrapBackgroundCommand(monitor)); err != nil {
+			return actionsHydrationState{}, exit(7, "start Actions hydration child witness on %s: %v", target.Host, err)
+		}
+		monitorStarted = true
+	}
+	cancelMonitor := func() {
+		if !monitorStarted {
+			return
+		}
+		cancelCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 45*time.Second)
+		cancelCtx = contextWithoutWorkspaceOwner(cancelCtx)
+		_ = runSSHQuiet(cancelCtx, target, remoteCancelActionsHydrationMonitorForTarget(target, leaseID))
+		cancel()
+		_ = waitWorkspaceOwnerNoChild(context.WithoutCancel(ctx), owner, 40*time.Second)
+	}
 	if err := dispatchGitHubActionsWorkflow(ctx, repo.Root, ghRepo, cfg.Actions.Workflow, ref, fields, target.ChildEnvDenylist); err != nil {
 		if expectedJob != "" && strings.Contains(err.Error(), "Unexpected input") {
 			fields = dropWorkflowField(fields, "crabbox_job")
 			expectedJob = ""
 			fmt.Fprintf(a.Stderr, "warning: retrying workflow dispatch without crabbox_job for compatibility\n")
 			if retryErr := dispatchGitHubActionsWorkflow(ctx, repo.Root, ghRepo, cfg.Actions.Workflow, ref, fields, target.ChildEnvDenylist); retryErr != nil {
+				cancelMonitor()
 				return actionsHydrationState{}, retryErr
 			}
 		} else {
+			cancelMonitor()
 			return actionsHydrationState{}, err
 		}
 	}
 	fmt.Fprintf(a.Stdout, "dispatched workflow=%s repo=%s ref=%s runner_label=%s\n", cfg.Actions.Workflow, ghRepo.Slug(), ref, label)
-	return waitForActionsHydration(ctx, target, leaseID, expectedJob, waitTimeout, a.Stderr)
+	// The monitor is the sole child witness while polling stays read-only. Masking
+	// the owner value avoids replacing it and still preserves owner cancellation.
+	waitCtx := contextWithoutWorkspaceOwner(ctx)
+	state, err := waitForActionsHydration(waitCtx, target, leaseID, expectedJob, waitTimeout, a.Stderr)
+	if err != nil {
+		cancelMonitor()
+		return actionsHydrationState{}, err
+	}
+	if err := waitWorkspaceOwnerNoChild(ctx, owner, 15*time.Second); err != nil {
+		return actionsHydrationState{}, err
+	}
+	return state, nil
 }
 
 func (a App) actionsRegister(ctx context.Context, args []string) error {
@@ -349,6 +405,10 @@ func (a App) actionsDispatch(ctx context.Context, args []string) error {
 }
 
 func (a App) registerGitHubActionsRunner(ctx context.Context, cfg Config, target SSHTarget, leaseID, slug string, ghRepo GitHubRepo, nameOverride string, extraLabels []string) error {
+	return a.registerGitHubActionsRunnerOwned(ctx, cfg, target, leaseID, slug, ghRepo, nameOverride, extraLabels, nil)
+}
+
+func (a App) registerGitHubActionsRunnerOwned(ctx context.Context, cfg Config, target SSHTarget, leaseID, slug string, ghRepo GitHubRepo, nameOverride string, extraLabels []string, owner *workspaceOwner) error {
 	if !supportsGitHubActionsRunnerTarget(target) {
 		return exit(2, "actions runner registration currently supports Linux and Windows targets only")
 	}
@@ -432,7 +492,7 @@ func exitCodeForError(err error, fallback int) int {
 	return fallback
 }
 
-func (a App) hydrateActionsLocally(ctx context.Context, cfg Config, repo Repo, target SSHTarget, leaseID, expectedJob string, fields []string, waitTimeout time.Duration, streamOutput bool, syncBefore bool) (actionsHydrationState, error) {
+func (a App) hydrateActionsLocally(ctx context.Context, cfg Config, repo Repo, target SSHTarget, leaseID, expectedJob string, fields []string, waitTimeout time.Duration, streamOutput bool, syncBefore bool, owner *workspaceOwner) (actionsHydrationState, error) {
 	if !supportsLocalActionsHydrateTarget(target) {
 		return actionsHydrationState{}, exit(2, "local Actions hydration currently supports Linux and Windows WSL2 targets only")
 	}
@@ -476,6 +536,9 @@ func (a App) hydrateActionsLocally(ctx context.Context, cfg Config, repo Repo, t
 	if streamOutput {
 		fmt.Fprintf(a.Stdout, "local actions hydrate workflow=%s job=%s workspace=%s\n", cfg.Actions.Workflow, jobName, workdir)
 	}
+	if err := invalidateActionsHydrationWorkspaces(ctx, cfg, repo, target, leaseID); err != nil {
+		return actionsHydrationState{}, err
+	}
 	if err := clearActionsHydrationState(ctx, target, leaseID); err != nil {
 		return actionsHydrationState{}, err
 	}
@@ -483,6 +546,9 @@ func (a App) hydrateActionsLocally(ctx context.Context, cfg Config, repo Repo, t
 		if err := a.syncLocalActionsWorkspace(ctx, cfg, repo, target, workdir); err != nil {
 			return actionsHydrationState{}, err
 		}
+	}
+	if _, err := runIdempotentSSHCombinedOutput(ctx, target, remoteInvalidateSyncFingerprintForTarget(target, workdir), idempotentSSHRetryDelay); err != nil {
+		return actionsHydrationState{}, exit(7, "invalidate reusable sync fingerprint before Actions hydration: %v", err)
 	}
 	script, err := localActionsHydrateScript(cfg, repo, workflow, job, jobName, leaseID, fields, workdir)
 	if err != nil {
@@ -498,10 +564,15 @@ func (a App) hydrateActionsLocally(ctx context.Context, cfg Config, repo Repo, t
 		return actionsHydrationState{}, exit(7, "install local Actions hydration script on %s: %v", target.Host, err)
 	}
 	if isWindowsWSL2Target(target) {
-		if err := runSSHInput(ctx, target, remoteRunLocalActionsHydrateScriptForeground(leaseID, waitTimeout), nil, stdout, stderr); err != nil {
+		remote := remoteRunLocalActionsHydrateScriptForeground(leaseID, waitTimeout)
+		if err := runSSHInput(ctx, target, remote, nil, stdout, stderr); err != nil {
 			return actionsHydrationState{}, exit(7, "run local Actions hydration on %s: %v", target.Host, err)
 		}
-		state, err := readActionsHydrationState(ctx, target, leaseID)
+		stateCtx := ctx
+		if owner != nil {
+			stateCtx = contextWithoutWorkspaceOwner(ctx)
+		}
+		state, err := readActionsHydrationState(stateCtx, target, leaseID)
 		if err != nil || state.Workspace == "" {
 			if err != nil {
 				return actionsHydrationState{}, exit(7, "read local Actions hydration marker for %s: %v", leaseID, err)
@@ -516,11 +587,47 @@ func (a App) hydrateActionsLocally(ctx context.Context, cfg Config, repo Repo, t
 		}
 		return state, nil
 	}
-	pid, err := runSSHOutput(ctx, target, remoteStartLocalActionsHydrateScript(leaseID))
+	startRemote := remoteStartLocalActionsHydrateScript(leaseID)
+	if owner != nil {
+		startRemote = owner.WrapBackgroundCommand(remoteLocalActionsHydrateBackgroundPayload(leaseID))
+	}
+	startCtx := ctx
+	if owner != nil {
+		startCtx = contextWithoutWorkspaceOwner(ctx)
+	}
+	pid, err := runSSHOutput(startCtx, target, startRemote)
 	if err != nil {
 		return actionsHydrationState{}, exit(7, "start local Actions hydration on %s: %v", target.Host, err)
 	}
-	return waitForLocalActionsHydration(ctx, target, leaseID, expectedJob, strings.TrimSpace(pid), waitTimeout, stderr)
+	waitCtx := ctx
+	if owner != nil {
+		waitCtx = contextWithoutWorkspaceOwner(ctx)
+	}
+	state, err := waitForLocalActionsHydration(waitCtx, target, leaseID, expectedJob, strings.TrimSpace(pid), waitTimeout, stderr)
+	if err != nil {
+		return actionsHydrationState{}, err
+	}
+	if err := waitWorkspaceOwnerNoChild(ctx, owner, 15*time.Second); err != nil {
+		return actionsHydrationState{}, err
+	}
+	return state, nil
+}
+
+func invalidateActionsHydrationWorkspaces(ctx context.Context, cfg Config, repo Repo, target SSHTarget, leaseID string) error {
+	workdirs := []string{remoteJoin(cfg, leaseID, repo.Name)}
+	state, err := readActionsHydrationState(ctx, target, leaseID)
+	if err != nil {
+		return exit(7, "read Actions workspace before fingerprint invalidation: %v", err)
+	}
+	if strings.TrimSpace(state.Workspace) != "" {
+		workdirs = appendUniqueStrings(workdirs, state.Workspace)
+	}
+	for _, workdir := range workdirs {
+		if _, err := runIdempotentSSHCombinedOutput(ctx, target, remoteInvalidateSyncFingerprintForTarget(target, workdir), idempotentSSHRetryDelay); err != nil {
+			return exit(7, "invalidate reusable sync fingerprint before Actions hydration: %v", err)
+		}
+	}
+	return nil
 }
 
 func (a App) syncLocalActionsWorkspace(ctx context.Context, cfg Config, repo Repo, target SSHTarget, workdir string) error {
@@ -541,12 +648,12 @@ func (a App) syncLocalActionsWorkspace(ctx context.Context, cfg Config, repo Rep
 	if _, err := runIdempotentSSHCombinedOutput(ctx, target, remoteMkdir(workdir), idempotentSSHRetryDelay); err != nil {
 		return exit(7, "create remote workdir: %v", err)
 	}
-	gitSeed, credentialBlocked := syncGitSeedDecision(cfg, repo)
+	coherence, credentialBlocked := syncGitCoherencePlan(cfg, repo)
 	if credentialBlocked {
 		warnCredentialBearingGitSeed(a.Stderr)
 	}
-	if gitSeed {
-		if _, err := runIdempotentSSHCombinedOutput(ctx, target, remoteGitSeed(workdir, repo.RemoteURL, repo.Head), idempotentSSHRetryDelay); err != nil {
+	if coherence.seedEnabled() {
+		if _, err := runIdempotentSSHCombinedOutput(ctx, target, remoteGitSeed(workdir, coherence), idempotentSSHRetryDelay); err != nil {
 			fmt.Fprintf(a.Stderr, "warning: remote git seed failed: %v\n", err)
 		}
 	}
@@ -574,7 +681,7 @@ func (a App) syncLocalActionsWorkspace(ctx context.Context, cfg Config, repo Rep
 	}
 	fingerprint := ""
 	if cfg.Sync.Fingerprint {
-		if value, err := syncFingerprintForManifest(repo, cfg, manifest, excludes); err == nil {
+		if value, err := syncFingerprintForManifest(repo, cfg, manifest, excludes, coherence); err == nil {
 			fingerprint = value
 		} else {
 			fmt.Fprintf(a.Stderr, "warning: sync fingerprint failed: %v\n", err)
@@ -587,6 +694,7 @@ func (a App) syncLocalActionsWorkspace(ctx context.Context, cfg Config, repo Rep
 		BaseSHA:            gitHydrateBaseSHA(repo, cfg.Sync.BaseRef),
 		Fingerprint:        fingerprint,
 		Token:              finalizeToken,
+		Coherence:          coherence,
 	})
 	if out, err := runIdempotentSSHCombinedOutput(ctx, target, finalizeCommand, idempotentSSHRetryDelay); err != nil {
 		if out != "" {
@@ -2364,11 +2472,149 @@ func remoteInstallLocalActionsHydrateScript(leaseID string) string {
 }
 
 func remoteStartLocalActionsHydrateScript(leaseID string) string {
+	payload := remoteLocalActionsHydrateBackgroundPayload(leaseID)
+	return "nohup sh -c " + shellQuote(payload) + " >/dev/null 2>&1 < /dev/null & printf '%s\\n' \"$!\""
+}
+
+func remoteLocalActionsHydrateBackgroundPayload(leaseID string) string {
 	script := "\"$HOME\"/" + shellQuote(actionsHydrationLocalScriptPath(leaseID))
 	logPath := "\"$HOME\"/" + shellQuote(actionsHydrationLocalLogPath(leaseID))
 	exitPath := "\"$HOME\"/" + shellQuote(actionsHydrationLocalExitPath(leaseID))
-	wrapper := `bash "$1" >"$2" 2>&1; printf '%s\n' "$?" >"$3"`
-	return "rm -f " + exitPath + " " + logPath + " && nohup bash -c " + shellQuote(wrapper) + " sh " + script + " " + logPath + " " + exitPath + " >/dev/null 2>&1 < /dev/null & printf '%s\\n' \"$!\""
+	wrapper := `rm -f "$3" "$2"; bash "$1" >"$2" 2>&1; code=$?; printf '%s\n' "$code" >"$3"; exit "$code"`
+	return "bash -c " + shellQuote(wrapper) + " sh " + script + " " + logPath + " " + exitPath
+}
+
+func remoteActionsHydrationMonitorForTarget(target SSHTarget, leaseID string, timeout time.Duration, owners ...*workspaceOwner) string {
+	if timeout <= 0 {
+		timeout = 20 * time.Minute
+	}
+	seconds := int((timeout + time.Second - 1) / time.Second)
+	var owner *workspaceOwner
+	if len(owners) > 0 {
+		owner = owners[0]
+	}
+	if isWindowsNativeTarget(target) {
+		path := windowsActionsHydrationPath(actionsHydrationStatePath(leaseID))
+		stop := windowsActionsHydrationPath(actionsHydrationOwnerMonitorStopPath(leaseID))
+		if owner != nil {
+			return powershellCommand(`$marker = ` + psQuote(path) + `
+$stop = ` + psQuote(stop) + `
+$ownerState = Join-Path $HOME ` + psQuote(`.crabbox\workspace-owners\`+owner.key+`.owner`) + `
+$ownerToken = ` + psQuote(owner.token) + `
+function Stop-CrabboxRunner {
+  Get-Process -Name "Runner.Worker","Runner.Listener" -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+  $deadline = [DateTime]::UtcNow.AddSeconds(30)
+  while ([DateTime]::UtcNow -lt $deadline) {
+    if ($null -eq (Get-Process -Name "Runner.Worker","Runner.Listener" -ErrorAction SilentlyContinue)) { return $true }
+    Start-Sleep -Milliseconds 250
+  }
+  return $false
+}
+while ($true) {
+  if (Test-Path -LiteralPath $marker -PathType Leaf) { exit 0 }
+  $mustStop = Test-Path -LiteralPath $stop -PathType Leaf
+  if (-not $mustStop) {
+    try {
+      $state = @(Get-Content -LiteralPath $ownerState -ErrorAction Stop)
+      $mustStop = $state.Count -ne 3 -or $state[0] -ne "v1" -or $state[1] -ne $ownerToken -or $state[2] -notmatch "^[0-9]+$" -or [DateTimeOffset]::UtcNow.ToUnixTimeSeconds() -ge [Int64]$state[2]
+    } catch { $mustStop = $true }
+  }
+  if ($mustStop -and (Stop-CrabboxRunner)) { exit 125 }
+  Start-Sleep -Seconds 1
+}
+`)
+		}
+		return powershellCommand(`$deadline = [DateTime]::UtcNow.AddSeconds(` + strconv.Itoa(seconds) + `)
+while ([DateTime]::UtcNow -lt $deadline) {
+  if (Test-Path -LiteralPath ` + psQuote(path) + ` -PathType Leaf) { exit 0 }
+  if (Test-Path -LiteralPath ` + psQuote(stop) + ` -PathType Leaf) { exit 125 }
+  Start-Sleep -Seconds 1
+}
+exit 124
+`)
+	}
+	path := "\"$HOME\"/" + shellQuote(actionsHydrationStatePath(leaseID))
+	stop := "\"$HOME\"/" + shellQuote(actionsHydrationOwnerMonitorStopPath(leaseID))
+	if owner != nil {
+		return `marker=` + path + `
+stop=` + stop + `
+owner_state="$HOME/.crabbox/workspace-owners/` + owner.key + `.owner"
+owner_token=` + shellQuote(owner.token) + `
+stop_runner() {
+	if command -v systemctl >/dev/null 2>&1; then
+		if [ "$(id -u)" = 0 ]; then systemctl stop crabbox-actions-runner.service >/dev/null 2>&1 || true
+		elif command -v sudo >/dev/null 2>&1; then sudo -n systemctl stop crabbox-actions-runner.service >/dev/null 2>&1 || true
+		fi
+	fi
+	pkill -TERM -f '[R]unner.Worker|[R]unner.Listener' >/dev/null 2>&1 || true
+	deadline=$(($(date +%s) + 30))
+	while ps -ax -o command= 2>/dev/null | grep -E '[R]unner.Worker|[R]unner.Listener' >/dev/null 2>&1; do
+		[ "$(date +%s)" -lt "$deadline" ] || return 1
+		sleep 0.25
+	done
+}
+while :; do
+	[ ! -f "$marker" ] || exit 0
+	must_stop=
+	[ ! -f "$stop" ] || must_stop=1
+	state_version=$(sed -n '1p' "$owner_state" 2>/dev/null || true)
+	state_token=$(sed -n '2p' "$owner_state" 2>/dev/null || true)
+	state_expiry=$(sed -n '3p' "$owner_state" 2>/dev/null || true)
+	case "$state_expiry" in ''|*[!0-9]*) must_stop=1; state_expiry=0 ;; esac
+	if [ "$state_version" != v1 ] || [ "$state_token" != "$owner_token" ] || [ "$(date +%s)" -ge "$state_expiry" ]; then must_stop=1; fi
+	if [ -n "$must_stop" ] && stop_runner; then exit 125; fi
+	sleep 1
+done`
+	}
+	return "deadline=$(($(date +%s) + " + strconv.Itoa(seconds) + ")); while [ \"$(date +%s)\" -lt \"$deadline\" ]; do [ -f " + path + " ] && exit 0; [ -f " + stop + " ] && exit 125; sleep 1; done; exit 124"
+}
+
+func remotePrepareActionsHydrationMonitorForTarget(target SSHTarget, leaseID string) string {
+	if isWindowsNativeTarget(target) {
+		return powershellCommand(`Remove-Item -LiteralPath ` + psQuote(windowsActionsHydrationPath(actionsHydrationOwnerMonitorStopPath(leaseID))) + ` -Force -ErrorAction SilentlyContinue
+exit 0
+`)
+	}
+	return "rm -f \"$HOME\"/" + shellQuote(actionsHydrationOwnerMonitorStopPath(leaseID))
+}
+
+func remoteCancelActionsHydrationMonitorForTarget(target SSHTarget, leaseID string) string {
+	if isWindowsNativeTarget(target) {
+		return powershellCommand(`$path = ` + psQuote(windowsActionsHydrationPath(actionsHydrationOwnerMonitorStopPath(leaseID))) + `
+New-Item -ItemType Directory -Force -Path ([IO.Path]::GetDirectoryName($path)) | Out-Null
+New-Item -ItemType File -Force -Path $path | Out-Null
+exit 0
+`)
+	}
+	return "mkdir -p \"$HOME\"/" + shellQuote(actionsHydrationDir()) + " && touch \"$HOME\"/" + shellQuote(actionsHydrationOwnerMonitorStopPath(leaseID))
+}
+
+func waitWorkspaceOwnerNoChild(ctx context.Context, owner *workspaceOwner, timeout time.Duration) error {
+	if owner == nil {
+		return nil
+	}
+	if timeout <= 0 {
+		timeout = 15 * time.Second
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		checkCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		err := owner.ConfirmNoChild(checkCtx)
+		cancel()
+		if err == nil {
+			return nil
+		}
+		if !strings.Contains(err.Error(), "child") || time.Now().After(deadline) {
+			return err
+		}
+		timer := time.NewTimer(250 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
 }
 
 func remoteRunLocalActionsHydrateScriptForeground(leaseID string, timeout time.Duration) string {
@@ -2424,7 +2670,7 @@ fi
 }
 
 func remoteClearActionsHydrationState(leaseID string) string {
-	return "rm -f \"$HOME\"/" + shellQuote(actionsHydrationStatePath(leaseID)) + " \"$HOME\"/" + shellQuote(actionsHydrationEnvPath(leaseID)) + " \"$HOME\"/" + shellQuote(actionsHydrationServicesPath(leaseID)) + " \"$HOME\"/" + shellQuote(actionsHydrationStopPath(leaseID)) + " \"$HOME\"/" + shellQuote(actionsHydrationLocalScriptPath(leaseID)) + " \"$HOME\"/" + shellQuote(actionsHydrationLocalLogPath(leaseID)) + " \"$HOME\"/" + shellQuote(actionsHydrationLocalExitPath(leaseID))
+	return "rm -f \"$HOME\"/" + shellQuote(actionsHydrationStatePath(leaseID)) + " \"$HOME\"/" + shellQuote(actionsHydrationEnvPath(leaseID)) + " \"$HOME\"/" + shellQuote(actionsHydrationServicesPath(leaseID)) + " \"$HOME\"/" + shellQuote(actionsHydrationStopPath(leaseID)) + " \"$HOME\"/" + shellQuote(actionsHydrationOwnerMonitorStopPath(leaseID)) + " \"$HOME\"/" + shellQuote(actionsHydrationLocalScriptPath(leaseID)) + " \"$HOME\"/" + shellQuote(actionsHydrationLocalLogPath(leaseID)) + " \"$HOME\"/" + shellQuote(actionsHydrationLocalExitPath(leaseID))
 }
 
 func remoteClearActionsHydrationStateForTarget(target SSHTarget, leaseID string) string {
@@ -2434,6 +2680,7 @@ func remoteClearActionsHydrationStateForTarget(target SSHTarget, leaseID string)
 			windowsActionsHydrationPath(actionsHydrationEnvPath(leaseID)),
 			windowsActionsHydrationPath(actionsHydrationServicesPath(leaseID)),
 			windowsActionsHydrationPath(actionsHydrationStopPath(leaseID)),
+			windowsActionsHydrationPath(actionsHydrationOwnerMonitorStopPath(leaseID)),
 			windowsActionsHydrationPath(actionsHydrationLocalScriptPath(leaseID)),
 			windowsActionsHydrationPath(actionsHydrationLocalLogPath(leaseID)),
 			windowsActionsHydrationPath(actionsHydrationLocalExitPath(leaseID)),
@@ -2473,6 +2720,10 @@ func actionsHydrationServicesPath(leaseID string) string {
 
 func actionsHydrationStopPath(leaseID string) string {
 	return actionsHydrationDir() + "/" + leaseID + ".stop"
+}
+
+func actionsHydrationOwnerMonitorStopPath(leaseID string) string {
+	return actionsHydrationDir() + "/" + leaseID + ".owner-monitor-stop"
 }
 
 func actionsHydrationLocalScriptPath(leaseID string) string {

--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -255,7 +255,7 @@ func (a App) hydrateActionsWithGitHubRunner(ctx context.Context, cfg Config, rep
 	}
 	monitorStarted := false
 	if owner != nil {
-		if err := runSSHQuiet(ctx, target, remotePrepareActionsHydrationMonitorForTarget(target, leaseID)); err != nil {
+		if err := runSSHQuiet(ctx, target, remotePrepareActionsHydrationMonitorForTarget(target, leaseID, owner)); err != nil {
 			return actionsHydrationState{}, exit(7, "prepare Actions hydration child witness on %s: %v", target.Host, err)
 		}
 		monitor := remoteActionsHydrationMonitorForTarget(target, leaseID, waitTimeout, owner)
@@ -270,9 +270,14 @@ func (a App) hydrateActionsWithGitHubRunner(ctx context.Context, cfg Config, rep
 		}
 		cancelCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 45*time.Second)
 		cancelCtx = contextWithoutWorkspaceOwner(cancelCtx)
-		_ = runSSHQuiet(cancelCtx, target, remoteCancelActionsHydrationMonitorForTarget(target, leaseID))
+		_ = runSSHQuiet(cancelCtx, target, remoteCancelActionsHydrationMonitorForTarget(target, leaseID, owner))
 		cancel()
-		_ = waitWorkspaceOwnerNoChild(context.WithoutCancel(ctx), owner, 40*time.Second)
+		if waitWorkspaceOwnerNoChild(context.WithoutCancel(ctx), owner, 40*time.Second) == nil {
+			cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+			cleanupCtx = contextWithoutWorkspaceOwner(cleanupCtx)
+			_ = runSSHQuiet(cleanupCtx, target, remotePrepareActionsHydrationMonitorForTarget(target, leaseID, owner))
+			cleanupCancel()
+		}
 	}
 	if err := dispatchGitHubActionsWorkflow(ctx, repo.Root, ghRepo, cfg.Actions.Workflow, ref, fields, target.ChildEnvDenylist); err != nil {
 		if expectedJob != "" && strings.Contains(err.Error(), "Unexpected input") {
@@ -2495,7 +2500,7 @@ func remoteActionsHydrationMonitorForTarget(target SSHTarget, leaseID string, ti
 	}
 	if isWindowsNativeTarget(target) {
 		path := windowsActionsHydrationPath(actionsHydrationStatePath(leaseID))
-		stop := windowsActionsHydrationPath(actionsHydrationOwnerMonitorStopPath(leaseID))
+		stop := windowsActionsHydrationPath(actionsHydrationOwnerMonitorStopPath(leaseID, ownerToken(owner)))
 		if owner != nil {
 			return powershellCommand(`$marker = ` + psQuote(path) + `
 $stop = ` + psQuote(stop) + `
@@ -2534,7 +2539,7 @@ exit 124
 `)
 	}
 	path := "\"$HOME\"/" + shellQuote(actionsHydrationStatePath(leaseID))
-	stop := "\"$HOME\"/" + shellQuote(actionsHydrationOwnerMonitorStopPath(leaseID))
+	stop := "\"$HOME\"/" + shellQuote(actionsHydrationOwnerMonitorStopPath(leaseID, ownerToken(owner)))
 	if owner != nil {
 		return `marker=` + path + `
 stop=` + stop + `
@@ -2569,24 +2574,26 @@ done`
 	return "deadline=$(($(date +%s) + " + strconv.Itoa(seconds) + ")); while [ \"$(date +%s)\" -lt \"$deadline\" ]; do [ -f " + path + " ] && exit 0; [ -f " + stop + " ] && exit 125; sleep 1; done; exit 124"
 }
 
-func remotePrepareActionsHydrationMonitorForTarget(target SSHTarget, leaseID string) string {
+func remotePrepareActionsHydrationMonitorForTarget(target SSHTarget, leaseID string, owner *workspaceOwner) string {
+	path := actionsHydrationOwnerMonitorStopPath(leaseID, ownerToken(owner))
 	if isWindowsNativeTarget(target) {
-		return powershellCommand(`Remove-Item -LiteralPath ` + psQuote(windowsActionsHydrationPath(actionsHydrationOwnerMonitorStopPath(leaseID))) + ` -Force -ErrorAction SilentlyContinue
+		return powershellCommand(`Remove-Item -LiteralPath ` + psQuote(windowsActionsHydrationPath(path)) + ` -Force -ErrorAction SilentlyContinue
 exit 0
 `)
 	}
-	return "rm -f \"$HOME\"/" + shellQuote(actionsHydrationOwnerMonitorStopPath(leaseID))
+	return "rm -f \"$HOME\"/" + shellQuote(path)
 }
 
-func remoteCancelActionsHydrationMonitorForTarget(target SSHTarget, leaseID string) string {
+func remoteCancelActionsHydrationMonitorForTarget(target SSHTarget, leaseID string, owner *workspaceOwner) string {
+	path := actionsHydrationOwnerMonitorStopPath(leaseID, ownerToken(owner))
 	if isWindowsNativeTarget(target) {
-		return powershellCommand(`$path = ` + psQuote(windowsActionsHydrationPath(actionsHydrationOwnerMonitorStopPath(leaseID))) + `
+		return powershellCommand(`$path = ` + psQuote(windowsActionsHydrationPath(path)) + `
 New-Item -ItemType Directory -Force -Path ([IO.Path]::GetDirectoryName($path)) | Out-Null
 New-Item -ItemType File -Force -Path $path | Out-Null
 exit 0
 `)
 	}
-	return "mkdir -p \"$HOME\"/" + shellQuote(actionsHydrationDir()) + " && touch \"$HOME\"/" + shellQuote(actionsHydrationOwnerMonitorStopPath(leaseID))
+	return "mkdir -p \"$HOME\"/" + shellQuote(actionsHydrationDir()) + " && touch \"$HOME\"/" + shellQuote(path)
 }
 
 func waitWorkspaceOwnerNoChild(ctx context.Context, owner *workspaceOwner, timeout time.Duration) error {
@@ -2670,7 +2677,7 @@ fi
 }
 
 func remoteClearActionsHydrationState(leaseID string) string {
-	return "rm -f \"$HOME\"/" + shellQuote(actionsHydrationStatePath(leaseID)) + " \"$HOME\"/" + shellQuote(actionsHydrationEnvPath(leaseID)) + " \"$HOME\"/" + shellQuote(actionsHydrationServicesPath(leaseID)) + " \"$HOME\"/" + shellQuote(actionsHydrationStopPath(leaseID)) + " \"$HOME\"/" + shellQuote(actionsHydrationOwnerMonitorStopPath(leaseID)) + " \"$HOME\"/" + shellQuote(actionsHydrationLocalScriptPath(leaseID)) + " \"$HOME\"/" + shellQuote(actionsHydrationLocalLogPath(leaseID)) + " \"$HOME\"/" + shellQuote(actionsHydrationLocalExitPath(leaseID))
+	return "rm -f \"$HOME\"/" + shellQuote(actionsHydrationStatePath(leaseID)) + " \"$HOME\"/" + shellQuote(actionsHydrationEnvPath(leaseID)) + " \"$HOME\"/" + shellQuote(actionsHydrationServicesPath(leaseID)) + " \"$HOME\"/" + shellQuote(actionsHydrationStopPath(leaseID)) + " \"$HOME\"/" + shellQuote(actionsHydrationLocalScriptPath(leaseID)) + " \"$HOME\"/" + shellQuote(actionsHydrationLocalLogPath(leaseID)) + " \"$HOME\"/" + shellQuote(actionsHydrationLocalExitPath(leaseID))
 }
 
 func remoteClearActionsHydrationStateForTarget(target SSHTarget, leaseID string) string {
@@ -2680,7 +2687,6 @@ func remoteClearActionsHydrationStateForTarget(target SSHTarget, leaseID string)
 			windowsActionsHydrationPath(actionsHydrationEnvPath(leaseID)),
 			windowsActionsHydrationPath(actionsHydrationServicesPath(leaseID)),
 			windowsActionsHydrationPath(actionsHydrationStopPath(leaseID)),
-			windowsActionsHydrationPath(actionsHydrationOwnerMonitorStopPath(leaseID)),
 			windowsActionsHydrationPath(actionsHydrationLocalScriptPath(leaseID)),
 			windowsActionsHydrationPath(actionsHydrationLocalLogPath(leaseID)),
 			windowsActionsHydrationPath(actionsHydrationLocalExitPath(leaseID)),
@@ -2722,8 +2728,15 @@ func actionsHydrationStopPath(leaseID string) string {
 	return actionsHydrationDir() + "/" + leaseID + ".stop"
 }
 
-func actionsHydrationOwnerMonitorStopPath(leaseID string) string {
-	return actionsHydrationDir() + "/" + leaseID + ".owner-monitor-stop"
+func ownerToken(owner *workspaceOwner) string {
+	if owner == nil || owner.token == "" {
+		return "unowned"
+	}
+	return owner.token
+}
+
+func actionsHydrationOwnerMonitorStopPath(leaseID, token string) string {
+	return actionsHydrationDir() + "/" + leaseID + ".owner-monitor-stop." + token
 }
 
 func actionsHydrationLocalScriptPath(leaseID string) string {

--- a/internal/cli/actions_test.go
+++ b/internal/cli/actions_test.go
@@ -1431,7 +1431,6 @@ func TestRemoteClearActionsHydrationStateRemovesReadyAndStop(t *testing.T) {
 		".crabbox/actions/cbx_123.env.sh",
 		".crabbox/actions/cbx_123.services",
 		".crabbox/actions/cbx_123.stop",
-		".crabbox/actions/cbx_123.owner-monitor-stop",
 		".crabbox/actions/cbx_123.local.sh",
 		".crabbox/actions/cbx_123.local.log",
 		".crabbox/actions/cbx_123.local.exit",

--- a/internal/cli/actions_test.go
+++ b/internal/cli/actions_test.go
@@ -1513,18 +1513,53 @@ func TestLocalActionsRemoteCommandsQuoteLeasePaths(t *testing.T) {
 
 func TestActionsHydrationOwnerMonitorGeneration(t *testing.T) {
 	leaseID := "cbx_123"
-	owner := &workspaceOwner{key: strings.Repeat("a", 64), token: strings.Repeat("b", 64)}
-	posix := remoteActionsHydrationMonitorForTarget(SSHTarget{TargetOS: targetLinux}, leaseID, 90*time.Second, owner)
-	for _, want := range []string{actionsHydrationStatePath(leaseID), actionsHydrationOwnerMonitorStopPath(leaseID), owner.key + ".owner", "state_expiry", "systemctl stop crabbox-actions-runner.service", "[R]unner.Worker", "exit 125"} {
+	ownerA := &workspaceOwner{key: strings.Repeat("a", 64), token: strings.Repeat("b", 64)}
+	ownerB := &workspaceOwner{key: ownerA.key, token: strings.Repeat("c", 64)}
+	markerA := actionsHydrationOwnerMonitorStopPath(leaseID, ownerA.token)
+	markerB := actionsHydrationOwnerMonitorStopPath(leaseID, ownerB.token)
+	if markerA == markerB {
+		t.Fatal("Actions owner monitor stop markers must be generation-specific")
+	}
+
+	posix := remoteActionsHydrationMonitorForTarget(SSHTarget{TargetOS: targetLinux}, leaseID, 90*time.Second, ownerB)
+	for _, want := range []string{actionsHydrationStatePath(leaseID), markerB, ownerB.key + ".owner", "state_expiry", "systemctl stop crabbox-actions-runner.service", "[R]unner.Worker", "exit 125"} {
 		if !strings.Contains(posix, want) {
 			t.Fatalf("POSIX owner monitor missing %q:\n%s", want, posix)
 		}
 	}
-	windows := decodePowerShellCommand(t, remoteActionsHydrationMonitorForTarget(SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeNormal}, leaseID, 90*time.Second, owner))
-	for _, want := range []string{windowsActionsHydrationPath(actionsHydrationStatePath(leaseID)), windowsActionsHydrationPath(actionsHydrationOwnerMonitorStopPath(leaseID)), owner.key + ".owner", "Stop-CrabboxRunner", "Runner.Worker", "ToUnixTimeSeconds()", "exit 125"} {
+	if strings.Contains(posix, markerA) {
+		t.Fatalf("POSIX generation B monitor watches generation A cancellation:\n%s", posix)
+	}
+	if cancelA := remoteCancelActionsHydrationMonitorForTarget(SSHTarget{TargetOS: targetLinux}, leaseID, ownerA); !strings.Contains(cancelA, markerA) || strings.Contains(cancelA, markerB) {
+		t.Fatalf("POSIX generation A cancellation is not isolated:\n%s", cancelA)
+	}
+	if prepareB := remotePrepareActionsHydrationMonitorForTarget(SSHTarget{TargetOS: targetLinux}, leaseID, ownerB); !strings.Contains(prepareB, markerB) || strings.Contains(prepareB, markerA) {
+		t.Fatalf("POSIX generation B preparation is not isolated:\n%s", prepareB)
+	}
+
+	windowsTarget := SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeNormal}
+	windows := decodePowerShellCommand(t, remoteActionsHydrationMonitorForTarget(windowsTarget, leaseID, 90*time.Second, ownerB))
+	for _, want := range []string{windowsActionsHydrationPath(actionsHydrationStatePath(leaseID)), windowsActionsHydrationPath(markerB), ownerB.key + ".owner", "Stop-CrabboxRunner", "Runner.Worker", "ToUnixTimeSeconds()", "exit 125"} {
 		if !strings.Contains(windows, want) {
 			t.Fatalf("Windows owner monitor missing %q:\n%s", want, windows)
 		}
+	}
+	if strings.Contains(windows, windowsActionsHydrationPath(markerA)) {
+		t.Fatalf("Windows generation B monitor watches generation A cancellation:\n%s", windows)
+	}
+	windowsCancelA := decodePowerShellCommand(t, remoteCancelActionsHydrationMonitorForTarget(windowsTarget, leaseID, ownerA))
+	if !strings.Contains(windowsCancelA, windowsActionsHydrationPath(markerA)) || strings.Contains(windowsCancelA, windowsActionsHydrationPath(markerB)) {
+		t.Fatalf("Windows generation A cancellation is not isolated:\n%s", windowsCancelA)
+	}
+	windowsPrepareB := decodePowerShellCommand(t, remotePrepareActionsHydrationMonitorForTarget(windowsTarget, leaseID, ownerB))
+	if !strings.Contains(windowsPrepareB, windowsActionsHydrationPath(markerB)) || strings.Contains(windowsPrepareB, windowsActionsHydrationPath(markerA)) {
+		t.Fatalf("Windows generation B preparation is not isolated:\n%s", windowsPrepareB)
+	}
+	if clear := remoteClearActionsHydrationState(leaseID); strings.Contains(clear, "owner-monitor-stop") {
+		t.Fatalf("broad POSIX hydration cleanup removed generation-specific monitor state:\n%s", clear)
+	}
+	if clear := decodePowerShellCommand(t, remoteClearActionsHydrationStateForTarget(windowsTarget, leaseID)); strings.Contains(clear, "owner-monitor-stop") {
+		t.Fatalf("broad Windows hydration cleanup removed generation-specific monitor state:\n%s", clear)
 	}
 }
 

--- a/internal/cli/actions_test.go
+++ b/internal/cli/actions_test.go
@@ -1,8 +1,10 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
+	"io"
 	"os"
 	"os/exec"
 	"path"
@@ -542,6 +544,50 @@ func TestSelectLocalHydrateJobAllowsSingleJobWorkflow(t *testing.T) {
 	}
 	if name != "setup" || job.Name != "Setup" {
 		t.Fatalf("selected job %q %#v, want setup", name, job)
+	}
+}
+
+func TestSyncLocalActionsWorkspaceUsesGitCoherenceFinalizer(t *testing.T) {
+	f := newGitCoherenceFixture(t)
+	tools := t.TempDir()
+	logPath := filepath.Join(tools, "ssh.log")
+	sshScript := `#!/bin/sh
+last=
+for arg do last="$arg"; done
+printf '%s\n' "$last" >> "$CRABBOX_ACTIONS_SSH_LOG"
+cat >/dev/null
+`
+	if err := os.WriteFile(filepath.Join(tools, "ssh"), []byte(sshScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tools, "rsync"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", tools+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CRABBOX_ACTIONS_SSH_LOG", logPath)
+
+	cfg := baseConfig()
+	cfg.Sync.Fingerprint = true
+	cfg.Sync.BaseRef = "main"
+	repo := Repo{Root: f.source, Name: "repo", RemoteURL: f.origin, Head: f.b, BaseRef: "main"}
+	var stderr bytes.Buffer
+	app := App{Stdout: io.Discard, Stderr: &stderr}
+	err := app.syncLocalActionsWorkspace(context.Background(), cfg, repo, SSHTarget{
+		User: "crabbox", Host: "example.test", Port: "22", TargetOS: targetLinux,
+	}, "/work/repo")
+	if err != nil {
+		t.Fatalf("sync local Actions workspace: %v\n%s", err, stderr.String())
+	}
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log := string(logData)
+	plan := f.plan(t, f.b)
+	for _, want := range []string{plan.RemoteURL, plan.Target, plan.Tree, "refs/crabbox/sync-", "read-tree --reset", "update-ref --no-deref HEAD"} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("Actions sync missing coherence contract %q:\n%s", want, log)
+		}
 	}
 }
 
@@ -1385,6 +1431,7 @@ func TestRemoteClearActionsHydrationStateRemovesReadyAndStop(t *testing.T) {
 		".crabbox/actions/cbx_123.env.sh",
 		".crabbox/actions/cbx_123.services",
 		".crabbox/actions/cbx_123.stop",
+		".crabbox/actions/cbx_123.owner-monitor-stop",
 		".crabbox/actions/cbx_123.local.sh",
 		".crabbox/actions/cbx_123.local.log",
 		".crabbox/actions/cbx_123.local.exit",
@@ -1447,7 +1494,6 @@ func TestLocalActionsRemoteCommandsQuoteLeasePaths(t *testing.T) {
 		want string
 	}{
 		"install":    {remoteInstallLocalActionsHydrateScript(leaseID), "\"$HOME\"/" + shellQuote(actionsHydrationLocalScriptPath(leaseID))},
-		"start":      {remoteStartLocalActionsHydrateScript(leaseID), "\"$HOME\"/" + shellQuote(actionsHydrationLocalLogPath(leaseID))},
 		"foreground": {remoteRunLocalActionsHydrateScriptForeground(leaseID, time.Minute), "\"$HOME\"/" + shellQuote(actionsHydrationLocalLogPath(leaseID))},
 		"status":     {remoteLocalActionsHydrateStatus(leaseID, "123"), "\"$HOME\"/" + shellQuote(actionsHydrationLocalExitPath(leaseID))},
 	} {
@@ -1456,6 +1502,28 @@ func TestLocalActionsRemoteCommandsQuoteLeasePaths(t *testing.T) {
 		}
 		if !strings.Contains(tc.got, tc.want) {
 			t.Fatalf("%s command missing quoted path %q:\n%s", name, tc.want, tc.got)
+		}
+	}
+	payload := remoteLocalActionsHydrateBackgroundPayload(leaseID)
+	wantLog := "\"$HOME\"/" + shellQuote(actionsHydrationLocalLogPath(leaseID))
+	if !strings.Contains(payload, wantLog) || !strings.Contains(remoteStartLocalActionsHydrateScript(leaseID), shellQuote(payload)) {
+		t.Fatalf("background hydrate command did not preserve nested path quoting:\npayload=%s\nstart=%s", payload, remoteStartLocalActionsHydrateScript(leaseID))
+	}
+}
+
+func TestActionsHydrationOwnerMonitorGeneration(t *testing.T) {
+	leaseID := "cbx_123"
+	owner := &workspaceOwner{key: strings.Repeat("a", 64), token: strings.Repeat("b", 64)}
+	posix := remoteActionsHydrationMonitorForTarget(SSHTarget{TargetOS: targetLinux}, leaseID, 90*time.Second, owner)
+	for _, want := range []string{actionsHydrationStatePath(leaseID), actionsHydrationOwnerMonitorStopPath(leaseID), owner.key + ".owner", "state_expiry", "systemctl stop crabbox-actions-runner.service", "[R]unner.Worker", "exit 125"} {
+		if !strings.Contains(posix, want) {
+			t.Fatalf("POSIX owner monitor missing %q:\n%s", want, posix)
+		}
+	}
+	windows := decodePowerShellCommand(t, remoteActionsHydrationMonitorForTarget(SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeNormal}, leaseID, 90*time.Second, owner))
+	for _, want := range []string{windowsActionsHydrationPath(actionsHydrationStatePath(leaseID)), windowsActionsHydrationPath(actionsHydrationOwnerMonitorStopPath(leaseID)), owner.key + ".owner", "Stop-CrabboxRunner", "Runner.Worker", "ToUnixTimeSeconds()", "exit 125"} {
+		if !strings.Contains(windows, want) {
+			t.Fatalf("Windows owner monitor missing %q:\n%s", want, windows)
 		}
 	}
 }

--- a/internal/cli/job_test.go
+++ b/internal/cli/job_test.go
@@ -169,13 +169,18 @@ func TestJobRunInjectsReservedExecutionMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 	logText := string(data)
-	for _, want := range []string{"CRABBOX_LEASE_ID='cbx_env_profile_test'", "CRABBOX_SLUG=''"} {
+	for _, want := range []string{"CRABBOX_LEASE_ID=", "cbx_env_profile_test", "CRABBOX_SLUG="} {
 		if !strings.Contains(logText, want) {
 			t.Fatalf("job command missing %q:\n%s", want, logText)
 		}
 	}
-	if !regexp.MustCompile(`CRABBOX_RUN_ID='run_[a-f0-9]{12}'`).MatchString(logText) {
+	if !regexp.MustCompile(`CRABBOX_RUN_ID=.*run_[a-f0-9]{12}`).MatchString(logText) {
 		t.Fatalf("job command missing run metadata:\n%s", logText)
+	}
+	invalidate := strings.Index(logText, `rm -f "$meta_dir/sync-fingerprint"`)
+	command := strings.Index(logText, "CRABBOX_LEASE_ID=")
+	if invalidate < 0 || command <= invalidate {
+		t.Fatalf("job command ran before fingerprint invalidation:\n%s", logText)
 	}
 }
 

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -126,6 +126,13 @@ type SSHLeaseBackend interface {
 	ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error
 }
 
+// ExclusiveOneShotAcquireBackend marks Acquire results that are newly
+// provisioned and exclusive to the caller until the one-shot run completes.
+// Backends are non-exclusive by default.
+type ExclusiveOneShotAcquireBackend interface {
+	AcquireIsExclusiveOneShot() bool
+}
+
 // StatusTouchClaimValidator lets a provider require identity labels that core
 // cannot interpret before status --wait extends a remotely visible lease.
 type StatusTouchClaimValidator interface {

--- a/internal/cli/provider_coordinator.go
+++ b/internal/cli/provider_coordinator.go
@@ -28,6 +28,8 @@ type coordinatorLeaseBackend struct {
 	rt     Runtime
 }
 
+func (b *coordinatorLeaseBackend) AcquireIsExclusiveOneShot() bool { return true }
+
 func (b *coordinatorLeaseBackend) Spec() ProviderSpec { return b.spec }
 
 func (b *coordinatorLeaseBackend) SupportsRequestedLeaseID() bool { return true }

--- a/internal/cli/ready_pool_test.go
+++ b/internal/cli/ready_pool_test.go
@@ -11,6 +11,19 @@ import (
 	"time"
 )
 
+type readyPoolWorkspaceOwnerTransport struct {
+	events     *[]string
+	releaseErr error
+}
+
+func (t readyPoolWorkspaceOwnerTransport) Do(_ context.Context, req workspaceOwnerRemoteRequest) (string, error) {
+	*t.events = append(*t.events, "owner."+string(req.Action))
+	if t.releaseErr != nil {
+		return "", t.releaseErr
+	}
+	return "RELEASED", nil
+}
+
 func TestReadyPoolReturnNeedsHydrationStop(t *testing.T) {
 	for _, tc := range []struct {
 		result string
@@ -24,6 +37,69 @@ func TestReadyPoolReturnNeedsHydrationStop(t *testing.T) {
 		if got := readyPoolReturnNeedsHydrationStop(tc.result); got != tc.want {
 			t.Fatalf("readyPoolReturnNeedsHydrationStop(%q)=%v, want %v", tc.result, got, tc.want)
 		}
+	}
+}
+
+func TestReadyPoolReturnReleasesWorkspaceOwnerBeforeCoordinator(t *testing.T) {
+	for _, disposition := range []string{"ready", "drain", "release"} {
+		t.Run(disposition, func(t *testing.T) {
+			events := []string{}
+			done := make(chan struct{})
+			close(done)
+			owner := &workspaceOwner{
+				transport: readyPoolWorkspaceOwnerTransport{events: &events},
+				key:       strings.Repeat("a", 64),
+				token:     strings.Repeat("b", 64),
+				stop:      make(chan struct{}),
+				done:      done,
+			}
+			err := returnReadyPoolAfterWorkspaceOwner(context.Background(), &owner, func() error {
+				events = append(events, "coordinator."+disposition)
+				return nil
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			// The run defer stops the borrow heartbeat only after this helper returns.
+			events = append(events, "heartbeat.stop")
+			want := "owner.release,coordinator." + disposition + ",heartbeat.stop"
+			if got := strings.Join(events, ","); got != want {
+				t.Fatalf("event order=%q, want %q", got, want)
+			}
+			if owner != nil {
+				t.Fatal("released owner remained installed for the outer defer")
+			}
+		})
+	}
+}
+
+func TestReadyPoolReturnStopsWhenWorkspaceOwnerReleaseFails(t *testing.T) {
+	events := []string{}
+	done := make(chan struct{})
+	close(done)
+	owner := &workspaceOwner{
+		transport: readyPoolWorkspaceOwnerTransport{events: &events, releaseErr: errors.New("release response lost")},
+		key:       strings.Repeat("a", 64),
+		token:     strings.Repeat("b", 64),
+		stop:      make(chan struct{}),
+		done:      done,
+	}
+	returned := false
+	err := returnReadyPoolAfterWorkspaceOwner(context.Background(), &owner, func() error {
+		returned = true
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "ambiguous remote state") {
+		t.Fatalf("release error=%v, want ambiguous failure", err)
+	}
+	if returned {
+		t.Fatal("coordinator return ran after workspace owner release failure")
+	}
+	if got := strings.Join(events, ","); got != "owner.release" {
+		t.Fatalf("events=%q, want only owner release", got)
+	}
+	if owner != nil {
+		t.Fatal("failed-close owner remained installed for a double close")
 	}
 }
 

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -310,19 +310,121 @@ func syncIncludes(cfg Config) []string {
 	return out
 }
 
-func syncGitSeedEnabled(cfg Config, repo Repo) bool {
-	enabled, _ := syncGitSeedDecision(cfg, repo)
-	return enabled
+type gitCoherencePlan struct{ RemoteURL, Target, Tree, Branch string }
+
+func (p gitCoherencePlan) seedEnabled() bool {
+	return p.RemoteURL != "" && normalizeGitRemoteURL(p.RemoteURL) == p.RemoteURL && p.Target != "" && p.Branch != ""
 }
 
-func syncGitSeedDecision(cfg Config, repo Repo) (enabled, credentialBlocked bool) {
-	if !cfg.Sync.GitSeed || len(syncIncludes(cfg)) != 0 || !remoteGitSeedSourceCandidate(repo) {
-		return false, false
+func (p gitCoherencePlan) enabled() bool { return p.seedEnabled() && p.Tree != "" }
+
+func syncGitCoherencePlan(cfg Config, repo Repo) (gitCoherencePlan, bool) {
+	if !cfg.Sync.GitSeed || len(syncIncludes(cfg)) != 0 || repo.Root == "" || repo.RemoteURL == "" || repo.Head == "" {
+		return gitCoherencePlan{}, false
 	}
 	if gitRemoteURLHasCredentials(repo.RemoteURL) {
-		return false, true
+		return gitCoherencePlan{}, true
 	}
-	return true, false
+	target := gitOutput(repo.Root, "rev-parse", "--verify", repo.Head+"^{commit}")
+	tree := gitOutput(repo.Root, "rev-parse", "--verify", repo.Head+"^{tree}")
+	branch := originBranchForTarget(repo.Root, repo.BaseRef, target)
+	plan := gitCoherencePlan{RemoteURL: normalizeGitRemoteURL(repo.RemoteURL), Target: target, Branch: branch}
+	if target == "" || target != repo.Head || branch == "" {
+		return gitCoherencePlan{}, false
+	}
+	overlayOnly, err := gitTargetRequiresOverlayOnly(repo.Root, target)
+	if tree == "" || err != nil || overlayOnly {
+		return plan, false
+	}
+	plan.Tree = tree
+	return plan, false
+}
+
+func originBranchForTarget(root, baseRef, target string) string {
+	if target == "" {
+		return ""
+	}
+	if branch := normalizedOriginBranch(baseRef); branch != "" &&
+		gitOutput(root, "rev-parse", "--verify", "refs/remotes/origin/"+branch+"^{commit}") == target {
+		return branch
+	}
+	originHead := gitOutput(root, "symbolic-ref", "--quiet", "refs/remotes/origin/HEAD")
+	if branch := normalizedOriginBranch(originHead); branch != "" &&
+		gitOutput(root, "rev-parse", "--verify", "refs/remotes/origin/"+branch+"^{commit}") == target {
+		return branch
+	}
+	out := gitOutput(root, "for-each-ref", "--contains="+target, "--sort=refname", "--format=%(refname)", "refs/remotes/origin")
+	for _, line := range strings.Split(out, "\n") {
+		if branch := normalizedOriginBranch(line); branch != "" {
+			return branch
+		}
+	}
+	return ""
+}
+
+func normalizedOriginBranch(ref string) string {
+	ref = strings.TrimSpace(ref)
+	switch {
+	case strings.HasPrefix(ref, "refs/remotes/origin/"):
+		ref = strings.TrimPrefix(ref, "refs/remotes/origin/")
+	case strings.HasPrefix(ref, "refs/heads/"):
+		ref = strings.TrimPrefix(ref, "refs/heads/")
+	case strings.HasPrefix(ref, "origin/"):
+		ref = strings.TrimPrefix(ref, "origin/")
+	}
+	if ref == "" || ref == "HEAD" {
+		return ""
+	}
+	cmd := exec.Command("git", "check-ref-format", "--branch", ref)
+	cmd.Env = repositoryGitEnvironment()
+	if err := cmd.Run(); err != nil {
+		return ""
+	}
+	return ref
+}
+
+func gitTargetRequiresOverlayOnly(root, target string) (bool, error) {
+	cmd := exec.Command("git", "ls-tree", "-r", "-z", "--full-tree", target)
+	cmd.Dir = root
+	cmd.Env = repositoryGitEnvironment()
+	out, err := cmd.Output()
+	if err != nil {
+		return false, err
+	}
+	var paths bytes.Buffer
+	for _, entry := range bytes.Split(out, []byte{0}) {
+		if len(entry) == 0 {
+			continue
+		}
+		metadata, name, ok := bytes.Cut(entry, []byte{'\t'})
+		if !ok {
+			return false, fmt.Errorf("parse target tree")
+		}
+		if bytes.HasPrefix(metadata, []byte("160000 ")) {
+			return true, nil
+		}
+		paths.Write(name)
+		paths.WriteByte(0)
+	}
+	if paths.Len() == 0 {
+		return false, nil
+	}
+	cmd = exec.Command("git", "check-attr", "--source="+target, "-z", "--stdin", "filter")
+	cmd.Dir = root
+	cmd.Env = repositoryGitEnvironment()
+	cmd.Stdin = bytes.NewReader(paths.Bytes())
+	out, err = cmd.Output()
+	if err != nil {
+		return false, err
+	}
+	fields := bytes.Split(out, []byte{0})
+	for i := 2; i < len(fields); i += 3 {
+		value := string(fields[i])
+		if value != "" && value != "unspecified" && value != "unset" {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func warnCredentialBearingGitSeed(w io.Writer) {
@@ -407,17 +509,6 @@ func gitOutput(root string, args ...string) string {
 	return strings.TrimSpace(string(out))
 }
 
-func remoteGitSeedCandidate(repo Repo) bool {
-	return remoteGitSeedSourceCandidate(repo) && !gitRemoteURLHasCredentials(repo.RemoteURL)
-}
-
-func remoteGitSeedSourceCandidate(repo Repo) bool {
-	if repo.Root == "" || repo.RemoteURL == "" || repo.Head == "" {
-		return false
-	}
-	return gitOutput(repo.Root, "for-each-ref", "--contains", repo.Head, "--format=%(refname)", "refs/remotes") != ""
-}
-
 func gitRemoteURLHasCredentials(remoteURL string) bool {
 	raw := strings.TrimSpace(remoteURL)
 	schemeEnd := strings.Index(raw, "://")
@@ -458,12 +549,12 @@ func defaultBaseRef(root string) string {
 	return ""
 }
 
-func syncFingerprintForManifest(repo Repo, cfg Config, manifest SyncManifest, excludes []string) (string, error) {
-	if repo.Head == "" {
+func syncFingerprintForManifest(repo Repo, cfg Config, manifest SyncManifest, excludes []string, plan gitCoherencePlan) (string, error) {
+	if !plan.enabled() {
 		return "", nil
 	}
 	h := sha256.New()
-	fmt.Fprintf(h, "v3\nhead=%s\n", repo.Head)
+	fmt.Fprintf(h, "v4\nremote=%s\nbranch=%s\nhead=%s\ntree=%s\n", plan.RemoteURL, plan.Branch, plan.Target, plan.Tree)
 	fmt.Fprintf(h, "delete=%t\nchecksum=%t\n", cfg.Sync.Delete, cfg.Sync.Checksum)
 	fmt.Fprintf(h, "manifest=%x\n", sha256.Sum256(manifest.NUL()))
 	fmt.Fprintf(h, "deleted=%x\n", sha256.Sum256(manifest.DeletedNUL()))

--- a/internal/cli/repo_test.go
+++ b/internal/cli/repo_test.go
@@ -369,9 +369,9 @@ func TestSyncGitSeedRejectsCredentialBearingRemote(t *testing.T) {
 	runGit(t, dir, "commit", "-m", "init")
 	runGit(t, dir, "update-ref", "refs/remotes/origin/main", "HEAD")
 	for _, remoteURL := range []string{
-		"https://runner:do-not-forward@example.test/repo.git",     // trufflehog:ignore
-		"ssh://runner:do-not-forward@example.test/repo.git",       // trufflehog:ignore
-		"git+https://runner:do-not-forward@example.test/repo.git", // trufflehog:ignore
+		"https://runner:do-not-forward@example.test/repo.git",
+		"ssh://runner:do-not-forward@example.test/repo.git",
+		"git+https://runner:do-not-forward@example.test/repo.git",
 	} {
 		t.Run(remoteURL, func(t *testing.T) {
 			repo := Repo{Root: dir, RemoteURL: remoteURL, Head: gitOutput(dir, "rev-parse", "HEAD")}
@@ -389,15 +389,15 @@ func TestGitRemoteURLHasCredentials(t *testing.T) {
 	}{
 		{remote: "https://example.test/repo.git", want: false},
 		{remote: "https://runner@example.test/repo.git", want: true},
-		{remote: "https://runner:token@example.test/repo.git", want: true}, // trufflehog:ignore
-		{remote: "HTTPS://runner:token@example.test/repo.git", want: true}, // trufflehog:ignore
+		{remote: "https://runner:token@example.test/repo.git", want: true},
+		{remote: "HTTPS://runner:token@example.test/repo.git", want: true},
 		{remote: "https://runner%zz@example.test/repo.git", want: true},
 		{remote: "ssh://git@example.test/repo.git", want: false},
-		{remote: "ssh://git:token@example.test/repo.git", want: true}, // trufflehog:ignore
-		{remote: "SSH://git:token@example.test/repo.git", want: true}, // trufflehog:ignore
+		{remote: "ssh://git:token@example.test/repo.git", want: true},
+		{remote: "SSH://git:token@example.test/repo.git", want: true},
 		{remote: "ssh://git:@example.test/repo.git", want: true},
-		{remote: "ssh://git%zz:token@example.test/repo.git", want: true},       // trufflehog:ignore
-		{remote: "git+https://runner:token@example.test/repo.git", want: true}, // trufflehog:ignore
+		{remote: "ssh://git%zz:token@example.test/repo.git", want: true},
+		{remote: "git+https://runner:token@example.test/repo.git", want: true},
 		{remote: "git@example.test:repo.git", want: false},
 	}
 	for _, tt := range tests {

--- a/internal/cli/repo_test.go
+++ b/internal/cli/repo_test.go
@@ -342,19 +342,19 @@ func TestSyncGitSeedDisabledByIncludeWhitelist(t *testing.T) {
 	repo := Repo{Root: dir, RemoteURL: "https://github.com/example-org/my-app.git", Head: head}
 
 	cfg := baseConfig()
-	if !syncGitSeedEnabled(cfg, repo) {
+	if plan, _ := syncGitCoherencePlan(cfg, repo); !plan.seedEnabled() {
 		t.Fatal("seedable repo without includes should use git seed")
 	}
 	cfg.Sync.Includes = []string{"src"}
-	if syncGitSeedEnabled(cfg, repo) {
+	if plan, _ := syncGitCoherencePlan(cfg, repo); plan.seedEnabled() {
 		t.Fatal("sync.include should disable full-repo git seed")
 	}
 	cfg.Sync.Includes = []string{" "}
-	if !syncGitSeedEnabled(cfg, repo) {
+	if plan, _ := syncGitCoherencePlan(cfg, repo); !plan.seedEnabled() {
 		t.Fatal("blank include entries should not disable git seed")
 	}
 	cfg.Sync.GitSeed = false
-	if syncGitSeedEnabled(cfg, repo) {
+	if plan, _ := syncGitCoherencePlan(cfg, repo); plan.seedEnabled() {
 		t.Fatal("gitSeed=false should disable git seed")
 	}
 }
@@ -369,17 +369,14 @@ func TestSyncGitSeedRejectsCredentialBearingRemote(t *testing.T) {
 	runGit(t, dir, "commit", "-m", "init")
 	runGit(t, dir, "update-ref", "refs/remotes/origin/main", "HEAD")
 	for _, remoteURL := range []string{
-		"https://runner:do-not-forward@example.test/repo.git",
-		"ssh://runner:do-not-forward@example.test/repo.git",
-		"git+https://runner:do-not-forward@example.test/repo.git",
+		"https://runner:do-not-forward@example.test/repo.git",     // trufflehog:ignore
+		"ssh://runner:do-not-forward@example.test/repo.git",       // trufflehog:ignore
+		"git+https://runner:do-not-forward@example.test/repo.git", // trufflehog:ignore
 	} {
 		t.Run(remoteURL, func(t *testing.T) {
 			repo := Repo{Root: dir, RemoteURL: remoteURL, Head: gitOutput(dir, "rev-parse", "HEAD")}
-			if enabled, blocked := syncGitSeedDecision(baseConfig(), repo); enabled || !blocked {
-				t.Fatalf("enabled=%v blocked=%v", enabled, blocked)
-			}
-			if remoteGitSeedCandidate(repo) {
-				t.Fatal("credential-bearing remote must not be a seed candidate")
+			if plan, blocked := syncGitCoherencePlan(baseConfig(), repo); plan.seedEnabled() || !blocked {
+				t.Fatalf("plan=%#v blocked=%v", plan, blocked)
 			}
 		})
 	}
@@ -392,15 +389,15 @@ func TestGitRemoteURLHasCredentials(t *testing.T) {
 	}{
 		{remote: "https://example.test/repo.git", want: false},
 		{remote: "https://runner@example.test/repo.git", want: true},
-		{remote: "https://runner:token@example.test/repo.git", want: true},
-		{remote: "HTTPS://runner:token@example.test/repo.git", want: true},
+		{remote: "https://runner:token@example.test/repo.git", want: true}, // trufflehog:ignore
+		{remote: "HTTPS://runner:token@example.test/repo.git", want: true}, // trufflehog:ignore
 		{remote: "https://runner%zz@example.test/repo.git", want: true},
 		{remote: "ssh://git@example.test/repo.git", want: false},
-		{remote: "ssh://git:token@example.test/repo.git", want: true},
-		{remote: "SSH://git:token@example.test/repo.git", want: true},
+		{remote: "ssh://git:token@example.test/repo.git", want: true}, // trufflehog:ignore
+		{remote: "SSH://git:token@example.test/repo.git", want: true}, // trufflehog:ignore
 		{remote: "ssh://git:@example.test/repo.git", want: true},
-		{remote: "ssh://git%zz:token@example.test/repo.git", want: true},
-		{remote: "git+https://runner:token@example.test/repo.git", want: true},
+		{remote: "ssh://git%zz:token@example.test/repo.git", want: true},       // trufflehog:ignore
+		{remote: "git+https://runner:token@example.test/repo.git", want: true}, // trufflehog:ignore
 		{remote: "git@example.test:repo.git", want: false},
 	}
 	for _, tt := range tests {
@@ -773,13 +770,103 @@ func TestRemoteGitSeedCandidateRequiresRemoteTrackingRef(t *testing.T) {
 	head := gitOutput(dir, "rev-parse", "HEAD")
 
 	repo := Repo{Root: dir, RemoteURL: "https://github.com/openclaw/crabbox.git", Head: head}
-	if remoteGitSeedCandidate(repo) {
+	if plan, _ := syncGitCoherencePlan(baseConfig(), repo); plan.enabled() {
 		t.Fatal("unpublished head should not be a seed candidate")
 	}
 	runGit(t, dir, "update-ref", "refs/remotes/origin/main", head)
-	if !remoteGitSeedCandidate(repo) {
+	if plan, _ := syncGitCoherencePlan(baseConfig(), repo); !plan.enabled() {
 		t.Fatal("head in a remote-tracking ref should be a seed candidate")
 	}
+}
+
+func TestSyncGitCoherencePlanSelectsEligibleOriginBranch(t *testing.T) {
+	newRepo := func(t *testing.T) string {
+		t.Helper()
+		dir := t.TempDir()
+		runGit(t, dir, "init")
+		runGit(t, dir, "config", "user.email", "test@example.com")
+		runGit(t, dir, "config", "user.name", "Test")
+		writeFile(t, filepath.Join(dir, "plain.txt"), "plain\n")
+		runGit(t, dir, "add", ".")
+		runGit(t, dir, "commit", "-m", "init")
+		runGit(t, dir, "update-ref", "refs/remotes/origin/main", "HEAD")
+		return dir
+	}
+	planFor := func(dir, target, baseRef string) gitCoherencePlan {
+		plan, _ := syncGitCoherencePlan(baseConfig(), Repo{
+			Root:      dir,
+			RemoteURL: "https://example.test/repo.git",
+			Head:      target,
+			BaseRef:   baseRef,
+		})
+		return plan
+	}
+	requireSeedOnly := func(t *testing.T, plan gitCoherencePlan) {
+		t.Helper()
+		if !plan.seedEnabled() || plan.enabled() {
+			t.Fatalf("plan should seed without coherence: %#v", plan)
+		}
+		fingerprint, _ := syncFingerprintForManifest(Repo{}, baseConfig(), SyncManifest{}, nil, plan)
+		if fingerprint != "" {
+			t.Fatalf("ineligible coherence published fingerprint %q", fingerprint)
+		}
+		if remoteGitSeed("/work/repo", plan) == "true" {
+			t.Fatal("ineligible coherence disabled Git seed")
+		}
+	}
+
+	t.Run("exact base ref wins with multiple containing refs", func(t *testing.T) {
+		dir := newRepo(t)
+		runGit(t, dir, "update-ref", "refs/remotes/origin/release", "HEAD")
+		plan := planFor(dir, gitOutput(dir, "rev-parse", "HEAD"), "release")
+		if !plan.enabled() || plan.Branch != "release" {
+			t.Fatalf("exact BaseRef plan=%#v", plan)
+		}
+	})
+
+	t.Run("origin HEAD exact tip fallback", func(t *testing.T) {
+		dir := newRepo(t)
+		runGit(t, dir, "update-ref", "refs/remotes/origin/trunk", "HEAD")
+		runGit(t, dir, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/trunk")
+		plan := planFor(dir, gitOutput(dir, "rev-parse", "HEAD"), "missing")
+		if !plan.enabled() || plan.Branch != "trunk" {
+			t.Fatalf("origin/HEAD plan=%#v", plan)
+		}
+	})
+
+	t.Run("deterministic containing ref fallback", func(t *testing.T) {
+		dir := newRepo(t)
+		target := gitOutput(dir, "rev-parse", "HEAD")
+		writeFile(t, filepath.Join(dir, "later.txt"), "later\n")
+		runGit(t, dir, "add", ".")
+		runGit(t, dir, "commit", "-m", "later")
+		runGit(t, dir, "update-ref", "refs/remotes/origin/zeta", "HEAD")
+		runGit(t, dir, "update-ref", "refs/remotes/origin/alpha", "HEAD")
+		runGit(t, dir, "update-ref", "-d", "refs/remotes/origin/main")
+		plan := planFor(dir, target, "")
+		if !plan.enabled() || plan.Branch != "alpha" {
+			t.Fatalf("deterministic containing-ref plan=%#v", plan)
+		}
+	})
+
+	t.Run("filter managed path", func(t *testing.T) {
+		dir := newRepo(t)
+		writeFile(t, filepath.Join(dir, ".gitattributes"), "*.bin filter=fixture -text\n")
+		writeFile(t, filepath.Join(dir, "asset.bin"), "payload\n")
+		runGit(t, dir, "-c", "filter.fixture.clean=cat", "-c", "filter.fixture.required=false", "add", ".")
+		runGit(t, dir, "commit", "-m", "filter")
+		runGit(t, dir, "update-ref", "refs/remotes/origin/main", "HEAD")
+		requireSeedOnly(t, planFor(dir, gitOutput(dir, "rev-parse", "HEAD"), ""))
+	})
+
+	t.Run("gitlink", func(t *testing.T) {
+		dir := newRepo(t)
+		head := gitOutput(dir, "rev-parse", "HEAD")
+		runGit(t, dir, "update-index", "--add", "--cacheinfo", "160000,"+head+",nested")
+		runGit(t, dir, "commit", "-m", "gitlink")
+		runGit(t, dir, "update-ref", "refs/remotes/origin/main", "HEAD")
+		requireSeedOnly(t, planFor(dir, gitOutput(dir, "rev-parse", "HEAD"), ""))
+	})
 }
 
 func TestCheckSyncPreflightFailsLargeCandidate(t *testing.T) {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -657,15 +657,14 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		if ownerQuiescent && readyPoolReturnNeedsHydrationStop(result) {
 			a.writeActionsHydrationStopBestEffort(context.WithoutCancel(ctx), target, borrowedPool.Entry.LeaseID)
 		}
-		if stopReadyPoolHeartbeat != nil {
-			stopReadyPoolHeartbeat()
-			stopReadyPoolHeartbeat = nil
-		}
 		returnCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
-		_, returnErr := coord.ReturnReadyPoolLease(returnCtx, borrowedPool.Entry.Key, borrowedPool.Entry.LeaseID, result, reason, borrowedPool.Entry.BorrowToken)
+		returnErr := returnReadyPoolAfterWorkspaceOwner(returnCtx, &lifecycleOwner, func() error {
+			_, err := coord.ReturnReadyPoolLease(returnCtx, borrowedPool.Entry.Key, borrowedPool.Entry.LeaseID, result, reason, borrowedPool.Entry.BorrowToken)
+			return err
+		})
 		cancel()
 		if returnErr != nil {
-			fmt.Fprintf(a.Stderr, "warning: ready-pool return failed for %s: %v\n", borrowedPool.Entry.LeaseID, returnErr)
+			fmt.Fprintf(a.Stderr, "warning: ready-pool owner release/return failed for %s: %v\n", borrowedPool.Entry.LeaseID, returnErr)
 			if failure == nil && scrubErr == nil {
 				err = returnErr
 			}
@@ -1025,7 +1024,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	} else if registrationCoord != nil && leaseID != "" {
 		startRunHeartbeat(nil)
 	}
-	if shouldAcquireWorkspaceOwner(acquired) {
+	if shouldAcquireWorkspaceOwner(acquired, sshBackend) {
 		target = bootstrapNetworkTarget(cfg, server, target)
 		if waitErr := waitForSSHReady(ctx, &target, a.Stderr, "workspace owner", 2*time.Minute); waitErr != nil {
 			return recordFailure(waitErr)
@@ -1964,6 +1963,17 @@ afterSync:
 		return recordFailure(ExitError{Code: code, Message: fmt.Sprintf("remote command exited %d", code)})
 	}
 	return nil
+}
+
+func returnReadyPoolAfterWorkspaceOwner(ctx context.Context, owner **workspaceOwner, returnLease func() error) error {
+	if owner != nil && *owner != nil {
+		current := *owner
+		*owner = nil
+		if err := current.Close(ctx); err != nil {
+			return fmt.Errorf("release workspace owner before pool return: %w", err)
+		}
+	}
+	return returnLease()
 }
 
 func applyRunEnvAllowFlags(cfg *Config, values []string) {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -565,6 +565,31 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	var runFailure error
 	var workdir string
 	var hydratedByActions bool
+	var lifecycleOwner *workspaceOwner
+	ownerParentCtx := ctx
+	defer func() {
+		if lifecycleOwner == nil {
+			return
+		}
+		if cleanup.Stopped {
+			if closeErr := lifecycleOwner.CloseAfterLeaseRelease(); closeErr != nil {
+				runFailure = recordRunFailure(&runFailure, closeErr)
+				err = errors.Join(err, closeErr)
+				fmt.Fprintf(a.Stderr, "warning: workspace owner stopped with released lease after renewal failure: %v\n", closeErr)
+			}
+			return
+		}
+		releaseCtx, cancel := context.WithTimeout(context.WithoutCancel(ownerParentCtx), 30*time.Second)
+		closeErr := lifecycleOwner.Close(releaseCtx)
+		cancel()
+		if closeErr != nil {
+			runFailure = recordRunFailure(&runFailure, closeErr)
+			err = errors.Join(err, closeErr)
+			fmt.Fprintf(a.Stderr, "warning: workspace owner release failed: %v\n", closeErr)
+			return
+		}
+		fmt.Fprintln(a.Stderr, "workspace owner released")
+	}()
 	defer func() {
 		if borrowedPool == nil {
 			return
@@ -578,6 +603,25 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		failure := runFailure
 		if failure == nil {
 			failure = err
+		}
+		ownerQuiescent := true
+		if lifecycleOwner != nil {
+			inspectCtx, cancel := context.WithTimeout(context.WithoutCancel(ownerParentCtx), 15*time.Second)
+			ownerErr := lifecycleOwner.ConfirmNoChild(inspectCtx)
+			cancel()
+			if ownerErr != nil {
+				ownerQuiescent = false
+				failure = ownerErr
+				runFailure = recordRunFailure(&runFailure, ownerErr)
+				if err == nil {
+					err = ownerErr
+				}
+				fmt.Fprintf(a.Stderr, "warning: ready-pool workspace owner is not quiescent: %v\n", ownerErr)
+			}
+		}
+		if !ownerQuiescent {
+			fmt.Fprintf(a.Stderr, "warning: ready-pool return deferred while a witnessed workspace child may still be alive\n")
+			return
 		}
 		var preparedCommit string
 		var scrubErr error
@@ -610,7 +654,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 			}
 			return
 		}
-		if readyPoolReturnNeedsHydrationStop(result) {
+		if ownerQuiescent && readyPoolReturnNeedsHydrationStop(result) {
 			a.writeActionsHydrationStopBestEffort(context.WithoutCancel(ctx), target, borrowedPool.Entry.LeaseID)
 		}
 		if stopReadyPoolHeartbeat != nil {
@@ -894,6 +938,18 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		if !shouldReleaseRunLease(acquired, *keep, keepFailedLease, *stopAfter, runFailure) {
 			return
 		}
+		if lifecycleOwner != nil {
+			inspectCtx, cancel := context.WithTimeout(context.WithoutCancel(ownerParentCtx), 15*time.Second)
+			ownerErr := lifecycleOwner.ConfirmNoChild(inspectCtx)
+			cancel()
+			if ownerErr != nil {
+				cleanup.Err = ownerErr
+				runFailure = recordRunFailure(&runFailure, ownerErr)
+				err = errors.Join(err, ownerErr)
+				fmt.Fprintf(a.Stderr, "lease cleanup skipped while workspace child remains possible: %v\n", ownerErr)
+				return
+			}
+		}
 		releaseApp := a
 		if *timingJSON {
 			releaseApp.Stderr = io.Discard
@@ -968,6 +1024,28 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		startRunHeartbeat(heartbeatIdleTimeout)
 	} else if registrationCoord != nil && leaseID != "" {
 		startRunHeartbeat(nil)
+	}
+	if shouldAcquireWorkspaceOwner(acquired) {
+		target = bootstrapNetworkTarget(cfg, server, target)
+		if waitErr := waitForSSHReady(ctx, &target, a.Stderr, "workspace owner", 2*time.Minute); waitErr != nil {
+			return recordFailure(waitErr)
+		}
+		a.refreshTailscaleMetadata(ctx, cfg, sshBackend, coord, useCoordinator, &server, target, leaseID)
+		_ = updateLeaseClaimEndpoint(leaseID, server, target)
+		if resolved, resolveErr := resolveNetworkTarget(ctx, cfg, server, target); resolveErr != nil {
+			return recordFailure(resolveErr)
+		} else {
+			target = resolved.Target
+			_ = updateLeaseClaimEndpoint(leaseID, server, target)
+			if resolved.FallbackReason != "" {
+				fmt.Fprintf(a.Stderr, "network fallback %s\n", resolved.FallbackReason)
+			}
+		}
+		lifecycleOwner, err = acquireWorkspaceOwner(ctx, target, leaseID, a.Stderr)
+		if err != nil {
+			return recordFailure(err)
+		}
+		ctx = contextWithWorkspaceOwner(lifecycleOwner.Context(), lifecycleOwner)
 	}
 
 	if cfg.Sync.BaseRef == "" {
@@ -1092,7 +1170,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		}
 		fields := actionsHydrateFields(leaseID, githubActionsLeaseLabel(leaseID), cfg.Actions.Job, 0, cfg.Actions.Fields)
 		recorder.Event("actions.hydrate.started", "hydrate", cfg.Actions.Workflow)
-		state, err := a.hydrateActionsLocally(ctx, cfg, repo, currentTarget, leaseID, cfg.Actions.Job, fields, 20*time.Minute, false, false)
+		state, err := a.hydrateActionsLocally(ctx, cfg, repo, currentTarget, leaseID, cfg.Actions.Job, fields, 20*time.Minute, false, false, lifecycleOwner)
 		if err != nil {
 			recorder.Event("actions.hydrate.failed", "hydrate", err.Error())
 			if *keepOnFailure {
@@ -1297,16 +1375,20 @@ retrySync:
 			return recordFailure(err)
 		}
 		timings.syncSteps.preflight = time.Since(stepStart)
+		coherence, credentialBlocked := syncGitCoherencePlan(cfg, repo)
+		if credentialBlocked {
+			warnCredentialBearingGitSeed(a.Stderr)
+		}
 		fingerprint := ""
 		if cfg.Sync.Fingerprint && !isWindowsNativeTarget(target) {
 			stepStart = time.Now()
-			fingerprint, err = syncFingerprintForManifest(repo, cfg, manifest, excludes)
+			fingerprint, err = syncFingerprintForManifest(repo, cfg, manifest, excludes, coherence)
 			timings.syncSteps.fingerprintLocal = time.Since(stepStart)
 			if err != nil {
 				fmt.Fprintf(a.Stderr, "warning: sync fingerprint failed: %v\n", err)
 			} else if !fullResyncRequested && fingerprint != "" {
 				stepStart = time.Now()
-				remoteFingerprint, err := runSSHOutput(ctx, target, remoteReadSyncFingerprint(workdir))
+				remoteFingerprint, err := runSSHOutput(ctx, target, remoteReadSyncFingerprint(workdir, coherence))
 				timings.syncSteps.fingerprintRemote = time.Since(stepStart)
 				if err == nil && remoteFingerprint == fingerprint {
 					timings.sync = time.Since(syncStart)
@@ -1337,7 +1419,7 @@ retrySync:
 		}
 		if isWindowsNativeTarget(target) {
 			stepStart = time.Now()
-			if err := syncWindowsNative(ctx, target, repo, cfg, workdir, manifest, a.Stdout, a.Stderr, rsyncOptions{Debug: *debugSync, Delete: cfg.Sync.Delete, Checksum: cfg.Sync.Checksum, FullResync: fullResyncRequested, Timeout: cfg.Sync.Timeout, HeartbeatInterval: 15 * time.Second}); err != nil {
+			if err := syncWindowsNative(ctx, target, repo, cfg, coherence, workdir, manifest, a.Stdout, a.Stderr, rsyncOptions{Debug: *debugSync, Delete: cfg.Sync.Delete, Checksum: cfg.Sync.Checksum, FullResync: fullResyncRequested, Timeout: cfg.Sync.Timeout, HeartbeatInterval: 15 * time.Second}); err != nil {
 				return recordFailure(err)
 			}
 			timings.syncSteps.rsync = time.Since(stepStart)
@@ -1346,13 +1428,9 @@ retrySync:
 			recorder.Event("sync.finished", "synced", fmt.Sprintf("duration=%s mode=archive", timings.sync.Round(time.Millisecond)))
 			goto afterSync
 		}
-		gitSeed, credentialBlocked := syncGitSeedDecision(cfg, repo)
-		if credentialBlocked {
-			warnCredentialBearingGitSeed(a.Stderr)
-		}
-		if gitSeed {
+		if coherence.seedEnabled() {
 			stepStart = time.Now()
-			if _, err := runIdempotentSSHCombinedOutput(ctx, target, remoteGitSeed(workdir, repo.RemoteURL, repo.Head), idempotentSSHRetryDelay); err != nil {
+			if _, err := runIdempotentSSHCombinedOutput(ctx, target, remoteGitSeed(workdir, coherence), idempotentSSHRetryDelay); err != nil {
 				fmt.Fprintf(a.Stderr, "warning: remote git seed failed: %v\n", err)
 			}
 			timings.syncSteps.gitSeed = time.Since(stepStart)
@@ -1421,6 +1499,7 @@ retrySync:
 			BaseSHA:            baseSHA,
 			Fingerprint:        fingerprint,
 			Token:              finalizeToken,
+			Coherence:          coherence,
 		})
 		if out, err := runIdempotentSSHCombinedOutput(ctx, target, finalizeCommand, idempotentSSHRetryDelay); err != nil {
 			if out != "" {
@@ -1437,6 +1516,11 @@ retrySync:
 		recorder.Event("sync.finished", "synced", "skipped by --no-sync")
 	}
 afterSync:
+	if !*syncOnly && !*noSync {
+		if _, err := runIdempotentSSHCombinedOutput(ctx, target, remoteInvalidateSyncFingerprintForTarget(target, workdir), idempotentSSHRetryDelay); err != nil {
+			return recordFailure(exit(7, "invalidate reusable sync fingerprint before execution: %v", err))
+		}
+	}
 	if !*noSync {
 		if err := autoHydrateActionsIfNeeded(target); err != nil {
 			return recordFailure(err)
@@ -1500,6 +1584,9 @@ afterSync:
 		}
 		if _, err := runIdempotentSSHCombinedOutput(ctx, target, mkdirCommand, idempotentSSHRetryDelay); err != nil {
 			return recordFailure(exit(7, "create remote workdir: %v", err))
+		}
+		if _, err := runIdempotentSSHCombinedOutput(ctx, target, remoteInvalidateSyncFingerprintForTarget(target, workdir), idempotentSSHRetryDelay); err != nil {
+			return recordFailure(exit(7, "invalidate reusable sync fingerprint before execution: %v", err))
 		}
 	}
 	if err := preflightRawJSRuntime(target); err != nil {
@@ -1671,6 +1758,9 @@ afterSync:
 	stderrPhaseWriter.Flush()
 	timings.command = time.Since(commandStart)
 	timings.commandPhases = phaseTracker.Finish(time.Now())
+	if err := waitWorkspaceOwnerNoChild(ctx, lifecycleOwner, 10*time.Second); err != nil {
+		return recordFailure(exit(7, "remote command child ownership remains active; refusing collection and cleanup: %v", err))
+	}
 	var results *TestResultSummary
 	if cfg.Results.Auto || len(cfg.Results.JUnit) > 0 {
 		results, err = collectRemoteJUnitResults(ctx, target, workdir, cfg.Results, resultsMarker)

--- a/internal/cli/run_recorder.go
+++ b/internal/cli/run_recorder.go
@@ -127,7 +127,7 @@ func (r *runRecorder) CaptureTelemetryStart(ctx context.Context, target SSHTarge
 	if r == nil || r.telemetryStart != nil {
 		return
 	}
-	r.telemetryStart = collectLeaseTelemetryBestEffort(ctx, leaseTelemetryCollectorForTarget(target))
+	r.telemetryStart = collectLeaseTelemetryBestEffort(contextWithoutWorkspaceOwner(ctx), leaseTelemetryCollectorForTarget(target))
 	r.recordTelemetrySample(r.telemetryStart)
 	r.appendTelemetryBestEffort(r.telemetryStart)
 }
@@ -141,7 +141,7 @@ func (r *runRecorder) StartTelemetrySampler(ctx context.Context, target SSHTarge
 		r.telemetryMu.Unlock()
 		return
 	}
-	sampleCtx, cancel := context.WithCancel(ctx)
+	sampleCtx, cancel := context.WithCancel(contextWithoutWorkspaceOwner(ctx))
 	done := make(chan struct{})
 	r.telemetryCancel = cancel
 	r.telemetryDone = done
@@ -187,7 +187,7 @@ func (r *runRecorder) Finish(ctx context.Context, target SSHTarget, exitCode int
 	r.waitForOutputEvents(runEventOutputPostWait)
 	r.finished = true
 	r.stopTelemetrySampler()
-	telemetryEnd := collectLeaseTelemetryBestEffort(ctx, leaseTelemetryCollectorForTarget(target))
+	telemetryEnd := collectLeaseTelemetryBestEffort(contextWithoutWorkspaceOwner(ctx), leaseTelemetryCollectorForTarget(target))
 	r.recordTelemetrySample(telemetryEnd)
 	ctx, cancel := context.WithTimeout(context.Background(), runRecorderFinishTimeout)
 	defer cancel()

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -225,6 +225,12 @@ func installRecordingSSH(t *testing.T, dir string) string {
 cmd=""
 for arg do cmd="$arg"; done
 printf '%s\n---\n' "$cmd" >> "$CRABBOX_FAKE_SSH_LOG"
+case "$cmd" in
+  *"protocol_action='acquire'"*) printf ACQUIRED; exit 0 ;;
+  *"protocol_action='renew'"*) printf RENEWED; exit 0 ;;
+  *"protocol_action='inspect'"*) printf OWNED; exit 0 ;;
+  *"protocol_action='release'"*) printf RELEASED; exit 0 ;;
+esac
 if [ -n "${CRABBOX_FAKE_SSH_STDIN_LOG:-}" ]; then
   /bin/cat >> "$CRABBOX_FAKE_SSH_STDIN_LOG" || true
 else
@@ -1975,7 +1981,7 @@ for arg do
 done
 printf '%s\n---\n' "$cmd" >> "$CRABBOX_FAKE_SSH_LOG"
 case "$cmd" in
-  *"nohup bash -c"*) printf '123\n'; exit 0 ;;
+  *"nohup sh -c"*) printf '123\n'; exit 0 ;;
   *"kill -0 '123'"*) printf 'exit=unknown\nno marker written\n'; exit 0 ;;
 esac
 exit 0

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -477,6 +477,8 @@ type runEnvProfileTestBackend struct {
 	spec ProviderSpec
 }
 
+func (b runEnvProfileTestBackend) AcquireIsExclusiveOneShot() bool { return true }
+
 var runEnvProfileTestReleaseErr error
 var runEnvProfileTestReleaseHook func() error
 var runEnvProfileTestConnectionCleanupSafe = true
@@ -1137,7 +1139,7 @@ func TestRunCommandInjectsReservedMetadataIntoStaticSSH(t *testing.T) {
 	logPath := installRecordingSSH(t, dir)
 	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, "missing.yaml"))
 	var stdout, stderr bytes.Buffer
-	err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
+	args := []string{
 		"--provider", "ssh",
 		"--static-host", "127.0.0.1",
 		"--static-user", "runner",
@@ -1145,9 +1147,11 @@ func TestRunCommandInjectsReservedMetadataIntoStaticSSH(t *testing.T) {
 		"--no-sync",
 		"--",
 		"env",
-	})
-	if err != nil {
-		t.Fatalf("static SSH run error=%v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	for iteration := 0; iteration < 2; iteration++ {
+		if err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), args); err != nil {
+			t.Fatalf("static SSH run %d error=%v\nstdout=%s\nstderr=%s", iteration+1, err, stdout.String(), stderr.String())
+		}
 	}
 	data, err := os.ReadFile(logPath)
 	if err != nil {
@@ -1155,13 +1159,16 @@ func TestRunCommandInjectsReservedMetadataIntoStaticSSH(t *testing.T) {
 	}
 	logText := string(data)
 	for _, pattern := range []string{
-		`CRABBOX_LEASE_ID='static_[^']+'`,
-		`CRABBOX_RUN_ID='run_[a-f0-9]{12}'`,
-		`CRABBOX_SLUG=''`,
+		`CRABBOX_LEASE_ID=.*static_127-0-0-1`,
+		`CRABBOX_RUN_ID=.*run_[a-f0-9]{12}`,
+		`CRABBOX_SLUG=`,
 	} {
 		if !regexp.MustCompile(pattern).MatchString(logText) {
 			t.Fatalf("static SSH metadata %q missing:\n%s", pattern, logText)
 		}
+	}
+	if got := strings.Count(logText, "protocol_action='acquire'"); got != 2 {
+		t.Fatalf("static no-id owner acquisitions=%d want 2:\n%s", got, logText)
 	}
 }
 

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -441,6 +441,7 @@ func runSSHQuietWithOptions(ctx context.Context, target SSHTarget, remote, conne
 }
 
 func runSSHQuietWithOptionsResolvePort(ctx context.Context, target *SSHTarget, remote, connectTimeout, connectionAttempts string) error {
+	remote = wrapWorkspaceOwnerRemote(ctx, remote, false)
 	remote = wrapRemoteForTarget(*target, remote)
 	var lastErr error
 	for _, port := range sshPortCandidates(target.Port, target.FallbackPorts) {
@@ -462,6 +463,7 @@ func runSSHQuietWithOptionsResolvePort(ctx context.Context, target *SSHTarget, r
 }
 
 func runSSHQuietWithRemoteWaitTimeout(ctx context.Context, target SSHTarget, remote string, waitTimeout time.Duration, connectTimeout, connectionAttempts string) error {
+	remote = wrapWorkspaceOwnerRemote(ctx, remote, false)
 	remote = wrapRemoteForTargetWithWaitTimeout(target, remote, waitTimeout)
 	var lastErr error
 	for _, port := range sshPortCandidates(target.Port, target.FallbackPorts) {
@@ -482,6 +484,7 @@ func runSSHQuietWithRemoteWaitTimeout(ctx context.Context, target SSHTarget, rem
 }
 
 func runSSHOutput(ctx context.Context, target SSHTarget, remote string) (string, error) {
+	remote = wrapWorkspaceOwnerRemote(ctx, remote, false)
 	remote = wrapRemoteForTarget(target, remote)
 	var lastOut []byte
 	var lastErr error
@@ -504,6 +507,7 @@ func runSSHOutput(ctx context.Context, target SSHTarget, remote string) (string,
 }
 
 func runSSHOutputWithRemoteWaitTimeout(ctx context.Context, target SSHTarget, remote string, waitTimeout time.Duration, connectTimeout, connectionAttempts string) (string, error) {
+	remote = wrapWorkspaceOwnerRemote(ctx, remote, false)
 	remote = wrapRemoteForTargetWithWaitTimeout(target, remote, waitTimeout)
 	var lastOut []byte
 	var lastErr error
@@ -527,6 +531,7 @@ func runSSHOutputWithRemoteWaitTimeout(ctx context.Context, target SSHTarget, re
 }
 
 func runSSHCombinedOutput(ctx context.Context, target SSHTarget, remote string) (string, error) {
+	remote = wrapWorkspaceOwnerRemote(ctx, remote, false)
 	remote = wrapRemoteForTarget(target, remote)
 	var lastOut []byte
 	var lastErr error
@@ -571,6 +576,7 @@ func runIdempotentSSHCombinedOutput(ctx context.Context, target SSHTarget, remot
 }
 
 func runWSL2ControlScriptCombinedOutput(ctx context.Context, target SSHTarget, remote string, waitTimeout time.Duration, connectTimeout, connectionAttempts string) (string, error) {
+	remote = wrapWorkspaceOwnerRemote(ctx, remote, false)
 	command := wsl2StdinScriptCommandWithWaitTimeout(waitTimeout)
 	var lastOut []byte
 	var lastErr error
@@ -599,6 +605,7 @@ func runSSHInputQuiet(ctx context.Context, target SSHTarget, remote, input strin
 }
 
 func runSSHInput(ctx context.Context, target SSHTarget, remote string, input io.Reader, stdout, stderr io.Writer) error {
+	remote = wrapWorkspaceOwnerRemote(ctx, remote, true)
 	remote = wrapRemoteForTarget(target, remote)
 	if input == nil {
 		input = strings.NewReader("")
@@ -626,6 +633,7 @@ func runSSHInput(ctx context.Context, target SSHTarget, remote string, input io.
 }
 
 func runSSHInputStream(ctx context.Context, target SSHTarget, remote string, input io.ReadSeeker, stdout, stderr io.Writer) error {
+	remote = wrapWorkspaceOwnerRemote(ctx, remote, true)
 	remote = wrapRemoteForTarget(target, remote)
 	if input == nil {
 		input = strings.NewReader("")
@@ -657,6 +665,7 @@ func runSSHStream(ctx context.Context, target SSHTarget, remote string, stdout, 
 }
 
 func runSSHStreamResult(ctx context.Context, target SSHTarget, remote string, stdout, stderr io.Writer) (int, error) {
+	remote = wrapWorkspaceOwnerRemote(ctx, remote, false)
 	remote = wrapRemoteForTarget(target, remote)
 	lastCode := 7
 	var lastErr error
@@ -868,6 +877,21 @@ func rsync(ctx context.Context, target SSHTarget, src, dst string, excludes []st
 		ctx, cancel = context.WithTimeout(ctx, opts.Timeout)
 		defer cancel()
 	}
+	owner := workspaceOwnerFromContext(ctx)
+	guardStarted := false
+	if owner != nil && !isWindowsNativeTarget(target) {
+		rawCtx := contextWithoutWorkspaceOwner(ctx)
+		if err := runSSHQuiet(rawCtx, target, owner.rsyncPrepareCommand()); err != nil {
+			return exit(7, "prepare rsync workspace witness: %v", err)
+		}
+		if _, err := runSSHOutput(rawCtx, target, owner.WrapBackgroundCommand(owner.rsyncGuardPayload(dst))); err != nil {
+			return exit(7, "start rsync workspace witness: %v", err)
+		}
+		if err := owner.WaitForChild(rawCtx, 10*time.Second); err != nil {
+			return err
+		}
+		guardStarted = true
+	}
 	args := []string{
 		"-az",
 		"-e", strings.Join(shellWords(append([]string{"ssh"}, sshBaseArgs(target)...)), " "),
@@ -912,6 +936,22 @@ func rsync(ctx context.Context, target SSHTarget, src, dst string, excludes []st
 	stopHeartbeat := startSyncHeartbeat(stderr, start, opts.HeartbeatInterval)
 	err := cmd.Run()
 	stopHeartbeat()
+	if guardStarted {
+		guardCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 20*time.Second)
+		rawGuardCtx := contextWithoutWorkspaceOwner(guardCtx)
+		guardErr := runSSHQuiet(rawGuardCtx, target, owner.rsyncStopCommand())
+		if guardErr == nil {
+			guardErr = waitWorkspaceOwnerNoChild(rawGuardCtx, owner, 15*time.Second)
+		}
+		cleanupErr := runSSHQuiet(rawGuardCtx, target, owner.rsyncPrepareCommand())
+		cancel()
+		if guardErr == nil {
+			guardErr = cleanupErr
+		}
+		if guardErr != nil && err == nil {
+			err = exit(7, "finish rsync workspace witness: %v", guardErr)
+		}
+	}
 	if ctx.Err() == context.DeadlineExceeded {
 		return exit(6, "rsync timed out after %s; next_action=retry with --full-resync, then use a fresh lease if sync still stalls", opts.Timeout)
 	}
@@ -1474,14 +1514,50 @@ func remoteResetWorkdir(workdir string) string {
 	return "bash -lc " + shellQuote(script)
 }
 
+func remoteGitWorkspaceFunctions() string {
+	return `exact_git_root() {
+  git_root="$(git rev-parse --show-toplevel 2>/dev/null)" || return 1
+  git_root="$(cd -P -- "$git_root" 2>/dev/null && pwd -P)" || return 1
+  [ "$git_root" = "$(pwd -P)" ]
+}
+usable_git_workspace() (
+  exact_git_root || exit 1
+  git rev-parse --verify HEAD^{commit} >/dev/null 2>&1 || exit 1
+  workspace_index="$(git rev-parse --git-path index 2>/dev/null)" || exit 1
+  case "$workspace_index" in /*) ;; *) workspace_index="$PWD/$workspace_index" ;; esac
+  [ -f "$workspace_index" ] || exit 1
+  workspace_tree="$(git write-tree 2>/dev/null)" || exit 1
+  [ -n "$workspace_tree" ]
+)
+normalize_git_remote() {
+  case "$1" in
+    git@github.com:*) remote_path="${1#git@github.com:}"; remote_path="${remote_path%.git}"; printf 'https://github.com/%s.git' "$remote_path" ;;
+    *) printf %s "$1" ;;
+  esac
+}
+origin_matches() {
+  actual_origin="$(git remote get-url origin 2>/dev/null)" || return 1
+  [ "$(normalize_git_remote "$actual_origin")" = "$expected_origin" ]
+}
+repair_origin() {
+  if git remote get-url origin >/dev/null 2>&1; then
+    git remote set-url origin "$expected_origin" >/dev/null 2>&1
+  else
+    git remote add origin "$expected_origin" >/dev/null 2>&1
+  fi && origin_matches
+}
+`
+}
+
 func remoteGitHydrateStatus(workdir, baseRef, expectedSHA string) string {
 	if baseRef == "" || expectedSHA == "" {
 		return "printf ''"
 	}
-	script := `cd ` + shellQuote(workdir) + ` && ` + remoteSyncMetaDirScript() + `
-if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+	script := `cd ` + shellQuote(workdir) + ` && ` + remoteGitWorkspaceFunctions() + `
+if ! exact_git_root; then
   exit 0
 fi
+` + remoteSyncMetaDirScript() + `
 marker="$meta_dir/git-hydrate-base"
 remote_sha="$(git rev-parse --verify ` + shellQuote("refs/remotes/origin/"+baseRef+"^{commit}") + ` 2>/dev/null || git rev-parse --verify ` + shellQuote("origin/"+baseRef+"^{commit}") + ` 2>/dev/null || true)"
 if [ "$remote_sha" = ` + shellQuote(expectedSHA) + ` ]; then
@@ -1498,21 +1574,42 @@ fi`
 	return "bash -lc " + shellQuote(script)
 }
 
-func remoteGitSeed(workdir, remoteURL, head string) string {
-	remoteURL = normalizeGitRemoteURL(remoteURL)
-	if remoteURL == "" || head == "" {
+func remoteGitSeed(workdir string, plan gitCoherencePlan) string {
+	if !plan.seedEnabled() {
 		return "true"
 	}
 	parent := filepath.ToSlash(filepath.Dir(workdir))
-	return "if [ ! -d " + shellQuote(workdir+"/.git") + " ]; then " +
-		"mkdir -p " + shellQuote(parent) + "; " +
-		"tmp=$(mktemp -d " + shellQuote(parent+"/.seed.XXXXXX") + "); " +
-		"if git clone --quiet --filter=blob:none --no-checkout " + shellQuote(remoteURL) + " \"$tmp\" >/dev/null 2>&1; then " +
-		"if (cd \"$tmp\" && (git fetch --quiet --depth=1 origin " + shellQuote(head) + " || true) && (git checkout --quiet " + shellQuote(head) + " || git checkout --quiet FETCH_HEAD)); then " +
-		"rm -rf " + shellQuote(workdir) + " && mv \"$tmp\" " + shellQuote(workdir) + "; " +
-		"else rm -rf \"$tmp\"; fi; " +
-		"else rm -rf \"$tmp\"; fi; " +
-		"fi"
+	script := `set -e
+workdir=` + shellQuote(workdir) + `
+expected_origin=` + shellQuote(plan.RemoteURL) + `
+expected_tree=` + shellQuote(plan.Tree) + `
+` + remoteGitWorkspaceFunctions() + `
+if [ -d "$workdir" ]; then
+  cd "$workdir"
+  if usable_git_workspace; then
+    repair_origin
+    exit 0
+  fi
+fi
+mkdir -p ` + shellQuote(parent) + `
+tmp="$(mktemp -d ` + shellQuote(parent+"/.seed.XXXXXX") + `)"
+cleanup_seed() { rm -rf -- "$tmp"; }
+trap cleanup_seed EXIT
+git clone --quiet --filter=blob:none --no-checkout --single-branch --branch ` + shellQuote(plan.Branch) + ` "$expected_origin" "$tmp" >/dev/null 2>&1
+git -C "$tmp" checkout --quiet --detach ` + shellQuote(plan.Target) + `
+[ "$(git -C "$tmp" rev-parse --verify HEAD^{commit})" = ` + shellQuote(plan.Target) + ` ]
+cd "$tmp"
+usable_git_workspace
+if [ -n "$expected_tree" ]; then
+  [ "$(git write-tree)" = "$expected_tree" ]
+fi
+repair_origin
+cd /
+rm -rf -- "$workdir"
+mv -- "$tmp" "$workdir"
+trap - EXIT
+`
+	return "bash -lc " + shellQuote(script)
 }
 
 func normalizeGitRemoteURL(remoteURL string) string {
@@ -1525,8 +1622,35 @@ func normalizeGitRemoteURL(remoteURL string) string {
 	return remoteURL
 }
 
-func remoteReadSyncFingerprint(workdir string) string {
-	script := "cd " + shellQuote(workdir) + " && " + remoteSyncMetaDirScript() + "cat \"$meta_dir/sync-fingerprint\" 2>/dev/null || true"
+func remoteReadSyncFingerprint(workdir string, plan gitCoherencePlan) string {
+	if !plan.enabled() {
+		return "printf ''"
+	}
+	script := "cd " + shellQuote(workdir) + " && " + `expected_origin=` + shellQuote(plan.RemoteURL) + `
+` + remoteGitWorkspaceFunctions() + `
+if ! exact_git_root || ! origin_matches; then
+  exit 0
+fi
+` + remoteSyncMetaDirScript() + `
+committed="$meta_dir/sync-finalize-token"
+complete="$meta_dir/sync-finalize-complete-token"
+if [ -f "$committed" ] && [ -f "$complete" ] &&
+   [ "$(cat "$committed")" = "$(cat "$complete")" ] &&
+   [ "$(git rev-parse --verify HEAD^{commit} 2>/dev/null || true)" = ` + shellQuote(plan.Target) + ` ] &&
+   [ "$(git write-tree 2>/dev/null || true)" = ` + shellQuote(plan.Tree) + ` ]; then
+  cat "$meta_dir/sync-fingerprint" 2>/dev/null || true
+fi`
+	return "bash -lc " + shellQuote(script)
+}
+
+func remoteInvalidateSyncFingerprintForTarget(target SSHTarget, workdir string) string {
+	if isWindowsNativeTarget(target) {
+		return powershellCommand("exit 0")
+	}
+	script := `set -e
+cd ` + shellQuote(workdir) + `
+` + remoteSyncMetaDirScript() + `
+rm -f "$meta_dir/sync-fingerprint"`
 	return "bash -lc " + shellQuote(script)
 }
 
@@ -1537,6 +1661,7 @@ type remoteSyncFinalizeOptions struct {
 	BaseSHA            string
 	Fingerprint        string
 	Token              string
+	Coherence          gitCoherencePlan
 }
 
 func remoteSyncPendingManifestName(token string) string {
@@ -1637,14 +1762,15 @@ with open(sys.argv[2], "wb") as handle:
 }
 
 func remoteSyncAbandonedMetadataCleanup() string {
-	return `find "$meta_dir" -type f \( -name 'sync-manifest.new' -o -name 'sync-deleted.new' -o -name 'sync-manifest.*.new' -o -name 'sync-deleted.*.new' -o -name 'sync-manifest.*.sorted' -o -name 'sync-finalize-token.tmp.*' -o -name 'sync-finalize-complete-token.tmp.*' \) -mtime +7 -exec rm -f -- {} \; 2>/dev/null || true`
+	return `find "$meta_dir" -type f \( -name 'sync-manifest.new' -o -name 'sync-deleted.new' -o -name 'sync-manifest.*.new' -o -name 'sync-deleted.*.new' -o -name 'sync-manifest.*.sorted' -o -name 'sync-finalize-token.tmp.*' -o -name 'sync-finalize-complete-token.tmp.*' -o -name 'sync-git-status.*' \) -mtime +7 -exec rm -f -- {} \; 2>/dev/null || true`
 }
 
 func remoteSeedSyncManifestFromGit(workdir string) string {
 	script := "set -e\ncd " + shellQuote(workdir) + `
+` + remoteGitWorkspaceFunctions() + `
 ` + remoteSyncMetaDirScript() + `
 old="$meta_dir/sync-manifest"
-if [ ! -f "$old" ] && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+if [ ! -f "$old" ] && exact_git_root; then
   mkdir -p "$meta_dir"
   git ls-files -z > "$old"
 fi
@@ -1769,6 +1895,7 @@ func remoteFinalizeSync(workdir string, opts remoteSyncFinalizeOptions) string {
 	deletedName := remoteSyncPendingDeletedName(opts.Token)
 	script := `set -e
 cd ` + shellQuote(workdir) + `
+` + remoteGitWorkspaceFunctions() + `
 ` + remoteSyncMetaDirScript() + `
 mkdir -p "$meta_dir"
 new="$meta_dir/` + manifestName + `"
@@ -1777,17 +1904,19 @@ manifest="$meta_dir/sync-manifest"
 committed_token="$meta_dir/sync-finalize-token"
 complete_token="$meta_dir/sync-finalize-complete-token"
 expected_token=` + shellQuote(opts.Token) + `
+publish_fingerprint=` + shellQuote(opts.Fingerprint) + `
 case "$expected_token" in
   ''|*[!0-9a-f]*) echo "remote sync finalize failed: invalid sync token" >&2; exit 67 ;;
 esac
 ` + remoteSyncFinalizeLockScript() + `
+git_status="$meta_dir/sync-git-status.$expected_token.$$"
+rm -f "$git_status"
 if [ -f "$manifest" ] &&
-   [ -f "$committed_token" ] &&
-   [ "$(cat "$committed_token")" = "$expected_token" ] &&
-   [ -f "$complete_token" ] &&
-   [ "$(cat "$complete_token")" = "$expected_token" ]; then
+   [ -f "$committed_token" ] && [ "$(cat "$committed_token")" = "$expected_token" ] &&
+   [ -f "$complete_token" ] && [ "$(cat "$complete_token")" = "$expected_token" ]; then
   exit 0
 fi
+rm -f "$complete_token"
 if [ -f "$new" ]; then
   committed_tmp="$committed_token.tmp.$$"
   printf %s "$expected_token" > "$committed_tmp"
@@ -1798,35 +1927,102 @@ elif [ ! -f "$manifest" ] || [ ! -f "$committed_token" ] || [ "$(cat "$committed
   echo "remote sync finalize failed: no committed manifest for this sync" >&2
   exit 67
 fi
-if test -d .git && git status --short >/tmp/crabbox-git-status 2>/dev/null; then
-  deletions=$(awk '/^ D|^D / { n++ } END { print n+0 }' /tmp/crabbox-git-status)
+`
+	if opts.Coherence.enabled() {
+		script += remoteGitCoherenceFinalizeScript(opts.Coherence, allowValue)
+	} else {
+		script += `publish_fingerprint=
+if exact_git_root && git status --short >"$git_status" 2>/dev/null; then
+  deletions=$(awk '/^ D|^D / { n++ } END { print n+0 }' "$git_status")
   if [ ` + shellQuote(allowValue) + ` != '1' ] && [ "$deletions" -ge 200 ]; then
     echo "remote sync sanity failed: $deletions tracked deletions" >&2
-    awk '/^ D|^D / { print "  " substr($0,4) }' /tmp/crabbox-git-status | head -20 >&2
+    awk '/^ D|^D / { print "  " substr($0,4) }' "$git_status" | head -20 >&2
     exit 66
   fi
 fi
 `
+	}
 	if opts.HydrateGit && opts.BaseRef != "" {
 		refspec := "+refs/heads/" + opts.BaseRef + ":refs/remotes/origin/" + opts.BaseRef
-		script += `if git rev-parse --is-inside-work-tree >/dev/null 2>&1 && git remote get-url origin >/dev/null 2>&1; then
+		script += `if exact_git_root && git remote get-url origin >/dev/null 2>&1; then
   git fetch --quiet --unshallow origin ` + shellQuote(refspec) + ` || git fetch --quiet --depth=1000 origin ` + shellQuote(refspec) + ` || git fetch --quiet origin ` + shellQuote(refspec) + ` || git fetch --quiet origin ` + shellQuote(opts.BaseRef) + ` || true
 fi
 `
 	}
 	if opts.BaseRef != "" && opts.BaseSHA != "" {
-		script += `printf %s ` + shellQuote(opts.BaseRef+" "+opts.BaseSHA+"\n") + ` > "$meta_dir/git-hydrate-base" || true
+		script += `base_tmp="$meta_dir/git-hydrate-base.tmp.$$"
+printf %s ` + shellQuote(opts.BaseRef+" "+opts.BaseSHA+"\n") + ` > "$base_tmp"
+mv "$base_tmp" "$meta_dir/git-hydrate-base"
 `
 	}
-	if opts.Fingerprint != "" {
-		script += `printf %s ` + shellQuote(opts.Fingerprint) + ` > "$meta_dir/sync-fingerprint" || true
-`
-	}
-	script += `complete_tmp="$complete_token.tmp.$$"
+	script += `if [ -n "$publish_fingerprint" ]; then
+  fingerprint_tmp="$meta_dir/sync-fingerprint.tmp.$$"
+  printf %s "$publish_fingerprint" > "$fingerprint_tmp"
+  mv "$fingerprint_tmp" "$meta_dir/sync-fingerprint"
+else
+  rm -f "$meta_dir/sync-fingerprint"
+fi
+complete_tmp="$complete_token.tmp.$$"
 printf %s "$expected_token" > "$complete_tmp"
 mv "$complete_tmp" "$complete_token"
+coherence_committed=1
 `
 	return "bash -lc " + shellQuote(script)
+}
+
+func remoteGitCoherenceFinalizeScript(plan gitCoherencePlan, allowMassDeletions string) string {
+	return `
+coherence_committed=; coherence_mutated=; head_changed=; index_changed=
+tmp_ref="refs/crabbox/sync-$expected_token"; advertised_branch=` + shellQuote(plan.Branch) + `; expected_origin=` + shellQuote(plan.RemoteURL) + `
+if ! exact_git_root; then
+	publish_fingerprint=
+elif ! repair_origin; then
+	echo "remote sync finalize failed: Git origin repair failed" >&2; cleanup_finalize_lock; exit 67
+elif ! git fetch --quiet --no-tags "$expected_origin" "+refs/heads/$advertised_branch:$tmp_ref"; then
+	git update-ref -d "$tmp_ref" >/dev/null 2>&1 || true; echo "remote sync finalize failed: Git coherence fetch failed" >&2; cleanup_finalize_lock; exit 67
+elif ! git merge-base --is-ancestor ` + shellQuote(plan.Target) + ` "$tmp_ref" >/dev/null 2>&1; then
+	git update-ref -d "$tmp_ref" >/dev/null 2>&1 || true; echo "remote sync finalize failed: requested commit is not on advertised branch" >&2; cleanup_finalize_lock; exit 67
+elif [ "$(git rev-parse --verify ` + shellQuote(plan.Target+"^{tree}") + ` 2>/dev/null || true)" != ` + shellQuote(plan.Tree) + ` ]; then
+	git update-ref -d "$tmp_ref" >/dev/null 2>&1 || true; echo "remote sync finalize failed: requested Git tree verification failed" >&2; cleanup_finalize_lock; exit 67
+else
+  coherence_cleanup() {
+    status=$?
+    if [ -z "$coherence_committed" ] && [ -n "$coherence_mutated" ]; then
+      if [ -n "$head_changed" ]; then
+        if git update-ref --no-deref HEAD "$old_head" ` + shellQuote(plan.Target) + `; then
+          if [ -n "$old_sym" ] && ! git symbolic-ref -q HEAD >/dev/null 2>&1 &&
+             [ "$(git rev-parse --verify HEAD^{commit} 2>/dev/null || true)" = "$old_head" ] &&
+             [ "$(git rev-parse --verify "$old_sym^{commit}" 2>/dev/null || true)" = "$old_head" ]; then git symbolic-ref HEAD "$old_sym" || status=67; fi
+        else status=67; fi
+      fi
+      if [ -n "$index_changed" ] && [ "$(cat "$index_lock" 2>/dev/null || true)" = "$index_marker" ] && cmp -s "$index_path" "$index_verify"; then
+        cp -p "$index_backup" "$index_restore" && mv "$index_restore" "$index_path" || status=67
+      elif [ -n "$index_changed" ]; then status=67; fi
+    fi
+    git update-ref -d "$tmp_ref" "$fetched_head" >/dev/null 2>&1 || true; rm -f "${index_backup:-}" "${index_candidate:-}" "${index_verify:-}" "${index_restore:-}"
+    if [ -n "${index_lock:-}" ] && [ "$(cat "$index_lock" 2>/dev/null || true)" = "${index_marker:-}" ]; then rm -f "$index_lock"; fi
+    cleanup_finalize_lock; exit "$status"
+  }
+  trap coherence_cleanup EXIT
+  fetched_head="$(git rev-parse --verify "$tmp_ref^{commit}")"; old_head="$(git rev-parse --verify HEAD^{commit})"
+  old_sym="$(git symbolic-ref -q HEAD 2>/dev/null || true)"
+  index_path="$(git rev-parse --git-path index)"
+  case "$index_path" in /*) ;; *) index_path="$PWD/$index_path" ;; esac
+  index_lock="$index_path.lock"; index_marker="$expected_token.$$"
+  index_backup="$index_path.crabbox.$$.backup"; index_candidate="$index_path.crabbox.$$.new"; index_verify="$index_path.crabbox.$$.verify"; index_restore="$index_path.crabbox.$$.restore"
+  cp -p "$index_path" "$index_backup"; git read-tree --reset --index-output="$index_candidate" ` + shellQuote(plan.Target) + `
+  [ "$(GIT_INDEX_FILE="$index_candidate" git write-tree)" = ` + shellQuote(plan.Tree) + ` ]
+  GIT_INDEX_FILE="$index_candidate" git diff-files --name-status >"$git_status" 2>/dev/null ||
+    { echo "remote sync sanity failed: candidate Git index inspection failed" >&2; exit 67; }
+  deletions=$(awk '$1 == "D" { n++ } END { print n+0 }' "$git_status"); [ ` + shellQuote(allowMassDeletions) + ` = '1' ] || [ "$deletions" -lt 200 ]
+  (set -C; printf %s "$index_marker" > "$index_lock") || { echo "remote sync finalize failed: Git index is busy" >&2; exit 67; }
+  cmp -s "$index_path" "$index_backup" || { echo "remote sync finalize failed: Git index changed concurrently" >&2; exit 67; }
+  cp -p "$index_candidate" "$index_verify"; mv "$index_candidate" "$index_path"; index_changed=1; coherence_mutated=1
+  cmp -s "$index_path" "$index_verify" && [ "$(GIT_INDEX_FILE="$index_verify" git write-tree)" = ` + shellQuote(plan.Tree) + ` ] || { echo "remote sync finalize failed: installed Git index verification failed" >&2; exit 67; }
+  git update-ref --no-deref HEAD ` + shellQuote(plan.Target) + ` "$old_head"; head_changed=1
+  [ "$(git rev-parse --verify HEAD^{commit})" = ` + shellQuote(plan.Target) + ` ]
+fi
+`
 }
 
 func remoteSyncFinalizeLockScript() string {
@@ -1874,6 +2070,9 @@ while ! ln -s "$$" "$lock_path" 2>/dev/null; do
   fi
 done
 cleanup_finalize_lock() {
+  if [ -n "${git_status:-}" ]; then
+    rm -f -- "$git_status"
+  fi
   if [ "$(readlink "$lock_path" 2>/dev/null || true)" = "$$" ]; then
     rm -f "$lock_path"
   fi
@@ -1886,7 +2085,11 @@ trap 'exit 143' TERM
 }
 
 func remoteSyncMetaDirScript() string {
-	return "meta_dir=$(if [ -d .git ]; then printf %s .git/crabbox; else printf %s .crabbox; fi); "
+	return `meta_dir=$(git_root=; if git_root="$(git rev-parse --show-toplevel 2>/dev/null)" &&
+  git_root="$(cd -P -- "$git_root" 2>/dev/null && pwd -P)" &&
+  [ "$git_root" = "$(pwd -P)" ]; then git rev-parse --git-path crabbox; else printf %s .crabbox; fi)
+case "$meta_dir" in /*) ;; *) meta_dir="$PWD/$meta_dir" ;; esac
+`
 }
 
 func remoteSyncSanity(workdir string, allowMassDeletions bool) string {
@@ -1895,11 +2098,11 @@ func remoteSyncSanity(workdir string, allowMassDeletions bool) string {
 		allowValue = "1"
 	}
 	return "cd " + shellQuote(workdir) + " && " +
-		"if test -d .git && git status --short >/tmp/crabbox-git-status 2>/dev/null; then " +
-		"deletions=$(awk '/^ D|^D / { n++ } END { print n+0 }' /tmp/crabbox-git-status); " +
+		"if test -d .git && git_status_output=$(git status --short 2>/dev/null); then " +
+		"deletions=$(printf '%s\\n' \"$git_status_output\" | awk '/^ D|^D / { n++ } END { print n+0 }'); " +
 		"if [ " + shellQuote(allowValue) + " != '1' ] && [ \"$deletions\" -ge 200 ]; then " +
 		"echo \"remote sync sanity failed: $deletions tracked deletions\" >&2; " +
-		"awk '/^ D|^D / { print \"  \" substr($0,4) }' /tmp/crabbox-git-status | head -20 >&2; " +
+		"printf '%s\\n' \"$git_status_output\" | awk '/^ D|^D / { print \"  \" substr($0,4) }' | head -20 >&2; " +
 		"exit 66; " +
 		"fi; " +
 		"fi"

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -474,14 +474,15 @@ exit 0
 	cfg.Sync.Delete = false
 	target := SSHTarget{User: "crabbox", Host: "203.0.113.10", Port: "22", TargetOS: targetWindows, WindowsMode: windowsModeNormal}
 	repo := Repo{Root: repoRoot, RemoteURL: "https://example.test/repo.git", Head: head}
-	if err := syncWindowsNative(context.Background(), target, repo, cfg, `C:\crabbox\cbx\repo`, manifest, io.Discard, io.Discard, rsyncOptions{FullResync: true}); err != nil {
+	coherence, _ := syncGitCoherencePlan(cfg, repo)
+	if err := syncWindowsNative(context.Background(), target, repo, cfg, coherence, `C:\crabbox\cbx\repo`, manifest, io.Discard, io.Discard, rsyncOptions{FullResync: true}); err != nil {
 		t.Fatal(err)
 	}
 	logData, err := os.ReadFile(logPath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got, want := strings.Count(string(logData), "ssh\n"), 4; got != want {
+	if got, want := strings.Count(string(logData), "ssh\n"), 5; got != want {
 		t.Fatalf("ssh calls=%d want %d; log:\n%s", got, want, logData)
 	}
 
@@ -491,7 +492,11 @@ exit 0
 	const secret = "do-not-forward"
 	repo.RemoteURL = "https://runner:" + secret + "@example.test/repo.git"
 	var stderr bytes.Buffer
-	if err := syncWindowsNative(context.Background(), target, repo, cfg, `C:\crabbox\cbx\repo`, manifest, io.Discard, &stderr, rsyncOptions{FullResync: true}); err != nil {
+	coherence, blocked := syncGitCoherencePlan(cfg, repo)
+	if blocked {
+		warnCredentialBearingGitSeed(&stderr)
+	}
+	if err := syncWindowsNative(context.Background(), target, repo, cfg, coherence, `C:\crabbox\cbx\repo`, manifest, io.Discard, &stderr, rsyncOptions{FullResync: true}); err != nil {
 		t.Fatal(err)
 	}
 	logData, err = os.ReadFile(logPath)
@@ -527,6 +532,25 @@ func decodePowerShellCommand(t *testing.T, command string) string {
 		units[i] = uint16(raw[i*2]) | uint16(raw[i*2+1])<<8
 	}
 	return string(utf16.Decode(units))
+}
+
+func runDecodedWindowsPowerShell(t *testing.T, command string) ([]byte, error) {
+	t.Helper()
+	return runWindowsPowerShellScript(t, decodePowerShellCommand(t, command))
+}
+
+func runWindowsPowerShellScript(t *testing.T, script string) ([]byte, error) {
+	t.Helper()
+	powerShell, err := exec.LookPath("powershell.exe")
+	if err != nil {
+		t.Fatal(err)
+	}
+	scriptPath := filepath.Join(t.TempDir(), "script.ps1")
+	if err := os.WriteFile(scriptPath, []byte(script), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(powerShell, "-NoLogo", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", scriptPath)
+	return cmd.CombinedOutput()
 }
 
 func TestWSL2WrapsRemoteCommand(t *testing.T) {
@@ -1714,10 +1738,7 @@ func TestRemoteApplySyncManifestOnlyCommitsManifest(t *testing.T) {
 func TestRemoteFinalizeSyncCommitsMetadataInOneCommand(t *testing.T) {
 	const finalizeToken = "0123456789abcdef0123456789abcdef"
 	workdir := t.TempDir()
-	if err := os.Mkdir(filepath.Join(workdir, ".git"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	metaDir := filepath.Join(workdir, ".git", "crabbox")
+	metaDir := filepath.Join(workdir, ".crabbox")
 	if err := os.MkdirAll(metaDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -1729,10 +1750,9 @@ func TestRemoteFinalizeSyncCommitsMetadataInOneCommand(t *testing.T) {
 	}
 
 	remote := remoteFinalizeSync(workdir, remoteSyncFinalizeOptions{
-		BaseRef:     "main",
-		BaseSHA:     "abc123",
-		Fingerprint: "fp123",
-		Token:       finalizeToken,
+		BaseRef: "main",
+		BaseSHA: "abc123",
+		Token:   finalizeToken,
 	})
 	for attempt := 1; attempt <= 2; attempt++ {
 		if out, err := exec.Command("bash", "-lc", remote).CombinedOutput(); err != nil {
@@ -1756,12 +1776,8 @@ func TestRemoteFinalizeSyncCommitsMetadataInOneCommand(t *testing.T) {
 	if string(marker) != "main abc123\n" {
 		t.Fatalf("unexpected hydrate marker: %q", marker)
 	}
-	fingerprint, err := os.ReadFile(filepath.Join(metaDir, "sync-fingerprint"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(fingerprint) != "fp123" {
-		t.Fatalf("unexpected fingerprint: %q", fingerprint)
+	if _, err := os.Stat(filepath.Join(metaDir, "sync-fingerprint")); !os.IsNotExist(err) {
+		t.Fatalf("overlay-only finalize should not publish fingerprint: %v", err)
 	}
 	token, err := os.ReadFile(filepath.Join(metaDir, "sync-finalize-token"))
 	if err != nil {
@@ -1983,6 +1999,15 @@ func TestRemoteFinalizeSyncWaitIsContextBounded(t *testing.T) {
 	if err == nil || ctx.Err() != context.DeadlineExceeded {
 		t.Fatalf("err=%v context=%v", err, ctx.Err())
 	}
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		if err := os.RemoveAll(workdir); err == nil {
+			break
+		} else if time.Now().After(deadline) {
+			t.Fatalf("clean canceled finalize fixture: %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 }
 
 func TestRemoteSyncFinalizeLockSerializesLiveOwner(t *testing.T) {
@@ -2051,6 +2076,168 @@ func TestRemoteSyncFinalizeLockSerializesLiveOwner(t *testing.T) {
 	}
 }
 
+func TestRemoteFinalizeSyncStatusIsWorkspaceScoped(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell finalization fixture")
+	}
+	f := newGitCoherenceFixture(t)
+	coherentWorkdir := f.workspace(t, f.a, true)
+	overlayWorkdir := f.workspace(t, f.a, false)
+	plan := f.plan(t, f.b)
+	mustWriteTestFile(t, filepath.Join(coherentWorkdir, "tracked.txt"), "B\n")
+	const token = "abababababababababababababababab"
+	stageCoherenceFinalize(t, coherentWorkdir, token)
+	stageCoherenceFinalize(t, overlayWorkdir, token)
+
+	tools := t.TempDir()
+	coherentReady := filepath.Join(tools, "coherent-ready")
+	overlayWrote := filepath.Join(tools, "overlay-wrote")
+	releaseOverlay := filepath.Join(tools, "release-overlay")
+	gitScript := `#!/bin/sh
+case "$CRABBOX_STATUS_ROLE:$1" in
+  coherent:diff-files)
+    touch "$CRABBOX_COHERENT_READY"
+    while [ ! -f "$CRABBOX_OVERLAY_WROTE" ]; do sleep 0.01; done
+    exit 0
+    ;;
+  overlay:status)
+    i=0
+    while [ "$i" -lt 200 ]; do
+      printf ' D deleted-%03d\n' "$i"
+      i=$((i + 1))
+    done
+    touch "$CRABBOX_OVERLAY_WROTE"
+    while [ ! -f "$CRABBOX_RELEASE_OVERLAY" ]; do sleep 0.01; done
+    exit 0
+    ;;
+esac
+exec ` + shellQuote(gitOutput("", "--exec-path")+"/git") + ` "$@"
+`
+	if err := os.WriteFile(filepath.Join(tools, "git"), []byte(gitScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	envFile := filepath.Join(tools, "env")
+	if err := os.WriteFile(envFile, []byte("export PATH="+shellQuote(tools)+":$PATH\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	commonEnv := []string{
+		"BASH_ENV=" + envFile,
+		"CRABBOX_COHERENT_READY=" + coherentReady,
+		"CRABBOX_OVERLAY_WROTE=" + overlayWrote,
+		"CRABBOX_RELEASE_OVERLAY=" + releaseOverlay,
+	}
+	coherent := exec.Command("bash", "-lc", remoteFinalizeSync(coherentWorkdir, remoteSyncFinalizeOptions{
+		Token:       token,
+		Fingerprint: "coherent",
+		Coherence:   plan,
+	}))
+	coherent.Env = append(os.Environ(), append(commonEnv, "CRABBOX_STATUS_ROLE=coherent")...)
+	var coherentOutput bytes.Buffer
+	coherent.Stdout = &coherentOutput
+	coherent.Stderr = &coherentOutput
+	if err := coherent.Start(); err != nil {
+		t.Fatal(err)
+	}
+	var overlay *exec.Cmd
+	t.Cleanup(func() {
+		_ = os.WriteFile(releaseOverlay, []byte("release"), 0o644)
+		if coherent.Process != nil {
+			_ = coherent.Process.Kill()
+		}
+		if overlay != nil && overlay.Process != nil {
+			_ = overlay.Process.Kill()
+		}
+	})
+	coherentDone := make(chan error, 1)
+	go func() { coherentDone <- coherent.Wait() }()
+
+	waitForPath := func(path, message string) {
+		t.Helper()
+		deadline := time.Now().Add(5 * time.Second)
+		for {
+			if _, err := os.Stat(path); err == nil {
+				return
+			}
+			if time.Now().After(deadline) {
+				t.Fatal(message)
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+	waitForPath(coherentReady, "coherent finalizer did not reach candidate status inspection")
+
+	overlay = exec.Command("bash", "-lc", remoteFinalizeSync(overlayWorkdir, remoteSyncFinalizeOptions{Token: token}))
+	overlay.Env = append(os.Environ(), append(commonEnv, "CRABBOX_STATUS_ROLE=overlay")...)
+	var overlayOutput bytes.Buffer
+	overlay.Stdout = &overlayOutput
+	overlay.Stderr = &overlayOutput
+	if err := overlay.Start(); err != nil {
+		t.Fatal(err)
+	}
+	overlayDone := make(chan error, 1)
+	go func() { overlayDone <- overlay.Wait() }()
+	waitForPath(overlayWrote, "overlay finalizer did not publish its deletion status")
+
+	select {
+	case err := <-coherentDone:
+		if err != nil {
+			t.Fatalf("coherent finalizer consumed another workspace status: %v\n%s", err, coherentOutput.Bytes())
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("coherent finalizer did not finish")
+	}
+	if err := os.WriteFile(releaseOverlay, []byte("release"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-overlayDone:
+		if err == nil || exitCode(err) != 66 {
+			t.Fatalf("overlay finalizer err=%v output=%q, want deletion failure", err, overlayOutput.Bytes())
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("overlay finalizer did not finish")
+	}
+	for _, workdir := range []string{coherentWorkdir, overlayWorkdir} {
+		statusFiles, err := filepath.Glob(filepath.Join(coherenceMetaDir(t, workdir), "sync-git-status.*"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(statusFiles) != 0 {
+			t.Fatalf("finalizer left status files in %s: %v", workdir, statusFiles)
+		}
+	}
+	for _, script := range []string{
+		remoteFinalizeSync(coherentWorkdir, remoteSyncFinalizeOptions{Token: token, Coherence: plan}),
+		remoteFinalizeSync(overlayWorkdir, remoteSyncFinalizeOptions{Token: token}),
+	} {
+		if strings.Contains(script, "/tmp/crabbox-git-status") {
+			t.Fatalf("finalizer still uses a global status file: %q", script)
+		}
+	}
+}
+
+func TestRemoteSyncAbandonedMetadataCleanupRemovesStatusFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell metadata cleanup fixture")
+	}
+	metaDir := t.TempDir()
+	statusPath := filepath.Join(metaDir, "sync-git-status.abandoned")
+	if err := os.WriteFile(statusPath, []byte("stale"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-9 * 24 * time.Hour)
+	if err := os.Chtimes(statusPath, old, old); err != nil {
+		t.Fatal(err)
+	}
+	script := "set -e\nmeta_dir=" + shellQuote(metaDir) + "\n" + remoteSyncAbandonedMetadataCleanup()
+	if out, err := exec.Command("bash", "-c", script).CombinedOutput(); err != nil {
+		t.Fatalf("cleanup abandoned status: %v\n%s", err, out)
+	}
+	if _, err := os.Stat(statusPath); !os.IsNotExist(err) {
+		t.Fatalf("abandoned status file survived cleanup: %v", err)
+	}
+}
+
 func TestRemoteFinalizeSyncDoesNotConsumeNewerPendingManifest(t *testing.T) {
 	const currentToken = "0123456789abcdef0123456789abcdef"
 	const newerToken = "fedcba9876543210fedcba9876543210"
@@ -2079,12 +2266,989 @@ func TestRemoteFinalizeSyncDoesNotConsumeNewerPendingManifest(t *testing.T) {
 	}
 }
 
-func TestRemoteGitSeedRemovesFailedCheckout(t *testing.T) {
-	got := remoteGitSeed("/work/repo", "https://github.com/openclaw/crabbox.git", "missing-sha")
+type gitCoherenceFixture struct {
+	source string
+	origin string
+	a      string
+	b      string
+	c      string
+}
+
+func newGitCoherenceFixture(t *testing.T) gitCoherenceFixture {
+	t.Helper()
+	root := t.TempDir()
+	source := filepath.Join(root, "source")
+	if err := os.Mkdir(source, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, source, "init")
+	runGit(t, source, "config", "user.email", "test@example.com")
+	runGit(t, source, "config", "user.name", "Test")
+	runGit(t, source, "branch", "-M", "main")
+	mustWriteTestFile(t, filepath.Join(source, "tracked.txt"), "A\n")
+	mustWriteTestFile(t, filepath.Join(source, "modified.txt"), "base\n")
+	mustWriteTestFile(t, filepath.Join(source, "deleted.txt"), "base\n")
+	mustWriteTestFile(t, filepath.Join(source, "src", "keep.txt"), "keep\n")
+	mustWriteTestFile(t, filepath.Join(source, "other", "omit.txt"), "omit\n")
+	runGit(t, source, "add", ".")
+	runGit(t, source, "commit", "-m", "A")
+	a := gitOutput(source, "rev-parse", "HEAD")
+	mustWriteTestFile(t, filepath.Join(source, "tracked.txt"), "B\n")
+	runGit(t, source, "commit", "-am", "B")
+	b := gitOutput(source, "rev-parse", "HEAD")
+	mustWriteTestFile(t, filepath.Join(source, "tracked.txt"), "C\n")
+	runGit(t, source, "commit", "-am", "C")
+	c := gitOutput(source, "rev-parse", "HEAD")
+	origin := filepath.Join(root, "origin.git")
+	if out, err := exec.Command("git", "clone", "--bare", source, origin).CombinedOutput(); err != nil {
+		t.Fatalf("create origin: %v\n%s", err, out)
+	}
+	runGit(t, source, "remote", "add", "origin", origin)
+	runGit(t, source, "fetch", "origin", "+refs/heads/*:refs/remotes/origin/*")
+	return gitCoherenceFixture{source: source, origin: origin, a: a, b: b, c: c}
+}
+
+func (f gitCoherenceFixture) plan(t *testing.T, target string) gitCoherencePlan {
+	t.Helper()
+	plan, blocked := syncGitCoherencePlan(baseConfig(), Repo{Root: f.source, RemoteURL: f.origin, Head: target})
+	if blocked || !plan.enabled() {
+		t.Fatalf("coherence plan unavailable: blocked=%v plan=%#v", blocked, plan)
+	}
+	return plan
+}
+
+func (f gitCoherenceFixture) workspace(t *testing.T, target string, symbolic bool) string {
+	t.Helper()
+	workdir := filepath.Join(t.TempDir(), "work")
+	if out, err := exec.Command("git", "clone", "--quiet", f.origin, workdir).CombinedOutput(); err != nil {
+		t.Fatalf("clone workspace: %v\n%s", err, out)
+	}
+	if symbolic {
+		runGit(t, workdir, "checkout", "-q", "-B", "workspace", target)
+	} else {
+		runGit(t, workdir, "checkout", "-q", "--detach", target)
+	}
+	return workdir
+}
+
+func (f gitCoherenceFixture) linkedWorkspace(t *testing.T, target string) string {
+	t.Helper()
+	base := filepath.Join(t.TempDir(), "base")
+	if out, err := exec.Command("git", "clone", "--quiet", f.origin, base).CombinedOutput(); err != nil {
+		t.Fatalf("clone linked base: %v\n%s", err, out)
+	}
+	workdir := filepath.Join(filepath.Dir(base), "linked")
+	runGit(t, base, "worktree", "add", "--detach", workdir, target)
+	return workdir
+}
+
+func coherenceMetaDir(t *testing.T, workdir string) string {
+	t.Helper()
+	meta := gitOutput(workdir, "rev-parse", "--git-path", "crabbox")
+	if !filepath.IsAbs(meta) {
+		meta = filepath.Join(workdir, meta)
+	}
+	if err := os.MkdirAll(meta, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return meta
+}
+
+func stageCoherenceFinalize(t *testing.T, workdir, token string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(coherenceMetaDir(t, workdir), remoteSyncPendingManifestName(token)), []byte("tracked.txt\x00"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func runCoherenceFinalize(workdir string, plan gitCoherencePlan, token, fingerprint string, env ...string) ([]byte, error) {
+	cmd := exec.Command("bash", "-lc", remoteFinalizeSync(workdir, remoteSyncFinalizeOptions{
+		Token:       token,
+		Fingerprint: fingerprint,
+		Coherence:   plan,
+	}))
+	cmd.Env = append(os.Environ(), env...)
+	return cmd.CombinedOutput()
+}
+
+func readCoherentFingerprint(t *testing.T, workdir string, plan gitCoherencePlan) string {
+	t.Helper()
+	out, err := exec.Command("bash", "-lc", remoteReadSyncFingerprint(workdir, plan)).CombinedOutput()
+	if err != nil {
+		t.Fatalf("read fingerprint: %v\n%s", err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func coherenceIndexPath(t *testing.T, workdir string) string {
+	t.Helper()
+	index := gitOutput(workdir, "rev-parse", "--git-path", "index")
+	if !filepath.IsAbs(index) {
+		index = filepath.Join(workdir, index)
+	}
+	return index
+}
+
+func coherenceIndexBytes(t *testing.T, workdir string) []byte {
+	t.Helper()
+	index := coherenceIndexPath(t, workdir)
+	data, err := os.ReadFile(index)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+func requireGitOutput(t *testing.T, workdir, want string, args ...string) {
+	t.Helper()
+	if got := gitOutput(workdir, args...); got != want {
+		t.Fatalf("git %v=%q want %q", args, got, want)
+	}
+}
+func TestRemoteGitCoherenceRepairsReuseBeforeFingerprintSkip(t *testing.T) {
+	f := newGitCoherenceFixture(t)
+	workdir := f.workspace(t, f.a, true)
+	planB := f.plan(t, f.b)
+	meta := coherenceMetaDir(t, workdir)
+	for name, value := range map[string]string{
+		"sync-fingerprint":             "fp-b",
+		"sync-finalize-token":          "stale",
+		"sync-finalize-complete-token": "stale",
+	} {
+		if err := os.WriteFile(filepath.Join(meta, name), []byte(value), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := readCoherentFingerprint(t, workdir, planB); got != "" {
+		t.Fatalf("stale A metadata certified B fingerprint %q", got)
+	}
+
+	mustWriteTestFile(t, filepath.Join(workdir, "tracked.txt"), "B\n")
+	mustWriteTestFile(t, filepath.Join(workdir, "modified.txt"), "dirty\n")
+	if err := os.Remove(filepath.Join(workdir, "deleted.txt")); err != nil {
+		t.Fatal(err)
+	}
+	mustWriteTestFile(t, filepath.Join(workdir, "untracked.txt"), "keep\n")
+	const tokenB = "11111111111111111111111111111111"
+	stageCoherenceFinalize(t, workdir, tokenB)
+	if out, err := runCoherenceFinalize(workdir, planB, tokenB, "fp-b"); err != nil {
+		t.Fatalf("finalize B: %v\n%s", err, out)
+	}
+	requireGitOutput(t, workdir, f.b, "rev-parse", "HEAD")
+	requireGitOutput(t, workdir, planB.Tree, "write-tree")
+	requireGitOutput(t, workdir, f.a, "rev-parse", "refs/heads/workspace")
+	requireGitOutput(t, workdir, "", "symbolic-ref", "-q", "HEAD")
+	for path, want := range map[string]string{"tracked.txt": "B\n", "modified.txt": "dirty\n", "untracked.txt": "keep\n"} {
+		got, err := os.ReadFile(filepath.Join(workdir, path))
+		if err != nil || string(got) != want {
+			t.Fatalf("%s=%q err=%v want %q", path, got, err, want)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(workdir, "deleted.txt")); !os.IsNotExist(err) {
+		t.Fatalf("deleted overlay path was restored: %v", err)
+	}
+	if got := readCoherentFingerprint(t, workdir, planB); got != "fp-b" {
+		t.Fatalf("coherent B fingerprint=%q", got)
+	}
+	if out, err := exec.Command("bash", "-lc", remoteInvalidateSyncFingerprintForTarget(SSHTarget{TargetOS: targetLinux}, workdir)).CombinedOutput(); err != nil {
+		t.Fatalf("invalidate fingerprint: %v\n%s", err, out)
+	}
+	if got := readCoherentFingerprint(t, workdir, planB); got != "" {
+		t.Fatalf("executed workspace retained fingerprint %q", got)
+	}
+
+	planC := f.plan(t, f.c)
+	mustWriteTestFile(t, filepath.Join(workdir, "tracked.txt"), "C\n")
+	const tokenC = "22222222222222222222222222222222"
+	stageCoherenceFinalize(t, workdir, tokenC)
+	if out, err := runCoherenceFinalize(workdir, planC, tokenC, "fp-c"); err != nil {
+		t.Fatalf("finalize C: %v\n%s", err, out)
+	}
+	if got := gitOutput(workdir, "rev-parse", "HEAD"); got != f.c {
+		t.Fatalf("HEAD=%s want C=%s", got, f.c)
+	}
+	if got := readCoherentFingerprint(t, workdir, planC); got != "fp-c" {
+		t.Fatalf("coherent C fingerprint=%q", got)
+	}
+}
+
+func TestRemoteGitCoherenceFailsClosedWhenAdvertisedBranchCannotBeVerified(t *testing.T) {
+	f := newGitCoherenceFixture(t)
+	workdir := f.workspace(t, f.a, true)
+	plan := f.plan(t, f.b)
+	plan.RemoteURL = filepath.Join(t.TempDir(), "missing-origin.git")
+	const token = "abababababababababababababababab"
+	stageCoherenceFinalize(t, workdir, token)
+	out, err := runCoherenceFinalize(workdir, plan, token, "must-not-publish")
+	if err == nil || !strings.Contains(string(out), "Git coherence fetch failed") {
+		t.Fatalf("unverified coherence out=%q err=%v", out, err)
+	}
+	requireGitOutput(t, workdir, f.a, "rev-parse", "HEAD")
+	if got := readCoherentFingerprint(t, workdir, plan); got != "" {
+		t.Fatalf("failed coherence published fingerprint %q", got)
+	}
+	if _, statErr := os.Lstat(filepath.Join(coherenceMetaDir(t, workdir), "sync-finalize-lock")); !os.IsNotExist(statErr) {
+		t.Fatalf("failed coherence stranded finalization lock: %v", statErr)
+	}
+}
+
+func TestRemoteGitCoherenceSupportsDetachedSparseSplitAndLinkedIndexes(t *testing.T) {
+	f := newGitCoherenceFixture(t)
+	for _, mode := range []string{"detached", "sparse", "split", "linked"} {
+		t.Run(mode, func(t *testing.T) {
+			workdir := f.workspace(t, f.a, false)
+			switch mode {
+			case "sparse":
+				runGit(t, workdir, "sparse-checkout", "init", "--cone", "--sparse-index")
+				runGit(t, workdir, "sparse-checkout", "set", "src")
+			case "split":
+				runGit(t, workdir, "update-index", "--split-index")
+			case "linked":
+				workdir = f.linkedWorkspace(t, f.a)
+			}
+			mustWriteTestFile(t, filepath.Join(workdir, "tracked.txt"), "B\n")
+			token := fmt.Sprintf("%032x", len(mode)+10)
+			plan := f.plan(t, f.b)
+			stageCoherenceFinalize(t, workdir, token)
+			if out, err := runCoherenceFinalize(workdir, plan, token, "fp-"+mode); err != nil {
+				t.Fatalf("finalize: %v\n%s", err, out)
+			}
+			if got := gitOutput(workdir, "rev-parse", "HEAD"); got != f.b {
+				t.Fatalf("HEAD=%s want %s", got, f.b)
+			}
+			if got := gitOutput(workdir, "write-tree"); got != plan.Tree {
+				t.Fatalf("tree=%s want %s", got, plan.Tree)
+			}
+		})
+	}
+}
+
+func coherenceFailureTools(t *testing.T, target string) string {
+	t.Helper()
+	dir := t.TempDir()
+	gitScript := `#!/bin/sh
+case "$CRABBOX_FAIL_GIT:$1" in
+  read-tree:read-tree|write-tree:write-tree|diff-files:diff-files) exit 91 ;;
+esac
+if [ "$CRABBOX_FAIL_GIT" = cas ] && [ "$1" = update-ref ] && [ "$2" = --no-deref ] && [ "$3" = HEAD ]; then exit 92; fi
+if [ "$CRABBOX_FAIL_GIT" = raw ] && [ "$1" = fetch ]; then
+  for arg do case "$arg" in +` + target + `:refs/crabbox/*) exit 93 ;; esac; done
+fi
+exec ` + shellQuote(gitOutput("", "--exec-path")+"/git") + ` "$@"
+`
+	mvScript := `#!/bin/sh
+last=
+for arg do last="$arg"; done
+case "$CRABBOX_FAIL_MV:$last" in
+  fingerprint:*/sync-fingerprint|complete:*/sync-finalize-complete-token) exit 94 ;;
+esac
+if [ "$CRABBOX_FAIL_MV" = concurrent-index ]; then
+  case "$last" in */sync-fingerprint) index=$(` + shellQuote(gitOutput("", "--exec-path")+"/git") + ` -C "$CRABBOX_CONCURRENT_WORKDIR" rev-parse --git-path index); case "$index" in /*) ;; *) index="$CRABBOX_CONCURRENT_WORKDIR/$index" ;; esac; printf concurrent-index > "$index"; exit 94 ;; esac
+fi
+if [ "$CRABBOX_FAIL_MV" = concurrent-head ]; then
+  case "$last" in */sync-fingerprint) ` + shellQuote(gitOutput("", "--exec-path")+"/git") + ` -C "$CRABBOX_CONCURRENT_WORKDIR" update-ref --no-deref HEAD "$CRABBOX_CONCURRENT_HEAD" "$CRABBOX_TARGET_HEAD"; exit 94 ;; esac
+fi
+if [ "$CRABBOX_FAIL_MV" = concurrent-branch ]; then
+  case "$last" in */sync-fingerprint) ` + shellQuote(gitOutput("", "--exec-path")+"/git") + ` -C "$CRABBOX_CONCURRENT_WORKDIR" update-ref refs/heads/workspace "$CRABBOX_CONCURRENT_HEAD" "$CRABBOX_OLD_HEAD"; exit 94 ;; esac
+fi
+if [ "$CRABBOX_FAIL_MV" = post-install-index ]; then case "$1" in *index.crabbox*) /bin/mv "$@"; printf post-install-index > "$last"; exit 0 ;; esac; fi
+exec /bin/mv "$@"
+`
+	if err := os.WriteFile(filepath.Join(dir, "git"), []byte(gitScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "mv"), []byte(mvScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "env"), []byte("export PATH="+shellQuote(dir)+":$PATH\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestRemoteGitCoherenceRollsBackFailuresAndRetries(t *testing.T) {
+	f := newGitCoherenceFixture(t)
+	for _, failure := range []string{"read-tree", "write-tree", "diff-files", "cas", "fingerprint", "complete"} {
+		t.Run(failure, func(t *testing.T) {
+			workdir := f.workspace(t, f.a, true)
+			plan := f.plan(t, f.b)
+			mustWriteTestFile(t, filepath.Join(workdir, "tracked.txt"), "B\n")
+			token := fmt.Sprintf("%032x", len(failure)+100)
+			stageCoherenceFinalize(t, workdir, token)
+			beforeIndex := coherenceIndexBytes(t, workdir)
+			tools := coherenceFailureTools(t, plan.Target)
+			env := []string{"BASH_ENV=" + filepath.Join(tools, "env")}
+			if failure == "fingerprint" || failure == "complete" {
+				env = append(env, "CRABBOX_FAIL_MV="+failure)
+			} else {
+				env = append(env, "CRABBOX_FAIL_GIT="+failure)
+			}
+			if out, err := runCoherenceFinalize(workdir, plan, token, "fp-"+failure, env...); err == nil {
+				t.Fatalf("fault %s unexpectedly succeeded\n%s", failure, out)
+			}
+			requireGitOutput(t, workdir, f.a, "rev-parse", "HEAD")
+			requireGitOutput(t, workdir, "refs/heads/workspace", "symbolic-ref", "-q", "HEAD")
+			if afterIndex := coherenceIndexBytes(t, workdir); !bytes.Equal(afterIndex, beforeIndex) {
+				t.Fatal("index bytes changed after failed finalization")
+			}
+			if got := readCoherentFingerprint(t, workdir, plan); got != "" {
+				t.Fatalf("failed finalization certified fingerprint %q", got)
+			}
+			if out, err := runCoherenceFinalize(workdir, plan, token, "fp-"+failure); err != nil {
+				t.Fatalf("retry: %v\n%s", err, out)
+			}
+			if got := readCoherentFingerprint(t, workdir, plan); got != "fp-"+failure {
+				t.Fatalf("retry fingerprint=%q", got)
+			}
+		})
+	}
+}
+func TestRemoteGitCoherenceDoesNotOverwriteConcurrentRollbackChanges(t *testing.T) {
+	f := newGitCoherenceFixture(t)
+	for _, failure := range []string{"concurrent-index", "post-install-index", "concurrent-head", "concurrent-branch"} {
+		t.Run(failure, func(t *testing.T) {
+			workdir := f.workspace(t, f.a, true)
+			plan := f.plan(t, f.b)
+			mustWriteTestFile(t, filepath.Join(workdir, "tracked.txt"), "B\n")
+			token := fmt.Sprintf("%032x", len(failure)+200)
+			stageCoherenceFinalize(t, workdir, token)
+			tools := coherenceFailureTools(t, plan.Target)
+			env := []string{"BASH_ENV=" + filepath.Join(tools, "env"), "CRABBOX_FAIL_MV=" + failure, "CRABBOX_CONCURRENT_WORKDIR=" + workdir, "CRABBOX_CONCURRENT_HEAD=" + f.c, "CRABBOX_TARGET_HEAD=" + f.b, "CRABBOX_OLD_HEAD=" + f.a}
+			out, err := runCoherenceFinalize(workdir, plan, token, "fp-"+failure, env...)
+			if err == nil {
+				t.Fatalf("concurrent fault unexpectedly succeeded\n%s", out)
+			}
+			switch failure {
+			case "concurrent-index", "post-install-index":
+				if got := coherenceIndexBytes(t, workdir); string(got) != failure {
+					t.Fatalf("concurrent index overwritten: %q", got)
+				}
+				requireGitOutput(t, workdir, f.a, "rev-parse", "HEAD")
+				if failure == "post-install-index" {
+					requireGitOutput(t, workdir, "refs/heads/workspace", "symbolic-ref", "-q", "HEAD")
+				}
+			case "concurrent-head":
+				requireGitOutput(t, workdir, f.c, "rev-parse", "HEAD")
+			case "concurrent-branch":
+				requireGitOutput(t, workdir, f.a, "rev-parse", "HEAD")
+				requireGitOutput(t, workdir, "", "symbolic-ref", "-q", "HEAD")
+				requireGitOutput(t, workdir, f.c, "rev-parse", "refs/heads/workspace")
+			}
+		})
+	}
+}
+func TestRemoteGitCoherenceRepairsAndVerifiesMismatchedOrigin(t *testing.T) {
+	f := newGitCoherenceFixture(t)
+	workdir := f.workspace(t, f.a, false)
+	wrong := filepath.Join(t.TempDir(), "wrong.git")
+	if err := os.Mkdir(wrong, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, wrong, "init", "--bare")
+	runGit(t, workdir, "remote", "set-url", "origin", wrong)
+	plan := f.plan(t, f.b)
+	mustWriteTestFile(t, filepath.Join(workdir, "tracked.txt"), "B\n")
+	const token = "33333333333333333333333333333333"
+	meta := coherenceMetaDir(t, workdir)
+	for name, value := range map[string]string{
+		"sync-fingerprint":             "stale",
+		"sync-finalize-token":          token,
+		"sync-finalize-complete-token": token,
+	} {
+		if err := os.WriteFile(filepath.Join(meta, name), []byte(value), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := readCoherentFingerprint(t, workdir, plan); got != "" {
+		t.Fatalf("mismatched origin certified fingerprint %q", got)
+	}
+	stageCoherenceFinalize(t, workdir, token)
+	if out, err := runCoherenceFinalize(workdir, plan, token, "fp-b"); err != nil {
+		t.Fatalf("repair origin: %v\n%s", err, out)
+	}
+	if got := gitOutput(workdir, "remote", "get-url", "origin"); got != plan.RemoteURL {
+		t.Fatalf("repaired origin=%q want planned origin", got)
+	}
+	if got := gitOutput(workdir, "rev-parse", "HEAD"); got != f.b {
+		t.Fatalf("HEAD=%s want %s", got, f.b)
+	}
+	if got := readCoherentFingerprint(t, workdir, plan); got != "fp-b" {
+		t.Fatalf("repaired origin fingerprint=%q", got)
+	}
+}
+
+func TestRemoteGitCoherenceRejectsAncestorRepository(t *testing.T) {
+	f := newGitCoherenceFixture(t)
+	outer := f.workspace(t, f.b, false)
+	workdir := filepath.Join(outer, "nested")
+	if err := os.Mkdir(workdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	plan := f.plan(t, f.b)
+	const token = "44444444444444444444444444444444"
+	meta := filepath.Join(workdir, ".crabbox")
+	if err := os.Mkdir(meta, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for name, value := range map[string]string{
+		"sync-fingerprint":                   "ancestor",
+		"sync-finalize-token":                token,
+		"sync-finalize-complete-token":       token,
+		remoteSyncPendingManifestName(token): "nested.txt\x00",
+		remoteSyncPendingDeletedName(token):  "",
+	} {
+		if err := os.WriteFile(filepath.Join(meta, name), []byte(value), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := readCoherentFingerprint(t, workdir, plan); got != "" {
+		t.Fatalf("ancestor repository certified fingerprint %q", got)
+	}
+	if out, err := runCoherenceFinalize(workdir, plan, token, "nested"); err != nil {
+		t.Fatalf("ancestor finalize: %v\n%s", err, out)
+	}
+	if got := gitOutput(outer, "rev-parse", "HEAD"); got != f.b {
+		t.Fatalf("ancestor HEAD changed to %s", got)
+	}
+	if _, err := os.Stat(filepath.Join(meta, "sync-fingerprint")); !os.IsNotExist(err) {
+		t.Fatalf("ancestor finalize published fingerprint: %v", err)
+	}
+}
+
+func TestWindowsGitCoherenceGeneration(t *testing.T) {
+	decoded := decodePowerShellCommand(t, windowsGitCoherence(`C:\work\repo`, gitCoherencePlan{
+		RemoteURL: "https://example.test/repo.git",
+		Target:    strings.Repeat("a", 40),
+		Tree:      strings.Repeat("b", 40),
+		Branch:    "main",
+	}))
 	for _, want := range []string{
-		"if (cd \"$tmp\"",
-		"git checkout --quiet 'missing-sha' || git checkout --quiet FETCH_HEAD",
-		"else rm -rf \"$tmp\"; fi",
+		"refs/crabbox/sync-",
+		"https://example.test/repo.git",
+		"+refs/heads/",
+		"rev-parse --show-toplevel",
+		"GetFinalPathNameByHandle",
+		"Test-CrabboxSameDirectory $workdir $reportedRoot",
+		"remote set-url origin",
+		"git read-tree --reset",
+		"git write-tree",
+		"& git update-ref --no-deref HEAD $target $oldHead",
+		"& git update-ref --no-deref HEAD $oldHead $target",
+		"Git HEAD remained symbolic during coherence",
+		"Git symbolic branch changed during coherence",
+		"Git coherence fetch failed",
+		"requested commit is not on advertised branch",
+		"requested Git tree verification failed",
+		"& git symbolic-ref HEAD $oldSym",
+		"[IO.File]::Replace($candidate, $index, $replaceBackup)",
+		"[IO.File]::Replace($replaceBackup, $index, $rollbackBackup)",
+		"ReadAllBytes($replaceBackup), [IO.File]::ReadAllBytes($compare)",
+		"ReadAllBytes($index), [IO.File]::ReadAllBytes($verify)",
+		"$failure = $_",
+		"$rollbackError = $null",
+	} {
+		if !strings.Contains(decoded, want) {
+			t.Fatalf("Windows coherence script missing %q:\n%s", want, decoded)
+		}
+	}
+	mergeBase := strings.Index(decoded, "& git merge-base --is-ancestor")
+	ancestryStatus := strings.Index(decoded, "$isAncestor = $LASTEXITCODE -eq 0")
+	targetTree := strings.Index(decoded, "$targetTree = & git rev-parse")
+	if mergeBase < 0 || ancestryStatus <= mergeBase || targetTree <= ancestryStatus {
+		t.Fatalf("Windows ancestry status is not preserved before target-tree inspection:\n%s", decoded)
+	}
+	if strings.Contains(decoded, "reset --hard") {
+		t.Fatalf("Windows coherence script uses destructive Git:\n%s", decoded)
+	}
+	if strings.Contains(decoded, "Resolve-Path -LiteralPath $workdir") {
+		t.Fatalf("Windows coherence script compares textual root paths:\n%s", decoded)
+	}
+	if strings.Contains(decoded, `[IO.File]::Replace($candidate, $index, $null)`) ||
+		strings.Contains(decoded, "NullString") {
+		t.Fatalf("Windows coherence script uses an invalid replacement backup path:\n%s", decoded)
+	}
+	headRollback := strings.Index(decoded, `[InvalidOperationException]::new("Git HEAD rollback failed")`)
+	indexRollback := strings.Index(decoded, `[IO.File]::Replace($replaceBackup, $index, $rollbackBackup)`)
+	throwRollback := strings.Index(decoded, `if ($rollbackError) { throw $rollbackError }`)
+	if headRollback < 0 || indexRollback <= headRollback || throwRollback <= indexRollback {
+		t.Fatalf("Windows rollback does not preserve the first error through index restoration:\n%s", decoded)
+	}
+	if got := strings.Count(decoded, "& git update-ref --no-deref HEAD"); got != 2 {
+		t.Fatalf("Windows coherence has %d detached HEAD updates, want mutation and rollback only:\n%s", got, decoded)
+	}
+	if strings.Contains(decoded, "git update-ref $oldSym") {
+		t.Fatalf("Windows coherence advances a symbolic branch ref:\n%s", decoded)
+	}
+}
+
+func TestWindowsGitSeedChecksGitBeforeInstallingClone(t *testing.T) {
+	decoded := decodePowerShellCommand(t, windowsGitSeed(`C:\work\repo`, gitCoherencePlan{
+		RemoteURL: "https://example.test/repo.git",
+		Target:    strings.Repeat("a", 40),
+		Tree:      strings.Repeat("b", 40),
+		Branch:    "main",
+	}))
+	clone := strings.Index(decoded, "& git clone")
+	cloneCheck := strings.Index(decoded, `if ($LASTEXITCODE -ne 0) { throw "Git seed clone failed" }`)
+	checkout := strings.Index(decoded, "& git -C $tmp checkout")
+	checkoutCheck := strings.Index(decoded, `if ($LASTEXITCODE -ne 0) { throw "Git seed checkout failed" }`)
+	removeWorkdir := strings.Index(decoded, "Remove-Item -LiteralPath $workdir -Recurse -Force")
+	moveClone := strings.Index(decoded, "Move-Item -LiteralPath $tmp -Destination $workdir")
+	if clone < 0 || cloneCheck <= clone || checkout <= cloneCheck || checkoutCheck <= checkout ||
+		removeWorkdir <= checkoutCheck || moveClone <= removeWorkdir {
+		t.Fatalf("Windows seed can install before clone and checkout verification:\n%s", decoded)
+	}
+	for _, want := range []string{
+		"rev-parse --show-toplevel",
+		"GetFinalPathNameByHandle",
+		"Test-CrabboxSameDirectory $Path $reportedRoot",
+		"Test-UsableGitWorkspace",
+		`$ErrorActionPreference = "Continue"`,
+		"rev-parse --verify 'HEAD^{commit}'",
+		"rev-parse --git-path index",
+		"Test-Path -LiteralPath $index -PathType Leaf",
+		"git -C $Path write-tree",
+		"remote set-url origin",
+		`if ($tmp -and (Test-Path -LiteralPath $tmp))`,
+	} {
+		if !strings.Contains(decoded, want) {
+			t.Fatalf("Windows seed missing %q:\n%s", want, decoded)
+		}
+	}
+	if strings.Contains(decoded, "Resolve-Path -LiteralPath $Path") {
+		t.Fatalf("Windows seed compares textual root paths:\n%s", decoded)
+	}
+	usable := strings.Index(decoded, "function Test-UsableGitWorkspace")
+	if usable < 0 {
+		t.Fatalf("Windows seed is missing the workspace usability probe:\n%s", decoded)
+	}
+	probePreference := usable + strings.Index(decoded[usable:], `$ErrorActionPreference = "Continue"`)
+	headProbe := usable + strings.Index(decoded[usable:], "$head = & git -C $Path rev-parse --verify")
+	if probePreference <= usable || headProbe <= probePreference {
+		t.Fatalf("Windows seed does not scope expected native Git failures before probing HEAD:\n%s", decoded)
+	}
+	reuse := strings.Index(decoded, "if (Test-UsableGitWorkspace $workdir)")
+	startClone := strings.Index(decoded, "$tmp = Join-Path")
+	if reuse < 0 || startClone <= reuse || !strings.Contains(decoded[reuse:startClone], "Repair-Origin $workdir\n  exit 0") {
+		t.Fatalf("Windows seed does not reject unborn or missing-index roots before reuse:\n%s", decoded)
+	}
+	verifyWorkspace := strings.Index(decoded, "if (-not (Test-UsableGitWorkspace $tmp))")
+	verifyTree := strings.Index(decoded, "if ($expectedTree) {")
+	if verifyWorkspace <= checkoutCheck || verifyTree <= verifyWorkspace || removeWorkdir <= verifyTree {
+		t.Fatalf("Windows seed can replace a workspace before the candidate index and tree are verified:\n%s", decoded)
+	}
+}
+
+func TestWindowsGitSeedSeedOnlyPlanSkipsTreeEquality(t *testing.T) {
+	decoded := decodePowerShellCommand(t, windowsGitSeed(`C:\work\repo`, gitCoherencePlan{
+		RemoteURL: "https://example.test/repo.git",
+		Target:    strings.Repeat("a", 40),
+		Branch:    "main",
+	}))
+	for _, want := range []string{
+		"$expectedTree = ''",
+		"Test-UsableGitWorkspace $tmp",
+		"return $treeStatus -eq 0 -and [bool]$tree",
+		"if ($expectedTree) {",
+		"([string]$seedTree).Trim() -ne $expectedTree",
+	} {
+		if !strings.Contains(decoded, want) {
+			t.Fatalf("Windows seed-only script missing %q:\n%s", want, decoded)
+		}
+	}
+	if strings.Contains(decoded, "([string]$seedTree).Trim() -ne ''") {
+		t.Fatalf("Windows seed-only script unconditionally compares against an empty tree:\n%s", decoded)
+	}
+}
+
+func TestWindowsGitRootIdentityGeneration(t *testing.T) {
+	script := windowsGitRootIdentityScript()
+	for _, want := range []string{
+		"GetFinalPathNameByHandle",
+		"Microsoft.Win32.SafeHandles.SafeFileHandle",
+		"[IO.FileShare]::ReadWrite -bor [IO.FileShare]::Delete",
+		"0x02000000",
+		"Test-CrabboxSameDirectory",
+		"[StringComparison]::OrdinalIgnoreCase",
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("Windows Git root identity script missing %q:\n%s", want, script)
+		}
+	}
+	if strings.Contains(script, "Resolve-Path") {
+		t.Fatalf("Windows Git root identity relies on textual path normalization:\n%s", script)
+	}
+}
+
+func TestWindowsGitRootIdentityAcceptsShortAliasAndRejectsDistinctRoot(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("native Windows path identity is covered by Windows CI")
+	}
+	base := t.TempDir()
+	root := filepath.Join(base, "workspace with a long name")
+	other := filepath.Join(base, "different workspace")
+	for _, path := range []string{root, other} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	script := `$ErrorActionPreference = "Stop"
+` + windowsGitRootIdentityScript() + `
+Add-Type -Name ShortPath -Namespace Cbx -MemberDefinition '[DllImport("kernel32.dll",CharSet=CharSet.Unicode,SetLastError=true)]public static extern uint GetShortPathName(string l,System.Text.StringBuilder s,uint n);'
+$longPath = Get-CrabboxFinalDirectoryPath ` + psQuote(root) + `
+$buffer = New-Object Text.StringBuilder 32768
+$length = [Cbx.ShortPath]::GetShortPathName($longPath, $buffer, $buffer.Capacity)
+if ($length -eq 0 -or $length -ge $buffer.Capacity) { throw "short path lookup failed" }
+$shortPath = $buffer.ToString()
+if ([string]::Equals($shortPath, $longPath, [StringComparison]::OrdinalIgnoreCase)) { throw "short path fixture did not produce an alias" }
+if (-not (Test-CrabboxSameDirectory $shortPath $longPath)) { throw "short and long paths did not match" }
+if (Test-CrabboxSameDirectory $shortPath ` + psQuote(other) + `) { throw "distinct roots matched" }
+`
+	if out, err := runWindowsPowerShellScript(t, script); err != nil {
+		t.Fatalf("Windows Git root identity failed: %v\n%s", err, out)
+	}
+}
+
+func requireWindowsExactGitRoot(t *testing.T, workdir string) {
+	t.Helper()
+	actual := gitOutput(workdir, "rev-parse", "--show-toplevel")
+	if actual == "" {
+		t.Fatal("Git reported no top-level worktree")
+	}
+	actualInfo, err := os.Stat(filepath.FromSlash(actual))
+	if err != nil {
+		t.Fatalf("stat reported Git root %q: %v", actual, err)
+	}
+	expectedInfo, err := os.Stat(workdir)
+	if err != nil {
+		t.Fatalf("stat expected workdir %q: %v", workdir, err)
+	}
+	if !os.SameFile(actualInfo, expectedInfo) {
+		t.Fatalf("Git root=%q does not identify exact workdir %q", actual, workdir)
+	}
+}
+
+func requireWindowsGitWorkspaceState(t *testing.T, workdir string, plan gitCoherencePlan) {
+	t.Helper()
+	requireWindowsExactGitRoot(t, workdir)
+	requireGitOutput(t, workdir, plan.Target, "rev-parse", "HEAD")
+	requireGitOutput(t, workdir, plan.Tree, "write-tree")
+	requireGitOutput(t, workdir, plan.RemoteURL, "remote", "get-url", "origin")
+	index := gitOutput(workdir, "rev-parse", "--git-path", "index")
+	if !filepath.IsAbs(index) {
+		index = filepath.Join(workdir, index)
+	}
+	if _, err := os.Stat(index); err != nil {
+		t.Fatalf("Git index missing: %v", err)
+	}
+}
+
+func TestWindowsGitSeedReplacesUnusableExactRootsAfterVerifiedClone(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("native Windows PowerShell execution is covered by Windows CI")
+	}
+	f := newGitCoherenceFixture(t)
+	plan := f.plan(t, f.b)
+	for _, mode := range []string{"unborn", "missing-index"} {
+		t.Run(mode, func(t *testing.T) {
+			workdir := filepath.Join(t.TempDir(), "work")
+			var missingIndex string
+			switch mode {
+			case "unborn":
+				if err := os.MkdirAll(workdir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				runGit(t, workdir, "init")
+			case "missing-index":
+				if out, err := exec.Command("git", "clone", "--quiet", f.origin, workdir).CombinedOutput(); err != nil {
+					t.Fatalf("clone missing-index fixture: %v\n%s", err, out)
+				}
+				missingIndex = gitOutput(workdir, "rev-parse", "--git-path", "index")
+				if !filepath.IsAbs(missingIndex) {
+					missingIndex = filepath.Join(workdir, missingIndex)
+				}
+				if err := os.Remove(missingIndex); err != nil {
+					t.Fatal(err)
+				}
+			}
+			requireWindowsExactGitRoot(t, workdir)
+			marker := filepath.Join(workdir, "preserve-until-verified.txt")
+			mustWriteTestFile(t, marker, "preserve\n")
+
+			unverified := plan
+			unverified.Tree = strings.Repeat("f", 40)
+			out, err := runDecodedWindowsPowerShell(t, windowsGitSeed(workdir, unverified))
+			if err == nil || !strings.Contains(string(out), "Git seed tree verification failed") {
+				t.Fatalf("unverified seed err=%v\n%s", err, out)
+			}
+			requireWindowsExactGitRoot(t, workdir)
+			if got, readErr := os.ReadFile(marker); readErr != nil || string(got) != "preserve\n" {
+				t.Fatalf("unverified seed replaced existing root: data=%q err=%v", got, readErr)
+			}
+			if missingIndex != "" {
+				if _, statErr := os.Stat(missingIndex); !os.IsNotExist(statErr) {
+					t.Fatalf("unverified seed changed missing-index root: %v", statErr)
+				}
+			}
+
+			if out, err := runDecodedWindowsPowerShell(t, windowsGitSeed(workdir, plan)); err != nil {
+				t.Fatalf("verified seed failed: %v\n%s", err, out)
+			}
+			requireWindowsGitWorkspaceState(t, workdir, plan)
+			if _, err := os.Stat(marker); !os.IsNotExist(err) {
+				t.Fatalf("verified seed did not replace unusable root: %v", err)
+			}
+		})
+	}
+}
+
+func TestWindowsGitCoherenceSupportsDetachedSparseSplitAndLinkedIndexes(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("native Windows PowerShell execution is covered by Windows CI")
+	}
+	f := newGitCoherenceFixture(t)
+	plan := f.plan(t, f.b)
+	for _, mode := range []string{"detached", "sparse-index", "split-index", "linked-worktree"} {
+		t.Run(mode, func(t *testing.T) {
+			var workdir string
+			switch mode {
+			case "linked-worktree":
+				workdir = f.linkedWorkspace(t, f.a)
+				gitFile, err := os.ReadFile(filepath.Join(workdir, ".git"))
+				if err != nil || !strings.HasPrefix(string(gitFile), "gitdir: ") {
+					t.Fatalf("linked worktree .git=%q err=%v", gitFile, err)
+				}
+			default:
+				workdir = f.workspace(t, f.a, false)
+			}
+			switch mode {
+			case "sparse-index":
+				runGit(t, workdir, "sparse-checkout", "init", "--cone", "--sparse-index")
+				runGit(t, workdir, "sparse-checkout", "set", "src")
+			case "split-index":
+				runGit(t, workdir, "update-index", "--split-index")
+			}
+			requireWindowsExactGitRoot(t, workdir)
+			requireGitOutput(t, workdir, f.a, "rev-parse", "HEAD")
+			mustWriteTestFile(t, filepath.Join(workdir, "tracked.txt"), "B\n")
+
+			if out, err := runDecodedWindowsPowerShell(t, windowsGitCoherence(workdir, plan)); err != nil {
+				t.Fatalf("Windows coherence failed: %v\n%s", err, out)
+			}
+			requireWindowsGitWorkspaceState(t, workdir, plan)
+		})
+	}
+}
+
+func TestWindowsGitCoherenceRollbackRestoresIndexAfterSymbolicHeadFailure(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("native Windows PowerShell execution is covered by Windows CI")
+	}
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f := newGitCoherenceFixture(t)
+	plan := f.plan(t, f.b)
+	for _, tc := range []struct {
+		name                  string
+		symbolic              bool
+		injectRollbackFailure bool
+		wantError             string
+	}{
+		{name: "symbolic", symbolic: true, injectRollbackFailure: true, wantError: "Git symbolic HEAD rollback failed"},
+		{name: "detached", wantError: "Git coherence verification failed"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			workdir := f.workspace(t, f.a, tc.symbolic)
+			mustWriteTestFile(t, filepath.Join(workdir, "tracked.txt"), "B\n")
+			beforeIndex := coherenceIndexBytes(t, workdir)
+			beforeTree := gitOutput(workdir, "write-tree")
+			beforeSym := gitOutput(workdir, "symbolic-ref", "-q", "HEAD")
+			if beforeTree == plan.Tree || tc.symbolic != (beforeSym != "") {
+				t.Fatalf("invalid rollback fixture: tree=%q target=%q sym=%q", beforeTree, plan.Tree, beforeSym)
+			}
+
+			shimDir := t.TempDir()
+			tracePath := filepath.Join(shimDir, "git-shim.trace")
+			beforeIndexPath := filepath.Join(shimDir, "before.index")
+			if err := os.WriteFile(beforeIndexPath, beforeIndex, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			injectRollbackFailure := "$false"
+			if tc.injectRollbackFailure {
+				injectRollbackFailure = "$true"
+			}
+			script := `$ErrorActionPreference = "Stop"
+$script:realGit = ` + psQuote(realGit) + `
+$script:workdir = ` + psQuote(workdir) + `
+$script:indexPath = ` + psQuote(coherenceIndexPath(t, workdir)) + `
+$script:beforeIndexPath = ` + psQuote(beforeIndexPath) + `
+$script:expectedOldHead = ` + psQuote(f.a) + `
+$script:expectedTarget = ` + psQuote(plan.Target) + `
+$script:expectedSymbolicHead = ` + psQuote(beforeSym) + `
+$script:injectRollbackFailure = ` + injectRollbackFailure + `
+$script:tracePath = ` + psQuote(tracePath) + `
+$script:gitShimCalls = 0
+$script:gitTrace = [Collections.Generic.List[string]]::new()
+$script:headUpdateObserved = $false
+$script:indexReplacementObserved = $false
+$script:targetHeadObserved = $false
+$script:symbolicHeadPreservedAtTarget = $false
+$script:postHeadFailureInjected = $false
+$script:branchRollbackCallObserved = $false
+$script:symbolicHeadRestoredBeforeFailure = $false
+$script:branchRollbackFailureInjected = $false
+function git {
+  $gitArgs = @($args | ForEach-Object { [string]$_ })
+  $script:gitShimCalls++
+  $null = $script:gitTrace.Add(($gitArgs -join '|'))
+  $verb = if ($gitArgs.Count -gt 0) { $gitArgs[0] } else { "" }
+  $isPostHeadVerify = $gitArgs.Count -ge 3 -and $verb -eq 'rev-parse' -and $gitArgs[1] -eq '--verify' -and $gitArgs[2] -eq 'HEAD^{commit}'
+  if ($script:headUpdateObserved -and -not $script:postHeadFailureInjected -and $isPostHeadVerify) {
+    $indexBytes = [IO.File]::ReadAllBytes($script:indexPath)
+    if ([Linq.Enumerable]::SequenceEqual($indexBytes, [IO.File]::ReadAllBytes($script:beforeIndexPath))) {
+      throw "Git shim reached post-HEAD verification before index replacement"
+    }
+    $verifyPattern = [IO.Path]::GetFileName($script:indexPath) + ".crabbox.*.verify"
+    $verifyFiles = @(Get-ChildItem -LiteralPath ([IO.Path]::GetDirectoryName($script:indexPath)) -Filter $verifyPattern -File)
+    if ($verifyFiles.Count -ne 1 -or -not [Linq.Enumerable]::SequenceEqual($indexBytes, [IO.File]::ReadAllBytes($verifyFiles[0].FullName))) {
+      throw "Git shim did not observe the verified candidate index after replacement"
+    }
+    $installedHead = & $script:realGit -C $script:workdir rev-parse --verify 'HEAD^{commit}' 2>$null
+    $headExit = $LASTEXITCODE
+    if ($headExit -ne 0 -or ([string]$installedHead).Trim() -ne $script:expectedTarget) {
+      throw "Git shim reached post-HEAD verification before HEAD replacement"
+    }
+	    if ($script:expectedSymbolicHead) {
+	      $installedSym = & $script:realGit -C $script:workdir symbolic-ref -q HEAD 2>$null
+	      $symExit = $LASTEXITCODE
+	      $installedBranch = & $script:realGit -C $script:workdir rev-parse --verify ($script:expectedSymbolicHead + "^{commit}") 2>$null
+	      $branchExit = $LASTEXITCODE
+	      if ($symExit -eq 0 -or -not [string]::IsNullOrWhiteSpace([string]$installedSym) -or $branchExit -ne 0 -or ([string]$installedBranch).Trim() -ne $script:expectedOldHead) {
+	        throw "Git shim did not observe detached HEAD with the symbolic branch preserved"
+	      }
+	      $script:symbolicHeadPreservedAtTarget = $true
+    }
+    $script:indexReplacementObserved = $true
+    $script:targetHeadObserved = $true
+    $script:postHeadFailureInjected = $true
+    $global:LASTEXITCODE = 95
+    return
+  }
+	  $isBranchRollback = $gitArgs.Count -ge 3 -and $verb -eq 'symbolic-ref' -and $gitArgs[1] -eq 'HEAD' -and $gitArgs[2] -eq $script:expectedSymbolicHead
+  if ($script:injectRollbackFailure -and $script:postHeadFailureInjected -and $isBranchRollback -and -not $script:branchRollbackFailureInjected) {
+    $script:branchRollbackCallObserved = $true
+    & $script:realGit @gitArgs
+    $rollbackExit = $LASTEXITCODE
+    if ($rollbackExit -ne 0) {
+      return
+    }
+    $restoredSym = & $script:realGit -C $script:workdir symbolic-ref -q HEAD 2>$null
+    $symExit = $LASTEXITCODE
+    $restoredBranch = & $script:realGit -C $script:workdir rev-parse --verify ($script:expectedSymbolicHead + "^{commit}") 2>$null
+    $branchExit = $LASTEXITCODE
+    if ($symExit -ne 0 -or ([string]$restoredSym).Trim() -ne $script:expectedSymbolicHead -or $branchExit -ne 0 -or ([string]$restoredBranch).Trim() -ne $script:expectedOldHead) {
+	      throw "Git shim did not restore symbolic HEAD without changing its branch before fault injection"
+    }
+    $script:symbolicHeadRestoredBeforeFailure = $true
+    $script:branchRollbackFailureInjected = $true
+    $global:LASTEXITCODE = 96
+    return
+  }
+  & $script:realGit @gitArgs
+  $gitExit = $LASTEXITCODE
+	  $isDetachedUpdate = $gitArgs.Count -ge 5 -and $verb -eq 'update-ref' -and $gitArgs[1] -eq '--no-deref' -and $gitArgs[2] -eq 'HEAD' -and $gitArgs[3] -eq $script:expectedTarget -and $gitArgs[4] -eq $script:expectedOldHead
+	  if ($gitExit -eq 0 -and $isDetachedUpdate) {
+    $script:headUpdateObserved = $true
+  }
+}
+$script:coherenceError = $null
+try {
+  & {
+` + decodePowerShellCommand(t, windowsGitCoherence(workdir, plan)) + `
+  }
+} catch {
+  $script:coherenceError = $_
+}
+@(
+  "calls=$($script:gitShimCalls)"
+  "head-update=$($script:headUpdateObserved)"
+  "index-installed=$($script:indexReplacementObserved)"
+  "target-head=$($script:targetHeadObserved)"
+  "symbolic-head-at-target=$($script:symbolicHeadPreservedAtTarget)"
+  "post-head-failure=$($script:postHeadFailureInjected)"
+  "branch-rollback-call=$($script:branchRollbackCallObserved)"
+  "symbolic-head-restored=$($script:symbolicHeadRestoredBeforeFailure)"
+  "branch-rollback-failure=$($script:branchRollbackFailureInjected)"
+  "coherence-error=$(if ($script:coherenceError) { $script:coherenceError.Exception.Message } else { '<none>' })"
+  $script:gitTrace | ForEach-Object { "git=$_" }
+) | Set-Content -LiteralPath $script:tracePath -Encoding ASCII
+if ($script:gitShimCalls -eq 0) { throw "Git shim was not invoked" }
+if (-not $script:headUpdateObserved) { throw "Git shim did not observe the HEAD update" }
+if (-not $script:postHeadFailureInjected) { throw "Git shim did not inject the post-HEAD verification failure" }
+if ($script:injectRollbackFailure -and -not $script:branchRollbackFailureInjected) { throw "Git shim did not inject the symbolic branch rollback failure" }
+if (-not $script:injectRollbackFailure -and $script:branchRollbackFailureInjected) { throw "Git shim unexpectedly injected a detached HEAD rollback failure" }
+if ($null -eq $script:coherenceError) { throw "Git coherence unexpectedly succeeded" }
+throw $script:coherenceError
+`
+			out, err := runWindowsPowerShellScript(t, script)
+			if err == nil {
+				t.Fatalf("injected rollback failure unexpectedly succeeded\n%s", out)
+			}
+			trace, readErr := os.ReadFile(tracePath)
+			if readErr != nil {
+				t.Fatalf("read Git shim trace: %v", readErr)
+			}
+			if !strings.Contains(string(out), tc.wantError) {
+				t.Fatalf("unexpected rollback failure: %v\n%s\ntrace:\n%s", err, out, trace)
+			}
+			for _, want := range []string{
+				"head-update=True",
+				"index-installed=True",
+				"target-head=True",
+				"post-head-failure=True",
+			} {
+				if !strings.Contains(string(trace), want) {
+					t.Fatalf("Git shim trace missing %q:\n%s", want, trace)
+				}
+			}
+			for _, state := range []struct {
+				key  string
+				want bool
+			}{
+				{key: "branch-rollback-call", want: tc.injectRollbackFailure},
+				{key: "symbolic-head-at-target", want: tc.symbolic},
+				{key: "symbolic-head-restored", want: tc.injectRollbackFailure},
+				{key: "branch-rollback-failure", want: tc.injectRollbackFailure},
+			} {
+				if got := strings.Contains(string(trace), state.key+"=True"); got != state.want {
+					t.Fatalf("Git shim trace %s=%t want %t:\n%s", state.key, got, state.want, trace)
+				}
+			}
+			if !strings.Contains(string(trace), "calls=") || strings.Contains(string(trace), "calls=0") {
+				t.Fatalf("Git shim was not invoked:\n%s", trace)
+			}
+			if afterIndex := coherenceIndexBytes(t, workdir); !bytes.Equal(afterIndex, beforeIndex) {
+				t.Fatal("Windows rollback did not restore the original index")
+			}
+			requireGitOutput(t, workdir, beforeTree, "write-tree")
+			requireGitOutput(t, workdir, f.a, "rev-parse", "HEAD")
+			requireGitOutput(t, workdir, beforeSym, "symbolic-ref", "-q", "HEAD")
+			if tc.symbolic {
+				requireGitOutput(t, workdir, f.a, "rev-parse", beforeSym+"^{commit}")
+			}
+		})
+	}
+}
+
+func TestRemoteGitSeedRemovesFailedCheckout(t *testing.T) {
+	got := remoteGitSeed("/work/repo", gitCoherencePlan{RemoteURL: "https://github.com/openclaw/crabbox.git", Target: "missing-sha", Tree: "tree", Branch: "main"})
+	for _, want := range []string{
+		"git -C \"$tmp\" checkout --quiet --detach",
+		"cleanup_seed() { rm -rf -- \"$tmp\"; }",
+		"trap cleanup_seed EXIT",
+		"mv -- \"$tmp\" \"$workdir\"",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("remoteGitSeed missing %q in %q", want, got)
@@ -2104,8 +3268,8 @@ func TestGitSeedCommandsRejectCredentialBearingRemote(t *testing.T) {
 	} {
 		t.Run(remoteName, func(t *testing.T) {
 			for target, command := range map[string]string{
-				"linux":   remoteGitSeed("/work/repo", remote, "abc123"),
-				"windows": windowsGitSeed(`C:\crabbox\repo`, remote, "abc123"),
+				"linux":   remoteGitSeed("/work/repo", gitCoherencePlan{RemoteURL: remote, Target: "abc123", Tree: "tree", Branch: "main"}),
+				"windows": windowsGitSeed(`C:\crabbox\repo`, gitCoherencePlan{RemoteURL: remote, Target: "abc123", Tree: "tree", Branch: "main"}),
 			} {
 				t.Run(target, func(t *testing.T) {
 					if strings.Contains(command, secret) || strings.Contains(command, "example.test") {
@@ -2133,20 +3297,44 @@ func TestRemoteGitSeedLocalCanary(t *testing.T) {
 	runGit(t, source, "add", ".")
 	runGit(t, source, "commit", "-m", "seed")
 	head := gitOutput(source, "rev-parse", "HEAD")
+	tree := gitOutput(source, "rev-parse", "HEAD^{tree}")
+	branch := gitOutput(source, "branch", "--show-current")
 	origin := filepath.Join(root, "origin.git")
 	clone := exec.Command("git", "clone", "--bare", source, origin)
 	if out, err := clone.CombinedOutput(); err != nil {
 		t.Fatalf("create bare origin: %v\n%s", err, out)
 	}
+	plan := gitCoherencePlan{RemoteURL: origin, Target: head, Tree: tree, Branch: branch}
+	runSeed := func(label, workdir string) {
+		t.Helper()
+		seed := exec.Command("bash", "-lc", remoteGitSeed(workdir, plan))
+		if out, err := seed.CombinedOutput(); err != nil {
+			t.Fatalf("%s: %v\n%s", label, err, out)
+		}
+	}
+	requireSeeded := func(workdir string) {
+		t.Helper()
+		if got := gitOutput(workdir, "remote", "get-url", "origin"); got != origin {
+			t.Fatalf("seeded origin=%q want %q", got, origin)
+		}
+		if got := gitOutput(workdir, "rev-parse", "HEAD"); got != head {
+			t.Fatalf("seeded HEAD=%q want %q", got, head)
+		}
+		if got := gitOutput(workdir, "write-tree"); got != tree {
+			t.Fatalf("seeded tree=%q want %q", got, tree)
+		}
+		index := gitOutput(workdir, "rev-parse", "--git-path", "index")
+		if !filepath.IsAbs(index) {
+			index = filepath.Join(workdir, index)
+		}
+		if _, err := os.Stat(index); err != nil {
+			t.Fatalf("seeded index missing: %v", err)
+		}
+	}
 
 	workdir := filepath.Join(root, "safe-workdir")
-	seed := exec.Command("bash", "-lc", remoteGitSeed(workdir, origin, head))
-	if out, err := seed.CombinedOutput(); err != nil {
-		t.Fatalf("run safe seed: %v\n%s", err, out)
-	}
-	if got := gitOutput(workdir, "remote", "get-url", "origin"); got != origin {
-		t.Fatalf("seeded origin=%q want %q", got, origin)
-	}
+	runSeed("run safe seed", workdir)
+	requireSeeded(workdir)
 	proof, err := os.ReadFile(filepath.Join(workdir, "proof.txt"))
 	if err != nil {
 		t.Fatal(err)
@@ -2154,14 +3342,96 @@ func TestRemoteGitSeedLocalCanary(t *testing.T) {
 	if got := strings.TrimSpace(string(proof)); got != "safe seed" {
 		t.Fatalf("seeded proof=%q", got)
 	}
+	preserved := filepath.Join(workdir, "local-overlay.txt")
+	mustWriteTestFile(t, preserved, "preserve\n")
+	runGit(t, workdir, "remote", "set-url", "origin", filepath.Join(root, "wrong.git"))
+	runSeed("reuse valid workspace", workdir)
+	requireSeeded(workdir)
+	if got, err := os.ReadFile(preserved); err != nil || string(got) != "preserve\n" {
+		t.Fatalf("valid reusable workspace was replaced: data=%q err=%v", got, err)
+	}
+
+	unbornWorkdir := filepath.Join(root, "unborn-workdir")
+	if err := os.Mkdir(unbornWorkdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, unbornWorkdir, "init")
+	mustWriteTestFile(t, filepath.Join(unbornWorkdir, "stale-unborn.txt"), "stale\n")
+	runSeed("replace unborn workspace", unbornWorkdir)
+	requireSeeded(unbornWorkdir)
+	if _, err := os.Stat(filepath.Join(unbornWorkdir, "stale-unborn.txt")); !os.IsNotExist(err) {
+		t.Fatalf("unborn workspace was reused instead of reseeded: %v", err)
+	}
+
+	missingIndexWorkdir := filepath.Join(root, "missing-index-workdir")
+	if out, err := exec.Command("git", "clone", "--quiet", origin, missingIndexWorkdir).CombinedOutput(); err != nil {
+		t.Fatalf("clone missing-index fixture: %v\n%s", err, out)
+	}
+	missingIndex := gitOutput(missingIndexWorkdir, "rev-parse", "--git-path", "index")
+	if !filepath.IsAbs(missingIndex) {
+		missingIndex = filepath.Join(missingIndexWorkdir, missingIndex)
+	}
+	if err := os.Remove(missingIndex); err != nil {
+		t.Fatal(err)
+	}
+	mustWriteTestFile(t, filepath.Join(missingIndexWorkdir, "stale-missing-index.txt"), "stale\n")
+	runSeed("replace missing-index workspace", missingIndexWorkdir)
+	requireSeeded(missingIndexWorkdir)
+	if _, err := os.Stat(filepath.Join(missingIndexWorkdir, "stale-missing-index.txt")); !os.IsNotExist(err) {
+		t.Fatalf("missing-index workspace was reused instead of reseeded: %v", err)
+	}
+
+	nestedWorkdir := filepath.Join(source, "nested-workdir")
+	if err := os.Mkdir(nestedWorkdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runSeed("seed inside ancestor repository", nestedWorkdir)
+	wantNestedRoot, err := filepath.EvalSymlinks(nestedWorkdir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := gitOutput(nestedWorkdir, "rev-parse", "--show-toplevel"); got != wantNestedRoot {
+		t.Fatalf("ancestor repository counted as nested seed root: got %q want %q", got, wantNestedRoot)
+	}
 
 	blockedWorkdir := filepath.Join(root, "blocked-workdir")
-	blocked := exec.Command("bash", "-lc", remoteGitSeed(blockedWorkdir, "https://runner:do-not-forward@example.test/repo.git", head))
+	blockedRemote := "https://runner:" + "do-not-forward" + "@example.test/repo.git"
+	blocked := exec.Command("bash", "-lc", remoteGitSeed(blockedWorkdir, gitCoherencePlan{RemoteURL: blockedRemote, Target: head, Tree: tree, Branch: branch}))
 	if out, err := blocked.CombinedOutput(); err != nil {
 		t.Fatalf("run blocked seed: %v\n%s", err, out)
 	}
 	if _, err := os.Stat(blockedWorkdir); !os.IsNotExist(err) {
 		t.Fatalf("credential-blocked seed created workdir: %v", err)
+	}
+}
+
+func TestRemoteGitSeedSupportsSeedOnlyPlanWithoutTree(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell Git seed fixture")
+	}
+	f := newGitCoherenceFixture(t)
+	plan := gitCoherencePlan{
+		RemoteURL: f.origin,
+		Target:    f.b,
+		Branch:    "main",
+	}
+	if !plan.seedEnabled() || plan.enabled() {
+		t.Fatalf("expected seed-only plan, got %#v", plan)
+	}
+	workdir := filepath.Join(t.TempDir(), "seed-only")
+	if out, err := exec.Command("bash", "-lc", remoteGitSeed(workdir, plan)).CombinedOutput(); err != nil {
+		t.Fatalf("seed-only Git seed failed: %v\n%s", err, out)
+	}
+	requireGitOutput(t, workdir, f.b, "rev-parse", "HEAD")
+	if tree := gitOutput(workdir, "write-tree"); tree == "" {
+		t.Fatal("seed-only Git seed produced no usable index tree")
+	}
+	index := gitOutput(workdir, "rev-parse", "--git-path", "index")
+	if !filepath.IsAbs(index) {
+		index = filepath.Join(workdir, index)
+	}
+	if _, err := os.Stat(index); err != nil {
+		t.Fatalf("seed-only Git seed index missing: %v", err)
 	}
 }
 
@@ -2393,9 +3663,7 @@ func mustWriteTestFailingCommand(t *testing.T, dir, name string, code int) {
 
 func TestRemoteSyncMetadataUsesGitDirForGitWorktree(t *testing.T) {
 	workdir := t.TempDir()
-	if err := os.Mkdir(filepath.Join(workdir, ".git"), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	runGit(t, workdir, "init")
 	cmd := exec.Command("bash", "-lc", remoteWriteSyncManifestNew(workdir))
 	cmd.Stdin = strings.NewReader("tracked.txt\x00")
 	if out, err := cmd.CombinedOutput(); err != nil {
@@ -2828,5 +4096,8 @@ func TestRemoteSyncSanityReportsDeletionSample(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Fatalf("remoteSyncSanity() missing %q in %q", want, got)
 		}
+	}
+	if strings.Contains(got, "/tmp/crabbox-git-status") {
+		t.Fatalf("remoteSyncSanity() uses a global status file: %q", got)
 	}
 }

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -3394,9 +3394,12 @@ func TestRemoteGitSeedLocalCanary(t *testing.T) {
 		t.Fatalf("ancestor repository counted as nested seed root: got %q want %q", got, wantNestedRoot)
 	}
 
+	renderGitSeed := remoteGitSeed
+	remoteGitSeed := func(workdir, remoteURL, target string) string {
+		return renderGitSeed(workdir, gitCoherencePlan{RemoteURL: remoteURL, Target: target, Tree: tree, Branch: branch})
+	}
 	blockedWorkdir := filepath.Join(root, "blocked-workdir")
-	blockedRemote := "https://runner:" + "do-not-forward" + "@example.test/repo.git"
-	blocked := exec.Command("bash", "-lc", remoteGitSeed(blockedWorkdir, gitCoherencePlan{RemoteURL: blockedRemote, Target: head, Tree: tree, Branch: branch}))
+	blocked := exec.Command("bash", "-lc", remoteGitSeed(blockedWorkdir, "https://runner:do-not-forward@example.test/repo.git", head))
 	if out, err := blocked.CombinedOutput(); err != nil {
 		t.Fatalf("run blocked seed: %v\n%s", err, out)
 	}

--- a/internal/cli/sync_windows_target.go
+++ b/internal/cli/sync_windows_target.go
@@ -9,20 +9,16 @@ import (
 	"time"
 )
 
-func syncWindowsNative(ctx context.Context, target SSHTarget, repo Repo, cfg Config, workdir string, manifest SyncManifest, stdout, stderr anyWriter, opts rsyncOptions) error {
+func syncWindowsNative(ctx context.Context, target SSHTarget, repo Repo, cfg Config, coherence gitCoherencePlan, workdir string, manifest SyncManifest, stdout, stderr anyWriter, opts rsyncOptions) error {
 	if err := runSSHQuiet(ctx, target, windowsPrepareWorkdir(workdir, cfg.Sync.Delete)); err != nil {
 		return exit(7, "prepare remote workdir: %v", err)
 	}
-	gitSeed, credentialBlocked := syncGitSeedDecision(cfg, repo)
-	if credentialBlocked {
-		warnCredentialBearingGitSeed(stderr)
-	}
-	if gitSeed {
-		if err := runSSHQuiet(ctx, target, windowsGitSeed(workdir, repo.RemoteURL, repo.Head)); err != nil {
+	if coherence.seedEnabled() {
+		if err := runSSHQuiet(ctx, target, windowsGitSeed(workdir, coherence)); err != nil {
 			fmt.Fprintf(stderr, "warning: remote git seed failed: %v\n", err)
 		}
 	}
-	if opts.FullResync && gitSeed {
+	if opts.FullResync && coherence.seedEnabled() {
 		// Git seed restores HEAD; full resync must remove paths absent locally before overlay.
 		manifestData := manifest.NUL()
 		manifestInput := fmt.Sprintf("%d\n", len(manifestData)) + string(manifestData) + string(manifest.DeletedNUL())
@@ -50,6 +46,11 @@ func syncWindowsNative(ctx context.Context, target SSHTarget, repo Repo, cfg Con
 	}
 	if err != nil {
 		return exit(6, "archive sync failed: %v", err)
+	}
+	if coherence.enabled() {
+		if err := runSSHQuiet(ctx, target, windowsGitCoherence(workdir, coherence)); err != nil {
+			return exit(6, "align remote Git metadata: %v", err)
+		}
 	}
 	return nil
 }
@@ -81,30 +82,220 @@ tar -xzf - -C $workdir
 `)
 }
 
-func windowsGitSeed(workdir, remoteURL, head string) string {
-	remoteURL = normalizeGitRemoteURL(remoteURL)
-	if remoteURL == "" || head == "" {
+// Git can report a long path for an 8.3 workdir alias. Compare handle-canonical
+// paths so aliases match without accepting an ancestor or sibling repository.
+func windowsGitRootIdentityScript() string {
+	return `Add-Type -Name GitRootIdentity -Namespace Cbx -MemberDefinition '[DllImport("kernel32.dll",CharSet=CharSet.Unicode,SetLastError=true)]public static extern uint GetFinalPathNameByHandle(Microsoft.Win32.SafeHandles.SafeFileHandle h,System.Text.StringBuilder p,uint n,uint f);[DllImport("kernel32.dll",CharSet=CharSet.Unicode,SetLastError=true)]public static extern Microsoft.Win32.SafeHandles.SafeFileHandle CreateFile(string p,uint a,System.IO.FileShare s,System.IntPtr z,System.IO.FileMode m,uint f,System.IntPtr t);'
+function Get-CrabboxFinalDirectoryPath([string]$Path) {
+  $share = [IO.FileShare]::ReadWrite -bor [IO.FileShare]::Delete
+  $handle = [Cbx.GitRootIdentity]::CreateFile($Path, 0, $share, [IntPtr]::Zero, [IO.FileMode]::Open, 0x02000000, [IntPtr]::Zero)
+  if ($handle.IsInvalid) { throw "directory identity open failed" }
+  try {
+    $buffer = New-Object Text.StringBuilder 32768
+    if (-not [Cbx.GitRootIdentity]::GetFinalPathNameByHandle($handle, $buffer, $buffer.Capacity, 0)) { throw "directory identity lookup failed" }
+    $finalPath = $buffer.ToString()
+  } finally {
+    $handle.Dispose()
+  }
+  if ($finalPath.StartsWith('\\?\UNC\')) { $finalPath = '\\' + $finalPath.Substring(8) }
+  elseif ($finalPath.StartsWith('\\?\')) { $finalPath = $finalPath.Substring(4) }
+  return $finalPath.TrimEnd('\')
+}
+function Test-CrabboxSameDirectory([string]$Left, [string]$Right) {
+  try {
+    $leftPath = Get-CrabboxFinalDirectoryPath $Left
+    $rightPath = Get-CrabboxFinalDirectoryPath $Right
+  } catch {
+    return $false
+  }
+  return [string]::Equals($leftPath, $rightPath, [StringComparison]::OrdinalIgnoreCase)
+}
+`
+}
+
+func windowsGitSeed(workdir string, plan gitCoherencePlan) string {
+	if !plan.seedEnabled() {
 		return powershellCommand(`exit 0`)
 	}
 	return powershellCommand(`$ErrorActionPreference = "Stop"
 $workdir = ` + psQuote(workdir) + `
+$expectedOrigin = ` + psQuote(plan.RemoteURL) + `
+$expectedTree = ` + psQuote(plan.Tree) + `
 $parent = Split-Path -Parent $workdir
 New-Item -ItemType Directory -Force -Path $parent | Out-Null
-if (-not (Test-Path -LiteralPath (Join-Path $workdir ".git"))) {
-  $tmp = Join-Path $parent (".seed-" + [System.Guid]::NewGuid().ToString("N"))
-  git clone --quiet --filter=blob:none --no-checkout ` + psQuote(remoteURL) + ` $tmp
-  Push-Location $tmp
-  git fetch --quiet --depth=1 origin ` + psQuote(head) + ` 2>$null
-  git checkout --quiet ` + psQuote(head) + ` 2>$null
-  if ($LASTEXITCODE -ne 0) { git checkout --quiet FETCH_HEAD 2>$null }
-  Pop-Location
-  if (Test-Path -LiteralPath $workdir) {
-    Get-ChildItem -LiteralPath $workdir -Force | Remove-Item -Recurse -Force
+` + windowsGitRootIdentityScript() + `
+function Test-ExactGitRoot([string]$Path) {
+  $ErrorActionPreference = "Continue"
+  if (-not (Test-Path -LiteralPath $Path -PathType Container)) { return $false }
+  $reportedRoot = & git -C $Path rev-parse --show-toplevel 2>$null
+  $gitStatus = $LASTEXITCODE
+  if ($gitStatus -ne 0 -or -not $reportedRoot) { return $false }
+  $reportedRoot = ([string]$reportedRoot).Trim()
+  return (Test-CrabboxSameDirectory $Path $reportedRoot)
+}
+function Test-UsableGitWorkspace([string]$Path) {
+  $ErrorActionPreference = "Continue"
+  if (-not (Test-ExactGitRoot $Path)) { return $false }
+  $head = & git -C $Path rev-parse --verify 'HEAD^{commit}' 2>$null
+  $headStatus = $LASTEXITCODE
+  if ($headStatus -ne 0 -or -not $head) { return $false }
+  $index = & git -C $Path rev-parse --git-path index 2>$null
+  $indexStatus = $LASTEXITCODE
+  if ($indexStatus -ne 0 -or -not $index) { return $false }
+  $index = ([string]$index).Trim()
+  if (-not [IO.Path]::IsPathRooted($index)) { $index = [IO.Path]::GetFullPath((Join-Path $Path $index)) }
+  if (-not (Test-Path -LiteralPath $index -PathType Leaf)) { return $false }
+  $tree = & git -C $Path write-tree 2>$null
+  $treeStatus = $LASTEXITCODE
+  return $treeStatus -eq 0 -and [bool]$tree
+}
+function Repair-Origin([string]$Path) {
+  $ErrorActionPreference = "Continue"
+  & git -C $Path remote get-url origin 2>$null | Out-Null
+  $originExists = $LASTEXITCODE -eq 0
+  if ($originExists) {
+    & git -C $Path remote set-url origin $expectedOrigin 2>$null
   } else {
-    New-Item -ItemType Directory -Force -Path $workdir | Out-Null
+    & git -C $Path remote add origin $expectedOrigin 2>$null
   }
-  Get-ChildItem -LiteralPath $tmp -Force | Move-Item -Destination $workdir -Force
-  Remove-Item -LiteralPath $tmp -Force
+  if ($LASTEXITCODE -ne 0) { throw "Git origin repair failed" }
+  $actualOrigin = & git -C $Path remote get-url origin 2>$null
+  if ($LASTEXITCODE -ne 0 -or ([string]$actualOrigin).Trim() -ne $expectedOrigin) { throw "Git origin verification failed" }
+}
+if (Test-UsableGitWorkspace $workdir) {
+  Repair-Origin $workdir
+  exit 0
+}
+$tmp = Join-Path $parent (".seed-" + [System.Guid]::NewGuid().ToString("N"))
+try {
+  & git clone --quiet --filter=blob:none --no-checkout --single-branch --branch ` + psQuote(plan.Branch) + ` $expectedOrigin $tmp
+  if ($LASTEXITCODE -ne 0) { throw "Git seed clone failed" }
+  & git -C $tmp checkout --quiet --detach ` + psQuote(plan.Target) + `
+  if ($LASTEXITCODE -ne 0) { throw "Git seed checkout failed" }
+  $seedHead = & git -C $tmp rev-parse --verify 'HEAD^{commit}' 2>$null
+  if ($LASTEXITCODE -ne 0 -or ([string]$seedHead).Trim() -ne ` + psQuote(plan.Target) + `) { throw "Git seed verification failed" }
+  if (-not (Test-UsableGitWorkspace $tmp)) { throw "Git seed workspace verification failed" }
+  if ($expectedTree) {
+    $seedTree = & git -C $tmp write-tree 2>$null
+    if ($LASTEXITCODE -ne 0 -or ([string]$seedTree).Trim() -ne $expectedTree) { throw "Git seed tree verification failed" }
+  }
+  Repair-Origin $tmp
+  if (Test-Path -LiteralPath $workdir) {
+    Remove-Item -LiteralPath $workdir -Recurse -Force
+  }
+  Move-Item -LiteralPath $tmp -Destination $workdir
+  $tmp = $null
+} finally {
+  if ($tmp -and (Test-Path -LiteralPath $tmp)) {
+    Remove-Item -LiteralPath $tmp -Recurse -Force -ErrorAction SilentlyContinue
+  }
+}
+`)
+}
+
+func windowsGitCoherence(workdir string, plan gitCoherencePlan) string {
+	if !plan.enabled() {
+		return powershellCommand(`exit 0`)
+	}
+	return powershellCommand(`$ErrorActionPreference = "Stop"
+$workdir = ` + psQuote(workdir) + `; Set-Location -LiteralPath $workdir
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) { exit 0 }
+` + windowsGitRootIdentityScript() + `
+$reportedRoot = & git rev-parse --show-toplevel 2>$null
+if ($LASTEXITCODE -ne 0 -or -not $reportedRoot) { exit 0 }
+$reportedRoot = ([string]$reportedRoot).Trim()
+if (-not (Test-CrabboxSameDirectory $workdir $reportedRoot)) { exit 0 }
+$expectedOrigin = ` + psQuote(plan.RemoteURL) + `
+& git remote get-url origin 2>$null | Out-Null
+$originExists = $LASTEXITCODE -eq 0
+if ($originExists) {
+  & git remote set-url origin $expectedOrigin 2>$null
+} else {
+  & git remote add origin $expectedOrigin 2>$null
+}
+if ($LASTEXITCODE -ne 0) { throw "Git origin repair failed" }
+$actualOrigin = & git remote get-url origin 2>$null
+if ($LASTEXITCODE -ne 0 -or ([string]$actualOrigin).Trim() -ne $expectedOrigin) { throw "Git origin verification failed" }
+$target = ` + psQuote(plan.Target) + `; $tree = ` + psQuote(plan.Tree) + `; $tmpRef = "refs/crabbox/sync-" + [Guid]::NewGuid().ToString("N")
+& git fetch --quiet --no-tags $expectedOrigin ("+refs/heads/" + ` + psQuote(plan.Branch) + ` + ":" + $tmpRef) 2>$null
+if ($LASTEXITCODE -ne 0) { & git update-ref -d $tmpRef 2>$null; $null = $LASTEXITCODE; throw "Git coherence fetch failed" }
+& git merge-base --is-ancestor $target $tmpRef 2>$null
+$isAncestor = $LASTEXITCODE -eq 0
+if (-not $isAncestor) { & git update-ref -d $tmpRef 2>$null; $null = $LASTEXITCODE; throw "requested commit is not on advertised branch" }
+$targetTree = & git rev-parse --verify ($target + "^{tree}") 2>$null
+if ($LASTEXITCODE -ne 0 -or ([string]$targetTree).Trim() -ne $tree) { & git update-ref -d $tmpRef 2>$null; $null = $LASTEXITCODE; throw "requested Git tree verification failed" }
+$oldHead = & git rev-parse --verify 'HEAD^{commit}' 2>$null
+if ($LASTEXITCODE -ne 0 -or -not $oldHead) { throw "Git HEAD inspection failed" }
+$oldHead = ([string]$oldHead).Trim()
+$oldSymOutput = & git symbolic-ref -q HEAD 2>$null
+$oldSymStatus = $LASTEXITCODE
+if ($oldSymStatus -ne 0 -and $oldSymStatus -ne 1) { throw "Git symbolic HEAD inspection failed" }
+$oldSym = if ($oldSymStatus -eq 0) { ([string]$oldSymOutput).Trim() } else { $null }
+$index = & git rev-parse --git-path index 2>$null
+if ($LASTEXITCODE -ne 0 -or -not $index) { throw "Git index path inspection failed" }
+$index = ([string]$index).Trim(); if (-not [IO.Path]::IsPathRooted($index)) { $index = [IO.Path]::GetFullPath((Join-Path $workdir $index)) }
+$lock = $index + ".lock"; $marker = [Guid]::NewGuid().ToString("N"); $compare = $index + ".crabbox." + $marker + ".compare"; $candidate = $index + ".crabbox." + $marker + ".new"
+$verify = $index + ".crabbox." + $marker + ".verify"; $replaceBackup = $index + ".crabbox." + $marker + ".original"; $rollbackBackup = $index + ".crabbox." + $marker + ".rollback"
+$indexChanged = $false; $headChanged = $false
+try {
+  [IO.File]::Copy($index, $compare, $true)
+  & git read-tree --reset ("--index-output=" + $candidate) $target
+  if ($LASTEXITCODE -ne 0) { throw "target index creation failed" }
+  $env:GIT_INDEX_FILE = $candidate
+  $candidateTree = & git write-tree 2>$null
+  if ($LASTEXITCODE -ne 0 -or ([string]$candidateTree).Trim() -ne $tree) { throw "target index verification failed" }
+  Remove-Item Env:GIT_INDEX_FILE -ErrorAction SilentlyContinue
+  $stream = [IO.File]::Open($lock, [IO.FileMode]::CreateNew, [IO.FileAccess]::Write, [IO.FileShare]::None)
+  try { $bytes = [Text.Encoding]::ASCII.GetBytes($marker); $stream.Write($bytes, 0, $bytes.Length) } finally { $stream.Dispose() }
+  if (-not [Linq.Enumerable]::SequenceEqual([IO.File]::ReadAllBytes($index), [IO.File]::ReadAllBytes($compare))) { throw "Git index changed concurrently" }
+  [IO.File]::Copy($candidate, $verify, $true); [IO.File]::Replace($candidate, $index, $replaceBackup); $indexChanged = $true; $env:GIT_INDEX_FILE = $verify
+  if (-not [Linq.Enumerable]::SequenceEqual([IO.File]::ReadAllBytes($replaceBackup), [IO.File]::ReadAllBytes($compare))) { throw "Git index changed during replacement" }
+  if (-not [Linq.Enumerable]::SequenceEqual([IO.File]::ReadAllBytes($index), [IO.File]::ReadAllBytes($verify))) { throw "installed index bytes changed" }
+  $installedTree = & git write-tree 2>$null
+  if ($LASTEXITCODE -ne 0 -or ([string]$installedTree).Trim() -ne $tree) { throw "installed index verification failed" }
+  Remove-Item Env:GIT_INDEX_FILE -ErrorAction SilentlyContinue
+  & git update-ref --no-deref HEAD $target $oldHead
+  if ($LASTEXITCODE -ne 0) { throw "HEAD compare-and-swap failed" }; $headChanged = $true
+  $installedHead = & git rev-parse --verify 'HEAD^{commit}' 2>$null
+  if ($LASTEXITCODE -ne 0 -or ([string]$installedHead).Trim() -ne $target) { throw "Git coherence verification failed" }
+  if ($oldSym) {
+    $installedSym = & git symbolic-ref -q HEAD 2>$null
+    if ($LASTEXITCODE -eq 0 -or -not [string]::IsNullOrWhiteSpace([string]$installedSym)) { throw "Git HEAD remained symbolic during coherence" }
+    $preservedBranch = & git rev-parse --verify ($oldSym + '^{commit}') 2>$null
+    if ($LASTEXITCODE -ne 0 -or ([string]$preservedBranch).Trim() -ne $oldHead) { throw "Git symbolic branch changed during coherence" }
+  }
+} catch {
+  $failure = $_
+  $rollbackError = $null
+  Remove-Item Env:GIT_INDEX_FILE -ErrorAction SilentlyContinue
+  if ($headChanged) {
+    & git update-ref --no-deref HEAD $oldHead $target 2>$null
+    if ($LASTEXITCODE -ne 0) {
+      $rollbackError = [InvalidOperationException]::new("Git HEAD rollback failed")
+    } elseif ($oldSym) {
+      $preservedBranch = & git rev-parse --verify ($oldSym + '^{commit}') 2>$null
+      if ($LASTEXITCODE -ne 0 -or ([string]$preservedBranch).Trim() -ne $oldHead) {
+        $rollbackError = [InvalidOperationException]::new("Git symbolic branch changed during rollback")
+      } else {
+        & git symbolic-ref HEAD $oldSym 2>$null
+        if ($LASTEXITCODE -ne 0) { $rollbackError = [InvalidOperationException]::new("Git symbolic HEAD rollback failed") }
+      }
+    }
+  }
+  if ($indexChanged) {
+    try {
+      if ((Get-Content -Raw -LiteralPath $lock) -eq $marker -and (Test-Path -LiteralPath $replaceBackup -PathType Leaf) -and [Linq.Enumerable]::SequenceEqual([IO.File]::ReadAllBytes($index), [IO.File]::ReadAllBytes($verify))) {
+        [IO.File]::Replace($replaceBackup, $index, $rollbackBackup)
+      }
+    } catch {
+      if ($null -eq $rollbackError) { $rollbackError = $_ }
+    }
+  }
+  if ($rollbackError) { throw $rollbackError }
+  throw $failure
+} finally {
+  Remove-Item Env:GIT_INDEX_FILE -ErrorAction SilentlyContinue; & git update-ref -d $tmpRef 2>$null; $null = $LASTEXITCODE
+  Remove-Item -LiteralPath $compare,$candidate,$verify,$replaceBackup,$rollbackBackup -Force -ErrorAction SilentlyContinue; if ((Test-Path -LiteralPath $lock) -and (Get-Content -Raw -LiteralPath $lock) -eq $marker) { Remove-Item -LiteralPath $lock -Force }
 }
 `)
 }

--- a/internal/cli/workspace_owner.go
+++ b/internal/cli/workspace_owner.go
@@ -1,0 +1,788 @@
+package cli
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	workspaceOwnerTTL           = 45 * time.Second
+	workspaceOwnerRenewInterval = 10 * time.Second
+	workspaceOwnerWaitTimeout   = 2 * time.Minute
+	workspaceOwnerPollInterval  = time.Second
+	workspaceOwnerProgressEvery = 10 * time.Second
+)
+
+type workspaceOwnerAction string
+
+const (
+	workspaceOwnerAcquire workspaceOwnerAction = "acquire"
+	workspaceOwnerRenew   workspaceOwnerAction = "renew"
+	workspaceOwnerInspect workspaceOwnerAction = "inspect"
+	workspaceOwnerRelease workspaceOwnerAction = "release"
+)
+
+type workspaceOwnerRemoteRequest struct {
+	Action workspaceOwnerAction
+	Key    string
+	Token  string
+	TTL    time.Duration
+}
+
+type workspaceOwnerTransport interface {
+	Do(context.Context, workspaceOwnerRemoteRequest) (string, error)
+}
+
+type sshWorkspaceOwnerTransport struct {
+	target SSHTarget
+}
+
+func (t sshWorkspaceOwnerTransport) Do(ctx context.Context, req workspaceOwnerRemoteRequest) (string, error) {
+	remote := remoteWorkspaceOwnerCommand(t.target, req)
+	out, err := runSSHCombinedOutput(contextWithoutWorkspaceOwner(ctx), t.target, remote)
+	return strings.TrimSpace(out), err
+}
+
+type workspaceOwner struct {
+	target    SSHTarget
+	transport workspaceOwnerTransport
+	key       string
+	token     string
+	ttl       time.Duration
+	ctx       context.Context
+	cancel    context.CancelFunc
+	stop      chan struct{}
+	done      chan struct{}
+	closeOnce sync.Once
+
+	mu       sync.Mutex
+	renewErr error
+}
+
+type workspaceOwnerContextKey struct{}
+
+func contextWithWorkspaceOwner(ctx context.Context, owner *workspaceOwner) context.Context {
+	return context.WithValue(ctx, workspaceOwnerContextKey{}, owner)
+}
+
+func contextWithoutWorkspaceOwner(ctx context.Context) context.Context {
+	return context.WithValue(ctx, workspaceOwnerContextKey{}, (*workspaceOwner)(nil))
+}
+
+func workspaceOwnerFromContext(ctx context.Context) *workspaceOwner {
+	owner, _ := ctx.Value(workspaceOwnerContextKey{}).(*workspaceOwner)
+	return owner
+}
+
+func wrapWorkspaceOwnerRemote(ctx context.Context, remote string, preserveInput bool) string {
+	owner := workspaceOwnerFromContext(ctx)
+	if owner == nil {
+		return remote
+	}
+	if preserveInput {
+		return owner.WrapInputCommand(remote)
+	}
+	return owner.WrapCommand(remote)
+}
+
+func workspaceOwnerKey(leaseID string) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte("crabbox-workspace-owner-v1\x00"+leaseID)))
+}
+
+func shouldAcquireWorkspaceOwner(acquired bool) bool {
+	return !acquired
+}
+
+func acquireWorkspaceOwner(ctx context.Context, target SSHTarget, leaseID string, stderr io.Writer) (*workspaceOwner, error) {
+	return acquireWorkspaceOwnerWithTransport(ctx, target, leaseID, stderr, sshWorkspaceOwnerTransport{target: target}, workspaceOwnerWaitTimeout, workspaceOwnerTTL, workspaceOwnerRenewInterval)
+}
+
+func acquireWorkspaceOwnerWithTransport(ctx context.Context, target SSHTarget, leaseID string, stderr io.Writer, transport workspaceOwnerTransport, waitTimeout, ttl, renewInterval time.Duration) (*workspaceOwner, error) {
+	if strings.TrimSpace(leaseID) == "" {
+		return nil, exit(7, "workspace owner requires a lease identity")
+	}
+	if waitTimeout <= 0 {
+		waitTimeout = workspaceOwnerWaitTimeout
+	}
+	if ttl <= 0 {
+		ttl = workspaceOwnerTTL
+	}
+	if renewInterval <= 0 || renewInterval >= ttl {
+		renewInterval = ttl / 3
+	}
+	token, err := randomHex(32)
+	if err != nil {
+		return nil, exit(7, "create workspace owner fencing token: %v", err)
+	}
+	owner := &workspaceOwner{
+		target:    target,
+		transport: transport,
+		key:       workspaceOwnerKey(leaseID),
+		token:     token,
+		ttl:       ttl,
+		stop:      make(chan struct{}),
+		done:      make(chan struct{}),
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, waitTimeout)
+	defer cancel()
+	started := time.Now()
+	nextProgress := workspaceOwnerProgressEvery
+	for {
+		response, callErr := transport.Do(waitCtx, workspaceOwnerRemoteRequest{Action: workspaceOwnerAcquire, Key: owner.key, Token: owner.token, TTL: ttl})
+		if callErr != nil {
+			return nil, exit(7, "acquire remote workspace owner: ambiguous remote state: %v", callErr)
+		}
+		switch response {
+		case "ACQUIRED", "RECOVERED":
+			owner.ctx, owner.cancel = context.WithCancel(ctx)
+			go owner.renewLoop(renewInterval)
+			fmt.Fprintf(stderr, "workspace owner acquired wait=%s recovered=%t\n", time.Since(started).Round(time.Millisecond), response == "RECOVERED")
+			return owner, nil
+		case "BUSY", "CHILD":
+			elapsed := time.Since(started)
+			if elapsed >= nextProgress {
+				fmt.Fprintf(stderr, "waiting for reusable workspace owner elapsed=%s state=%s\n", elapsed.Round(time.Second), strings.ToLower(response))
+				nextProgress += workspaceOwnerProgressEvery
+			}
+		case "AMBIGUOUS":
+			return nil, exit(7, "acquire remote workspace owner: ambiguous protocol state")
+		default:
+			return nil, exit(7, "acquire remote workspace owner: unexpected protocol response %q", response)
+		}
+		timer := time.NewTimer(workspaceOwnerPollInterval)
+		select {
+		case <-waitCtx.Done():
+			timer.Stop()
+			if errors.Is(waitCtx.Err(), context.DeadlineExceeded) {
+				return nil, exit(7, "timed out after %s waiting for reusable workspace owner", waitTimeout)
+			}
+			return nil, waitCtx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func (o *workspaceOwner) Context() context.Context {
+	if o == nil || o.ctx == nil {
+		return context.Background()
+	}
+	return o.ctx
+}
+
+func (o *workspaceOwner) renewLoop(interval time.Duration) {
+	defer close(o.done)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-o.stop:
+			return
+		case <-o.ctx.Done():
+			return
+		case <-ticker.C:
+			callCtx, cancel := context.WithTimeout(context.WithoutCancel(o.ctx), interval)
+			response, err := o.transport.Do(callCtx, workspaceOwnerRemoteRequest{Action: workspaceOwnerRenew, Key: o.key, Token: o.token, TTL: o.ttl})
+			cancel()
+			if err == nil && response == "RENEWED" {
+				continue
+			}
+			if err == nil {
+				err = fmt.Errorf("unexpected protocol response %q", response)
+			}
+			o.mu.Lock()
+			o.renewErr = exit(7, "remote workspace owner renewal failed closed: %v", err)
+			o.mu.Unlock()
+			o.cancel()
+			return
+		}
+	}
+}
+
+func (o *workspaceOwner) Err() error {
+	if o == nil {
+		return nil
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.renewErr
+}
+
+func (o *workspaceOwner) ConfirmNoChild(ctx context.Context) error {
+	if o == nil {
+		return nil
+	}
+	if err := o.Err(); err != nil {
+		return err
+	}
+	response, err := o.transport.Do(ctx, workspaceOwnerRemoteRequest{Action: workspaceOwnerInspect, Key: o.key, Token: o.token, TTL: o.ttl})
+	if err != nil {
+		return exit(7, "confirm remote workspace owner child state: ambiguous remote state: %v", err)
+	}
+	if response != "OWNED" {
+		return exit(7, "confirm remote workspace owner child state failed closed: %s", strings.ToLower(firstNonBlank(response, "ambiguous")))
+	}
+	return nil
+}
+
+func (o *workspaceOwner) WaitForChild(ctx context.Context, timeout time.Duration) error {
+	if o == nil {
+		return nil
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		response, err := o.transport.Do(ctx, workspaceOwnerRemoteRequest{Action: workspaceOwnerInspect, Key: o.key, Token: o.token, TTL: o.ttl})
+		if err != nil {
+			return exit(7, "confirm remote workspace phase witness: ambiguous remote state: %v", err)
+		}
+		switch response {
+		case "CHILD":
+			return nil
+		case "OWNED":
+			if time.Now().After(deadline) {
+				return exit(7, "timed out waiting for remote workspace phase witness")
+			}
+		case "MISMATCH", "AMBIGUOUS":
+			return exit(7, "confirm remote workspace phase witness failed closed: %s", strings.ToLower(response))
+		default:
+			return exit(7, "confirm remote workspace phase witness: unexpected protocol response %q", response)
+		}
+		timer := time.NewTimer(50 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func (o *workspaceOwner) rsyncGuardPayload(destination string) string {
+	stop := ".crabbox/workspace-owners/" + o.key + ".rsync-stop." + o.token
+	state := ".crabbox/workspace-owners/" + o.key + ".owner"
+	return `stop="$HOME/` + stop + `"
+state="$HOME/` + state + `"
+token=` + shellQuote(o.token) + `
+destination=` + shellQuote(destination) + `
+while :; do
+	state_token=$(sed -n '2p' "$state" 2>/dev/null || true)
+	state_expiry=$(sed -n '3p' "$state" 2>/dev/null || true)
+	case "$state_expiry" in ''|*[!0-9]*) state_expiry=0 ;; esac
+	phase_live=
+	if ps -ax -o comm=,command= 2>/dev/null | awk -v dst="$destination" '$1 ~ /(^|\/)rsync$/ && index($0, dst) { found=1 } END { exit !found }'; then phase_live=1; fi
+	if [ -f "$stop" ] && [ -z "$phase_live" ]; then exit 0; fi
+	if { [ "$state_token" != "$token" ] || [ "$(date +%s)" -ge "$state_expiry" ]; } && [ -z "$phase_live" ]; then exit 0; fi
+	sleep 0.2
+done`
+}
+
+func (o *workspaceOwner) rsyncStopCommand() string {
+	path := ".crabbox/workspace-owners/" + o.key + ".rsync-stop." + o.token
+	return `touch "$HOME/` + path + `"`
+}
+
+func (o *workspaceOwner) rsyncPrepareCommand() string {
+	path := ".crabbox/workspace-owners/" + o.key + ".rsync-stop." + o.token
+	return `rm -f "$HOME/` + path + `"`
+}
+
+func (o *workspaceOwner) Close(ctx context.Context) error {
+	if o == nil {
+		return nil
+	}
+	o.closeOnce.Do(func() {
+		close(o.stop)
+		<-o.done
+	})
+	renewErr := o.Err()
+	response, releaseErr := o.transport.Do(ctx, workspaceOwnerRemoteRequest{Action: workspaceOwnerRelease, Key: o.key, Token: o.token, TTL: o.ttl})
+	if releaseErr != nil {
+		releaseErr = exit(7, "release remote workspace owner: ambiguous remote state: %v", releaseErr)
+	} else if response != "RELEASED" {
+		releaseErr = exit(7, "release remote workspace owner failed closed: %s", strings.ToLower(firstNonBlank(response, "ambiguous")))
+	}
+	return errors.Join(renewErr, releaseErr)
+}
+
+func (o *workspaceOwner) CloseAfterLeaseRelease() error {
+	if o == nil {
+		return nil
+	}
+	o.closeOnce.Do(func() {
+		close(o.stop)
+		<-o.done
+	})
+	return o.Err()
+}
+
+func (o *workspaceOwner) WrapCommand(remote string) string {
+	return o.wrapCommand(remote, false)
+}
+
+func (o *workspaceOwner) WrapInputCommand(remote string) string {
+	return o.wrapCommand(remote, true)
+}
+
+func (o *workspaceOwner) wrapCommand(remote string, preserveInput bool) string {
+	if o == nil {
+		return remote
+	}
+	if isWindowsNativeTarget(o.target) {
+		return remoteWorkspaceOwnerWindowsWitness(o.key, o.token, remote, preserveInput)
+	}
+	return remoteWorkspaceOwnerPOSIXWitness(o.key, o.token, remote, preserveInput)
+}
+
+func (o *workspaceOwner) WrapBackgroundCommand(remote string) string {
+	if o == nil {
+		return remote
+	}
+	wrapped := o.WrapCommand(remote)
+	if isWindowsNativeTarget(o.target) {
+		encoded := base64.StdEncoding.EncodeToString(utf16LE([]byte(wrapped)))
+		return powershellCommand(`$p = Start-Process -FilePath "powershell.exe" -ArgumentList @("-NoLogo", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-EncodedCommand", ` + psQuote(encoded) + `) -WindowStyle Hidden -PassThru
+Write-Output $p.Id
+exit 0
+`)
+	}
+	return "nohup sh -c " + shellQuote(wrapped) + " >/dev/null 2>&1 < /dev/null & printf '%s\\n' \"$!\""
+}
+
+func remoteWorkspaceOwnerCommand(target SSHTarget, req workspaceOwnerRemoteRequest) string {
+	if isWindowsNativeTarget(target) {
+		return remoteWorkspaceOwnerWindows(req)
+	}
+	return remoteWorkspaceOwnerPOSIX(req)
+}
+
+func workspaceOwnerTTLSeconds(ttl time.Duration) int64 {
+	seconds := int64((ttl + time.Second - 1) / time.Second)
+	if seconds < 1 {
+		return 1
+	}
+	return seconds
+}
+
+func remoteWorkspaceOwnerPOSIX(req workspaceOwnerRemoteRequest) string {
+	body := `set -eu
+root="$HOME/.crabbox/workspace-owners"
+key=` + shellQuote(req.Key) + `
+token=` + shellQuote(req.Token) + `
+action=` + shellQuote(string(req.Action)) + `
+ttl=` + strconv.FormatInt(workspaceOwnerTTLSeconds(req.TTL), 10) + `
+state="$root/$key.owner"
+child="$root/$key.child"
+mkdir -p "$root"
+chmod 700 "$HOME/.crabbox" "$root" 2>/dev/null || true
+read_state() {
+  [ -f "$state" ] || return 1
+  state_version=$(sed -n '1p' "$state" 2>/dev/null || true)
+  state_token=$(sed -n '2p' "$state" 2>/dev/null || true)
+  state_expiry=$(sed -n '3p' "$state" 2>/dev/null || true)
+  [ "$state_version" = v1 ] || return 2
+  case "$state_token" in ''|*[!0-9a-f]*) return 2 ;; esac
+  [ "${#state_token}" -eq 64 ] || return 2
+  case "$state_expiry" in ''|*[!0-9]*) return 2 ;; esac
+  return 0
+}
+write_state() {
+  next_expiry=$(($(date +%s) + ttl))
+  tmp="$state.tmp.$$"
+  (umask 077; printf 'v1\n%s\n%s\n' "$token" "$next_expiry" >"$tmp")
+  mv "$tmp" "$state"
+}
+child_status() {
+  [ -f "$child" ] || return 1
+  child_pid=$(sed -n '1p' "$child" 2>/dev/null || true)
+  child_identity=$(sed -n '2p' "$child" 2>/dev/null || true)
+  case "$child_pid" in ''|*[!0-9]*) return 2 ;; esac
+  [ -n "$child_identity" ] && [ "${#child_identity}" -le 96 ] || return 2
+  if kill -0 "$child_pid" 2>/dev/null; then
+    live_identity=$(ps -o lstart= -p "$child_pid" 2>/dev/null | tr -s ' ' | sed 's/^ //;s/ $//' | cut -c1-96)
+    [ -n "$live_identity" ] || return 2
+    [ "$live_identity" = "$child_identity" ] && return 0
+  fi
+  return 1
+}
+case "$action" in
+  acquire)
+    if read_state; then
+      now=$(date +%s)
+      if [ "$state_expiry" -gt "$now" ]; then printf BUSY; exit 0; fi
+      if child_status; then printf CHILD; exit 0; else child_rc=$?; fi
+      if [ "$child_rc" -eq 2 ]; then printf AMBIGUOUS; exit 74; fi
+      rm -f "$child"
+      write_state
+      printf RECOVERED
+      exit 0
+    else state_rc=$?; fi
+    if [ "$state_rc" -eq 2 ]; then printf AMBIGUOUS; exit 74; fi
+    [ ! -e "$state" ] || { printf AMBIGUOUS; exit 74; }
+    write_state
+    printf ACQUIRED
+    ;;
+  renew)
+    read_state || { printf AMBIGUOUS; exit 74; }
+    [ "$state_token" = "$token" ] || { printf MISMATCH; exit 75; }
+    write_state
+    printf RENEWED
+    ;;
+  inspect)
+    read_state || { printf AMBIGUOUS; exit 74; }
+    [ "$state_token" = "$token" ] || { printf MISMATCH; exit 75; }
+    if child_status; then printf CHILD; exit 0; else child_rc=$?; fi
+    [ "$child_rc" -ne 2 ] || { printf AMBIGUOUS; exit 74; }
+    rm -f "$child"
+    printf OWNED
+    ;;
+  release)
+    read_state || { printf AMBIGUOUS; exit 74; }
+    [ "$state_token" = "$token" ] || { printf MISMATCH; exit 75; }
+    if child_status; then printf CHILD; exit 75; else child_rc=$?; fi
+    [ "$child_rc" -ne 2 ] || { printf AMBIGUOUS; exit 74; }
+    rm -f "$child" "$state"
+    [ ! -e "$state" ] || { printf AMBIGUOUS; exit 74; }
+    printf RELEASED
+    ;;
+  *) printf AMBIGUOUS; exit 74 ;;
+esac
+`
+	timeout := "5"
+	if req.Action == workspaceOwnerAcquire {
+		timeout = "0"
+	}
+	return `set -u
+root="$HOME/.crabbox/workspace-owners"
+mkdir -p "$root"
+chmod 700 "$HOME/.crabbox" "$root" 2>/dev/null || true
+protocol_action=` + shellQuote(string(req.Action)) + `
+gate="$root/` + req.Key + `.gate"
+body=` + shellQuote(body) + `
+run_locked() {
+	if command -v flock >/dev/null 2>&1; then
+		flock -x -w ` + timeout + ` "$gate" bash -c "$body"
+	elif command -v lockf >/dev/null 2>&1; then
+		lockf -t ` + timeout + ` "$gate" bash -c "$body"
+	else
+		return 73
+	fi
+}
+set +e
+output=$(run_locked)
+lock_status=$?
+set -e
+if [ "$lock_status" -ne 0 ] && [ -z "$output" ]; then
+	if [ ` + shellQuote(string(req.Action)) + ` = acquire ]; then printf BUSY; exit 0; fi
+	printf AMBIGUOUS; exit 74
+fi
+printf %s "$output"
+exit "$lock_status"
+`
+}
+
+func remoteWorkspaceOwnerWindows(req workspaceOwnerRemoteRequest) string {
+	return powershellCommand(`$ErrorActionPreference = "Stop"
+$root = Join-Path $HOME ".crabbox\workspace-owners"
+$key = ` + psQuote(req.Key) + `
+$token = ` + psQuote(req.Token) + `
+$action = ` + psQuote(string(req.Action)) + `
+$ttl = ` + strconv.FormatInt(workspaceOwnerTTLSeconds(req.TTL), 10) + `
+$state = Join-Path $root ($key + ".owner")
+$child = Join-Path $root ($key + ".child")
+$gate = Join-Path $root ($key + ".gate")
+New-Item -ItemType Directory -Force -Path $root | Out-Null
+function Enter-Gate {
+	for ($i = 0; $i -lt 50; $i++) {
+		try {
+			$stream = [IO.File]::Open($gate, [IO.FileMode]::CreateNew, [IO.FileAccess]::ReadWrite, [IO.FileShare]::None)
+			$lines = "v1" + [Environment]::NewLine + $PID + [Environment]::NewLine + $token + [Environment]::NewLine
+			$bytes = [Text.Encoding]::UTF8.GetBytes($lines)
+			$stream.Write($bytes, 0, $bytes.Length)
+			$stream.Flush()
+			return $stream
+		} catch {}
+		try {
+			$stale = [IO.File]::Open($gate, [IO.FileMode]::Open, [IO.FileAccess]::ReadWrite, [IO.FileShare]::None)
+			$stale.Dispose()
+			Remove-Item -LiteralPath $gate -Force -ErrorAction Stop
+			continue
+		} catch {
+			if ($action -eq "acquire") { return $null }
+			Start-Sleep -Milliseconds 100
+		}
+	}
+	throw "workspace owner gate is ambiguous"
+}
+function Read-State {
+  if (-not (Test-Path -LiteralPath $state -PathType Leaf)) { return $null }
+  $lines = @(Get-Content -LiteralPath $state -ErrorAction Stop)
+  if ($lines.Count -ne 3 -or $lines[0] -ne "v1" -or $lines[1] -notmatch "^[0-9a-f]{64}$" -or $lines[2] -notmatch "^[0-9]+$") { throw "workspace owner state is ambiguous" }
+  return @{ Token = [string]$lines[1]; Expiry = [Int64]$lines[2] }
+}
+function Write-State {
+  $tmp = $state + ".tmp." + [Guid]::NewGuid().ToString("N")
+  $expiry = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds() + $ttl
+  [IO.File]::WriteAllLines($tmp, @("v1", $token, [string]$expiry), [Text.UTF8Encoding]::new($false))
+  Move-Item -LiteralPath $tmp -Destination $state -Force
+}
+function Get-ChildStatus {
+  if (-not (Test-Path -LiteralPath $child -PathType Leaf)) { return "dead" }
+  $lines = @(Get-Content -LiteralPath $child -ErrorAction Stop)
+  if ($lines.Count -ne 2 -or $lines[0] -notmatch "^[0-9]+$" -or $lines[1] -notmatch "^[0-9]+$") { return "ambiguous" }
+	try {
+		$process = [Diagnostics.Process]::GetProcessById([int]$lines[0])
+	} catch [ArgumentException] {
+		return "dead"
+	} catch {
+		return "ambiguous"
+	}
+	try {
+		if ([string]$process.StartTime.ToUniversalTime().Ticks -eq [string]$lines[1]) { return "live" }
+		return "dead"
+	} catch {
+		try { $null = [Diagnostics.Process]::GetProcessById([int]$lines[0]); return "ambiguous" }
+		catch [ArgumentException] { return "dead" }
+		catch { return "ambiguous" }
+	}
+}
+$gateStream = Enter-Gate
+if ($null -eq $gateStream) { Write-Output "BUSY"; exit 0 }
+try {
+  $current = Read-State
+  switch ($action) {
+    "acquire" {
+      if ($null -eq $current) { Write-State; Write-Output "ACQUIRED"; break }
+      if ($current.Expiry -gt [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()) { Write-Output "BUSY"; break }
+      $childStatus = Get-ChildStatus
+      if ($childStatus -eq "live") { Write-Output "CHILD"; break }
+      if ($childStatus -eq "ambiguous") { throw "workspace owner child state is ambiguous" }
+      Remove-Item -LiteralPath $child -Force -ErrorAction SilentlyContinue
+      Write-State
+      Write-Output "RECOVERED"
+      break
+    }
+    "renew" {
+      if ($null -eq $current -or $current.Token -ne $token) { Write-Output "MISMATCH"; exit 75 }
+      Write-State
+      Write-Output "RENEWED"
+      break
+    }
+    "inspect" {
+      if ($null -eq $current -or $current.Token -ne $token) { Write-Output "MISMATCH"; exit 75 }
+      $childStatus = Get-ChildStatus
+      if ($childStatus -eq "live") { Write-Output "CHILD"; break }
+      if ($childStatus -eq "ambiguous") { throw "workspace owner child state is ambiguous" }
+      Remove-Item -LiteralPath $child -Force -ErrorAction SilentlyContinue
+      Write-Output "OWNED"
+      break
+    }
+    "release" {
+      if ($null -eq $current -or $current.Token -ne $token) { Write-Output "MISMATCH"; exit 75 }
+      $childStatus = Get-ChildStatus
+      if ($childStatus -eq "live") { Write-Output "CHILD"; exit 75 }
+      if ($childStatus -eq "ambiguous") { throw "workspace owner child state is ambiguous" }
+      Remove-Item -LiteralPath $child -Force -ErrorAction SilentlyContinue
+      Remove-Item -LiteralPath $state -Force -ErrorAction Stop
+      if (Test-Path -LiteralPath $state) { throw "workspace owner release is ambiguous" }
+      Write-Output "RELEASED"
+      break
+    }
+    default { throw "workspace owner action is ambiguous" }
+  }
+} catch {
+	Write-Output "AMBIGUOUS"
+	exit 74
+} finally {
+	$gateStream.Dispose()
+	Remove-Item -LiteralPath $gate -Force -ErrorAction SilentlyContinue
+}
+`)
+}
+
+func remoteWorkspaceOwnerPOSIXWitness(key, token, remote string, preserveInput ...bool) string {
+	inputSetup := ""
+	inputRedirect := ""
+	if len(preserveInput) > 0 && preserveInput[0] {
+		inputSetup = `(umask 077; cat >"$run_dir/input") || { rm -rf "$run_dir"; exit 74; }
+`
+		inputRedirect = ` <"$run_dir/input"`
+	}
+	installBody := `set -eu
+[ "$(sed -n '2p' "$state" 2>/dev/null || true)" = "$token" ] || exit 75
+if [ -f "$child" ]; then
+	existing_pid=$(sed -n '1p' "$child" 2>/dev/null || true)
+	existing_identity=$(sed -n '2p' "$child" 2>/dev/null || true)
+	case "$existing_pid" in ''|*[!0-9]*) exit 74 ;; esac
+	[ -n "$existing_identity" ] && [ "${#existing_identity}" -le 96 ] || exit 74
+	if kill -0 "$existing_pid" 2>/dev/null; then
+		live_existing_identity=$(ps -o lstart= -p "$existing_pid" 2>/dev/null | tr -s ' ' | sed 's/^ //;s/ $//' | cut -c1-96)
+		[ -n "$live_existing_identity" ] || exit 74
+		[ "$live_existing_identity" != "$existing_identity" ] || exit 75
+	fi
+	rm -f "$child"
+fi
+child_tmp="$child.tmp.$$"
+(umask 077; printf '%s\n%s\n' "$child_pid" "$child_identity" >"$child_tmp")
+mv "$child_tmp" "$child"`
+	clearBody := `set -eu
+[ "$(sed -n '2p' "$state" 2>/dev/null || true)" = "$token" ] || exit 75
+recorded_pid=$(sed -n '1p' "$child" 2>/dev/null || true)
+recorded_identity=$(sed -n '2p' "$child" 2>/dev/null || true)
+[ "$recorded_pid" = "$child_pid" ] && [ "$recorded_identity" = "$child_identity" ] || exit 74
+rm -f "$child"`
+	return `set -u
+root="$HOME/.crabbox/workspace-owners"
+key=` + shellQuote(key) + `
+token=` + shellQuote(token) + `
+payload=` + shellQuote(remote) + `
+state="$root/$key.owner"
+child="$root/$key.child"
+gate="$root/$key.gate"
+run_dir="$root/$key.run.$token"
+start="$run_dir/start"
+run_owner_gate() {
+	if command -v flock >/dev/null 2>&1; then
+		flock -x -w 5 "$gate" bash -c "$1"
+	elif command -v lockf >/dev/null 2>&1; then
+		lockf -t 5 "$gate" bash -c "$1"
+	else
+		return 74
+	fi
+}
+rm -rf "$run_dir"
+mkdir -m 700 "$run_dir" || exit 74
+` + inputSetup + `(trap '' HUP; while [ ! -f "$start" ]; do sleep 0.05; done; exec sh -c "$payload"` + inputRedirect + `) &
+child_pid=$!
+child_identity=$(ps -o lstart= -p "$child_pid" 2>/dev/null | tr -s ' ' | sed 's/^ //;s/ $//' | cut -c1-96)
+if [ -z "$child_identity" ] || ! kill -0 "$child_pid" 2>/dev/null; then kill "$child_pid" 2>/dev/null || true; rm -rf "$run_dir"; exit 74; fi
+export state child token child_pid child_identity
+set +e
+run_owner_gate ` + shellQuote(installBody) + `
+gate_status=$?
+set -e
+if [ "$gate_status" -ne 0 ]; then kill "$child_pid" 2>/dev/null || true; rm -rf "$run_dir"; exit "$gate_status"; fi
+touch "$start"
+wait "$child_pid"
+code=$?
+set +e
+run_owner_gate ` + shellQuote(clearBody) + `
+clear_status=$?
+set -e
+rm -rf "$run_dir"
+[ "$clear_status" -eq 0 ] || exit "$clear_status"
+exit "$code"
+`
+}
+
+func remoteWorkspaceOwnerWindowsWitness(key, token, remote string, preserveInput ...bool) string {
+	payload := base64.StdEncoding.EncodeToString([]byte(remote))
+	inputSetup := ""
+	inputArgument := ""
+	if len(preserveInput) > 0 && preserveInput[0] {
+		inputSetup = `$inputPath = Join-Path $runDir "input"
+$inputFile = [IO.File]::Open($inputPath, [IO.FileMode]::CreateNew, [IO.FileAccess]::Write, [IO.FileShare]::None)
+try { [Console]::OpenStandardInput().CopyTo($inputFile); $inputFile.Flush() } finally { $inputFile.Dispose() }
+`
+		inputArgument = ` -RedirectStandardInput $inputPath`
+	}
+	return powershellCommand(`$ErrorActionPreference = "Stop"
+$root = Join-Path $HOME ".crabbox\workspace-owners"
+$key = ` + psQuote(key) + `
+$token = ` + psQuote(token) + `
+$state = Join-Path $root ($key + ".owner")
+$child = Join-Path $root ($key + ".child")
+$gate = Join-Path $root ($key + ".gate")
+$runDir = Join-Path $root ($key + ".run." + $token)
+$start = Join-Path $runDir "start"
+function Enter-Gate {
+	for ($i = 0; $i -lt 50; $i++) {
+		try {
+			$stream = [IO.File]::Open($gate, [IO.FileMode]::CreateNew, [IO.FileAccess]::ReadWrite, [IO.FileShare]::None)
+			$lines = "v1" + [Environment]::NewLine + $PID + [Environment]::NewLine + $token + [Environment]::NewLine
+			$bytes = [Text.Encoding]::UTF8.GetBytes($lines)
+			$stream.Write($bytes, 0, $bytes.Length)
+			$stream.Flush()
+			return $stream
+		} catch {}
+		try {
+			$stale = [IO.File]::Open($gate, [IO.FileMode]::Open, [IO.FileAccess]::ReadWrite, [IO.FileShare]::None)
+			$stale.Dispose()
+			Remove-Item -LiteralPath $gate -Force -ErrorAction Stop
+			continue
+		} catch { Start-Sleep -Milliseconds 100 }
+	}
+	return $null
+}
+function Read-Token {
+	$lines = @(Get-Content -LiteralPath $state -ErrorAction Stop)
+	if ($lines.Count -ne 3 -or $lines[0] -ne "v1") { throw "ambiguous owner state" }
+	return [string]$lines[1]
+}
+function Get-ExistingChildStatus {
+	if (-not (Test-Path -LiteralPath $child -PathType Leaf)) { return "dead" }
+	$lines = @(Get-Content -LiteralPath $child -ErrorAction Stop)
+	if ($lines.Count -ne 2 -or $lines[0] -notmatch "^[0-9]+$" -or $lines[1] -notmatch "^[0-9]+$") { return "ambiguous" }
+	try { $existing = [Diagnostics.Process]::GetProcessById([int]$lines[0]) }
+	catch [ArgumentException] { return "dead" }
+	catch { return "ambiguous" }
+	try {
+		if ([string]$existing.StartTime.ToUniversalTime().Ticks -eq [string]$lines[1]) { return "live" }
+		return "dead"
+	} catch {
+		try { $null = [Diagnostics.Process]::GetProcessById([int]$lines[0]); return "ambiguous" }
+		catch [ArgumentException] { return "dead" }
+		catch { return "ambiguous" }
+	}
+}
+Remove-Item -LiteralPath $runDir -Recurse -Force -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Path $runDir -ErrorAction Stop | Out-Null
+` + inputSetup + `
+$childSource = @'
+$ErrorActionPreference = "Stop"
+while (-not (Test-Path -LiteralPath '__START__')) { Start-Sleep -Milliseconds 50 }
+$payload = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('__PAYLOAD__'))
+& ([ScriptBlock]::Create($payload))
+exit $LASTEXITCODE
+'@
+$childSource = $childSource.Replace('__START__', $start.Replace("'", "''")).Replace('__PAYLOAD__', ` + psQuote(payload) + `)
+$childEncoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($childSource))
+$process = Start-Process -FilePath "powershell.exe" -ArgumentList @("-NoLogo", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-EncodedCommand", $childEncoded) -NoNewWindow -PassThru` + inputArgument + `
+$identity = [string]$process.StartTime.ToUniversalTime().Ticks
+$gateStream = Enter-Gate
+if ($null -eq $gateStream) { Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue; throw "ambiguous owner gate" }
+try {
+	if ((Read-Token) -ne $token) { Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue; exit 75 }
+	$existingStatus = Get-ExistingChildStatus
+	if ($existingStatus -eq "live") { Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue; exit 75 }
+	if ($existingStatus -eq "ambiguous") { Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue; exit 74 }
+	Remove-Item -LiteralPath $child -Force -ErrorAction SilentlyContinue
+	$tmp = $child + ".tmp." + [Guid]::NewGuid().ToString("N")
+	[IO.File]::WriteAllLines($tmp, @([string]$process.Id, $identity), [Text.UTF8Encoding]::new($false))
+	Move-Item -LiteralPath $tmp -Destination $child -Force
+} finally { $gateStream.Dispose(); Remove-Item -LiteralPath $gate -Force -ErrorAction SilentlyContinue }
+New-Item -ItemType File -Path $start -Force | Out-Null
+$process.WaitForExit()
+$code = $process.ExitCode
+$clear = $false
+$gateStream = Enter-Gate
+if ($null -ne $gateStream) {
+	try {
+		$recorded = @(Get-Content -LiteralPath $child -ErrorAction Stop)
+    if ((Read-Token) -eq $token -and $recorded.Count -eq 2 -and $recorded[0] -eq [string]$process.Id -and $recorded[1] -eq $identity) {
+      Remove-Item -LiteralPath $child -Force -ErrorAction Stop
+      $clear = $true
+    }
+	} finally { $gateStream.Dispose(); Remove-Item -LiteralPath $gate -Force -ErrorAction SilentlyContinue }
+}
+Remove-Item -LiteralPath $runDir -Recurse -Force -ErrorAction SilentlyContinue
+if (-not $clear) { exit 74 }
+exit $code
+`)
+}

--- a/internal/cli/workspace_owner.go
+++ b/internal/cli/workspace_owner.go
@@ -97,8 +97,12 @@ func workspaceOwnerKey(leaseID string) string {
 	return fmt.Sprintf("%x", sha256.Sum256([]byte("crabbox-workspace-owner-v1\x00"+leaseID)))
 }
 
-func shouldAcquireWorkspaceOwner(acquired bool) bool {
-	return !acquired
+func shouldAcquireWorkspaceOwner(acquired bool, backend SSHLeaseBackend) bool {
+	if !acquired {
+		return true
+	}
+	exclusive, ok := backend.(ExclusiveOneShotAcquireBackend)
+	return !ok || !exclusive.AcquireIsExclusiveOneShot()
 }
 
 func acquireWorkspaceOwner(ctx context.Context, target SSHTarget, leaseID string, stderr io.Writer) (*workspaceOwner, error) {
@@ -431,12 +435,14 @@ case "$action" in
   renew)
     read_state || { printf AMBIGUOUS; exit 74; }
     [ "$state_token" = "$token" ] || { printf MISMATCH; exit 75; }
+    [ "$state_expiry" -gt "$(date +%s)" ] || { printf EXPIRED; exit 75; }
     write_state
     printf RENEWED
     ;;
   inspect)
     read_state || { printf AMBIGUOUS; exit 74; }
     [ "$state_token" = "$token" ] || { printf MISMATCH; exit 75; }
+    [ "$state_expiry" -gt "$(date +%s)" ] || { printf EXPIRED; exit 75; }
     if child_status; then printf CHILD; exit 0; else child_rc=$?; fi
     [ "$child_rc" -ne 2 ] || { printf AMBIGUOUS; exit 74; }
     rm -f "$child"
@@ -570,12 +576,14 @@ try {
     }
     "renew" {
       if ($null -eq $current -or $current.Token -ne $token) { Write-Output "MISMATCH"; exit 75 }
+      if ($current.Expiry -le [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()) { Write-Output "EXPIRED"; exit 75 }
       Write-State
       Write-Output "RENEWED"
       break
     }
     "inspect" {
       if ($null -eq $current -or $current.Token -ne $token) { Write-Output "MISMATCH"; exit 75 }
+      if ($current.Expiry -le [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()) { Write-Output "EXPIRED"; exit 75 }
       $childStatus = Get-ChildStatus
       if ($childStatus -eq "live") { Write-Output "CHILD"; break }
       if ($childStatus -eq "ambiguous") { throw "workspace owner child state is ambiguous" }
@@ -616,6 +624,9 @@ func remoteWorkspaceOwnerPOSIXWitness(key, token, remote string, preserveInput .
 	}
 	installBody := `set -eu
 [ "$(sed -n '2p' "$state" 2>/dev/null || true)" = "$token" ] || exit 75
+owner_expiry=$(sed -n '3p' "$state" 2>/dev/null || true)
+case "$owner_expiry" in ''|*[!0-9]*) exit 74 ;; esac
+[ "$owner_expiry" -gt "$(date +%s)" ] || exit 75
 if [ -f "$child" ]; then
 	existing_pid=$(sed -n '1p' "$child" 2>/dev/null || true)
 	existing_identity=$(sed -n '2p' "$child" 2>/dev/null || true)
@@ -725,6 +736,11 @@ function Read-Token {
 	if ($lines.Count -ne 3 -or $lines[0] -ne "v1") { throw "ambiguous owner state" }
 	return [string]$lines[1]
 }
+function Read-Expiry {
+	$lines = @(Get-Content -LiteralPath $state -ErrorAction Stop)
+	if ($lines.Count -ne 3 -or $lines[0] -ne "v1" -or $lines[2] -notmatch "^[0-9]+$") { throw "ambiguous owner state" }
+	return [Int64]$lines[2]
+}
 function Get-ExistingChildStatus {
 	if (-not (Test-Path -LiteralPath $child -PathType Leaf)) { return "dead" }
 	$lines = @(Get-Content -LiteralPath $child -ErrorAction Stop)
@@ -759,6 +775,7 @@ $gateStream = Enter-Gate
 if ($null -eq $gateStream) { Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue; throw "ambiguous owner gate" }
 try {
 	if ((Read-Token) -ne $token) { Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue; exit 75 }
+	if ((Read-Expiry) -le [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()) { Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue; exit 75 }
 	$existingStatus = Get-ExistingChildStatus
 	if ($existingStatus -eq "live") { Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue; exit 75 }
 	if ($existingStatus -eq "ambiguous") { Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue; exit 74 }

--- a/internal/cli/workspace_owner_test.go
+++ b/internal/cli/workspace_owner_test.go
@@ -288,10 +288,15 @@ func TestWorkspaceOwnerTokenAndTransportFailuresFailClosed(t *testing.T) {
 }
 
 func TestWorkspaceOwnerAcquisitionBoundary(t *testing.T) {
-	if shouldAcquireWorkspaceOwner(true) {
-		t.Fatal("newly acquired one-shot lease must bypass the reuse owner")
+	nonExclusive := newWatchTestBackend()
+	if !shouldAcquireWorkspaceOwner(true, nonExclusive) {
+		t.Fatal("a successful non-exclusive acquisition must acquire the workspace owner")
 	}
-	if !shouldAcquireWorkspaceOwner(false) {
+	exclusive := runEnvProfileTestBackend{}
+	if shouldAcquireWorkspaceOwner(true, exclusive) {
+		t.Fatal("newly acquired exclusive one-shot lease must bypass the workspace owner")
+	}
+	if !shouldAcquireWorkspaceOwner(false, exclusive) {
 		t.Fatal("existing, pooled, and watch-reused leases must acquire the reuse owner")
 	}
 }
@@ -326,14 +331,17 @@ func TestWorkspaceOwnerLifecycleBoundaryMatrix(t *testing.T) {
 		"watch iteration",
 	} {
 		t.Run(lifecycle, func(t *testing.T) {
-			if !shouldAcquireWorkspaceOwner(false) {
+			if !shouldAcquireWorkspaceOwner(false, nil) {
 				t.Fatalf("reused %s path bypassed workspace ownership", lifecycle)
 			}
 		})
 	}
 }
 
-func TestWorkspaceOwnerSerializesRunAndStandaloneActionsHydration(t *testing.T) {
+func TestWorkspaceOwnerSerializesStaticRunAndStandaloneActionsHydration(t *testing.T) {
+	if !shouldAcquireWorkspaceOwner(true, testStaticSSHBackend{}) {
+		t.Fatal("static SSH acquisition bypassed workspace ownership")
+	}
 	remote := newFakeWorkspaceOwnerRemote()
 	remote.blockBusyAcquire = true
 	runOwner := acquireFakeWorkspaceOwner(t, context.Background(), remote, "cbx_run_hydrate")
@@ -381,7 +389,7 @@ func TestWorkspaceOwnerProtocolGeneration(t *testing.T) {
 	if posix != wsl {
 		t.Fatal("POSIX and WSL2 must use the same owner protocol")
 	}
-	for _, want := range []string{".crabbox/workspace-owners", key + ".gate", "$key.owner", "$key.child", "flock -x -w 0", "lockf -t 0", "ps -o lstart=", "RECOVERED", "MISMATCH", "AMBIGUOUS"} {
+	for _, want := range []string{".crabbox/workspace-owners", key + ".gate", "$key.owner", "$key.child", "flock -x -w 0", "lockf -t 0", "ps -o lstart=", "RECOVERED", "MISMATCH", "EXPIRED", "AMBIGUOUS", `[ "$state_expiry" -gt "$(date +%s)" ]`} {
 		if !strings.Contains(posix, want) {
 			t.Fatalf("POSIX protocol missing %q:\n%s", want, posix)
 		}
@@ -391,7 +399,7 @@ func TestWorkspaceOwnerProtocolGeneration(t *testing.T) {
 	}
 
 	windows := decodePowerShellCommand(t, remoteWorkspaceOwnerCommand(SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeNormal}, req))
-	for _, want := range []string{".crabbox\\workspace-owners", "$key = '" + key + "'", "$key + \".owner\"", "$key + \".child\"", "[Diagnostics.Process]::GetProcessById", "return \"ambiguous\"", "StartTime.ToUniversalTime().Ticks", "RECOVERED", "MISMATCH", "AMBIGUOUS"} {
+	for _, want := range []string{".crabbox\\workspace-owners", "$key = '" + key + "'", "$key + \".owner\"", "$key + \".child\"", "[Diagnostics.Process]::GetProcessById", "return \"ambiguous\"", "StartTime.ToUniversalTime().Ticks", "RECOVERED", "MISMATCH", "EXPIRED", "AMBIGUOUS", "$current.Expiry -le [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()"} {
 		if !strings.Contains(windows, want) {
 			t.Fatalf("Windows protocol missing %q:\n%s", want, windows)
 		}
@@ -400,13 +408,13 @@ func TestWorkspaceOwnerProtocolGeneration(t *testing.T) {
 		t.Fatalf("Windows protocol exposed raw lease ID: %s", windows)
 	}
 	posixWitness := remoteWorkspaceOwnerPOSIXWitness(key, token, "printf ok")
-	for _, want := range []string{"child_identity=$(ps -o lstart=", "mv \"$child_tmp\" \"$child\"", "touch \"$start\"", "wait \"$child_pid\"", "rm -f \"$child\""} {
+	for _, want := range []string{"child_identity=$(ps -o lstart=", "owner_expiry=$(sed -n", "owner_expiry", "date +%s", "mv \"$child_tmp\" \"$child\"", "touch \"$start\"", "wait \"$child_pid\"", "rm -f \"$child\""} {
 		if !strings.Contains(posixWitness, want) {
 			t.Fatalf("POSIX child witness missing %q:\n%s", want, posixWitness)
 		}
 	}
 	windowsWitness := decodePowerShellCommand(t, remoteWorkspaceOwnerWindowsWitness(key, token, "Write-Output ok"))
-	for _, want := range []string{"Start-Process", "StartTime.ToUniversalTime().Ticks", "Move-Item -LiteralPath $tmp -Destination $child", "$process.WaitForExit()", "Remove-Item -LiteralPath $child"} {
+	for _, want := range []string{"Start-Process", "StartTime.ToUniversalTime().Ticks", "Read-Expiry", "(Read-Expiry) -le [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()", "Move-Item -LiteralPath $tmp -Destination $child", "$process.WaitForExit()", "Remove-Item -LiteralPath $child"} {
 		if !strings.Contains(windowsWitness, want) {
 			t.Fatalf("Windows child witness missing %q:\n%s", want, windowsWitness)
 		}
@@ -444,6 +452,34 @@ func TestWorkspaceOwnerPOSIXProtocolBehavior(t *testing.T) {
 	if out, err := runPOSIXWorkspaceOwnerScript(t, home, remoteWorkspaceOwnerPOSIX(request(workspaceOwnerRenew, tokenB))); err == nil || out != "MISMATCH" {
 		t.Fatalf("mismatched renew out=%q err=%v", out, err)
 	}
+	statePath := filepath.Join(home, ".crabbox", "workspace-owners", key+".owner")
+	childPath := filepath.Join(home, ".crabbox", "workspace-owners", key+".child")
+	expiredState := "v1\n" + tokenA + "\n1\n"
+	if err := os.WriteFile(statePath, []byte(expiredState), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := runPOSIXWorkspaceOwnerScript(t, home, remoteWorkspaceOwnerPOSIX(request(workspaceOwnerRenew, tokenA))); err == nil || out != "EXPIRED" {
+		t.Fatalf("late same-token renew out=%q err=%v", out, err)
+	}
+	if data, err := os.ReadFile(statePath); err != nil || string(data) != expiredState {
+		t.Fatalf("late renew changed expired state: data=%q err=%v", data, err)
+	}
+	if out, err := runPOSIXWorkspaceOwnerScript(t, home, remoteWorkspaceOwnerPOSIX(request(workspaceOwnerInspect, tokenA))); err == nil || out != "EXPIRED" {
+		t.Fatalf("late same-token inspect out=%q err=%v", out, err)
+	}
+	lateResultPath := filepath.Join(home, "late-child.txt")
+	if out, err := runPOSIXWorkspaceOwnerScript(t, home, remoteWorkspaceOwnerPOSIXWitness(key, tokenA, "touch "+shellQuote(lateResultPath))); err == nil {
+		t.Fatalf("late same-token witness succeeded: out=%q", out)
+	}
+	if _, err := os.Stat(childPath); !os.IsNotExist(err) {
+		t.Fatalf("late witness published child state: %v", err)
+	}
+	if _, err := os.Stat(lateResultPath); !os.IsNotExist(err) {
+		t.Fatalf("late witness executed child command: %v", err)
+	}
+	if out, err := runPOSIXWorkspaceOwnerScript(t, home, remoteWorkspaceOwnerPOSIX(request(workspaceOwnerAcquire, tokenA))); err != nil || out != "RECOVERED" {
+		t.Fatalf("recover expired generation out=%q err=%v", out, err)
+	}
 
 	resultPath := filepath.Join(home, "revision.txt")
 	witness := remoteWorkspaceOwnerPOSIXWitness(key, tokenA, "printf revision-a > "+shellQuote(resultPath))
@@ -469,7 +505,6 @@ func TestWorkspaceOwnerPOSIXProtocolBehavior(t *testing.T) {
 		t.Fatal(err)
 	}
 	identity := strings.TrimSpace(strings.Join(strings.Fields(string(identityOut)), " "))
-	childPath := filepath.Join(home, ".crabbox", "workspace-owners", key+".child")
 	existingWitness := strconv.Itoa(os.Getpid()) + "\n" + identity + "\n"
 	if err := os.WriteFile(childPath, []byte(existingWitness), 0o600); err != nil {
 		t.Fatal(err)
@@ -514,7 +549,6 @@ func TestWorkspaceOwnerPOSIXProtocolBehavior(t *testing.T) {
 		t.Fatalf("child witness remained after exit: %v", err)
 	}
 
-	statePath := filepath.Join(home, ".crabbox", "workspace-owners", key+".owner")
 	if err := os.WriteFile(statePath, []byte("v1\n"+tokenA+"\n1\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -575,6 +609,38 @@ Set-Content -LiteralPath (Join-Path $root (` + psQuote(key) + ` + ".gate")) -Val
 	req := workspaceOwnerRemoteRequest{Action: workspaceOwnerAcquire, Key: key, Token: token, TTL: 30 * time.Second}
 	if out, err := runWindowsPowerShellScript(t, decodePowerShellCommand(t, remoteWorkspaceOwnerWindows(req))); err != nil || !strings.Contains(string(out), "ACQUIRED") {
 		t.Fatalf("Windows acquire out=%q err=%v", out, err)
+	}
+	expire := `$root = Join-Path $HOME ".crabbox\workspace-owners"
+$state = Join-Path $root (` + psQuote(key) + ` + ".owner")
+Set-Content -LiteralPath $state -Value @("v1", ` + psQuote(token) + `, "1") -Encoding ASCII
+`
+	if out, err := runWindowsPowerShellScript(t, expire); err != nil {
+		t.Fatalf("expire Windows owner state out=%q err=%v", out, err)
+	}
+	req.Action = workspaceOwnerRenew
+	if out, err := runWindowsPowerShellScript(t, decodePowerShellCommand(t, remoteWorkspaceOwnerWindows(req))); err == nil || !strings.Contains(string(out), "EXPIRED") {
+		t.Fatalf("late Windows renew out=%q err=%v", out, err)
+	}
+	req.Action = workspaceOwnerInspect
+	if out, err := runWindowsPowerShellScript(t, decodePowerShellCommand(t, remoteWorkspaceOwnerWindows(req))); err == nil || !strings.Contains(string(out), "EXPIRED") {
+		t.Fatalf("late Windows inspect out=%q err=%v", out, err)
+	}
+	if out, err := runWindowsPowerShellScript(t, decodePowerShellCommand(t, remoteWorkspaceOwnerWindowsWitness(key, token, "Write-Output late-child"))); err == nil || strings.Contains(string(out), "late-child") {
+		t.Fatalf("late Windows witness executed: out=%q err=%v", out, err)
+	}
+	verifyExpired := `$root = Join-Path $HOME ".crabbox\workspace-owners"
+$state = Join-Path $root (` + psQuote(key) + ` + ".owner")
+$child = Join-Path $root (` + psQuote(key) + ` + ".child")
+$lines = @(Get-Content -LiteralPath $state -ErrorAction Stop)
+if ($lines.Count -ne 3 -or $lines[2] -ne "1") { throw "expired state changed" }
+if (Test-Path -LiteralPath $child) { throw "late witness published child" }
+`
+	if out, err := runWindowsPowerShellScript(t, verifyExpired); err != nil {
+		t.Fatalf("verify expired Windows generation out=%q err=%v", out, err)
+	}
+	req.Action = workspaceOwnerAcquire
+	if out, err := runWindowsPowerShellScript(t, decodePowerShellCommand(t, remoteWorkspaceOwnerWindows(req))); err != nil || !strings.Contains(string(out), "RECOVERED") {
+		t.Fatalf("recover expired Windows generation out=%q err=%v", out, err)
 	}
 	if out, err := runWindowsPowerShellScript(t, decodePowerShellCommand(t, remoteWorkspaceOwnerWindowsWitness(key, token, "Write-Output child-ok"))); err != nil || !strings.Contains(string(out), "child-ok") {
 		t.Fatalf("Windows witnessed child out=%q err=%v", out, err)

--- a/internal/cli/workspace_owner_test.go
+++ b/internal/cli/workspace_owner_test.go
@@ -1,0 +1,586 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type fakeWorkspaceOwnerRemote struct {
+	mu               sync.Mutex
+	token            string
+	expires          time.Time
+	childAlive       bool
+	failRenew        bool
+	ambiguousRelease bool
+	blockBusyAcquire bool
+	changed          chan struct{}
+}
+
+func newFakeWorkspaceOwnerRemote() *fakeWorkspaceOwnerRemote {
+	return &fakeWorkspaceOwnerRemote{changed: make(chan struct{})}
+}
+
+func (f *fakeWorkspaceOwnerRemote) signalLocked() {
+	close(f.changed)
+	f.changed = make(chan struct{})
+}
+
+func (f *fakeWorkspaceOwnerRemote) Do(ctx context.Context, req workspaceOwnerRemoteRequest) (string, error) {
+	for {
+		f.mu.Lock()
+		switch req.Action {
+		case workspaceOwnerAcquire:
+			if f.token == "" {
+				f.token = req.Token
+				f.expires = time.Now().Add(req.TTL)
+				f.signalLocked()
+				f.mu.Unlock()
+				return "ACQUIRED", nil
+			}
+			if time.Now().After(f.expires) {
+				if f.childAlive {
+					f.mu.Unlock()
+					return "CHILD", nil
+				}
+				f.token = req.Token
+				f.expires = time.Now().Add(req.TTL)
+				f.signalLocked()
+				f.mu.Unlock()
+				return "RECOVERED", nil
+			}
+			if !f.blockBusyAcquire {
+				f.mu.Unlock()
+				return "BUSY", nil
+			}
+			changed := f.changed
+			f.mu.Unlock()
+			select {
+			case <-ctx.Done():
+				return "", ctx.Err()
+			case <-changed:
+				continue
+			}
+		case workspaceOwnerRenew:
+			if f.failRenew {
+				f.mu.Unlock()
+				return "", errors.New("renew transport lost")
+			}
+			if f.token != req.Token {
+				f.mu.Unlock()
+				return "MISMATCH", nil
+			}
+			f.expires = time.Now().Add(req.TTL)
+			f.mu.Unlock()
+			return "RENEWED", nil
+		case workspaceOwnerInspect:
+			if f.token != req.Token {
+				f.mu.Unlock()
+				return "MISMATCH", nil
+			}
+			if f.childAlive {
+				f.mu.Unlock()
+				return "CHILD", nil
+			}
+			f.mu.Unlock()
+			return "OWNED", nil
+		case workspaceOwnerRelease:
+			if f.ambiguousRelease {
+				f.mu.Unlock()
+				return "", errors.New("release response lost")
+			}
+			if f.token != req.Token {
+				f.mu.Unlock()
+				return "MISMATCH", nil
+			}
+			if f.childAlive {
+				f.mu.Unlock()
+				return "CHILD", nil
+			}
+			f.token = ""
+			f.signalLocked()
+			f.mu.Unlock()
+			return "RELEASED", nil
+		default:
+			f.mu.Unlock()
+			return "AMBIGUOUS", nil
+		}
+	}
+}
+
+func acquireFakeWorkspaceOwner(t *testing.T, ctx context.Context, remote *fakeWorkspaceOwnerRemote, leaseID string) *workspaceOwner {
+	t.Helper()
+	owner, err := acquireWorkspaceOwnerWithTransport(ctx, SSHTarget{}, leaseID, &bytes.Buffer{}, remote, 250*time.Millisecond, 80*time.Millisecond, 20*time.Millisecond)
+	if err != nil {
+		t.Fatalf("acquire workspace owner: %v", err)
+	}
+	return owner
+}
+
+func crashFakeWorkspaceOwner(t *testing.T, owner *workspaceOwner) {
+	t.Helper()
+	owner.closeOnce.Do(func() {
+		close(owner.stop)
+		<-owner.done
+	})
+}
+
+func TestWorkspaceOwnerSerializesIndependentClientsAndRevisions(t *testing.T) {
+	remote := newFakeWorkspaceOwnerRemote()
+	remote.blockBusyAcquire = true
+	ownerA := acquireFakeWorkspaceOwner(t, context.Background(), remote, "cbx_shared")
+
+	type fakeWorkspace struct {
+		sync.Mutex
+		revision string
+	}
+	var workspace fakeWorkspace
+	var active atomic.Int32
+	var overlap atomic.Bool
+	startedA := make(chan struct{})
+	releaseA := make(chan struct{})
+	done := make(chan error, 2)
+	run := func(owner *workspaceOwner, revision string, started chan<- struct{}, release <-chan struct{}) {
+		if active.Add(1) != 1 {
+			overlap.Store(true)
+		}
+		defer active.Add(-1)
+		workspace.Lock()
+		workspace.revision = revision
+		workspace.Unlock()
+		if started != nil {
+			close(started)
+		}
+		if release != nil {
+			<-release
+		}
+		workspace.Lock()
+		executed := workspace.revision
+		workspace.Unlock()
+		if executed != revision {
+			done <- fmt.Errorf("executed revision %s, want %s", executed, revision)
+			return
+		}
+		done <- nil
+	}
+	go run(ownerA, "revision-a", startedA, releaseA)
+	<-startedA
+
+	ownerBCh := make(chan *workspaceOwner, 1)
+	errBCh := make(chan error, 1)
+	go func() {
+		ownerB, err := acquireWorkspaceOwnerWithTransport(context.Background(), SSHTarget{}, "cbx_shared", &bytes.Buffer{}, remote, time.Second, 80*time.Millisecond, 20*time.Millisecond)
+		if err != nil {
+			errBCh <- err
+			return
+		}
+		ownerBCh <- ownerB
+	}()
+	select {
+	case ownerB := <-ownerBCh:
+		_ = ownerB.Close(context.Background())
+		t.Fatal("second client acquired while the first lifecycle was active")
+	case err := <-errBCh:
+		t.Fatalf("second client failed instead of waiting: %v", err)
+	case <-time.After(30 * time.Millisecond):
+	}
+	close(releaseA)
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+	if err := ownerA.Close(context.Background()); err != nil {
+		t.Fatalf("release first owner: %v", err)
+	}
+	var ownerB *workspaceOwner
+	select {
+	case ownerB = <-ownerBCh:
+	case err := <-errBCh:
+		t.Fatalf("second client acquire: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("second client did not acquire after release")
+	}
+	go run(ownerB, "revision-b", nil, nil)
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+	if overlap.Load() {
+		t.Fatal("independent clients overlapped workspace lifecycle operations")
+	}
+	if err := ownerB.Close(context.Background()); err != nil {
+		t.Fatalf("release second owner: %v", err)
+	}
+}
+
+func TestWorkspaceOwnerCrashRecoveryHonorsWitnessedChild(t *testing.T) {
+	remote := newFakeWorkspaceOwnerRemote()
+	owner := acquireFakeWorkspaceOwner(t, context.Background(), remote, "cbx_child")
+	crashFakeWorkspaceOwner(t, owner)
+	remote.mu.Lock()
+	remote.expires = time.Now().Add(-time.Second)
+	remote.childAlive = true
+	remote.mu.Unlock()
+
+	_, err := acquireWorkspaceOwnerWithTransport(context.Background(), SSHTarget{}, "cbx_child", &bytes.Buffer{}, remote, 40*time.Millisecond, time.Second, 100*time.Millisecond)
+	if err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("live witnessed child takeover err=%v, want bounded refusal", err)
+	}
+	remote.mu.Lock()
+	remote.childAlive = false
+	remote.mu.Unlock()
+	recovered := acquireFakeWorkspaceOwner(t, context.Background(), remote, "cbx_child")
+	if err := recovered.Close(context.Background()); err != nil {
+		t.Fatalf("release recovered owner: %v", err)
+	}
+}
+
+func TestWorkspaceOwnerTokenAndTransportFailuresFailClosed(t *testing.T) {
+	t.Run("token mismatch", func(t *testing.T) {
+		remote := newFakeWorkspaceOwnerRemote()
+		owner := acquireFakeWorkspaceOwner(t, context.Background(), remote, "cbx_token")
+		remote.mu.Lock()
+		remote.token = strings.Repeat("f", 64)
+		remote.mu.Unlock()
+		if err := owner.Close(context.Background()); err == nil || !strings.Contains(err.Error(), "mismatch") {
+			t.Fatalf("close err=%v, want token mismatch", err)
+		}
+	})
+
+	t.Run("failed renew", func(t *testing.T) {
+		remote := newFakeWorkspaceOwnerRemote()
+		owner, err := acquireWorkspaceOwnerWithTransport(context.Background(), SSHTarget{}, "cbx_renew", &bytes.Buffer{}, remote, time.Second, 50*time.Millisecond, 5*time.Millisecond)
+		if err != nil {
+			t.Fatal(err)
+		}
+		remote.mu.Lock()
+		remote.failRenew = true
+		remote.mu.Unlock()
+		select {
+		case <-owner.Context().Done():
+		case <-time.After(time.Second):
+			t.Fatal("renewal failure did not cancel lifecycle context")
+		}
+		if err := owner.Close(context.Background()); err == nil || !strings.Contains(err.Error(), "renewal failed closed") {
+			t.Fatalf("close err=%v, want renewal failure", err)
+		}
+	})
+
+	t.Run("ambiguous release", func(t *testing.T) {
+		remote := newFakeWorkspaceOwnerRemote()
+		owner := acquireFakeWorkspaceOwner(t, context.Background(), remote, "cbx_release")
+		remote.mu.Lock()
+		remote.ambiguousRelease = true
+		remote.mu.Unlock()
+		if err := owner.Close(context.Background()); err == nil || !strings.Contains(err.Error(), "ambiguous remote state") {
+			t.Fatalf("close err=%v, want ambiguous release", err)
+		}
+	})
+}
+
+func TestWorkspaceOwnerAcquisitionBoundary(t *testing.T) {
+	if shouldAcquireWorkspaceOwner(true) {
+		t.Fatal("newly acquired one-shot lease must bypass the reuse owner")
+	}
+	if !shouldAcquireWorkspaceOwner(false) {
+		t.Fatal("existing, pooled, and watch-reused leases must acquire the reuse owner")
+	}
+}
+
+func TestWorkspaceOwnerContextWrapsEverySSHChild(t *testing.T) {
+	owner := &workspaceOwner{target: SSHTarget{TargetOS: targetLinux}, key: strings.Repeat("a", 64), token: strings.Repeat("b", 64)}
+	ctx := contextWithWorkspaceOwner(context.Background(), owner)
+	if got := wrapWorkspaceOwnerRemote(ctx, "printf ok", false); !strings.Contains(got, "child_identity=$(ps -o lstart=") {
+		t.Fatalf("ordinary SSH child was not witnessed:\n%s", got)
+	}
+	if got := wrapWorkspaceOwnerRemote(ctx, "cat", true); !strings.Contains(got, `cat >"$run_dir/input"`) || !strings.Contains(got, `<"$run_dir/input"`) {
+		t.Fatalf("input SSH child did not preserve stdin:\n%s", got)
+	}
+	if got := wrapWorkspaceOwnerRemote(contextWithoutWorkspaceOwner(ctx), "printf raw", false); got != "printf raw" {
+		t.Fatalf("owner bypass wrapped protocol-internal command: %q", got)
+	}
+}
+
+func TestWorkspaceOwnerLifecycleBoundaryMatrix(t *testing.T) {
+	for _, lifecycle := range []string{
+		"fingerprint skip",
+		"normal sync",
+		"full resync",
+		"no sync",
+		"sync only",
+		"fresh pr",
+		"actions hydration",
+		"command",
+		"results and artifacts",
+		"failure bundle",
+		"pool scrub and return",
+		"watch iteration",
+	} {
+		t.Run(lifecycle, func(t *testing.T) {
+			if !shouldAcquireWorkspaceOwner(false) {
+				t.Fatalf("reused %s path bypassed workspace ownership", lifecycle)
+			}
+		})
+	}
+}
+
+func TestWorkspaceOwnerSerializesRunAndStandaloneActionsHydration(t *testing.T) {
+	remote := newFakeWorkspaceOwnerRemote()
+	remote.blockBusyAcquire = true
+	runOwner := acquireFakeWorkspaceOwner(t, context.Background(), remote, "cbx_run_hydrate")
+	hydrateOwner := make(chan *workspaceOwner, 1)
+	hydrateErr := make(chan error, 1)
+	go func() {
+		owner, err := acquireWorkspaceOwnerWithTransport(context.Background(), SSHTarget{}, "cbx_run_hydrate", &bytes.Buffer{}, remote, time.Second, time.Second, 100*time.Millisecond)
+		if err != nil {
+			hydrateErr <- err
+			return
+		}
+		hydrateOwner <- owner
+	}()
+	select {
+	case owner := <-hydrateOwner:
+		_ = owner.Close(context.Background())
+		t.Fatal("standalone Actions hydration overlapped the normal run owner")
+	case err := <-hydrateErr:
+		t.Fatalf("standalone Actions hydration failed instead of contending: %v", err)
+	case <-time.After(30 * time.Millisecond):
+	}
+	if err := runOwner.Close(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case owner := <-hydrateOwner:
+		if err := owner.Close(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	case err := <-hydrateErr:
+		t.Fatal(err)
+	case <-time.After(time.Second):
+		t.Fatal("standalone Actions hydration did not acquire after the run released")
+	}
+}
+
+func TestWorkspaceOwnerProtocolGeneration(t *testing.T) {
+	leaseID := "cbx_raw-lease-must-not-appear"
+	key := workspaceOwnerKey(leaseID)
+	token := strings.Repeat("a", 64)
+	req := workspaceOwnerRemoteRequest{Action: workspaceOwnerAcquire, Key: key, Token: token, TTL: time.Minute}
+
+	posix := remoteWorkspaceOwnerCommand(SSHTarget{TargetOS: targetLinux}, req)
+	wsl := remoteWorkspaceOwnerCommand(SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeWSL2}, req)
+	if posix != wsl {
+		t.Fatal("POSIX and WSL2 must use the same owner protocol")
+	}
+	for _, want := range []string{".crabbox/workspace-owners", key + ".gate", "$key.owner", "$key.child", "flock -x -w 0", "lockf -t 0", "ps -o lstart=", "RECOVERED", "MISMATCH", "AMBIGUOUS"} {
+		if !strings.Contains(posix, want) {
+			t.Fatalf("POSIX protocol missing %q:\n%s", want, posix)
+		}
+	}
+	if strings.Contains(posix, leaseID) {
+		t.Fatalf("POSIX protocol exposed raw lease ID: %s", posix)
+	}
+
+	windows := decodePowerShellCommand(t, remoteWorkspaceOwnerCommand(SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeNormal}, req))
+	for _, want := range []string{".crabbox\\workspace-owners", "$key = '" + key + "'", "$key + \".owner\"", "$key + \".child\"", "[Diagnostics.Process]::GetProcessById", "return \"ambiguous\"", "StartTime.ToUniversalTime().Ticks", "RECOVERED", "MISMATCH", "AMBIGUOUS"} {
+		if !strings.Contains(windows, want) {
+			t.Fatalf("Windows protocol missing %q:\n%s", want, windows)
+		}
+	}
+	if strings.Contains(windows, leaseID) {
+		t.Fatalf("Windows protocol exposed raw lease ID: %s", windows)
+	}
+	posixWitness := remoteWorkspaceOwnerPOSIXWitness(key, token, "printf ok")
+	for _, want := range []string{"child_identity=$(ps -o lstart=", "mv \"$child_tmp\" \"$child\"", "touch \"$start\"", "wait \"$child_pid\"", "rm -f \"$child\""} {
+		if !strings.Contains(posixWitness, want) {
+			t.Fatalf("POSIX child witness missing %q:\n%s", want, posixWitness)
+		}
+	}
+	windowsWitness := decodePowerShellCommand(t, remoteWorkspaceOwnerWindowsWitness(key, token, "Write-Output ok"))
+	for _, want := range []string{"Start-Process", "StartTime.ToUniversalTime().Ticks", "Move-Item -LiteralPath $tmp -Destination $child", "$process.WaitForExit()", "Remove-Item -LiteralPath $child"} {
+		if !strings.Contains(windowsWitness, want) {
+			t.Fatalf("Windows child witness missing %q:\n%s", want, windowsWitness)
+		}
+	}
+	windowsInputWitness := decodePowerShellCommand(t, remoteWorkspaceOwnerWindowsWitness(key, token, "Write-Output ok", true))
+	for _, want := range []string{"[Console]::OpenStandardInput().CopyTo($inputFile)", "-RedirectStandardInput $inputPath", "[IO.FileShare]::None"} {
+		if !strings.Contains(windowsInputWitness, want) {
+			t.Fatalf("Windows input witness missing %q:\n%s", want, windowsInputWitness)
+		}
+	}
+}
+
+func runPOSIXWorkspaceOwnerScript(t *testing.T, home, script string) (string, error) {
+	t.Helper()
+	cmd := exec.Command("sh", "-c", script)
+	cmd.Env = append(os.Environ(), "HOME="+home)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+func TestWorkspaceOwnerPOSIXProtocolBehavior(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX protocol execution requires sh")
+	}
+	home := t.TempDir()
+	key := workspaceOwnerKey("cbx_protocol")
+	tokenA := strings.Repeat("a", 64)
+	tokenB := strings.Repeat("b", 64)
+	request := func(action workspaceOwnerAction, token string) workspaceOwnerRemoteRequest {
+		return workspaceOwnerRemoteRequest{Action: action, Key: key, Token: token, TTL: 30 * time.Second}
+	}
+	if out, err := runPOSIXWorkspaceOwnerScript(t, home, remoteWorkspaceOwnerPOSIX(request(workspaceOwnerAcquire, tokenA))); err != nil || out != "ACQUIRED" {
+		t.Fatalf("acquire out=%q err=%v", out, err)
+	}
+	if out, err := runPOSIXWorkspaceOwnerScript(t, home, remoteWorkspaceOwnerPOSIX(request(workspaceOwnerRenew, tokenB))); err == nil || out != "MISMATCH" {
+		t.Fatalf("mismatched renew out=%q err=%v", out, err)
+	}
+
+	resultPath := filepath.Join(home, "revision.txt")
+	witness := remoteWorkspaceOwnerPOSIXWitness(key, tokenA, "printf revision-a > "+shellQuote(resultPath))
+	if out, err := runPOSIXWorkspaceOwnerScript(t, home, witness); err != nil {
+		t.Fatalf("witnessed command out=%q err=%v", out, err)
+	}
+	if data, err := os.ReadFile(resultPath); err != nil || string(data) != "revision-a" {
+		t.Fatalf("witnessed result=%q err=%v", data, err)
+	}
+	inputPath := filepath.Join(home, "input.txt")
+	inputWitness := remoteWorkspaceOwnerPOSIXWitness(key, tokenA, "cat > "+shellQuote(inputPath), true)
+	cmd := exec.Command("sh", "-c", inputWitness)
+	cmd.Env = append(os.Environ(), "HOME="+home)
+	cmd.Stdin = strings.NewReader("registration-input")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("input witness out=%q err=%v", out, err)
+	}
+	if data, err := os.ReadFile(inputPath); err != nil || string(data) != "registration-input" {
+		t.Fatalf("witnessed input=%q err=%v", data, err)
+	}
+	identityOut, err := exec.Command("ps", "-o", "lstart=", "-p", strconv.Itoa(os.Getpid())).Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity := strings.TrimSpace(strings.Join(strings.Fields(string(identityOut)), " "))
+	childPath := filepath.Join(home, ".crabbox", "workspace-owners", key+".child")
+	existingWitness := strconv.Itoa(os.Getpid()) + "\n" + identity + "\n"
+	if err := os.WriteFile(childPath, []byte(existingWitness), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := runPOSIXWorkspaceOwnerScript(t, home, remoteWorkspaceOwnerPOSIXWitness(key, tokenA, "true")); err == nil {
+		t.Fatalf("overlapping witness replaced live child: out=%q", out)
+	}
+	if data, err := os.ReadFile(childPath); err != nil || string(data) != existingWitness {
+		t.Fatalf("live witness changed: data=%q err=%v", data, err)
+	}
+	if err := os.Remove(childPath); err != nil {
+		t.Fatal(err)
+	}
+	guardOwner := &workspaceOwner{target: SSHTarget{TargetOS: targetLinux}, key: key, token: tokenA}
+	if out, err := runPOSIXWorkspaceOwnerScript(t, home, guardOwner.WrapBackgroundCommand(guardOwner.rsyncGuardPayload(filepath.Join(home, "guard-destination")))); err != nil || strings.TrimSpace(out) == "" {
+		t.Fatalf("start rsync guard out=%q err=%v", out, err)
+	}
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		if _, err := os.Stat(childPath); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("rsync guard did not publish its child witness")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if out, err := runPOSIXWorkspaceOwnerScript(t, home, guardOwner.rsyncStopCommand()); err != nil {
+		t.Fatalf("stop rsync guard out=%q err=%v", out, err)
+	}
+	deadline = time.Now().Add(3 * time.Second)
+	for {
+		if _, err := os.Stat(childPath); os.IsNotExist(err) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("rsync guard did not clear its child witness")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if _, err := os.Stat(childPath); !os.IsNotExist(err) {
+		t.Fatalf("child witness remained after exit: %v", err)
+	}
+
+	statePath := filepath.Join(home, ".crabbox", "workspace-owners", key+".owner")
+	if err := os.WriteFile(statePath, []byte("v1\n"+tokenA+"\n1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(childPath, []byte(strconv.Itoa(os.Getpid())+"\n"+identity+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := runPOSIXWorkspaceOwnerScript(t, home, remoteWorkspaceOwnerPOSIX(request(workspaceOwnerAcquire, tokenB))); err != nil || out != "CHILD" {
+		t.Fatalf("live child acquire out=%q err=%v", out, err)
+	}
+	if err := os.WriteFile(childPath, []byte("999999999\nold identity\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := runPOSIXWorkspaceOwnerScript(t, home, remoteWorkspaceOwnerPOSIX(request(workspaceOwnerAcquire, tokenB))); err != nil || out != "RECOVERED" {
+		t.Fatalf("stale recovery out=%q err=%v", out, err)
+	}
+	if out, err := runPOSIXWorkspaceOwnerScript(t, home, remoteWorkspaceOwnerPOSIX(request(workspaceOwnerRelease, tokenB))); err != nil || out != "RELEASED" {
+		t.Fatalf("release out=%q err=%v", out, err)
+	}
+}
+
+func TestWorkspaceOwnerPOSIXRecoversAbandonedGate(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX protocol execution requires sh")
+	}
+	home := t.TempDir()
+	key := workspaceOwnerKey("cbx_stale_gate")
+	token := strings.Repeat("d", 64)
+	root := filepath.Join(home, ".crabbox", "workspace-owners")
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, key+".gate"), []byte("abandoned"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	req := workspaceOwnerRemoteRequest{Action: workspaceOwnerAcquire, Key: key, Token: token, TTL: 30 * time.Second}
+	if out, err := runPOSIXWorkspaceOwnerScript(t, home, remoteWorkspaceOwnerPOSIX(req)); err != nil || out != "ACQUIRED" {
+		t.Fatalf("recover abandoned gate out=%q err=%v", out, err)
+	}
+	req.Action = workspaceOwnerRelease
+	if out, err := runPOSIXWorkspaceOwnerScript(t, home, remoteWorkspaceOwnerPOSIX(req)); err != nil || out != "RELEASED" {
+		t.Fatalf("release after gate recovery out=%q err=%v", out, err)
+	}
+}
+
+func TestWorkspaceOwnerWindowsProtocolBehavior(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("native Windows protocol execution runs in Windows CI")
+	}
+	key := workspaceOwnerKey("cbx_windows_protocol_" + strconv.FormatInt(time.Now().UnixNano(), 10))
+	token := strings.Repeat("c", 64)
+	prepare := `$root = Join-Path $HOME ".crabbox\workspace-owners"
+New-Item -ItemType Directory -Force -Path $root | Out-Null
+Set-Content -LiteralPath (Join-Path $root (` + psQuote(key) + ` + ".gate")) -Value "abandoned" -Encoding ASCII
+`
+	if out, err := runWindowsPowerShellScript(t, prepare); err != nil {
+		t.Fatalf("prepare abandoned Windows gate out=%q err=%v", out, err)
+	}
+	req := workspaceOwnerRemoteRequest{Action: workspaceOwnerAcquire, Key: key, Token: token, TTL: 30 * time.Second}
+	if out, err := runWindowsPowerShellScript(t, decodePowerShellCommand(t, remoteWorkspaceOwnerWindows(req))); err != nil || !strings.Contains(string(out), "ACQUIRED") {
+		t.Fatalf("Windows acquire out=%q err=%v", out, err)
+	}
+	if out, err := runWindowsPowerShellScript(t, decodePowerShellCommand(t, remoteWorkspaceOwnerWindowsWitness(key, token, "Write-Output child-ok"))); err != nil || !strings.Contains(string(out), "child-ok") {
+		t.Fatalf("Windows witnessed child out=%q err=%v", out, err)
+	}
+	req.Action = workspaceOwnerRelease
+	if out, err := runWindowsPowerShellScript(t, decodePowerShellCommand(t, remoteWorkspaceOwnerWindows(req))); err != nil || !strings.Contains(string(out), "RELEASED") {
+		t.Fatalf("Windows release out=%q err=%v", out, err)
+	}
+}


### PR DESCRIPTION
Closes https://github.com/openclaw/crabbox/issues/1244

## What Problem This Solves

Fixes an issue where concurrent clients reusing the same SSH lease could inspect, sync, hydrate, execute, or collect from one mutable workspace at the same time. That race could silently execute files from a different revision than the reported fingerprint.

It also completes the original Git-coherence work in this pull request so reusable POSIX, WSL2, and native Windows workspaces keep their requested commit, index, origin, and fingerprint aligned without advancing an existing symbolic branch.

## Why This Change Was Made

Reusable SSH leases now acquire one provider-neutral, remote lease-scoped workspace owner before any workspace or hydration-state inspection. The fenced owner remains active through sync, Actions hydration, command execution, result and artifact collection, failure capture, scrub, and ready-pool return.

The protocol uses a digest-derived remote identity, opaque generation tokens, bounded waits with progress, heartbeat expiry, witnessed remote child identity, token-bound release, and fail-closed ambiguous-state handling. Expired generations cannot renew, inspect, or publish new children. Stale recovery is allowed only when no witnessed child remains alive.

POSIX, WSL2, and native Windows implement the same semantics through target-specific command adapters. Static SSH acquisitions serialize because they reuse a configured host; only genuinely new exclusive one-shot leases bypass ownership. Ready-pool entries are not published or destroyed until remote ownership is released, and Actions cancellation markers are generation-scoped.

## User Impact

Two clients can safely reuse one lease without overlapping workspace mutations or executing the wrong revision. A contending client waits with visible progress, then continues after the current owner releases. Crashed owners recover only after expiry and only when no witnessed child is still running.

## Evidence

- Deterministic independent-client and revision serialization coverage.
- Client-death tests with live-child refusal and no-child stale recovery.
- Token mismatch, expired renewal/inspection/witness, ambiguous transport, and release failure coverage.
- Run versus standalone Actions hydration contention and generation-scoped cancellation tests.
- Ready-pool ready/drain/release ordering and owner-release failure tests.
- POSIX, WSL2, and native Windows protocol generation/behavior coverage.
- Windows Git coherence forward/rollback tests preserve symbolic branches.
- `go vet ./...`
- `go test -race ./...`
- `scripts/test-go-modules.sh`
- `scripts/check-go-coverage.sh 90.0`
- `go build -trimpath -o /tmp/crabbox-1244 ./cmd/crabbox`
- `scripts/check-docs.sh`
- `node --test scripts/*.test.js`
- Final structured autoreview: no accepted/actionable findings.
- Live local-container proof: run A synced and held marker A for 15 seconds; run B waited on the same remote owner, then began after A ended and observed marker B. Both released ownership, the lease stopped, and inventory was empty.
