### PR TITLE
fix: prevent orphan leases after canceled coordinator creates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixed
 
 - Redacted configured credentials reflected by provider-controlled Orgo, FastAPI Cloud, and DigitalOcean response diagnostics before they reach terminal or CI output. Thanks @coygeek.
-- Released late-accepted ordinary coordinator leases after canceled creation, with bounded transient/final retries and generation-fenced retained AWS Mac request-ID cleanup while fixed-ID leases remain available for replay. Thanks @fuller-stack-dev.
+- Made canceled ordinary coordinator creates durable and token-bound, including concurrent same-token replay, atomic cleanup claims, late provider cleanup evidence, generation-fenced retained AWS Mac reactivation, and bounded cancellation retries while fixed-ID creates remain replay-owned. Thanks @fuller-stack-dev.
 
 ## 0.41.1 - 2026-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Redacted configured credentials reflected by provider-controlled Orgo, FastAPI Cloud, and DigitalOcean response diagnostics before they reach terminal or CI output. Thanks @coygeek.
+- Released late-accepted ordinary coordinator leases after canceled creation, with bounded transient/final retries and generation-fenced retained AWS Mac request-ID cleanup while fixed-ID leases remain available for replay. Thanks @fuller-stack-dev.
 
 ## 0.41.1 - 2026-08-09
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -192,6 +192,7 @@ Lease lifecycle:
 GET  /v1/leases
 GET  /v1/leases/{id-or-slug}
 POST /v1/leases
+POST /v1/leases/{requested-id}/cancel-create
 POST /v1/leases/{id-or-slug}/heartbeat
 POST /v1/leases/{id-or-slug}/release
 POST /v1/leases/{id-or-slug}/tailscale

--- a/docs/features/coordinator.md
+++ b/docs/features/coordinator.md
@@ -124,6 +124,7 @@ GET    /v1/leases
 GET    /v1/leases/{id-or-slug}
 POST   /v1/leases/{id-or-slug}/heartbeat
 POST   /v1/leases/{id-or-slug}/release
+POST   /v1/leases/{requested-id}/cancel-create
 POST   /v1/leases/{id-or-slug}/tailscale
 GET    /v1/leases/{id-or-slug}/share
 PUT    /v1/leases/{id-or-slug}/share
@@ -145,6 +146,23 @@ GET    /v1/adapters/{adapter-id}
 GET    /v1/adapters/{adapter-id}/agent    (websocket; one-time ticket auth)
 *      /v1/adapters/{adapter-id}/proxy/v1/workspaces/...
 ```
+
+Current CLIs bind each ordinary `POST` create to a fresh opaque attempt token
+and repeat only that same token after an ambiguous response. `cancel-create`
+persists a permanent token-bound cancellation tombstone, including when it
+arrives before the create request, and releases only the matching canonical
+generation if one was already accepted. Concurrent same-token POSTs replay that
+canonical provisioning or active lease instead of competing for its ID.
+An unbound canceled tombstone rejects only that exact owner/org/token operation;
+it does not reserve the provisional ID against a fresh token or a fixed,
+registered, or workspace lifecycle. Pending and canonical-bound attempts remain
+global ID reservations.
+Tokenless POSTs from older CLIs remain supported with their previous behavior,
+but they do not gain this cancellation guarantee. Roll out the coordinator
+before distributing a CLI that sends create attempts; once token-bound creates
+begin, do not roll the coordinator back to a version that ignores their
+tombstones. A newer CLI against an older coordinator fails cancellation closed
+rather than falling back to an unsafe ID-only release.
 
 The fixed-ID `PUT` route is fail-closed and does not replace legacy `POST`.
 It atomically reserves a versioned normalized immutable request hash before
@@ -277,8 +295,9 @@ events are inspectable without pasting a bearer token into the browser.
 
 ## Lease lifecycle through the broker
 
-**Create.** The CLI generates the lease ID (`cbx_<12 hex>`), allocates a slug,
-mints a per-lease SSH key, then `POST /v1/leases` with the full request.
+**Create.** The CLI generates the lease ID (`cbx_<12 hex>`), a fresh opaque
+create-attempt token, a slug, and a per-lease SSH key, then `POST /v1/leases`
+with the full request.
 `createLease` (`worker/src/fleet.ts`) coerces the request into a `LeaseConfig`
 (`worker/src/config.ts`) with defaults: provider `hetzner`, TTL `5400`s (capped
 at `86400`), idle timeout `1800`s, SSH port `2222` (fallback `22`), class
@@ -294,6 +313,17 @@ recomputes `expiresAt`, clears cleanup metadata, and reschedules the alarm. It
 updates the idle timeout **only** when the request explicitly sends a positive
 `idleTimeoutSeconds` (clamped to `86400`); telemetry samples may ride along in
 the same body.
+
+**Cancel create.** If the caller cancels an ordinary create, the CLI sends
+`POST /v1/leases/{requested-id}/cancel-create` with the exact create-attempt
+token on a cancellation-independent bounded context. The coordinator persists
+the canceled tombstone even when cancellation arrives first. When a matching
+canonical lease exists, its released state and durable cleanup claim are written
+under the same state lock before provider deletion, so ordinary maintenance can
+resume cleanup after a restart. It releases a reserved, provisioning, or
+retained canonical lease only when its private token, owner/org, and retained
+generation match; otherwise it fails closed. Fixed-ID `PUT` creates remain
+replay-owned and never use cancellation cleanup.
 
 **Release.** `POST /v1/leases/{id}/release` (body `{delete?}`, defaulting to
 `!keep`) deletes the cloud server when the lease is still active and sets state

--- a/docs/features/identifiers.md
+++ b/docs/features/identifiers.md
@@ -29,6 +29,14 @@ The CLI normally mints a provisional lease ID before calling the broker. A
 broker may return a different final ID, in which case the CLI moves the local
 SSH key directory from the provisional ID to the final ID with
 `MoveStoredTestboxKey` and re-keys the claim and other references accordingly.
+When an ordinary coordinator request reactivates a retained AWS Mac lease, the
+coordinator permanently reserves that provisional ID in a private,
+generation-bound release mapping to the retained canonical ID. Only the release
+route accepts the mapping, and only for the owning user and organization (or an
+administrator); status, heartbeat, sharing, runs, and other lease lookups remain
+canonical-only. This lets a canceled client delete a late-accepted retained
+lease even when its create response was lost, without relabeling the provider
+resource or allowing the provisional ID to target a later reactivation.
 
 Automation may instead supply the canonical ID with `warmup --lease-id`. For
 direct AWS and managed coordinator leases, that ID is an immutable create

--- a/docs/features/identifiers.md
+++ b/docs/features/identifiers.md
@@ -29,14 +29,32 @@ The CLI normally mints a provisional lease ID before calling the broker. A
 broker may return a different final ID, in which case the CLI moves the local
 SSH key directory from the provisional ID to the final ID with
 `MoveStoredTestboxKey` and re-keys the claim and other references accordingly.
-When an ordinary coordinator request reactivates a retained AWS Mac lease, the
-coordinator permanently reserves that provisional ID in a private,
-generation-bound release mapping to the retained canonical ID. Only the release
-route accepts the mapping, and only for the owning user and organization (or an
-administrator); status, heartbeat, sharing, runs, and other lease lookups remain
-canonical-only. This lets a canceled client delete a late-accepted retained
-lease even when its create response was lost, without relabeling the provider
-resource or allowing the provisional ID to target a later reactivation.
+For each ordinary coordinator `POST` create, the CLI also mints a fresh opaque
+create-attempt token. The coordinator reserves the provisional ID in a private
+`pending` attempt record after synchronous request validation and before
+provider preparation. Cancellation uses the exact ID and token on the
+dedicated `cancel-create` route, so a cancel that arrives before the create
+still wins durably. An unbound canceled record tombstones only that exact
+owner/org/token operation: a fresh token may replace it after the coordinator
+rechecks that no exact lease or workspace reservation exists. Fixed-ID,
+registration, and workspace allocation also ignore unbound canceled records.
+Pending attempts and attempts bound to a canonical lease remain global ID
+reservations.
+
+New ordinary lease records bind to the token. Retained AWS Mac reactivation
+also binds the private attempt to the canonical lease, cloud ID, and a fresh
+generation. Only same-token create replay and create cancellation consume that
+mapping; status, heartbeat, sharing, runs, and normal release lookups remain
+canonical-only. Same-token concurrent creates replay the already bound
+provisioning or active canonical lease. Cancellation writes its tombstone and
+the canonical lease's release/cleanup claim together before provider deletion.
+Provisional IDs are permanently unavailable to ordinary, fixed-ID, registration,
+and workspace allocators once pending or bound to a canonical lease. Superseded
+unbound cancellations remain exact-operation tombstones, so the old token still
+returns `create_canceled` without affecting the replacement lifecycle. The
+private token and generation never appear in public lease records. Fixed-ID
+`PUT` creates do not use this protocol: their exact ID and intent hash continue
+to own replay, and caller cancellation never releases them.
 
 Automation may instead supply the canonical ID with `warmup --lease-id`. For
 direct AWS and managed coordinator leases, that ID is an immutable create

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -106,6 +106,11 @@ type CoordinatorLease struct {
 	ProviderMetadata      map[string]any                 `json:"providerMetadata,omitempty"`
 }
 
+type CoordinatorCanceledCreateReleaseResult struct {
+	Lease          CoordinatorLease `json:"lease"`
+	RequestLeaseID string           `json:"requestLeaseID,omitempty"`
+}
+
 type CoordinatorLeaseImage struct {
 	ID         string `json:"id"`
 	Source     string `json:"source"`
@@ -1102,6 +1107,12 @@ func (c *CoordinatorClient) ReleaseLease(ctx context.Context, id string, deleteS
 	}
 	err := c.do(ctx, http.MethodPost, "/v1/leases/"+url.PathEscape(id)+"/release", map[string]any{"delete": deleteServer}, &res)
 	return res.Lease, err
+}
+
+func (c *CoordinatorClient) ReleaseLeaseAfterCanceledCreate(ctx context.Context, id string, deleteServer bool) (CoordinatorCanceledCreateReleaseResult, error) {
+	var result CoordinatorCanceledCreateReleaseResult
+	err := c.do(ctx, http.MethodPost, "/v1/leases/"+url.PathEscape(id)+"/release", map[string]any{"delete": deleteServer}, &result)
+	return result, err
 }
 
 func (c *CoordinatorClient) CompleteRuntimeAdapterDelete(ctx context.Context, id, adapterID, workspaceID, registrationID string) (CoordinatorLease, error) {

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -106,9 +106,16 @@ type CoordinatorLease struct {
 	ProviderMetadata      map[string]any                 `json:"providerMetadata,omitempty"`
 }
 
-type CoordinatorCanceledCreateReleaseResult struct {
-	Lease          CoordinatorLease `json:"lease"`
-	RequestLeaseID string           `json:"requestLeaseID,omitempty"`
+type CoordinatorCanceledCreateAttestation struct {
+	Version          int    `json:"version"`
+	RequestedLeaseID string `json:"requestedLeaseID"`
+	CreateAttemptID  string `json:"createAttemptID"`
+	State            string `json:"state"`
+}
+
+type CoordinatorCanceledCreateResult struct {
+	CanceledCreate CoordinatorCanceledCreateAttestation `json:"canceledCreate"`
+	Lease          *CoordinatorLease                    `json:"lease,omitempty"`
 }
 
 type CoordinatorLeaseImage struct {
@@ -865,14 +872,18 @@ func newCoordinatorClient(cfg Config) (*CoordinatorClient, bool, error) {
 }
 
 func (c *CoordinatorClient) CreateLease(ctx context.Context, cfg Config, publicKey string, keep bool, leaseID, slug string) (CoordinatorLease, error) {
-	return c.createLease(ctx, cfg, publicKey, keep, leaseID, slug, false)
+	return c.CreateLeaseWithAttempt(ctx, cfg, publicKey, keep, leaseID, slug, newCreateAttemptID())
+}
+
+func (c *CoordinatorClient) CreateLeaseWithAttempt(ctx context.Context, cfg Config, publicKey string, keep bool, leaseID, slug, createAttemptID string) (CoordinatorLease, error) {
+	return c.createLease(ctx, cfg, publicKey, keep, leaseID, slug, createAttemptID, false)
 }
 
 func (c *CoordinatorClient) EnsureLease(ctx context.Context, cfg Config, publicKey string, keep bool, leaseID, slug string) (CoordinatorLease, error) {
-	return c.createLease(ctx, cfg, publicKey, keep, leaseID, slug, true)
+	return c.createLease(ctx, cfg, publicKey, keep, leaseID, slug, "", true)
 }
 
-func (c *CoordinatorClient) createLease(ctx context.Context, cfg Config, publicKey string, keep bool, leaseID, slug string, fixed bool) (CoordinatorLease, error) {
+func (c *CoordinatorClient) createLease(ctx context.Context, cfg Config, publicKey string, keep bool, leaseID, slug, createAttemptID string, fixed bool) (CoordinatorLease, error) {
 	var res struct {
 		Lease CoordinatorLease `json:"lease"`
 	}
@@ -949,6 +960,9 @@ func (c *CoordinatorClient) createLease(ctx context.Context, cfg Config, publicK
 		"sshPublicKey":                    publicKey,
 		"pond":                            cfg.Pond,
 		"exposedPorts":                    cfg.ExposedPorts,
+	}
+	if !fixed {
+		req["createAttemptID"] = createAttemptID
 	}
 	if cfg.Provider != "daytona" || cfg.architectureExplicit {
 		req["architecture"] = effectiveArchitectureForConfig(cfg)
@@ -1109,9 +1123,9 @@ func (c *CoordinatorClient) ReleaseLease(ctx context.Context, id string, deleteS
 	return res.Lease, err
 }
 
-func (c *CoordinatorClient) ReleaseLeaseAfterCanceledCreate(ctx context.Context, id string, deleteServer bool) (CoordinatorCanceledCreateReleaseResult, error) {
-	var result CoordinatorCanceledCreateReleaseResult
-	err := c.do(ctx, http.MethodPost, "/v1/leases/"+url.PathEscape(id)+"/release", map[string]any{"delete": deleteServer}, &result)
+func (c *CoordinatorClient) CancelLeaseCreate(ctx context.Context, id, createAttemptID string) (CoordinatorCanceledCreateResult, error) {
+	var result CoordinatorCanceledCreateResult
+	err := c.do(ctx, http.MethodPost, "/v1/leases/"+url.PathEscape(id)+"/cancel-create", map[string]any{"createAttemptID": createAttemptID}, &result)
 	return result, err
 }
 

--- a/internal/cli/cp_ssh_unix_test.go
+++ b/internal/cli/cp_ssh_unix_test.go
@@ -163,11 +163,13 @@ wait "$child"
 	for time.Now().Before(deadline) {
 		data, err := os.ReadFile(pidPath)
 		if err == nil {
-			childPID, err = strconv.Atoi(strings.TrimSpace(string(data)))
-			if err != nil {
-				t.Fatal(err)
+			value := strings.TrimSpace(string(data))
+			if value != "" {
+				if parsed, parseErr := strconv.Atoi(value); parseErr == nil && parsed > 0 {
+					childPID = parsed
+					break
+				}
 			}
-			break
 		}
 		time.Sleep(20 * time.Millisecond)
 	}

--- a/internal/cli/lease.go
+++ b/internal/cli/lease.go
@@ -19,6 +19,15 @@ func newLeaseID() string {
 	return "cbx_" + hex.EncodeToString(b[:])
 }
 
+func newCreateAttemptID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		digits := strings.ReplaceAll(time.Now().UTC().Format("20060102150405.000000000"), ".", "")
+		return "cat_" + (digits + "00000000000000000000000000000000")[:32]
+	}
+	return "cat_" + hex.EncodeToString(b[:])
+}
+
 func NewLeaseID() string {
 	return newLeaseID()
 }

--- a/internal/cli/lease_test.go
+++ b/internal/cli/lease_test.go
@@ -21,6 +21,18 @@ func TestNewRunIDUsesCanonicalFormatAndIsUnique(t *testing.T) {
 	}
 }
 
+func TestNewCreateAttemptIDIsOpaqueAndUnique(t *testing.T) {
+	first := newCreateAttemptID()
+	second := newCreateAttemptID()
+	pattern := regexp.MustCompile(`^cat_[a-f0-9]{32}$`)
+	if !pattern.MatchString(first) || !pattern.MatchString(second) {
+		t.Fatalf("create attempt IDs must use the opaque canonical format: first=%q second=%q", first, second)
+	}
+	if first == second {
+		t.Fatalf("create attempt IDs must be fresh per acquisition: %q", first)
+	}
+}
+
 func TestLeaseOperationLockSerializesFixedIDKeyCreation(t *testing.T) {
 	isolateTestUserDirs(t)
 	const leaseID = "cbx_abcdef123456"

--- a/internal/cli/provider_coordinator.go
+++ b/internal/cli/provider_coordinator.go
@@ -5,15 +5,18 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
 	"time"
 )
 
 var (
-	coordinatorCreateLeaseProgressInterval = 30 * time.Second
-	coordinatorCreateLeaseTimeoutForConfig = defaultCoordinatorCreateLeaseTimeoutForConfig
-	coordinatorCreateLeaseRecoveryTimeout  = 90 * time.Second
-	coordinatorCreateLeaseRecoveryInterval = 5 * time.Second
+	coordinatorCreateLeaseProgressInterval   = 30 * time.Second
+	coordinatorCreateLeaseTimeoutForConfig   = defaultCoordinatorCreateLeaseTimeoutForConfig
+	coordinatorCreateLeaseRecoveryTimeout    = 90 * time.Second
+	coordinatorCreateLeaseRecoveryInterval   = 5 * time.Second
+	coordinatorCanceledCreateRecoveryTimeout = 10 * time.Second
+	coordinatorCanceledCreateFinalTimeout    = 10 * time.Second
 )
 
 type coordinatorLeaseBackend struct {
@@ -216,6 +219,9 @@ func (b *coordinatorLeaseBackend) createCoordinatorLeaseWithProgressMode(ctx con
 	for {
 		select {
 		case result := <-resultCh:
+			if ctx.Err() != nil {
+				return CoordinatorLease{}, b.canceledCoordinatorLeaseCreateError(ctx, leaseID, slug, fixed, result.err)
+			}
 			if fixed && result.err != nil {
 				if lease, recoverErr, handled := b.recoverFixedCoordinatorLeaseAfterCreateError(ctx, cfg, publicKey, keep, leaseID, slug, result.err); handled {
 					return lease, recoverErr
@@ -235,14 +241,19 @@ func (b *coordinatorLeaseBackend) createCoordinatorLeaseWithProgressMode(ctx con
 				}
 			}
 			if result.err == nil && result.lease.State == "provisioning" {
-				return b.waitForCoordinatorLeaseActivation(createCtx, leaseID, result.lease)
+				lease, err := b.waitForCoordinatorLeaseActivation(createCtx, leaseID, result.lease)
+				if err != nil && ctx.Err() != nil {
+					cancelErr := b.canceledCoordinatorLeaseCreateError(ctx, leaseID, slug, fixed, nil)
+					return CoordinatorLease{}, errors.Join(cancelErr, definitiveCoordinatorCreateError(err))
+				}
+				return lease, err
 			}
 			return result.lease, result.err
 		case <-ticker.C:
 			fmt.Fprintf(b.rt.Stderr, "waiting for coordinator lease provider=%s slug=%s elapsed=%s timeout=%s\n", cfg.Provider, slug, time.Since(started).Round(time.Second), timeout)
 		case <-createCtx.Done():
 			if ctx.Err() != nil {
-				return CoordinatorLease{}, ctx.Err()
+				return CoordinatorLease{}, b.canceledCoordinatorLeaseCreateError(ctx, leaseID, slug, fixed, nil)
 			}
 			err := coordinatorCreateLeaseTimeoutError(cfg, leaseID, slug, timeout)
 			if fixed {
@@ -256,9 +267,87 @@ func (b *coordinatorLeaseBackend) createCoordinatorLeaseWithProgressMode(ctx con
 			}
 			return CoordinatorLease{}, err
 		case <-ctx.Done():
-			return CoordinatorLease{}, ctx.Err()
+			var createErr error
+			select {
+			case result := <-resultCh:
+				createErr = result.err
+			default:
+			}
+			return CoordinatorLease{}, b.canceledCoordinatorLeaseCreateError(ctx, leaseID, slug, fixed, createErr)
 		}
 	}
+}
+
+func (b *coordinatorLeaseBackend) canceledCoordinatorLeaseCreateError(ctx context.Context, leaseID, slug string, fixed bool, createErr error) error {
+	callerErr := ctx.Err()
+	if definitiveErr := definitiveCoordinatorCreateError(createErr); definitiveErr != nil {
+		return errors.Join(callerErr, definitiveErr)
+	}
+	if fixed {
+		return callerErr
+	}
+	recoverCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), coordinatorCanceledCreateRecoveryTimeout)
+	defer cancel()
+	fmt.Fprintf(b.rt.Stderr, "warning: coordinator lease create canceled for %s; reconciling late acceptance for cleanup\n", leaseID)
+	if err := b.releaseCoordinatorLeaseAfterCanceledCreate(recoverCtx, leaseID, slug); err != nil {
+		return errors.Join(callerErr, fmt.Errorf("reconcile canceled coordinator lease %s: %w", leaseID, err))
+	}
+	return callerErr
+}
+
+func (b *coordinatorLeaseBackend) releaseCoordinatorLeaseAfterCanceledCreate(ctx context.Context, leaseID, slug string) error {
+	ticker := time.NewTicker(coordinatorCreateLeaseRecoveryInterval)
+	defer ticker.Stop()
+	for {
+		result, err := b.coord.ReleaseLeaseAfterCanceledCreate(ctx, leaseID, true)
+		if err == nil {
+			return b.validateCanceledCreateRelease(result, leaseID, slug)
+		}
+		if !coordinatorCanceledCreateReleaseErrorRetryable(err) {
+			return fmt.Errorf("request delete-release: %w", err)
+		}
+		select {
+		case <-ticker.C:
+		case <-ctx.Done():
+			return b.finalReleaseCoordinatorLeaseAfterCanceledCreate(ctx, leaseID, slug)
+		}
+	}
+}
+
+func (b *coordinatorLeaseBackend) finalReleaseCoordinatorLeaseAfterCanceledCreate(expiredCtx context.Context, leaseID, slug string) error {
+	finalCtx, cancel := context.WithTimeout(context.WithoutCancel(expiredCtx), coordinatorCanceledCreateFinalTimeout)
+	defer cancel()
+	result, err := b.coord.ReleaseLeaseAfterCanceledCreate(finalCtx, leaseID, true)
+	if err != nil {
+		return errors.Join(expiredCtx.Err(), fmt.Errorf("final request delete-release: %w", err))
+	}
+	return b.validateCanceledCreateRelease(result, leaseID, slug)
+}
+
+func (b *coordinatorLeaseBackend) validateCanceledCreateRelease(result CoordinatorCanceledCreateReleaseResult, leaseID, slug string) error {
+	if result.Lease.ID != leaseID && result.RequestLeaseID != leaseID {
+		return fmt.Errorf("coordinator returned lease %q while releasing %q without matching requestLeaseID attestation", result.Lease.ID, leaseID)
+	}
+	fmt.Fprintf(b.rt.Stderr, "released coordinator lease %s slug=%s after canceled create\n", result.Lease.ID, blank(result.Lease.Slug, slug))
+	return nil
+}
+
+func coordinatorCanceledCreateReleaseErrorRetryable(err error) bool {
+	if isCoordinatorNotFoundError(err) || coordinatorCreateLeaseErrorMayHaveCommitted(err) {
+		return true
+	}
+	var httpErr CoordinatorHTTPError
+	return errors.As(err, &httpErr) &&
+		(httpErr.StatusCode == http.StatusRequestTimeout ||
+			httpErr.StatusCode == http.StatusTooManyRequests ||
+			httpErr.StatusCode >= http.StatusInternalServerError)
+}
+
+func definitiveCoordinatorCreateError(err error) error {
+	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || coordinatorCreateLeaseErrorMayHaveCommitted(err) {
+		return nil
+	}
+	return fmt.Errorf("create coordinator lease: %w", err)
 }
 
 func (b *coordinatorLeaseBackend) recoverFixedCoordinatorLeaseAfterCreateError(ctx context.Context, cfg Config, publicKey string, keep bool, leaseID, slug string, createErr error) (CoordinatorLease, error, bool) {

--- a/internal/cli/provider_coordinator.go
+++ b/internal/cli/provider_coordinator.go
@@ -17,6 +17,7 @@ var (
 	coordinatorCreateLeaseRecoveryInterval   = 5 * time.Second
 	coordinatorCanceledCreateRecoveryTimeout = 10 * time.Second
 	coordinatorCanceledCreateFinalTimeout    = 10 * time.Second
+	coordinatorCreateAttemptID               = newCreateAttemptID
 )
 
 type coordinatorLeaseBackend struct {
@@ -104,10 +105,10 @@ func (b *coordinatorLeaseBackend) acquireOnceWithLeaseID(ctx context.Context, ke
 	lease, err := b.createCoordinatorLeaseWithProgressMode(ctx, cfg, publicKey, keep, leaseID, slug, requestedLeaseID != "")
 	if err != nil {
 		if requestedLeaseID == "" {
-			if isCoordinatorStaleInstanceCleanedSignal(err) {
-				return LeaseTarget{}, coordinatorStaleInstanceCleanedError{err: err}
+			if isCoordinatorStaleInstanceCleanedError(err) {
+				return LeaseTarget{}, err
 			}
-			if isCoordinatorStaleInstanceError(err) && b.releaseStaleCoordinatorLeaseForRetry(leaseID) {
+			if isCoordinatorStaleInstanceCleanedSignal(err) {
 				return LeaseTarget{}, coordinatorStaleInstanceCleanedError{err: err}
 			}
 		}
@@ -198,6 +199,10 @@ func (b *coordinatorLeaseBackend) createCoordinatorLeaseWithProgress(ctx context
 }
 
 func (b *coordinatorLeaseBackend) createCoordinatorLeaseWithProgressMode(ctx context.Context, cfg Config, publicKey string, keep bool, leaseID, slug string, fixed bool) (CoordinatorLease, error) {
+	createAttemptID := ""
+	if !fixed {
+		createAttemptID = coordinatorCreateAttemptID()
+	}
 	timeout := coordinatorCreateLeaseTimeoutForConfig(cfg)
 	createCtx, cancelCreate := context.WithTimeout(ctx, timeout)
 	defer cancelCreate()
@@ -208,7 +213,7 @@ func (b *coordinatorLeaseBackend) createCoordinatorLeaseWithProgressMode(ctx con
 		if fixed {
 			lease, err = b.coord.EnsureLease(createCtx, cfg, publicKey, keep, leaseID, slug)
 		} else {
-			lease, err = b.coord.CreateLease(createCtx, cfg, publicKey, keep, leaseID, slug)
+			lease, err = b.coord.CreateLeaseWithAttempt(createCtx, cfg, publicKey, keep, leaseID, slug, createAttemptID)
 		}
 		resultCh <- coordinatorCreateLeaseResult{lease: lease, err: err}
 	}()
@@ -220,7 +225,7 @@ func (b *coordinatorLeaseBackend) createCoordinatorLeaseWithProgressMode(ctx con
 		select {
 		case result := <-resultCh:
 			if ctx.Err() != nil {
-				return CoordinatorLease{}, b.canceledCoordinatorLeaseCreateError(ctx, leaseID, slug, fixed, result.err)
+				return CoordinatorLease{}, b.canceledCoordinatorLeaseCreateError(ctx, leaseID, slug, createAttemptID, fixed, result.err)
 			}
 			if fixed && result.err != nil {
 				if lease, recoverErr, handled := b.recoverFixedCoordinatorLeaseAfterCreateError(ctx, cfg, publicKey, keep, leaseID, slug, result.err); handled {
@@ -230,21 +235,39 @@ func (b *coordinatorLeaseBackend) createCoordinatorLeaseWithProgressMode(ctx con
 			}
 			if result.err != nil && errors.Is(result.err, context.DeadlineExceeded) && ctx.Err() == nil {
 				err := coordinatorCreateLeaseTimeoutError(cfg, leaseID, slug, timeout)
-				if lease, ok := b.recoverCoordinatorLeaseAfterCreateError(ctx, cfg, leaseID, slug, err); ok {
+				if lease, ok := b.recoverCoordinatorLeaseAfterCreateError(ctx, cfg, publicKey, keep, leaseID, slug, createAttemptID, err); ok {
 					return lease, nil
 				}
-				return CoordinatorLease{}, err
+				if ctx.Err() != nil {
+					return CoordinatorLease{}, b.canceledCoordinatorLeaseCreateError(ctx, leaseID, slug, createAttemptID, false, result.err)
+				}
+				return CoordinatorLease{}, b.abandonUnrecoveredCoordinatorLeaseCreate(ctx, leaseID, slug, createAttemptID, err)
 			}
 			if result.err != nil {
-				if lease, ok := b.recoverCoordinatorLeaseAfterCreateError(ctx, cfg, leaseID, slug, result.err); ok {
+				if lease, ok := b.recoverCoordinatorLeaseAfterCreateError(ctx, cfg, publicKey, keep, leaseID, slug, createAttemptID, result.err); ok {
 					return lease, nil
+				}
+				if ctx.Err() != nil {
+					return CoordinatorLease{}, b.canceledCoordinatorLeaseCreateError(ctx, leaseID, slug, createAttemptID, false, result.err)
+				}
+				if isCoordinatorStaleInstanceCleanedSignal(result.err) {
+					return CoordinatorLease{}, result.err
+				}
+				if isCoordinatorStaleInstanceError(result.err) {
+					return CoordinatorLease{}, b.abandonUnrecoveredCoordinatorLeaseCreate(ctx, leaseID, slug, createAttemptID, result.err)
+				}
+				if coordinatorCreateLeaseErrorMayHaveCommitted(result.err) {
+					return CoordinatorLease{}, b.abandonUnrecoveredCoordinatorLeaseCreate(ctx, leaseID, slug, createAttemptID, result.err)
 				}
 			}
 			if result.err == nil && result.lease.State == "provisioning" {
-				lease, err := b.waitForCoordinatorLeaseActivation(createCtx, leaseID, result.lease)
+				lease, err := b.waitForCoordinatorLeaseActivation(createCtx, blank(result.lease.ID, leaseID), result.lease)
 				if err != nil && ctx.Err() != nil {
-					cancelErr := b.canceledCoordinatorLeaseCreateError(ctx, leaseID, slug, fixed, nil)
+					cancelErr := b.canceledCoordinatorLeaseCreateError(ctx, leaseID, slug, createAttemptID, fixed, nil)
 					return CoordinatorLease{}, errors.Join(cancelErr, definitiveCoordinatorCreateError(err))
+				}
+				if err != nil && !fixed {
+					return CoordinatorLease{}, b.abandonUnrecoveredCoordinatorLeaseCreate(ctx, leaseID, slug, createAttemptID, err)
 				}
 				return lease, err
 			}
@@ -253,7 +276,7 @@ func (b *coordinatorLeaseBackend) createCoordinatorLeaseWithProgressMode(ctx con
 			fmt.Fprintf(b.rt.Stderr, "waiting for coordinator lease provider=%s slug=%s elapsed=%s timeout=%s\n", cfg.Provider, slug, time.Since(started).Round(time.Second), timeout)
 		case <-createCtx.Done():
 			if ctx.Err() != nil {
-				return CoordinatorLease{}, b.canceledCoordinatorLeaseCreateError(ctx, leaseID, slug, fixed, nil)
+				return CoordinatorLease{}, b.canceledCoordinatorLeaseCreateError(ctx, leaseID, slug, createAttemptID, fixed, nil)
 			}
 			err := coordinatorCreateLeaseTimeoutError(cfg, leaseID, slug, timeout)
 			if fixed {
@@ -262,10 +285,13 @@ func (b *coordinatorLeaseBackend) createCoordinatorLeaseWithProgressMode(ctx con
 				}
 				return CoordinatorLease{}, err
 			}
-			if lease, ok := b.recoverCoordinatorLeaseAfterCreateError(ctx, cfg, leaseID, slug, err); ok {
+			if lease, ok := b.recoverCoordinatorLeaseAfterCreateError(ctx, cfg, publicKey, keep, leaseID, slug, createAttemptID, err); ok {
 				return lease, nil
 			}
-			return CoordinatorLease{}, err
+			if ctx.Err() != nil {
+				return CoordinatorLease{}, b.canceledCoordinatorLeaseCreateError(ctx, leaseID, slug, createAttemptID, false, nil)
+			}
+			return CoordinatorLease{}, b.abandonUnrecoveredCoordinatorLeaseCreate(ctx, leaseID, slug, createAttemptID, err)
 		case <-ctx.Done():
 			var createErr error
 			select {
@@ -273,67 +299,79 @@ func (b *coordinatorLeaseBackend) createCoordinatorLeaseWithProgressMode(ctx con
 				createErr = result.err
 			default:
 			}
-			return CoordinatorLease{}, b.canceledCoordinatorLeaseCreateError(ctx, leaseID, slug, fixed, createErr)
+			return CoordinatorLease{}, b.canceledCoordinatorLeaseCreateError(ctx, leaseID, slug, createAttemptID, fixed, createErr)
 		}
 	}
 }
 
-func (b *coordinatorLeaseBackend) canceledCoordinatorLeaseCreateError(ctx context.Context, leaseID, slug string, fixed bool, createErr error) error {
+func (b *coordinatorLeaseBackend) canceledCoordinatorLeaseCreateError(ctx context.Context, leaseID, slug, createAttemptID string, fixed bool, createErr error) error {
 	callerErr := ctx.Err()
-	if definitiveErr := definitiveCoordinatorCreateError(createErr); definitiveErr != nil {
-		return errors.Join(callerErr, definitiveErr)
-	}
+	definitiveErr := definitiveCoordinatorCreateError(createErr)
 	if fixed {
-		return callerErr
+		return errors.Join(callerErr, definitiveErr)
 	}
 	recoverCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), coordinatorCanceledCreateRecoveryTimeout)
 	defer cancel()
-	fmt.Fprintf(b.rt.Stderr, "warning: coordinator lease create canceled for %s; reconciling late acceptance for cleanup\n", leaseID)
-	if err := b.releaseCoordinatorLeaseAfterCanceledCreate(recoverCtx, leaseID, slug); err != nil {
-		return errors.Join(callerErr, fmt.Errorf("reconcile canceled coordinator lease %s: %w", leaseID, err))
+	fmt.Fprintf(b.rt.Stderr, "warning: coordinator lease create canceled for %s; recording durable create cancellation\n", leaseID)
+	if err := b.cancelCoordinatorLeaseCreate(recoverCtx, leaseID, slug, createAttemptID); err != nil {
+		return errors.Join(callerErr, definitiveErr, fmt.Errorf("cancel coordinator lease create %s: %w", leaseID, err))
 	}
-	return callerErr
+	return errors.Join(callerErr, definitiveErr)
 }
 
-func (b *coordinatorLeaseBackend) releaseCoordinatorLeaseAfterCanceledCreate(ctx context.Context, leaseID, slug string) error {
+func (b *coordinatorLeaseBackend) abandonUnrecoveredCoordinatorLeaseCreate(ctx context.Context, leaseID, slug, createAttemptID string, createErr error) error {
+	cancelCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), coordinatorCanceledCreateRecoveryTimeout)
+	defer cancel()
+	fmt.Fprintf(b.rt.Stderr, "warning: abandoning uncertain coordinator create %s; recording durable cancellation\n", leaseID)
+	if err := b.cancelCoordinatorLeaseCreate(cancelCtx, leaseID, slug, createAttemptID); err != nil {
+		return errors.Join(createErr, fmt.Errorf("cancel unrecovered coordinator lease create %s: %w", leaseID, err))
+	}
+	if isCoordinatorStaleInstanceError(createErr) {
+		return coordinatorStaleInstanceCleanedError{err: createErr}
+	}
+	return createErr
+}
+
+func (b *coordinatorLeaseBackend) cancelCoordinatorLeaseCreate(ctx context.Context, leaseID, slug, createAttemptID string) error {
 	ticker := time.NewTicker(coordinatorCreateLeaseRecoveryInterval)
 	defer ticker.Stop()
 	for {
-		result, err := b.coord.ReleaseLeaseAfterCanceledCreate(ctx, leaseID, true)
+		result, err := b.coord.CancelLeaseCreate(ctx, leaseID, createAttemptID)
 		if err == nil {
-			return b.validateCanceledCreateRelease(result, leaseID, slug)
+			return b.validateCanceledCreateAttestation(result, leaseID, slug, createAttemptID)
 		}
-		if !coordinatorCanceledCreateReleaseErrorRetryable(err) {
-			return fmt.Errorf("request delete-release: %w", err)
+		if !coordinatorCancelCreateErrorRetryable(err) {
+			return fmt.Errorf("request cancel-create: %w", err)
 		}
 		select {
 		case <-ticker.C:
 		case <-ctx.Done():
-			return b.finalReleaseCoordinatorLeaseAfterCanceledCreate(ctx, leaseID, slug)
+			return b.finalCancelCoordinatorLeaseCreate(ctx, leaseID, slug, createAttemptID)
 		}
 	}
 }
 
-func (b *coordinatorLeaseBackend) finalReleaseCoordinatorLeaseAfterCanceledCreate(expiredCtx context.Context, leaseID, slug string) error {
+func (b *coordinatorLeaseBackend) finalCancelCoordinatorLeaseCreate(expiredCtx context.Context, leaseID, slug, createAttemptID string) error {
 	finalCtx, cancel := context.WithTimeout(context.WithoutCancel(expiredCtx), coordinatorCanceledCreateFinalTimeout)
 	defer cancel()
-	result, err := b.coord.ReleaseLeaseAfterCanceledCreate(finalCtx, leaseID, true)
+	result, err := b.coord.CancelLeaseCreate(finalCtx, leaseID, createAttemptID)
 	if err != nil {
-		return errors.Join(expiredCtx.Err(), fmt.Errorf("final request delete-release: %w", err))
+		return errors.Join(expiredCtx.Err(), fmt.Errorf("final request cancel-create: %w", err))
 	}
-	return b.validateCanceledCreateRelease(result, leaseID, slug)
+	return b.validateCanceledCreateAttestation(result, leaseID, slug, createAttemptID)
 }
 
-func (b *coordinatorLeaseBackend) validateCanceledCreateRelease(result CoordinatorCanceledCreateReleaseResult, leaseID, slug string) error {
-	if result.Lease.ID != leaseID && result.RequestLeaseID != leaseID {
-		return fmt.Errorf("coordinator returned lease %q while releasing %q without matching requestLeaseID attestation", result.Lease.ID, leaseID)
+func (b *coordinatorLeaseBackend) validateCanceledCreateAttestation(result CoordinatorCanceledCreateResult, leaseID, slug, createAttemptID string) error {
+	attestation := result.CanceledCreate
+	if attestation.Version != 1 || attestation.RequestedLeaseID != leaseID || attestation.CreateAttemptID != createAttemptID || attestation.State != "canceled" {
+		return fmt.Errorf("coordinator returned mismatched cancel-create attestation for lease %q attempt %q", leaseID, createAttemptID)
 	}
-	fmt.Fprintf(b.rt.Stderr, "released coordinator lease %s slug=%s after canceled create\n", result.Lease.ID, blank(result.Lease.Slug, slug))
+	fmt.Fprintf(b.rt.Stderr, "recorded canceled coordinator create %s slug=%s\n", leaseID, slug)
 	return nil
 }
 
-func coordinatorCanceledCreateReleaseErrorRetryable(err error) bool {
-	if isCoordinatorNotFoundError(err) || coordinatorCreateLeaseErrorMayHaveCommitted(err) {
+func coordinatorCancelCreateErrorRetryable(err error) bool {
+	if isCoordinatorTransportError(err) || errors.Is(err, context.DeadlineExceeded) {
 		return true
 	}
 	var httpErr CoordinatorHTTPError
@@ -406,26 +444,34 @@ func (b *coordinatorLeaseBackend) waitForCoordinatorLeaseActivation(ctx context.
 	}
 }
 
-func (b *coordinatorLeaseBackend) recoverCoordinatorLeaseAfterCreateError(ctx context.Context, cfg Config, leaseID, slug string, createErr error) (CoordinatorLease, bool) {
+func (b *coordinatorLeaseBackend) recoverCoordinatorLeaseAfterCreateError(ctx context.Context, cfg Config, publicKey string, keep bool, leaseID, slug, createAttemptID string, createErr error) (CoordinatorLease, bool) {
 	if !coordinatorCreateLeaseErrorMayHaveCommitted(createErr) {
 		return CoordinatorLease{}, false
 	}
 	recoverCtx, cancel := context.WithTimeout(ctx, coordinatorCreateLeaseRecoveryTimeout)
 	defer cancel()
-	fmt.Fprintf(b.rt.Stderr, "warning: coordinator lease create returned uncertain result for %s; polling existing lease: %v\n", leaseID, createErr)
+	fmt.Fprintf(b.rt.Stderr, "warning: coordinator lease create returned uncertain result for %s; repeating token-bound POST: %v\n", leaseID, createErr)
 	ticker := time.NewTicker(coordinatorCreateLeaseRecoveryInterval)
 	defer ticker.Stop()
 	for {
-		lease, err := b.coord.GetLease(recoverCtx, leaseID)
+		lease, err := b.coord.CreateLeaseWithAttempt(recoverCtx, cfg, publicKey, keep, leaseID, slug, createAttemptID)
 		if err == nil {
 			if coordinatorLeaseRecoveredFromCreateError(cfg, lease) {
-				fmt.Fprintf(b.rt.Stderr, "recovered coordinator lease %s slug=%s after uncertain create response\n", leaseID, blank(lease.Slug, slug))
+				fmt.Fprintf(b.rt.Stderr, "recovered coordinator lease %s slug=%s with token-bound POST after uncertain response\n", lease.ID, blank(lease.Slug, slug))
 				return lease, true
+			}
+			if lease.State == "provisioning" {
+				active, waitErr := b.waitForCoordinatorLeaseActivation(recoverCtx, blank(lease.ID, leaseID), lease)
+				if waitErr == nil {
+					fmt.Fprintf(b.rt.Stderr, "recovered coordinator lease %s slug=%s with token-bound POST after uncertain response\n", active.ID, blank(active.Slug, slug))
+					return active, true
+				}
+				return CoordinatorLease{}, false
 			}
 			if lease.State == "failed" || lease.State == "released" || lease.State == "expired" {
 				return CoordinatorLease{}, false
 			}
-		} else if !isCoordinatorNotFoundError(err) && !coordinatorCreateLeaseErrorMayHaveCommitted(err) {
+		} else if !coordinatorCreateLeaseErrorMayHaveCommitted(err) {
 			return CoordinatorLease{}, false
 		}
 		select {
@@ -447,9 +493,7 @@ func coordinatorCreateLeaseErrorMayHaveCommitted(err error) bool {
 		return true
 	}
 	var httpErr CoordinatorHTTPError
-	return errors.As(err, &httpErr) &&
-		httpErr.StatusCode >= 500 &&
-		strings.Contains(httpErr.Message, "error code: 1101")
+	return errors.As(err, &httpErr) && httpErr.StatusCode >= http.StatusInternalServerError
 }
 
 func coordinatorLeaseRecoveredFromCreateError(cfg Config, lease CoordinatorLease) bool {
@@ -486,23 +530,6 @@ func coordinatorCreateLeaseTimeoutError(cfg Config, leaseID, slug string, timeou
 		cfg.TargetOS,
 		leaseID,
 	)
-}
-
-func (b *coordinatorLeaseBackend) releaseStaleCoordinatorLeaseForRetry(leaseID string) bool {
-	releaseCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	if _, err := b.coord.ReleaseLease(releaseCtx, leaseID, true); err != nil {
-		// A missing coordinator record means there is nothing left to discard.
-		// Treat it as cleaned so acquire can retry with a new lease id.
-		if isCoordinatorNotFoundError(err) {
-			fmt.Fprintf(b.rt.Stderr, "stale coordinator lease %s was already gone; retrying with fresh lease\n", leaseID)
-			return true
-		}
-		fmt.Fprintf(b.rt.Stderr, "warning: release failed after stale coordinator instance for %s; not retrying: %v\n", leaseID, err)
-		return false
-	}
-	fmt.Fprintf(b.rt.Stderr, "discarded stale coordinator lease %s\n", leaseID)
-	return true
 }
 
 func isCoordinatorStaleInstanceError(err error) bool {

--- a/internal/cli/provider_coordinator_test.go
+++ b/internal/cli/provider_coordinator_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -13,6 +15,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -602,6 +606,438 @@ func TestCoordinatorCreateLeaseTimesOutWithDiagnostics(t *testing.T) {
 	}
 }
 
+func TestCoordinatorCreateLeaseCancellationReleasesLateAcceptedLease(t *testing.T) {
+	oldRecoveryTimeout := coordinatorCanceledCreateRecoveryTimeout
+	oldRecoveryInterval := coordinatorCreateLeaseRecoveryInterval
+	coordinatorCanceledCreateRecoveryTimeout = time.Second
+	coordinatorCreateLeaseRecoveryInterval = 10 * time.Millisecond
+	defer func() {
+		coordinatorCanceledCreateRecoveryTimeout = oldRecoveryTimeout
+		coordinatorCreateLeaseRecoveryInterval = oldRecoveryInterval
+	}()
+
+	createStarted := make(chan struct{})
+	allowCreateCommit := make(chan struct{})
+	leaseAccepted := make(chan struct{})
+	firstReconcileRelease := make(chan struct{})
+	releaseObserved := make(chan struct{})
+	var firstReleaseAttempt sync.Once
+	var firstRelease sync.Once
+	var releaseCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/leases":
+			close(createStarted)
+			<-allowCreateCommit // Model a coordinator/provider path that commits after client cancellation.
+			close(leaseAccepted)
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
+				ID:       "cbx_cancel_late",
+				Slug:     "pearl-prawn",
+				Provider: "aws",
+				TargetOS: targetLinux,
+				Host:     "203.0.113.44",
+				State:    "active",
+			}})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/leases/cbx_cancel_late/release":
+			select {
+			case <-leaseAccepted:
+			default:
+				firstReleaseAttempt.Do(func() { close(firstReconcileRelease) })
+				http.Error(w, `{"error":"not_found"}`, http.StatusNotFound)
+				return
+			}
+			var body struct {
+				Delete bool `json:"delete"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Error(err)
+			}
+			if !body.Delete {
+				t.Error("late lease release did not request provider deletion")
+			}
+			releaseCount.Add(1)
+			firstRelease.Do(func() { close(releaseObserved) })
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
+				ID:       "cbx_cancel_late",
+				Provider: "aws",
+				State:    "released",
+			}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	cfg := baseConfig()
+	cfg.Provider = "aws"
+	cfg.TargetOS = targetLinux
+	cfg.Coordinator = server.URL
+	cfg.CoordToken = "user-token"
+	coord, _, err := newCoordinatorClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stderr bytes.Buffer
+	backend := &coordinatorLeaseBackend{cfg: cfg, coord: coord, rt: Runtime{Stderr: &stderr}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	resultCh := make(chan coordinatorCreateLeaseResult, 1)
+	go func() {
+		lease, err := backend.createCoordinatorLeaseWithProgress(
+			ctx,
+			cfg,
+			"ssh-rsa test",
+			false,
+			"cbx_cancel_late",
+			"pearl-prawn",
+		)
+		resultCh <- coordinatorCreateLeaseResult{lease: lease, err: err}
+	}()
+	<-createStarted
+	cancel()
+
+	select {
+	case <-firstReconcileRelease:
+	case <-time.After(250 * time.Millisecond):
+		close(allowCreateCommit)
+		t.Fatal("canceled create did not reconcile its pre-generated lease id with delete-release")
+	}
+	close(allowCreateCommit)
+
+	select {
+	case result := <-resultCh:
+		if !errors.Is(result.err, context.Canceled) {
+			t.Fatalf("create err=%v, want context canceled", result.err)
+		}
+		if result.lease.ID != "" {
+			t.Fatalf("canceled create adopted lease=%#v", result.lease)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("canceled create did not return within its reconciliation bound")
+	}
+
+	select {
+	case <-releaseObserved:
+	case <-time.After(time.Second):
+		t.Fatalf("late accepted lease was not released; stderr=%q", stderr.String())
+	}
+	if got := releaseCount.Load(); got != 1 {
+		t.Fatalf("release requests=%d, want 1", got)
+	}
+}
+
+func TestCanceledCoordinatorCreateRetriesTransientReleaseFailure(t *testing.T) {
+	oldRecoveryInterval := coordinatorCreateLeaseRecoveryInterval
+	coordinatorCreateLeaseRecoveryInterval = time.Millisecond
+	defer func() { coordinatorCreateLeaseRecoveryInterval = oldRecoveryInterval }()
+
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/leases/cbx_cancel_transient/release" {
+			http.NotFound(w, r)
+			return
+		}
+		if attempts.Add(1) == 1 {
+			http.Error(w, `{"error":"temporarily_unavailable"}`, http.StatusServiceUnavailable)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
+			ID: "cbx_cancel_transient", Slug: "retry-crab", State: "released",
+		}})
+	}))
+	defer server.Close()
+
+	cfg := baseConfig()
+	cfg.Provider = "aws"
+	cfg.TargetOS = targetLinux
+	cfg.Coordinator = server.URL
+	cfg.CoordToken = "user-token"
+	coord, _, err := newCoordinatorClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend := &coordinatorLeaseBackend{coord: coord, rt: Runtime{Stderr: &bytes.Buffer{}}}
+	recoverCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	if err := backend.releaseCoordinatorLeaseAfterCanceledCreate(recoverCtx, "cbx_cancel_transient", "retry-crab"); err != nil {
+		t.Fatal(err)
+	}
+	if got := attempts.Load(); got != 2 {
+		t.Fatalf("delete-release attempts=%d, want transient failure plus retry", got)
+	}
+}
+
+func TestCanceledCoordinatorCreateMakesOneFreshFinalReleaseAttemptAtRecoveryDeadline(t *testing.T) {
+	oldFinalTimeout := coordinatorCanceledCreateFinalTimeout
+	oldRecoveryInterval := coordinatorCreateLeaseRecoveryInterval
+	coordinatorCanceledCreateFinalTimeout = time.Second
+	coordinatorCreateLeaseRecoveryInterval = time.Hour
+	defer func() {
+		coordinatorCanceledCreateFinalTimeout = oldFinalTimeout
+		coordinatorCreateLeaseRecoveryInterval = oldRecoveryInterval
+	}()
+
+	var attempts atomic.Int32
+	var deadlines [2]time.Time
+	coord := &CoordinatorClient{
+		BaseURL: "http://coordinator.test",
+		Token:   "user-token",
+		Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			attempt := int(attempts.Add(1))
+			if req.Method != http.MethodPost || req.URL.Path != "/v1/leases/cbx_cancel_final/release" {
+				return nil, fmt.Errorf("unexpected request %s %s", req.Method, req.URL.Path)
+			}
+			deadline, ok := req.Context().Deadline()
+			if !ok {
+				return nil, errors.New("delete-release attempt had no deadline")
+			}
+			if attempt > len(deadlines) {
+				return nil, fmt.Errorf("unexpected delete-release attempt %d", attempt)
+			}
+			deadlines[attempt-1] = deadline
+			if attempt == 1 {
+				<-req.Context().Done()
+				return nil, req.Context().Err()
+			}
+			if err := req.Context().Err(); err != nil {
+				return nil, fmt.Errorf("final delete-release started with expired context: %w", err)
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body: io.NopCloser(strings.NewReader(
+					`{"lease":{"id":"cbx_cancel_final","slug":"final-crab","state":"released"}}`,
+				)),
+				Request: req,
+			}, nil
+		})},
+	}
+	backend := &coordinatorLeaseBackend{coord: coord, rt: Runtime{Stderr: &bytes.Buffer{}}}
+	recoverCtx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	if err := backend.releaseCoordinatorLeaseAfterCanceledCreate(recoverCtx, "cbx_cancel_final", "final-crab"); err != nil {
+		t.Fatal(err)
+	}
+	if got := attempts.Load(); got != 2 {
+		t.Fatalf("delete-release attempts=%d, want recovery attempt plus exactly one final attempt", got)
+	}
+	if !deadlines[1].After(deadlines[0]) {
+		t.Fatalf("final deadline=%s, want fresh deadline after expired recovery deadline=%s", deadlines[1], deadlines[0])
+	}
+}
+
+func TestCoordinatorFixedCreateCancellationDoesNotReleaseDurableLease(t *testing.T) {
+	putStarted := make(chan struct{})
+	allowPutReturn := make(chan struct{})
+	putFinished := make(chan struct{})
+	var releases atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/leases/cbx_fixed_cancel":
+			close(putStarted)
+			<-allowPutReturn
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
+				ID: "cbx_fixed_cancel", Slug: "durable-crab", Provider: "aws", TargetOS: targetLinux,
+				State: "active", Host: "203.0.113.55",
+			}})
+			close(putFinished)
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/leases/cbx_fixed_cancel/release":
+			releases.Add(1)
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{ID: "cbx_fixed_cancel", State: "released"}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	cfg := baseConfig()
+	cfg.Provider = "aws"
+	cfg.TargetOS = targetLinux
+	cfg.Coordinator = server.URL
+	cfg.CoordToken = "user-token"
+	coord, _, err := newCoordinatorClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend := &coordinatorLeaseBackend{cfg: cfg, coord: coord, rt: Runtime{Stderr: &bytes.Buffer{}}}
+	ctx, cancel := context.WithCancel(context.Background())
+	resultCh := make(chan coordinatorCreateLeaseResult, 1)
+	go func() {
+		lease, createErr := backend.createCoordinatorLeaseWithProgressMode(
+			ctx, cfg, "ssh-ed25519 test", true, "cbx_fixed_cancel", "durable-crab", true,
+		)
+		resultCh <- coordinatorCreateLeaseResult{lease: lease, err: createErr}
+	}()
+	<-putStarted
+	cancel()
+
+	select {
+	case result := <-resultCh:
+		if !errors.Is(result.err, context.Canceled) {
+			t.Fatalf("fixed create err=%v, want context canceled", result.err)
+		}
+		if result.lease.ID != "" {
+			t.Fatalf("fixed canceled create returned lease=%#v", result.lease)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("fixed canceled create did not return")
+	}
+	close(allowPutReturn)
+	select {
+	case <-putFinished:
+	case <-time.After(time.Second):
+		t.Fatal("fixed PUT handler did not finish")
+	}
+	if got := releases.Load(); got != 0 {
+		t.Fatalf("fixed replay-owned lease was released %d time(s)", got)
+	}
+}
+
+func TestCanceledCoordinatorCreateJoinsDefinitiveCreateError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	createErr := CoordinatorHTTPError{
+		Method:     http.MethodPost,
+		Path:       "/v1/leases",
+		StatusCode: http.StatusBadRequest,
+		Message:    `{"error":"invalid_configuration"}`,
+	}
+	backend := &coordinatorLeaseBackend{rt: Runtime{Stderr: &bytes.Buffer{}}}
+
+	err := backend.canceledCoordinatorLeaseCreateError(ctx, "cbx_definitive_cancel", "amber-crab", false, createErr)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err=%v, want caller cancellation", err)
+	}
+	var gotHTTPError CoordinatorHTTPError
+	if !errors.As(err, &gotHTTPError) || gotHTTPError.StatusCode != http.StatusBadRequest {
+		t.Fatalf("err=%v, want joined definitive create error", err)
+	}
+}
+
+func TestCanceledCoordinatorCreateDeletesReleasedRetainedLease(t *testing.T) {
+	var gets atomic.Int32
+	var releases atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/leases/cbx_cancel_retained":
+			gets.Add(1)
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
+				ID:       "cbx_cancel_retained",
+				Slug:     "coral-crab",
+				Provider: "aws",
+				State:    "released",
+				Keep:     true,
+			}})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/leases/cbx_cancel_retained/release":
+			var body struct {
+				Delete bool `json:"delete"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Error(err)
+			}
+			if !body.Delete {
+				t.Error("retained lease release did not request provider deletion")
+			}
+			releases.Add(1)
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
+				ID:       "cbx_cancel_retained",
+				Provider: "aws",
+				State:    "released",
+			}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	cfg := baseConfig()
+	cfg.Provider = "aws"
+	cfg.TargetOS = targetLinux
+	cfg.Coordinator = server.URL
+	cfg.CoordToken = "user-token"
+	coord, _, err := newCoordinatorClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend := &coordinatorLeaseBackend{
+		cfg:   cfg,
+		coord: coord,
+		rt:    Runtime{Stderr: &bytes.Buffer{}},
+	}
+
+	if err := backend.releaseCoordinatorLeaseAfterCanceledCreate(
+		context.Background(),
+		"cbx_cancel_retained",
+		"coral-crab",
+	); err != nil {
+		t.Fatal(err)
+	}
+	if got := releases.Load(); got != 1 {
+		t.Fatalf("released retained lease release requests=%d, want 1", got)
+	}
+	if got := gets.Load(); got != 0 {
+		t.Fatalf("released retained lease GET requests=%d, want direct release", got)
+	}
+}
+
+func TestCanceledCoordinatorCreateRequiresRequestedLeaseIDAttestationForCanonicalRelease(t *testing.T) {
+	tests := []struct {
+		name           string
+		requestLeaseID any
+		wantError      bool
+	}{
+		{name: "correct", requestLeaseID: "cbx_cancel_expected"},
+		{name: "incorrect", requestLeaseID: "cbx_cancel_other", wantError: true},
+		{name: "missing", wantError: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost || r.URL.Path != "/v1/leases/cbx_cancel_expected/release" {
+					http.NotFound(w, r)
+					return
+				}
+				response := map[string]any{"lease": CoordinatorLease{
+					ID: "cbx_cancel_canonical", State: "released",
+				}}
+				if tt.requestLeaseID != nil {
+					response["requestLeaseID"] = tt.requestLeaseID
+				}
+				_ = json.NewEncoder(w).Encode(response)
+			}))
+			defer server.Close()
+
+			cfg := baseConfig()
+			cfg.Provider = "aws"
+			cfg.TargetOS = targetLinux
+			cfg.Coordinator = server.URL
+			cfg.CoordToken = "user-token"
+			coord, _, err := newCoordinatorClient(cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			backend := &coordinatorLeaseBackend{coord: coord, rt: Runtime{Stderr: &bytes.Buffer{}}}
+
+			err = backend.releaseCoordinatorLeaseAfterCanceledCreate(
+				context.Background(),
+				"cbx_cancel_expected",
+				"expected-crab",
+			)
+			if tt.wantError {
+				if err == nil || !strings.Contains(err.Error(), "without matching requestLeaseID attestation") {
+					t.Fatalf("err=%v, want missing or mismatched attestation", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
 func TestCoordinatorCreateLeaseRecoversLeaseCommittedAfterCreateError(t *testing.T) {
 	oldRecoveryTimeout := coordinatorCreateLeaseRecoveryTimeout
 	oldRecoveryInterval := coordinatorCreateLeaseRecoveryInterval
@@ -614,6 +1050,7 @@ func TestCoordinatorCreateLeaseRecoversLeaseCommittedAfterCreateError(t *testing
 
 	var createdLeaseID string
 	gets := 0
+	releases := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/leases":
@@ -642,6 +1079,13 @@ func TestCoordinatorCreateLeaseRecoversLeaseCommittedAfterCreateError(t *testing
 				State:              "active",
 				ServerType:         "Standard_D2ads_v6",
 				IdleTimeoutSeconds: 1800,
+			}})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/release"):
+			releases++
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
+				ID:       createdLeaseID,
+				Provider: "azure",
+				State:    "released",
 			}})
 		default:
 			http.NotFound(w, r)
@@ -672,6 +1116,9 @@ func TestCoordinatorCreateLeaseRecoversLeaseCommittedAfterCreateError(t *testing
 	if gets == 0 {
 		t.Fatal("expected recovery GET")
 	}
+	if releases != 0 {
+		t.Fatalf("active uncertain create release requests=%d, want 0", releases)
+	}
 	for _, want := range []string{
 		"uncertain result",
 		"recovered coordinator lease",
@@ -680,6 +1127,59 @@ func TestCoordinatorCreateLeaseRecoversLeaseCommittedAfterCreateError(t *testing
 		if !strings.Contains(stderr.String(), want) {
 			t.Fatalf("stderr=%q missing %q", stderr.String(), want)
 		}
+	}
+}
+
+func TestCoordinatorCreateLeaseDefinitiveErrorDoesNotReconcile(t *testing.T) {
+	var gets atomic.Int32
+	var releases atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/leases":
+			http.Error(w, `{"error":"invalid_configuration"}`, http.StatusBadRequest)
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/leases/cbx_definitive":
+			gets.Add(1)
+			http.NotFound(w, r)
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/leases/cbx_definitive/release":
+			releases.Add(1)
+			http.NotFound(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	cfg := baseConfig()
+	cfg.Provider = "aws"
+	cfg.TargetOS = targetLinux
+	cfg.Coordinator = server.URL
+	cfg.CoordToken = "user-token"
+	coord, _, err := newCoordinatorClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend := &coordinatorLeaseBackend{
+		cfg:   cfg,
+		coord: coord,
+		rt:    Runtime{Stderr: &bytes.Buffer{}},
+	}
+
+	lease, err := backend.createCoordinatorLeaseWithProgress(
+		context.Background(),
+		cfg,
+		"ssh-rsa test",
+		false,
+		"cbx_definitive",
+		"amber-crab",
+	)
+	if err == nil || !strings.Contains(err.Error(), "http 400") {
+		t.Fatalf("create err=%v, want definitive http 400", err)
+	}
+	if lease.ID != "" {
+		t.Fatalf("definitive error returned lease=%#v", lease)
+	}
+	if gets.Load() != 0 || releases.Load() != 0 {
+		t.Fatalf("definitive error reconciliation gets=%d releases=%d, want 0/0", gets.Load(), releases.Load())
 	}
 }
 

--- a/internal/cli/provider_coordinator_test.go
+++ b/internal/cli/provider_coordinator_test.go
@@ -390,6 +390,57 @@ func TestCoordinatorFixedAcquireUsesRequestedIDAndJoinsProvisioning(t *testing.T
 	}
 }
 
+func TestCoordinatorAcquirePollsCanonicalIDFromProvisioningReplay(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	oldInterval := coordinatorCreateLeaseRecoveryInterval
+	coordinatorCreateLeaseRecoveryInterval = time.Millisecond
+	defer func() { coordinatorCreateLeaseRecoveryInterval = oldInterval }()
+
+	const requestedID = "cbx_abcdef123456"
+	const canonicalID = "cbx_abcdef123457"
+	gets := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/leases":
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
+				ID: canonicalID, Slug: "retained-canonical", Provider: "aws", TargetOS: targetLinux, State: "provisioning",
+			}})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/leases/"+canonicalID:
+			gets++
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
+				ID: canonicalID, Slug: "retained-canonical", Provider: "aws", TargetOS: targetLinux,
+				State: "active", CloudID: "i-retained", Host: "203.0.113.10", SSHUser: "crabbox", SSHPort: "2222", WorkRoot: defaultPOSIXWorkRoot,
+			}})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/leases/"+requestedID:
+			t.Fatalf("polled provisional ID instead of canonical ID")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	cfg := baseConfig()
+	cfg.Provider = "aws"
+	cfg.TargetOS = targetLinux
+	cfg.Coordinator = server.URL
+	cfg.CoordToken = "user-token"
+	coord, _, err := newCoordinatorClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend := &coordinatorLeaseBackend{cfg: cfg, coord: coord, rt: Runtime{Stderr: &bytes.Buffer{}}}
+	lease, err := backend.createCoordinatorLeaseWithProgressMode(
+		context.Background(), cfg, "ssh-ed25519 test", true, requestedID, "retained-canonical", false,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.ID != canonicalID || lease.CloudID != "i-retained" || gets == 0 {
+		t.Fatalf("lease=%#v gets=%d", lease, gets)
+	}
+}
+
 func TestCoordinatorFixedAcquireInvokesOnAcquiredOnceAndPropagatesError(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("POSIX fake ssh helper requires a unix-like host")
@@ -551,21 +602,38 @@ func TestCoordinatorAcquireReportsSelectedImageAndProviderStartupTiming(t *testi
 
 func TestCoordinatorCreateLeaseTimesOutWithDiagnostics(t *testing.T) {
 	oldTimeout := coordinatorCreateLeaseTimeoutForConfig
-	oldInterval := coordinatorCreateLeaseProgressInterval
+	oldProgressInterval := coordinatorCreateLeaseProgressInterval
+	oldRecoveryTimeout := coordinatorCreateLeaseRecoveryTimeout
+	oldRecoveryInterval := coordinatorCreateLeaseRecoveryInterval
+	oldAttemptID := coordinatorCreateAttemptID
 	coordinatorCreateLeaseTimeoutForConfig = func(Config) time.Duration { return 80 * time.Millisecond }
 	coordinatorCreateLeaseProgressInterval = 10 * time.Millisecond
+	coordinatorCreateLeaseRecoveryTimeout = 30 * time.Millisecond
+	coordinatorCreateLeaseRecoveryInterval = 5 * time.Millisecond
+	coordinatorCreateAttemptID = func() string { return "cat_99999999999999999999999999999999" }
 	defer func() {
 		coordinatorCreateLeaseTimeoutForConfig = oldTimeout
-		coordinatorCreateLeaseProgressInterval = oldInterval
+		coordinatorCreateLeaseProgressInterval = oldProgressInterval
+		coordinatorCreateLeaseRecoveryTimeout = oldRecoveryTimeout
+		coordinatorCreateLeaseRecoveryInterval = oldRecoveryInterval
+		coordinatorCreateAttemptID = oldAttemptID
 	}()
 
+	var cancellations atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost || r.URL.Path != "/v1/leases" {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/leases":
+			time.Sleep(250 * time.Millisecond)
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{ID: "cbx_timeout"}})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/leases/cbx_timeout/cancel-create":
+			cancellations.Add(1)
+			_ = json.NewEncoder(w).Encode(map[string]any{"canceledCreate": map[string]any{
+				"version": 1, "requestedLeaseID": "cbx_timeout",
+				"createAttemptID": "cat_99999999999999999999999999999999", "state": "canceled",
+			}})
+		default:
 			http.NotFound(w, r)
-			return
 		}
-		time.Sleep(250 * time.Millisecond)
-		_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{ID: "cbx_timeout"}})
 	}))
 	defer server.Close()
 
@@ -601,24 +669,30 @@ func TestCoordinatorCreateLeaseTimesOutWithDiagnostics(t *testing.T) {
 			t.Fatalf("err=%q missing %q", err, want)
 		}
 	}
-	if !strings.Contains(stderr.String(), "waiting for coordinator lease provider=azure slug=crimson-lobster") {
-		t.Fatalf("missing progress output: %q", stderr.String())
+	if !strings.Contains(stderr.String(), "waiting for coordinator lease provider=azure slug=crimson-lobster") ||
+		!strings.Contains(stderr.String(), "abandoning uncertain coordinator create cbx_timeout; recording durable cancellation") {
+		t.Fatalf("missing progress or cancellation output: %q", stderr.String())
+	}
+	if got := cancellations.Load(); got != 1 {
+		t.Fatalf("cancel-create requests=%d, want 1", got)
 	}
 }
 
-func TestCoordinatorCreateLeaseCancellationReleasesLateAcceptedLease(t *testing.T) {
+func TestCoordinatorCreateLeaseCancellationUsesExactDurableAttemptToken(t *testing.T) {
 	oldRecoveryTimeout := coordinatorCanceledCreateRecoveryTimeout
 	oldRecoveryInterval := coordinatorCreateLeaseRecoveryInterval
 	coordinatorCanceledCreateRecoveryTimeout = time.Second
 	coordinatorCreateLeaseRecoveryInterval = 10 * time.Millisecond
+	oldAttemptID := coordinatorCreateAttemptID
+	coordinatorCreateAttemptID = func() string { return "cat_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }
 	defer func() {
 		coordinatorCanceledCreateRecoveryTimeout = oldRecoveryTimeout
 		coordinatorCreateLeaseRecoveryInterval = oldRecoveryInterval
+		coordinatorCreateAttemptID = oldAttemptID
 	}()
 
 	createStarted := make(chan struct{})
 	allowCreateCommit := make(chan struct{})
-	leaseAccepted := make(chan struct{})
 	firstReconcileRelease := make(chan struct{})
 	releaseObserved := make(chan struct{})
 	var firstReleaseAttempt sync.Once
@@ -627,9 +701,17 @@ func TestCoordinatorCreateLeaseCancellationReleasesLateAcceptedLease(t *testing.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/leases":
+			var body struct {
+				CreateAttemptID string `json:"createAttemptID"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Error(err)
+			}
+			if body.CreateAttemptID != "cat_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" {
+				t.Errorf("create attempt=%q", body.CreateAttemptID)
+			}
 			close(createStarted)
 			<-allowCreateCommit // Model a coordinator/provider path that commits after client cancellation.
