### PR TITLE
fix(run): classify local-container OOM failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Clarified that POSIX SSH `run --script` uploads a content-hashed standalone copy whose `$0` points under `.crabbox/scripts/`, and documented synced-path execution for scripts that need adjacent repository assets. Thanks @coygeek.
+- Classified per-run local-container cgroup OOM-kill increments as memory resource exhaustion, with bounded evidence collection and actionable memory/concurrency guidance while ignoring historical OOM counts on reused leases. Thanks @coygeek.
 - Reconciled exact-owned Azure VM, NIC, public IP, and managed OS disk orphan sets with stable-identity quarantine and fail-closed durable deletion progress. Thanks @chsong1.
 - Invalidated adopted Actions workspace readiness markers before full resync and rehydrated the canonical workspace before running commands. Thanks @vincentkoc.
 - Stopped sparse-checkout and skip-worktree omissions from deleting in-scope remote files, and kept staged gitlink removals out of file-deletion manifests. Thanks @vincentkoc.

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -498,17 +498,23 @@ record.
 When a remote command exits non-zero, `run` prints a compact failure digest
 after the timing summary: the failed phase when phase markers are known, a
 likely area (provider auth, SSH/connectivity, sync, install/setup, user command,
-or model/tool/provider limit), retryability when inferable, next commands
+model/tool/provider limit, or resource exhaustion), retryability when inferable, next commands
 (`logs`, `events`, `doctor --from-run`, `ssh`, retrying with `--fresh-sync`, and
 `stop`), and a short redacted stdout/stderr tail. It does not reconstruct secrets
-or hidden local shell state.
+or hidden local shell state. When an SSH backend supplies per-run memory
+exhaustion evidence, the summary and digest use
+`blocked_stage=resource_exhaustion resource_exhaustion=memory retry_likely=false`
+and recommend increasing the memory limit or reducing workload concurrency.
+Evidence read failures are warnings and do not replace the original command
+failure.
 
 Use `--timing-json` to emit a final JSON timing record with provider, lease ID,
 slug, run ID, machine type, repo path, remote workdir, lease acquisition,
 bootstrap, sync phases, command phases, command duration, command-path total,
 end-to-end duration, exit code, normalized `runStatus`, optional `errorKind`,
 stop command, artifacts, and Actions run URL when available. Failed runs also
-include `blockedStage` and `retryLikely` when classifiable. Commands can emit
+include `blockedStage`, `resourceExhaustion`, and `retryLikely` when classifiable.
+Commands can emit
 phase markers on stdout or stderr as
 `CRABBOX_PHASE:<name>`; Crabbox records those as `commandPhases` without removing
 the marker line from output. In `blacksmith-testbox` mode, sync is reported as

--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -207,6 +207,25 @@ Native checkpoint and fork support follow the same pattern through
 provider-specific capability areas, such as pricing or image management, should
 add similarly narrow interfaces rather than widening the base backend.
 
+Failed-run evidence for SSH leases is also optional. A supporting backend may
+capture a bounded, per-command baseline immediately before execution and return
+a collector that core calls only after a nonzero exit or command-transport
+failure:
+
+```go
+type SSHRunFailureEvidenceBackend interface {
+	Backend
+	BeginRunFailureEvidence(context.Context, RunFailureEvidenceRequest) (RunFailureEvidenceCollector, error)
+}
+```
+
+The collector keeps provider-native counters and parsing inside the adapter. It
+returns only normalized `RunFailureEvidence` values; initially the sole resource
+exhaustion reason is `memory`. Baseline and collection errors are warnings and
+must never replace the command failure. A fresh collector is created for every
+command, including watch iterations and reused leases, so historical provider
+counters cannot be attributed to a later run.
+
 ## Package layout
 
 Built-in providers live under `internal/providers/<name>`. The registry is

--- a/docs/providers/local-container.md
+++ b/docs/providers/local-container.md
@@ -87,6 +87,21 @@ When `runtime` is unset or left at `docker`, Crabbox detects an installed
 container CLI. If both `docker` and `podman` are available, `docker` is selected
 unless `runtime` is set explicitly.
 
