### PR TITLE
chore(release): prepare v0.41.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.41.3 - Unreleased
+## 0.41.3 - 2026-08-11
 
 ### Fixed
 

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/crabbox-worker",
-  "version": "0.41.2",
+  "version": "0.41.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/crabbox-worker",
-      "version": "0.41.2",
+      "version": "0.41.3",
       "dependencies": {
         "@aws-sdk/credential-providers": "^3.1095.0",
         "@cloudflare/containers": "^0.3.7",

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/crabbox-worker",
-  "version": "0.41.2",
+  "version": "0.41.3",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## What Problem This Solves

Prepares the verified Crabbox 0.41.3 source after the reusable-workspace lifecycle ownership fix and the other accumulated correctness repairs landed on `main`.

## Why This Change Was Made

This dates the canonical 0.41.3 changelog section and updates every version-bearing Worker package field required by the release checklist. It does not create a tag, authorization record, draft, release, or Homebrew change.

## User Impact

The 0.41.3 release notes now describe the complete shipped fix set, led by serialized reusable-workspace ownership and Git coherence, followed by AWS fallback classification, source-build identity, local-container image PATH preservation, and claim-provider routing.

## Evidence

- `go vet ./...`
- `go test -race ./...`
- `scripts/test-go-modules.sh`
- `scripts/check-go-coverage.sh 90.0`
- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- Worker format, lint, typecheck, test, and dry-run build gates passed.
- `node --test scripts/*.test.js`
- `scripts/check-docs.sh`
- `git diff --check`
- Structured autoreview: no accepted/actionable findings.
- Coordinator-backed AWS release smoke passed with run, attach, events, logs, exact lease release, and empty final inventory.

The initial concurrent coverage/module invocation exposed two shared-fixture collisions; both exact tests passed 20 isolated repetitions, and both full gates passed when rerun sequentially.
