### PR TITLE
fix(release): separate workflow and provenance commits

### DIFF
--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -21,7 +21,11 @@ on:
         required: true
         type: string
       verifier_commit:
-        description: "Protected default-branch verifier commit SHA"
+        description: "Immutable candidate provenance verifier commit SHA"
+        required: true
+        type: string
+      workflow_commit:
+        description: "Current protected default-branch workflow commit SHA"
         required: true
         type: string
       draft:
@@ -57,22 +61,36 @@ jobs:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           RELEASE_TAG: ${{ inputs.tag }}
           VERIFIER_COMMIT: ${{ inputs.verifier_commit }}
+          WORKFLOW_COMMIT: ${{ inputs.workflow_commit }}
         run: |
           set -euo pipefail
           [[ "$RELEASE_TAG" =~ ^v[0-9]+[.][0-9]+[.][0-9]+$ ]]
           [[ "$VERIFIER_COMMIT" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$WORKFLOW_COMMIT" =~ ^[0-9a-f]{40}$ ]]
           expected_ref="refs/heads/$DEFAULT_BRANCH"
           expected_workflow_ref="$GITHUB_REPOSITORY/.github/workflows/release-assets.yml@$expected_ref"
           [[ "$GITHUB_REF" == "$expected_ref" ]]
           [[ "$GITHUB_WORKFLOW_REF" == "$expected_workflow_ref" ]]
-          [[ "${{ github.workflow_sha }}" == "$VERIFIER_COMMIT" ]]
+          [[ "${{ github.workflow_sha }}" == "$WORKFLOW_COMMIT" ]]
 
-      - name: Check out protected verifier tooling
+      - name: Check out protected workflow tooling
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
           ref: ${{ github.workflow_sha }}
+
+      - name: Bind provenance verifier to protected workflow ancestry
+        shell: bash
+        env:
+          SOURCE_COMMIT: ${{ inputs.tag_commit }}
+          VERIFIER_COMMIT: ${{ inputs.verifier_commit }}
+          WORKFLOW_COMMIT: ${{ inputs.workflow_commit }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$WORKFLOW_COMMIT"
+          git merge-base --is-ancestor "$SOURCE_COMMIT" "$VERIFIER_COMMIT"
+          git merge-base --is-ancestor "$VERIFIER_COMMIT" "$WORKFLOW_COMMIT"
 
       - name: Set up Go for Apple VM source verification
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
@@ -113,9 +131,9 @@ jobs:
           EXPECTED_TAG_COMMIT: ${{ inputs.tag_commit }}
           EXPECTED_TAG_OBJECT: ${{ inputs.tag_object }}
           RELEASE_TAG: ${{ inputs.tag }}
-          TRUSTED_HEAD: ${{ inputs.verifier_commit }}
+          TRUSTED_HEAD: ${{ inputs.workflow_commit }}
           WORKFLOW_REF: ${{ github.ref }}
-          WORKFLOW_SHA: ${{ github.workflow_sha }}
+          WORKFLOW_SHA: ${{ inputs.workflow_commit }}
           REQUIRE_PUBLISHABLE: "1"
         run: |
           set -euo pipefail
@@ -252,7 +270,7 @@ jobs:
           - runner: macos-15-intel
             arch: x86_64
     steps:
-      - name: Check out protected verifier tooling
+      - name: Check out protected workflow tooling
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
@@ -291,6 +309,7 @@ jobs:
           RELEASE_TAG_OBJECT: ${{ inputs.tag_object }}
           RELEASE_COMMIT: ${{ inputs.tag_commit }}
           VERIFIER_COMMIT: ${{ inputs.verifier_commit }}
+          WORKFLOW_COMMIT: ${{ inputs.workflow_commit }}
           VERIFY_ARCH: ${{ matrix.arch }}
         run: |
           set -euo pipefail
@@ -298,6 +317,7 @@ jobs:
           env -i \
             CRABBOX_VERIFY_EXEC_ARCH="$VERIFY_ARCH" \
             CRABBOX_VERIFY_MODE=static \
+            CRABBOX_VERIFY_TOOLING_COMMIT="$WORKFLOW_COMMIT" \
             HOME="$RUNNER_TEMP/verify-home" LANG=C LC_ALL=C \
             PATH="$PATH" TMPDIR="$RUNNER_TEMP" \
             scripts/verify-release.sh \
@@ -311,6 +331,7 @@ jobs:
           RELEASE_TAG_OBJECT: ${{ inputs.tag_object }}
           RELEASE_COMMIT: ${{ inputs.tag_commit }}
           VERIFIER_COMMIT: ${{ inputs.verifier_commit }}
+          WORKFLOW_COMMIT: ${{ inputs.workflow_commit }}
           VERIFY_ARCH: ${{ matrix.arch }}
           EXPECTED_DRAFT: ${{ inputs.draft }}
         run: |
@@ -321,7 +342,7 @@ jobs:
             RELEASE_ID="$RELEASE_ID" RELEASE_JSON="$RUNNER_TEMP/release-input/release.json" \
             RELEASE_PROOF="$RUNNER_TEMP/verified-assets.json" RELEASE_TAG="$RELEASE_TAG" \
             RELEASE_TAG_OBJECT="$RELEASE_TAG_OBJECT" VERIFIER_COMMIT="$VERIFIER_COMMIT" \
-            PATH="$PATH" VERIFY_ARCH="$VERIFY_ARCH" node <<'NODE'
+            WORKFLOW_COMMIT="$WORKFLOW_COMMIT" PATH="$PATH" VERIFY_ARCH="$VERIFY_ARCH" node <<'NODE'
           const crypto = require('node:crypto');
           const fs = require('node:fs');
           const path = require('node:path');
@@ -344,6 +365,7 @@ jobs:
             tagObject: process.env.RELEASE_TAG_OBJECT,
             sourceCommit: process.env.RELEASE_COMMIT,
             verifierCommit: process.env.VERIFIER_COMMIT,
+            workflowCommit: process.env.WORKFLOW_COMMIT,
             verifierArch: process.env.VERIFY_ARCH,
             title: release.name,
             targetCommitish: release.target_commitish,
@@ -385,7 +407,7 @@ jobs:
           - runner: macos-15-intel
             arch: x86_64
     steps:
-      - name: Check out protected verifier tooling
+      - name: Check out protected workflow tooling
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
@@ -424,6 +446,7 @@ jobs:
           RELEASE_TAG_OBJECT: ${{ inputs.tag_object }}
           RELEASE_COMMIT: ${{ inputs.tag_commit }}
           VERIFIER_COMMIT: ${{ inputs.verifier_commit }}
+          WORKFLOW_COMMIT: ${{ inputs.workflow_commit }}
           VERIFY_ARCH: ${{ matrix.arch }}
         run: |
           set -euo pipefail
@@ -431,6 +454,7 @@ jobs:
           exec env -i \
             CRABBOX_VERIFY_EXEC_ARCH="$VERIFY_ARCH" \
             CRABBOX_VERIFY_MODE=execute \
+            CRABBOX_VERIFY_TOOLING_COMMIT="$WORKFLOW_COMMIT" \
             HOME="$RUNNER_TEMP/execute-home" LANG=C LC_ALL=C \
             PATH="$PATH" TMPDIR="$RUNNER_TEMP" \
             scripts/verify-release.sh \

--- a/.github/workflows/verify-homebrew.yml
+++ b/.github/workflows/verify-homebrew.yml
@@ -39,6 +39,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Check out protected Homebrew workflow tooling
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.workflow_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
       - name: Guard published release and protected verifier run
         shell: bash
         env:
@@ -47,6 +54,7 @@ jobs:
           REF_PROTECTED: ${{ github.ref_protected }}
           RELEASE_ID: ${{ inputs.release_id }}
           RELEASE_TAG: ${{ inputs.tag }}
+          SOURCE_COMMIT: ${{ inputs.source_commit }}
           PUBLIC_VERIFIER_RUN_ID: ${{ inputs.public_verifier_run_id }}
           RUN_SHA: ${{ github.sha }}
           VERIFIER_COMMIT: ${{ inputs.verifier_commit }}
@@ -54,6 +62,7 @@ jobs:
         run: |
           set -euo pipefail
           [[ "$RELEASE_TAG" =~ ^v[0-9]+[.][0-9]+[.][0-9]+$ ]]
+          [[ "$SOURCE_COMMIT" =~ ^[0-9a-f]{40}$ ]]
           [[ "$VERIFIER_COMMIT" =~ ^[0-9a-f]{40}$ ]]
           [[ "$RELEASE_ID" =~ ^[1-9][0-9]*$ ]]
           [[ "$PUBLIC_VERIFIER_RUN_ID" =~ ^[1-9][0-9]*$ ]]
@@ -72,6 +81,8 @@ jobs:
           workflow_id=$(jq -er '.workflow_id | select(type == "number" and . > 0)' "$work/run.json")
           gh api --method GET "repos/$GITHUB_REPOSITORY/actions/workflows/$workflow_id" \
             >"$work/workflow.json"
+          gh api --method GET "repos/$GITHUB_REPOSITORY/branches/$DEFAULT_BRANCH" \
+            >"$work/branch.json"
           jq -e \
             --argjson id "$RELEASE_ID" \
             --arg tag "$RELEASE_TAG" '
@@ -94,6 +105,19 @@ jobs:
           jq -e '
             .path == ".github/workflows/release-assets.yml" and .state == "active"
           ' "$work/workflow.json" >/dev/null
+          public_workflow_commit=$(jq -er '.head_sha' "$work/run.json")
+          canonical_commit=$(jq -er \
+            --arg branch "$DEFAULT_BRANCH" '
+              select(.name == $branch and .protected == true) | .commit.sha |
+              select(type == "string" and test("^[0-9a-f]{40}$"))
+            ' "$work/branch.json")
+          git -c fetch.writeCommitGraph=false fetch --quiet --no-tags \
+            "https://github.com/$GITHUB_REPOSITORY" "$canonical_commit"
+          test "$(git rev-parse HEAD)" = "$WORKFLOW_SHA"
+          git merge-base --is-ancestor "$SOURCE_COMMIT" "$VERIFIER_COMMIT"
+          git merge-base --is-ancestor "$VERIFIER_COMMIT" "$public_workflow_commit"
+          git merge-base --is-ancestor "$public_workflow_commit" "$WORKFLOW_SHA"
+          git merge-base --is-ancestor "$WORKFLOW_SHA" "$canonical_commit"
 
   public-witness-preflight:
     name: freeze-anonymous-public-witness
@@ -105,6 +129,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.workflow_sha }}
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Freeze anonymous public metadata before native execution
@@ -119,6 +144,30 @@ jobs:
           scripts/fetch-public-release-witness.sh \
             "$GITHUB_REPOSITORY" "$RELEASE_ID" "$PUBLIC_VERIFIER_RUN_ID" \
             "$RUNNER_TEMP/public-witness"
+
+      - name: Verify frozen public workflow ancestry
+        shell: bash
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          SOURCE_COMMIT: ${{ inputs.source_commit }}
+          VERIFIER_COMMIT: ${{ inputs.verifier_commit }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+        run: |
+          set -euo pipefail
+          unset ACTIONS_ID_TOKEN_REQUEST_TOKEN ACTIONS_RUNTIME_TOKEN GH_TOKEN GITHUB_TOKEN
+          public_workflow_commit=$(jq -er \
+            '.head_sha | select(type == "string" and test("^[0-9a-f]{40}$"))' \
+            "$RUNNER_TEMP/public-witness/run.json")
+          canonical_commit=$(git ls-remote "https://github.com/$GITHUB_REPOSITORY" \
+            "refs/heads/$DEFAULT_BRANCH" | awk '{print $1}')
+          [[ "$canonical_commit" =~ ^[0-9a-f]{40}$ ]]
+          git -c fetch.writeCommitGraph=false fetch --quiet --no-tags \
+            "https://github.com/$GITHUB_REPOSITORY" "$canonical_commit"
+          test "$(git rev-parse HEAD)" = "$WORKFLOW_SHA"
+          git merge-base --is-ancestor "$SOURCE_COMMIT" "$VERIFIER_COMMIT"
+          git merge-base --is-ancestor "$VERIFIER_COMMIT" "$public_workflow_commit"
+          git merge-base --is-ancestor "$public_workflow_commit" "$WORKFLOW_SHA"
+          git merge-base --is-ancestor "$WORKFLOW_SHA" "$canonical_commit"
 
       - name: Freeze public witness for native jobs
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/verify-homebrew.yml
+++ b/.github/workflows/verify-homebrew.yml
@@ -82,11 +82,12 @@ jobs:
             ' "$work/release.json" >/dev/null
           jq -e \
             --argjson id "$PUBLIC_VERIFIER_RUN_ID" \
-            --arg branch "$DEFAULT_BRANCH" \
-            --arg sha "$VERIFIER_COMMIT" '
+            --arg branch "$DEFAULT_BRANCH" '
               .id == $id and .event == "workflow_dispatch" and
               .status == "completed" and .conclusion == "success" and
-              .head_branch == $branch and .head_sha == $sha and
+              .head_branch == $branch and
+              (.head_sha | type == "string" and test("^[0-9a-f]{40}$")) and
+              .head_commit.id == .head_sha and
               .repository.full_name == env.GITHUB_REPOSITORY and
               .head_repository.full_name == env.GITHUB_REPOSITORY
             ' "$work/run.json" >/dev/null
@@ -143,10 +144,10 @@ jobs:
             arch: x86_64
     steps:
 
-      - name: Check out protected release verifier
+      - name: Check out protected Homebrew tooling
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ inputs.verifier_commit }}
+          ref: ${{ github.workflow_sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -162,7 +163,7 @@ jobs:
           name: homebrew-public-witness-${{ github.run_id }}
           path: ${{ runner.temp }}/public-witness
 
-      - name: Preserve pinned release tools in the frozen verifier path
+      - name: Preserve protected release tools in the workflow path
         shell: bash
         run: |
           set -euo pipefail
@@ -212,10 +213,10 @@ jobs:
         shell: bash
         env:
           RELEASE_TAG: ${{ inputs.tag }}
-          VERIFIER_COMMIT: ${{ inputs.verifier_commit }}
+          WORKFLOW_COMMIT: ${{ github.workflow_sha }}
         run: |
           set -euo pipefail
-          test "$(git rev-parse HEAD)" = "$VERIFIER_COMMIT"
+          test "$(git rev-parse HEAD)" = "$WORKFLOW_COMMIT"
           version=${RELEASE_TAG#v}
           assets=(
             checksums.txt
@@ -269,12 +270,14 @@ jobs:
           TAG_OBJECT: ${{ inputs.tag_object }}
           PUBLIC_VERIFIER_RUN_ID: ${{ inputs.public_verifier_run_id }}
           VERIFIER_COMMIT: ${{ inputs.verifier_commit }}
+          WORKFLOW_COMMIT: ${{ github.workflow_sha }}
         run: |
           set -euo pipefail
           unset ACTIONS_ID_TOKEN_REQUEST_TOKEN ACTIONS_RUNTIME_TOKEN GH_TOKEN GITHUB_TOKEN
           unset HOMEBREW_GITHUB_API_TOKEN HOMEBREW_TAP_GITHUB_TOKEN
           HOMEBREW_NO_AUTO_UPDATE=1 brew tap openclaw/tap
-          scripts/verify-homebrew-release.sh \
+          CRABBOX_VERIFY_TOOLING_COMMIT="$WORKFLOW_COMMIT" \
+            scripts/verify-homebrew-release.sh \
             "$RELEASE_TAG" "$RUNNER_TEMP/release-assets" \
             "$TAG_OBJECT" "$SOURCE_COMMIT" "$VERIFIER_COMMIT" \
             "$RELEASE_ID" "$PUBLIC_VERIFIER_RUN_ID" "$RUNNER_TEMP/public-proofs"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -305,13 +305,15 @@ gh run watch "$DRAFT_VERIFIER_RUN_ID" \
 ```
 
 Stop for the publication gate. Publication takes the exact successful draft
-run ID and repeats the tag as its explicit confirmation:
+run ID, its protected workflow commit, and repeats the tag as its explicit
+confirmation. The seven-argument compatibility form is only for historical
+runs where `WORKFLOW_COMMIT` exactly equals `VERIFIER_COMMIT`:
 
 ```sh
 CRABBOX_RELEASE_SERIALIZATION_CONFIRMED="$TAG:$RELEASE_ID" \
 scripts/publish-release.sh \
   "$RELEASE_ID" "$TAG" "$TAG_OBJECT" "$TAG_COMMIT" \
-  "$VERIFIER_COMMIT" "$DRAFT_VERIFIER_RUN_ID" "$TAG"
+  "$VERIFIER_COMMIT" "$WORKFLOW_COMMIT" "$DRAFT_VERIFIER_RUN_ID" "$TAG"
 ```
 
 Stop again. Dispatch a new native run against the published state; do not reuse

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -198,6 +198,7 @@ TAG=vX.Y.Z
 TAG_OBJECT=$(git rev-parse "refs/tags/$TAG")
 TAG_COMMIT=$(git rev-parse "refs/tags/$TAG^{commit}")
 VERIFIER_COMMIT=$(git rev-parse HEAD)
+WORKFLOW_COMMIT=$VERIFIER_COMMIT
 
 DEFAULT_BRANCH=main \
 RELEASE_TAG="$TAG" \
@@ -295,6 +296,7 @@ gh workflow run release-assets.yml \
   -f tag_object="$TAG_OBJECT" \
   -f tag_commit="$TAG_COMMIT" \
   -f verifier_commit="$VERIFIER_COMMIT" \
+  -f workflow_commit="$WORKFLOW_COMMIT" \
   -f draft=true
 
 : "${DRAFT_VERIFIER_RUN_ID:?set to the numeric ID of that exact draft run}"
@@ -313,9 +315,16 @@ scripts/publish-release.sh \
 ```
 
 Stop again. Dispatch a new native run against the published state; do not reuse
-the draft proof. Capture and wait for the exact new run:
+the draft proof. `VERIFIER_COMMIT` remains the immutable candidate-provenance
+commit. Bind the new run separately to the current protected workflow commit,
+which must descend from that verifier, then capture and wait for the exact run:
 
 ```sh
+WORKFLOW_COMMIT=$(git rev-parse HEAD)
+test "$(git ls-remote origin refs/heads/main | awk '{print $1}')" = "$WORKFLOW_COMMIT"
+git merge-base --is-ancestor "$VERIFIER_COMMIT" "$WORKFLOW_COMMIT"
+git merge-base --is-ancestor "$TAG_COMMIT" "$VERIFIER_COMMIT"
+
 gh workflow run release-assets.yml \
   --repo openclaw/crabbox \
   --ref main \
@@ -324,6 +333,7 @@ gh workflow run release-assets.yml \
   -f tag_object="$TAG_OBJECT" \
   -f tag_commit="$TAG_COMMIT" \
   -f verifier_commit="$VERIFIER_COMMIT" \
+  -f workflow_commit="$WORKFLOW_COMMIT" \
   -f draft=false
 
 : "${PUBLIC_VERIFIER_RUN_ID:?set to the numeric ID of that exact public run}"
@@ -397,7 +407,19 @@ emitted only after success, so retries cannot append to partial JSON. The wrappe
 never adds an authorization header or skips a pre/postflight read.
 
 ```sh
-
+HOMEBREW_TOOLING_COMMIT=$(git rev-parse HEAD)
+case "$(git remote get-url origin)" in
+  https://github.com/openclaw/crabbox | https://github.com/openclaw/crabbox.git) ;;
+  *) false ;;
+esac
+REMOTE_MAIN=$(git ls-remote https://github.com/openclaw/crabbox \
+  refs/heads/main | awk '{print $1}')
+git -c fetch.writeCommitGraph=false fetch --quiet --no-tags \
+  https://github.com/openclaw/crabbox "$REMOTE_MAIN"
+git merge-base --is-ancestor "$HOMEBREW_TOOLING_COMMIT" "$REMOTE_MAIN"
+git merge-base --is-ancestor "$VERIFIER_COMMIT" "$HOMEBREW_TOOLING_COMMIT"
+git merge-base --is-ancestor "$TAG_COMMIT" "$VERIFIER_COMMIT"
+CRABBOX_VERIFY_TOOLING_COMMIT="$HOMEBREW_TOOLING_COMMIT" \
 scripts/verify-homebrew-release.sh \
   "$TAG" "$PUBLIC_ASSETS" \
   "$TAG_OBJECT" "$TAG_COMMIT" "$VERIFIER_COMMIT" \
@@ -416,8 +438,8 @@ comparison to close the verification window. It does not update the tap. The
 tap formula must be byte-for-byte output from the protected
 `scripts/render-homebrew-formula.mjs`; any additional Ruby, interpolation, or
 format drift is rejected before Homebrew evaluates it. Protected downstream
-tooling must remain clean at the verifier commit before and after candidate
-execution. The
+tooling must remain clean at the explicit tooling commit, and the immutable
+candidate verifier must be its ancestor, before and after candidate execution. The
 lower-level `codesign-macos.sh`, `extract-release-notes.sh`,
 `release-provenance.mjs`, `validate-release-publication.mjs`,
 `verify-go-release-binary.mjs`, and `verify-macos-binary.sh` are internal to the
@@ -530,10 +552,12 @@ notarization checks. Apple Silicon also runs the helper's non-mutating info path
 This bounded verifier is the installed-binary smoke; it does not create a lease.
 Only both native proofs complete the Homebrew gate.
 
-The Homebrew workflow itself runs from the current protected `main` commit,
-while its verification checkout remains pinned to the release record's
-protected verifier commit. This keeps published provenance immutable while
-allowing a protected workflow-only repair to restore the downstream proof.
+The Homebrew workflow and verification checkout run from the current protected
+`main` commit. The public release run and proof bind their own workflow commit,
+while candidate provenance remains pinned to the older verifier commit; each
+tooling commit must descend from that immutable verifier. This keeps published
+provenance immutable while allowing a protected workflow-only repair to restore
+the downstream proof.
 
 ## Cancellation And Recovery
 

--- a/scripts/homebrew-release.test.js
+++ b/scripts/homebrew-release.test.js
@@ -909,7 +909,10 @@ test("blocked v0.37.0 record stops before the mocked brew executable", () => {
       },
     );
     assert.notEqual(result.status, 0);
-    assert.match(result.stderr, /release v0\.37\.0 is blocked|protected downstream verifier tooling is dirty/);
+    assert.match(
+      result.stderr,
+      /release v0\.37\.0 is blocked|protected downstream verifier tooling is dirty|protected tooling commit is not in canonical default-branch history/,
+    );
     assert.equal(fs.existsSync(marker), false, "brew ran despite the protected blocked record");
   } finally {
     fs.rmSync(root, { recursive: true, force: true });

--- a/scripts/homebrew-release.test.js
+++ b/scripts/homebrew-release.test.js
@@ -439,7 +439,7 @@ test("Homebrew verifier cleanup survives main function scope", () => {
   assert.equal(fs.existsSync(root), false);
 });
 
-test("public workflow commit must descend from the provenance verifier", () => {
+test("public workflow commit must be between the provenance verifier and protected tooling", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-public-workflow-ancestry-"));
   try {
     execFileSync("git", ["init", "-b", "main"], { cwd: root, stdio: "ignore" });
@@ -459,34 +459,52 @@ test("public workflow commit must descend from the provenance verifier", () => {
       cwd: root,
       encoding: "utf8",
     }).trim();
+    fs.writeFileSync(path.join(root, "tooling.txt"), "tooling\n");
+    execFileSync("git", ["add", "tooling.txt"], { cwd: root });
+    execFileSync("git", ["commit", "-m", "tooling"], { cwd: root, stdio: "ignore" });
+    const toolingCommit = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: root,
+      encoding: "utf8",
+    }).trim();
     const emptyTree = execFileSync("git", ["hash-object", "-w", "-t", "tree", "/dev/null"], {
       cwd: root,
       encoding: "utf8",
     }).trim();
-    const divergentCommit = execFileSync("git", ["commit-tree", emptyTree, "-m", "divergent"], {
+    const orphanCommit = execFileSync("git", ["commit-tree", emptyTree, "-m", "orphan"], {
       cwd: root,
       encoding: "utf8",
     }).trim();
-    const runAncestry = (commit) =>
+    const divergentCommit = execFileSync(
+      "git",
+      ["commit-tree", emptyTree, "-p", verifierCommit, "-m", "divergent"],
+      { cwd: root, encoding: "utf8" },
+    ).trim();
+    const runAncestry = (commit, tooling = toolingCommit) =>
       spawnSync(
         "/bin/bash",
         [
           "-c",
-          'source "$1"; ROOT=$2; require_public_workflow_ancestry "$3" "$4"',
+          'source "$1"; ROOT=$2; require_public_workflow_ancestry "$3" "$4" "$5"',
           "public-workflow-ancestry",
           verifier,
           root,
           verifierCommit,
           commit,
+          tooling,
         ],
         { encoding: "utf8" },
       );
 
     const valid = runAncestry(workflowCommit);
     assert.equal(valid.status, 0, valid.stderr);
+    const current = runAncestry(toolingCommit);
+    assert.equal(current.status, 0, current.stderr);
+    const orphan = runAncestry(orphanCommit);
+    assert.notEqual(orphan.status, 0);
+    assert.match(orphan.stderr, /public workflow commit is not a descendant/);
     const divergent = runAncestry(divergentCommit);
     assert.notEqual(divergent.status, 0);
-    assert.match(divergent.stderr, /public workflow commit is not a descendant/);
+    assert.match(divergent.stderr, /public workflow commit is not an ancestor of protected tooling/);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/scripts/homebrew-release.test.js
+++ b/scripts/homebrew-release.test.js
@@ -384,6 +384,11 @@ test("Homebrew verifier is publishability-gated, native, token-free, and read-on
   assert.match(source, /validate-release-publication\.mjs" public-proof/);
   assert.match(source, /public-verifier-run-id/);
   assert.match(source, /artifact\.digest|\.digest \| select/);
+  assert.match(source, /git -C "\$ROOT" remote get-url origin/);
+  assert.match(source, /git ls-remote "\$expected_remote"/);
+  assert.match(source, /fetch --quiet --no-tags/);
+  assert.match(source, /merge-base --is-ancestor "\$tooling_commit" "\$remote_commit"/);
+  assert.match(source, /protected tooling commit is not in canonical default-branch history/);
   assert.match(
     source,
     /CRABBOX_VERIFY_EXEC_ARCH="\$native_arch"[\s\S]*scripts\/verify-release\.sh/,
@@ -434,6 +439,59 @@ test("Homebrew verifier cleanup survives main function scope", () => {
   assert.equal(fs.existsSync(root), false);
 });
 
+test("public workflow commit must descend from the provenance verifier", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-public-workflow-ancestry-"));
+  try {
+    execFileSync("git", ["init", "-b", "main"], { cwd: root, stdio: "ignore" });
+    execFileSync("git", ["config", "user.name", "Release Test"], { cwd: root });
+    execFileSync("git", ["config", "user.email", "release@example.test"], { cwd: root });
+    fs.writeFileSync(path.join(root, "base.txt"), "verifier\n");
+    execFileSync("git", ["add", "base.txt"], { cwd: root });
+    execFileSync("git", ["commit", "-m", "verifier"], { cwd: root, stdio: "ignore" });
+    const verifierCommit = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: root,
+      encoding: "utf8",
+    }).trim();
+    fs.writeFileSync(path.join(root, "workflow.txt"), "workflow\n");
+    execFileSync("git", ["add", "workflow.txt"], { cwd: root });
+    execFileSync("git", ["commit", "-m", "workflow"], { cwd: root, stdio: "ignore" });
+    const workflowCommit = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: root,
+      encoding: "utf8",
+    }).trim();
+    const emptyTree = execFileSync("git", ["hash-object", "-w", "-t", "tree", "/dev/null"], {
+      cwd: root,
+      encoding: "utf8",
+    }).trim();
+    const divergentCommit = execFileSync("git", ["commit-tree", emptyTree, "-m", "divergent"], {
+      cwd: root,
+      encoding: "utf8",
+    }).trim();
+    const runAncestry = (commit) =>
+      spawnSync(
+        "/bin/bash",
+        [
+          "-c",
+          'source "$1"; ROOT=$2; require_public_workflow_ancestry "$3" "$4"',
+          "public-workflow-ancestry",
+          verifier,
+          root,
+          verifierCommit,
+          commit,
+        ],
+        { encoding: "utf8" },
+      );
+
+    const valid = runAncestry(workflowCommit);
+    assert.equal(valid.status, 0, valid.stderr);
+    const divergent = runAncestry(divergentCommit);
+    assert.notEqual(divergent.status, 0);
+    assert.match(divergent.stderr, /public workflow commit is not a descendant/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("public Homebrew proof binds the current release, successful run, both native proofs, and local bytes", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-public-proof-"));
   const assetDirectory = path.join(root, "assets");
@@ -450,6 +508,9 @@ test("public Homebrew proof binds the current release, successful run, both nati
     }),
   );
   const notes = "exact notes\n";
+  const verifierCommit = "c".repeat(40);
+  const workflowCommit = "d".repeat(40);
+  const wrongCommit = "e".repeat(40);
   fs.writeFileSync(path.join(root, "names.txt"), `${names.join("\n")}\n`);
   fs.writeFileSync(path.join(root, "notes.md"), notes);
   const assets = names.map((name, index) => ({
@@ -478,7 +539,7 @@ test("public Homebrew proof binds the current release, successful run, both nati
   const run = {
     id: 9002,
     name: "Verify Release Assets",
-    display_title: `Verify published 123 for v1.2.3 at ${"c".repeat(40)}`,
+    display_title: `Verify published 123 for v1.2.3 at ${verifierCommit}`,
     path: ".github/workflows/release-assets.yml",
     workflow_id: 77,
     workflow_url: "https://api.github.com/repos/openclaw/crabbox/actions/workflows/77",
@@ -486,10 +547,10 @@ test("public Homebrew proof binds the current release, successful run, both nati
     status: "completed",
     conclusion: "success",
     head_branch: "main",
-    head_sha: "c".repeat(40),
+    head_sha: workflowCommit,
     repository: { full_name: "openclaw/crabbox" },
     head_repository: { full_name: "openclaw/crabbox" },
-    head_commit: { id: "c".repeat(40) },
+    head_commit: { id: workflowCommit },
     run_attempt: 1,
     created_at: "2026-07-10T10:10:00Z",
     run_started_at: "2026-07-10T10:10:01Z",
@@ -512,7 +573,7 @@ test("public Homebrew proof binds the current release, successful run, both nati
         expired: false,
         created_at: "2026-07-10T10:11:00Z",
         updated_at: "2026-07-10T10:11:00Z",
-        workflow_run: { id: 9002, head_branch: "main", head_sha: "c".repeat(40) },
+        workflow_run: { id: 9002, head_branch: "main", head_sha: workflowCommit },
       }),
     ),
   };
@@ -525,7 +586,8 @@ test("public Homebrew proof binds the current release, successful run, both nati
       tag: "v1.2.3",
       tagObject: "a".repeat(40),
       sourceCommit: "b".repeat(40),
-      verifierCommit: "c".repeat(40),
+      verifierCommit,
+      workflowCommit,
       verifierArch: arch,
       title: "v1.2.3",
       targetCommitish: "main",
@@ -566,7 +628,8 @@ test("public Homebrew proof binds the current release, successful run, both nati
     CRABBOX_PUBLISH_TAG: "v1.2.3",
     CRABBOX_PUBLISH_TAG_OBJECT: "a".repeat(40),
     CRABBOX_PUBLISH_SOURCE_COMMIT: "b".repeat(40),
-    CRABBOX_PUBLISH_VERIFIER_COMMIT: "c".repeat(40),
+    CRABBOX_PUBLISH_VERIFIER_COMMIT: verifierCommit,
+    CRABBOX_PUBLISH_WORKFLOW_COMMIT: workflowCommit,
     CRABBOX_PUBLISH_VERIFIER_RUN_ID: "9002",
     CRABBOX_PUBLISH_DEFAULT_BRANCH: "main",
     CRABBOX_PUBLISH_WORKFLOW_PATH: ".github/workflows/release-assets.yml",
@@ -574,6 +637,42 @@ test("public Homebrew proof binds the current release, successful run, both nati
   try {
     const valid = spawnSync(process.execPath, args, { encoding: "utf8", env });
     assert.equal(valid.status, 0, valid.stderr);
+    assert.equal(JSON.parse(valid.stdout).verifierCommit, verifierCommit);
+    assert.equal(JSON.parse(valid.stdout).workflowCommit, workflowCommit);
+
+    const wrongWorkflow = spawnSync(process.execPath, args, {
+      encoding: "utf8",
+      env: { ...env, CRABBOX_PUBLISH_WORKFLOW_COMMIT: wrongCommit },
+    });
+    assert.notEqual(wrongWorkflow.status, 0);
+    assert.match(wrongWorkflow.stderr, /protected workflow identity/);
+
+    const armProof = proof("arm64");
+    armProof.workflowCommit = wrongCommit;
+    delete armProof.manifestSha256;
+    armProof.manifestSha256 = createHash("sha256").update(JSON.stringify(armProof)).digest("hex");
+    writeJson("arm.json", armProof);
+    const wrongProofWorkflow = spawnSync(process.execPath, args, { encoding: "utf8", env });
+    assert.notEqual(wrongProofWorkflow.status, 0);
+    assert.match(wrongProofWorkflow.stderr, /proof does not bind/);
+    writeJson("arm.json", proof("arm64"));
+
+    artifacts.artifacts[1].workflow_run.head_sha = wrongCommit;
+    writeJson("artifacts.json", artifacts);
+    const artifactHeadDrift = spawnSync(process.execPath, args, { encoding: "utf8", env });
+    assert.notEqual(artifactHeadDrift.status, 0);
+    assert.match(artifactHeadDrift.stderr, /not bound to the selected verifier run/);
+    artifacts.artifacts[1].workflow_run.head_sha = workflowCommit;
+    writeJson("artifacts.json", artifacts);
+
+    run.head_sha = wrongCommit;
+    run.head_commit.id = wrongCommit;
+    writeJson("run.json", run);
+    const runHeadDrift = spawnSync(process.execPath, args, { encoding: "utf8", env });
+    assert.notEqual(runHeadDrift.status, 0);
+    assert.match(runHeadDrift.stderr, /protected workflow identity/);
+    run.head_sha = workflowCommit;
+    run.head_commit.id = workflowCommit;
 
     run.created_at = "2026-07-10T10:03:00Z";
     run.run_started_at = "2026-07-10T10:04:00Z";
@@ -581,6 +680,31 @@ test("public Homebrew proof binds the current release, successful run, both nati
     const stale = spawnSync(process.execPath, args, { encoding: "utf8", env });
     assert.notEqual(stale.status, 0);
     assert.match(stale.stderr, /not newer than release updated_at/);
+
+    run.head_sha = verifierCommit;
+    run.head_commit.id = verifierCommit;
+    run.created_at = "2026-07-10T10:10:00Z";
+    run.run_started_at = "2026-07-10T10:10:01Z";
+    writeJson("run.json", run);
+    for (const artifact of artifacts.artifacts) artifact.workflow_run.head_sha = verifierCommit;
+    writeJson("artifacts.json", artifacts);
+    for (const arch of ["arm64", "x86_64"]) {
+      const compatible = proof(arch);
+      compatible.workflowCommit = verifierCommit;
+      delete compatible.manifestSha256;
+      delete compatible.workflowCommit;
+      compatible.manifestSha256 = createHash("sha256")
+        .update(JSON.stringify(compatible))
+        .digest("hex");
+      writeJson(arch === "arm64" ? "arm.json" : "x86.json", compatible);
+    }
+    const compatibleEnv = { ...env };
+    delete compatibleEnv.CRABBOX_PUBLISH_WORKFLOW_COMMIT;
+    const sameCommitCompatible = spawnSync(process.execPath, args, {
+      encoding: "utf8",
+      env: compatibleEnv,
+    });
+    assert.equal(sameCommitCompatible.status, 0, sameCommitCompatible.stderr);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -4,18 +4,25 @@ set -euo pipefail
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 
 usage() {
-  echo "usage: $0 <release-id> <tag> <tag-object> <source-commit> <verifier-commit> <native-verifier-run-id> <confirm-tag>" >&2
+  echo "usage: $0 <release-id> <tag> <tag-object> <source-commit> <verifier-commit> [<workflow-commit>] <native-verifier-run-id> <confirm-tag>" >&2
   exit 2
 }
 
-[[ $# -eq 7 ]] || usage
+[[ $# -eq 7 || $# -eq 8 ]] || usage
 RELEASE_ID=$1
 TAG=$2
 TAG_OBJECT=$3
 SOURCE_COMMIT=$4
 VERIFIER_COMMIT=$5
-VERIFIER_RUN_ID=$6
-CONFIRM_TAG=$7
+if [[ $# -eq 8 ]]; then
+  WORKFLOW_COMMIT=$6
+  VERIFIER_RUN_ID=$7
+  CONFIRM_TAG=$8
+else
+  WORKFLOW_COMMIT=$VERIFIER_COMMIT
+  VERIFIER_RUN_ID=$6
+  CONFIRM_TAG=$7
+fi
 
 [[ "$RELEASE_ID" =~ ^[1-9][0-9]*$ ]] || usage
 [[ "$VERIFIER_RUN_ID" =~ ^[1-9][0-9]*$ ]] || usage
@@ -23,6 +30,7 @@ CONFIRM_TAG=$7
 [[ "$TAG_OBJECT" =~ ^[0-9a-f]{40}$ ]] || usage
 [[ "$SOURCE_COMMIT" =~ ^[0-9a-f]{40}$ ]] || usage
 [[ "$VERIFIER_COMMIT" =~ ^[0-9a-f]{40}$ ]] || usage
+[[ "$WORKFLOW_COMMIT" =~ ^[0-9a-f]{40}$ ]] || usage
 [[ "$CONFIRM_TAG" == "$TAG" ]] || {
   echo "publication confirmation must exactly equal $TAG" >&2
   exit 2
@@ -48,18 +56,26 @@ PROTECTED_TOOLING=(
   scripts/verify-release-source.sh
 )
 actual_head=$(git -C "$ROOT" rev-parse --verify 'HEAD^{commit}')
-[[ "$actual_head" == "$VERIFIER_COMMIT" ]] || {
-  echo "local HEAD must exactly equal protected verifier commit $VERIFIER_COMMIT" >&2
+[[ "$actual_head" == "$WORKFLOW_COMMIT" ]] || {
+  echo "local HEAD must exactly equal protected workflow commit $WORKFLOW_COMMIT" >&2
+  exit 1
+}
+git -C "$ROOT" merge-base --is-ancestor "$SOURCE_COMMIT" "$VERIFIER_COMMIT" || {
+  echo "release source commit is not an ancestor of the provenance verifier" >&2
+  exit 1
+}
+git -C "$ROOT" merge-base --is-ancestor "$VERIFIER_COMMIT" "$WORKFLOW_COMMIT" || {
+  echo "provenance verifier commit is not an ancestor of protected workflow tooling" >&2
   exit 1
 }
 tooling_status=$(git -C "$ROOT" status --porcelain=v1 --untracked-files=all -- "${PROTECTED_TOOLING[@]}")
 [[ -z "$tooling_status" ]] || {
-  echo "protected release tooling is dirty; publish only from the exact clean verifier commit" >&2
+  echo "protected release tooling is dirty; publish only from the exact clean workflow commit" >&2
   printf '%s\n' "$tooling_status" >&2
   exit 1
 }
-git -C "$ROOT" diff --quiet "$VERIFIER_COMMIT" -- "${PROTECTED_TOOLING[@]}" || {
-  echo "protected release tooling does not match verifier commit $VERIFIER_COMMIT" >&2
+git -C "$ROOT" diff --quiet "$WORKFLOW_COMMIT" -- "${PROTECTED_TOOLING[@]}" || {
+  echo "protected release tooling does not match workflow commit $WORKFLOW_COMMIT" >&2
   exit 1
 }
 [[ "${CRABBOX_RELEASE_SERIALIZATION_CONFIRMED:-}" == "$TAG:$RELEASE_ID" ]] || {
@@ -77,12 +93,12 @@ WORKFLOW_PATH=.github/workflows/release-assets.yml
 WORK=$(mktemp -d "${TMPDIR:-/tmp}/crabbox-publish-release.XXXXXX")
 chmod 700 "$WORK"
 trap 'rm -rf "$WORK"' EXIT
-git -C "$ROOT" show "$VERIFIER_COMMIT:release/records/$TAG.json" >"$WORK/protected-release-record.json" || {
-  echo "protected verifier commit does not contain the release record for $TAG" >&2
+git -C "$ROOT" show "$WORKFLOW_COMMIT:release/records/$TAG.json" >"$WORK/protected-release-record.json" || {
+  echo "protected workflow commit does not contain the release record for $TAG" >&2
   exit 1
 }
-git -C "$ROOT" show "$VERIFIER_COMMIT:.github/release-allowed-signers" >"$WORK/protected-release-allowed-signers" || {
-  echo "protected verifier commit does not contain the release signer policy" >&2
+git -C "$ROOT" show "$WORKFLOW_COMMIT:.github/release-allowed-signers" >"$WORK/protected-release-allowed-signers" || {
+  echo "protected workflow commit does not contain the release signer policy" >&2
   exit 1
 }
 
@@ -115,6 +131,7 @@ publication_environment() {
     "CRABBOX_PUBLISH_TAG_OBJECT=$TAG_OBJECT" \
     "CRABBOX_PUBLISH_SOURCE_COMMIT=$SOURCE_COMMIT" \
     "CRABBOX_PUBLISH_VERIFIER_COMMIT=$VERIFIER_COMMIT" \
+    "CRABBOX_PUBLISH_WORKFLOW_COMMIT=$WORKFLOW_COMMIT" \
     "CRABBOX_PUBLISH_VERIFIER_RUN_ID=$VERIFIER_RUN_ID" \
     "CRABBOX_PUBLISH_DEFAULT_BRANCH=$DEFAULT_BRANCH" \
     "CRABBOX_PUBLISH_WORKFLOW_PATH=$WORKFLOW_PATH" \
@@ -158,10 +175,10 @@ verify_protected_source() {
     "$REPOSITORY" "$DEFAULT_BRANCH" "$TAG" >/dev/null
   jq -e \
     --arg branch "$DEFAULT_BRANCH" \
-    --arg commit "$VERIFIER_COMMIT" '
+    --arg commit "$WORKFLOW_COMMIT" '
       .name == $branch and .protected == true and .commit.sha == $commit
     ' "$WORK/$prefix-branch.json" >/dev/null || {
-    echo "protected default-branch head does not match the verifier commit" >&2
+    echo "protected default-branch head does not match the workflow commit" >&2
     exit 1
   }
   jq -e \
@@ -192,7 +209,7 @@ verify_protected_source() {
   RELEASE_TAG=$TAG \
   EXPECTED_TAG_OBJECT=$TAG_OBJECT \
   EXPECTED_TAG_COMMIT=$SOURCE_COMMIT \
-  TRUSTED_HEAD=$VERIFIER_COMMIT \
+  TRUSTED_HEAD=$WORKFLOW_COMMIT \
   RELEASE_RECORD="$WORK/protected-release-record.json" \
   ALLOWED_SIGNERS="$WORK/protected-release-allowed-signers" \
   REQUIRE_PUBLISHABLE=1 \

--- a/scripts/publish-release.test.js
+++ b/scripts/publish-release.test.js
@@ -35,7 +35,12 @@ function git(root, ...args) {
   }).trim();
 }
 
-function prepareFixture({ publishable = true, dynamicRunName = true } = {}) {
+function prepareFixture({
+  publishable = true,
+  dynamicRunName = true,
+  splitCommit = false,
+  divergentWorkflow = false,
+} = {}) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-publish-test-"));
   const checkout = path.join(root, "repo");
   const api = path.join(root, "api");
@@ -83,6 +88,34 @@ function prepareFixture({ publishable = true, dynamicRunName = true } = {}) {
     "test: protected publication fixture",
   );
   const verifierCommit = git(checkout, "rev-parse", "HEAD");
+  let workflowCommit = verifierCommit;
+  if (splitCommit) {
+    fs.writeFileSync(path.join(checkout, "workflow-tooling.txt"), "protected workflow tooling\n");
+    git(checkout, "add", "workflow-tooling.txt");
+    git(
+      checkout,
+      "-c",
+      "commit.gpgsign=false",
+      "commit",
+      "-m",
+      "test: advance protected workflow tooling",
+    );
+    workflowCommit = git(checkout, "rev-parse", "HEAD");
+  } else if (divergentWorkflow) {
+    const tree = git(checkout, "write-tree");
+    workflowCommit = git(
+      checkout,
+      "-c",
+      "commit.gpgsign=false",
+      "commit-tree",
+      tree,
+      "-p",
+      sourceCommit,
+      "-m",
+      "test: divergent workflow tooling",
+    );
+    git(checkout, "switch", "--detach", workflowCommit);
+  }
 
   const version = tag.slice(1);
   const assetNames = execFileSync(
@@ -143,7 +176,12 @@ function prepareFixture({ publishable = true, dynamicRunName = true } = {}) {
   writeJson(path.join(api, "branch.json"), {
     name: "main",
     protected: true,
-    commit: { sha: verifierCommit },
+    commit: { sha: workflowCommit },
+  });
+  writeJson(path.join(api, "branch-wrong.json"), {
+    name: "main",
+    protected: true,
+    commit: { sha: "f".repeat(40) },
   });
   writeJson(path.join(api, "ruleset-list.json"), [
     { id: 701 },
@@ -442,7 +480,7 @@ function prepareFixture({ publishable = true, dynamicRunName = true } = {}) {
     verification: { verified: true, reason: "valid" },
   });
   const workflowUrl = `https://api.github.com/repos/${repository}/actions/workflows/${workflowId}`;
-  writeJson(path.join(api, "run.json"), {
+  const runRecord = {
     id: runId,
     name: dynamicRunName
       ? `Verify draft ${releaseId} for ${tag} at ${verifierCommit}`
@@ -455,13 +493,19 @@ function prepareFixture({ publishable = true, dynamicRunName = true } = {}) {
     status: "completed",
     conclusion: "success",
     head_branch: "main",
-    head_sha: verifierCommit,
+    head_sha: workflowCommit,
     repository: { full_name: repository },
     head_repository: { full_name: repository },
-    head_commit: { id: verifierCommit },
+    head_commit: { id: workflowCommit },
     run_attempt: 1,
     created_at: "2026-07-10T10:05:00Z",
     run_started_at: "2026-07-10T10:05:01Z",
+  };
+  writeJson(path.join(api, "run.json"), runRecord);
+  writeJson(path.join(api, "run-wrong-head.json"), {
+    ...runRecord,
+    head_sha: verifierCommit,
+    head_commit: { id: verifierCommit },
   });
   writeJson(path.join(api, "workflow.json"), {
     id: workflowId,
@@ -489,7 +533,7 @@ function prepareFixture({ publishable = true, dynamicRunName = true } = {}) {
       expired: false,
       created_at: "2026-07-10T10:04:00Z",
       updated_at: "2026-07-10T10:04:00Z",
-      workflow_run: { id: runId, head_branch: "main", head_sha: verifierCommit },
+      workflow_run: { id: runId, head_branch: "main", head_sha: workflowCommit },
     },
   ];
   let driftArmZipSize = 0;
@@ -508,6 +552,7 @@ function prepareFixture({ publishable = true, dynamicRunName = true } = {}) {
       tagObject,
       sourceCommit,
       verifierCommit,
+      ...(workflowCommit === verifierCommit ? {} : { workflowCommit }),
       verifierArch: arch,
       title: release.name,
       targetCommitish: release.target_commitish,
@@ -587,7 +632,7 @@ function prepareFixture({ publishable = true, dynamicRunName = true } = {}) {
       workflow_run: {
         id: runId,
         head_branch: "main",
-        head_sha: verifierCommit,
+        head_sha: workflowCommit,
       },
     });
   }
@@ -650,7 +695,9 @@ if (method === "PATCH") {
 }
 if (method !== "GET") process.exit(93);
 if (endpoint === "repos/${repository}") outputFile("repository.json");
-else if (endpoint === "repos/${repository}/branches/main") outputFile("branch.json");
+else if (endpoint === "repos/${repository}/branches/main") {
+  outputFile(process.env.MOCK_MODE === "current-main-drift" ? "branch-wrong.json" : "branch.json");
+}
 else if (endpoint === "repos/${repository}/rulesets?per_page=100") {
   outputFile(
     [
@@ -735,7 +782,9 @@ else if (endpoint === "repos/${repository}/rulesets/705") {
 }
 else if (endpoint === "repos/${repository}/git/ref/tags/${tag}") outputFile("tag-ref.json");
 else if (endpoint === "repos/${repository}/git/tags/${tagObject}") outputFile("tag-object.json");
-else if (endpoint === "repos/${repository}/actions/runs/${runId}") outputFile("run.json");
+else if (endpoint === "repos/${repository}/actions/runs/${runId}") {
+  outputFile(process.env.MOCK_MODE === "run-head-drift" ? "run-wrong-head.json" : "run.json");
+}
 else if (endpoint === "repos/${repository}/immutable-releases") {
   outputJson({
     enabled: process.env.MOCK_MODE !== "immutable-disabled",
@@ -793,7 +842,14 @@ else if (endpoint === "repos/${repository}/releases/${releaseId}") {
   fs.chmodSync(gh, 0o755);
 
   const log = path.join(root, "gh.log");
-  const run = (mode, { serializationConfirmed = true } = {}) => {
+  const run = (
+    mode,
+    {
+      serializationConfirmed = true,
+      suppliedWorkflowCommit = workflowCommit,
+      explicitWorkflow = splitCommit || divergentWorkflow,
+    } = {},
+  ) => {
     const childEnv = {
       ...process.env,
       PATH: `${bin}:${process.env.PATH}`,
@@ -806,18 +862,19 @@ else if (endpoint === "repos/${repository}/releases/${releaseId}") {
     } else {
       delete childEnv.CRABBOX_RELEASE_SERIALIZATION_CONFIRMED;
     }
+    const args = [
+      path.join(checkout, "scripts", "publish-release.sh"),
+      String(releaseId),
+      tag,
+      tagObject,
+      sourceCommit,
+      verifierCommit,
+    ];
+    if (explicitWorkflow) args.push(suppliedWorkflowCommit);
+    args.push(String(runId), tag);
     return spawnSync(
       "bash",
-      [
-        path.join(checkout, "scripts", "publish-release.sh"),
-        String(releaseId),
-        tag,
-        tagObject,
-        sourceCommit,
-        verifierCommit,
-        String(runId),
-        tag,
-      ],
+      args,
       {
         cwd: checkout,
         env: childEnv,
@@ -834,7 +891,7 @@ else if (endpoint === "repos/${repository}/releases/${releaseId}") {
       .filter(Boolean)
       .filter((line) => !line.startsWith("GET\t"));
   };
-  return { checkout, root, run, mutations };
+  return { checkout, root, run, mutations, verifierCommit, workflowCommit };
 }
 
 function withFixture(options, callback) {
@@ -1118,7 +1175,7 @@ test("local HEAD drift fails before any network call", () => {
     git(checkout, "-c", "commit.gpgsign=false", "commit", "-m", "test: move local head");
     const result = run("success");
     assert.notEqual(result.status, 0);
-    assert.match(result.stderr, /local HEAD must exactly equal protected verifier commit/);
+    assert.match(result.stderr, /local HEAD must exactly equal protected workflow commit/);
     assert.deepEqual(mutations(), []);
   });
 });
@@ -1147,6 +1204,54 @@ test("exact protected proof performs one draft-state PATCH and no other mutation
     assert.equal(result.status, 0, result.stderr || result.stdout);
     assert.match(result.stdout, /Published exact verified release v0\.37\.0/);
     assert.deepEqual(mutations(), [`PATCH\trepos/${repository}/releases/${releaseId}`]);
+  });
+});
+
+test("split verifier and workflow commits permit publication from exact protected main", () => {
+  withFixture({ splitCommit: true }, ({ run, mutations, verifierCommit, workflowCommit }) => {
+    assert.notEqual(workflowCommit, verifierCommit);
+    const result = run("success");
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.deepEqual(mutations(), [`PATCH\trepos/${repository}/releases/${releaseId}`]);
+  });
+});
+
+test("mismatched supplied workflow commit fails before any network call", () => {
+  withFixture({ splitCommit: true }, ({ run, mutations, verifierCommit }) => {
+    const result = run("success", {
+      explicitWorkflow: true,
+      suppliedWorkflowCommit: verifierCommit,
+    });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /local HEAD must exactly equal protected workflow commit/);
+    assert.deepEqual(mutations(), []);
+  });
+});
+
+test("selected verifier run with a different workflow head fails before publication", () => {
+  withFixture({ splitCommit: true }, ({ run, mutations }) => {
+    const result = run("run-head-drift");
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /protected workflow identity/);
+    assert.deepEqual(mutations(), []);
+  });
+});
+
+test("divergent workflow commit fails before any network call", () => {
+  withFixture({ divergentWorkflow: true }, ({ run, mutations }) => {
+    const result = run("success");
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /provenance verifier commit is not an ancestor/);
+    assert.deepEqual(mutations(), []);
+  });
+});
+
+test("workflow commit that is not current protected main fails before publication", () => {
+  withFixture({ splitCommit: true }, ({ run, mutations }) => {
+    const result = run("current-main-drift");
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /protected default-branch head does not match the workflow commit/);
+    assert.deepEqual(mutations(), []);
   });
 });
 

--- a/scripts/publish-release.test.js
+++ b/scripts/publish-release.test.js
@@ -494,6 +494,7 @@ function prepareFixture({ publishable = true, dynamicRunName = true } = {}) {
   ];
   let driftArmZipSize = 0;
   let metadataDriftArmZipSize = 0;
+  let workflowDriftArmZipSize = 0;
   for (const [arch, artifactId] of [
     ["arm64", 501],
     ["x86_64", 502],
@@ -556,6 +557,24 @@ function prepareFixture({ publishable = true, dynamicRunName = true } = {}) {
         path.join(metadataDriftDirectory, "verified-assets.json"),
       ]);
       metadataDriftArmZipSize = fs.statSync(metadataDriftZip).size;
+
+      const workflowDriftProof = structuredClone(proof);
+      workflowDriftProof.workflowCommit = "d".repeat(40);
+      delete workflowDriftProof.manifestSha256;
+      workflowDriftProof.manifestSha256 = sha256(
+        Buffer.from(JSON.stringify(workflowDriftProof), "utf8"),
+      );
+      const workflowDriftDirectory = path.join(root, "proof-arm64-workflow-drift");
+      fs.mkdirSync(workflowDriftDirectory);
+      writeJson(path.join(workflowDriftDirectory, "verified-assets.json"), workflowDriftProof);
+      const workflowDriftZip = path.join(api, "proof-arm64-workflow-drift.zip");
+      execFileSync("zip", [
+        "-q",
+        "-j",
+        workflowDriftZip,
+        path.join(workflowDriftDirectory, "verified-assets.json"),
+      ]);
+      workflowDriftArmZipSize = fs.statSync(workflowDriftZip).size;
     }
     artifactRows.push({
       id: artifactId,
@@ -590,6 +609,13 @@ function prepareFixture({ publishable = true, dynamicRunName = true } = {}) {
   writeJson(path.join(api, "artifacts-proof-metadata-drift.json"), {
     total_count: 3,
     artifacts: proofMetadataDriftArtifacts,
+  });
+  const proofWorkflowDriftArtifacts = structuredClone(artifactRows);
+  proofWorkflowDriftArtifacts[1].size_in_bytes = workflowDriftArmZipSize;
+  proofWorkflowDriftArtifacts[1].digest = `sha256:${sha256(fs.readFileSync(path.join(api, "proof-arm64-workflow-drift.zip")))}`;
+  writeJson(path.join(api, "artifacts-proof-workflow-drift.json"), {
+    total_count: 3,
+    artifacts: proofWorkflowDriftArtifacts,
   });
 
   const gh = path.join(bin, "gh");
@@ -724,7 +750,9 @@ else if (endpoint === "repos/${repository}/actions/runs/${runId}/artifacts?per_p
       : process.env.MOCK_MODE === "proof-drift"
         ? "artifacts-proof-drift.json"
         : process.env.MOCK_MODE === "proof-metadata-drift"
-          ? "artifacts-proof-metadata-drift.json"
+        ? "artifacts-proof-metadata-drift.json"
+        : process.env.MOCK_MODE === "proof-workflow-drift"
+          ? "artifacts-proof-workflow-drift.json"
           : "artifacts.json",
   );
 } else if (endpoint === "repos/${repository}/actions/artifacts/501/zip") {
@@ -733,7 +761,9 @@ else if (endpoint === "repos/${repository}/actions/runs/${runId}/artifacts?per_p
       ? "proof-arm64-drift.zip"
       : process.env.MOCK_MODE === "proof-metadata-drift"
         ? "proof-arm64-metadata-drift.zip"
-        : "proof-arm64.zip",
+        : process.env.MOCK_MODE === "proof-workflow-drift"
+          ? "proof-arm64-workflow-drift.zip"
+          : "proof-arm64.zip",
   );
 }
 else if (endpoint === "repos/${repository}/actions/artifacts/502/zip") outputFile("proof-x86_64.zip");
@@ -848,6 +878,15 @@ test("tampered native proof draft metadata fails before any mutation", () => {
     const result = run("proof-metadata-drift");
     assert.notEqual(result.status, 0);
     assert.match(result.stderr, /proof draft record differs from current release/);
+    assert.deepEqual(mutations(), []);
+  });
+});
+
+test("tampered native proof workflow commit fails before any mutation", () => {
+  withFixture({}, ({ run, mutations }) => {
+    const result = run("proof-workflow-drift");
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /proof does not bind/);
     assert.deepEqual(mutations(), []);
   });
 });

--- a/scripts/release-workflow.test.js
+++ b/scripts/release-workflow.test.js
@@ -17,6 +17,10 @@ test("release workflow is verifier-only, protected-default, dual-native, and tok
   assert.match(workflow, /expected_workflow_ref="\$GITHUB_REPOSITORY\/\.github\/workflows\/release-assets\.yml@\$expected_ref"/);
   assert.match(workflow, /\[\[ "\$GITHUB_WORKFLOW_REF" == "\$expected_workflow_ref" \]\]/);
   assert.match(workflow, /verify-github-release-policy\.mjs/);
+  assert.match(workflow, /workflow_commit:\n\s+description: "Current protected default-branch workflow commit SHA"\n\s+required: true/);
+  assert.match(workflow, /\[\[ "\$\{\{ github\.workflow_sha \}\}" == "\$WORKFLOW_COMMIT" \]\]/);
+  assert.match(workflow, /git merge-base --is-ancestor "\$VERIFIER_COMMIT" "\$WORKFLOW_COMMIT"/);
+  assert.match(workflow, /git merge-base --is-ancestor "\$SOURCE_COMMIT" "\$VERIFIER_COMMIT"/);
   assert.match(workflow, /ref: \$\{\{ github\.workflow_sha \}\}/);
   assert.match(workflow, /persist-credentials: false/);
   assert.match(
@@ -40,6 +44,8 @@ test("release workflow is verifier-only, protected-default, dual-native, and tok
   );
   assert.match(workflow, /name: Execute candidate in isolated clean job without release credentials[\s\S]*exec env -i/);
   assert.match(workflow, /CRABBOX_VERIFY_EXEC_ARCH="\$VERIFY_ARCH"/);
+  assert.equal((workflow.match(/CRABBOX_VERIFY_TOOLING_COMMIT="\$WORKFLOW_COMMIT"/g) ?? []).length, 2);
+  assert.match(workflow, /verifierCommit: process\.env\.VERIFIER_COMMIT,\n\s+workflowCommit: process\.env\.WORKFLOW_COMMIT,/);
   assert.match(workflow, /scripts\/verify-release\.sh/);
   assert.match(workflow, /name: release-input/);
   assert.match(workflow, /name: verified-assets-\$\{\{ matrix\.arch \}\}/);
@@ -61,6 +67,97 @@ test("release workflow is verifier-only, protected-default, dual-native, and tok
   );
 });
 
+test("release verifier rejects provenance that is not an ancestor of protected tooling", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-verifier-ancestry-"));
+  try {
+    fs.mkdirSync(path.join(directory, "scripts"));
+    fs.copyFileSync(
+      path.join(repoRoot, "scripts", "verify-release.sh"),
+      path.join(directory, "scripts", "verify-release.sh"),
+    );
+    fs.writeFileSync(path.join(directory, "scripts", "release-config.sh"), "#!/usr/bin/env bash\n");
+    execFileSync("git", ["init", "-b", "main"], { cwd: directory, stdio: "ignore" });
+    execFileSync("git", ["config", "user.name", "Release Test"], { cwd: directory });
+    execFileSync("git", ["config", "user.email", "release@example.test"], { cwd: directory });
+    execFileSync("git", ["add", "scripts"], { cwd: directory });
+    execFileSync("git", ["commit", "-m", "tooling base"], { cwd: directory, stdio: "ignore" });
+    const base = execFileSync("git", ["rev-parse", "HEAD"], { cwd: directory, encoding: "utf8" }).trim();
+    fs.writeFileSync(path.join(directory, "tooling.txt"), "protected tooling\n");
+    execFileSync("git", ["add", "tooling.txt"], { cwd: directory });
+    execFileSync("git", ["commit", "-m", "tooling head"], { cwd: directory, stdio: "ignore" });
+    const tooling = execFileSync("git", ["rev-parse", "HEAD"], { cwd: directory, encoding: "utf8" }).trim();
+    execFileSync("git", ["switch", "--detach", base], { cwd: directory, stdio: "ignore" });
+    fs.writeFileSync(path.join(directory, "unrelated.txt"), "unrelated verifier\n");
+    execFileSync("git", ["add", "unrelated.txt"], { cwd: directory });
+    execFileSync("git", ["commit", "-m", "unrelated verifier"], { cwd: directory, stdio: "ignore" });
+    const unrelated = execFileSync("git", ["rev-parse", "HEAD"], { cwd: directory, encoding: "utf8" }).trim();
+    execFileSync("git", ["switch", "--detach", tooling], { cwd: directory, stdio: "ignore" });
+
+    const bin = path.join(directory, "bin");
+    fs.mkdirSync(bin);
+    fs.writeFileSync(
+      path.join(bin, "uname"),
+      "#!/bin/sh\ncase \"${1:-}\" in -s) echo Darwin ;; -m) echo arm64 ;; *) exit 64 ;; esac\n",
+    );
+    fs.chmodSync(path.join(bin, "uname"), 0o755);
+    for (const tool of ["codesign", "lipo"]) {
+      fs.writeFileSync(path.join(bin, tool), "#!/bin/sh\nexit 0\n");
+      fs.chmodSync(path.join(bin, tool), 0o755);
+    }
+    const result = spawnSync(
+      "bash",
+      [
+        path.join(directory, "scripts", "verify-release.sh"),
+        "v1.2.3",
+        directory,
+        "a".repeat(40),
+        "b".repeat(40),
+        unrelated,
+      ],
+      {
+        cwd: directory,
+        encoding: "utf8",
+        env: {
+          HOME: process.env.HOME,
+          PATH: `${bin}:${process.env.PATH}`,
+          CRABBOX_VERIFY_EXEC_ARCH: "arm64",
+          CRABBOX_VERIFY_MODE: "static",
+          CRABBOX_VERIFY_TOOLING_COMMIT: tooling,
+        },
+      },
+    );
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /provenance verifier commit is not an ancestor of protected tooling/);
+
+    const sourceDrift = spawnSync(
+      "bash",
+      [
+        path.join(directory, "scripts", "verify-release.sh"),
+        "v1.2.3",
+        directory,
+        "a".repeat(40),
+        unrelated,
+        base,
+      ],
+      {
+        cwd: directory,
+        encoding: "utf8",
+        env: {
+          HOME: process.env.HOME,
+          PATH: `${bin}:${process.env.PATH}`,
+          CRABBOX_VERIFY_EXEC_ARCH: "arm64",
+          CRABBOX_VERIFY_MODE: "static",
+          CRABBOX_VERIFY_TOOLING_COMMIT: tooling,
+        },
+      },
+    );
+    assert.notEqual(sourceDrift.status, 0);
+    assert.match(sourceDrift.stderr, /release source commit is not an ancestor of the provenance verifier/);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
 test("Homebrew verifier keeps downloaded proof inputs outside the protected checkout", () => {
   const workflow = read(".github/workflows/verify-homebrew.yml");
   const proofDownloadStart = workflow.indexOf("      - name: Download immutable native proof ZIPs");
@@ -68,7 +165,7 @@ test("Homebrew verifier keeps downloaded proof inputs outside the protected chec
     "      - name: Verify public Homebrew install without credentials",
   );
   const toolsStepStart = workflow.indexOf(
-    "      - name: Preserve pinned release tools in the frozen verifier path",
+    "      - name: Preserve protected release tools in the workflow path",
   );
   const toolsStepEnd = workflow.indexOf("      - name: Download frozen public release assets");
   assert.notEqual(proofDownloadStart, -1);
@@ -87,13 +184,15 @@ test("Homebrew verifier keeps downloaded proof inputs outside the protected chec
   assert.match(workflow, /WORKFLOW_SHA: \$\{\{ github\.workflow_sha \}\}/);
   assert.match(workflow, /RUN_SHA: \$\{\{ github\.sha \}\}/);
   assert.match(workflow, /\[\[ "\$WORKFLOW_SHA" == "\$RUN_SHA" \]\]/);
+  assert.match(workflow, /name: Check out protected Homebrew tooling[\s\S]*ref: \$\{\{ github\.workflow_sha \}\}/);
+  assert.doesNotMatch(workflow, /ref: \$\{\{ inputs\.verifier_commit \}\}/);
   assert.match(
     workflow,
     /name: Set up Go for build-info inspection\n\s+uses: actions\/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16/,
   );
   assert.match(workflow, /go-version-file: go\.mod/);
   assert.match(workflow, /go-version-file: go\.mod\n\s+cache: false/);
-  assert.match(workflow, /name: Preserve pinned release tools in the frozen verifier path/);
+  assert.match(workflow, /name: Preserve protected release tools in the workflow path/);
   assert.match(workflow, /tools="\$RUNNER_TEMP\/release-tools"/);
   assert.match(workflow, /brew_path=\$\(command -v brew\)/);
   assert.match(workflow, /curl_path=\$\(command -v curl\)/);
@@ -137,6 +236,8 @@ test("Homebrew verifier keeps downloaded proof inputs outside the protected chec
     /for name in artifacts\.json release\.json run\.json workflow\.json manifest\.sha256; do[\s\S]*cmp/,
   );
   const homebrewVerifier = read("scripts/verify-homebrew-release.sh");
+  assert.match(homebrewVerifier, /workflow_commit=\$\(jq -er '\.head_sha/);
+  assert.match(homebrewVerifier, /CRABBOX_PUBLISH_WORKFLOW_COMMIT="\$workflow_commit"/);
   assert.match(homebrewVerifier, /external public postflight requires the protected Homebrew workflow/);
   assert.equal(
     (homebrewVerifier.match(/freeze_public_release \\\n/g) ?? []).length,

--- a/scripts/release-workflow.test.js
+++ b/scripts/release-workflow.test.js
@@ -186,6 +186,15 @@ test("Homebrew verifier keeps downloaded proof inputs outside the protected chec
   assert.match(workflow, /\[\[ "\$WORKFLOW_SHA" == "\$RUN_SHA" \]\]/);
   assert.match(workflow, /name: Check out protected Homebrew tooling[\s\S]*ref: \$\{\{ github\.workflow_sha \}\}/);
   assert.doesNotMatch(workflow, /ref: \$\{\{ inputs\.verifier_commit \}\}/);
+  assert.ok((workflow.match(/fetch-depth: 0/g) ?? []).length >= 2);
+  for (const ancestry of [
+    /git merge-base --is-ancestor "\$SOURCE_COMMIT" "\$VERIFIER_COMMIT"/g,
+    /git merge-base --is-ancestor "\$VERIFIER_COMMIT" "\$public_workflow_commit"/g,
+    /git merge-base --is-ancestor "\$public_workflow_commit" "\$WORKFLOW_SHA"/g,
+    /git merge-base --is-ancestor "\$WORKFLOW_SHA" "\$canonical_commit"/g,
+  ]) {
+    assert.equal((workflow.match(ancestry) ?? []).length, 2);
+  }
   assert.match(
     workflow,
     /name: Set up Go for build-info inspection\n\s+uses: actions\/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16/,
@@ -229,7 +238,7 @@ test("Homebrew verifier keeps downloaded proof inputs outside the protected chec
   assert.equal(
     (workflow.match(/unset ACTIONS_ID_TOKEN_REQUEST_TOKEN ACTIONS_RUNTIME_TOKEN GH_TOKEN GITHUB_TOKEN/g) ?? [])
       .length,
-    3,
+    4,
   );
   assert.match(
     workflow,
@@ -238,6 +247,10 @@ test("Homebrew verifier keeps downloaded proof inputs outside the protected chec
   const homebrewVerifier = read("scripts/verify-homebrew-release.sh");
   assert.match(homebrewVerifier, /workflow_commit=\$\(jq -er '\.head_sha/);
   assert.match(homebrewVerifier, /CRABBOX_PUBLISH_WORKFLOW_COMMIT="\$workflow_commit"/);
+  assert.match(
+    homebrewVerifier,
+    /merge-base --is-ancestor "\$workflow_commit" "\$tooling_commit"/,
+  );
   assert.match(homebrewVerifier, /external public postflight requires the protected Homebrew workflow/);
   assert.equal(
     (homebrewVerifier.match(/freeze_public_release \\\n/g) ?? []).length,

--- a/scripts/validate-release-publication.mjs
+++ b/scripts/validate-release-publication.mjs
@@ -26,6 +26,13 @@ function positiveSafeInteger(value, label) {
   return value;
 }
 
+function commitSha(value, label) {
+  if (typeof value !== "string" || !/^[0-9a-f]{40}$/.test(value)) {
+    fail(`${label} must be a full lowercase commit SHA`);
+  }
+  return value;
+}
+
 function timestamp(value, label) {
   if (typeof value !== "string" || !Number.isFinite(Date.parse(value))) {
     fail(`${label} must be an RFC 3339 timestamp`);
@@ -41,13 +48,15 @@ function sha256(value) {
   return crypto.createHash("sha256").update(value).digest("hex");
 }
 
+const verifierCommit = requireValue("CRABBOX_PUBLISH_VERIFIER_COMMIT");
 const metadata = {
   repository: requireValue("CRABBOX_PUBLISH_REPOSITORY"),
   releaseId: Number(requireValue("CRABBOX_PUBLISH_RELEASE_ID")),
   tag: requireValue("CRABBOX_PUBLISH_TAG"),
   tagObject: requireValue("CRABBOX_PUBLISH_TAG_OBJECT"),
   sourceCommit: requireValue("CRABBOX_PUBLISH_SOURCE_COMMIT"),
-  verifierCommit: requireValue("CRABBOX_PUBLISH_VERIFIER_COMMIT"),
+  verifierCommit,
+  workflowCommit: process.env.CRABBOX_PUBLISH_WORKFLOW_COMMIT || verifierCommit,
   verifierRunId: Number(requireValue("CRABBOX_PUBLISH_VERIFIER_RUN_ID")),
   defaultBranch: requireValue("CRABBOX_PUBLISH_DEFAULT_BRANCH"),
   workflowPath: requireValue("CRABBOX_PUBLISH_WORKFLOW_PATH"),
@@ -55,6 +64,8 @@ const metadata = {
 };
 positiveSafeInteger(metadata.releaseId, "release ID");
 positiveSafeInteger(metadata.verifierRunId, "verifier run ID");
+commitSha(metadata.verifierCommit, "verifier commit");
+commitSha(metadata.workflowCommit, "workflow commit");
 
 function expectedAssetNames(file) {
   const names = fs.readFileSync(file, "utf8").split("\n").filter(Boolean);
@@ -169,10 +180,10 @@ function validateWorkflowRun(run, workflow, state = "draft") {
     run.status !== "completed" ||
     run.conclusion !== "success" ||
     run.head_branch !== metadata.defaultBranch ||
-    run.head_sha !== metadata.verifierCommit ||
+    run.head_sha !== metadata.workflowCommit ||
     run.repository?.full_name !== metadata.repository ||
     run.head_repository?.full_name !== metadata.repository ||
-    run.head_commit?.id !== metadata.verifierCommit
+    run.head_commit?.id !== metadata.workflowCommit
   ) {
     fail("native verifier run does not match the exact protected workflow identity");
   }
@@ -214,7 +225,7 @@ function validateArtifactList(value) {
     if (
       artifact.workflow_run?.id !== metadata.verifierRunId ||
       artifact.workflow_run?.head_branch !== metadata.defaultBranch ||
-      artifact.workflow_run?.head_sha !== metadata.verifierCommit
+      artifact.workflow_run?.head_sha !== metadata.workflowCommit
     ) {
       fail(`native proof artifact is not bound to the selected verifier run: ${artifact.name}`);
     }
@@ -273,6 +284,7 @@ function validateProof(manifest, arch, expectedRecord, state = "draft") {
     manifest.tagObject !== metadata.tagObject ||
     manifest.sourceCommit !== metadata.sourceCommit ||
     manifest.verifierCommit !== metadata.verifierCommit ||
+    (manifest.workflowCommit ?? manifest.verifierCommit) !== metadata.workflowCommit ||
     manifest.verifierArch !== arch
   ) {
     fail(`${arch} proof does not bind the exact ${state} release and protected verifier inputs`);
@@ -352,7 +364,13 @@ function publicProof(args) {
       fail(`local public asset digest differs from GitHub: ${asset.name}`);
     }
   }
-  process.stdout.write(`${JSON.stringify(current, null, 2)}\n`);
+  process.stdout.write(
+    `${JSON.stringify({
+      ...current,
+      verifierCommit: metadata.verifierCommit,
+      workflowCommit: metadata.workflowCommit,
+    }, null, 2)}\n`,
+  );
 }
 
 function preflight(args) {
@@ -418,6 +436,7 @@ function preflight(args) {
     tagObject: metadata.tagObject,
     sourceCommit: metadata.sourceCommit,
     verifierCommit: metadata.verifierCommit,
+    workflowCommit: metadata.workflowCommit,
     verifierRunId: metadata.verifierRunId,
     createdAt: release.created_at,
     releaseUpdatedAt: release.updated_at,
@@ -449,6 +468,7 @@ function assertState(args) {
     snapshot.tagObject !== metadata.tagObject ||
     snapshot.sourceCommit !== metadata.sourceCommit ||
     snapshot.verifierCommit !== metadata.verifierCommit ||
+    (snapshot.workflowCommit ?? snapshot.verifierCommit) !== metadata.workflowCommit ||
     snapshot.verifierRunId !== metadata.verifierRunId ||
     snapshot.notesSha256 !== sha256(Buffer.from(notes, "utf8"))
   ) {

--- a/scripts/verify-homebrew-release.sh
+++ b/scripts/verify-homebrew-release.sh
@@ -183,9 +183,13 @@ sha256_file() {
 }
 
 require_public_workflow_ancestry() {
-  local verifier_commit=$1 workflow_commit=$2
+  local verifier_commit=$1 workflow_commit=$2 tooling_commit=$3
   git -C "$ROOT" merge-base --is-ancestor "$verifier_commit" "$workflow_commit" || {
     echo "public workflow commit is not a descendant of the provenance verifier" >&2
+    return 1
+  }
+  git -C "$ROOT" merge-base --is-ancestor "$workflow_commit" "$tooling_commit" || {
+    echo "public workflow commit is not an ancestor of protected tooling" >&2
     return 1
   }
 }
@@ -194,7 +198,8 @@ freeze_public_release() {
   [[ $# -eq 10 ]] || usage
   local tag=$1 asset_dir=$2 tag_object=$3 source_commit=$4 verifier_commit=$5
   local release_id=$6 run_id=$7 proof_dir=$8 work=$9 node_bin=${10}
-  local repository=$CRABBOX_RELEASE_REPOSITORY version=${tag#v} workflow_id workflow_commit arch
+  local repository=$CRABBOX_RELEASE_REPOSITORY version=${tag#v} workflow_id workflow_commit tooling_commit arch
+  tooling_commit=${CRABBOX_VERIFY_TOOLING_COMMIT:-$verifier_commit}
   [[ "$release_id" =~ ^[1-9][0-9]*$ && "$run_id" =~ ^[1-9][0-9]*$ ]] || usage
   [[ -d "$proof_dir" && ! -L "$proof_dir" ]] || {
     echo "public proof ZIP directory must be a real directory" >&2
@@ -232,7 +237,7 @@ freeze_public_release() {
   public_api_get "repos/$repository/actions/runs/$run_id" >"$work/public-run.json"
   workflow_commit=$(jq -er '.head_sha | select(type == "string" and test("^[0-9a-f]{40}$"))' \
     "$work/public-run.json")
-  require_public_workflow_ancestry "$verifier_commit" "$workflow_commit"
+  require_public_workflow_ancestry "$verifier_commit" "$workflow_commit" "$tooling_commit"
   workflow_id=$(jq -er '.workflow_id | select(type == "number" and . > 0)' "$work/public-run.json")
   public_api_get "repos/$repository/actions/workflows/$workflow_id" >"$work/public-workflow.json"
   public_api_get "repos/$repository/actions/runs/$run_id/artifacts?per_page=100" \

--- a/scripts/verify-homebrew-release.sh
+++ b/scripts/verify-homebrew-release.sh
@@ -88,6 +88,7 @@ assert_clean_homebrew_environment() {
   while IFS= read -r name; do
     case "$name" in
       CRABBOX_HOMEBREW_CLEAN_CHILD | \
+        CRABBOX_VERIFY_TOOLING_COMMIT | \
         HOME | HOMEBREW_CACHE | HOMEBREW_NO_ANALYTICS | HOMEBREW_NO_AUTO_UPDATE | \
         HOMEBREW_NO_ENV_HINTS | HOMEBREW_NO_INSTALL_CLEANUP | \
         LC_ALL | LOGNAME | NONINTERACTIVE | PATH | PWD | SHLVL | TMPDIR | USER) ;;
@@ -101,16 +102,27 @@ assert_clean_homebrew_environment() {
 
 validate_release_identity() {
   local tag=${1:-} tag_object=${2:-} source_commit=${3:-} verifier_commit=${4:-}
+  local tooling_commit=${CRABBOX_VERIFY_TOOLING_COMMIT:-$verifier_commit}
   [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] &&
     [[ "$tag_object" =~ ^[0-9a-f]{40}$ ]] &&
     [[ "$source_commit" =~ ^[0-9a-f]{40}$ ]] &&
-    [[ "$verifier_commit" =~ ^[0-9a-f]{40}$ ]] || usage
+    [[ "$verifier_commit" =~ ^[0-9a-f]{40}$ ]] &&
+    [[ "$tooling_commit" =~ ^[0-9a-f]{40}$ ]] || usage
 }
 
 require_publishable_source() {
   local tag=$1 tag_object=$2 source_commit=$3 verifier_commit=$4
-  [[ "$(git -C "$ROOT" rev-parse HEAD)" == "$verifier_commit" ]] || {
-    echo "protected verifier checkout does not match the supplied verifier commit" >&2
+  local tooling_commit=${CRABBOX_VERIFY_TOOLING_COMMIT:-$verifier_commit}
+  [[ "$(git -C "$ROOT" rev-parse HEAD)" == "$tooling_commit" ]] || {
+    echo "protected tooling checkout does not match the supplied tooling commit" >&2
+    return 1
+  }
+  git -C "$ROOT" merge-base --is-ancestor "$verifier_commit" "$tooling_commit" || {
+    echo "provenance verifier commit is not an ancestor of protected tooling" >&2
+    return 1
+  }
+  git -C "$ROOT" merge-base --is-ancestor "$source_commit" "$verifier_commit" || {
+    echo "release source commit is not an ancestor of the provenance verifier" >&2
     return 1
   }
   (
@@ -119,14 +131,15 @@ require_publishable_source() {
       RELEASE_TAG="$tag" \
       EXPECTED_TAG_OBJECT="$tag_object" \
       EXPECTED_TAG_COMMIT="$source_commit" \
-      TRUSTED_HEAD="$verifier_commit" \
+      TRUSTED_HEAD="$tooling_commit" \
       REQUIRE_PUBLISHABLE=1 \
       "$ROOT/scripts/verify-release-source.sh" >/dev/null
   )
 }
 
 require_protected_homebrew_tooling() {
-  local verifier_commit=$1 tag=$2 tooling_status
+  local verifier_commit=$1 tag=$2 tooling_status expected_remote remote_commit
+  local tooling_commit=${CRABBOX_VERIFY_TOOLING_COMMIT:-$verifier_commit}
   tooling_status=$(git -C "$ROOT" status --porcelain=v1 --untracked-files=all -- \
     "${PROTECTED_HOMEBREW_TOOLING[@]}" "release/records/$tag.json")
   [[ -z "$tooling_status" ]] || {
@@ -134,9 +147,33 @@ require_protected_homebrew_tooling() {
     printf '%s\n' "$tooling_status" >&2
     return 1
   }
-  git -C "$ROOT" diff --quiet "$verifier_commit" -- \
+  expected_remote="https://github.com/$CRABBOX_RELEASE_REPOSITORY"
+  case "$(git -C "$ROOT" remote get-url origin)" in
+    "$expected_remote" | "$expected_remote.git") ;;
+    *)
+      echo "protected downstream verifier requires canonical origin $expected_remote" >&2
+      return 1
+      ;;
+  esac
+  remote_commit=$(git ls-remote "$expected_remote" \
+    "refs/heads/$CRABBOX_RELEASE_DEFAULT_BRANCH" | awk '{print $1}')
+  [[ "$remote_commit" =~ ^[0-9a-f]{40}$ ]] || {
+    echo "canonical default-branch tip is invalid" >&2
+    return 1
+  }
+  git -C "$ROOT" -c fetch.writeCommitGraph=false fetch --quiet --no-tags \
+    "$expected_remote" "$remote_commit"
+  git -C "$ROOT" merge-base --is-ancestor "$tooling_commit" "$remote_commit" || {
+    echo "protected tooling commit is not in canonical default-branch history" >&2
+    return 1
+  }
+  git -C "$ROOT" merge-base --is-ancestor "$verifier_commit" "$tooling_commit" || {
+    echo "provenance verifier commit is not an ancestor of protected tooling" >&2
+    return 1
+  }
+  git -C "$ROOT" diff --quiet "$tooling_commit" -- \
     "${PROTECTED_HOMEBREW_TOOLING[@]}" "release/records/$tag.json" || {
-    echo "protected downstream verifier tooling differs from $verifier_commit" >&2
+    echo "protected downstream verifier tooling differs from $tooling_commit" >&2
     return 1
   }
 }
@@ -145,11 +182,19 @@ sha256_file() {
   shasum -a 256 "$1" | awk '{print $1}'
 }
 
+require_public_workflow_ancestry() {
+  local verifier_commit=$1 workflow_commit=$2
+  git -C "$ROOT" merge-base --is-ancestor "$verifier_commit" "$workflow_commit" || {
+    echo "public workflow commit is not a descendant of the provenance verifier" >&2
+    return 1
+  }
+}
+
 freeze_public_release() {
   [[ $# -eq 10 ]] || usage
   local tag=$1 asset_dir=$2 tag_object=$3 source_commit=$4 verifier_commit=$5
   local release_id=$6 run_id=$7 proof_dir=$8 work=$9 node_bin=${10}
-  local repository=$CRABBOX_RELEASE_REPOSITORY version=${tag#v} workflow_id arch
+  local repository=$CRABBOX_RELEASE_REPOSITORY version=${tag#v} workflow_id workflow_commit arch
   [[ "$release_id" =~ ^[1-9][0-9]*$ && "$run_id" =~ ^[1-9][0-9]*$ ]] || usage
   [[ -d "$proof_dir" && ! -L "$proof_dir" ]] || {
     echo "public proof ZIP directory must be a real directory" >&2
@@ -185,6 +230,9 @@ freeze_public_release() {
   }
   public_api_get "repos/$repository/releases/$release_id" >"$work/public-release.json"
   public_api_get "repos/$repository/actions/runs/$run_id" >"$work/public-run.json"
+  workflow_commit=$(jq -er '.head_sha | select(type == "string" and test("^[0-9a-f]{40}$"))' \
+    "$work/public-run.json")
+  require_public_workflow_ancestry "$verifier_commit" "$workflow_commit"
   workflow_id=$(jq -er '.workflow_id | select(type == "number" and . > 0)' "$work/public-run.json")
   public_api_get "repos/$repository/actions/workflows/$workflow_id" >"$work/public-workflow.json"
   public_api_get "repos/$repository/actions/runs/$run_id/artifacts?per_page=100" \
@@ -218,6 +266,7 @@ freeze_public_release() {
     CRABBOX_PUBLISH_TAG_OBJECT="$tag_object" \
     CRABBOX_PUBLISH_SOURCE_COMMIT="$source_commit" \
     CRABBOX_PUBLISH_VERIFIER_COMMIT="$verifier_commit" \
+    CRABBOX_PUBLISH_WORKFLOW_COMMIT="$workflow_commit" \
     CRABBOX_PUBLISH_VERIFIER_RUN_ID="$run_id" \
     CRABBOX_PUBLISH_DEFAULT_BRANCH="$CRABBOX_RELEASE_DEFAULT_BRANCH" \
     CRABBOX_PUBLISH_WORKFLOW_PATH=.github/workflows/release-assets.yml \
@@ -453,6 +502,7 @@ homebrew_phase() {
   (
     cd "$ROOT"
     CRABBOX_VERIFY_EXEC_ARCH="$native_arch" \
+      CRABBOX_VERIFY_TOOLING_COMMIT="${CRABBOX_VERIFY_TOOLING_COMMIT:-$verifier_commit}" \
       "$ROOT/scripts/verify-release.sh" \
       "$tag" "$asset_dir" "$tag_object" "$source_commit" "$verifier_commit"
   )
@@ -594,8 +644,9 @@ main() {
   [[ $# -eq 8 ]] || usage
   local tag=$1 asset_dir=$2 tag_object=$3 source_commit=$4 verifier_commit=$5
   local release_id=$6 public_run_id=$7 proof_dir=$8
-  local native_arch brew_bin node_bin go_bin work clean_path user_name homebrew_home homebrew_cache source_asset_dir
+  local native_arch brew_bin node_bin go_bin work clean_path user_name homebrew_home homebrew_cache source_asset_dir tooling_commit
   validate_release_identity "$tag" "$tag_object" "$source_commit" "$verifier_commit"
+  tooling_commit=${CRABBOX_VERIFY_TOOLING_COMMIT:-$verifier_commit}
   assert_no_downstream_credentials
   case "${CRABBOX_HOMEBREW_EXTERNAL_PUBLIC_POSTFLIGHT:-}" in
     "") ;;
@@ -671,6 +722,7 @@ main() {
     HOMEBREW_NO_INSTALL_CLEANUP=1 \
     NONINTERACTIVE=1 \
     CRABBOX_HOMEBREW_CLEAN_CHILD=1 \
+    CRABBOX_VERIFY_TOOLING_COMMIT="$tooling_commit" \
     /bin/bash -c 'source "$1"; shift; homebrew_phase "$@"' \
       crabbox-homebrew-phase "$SCRIPT_PATH" \
       "$tag" "$asset_dir" "$tag_object" "$source_commit" "$verifier_commit" \

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -10,13 +10,15 @@ ASSET_DIR=${2:-"$ROOT/dist-release"}
 TAG_OBJECT=${3:-}
 TAG_COMMIT=${4:-}
 VERIFIER_COMMIT=${5:-}
+TOOLING_COMMIT=${CRABBOX_VERIFY_TOOLING_COMMIT:-$VERIFIER_COMMIT}
 EXEC_ARCH=${CRABBOX_VERIFY_EXEC_ARCH:-}
 VERIFY_MODE=${CRABBOX_VERIFY_MODE:-execute}
 
 if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] ||
   [[ ! "$TAG_OBJECT" =~ ^[0-9a-f]{40}$ ]] ||
   [[ ! "$TAG_COMMIT" =~ ^[0-9a-f]{40}$ ]] ||
-  [[ ! "$VERIFIER_COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
+  [[ ! "$VERIFIER_COMMIT" =~ ^[0-9a-f]{40}$ ]] ||
+  [[ ! "$TOOLING_COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
   echo "usage: $0 vX.Y.Z <asset-directory> <tag-object> <tag-commit> <verifier-commit>" >&2
   exit 2
 fi
@@ -61,15 +63,23 @@ for tool in codesign git go lipo node shasum tar unzip; do
   }
 done
 
-[[ "$(git -C "$ROOT" rev-parse HEAD)" == "$VERIFIER_COMMIT" ]] || {
-  echo "protected verifier checkout does not match provenance" >&2
+[[ "$(git -C "$ROOT" rev-parse HEAD)" == "$TOOLING_COMMIT" ]] || {
+  echo "protected tooling checkout does not match tooling commit" >&2
+  exit 1
+}
+git -C "$ROOT" merge-base --is-ancestor "$VERIFIER_COMMIT" "$TOOLING_COMMIT" || {
+  echo "provenance verifier commit is not an ancestor of protected tooling" >&2
+  exit 1
+}
+git -C "$ROOT" merge-base --is-ancestor "$TAG_COMMIT" "$VERIFIER_COMMIT" || {
+  echo "release source commit is not an ancestor of the provenance verifier" >&2
   exit 1
 }
 DEFAULT_BRANCH="$CRABBOX_RELEASE_DEFAULT_BRANCH" \
 RELEASE_TAG="$TAG" \
 EXPECTED_TAG_OBJECT="$TAG_OBJECT" \
 EXPECTED_TAG_COMMIT="$TAG_COMMIT" \
-TRUSTED_HEAD="$VERIFIER_COMMIT" \
+TRUSTED_HEAD="$TOOLING_COMMIT" \
   "$ROOT/scripts/verify-release-source.sh" >/dev/null
 [[ -z "$(git -C "$ROOT" status --porcelain --untracked-files=normal)" ]] || {
   echo "protected verifier checkout is not clean" >&2
@@ -176,7 +186,7 @@ provenance_vmd_sha=$(node -e '
 ' "$ASSET_DIR/provenance.json")
 
 if [[ "$VERIFY_MODE" == static ]]; then
-  echo "Statically verified $TAG release assets from $TAG_COMMIT with protected tooling $VERIFIER_COMMIT"
+  echo "Statically verified $TAG release assets from $TAG_COMMIT with provenance $VERIFIER_COMMIT and protected tooling $TOOLING_COMMIT"
   exit 0
 fi
 
@@ -217,4 +227,4 @@ actual_version=$(env -i \
   exit 1
 }
 
-echo "Verified $TAG release assets from $TAG_COMMIT with protected tooling $VERIFIER_COMMIT"
+echo "Verified $TAG release assets from $TAG_COMMIT with provenance $VERIFIER_COMMIT and protected tooling $TOOLING_COMMIT"


### PR DESCRIPTION
## What Problem This Solves

Repairs post-publication verification when protected `main` advances after an immutable candidate was produced.

Crabbox v0.41.3 was built and published with candidate provenance verifier `1568766f`. A later public verifier correctly ran from newer protected `main`, but the workflow conflated the current workflow commit with the immutable provenance verifier and stopped before downloading assets.

## Why This Change Was Made

The release flow now carries two explicit identities:

- `verifierCommit`: immutable candidate/provenance verifier recorded in `provenance.json`;
- `workflowCommit`: current protected default-branch workflow/tooling commit executing the later proof.

The complete trust chain is enforced as:

`sourceCommit ≤ verifierCommit ≤ publicWorkflowCommit ≤ toolingCommit ≤ canonicalMain`

The current workflow SHA is bound to protected `main`; candidate verification retains the original provenance commit; run, workflow, artifact, proof, and Homebrew witness metadata bind the current workflow commit. Same-commit historical flows remain compatible.

## User Impact

An immutable release can receive a fresh public verifier and Homebrew proof even when protected release tooling advances after candidate production, without rebuilding or changing the release.

## Evidence

- 90/90 targeted release workflow, publication, Homebrew, and isolation tests passed.
- Split-commit success and divergent/orphaned workflow commit failures are covered.
- `scripts/check-docs.sh`
- actionlint and shell/Node syntax checks
- `git diff --check`
- Structured autoreview: no accepted/actionable findings.

This PR does not modify the v0.41.3 tag, release record, notes, assets, source authorization, or Homebrew formula.
