### PR TITLE
chore(release): open v0.41.3 development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 0.41.3 - Unreleased
+
 ## 0.41.2 - 2026-08-10
 
 ### Fixed


### PR DESCRIPTION
## Summary

Open v0.41.3 development after the verified v0.41.2 release.

## Verification

- `git diff --check`
- `node --test scripts/release-workflow.test.js scripts/publish-release.test.js`
- `scripts/check-docs.sh`
- closeout autoreview: clean

## Release proof

- Release: https://github.com/openclaw/crabbox/releases/tag/v0.41.2
- Public native verifier: https://github.com/openclaw/crabbox/actions/runs/31400542338
- Native Homebrew verifier: https://github.com/openclaw/crabbox/actions/runs/31405280801
- Homebrew tap update: https://github.com/openclaw/homebrew-tap/pull/16
