### PR TITLE
fix(doctor): distinguish compiled provider defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Clarified that POSIX SSH `run --script` uploads a content-hashed standalone copy whose `$0` points under `.crabbox/scripts/`, and documented synced-path execution for scripts that need adjacent repository assets. Thanks @coygeek.
 - Classified per-run local-container cgroup OOM-kill increments as memory resource exhaustion, with bounded evidence collection and actionable memory/concurrency guidance while ignoring historical OOM counts on reused leases. Thanks @coygeek.
+- Made bare `crabbox doctor` report compiled-default provider provenance and skip that unchosen provider's credential readiness without weakening explicitly configured provider checks. Thanks @coygeek.
 - Reconciled exact-owned Azure VM, NIC, public IP, and managed OS disk orphan sets with stable-identity quarantine and fail-closed durable deletion progress. Thanks @chsong1.
 - Invalidated adopted Actions workspace readiness markers before full resync and rehydrated the canonical workspace before running commands. Thanks @vincentkoc.
 - Stopped sparse-checkout and skip-worktree omissions from deleting in-scope remote files, and kept staged gitlink removals out of file-deletion manifests. Thanks @vincentkoc.

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -40,7 +40,11 @@ skipped). This changes selection only: an explicit path inside the active
 repository, or a symlink that resolves into it, still has repository trust.
 `config show` reflects the resulting effective values, including
 provider defaults applied at load time; per-command flags are not part of what
-it reports.
+it reports. The provider line also includes `provider_source` (and JSON includes
+`providerSource`) so diagnostics distinguish a `compiled_default` from a
+selection in `user_config`, `repo_config`, or the `environment`. Passing
+`config show --provider <name>` reports `flag` because that command-scoped
+override wins the merge.
 
 Secrets are never printed. Token-bearing fields are reduced to a status word:
 

--- a/docs/commands/doctor.md
+++ b/docs/commands/doctor.md
@@ -2,9 +2,11 @@
 
 `crabbox doctor` runs a preflight before you commit to a long workflow. It is
 fast on a healthy machine, non-destructive, and never creates, mutates, or
-deletes provider resources. Run it before your first `crabbox run`, after
-rotating tokens or editing config, and as a sanity check in agent boot
-sequences or CI smoke jobs.
+deletes provider resources. Bare `crabbox doctor` is also the pre-configuration
+local-readiness check: when the provider comes only from Crabbox's compiled
+default, doctor reports that provenance and skips provider credential readiness
+with a warning. Run it before your first `crabbox run`, after rotating tokens or
+editing config, and as a sanity check in agent boot sequences or CI smoke jobs.
 
 ```sh
 crabbox doctor
@@ -28,6 +30,7 @@ selected provider, target, or context:
 
 ```text
 config     writable config file exists and has safe permissions (expects 0600)
+provider-selection selected provider and its winning config source
 tools      provider-applicable local tools are present and executable
 remote     optional SSH/tool probe against a resolved lease (--id / --from-run)
 coord      coordinator URL is reachable and healthy (brokered providers)
@@ -49,6 +52,16 @@ A missing tool prints `missing` and fails the run.
 ### Provider readiness
 
 Provider readiness validates the selected provider without creating a lease.
+
+Doctor first prints `provider-selection` with the resolved provider and source:
+`compiled_default`, `user_config`, `repo_config`, `environment`, `flag`,
+`recorded_run`, or `lease_context`. If the only source is `compiled_default`, doctor prints
+`warning provider ... readiness=skipped` and does not run either direct or
+coordinator provider credential readiness. This warning does not hide other
+failures: missing local tools, invalid coordinator authentication, unsafe config
+permissions, and other applicable checks still determine the exit status.
+Selecting the same provider explicitly is strict; for example,
+`crabbox doctor --provider hetzner` still fails when its credentials are absent.
 
 - When a coordinator is configured for a brokered provider (`aws`, `azure`,
   `daytona`, `gcp`, `hetzner`), doctor asks the broker for secret readiness. It
@@ -138,7 +151,9 @@ supported for native Windows targets (exits `2`).
 `crabbox doctor --from-run <run-id>` is for triaging a recorded failure. Doctor
 fetches the run record and applies its provider, target, class, server type,
 lease, and phase before running diagnostics. This requires a configured
-coordinator (exits `2` otherwise). Older run records may omit fields; doctor
+coordinator (exits `2` otherwise). An explicit `--provider` remains the
+higher-precedence provider selection while the other recorded context is
+retained. Older run records may omit fields; doctor
 prints a `warning run` line with `missing=...` and skips checks that cannot be
 tied to the run, such as the remote probe when no lease ID was recorded.
 
