### PR TITLE
chore(release): authorize v0.41.0 source

### DIFF
--- a/release/records/v0.41.0.json
+++ b/release/records/v0.41.0.json
@@ -2,8 +2,7 @@
   "schemaVersion": 1,
   "repository": "openclaw/crabbox",
   "tag": "v0.41.0",
-  "tagObject": "PENDING_AFTER_SIGNED_TAG",
-  "sourceCommit": "PENDING_AFTER_PREPARATION_MERGE",
-  "publicationStatus": "blocked",
-  "blocker": "Pending signed v0.41.0 tag object and peeled source commit; update both fields and set publicationStatus to ready only after the tag is signed and verified."
+  "tagObject": "61c086742ccf39d8f2777bec8467484946fb656f",
+  "sourceCommit": "34877fdd2cc86150d8fe3c431ad6d11597421b25",
+  "publicationStatus": "ready"
 }


### PR DESCRIPTION
## What Problem This Solves

The protected v0.41.0 release record is intentionally blocked until the signed
tag object and peeled source commit are known.

## Why This Change Was Made

Records the immutable signed tag object
`61c086742ccf39d8f2777bec8467484946fb656f` and source commit
`34877fdd2cc86150d8fe3c431ad6d11597421b25`, then marks the release source ready.
The tag remains unchanged and is not pushed by this PR.

## User Impact

Release operators can build and verify the v0.41.0 candidate against a protected,
reviewed source record.

## Evidence

- Signed annotated tag `v0.41.0` verifies against `.github/release-allowed-signers`.
- `scripts/verify-release-source.sh` passes with `REQUIRE_PUBLISHABLE=1`.
- `git diff --check` passes.
- Fresh autoreview: clean, no actionable findings.