-			close(leaseAccepted)
 			_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
 				ID:       "cbx_cancel_late",
 				Slug:     "pearl-prawn",
@@ -638,29 +720,22 @@ func TestCoordinatorCreateLeaseCancellationReleasesLateAcceptedLease(t *testing.
 				Host:     "203.0.113.44",
 				State:    "active",
 			}})
-		case r.Method == http.MethodPost && r.URL.Path == "/v1/leases/cbx_cancel_late/release":
-			select {
-			case <-leaseAccepted:
-			default:
-				firstReleaseAttempt.Do(func() { close(firstReconcileRelease) })
-				http.Error(w, `{"error":"not_found"}`, http.StatusNotFound)
-				return
-			}
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/leases/cbx_cancel_late/cancel-create":
 			var body struct {
-				Delete bool `json:"delete"`
+				CreateAttemptID string `json:"createAttemptID"`
 			}
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 				t.Error(err)
 			}
-			if !body.Delete {
-				t.Error("late lease release did not request provider deletion")
+			if body.CreateAttemptID != "cat_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" {
+				t.Errorf("cancel attempt=%q", body.CreateAttemptID)
 			}
+			firstReleaseAttempt.Do(func() { close(firstReconcileRelease) })
 			releaseCount.Add(1)
 			firstRelease.Do(func() { close(releaseObserved) })
-			_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
-				ID:       "cbx_cancel_late",
-				Provider: "aws",
-				State:    "released",
+			_ = json.NewEncoder(w).Encode(map[string]any{"canceledCreate": map[string]any{
+				"version": 1, "requestedLeaseID": "cbx_cancel_late",
+				"createAttemptID": body.CreateAttemptID, "state": "canceled",
 			}})
 		default:
 			http.NotFound(w, r)
@@ -700,7 +775,7 @@ func TestCoordinatorCreateLeaseCancellationReleasesLateAcceptedLease(t *testing.
 	case <-firstReconcileRelease:
 	case <-time.After(250 * time.Millisecond):
 		close(allowCreateCommit)
-		t.Fatal("canceled create did not reconcile its pre-generated lease id with delete-release")
+		t.Fatal("canceled create did not send its pre-generated create attempt token")
 	}
 	close(allowCreateCommit)
 
@@ -719,21 +794,21 @@ func TestCoordinatorCreateLeaseCancellationReleasesLateAcceptedLease(t *testing.
 	select {
 	case <-releaseObserved:
 	case <-time.After(time.Second):
-		t.Fatalf("late accepted lease was not released; stderr=%q", stderr.String())
+		t.Fatalf("durable create cancellation was not recorded; stderr=%q", stderr.String())
 	}
 	if got := releaseCount.Load(); got != 1 {
-		t.Fatalf("release requests=%d, want 1", got)
+		t.Fatalf("cancel-create requests=%d, want 1", got)
 	}
 }
 
-func TestCanceledCoordinatorCreateRetriesTransientReleaseFailure(t *testing.T) {
+func TestCanceledCoordinatorCreateRetriesTransientCancelFailure(t *testing.T) {
 	oldRecoveryInterval := coordinatorCreateLeaseRecoveryInterval
 	coordinatorCreateLeaseRecoveryInterval = time.Millisecond
 	defer func() { coordinatorCreateLeaseRecoveryInterval = oldRecoveryInterval }()
 
 	var attempts atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost || r.URL.Path != "/v1/leases/cbx_cancel_transient/release" {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/leases/cbx_cancel_transient/cancel-create" {
 			http.NotFound(w, r)
 			return
 		}
@@ -741,8 +816,9 @@ func TestCanceledCoordinatorCreateRetriesTransientReleaseFailure(t *testing.T) {
 			http.Error(w, `{"error":"temporarily_unavailable"}`, http.StatusServiceUnavailable)
 			return
 		}
-		_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
-			ID: "cbx_cancel_transient", Slug: "retry-crab", State: "released",
+		_ = json.NewEncoder(w).Encode(map[string]any{"canceledCreate": map[string]any{
+			"version": 1, "requestedLeaseID": "cbx_cancel_transient",
+			"createAttemptID": "cat_11111111111111111111111111111111", "state": "canceled",
 		}})
 	}))
 	defer server.Close()
