### PR TITLE
fix: route reused leases by recorded provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Stopped market-independent AWS Spot launch request errors from being retried as On-Demand while preserving fallback for Spot-recoverable capacity, quota, and unsupported-market failures. Thanks @vincentkoc.
 - Made plain source builds report `dev` instead of the stale `0.15.0` release identity while preserving injected release versions and tagged Go module build information. Thanks @coygeek.
 - Preserved custom local-container image `PATH` entries for commands executed through the managed SSH user. Thanks @coygeek.
+- Routed implicit `run --id` and `watch --id` reuse through the provider recorded in the local lease claim before validating the configured provider. Thanks @coygeek.
 
 ## 0.41.2 - 2026-08-10
 

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -38,7 +38,12 @@ snippets, pipes, or shell expansion.
 If `--id` is omitted, Crabbox creates a fresh, non-kept lease and releases it
 when the command exits. With `--id` it reuses an existing lease; `--id` accepts
 either the stable `cbx_...` ID or the active friendly slug (see
-[identifiers](../features/identifiers.md)).
+[identifiers](../features/identifiers.md)). When `--provider` is omitted, a
+provider-bearing local claim selects the existing lease's provider before that
+provider is configured. Exact lease IDs take precedence. Slug matches may span
+multiple scopes of one canonical provider, which that provider resolves; claims
+from different providers require a canonical ID or explicit provider. An
+explicit `--provider` remains authoritative.
 
 With `--pool <key>`, Crabbox borrows one hydrated broker ready-pool lease,
 uses the pool-recorded SSH endpoint, keeps the borrow deadline alive while it

--- a/docs/features/identifiers.md
+++ b/docs/features/identifiers.md
@@ -255,18 +255,23 @@ metadata, and leaves legacy, unowned, shared, or custom keys intact.
 
 Resolution order:
 
-1. Read the local claim store. `resolveLeaseClaim` first tries the literal
-   identifier as a claim filename, then scans `claims/*.json` for any claim
-   whose `leaseID` or normalized `slug` matches.
-2. If a matching claim exists, use its `leaseID` as the canonical handle.
-3. If no claim is found and a coordinator is configured, ask the coordinator to
+1. Read the local claim store. A literal claim filename has precedence. When
+   `--provider` is omitted, its recorded provider is selected before backend
+   configuration; legacy claims without a provider keep the configured default.
+2. For a slug without an explicit provider, require all provider-bearing local
+   claims to agree on one canonical provider. Multiple scopes within that
+   provider remain available to its normal resolver; claims from different
+   providers fail with guidance to use a canonical lease ID or pass
+   `--provider`. An explicit provider remains authoritative.
+3. Use the matching claim's `leaseID` as the canonical handle.
+4. If no claim is found and a coordinator is configured, ask the coordinator to
    resolve the identifier (slug or canonical ID).
-4. For static SSH and direct-provider modes, fall back to the provider's
+5. For static SSH and direct-provider modes, fall back to the provider's
    `Resolve` implementation on `SSHLeaseBackend`.
 
-The first source that returns a hit wins. This is why `--id blue-lobster` works
-from any directory once a warmup ran in some other repo — the local claim
-translates the slug to a lease ID before the broker is ever involved.
+This is why `--id blue-lobster` can select both the canonical lease and its
+provider before provider credentials or configuration are validated. Exact IDs
+remain deterministic even when another claim uses the same text as a slug.
 
 ## Identifier Lifetime
 

