### PR TITLE
fix(apple-vm): refresh default Ubuntu image

### DIFF
--- a/.github/workflows/apple-vm-image-source.yml
+++ b/.github/workflows/apple-vm-image-source.yml
@@ -1,0 +1,49 @@
+name: Verify Apple VM Image Source
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 4 * * 1"
+  pull_request:
+    paths:
+      - "internal/cli/os_image.go"
+      - "internal/providers/applevm/backend.go"
+      - "docs/features/configuration.md"
+      - "docs/providers/apple-vm.md"
+      - "scripts/apple-vm-image-source/**"
+      - ".github/workflows/apple-vm-image-source.yml"
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+    paths:
+      - "internal/cli/os_image.go"
+      - "internal/providers/applevm/backend.go"
+      - "docs/features/configuration.md"
+      - "docs/providers/apple-vm.md"
+      - "scripts/apple-vm-image-source/**"
+      - ".github/workflows/apple-vm-image-source.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Verify pinned Canonical source
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Verify shipped image source
+        run: go run ./scripts/apple-vm-image-source

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -74,6 +74,12 @@ jobs:
           persist-credentials: false
           ref: ${{ github.workflow_sha }}
 
+      - name: Set up Go for Apple VM source verification
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+          cache: false
+
       - name: Verify live branch and stable-tag rulesets
         shell: bash
         env:
@@ -117,6 +123,18 @@ jobs:
           git config gpg.format ssh
           git config gpg.ssh.allowedSignersFile "$GITHUB_WORKSPACE/.github/release-allowed-signers"
           scripts/verify-release-source.sh
+
+      - name: Verify shipped Apple VM image source
+        shell: bash
+        env:
+          RELEASE_COMMIT: ${{ inputs.tag_commit }}
+        run: |
+          set -euo pipefail
+          source_root="$RUNNER_TEMP/apple-vm-image-source"
+          mkdir -m 700 "$source_root" "$source_root/internal" "$source_root/internal/cli" "$source_root/internal/providers" "$source_root/internal/providers/applevm"
+          git show "$RELEASE_COMMIT:internal/cli/os_image.go" >"$source_root/internal/cli/os_image.go"
+          git show "$RELEASE_COMMIT:internal/providers/applevm/backend.go" >"$source_root/internal/providers/applevm/backend.go"
+          go run ./scripts/apple-vm-image-source "$source_root"
 
       - name: Pin exact release notes
         id: notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Updated the checksum-pinned Ubuntu 26.04 Apple VM image to the current immutable Canonical release. Thanks @coygeek.
 - Redacted configured credentials reflected by provider-controlled Orgo, FastAPI Cloud, and DigitalOcean response diagnostics before they reach terminal or CI output. Thanks @coygeek.
 - Made canceled ordinary coordinator creates durable and token-bound, including concurrent same-token replay, atomic cleanup claims, late provider cleanup evidence, generation-fenced retained AWS Mac reactivation, and bounded cancellation retries while fixed-ID creates remain replay-owned. Thanks @fuller-stack-dev.
 

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -579,8 +579,8 @@ provider: apple-vm
 appleVM:
   # Optional for normal Homebrew/release installs.
   helperPath: /custom/path/crabbox-apple-vm-helper
-  image: https://cloud-images.ubuntu.com/releases/resolute/release-20260520/ubuntu-26.04-server-cloudimg-arm64.img
-  imageSHA256: 5e091e27d60116efbb0c743b8dd5cb2d15618e414ef04db0817ed43c8e2d7c7b
+  image: https://cloud-images.ubuntu.com/releases/resolute/release-20260731/ubuntu-26.04-server-cloudimg-arm64.img
+  imageSHA256: 3e113fdd41f39e13729375173bb2ae793f87dc6db4294e5251ff2476971788ba
   user: crabbox
   workRoot: /work/crabbox
   cpus: 4

--- a/docs/providers/apple-vm.md
+++ b/docs/providers/apple-vm.md
@@ -125,8 +125,8 @@ appleVM:
   helperPath: /custom/path/crabbox-apple-vm-helper
 
   # Optional image override. Remote URLs require imageSHA256.
-  image: https://cloud-images.ubuntu.com/releases/resolute/release-20260520/ubuntu-26.04-server-cloudimg-arm64.img
-  imageSHA256: 5e091e27d60116efbb0c743b8dd5cb2d15618e414ef04db0817ed43c8e2d7c7b
+  image: https://cloud-images.ubuntu.com/releases/resolute/release-20260731/ubuntu-26.04-server-cloudimg-arm64.img
+  imageSHA256: 3e113fdd41f39e13729375173bb2ae793f87dc6db4294e5251ff2476971788ba
 
   user: crabbox
   workRoot: /work/crabbox

--- a/internal/applevmhelper/runtime_darwin_arm64.go
+++ b/internal/applevmhelper/runtime_darwin_arm64.go
@@ -52,6 +52,8 @@ var execSeedImageCommand = func(ctx context.Context, name string, args ...string
 	return exec.CommandContext(ctx, name, args...).CombinedOutput()
 }
 
