### PR TITLE
fix: AWS SSH stays reachable when broker uses IPv6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Made GitHub team authorization fail closed on malformed selectors, enforced same-org team scope, and invalidated membership and device proofs when the normalized policy changes. Thanks @dwin-gharibi.
 - Rejected invalid or overlong coordinator-requested lease slugs before provisioning while preserving exact fixed-ID replays created under the legacy length behavior. Thanks @dwin-gharibi.
 - Bound valid caller-declared artifact SHA-256 digests into signed broker upload grants, rejected malformed nonblank digests instead of silently disabling integrity checks, and made object storage reject mismatching payloads. Thanks @dwin-gharibi.
+- Preserved pinned AWS SSH ingress and dynamic CIDRs from the other IP family when broker heartbeats refresh access, while replacing obsolete same-family dynamic sources. Thanks @jalehman.
 
 ## 0.41.5 - 2026-08-12
 

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -21728,6 +21728,20 @@ function awsGlobalSSHSourceCIDRs(env: Env): string[] {
   return uniqueNonEmpty(validCIDRs((env.CRABBOX_AWS_SSH_CIDRS ?? "").split(",")));
 }
 
+// A refresh owns only dynamic CIDRs from address families represented by the incoming request.
+function refreshedAWSSSHSourceCIDRs(lease: LeaseRecord, incomingCIDRs: string[]): string[] {
+  const pinnedCIDRs = uniqueNonEmpty(validCIDRs(lease.network?.sshPinnedSourceCIDRs ?? []));
+  const pinned = new Set(pinnedCIDRs);
+  const incoming = uniqueNonEmpty(validCIDRs(incomingCIDRs));
+  const refreshedFamilies = new Set(incoming.map((cidr) => (cidr.includes(":") ? "ipv6" : "ipv4")));
+  const retainedDynamicCIDRs = uniqueNonEmpty(
+    validCIDRs(lease.network?.sshSourceCIDRs ?? []),
+  ).filter(
+    (cidr) => !pinned.has(cidr) && !refreshedFamilies.has(cidr.includes(":") ? "ipv6" : "ipv4"),
+  );
+  return uniqueNonEmpty([...pinnedCIDRs, ...retainedDynamicCIDRs, ...incoming]);
+}
+
 function withLeaseSSHSourceCIDRs(
   lease: LeaseRecord,
   cidrs: string[],
@@ -23574,20 +23588,10 @@ export class AWSProvider implements CloudProvider {
     if (lease.state !== "active") {
       return;
     }
-    const sourceCIDRs = context.requestSourceCIDRs;
+    const sourceCIDRs = validCIDRs(context.requestSourceCIDRs);
     const nextLease =
       sourceCIDRs.length > 0
-        ? withLeaseSSHSourceCIDRs(
-            lease,
-            // Broker HTTP and direct SSH can use different routes or address families.
-            // Keep lease-proven sources until lifecycle reconciliation removes its access.
-            uniqueNonEmpty([
-              ...(lease.network?.sshSourceCIDRs ?? []),
-              ...(lease.network?.sshPinnedSourceCIDRs ?? []),
-              ...sourceCIDRs,
-            ]),
-            true,
-          )
+        ? withLeaseSSHSourceCIDRs(lease, refreshedAWSSSHSourceCIDRs(lease, sourceCIDRs), true)
         : lease;
     const activeLeases = replaceProviderAccessState(context.activeLeases, nextLease);
     try {

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -23579,7 +23579,13 @@ export class AWSProvider implements CloudProvider {
       sourceCIDRs.length > 0
         ? withLeaseSSHSourceCIDRs(
             lease,
-            uniqueNonEmpty([...(lease.network?.sshPinnedSourceCIDRs ?? []), ...sourceCIDRs]),
+            // Broker HTTP and direct SSH can use different routes or address families.
+            // Keep lease-proven sources until lifecycle reconciliation removes its access.
+            uniqueNonEmpty([
+              ...(lease.network?.sshSourceCIDRs ?? []),
+              ...(lease.network?.sshPinnedSourceCIDRs ?? []),
+              ...sourceCIDRs,
+            ]),
             true,
           )
         : lease;

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -17150,6 +17150,70 @@ describe("fleet lease identity and idle", () => {
     expect(refreshed?.network?.sshSourceCIDRs).toEqual(["0.0.0.0/0", "203.0.113.7/32"]);
   });
 
+  it.each([
+    {
+      name: "replaces dynamic IPv4 with incoming IPv4",
+      existing: ["198.51.100.7/32"],
+      incoming: ["203.0.113.8/32"],
+      expected: ["203.0.113.8/32"],
+    },
+    {
+      name: "retains dynamic IPv4 with incoming IPv6",
+      existing: ["198.51.100.7/32"],
+      incoming: ["2001:db8::8/128"],
+      expected: ["198.51.100.7/32", "2001:db8::8/128"],
+    },
+    {
+      name: "replaces dynamic IPv6 with incoming IPv6",
+      existing: ["2001:db8::7/128"],
+      incoming: ["2001:db8::8/128"],
+      expected: ["2001:db8::8/128"],
+    },
+    {
+      name: "retains dynamic IPv6 with incoming IPv4",
+      existing: ["2001:db8::7/128"],
+      incoming: ["203.0.113.8/32"],
+      expected: ["2001:db8::7/128", "203.0.113.8/32"],
+    },
+    {
+      name: "retains pinned CIDRs from both families",
+      existing: ["192.0.2.0/24", "2001:db8:1::/64", "198.51.100.7/32", "2001:db8::7/128"],
+      pinned: ["192.0.2.0/24", "2001:db8:1::/64"],
+      incoming: ["203.0.113.8/32", "2001:db8::8/128"],
+      expected: ["192.0.2.0/24", "2001:db8:1::/64", "203.0.113.8/32", "2001:db8::8/128"],
+    },
+    {
+      name: "retains multiple incoming CIDRs from one family",
+      existing: ["198.51.100.7/32", "2001:db8::7/128"],
+      incoming: ["203.0.113.8/32", "203.0.113.9/32"],
+      expected: ["2001:db8::7/128", "203.0.113.8/32", "203.0.113.9/32"],
+    },
+    {
+      name: "does not preserve invalid stored CIDRs",
+      existing: ["not-a-cidr", "198.51.100.7/32"],
+      incoming: ["2001:db8::8/128"],
+      expected: ["198.51.100.7/32", "2001:db8::8/128"],
+    },
+  ])("$name", async ({ existing, pinned = [], incoming, expected }) => {
+    const provider = new AWSProvider({} as Env, "eu-west-1", new MemoryStorage());
+    vi.spyOn(provider, "reconcileLeaseAccess").mockResolvedValue();
+    const lease = testLease({
+      provider: "aws",
+      network: {
+        sshSourceCIDRs: existing,
+        sshPinnedSourceCIDRs: pinned,
+        sshSourceCIDRsComplete: true,
+      },
+    });
+
+    const refreshed = await provider.refreshLeaseAccess(lease, {
+      requestSourceCIDRs: incoming,
+      activeLeases: [lease],
+    });
+
+    expect(refreshed?.network?.sshSourceCIDRs).toEqual(expected);
+  });
+
   it("keeps IPv4 SSH ingress when an HTTP heartbeat arrives over IPv6", async () => {
     const storage = new MemoryStorage();
     const ingressRequests: Array<{ action: string; ipv4: string; ipv6: string }> = [];

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -17115,7 +17115,7 @@ describe("fleet lease identity and idle", () => {
     expect(otherPrepared.lease.network?.awsSecurityGroupName).not.toBe(managedGroupName);
   });
 
-  it("preserves configured AWS SSH CIDRs when refreshing lease access", async () => {
+  it("preserves lease SSH CIDRs when refreshing access", async () => {
     const provider = new AWSProvider({} as Env, "eu-west-1", new MemoryStorage());
     vi.spyOn(provider, "reconcileLeaseAccess").mockResolvedValue();
     expect(
@@ -17154,10 +17154,13 @@ describe("fleet lease identity and idle", () => {
       network: { sshSourceCIDRs: ["198.51.100.7/32"], sshSourceCIDRsComplete: true },
     });
     const refreshedDynamic = await provider.refreshLeaseAccess(dynamic, {
-      requestSourceCIDRs: ["203.0.113.8/32"],
+      requestSourceCIDRs: ["2001:db8::8/128"],
       activeLeases: [dynamic],
     });
-    expect(refreshedDynamic?.network?.sshSourceCIDRs).toEqual(["203.0.113.8/32"]);
+    expect(refreshedDynamic?.network?.sshSourceCIDRs).toEqual([
+      "198.51.100.7/32",
+      "2001:db8::8/128",
+    ]);
   });
 
   it("reports each AWS fallback region before provisioning mutates it", async () => {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -17115,7 +17115,7 @@ describe("fleet lease identity and idle", () => {
     expect(otherPrepared.lease.network?.awsSecurityGroupName).not.toBe(managedGroupName);
   });
 
-  it("preserves lease SSH CIDRs when refreshing access", async () => {
+  it("preserves configured AWS SSH CIDRs when refreshing lease access", async () => {
     const provider = new AWSProvider({} as Env, "eu-west-1", new MemoryStorage());
     vi.spyOn(provider, "reconcileLeaseAccess").mockResolvedValue();
     expect(
@@ -17148,19 +17148,81 @@ describe("fleet lease identity and idle", () => {
     });
 
     expect(refreshed?.network?.sshSourceCIDRs).toEqual(["0.0.0.0/0", "203.0.113.7/32"]);
+  });
 
-    const dynamic = testLease({
+  it("keeps IPv4 SSH ingress when an HTTP heartbeat arrives over IPv6", async () => {
+    const storage = new MemoryStorage();
+    const ingressRequests: Array<{ action: string; ipv4: string; ipv6: string }> = [];
+    // Exercise the EC2 query boundary against a group that already admits the SSH IPv4.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const fetchRequest = input instanceof Request ? input : new Request(input, init);
+        const params = new URLSearchParams(await fetchRequest.clone().text());
+        const action = params.get("Action") ?? "";
+        ingressRequests.push({
+          action,
+          ipv4: params.get("IpPermissions.1.IpRanges.1.CidrIp") ?? "",
+          ipv6: params.get("IpPermissions.1.Ipv6Ranges.1.CidrIpv6") ?? "",
+        });
+        if (action === "DescribeSecurityGroups") {
+          return ec2XMLResponse(`<?xml version="1.0" encoding="UTF-8"?>
+<DescribeSecurityGroupsResponse><securityGroupInfo><item><groupId>sg-shared</groupId><ipPermissions><item><ipProtocol>tcp</ipProtocol><fromPort>22</fromPort><toPort>22</toPort><ipRanges><item><cidrIp>198.51.100.7/32</cidrIp><description>Crabbox SSH</description></item></ipRanges></item></ipPermissions></item></securityGroupInfo></DescribeSecurityGroupsResponse>`);
+        }
+        return ec2XMLResponse("<Response />");
+      }),
+    );
+    const env = {
+      AWS_ACCESS_KEY_ID: "test",
+      AWS_SECRET_ACCESS_KEY: "secret",
+    } as Env;
+    const fleet = testFleet(storage, { aws: new AWSProvider(env, "eu-west-1", storage) }, env);
+    // Match the active broker record to the managed group returned by the EC2 fixture.
+    const lease = testLease({
+      id: "cbx_abcdef123456",
       provider: "aws",
-      network: { sshSourceCIDRs: ["198.51.100.7/32"], sshSourceCIDRsComplete: true },
+      owner: "alice@example.com",
+      org: "example-org",
+      region: "eu-west-1",
+      sshPort: "22",
+      sshFallbackPorts: [],
+      network: {
+        awsSecurityGroupID: "sg-shared",
+        sshSourceCIDRs: ["198.51.100.7/32"],
+        sshSourceCIDRsComplete: true,
+      },
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
     });
-    const refreshedDynamic = await provider.refreshLeaseAccess(dynamic, {
-      requestSourceCIDRs: ["2001:db8::8/128"],
-      activeLeases: [dynamic],
-    });
-    expect(refreshedDynamic?.network?.sshSourceCIDRs).toEqual([
+    storage.seed(`lease:${lease.id}`, lease);
+
+    // Drive the public heartbeat route so Cloudflare's IPv6 source reaches AWS reconciliation.
+    const heartbeat = await fleet.fetch(
+      request("POST", `/v1/leases/${lease.id}/heartbeat`, {
+        headers: {
+          "cf-connecting-ip": "2001:db8::8",
+          "x-crabbox-owner": lease.owner,
+          "x-crabbox-org": "example-org",
+        },
+        body: {},
+      }),
+    );
+
+    expect(heartbeat.status).toBe(200);
+    // The refresh may add IPv6 access, but it must not revoke the working SSH IPv4.
+    expect(
+      ingressRequests.filter(
+        (entry) => entry.action === "RevokeSecurityGroupIngress" && entry.ipv4 !== "0.0.0.0/0",
+      ),
+    ).toEqual([]);
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)?.network?.sshSourceCIDRs).toEqual([
       "198.51.100.7/32",
       "2001:db8::8/128",
     ]);
+    expect(ingressRequests).toContainEqual({
+      action: "AuthorizeSecurityGroupIngress",
+      ipv4: "",
+      ipv6: "2001:db8::8/128",
+    });
   });
 
   it("reports each AWS fallback region before provisioning mutates it", async () => {


### PR DESCRIPTION
## Summary

AWS access refresh previously replaced the lease's dynamic SSH source list with the current heartbeat address. When the broker heartbeat arrived over IPv6 but SSH still used IPv4, reconciliation could revoke the working IPv4 rule.

This PR now treats each incoming address family as the refresh ownership boundary: pinned CIDRs always survive, incoming IPv4 replaces only old dynamic IPv4, incoming IPv6 replaces only old dynamic IPv6, and dynamic CIDRs from the other family remain available. Stored and incoming values are validated and deduplicated so stale same-family addresses still expire rather than accumulating indefinitely.

## Verification

- focused IPv4/IPv6, pinned, multi-source, invalid-source, and public-heartbeat regressions: passed
- full AWS/fleet and Worker suites before final rebase: passed
- Worker formatting, lint, TypeScript checks, and dry-run build
- structured P1 full-branch autoreview: clean
