### PR TITLE
fix: preserve custom image PATH for local containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Stopped market-independent AWS Spot launch request errors from being retried as On-Demand while preserving fallback for Spot-recoverable capacity, quota, and unsupported-market failures. Thanks @vincentkoc.
 - Made plain source builds report `dev` instead of the stale `0.15.0` release identity while preserving injected release versions and tagged Go module build information. Thanks @coygeek.
+- Preserved custom local-container image `PATH` entries for commands executed through the managed SSH user. Thanks @coygeek.
 
 ## 0.41.2 - 2026-08-10
 

--- a/cmd/crabbox/local_container_e2e_test.go
+++ b/cmd/crabbox/local_container_e2e_test.go
@@ -68,10 +68,13 @@ func TestLocalContainerProviderE2E(t *testing.T) {
 		"--timing-json",
 		"--shell",
 		"--",
-		"set -eu; test -f go.mod; test -f internal/providers/localcontainer/backend.go; echo CRABBOX_LOCAL_CONTAINER_SYNC_OK",
+		"set -eu; test -f go.mod; test -f internal/providers/localcontainer/backend.go; printf 'CRABBOX_LOCAL_CONTAINER_IMAGE_PATH=%s\\n' \"$PATH\"; echo CRABBOX_LOCAL_CONTAINER_SYNC_OK",
 	)
 	if !strings.Contains(oneShot.Stdout, "CRABBOX_LOCAL_CONTAINER_SYNC_OK") {
 		t.Fatalf("one-shot output missing sync marker: stdout=%q stderr=%q", oneShot.Stdout, oneShot.Stderr)
+	}
+	if imagePath := localContainerE2EImagePath(t, ctx, image); imagePath != "" && !strings.Contains(oneShot.Stdout, "CRABBOX_LOCAL_CONTAINER_IMAGE_PATH="+imagePath+"\n") {
+		t.Fatalf("one-shot PATH did not preserve image PATH %q: stdout=%q stderr=%q", imagePath, oneShot.Stdout, oneShot.Stderr)
 	}
 	assertNoLocalContainerForSlug(t, ctx, oneShotSlug)
 
