### PR TITLE
fix(sync): report actionable error for non-Git workdir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Made local sync report actionable non-Git workdir diagnostics and fail before lease acquisition, resolution, preparation, or ready-pool borrowing. Thanks @bunlongheng.
+
 ## 0.41.3 - 2026-08-11
 
 ### Fixed

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -595,6 +596,38 @@ type SyncManifest struct {
 	ChangedBytes int64
 }
 
+// gitManifestError turns a raw git ls-files failure into an actionable,
+// workdir-aware diagnostic.
+func gitManifestError(root string, err error) error {
+	stderr := ""
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		stderr = strings.TrimSpace(string(exitErr.Stderr))
+	}
+	if isNotAGitRepoError(stderr) {
+		return fmt.Errorf("%s is not a Git repository: crabbox builds its sync manifest from Git; run `git init` here to sync files, or pass --no-sync to run without syncing local files", root)
+	}
+	if stderr != "" {
+		return fmt.Errorf("git ls-files in %s failed: %s", root, firstLine(stderr))
+	}
+	return fmt.Errorf("git ls-files in %s failed: %w", root, err)
+}
+
+func isNotAGitRepoError(stderr string) bool {
+	return strings.Contains(strings.ToLower(stderr), "not a git repository")
+}
+
+func gitSyncFileList(root string) ([]byte, error) {
+	cmd := exec.Command("git", "ls-files", "--cached", "--others", "--exclude-standard", "-z")
+	cmd.Dir = root
+	cmd.Env = repositoryGitEnvironment()
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, gitManifestError(root, err)
+	}
+	return out, nil
+}
+
 func syncManifest(root string, excludes []string) (SyncManifest, error) {
 	return syncManifestFiltered(root, excludes, nil)
 }