@@ -170,6 +185,7 @@ For the full per-check breakdown of how each one decides between `ok`, `skip`,
 
 ```text
 ok      config   ~/.config/crabbox/config.yaml permissions=0600
+ok      provider-selection provider=aws source=repo_config
 ok      git      /usr/bin/git
 ok      ssh      /usr/bin/ssh
 ok      ssh-keygen /usr/bin/ssh-keygen
@@ -186,7 +202,8 @@ exits `0` unless another check fails.
 
 `--json` prints the same checks as a structured object with `ok`, `provider`,
 and `checks` fields. Each check includes `status`, `check`, `message`, and
-parsed `details` when available.
+parsed `details` when available; the `provider-selection` details include
+`source`.
 
 Both output modes apply the same final diagnostic redaction to coordinator and
 provider messages and details. Configured credentials, authorization headers,
@@ -206,7 +223,7 @@ Exit codes:
 ## Flags
 
 ```text
---provider <name>             provider to validate (defaults to configured provider)
+--provider <name>             provider to validate strictly (defaults to resolved provider)
 --profile <name>              configured profile for remote prerequisite checks
 --id <lease-id-or-slug>       resolve a lease and run a remote SSH/tool probe
 --from-run <run-id>           load provider/target/lease/phase context from a recorded run

--- a/docs/features/doctor.md
+++ b/docs/features/doctor.md
@@ -15,7 +15,9 @@ each check decides its status and how to add a new one.
 The command is fast (under a second on a healthy machine), non-destructive, and
 never calls billable provider create APIs. When a coordinator is configured it
 performs cheap broker checks such as health, identity, and provider secret
-readiness. The provider readiness probe is bounded to a 10s timeout.
+readiness. The provider readiness probe is bounded to a 10s timeout. Bare doctor
+skips that probe when the resolved provider is only the compiled default; all
+explicit or configured provider selections remain strict.
 
 ## Output Model
 