--- a/internal/cli/claim.go
+++ b/internal/cli/claim.go
@@ -1122,13 +1122,51 @@ func fsyncDir(dir string) {
 }
 
 func canonicalClaimProvider(provider string) string {
-	if strings.TrimSpace(provider) == FixedAWSClaimProvider {
+	switch strings.TrimSpace(provider) {
+	case FixedAWSClaimProvider:
 		return "aws"
+	case "exec-provider":
+		return "external"
 	}
 	if resolved, err := ProviderFor(provider); err == nil {
 		return resolved.Name()
 	}
 	return normalizeProviderName(provider)
+}
+
+func claimProviderForIdentifier(identifier string) (string, bool, error) {
+	identifier = strings.TrimSpace(identifier)
+	if identifier == "" {
+		return "", false, nil
+	}
+	exact, exists, err := readLeaseClaimWithPresence(identifier)
+	if err != nil {
+		return "", false, err
+	}
+	if exists {
+		provider := canonicalClaimProvider(exact.Provider)
+		return provider, provider != "", nil
+	}
+	claims, err := listLeaseClaims()
+	if err != nil {
+		return "", false, err
+	}
+	slug := normalizeLeaseSlug(identifier)
+	provider := ""
+	for _, claim := range claims {
+		if claim.LeaseID != identifier && (slug == "" || normalizeLeaseSlug(claim.Slug) != slug) {
+			continue
+		}
+		candidate := canonicalClaimProvider(claim.Provider)
+		if candidate == "" {
+			continue
+		}
+		if provider != "" && provider != candidate {
+			return "", false, exit(2, "lease identifier %s matches local claims from multiple providers; use a canonical lease id or pass --provider", identifier)
+		}
+		provider = candidate
+	}
+	return provider, provider != "", nil
 }
 
 func providerClaimScope(provider string, cfg Config) string {

--- a/internal/cli/external_routing_test.go
+++ b/internal/cli/external_routing_test.go
@@ -560,6 +560,31 @@ func TestAutoRouteExternalLeaseUsesPersistedClaimRouting(t *testing.T) {
 	}
 }
 
+func TestAutoRouteExternalLeaseAcceptsCanonicalProviderAliasClaims(t *testing.T) {
+	for _, identifier := range []string{"cbx_1257eeee0001", "legacy-external"} {
+		t.Run(identifier, func(t *testing.T) {
+			root := setExternalRoutingTestHome(t)
+			const leaseID = "cbx_1257eeee0001"
+			routing := ExternalConfig{Command: "legacy-provider", WorkRoot: "/legacy/work"}
+			if _, err := PersistExternalRouting(leaseID, routing); err != nil {
+				t.Fatal(err)
+			}
+			if err := claimLeaseForRepoProviderScope(leaseID, "legacy-external", "exec-provider", "legacy-scope", root, time.Minute, false); err != nil {
+				t.Fatal(err)
+			}
+			cfg := baseConfig()
+			cfg.Provider = "external"
+			fs := newFlagSet("test", os.Stderr)
+			if err := autoRouteExternalLease(&cfg, fs, identifier); err != nil {
+				t.Fatal(err)
+			}
+			if cfg.External.Command != routing.Command || cfg.External.WorkRoot != routing.WorkRoot || cfg.WorkRoot != routing.WorkRoot {
+				t.Fatalf("config=%#v", cfg)
+			}
+		})
+	}
+}
+
 func TestAutoRouteExternalLeaseRejectsAmbiguousAlias(t *testing.T) {
 	root := setExternalRoutingTestHome(t)
 	for _, leaseID := range []string{"cbx_111111111111", "cbx_222222222222"} {

--- a/internal/cli/lease_flags.go
+++ b/internal/cli/lease_flags.go
@@ -88,6 +88,20 @@ func applyLeaseCreateFlagsForLease(cfg *Config, fs *flag.FlagSet, values leaseCr
 	return applyLeaseCreateFlagsForLeaseMode(cfg, fs, values, existingLeaseID, true)
 }
 
+func autoRouteClaimLeaseProvider(cfg *Config, fs *flag.FlagSet, identifier string) error {
+	if flagWasSet(fs, "provider") {
+		return nil
+	}
+	provider, ok, err := claimProviderForIdentifier(identifier)
+	if err != nil {
+		return err
+	}
+	if ok {
+		cfg.Provider = provider
+	}
+	return nil
+}
+
 func applyLeaseCreateFlagsForLeaseMode(cfg *Config, fs *flag.FlagSet, values leaseCreateFlagValues, existingLeaseID string, mutateExternal bool) error {
 	cfg.Provider = *values.Provider
 	prepareProviderDefaults(cfg)
@@ -146,6 +160,9 @@ func applyLeaseCreateFlagsForLeaseMode(cfg *Config, fs *flag.FlagSet, values lea
 	}
 	cfg.DesktopEnv = *values.DesktopEnv
 	if err := applyTargetFlagOverrides(cfg, fs, values.Target); err != nil {
+		return err
+	}
+	if err := autoRouteClaimLeaseProvider(cfg, fs, existingLeaseID); err != nil {
 		return err
 	}
 	if err := autoRouteStaticLease(cfg, fs, existingLeaseID); err != nil {

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -648,6 +648,39 @@ func TestRunWithExistingLeaseRequestsProviderPreparation(t *testing.T) {
 	}
 }
 
+func TestRunWithExistingLeaseRoutesProviderFromClaim(t *testing.T) {
+	clearConfigEnv(t)
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CRABBOX_PROVIDER", "hetzner")
+	repo, err := findRepo()
+	if err != nil {
+		t.Fatal(err)
+	}
+	const leaseID = "cbx_1257abcdefff"
+	if err := claimLeaseForRepoProvider(leaseID, "claim-routed", "run-prepare-test", repo.Root, time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+
+	runPrepareTestResolveRequests = nil
+	var stdout, stderr bytes.Buffer
+	err = (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
+		"--id", leaseID,
+		"--no-sync",
+		"--",
+		"true",
+	})
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 9 || !strings.Contains(exitErr.Message, "resolve captured") {
+		t.Fatalf("run error=%v, want claim-routed resolve-captured exit; stderr=%s", err, stderr.String())
+	}
+	if len(runPrepareTestResolveRequests) != 1 {
+		t.Fatalf("resolve requests=%#v, want one", runPrepareTestResolveRequests)
+	}
+	if got := runPrepareTestResolveRequests[0]; got.ID != leaseID || !got.Prepare {
+		t.Fatalf("resolve request=%#v, want claim-routed existing id with Prepare", got)
+	}
+}
+
 func TestFormatRunSummary(t *testing.T) {
 	endToEndStartedAt := time.Unix(0, 0)
 	got := formatRunSummary(runTimings{
@@ -3090,6 +3123,162 @@ func TestApplyCapacityMarketFlag(t *testing.T) {
 	if err := applyCapacityMarketFlag(&cfg, fs, *market); err == nil {
 		t.Fatal("expected invalid market failure")
 	}
+}
+
+func TestAutoRouteClaimLeaseProvider(t *testing.T) {
+	newFlags := func(t *testing.T, configured string, args ...string) (*flag.FlagSet, *string) {
+		t.Helper()
+		fs := newFlagSet("test", io.Discard)
+		provider := fs.String("provider", configured, "")
+		if err := parseFlags(fs, args); err != nil {
+			t.Fatal(err)
+		}
+		return fs, provider
+	}
+
+	t.Run("exact id canonicalizes fixed AWS marker", func(t *testing.T) {
+		t.Setenv("XDG_STATE_HOME", t.TempDir())
+		const leaseID = "cbx_1257aaaa0001"
+		if err := claimLeaseForRepoProvider(leaseID, "fixed", FixedAWSClaimProvider, "/repo", time.Minute, false); err != nil {
+			t.Fatal(err)
+		}
+		fs, provider := newFlags(t, "hetzner")
+		cfg := Config{Provider: *provider}
+		if err := autoRouteClaimLeaseProvider(&cfg, fs, leaseID); err != nil {
+			t.Fatal(err)
+		}
+		if cfg.Provider != "aws" {
+			t.Fatalf("provider=%q want aws", cfg.Provider)
+		}
+	})
+
+	t.Run("exact id wins over slug collision", func(t *testing.T) {
+		t.Setenv("XDG_STATE_HOME", t.TempDir())
+		const leaseID = "cbx_1257aaaa0002"
+		if err := claimLeaseForRepoProvider(leaseID, "exact-owner", "run-prepare-test", "/repo-a", time.Minute, false); err != nil {
+			t.Fatal(err)
+		}
+		if err := claimLeaseForRepoProvider("cbx_1257bbbb0002", leaseID, "local-container", "/repo-b", time.Minute, false); err != nil {
+			t.Fatal(err)
+		}
+		fs, provider := newFlags(t, "hetzner")
+		cfg := Config{Provider: *provider}
+		if err := autoRouteClaimLeaseProvider(&cfg, fs, leaseID); err != nil {
+			t.Fatal(err)
+		}
+		if cfg.Provider != "run-prepare-test" {
+			t.Fatalf("provider=%q want exact claim provider", cfg.Provider)
+		}
+	})
+
+	t.Run("unique slug routes provider", func(t *testing.T) {
+		t.Setenv("XDG_STATE_HOME", t.TempDir())
+		if err := claimLeaseForRepoProvider("cbx_1257aaaa0003", "Blue Lobster", "local-container", "/repo", time.Minute, false); err != nil {
+			t.Fatal(err)
+		}
+		fs, provider := newFlags(t, "hetzner")
+		cfg := Config{Provider: *provider}
+		if err := autoRouteClaimLeaseProvider(&cfg, fs, "blue-lobster"); err != nil {
+			t.Fatal(err)
+		}
+		if cfg.Provider != "local-container" {
+			t.Fatalf("provider=%q want local-container", cfg.Provider)
+		}
+	})
+
+	t.Run("duplicate slug within one provider defers scope resolution", func(t *testing.T) {
+		t.Setenv("XDG_STATE_HOME", t.TempDir())
+		for _, leaseID := range []string{"cbx_1257aaaa0007", "cbx_1257bbbb0007"} {
+			if err := claimLeaseForRepoProviderScope(leaseID, "Scoped Slug", "local-container", leaseID, "/repo", time.Minute, false); err != nil {
+				t.Fatal(err)
+			}
+		}
+		fs, provider := newFlags(t, "hetzner")
+		cfg := Config{Provider: *provider}
+		if err := autoRouteClaimLeaseProvider(&cfg, fs, "scoped-slug"); err != nil {
+			t.Fatal(err)
+		}
+		if cfg.Provider != "local-container" {
+			t.Fatalf("provider=%q want local-container", cfg.Provider)
+		}
+	})
+
+	t.Run("aliases of one provider do not create ambiguity", func(t *testing.T) {
+		t.Setenv("XDG_STATE_HOME", t.TempDir())
+		for i, providerName := range []string{"external", "exec-provider"} {
+			leaseID := fmt.Sprintf("cbx_1257eeee000%d", i)
+			if err := claimLeaseForRepoProviderScope(leaseID, "External Alias", providerName, leaseID, "/repo", time.Minute, false); err != nil {
+				t.Fatal(err)
+			}
+		}
+		fs, provider := newFlags(t, "hetzner")
+		cfg := Config{Provider: *provider}
+		if err := autoRouteClaimLeaseProvider(&cfg, fs, "external-alias"); err != nil {
+			t.Fatal(err)
+		}
+		if cfg.Provider != "external" {
+			t.Fatalf("provider=%q want external", cfg.Provider)
+		}
+	})
+
+	t.Run("ambiguous slug fails with guidance", func(t *testing.T) {
+		t.Setenv("XDG_STATE_HOME", t.TempDir())
+		if err := claimLeaseForRepoProvider("cbx_1257aaaa0004", "Shared Slug", "local-container", "/repo-a", time.Minute, false); err != nil {
+			t.Fatal(err)
+		}
+		if err := claimLeaseForRepoProvider("cbx_1257bbbb0004", "Shared Slug", "run-prepare-test", "/repo-b", time.Minute, false); err != nil {
+			t.Fatal(err)
+		}
+		fs, provider := newFlags(t, "hetzner")
+		cfg := Config{Provider: *provider}
+		err := autoRouteClaimLeaseProvider(&cfg, fs, "shared-slug")
+		if err == nil || !strings.Contains(err.Error(), "canonical lease id") || !strings.Contains(err.Error(), "--provider") {
+			t.Fatalf("err=%v, want ambiguity guidance", err)
+		}
+	})
+
+	t.Run("explicit provider remains authoritative", func(t *testing.T) {
+		t.Setenv("XDG_STATE_HOME", t.TempDir())
+		const leaseID = "cbx_1257aaaa0005"
+		if err := claimLeaseForRepoProvider(leaseID, "explicit", "local-container", "/repo", time.Minute, false); err != nil {
+			t.Fatal(err)
+		}
+		fs, provider := newFlags(t, "hetzner", "--provider", "run-prepare-test")
+		cfg := Config{Provider: *provider}
+		if err := autoRouteClaimLeaseProvider(&cfg, fs, leaseID); err != nil {
+			t.Fatal(err)
+		}
+		if cfg.Provider != "run-prepare-test" {
+			t.Fatalf("provider=%q want explicit provider", cfg.Provider)
+		}
+	})
+
+	t.Run("legacy claim without provider preserves configured provider", func(t *testing.T) {
+		t.Setenv("XDG_STATE_HOME", t.TempDir())
+		const leaseID = "cbx_1257aaaa0006"
+		if err := claimLeaseForRepo(leaseID, "legacy", "/repo", time.Minute, false); err != nil {
+			t.Fatal(err)
+		}
+		fs, provider := newFlags(t, "hetzner")
+		cfg := Config{Provider: *provider}
+		if err := autoRouteClaimLeaseProvider(&cfg, fs, leaseID); err != nil {
+			t.Fatal(err)
+		}
+		if cfg.Provider != "hetzner" {
+			t.Fatalf("provider=%q want configured provider", cfg.Provider)
+		}
+	})
+
+	t.Run("empty identifier preserves configured provider", func(t *testing.T) {
+		fs, provider := newFlags(t, "hetzner")
+		cfg := Config{Provider: *provider}
+		if err := autoRouteClaimLeaseProvider(&cfg, fs, ""); err != nil {
+			t.Fatal(err)
+		}
+		if cfg.Provider != "hetzner" {
+			t.Fatalf("provider=%q want configured provider", cfg.Provider)
+		}
+	})
 }
 
 func TestApplyLeaseCreateFlagsForExistingAWSMacOSLeaseDefaultsOnDemand(t *testing.T) {

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -3269,6 +3269,33 @@ func TestAutoRouteClaimLeaseProvider(t *testing.T) {
 		}
 	})
 
+	t.Run("provider-empty slug preserves configured provider", func(t *testing.T) {
+		t.Setenv("XDG_STATE_HOME", t.TempDir())
+		if err := claimLeaseForRepo("cbx_1257aaaa0008", "Legacy Slug", "/repo", time.Minute, false); err != nil {
+			t.Fatal(err)
+		}
+		fs, provider := newFlags(t, "hetzner")
+		cfg := Config{Provider: *provider}
+		if err := autoRouteClaimLeaseProvider(&cfg, fs, "legacy-slug"); err != nil {
+			t.Fatal(err)
+		}
+		if cfg.Provider != "hetzner" {
+			t.Fatalf("provider=%q want configured provider", cfg.Provider)
+		}
+	})
+
+	t.Run("missing identifier preserves configured provider", func(t *testing.T) {
+		t.Setenv("XDG_STATE_HOME", t.TempDir())
+		fs, provider := newFlags(t, "hetzner")
+		cfg := Config{Provider: *provider}
+		if err := autoRouteClaimLeaseProvider(&cfg, fs, "missing-slug"); err != nil {
+			t.Fatal(err)
+		}
+		if cfg.Provider != "hetzner" {
+			t.Fatalf("provider=%q want configured provider", cfg.Provider)
+		}
+	})
+
 	t.Run("empty identifier preserves configured provider", func(t *testing.T) {
 		fs, provider := newFlags(t, "hetzner")
 		cfg := Config{Provider: *provider}
@@ -3277,6 +3304,45 @@ func TestAutoRouteClaimLeaseProvider(t *testing.T) {
 		}
 		if cfg.Provider != "hetzner" {
 			t.Fatalf("provider=%q want configured provider", cfg.Provider)
+		}
+	})
+
+	t.Run("malformed exact claim fails", func(t *testing.T) {
+		t.Setenv("XDG_STATE_HOME", t.TempDir())
+		const leaseID = "cbx_1257aaaa0009"
+		path, err := leaseClaimPath(leaseID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte("{"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		fs, provider := newFlags(t, "hetzner")
+		cfg := Config{Provider: *provider}
+		if err := autoRouteClaimLeaseProvider(&cfg, fs, leaseID); err == nil || !strings.Contains(err.Error(), "parse claim") {
+			t.Fatalf("err=%v, want malformed exact claim failure", err)
+		}
+	})
+
+	t.Run("malformed claim directory entry fails slug routing", func(t *testing.T) {
+		t.Setenv("XDG_STATE_HOME", t.TempDir())
+		path, err := leaseClaimPath("cbx_1257aaaa0010")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte("{"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		fs, provider := newFlags(t, "hetzner")
+		cfg := Config{Provider: *provider}
+		if err := autoRouteClaimLeaseProvider(&cfg, fs, "some-slug"); err == nil || !strings.Contains(err.Error(), "parse claim") {
+			t.Fatalf("err=%v, want malformed claim directory failure", err)
 		}
 	})
 }

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -499,7 +499,7 @@ func uniqueExternalLeaseClaim(identifier string, providerSelected bool) (leaseCl
 		return leaseClaim{}, false, err
 	}
 	if exists {
-		if exact.Provider != "external" {
+		if canonicalClaimProvider(exact.Provider) != "external" {
 			return leaseClaim{}, false, nil
 		}
 		return exact, true, nil
@@ -515,7 +515,7 @@ func uniqueExternalLeaseClaim(identifier string, providerSelected bool) (leaseCl
 			continue
 		}
 		matches = append(matches, claim)
-		if claim.Provider == "external" {
+		if canonicalClaimProvider(claim.Provider) == "external" {
 			externalMatches = append(externalMatches, claim)
 		}
 	}


### PR DESCRIPTION
Closes https://github.com/openclaw/crabbox/issues/1257

## What Problem This Solves

Fixes an issue where `run --id` and `watch --id` could validate the currently configured provider before reading the existing lease's local claim. A healthy lease recorded under another provider could therefore fail immediately on unrelated credentials or configuration.

## Why This Change Was Made

Implicit lease reuse now consults provider-bearing local claims before backend construction. Literal claim IDs remain authoritative; slug matches may span multiple scopes or aliases of one canonical provider, while claims from different providers fail with guidance to use a canonical ID or explicit provider. Explicit `--provider` remains authoritative, and legacy claims without provider metadata preserve the configured-provider behavior.

The existing static and external routing paths remain responsible for restoring provider-specific endpoint and lifecycle state. External claim comparisons now canonicalize the legacy `exec-provider` alias consistently.

## User Impact

Users can reuse a known lease by ID or unambiguous slug without first matching the ambient provider configuration or credentials. Provider-scoped duplicate slugs continue to use the provider's established scope resolver instead of being rejected globally.

## Evidence

- Command-level regression: a configured Hetzner provider without credentials is bypassed by an implicit `--id` claim recorded for the test provider, reaching `Resolve` with `Prepare: true`.
- Focused race coverage for exact-ID precedence, fixed-AWS canonicalization, unique and cross-provider slugs, same-provider multi-scope slugs, canonical/legacy external aliases, explicit provider authority, legacy provider-empty claims, and no-ID behavior.
- `go vet ./...`
- `go test -race ./...`
- `go build -trimpath -o /tmp/crabbox-issue-1257-full ./cmd/crabbox`
- Command docs, provider matrix, links, generated docs site, and docs-site tests passed.
- Independent review completed with no actionable findings.
