### PR TITLE
fix: make fixed lease IDs idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.41.1 - Unreleased
+
+### Fixed
+
+- Made caller-supplied `warmup --lease-id` creation idempotent across direct AWS and coordinator restarts, with exact-PUT coordinator recovery, exactly-once post-lock acquisition acknowledgment, at-most-once and attempt-attested direct AWS launch reconciliation, explicit SSH-CIDR intent binding, downgrade-safe `aws-fixed-v1` claims, stable conflicts on request drift, and compact terminal tombstones that prevent operation-ID reuse after release or missing-resource cleanup.
+
 ## 0.41.0 - 2026-08-06
 
 ### Added

--- a/docs/commands/warmup.md
+++ b/docs/commands/warmup.md
@@ -14,6 +14,7 @@ crabbox warmup --provider azure --arch arm64 --class fast
 crabbox warmup --browser
 crabbox warmup --tailscale
 crabbox warmup --slug update-flow-smoke
+crabbox warmup --provider aws --lease-id cbx_abcdef123456 --slug update-flow-smoke
 crabbox warmup --pond alpha --slug db
 crabbox warmup --provider aws --target windows --desktop
 crabbox warmup --provider azure --target windows
@@ -54,6 +55,30 @@ Warmup records a local claim binding the lease to the current repo checkout. Use
 
 `--slug <slug>` requests a human-chosen slug for a new lease. Crabbox normalizes
 it and may append a short suffix if an active lease already uses that slug.
+
+`--lease-id cbx_<12 lowercase hex>` is the automation idempotency contract for
+providers that explicitly support fixed identities. Direct AWS and managed
+coordinator leases accept it. Replaying the same normalized create intent
+returns or joins the same lease, including after the creating process loses its
+response. Reusing the ID with a different provider, slug request, SSH key,
+machine shape, capabilities, lifetime, or other immutable create input fails
+with `lease_id_conflict` before another provider create. Slugs remain display
+aliases and are never used as the idempotency key.
+
+Coordinator-backed fixed-ID creation uses a versioned `PUT /v1/leases/<id>`
+route. An older coordinator therefore rejects the request before provisioning;
+the CLI never falls back to slug lookup or legacy create behavior. After an
+ambiguous fixed create response, the CLI repeats that exact PUT to atomically
+confirm the same intent before it may poll lease status with GET.
+
+A fixed lease ID is single-use. If direct AWS acquisition completed and its
+bound instance later disappears, replay fails closed instead of relying on EC2
+client-token retention. Successful stop and missing-resource cleanup replace
+the live local claim with a compact terminal tombstone, so the ID remains
+rejected after release. Use a new operation ID for every later lease.
+If an AWS launch attempt was durably recorded but its instance is not yet
+visible, replay fails closed without resubmitting it; retry later to adopt the
+resource after provider inventory converges.
 
 `--pond <name>` tags a new lease into a named pond (stored as a reserved
 provider label); `crabbox list --pond <name>` filters by it. When combined with
@@ -259,6 +284,7 @@ warmup, because it also dispatches the workflow and waits for the ready marker.
 --type <provider-type>             provider server/instance type
 --market spot|on-demand            capacity market (AWS)
 --slug <slug>                      request a friendly slug for a new lease
+--lease-id cbx_<12 lowercase hex> fixed lease ID for idempotent automation
 --pond <name>                      tag this lease into a pond
 --expose <port>                    declare a TCP port reachable over the SSH-mesh plane; repeatable
 --cache-volume [name=]key:path     require a provider-backed cache volume; repeatable

--- a/docs/features/coordinator.md
+++ b/docs/features/coordinator.md
@@ -118,6 +118,7 @@ GET    /v1/whoami
 GET    /v1/providers/{provider}/readiness
 GET    /v1/control                       (websocket: run events + heartbeats)
 POST   /v1/leases
+PUT    /v1/leases/{canonical-id}       (fixed-ID idempotent create)
 PUT    /v1/leases/{id}/registration
 GET    /v1/leases
 GET    /v1/leases/{id-or-slug}
@@ -144,6 +145,18 @@ GET    /v1/adapters/{adapter-id}
 GET    /v1/adapters/{adapter-id}/agent    (websocket; one-time ticket auth)
 *      /v1/adapters/{adapter-id}/proxy/v1/workspaces/...
 ```
+
+The fixed-ID `PUT` route is fail-closed and does not replace legacy `POST`.
+It atomically reserves a versioned normalized immutable request hash before
+provider work. An identical owner-scoped replay returns an active lease or the
+same provisioning record; request drift and terminal-ID reuse return
+`lease_id_conflict` without invoking the provider. CLIs using `--lease-id`
+poll a provisioning replay until it becomes active or terminal. Coordinators
+that predate this route return not found before any create side effect.
+If the PUT response is ambiguous, the CLI repeats the full identical PUT until
+the coordinator atomically confirms the same stored intent or returns a
+conflict/definite error. Public GET is used only after that PUT confirmation,
+never to adopt an unverified fixed-ID record.
 
 Registration accepts generic provider and SSH metadata. Repeating the same
 owner/org/id/provider tuple refreshes it and reactivates an expired record.

--- a/docs/features/identifiers.md
+++ b/docs/features/identifiers.md
@@ -25,12 +25,35 @@ characters. `newLeaseID` mints one from 6 random bytes, and the regex
 `^cbx_[a-f0-9]{12}$` (`isCanonicalLeaseID`) decides whether a value is a
 canonical ID; anything that fails the pattern is treated as a slug.
 
-The CLI mints a provisional lease ID before calling the broker. The broker may
-return a different final ID (when the Worker dedupes a retried request, for
-example). When that happens, the CLI moves the local SSH key directory from the
-provisional ID to the final ID with `MoveStoredTestboxKey` (an atomic
-`os.Rename` of the per-lease directory) and re-keys the claim and other
-references accordingly.
+The CLI normally mints a provisional lease ID before calling the broker. A
+broker may return a different final ID, in which case the CLI moves the local
+SSH key directory from the provisional ID to the final ID with
+`MoveStoredTestboxKey` and re-keys the claim and other references accordingly.
+
+Automation may instead supply the canonical ID with `warmup --lease-id`. For
+direct AWS and managed coordinator leases, that ID is an immutable create
+identity: an identical semantic replay returns the same lease, while intent
+drift returns `lease_id_conflict`. The coordinator durably stores a versioned
+normalized request hash. Direct AWS durably stores the intent and current
+resolved EC2 attempt in the normal lease claim before `RunInstances`, then uses
+a deterministic regional/zonal client token. Neither path uses the slug to
+decide replay ownership.
+
+After the direct AWS launch attempt is durable, Crabbox never submits that
+attempt again. An ambiguous replay with no visible tagged instance fails closed;
+a later replay can adopt the one instance after inventory converges only when
+its non-secret attempt-attestation tags and provider-reported launch identity
+match the persisted attempt exactly. Fixed AWS
+claims use the downgrade-safe local discriminator `aws-fixed-v1`; current
+clients map it to runtime AWS, while older clients skip/refuse it.
+
+Fixed IDs are single-use operation identities. Direct AWS keeps a compact
+terminal claim tombstone after successful release or exact missing-resource
+cleanup. Tombstones contain only the ID, slug, provider scope, versioned intent
+hash, timestamps, and terminal state; automatic AWS cleanup never prunes them.
+There is no time-based reuse window. Explicitly deleting local Crabbox claim
+state forfeits this replay protection, so automation must instead mint a new
+operation ID.
 
 Provider resources reference the lease ID through a Crabbox label (the label key
 is literally `lease`):
@@ -67,6 +90,7 @@ crabbox checkpoint fork chk_abc123def456 --slug update-flow-smoke
 
 `--slug` is creation-time metadata, not a rename. It is honored only when
 Crabbox is creating a new lease; existing leases keep their assigned slug.
+It is never an operation or idempotency key.
 
 Slugs are normalized everywhere they are accepted. `normalizeLeaseSlug`
 lowercases, keeps only `[a-z0-9]`, collapses every other run of characters into

--- a/docs/features/ssh-keys.md
+++ b/docs/features/ssh-keys.md
@@ -16,6 +16,9 @@ When a lease is created, the CLI runs `ssh-keygen` to produce a key it stores
 locally. The key type is `ed25519` for most leases, and `rsa` (4096-bit) only
 for AWS and Azure Windows targets, where the platform requires RSA. Generation
 is idempotent: if a key already exists for the lease ID, it is reused as-is.
+Fixed-ID AWS acquisition holds the normal durable claim lock while creating or
+reusing this key, so concurrent replays cannot race two different keypairs into
+one EC2 idempotency identity.
 
 Local key storage lives under the Crabbox user config directory, outside the
 repository:

--- a/docs/providers/aws.md
+++ b/docs/providers/aws.md
@@ -41,11 +41,50 @@ crabbox run --provider aws --market on-demand -- pnpm check
 crabbox warmup --provider aws --target windows --desktop
 crabbox warmup --provider aws --target windows --windows-mode wsl2
 crabbox warmup --provider aws --target macos --desktop --market on-demand
+crabbox warmup --provider aws --lease-id cbx_abcdef123456 --slug operation-display
 ```
 
 `--type` is exact: if EC2 rejects the requested type, Crabbox fails rather than
 silently substituting another instance. Use `--class` when you want capacity
 fallback across instance families.
+
+### Fixed-ID replay
+
+`warmup --lease-id cbx_<12 lowercase hex>` makes direct AWS acquisition
+idempotent across process restarts. Crabbox writes the normalized create intent
+to the ordinary durable lease claim under its existing cross-process lock
+before any provider mutation. Each resolved launch attempt records its exact
+region or availability zone, subnet, type, market, AMI, security group, keypair,
+stable timestamps, parameter hash, and a deterministic per-attempt EC2 client
+token before `RunInstances`.
+
+An ambiguous response remains pinned to that attempt. Replay first reconciles
+all matching Crabbox-tagged resources, fails closed if more than one exists,
+and fails closed without another `RunInstances` call while the resource is not
+visible. The initial request writes non-secret attempt-attestation tags, and a
+later replay adopts a visible instance only when its provider identity and every
+attempt tag match the persisted region/AZ/subnet/type/market/image/security-group/
+host/key/token tuple. This deliberately
+accepts a false-negative if the process crashes after persisting the attempt but
+before sending the network request, preserving at-most-once launch semantics.
+Capacity fallback advances only after a definite no-resource response clears
+the attempt during the original invocation. A changed create intent returns
+`lease_id_conflict`; a matching slug alone never authorizes adoption. Once
+acquisition is marked complete, a missing bound instance is also a terminal
+conflict rather than permission to call `RunInstances` again.
+
+Acknowledged stop and exact missing-resource cleanup replace the live claim
+with a compact terminal tombstone containing the versioned fingerprint,
+provider scope, slug, and terminal state. Automatic AWS cleanup does not prune
+these tombstones and there is no time-based operation-ID reuse window. Explicit
+local claim deletion forfeits this guarantee; normal automation must always use
+a new operation ID for a later lease.
+
+Fixed claims and tombstones use the local provider discriminator
+`aws-fixed-v1`. Current Crabbox resolves that marker to runtime provider AWS,
+while older clients see an unknown provider and therefore skip or refuse
+destructive AWS claim cleanup instead of erasing fixed identity state. Cloud
+resource provider tags remain `aws`.
 
 ### Instance classes
 

--- a/docs/source-map.md
+++ b/docs/source-map.md
@@ -73,6 +73,8 @@ Crabbox has three implementation surfaces:
 - Canonical lease IDs (`cbx_<12 hex>`) and per-lease SSH key paths: `internal/cli/lease.go`
 - Friendly slug generation, normalization, and collision handling: `internal/cli/slug.go`
 - Repo-local claim files and `--reclaim` checks: `internal/cli/claim.go`
+- Fixed-ID direct acquisition intent, cross-process locking, and durable EC2
+  attempt checkpoints: `internal/cli/claim.go`, `internal/providers/aws/backend.go`
 - Direct-provider labels, safe label encoding, idle-touch labels, TTL cap math: `internal/cli/provider_labels.go`
 - Lease status/inspect/list/share/unshare/stop/cleanup commands: `internal/cli/status.go`, `internal/cli/inspect.go`, `internal/cli/pool.go`, `internal/cli/share.go`, `internal/cli/rescue.go`
 - Coordinator client request/response structs, same-origin credential redirect guard, curl fallback, slug lookup, heartbeats, usage, and run history: `internal/cli/coordinator.go`, `internal/cli/provider_coordinator.go`

