### PR TITLE
chore(release): open v0.41.2 development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 0.41.2 - Unreleased
+
 ## 0.41.1 - 2026-08-09
 
 ### Fixed


### PR DESCRIPTION
## What Problem This Solves

Completes the verified v0.41.1 release by opening the next patch development section in the changelog.

## Why This Change Was Made

Adds only the empty 0.41.2 Unreleased heading required by the release closeout procedure. Historical changelog text and all versioned artifacts remain unchanged.

## User Impact

No runtime behavior changes. Future changes now have the correct 0.41.2 development section.

## Evidence

- Public release v0.41.1, release ID 367532122: https://github.com/openclaw/crabbox/releases/tag/v0.41.1
- Public asset verifier: https://github.com/openclaw/crabbox/actions/runs/31327187485
- Homebrew verifier: https://github.com/openclaw/crabbox/actions/runs/31327691590
- Merged tap update: https://github.com/openclaw/homebrew-tap/pull/15
- git diff --check
- v0.41.1 release-note extraction from CHANGELOG.md
- Internal Markdown link validation: 236 files checked
- Autoreview: clean, no accepted or actionable findings
