### PR TITLE
fix(worker): reconcile orphaned Azure companion resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Reconciled exact-owned Azure VM, NIC, public IP, and managed OS disk orphan sets with stable-identity quarantine and fail-closed durable deletion progress. Thanks @chsong1.
 - Invalidated adopted Actions workspace readiness markers before full resync and rehydrated the canonical workspace before running commands. Thanks @vincentkoc.
 - Stopped sparse-checkout and skip-worktree omissions from deleting in-scope remote files, and kept staged gitlink removals out of file-deletion manifests. Thanks @vincentkoc.
 - Deferred ordinary coordinator lease provider cleanup to durable alarm-owned retries while preserving synchronous force-admin deletion and visible retry state. Thanks @fuller-stack-dev.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -158,8 +158,9 @@ One logical `FleetCoordinator` (`worker/src/fleet.ts`) owns:
   owner/org/provider/server type for the month; served at `GET /v1/usage`.
 - **Cleanup and expiry** — runtime alarms/jobs and reconciliation run maintenance:
   `expireLeases` deletes the cloud server for active leases past `expiresAt`
-  (retrying after a 5-minute backoff on failure), then an optional AWS orphan
-  sweep, then `scheduleAlarm` arms the next alarm at the soonest pending expiry.
+  (retrying after a 5-minute backoff on failure), then optional AWS and Azure
+  orphan sweeps, then `scheduleAlarm` arms the next alarm at the soonest pending
+  expiry.
 - **Runs, run events, run logs, and telemetry** — see
   [What Flows on a Run](#what-flows-on-a-run).
 - **Live bridges** — WebSocket relays for WebVNC (agent ↔ viewer), the
@@ -237,7 +238,10 @@ GET  /v1/admin/leases
 GET  /v1/admin/lease-audit
 POST /v1/admin/leases/{id-or-slug}/release | delete
 GET  /v1/admin/hosts
+GET  /v1/admin/aws-orphan-sweep
 POST /v1/admin/aws-orphan-sweep
+GET  /v1/admin/azure-orphan-sweep
+POST /v1/admin/azure-orphan-sweep
 ```
 
 `GET /v1/pool` and `/v1/admin/*` require the admin token. User tokens scope

--- a/docs/features/azure.md
+++ b/docs/features/azure.md
@@ -276,6 +276,10 @@ Direct cleanup is best-effort through Crabbox lease tags. `crabbox cleanup
 unexpired leases, and cascade-deletes expired ones. The shared resource group,
 vnet, subnet, and NSG are preserved.
 
+Brokered Azure orphan cleanup uses the coordinator's canonical-resource checks;
+see [Lifecycle and cleanup](lifecycle-cleanup.md) for the fail-closed inventory,
+quarantine, and deletion rules.
+
 ## Related docs
 
 - [Provider Reference](../providers/README.md)

--- a/docs/features/coordinator.md
+++ b/docs/features/coordinator.md
@@ -248,6 +248,8 @@ GET    /v1/admin/hosts/...
 GET    /v1/admin/mac-hosts/...
 GET    /v1/admin/aws-orphan-sweep
 POST   /v1/admin/aws-orphan-sweep
+GET    /v1/admin/azure-orphan-sweep
+POST   /v1/admin/azure-orphan-sweep
 POST   /v1/admin/leases/{id-or-slug}/release
 POST   /v1/admin/leases/{id-or-slug}/delete
 POST   /v1/images
@@ -336,11 +338,12 @@ request 404s or 401s.
 
 **Expiry and cleanup.** A DO alarm and the cron both run maintenance:
 `expireLeases` deletes cloud servers for active leases past `expiresAt`
-(state `expired`), retrying after ~5 minutes on failure, and an AWS orphan sweep
-(report or delete, gated by `CRABBOX_AWS_ORPHAN_SWEEP_*`) reports untracked
-instances and deletes or releases only resources with exact retained coordinator
-bindings. The next alarm is scheduled for
-the soonest upcoming expiry or sweep time.
+(state `expired`), retrying after ~5 minutes on failure, and the AWS and Azure
+orphan sweeps report untracked provider resources and delete or release only
+resources with exact retained coordinator bindings. Each sweep is gated by its
+provider-specific settings. See [Lifecycle and cleanup](lifecycle-cleanup.md)
+for the detailed cleanup rules. The next alarm is scheduled for the soonest
+upcoming expiry or sweep time.
 
 Lease responses carry the canonical `cbx_...` ID, the friendly slug when present,
 provider metadata, owner/org, `createdAt`, `lastTouchedAt`, `idleTimeoutSeconds`,

--- a/docs/features/lifecycle-cleanup.md
+++ b/docs/features/lifecycle-cleanup.md
@@ -3,7 +3,8 @@
 Read this when:
 
 - changing how leases are released or expired;
-- debugging leaked provider resources (instances, disks, Mac hosts);
+- debugging leaked provider resources (instances, NICs, public IPs, disks, Mac
+  hosts);
 - changing direct-provider cleanup behavior.
 
 A lease holds a remote box until it is released or expires. Two independent
@@ -76,6 +77,56 @@ longer map to an active lease. Delete mode terminates instances or releases idle
 Mac dedicated hosts only when retained coordinator state binds the exact
 resource; tag-only and legacy candidates stay report-only. It runs from the same
 alarm/cron, gated by `CRABBOX_AWS_ORPHAN_SWEEP_*` environment variables.
+
+### Azure orphan sweep
+
+The coordinator's Azure sweep uses a reconciliation-specific inventory of the
+configured resource group across canonical per-lease VMs, NICs, public IPs, and
+managed OS disks. The ordinary VM list/pool path remains VM-only. The sweep can
+group a complete exact-owned NIC, public IP, and managed-disk set even when an
+interrupted provisioning attempt left no VM.
+
+An exact group must retain consistent Crabbox ownership tags, location,
+canonical topology, and stable Azure resource identities. Mixed or incomplete
+groups remain report-only. VMs with any data disk are also report-only because
+VM deletion can cascade through data-disk delete options. VM managed-disk,
+VM-to-NIC, and NIC-to-public-IP cascade-delete options are likewise rejected and
+fingerprinted. A change to the member set, ownership labels, location, topology,
+or stable identity changes the reconciliation fingerprint and resets the grace
+quarantine. Ordinary release still supports a verified VM/NIC/public-IP set
+whose OS disk is explicitly ephemeral (`diffDiskSettings.option=Local`); the
+managed-disk orphan sweep keeps that non-managed shape report-only.
+
+Delete mode releases only a group bound to an exact retained coordinator lease
+after the same complete resource identity has survived the grace period and two
+successful authoritative inventories. The normal owned-resource delete path
+performs a fresh preflight before each deletion. Shared VNets, subnets, NSGs,
+and resource groups are not part of the inventory or deletion path. With all
+four Azure broker credentials configured, the sweep is enabled unless
+`CRABBOX_AZURE_ORPHAN_SWEEP_ENABLED=0`; set
+`CRABBOX_AZURE_ORPHAN_SWEEP_DELETE=1` to allow deletion. Its interval and grace
+default to 3600 and 900 seconds and are controlled by
+`CRABBOX_AZURE_ORPHAN_SWEEP_INTERVAL_SECONDS` and
+`CRABBOX_AZURE_ORPHAN_SWEEP_GRACE_SECONDS`.
+
+Durable owned-delete claims persist each successful member deletion with that
+member's stable resource identity before cleanup advances. A missing member is
+accepted on retry only when the same claim contains that exact ordered progress;
+an external disappearance or failed progress write stops the remaining cleanup.
+Progress updates transactionally merge the longest verified prefix so concurrent
+cleanup attempts cannot overwrite newer evidence. Fresh preflight also compares
+the quarantined ownership labels, including `keep` and expiry, on every survivor.
+New cleanup starts with a transactional version-2 preparing reservation, then
+binds the complete inspected identity before the first deletion. Every later
+claim transition and completed-claim clear is transactional, so a delayed
+preparation, replacement, or empty-set observer cannot overwrite or erase newer
+progress. Older workers reject version-2 claims rather than replaying them with
+version-1 semantics. Legacy version-1 claims still
+replay through the same scope and topology checks, but a
+legacy partial claim with an unexplained missing member fails closed because it
+cannot prove which cleanup deleted that member. A legacy claim can establish a
+new stable baseline only while the VM, NIC, public IP, and managed disk are all
+still present; an already-empty legacy claim can be cleared without mutation.
 
 ## Direct-provider lifecycle
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -469,6 +469,10 @@ CRABBOX_AWS_ORPHAN_SWEEP_DELETE   optional; set 1 to terminate coordinator-owned
 CRABBOX_AWS_ORPHAN_SWEEP_INTERVAL_SECONDS optional; default 3600
 CRABBOX_AWS_ORPHAN_SWEEP_GRACE_SECONDS    optional; default 900
 CRABBOX_AWS_MAC_HOST_SWEEP_RELEASE optional; set 1 to release stale pending EC2 Mac hosts during orphan sweep
+CRABBOX_AZURE_ORPHAN_SWEEP_ENABLED optional; defaults on when Azure broker credentials exist
+CRABBOX_AZURE_ORPHAN_SWEEP_DELETE   optional; set 1 to release coordinator-owned Azure orphan resources
+CRABBOX_AZURE_ORPHAN_SWEEP_INTERVAL_SECONDS optional; default 3600
+CRABBOX_AZURE_ORPHAN_SWEEP_GRACE_SECONDS    optional; default 900
 ```
 
 Normal SSH-based AWS workspace bridges use a dedicated `crabbox-workspaces`
@@ -632,9 +636,18 @@ bin/crabbox inspect --id blue-lobster --json
 bin/crabbox stop blue-lobster
 ```
 
-Azure release persists an immutable managed-disk cleanup claim before deleting
-the VM. Retries use that durable claim and recheck any live disk attachment;
-they never treat names or Crabbox-written ownership tags as sufficient proof.
+Azure brokered release persists a durable claim for the observed canonical
+resource set, including stable resource identities. Retries recheck live
+attachments and identity before each deletion; names or Crabbox-written
+ownership tags are never sufficient proof. Successful per-member deletion
+progress is transactionally merged before cleanup advances, and an absent member
+without that exact progress makes the remaining set report-only. Fresh reads
+also reject changed ownership labels and any VM data-disk attachment. See
+[Lifecycle and cleanup](features/lifecycle-cleanup.md) for the VM-less orphan-set
+and quarantine rules. Legacy claims may upgrade only from a fully present
+canonical set (including the explicit ephemeral-OS-disk shape); partial legacy
+claims require manual resolution. New claims use a version-2 transactional
+preparation state, which older workers reject safely.
 
 Trusted operators can use `crabbox admin release` or `crabbox admin delete --force` for stuck leases.
 
@@ -677,6 +690,22 @@ curl -X POST -H "Authorization: Bearer $CRABBOX_COORDINATOR_ADMIN_TOKEN" \
 ```
 
 See [Lifecycle and Cleanup](features/lifecycle-cleanup.md) for the full lease-expiry model.
+
+### Azure orphan sweep
+
+Trusted admins can inspect or trigger the coordinator's Azure orphan sweep:
+
+```sh
+curl -H "Authorization: Bearer $CRABBOX_COORDINATOR_ADMIN_TOKEN" \
+  https://broker.example.com/v1/admin/azure-orphan-sweep
+
+curl -X POST -H "Authorization: Bearer $CRABBOX_COORDINATOR_ADMIN_TOKEN" \
+  https://broker.example.com/v1/admin/azure-orphan-sweep
+```
+
+The sweep uses the configured Azure resource group and the Azure orphan-sweep
+settings listed above. See [Lifecycle and Cleanup](features/lifecycle-cleanup.md)
+for its inventory, quarantine, and deletion rules.
 
 ## AWS Security Guardrails
 

--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -134,10 +134,10 @@ coordinator keeps the lease `active`, records `cleanupAttempts`,
 5 minutes) rather than marking the lease `expired` while the machine may still
 exist. On success the lease moves to `expired`.
 
-Maintenance runs at the earliest active-lease expiry or AWS orphan-sweep time.
-The orphan sweep (report or delete mode, gated by
-`CRABBOX_AWS_ORPHAN_SWEEP_*`) reports untracked instances and releases or
-terminates only exact resources retained in coordinator lease state.
+Maintenance runs at the earliest active-lease expiry or provider orphan-sweep
+time. The AWS and Azure orphan sweeps (report or delete mode, gated by
+provider-specific settings) report untracked provider resources and release or
+terminate only exact resources retained in coordinator lease state.
 
 Direct cleanup only deletes machines that are clearly safe:
 

--- a/docs/providers/azure.md
+++ b/docs/providers/azure.md
@@ -230,8 +230,10 @@ until the required service-principal secrets are present.
     enable WSL/VirtualMachinePlatform/HypervisorPlatform, reboot as needed, import
     Ubuntu, and wait for the Linux-side `crabbox-ready` check.
 11. Let core sync and run over SSH.
-12. On release/cleanup, cascade-delete VM -> NIC -> public IP -> OS disk. The
-    shared infra remains.
+12. On direct release/cleanup, cascade-delete VM -> NIC -> public IP -> OS disk;
+    the shared infra remains. Brokered release and orphan cleanup use the
+    coordinator's canonical-resource, quarantine, and fresh-preflight rules; see
+    [Lifecycle and cleanup](../features/lifecycle-cleanup.md).
 
 ## Classes
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -671,8 +671,8 @@ Layered protections:
 - Explicit release (`crabbox stop` / `release`).
 - A Durable Object alarm or pg-boss job that expires leases and reschedules the
   next pending deadline, plus periodic reconciliation.
-- A coordinator-side AWS orphan sweep over current broker credentials and
-  capacity regions.
+- Coordinator-side AWS and Azure orphan sweeps over current broker credentials
+  and configured provider scopes.
 - A provider-label sweep for clearly expired, inactive orphan machines.
 
 In direct-CLI mode, cleanup runs from the CLI using provider labels: it skips
@@ -686,11 +686,9 @@ Provider tags discover candidates and explain why they look stale, but do not
 authorize a destructive action. Automatic AWS or Azure deletion requires an
 exact retained coordinator lease binding for the same provider resource and
 region; EC2 Mac host release likewise requires an exact retained host binding.
-Before coordinator Azure cleanup deletes a VM, it also persists the managed
-disk's immutable ID while the live `managedBy` association still matches that
-VM. Later disk deletion revalidates that identity and any current attachment;
-an interrupted cleanup may continue after the VM is gone without trusting
-self-written tags, while missing or mismatched claims fail closed.
+Azure's canonical-set, topology, stable-identity, quarantine, and fresh-preflight
+rules are maintained in [Lifecycle and cleanup](features/lifecycle-cleanup.md);
+shared VNets, subnets, NSGs, and resource groups are never sweep candidates.
 Tag-only and legacy candidates remain report-only. Sweeps skip `keep=true`
 resources and apply a grace window before reporting missing labels or stale
 lease mappings.

--- a/docs/source-map.md
+++ b/docs/source-map.md
@@ -168,7 +168,9 @@ Coordinator-side provider operations (brokered providers only):
 
 - Hetzner: `worker/src/hetzner.ts`
 - AWS EC2 (provision, capacity fallback, private SSM workspaces, Mac hosts, orphan sweep): `worker/src/aws.ts`
-- Azure / GCP provision and image routes: `worker/src/azure.ts`, `worker/src/gcp.ts`
+- Azure VM provision, canonical resource inventory, and owned-resource cleanup:
+  `worker/src/azure.ts`; coordinator lease and sweep orchestration:
+  `worker/src/fleet.ts`; GCP provision and image routes: `worker/src/gcp.ts`
 - Daytona sandbox lifecycle and rotating SSH access: `worker/src/daytona.ts`
 - Image create/read/delete/promote routing: `worker/src/fleet.ts`, `worker/src/os-image.ts`
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -191,8 +191,8 @@ crabbox admin leases --state active
 - Use `crabbox stop <id-or-slug>` for active leases; reserve provider/admin
   cleanup (`crabbox cleanup`, `crabbox admin delete`) for confirmed orphans.
 
-The broker also sweeps untracked AWS instances and idle Mac dedicated hosts on a
-schedule. See [lifecycle & cleanup](features/lifecycle-cleanup.md).
+The broker also sweeps untracked AWS instances, Azure per-lease resource sets,
+and idle Mac dedicated hosts on a schedule. See [lifecycle & cleanup](features/lifecycle-cleanup.md).
 
 ## SSH never becomes ready
 

--- a/worker/src/azure.ts
+++ b/worker/src/azure.ts
@@ -106,16 +106,30 @@ interface AzureVM {
   location?: string;
   tags?: Record<string, string>;
   properties?: {
+    vmId?: string;
     provisioningState?: string;
     hardwareProfile?: { vmSize?: string };
     storageProfile?: {
       osDisk?: {
         managedDisk?: { id?: string };
         osType?: string;
+        deleteOption?: string;
         diffDiskSettings?: { option?: string; placement?: string; enableFullCaching?: boolean };
       };
+      dataDisks?: {
+        name?: string;
+        lun?: number;
+        deleteOption?: string;
+        managedDisk?: { id?: string };
+      }[];
     };
-    networkProfile?: { networkInterfaces?: { id?: string }[] };
+    networkProfile?: {
+      networkInterfaces?: {
+        id?: string;
+        deleteOption?: string;
+        properties?: { deleteOption?: string };
+      }[];
+    };
   };
 }
 
@@ -138,7 +152,33 @@ interface AzurePublicIP {
   name?: string;
   location?: string;
   tags?: Record<string, string>;
-  properties?: { ipAddress?: string };
+  properties?: {
+    ipAddress?: string;
+    resourceGuid?: string;
+    ipConfiguration?: { id?: string } | null;
+    natGateway?: { id?: string } | null;
+    linkedPublicIPAddress?: { id?: string } | null;
+    servicePublicIPAddress?: { id?: string } | null;
+  };
+}
+
+interface AzureResourceReference {
+  id?: string;
+  deleteOption?: string;
+}
+
+interface AzureNICIPConfiguration {
+  id?: string;
+  properties?: {
+    publicIPAddress?: AzureResourceReference;
+    loadBalancerBackendAddressPools?: AzureResourceReference[];
+    applicationGatewayBackendAddressPools?: AzureResourceReference[];
+    applicationSecurityGroups?: AzureResourceReference[];
+    loadBalancerInboundNatRules?: AzureResourceReference[];
+    privateLinkConnectionProperties?: Record<string, unknown> | null;
+    virtualNetworkTaps?: AzureResourceReference[];
+    gatewayLoadBalancer?: AzureResourceReference | null;
+  };
 }
 
 interface AzureNIC {
@@ -147,7 +187,13 @@ interface AzureNIC {
   location?: string;
   tags?: Record<string, string>;
   properties?: {
-    ipConfigurations?: { properties?: { publicIPAddress?: { id?: string } } }[];
+    resourceGuid?: string;
+    virtualMachine?: AzureResourceReference;
+    privateEndpoint?: AzureResourceReference | null;
+    privateLinkService?: AzureResourceReference | null;
+    hostedWorkloads?: string[];
+    tapConfigurations?: AzureResourceReference[];
+    ipConfigurations?: AzureNICIPConfiguration[];
   };
 }
 
@@ -156,9 +202,40 @@ interface AzureDisk {
   name?: string;
   location?: string;
   managedBy?: string;
+  managedByExtended?: string[];
   tags?: Record<string, string>;
   properties?: { uniqueId?: string };
 }
+
+interface AzureLeaseResourceInventory {
+  vms: AzureVM[];
+  nics: AzureNIC[];
+  pips: AzurePublicIP[];
+  disks: AzureDisk[];
+}
+
+interface AzureReconciliationResourceSet {
+  cloudID: string;
+  canonicalVMID: string;
+  canonicalNICID: string;
+  canonicalPIPID: string;
+  vm?: AzureVM;
+  nic?: AzureNIC;
+  pip?: AzurePublicIP;
+  disk?: AzureDisk;
+}
+
+interface AzureReconciliationCanonicalIDs {
+  vmID: string;
+  nicID: string;
+  pipID: string;
+}
+
+type AzureLeaseResource =
+  | { kind: "virtualMachines"; resource: AzureVM }
+  | { kind: "networkInterfaces"; resource: AzureNIC }
+  | { kind: "publicIPAddresses"; resource: AzurePublicIP }
+  | { kind: "disks"; resource: AzureDisk };
 
 interface AzureOwnedDeleteResources {
   vm: boolean;
@@ -169,20 +246,33 @@ interface AzureOwnedDeleteResources {
 
 interface AzureOwnedDeleteInspection extends AzureOwnedDeleteResources {
   diskResource?: AzureDisk;
+  stableResourceIdentity: string;
+  ephemeralOSDisk: boolean;
 }
 
 interface AzureOwnedDeleteClaim {
-  version: 1;
+  version: 1 | 2;
   provider: "azure";
   leaseID: string;
   slug: string;
   owner: string;
   cloudID: string;
   providerScope: string;
+  preparing?: true;
+  canonicalVMID?: string;
+  canonicalNICID?: string;
+  resourceIdentity?: string;
+  stableResourceIdentity?: string;
+  partialStableResourceIdentity?: string;
+  deletedStableResourceIdentity?: string;
   disk?: {
     resourceID: string;
     uniqueID: string;
   };
+}
+
+export interface AzureOwnedDeleteReleaseContext {
+  resourceIdentity: string;
 }
 
 interface AzureResourceList<T> {
@@ -191,6 +281,15 @@ interface AzureResourceList<T> {
 }
 
 export interface AzureOwnedDeleteClaimStorage {
+  get<T>(key: string): Promise<T | undefined>;
+  put<T>(key: string, value: T): Promise<void>;
+  delete(key: string): Promise<unknown>;
+  transaction?<T>(
+    callback: (transaction: AzureOwnedDeleteClaimTransaction) => Promise<T>,
+  ): Promise<T>;
+}
+
+interface AzureOwnedDeleteClaimTransaction {
   get<T>(key: string): Promise<T | undefined>;
   put<T>(key: string, value: T): Promise<void>;
   delete(key: string): Promise<unknown>;
@@ -316,6 +415,40 @@ export class AzureClient {
     return tagged.map((vm, index) => toMachine(vm, ips[index] ?? ""));
   }
 
+  async listReconciliationResources(): Promise<ProviderMachine[]> {
+    return azureReconciliationMachines(await this.listLeaseResourceInventory(), (cloudID) => ({
+      vmID: this.resourceID(vmPath(this.resourceGroup, cloudID)),
+      nicID: this.resourceID(
+        networkPath(this.resourceGroup, "networkInterfaces", `${cloudID}-nic`),
+      ),
+      pipID: this.resourceID(
+        networkPath(this.resourceGroup, "publicIPAddresses", `${cloudID}-pip`),
+      ),
+    }));
+  }
+
+  private async listLeaseResourceInventory(): Promise<AzureLeaseResourceInventory> {
+    const [vms, nics, pips, disks] = await Promise.all([
+      this.listResources<AzureVM>(
+        `/resourceGroups/${this.resourceGroup}/providers/Microsoft.Compute/virtualMachines`,
+        API_VERSIONS.compute,
+      ),
+      this.listResources<AzureNIC>(
+        `/resourceGroups/${this.resourceGroup}/providers/Microsoft.Network/networkInterfaces`,
+        API_VERSIONS.network,
+      ),
+      this.listResources<AzurePublicIP>(
+        `/resourceGroups/${this.resourceGroup}/providers/Microsoft.Network/publicIPAddresses`,
+        API_VERSIONS.network,
+      ),
+      this.listResources<AzureDisk>(
+        `/resourceGroups/${this.resourceGroup}/providers/Microsoft.Compute/disks`,
+        API_VERSIONS.disks,
+      ),
+    ]);
+    return { vms, nics, pips, disks };
+  }
+
   async getServer(name: string): Promise<ProviderMachine> {
     return toMachine(
       await this.arm<AzureVM>("GET", vmPath(this.resourceGroup, name), API_VERSIONS.compute),
@@ -345,30 +478,8 @@ export class AzureClient {
       | "region"
     >,
   ): Promise<ProviderMachine | undefined> {
-    const [vms, nics, pips, disks] = await Promise.all([
-      this.listResources<AzureVM>(
-        `/resourceGroups/${this.resourceGroup}/providers/Microsoft.Compute/virtualMachines`,
-        API_VERSIONS.compute,
-      ),
-      this.listResources<AzureNIC>(
-        `/resourceGroups/${this.resourceGroup}/providers/Microsoft.Network/networkInterfaces`,
-        API_VERSIONS.network,
-      ),
-      this.listResources<AzurePublicIP>(
-        `/resourceGroups/${this.resourceGroup}/providers/Microsoft.Network/publicIPAddresses`,
-        API_VERSIONS.network,
-      ),
-      this.listResources<AzureDisk>(
-        `/resourceGroups/${this.resourceGroup}/providers/Microsoft.Compute/disks`,
-        API_VERSIONS.disks,
-      ),
-    ]);
-    const resources = [
-      ...vms.map((resource) => ({ kind: "virtualMachines" as const, resource })),
-      ...nics.map((resource) => ({ kind: "networkInterfaces" as const, resource })),
-      ...pips.map((resource) => ({ kind: "publicIPAddresses" as const, resource })),
-      ...disks.map((resource) => ({ kind: "disks" as const, resource })),
-    ];
+    const { vms, nics, pips, disks } = await this.listLeaseResourceInventory();
+    const resources = azureLeaseResources({ vms, nics, pips, disks });
     const ownedCloudIDs = new Set<string>();
     for (const candidate of resources) {
       const labels = azureLabelsFromTags(candidate.resource.tags ?? {});
@@ -452,7 +563,7 @@ export class AzureClient {
     ) {
       throw new Error(`refusing to recover Azure lease ${lease.id}: NIC ownership is incomplete`);
     }
-    if (disk?.managedBy && !azureResourceIDEqual(disk.managedBy, expectedVMID)) {
+    if (disk && !azureDiskAttachmentsMatchVM(disk, expectedVMID, Boolean(vm))) {
       throw new Error(`refusing to recover Azure lease ${lease.id}: disk ownership is incomplete`);
     }
 
@@ -684,20 +795,126 @@ export class AzureClient {
 
   async deleteOwnedServer(
     lease: Pick<LeaseRecord, "id" | "slug" | "provider" | "cloudID" | "owner" | "providerScope">,
+    context?: AzureOwnedDeleteReleaseContext,
   ): Promise<void> {
+    if (this.ownedDeleteClaimStorage && !this.ownedDeleteClaimStorage.transaction) {
+      throw new Error(
+        `refusing to delete Azure lease ${lease.id}: transactional cleanup claim storage is required`,
+      );
+    }
     if (lease.providerScope !== this.providerScope()) {
       throw new Error(
         `refusing to delete Azure lease ${lease.id}: stored provider scope does not match the cleanup client`,
       );
     }
     const claimKey = azureOwnedDeleteClaimKey(this.providerScope(), lease.cloudID, lease.id);
+    const observedStableResourceIdentity = context
+      ? azureStableResourceIdentityFromObserved(context.resourceIdentity)
+      : undefined;
     let claim = await this.ownedDeleteClaimStorage?.get<AzureOwnedDeleteClaim>(claimKey);
     if (!claim) {
-      const inspection = await this.ownedDeleteResources(lease, { prepareClaim: true });
-      claim = this.ownedDeleteClaim(lease, inspection.diskResource);
-      await this.ownedDeleteClaimStorage?.put(claimKey, claim);
+      claim = await this.persistOwnedDeleteClaimCreation(
+        claimKey,
+        lease,
+        this.ownedDeleteClaimPreparation(lease),
+      );
+    }
+    if (claim.preparing) {
+      const inspection = await this.ownedDeleteResources(lease, {
+        prepareClaim: true,
+        ...(context?.resourceIdentity
+          ? { expectedResourceIdentity: context.resourceIdentity }
+          : {}),
+        ...(observedStableResourceIdentity
+          ? { expectedStableResourceIdentity: observedStableResourceIdentity }
+          : {}),
+      });
+      const preparedClaim = this.ownedDeleteClaim(
+        lease,
+        inspection.diskResource,
+        context?.resourceIdentity,
+        observedStableResourceIdentity ?? inspection.stableResourceIdentity,
+      );
+      claim = await this.persistOwnedDeleteClaimTransition(claimKey, lease, claim, preparedClaim);
     }
     this.requireOwnedDeleteClaim(lease, claim);
+    const canonicalVMID = this.resourceID(vmPath(this.resourceGroup, lease.cloudID));
+    const canonicalNICID = this.resourceID(
+      networkPath(this.resourceGroup, "networkInterfaces", `${lease.cloudID}-nic`),
+    );
+    if (!claim.stableResourceIdentity && (!claim.canonicalVMID || !claim.canonicalNICID)) {
+      const previousClaim = claim;
+      const canonicalClaim = {
+        ...claim,
+        canonicalVMID: claim.canonicalVMID ?? canonicalVMID,
+        canonicalNICID: claim.canonicalNICID ?? canonicalNICID,
+      };
+      claim = await this.persistOwnedDeleteClaimTransition(
+        claimKey,
+        lease,
+        previousClaim,
+        canonicalClaim,
+      );
+    }
+    if (
+      observedStableResourceIdentity &&
+      claim.stableResourceIdentity &&
+      !azureStableResourceIdentityExactlyMatches(
+        claim.stableResourceIdentity,
+        observedStableResourceIdentity,
+      )
+    ) {
+      const previousPartialStableResourceIdentity =
+        claim.partialStableResourceIdentity ?? claim.stableResourceIdentity;
+      const currentInspection = await this.ownedDeleteResources(lease, {
+        claim,
+        prepareClaim: true,
+        ...(claim.resourceIdentity ? { expectedResourceIdentity: claim.resourceIdentity } : {}),
+      });
+      const verifiedPartial = Boolean(
+        previousPartialStableResourceIdentity &&
+        azureStableResourceIdentityMatches(
+          previousPartialStableResourceIdentity,
+          currentInspection.stableResourceIdentity,
+          claim.deletedStableResourceIdentity,
+        ),
+      );
+      const inspection = await this.ownedDeleteResources(lease, {
+        claim,
+        prepareClaim: true,
+        ...(context?.resourceIdentity
+          ? { expectedResourceIdentity: context.resourceIdentity }
+          : {}),
+        expectedStableResourceIdentity: observedStableResourceIdentity,
+      });
+      const replacementClaim = this.ownedDeleteClaim(
+        lease,
+        inspection.diskResource,
+        context?.resourceIdentity,
+        observedStableResourceIdentity,
+      );
+      const previousClaim = claim;
+      const nextClaim = {
+        ...replacementClaim,
+        ...(claim.canonicalVMID ? { canonicalVMID: claim.canonicalVMID } : {}),
+        ...(claim.canonicalNICID ? { canonicalNICID: claim.canonicalNICID } : {}),
+        ...(verifiedPartial
+          ? { partialStableResourceIdentity: previousPartialStableResourceIdentity }
+          : {}),
+        ...(claim.deletedStableResourceIdentity
+          ? { deletedStableResourceIdentity: claim.deletedStableResourceIdentity }
+          : {}),
+      };
+      claim = await this.persistOwnedDeleteClaimTransition(
+        claimKey,
+        lease,
+        previousClaim,
+        nextClaim,
+      );
+    }
+    let expectedStableResourceIdentity =
+      claim.stableResourceIdentity ?? observedStableResourceIdentity;
+    const expectedResourceIdentity = context?.resourceIdentity || claim.resourceIdentity;
 
     const order: (keyof AzureOwnedDeleteResources)[] = ["vm", "nic", "pip", "disk"];
     for (const kind of order) {
@@ -705,11 +922,43 @@ export class AzureClient {
         // Re-read every surviving resource before each destructive operation so
         // a same-name replacement cannot inherit authorization from an older read.
         // oxlint-disable-next-line eslint/no-await-in-loop -- every delete requires fresh ownership proof.
-        const resources = await this.ownedDeleteResources(lease, { claim });
+        const resources = await this.ownedDeleteResources(lease, {
+          claim,
+          ...(expectedResourceIdentity ? { expectedResourceIdentity } : {}),
+          ...(expectedStableResourceIdentity ? { expectedStableResourceIdentity } : {}),
+        });
         if (!resources.vm && !resources.nic && !resources.pip && !resources.disk) {
-          // oxlint-disable-next-line eslint/no-await-in-loop -- clear only after the fresh inventory proves cleanup complete.
-          await this.ownedDeleteClaimStorage?.delete(claimKey);
+          // oxlint-disable-next-line eslint/no-await-in-loop -- clear only after the fresh inventory and claim sequence both prove cleanup complete.
+          await this.clearOwnedDeleteClaim(claimKey, lease, claim);
           return;
+        }
+        if (!claim.stableResourceIdentity) {
+          if (
+            !resources.vm ||
+            !resources.nic ||
+            !resources.pip ||
+            (!resources.disk && !resources.ephemeralOSDisk)
+          ) {
+            throw new Error(
+              `refusing to delete Azure resources for ${lease.cloudID}: legacy cleanup claim cannot prove the complete original resource set`,
+            );
+          }
+          const previousClaim = claim;
+          const upgradedClaim = {
+            ...claim,
+            version: 2 as const,
+            ...(context?.resourceIdentity ? { resourceIdentity: context.resourceIdentity } : {}),
+            stableResourceIdentity:
+              expectedStableResourceIdentity ?? resources.stableResourceIdentity,
+          };
+          // oxlint-disable-next-line eslint/no-await-in-loop -- the versioned legacy transition fences deletion before the loop can advance.
+          claim = await this.persistOwnedDeleteClaimTransition(
+            claimKey,
+            lease,
+            previousClaim,
+            upgradedClaim,
+          );
+          expectedStableResourceIdentity = claim.stableResourceIdentity;
         }
         if (!resources[kind]) break;
         const selected: AzureOwnedDeleteResources = {
@@ -721,7 +970,21 @@ export class AzureClient {
         selected[kind] = true;
         // oxlint-disable-next-line eslint/no-await-in-loop -- each delete uses the fresh ownership proof above.
         const result = await this.deleteServerOnce(lease.cloudID, selected, true);
-        if (result.errors.length === 0) break;
+        if (result.errors.length === 0) {
+          const nextClaim = {
+            ...claim,
+            deletedStableResourceIdentity: azureStableResourceIdentityWithDeletedMember(
+              claim.deletedStableResourceIdentity,
+              resources.stableResourceIdentity,
+              kind,
+            ),
+          };
+          // Persist successful deletion progress before another member can be
+          // considered absent on a retry. A failed write therefore stops cleanup.
+          // oxlint-disable-next-line eslint/no-await-in-loop -- ordered cleanup is fenced by the durable progress write.
+          claim = await this.persistOwnedDeleteProgress(claimKey, lease, nextClaim);
+          break;
+        }
         if (!result.retry || attempt >= DELETE_RETRY_ATTEMPTS - 1) {
           throw new Error(result.errors.join("; "));
         }
@@ -732,12 +995,151 @@ export class AzureClient {
         await sleep(DELETE_RETRY_DELAY_MS);
       }
     }
-    await this.ownedDeleteClaimStorage?.delete(claimKey);
+    await this.clearOwnedDeleteClaim(claimKey, lease, claim);
+  }
+
+  private async clearOwnedDeleteClaim(
+    claimKey: string,
+    lease: Pick<LeaseRecord, "id" | "slug" | "provider" | "cloudID" | "owner">,
+    claim: AzureOwnedDeleteClaim,
+  ): Promise<void> {
+    this.requireOwnedDeleteClaim(lease, claim);
+    const storage = this.ownedDeleteClaimStorage;
+    if (!storage) return;
+    if (!storage.transaction) {
+      throw new Error(
+        `refusing to clear Azure lease ${lease.id}: transactional cleanup claim storage is required`,
+      );
+    }
+    await storage.transaction(async (transaction) => {
+      const latest = await transaction.get<AzureOwnedDeleteClaim>(claimKey);
+      if (!latest) return;
+      this.requireOwnedDeleteClaim(lease, latest);
+      if (!azureOwnedDeleteClaimsShareSequence(latest, claim)) {
+        throw new Error(`refusing to clear Azure lease ${lease.id}: durable cleanup claim changed`);
+      }
+      await transaction.delete(claimKey);
+    });
+  }
+
+  private async persistOwnedDeleteClaimCreation(
+    claimKey: string,
+    lease: Pick<LeaseRecord, "id" | "slug" | "provider" | "cloudID" | "owner">,
+    claim: AzureOwnedDeleteClaim,
+  ): Promise<AzureOwnedDeleteClaim> {
+    this.requireOwnedDeleteClaim(lease, claim);
+    const storage = this.ownedDeleteClaimStorage;
+    if (!storage) return claim;
+    if (!storage.transaction) {
+      throw new Error(
+        `refusing to create Azure lease ${lease.id}: transactional cleanup claim storage is required`,
+      );
+    }
+    return await storage.transaction(async (transaction) => {
+      const latest = await transaction.get<AzureOwnedDeleteClaim>(claimKey);
+      if (latest) {
+        this.requireOwnedDeleteClaim(lease, latest);
+        return latest;
+      }
+      await transaction.put(claimKey, claim);
+      return claim;
+    });
+  }
+
+  private async persistOwnedDeleteClaimTransition(
+    claimKey: string,
+    lease: Pick<LeaseRecord, "id" | "slug" | "provider" | "cloudID" | "owner">,
+    previous: AzureOwnedDeleteClaim,
+    next: AzureOwnedDeleteClaim,
+  ): Promise<AzureOwnedDeleteClaim> {
+    this.requireOwnedDeleteClaim(lease, previous);
+    this.requireOwnedDeleteClaim(lease, next);
+    const storage = this.ownedDeleteClaimStorage;
+    if (!storage) return next;
+    if (!storage.transaction) {
+      throw new Error(
+        `refusing to update Azure lease ${lease.id}: transactional cleanup claim storage is required`,
+      );
+    }
+    return await storage.transaction(async (transaction) => {
+      const latest = await transaction.get<AzureOwnedDeleteClaim>(claimKey);
+      if (!latest) {
+        throw new Error(
+          `refusing to update Azure lease ${lease.id}: durable cleanup claim disappeared`,
+        );
+      }
+      this.requireOwnedDeleteClaim(lease, latest);
+      const latestAlreadyTransitioned = azureOwnedDeleteClaimsShareSequence(latest, next);
+      if (!latestAlreadyTransitioned && !azureOwnedDeleteClaimsShareSequence(latest, previous)) {
+        throw new Error(
+          `refusing to update Azure lease ${lease.id}: durable cleanup claim changed`,
+        );
+      }
+      const mergedProgress = azureMergeDeletedStableResourceIdentity(
+        latest.deletedStableResourceIdentity,
+        next.deletedStableResourceIdentity,
+      );
+      const transitioned: AzureOwnedDeleteClaim = {
+        ...(latestAlreadyTransitioned ? latest : next),
+        ...(mergedProgress ? { deletedStableResourceIdentity: mergedProgress } : {}),
+      };
+      this.requireOwnedDeleteClaim(lease, transitioned);
+      await transaction.put(claimKey, transitioned);
+      return transitioned;
+    });
+  }
+
+  private async persistOwnedDeleteProgress(
+    claimKey: string,
+    lease: Pick<LeaseRecord, "id" | "slug" | "provider" | "cloudID" | "owner">,
+    claim: AzureOwnedDeleteClaim,
+  ): Promise<AzureOwnedDeleteClaim> {
+    this.requireOwnedDeleteClaim(lease, claim);
+    const storage = this.ownedDeleteClaimStorage;
+    if (!storage) return claim;
+    if (!storage.transaction) {
+      throw new Error(
+        `refusing to update Azure lease ${lease.id}: transactional cleanup claim storage is required`,
+      );
+    }
+    return await storage.transaction(async (transaction) => {
+      const latest = await transaction.get<AzureOwnedDeleteClaim>(claimKey);
+      if (!latest) {
+        throw new Error(
+          `refusing to update Azure lease ${lease.id}: durable cleanup claim disappeared`,
+        );
+      }
+      this.requireOwnedDeleteClaim(lease, latest);
+      if (!azureOwnedDeleteClaimsShareSequence(latest, claim)) {
+        throw new Error(
+          `refusing to update Azure lease ${lease.id}: durable cleanup claim changed`,
+        );
+      }
+      const mergedProgress = azureMergeDeletedStableResourceIdentity(
+        latest.deletedStableResourceIdentity,
+        claim.deletedStableResourceIdentity,
+      );
+      if (!mergedProgress) {
+        throw new Error(`refusing to update Azure lease ${lease.id}: deletion progress is empty`);
+      }
+      const merged: AzureOwnedDeleteClaim = {
+        ...latest,
+        deletedStableResourceIdentity: mergedProgress,
+      };
+      this.requireOwnedDeleteClaim(lease, merged);
+      await transaction.put(claimKey, merged);
+      return merged;
+    });
   }
 
   private async ownedDeleteResources(
     lease: Pick<LeaseRecord, "id" | "slug" | "provider" | "cloudID" | "owner">,
-    options: { claim?: AzureOwnedDeleteClaim; prepareClaim?: boolean } = {},
+    options: {
+      claim?: AzureOwnedDeleteClaim;
+      prepareClaim?: boolean;
+      expectedResourceIdentity?: string;
+      expectedStableResourceIdentity?: string;
+    } = {},
   ): Promise<AzureOwnedDeleteInspection> {
     const name = lease.cloudID;
     const vmResourcePath = vmPath(this.resourceGroup, name);
@@ -769,11 +1171,84 @@ export class AzureClient {
     if (vm) this.requireOwnedResource("VM", vm, vmResourcePath, lease);
     if (nic) this.requireOwnedResource("NIC", nic, nicResourcePath, lease);
     if (pip) this.requireOwnedResource("public IP", pip, pipResourcePath, lease);
+    const initialClaimSetIncomplete =
+      options.prepareClaim &&
+      !options.claim &&
+      Boolean(vm || nic || pip || initialDisk) &&
+      (!nic || !pip || (!initialDisk && !azureVMUsesEphemeralOSDisk(vm)));
 
     const expectedNICID = this.resourceID(nicResourcePath);
     const expectedPIPID = this.resourceID(pipResourcePath);
     const expectedDiskID = this.resourceID(diskResourcePath);
+    const expectedVMID = this.resourceID(vmResourcePath);
+    const currentResources: AzureLeaseResource[] = [
+      ...(vm ? [{ kind: "virtualMachines" as const, resource: vm }] : []),
+      ...(nic ? [{ kind: "networkInterfaces" as const, resource: nic }] : []),
+      ...(pip ? [{ kind: "publicIPAddresses" as const, resource: pip }] : []),
+      ...(initialDisk ? [{ kind: "disks" as const, resource: initialDisk }] : []),
+    ];
+    const currentStableResourceIdentity = azureStableResourceIdentity(currentResources);
+    const currentResourceIdentity = azureReconciliationResourceIdentity(currentResources);
+    if (
+      options.expectedStableResourceIdentity &&
+      !azureStableResourceIdentityMatches(
+        options.expectedStableResourceIdentity,
+        currentStableResourceIdentity,
+        options.claim?.deletedStableResourceIdentity,
+      )
+    ) {
+      throw new Error(
+        `refusing to delete Azure resources for ${name}: observed resource identity changed`,
+      );
+    }
+    if (
+      options.expectedResourceIdentity &&
+      !azureResourceIdentityMatches(
+        options.expectedResourceIdentity,
+        currentResourceIdentity,
+        options.claim?.deletedStableResourceIdentity,
+      )
+    ) {
+      throw new Error(
+        `refusing to delete Azure resources for ${name}: observed resource labels changed`,
+      );
+    }
     const vmDiskID = vm?.properties?.storageProfile?.osDisk?.managedDisk?.id;
+    if (vm && azureVMHasDataDisks(vm)) {
+      throw new Error(
+        `refusing to delete Azure resources for ${name}: VM has unexpected data disks`,
+      );
+    }
+    if (vm && azureVMHasCascadeDelete(vm)) {
+      throw new Error(
+        `refusing to delete Azure resources for ${name}: VM has cascading delete options`,
+      );
+    }
+    const nicVirtualMachine = nic?.properties?.virtualMachine;
+    const staleCanonicalNICAttachmentAllowed =
+      !vm &&
+      azureStableResourceIdentityIncludesResourceID(
+        options.claim?.deletedStableResourceIdentity,
+        "virtualMachines",
+        expectedVMID,
+      );
+    if (
+      nicVirtualMachine &&
+      (!azureResourceIDEqual(nicVirtualMachine.id, expectedVMID) ||
+        (!vm && !staleCanonicalNICAttachmentAllowed))
+    ) {
+      throw new Error(
+        `refusing to delete Azure resources for ${name}: NIC is attached to an unexpected VM`,
+      );
+    }
+    if (vm && !azureVMReferencesOnlyNIC(vm, expectedNICID)) {
+      throw new Error(
+        `refusing to delete Azure resources for ${name}: VM references an unexpected NIC`,
+      );
+    }
+    if (vm && !nic) {
+      throw new Error(`refusing to delete Azure resources for ${name}: canonical NIC is missing`);
+    }
     if (
       vm &&
       !vm.properties?.networkProfile?.networkInterfaces?.some((item) =>
@@ -782,6 +1257,31 @@ export class AzureClient {
     ) {
       throw new Error(
         `refusing to delete Azure resources for ${name}: VM does not own ${name}-nic`,
+      );
+    }
+    if (nic && azureNICHasDisqualifyingServiceAssociation(nic)) {
+      throw new Error(
+        `refusing to delete Azure resources for ${name}: NIC has an unexpected service association`,
+      );
+    }
+    if (nic && azureNICHasCascadeDelete(nic)) {
+      throw new Error(
+        `refusing to delete Azure resources for ${name}: NIC has cascading delete options`,
+      );
+    }
+    const missingCanonicalPIPAllowed =
+      !pip &&
+      azureStableResourceIdentityIncludesResourceID(
+        options.claim?.deletedStableResourceIdentity,
+        "publicIPAddresses",
+        expectedPIPID,
+      );
+    if (
+      nic &&
+      !azureNICReferencesOnlyPIP(nic, expectedPIPID, Boolean(pip) || missingCanonicalPIPAllowed)
+    ) {
+      throw new Error(
+        `refusing to delete Azure resources for ${name}: NIC references an unexpected public IP`,
       );
     }
     if (
@@ -793,6 +1293,25 @@ export class AzureClient {
     ) {
       throw new Error(
         `refusing to delete Azure resources for ${name}: NIC does not own ${name}-pip`,
+      );
+    }
+    if (
+      pip &&
+      !azurePublicIPAttachmentMatchesNIC(
+        pip,
+        nic,
+        expectedPIPID,
+        expectedNICID,
+        !nic &&
+          azureStableResourceIdentityIncludesResourceID(
+            options.claim?.deletedStableResourceIdentity,
+            "networkInterfaces",
+            expectedNICID,
+          ),
+      )
+    ) {
+      throw new Error(
+        `refusing to delete Azure resources for ${name}: public IP is attached to an unexpected configuration`,
       );
     }
     if (options.prepareClaim && vmDiskID) {
@@ -833,7 +1352,7 @@ export class AzureClient {
           !options.prepareClaim ||
           !vm ||
           !azureResourceIDEqual(vmDiskID, expectedDiskID) ||
-          !azureResourceIDEqual(disk.managedBy, this.resourceID(vmResourcePath))
+          !azureDiskAttachmentsMatchVM(disk, this.resourceID(vmResourcePath), true)
         ) {
           throw new Error(
             `refusing to delete Azure disk ${name}-osdisk: ownership does not match lease ${lease.id}`,
@@ -851,7 +1370,7 @@ export class AzureClient {
         this.requireOwnedResource("disk", taggedDisk, diskResourcePath, lease);
         if (
           this.requireDiskUniqueID(taggedDisk, lease.id) !== uniqueID ||
-          !azureResourceIDEqual(taggedDisk.managedBy, this.resourceID(vmResourcePath))
+          !azureDiskAttachmentsMatchVM(taggedDisk, this.resourceID(vmResourcePath), true)
         ) {
           throw new Error(
             `refusing to delete Azure disk ${name}-osdisk: live association changed while binding lease ${lease.id}`,
@@ -868,7 +1387,7 @@ export class AzureClient {
         if (vm) {
           if (
             !azureResourceIDEqual(vmDiskID, expectedDiskID) ||
-            !azureResourceIDEqual(disk.managedBy, this.resourceID(vmResourcePath))
+            !azureDiskAttachmentsMatchVM(disk, this.resourceID(vmResourcePath), true)
           ) {
             throw new Error(
               `refusing to delete Azure disk ${name}-osdisk: live association does not match lease ${lease.id}`,
@@ -876,7 +1395,7 @@ export class AzureClient {
           }
         } else if (
           !diskOwnedByLease ||
-          (disk.managedBy && !azureResourceIDEqual(disk.managedBy, this.resourceID(vmResourcePath)))
+          !azureDiskAttachmentsMatchVM(disk, this.resourceID(vmResourcePath), false)
         ) {
           throw new Error(
             `refusing to delete Azure disk ${name}-osdisk: live association does not match lease ${lease.id}`,
@@ -893,12 +1412,7 @@ export class AzureClient {
             `refusing to delete Azure disk ${name}-osdisk: immutable identity does not match lease ${lease.id}`,
           );
         }
-        if (
-          (vm && !azureResourceIDEqual(disk.managedBy, this.resourceID(vmResourcePath))) ||
-          (!vm &&
-            disk.managedBy &&
-            !azureResourceIDEqual(disk.managedBy, this.resourceID(vmResourcePath)))
-        ) {
+        if (!azureDiskAttachmentsMatchVM(disk, this.resourceID(vmResourcePath), Boolean(vm))) {
           throw new Error(
             `refusing to delete Azure disk ${name}-osdisk: live association does not match lease ${lease.id}`,
           );
@@ -906,28 +1420,55 @@ export class AzureClient {
       }
     }
 
+    if (initialClaimSetIncomplete) {
+      throw new Error(
+        `refusing to delete Azure resources for ${name}: canonical companion set is incomplete`,
+      );
+    }
+
     return {
       vm: Boolean(vm),
       nic: Boolean(nic),
       pip: Boolean(pip),
       disk: Boolean(disk),
+      stableResourceIdentity: currentStableResourceIdentity,
+      ephemeralOSDisk: azureVMUsesEphemeralOSDisk(vm),
       ...(disk ? { diskResource: disk } : {}),
     };
   }
 
-  private ownedDeleteClaim(
+  private ownedDeleteClaimPreparation(
     lease: Pick<LeaseRecord, "id" | "slug" | "provider" | "cloudID" | "owner">,
-    disk: AzureDisk | undefined,
   ): AzureOwnedDeleteClaim {
-    const diskResourcePath = `/resourceGroups/${this.resourceGroup}/providers/Microsoft.Compute/disks/${lease.cloudID}-osdisk`;
     return {
-      version: 1,
+      version: 2,
       provider: "azure",
       leaseID: lease.id,
       slug: lease.slug ?? "",
       owner: lease.owner,
       cloudID: lease.cloudID,
       providerScope: this.providerScope(),
+      preparing: true,
+    };
+  }
+
+  private ownedDeleteClaim(
+    lease: Pick<LeaseRecord, "id" | "slug" | "provider" | "cloudID" | "owner">,
+    disk: AzureDisk | undefined,
+    resourceIdentity: string | undefined,
+    stableResourceIdentity: string,
+  ): AzureOwnedDeleteClaim {
+    const diskResourcePath = `/resourceGroups/${this.resourceGroup}/providers/Microsoft.Compute/disks/${lease.cloudID}-osdisk`;
+    return {
+      version: 2,
+      provider: "azure",
+      leaseID: lease.id,
+      slug: lease.slug ?? "",
+      owner: lease.owner,
+      cloudID: lease.cloudID,
+      providerScope: this.providerScope(),
+      ...(resourceIdentity ? { resourceIdentity } : {}),
+      stableResourceIdentity,
       ...(disk
         ? {
             disk: {
@@ -946,14 +1487,59 @@ export class AzureClient {
     const expectedDiskID = this.resourceID(
       `/resourceGroups/${this.resourceGroup}/providers/Microsoft.Compute/disks/${lease.cloudID}-osdisk`,
     );
+    const expectedVMID = this.resourceID(vmPath(this.resourceGroup, lease.cloudID));
+    const expectedNICID = this.resourceID(
+      networkPath(this.resourceGroup, "networkInterfaces", `${lease.cloudID}-nic`),
+    );
+    try {
+      if (claim.resourceIdentity !== undefined) {
+        if (
+          claim.stableResourceIdentity !==
+          azureStableResourceIdentityFromObserved(claim.resourceIdentity)
+        ) {
+          throw new Error("resource identity mismatch");
+        }
+      }
+      if (claim.stableResourceIdentity !== undefined) {
+        azureStableResourceIdentityEntries(claim.stableResourceIdentity);
+      }
+      if (claim.partialStableResourceIdentity !== undefined) {
+        azureStableResourceIdentityEntries(claim.partialStableResourceIdentity);
+      }
+      if (
+        !azureStableResourceIdentityDeletionProgressValid(
+          claim.stableResourceIdentity,
+          claim.partialStableResourceIdentity,
+          claim.deletedStableResourceIdentity,
+        )
+      ) {
+        throw new Error("invalid deletion progress");
+      }
+    } catch {
+      throw new Error(`refusing to delete Azure lease ${lease.id}: durable cleanup claim mismatch`);
+    }
+    const preparingValid = claim.preparing
+      ? claim.version === 2 &&
+        claim.resourceIdentity === undefined &&
+        claim.stableResourceIdentity === undefined &&
+        claim.partialStableResourceIdentity === undefined &&
+        claim.deletedStableResourceIdentity === undefined &&
+        claim.disk === undefined
+      : claim.preparing === undefined &&
+        (claim.version === 1 || claim.stableResourceIdentity !== undefined);
     if (
-      claim.version !== 1 ||
+      (claim.version !== 1 && claim.version !== 2) ||
+      !preparingValid ||
       claim.provider !== "azure" ||
       claim.leaseID !== lease.id ||
       claim.slug !== (lease.slug ?? "") ||
       claim.owner !== lease.owner ||
       claim.cloudID !== lease.cloudID ||
       claim.providerScope !== this.providerScope() ||
+      (claim.canonicalVMID !== undefined &&
+        !azureResourceIDEqual(claim.canonicalVMID, expectedVMID)) ||
+      (claim.canonicalNICID !== undefined &&
+        !azureResourceIDEqual(claim.canonicalNICID, expectedNICID)) ||
       (claim.disk &&
         (!azureResourceIDEqual(claim.disk.resourceID, expectedDiskID) ||
           !claim.disk.uniqueID.trim()))
@@ -2051,11 +2637,10 @@ function azureResourceName(value: string): string {
   return value.slice(value.lastIndexOf("/") + 1);
 }
 
-function azureRecoveryCloudID(
-  kind: "virtualMachines" | "networkInterfaces" | "publicIPAddresses" | "disks",
+function azureResourceSetCloudID(
+  kind: AzureLeaseResource["kind"],
   name: string | undefined,
-  leaseID: string,
-): string {
+): string | undefined {
   const suffix =
     kind === "networkInterfaces"
       ? "-nic"
@@ -2065,18 +2650,954 @@ function azureRecoveryCloudID(
           ? "-osdisk"
           : "";
   const resourceName = name?.trim() ?? "";
-  const cloudID =
-    suffix && resourceName.endsWith(suffix)
-      ? resourceName.slice(0, -suffix.length)
-      : suffix
-        ? ""
-        : resourceName;
+  if (!resourceName) {
+    return undefined;
+  }
+  if (!suffix) {
+    return resourceName;
+  }
+  return resourceName.endsWith(suffix)
+    ? resourceName.slice(0, -suffix.length) || undefined
+    : undefined;
+}
+
+function azureRecoveryCloudID(
+  kind: AzureLeaseResource["kind"],
+  name: string | undefined,
+  leaseID: string,
+): string {
+  const cloudID = azureResourceSetCloudID(kind, name);
   if (!cloudID) {
     throw new Error(
       `refusing to recover Azure lease ${leaseID}: invalid ${kind} resource identity`,
     );
   }
   return cloudID;
+}
+
+const azureReconciliationLabelKeys = [
+  "crabbox",
+  "created_by",
+  "lease",
+  "owner",
+  "provider",
+  "provider_key",
+  "slug",
+  "keep",
+  "created_at",
+  "expires_at",
+] as const;
+
+function azureLeaseResources(inventory: AzureLeaseResourceInventory): AzureLeaseResource[] {
+  return [
+    ...inventory.vms.map((resource) => ({ kind: "virtualMachines" as const, resource })),
+    ...inventory.nics.map((resource) => ({ kind: "networkInterfaces" as const, resource })),
+    ...inventory.pips.map((resource) => ({ kind: "publicIPAddresses" as const, resource })),
+    ...inventory.disks.map((resource) => ({ kind: "disks" as const, resource })),
+  ];
+}
+
+function azureReconciliationLabelIdentity(resource: AzureLeaseResource["resource"]): string {
+  const labels = azureLabelsFromTags(resource.tags ?? {});
+  return JSON.stringify(
+    Object.fromEntries(azureReconciliationLabelKeys.map((key) => [key, labels[key] ?? ""])),
+  );
+}
+
+function azureReconciliationImmutableIdentity(candidate: AzureLeaseResource): string {
+  if (candidate.kind === "virtualMachines") {
+    return candidate.resource.properties?.vmId ?? "";
+  }
+  if (candidate.kind === "networkInterfaces") {
+    return candidate.resource.properties?.resourceGuid ?? "";
+  }
+  if (candidate.kind === "publicIPAddresses") {
+    return candidate.resource.properties?.resourceGuid ?? "";
+  }
+  return candidate.resource.properties?.uniqueId ?? "";
+}
+
+function azureReconciliationMemberHasStableIdentity(candidate: AzureLeaseResource): boolean {
+  const resourceID = candidate.resource.id?.trim();
+  const resourceName = candidate.resource.name?.trim();
+  const immutableIdentity = azureReconciliationImmutableIdentity(candidate).trim();
+  const location = candidate.resource.location?.trim();
+  return Boolean(
+    resourceID &&
+    resourceName &&
+    azureResourceName(resourceID).toLowerCase() === resourceName.toLowerCase() &&
+    immutableIdentity &&
+    location,
+  );
+}
+
+function azureResourceIDsEqual(left: string | undefined, right: string | undefined): boolean {
+  const normalizedLeft = azureNormalizedResourceID(left);
+  const normalizedRight = azureNormalizedResourceID(right);
+  return Boolean(normalizedLeft && normalizedRight && normalizedLeft === normalizedRight);
+}
+
+function azureDiskAttachmentIDs(disk: AzureDisk): string[] {
+  return [
+    ...new Set(
+      [...(disk.managedBy ? [disk.managedBy] : []), ...(disk.managedByExtended ?? [])].map(
+        (attachment) => attachment.trim().toLowerCase(),
+      ),
+    ),
+  ].toSorted();
+}
+
+function azureDiskAttachmentsMatchVM(
+  disk: AzureDisk,
+  expectedVMID: string,
+  requireAttachment = false,
+): boolean {
+  const attachments = [
+    ...(disk.managedBy ? [disk.managedBy] : []),
+    ...(disk.managedByExtended ?? []),
+  ];
+  return (
+    (!requireAttachment || attachments.length > 0) &&
+    attachments.every((attachment) => azureResourceIDsEqual(attachment, expectedVMID))
+  );
+}
+
+function azureVMReferencesOnlyNIC(vm: AzureVM, expectedNICID: string): boolean {
+  return (vm.properties?.networkProfile?.networkInterfaces ?? []).every((networkInterface) =>
+    azureResourceIDsEqual(networkInterface.id, expectedNICID),
+  );
+}
+
+function azureVMHasDataDisks(vm: AzureVM): boolean {
+  return (vm.properties?.storageProfile?.dataDisks ?? []).length > 0;
+}
+
+function azureVMUsesEphemeralOSDisk(vm: AzureVM | undefined): boolean {
+  return (
+    vm?.properties?.storageProfile?.osDisk?.diffDiskSettings?.option?.trim().toLowerCase() ===
+    "local"
+  );
+}
+
+function azureDeleteOptionIsSafe(value: string | undefined): boolean {
+  const normalized = value?.trim().toLowerCase();
+  return !normalized || normalized === "detach";
+}
+
+function azureVMHasCascadeDelete(vm: AzureVM): boolean {
+  const osDisk = vm.properties?.storageProfile?.osDisk;
+  if (!azureVMUsesEphemeralOSDisk(vm) && !azureDeleteOptionIsSafe(osDisk?.deleteOption)) {
+    return true;
+  }
+  return (vm.properties?.networkProfile?.networkInterfaces ?? []).some(
+    (networkInterface) =>
+      !azureDeleteOptionIsSafe(
+        networkInterface.deleteOption ?? networkInterface.properties?.deleteOption,
+      ),
+  );
+}
+
+function azureNICHasCascadeDelete(nic: AzureNIC): boolean {
+  return (nic.properties?.ipConfigurations ?? []).some(
+    (configuration) =>
+      !azureDeleteOptionIsSafe(configuration.properties?.publicIPAddress?.deleteOption),
+  );
+}
+
+function azureResourceReferenceIdentity(
+  reference: AzureResourceReference | null | undefined,
+  label: string,
+): string {
+  return azureNormalizedResourceID(reference?.id) || `${label}:attached`;
+}
+
+function azureResourceReferenceListIdentity(
+  references: AzureResourceReference[] | undefined,
+  label: string,
+): string[] {
+  return (references ?? [])
+    .map((reference, index) => azureResourceReferenceIdentity(reference, `${label}:${index}`))
+    .toSorted();
+}
+
+function azureNICServiceAssociationTopology(nic: AzureNIC): Record<string, string[]> {
+  const properties = nic.properties;
+  const ipConfigurations = properties?.ipConfigurations ?? [];
+  return {
+    privateEndpointIDs: properties?.privateEndpoint
+      ? [azureResourceReferenceIdentity(properties.privateEndpoint, "privateEndpoint")]
+      : [],
+    privateLinkServiceIDs: properties?.privateLinkService
+      ? [azureResourceReferenceIdentity(properties.privateLinkService, "privateLinkService")]
+      : [],
+    hostedWorkloadIDs: (properties?.hostedWorkloads ?? [])
+      .map((workload, index) => workload.trim().toLowerCase() || `hostedWorkload:${index}`)
+      .toSorted(),
+    tapConfigurationIDs: azureResourceReferenceListIdentity(
+      properties?.tapConfigurations,
+      "tapConfiguration",
+    ),
+    loadBalancerBackendAddressPoolIDs: ipConfigurations
+      .flatMap((configuration) =>
+        azureResourceReferenceListIdentity(
+          configuration.properties?.loadBalancerBackendAddressPools,
+          "loadBalancerBackendAddressPool",
+        ),
+      )
+      .toSorted(),
+    applicationGatewayBackendAddressPoolIDs: ipConfigurations
+      .flatMap((configuration) =>
+        azureResourceReferenceListIdentity(
+          configuration.properties?.applicationGatewayBackendAddressPools,
+          "applicationGatewayBackendAddressPool",
+        ),
+      )
+      .toSorted(),
+    applicationSecurityGroupIDs: ipConfigurations
+      .flatMap((configuration) =>
+        azureResourceReferenceListIdentity(
+          configuration.properties?.applicationSecurityGroups,
+          "applicationSecurityGroup",
+        ),
+      )
+      .toSorted(),
+    loadBalancerInboundNatRuleIDs: ipConfigurations
+      .flatMap((configuration) =>
+        azureResourceReferenceListIdentity(
+          configuration.properties?.loadBalancerInboundNatRules,
+          "loadBalancerInboundNatRule",
+        ),
+      )
+      .toSorted(),
+    privateLinkConnectionIDs: ipConfigurations
+      .flatMap((configuration, index) =>
+        configuration.properties?.privateLinkConnectionProperties
+          ? [`privateLinkConnection:${index}:attached`]
+          : [],
+      )
+      .toSorted(),
+    virtualNetworkTapIDs: ipConfigurations
+      .flatMap((configuration) =>
+        azureResourceReferenceListIdentity(
+          configuration.properties?.virtualNetworkTaps,
+          "virtualNetworkTap",
+        ),
+      )
+      .toSorted(),
+    gatewayLoadBalancerIDs: ipConfigurations
+      .flatMap((configuration, index) =>
+        configuration.properties?.gatewayLoadBalancer
+          ? [
+              azureResourceReferenceIdentity(
+                configuration.properties.gatewayLoadBalancer,
+                `gatewayLoadBalancer:${index}`,
+              ),
+            ]
+          : [],
+      )
+      .toSorted(),
+  };
+}
+
+function azureNICHasDisqualifyingServiceAssociation(nic: AzureNIC): boolean {
+  return Object.values(azureNICServiceAssociationTopology(nic)).some(
+    (associations) => associations.length > 0,
+  );
+}
+
+function azureNICReferencesOnlyPIP(
+  nic: AzureNIC,
+  expectedPIPID: string,
+  canonicalPIPPresent: boolean,
+): boolean {
+  if (azureNICHasDisqualifyingServiceAssociation(nic)) return false;
+  const publicIPReferences = (nic.properties?.ipConfigurations ?? []).flatMap((configuration) => {
+    const publicIPAddress = configuration.properties?.publicIPAddress;
+    return publicIPAddress ? [publicIPAddress.id] : [];
+  });
+  return (
+    (canonicalPIPPresent || publicIPReferences.length === 0) &&
+    publicIPReferences.every((id) => azureResourceIDsEqual(id, expectedPIPID))
+  );
+}
+
+function azurePublicIPAttachmentMatchesNIC(
+  pip: AzurePublicIP,
+  nic: AzureNIC | undefined,
+  expectedPIPID: string | undefined,
+  expectedNICID?: string,
+  allowMissingNIC = false,
+): boolean {
+  if (
+    pip.properties?.natGateway ||
+    pip.properties?.linkedPublicIPAddress ||
+    pip.properties?.servicePublicIPAddress
+  ) {
+    return false;
+  }
+  const ipConfiguration = pip.properties?.ipConfiguration;
+  if (!ipConfiguration) {
+    return true;
+  }
+  if (!nic && allowMissingNIC) {
+    const normalizedIPConfigurationID = azureNormalizedResourceID(ipConfiguration.id);
+    const normalizedNICID = azureNormalizedResourceID(expectedNICID);
+    return Boolean(
+      normalizedIPConfigurationID &&
+      normalizedNICID &&
+      normalizedIPConfigurationID.startsWith(`${normalizedNICID}/`),
+    );
+  }
+  return Boolean(
+    nic &&
+    expectedPIPID &&
+    (nic.properties?.ipConfigurations ?? []).some(
+      (configuration) =>
+        azureResourceIDsEqual(configuration.id, ipConfiguration.id) &&
+        azureResourceIDsEqual(configuration.properties?.publicIPAddress?.id, expectedPIPID),
+    ),
+  );
+}
+
+function azureReconciliationTopologyConsistent(set: AzureReconciliationResourceSet): boolean {
+  if (!set.nic || !set.pip || !set.disk) {
+    return false;
+  }
+  const nicVirtualMachine = set.nic?.properties?.virtualMachine;
+  if (
+    nicVirtualMachine &&
+    (!set.vm || !azureResourceIDsEqual(nicVirtualMachine.id, set.canonicalVMID))
+  ) {
+    return false;
+  }
+  if (set.vm && !azureResourceIDsEqual(set.vm.id, set.canonicalVMID)) {
+    return false;
+  }
+  if (set.vm && azureVMHasDataDisks(set.vm)) {
+    return false;
+  }
+  if (set.vm && azureVMHasCascadeDelete(set.vm)) {
+    return false;
+  }
+  if (set.nic && azureNICHasCascadeDelete(set.nic)) {
+    return false;
+  }
+  if (set.vm && !azureVMReferencesOnlyNIC(set.vm, set.canonicalNICID)) {
+    return false;
+  }
+  if (set.vm && !set.nic) {
+    return false;
+  }
+  if (
+    set.vm &&
+    set.nic &&
+    !(set.vm.properties?.networkProfile?.networkInterfaces ?? []).some((networkInterface) =>
+      azureResourceIDsEqual(networkInterface.id, set.canonicalNICID),
+    )
+  ) {
+    return false;
+  }
+  if (set.nic && !azureNICReferencesOnlyPIP(set.nic, set.canonicalPIPID, Boolean(set.pip))) {
+    return false;
+  }
+  if (
+    set.nic &&
+    set.pip &&
+    !(set.nic.properties?.ipConfigurations ?? []).some((configuration) =>
+      azureResourceIDsEqual(configuration.properties?.publicIPAddress?.id, set.canonicalPIPID),
+    )
+  ) {
+    return false;
+  }
+  if (set.pip && !azurePublicIPAttachmentMatchesNIC(set.pip, set.nic, set.canonicalPIPID)) {
+    return false;
+  }
+  if (set.disk && !azureDiskAttachmentsMatchVM(set.disk, set.canonicalVMID, Boolean(set.vm))) {
+    return false;
+  }
+  if (
+    set.vm &&
+    set.disk &&
+    (!azureResourceIDsEqual(
+      set.vm.properties?.storageProfile?.osDisk?.managedDisk?.id,
+      set.disk.id,
+    ) ||
+      !azureDiskAttachmentsMatchVM(set.disk, set.canonicalVMID, true))
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function azureReconciliationTopologyIdentity(
+  candidate: AzureLeaseResource,
+): Record<string, string | string[]> {
+  if (candidate.kind === "virtualMachines") {
+    return {
+      managedDiskID:
+        candidate.resource.properties?.storageProfile?.osDisk?.managedDisk?.id?.toLowerCase() ?? "",
+      osDiskDiffOption:
+        candidate.resource.properties?.storageProfile?.osDisk?.diffDiskSettings?.option
+          ?.trim()
+          .toLowerCase() ?? "",
+      osDiskDeleteOption:
+        candidate.resource.properties?.storageProfile?.osDisk?.deleteOption?.trim().toLowerCase() ??
+        "",
+      dataDiskIDs: (candidate.resource.properties?.storageProfile?.dataDisks ?? [])
+        .map(
+          (disk, index) =>
+            azureNormalizedResourceID(disk.managedDisk?.id) || `dataDisk:${index}:attached`,
+        )
+        .toSorted(),
+      dataDiskDeleteOptions: (candidate.resource.properties?.storageProfile?.dataDisks ?? [])
+        .map((disk, index) => `${index}:${disk.deleteOption?.trim().toLowerCase() || "default"}`)
+        .toSorted(),
+      networkInterfaceIDs: (candidate.resource.properties?.networkProfile?.networkInterfaces ?? [])
+        .flatMap((networkInterface) =>
+          networkInterface.id ? [networkInterface.id.toLowerCase()] : [],
+        )
+        .toSorted(),
+      networkInterfaceDeleteOptions: (
+        candidate.resource.properties?.networkProfile?.networkInterfaces ?? []
+      )
+        .flatMap((networkInterface, index) => {
+          const value = (networkInterface.deleteOption ?? networkInterface.properties?.deleteOption)
+            ?.trim()
+            .toLowerCase();
+          return value ? [`${index}:${value}`] : [];
+        })
+        .toSorted(),
+    };
+  }
+  if (candidate.kind === "networkInterfaces") {
+    return {
+      virtualMachineID: candidate.resource.properties?.virtualMachine?.id?.toLowerCase() ?? "",
+      publicIPIDs: (candidate.resource.properties?.ipConfigurations ?? [])
+        .flatMap((configuration) => {
+          const id = configuration.properties?.publicIPAddress?.id;
+          return id ? [id.toLowerCase()] : [];
+        })
+        .toSorted(),
+      publicIPDeleteOptions: (candidate.resource.properties?.ipConfigurations ?? [])
+        .flatMap((configuration, index) => {
+          const value = configuration.properties?.publicIPAddress?.deleteOption
+            ?.trim()
+            .toLowerCase();
+          return value ? [`${index}:${value}`] : [];
+        })
+        .toSorted(),
+      ...azureNICServiceAssociationTopology(candidate.resource),
+    };
+  }
+  if (candidate.kind === "publicIPAddresses") {
+    return {
+      ipConfigurationID: candidate.resource.properties?.ipConfiguration?.id?.toLowerCase() ?? "",
+      natGatewayID: candidate.resource.properties?.natGateway?.id?.toLowerCase() ?? "",
+      linkedPublicIPAddressID:
+        candidate.resource.properties?.linkedPublicIPAddress?.id?.toLowerCase() ?? "",
+      servicePublicIPAddressID:
+        candidate.resource.properties?.servicePublicIPAddress?.id?.toLowerCase() ?? "",
+    };
+  }
+  if (candidate.kind === "disks") {
+    return {
+      managedBy: candidate.resource.managedBy?.toLowerCase() ?? "",
+      managedByExtended: azureDiskAttachmentIDs(candidate.resource),
+    };
+  }
+  return {};
+}
+
+interface AzureReconciliationIdentityEntry {
+  kind: AzureLeaseResource["kind"];
+  id: string;
+  immutableID: string;
+  location: string;
+  topology: Record<string, string | string[]>;
+  labels?: string;
+}
+
+function azureReconciliationIdentityEntries(
+  resources: AzureLeaseResource[],
+  includeLabels: boolean,
+): AzureReconciliationIdentityEntry[] {
+  return resources.map((candidate) => {
+    const entry: AzureReconciliationIdentityEntry = {
+      kind: candidate.kind,
+      id: (candidate.resource.id ?? candidate.resource.name ?? "").toLowerCase(),
+      immutableID: azureReconciliationImmutableIdentity(candidate),
+      location: candidate.resource.location?.trim().toLowerCase() ?? "",
+      topology: azureReconciliationTopologyIdentity(candidate),
+    };
+    if (includeLabels) {
+      entry.labels = azureReconciliationLabelIdentity(candidate.resource);
+    }
+    return entry;
+  });
+}
+
+function azureReconciliationResourceIdentity(resources: AzureLeaseResource[]): string {
+  return JSON.stringify(azureReconciliationIdentityEntries(resources, true));
+}
+
+function azureStableResourceIdentity(resources: AzureLeaseResource[]): string {
+  return JSON.stringify(azureReconciliationIdentityEntries(resources, false));
+}
+
+function azureStableResourceIdentityEntries(value: string): AzureReconciliationIdentityEntry[] {
+  const parsed: unknown = JSON.parse(value);
+  if (!Array.isArray(parsed)) {
+    throw new Error("Azure reconciliation resource identity must be an array");
+  }
+  const kinds = new Set<AzureLeaseResource["kind"]>();
+  return parsed.map((entry): AzureReconciliationIdentityEntry => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      throw new Error("Azure reconciliation resource identity member is invalid");
+    }
+    const member = entry as Record<string, unknown>;
+    const kind = member["kind"];
+    if (
+      kind !== "virtualMachines" &&
+      kind !== "networkInterfaces" &&
+      kind !== "publicIPAddresses" &&
+      kind !== "disks"
+    ) {
+      throw new Error("Azure reconciliation resource identity kind is invalid");
+    }
+    if (kinds.has(kind)) {
+      throw new Error("Azure reconciliation resource identity has duplicate members");
+    }
+    const id = member["id"];
+    const immutableID = member["immutableID"];
+    const location = member["location"];
+    const topology = member["topology"];
+    const labels = member["labels"];
+    if (
+      typeof id !== "string" ||
+      typeof immutableID !== "string" ||
+      typeof location !== "string" ||
+      (labels !== undefined && typeof labels !== "string") ||
+      !topology ||
+      typeof topology !== "object" ||
+      Array.isArray(topology) ||
+      !Object.values(topology).every(
+        (topologyValue) =>
+          typeof topologyValue === "string" ||
+          (Array.isArray(topologyValue) && topologyValue.every((item) => typeof item === "string")),
+      )
+    ) {
+      throw new Error("Azure reconciliation resource identity member is incomplete");
+    }
+    kinds.add(kind);
+    return {
+      kind,
+      id,
+      immutableID,
+      location,
+      topology: topology as Record<string, string | string[]>,
+      ...(typeof labels === "string" ? { labels } : {}),
+    };
+  });
+}
+
+function azureStableResourceIdentityFromObserved(resourceIdentity: string): string {
+  const entries = azureStableResourceIdentityEntries(resourceIdentity);
+  if (
+    entries.some((entry) => !entry.id.trim() || !entry.immutableID.trim() || !entry.location.trim())
+  ) {
+    throw new Error("Azure reconciliation resource identity is not stable");
+  }
+  return JSON.stringify(entries.map(({ labels: _labels, ...entry }) => entry));
+}
+
+function azureStableTopologyReferenceEntry(
+  reference: string,
+  entries: AzureReconciliationIdentityEntry[],
+): AzureReconciliationIdentityEntry | undefined {
+  const normalizedReference = azureNormalizedResourceID(reference);
+  if (!normalizedReference) return undefined;
+  return entries.find((entry) => {
+    const normalizedID = azureNormalizedResourceID(entry.id);
+    return Boolean(
+      normalizedID &&
+      (normalizedReference === normalizedID || normalizedReference.startsWith(`${normalizedID}/`)),
+    );
+  });
+}
+
+function azureStableTopologyMatches(
+  expected: AzureReconciliationIdentityEntry,
+  current: AzureReconciliationIdentityEntry,
+  expectedEntries: AzureReconciliationIdentityEntry[],
+  currentKinds: Set<AzureLeaseResource["kind"]>,
+): boolean {
+  const keys = new Set([...Object.keys(expected.topology), ...Object.keys(current.topology)]);
+  for (const key of keys) {
+    const expectedValue = expected.topology[key];
+    const currentValue = current.topology[key];
+    if (
+      (expectedValue === undefined &&
+        (currentValue === "" || (Array.isArray(currentValue) && currentValue.length === 0))) ||
+      (currentValue === undefined &&
+        (expectedValue === "" || (Array.isArray(expectedValue) && expectedValue.length === 0)))
+    ) {
+      continue;
+    }
+    if (Array.isArray(expectedValue) && Array.isArray(currentValue)) {
+      const observedExpectedReferences = expectedValue.map(azureNormalizedResourceID);
+      const expectedReferences = observedExpectedReferences
+        .filter((reference) => {
+          const entry = azureStableTopologyReferenceEntry(reference, expectedEntries);
+          return !entry || currentKinds.has(entry.kind);
+        })
+        .toSorted();
+      const expectedReferenceSet = new Set(observedExpectedReferences);
+      const currentReferences = currentValue
+        .map(azureNormalizedResourceID)
+        .filter((reference) => {
+          const entry = azureStableTopologyReferenceEntry(reference, expectedEntries);
+          return !entry || currentKinds.has(entry.kind) || !expectedReferenceSet.has(reference);
+        })
+        .toSorted();
+      if (JSON.stringify(expectedReferences) !== JSON.stringify(currentReferences)) {
+        return false;
+      }
+      continue;
+    }
+    if (typeof expectedValue !== "string" || typeof currentValue !== "string") {
+      return false;
+    }
+    const expectedReference = azureNormalizedResourceID(expectedValue);
+    const currentReference = azureNormalizedResourceID(currentValue);
+    if (expectedReference === currentReference) continue;
+    const expectedEntry = azureStableTopologyReferenceEntry(expectedReference, expectedEntries);
+    if (
+      currentReference ||
+      !expectedReference ||
+      !expectedEntry ||
+      currentKinds.has(expectedEntry.kind)
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function azureStableNormalizedTopology(
+  topology: Record<string, string | string[]>,
+): Record<string, string | string[]> {
+  return Object.fromEntries(
+    Object.entries(topology)
+      .filter(([, value]) => value !== "" && (!Array.isArray(value) || value.length > 0))
+      .toSorted(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey)),
+  );
+}
+
+function azureStableIdentityEntryExactlyMatches(
+  left: AzureReconciliationIdentityEntry,
+  right: AzureReconciliationIdentityEntry,
+): boolean {
+  return (
+    left.kind === right.kind &&
+    left.id === right.id &&
+    left.immutableID === right.immutableID &&
+    left.location === right.location &&
+    JSON.stringify(azureStableNormalizedTopology(left.topology)) ===
+      JSON.stringify(azureStableNormalizedTopology(right.topology))
+  );
+}
+
+function azureStableIdentityEntryMatchesDeletedResource(
+  expected: AzureReconciliationIdentityEntry,
+  deleted: AzureReconciliationIdentityEntry,
+  expectedEntries: AzureReconciliationIdentityEntry[],
+  survivingKinds: Set<AzureLeaseResource["kind"]>,
+): boolean {
+  return (
+    expected.kind === deleted.kind &&
+    expected.id === deleted.id &&
+    expected.immutableID === deleted.immutableID &&
+    expected.location === deleted.location &&
+    azureStableTopologyMatches(expected, deleted, expectedEntries, survivingKinds)
+  );
+}
+
+const azureOwnedDeleteResourceKind: Record<
+  keyof AzureOwnedDeleteResources,
+  AzureLeaseResource["kind"]
+> = {
+  vm: "virtualMachines",
+  nic: "networkInterfaces",
+  pip: "publicIPAddresses",
+  disk: "disks",
+};
+
+function azureOwnedDeleteClaimsShareSequence(
+  left: AzureOwnedDeleteClaim,
+  right: AzureOwnedDeleteClaim,
+): boolean {
+  return (
+    left.version === right.version &&
+    left.provider === right.provider &&
+    left.leaseID === right.leaseID &&
+    left.slug === right.slug &&
+    left.owner === right.owner &&
+    left.cloudID === right.cloudID &&
+    left.providerScope === right.providerScope &&
+    left.preparing === right.preparing &&
+    left.canonicalVMID === right.canonicalVMID &&
+    left.canonicalNICID === right.canonicalNICID &&
+    left.resourceIdentity === right.resourceIdentity &&
+    left.stableResourceIdentity === right.stableResourceIdentity &&
+    left.partialStableResourceIdentity === right.partialStableResourceIdentity &&
+    JSON.stringify(left.disk) === JSON.stringify(right.disk)
+  );
+}
+
+function azureMergeDeletedStableResourceIdentity(
+  left: string | undefined,
+  right: string | undefined,
+): string | undefined {
+  if (!left) return right;
+  if (!right) return left;
+  const leftEntries = azureStableResourceIdentityEntries(left);
+  const rightEntries = azureStableResourceIdentityEntries(right);
+  const [shorter, longer] =
+    leftEntries.length <= rightEntries.length
+      ? [leftEntries, rightEntries]
+      : [rightEntries, leftEntries];
+  if (
+    !shorter.every((entry, index) => azureStableIdentityEntryExactlyMatches(entry, longer[index]!))
+  ) {
+    throw new Error("Azure cleanup progress branches conflict");
+  }
+  return JSON.stringify(longer);
+}
+
+function azureStableResourceIdentityWithDeletedMember(
+  deleted: string | undefined,
+  current: string,
+  kind: keyof AzureOwnedDeleteResources,
+): string {
+  const resourceKind = azureOwnedDeleteResourceKind[kind];
+  const currentEntry = azureStableResourceIdentityEntries(current).find(
+    (entry) => entry.kind === resourceKind,
+  );
+  if (!currentEntry) {
+    throw new Error(`Azure cleanup progress is missing the deleted ${resourceKind} identity`);
+  }
+  const deletedEntries = deleted ? azureStableResourceIdentityEntries(deleted) : [];
+  const previous = deletedEntries.find((entry) => entry.kind === resourceKind);
+  if (previous) {
+    if (!azureStableIdentityEntryExactlyMatches(previous, currentEntry)) {
+      throw new Error(`Azure cleanup progress changed the deleted ${resourceKind} identity`);
+    }
+    return JSON.stringify(deletedEntries);
+  }
+  return JSON.stringify([...deletedEntries, currentEntry]);
+}
+
+function azureStableResourceIdentityDeletionProgressValid(
+  stable: string | undefined,
+  partial: string | undefined,
+  deleted: string | undefined,
+): boolean {
+  if (!deleted) return true;
+  if (!stable && !partial) return false;
+  try {
+    const stableEntries = stable ? azureStableResourceIdentityEntries(stable) : [];
+    const partialEntries = partial ? azureStableResourceIdentityEntries(partial) : [];
+    const deletedEntries = azureStableResourceIdentityEntries(deleted);
+    const expectedEntries = [...stableEntries, ...partialEntries];
+    const expectedKinds = Object.values(azureOwnedDeleteResourceKind).filter((kind) =>
+      expectedEntries.some((entry) => entry.kind === kind),
+    );
+    if (deletedEntries.length > expectedKinds.length) return false;
+    return deletedEntries.every((entry, index) => {
+      if (entry.kind !== expectedKinds[index]) return false;
+      const survivingKinds = new Set(expectedKinds.slice(index));
+      return expectedEntries.some((expected) =>
+        azureStableIdentityEntryMatchesDeletedResource(
+          expected,
+          entry,
+          expectedEntries,
+          survivingKinds,
+        ),
+      );
+    });
+  } catch {
+    return false;
+  }
+}
+
+function azureStableResourceIdentityMatches(
+  expected: string,
+  current: string,
+  deleted?: string,
+): boolean {
+  try {
+    const expectedEntries = azureStableResourceIdentityEntries(expected);
+    const currentEntries = azureStableResourceIdentityEntries(current);
+    const deletedEntries = deleted ? azureStableResourceIdentityEntries(deleted) : [];
+    const expectedByKind = new Map(expectedEntries.map((entry) => [entry.kind, entry]));
+    const currentByKind = new Map(currentEntries.map((entry) => [entry.kind, entry]));
+    const deletedByKind = new Map(deletedEntries.map((entry) => [entry.kind, entry]));
+    const currentKinds = new Set(currentEntries.map((entry) => entry.kind));
+    return (
+      currentEntries.every((entry) => {
+        if (deletedByKind.has(entry.kind)) return false;
+        const expectedEntry = expectedByKind.get(entry.kind);
+        return Boolean(
+          expectedEntry &&
+          expectedEntry.id === entry.id &&
+          expectedEntry.immutableID === entry.immutableID &&
+          expectedEntry.location === entry.location &&
+          azureStableTopologyMatches(expectedEntry, entry, expectedEntries, currentKinds),
+        );
+      }) &&
+      expectedEntries.every((entry) => {
+        const currentEntry = currentByKind.get(entry.kind);
+        if (currentEntry) return true;
+        const deletedEntry = deletedByKind.get(entry.kind);
+        return Boolean(
+          deletedEntry &&
+          azureStableIdentityEntryMatchesDeletedResource(
+            entry,
+            deletedEntry,
+            expectedEntries,
+            currentKinds,
+          ),
+        );
+      })
+    );
+  } catch {
+    return false;
+  }
+}
+
+function azureResourceIdentityMatches(
+  expected: string,
+  current: string,
+  deleted?: string,
+): boolean {
+  try {
+    if (!azureStableResourceIdentityMatches(expected, current, deleted)) return false;
+    const expectedByKind = new Map(
+      azureStableResourceIdentityEntries(expected).map((entry) => [entry.kind, entry]),
+    );
+    return azureStableResourceIdentityEntries(current).every((entry) => {
+      const expectedEntry = expectedByKind.get(entry.kind);
+      return Boolean(
+        expectedEntry &&
+        (expectedEntry.labels === undefined || expectedEntry.labels === entry.labels),
+      );
+    });
+  } catch {
+    return false;
+  }
+}
+
+function azureStableResourceIdentityExactlyMatches(left: string, right: string): boolean {
+  return (
+    azureStableResourceIdentityMatches(left, right) &&
+    azureStableResourceIdentityMatches(right, left)
+  );
+}
+
+function azureStableResourceIdentityIncludesResourceID(
+  value: string | undefined,
+  kind: AzureLeaseResource["kind"],
+  expectedID: string,
+): boolean {
+  if (!value) return false;
+  try {
+    return azureStableResourceIdentityEntries(value).some(
+      (entry) => entry.kind === kind && azureResourceIDEqual(entry.id, expectedID),
+    );
+  } catch {
+    return false;
+  }
+}
+
+function azureReconciliationMachine(
+  set: AzureReconciliationResourceSet,
+): ProviderMachine | undefined {
+  const resources: AzureLeaseResource[] = [
+    ...(set.vm ? [{ kind: "virtualMachines" as const, resource: set.vm }] : []),
+    ...(set.nic ? [{ kind: "networkInterfaces" as const, resource: set.nic }] : []),
+    ...(set.pip ? [{ kind: "publicIPAddresses" as const, resource: set.pip }] : []),
+    ...(set.disk ? [{ kind: "disks" as const, resource: set.disk }] : []),
+  ];
+  const tagged = resources.filter((candidate) => candidate.resource.tags?.["crabbox"] === "true");
+  const representative = tagged[0];
+  if (!representative) {
+    return undefined;
+  }
+  const labels = azureLabelsFromTags(representative.resource.tags ?? {});
+  const ownershipIdentities = new Set(
+    tagged.map(({ resource }) => azureReconciliationLabelIdentity(resource)),
+  );
+  const locations = new Set(
+    resources.map(({ resource }) => azureLocationKey(resource.location ?? "")),
+  );
+  if (
+    tagged.length !== resources.length ||
+    !resources.every(azureReconciliationMemberHasStableIdentity) ||
+    !azureReconciliationTopologyConsistent(set) ||
+    ownershipIdentities.size > 1 ||
+    locations.size !== 1
+  ) {
+    labels["lease"] = "";
+  }
+  if (tagged.some(({ resource }) => azureLabelsFromTags(resource.tags ?? {})["keep"] === "true")) {
+    labels["keep"] = "true";
+  }
+  return {
+    provider: "azure",
+    id: 0,
+    cloudID: set.cloudID,
+    ...(locations.size === 1 ? { region: [...locations][0] } : {}),
+    name: set.cloudID,
+    status: set.vm?.properties?.provisioningState ?? "provisioning",
+    serverType: set.vm?.properties?.hardwareProfile?.vmSize ?? labels["server_type"] ?? "",
+    host: set.pip?.properties?.ipAddress ?? "",
+    labels,
+    resourceIdentity: azureReconciliationResourceIdentity(resources),
+  };
+}
+
+function azureReconciliationMachines(
+  inventory: AzureLeaseResourceInventory,
+  canonicalIDsForCloudID: (cloudID: string) => AzureReconciliationCanonicalIDs,
+): ProviderMachine[] {
+  const sets = new Map<string, AzureReconciliationResourceSet>();
+  for (const candidate of azureLeaseResources(inventory)) {
+    const cloudID = azureResourceSetCloudID(candidate.kind, candidate.resource.name);
+    if (!cloudID) {
+      continue;
+    }
+    const canonicalIDs = canonicalIDsForCloudID(cloudID);
+    const set = sets.get(cloudID) ?? {
+      cloudID,
+      canonicalVMID: canonicalIDs.vmID,
+      canonicalNICID: canonicalIDs.nicID,
+      canonicalPIPID: canonicalIDs.pipID,
+    };
+    if (candidate.kind === "virtualMachines") {
+      set.vm = candidate.resource;
+    } else if (candidate.kind === "networkInterfaces") {
+      set.nic = candidate.resource;
+    } else if (candidate.kind === "publicIPAddresses") {
+      set.pip = candidate.resource;
+    } else {
+      set.disk = candidate.resource;
+    }
+    sets.set(cloudID, set);
+  }
+  return [...sets.values()]
+    .toSorted((left, right) => left.cloudID.localeCompare(right.cloudID))
+    .map(azureReconciliationMachine)
+    .filter((machine): machine is ProviderMachine => Boolean(machine));
 }
 
 function shellQuote(value: string): string {
@@ -2177,8 +3698,12 @@ function azureResourceNotFound(error: unknown, kind: string, name: string): bool
   );
 }
 
+function azureNormalizedResourceID(value: string | undefined): string {
+  return value?.trim().replace(/^\/+/, "").toLowerCase() ?? "";
+}
+
 function azureResourceIDEqual(actual: string | undefined, expected: string): boolean {
-  return actual?.trim().toLowerCase() === expected.trim().toLowerCase();
+  return azureNormalizedResourceID(actual) === azureNormalizedResourceID(expected);
 }
 
 function azureHasOwnershipClaims(labels: Record<string, string>): boolean {

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -14763,7 +14763,10 @@ export class FleetCoordinator {
         });
       } else {
         // Azure inventory is resource-group scoped, not location scoped. One successful read is authoritative.
-        const machines = await this.provider("azure", inventoryRegion).listCrabboxServers();
+        const provider = this.provider("azure", inventoryRegion);
+        const machines = provider.listReconciliationResources
+          ? await provider.listReconciliationResources()
+          : await provider.listCrabboxServers();
         for (const machine of machines) {
           scanned += 1;
           const candidateRegion = machine.region || inventoryRegion;
@@ -14855,7 +14858,9 @@ export class FleetCoordinator {
         try {
           // Azure release uses the persisted provider scope and resumable owned-resource deletion.
           // oxlint-disable-next-line eslint/no-await-in-loop -- release failures must stay attached to the candidate.
-          await this.provider("azure", region).releaseLease(exactOwnershipLease);
+          await this.provider("azure", region).releaseLease(exactOwnershipLease, {
+            resourceIdentity: machine.resourceIdentity ?? "",
+          });
           candidate.action = "terminated";
           released = true;
         } catch (error) {
@@ -21996,6 +22001,7 @@ function parseProviderLabelTime(value: string | undefined): number {
 
 interface CloudProvider {
   listCrabboxServers(): Promise<ProviderMachine[]>;
+  listReconciliationResources?(): Promise<ProviderMachine[]>;
   workspaceCapability?(
     lease?: LeaseRecord,
     purpose?: "operate" | "observe",
@@ -22045,7 +22051,7 @@ interface CloudProvider {
     server: ProviderMachine,
     attempts: ProvisioningAttempt[],
   ): Promise<ProviderLeaseCreateFinalization>;
-  releaseLease(lease: LeaseRecord): Promise<void>;
+  releaseLease(lease: LeaseRecord, context?: ProviderReleaseContext): Promise<void>;
   deleteServer(id: string): Promise<void>;
   deleteOwnedServer?(lease: LeaseRecord): Promise<void>;
   supportsNativeImages(): boolean;
@@ -22134,6 +22140,10 @@ interface ProviderStateStorage {
 interface ProviderAccessContext {
   requestSourceCIDRs: string[];
   activeLeases: LeaseRecord[];
+}
+
+interface ProviderReleaseContext {
+  resourceIdentity?: string;
 }
 
 interface ProviderLeaseCreatePreparation {
@@ -22333,6 +22343,10 @@ export class AzureProvider implements CloudProvider {
     return this.client.listCrabboxServers();
   }
 
+  listReconciliationResources(): Promise<ProviderMachine[]> {
+    return this.client.listReconciliationResources();
+  }
+
   supportsSSHHostKeyInjection(config: ReturnType<typeof leaseConfig>): boolean {
     return config.target === "linux" && !config.azureSnapshot;
   }
@@ -22458,7 +22472,7 @@ export class AzureProvider implements CloudProvider {
     return this.client.deleteServer(id);
   }
 
-  deleteOwnedServer(lease: LeaseRecord): Promise<void> {
+  deleteOwnedServer(lease: LeaseRecord, context?: ProviderReleaseContext): Promise<void> {
     const scope = azureProviderScope(lease.providerScope);
     if (!scope) {
       return Promise.reject(
@@ -22467,13 +22481,16 @@ export class AzureProvider implements CloudProvider {
         ),
       );
     }
-    return new AzureClient(this.env, {
+    const client = new AzureClient(this.env, {
       ...(this.location ? { location: this.location } : {}),
       ...(this.deferredCleanup ? { deferredCleanup: this.deferredCleanup } : {}),
       subscription: scope.subscription,
       resourceGroup: scope.resourceGroup,
       ...(this.storage ? { ownedDeleteClaimStorage: this.storage } : {}),
-    }).deleteOwnedServer(lease);
+    });
+    return context?.resourceIdentity === undefined
+      ? client.deleteOwnedServer(lease)
+      : client.deleteOwnedServer(lease, { resourceIdentity: context.resourceIdentity });
   }
 
   async finalizeLeaseCreate(
@@ -22496,8 +22513,12 @@ export class AzureProvider implements CloudProvider {
     return { config: nextConfig, lease: nextLease };
   }
 
-  async releaseLease(lease: LeaseRecord): Promise<void> {
-    await this.deleteOwnedServer(lease);
+  async releaseLease(lease: LeaseRecord, context?: ProviderReleaseContext): Promise<void> {
+    if (context === undefined) {
+      await this.deleteOwnedServer(lease);
+      return;
+    }
+    await this.deleteOwnedServer(lease, context);
   }
 
   supportsNativeImages(): boolean {

--- a/worker/src/provider-reconciliation.ts
+++ b/worker/src/provider-reconciliation.ts
@@ -27,7 +27,7 @@ export type ProviderReconciliationObservation =
 export function providerReconciliationFingerprint(
   provider: Provider,
   scope: string,
-  machine: Pick<ProviderMachine, "cloudID" | "id" | "name" | "labels">,
+  machine: Pick<ProviderMachine, "cloudID" | "id" | "name" | "labels" | "resourceIdentity">,
 ): string {
   const labels = machine.labels ?? {};
   return JSON.stringify({
@@ -42,6 +42,9 @@ export function providerReconciliationFingerprint(
     keep: labels["keep"] ?? "",
     createdAt: labels["created_at"] ?? "",
     expiresAt: labels["expires_at"] ?? "",
+    ...(machine.resourceIdentity === undefined
+      ? {}
+      : { resourceIdentity: machine.resourceIdentity }),
   });
 }
 

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -942,6 +942,7 @@ export interface ProviderMachine {
   awsRootVolumeID?: string;
   awsRootDeleteOnTermination?: boolean;
   labels: Record<string, string>;
+  resourceIdentity?: string;
   providerKey?: string;
   awsSSMCommandID?: string;
   awsSSMCommandStatus?: string;

--- a/worker/test/azure.test.ts
+++ b/worker/test/azure.test.ts
@@ -95,19 +95,34 @@ function memoryAzureDeleteClaimStorage(): {
 } {
   const records = new Map<string, unknown>();
   const putKeys: string[] = [];
+  let transactionTail = Promise.resolve();
+  const storage: AzureOwnedDeleteClaimStorage = {
+    get: async <T>(key: string) => records.get(key) as T | undefined,
+    put: async <T>(key: string, value: T) => {
+      putKeys.push(key);
+      records.set(key, value);
+    },
+    delete: async (key: string) => {
+      records.delete(key);
+    },
+    transaction: async (callback) => {
+      const previous = transactionTail;
+      let release!: () => void;
+      transactionTail = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      await previous;
+      try {
+        return await callback(storage);
+      } finally {
+        release();
+      }
+    },
+  };
   return {
     records,
     putKeys,
-    storage: {
-      get: async <T>(key: string) => records.get(key) as T | undefined,
-      put: async <T>(key: string, value: T) => {
-        putKeys.push(key);
-        records.set(key, value);
-      },
-      delete: async (key: string) => {
-        records.delete(key);
-      },
-    },
+    storage,
   };
 }
 
@@ -122,6 +137,72 @@ function azureResourceNotFoundResponse(url: URL): Response {
     }),
     { status: 404 },
   );
+}
+
+function azurePIPDiskCleanupClient(input: {
+  storage: AzureOwnedDeleteClaimStorage;
+  deleted: Set<string>;
+  deletes: string[];
+  failDelete: () => "pip" | "disk" | undefined;
+  beforeDelete?: (path: string) => Promise<void>;
+  beforeRead?: (path: string) => Promise<void>;
+}): { client: AzureClient; nicID: string; pipID: string; diskID: string } {
+  const nicID =
+    "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/networkInterfaces/crabbox-blue-lobster-nic";
+  const pipID =
+    "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/publicIPAddresses/crabbox-blue-lobster-pip";
+  const diskID =
+    "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/disks/crabbox-blue-lobster-osdisk";
+  const client = new AzureClient(baseEnv, { ownedDeleteClaimStorage: input.storage });
+  seedAzureAuthCache(client);
+  client.fetcher = async (request, init) => {
+    const url = new URL(String(request));
+    if (init?.method === "DELETE") {
+      input.deletes.push(url.pathname);
+      await input.beforeDelete?.(url.pathname);
+      const kind = url.pathname === pipID ? "pip" : url.pathname === diskID ? "disk" : undefined;
+      if (kind && input.failDelete() === kind) {
+        return new Response(`injected ${kind} interruption`, { status: 400 });
+      }
+      input.deleted.add(url.pathname);
+      return new Response(null, { status: 204 });
+    }
+    const deletedAtReadStart = input.deleted.has(url.pathname);
+    await input.beforeRead?.(url.pathname);
+    if (deletedAtReadStart) return azureResourceNotFoundResponse(url);
+    if (url.pathname === nicID) {
+      return Response.json({
+        id: nicID,
+        name: "crabbox-blue-lobster-nic",
+        location: "eastus",
+        tags: ownedAzureTags(),
+        properties: {
+          resourceGuid: "nic-immutable-id",
+          ipConfigurations: [{ properties: { publicIPAddress: { id: pipID } } }],
+        },
+      });
+    }
+    if (url.pathname === pipID) {
+      return Response.json({
+        id: pipID,
+        name: "crabbox-blue-lobster-pip",
+        location: "eastus",
+        tags: ownedAzureTags(),
+        properties: { resourceGuid: "pip-immutable-id" },
+      });
+    }
+    if (url.pathname === diskID) {
+      return Response.json({
+        id: diskID,
+        name: "crabbox-blue-lobster-osdisk",
+        location: "eastus",
+        tags: ownedAzureTags(),
+        properties: { uniqueId: "disk-immutable-id" },
+      });
+    }
+    return azureResourceNotFoundResponse(url);
+  };
+  return { client, nicID, pipID, diskID };
 }
 
 function testLeaseConfig(overrides: Partial<LeaseConfig> = {}): LeaseConfig {
@@ -771,13 +852,16 @@ describe("azure provider", () => {
       expiresAt: Date.now() + 3_600_000,
     };
     const deletes: string[] = [];
+    const deleted = new Set<string>();
     client.fetcher = async (input, init) => {
       const url = new URL(String(input));
       const method = init?.method ?? "GET";
       if (method === "DELETE") {
         deletes.push(url.pathname);
+        deleted.add(url.pathname);
         return new Response(null, { status: 204 });
       }
+      if (deleted.has(url.pathname)) return azureResourceNotFoundResponse(url);
       if (url.pathname.endsWith("/virtualMachines/crabbox-blue-lobster")) {
         return Response.json({
           id: url.pathname,
@@ -809,6 +893,7 @@ describe("azure provider", () => {
           properties: {
             ipConfigurations: [
               {
+                id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/networkInterfaces/crabbox-blue-lobster-nic/ipConfigurations/ipconfig1",
                 properties: {
                   publicIPAddress: {
                     id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/publicIPAddresses/crabbox-blue-lobster-pip",
@@ -824,6 +909,11 @@ describe("azure provider", () => {
           id: url.pathname,
           name: "crabbox-blue-lobster-pip",
           tags: ownedAzureTags(),
+          properties: {
+            ipConfiguration: {
+              id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/networkInterfaces/crabbox-blue-lobster-nic/ipConfigurations/ipconfig1",
+            },
+          },
         });
       }
       if (url.pathname.endsWith("/disks/crabbox-blue-lobster-osdisk")) {
@@ -843,6 +933,81 @@ describe("azure provider", () => {
     expect(deletes).toHaveLength(4);
   });
 
+  it("refuses to delete an Azure VM with an unexpected NIC reference", async () => {
+    const client = new AzureClient(baseEnv);
+    seedAzureAuthCache(client);
+    const deletes: string[] = [];
+    client.fetcher = async (input, init) => {
+      const url = new URL(String(input));
+      if (init?.method === "DELETE") {
+        deletes.push(url.pathname);
+        return new Response(null, { status: 204 });
+      }
+      if (url.pathname.endsWith("/virtualMachines/crabbox-blue-lobster")) {
+        return Response.json({
+          id: url.pathname,
+          name: "crabbox-blue-lobster",
+          tags: ownedAzureTags(),
+          properties: {
+            networkProfile: {
+              networkInterfaces: [
+                {
+                  id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/networkInterfaces/crabbox-blue-lobster-nic",
+                },
+                {
+                  id: "/subscriptions/sub/resourceGroups/shared/providers/Microsoft.Network/networkInterfaces/shared-nic",
+                },
+              ],
+            },
+          },
+        });
+      }
+      return azureResourceNotFoundResponse(url);
+    };
+
+    await expect(client.deleteOwnedServer(ownedAzureLease())).rejects.toThrow(
+      "VM references an unexpected NIC",
+    );
+    expect(deletes).toEqual([]);
+  });
+
+  it("refuses to delete an Azure VM when its exact canonical NIC is absent", async () => {
+    const client = new AzureClient(baseEnv);
+    seedAzureAuthCache(client);
+    const deletes: string[] = [];
+    client.fetcher = async (input, init) => {
+      const url = new URL(String(input));
+      if (init?.method === "DELETE") {
+        deletes.push(url.pathname);
+        return new Response(null, { status: 204 });
+      }
+      if (url.pathname.endsWith("/virtualMachines/crabbox-blue-lobster")) {
+        return Response.json({
+          id: url.pathname,
+          name: "crabbox-blue-lobster",
+          location: "eastus",
+          tags: ownedAzureTags(),
+          properties: {
+            vmId: "vm-immutable-id",
+            networkProfile: {
+              networkInterfaces: [
+                {
+                  id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/networkInterfaces/crabbox-blue-lobster-nic",
+                },
+              ],
+            },
+          },
+        });
+      }
+      return azureResourceNotFoundResponse(url);
+    };
+
+    await expect(client.deleteOwnedServer(ownedAzureLease())).rejects.toThrow(
+      "canonical NIC is missing",
+    );
+    expect(deletes).toEqual([]);
+  });
+
   it("scopes durable Azure cleanup claims to the exact VM attempt", async () => {
     const { putKeys, storage } = memoryAzureDeleteClaimStorage();
     for (const cloudID of ["crabbox-blue-lobster-attempt-1", "crabbox-blue-lobster-attempt-2"]) {
@@ -858,11 +1023,11 @@ describe("azure provider", () => {
       ).resolves.toBeUndefined();
     }
 
-    expect(putKeys).toHaveLength(2);
+    expect(putKeys).toHaveLength(4);
     expect(new Set(putKeys).size).toBe(2);
   });
 
-  it("cleans an exact Azure NIC and public IP set without a VM", async () => {
+  it("cleans an exact Azure NIC, public IP, and managed disk set without a VM", async () => {
     const client = new AzureClient(baseEnv);
     seedAzureAuthCache(client);
     const deleted = new Set<string>();
@@ -885,6 +1050,138 @@ describe("azure provider", () => {
           properties: {
             ipConfigurations: [
               {
+                id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/networkInterfaces/crabbox-blue-lobster-nic/ipConfigurations/ipconfig1",
+                properties: {
+                  publicIPAddress: {
+                    id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/publicIPAddresses/crabbox-blue-lobster-pip",
+                  },
+                },
+              },
+            ],
+          },
+        });
+      }
+      if (url.pathname.endsWith("/publicIPAddresses/crabbox-blue-lobster-pip")) {
+        return Response.json({
+          id: url.pathname,
+          name: "crabbox-blue-lobster-pip",
+          tags: ownedAzureTags(),
+          properties: {
+            ipConfiguration: {
+              id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/networkInterfaces/crabbox-blue-lobster-nic/ipConfigurations/ipconfig1",
+            },
+          },
+        });
+      }
+      if (url.pathname.endsWith("/disks/crabbox-blue-lobster-osdisk")) {
+        return Response.json({
+          id: url.pathname,
+          name: "crabbox-blue-lobster-osdisk",
+          tags: ownedAzureTags(),
+          properties: { uniqueId: "disk-unique-id" },
+        });
+      }
+      return azureResourceNotFoundResponse(url);
+    };
+
+    await expect(client.deleteOwnedServer(ownedAzureLease())).resolves.toBeUndefined();
+    expect(deletes).toEqual([
+      "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/networkInterfaces/crabbox-blue-lobster-nic",
+      "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/publicIPAddresses/crabbox-blue-lobster-pip",
+      "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/disks/crabbox-blue-lobster-osdisk",
+    ]);
+  });
+
+  it("releases a VM with an ephemeral OS disk and no managed disk resource", async () => {
+    const client = new AzureClient(baseEnv);
+    seedAzureAuthCache(client);
+    const deleted = new Set<string>();
+    const deletes: string[] = [];
+    const vmID =
+      "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/virtualMachines/crabbox-blue-lobster";
+    const nicID =
+      "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/networkInterfaces/crabbox-blue-lobster-nic";
+    const pipID =
+      "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/publicIPAddresses/crabbox-blue-lobster-pip";
+    client.fetcher = async (input, init) => {
+      const url = new URL(String(input));
+      if (init?.method === "DELETE") {
+        deletes.push(url.pathname);
+        deleted.add(url.pathname);
+        return new Response(null, { status: 204 });
+      }
+      if (deleted.has(url.pathname)) return azureResourceNotFoundResponse(url);
+      if (url.pathname === vmID) {
+        return Response.json({
+          id: vmID,
+          name: "crabbox-blue-lobster",
+          location: "eastus",
+          tags: ownedAzureTags(),
+          properties: {
+            vmId: "vm-immutable-id",
+            networkProfile: { networkInterfaces: [{ id: nicID }] },
+            storageProfile: { osDisk: { diffDiskSettings: { option: "Local" } } },
+          },
+        });
+      }
+      if (url.pathname === nicID) {
+        return Response.json({
+          id: nicID,
+          name: "crabbox-blue-lobster-nic",
+          location: "eastus",
+          tags: ownedAzureTags(),
+          properties: {
+            resourceGuid: "nic-immutable-id",
+            virtualMachine: { id: vmID },
+            ipConfigurations: [
+              {
+                id: `${nicID}/ipConfigurations/ipconfig1`,
+                properties: { publicIPAddress: { id: pipID } },
+              },
+            ],
+          },
+        });
+      }
+      if (url.pathname === pipID) {
+        return Response.json({
+          id: pipID,
+          name: "crabbox-blue-lobster-pip",
+          location: "eastus",
+          tags: ownedAzureTags(),
+          properties: {
+            resourceGuid: "pip-immutable-id",
+            ipConfiguration: { id: `${nicID}/ipConfigurations/ipconfig1` },
+          },
+        });
+      }
+      return azureResourceNotFoundResponse(url);
+    };
+
+    await expect(client.deleteOwnedServer(ownedAzureLease())).resolves.toBeUndefined();
+    expect(deletes).toEqual([vmID, nicID, pipID]);
+  });
+
+  it("refuses to delete a VM-less Azure NIC attached to another VM", async () => {
+    const client = new AzureClient(baseEnv);
+    seedAzureAuthCache(client);
+    const deletes: string[] = [];
+    client.fetcher = async (input, init) => {
+      const url = new URL(String(input));
+      if (init?.method === "DELETE") {
+        deletes.push(url.pathname);
+        return new Response(null, { status: 204 });
+      }
+      if (url.pathname.endsWith("/networkInterfaces/crabbox-blue-lobster-nic")) {
+        return Response.json({
+          id: url.pathname,
+          name: "crabbox-blue-lobster-nic",
+          tags: ownedAzureTags(),
+          properties: {
+            virtualMachine: {
+              id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/virtualMachines/crabbox-other",
+            },
+            ipConfigurations: [
+              {
                 properties: {
                   publicIPAddress: {
                     id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/publicIPAddresses/crabbox-blue-lobster-pip",
@@ -905,14 +1202,183 @@ describe("azure provider", () => {
       return azureResourceNotFoundResponse(url);
     };
 
-    await expect(client.deleteOwnedServer(ownedAzureLease())).resolves.toBeUndefined();
-    expect(deletes).toEqual([
-      "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/networkInterfaces/crabbox-blue-lobster-nic",
-      "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/publicIPAddresses/crabbox-blue-lobster-pip",
-    ]);
+    await expect(client.deleteOwnedServer(ownedAzureLease())).rejects.toThrow(
+      "NIC is attached to an unexpected VM",
+    );
+    expect(deletes).toEqual([]);
   });
 
-  it("cleans a fully tagged Azure disk when VM creation never completed", async () => {
+  it("refuses to delete a VM-less Azure NIC referencing a foreign public IP", async () => {
+    const client = new AzureClient(baseEnv);
+    seedAzureAuthCache(client);
+    const deletes: string[] = [];
+    client.fetcher = async (input, init) => {
+      const url = new URL(String(input));
+      if (init?.method === "DELETE") {
+        deletes.push(url.pathname);
+        return new Response(null, { status: 204 });
+      }
+      if (url.pathname.endsWith("/networkInterfaces/crabbox-blue-lobster-nic")) {
+        return Response.json({
+          id: url.pathname,
+          name: "crabbox-blue-lobster-nic",
+          tags: ownedAzureTags(),
+          properties: {
+            ipConfigurations: [
+              {
+                properties: {
+                  publicIPAddress: {
+                    id: "/subscriptions/sub/resourceGroups/shared/providers/Microsoft.Network/publicIPAddresses/shared-pip",
+                  },
+                },
+              },
+            ],
+          },
+        });
+      }
+      return azureResourceNotFoundResponse(url);
+    };
+
+    await expect(client.deleteOwnedServer(ownedAzureLease())).rejects.toThrow(
+      "NIC references an unexpected public IP",
+    );
+    expect(deletes).toEqual([]);
+  });
+
+  it("refuses to delete a VM-less Azure NIC when its canonical public IP is missing", async () => {
+    const client = new AzureClient(baseEnv);
+    seedAzureAuthCache(client);
+    const deletes: string[] = [];
+    const pipID =
+      "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/publicIPAddresses/crabbox-blue-lobster-pip";
+    client.fetcher = async (input, init) => {
+      const url = new URL(String(input));
+      if (init?.method === "DELETE") {
+        deletes.push(url.pathname);
+        return new Response(null, { status: 204 });
+      }
+      if (url.pathname.endsWith("/networkInterfaces/crabbox-blue-lobster-nic")) {
+        return Response.json({
+          id: url.pathname,
+          name: "crabbox-blue-lobster-nic",
+          tags: ownedAzureTags(),
+          properties: {
+            ipConfigurations: [
+              {
+                properties: {
+                  publicIPAddress: { id: pipID },
+                },
+              },
+            ],
+          },
+        });
+      }
+      return azureResourceNotFoundResponse(url);
+    };
+
+    await expect(client.deleteOwnedServer(ownedAzureLease())).rejects.toThrow(
+      "NIC references an unexpected public IP",
+    );
+    expect(deletes).toEqual([]);
+  });
+
+  it("refuses to delete a VM-less Azure public IP attached to another resource", async () => {
+    const client = new AzureClient(baseEnv);
+    seedAzureAuthCache(client);
+    const deletes: string[] = [];
+    client.fetcher = async (input, init) => {
+      const url = new URL(String(input));
+      if (init?.method === "DELETE") {
+        deletes.push(url.pathname);
+        return new Response(null, { status: 204 });
+      }
+      if (url.pathname.endsWith("/publicIPAddresses/crabbox-blue-lobster-pip")) {
+        return Response.json({
+          id: url.pathname,
+          name: "crabbox-blue-lobster-pip",
+          tags: ownedAzureTags(),
+          properties: {
+            ipConfiguration: {
+              id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/loadBalancers/other/frontendIPConfigurations/frontend",
+            },
+          },
+        });
+      }
+      return azureResourceNotFoundResponse(url);
+    };
+
+    await expect(client.deleteOwnedServer(ownedAzureLease())).rejects.toThrow(
+      "public IP is attached to an unexpected configuration",
+    );
+    expect(deletes).toEqual([]);
+  });
+
+  it("refuses to delete a VM-less Azure public IP attached to a NAT gateway", async () => {
+    const client = new AzureClient(baseEnv);
+    seedAzureAuthCache(client);
+    const deletes: string[] = [];
+    client.fetcher = async (input, init) => {
+      const url = new URL(String(input));
+      if (init?.method === "DELETE") {
+        deletes.push(url.pathname);
+        return new Response(null, { status: 204 });
+      }
+      if (url.pathname.endsWith("/publicIPAddresses/crabbox-blue-lobster-pip")) {
+        return Response.json({
+          id: url.pathname,
+          name: "crabbox-blue-lobster-pip",
+          tags: ownedAzureTags(),
+          properties: {
+            natGateway: {
+              id: "/subscriptions/sub/resourceGroups/shared/providers/Microsoft.Network/natGateways/shared-nat",
+            },
+          },
+        });
+      }
+      return azureResourceNotFoundResponse(url);
+    };
+
+    await expect(client.deleteOwnedServer(ownedAzureLease())).rejects.toThrow(
+      "public IP is attached to an unexpected configuration",
+    );
+    expect(deletes).toEqual([]);
+  });
+
+  it.each(["linkedPublicIPAddress", "servicePublicIPAddress"] as const)(
+    "refuses to delete a VM-less Azure public IP with a %s attachment",
+    async (attachment) => {
+      const client = new AzureClient(baseEnv);
+      seedAzureAuthCache(client);
+      const deletes: string[] = [];
+      client.fetcher = async (input, init) => {
+        const url = new URL(String(input));
+        if (init?.method === "DELETE") {
+          deletes.push(url.pathname);
+          return new Response(null, { status: 204 });
+        }
+        if (url.pathname.endsWith("/publicIPAddresses/crabbox-blue-lobster-pip")) {
+          return Response.json({
+            id: url.pathname,
+            name: "crabbox-blue-lobster-pip",
+            tags: ownedAzureTags(),
+            properties: {
+              [attachment]: {
+                id: "/subscriptions/sub/resourceGroups/shared/providers/Microsoft.Network/publicIPAddresses/shared-pip",
+              },
+            },
+          });
+        }
+        return azureResourceNotFoundResponse(url);
+      };
+
+      await expect(client.deleteOwnedServer(ownedAzureLease())).rejects.toThrow(
+        "public IP is attached to an unexpected configuration",
+      );
+      expect(deletes).toEqual([]);
+    },
+  );
+
+  it("keeps a lone fully tagged Azure disk report-only", async () => {
     const { storage } = memoryAzureDeleteClaimStorage();
     const client = new AzureClient(baseEnv, { ownedDeleteClaimStorage: storage });
     seedAzureAuthCache(client);
@@ -934,10 +1400,362 @@ describe("azure provider", () => {
       return azureResourceNotFoundResponse(url);
     };
 
-    await expect(client.deleteOwnedServer(ownedAzureLease())).resolves.toBeUndefined();
-    expect(deletes).toEqual([
-      "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/disks/crabbox-blue-lobster-osdisk",
+    await expect(client.deleteOwnedServer(ownedAzureLease())).rejects.toThrow(
+      "canonical companion set is incomplete",
+    );
+    expect(deletes).toEqual([]);
+  });
+
+  it("refuses to delete a disk attached through managedByExtended", async () => {
+    const client = new AzureClient(baseEnv);
+    seedAzureAuthCache(client);
+    const deletes: string[] = [];
+    client.fetcher = async (input, init) => {
+      const url = new URL(String(input));
+      if (init?.method === "DELETE") {
+        deletes.push(url.pathname);
+        return new Response(null, { status: 204 });
+      }
+      if (url.pathname.endsWith("/disks/crabbox-blue-lobster-osdisk")) {
+        return Response.json({
+          id: url.pathname,
+          name: "crabbox-blue-lobster-osdisk",
+          managedByExtended: [
+            "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/virtualMachines/crabbox-other",
+          ],
+          tags: ownedAzureTags(),
+          properties: { uniqueId: "disk-unique-id" },
+        });
+      }
+      return azureResourceNotFoundResponse(url);
+    };
+
+    await expect(client.deleteOwnedServer(ownedAzureLease())).rejects.toThrow(
+      "live association does not match lease",
+    );
+    expect(deletes).toEqual([]);
+  });
+
+  it("blocks replacement identities after a durable Azure cleanup claim", async () => {
+    const { records, storage } = memoryAzureDeleteClaimStorage();
+    const client = new AzureClient(baseEnv, { ownedDeleteClaimStorage: storage });
+    seedAzureAuthCache(client);
+    let vmImmutableID = "vm-original-id";
+    let vmDataDisks = [
+      {
+        name: "shared-data",
+        lun: 0,
+        deleteOption: "Delete",
+        managedDisk: {
+          id: "/subscriptions/sub/resourceGroups/shared/providers/Microsoft.Compute/disks/shared-data",
+        },
+      },
+    ];
+    let vmOSDiskDeleteOption: string | undefined;
+    let vmNICDeleteOption: string | undefined;
+    let nicPIPDeleteOption: string | undefined;
+    let resourceTags = ownedAzureTags();
+    let failDelete = true;
+    const deleted = new Set<string>();
+    const deletes: string[] = [];
+    const canonicalVMID =
+      "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/virtualMachines/crabbox-blue-lobster";
+    const canonicalNICID =
+      "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/networkInterfaces/crabbox-blue-lobster-nic";
+    const canonicalPIPID =
+      "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/publicIPAddresses/crabbox-blue-lobster-pip";
+    const canonicalDiskID =
+      "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/disks/crabbox-blue-lobster-osdisk";
+    client.fetcher = async (input, init) => {
+      const url = new URL(String(input));
+      if (init?.method === "DELETE") {
+        deletes.push(url.pathname);
+        if (failDelete) {
+          return new Response("interrupted", { status: 400 });
+        }
+        deleted.add(url.pathname);
+        return new Response(null, { status: 204 });
+      }
+      if (deleted.has(url.pathname)) {
+        return azureResourceNotFoundResponse(url);
+      }
+      if (url.pathname.endsWith("/virtualMachines/crabbox-blue-lobster")) {
+        return Response.json({
+          id: url.pathname,
+          name: "crabbox-blue-lobster",
+          location: "eastus",
+          tags: resourceTags,
+          properties: {
+            vmId: vmImmutableID,
+            networkProfile: {
+              networkInterfaces: [
+                {
+                  id: canonicalNICID,
+                  ...(vmNICDeleteOption ? { deleteOption: vmNICDeleteOption } : {}),
+                },
+              ],
+            },
+            storageProfile: {
+              osDisk: {
+                managedDisk: { id: canonicalDiskID },
+                ...(vmOSDiskDeleteOption ? { deleteOption: vmOSDiskDeleteOption } : {}),
+              },
+              dataDisks: vmDataDisks,
+            },
+          },
+        });
+      }
+      if (url.pathname.endsWith("/networkInterfaces/crabbox-blue-lobster-nic")) {
+        return Response.json({
+          id: url.pathname,
+          name: "crabbox-blue-lobster-nic",
+          location: "eastus",
+          tags: resourceTags,
+          properties: {
+            resourceGuid: "nic-immutable-id",
+            virtualMachine: { id: canonicalVMID },
+            ipConfigurations: [
+              {
+                id: `${canonicalNICID}/ipConfigurations/ipconfig1`,
+                properties: {
+                  publicIPAddress: {
+                    id: canonicalPIPID,
+                    ...(nicPIPDeleteOption ? { deleteOption: nicPIPDeleteOption } : {}),
+                  },
+                },
+              },
+            ],
+          },
+        });
+      }
+      if (url.pathname.endsWith("/publicIPAddresses/crabbox-blue-lobster-pip")) {
+        return Response.json({
+          id: canonicalPIPID,
+          name: "crabbox-blue-lobster-pip",
+          location: "eastus",
+          tags: resourceTags,
+          properties: {
+            resourceGuid: "pip-immutable-id",
+            ipConfiguration: { id: `${canonicalNICID}/ipConfigurations/ipconfig1` },
+          },
+        });
+      }
+      if (url.pathname.endsWith("/disks/crabbox-blue-lobster-osdisk")) {
+        return Response.json({
+          id: canonicalDiskID,
+          name: "crabbox-blue-lobster-osdisk",
+          location: "eastus",
+          managedBy: canonicalVMID,
+          tags: resourceTags,
+          properties: { uniqueId: "disk-immutable-id" },
+        });
+      }
+      return azureResourceNotFoundResponse(url);
+    };
+
+    await expect(client.deleteOwnedServer(ownedAzureLease())).rejects.toThrow(
+      "VM has unexpected data disks",
+    );
+    expect(records.size).toBe(1);
+    expect(deletes).toEqual([]);
+
+    vmDataDisks = [];
+    vmOSDiskDeleteOption = "Delete";
+    await expect(client.deleteOwnedServer(ownedAzureLease())).rejects.toThrow(
+      "VM has cascading delete options",
+    );
+    vmOSDiskDeleteOption = undefined;
+    vmNICDeleteOption = "Delete";
+    await expect(client.deleteOwnedServer(ownedAzureLease())).rejects.toThrow(
+      "VM has cascading delete options",
+    );
+    vmNICDeleteOption = undefined;
+    nicPIPDeleteOption = "Delete";
+    await expect(client.deleteOwnedServer(ownedAzureLease())).rejects.toThrow(
+      "NIC has cascading delete options",
+    );
+    nicPIPDeleteOption = undefined;
+    expect(deletes).toEqual([]);
+
+    await expect(client.deleteOwnedServer(ownedAzureLease())).rejects.toThrow("delete vm");
+    expect(records.size).toBe(1);
+    const [claimKey, storedClaim] = [...records.entries()][0] as [
+      string,
+      { stableResourceIdentity: string },
+    ];
+    const labelIdentity = JSON.stringify({
+      crabbox: "true",
+      created_by: "crabbox",
+      lease: "cbx_abcdef123456",
+      owner: "alice_example.com",
+      provider: "azure",
+      provider_key: "",
+      slug: "blue-lobster",
+      keep: "",
+      created_at: "",
+      expires_at: "",
+    });
+    const stableResourceIdentity = storedClaim.stableResourceIdentity;
+    const observedResourceIdentity = JSON.stringify(
+      (JSON.parse(storedClaim.stableResourceIdentity) as Array<Record<string, unknown>>).map(
+        (entry) => ({ ...entry, labels: labelIdentity }),
+      ),
+    );
+    expect(observedResourceIdentity).toEqual(expect.any(String));
+    records.set(claimKey, { ...storedClaim, resourceIdentity: observedResourceIdentity });
+
+    resourceTags = ownedAzureTags({ keep: "true" });
+    await expect(
+      client.deleteOwnedServer(ownedAzureLease(), { resourceIdentity: observedResourceIdentity }),
+    ).rejects.toThrow("observed resource labels changed");
+    expect(deletes).toHaveLength(1);
+
+    resourceTags = ownedAzureTags();
+    records.set(claimKey, storedClaim);
+    vmImmutableID = "vm-replacement-id";
+    await expect(
+      client.deleteOwnedServer(ownedAzureLease(), { resourceIdentity: stableResourceIdentity }),
+    ).rejects.toThrow("observed resource identity changed");
+    expect(deletes).toHaveLength(1);
+
+    failDelete = false;
+    const replacementResourceIdentity = stableResourceIdentity.replace(
+      "vm-original-id",
+      "vm-replacement-id",
+    );
+    await expect(
+      client.deleteOwnedServer(ownedAzureLease(), {
+        resourceIdentity: replacementResourceIdentity,
+      }),
+    ).resolves.toBeUndefined();
+    expect(records.size).toBe(0);
+    expect(deletes).toHaveLength(5);
+    expect(deleted.size).toBe(4);
+  });
+
+  it("preserves verified partial evidence when Azure cleanup identities change", async () => {
+    const { records, storage } = memoryAzureDeleteClaimStorage();
+    const deleted = new Set<string>();
+    const deletes: string[] = [];
+    let failNICDelete = true;
+    const vmID =
+      "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/virtualMachines/crabbox-blue-lobster";
+    const nicID =
+      "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/networkInterfaces/crabbox-blue-lobster-nic";
+    const pipID =
+      "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/publicIPAddresses/crabbox-blue-lobster-pip";
+    const diskID =
+      "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/disks/crabbox-blue-lobster-osdisk";
+    const observedResourceIdentity = JSON.stringify([
+      {
+        kind: "networkInterfaces",
+        id: nicID.toLowerCase(),
+        immutableID: "nic-immutable-id",
+        location: "eastus",
+        topology: {
+          virtualMachineID: vmID.toLowerCase(),
+          publicIPIDs: [pipID.toLowerCase()],
+          privateEndpointIDs: [],
+          privateLinkServiceIDs: [],
+          hostedWorkloadIDs: [],
+          loadBalancerBackendAddressPoolIDs: [],
+          applicationGatewayBackendAddressPoolIDs: [],
+          loadBalancerInboundNatRuleIDs: [],
+          privateLinkConnectionIDs: [],
+          virtualNetworkTapIDs: [],
+          gatewayLoadBalancerIDs: [],
+        },
+      },
+      {
+        kind: "publicIPAddresses",
+        id: pipID.toLowerCase(),
+        immutableID: "pip-immutable-id",
+        location: "eastus",
+        topology: {
+          ipConfigurationID: `${nicID}/ipConfigurations/ipconfig1`.toLowerCase(),
+          natGatewayID: "",
+          linkedPublicIPAddressID: "",
+          servicePublicIPAddressID: "",
+        },
+      },
+      {
+        kind: "disks",
+        id: diskID.toLowerCase(),
+        immutableID: "disk-immutable-id",
+        location: "eastus",
+        topology: { managedBy: "", managedByExtended: [] },
+      },
     ]);
+    const client = new AzureClient(baseEnv, { ownedDeleteClaimStorage: storage });
+    seedAzureAuthCache(client);
+    client.fetcher = async (input, init) => {
+      const url = new URL(String(input));
+      const method = init?.method ?? "GET";
+      if (method === "DELETE") {
+        deletes.push(url.pathname);
+        if (failNICDelete && url.pathname === nicID) {
+          return new Response("injected NIC interruption", { status: 400 });
+        }
+        deleted.add(url.pathname);
+        return new Response(null, { status: 204 });
+      }
+      if (deleted.has(url.pathname)) return azureResourceNotFoundResponse(url);
+      const isVM = url.pathname === vmID;
+      const isNIC = url.pathname === nicID;
+      const isPIP = url.pathname === pipID;
+      const isDisk = url.pathname === diskID;
+      if (!isVM && !isNIC && !isPIP && !isDisk) return azureResourceNotFoundResponse(url);
+      const properties = isVM
+        ? {
+            vmId: "vm-immutable-id",
+            networkProfile: { networkInterfaces: [{ id: nicID }] },
+            storageProfile: { osDisk: { managedDisk: { id: diskID } } },
+          }
+        : isNIC
+          ? {
+              resourceGuid: "nic-immutable-id",
+              virtualMachine: { id: vmID },
+              ipConfigurations: [
+                {
+                  id: `${nicID}/ipConfigurations/ipconfig1`,
+                  properties: { publicIPAddress: { id: pipID } },
+                },
+              ],
+            }
+          : isPIP
+            ? {
+                resourceGuid: "pip-immutable-id",
+                ipConfiguration: { id: `${nicID}/ipConfigurations/ipconfig1` },
+              }
+            : { uniqueId: "disk-immutable-id" };
+      return Response.json({
+        id: url.pathname,
+        name: url.pathname.slice(url.pathname.lastIndexOf("/") + 1),
+        location: "eastus",
+        managedBy: isDisk && !deleted.has(vmID) ? vmID : undefined,
+        tags: ownedAzureTags(),
+        properties,
+      });
+    };
+
+    await expect(client.deleteOwnedServer(ownedAzureLease())).rejects.toThrow(
+      "injected NIC interruption",
+    );
+    expect(deleted).toEqual(new Set([vmID]));
+
+    await expect(
+      client.deleteOwnedServer(ownedAzureLease(), { resourceIdentity: observedResourceIdentity }),
+    ).rejects.toThrow("injected NIC interruption");
+    const storedClaim = [...records.values()][0] as Record<string, unknown>;
+    expect(storedClaim.partialStableResourceIdentity).toEqual(expect.any(String));
+    expect(deletes).toEqual([vmID, nicID, nicID]);
+
+    failNICDelete = false;
+    await expect(
+      client.deleteOwnedServer(ownedAzureLease(), { resourceIdentity: observedResourceIdentity }),
+    ).resolves.toBeUndefined();
+    expect(records.size).toBe(0);
+    expect(deleted).toEqual(new Set([vmID, nicID, pipID, diskID]));
   });
 
   it("keeps durable cleanup claim storage on regional Azure fallback clients", () => {
@@ -991,6 +1809,14 @@ describe("azure provider", () => {
           },
         });
       }
+      if (url.pathname.includes("/networkInterfaces/")) {
+        return Response.json({
+          id: url.pathname,
+          name: "crabbox-blue-lobster-nic",
+          tags: ownedAzureTags(),
+          properties: { ipConfigurations: [] },
+        });
+      }
       return azureResourceNotFoundResponse(url);
     };
 
@@ -1000,8 +1826,8 @@ describe("azure provider", () => {
     expect(deletes).toEqual([]);
   });
 
-  it("resumes verified Azure companion cleanup from a durable claim after the VM is gone", async () => {
-    const { records, storage } = memoryAzureDeleteClaimStorage();
+  it("resumes verified Azure companion cleanup but rejects a legacy partial claim", async () => {
+    const { records, putKeys, storage } = memoryAzureDeleteClaimStorage();
     const deleted = new Set<string>();
     const deletes: string[] = [];
     let failNICDelete = true;
@@ -1057,6 +1883,9 @@ describe("azure provider", () => {
             }
           : isNIC
             ? {
+                virtualMachine: {
+                  id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/virtualMachines/crabbox-blue-lobster",
+                },
                 ipConfigurations: [
                   {
                     properties: {
@@ -1094,11 +1923,289 @@ describe("azure provider", () => {
     expect(deleted.size).toBe(1);
     expect([...deleted][0]).toContain("/virtualMachines/");
 
+    const [claimKey, storedClaim] = [...records.entries()][0]!;
+    records.set(claimKey, {
+      ...(storedClaim as Record<string, unknown>),
+      version: 1,
+      preparing: undefined,
+      resourceIdentity: undefined,
+      stableResourceIdentity: undefined,
+      deletedStableResourceIdentity: undefined,
+    });
+    const writesBeforeLegacyReplay = putKeys.length;
+    await expect(client().deleteOwnedServer(ownedAzureLease())).rejects.toThrow(
+      "NIC is attached to an unexpected VM",
+    );
+    expect(putKeys).toHaveLength(writesBeforeLegacyReplay + 1);
+    expect([...records.values()][0]).toMatchObject({
+      stableResourceIdentity: undefined,
+      deletedStableResourceIdentity: undefined,
+    });
+
+    records.set(claimKey, storedClaim);
     failNICDelete = false;
     await expect(client().deleteOwnedServer(ownedAzureLease())).resolves.toBeUndefined();
     expect(records.size).toBe(0);
     expect(deletes.filter((path) => path.includes("/virtualMachines/"))).toHaveLength(1);
     expect(deleted.size).toBe(4);
+  });
+
+  it("does not clear a newer claim transition after observing an empty legacy set", async () => {
+    const { records, putKeys, storage } = memoryAzureDeleteClaimStorage();
+    const seed = new AzureClient(baseEnv, { ownedDeleteClaimStorage: storage });
+    seedAzureAuthCache(seed);
+    seed.fetcher = async (input) => azureResourceNotFoundResponse(new URL(String(input)));
+    await seed.deleteOwnedServer(ownedAzureLease());
+    const claimKey = putKeys[0]!;
+    records.set(claimKey, {
+      version: 1,
+      provider: "azure",
+      leaseID: "cbx_abcdef123456",
+      slug: "blue-lobster",
+      owner: "alice@example.com",
+      cloudID: "crabbox-blue-lobster",
+      providerScope: "/subscriptions/sub/resourceGroups/crabbox-leases",
+    });
+
+    let releaseRead!: () => void;
+    const readGate = new Promise<void>((resolve) => {
+      releaseRead = resolve;
+    });
+    let signalRead!: () => void;
+    const readStarted = new Promise<void>((resolve) => {
+      signalRead = resolve;
+    });
+    let pendingRead = true;
+    const client = new AzureClient(baseEnv, { ownedDeleteClaimStorage: storage });
+    seedAzureAuthCache(client);
+    client.fetcher = async (input) => {
+      const url = new URL(String(input));
+      if (pendingRead && url.pathname.includes("/networkInterfaces/")) {
+        pendingRead = false;
+        signalRead();
+        await readGate;
+      }
+      return azureResourceNotFoundResponse(url);
+    };
+    const cleanup = client.deleteOwnedServer(ownedAzureLease());
+    await readStarted;
+    const newerPreparation = {
+      version: 2,
+      provider: "azure",
+      leaseID: "cbx_abcdef123456",
+      slug: "blue-lobster",
+      owner: "alice@example.com",
+      cloudID: "crabbox-blue-lobster",
+      providerScope: "/subscriptions/sub/resourceGroups/crabbox-leases",
+      preparing: true,
+    };
+    records.set(claimKey, newerPreparation);
+    releaseRead();
+
+    await expect(cleanup).rejects.toThrow("durable cleanup claim changed");
+    expect(records.get(claimKey)).toEqual(newerPreparation);
+  });
+
+  it("rejects an absent PIP after its durable deletion attempt failed", async () => {
+    const { records, storage } = memoryAzureDeleteClaimStorage();
+    const deleted = new Set<string>();
+    const deletes: string[] = [];
+    let failure: "pip" | "disk" | undefined = "pip";
+    const first = azurePIPDiskCleanupClient({
+      storage,
+      deleted,
+      deletes,
+      failDelete: () => failure,
+    });
+
+    await expect(first.client.deleteOwnedServer(ownedAzureLease())).rejects.toThrow(
+      "injected pip interruption",
+    );
+    expect(deletes).toEqual([first.nicID, first.pipID]);
+
+    deleted.add(first.pipID);
+    failure = undefined;
+    const retry = azurePIPDiskCleanupClient({
+      storage,
+      deleted,
+      deletes,
+      failDelete: () => failure,
+    });
+    await expect(retry.client.deleteOwnedServer(ownedAzureLease())).rejects.toThrow(
+      "observed resource identity changed",
+    );
+    expect(deletes).toEqual([first.nicID, first.pipID]);
+    expect(deleted.has(first.diskID)).toBe(false);
+    expect(records.size).toBe(1);
+  });
+
+  it("rejects an absent PIP when its successful deletion progress was not persisted", async () => {
+    const memory = memoryAzureDeleteClaimStorage();
+    const deleted = new Set<string>();
+    const deletes: string[] = [];
+    const put = async <T>(key: string, value: T) => {
+      const progress = (value as { deletedStableResourceIdentity?: string })
+        .deletedStableResourceIdentity;
+      if (progress?.includes("pip-immutable-id")) {
+        throw new Error("injected progress write interruption");
+      }
+      await memory.storage.put(key, value);
+    };
+    const storage: AzureOwnedDeleteClaimStorage = {
+      get: memory.storage.get.bind(memory.storage),
+      put,
+      delete: memory.storage.delete.bind(memory.storage),
+      transaction: async (callback) => await callback(storage),
+    };
+    const first = azurePIPDiskCleanupClient({
+      storage,
+      deleted,
+      deletes,
+      failDelete: () => undefined,
+    });
+
+    await expect(first.client.deleteOwnedServer(ownedAzureLease())).rejects.toThrow(
+      "injected progress write interruption",
+    );
+    expect(deleted).toEqual(new Set([first.nicID, first.pipID]));
+
+    const retry = azurePIPDiskCleanupClient({
+      storage: memory.storage,
+      deleted,
+      deletes,
+      failDelete: () => undefined,
+    });
+    await expect(retry.client.deleteOwnedServer(ownedAzureLease())).rejects.toThrow(
+      "observed resource identity changed",
+    );
+    expect(deletes).toEqual([first.nicID, first.pipID]);
+    expect(deleted.has(first.diskID)).toBe(false);
+    expect(memory.records.size).toBe(1);
+  });
+
+  it("continues after the exact PIP deletion identity is durably verified", async () => {
+    const { records, storage } = memoryAzureDeleteClaimStorage();
+    const deleted = new Set<string>();
+    const deletes: string[] = [];
+    let failure: "pip" | "disk" | undefined = "disk";
+    const first = azurePIPDiskCleanupClient({
+      storage,
+      deleted,
+      deletes,
+      failDelete: () => failure,
+    });
+
+    await expect(first.client.deleteOwnedServer(ownedAzureLease())).rejects.toThrow(
+      "injected disk interruption",
+    );
+    const claim = [...records.values()][0] as { deletedStableResourceIdentity?: string };
+    expect(claim.deletedStableResourceIdentity).toContain("pip-immutable-id");
+    expect(deleted).toEqual(new Set([first.nicID, first.pipID]));
+
+    failure = undefined;
+    const retry = azurePIPDiskCleanupClient({
+      storage,
+      deleted,
+      deletes,
+      failDelete: () => failure,
+    });
+    await expect(retry.client.deleteOwnedServer(ownedAzureLease())).resolves.toBeUndefined();
+    expect(deletes).toEqual([first.nicID, first.pipID, first.diskID, first.diskID]);
+    expect(deleted).toEqual(new Set([first.nicID, first.pipID, first.diskID]));
+    expect(records.size).toBe(0);
+  });
+
+  it("merges concurrent deletion progress without regressing a longer prefix", async () => {
+    const { records, storage } = memoryAzureDeleteClaimStorage();
+    const deleted = new Set<string>();
+    const deletes: string[] = [];
+    let releaseSlowNIC!: () => void;
+    const slowNICGate = new Promise<void>((resolve) => {
+      releaseSlowNIC = resolve;
+    });
+    let signalSlowNIC!: () => void;
+    const slowNICStarted = new Promise<void>((resolve) => {
+      signalSlowNIC = resolve;
+    });
+    let slowNICPending = true;
+    const slow = azurePIPDiskCleanupClient({
+      storage,
+      deleted,
+      deletes,
+      failDelete: () => "disk",
+      beforeDelete: async (path) => {
+        if (slowNICPending && path.includes("/networkInterfaces/")) {
+          slowNICPending = false;
+          signalSlowNIC();
+          await slowNICGate;
+        }
+      },
+    });
+    const slowResult = slow.client.deleteOwnedServer(ownedAzureLease());
+    await slowNICStarted;
+
+    const fast = azurePIPDiskCleanupClient({
+      storage,
+      deleted,
+      deletes,
+      failDelete: () => "disk",
+    });
+    await expect(fast.client.deleteOwnedServer(ownedAzureLease())).rejects.toThrow(
+      "injected disk interruption",
+    );
+
+    releaseSlowNIC();
+    await expect(slowResult).rejects.toThrow("injected disk interruption");
+    const claim = [...records.values()][0] as { deletedStableResourceIdentity?: string };
+    expect(claim.deletedStableResourceIdentity).toContain("nic-immutable-id");
+    expect(claim.deletedStableResourceIdentity).toContain("pip-immutable-id");
+    expect(deleted.has(slow.diskID)).toBe(false);
+  });
+
+  it("does not let a delayed claim preparation overwrite concurrent progress", async () => {
+    const { records, storage } = memoryAzureDeleteClaimStorage();
+    const deleted = new Set<string>();
+    const deletes: string[] = [];
+    let releasePreparation!: () => void;
+    const preparationGate = new Promise<void>((resolve) => {
+      releasePreparation = resolve;
+    });
+    let signalPreparation!: () => void;
+    const preparationStarted = new Promise<void>((resolve) => {
+      signalPreparation = resolve;
+    });
+    let preparationPending = true;
+    const slow = azurePIPDiskCleanupClient({
+      storage,
+      deleted,
+      deletes,
+      failDelete: () => "disk",
+      beforeRead: async (path) => {
+        if (preparationPending && path.includes("/networkInterfaces/")) {
+          preparationPending = false;
+          signalPreparation();
+          await preparationGate;
+        }
+      },
+    });
+    const slowResult = slow.client.deleteOwnedServer(ownedAzureLease());
+    await preparationStarted;
+
+    const fast = azurePIPDiskCleanupClient({
+      storage,
+      deleted,
+      deletes,
+      failDelete: () => "disk",
+    });
+    await expect(fast.client.deleteOwnedServer(ownedAzureLease())).rejects.toThrow(
+      "injected disk interruption",
+    );
+
+    releasePreparation();
+    await expect(slowResult).rejects.toThrow("injected disk interruption");
+    const claim = [...records.values()][0] as { deletedStableResourceIdentity?: string };
+    expect(claim.deletedStableResourceIdentity).toContain("pip-immutable-id");
+    expect(deleted.has(slow.diskID)).toBe(false);
   });
 
   it("refuses all Azure deletion when a companion belongs to another lease", async () => {
@@ -1159,6 +2266,103 @@ describe("azure provider", () => {
     expect(deletes).toEqual([]);
   });
 
+  it("blocks Azure NIC service associations before any destructive request", async () => {
+    const cases = [
+      {
+        privateEndpoint: undefined,
+        ipConfigurationProperties: {
+          loadBalancerBackendAddressPools: [
+            {
+              id: "/subscriptions/sub/resourceGroups/shared/providers/Microsoft.Network/loadBalancers/shared/backendAddressPools/pool",
+            },
+          ],
+        },
+      },
+      {
+        privateEndpoint: undefined,
+        ipConfigurationProperties: {
+          applicationGatewayBackendAddressPools: [
+            {
+              id: "/subscriptions/sub/resourceGroups/shared/providers/Microsoft.Network/applicationGateways/shared/backendAddressPools/pool",
+            },
+          ],
+        },
+      },
+      {
+        privateEndpoint: undefined,
+        ipConfigurationProperties: {
+          applicationSecurityGroups: [
+            {
+              id: "/subscriptions/sub/resourceGroups/shared/providers/Microsoft.Network/applicationSecurityGroups/shared",
+            },
+          ],
+        },
+      },
+      {
+        privateEndpoint: undefined,
+        ipConfigurationProperties: {
+          loadBalancerInboundNatRules: [
+            {
+              id: "/subscriptions/sub/resourceGroups/shared/providers/Microsoft.Network/loadBalancers/shared/inboundNatRules/rule",
+            },
+          ],
+        },
+      },
+      {
+        ipConfigurationProperties: undefined,
+        privateEndpoint: {
+          id: "/subscriptions/sub/resourceGroups/shared/providers/Microsoft.Network/privateEndpoints/shared",
+        },
+      },
+    ];
+
+    await Promise.all(
+      cases.map(async ({ ipConfigurationProperties, privateEndpoint }) => {
+        const client = new AzureClient(baseEnv);
+        seedAzureAuthCache(client);
+        const deletes: string[] = [];
+        const nicID =
+          "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/networkInterfaces/crabbox-blue-lobster-nic";
+        const pipID =
+          "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/publicIPAddresses/crabbox-blue-lobster-pip";
+        client.fetcher = async (input, init) => {
+          const url = new URL(String(input));
+          if (init?.method === "DELETE") {
+            deletes.push(url.pathname);
+            return new Response(null, { status: 204 });
+          }
+          if (url.pathname.includes("/networkInterfaces/")) {
+            return Response.json({
+              id: url.pathname,
+              name: "crabbox-blue-lobster-nic",
+              location: "eastus",
+              tags: ownedAzureTags(),
+              properties: {
+                resourceGuid: "nic-immutable-id",
+                ...(privateEndpoint ? { privateEndpoint } : {}),
+                ipConfigurations: [
+                  {
+                    id: `${nicID}/ipConfigurations/ipconfig1`,
+                    properties: {
+                      publicIPAddress: { id: pipID },
+                      ...ipConfigurationProperties,
+                    },
+                  },
+                ],
+              },
+            });
+          }
+          return azureResourceNotFoundResponse(url);
+        };
+
+        await expect(client.deleteOwnedServer(ownedAzureLease())).rejects.toThrow(
+          "NIC has an unexpected service association",
+        );
+        expect(deletes).toEqual([]);
+      }),
+    );
+  });
+
   it("binds an untagged Azure OS disk through the verified live VM before deletion", async () => {
     const client = new AzureClient(baseEnv);
     (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
@@ -1166,12 +2370,17 @@ describe("azure provider", () => {
       expiresAt: Date.now() + 3_600_000,
     };
     let diskTagged = false;
+    const deleted = new Set<string>();
     const methods: string[] = [];
     client.fetcher = async (input, init) => {
       const url = new URL(String(input));
       const method = init?.method ?? "GET";
       methods.push(`${method} ${url.pathname}`);
-      if (method === "DELETE") return new Response(null, { status: 204 });
+      if (method === "DELETE") {
+        deleted.add(url.pathname);
+        return new Response(null, { status: 204 });
+      }
+      if (deleted.has(url.pathname)) return azureResourceNotFoundResponse(url);
       if (method === "PATCH") {
         diskTagged = true;
         return Response.json({});
@@ -2811,5 +4020,390 @@ describe("azure provider", () => {
     expect(machines).toHaveLength(1);
     expect(machines[0]?.name).toBe("kept");
     expect(machines[0]?.host).toBe("1.2.3.4");
+  });
+
+  it("keeps a VM with a missing canonical NIC report-only in reconciliation", async () => {
+    const client = new AzureClient(baseEnv);
+    const cloudID = "crabbox-blue-lobster";
+    const resourcePrefix = "/subscriptions/sub/resourceGroups/crabbox-leases/providers";
+    const vmID = `${resourcePrefix}/Microsoft.Compute/virtualMachines/${cloudID}`;
+    const nicID = `${resourcePrefix}/Microsoft.Network/networkInterfaces/${cloudID}-nic`;
+    client.fetcher = async (input) => {
+      const url = new URL(String(input));
+      if (isAzureLoginURL(url.toString())) {
+        return Response.json({ access_token: "tkn", expires_in: 3600 });
+      }
+      if (url.pathname.endsWith("/virtualMachines")) {
+        return Response.json({
+          value: [
+            {
+              id: vmID,
+              name: cloudID,
+              location: "eastus",
+              tags: ownedAzureTags(),
+              properties: {
+                vmId: "vm-immutable-id",
+                networkProfile: { networkInterfaces: [{ id: nicID }] },
+              },
+            },
+          ],
+        });
+      }
+      if (
+        url.pathname.endsWith("/networkInterfaces") ||
+        url.pathname.endsWith("/publicIPAddresses") ||
+        url.pathname.endsWith("/disks")
+      ) {
+        return Response.json({ value: [] });
+      }
+      return new Response("unexpected request", { status: 500 });
+    };
+
+    const machines = await client.listReconciliationResources();
+    expect(machines).toHaveLength(1);
+    expect(machines[0]?.labels["lease"]).toBe("");
+    expect(machines[0]?.resourceIdentity).toContain("vm-immutable-id");
+  });
+
+  it("lists VM-less Azure resources and rejects mixed ownership and topology", async () => {
+    const client = new AzureClient(baseEnv);
+    const cloudID = "crabbox-blue-lobster";
+    const tags = ownedAzureTags({ server_type: "Standard_D4ads_v6" });
+    let publicIPTags = tags;
+    let nicVirtualMachineID: string | undefined;
+    let nicPublicIPID: string | undefined;
+    let nicLocation = "eastus";
+    let nicResourceGuid = "nic-immutable-id";
+    let publicIPConfigurationID: string | undefined;
+    let publicIPNatGatewayID: string | undefined;
+    let includeNIC = true;
+    let includePublicIP = true;
+    let includeDisk = true;
+    let includeVMWithDataDisk = false;
+    let diskManagedBy: string | undefined;
+    let diskManagedByExtended: string[] | undefined;
+    let nicServiceAssociation:
+      | {
+          privateEndpoint?: { id: string };
+          ipConfigurationProperties?: Record<string, unknown>;
+        }
+      | undefined;
+    const resourcePrefix = "/subscriptions/sub/resourceGroups/crabbox-leases/providers";
+    const nicID = `${resourcePrefix}/Microsoft.Network/networkInterfaces/${cloudID}-nic`;
+    const pipID = `${resourcePrefix}/Microsoft.Network/publicIPAddresses/${cloudID}-pip`;
+    const diskID = `${resourcePrefix}/Microsoft.Compute/disks/${cloudID}-osdisk`;
+    const canonicalVMID = `${resourcePrefix}/Microsoft.Compute/virtualMachines/${cloudID}`;
+    const nicIPConfigurationID = `${nicID}/ipConfigurations/ipconfig1`;
+    const inventoryPaths: string[] = [];
+    nicPublicIPID = pipID;
+    const fakeFetch = ((input: RequestInfo | URL): Promise<Response> => {
+      const url = new URL(String(input));
+      if (isAzureLoginURL(url.toString())) {
+        return Promise.resolve(Response.json({ access_token: "tkn", expires_in: 3600 }));
+      }
+      inventoryPaths.push(url.pathname);
+      if (url.pathname.endsWith("/virtualMachines")) {
+        return Promise.resolve(
+          Response.json({
+            value: includeVMWithDataDisk
+              ? [
+                  {
+                    id: canonicalVMID,
+                    name: cloudID,
+                    location: "eastus",
+                    tags,
+                    properties: {
+                      vmId: "vm-immutable-id",
+                      networkProfile: { networkInterfaces: [{ id: nicID }] },
+                      storageProfile: {
+                        osDisk: { managedDisk: { id: diskID } },
+                        dataDisks: [
+                          {
+                            name: "shared-data",
+                            lun: 0,
+                            deleteOption: "Delete",
+                            managedDisk: {
+                              id: `${resourcePrefix}/Microsoft.Compute/disks/shared-data`,
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  },
+                ]
+              : [],
+          }),
+        );
+      }
+      if (url.pathname.endsWith("/networkInterfaces")) {
+        return Promise.resolve(
+          Response.json({
+            value: includeNIC
+              ? [
+                  {
+                    id: nicID,
+                    name: `${cloudID}-nic`,
+                    location: nicLocation,
+                    tags,
+                    properties: {
+                      ...(nicVirtualMachineID
+                        ? { virtualMachine: { id: nicVirtualMachineID } }
+                        : {}),
+                      resourceGuid: nicResourceGuid,
+                      ipConfigurations: [
+                        {
+                          id: nicIPConfigurationID,
+                          properties: {
+                            ...(nicPublicIPID ? { publicIPAddress: { id: nicPublicIPID } } : {}),
+                            ...nicServiceAssociation?.ipConfigurationProperties,
+                          },
+                        },
+                      ],
+                      ...(nicServiceAssociation?.privateEndpoint
+                        ? { privateEndpoint: nicServiceAssociation.privateEndpoint }
+                        : {}),
+                    },
+                  },
+                ]
+              : [],
+          }),
+        );
+      }
+      if (url.pathname.endsWith("/publicIPAddresses")) {
+        return Promise.resolve(
+          Response.json({
+            value: includePublicIP
+              ? [
+                  {
+                    id: pipID,
+                    name: `${cloudID}-pip`,
+                    location: "eastus",
+                    tags: publicIPTags,
+                    properties: {
+                      resourceGuid: "pip-immutable-id",
+                      ipAddress: "192.0.2.20",
+                      ...(publicIPConfigurationID
+                        ? { ipConfiguration: { id: publicIPConfigurationID } }
+                        : {}),
+                      ...(publicIPNatGatewayID ? { natGateway: { id: publicIPNatGatewayID } } : {}),
+                    },
+                  },
+                ]
+              : [],
+          }),
+        );
+      }
+      if (url.pathname.endsWith("/disks")) {
+        return Promise.resolve(
+          Response.json({
+            value: includeDisk
+              ? [
+                  {
+                    id: diskID,
+                    name: `${cloudID}-osdisk`,
+                    location: "eastus",
+                    managedBy: diskManagedBy,
+                    ...(diskManagedByExtended ? { managedByExtended: diskManagedByExtended } : {}),
+                    tags,
+                    properties: { uniqueId: "disk-immutable-id" },
+                  },
+                ]
+              : [],
+          }),
+        );
+      }
+      return Promise.resolve(new Response("unexpected request", { status: 500 }));
+    }) as typeof fetch;
+    client.fetcher = fakeFetch;
+
+    const machines = await client.listReconciliationResources();
+
+    expect(machines).toHaveLength(1);
+    expect(machines[0]).toMatchObject({
+      provider: "azure",
+      id: 0,
+      cloudID,
+      name: cloudID,
+      status: "provisioning",
+      serverType: "Standard_D4ads_v6",
+      region: "eastus",
+      host: "192.0.2.20",
+      labels: azureLabelsFromTags(tags),
+    });
+    expect(machines[0]?.resourceIdentity).toEqual(expect.any(String));
+    expect(machines[0]?.resourceIdentity?.length).toBeGreaterThan(0);
+    expect(inventoryPaths).toHaveLength(4);
+    expect(
+      inventoryPaths.every((path) =>
+        /\/(virtualMachines|networkInterfaces|publicIPAddresses|disks)$/.test(path),
+      ),
+    ).toBe(true);
+
+    includeVMWithDataDisk = true;
+    nicVirtualMachineID = canonicalVMID;
+    diskManagedBy = canonicalVMID;
+    const withDataDisk = await client.listReconciliationResources();
+    expect(withDataDisk[0]?.labels["lease"]).toBe("");
+    expect(withDataDisk[0]?.resourceIdentity).toContain("shared-data");
+    includeVMWithDataDisk = false;
+    nicVirtualMachineID = undefined;
+    diskManagedBy = undefined;
+
+    diskManagedBy = canonicalVMID;
+    const canonicalDisk = await client.listReconciliationResources();
+    expect(canonicalDisk[0]?.labels["lease"]).toBe(tags.lease);
+    expect(canonicalDisk[0]?.resourceIdentity).not.toBe(machines[0]?.resourceIdentity);
+
+    diskManagedBy =
+      "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/virtualMachines/crabbox-other";
+    const attachedDisk = await client.listReconciliationResources();
+    expect(attachedDisk[0]?.labels["lease"]).toBe("");
+    expect(attachedDisk[0]?.resourceIdentity).not.toBe(canonicalDisk[0]?.resourceIdentity);
+
+    diskManagedBy = undefined;
+    diskManagedByExtended = [
+      "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/virtualMachines/crabbox-other",
+    ];
+    const attachedExtendedDisk = await client.listReconciliationResources();
+    expect(attachedExtendedDisk[0]?.labels["lease"]).toBe("");
+    expect(attachedExtendedDisk[0]?.resourceIdentity).not.toBe(machines[0]?.resourceIdentity);
+
+    diskManagedByExtended = [canonicalVMID];
+    const canonicalExtendedDisk = await client.listReconciliationResources();
+    expect(canonicalExtendedDisk[0]?.labels["lease"]).toBe(tags.lease);
+    expect(canonicalExtendedDisk[0]?.resourceIdentity).not.toBe(machines[0]?.resourceIdentity);
+
+    diskManagedByExtended = undefined;
+    publicIPConfigurationID =
+      "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/networkInterfaces/other-nic/ipConfigurations/ipconfig1";
+    const attachedPublicIP = await client.listReconciliationResources();
+    expect(attachedPublicIP[0]?.labels["lease"]).toBe("");
+    expect(attachedPublicIP[0]?.resourceIdentity).not.toBe(machines[0]?.resourceIdentity);
+
+    publicIPConfigurationID = undefined;
+    nicPublicIPID =
+      "/subscriptions/sub/resourceGroups/shared/providers/Microsoft.Network/publicIPAddresses/shared-pip";
+    const foreignForwardWithCanonicalPIP = await client.listReconciliationResources();
+    expect(foreignForwardWithCanonicalPIP[0]?.labels["lease"]).toBe("");
+    expect(foreignForwardWithCanonicalPIP[0]?.resourceIdentity).not.toBe(
+      machines[0]?.resourceIdentity,
+    );
+
+    includePublicIP = false;
+    const foreignForwardWithoutCanonicalPIP = await client.listReconciliationResources();
+    expect(foreignForwardWithoutCanonicalPIP[0]?.labels["lease"]).toBe("");
+    expect(foreignForwardWithoutCanonicalPIP[0]?.resourceIdentity).not.toBe(
+      machines[0]?.resourceIdentity,
+    );
+
+    nicPublicIPID = pipID;
+    const incompleteForward = await client.listReconciliationResources();
+    expect(incompleteForward[0]?.labels["lease"]).toBe("");
+    expect(incompleteForward[0]?.resourceIdentity).not.toBe(
+      foreignForwardWithoutCanonicalPIP[0]?.resourceIdentity,
+    );
+
+    includePublicIP = true;
+    publicIPNatGatewayID =
+      "/subscriptions/sub/resourceGroups/shared/providers/Microsoft.Network/natGateways/shared-nat";
+    const attachedNATGateway = await client.listReconciliationResources();
+    expect(attachedNATGateway[0]?.labels["lease"]).toBe("");
+    expect(attachedNATGateway[0]?.resourceIdentity).not.toBe(machines[0]?.resourceIdentity);
+
+    publicIPNatGatewayID = undefined;
+    nicVirtualMachineID =
+      "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/virtualMachines/crabbox-other";
+    const attachedNIC = await client.listReconciliationResources();
+    expect(attachedNIC[0]?.labels["lease"]).toBe("");
+    expect(attachedNIC[0]?.resourceIdentity).not.toBe(attachedPublicIP[0]?.resourceIdentity);
+
+    nicVirtualMachineID = undefined;
+    const serviceAssociations = [
+      {
+        ipConfigurationProperties: {
+          loadBalancerBackendAddressPools: [
+            { id: `${nicID}/loadBalancerBackendAddressPools/pool` },
+          ],
+        },
+      },
+      {
+        ipConfigurationProperties: {
+          applicationGatewayBackendAddressPools: [
+            { id: `${nicID}/applicationGatewayBackendAddressPools/pool` },
+          ],
+        },
+      },
+      {
+        ipConfigurationProperties: {
+          applicationSecurityGroups: [
+            {
+              id: ` /SUBSCRIPTIONS/SUB/RESOURCEGROUPS/SHARED/PROVIDERS/MICROSOFT.NETWORK/APPLICATIONSECURITYGROUPS/SHARED `,
+            },
+          ],
+        },
+      },
+      {
+        ipConfigurationProperties: {
+          loadBalancerInboundNatRules: [{ id: `${nicID}/loadBalancerInboundNatRules/rule` }],
+        },
+      },
+      {
+        privateEndpoint: {
+          id: `${resourcePrefix}/Microsoft.Network/privateEndpoints/foreign-private-endpoint`,
+        },
+      },
+    ];
+    let applicationSecurityGroupResourceIdentity: string | undefined;
+    for (const association of serviceAssociations) {
+      nicServiceAssociation = association;
+      // oxlint-disable-next-line eslint/no-await-in-loop -- each association must be observed after mutating the fixture.
+      const attachedService = await client.listReconciliationResources();
+      expect(attachedService[0]?.labels["lease"]).toBe("");
+      expect(attachedService[0]?.resourceIdentity).not.toBe(machines[0]?.resourceIdentity);
+      if ("applicationSecurityGroups" in (association.ipConfigurationProperties ?? {})) {
+        applicationSecurityGroupResourceIdentity = attachedService[0]?.resourceIdentity;
+      }
+    }
+    expect(applicationSecurityGroupResourceIdentity).toEqual(expect.any(String));
+    const identityEntries = JSON.parse(applicationSecurityGroupResourceIdentity ?? "[]") as Array<{
+      kind: string;
+      topology?: Record<string, unknown>;
+    }>;
+    const nicEntry = identityEntries.find((entry) => entry.kind === "networkInterfaces");
+    expect(nicEntry?.topology?.applicationSecurityGroupIDs).toEqual([
+      "subscriptions/sub/resourcegroups/shared/providers/microsoft.network/applicationsecuritygroups/shared",
+    ]);
+    nicServiceAssociation = undefined;
+
+    publicIPTags = { ...tags, owner: "other_owner" };
+    const mixed = await client.listReconciliationResources();
+    expect(mixed).toHaveLength(1);
+    expect(mixed[0]?.labels["lease"]).toBe("");
+    expect(mixed[0]?.resourceIdentity).not.toBe(machines[0]?.resourceIdentity);
+
+    publicIPTags = tags;
+    nicLocation = "";
+    const incompleteLocation = await client.listReconciliationResources();
+    expect(incompleteLocation[0]?.labels["lease"]).toBe("");
+
+    nicLocation = "eastus";
+    nicResourceGuid = "   ";
+    const incompleteImmutableIdentity = await client.listReconciliationResources();
+    expect(incompleteImmutableIdentity[0]?.labels["lease"]).toBe("");
+
+    nicResourceGuid = "nic-immutable-id";
+    includeNIC = false;
+    includePublicIP = false;
+    const loneDisk = await client.listReconciliationResources();
+    expect(loneDisk[0]?.labels["lease"]).toBe("");
+
+    includeNIC = true;
+    const nicAndDisk = await client.listReconciliationResources();
+    expect(nicAndDisk[0]?.labels["lease"]).toBe("");
+
+    includePublicIP = true;
+    includeDisk = false;
+    const nicAndPublicIP = await client.listReconciliationResources();
+    expect(nicAndPublicIP[0]?.labels["lease"]).toBe("");
   });
 });

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -11822,15 +11822,19 @@ describe("fleet lease identity and idle", () => {
   });
 
   it("deletes only coordinator-owned Azure orphan sweep candidates", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-01T00:00:00.000Z"));
     const storage = new MemoryStorage();
     const list = vi.spyOn(storage, "list");
     const ownedDeleted: LeaseRecord[] = [];
+    const releaseContexts: Array<{ resourceIdentity?: string } | undefined> = [];
     const oldSeconds = String(Math.trunc((Date.now() - 60 * 60 * 1000) / 1000));
     const orphanMachine = testMachine({
       provider: "azure",
       cloudID: "vm-orphan",
       region: "westus2",
       name: "vm-orphan",
+      resourceIdentity: "azure-components-v1",
       labels: {
         crabbox: "true",
         created_by: "crabbox",
@@ -11911,13 +11915,13 @@ describe("fleet lease identity and idle", () => {
         }),
       );
     }
-    seedProviderReconciliationEligible(storage, "azure", "westus2", orphanMachine);
     const fleet = testFleet(
       storage,
       {
         azure: fakeProvider(undefined, {
           provider: "azure",
-          servers: [
+          servers: [],
+          reconciliationServers: [
             orphanMachine,
             testMachine({
               provider: "azure",
@@ -11988,8 +11992,9 @@ describe("fleet lease identity and idle", () => {
               },
             }),
           ],
-          onReleaseLease(lease) {
+          onReleaseLease(lease, context) {
             ownedDeleted.push(structuredClone(lease));
+            releaseContexts.push(context);
           },
         }),
       },
@@ -12000,11 +12005,54 @@ describe("fleet lease identity and idle", () => {
         AZURE_SUBSCRIPTION_ID: "subscription",
         CRABBOX_AZURE_LOCATION: "eastus",
         CRABBOX_AZURE_ORPHAN_SWEEP_DELETE: "1",
+        CRABBOX_AZURE_ORPHAN_SWEEP_INTERVAL_SECONDS: "1",
         CRABBOX_AZURE_ORPHAN_SWEEP_GRACE_SECONDS: "1",
       },
     );
 
     await fleet.alarm();
+
+    const firstSweep = storage.value<{
+      mode: string;
+      terminated: number;
+      candidates: Array<Record<string, unknown>>;
+    }>("azure-orphan-sweep:last");
+    expect(ownedDeleted).toEqual([]);
+    expect(firstSweep).toMatchObject({ mode: "delete", terminated: 0 });
+    expect(firstSweep?.candidates).toEqual([
+      expect.objectContaining({
+        cloudID: "vm-orphan",
+        region: "westus2",
+        leaseID: "cbx_000000000776",
+        reason: "expired-provider-tag",
+        ownership: "coordinator-lease",
+        ownershipLeaseID: "cbx_000000000776",
+        action: "quarantined",
+      }),
+      expect.objectContaining({
+        cloudID: "vm-tag-only",
+        region: "westus2",
+        ownership: "provider-tags-only",
+        action: "reported",
+      }),
+    ]);
+    expect(firstSweep?.candidates.map((candidate) => candidate.cloudID)).not.toEqual(
+      expect.arrayContaining([
+        "vm-kept",
+        "vm-provisioning",
+        "vm-cleaning",
+        "vm-retaining",
+        "vm-retained",
+      ]),
+    );
+    expect(storage.value("provider-reconciliation:azure:westus2:vm-orphan")).toMatchObject({
+      observations: 1,
+    });
+
+    seedProviderReconciliationEligible(storage, "azure", "westus2", orphanMachine);
+    vi.setSystemTime(new Date("2026-08-01T00:00:02.000Z"));
+    await fleet.alarm();
+    vi.useRealTimers();
 
     const sweep = storage.value<{
       mode: string;
@@ -12020,10 +12068,12 @@ describe("fleet lease identity and idle", () => {
         providerScope: "/subscriptions/subscription/resourceGroups/crabbox-leases",
       }),
     ]);
+    expect(releaseContexts).toEqual([{ resourceIdentity: "azure-components-v1" }]);
     const boundedLeaseScans = list.mock.calls.filter(
       ([options]) => options?.prefix === "lease:" && options.limit === 128,
     );
     expect(boundedLeaseScans.length).toBeGreaterThanOrEqual(2);
+    expect(storage.value("provider-reconciliation:azure:westus2:vm-orphan")).toBeUndefined();
     expect(sweep).toMatchObject({ mode: "delete", terminated: 1 });
     expect(sweep?.candidates).toEqual([
       expect.objectContaining({
@@ -32480,6 +32530,8 @@ function fakeProvider(
     market?: string;
     attempts?: ProvisioningAttempt[];
     servers?: ProviderMachine[];
+    reconciliationServers?: ProviderMachine[];
+    onListReconciliationResources?: () => Promise<ProviderMachine[]> | ProviderMachine[];
     onList?: () => Promise<ProviderMachine[]> | ProviderMachine[];
     onCreateImage?: (
       instanceID: string,
@@ -32549,7 +32601,10 @@ function fakeProvider(
           lease: LeaseRecord;
         }
       | undefined;
-    onReleaseLease?: (lease: LeaseRecord) => Promise<void> | void;
+    onReleaseLease?: (
+      lease: LeaseRecord,
+      context?: { resourceIdentity?: string },
+    ) => Promise<void> | void;
     onDeleteOwnedServer?: (lease: LeaseRecord) => Promise<void> | void;
     onRecoverServer?: (
       lease: LeaseRecord,
@@ -32569,6 +32624,16 @@ function fakeProvider(
       }
       return result.servers ?? [];
     },
+    ...(result.onListReconciliationResources || result.reconciliationServers !== undefined
+      ? {
+          async listReconciliationResources() {
+            if (result.onListReconciliationResources) {
+              return await result.onListReconciliationResources();
+            }
+            return result.reconciliationServers ?? [];
+          },
+        }
+      : {}),
     supportsSSHHostKeyInjection(config: LeaseConfig) {
       const provider = result.provider ?? config.provider;
       return (
@@ -32740,8 +32805,8 @@ function fakeProvider(
           },
         }
       : {}),
-    async releaseLease(lease: LeaseRecord) {
-      await result.onReleaseLease?.(lease);
+    async releaseLease(lease: LeaseRecord, context?: { resourceIdentity?: string }) {
+      await result.onReleaseLease?.(lease, context);
       await onDelete?.(
         (lease.provider ?? result.provider) === "hetzner" ? String(lease.serverID) : lease.cloudID,
       );

--- a/worker/test/provider-reconciliation.test.ts
+++ b/worker/test/provider-reconciliation.test.ts
@@ -51,6 +51,24 @@ describe("provider reconciliation", () => {
     );
   });
 
+  it("preserves legacy fingerprints for providers without resource identity", () => {
+    expect(providerReconciliationFingerprint("aws", "eu-west-1", machine)).toBe(
+      JSON.stringify({
+        provider: "aws",
+        scope: "eu-west-1",
+        cloudID: "i-123",
+        name: "crabbox-cbx_123456789abc",
+        lease: "cbx_123456789abc",
+        owner: "alice",
+        providerLabel: "aws",
+        slug: "blue-box",
+        keep: "",
+        createdAt: "",
+        expiresAt: "",
+      }),
+    );
+  });
+
   it("changes the fingerprint when ownership identity changes", () => {
     const changed = {
       ...machine,
@@ -73,6 +91,32 @@ describe("provider reconciliation", () => {
 
     expect(providerReconciliationFingerprint("aws", "eu-west-1", withLargeDiagnosticLabel)).toBe(
       providerReconciliationFingerprint("aws", "eu-west-1", machine),
+    );
+  });
+
+  it("changes the provider fingerprint for reconciliation resource identity while ignoring metadata", () => {
+    const withIdentity: ProviderMachine = {
+      ...machine,
+      resourceIdentity: "azure-components-v1",
+    };
+    const changedIdentity: ProviderMachine = {
+      ...withIdentity,
+      resourceIdentity: "azure-components-v2",
+    };
+    const withMetadata: ProviderMachine = {
+      ...withIdentity,
+      host: "198.51.100.42",
+      labels: {
+        ...withIdentity.labels,
+        provider_diagnostic: "inventory-page-2",
+      },
+    };
+
+    expect(providerReconciliationFingerprint("azure", "eastus", changedIdentity)).not.toBe(
+      providerReconciliationFingerprint("azure", "eastus", withIdentity),
+    );
+    expect(providerReconciliationFingerprint("azure", "eastus", withMetadata)).toBe(
+      providerReconciliationFingerprint("azure", "eastus", withIdentity),
     );
   });
 


### PR DESCRIPTION
## Intent

Repair Azure orphan reconciliation without widening ordinary VM listing or pool behavior. The coordinator may discover a complete, exact-owned canonical per-lease set consisting of an optional VM plus its NIC, public IP, and managed OS disk, including VM-less interrupted provisioning. Mixed, incomplete, shared, data-disk, cascade-delete, or otherwise non-canonical shapes remain report-only.

## Safety repairs

- Inventory is provider-owned and reconciliation-specific. Ordinary `listCrabboxServers` remains VM-only. Reconciliation requires consistent ownership labels, location, topology, canonical names, immutable Azure identities, and the exact retained coordinator lease. A VM whose canonical NIC is missing is report-only in inventory and rejected again during fresh deletion preflight.
- Cleanup re-reads labels, location, topology, stable identities, and lease scope before every deletion. Shared VNets, subnets, NSGs, resource groups, service-associated NICs, data disks, and cascade-delete relationships are never admitted to the destructive path.
- Version-2 cleanup claims use transactional preparation, transitions, per-member progress, and completion. Each successfully deleted member's stable identity is durably appended before a later missing companion may be accepted. A failed delete, failed progress write, external disappearance, concurrent stale preparation, or stale completion observer therefore fails closed. Progress merges only as a monotonic ordered prefix.
- Version-1 claims upgrade lazily only while a complete canonical shape remains visible. Partial legacy state fails closed. Older workers reject version-2 claims safely, so this does not require a bulk migration or a rollback-time rewrite.

These changes resolve both P1 code findings from the previous review: unproven missing companions can no longer authorize continued cleanup, and VMs with a missing canonical NIC can no longer enter or pass the destructive path.

## Local and mock proof

- 84 Azure provider tests and 8 reconciliation tests passed (92 focused tests), plus the focused coordinator/fleet release-context regression.
- A broader three-file Azure/reconciliation/fleet run passed 643/643 tests.
- Full Worker suite: 1,255 passed, 3 skipped; 37 files passed, 2 skipped.
- Worker format, lint, TypeScript typecheck, and Wrangler dry-run build passed.
- Documentation link checks and docs-site build passed.
- Source-blind mock contract: 17/17 scenarios passed, covering complete VM-less discovery, report-only negative shapes, missing-NIC rejection, fresh identity checks, failed/unpersisted deletion, verified replay, and transactional fencing.
- Final diff check and exact-change secret scan passed. Full-diff P1 review found no code defect; its sole remaining finding was the live Azure evidence disposition below.

No Azure resources were created, changed, or deleted while preparing this update.

## Maintainer proof disposition

The repository owner explicitly accepted the exact head's local, mock, source-blind, full Worker, and CI evidence and waived live Azure proof for this merge.

Residual risk remains: real Azure ARM topology, response shapes, deletion responses, and timing may differ from the mocks. The full disposable-Azure protocol below remains recommended post-merge validation and follow-up; it is not completed evidence and this PR makes no claim that it has been run.

No Azure session or resource was created during this landing, so no teardown is needed. No configuration or secret migration is required.

### Recommended post-merge disposable-Azure protocol

An explicitly authorized operator should run this later in a disposable subscription or isolated resource group with a dedicated least-privilege service principal and a staging coordinator pinned to the landed source:

1. Record an empty baseline for the disposable resource group and the staging coordinator's retained lease/claim state.
2. Create a canonical VM + NIC + public IP + managed OS disk lease, and separately create a VM-less interrupted-provisioning set with the same exact canonical companions. Show that two unchanged authoritative inventories quarantine and then admit only the complete exact-owned sets.
3. Exercise report-only canaries one at a time: incomplete companion sets, a VM missing its canonical NIC, mixed ownership labels, changed location or immutable identity, a NIC/service or shared-resource association, a VM data disk, and cascade-delete options. Show zero destructive ARM requests for every canary. Mutate an admitted identity between sweeps and show quarantine resets.
4. For an admitted disposable set, capture the fresh GET/preflight before every DELETE and prove that labels, scope, location, topology, immutable IDs, and the retained coordinator lease still match.
5. Prove failed/external-disappearance fencing with a temporary resource lock or equivalent targeted denial: make one companion DELETE fail, verify no progress is recorded for it, then remove the lock and delete that companion out of band. The next cleanup must fail closed without deleting survivors.
6. Prove failed-persistence fencing in the isolated staging coordinator with a one-shot storage fault after a successful companion DELETE but before the progress transaction commits. On retry, the absent companion must not be accepted and no survivor may be deleted.
7. Prove successful replay by allowing exact per-member progress to commit, interrupting a later deletion, and retrying. The retry must continue only from the exact verified ordered prefix and must fence stale concurrent preparation/cleanup attempts.
8. Seed a complete version-1 claim and show lazy upgrade to version 2 before deletion; seed partial version-1 state and show fail-closed behavior. Verify a rollback worker rejects the version-2 claim rather than replaying it.
9. Capture timestamps, request methods/statuses, redacted resource aliases, sweep decisions, claim version/progress transitions, and the final empty inventory. Preserve identity-equality evidence while redacting subscription, tenant, service-principal IDs, tokens, coordinator secrets/URLs, public IPs, and full Azure resource IDs. Never print credential environment values or authorization headers.
10. Remove fault injection and locks, delete the disposable resource group and service principal, revoke its credential, clear staging-only coordinator state, and verify both Azure inventory and coordinator claims are empty. Record cleanup proof and review the artifact once more for secrets before attaching it.
