### PR TITLE
fix(version): report dev for source builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Stopped market-independent AWS Spot launch request errors from being retried as On-Demand while preserving fallback for Spot-recoverable capacity, quota, and unsupported-market failures. Thanks @vincentkoc.
+- Made plain source builds report `dev` instead of the stale `0.15.0` release identity while preserving injected release versions and tagged Go module build information. Thanks @coygeek.
 
 ## 0.41.2 - 2026-08-10
 

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-var version = "0.15.0"
+var version = "dev"
 
 func currentVersion() string {
 	buildInfoVersion := ""
@@ -16,7 +16,7 @@ func currentVersion() string {
 }
 
 func resolveVersion(injected, buildInfoVersion string) string {
-	if normalized := normalizeBuildVersion(injected); normalized != "" && !strings.HasSuffix(normalized, "-dev") {
+	if normalized := normalizeBuildVersion(injected); normalized != "" && normalized != "dev" && !strings.HasSuffix(normalized, "-dev") {
 		return normalized
 	}
 	if normalized := normalizeTaggedBuildInfoVersion(buildInfoVersion); normalized != "" {

--- a/internal/cli/version_test.go
+++ b/internal/cli/version_test.go
@@ -2,6 +2,36 @@ package cli
 
 import "testing"
 
+func TestDefaultVersionIsDevelopmentIdentity(t *testing.T) {
+	if version != "dev" {
+		t.Fatalf("default version=%q want dev", version)
+	}
+	if got := resolveVersion(version, "(devel)"); got != "dev" {
+		t.Fatalf("plain source version=%q want dev", got)
+	}
+}
+
+func TestResolveVersionUsesTaggedBuildInfoForDevDefault(t *testing.T) {
+	got := resolveVersion("dev", "v1.2.3")
+	if got != "1.2.3" {
+		t.Fatalf("version=%q want 1.2.3", got)
+	}
+}
+
+func TestResolveVersionKeepsDevForPseudoBuildInfo(t *testing.T) {
+	got := resolveVersion("dev", "v1.2.4-0.20260810123456-abcdef123456")
+	if got != "dev" {
+		t.Fatalf("version=%q want dev", got)
+	}
+}
+
+func TestResolveVersionKeepsDevForDirtyBuildInfo(t *testing.T) {
+	got := resolveVersion("dev", "v1.2.4-0.20260810123456-abcdef123456+dirty")
+	if got != "dev" {
+		t.Fatalf("version=%q want dev", got)
+	}
+}
+
 func TestResolveVersionPrefersInjectedRelease(t *testing.T) {
 	got := resolveVersion("v1.2.3", "v9.9.9")
 	if got != "1.2.3" {

--- a/internal/cli/webvnc_local_test.go
+++ b/internal/cli/webvnc_local_test.go
@@ -1426,9 +1426,13 @@ func TestServeLocalWebVNCBridgeScrubsPassedTargetEnvironmentFromViewer(t *testin
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for WebVNC viewer launch")
 	}
-	deadline := time.Now().Add(2 * time.Second)
+	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {
 		if data, err := os.ReadFile(result); err == nil {
+			if len(data) == 0 {
+				time.Sleep(10 * time.Millisecond)
+				continue
+			}
 			if string(data) != "scrubbed" {
 				t.Fatalf("viewer environment=%q", data)
 			}


### PR DESCRIPTION
## Summary

- make plain source builds report `dev` instead of the stale `0.15.0` release identity
- keep explicit release linker injection authoritative
- keep valid tagged Go module build information ahead of the development fallback
- stabilize a repeatedly observed WebVNC test race where shell redirection briefly exposes an empty result file

Fixes https://github.com/openclaw/crabbox/issues/1255

## Verification

- plain documented build reports `dev`
- representative linker-injected build reports `9.8.7`
- tagged, pseudo-version, and dirty build-info resolver tests
- `go vet ./...`
- `go test -race ./...`
- `go build -trimpath -o /tmp/crabbox-version-fix ./cmd/crabbox`
- WebVNC environment-scrubbing test: 50 race-enabled repetitions
- `scripts/check-docs.sh`
- release workflow tests
- final autoreview: clean, no actionable findings

## Notes

The WebVNC change is test-only. Production intentionally starts the platform URL opener asynchronously; the test now waits through the shell's zero-length file creation window while still failing immediately if any nonempty leaked value appears.