@@ -604,10 +637,7 @@ func syncManifest(root string, excludes []string) (SyncManifest, error) {
 // synced. This lets a job sync a few selected paths instead of the whole working
 // tree (e.g. sync just `src/` and `scripts/` out of a large repo).
 func syncManifestFiltered(root string, excludes, includes []string) (SyncManifest, error) {
-	cmd := exec.Command("git", "ls-files", "--cached", "--others", "--exclude-standard", "-z")
-	cmd.Dir = root
-	cmd.Env = repositoryGitEnvironment()
-	out, err := cmd.Output()
+	out, err := gitSyncFileList(root)
 	if err != nil {
 		return SyncManifest{}, err
 	}

--- a/internal/cli/repo_test.go
+++ b/internal/cli/repo_test.go
@@ -271,6 +271,31 @@ func TestSyncManifestUsesGitFilesAndIgnoresIgnoredJunk(t *testing.T) {
 	}
 }
 
+func TestSyncManifestNonGitWorkdirReturnsActionableError(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "main.txt"), "hello\n")
+
+	_, err := syncManifest(dir, configuredExcludes(baseConfig()))
+	if err == nil {
+		t.Fatal("expected error for non-Git workdir, got nil")
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "exit status") {
+		t.Fatalf("error should not surface an opaque process status: %q", msg)
+	}
+	if !strings.Contains(msg, dir) {
+		t.Fatalf("error should name the workdir %q: %q", dir, msg)
+	}
+	if !strings.Contains(msg, "not a Git repository") {
+		t.Fatalf("error should identify the non-Git cause: %q", msg)
+	}
+	for _, want := range []string{"git init", "--no-sync"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("error should suggest %q: %q", want, msg)
+		}
+	}
+}
+
 func TestSyncManifestIncludeWhitelist(t *testing.T) {
 	dir := t.TempDir()
 	runGit(t, dir, "init")

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -792,6 +792,12 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	if !ok {
 		return exit(2, "provider=%s does not support run", backend.Spec().Name)
 	}
+	if !*noSync && freshPR.Empty() {
+		_, err = gitSyncFileList(repo.Root)
+		if err != nil {
+			return exit(6, "build sync file list: %v", err)
+		}
+	}
 	coord := backendCoordinator(backend)
 	var registrationCoord *CoordinatorClient
 	if shouldRegisterCoordinatorLease(cfg) {

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -24,6 +26,7 @@ import (
 func init() {
 	RegisterProvider(windowsEnvHelperTestProvider{})
 	RegisterProvider(runEnvProfileTestProvider{})
+	RegisterProvider(runReadyPoolPreflightTestProvider{})
 	RegisterProvider(runPrepareTestProvider{})
 	RegisterProvider(runModuleRuntimeTestProvider{})
 }
@@ -473,6 +476,31 @@ func (p runEnvProfileTestProvider) Configure(Config, Runtime) (Backend, error) {
 	return runEnvProfileTestBackend{spec: p.Spec()}, nil
 }
 
+type runReadyPoolPreflightTestProvider struct{}
+
+func (runReadyPoolPreflightTestProvider) Name() string { return "run-ready-pool-preflight-test" }
+func (runReadyPoolPreflightTestProvider) Aliases() []string {
+	return nil
+}
+func (runReadyPoolPreflightTestProvider) Spec() ProviderSpec {
+	return ProviderSpec{
+		Name:        "run-ready-pool-preflight-test",
+		Kind:        ProviderKindSSHLease,
+		Targets:     []TargetSpec{{OS: targetLinux}},
+		Features:    FeatureSet{FeatureSSH, FeatureCrabboxSync},
+		Coordinator: CoordinatorSupported,
+	}
+}
+func (runReadyPoolPreflightTestProvider) RegisterFlags(*flag.FlagSet, Config) any {
+	return noProviderFlags{}
+}
+func (runReadyPoolPreflightTestProvider) ApplyFlags(*Config, *flag.FlagSet, any) error {
+	return nil
+}
+func (p runReadyPoolPreflightTestProvider) Configure(Config, Runtime) (Backend, error) {
+	return runEnvProfileTestBackend{spec: p.Spec()}, nil
+}
+
 type runEnvProfileTestBackend struct {
 	spec ProviderSpec
 }
@@ -482,9 +510,13 @@ func (b runEnvProfileTestBackend) AcquireIsExclusiveOneShot() bool { return true
 var runEnvProfileTestReleaseErr error
 var runEnvProfileTestReleaseHook func() error
 var runEnvProfileTestConnectionCleanupSafe = true
+var runEnvProfileTestAcquireHook func(AcquireRequest)
 
 func (b runEnvProfileTestBackend) Spec() ProviderSpec { return b.spec }
-func (b runEnvProfileTestBackend) Acquire(context.Context, AcquireRequest) (LeaseTarget, error) {
+func (b runEnvProfileTestBackend) Acquire(_ context.Context, req AcquireRequest) (LeaseTarget, error) {
+	if runEnvProfileTestAcquireHook != nil {
+		runEnvProfileTestAcquireHook(req)
+	}
 	return LeaseTarget{
 		Server: Server{Provider: b.spec.Name},
 		SSH: SSHTarget{
@@ -519,6 +551,128 @@ func (b runEnvProfileTestBackend) Touch(context.Context, TouchRequest) (Server, 
 }
 func (b runEnvProfileTestBackend) ReleaseLeaseConnectionCleanupSafe() bool {
 	return runEnvProfileTestConnectionCleanupSafe
+}
+
+func TestRunNonGitWorkdirFailsBeforeAcquire(t *testing.T) {
+	clearConfigEnv(t)
+	dir := t.TempDir()
+	isolateRunTestUserDirs(t, dir)
+	t.Chdir(dir)
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, "missing.yaml"))
+	acquireCalls := 0
+	runEnvProfileTestAcquireHook = func(AcquireRequest) { acquireCalls++ }
+	t.Cleanup(func() { runEnvProfileTestAcquireHook = nil })
+
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
+		"--provider", "run-env-profile-test",
+		"--", "true",
+	})
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 6 {
+		t.Fatalf("error=%v, want exit 6\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	if acquireCalls != 0 {
+		t.Fatalf("Acquire called %d time(s) before local manifest failure", acquireCalls)
+	}
+	for _, want := range []string{dir, "not a Git repository", "git init", "--no-sync"} {
+		if !strings.Contains(exitErr.Message, want) {
+			t.Fatalf("message missing %q: %q", want, exitErr.Message)
+		}
+	}
+}
+
+func TestRunNonGitWorkdirFailsBeforeReadyPoolBorrow(t *testing.T) {
+	clearConfigEnv(t)
+	dir := t.TempDir()
+	isolateRunTestUserDirs(t, dir)
+	t.Chdir(dir)
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, "missing.yaml"))
+	requests := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests <- r.Method + " " + r.URL.Path
+		http.Error(w, "unexpected request", http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+	t.Setenv("CRABBOX_COORDINATOR", server.URL)
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "test-token")
+
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
+		"--provider", "run-ready-pool-preflight-test",
+		"--pool", "shared-linux",
+		"--pool-return", "drain",
+		"--", "true",
+	})
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 6 || !strings.Contains(exitErr.Message, "not a Git repository") {
+		t.Fatalf("error=%v, want non-Git exit 6\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	select {
+	case request := <-requests:
+		t.Fatalf("ready-pool request occurred before local manifest failure: %s", request)
+	default:
+	}
+}
+
+func TestRunBuildsSyncManifestAfterAcquire(t *testing.T) {
+	clearConfigEnv(t)
+	dir := t.TempDir()
+	isolateRunTestUserDirs(t, dir)
+	t.Chdir(dir)
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, "missing.yaml"))
+	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.email", "test@example.com")
+	runGit(t, dir, "config", "user.name", "Test")
+	writeFile(t, filepath.Join(dir, "before-acquire.txt"), "before\n")
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-m", "init")
+
+	binDir := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sshPath := filepath.Join(binDir, "ssh")
+	if err := os.WriteFile(sshPath, []byte("#!/bin/sh\n/bin/cat >/dev/null || true\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rsyncLog := filepath.Join(dir, "rsync-manifest.log")
+	rsyncPath := filepath.Join(binDir, "rsync")
+	if err := os.WriteFile(rsyncPath, []byte("#!/bin/sh\n/bin/cat > \"$CRABBOX_FAKE_RSYNC_STDIN_LOG\"\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CRABBOX_FAKE_RSYNC_STDIN_LOG", rsyncLog)
+	t.Setenv("CRABBOX_FAKE_SSH_PORT", "22")
+	t.Setenv("CRABBOX_FAKE_SSH_PROXY", "1")
+	acquireCalls := 0
+	runEnvProfileTestAcquireHook = func(req AcquireRequest) {
+		acquireCalls++
+		writeFile(t, filepath.Join(req.Repo.Root, "after-acquire.txt"), "after\n")
+	}
+	t.Cleanup(func() { runEnvProfileTestAcquireHook = nil })
+
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
+		"--provider", "run-env-profile-test",
+		"--", "true",
+	})
+	if err != nil {
+		t.Fatalf("run error=%v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	if acquireCalls != 1 {
+		t.Fatalf("Acquire calls=%d, want 1", acquireCalls)
+	}
+	manifest, err := os.ReadFile(rsyncLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(manifest, []byte("before-acquire.txt\x00")) {
+		t.Fatalf("ordinary sync omitted initial file: %q", manifest)
+	}
+	if !bytes.Contains(manifest, []byte("after-acquire.txt\x00")) {
+		t.Fatalf("ordinary sync reused the pre-acquisition file list: %q", manifest)
+	}
 }
 
 type runPrepareTestProvider struct{}
@@ -635,6 +789,11 @@ func (b runModuleRuntimeTestBackend) Stop(context.Context, StopRequest) error {
 }
 
 func TestRunWithExistingLeaseRequestsProviderPreparation(t *testing.T) {
+	clearConfigEnv(t)
+	dir := t.TempDir()
+	isolateRunTestUserDirs(t, dir)
+	t.Chdir(dir)
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, "missing.yaml"))
 	runPrepareTestResolveRequests = nil
 	var stdout, stderr bytes.Buffer
 	err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
@@ -653,6 +812,53 @@ func TestRunWithExistingLeaseRequestsProviderPreparation(t *testing.T) {
 	}
 	if got := runPrepareTestResolveRequests[0]; got.ID != "cbx_existing" || !got.Prepare {
 		t.Fatalf("resolve request=%#v, want existing id with Prepare", got)
+	}
+}
+
+func TestRunNonGitWorkdirFailsBeforeExistingLeaseResolveAndPrepare(t *testing.T) {
+	clearConfigEnv(t)
+	dir := t.TempDir()
+	isolateRunTestUserDirs(t, dir)
+	t.Chdir(dir)
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, "missing.yaml"))
+	runPrepareTestResolveRequests = nil
+
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
+		"--provider", "run-prepare-test",
+		"--id", "cbx_existing",
+		"--", "true",
+	})
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 6 || !strings.Contains(exitErr.Message, "not a Git repository") {
+		t.Fatalf("error=%v, want non-Git exit 6\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	if len(runPrepareTestResolveRequests) != 0 {
+		t.Fatalf("Resolve/Prepare called before local manifest failure: %#v", runPrepareTestResolveRequests)
+	}
+}
+
+func TestRunNonGitFreshPRStillResolvesExistingLease(t *testing.T) {
+	clearConfigEnv(t)
+	dir := t.TempDir()
+	isolateRunTestUserDirs(t, dir)
+	t.Chdir(dir)
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, "missing.yaml"))
+	runPrepareTestResolveRequests = nil
+
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
+		"--provider", "run-prepare-test",
+		"--id", "cbx_existing",
+		"--fresh-pr", "example-org/my-app#123",
+		"--", "true",
+	})
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 9 || !strings.Contains(exitErr.Message, "resolve captured") {
+		t.Fatalf("run error=%v, want resolve-captured exit\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	if len(runPrepareTestResolveRequests) != 1 || !runPrepareTestResolveRequests[0].Prepare {
+		t.Fatalf("fresh-PR run did not reach Resolve/Prepare: %#v", runPrepareTestResolveRequests)
 	}
 }
 
