### PR TITLE
fix: redact provider response credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.41.2 - Unreleased
 
+### Fixed
+
+- Redacted configured credentials reflected by provider-controlled Orgo, FastAPI Cloud, and DigitalOcean response diagnostics before they reach terminal or CI output. Thanks @coygeek.
+
 ## 0.41.1 - 2026-08-09
 
 ### Fixed

--- a/docs/security.md
+++ b/docs/security.md
@@ -372,8 +372,8 @@ session.
 
 Configured provider credentials are redacted from documented HTTP or streamed
 error diagnostics, including Azure Dynamic Sessions, Cloudflare runner, Daytona,
-E2B, Freestyle, Islo, Morph, OpenComputer, Railway, RunPod, Semaphore, SmolVM,
-Sprites, and Upstash Box. The same final redaction covers `doctor` text and JSON
+DigitalOcean, E2B, FastAPI Cloud, Freestyle, Islo, Morph, OpenComputer, Orgo,
+Railway, RunPod, Semaphore, SmolVM, Sprites, and Upstash Box. The same final redaction covers `doctor` text and JSON
 messages/details. It removes exact configured secrets, authorization and API-key
 headers, credential-bearing URL query/userinfo components, common secret JSON
 fields, bearer values, and PEM private keys while retaining non-secret routing

