### PR TITLE
chore(release): open v0.41.4 development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.41.4 - Unreleased
 
 ### Fixed
 


### PR DESCRIPTION
## Summary

- label the existing post-v0.41.3 changelog section as `0.41.4 - Unreleased`
- preserve the fixes already accumulated on `main`

## Release verification

- Public release: https://github.com/openclaw/crabbox/releases/tag/v0.41.3
- Post-public native verification: https://github.com/openclaw/crabbox/actions/runs/31509564837
- Homebrew native verification: https://github.com/openclaw/crabbox/actions/runs/31509902924
- The reconciled `openclaw/homebrew-tap` formula is byte-for-byte the protected renderer output for v0.41.3.

## Local verification

- `git diff --check`
- `node scripts/build-docs-site.mjs`
- autoreview clean
