### PR TITLE
docs(run): clarify uploaded script path semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Clarified that POSIX SSH `run --script` uploads a content-hashed standalone copy whose `$0` points under `.crabbox/scripts/`, and documented synced-path execution for scripts that need adjacent repository assets. Thanks @coygeek.
 - Reconciled exact-owned Azure VM, NIC, public IP, and managed OS disk orphan sets with stable-identity quarantine and fail-closed durable deletion progress. Thanks @chsong1.
 - Invalidated adopted Actions workspace readiness markers before full resync and rehydrated the canonical workspace before running commands. Thanks @vincentkoc.
 - Stopped sparse-checkout and skip-worktree omissions from deleting in-scope remote files, and kept staged gitlink removals out of file-deletion manifests. Thanks @vincentkoc.

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -299,11 +299,25 @@ page.
 
 ## Scripts
 
-Use `--script <file>` or `--script-stdin` for multi-line remote commands.
-Crabbox uploads the script into `.crabbox/scripts/` under the remote workdir,
-runs it as a file, and includes that script directory in failure bundles. A
-shebang is honored on POSIX targets; scripts without one run through `bash`.
-Native Windows targets run uploaded scripts through Windows PowerShell, and
+Use `--script <file>` or `--script-stdin` for multi-line remote commands. On
+POSIX SSH leases, Crabbox uploads a standalone, content-hashed copy into
+`.crabbox/scripts/` under the remote workdir and executes that copy with the
+workdir as its process PWD. `$0` identifies the generated upload path, so
+`dirname "$0"` resolves to `.crabbox/scripts/`, not the script's original local
+directory. That directory component is not preserved in the uploaded copy and
+cannot be recovered from `$0`. Standalone uploaded scripts should resolve
+synced project assets from `$PWD`.
+
+If a Git-managed script needs its synced repository path or adjacent assets,
+invoke it as trailing argv so the project copy runs in place:
+
+```sh
+crabbox run -- ./scripts/check.sh
+```
+
+Crabbox includes the uploaded script directory in failure bundles. A shebang is
+honored on POSIX targets; scripts without one run through `bash`. Native Windows
+targets run uploaded scripts through Windows PowerShell, and
 `--script-stdin` is treated as a PowerShell script; a non-`.ps1` script path
 gets a `.ps1` extension added before upload. Trailing arguments after `--` are
 passed to the script. This is an SSH-run feature for OS-backed providers.

--- a/internal/cli/app_help_test.go
+++ b/internal/cli/app_help_test.go
@@ -41,6 +41,19 @@ func TestCleanupHelpListsRegisteredXCPNgProvider(t *testing.T) {
 	}
 }
 
+func TestRunHelpDescribesStandaloneScriptUpload(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).Run(context.Background(), []string{"run", "--help"})
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 0 {
+		t.Fatalf("crabbox run --help error=%v stderr=%q", err, stderr.String())
+	}
+	want := "on POSIX SSH leases, upload and run a standalone content-hashed copy under .crabbox/scripts/; delegated module runtimes use source input"
+	if !strings.Contains(stderr.String(), want) {
+		t.Fatalf("run help omitted standalone script upload semantics:\n%s", stderr.String())
+	}
+}
+
 func TestTopLevelAndCommandHelpDescribeInteractiveConnect(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	app := App{Stdout: &stdout, Stderr: &stderr}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -222,7 +222,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	captureOnFail := fs.Bool("capture-on-fail", false, "compatibility alias; failure bundles are saved by default on non-zero exit")
 	preflight := fs.Bool("preflight", false, "print remote capability preflight before running the command")
 	preflightTools := fs.String("preflight-tools", "", "comma-separated preflight tools to probe; overrides run.preflightTools")
-	scriptPath := fs.String("script", "", "upload and run a local script file")
+	scriptPath := fs.String("script", "", "on POSIX SSH leases, upload and run a standalone content-hashed copy under .crabbox/scripts/; delegated module runtimes use source input")
 	scriptStdin := fs.Bool("script-stdin", false, "read a script from stdin, upload it, and run it")
 	freshPRValue := fs.String("fresh-pr", "", "run from a fresh remote checkout of a GitHub PR: owner/repo#123, URL, or number")
 	applyLocalPatch := fs.Bool("apply-local-patch", false, "apply the local git diff on top of --fresh-pr checkout")

--- a/internal/cli/run_script_test.go
+++ b/internal/cli/run_script_test.go
@@ -1,9 +1,43 @@
 package cli
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
 	"strings"
 	"testing"
 )