@@ -760,15 +836,48 @@ func TestCanceledCoordinatorCreateRetriesTransientReleaseFailure(t *testing.T) {
 	recoverCtx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
-	if err := backend.releaseCoordinatorLeaseAfterCanceledCreate(recoverCtx, "cbx_cancel_transient", "retry-crab"); err != nil {
+	if err := backend.cancelCoordinatorLeaseCreate(recoverCtx, "cbx_cancel_transient", "retry-crab", "cat_11111111111111111111111111111111"); err != nil {
 		t.Fatal(err)
 	}
 	if got := attempts.Load(); got != 2 {
-		t.Fatalf("delete-release attempts=%d, want transient failure plus retry", got)
+		t.Fatalf("cancel-create attempts=%d, want transient failure plus retry", got)
 	}
 }
 
-func TestCanceledCoordinatorCreateMakesOneFreshFinalReleaseAttemptAtRecoveryDeadline(t *testing.T) {
+func TestCoordinatorCancelCreateRetryableStatuses(t *testing.T) {
+	for _, statusCode := range []int{
+		http.StatusRequestTimeout,
+		http.StatusTooManyRequests,
+		http.StatusInternalServerError,
+		http.StatusBadGateway,
+	} {
+		err := CoordinatorHTTPError{StatusCode: statusCode}
+		if !coordinatorCancelCreateErrorRetryable(err) {
+			t.Fatalf("status %d must be retryable", statusCode)
+		}
+	}
+	if coordinatorCancelCreateErrorRetryable(CoordinatorHTTPError{StatusCode: http.StatusConflict}) {
+		t.Fatal("conflict must not be retried")
+	}
+}
+
+func TestCoordinatorCreateLeaseTreatsAllServerErrorsAsAmbiguous(t *testing.T) {
+	for _, statusCode := range []int{
+		http.StatusInternalServerError,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout,
+	} {
+		if !coordinatorCreateLeaseErrorMayHaveCommitted(CoordinatorHTTPError{StatusCode: statusCode}) {
+			t.Fatalf("status %d must be treated as an ambiguous create result", statusCode)
+		}
+	}
+	if coordinatorCreateLeaseErrorMayHaveCommitted(CoordinatorHTTPError{StatusCode: http.StatusConflict}) {
+		t.Fatal("conflict must remain definitive")
+	}
+}
+
+func TestCanceledCoordinatorCreateMakesOneFreshFinalCancelAttemptAtRecoveryDeadline(t *testing.T) {
 	oldFinalTimeout := coordinatorCanceledCreateFinalTimeout
 	oldRecoveryInterval := coordinatorCreateLeaseRecoveryInterval
 	coordinatorCanceledCreateFinalTimeout = time.Second
@@ -785,15 +894,15 @@ func TestCanceledCoordinatorCreateMakesOneFreshFinalReleaseAttemptAtRecoveryDead
 		Token:   "user-token",
 		Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 			attempt := int(attempts.Add(1))
-			if req.Method != http.MethodPost || req.URL.Path != "/v1/leases/cbx_cancel_final/release" {
+			if req.Method != http.MethodPost || req.URL.Path != "/v1/leases/cbx_cancel_final/cancel-create" {
 				return nil, fmt.Errorf("unexpected request %s %s", req.Method, req.URL.Path)
 			}
 			deadline, ok := req.Context().Deadline()
 			if !ok {
-				return nil, errors.New("delete-release attempt had no deadline")
+				return nil, errors.New("cancel-create attempt had no deadline")
 			}
 			if attempt > len(deadlines) {
-				return nil, fmt.Errorf("unexpected delete-release attempt %d", attempt)
+				return nil, fmt.Errorf("unexpected cancel-create attempt %d", attempt)
 			}
 			deadlines[attempt-1] = deadline
 			if attempt == 1 {
@@ -801,13 +910,13 @@ func TestCanceledCoordinatorCreateMakesOneFreshFinalReleaseAttemptAtRecoveryDead
 				return nil, req.Context().Err()
 			}
 			if err := req.Context().Err(); err != nil {
-				return nil, fmt.Errorf("final delete-release started with expired context: %w", err)
+				return nil, fmt.Errorf("final cancel-create started with expired context: %w", err)
 			}
 			return &http.Response{
 				StatusCode: http.StatusOK,
 				Header:     make(http.Header),
 				Body: io.NopCloser(strings.NewReader(
-					`{"lease":{"id":"cbx_cancel_final","slug":"final-crab","state":"released"}}`,
+					`{"canceledCreate":{"version":1,"requestedLeaseID":"cbx_cancel_final","createAttemptID":"cat_22222222222222222222222222222222","state":"canceled"}}`,
 				)),
 				Request: req,
 			}, nil
@@ -817,11 +926,11 @@ func TestCanceledCoordinatorCreateMakesOneFreshFinalReleaseAttemptAtRecoveryDead
 	recoverCtx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
 	defer cancel()
 
-	if err := backend.releaseCoordinatorLeaseAfterCanceledCreate(recoverCtx, "cbx_cancel_final", "final-crab"); err != nil {
+	if err := backend.cancelCoordinatorLeaseCreate(recoverCtx, "cbx_cancel_final", "final-crab", "cat_22222222222222222222222222222222"); err != nil {
 		t.Fatal(err)
 	}
 	if got := attempts.Load(); got != 2 {
-		t.Fatalf("delete-release attempts=%d, want recovery attempt plus exactly one final attempt", got)
+		t.Fatalf("cancel-create attempts=%d, want recovery attempt plus exactly one final attempt", got)
 	}
 	if !deadlines[1].After(deadlines[0]) {
 		t.Fatalf("final deadline=%s, want fresh deadline after expired recovery deadline=%s", deadlines[1], deadlines[0])
@@ -832,7 +941,7 @@ func TestCoordinatorFixedCreateCancellationDoesNotReleaseDurableLease(t *testing
 	putStarted := make(chan struct{})
 	allowPutReturn := make(chan struct{})
 	putFinished := make(chan struct{})
-	var releases atomic.Int32
+	var cleanupRequests atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodPut && r.URL.Path == "/v1/leases/cbx_fixed_cancel":
@@ -843,8 +952,8 @@ func TestCoordinatorFixedCreateCancellationDoesNotReleaseDurableLease(t *testing
 				State: "active", Host: "203.0.113.55",
 			}})
 			close(putFinished)
-		case r.Method == http.MethodPost && r.URL.Path == "/v1/leases/cbx_fixed_cancel/release":
-			releases.Add(1)
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v1/leases/cbx_fixed_cancel/"):
+			cleanupRequests.Add(1)
 			_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{ID: "cbx_fixed_cancel", State: "released"}})
 		default:
 			http.NotFound(w, r)
@@ -890,8 +999,8 @@ func TestCoordinatorFixedCreateCancellationDoesNotReleaseDurableLease(t *testing
 	case <-time.After(time.Second):
 		t.Fatal("fixed PUT handler did not finish")
 	}
-	if got := releases.Load(); got != 0 {
-		t.Fatalf("fixed replay-owned lease was released %d time(s)", got)
+	if got := cleanupRequests.Load(); got != 0 {
+		t.Fatalf("fixed replay-owned lease received %d cancellation cleanup request(s)", got)
 	}
 }
 
@@ -904,9 +1013,19 @@ func TestCanceledCoordinatorCreateJoinsDefinitiveCreateError(t *testing.T) {
 		StatusCode: http.StatusBadRequest,
 		Message:    `{"error":"invalid_configuration"}`,
 	}
-	backend := &coordinatorLeaseBackend{rt: Runtime{Stderr: &bytes.Buffer{}}}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"canceledCreate": map[string]any{
+			"version": 1, "requestedLeaseID": "cbx_definitive_cancel",
+			"createAttemptID": "cat_33333333333333333333333333333333", "state": "canceled",
+		}})
+	}))
+	defer server.Close()
+	backend := &coordinatorLeaseBackend{
+		coord: &CoordinatorClient{BaseURL: server.URL, Client: server.Client()},
+		rt:    Runtime{Stderr: &bytes.Buffer{}},
+	}
 
-	err := backend.canceledCoordinatorLeaseCreateError(ctx, "cbx_definitive_cancel", "amber-crab", false, createErr)
+	err := backend.canceledCoordinatorLeaseCreateError(ctx, "cbx_definitive_cancel", "amber-crab", "cat_33333333333333333333333333333333", false, createErr)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("err=%v, want caller cancellation", err)
 	}
@@ -916,35 +1035,25 @@ func TestCanceledCoordinatorCreateJoinsDefinitiveCreateError(t *testing.T) {
 	}
 }
 
-func TestCanceledCoordinatorCreateDeletesReleasedRetainedLease(t *testing.T) {
+func TestCanceledCoordinatorCreateAcceptsDurableTombstoneWithoutLease(t *testing.T) {
 	var gets atomic.Int32
 	var releases atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/v1/leases/cbx_cancel_retained":
-			gets.Add(1)
-			_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
-				ID:       "cbx_cancel_retained",
-				Slug:     "coral-crab",
-				Provider: "aws",
-				State:    "released",
-				Keep:     true,
-			}})
-		case r.Method == http.MethodPost && r.URL.Path == "/v1/leases/cbx_cancel_retained/release":
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/leases/cbx_cancel_retained/cancel-create":
 			var body struct {
-				Delete bool `json:"delete"`
+				CreateAttemptID string `json:"createAttemptID"`
 			}
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 				t.Error(err)
 			}