@@ -197,6 +200,23 @@ func runDockerLocalContainerE2EMust(t *testing.T, ctx context.Context, args ...s
 	if out, err := exec.CommandContext(commandCtx, "docker", args...).CombinedOutput(); err != nil {
 		t.Fatalf("docker %s failed: %v: %s", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
 	}
+}
+
+func localContainerE2EImagePath(t *testing.T, ctx context.Context, image string) string {
+	t.Helper()
+	commandCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(commandCtx, "docker", "image", "inspect", "--format", "{{range .Config.Env}}{{println .}}{{end}}", image).CombinedOutput()
+	if err != nil {
+		t.Fatalf("docker image inspect %s failed: %v: %s", image, err, strings.TrimSpace(string(out)))
+	}
+	var imagePath string
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.HasPrefix(line, "PATH=") {
+			imagePath = strings.TrimPrefix(line, "PATH=")
+		}
+	}
+	return imagePath
 }
 
 func parseLocalContainerE2ELeaseID(stdout string) string {

--- a/docs/providers/local-container.md
+++ b/docs/providers/local-container.md
@@ -173,7 +173,8 @@ metadata updates.
 2. The provider runs `docker run -d` with Crabbox labels, loopback SSH port
    publishing, and the public-key auth environment the bootstrap script needs.
 3. On Debian/Ubuntu-compatible images, the container installs
-   `openssh-server`, `git`, `rsync`, `curl`, and `sudo` when they are missing.
+   `openssh-server`, `git`, `rsync`, `curl`, and `sudo` when they are missing,
+   then restores the selected image's declared `PATH` for the managed SSH login.
 4. With `--desktop`, the container installs and starts Xvfb, XFCE, x11vnc,
    xdotool, screenshot tools, ffmpeg, noVNC, and websockify — no systemd
    required.

--- a/internal/providers/localcontainer/backend.go
+++ b/internal/providers/localcontainer/backend.go
@@ -1701,6 +1701,7 @@ install_verified_apt_keyring() {
 
 const bootstrapScript = `
 set -eu
+image_path="${PATH:-/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin}"
 export DEBIAN_FRONTEND=noninteractive
 user="${CRABBOX_SSH_USER:-crabbox}"
 work_root="${CRABBOX_WORK_ROOT:-/work/crabbox}"
@@ -1903,6 +1904,61 @@ if [ "${CRABBOX_DOCKER_SOCKET:-0}" = "1" ]; then
 else
   chown -R "$user" "$home_dir/.ssh" "$work_root"
 fi
+mkdir -p "$home_dir/.config/crabbox"
+printf '%s' "$image_path" > "$home_dir/.config/crabbox/image-path"
+chown "$user" "$home_dir/.config" "$home_dir/.config/crabbox" "$home_dir/.config/crabbox/image-path"
+chmod 0700 "$home_dir/.config/crabbox"
+chmod 0600 "$home_dir/.config/crabbox/image-path"
+login_profile=""
+for candidate in "$home_dir/.bash_profile" "$home_dir/.bash_login" "$home_dir/.profile"; do
+  if [ -e "$candidate" ]; then
+    login_profile="$candidate"
+    break
+  fi
+done
+if [ -z "$login_profile" ]; then
+  login_profile="$home_dir/.bash_profile"
+  : > "$login_profile"
+  chmod 0644 "$login_profile"
+fi
+python3 - "$login_profile" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+data = path.read_bytes()
+block = rb'''# crabbox managed image PATH
+if [ -r "$HOME/.config/crabbox/image-path" ]; then
+  PATH="$(cat "$HOME/.config/crabbox/image-path"; printf '\001')"
+  PATH="${PATH%?}"
+  export PATH
+fi
+# end crabbox managed image PATH
+'''
+
+def find_line_sequence(content, sequence, offset=0):
+    position = content.find(sequence, offset)
+    while position >= 0:
+        if position == 0 or content[position - 1:position] == b"\n":
+            return position
+        position = content.find(sequence, position + 1)
+    return -1
+
+while True:
+    block_start = find_line_sequence(data, block)
+    if block_start < 0:
+        break
+    block_end = block_start + len(block)
+    suffix = data[block_end:]
+    remove_from = block_start
+    if not suffix and remove_from > 0 and data[remove_from - 1:remove_from] == b"\n":
+        remove_from -= 1
+    data = data[:remove_from] + suffix
+if data:
+    data += b"\n"
+path.write_bytes(data + block)
+PY
+chown "$user" "$login_profile"
 chown -R "$user" /var/cache/crabbox
 env | sed -n 's/^CRABBOX_CACHE_VOLUME_PATH_[0-9][0-9]*=//p' | while IFS= read -r cache_path; do
   [ -n "$cache_path" ] || continue

--- a/internal/providers/localcontainer/backend_test.go
+++ b/internal/providers/localcontainer/backend_test.go
@@ -1314,6 +1314,17 @@ func TestLocalContainerReadyCheckReportsFailureDiagnostics(t *testing.T) {
 func TestBootstrapScriptUsesAccountHomeDirectory(t *testing.T) {
 	for _, want := range []string{
 		`home_dir="$(getent passwd "$user" | cut -d: -f6)"`,
+		`image_path="${PATH:-/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin}"`,
+		`printf '%s' "$image_path" > "$home_dir/.config/crabbox/image-path"`,
+		`chmod 0600 "$home_dir/.config/crabbox/image-path"`,
+		`for candidate in "$home_dir/.bash_profile" "$home_dir/.bash_login" "$home_dir/.profile"; do`,
+		`python3 - "$login_profile" <<'PY'`,
+		`def find_line_sequence(content, sequence, offset=0):`,
+		`data = data[:remove_from] + suffix`,
+		`PATH="$(cat "$HOME/.config/crabbox/image-path"; printf '\001')"`,
+		`PATH="${PATH%?}"`,
+		`path.write_bytes(data + block)`,
+		`# end crabbox managed image PATH`,
 		`"$home_dir/.ssh/authorized_keys"`,
 		`sed -i 's/^[#[:space:]]*UsePAM[[:space:]].*/UsePAM no/' /etc/ssh/sshd_config`,
 		`printf '\nUsePAM no\n' >> /etc/ssh/sshd_config`,
@@ -1387,6 +1398,99 @@ func TestBootstrapScriptUsesAccountHomeDirectory(t *testing.T) {
 	}
 	if strings.Contains(bootstrapScript, `|| XDG_RUNTIME_DIR="$runtime"`) {
 		t.Fatal("bootstrap script can launch a stale fallback swaybg after termination")
+	}
+}
+
+func TestBootstrapImagePathReadPreservesLiteralBytes(t *testing.T) {
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skipf("bash unavailable: %v", err)
+	}
+	home := t.TempDir()
+	marker := filepath.Join(home, "must-not-exist")
+	want := "/opt/tool dir:$HOME:$(touch " + marker + "):`false`:\n"
+	if err := os.WriteFile(filepath.Join(home, "image-path"), []byte(want), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(bash, "-c", `set -eu
+HOME="$1"
+PATH="$(cat "$HOME/image-path"; printf '\001')"
+PATH="${PATH%?}"
+printf '%s' "$PATH"
+`, "bash", home)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("read image PATH: %v: %s", err, out)
+	}
+	if got := string(out); got != want {
+		t.Fatalf("image PATH = %q, want %q", got, want)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("image PATH content was evaluated: %v", err)
+	}
+}
+
+func TestBootstrapImagePathProfileCanonicalization(t *testing.T) {
+	python, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skipf("python3 unavailable: %v", err)
+	}
+	const opener = "python3 - \"$login_profile\" <<'PY'\n"
+	const closer = "\nPY\nchown \"$user\" \"$login_profile\""
+	start := strings.Index(bootstrapScript, opener)
+	if start < 0 {
+		t.Fatal("bootstrap script missing profile transformation opener")
+	}
+	start += len(opener)
+	end := strings.Index(bootstrapScript[start:], closer)
+	if end < 0 {
+		t.Fatal("bootstrap script missing profile transformation closer")
+	}
+	script := bootstrapScript[start : start+end]
+	profile := filepath.Join(t.TempDir(), ".bash_profile")
+	run := func(input string) string {
+		t.Helper()
+		if err := os.WriteFile(profile, []byte(input), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cmd := exec.Command(python, "-", profile)
+		cmd.Stdin = strings.NewReader(script)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("canonicalize login profile: %v: %s", err, out)
+		}
+		out, err := os.ReadFile(profile)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return string(out)
+	}
+
+	canonical := run("")
+	if strings.Count(canonical, "# crabbox managed image PATH\n") != 1 ||
+		!strings.HasSuffix(canonical, "# end crabbox managed image PATH\n") {
+		t.Fatalf("unexpected canonical block: %q", canonical)
+	}
+	if got := run(canonical); got != canonical {
+		t.Fatalf("canonicalization is not idempotent:\nfirst:  %q\nsecond: %q", canonical, got)
+	}
+
+	withLaterOverride := "PATH=/before\n" + canonical + "PATH=/after\n"
+	got := run(withLaterOverride)
+	if !strings.Contains(got, "PATH=/before\nPATH=/after\n") ||
+		strings.Count(got, canonical) != 1 || !strings.HasSuffix(got, canonical) {
+		t.Fatalf("later profile content was not preserved before one final managed block: %q", got)
+	}
+
+	heredoc := "cat <<'PROFILE'\n# crabbox managed image PATH\nnot the managed block\n# end crabbox managed image PATH\nPROFILE\n"
+	got = run(heredoc)
+	if !strings.HasPrefix(got, heredoc) || strings.Count(got, "# crabbox managed image PATH\n") != 2 {
+		t.Fatalf("line-aligned marker text was modified: %q", got)
+	}
+
+	unmatched := "# crabbox managed image PATH\nPATH=/user\n"
+	got = run(unmatched)
+	if !strings.HasPrefix(got, unmatched) || strings.Count(got, "# crabbox managed image PATH\n") != 2 {
+		t.Fatalf("unmatched marker was modified: %q", got)
 	}
 }
 


