### PR TITLE
chore(release): authorize v0.41.2 source

### DIFF
--- a/release/records/v0.41.2.json
+++ b/release/records/v0.41.2.json
@@ -2,8 +2,7 @@
   "schemaVersion": 1,
   "repository": "openclaw/crabbox",
   "tag": "v0.41.2",
-  "tagObject": "PENDING_AFTER_SIGNED_TAG",
-  "sourceCommit": "PENDING_AFTER_PREPARATION_MERGE",
-  "publicationStatus": "blocked",
-  "blocker": "Pending signed v0.41.2 tag object and peeled source commit; update both fields and set publicationStatus to ready only after the tag is signed and verified."
+  "tagObject": "db14e46db44ec82eccd4288ab1151599580f42c3",
+  "sourceCommit": "dcb6f6b4c2ba57742544da9f037a834504f48a7d",
+  "publicationStatus": "ready"
 }


### PR DESCRIPTION
## Summary

- bind the protected v0.41.2 source record to signed tag object `db14e46db44ec82eccd4288ab1151599580f42c3`
- bind the peeled source commit to `dcb6f6b4c2ba57742544da9f037a834504f48a7d`
- mark the record ready only after local and remote tag identity and signature verification

## Verification

- `git diff --check`
- `node --test scripts/release-workflow.test.js scripts/publish-release.test.js`
- `scripts/verify-release-source.sh` with `REQUIRE_PUBLISHABLE=1`
- local and remote tag object/commit equality
- approved SSH signature verification against `.github/release-allowed-signers`
- authorization autoreview: clean

## Release state

This PR authorizes candidate production from the already signed, protected `v0.41.2` tag. It does not build, upload, publish, replace, or delete release artifacts.