@@ -1041,8 +1247,13 @@ func TestRunCommandRejectsDelegatedScriptStdinBeforeReading(t *testing.T) {
 }
 
 func TestRunCommandPassesScriptToModuleDelegatedProvider(t *testing.T) {
+	clearConfigEnv(t)
 	runModuleRuntimeTestRequests = nil
-	script := filepath.Join(t.TempDir(), "worker.mjs")
+	dir := t.TempDir()
+	isolateRunTestUserDirs(t, dir)
+	t.Chdir(dir)
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, "missing.yaml"))
+	script := filepath.Join(dir, "worker.mjs")
 	if err := os.WriteFile(script, []byte("export default { fetch() { return new Response('ok') } }\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Root cause

Crabbox builds ordinary local-sync manifests with `git ls-files`. Outside a Git repository, the shared manifest path discarded Git's stderr and surfaced only `exit status 128`. `run` also discovered that local prerequisite after lease acquisition, existing-lease preparation, or ready-pool borrowing had already begun.

## Fix

- A shared Git file-list command captures stderr and reports a workdir-aware non-Git error with both recovery choices: run `git init` to sync local files, or pass `--no-sync`.
- Other Git file-list failures now surface Git's own diagnostic instead of an opaque exit status.
- SSH-lease runs that will perform ordinary local sync validate the file-list source before Acquire, Resolve/Prepare, or ready-pool Borrow. `--no-sync`, fresh-PR/remote-checkout, and delegated-run providers retain their existing contracts.
- The preflight result is intentionally throwaway. Crabbox rebuilds the complete sync manifest, deletion set, sizes, changed-byte accounting, large-sync guard input, and rsync file list immediately before the actual sync, so files added while a lease is being acquired are included.

## Behavior and proof

Black-box validation used the freshly built CLI from an isolated non-Git directory with the local-container provider. Both an empty directory and the same directory after adding a normal file exited 6 with the absolute workdir, `not a Git repository`, `git init`, and `--no-sync`; Docker inventory was unchanged before and after each attempt.

Regression coverage proves the non-Git failure occurs before new Acquire, existing-lease Resolve/Prepare, and ready-pool Borrow, while fresh-PR, `--no-sync`, and delegated paths remain exempt. A separate acquisition hook adds a file during Acquire and proves the later rsync manifest includes it.

Validation completed:

- focused diagnostic, no-side-effect, TOCTOU, ready-pool, fresh-PR, no-sync, and delegated tests
- focused race coverage
- full `go test ./internal/cli -count=1 -timeout=20m`
- `go vet ./internal/cli`
- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- formatting and `git diff --check`
- TruffleHog and global P1 autoreview

No configuration changes, secret changes, or migrations are required.

Closes https://github.com/openclaw/crabbox/issues/1248