@@ -38,6 +40,7 @@ Check names you can see, roughly in emission order:
 ```text
 run        --from-run context summary (provider/target/lease/phase)
 config     writable config file exists with safe permissions (0600)
+provider-selection resolved provider and its winning selection source
 git        git is on PATH
 ssh        ssh is on PATH (SSH-backed providers)
 ssh-keygen ssh-keygen is on PATH (SSH-backed providers)
@@ -97,6 +100,18 @@ coordinator, doctor falls through to the direct provider check below.
 ## Provider Readiness (`provider`)
 
 Provider readiness validates the selected provider without creating a lease.
+
+Before local tool checks, `provider-selection` reports the canonical provider
+and the winning source: `compiled_default`, `user_config`, `repo_config`,
+`environment`, `flag`, `recorded_run`, or `lease_context`. This provenance is
+resolved while configuration and command context are applied; doctor does not
+infer it from the provider name.
+
+When the source is `compiled_default`, doctor skips both brokered and direct
+provider credential readiness and emits an advisory provider warning with
+`readiness=skipped`. Other checks still run and can fail the command. A provider
+selected from any higher-precedence source remains strict, including an
+explicit flag that happens to select the same provider as the compiled default.
 
 **Brokered path (coordinator configured).** For providers whose coordinator
 support is `supported` (`aws`, `azure`, `daytona`, `gcp`, `hetzner`), doctor asks
@@ -181,7 +196,8 @@ erroring.
 `crabbox doctor --from-run <run-id>` triages a recorded failure. Doctor fetches
 the run record and applies its provider, target, class, server type, lease, and
 phase before running diagnostics; it requires a configured coordinator (exit `2`
-otherwise). Older run records may omit fields — doctor then prints a
+otherwise). An explicit `--provider` keeps normal flag precedence over the
+recorded provider. Older run records may omit fields — doctor then prints a
 `warning run` line listing `missing=...` and skips checks that cannot be tied to
 the run, such as the remote probe when no lease ID was recorded.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -25,8 +25,11 @@ crabbox doctor
 ```
 
 `crabbox doctor` prints one line per check. Local tool checks (`git`, `ssh`,
-`ssh-keygen`, `rsync`) should report `ok`. It is fine if the broker and provider
-checks fail for now - we configure those next.
+`ssh-keygen`, `rsync`) should report `ok`. On a fresh install, doctor reports the
+compiled provider default as `source=compiled_default` and warns that provider
+credential readiness was skipped; the warning does not fail the command. Once
+you select a provider through config, `CRABBOX_PROVIDER`, or `--provider`, its
+broker or direct credential check is strict and can fail until you configure it.
 
 If you do not use Homebrew, GitHub Releases ship signed archives for macOS,
 Linux, and Windows. Download the matching archive from

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -18,6 +18,7 @@ import (
 type Config struct {
 	Profile                       string
 	Provider                      string
+	providerSelectionSource       providerSelectionSource
 	externalDesktopCredentialName string
 	externalDesktopCredential     transientSecret
 	externalDesktopEnvDenylist    []string
@@ -254,6 +255,30 @@ type Config struct {
 	Presets                       map[string]PresetConfig
 	ProofTemplates                map[string]ProofTemplateConfig
 	Jobs                          map[string]JobConfig
+}
+
+type providerSelectionSource string
+
+const (
+	providerSelectionCompiledDefault providerSelectionSource = "compiled_default"
+	providerSelectionUserConfig      providerSelectionSource = "user_config"
+	providerSelectionRepoConfig      providerSelectionSource = "repo_config"
+	providerSelectionEnvironment     providerSelectionSource = "environment"
+	providerSelectionFlag            providerSelectionSource = "flag"
+	providerSelectionRecordedRun     providerSelectionSource = "recorded_run"
+	providerSelectionLeaseContext    providerSelectionSource = "lease_context"
+)
+
+func setProviderSelection(cfg *Config, provider string, source providerSelectionSource) {
+	cfg.Provider = provider
+	cfg.providerSelectionSource = source
+}
+
+func providerSelectionSourceForConfigPath(trust configPathTrust) providerSelectionSource {
+	if !trust.trusted {
+		return providerSelectionRepoConfig
+	}
+	return providerSelectionUserConfig
 }
 
 type SyncConfig struct {
@@ -1652,7 +1677,7 @@ func loadConfigWithOverrides(coordinator, provider string) (Config, error) {
 		markCoordinatorDestinationExplicit(&cfg)
 	}
 	if provider = strings.TrimSpace(provider); provider != "" {
-		cfg.Provider = provider
+		setProviderSelection(&cfg, provider, providerSelectionFlag)
 		cfg.brokerProvider = ""
 	}
 	if err := normalizeBrokerConfig(&cfg); err != nil {
@@ -2823,22 +2848,23 @@ func baseConfig() Config {
 	hetznerImage, azureImage, gcpImage, linodeImage, isloImage, containerImage, _ := osImageDefaultProviderImages(osImage)
 	multipassImage, _ := osImageDefaultMultipassImage(osImage)
 	return Config{
-		Profile:          "default",
-		Provider:         provider,
-		TargetOS:         "linux",
-		Architecture:     ArchitectureAMD64,
-		OSImage:          osImage,
-		WindowsMode:      "normal",
-		DesktopEnv:       desktopEnvXFCE,
-		Network:          NetworkAuto,
-		Class:            class,
-		ServerType:       "",
-		BrokerMode:       BrokerModeManaged,
-		BrokerAutoWebVNC: true,
-		Location:         "fsn1",
-		Image:            hetznerImage,
-		AWSRegion:        "eu-west-1",
-		AWSRootGB:        400,
+		Profile:                 "default",
+		Provider:                provider,
+		providerSelectionSource: providerSelectionCompiledDefault,
+		TargetOS:                "linux",
+		Architecture:            ArchitectureAMD64,
+		OSImage:                 osImage,
+		WindowsMode:             "normal",
+		DesktopEnv:              desktopEnvXFCE,
+		Network:                 NetworkAuto,
+		Class:                   class,
+		ServerType:              "",
+		BrokerMode:              BrokerModeManaged,
+		BrokerAutoWebVNC:        true,
+		Location:                "fsn1",
+		Image:                   hetznerImage,
+		AWSRegion:               "eu-west-1",
+		AWSRootGB:               400,
 		AWSLambdaMicroVM: AWSLambdaMicroVMConfig{
 			Workdir: "/workspace/crabbox",
 		},
@@ -5013,11 +5039,11 @@ func applyConfigFile(cfg *Config, path string, trust configPathTrust) error {
 	if !trust.trusted && trust.repositoryRoot != "" {
 		cfg.credentialProvenance.repositoryRoot = trust.repositoryRoot
 	}
-	return applyFileConfigWithTrust(cfg, file, trust.trusted)
+	return applyFileConfigWithTrustAndProviderSource(cfg, file, trust.trusted, providerSelectionSourceForConfigPath(trust))
 }
 
 func applyFileConfig(cfg *Config, file fileConfig) error {
-	return applyFileConfigWithTrust(cfg, file, true)
+	return applyFileConfigWithTrustAndProviderSource(cfg, file, true, providerSelectionUserConfig)
 }
 
 func classifyConfigPath(path string) configPathTrust {
@@ -5076,6 +5102,14 @@ func inlineSSHPublicKey(value string) bool {
 }
 
 func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error {
+	source := providerSelectionRepoConfig
+	if trusted {
+		source = providerSelectionUserConfig
+	}
+	return applyFileConfigWithTrustAndProviderSource(cfg, file, trusted, source)
+}
+
+func applyFileConfigWithTrustAndProviderSource(cfg *Config, file fileConfig, trusted bool, providerSource providerSelectionSource) error {
 	credentialSource := credentialSourceForFile(trusted)
 	if !trusted && cfg.credentialProvenance.repositoryRoot == "" {
 		if root, err := os.Getwd(); err == nil {
@@ -5086,7 +5120,7 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 		cfg.Profile = file.Profile
 	}
 	if file.Provider != "" {
-		cfg.Provider = file.Provider
+		setProviderSelection(cfg, file.Provider, providerSource)
 		cfg.brokerProvider = ""
 	}
 	if file.Target != "" {
@@ -5170,7 +5204,7 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 			cfg.credentialProvenance.coordAdminToken = credentialSource
 		}
 		if file.Broker.Provider != "" {
-			cfg.Provider = file.Broker.Provider
+			setProviderSelection(cfg, file.Broker.Provider, providerSource)
 			cfg.brokerProvider = file.Broker.Provider
 		}
 		if file.Broker.Access != nil {
@@ -8130,7 +8164,7 @@ func appleVMEnv(name string) string {
 func applyEnv(cfg *Config) error {
 	cfg.Profile = getenv("CRABBOX_PROFILE", cfg.Profile)
 	if provider := os.Getenv("CRABBOX_PROVIDER"); provider != "" {
-		cfg.Provider = provider
+		setProviderSelection(cfg, provider, providerSelectionEnvironment)
 		cfg.brokerProvider = ""
 	}
 	if t := os.Getenv("CRABBOX_TARGET"); t != "" {

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -145,6 +145,7 @@ func configShowView(cfg Config) map[string]any {
 	return map[string]any{
 		"profile":                    cfg.Profile,
 		"provider":                   cfg.Provider,
+		"providerSource":             cfg.providerSelectionSource,
 		"target":                     cfg.TargetOS,
 		"architecture":               effectiveArchitectureForConfig(cfg),
 		"os":                         cfg.OSImage,
@@ -753,7 +754,7 @@ func redactedParallelsHostConfigs(hosts []ParallelsHostConfig) []ParallelsHostCo
 
 func writeConfigShowText(w io.Writer, cfg Config) {
 	fmt.Fprintf(w, "config=%s\n", userConfigPath())
-	fmt.Fprintf(w, "provider=%s target=%s arch=%s os=%s windows_mode=%s class=%s type=%s profile=%s\n", cfg.Provider, cfg.TargetOS, effectiveArchitectureForConfig(cfg), cfg.OSImage, cfg.WindowsMode, cfg.Class, cfg.ServerType, cfg.Profile)
+	fmt.Fprintf(w, "provider=%s provider_source=%s target=%s arch=%s os=%s windows_mode=%s class=%s type=%s profile=%s\n", cfg.Provider, cfg.providerSelectionSource, cfg.TargetOS, effectiveArchitectureForConfig(cfg), cfg.OSImage, cfg.WindowsMode, cfg.Class, cfg.ServerType, cfg.Profile)
 	fmt.Fprintf(w, "broker=%s mode=%s auto_webvnc=%t login_redirect_origins=%s auth=%s admin_auth=%s\n", blank(redactedConfigURL(cfg.Coordinator), "-"), cfg.BrokerMode, cfg.BrokerAutoWebVNC, blank(strings.Join(cfg.BrokerLoginRedirectOrigins, ","), "-"), coordinatorTokenState(cfg), tokenState(cfg.CoordAdminToken))
 	fmt.Fprintf(w, "access_auth=%s\n", accessAuthState(cfg.Access))
 	fmt.Fprintf(w, "ssh=%s@<host>:%s fallback_ports=%s key=%s\n", cfg.SSHUser, cfg.SSHPort, blank(strings.Join(cfg.SSHFallbackPorts, ","), "-"), cfg.SSHKey)

--- a/internal/cli/config_cmd_test.go
+++ b/internal/cli/config_cmd_test.go
@@ -11,6 +11,34 @@ import (
 	"time"
 )
 
+func TestConfigShowReportsProviderSelectionSource(t *testing.T) {
+	t.Run("compiled default text", func(t *testing.T) {
+		isolateDoctorProviderSelectionTest(t)
+		var stdout, stderr bytes.Buffer
+		if err := (App{Stdout: &stdout, Stderr: &stderr}).configShow(nil); err != nil {
+			t.Fatalf("config show error=%v stderr=%q", err, stderr.String())
+		}
+		if !strings.Contains(stdout.String(), "provider=hetzner provider_source=compiled_default") {
+			t.Fatalf("config show missing compiled-default provenance:\n%s", stdout.String())
+		}
+	})
+
+	t.Run("command override json", func(t *testing.T) {
+		isolateDoctorProviderSelectionTest(t)
+		var stdout, stderr bytes.Buffer
+		if err := (App{Stdout: &stdout, Stderr: &stderr}).configShow([]string{"--provider", "hetzner", "--json"}); err != nil {
+			t.Fatalf("config show error=%v stderr=%q", err, stderr.String())
+		}
+		var view map[string]any
+		if err := json.Unmarshal(stdout.Bytes(), &view); err != nil {
+			t.Fatalf("config show JSON invalid: %v\n%s", err, stdout.String())
+		}
+		if view["provider"] != "hetzner" || view["providerSource"] != "flag" {
+			t.Fatalf("config show provider provenance=%#v", view)
+		}
+	})
+}
+
 func TestNamespaceInstanceConfigShowRedactsEndpointCredentials(t *testing.T) {
 	cfg := baseConfig()
 	cfg.NamespaceInstance.Endpoint = "https://user:secret@api.example.test/path"

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -141,7 +141,7 @@ func (a App) doctor(ctx context.Context, args []string) error {
 		if err != nil {
 			return err
 		}
-		if run.Provider != "" {
+		if run.Provider != "" && !flagWasSet(fs, "provider") {
 			*provider = run.Provider
 		}
 		if resolvedDoctorID == "" && run.LeaseID != "" {
@@ -177,6 +177,9 @@ func (a App) doctor(ctx context.Context, args []string) error {
 	if err := prepareProviderSelection(&cfg, *provider); err != nil {
 		return err
 	}
+	if flagWasSet(fs, "provider") && cfg.providerSelectionSource != providerSelectionRecordedRun {
+		cfg.providerSelectionSource = providerSelectionFlag
+	}
 	if err := applyTargetFlagOverrides(&cfg, fs, targetFlags); err != nil {
 		return err
 	}
@@ -201,6 +204,10 @@ func (a App) doctor(ctx context.Context, args []string) error {
 			return err
 		}
 	}
+	record("ok", "provider-selection", fmt.Sprintf("provider=%s source=%s", cfg.Provider, cfg.providerSelectionSource), map[string]string{
+		"provider": cfg.Provider,
+		"source":   string(cfg.providerSelectionSource),
+	})
 	for _, tool := range doctorLocalTools(providerDef.Spec()) {
 		path, err := exec.LookPath(tool)
 		if err != nil {
@@ -291,7 +298,7 @@ func (a App) doctor(ctx context.Context, args []string) error {
 					}
 					record("ok", "broker", doctorBrokerOKMessage(whoami, cfg.ServerType), details)
 				}
-				if brokerOK && coordinatorProviderReadinessSupported(cfg.Provider) {
+				if brokerOK && cfg.providerSelectionSource != providerSelectionCompiledDefault && coordinatorProviderReadinessSupported(cfg.Provider) {
 					readiness, err := coord.ProviderReadiness(ctx, cfg)
 					if err == nil {
 						if readiness.Configured {
@@ -349,6 +356,15 @@ func (a App) doctor(ctx context.Context, args []string) error {
 		}
 	} else {
 		record("ok", "ssh-key", "per-lease", map[string]string{"mode": "per-lease"})
+	}
+	if cfg.providerSelectionSource == providerSelectionCompiledDefault {
+		record("warning", "provider", fmt.Sprintf("provider=%s source=%s readiness=skipped hint=select_provider_with_flag_env_or_config", cfg.Provider, cfg.providerSelectionSource), map[string]string{
+			"provider":  cfg.Provider,
+			"source":    string(cfg.providerSelectionSource),
+			"readiness": "skipped",
+			"hint":      "select_provider_with_flag_env_or_config",
+		})
+		return finish()
 	}
 
 	if useCoordinator {
@@ -428,7 +444,7 @@ func applyDoctorFromRunContext(ctx context.Context, cfg *Config, runID string) (
 	}
 	var missing []string
 	if strings.TrimSpace(run.Provider) != "" {
-		cfg.Provider = strings.TrimSpace(run.Provider)
+		setProviderSelection(cfg, strings.TrimSpace(run.Provider), providerSelectionRecordedRun)
 		prepareProviderDefaults(cfg)
 	} else {
 		missing = append(missing, "provider")

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -83,6 +83,223 @@ func TestDoctorLocalToolsAreProviderAware(t *testing.T) {
 	}
 }
 
+func TestDoctorProviderSelectionProvenanceAndStrictness(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		setup      func(*testing.T)
+		wantSource providerSelectionSource
+		wantOK     bool
+	}{
+		{
+			name:       "compiled default",
+			wantSource: providerSelectionCompiledDefault,
+			wantOK:     true,
+		},
+		{
+			name:       "provider flag",
+			args:       []string{"--provider", "hetzner"},
+			wantSource: providerSelectionFlag,
+		},
+		{
+			name: "environment",
+			setup: func(t *testing.T) {
+				t.Setenv("CRABBOX_PROVIDER", "hetzner")
+			},
+			wantSource: providerSelectionEnvironment,
+		},
+		{
+			name: "repository config",
+			setup: func(t *testing.T) {
+				if err := os.WriteFile(".crabbox.yaml", []byte("provider: hetzner\n"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantSource: providerSelectionRepoConfig,
+		},
+		{
+			name: "user config with selected profile",
+			setup: func(t *testing.T) {
+				path := userConfigPath()
+				if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+					t.Fatal(err)
+				}
+				body := "provider: hetzner\nprofile: qa\nprofiles:\n  qa:\n    doctor:\n      enabled: false\n"
+				if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantSource: providerSelectionUserConfig,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isolateDoctorProviderSelectionTest(t)
+			if tt.setup != nil {
+				tt.setup(t)
+			}
+			var stdout, stderr bytes.Buffer
+			err := (App{Stdout: &stdout, Stderr: &stderr}).doctor(context.Background(), tt.args)
+			if tt.wantOK {
+				if err != nil {
+					t.Fatalf("doctor error=%v stdout=%q stderr=%q", err, stdout.String(), stderr.String())
+				}
+				if !strings.Contains(stdout.String(), "warning provider provider=hetzner source=compiled_default readiness=skipped") {
+					t.Fatalf("doctor did not skip compiled-default readiness:\n%s", stdout.String())
+				}
+			} else {
+				var exitErr ExitError
+				if !AsExitError(err, &exitErr) || exitErr.Code != 1 {
+					t.Fatalf("doctor error=%v, want exit 1; stdout=%q stderr=%q", err, stdout.String(), stderr.String())
+				}
+				if !strings.Contains(stdout.String(), "failed  provider provider=hetzner") || !strings.Contains(stdout.String(), "HCLOUD_TOKEN or HETZNER_TOKEN is required") {
+					t.Fatalf("doctor did not preserve strict provider readiness:\n%s", stdout.String())
+				}
+			}
+			wantSelection := "provider-selection provider=hetzner source=" + string(tt.wantSource)
+			if !strings.Contains(stdout.String(), wantSelection) {
+				t.Fatalf("doctor selection provenance missing %q:\n%s", wantSelection, stdout.String())
+			}
+		})
+	}
+}
+
+func TestDoctorCompiledDefaultSkipsCoordinatorProviderReadiness(t *testing.T) {
+	isolateDoctorProviderSelectionTest(t)
+	readinessCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/health":
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+		case "/v1/whoami":
+			_ = json.NewEncoder(w).Encode(CoordinatorWhoami{Auth: "token", Owner: "alice@example.test", Org: "example-org"})
+		case "/v1/providers/hetzner/readiness":
+			readinessCalled = true
+			http.Error(w, "compiled-default readiness should be skipped", http.StatusInternalServerError)
+		default:
+			http.Error(w, "unexpected "+r.URL.Path, http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+	t.Setenv("CRABBOX_COORDINATOR", server.URL)
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "token")
+
+	var stdout, stderr bytes.Buffer
+	if err := (App{Stdout: &stdout, Stderr: &stderr}).doctor(context.Background(), nil); err != nil {
+		t.Fatalf("doctor error=%v stdout=%q stderr=%q", err, stdout.String(), stderr.String())
+	}
+	if readinessCalled {
+		t.Fatal("doctor called coordinator readiness for the compiled default")
+	}
+	for _, want := range []string{"ok      coord", "ok      broker", "warning provider provider=hetzner source=compiled_default readiness=skipped"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("doctor output missing %q:\n%s", want, stdout.String())
+		}
+	}
+}
+
+func TestDoctorCompiledDefaultJSONReportsSkippedReadiness(t *testing.T) {
+	isolateDoctorProviderSelectionTest(t)
+	var stdout, stderr bytes.Buffer
+	if err := (App{Stdout: &stdout, Stderr: &stderr}).doctor(context.Background(), []string{"--json"}); err != nil {
+		t.Fatalf("doctor error=%v stdout=%q stderr=%q", err, stdout.String(), stderr.String())
+	}
+	var view doctorJSONOutput
+	if err := json.Unmarshal(stdout.Bytes(), &view); err != nil {
+		t.Fatalf("doctor JSON invalid: %v\n%s", err, stdout.String())
+	}
+	if !view.OK || view.Provider != "hetzner" {
+		t.Fatalf("doctor view=%#v", view)
+	}
+	var selection, readiness bool
+	for _, check := range view.Checks {
+		selection = selection || (check.Check == "provider-selection" && check.Details["source"] == "compiled_default")
+		readiness = readiness || (check.Check == "provider" && check.Status == "warning" && check.Details["readiness"] == "skipped")
+	}
+	if !selection || !readiness {
+		t.Fatalf("doctor JSON missing provenance or skip: %#v", view.Checks)
+	}
+}
+
+func TestDoctorConfiguredProviderKeepsCoordinatorReadinessStrict(t *testing.T) {
+	isolateDoctorProviderSelectionTest(t)
+	t.Setenv("CRABBOX_PROVIDER", "aws")
+	readinessCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/health":
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+		case "/v1/whoami":
+			_ = json.NewEncoder(w).Encode(CoordinatorWhoami{Auth: "token", Owner: "alice@example.test", Org: "example-org"})
+		case "/v1/providers/aws/readiness":
+			readinessCalled = true
+			_ = json.NewEncoder(w).Encode(CoordinatorProviderReadiness{Provider: "aws", Configured: false, Missing: []string{"AWS_ACCESS_KEY_ID"}})
+		default:
+			http.Error(w, "unexpected "+r.URL.Path, http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+	t.Setenv("CRABBOX_COORDINATOR", server.URL)
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "token")
+
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).doctor(context.Background(), nil)
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 1 {
+		t.Fatalf("doctor error=%v, want exit 1; stdout=%q stderr=%q", err, stdout.String(), stderr.String())
+	}
+	if !readinessCalled {
+		t.Fatal("doctor skipped coordinator readiness for a configured provider")
+	}
+	for _, want := range []string{"provider-selection provider=aws source=environment", "failed  provider provider=aws missing=AWS_ACCESS_KEY_ID"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("doctor output missing %q:\n%s", want, stdout.String())
+		}
+	}
+}
+
+func TestDoctorCompiledDefaultStillFailsOtherReadinessChecks(t *testing.T) {
+	isolateDoctorProviderSelectionTest(t)
+	t.Setenv("PATH", doctorTestToolPath(t, []string{"git"}))
+
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).doctor(context.Background(), nil)
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 1 {
+		t.Fatalf("doctor error=%v, want exit 1; stdout=%q stderr=%q", err, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "missing ssh") || !strings.Contains(stdout.String(), "readiness=skipped") {
+		t.Fatalf("doctor did not preserve non-provider failures:\n%s", stdout.String())
+	}
+}
+
+func isolateDoctorProviderSelectionTest(t *testing.T) {
+	t.Helper()
+	clearConfigEnv(t)
+	t.Setenv("CRABBOX_CONFIG", "")
+	t.Setenv("CRABBOX_PROVIDER", "")
+	t.Setenv("CRABBOX_PROFILE", "")
+	t.Setenv("CRABBOX_COORDINATOR", "")
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "")
+	t.Setenv("HCLOUD_TOKEN", "")
+	t.Setenv("HETZNER_TOKEN", "")
+	t.Chdir(t.TempDir())
+	t.Setenv("PATH", doctorTestToolPath(t, []string{"git", "ssh", "ssh-keygen", "rsync"}))
+}
+
+func doctorTestToolPath(t *testing.T, tools []string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for _, tool := range tools {
+		path := filepath.Join(dir, tool)
+		if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
 func TestDoctorRejectsUnsupportedProviderTarget(t *testing.T) {
 	for _, tool := range []string{"git", "ssh", "ssh-keygen", "rsync"} {
 		if _, err := exec.LookPath(tool); err != nil {
@@ -249,12 +466,23 @@ func TestDoctorFromRunAppliesRecordedContext(t *testing.T) {
 	text := stdout.String()
 	for _, want := range []string{
 		"warning run      run=run_123 provider=proxmox target=linux class=standard type=vm-large lease=- phase=test missing=leaseID",
+		"provider-selection provider=proxmox source=recorded_run",
 		"skip    remote   from_run=run_123 lease=missing remote_checks=skipped",
 		"skip    provider provider=proxmox direct_doctor=unsupported",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("doctor --from-run output missing %q:\n%s", want, text)
 		}
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	err = (App{Stdout: &stdout, Stderr: &stderr}).doctor(context.Background(), []string{"--from-run", "run_123", "--provider", "proxmox"})
+	if err != nil {
+		t.Fatalf("doctor --from-run --provider error=%v stdout=%q stderr=%q", err, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "provider-selection provider=proxmox source=flag") {
+		t.Fatalf("explicit provider did not retain flag provenance:\n%s", stdout.String())
 	}
 }
 

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -1186,6 +1186,7 @@ func applyProviderRoutingFlags(cfg *Config, fs *flag.FlagSet, values providerFla
 func applyProviderFlags(cfg *Config, fs *flag.FlagSet, values providerFlagValues) error {
 	if flagWasSet(fs, "provider") {
 		cfg.providerExplicit = true
+		cfg.providerSelectionSource = providerSelectionFlag
 	}
 	if _, err := routeProviderFlagOverride(cfg, fs, values); err != nil {
 		return err
@@ -1259,7 +1260,7 @@ func routeProviderFlagOverride(cfg *Config, fs *flag.FlagSet, values providerFla
 		if !ok {
 			continue
 		}
-		cfg.Provider = candidate.Name()
+		setProviderSelection(cfg, candidate.Name(), providerSelectionFlag)
 		if err := router.RouteConfig(cfg, fs, values[candidate.Name()]); err != nil {
 			return true, err
 		}

--- a/internal/cli/providers_builtin_test.go
+++ b/internal/cli/providers_builtin_test.go
@@ -400,6 +400,12 @@ func (testHetznerProvider) ApplyFlags(*Config, *flag.FlagSet, any) error {
 func (p testHetznerProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
 	return testSSHBackend{spec: p.Spec()}, nil
 }
+func (p testHetznerProvider) ConfigureDoctor(Config, Runtime) (DoctorBackend, error) {
+	if _, err := newHetznerClient(); err != nil {
+		return nil, err
+	}
+	return testDoctorDelegatedBackend{testDelegatedBackend{spec: p.Spec()}}, nil
+}
 
 type testDigitalOceanProvider struct{}
 

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -312,7 +312,7 @@ func autoRouteStaticLease(cfg *Config, fs *flag.FlagSet, id string) error {
 		return nil
 	}
 	if !flagWasSet(fs, "provider") {
-		cfg.Provider = staticProvider
+		setProviderSelection(cfg, staticProvider, providerSelectionLeaseContext)
 	}
 	if !isStaticProvider(cfg.Provider) {
 		return nil
@@ -383,7 +383,7 @@ func autoRouteExternalLeaseWithHints(cfg *Config, id string, routingExplicit, ta
 	}
 	if routingExplicit {
 		if !cfg.providerExplicit {
-			cfg.Provider = "external"
+			setProviderSelection(cfg, "external", providerSelectionFlag)
 		}
 		return restoreExternalLeaseTarget(cfg, targetExplicit, windowsModeExplicit)
 	}
@@ -413,7 +413,7 @@ func autoRouteExternalLeaseWithHints(cfg *Config, id string, routingExplicit, ta
 		return err
 	}
 	if !cfg.providerExplicit {
-		cfg.Provider = "external"
+		setProviderSelection(cfg, "external", providerSelectionLeaseContext)
 	}
 	if err := loadExternalRoutingConfig(cfg, path, true); err != nil {
 		return err


### PR DESCRIPTION
## Summary

- Track the provenance of the resolved provider across flags, environment, config files, and compiled defaults.
- Let bare `crabbox doctor` skip provider credential readiness only when the provider comes solely from the compiled default.
- Keep provider readiness strict for explicit flag, environment, and config selections, and expose the selection source in `crabbox config show`.
- Document the resolved-config behavior and cover it with focused regression tests.

## Verification

- Focused `internal/cli` race tests for provider-selection provenance, strictness, compiled defaults, config output, and recorded run context.
- `go vet ./...`
- Trimmed CLI build and `scripts/check-docs.sh`
- Source-blind binary checks with an explicitly missing config path: bare doctor exits 0 with compiled-default readiness skipped; explicit Hetzner selection by flag or environment exits 1 for missing credentials.

Fixes https://github.com/openclaw/crabbox/issues/1247
