### PR TITLE
chore(release): authorize v0.41.3 source

### DIFF
--- a/release/records/v0.41.3.json
+++ b/release/records/v0.41.3.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "repository": "openclaw/crabbox",
+  "tag": "v0.41.3",
+  "tagObject": "167be2516f92a0925de3f0c54110b4e7261633ca",
+  "sourceCommit": "8ff37c2ce1238ad645c4923f111cbda9ce0975a1",
+  "publicationStatus": "ready"
+}


### PR DESCRIPTION
## What Problem This Solves

Authorizes the immutable signed source for Crabbox v0.41.3 so the credential-free producer and protected release verifier can bind every artifact to the exact tag object and source commit.

## Source Identity

- Tag: `v0.41.3`
- Annotated tag object: `167be2516f92a0925de3f0c54110b4e7261633ca`
- Peeled source commit: `8ff37c2ce1238ad645c4923f111cbda9ce0975a1`
- Publication status: `ready`

The signed tag annotation is exactly `v0.41.3`, its signature verifies against the checked-in release signer policy, and the source commit is the protected release-preparation merge on `main`.

## Evidence

`REQUIRE_PUBLISHABLE=1 scripts/verify-release-source.sh` passed with the captured identities. Structured autoreview and TruffleHog passed. This PR does not build, sign, upload, draft, publish, or update Homebrew.