-			if !body.Delete {
-				t.Error("retained lease release did not request provider deletion")
+			if body.CreateAttemptID != "cat_44444444444444444444444444444444" {
+				t.Errorf("create attempt=%q", body.CreateAttemptID)
 			}
 			releases.Add(1)
-			_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
-				ID:       "cbx_cancel_retained",
-				Provider: "aws",
-				State:    "released",
+			_ = json.NewEncoder(w).Encode(map[string]any{"canceledCreate": map[string]any{
+				"version": 1, "requestedLeaseID": "cbx_cancel_retained",
+				"createAttemptID": body.CreateAttemptID, "state": "canceled",
 			}})
 		default:
 			http.NotFound(w, r)
@@ -967,45 +1076,51 @@ func TestCanceledCoordinatorCreateDeletesReleasedRetainedLease(t *testing.T) {
 		rt:    Runtime{Stderr: &bytes.Buffer{}},
 	}
 
-	if err := backend.releaseCoordinatorLeaseAfterCanceledCreate(
+	if err := backend.cancelCoordinatorLeaseCreate(
 		context.Background(),
 		"cbx_cancel_retained",
 		"coral-crab",
+		"cat_44444444444444444444444444444444",
 	); err != nil {
 		t.Fatal(err)
 	}
 	if got := releases.Load(); got != 1 {
-		t.Fatalf("released retained lease release requests=%d, want 1", got)
+		t.Fatalf("cancel-create requests=%d, want 1", got)
 	}
 	if got := gets.Load(); got != 0 {
-		t.Fatalf("released retained lease GET requests=%d, want direct release", got)
+		t.Fatalf("lease GET requests=%d, want none", got)
 	}
 }
 
-func TestCanceledCoordinatorCreateRequiresRequestedLeaseIDAttestationForCanonicalRelease(t *testing.T) {
+func TestCanceledCoordinatorCreateValidatesAttestation(t *testing.T) {
 	tests := []struct {
 		name           string
 		requestLeaseID any
+		createAttempt  any
 		wantError      bool
 	}{
-		{name: "correct", requestLeaseID: "cbx_cancel_expected"},
-		{name: "incorrect", requestLeaseID: "cbx_cancel_other", wantError: true},
+		{name: "correct", requestLeaseID: "cbx_cancel_expected", createAttempt: "cat_55555555555555555555555555555555"},
+		{name: "incorrect lease", requestLeaseID: "cbx_cancel_other", createAttempt: "cat_55555555555555555555555555555555", wantError: true},
+		{name: "incorrect token", requestLeaseID: "cbx_cancel_expected", createAttempt: "cat_66666666666666666666666666666666", wantError: true},
 		{name: "missing", wantError: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.Method != http.MethodPost || r.URL.Path != "/v1/leases/cbx_cancel_expected/release" {
+				if r.Method != http.MethodPost || r.URL.Path != "/v1/leases/cbx_cancel_expected/cancel-create" {
 					http.NotFound(w, r)
 					return
 				}
-				response := map[string]any{"lease": CoordinatorLease{
-					ID: "cbx_cancel_canonical", State: "released",
-				}}
-				if tt.requestLeaseID != nil {
-					response["requestLeaseID"] = tt.requestLeaseID
+				attestation := map[string]any{
+					"version": 1, "state": "canceled",
 				}
-				_ = json.NewEncoder(w).Encode(response)
+				if tt.requestLeaseID != nil {
+					attestation["requestedLeaseID"] = tt.requestLeaseID
+				}
+				if tt.createAttempt != nil {
+					attestation["createAttemptID"] = tt.createAttempt
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{"canceledCreate": attestation})
 			}))
 			defer server.Close()
 
@@ -1020,13 +1135,14 @@ func TestCanceledCoordinatorCreateRequiresRequestedLeaseIDAttestationForCanonica
 			}
 			backend := &coordinatorLeaseBackend{coord: coord, rt: Runtime{Stderr: &bytes.Buffer{}}}
 
-			err = backend.releaseCoordinatorLeaseAfterCanceledCreate(
+			err = backend.cancelCoordinatorLeaseCreate(
 				context.Background(),
 				"cbx_cancel_expected",
 				"expected-crab",
+				"cat_55555555555555555555555555555555",
 			)
 			if tt.wantError {
-				if err == nil || !strings.Contains(err.Error(), "without matching requestLeaseID attestation") {
+				if err == nil || !strings.Contains(err.Error(), "mismatched cancel-create attestation") {
 					t.Fatalf("err=%v, want missing or mismatched attestation", err)
 				}
 				return
@@ -1038,7 +1154,7 @@ func TestCanceledCoordinatorCreateRequiresRequestedLeaseIDAttestationForCanonica
 	}
 }
 
-func TestCoordinatorCreateLeaseRecoversLeaseCommittedAfterCreateError(t *testing.T) {
+func TestCoordinatorCreateLeaseRecoversWithSameTokenBoundPost(t *testing.T) {
 	oldRecoveryTimeout := coordinatorCreateLeaseRecoveryTimeout
 	oldRecoveryInterval := coordinatorCreateLeaseRecoveryInterval
 	coordinatorCreateLeaseRecoveryTimeout = time.Second
@@ -1049,17 +1165,37 @@ func TestCoordinatorCreateLeaseRecoversLeaseCommittedAfterCreateError(t *testing
 	}()
 
 	var createdLeaseID string
+	const canonicalLeaseID = "cbx_recovered_canonical"
+	var createAttemptID string
+	posts := 0
 	gets := 0
 	releases := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/leases":
+			posts++
 			var body map[string]any
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 				t.Fatal(err)
 			}
 			createdLeaseID, _ = body["leaseID"].(string)
-			http.Error(w, "error code: 1101", http.StatusInternalServerError)
+			gotAttemptID, _ := body["createAttemptID"].(string)
+			if createAttemptID == "" {
+				createAttemptID = gotAttemptID
+			}
+			if gotAttemptID != createAttemptID {
+				t.Fatalf("create attempt changed across retry: first=%q got=%q", createAttemptID, gotAttemptID)
+			}
+			if posts == 1 {
+				http.Error(w, "error code: 1101", http.StatusInternalServerError)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
+				ID: canonicalLeaseID, Slug: "jade-crab", Provider: "azure", TargetOS: targetWindows,
+				WindowsMode: windowsModeNormal, CloudID: "crabbox-jade-crab", Host: "203.0.113.44",
+				SSHUser: "crabbox", SSHPort: "22", WorkRoot: defaultWindowsWorkRoot,
+				State: "active", ServerType: "Standard_D2ads_v6", IdleTimeoutSeconds: 1800,
+			}})
 		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/leases/"):
 			gets++
 			if createdLeaseID == "" || !strings.HasSuffix(r.URL.Path, createdLeaseID) {
@@ -1110,18 +1246,18 @@ func TestCoordinatorCreateLeaseRecoversLeaseCommittedAfterCreateError(t *testing
 	if err != nil {
 		t.Fatal(err)
 	}
-	if lease.ID != createdLeaseID || lease.Host != "203.0.113.44" {
+	if lease.ID != canonicalLeaseID || lease.Host != "203.0.113.44" {
 		t.Fatalf("lease=%#v created=%s", lease, createdLeaseID)
 	}
-	if gets == 0 {
-		t.Fatal("expected recovery GET")
+	if posts != 2 || gets != 0 {
+		t.Fatalf("posts=%d gets=%d, want same-token POST retry and no polling GET", posts, gets)
 	}
 	if releases != 0 {
 		t.Fatalf("active uncertain create release requests=%d, want 0", releases)
 	}
 	for _, want := range []string{
 		"uncertain result",
-		"recovered coordinator lease",
+		"token-bound POST",
 		createdLeaseID,
 	} {
 		if !strings.Contains(stderr.String(), want) {
@@ -1523,12 +1659,13 @@ func TestCoordinatorReleaseFallsBackToAdminToken(t *testing.T) {
 	}
 }
 
-func TestCoordinatorAcquireReleasesStaleInstanceLease(t *testing.T) {
+func TestCoordinatorAcquireCancelsStaleInstanceLease(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 
 	var createdLeaseID string
-	releases := 0
+	var createAttemptID string
+	cancellations := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/leases":
@@ -1537,16 +1674,16 @@ func TestCoordinatorAcquireReleasesStaleInstanceLease(t *testing.T) {
 				t.Fatal(err)
 			}
 			createdLeaseID, _ = body["leaseID"].(string)
+			createAttemptID, _ = body["createAttemptID"].(string)
 			http.Error(w, `{"error":"InvalidInstanceID.NotFound: instance disappeared"}`, http.StatusInternalServerError)
-		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/release"):
-			releases++
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/cancel-create"):
+			cancellations++
 			if createdLeaseID == "" || !strings.Contains(r.URL.Path, createdLeaseID) {
-				t.Fatalf("release path=%s created=%s", r.URL.Path, createdLeaseID)
+				t.Fatalf("cancel path=%s created=%s", r.URL.Path, createdLeaseID)
 			}
-			_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
-				ID:       createdLeaseID,
-				Provider: "aws",
-				State:    "released",
+			_ = json.NewEncoder(w).Encode(map[string]any{"canceledCreate": map[string]any{
+				"version": 1, "requestedLeaseID": createdLeaseID,
+				"createAttemptID": createAttemptID, "state": "canceled",
 			}})
 		default:
 			http.NotFound(w, r)
@@ -1573,32 +1710,42 @@ func TestCoordinatorAcquireReleasesStaleInstanceLease(t *testing.T) {
 	if !isCoordinatorStaleInstanceCleanedError(err) {
 		t.Fatalf("err=%T, want cleaned stale instance wrapper", err)
 	}
-	if releases != 1 {
-		t.Fatalf("releases=%d want 1", releases)
+	if cancellations != 1 {
+		t.Fatalf("cancel-create requests=%d want 1", cancellations)
 	}
-	if !strings.Contains(stderr.String(), "discarded stale coordinator lease") {
-		t.Fatalf("missing discard warning: %q", stderr.String())
+	if !strings.Contains(stderr.String(), "recorded canceled coordinator create") {
+		t.Fatalf("missing cancel-create warning: %q", stderr.String())
 	}
 }
 
-func TestCoordinatorAcquireRetriesStaleInstanceWhenReleaseMissing(t *testing.T) {
+func TestCoordinatorAcquireRetriesStaleInstanceAfterTokenCancellation(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 
 	creates := 0
-	releases := 0
+	cancellations := 0
+	var leaseID, createAttemptID string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/leases":
 			creates++
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatal(err)
+			}
 			if creates > 1 {
-				http.Error(w, `{"error":"capacity exhausted after retry"}`, http.StatusInternalServerError)
+				http.Error(w, `{"error":"capacity exhausted after retry"}`, http.StatusConflict)
 				return
 			}
+			leaseID, _ = body["leaseID"].(string)
+			createAttemptID, _ = body["createAttemptID"].(string)
 			http.Error(w, `{"error":"InvalidInstanceID.NotFound: instance disappeared"}`, http.StatusInternalServerError)
-		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/release"):
-			releases++
-			http.Error(w, `{"error":"lease not found"}`, http.StatusNotFound)
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/cancel-create"):
+			cancellations++
+			_ = json.NewEncoder(w).Encode(map[string]any{"canceledCreate": map[string]any{
+				"version": 1, "requestedLeaseID": leaseID,
+				"createAttemptID": createAttemptID, "state": "canceled",
+			}})
 		default:
 			http.NotFound(w, r)
 		}
@@ -1624,10 +1771,10 @@ func TestCoordinatorAcquireRetriesStaleInstanceWhenReleaseMissing(t *testing.T) 
 	if creates != 2 {
 		t.Fatalf("creates=%d want 2", creates)
 	}
-	if releases != 1 {
-		t.Fatalf("releases=%d want 1", releases)
+	if cancellations != 1 {
+		t.Fatalf("cancel-create requests=%d want 1", cancellations)
 	}
-	if !strings.Contains(stderr.String(), "already gone; retrying with fresh lease") {
+	if !strings.Contains(stderr.String(), "recorded canceled coordinator create") {
 		t.Fatalf("missing retry warning: %q", stderr.String())
 	}
 }

--- a/worker/src/coordinator-runtime.ts
+++ b/worker/src/coordinator-runtime.ts
@@ -32,7 +32,10 @@ export function coordinatorRequestQueue(request: Request): CoordinatorRequestQue
   ) {
     return "direct";
   }
-  if (method === "POST" && path.join("/") === "v1/leases") {
+  if (
+    method === "POST" &&
+    (path.join("/") === "v1/leases" || path.join("/") === "v1/leases/capability-aware")
+  ) {
     return "direct";
   }
   if (
@@ -86,7 +89,7 @@ export function coordinatorRequestQueue(request: Request): CoordinatorRequestQue
     path[1] === "leases" &&
     path[2] &&
     method === "POST" &&
-    (path[3] === "heartbeat" || path[3] === "release")
+    (path[3] === "heartbeat" || path[3] === "release" || path[3] === "cancel-create")
   ) {
     return "direct";
   }

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -6647,11 +6647,21 @@ export class FleetCoordinator {
     try {
       released = await this.releaseResolvedLease(lease, {
         deleteServer: shouldDelete,
+        expectedLease: lease,
         ...(binding ? { requestBinding: binding } : {}),
       });
     } catch (error) {
       if (error instanceof LeaseRequestBindingConflictError) {
         return leaseRequestBindingConflictResponse();
+      }
+      if (error instanceof LeaseReleaseResolutionConflictError) {
+        return json(
+          {
+            error: "lease_state_changed",
+            message: "lease changed after release authorization",
+          },
+          { status: 409 },
+        );
       }
       throw error;
     }
@@ -6679,14 +6689,23 @@ export class FleetCoordinator {
     request: Request,
     admin: boolean,
   ): Promise<{ lease: LeaseRecord; binding?: LeaseRequestBinding } | Response> {
-    return await this.state.runExclusive(async () => {
-      const exact = await this.getLease(identifier);
-      const binding = await this.getLeaseRequestBinding(identifier);
-      if (exact && binding) {
+    const exact = await this.getLease(identifier);
+    if (exact) {
+      if (await this.getLeaseRequestBinding(identifier)) {
         return leaseRequestBindingConflictResponse();
       }
-      if (exact) {
-        return this.leaseVisibleToRequest(exact, request, admin) ? { lease: exact } : notFound();
+      return this.leaseVisibleToRequest(exact, request, admin) ? { lease: exact } : notFound();
+    }
+    return await this.state.runExclusive(async () => {
+      const lockedExact = await this.getLease(identifier);
+      const binding = await this.getLeaseRequestBinding(identifier);
+      if (lockedExact && binding) {
+        return leaseRequestBindingConflictResponse();
+      }
+      if (lockedExact) {
+        return this.leaseVisibleToRequest(lockedExact, request, admin)
+          ? { lease: lockedExact }
+          : notFound();
       }
       if (!binding) {
         const lease = await this.resolveLease(identifier, request, admin);
@@ -15601,14 +15620,22 @@ export class FleetCoordinator {
       deleteServer: boolean;
       keep?: boolean;
       requestBinding?: LeaseRequestBinding;
+      expectedLease?: LeaseRecord;
     },
   ): Promise<LeaseRecord> {
     const current = (await this.getLease(lease.id)) ?? lease;
-    if (current.runtimeAdapterDeleteRequestedAt) {
+    if (
+      options.expectedLease &&
+      (!sameLeaseReleaseIdentity(current, options.expectedLease) || current.workspaceID)
+    ) {
+      throw new LeaseReleaseResolutionConflictError();
+    }
+    if (current.runtimeAdapterDeleteRequestedAt && !options.expectedLease) {
       return current;
     }
     await this.markWorkspaceReleaseRequested(current);
     if (
+      !options.expectedLease &&
       current.workspaceID &&
       !current.cloudID &&
       (current.state === "provisioning" ||
@@ -15652,6 +15679,7 @@ export class FleetCoordinator {
       deleteServer: boolean;
       keep?: boolean;
       requestBinding?: LeaseRequestBinding;
+      expectedLease?: LeaseRecord;
     },
   ): Promise<LeaseRecord> {
     const preparation = await this.state.runExclusive(async () => {
@@ -15661,7 +15689,14 @@ export class FleetCoordinator {
       ) {
         throw new LeaseRequestBindingConflictError();
       }
-      const current = (await this.getLease(lease.id)) ?? structuredClone(lease);
+      const stored = await this.getLease(lease.id);
+      if (
+        options.expectedLease &&
+        (!stored || !sameLeaseReleaseIdentity(stored, options.expectedLease))
+      ) {
+        throw new LeaseReleaseResolutionConflictError();
+      }
+      const current = stored ?? structuredClone(lease);
       if (current.runtimeAdapterDeleteRequestedAt) {
         return { cleanup: false as const, blocked: true as const, lease: current };
       }
@@ -15806,6 +15841,8 @@ interface LeaseRequestBinding {
 }
 
 class LeaseRequestBindingConflictError extends Error {}
+
+class LeaseReleaseResolutionConflictError extends Error {}
 
 interface ProviderReadiness {
   provider: Provider;
@@ -16769,6 +16806,16 @@ function leaseRequestBindingConflictResponse(): Response {
       message: "lease request binding does not match the current canonical lease generation",
     },
     { status: 409 },
+  );
+}
+
+function sameLeaseReleaseIdentity(left: LeaseRecord, right: LeaseRecord): boolean {
+  return (
+    left.id === right.id &&
+    left.owner === right.owner &&
+    left.org === right.org &&
+    left.createdAt === right.createdAt &&
+    left.requestLeaseGeneration === right.requestLeaseGeneration
   );
 }
 

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -3083,14 +3083,17 @@ export class FleetCoordinator {
         config,
         normalizeLeaseSlug(input.slug ?? input.requestedSlug),
       );
-      const replay = await this.state.runExclusive(async () =>
-        this.fixedLeaseReplayResponse(
+      const replay = await this.state.runExclusive(async () => {
+        if (await this.getLeaseRequestBinding(fixedLeaseID)) {
+          return leaseRequestIDConflictResponse();
+        }
+        return this.fixedLeaseReplayResponse(
           await this.getLease(fixedLeaseID),
           owner,
           org,
           fixedCreateIntentHash!,
-        ),
-      );
+        );
+      });
       if (replay) {
         return replay;
       }
@@ -3265,14 +3268,33 @@ export class FleetCoordinator {
         ) {
           return undefined;
         }
+        if (
+          (await this.getLease(leaseID)) ||
+          (await this.state.storage.get(workspaceLeaseReservationKey(leaseID))) ||
+          (await this.getLeaseRequestBinding(leaseID))
+        ) {
+          return leaseRequestIDConflictResponse();
+        }
         const blocked = await reservationGuard?.();
         if (blocked) {
           return blocked;
         }
         const now = new Date();
         const admission = await this.leaseAdmissionState({ owner, org }, now, current.id);
+        const requestLeaseGeneration = newLeaseRequestGeneration();
+        const binding: LeaseRequestBinding = {
+          version: 1,
+          requestLeaseID: leaseID,
+          leaseID: current.id,
+          owner,
+          org,
+          cloudID: current.cloudID,
+          generation: requestLeaseGeneration,
+          createdAt: now.toISOString(),
+        };
         let reactivated: LeaseRecord = {
           ...current,
+          requestLeaseGeneration,
           profile: config.profile,
           class: config.class,
           requestedServerType: config.serverType,
@@ -3331,6 +3353,7 @@ export class FleetCoordinator {
         if (limitError) {
           return json({ error: "cost_limit_exceeded", message: limitError }, { status: 429 });
         }
+        await this.putLeaseRequestBinding(binding);
         await this.putLease(reactivated);
         await this.markAWSIngressReconcilePending(reactivated);
         await this.scheduleAlarm();
@@ -3380,6 +3403,9 @@ export class FleetCoordinator {
       }
       if (!workspaceID && (await this.state.storage.get(workspaceLeaseReservationKey(leaseID)))) {
         return workspaceManagedLeaseResponse();
+      }
+      if (await this.getLeaseRequestBinding(leaseID)) {
+        return leaseRequestIDConflictResponse();
       }
       const existingLease = await this.getLease(leaseID);
       if (existingLease && fixedLeaseID) {
@@ -4348,7 +4374,8 @@ export class FleetCoordinator {
     const leaseID = newLeaseID();
     if (
       (await this.getLease(leaseID)) ||
-      (await this.state.storage.get(workspaceLeaseReservationKey(leaseID)))
+      (await this.state.storage.get(workspaceLeaseReservationKey(leaseID))) ||
+      (await this.getLeaseRequestBinding(leaseID))
     ) {
       return await this.allocateWorkspaceLeaseID();
     }
@@ -6031,6 +6058,9 @@ export class FleetCoordinator {
     if (await this.state.storage.get(workspaceLeaseReservationKey(leaseID))) {
       return workspaceManagedLeaseResponse();
     }
+    if (await this.getLeaseRequestBinding(leaseID)) {
+      return leaseRequestIDConflictResponse();
+    }
     const existing = await this.getLease(leaseID);
     if (
       existing &&
@@ -6493,11 +6523,12 @@ export class FleetCoordinator {
   }
 
   private async releaseLease(request: Request, leaseID: string, admin: boolean): Promise<Response> {
-    const lease = await this.resolveLease(leaseID, request, admin);
-    if (!lease) {
-      return notFound();
+    const resolution = await this.resolveLeaseForRelease(leaseID, request, admin);
+    if (resolution instanceof Response) {
+      return resolution;
     }
-    if (!this.leaseManageableByRequest(lease, request, admin)) {
+    const { lease, binding } = resolution;
+    if (!binding && !this.leaseManageableByRequest(lease, request, admin)) {
       return json({ error: "forbidden", message: "lease manage access required" }, { status: 403 });
     }
     if (lease.workspaceID) {
@@ -6598,10 +6629,32 @@ export class FleetCoordinator {
           { status: 409 },
         );
       }
+      if (binding) {
+        const valid = await this.state.runExclusive(() =>
+          this.leaseRequestBindingMatchesCurrent(binding),
+        );
+        if (!valid) {
+          return leaseRequestBindingConflictResponse();
+        }
+      }
       await this.scheduleAlarm();
-      return json({ lease: this.leaseForRequest(lease, request, admin) });
+      return json({
+        lease: this.leaseForRequest(lease, request, admin),
+        ...(binding ? { requestLeaseID: leaseID } : {}),
+      });
     }
-    const released = await this.releaseResolvedLease(lease, { deleteServer: shouldDelete });
+    let released: LeaseRecord;
+    try {
+      released = await this.releaseResolvedLease(lease, {
+        deleteServer: shouldDelete,
+        ...(binding ? { requestBinding: binding } : {}),
+      });
+    } catch (error) {
+      if (error instanceof LeaseRequestBindingConflictError) {
+        return leaseRequestBindingConflictResponse();
+      }
+      throw error;
+    }
     if (released.runtimeAdapterDeleteRequestedAt) {
       return this.runtimeAdapterDeletePendingResponse(released, request, admin);
     }
@@ -6615,7 +6668,57 @@ export class FleetCoordinator {
         { status: 409 },
       );
     }
-    return json({ lease: this.leaseForRequest(released, request, admin) });
+    return json({
+      lease: this.leaseForRequest(released, request, admin),
+      ...(binding ? { requestLeaseID: leaseID } : {}),
+    });
+  }
+
+  private async resolveLeaseForRelease(
+    identifier: string,
+    request: Request,
+    admin: boolean,
+  ): Promise<{ lease: LeaseRecord; binding?: LeaseRequestBinding } | Response> {
+    return await this.state.runExclusive(async () => {
+      const exact = await this.getLease(identifier);
+      const binding = await this.getLeaseRequestBinding(identifier);
+      if (exact && binding) {
+        return leaseRequestBindingConflictResponse();
+      }
+      if (exact) {
+        return this.leaseVisibleToRequest(exact, request, admin) ? { lease: exact } : notFound();
+      }
+      if (!binding) {
+        const lease = await this.resolveLease(identifier, request, admin);
+        return lease ? { lease } : notFound();
+      }
+      if (
+        !admin &&
+        (binding.owner !== requestOwner(request) || binding.org !== requestOrg(request, this.env))
+      ) {
+        return notFound();
+      }
+      const lease = await this.getLease(binding.leaseID);
+      if (!lease || !leaseRequestBindingMatchesLease(binding, lease)) {
+        return leaseRequestBindingConflictResponse();
+      }
+      return { lease, binding };
+    });
+  }
+
+  private async leaseRequestBindingMatchesCurrent(binding: LeaseRequestBinding): Promise<boolean> {
+    const [exact, stored, lease] = await Promise.all([
+      this.getLease(binding.requestLeaseID),
+      this.getLeaseRequestBinding(binding.requestLeaseID),
+      this.getLease(binding.leaseID),
+    ]);
+    return Boolean(
+      !exact &&
+      stored &&
+      sameLeaseRequestBinding(stored, binding) &&
+      lease &&
+      leaseRequestBindingMatchesLease(binding, lease),
+    );
   }
 
   private async completeRuntimeAdapterDelete(
@@ -14350,6 +14453,16 @@ export class FleetCoordinator {
     return this.state.storage.get<LeaseRecord>(leaseKey(leaseID), options);
   }
 
+  private async getLeaseRequestBinding(
+    requestLeaseID: string,
+  ): Promise<LeaseRequestBinding | undefined> {
+    return this.state.storage.get<LeaseRequestBinding>(leaseRequestBindingKey(requestLeaseID));
+  }
+
+  private async putLeaseRequestBinding(binding: LeaseRequestBinding): Promise<void> {
+    await this.state.storage.put(leaseRequestBindingKey(binding.requestLeaseID), binding);
+  }
+
   private async resolveLease(
     identifier: string,
     request: Request,
@@ -15484,7 +15597,11 @@ export class FleetCoordinator {
 
   private async releaseResolvedLease(
     lease: LeaseRecord,
-    options: { deleteServer: boolean; keep?: boolean },
+    options: {
+      deleteServer: boolean;
+      keep?: boolean;
+      requestBinding?: LeaseRequestBinding;
+    },
   ): Promise<LeaseRecord> {
     const current = (await this.getLease(lease.id)) ?? lease;
     if (current.runtimeAdapterDeleteRequestedAt) {
@@ -15531,9 +15648,19 @@ export class FleetCoordinator {
 
   private async releaseResolvedLeaseOperation(
     lease: LeaseRecord,
-    options: { deleteServer: boolean; keep?: boolean },
+    options: {
+      deleteServer: boolean;
+      keep?: boolean;
+      requestBinding?: LeaseRequestBinding;
+    },
   ): Promise<LeaseRecord> {
     const preparation = await this.state.runExclusive(async () => {
+      if (
+        options.requestBinding &&
+        !(await this.leaseRequestBindingMatchesCurrent(options.requestBinding))
+      ) {
+        throw new LeaseRequestBindingConflictError();
+      }
       const current = (await this.getLease(lease.id)) ?? structuredClone(lease);
       if (current.runtimeAdapterDeleteRequestedAt) {
         return { cleanup: false as const, blocked: true as const, lease: current };
@@ -15667,6 +15794,19 @@ export class FleetDurableObject extends FleetCoordinator implements DurableObjec
   }
 }
 
+interface LeaseRequestBinding {
+  version: 1;
+  requestLeaseID: string;
+  leaseID: string;
+  owner: string;
+  org: string;
+  cloudID: string;
+  generation: string;
+  createdAt: string;
+}
+
+class LeaseRequestBindingConflictError extends Error {}
+
 interface ProviderReadiness {
   provider: Provider;
   configured: boolean;
@@ -15769,6 +15909,10 @@ function portalReturnLocation(request: Request): string {
 
 function leaseKey(leaseID: string): string {
   return `lease:${leaseID}`;
+}
+
+function leaseRequestBindingKey(requestLeaseID: string): string {
+  return `lease-request:${requestLeaseID}`;
 }
 
 function workspaceLeaseReservationKey(leaseID: string): string {
@@ -16582,6 +16726,10 @@ function newLeaseID(): string {
   return `cbx_${[...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("")}`;
 }
 
+function newLeaseRequestGeneration(): string {
+  return crypto.randomUUID();
+}
+
 function validWorkspaceID(value: string | undefined): value is string {
   return (
     typeof value === "string" &&
@@ -16601,6 +16749,63 @@ function workspaceManagedLeaseResponse(): Response {
       message: "workspace leases must be managed through the workspace lifecycle",
     },
     { status: 409 },
+  );
+}
+
+function leaseRequestIDConflictResponse(): Response {
+  return json(
+    {
+      error: "lease_id_conflict",
+      message: "lease id is already reserved",
+    },
+    { status: 409 },
+  );
+}
+
+function leaseRequestBindingConflictResponse(): Response {
+  return json(
+    {
+      error: "lease_request_binding_conflict",
+      message: "lease request binding does not match the current canonical lease generation",
+    },
+    { status: 409 },
+  );
+}
+
+function sameLeaseRequestBinding(left: LeaseRequestBinding, right: LeaseRequestBinding): boolean {
+  return (
+    left.version === 1 &&
+    right.version === 1 &&
+    left.requestLeaseID === right.requestLeaseID &&
+    left.leaseID === right.leaseID &&
+    left.owner === right.owner &&
+    left.org === right.org &&
+    left.cloudID === right.cloudID &&
+    left.generation === right.generation &&
+    left.createdAt === right.createdAt
+  );
+}
+
+function leaseRequestBindingMatchesLease(
+  binding: LeaseRequestBinding,
+  lease: LeaseRecord,
+): boolean {
+  return (
+    binding.version === 1 &&
+    validLeaseID(binding.requestLeaseID) &&
+    validLeaseID(binding.leaseID) &&
+    binding.requestLeaseID !== binding.leaseID &&
+    binding.leaseID === lease.id &&
+    binding.owner === lease.owner &&
+    binding.org === lease.org &&
+    Boolean(binding.cloudID) &&
+    binding.cloudID === lease.cloudID &&
+    Boolean(binding.generation) &&
+    binding.generation === lease.requestLeaseGeneration &&
+    lease.provider === "aws" &&
+    lease.target === "macos" &&
+    !lease.workspaceID &&
+    !isRegisteredLease(lease)
   );
 }
 

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -1047,6 +1047,7 @@ export class FleetCoordinator {
     private readonly env: Env,
     private readonly testProviders: Partial<Record<Provider, CloudProvider>> = {},
     private readonly authContext: AuthRequestContext = {},
+    private readonly coordinatorGeneration: string = crypto.randomUUID(),
   ) {
     this.webVNCCredentialHandoffs = new WebVNCCredentialHandoffs(state);
     this.restoreBridgeWebSockets();
@@ -1213,6 +1214,16 @@ export class FleetCoordinator {
       }
       if (method === "POST" && parts.join("/") === "v1/leases/capability-aware") {
         return await this.createLease(request);
+      }
+      if (
+        method === "POST" &&
+        parts[0] === "v1" &&
+        parts[1] === "leases" &&
+        parts[2] &&
+        parts[3] === "cancel-create" &&
+        parts.length === 4
+      ) {
+        return await this.cancelCreate(request, parts[2]);
       }
       if (
         method === "PUT" &&
@@ -2994,6 +3005,303 @@ export class FleetCoordinator {
     return json({ ok: true });
   }
 
+  private async reserveCreateAttempt(
+    requestedLeaseID: string,
+    token: string,
+    owner: string,
+    org: string,
+  ): Promise<{ attempt: CreateAttemptRecord; replayLease?: LeaseRecord } | Response> {
+    return await this.state.runExclusive(async () => {
+      const canceled = await this.getArchivedCanceledCreateAttempt(requestedLeaseID, token);
+      if (canceled) {
+        return canceled.owner === owner && canceled.org === org
+          ? createCanceledResponse()
+          : createAttemptConflictResponse();
+      }
+      const existing = await this.getCreateAttempt(requestedLeaseID);
+      if (existing) {
+        if (existing.token !== token) {
+          if (unboundCanceledCreateAttempt(existing, requestedLeaseID)) {
+            const [exactLease, workspaceReservation] = await Promise.all([
+              this.getLease(requestedLeaseID),
+              this.state.storage.get(workspaceLeaseReservationKey(requestedLeaseID)),
+            ]);
+            if (workspaceReservation) {
+              return workspaceManagedLeaseResponse();
+            }
+            if (exactLease) {
+              return createAttemptIDConflictResponse();
+            }
+            await this.archiveCanceledCreateAttempt(existing);
+            const now = new Date().toISOString();
+            const attempt: CreateAttemptRecord = {
+              version: 1,
+              requestedLeaseID,
+              token,
+              owner,
+              org,
+              state: "pending",
+              createdAt: now,
+              updatedAt: now,
+            };
+            await this.putCreateAttempt(attempt);
+            return { attempt };
+          }
+          return createAttemptConflictResponse();
+        }
+        if (existing.owner !== owner || existing.org !== org) {
+          return createAttemptConflictResponse();
+        }
+        if (existing.state === "canceled") {
+          return createCanceledResponse();
+        }
+        if (!existing.canonicalLeaseID) {
+          return { attempt: existing };
+        }
+        const replayLease = await this.getLease(existing.canonicalLeaseID);
+        if (!replayLease || !createAttemptMatchesLease(existing, replayLease)) {
+          return createAttemptBindingConflictResponse();
+        }
+        return { attempt: existing, replayLease };
+      }
+      if (await this.state.storage.get(workspaceLeaseReservationKey(requestedLeaseID))) {
+        return workspaceManagedLeaseResponse();
+      }
+      if (await this.getLease(requestedLeaseID)) {
+        return createAttemptIDConflictResponse();
+      }
+      const now = new Date().toISOString();
+      const attempt: CreateAttemptRecord = {
+        version: 1,
+        requestedLeaseID,
+        token,
+        owner,
+        org,
+        state: "pending",
+        createdAt: now,
+        updatedAt: now,
+      };
+      await this.putCreateAttempt(attempt);
+      return { attempt };
+    });
+  }
+
+  private async replayCreateAttempt(
+    requestedLeaseID: string,
+    token: string,
+    owner: string,
+    org: string,
+  ): Promise<Response | undefined> {
+    return await this.state.runExclusive(async () => {
+      const canceled = await this.getArchivedCanceledCreateAttempt(requestedLeaseID, token);
+      if (canceled) {
+        return canceled.owner === owner && canceled.org === org
+          ? createCanceledResponse()
+          : createAttemptConflictResponse();
+      }
+      const existing = await this.getCreateAttempt(requestedLeaseID);
+      if (!existing) {
+        return undefined;
+      }
+      if (existing.token !== token) {
+        return unboundCanceledCreateAttempt(existing, requestedLeaseID)
+          ? undefined
+          : createAttemptConflictResponse();
+      }
+      if (existing.owner !== owner || existing.org !== org) {
+        return createAttemptConflictResponse();
+      }
+      if (existing.state === "canceled") {
+        return createCanceledResponse();
+      }
+      if (!existing.canonicalLeaseID) {
+        return undefined;
+      }
+      const replayLease = await this.getLease(existing.canonicalLeaseID);
+      if (!replayLease || !createAttemptMatchesLease(existing, replayLease)) {
+        return createAttemptBindingConflictResponse();
+      }
+      return createAttemptReplayResponse(replayLease);
+    });
+  }
+
+  private async pendingCreateAttempt(
+    requestedLeaseID: string,
+    token: string,
+    owner: string,
+    org: string,
+  ): Promise<CreateAttemptRecord | undefined> {
+    const attempt = await this.getCreateAttempt(requestedLeaseID);
+    return attempt?.version === 1 &&
+      attempt.requestedLeaseID === requestedLeaseID &&
+      attempt.token === token &&
+      attempt.owner === owner &&
+      attempt.org === org &&
+      attempt.state === "pending"
+      ? attempt
+      : undefined;
+  }
+
+  private async cancelCreate(request: Request, requestedLeaseID: string): Promise<Response> {
+    if (!validLeaseID(requestedLeaseID)) {
+      return json({ error: "invalid_lease_id" }, { status: 400 });
+    }
+    const input = await readJson<{ createAttemptID?: string }>(request);
+    if (!validCreateAttemptID(input.createAttemptID)) {
+      return json({ error: "invalid_create_attempt_id" }, { status: 400 });
+    }
+    const token = input.createAttemptID;
+    const owner = requestOwner(request);
+    const org = requestOrg(request, this.env);
+    const admin = isAdminRequest(request);
+    const cancellation = await this.state.runExclusive(async () => {
+      const archived = await this.getArchivedCanceledCreateAttempt(requestedLeaseID, token);
+      if (archived) {
+        if (!admin && (archived.owner !== owner || archived.org !== org)) {
+          return notFound();
+        }
+        return { attempt: archived };
+      }
+      let existing = await this.getCreateAttempt(requestedLeaseID);
+      if (existing?.token !== undefined && existing.token !== token) {
+        if (!unboundCanceledCreateAttempt(existing, requestedLeaseID)) {
+          return createAttemptConflictResponse();
+        }
+        const [exactLease, workspaceReservation] = await Promise.all([
+          this.getLease(requestedLeaseID),
+          this.state.storage.get(workspaceLeaseReservationKey(requestedLeaseID)),
+        ]);
+        if (exactLease || workspaceReservation) {
+          return createAttemptIDConflictResponse();
+        }
+        await this.archiveCanceledCreateAttempt(existing);
+        existing = undefined;
+      }
+      if (existing && !admin && (existing.owner !== owner || existing.org !== org)) {
+        return notFound();
+      }
+      if (!existing) {
+        const [exactLease, workspaceReservation] = await Promise.all([
+          this.getLease(requestedLeaseID),
+          this.state.storage.get(workspaceLeaseReservationKey(requestedLeaseID)),
+        ]);
+        if (exactLease || workspaceReservation) {
+          return createAttemptIDConflictResponse();
+        }
+      }
+      const now = new Date().toISOString();
+      const attempt: CreateAttemptRecord = existing
+        ? existing.state === "canceled"
+          ? existing
+          : { ...existing, state: "canceled", updatedAt: now }
+        : {
+            version: 1,
+            requestedLeaseID,
+            token,
+            owner,
+            org,
+            state: "canceled",
+            createdAt: now,
+            updatedAt: now,
+          };
+      if (!attempt.canonicalLeaseID) {
+        await this.putCreateAttempt(attempt);
+        return { attempt };
+      }
+      const lease = await this.getLease(attempt.canonicalLeaseID);
+      if (!lease) {
+        await this.putCreateAttempt(attempt);
+        return { attempt };
+      }
+      if (!createAttemptMatchesLease(attempt, lease)) {
+        await this.putCreateAttempt(attempt);
+        return createAttemptBindingConflictResponse();
+      }
+      if (lease.cleanupStartedAt) {
+        await this.putCreateAttempt(attempt);
+        await this.scheduleAlarm();
+        return { attempt, lease };
+      }
+      const shouldDelete = Boolean(
+        lease.providerKeyCleanupPending ||
+        (lease.cloudID &&
+          (leaseIsLive(lease) || lease.releaseDeletesServer !== undefined || lease.cleanupError)),
+      );
+      const canceledBeforeProviderIdentity = Boolean(
+        (lease.state === "provisioning" ||
+          (lease.state === "failed" && lease.provisioningResourceMayExist) ||
+          (lease.state === "released" &&
+            lease.releaseDeletesServer === true &&
+            lease.provisioningResourceMayExist === true)) &&
+        !lease.cloudID &&
+        lease.provisioningRequestStartedAt,
+      );
+      const released = finalizedReleasedLease(lease, true, false);
+      if (canceledBeforeProviderIdentity) {
+        released.provisioningRequestStartedAt = lease.provisioningRequestStartedAt!;
+        if (lease.provisioningCoordinatorVersion) {
+          released.provisioningCoordinatorVersion = lease.provisioningCoordinatorVersion;
+        }
+        if (lease.provisioningRequestSettledAt) {
+          released.provisioningRequestSettledAt = lease.provisioningRequestSettledAt;
+        }
+        if (lease.provisioningRecoveryObservedAt) {
+          released.provisioningRecoveryObservedAt = lease.provisioningRecoveryObservedAt;
+        }
+        if (lease.provisioningRecoveryMissingSince) {
+          released.provisioningRecoveryMissingSince = lease.provisioningRecoveryMissingSince;
+        }
+        released.releaseDeletesServer = true;
+        released.provisioningResourceMayExist = true;
+        released.provisioningFailureRetryable = true;
+      }
+      if (shouldDelete) {
+        const cleanupStarted = new Date();
+        released.cleanupStartedAt = cleanupStarted.toISOString();
+        released.cleanupClaimExpiresAt = new Date(
+          cleanupStarted.getTime() + leaseCleanupClaimStaleMs,
+        ).toISOString();
+        released.releaseDeletesServer = true;
+      }
+      await this.putLease(released);
+      await this.putCreateAttempt(attempt);
+      await this.markAWSIngressReconcilePending(released);
+      await this.scheduleAlarm();
+      return {
+        attempt,
+        lease: released,
+        ...(released.cleanupStartedAt
+          ? { cleanup: { lease: structuredClone(released), claim: released.cleanupStartedAt } }
+          : {}),
+      };
+    });
+    if (cancellation instanceof Response) {
+      return cancellation;
+    }
+    let released: LeaseRecord | undefined;
+    if ("lease" in cancellation) {
+      released = cancellation.lease;
+      await this.closeLeaseBridges(cancellation.lease.id, 1008, "lease ended");
+      if ("cleanup" in cancellation && cancellation.cleanup) {
+        const cleanup = () => this.finishLeaseCleanupClaim(cancellation.cleanup!);
+        released =
+          managedLeaseProvider(cancellation.cleanup.lease) === "aws" &&
+          !cancellation.cleanup.lease.network?.awsPrivate
+            ? await this.withAWSIngressOperationLock(cleanup)
+            : await cleanup();
+      }
+    }
+    return json({
+      canceledCreate: {
+        version: 1,
+        requestedLeaseID,
+        createAttemptID: token,
+        state: "canceled",
+      },
+      ...(released ? { lease: publicLeaseRecord(released) } : {}),
+    });
+  }
+
   private async createLease(
     request: Request,
     reservationGuard?: () => Promise<Response | undefined>,
@@ -3004,6 +3312,7 @@ export class FleetCoordinator {
     const owner = requestOwner(request);
     const org = requestOrg(request, this.env);
     const input = await readJson<LeaseRequest>(request);
+    const ordinaryCreate = !fixedLeaseID && !workspaceID;
     if (fixedLeaseID) {
       if (!validLeaseID(fixedLeaseID)) {
         return json({ error: "invalid_lease_id" }, { status: 400 });
@@ -3013,6 +3322,26 @@ export class FleetCoordinator {
           { error: "lease_id_mismatch", message: "request leaseID must match the route" },
           { status: 400 },
         );
+      }
+      if (input.createAttemptID !== undefined) {
+        return json({ error: "create_attempt_not_allowed" }, { status: 400 });
+      }
+    }
+    if (ordinaryCreate && input.createAttemptID !== undefined && !validLeaseID(input.leaseID)) {
+      return json({ error: "invalid_lease_id" }, { status: 400 });
+    }
+    if (
+      ordinaryCreate &&
+      input.createAttemptID !== undefined &&
+      !validCreateAttemptID(input.createAttemptID)
+    ) {
+      return json({ error: "invalid_create_attempt_id" }, { status: 400 });
+    }
+    const leaseID = fixedLeaseID ?? (validLeaseID(input.leaseID) ? input.leaseID : newLeaseID());
+    if (ordinaryCreate && input.createAttemptID !== undefined) {
+      const replay = await this.replayCreateAttempt(leaseID, input.createAttemptID, owner, org);
+      if (replay) {
+        return replay;
       }
     }
     const defaults: LeaseConfigDefaults = { allowAzurePromotedImage: true };
@@ -3084,8 +3413,8 @@ export class FleetCoordinator {
         normalizeLeaseSlug(input.slug ?? input.requestedSlug),
       );
       const replay = await this.state.runExclusive(async () => {
-        if (await this.getLeaseRequestBinding(fixedLeaseID)) {
-          return leaseRequestIDConflictResponse();
+        if (createAttemptBlocksLeaseID(await this.getCreateAttempt(fixedLeaseID))) {
+          return createAttemptIDConflictResponse();
         }
         return this.fixedLeaseReplayResponse(
           await this.getLease(fixedLeaseID),
@@ -3176,7 +3505,6 @@ export class FleetCoordinator {
     if (retainedMacHostLease) {
       config = { ...config, providerKey: retainedMacHostLease.providerKey };
     }
-    const leaseID = fixedLeaseID ?? (validLeaseID(input.leaseID) ? input.leaseID : newLeaseID());
     const canonicalProviderKey = providerKeyForLease(leaseID);
     const providerKeyLeaseID = leaseIDForProviderKey(config.providerKey);
     if (!retainedMacHostLease && providerKeyLeaseID && providerKeyLeaseID !== leaseID) {
@@ -3221,6 +3549,17 @@ export class FleetCoordinator {
         { status: 424 },
       );
     }
+    let createAttempt: CreateAttemptRecord | undefined;
+    if (ordinaryCreate && input.createAttemptID !== undefined) {
+      const reserved = await this.reserveCreateAttempt(leaseID, input.createAttemptID, owner, org);
+      if (reserved instanceof Response) {
+        return reserved;
+      }
+      createAttempt = reserved.attempt;
+      if (reserved.replayLease) {
+        return createAttemptReplayResponse(reserved.replayLease);
+      }
+    }
     try {
       config = (await configProvider.prepareLeaseConfig?.(config)) ?? config;
     } catch (error) {
@@ -3231,6 +3570,12 @@ export class FleetCoordinator {
         );
       }
       throw error;
+    }
+    if (
+      createAttempt &&
+      !(await this.pendingCreateAttempt(leaseID, createAttempt.token, owner, org))
+    ) {
+      return createCanceledResponse();
     }
     const provider = this.provider(
       config.provider,
@@ -3244,6 +3589,12 @@ export class FleetCoordinator {
     const providerHourlyUSD = await provider
       .hourlyPriceUSD(config.serverType, config)
       .catch(() => undefined);
+    if (
+      createAttempt &&
+      !(await this.pendingCreateAttempt(leaseID, createAttempt.token, owner, org))
+    ) {
+      return createCanceledResponse();
+    }
     const cost = leaseCost(
       this.env,
       config.provider,
@@ -3253,6 +3604,23 @@ export class FleetCoordinator {
     );
     if (!workspaceID && retainedMacHostLease) {
       const reactivation = await this.state.runExclusive(async () => {
+        const reservedAttempt = await this.getCreateAttempt(leaseID);
+        const currentAttempt = createAttempt
+          ? await this.pendingCreateAttempt(leaseID, createAttempt.token, owner, org)
+          : undefined;
+        if (currentAttempt?.canonicalLeaseID) {
+          const replayLease = await this.getLease(currentAttempt.canonicalLeaseID);
+          if (!replayLease || !createAttemptMatchesLease(currentAttempt, replayLease)) {
+            return createAttemptBindingConflictResponse();
+          }
+          return createAttemptReplayResponse(replayLease);
+        }
+        if (createAttempt && !currentAttempt) {
+          return createCanceledResponse();
+        }
+        if (!createAttempt && reservedAttempt) {
+          return createAttemptIDConflictResponse();
+        }
         const current = await this.getLease(retainedMacHostLease.id);
         if (
           !current ||
@@ -3270,10 +3638,9 @@ export class FleetCoordinator {
         }
         if (
           (await this.getLease(leaseID)) ||
-          (await this.state.storage.get(workspaceLeaseReservationKey(leaseID))) ||
-          (await this.getLeaseRequestBinding(leaseID))
+          (await this.state.storage.get(workspaceLeaseReservationKey(leaseID)))
         ) {
-          return leaseRequestIDConflictResponse();
+          return createAttemptIDConflictResponse();
         }
         const blocked = await reservationGuard?.();
         if (blocked) {
@@ -3281,20 +3648,24 @@ export class FleetCoordinator {
         }
         const now = new Date();
         const admission = await this.leaseAdmissionState({ owner, org }, now, current.id);
-        const requestLeaseGeneration = newLeaseRequestGeneration();
-        const binding: LeaseRequestBinding = {
-          version: 1,
-          requestLeaseID: leaseID,
-          leaseID: current.id,
-          owner,
-          org,
-          cloudID: current.cloudID,
-          generation: requestLeaseGeneration,
-          createdAt: now.toISOString(),
-        };
+        const createAttemptGeneration = newCreateAttemptGeneration();
+        const boundAttempt: CreateAttemptRecord | undefined = currentAttempt
+          ? {
+              ...currentAttempt,
+              canonicalLeaseID: current.id,
+              cloudID: current.cloudID,
+              generation: createAttemptGeneration!,
+              updatedAt: now.toISOString(),
+            }
+          : undefined;
         let reactivated: LeaseRecord = {
           ...current,
-          requestLeaseGeneration,
+          createAttemptGeneration,
+          ...(boundAttempt
+            ? {
+                createAttemptID: boundAttempt.token,
+              }
+            : {}),
           profile: config.profile,
           class: config.class,
           requestedServerType: config.serverType,
@@ -3303,7 +3674,7 @@ export class FleetCoordinator {
           idleTimeoutSeconds: config.idleTimeoutSeconds,
           estimatedHourlyUSD: cost.hourlyUSD,
           maxEstimatedUSD: cost.maxUSD,
-          state: "active",
+          state: "provisioning",
           createdAt: now.toISOString(),
           updatedAt: now.toISOString(),
           lastTouchedAt: now.toISOString(),
@@ -3314,6 +3685,9 @@ export class FleetCoordinator {
             config.idleTimeoutSeconds,
           ).toISOString(),
         };
+        if (!boundAttempt) {
+          delete reactivated.createAttemptID;
+        }
         const sourceCIDRs = awsLeaseSSHSourceCIDRs(
           config,
           providerAccessContext(requestSourceCIDRs(request), admission.accessLeases),
@@ -3342,6 +3716,7 @@ export class FleetCoordinator {
         delete reactivated.failureError;
         delete reactivated.provisioningRequestStartedAt;
         delete reactivated.provisioningCoordinatorVersion;
+        delete reactivated.provisioningRequestSettledAt;
         delete reactivated.provisioningRecoveryObservedAt;
         delete reactivated.provisioningRecoveryMissingSince;
         clearLeaseCleanupMetadata(reactivated);
@@ -3353,11 +3728,18 @@ export class FleetCoordinator {
         if (limitError) {
           return json({ error: "cost_limit_exceeded", message: limitError }, { status: 429 });
         }
-        await this.putLeaseRequestBinding(binding);
+        if (boundAttempt) {
+          await this.putCreateAttempt(boundAttempt);
+        }
         await this.putLease(reactivated);
         await this.markAWSIngressReconcilePending(reactivated);
         await this.scheduleAlarm();
-        return { previous: structuredClone(current), reactivated };
+        return {
+          previous: structuredClone(current),
+          previousAttempt: currentAttempt ? structuredClone(currentAttempt) : undefined,
+          boundAttempt: boundAttempt ? structuredClone(boundAttempt) : undefined,
+          reactivated,
+        };
       });
       if (reactivation instanceof Response) {
         return reactivation;
@@ -3377,16 +3759,65 @@ export class FleetCoordinator {
           await this.state.runExclusive(async () => {
             const current = await this.getLease(reactivation.reactivated.id);
             if (
-              current?.state === "active" &&
-              current.updatedAt === reactivation.reactivated.updatedAt
+              current?.state === "provisioning" &&
+              sameLeaseReleaseIdentity(current, reactivation.reactivated)
             ) {
               await this.putLease(reactivation.previous);
+              if (reactivation.boundAttempt) {
+                const currentAttempt = await this.getCreateAttempt(
+                  reactivation.boundAttempt.requestedLeaseID,
+                );
+                if (
+                  currentAttempt &&
+                  sameCreateAttempt(currentAttempt, reactivation.boundAttempt)
+                ) {
+                  if (reactivation.previousAttempt) {
+                    await this.putCreateAttempt(reactivation.previousAttempt);
+                  } else {
+                    await this.state.storage.delete(
+                      createAttemptKey(reactivation.boundAttempt.requestedLeaseID),
+                    );
+                  }
+                }
+              }
               await this.scheduleAlarm();
             }
           });
           throw error;
         }
-        return json({ lease: publicLeaseRecord(reactivation.reactivated) }, { status: 201 });
+        const activation = await this.state.runExclusive(async () => {
+          const current = await this.getLease(reactivation.reactivated.id);
+          const pending = createAttempt
+            ? await this.pendingCreateAttempt(leaseID, createAttempt.token, owner, org)
+            : undefined;
+          if (
+            !current ||
+            current.state !== "provisioning" ||
+            !sameLeaseReleaseIdentity(current, reactivation.reactivated) ||
+            (createAttempt && (!pending || !createAttemptMatchesLease(pending, current)))
+          ) {
+            return { committed: false as const, current, pending };
+          }
+          current.state = "active";
+          current.updatedAt = new Date().toISOString();
+          await this.putLease(current);
+          await this.scheduleAlarm();
+          return { committed: true as const, current };
+        });
+        if (!activation.committed) {
+          if (createAttempt && !activation.pending) {
+            return createCanceledResponse();
+          }
+          return json(
+            {
+              error: "lease_state_changed",
+              message: "retained lease changed state while access reconciliation was in progress",
+              lease: activation.current ? publicLeaseRecord(activation.current) : undefined,
+            },
+            { status: 409 },
+          );
+        }
+        return json({ lease: publicLeaseRecord(activation.current) }, { status: 201 });
       }
       return json(
         {
@@ -3397,6 +3828,20 @@ export class FleetCoordinator {
       );
     }
     const reservation = await this.state.runExclusive(async () => {
+      const reservedAttempt = await this.getCreateAttempt(leaseID);
+      const currentAttempt = createAttempt
+        ? await this.pendingCreateAttempt(leaseID, createAttempt.token, owner, org)
+        : undefined;
+      if (createAttempt && !currentAttempt) {
+        return createCanceledResponse();
+      }
+      if (
+        !createAttempt &&
+        reservedAttempt &&
+        (ordinaryCreate || createAttemptBlocksLeaseID(reservedAttempt))
+      ) {
+        return createAttemptIDConflictResponse();
+      }
       const blocked = await reservationGuard?.();
       if (blocked) {
         return blocked;
@@ -3404,12 +3849,16 @@ export class FleetCoordinator {
       if (!workspaceID && (await this.state.storage.get(workspaceLeaseReservationKey(leaseID)))) {
         return workspaceManagedLeaseResponse();
       }
-      if (await this.getLeaseRequestBinding(leaseID)) {
-        return leaseRequestIDConflictResponse();
-      }
       const existingLease = await this.getLease(leaseID);
       if (existingLease && fixedLeaseID) {
         return this.fixedLeaseReplayResponse(existingLease, owner, org, fixedCreateIntentHash!)!;
+      }
+      if (
+        existingLease &&
+        currentAttempt &&
+        createAttemptMatchesLease(currentAttempt, existingLease)
+      ) {
+        return createAttemptReplayResponse(existingLease);
       }
       if (existingLease) {
         return json(
@@ -3418,6 +3867,7 @@ export class FleetCoordinator {
         );
       }
       const now = new Date();
+      const createAttemptGeneration = currentAttempt ? newCreateAttemptGeneration() : undefined;
       const admission = await this.leaseAdmissionState({ owner, org }, now);
       const slug = allocateLeaseSlug(
         normalizeLeaseSlug(input.slug ?? input.requestedSlug) || leaseSlugFromID(leaseID),
@@ -3433,6 +3883,12 @@ export class FleetCoordinator {
       let record: LeaseRecord = {
         id: leaseID,
         slug,
+        ...(currentAttempt
+          ? {
+              createAttemptID: currentAttempt.token,
+              createAttemptGeneration: createAttemptGeneration!,
+            }
+          : {}),
         ...(fixedCreateIntentHash
           ? {
               fixedCreateIntentVersion: fixedLeaseCreateIntentVersion,
@@ -3508,6 +3964,14 @@ export class FleetCoordinator {
       if (limitError) {
         return json({ error: "cost_limit_exceeded", message: limitError }, { status: 429 });
       }
+      if (currentAttempt) {
+        await this.putCreateAttempt({
+          ...currentAttempt,
+          canonicalLeaseID: leaseID,
+          generation: createAttemptGeneration!,
+          updatedAt: now.toISOString(),
+        });
+      }
       await this.putLease(record);
       await this.scheduleAlarm();
       return { record, slug };
@@ -3518,6 +3982,13 @@ export class FleetCoordinator {
     let { record } = reservation;
     const { slug } = reservation;
     const tailscaleError = await this.prepareTailscaleConfig(config, input, leaseID, slug);
+    if (
+      createAttempt &&
+      !(await this.pendingCreateAttempt(leaseID, createAttempt.token, owner, org))
+    ) {
+      await this.removeReleasedLeaseReservation(record);
+      return createCanceledResponse();
+    }
     if (tailscaleError) {
       await this.cancelLeaseReservation(record);
       await this.removeReleasedLeaseReservation(record);
@@ -3536,35 +4007,63 @@ export class FleetCoordinator {
           record: LeaseRecord;
         };
     try {
-      preparation = await this.state.runExclusive(async () => {
+      const preparationInput = await this.state.runExclusive(async () => {
         const latest = await this.getLease(record.id);
-        if (!latest || latest.state !== "provisioning") {
-          return { committed: false as const, current: latest };
+        const currentAttempt = createAttempt
+          ? await this.pendingCreateAttempt(leaseID, createAttempt.token, owner, org)
+          : undefined;
+        if (!latest || latest.state !== "provisioning" || (createAttempt && !currentAttempt)) {
+          return { ready: false as const, current: latest };
         }
         const accessLeases = await this.providerAccessLeaseRecords();
-        const accessContext = providerAccessContext(requestSourceCIDRs(request), accessLeases);
-        const prepared = await provider.prepareLeaseCreate?.(config, record, accessContext);
-        const preparedConfig = prepared?.config ?? config;
-        const preparedRecord = prepared?.lease ?? record;
-        const committedRecord = applyLeaseRecordChanges(latest, reservation.record, preparedRecord);
-        if (prepared?.provisioning?.publishAccessBeforeProvisioning) {
-          await this.putProviderAccess(providerAccessReservation(committedRecord, new Date()));
-        }
-        await this.putLease(committedRecord);
-        if (
-          committedRecord.provider === "aws" &&
-          prepared?.provisioning?.sshIngressReconcile === "additive"
-        ) {
-          await this.markAWSIngressReconcilePending(committedRecord);
-        }
-        await this.scheduleAlarm();
         return {
-          committed: true as const,
-          config: preparedConfig,
-          prepared,
-          record: committedRecord,
+          ready: true as const,
+          latest,
+          accessContext: providerAccessContext(requestSourceCIDRs(request), accessLeases),
         };
       });
+      if (!preparationInput.ready) {
+        preparation = { committed: false, current: preparationInput.current };
+      } else {
+        const prepared = await provider.prepareLeaseCreate?.(
+          config,
+          record,
+          preparationInput.accessContext,
+        );
+        const preparedConfig = prepared?.config ?? config;
+        const preparedRecord = prepared?.lease ?? record;
+        preparation = await this.state.runExclusive(async () => {
+          const latest = await this.getLease(record.id);
+          const currentAttempt = createAttempt
+            ? await this.pendingCreateAttempt(leaseID, createAttempt.token, owner, org)
+            : undefined;
+          if (!latest || latest.state !== "provisioning" || (createAttempt && !currentAttempt)) {
+            return { committed: false as const, current: latest };
+          }
+          const committedRecord = applyLeaseRecordChanges(
+            latest,
+            reservation.record,
+            preparedRecord,
+          );
+          if (prepared?.provisioning?.publishAccessBeforeProvisioning) {
+            await this.putProviderAccess(providerAccessReservation(committedRecord, new Date()));
+          }
+          await this.putLease(committedRecord);
+          if (
+            committedRecord.provider === "aws" &&
+            prepared?.provisioning?.sshIngressReconcile === "additive"
+          ) {
+            await this.markAWSIngressReconcilePending(committedRecord);
+          }
+          await this.scheduleAlarm();
+          return {
+            committed: true as const,
+            config: preparedConfig,
+            prepared,
+            record: committedRecord,
+          };
+        });
+      }
     } catch (error) {
       await this.cancelLeaseReservation(record);
       await this.removeReleasedLeaseReservation(record);
@@ -3572,6 +4071,12 @@ export class FleetCoordinator {
     }
     if (!preparation.committed) {
       const current = await this.removeReleasedLeaseReservation(record);
+      if (
+        createAttempt &&
+        !(await this.pendingCreateAttempt(leaseID, createAttempt.token, owner, org))
+      ) {
+        return createCanceledResponse();
+      }
       return json(
         {
           error: "lease_state_changed",
@@ -3590,13 +4095,35 @@ export class FleetCoordinator {
           ...prepared.provisioning,
           onTargetAttempt: async (target: ProviderProvisioningTarget) => {
             lastProvisioningTarget = { ...target };
+            if (
+              createAttempt &&
+              !(await this.pendingCreateAttempt(leaseID, createAttempt.token, owner, org))
+            ) {
+              throw new CreateAttemptCanceledError();
+            }
             await prepared.provisioning?.onTargetAttempt?.(target);
+            if (
+              createAttempt &&
+              !(await this.pendingCreateAttempt(leaseID, createAttempt.token, owner, org))
+            ) {
+              throw new CreateAttemptCanceledError();
+            }
             const region = target.region;
             if (!region) {
               return;
             }
             await this.state.runExclusive(async () => {
-              const current = (await this.getLease(record.id)) ?? record;
+              const current = await this.getLease(record.id);
+              const currentAttempt = createAttempt
+                ? await this.pendingCreateAttempt(leaseID, createAttempt.token, owner, org)
+                : undefined;
+              if (
+                !current ||
+                current.state !== "provisioning" ||
+                (createAttempt && !currentAttempt)
+              ) {
+                return;
+              }
               if (record.provider === "aws") {
                 await this.markAWSIngressReconcilePending({ ...current, region });
               } else {
@@ -3611,7 +4138,10 @@ export class FleetCoordinator {
       : undefined;
     const provisioningStart = await this.state.runExclusive(async () => {
       const current = await this.getLease(record.id);
-      if (!current || current.state !== "provisioning") {
+      const currentAttempt = createAttempt
+        ? await this.pendingCreateAttempt(leaseID, createAttempt.token, owner, org)
+        : undefined;
+      if (!current || current.state !== "provisioning" || (createAttempt && !currentAttempt)) {
         return { started: false as const, current };
       }
       if (current.workspaceID) {
@@ -3626,10 +4156,8 @@ export class FleetCoordinator {
         }
       }
       current.provisioningRequestStartedAt = new Date().toISOString();
-      const coordinatorVersion = this.env.CF_VERSION_METADATA?.id.trim();
-      if (coordinatorVersion) {
-        current.provisioningCoordinatorVersion = coordinatorVersion;
-      }
+      delete current.provisioningRequestSettledAt;
+      current.provisioningCoordinatorVersion = this.coordinatorGeneration;
       current.updatedAt = current.provisioningRequestStartedAt;
       await this.putLease(current);
       return { started: true as const, current };
@@ -3641,6 +4169,12 @@ export class FleetCoordinator {
             provisioningStart.current,
           )
         : await this.removeReleasedLeaseReservation(record);
+      if (
+        createAttempt &&
+        !(await this.pendingCreateAttempt(leaseID, createAttempt.token, owner, org))
+      ) {
+        return createCanceledResponse();
+      }
       return json(
         {
           error: "lease_state_changed",
@@ -3698,79 +4232,33 @@ export class FleetCoordinator {
             await this.deleteProviderAccess(record.id);
           }
           const current = await this.getLease(record.id);
-          if (!current || current.state !== "provisioning") {
-            if (cleanupClaim) {
-              const failedAt = new Date().toISOString();
-              record = structuredClone(current ?? record);
-              if (record.state !== "released" && record.state !== "expired") {
-                record.state = "failed";
-                record.endedAt = failedAt;
-              }
-              retainProvisioningCleanupClaim(
-                record,
-                cleanupClaim,
-                coordinatorErrorMessage(this.env, error),
-                failedAt,
-              );
-              await this.putLease(record);
-            }
+          const failedAt = new Date().toISOString();
+          if (
+            current &&
+            (current.createdAt !== record.createdAt ||
+              current.createAttemptID !== record.createAttemptID ||
+              current.createAttemptGeneration !== record.createAttemptGeneration)
+          ) {
+            record = structuredClone(current);
             await this.markAWSIngressReconcilePending(record);
             await this.scheduleAlarm();
             return;
           }
-          const failedAt = new Date().toISOString();
-          record = { ...current };
-          record.state = "failed";
-          record.updatedAt = failedAt;
-          record.endedAt = failedAt;
-          delete record.provisioningCoordinatorVersion;
-          delete record.provisioningRecoveryObservedAt;
-          delete record.provisioningRecoveryMissingSince;
-          record.cleanupFailedAt = failedAt;
-          record.cleanupError = coordinatorErrorMessage(this.env, error);
-          const awsOutcomeUncertain =
-            config.provider === "aws" &&
-            config.awsPrivate &&
-            isAWSRunInstancesOutcomeUncertain(record.cleanupError);
-          record.provisioningResourceMayExist = cleanupClaim
-            ? true
-            : awsOutcomeUncertain ||
-              (config.provider === "hetzner" && hetznerProvisioningFailureMayHaveResource(error));
-          record.provisioningFailureRetryable = cleanupClaim
-            ? false
-            : !awsOutcomeUncertain &&
-              config.provider === "hetzner" &&
-              hetznerProvisioningFailureRetryable(error);
-          if (cleanupClaim) {
-            retainProvisioningCleanupClaim(record, cleanupClaim, record.cleanupError, failedAt);
+          record = structuredClone(current ?? record);
+          if (!current || current.state === "provisioning") {
+            record.state = "failed";
+            record.endedAt = failedAt;
           }
-          const failedHetznerServerID =
-            config.provider === "hetzner" ? hetznerProvisioningResourceID(error) : undefined;
-          if (failedHetznerServerID !== undefined) {
-            record.cloudID = String(failedHetznerServerID);
-            record.serverID = failedHetznerServerID;
-            record.releaseDeletesServer = true;
-          }
-          if (
-            error instanceof HetznerProvisioningError &&
-            error.providerKeyCleanupID !== undefined
-          ) {
-            record.providerKeyCleanupPending = true;
-            record.providerKeyCleanupID = String(error.providerKeyCleanupID);
-          }
-          if (
-            cleanupClaim ||
-            failedHetznerServerID !== undefined ||
-            record.providerKeyCleanupPending
-          ) {
-            record.cleanupRetryAt = new Date(
-              Date.parse(failedAt) + leaseCleanupRetryDelayMs,
-            ).toISOString();
-          }
-          if (record.provisioningResourceMayExist || record.provisioningFailureRetryable) {
-            delete record.failureError;
-          } else {
-            record.failureError = record.cleanupError;
+          mergeProvisioningFailureMetadata(
+            record,
+            config,
+            error,
+            cleanupClaim,
+            coordinatorErrorMessage(this.env, error),
+            failedAt,
+          );
+          if (record.provisioningResourceMayExist && !record.cloudID) {
+            record.provisioningRequestSettledAt = failedAt;
           }
           await this.putLease(record);
           await this.markAWSIngressReconcilePending(record);
@@ -3779,7 +4267,10 @@ export class FleetCoordinator {
         throw error;
       });
     let current = await this.getLease(record.id);
-    if (!current || current.state !== "provisioning") {
+    const pendingAfterProvision = createAttempt
+      ? await this.pendingCreateAttempt(leaseID, createAttempt.token, owner, org)
+      : undefined;
+    if (!current || current.state !== "provisioning" || (createAttempt && !pendingAfterProvision)) {
       return this.abortProvisionedLeaseAfterStateChange(
         record,
         config,
@@ -3793,6 +4284,7 @@ export class FleetCoordinator {
     record.state = "active";
     delete record.provisioningRequestStartedAt;
     delete record.provisioningCoordinatorVersion;
+    delete record.provisioningRequestSettledAt;
     delete record.provisioningRecoveryObservedAt;
     delete record.provisioningRecoveryMissingSince;
     record.cloudID = server.cloudID;
@@ -3834,11 +4326,21 @@ export class FleetCoordinator {
     record.maxEstimatedUSD = finalCost.maxUSD;
     const finalization = await this.state.runExclusive(async () => {
       const latest = await this.getLease(record.id);
-      if (!latest || latest.state !== "provisioning") {
+      const currentAttempt = createAttempt
+        ? await this.pendingCreateAttempt(leaseID, createAttempt.token, owner, org)
+        : undefined;
+      if (!latest || latest.state !== "provisioning" || (createAttempt && !currentAttempt)) {
         return { committed: false as const, current: latest };
       }
       const committedRecord = applyLeaseRecordChanges(latest, finalizationBase, record);
       await this.putLease(committedRecord);
+      if (currentAttempt) {
+        await this.putCreateAttempt({
+          ...currentAttempt,
+          cloudID: committedRecord.cloudID,
+          updatedAt: new Date().toISOString(),
+        });
+      }
       if (prepared?.provisioning?.publishAccessBeforeProvisioning) {
         await this.deleteProviderAccess(committedRecord.id);
       }
@@ -4375,7 +4877,7 @@ export class FleetCoordinator {
     if (
       (await this.getLease(leaseID)) ||
       (await this.state.storage.get(workspaceLeaseReservationKey(leaseID))) ||
-      (await this.getLeaseRequestBinding(leaseID))
+      createAttemptBlocksLeaseID(await this.getCreateAttempt(leaseID))
     ) {
       return await this.allocateWorkspaceLeaseID();
     }
@@ -4864,6 +5366,7 @@ export class FleetCoordinator {
         delete current.provisioningFailureRetryable;
         delete current.provisioningRequestStartedAt;
         delete current.provisioningCoordinatorVersion;
+        delete current.provisioningRequestSettledAt;
         delete current.provisioningRecoveryObservedAt;
         delete current.provisioningRecoveryMissingSince;
         delete current.endedAt;
@@ -4935,6 +5438,7 @@ export class FleetCoordinator {
       current.provisioningFailureRetryable = true;
       delete current.provisioningRequestStartedAt;
       delete current.provisioningCoordinatorVersion;
+      delete current.provisioningRequestSettledAt;
       delete current.provisioningRecoveryObservedAt;
       delete current.provisioningRecoveryMissingSince;
       current.updatedAt = new Date().toISOString();
@@ -5908,6 +6412,7 @@ export class FleetCoordinator {
       current.provisioningFailureRetryable = false;
       delete current.provisioningRequestStartedAt;
       delete current.provisioningCoordinatorVersion;
+      delete current.provisioningRequestSettledAt;
       delete current.provisioningRecoveryObservedAt;
       delete current.provisioningRecoveryMissingSince;
       if (releaseRequested) {
@@ -6058,8 +6563,8 @@ export class FleetCoordinator {
     if (await this.state.storage.get(workspaceLeaseReservationKey(leaseID))) {
       return workspaceManagedLeaseResponse();
     }
-    if (await this.getLeaseRequestBinding(leaseID)) {
-      return leaseRequestIDConflictResponse();
+    if (createAttemptBlocksLeaseID(await this.getCreateAttempt(leaseID))) {
+      return createAttemptIDConflictResponse();
     }
     const existing = await this.getLease(leaseID);
     if (
@@ -6523,12 +7028,11 @@ export class FleetCoordinator {
   }
 
   private async releaseLease(request: Request, leaseID: string, admin: boolean): Promise<Response> {
-    const resolution = await this.resolveLeaseForRelease(leaseID, request, admin);
-    if (resolution instanceof Response) {
-      return resolution;
+    const lease = await this.resolveLease(leaseID, request, admin);
+    if (!lease) {
+      return notFound();
     }
-    const { lease, binding } = resolution;
-    if (!binding && !this.leaseManageableByRequest(lease, request, admin)) {
+    if (!this.leaseManageableByRequest(lease, request, admin)) {
       return json({ error: "forbidden", message: "lease manage access required" }, { status: 403 });
     }
     if (lease.workspaceID) {
@@ -6629,31 +7133,16 @@ export class FleetCoordinator {
           { status: 409 },
         );
       }
-      if (binding) {
-        const valid = await this.state.runExclusive(() =>
-          this.leaseRequestBindingMatchesCurrent(binding),
-        );
-        if (!valid) {
-          return leaseRequestBindingConflictResponse();
-        }
-      }
       await this.scheduleAlarm();
-      return json({
-        lease: this.leaseForRequest(lease, request, admin),
-        ...(binding ? { requestLeaseID: leaseID } : {}),
-      });
+      return json({ lease: this.leaseForRequest(lease, request, admin) });
     }
     let released: LeaseRecord;
     try {
       released = await this.releaseResolvedLease(lease, {
         deleteServer: shouldDelete,
         expectedLease: lease,
-        ...(binding ? { requestBinding: binding } : {}),
       });
     } catch (error) {
-      if (error instanceof LeaseRequestBindingConflictError) {
-        return leaseRequestBindingConflictResponse();
-      }
       if (error instanceof LeaseReleaseResolutionConflictError) {
         return json(
           {
@@ -6678,66 +7167,7 @@ export class FleetCoordinator {
         { status: 409 },
       );
     }
-    return json({
-      lease: this.leaseForRequest(released, request, admin),
-      ...(binding ? { requestLeaseID: leaseID } : {}),
-    });
-  }
-
-  private async resolveLeaseForRelease(
-    identifier: string,
-    request: Request,
-    admin: boolean,
-  ): Promise<{ lease: LeaseRecord; binding?: LeaseRequestBinding } | Response> {
-    const exact = await this.getLease(identifier);
-    if (exact) {
-      if (await this.getLeaseRequestBinding(identifier)) {
-        return leaseRequestBindingConflictResponse();
-      }
-      return this.leaseVisibleToRequest(exact, request, admin) ? { lease: exact } : notFound();
-    }
-    return await this.state.runExclusive(async () => {
-      const lockedExact = await this.getLease(identifier);
-      const binding = await this.getLeaseRequestBinding(identifier);
-      if (lockedExact && binding) {
-        return leaseRequestBindingConflictResponse();
-      }
-      if (lockedExact) {
-        return this.leaseVisibleToRequest(lockedExact, request, admin)
-          ? { lease: lockedExact }
-          : notFound();
-      }
-      if (!binding) {
-        const lease = await this.resolveLease(identifier, request, admin);
-        return lease ? { lease } : notFound();
-      }
-      if (
-        !admin &&
-        (binding.owner !== requestOwner(request) || binding.org !== requestOrg(request, this.env))
-      ) {
-        return notFound();
-      }
-      const lease = await this.getLease(binding.leaseID);
-      if (!lease || !leaseRequestBindingMatchesLease(binding, lease)) {
-        return leaseRequestBindingConflictResponse();
-      }
-      return { lease, binding };
-    });
-  }
-
-  private async leaseRequestBindingMatchesCurrent(binding: LeaseRequestBinding): Promise<boolean> {
-    const [exact, stored, lease] = await Promise.all([
-      this.getLease(binding.requestLeaseID),
-      this.getLeaseRequestBinding(binding.requestLeaseID),
-      this.getLease(binding.leaseID),
-    ]);
-    return Boolean(
-      !exact &&
-      stored &&
-      sameLeaseRequestBinding(stored, binding) &&
-      lease &&
-      leaseRequestBindingMatchesLease(binding, lease),
-    );
+    return json({ lease: this.leaseForRequest(released, request, admin) });
   }
 
   private async completeRuntimeAdapterDelete(
@@ -7763,7 +8193,22 @@ export class FleetCoordinator {
         response.status,
       );
     }
-    await this.releaseResolvedLease(lease, { deleteServer: true, keep: false });
+    try {
+      await this.releaseResolvedLease(lease, {
+        deleteServer: true,
+        keep: false,
+        ...(lease.workspaceID ? {} : { expectedLease: lease }),
+      });
+    } catch (error) {
+      if (error instanceof LeaseReleaseResolutionConflictError) {
+        return portalError(
+          "Stop unavailable",
+          "The lease changed after release authorization. Refresh and try again.",
+          409,
+        );
+      }
+      throw error;
+    }
     return new Response(null, {
       status: 303,
       headers: { location: portalReturnLocation(request) },
@@ -13293,7 +13738,11 @@ export class FleetCoordinator {
         if (due.length >= interruptedProvisioningRecoveryBatchSize) {
           return;
         }
-        const recoveryAt = interruptedProvisioningRecoveryAt(lease, this.env, now);
+        const recoveryAt = interruptedProvisioningRecoveryAt(
+          lease,
+          this.coordinatorGeneration,
+          now,
+        );
         if (recoveryAt === undefined) {
           return;
         }
@@ -13356,10 +13805,11 @@ export class FleetCoordinator {
       const interruption = "coordinator deployment interrupted provider provisioning";
       current.updatedAt = failedAt;
       if (server) {
-        current.state = "failed";
+        current.state = lease.state === "released" ? "released" : "failed";
         current.endedAt = failedAt;
         delete current.provisioningRequestStartedAt;
         delete current.provisioningCoordinatorVersion;
+        delete current.provisioningRequestSettledAt;
         delete current.provisioningRecoveryObservedAt;
         delete current.provisioningRecoveryMissingSince;
         applyRecoveredServerIdentity(current, server);
@@ -13389,14 +13839,19 @@ export class FleetCoordinator {
             failedAtDate.getTime() + leaseCleanupRetryDelayMs,
           ).toISOString();
           delete current.failureError;
-          delete current.releaseDeletesServer;
+          if (lease.state === "released") {
+            current.releaseDeletesServer = true;
+          } else {
+            delete current.releaseDeletesServer;
+          }
           await this.putLease(current);
           return;
         }
-        current.state = "failed";
+        current.state = lease.state === "released" ? "released" : "failed";
         current.endedAt = failedAt;
         delete current.provisioningRequestStartedAt;
         delete current.provisioningCoordinatorVersion;
+        delete current.provisioningRequestSettledAt;
         delete current.provisioningRecoveryObservedAt;
         delete current.provisioningRecoveryMissingSince;
         current.cloudID = "";
@@ -13468,6 +13923,7 @@ export class FleetCoordinator {
           lease.updatedAt = nowISO;
           lease.endedAt = nowISO;
           delete lease.provisioningCoordinatorVersion;
+          delete lease.provisioningRequestSettledAt;
           delete lease.provisioningRecoveryObservedAt;
           delete lease.provisioningRecoveryMissingSince;
           lease.cleanupFailedAt = nowISO;
@@ -13627,9 +14083,10 @@ export class FleetCoordinator {
       if (
         leaseIsLive(lease) ||
         lease.runtimeAdapterDeleteRequestedAt ||
-        leaseNeedsCleanup(lease, now)
+        leaseNeedsCleanup(lease, now) ||
+        leaseMayNeedInterruptedProvisioningRecovery(lease)
       ) {
-        retainAlarm(nextLeaseAlarmTime(lease, this.env));
+        retainAlarm(nextLeaseAlarmTime(lease, this.coordinatorGeneration));
       }
     });
     for (const handoffAlarm of await this.webVNCCredentialHandoffs.alarmTimes(now)) {
@@ -14472,14 +14929,30 @@ export class FleetCoordinator {
     return this.state.storage.get<LeaseRecord>(leaseKey(leaseID), options);
   }
 
-  private async getLeaseRequestBinding(
-    requestLeaseID: string,
-  ): Promise<LeaseRequestBinding | undefined> {
-    return this.state.storage.get<LeaseRequestBinding>(leaseRequestBindingKey(requestLeaseID));
+  private async getCreateAttempt(
+    requestedLeaseID: string,
+  ): Promise<CreateAttemptRecord | undefined> {
+    return this.state.storage.get<CreateAttemptRecord>(createAttemptKey(requestedLeaseID));
   }
 
-  private async putLeaseRequestBinding(binding: LeaseRequestBinding): Promise<void> {
-    await this.state.storage.put(leaseRequestBindingKey(binding.requestLeaseID), binding);
+  private async putCreateAttempt(attempt: CreateAttemptRecord): Promise<void> {
+    await this.state.storage.put(createAttemptKey(attempt.requestedLeaseID), attempt);
+  }
+
+  private async getArchivedCanceledCreateAttempt(
+    requestedLeaseID: string,
+    token: string,
+  ): Promise<CreateAttemptRecord | undefined> {
+    return this.state.storage.get<CreateAttemptRecord>(
+      archivedCanceledCreateAttemptKey(requestedLeaseID, token),
+    );
+  }
+
+  private async archiveCanceledCreateAttempt(attempt: CreateAttemptRecord): Promise<void> {
+    await this.state.storage.put(
+      archivedCanceledCreateAttemptKey(attempt.requestedLeaseID, attempt.token),
+      attempt,
+    );
   }
 
   private async resolveLease(
@@ -15316,8 +15789,33 @@ export class FleetCoordinator {
       }
       await this.deleteProviderAccess(reservation.id);
       await this.state.storage.delete(leaseKey(reservation.id));
+      await this.unbindPendingCreateAttemptReservation(current);
       await this.scheduleAlarm();
     });
+  }
+
+  private async unbindPendingCreateAttemptReservation(reservation: LeaseRecord): Promise<void> {
+    if (!reservation.createAttemptID || !reservation.createAttemptGeneration) {
+      return;
+    }
+    const attempt = await this.getCreateAttempt(reservation.id);
+    if (
+      !attempt ||
+      attempt.state !== "pending" ||
+      attempt.requestedLeaseID !== reservation.id ||
+      attempt.token !== reservation.createAttemptID ||
+      attempt.owner !== reservation.owner ||
+      attempt.org !== reservation.org ||
+      attempt.canonicalLeaseID !== reservation.id ||
+      attempt.generation !== reservation.createAttemptGeneration
+    ) {
+      return;
+    }
+    const unbound = { ...attempt, updatedAt: new Date().toISOString() };
+    delete unbound.canonicalLeaseID;
+    delete unbound.cloudID;
+    delete unbound.generation;
+    await this.putCreateAttempt(unbound);
   }
 
   private async removeReleasedLeaseReservation(
@@ -15619,22 +16117,33 @@ export class FleetCoordinator {
     options: {
       deleteServer: boolean;
       keep?: boolean;
-      requestBinding?: LeaseRequestBinding;
+      expectedCreateAttempt?: CreateAttemptRecord;
       expectedLease?: LeaseRecord;
     },
   ): Promise<LeaseRecord> {
     const current = (await this.getLease(lease.id)) ?? lease;
+    if (
+      options.expectedCreateAttempt &&
+      !createAttemptMatchesLease(options.expectedCreateAttempt, current)
+    ) {
+      throw new CreateAttemptConflictError();
+    }
     if (
       options.expectedLease &&
       (!sameLeaseReleaseIdentity(current, options.expectedLease) || current.workspaceID)
     ) {
       throw new LeaseReleaseResolutionConflictError();
     }
-    if (current.runtimeAdapterDeleteRequestedAt && !options.expectedLease) {
+    if (
+      current.runtimeAdapterDeleteRequestedAt &&
+      !options.expectedCreateAttempt &&
+      !options.expectedLease
+    ) {
       return current;
     }
     await this.markWorkspaceReleaseRequested(current);
     if (
+      !options.expectedCreateAttempt &&
       !options.expectedLease &&
       current.workspaceID &&
       !current.cloudID &&
@@ -15678,18 +16187,25 @@ export class FleetCoordinator {
     options: {
       deleteServer: boolean;
       keep?: boolean;
-      requestBinding?: LeaseRequestBinding;
+      expectedCreateAttempt?: CreateAttemptRecord;
       expectedLease?: LeaseRecord;
     },
   ): Promise<LeaseRecord> {
     const preparation = await this.state.runExclusive(async () => {
-      if (
-        options.requestBinding &&
-        !(await this.leaseRequestBindingMatchesCurrent(options.requestBinding))
-      ) {
-        throw new LeaseRequestBindingConflictError();
-      }
       const stored = await this.getLease(lease.id);
+      if (options.expectedCreateAttempt) {
+        const currentAttempt = await this.getCreateAttempt(
+          options.expectedCreateAttempt.requestedLeaseID,
+        );
+        if (
+          !stored ||
+          !currentAttempt ||
+          !sameCreateAttempt(currentAttempt, options.expectedCreateAttempt) ||
+          !createAttemptMatchesLease(currentAttempt, stored)
+        ) {
+          throw new CreateAttemptConflictError();
+        }
+      }
       if (
         options.expectedLease &&
         (!stored || !sameLeaseReleaseIdentity(stored, options.expectedLease))
@@ -15744,6 +16260,18 @@ export class FleetCoordinator {
     if (!preparation.cleanup) {
       return preparation.lease;
     }
+    return await this.finishLeaseCleanupClaim({
+      lease: preparation.lease,
+      claim: preparation.claim,
+      ...(options.keep === undefined ? {} : { keep: options.keep }),
+    });
+  }
+
+  private async finishLeaseCleanupClaim(preparation: {
+    lease: LeaseRecord;
+    claim: string;
+    keep?: boolean;
+  }): Promise<LeaseRecord> {
     try {
       await this.deleteLeaseServer(preparation.lease);
     } catch (error) {
@@ -15783,7 +16311,7 @@ export class FleetCoordinator {
       if (!current || current.cleanupStartedAt !== preparation.claim) {
         return current ?? preparation.lease;
       }
-      const released = finalizedReleasedLease(current, true, options.keep);
+      const released = finalizedReleasedLease(current, true, preparation.keep);
       delete released.providerKeyCleanupPending;
       delete released.providerKeyCleanupID;
       await this.putLease(released);
@@ -15802,9 +16330,10 @@ export class FleetDurableObject extends FleetCoordinator implements DurableObjec
     state: DurableObjectState,
     env: Env,
     testProviders: Partial<Record<Provider, CloudProvider>> = {},
+    coordinatorGeneration?: string,
   ) {
     const runtime = new CloudflareCoordinatorRuntime(state);
-    super(runtime, env, testProviders);
+    super(runtime, env, testProviders, {}, coordinatorGeneration);
     this.runtime = runtime;
   }
 
@@ -15829,20 +16358,25 @@ export class FleetDurableObject extends FleetCoordinator implements DurableObjec
   }
 }
 
-interface LeaseRequestBinding {
+interface CreateAttemptRecord {
   version: 1;
-  requestLeaseID: string;
-  leaseID: string;
+  requestedLeaseID: string;
+  token: string;
   owner: string;
   org: string;
-  cloudID: string;
-  generation: string;
+  state: "pending" | "canceled";
+  canonicalLeaseID?: string;
+  cloudID?: string;
+  generation?: string;
   createdAt: string;
+  updatedAt: string;
 }
 
-class LeaseRequestBindingConflictError extends Error {}
+class CreateAttemptConflictError extends Error {}
 
 class LeaseReleaseResolutionConflictError extends Error {}
+
+class CreateAttemptCanceledError extends Error {}
 
 interface ProviderReadiness {
   provider: Provider;
@@ -15948,8 +16482,12 @@ function leaseKey(leaseID: string): string {
   return `lease:${leaseID}`;
 }
 
-function leaseRequestBindingKey(requestLeaseID: string): string {
-  return `lease-request:${requestLeaseID}`;
+function createAttemptKey(requestedLeaseID: string): string {
+  return `create-attempt:${requestedLeaseID}`;
+}
+
+function archivedCanceledCreateAttemptKey(requestedLeaseID: string, token: string): string {
+  return `create-attempt-canceled:${requestedLeaseID}:${token}`;
 }
 
 function workspaceLeaseReservationKey(leaseID: string): string {
@@ -16763,7 +17301,7 @@ function newLeaseID(): string {
   return `cbx_${[...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("")}`;
 }
 
-function newLeaseRequestGeneration(): string {
+function newCreateAttemptGeneration(): string {
   return crypto.randomUUID();
 }
 
@@ -16789,7 +17327,7 @@ function workspaceManagedLeaseResponse(): Response {
   );
 }
 
-function leaseRequestIDConflictResponse(): Response {
+function createAttemptIDConflictResponse(): Response {
   return json(
     {
       error: "lease_id_conflict",
@@ -16799,11 +17337,45 @@ function leaseRequestIDConflictResponse(): Response {
   );
 }
 
-function leaseRequestBindingConflictResponse(): Response {
+function createAttemptConflictResponse(): Response {
   return json(
     {
-      error: "lease_request_binding_conflict",
-      message: "lease request binding does not match the current canonical lease generation",
+      error: "create_attempt_conflict",
+      message: "requested lease id is permanently bound to another create attempt",
+    },
+    { status: 409 },
+  );
+}
+
+function createCanceledResponse(): Response {
+  return json(
+    {
+      error: "create_canceled",
+      message: "create attempt was canceled before completion",
+    },
+    { status: 409 },
+  );
+}
+
+function createAttemptBindingConflictResponse(): Response {
+  return json(
+    {
+      error: "create_attempt_binding_conflict",
+      message: "create attempt does not match the current canonical lease generation",
+    },
+    { status: 409 },
+  );
+}
+
+function createAttemptReplayResponse(lease: LeaseRecord): Response {
+  if (leaseIsLive(lease)) {
+    return json({ lease: publicLeaseRecord(lease) }, { status: 200 });
+  }
+  return json(
+    {
+      error: "lease_state_changed",
+      message: "create attempt is already terminal",
+      lease: publicLeaseRecord(lease),
     },
     { status: 409 },
   );
@@ -16815,42 +17387,59 @@ function sameLeaseReleaseIdentity(left: LeaseRecord, right: LeaseRecord): boolea
     left.owner === right.owner &&
     left.org === right.org &&
     left.createdAt === right.createdAt &&
-    left.requestLeaseGeneration === right.requestLeaseGeneration
+    left.createAttemptGeneration === right.createAttemptGeneration &&
+    left.runtimeAdapterRegistrationID === right.runtimeAdapterRegistrationID
   );
 }
 
-function sameLeaseRequestBinding(left: LeaseRequestBinding, right: LeaseRequestBinding): boolean {
+function sameCreateAttempt(left: CreateAttemptRecord, right: CreateAttemptRecord): boolean {
   return (
     left.version === 1 &&
     right.version === 1 &&
-    left.requestLeaseID === right.requestLeaseID &&
-    left.leaseID === right.leaseID &&
+    left.requestedLeaseID === right.requestedLeaseID &&
+    left.token === right.token &&
     left.owner === right.owner &&
     left.org === right.org &&
+    left.state === right.state &&
+    left.canonicalLeaseID === right.canonicalLeaseID &&
     left.cloudID === right.cloudID &&
     left.generation === right.generation &&
-    left.createdAt === right.createdAt
+    left.createdAt === right.createdAt &&
+    left.updatedAt === right.updatedAt
   );
 }
 
-function leaseRequestBindingMatchesLease(
-  binding: LeaseRequestBinding,
-  lease: LeaseRecord,
-): boolean {
+function unboundCanceledCreateAttempt(
+  attempt: CreateAttemptRecord | undefined,
+  requestedLeaseID?: string,
+): attempt is CreateAttemptRecord {
+  return Boolean(
+    attempt?.version === 1 &&
+    attempt.state === "canceled" &&
+    !attempt.canonicalLeaseID &&
+    (requestedLeaseID === undefined || attempt.requestedLeaseID === requestedLeaseID),
+  );
+}
+
+function createAttemptBlocksLeaseID(attempt: CreateAttemptRecord | undefined): boolean {
+  return Boolean(attempt && !unboundCanceledCreateAttempt(attempt));
+}
+
+function createAttemptMatchesLease(attempt: CreateAttemptRecord, lease: LeaseRecord): boolean {
   return (
-    binding.version === 1 &&
-    validLeaseID(binding.requestLeaseID) &&
-    validLeaseID(binding.leaseID) &&
-    binding.requestLeaseID !== binding.leaseID &&
-    binding.leaseID === lease.id &&
-    binding.owner === lease.owner &&
-    binding.org === lease.org &&
-    Boolean(binding.cloudID) &&
-    binding.cloudID === lease.cloudID &&
-    Boolean(binding.generation) &&
-    binding.generation === lease.requestLeaseGeneration &&
-    lease.provider === "aws" &&
-    lease.target === "macos" &&
+    attempt.version === 1 &&
+    validLeaseID(attempt.requestedLeaseID) &&
+    validCreateAttemptID(attempt.token) &&
+    Boolean(attempt.canonicalLeaseID) &&
+    attempt.canonicalLeaseID === lease.id &&
+    attempt.owner === lease.owner &&
+    attempt.org === lease.org &&
+    attempt.token === lease.createAttemptID &&
+    Boolean(attempt.generation) &&
+    attempt.generation === lease.createAttemptGeneration &&
+    (attempt.cloudID === undefined || attempt.cloudID === lease.cloudID) &&
+    (attempt.requestedLeaseID === lease.id ||
+      (lease.provider === "aws" && lease.target === "macos")) &&
     !lease.workspaceID &&
     !isRegisteredLease(lease)
   );
@@ -18141,6 +18730,10 @@ export function shouldActivateEgressSession(
 
 function validLeaseID(value: string | undefined): value is string {
   return typeof value === "string" && /^cbx_[a-f0-9]{12}$/.test(value);
+}
+
+function validCreateAttemptID(value: string | undefined): value is string {
+  return typeof value === "string" && /^cat_[a-f0-9]{32}$/.test(value);
 }
 
 function validRegisteredLeaseID(value: string | undefined): value is string {
@@ -20493,6 +21086,94 @@ function provisionedLeaseRecord(
   };
 }
 
+function mergeProvisioningFailureMetadata(
+  lease: LeaseRecord,
+  config: LeaseConfig,
+  error: unknown,
+  cleanupClaim: ProviderProvisioningCleanupClaim | undefined,
+  message: string,
+  failedAt: string,
+): void {
+  const retainResource = lease.state === "released" && lease.releaseDeletesServer === false;
+  const awsOutcomeUncertain =
+    config.provider === "aws" && config.awsPrivate && isAWSRunInstancesOutcomeUncertain(message);
+  const hetznerResourceMayExist =
+    config.provider === "hetzner" && hetznerProvisioningFailureMayHaveResource(error);
+  const hetznerRetryable =
+    config.provider === "hetzner" && hetznerProvisioningFailureRetryable(error);
+  const failedHetznerServerID =
+    config.provider === "hetzner" ? hetznerProvisioningResourceID(error) : undefined;
+  const providerKeyCleanupID =
+    error instanceof HetznerProvisioningError ? error.providerKeyCleanupID : undefined;
+  const resourceMayExist = Boolean(
+    cleanupClaim ||
+    awsOutcomeUncertain ||
+    hetznerResourceMayExist ||
+    lease.provisioningResourceMayExist,
+  );
+
+  lease.updatedAt = failedAt;
+  lease.cleanupFailedAt = failedAt;
+  lease.cleanupError = message;
+  lease.provisioningResourceMayExist = resourceMayExist;
+  lease.provisioningFailureRetryable = Boolean(
+    !cleanupClaim &&
+    !awsOutcomeUncertain &&
+    (hetznerRetryable || lease.provisioningFailureRetryable),
+  );
+
+  if (resourceMayExist && lease.cleanupStartedAt) {
+    // An in-flight cleanup used an older snapshot. Invalidate it before publishing
+    // newly discovered provider identity so its completion cannot erase this evidence.
+    delete lease.cleanupStartedAt;
+    delete lease.cleanupClaimExpiresAt;
+  }
+  if (cleanupClaim) {
+    retainProvisioningCleanupClaim(lease, cleanupClaim, message, failedAt);
+  }
+  if (failedHetznerServerID !== undefined) {
+    lease.cloudID = String(failedHetznerServerID);
+    lease.serverID = failedHetznerServerID;
+    if (!retainResource) lease.releaseDeletesServer = true;
+  }
+  if (providerKeyCleanupID !== undefined) {
+    lease.providerKeyCleanupPending = true;
+    lease.providerKeyCleanupID = String(providerKeyCleanupID);
+    if (!retainResource) lease.releaseDeletesServer = true;
+  }
+  if (!resourceMayExist || lease.cloudID) {
+    delete lease.provisioningRequestStartedAt;
+    delete lease.provisioningCoordinatorVersion;
+    delete lease.provisioningRequestSettledAt;
+    delete lease.provisioningRecoveryObservedAt;
+    delete lease.provisioningRecoveryMissingSince;
+  }
+
+  if (retainResource) {
+    lease.keep = true;
+    lease.releaseDeletesServer = false;
+    clearLeaseCleanupMetadata(lease);
+    delete lease.cleanupStartedAt;
+    delete lease.cleanupClaimExpiresAt;
+    delete lease.provisioningResourceMayExist;
+    delete lease.provisioningFailureRetryable;
+    return;
+  }
+  if (
+    cleanupClaim ||
+    failedHetznerServerID !== undefined ||
+    providerKeyCleanupID !== undefined ||
+    (lease.cloudID && lease.releaseDeletesServer === true)
+  ) {
+    lease.cleanupRetryAt = new Date(Date.parse(failedAt) + leaseCleanupRetryDelayMs).toISOString();
+  }
+  if (lease.provisioningResourceMayExist || lease.provisioningFailureRetryable) {
+    delete lease.failureError;
+  } else {
+    lease.failureError = message;
+  }
+}
+
 function retainProvisioningCleanupClaim(
   lease: LeaseRecord,
   claim: ProviderProvisioningCleanupClaim,
@@ -20522,27 +21203,42 @@ function retainProvisioningCleanupClaim(
   lease.cleanupRetryAt = new Date(Date.parse(failedAt) + leaseCleanupRetryDelayMs).toISOString();
 }
 
+function leaseMayNeedInterruptedProvisioningRecovery(lease: LeaseRecord): boolean {
+  const canceledProvisioning =
+    lease.state === "released" &&
+    lease.releaseDeletesServer === true &&
+    Boolean(lease.createAttemptID);
+  const failedUncertainProvisioning =
+    lease.state === "failed" && lease.provisioningResourceMayExist === true;
+  return Boolean(
+    !lease.workspaceID &&
+    (lease.state === "provisioning" || canceledProvisioning || failedUncertainProvisioning) &&
+    !lease.cloudID &&
+    managedLeaseProvider(lease) &&
+    Number.isFinite(Date.parse(lease.provisioningRequestStartedAt ?? "")),
+  );
+}
+
 function interruptedProvisioningRecoveryAt(
   lease: LeaseRecord,
-  env: Pick<Env, "CF_VERSION_METADATA">,
+  coordinatorGeneration: string,
   now = Date.now(),
 ): number | undefined {
-  if (
-    lease.workspaceID ||
-    lease.state !== "provisioning" ||
-    lease.cloudID ||
-    !managedLeaseProvider(lease)
-  ) {
+  if (!leaseMayNeedInterruptedProvisioningRecovery(lease)) {
     return undefined;
   }
   const startedAt = Date.parse(lease.provisioningRequestStartedAt ?? "");
   if (!Number.isFinite(startedAt)) {
     return undefined;
   }
-  if (!interruptedProvisioningVersionMismatch(lease, env)) {
+  const settledAt = Date.parse(lease.provisioningRequestSettledAt ?? "");
+  if (
+    !Number.isFinite(settledAt) &&
+    !interruptedProvisioningVersionMismatch(lease, coordinatorGeneration)
+  ) {
     // Provider creates have no shared upper bound, so age alone cannot distinguish an
-    // abandoned request from live provisioning. Only a deployment version change proves
-    // this Durable Object no longer owns the in-flight create.
+    // abandoned request from live provisioning. A settled provider call or a runtime-
+    // generation change proves no current request still owns the create.
     return undefined;
   }
   const observedAt = Date.parse(lease.provisioningRecoveryObservedAt ?? "");
@@ -20555,13 +21251,12 @@ function interruptedProvisioningRecoveryAt(
 
 function interruptedProvisioningVersionMismatch(
   lease: LeaseRecord,
-  env: Pick<Env, "CF_VERSION_METADATA">,
+  coordinatorGeneration: string,
 ): boolean {
-  const currentVersion = env.CF_VERSION_METADATA?.id.trim();
   return Boolean(
-    currentVersion &&
+    coordinatorGeneration &&
     lease.provisioningCoordinatorVersion &&
-    lease.provisioningCoordinatorVersion !== currentVersion,
+    lease.provisioningCoordinatorVersion !== coordinatorGeneration,
   );
 }
 
@@ -20571,19 +21266,23 @@ function sameProvisioningAttempt(
 ): current is LeaseRecord {
   return Boolean(
     current &&
-    current.state === "provisioning" &&
+    current.state === expected.state &&
+    (current.state === "provisioning" ||
+      (current.state === "released" && current.releaseDeletesServer === true) ||
+      (current.state === "failed" && current.provisioningResourceMayExist === true)) &&
     !current.cloudID &&
     current.provisioningRequestStartedAt === expected.provisioningRequestStartedAt &&
+    current.provisioningRequestSettledAt === expected.provisioningRequestSettledAt &&
     current.provisioningCoordinatorVersion === expected.provisioningCoordinatorVersion &&
     current.provisioningRecoveryObservedAt === expected.provisioningRecoveryObservedAt &&
     current.provisioningRecoveryMissingSince === expected.provisioningRecoveryMissingSince,
   );
 }
 
-function nextLeaseAlarmTime(lease: LeaseRecord, env: Pick<Env, "CF_VERSION_METADATA">): number {
+function nextLeaseAlarmTime(lease: LeaseRecord, coordinatorGeneration: string): number {
   const now = Date.now();
   const expiresAt = Date.parse(lease.expiresAt);
-  const interruptedProvisioningAt = interruptedProvisioningRecoveryAt(lease, env);
+  const interruptedProvisioningAt = interruptedProvisioningRecoveryAt(lease, coordinatorGeneration);
   const includeInterruptedProvisioning = (candidate: number): number =>
     interruptedProvisioningAt === undefined
       ? candidate
@@ -20666,6 +21365,7 @@ function terminalizeManualProviderCleanup(
   delete lease.provisioningResourceMayExist;
   delete lease.provisioningFailureRetryable;
   delete lease.provisioningCoordinatorVersion;
+  delete lease.provisioningRequestSettledAt;
   delete lease.provisioningRecoveryObservedAt;
   delete lease.provisioningRecoveryMissingSince;
 }
@@ -20719,6 +21419,7 @@ function finalizedReleasedLease(
   lease.releasedAt = now;
   lease.endedAt = now;
   delete lease.provisioningCoordinatorVersion;
+  delete lease.provisioningRequestSettledAt;
   delete lease.provisioningRecoveryObservedAt;
   delete lease.provisioningRecoveryMissingSince;
   if (wasUnprovisionedRelease) {

--- a/worker/src/org-records.ts
+++ b/worker/src/org-records.ts
@@ -18,11 +18,13 @@ export function publicLeaseRecord(record: LeaseRecord): LeaseRecord {
     org: orgLabelForDisplay(record.org),
   };
   delete publicRecord.provisioningCoordinatorVersion;
+  delete publicRecord.provisioningRequestSettledAt;
   delete publicRecord.provisioningRecoveryObservedAt;
   delete publicRecord.provisioningRecoveryMissingSince;
   delete publicRecord.fixedCreateIntentVersion;
   delete publicRecord.fixedCreateIntentHash;
-  delete publicRecord.requestLeaseGeneration;
+  delete publicRecord.createAttemptID;
+  delete publicRecord.createAttemptGeneration;
   return publicRecord;
 }
 

--- a/worker/src/org-records.ts
+++ b/worker/src/org-records.ts
@@ -22,6 +22,7 @@ export function publicLeaseRecord(record: LeaseRecord): LeaseRecord {
   delete publicRecord.provisioningRecoveryMissingSince;
   delete publicRecord.fixedCreateIntentVersion;
   delete publicRecord.fixedCreateIntentHash;
+  delete publicRecord.requestLeaseGeneration;
   return publicRecord;
 }
 

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -392,6 +392,7 @@ export interface LeaseRecord {
   slug?: string;
   fixedCreateIntentVersion?: number;
   fixedCreateIntentHash?: string;
+  requestLeaseGeneration?: string;
   workspaceID?: string;
   provider: string;
   lifecycle?: LeaseLifecycle;

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -179,6 +179,7 @@ export interface Env {
 
 export interface LeaseRequest {
   leaseID?: string;
+  createAttemptID?: string;
   slug?: string;
   requestedSlug?: string;
   provider?: Provider;
@@ -392,7 +393,8 @@ export interface LeaseRecord {
   slug?: string;
   fixedCreateIntentVersion?: number;
   fixedCreateIntentHash?: string;
-  requestLeaseGeneration?: string;
+  createAttemptID?: string;
+  createAttemptGeneration?: string;
   workspaceID?: string;
   provider: string;
   lifecycle?: LeaseLifecycle;
@@ -473,6 +475,7 @@ export interface LeaseRecord {
   provisioningResourceMayExist?: boolean;
   provisioningFailureRetryable?: boolean;
   provisioningRequestStartedAt?: string;
+  provisioningRequestSettledAt?: string;
   provisioningCoordinatorVersion?: string;
   provisioningRecoveryObservedAt?: string;
   provisioningRecoveryMissingSince?: string;

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -107,6 +107,7 @@ class MemoryStorage {
   private readonly values = new Map<string, unknown>();
   private alarmTime: number | undefined;
   beforeGet?: (key: string) => Promise<void>;
+  beforePut?: (key: string, value: unknown) => Promise<void>;
 
   async get<T>(key: string, _options?: { noCache?: boolean }): Promise<T | undefined> {
     await this.beforeGet?.(key);
@@ -114,6 +115,7 @@ class MemoryStorage {
   }
 
   async put<T>(key: string, value: T, _options?: { noCache?: boolean }): Promise<void> {
+    await this.beforePut?.(key, value);
     this.values.set(key, value);
   }
 
@@ -15290,7 +15292,9 @@ describe("fleet lease identity and idle", () => {
       }),
     );
     expect(conflictingCreate.status).toBe(409);
-    await expect(conflictingCreate.json()).resolves.toMatchObject({ error: "lease_id_conflict" });
+    await expect(conflictingCreate.json()).resolves.toMatchObject({
+      error: "create_attempt_conflict",
+    });
     expect(storage.value<LeaseRecord>("lease:cbx_abcdef123456")).toMatchObject({
       owner: "alice@example.com",
       org: orgKeyForLabel("example-org"),
@@ -16096,9 +16100,13 @@ describe("fleet lease identity and idle", () => {
       lastTouchedAt: heartbeatLease.lastTouchedAt,
       expiresAt: heartbeatLease.expiresAt,
     });
-    expect(storage.value<LeaseRecord>("lease:cbx_abcdef123456")).toEqual(
-      currentOrgFixture(createdLease),
-    );
+    expect(createdLease.createAttemptID).toBeUndefined();
+    expect(createdLease.createAttemptGeneration).toBeUndefined();
+    expect(storage.value<LeaseRecord>("lease:cbx_abcdef123456")).toMatchObject({
+      ...currentOrgFixture(createdLease),
+      createAttemptID: expect.stringMatching(/^cat_[a-f0-9]{32}$/),
+      createAttemptGeneration: expect.any(String),
+    });
   });
 
   it("buffers Cloudflare heartbeat bodies before serializing state transitions", async () => {
@@ -18113,34 +18121,40 @@ describe("fleet lease identity and idle", () => {
     await expect(deletedHostReuse.json()).resolves.toMatchObject({ error: "admin_required" });
   });
 
-  it("releases a lost-response retained Mac reactivation only through its private requested-ID binding", async () => {
+  it("rolls back a retained Mac attempt binding when access reconciliation fails", async () => {
     const storage = new MemoryStorage();
-    const canonicalID = "cbx_000000000110";
-    const requestLeaseID = "cbx_abcdef123460";
-    const retained = testLease({
-      id: canonicalID,
-      provider: "aws",
-      target: "macos",
-      state: "released",
-      owner: "alice@example.com",
-      org: "example-org",
-      hostId: "h-alias-success",
-      serverType: "mac2.metal",
-      providerKey: "crabbox-retained-alias",
-      cloudID: "i-retained-alias",
-      releaseDeletesServer: false,
-    });
-    storage.seed(`lease:${canonicalID}`, retained);
-    const released: LeaseRecord[] = [];
+    const canonicalLeaseID = "cbx_ca1100000020";
+    const requestedLeaseID = "cbx_ca1100000021";
+    const createAttemptID = "cat_20000000000000000000000000000020";
+    storage.seed(
+      `lease:${canonicalLeaseID}`,
+      testLease({
+        id: canonicalLeaseID,
+        provider: "aws",
+        target: "macos",
+        state: "released",
+        owner: "alice@example.com",
+        org: "example-org",
+        hostId: "h-rollback",
+        serverType: "mac2.metal",
+        cloudID: "i-rollback",
+        providerKey: "crabbox-rollback",
+        releaseDeletesServer: false,
+        updatedAt: "2026-08-01T00:00:00.000Z",
+      }),
+    );
+    let reconciliations = 0;
+    let creates = 0;
     const fleet = testFleet(storage, {
       aws: fakeProvider(
         () => {
-          throw new Error("retained instance must not launch a replacement");
+          creates += 1;
         },
         {
           provider: "aws",
-          onReleaseLease: (lease) => {
-            released.push(structuredClone(lease));
+          onReconcileLeaseAccess() {
+            reconciliations += 1;
+            if (reconciliations === 1) throw new Error("temporary ingress failure");
           },
         },
       ),
@@ -18149,523 +18163,570 @@ describe("fleet lease identity and idle", () => {
       "x-crabbox-owner": "alice@example.com",
       "x-crabbox-org": "example-org",
     };
-    const created = await fleet.fetch(
-      request("POST", "/v1/leases", {
-        headers,
-        body: {
-          leaseID: requestLeaseID,
-          provider: "aws",
-          target: "macos",
-          hostId: "h-alias-success",
-          serverType: "mac2.metal",
-          capacity: { market: "on-demand" },
-          keep: true,
-          sshPublicKey: "ssh-ed25519 test",
-        },
-      }),
-    );
-    expect(created.status).toBe(201);
-    const createdBody = (await created.json()) as { lease: LeaseRecord };
-    expect(createdBody).toMatchObject({
-      lease: { id: canonicalID, cloudID: "i-retained-alias", state: "active" },
-    });
-    expect(createdBody.lease.requestLeaseGeneration).toBeUndefined();
-    const canonical = storage.value<LeaseRecord>(`lease:${canonicalID}`)!;
-    expect(canonical.requestLeaseGeneration).toMatch(/^[0-9a-f-]{36}$/);
-    expect(storage.value(`lease-request:${requestLeaseID}`)).toMatchObject({
-      version: 1,
-      requestLeaseID,
-      leaseID: canonicalID,
-      owner: "alice@example.com",
-      org: orgKeyForLabel("example-org"),
-      cloudID: "i-retained-alias",
-      generation: canonical.requestLeaseGeneration,
-    });
-
-    const getAlias = await fleet.fetch(request("GET", `/v1/leases/${requestLeaseID}`, { headers }));
-    expect(getAlias.status).toBe(404);
-    const heartbeatAlias = await fleet.fetch(
-      request("POST", `/v1/leases/${requestLeaseID}/heartbeat`, { headers }),
-    );
-    expect(heartbeatAlias.status).toBe(404);
-    const shareAlias = await fleet.fetch(
-      request("GET", `/v1/leases/${requestLeaseID}/share`, { headers }),
-    );
-    expect(shareAlias.status).toBe(404);
-    const runAlias = await fleet.fetch(
-      request("POST", "/v1/runs", {
-        headers,
-        body: { leaseID: requestLeaseID, command: ["true"] },
-      }),
-    );
-    expect(runAlias.status).toBe(201);
-    await expect(runAlias.json()).resolves.toMatchObject({
-      run: { leaseID: requestLeaseID, leaseOwners: [], provider: "hetzner" },
-    });
-
-    const release = await fleet.fetch(
-      request("POST", `/v1/leases/${requestLeaseID}/release`, {
-        headers,
-        body: { delete: true },
-      }),
-    );
-    expect(release.status).toBe(200);
-    const releaseBody = (await release.json()) as {
-      lease: LeaseRecord;
-      requestLeaseID: string;
+    const body = {
+      leaseID: requestedLeaseID,
+      createAttemptID,
+      provider: "aws" as const,
+      target: "macos" as const,
+      hostId: "h-rollback",
+      serverType: "mac2.metal",
+      capacity: { market: "on-demand" as const },
+      keep: true,
+      sshPublicKey: "ssh-ed25519 retained-rollback",
     };
-    expect(releaseBody).toMatchObject({
-      requestLeaseID,
-      lease: { id: canonicalID, cloudID: "i-retained-alias", state: "released" },
+
+    const failed = await fleet.fetch(request("POST", "/v1/leases", { headers, body }));
+    expect(failed.status).toBe(500);
+    expect(storage.value<LeaseRecord>(`lease:${canonicalLeaseID}`)).toMatchObject({
+      state: "released",
+      releaseDeletesServer: false,
+      cloudID: "i-rollback",
     });
-    expect(releaseBody.lease.requestLeaseGeneration).toBeUndefined();
-    expect(released).toHaveLength(1);
-    expect(released[0]).toMatchObject({ id: canonicalID, cloudID: "i-retained-alias" });
-    expect(storage.value(`lease-request:${requestLeaseID}`)).toBeDefined();
+    expect(storage.value(`create-attempt:${requestedLeaseID}`)).toMatchObject({
+      state: "pending",
+      token: createAttemptID,
+    });
+    expect(storage.value(`create-attempt:${requestedLeaseID}`)).not.toHaveProperty(
+      "canonicalLeaseID",
+    );
+
+    const retried = await fleet.fetch(request("POST", "/v1/leases", { headers, body }));
+    expect(retried.status).toBe(201);
+    await expect(retried.json()).resolves.toMatchObject({
+      lease: { id: canonicalLeaseID, state: "active", cloudID: "i-rollback" },
+    });
+    expect(reconciliations).toBe(2);
+    expect(creates).toBe(0);
   });
 
-  it("keeps retained request IDs permanently reserved across every lease allocator", async () => {
+  it("replays a retained Mac as provisioning until access reconciliation commits", async () => {
     const storage = new MemoryStorage();
-    const reservedID = "cbx_aaaaaaaaaaaa";
-    storage.seed(`lease-request:${reservedID}`, {
-      version: 1,
-      requestLeaseID: reservedID,
-      leaseID: "cbx_000000000111",
-      owner: "alice@example.com",
-      org: "example-org",
-      cloudID: "i-old-generation",
-      generation: "old-generation",
-      createdAt: "2026-08-01T00:00:00.000Z",
-    });
+    const canonicalLeaseID = "cbx_ca1100000032";
+    const requestedLeaseID = "cbx_ca1100000033";
+    const createAttemptID = "cat_32000000000000000000000000000032";
     storage.seed(
-      "lease:cbx_000000000112",
+      `lease:${canonicalLeaseID}`,
       testLease({
-        id: "cbx_000000000112",
+        id: canonicalLeaseID,
         provider: "aws",
         target: "macos",
         state: "released",
         owner: "alice@example.com",
         org: "example-org",
-        hostId: "h-reserved-alias",
+        hostId: "h-replay-reconcile",
         serverType: "mac2.metal",
+        cloudID: "i-replay-reconcile",
+        providerKey: "crabbox-replay-reconcile",
         releaseDeletesServer: false,
       }),
     );
-    const fleet = testFleet(
-      storage,
-      { aws: fakeProvider(undefined, { provider: "aws" }), hetzner: fakeProvider() },
-      { CRABBOX_WORKSPACE_SSH_PUBLIC_KEY: "ssh-ed25519 workspace-test" },
-    );
+    const bothPrepared = deferred<void>();
+    const finishPreparation = deferred<void>();
+    const reconciliationStarted = deferred<void>();
+    const finishReconciliation = deferred<void>();
+    let preparations = 0;
+    const fleet = testFleet(storage, {
+      aws: fakeProvider(undefined, {
+        provider: "aws",
+        async onPrepareLeaseConfig(config) {
+          preparations += 1;
+          if (preparations === 2) bothPrepared.resolve();
+          await finishPreparation.promise;
+          return config;
+        },
+        async onReconcileLeaseAccess() {
+          reconciliationStarted.resolve();
+          await finishReconciliation.promise;
+        },
+      }),
+    });
     const headers = {
       "x-crabbox-owner": "alice@example.com",
       "x-crabbox-org": "example-org",
     };
-    const ordinary = await fleet.fetch(
-      request("POST", "/v1/leases", {
-        headers,
-        body: {
-          leaseID: reservedID,
-          provider: "hetzner",
-          sshPublicKey: "ssh-ed25519 ordinary",
-        },
-      }),
-    );
-    expect(ordinary.status).toBe(409);
-    const fixed = await fleet.fetch(
-      request("PUT", `/v1/leases/${reservedID}`, {
-        headers,
-        body: { provider: "hetzner", sshPublicKey: "ssh-ed25519 fixed" },
-      }),
-    );
-    expect(fixed.status).toBe(409);
-    const registered = await fleet.fetch(
-      request("PUT", `/v1/leases/${reservedID}/registration`, {
-        headers,
-        body: { provider: "external", target: "linux", host: "host.example.test" },
-      }),
-    );
-    expect(registered.status).toBe(409);
-    const retained = await fleet.fetch(
-      request("POST", "/v1/leases", {
-        headers,
-        body: {
-          leaseID: reservedID,
-          provider: "aws",
-          target: "macos",
-          hostId: "h-reserved-alias",
-          serverType: "mac2.metal",
-          capacity: { market: "on-demand" },
-          keep: true,
-          sshPublicKey: "ssh-ed25519 retained",
-        },
-      }),
-    );
-    expect(retained.status).toBe(409);
-    await Promise.all(
-      [ordinary, fixed, registered, retained].map(async (response) => {
-        await expect(response.json()).resolves.toMatchObject({ error: "lease_id_conflict" });
-      }),
-    );
+    const body = {
+      leaseID: requestedLeaseID,
+      createAttemptID,
+      provider: "aws" as const,
+      target: "macos" as const,
+      hostId: "h-replay-reconcile",
+      serverType: "mac2.metal",
+      capacity: { market: "on-demand" as const },
+      keep: true,
+      sshPublicKey: "ssh-ed25519 retained-replay",
+    };
 
-    let allocations = 0;
-    const random = vi.spyOn(crypto, "getRandomValues").mockImplementation((array) => {
-      (array as Uint8Array).fill(allocations++ === 0 ? 0xaa : 0xbb);
-      return array;
+    const first = fleet.fetch(request("POST", "/v1/leases", { headers, body }));
+    const second = fleet.fetch(request("POST", "/v1/leases", { headers, body }));
+    await bothPrepared.promise;
+    finishPreparation.resolve();
+    await reconciliationStarted.promise;
+
+    const inFlightReplay = await Promise.race([first, second]);
+    expect(inFlightReplay.status).toBe(200);
+    await expect(inFlightReplay.json()).resolves.toMatchObject({
+      lease: { id: canonicalLeaseID, state: "provisioning" },
     });
-    const workspace = await fleet.fetch(
-      request("POST", "/v1/workspaces", {
-        headers,
-        body: {
-          id: "reserved-alias-workspace",
-          runtime: "crabbox",
-          ttlSeconds: 1800,
-          idleTimeoutSeconds: 360,
-          capabilities: { desktop: false },
-        },
-      }),
-    );
-    random.mockRestore();
-    expect(workspace.status).toBe(202);
-    await expect(workspace.json()).resolves.toMatchObject({
-      providerResourceId: "cbx_bbbbbbbbbbbb",
+
+    finishReconciliation.resolve();
+    const statuses = await Promise.all([
+      first.then((response) => response.status),
+      second.then((response) => response.status),
+    ]);
+    expect(statuses.toSorted()).toEqual([200, 201]);
+    const committedReplay = await fleet.fetch(request("POST", "/v1/leases", { headers, body }));
+    expect(committedReplay.status).toBe(200);
+    await expect(committedReplay.json()).resolves.toMatchObject({
+      lease: { id: canonicalLeaseID, state: "active" },
     });
   });
 
-  it.each(["canonical lease", "workspace reservation", "request binding"])(
-    "rejects retained reactivation when its requested ID collides with a %s",
-    async (collision) => {
+  it("persists a cancel-before-create tombstone and rejects the later create without provisioning", async () => {
+    const storage = new MemoryStorage();
+    let creates = 0;
+    const fleet = testFleet(storage, { hetzner: fakeProvider(() => creates++) });
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const leaseID = "cbx_ca1100000001";
+    const createAttemptID = "cat_10000000000000000000000000000001";
+
+    const canceled = await fleet.fetch(
+      request("POST", `/v1/leases/${leaseID}/cancel-create`, {
+        headers,
+        body: { createAttemptID },
+      }),
+    );
+    expect(canceled.status).toBe(200);
+    await expect(canceled.json()).resolves.toMatchObject({
+      canceledCreate: { version: 1, requestedLeaseID: leaseID, createAttemptID, state: "canceled" },
+    });
+    expect(storage.value(`create-attempt:${leaseID}`)).toMatchObject({
+      token: createAttemptID,
+      state: "canceled",
+    });
+    const repeated = await fleet.fetch(
+      request("POST", `/v1/leases/${leaseID}/cancel-create`, {
+        headers,
+        body: { createAttemptID },
+      }),
+    );
+    expect(repeated.status).toBe(200);
+
+    const create = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers,
+        body: { leaseID, createAttemptID, provider: "hetzner", sshPublicKey: "ssh-ed25519 x" },
+      }),
+    );
+    expect(create.status).toBe(409);
+    await expect(create.json()).resolves.toMatchObject({ error: "create_canceled" });
+    expect(creates).toBe(0);
+    expect(storage.value(`lease:${leaseID}`)).toBeUndefined();
+  });
+
+  it("lets a new cancellation supersede a foreign unbound tombstone", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const leaseID = "cbx_ca1100000024";
+    const firstToken = "cat_24000000000000000000000000000024";
+    const secondToken = "cat_25000000000000000000000000000025";
+    const firstHeaders = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const secondHeaders = {
+      "x-crabbox-owner": "bob@example.com",
+      "x-crabbox-org": "other-org",
+    };
+
+    const first = await fleet.fetch(
+      request("POST", `/v1/leases/${leaseID}/cancel-create`, {
+        headers: firstHeaders,
+        body: { createAttemptID: firstToken },
+      }),
+    );
+    expect(first.status).toBe(200);
+    const second = await fleet.fetch(
+      request("POST", `/v1/leases/${leaseID}/cancel-create`, {
+        headers: secondHeaders,
+        body: { createAttemptID: secondToken },
+      }),
+    );
+    expect(second.status).toBe(200);
+    expect(storage.value(`create-attempt:${leaseID}`)).toMatchObject({
+      token: secondToken,
+      owner: "bob@example.com",
+      state: "canceled",
+    });
+    expect(storage.value(`create-attempt-canceled:${leaseID}:${firstToken}`)).toMatchObject({
+      token: firstToken,
+      owner: "alice@example.com",
+      state: "canceled",
+    });
+
+    const delayed = await Promise.all(
+      [
+        [firstHeaders, firstToken],
+        [secondHeaders, secondToken],
+      ].map(([headers, createAttemptID]) =>
+        fleet.fetch(
+          request("POST", "/v1/leases", {
+            headers,
+            body: {
+              leaseID,
+              createAttemptID,
+              provider: "hetzner",
+              sshPublicKey: "ssh-ed25519 delayed-canceled-create",
+            },
+          }),
+        ),
+      ),
+    );
+    expect(delayed.map((response) => response.status)).toEqual([409, 409]);
+    await expect(Promise.all(delayed.map((response) => response.json()))).resolves.toEqual([
+      expect.objectContaining({ error: "create_canceled" }),
+      expect.objectContaining({ error: "create_canceled" }),
+    ]);
+    expect(storage.value(`lease:${leaseID}`)).toBeUndefined();
+  });
+
+  it("never lets a tombstone or mismatched token delete an older exact lease", async () => {
+    const storage = new MemoryStorage();
+    const leaseID = "cbx_ca1100000002";
+    storage.seed(
+      `lease:${leaseID}`,
+      testLease({ id: leaseID, owner: "alice@example.com", org: "example-org" }),
+    );
+    let releases = 0;
+    const fleet = testFleet(storage, {
+      hetzner: fakeProvider(undefined, { onReleaseLease: () => releases++ }),
+    });
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const token = "cat_20000000000000000000000000000002";
+    const canceled = await fleet.fetch(
+      request("POST", `/v1/leases/${leaseID}/cancel-create`, {
+        headers,
+        body: { createAttemptID: token },
+      }),
+    );
+    expect(canceled.status).toBe(409);
+    await expect(canceled.json()).resolves.toMatchObject({ error: "lease_id_conflict" });
+    expect(releases).toBe(0);
+    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)?.state).toBe("active");
+    expect(storage.value(`create-attempt:${leaseID}`)).toBeUndefined();
+
+    const mismatch = await fleet.fetch(
+      request("POST", `/v1/leases/${leaseID}/cancel-create`, {
+        headers,
+        body: { createAttemptID: "cat_20000000000000000000000000000003" },
+      }),
+    );
+    expect(mismatch.status).toBe(409);
+    await expect(mismatch.json()).resolves.toMatchObject({ error: "lease_id_conflict" });
+    expect(releases).toBe(0);
+  });
+
+  it("replays the same ordinary create attempt without provisioning twice", async () => {
+    const storage = new MemoryStorage();
+    let creates = 0;
+    const fleet = testFleet(storage, { hetzner: fakeProvider(() => creates++) });
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const body = {
+      leaseID: "cbx_ca1100000012",
+      createAttemptID: "cat_12000000000000000000000000000012",
+      provider: "hetzner" as const,
+      sshPublicKey: "ssh-ed25519 x",
+    };
+    const first = await fleet.fetch(request("POST", "/v1/leases", { headers, body }));
+    const replay = await fleet.fetch(request("POST", "/v1/leases", { headers, body }));
+    expect(first.status).toBe(201);
+    expect(replay.status).toBe(200);
+    expect(creates).toBe(1);
+    await expect(replay.json()).resolves.toMatchObject({
+      lease: { id: body.leaseID, state: "active" },
+    });
+  });
+
+  it.each(["provisioning", "active"] as const)(
+    "replays a bound %s create before missing provider configuration is validated",
+    async (state) => {
       const storage = new MemoryStorage();
-      const requestLeaseID = "cbx_abcdef123461";
+      const leaseID = state === "provisioning" ? "cbx_ca1100000030" : "cbx_ca1100000031";
+      const createAttemptID =
+        state === "provisioning"
+          ? "cat_30000000000000000000000000000030"
+          : "cat_31000000000000000000000000000031";
+      const generation = `${state}-generation`;
+      storage.seed(`create-attempt:${leaseID}`, {
+        version: 1,
+        requestedLeaseID: leaseID,
+        token: createAttemptID,
+        owner: "alice@example.com",
+        org: orgKeyForLabel("example-org"),
+        state: "pending",
+        canonicalLeaseID: leaseID,
+        generation,
+        createdAt: "2026-08-09T00:00:00.000Z",
+        updatedAt: "2026-08-09T00:00:00.000Z",
+      });
       storage.seed(
-        "lease:cbx_000000000113",
+        `lease:${leaseID}`,
         testLease({
-          id: "cbx_000000000113",
-          provider: "aws",
-          target: "macos",
-          state: "released",
+          id: leaseID,
+          provider: "azure",
+          state,
           owner: "alice@example.com",
           org: "example-org",
-          hostId: "h-collision",
-          serverType: "mac2.metal",
-          releaseDeletesServer: false,
+          cloudID: state === "active" ? "vm-replay" : "",
+          createAttemptID,
+          createAttemptGeneration: generation,
         }),
       );
-      if (collision === "canonical lease") {
-        storage.seed(`lease:${requestLeaseID}`, testLease({ id: requestLeaseID }));
-      } else if (collision === "workspace reservation") {
-        storage.seed(`workspace-lease:${requestLeaseID}`, true);
-      } else {
-        storage.seed(`lease-request:${requestLeaseID}`, {
-          version: 1,
-          requestLeaseID,
-          leaseID: "cbx_000000000114",
-          owner: "alice@example.com",
-          org: "example-org",
-          cloudID: "i-other",
-          generation: "other-generation",
-          createdAt: "2026-08-01T00:00:00.000Z",
-        });
-      }
-      const fleet = testFleet(storage, { aws: fakeProvider(undefined, { provider: "aws" }) });
-      const response = await fleet.fetch(
+      const fleet = testFleet(storage);
+
+      const replay = await fleet.fetch(
         request("POST", "/v1/leases", {
           headers: {
             "x-crabbox-owner": "alice@example.com",
             "x-crabbox-org": "example-org",
           },
           body: {
-            leaseID: requestLeaseID,
-            provider: "aws",
-            target: "macos",
-            hostId: "h-collision",
-            serverType: "mac2.metal",
-            capacity: { market: "on-demand" },
-            keep: true,
-            sshPublicKey: "ssh-ed25519 collision",
+            leaseID,
+            createAttemptID,
+            provider: "azure",
+            azureLocation: "eastus",
+            sshPublicKey: "ssh-ed25519 replay",
           },
         }),
       );
-      expect(response.status).toBe(409);
-      await expect(response.json()).resolves.toMatchObject({ error: "lease_id_conflict" });
-      expect(storage.value<LeaseRecord>("lease:cbx_000000000113")?.state).toBe("released");
+
+      expect(replay.status).toBe(200);
+      await expect(replay.json()).resolves.toMatchObject({ lease: { id: leaseID, state } });
     },
   );
 
-  it("fails closed for stale, interrupted, foreign, and exact-conflicting release aliases", async () => {
-    const requestLeaseID = "cbx_abcdef123462";
-    const canonicalID = "cbx_000000000115";
-    const binding = {
+  it("returns the terminal create response for a bound failed attempt before provider validation", async () => {
+    const storage = new MemoryStorage();
+    const leaseID = "cbx_ca1100000034";
+    const createAttemptID = "cat_34000000000000000000000000000034";
+    const generation = "failed-generation";
+    storage.seed(`create-attempt:${leaseID}`, {
       version: 1,
-      requestLeaseID,
-      leaseID: canonicalID,
+      requestedLeaseID: leaseID,
+      token: createAttemptID,
       owner: "alice@example.com",
-      org: "example-org",
-      cloudID: "i-alias-guard",
-      generation: "generation-one",
-      createdAt: "2026-08-01T00:00:00.000Z",
-    };
-    const headers = {
-      "x-crabbox-owner": "alice@example.com",
-      "x-crabbox-org": "example-org",
-    };
-    await Promise.all(
-      (["stale", "interrupted", "exact-conflict"] as const).map(async (mode) => {
-        const storage = new MemoryStorage();
-        storage.seed(`lease-request:${requestLeaseID}`, binding);
-        storage.seed(
-          `lease:${canonicalID}`,
-          testLease({
-            id: canonicalID,
-            provider: "aws",
-            target: "macos",
-            owner: "alice@example.com",
-            org: "example-org",
-            cloudID: "i-alias-guard",
-            requestLeaseGeneration:
-              mode === "stale"
-                ? "generation-two"
-                : mode === "interrupted"
-                  ? undefined
-                  : "generation-one",
-          }),
-        );
-        if (mode === "exact-conflict") {
-          storage.seed(`lease:${requestLeaseID}`, testLease({ id: requestLeaseID }));
-        }
-        let releases = 0;
-        const fleet = testFleet(storage, {
-          aws: fakeProvider(undefined, { provider: "aws", onReleaseLease: () => releases++ }),
-        });
-        const response = await fleet.fetch(
-          request("POST", `/v1/leases/${requestLeaseID}/release`, {
-            headers,
-            body: { delete: true },
-          }),
-        );
-        expect(response.status).toBe(409);
-        await expect(response.json()).resolves.toMatchObject({
-          error: "lease_request_binding_conflict",
-        });
-        expect(releases).toBe(0);
-      }),
-    );
-
-    const ownerStorage = new MemoryStorage();
-    ownerStorage.seed(`lease-request:${requestLeaseID}`, binding);
-    ownerStorage.seed(
-      `lease:${canonicalID}`,
-      testLease({
-        id: canonicalID,
-        provider: "aws",
-        target: "macos",
-        owner: "alice@example.com",
-        org: "example-org",
-        cloudID: "i-alias-guard",
-        requestLeaseGeneration: "generation-one",
-      }),
-    );
-    let releases = 0;
-    const ownerFleet = testFleet(ownerStorage, {
-      aws: fakeProvider(undefined, { provider: "aws", onReleaseLease: () => releases++ }),
+      org: orgKeyForLabel("example-org"),
+      state: "pending",
+      canonicalLeaseID: leaseID,
+      generation,
+      createdAt: "2026-08-09T00:00:00.000Z",
+      updatedAt: "2026-08-09T00:00:00.000Z",
     });
-    await Promise.all(
-      [
-        { "x-crabbox-owner": "bob@example.com", "x-crabbox-org": "example-org" },
-        { "x-crabbox-owner": "alice@example.com", "x-crabbox-org": "other-org" },
-      ].map(async (foreignHeaders) => {
-        const response = await ownerFleet.fetch(
-          request("POST", `/v1/leases/${requestLeaseID}/release`, {
-            headers: foreignHeaders,
-            body: { delete: true },
-          }),
-        );
-        expect(response.status).toBe(404);
-      }),
-    );
-    expect(releases).toBe(0);
-    const adminRelease = await ownerFleet.fetch(
-      request("POST", `/v1/admin/leases/${requestLeaseID}/release`, {
-        headers: {
-          "x-crabbox-admin": "true",
-          "x-crabbox-owner": "admin@example.com",
-          "x-crabbox-org": "admin-org",
-        },
-        body: { delete: true },
-      }),
-    );
-    expect(adminRelease.status).toBe(200);
-    await expect(adminRelease.json()).resolves.toMatchObject({
-      requestLeaseID,
-      lease: { id: canonicalID, state: "released" },
-    });
-    expect(releases).toBe(1);
-  });
-
-  it("leaves an interrupted binding reserved and inert when canonical generation persistence fails", async () => {
-    const storage = new HookedMemoryStorage();
-    const canonicalID = "cbx_000000000117";
-    const requestLeaseID = "cbx_abcdef123464";
     storage.seed(
-      `lease:${canonicalID}`,
+      `lease:${leaseID}`,
       testLease({
-        id: canonicalID,
-        provider: "aws",
-        target: "macos",
-        state: "released",
+        id: leaseID,
+        provider: "azure",
+        state: "failed",
         owner: "alice@example.com",
         org: "example-org",
-        hostId: "h-interrupted-binding",
-        serverType: "mac2.metal",
-        cloudID: "i-interrupted-binding",
-        releaseDeletesServer: false,
+        createAttemptID,
+        createAttemptGeneration: generation,
+        failureError: "provider create failed",
       }),
     );
-    storage.beforePut = async (key, value) => {
-      if (
-        key === `lease:${canonicalID}` &&
-        (value as LeaseRecord).requestLeaseGeneration !== undefined
-      ) {
-        throw new Error("injected canonical generation write failure");
-      }
-    };
-    let releases = 0;
-    const fleet = testFleet(storage, {
-      aws: fakeProvider(undefined, { provider: "aws", onReleaseLease: () => releases++ }),
-    });
-    const headers = {
-      "x-crabbox-owner": "alice@example.com",
-      "x-crabbox-org": "example-org",
-    };
-    const create = await fleet.fetch(
+    const fleet = testFleet(storage);
+
+    const replay = await fleet.fetch(
       request("POST", "/v1/leases", {
-        headers,
+        headers: {
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
+        },
         body: {
-          leaseID: requestLeaseID,
-          provider: "aws",
-          target: "macos",
-          hostId: "h-interrupted-binding",
-          serverType: "mac2.metal",
-          capacity: { market: "on-demand" },
-          keep: true,
-          sshPublicKey: "ssh-ed25519 interrupted",
+          leaseID,
+          createAttemptID,
+          provider: "azure",
+          azureLocation: "eastus",
+          sshPublicKey: "ssh-ed25519 failed-replay",
         },
       }),
     );
-    expect(create.status).toBe(500);
-    expect(storage.value(`lease-request:${requestLeaseID}`)).toBeDefined();
-    const storedCanonical = storage.value<LeaseRecord>(`lease:${canonicalID}`)!;
-    expect(storedCanonical.state).toBe("released");
-    expect(storedCanonical.requestLeaseGeneration).toBeUndefined();
-    storage.beforePut = undefined;
-    const release = await fleet.fetch(
-      request("POST", `/v1/leases/${requestLeaseID}/release`, {
-        headers,
-        body: { delete: true },
-      }),
-    );
-    expect(release.status).toBe(409);
-    await expect(release.json()).resolves.toMatchObject({
-      error: "lease_request_binding_conflict",
+
+    expect(replay.status).toBe(409);
+    await expect(replay.json()).resolves.toMatchObject({
+      error: "lease_state_changed",
+      lease: { id: leaseID, state: "failed" },
     });
-    expect(releases).toBe(0);
   });
 
-  it("serializes alias release resolution with retained binding publication", async () => {
-    const storage = new HookedMemoryStorage();
-    const canonicalID = "cbx_000000000118";
-    const requestLeaseID = "cbx_abcdef123465";
-    storage.seed(
-      `lease:${canonicalID}`,
-      testLease({
-        id: canonicalID,
-        provider: "aws",
-        target: "macos",
-        state: "released",
-        owner: "alice@example.com",
-        org: "example-org",
-        hostId: "h-publication-race",
-        serverType: "mac2.metal",
-        cloudID: "i-publication-race",
-        releaseDeletesServer: false,
+  it("unwinds an attempt binding after pre-provision preparation fails", async () => {
+    const storage = new MemoryStorage();
+    let preparations = 0;
+    let creates = 0;
+    const fleet = testFleet(storage, {
+      hetzner: fakeProvider(() => creates++, {
+        onPrepareLeaseCreate() {
+          preparations += 1;
+          if (preparations === 1) {
+            throw new Error("transient preparation failure");
+          }
+          return undefined;
+        },
       }),
-    );
-    let canonicalPutStarted!: () => void;
-    const canonicalPutStartedPromise = new Promise<void>((resolve) => {
-      canonicalPutStarted = resolve;
     });
-    let allowCanonicalPut!: () => void;
-    const allowCanonicalPutPromise = new Promise<void>((resolve) => {
-      allowCanonicalPut = resolve;
-    });
-    storage.beforePut = async (key, value) => {
-      if (
-        key === `lease:${canonicalID}` &&
-        (value as LeaseRecord).requestLeaseGeneration !== undefined
-      ) {
-        canonicalPutStarted();
-        await allowCanonicalPutPromise;
-      }
+    const leaseID = "cbx_ca1100000037";
+    const createAttemptID = "cat_37000000000000000000000000000037";
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
     };
+    const body = {
+      leaseID,
+      createAttemptID,
+      provider: "hetzner" as const,
+      sshPublicKey: "ssh-ed25519 preparation-retry",
+    };
+
+    const failed = await fleet.fetch(request("POST", "/v1/leases", { headers, body }));
+    expect(failed.status).toBe(500);
+    expect(storage.value(`lease:${leaseID}`)).toBeUndefined();
+    expect(storage.value(`create-attempt:${leaseID}`)).toMatchObject({
+      token: createAttemptID,
+      state: "pending",
+    });
+    expect(storage.value(`create-attempt:${leaseID}`)).not.toHaveProperty("canonicalLeaseID");
+    expect(storage.value(`create-attempt:${leaseID}`)).not.toHaveProperty("generation");
+
+    const retried = await fleet.fetch(request("POST", "/v1/leases", { headers, body }));
+    expect(retried.status).toBe(201);
+    await expect(retried.json()).resolves.toMatchObject({
+      lease: { id: leaseID, state: "active" },
+    });
+    expect(preparations).toBe(2);
+    expect(creates).toBe(1);
+  });
+
+  it("replays a concurrently bound ordinary create attempt without a second provision or cancel", async () => {
+    const storage = new MemoryStorage();
+    const bothPrepared = deferred<void>();
+    const finishPreparation = deferred<void>();
+    const provisionStarted = deferred<void>();
+    const finishProvision = deferred<void>();
+    let preparations = 0;
+    let creates = 0;
     let releases = 0;
     const fleet = testFleet(storage, {
-      aws: fakeProvider(
-        () => {
-          throw new Error("retained instance must not launch a replacement");
+      hetzner: fakeProvider(
+        async () => {
+          creates += 1;
+          provisionStarted.resolve();
+          await finishProvision.promise;
         },
-        { provider: "aws", onReleaseLease: () => releases++ },
+        {
+          provider: "hetzner",
+          async onPrepareLeaseConfig(config) {
+            preparations += 1;
+            if (preparations === 2) bothPrepared.resolve();
+            await finishPreparation.promise;
+            return config;
+          },
+          onReleaseLease() {
+            releases += 1;
+          },
+        },
       ),
     });
     const headers = {
       "x-crabbox-owner": "alice@example.com",
       "x-crabbox-org": "example-org",
     };
-    const createPromise = fleet.fetch(
+    const body = {
+      leaseID: "cbx_ca1100000015",
+      createAttemptID: "cat_15000000000000000000000000000015",
+      provider: "hetzner" as const,
+      sshPublicKey: "ssh-ed25519 concurrent-replay",
+    };
+
+    const first = fleet.fetch(request("POST", "/v1/leases", { headers, body }));
+    const second = fleet.fetch(request("POST", "/v1/leases", { headers, body }));
+    await bothPrepared.promise;
+    finishPreparation.resolve();
+
+    const replay = await Promise.race([first, second]);
+    expect(replay.status).toBe(200);
+    await expect(replay.json()).resolves.toMatchObject({
+      lease: { id: body.leaseID, state: "provisioning" },
+    });
+    await provisionStarted.promise;
+    expect(creates).toBe(1);
+    expect(releases).toBe(0);
+
+    finishProvision.resolve();
+    const statuses = await Promise.all([
+      first.then((response) => response.status),
+      second.then((response) => response.status),
+    ]);
+    expect(statuses.toSorted()).toEqual([200, 201]);
+    expect(creates).toBe(1);
+    expect(releases).toBe(0);
+  });
+
+  it("keeps legacy ordinary creates without attempt tokens compatible", async () => {
+    const storage = new MemoryStorage();
+    let creates = 0;
+    const fleet = testFleet(storage, { hetzner: fakeProvider(() => creates++) });
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const explicitLeaseID = "cbx_1e9ac0000001";
+    const explicit = await fleet.fetch(
       request("POST", "/v1/leases", {
         headers,
         body: {
-          leaseID: requestLeaseID,
-          provider: "aws",
-          target: "macos",
-          hostId: "h-publication-race",
-          serverType: "mac2.metal",
-          capacity: { market: "on-demand" },
-          keep: true,
-          sshPublicKey: "ssh-ed25519 publication-race",
+          leaseID: explicitLeaseID,
+          createAttemptID: undefined,
+          provider: "hetzner",
+          sshPublicKey: "ssh-ed25519 legacy-explicit",
         },
       }),
     );
-    await canonicalPutStartedPromise;
-    expect(storage.value(`lease-request:${requestLeaseID}`)).toBeDefined();
+    expect(explicit.status).toBe(201);
+    await expect(explicit.json()).resolves.toMatchObject({ lease: { id: explicitLeaseID } });
 
-    const releasePromise = fleet.fetch(
-      request("POST", `/v1/leases/${requestLeaseID}/release`, {
+    const generated = await fleet.fetch(
+      request("POST", "/v1/leases", {
         headers,
-        body: { delete: true },
+        body: {
+          leaseID: undefined,
+          createAttemptID: undefined,
+          provider: "hetzner",
+          sshPublicKey: "ssh-ed25519 legacy-generated",
+        },
       }),
     );
-    const earlyRelease = await Promise.race([
-      releasePromise.then(() => "completed"),
-      new Promise<string>((resolve) => setTimeout(() => resolve("waiting"), 20)),
-    ]);
-    expect(earlyRelease).toBe("waiting");
-
-    allowCanonicalPut();
-    expect((await createPromise).status).toBe(201);
-    const release = await releasePromise;
-    expect(release.status).toBe(200);
-    await expect(release.json()).resolves.toMatchObject({
-      requestLeaseID,
-      lease: { id: canonicalID, state: "released" },
-    });
-    expect(releases).toBe(1);
+    expect(generated.status).toBe(201);
+    const generatedBody = (await generated.json()) as { lease: LeaseRecord };
+    expect(generatedBody.lease.id).toMatch(/^cbx_[a-f0-9]{12}$/);
+    expect(creates).toBe(2);
+    expect((await storage.list({ prefix: "create-attempt:" })).size).toBe(0);
   });
 
   it.each([
     { name: "before release side effects", replaceAtRead: 2 },
     { name: "before release mutation", replaceAtRead: 3 },
-  ])("rejects an exact lease generation change $name", async ({ replaceAtRead }) => {
+  ])("generation-fences normal release $name", async ({ replaceAtRead }) => {
     const storage = new MemoryStorage();
-    const leaseID = "cbx_abcdef123466";
+    const leaseID = "cbx_1e9ac0000002";
     const original = testLease({
       id: leaseID,
       provider: "aws",
@@ -18674,18 +18735,12 @@ describe("fleet lease identity and idle", () => {
       org: "example-org",
       cloudID: "i-same-resource",
       createdAt: "2026-08-01T00:00:00.000Z",
-      requestLeaseGeneration: "generation-one",
+      createAttemptGeneration: "generation-one",
     });
-    const replacement = testLease({
-      id: leaseID,
-      provider: "aws",
-      state: "active",
-      owner: "alice@example.com",
-      org: "example-org",
-      cloudID: "i-same-resource",
-      createdAt: "2026-08-01T00:00:00.000Z",
-      requestLeaseGeneration: "generation-two",
-    });
+    const replacement = {
+      ...original,
+      createAttemptGeneration: "generation-two",
+    };
     storage.seed(`lease:${leaseID}`, original);
     let exactReads = 0;
     storage.beforeGet = async (key) => {
@@ -18711,43 +18766,31 @@ describe("fleet lease identity and idle", () => {
     await expect(response.json()).resolves.toMatchObject({ error: "lease_state_changed" });
     expect(releases).toBe(0);
     expect(storage.value<LeaseRecord>(`lease:${leaseID}`)).toMatchObject({
-      owner: "alice@example.com",
-      cloudID: "i-same-resource",
       state: "active",
-      requestLeaseGeneration: "generation-two",
+      createAttemptGeneration: "generation-two",
     });
   });
 
-  it("rechecks the alias generation inside the release mutation lock", async () => {
+  it("generation-fences portal release across retained reactivation", async () => {
     const storage = new MemoryStorage();
-    const requestLeaseID = "cbx_abcdef123463";
-    const canonicalID = "cbx_000000000116";
-    storage.seed(`lease-request:${requestLeaseID}`, {
-      version: 1,
-      requestLeaseID,
-      leaseID: canonicalID,
-      owner: "alice@example.com",
-      org: "example-org",
-      cloudID: "i-final-generation",
-      generation: "generation-one",
-      createdAt: "2026-08-01T00:00:00.000Z",
-    });
-    const canonical = testLease({
-      id: canonicalID,
+    const leaseID = "cbx_1e9ac0000003";
+    const original = testLease({
+      id: leaseID,
       provider: "aws",
-      target: "macos",
+      state: "active",
       owner: "alice@example.com",
       org: "example-org",
-      cloudID: "i-final-generation",
-      requestLeaseGeneration: "generation-one",
+      cloudID: "i-portal-resource",
+      createdAt: "2026-08-01T00:00:00.000Z",
+      createAttemptGeneration: "portal-generation-one",
     });
-    storage.seed(`lease:${canonicalID}`, canonical);
-    let canonicalReads = 0;
+    storage.seed(`lease:${leaseID}`, original);
+    let exactReads = 0;
     storage.beforeGet = async (key) => {
-      if (key === `lease:${canonicalID}` && ++canonicalReads === 3) {
-        storage.seed(`lease:${canonicalID}`, {
-          ...canonical,
-          requestLeaseGeneration: "generation-two",
+      if (key === `lease:${leaseID}` && ++exactReads === 3) {
+        storage.seed(`lease:${leaseID}`, {
+          ...original,
+          createAttemptGeneration: "portal-generation-two",
         });
       }
     };
@@ -18756,20 +18799,1270 @@ describe("fleet lease identity and idle", () => {
       aws: fakeProvider(undefined, { provider: "aws", onReleaseLease: () => releases++ }),
     });
     const response = await fleet.fetch(
-      request("POST", `/v1/leases/${requestLeaseID}/release`, {
+      request("POST", `/portal/leases/${leaseID}/release`, {
         headers: {
           "x-crabbox-owner": "alice@example.com",
           "x-crabbox-org": "example-org",
         },
-        body: { delete: true },
       }),
     );
     expect(response.status).toBe(409);
-    await expect(response.json()).resolves.toMatchObject({
-      error: "lease_request_binding_conflict",
+    expect(releases).toBe(0);
+    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)).toMatchObject({
+      state: "active",
+      createAttemptGeneration: "portal-generation-two",
+    });
+  });
+
+  it("generation-fences registered lease release by registration ID", async () => {
+    const storage = new MemoryStorage();
+    const leaseID = "registered-release-generation";
+    const original = testLease({
+      id: leaseID,
+      provider: "external",
+      lifecycle: "registered",
+      state: "active",
+      owner: "alice@example.com",
+      org: "example-org",
+      createdAt: "2026-08-01T00:00:00.000Z",
+      runtimeAdapterRegistrationID: "registration-one",
+    });
+    storage.seed(`lease:${leaseID}`, original);
+    let exactReads = 0;
+    storage.beforeGet = async (key) => {
+      if (key === `lease:${leaseID}` && ++exactReads === 3) {
+        storage.seed(`lease:${leaseID}`, {
+          ...original,
+          runtimeAdapterRegistrationID: "registration-two",
+        });
+      }
+    };
+    const fleet = testFleet(storage);
+    const response = await fleet.fetch(
+      request("POST", `/v1/leases/${leaseID}/release`, {
+        headers: {
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
+        },
+        body: { delete: false },
+      }),
+    );
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({ error: "lease_state_changed" });
+    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)).toMatchObject({
+      state: "active",
+      runtimeAdapterRegistrationID: "registration-two",
+    });
+  });
+
+  it("isolates create attempts by owner and organization while allowing an admin with the exact token", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const leaseID = "cbx_ca1100000003";
+    const createAttemptID = "cat_30000000000000000000000000000003";
+    await fleet.fetch(
+      request("POST", `/v1/leases/${leaseID}/cancel-create`, {
+        headers: { "x-crabbox-owner": "alice@example.com", "x-crabbox-org": "example-org" },
+        body: { createAttemptID },
+      }),
+    );
+    const foreign = await fleet.fetch(
+      request("POST", `/v1/leases/${leaseID}/cancel-create`, {
+        headers: { "x-crabbox-owner": "bob@example.com", "x-crabbox-org": "other-org" },
+        body: { createAttemptID },
+      }),
+    );
+    expect(foreign.status).toBe(404);
+    const admin = await fleet.fetch(
+      request("POST", `/v1/leases/${leaseID}/cancel-create`, {
+        headers: {
+          "x-crabbox-admin": "true",
+          "x-crabbox-owner": "admin@example.com",
+          "x-crabbox-org": "admin-org",
+        },
+        body: { createAttemptID },
+      }),
+    );
+    expect(admin.status).toBe(200);
+  });
+
+  it("lets cancellation win during slow config preparation before lease reservation", async () => {
+    const storage = new MemoryStorage();
+    let releasePreparation!: () => void;
+    let preparationStarted!: () => void;
+    const preparationStartedPromise = new Promise<void>(
+      (resolve) => (preparationStarted = resolve),
+    );
+    const releasePreparationPromise = new Promise<void>(
+      (resolve) => (releasePreparation = resolve),
+    );
+    let creates = 0;
+    const fleet = testFleet(storage, {
+      hetzner: fakeProvider(() => creates++, {
+        onPrepareLeaseConfig: async (config) => {
+          preparationStarted();
+          await releasePreparationPromise;
+          return config;
+        },
+      }),
+    });
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const leaseID = "cbx_ca1100000004";
+    const createAttemptID = "cat_40000000000000000000000000000004";
+    const creating = fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers,
+        body: { leaseID, createAttemptID, provider: "hetzner", sshPublicKey: "ssh-ed25519 x" },
+      }),
+    );
+    await preparationStartedPromise;
+    const canceled = await fleet.fetch(
+      request("POST", `/v1/leases/${leaseID}/cancel-create`, {
+        headers,
+        body: { createAttemptID },
+      }),
+    );
+    expect(canceled.status).toBe(200);
+    releasePreparation();
+    expect((await creating).status).toBe(409);
+    expect(storage.value(`lease:${leaseID}`)).toBeUndefined();
+    expect(creates).toBe(0);
+  });
+
+  it.each([
+    {
+      name: "legacy ordinary POST",
+      method: "POST",
+      path: "/v1/leases",
+      expectedStatus: 409,
+      expectedCreates: 0,
+    },
+    {
+      name: "fixed PUT",
+      method: "PUT",
+      path: "/v1/leases/cbx_ca1100000013",
+      expectedStatus: 201,
+      expectedCreates: 1,
+    },
+  ])(
+    "applies a racing unbound attempt tombstone to $name without crossing lifecycle ownership",
+    async ({ method, path, expectedStatus, expectedCreates }) => {
+      const storage = new MemoryStorage();
+      let releasePreparation!: () => void;
+      let preparationStarted!: () => void;
+      const preparationStartedPromise = new Promise<void>(
+        (resolve) => (preparationStarted = resolve),
+      );
+      const releasePreparationPromise = new Promise<void>(
+        (resolve) => (releasePreparation = resolve),
+      );
+      let creates = 0;
+      const fleet = testFleet(storage, {
+        hetzner: fakeProvider(() => creates++, {
+          onPrepareLeaseConfig: async (config) => {
+            preparationStarted();
+            await releasePreparationPromise;
+            return config;
+          },
+        }),
+      });
+      const headers = {
+        "x-crabbox-owner": "alice@example.com",
+        "x-crabbox-org": "example-org",
+      };
+      const leaseID = "cbx_ca1100000013";
+      const createAttemptID = "cat_13000000000000000000000000000013";
+      const creating = fleet.fetch(
+        request(method, path, {
+          headers,
+          body: {
+            leaseID,
+            createAttemptID: undefined,
+            provider: "hetzner",
+            sshPublicKey: "ssh-ed25519 racing-tombstone",
+          },
+        }),
+      );
+      await preparationStartedPromise;
+      const canceled = await fleet.fetch(
+        request("POST", `/v1/leases/${leaseID}/cancel-create`, {
+          headers,
+          body: { createAttemptID },
+        }),
+      );
+      expect(canceled.status).toBe(200);
+      releasePreparation();
+      expect((await creating).status).toBe(expectedStatus);
+      expect(storage.value<LeaseRecord>(`lease:${leaseID}`)?.state).toBe(
+        expectedStatus === 201 ? "active" : undefined,
+      );
+      expect(creates).toBe(expectedCreates);
+    },
+  );
+
+  it("cancels after ordinary reservation and deletes a provider resource that completes late", async () => {
+    const storage = new MemoryStorage();
+    let createStarted!: () => void;
+    let finishCreate!: () => void;
+    const createStartedPromise = new Promise<void>((resolve) => (createStarted = resolve));
+    const finishCreatePromise = new Promise<void>((resolve) => (finishCreate = resolve));
+    const deleted: string[] = [];
+    const fleet = testFleet(storage, {
+      hetzner: fakeProvider(
+        async () => {
+          createStarted();
+          await finishCreatePromise;
+        },
+        { cloudID: "late-cloud" },
+        (id) => deleted.push(id),
+      ),
+    });
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const leaseID = "cbx_ca1100000005";
+    const createAttemptID = "cat_50000000000000000000000000000005";
+    const creating = fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers,
+        body: { leaseID, createAttemptID, provider: "hetzner", sshPublicKey: "ssh-ed25519 x" },
+      }),
+    );
+    await createStartedPromise;
+    const canceled = await fleet.fetch(
+      request("POST", `/v1/leases/${leaseID}/cancel-create`, {
+        headers,
+        body: { createAttemptID },
+      }),
+    );
+    expect(canceled.status).toBe(200);
+    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)?.state).toBe("released");
+    finishCreate();
+    expect((await creating).status).toBe(409);
+    expect(deleted).toEqual(["123"]);
+    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)?.state).toBe("released");
+  });
+
+  it("retains an explicit cleanup claim from a provider failure that arrives after cancellation", async () => {
+    const storage = new MemoryStorage();
+    const createStarted = deferred<void>();
+    const finishCreate = deferred<void>();
+    const leaseID = "cbx_ca1100000016";
+    const createAttemptID = "cat_16000000000000000000000000000016";
+    const fleet = testFleet(storage, {
+      gcp: fakeProvider(
+        async () => {
+          createStarted.resolve();
+          await finishCreate.promise;
+          throw new ProviderProvisioningCleanupError(
+            "create failed after cancellation",
+            {
+              provider: "gcp",
+              cloudID: "crabbox-canceled-late",
+              region: "us-central1-b",
+              providerProject: "cleanup-project",
+            },
+            new Error("cleanup unavailable"),
+          );
+        },
+        { provider: "gcp" },
+      ),
+    });
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const creating = fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers,
+        body: {
+          leaseID,
+          createAttemptID,
+          provider: "gcp",
+          gcpProject: "request-project",
+          gcpZone: "us-central1-a",
+          sshPublicKey: "ssh-ed25519 canceled-claim",
+        },
+      }),
+    );
+    await createStarted.promise;
+    expect(
+      (
+        await fleet.fetch(
+          request("POST", `/v1/leases/${leaseID}/cancel-create`, {
+            headers,
+            body: { createAttemptID },
+          }),
+        )
+      ).status,
+    ).toBe(200);
+
+    finishCreate.resolve();
+    expect((await creating).status).toBe(500);
+    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)).toMatchObject({
+      state: "released",
+      cloudID: "crabbox-canceled-late",
+      region: "us-central1-b",
+      providerProject: "cleanup-project",
+      releaseDeletesServer: true,
+      provisioningResourceMayExist: true,
+      cleanupRetryAt: expect.any(String),
+    });
+  });
+
+  it("retains Hetzner cleanup identity from a provider failure that arrives after cancellation", async () => {
+    const storage = new MemoryStorage();
+    const createStarted = deferred<void>();
+    const finishCreate = deferred<void>();
+    const leaseID = "cbx_ca1100000017";
+    const createAttemptID = "cat_17000000000000000000000000000017";
+    const fleet = testFleet(storage, {
+      hetzner: fakeProvider(
+        async () => {
+          createStarted.resolve();
+          await finishCreate.promise;
+          throw new HetznerProvisioningError(
+            "IP wait failed; cleanup server 123 and key 7 failed",
+            true,
+            true,
+            123,
+            7,
+          );
+        },
+        { provider: "hetzner" },
+      ),
+    });
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const creating = fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers,
+        body: {
+          leaseID,
+          createAttemptID,
+          provider: "hetzner",
+          sshPublicKey: "ssh-ed25519 canceled-hetzner",
+        },
+      }),
+    );
+    await createStarted.promise;
+    expect(
+      (
+        await fleet.fetch(
+          request("POST", `/v1/leases/${leaseID}/cancel-create`, {
+            headers,
+            body: { createAttemptID },
+          }),
+        )
+      ).status,
+    ).toBe(200);
+
+    finishCreate.resolve();
+    expect((await creating).status).toBe(500);
+    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)).toMatchObject({
+      state: "released",
+      cloudID: "123",
+      serverID: 123,
+      providerKeyCleanupPending: true,
+      providerKeyCleanupID: "7",
+      releaseDeletesServer: true,
+      provisioningResourceMayExist: true,
+      provisioningFailureRetryable: true,
+      cleanupRetryAt: expect.any(String),
+    });
+  });
+
+  it("retains uncertain AWS outcome metadata from a failure that arrives after cancellation", async () => {
+    const storage = new MemoryStorage();
+    const createStarted = deferred<void>();
+    const finishCreate = deferred<void>();
+    const leaseID = "cbx_ca1100000018";
+    const createAttemptID = "cat_18000000000000000000000000000018";
+    const deleted: string[] = [];
+    const fleet = testFleet(storage, {
+      aws: fakeProvider(
+        async () => {
+          createStarted.resolve();
+          await finishCreate.promise;
+          throw new Error("crabbox_aws_run_instances_outcome_uncertain: request timed out");
+        },
+        {
+          provider: "aws",
+          onRecoverServer: () => ({
+            provider: "aws",
+            id: 0,
+            cloudID: "i-canceled-uncertain",
+            name: "crabbox-canceled-uncertain",
+            status: "running",
+            serverType: "t3.small",
+            host: "192.0.2.55",
+            region: "us-east-1",
+            labels: {
+              crabbox: "true",
+              created_by: "crabbox",
+              lease: leaseID,
+              owner: "alice_example.com",
+              provider: "aws",
+              slug: "harbor-prawn",
+            },
+          }),
+          onReleaseLease: (lease) => deleted.push(lease.cloudID),
+        },
+      ),
+    });
+    const headers = {
+      "x-crabbox-admin": "true",
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const creating = fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers,
+        body: {
+          leaseID,
+          createAttemptID,
+          provider: "aws",
+          awsPrivate: true,
+          awsRequireSSM: true,
+          sshPublicKey: "ssh-ed25519 canceled-aws",
+        },
+      }),
+    );
+    await createStarted.promise;
+    expect(
+      (
+        await fleet.fetch(
+          request("POST", `/v1/leases/${leaseID}/cancel-create`, {
+            headers,
+            body: { createAttemptID },
+          }),
+        )
+      ).status,
+    ).toBe(200);
+
+    finishCreate.resolve();
+    expect((await creating).status).toBe(500);
+    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)).toMatchObject({
+      state: "released",
+      releaseDeletesServer: true,
+      provisioningResourceMayExist: true,
+      provisioningFailureRetryable: false,
+      provisioningRequestSettledAt: expect.any(String),
+      cleanupError: expect.stringContaining("crabbox_aws_run_instances_outcome_uncertain"),
+    });
+    expect(storage.alarm()).toBeDefined();
+    const visible = await fleet.fetch(request("GET", `/v1/leases/${leaseID}`, { headers }));
+    const visibleLease = ((await visible.json()) as { lease: LeaseRecord }).lease;
+    expect(visibleLease.provisioningRequestSettledAt).toBeUndefined();
+
+    await fleet.alarm();
+    const observed = storage.value<LeaseRecord>(`lease:${leaseID}`)!;
+    expect(observed.provisioningRecoveryObservedAt).toEqual(expect.any(String));
+    storage.seed(`lease:${leaseID}`, {
+      ...observed,
+      provisioningRecoveryObservedAt: new Date(Date.now() - 10 * 60_000).toISOString(),
+      cleanupRetryAt: new Date(Date.now() - 1_000).toISOString(),
+    });
+    await fleet.alarm();
+
+    expect(deleted).toEqual(["i-canceled-uncertain"]);
+    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)).toMatchObject({
+      state: "released",
+      cloudID: "i-canceled-uncertain",
+    });
+    expect(
+      storage.value<LeaseRecord>(`lease:${leaseID}`)?.provisioningRequestSettledAt,
+    ).toBeUndefined();
+  });
+
+  it("persists the cleanup claim before a canceled tombstone write can fail", async () => {
+    const storage = new HookedMemoryStorage();
+    const leaseID = "cbx_ca1100000022";
+    const createAttemptID = "cat_22000000000000000000000000000022";
+    const generation = "cancel-write-order-generation";
+    const now = new Date().toISOString();
+    storage.seed(`create-attempt:${leaseID}`, {
+      version: 1,
+      requestedLeaseID: leaseID,
+      token: createAttemptID,
+      owner: "alice@example.com",
+      org: orgKeyForLabel("example-org"),
+      state: "pending",
+      canonicalLeaseID: leaseID,
+      cloudID: "i-cancel-write-order",
+      generation,
+      createdAt: now,
+      updatedAt: now,
+    });
+    storage.seed(
+      `lease:${leaseID}`,
+      testLease({
+        id: leaseID,
+        provider: "aws",
+        owner: "alice@example.com",
+        org: "example-org",
+        cloudID: "i-cancel-write-order",
+        createAttemptID,
+        createAttemptGeneration: generation,
+      }),
+    );
+    let failCanceledAttemptWrite = true;
+    storage.beforePut = async (key, value) => {
+      if (
+        failCanceledAttemptWrite &&
+        key === `create-attempt:${leaseID}` &&
+        (value as { state?: string }).state === "canceled"
+      ) {
+        failCanceledAttemptWrite = false;
+        throw new Error("injected canceled tombstone write failure");
+      }
+    };
+    let releases = 0;
+    const fleet = testFleet(storage, {
+      aws: fakeProvider(undefined, { provider: "aws", onReleaseLease: () => releases++ }),
+    });
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+
+    const failed = await fleet.fetch(
+      request("POST", `/v1/leases/${leaseID}/cancel-create`, {
+        headers,
+        body: { createAttemptID },
+      }),
+    );
+    expect(failed.status).toBe(500);
+    expect(storage.value(`create-attempt:${leaseID}`)).toMatchObject({ state: "pending" });
+    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)).toMatchObject({
+      state: "released",
+      releaseDeletesServer: true,
+      cleanupStartedAt: expect.any(String),
+      cleanupClaimExpiresAt: expect.any(String),
     });
     expect(releases).toBe(0);
+
+    storage.beforePut = undefined;
+    const retried = await fleet.fetch(
+      request("POST", `/v1/leases/${leaseID}/cancel-create`, {
+        headers,
+        body: { createAttemptID },
+      }),
+    );
+    expect(retried.status).toBe(200);
+    expect(storage.value(`create-attempt:${leaseID}`)).toMatchObject({ state: "canceled" });
+    expect(storage.alarm()).toBeDefined();
+    expect(releases).toBe(0);
+  });
+
+  it.each([
+    { name: "in-flight", state: "provisioning" as const, resourceMayExist: false },
+    { name: "failed uncertain", state: "failed" as const, resourceMayExist: true },
+  ])(
+    "recovers a canceled $name pre-identity create after coordinator restart",
+    async ({ state, resourceMayExist }) => {
+      const storage = new MemoryStorage();
+      const leaseID = "cbx_ca1100000023";
+      const createAttemptID = "cat_23000000000000000000000000000023";
+      const generation = "canceled-pre-identity-generation";
+      const now = Date.now();
+      const provisioningRequestStartedAt = new Date(now - 60_000).toISOString();
+      const provisioningRecoveryObservedAt = new Date(now - 10 * 60_000).toISOString();
+      const provisioningRecoveryMissingSince = new Date(now - 5 * 60_000).toISOString();
+      storage.seed(`create-attempt:${leaseID}`, {
+        version: 1,
+        requestedLeaseID: leaseID,
+        token: createAttemptID,
+        owner: "alice@example.com",
+        org: orgKeyForLabel("example-org"),
+        state: "pending",
+        canonicalLeaseID: leaseID,
+        generation,
+        createdAt: new Date(now - 60_000).toISOString(),
+        updatedAt: new Date(now - 60_000).toISOString(),
+      });
+      storage.seed(
+        `lease:${leaseID}`,
+        testLease({
+          id: leaseID,
+          provider: "azure",
+          state,
+          ...(resourceMayExist
+            ? {
+                provisioningResourceMayExist: true,
+                provisioningFailureRetryable: true,
+                cleanupError: "provider create outcome remains uncertain",
+              }
+            : {}),
+          owner: "alice@example.com",
+          org: "example-org",
+          cloudID: "",
+          serverID: 0,
+          serverName: "",
+          host: "",
+          createAttemptID,
+          createAttemptGeneration: generation,
+          provisioningRequestStartedAt,
+          provisioningCoordinatorVersion: "old-version",
+          provisioningRecoveryObservedAt,
+          provisioningRecoveryMissingSince,
+          expiresAt: new Date(now + 60 * 60_000).toISOString(),
+        }),
+      );
+      const recovered = {
+        provider: "azure" as const,
+        id: 123,
+        cloudID: "vm-canceled-late",
+        name: "crabbox-canceled-late",
+        status: "running",
+        serverType: "Standard_D2ads_v6",
+        host: "192.0.2.44",
+        region: "eastus2",
+        labels: {
+          crabbox: "true",
+          created_by: "crabbox",
+          lease: leaseID,
+          owner: "alice_example.com",
+          provider: "azure",
+          slug: "blue-lobster",
+        },
+      };
+      const deleted: string[] = [];
+      const fleet = testFleet(
+        storage,
+        {
+          azure: fakeProvider(undefined, {
+            provider: "azure",
+            onRecoverServer: () => recovered,
+            onReleaseLease: (lease) => deleted.push(lease.cloudID),
+          }),
+        },
+        {
+          CF_VERSION_METADATA: {
+            id: "new-version",
+            timestamp: new Date(now).toISOString(),
+          },
+        },
+      );
+      const headers = {
+        "x-crabbox-owner": "alice@example.com",
+        "x-crabbox-org": "example-org",
+      };
+
+      const canceled = await fleet.fetch(
+        request("POST", `/v1/leases/${leaseID}/cancel-create`, {
+          headers,
+          body: { createAttemptID },
+        }),
+      );
+      expect(canceled.status).toBe(200);
+      const repeated = await fleet.fetch(
+        request("POST", `/v1/leases/${leaseID}/cancel-create`, {
+          headers,
+          body: { createAttemptID },
+        }),
+      );
+      expect(repeated.status).toBe(200);
+      expect(storage.value<LeaseRecord>(`lease:${leaseID}`)).toMatchObject({
+        state: "released",
+        cloudID: "",
+        releaseDeletesServer: true,
+        provisioningResourceMayExist: true,
+        provisioningRequestStartedAt,
+        provisioningCoordinatorVersion: "old-version",
+        provisioningRecoveryObservedAt,
+        provisioningRecoveryMissingSince,
+      });
+      expect(storage.alarm()).toBeDefined();
+
+      await fleet.alarm();
+
+      expect(deleted).toEqual(["vm-canceled-late"]);
+      expect(storage.value<LeaseRecord>(`lease:${leaseID}`)).toMatchObject({ state: "released" });
+      expect(storage.value<LeaseRecord>(`lease:${leaseID}`)?.cloudID).toBe("vm-canceled-late");
+      expect(storage.value<LeaseRecord>(`lease:${leaseID}`)?.cleanupStartedAt).toBeUndefined();
+    },
+  );
+
+  it("persists the cancel tombstone and cleanup claim before deletion so maintenance can resume", async () => {
+    const storage = new MemoryStorage();
+    const deletionStarted = deferred<void>();
+    const finishInterruptedDeletion = deferred<void>();
+    const leaseID = "cbx_ca1100000019";
+    const createAttemptID = "cat_19000000000000000000000000000019";
+    const generation = "cancel-claim-generation";
+    const now = new Date().toISOString();
+    storage.seed(`create-attempt:${leaseID}`, {
+      version: 1,
+      requestedLeaseID: leaseID,
+      token: createAttemptID,
+      owner: "alice@example.com",
+      org: orgKeyForLabel("example-org"),
+      state: "pending",
+      canonicalLeaseID: leaseID,
+      cloudID: "i-cancel-claim",
+      generation,
+      createdAt: now,
+      updatedAt: now,
+    });
+    storage.seed(
+      `lease:${leaseID}`,
+      testLease({
+        id: leaseID,
+        provider: "aws",
+        owner: "alice@example.com",
+        org: "example-org",
+        cloudID: "i-cancel-claim",
+        createAttemptID,
+        createAttemptGeneration: generation,
+      }),
+    );
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const interruptedFleet = testFleet(storage, {
+      aws: fakeProvider(undefined, {
+        provider: "aws",
+        async onReleaseLease() {
+          deletionStarted.resolve();
+          await finishInterruptedDeletion.promise;
+        },
+      }),
+    });
+
+    const canceling = interruptedFleet.fetch(
+      request("POST", `/v1/leases/${leaseID}/cancel-create`, {
+        headers,
+        body: { createAttemptID },
+      }),
+    );
+    await deletionStarted.promise;
+
+    expect(storage.value(`create-attempt:${leaseID}`)).toMatchObject({ state: "canceled" });
+    const claimed = storage.value<LeaseRecord>(`lease:${leaseID}`)!;
+    expect(claimed).toMatchObject({
+      state: "released",
+      releaseDeletesServer: true,
+      cleanupStartedAt: expect.any(String),
+      cleanupClaimExpiresAt: expect.any(String),
+    });
+
+    storage.seed(`lease:${leaseID}`, {
+      ...claimed,
+      cleanupClaimExpiresAt: new Date(Date.now() - 1_000).toISOString(),
+    });
+    const resumedCleanups: string[] = [];
+    const restartedFleet = testFleet(storage, {
+      aws: fakeProvider(undefined, {
+        provider: "aws",
+        onReleaseLease(lease) {
+          resumedCleanups.push(lease.cloudID);
+        },
+      }),
+    });
+    await restartedFleet.alarm();
+
+    expect(resumedCleanups).toEqual(["i-cancel-claim"]);
+    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)).toMatchObject({ state: "released" });
+    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)?.cleanupStartedAt).toBeUndefined();
+    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)?.releaseDeletesServer).toBeUndefined();
+
+    finishInterruptedDeletion.resolve();
+    expect((await canceling).status).toBe(200);
+    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)?.state).toBe("released");
+  });
+
+  it("generation-fences retained canonical cancellation and keeps the requested ID private", async () => {
+    const storage = new MemoryStorage();
+    const canonicalID = "cbx_ca1100000006";
+    const requestedLeaseID = "cbx_ca1100000007";
+    const createAttemptID = "cat_60000000000000000000000000000006";
+    storage.seed(
+      `lease:${canonicalID}`,
+      testLease({
+        id: canonicalID,
+        provider: "aws",
+        target: "macos",
+        state: "released",
+        owner: "alice@example.com",
+        org: "example-org",
+        hostId: "h-create-attempt",
+        serverType: "mac2.metal",
+        cloudID: "i-retained",
+        providerKey: "crabbox-retained",
+        releaseDeletesServer: false,
+      }),
+    );
+    let releases = 0;
+    const fleet = testFleet(storage, {
+      aws: fakeProvider(undefined, { provider: "aws", onReleaseLease: () => releases++ }),
+    });
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const create = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers,
+        body: {
+          leaseID: requestedLeaseID,
+          createAttemptID,
+          provider: "aws",
+          target: "macos",
+          hostId: "h-create-attempt",
+          serverType: "mac2.metal",
+          capacity: { market: "on-demand" },
+          keep: true,
+          sshPublicKey: "ssh-ed25519 x",
+        },
+      }),
+    );
+    expect(create.status).toBe(201);
+    const publicLease = ((await create.json()) as { lease: LeaseRecord }).lease;
+    expect(publicLease.id).toBe(canonicalID);
+    expect(publicLease.createAttemptID).toBeUndefined();
+    expect(publicLease.createAttemptGeneration).toBeUndefined();
+    const tokenBoundGeneration = storage.value<LeaseRecord>(
+      `lease:${canonicalID}`,
+    )!.createAttemptGeneration;
+    expect(tokenBoundGeneration).toEqual(expect.any(String));
+    expect(
+      (await fleet.fetch(request("GET", `/v1/leases/${requestedLeaseID}`, { headers }))).status,
+    ).toBe(404);
+
+    const retained = await fleet.fetch(
+      request("POST", `/v1/leases/${canonicalID}/release`, {
+        headers,
+        body: { delete: false },
+      }),
+    );
+    expect(retained.status).toBe(200);
+    const legacyReactivation = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers,
+        body: {
+          leaseID: "cbx_ca1100000014",
+          createAttemptID: undefined,
+          provider: "aws",
+          target: "macos",
+          hostId: "h-create-attempt",
+          serverType: "mac2.metal",
+          capacity: { market: "on-demand" },
+          keep: true,
+          sshPublicKey: "ssh-ed25519 legacy-reactivation",
+        },
+      }),
+    );
+    expect(legacyReactivation.status).toBe(201);
+    const legacyCanonical = storage.value<LeaseRecord>(`lease:${canonicalID}`)!;
+    expect(legacyCanonical.state).toBe("active");
+    expect(legacyCanonical.createAttemptID).toBeUndefined();
+    expect(legacyCanonical.createAttemptGeneration).toEqual(expect.any(String));
+    expect(legacyCanonical.createAttemptGeneration).not.toBe(tokenBoundGeneration);
+    const legacyPublicLease = ((await legacyReactivation.json()) as { lease: LeaseRecord }).lease;
+    expect(legacyPublicLease).not.toHaveProperty("createAttemptID");
+    expect(legacyPublicLease).not.toHaveProperty("createAttemptGeneration");
+
+    const stale = await fleet.fetch(
+      request("POST", `/v1/leases/${requestedLeaseID}/cancel-create`, {
+        headers,
+        body: { createAttemptID },
+      }),
+    );
+    expect(stale.status).toBe(409);
     expect(storage.value<LeaseRecord>(`lease:${canonicalID}`)?.state).toBe("active");
+    expect(releases).toBe(0);
+  });
+
+  it("generation-fences canonical release across tokenless retained-Mac reactivation", async () => {
+    const storage = new MemoryStorage();
+    const canonicalID = "cbx_ca1100000036";
+    const requestedLeaseID = "cbx_ca1100000035";
+    const releasedGeneration = "released-generation";
+    storage.seed(
+      `lease:${canonicalID}`,
+      testLease({
+        id: canonicalID,
+        provider: "aws",
+        target: "macos",
+        state: "released",
+        owner: "alice@example.com",
+        org: "example-org",
+        hostId: "h-tokenless-race",
+        serverType: "mac2.metal",
+        cloudID: "i-tokenless-race",
+        providerKey: "crabbox-tokenless-race",
+        releaseDeletesServer: false,
+        createAttemptGeneration: releasedGeneration,
+      }),
+    );
+    const releaseReadStarted = deferred<void>();
+    const continueRelease = deferred<void>();
+    let canonicalReads = 0;
+    storage.beforeGet = async (key) => {
+      if (key === `lease:${canonicalID}` && ++canonicalReads === 2) {
+        releaseReadStarted.resolve();
+        await continueRelease.promise;
+      }
+    };
+    let releases = 0;
+    const fleet = testFleet(storage, {
+      aws: fakeProvider(undefined, {
+        provider: "aws",
+        onReleaseLease: () => releases++,
+      }),
+    });
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+
+    const releasing = fleet.fetch(
+      request("POST", `/v1/leases/${canonicalID}/release`, {
+        headers,
+        body: { delete: true },
+      }),
+    );
+    await releaseReadStarted.promise;
+    const reactivated = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers,
+        body: {
+          leaseID: requestedLeaseID,
+          createAttemptID: undefined,
+          provider: "aws",
+          target: "macos",
+          hostId: "h-tokenless-race",
+          serverType: "mac2.metal",
+          capacity: { market: "on-demand" },
+          keep: true,
+          sshPublicKey: "ssh-ed25519 tokenless-race",
+        },
+      }),
+    );
+    expect(reactivated.status).toBe(201);
+    const current = storage.value<LeaseRecord>(`lease:${canonicalID}`)!;
+    expect(current).toMatchObject({ id: canonicalID, state: "active" });
+    expect(current.createAttemptID).toBeUndefined();
+    expect(current.createAttemptGeneration).toEqual(expect.any(String));
+    expect(current.createAttemptGeneration).not.toBe(releasedGeneration);
+
+    continueRelease.resolve();
+    const staleRelease = await releasing;
+    expect(staleRelease.status).toBe(409);
+    await expect(staleRelease.json()).resolves.toMatchObject({
+      error: "lease_state_changed",
+    });
+    expect(storage.value<LeaseRecord>(`lease:${canonicalID}`)).toMatchObject({
+      state: "active",
+      createAttemptGeneration: current.createAttemptGeneration,
+    });
+    expect(releases).toBe(0);
+  });
+
+  it("lets cancellation win while a retained canonical generation is being published", async () => {
+    const storage = new MemoryStorage();
+    const canonicalID = "cbx_ca1100000010";
+    const requestedLeaseID = "cbx_ca1100000011";
+    const createAttemptID = "cat_70000000000000000000000000000007";
+    storage.seed(
+      `lease:${canonicalID}`,
+      testLease({
+        id: canonicalID,
+        provider: "aws",
+        target: "macos",
+        state: "released",
+        owner: "alice@example.com",
+        org: "example-org",
+        hostId: "h-publish",
+        serverType: "mac2.metal",
+        cloudID: "i-publish",
+        providerKey: "crabbox-publish",
+        releaseDeletesServer: false,
+      }),
+    );
+    let publicationStarted!: () => void;
+    let finishPublication!: () => void;
+    const publicationStartedPromise = new Promise<void>(
+      (resolve) => (publicationStarted = resolve),
+    );
+    const finishPublicationPromise = new Promise<void>((resolve) => (finishPublication = resolve));
+    let blocked = false;
+    storage.beforePut = async (key, value) => {
+      const lease = value as Partial<LeaseRecord>;
+      if (key === `lease:${canonicalID}` && lease.createAttemptID && !blocked) {
+        blocked = true;
+        publicationStarted();
+        await finishPublicationPromise;
+      }
+    };
+    let releases = 0;
+    const fleet = testFleet(storage, {
+      aws: fakeProvider(undefined, { provider: "aws", onReleaseLease: () => releases++ }),
+    });
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const creating = fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers,
+        body: {
+          leaseID: requestedLeaseID,
+          createAttemptID,
+          provider: "aws",
+          target: "macos",
+          hostId: "h-publish",
+          serverType: "mac2.metal",
+          capacity: { market: "on-demand" },
+          keep: true,
+          sshPublicKey: "ssh-ed25519 x",
+        },
+      }),
+    );
+    await publicationStartedPromise;
+    const canceling = fleet.fetch(
+      request("POST", `/v1/leases/${requestedLeaseID}/cancel-create`, {
+        headers,
+        body: { createAttemptID },
+      }),
+    );
+    finishPublication();
+    expect((await canceling).status).toBe(200);
+    expect((await creating).status).toBe(409);
+    expect(storage.value<LeaseRecord>(`lease:${canonicalID}`)?.state).toBe("released");
+    expect(releases).toBe(1);
+  });
+
+  it("does not let an unbound canceled attempt squat an ID across tenants or lifecycles", async () => {
+    const storage = new MemoryStorage();
+    const fixedID = "cbx_ca1100000008";
+    const registrationID = "cbx_ca1100000009";
+    const ordinaryID = "cbx_ca110000000a";
+    const workspaceID = "cbx_ca110000000b";
+    const canceledTokens = new Map([
+      [fixedID, "cat_80000000000000000000000000000008"],
+      [registrationID, "cat_80000000000000000000000000000009"],
+      [ordinaryID, "cat_8000000000000000000000000000000a"],
+      [workspaceID, "cat_8000000000000000000000000000000b"],
+    ]);
+    for (const [requestedLeaseID, token] of canceledTokens) {
+      storage.seed(`create-attempt:${requestedLeaseID}`, {
+        version: 1,
+        requestedLeaseID,
+        token,
+        owner: "alice@example.com",
+        org: orgKeyForLabel("example-org"),
+        state: "canceled",
+        createdAt: "2026-08-09T00:00:00.000Z",
+        updatedAt: "2026-08-09T00:00:00.000Z",
+      });
+    }
+    const realCrypto = crypto;
+    vi.stubGlobal("crypto", {
+      subtle: realCrypto.subtle,
+      randomUUID: () => realCrypto.randomUUID(),
+      getRandomValues: (bytes: Uint8Array) => {
+        bytes.set(
+          workspaceID
+            .slice(4)
+            .match(/../g)!
+            .map((part) => Number.parseInt(part, 16)),
+        );
+        return bytes;
+      },
+    });
+    const fleet = testFleet(
+      storage,
+      { hetzner: fakeProvider() },
+      { CRABBOX_WORKSPACE_SSH_PUBLIC_KEY: "ssh-ed25519 workspace" },
+    );
+    const headers = {
+      "x-crabbox-owner": "bob@example.com",
+      "x-crabbox-org": "other-org",
+    };
+    const fixed = await fleet.fetch(
+      request("PUT", `/v1/leases/${fixedID}`, {
+        headers,
+        body: { provider: "hetzner", sshPublicKey: "ssh-ed25519 x" },
+      }),
+    );
+    const registration = await fleet.fetch(
+      request("PUT", `/v1/leases/${registrationID}/registration`, {
+        headers,
+        body: { provider: "external", target: "linux", host: "host.example" },
+      }),
+    );
+    const ordinary = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers,
+        body: {
+          leaseID: ordinaryID,
+          createAttemptID: "cat_800000000000000000000000000000ff",
+          provider: "hetzner",
+          sshPublicKey: "ssh-ed25519 x",
+        },
+      }),
+    );
+    expect([fixed.status, registration.status, ordinary.status]).toEqual([201, 201, 201]);
+    const workspace = await fleet.fetch(
+      request("POST", "/v1/workspaces", {
+        headers,
+        body: { id: "attempt-reservation", runtime: "crabbox" },
+      }),
+    );
+    expect(workspace.status).toBe(202);
+    await expect(workspace.json()).resolves.toMatchObject({
+      providerResourceId: workspaceID,
+    });
+
+    const fixedReplacement = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers,
+        body: {
+          leaseID: fixedID,
+          createAttemptID: "cat_800000000000000000000000000000f1",
+          provider: "hetzner",
+          sshPublicKey: "ssh-ed25519 fixed-replacement",
+        },
+      }),
+    );
+    const workspaceReplacement = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers,
+        body: {
+          leaseID: workspaceID,
+          createAttemptID: "cat_800000000000000000000000000000f2",
+          provider: "hetzner",
+          sshPublicKey: "ssh-ed25519 workspace-replacement",
+        },
+      }),
+    );
+    expect([fixedReplacement.status, workspaceReplacement.status]).toEqual([409, 409]);
+    expect(storage.value<{ token: string }>(`create-attempt:${fixedID}`)?.token).toBe(
+      canceledTokens.get(fixedID),
+    );
+    expect(storage.value<{ token: string }>(`create-attempt:${workspaceID}`)?.token).toBe(
+      canceledTokens.get(workspaceID),
+    );
+
+    const delayedCanceledCreate = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers: {
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
+        },
+        body: {
+          leaseID: ordinaryID,
+          createAttemptID: canceledTokens.get(ordinaryID),
+          provider: "hetzner",
+          sshPublicKey: "ssh-ed25519 delayed-old-create",
+        },
+      }),
+    );
+    expect(delayedCanceledCreate.status).toBe(409);
+    await expect(delayedCanceledCreate.json()).resolves.toMatchObject({
+      error: "create_canceled",
+    });
+    expect(storage.value<LeaseRecord>(`lease:${ordinaryID}`)).toMatchObject({
+      owner: "bob@example.com",
+      state: "active",
+    });
+  });
+
+  it("keeps pending and canonical-bound create attempts as global ID blockers", async () => {
+    const storage = new MemoryStorage();
+    const pendingID = "cbx_ca110000000c";
+    const boundID = "cbx_ca110000000d";
+    const freeID = "cbx_ca110000000e";
+    storage.seed(`create-attempt:${pendingID}`, {
+      version: 1,
+      requestedLeaseID: pendingID,
+      token: "cat_8000000000000000000000000000000c",
+      owner: "alice@example.com",
+      org: orgKeyForLabel("example-org"),
+      state: "pending",
+      createdAt: "2026-08-09T00:00:00.000Z",
+      updatedAt: "2026-08-09T00:00:00.000Z",
+    });
+    storage.seed(`create-attempt:${boundID}`, {
+      version: 1,
+      requestedLeaseID: boundID,
+      token: "cat_8000000000000000000000000000000d",
+      owner: "alice@example.com",
+      org: orgKeyForLabel("example-org"),
+      state: "canceled",
+      canonicalLeaseID: "cbx_ca11000000fd",
+      generation: "bound-generation",
+      createdAt: "2026-08-09T00:00:00.000Z",
+      updatedAt: "2026-08-09T00:00:00.000Z",
+    });
+    const realCrypto = crypto;
+    const generatedIDs = [pendingID, boundID, freeID];
+    vi.stubGlobal("crypto", {
+      subtle: realCrypto.subtle,
+      randomUUID: () => realCrypto.randomUUID(),
+      getRandomValues: (bytes: Uint8Array) => {
+        const hex = generatedIDs.shift() ?? freeID;
+        bytes.set(
+          hex
+            .slice(4)
+            .match(/../g)!
+            .map((part) => Number.parseInt(part, 16)),
+        );
+        return bytes;
+      },
+    });
+    const fleet = testFleet(
+      storage,
+      { hetzner: fakeProvider() },
+      { CRABBOX_WORKSPACE_SSH_PUBLIC_KEY: "ssh-ed25519 workspace" },
+    );
+    const headers = {
+      "x-crabbox-owner": "bob@example.com",
+      "x-crabbox-org": "other-org",
+    };
+
+    const fixed = await fleet.fetch(
+      request("PUT", `/v1/leases/${pendingID}`, {
+        headers,
+        body: { provider: "hetzner", sshPublicKey: "ssh-ed25519 fixed" },
+      }),
+    );
+    const registration = await fleet.fetch(
+      request("PUT", `/v1/leases/${boundID}/registration`, {
+        headers,
+        body: { provider: "external", target: "linux", host: "host.example" },
+      }),
+    );
+    const ordinary = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers,
+        body: {
+          leaseID: pendingID,
+          createAttemptID: "cat_800000000000000000000000000000ee",
+          provider: "hetzner",
+          sshPublicKey: "ssh-ed25519 ordinary",
+        },
+      }),
+    );
+    expect([fixed.status, registration.status, ordinary.status]).toEqual([409, 409, 409]);
+
+    const workspace = await fleet.fetch(
+      request("POST", "/v1/workspaces", {
+        headers,
+        body: { id: "blocked-attempt-reservations", runtime: "crabbox" },
+      }),
+    );
+    expect(workspace.status).toBe(202);
+    await expect(workspace.json()).resolves.toMatchObject({ providerResourceId: freeID });
   });
 
   it("reactivates a retained pinned Mac host family when the request type was defaulted", async () => {
@@ -18805,6 +20098,7 @@ describe("fleet lease identity and idle", () => {
           "x-crabbox-org": "example-org",
         },
         body: {
+          createAttemptID: undefined,
           provider: "aws",
           target: "macos",
           hostId: "h-m4",
@@ -30799,6 +32093,7 @@ function testFleet(
     { storage } as unknown as DurableObjectState,
     { CRABBOX_DEFAULT_ORG: "default-org", ...env } as Env,
     providers,
+    env.CF_VERSION_METADATA?.id,
   );
 }
 
@@ -30818,6 +32113,8 @@ function testCoordinator(
     new CloudflareCoordinatorRuntime({ storage } as unknown as DurableObjectState),
     { CRABBOX_DEFAULT_ORG: "default-org", ...env } as Env,
     providers,
+    {},
+    env.CF_VERSION_METADATA?.id,
   );
 }
 
@@ -31882,18 +33179,36 @@ function testRun(overrides: Partial<RunRecord>): RunRecord {
   });
 }
 
+let ordinaryCreateRequestSequence = 0;
+
 function request(
   method: string,
   path: string,
   init: { headers?: Record<string, string>; body?: unknown } = {},
 ): Request {
+  let body = init.body;
+  if (
+    method === "POST" &&
+    (path === "/v1/leases" || path === "/v1/leases/capability-aware") &&
+    body &&
+    typeof body === "object" &&
+    !Array.isArray(body)
+  ) {
+    ordinaryCreateRequestSequence += 1;
+    const sequence = ordinaryCreateRequestSequence.toString(16);
+    body = {
+      leaseID: `cbx_${sequence.padStart(12, "0").slice(-12)}`,
+      createAttemptID: `cat_${sequence.padStart(32, "0").slice(-32)}`,
+      ...(body as Record<string, unknown>),
+    };
+  }
   return new Request(`https://crabbox.test${path}`, {
     method,
     headers: {
-      ...(init.body === undefined ? {} : { "content-type": "application/json" }),
+      ...(body === undefined ? {} : { "content-type": "application/json" }),
       ...init.headers,
     },
-    body: init.body === undefined ? undefined : JSON.stringify(init.body),
+    body: body === undefined ? undefined : JSON.stringify(body),
   });
 }
 

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -18660,6 +18660,64 @@ describe("fleet lease identity and idle", () => {
     expect(releases).toBe(1);
   });
 
+  it.each([
+    { name: "before release side effects", replaceAtRead: 2 },
+    { name: "before release mutation", replaceAtRead: 3 },
+  ])("rejects an exact lease generation change $name", async ({ replaceAtRead }) => {
+    const storage = new MemoryStorage();
+    const leaseID = "cbx_abcdef123466";
+    const original = testLease({
+      id: leaseID,
+      provider: "aws",
+      state: "active",
+      owner: "alice@example.com",
+      org: "example-org",
+      cloudID: "i-same-resource",
+      createdAt: "2026-08-01T00:00:00.000Z",
+      requestLeaseGeneration: "generation-one",
+    });
+    const replacement = testLease({
+      id: leaseID,
+      provider: "aws",
+      state: "active",
+      owner: "alice@example.com",
+      org: "example-org",
+      cloudID: "i-same-resource",
+      createdAt: "2026-08-01T00:00:00.000Z",
+      requestLeaseGeneration: "generation-two",
+    });
+    storage.seed(`lease:${leaseID}`, original);
+    let exactReads = 0;
+    storage.beforeGet = async (key) => {
+      if (key === `lease:${leaseID}` && ++exactReads === replaceAtRead) {
+        storage.seed(`lease:${leaseID}`, replacement);
+      }
+    };
+    let releases = 0;
+    const fleet = testFleet(storage, {
+      aws: fakeProvider(undefined, { provider: "aws", onReleaseLease: () => releases++ }),
+    });
+
+    const response = await fleet.fetch(
+      request("POST", `/v1/leases/${leaseID}/release`, {
+        headers: {
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
+        },
+        body: { delete: true },
+      }),
+    );
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({ error: "lease_state_changed" });
+    expect(releases).toBe(0);
+    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)).toMatchObject({
+      owner: "alice@example.com",
+      cloudID: "i-same-resource",
+      state: "active",
+      requestLeaseGeneration: "generation-two",
+    });
+  });
+
   it("rechecks the alias generation inside the release mutation lock", async () => {
     const storage = new MemoryStorage();
     const requestLeaseID = "cbx_abcdef123463";

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -18113,6 +18113,607 @@ describe("fleet lease identity and idle", () => {
     await expect(deletedHostReuse.json()).resolves.toMatchObject({ error: "admin_required" });
   });
 
+  it("releases a lost-response retained Mac reactivation only through its private requested-ID binding", async () => {
+    const storage = new MemoryStorage();
+    const canonicalID = "cbx_000000000110";
+    const requestLeaseID = "cbx_abcdef123460";
+    const retained = testLease({
+      id: canonicalID,
+      provider: "aws",
+      target: "macos",
+      state: "released",
+      owner: "alice@example.com",
+      org: "example-org",
+      hostId: "h-alias-success",
+      serverType: "mac2.metal",
+      providerKey: "crabbox-retained-alias",
+      cloudID: "i-retained-alias",
+      releaseDeletesServer: false,
+    });
+    storage.seed(`lease:${canonicalID}`, retained);
+    const released: LeaseRecord[] = [];
+    const fleet = testFleet(storage, {
+      aws: fakeProvider(
+        () => {
+          throw new Error("retained instance must not launch a replacement");
+        },
+        {
+          provider: "aws",
+          onReleaseLease: (lease) => {
+            released.push(structuredClone(lease));
+          },
+        },
+      ),
+    });
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const created = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers,
+        body: {
+          leaseID: requestLeaseID,
+          provider: "aws",
+          target: "macos",
+          hostId: "h-alias-success",
+          serverType: "mac2.metal",
+          capacity: { market: "on-demand" },
+          keep: true,
+          sshPublicKey: "ssh-ed25519 test",
+        },
+      }),
+    );
+    expect(created.status).toBe(201);
+    const createdBody = (await created.json()) as { lease: LeaseRecord };
+    expect(createdBody).toMatchObject({
+      lease: { id: canonicalID, cloudID: "i-retained-alias", state: "active" },
+    });
+    expect(createdBody.lease.requestLeaseGeneration).toBeUndefined();
+    const canonical = storage.value<LeaseRecord>(`lease:${canonicalID}`)!;
+    expect(canonical.requestLeaseGeneration).toMatch(/^[0-9a-f-]{36}$/);
+    expect(storage.value(`lease-request:${requestLeaseID}`)).toMatchObject({
+      version: 1,
+      requestLeaseID,
+      leaseID: canonicalID,
+      owner: "alice@example.com",
+      org: orgKeyForLabel("example-org"),
+      cloudID: "i-retained-alias",
+      generation: canonical.requestLeaseGeneration,
+    });
+
+    const getAlias = await fleet.fetch(request("GET", `/v1/leases/${requestLeaseID}`, { headers }));
+    expect(getAlias.status).toBe(404);
+    const heartbeatAlias = await fleet.fetch(
+      request("POST", `/v1/leases/${requestLeaseID}/heartbeat`, { headers }),
+    );
+    expect(heartbeatAlias.status).toBe(404);
+    const shareAlias = await fleet.fetch(
+      request("GET", `/v1/leases/${requestLeaseID}/share`, { headers }),
+    );
+    expect(shareAlias.status).toBe(404);
+    const runAlias = await fleet.fetch(
+      request("POST", "/v1/runs", {
+        headers,
+        body: { leaseID: requestLeaseID, command: ["true"] },
+      }),
+    );
+    expect(runAlias.status).toBe(201);
+    await expect(runAlias.json()).resolves.toMatchObject({
+      run: { leaseID: requestLeaseID, leaseOwners: [], provider: "hetzner" },
+    });
+
+    const release = await fleet.fetch(
+      request("POST", `/v1/leases/${requestLeaseID}/release`, {
+        headers,
+        body: { delete: true },
+      }),
+    );
+    expect(release.status).toBe(200);
+    const releaseBody = (await release.json()) as {
+      lease: LeaseRecord;
+      requestLeaseID: string;
+    };
+    expect(releaseBody).toMatchObject({
+      requestLeaseID,
+      lease: { id: canonicalID, cloudID: "i-retained-alias", state: "released" },
+    });
+    expect(releaseBody.lease.requestLeaseGeneration).toBeUndefined();
+    expect(released).toHaveLength(1);
+    expect(released[0]).toMatchObject({ id: canonicalID, cloudID: "i-retained-alias" });
+    expect(storage.value(`lease-request:${requestLeaseID}`)).toBeDefined();
+  });
+
+  it("keeps retained request IDs permanently reserved across every lease allocator", async () => {
+    const storage = new MemoryStorage();
+    const reservedID = "cbx_aaaaaaaaaaaa";
+    storage.seed(`lease-request:${reservedID}`, {
+      version: 1,
+      requestLeaseID: reservedID,
+      leaseID: "cbx_000000000111",
+      owner: "alice@example.com",
+      org: "example-org",
+      cloudID: "i-old-generation",
+      generation: "old-generation",
+      createdAt: "2026-08-01T00:00:00.000Z",
+    });
+    storage.seed(
+      "lease:cbx_000000000112",
+      testLease({
+        id: "cbx_000000000112",
+        provider: "aws",
+        target: "macos",
+        state: "released",
+        owner: "alice@example.com",
+        org: "example-org",
+        hostId: "h-reserved-alias",
+        serverType: "mac2.metal",
+        releaseDeletesServer: false,
+      }),
+    );
+    const fleet = testFleet(
+      storage,
+      { aws: fakeProvider(undefined, { provider: "aws" }), hetzner: fakeProvider() },
+      { CRABBOX_WORKSPACE_SSH_PUBLIC_KEY: "ssh-ed25519 workspace-test" },
+    );
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const ordinary = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers,
+        body: {
+          leaseID: reservedID,
+          provider: "hetzner",
+          sshPublicKey: "ssh-ed25519 ordinary",
+        },
+      }),
+    );
+    expect(ordinary.status).toBe(409);
+    const fixed = await fleet.fetch(
+      request("PUT", `/v1/leases/${reservedID}`, {
+        headers,
+        body: { provider: "hetzner", sshPublicKey: "ssh-ed25519 fixed" },
+      }),
+    );
+    expect(fixed.status).toBe(409);
+    const registered = await fleet.fetch(
+      request("PUT", `/v1/leases/${reservedID}/registration`, {
+        headers,
+        body: { provider: "external", target: "linux", host: "host.example.test" },
+      }),
+    );
+    expect(registered.status).toBe(409);
+    const retained = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers,
+        body: {
+          leaseID: reservedID,
+          provider: "aws",
+          target: "macos",
+          hostId: "h-reserved-alias",
+          serverType: "mac2.metal",
+          capacity: { market: "on-demand" },
+          keep: true,
+          sshPublicKey: "ssh-ed25519 retained",
+        },
+      }),
+    );
+    expect(retained.status).toBe(409);
+    await Promise.all(
+      [ordinary, fixed, registered, retained].map(async (response) => {
+        await expect(response.json()).resolves.toMatchObject({ error: "lease_id_conflict" });
+      }),
+    );
+
+    let allocations = 0;
+    const random = vi.spyOn(crypto, "getRandomValues").mockImplementation((array) => {
+      (array as Uint8Array).fill(allocations++ === 0 ? 0xaa : 0xbb);
+      return array;
+    });
+    const workspace = await fleet.fetch(
+      request("POST", "/v1/workspaces", {
+        headers,
+        body: {
+          id: "reserved-alias-workspace",
+          runtime: "crabbox",
+          ttlSeconds: 1800,
+          idleTimeoutSeconds: 360,
+          capabilities: { desktop: false },
+        },
+      }),
+    );
+    random.mockRestore();
+    expect(workspace.status).toBe(202);
+    await expect(workspace.json()).resolves.toMatchObject({
+      providerResourceId: "cbx_bbbbbbbbbbbb",
+    });
+  });
+
+  it.each(["canonical lease", "workspace reservation", "request binding"])(
+    "rejects retained reactivation when its requested ID collides with a %s",
+    async (collision) => {
+      const storage = new MemoryStorage();
+      const requestLeaseID = "cbx_abcdef123461";
+      storage.seed(
+        "lease:cbx_000000000113",
+        testLease({
+          id: "cbx_000000000113",
+          provider: "aws",
+          target: "macos",
+          state: "released",
+          owner: "alice@example.com",
+          org: "example-org",
+          hostId: "h-collision",
+          serverType: "mac2.metal",
+          releaseDeletesServer: false,
+        }),
+      );
+      if (collision === "canonical lease") {
+        storage.seed(`lease:${requestLeaseID}`, testLease({ id: requestLeaseID }));
+      } else if (collision === "workspace reservation") {
+        storage.seed(`workspace-lease:${requestLeaseID}`, true);
+      } else {
+        storage.seed(`lease-request:${requestLeaseID}`, {
+          version: 1,
+          requestLeaseID,
+          leaseID: "cbx_000000000114",
+          owner: "alice@example.com",
+          org: "example-org",
+          cloudID: "i-other",
+          generation: "other-generation",
+          createdAt: "2026-08-01T00:00:00.000Z",
+        });
+      }
+      const fleet = testFleet(storage, { aws: fakeProvider(undefined, { provider: "aws" }) });
+      const response = await fleet.fetch(
+        request("POST", "/v1/leases", {
+          headers: {
+            "x-crabbox-owner": "alice@example.com",
+            "x-crabbox-org": "example-org",
+          },
+          body: {
+            leaseID: requestLeaseID,
+            provider: "aws",
+            target: "macos",
+            hostId: "h-collision",
+            serverType: "mac2.metal",
+            capacity: { market: "on-demand" },
+            keep: true,
+            sshPublicKey: "ssh-ed25519 collision",
+          },
+        }),
+      );
+      expect(response.status).toBe(409);
+      await expect(response.json()).resolves.toMatchObject({ error: "lease_id_conflict" });
+      expect(storage.value<LeaseRecord>("lease:cbx_000000000113")?.state).toBe("released");
+    },
+  );
+
+  it("fails closed for stale, interrupted, foreign, and exact-conflicting release aliases", async () => {
+    const requestLeaseID = "cbx_abcdef123462";
+    const canonicalID = "cbx_000000000115";
+    const binding = {
+      version: 1,
+      requestLeaseID,
+      leaseID: canonicalID,
+      owner: "alice@example.com",
+      org: "example-org",
+      cloudID: "i-alias-guard",
+      generation: "generation-one",
+      createdAt: "2026-08-01T00:00:00.000Z",
+    };
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    await Promise.all(
+      (["stale", "interrupted", "exact-conflict"] as const).map(async (mode) => {
+        const storage = new MemoryStorage();
+        storage.seed(`lease-request:${requestLeaseID}`, binding);
+        storage.seed(
+          `lease:${canonicalID}`,
+          testLease({
+            id: canonicalID,
+            provider: "aws",
+            target: "macos",
+            owner: "alice@example.com",
+            org: "example-org",
+            cloudID: "i-alias-guard",
+            requestLeaseGeneration:
+              mode === "stale"
+                ? "generation-two"
+                : mode === "interrupted"
+                  ? undefined
+                  : "generation-one",
+          }),
+        );
+        if (mode === "exact-conflict") {
+          storage.seed(`lease:${requestLeaseID}`, testLease({ id: requestLeaseID }));
+        }
+        let releases = 0;
+        const fleet = testFleet(storage, {
+          aws: fakeProvider(undefined, { provider: "aws", onReleaseLease: () => releases++ }),
+        });
+        const response = await fleet.fetch(
+          request("POST", `/v1/leases/${requestLeaseID}/release`, {
+            headers,
+            body: { delete: true },
+          }),
+        );
+        expect(response.status).toBe(409);
+        await expect(response.json()).resolves.toMatchObject({
+          error: "lease_request_binding_conflict",
+        });
+        expect(releases).toBe(0);
+      }),
+    );
+
+    const ownerStorage = new MemoryStorage();
+    ownerStorage.seed(`lease-request:${requestLeaseID}`, binding);
+    ownerStorage.seed(
+      `lease:${canonicalID}`,
+      testLease({
+        id: canonicalID,
+        provider: "aws",
+        target: "macos",
+        owner: "alice@example.com",
+        org: "example-org",
+        cloudID: "i-alias-guard",
+        requestLeaseGeneration: "generation-one",
+      }),
+    );
+    let releases = 0;
+    const ownerFleet = testFleet(ownerStorage, {
+      aws: fakeProvider(undefined, { provider: "aws", onReleaseLease: () => releases++ }),
+    });
+    await Promise.all(
+      [
+        { "x-crabbox-owner": "bob@example.com", "x-crabbox-org": "example-org" },
+        { "x-crabbox-owner": "alice@example.com", "x-crabbox-org": "other-org" },
+      ].map(async (foreignHeaders) => {
+        const response = await ownerFleet.fetch(
+          request("POST", `/v1/leases/${requestLeaseID}/release`, {
+            headers: foreignHeaders,
+            body: { delete: true },
+          }),
+        );
+        expect(response.status).toBe(404);
+      }),
+    );
+    expect(releases).toBe(0);
+    const adminRelease = await ownerFleet.fetch(
+      request("POST", `/v1/admin/leases/${requestLeaseID}/release`, {
+        headers: {
+          "x-crabbox-admin": "true",
+          "x-crabbox-owner": "admin@example.com",
+          "x-crabbox-org": "admin-org",
+        },
+        body: { delete: true },
+      }),
+    );
+    expect(adminRelease.status).toBe(200);
+    await expect(adminRelease.json()).resolves.toMatchObject({
+      requestLeaseID,
+      lease: { id: canonicalID, state: "released" },
+    });
+    expect(releases).toBe(1);
+  });
+
+  it("leaves an interrupted binding reserved and inert when canonical generation persistence fails", async () => {
+    const storage = new HookedMemoryStorage();
+    const canonicalID = "cbx_000000000117";
+    const requestLeaseID = "cbx_abcdef123464";
+    storage.seed(
+      `lease:${canonicalID}`,
+      testLease({
+        id: canonicalID,
+        provider: "aws",
+        target: "macos",
+        state: "released",
+        owner: "alice@example.com",
+        org: "example-org",
+        hostId: "h-interrupted-binding",
+        serverType: "mac2.metal",
+        cloudID: "i-interrupted-binding",
+        releaseDeletesServer: false,
+      }),
+    );
+    storage.beforePut = async (key, value) => {
+      if (
+        key === `lease:${canonicalID}` &&
+        (value as LeaseRecord).requestLeaseGeneration !== undefined
+      ) {
+        throw new Error("injected canonical generation write failure");
+      }
+    };
+    let releases = 0;
+    const fleet = testFleet(storage, {
+      aws: fakeProvider(undefined, { provider: "aws", onReleaseLease: () => releases++ }),
+    });
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const create = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers,
+        body: {
+          leaseID: requestLeaseID,
+          provider: "aws",
+          target: "macos",
+          hostId: "h-interrupted-binding",
+          serverType: "mac2.metal",
+          capacity: { market: "on-demand" },
+          keep: true,
+          sshPublicKey: "ssh-ed25519 interrupted",
+        },
+      }),
+    );
+    expect(create.status).toBe(500);
+    expect(storage.value(`lease-request:${requestLeaseID}`)).toBeDefined();
+    const storedCanonical = storage.value<LeaseRecord>(`lease:${canonicalID}`)!;
+    expect(storedCanonical.state).toBe("released");
+    expect(storedCanonical.requestLeaseGeneration).toBeUndefined();
+    storage.beforePut = undefined;
+    const release = await fleet.fetch(
+      request("POST", `/v1/leases/${requestLeaseID}/release`, {
+        headers,
+        body: { delete: true },
+      }),
+    );
+    expect(release.status).toBe(409);
+    await expect(release.json()).resolves.toMatchObject({
+      error: "lease_request_binding_conflict",
+    });
+    expect(releases).toBe(0);
+  });
+
+  it("serializes alias release resolution with retained binding publication", async () => {
+    const storage = new HookedMemoryStorage();
+    const canonicalID = "cbx_000000000118";
+    const requestLeaseID = "cbx_abcdef123465";
+    storage.seed(
+      `lease:${canonicalID}`,
+      testLease({
+        id: canonicalID,
+        provider: "aws",
+        target: "macos",
+        state: "released",
+        owner: "alice@example.com",
+        org: "example-org",
+        hostId: "h-publication-race",
+        serverType: "mac2.metal",
+        cloudID: "i-publication-race",
+        releaseDeletesServer: false,
+      }),
+    );
+    let canonicalPutStarted!: () => void;
+    const canonicalPutStartedPromise = new Promise<void>((resolve) => {
+      canonicalPutStarted = resolve;
+    });
+    let allowCanonicalPut!: () => void;
+    const allowCanonicalPutPromise = new Promise<void>((resolve) => {
+      allowCanonicalPut = resolve;
+    });
+    storage.beforePut = async (key, value) => {
+      if (
+        key === `lease:${canonicalID}` &&
+        (value as LeaseRecord).requestLeaseGeneration !== undefined
+      ) {
+        canonicalPutStarted();
+        await allowCanonicalPutPromise;
+      }
+    };
+    let releases = 0;
+    const fleet = testFleet(storage, {
+      aws: fakeProvider(
+        () => {
+          throw new Error("retained instance must not launch a replacement");
+        },
+        { provider: "aws", onReleaseLease: () => releases++ },
+      ),
+    });
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const createPromise = fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers,
+        body: {
+          leaseID: requestLeaseID,
+          provider: "aws",
+          target: "macos",
+          hostId: "h-publication-race",
+          serverType: "mac2.metal",
+          capacity: { market: "on-demand" },
+          keep: true,
+          sshPublicKey: "ssh-ed25519 publication-race",
+        },
+      }),
+    );
+    await canonicalPutStartedPromise;
+    expect(storage.value(`lease-request:${requestLeaseID}`)).toBeDefined();
+
+    const releasePromise = fleet.fetch(
+      request("POST", `/v1/leases/${requestLeaseID}/release`, {
+        headers,
+        body: { delete: true },
+      }),
+    );
+    const earlyRelease = await Promise.race([
+      releasePromise.then(() => "completed"),
+      new Promise<string>((resolve) => setTimeout(() => resolve("waiting"), 20)),
+    ]);
+    expect(earlyRelease).toBe("waiting");
+
+    allowCanonicalPut();
+    expect((await createPromise).status).toBe(201);
+    const release = await releasePromise;
+    expect(release.status).toBe(200);
+    await expect(release.json()).resolves.toMatchObject({
+      requestLeaseID,
+      lease: { id: canonicalID, state: "released" },
+    });
+    expect(releases).toBe(1);
+  });
+
+  it("rechecks the alias generation inside the release mutation lock", async () => {
+    const storage = new MemoryStorage();
+    const requestLeaseID = "cbx_abcdef123463";
+    const canonicalID = "cbx_000000000116";
+    storage.seed(`lease-request:${requestLeaseID}`, {
+      version: 1,
+      requestLeaseID,
+      leaseID: canonicalID,
+      owner: "alice@example.com",
+      org: "example-org",
+      cloudID: "i-final-generation",
+      generation: "generation-one",
+      createdAt: "2026-08-01T00:00:00.000Z",
+    });
+    const canonical = testLease({
+      id: canonicalID,
+      provider: "aws",
+      target: "macos",
+      owner: "alice@example.com",
+      org: "example-org",
+      cloudID: "i-final-generation",
+      requestLeaseGeneration: "generation-one",
+    });
+    storage.seed(`lease:${canonicalID}`, canonical);
+    let canonicalReads = 0;
+    storage.beforeGet = async (key) => {
+      if (key === `lease:${canonicalID}` && ++canonicalReads === 3) {
+        storage.seed(`lease:${canonicalID}`, {
+          ...canonical,
+          requestLeaseGeneration: "generation-two",
+        });
+      }
+    };
+    let releases = 0;
+    const fleet = testFleet(storage, {
+      aws: fakeProvider(undefined, { provider: "aws", onReleaseLease: () => releases++ }),
+    });
+    const response = await fleet.fetch(
+      request("POST", `/v1/leases/${requestLeaseID}/release`, {
+        headers: {
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
+        },
+        body: { delete: true },
+      }),
+    );
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "lease_request_binding_conflict",
+    });
+    expect(releases).toBe(0);
+    expect(storage.value<LeaseRecord>(`lease:${canonicalID}`)?.state).toBe("active");
+  });
+
   it("reactivates a retained pinned Mac host family when the request type was defaulted", async () => {
     const storage = new MemoryStorage();
     storage.seed(


### PR DESCRIPTION
## What Problem This Solves

Canceling an ordinary coordinator-backed lease create could return before ownership of a late provider resource was durably transferred to cleanup. A client-side retry or release-by-requested-ID is not sufficient: a retained AWS Mac create may resolve to a different canonical lease ID, a colliding requested ID may already belong to another lifecycle, and the coordinator can commit state immediately before the client loses the response.

This was discovered while reproducing https://github.com/openclaw/openclaw/issues/119989.

## Why This Change Was Made

The coordinator now owns an explicit durable create-attempt protocol for ordinary `POST /v1/leases` operations:

- The CLI mints one opaque `cat_<32 lowercase hex>` attempt token and reuses it across ambiguous retries.
- The Worker reserves the requested ID and token before provider preparation, binds it to the canonical lease generation when accepted, and replays the same provisioning or active lease for concurrent or restarted same-token requests.
- `POST /v1/leases/{requested-id}/cancel-create` persists a token-bound cancellation tombstone even when cancellation arrives before creation.
- When a matching canonical lease exists, the coordinator writes released state and a durable cleanup claim before provider deletion. Cleanup and interrupted-provisioning recovery survive coordinator restarts, including provider calls that settle with an uncertain outcome and no resource identity.
- Retained AWS Mac reactivation is fenced by a fresh private generation. A stale cancellation or release cannot delete a later reactivation, and tokenless legacy POSTs retain their prior behavior without gaining unsafe requested-ID aliases.
- An unbound canceled tombstone rejects only the exact owner/org/token operation. It cannot permanently squat another tenant's fixed, registered, ordinary, or workspace lifecycle; pending and canonical-bound attempts remain global reservations.
- Fixed-ID `PUT` creates remain replay-owned and never participate in cancellation cleanup.

The CLI retries cancel-create on transport failures, deadline expiry, HTTP 408, HTTP 429, and HTTP 5xx, then makes one final request on a fresh bounded context. All create HTTP 5xx responses are treated as ambiguous. Stale-instance retries use the token-bound cancellation path rather than release-by-ID.

## Compatibility And Rollout

Tokenless POSTs from older CLIs remain supported with their previous behavior. Deploy the coordinator before distributing a CLI that sends create-attempt tokens. Once tokenized creates begin, do not roll the coordinator back to a version that ignores `create-attempt:*` records. A new CLI against an old coordinator fails cancellation closed; it does not fall back to unsafe ID-only release.

No configuration or secret changes are required.

## User Impact

Canceled or ambiguously failed ordinary coordinator creates no longer leave an unowned paid resource behind. Exact retries converge on one canonical lease, cancellation cannot delete an older colliding lease, and cleanup resumes after process, Node runtime, or Durable Object restart.

## Evidence

Exact pushed head: `81bd166943db7838de1dedd6148a6618dbe13d77`

- `go test -race ./internal/cli -timeout 15m` — passed in 452.406s.
- All remaining Go packages passed under the race detector with a 15-minute package timeout.
- `go vet ./...`
- `go build -trimpath -o /tmp/crabbox-pr1254 ./cmd/crabbox`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm run check:node --prefix worker`
- `npm test --prefix worker` — 1,220 passed, 3 skipped.
- `npm run build --prefix worker`
- `node scripts/build-docs-site.mjs`
- `git diff --cached --check`
- Final Codex autoreview: clean; no accepted or actionable findings.

Focused fault coverage includes cancel-before-create, cross-tenant tombstone replacement, concurrent same-token replay, canonical-ID polling, stale-instance retry, transient cancel retry and final-attempt boundaries, retained-Mac publication and generation races, cleanup-claim write ordering, late provider cleanup evidence, same-runtime settled-outcome recovery, and restart recovery for canceled or failed-uncertain pre-identity creates.

## Credit

This repairs and substantially extends the original contribution from @fuller-stack-dev. Their original commit remains in the branch, and the maintainer follow-up commits retain co-author credit.