--- a/internal/providers/digitalocean/client.go
+++ b/internal/providers/digitalocean/client.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const apiBaseURL = "https://api.digitalocean.com/v2"
@@ -170,10 +171,10 @@ func (c *digitalOceanClient) do(ctx context.Context, method, path string, body a
 	defer resp.Body.Close()
 	data, readErr := io.ReadAll(resp.Body)
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		if len(data) > 400 {
-			data = data[:400]
+		body := shared.RedactErrorSecrets(strings.TrimSpace(string(data)), c.token)
+		if len(body) > 400 {
+			body = body[:400]
 		}
-		body := strings.TrimSpace(string(data))
 		if readErr != nil {
 			if body != "" {
 				body += "; "
@@ -365,7 +366,7 @@ func (c *digitalOceanClient) CreateDroplet(ctx context.Context, cfg core.Config,
 		incomplete := fmt.Errorf(
 			"digitalocean create returned incomplete droplet identity: id=%d name=%q, want name=%q",
 			res.Droplet.ID,
-			res.Droplet.Name,
+			shared.RedactErrorSecrets(res.Droplet.Name, c.token),
 			name,
 		)
 		if item, reconcileErr := c.reconcileDropletCreate(leaseTag, leaseTagResolved, leaseID, name); reconcileErr == nil {
@@ -526,7 +527,7 @@ func (c *digitalOceanClient) EnsureSSHKey(ctx context.Context, name, publicKey s
 				return sshKey{}, false, conflict
 			}
 			return sshKey{}, false, &ambiguousSSHKeyCreateError{err: errors.Join(
-				fmt.Errorf("digitalocean ssh key creation returned incomplete identity: id=%d name=%q", res.SSHKey.ID, res.SSHKey.Name),
+				fmt.Errorf("digitalocean ssh key creation returned incomplete identity: id=%d name=%q", res.SSHKey.ID, shared.RedactErrorSecrets(res.SSHKey.Name, c.token)),
 				reconcileErr,
 			)}
 		}
@@ -670,7 +671,7 @@ func (c *digitalOceanClient) resolveCreateTagConflict(ctx context.Context, tags 
 	for _, tag := range tags {
 		name := tag
 		if existingName := known[strings.ToLower(tag)]; existingName != "" {
-			name, err = canonicalTagName(tag, existingName)
+			name, err = canonicalTagName(tag, existingName, c.token)
 			if err != nil {
 				return nil, "", false, err
 			}
@@ -691,19 +692,20 @@ func (c *digitalOceanClient) resolveCanonicalLeaseTag(ctx context.Context, lease
 		return "", err
 	}
 	if existing := canonicalTagNames(tags)[strings.ToLower(requested)]; existing != "" {
-		return canonicalTagName(requested, existing)
+		return canonicalTagName(requested, existing, c.token)
 	}
 	return requested, nil
 }
 
-func canonicalTagName(requested, existing string) (string, error) {
+func canonicalTagName(requested, existing string, secrets ...string) (string, error) {
 	existing = strings.TrimSpace(existing)
 	if existing == "" {
 		existing = requested
 	}
 	requestedLabels := labelsFromTags([]string{requested})
 	if len(requestedLabels) == 0 || !maps.Equal(requestedLabels, labelsFromTags([]string{existing})) {
-		return "", core.Exit(2, "digitalocean tag %q conflicts with existing account tag %q", requested, existing)
+		safeExisting := shared.RedactErrorSecrets(existing, secrets...)
+		return "", core.Exit(2, "digitalocean tag %q conflicts with existing account tag %q", requested, safeExisting)
 	}
 	return existing, nil
 }
@@ -725,12 +727,12 @@ func (c *digitalOceanClient) GetTag(ctx context.Context, name string) (digitalOc
 func (c *digitalOceanClient) EnsureTag(ctx context.Context, tag string, known map[string]string) (string, error) {
 	key := strings.ToLower(tag)
 	if canonical := known[key]; canonical != "" {
-		return canonicalTagName(tag, canonical)
+		return canonicalTagName(tag, canonical, c.token)
 	}
 	if existing, ok, err := c.GetTag(ctx, tag); err != nil {
 		return "", err
 	} else if ok {
-		canonical, canonicalErr := canonicalTagName(tag, existing.Name)
+		canonical, canonicalErr := canonicalTagName(tag, existing.Name, c.token)
 		if canonicalErr != nil {
 			return "", canonicalErr
 		}
@@ -742,7 +744,7 @@ func (c *digitalOceanClient) EnsureTag(ctx context.Context, tag string, known ma
 	}
 	err := c.do(ctx, http.MethodPost, "/tags", map[string]any{"name": tag}, &res)
 	if err == nil {
-		canonical, canonicalErr := canonicalTagName(tag, res.Tag.Name)
+		canonical, canonicalErr := canonicalTagName(tag, res.Tag.Name, c.token)
 		if canonicalErr != nil {
 			return "", canonicalErr
 		}
@@ -761,7 +763,7 @@ func (c *digitalOceanClient) EnsureTag(ctx context.Context, tag string, known ma
 		known[folded] = canonical
 	}
 	if canonical := known[key]; canonical != "" {
-		return canonicalTagName(tag, canonical)
+		return canonicalTagName(tag, canonical, c.token)
 	}
 	return "", err
 }

--- a/internal/providers/digitalocean/client_test.go
+++ b/internal/providers/digitalocean/client_test.go
@@ -950,6 +950,201 @@ func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return fn(req)
 }
 
+func TestDigitalOceanClientRedactsReflectedToken(t *testing.T) {
+	const token = "sibling-secret-token"
+	for _, tt := range []struct {
+		name        string
+		body        string
+		wantContext string
+	}{
+		{
+			name:        "ordinary reflection",
+			body:        `{"message":"credential ` + token + ` rejected","request":"safe-digitalocean-context"}`,
+			wantContext: "safe-digitalocean-context",
+		},
+		{
+			name: "credential crosses diagnostic cutoff",
+			body: strings.Repeat("x", 390) + token + " trailing provider detail",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &digitalOceanClient{
+				token:   token,
+				baseURL: "https://api.digitalocean.test",
+				client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+					if got := req.Header.Get("Authorization"); got != "Bearer "+token {
+						t.Fatalf("authorization=%q", got)
+					}
+					return &http.Response{
+						StatusCode: http.StatusUnauthorized,
+						Header:     make(http.Header),
+						Body:       io.NopCloser(strings.NewReader(tt.body)),
+						Request:    req,
+					}, nil
+				})},
+			}
+
+			err := client.do(context.Background(), http.MethodGet, "/account", nil, nil)
+			var apiErr *digitalOceanAPIError
+			if !errors.As(err, &apiErr) {
+				t.Fatalf("err=%v, want *digitalOceanAPIError", err)
+			}
+			if apiErr.Status != http.StatusUnauthorized {
+				t.Fatalf("status=%d, want %d", apiErr.Status, http.StatusUnauthorized)
+			}
+			for _, value := range []string{apiErr.Body, err.Error()} {
+				for _, leaked := range []string{token, token[:10]} {
+					if strings.Contains(value, leaked) {
+						t.Fatalf("token fragment %q leaked in %q", leaked, value)
+					}
+				}
+				if !strings.Contains(value, "[redacted]") {
+					t.Fatalf("reflected token was not redacted in %q", value)
+				}
+				if tt.wantContext != "" && !strings.Contains(value, tt.wantContext) {
+					t.Fatalf("redacted error lost useful context: %q", value)
+				}
+			}
+		})
+	}
+}
+
+func TestDigitalOceanClientRedactsSemanticDropletName(t *testing.T) {
+	const token = "digitalocean-droplet-secret"
+	const leaseID = "cbx_abcdef123456"
+	const publicKey = "ssh-ed25519 test"
+	keyName := providerKeyForLease(leaseID)
+	client := &digitalOceanClient{
+		token:             token,
+		baseURL:           "https://api.digitalocean.test",
+		reconcileTimeout:  time.Millisecond,
+		reconcileInterval: time.Millisecond,
+		client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if got := req.Header.Get("Authorization"); got != "Bearer "+token {
+				t.Fatalf("authorization=%q", got)
+			}
+			switch {
+			case req.Method == http.MethodGet && req.URL.Path == "/account/keys":
+				body, _ := json.Marshal(map[string]any{
+					"ssh_keys": []map[string]any{{"id": 123, "name": keyName, "public_key": publicKey}},
+					"links":    map[string]any{"pages": map[string]any{}},
+				})
+				return digitalOceanTestResponse(req, http.StatusOK, string(body)), nil
+			case req.Method == http.MethodPost && req.URL.Path == "/droplets":
+				body := `{"droplet":{"id":456,"name":"safe-droplet-context-` + token + `"}}`
+				return digitalOceanTestResponse(req, http.StatusAccepted, body), nil
+			case req.Method == http.MethodGet && req.URL.Path == "/tags":
+				return nil, errors.New("synthetic reconciliation failure")
+			default:
+				t.Fatalf("unexpected request %s %s", req.Method, req.URL.RequestURI())
+				return nil, nil
+			}
+		})},
+	}
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.TargetOS = core.TargetLinux
+	cfg.ServerType = "s-1vcpu-1gb"
+
+	_, err := client.CreateDroplet(context.Background(), cfg, publicKey, leaseID, "blue", false, time.Now())
+	assertDigitalOceanSemanticDiagnostic(t, err, token, "safe-droplet-context")
+}
+
+func TestDigitalOceanClientRedactsSemanticSSHKeyName(t *testing.T) {
+	const token = "digitalocean-key-secret"
+	keyListCalls := 0
+	client := &digitalOceanClient{
+		token:             token,
+		baseURL:           "https://api.digitalocean.test",
+		reconcileTimeout:  time.Millisecond,
+		reconcileInterval: time.Millisecond,
+		client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			switch {
+			case req.Method == http.MethodGet && req.URL.Path == "/account/keys":
+				keyListCalls++
+				if keyListCalls == 1 {
+					return digitalOceanTestResponse(req, http.StatusOK, `{"ssh_keys":[],"links":{"pages":{}}}`), nil
+				}
+				return nil, errors.New("synthetic reconciliation failure")
+			case req.Method == http.MethodPost && req.URL.Path == "/account/keys":
+				body := `{"ssh_key":{"id":0,"name":"safe-key-context-` + token + `","public_key":"wrong"}}`
+				return digitalOceanTestResponse(req, http.StatusCreated, body), nil
+			default:
+				t.Fatalf("unexpected request %s %s", req.Method, req.URL.RequestURI())
+				return nil, nil
+			}
+		})},
+	}
+
+	_, _, err := client.EnsureSSHKey(context.Background(), "expected-key", "ssh-ed25519 expected")
+	assertDigitalOceanSemanticDiagnostic(t, err, token, "safe-key-context")
+}
+
+func TestDigitalOceanClientRedactsSemanticTagNames(t *testing.T) {
+	const token = "digitalocean-tag-secret"
+	const requested = "crabbox:slug:blue"
+	for _, tt := range []struct {
+		name string
+		http func(*http.Request) (*http.Response, error)
+		safe string
+	}{
+		{
+			name: "existing tag",
+			safe: "safe-existing-tag-context",
+			http: func(req *http.Request) (*http.Response, error) {
+				body := `{"tag":{"name":"safe-existing-tag-context-` + token + `"}}`
+				return digitalOceanTestResponse(req, http.StatusOK, body), nil
+			},
+		},
+		{
+			name: "created tag",
+			safe: "safe-created-tag-context",
+			http: func(req *http.Request) (*http.Response, error) {
+				if req.Method == http.MethodGet {
+					return digitalOceanTestResponse(req, http.StatusNotFound, `{"id":"not_found"}`), nil
+				}
+				body := `{"tag":{"name":"safe-created-tag-context-` + token + `"}}`
+				return digitalOceanTestResponse(req, http.StatusCreated, body), nil
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &digitalOceanClient{
+				token:   token,
+				baseURL: "https://api.digitalocean.test",
+				client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+					if req.URL.Path != "/tags/"+requested && req.URL.Path != "/tags" {
+						t.Fatalf("unexpected request %s %s", req.Method, req.URL.RequestURI())
+					}
+					return tt.http(req)
+				})},
+			}
+
+			_, err := client.EnsureTag(context.Background(), requested, map[string]string{})
+			assertDigitalOceanSemanticDiagnostic(t, err, token, tt.safe)
+		})
+	}
+}
+
+func digitalOceanTestResponse(req *http.Request, status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Request:    req,
+	}
+}
+
+func assertDigitalOceanSemanticDiagnostic(t *testing.T, err error, token, safeContext string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("semantic mismatch was accepted")
+	}
+	if strings.Contains(err.Error(), token) || !strings.Contains(err.Error(), "[redacted]") || !strings.Contains(err.Error(), safeContext) {
+		t.Fatalf("semantic diagnostic=%q", err)
+	}
+}
+
 type errorAfterReader struct {
 	data []byte
 	err  error

--- a/internal/providers/fastapicloud/backend_test.go
+++ b/internal/providers/fastapicloud/backend_test.go
@@ -280,8 +280,8 @@ func TestFastAPICloudClientSurfacesNon2xxAsAPIError(t *testing.T) {
 	if apiErr.StatusCode != http.StatusForbidden {
 		t.Fatalf("status = %d, want 403", apiErr.StatusCode)
 	}
-	if !strings.Contains(apiErr.Body, "forbidden by token") {
-		t.Fatalf("body = %q, want forbidden snippet", apiErr.Body)
+	if apiErr.Body != "forbidden by token" || strings.Contains(apiErr.Body, "[redacted]") {
+		t.Fatalf("body = %q, want unchanged benign diagnostic", apiErr.Body)
 	}
 }
 
@@ -531,27 +531,100 @@ func newTestFastAPICloudClient(t *testing.T, server *httptest.Server) fastAPIClo
 	return client
 }
 
-func TestFastAPICloudClientUnauthorizedNoTokenLeak(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("Authorization") != "Bearer secret-tok" {
-			http.Error(w, "bad bearer", http.StatusBadRequest)
-			return
-		}
-		w.WriteHeader(http.StatusUnauthorized)
-		_, _ = io.WriteString(w, `{"detail":"Invalid credentials"}`)
-	}))
-	defer server.Close()
-	_, err := newTestFastAPICloudClient(t, server).GetApp(context.Background(), "app-1")
+func TestFastAPICloudClientUnauthorizedRedactsReflectedToken(t *testing.T) {
+	const token = "fastapi-secret-token"
+	client := &fastAPICloudClient{
+		token:  token,
+		apiURL: "https://api.fastapicloud.test/api/v1",
+		httpClient: &http.Client{Transport: fastAPICloudRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if got := req.Header.Get("Authorization"); got != "Bearer "+token {
+				t.Fatalf("authorization=%q", got)
+			}
+			return &http.Response{
+				StatusCode: http.StatusUnauthorized,
+				Status:     "401 upstream rejected " + token,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"detail":"credential ` + token + ` rejected","request":"safe-fastapi-context"}`)),
+				Request:    req,
+			}, nil
+		})},
+	}
+	_, err := client.GetApp(context.Background(), "app-1")
 	var apiErr *fastAPICloudAPIError
 	if !errors.As(err, &apiErr) {
 		t.Fatalf("err = %v, want *fastAPICloudAPIError", err)
 	}
-	if apiErr.StatusCode != 401 || !strings.Contains(apiErr.Body, "Invalid credentials") {
-		t.Fatalf("apiErr = %#v, want 401 with detail body", apiErr)
+	if apiErr.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status=%d, want %d", apiErr.StatusCode, http.StatusUnauthorized)
 	}
-	if strings.Contains(err.Error(), "secret-tok") {
-		t.Fatal("token leaked into error message")
+	for _, value := range []string{apiErr.Status, apiErr.Body, err.Error()} {
+		if strings.Contains(value, token) {
+			t.Fatalf("token leaked in %q", value)
+		}
+		if !strings.Contains(value, "[redacted]") {
+			t.Fatalf("reflected token was not redacted in %q", value)
+		}
 	}
+	if !strings.Contains(apiErr.Body, "safe-fastapi-context") || !strings.Contains(apiErr.Status, "upstream rejected") {
+		t.Fatalf("redacted error lost safe diagnostics: %#v", apiErr)
+	}
+}
+
+func TestFastAPICloudClientRedactsUnexpectedContentType(t *testing.T) {
+	const token = "fastapi-content-type-secret"
+	for _, tt := range []struct {
+		name          string
+		contentType   string
+		wantRedacted  bool
+		wantSafeValue string
+	}{
+		{
+			name:          "reflected token",
+			contentType:   `text/plain; credential="` + token + `"; context=safe-fastapi-content-type`,
+			wantRedacted:  true,
+			wantSafeValue: "safe-fastapi-content-type",
+		},
+		{
+			name:          "benign content type",
+			contentType:   "text/html; charset=utf-8",
+			wantSafeValue: "text/html; charset=utf-8",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &fastAPICloudClient{
+				token:  token,
+				apiURL: "https://api.fastapicloud.test/api/v1",
+				httpClient: &http.Client{Transport: fastAPICloudRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+					header := make(http.Header)
+					header.Set("Content-Type", tt.contentType)
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Status:     "200 OK",
+						Header:     header,
+						Body:       io.NopCloser(strings.NewReader(`{"id":"app-1"}`)),
+						Request:    req,
+					}, nil
+				})},
+			}
+
+			_, err := client.GetApp(context.Background(), "app-1")
+			if err == nil {
+				t.Fatal("GetApp accepted unexpected Content-Type")
+			}
+			if strings.Contains(err.Error(), token) || !strings.Contains(err.Error(), tt.wantSafeValue) {
+				t.Fatalf("content-type diagnostic=%q", err)
+			}
+			if got := strings.Contains(err.Error(), "[redacted]"); got != tt.wantRedacted {
+				t.Fatalf("redacted=%t, want %t: %q", got, tt.wantRedacted, err)
+			}
+		})
+	}
+}
+
+type fastAPICloudRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn fastAPICloudRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
 }
 
 func TestFastAPICloudAPIErrorMessage(t *testing.T) {

--- a/internal/providers/fastapicloud/client.go
+++ b/internal/providers/fastapicloud/client.go
@@ -11,6 +11,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type fastAPICloudAPI interface {
@@ -328,14 +330,19 @@ func (c *fastAPICloudClient) get(ctx context.Context, apiPath string, params url
 		return fmt.Errorf("%s response exceeds %d bytes", providerName, fastAPICloudMaxResponseBytes)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return &fastAPICloudAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: strings.TrimSpace(string(data))}
+		return &fastAPICloudAPIError{
+			StatusCode: resp.StatusCode,
+			Status:     shared.RedactErrorSecrets(resp.Status, c.token),
+			Body:       shared.RedactErrorSecrets(strings.TrimSpace(string(data)), c.token),
+		}
 	}
 	if out != nil {
 		// A 2xx with a non-JSON body (an HTML error page from a proxy, a
 		// misconfigured gateway) would otherwise surface only as an opaque
 		// json.Unmarshal error; check the media type first for a clearer message.
-		if mediaType, _, _ := mime.ParseMediaType(resp.Header.Get("Content-Type")); mediaType != "" && mediaType != "application/json" {
-			return fmt.Errorf("%s expected application/json response, got %q", providerName, resp.Header.Get("Content-Type"))
+		contentType := resp.Header.Get("Content-Type")
+		if mediaType, _, _ := mime.ParseMediaType(contentType); mediaType != "" && mediaType != "application/json" {
+			return fmt.Errorf("%s expected application/json response, got %q", providerName, shared.RedactErrorSecrets(contentType, c.token))
 		}
 		if err := json.Unmarshal(data, out); err != nil {
 			return fmt.Errorf("decode %s response: %w", providerName, err)

--- a/internal/providers/orgo/client.go
+++ b/internal/providers/orgo/client.go
@@ -10,9 +10,14 @@ import (
 	"net/url"
 	"os"
 	"strings"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-const defaultAPIBase = "https://www.orgo.ai/api"
+const (
+	defaultAPIBase           = "https://www.orgo.ai/api"
+	orgoMaxResponseBodyBytes = 4 << 20
+)
 
 type orgoAPI interface {
 	CreateWorkspace(ctx context.Context, name string) (orgoWorkspace, error)
@@ -232,7 +237,8 @@ func (c *orgoHTTPClient) StartComputer(ctx context.Context, id string) error {
 		return err
 	}
 	if res.Success == nil || !*res.Success {
-		return fmt.Errorf("orgo did not start computer %s (status=%s)", id, strings.TrimSpace(res.Status))
+		status := shared.RedactErrorSecrets(strings.TrimSpace(res.Status), c.apiKey)
+		return fmt.Errorf("orgo did not start computer %s (status=%s)", id, status)
 	}
 	return nil
 }
@@ -247,7 +253,8 @@ func (c *orgoHTTPClient) deleteResource(ctx context.Context, path, kind, id stri
 		return err
 	}
 	if res.Success != nil && !*res.Success {
-		return fmt.Errorf("orgo did not delete %s %s (status=%s)", kind, id, strings.TrimSpace(res.Status))
+		status := shared.RedactErrorSecrets(strings.TrimSpace(res.Status), c.apiKey)
+		return fmt.Errorf("orgo did not delete %s %s (status=%s)", kind, id, status)
 	}
 	return nil
 }
@@ -307,12 +314,23 @@ func (c *orgoHTTPClient) doJSON(ctx context.Context, method, path string, body a
 		return err
 	}
 	defer res.Body.Close()
-	data, err := io.ReadAll(io.LimitReader(res.Body, 4<<20))
+	responseLimit := int64(orgoMaxResponseBodyBytes)
+	safeErrorDiagnostic := true
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		responseLimit, safeErrorDiagnostic = orgoErrorResponseReadLimit(c.apiKey)
+	}
+	data, err := io.ReadAll(io.LimitReader(res.Body, responseLimit))
 	if err != nil {
 		return err
 	}
 	if res.StatusCode < 200 || res.StatusCode >= 300 {
-		return &orgoHTTPError{StatusCode: res.StatusCode, Body: string(data)}
+		if !safeErrorDiagnostic {
+			return &orgoHTTPError{StatusCode: res.StatusCode, Body: "response exceeds safe diagnostic limit"}
+		}
+		return &orgoHTTPError{
+			StatusCode: res.StatusCode,
+			Body:       orgoBoundedErrorDiagnostic(data, c.apiKey),
+		}
 	}
 	if out == nil {
 		return nil
@@ -328,4 +346,70 @@ func (c *orgoHTTPClient) doJSON(ctx context.Context, method, path string, body a
 		return fmt.Errorf("decode orgo response: %w", err)
 	}
 	return nil
+}
+
+func orgoErrorResponseReadLimit(apiKey string) (int64, bool) {
+	if len(apiKey) <= 1 {
+		return orgoMaxResponseBodyBytes, true
+	}
+	const maxInt64 = int64(1<<63 - 1)
+	extra := uint64(len(apiKey) - 1)
+	if extra > uint64(maxInt64-orgoMaxResponseBodyBytes) {
+		return orgoMaxResponseBodyBytes, false
+	}
+	return orgoMaxResponseBodyBytes + int64(extra), true
+}
+
+func orgoBoundedErrorDiagnostic(data []byte, apiKey string) string {
+	body := orgoMaskExactSecret(data, apiKey)
+	if len(body) > orgoMaxResponseBodyBytes {
+		body = body[:orgoMaxResponseBodyBytes]
+	}
+	return shared.RedactErrorSecrets(body, apiKey)
+}
+
+func orgoMaskExactSecret(data []byte, secret string) string {
+	if secret == "" || len(data) < len(secret) {
+		return string(data)
+	}
+	masked := append([]byte(nil), data...)
+	matched := make([]bool, len(data))
+	source := string(data)
+	for offset := 0; offset+len(secret) <= len(source); {
+		relative := strings.Index(source[offset:], secret)
+		if relative < 0 {
+			break
+		}
+		start := offset + relative
+		for index := start; index < start+len(secret); index++ {
+			matched[index] = true
+		}
+		offset = start + 1
+	}
+	filler := byte(0x1f)
+	for candidate := byte(33); candidate <= 126; candidate++ {
+		if !strings.ContainsRune(secret, rune(candidate)) {
+			filler = candidate
+			break
+		}
+	}
+	const marker = "[redacted]"
+	for start := 0; start < len(masked); {
+		if !matched[start] {
+			start++
+			continue
+		}
+		end := start + 1
+		for end < len(masked) && matched[end] {
+			end++
+		}
+		for index := start; index < end; index++ {
+			masked[index] = filler
+		}
+		if end-start >= len(marker) && !strings.Contains(marker, secret) {
+			copy(masked[start:end], marker)
+		}
+		start = end
+	}
+	return string(masked)
 }

--- a/internal/providers/orgo/client.go
+++ b/internal/providers/orgo/client.go
@@ -386,11 +386,14 @@ func orgoMaskExactSecret(data []byte, secret string) string {
 		}
 		offset = start + 1
 	}
-	filler := byte(0x1f)
-	for candidate := byte(33); candidate <= 126; candidate++ {
-		if !strings.ContainsRune(secret, rune(candidate)) {
-			filler = candidate
-			break
+	filler := byte('*')
+	if strings.IndexByte(secret, filler) >= 0 {
+		filler = byte(0x1f)
+		for candidate := byte(33); candidate <= 126; candidate++ {
+			if !strings.ContainsRune(secret, rune(candidate)) {
+				filler = candidate
+				break
+			}
 		}
 	}
 	const marker = "[redacted]"

--- a/internal/providers/orgo/client_test.go
+++ b/internal/providers/orgo/client_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -183,6 +185,218 @@ func TestListWorkspacesReadsLiveProjectsEnvelope(t *testing.T) {
 	if len(workspaces) != 1 || workspaces[0].ID != "workspace_test" {
 		t.Fatalf("workspaces=%#v", workspaces)
 	}
+}
+
+func TestOrgoClientRedactsReflectedAPIKey(t *testing.T) {
+	const apiKey = "orgo-secret-token"
+	client := &orgoHTTPClient{
+		baseURL: "https://api.orgo.test",
+		apiKey:  apiKey,
+		http: &http.Client{Transport: orgoRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if got := req.Header.Get("Authorization"); got != "Bearer "+apiKey {
+				t.Fatalf("authorization=%q", got)
+			}
+			return &http.Response{
+				StatusCode: http.StatusUnauthorized,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"message":"credential ` + apiKey + ` rejected","request":"safe-orgo-context"}`)),
+				Request:    req,
+			}, nil
+		})},
+	}
+	_, err := client.GetWorkspace(context.Background(), "workspace_test")
+	if err == nil {
+		t.Fatal("GetWorkspace accepted unauthorized response")
+	}
+	var apiErr *orgoHTTPError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("err=%T, want *orgoHTTPError", err)
+	}
+	if apiErr.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status=%d, want %d", apiErr.StatusCode, http.StatusUnauthorized)
+	}
+	for _, value := range []string{apiErr.Body, err.Error()} {
+		if strings.Contains(value, apiKey) {
+			t.Fatalf("API key leaked in %q", value)
+		}
+		if !strings.Contains(value, "[redacted]") || !strings.Contains(value, "safe-orgo-context") {
+			t.Fatalf("redacted error lost useful context: %q", value)
+		}
+	}
+}
+
+func TestOrgoClientRedactsAPIKeyAcrossResponseLimit(t *testing.T) {
+	const apiKey = "zxqv-orgo-boundary-secret-token"
+	const safeContext = "safe-orgo-boundary-context|"
+	prefixLen := orgoMaxResponseBodyBytes - len("[redacted]") - len(safeContext)
+	body := safeContext + strings.Repeat("x", prefixLen) + apiKey + " trailing provider detail"
+	client := &orgoHTTPClient{
+		baseURL: "https://api.orgo.test",
+		apiKey:  apiKey,
+		http: &http.Client{Transport: orgoRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusUnauthorized,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Request:    req,
+			}, nil
+		})},
+	}
+
+	_, err := client.GetWorkspace(context.Background(), "workspace_test")
+	var apiErr *orgoHTTPError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("err=%v, want *orgoHTTPError", err)
+	}
+	if len(apiErr.Body) != orgoMaxResponseBodyBytes {
+		t.Fatalf("diagnostic bytes=%d, want %d", len(apiErr.Body), orgoMaxResponseBodyBytes)
+	}
+	for _, leaked := range []string{apiKey, apiKey[:10]} {
+		if strings.Contains(apiErr.Body, leaked) {
+			t.Fatalf("API key fragment %q leaked across response limit", leaked)
+		}
+	}
+	if !strings.Contains(apiErr.Body, safeContext) || !strings.HasSuffix(apiErr.Body, "[redacted]") {
+		t.Fatalf("bounded diagnostic lost safe context or redaction marker")
+	}
+}
+
+func TestOrgoClientRepeatedRedactionsDoNotExposeBoundaryFragment(t *testing.T) {
+	const apiKey = "zxqv-orgo-repeated-boundary-secret-token"
+	const safeContext = "safe-orgo-repeated-boundary-context|"
+	prefix := safeContext + apiKey + "|" + apiKey + "|"
+	body := prefix + strings.Repeat("x", orgoMaxResponseBodyBytes-len(prefix)) + apiKey
+	client := &orgoHTTPClient{
+		baseURL: "https://api.orgo.test",
+		apiKey:  apiKey,
+		http: &http.Client{Transport: orgoRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusUnauthorized,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Request:    req,
+			}, nil
+		})},
+	}
+
+	_, err := client.GetWorkspace(context.Background(), "workspace_test")
+	var apiErr *orgoHTTPError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("err=%v, want *orgoHTTPError", err)
+	}
+	if len(apiErr.Body) != orgoMaxResponseBodyBytes {
+		t.Fatalf("diagnostic bytes=%d, want %d", len(apiErr.Body), orgoMaxResponseBodyBytes)
+	}
+	for prefixLen := 1; prefixLen <= len(apiKey); prefixLen++ {
+		if strings.HasSuffix(apiErr.Body, apiKey[:prefixLen]) {
+			t.Fatalf("API key prefix of %d bytes leaked at response boundary", prefixLen)
+		}
+	}
+	if !strings.Contains(apiErr.Body, safeContext) || strings.Count(apiErr.Body, "[redacted]") != 2 {
+		t.Fatalf("bounded diagnostic lost safe context or complete redactions")
+	}
+}
+
+func TestOrgoClientMasksOverlappingAPIKeyMatches(t *testing.T) {
+	apiKey := strings.Repeat("a", 24)
+	const safeContext = "safe-orgo-overlap-context|"
+	body := safeContext + strings.Repeat("a", 2*len(apiKey)-1)
+	client := &orgoHTTPClient{
+		baseURL: "https://api.orgo.test",
+		apiKey:  apiKey,
+		http: &http.Client{Transport: orgoRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusUnauthorized,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Request:    req,
+			}, nil
+		})},
+	}
+
+	_, err := client.GetWorkspace(context.Background(), "workspace_test")
+	var apiErr *orgoHTTPError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("err=%v, want *orgoHTTPError", err)
+	}
+	if strings.Contains(apiErr.Body, apiKey[:len(apiKey)-1]) {
+		t.Fatalf("overlapping API key fragment leaked in %q", apiErr.Body)
+	}
+	if !strings.Contains(apiErr.Body, safeContext) || !strings.Contains(apiErr.Body, "[redacted]") {
+		t.Fatalf("overlap-safe diagnostic lost context or redaction marker: %q", apiErr.Body)
+	}
+}
+
+func TestOrgoActionErrorsRedactReflectedAPIKey(t *testing.T) {
+	const apiKey = "orgo-semantic-secret-token"
+	const safeContext = "safe-orgo-semantic-context"
+	for _, tt := range []struct {
+		name   string
+		method string
+		path   string
+		run    func(*orgoHTTPClient) error
+	}{
+		{
+			name:   "start computer",
+			method: http.MethodPost,
+			path:   "/computers/computer_test/start",
+			run: func(client *orgoHTTPClient) error {
+				return client.StartComputer(context.Background(), "computer_test")
+			},
+		},
+		{
+			name:   "delete computer",
+			method: http.MethodDelete,
+			path:   "/computers/computer_test",
+			run: func(client *orgoHTTPClient) error {
+				return client.DeleteComputer(context.Background(), "computer_test")
+			},
+		},
+		{
+			name:   "delete workspace",
+			method: http.MethodDelete,
+			path:   "/workspaces/workspace_test",
+			run: func(client *orgoHTTPClient) error {
+				return client.DeleteWorkspace(context.Background(), "workspace_test")
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &orgoHTTPClient{
+				baseURL: "https://api.orgo.test",
+				apiKey:  apiKey,
+				http: &http.Client{Transport: orgoRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+					if req.Method != tt.method || req.URL.Path != tt.path {
+						t.Fatalf("request=%s %s, want %s %s", req.Method, req.URL.Path, tt.method, tt.path)
+					}
+					if got := req.Header.Get("Authorization"); got != "Bearer "+apiKey {
+						t.Fatalf("authorization=%q", got)
+					}
+					body := `{"success":false,"status":"credential ` + apiKey + ` rejected; ` + safeContext + `"}`
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Header:     make(http.Header),
+						Body:       io.NopCloser(strings.NewReader(body)),
+						Request:    req,
+					}, nil
+				})},
+			}
+
+			err := tt.run(client)
+			if err == nil {
+				t.Fatal("semantic failure was accepted")
+			}
+			if strings.Contains(err.Error(), apiKey) || !strings.Contains(err.Error(), "[redacted]") || !strings.Contains(err.Error(), safeContext) {
+				t.Fatalf("semantic diagnostic=%q", err)
+			}
+		})
+	}
+}
+
+type orgoRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn orgoRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
 }
 
 func TestNewOrgoClientRejectsInsecureNonLoopbackAPIBase(t *testing.T) {


### PR DESCRIPTION
## Summary

- redact configured credentials reflected by Orgo, FastAPI Cloud, and DigitalOcean response diagnostics
- redact before diagnostic truncation, including Orgo boundary-spanning and overlapping credential matches
- cover non-2xx bodies/status, 2xx semantic failures, unexpected content types, and DigitalOcean semantic identity validation
- document the expanded provider redaction coverage

Fixes https://github.com/openclaw/crabbox/issues/1239

Thanks @coygeek for the source-level report and reproduction.

## Verification

- `go test -count=1 ./internal/providers/orgo ./internal/providers/fastapicloud ./internal/providers/digitalocean`
- `go test -race ./...`
- `go vet ./...`
- `node scripts/build-docs-site.mjs`
- `git diff --check`
- independent autoreview: no actionable findings
- built exact-head CLI against a real loopback HTTP boundary that verified the bearer request, returned a 401 reflecting the fake credential, and produced exit 77 with safe context preserved and the credential removed:

  ```text
  orgo API http 401: {"message":"credential [redacted]****************** rejected","request":"safe-live-cli-context"}
  ```
