### PR TITLE
fix(local-container): preserve PATH across profile changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Stopped market-independent AWS Spot launch request errors from being retried as On-Demand while preserving fallback for Spot-recoverable capacity, quota, and unsupported-market failures. Thanks @vincentkoc.
 - Made plain source builds report `dev` instead of the stale `0.15.0` release identity while preserving injected release versions and tagged Go module build information. Thanks @coygeek.
-- Preserved custom local-container image `PATH` entries for commands executed through the managed SSH user. Thanks @coygeek.
+- Preserved custom local-container image `PATH` entries across managed SSH logins, including when users add or switch login-profile files after bootstrap. Thanks @coygeek.
 - Routed implicit `run --id` and `watch --id` reuse through the provider recorded in the local lease claim before validating the configured provider. Thanks @coygeek.
 
 ## 0.41.2 - 2026-08-10

--- a/cmd/crabbox/local_container_e2e_test.go
+++ b/cmd/crabbox/local_container_e2e_test.go
@@ -40,7 +40,7 @@ func TestLocalContainerProviderE2E(t *testing.T) {
 
 	image := strings.TrimSpace(os.Getenv("CRABBOX_LOCAL_CONTAINER_E2E_IMAGE"))
 	if image == "" {
-		image = "debian:bookworm"
+		image = "golang:1.26-bookworm"
 	}
 	tag := strings.ToLower(strings.ReplaceAll(t.Name(), "_", "-"))
 	if len(tag) > 16 {
@@ -97,20 +97,35 @@ func TestLocalContainerProviderE2E(t *testing.T) {
 	})
 
 	runCrabboxLocalContainerE2EMust(t, ctx, "status", "--provider", "docker", "--id", leaseID, "--wait", "--json")
-	reuse := runCrabboxLocalContainerE2EMust(t, ctx,
+	firstLogin := runCrabboxLocalContainerE2EMust(t, ctx,
 		"run",
 		"--provider", "docker",
 		"--id", leaseID,
 		"--no-sync",
 		"--timing-json",
+		"--shell",
 		"--",
-		"echo", "CRABBOX_LOCAL_CONTAINER_REUSE_OK",
+		`set -eu; test "$(command -v go)" = /usr/local/go/bin/go; test "$(stat -c '%U:%G:%a' /etc/profile.d/crabbox-image-path.sh)" = root:root:644; mkdir -p "$HOME/profile-bin"; printf '%s\n' 'export PATH="$HOME/profile-bin:$PATH"' > "$HOME/.bash_profile"; echo CRABBOX_LOCAL_CONTAINER_FIRST_LOGIN_OK`,
 	)
-	if !strings.Contains(reuse.Stdout, "CRABBOX_LOCAL_CONTAINER_REUSE_OK") {
-		t.Fatalf("reuse output missing marker: stdout=%q stderr=%q", reuse.Stdout, reuse.Stderr)
+	if !strings.Contains(firstLogin.Stdout, "CRABBOX_LOCAL_CONTAINER_FIRST_LOGIN_OK") {
+		t.Fatalf("first login output missing marker: stdout=%q stderr=%q", firstLogin.Stdout, firstLogin.Stderr)
+	}
+	secondLogin := runCrabboxLocalContainerE2EMust(t, ctx,
+		"run",
+		"--provider", "docker",
+		"--id", leaseID,
+		"--no-sync",
+		"--timing-json",
+		"--shell",
+		"--",
+		`set -eu; test "$(command -v go)" = /usr/local/go/bin/go; test "${PATH%%:*}" = "$HOME/profile-bin"; printf 'CRABBOX_LOCAL_CONTAINER_PROFILE_PATH=%s\n' "$PATH"; echo CRABBOX_LOCAL_CONTAINER_SECOND_LOGIN_OK`,
+	)
+	if !strings.Contains(secondLogin.Stdout, "CRABBOX_LOCAL_CONTAINER_SECOND_LOGIN_OK") ||
+		!strings.Contains(secondLogin.Stdout, "CRABBOX_LOCAL_CONTAINER_PROFILE_PATH=/home/crabbox/profile-bin:") {
+		t.Fatalf("second login did not retain profile precedence and image PATH: stdout=%q stderr=%q", secondLogin.Stdout, secondLogin.Stderr)
 	}
 	runCrabboxLocalContainerE2EMust(t, ctx, "stop", "--provider", "docker", leaseID)
-	assertNoLocalContainerForSlug(t, ctx, warmSlug)
+	assertNoLocalContainerLeaseState(t, ctx, leaseID, warmSlug)
 
 	staleWarmup := runCrabboxLocalContainerE2EMust(t, ctx,
 		"warmup",
@@ -168,6 +183,25 @@ func assertNoLocalContainerForSlug(t *testing.T, ctx context.Context, slug strin
 	t.Helper()
 	if id := localContainerIDForSlug(t, ctx, slug); id != "" {
 		t.Fatalf("local-container e2e left container for slug=%s: %s", slug, id)
+	}
+}
+
+func assertNoLocalContainerLeaseState(t *testing.T, ctx context.Context, leaseID, slug string) {
+	t.Helper()
+	assertNoLocalContainerForSlug(t, ctx, slug)
+	claim, err := cli.ReadLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claim.LeaseID != "" {
+		t.Fatalf("local-container e2e left lease claim after cleanup: %#v", claim)
+	}
+	keyPath, err := cli.TestboxKeyPath(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(keyPath); !os.IsNotExist(err) {
+		t.Fatalf("local-container e2e left SSH key after cleanup: %v", err)
 	}
 }
 

--- a/docs/providers/local-container.md
+++ b/docs/providers/local-container.md
@@ -174,7 +174,10 @@ metadata updates.
    publishing, and the public-key auth environment the bootstrap script needs.
 3. On Debian/Ubuntu-compatible images, the container installs
    `openssh-server`, `git`, `rsync`, `curl`, and `sudo` when they are missing,
-   then restores the selected image's declared `PATH` for the managed SSH login.
+   then restores the selected image's declared `PATH` before each managed SSH
+   login profile. Profiles added after bootstrap can prepend to or intentionally
+   replace that baseline; the profile selected during bootstrap keeps its final
+   managed restore block.
 4. With `--desktop`, the container installs and starts Xvfb, XFCE, x11vnc,
    xdotool, screenshot tools, ffmpeg, noVNC, and websockify — no systemd
    required.

--- a/internal/providers/localcontainer/backend.go
+++ b/internal/providers/localcontainer/backend.go
@@ -1668,6 +1668,15 @@ func isDefaultWorkRoot(value string) bool {
 
 const localContainerDockerSigningKeyFingerprint = "9DC858229FC7DD38854AE2D88D81803C0EBFCD88"
 
+const localContainerImagePathRestoreBlock = `# crabbox managed image PATH
+if [ -r "$HOME/.config/crabbox/image-path" ]; then
+  PATH="$(/bin/cat "$HOME/.config/crabbox/image-path"; printf '\001')"
+  PATH="${PATH%?}"
+  export PATH
+fi
+# end crabbox managed image PATH
+`
+
 const installVerifiedAPTKeyringScript = `
 install_verified_apt_keyring() {
   apt_key_url="$1"
@@ -1909,6 +1918,14 @@ printf '%s' "$image_path" > "$home_dir/.config/crabbox/image-path"
 chown "$user" "$home_dir/.config" "$home_dir/.config/crabbox" "$home_dir/.config/crabbox/image-path"
 chmod 0700 "$home_dir/.config/crabbox"
 chmod 0600 "$home_dir/.config/crabbox/image-path"
+image_path_hook=/etc/profile.d/crabbox-image-path.sh
+install -d -m 0755 /etc/profile.d
+image_path_hook_tmp="$(mktemp "${image_path_hook}.tmp.XXXXXX")"
+cat > "$image_path_hook_tmp" <<'CRABBOX_IMAGE_PATH_HOOK'
+` + localContainerImagePathRestoreBlock + `CRABBOX_IMAGE_PATH_HOOK
+chown 0:0 "$image_path_hook_tmp"
+chmod 0644 "$image_path_hook_tmp"
+mv -f "$image_path_hook_tmp" "$image_path_hook"
 login_profile=""
 for candidate in "$home_dir/.bash_profile" "$home_dir/.bash_login" "$home_dir/.profile"; do
   if [ -e "$candidate" ]; then
@@ -1927,14 +1944,7 @@ import sys
 
 path = Path(sys.argv[1])
 data = path.read_bytes()
-block = rb'''# crabbox managed image PATH
-if [ -r "$HOME/.config/crabbox/image-path" ]; then
-  PATH="$(cat "$HOME/.config/crabbox/image-path"; printf '\001')"
-  PATH="${PATH%?}"
-  export PATH
-fi
-# end crabbox managed image PATH
-'''
+block = rb'''` + localContainerImagePathRestoreBlock + `'''
 
 def find_line_sequence(content, sequence, offset=0):
     position = content.find(sequence, offset)

--- a/internal/providers/localcontainer/backend_test.go
+++ b/internal/providers/localcontainer/backend_test.go
@@ -1317,11 +1317,16 @@ func TestBootstrapScriptUsesAccountHomeDirectory(t *testing.T) {
 		`image_path="${PATH:-/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin}"`,
 		`printf '%s' "$image_path" > "$home_dir/.config/crabbox/image-path"`,
 		`chmod 0600 "$home_dir/.config/crabbox/image-path"`,
+		`image_path_hook=/etc/profile.d/crabbox-image-path.sh`,
+		`image_path_hook_tmp="$(mktemp "${image_path_hook}.tmp.XXXXXX")"`,
+		`chown 0:0 "$image_path_hook_tmp"`,
+		`chmod 0644 "$image_path_hook_tmp"`,
+		`mv -f "$image_path_hook_tmp" "$image_path_hook"`,
 		`for candidate in "$home_dir/.bash_profile" "$home_dir/.bash_login" "$home_dir/.profile"; do`,
 		`python3 - "$login_profile" <<'PY'`,
 		`def find_line_sequence(content, sequence, offset=0):`,
 		`data = data[:remove_from] + suffix`,
-		`PATH="$(cat "$HOME/.config/crabbox/image-path"; printf '\001')"`,
+		`PATH="$(/bin/cat "$HOME/.config/crabbox/image-path"; printf '\001')"`,
 		`PATH="${PATH%?}"`,
 		`path.write_bytes(data + block)`,
 		`# end crabbox managed image PATH`,
@@ -1401,7 +1406,48 @@ func TestBootstrapScriptUsesAccountHomeDirectory(t *testing.T) {
 	}
 }
 
-func TestBootstrapImagePathReadPreservesLiteralBytes(t *testing.T) {
+func TestBootstrapImagePathHookContract(t *testing.T) {
+	if strings.Count(bootstrapScript, localContainerImagePathRestoreBlock) != 2 {
+		t.Fatalf("restore block should be reused exactly by system hook and selected profile")
+	}
+	if strings.Contains(localContainerImagePathRestoreBlock, "eval") {
+		t.Fatal("image PATH restore block must not evaluate saved content")
+	}
+	for _, want := range []string{
+		"# crabbox managed image PATH\n",
+		`PATH="$(/bin/cat "$HOME/.config/crabbox/image-path"; printf '\001')"`,
+		`PATH="${PATH%?}"`,
+		"# end crabbox managed image PATH\n",
+	} {
+		if !strings.Contains(localContainerImagePathRestoreBlock, want) {
+			t.Fatalf("restore block missing %q", want)
+		}
+	}
+
+	install := strings.Join([]string{
+		`image_path_hook=/etc/profile.d/crabbox-image-path.sh`,
+		`install -d -m 0755 /etc/profile.d`,
+		`image_path_hook_tmp="$(mktemp "${image_path_hook}.tmp.XXXXXX")"`,
+		`cat > "$image_path_hook_tmp" <<'CRABBOX_IMAGE_PATH_HOOK'`,
+		localContainerImagePathRestoreBlock + `CRABBOX_IMAGE_PATH_HOOK`,
+		`chown 0:0 "$image_path_hook_tmp"`,
+		`chmod 0644 "$image_path_hook_tmp"`,
+		`mv -f "$image_path_hook_tmp" "$image_path_hook"`,
+	}, "\n")
+	if !strings.Contains(bootstrapScript, install) {
+		t.Fatal("image PATH hook is not installed atomically with root ownership and mode 0644")
+	}
+
+	savedPath := strings.Index(bootstrapScript, `printf '%s' "$image_path" > "$home_dir/.config/crabbox/image-path"`)
+	hook := strings.Index(bootstrapScript, `image_path_hook=/etc/profile.d/crabbox-image-path.sh`)
+	profile := strings.Index(bootstrapScript, `login_profile=""`)
+	sshd := strings.LastIndex(bootstrapScript, `exec /usr/sbin/sshd`)
+	if savedPath < 0 || hook <= savedPath || profile <= hook || sshd <= profile {
+		t.Fatalf("unexpected image PATH bootstrap order: saved=%d hook=%d profile=%d sshd=%d", savedPath, hook, profile, sshd)
+	}
+}
+
+func TestBootstrapImagePathRestoreIsIdempotentAndPreservesLiteralBytes(t *testing.T) {
 	bash, err := exec.LookPath("bash")
 	if err != nil {
 		t.Skipf("bash unavailable: %v", err)
@@ -1409,13 +1455,16 @@ func TestBootstrapImagePathReadPreservesLiteralBytes(t *testing.T) {
 	home := t.TempDir()
 	marker := filepath.Join(home, "must-not-exist")
 	want := "/opt/tool dir:$HOME:$(touch " + marker + "):`false`:\n"
-	if err := os.WriteFile(filepath.Join(home, "image-path"), []byte(want), 0o600); err != nil {
+	pathDir := filepath.Join(home, ".config", "crabbox")
+	if err := os.MkdirAll(pathDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pathDir, "image-path"), []byte(want), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	cmd := exec.Command(bash, "-c", `set -eu
 HOME="$1"
-PATH="$(cat "$HOME/image-path"; printf '\001')"
-PATH="${PATH%?}"
+`+localContainerImagePathRestoreBlock+localContainerImagePathRestoreBlock+`
 printf '%s' "$PATH"
 `, "bash", home)
 	out, err := cmd.CombinedOutput()


### PR DESCRIPTION
## Summary

- install an atomic, root-owned `/etc/profile.d/crabbox-image-path.sh` hook after the saved image PATH exists and before `sshd` starts
- reuse the existing sentinel-based, non-evaluating restore block in both the system hook and the selected user profile
- preserve the predecessor's exact end-of-selected-profile behavior while allowing a profile created or selected after bootstrap to prepend to the restored image baseline

## Current-main reproduction

Against `847f0e51557f739f4b0544e218efdc018d199acf`, a warm `golang:1.26-bookworm` lease initially resolved `/usr/local/go/bin/go`. After a run created a higher-precedence `.bash_profile` containing `export PATH="$HOME/profile-bin:$PATH"`, the next login skipped the bootstrap-modified `.profile`; `go` disappeared and PATH fell back to the system directories.

The fix belongs at the system login-profile boundary: the root-owned hook restores the saved image PATH before Bash selects `.bash_profile`, `.bash_login`, or `.profile`. A later profile prepend therefore keeps user precedence and image paths. Profiles may still intentionally replace PATH, and PATH is not made readonly.

## Verification

- `go test ./internal/providers/localcontainer -run 'TestBootstrap(ImagePath|ScriptUsesAccountHomeDirectory)' -count=1`
- `go test -tags localcontainer ./cmd/crabbox -run '^TestLocalContainerProviderE2E$' -v -count=1` with `golang:1.26-bookworm`
  - first login: `/usr/local/go/bin/go`
  - second login after creating `.bash_profile`: `/home/crabbox/profile-bin` first and `/usr/local/go/bin/go` still resolved
  - hook: `root:root`, mode `0644`
  - cleanup: container, local lease claim, and SSH key absent
- source-blind built-CLI replay, including an intentional PATH replacement and empty post-stop container/CLI inventory
- `go test -race ./internal/providers/localcontainer -count=1`
- `go test -race ./cmd/crabbox -count=1`
- `go vet ./...`
- `go test -race ./...`
- `scripts/check-docs.sh`
- `git diff --check`
- global P1 autoreview: clean after one documentation-precision fix cycle

No config, secret, or data migration is required.

Predecessor: https://github.com/openclaw/crabbox/pull/1276

Original issue context: https://github.com/openclaw/crabbox/issues/1259
