### PR TITLE
fix: include commands in failure bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Included the normalized, secret-redacted command beside the durable run ID in failure bundle metadata. Thanks @goutamadwant.
 - Serialized each reused SSH lease's complete workspace lifecycle across clients and watch iterations, from hydration-state and fingerprint inspection through sync, execution, evidence collection, failure capture, and pool scrub/return, with fenced stale-owner recovery on POSIX, WSL2, and native Windows. Reused Git workspaces now also keep `HEAD`, the index, the requested tree, and sync fingerprints coherent without advancing symbolic branches. Thanks @vincentkoc.
 - Stopped market-independent AWS Spot launch request errors from being retried as On-Demand while preserving fallback for Spot-recoverable capacity, quota, and unsupported-market failures. Thanks @vincentkoc.
 - Made plain source builds report `dev` instead of the stale `0.15.0` release identity while preserving injected release versions and tagged Go module build information. Thanks @coygeek.

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1925,6 +1925,7 @@ afterSync:
 			LeaseID:        leaseID,
 			Slug:           serverSlug(server),
 			RunID:          executionRunID,
+			CommandDisplay: commandDisplay,
 			Workdir:        workdir,
 			ExitCode:       code,
 			ActionsRunURL:  actionsURL,

--- a/internal/cli/run_observability.go
+++ b/internal/cli/run_observability.go
@@ -643,6 +643,7 @@ type FailureCaptureMetadata struct {
 	LeaseID        string
 	Slug           string
 	RunID          string
+	CommandDisplay string
 	Workdir        string
 	ExitCode       int
 	ActionsRunURL  string
@@ -763,11 +764,18 @@ func writeLocalFailureBundle(name, remoteTarPath string, meta FailureCaptureMeta
 }
 
 func addFailureBundleMetadata(tw *tar.Writer, meta FailureCaptureMetadata) error {
+	commandSecrets := configuredDiagnosticSecrets(meta.Config)
+	for _, value := range meta.Env {
+		if strings.TrimSpace(value) != "" {
+			commandSecrets = append(commandSecrets, value)
+		}
+	}
 	run := map[string]any{
 		"provider":          meta.Provider,
 		"leaseId":           meta.LeaseID,
 		"slug":              meta.Slug,
 		"runId":             meta.RunID,
+		"command":           RedactDiagnosticSecrets(meta.CommandDisplay, commandSecrets...),
 		"workdir":           meta.Workdir,
 		"exitCode":          meta.ExitCode,
 		"actionsRunUrl":     meta.ActionsRunURL,

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -2797,17 +2797,61 @@ func TestWriteLocalFailureBundleIncludesMetadataStreamsAndRemoteFiles(t *testing
 		t.Fatalf("remote capture command failed: %v\n%s", err, out)
 	}
 
+	const (
+		urlUser     = "url-user"
+		urlPassword = "url-password"
+	)
+	knownSecrets := []string{
+		"configured-overlap-secret",
+		"overlap-secret",
+		"configured-profile-secret",
+		"forwarded-exact-secret",
+		"q7x",
+		"z9q",
+		urlUser,
+		urlPassword,
+		"query-token",
+		"assignment-token",
+		"client-token",
+		"header-token",
+	}
+	commandDisplay := strings.Join([]string{
+		"deploy --region us-west-2 --artifact report.json",
+		"--endpoint=https://" + urlUser + ":" + urlPassword + "@example.test/v1?token=query-token&trace=keep",
+		"api-key=assignment-token client-secret:client-token --token=forwarded-exact-secret",
+		"configured-overlap-secret overlap-secret configured-profile-secret",
+		"forwarded-exact-secret forwarded-exact-secret q7x",
+		"--header 'Authorization: Bearer header-token'",
+		"z9q",
+	}, " ")
 	local, _, err := writeLocalFailureBundle("bundle.tar.gz", filepath.Join(remoteWorkdir, ".crabbox", "remote.tar.gz"), FailureCaptureMetadata{
-		Provider:   "aws",
-		LeaseID:    "cbx_123",
-		Slug:       "blue-crab",
-		RunID:      "run_123",
-		Workdir:    "/work/crabbox/cbx_123/repo",
-		ExitCode:   7,
-		Timing:     timingReport{Provider: "aws", LeaseID: "cbx_123", ExitCode: 7},
-		EnvAllow:   []string{"API_TOKEN"},
-		Env:        map[string]string{"API_TOKEN": "secret-value"},
-		Config:     Config{Provider: "aws", TargetOS: targetLinux, Class: "standard", IdleTimeout: time.Minute, TTL: time.Hour, WorkRoot: "/work/crabbox"},
+		Provider:       "aws",
+		LeaseID:        "cbx_123",
+		Slug:           "blue-crab",
+		RunID:          "run_123",
+		CommandDisplay: commandDisplay,
+		Workdir:        "/work/crabbox/cbx_123/repo",
+		ExitCode:       7,
+		Timing:         timingReport{Provider: "aws", LeaseID: "cbx_123", ExitCode: 7},
+		EnvAllow:       []string{"API_TOKEN", "OVERLAP_TOKEN", "SHORT_SECRET", "TRAILING_SECRET"},
+		Env: map[string]string{
+			"API_TOKEN":       "forwarded-exact-secret",
+			"OVERLAP_TOKEN":   "overlap-secret",
+			"SHORT_SECRET":    "q7x",
+			"TRAILING_SECRET": "z9q ",
+		},
+		Config: Config{
+			Provider:    "aws",
+			TargetOS:    targetLinux,
+			Class:       "standard",
+			IdleTimeout: time.Minute,
+			TTL:         time.Hour,
+			WorkRoot:    "/work/crabbox",
+			CoordToken:  "configured-overlap-secret",
+			Profiles: map[string]ProfileConfig{
+				"proof": {Env: map[string]string{"SERVICE_TOKEN": "configured-profile-secret"}},
+			},
+		},
 		StdoutPath: stdoutPath,
 		StderrPath: stderrPath,
 	})
@@ -2828,9 +2872,29 @@ func TestWriteLocalFailureBundleIncludesMetadataStreamsAndRemoteFiles(t *testing
 			t.Fatalf("bundle missing %q; entries=%#v", want, contents)
 		}
 	}
+	var runMetadata struct {
+		Command string `json:"command"`
+		RunID   string `json:"runId"`
+	}
+	if err := json.Unmarshal(contents["crabbox-artifacts/crabbox-run.json"], &runMetadata); err != nil {
+		t.Fatalf("decode crabbox-run.json: %v", err)
+	}
+	if runMetadata.RunID != "run_123" {
+		t.Fatalf("run metadata ID=%q, want durable run_123", runMetadata.RunID)
+	}
+	for _, want := range []string{"deploy", "--region us-west-2", "--artifact report.json", "example.test/v1", "trace=keep"} {
+		if !strings.Contains(runMetadata.Command, want) {
+			t.Fatalf("redacted command lost harmless context %q: %q", want, runMetadata.Command)
+		}
+	}
+	if !strings.Contains(runMetadata.Command, diagnosticRedaction) {
+		t.Fatalf("command metadata contains no redaction marker: %q", runMetadata.Command)
+	}
 	for name, data := range contents {
-		if bytes.Contains(data, []byte("secret-value")) {
-			t.Fatalf("bundle entry %s leaked secret value", name)
+		for _, secret := range knownSecrets {
+			if bytes.Contains(data, []byte(secret)) {
+				t.Fatalf("bundle entry %s leaked known secret %q", name, secret)
+			}
 		}
 	}
 }
@@ -2914,15 +2978,16 @@ func TestNativeWindowsFailureBundleUsesLocalStreams(t *testing.T) {
 		t.Fatal(err)
 	}
 	local, _, err := captureFailureBundle(context.Background(), SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeNormal}, "C:\\crabbox\\repo", "cbx_win", "run_win", FailureCaptureMetadata{
-		Provider:   "aws",
-		LeaseID:    "cbx_win",
-		RunID:      "run_win",
-		Workdir:    "C:\\crabbox\\repo",
-		ExitCode:   9,
-		Timing:     timingReport{Provider: "aws", LeaseID: "cbx_win", ExitCode: 9},
-		Config:     Config{Provider: "aws", TargetOS: targetWindows, WindowsMode: windowsModeNormal},
-		StdoutPath: stdoutPath,
-		StderrPath: stderrPath,
+		Provider:       "aws",
+		LeaseID:        "cbx_win",
+		RunID:          "run_win",
+		CommandDisplay: "dotnet test --configuration Release",
+		Workdir:        "C:\\crabbox\\repo",
+		ExitCode:       9,
+		Timing:         timingReport{Provider: "aws", LeaseID: "cbx_win", ExitCode: 9},
+		Config:         Config{Provider: "aws", TargetOS: targetWindows, WindowsMode: windowsModeNormal},
+		StdoutPath:     stdoutPath,
+		StderrPath:     stderrPath,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -2933,6 +2998,16 @@ func TestNativeWindowsFailureBundleUsesLocalStreams(t *testing.T) {
 	}
 	if !bytes.Contains(contents["crabbox-artifacts/stderr.log"], []byte("native stderr")) {
 		t.Fatalf("stderr missing: %#v", contents["crabbox-artifacts/stderr.log"])
+	}
+	var runMetadata struct {
+		Command string `json:"command"`
+		RunID   string `json:"runId"`
+	}
+	if err := json.Unmarshal(contents["crabbox-artifacts/crabbox-run.json"], &runMetadata); err != nil {
+		t.Fatalf("decode native Windows crabbox-run.json: %v", err)
+	}
+	if runMetadata.Command != "dotnet test --configuration Release" || runMetadata.RunID != "run_win" {
+		t.Fatalf("native Windows run metadata=%+v", runMetadata)
 	}
 	if _, ok := contents["crabbox-artifacts/remote/.crabbox/capture-manifest.txt"]; ok {
 		t.Fatalf("native Windows bundle should be local-only: %#v", contents)


### PR DESCRIPTION
Closes https://github.com/openclaw/crabbox/issues/1238

## Summary

Failure bundles already recorded a durable local run ID, but they omitted the command that produced the failure. The run path had a normalized command display for terminal output and other run records; it simply was not threaded into failure-capture metadata.

This change carries that existing normalized display into `FailureCaptureMetadata` and writes it as `command` beside `runId` in `crabbox-artifacts/crabbox-run.json`.

## Redaction and compatibility

Redaction happens at the archive metadata boundary, so POSIX, coordinatorless, and native Windows bundle paths share the same policy. The command is passed through the established diagnostic redactor with configured secrets and every effective forwarded value; structural URL userinfo, query credentials, authorization headers, and credential assignments are covered by the same redactor.

This is an additive metadata field. It requires no config or secret migration and changes no package version. Unknown literal argv secrets and captured stdout, stderr, or remote files are not universally scrubbed; failure bundles remain caller-reviewed before sharing, as their embedded README states.

## Verification

- Focused failure-bundle tests, including adversarial configured/profile/forwarded values, short and whitespace-normalized values, structural credentials, repeated/overlapping values, harmless context, every archive entry, durable run IDs, and native Windows local streams
- Focused failure-bundle tests under the race detector
- Full `go test ./internal/cli -count=1 -timeout=20m`
- `go vet ./internal/cli`
- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- `git diff --check`
- Global P1 autoreview and its TruffleHog scan
- Live coordinatorless `local-container` exit-7 run: one archive was created, the durable run ID and harmless command context were retained, all supplied credential forms were redacted across every archive entry, the caller-review warning remained, and lease cleanup succeeded
