### PR TITLE
fix: terminalize definitive AWS launch rejections

### DIFF
--- a/internal/cli/aws.go
+++ b/internal/cli/aws.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/servicequotas"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/aws/smithy-go"
 )
 
 const (
@@ -71,6 +72,7 @@ type AWSFixedCreateControl struct {
 	KeyPairID         string
 	PinnedAttempt     *AWSLaunchAttempt
 	FailedTokens      map[string]bool
+	TerminalRejection bool
 	BeforeAttempt     func(AWSLaunchAttempt) error
 	DefiniteFailure   func(AWSLaunchAttempt) error
 }
@@ -512,11 +514,7 @@ func shouldRetryAWSRegionAfterCreateError(err error, control *AWSFixedCreateCont
 	return (control == nil || control.PinnedAttempt == nil) && isRetryableAWSRegionProvisioningError(err)
 }
 
-func (c *AWSClient) createServerWithFallbackInRegion(ctx context.Context, cfg Config, publicKey, leaseID, slug string, keep bool, logf func(string, ...any), controls ...*AWSFixedCreateControl) (result Server, resolved Config, resultErr error) {
-	var control *AWSFixedCreateControl
-	if len(controls) > 0 {
-		control = controls[0]
-	}
+func (c *AWSClient) createServerWithFallbackInRegion(ctx context.Context, cfg Config, publicKey, leaseID, slug string, keep bool, logf func(string, ...any), control *AWSFixedCreateControl) (result Server, resolved Config, resultErr error) {
 	if cfg.ProviderKey == "" {
 		cfg.ProviderKey = "crabbox-steipete"
 	}
@@ -528,13 +526,29 @@ func (c *AWSClient) createServerWithFallbackInRegion(ctx context.Context, cfg Co
 		control.KeyPairID = keyBinding.ID
 	}
 	defer func() {
-		if resultErr == nil || !keyBinding.Created || (control != nil && control.PinnedAttempt != nil) {
+		if resultErr == nil {
 			return
 		}
-		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Minute)
-		defer cancel()
-		if err := c.DeleteCleanupSSHKeyID(cleanupCtx, keyBinding.ID); err != nil {
-			resultErr = errors.Join(resultErr, fmt.Errorf("rollback AWS key pair %s: %w", keyBinding.ID, err))
+		terminal := control != nil && control.TerminalRejection && control.PinnedAttempt != nil
+		cleanupKey := (keyBinding.Created && (control == nil || control.PinnedAttempt == nil)) ||
+			(terminal && keyBinding.Managed)
+		if cleanupKey {
+			cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Minute)
+			defer cancel()
+			if err := c.DeleteCleanupSSHKeyID(cleanupCtx, keyBinding.ID); err != nil {
+				if code := awsAPIErrorCode(err); code != "" {
+					err = fmt.Errorf("AWS DeleteKeyPair rejected request (%s)", code)
+				}
+				resultErr = errors.Join(resultErr, fmt.Errorf("rollback AWS key pair %s: %w", keyBinding.ID, err))
+				return
+			}
+		}
+		if terminal && control.DefiniteFailure != nil {
+			if err := control.DefiniteFailure(*control.PinnedAttempt); err != nil {
+				resultErr = errors.Join(resultErr, err)
+				return
+			}
+			control.PinnedAttempt = nil
 		}
 	}()
 	bindCleanupKey := func(server Server) Server {
@@ -542,9 +556,6 @@ func (c *AWSClient) createServerWithFallbackInRegion(ctx context.Context, cfg Co
 			server.Labels["aws_key_pair_id"] = keyBinding.ID
 		}
 		return server
-	}
-	if control != nil && control.PinnedAttempt != nil {
-		return Server{}, cfg, exit(4, "lease_id_conflict: fixed AWS lease %s has an unresolved launch attempt", leaseID)
 	}
 	staticImageID := ""
 	if cfg.TargetOS != targetMacOS || cfg.AWSAMI != "" {
@@ -562,28 +573,28 @@ func (c *AWSClient) createServerWithFallbackInRegion(ctx context.Context, cfg Co
 	useSpot := cfg.Capacity.Market != "on-demand"
 	var marketFallbackCandidates []string
 	var errs []error
-	for i, instanceType := range candidates {
+	tryCreate := func(instanceType string, spot bool, prefix string) (Server, Config, error) {
 		next := cfg
 		next.ServerType = instanceType
+		imageID, err := c.resolveLaunchAMI(ctx, next, staticImageID)
+		if err != nil {
+			return Server{}, next, fmt.Errorf("%s%s image: %w", prefix, instanceType, err)
+		}
+		server, err := c.createServer(ctx, next, publicKey, leaseID, slug, keep, imageID, securityGroupID, spot, control)
+		if err != nil {
+			return Server{}, next, fmt.Errorf("%s%s: %w", prefix, instanceType, err)
+		}
+		return bindCleanupKey(server), next, nil
+	}
+	for i, instanceType := range candidates {
 		if i > 0 && logf != nil {
 			logf("fallback provisioning type=%s after capacity/quota rejection\n", instanceType)
 		}
-		imageID, err := c.resolveLaunchAMI(ctx, next, staticImageID)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("%s image: %w", instanceType, err))
-			if !isRetryableAWSProvisioningError(err) {
-				return Server{}, next, joinErrors(errs)
-			}
-			if useSpot {
-				marketFallbackCandidates = appendAWSMarketFallbackCandidate(marketFallbackCandidates, instanceType, err)
-			}
-			continue
-		}
-		server, err := c.createServer(ctx, next, publicKey, leaseID, slug, keep, imageID, securityGroupID, useSpot, control)
+		server, next, err := tryCreate(instanceType, useSpot, "")
 		if err == nil {
-			return bindCleanupKey(server), next, nil
+			return server, next, nil
 		}
-		errs = append(errs, fmt.Errorf("%s: %w", instanceType, err))
+		errs = append(errs, err)
 		if !isRetryableAWSProvisioningError(err) {
 			return Server{}, next, joinErrors(errs)
 		}
@@ -593,24 +604,14 @@ func (c *AWSClient) createServerWithFallbackInRegion(ctx context.Context, cfg Co
 	}
 	if len(marketFallbackCandidates) > 0 && strings.HasPrefix(cfg.Capacity.Fallback, "on-demand") {
 		for _, instanceType := range marketFallbackCandidates {
-			next := cfg
-			next.ServerType = instanceType
 			if logf != nil {
 				logf("fallback provisioning type=%s market=on-demand after spot rejection\n", instanceType)
 			}
-			imageID, err := c.resolveLaunchAMI(ctx, next, staticImageID)
-			if err != nil {
-				errs = append(errs, fmt.Errorf("on-demand %s image: %w", instanceType, err))
-				if !isRetryableAWSProvisioningError(err) {
-					return Server{}, next, joinErrors(errs)
-				}
-				continue
-			}
-			server, err := c.createServer(ctx, next, publicKey, leaseID, slug, keep, imageID, securityGroupID, false, control)
+			server, next, err := tryCreate(instanceType, false, "on-demand ")
 			if err == nil {
-				return bindCleanupKey(server), next, nil
+				return server, next, nil
 			}
-			errs = append(errs, fmt.Errorf("on-demand %s: %w", instanceType, err))
+			errs = append(errs, err)
 			if !isRetryableAWSProvisioningError(err) {
 				return Server{}, next, joinErrors(errs)
 			}
@@ -724,7 +725,6 @@ func (c *AWSClient) createServer(ctx context.Context, cfg Config, publicKey, lea
 		ImageID:         imageID,
 		SecurityGroupID: securityGroupID,
 		HostID:          cfg.HostID,
-		KeyPairID:       controlKeyPairID(control),
 		ClientToken:     clientToken,
 	}
 	if input.Placement != nil {
@@ -734,6 +734,7 @@ func (c *AWSClient) createServer(ctx context.Context, cfg Config, publicKey, lea
 		}
 	}
 	if control != nil {
+		attempt.KeyPairID = control.KeyPairID
 		for key, value := range AWSFixedAttemptAttestationLabels(attempt) {
 			labels[key] = value
 		}
@@ -766,6 +767,14 @@ func (c *AWSClient) createServer(ctx context.Context, cfg Config, publicKey, lea
 	}
 	out, err := c.ec2.RunInstances(ctx, input)
 	if err != nil {
+		code := awsAPIErrorCode(err)
+		switch code {
+		case "AuthFailure", "Blocked", "InvalidClientTokenId", "OptInRequired", "PendingVerification", "UnauthorizedOperation":
+			if control != nil {
+				control.TerminalRejection = true
+			}
+			err = fmt.Errorf("AWS RunInstances rejected request (%s)", code)
+		}
 		if control != nil && isRetryableAWSProvisioningError(err) && control.DefiniteFailure != nil {
 			if persistErr := control.DefiniteFailure(attempt); persistErr != nil {
 				return Server{}, errors.Join(err, persistErr)
@@ -780,11 +789,12 @@ func (c *AWSClient) createServer(ctx context.Context, cfg Config, publicKey, lea
 	return awsInstanceToServer(out.Instances[0]), nil
 }
 
-func controlKeyPairID(control *AWSFixedCreateControl) string {
-	if control == nil {
-		return ""
+func awsAPIErrorCode(err error) string {
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.ErrorCode()
 	}
-	return control.KeyPairID
+	return ""
 }
 
 func awsFixedAttemptClientToken(leaseID string, cfg Config, imageID, securityGroupID string, spot bool) string {

--- a/internal/cli/aws_test.go
+++ b/internal/cli/aws_test.go
@@ -211,6 +211,119 @@ func TestAWSFixedPinnedAttemptNeverResubmitsRunInstances(t *testing.T) {
 	}
 }
 
+func TestAWSFixedTerminalRunInstancesRejectionCleansKeyBeforeClearingAttempt(t *testing.T) {
+	publicKey := testOpenSSHPublicKey("ssh-ed25519", testBytes(32, 11))
+	const keyPairID = "key-terminal-rejection"
+	var actions []string
+	deleteDenied := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		params, err := url.ParseQuery(string(body))
+		if err != nil {
+			t.Fatal(err)
+		}
+		action := params.Get("Action")
+		actions = append(actions, action)
+		switch action {
+		case "DescribeKeyPairs":
+			writeEC2Error(w, "InvalidKeyPair.NotFound", "missing", http.StatusBadRequest)
+		case "ImportKeyPair":
+			writeEC2XML(w, `<ImportKeyPairResponse><keyName>crabbox-test</keyName><keyPairId>`+keyPairID+`</keyPairId></ImportKeyPairResponse>`)
+		case "DescribeSecurityGroups":
+			writeEC2XML(w, `<DescribeSecurityGroupsResponse><securityGroupInfo><item><groupId>sg-fixed</groupId></item></securityGroupInfo></DescribeSecurityGroupsResponse>`)
+		case "AuthorizeSecurityGroupIngress":
+			writeEC2XML(w, `<AuthorizeSecurityGroupIngressResponse />`)
+		case "RunInstances":
+			writeEC2Error(w, "Blocked", "encoded authorization detail must not escape", http.StatusBadRequest)
+		case "DeleteKeyPair":
+			if got := params.Get("KeyPairId"); got != keyPairID {
+				t.Fatalf("KeyPairId=%q, want %q", got, keyPairID)
+			}
+			if deleteDenied {
+				writeEC2Error(w, "UnauthorizedOperation", "encoded cleanup authorization detail must not escape", http.StatusForbidden)
+				return
+			}
+			writeEC2XML(w, `<DeleteKeyPairResponse><return>true</return></DeleteKeyPairResponse>`)
+		default:
+			writeEC2Error(w, "Unexpected", action, http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	persisted := false
+	cleared := false
+	newControl := func() *AWSFixedCreateControl {
+		control := &AWSFixedCreateControl{
+			CreatedAt: time.Now().UTC(), IntentFingerprint: strings.Repeat("b", 64),
+			AccountID: "123456789012", FailedTokens: map[string]bool{},
+		}
+		control.BeforeAttempt = func(AWSLaunchAttempt) error {
+			persisted = true
+			return nil
+		}
+		control.DefiniteFailure = func(AWSLaunchAttempt) error {
+			if got := actions[len(actions)-1]; got != "DeleteKeyPair" {
+				t.Fatalf("attempt cleared before support-resource cleanup: last action=%s", got)
+			}
+			cleared = true
+			return nil
+		}
+		return control
+	}
+	control := newControl()
+	cfg := baseConfig()
+	cfg.Provider = "aws"
+	cfg.ProviderKey = "crabbox-test"
+	cfg.AWSAMI = "ami-fixed"
+	cfg.AWSSGID = "sg-fixed"
+	cfg.ServerType = "t3.medium"
+	cfg.ServerTypeExplicit = true
+	cfg.Capacity.Market = "on-demand"
+	cfg.SSHPort = "22"
+	cfg.SSHFallbackPorts = nil
+
+	_, _, err := testAWSClient(server.URL).createServerWithFallbackInRegion(
+		context.Background(), cfg, publicKey, "cbx_abcdef123456", "fixed", true, nil, control,
+	)
+	if err == nil || !strings.Contains(err.Error(), "AWS RunInstances rejected request (Blocked)") {
+		t.Fatalf("err=%v, want sanitized terminal rejection", err)
+	}
+	if strings.Contains(err.Error(), "encoded authorization detail") {
+		t.Fatalf("terminal rejection leaked provider detail: %v", err)
+	}
+	if !persisted || !cleared || control.PinnedAttempt != nil {
+		t.Fatalf("persisted=%t cleared=%t pinned=%#v", persisted, cleared, control.PinnedAttempt)
+	}
+	wantActions := []string{"DescribeKeyPairs", "ImportKeyPair", "DescribeSecurityGroups", "AuthorizeSecurityGroupIngress", "RunInstances", "DeleteKeyPair"}
+	if !slices.Equal(actions, wantActions) {
+		t.Fatalf("actions=%v, want %v", actions, wantActions)
+	}
+
+	actions = nil
+	persisted = false
+	cleared = false
+	deleteDenied = true
+	control = newControl()
+	_, _, err = testAWSClient(server.URL).createServerWithFallbackInRegion(
+		context.Background(), cfg, publicKey, "cbx_abcdef123457", "fixed", true, nil, control,
+	)
+	if err == nil || !strings.Contains(err.Error(), "AWS DeleteKeyPair rejected request (UnauthorizedOperation)") {
+		t.Fatalf("cleanup err=%v, want sanitized DeleteKeyPair rejection", err)
+	}
+	if strings.Contains(err.Error(), "encoded cleanup authorization detail") {
+		t.Fatalf("cleanup rejection leaked provider detail: %v", err)
+	}
+	if !persisted || cleared || control.PinnedAttempt == nil {
+		t.Fatalf("cleanup failure persisted=%t cleared=%t pinned=%#v", persisted, cleared, control.PinnedAttempt)
+	}
+	if !slices.Equal(actions, wantActions) {
+		t.Fatalf("cleanup failure actions=%v, want %v", actions, wantActions)
+	}
+}
+
 func TestAWSOrdinaryRunInstancesOmitsFixedAttemptTags(t *testing.T) {
 	publicKey := testOpenSSHPublicKey("ssh-ed25519", testBytes(32, 10))
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -393,7 +506,7 @@ func TestAWSCreateRollbackDeletesOnlyNewImmutableKeyID(t *testing.T) {
 	defer server.Close()
 
 	cfg := Config{Provider: "aws", ProviderKey: "crabbox-test", AWSAMI: "ami-test", AWSSGID: "sg-test"}
-	_, _, err := testAWSClient(server.URL).createServerWithFallbackInRegion(context.Background(), cfg, publicKey, "cbx_123", "rollback", false, nil)
+	_, _, err := testAWSClient(server.URL).createServerWithFallbackInRegion(context.Background(), cfg, publicKey, "cbx_123", "rollback", false, nil, nil)
 	if err == nil {
 		t.Fatal("expected create failure")
 	}
@@ -430,7 +543,7 @@ func TestAWSCreateRollbackPreservesMatchingUnmanagedKey(t *testing.T) {
 	defer server.Close()
 
 	cfg := Config{Provider: "aws", ProviderKey: "crabbox-test", AWSAMI: "ami-test", AWSSGID: "sg-test"}
-	_, _, err := testAWSClient(server.URL).createServerWithFallbackInRegion(context.Background(), cfg, publicKey, "cbx_123", "rollback", false, nil)
+	_, _, err := testAWSClient(server.URL).createServerWithFallbackInRegion(context.Background(), cfg, publicKey, "cbx_123", "rollback", false, nil, nil)
 	if err == nil {
 		t.Fatal("expected create failure")
 	}
@@ -1077,7 +1190,7 @@ func TestAWSMacOSFallbackResolvesAMIForEachInstanceType(t *testing.T) {
 		SSHPort: "22",
 	}
 
-	serverRecord, resolved, err := client.createServerWithFallbackInRegion(context.Background(), cfg, publicKey, "cbx_123", "mac-test", false, nil)
+	serverRecord, resolved, err := client.createServerWithFallbackInRegion(context.Background(), cfg, publicKey, "cbx_123", "mac-test", false, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/providers/aws/backend.go
+++ b/internal/providers/aws/backend.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"slices"
 	"strconv"
@@ -159,6 +160,9 @@ func (b *awsLeaseBackend) acquireFixed(ctx context.Context, req AcquireRequest) 
 		if b.Cfg.Tailscale.Enabled && b.Cfg.Tailscale.AuthKey == "" {
 			return exit(2, "direct --tailscale requires %s to contain a Tailscale auth key; brokered mode uses coordinator OAuth secrets", b.Cfg.Tailscale.AuthKeyEnv)
 		}
+		if exists && isFixedAWSClaim(*claim) && claim.FixedCreateIntent.State == fixedAWSIntentReleased {
+			return exit(4, "lease_id_conflict: fixed lease %s is terminal and cannot be replayed", leaseID)
+		}
 		cfg := b.Cfg
 		client, err := newAWSClient(ctx, cfg)
 		if err != nil {
@@ -178,7 +182,9 @@ func (b *awsLeaseBackend) acquireFixed(ctx context.Context, req AcquireRequest) 
 		cfg.AWSSSHCIDRsPinned = len(cfg.AWSSSHCIDRs) > 0
 		ensureAWSSSHCIDRs(ctx, &cfg)
 		requestedSlug := core.NormalizeLeaseSlug(req.RequestedSlug)
-		fingerprint, err := fixedAWSCreateFingerprint(cfg, accountID, requestedSlug, publicKey, req.Keep)
+		fingerprint, err := core.FixedAWSCreateIntentFingerprint(cfg, core.FixedAWSCreateIntentRequest{
+			AccountID: accountID, RequestedSlug: requestedSlug, SSHPublicKey: publicKey, Keep: req.Keep,
+		})
 		if err != nil {
 			return err
 		}
@@ -230,11 +236,7 @@ func (b *awsLeaseBackend) acquireFixed(ctx context.Context, req AcquireRequest) 
 		}
 
 		intent := claim.FixedCreateIntent
-		switch intent.State {
-		case fixedAWSIntentPrepared, fixedAWSIntentAcquired:
-		case fixedAWSIntentReleased:
-			return exit(4, "lease_id_conflict: fixed lease %s is terminal and cannot be replayed", leaseID)
-		default:
+		if intent.State != fixedAWSIntentPrepared && intent.State != fixedAWSIntentAcquired {
 			return exit(4, "lease_id_conflict: fixed lease %s has invalid create state %q", leaseID, intent.State)
 		}
 		createdAt, err := time.Parse(time.RFC3339Nano, intent.CreatedAt)
@@ -293,14 +295,22 @@ func (b *awsLeaseBackend) acquireFixed(ctx context.Context, req AcquireRequest) 
 				FailedTokens:      failed,
 			}
 			control.BeforeAttempt = func(attempt core.AWSLaunchAttempt) error {
-				encoded, err := fixedAWSAttemptMap(attempt)
+				data, err := json.Marshal(attempt)
 				if err != nil {
 					return err
 				}
-				intent.Attempt = encoded
+				intent.Attempt = map[string]string{"aws": string(data)}
 				return persist()
 			}
 			control.DefiniteFailure = func(attempt core.AWSLaunchAttempt) error {
+				if control.TerminalRejection {
+					*claim = fixedAWSTerminalClaim(*claim, time.Now().UTC())
+					if err := persist(); err != nil {
+						return err
+					}
+					core.RemoveStoredTestboxKey(leaseID)
+					return nil
+				}
 				if !failed[attempt.ClientToken] {
 					intent.FailedAttempts = append(intent.FailedAttempts, attempt.ClientToken)
 					failed[attempt.ClientToken] = true
@@ -313,6 +323,9 @@ func (b *awsLeaseBackend) acquireFixed(ctx context.Context, req AcquireRequest) 
 				fmt.Fprintf(b.RT.Stderr, format, args...)
 			}, control)
 			if err != nil {
+				if control.TerminalRejection && control.PinnedAttempt == nil {
+					return exit(4, "lease_id_conflict: fixed AWS lease %s terminated after %v", leaseID, err)
+				}
 				return err
 			}
 		}
@@ -348,7 +361,7 @@ func (b *awsLeaseBackend) acquireFixed(ctx context.Context, req AcquireRequest) 
 		claim.Slug = intent.Slug
 		claim.Provider = core.FixedAWSClaimProvider
 		claim.ProviderScope = providerScope
-		claim.Labels = cloneAWSLabels(server.Labels)
+		claim.Labels = maps.Clone(server.Labels)
 		claim.SSHHost = target.Host
 		claim.LastUsedAt = time.Now().UTC().Format(time.RFC3339)
 		if port, parseErr := strconv.Atoi(strings.TrimSpace(target.Port)); parseErr == nil {
@@ -370,15 +383,6 @@ func (b *awsLeaseBackend) acquireFixed(ctx context.Context, req AcquireRequest) 
 		}
 	}
 	return acquired, nil
-}
-
-func fixedAWSCreateFingerprint(cfg Config, accountID, requestedSlug, publicKey string, keep bool) (string, error) {
-	return core.FixedAWSCreateIntentFingerprint(cfg, core.FixedAWSCreateIntentRequest{
-		AccountID:     accountID,
-		RequestedSlug: requestedSlug,
-		SSHPublicKey:  publicKey,
-		Keep:          keep,
-	})
 }
 
 func fixedAWSLeaseMatches(servers []LeaseView, leaseID string) []Server {
@@ -450,14 +454,6 @@ func validateFixedAWSAttemptProviderMetadata(server Server, attempt core.AWSLaun
 	return nil
 }
 
-func fixedAWSAttemptMap(attempt core.AWSLaunchAttempt) (map[string]string, error) {
-	data, err := json.Marshal(attempt)
-	if err != nil {
-		return nil, err
-	}
-	return map[string]string{"aws": string(data)}, nil
-}
-
 func fixedAWSAttemptFromIntent(intent *core.FixedCreateIntent) (*core.AWSLaunchAttempt, error) {
 	if len(intent.Attempt) == 0 {
 		return nil, nil
@@ -475,14 +471,6 @@ func fixedAWSAttemptFromIntent(intent *core.FixedCreateIntent) (*core.AWSLaunchA
 		return nil, errors.New("incomplete AWS attempt payload")
 	}
 	return &attempt, nil
-}
-
-func cloneAWSLabels(labels map[string]string) map[string]string {
-	cloned := make(map[string]string, len(labels))
-	for key, value := range labels {
-		cloned[key] = value
-	}
-	return cloned
 }
 
 func (b *awsLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {

--- a/internal/providers/aws/backend_test.go
+++ b/internal/providers/aws/backend_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"maps"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -663,6 +664,56 @@ func TestAWSFixedAcquireRecoversCommitThenTimeoutAfterFreshBackend(t *testing.T)
 	}
 	if lease.Server.CloudID != "i-fixed" || fake.createCalls != 1 || resourceCount != 1 {
 		t.Fatalf("lease=%#v creates=%d resources=%d", lease, fake.createCalls, resourceCount)
+	}
+}
+
+func TestAWSFixedAcquireTerminalizesDefinitiveProviderRejection(t *testing.T) {
+	testutil.IsolateUserDirs(t)
+	fake := &fakeAWSClient{}
+	fake.controlCreate = func(control *core.AWSFixedCreateControl, cfg Config, leaseID, _ string) (Server, Config, error) {
+		fake.createCalls++
+		attempt := fixedAWSTestAttempt(cfg)
+		if err := control.BeforeAttempt(attempt); err != nil {
+			return Server{}, cfg, err
+		}
+		control.PinnedAttempt = &attempt
+		control.TerminalRejection = true
+		if err := control.DefiniteFailure(attempt); err != nil {
+			return Server{}, cfg, err
+		}
+		control.PinnedAttempt = nil
+		return Server{}, cfg, errors.New("AWS RunInstances rejected request (Blocked)")
+	}
+	restore := installFixedAWSTestClient(t, fake)
+	defer restore()
+	req := AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef123488", RequestedSlug: "terminal-rejection"}
+	backend := NewAWSLeaseBackend(ProviderSpec{}, fixedAWSTestConfig(), Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+
+	_, err := backend.Acquire(context.Background(), req)
+	var exitErr core.ExitError
+	if !core.AsExitError(err, &exitErr) || exitErr.Code != 4 || !strings.Contains(err.Error(), "lease_id_conflict") {
+		t.Fatalf("err=%v, want terminal lease conflict", err)
+	}
+	claim, exists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+	if err != nil || !exists || claim.FixedCreateIntent == nil {
+		t.Fatalf("claim=%#v exists=%t err=%v", claim, exists, err)
+	}
+	if err := validateFixedAWSTerminalClaim(claim, core.LeaseClaim{}, req.RequestedLeaseID); err != nil {
+		t.Fatalf("terminal claim: %v", err)
+	}
+	keyPath, err := core.TestboxKeyPath(req.RequestedLeaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(keyPath); !os.IsNotExist(err) {
+		t.Fatalf("stored key survived terminal no-allocation result: %v", err)
+	}
+	creates := fake.createCalls
+	if _, err := backend.Acquire(context.Background(), req); err == nil || !strings.Contains(err.Error(), "terminal") {
+		t.Fatalf("terminal replay err=%v", err)
+	}
+	if fake.createCalls != creates {
+		t.Fatalf("terminal replay called create: before=%d after=%d", creates, fake.createCalls)
 	}
 }
 


### PR DESCRIPTION
## Summary

- classify definitive EC2 `RunInstances` account/auth rejection codes through typed Smithy API errors
- sanitize provider text, delete the exact validated Crabbox key-pair ID, then persist a terminal no-allocation tombstone
- keep network, timeout, and unknown launch outcomes pinned and replay-safe
- collapse duplicated spot/on-demand launch code and remove one-use AWS helpers (production LOC: -2 net)

## Root cause

Fixed AWS launch attempts were durably pinned before `RunInstances`, correctly protecting unknown provider outcomes. The same safety behavior also trapped definitive provider rejections such as `Blocked`: no instance could have been allocated, but the claim and local key remained unresolved forever. Raw AWS error details were also returned to callers.

The fix distinguishes provider-authoritative rejection from ambiguous transport failure. It terminalizes only typed, definitive account/auth API codes. The terminal state is written only after exact immutable key cleanup succeeds; cleanup denial leaves the attempt pinned.

## Live proof

An isolated OpenClaw gateway using this branch dispatched an x86 `t3.medium` AWS cloud worker in `eu-west-1`. AWS returned account-level code `Blocked` after 23,295 ms. The caller received only the sanitized action/code, the placement became terminal/non-retryable, the claim became a released tombstone, and local key material was removed.

Authoritative before/after AWS inventory delta was exactly empty (`added=[]`, `removed=[]`); no instance, volume, image, snapshot, or Spot request was allocated.

## Verification

- `go test ./internal/cli ./internal/providers/aws -run 'TestAWS(Fixed|MacOSFallback|MarketFallback|CreateRollback)' -count=1`
- `go test -race ./internal/cli ./internal/providers/aws -run 'TestAWS(Fixed|MacOSFallback|MarketFallback|CreateRollback)' -count=1`
- `go vet ./internal/cli ./internal/providers/aws`
- `git diff --check`

Focused tests include pre-fix failure proof, terminal cleanup ordering, sanitized `RunInstances` and `DeleteKeyPair` failures, tombstone replay rejection, and preservation of the pinned attempt when cleanup fails.