+
+func TestLoadRunScriptUsesContentHashedStandalonePath(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "scripts")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	source := filepath.Join(dir, "check.sh")
+	if err := os.WriteFile(source, []byte("#!/bin/sh\necho first\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	first, err := loadRunScript(source, false, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if matched, err := regexp.MatchString(`^\.crabbox/scripts/[0-9a-f]{12}-check\.sh$`, filepath.ToSlash(first.RemotePath)); err != nil || !matched {
+		t.Fatalf("remote path=%q, want content-hashed standalone path", first.RemotePath)
+	}
+
+	if err := os.WriteFile(source, []byte("#!/bin/sh\necho second\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	second, err := loadRunScript(source, false, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.RemotePath == second.RemotePath {
+		t.Fatalf("remote path did not change with script content: %q", first.RemotePath)
+	}
+}
 
 func TestRemoteRunScriptCommandUsesUploadedFile(t *testing.T) {
 	spec := &RunScriptSpec{
@@ -21,6 +55,45 @@ func TestRemoteRunScriptCommandUsesUploadedFile(t *testing.T) {
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("remote command missing %q in %q", want, got)
+		}
+	}
+}
+
+func TestRemoteRunScriptCommandUsesWorkdirAndUploadedScriptIdentity(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shell execution")
+	}
+	workdir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	remotePath := ".crabbox/scripts/abc-check.sh"
+	fullPath := filepath.Join(workdir, filepath.FromSlash(remotePath))
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	script := `#!/bin/sh
+set -eu
+if [ "$PWD" = "$1" ]; then echo PWD_WORKDIR=yes; fi
+case "$0" in
+  .crabbox/scripts/abc-check.sh|"$1"/.crabbox/scripts/abc-check.sh) echo ZERO_UPLOAD=yes ;;
+esac
+script_dir=$(cd "$(dirname "$0")" && pwd -P)
+upload_dir=$(cd "$1/.crabbox/scripts" && pwd -P)
+if [ "$script_dir" = "$upload_dir" ]; then echo DIR_UPLOAD=yes; fi
+`
+	if err := os.WriteFile(fullPath, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	spec := &RunScriptSpec{Source: "./scripts/check.sh", RemotePath: remotePath, Shebang: true}
+	command := remoteRunScriptCommandWithEnvFile(workdir, nil, "", spec, []string{workdir})
+	output, err := exec.Command("bash", "-lc", command).CombinedOutput()
+	if err != nil {
+		t.Fatalf("execute remote script command: %v\n%s", err, output)
+	}
+	for _, want := range []string{"PWD_WORKDIR=yes", "ZERO_UPLOAD=yes", "DIR_UPLOAD=yes"} {
+		if !strings.Contains(string(output), want) {
+			t.Fatalf("script output missing %q:\n%s", want, output)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- document that POSIX SSH `run --script` uploads a standalone content-hashed copy under `.crabbox/scripts/`
- explain that `$0` and `dirname "$0"` identify the generated upload path while the remote workdir remains `$PWD`
- direct Git-managed scripts that need adjacent repository assets to trailing-argv execution
- keep native Windows PowerShell and delegated module-runtime semantics explicitly separate
- add regression coverage for the content-hashed path, process working directory, uploaded-script identity, and help text

Fixes https://github.com/openclaw/crabbox/issues/1249

## Verification

- `go test ./internal/cli -run 'TestRunHelpDescribesStandaloneScriptUpload|TestLoadRunScriptUsesContentHashedStandalonePath|TestRemoteRunScriptCommandUsesWorkdirAndUploadedScriptIdentity|TestWindowsRunScript'`
- `scripts/check-docs.sh`
- `gofmt -w internal/cli/run.go internal/cli/app_help_test.go internal/cli/run_script_test.go`
- `git diff --check`
- P1 autoreview: clean, no accepted/actionable findings