### PR DESCRIPTION
Closes https://github.com/openclaw/crabbox/issues/1259

## What Problem This Solves

Fixes an issue where users selecting a custom local-container image could provision successfully but then lose that image's declared `PATH` when commands ran through the managed SSH login. Toolchain executables such as `go` were present in the container but unavailable by name.

## Why This Change Was Made

The local-container bootstrap now captures the image `PATH` before installing packages, stores only that value as data in the managed user's private Crabbox configuration, and restores it from the Bash login profile that Bash will actually select. On every bootstrap it removes prior complete managed blocks while preserving other profile bytes, then appends one canonical block at EOF. The restore path uses no `eval` and preserves shell metacharacters and legal trailing newlines as literal PATH data.

The Docker-tagged E2E test now compares the SSH command's `PATH` with the selected image's actual OCI `Config.Env` value, providing a provider-level regression rather than relying only on static bootstrap assertions.

## User Impact

Custom toolchain images retain their intended command lookup behavior through Crabbox's managed SSH user. Existing `.bash_profile`, `.bash_login`, or `.profile` content remains in place, including profiles without a trailing newline.

## Evidence

- `go test -race ./internal/providers/localcontainer -count=1`
- `go vet ./...`
- `go test -race ./...`
- `go build -trimpath -o /tmp/crabbox-issue-1259-full ./cmd/crabbox`
- `CRABBOX_LOCAL_CONTAINER_E2E_IMAGE=golang:1.26-bookworm go test -tags localcontainer ./cmd/crabbox -run '^TestLocalContainerProviderE2E$' -count=1 -v`
- Docs validation and generated-site tests passed.
- Live custom-image proof used an existing `crabbox` user, an image-only executable under `/opt/image/bin`, and a newline-less `.bash_profile` that reset `PATH` to `/usr/bin:/bin`. The first SSH login resolved the image-only executable, a repeated bootstrap left exactly one managed block, configuration modes remained `0700`/`0600`, and cleanup left no container or inventory entry.