+var errRedirectToNonLoopbackHTTP = errors.New("redirect to non-loopback HTTP is not allowed")
+
 func prepareInstanceAssets(ctx context.Context, cfg startConfig) (Instance, error) {
 	inst := cfg.Instance
 	if err := ensurePrivateDir(InstanceDir(cfg.StateRoot, inst.Name)); err != nil {
@@ -254,7 +256,7 @@ func validateImageRedirect(target *url.URL, originLoopback bool) error {
 		return fmt.Errorf("redirect crosses the loopback trust boundary")
 	}
 	if target.Scheme == "http" && !targetLoopback {
-		return fmt.Errorf("redirect to non-loopback HTTP is not allowed")
+		return errRedirectToNonLoopbackHTTP
 	}
 	return nil
 }
@@ -459,6 +461,8 @@ func safeDownloadError(err error) string {
 		return "request canceled"
 	case errors.Is(err, context.DeadlineExceeded):
 		return "request timed out"
+	case errors.Is(err, errRedirectToNonLoopbackHTTP):
+		return errRedirectToNonLoopbackHTTP.Error()
 	}
 	var netErr net.Error
 	if errors.As(err, &netErr) && netErr.Timeout() {

--- a/internal/applevmhelper/runtime_darwin_arm64_test.go
+++ b/internal/applevmhelper/runtime_darwin_arm64_test.go
@@ -302,6 +302,29 @@ func TestResolveSourceImageRejectsRedirectToNonLoopbackHTTP(t *testing.T) {
 	}
 }
 
+func TestSafeDownloadErrorReportsNonLoopbackHTTPRedirectWithoutURL(t *testing.T) {
+	sensitiveURL := (&url.URL{
+		Scheme:   "http",
+		Host:     "downloads.example.test",
+		Path:     "/bearer-secret/image.img",
+		RawQuery: "token=private",
+	}).String()
+	err := &url.Error{
+		Op:  http.MethodGet,
+		URL: sensitiveURL,
+		Err: errRedirectToNonLoopbackHTTP,
+	}
+	got := safeDownloadError(err)
+	if got != errRedirectToNonLoopbackHTTP.Error() {
+		t.Fatalf("safeDownloadError()=%q, want specific HTTP downgrade failure", got)
+	}
+	for _, secret := range []string{"bearer-secret", "private", "downloads.example.test"} {
+		if strings.Contains(got, secret) {
+			t.Fatalf("safe redirect diagnostic exposes URL component %q: %q", secret, got)
+		}
+	}
+}
+
 func TestValidateImageRedirectCannotCrossLoopbackBoundary(t *testing.T) {
 	for _, tc := range []struct {
 		name           string
@@ -310,6 +333,7 @@ func TestValidateImageRedirectCannotCrossLoopbackBoundary(t *testing.T) {
 		wantErr        bool
 	}{
 		{name: "remote https", target: "https://cdn.example.test/image.img", wantErr: false},
+		{name: "remote http", target: "http://downloads.example.test/image.img", wantErr: true},
 		{name: "remote to loopback https", target: "https://127.0.0.1/image.img", wantErr: true},
 		{name: "remote to loopback http", target: "http://localhost/image.img", wantErr: true},
 		{name: "loopback http", target: "http://127.0.0.1/image.img", originLoopback: true, wantErr: false},
@@ -326,6 +350,9 @@ func TestValidateImageRedirectCannotCrossLoopbackBoundary(t *testing.T) {
 			}
 			if !tc.wantErr && err != nil {
 				t.Fatalf("redirect rejected: %v", err)
+			}
+			if tc.target == "http://downloads.example.test/image.img" && !errors.Is(err, errRedirectToNonLoopbackHTTP) {
+				t.Fatalf("redirect error=%v, want non-loopback HTTP sentinel", err)
 			}
 		})
 	}

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -3220,8 +3220,16 @@ func TestAppleVMConfigDefaultsFileAndEnv(t *testing.T) {
 	if cfg.AppleVM.User != "crabbox" || cfg.AppleVM.WorkRoot != "/work/crabbox" || cfg.AppleVM.CPUs != 4 || cfg.AppleVM.MemoryMiB != 8192 || cfg.AppleVM.DiskGiB != 30 {
 		t.Fatalf("apple-vm defaults not applied: %#v", cfg.AppleVM)
 	}
-	if cfg.AppleVM.ImageSHA256 == "" {
-		t.Fatalf("apple-vm default image checksum not applied: %#v", cfg.AppleVM)
+	wantImage, err := osImageDefaultAppleVMImage("ubuntu:26.04")
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantSHA256, err := osImageDefaultAppleVMSHA256("ubuntu:26.04")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.AppleVM.Image != wantImage || cfg.AppleVM.ImageSHA256 != wantSHA256 {
+		t.Fatalf("apple-vm default source=(%q, %q), want portable OS image source", cfg.AppleVM.Image, cfg.AppleVM.ImageSHA256)
 	}
 	if cfg.SSHUser != "crabbox" || cfg.SSHPort != "22" || cfg.WorkRoot != "/work/crabbox" || cfg.TargetOS != targetLinux {
 		t.Fatalf("apple-vm derived defaults not applied: sshUser=%q sshPort=%q workRoot=%q target=%q", cfg.SSHUser, cfg.SSHPort, cfg.WorkRoot, cfg.TargetOS)

--- a/internal/cli/os_image.go
+++ b/internal/cli/os_image.go
@@ -52,8 +52,8 @@ var osImageSpecs = map[string]osImageSpec{
 		HetznerImage:    "ubuntu-24.04",
 		DockerImage:     "docker.io/library/ubuntu:26.04",
 		ContainerName:   "ubuntu:26.04",
-		AppleVMImage:    "https://cloud-images.ubuntu.com/releases/resolute/release-20260520/ubuntu-26.04-server-cloudimg-arm64.img",
-		AppleVMSHA256:   "5e091e27d60116efbb0c743b8dd5cb2d15618e414ef04db0817ed43c8e2d7c7b",
+		AppleVMImage:    "https://cloud-images.ubuntu.com/releases/resolute/release-20260731/ubuntu-26.04-server-cloudimg-arm64.img",
+		AppleVMSHA256:   "3e113fdd41f39e13729375173bb2ae793f87dc6db4294e5251ff2476971788ba",
 	},
 }
 

--- a/internal/cli/os_image_test.go
+++ b/internal/cli/os_image_test.go
@@ -1,6 +1,40 @@
 package cli
 
-import "testing"
+import (
+	"encoding/hex"
+	"net/url"
+	"regexp"
+	"testing"
+)
+
+func TestUbuntu2604AppleVMImageSourceContract(t *testing.T) {
+	t.Parallel()
+	const (
+		approvedURL    = "https://cloud-images.ubuntu.com/releases/resolute/release-20260731/ubuntu-26.04-server-cloudimg-arm64.img"
+		approvedSHA256 = "3e113fdd41f39e13729375173bb2ae793f87dc6db4294e5251ff2476971788ba"
+	)
+
+	spec := osImageSpecs["ubuntu:26.04"]
+	if spec.AppleVMImage != approvedURL || spec.AppleVMSHA256 != approvedSHA256 {
+		t.Fatalf("Ubuntu 26.04 Apple VM source=(%q, %q), want approved immutable source", spec.AppleVMImage, spec.AppleVMSHA256)
+	}
+	imageURL, err := url.Parse(spec.AppleVMImage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if imageURL.Scheme != "https" || imageURL.Host != "cloud-images.ubuntu.com" || imageURL.User != nil || imageURL.RawQuery != "" || imageURL.Fragment != "" {
+		t.Fatalf("Ubuntu 26.04 Apple VM source is not a credential-free canonical HTTPS URL: %q", spec.AppleVMImage)
+	}
+	if !regexp.MustCompile(`^/releases/resolute/release-[0-9]{8}/ubuntu-26[.]04-server-cloudimg-arm64[.]img$`).MatchString(imageURL.Path) {
+		t.Fatalf("Ubuntu 26.04 Apple VM source is not pinned to an immutable dated release: %q", spec.AppleVMImage)
+	}
+	if len(spec.AppleVMSHA256) != 64 {
+		t.Fatalf("Ubuntu 26.04 Apple VM digest length=%d, want 64", len(spec.AppleVMSHA256))
+	}
+	if _, err := hex.DecodeString(spec.AppleVMSHA256); err != nil {
+		t.Fatalf("Ubuntu 26.04 Apple VM digest is not canonical hex: %v", err)
+	}
+}
 
 func TestNormalizeOSImage(t *testing.T) {
 	t.Parallel()

--- a/internal/providers/applevm/backend.go
+++ b/internal/providers/applevm/backend.go
@@ -102,14 +102,14 @@ func defaultAppleVMImage(osImage string) string {
 	if image, err := core.OSImageDefaultAppleVMImage(osImage); err == nil && strings.TrimSpace(image) != "" {
 		return image
 	}
-	return "https://cloud-images.ubuntu.com/releases/resolute/release-20260520/ubuntu-26.04-server-cloudimg-arm64.img"
+	return "https://cloud-images.ubuntu.com/releases/resolute/release-20260731/ubuntu-26.04-server-cloudimg-arm64.img"
 }
 
 func defaultAppleVMImageSHA256(osImage string) string {
 	if checksum, err := core.OSImageDefaultAppleVMSHA256(osImage); err == nil && strings.TrimSpace(checksum) != "" {
 		return checksum
 	}
-	return "5e091e27d60116efbb0c743b8dd5cb2d15618e414ef04db0817ed43c8e2d7c7b"
+	return "3e113fdd41f39e13729375173bb2ae793f87dc6db4294e5251ff2476971788ba"
 }
 
 func (b *backend) Spec() core.ProviderSpec { return b.spec }

--- a/internal/providers/applevm/provider_test.go
+++ b/internal/providers/applevm/provider_test.go
@@ -201,6 +201,23 @@ func TestApplyDefaults(t *testing.T) {
 	}
 }
 
+func TestDefensiveImageFallbackMatchesPortableOSImageDefault(t *testing.T) {
+	wantImage, err := core.OSImageDefaultAppleVMImage("ubuntu:26.04")
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantSHA256, err := core.OSImageDefaultAppleVMSHA256("ubuntu:26.04")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := defaultAppleVMImage("unsupported"); got != wantImage {
+		t.Fatalf("defensive image fallback=%q, want portable default %q", got, wantImage)
+	}
+	if got := defaultAppleVMImageSHA256("unsupported"); got != wantSHA256 {
+		t.Fatalf("defensive digest fallback=%q, want portable default %q", got, wantSHA256)
+	}
+}
+
 func TestValidateConfigRejectsUnsafeGuestIdentity(t *testing.T) {
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName

--- a/scripts/apple-vm-image-source-workflow.test.js
+++ b/scripts/apple-vm-image-source-workflow.test.js
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const workflow = fs.readFileSync(
+  path.join(repoRoot, ".github/workflows/apple-vm-image-source.yml"),
+  "utf8",
+);
+
+test("Apple VM image source workflow covers source changes and stable releases", () => {
+  assert.match(workflow, /^  workflow_dispatch:$/m);
+  assert.match(workflow, /^  schedule:\n    - cron: "17 4 \* \* 1"$/m);
+  assert.match(workflow, /^  pull_request:\n    paths:/m);
+  assert.match(workflow, /^  push:\n    branches:\n      - main\n    tags:\n      - "v\*"\n    paths:/m);
+  for (const source of [
+    "internal/cli/os_image.go",
+    "internal/providers/applevm/backend.go",
+    "scripts/apple-vm-image-source/**",
+    ".github/workflows/apple-vm-image-source.yml",
+  ]) {
+    assert.equal(workflow.split(`- "${source}"`).length - 1, 2, `${source} must trigger PR and main checks`);
+  }
+  assert.match(workflow, /^permissions:\n  contents: read$/m);
+  assert.doesNotMatch(workflow, /contents: write|secrets[.]/);
+  assert.match(workflow, /timeout-minutes: 5/);
+  assert.match(workflow, /actions\/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0/);
+  assert.match(workflow, /actions\/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16/);
+  assert.match(workflow, /go-version-file: go[.]mod\n\s+cache: false/);
+  assert.match(workflow, /run: go run [.][/]scripts\/apple-vm-image-source/);
+  assert.doesNotMatch(workflow, /setup-node|node-version/);
+});

--- a/scripts/apple-vm-image-source/main.go
+++ b/scripts/apple-vm-image-source/main.go
@@ -1,0 +1,380 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	portableSourcePath = "internal/cli/os_image.go"
+	providerSourcePath = "internal/providers/applevm/backend.go"
+	maxChecksumBytes   = 1024 * 1024
+	requestTimeout     = 20 * time.Second
+)
+
+var (
+	canonicalImagePath = regexp.MustCompile(`^/releases/resolute/release-[0-9]{8}/ubuntu-26[.]04-server-cloudimg-arm64[.]img$`)
+	checksumLine       = regexp.MustCompile(`^([0-9A-Fa-f]{64})[ \t]+[*]?(.+)$`)
+	errRedirect        = errors.New("redirects are disabled")
+)
+
+type imageSource struct {
+	image  string
+	digest string
+}
+
+func main() {
+	if len(os.Args) > 2 {
+		fmt.Fprintln(os.Stderr, "Apple VM image source check failed: expected at most one source-root argument")
+		os.Exit(1)
+	}
+	root := "."
+	if len(os.Args) == 2 {
+		root = os.Args[1]
+	}
+	if err := run(context.Background(), root, newHTTPClient()); err != nil {
+		fmt.Fprintf(os.Stderr, "Apple VM image source check failed: %s\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("Apple VM Ubuntu 26.04 image source verified")
+}
+
+func run(ctx context.Context, root string, client *http.Client) error {
+	portableFile, err := parseRequiredFile(root, portableSourcePath)
+	if err != nil {
+		return err
+	}
+	portable, err := extractPortableSource(portableFile)
+	if err != nil {
+		return err
+	}
+
+	providerFile, err := parseRequiredFile(root, providerSourcePath)
+	if err != nil {
+		return err
+	}
+	provider := imageSource{}
+	provider.image, err = extractFinalFallback(providerFile, "defaultAppleVMImage")
+	if err != nil {
+		return err
+	}
+	provider.digest, err = extractFinalFallback(providerFile, "defaultAppleVMImageSHA256")
+	if err != nil {
+		return err
+	}
+	if provider != portable {
+		return errors.New("Apple VM defensive fallback does not match the portable Ubuntu 26.04 source")
+	}
+
+	imageURL, err := validateSource(portable)
+	if err != nil {
+		return err
+	}
+	return verifyRemoteSource(ctx, client, imageURL, portable.digest)
+}
+
+func parseRequiredFile(root, relativePath string) (*ast.File, error) {
+	contents, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(relativePath)))
+	if err != nil {
+		return nil, fmt.Errorf("required source file is unreadable: %s", relativePath)
+	}
+	file, err := parser.ParseFile(token.NewFileSet(), relativePath, contents, 0)
+	if err != nil {
+		return nil, fmt.Errorf("required source file is invalid Go: %s", relativePath)
+	}
+	return file, nil
+}
+
+func extractPortableSource(file *ast.File) (imageSource, error) {
+	var declarations []ast.Expr
+	for _, declaration := range file.Decls {
+		general, ok := declaration.(*ast.GenDecl)
+		if !ok || general.Tok != token.VAR {
+			continue
+		}
+		for _, specification := range general.Specs {
+			valueSpec, ok := specification.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for index, name := range valueSpec.Names {
+				if name.Name != "osImageSpecs" {
+					continue
+				}
+				if index >= len(valueSpec.Values) {
+					return imageSource{}, errors.New("portable OS image specification must have a direct initializer")
+				}
+				declarations = append(declarations, valueSpec.Values[index])
+			}
+		}
+	}
+	if len(declarations) != 1 {
+		return imageSource{}, errors.New("portable OS image specification must be declared exactly once")
+	}
+
+	imageMap, ok := declarations[0].(*ast.CompositeLit)
+	if !ok {
+		return imageSource{}, errors.New("portable OS image specification must be a map literal")
+	}
+	if _, ok := imageMap.Type.(*ast.MapType); !ok {
+		return imageSource{}, errors.New("portable OS image specification must be a map literal")
+	}
+
+	var entries []*ast.CompositeLit
+	for _, element := range imageMap.Elts {
+		keyValue, ok := element.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		key, ok := directStringLiteral(keyValue.Key)
+		if !ok || key != "ubuntu:26.04" {
+			continue
+		}
+		entry, ok := keyValue.Value.(*ast.CompositeLit)
+		if !ok {
+			return imageSource{}, errors.New("portable Ubuntu 26.04 image specification must be a struct literal")
+		}
+		entries = append(entries, entry)
+	}
+	if len(entries) != 1 {
+		return imageSource{}, errors.New("portable Ubuntu 26.04 image specification must appear exactly once")
+	}
+
+	image, err := extractLiteralField(entries[0], "AppleVMImage")
+	if err != nil {
+		return imageSource{}, err
+	}
+	digest, err := extractLiteralField(entries[0], "AppleVMSHA256")
+	if err != nil {
+		return imageSource{}, err
+	}
+	return imageSource{image: image, digest: digest}, nil
+}
+
+func extractLiteralField(literal *ast.CompositeLit, fieldName string) (string, error) {
+	var values []ast.Expr
+	for _, element := range literal.Elts {
+		keyValue, ok := element.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		identifier, ok := keyValue.Key.(*ast.Ident)
+		if ok && identifier.Name == fieldName {
+			values = append(values, keyValue.Value)
+		}
+	}
+	if len(values) != 1 {
+		return "", fmt.Errorf("portable Ubuntu 26.04 %s must appear exactly once", fieldName)
+	}
+	value, ok := directStringLiteral(values[0])
+	if !ok {
+		return "", fmt.Errorf("portable Ubuntu 26.04 %s must be a direct string literal", fieldName)
+	}
+	return value, nil
+}
+
+func extractFinalFallback(file *ast.File, functionName string) (string, error) {
+	var functions []*ast.FuncDecl
+	for _, declaration := range file.Decls {
+		function, ok := declaration.(*ast.FuncDecl)
+		if ok && function.Recv == nil && function.Name.Name == functionName {
+			functions = append(functions, function)
+		}
+	}
+	if len(functions) != 1 {
+		return "", fmt.Errorf("Apple VM %s fallback must be declared exactly once", functionName)
+	}
+	function := functions[0]
+	if function.Body == nil || len(function.Body.List) == 0 {
+		return "", fmt.Errorf("Apple VM %s final defensive fallback is missing", functionName)
+	}
+	if function.Type.Results == nil || len(function.Type.Results.List) != 1 {
+		return "", fmt.Errorf("Apple VM %s fallback must return one string", functionName)
+	}
+	resultType, ok := function.Type.Results.List[0].Type.(*ast.Ident)
+	if !ok || resultType.Name != "string" {
+		return "", fmt.Errorf("Apple VM %s fallback must return one string", functionName)
+	}
+
+	finalReturn, ok := function.Body.List[len(function.Body.List)-1].(*ast.ReturnStmt)
+	if !ok || len(finalReturn.Results) != 1 {
+		return "", fmt.Errorf("Apple VM %s final defensive fallback must be a return statement", functionName)
+	}
+	value, ok := directStringLiteral(finalReturn.Results[0])
+	if !ok {
+		return "", fmt.Errorf("Apple VM %s final defensive fallback must be a direct string literal", functionName)
+	}
+	return value, nil
+}
+
+func directStringLiteral(expression ast.Expr) (string, bool) {
+	literal, ok := expression.(*ast.BasicLit)
+	if !ok || literal.Kind != token.STRING {
+		return "", false
+	}
+	value, err := strconv.Unquote(literal.Value)
+	return value, err == nil
+}
+
+func validateSource(source imageSource) (*url.URL, error) {
+	if len(source.digest) != 64 {
+		return nil, errors.New("portable Ubuntu 26.04 Apple VM digest is not canonical SHA-256 hex")
+	}
+	for _, character := range source.digest {
+		if character < '0' || (character > '9' && character < 'a') || character > 'f' {
+			return nil, errors.New("portable Ubuntu 26.04 Apple VM digest is not canonical SHA-256 hex")
+		}
+	}
+
+	imageURL, err := url.Parse(source.image)
+	if err != nil || imageURL.Scheme != "https" || imageURL.Host != "cloud-images.ubuntu.com" ||
+		imageURL.User != nil || imageURL.RawQuery != "" || imageURL.ForceQuery || imageURL.Fragment != "" ||
+		imageURL.Opaque != "" || imageURL.RawPath != "" || !canonicalImagePath.MatchString(imageURL.Path) {
+		return nil, errors.New("portable Ubuntu 26.04 Apple VM URL is not a credential-free dated Canonical HTTPS release")
+	}
+	return imageURL, nil
+}
+
+func newHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: requestTimeout,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return errRedirect
+		},
+	}
+}
+
+func verifyRemoteSource(ctx context.Context, client *http.Client, imageURL *url.URL, digest string) error {
+	if err := probeImage(ctx, client, imageURL); err != nil {
+		return err
+	}
+	manifest, err := fetchChecksumManifest(ctx, client, imageURL)
+	if err != nil {
+		return err
+	}
+	return verifyChecksumEntry(manifest, imageURL, digest)
+}
+
+func probeImage(ctx context.Context, client *http.Client, imageURL *url.URL) error {
+	response, cancel, err := fetchDirect(ctx, client, imageURL, "image probe", map[int]bool{
+		http.StatusOK:             true,
+		http.StatusPartialContent: true,
+	}, map[string]string{
+		"Accept":          "application/octet-stream",
+		"Accept-Encoding": "identity",
+		"Range":           "bytes=0-0",
+		"User-Agent":      "crabbox-apple-vm-image-source-check",
+	})
+	if err != nil {
+		return err
+	}
+	defer cancel()
+	defer response.Body.Close()
+
+	var firstByte [1]byte
+	if _, err := io.ReadFull(response.Body, firstByte[:]); err != nil {
+		return errors.New("image probe response did not contain the requested byte")
+	}
+	return nil
+}
+
+func fetchChecksumManifest(ctx context.Context, client *http.Client, imageURL *url.URL) (string, error) {
+	checksumURL := imageURL.ResolveReference(&url.URL{Path: path.Join(path.Dir(imageURL.Path), "SHA256SUMS")})
+	response, cancel, err := fetchDirect(ctx, client, checksumURL, "checksum manifest", map[int]bool{
+		http.StatusOK: true,
+	}, map[string]string{
+		"Accept":          "text/plain",
+		"Accept-Encoding": "identity",
+		"User-Agent":      "crabbox-apple-vm-image-source-check",
+	})
+	if err != nil {
+		return "", err
+	}
+	defer cancel()
+	defer response.Body.Close()
+
+	if response.ContentLength > maxChecksumBytes {
+		return "", errors.New("checksum manifest exceeds the bounded read limit")
+	}
+	contents, err := io.ReadAll(io.LimitReader(response.Body, maxChecksumBytes+1))
+	if err != nil {
+		return "", errors.New("checksum manifest body read failed")
+	}
+	if len(contents) > maxChecksumBytes {
+		return "", errors.New("checksum manifest exceeds the bounded read limit")
+	}
+	return string(contents), nil
+}
+
+func fetchDirect(ctx context.Context, client *http.Client, requestedURL *url.URL, label string, acceptedStatuses map[int]bool, headers map[string]string) (*http.Response, context.CancelFunc, error) {
+	requestContext, cancel := context.WithTimeout(ctx, requestTimeout)
+	request, err := http.NewRequestWithContext(requestContext, http.MethodGet, requestedURL.String(), nil)
+	if err != nil {
+		cancel()
+		return nil, nil, fmt.Errorf("%s request could not be created", label)
+	}
+	for name, value := range headers {
+		request.Header.Set(name, value)
+	}
+
+	response, err := client.Do(request)
+	if err != nil {
+		cancel()
+		if response != nil && response.Body != nil {
+			response.Body.Close()
+		}
+		if errors.Is(err, errRedirect) {
+			return nil, nil, fmt.Errorf("%s response redirected", label)
+		}
+		return nil, nil, fmt.Errorf("%s request failed", label)
+	}
+	if response.Request == nil || response.Request.URL == nil ||
+		response.Request.URL.Scheme != requestedURL.Scheme || response.Request.URL.Host != requestedURL.Host {
+		response.Body.Close()
+		cancel()
+		return nil, nil, fmt.Errorf("%s response changed scheme or host", label)
+	}
+	if len(response.Header.Values("Location")) != 0 {
+		response.Body.Close()
+		cancel()
+		return nil, nil, fmt.Errorf("%s response contains a redirect location", label)
+	}
+	if !acceptedStatuses[response.StatusCode] {
+		response.Body.Close()
+		cancel()
+		return nil, nil, fmt.Errorf("%s returned HTTP %d", label, response.StatusCode)
+	}
+	return response, cancel, nil
+}
+
+func verifyChecksumEntry(manifest string, imageURL *url.URL, digest string) error {
+	filename := path.Base(imageURL.Path)
+	matchingFilename := 0
+	matchingDigest := ""
+	for _, line := range strings.Split(strings.ReplaceAll(manifest, "\r\n", "\n"), "\n") {
+		match := checksumLine.FindStringSubmatch(line)
+		if match == nil || match[2] != filename {
+			continue
+		}
+		matchingFilename++
+		matchingDigest = match[1]
+	}
+	if matchingFilename != 1 || matchingDigest != digest {
+		return errors.New("checksum manifest does not contain the exact shipped filename and digest")
+	}
+	return nil
+}

--- a/scripts/apple-vm-image-source/main_test.go
+++ b/scripts/apple-vm-image-source/main_test.go
@@ -1,0 +1,285 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const (
+	testImage  = "https://cloud-images.ubuntu.com/releases/resolute/release-20260731/ubuntu-26.04-server-cloudimg-arm64.img"
+	testDigest = "3e113fdd41f39e13729375173bb2ae793f87dc6db4294e5251ff2476971788ba"
+)
+
+func parseTestFile(t *testing.T, source string) *ast.File {
+	t.Helper()
+	file, err := parser.ParseFile(token.NewFileSet(), "test.go", source, 0)
+	if err != nil {
+		t.Fatalf("parse test source: %v", err)
+	}
+	return file
+}
+
+func portableSource(imageExpression, digestExpression string) string {
+	return fmt.Sprintf(`package cli
+var osImageSpecs = map[string]osImageSpec{
+	"ubuntu:26.04": {
+		AppleVMImage: %s,
+		AppleVMSHA256: %s,
+	},
+}
+`, imageExpression, digestExpression)
+}
+
+func TestExtractPortableSourceIgnoresCommentsAndStringDecoys(t *testing.T) {
+	source := fmt.Sprintf(`package cli
+// "ubuntu:26.04": { AppleVMImage: "https://comment.invalid/image.img" }
+var interpretedDecoy = "AppleVMImage: %s AppleVMSHA256: %s"
+var rawDecoy = %s
+var osImageSpecs = map[string]osImageSpec{
+	"ubuntu:26.04": {
+		AppleVMImage: %q,
+		AppleVMSHA256: %q,
+	},
+}
+`, testImage, testDigest, "`\"ubuntu:26.04\": { AppleVMImage: \"https://raw.invalid/image.img\" }`", testImage, testDigest)
+
+	got, err := extractPortableSource(parseTestFile(t, source))
+	if err != nil {
+		t.Fatalf("extract portable source: %v", err)
+	}
+	if got != (imageSource{image: testImage, digest: testDigest}) {
+		t.Fatalf("extractPortableSource() = %#v", got)
+	}
+}
+
+func TestExtractPortableSourceRejectsNonLiteralExpressions(t *testing.T) {
+	tests := []struct {
+		name   string
+		image  string
+		digest string
+	}{
+		{name: "identifier", image: "imageURL", digest: fmt.Sprintf("%q", testDigest)},
+		{name: "call", image: "imageURL()", digest: fmt.Sprintf("%q", testDigest)},
+		{name: "concatenation", image: `"https://cloud-images.ubuntu.com/" + "image.img"`, digest: fmt.Sprintf("%q", testDigest)},
+		{name: "digest identifier", image: fmt.Sprintf("%q", testImage), digest: "imageDigest"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := extractPortableSource(parseTestFile(t, portableSource(test.image, test.digest)))
+			if err == nil || !strings.Contains(err.Error(), "direct string literal") {
+				t.Fatalf("extractPortableSource() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestExtractPortableSourceRejectsDuplicateAndMissingFields(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+	}{
+		{
+			name: "duplicate field",
+			source: fmt.Sprintf(`package cli
+var osImageSpecs = map[string]osImageSpec{
+	"ubuntu:26.04": {AppleVMImage: %q, AppleVMImage: %q, AppleVMSHA256: %q},
+}`, testImage, testImage, testDigest),
+		},
+		{
+			name: "missing field",
+			source: fmt.Sprintf(`package cli
+var osImageSpecs = map[string]osImageSpec{
+	"ubuntu:26.04": {AppleVMImage: %q},
+}`, testImage),
+		},
+		{
+			name: "duplicate entry",
+			source: fmt.Sprintf(`package cli
+var osImageSpecs = map[string]osImageSpec{
+	"ubuntu:26.04": {AppleVMImage: %q, AppleVMSHA256: %q},
+	"ubuntu:26.04": {AppleVMImage: %q, AppleVMSHA256: %q},
+}`, testImage, testDigest, testImage, testDigest),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := extractPortableSource(parseTestFile(t, test.source)); err == nil || !strings.Contains(err.Error(), "exactly once") {
+				t.Fatalf("extractPortableSource() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestExtractFinalFallbackUsesFinalTopLevelReturn(t *testing.T) {
+	source := fmt.Sprintf(`package applevm
+func defaultAppleVMImage(osImage string) string {
+	if osImage != "" {
+		return "https://nested.invalid/image.img"
+	}
+	for false {
+		return "https://nested-loop.invalid/image.img"
+	}
+	return %q
+}
+`, testImage)
+	got, err := extractFinalFallback(parseTestFile(t, source), "defaultAppleVMImage")
+	if err != nil {
+		t.Fatalf("extract final fallback: %v", err)
+	}
+	if got != testImage {
+		t.Fatalf("extractFinalFallback() = %q, want %q", got, testImage)
+	}
+}
+
+func TestExtractFinalFallbackRejectsNonLiteralFinalReturn(t *testing.T) {
+	for _, expression := range []string{"imageURL", "imageURL()", `"https://example.invalid/" + "image.img"`} {
+		source := fmt.Sprintf(`package applevm
+func defaultAppleVMImage(osImage string) string {
+	if osImage != "" { return %q }
+	return %s
+}`, testImage, expression)
+		_, err := extractFinalFallback(parseTestFile(t, source), "defaultAppleVMImage")
+		if err == nil || !strings.Contains(err.Error(), "direct string literal") {
+			t.Fatalf("extractFinalFallback(%q) error = %v", expression, err)
+		}
+	}
+}
+
+func TestExtractCurrentRealSource(t *testing.T) {
+	root := filepath.Join("..", "..")
+	portableFile, err := parseRequiredFile(root, portableSourcePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	portable, err := extractPortableSource(portableFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if portable != (imageSource{image: testImage, digest: testDigest}) {
+		t.Fatalf("portable source = %#v", portable)
+	}
+
+	providerFile, err := parseRequiredFile(root, providerSourcePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	image, err := extractFinalFallback(providerFile, "defaultAppleVMImage")
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest, err := extractFinalFallback(providerFile, "defaultAppleVMImageSHA256")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if image != portable.image || digest != portable.digest {
+		t.Fatalf("provider fallback = %q/%q, portable = %#v", image, digest, portable)
+	}
+}
+
+func TestProbeImageRejectsRedirectWithoutExposingLocation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "https://example.invalid/bearer-secret/image.img?token=private", http.StatusFound)
+	}))
+	defer server.Close()
+
+	imageURL, err := url.Parse(server.URL + "/image.img")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = probeImage(context.Background(), newHTTPClient(), imageURL)
+	if err == nil || !strings.Contains(err.Error(), "redirected") {
+		t.Fatalf("probeImage() error = %v", err)
+	}
+	for _, sensitive := range []string{"bearer-secret", "private", "example.invalid"} {
+		if strings.Contains(err.Error(), sensitive) {
+			t.Fatalf("redirect error exposed %q: %v", sensitive, err)
+		}
+	}
+}
+
+func TestFetchChecksumManifestRejectsOversizedBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(strings.Repeat("x", maxChecksumBytes+1)))
+	}))
+	defer server.Close()
+
+	imageURL, err := url.Parse(server.URL + "/release/image.img")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = fetchChecksumManifest(context.Background(), newHTTPClient(), imageURL)
+	if err == nil || !strings.Contains(err.Error(), "bounded read limit") {
+		t.Fatalf("fetchChecksumManifest() error = %v", err)
+	}
+}
+
+func TestVerifyRemoteSourceRejectsDigestMismatch(t *testing.T) {
+	server := newImageServer(t, strings.Repeat("f", 64))
+	defer server.Close()
+
+	imageURL, err := url.Parse(server.URL + "/release/image.img")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = verifyRemoteSource(context.Background(), newHTTPClient(), imageURL, testDigest)
+	if err == nil || !strings.Contains(err.Error(), "exact shipped filename and digest") {
+		t.Fatalf("verifyRemoteSource() error = %v", err)
+	}
+}
+
+func TestVerifyRemoteSourceSuccessUsesOneByteRange(t *testing.T) {
+	var imageRequests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/release/image.img":
+			imageRequests++
+			if got := r.Header.Get("Range"); got != "bytes=0-0" {
+				t.Errorf("Range = %q", got)
+			}
+			w.Header().Set("Content-Range", "bytes 0-0/999999999")
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = w.Write([]byte{0})
+		case "/release/SHA256SUMS":
+			_, _ = fmt.Fprintf(w, "%s *image.img\n", testDigest)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	imageURL, err := url.Parse(server.URL + "/release/image.img")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := verifyRemoteSource(context.Background(), newHTTPClient(), imageURL, testDigest); err != nil {
+		t.Fatalf("verifyRemoteSource() error = %v", err)
+	}
+	if imageRequests != 1 {
+		t.Fatalf("image requests = %d, want 1", imageRequests)
+	}
+}
+
+func newImageServer(t *testing.T, manifestDigest string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/release/image.img":
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = w.Write([]byte{0})
+		case "/release/SHA256SUMS":
+			_, _ = fmt.Fprintf(w, "%s *image.img\n", manifestDigest)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}

--- a/scripts/release-workflow.test.js
+++ b/scripts/release-workflow.test.js
@@ -19,6 +19,10 @@ test("release workflow is verifier-only, protected-default, dual-native, and tok
   assert.match(workflow, /verify-github-release-policy\.mjs/);
   assert.match(workflow, /ref: \$\{\{ github\.workflow_sha \}\}/);
   assert.match(workflow, /persist-credentials: false/);
+  assert.match(
+    workflow,
+    /name: Set up Go for Apple VM source verification\n\s+uses: actions\/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16[\s\S]*name: Verify shipped Apple VM image source[\s\S]*git show "\$RELEASE_COMMIT:internal\/cli\/os_image[.]go"[\s\S]*git show "\$RELEASE_COMMIT:internal\/providers\/applevm\/backend[.]go"[\s\S]*go run [.][/]scripts\/apple-vm-image-source "\$source_root"/,
+  );
   assert.match(workflow, /runner: macos-15\n\s+arch: arm64/);
   assert.match(workflow, /runner: macos-15-intel\n\s+arch: x86_64/);
   assert.match(workflow, /cancel-in-progress: false/);


### PR DESCRIPTION
## What Problem This Solves

Fixes https://github.com/openclaw/crabbox/issues/1267. The built-in Ubuntu 26.04 Apple VM image URL redirected from HTTPS to non-loopback HTTP, so Crabbox correctly rejected the documented cold-start path before VM creation.

## Why This Change Was Made

- Replaces the retired `release-20260520` pin with Canonical's current immutable `release-20260731` HTTPS object and its official SHA-256 digest.
- Updates the portable OS-image mapping, Apple VM defensive fallback, and user-facing configuration documentation together.
- Keeps the existing HTTPS and loopback trust boundary unchanged.
- Reports the specific credential-safe `redirect to non-loopback HTTP is not allowed` reason instead of the generic `request failed` message.
- Adds a syntax-aware standard-library Go verifier that parses the executable Go AST, rejects indirect or spoofed source expressions, requests only one image byte without redirects, and checks the exact digest against Canonical's bounded `SHA256SUMS` manifest.
- Runs that verifier on relevant PR/main/tag changes, weekly, and from the protected release verifier against the exact release commit.

## User Impact

A cold default Apple VM acquisition can again download and verify Ubuntu 26.04 without weakening redirect or checksum policy. Custom image behavior is unchanged.

No configuration, credential, dependency, or API changes are required.

## Evidence

Exact head: `c5148ad3a90fd8571f5174b590bcc9a79eef2596`

Live source proof:

- Old pin: direct request returns `302` with an HTTP archive location.
- New pin: direct HTTPS `200`, content length `940920832`.
- Canonical manifest: `3e113fdd41f39e13729375173bb2ae793f87dc6db4294e5251ff2476971788ba *ubuntu-26.04-server-cloudimg-arm64.img`.
- `go run ./scripts/apple-vm-image-source` — passed using a one-byte range probe and bounded manifest read.

Local verification:

- `go test ./scripts/apple-vm-image-source -count=1`
- `go test -race ./internal/applevmhelper ./internal/providers/applevm -count=1`
- `go test ./internal/cli -count=1` — passed in 473.075s.
- `go vet ./internal/applevmhelper ./internal/providers/applevm ./internal/cli ./scripts/apple-vm-image-source`
- `node --test scripts/apple-vm-image-source-workflow.test.js scripts/release-workflow.test.js scripts/workflow-action-pins.test.js` — 28 passed.
- `actionlint .github/workflows/apple-vm-image-source.yml .github/workflows/release-assets.yml`
- `node scripts/build-docs-site.mjs`
- `git diff --cached --check`
- Structured Codex autoreview: clean, no actionable findings; overall correctness confidence `0.97`.
- TruffleHog preflight: clean.

## Release Scope

This PR only repairs and guards the release blocker. It does not publish a release or choose a long-term Crabbox-controlled mirror; an immutable mirror or signature-verified discovery strategy can be considered separately if repeated upstream archival becomes a problem.
