### PR TITLE
chore(release): prepare v0.41.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.41.1 - Unreleased
+## 0.41.1 - 2026-08-09
 
 ### Fixed
 

--- a/release/records/v0.41.1.json
+++ b/release/records/v0.41.1.json
@@ -1,0 +1,9 @@
+{
+  "schemaVersion": 1,
+  "repository": "openclaw/crabbox",
+  "tag": "v0.41.1",
+  "tagObject": "PENDING_AFTER_SIGNED_TAG",
+  "sourceCommit": "PENDING_AFTER_PREPARATION_MERGE",
+  "publicationStatus": "blocked",
+  "blocker": "Pending signed v0.41.1 tag object and peeled source commit; update both fields and set publicationStatus to ready only after the tag is signed and verified."
+}

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/crabbox-worker",
-  "version": "0.41.0",
+  "version": "0.41.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/crabbox-worker",
-      "version": "0.41.0",
+      "version": "0.41.1",
       "dependencies": {
         "@aws-sdk/credential-providers": "^3.1095.0",
         "@cloudflare/containers": "^0.3.7",

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/crabbox-worker",
-  "version": "0.41.0",
+  "version": "0.41.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## What Problem This Solves

Crabbox v0.41.1 has complete user-facing release notes on current `main`, but its canonical package metadata and protected source record still identify v0.41.0. The release cannot safely advance to the separately authorized signed-tag gate until those reversible preparation surfaces agree on v0.41.1.

## Why This Change Was Made

Prepare v0.41.1 from exact `origin/main` commit `df2544913964373880fc4bd26a12d3d816fd6797`: date the existing changelog section without changing its bullet wording, update only the Worker package and root lockfile version fields, and add a deliberately blocked protected source record. The record keeps both immutable source identities pending until a later signed-tag authorization.

This PR does not create, sign, or push a tag; authorize the source record; build a candidate; access signing or notary credentials; create a release draft; publish or deploy anything; or update Homebrew.

## User Impact

There is no runtime behavior change. Once merged, release operators have consistent v0.41.1 preparation metadata while publication remains blocked behind the repository's serialized release gates.

## Evidence

- Exact branch head: `91a8e390558ad9d6540245109c97ade66e3c23db`.
- Base: current `origin/main` at `df2544913964373880fc4bd26a12d3d816fd6797`.
- `GOTOOLCHAIN=go1.26.5 node --test scripts/release*.test.js scripts/homebrew-release.test.js`: 45/45 passed.
- `git diff --check`: passed.
- Direct `REQUIRE_PUBLISHABLE=1` invocation of `scripts/verify-release-source.sh` rejected the blocked v0.41.1 record with the expected `release v0.41.1 is blocked` error before tag verification.
- Codex autoreview: clean, no accepted/actionable findings; patch correct at 0.98 confidence.
- Exact-head CI: 21 passed, 5 conditional skips, 0 pending or failed. Core CI: https://github.com/openclaw/crabbox/actions/runs/31320368702; protected release check: https://github.com/openclaw/crabbox/actions/runs/31320368710; CodeQL: https://github.com/openclaw/crabbox/actions/runs/31320368082.
- Changed files are limited to `CHANGELOG.md`, `worker/package.json`, `worker/package-lock.json`, and `release/records/v0.41.1.json`.
- Worker dependency versions, historical changelog content, release scripts, documentation, and generated artifacts are unchanged.
- No configuration or secret implications.