--- a/internal/cli/aws.go
+++ b/internal/cli/aws.go
@@ -10,6 +10,7 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
@@ -47,6 +48,31 @@ type AWSClient struct {
 	serviceQuotas *servicequotas.Client
 	sts           *sts.Client
 	region        string
+}
+
+type AWSLaunchAttempt struct {
+	Region           string `json:"region"`
+	AvailabilityZone string `json:"availabilityZone,omitempty"`
+	SubnetID         string `json:"subnetID,omitempty"`
+	ServerType       string `json:"serverType"`
+	Market           string `json:"market"`
+	ImageID          string `json:"imageID"`
+	SecurityGroupID  string `json:"securityGroupID"`
+	HostID           string `json:"hostID,omitempty"`
+	KeyPairID        string `json:"keyPairID,omitempty"`
+	ClientToken      string `json:"clientToken"`
+	ParametersSHA256 string `json:"parametersSHA256"`
+}
+
+type AWSFixedCreateControl struct {
+	CreatedAt         time.Time
+	IntentFingerprint string
+	AccountID         string
+	KeyPairID         string
+	PinnedAttempt     *AWSLaunchAttempt
+	FailedTokens      map[string]bool
+	BeforeAttempt     func(AWSLaunchAttempt) error
+	DefiniteFailure   func(AWSLaunchAttempt) error
 }
 
 func newAWSClient(ctx context.Context, cfg Config) (*AWSClient, error) {
@@ -443,6 +469,13 @@ func (c *AWSClient) DeleteCleanupSSHKeyID(ctx context.Context, keyPairID string)
 }
 
 func (c *AWSClient) CreateServerWithFallback(ctx context.Context, cfg Config, publicKey, leaseID, slug string, keep bool, logf func(string, ...any)) (Server, Config, error) {
+	return c.CreateServerWithFallbackControl(ctx, cfg, publicKey, leaseID, slug, keep, logf, nil)
+}
+
+func (c *AWSClient) CreateServerWithFallbackControl(ctx context.Context, cfg Config, publicKey, leaseID, slug string, keep bool, logf func(string, ...any), control *AWSFixedCreateControl) (Server, Config, error) {
+	if control != nil && control.PinnedAttempt != nil {
+		return Server{}, cfg, exit(4, "lease_id_conflict: fixed AWS lease %s has an unresolved launch attempt", leaseID)
+	}
 	regions := awsRegionCandidates(cfg, c.region)
 	if len(regions) > 1 {
 		var errs []error
@@ -461,21 +494,29 @@ func (c *AWSClient) CreateServerWithFallback(ctx context.Context, cfg Config, pu
 			if logf != nil && region != c.region {
 				logf("fallback provisioning region=%s after capacity/quota rejection\n", region)
 			}
-			server, resolved, err := client.createServerWithFallbackInRegion(ctx, next, publicKey, leaseID, slug, keep, logf)
+			server, resolved, err := client.createServerWithFallbackInRegion(ctx, next, publicKey, leaseID, slug, keep, logf, control)
 			if err == nil {
 				return server, resolved, nil
 			}
 			errs = append(errs, fmt.Errorf("%s: %w", region, err))
-			if !isRetryableAWSRegionProvisioningError(err) {
+			if !shouldRetryAWSRegionAfterCreateError(err, control) {
 				return Server{}, resolved, joinErrors(errs)
 			}
 		}
 		return Server{}, cfg, joinErrors(errs)
 	}
-	return c.createServerWithFallbackInRegion(ctx, cfg, publicKey, leaseID, slug, keep, logf)
+	return c.createServerWithFallbackInRegion(ctx, cfg, publicKey, leaseID, slug, keep, logf, control)
 }
 
-func (c *AWSClient) createServerWithFallbackInRegion(ctx context.Context, cfg Config, publicKey, leaseID, slug string, keep bool, logf func(string, ...any)) (result Server, resolved Config, resultErr error) {
+func shouldRetryAWSRegionAfterCreateError(err error, control *AWSFixedCreateControl) bool {
+	return (control == nil || control.PinnedAttempt == nil) && isRetryableAWSRegionProvisioningError(err)
+}
+
+func (c *AWSClient) createServerWithFallbackInRegion(ctx context.Context, cfg Config, publicKey, leaseID, slug string, keep bool, logf func(string, ...any), controls ...*AWSFixedCreateControl) (result Server, resolved Config, resultErr error) {
+	var control *AWSFixedCreateControl
+	if len(controls) > 0 {
+		control = controls[0]
+	}
 	if cfg.ProviderKey == "" {
 		cfg.ProviderKey = "crabbox-steipete"
 	}
@@ -483,8 +524,11 @@ func (c *AWSClient) createServerWithFallbackInRegion(ctx context.Context, cfg Co
 	if err != nil {
 		return Server{}, cfg, err
 	}
+	if control != nil {
+		control.KeyPairID = keyBinding.ID
+	}
 	defer func() {
-		if resultErr == nil || !keyBinding.Created {
+		if resultErr == nil || !keyBinding.Created || (control != nil && control.PinnedAttempt != nil) {
 			return
 		}
 		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Minute)
@@ -498,6 +542,9 @@ func (c *AWSClient) createServerWithFallbackInRegion(ctx context.Context, cfg Co
 			server.Labels["aws_key_pair_id"] = keyBinding.ID
 		}
 		return server
+	}
+	if control != nil && control.PinnedAttempt != nil {
+		return Server{}, cfg, exit(4, "lease_id_conflict: fixed AWS lease %s has an unresolved launch attempt", leaseID)
 	}
 	staticImageID := ""
 	if cfg.TargetOS != targetMacOS || cfg.AWSAMI != "" {
@@ -528,7 +575,7 @@ func (c *AWSClient) createServerWithFallbackInRegion(ctx context.Context, cfg Co
 			}
 			continue
 		}
-		server, err := c.createServer(ctx, next, publicKey, leaseID, slug, keep, imageID, securityGroupID, useSpot)
+		server, err := c.createServer(ctx, next, publicKey, leaseID, slug, keep, imageID, securityGroupID, useSpot, control)
 		if err == nil {
 			return bindCleanupKey(server), next, nil
 		}
@@ -552,7 +599,7 @@ func (c *AWSClient) createServerWithFallbackInRegion(ctx context.Context, cfg Co
 				}
 				continue
 			}
-			server, err := c.createServer(ctx, next, publicKey, leaseID, slug, keep, imageID, securityGroupID, false)
+			server, err := c.createServer(ctx, next, publicKey, leaseID, slug, keep, imageID, securityGroupID, false, control)
 			if err == nil {
 				return bindCleanupKey(server), next, nil
 			}
@@ -575,15 +622,25 @@ func (c *AWSClient) resolveLaunchAMI(ctx context.Context, cfg Config, staticImag
 	return c.resolveAMI(ctx, cfg)
 }
 
-func (c *AWSClient) createServer(ctx context.Context, cfg Config, publicKey, leaseID, slug string, keep bool, imageID, securityGroupID string, spot bool) (Server, error) {
+func (c *AWSClient) createServer(ctx context.Context, cfg Config, publicKey, leaseID, slug string, keep bool, imageID, securityGroupID string, spot bool, control *AWSFixedCreateControl) (Server, error) {
 	_ = publicKey
 	name := leaseProviderName(leaseID, slug)
 	if cfg.Tailscale.Enabled && cfg.Tailscale.Hostname == "" {
 		cfg.Tailscale.Hostname = renderTailscaleHostname(cfg.Tailscale.HostnameTemplate, leaseID, slug, cfg.Provider)
 	}
 	now := time.Now().UTC()
+	if control != nil && !control.CreatedAt.IsZero() {
+		now = control.CreatedAt.UTC()
+	}
 	labels := directLeaseLabels(cfg, leaseID, slug, "aws", mapMarket(spot), keep, now)
 	labels["aws_region"] = cfg.AWSRegion
+	if control != nil {
+		labels["fixed_intent_sha256"] = control.IntentFingerprint
+		labels["aws_account_id"] = control.AccountID
+		if control.KeyPairID != "" {
+			labels["aws_key_pair_id"] = control.KeyPairID
+		}
+	}
 	userData := base64.StdEncoding.EncodeToString([]byte(awsUserData(cfg, publicKey)))
 	rootGB := cfg.AWSRootGB
 	if rootGB <= 0 {
@@ -591,12 +648,9 @@ func (c *AWSClient) createServer(ctx context.Context, cfg Config, publicKey, lea
 	}
 	one := int32(1)
 	rootDevice := "/dev/sda1"
-	tagSpecifications := []types.TagSpecification{
-		{ResourceType: types.ResourceTypeInstance, Tags: awsTagsWithName(labels, name)},
-		{ResourceType: types.ResourceTypeVolume, Tags: awsTagsWithName(labels, name)},
-	}
-	if spot {
-		tagSpecifications = append(tagSpecifications, types.TagSpecification{ResourceType: types.ResourceTypeSpotInstancesRequest, Tags: awsTagsWithName(labels, name)})
+	clientToken := leaseID
+	if control != nil {
+		clientToken = awsFixedAttemptClientToken(leaseID, cfg, imageID, securityGroupID, spot)
 	}
 	input := &ec2.RunInstancesInput{
 		BlockDeviceMappings: []types.BlockDeviceMapping{
@@ -610,15 +664,14 @@ func (c *AWSClient) createServer(ctx context.Context, cfg Config, publicKey, lea
 				},
 			},
 		},
-		ClientToken:       aws.String(leaseID),
-		ImageId:           aws.String(imageID),
-		InstanceType:      types.InstanceType(cfg.ServerType),
-		KeyName:           aws.String(cfg.ProviderKey),
-		MaxCount:          aws.Int32(one),
-		MinCount:          aws.Int32(one),
-		SecurityGroupIds:  []string{securityGroupID},
-		TagSpecifications: tagSpecifications,
-		UserData:          aws.String(userData),
+		ClientToken:      aws.String(clientToken),
+		ImageId:          aws.String(imageID),
+		InstanceType:     types.InstanceType(cfg.ServerType),
+		KeyName:          aws.String(cfg.ProviderKey),
+		MaxCount:         aws.Int32(one),
+		MinCount:         aws.Int32(one),
+		SecurityGroupIds: []string{securityGroupID},
+		UserData:         aws.String(userData),
 	}
 	if spot {
 		input.InstanceMarketOptions = &types.InstanceMarketOptionsRequest{
@@ -656,14 +709,105 @@ func (c *AWSClient) createServer(ctx context.Context, cfg Config, publicKey, lea
 			input.Placement = &types.Placement{AvailabilityZone: aws.String(zone)}
 		}
 	}
+	attempt := AWSLaunchAttempt{
+		Region:          cfg.AWSRegion,
+		SubnetID:        cfg.AWSSubnetID,
+		ServerType:      cfg.ServerType,
+		Market:          mapMarket(spot),
+		ImageID:         imageID,
+		SecurityGroupID: securityGroupID,
+		HostID:          cfg.HostID,
+		KeyPairID:       controlKeyPairID(control),
+		ClientToken:     clientToken,
+	}
+	if input.Placement != nil {
+		attempt.AvailabilityZone = aws.ToString(input.Placement.AvailabilityZone)
+		if attempt.HostID == "" {
+			attempt.HostID = aws.ToString(input.Placement.HostId)
+		}
+	}
+	if control != nil {
+		for key, value := range AWSFixedAttemptAttestationLabels(attempt) {
+			labels[key] = value
+		}
+	}
+	tagSpecifications := []types.TagSpecification{
+		{ResourceType: types.ResourceTypeInstance, Tags: awsTagsWithName(labels, name)},
+		{ResourceType: types.ResourceTypeVolume, Tags: awsTagsWithName(labels, name)},
+	}
+	if spot {
+		tagSpecifications = append(tagSpecifications, types.TagSpecification{ResourceType: types.ResourceTypeSpotInstancesRequest, Tags: awsTagsWithName(labels, name)})
+	}
+	input.TagSpecifications = tagSpecifications
+	parametersSHA256, err := awsRunInstancesParametersSHA256(input)
+	if err != nil {
+		return Server{}, err
+	}
+	attempt.ParametersSHA256 = parametersSHA256
+	if control != nil {
+		if control.FailedTokens[attempt.ClientToken] {
+			return Server{}, fmt.Errorf("fixed AWS launch attempt %s already failed without a resource: InsufficientInstanceCapacity", attempt.ClientToken)
+		}
+		if control.PinnedAttempt != nil {
+			return Server{}, exit(4, "lease_id_conflict: fixed AWS lease %s has an unresolved launch attempt", leaseID)
+		} else if control.BeforeAttempt != nil {
+			if err := control.BeforeAttempt(attempt); err != nil {
+				return Server{}, err
+			}
+			control.PinnedAttempt = &attempt
+		}
+	}
 	out, err := c.ec2.RunInstances(ctx, input)
 	if err != nil {
+		if control != nil && isRetryableAWSProvisioningError(err) && control.DefiniteFailure != nil {
+			if persistErr := control.DefiniteFailure(attempt); persistErr != nil {
+				return Server{}, errors.Join(err, persistErr)
+			}
+			control.PinnedAttempt = nil
+		}
 		return Server{}, err
 	}
 	if len(out.Instances) == 0 {
 		return Server{}, exit(5, "aws returned no instances")
 	}
 	return awsInstanceToServer(out.Instances[0]), nil
+}
+
+func controlKeyPairID(control *AWSFixedCreateControl) string {
+	if control == nil {
+		return ""
+	}
+	return control.KeyPairID
+}
+
+func awsFixedAttemptClientToken(leaseID string, cfg Config, imageID, securityGroupID string, spot bool) string {
+	hostID := cfg.HostID
+	if hostID == "" {
+		hostID = cfg.AWSMacHostID
+	}
+	material := strings.Join([]string{
+		"crabbox-aws-fixed-attempt-v1",
+		leaseID,
+		cfg.AWSRegion,
+		awsAvailabilityZoneForRegion(cfg, cfg.AWSRegion),
+		cfg.AWSSubnetID,
+		cfg.ServerType,
+		mapMarket(spot),
+		imageID,
+		securityGroupID,
+		hostID,
+	}, "\x00")
+	digest := sha256.Sum256([]byte(material))
+	return "cbx-" + hex.EncodeToString(digest[:])[:60]
+}
+
+func awsRunInstancesParametersSHA256(input *ec2.RunInstancesInput) (string, error) {
+	data, err := json.Marshal(input)
+	if err != nil {
+		return "", fmt.Errorf("encode AWS RunInstances parameters: %w", err)
+	}
+	digest := sha256.Sum256(data)
+	return hex.EncodeToString(digest[:]), nil
 }
 
 func mapMarket(spot bool) string {
@@ -1224,6 +1368,21 @@ func awsInstanceToServer(instance types.Instance) Server {
 			name = value
 		}
 	}
+	securityGroupIDs := make([]string, 0, len(instance.SecurityGroups))
+	for _, group := range instance.SecurityGroups {
+		if groupID := strings.TrimSpace(aws.ToString(group.GroupId)); groupID != "" {
+			securityGroupIDs = append(securityGroupIDs, groupID)
+		}
+	}
+	sort.Strings(securityGroupIDs)
+	market := "on-demand"
+	if instance.InstanceLifecycle == types.InstanceLifecycleTypeSpot {
+		market = "spot"
+	}
+	availabilityZone := ""
+	if instance.Placement != nil {
+		availabilityZone = aws.ToString(instance.Placement.AvailabilityZone)
+	}
 	server := Server{
 		CloudID:  aws.ToString(instance.InstanceId),
 		Provider: "aws",
@@ -1232,6 +1391,11 @@ func awsInstanceToServer(instance types.Instance) Server {
 		Labels:   labels,
 		ProviderMetadata: map[string]any{
 			"instanceProfileAttached": instance.IamInstanceProfile != nil,
+			"availabilityZone":        availabilityZone,
+			"subnetID":                aws.ToString(instance.SubnetId),
+			"imageID":                 aws.ToString(instance.ImageId),
+			"securityGroupIDs":        securityGroupIDs,
+			"market":                  market,
 		},
 	}
 	if instance.Placement != nil {

--- a/internal/cli/aws_fixed_attempt.go
+++ b/internal/cli/aws_fixed_attempt.go
@@ -1,0 +1,95 @@
+package cli
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+const (
+	awsFixedAttemptTagSHA256      = "fixed_attempt_sha256"
+	awsFixedAttemptTagRegion      = "fixed_attempt_region"
+	awsFixedAttemptTagAZ          = "fixed_attempt_az"
+	awsFixedAttemptTagSubnet      = "fixed_attempt_subnet"
+	awsFixedAttemptTagType        = "fixed_attempt_type"
+	awsFixedAttemptTagMarket      = "fixed_attempt_market"
+	awsFixedAttemptTagImage       = "fixed_attempt_image"
+	awsFixedAttemptTagSG          = "fixed_attempt_sg"
+	awsFixedAttemptTagHost        = "fixed_attempt_host"
+	awsFixedAttemptTagKeyPair     = "fixed_attempt_key_pair"
+	awsFixedAttemptTagTokenSHA256 = "fixed_attempt_token_sha256"
+)
+
+type awsFixedAttemptAttestation struct {
+	Region            string `json:"region"`
+	AvailabilityZone  string `json:"availabilityZone"`
+	SubnetID          string `json:"subnetID"`
+	ServerType        string `json:"serverType"`
+	Market            string `json:"market"`
+	ImageID           string `json:"imageID"`
+	SecurityGroupID   string `json:"securityGroupID"`
+	HostID            string `json:"hostID"`
+	KeyPairID         string `json:"keyPairID"`
+	ClientTokenSHA256 string `json:"clientTokenSHA256"`
+}
+
+func AWSFixedAttemptAttestationLabels(attempt AWSLaunchAttempt) map[string]string {
+	attestation := awsFixedAttemptAttestationFor(attempt)
+	digest := sha256.Sum256([]byte(strings.Join([]string{
+		"crabbox-fixed-aws-attempt-attestation-v1",
+		attestation.Region,
+		attestation.AvailabilityZone,
+		attestation.SubnetID,
+		attestation.ServerType,
+		attestation.Market,
+		attestation.ImageID,
+		attestation.SecurityGroupID,
+		attestation.HostID,
+		attestation.KeyPairID,
+		attestation.ClientTokenSHA256,
+	}, "\x00")))
+	return map[string]string{
+		awsFixedAttemptTagSHA256:      hex.EncodeToString(digest[:]),
+		awsFixedAttemptTagRegion:      attestation.Region,
+		awsFixedAttemptTagAZ:          attestation.AvailabilityZone,
+		awsFixedAttemptTagSubnet:      attestation.SubnetID,
+		awsFixedAttemptTagType:        attestation.ServerType,
+		awsFixedAttemptTagMarket:      attestation.Market,
+		awsFixedAttemptTagImage:       attestation.ImageID,
+		awsFixedAttemptTagSG:          attestation.SecurityGroupID,
+		awsFixedAttemptTagHost:        attestation.HostID,
+		awsFixedAttemptTagKeyPair:     attestation.KeyPairID,
+		awsFixedAttemptTagTokenSHA256: attestation.ClientTokenSHA256,
+	}
+}
+
+func ValidateAWSFixedAttemptAttestation(labels map[string]string, attempt AWSLaunchAttempt) error {
+	expected := AWSFixedAttemptAttestationLabels(attempt)
+	for key, expectedValue := range expected {
+		actualValue, ok := labels[key]
+		if !ok {
+			return fmt.Errorf("missing AWS fixed attempt tag %s", key)
+		}
+		if actualValue != expectedValue {
+			return fmt.Errorf("AWS fixed attempt tag %s=%q does not match %q", key, actualValue, expectedValue)
+		}
+	}
+	return nil
+}
+
+func awsFixedAttemptAttestationFor(attempt AWSLaunchAttempt) awsFixedAttemptAttestation {
+	clientTokenDigest := sha256.Sum256([]byte(strings.TrimSpace(attempt.ClientToken)))
+	return awsFixedAttemptAttestation{
+		Region:            strings.TrimSpace(attempt.Region),
+		AvailabilityZone:  strings.TrimSpace(attempt.AvailabilityZone),
+		SubnetID:          strings.TrimSpace(attempt.SubnetID),
+		ServerType:        strings.TrimSpace(attempt.ServerType),
+		Market:            strings.TrimSpace(attempt.Market),
+		ImageID:           strings.TrimSpace(attempt.ImageID),
+		SecurityGroupID:   strings.TrimSpace(attempt.SecurityGroupID),
+		HostID:            strings.TrimSpace(attempt.HostID),
+		KeyPairID:         strings.TrimSpace(attempt.KeyPairID),
+		ClientTokenSHA256: hex.EncodeToString(clientTokenDigest[:]),
+	}
+}

--- a/internal/cli/aws_fixed_create_intent.go
+++ b/internal/cli/aws_fixed_create_intent.go
@@ -1,0 +1,315 @@
+package cli
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const FixedAWSCreateIntentVersion = 2
+
+type FixedAWSCreateIntentRequest struct {
+	AccountID     string
+	RequestedSlug string
+	SSHPublicKey  string
+	Keep          bool
+}
+
+type fixedAWSCreateIntent struct {
+	Version       int                           `json:"version"`
+	AccountID     string                        `json:"accountID"`
+	RequestedSlug string                        `json:"requestedSlug"`
+	Provider      string                        `json:"provider" configFields:"Provider"`
+	Profile       string                        `json:"profile" configFields:"Profile"`
+	Machine       fixedAWSCreateIntentMachine   `json:"machine"`
+	Capabilities  fixedAWSCreateIntentFeatures  `json:"capabilities"`
+	Networking    fixedAWSCreateIntentNetwork   `json:"networking"`
+	Capacity      fixedAWSCreateIntentCapacity  `json:"capacity" configFields:"Capacity"`
+	Lifecycle     fixedAWSCreateIntentLifecycle `json:"lifecycle"`
+	Workload      fixedAWSCreateIntentWorkload  `json:"workload"`
+	Cache         fixedAWSCreateIntentCache     `json:"cache" configFields:"Cache"`
+}
+
+type fixedAWSCreateIntentMachine struct {
+	TargetOS           string `json:"targetOS" configFields:"TargetOS"`
+	Architecture       string `json:"architecture" configFields:"Architecture"`
+	OSImage            string `json:"osImage" configFields:"OSImage"`
+	WindowsMode        string `json:"windowsMode" configFields:"WindowsMode"`
+	Class              string `json:"class" configFields:"Class"`
+	ServerType         string `json:"serverType" configFields:"ServerType"`
+	ServerTypeExplicit bool   `json:"serverTypeExplicit" configFields:"ServerTypeExplicit"`
+	HostID             string `json:"hostID,omitempty" configFields:"HostID,AWSMacHostID"`
+	Region             string `json:"region" configFields:"AWSRegion"`
+	AMI                string `json:"ami,omitempty" configFields:"AWSAMI"`
+	Snapshot           string `json:"snapshot,omitempty" configFields:"AWSSnapshot"`
+	SubnetID           string `json:"subnetID,omitempty" configFields:"AWSSubnetID"`
+	InstanceProfile    string `json:"instanceProfile,omitempty" configFields:"AWSProfile"`
+	RootGB             int32  `json:"rootGB" configFields:"AWSRootGB"`
+}
+
+type fixedAWSCreateIntentFeatures struct {
+	Desktop           bool              `json:"desktop" configFields:"Desktop"`
+	DesktopEnv        string            `json:"desktopEnv" configFields:"DesktopEnv"`
+	Browser           bool              `json:"browser" configFields:"Browser"`
+	Code              bool              `json:"code" configFields:"Code"`
+	ImageRequirements imageRequirements `json:"imageRequirements"`
+}
+
+type fixedAWSCreateIntentNetwork struct {
+	Mode            NetworkMode                   `json:"mode" configFields:"Network"`
+	SecurityGroupID string                        `json:"securityGroupID,omitempty" configFields:"AWSSGID"`
+	SSHCIDRsPinned  bool                          `json:"sshCIDRsPinned" configFields:"AWSSSHCIDRsPinned"`
+	SSHCIDRs        []string                      `json:"sshCIDRs,omitempty" configFields:"AWSSSHCIDRs"`
+	SSH             fixedAWSCreateIntentSSH       `json:"ssh"`
+	Tailscale       fixedAWSCreateIntentTailscale `json:"tailscale" configFields:"Tailscale"`
+}
+
+type fixedAWSCreateIntentSSH struct {
+	User            string   `json:"user" configFields:"SSHUser"`
+	Port            string   `json:"port" configFields:"SSHPort"`
+	FallbackPorts   []string `json:"fallbackPorts,omitempty" configFields:"SSHFallbackPorts"`
+	ProviderKey     string   `json:"providerKey" configFields:"ProviderKey"`
+	PublicKeySHA256 string   `json:"publicKeySHA256"`
+}
+
+type fixedAWSCreateIntentTailscale struct {
+	Enabled                bool     `json:"enabled"`
+	Tags                   []string `json:"tags,omitempty"`
+	HostnameTemplate       string   `json:"hostnameTemplate,omitempty"`
+	Hostname               string   `json:"hostname,omitempty"`
+	ExitNode               string   `json:"exitNode,omitempty"`
+	ExitNodeAllowLANAccess bool     `json:"exitNodeAllowLANAccess,omitempty"`
+}
+
+type fixedAWSCreateIntentCapacity struct {
+	Market            string   `json:"market"`
+	Strategy          string   `json:"strategy"`
+	Fallback          string   `json:"fallback"`
+	Regions           []string `json:"regions,omitempty"`
+	AvailabilityZones []string `json:"availabilityZones,omitempty"`
+	Hints             bool     `json:"hints"`
+}
+
+type fixedAWSCreateIntentLifecycle struct {
+	Keep            bool  `json:"keep"`
+	TTLNanoseconds  int64 `json:"ttlNanoseconds" configFields:"TTL"`
+	IdleNanoseconds int64 `json:"idleNanoseconds" configFields:"IdleTimeout"`
+}
+
+type fixedAWSCreateIntentWorkload struct {
+	Pond         string   `json:"pond,omitempty" configFields:"Pond"`
+	ExposedPorts []string `json:"exposedPorts,omitempty" configFields:"ExposedPorts"`
+	WorkRoot     string   `json:"workRoot" configFields:"WorkRoot"`
+}
+
+type fixedAWSCreateIntentCache struct {
+	Pnpm           bool                              `json:"pnpm"`
+	Npm            bool                              `json:"npm"`
+	Docker         bool                              `json:"docker"`
+	Git            bool                              `json:"git"`
+	MaxGB          int                               `json:"maxGB"`
+	PurgeOnRelease bool                              `json:"purgeOnRelease"`
+	Volumes        []fixedAWSCreateIntentCacheVolume `json:"volumes,omitempty"`
+}
+
+type fixedAWSCreateIntentCacheVolume struct {
+	Name     string `json:"name"`
+	Key      string `json:"key"`
+	Path     string `json:"path"`
+	SizeGB   int    `json:"sizeGB"`
+	Required bool   `json:"required"`
+}
+
+func FixedAWSCreateIntentFingerprint(cfg Config, req FixedAWSCreateIntentRequest) (string, error) {
+	intent, err := fixedAWSCreateIntentForConfig(cfg, req)
+	if err != nil {
+		return "", err
+	}
+	data, err := json.Marshal(intent)
+	if err != nil {
+		return "", fmt.Errorf("encode fixed AWS create intent: %w", err)
+	}
+	digest := sha256.Sum256(append([]byte("crabbox-fixed-aws-create-intent-v2\x00"), data...))
+	return hex.EncodeToString(digest[:]), nil
+}
+
+func fixedAWSCreateIntentForConfig(cfg Config, req FixedAWSCreateIntentRequest) (fixedAWSCreateIntent, error) {
+	network, err := parseNetworkMode(string(cfg.Network))
+	if err != nil {
+		return fixedAWSCreateIntent{}, err
+	}
+	osImage, err := normalizeOSImage(cfg.OSImage)
+	if err != nil {
+		return fixedAWSCreateIntent{}, err
+	}
+	exposedPorts, err := requestedExposedPorts(cfg.ExposedPorts)
+	if err != nil {
+		return fixedAWSCreateIntent{}, err
+	}
+	cacheVolumes, err := fixedAWSCreateIntentCacheVolumes(cfg.Cache.Volumes)
+	if err != nil {
+		return fixedAWSCreateIntent{}, err
+	}
+	publicKeyHash := sha256.Sum256([]byte(strings.TrimSpace(req.SSHPublicKey)))
+	rootGB := cfg.AWSRootGB
+	if rootGB <= 0 {
+		rootGB = 400
+	}
+	hostID := strings.TrimSpace(cfg.HostID)
+	if hostID == "" {
+		hostID = strings.TrimSpace(cfg.AWSMacHostID)
+	}
+	sshCIDRs := []string(nil)
+	if cfg.AWSSSHCIDRsPinned {
+		sshCIDRs = fixedAWSCanonicalStringSet(cfg.AWSSSHCIDRs)
+	}
+	return fixedAWSCreateIntent{
+		Version:       FixedAWSCreateIntentVersion,
+		AccountID:     strings.TrimSpace(req.AccountID),
+		RequestedSlug: normalizeLeaseSlug(req.RequestedSlug),
+		Provider:      strings.TrimSpace(cfg.Provider),
+		Profile:       strings.TrimSpace(cfg.Profile),
+		Machine: fixedAWSCreateIntentMachine{
+			TargetOS:           strings.TrimSpace(cfg.TargetOS),
+			Architecture:       effectiveArchitectureForConfig(cfg),
+			OSImage:            osImage,
+			WindowsMode:        strings.TrimSpace(cfg.WindowsMode),
+			Class:              strings.TrimSpace(cfg.Class),
+			ServerType:         strings.TrimSpace(cfg.ServerType),
+			ServerTypeExplicit: cfg.ServerTypeExplicit,
+			HostID:             hostID,
+			Region:             strings.TrimSpace(cfg.AWSRegion),
+			AMI:                strings.TrimSpace(cfg.AWSAMI),
+			Snapshot:           strings.TrimSpace(cfg.AWSSnapshot),
+			SubnetID:           strings.TrimSpace(cfg.AWSSubnetID),
+			InstanceProfile:    strings.TrimSpace(cfg.AWSProfile),
+			RootGB:             rootGB,
+		},
+		Capabilities: fixedAWSCreateIntentFeatures{
+			Desktop:           cfg.Desktop,
+			DesktopEnv:        normalizedDesktopEnv(cfg.DesktopEnv),
+			Browser:           cfg.Browser,
+			Code:              cfg.Code,
+			ImageRequirements: cfg.imageRequirements,
+		},
+		Networking: fixedAWSCreateIntentNetwork{
+			Mode:            network,
+			SecurityGroupID: strings.TrimSpace(cfg.AWSSGID),
+			SSHCIDRsPinned:  cfg.AWSSSHCIDRsPinned,
+			SSHCIDRs:        sshCIDRs,
+			SSH: fixedAWSCreateIntentSSH{
+				User:            strings.TrimSpace(cfg.SSHUser),
+				Port:            strings.TrimSpace(cfg.SSHPort),
+				FallbackPorts:   fixedAWSCanonicalOrderedStrings(cfg.SSHFallbackPorts),
+				ProviderKey:     strings.TrimSpace(cfg.ProviderKey),
+				PublicKeySHA256: hex.EncodeToString(publicKeyHash[:]),
+			},
+			Tailscale: fixedAWSCreateIntentTailscale{
+				Enabled:                cfg.Tailscale.Enabled,
+				Tags:                   fixedAWSCanonicalStringSet(cfg.Tailscale.Tags),
+				HostnameTemplate:       strings.TrimSpace(cfg.Tailscale.HostnameTemplate),
+				Hostname:               strings.TrimSpace(cfg.Tailscale.Hostname),
+				ExitNode:               strings.TrimSpace(cfg.Tailscale.ExitNode),
+				ExitNodeAllowLANAccess: cfg.Tailscale.ExitNodeAllowLANAccess,
+			},
+		},
+		Capacity: fixedAWSCreateIntentCapacity{
+			Market:            strings.TrimSpace(cfg.Capacity.Market),
+			Strategy:          strings.TrimSpace(cfg.Capacity.Strategy),
+			Fallback:          strings.TrimSpace(cfg.Capacity.Fallback),
+			Regions:           fixedAWSCanonicalOrderedStrings(cfg.Capacity.Regions),
+			AvailabilityZones: fixedAWSCanonicalOrderedStrings(cfg.Capacity.AvailabilityZones),
+			Hints:             cfg.Capacity.Hints,
+		},
+		Lifecycle: fixedAWSCreateIntentLifecycle{
+			Keep:            req.Keep,
+			TTLNanoseconds:  fixedAWSCanonicalDuration(cfg.TTL),
+			IdleNanoseconds: fixedAWSCanonicalDuration(cfg.IdleTimeout),
+		},
+		Workload: fixedAWSCreateIntentWorkload{
+			Pond:         normalizePondName(cfg.Pond),
+			ExposedPorts: exposedPorts,
+			WorkRoot:     strings.TrimSpace(cfg.WorkRoot),
+		},
+		Cache: fixedAWSCreateIntentCache{
+			Pnpm:           cfg.Cache.Pnpm,
+			Npm:            cfg.Cache.Npm,
+			Docker:         cfg.Cache.Docker,
+			Git:            cfg.Cache.Git,
+			MaxGB:          cfg.Cache.MaxGB,
+			PurgeOnRelease: cfg.Cache.PurgeOnRelease,
+			Volumes:        cacheVolumes,
+		},
+	}, nil
+}
+
+func fixedAWSCreateIntentCacheVolumes(volumes []CacheVolumeConfig) ([]fixedAWSCreateIntentCacheVolume, error) {
+	canonical := make([]fixedAWSCreateIntentCacheVolume, 0, len(volumes))
+	for _, raw := range volumes {
+		volume := CacheVolumeConfig{
+			Name:     strings.TrimSpace(raw.Name),
+			Key:      strings.TrimSpace(raw.Key),
+			Path:     strings.TrimSpace(raw.Path),
+			SizeGB:   raw.SizeGB,
+			Required: raw.Required,
+		}
+		if volume.Name == "" {
+			volume.Name = volume.Key
+		}
+		if err := validateCacheVolume(volume); err != nil {
+			return nil, err
+		}
+		canonical = append(canonical, fixedAWSCreateIntentCacheVolume(volume))
+	}
+	sort.Slice(canonical, func(i, j int) bool {
+		left, right := canonical[i], canonical[j]
+		if left.Name != right.Name {
+			return left.Name < right.Name
+		}
+		if left.Key != right.Key {
+			return left.Key < right.Key
+		}
+		if left.Path != right.Path {
+			return left.Path < right.Path
+		}
+		if left.SizeGB != right.SizeGB {
+			return left.SizeGB < right.SizeGB
+		}
+		return !left.Required && right.Required
+	})
+	if len(canonical) == 0 {
+		return nil, nil
+	}
+	return canonical, nil
+}
+
+func fixedAWSCanonicalStringSet(values []string) []string {
+	canonical := fixedAWSCanonicalOrderedStrings(values)
+	sort.Strings(canonical)
+	return canonical
+}
+
+func fixedAWSCanonicalOrderedStrings(values []string) []string {
+	canonical := make([]string, 0, len(values))
+	seen := map[string]bool{}
+	for _, raw := range values {
+		value := strings.TrimSpace(raw)
+		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		canonical = append(canonical, value)
+	}
+	if len(canonical) == 0 {
+		return nil
+	}
+	return canonical
+}
+
+func fixedAWSCanonicalDuration(value time.Duration) int64 {
+	return value.Nanoseconds()
+}

--- a/internal/cli/aws_fixed_create_intent_test.go
+++ b/internal/cli/aws_fixed_create_intent_test.go
@@ -1,0 +1,179 @@
+package cli
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestFixedAWSCreateIntentEquivalentNormalizedConfig(t *testing.T) {
+	left := BaseConfig()
+	left.Provider = "aws"
+	left.HostID = ""
+	left.AWSMacHostID = " host-123 "
+	left.ExposedPorts = []string{"8080", "80", "8080"}
+	left.AWSSSHCIDRsPinned = true
+	left.AWSSSHCIDRs = []string{"203.0.113.8/32", "198.51.100.4/32", "203.0.113.8/32"}
+	left.SSHFallbackPorts = []string{"22", "2222", "22"}
+	left.Tailscale.Tags = []string{"tag:zeta", "tag:alpha", "tag:zeta"}
+	left.Cache.Volumes = []CacheVolumeConfig{
+		{Name: " npm ", Key: " npm-key ", Path: " /var/cache/npm ", SizeGB: 20},
+		{Name: "", Key: "pnpm-key", Path: "/var/cache/pnpm", Required: true},
+	}
+
+	right := left
+	right.HostID = "host-123"
+	right.AWSMacHostID = ""
+	right.ExposedPorts = []string{"80", "8080"}
+	right.AWSSSHCIDRs = []string{"198.51.100.4/32", "203.0.113.8/32"}
+	right.SSHFallbackPorts = []string{"22", "2222"}
+	right.Tailscale.Tags = []string{"tag:alpha", "tag:zeta"}
+	right.Cache.Volumes = []CacheVolumeConfig{
+		{Name: "pnpm-key", Key: "pnpm-key", Path: "/var/cache/pnpm", Required: true},
+		{Name: "npm", Key: "npm-key", Path: "/var/cache/npm", SizeGB: 20},
+	}
+
+	leftFingerprint, err := FixedAWSCreateIntentFingerprint(left, FixedAWSCreateIntentRequest{
+		AccountID: " 123456789012 ", RequestedSlug: " Fixed__Lease ", SSHPublicKey: " ssh-ed25519 test ", Keep: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rightFingerprint, err := FixedAWSCreateIntentFingerprint(right, FixedAWSCreateIntentRequest{
+		AccountID: "123456789012", RequestedSlug: "fixed-lease", SSHPublicKey: "ssh-ed25519 test", Keep: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if leftFingerprint != rightFingerprint {
+		t.Fatalf("equivalent normalized intents differ: left=%s right=%s", leftFingerprint, rightFingerprint)
+	}
+}
+
+func TestFixedAWSCreateIntentExcludesSecrets(t *testing.T) {
+	const firstSecret = "sentinel-first-secret"
+	const secondSecret = "sentinel-second-secret"
+	cfg := BaseConfig()
+	cfg.Provider = "aws"
+	cfg.CoordToken = firstSecret
+	cfg.CoordAdminToken = firstSecret
+	cfg.Access.ClientID = firstSecret
+	cfg.Access.ClientSecret = firstSecret
+	cfg.Access.Token = firstSecret
+	cfg.SSHKey = firstSecret
+	cfg.Tailscale.AuthKey = firstSecret
+	cfg.Tailscale.AuthKeyEnv = firstSecret
+	cfg.Profiles = map[string]ProfileConfig{"secret": {Env: map[string]string{"TOKEN": firstSecret}}}
+
+	request := FixedAWSCreateIntentRequest{
+		AccountID: "123456789012", RequestedSlug: "secret-free", SSHPublicKey: "ssh-ed25519 public", Keep: true,
+	}
+	intent, err := fixedAWSCreateIntentForConfig(cfg, request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(intent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), firstSecret) {
+		t.Fatalf("fixed intent persisted secret material: %s", data)
+	}
+	firstFingerprint, err := FixedAWSCreateIntentFingerprint(cfg, request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.CoordToken = secondSecret
+	cfg.CoordAdminToken = secondSecret
+	cfg.Access.ClientID = secondSecret
+	cfg.Access.ClientSecret = secondSecret
+	cfg.Access.Token = secondSecret
+	cfg.SSHKey = secondSecret
+	cfg.Tailscale.AuthKey = secondSecret
+	cfg.Tailscale.AuthKeyEnv = secondSecret
+	cfg.Profiles = map[string]ProfileConfig{"secret": {Env: map[string]string{"TOKEN": secondSecret}}}
+	secondFingerprint, err := FixedAWSCreateIntentFingerprint(cfg, request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstFingerprint != secondFingerprint {
+		t.Fatalf("credential rotation changed immutable intent: first=%s second=%s", firstFingerprint, secondFingerprint)
+	}
+}
+
+func TestFixedAWSCreateIntentClassifiesEveryExportedConfigField(t *testing.T) {
+	included := map[string]bool{}
+	collectFixedAWSConfigFields(reflect.TypeOf(fixedAWSCreateIntent{}), included)
+	excluded := map[string]string{}
+	classify := func(reason, fields string) {
+		for _, name := range strings.Fields(fields) {
+			if previous := excluded[name]; previous != "" {
+				t.Fatalf("Config field %s classified twice as %s and %s", name, previous, reason)
+			}
+			excluded[name] = reason
+		}
+	}
+	classify("coordinator transport or credential", `
+		Coordinator BrokerMode BrokerLoginRedirectOrigins BrokerAutoWebVNC
+		CoordToken CoordTokenCommand CoordAdminToken Access SSHKey
+	`)
+	classify("non-AWS provider selection", `
+		Location Image AWSLambdaMicroVM
+		AzureSubscription AzureTenant AzureClientID AzureLocation AzureBackend AzureResourceGroup
+		AzureImage AzureSnapshot AzureSnapshotSKU AzureOSDisk AzureOSDiskExplicit AzureOSDiskSKU
+		AzureVNet AzureSubnet AzureNSG AzureSSHCIDRs AzureNetwork AzureDynamicSessions
+		GCPProject GCPZone GCPImage GCPMachineImage GCPSnapshot GCPNetwork GCPSubnet GCPTags
+		GCPSSHCIDRs GCPRootGB GCPServiceAccount DigitalOcean Vultr Linode GitHubCodespaces
+		Lambda Nebius OVH Scaleway TencentCloud Incus Proxmox Firecracker XCPNg Parallels
+		Blacksmith KubeVirt SealosDevbox AgentSandbox External Namespace NamespaceInstance
+		Phala Coder Morph Daytona E2B CubeSandbox ExeDev Railway FastAPICloud UnikraftCloud
+		Runpod Vast NvidiaBrev Hostinger Wandb Orgo Islo Freestyle Tenki Tensorlake Cua
+		OpenComputer CodeSandbox OpenSandbox Nomad Blaxel VercelSandbox CloudflareSandbox
+		Superserve Crownest DockerSandbox AnthropicSRT CloudRunSandbox Modal UpstashBox
+		Smolvm AsciiBox Cloudflare CloudflareDynamicWorkers Semaphore Sprites LocalContainer
+		AppleContainer AppleVM MXC Multipass Tart Lume HyperV WindowsSandbox Static
+	`)
+	classify("post-acquisition command, transport, or reporting behavior", `
+		Sync Run EnvAllow Actions Results Shard Profiles Presets ProofTemplates Jobs
+	`)
+
+	configType := reflect.TypeOf(Config{})
+	known := map[string]bool{}
+	for index := 0; index < configType.NumField(); index++ {
+		field := configType.Field(index)
+		if !field.IsExported() {
+			continue
+		}
+		known[field.Name] = true
+		_, isIncluded := included[field.Name]
+		_, isExcluded := excluded[field.Name]
+		if isIncluded == isExcluded {
+			t.Errorf("exported Config field %s must be classified exactly once (included=%t excluded=%t)", field.Name, isIncluded, isExcluded)
+		}
+	}
+	for name := range included {
+		if !known[name] {
+			t.Errorf("fixed intent configFields tag references unknown or unexported Config field %s", name)
+		}
+	}
+	for name := range excluded {
+		if !known[name] {
+			t.Errorf("excluded fixed intent classification references unknown Config field %s", name)
+		}
+	}
+}
+
+func collectFixedAWSConfigFields(value reflect.Type, fields map[string]bool) {
+	for index := 0; index < value.NumField(); index++ {
+		field := value.Field(index)
+		for _, name := range strings.Split(field.Tag.Get("configFields"), ",") {
+			if name = strings.TrimSpace(name); name != "" {
+				fields[name] = true
+			}
+		}
+		if field.Type.Kind() == reflect.Struct && strings.HasPrefix(field.Type.Name(), "fixedAWSCreateIntent") {
+			collectFixedAWSConfigFields(field.Type, fields)
+		}
+	}
+}

--- a/internal/cli/aws_test.go
+++ b/internal/cli/aws_test.go
@@ -5,13 +5,17 @@ import (
 	"crypto/md5"
 	"encoding/base64"
 	"encoding/binary"
+	"encoding/json"
+	"errors"
 	"io"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/credentials"
@@ -38,6 +42,201 @@ func TestValidateAWSCleanupKeyPair(t *testing.T) {
 	_, err := validateAWSCleanupKeyPair(name, []types.KeyPairInfo{unowned})
 	if err == nil || !IsAWSCleanupKeyOwnershipError(err) {
 		t.Fatalf("unowned key error=%v", err)
+	}
+}
+
+func TestAWSFixedAttemptIdentityIsStableAndScopedToResolvedLaunch(t *testing.T) {
+	cfg := baseConfig()
+	cfg.Provider = "aws"
+	cfg.AWSRegion = "us-east-1"
+	cfg.ServerType = "m7i.large"
+	cfg.Capacity.Market = "on-demand"
+	cfg.Capacity.AvailabilityZones = []string{"us-east-1a"}
+	first := awsFixedAttemptClientToken("cbx_abcdef123456", cfg, "ami-fixed", "sg-fixed", false)
+	second := awsFixedAttemptClientToken("cbx_abcdef123456", cfg, "ami-fixed", "sg-fixed", false)
+	if first != second || len(first) != 64 {
+		t.Fatalf("tokens first=%q second=%q", first, second)
+	}
+	drifted := cfg
+	drifted.ServerType = "m7i.xlarge"
+	if got := awsFixedAttemptClientToken("cbx_abcdef123456", drifted, "ami-fixed", "sg-fixed", false); got == first {
+		t.Fatal("server type drift did not change the fixed attempt token")
+	}
+
+	createdAt := time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+	left := directLeaseLabels(cfg, "cbx_abcdef123456", "fixed", "aws", "on-demand", true, createdAt)
+	right := directLeaseLabels(cfg, "cbx_abcdef123456", "fixed", "aws", "on-demand", true, createdAt)
+	leftData, err := json.Marshal(left)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rightData, err := json.Marshal(right)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(leftData) != string(rightData) {
+		t.Fatalf("fixed create labels drifted:\n%s\n%s", leftData, rightData)
+	}
+}
+
+func TestAWSFixedAttemptAttestationIsNonCircularAndSecretFree(t *testing.T) {
+	attempt := AWSLaunchAttempt{
+		Region: "us-east-1", AvailabilityZone: "us-east-1a", SubnetID: "subnet-fixed",
+		ServerType: "m7i.large", Market: "on-demand", ImageID: "ami-fixed",
+		SecurityGroupID: "sg-fixed", HostID: "h-fixed", KeyPairID: "key-fixed",
+		ClientToken: "cbx-client-token", ParametersSHA256: strings.Repeat("a", 64),
+	}
+	first := AWSFixedAttemptAttestationLabels(attempt)
+	withDifferentParameters := attempt
+	withDifferentParameters.ParametersSHA256 = strings.Repeat("b", 64)
+	if second := AWSFixedAttemptAttestationLabels(withDifferentParameters); !maps.Equal(first, second) {
+		t.Fatalf("parameters hash changed pre-submit attestation: first=%v second=%v", first, second)
+	}
+	withDifferentImage := attempt
+	withDifferentImage.ImageID = "ami-other"
+	if second := AWSFixedAttemptAttestationLabels(withDifferentImage); maps.Equal(first, second) {
+		t.Fatal("launch tuple drift did not change attempt attestation")
+	}
+	for key, value := range first {
+		if strings.Contains(key, "client") && value == attempt.ClientToken {
+			t.Fatalf("attempt tag %s persisted raw client token", key)
+		}
+	}
+}
+
+func TestAWSFixedPinnedAttemptBlocksBroadRegionFallback(t *testing.T) {
+	control := &AWSFixedCreateControl{PinnedAttempt: &AWSLaunchAttempt{ClientToken: "pinned"}}
+	err := errors.New("transport closed while waiting for capacity response")
+	if !isRetryableAWSRegionProvisioningError(err) {
+		t.Fatal("test error must exercise the broad region retry classifier")
+	}
+	if isRetryableAWSProvisioningError(err) {
+		t.Fatal("test error must remain ambiguous at the RunInstances classifier")
+	}
+	if shouldRetryAWSRegionAfterCreateError(err, control) {
+		t.Fatal("ambiguous fixed attempt advanced to another region")
+	}
+}
+
+func TestAWSFixedPinnedAttemptNeverResubmitsRunInstances(t *testing.T) {
+	publicKey := testOpenSSHPublicKey("ssh-ed25519", testBytes(32, 9))
+	var requests []string
+	var pinned AWSLaunchAttempt
+	persisted := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		params, err := url.ParseQuery(string(body))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if params.Get("Action") != "RunInstances" {
+			t.Fatalf("action=%q", params.Get("Action"))
+		}
+		if !persisted {
+			t.Fatal("RunInstances reached the provider before the attempt was persisted")
+		}
+		assertAWSFixedAttemptRequestTags(t, params, pinned)
+		requests = append(requests, params.Encode())
+		writeEC2XML(w, `<RunInstancesResponse><instancesSet><item><instanceId>i-fixed</instanceId><instanceType>m7i.large</instanceType><ipAddress>203.0.113.44</ipAddress><instanceState><name>pending</name></instanceState></item></instancesSet></RunInstancesResponse>`)
+	}))
+	defer server.Close()
+
+	cfg := baseConfig()
+	cfg.Provider = "aws"
+	cfg.TargetOS = targetLinux
+	cfg.AWSRegion = "eu-west-1"
+	cfg.ServerType = "m7i.large"
+	cfg.ProviderKey = "crabbox-cbx-abcdef123456"
+	cfg.Capacity.Market = "on-demand"
+	createdAt := time.Date(2026, 8, 9, 12, 0, 0, 123, time.UTC)
+	control := &AWSFixedCreateControl{
+		CreatedAt: createdAt, IntentFingerprint: strings.Repeat("b", 64),
+		AccountID: "123456789012", KeyPairID: "key-fixed", FailedTokens: map[string]bool{},
+	}
+	control.BeforeAttempt = func(attempt AWSLaunchAttempt) error {
+		pinned = attempt
+		persisted = true
+		return nil
+	}
+	client := testAWSClient(server.URL)
+	if _, err := client.createServer(context.Background(), cfg, publicKey, "cbx_abcdef123456", "fixed", true, "ami-fixed", "sg-fixed", false, control); err != nil {
+		t.Fatal(err)
+	}
+
+	persisted = true
+	replay := &AWSFixedCreateControl{
+		CreatedAt: createdAt, IntentFingerprint: strings.Repeat("b", 64),
+		AccountID: "123456789012", KeyPairID: "key-fixed", PinnedAttempt: &pinned,
+		FailedTokens: map[string]bool{},
+	}
+	if _, err := client.createServer(context.Background(), cfg, publicKey, "cbx_abcdef123456", "fixed", true, "ami-fixed", "sg-fixed", false, replay); err == nil || !strings.Contains(err.Error(), "lease_id_conflict") {
+		t.Fatalf("pinned replay err=%v", err)
+	}
+	if len(requests) != 1 {
+		t.Fatalf("pinned replay reached RunInstances: requests=%d", len(requests))
+	}
+}
+
+func TestAWSOrdinaryRunInstancesOmitsFixedAttemptTags(t *testing.T) {
+	publicKey := testOpenSSHPublicKey("ssh-ed25519", testBytes(32, 10))
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		params, err := url.ParseQuery(string(body))
+		if err != nil {
+			t.Fatal(err)
+		}
+		for name := range params {
+			if !strings.HasSuffix(name, ".Key") {
+				continue
+			}
+			if tag := params.Get(name); strings.HasPrefix(tag, "fixed_attempt_") {
+				t.Fatalf("ordinary RunInstances included fixed attempt tag %q", tag)
+			}
+		}
+		writeEC2XML(w, `<RunInstancesResponse><instancesSet><item><instanceId>i-ordinary</instanceId><instanceType>m7i.large</instanceType><ipAddress>203.0.113.45</ipAddress><instanceState><name>pending</name></instanceState></item></instancesSet></RunInstancesResponse>`)
+	}))
+	defer server.Close()
+
+	cfg := baseConfig()
+	cfg.Provider = "aws"
+	cfg.TargetOS = targetLinux
+	cfg.AWSRegion = "eu-west-1"
+	cfg.ServerType = "m7i.large"
+	cfg.ProviderKey = "crabbox-cbx-abcdef123483"
+	cfg.Capacity.Market = "on-demand"
+	client := testAWSClient(server.URL)
+	if _, err := client.createServer(context.Background(), cfg, publicKey, "cbx_abcdef123483", "ordinary", true, "ami-ordinary", "sg-ordinary", false, nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertAWSFixedAttemptRequestTags(t *testing.T, params url.Values, attempt AWSLaunchAttempt) {
+	t.Helper()
+	expected := AWSFixedAttemptAttestationLabels(attempt)
+	found := map[string]string{}
+	for name := range params {
+		if !strings.HasSuffix(name, ".Key") {
+			continue
+		}
+		tag := params.Get(name)
+		if _, ok := expected[tag]; !ok {
+			continue
+		}
+		value := params.Get(strings.TrimSuffix(name, ".Key") + ".Value")
+		found[tag] = value
+	}
+	for key, value := range expected {
+		if actual, ok := found[key]; !ok {
+			t.Errorf("RunInstances missing fixed attempt tag %s", key)
+		} else if actual != value {
+			t.Errorf("RunInstances fixed attempt tag %s=%q, want %q", key, actual, value)
+		}
 	}
 }
 

--- a/internal/cli/azure_test.go
+++ b/internal/cli/azure_test.go
@@ -1273,7 +1273,7 @@ func TestWaitForAzureExtensionUsesResourceSuccess(t *testing.T) {
 	}
 	select {
 	case <-pollStarted:
-	default:
+	case <-time.After(time.Second):
 		t.Fatal("SDK poller was not started")
 	}
 }

--- a/internal/cli/claim.go
+++ b/internal/cli/claim.go
@@ -27,35 +27,52 @@ type leaseClaim struct {
 	// CloudNumericID binds providers whose CloudID is a reusable resource name.
 	CloudNumericID int64 `json:"cloudNumericID,omitempty"`
 	// CloudImmutableID binds providers whose immutable identity is a string.
-	CloudImmutableID                    string            `json:"cloudImmutableID,omitempty"`
-	ProviderScope                       string            `json:"providerScope,omitempty"`
-	StaticHost                          string            `json:"staticHost,omitempty"`
-	StaticUser                          string            `json:"staticUser,omitempty"`
-	StaticPort                          string            `json:"staticPort,omitempty"`
-	StaticWorkRoot                      string            `json:"staticWorkRoot,omitempty"`
-	TargetOS                            string            `json:"targetOS,omitempty"`
-	WindowsMode                         string            `json:"windowsMode,omitempty"`
-	Pond                                string            `json:"pond,omitempty"`
-	RepoRoot                            string            `json:"repoRoot"`
-	ClaimedAt                           string            `json:"claimedAt"`
-	LastUsedAt                          string            `json:"lastUsedAt"`
-	IdleTimeoutSeconds                  int               `json:"idleTimeoutSeconds,omitempty"`
-	TailscaleIPv4                       string            `json:"tailscaleIPv4,omitempty"`
-	TailscaleFQDN                       string            `json:"tailscaleFQDN,omitempty"`
-	TailscaleHostname                   string            `json:"tailscaleHostname,omitempty"`
-	TailscaleTags                       []string          `json:"tailscaleTags,omitempty"`
-	TailscaleLoginURL                   string            `json:"tailscaleLoginURL,omitempty"`
-	TailscaleExitNode                   string            `json:"tailscaleExitNode,omitempty"`
-	TailscaleExitLAN                    bool              `json:"tailscaleExitLAN,omitempty"`
-	SSHHost                             string            `json:"sshHost,omitempty"`
-	SSHPort                             int               `json:"sshPort,omitempty"`
-	BridgeURL                           string            `json:"bridgeURL,omitempty"`
-	CoordinatorRegistrationURL          string            `json:"coordinatorRegistrationURL,omitempty"`
-	RuntimeAdapterRegistrationID        string            `json:"runtimeAdapterRegistrationID,omitempty"`
-	RuntimeAdapterPendingRegistrationID string            `json:"runtimeAdapterPendingRegistrationID,omitempty"`
-	CacheVolumes                        []string          `json:"cacheVolumes,omitempty"`
-	Labels                              map[string]string `json:"labels,omitempty"`
+	CloudImmutableID                    string             `json:"cloudImmutableID,omitempty"`
+	ProviderScope                       string             `json:"providerScope,omitempty"`
+	StaticHost                          string             `json:"staticHost,omitempty"`
+	StaticUser                          string             `json:"staticUser,omitempty"`
+	StaticPort                          string             `json:"staticPort,omitempty"`
+	StaticWorkRoot                      string             `json:"staticWorkRoot,omitempty"`
+	TargetOS                            string             `json:"targetOS,omitempty"`
+	WindowsMode                         string             `json:"windowsMode,omitempty"`
+	Pond                                string             `json:"pond,omitempty"`
+	RepoRoot                            string             `json:"repoRoot"`
+	ClaimedAt                           string             `json:"claimedAt"`
+	LastUsedAt                          string             `json:"lastUsedAt"`
+	IdleTimeoutSeconds                  int                `json:"idleTimeoutSeconds,omitempty"`
+	TailscaleIPv4                       string             `json:"tailscaleIPv4,omitempty"`
+	TailscaleFQDN                       string             `json:"tailscaleFQDN,omitempty"`
+	TailscaleHostname                   string             `json:"tailscaleHostname,omitempty"`
+	TailscaleTags                       []string           `json:"tailscaleTags,omitempty"`
+	TailscaleLoginURL                   string             `json:"tailscaleLoginURL,omitempty"`
+	TailscaleExitNode                   string             `json:"tailscaleExitNode,omitempty"`
+	TailscaleExitLAN                    bool               `json:"tailscaleExitLAN,omitempty"`
+	SSHHost                             string             `json:"sshHost,omitempty"`
+	SSHPort                             int                `json:"sshPort,omitempty"`
+	BridgeURL                           string             `json:"bridgeURL,omitempty"`
+	CoordinatorRegistrationURL          string             `json:"coordinatorRegistrationURL,omitempty"`
+	RuntimeAdapterRegistrationID        string             `json:"runtimeAdapterRegistrationID,omitempty"`
+	RuntimeAdapterPendingRegistrationID string             `json:"runtimeAdapterPendingRegistrationID,omitempty"`
+	CacheVolumes                        []string           `json:"cacheVolumes,omitempty"`
+	Labels                              map[string]string  `json:"labels,omitempty"`
+	FixedCreateIntent                   *FixedCreateIntent `json:"fixedCreateIntent,omitempty"`
 }
+
+// FixedCreateIntent is the durable, provider-neutral envelope for a
+// caller-supplied lease identity. Provider adapters own the opaque attempt
+// fields and their interpretation; the claim layer only persists and locks it.
+type FixedCreateIntent struct {
+	Version        int               `json:"version"`
+	Fingerprint    string            `json:"fingerprint"`
+	ProviderScope  string            `json:"providerScope"`
+	Slug           string            `json:"slug"`
+	CreatedAt      string            `json:"createdAt"`
+	State          string            `json:"state"`
+	Attempt        map[string]string `json:"attempt,omitempty"`
+	FailedAttempts []string          `json:"failedAttempts,omitempty"`
+}
+
+const FixedAWSClaimProvider = "aws-fixed-v1"
 
 var claimMutationMutexes sync.Map
 
@@ -274,7 +291,13 @@ func claimLeaseForRepoProviderScopePondDetailsMetadata(leaseID, slug, provider, 
 		existing.LeaseID = leaseID
 		existing.Slug = slug
 		if provider != "" {
-			existing.Provider = provider
+			if existing.FixedCreateIntent != nil && existing.Provider != "" {
+				if canonicalClaimProvider(existing.Provider) != canonicalClaimProvider(provider) {
+					return exit(2, "lease %s fixed claim provider changed from %s to %s", leaseID, existing.Provider, provider)
+				}
+			} else {
+				existing.Provider = provider
+			}
 		}
 		if providerScope != "" {
 			existing.ProviderScope = providerScope
@@ -439,7 +462,7 @@ func updateLeaseClaimEndpoint(leaseID string, server Server, target SSHTarget) e
 }
 
 func prepareLeaseClaimEndpoint(existing leaseClaim, providerName, slug string, server Server, allowProviderMetadata bool) (Server, error) {
-	provider, err := ProviderFor(firstNonBlank(existing.Provider, providerName))
+	provider, err := ProviderFor(canonicalClaimProvider(firstNonBlank(existing.Provider, providerName)))
 	if err != nil {
 		return Server{}, exit(2, "lease %s claim has unavailable provider %q", existing.LeaseID, existing.Provider)
 	}
@@ -669,6 +692,12 @@ func cloneLeaseClaim(claim leaseClaim) leaseClaim {
 	claim.Labels = cloneStringMap(claim.Labels)
 	claim.TailscaleTags = append([]string(nil), claim.TailscaleTags...)
 	claim.CacheVolumes = append([]string(nil), claim.CacheVolumes...)
+	if claim.FixedCreateIntent != nil {
+		intent := *claim.FixedCreateIntent
+		intent.Attempt = cloneStringMap(intent.Attempt)
+		intent.FailedAttempts = append([]string(nil), intent.FailedAttempts...)
+		claim.FixedCreateIntent = &intent
+	}
 	return claim
 }
 
@@ -923,6 +952,58 @@ func withLeaseClaimLock(path string, fn func() error) error {
 	return fn()
 }
 
+func withLeaseIDOperationLock(leaseID string, action func() error) error {
+	path, err := leaseClaimPath(leaseID)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return exit(2, "create claim directory: %v", err)
+	}
+	return withLeaseClaimLock(path, action)
+}
+
+func withDurableLeaseClaimLock(leaseID string, action func(*leaseClaim, bool, func() error) error) error {
+	path, err := leaseClaimPath(leaseID)
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(path)
+	firstExistingDir, err := nearestExistingClaimDirectory(dir)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return exit(2, "create claim directory: %v", err)
+	}
+	return withLeaseClaimLock(path, func() error {
+		claim, exists, err := readLeaseClaimPathWithPresence(path)
+		if err != nil {
+			return err
+		}
+		if err := validateLeaseClaimFileIdentity(leaseID, claim, exists); err != nil {
+			return err
+		}
+		persist := func() error {
+			if claim.LeaseID == "" {
+				claim.LeaseID = leaseID
+			}
+			if claim.LeaseID != leaseID {
+				return invalidLeaseClaimIDError{id: claim.LeaseID}
+			}
+			if err := refreshLeaseClaimRevision(&claim); err != nil {
+				return err
+			}
+			if err := writeLeaseClaimAtomicDurableWithSync(path, claim, firstExistingDir, syncControllerDirectory); err != nil {
+				return err
+			}
+			exists = true
+			return nil
+		}
+		return action(&claim, exists, persist)
+	})
+}
+
 func leaseClaimLockPath(path string) (string, error) {
 	dir := filepath.Join(filepath.Dir(filepath.Dir(path)), "claim-locks")
 	if err := os.MkdirAll(dir, 0o700); err != nil {
@@ -1041,6 +1122,9 @@ func fsyncDir(dir string) {
 }
 
 func canonicalClaimProvider(provider string) string {
+	if strings.TrimSpace(provider) == FixedAWSClaimProvider {
+		return "aws"
+	}
 	if resolved, err := ProviderFor(provider); err == nil {
 		return resolved.Name()
 	}
@@ -1576,6 +1660,38 @@ func replaceLeaseClaimIfUnchanged(leaseID string, current, replacement leaseClai
 
 func replaceLeaseClaimIfUnchangedDurableReturning(leaseID string, current, replacement leaseClaim) (leaseClaim, error) {
 	return replaceLeaseClaimIfUnchangedWithWrite(leaseID, current, replacement, writeLeaseClaimAtomicDurable)
+}
+
+func replaceLeaseClaimIfUnchangedDurableAfter(leaseID string, current, replacement leaseClaim, action func() error) (leaseClaim, error) {
+	path, err := leaseClaimPath(leaseID)
+	if err != nil {
+		return leaseClaim{}, err
+	}
+	var written leaseClaim
+	err = withLeaseClaimLock(path, func() error {
+		claim, exists, err := readLeaseClaimPathWithPresence(path)
+		if err != nil {
+			return err
+		}
+		if err := validateLeaseClaimFileIdentity(leaseID, claim, exists); err != nil {
+			return err
+		}
+		if err := unchangedLeaseClaimGuard(leaseID, current, true)(claim, exists); err != nil {
+			return err
+		}
+		if action != nil {
+			if err := action(); err != nil {
+				return err
+			}
+		}
+		written = cloneLeaseClaim(replacement)
+		written.LeaseID = leaseID
+		if err := refreshLeaseClaimRevision(&written); err != nil {
+			return err
+		}
+		return writeLeaseClaimAtomicDurable(path, written)
+	})
+	return written, err
 }
 
 func replaceLeaseClaimIfUnchangedWithWrite(leaseID string, current, replacement leaseClaim, write func(string, leaseClaim) error) (leaseClaim, error) {

--- a/internal/cli/claim_test.go
+++ b/internal/cli/claim_test.go
@@ -811,6 +811,69 @@ func TestReplaceLeaseClaimIfUnchangedPreservesSelectedRuntimeState(t *testing.T)
 	}
 }
 
+func TestDurableClaimReplacementHelpersPublishOnlyAfterAction(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	const leaseID = "cbx_durable123456"
+	if err := claimLeaseForRepoProvider(leaseID, "durable", "aws", "/repo", time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	current, err := readLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacement := cloneLeaseClaim(current)
+	replacement.Slug = "durable-returning"
+	written, err := replaceLeaseClaimIfUnchangedDurableReturning(leaseID, current, replacement)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if written.Slug != replacement.Slug || written.Revision == current.Revision {
+		t.Fatalf("durable replacement=%#v current=%#v", written, current)
+	}
+
+	next := cloneLeaseClaim(written)
+	next.Slug = "durable-after"
+	path, err := leaseClaimPath(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	actionCalled := false
+	writtenAfter, err := replaceLeaseClaimIfUnchangedDurableAfter(leaseID, written, next, func() error {
+		actionCalled = true
+		beforePublish, exists, err := readLeaseClaimPathWithPresence(path)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return errors.New("claim disappeared before replacement action")
+		}
+		if beforePublish.Slug != written.Slug {
+			return fmt.Errorf("replacement published before action: %#v", beforePublish)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !actionCalled || writtenAfter.Slug != next.Slug || writtenAfter.Revision == written.Revision {
+		t.Fatalf("actionCalled=%t written=%#v previous=%#v", actionCalled, writtenAfter, written)
+	}
+
+	want := errors.New("provider cleanup failed")
+	failedReplacement := cloneLeaseClaim(writtenAfter)
+	failedReplacement.Slug = "must-not-publish"
+	if _, err := replaceLeaseClaimIfUnchangedDurableAfter(leaseID, writtenAfter, failedReplacement, func() error { return want }); !errors.Is(err, want) {
+		t.Fatalf("action failure err=%v", err)
+	}
+	unchanged, err := readLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if unchanged.Slug != writtenAfter.Slug || unchanged.Revision != writtenAfter.Revision {
+		t.Fatalf("failed action changed claim: got=%#v want=%#v", unchanged, writtenAfter)
+	}
+}
+
 func TestConditionalClaimCreateRejectsExistingEmptyFile(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	leaseID := "cbx_emptyclaim123"

--- a/internal/cli/claim_test.go
+++ b/internal/cli/claim_test.go
@@ -12,6 +12,44 @@ import (
 	"time"
 )
 
+func TestFixedAWSClaimProviderCanonicalizesWithoutOverwritingMarker(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	const leaseID = "cbx_abcdef123464"
+	err := withDurableLeaseClaimLock(leaseID, func(claim *leaseClaim, _ bool, persist func() error) error {
+		claim.LeaseID = leaseID
+		claim.Slug = "fixed-marker"
+		claim.Provider = FixedAWSClaimProvider
+		claim.ProviderScope = "account:123456789012"
+		claim.RepoRoot = "/repo"
+		claim.FixedCreateIntent = &FixedCreateIntent{
+			Version: 1, Fingerprint: strings.Repeat("a", 64), ProviderScope: claim.ProviderScope,
+			Slug: claim.Slug, CreatedAt: time.Now().UTC().Format(time.RFC3339Nano), State: "acquired",
+		}
+		return persist()
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if canonicalClaimProvider(FixedAWSClaimProvider) != "aws" {
+		t.Fatalf("fixed marker canonicalized to %q", canonicalClaimProvider(FixedAWSClaimProvider))
+	}
+	resolved, ok, exact, err := resolveLeaseClaimForProviderWithExact(leaseID, "aws")
+	if err != nil || !ok || !exact || resolved.Provider != FixedAWSClaimProvider {
+		t.Fatalf("resolved=%#v ok=%t exact=%t err=%v", resolved, ok, exact, err)
+	}
+	if err := claimLeaseForRepoProvider(leaseID, "fixed-marker", "aws", "/repo", time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	after, exists, err := readLeaseClaimWithPresence(leaseID)
+	if err != nil || !exists || after.Provider != FixedAWSClaimProvider {
+		t.Fatalf("runtime AWS claim update overwrote marker: claim=%#v exists=%t err=%v", after, exists, err)
+	}
+	peer := bridgePeerFromClaim(after, TransportNone)
+	if peer.Provider != "aws" {
+		t.Fatalf("fixed marker displayed as provider %q", peer.Provider)
+	}
+}
+
 func TestClaimEndpointReservationDeadlineStartsAfterClaimLockAcquired(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	const leaseID = "cbx_reservation_lock"

--- a/internal/cli/controller_subprocess_test.go
+++ b/internal/cli/controller_subprocess_test.go
@@ -35,10 +35,11 @@ type fixedIdentityExecControllerRunner struct {
 type confirmedAbsentCleanupTestBackend struct {
 	cleanupCalls int
 	cleanupErr   error
+	provider     string
 }
 
 func (b *confirmedAbsentCleanupTestBackend) Spec() ProviderSpec {
-	return ProviderSpec{Name: "external"}
+	return ProviderSpec{Name: blank(b.provider, "external")}
 }
 
 func (b *confirmedAbsentCleanupTestBackend) CleanupConfirmedAbsentLocalState(_ context.Context, _ ConfirmedAbsentLocalCleanupRequest) error {
@@ -1293,6 +1294,40 @@ func TestConfirmedAbsentLocalCleanupRemovesOnlyFullyMatchingClaim(t *testing.T) 
 	}
 	if claim, exists, err := readLeaseClaimWithPresence(leaseID); err != nil || exists || claim.LeaseID != "" {
 		t.Fatalf("claim=%#v exists=%t err=%v", claim, exists, err)
+	}
+}
+
+func TestConfirmedAbsentLocalCleanupFailsClosedForFixedAWSMarker(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	const leaseID = "cbx_abcdef123465"
+	const scope = "account:123456789012"
+	err := withDurableLeaseClaimLock(leaseID, func(claim *leaseClaim, _ bool, persist func() error) error {
+		claim.LeaseID = leaseID
+		claim.Slug = "fixed-confirmed-absent"
+		claim.Provider = FixedAWSClaimProvider
+		claim.ProviderScope = scope
+		claim.CloudID = "i-fixed"
+		claim.FixedCreateIntent = &FixedCreateIntent{
+			Version: 1, Fingerprint: strings.Repeat("b", 64), ProviderScope: scope,
+			Slug: claim.Slug, CreatedAt: time.Now().UTC().Format(time.RFC3339Nano), State: "acquired",
+		}
+		return persist()
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend := &confirmedAbsentCleanupTestBackend{provider: "aws"}
+	err = cleanupConfirmedAbsentLocalState(context.Background(), backend, ProviderIdentityExpectation{
+		LeaseID: leaseID, AttemptLeaseID: leaseID, Slug: "fixed-confirmed-absent", ResourceID: "i-fixed",
+	}, scope)
+	if err == nil || !strings.Contains(err.Error(), "claim provider changed") {
+		t.Fatalf("err=%v, want fixed marker fail-closed error", err)
+	}
+	if backend.cleanupCalls != 0 {
+		t.Fatalf("confirmed-absence sidecar cleanup calls=%d, want 0", backend.cleanupCalls)
+	}
+	if claim, exists, readErr := readLeaseClaimWithPresence(leaseID); readErr != nil || !exists || claim.Provider != FixedAWSClaimProvider {
+		t.Fatalf("fixed claim was removed: claim=%#v exists=%t err=%v", claim, exists, readErr)
 	}
 }
 

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -860,6 +860,14 @@ func newCoordinatorClient(cfg Config) (*CoordinatorClient, bool, error) {
 }
 
 func (c *CoordinatorClient) CreateLease(ctx context.Context, cfg Config, publicKey string, keep bool, leaseID, slug string) (CoordinatorLease, error) {
+	return c.createLease(ctx, cfg, publicKey, keep, leaseID, slug, false)
+}
+
+func (c *CoordinatorClient) EnsureLease(ctx context.Context, cfg Config, publicKey string, keep bool, leaseID, slug string) (CoordinatorLease, error) {
+	return c.createLease(ctx, cfg, publicKey, keep, leaseID, slug, true)
+}
+
+func (c *CoordinatorClient) createLease(ctx context.Context, cfg Config, publicKey string, keep bool, leaseID, slug string, fixed bool) (CoordinatorLease, error) {
 	var res struct {
 		Lease CoordinatorLease `json:"lease"`
 	}
@@ -956,12 +964,16 @@ func (c *CoordinatorClient) CreateLease(ctx context.Context, cfg Config, publicK
 		req["azureOSDisk"] = cfg.AzureOSDisk
 	}
 	addCoordinatorGCPFields(req, cfg)
+	method := http.MethodPost
 	path := "/v1/leases"
-	if !imageRequirementsEmpty(cfg.imageRequirements) {
+	if fixed {
+		method = http.MethodPut
+		path = "/v1/leases/" + url.PathEscape(leaseID)
+	} else if !imageRequirementsEmpty(cfg.imageRequirements) {
 		// Older coordinators do not have this route, so mixed-version use fails closed.
 		path = "/v1/leases/capability-aware"
 	}
-	err = c.do(ctx, http.MethodPost, path, req, &res)
+	err = c.do(ctx, method, path, req, &res)
 	return res.Lease, err
 }
 

--- a/internal/cli/coordinator_test.go
+++ b/internal/cli/coordinator_test.go
@@ -1297,6 +1297,32 @@ func TestCoordinatorCreateLeaseSendsAWSSSHCIDRs(t *testing.T) {
 	}
 }
 
+func TestCoordinatorEnsureLeaseUsesFailClosedFixedIDRoute(t *testing.T) {
+	var method, path, bodyLeaseID string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		method, path = r.Method, r.URL.Path
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		bodyLeaseID, _ = body["leaseID"].(string)
+		_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{ID: bodyLeaseID, State: "active"}})
+	}))
+	defer server.Close()
+
+	client := &CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
+	lease, err := client.EnsureLease(context.Background(), baseConfig(), "ssh-ed25519 test", true, "cbx_abcdef123456", "fixed-route")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if method != http.MethodPut || path != "/v1/leases/cbx_abcdef123456" || bodyLeaseID != "cbx_abcdef123456" {
+		t.Fatalf("request=%s %s leaseID=%q", method, path, bodyLeaseID)
+	}
+	if lease.ID != bodyLeaseID {
+		t.Fatalf("lease=%#v", lease)
+	}
+}
+
 func TestCoordinatorCreateLeaseSendsImageRequirementsOnFailClosedRoute(t *testing.T) {
 	var body struct {
 		ImageRequirements imageRequirements `json:"imageRequirements"`

--- a/internal/cli/image_capabilities_test.go
+++ b/internal/cli/image_capabilities_test.go
@@ -6,6 +6,22 @@ import (
 	"testing"
 )
 
+func TestImageRequirementsIntentChangesWithSemanticRequirements(t *testing.T) {
+	cfg := baseConfig()
+	base, err := ImageRequirementsIntent(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.imageRequirements = imageRequirements{MinOS: "15.4", SDKs: map[string]string{"xcode": "16.3"}}
+	changed, err := ImageRequirementsIntent(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if base == changed || changed == "" {
+		t.Fatalf("image requirement intent did not change: base=%q changed=%q", base, changed)
+	}
+}
+
 func TestLeaseImageCapabilityFlags(t *testing.T) {
 	cfg := baseConfig()
 	cfg.Provider = "aws"

--- a/internal/cli/lease_test.go
+++ b/internal/cli/lease_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -17,6 +18,41 @@ func TestNewRunIDUsesCanonicalFormatAndIsUnique(t *testing.T) {
 	}
 	if first == second {
 		t.Fatalf("run IDs must be unique per invocation: %q", first)
+	}
+}
+
+func TestLeaseOperationLockSerializesFixedIDKeyCreation(t *testing.T) {
+	isolateTestUserDirs(t)
+	const leaseID = "cbx_abcdef123456"
+	start := make(chan struct{})
+	paths := make(chan string, 2)
+	errs := make(chan error, 2)
+	var ready sync.WaitGroup
+	ready.Add(2)
+	for range 2 {
+		go func() {
+			ready.Done()
+			<-start
+			err := withLeaseIDOperationLock(leaseID, func() error {
+				path, _, err := ensureTestboxKey(leaseID)
+				if err == nil {
+					paths <- path
+				}
+				return err
+			})
+			errs <- err
+		}()
+	}
+	ready.Wait()
+	close(start)
+	for range 2 {
+		if err := <-errs; err != nil {
+			t.Fatal(err)
+		}
+	}
+	first, second := <-paths, <-paths
+	if first != second {
+		t.Fatalf("key paths differ: %q != %q", first, second)
 	}
 }
 

--- a/internal/cli/pond.go
+++ b/internal/cli/pond.go
@@ -204,7 +204,7 @@ func pondClaimProviderSummary(pond string) (bool, bool) {
 			continue
 		}
 		hasClaims = true
-		caps := providerCapabilities(claim.Provider)
+		caps := providerCapabilities(canonicalClaimProvider(claim.Provider))
 		if (caps.Tailscale || caps.TailscaleEgress) && (!caps.URLBridge || claimHasTailscaleMetadata(claim)) {
 			hasTailscale = true
 		}

--- a/internal/cli/pond_bridge.go
+++ b/internal/cli/pond_bridge.go
@@ -191,9 +191,9 @@ func (a App) pondRelease(ctx context.Context, args []string) error {
 			fmt.Fprintf(a.Stderr, "warning: skip %s/%s: load config: %v\n", claim.Provider, claim.LeaseID, cerr)
 			continue
 		}
-		cfg.Provider = claim.Provider
+		cfg.Provider = canonicalClaimProvider(claim.Provider)
 		var routeErr error
-		if claim.Provider == "external" {
+		if canonicalClaimProvider(claim.Provider) == "external" {
 			routeErr = routeExternalLeaseClaim(&cfg, claim.LeaseID)
 		} else {
 			routeErr = autoRouteExternalLeaseForConfig(&cfg, claim.LeaseID)
@@ -249,20 +249,35 @@ func (a App) pondRelease(ctx context.Context, args []string) error {
 			}
 			fmt.Fprintf(a.Stderr, "warning: %s/%s release failed: %v\n", claim.Provider, claim.LeaseID, lerr)
 		} else {
-			retained := finalizePondReleaseClaim(backend, lease, claim)
+			retained, finalizeErr := finalizePondReleaseClaim(backend, lease, claim)
+			if finalizeErr != nil {
+				if firstErr == nil {
+					firstErr = finalizeErr
+				}
+				fmt.Fprintf(a.Stderr, "warning: %s/%s claim finalization failed after release: %v\n", claim.Provider, claim.LeaseID, finalizeErr)
+				continue
+			}
 			fmt.Fprintf(a.Stderr, "released %s/%s slug=%s claim_retained=%t\n", claim.Provider, claim.LeaseID, blank(claim.Slug, "-"), retained)
 		}
 	}
 	return firstErr
 }
 
-func finalizePondReleaseClaim(backend Backend, lease LeaseTarget, claim leaseClaim) bool {
-	retainer, ok := backend.(ReleaseLeaseClaimRetainer)
-	retained := ok && retainer.RetainLeaseClaimAfterRelease(lease)
+func finalizePondReleaseClaim(backend Backend, lease LeaseTarget, claim leaseClaim) (bool, error) {
+	retained := false
+	if verifier, ok := backend.(ReleaseLeaseClaimRetentionVerifier); ok {
+		var err error
+		retained, err = verifier.RetainLeaseClaimAfterReleaseWithClaim(lease, claim)
+		if err != nil {
+			return false, err
+		}
+	} else if retainer, ok := backend.(ReleaseLeaseClaimRetainer); ok {
+		retained = retainer.RetainLeaseClaimAfterRelease(lease)
+	}
 	if !retained {
 		removeLeaseClaim(claim.LeaseID)
 	}
-	return retained
+	return retained, nil
 }
 
 // pondPeersJSON wraps the peer list so the JSON output matches the
@@ -297,7 +312,7 @@ func resolvePondPeers(ctx context.Context, rt Runtime, pond, provider string, fl
 	byProvider := make(map[string][]leaseClaim)
 	order := make([]string, 0, 4)
 	for _, claim := range matches {
-		key := strings.TrimSpace(claim.Provider)
+		key := canonicalClaimProvider(claim.Provider)
 		if _, ok := byProvider[key]; !ok {
 			order = append(order, key)
 		}
@@ -366,7 +381,7 @@ func resolvePondPeersForProvider(ctx context.Context, rt Runtime, provider strin
 	var bridgeLoadErr error
 	for _, claim := range claims {
 		peer := bridgePeerFromClaim(claim, class)
-		caps := providerCapabilities(claim.Provider)
+		caps := providerCapabilities(canonicalClaimProvider(claim.Provider))
 		urlCapable := caps.URLBridge
 		useBridge := peer.Transport == TransportURL || urlCapable
 		if useBridge {
@@ -510,11 +525,12 @@ func hasResolvedPrimary(peers []BridgePeer) bool {
 // the provider once for the fan-out path); the rest of the row is filled in
 // from the claim sidecar without any provider API calls.
 func bridgePeerFromClaim(claim leaseClaim, class string) BridgePeer {
-	caps := providerCapabilities(claim.Provider)
+	provider := canonicalClaimProvider(claim.Provider)
+	caps := providerCapabilities(provider)
 	peer := BridgePeer{
 		Slug:       claim.Slug,
 		LeaseID:    claim.LeaseID,
-		Provider:   claim.Provider,
+		Provider:   provider,
 		Pond:       claim.Pond,
 		Labels:     cloneStringMap(claim.Labels),
 		Transports: caps.Available(),
@@ -531,7 +547,7 @@ func bridgePeerFromClaim(claim leaseClaim, class string) BridgePeer {
 			// bridge (e.g. islo, which only records a tailnet IP when the lease
 			// was warmed with --tailscale), fall back to the bridge plane
 			// instead of stranding the member as "pending".
-			if providerCapabilities(claim.Provider).URLBridge {
+			if providerCapabilities(provider).URLBridge {
 				peer.Transport = TransportURL
 				peer.Endpoint = claim.BridgeURL
 				return peer
@@ -560,14 +576,14 @@ func bridgePeerFromClaim(claim leaseClaim, class string) BridgePeer {
 		peer.Endpoint = claim.BridgeURL
 	case TransportNone:
 		peer.Transport = TransportNone
-		if isBlacksmithProvider(claim.Provider) {
+		if isBlacksmithProvider(provider) {
 			peer.Note = "blacksmith owns connectivity"
 		} else {
-			peer.Note = fmt.Sprintf("no advertised pond transport for provider %s", claim.Provider)
+			peer.Note = fmt.Sprintf("no advertised pond transport for provider %s", provider)
 		}
 	default:
 		peer.Transport = TransportNone
-		peer.Note = fmt.Sprintf("no advertised pond transport for provider %s", claim.Provider)
+		peer.Note = fmt.Sprintf("no advertised pond transport for provider %s", provider)
 	}
 	return peer
 }
@@ -615,7 +631,7 @@ func filterClaimsForPond(claims []leaseClaim, pond, provider string) []leaseClai
 		if normalizePondName(claim.Pond) != pond {
 			continue
 		}
-		if provider != "" && claim.Provider != canonProvider {
+		if provider != "" && canonicalClaimProvider(claim.Provider) != canonProvider {
 			continue
 		}
 		out = append(out, claim)

--- a/internal/cli/pond_bridge_test.go
+++ b/internal/cli/pond_bridge_test.go
@@ -66,6 +66,19 @@ func (b pondReleaseRetentionBackend) RetainLeaseClaimAfterRelease(LeaseTarget) b
 	return b.retain
 }
 
+type pondReleaseRetentionVerifierBackend struct {
+	retain bool
+	err    error
+}
+
+func (b pondReleaseRetentionVerifierBackend) Spec() ProviderSpec {
+	return ProviderSpec{Name: "test"}
+}
+
+func (b pondReleaseRetentionVerifierBackend) RetainLeaseClaimAfterReleaseWithClaim(LeaseTarget, LeaseClaim) (bool, error) {
+	return b.retain, b.err
+}
+
 func (f *fakeTailnetBridgeProvider) ValidateTailnetPeer(context.Context, string) (TailscaleMetadata, error) {
 	return f.meta, f.validateErr
 }
@@ -670,7 +683,11 @@ func TestFinalizePondReleaseClaimUsesProviderPolicy(t *testing.T) {
 			withTempClaims(t, []leaseClaim{claim})
 			lease := LeaseTarget{LeaseID: claim.LeaseID}
 
-			if got := finalizePondReleaseClaim(pondReleaseRetentionBackend{retain: tc.retain}, lease, claim); got != tc.retain {
+			got, err := finalizePondReleaseClaim(pondReleaseRetentionBackend{retain: tc.retain}, lease, claim)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.retain {
 				t.Fatalf("retained=%v want %v", got, tc.retain)
 			}
 			claims, err := listLeaseClaims()
@@ -684,6 +701,27 @@ func TestFinalizePondReleaseClaimUsesProviderPolicy(t *testing.T) {
 				t.Fatalf("released claim remains: %#v", claims)
 			}
 		})
+	}
+}
+
+func TestFinalizePondReleaseClaimPreservesClaimOnRetentionError(t *testing.T) {
+	claim := leaseClaim{LeaseID: "cbx_retention_error", Slug: "retained", Provider: "test", Pond: "demo", RepoRoot: "/repo"}
+	withTempClaims(t, []leaseClaim{claim})
+	want := errors.New("cannot re-attest durable claim")
+	retained, err := finalizePondReleaseClaim(
+		pondReleaseRetentionVerifierBackend{err: want},
+		LeaseTarget{LeaseID: claim.LeaseID},
+		claim,
+	)
+	if retained || !errors.Is(err, want) {
+		t.Fatalf("retained=%t err=%v", retained, err)
+	}
+	claims, listErr := listLeaseClaims()
+	if listErr != nil {
+		t.Fatal(listErr)
+	}
+	if len(claims) != 1 || claims[0].LeaseID != claim.LeaseID {
+		t.Fatalf("retention error erased claim: %#v", claims)
 	}
 }
 

--- a/internal/cli/pond_mesh.go
+++ b/internal/cli/pond_mesh.go
@@ -572,7 +572,7 @@ func collectPondMembersAcrossProviders(ctx context.Context, rt Runtime, cfg Conf
 	byProvider := make(map[string][]leaseClaim)
 	order := make([]string, 0, 4)
 	for _, claim := range matches {
-		key := strings.TrimSpace(claim.Provider)
+		key := canonicalClaimProvider(claim.Provider)
 		if _, seen := byProvider[key]; !seen {
 			order = append(order, key)
 		}

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -239,6 +239,11 @@ type ReleaseLeaseClaimRetainer interface {
 	RetainLeaseClaimAfterRelease(lease LeaseTarget) bool
 }
 
+type ReleaseLeaseClaimRetentionVerifier interface {
+	// An error leaves claim state untouched so uncertain ownership fails closed.
+	RetainLeaseClaimAfterReleaseWithClaim(lease LeaseTarget, previous LeaseClaim) (bool, error)
+}
+
 type NativeCheckpointCapability struct {
 	Kind              string
 	Direct            bool

--- a/internal/cli/provider_coordinator.go
+++ b/internal/cli/provider_coordinator.go
@@ -26,6 +26,8 @@ type coordinatorLeaseBackend struct {
 
 func (b *coordinatorLeaseBackend) Spec() ProviderSpec { return b.spec }
 
+func (b *coordinatorLeaseBackend) SupportsRequestedLeaseID() bool { return true }
+
 func (b *coordinatorLeaseBackend) RebindResolvedLeaseTarget(target *LeaseTarget, leaseID string) error {
 	if rebinder, ok := b.direct.(ResolvedLeaseTargetRebinder); ok {
 		return rebinder.RebindResolvedLeaseTarget(target, leaseID)
@@ -34,18 +36,56 @@ func (b *coordinatorLeaseBackend) RebindResolvedLeaseTarget(target *LeaseTarget,
 }
 
 func (b *coordinatorLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
+	if strings.TrimSpace(req.RequestedLeaseID) != "" {
+		acquired, err := b.acquireOnceWithLeaseID(ctx, req.Keep, strings.TrimSpace(req.RequestedLeaseID), req.RequestedSlug)
+		if err != nil {
+			return LeaseTarget{}, err
+		}
+		if req.OnAcquired != nil {
+			if err := req.OnAcquired(acquired); err != nil {
+				return LeaseTarget{}, fmt.Errorf("acknowledge fixed coordinator acquisition: %w", err)
+			}
+		}
+		return acquired, nil
+	}
 	return acquireAttemptsRetry(b.rt, req.Keep, func() (LeaseTarget, error) {
 		return b.acquireOnce(ctx, req.Keep, req.RequestedSlug)
 	})
 }
 
 func (b *coordinatorLeaseBackend) acquireOnce(ctx context.Context, keep bool, requestedSlug string) (LeaseTarget, error) {
-	leaseID := newLeaseID()
-	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
-	if err != nil {
-		return LeaseTarget{}, err
+	return b.acquireOnceWithLeaseID(ctx, keep, "", requestedSlug)
+}
+
+func (b *coordinatorLeaseBackend) acquireOnceWithLeaseID(ctx context.Context, keep bool, requestedLeaseID, requestedSlug string) (LeaseTarget, error) {
+	leaseID := requestedLeaseID
+	if leaseID == "" {
+		leaseID = newLeaseID()
 	}
-	keyPath, publicKey, err := ensureTestboxKeyForConfig(b.cfg, leaseID)
+	var slug string
+	var err error
+	if requestedLeaseID != "" {
+		slug = normalizeLeaseSlug(requestedSlug)
+		if slug == "" {
+			slug = newLeaseSlug(leaseID)
+		}
+	} else {
+		slug, err = allocateClaimLeaseSlug(leaseID, requestedSlug)
+		if err != nil {
+			return LeaseTarget{}, err
+		}
+	}
+	var keyPath, publicKey string
+	keyAction := func() error {
+		var keyErr error
+		keyPath, publicKey, keyErr = ensureTestboxKeyForConfig(b.cfg, leaseID)
+		return keyErr
+	}
+	if requestedLeaseID != "" {
+		err = withLeaseIDOperationLock(leaseID, keyAction)
+	} else {
+		err = keyAction()
+	}
 	if err != nil {
 		return LeaseTarget{}, err
 	}
@@ -58,15 +98,20 @@ func (b *coordinatorLeaseBackend) acquireOnce(ctx context.Context, keep bool, re
 	cfg.AWSSSHCIDRsPinned = len(cfg.AWSSSHCIDRs) > 0
 	ensureAWSSSHCIDRs(ctx, &cfg)
 	fmt.Fprintf(b.rt.Stderr, "coordinator lease class=%s preferred_type=%s keep=%v slug=%s idle_timeout=%s ttl=%s\n", cfg.Class, cfg.ServerType, keep, slug, cfg.IdleTimeout, cfg.TTL)
-	lease, err := b.createCoordinatorLeaseWithProgress(ctx, cfg, publicKey, keep, leaseID, slug)
+	lease, err := b.createCoordinatorLeaseWithProgressMode(ctx, cfg, publicKey, keep, leaseID, slug, requestedLeaseID != "")
 	if err != nil {
-		if isCoordinatorStaleInstanceCleanedSignal(err) {
-			return LeaseTarget{}, coordinatorStaleInstanceCleanedError{err: err}
-		}
-		if isCoordinatorStaleInstanceError(err) && b.releaseStaleCoordinatorLeaseForRetry(leaseID) {
-			return LeaseTarget{}, coordinatorStaleInstanceCleanedError{err: err}
+		if requestedLeaseID == "" {
+			if isCoordinatorStaleInstanceCleanedSignal(err) {
+				return LeaseTarget{}, coordinatorStaleInstanceCleanedError{err: err}
+			}
+			if isCoordinatorStaleInstanceError(err) && b.releaseStaleCoordinatorLeaseForRetry(leaseID) {
+				return LeaseTarget{}, coordinatorStaleInstanceCleanedError{err: err}
+			}
 		}
 		return LeaseTarget{}, err
+	}
+	if requestedLeaseID != "" && lease.ID != leaseID {
+		return LeaseTarget{}, exit(4, "lease_id_conflict: coordinator fixed create returned lease %s for operation %s", blank(lease.ID, "<empty>"), leaseID)
 	}
 	if lease.ID != "" && lease.ID != leaseID {
 		if err := moveStoredTestboxKey(leaseID, lease.ID); err != nil {
@@ -74,8 +119,10 @@ func (b *coordinatorLeaseBackend) acquireOnce(ctx context.Context, keep bool, re
 		}
 	}
 	if err := validateCoordinatorLeaseCapabilities(cfg, lease); err != nil {
-		if releaseErr := releaseCoordinatorLease(context.Background(), b.coord, blank(lease.ID, leaseID)); releaseErr != nil {
-			fmt.Fprintf(b.rt.Stderr, "warning: release failed after capability mismatch for %s: %v\n", blank(lease.ID, leaseID), releaseErr)
+		if requestedLeaseID == "" {
+			if releaseErr := releaseCoordinatorLease(context.Background(), b.coord, blank(lease.ID, leaseID)); releaseErr != nil {
+				fmt.Fprintf(b.rt.Stderr, "warning: release failed after capability mismatch for %s: %v\n", blank(lease.ID, leaseID), releaseErr)
+			}
 		}
 		return LeaseTarget{}, err
 	}
@@ -96,8 +143,10 @@ func (b *coordinatorLeaseBackend) acquireOnce(ctx context.Context, keep bool, re
 	defer stopLeaseWatch()
 	bootstrapTarget := bootstrapNetworkTarget(cfg, server, target)
 	if err := bootstrapManagedWindowsDesktop(waitCtx, cfg, &bootstrapTarget, publicKey, b.rt.Stderr); err != nil {
-		if releaseErr := releaseCoordinatorLease(context.Background(), b.coord, leaseID); releaseErr != nil {
-			fmt.Fprintf(b.rt.Stderr, "warning: release failed after bootstrap error for %s: %v\n", leaseID, releaseErr)
+		if requestedLeaseID == "" {
+			if releaseErr := releaseCoordinatorLease(context.Background(), b.coord, leaseID); releaseErr != nil {
+				fmt.Fprintf(b.rt.Stderr, "warning: release failed after bootstrap error for %s: %v\n", leaseID, releaseErr)
+			}
 		}
 		return LeaseTarget{}, err
 	}
@@ -142,12 +191,22 @@ type coordinatorCreateLeaseResult struct {
 }
 
 func (b *coordinatorLeaseBackend) createCoordinatorLeaseWithProgress(ctx context.Context, cfg Config, publicKey string, keep bool, leaseID, slug string) (CoordinatorLease, error) {
+	return b.createCoordinatorLeaseWithProgressMode(ctx, cfg, publicKey, keep, leaseID, slug, false)
+}
+
+func (b *coordinatorLeaseBackend) createCoordinatorLeaseWithProgressMode(ctx context.Context, cfg Config, publicKey string, keep bool, leaseID, slug string, fixed bool) (CoordinatorLease, error) {
 	timeout := coordinatorCreateLeaseTimeoutForConfig(cfg)
 	createCtx, cancelCreate := context.WithTimeout(ctx, timeout)
 	defer cancelCreate()
 	resultCh := make(chan coordinatorCreateLeaseResult, 1)
 	go func() {
-		lease, err := b.coord.CreateLease(createCtx, cfg, publicKey, keep, leaseID, slug)
+		var lease CoordinatorLease
+		var err error
+		if fixed {
+			lease, err = b.coord.EnsureLease(createCtx, cfg, publicKey, keep, leaseID, slug)
+		} else {
+			lease, err = b.coord.CreateLease(createCtx, cfg, publicKey, keep, leaseID, slug)
+		}
 		resultCh <- coordinatorCreateLeaseResult{lease: lease, err: err}
 	}()
 
@@ -157,6 +216,12 @@ func (b *coordinatorLeaseBackend) createCoordinatorLeaseWithProgress(ctx context
 	for {
 		select {
 		case result := <-resultCh:
+			if fixed && result.err != nil {
+				if lease, recoverErr, handled := b.recoverFixedCoordinatorLeaseAfterCreateError(ctx, cfg, publicKey, keep, leaseID, slug, result.err); handled {
+					return lease, recoverErr
+				}
+				return CoordinatorLease{}, result.err
+			}
 			if result.err != nil && errors.Is(result.err, context.DeadlineExceeded) && ctx.Err() == nil {
 				err := coordinatorCreateLeaseTimeoutError(cfg, leaseID, slug, timeout)
 				if lease, ok := b.recoverCoordinatorLeaseAfterCreateError(ctx, cfg, leaseID, slug, err); ok {
@@ -169,6 +234,9 @@ func (b *coordinatorLeaseBackend) createCoordinatorLeaseWithProgress(ctx context
 					return lease, nil
 				}
 			}
+			if result.err == nil && result.lease.State == "provisioning" {
+				return b.waitForCoordinatorLeaseActivation(createCtx, leaseID, result.lease)
+			}
 			return result.lease, result.err
 		case <-ticker.C:
 			fmt.Fprintf(b.rt.Stderr, "waiting for coordinator lease provider=%s slug=%s elapsed=%s timeout=%s\n", cfg.Provider, slug, time.Since(started).Round(time.Second), timeout)
@@ -177,10 +245,72 @@ func (b *coordinatorLeaseBackend) createCoordinatorLeaseWithProgress(ctx context
 				return CoordinatorLease{}, ctx.Err()
 			}
 			err := coordinatorCreateLeaseTimeoutError(cfg, leaseID, slug, timeout)
+			if fixed {
+				if lease, recoverErr, handled := b.recoverFixedCoordinatorLeaseAfterCreateError(ctx, cfg, publicKey, keep, leaseID, slug, err); handled {
+					return lease, recoverErr
+				}
+				return CoordinatorLease{}, err
+			}
 			if lease, ok := b.recoverCoordinatorLeaseAfterCreateError(ctx, cfg, leaseID, slug, err); ok {
 				return lease, nil
 			}
 			return CoordinatorLease{}, err
+		case <-ctx.Done():
+			return CoordinatorLease{}, ctx.Err()
+		}
+	}
+}
+
+func (b *coordinatorLeaseBackend) recoverFixedCoordinatorLeaseAfterCreateError(ctx context.Context, cfg Config, publicKey string, keep bool, leaseID, slug string, createErr error) (CoordinatorLease, error, bool) {
+	if !coordinatorCreateLeaseErrorMayHaveCommitted(createErr) {
+		return CoordinatorLease{}, nil, false
+	}
+	recoverCtx, cancel := context.WithTimeout(ctx, coordinatorCreateLeaseRecoveryTimeout)
+	defer cancel()
+	fmt.Fprintf(b.rt.Stderr, "warning: coordinator fixed lease create returned uncertain result for %s; repeating exact PUT: %v\n", leaseID, createErr)
+	ticker := time.NewTicker(coordinatorCreateLeaseRecoveryInterval)
+	defer ticker.Stop()
+	for {
+		lease, err := b.coord.EnsureLease(recoverCtx, cfg, publicKey, keep, leaseID, slug)
+		if err == nil {
+			fmt.Fprintf(b.rt.Stderr, "confirmed coordinator fixed lease %s slug=%s with exact PUT after uncertain create\n", leaseID, blank(lease.Slug, slug))
+			if lease.State == "provisioning" {
+				active, waitErr := b.waitForCoordinatorLeaseActivation(recoverCtx, leaseID, lease)
+				return active, waitErr, true
+			}
+			return lease, nil, true
+		}
+		if !coordinatorCreateLeaseErrorMayHaveCommitted(err) {
+			return CoordinatorLease{}, err, true
+		}
+		select {
+		case <-ticker.C:
+		case <-recoverCtx.Done():
+			return CoordinatorLease{}, errors.Join(createErr, recoverCtx.Err()), true
+		}
+	}
+}
+
+func (b *coordinatorLeaseBackend) waitForCoordinatorLeaseActivation(ctx context.Context, leaseID string, current CoordinatorLease) (CoordinatorLease, error) {
+	ticker := time.NewTicker(coordinatorCreateLeaseRecoveryInterval)
+	defer ticker.Stop()
+	for {
+		if current.State == "active" && current.Host != "" {
+			return current, nil
+		}
+		if current.State == "failed" || current.State == "released" || current.State == "expired" {
+			return CoordinatorLease{}, fmt.Errorf("coordinator fixed lease %s ended while provisioning: state=%s error=%s", leaseID, current.State, current.FailureError)
+		}
+		select {
+		case <-ticker.C:
+			lease, err := b.coord.GetLease(ctx, leaseID)
+			if err != nil {
+				if !coordinatorCreateLeaseErrorMayHaveCommitted(err) {
+					return CoordinatorLease{}, err
+				}
+				continue
+			}
+			current = lease
 		case <-ctx.Done():
 			return CoordinatorLease{}, ctx.Err()
 		}

--- a/internal/cli/provider_coordinator_test.go
+++ b/internal/cli/provider_coordinator_test.go
@@ -4,9 +4,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -331,6 +336,174 @@ func TestCoordinatorAcquireSendsTailscaleHostnameTemplate(t *testing.T) {
 	}
 }
 
+func TestCoordinatorFixedAcquireUsesRequestedIDAndJoinsProvisioning(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	oldInterval := coordinatorCreateLeaseRecoveryInterval
+	coordinatorCreateLeaseRecoveryInterval = time.Millisecond
+	defer func() { coordinatorCreateLeaseRecoveryInterval = oldInterval }()
+
+	puts := 0
+	gets := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/leases/cbx_abcdef123456":
+			puts++
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
+				ID: "cbx_abcdef123456", Slug: "fixed-coordinator", Provider: "aws", TargetOS: targetLinux, State: "provisioning",
+			}})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/leases/cbx_abcdef123456":
+			gets++
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
+				ID: "cbx_abcdef123456", Slug: "fixed-coordinator", Provider: "aws", TargetOS: targetLinux,
+				State: "active", CloudID: "i-fixed", Host: "203.0.113.10", SSHUser: "crabbox", SSHPort: "2222", WorkRoot: defaultPOSIXWorkRoot,
+			}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	cfg := baseConfig()
+	cfg.Provider = "aws"
+	cfg.TargetOS = targetLinux
+	cfg.Coordinator = server.URL
+	cfg.CoordToken = "user-token"
+	coord, _, err := newCoordinatorClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend := &coordinatorLeaseBackend{cfg: cfg, coord: coord, rt: Runtime{Stderr: &bytes.Buffer{}}}
+	lease, err := backend.createCoordinatorLeaseWithProgressMode(
+		context.Background(), cfg, "ssh-ed25519 test", true,
+		"cbx_abcdef123456", "fixed-coordinator", true,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.ID != "cbx_abcdef123456" || lease.CloudID != "i-fixed" || puts != 1 || gets == 0 {
+		t.Fatalf("lease=%#v puts=%d gets=%d", lease, puts, gets)
+	}
+}
+
+func TestCoordinatorFixedAcquireInvokesOnAcquiredOnceAndPropagatesError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX fake ssh helper requires a unix-like host")
+	}
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	toolDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(toolDir, "ssh"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", toolDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	readyServer := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	defer readyServer.Close()
+	readyURL, err := url.Parse(readyServer.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	host, port, err := net.SplitHostPort(readyURL.Host)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	creates := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		lease := CoordinatorLease{
+			ID: "cbx_abcdef123467", Slug: "fixed-callback", Provider: "aws", TargetOS: targetLinux,
+			State: "active", CloudID: "i-fixed", Host: host, SSHUser: "crabbox", SSHPort: port, WorkRoot: defaultPOSIXWorkRoot,
+		}
+		switch {
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/leases/cbx_abcdef123467":
+			creates++
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/leases/cbx_abcdef123467":
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/leases/cbx_abcdef123467/heartbeat":
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	cfg := baseConfig()
+	cfg.Provider = "aws"
+	cfg.TargetOS = targetLinux
+	cfg.Coordinator = server.URL
+	cfg.CoordToken = "user-token"
+	coord, _, err := newCoordinatorClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend := &coordinatorLeaseBackend{cfg: cfg, coord: coord, rt: Runtime{Stderr: &bytes.Buffer{}}}
+	want := errors.New("acknowledgment rejected")
+	callbacks := 0
+	lease, err := backend.Acquire(context.Background(), AcquireRequest{
+		Keep: true, RequestedLeaseID: "cbx_abcdef123467", RequestedSlug: "fixed-callback",
+		OnAcquired: func(acquired LeaseTarget) error {
+			callbacks++
+			if acquired.LeaseID != "cbx_abcdef123467" || acquired.Server.CloudID != "i-fixed" {
+				t.Fatalf("callback acquired=%#v", acquired)
+			}
+			return want
+		},
+	})
+	if !errors.Is(err, want) || !strings.Contains(err.Error(), "acknowledge fixed coordinator acquisition") {
+		t.Fatalf("lease=%#v err=%v", lease, err)
+	}
+	if lease.LeaseID != "" {
+		t.Fatalf("error returned non-empty lease=%#v", lease)
+	}
+	if callbacks != 1 || creates != 1 {
+		t.Fatalf("callbacks=%d creates=%d, want one each", callbacks, creates)
+	}
+}
+
+func TestCoordinatorFixedAcquireDoesNotReleaseCommittedLeaseAfterClientBootstrapFailure(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	releases := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/leases/cbx_abcdef123457":
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
+				ID: "cbx_abcdef123457", Slug: "fixed-bootstrap", Provider: "aws", TargetOS: targetLinux,
+				State: "active", CloudID: "i-fixed", Host: "127.0.0.1", SSHUser: "crabbox", SSHPort: "1", WorkRoot: defaultPOSIXWorkRoot,
+			}})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/leases/cbx_abcdef123457/release":
+			releases++
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{ID: "cbx_abcdef123457", State: "released"}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	cfg := baseConfig()
+	cfg.Provider = "aws"
+	cfg.TargetOS = targetLinux
+	cfg.Coordinator = server.URL
+	cfg.CoordToken = "user-token"
+	coord, _, err := newCoordinatorClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend := &coordinatorLeaseBackend{cfg: cfg, coord: coord, rt: Runtime{Stderr: &bytes.Buffer{}}}
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	_, err = backend.Acquire(ctx, AcquireRequest{
+		Keep: true, RequestedLeaseID: "cbx_abcdef123457", RequestedSlug: "fixed-bootstrap",
+	})
+	if err == nil {
+		t.Fatal("expected client-side bootstrap failure")
+	}
+	if releases != 0 {
+		t.Fatalf("fixed replay released committed coordinator lease %d time(s)", releases)
+	}
+}
+
 func TestCoordinatorAcquireReportsSelectedImageAndProviderStartupTiming(t *testing.T) {
 	lease := CoordinatorLease{
 		ID:         "cbx_image",
@@ -507,6 +680,121 @@ func TestCoordinatorCreateLeaseRecoversLeaseCommittedAfterCreateError(t *testing
 		if !strings.Contains(stderr.String(), want) {
 			t.Fatalf("stderr=%q missing %q", stderr.String(), want)
 		}
+	}
+}
+
+func TestCoordinatorFixedCreateAmbiguousErrorRepeatsPutAndDoesNotAdoptConflictingGet(t *testing.T) {
+	oldRecoveryTimeout := coordinatorCreateLeaseRecoveryTimeout
+	oldRecoveryInterval := coordinatorCreateLeaseRecoveryInterval
+	coordinatorCreateLeaseRecoveryTimeout = time.Second
+	coordinatorCreateLeaseRecoveryInterval = time.Millisecond
+	defer func() {
+		coordinatorCreateLeaseRecoveryTimeout = oldRecoveryTimeout
+		coordinatorCreateLeaseRecoveryInterval = oldRecoveryInterval
+	}()
+
+	puts := 0
+	gets := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/leases/cbx_abcdef123462":
+			puts++
+			if puts == 1 {
+				http.Error(w, "error code: 1101", http.StatusInternalServerError)
+				return
+			}
+			http.Error(w, `{"error":"lease_id_conflict","message":"lease id is bound to another create intent"}`, http.StatusConflict)
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/leases/cbx_abcdef123462":
+			gets++
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
+				ID: "cbx_abcdef123462", Slug: "other-intent", Provider: "aws", TargetOS: targetLinux,
+				State: "active", CloudID: "i-other", Host: "203.0.113.99",
+			}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	cfg := baseConfig()
+	cfg.Provider = "aws"
+	cfg.TargetOS = targetLinux
+	cfg.Coordinator = server.URL
+	cfg.CoordToken = "user-token"
+	coord, _, err := newCoordinatorClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend := &coordinatorLeaseBackend{cfg: cfg, coord: coord, rt: Runtime{Stderr: &bytes.Buffer{}}}
+	_, err = backend.createCoordinatorLeaseWithProgressMode(
+		context.Background(), cfg, "ssh-ed25519 test", true,
+		"cbx_abcdef123462", "fixed-conflict", true,
+	)
+	if err == nil || !strings.Contains(err.Error(), "lease_id_conflict") {
+		t.Fatalf("err=%v, want fixed intent conflict", err)
+	}
+	if puts != 2 || gets != 0 {
+		t.Fatalf("puts=%d gets=%d, want exact PUT retry and no GET adoption", puts, gets)
+	}
+}
+
+func TestCoordinatorFixedCreateCommitThenTimeoutRepeatsPutAndCreatesOnce(t *testing.T) {
+	oldRecoveryTimeout := coordinatorCreateLeaseRecoveryTimeout
+	oldRecoveryInterval := coordinatorCreateLeaseRecoveryInterval
+	coordinatorCreateLeaseRecoveryTimeout = time.Second
+	coordinatorCreateLeaseRecoveryInterval = time.Millisecond
+	defer func() {
+		coordinatorCreateLeaseRecoveryTimeout = oldRecoveryTimeout
+		coordinatorCreateLeaseRecoveryInterval = oldRecoveryInterval
+	}()
+
+	puts := 0
+	gets := 0
+	creates := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/leases/cbx_abcdef123463":
+			puts++
+			if puts == 1 {
+				creates++
+				http.Error(w, "error code: 1101", http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
+				ID: "cbx_abcdef123463", Slug: "fixed-commit", Provider: "aws", TargetOS: targetLinux, State: "provisioning",
+			}})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/leases/cbx_abcdef123463":
+			gets++
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
+				ID: "cbx_abcdef123463", Slug: "fixed-commit", Provider: "aws", TargetOS: targetLinux,
+				State: "active", CloudID: "i-fixed", Host: "203.0.113.44",
+			}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	cfg := baseConfig()
+	cfg.Provider = "aws"
+	cfg.TargetOS = targetLinux
+	cfg.Coordinator = server.URL
+	cfg.CoordToken = "user-token"
+	coord, _, err := newCoordinatorClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend := &coordinatorLeaseBackend{cfg: cfg, coord: coord, rt: Runtime{Stderr: &bytes.Buffer{}}}
+	lease, err := backend.createCoordinatorLeaseWithProgressMode(
+		context.Background(), cfg, "ssh-ed25519 test", true,
+		"cbx_abcdef123463", "fixed-commit", true,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.ID != "cbx_abcdef123463" || lease.CloudID != "i-fixed" || puts != 2 || gets == 0 || creates != 1 {
+		t.Fatalf("lease=%#v puts=%d gets=%d creates=%d", lease, puts, gets, creates)
 	}
 }
 

--- a/internal/cli/provider_exports.go
+++ b/internal/cli/provider_exports.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 )
@@ -241,6 +242,10 @@ func ReplaceLeaseClaimIfUnchangedDurableReturning(leaseID string, current, repla
 	return replaceLeaseClaimIfUnchangedDurableReturning(leaseID, current, replacement)
 }
 
+func ReplaceLeaseClaimIfUnchangedDurableAfter(leaseID string, current, replacement LeaseClaim, action func() error) (LeaseClaim, error) {
+	return replaceLeaseClaimIfUnchangedDurableAfter(leaseID, current, replacement, action)
+}
+
 func ValidateAzureSSHCIDRsForAcquire(ctx context.Context, cfg Config) error {
 	_, err := azureSSHCIDRsForRules(ctx, cfg, nil)
 	return err
@@ -274,6 +279,12 @@ func UpdateLeaseClaimEndpointIfUnchangedAfter(leaseID string, expected LeaseClai
 
 func WithLeaseClaimUnchanged(leaseID string, expected LeaseClaim, action func() error) error {
 	return withLeaseClaimUnchanged(leaseID, expected, action)
+}
+
+// WithDurableLeaseClaimLock serializes a provider operation on the existing
+// claim lock and exposes explicit durable checkpoints before side effects.
+func WithDurableLeaseClaimLock(leaseID string, action func(*LeaseClaim, bool, func() error) error) error {
+	return withDurableLeaseClaimLock(leaseID, action)
 }
 
 func ResolveLeaseClaimAfterActionIfUnchanged(
@@ -365,6 +376,14 @@ func ServerLeaseClaimSnapshot(server Server) (LeaseClaim, bool, bool) {
 
 func OSImageWasExplicit(cfg Config) bool {
 	return cfg.osImageExplicit
+}
+
+func ImageRequirementsIntent(cfg Config) (string, error) {
+	data, err := json.Marshal(cfg.imageRequirements)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
 }
 
 func ClassWasExplicit(cfg Config) bool {

--- a/internal/providers/aws/backend.go
+++ b/internal/providers/aws/backend.go
@@ -2,10 +2,13 @@ package aws
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"os"
+	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -36,6 +39,7 @@ const awsAcquireRollbackTimeout = 2 * time.Minute
 type awsClient interface {
 	ListCrabboxServers(context.Context) ([]Server, error)
 	CreateServerWithFallback(context.Context, Config, string, string, string, bool, func(string, ...any)) (Server, Config, error)
+	CreateServerWithFallbackControl(context.Context, Config, string, string, string, bool, func(string, ...any), *core.AWSFixedCreateControl) (Server, Config, error)
 	WaitForServerIP(context.Context, string) (Server, error)
 	GetServer(context.Context, string) (Server, error)
 	DeleteServer(context.Context, string) error
@@ -53,7 +57,12 @@ func NewAWSLeaseBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
 	return &awsLeaseBackend{DirectSSHBackend: shared.DirectSSHBackend{SpecValue: spec, Cfg: cfg, RT: rt, Delete: deleteServer, StoredLeaseKeys: true}}
 }
 
+func (b *awsLeaseBackend) SupportsRequestedLeaseID() bool { return true }
+
 func (b *awsLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
+	if strings.TrimSpace(req.RequestedLeaseID) != "" {
+		return b.acquireFixed(ctx, req)
+	}
 	return acquireAttemptsRetry(b.RT, req.Keep, func() (LeaseTarget, error) {
 		return b.acquireOnce(ctx, req.Keep, req.RequestedSlug)
 	})
@@ -134,6 +143,346 @@ func (b *awsLeaseBackend) acquireOnce(ctx context.Context, keep bool, requestedS
 	}
 	rollback = false
 	return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+}
+
+const (
+	fixedAWSCreateIntentVersion = core.FixedAWSCreateIntentVersion
+	fixedAWSIntentPrepared      = "prepared"
+	fixedAWSIntentAcquired      = "acquired"
+	fixedAWSIntentReleased      = "released"
+)
+
+func (b *awsLeaseBackend) acquireFixed(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
+	leaseID := strings.TrimSpace(req.RequestedLeaseID)
+	var acquired LeaseTarget
+	err := core.WithDurableLeaseClaimLock(leaseID, func(claim *core.LeaseClaim, exists bool, persist func() error) error {
+		if b.Cfg.Tailscale.Enabled && b.Cfg.Tailscale.AuthKey == "" {
+			return exit(2, "direct --tailscale requires %s to contain a Tailscale auth key; brokered mode uses coordinator OAuth secrets", b.Cfg.Tailscale.AuthKeyEnv)
+		}
+		cfg := b.Cfg
+		client, err := newAWSClient(ctx, cfg)
+		if err != nil {
+			return err
+		}
+		accountID, err := client.CallerAccountID(ctx)
+		if err != nil {
+			return fmt.Errorf("bind fixed AWS lease account: %w", err)
+		}
+		providerScope := "account:" + accountID
+		keyPath, publicKey, err := ensureTestboxKeyForConfig(cfg, leaseID)
+		if err != nil {
+			return err
+		}
+		cfg.SSHKey = keyPath
+		cfg.ProviderKey = providerKeyForLease(leaseID)
+		cfg.AWSSSHCIDRsPinned = len(cfg.AWSSSHCIDRs) > 0
+		ensureAWSSSHCIDRs(ctx, &cfg)
+		requestedSlug := core.NormalizeLeaseSlug(req.RequestedSlug)
+		fingerprint, err := fixedAWSCreateFingerprint(cfg, accountID, requestedSlug, publicKey, req.Keep)
+		if err != nil {
+			return err
+		}
+
+		if exists {
+			if claim.FixedCreateIntent == nil ||
+				claim.FixedCreateIntent.Version != fixedAWSCreateIntentVersion ||
+				claim.FixedCreateIntent.Fingerprint != fingerprint ||
+				claim.FixedCreateIntent.ProviderScope != providerScope {
+				return exit(4, "lease_id_conflict: lease %s is bound to another create intent", leaseID)
+			}
+			if claim.Provider != core.FixedAWSClaimProvider {
+				return exit(4, "lease_id_conflict: lease %s is bound to provider=%s", leaseID, claim.Provider)
+			}
+			if claim.RepoRoot != "" && claim.RepoRoot != req.Repo.Root && !req.Reclaim {
+				return exit(4, "lease_id_conflict: lease %s is bound to another repository", leaseID)
+			}
+		} else {
+			servers, err := b.listAcrossRegions(ctx)
+			if err != nil {
+				return err
+			}
+			slug, err := allocateDirectLeaseSlug(leaseID, requestedSlug, servers)
+			if err != nil {
+				return err
+			}
+			now := time.Now().UTC()
+			claim.LeaseID = leaseID
+			claim.Slug = slug
+			claim.Provider = core.FixedAWSClaimProvider
+			claim.ProviderScope = providerScope
+			claim.TargetOS = cfg.TargetOS
+			claim.WindowsMode = cfg.WindowsMode
+			claim.RepoRoot = req.Repo.Root
+			claim.ClaimedAt = now.Format(time.RFC3339)
+			claim.LastUsedAt = claim.ClaimedAt
+			claim.IdleTimeoutSeconds = int(cfg.IdleTimeout.Seconds())
+			claim.FixedCreateIntent = &core.FixedCreateIntent{
+				Version:       fixedAWSCreateIntentVersion,
+				Fingerprint:   fingerprint,
+				ProviderScope: providerScope,
+				Slug:          slug,
+				CreatedAt:     now.Format(time.RFC3339Nano),
+				State:         fixedAWSIntentPrepared,
+			}
+			if err := persist(); err != nil {
+				return err
+			}
+		}
+
+		intent := claim.FixedCreateIntent
+		switch intent.State {
+		case fixedAWSIntentPrepared, fixedAWSIntentAcquired:
+		case fixedAWSIntentReleased:
+			return exit(4, "lease_id_conflict: fixed lease %s is terminal and cannot be replayed", leaseID)
+		default:
+			return exit(4, "lease_id_conflict: fixed lease %s has invalid create state %q", leaseID, intent.State)
+		}
+		createdAt, err := time.Parse(time.RFC3339Nano, intent.CreatedAt)
+		if err != nil {
+			return exit(4, "lease_id_conflict: lease %s has invalid fixed create timestamp", leaseID)
+		}
+		if cfg.TTL > 0 && time.Now().UTC().After(createdAt.Add(cfg.TTL)) {
+			return exit(4, "lease_id_conflict: fixed create intent for lease %s has expired", leaseID)
+		}
+		servers, err := b.listAcrossRegions(ctx)
+		if err != nil {
+			return err
+		}
+		matching := fixedAWSLeaseMatches(servers, leaseID)
+		if len(matching) > 1 {
+			return exit(4, "lease_id_conflict: multiple AWS resources match fixed lease %s", leaseID)
+		}
+		pinned, err := fixedAWSAttemptFromIntent(intent)
+		if err != nil {
+			return exit(4, "lease_id_conflict: invalid fixed AWS attempt for lease %s: %v", leaseID, err)
+		}
+		var server Server
+		resolvedCfg := cfg
+		if len(matching) == 1 {
+			server = matching[0]
+			if intent.State == fixedAWSIntentAcquired || claim.CloudID != "" {
+				if claim.CloudID == "" || server.CloudID != claim.CloudID {
+					return exit(4, "lease_id_conflict: fixed lease %s resource %s does not match acquired CloudID %s", leaseID, blank(server.CloudID, "<empty>"), blank(claim.CloudID, "<empty>"))
+				}
+			}
+			if err := validateFixedAWSServer(server, leaseID, intent.Slug, fingerprint, accountID); err != nil {
+				return err
+			}
+			if pinned == nil {
+				return exit(4, "lease_id_conflict: fixed AWS resource for lease %s has no durable launch attempt", leaseID)
+			}
+			if err := validateFixedAWSAttemptServer(server, leaseID, *pinned); err != nil {
+				return err
+			}
+			resolvedCfg = awsConfigForServer(cfg, server)
+		} else {
+			if intent.State == fixedAWSIntentAcquired || claim.CloudID != "" {
+				return exit(4, "lease_id_conflict: acquired fixed lease %s is missing its bound AWS instance", leaseID)
+			}
+			if pinned != nil {
+				return exit(4, "lease_id_conflict: fixed AWS lease %s has an unresolved launch attempt; retry after provider inventory converges", leaseID)
+			}
+			failed := make(map[string]bool, len(intent.FailedAttempts))
+			for _, token := range intent.FailedAttempts {
+				failed[token] = true
+			}
+			control := &core.AWSFixedCreateControl{
+				CreatedAt:         createdAt,
+				IntentFingerprint: fingerprint,
+				AccountID:         accountID,
+				FailedTokens:      failed,
+			}
+			control.BeforeAttempt = func(attempt core.AWSLaunchAttempt) error {
+				encoded, err := fixedAWSAttemptMap(attempt)
+				if err != nil {
+					return err
+				}
+				intent.Attempt = encoded
+				return persist()
+			}
+			control.DefiniteFailure = func(attempt core.AWSLaunchAttempt) error {
+				if !failed[attempt.ClientToken] {
+					intent.FailedAttempts = append(intent.FailedAttempts, attempt.ClientToken)
+					failed[attempt.ClientToken] = true
+				}
+				intent.Attempt = nil
+				return persist()
+			}
+			fmt.Fprintf(b.RT.Stderr, "provisioning provider=aws lease=%s slug=%s class=%s preferred_type=%s region=%s keep=%v market=%s strategy=%s fixed=true\n", leaseID, intent.Slug, cfg.Class, cfg.ServerType, cfg.AWSRegion, req.Keep, cfg.Capacity.Market, cfg.Capacity.Strategy)
+			server, resolvedCfg, err = client.CreateServerWithFallbackControl(ctx, cfg, publicKey, leaseID, intent.Slug, req.Keep, func(format string, args ...any) {
+				fmt.Fprintf(b.RT.Stderr, format, args...)
+			}, control)
+			if err != nil {
+				return err
+			}
+		}
+
+		serverClient, err := newAWSClient(ctx, resolvedCfg)
+		if err != nil {
+			return err
+		}
+		server, err = serverClient.WaitForServerIP(ctx, server.CloudID)
+		if err != nil {
+			return err
+		}
+		server = annotateAWSServerRegion(server, resolvedCfg.AWSRegion)
+		if err := validateFixedAWSServer(server, leaseID, intent.Slug, fingerprint, accountID); err != nil {
+			return err
+		}
+		pinned, err = fixedAWSAttemptFromIntent(intent)
+		if err != nil || pinned == nil {
+			return exit(4, "lease_id_conflict: fixed AWS lease %s has no valid durable launch attempt after provisioning", leaseID)
+		}
+		if err := validateFixedAWSAttemptServer(server, leaseID, *pinned); err != nil {
+			return err
+		}
+		target := sshTargetForBootstrap(resolvedCfg, server.PublicNet.IPv4.IP, leaseID, intent.Slug)
+		if err := bootstrapAWSWindowsDesktop(ctx, resolvedCfg, &target, publicKey, b.RT.Stderr); err != nil {
+			return err
+		}
+		server.Labels["state"] = "ready"
+		if err := serverClient.SetTags(ctx, server.CloudID, server.Labels); err != nil {
+			return fmt.Errorf("persist AWS fixed lease identity tags: %w", err)
+		}
+		claim.CloudID = server.CloudID
+		claim.Slug = intent.Slug
+		claim.Provider = core.FixedAWSClaimProvider
+		claim.ProviderScope = providerScope
+		claim.Labels = cloneAWSLabels(server.Labels)
+		claim.SSHHost = target.Host
+		claim.LastUsedAt = time.Now().UTC().Format(time.RFC3339)
+		if port, parseErr := strconv.Atoi(strings.TrimSpace(target.Port)); parseErr == nil {
+			claim.SSHPort = port
+		}
+		intent.State = fixedAWSIntentAcquired
+		if err := persist(); err != nil {
+			return err
+		}
+		acquired = LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}
+		return nil
+	})
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	if req.OnAcquired != nil {
+		if err := req.OnAcquired(acquired); err != nil {
+			return LeaseTarget{}, fmt.Errorf("acknowledge fixed AWS acquisition: %w", err)
+		}
+	}
+	return acquired, nil
+}
+
+func fixedAWSCreateFingerprint(cfg Config, accountID, requestedSlug, publicKey string, keep bool) (string, error) {
+	return core.FixedAWSCreateIntentFingerprint(cfg, core.FixedAWSCreateIntentRequest{
+		AccountID:     accountID,
+		RequestedSlug: requestedSlug,
+		SSHPublicKey:  publicKey,
+		Keep:          keep,
+	})
+}
+
+func fixedAWSLeaseMatches(servers []LeaseView, leaseID string) []Server {
+	var matching []Server
+	for _, server := range servers {
+		if server.Labels["lease"] == leaseID {
+			matching = append(matching, server)
+		}
+	}
+	return matching
+}
+
+func validateFixedAWSServer(server Server, leaseID, slug, fingerprint, accountID string) error {
+	if !isCrabboxAWSLease(server) || server.Labels["lease"] != leaseID ||
+		core.NormalizeLeaseSlug(server.Labels["slug"]) != slug ||
+		server.Labels["fixed_intent_sha256"] != fingerprint ||
+		server.Labels["aws_account_id"] != accountID {
+		return exit(4, "lease_id_conflict: AWS resource for lease %s does not match its fixed create intent", leaseID)
+	}
+	return nil
+}
+
+func validateFixedAWSAttemptServer(server Server, leaseID string, attempt core.AWSLaunchAttempt) error {
+	if err := core.ValidateAWSFixedAttemptAttestation(server.Labels, attempt); err != nil {
+		return exit(4, "lease_id_conflict: AWS resource for lease %s does not match its durable launch attempt: %v", leaseID, err)
+	}
+	if strings.TrimSpace(server.ServerType.Name) != strings.TrimSpace(attempt.ServerType) ||
+		awsServerRegion(server) != strings.TrimSpace(attempt.Region) ||
+		strings.TrimSpace(server.HostID) != strings.TrimSpace(attempt.HostID) {
+		return exit(4, "lease_id_conflict: AWS resource for lease %s provider identity does not match its durable launch attempt", leaseID)
+	}
+	if err := validateFixedAWSAttemptProviderMetadata(server, attempt); err != nil {
+		return exit(4, "lease_id_conflict: AWS resource for lease %s provider metadata does not match its durable launch attempt: %v", leaseID, err)
+	}
+	return nil
+}
+
+func validateFixedAWSAttemptProviderMetadata(server Server, attempt core.AWSLaunchAttempt) error {
+	metadata := server.ProviderMetadata
+	require := func(key, expected string) error {
+		if strings.TrimSpace(expected) == "" {
+			return nil
+		}
+		actual, ok := metadata[key].(string)
+		if !ok || strings.TrimSpace(actual) != strings.TrimSpace(expected) {
+			return fmt.Errorf("%s=%q, want %q", key, actual, expected)
+		}
+		return nil
+	}
+	if err := require("region", attempt.Region); err != nil {
+		return err
+	}
+	if err := require("availabilityZone", attempt.AvailabilityZone); err != nil {
+		return err
+	}
+	if err := require("subnetID", attempt.SubnetID); err != nil {
+		return err
+	}
+	if err := require("imageID", attempt.ImageID); err != nil {
+		return err
+	}
+	if err := require("market", attempt.Market); err != nil {
+		return err
+	}
+	groups, ok := metadata["securityGroupIDs"].([]string)
+	if !ok || !slices.Contains(groups, attempt.SecurityGroupID) {
+		return fmt.Errorf("securityGroupIDs=%v do not contain %q", groups, attempt.SecurityGroupID)
+	}
+	return nil
+}
+
+func fixedAWSAttemptMap(attempt core.AWSLaunchAttempt) (map[string]string, error) {
+	data, err := json.Marshal(attempt)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]string{"aws": string(data)}, nil
+}
+
+func fixedAWSAttemptFromIntent(intent *core.FixedCreateIntent) (*core.AWSLaunchAttempt, error) {
+	if len(intent.Attempt) == 0 {
+		return nil, nil
+	}
+	value := intent.Attempt["aws"]
+	if value == "" {
+		return nil, errors.New("missing AWS attempt payload")
+	}
+	var attempt core.AWSLaunchAttempt
+	if err := json.Unmarshal([]byte(value), &attempt); err != nil {
+		return nil, err
+	}
+	if attempt.Region == "" || attempt.ServerType == "" || attempt.ImageID == "" ||
+		attempt.SecurityGroupID == "" || attempt.ClientToken == "" || attempt.ParametersSHA256 == "" {
+		return nil, errors.New("incomplete AWS attempt payload")
+	}
+	return &attempt, nil
+}
+
+func cloneAWSLabels(labels map[string]string) map[string]string {
+	cloned := make(map[string]string, len(labels))
+	for key, value := range labels {
+		cloned[key] = value
+	}
+	return cloned
 }
 
 func (b *awsLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {
@@ -224,6 +573,22 @@ func (b *awsLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequ
 	if !isCrabboxAWSLease(req.Lease.Server) || req.Lease.LeaseID != req.Lease.Server.Labels["lease"] {
 		return exit(4, "refusing to release AWS instance %s without matching canonical Crabbox ownership tags", req.Lease.Server.DisplayID())
 	}
+	claim, exists, err := core.ReadLeaseClaimWithPresence(req.Lease.LeaseID)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(req.Lease.Server.Labels["fixed_intent_sha256"]) != "" && (!exists || !isFixedAWSClaim(claim)) {
+		return exit(4, "refusing to release fixed AWS lease %s without its durable create intent", req.Lease.LeaseID)
+	}
+	if exists && isFixedAWSClaim(claim) {
+		exact, err := requireExactAWSClaim(req.Lease.Server, req.Lease.LeaseID)
+		if err != nil {
+			return err
+		}
+		return finalizeAWSClaimAfterCleanup(exact, func() error {
+			return deleteServer(ctx, awsConfigForServer(b.Cfg, req.Lease.Server), req.Lease.Server)
+		})
+	}
 	if err := deleteServer(ctx, awsConfigForServer(b.Cfg, req.Lease.Server), req.Lease.Server); err != nil {
 		var keyErr *awsProviderKeyCleanupError
 		if errors.As(err, &keyErr) {
@@ -237,6 +602,37 @@ func (b *awsLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequ
 
 func (b *awsLeaseBackend) ReleaseLeaseMessage(lease LeaseTarget) string {
 	return fmt.Sprintf("deleted lease=%s server=%s name=%s", lease.LeaseID, lease.Server.DisplayID(), lease.Server.Name)
+}
+
+func (b *awsLeaseBackend) RetainLeaseClaimAfterRelease(lease LeaseTarget) bool {
+	retained, err := b.retainLeaseClaimAfterRelease(lease, core.LeaseClaim{})
+	return retained || err != nil
+}
+
+func (b *awsLeaseBackend) RetainLeaseClaimAfterReleaseWithClaim(lease LeaseTarget, previous core.LeaseClaim) (bool, error) {
+	return b.retainLeaseClaimAfterRelease(lease, previous)
+}
+
+func (b *awsLeaseBackend) retainLeaseClaimAfterRelease(lease LeaseTarget, previous core.LeaseClaim) (bool, error) {
+	claim, exists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+	if err != nil {
+		return false, fmt.Errorf("re-attest released AWS claim %s: %w", lease.LeaseID, err)
+	}
+	serverFingerprint := strings.TrimSpace(lease.Server.Labels["fixed_intent_sha256"])
+	previousFixed := isFixedAWSClaim(previous)
+	if !exists || !isFixedAWSClaim(claim) {
+		if previousFixed || serverFingerprint != "" {
+			return false, exit(4, "lease_id_conflict: fixed AWS lease %s has no valid terminal tombstone after release", lease.LeaseID)
+		}
+		return false, nil
+	}
+	if err := validateFixedAWSTerminalClaim(claim, previous, lease.LeaseID); err != nil {
+		return false, err
+	}
+	if serverFingerprint != "" && serverFingerprint != claim.FixedCreateIntent.Fingerprint {
+		return false, exit(4, "lease_id_conflict: fixed AWS lease %s server tag differs from its terminal tombstone", lease.LeaseID)
+	}
+	return true, nil
 }
 
 func (b *awsLeaseBackend) Touch(ctx context.Context, req TouchRequest) (Server, error) {
@@ -407,8 +803,10 @@ func allocateDirectLeaseSlug(id, requested string, servers []Server) (string, er
 func ensureTestboxKeyForConfig(cfg Config, leaseID string) (string, string, error) {
 	return core.EnsureTestboxKeyForConfig(cfg, leaseID)
 }
-func providerKeyForLease(leaseID string) string          { return core.ProviderKeyForLease(leaseID) }
-func ensureAWSSSHCIDRs(ctx context.Context, cfg *Config) { core.EnsureAWSSSHCIDRs(ctx, cfg) }
+func providerKeyForLease(leaseID string) string { return core.ProviderKeyForLease(leaseID) }
+
+var ensureAWSSSHCIDRs = func(ctx context.Context, cfg *Config) { core.EnsureAWSSSHCIDRs(ctx, cfg) }
+
 func sshTargetFromConfig(cfg Config, host string) SSHTarget {
 	return core.SSHTargetFromConfig(cfg, host)
 }
@@ -480,7 +878,7 @@ func requireExactAWSClaim(server Server, expectedLeaseID string) (core.LeaseClai
 	}
 	if !isCrabboxAWSLease(server) ||
 		claim.LeaseID != expectedLeaseID ||
-		claim.Provider != "aws" ||
+		!isAWSClaimProvider(claim.Provider) ||
 		claim.CloudID == "" ||
 		claim.CloudID != server.CloudID ||
 		claim.Slug == "" ||
@@ -502,7 +900,7 @@ func requireExactAWSClaim(server Server, expectedLeaseID string) (core.LeaseClai
 
 func deleteClaimedAWSServerWithClient(ctx context.Context, client awsClient, server Server, claim core.LeaseClaim, cleanupKeyID string) error {
 	var cleanupErr error
-	err := core.RemoveLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, func() error {
+	err := finalizeAWSClaimAfterCleanup(claim, func() error {
 		cleanupErr = deleteAWSCleanupServerWithClient(ctx, client, server, cleanupKeyID)
 		return cleanupErr
 	})
@@ -555,7 +953,7 @@ func (b *awsLeaseBackend) cleanupOrphanedAWSClaims(ctx context.Context, dryRun b
 		return err
 	}
 	for _, claim := range claims {
-		if claim.Provider != "aws" || !core.IsCanonicalLeaseID(claim.LeaseID) {
+		if !isAWSClaimProvider(claim.Provider) || !core.IsCanonicalLeaseID(claim.LeaseID) {
 			continue
 		}
 		labels := claim.Labels
@@ -605,9 +1003,68 @@ func (b *awsLeaseBackend) cleanupOrphanedAWSClaims(ctx context.Context, dryRun b
 }
 
 func deleteMissingClaimedAWSResourcesWithClient(ctx context.Context, client awsClient, claim core.LeaseClaim, cleanupKeyID string) error {
-	return core.RemoveLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, func() error {
+	return finalizeAWSClaimAfterCleanup(claim, func() error {
 		return client.DeleteCleanupSSHKeyID(ctx, cleanupKeyID)
 	})
+}
+
+func isFixedAWSClaim(claim core.LeaseClaim) bool {
+	return claim.Provider == core.FixedAWSClaimProvider && claim.FixedCreateIntent != nil
+}
+
+func isAWSClaimProvider(provider string) bool {
+	return provider == "aws" || provider == core.FixedAWSClaimProvider
+}
+
+func finalizeAWSClaimAfterCleanup(claim core.LeaseClaim, action func() error) error {
+	if !isFixedAWSClaim(claim) {
+		return core.RemoveLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, action)
+	}
+	tombstone := fixedAWSTerminalClaim(claim, time.Now().UTC())
+	_, err := core.ReplaceLeaseClaimIfUnchangedDurableAfter(claim.LeaseID, claim, tombstone, action)
+	return err
+}
+
+func fixedAWSTerminalClaim(claim core.LeaseClaim, now time.Time) core.LeaseClaim {
+	intent := *claim.FixedCreateIntent
+	intent.State = fixedAWSIntentReleased
+	intent.Attempt = nil
+	intent.FailedAttempts = nil
+	return core.LeaseClaim{
+		LeaseID:           claim.LeaseID,
+		Slug:              intent.Slug,
+		Provider:          core.FixedAWSClaimProvider,
+		ProviderScope:     intent.ProviderScope,
+		ClaimedAt:         claim.ClaimedAt,
+		LastUsedAt:        now.Format(time.RFC3339),
+		FixedCreateIntent: &intent,
+	}
+}
+
+func validateFixedAWSTerminalClaim(claim, previous core.LeaseClaim, leaseID string) error {
+	intent := claim.FixedCreateIntent
+	if claim.LeaseID != leaseID || !isFixedAWSClaim(claim) ||
+		intent.Version != fixedAWSCreateIntentVersion ||
+		strings.TrimSpace(intent.Fingerprint) == "" ||
+		strings.TrimSpace(intent.ProviderScope) == "" ||
+		claim.ProviderScope != intent.ProviderScope ||
+		claim.Slug != intent.Slug ||
+		intent.State != fixedAWSIntentReleased ||
+		claim.CloudID != "" || len(claim.Labels) != 0 || claim.SSHHost != "" || claim.SSHPort != 0 ||
+		len(intent.Attempt) != 0 || len(intent.FailedAttempts) != 0 {
+		return exit(4, "lease_id_conflict: fixed AWS lease %s has an invalid terminal tombstone", leaseID)
+	}
+	if isFixedAWSClaim(previous) {
+		previousIntent := previous.FixedCreateIntent
+		if previous.LeaseID != leaseID ||
+			previousIntent.Version != intent.Version ||
+			previousIntent.Fingerprint != intent.Fingerprint ||
+			previousIntent.ProviderScope != intent.ProviderScope ||
+			previousIntent.Slug != intent.Slug {
+			return exit(4, "lease_id_conflict: fixed AWS lease %s terminal tombstone changed identity", leaseID)
+		}
+	}
+	return nil
 }
 
 func deleteAWSCleanupServerWithClient(ctx context.Context, client awsClient, server Server, cleanupKeyID string) error {
@@ -718,6 +1175,10 @@ func annotateAWSServerRegion(server Server, region string) Server {
 	if server.Labels == nil {
 		server.Labels = map[string]string{}
 	}
+	if server.ProviderMetadata == nil {
+		server.ProviderMetadata = map[string]any{}
+	}
+	server.ProviderMetadata["region"] = region
 	if strings.TrimSpace(server.Labels["aws_region"]) == "" {
 		server.Labels["aws_region"] = region
 	}

--- a/internal/providers/aws/backend_test.go
+++ b/internal/providers/aws/backend_test.go
@@ -2,10 +2,12 @@ package aws
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"maps"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -15,6 +17,7 @@ import (
 )
 
 type fakeAWSClient struct {
+	mu               sync.Mutex
 	servers          []Server
 	created          Server
 	createCalls      int
@@ -37,10 +40,13 @@ type fakeAWSClient struct {
 	accountErr       error
 	tagged           []string
 	setTagsErr       error
+	controlCreate    func(*core.AWSFixedCreateControl, Config, string, string) (Server, Config, error)
 }
 
 func (c *fakeAWSClient) ListCrabboxServers(context.Context) ([]Server, error) {
-	return c.servers, nil
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]Server(nil), c.servers...), nil
 }
 
 func (c *fakeAWSClient) CreateServerWithFallback(_ context.Context, cfg Config, _, leaseID, slug string, _ bool, _ func(string, ...any)) (Server, Config, error) {
@@ -62,7 +68,34 @@ func (c *fakeAWSClient) CreateServerWithFallback(_ context.Context, cfg Config, 
 	return c.created, c.createCfg, nil
 }
 
+func (c *fakeAWSClient) CreateServerWithFallbackControl(ctx context.Context, cfg Config, publicKey, leaseID, slug string, keep bool, logf func(string, ...any), control *core.AWSFixedCreateControl) (Server, Config, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.controlCreate != nil {
+		return c.controlCreate(control, cfg, leaseID, slug)
+	}
+	c.createCalls++
+	c.createSlugs = append(c.createSlugs, slug)
+	attempt := core.AWSLaunchAttempt{
+		Region: cfg.AWSRegion, ServerType: cfg.ServerType, Market: cfg.Capacity.Market,
+		ImageID: "ami-fixed", SecurityGroupID: "sg-fixed", KeyPairID: "key-id-for-" + cfg.ProviderKey,
+		ClientToken: "fixed-token", ParametersSHA256: strings.Repeat("a", 64),
+	}
+	if control.BeforeAttempt != nil {
+		if err := control.BeforeAttempt(attempt); err != nil {
+			return Server{}, cfg, err
+		}
+	}
+	server := fixedAWSTestServer(control, cfg, leaseID, slug, attempt)
+	c.created = server
+	c.servers = []Server{server}
+	c.createCfg = cfg
+	return server, cfg, nil
+}
+
 func (c *fakeAWSClient) WaitForServerIP(context.Context, string) (Server, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	if c.waitErr != nil {
 		return Server{}, c.waitErr
 	}
@@ -163,6 +196,747 @@ func TestAWSAcquireCleansUpCreatedServerAndKeyOnIPFailure(t *testing.T) {
 	}
 	if len(fake.deletedKeys) != 1 || fake.deletedKeys[0] != fake.created.Labels["aws_key_pair_id"] {
 		t.Fatalf("deleted keys=%v, want immutable created key cleanup", fake.deletedKeys)
+	}
+}
+
+func TestAWSFixedAcquireReplaysSameLeaseAndRejectsIntentDrift(t *testing.T) {
+	testutil.IsolateUserDirs(t)
+	fake := &fakeAWSClient{}
+	restore := installFixedAWSTestClient(t, fake)
+	defer restore()
+	cfg := fixedAWSTestConfig()
+	repo := t.TempDir()
+	req := AcquireRequest{Repo: core.Repo{Root: repo}, Keep: true, RequestedLeaseID: "cbx_abcdef123456", RequestedSlug: "fixed-aws"}
+
+	first := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	lease, err := first.Acquire(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	replayed, err := second.Acquire(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.LeaseID != req.RequestedLeaseID || replayed.Server.CloudID != lease.Server.CloudID || fake.createCalls != 1 {
+		t.Fatalf("lease=%#v replay=%#v creates=%d", lease, replayed, fake.createCalls)
+	}
+
+	drifted := req
+	drifted.RequestedSlug = "different-slug"
+	if _, err := second.Acquire(context.Background(), drifted); err == nil || !strings.Contains(err.Error(), "lease_id_conflict") {
+		t.Fatalf("drift err=%v", err)
+	}
+	if fake.createCalls != 1 {
+		t.Fatalf("creates=%d after drift, want 1", fake.createCalls)
+	}
+
+	duplicate := fake.servers[0]
+	duplicate.CloudID = "i-fixed-duplicate"
+	fake.servers = append(fake.servers, duplicate)
+	if _, err := second.Acquire(context.Background(), req); err == nil || !strings.Contains(err.Error(), "multiple AWS resources") {
+		t.Fatalf("duplicate err=%v", err)
+	}
+	if fake.createCalls != 1 {
+		t.Fatalf("creates=%d after duplicate detection, want 1", fake.createCalls)
+	}
+}
+
+func TestAWSFixedAcquireRejectsDifferentAcquiredCloudIDWithCopiedTags(t *testing.T) {
+	testutil.IsolateUserDirs(t)
+	fake := &fakeAWSClient{}
+	restore := installFixedAWSTestClient(t, fake)
+	defer restore()
+	cfg := fixedAWSTestConfig()
+	req := AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef123481", RequestedSlug: "cloud-id-bound"}
+	lease, err := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	impostor := lease.Server
+	impostor.CloudID = "i-copied-fixed-tags"
+	impostor.Labels = maps.Clone(lease.Server.Labels)
+	fake.servers = []Server{impostor}
+	creates := fake.createCalls
+
+	_, err = NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req)
+	if err == nil || !strings.Contains(err.Error(), "lease_id_conflict") || !strings.Contains(err.Error(), "acquired CloudID") {
+		t.Fatalf("different acquired CloudID replay err=%v", err)
+	}
+	if fake.createCalls != creates {
+		t.Fatalf("different acquired CloudID replay called create: before=%d after=%d", creates, fake.createCalls)
+	}
+}
+
+func TestAWSFixedAcquireConflictsOnExplicitSSHCIDRDrift(t *testing.T) {
+	testutil.IsolateUserDirs(t)
+	fake := &fakeAWSClient{}
+	restore := installFixedAWSTestClient(t, fake)
+	defer restore()
+	repo := t.TempDir()
+	req := AcquireRequest{Repo: core.Repo{Root: repo}, Keep: true, RequestedLeaseID: "cbx_abcdef123468", RequestedSlug: "cidr-drift"}
+	firstCfg := fixedAWSTestConfig()
+	firstCfg.AWSSSHCIDRs = []string{"198.51.100.10/32"}
+	if _, err := NewAWSLeaseBackend(ProviderSpec{}, firstCfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	creates := fake.createCalls
+	secondCfg := fixedAWSTestConfig()
+	secondCfg.AWSSSHCIDRs = []string{"203.0.113.20/32"}
+	if _, err := NewAWSLeaseBackend(ProviderSpec{}, secondCfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req); err == nil || !strings.Contains(err.Error(), "lease_id_conflict") {
+		t.Fatalf("explicit CIDR drift err=%v", err)
+	}
+	if fake.createCalls != creates {
+		t.Fatalf("explicit CIDR drift called create: before=%d after=%d", creates, fake.createCalls)
+	}
+}
+
+func TestAWSFixedAcquireIgnoresDiscoveredUnpinnedSSHCIDRDrift(t *testing.T) {
+	testutil.IsolateUserDirs(t)
+	fake := &fakeAWSClient{}
+	restore := installFixedAWSTestClient(t, fake)
+	defer restore()
+	oldEnsure := ensureAWSSSHCIDRs
+	detected := "198.51.100.10/32"
+	var pinnedValues []bool
+	ensureAWSSSHCIDRs = func(_ context.Context, cfg *Config) {
+		pinnedValues = append(pinnedValues, cfg.AWSSSHCIDRsPinned)
+		if len(cfg.AWSSSHCIDRs) == 0 {
+			cfg.AWSSSHCIDRs = []string{detected}
+		}
+	}
+	defer func() { ensureAWSSSHCIDRs = oldEnsure }()
+	req := AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef123469", RequestedSlug: "cidr-discovered"}
+	if _, err := NewAWSLeaseBackend(ProviderSpec{}, fixedAWSTestConfig(), Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	detected = "203.0.113.20/32"
+	if _, err := NewAWSLeaseBackend(ProviderSpec{}, fixedAWSTestConfig(), Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	if len(pinnedValues) != 2 || pinnedValues[0] || pinnedValues[1] {
+		t.Fatalf("discovered CIDR pin states=%v, want two unpinned calls", pinnedValues)
+	}
+	if fake.createCalls != 1 || len(fake.servers) != 1 {
+		t.Fatalf("discovered CIDR replay creates=%d resources=%d, want one", fake.createCalls, len(fake.servers))
+	}
+}
+
+func TestAWSFixedAcquireConflictsOnCacheVolumeDrift(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		leaseID string
+		mutate  func(*core.CacheVolumeConfig)
+	}{
+		{name: "name", leaseID: "cbx_abcdef12347a", mutate: func(volume *core.CacheVolumeConfig) { volume.Name = "npm" }},
+		{name: "key", leaseID: "cbx_abcdef12347b", mutate: func(volume *core.CacheVolumeConfig) { volume.Key = "repo-npm" }},
+		{name: "path", leaseID: "cbx_abcdef12347c", mutate: func(volume *core.CacheVolumeConfig) { volume.Path = "/var/cache/npm" }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			testutil.IsolateUserDirs(t)
+			fake := &fakeAWSClient{}
+			restore := installFixedAWSTestClient(t, fake)
+			defer restore()
+			req := AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: test.leaseID, RequestedSlug: "cache-drift"}
+			firstCfg := fixedAWSTestConfig()
+			firstCfg.Cache.Volumes = []core.CacheVolumeConfig{{
+				Name: "pnpm", Key: "repo-pnpm", Path: "/var/cache/pnpm", SizeGB: 40, Required: true,
+			}}
+			if _, err := NewAWSLeaseBackend(ProviderSpec{}, firstCfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req); err != nil {
+				t.Fatal(err)
+			}
+			creates := fake.createCalls
+			secondCfg := firstCfg
+			secondCfg.Cache.Volumes = append([]core.CacheVolumeConfig(nil), firstCfg.Cache.Volumes...)
+			test.mutate(&secondCfg.Cache.Volumes[0])
+			if _, err := NewAWSLeaseBackend(ProviderSpec{}, secondCfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req); err == nil || !strings.Contains(err.Error(), "lease_id_conflict") {
+				t.Fatalf("cache %s drift err=%v", test.name, err)
+			}
+			if fake.createCalls != creates {
+				t.Fatalf("cache %s drift called create: before=%d after=%d", test.name, creates, fake.createCalls)
+			}
+		})
+	}
+}
+
+func TestAWSFixedAcquireClaimDoesNotPersistSecrets(t *testing.T) {
+	testutil.IsolateUserDirs(t)
+	fake := &fakeAWSClient{}
+	restore := installFixedAWSTestClient(t, fake)
+	defer restore()
+	const secret = "sentinel-fixed-aws-secret"
+	cfg := fixedAWSTestConfig()
+	cfg.CoordToken = secret
+	cfg.CoordAdminToken = secret
+	cfg.Access.ClientID = secret
+	cfg.Access.ClientSecret = secret
+	cfg.Access.Token = secret
+	cfg.Tailscale.Enabled = true
+	cfg.Tailscale.AuthKey = secret
+	cfg.Tailscale.AuthKeyEnv = "SECRET_ENV"
+	req := AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef12347d", RequestedSlug: "secret-free"}
+	if _, err := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	claim, exists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+	if err != nil || !exists {
+		t.Fatalf("read fixed claim: exists=%t err=%v", exists, err)
+	}
+	data, err := json.Marshal(claim)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), secret) {
+		t.Fatalf("fixed claim persisted secret material: %s", data)
+	}
+	if fake.createCalls != 1 {
+		t.Fatalf("creates=%d, want one", fake.createCalls)
+	}
+}
+
+func TestAWSFixedAcquireRejectsPriorFingerprintVersion(t *testing.T) {
+	testutil.IsolateUserDirs(t)
+	fake := &fakeAWSClient{}
+	restore := installFixedAWSTestClient(t, fake)
+	defer restore()
+	cfg := fixedAWSTestConfig()
+	req := AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef12347e", RequestedSlug: "old-version"}
+	backend := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	if _, err := backend.Acquire(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	if err := core.WithDurableLeaseClaimLock(req.RequestedLeaseID, func(claim *core.LeaseClaim, exists bool, persist func() error) error {
+		if !exists || claim.FixedCreateIntent == nil {
+			t.Fatal("fixed claim missing")
+		}
+		claim.FixedCreateIntent.Version = fixedAWSCreateIntentVersion - 1
+		return persist()
+	}); err != nil {
+		t.Fatal(err)
+	}
+	creates := fake.createCalls
+	if _, err := backend.Acquire(context.Background(), req); err == nil || !strings.Contains(err.Error(), "lease_id_conflict") {
+		t.Fatalf("old fingerprint version replay err=%v", err)
+	}
+	if fake.createCalls != creates {
+		t.Fatalf("old fingerprint version replay called create: before=%d after=%d", creates, fake.createCalls)
+	}
+}
+
+func TestAWSFixedAcquireRejectsAcquiredLeaseWhenBoundInstanceIsMissing(t *testing.T) {
+	testutil.IsolateUserDirs(t)
+	fake := &fakeAWSClient{}
+	restore := installFixedAWSTestClient(t, fake)
+	defer restore()
+	cfg := fixedAWSTestConfig()
+	req := AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef123460", RequestedSlug: "acquired-missing"}
+	backend := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	if _, err := backend.Acquire(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	creates := fake.createCalls
+	fake.servers = nil
+
+	restarted := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	if _, err := restarted.Acquire(context.Background(), req); err == nil || !strings.Contains(err.Error(), "lease_id_conflict") || !strings.Contains(err.Error(), "missing its bound AWS instance") {
+		t.Fatalf("missing acquired replay err=%v", err)
+	}
+	if fake.createCalls != creates {
+		t.Fatalf("missing acquired replay called create: before=%d after=%d", creates, fake.createCalls)
+	}
+	if err := restarted.cleanupOrphanedAWSClaims(context.Background(), false); err != nil {
+		t.Fatal(err)
+	}
+	claim, exists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+	if err != nil || !exists || claim.FixedCreateIntent == nil || claim.FixedCreateIntent.State != fixedAWSIntentReleased {
+		t.Fatalf("missing acquired cleanup did not retain terminal tombstone: exists=%t claim=%#v err=%v", exists, claim, err)
+	}
+	if fake.createCalls != creates {
+		t.Fatalf("missing acquired cleanup called create: before=%d after=%d", creates, fake.createCalls)
+	}
+}
+
+func TestAWSFixedReleasePersistsTerminalTombstoneAndRejectsReplay(t *testing.T) {
+	testutil.IsolateUserDirs(t)
+	fake := &fakeAWSClient{}
+	restore := installFixedAWSTestClient(t, fake)
+	defer restore()
+	cfg := fixedAWSTestConfig()
+	req := AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef123461", RequestedSlug: "released-fixed"}
+	backend := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	lease, err := backend.Acquire(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := core.ClaimLeaseTargetForRepoConfig(lease.LeaseID, req.RequestedSlug, cfg, lease.Server, lease.SSH, req.Repo.Root, cfg.IdleTimeout, false); err != nil {
+		t.Fatal(err)
+	}
+	liveClaim, exists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+	if err != nil || !exists {
+		t.Fatalf("read fixed claim: exists=%t err=%v", exists, err)
+	}
+	if liveClaim.Provider != core.FixedAWSClaimProvider {
+		t.Fatalf("fixed claim provider=%q, want downgrade-safe marker", liveClaim.Provider)
+	}
+	if resolved, ok, err := core.ResolveLeaseClaimForProvider(req.RequestedLeaseID, "aws"); err != nil || !ok || resolved.Provider != core.FixedAWSClaimProvider {
+		t.Fatalf("new client did not resolve fixed marker as AWS: claim=%#v ok=%t err=%v", resolved, ok, err)
+	}
+	legacyVisible := 0
+	for _, candidate := range mustListAWSClaims(t) {
+		if candidate.Provider == "aws" {
+			legacyVisible++
+		}
+	}
+	if legacyVisible != 0 {
+		t.Fatalf("legacy-style Provider==aws cleanup saw %d fixed claim(s)", legacyVisible)
+	}
+	strippedLease := lease
+	strippedLease.Server.Labels = maps.Clone(lease.Server.Labels)
+	delete(strippedLease.Server.Labels, "fixed_intent_sha256")
+	creates := fake.createCalls
+	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: strippedLease}); err != nil {
+		t.Fatal(err)
+	}
+	retained, err := backend.RetainLeaseClaimAfterReleaseWithClaim(strippedLease, liveClaim)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !retained {
+		core.RemoveLeaseClaim(strippedLease.LeaseID)
+		t.Fatal("fixed AWS outer release cleanup would erase its terminal tombstone")
+	}
+	if !backend.RetainLeaseClaimAfterRelease(strippedLease) {
+		t.Fatal("legacy retention hook did not fail closed on the durable fixed tombstone")
+	}
+	claim, exists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists || claim.FixedCreateIntent == nil {
+		t.Fatalf("fixed release removed its tombstone: exists=%t claim=%#v", exists, claim)
+	}
+	if claim.Provider != core.FixedAWSClaimProvider {
+		t.Fatalf("terminal provider=%q, want downgrade-safe marker", claim.Provider)
+	}
+	intent := claim.FixedCreateIntent
+	if intent.Version != fixedAWSCreateIntentVersion || intent.Fingerprint == "" || intent.ProviderScope == "" || intent.Slug != req.RequestedSlug || intent.State != fixedAWSIntentReleased {
+		t.Fatalf("terminal intent=%#v", intent)
+	}
+	if claim.CloudID != "" || claim.Labels != nil || claim.SSHHost != "" || len(intent.Attempt) != 0 || len(intent.FailedAttempts) != 0 {
+		t.Fatalf("terminal tombstone retained live resource state: claim=%#v", claim)
+	}
+
+	if err := backend.cleanupOrphanedAWSClaims(context.Background(), false); err != nil {
+		t.Fatal(err)
+	}
+	if _, stillExists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID); err != nil || !stillExists {
+		t.Fatalf("automatic orphan cleanup removed fixed tombstone: exists=%t err=%v", stillExists, err)
+	}
+	restarted := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	if _, err := restarted.Acquire(context.Background(), req); err == nil || !strings.Contains(err.Error(), "lease_id_conflict") || !strings.Contains(err.Error(), "terminal") {
+		t.Fatalf("released fixed replay err=%v", err)
+	}
+	if fake.createCalls != creates {
+		t.Fatalf("released fixed replay called create: before=%d after=%d", creates, fake.createCalls)
+	}
+	if len(fake.deletedInstances) != 1 {
+		t.Fatalf("deleted instances=%v, want one release", fake.deletedInstances)
+	}
+}
+
+func TestAWSOrdinaryReleaseKeepsLegacyClaimDeletionBehavior(t *testing.T) {
+	testutil.IsolateUserDirs(t)
+	server := awsTestServer("i-ordinary-release", "cbx_abcdef12347f", "ordinary-release", "us-east-1")
+	server.Labels["provider_key"] = core.ProviderKeyForLease(server.Labels["lease"])
+	fake := &fakeAWSClient{servers: []Server{server}}
+	restore := installFixedAWSTestClient(t, fake)
+	defer restore()
+	cfg := fixedAWSTestConfig()
+	if err := core.ClaimLeaseTargetForConfig(server.Labels["lease"], server.Labels["slug"], cfg, server, SSHTarget{}, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	previous, exists, err := core.ReadLeaseClaimWithPresence(server.Labels["lease"])
+	if err != nil || !exists {
+		t.Fatalf("read ordinary claim: exists=%t err=%v", exists, err)
+	}
+	backend := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	lease := LeaseTarget{LeaseID: server.Labels["lease"], Server: server}
+	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+	retained, err := backend.RetainLeaseClaimAfterReleaseWithClaim(lease, previous)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if retained {
+		t.Fatal("ordinary AWS release unexpectedly retained its claim")
+	}
+	if backend.RetainLeaseClaimAfterRelease(lease) {
+		t.Fatal("ordinary AWS legacy retention hook unexpectedly retained its claim")
+	}
+	if _, exists, err := core.ReadLeaseClaimWithPresence(server.Labels["lease"]); err != nil || exists {
+		t.Fatalf("ordinary AWS claim exists=%t err=%v, want deleted", exists, err)
+	}
+	if len(fake.deletedInstances) != 1 || fake.deletedInstances[0] != server.CloudID {
+		t.Fatalf("deleted instances=%v, want ordinary instance", fake.deletedInstances)
+	}
+}
+
+func TestAWSReleaseRejectsFixedTagWithoutDurableClaim(t *testing.T) {
+	testutil.IsolateUserDirs(t)
+	server := awsTestServer("i-fixed-no-claim", "cbx_abcdef123480", "fixed-no-claim", "us-east-1")
+	server.Labels["fixed_intent_sha256"] = strings.Repeat("a", 64)
+	fake := &fakeAWSClient{servers: []Server{server}}
+	restore := installFixedAWSTestClient(t, fake)
+	defer restore()
+	backend := NewAWSLeaseBackend(ProviderSpec{}, fixedAWSTestConfig(), Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: server.Labels["lease"], Server: server}})
+	if err == nil || !strings.Contains(err.Error(), "without its durable create intent") {
+		t.Fatalf("release err=%v", err)
+	}
+	if len(fake.deletedInstances) != 0 {
+		t.Fatalf("fixed-looking server deleted without durable claim: %v", fake.deletedInstances)
+	}
+}
+
+func mustListAWSClaims(t *testing.T) []core.LeaseClaim {
+	t.Helper()
+	claims, err := core.ListLeaseClaims()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return claims
+}
+
+func TestAWSFixedAcquireRecoversCommitThenTimeoutAfterFreshBackend(t *testing.T) {
+	testutil.IsolateUserDirs(t)
+	fake := &fakeAWSClient{}
+	resourceCount := 0
+	fake.controlCreate = func(control *core.AWSFixedCreateControl, cfg Config, leaseID, slug string) (Server, Config, error) {
+		fake.createCalls++
+		attempt := fixedAWSTestAttempt(cfg)
+		if err := control.BeforeAttempt(attempt); err != nil {
+			return Server{}, cfg, err
+		}
+		server := fixedAWSTestServer(control, cfg, leaseID, slug, attempt)
+		fake.created = server
+		fake.servers = []Server{server}
+		resourceCount = 1
+		return Server{}, cfg, errors.New("transport closed after RunInstances committed")
+	}
+	restore := installFixedAWSTestClient(t, fake)
+	defer restore()
+	req := AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef123457", RequestedSlug: "commit-timeout"}
+	cfg := fixedAWSTestConfig()
+	cfg.Tailscale.AuthKey = "fixed-intent-secret-must-not-persist"
+
+	first := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	if _, err := first.Acquire(context.Background(), req); err == nil {
+		t.Fatal("expected uncertain create error")
+	}
+	claim, err := core.ReadLeaseClaim(req.RequestedLeaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	claimJSON, err := json.Marshal(claim)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(claimJSON), cfg.Tailscale.AuthKey) {
+		t.Fatalf("fixed create claim persisted a secret: %s", claimJSON)
+	}
+	if claim.FixedCreateIntent == nil || len(claim.FixedCreateIntent.Attempt) == 0 {
+		t.Fatalf("fixed create attempt was not persisted before the provider error: %#v", claim.FixedCreateIntent)
+	}
+	attempt, err := fixedAWSAttemptFromIntent(claim.FixedCreateIntent)
+	if err != nil || attempt == nil {
+		t.Fatalf("read persisted fixed attempt: attempt=%#v err=%v", attempt, err)
+	}
+	if err := core.ValidateAWSFixedAttemptAttestation(fake.servers[0].Labels, *attempt); err != nil {
+		t.Fatalf("created resource lacks exact attempt attestation: %v", err)
+	}
+	fake.controlCreate = nil
+	second := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	lease, err := second.Acquire(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.Server.CloudID != "i-fixed" || fake.createCalls != 1 || resourceCount != 1 {
+		t.Fatalf("lease=%#v creates=%d resources=%d", lease, fake.createCalls, resourceCount)
+	}
+}
+
+func TestAWSFixedAcquireRejectsMismatchedOrMissingAttemptAttestation(t *testing.T) {
+	for _, tag := range []string{
+		"fixed_attempt_region",
+		"fixed_attempt_az",
+		"fixed_attempt_subnet",
+		"fixed_attempt_type",
+		"fixed_attempt_market",
+		"fixed_attempt_image",
+		"fixed_attempt_sg",
+		"fixed_attempt_host",
+		"fixed_attempt_key_pair",
+		"fixed_attempt_token_sha256",
+		"fixed_attempt_sha256",
+	} {
+		for _, mutation := range []string{"missing", "mismatched"} {
+			t.Run(strings.TrimPrefix(tag, "fixed_attempt_")+"/"+mutation, func(t *testing.T) {
+				testutil.IsolateUserDirs(t)
+				fake := &fakeAWSClient{}
+				fake.controlCreate = func(control *core.AWSFixedCreateControl, cfg Config, leaseID, slug string) (Server, Config, error) {
+					fake.createCalls++
+					attempt := fixedAWSTestAttempt(cfg)
+					attempt.AvailabilityZone = "us-east-1a"
+					attempt.SubnetID = "subnet-fixed"
+					attempt.HostID = "h-fixed"
+					if err := control.BeforeAttempt(attempt); err != nil {
+						return Server{}, cfg, err
+					}
+					fake.created = fixedAWSTestServer(control, cfg, leaseID, slug, attempt)
+					return Server{}, cfg, errors.New("transport closed after ambiguous fixed create")
+				}
+				restore := installFixedAWSTestClient(t, fake)
+				defer restore()
+				cfg := fixedAWSTestConfig()
+				req := AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef123482", RequestedSlug: "attempt-attested"}
+				if _, err := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req); err == nil {
+					t.Fatal("expected ambiguous create error")
+				}
+				candidate := fake.created
+				candidate.Labels = maps.Clone(fake.created.Labels)
+				if mutation == "missing" {
+					delete(candidate.Labels, tag)
+				} else {
+					candidate.Labels[tag] += "-other"
+				}
+				fake.servers = []Server{candidate}
+				fake.controlCreate = nil
+				creates := fake.createCalls
+
+				_, err := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req)
+				if err == nil || !strings.Contains(err.Error(), "lease_id_conflict") || !strings.Contains(err.Error(), "durable launch attempt") {
+					t.Fatalf("%s %s attestation replay err=%v", tag, mutation, err)
+				}
+				if fake.createCalls != creates {
+					t.Fatalf("%s %s attestation replay called create: before=%d after=%d", tag, mutation, creates, fake.createCalls)
+				}
+			})
+		}
+	}
+}
+
+func TestAWSFixedAcquireRejectsCopiedAttemptTagsWhenProviderTypeDiffers(t *testing.T) {
+	testutil.IsolateUserDirs(t)
+	fake := &fakeAWSClient{}
+	fake.controlCreate = func(control *core.AWSFixedCreateControl, cfg Config, leaseID, slug string) (Server, Config, error) {
+		fake.createCalls++
+		attempt := fixedAWSTestAttempt(cfg)
+		if err := control.BeforeAttempt(attempt); err != nil {
+			return Server{}, cfg, err
+		}
+		fake.created = fixedAWSTestServer(control, cfg, leaseID, slug, attempt)
+		return Server{}, cfg, errors.New("transport closed after ambiguous fixed create")
+	}
+	restore := installFixedAWSTestClient(t, fake)
+	defer restore()
+	cfg := fixedAWSTestConfig()
+	req := AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef123484", RequestedSlug: "provider-attested"}
+	if _, err := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req); err == nil {
+		t.Fatal("expected ambiguous create error")
+	}
+	candidate := fake.created
+	candidate.Labels = maps.Clone(fake.created.Labels)
+	candidate.ServerType.Name = "m7i.xlarge"
+	fake.servers = []Server{candidate}
+	fake.controlCreate = nil
+	creates := fake.createCalls
+
+	_, err := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req)
+	if err == nil || !strings.Contains(err.Error(), "lease_id_conflict") || !strings.Contains(err.Error(), "provider identity") {
+		t.Fatalf("copied attempt tags with wrong provider type err=%v", err)
+	}
+	if fake.createCalls != creates {
+		t.Fatalf("copied attempt tags replay called create: before=%d after=%d", creates, fake.createCalls)
+	}
+}
+
+func TestAWSFixedAcquireWaitsForDelayedVisibilityWithoutResubmitting(t *testing.T) {
+	testutil.IsolateUserDirs(t)
+	fake := &fakeAWSClient{}
+	providerCalls := 0
+	resourceCount := 0
+	fake.controlCreate = func(control *core.AWSFixedCreateControl, cfg Config, leaseID, slug string) (Server, Config, error) {
+		providerCalls++
+		attempt := fixedAWSTestAttempt(cfg)
+		if providerCalls != 1 {
+			return Server{}, cfg, errors.New("persisted fixed attempt was resubmitted")
+		}
+		if err := control.BeforeAttempt(attempt); err != nil {
+			return Server{}, cfg, err
+		}
+		fake.created = fixedAWSTestServer(control, cfg, leaseID, slug, attempt)
+		resourceCount = 1
+		return Server{}, cfg, errors.New("transport closed before instance became visible")
+	}
+	restore := installFixedAWSTestClient(t, fake)
+	defer restore()
+	req := AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef123458", RequestedSlug: "delayed-visible"}
+
+	if _, err := NewAWSLeaseBackend(ProviderSpec{}, fixedAWSTestConfig(), Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req); err == nil {
+		t.Fatal("expected first transport error")
+	}
+	if _, err := NewAWSLeaseBackend(ProviderSpec{}, fixedAWSTestConfig(), Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req); err == nil || !strings.Contains(err.Error(), "lease_id_conflict") || !strings.Contains(err.Error(), "inventory converges") {
+		t.Fatalf("first replay err=%v", err)
+	}
+	if providerCalls != 1 || resourceCount != 1 {
+		t.Fatalf("first replay providerCalls=%d resources=%d", providerCalls, resourceCount)
+	}
+	fake.servers = []Server{fake.created}
+	lease, err := NewAWSLeaseBackend(ProviderSpec{}, fixedAWSTestConfig(), Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.Server.CloudID != "i-fixed" || providerCalls != 1 || resourceCount != 1 {
+		t.Fatalf("lease=%#v providerCalls=%d resources=%d", lease, providerCalls, resourceCount)
+	}
+}
+
+func TestAWSFixedAcquireSerializesConcurrentReplay(t *testing.T) {
+	testutil.IsolateUserDirs(t)
+	fake := &fakeAWSClient{}
+	restore := installFixedAWSTestClient(t, fake)
+	defer restore()
+	req := AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef123459", RequestedSlug: "concurrent"}
+	start := make(chan struct{})
+	results := make(chan error, 2)
+	for range 2 {
+		go func() {
+			<-start
+			_, err := NewAWSLeaseBackend(ProviderSpec{}, fixedAWSTestConfig(), Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req)
+			results <- err
+		}()
+	}
+	close(start)
+	for range 2 {
+		if err := <-results; err != nil {
+			t.Fatal(err)
+		}
+	}
+	if fake.createCalls != 1 || len(fake.servers) != 1 {
+		t.Fatalf("creates=%d servers=%d", fake.createCalls, len(fake.servers))
+	}
+}
+
+func TestAWSFixedAcquireOnAcquiredCanReenterClaimLock(t *testing.T) {
+	testutil.IsolateUserDirs(t)
+	fake := &fakeAWSClient{}
+	restore := installFixedAWSTestClient(t, fake)
+	defer restore()
+	cfg := fixedAWSTestConfig()
+	repo := t.TempDir()
+	callbackCalled := make(chan struct{}, 1)
+	req := AcquireRequest{
+		Repo: core.Repo{Root: repo}, Keep: true, RequestedLeaseID: "cbx_abcdef123466", RequestedSlug: "callback-reentry",
+		OnAcquired: func(acquired LeaseTarget) error {
+			if err := core.ClaimLeaseTargetForRepoConfig(
+				acquired.LeaseID, "callback-reentry", cfg, acquired.Server, acquired.SSH,
+				repo, cfg.IdleTimeout, false,
+			); err != nil {
+				return err
+			}
+			callbackCalled <- struct{}{}
+			return nil
+		},
+	}
+	type acquireResult struct {
+		lease LeaseTarget
+		err   error
+	}
+	result := make(chan acquireResult, 1)
+	go func() {
+		lease, err := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req)
+		result <- acquireResult{lease: lease, err: err}
+	}()
+
+	timeout := 2 * time.Second
+	if testing.Short() {
+		timeout = time.Second
+	}
+	select {
+	case got := <-result:
+		if got.err != nil {
+			t.Fatal(got.err)
+		}
+		if got.lease.LeaseID != req.RequestedLeaseID {
+			t.Fatalf("lease=%#v", got.lease)
+		}
+	case <-time.After(timeout):
+		t.Fatal("fixed OnAcquired callback deadlocked while re-entering the claim lock")
+	}
+	select {
+	case <-callbackCalled:
+	default:
+		t.Fatal("OnAcquired callback was not called")
+	}
+	claim, exists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+	if err != nil || !exists || claim.FixedCreateIntent == nil || claim.FixedCreateIntent.State != fixedAWSIntentAcquired {
+		t.Fatalf("claim=%#v exists=%t err=%v", claim, exists, err)
+	}
+	if fake.createCalls != 1 || len(fake.servers) != 1 {
+		t.Fatalf("creates=%d resources=%d, want one", fake.createCalls, len(fake.servers))
+	}
+}
+
+func fixedAWSTestConfig() Config {
+	cfg := core.BaseConfig()
+	cfg.Provider = "aws"
+	cfg.TargetOS = "linux"
+	cfg.AWSRegion = "us-east-1"
+	cfg.ServerType = "m7i.large"
+	cfg.Capacity.Market = "on-demand"
+	return cfg
+}
+
+func fixedAWSTestAttempt(cfg Config) core.AWSLaunchAttempt {
+	return core.AWSLaunchAttempt{
+		Region: cfg.AWSRegion, ServerType: cfg.ServerType, Market: cfg.Capacity.Market,
+		ImageID: "ami-fixed", SecurityGroupID: "sg-fixed", KeyPairID: "key-id-for-" + cfg.ProviderKey,
+		ClientToken: "fixed-token", ParametersSHA256: strings.Repeat("a", 64),
+	}
+}
+
+func fixedAWSTestServer(control *core.AWSFixedCreateControl, cfg Config, leaseID, slug string, attempt core.AWSLaunchAttempt) Server {
+	server := awsTestServer("i-fixed", leaseID, slug, cfg.AWSRegion)
+	server.ServerType.Name = attempt.ServerType
+	server.HostID = attempt.HostID
+	server.ProviderMetadata = map[string]any{
+		"region":           attempt.Region,
+		"availabilityZone": attempt.AvailabilityZone,
+		"subnetID":         attempt.SubnetID,
+		"imageID":          attempt.ImageID,
+		"securityGroupIDs": []string{attempt.SecurityGroupID},
+		"market":           attempt.Market,
+	}
+	server.Labels["fixed_intent_sha256"] = control.IntentFingerprint
+	server.Labels["aws_account_id"] = control.AccountID
+	server.Labels["aws_key_pair_id"] = attempt.KeyPairID
+	server.Labels["provider_key"] = cfg.ProviderKey
+	for key, value := range core.AWSFixedAttemptAttestationLabels(attempt) {
+		server.Labels[key] = value
+	}
+	return server
+}
+
+func installFixedAWSTestClient(t *testing.T, fake *fakeAWSClient) func() {
+	t.Helper()
+	oldClient := newAWSClient
+	oldBootstrap := bootstrapAWSWindowsDesktop
+	newAWSClient = func(context.Context, Config) (awsClient, error) { return fake, nil }
+	bootstrapAWSWindowsDesktop = func(context.Context, Config, *SSHTarget, string, io.Writer) error { return nil }
+	return func() {
+		newAWSClient = oldClient
+		bootstrapAWSWindowsDesktop = oldBootstrap
 	}
 }
 

--- a/internal/providers/dockersandbox/backend_test.go
+++ b/internal/providers/dockersandbox/backend_test.go
@@ -818,7 +818,7 @@ func TestStatusWaitTimeoutDoesNotSleepPastDeadline(t *testing.T) {
 	}
 
 	oldPoll := statusPollInterval
-	statusPollInterval = 200 * time.Millisecond
+	statusPollInterval = 2 * time.Second
 	defer func() { statusPollInterval = oldPoll }()
 
 	runner := newRunner(map[string]scriptedReply{
@@ -837,7 +837,7 @@ func TestStatusWaitTimeoutDoesNotSleepPastDeadline(t *testing.T) {
 		t.Fatalf("Status err=%v want timeout", err)
 	}
 	if elapsed >= statusPollInterval/2 {
-		t.Fatalf("status wait elapsed=%s, want it bounded by the 20ms wait timeout rather than the 200ms poll interval", elapsed)
+		t.Fatalf("status wait elapsed=%s, want it bounded by the 20ms wait timeout rather than the 2s poll interval", elapsed)
 	}
 }
 

--- a/worker/src/coordinator-runtime.ts
+++ b/worker/src/coordinator-runtime.ts
@@ -35,6 +35,15 @@ export function coordinatorRequestQueue(request: Request): CoordinatorRequestQue
   if (method === "POST" && path.join("/") === "v1/leases") {
     return "direct";
   }
+  if (
+    method === "PUT" &&
+    path[0] === "v1" &&
+    path[1] === "leases" &&
+    path[2] &&
+    path.length === 3
+  ) {
+    return "direct";
+  }
   if (path[0] === "v1" && path[1] === "workspaces") {
     return "direct";
   }

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -1214,6 +1214,15 @@ export class FleetCoordinator {
       if (method === "POST" && parts.join("/") === "v1/leases/capability-aware") {
         return await this.createLease(request);
       }
+      if (
+        method === "PUT" &&
+        parts[0] === "v1" &&
+        parts[1] === "leases" &&
+        parts[2] &&
+        parts.length === 3
+      ) {
+        return await this.createLease(request, undefined, undefined, undefined, parts[2]);
+      }
       if (method === "POST" && parts.join("/") === "v1/workspaces") {
         return await this.createWorkspace(request);
       }
@@ -2990,10 +2999,22 @@ export class FleetCoordinator {
     reservationGuard?: () => Promise<Response | undefined>,
     workspaceID?: string,
     workspaceCapability?: ProviderWorkspaceCapability,
+    fixedLeaseID?: string,
   ): Promise<Response> {
     const owner = requestOwner(request);
     const org = requestOrg(request, this.env);
     const input = await readJson<LeaseRequest>(request);
+    if (fixedLeaseID) {
+      if (!validLeaseID(fixedLeaseID)) {
+        return json({ error: "invalid_lease_id" }, { status: 400 });
+      }
+      if (input.leaseID !== undefined && input.leaseID !== fixedLeaseID) {
+        return json(
+          { error: "lease_id_mismatch", message: "request leaseID must match the route" },
+          { status: 400 },
+        );
+      }
+    }
     const defaults: LeaseConfigDefaults = { allowAzurePromotedImage: true };
     const azureImage = this.env.CRABBOX_AZURE_IMAGE?.trim();
     if (azureImage) defaults.azureImage = azureImage;
@@ -3053,6 +3074,27 @@ export class FleetCoordinator {
         { status: 400 },
       );
     }
+    let fixedCreateIntentHash: string | undefined;
+    if (fixedLeaseID) {
+      if (!config.providerKey) {
+        config = { ...config, providerKey: providerKeyForLease(fixedLeaseID) };
+      }
+      fixedCreateIntentHash = await fixedLeaseCreateIntentHash(
+        config,
+        normalizeLeaseSlug(input.slug ?? input.requestedSlug),
+      );
+      const replay = await this.state.runExclusive(async () =>
+        this.fixedLeaseReplayResponse(
+          await this.getLease(fixedLeaseID),
+          owner,
+          org,
+          fixedCreateIntentHash!,
+        ),
+      );
+      if (replay) {
+        return replay;
+      }
+    }
     const configProvider = this.provider(
       config.provider,
       providerRegionForConfig(config),
@@ -3082,7 +3124,7 @@ export class FleetCoordinator {
     }
     const requestedHostID = config.hostID || config.awsMacHostID;
     const retainedMacHostLease =
-      requestedHostID && config.provider === "aws" && config.target === "macos"
+      !fixedLeaseID && requestedHostID && config.provider === "aws" && config.target === "macos"
         ? await this.retainedMacHostLease(
             owner,
             org,
@@ -3131,7 +3173,7 @@ export class FleetCoordinator {
     if (retainedMacHostLease) {
       config = { ...config, providerKey: retainedMacHostLease.providerKey };
     }
-    const leaseID = validLeaseID(input.leaseID) ? input.leaseID : newLeaseID();
+    const leaseID = fixedLeaseID ?? (validLeaseID(input.leaseID) ? input.leaseID : newLeaseID());
     const canonicalProviderKey = providerKeyForLease(leaseID);
     const providerKeyLeaseID = leaseIDForProviderKey(config.providerKey);
     if (!retainedMacHostLease && providerKeyLeaseID && providerKeyLeaseID !== leaseID) {
@@ -3339,7 +3381,11 @@ export class FleetCoordinator {
       if (!workspaceID && (await this.state.storage.get(workspaceLeaseReservationKey(leaseID)))) {
         return workspaceManagedLeaseResponse();
       }
-      if (await this.getLease(leaseID)) {
+      const existingLease = await this.getLease(leaseID);
+      if (existingLease && fixedLeaseID) {
+        return this.fixedLeaseReplayResponse(existingLease, owner, org, fixedCreateIntentHash!)!;
+      }
+      if (existingLease) {
         return json(
           { error: "lease_id_conflict", message: "lease id already exists" },
           { status: 409 },
@@ -3361,6 +3407,12 @@ export class FleetCoordinator {
       let record: LeaseRecord = {
         id: leaseID,
         slug,
+        ...(fixedCreateIntentHash
+          ? {
+              fixedCreateIntentVersion: fixedLeaseCreateIntentVersion,
+              fixedCreateIntentHash,
+            }
+          : {}),
         ...(workspaceID ? { workspaceID } : {}),
         provider: config.provider,
         target: config.target,
@@ -3786,6 +3838,29 @@ export class FleetCoordinator {
       ssm_command_id: record.awsSSMCommandID,
     });
     return json({ lease: publicLeaseRecord(record) }, { status: 201 });
+  }
+
+  private fixedLeaseReplayResponse(
+    existing: LeaseRecord | undefined,
+    owner: string,
+    org: string,
+    intentHash: string,
+  ): Response | undefined {
+    if (!existing) return undefined;
+    const sameOwner = existing.owner === owner && existing.org === org;
+    const sameIntent =
+      existing.fixedCreateIntentVersion === fixedLeaseCreateIntentVersion &&
+      existing.fixedCreateIntentHash === intentHash;
+    if (!sameOwner || !sameIntent || !leaseIsLive(existing)) {
+      return json(
+        { error: "lease_id_conflict", message: "lease id is bound to another create intent" },
+        { status: 409 },
+      );
+    }
+    return json(
+      { lease: publicLeaseRecord(existing) },
+      { status: existing.state === "active" ? 200 : 202 },
+    );
   }
 
   private async createWorkspace(request: Request): Promise<Response> {
@@ -19964,6 +20039,46 @@ function boundedTelemetrySamples(samples: LeaseTelemetry[], max: number): LeaseT
   return [...byTime.values()]
     .toSorted((left, right) => left.capturedAt.localeCompare(right.capturedAt))
     .slice(-max);
+}
+
+const fixedLeaseCreateIntentVersion = 2;
+
+async function fixedLeaseCreateIntentHash(
+  config: LeaseConfig,
+  requestedSlug: string,
+): Promise<string> {
+  const { keep, ...normalizedConfig } = config;
+  const semanticConfig: Record<string, unknown> = { ...normalizedConfig };
+  delete semanticConfig["tailscaleAuthKey"];
+  delete semanticConfig["sshHostPrivateKey"];
+  delete semanticConfig["sshHostPublicKey"];
+  delete semanticConfig["sshPublicKey"];
+  if (!config.awsSSHCIDRsPinned) {
+    semanticConfig["awsSSHCIDRs"] = [];
+  }
+  semanticConfig["sshPublicKeyHash"] = await sha256Hex(config.sshPublicKey);
+  return await sha256Hex(
+    `crabbox-fixed-lease-create-v${fixedLeaseCreateIntentVersion}\0${canonicalJSONStringify({
+      requestedSlug,
+      lifecycle: { keep },
+      config: semanticConfig,
+    })}`,
+  );
+}
+
+function canonicalJSONStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalJSONStringify).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .filter(([, item]) => item !== undefined)
+      .toSorted(([left], [right]) => left.localeCompare(right));
+    return `{${entries
+      .map(([key, item]) => `${JSON.stringify(key)}:${canonicalJSONStringify(item)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "null";
 }
 
 function sanitizeTelemetryTimestamp(value: string | undefined, now: Date): string {

--- a/worker/src/org-records.ts
+++ b/worker/src/org-records.ts
@@ -20,6 +20,8 @@ export function publicLeaseRecord(record: LeaseRecord): LeaseRecord {
   delete publicRecord.provisioningCoordinatorVersion;
   delete publicRecord.provisioningRecoveryObservedAt;
   delete publicRecord.provisioningRecoveryMissingSince;
+  delete publicRecord.fixedCreateIntentVersion;
+  delete publicRecord.fixedCreateIntentHash;
   return publicRecord;
 }
 

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -390,6 +390,8 @@ export interface RunTelemetrySummary {
 export interface LeaseRecord {
   id: string;
   slug?: string;
+  fixedCreateIntentVersion?: number;
+  fixedCreateIntentHash?: string;
   workspaceID?: string;
   provider: string;
   lifecycle?: LeaseLifecycle;

--- a/worker/test/coordinator-runtime.test.ts
+++ b/worker/test/coordinator-runtime.test.ts
@@ -556,6 +556,7 @@ describe("coordinator runtimes", () => {
       ["DELETE", "/v1/workspaces/fleet-is-101"],
       ["GET", "/v1/native-vnc/handoff"],
       ["GET", "/v1/leases/cbx_abcdef123456"],
+      ["PUT", "/v1/leases/cbx_abcdef123456"],
       ["GET", "/v1/adapters/applied-alice"],
       ["POST", "/v1/adapters/applied-alice/proxy/v1/workspaces"],
     ]) {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -15307,6 +15307,237 @@ describe("fleet lease identity and idle", () => {
     });
   });
 
+  it("replays an identical fixed lease create without a second provider create", async () => {
+    const storage = new MemoryStorage();
+    let creates = 0;
+    const providers = {
+      azure: fakeProvider(
+        () => {
+          creates += 1;
+        },
+        { provider: "azure", cloudID: "vm-cbx-abcdef123456", region: "eastus" },
+      ),
+    };
+    const body = {
+      leaseID: "cbx_abcdef123456",
+      slug: "fixed-replay",
+      provider: "azure" as const,
+      azureLocation: "eastus",
+      sshPublicKey: "ssh-ed25519 fixed-replay",
+    };
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const firstFleet = testFleet(storage, providers);
+    const first = await firstFleet.fetch(
+      request("PUT", "/v1/leases/cbx_abcdef123456", { headers, body }),
+    );
+    expect(first.status).toBe(201);
+    const firstBody = (await first.json()) as { lease: LeaseRecord };
+    expect(firstBody.lease.fixedCreateIntentVersion).toBeUndefined();
+    expect(firstBody.lease.fixedCreateIntentHash).toBeUndefined();
+    expect(storage.value<LeaseRecord>("lease:cbx_abcdef123456")).toMatchObject({
+      fixedCreateIntentVersion: 2,
+      fixedCreateIntentHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+    });
+
+    const restartedFleet = testFleet(storage, {
+      azure: fakeProvider(
+        () => {
+          creates += 1;
+        },
+        {
+          provider: "azure",
+          cloudID: "vm-cbx-abcdef123456",
+          region: "eastus",
+          onRestrictedLeaseRequestFields: () => ["serverType"],
+        },
+      ),
+    });
+    const replay = await restartedFleet.fetch(
+      request("PUT", "/v1/leases/cbx_abcdef123456", { headers, body }),
+    );
+    expect(replay.status).toBe(200);
+    await expect(replay.json()).resolves.toMatchObject({
+      lease: { id: "cbx_abcdef123456", state: "active", cloudID: "vm-cbx-abcdef123456" },
+    });
+    expect(creates).toBe(1);
+
+    const drift = await restartedFleet.fetch(
+      request("PUT", "/v1/leases/cbx_abcdef123456", {
+        headers,
+        body: { ...body, class: "standard" },
+      }),
+    );
+    expect(drift.status).toBe(409);
+    const driftBody = await drift.json();
+    expect(driftBody).toMatchObject({ error: "lease_id_conflict" });
+    expect(creates).toBe(1);
+
+    const wrongOwner = await restartedFleet.fetch(
+      request("PUT", "/v1/leases/cbx_abcdef123456", {
+        headers: { ...headers, "x-crabbox-owner": "mallory@example.com" },
+        body,
+      }),
+    );
+    expect(wrongOwner.status).toBe(409);
+    expect(await wrongOwner.json()).toEqual(driftBody);
+    expect(creates).toBe(1);
+
+    const terminal = storage.value<LeaseRecord>("lease:cbx_abcdef123456");
+    await storage.put("lease:cbx_abcdef123456", { ...terminal!, state: "released" });
+    const terminalReplay = await restartedFleet.fetch(
+      request("PUT", "/v1/leases/cbx_abcdef123456", { headers, body }),
+    );
+    expect(terminalReplay.status).toBe(409);
+    await expect(terminalReplay.json()).resolves.toMatchObject({ error: "lease_id_conflict" });
+    expect(creates).toBe(1);
+  });
+
+  it("rejects fixed lease keep drift without another provider create", async () => {
+    const storage = new MemoryStorage();
+    let creates = 0;
+    const fleet = testFleet(storage, {
+      azure: fakeProvider(
+        () => {
+          creates += 1;
+        },
+        { provider: "azure", cloudID: "vm-fixed-keep", region: "eastus" },
+      ),
+    });
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const body = {
+      leaseID: "cbx_abcdef123470",
+      slug: "fixed-keep",
+      provider: "azure" as const,
+      azureLocation: "eastus",
+      sshPublicKey: "ssh-ed25519 fixed-keep",
+    };
+
+    const first = await fleet.fetch(
+      request("PUT", "/v1/leases/cbx_abcdef123470", { headers, body }),
+    );
+    expect(first.status).toBe(201);
+
+    const normalizedReplay = await fleet.fetch(
+      request("PUT", "/v1/leases/cbx_abcdef123470", {
+        headers,
+        body: { ...body, keep: false },
+      }),
+    );
+    expect(normalizedReplay.status).toBe(200);
+
+    const drift = await fleet.fetch(
+      request("PUT", "/v1/leases/cbx_abcdef123470", {
+        headers,
+        body: { ...body, keep: true },
+      }),
+    );
+    expect(drift.status).toBe(409);
+    await expect(drift.json()).resolves.toMatchObject({ error: "lease_id_conflict" });
+    expect(creates).toBe(1);
+  });
+
+  it("rejects normalized fixed lease slug drift without another provider create", async () => {
+    const storage = new MemoryStorage();
+    let creates = 0;
+    const fleet = testFleet(storage, {
+      azure: fakeProvider(
+        () => {
+          creates += 1;
+        },
+        { provider: "azure", cloudID: "vm-fixed-slug", region: "eastus" },
+      ),
+    });
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const config = {
+      leaseID: "cbx_abcdef123471",
+      provider: "azure" as const,
+      azureLocation: "eastus",
+      sshPublicKey: "ssh-ed25519 fixed-slug",
+    };
+
+    const first = await fleet.fetch(
+      request("PUT", "/v1/leases/cbx_abcdef123471", {
+        headers,
+        body: { ...config, slug: "Fixed Slug" },
+      }),
+    );
+    expect(first.status).toBe(201);
+
+    const normalizedReplay = await fleet.fetch(
+      request("PUT", "/v1/leases/cbx_abcdef123471", {
+        headers,
+        body: { ...config, requestedSlug: "fixed-slug" },
+      }),
+    );
+    expect(normalizedReplay.status).toBe(200);
+
+    const drift = await fleet.fetch(
+      request("PUT", "/v1/leases/cbx_abcdef123471", {
+        headers,
+        body: { ...config, requestedSlug: "other-slug" },
+      }),
+    );
+    expect(drift.status).toBe(409);
+    await expect(drift.json()).resolves.toMatchObject({ error: "lease_id_conflict" });
+    expect(creates).toBe(1);
+  });
+
+  it("joins a concurrent fixed lease create while provisioning", async () => {
+    const storage = new MemoryStorage();
+    let creates = 0;
+    let createStarted!: () => void;
+    let finishCreate!: () => void;
+    const started = new Promise<void>((resolve) => {
+      createStarted = resolve;
+    });
+    const finish = new Promise<void>((resolve) => {
+      finishCreate = resolve;
+    });
+    const fleet = testFleet(storage, {
+      azure: fakeProvider(
+        async () => {
+          creates += 1;
+          createStarted();
+          await finish;
+        },
+        { provider: "azure", cloudID: "vm-fixed-concurrent", region: "eastus" },
+      ),
+    });
+    const options = {
+      headers: {
+        "x-crabbox-owner": "alice@example.com",
+        "x-crabbox-org": "example-org",
+      },
+      body: {
+        leaseID: "cbx_abcdef123457",
+        slug: "fixed-concurrent",
+        provider: "azure" as const,
+        azureLocation: "eastus",
+        sshPublicKey: "ssh-ed25519 fixed-concurrent",
+      },
+    };
+    const first = fleet.fetch(request("PUT", "/v1/leases/cbx_abcdef123457", options));
+    await started;
+    const replay = await fleet.fetch(request("PUT", "/v1/leases/cbx_abcdef123457", options));
+    expect(replay.status).toBe(202);
+    await expect(replay.json()).resolves.toMatchObject({
+      lease: { id: "cbx_abcdef123457", state: "provisioning" },
+    });
+    expect(creates).toBe(1);
+    finishCreate();
+    expect((await first).status).toBe(201);
+    expect(creates).toBe(1);
+  });
+
   it("marks provisioning leases failed when provider create fails", async () => {
     const storage = new MemoryStorage();
     const fleet = testFleet(storage, {


### PR DESCRIPTION
## Summary

- make `crabbox warmup --lease-id cbx_<12 lowercase hex>` the fixed operation identity for direct AWS and coordinator-backed creation
- replay identical intent atomically across client/coordinator process restarts, while returning stable `lease_id_conflict` before side effects on immutable-intent drift
- keep slugs as display metadata rather than an idempotency primitive

## Direct AWS

- persist the normalized, versioned, secret-sanitized create intent in the existing durable claim before provider work
- persist the resolved AWS launch attempt before `RunInstances`, derive deterministic regional/zonal client tokens, and never resubmit an ambiguous persisted attempt
- reconcile only the exact acquired CloudID or a uniquely visible resource whose provider facts and non-secret attempt-attestation tags match the durable attempt
- retain downgrade-safe `aws-fixed-v1` terminal tombstones after release or exact missing-resource cleanup so operation IDs cannot be reused
- fail closed on missing, duplicate, conflicting, stale, or incompletely attested resources

## Coordinator

- add fixed-ID `PUT /v1/leases/:id` while leaving legacy random-ID POST behavior unchanged
- atomically reserve the existing durable lease record with owner and versioned normalized intent hash
- return/join the same provisioning or active lease for identical replay and reject owner/intent drift
- recover ambiguous responses by repeating the exact PUT before polling with GET

## Tests and documentation

- add commit-then-timeout, fresh-process/storage restart, delayed visibility, concurrency, intent drift, terminal replay, exact reconciliation, callback/re-entry, and exactly-one-create fault coverage
- document fixed-ID replay, at-most-once AWS ambiguity, attempt attestation, terminal tombstones, compatibility behavior, and the coordinator PUT contract
- add the repository-style 0.41.1 Unreleased changelog entry without changing package versions

## Verification

- `go test -race ./...`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker`
- `npm run build --prefix worker`
- Codex autoreview: clean P0/P1 gate with no accepted/actionable findings; a later P2 suggestion to expand the explicitly non-circular AWS attestation protocol was reviewed and rejected as outside the frozen contract

The live OpenClaw timeout-recovery proof is intentionally the downstream phase after this Crabbox change lands. This PR does not touch OpenClaw and no release, publication, coordinator deployment, package-version bump, or live-infrastructure mutation was performed.
