### PR TITLE
chore(release): authorize v0.41.1 source

### DIFF
--- a/release/records/v0.41.1.json
+++ b/release/records/v0.41.1.json
@@ -2,8 +2,7 @@
   "schemaVersion": 1,
   "repository": "openclaw/crabbox",
   "tag": "v0.41.1",
-  "tagObject": "PENDING_AFTER_SIGNED_TAG",
-  "sourceCommit": "PENDING_AFTER_PREPARATION_MERGE",
-  "publicationStatus": "blocked",
-  "blocker": "Pending signed v0.41.1 tag object and peeled source commit; update both fields and set publicationStatus to ready only after the tag is signed and verified."
+  "tagObject": "3e3658cb65570d88e6cf876f7155de6e357132c1",
+  "sourceCommit": "70aaebd1083615eadeddb920b1f344822a2f013b",
+  "publicationStatus": "ready"
 }


### PR DESCRIPTION
## What Problem This Solves

The protected v0.41.1 release record is intentionally blocked until the signed
tag object and peeled source commit are known.

## Why This Change Was Made

Records the immutable signed tag object
`3e3658cb65570d88e6cf876f7155de6e357132c1` and source commit
`70aaebd1083615eadeddb920b1f344822a2f013b`, then marks the release source ready.
The local signed tag remains unchanged and is not pushed by this PR.

## User Impact

Release operators can build and verify the v0.41.1 candidate against a protected,
reviewed source record after the separately gated tag publication step.

## Evidence

- Signed annotated tag `v0.41.1` was independently verified against `.github/release-allowed-signers`; its annotation subject is exactly `v0.41.1`.
- `git diff --check origin/main...HEAD` passes.
- `node --test scripts/release-workflow.test.js scripts/release-verifier-isolation.test.js scripts/publish-release.test.js scripts/homebrew-release.test.js` passes: 82 tests, 0 failures.
- `DEFAULT_BRANCH=main RELEASE_TAG=v0.41.1 EXPECTED_TAG_OBJECT=3e3658cb65570d88e6cf876f7155de6e357132c1 EXPECTED_TAG_COMMIT=70aaebd1083615eadeddb920b1f344822a2f013b TRUSTED_HEAD=$(git rev-parse HEAD) REQUIRE_PUBLISHABLE=1 scripts/verify-release-source.sh` passes and prints the expected tag object and source commit.
- Codex autoreview (`--mode local`) is clean: no accepted/actionable findings.