+### Memory-failure evidence
+
+For every user command, Local Container reads the container cgroup OOM-kill
+counter immediately before execution. After a nonzero exit or SSH transport
+failure, it reads the counter again. Only a positive increment for that command
+is reported as `resource_exhaustion=memory`; an OOM from an earlier command on a
+reused lease does not classify a later ordinary failure. Docker/Podman cgroup
+paths and counter parsing remain inside this provider.
+
+The failure digest marks this condition non-retryable with the unchanged
+configuration and suggests increasing `localContainer.memory` (or
+`--local-container-memory`) or reducing workload concurrency. If cgroup evidence
+cannot be read, Crabbox prints a diagnostic warning and preserves the original
+command failure and ordinary user-command classification.
+
 Provider flags:
 
 ```text

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -126,6 +126,31 @@ type SSHLeaseBackend interface {
 	ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error
 }
 
+// SSHRunFailureEvidenceBackend optionally captures provider-owned state just
+// before an SSH command starts. The returned collector retains that baseline
+// inside the provider and returns only normalized evidence to core after a
+// command or transport failure.
+type SSHRunFailureEvidenceBackend interface {
+	Backend
+	BeginRunFailureEvidence(ctx context.Context, req RunFailureEvidenceRequest) (RunFailureEvidenceCollector, error)
+}
+
+type RunFailureEvidenceRequest struct {
+	Lease LeaseTarget
+}
+
+type RunFailureEvidenceCollector func(context.Context) (RunFailureEvidence, error)
+
+type RunFailureEvidence struct {
+	ResourceExhaustion ResourceExhaustionReason
+}
+
+type ResourceExhaustionReason string
+
+const (
+	ResourceExhaustionMemory ResourceExhaustionReason = "memory"
+)
+
 // ExclusiveOneShotAcquireBackend marks Acquire results that are newly
 // provisioned and exclusive to the caller until the one-shot run completes.
 // Backends are non-exclusive by default.

--- a/internal/cli/provider_coordinator.go
+++ b/internal/cli/provider_coordinator.go
@@ -28,6 +28,14 @@ type coordinatorLeaseBackend struct {
 	rt     Runtime
 }
 
+func (b *coordinatorLeaseBackend) BeginRunFailureEvidence(ctx context.Context, req RunFailureEvidenceRequest) (RunFailureEvidenceCollector, error) {
+	capability, ok := b.direct.(SSHRunFailureEvidenceBackend)
+	if !ok {
+		return nil, nil
+	}
+	return capability.BeginRunFailureEvidence(ctx, req)
+}
+
 func (b *coordinatorLeaseBackend) AcquireIsExclusiveOneShot() bool { return true }
 
 func (b *coordinatorLeaseBackend) Spec() ProviderSpec { return b.spec }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1795,9 +1795,16 @@ afterSync:
 			return recordFailure(exit(7, "prepare test result freshness marker: %v", err))
 		}
 	}
+	leaseForEvidence := LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: coord}
+	failureEvidenceCollector := beginRunFailureEvidence(ctx, sshBackend, leaseForEvidence, a.Stderr)
 	code, streamErr := runSSHStreamResult(ctx, target, remote, stdout, stderr)
-	if err := streamCaptures.closeAfterStream(streamErr, code, a.Stderr); err != nil {
-		return recordFailure(err)
+	failureEvidence := RunFailureEvidence{}
+	if code != 0 || streamErr != nil {
+		failureEvidence = collectRunFailureEvidence(ctx, failureEvidenceCollector, a.Stderr)
+	}
+	streamCaptureErr := streamCaptures.closeAfterStream(streamErr, code, a.Stderr)
+	if streamCaptureErr != nil && failureEvidence.ResourceExhaustion == "" {
+		return recordFailure(streamCaptureErr)
 	}
 	if !stdoutCaptured {
 		stdoutEvents.Flush()
@@ -1881,11 +1888,9 @@ afterSync:
 		if artifactFailure != nil {
 			classificationLog = strings.TrimSpace(classificationLog + "\n" + artifactFailure.Error())
 		}
-		classification = ClassifyRunFailure(code, classificationLog, timings.commandPhases)
-		if testResultsFailure != nil {
-			classification = FailureClassification{BlockedStage: "test", RetryLikely: "false"}
-		}
+		classification = classifyRunOutcomeFailure(code, classificationLog, timings.commandPhases, failureEvidence, testResultsFailure != nil)
 		timings.blockedStage = classification.BlockedStage
+		timings.resourceExhaustion = classification.ResourceExhaustion
 		timings.retryLikely = classification.RetryLikely
 		failureClassificationPrinted = true
 	}
@@ -2012,6 +2017,9 @@ afterSync:
 		}
 		if testResultsFailure != nil {
 			return recordFailure(testResultsFailure)
+		}
+		if streamCaptureErr != nil {
+			return recordFailure(streamCaptureErr)
 		}
 		return recordFailure(ExitError{Code: code, Message: fmt.Sprintf("remote command exited %d", code)})
 	}
@@ -2455,17 +2463,18 @@ func routingSafeURL(value string) string {
 }
 
 type runTimings struct {
-	started           time.Time
-	endToEndStartedAt time.Time
-	lease             time.Duration
-	bootstrap         time.Duration
-	sync              time.Duration
-	command           time.Duration
-	syncSteps         syncStepTimings
-	commandPhases     []timingPhase
-	syncSkipped       bool
-	blockedStage      string
-	retryLikely       string
+	started            time.Time
+	endToEndStartedAt  time.Time
+	lease              time.Duration
+	bootstrap          time.Duration
+	sync               time.Duration
+	command            time.Duration
+	syncSteps          syncStepTimings
+	commandPhases      []timingPhase
+	syncSkipped        bool
+	blockedStage       string
+	resourceExhaustion ResourceExhaustionReason
+	retryLikely        string
 }
 
 type syncStepTimings struct {
@@ -2506,7 +2515,7 @@ func formatRunSummary(timings runTimings, total time.Duration, exitCode int) str
 	if breakdown := formatCommandPhaseTimings(timings.commandPhases); breakdown != "" {
 		summary += " command_phases=" + breakdown
 	}
-	summary += FormatFailureClassificationFields(FailureClassification{BlockedStage: timings.blockedStage, RetryLikely: timings.retryLikely})
+	summary += FormatFailureClassificationFields(FailureClassification{BlockedStage: timings.blockedStage, ResourceExhaustion: timings.resourceExhaustion, RetryLikely: timings.retryLikely})
 	return summary
 }
 

--- a/internal/cli/run_failure.go
+++ b/internal/cli/run_failure.go
@@ -1,17 +1,33 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strings"
+	"time"
 )
 
+const runFailureEvidenceTimeout = 5 * time.Second
+
 type FailureClassification struct {
-	BlockedStage string
-	RetryLikely  string
+	BlockedStage       string
+	ResourceExhaustion ResourceExhaustionReason
+	RetryLikely        string
 }
 
 func ClassifyRunFailure(exitCode int, text string, phases []TimingPhase) FailureClassification {
+	return ClassifyRunFailureWithEvidence(exitCode, text, phases, RunFailureEvidence{})
+}
+
+func ClassifyRunFailureWithEvidence(exitCode int, text string, phases []TimingPhase, evidence RunFailureEvidence) FailureClassification {
+	if evidence.ResourceExhaustion == ResourceExhaustionMemory {
+		return FailureClassification{
+			BlockedStage:       "resource_exhaustion",
+			ResourceExhaustion: ResourceExhaustionMemory,
+			RetryLikely:        "false",
+		}
+	}
 	if exitCode == 0 {
 		return FailureClassification{}
 	}
@@ -52,6 +68,14 @@ func ClassifyRunFailure(exitCode int, text string, phases []TimingPhase) Failure
 	return FailureClassification{BlockedStage: "unknown", RetryLikely: "unknown"}
 }
 
+func classifyRunOutcomeFailure(exitCode int, text string, phases []TimingPhase, evidence RunFailureEvidence, testResultsFailed bool) FailureClassification {
+	classification := ClassifyRunFailureWithEvidence(exitCode, text, phases, evidence)
+	if testResultsFailed && classification.ResourceExhaustion == "" {
+		return FailureClassification{BlockedStage: "test", RetryLikely: "false"}
+	}
+	return classification
+}
+
 func isBlacksmithActionsCancelled(lower string) bool {
 	if !strings.Contains(lower, "testbox ready") {
 		return false
@@ -76,6 +100,7 @@ func ApplyFailureClassification(report *TimingReport, classification FailureClas
 		return
 	}
 	report.BlockedStage = classification.BlockedStage
+	report.ResourceExhaustion = classification.ResourceExhaustion
 	report.RetryLikely = classification.RetryLikely
 }
 
@@ -87,7 +112,53 @@ func FormatFailureClassificationFields(classification FailureClassification) str
 	if retry == "" {
 		retry = "unknown"
 	}
-	return fmt.Sprintf(" blocked_stage=%s retry_likely=%s", classification.BlockedStage, retry)
+	fields := fmt.Sprintf(" blocked_stage=%s", classification.BlockedStage)
+	if classification.ResourceExhaustion != "" {
+		fields += fmt.Sprintf(" resource_exhaustion=%s", classification.ResourceExhaustion)
+	}
+	return fields + fmt.Sprintf(" retry_likely=%s", retry)
+}
+
+func beginRunFailureEvidence(ctx context.Context, backend SSHLeaseBackend, lease LeaseTarget, warnings io.Writer) RunFailureEvidenceCollector {
+	capability, ok := backend.(SSHRunFailureEvidenceBackend)
+	if !ok {
+		return nil
+	}
+	bounded, cancel := context.WithTimeout(ctx, runFailureEvidenceTimeout)
+	defer cancel()
+	collector, err := capability.BeginRunFailureEvidence(bounded, RunFailureEvidenceRequest{Lease: lease})
+	if err != nil {
+		fmt.Fprintf(nonNilWriter(warnings), "warning: failed-run evidence baseline unavailable: %v\n", err)
+		return nil
+	}
+	return collector
+}
+
+func collectRunFailureEvidence(ctx context.Context, collector RunFailureEvidenceCollector, warnings io.Writer) RunFailureEvidence {
+	if collector == nil {
+		return RunFailureEvidence{}
+	}
+	bounded, cancel := context.WithTimeout(context.WithoutCancel(ctx), runFailureEvidenceTimeout)
+	defer cancel()
+	evidence, err := collector(bounded)
+	if err != nil {
+		fmt.Fprintf(nonNilWriter(warnings), "warning: failed-run evidence collection incomplete: %v\n", err)
+		return RunFailureEvidence{}
+	}
+	switch evidence.ResourceExhaustion {
+	case "", ResourceExhaustionMemory:
+		return evidence
+	default:
+		fmt.Fprintf(nonNilWriter(warnings), "warning: failed-run evidence collection returned unsupported resource exhaustion reason %q\n", evidence.ResourceExhaustion)
+		return RunFailureEvidence{}
+	}
+}
+
+func nonNilWriter(w io.Writer) io.Writer {
+	if w == nil {
+		return io.Discard
+	}
+	return w
 }
 
 func RedactKnownFailureBody(text string) (string, bool) {
@@ -191,6 +262,12 @@ func printRunFailureDigest(w io.Writer, input runFailureDigestInput, stdoutTail,
 	fmt.Fprintf(w, "  phase: %s\n", blank(phase, "unknown"))
 	fmt.Fprintf(w, "  area: %s\n", area)
 	fmt.Fprintf(w, "  retryable: %s\n", retry)
+	if input.Classification.ResourceExhaustion != "" {
+		fmt.Fprintf(w, "  resource_exhaustion: %s\n", input.Classification.ResourceExhaustion)
+	}
+	if input.Classification.ResourceExhaustion == ResourceExhaustionMemory {
+		fmt.Fprintln(w, "  hint: increase the memory limit or reduce workload concurrency before retrying")
+	}
 	if input.RunHistoryUnavailable {
 		fmt.Fprintln(w, "  run_history: unavailable; use lease-based recovery commands below")
 	}
@@ -246,6 +323,8 @@ func failureDigestArea(classification FailureClassification, phase string) strin
 		return "install_setup"
 	case "model_call":
 		return "model_tool_provider_limit"
+	case "resource_exhaustion":
+		return "resource_exhaustion"
 	}
 	switch {
 	case strings.Contains(phase, "sync"):

--- a/internal/cli/run_failure_test.go
+++ b/internal/cli/run_failure_test.go
@@ -2,11 +2,39 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 	"time"
 )
+
+type fakeRunFailureEvidenceBackend struct {
+	begin func(context.Context, RunFailureEvidenceRequest) (RunFailureEvidenceCollector, error)
+}
+
+func (b fakeRunFailureEvidenceBackend) Spec() ProviderSpec {
+	return ProviderSpec{Name: "evidence-test"}
+}
+func (b fakeRunFailureEvidenceBackend) Acquire(context.Context, AcquireRequest) (LeaseTarget, error) {
+	return LeaseTarget{}, nil
+}
+func (b fakeRunFailureEvidenceBackend) Resolve(context.Context, ResolveRequest) (LeaseTarget, error) {
+	return LeaseTarget{}, nil
+}
+func (b fakeRunFailureEvidenceBackend) List(context.Context, ListRequest) ([]LeaseView, error) {
+	return nil, nil
+}
+func (b fakeRunFailureEvidenceBackend) ReleaseLease(context.Context, ReleaseLeaseRequest) error {
+	return nil
+}
+func (b fakeRunFailureEvidenceBackend) Touch(context.Context, TouchRequest) (Server, error) {
+	return Server{}, nil
+}
+func (b fakeRunFailureEvidenceBackend) BeginRunFailureEvidence(ctx context.Context, req RunFailureEvidenceRequest) (RunFailureEvidenceCollector, error) {
+	return b.begin(ctx, req)
+}
 
 func TestClassifyRunFailureStages(t *testing.T) {
 	tests := []struct {
@@ -28,6 +56,65 @@ func TestClassifyRunFailureStages(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestClassifyRunFailureUsesNormalizedMemoryEvidence(t *testing.T) {
+	got := ClassifyRunFailureWithEvidence(255, "connection reset by peer", []TimingPhase{{Name: "test"}}, RunFailureEvidence{
+		ResourceExhaustion: ResourceExhaustionMemory,
+	})
+	if got.BlockedStage != "resource_exhaustion" || got.ResourceExhaustion != ResourceExhaustionMemory || got.RetryLikely != "false" {
+		t.Fatalf("ClassifyRunFailureWithEvidence()=%#v", got)
+	}
+	fields := FormatFailureClassificationFields(got)
+	for _, want := range []string{"blocked_stage=resource_exhaustion", "resource_exhaustion=memory", "retry_likely=false"} {
+		if !strings.Contains(fields, want) {
+			t.Fatalf("classification fields missing %q: %s", want, fields)
+		}
+	}
+}
+
+func TestRunOutcomeFailureKeepsMemoryEvidenceAcrossSecondaryFailures(t *testing.T) {
+	got := classifyRunOutcomeFailure(0, "", nil, RunFailureEvidence{
+		ResourceExhaustion: ResourceExhaustionMemory,
+	}, true)
+	if got.BlockedStage != "resource_exhaustion" || got.ResourceExhaustion != ResourceExhaustionMemory || got.RetryLikely != "false" {
+		t.Fatalf("classifyRunOutcomeFailure()=%#v, want memory exhaustion", got)
+	}
+
+	got = classifyRunOutcomeFailure(0, "", nil, RunFailureEvidence{}, true)
+	if got.BlockedStage != "test" || got.ResourceExhaustion != "" || got.RetryLikely != "false" {
+		t.Fatalf("classifyRunOutcomeFailure()=%#v, want test failure", got)
+	}
+}
+
+func TestRunFailureEvidenceErrorsAreWarnings(t *testing.T) {
+	t.Run("baseline", func(t *testing.T) {
+		var warnings bytes.Buffer
+		backend := fakeRunFailureEvidenceBackend{begin: func(context.Context, RunFailureEvidenceRequest) (RunFailureEvidenceCollector, error) {
+			return nil, errors.New("baseline read failed")
+		}}
+		if collector := beginRunFailureEvidence(context.Background(), backend, LeaseTarget{}, &warnings); collector != nil {
+			t.Fatal("baseline error returned a collector")
+		}
+		if !strings.Contains(warnings.String(), "warning: failed-run evidence baseline unavailable") {
+			t.Fatalf("missing baseline warning: %s", warnings.String())
+		}
+	})
+
+	t.Run("collection", func(t *testing.T) {
+		var warnings bytes.Buffer
+		collector := RunFailureEvidenceCollector(func(context.Context) (RunFailureEvidence, error) {
+			return RunFailureEvidence{}, errors.New("post-failure read failed")
+		})
+		canceled, cancel := context.WithCancel(context.Background())
+		cancel()
+		if evidence := collectRunFailureEvidence(canceled, collector, &warnings); evidence.ResourceExhaustion != "" {
+			t.Fatalf("evidence=%#v, want empty", evidence)
+		}
+		if !strings.Contains(warnings.String(), "warning: failed-run evidence collection incomplete") {
+			t.Fatalf("missing collection warning: %s", warnings.String())
+		}
+	})
 }
 
 func TestClassifyRunFailureBlacksmithInfraStages(t *testing.T) {
@@ -146,8 +233,9 @@ func TestFormatRunSummaryIncludesFailureClassification(t *testing.T) {
 
 func TestTimingJSONIncludesFailureClassification(t *testing.T) {
 	report := timingReportFromRun("aws", "cbx_123", "slug", runTimings{
-		blockedStage: "ssh",
-		retryLikely:  "true",
+		blockedStage:       "resource_exhaustion",
+		resourceExhaustion: ResourceExhaustionMemory,
+		retryLikely:        "false",
 	}, time.Second, 1)
 	var buf bytes.Buffer
 	if err := writeTimingJSON(&buf, report); err != nil {
@@ -157,8 +245,35 @@ func TestTimingJSONIncludesFailureClassification(t *testing.T) {
 	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
 		t.Fatal(err)
 	}
-	if got.BlockedStage != "ssh" || got.RetryLikely != "true" {
+	if got.BlockedStage != "resource_exhaustion" || got.ResourceExhaustion != ResourceExhaustionMemory || got.RetryLikely != "false" {
 		t.Fatalf("classification not encoded: %#v", got)
+	}
+}
+
+func TestPrintRunFailureDigestIncludesMemoryGuidance(t *testing.T) {
+	var buf bytes.Buffer
+	printRunFailureDigest(&buf, runFailureDigestInput{
+		LeaseID:        "cbx_123",
+		CommandDisplay: "go test ./...",
+		Classification: FailureClassification{
+			BlockedStage:       "resource_exhaustion",
+			ResourceExhaustion: ResourceExhaustionMemory,
+			RetryLikely:        "false",
+		},
+	}, newStreamTailBuffer(40), newStreamTailBuffer(40), "", "")
+	out := buf.String()
+	for _, want := range []string{
+		"area: resource_exhaustion",
+		"retryable: false",
+		"resource_exhaustion: memory",
+		"hint: increase the memory limit or reduce workload concurrency before retrying",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("digest missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "next: crabbox run") {
+		t.Fatalf("deterministic memory exhaustion should not suggest an unchanged retry:\n%s", out)
 	}
 }
 

--- a/internal/cli/timing.go
+++ b/internal/cli/timing.go
@@ -7,35 +7,36 @@ import (
 )
 
 type TimingReport struct {
-	Provider      string        `json:"provider"`
-	LeaseID       string        `json:"leaseId,omitempty"`
-	Slug          string        `json:"slug,omitempty"`
-	LeaseMs       int64         `json:"leaseMs,omitempty"`
-	BootstrapMs   int64         `json:"bootstrapMs,omitempty"`
-	SyncMs        int64         `json:"syncMs"`
-	SyncPhases    []TimingPhase `json:"syncPhases,omitempty"`
-	SyncSkipped   bool          `json:"syncSkipped"`
-	SyncDelegated bool          `json:"syncDelegated,omitempty"`
-	HydrateMs     int64         `json:"hydrateMs,omitempty"`
-	ProbeMs       int64         `json:"probeMs,omitempty"`
-	CommandMs     int64         `json:"commandMs"`
-	CommandPhases []TimingPhase `json:"commandPhases,omitempty"`
-	TotalMs       int64         `json:"totalMs"`
-	EndToEndMs    int64         `json:"endToEndMs"`
-	ExitCode      int           `json:"exitCode"`
-	RunStatus     RunStatus     `json:"runStatus,omitempty"`
-	ErrorKind     RunErrorKind  `json:"errorKind,omitempty"`
-	ActionsRunURL string        `json:"actionsRunUrl,omitempty"`
-	RunID         string        `json:"runId,omitempty"`
-	Label         string        `json:"label,omitempty"`
-	MachineType   string        `json:"machineType,omitempty"`
-	RepoPath      string        `json:"repoPath,omitempty"`
-	Workdir       string        `json:"workdir,omitempty"`
-	StopCommand   string        `json:"stopCommand,omitempty"`
-	IdleTimeout   string        `json:"idleTimeout,omitempty"`
-	BlockedStage  string        `json:"blockedStage,omitempty"`
-	RetryLikely   string        `json:"retryLikely,omitempty"`
-	Artifacts     []runArtifact `json:"artifacts,omitempty"`
+	Provider           string                   `json:"provider"`
+	LeaseID            string                   `json:"leaseId,omitempty"`
+	Slug               string                   `json:"slug,omitempty"`
+	LeaseMs            int64                    `json:"leaseMs,omitempty"`
+	BootstrapMs        int64                    `json:"bootstrapMs,omitempty"`
+	SyncMs             int64                    `json:"syncMs"`
+	SyncPhases         []TimingPhase            `json:"syncPhases,omitempty"`
+	SyncSkipped        bool                     `json:"syncSkipped"`
+	SyncDelegated      bool                     `json:"syncDelegated,omitempty"`
+	HydrateMs          int64                    `json:"hydrateMs,omitempty"`
+	ProbeMs            int64                    `json:"probeMs,omitempty"`
+	CommandMs          int64                    `json:"commandMs"`
+	CommandPhases      []TimingPhase            `json:"commandPhases,omitempty"`
+	TotalMs            int64                    `json:"totalMs"`
+	EndToEndMs         int64                    `json:"endToEndMs"`
+	ExitCode           int                      `json:"exitCode"`
+	RunStatus          RunStatus                `json:"runStatus,omitempty"`
+	ErrorKind          RunErrorKind             `json:"errorKind,omitempty"`
+	ActionsRunURL      string                   `json:"actionsRunUrl,omitempty"`
+	RunID              string                   `json:"runId,omitempty"`
+	Label              string                   `json:"label,omitempty"`
+	MachineType        string                   `json:"machineType,omitempty"`
+	RepoPath           string                   `json:"repoPath,omitempty"`
+	Workdir            string                   `json:"workdir,omitempty"`
+	StopCommand        string                   `json:"stopCommand,omitempty"`
+	IdleTimeout        string                   `json:"idleTimeout,omitempty"`
+	BlockedStage       string                   `json:"blockedStage,omitempty"`
+	ResourceExhaustion ResourceExhaustionReason `json:"resourceExhaustion,omitempty"`
+	RetryLikely        string                   `json:"retryLikely,omitempty"`
+	Artifacts          []runArtifact            `json:"artifacts,omitempty"`
 
 	SchemaValidations []SchemaValidationResult `json:"schemaValidations,omitempty"`
 
@@ -116,21 +117,22 @@ func DurationMinutesCeil(duration time.Duration) int {
 
 func timingReportFromRun(provider, leaseID, slug string, timings runTimings, total time.Duration, exitCode int) timingReport {
 	return timingReport{
-		Provider:      provider,
-		LeaseID:       leaseID,
-		Slug:          slug,
-		LeaseMs:       timings.lease.Milliseconds(),
-		BootstrapMs:   timings.bootstrap.Milliseconds(),
-		SyncMs:        timings.sync.Milliseconds(),
-		SyncPhases:    syncTimingPhases(timings.syncSteps),
-		SyncSkipped:   timings.syncSkipped,
-		CommandMs:     timings.command.Milliseconds(),
-		CommandPhases: timings.commandPhases,
-		TotalMs:       total.Milliseconds(),
-		EndToEndMs:    runEndToEndDuration(timings, total).Milliseconds(),
-		ExitCode:      exitCode,
-		BlockedStage:  timings.blockedStage,
-		RetryLikely:   timings.retryLikely,
+		Provider:           provider,
+		LeaseID:            leaseID,
+		Slug:               slug,
+		LeaseMs:            timings.lease.Milliseconds(),
+		BootstrapMs:        timings.bootstrap.Milliseconds(),
+		SyncMs:             timings.sync.Milliseconds(),
+		SyncPhases:         syncTimingPhases(timings.syncSteps),
+		SyncSkipped:        timings.syncSkipped,
+		CommandMs:          timings.command.Milliseconds(),
+		CommandPhases:      timings.commandPhases,
+		TotalMs:            total.Milliseconds(),
+		EndToEndMs:         runEndToEndDuration(timings, total).Milliseconds(),
+		ExitCode:           exitCode,
+		BlockedStage:       timings.blockedStage,
+		ResourceExhaustion: timings.resourceExhaustion,
+		RetryLikely:        timings.retryLikely,
 	}
 }
 

--- a/internal/providers/localcontainer/backend.go
+++ b/internal/providers/localcontainer/backend.go
@@ -25,7 +25,13 @@ const (
 	workRootMarkerName  = ".crabbox-local-container-work-root"
 	dockerSocketInGuest = "/var/run/docker.sock"
 	rollbackTimeout     = 10 * time.Second
+	cgroupEvidenceLimit = 4 << 10
 )
+
+var cgroupOOMCounterPaths = []string{
+	"/sys/fs/cgroup/memory.events",
+	"/sys/fs/cgroup/memory/memory.oom_control",
+}
 
 type backend struct {
 	spec core.ProviderSpec
@@ -48,8 +54,9 @@ type inspectConfig struct {
 }
 
 type inspectState struct {
-	Status  string `json:"Status"`
-	Running bool   `json:"Running"`
+	Status    string `json:"Status"`
+	Running   bool   `json:"Running"`
+	OOMKilled bool   `json:"OOMKilled"`
 }
 
 type inspectNetworking struct {
@@ -67,6 +74,73 @@ func newBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.B
 }
 
 func (b *backend) Spec() core.ProviderSpec { return b.spec }
+
+func (b *backend) BeginRunFailureEvidence(ctx context.Context, req core.RunFailureEvidenceRequest) (core.RunFailureEvidenceCollector, error) {
+	containerID := strings.TrimSpace(req.Lease.Server.CloudID)
+	if containerID == "" {
+		return nil, core.Exit(2, "local-container failed-run evidence requires a container id")
+	}
+	baseline, err := b.readOOMKillCount(ctx, containerID)
+	if err != nil {
+		return nil, err
+	}
+	baselineContainer, err := b.inspectContainer(ctx, containerID)
+	if err != nil {
+		return nil, err
+	}
+	return func(ctx context.Context) (core.RunFailureEvidence, error) {
+		current, err := b.readOOMKillCount(ctx, containerID)
+		if err == nil && current > baseline {
+			return core.RunFailureEvidence{ResourceExhaustion: core.ResourceExhaustionMemory}, nil
+		}
+		if err == nil {
+			return core.RunFailureEvidence{}, nil
+		}
+		container, inspectErr := b.inspectContainer(ctx, containerID)
+		if inspectErr == nil && !baselineContainer.State.OOMKilled && container.State.OOMKilled {
+			return core.RunFailureEvidence{ResourceExhaustion: core.ResourceExhaustionMemory}, nil
+		}
+		if inspectErr != nil {
+			return core.RunFailureEvidence{}, fmt.Errorf("%v; inspect container OOM state: %w", err, inspectErr)
+		}
+		return core.RunFailureEvidence{}, err
+	}, nil
+}
+
+func (b *backend) readOOMKillCount(ctx context.Context, containerID string) (uint64, error) {
+	var failures []string
+	for _, cgroupPath := range cgroupOOMCounterPaths {
+		result, err := b.docker(ctx, []string{"exec", containerID, "cat", cgroupPath}, nil, nil)
+		if err != nil {
+			failures = append(failures, fmt.Sprintf("%s: %v", cgroupPath, err))
+			continue
+		}
+		count, err := parseOOMKillCount(result.Stdout)
+		if err == nil {
+			return count, nil
+		}
+		failures = append(failures, fmt.Sprintf("%s: %v", cgroupPath, err))
+	}
+	return 0, core.Exit(2, "read local-container OOM counter: %s", strings.Join(failures, "; "))
+}
+
+func parseOOMKillCount(text string) (uint64, error) {
+	if len(text) > cgroupEvidenceLimit {
+		return 0, fmt.Errorf("cgroup counter output exceeds %d bytes", cgroupEvidenceLimit)
+	}
+	fields := strings.Fields(text)
+	for i := 0; i+1 < len(fields); i += 2 {
+		if fields[i] != "oom_kill" {
+			continue
+		}
+		count, err := strconv.ParseUint(fields[i+1], 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("parse oom_kill counter: %w", err)
+		}
+		return count, nil
+	}
+	return 0, fmt.Errorf("oom_kill counter is missing")
+}
 
 func (b *backend) RebindResolvedLeaseTarget(target *core.LeaseTarget, leaseID string) error {
 	core.UseStoredTestboxKey(&target.SSH, leaseID)

--- a/internal/providers/localcontainer/backend_test.go
+++ b/internal/providers/localcontainer/backend_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"flag"
+	"fmt"
 	"io"
 	"net"
 	"os"
@@ -82,6 +83,237 @@ func testBackend(runner *recordingRunner) *backend {
 		Network:  "bridge",
 	}
 	return newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}).(*backend)
+}
+
+func TestRunFailureEvidenceUsesPerRunOOMKillIncrement(t *testing.T) {
+	tests := []struct {
+		name              string
+		counts            []string
+		baselineOOMKilled bool
+		expected          core.ResourceExhaustionReason
+	}{
+		{name: "increment", counts: []string{"oom 3\noom_kill 4\n", "oom 4\noom_kill 5\n"}, expected: core.ResourceExhaustionMemory},
+		{name: "no increment", counts: []string{"oom 3\noom_kill 4\n", "oom 3\noom_kill 4\n"}},
+		{name: "counter reset", counts: []string{"oom 8\noom_kill 9\n", "oom 0\noom_kill 0\n"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			index := 0
+			runner := &recordingRunner{run: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+				if req.Args[0] == "inspect" {
+					return core.LocalCommandResult{Stdout: fmt.Sprintf(`[{"Id":"container-123","State":{"Running":true,"OOMKilled":%t}}]`, tt.baselineOOMKilled)}, nil
+				}
+				if len(req.Args) != 4 || req.Args[0] != "exec" || req.Args[1] != "container-123" || req.Args[2] != "cat" || req.Args[3] != cgroupOOMCounterPaths[0] {
+					t.Fatalf("unexpected runtime request: %#v", req.Args)
+				}
+				if index >= len(tt.counts) {
+					t.Fatalf("unexpected extra OOM counter read")
+				}
+				result := core.LocalCommandResult{Stdout: tt.counts[index]}
+				index++
+				return result, nil
+			}}
+			b := testBackend(runner)
+			core.MarkLocalContainerRuntimeExplicit(&b.cfg)
+			collector, err := b.BeginRunFailureEvidence(context.Background(), core.RunFailureEvidenceRequest{
+				Lease: core.LeaseTarget{Server: core.Server{CloudID: "container-123"}},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			evidence, err := collector(context.Background())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if evidence.ResourceExhaustion != tt.expected {
+				t.Fatalf("resource exhaustion=%q, want %q", evidence.ResourceExhaustion, tt.expected)
+			}
+			if index != 2 {
+				t.Fatalf("counter reads=%d, want 2", index)
+			}
+		})
+	}
+}
+
+func TestRunFailureEvidenceReusedLeaseGetsFreshBaseline(t *testing.T) {
+	counts := []string{
+		"oom_kill 4\n",
+		"oom_kill 5\n",
+		"oom_kill 5\n",
+		"oom_kill 5\n",
+	}
+	index := 0
+	runner := &recordingRunner{run: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		if req.Args[0] == "inspect" {
+			return core.LocalCommandResult{Stdout: `[{"Id":"container-reused","State":{"Running":true,"OOMKilled":false}}]`}, nil
+		}
+		if req.Args[0] != "exec" || req.Args[1] != "container-reused" {
+			t.Fatalf("unexpected runtime request: %#v", req.Args)
+		}
+		result := core.LocalCommandResult{Stdout: counts[index]}
+		index++
+		return result, nil
+	}}
+	b := testBackend(runner)
+	core.MarkLocalContainerRuntimeExplicit(&b.cfg)
+	req := core.RunFailureEvidenceRequest{Lease: core.LeaseTarget{Server: core.Server{CloudID: "container-reused"}}}
+
+	first, err := b.BeginRunFailureEvidence(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstEvidence, err := first(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstEvidence.ResourceExhaustion != core.ResourceExhaustionMemory {
+		t.Fatalf("first run evidence=%#v, want memory exhaustion", firstEvidence)
+	}
+
+	second, err := b.BeginRunFailureEvidence(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondEvidence, err := second(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if secondEvidence.ResourceExhaustion != "" {
+		t.Fatalf("historical OOM misclassified reused run: %#v", secondEvidence)
+	}
+}
+
+func TestRunFailureEvidenceReadErrorsRemainDiagnostic(t *testing.T) {
+	t.Run("baseline", func(t *testing.T) {
+		runner := &recordingRunner{run: func(core.LocalCommandRequest) (core.LocalCommandResult, error) {
+			return core.LocalCommandResult{ExitCode: 1}, errors.New("counter unavailable")
+		}}
+		b := testBackend(runner)
+		core.MarkLocalContainerRuntimeExplicit(&b.cfg)
+		collector, err := b.BeginRunFailureEvidence(context.Background(), core.RunFailureEvidenceRequest{
+			Lease: core.LeaseTarget{Server: core.Server{CloudID: "container-123"}},
+		})
+		if err == nil || collector != nil {
+			t.Fatalf("collector=%v err=%v, want baseline error", collector != nil, err)
+		}
+	})
+
+	t.Run("collection", func(t *testing.T) {
+		reads := 0
+		runner := &recordingRunner{run: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+			if req.Args[0] == "inspect" && reads == 1 {
+				return core.LocalCommandResult{Stdout: `[{"Id":"container-123","State":{"Running":true,"OOMKilled":false}}]`}, nil
+			}
+			reads++
+			if reads == 1 {
+				return core.LocalCommandResult{Stdout: "oom_kill 2\n"}, nil
+			}
+			return core.LocalCommandResult{ExitCode: 1}, errors.New("counter unavailable")
+		}}
+		b := testBackend(runner)
+		core.MarkLocalContainerRuntimeExplicit(&b.cfg)
+		collector, err := b.BeginRunFailureEvidence(context.Background(), core.RunFailureEvidenceRequest{
+			Lease: core.LeaseTarget{Server: core.Server{CloudID: "container-123"}},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if evidence, err := collector(context.Background()); err == nil || evidence.ResourceExhaustion != "" {
+			t.Fatalf("evidence=%#v err=%v, want collection error without classification", evidence, err)
+		}
+	})
+}
+
+func TestRunFailureEvidenceUsesContainerOOMStateWhenCounterBecomesUnreadable(t *testing.T) {
+	reads := 0
+	inspects := 0
+	runner := &recordingRunner{run: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		if req.Args[0] == "exec" {
+			reads++
+			if reads == 1 {
+				return core.LocalCommandResult{Stdout: "oom_kill 0\n"}, nil
+			}
+			return core.LocalCommandResult{ExitCode: 128}, errors.New("container is not running")
+		}
+		if req.Args[0] == "inspect" {
+			inspects++
+			oomKilled := inspects > 1
+			return core.LocalCommandResult{Stdout: fmt.Sprintf(`[{"Id":"container-123","State":{"Status":"exited","Running":false,"OOMKilled":%t}}]`, oomKilled)}, nil
+		}
+		t.Fatalf("unexpected runtime request: %#v", req.Args)
+		return core.LocalCommandResult{}, nil
+	}}
+	b := testBackend(runner)
+	core.MarkLocalContainerRuntimeExplicit(&b.cfg)
+	collector, err := b.BeginRunFailureEvidence(context.Background(), core.RunFailureEvidenceRequest{
+		Lease: core.LeaseTarget{Server: core.Server{CloudID: "container-123"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	evidence, err := collector(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if evidence.ResourceExhaustion != core.ResourceExhaustionMemory {
+		t.Fatalf("evidence=%#v, want memory exhaustion", evidence)
+	}
+}
+
+func TestRunFailureEvidenceDoesNotReuseHistoricalContainerOOMState(t *testing.T) {
+	reads := 0
+	runner := &recordingRunner{run: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		if req.Args[0] == "exec" {
+			reads++
+			if reads == 1 {
+				return core.LocalCommandResult{Stdout: "oom_kill 3\n"}, nil
+			}
+			return core.LocalCommandResult{ExitCode: 128}, errors.New("container is not running")
+		}
+		if req.Args[0] == "inspect" {
+			return core.LocalCommandResult{Stdout: `[{"Id":"container-123","State":{"Status":"running","Running":true,"OOMKilled":true}}]`}, nil
+		}
+		t.Fatalf("unexpected runtime request: %#v", req.Args)
+		return core.LocalCommandResult{}, nil
+	}}
+	b := testBackend(runner)
+	core.MarkLocalContainerRuntimeExplicit(&b.cfg)
+	collector, err := b.BeginRunFailureEvidence(context.Background(), core.RunFailureEvidenceRequest{
+		Lease: core.LeaseTarget{Server: core.Server{CloudID: "container-123"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	evidence, err := collector(context.Background())
+	if err == nil {
+		t.Fatal("unreadable post-run counter should remain a diagnostic error")
+	}
+	if evidence.ResourceExhaustion != "" {
+		t.Fatalf("historical container OOM state was reused: %#v", evidence)
+	}
+}
+
+func TestReadOOMKillCountFallsBackToCgroupV1(t *testing.T) {
+	runner := &recordingRunner{run: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		switch req.Args[3] {
+		case cgroupOOMCounterPaths[0]:
+			return core.LocalCommandResult{ExitCode: 1}, errors.New("not found")
+		case cgroupOOMCounterPaths[1]:
+			return core.LocalCommandResult{Stdout: "oom_kill_disable 0\nunder_oom 0\noom_kill 7\n"}, nil
+		default:
+			t.Fatalf("unexpected cgroup path: %#v", req.Args)
+			return core.LocalCommandResult{}, nil
+		}
+	}}
+	b := testBackend(runner)
+	core.MarkLocalContainerRuntimeExplicit(&b.cfg)
+	count, err := b.readOOMKillCount(context.Background(), "container-123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 7 {
+		t.Fatalf("count=%d, want 7", count)
+	}
 }
 
 func TestDockerPinsCheckpointForkScope(t *testing.T) {
@@ -294,6 +526,9 @@ func TestProviderAliases(t *testing.T) {
 	}
 	if !spec.Features.Has(core.FeatureCacheVolume) {
 		t.Fatalf("local-container features=%v, want cache-volume", spec.Features)
+	}
+	if _, ok := newBackend(spec, core.BaseConfig(), core.Runtime{Exec: &recordingRunner{}}).(core.SSHRunFailureEvidenceBackend); !ok {
+		t.Fatal("local-container backend does not expose failed-run evidence capability")
 	}
 }
 

--- a/internal/providers/localcontainer/oom_dockerproof_test.go
+++ b/internal/providers/localcontainer/oom_dockerproof_test.go
@@ -1,0 +1,97 @@
+//go:build dockerproof
+
+package localcontainer
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type oomProofRunner struct{}
+
+func (oomProofRunner) Run(ctx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+	cmd := exec.CommandContext(ctx, req.Name, req.Args...)
+	cmd.Env = append(os.Environ(), req.Env...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	result := core.LocalCommandResult{Stdout: stdout.String(), Stderr: stderr.String()}
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		result.ExitCode = exitErr.ExitCode()
+	}
+	return result, err
+}
+
+func TestDockerOOMKillEvidenceProof(t *testing.T) {
+	runtimeName := strings.TrimSpace(os.Getenv("CRABBOX_LOCAL_CONTAINER_RUNTIME"))
+	if runtimeName == "" {
+		runtimeName = "docker"
+	}
+	if _, err := exec.LookPath(runtimeName); err != nil {
+		t.Skipf("%s is not installed: %v", runtimeName, err)
+	}
+	if out, err := exec.Command(runtimeName, "info").CombinedOutput(); err != nil {
+		t.Skipf("%s daemon is unavailable: %v: %s", runtimeName, err, out)
+	}
+
+	name := fmt.Sprintf("crabbox-oom-proof-%d", time.Now().UnixNano())
+	image := "alpine:3"
+	create := exec.Command(runtimeName, "run", "-d", "--name", name, "--memory", "64m", image, "sleep", "300")
+	out, err := create.CombinedOutput()
+	if err != nil {
+		t.Skipf("cannot create bounded proof container: %v: %s", err, out)
+	}
+	containerID := name
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+		_ = exec.CommandContext(cleanupCtx, runtimeName, "rm", "-f", containerID).Run()
+	})
+
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.LocalContainer.Runtime = runtimeName
+	core.MarkLocalContainerRuntimeExplicit(&cfg)
+	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Exec: oomProofRunner{}, Stdout: os.Stdout, Stderr: os.Stderr}).(*backend)
+	req := core.RunFailureEvidenceRequest{Lease: core.LeaseTarget{Server: core.Server{CloudID: containerID}}}
+
+	ordinary, err := b.BeginRunFailureEvidence(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := exec.Command(runtimeName, "exec", containerID, "sh", "-c", "exit 7").Run(); err == nil {
+		t.Fatal("ordinary failure control exited zero")
+	}
+	ordinaryEvidence, err := ordinary(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ordinaryEvidence.ResourceExhaustion != "" {
+		t.Fatalf("ordinary exit produced resource exhaustion: %#v", ordinaryEvidence)
+	}
+
+	oom, err := b.BeginRunFailureEvidence(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oomCommand := "dd if=/dev/zero of=/dev/shm/crabbox-oom bs=1M count=256 2>/dev/null"
+	if err := exec.Command(runtimeName, "exec", containerID, "sh", "-c", oomCommand).Run(); err == nil {
+		t.Fatal("memory exhaustion command unexpectedly exited zero")
+	}
+	oomEvidence, err := oom(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if oomEvidence.ResourceExhaustion != core.ResourceExhaustionMemory {
+		t.Fatalf("OOM evidence=%#v, want memory resource exhaustion", oomEvidence)
+	}
+}


### PR DESCRIPTION
## Summary

- Preserve provider-neutral failed-run evidence through the run pipeline so backends can report bounded resource-exhaustion context without moving provider-specific cgroup logic into core.
- Record a per-command local-container cgroup `oom_kill` baseline and classify only a positive post-command delta, avoiding stale OOM counts on reused leases.
- Keep memory evidence available across secondary transport and capture failures, then expose the normalized classification in timing JSON, the run summary, and actionable failure-digest guidance.

## Verification

```text
go test -race ./internal/cli ./internal/providers/localcontainer -run 'TestClassifyRunFailureUsesNormalizedMemoryEvidence|TestRunOutcomeFailureKeepsMemoryEvidenceAcrossSecondaryFailures|TestRunFailureEvidence|TestReadOOMKillCount|TestPrintRunFailureDigestIncludesMemoryGuidance|TestTimingJSONIncludesFailureClassification|TestFormatRunSummaryIncludesFailureClassification'
go test -tags=dockerproof ./internal/providers/localcontainer -run TestDockerOOMKillEvidenceProof -count=1 -v
go vet ./...
git diff origin/main...HEAD --check
```

The live Docker proof exercised both an actual memory-limited OOM kill and its non-OOM control path.

A broader affected `go test -race` run previously reached the global 10-minute timeout in the existing unrelated `TestRelayWebSocketVNCWithARDAuthenticationTimeoutIsConfigurable` suite. Running that exact test alone under the race detector then passed in 0.08 seconds.

Fixes https://github.com/openclaw/crabbox/issues/1237
