### PR TITLE
ci: extend script test timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,7 @@ jobs:
   scripts:
     name: Scripts
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
 
     steps:
       - name: Check out

--- a/scripts/release-workflow.test.js
+++ b/scripts/release-workflow.test.js
@@ -270,6 +270,7 @@ test("script CI fetches signed release tags for publication fixtures", () => {
   const ci = read(".github/workflows/ci.yml");
   const scriptsJob = ci.slice(ci.indexOf("  scripts:"), ci.indexOf("  docs:"));
   assert.match(scriptsJob, /uses: actions\/checkout@[^\n]+\n\s+with:\n\s+fetch-depth: 0/);
+  assert.match(scriptsJob, /timeout-minutes: 10/);
 });
 
 test("Crabbox CI cannot redefine the organization-required release check", () => {


### PR DESCRIPTION
## What Problem This Solves

Post-merge CI for https://github.com/openclaw/crabbox/pull/1270 canceled the `Scripts` job twice at the job's five-minute timeout. Both attempts completed setup successfully and were canceled mid-test without a failing assertion; every other CI job passed.

## Why This Change Was Made

The script suite now regularly runs near the existing ceiling. This raises only the `Scripts` job timeout from five to ten minutes and adds a workflow contract assertion so the ceiling is not accidentally reduced again.

No product, release, dependency, secret, or runtime behavior changes.

## Evidence

Exact head: `96f0a829dce74ae1a3475c010438d67e8259683b`

- First canceled run: https://github.com/openclaw/crabbox/actions/runs/31360044080 — `Scripts` canceled during `Test` at the five-minute job boundary; all six sibling jobs passed.
- Failed-job rerun of the same SHA: the isolated `Scripts` job was canceled again at the same boundary with no failure output.
- After-fix exact-head CI: https://github.com/openclaw/crabbox/actions/runs/31361955949 — `Scripts` passed in 5 minutes 1 second, beyond the old five-minute ceiling; all sibling jobs also passed.
- `node --test scripts/release-workflow.test.js scripts/workflow-action-pins.test.js` — 27 passed.
- `actionlint .github/workflows/ci.yml`
- `git diff --cached --check`
- Structured Codex autoreview: clean, no actionable findings; overall correctness confidence `0.99`.
- TruffleHog preflight: clean.
