### PR TITLE
chore(release): prepare v0.41.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.41.2 - Unreleased
+## 0.41.2 - 2026-08-10
 
 ### Fixed
 

--- a/release/records/v0.41.2.json
+++ b/release/records/v0.41.2.json
@@ -1,0 +1,9 @@
+{
+  "schemaVersion": 1,
+  "repository": "openclaw/crabbox",
+  "tag": "v0.41.2",
+  "tagObject": "PENDING_AFTER_SIGNED_TAG",
+  "sourceCommit": "PENDING_AFTER_PREPARATION_MERGE",
+  "publicationStatus": "blocked",
+  "blocker": "Pending signed v0.41.2 tag object and peeled source commit; update both fields and set publicationStatus to ready only after the tag is signed and verified."
+}

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/crabbox-worker",
-  "version": "0.41.1",
+  "version": "0.41.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/crabbox-worker",
-      "version": "0.41.1",
+      "version": "0.41.2",
       "dependencies": {
         "@aws-sdk/credential-providers": "^3.1095.0",
         "@cloudflare/containers": "^0.3.7",

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/crabbox-worker",
-  "version": "0.41.1",
+  "version": "0.41.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- date the 0.41.2 changelog section
- bump the private Worker package and lockfile metadata to 0.41.2
- add the fail-closed pending source authorization record

## Verification

- `go vet ./...`
- `go test -race ./...`
- `scripts/test-go-modules.sh`
- `scripts/check-go-coverage.sh 90.0`
- `go build -trimpath -o /tmp/crabbox-v0.41.2 ./cmd/crabbox`
- `npm ci --prefix worker`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm run check:node --prefix worker`
- `npm test --prefix worker`
- `npm run build --prefix worker`
- `npm run build:cloudflare-dynamic-workers --prefix worker`
- `npm run build:node --prefix worker`
- `node --test scripts/*.test.js`
- `scripts/check-docs.sh`
- `go run ./scripts/apple-vm-image-source`
- release preparation autoreview: clean

## Release state

The source record remains blocked until the signed `v0.41.2` tag exists and a separate authorization PR binds its tag object and source commit. No release artifacts or credentials are involved in this PR.
