### PR TITLE
fix(sync): preserve tracked artifact paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Kept Git-tracked regular files under ambiguous built-in artifact directories in sync manifests while preserving authoritative project excludes, untracked-output filtering, ordered re-includes, and bounded path-and-pattern warnings. Thanks @salmonumbrella.
 - Clarified that POSIX SSH `run --script` uploads a content-hashed standalone copy whose `$0` points under `.crabbox/scripts/`, and documented synced-path execution for scripts that need adjacent repository assets. Thanks @coygeek.
 - Classified per-run local-container cgroup OOM-kill increments as memory resource exhaustion, with bounded evidence collection and actionable memory/concurrency guidance while ignoring historical OOM counts on reused leases. Thanks @coygeek.
 - Made bare `crabbox doctor` report compiled-default provider provenance and skip that unchosen provider's credential readiness without weakening explicitly configured provider checks. Thanks @coygeek.

--- a/docs/commands/sync-plan.md
+++ b/docs/commands/sync-plan.md
@@ -28,6 +28,13 @@ matches what an actual sync would ship:
 Ordered exclude rules are applied before size accounting; a later `!pattern`
 can re-include a path matched by an earlier rule.
 
+Crabbox-owned built-ins for ambiguous artifact directory names (`dist`,
+`dist-runtime`, `coverage`, `playwright-report`, `test-results`, `.build`, and
+`target`) omit untracked output but do not silently remove Git-tracked regular
+files. Text output adds one bounded warning naming protected paths and matching
+patterns. Explicit `sync.exclude` and `.crabboxignore` rules remain
+authoritative for tracked files, including bare component-wide patterns.
+
 The same preflight rejects tracked non-gitlink paths hidden by sparse-checkout
 or `skip-worktree` state only when they remain in the effective manifest after
 `sync.include` and ordered excludes. On Git older than 2.41, an ambiguous
@@ -66,6 +73,10 @@ machine-readable shape for CI checks and agent preflights:
   "candidate": { "files": 1843, "bytes": 327680000, "humanBytes": "312.5 MiB" },
   "dirtyDelta": { "files": 12, "bytes": 524288, "humanBytes": "512.0 KiB" },
   "deletedTrackedPaths": 2,
+  "protectedTrackedFiles": {
+    "count": 1,
+    "examples": [{ "path": "internal/web/dist/stub.html", "pattern": "dist" }]
+  },
   "guardrail": {
     "scope": "dirty_delta",
     "files": 12,
@@ -83,6 +94,8 @@ machine-readable shape for CI checks and agent preflights:
 `candidate` is the full manifest that would be present on the remote after
 sync. `dirtyDelta` is the locally changed/untracked/deleted path set that
 `crabbox run` uses for large-sync guardrails when it is non-empty.
+`protectedTrackedFiles` counts tracked regular files kept despite an ambiguous
+built-in exclude and includes up to five path-and-pattern examples.
 `guardrail.scope` is therefore either `dirty_delta` or `candidate`, matching
 the sync preflight path. `guardrail.status` is `ok`, `warning`, or `failed`;
 warnings and failures are listed in `guardrail.reasons` when configured

--- a/docs/features/sync.md
+++ b/docs/features/sync.md
@@ -47,9 +47,27 @@ such as `node_modules`, `.git`, `dist`, `coverage`, `playwright-report`,
 `test-results`, `.next`, `.vite`, `.turbo`, `target`, `.venv`, `__pycache__`,
 `.gradle`, and Crabbox runtime state under `.crabbox/env`,
 `.crabbox/scripts`, `.crabbox/logs`, `.crabbox/captures`, and
-`.crabbox/runs`. Crabbox does not globally drop tracked source files just
-because a path segment happens to be named `build` or `out`. Put
-project-specific generated directories in `.crabboxignore` or `sync.exclude`.
+`.crabbox/runs`. Built-in rules for the ambiguous artifact names `dist`,
+`dist-runtime`, `coverage`, `playwright-report`, `test-results`, `.build`, and
+`target` still omit untracked output, but do not omit a Git-tracked regular file
+solely because one of those names appears in its path. Crabbox reports a bounded
+path-and-pattern summary when it protects such files. Unmistakable dependency
+and cache rules such as `node_modules`, `.cache`, `.venv`, and `__pycache__`
+remain component-wide, including for tracked files.
+
+Except for the protected Crabbox runtime state described below, rules from
+`sync.exclude` and `.crabboxignore` are authoritative, including bare
+component-wide patterns. They can deliberately exclude tracked artifact files
+or trees, and a later `!pattern` can re-include them. This keeps existing
+repository policy intact across upgrades while making Crabbox-owned ambiguous
+defaults safe. Crabbox also does not globally drop tracked source files just
+because a path segment happens to be named `build` or `out`. Put project-specific
+generated directories in `.crabboxignore` or `sync.exclude`.
+
+`crabbox watch` observes only the ancestor chains needed by tracked protected
+files or explicit re-includes, so unrelated untracked artifact trees do not
+create watch churn. It also watches Git's resolved index and attaches the parent
+chain when an index-only transition makes an artifact path tracked.
 
 ## Excludes
 
@@ -183,8 +201,11 @@ PR head; add `--apply-local-patch` to layer your local git diff on top. The
 
 Use `crabbox sync-plan` to inspect the manifest before leasing a box. It prints
 the candidate file count, total bytes, the count of deleted tracked paths, and
-the largest files and directories, using the same excludes as `run`. Use
-`--limit` to change how many top files and directories are listed (default 20).
+the largest files and directories, using the same excludes as `run`. When an
+ambiguous built-in artifact rule would otherwise hide a tracked regular file,
+the plan also prints a bounded annotation naming the protected paths and
+patterns. Use `--limit` to change how many top files and directories are listed
+(default 20).
 
 ```text
 $ crabbox sync-plan

--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -667,7 +667,7 @@ func (a App) syncLocalActionsWorkspace(ctx context.Context, cfg Config, repo Rep
 	if err != nil {
 		return err
 	}
-	manifest, err := syncManifestFiltered(repo.Root, excludes, syncIncludes(cfg))
+	manifest, err := syncManifestFilteredRules(repo.Root, excludes, syncIncludes(cfg))
 	if err != nil {
 		return exit(6, "build sync file list: %v", err)
 	}
@@ -705,7 +705,7 @@ func (a App) syncLocalActionsWorkspace(ctx context.Context, cfg Config, repo Rep
 		}
 	}
 	fmt.Fprintf(a.Stderr, "syncing %s -> %s:%s for local actions hydrate\n", repo.Root, target.Host, workdir)
-	if err := rsync(ctx, target, repo.Root, workdir, excludes, a.Stdout, a.Stderr, rsyncOptions{Checksum: cfg.Sync.Checksum, UseFilesFrom: true, FilesFrom: manifestData, NoTimes: localContainerDockerSocketConfig(cfg), Timeout: cfg.Sync.Timeout, HeartbeatInterval: 15 * time.Second}); err != nil {
+	if err := rsync(ctx, target, repo.Root, workdir, excludes.patterns(), a.Stdout, a.Stderr, rsyncOptions{Checksum: cfg.Sync.Checksum, UseFilesFrom: true, FilesFrom: manifestData, NoTimes: localContainerDockerSocketConfig(cfg), Timeout: cfg.Sync.Timeout, HeartbeatInterval: 15 * time.Second}); err != nil {
 		return exit(6, "rsync failed: %v", err)
 	}
 	fingerprint := ""

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -166,7 +166,7 @@ func configShowView(cfg Config) map[string]any {
 		"sshFallbackPorts":           cfg.SSHFallbackPorts,
 		"workRoot":                   cfg.WorkRoot,
 		"sync": map[string]any{
-			"exclude":     configuredExcludes(cfg),
+			"exclude":     configuredExcludes(cfg).patterns(),
 			"include":     syncIncludes(cfg),
 			"delete":      cfg.Sync.Delete,
 			"checksum":    cfg.Sync.Checksum,
@@ -758,7 +758,7 @@ func writeConfigShowText(w io.Writer, cfg Config) {
 	fmt.Fprintf(w, "broker=%s mode=%s auto_webvnc=%t login_redirect_origins=%s auth=%s admin_auth=%s\n", blank(redactedConfigURL(cfg.Coordinator), "-"), cfg.BrokerMode, cfg.BrokerAutoWebVNC, blank(strings.Join(cfg.BrokerLoginRedirectOrigins, ","), "-"), coordinatorTokenState(cfg), tokenState(cfg.CoordAdminToken))
 	fmt.Fprintf(w, "access_auth=%s\n", accessAuthState(cfg.Access))
 	fmt.Fprintf(w, "ssh=%s@<host>:%s fallback_ports=%s key=%s\n", cfg.SSHUser, cfg.SSHPort, blank(strings.Join(cfg.SSHFallbackPorts, ","), "-"), cfg.SSHKey)
-	fmt.Fprintf(w, "sync delete=%t checksum=%t git_seed=%t fingerprint=%t base_ref=%s excludes=%d includes=%d timeout=%s\n", cfg.Sync.Delete, cfg.Sync.Checksum, cfg.Sync.GitSeed, cfg.Sync.Fingerprint, blank(cfg.Sync.BaseRef, "-"), len(configuredExcludes(cfg)), len(syncIncludes(cfg)), cfg.Sync.Timeout)
+	fmt.Fprintf(w, "sync delete=%t checksum=%t git_seed=%t fingerprint=%t base_ref=%s excludes=%d includes=%d timeout=%s\n", cfg.Sync.Delete, cfg.Sync.Checksum, cfg.Sync.GitSeed, cfg.Sync.Fingerprint, blank(cfg.Sync.BaseRef, "-"), len(configuredExcludes(cfg).rules), len(syncIncludes(cfg)), cfg.Sync.Timeout)
 	fmt.Fprintf(w, "env allow=%s\n", strings.Join(cfg.EnvAllow, ","))
 	fmt.Fprintf(w, "run preflight_tools=%s\n", blank(strings.Join(cfg.Run.PreflightTools, ","), "-"))
 	fmt.Fprintf(w, "capacity market=%s strategy=%s fallback=%s regions=%s hints=%t\n", cfg.Capacity.Market, cfg.Capacity.Strategy, cfg.Capacity.Fallback, blank(strings.Join(cfg.Capacity.Regions, ","), "-"), cfg.Capacity.Hints)

--- a/internal/cli/delegated_archive_sync.go
+++ b/internal/cli/delegated_archive_sync.go
@@ -68,7 +68,7 @@ func RunDelegatedArchiveSync(ctx context.Context, req DelegatedArchiveSyncReques
 		return nil, 0, err
 	}
 	manifestStart := now()
-	manifest, err := syncManifestFiltered(req.Repo.Root, excludes, req.Config.Sync.Includes)
+	manifest, err := syncManifestFilteredRules(req.Repo.Root, excludes, req.Config.Sync.Includes)
 	if err != nil {
 		return nil, 0, exit(6, "build sync file list: %v", err)
 	}

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -331,18 +331,65 @@ func defaultExcludes() []string {
 	return append(excludes, protectedSyncExcludes()...)
 }
 
-func configuredExcludes(cfg Config) []string {
-	return appendOrderedStrings(defaultExcludes(), cfg.Sync.Excludes...)
+type syncExcludeOrigin uint8
+
+const (
+	syncExcludeBuiltIn syncExcludeOrigin = iota
+	syncExcludeConfigured
+	syncExcludeProtected
+)
+
+type syncExcludeRule struct {
+	pattern string
+	origin  syncExcludeOrigin
 }
 
-func syncExcludes(root string, cfg Config) ([]string, error) {
+// SyncExcludeRules keeps ordered matcher provenance internal while allowing
+// provider adapters to pass the rules back to the core manifest owner.
+type SyncExcludeRules struct {
+	rules []syncExcludeRule
+}
+
+func configuredExcludes(cfg Config) SyncExcludeRules {
+	rules := newSyncExcludeRules(defaultExcludes(), syncExcludeBuiltIn)
+	for i := range rules.rules {
+		if isProtectedSyncExclude(rules.rules[i].pattern) {
+			rules.rules[i].origin = syncExcludeProtected
+		}
+	}
+	return rules.append(cfg.Sync.Excludes, syncExcludeConfigured)
+}
+
+func syncExcludes(root string, cfg Config) (SyncExcludeRules, error) {
 	excludes := configuredExcludes(cfg)
 	ignore, err := readCrabboxIgnore(root)
 	if err != nil {
-		return nil, err
+		return SyncExcludeRules{}, err
 	}
-	excludes = appendOrderedStrings(excludes, ignore...)
-	return appendOrderedStrings(excludes, protectedSyncExcludes()...), nil
+	excludes = excludes.append(ignore, syncExcludeConfigured)
+	return excludes.append(protectedSyncExcludes(), syncExcludeProtected), nil
+}
+
+func newSyncExcludeRules(patterns []string, origin syncExcludeOrigin) SyncExcludeRules {
+	return (SyncExcludeRules{}).append(patterns, origin)
+}
+
+func (r SyncExcludeRules) append(patterns []string, origin syncExcludeOrigin) SyncExcludeRules {
+	out := SyncExcludeRules{rules: append([]syncExcludeRule(nil), r.rules...)}
+	for _, pattern := range patterns {
+		if pattern = strings.TrimSpace(pattern); pattern != "" {
+			out.rules = append(out.rules, syncExcludeRule{pattern: pattern, origin: origin})
+		}
+	}
+	return out
+}
+
+func (r SyncExcludeRules) patterns() []string {
+	out := make([]string, 0, len(r.rules))
+	for _, rule := range r.rules {
+		out = append(out, rule.pattern)
+	}
+	return out
 }
 
 func protectedSyncExcludes() []string {
@@ -352,6 +399,30 @@ func protectedSyncExcludes() []string {
 		".crabbox/logs",
 		".crabbox/captures",
 		".crabbox/runs",
+	}
+}
+
+func isProtectedSyncExclude(pattern string) bool {
+	pattern = strings.ToLower(strings.Trim(filepath.ToSlash(pattern), "/"))
+	for _, protected := range protectedSyncExcludes() {
+		if pattern == protected {
+			return true
+		}
+	}
+	return false
+}
+
+func isAmbiguousBuiltInExclude(pattern string) bool {
+	pattern, negated := excludeRule(pattern)
+	if negated {
+		return false
+	}
+	pattern = strings.Trim(filepath.ToSlash(pattern), "/")
+	switch pattern {
+	case "dist", "dist-runtime", "coverage", "playwright-report", "test-results", ".build", "apps/*/.build", "target":
+		return true
+	default:
+		return false
 	}
 }
 
@@ -500,7 +571,7 @@ func warnCredentialBearingGitSeed(w io.Writer) {
 	fmt.Fprintln(w, "warning: git seed disabled because origin URL contains embedded credentials; continuing with file sync without forwarding the remote URL")
 }
 
-func SyncExcludes(root string, cfg Config) ([]string, error) {
+func SyncExcludes(root string, cfg Config) (SyncExcludeRules, error) {
 	return syncExcludes(root, cfg)
 }
 
@@ -618,17 +689,17 @@ func defaultBaseRef(root string) string {
 	return ""
 }
 
-func syncFingerprintForManifest(repo Repo, cfg Config, manifest SyncManifest, excludes []string, plan gitCoherencePlan) (string, error) {
+func syncFingerprintForManifest(repo Repo, cfg Config, manifest SyncManifest, excludes SyncExcludeRules, plan gitCoherencePlan) (string, error) {
 	if !plan.enabled() {
 		return "", nil
 	}
 	h := sha256.New()
-	fmt.Fprintf(h, "v4\nremote=%s\nbranch=%s\nhead=%s\ntree=%s\n", plan.RemoteURL, plan.Branch, plan.Target, plan.Tree)
+	fmt.Fprintf(h, "v5\nremote=%s\nbranch=%s\nhead=%s\ntree=%s\n", plan.RemoteURL, plan.Branch, plan.Target, plan.Tree)
 	fmt.Fprintf(h, "delete=%t\nchecksum=%t\n", cfg.Sync.Delete, cfg.Sync.Checksum)
 	fmt.Fprintf(h, "manifest=%x\n", sha256.Sum256(manifest.NUL()))
 	fmt.Fprintf(h, "deleted=%x\n", sha256.Sum256(manifest.DeletedNUL()))
-	for _, exclude := range excludes {
-		fmt.Fprintf(h, "exclude=%s\n", exclude)
+	for _, exclude := range excludes.rules {
+		fmt.Fprintf(h, "exclude=%d:%s\n", exclude.origin, exclude.pattern)
 	}
 	for _, rel := range manifest.Changed {
 		fmt.Fprintf(h, "path=%s\n", rel)
@@ -657,11 +728,17 @@ func syncFingerprintForManifest(repo Repo, cfg Config, manifest SyncManifest, ex
 }
 
 type SyncManifest struct {
-	Files        []string
-	Deleted      []string
-	Changed      []string
-	Bytes        int64
-	ChangedBytes int64
+	Files                    []string
+	Deleted                  []string
+	Changed                  []string
+	ProtectedTrackedExcludes []SyncProtectedTrackedExclude
+	Bytes                    int64
+	ChangedBytes             int64
+}
+
+type SyncProtectedTrackedExclude struct {
+	Path    string `json:"path"`
+	Pattern string `json:"pattern"`
 }
 
 // gitManifestError turns a raw git ls-files failure into an actionable,
@@ -696,8 +773,8 @@ func gitSyncFileList(root string) ([]byte, error) {
 	return out, nil
 }
 
-func syncManifest(root string, excludes []string) (SyncManifest, error) {
-	return syncManifestFiltered(root, excludes, nil)
+func syncManifest(root string, excludes SyncExcludeRules) (SyncManifest, error) {
+	return syncManifestFilteredRules(root, excludes, nil)
 }
 
 // syncManifestFiltered builds the sync manifest applying excludes and, when
@@ -705,6 +782,10 @@ func syncManifest(root string, excludes []string) (SyncManifest, error) {
 // synced. This lets a job sync a few selected paths instead of the whole working
 // tree (e.g. sync just `src/` and `scripts/` out of a large repo).
 func syncManifestFiltered(root string, excludes, includes []string) (SyncManifest, error) {
+	return syncManifestFilteredRules(root, newSyncExcludeRules(excludes, syncExcludeConfigured), includes)
+}
+
+func syncManifestFilteredRules(root string, excludes SyncExcludeRules, includes []string) (SyncManifest, error) {
 	out, err := gitSyncFileList(root)
 	if err != nil {
 		return SyncManifest{}, err
@@ -713,10 +794,11 @@ func syncManifestFiltered(root string, excludes, includes []string) (SyncManifes
 	if err != nil {
 		return SyncManifest{}, fmt.Errorf("verify sync manifest scope: %w", err)
 	}
+	trackedRegular := trackedRegularPathSet(tracked)
 	inManifestScope := func(entry gitTrackedPath) bool {
 		rel := filepath.ToSlash(entry.name)
 		return safeRepoRel(rel) &&
-			!pathExcluded(rel, excludes) &&
+			!pathExcludedByRules(rel, excludes, gitModeIsRegular(entry.mode)) &&
 			pathIncluded(rel, includes)
 	}
 	gitlinkPaths, err := trackedGitlinkPaths(tracked, inManifestScope)
@@ -736,7 +818,9 @@ func syncManifestFiltered(root string, excludes, includes []string) (SyncManifes
 	manifest := SyncManifest{}
 	for _, rel := range splitNul(out) {
 		rel = filepath.ToSlash(rel)
-		if _, isGitlink := gitlinkPaths[rel]; isGitlink || !safeRepoRel(rel) || pathExcluded(rel, excludes) || !pathIncluded(rel, includes) || seen[rel] {
+		_, isTrackedRegular := trackedRegular[rel]
+		excluded, protectedPattern := pathExcludeDecision(rel, excludes, isTrackedRegular)
+		if _, isGitlink := gitlinkPaths[rel]; isGitlink || !safeRepoRel(rel) || excluded || !pathIncluded(rel, includes) || seen[rel] {
 			continue
 		}
 		full := filepath.Join(root, filepath.FromSlash(rel))
@@ -747,9 +831,18 @@ func syncManifestFiltered(root string, excludes, includes []string) (SyncManifes
 		seen[rel] = true
 		manifest.Files = append(manifest.Files, rel)
 		manifest.Bytes += info.Size()
+		if protectedPattern != "" {
+			manifest.ProtectedTrackedExcludes = append(manifest.ProtectedTrackedExcludes, SyncProtectedTrackedExclude{
+				Path:    rel,
+				Pattern: protectedPattern,
+			})
+		}
 	}
 	sort.Strings(manifest.Files)
-	deleted, deletedGitlinks, err := syncDeletedPaths(root, excludes, includes)
+	sort.Slice(manifest.ProtectedTrackedExcludes, func(i, j int) bool {
+		return manifest.ProtectedTrackedExcludes[i].Path < manifest.ProtectedTrackedExcludes[j].Path
+	})
+	deleted, deletedGitlinks, deletedRegular, err := syncDeletedPaths(root, excludes, includes, trackedRegular)
 	if err != nil {
 		return SyncManifest{}, err
 	}
@@ -757,12 +850,29 @@ func syncManifestFiltered(root string, excludes, includes []string) (SyncManifes
 		gitlinkPaths[rel] = struct{}{}
 	}
 	manifest.Deleted = filterDeletedPaths(deleted, seen, gitlinkPaths)
-	changed, err := changedSyncPaths(root, excludes, includes)
+	for rel := range deletedRegular {
+		trackedRegular[rel] = struct{}{}
+	}
+	changed, err := changedSyncPaths(root, excludes, includes, trackedRegular)
 	if err != nil {
 		return SyncManifest{}, err
 	}
 	manifest.Changed, manifest.ChangedBytes = changedPathSetBytes(root, changed)
 	return manifest, nil
+}
+
+func trackedRegularPathSet(tracked []gitTrackedPath) map[string]struct{} {
+	paths := make(map[string]struct{})
+	for _, entry := range tracked {
+		if gitModeIsRegular(entry.mode) {
+			paths[filepath.ToSlash(entry.name)] = struct{}{}
+		}
+	}
+	return paths
+}
+
+func gitModeIsRegular(mode string) bool {
+	return mode == "100644" || mode == "100755"
 }
 
 func trackedGitlinkPaths(tracked []gitTrackedPath, inScope func(gitTrackedPath) bool) (map[string]struct{}, error) {
@@ -799,8 +909,8 @@ func trackedGitlinkPaths(tracked []gitTrackedPath, inScope func(gitTrackedPath) 
 	return paths, nil
 }
 
-func BuildSyncManifestFiltered(root string, excludes, includes []string) (SyncManifest, error) {
-	return syncManifestFiltered(root, excludes, includes)
+func BuildSyncManifestFiltered(root string, excludes SyncExcludeRules, includes []string) (SyncManifest, error) {
+	return syncManifestFilteredRules(root, excludes, includes)
 }
 
 func (m SyncManifest) NUL() []byte {
@@ -826,44 +936,46 @@ type gitCachedDeletion struct {
 	preimageMode string
 }
 
-func syncDeletedPaths(root string, excludes, includes []string) ([]string, map[string]struct{}, error) {
+func syncDeletedPaths(root string, excludes SyncExcludeRules, includes []string, trackedRegular map[string]struct{}) ([]string, map[string]struct{}, map[string]struct{}, error) {
 	cmd := exec.Command("git", "ls-files", "--deleted", "-z")
 	cmd.Dir = root
 	cmd.Env = repositoryGitEnvironment()
 	worktreeOut, err := cmd.Output()
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
-	cmd = exec.Command("git", "diff", "--cached", "--raw", "--format=", "-z", "--diff-filter=D", "--no-renames")
-	cmd.Dir = root
-	cmd.Env = repositoryGitEnvironment()
-	cachedOut, err := cmd.Output()
+	cached, err := loadGitCachedDeletions(root)
 	if err != nil {
-		return nil, nil, err
-	}
-	cached, err := parseGitCachedDeletions(cachedOut)
-	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	seen := map[string]bool{}
 	gitlinks := map[string]struct{}{}
-	inScope := func(rel string) bool {
-		return safeRepoRel(rel) && !pathExcluded(rel, excludes) && pathIncluded(rel, includes)
+	regular := map[string]struct{}{}
+	inScope := func(rel string, isRegular bool) bool {
+		return safeRepoRel(rel) && !pathExcludedByRules(rel, excludes, isRegular) && pathIncluded(rel, includes)
 	}
 	for _, rel := range splitNul(worktreeOut) {
 		rel = filepath.ToSlash(rel)
-		if inScope(rel) {
+		_, isRegular := trackedRegular[rel]
+		if inScope(rel, isRegular) {
 			seen[rel] = true
+			if isRegular {
+				regular[rel] = struct{}{}
+			}
 		}
 	}
 	for _, deletion := range cached {
 		rel := filepath.ToSlash(deletion.name)
-		if !inScope(rel) {
+		isRegular := gitModeIsRegular(deletion.preimageMode)
+		if !inScope(rel, isRegular) {
 			continue
 		}
 		seen[rel] = true
 		if deletion.preimageMode == "160000" {
 			gitlinks[rel] = struct{}{}
+		}
+		if isRegular {
+			regular[rel] = struct{}{}
 		}
 	}
 	out := make([]string, 0, len(seen))
@@ -871,7 +983,32 @@ func syncDeletedPaths(root string, excludes, includes []string) ([]string, map[s
 		out = append(out, rel)
 	}
 	sort.Strings(out)
-	return out, gitlinks, nil
+	return out, gitlinks, regular, nil
+}
+
+func loadGitCachedDeletions(root string) ([]gitCachedDeletion, error) {
+	cmd := exec.Command("git", "diff", "--cached", "--raw", "--format=", "-z", "--diff-filter=D", "--no-renames")
+	cmd.Dir = root
+	cmd.Env = repositoryGitEnvironment()
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	return parseGitCachedDeletions(out)
+}
+
+func trackedRegularPathSetWithCachedDeletions(root string, tracked []gitTrackedPath) (map[string]struct{}, error) {
+	paths := trackedRegularPathSet(tracked)
+	deletions, err := loadGitCachedDeletions(root)
+	if err != nil {
+		return nil, err
+	}
+	for _, deletion := range deletions {
+		if gitModeIsRegular(deletion.preimageMode) {
+			paths[filepath.ToSlash(deletion.name)] = struct{}{}
+		}
+	}
+	return paths, nil
 }
 
 func parseGitCachedDeletions(raw []byte) ([]gitCachedDeletion, error) {
@@ -947,6 +1084,7 @@ func safeRepoRel(rel string) bool {
 func checkSyncPreflight(manifest SyncManifest, cfg Config, force bool, stderr io.Writer) error {
 	fileCount := len(manifest.Files)
 	guard := evaluateSyncGuardrail(manifest, cfg, force)
+	printProtectedTrackedExcludes(stderr, manifest)
 	if len(manifest.Changed) > 0 {
 		fmt.Fprintf(stderr, "sync candidate: %d files, %s dirty_delta=%d files, %s\n", fileCount, humanBytes(manifest.Bytes), len(manifest.Changed), humanBytes(manifest.ChangedBytes))
 	} else {
@@ -978,6 +1116,25 @@ func checkSyncPreflight(manifest SyncManifest, cfg Config, force bool, stderr io
 		printSyncTopDirs(stderr, guard.Paths)
 	}
 	return nil
+}
+
+func printProtectedTrackedExcludes(w io.Writer, manifest SyncManifest) {
+	if w == nil || len(manifest.ProtectedTrackedExcludes) == 0 {
+		return
+	}
+	limit := len(manifest.ProtectedTrackedExcludes)
+	if limit > protectedTrackedExcludeExampleLimit {
+		limit = protectedTrackedExcludeExampleLimit
+	}
+	items := make([]string, 0, limit)
+	for _, protected := range manifest.ProtectedTrackedExcludes[:limit] {
+		items = append(items, fmt.Sprintf("%s (%s)", protected.Path, protected.Pattern))
+	}
+	more := ""
+	if remaining := len(manifest.ProtectedTrackedExcludes) - limit; remaining > 0 {
+		more = fmt.Sprintf(" (+%d more)", remaining)
+	}
+	fmt.Fprintf(w, "warning: protected %d tracked files from built-in artifact excludes: %s%s\n", len(manifest.ProtectedTrackedExcludes), strings.Join(items, ", "), more)
 }
 
 type syncGuardrailEvaluation struct {
@@ -1101,7 +1258,7 @@ func humanBytes(n int64) string {
 	return fmt.Sprintf("%.1f PiB", value/unit)
 }
 
-func changedSyncPaths(root string, excludes, includes []string) ([]string, error) {
+func changedSyncPaths(root string, excludes SyncExcludeRules, includes []string, trackedRegular map[string]struct{}) ([]string, error) {
 	sets := [][]string{}
 	for _, args := range [][]string{
 		{"diff", "--name-only", "-z"},
@@ -1121,7 +1278,8 @@ func changedSyncPaths(root string, excludes, includes []string) ([]string, error
 	for _, set := range sets {
 		for _, rel := range set {
 			rel = filepath.ToSlash(rel)
-			if rel == "" || pathExcluded(rel, excludes) || !pathIncluded(rel, includes) {
+			_, isTrackedRegular := trackedRegular[rel]
+			if rel == "" || pathExcludedByRules(rel, excludes, isTrackedRegular) || !pathIncluded(rel, includes) {
 				continue
 			}
 			seen[rel] = true
@@ -1150,15 +1308,35 @@ func splitNul(data []byte) []string {
 }
 
 func pathExcluded(rel string, excludes []string) bool {
+	rules := newSyncExcludeRules(excludes, syncExcludeConfigured)
+	excluded, _ := pathExcludeDecision(rel, rules, false)
+	return excluded
+}
+
+func pathExcludedByRules(rel string, rules SyncExcludeRules, trackedRegular bool) bool {
+	excluded, _ := pathExcludeDecision(rel, rules, trackedRegular)
+	return excluded
+}
+
+func pathExcludeDecision(rel string, rules SyncExcludeRules, trackedRegular bool) (bool, string) {
 	rel = filepath.ToSlash(rel)
 	excluded := false
-	for _, exclude := range excludes {
-		exclude, negated := excludeRule(exclude)
+	protectedPattern := ""
+	for _, rule := range rules.rules {
+		exclude, negated := excludeRule(rule.pattern)
 		if excludeMatches(rel, exclude) || protectedSyncExcludeMatches(rel, exclude) {
+			if trackedRegular && rule.origin == syncExcludeBuiltIn && !negated && isAmbiguousBuiltInExclude(rule.pattern) {
+				protectedPattern = exclude
+				continue
+			}
 			excluded = !negated
+			protectedPattern = ""
 		}
 	}
-	return excluded
+	if excluded {
+		protectedPattern = ""
+	}
+	return excluded, protectedPattern
 }
 
 func excludeRule(rule string) (pattern string, negated bool) {

--- a/internal/cli/repo_test.go
+++ b/internal/cli/repo_test.go
@@ -602,7 +602,7 @@ func TestSyncManifestIncludeWhitelist(t *testing.T) {
 	runGit(t, dir, "add", ".")
 	runGit(t, dir, "commit", "-m", "init")
 
-	manifest, err := syncManifestFiltered(dir, configuredExcludes(baseConfig()), []string{"src", "scripts", "package.json"})
+	manifest, err := syncManifestFilteredRules(dir, configuredExcludes(baseConfig()), []string{"src", "scripts", "package.json"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -734,11 +734,11 @@ func TestSyncManifestPrunesNestedDefaultExcludes(t *testing.T) {
 	runGit(t, dir, "config", "user.name", "Test")
 	writeFile(t, filepath.Join(dir, "packages", "app", "node_modules", "lib.js"), "cache")
 	writeFile(t, filepath.Join(dir, ".ignored", "churn"), "cache")
-	writeFile(t, filepath.Join(dir, "playwright-report", "index.html"), "cache")
-	writeFile(t, filepath.Join(dir, "apps", "foo", ".build", "debug.o"), "cache")
 	writeFile(t, filepath.Join(dir, "apps", "foo", "src", "main.go"), "package main\n")
 	runGit(t, dir, "add", ".")
 	runGit(t, dir, "commit", "-m", "init")
+	writeFile(t, filepath.Join(dir, "playwright-report", "index.html"), "cache")
+	writeFile(t, filepath.Join(dir, "apps", "foo", ".build", "debug.o"), "cache")
 
 	manifest, err := syncManifest(dir, configuredExcludes(baseConfig()))
 	if err != nil {
@@ -750,6 +750,204 @@ func TestSyncManifestPrunesNestedDefaultExcludes(t *testing.T) {
 	}
 	if !strings.Contains(got, "apps/foo/src/main.go") {
 		t.Fatalf("manifest missing source file: %q", got)
+	}
+}
+
+func TestSyncManifestProtectsTrackedFilesFromAmbiguousBuiltInExcludes(t *testing.T) {
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.email", "test@example.com")
+	runGit(t, dir, "config", "user.name", "Test")
+	ambiguous := []string{"dist", "dist-runtime", "coverage", "playwright-report", "test-results", ".build", "target"}
+	var tracked []string
+	for _, component := range ambiguous {
+		for _, rel := range []string{
+			component + "/root.txt",
+			"packages/app/" + component + "/nested.txt",
+		} {
+			writeFile(t, filepath.Join(dir, filepath.FromSlash(rel)), "tracked\n")
+			tracked = append(tracked, rel)
+		}
+	}
+	for _, rel := range []string{
+		"vendor/node_modules/pkg/index.js",
+		"nested/.cache/state.bin",
+		"python/.venv/lib.py",
+		"python/__pycache__/module.pyc",
+	} {
+		writeFile(t, filepath.Join(dir, filepath.FromSlash(rel)), "tracked cache\n")
+	}
+	writeFile(t, filepath.Join(dir, "src", "main.go"), "package main\n")
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-m", "init")
+	for _, component := range ambiguous {
+		writeFile(t, filepath.Join(dir, "generated", component, "output.bin"), "untracked output\n")
+	}
+
+	manifest, err := syncManifest(dir, configuredExcludes(baseConfig()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	files := strings.Join(manifest.Files, ",")
+	for _, rel := range tracked {
+		if !strings.Contains(files, rel) {
+			t.Errorf("manifest missing protected tracked path %q: %s", rel, files)
+		}
+	}
+	for _, component := range ambiguous {
+		rel := "generated/" + component + "/output.bin"
+		if strings.Contains(files, rel) {
+			t.Errorf("manifest included untracked generated path %q", rel)
+		}
+	}
+	for _, rel := range []string{"vendor/node_modules/pkg/index.js", "nested/.cache/state.bin", "python/.venv/lib.py", "python/__pycache__/module.pyc"} {
+		if strings.Contains(files, rel) {
+			t.Errorf("manifest included tracked dependency/cache path %q", rel)
+		}
+	}
+	if got, want := len(manifest.ProtectedTrackedExcludes), len(tracked); got != want {
+		t.Fatalf("protected annotations=%d want %d: %+v", got, want, manifest.ProtectedTrackedExcludes)
+	}
+}
+
+func TestSyncManifestConfiguredExcludesRemainAuthoritativeForTrackedArtifacts(t *testing.T) {
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.email", "test@example.com")
+	runGit(t, dir, "config", "user.name", "Test")
+	for _, rel := range []string{"target/drop.txt", "target/keep.txt", "coverage/drop.txt", "coverage/keep.txt", "dist/repo-excluded.txt"} {
+		writeFile(t, filepath.Join(dir, filepath.FromSlash(rel)), "tracked\n")
+	}
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-m", "init")
+	writeFile(t, filepath.Join(dir, ".crabboxignore"), "dist\n")
+
+	cfg := baseConfig()
+	cfg.Sync.Excludes = []string{"target", "!target/keep.txt", "coverage/drop.txt"}
+	rules, err := syncExcludes(dir, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := syncManifest(dir, rules)
+	if err != nil {
+		t.Fatal(err)
+	}
+	files := strings.Join(manifest.Files, ",")
+	for _, want := range []string{"target/keep.txt", "coverage/keep.txt"} {
+		if !strings.Contains(files, want) {
+			t.Errorf("manifest missing %q after ordered re-include: %s", want, files)
+		}
+	}
+	for _, excluded := range []string{"target/drop.txt", "coverage/drop.txt", "dist/repo-excluded.txt"} {
+		if strings.Contains(files, excluded) {
+			t.Errorf("manifest ignored configured exclude for %q: %s", excluded, files)
+		}
+	}
+	if got := len(manifest.ProtectedTrackedExcludes); got != 1 || manifest.ProtectedTrackedExcludes[0].Path != "coverage/keep.txt" {
+		t.Fatalf("protected annotations=%+v, want only coverage/keep.txt", manifest.ProtectedTrackedExcludes)
+	}
+}
+
+func TestSyncManifestIncludeWhitelistScopesTrackedProtection(t *testing.T) {
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.email", "test@example.com")
+	runGit(t, dir, "config", "user.name", "Test")
+	writeFile(t, filepath.Join(dir, "target", "keep.txt"), "tracked\n")
+	writeFile(t, filepath.Join(dir, "dist", "outside.txt"), "tracked\n")
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-m", "init")
+
+	manifest, err := syncManifestFilteredRules(dir, configuredExcludes(baseConfig()), []string{"target"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(manifest.Files, ","); got != "target/keep.txt" {
+		t.Fatalf("manifest files=%q", got)
+	}
+	if got := manifest.ProtectedTrackedExcludes; len(got) != 1 || got[0].Path != "target/keep.txt" || got[0].Pattern != "target" {
+		t.Fatalf("protected annotations=%+v", got)
+	}
+}
+
+func TestSyncManifestTrackedAmbiguousDeletionFollowsEffectiveRules(t *testing.T) {
+	for _, staged := range []bool{false, true} {
+		t.Run(fmt.Sprintf("staged=%t", staged), func(t *testing.T) {
+			dir := t.TempDir()
+			runGit(t, dir, "init")
+			runGit(t, dir, "config", "user.email", "test@example.com")
+			runGit(t, dir, "config", "user.name", "Test")
+			writeFile(t, filepath.Join(dir, "target", "obsolete.txt"), "tracked\n")
+			runGit(t, dir, "add", ".")
+			runGit(t, dir, "commit", "-m", "init")
+			if staged {
+				runGit(t, dir, "rm", "target/obsolete.txt")
+			} else if err := os.Remove(filepath.Join(dir, "target", "obsolete.txt")); err != nil {
+				t.Fatal(err)
+			}
+
+			manifest, err := syncManifest(dir, configuredExcludes(baseConfig()))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := strings.Join(manifest.Deleted, ","); got != "target/obsolete.txt" {
+				t.Fatalf("default deleted=%q", got)
+			}
+			if got := strings.Join(manifest.Changed, ","); got != "target/obsolete.txt" {
+				t.Fatalf("default dirty delta=%q", got)
+			}
+
+			cfg := baseConfig()
+			cfg.Sync.Excludes = []string{"target"}
+			manifest, err = syncManifest(dir, configuredExcludes(cfg))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(manifest.Deleted) != 0 || len(manifest.Changed) != 0 {
+				t.Fatalf("configured exclude should omit deletion and dirty delta: %+v", manifest)
+			}
+		})
+	}
+}
+
+func TestSyncFingerprintIncludesExcludeRuleProvenance(t *testing.T) {
+	plan := gitCoherencePlan{RemoteURL: "https://example.test/repo.git", Target: "target", Tree: "tree", Branch: "main"}
+	builtIn := newSyncExcludeRules([]string{"target"}, syncExcludeBuiltIn)
+	configured := newSyncExcludeRules([]string{"target"}, syncExcludeConfigured)
+	a, err := syncFingerprintForManifest(Repo{Root: t.TempDir()}, baseConfig(), SyncManifest{}, builtIn, plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := syncFingerprintForManifest(Repo{Root: t.TempDir()}, baseConfig(), SyncManifest{}, configured, plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a == b {
+		t.Fatalf("fingerprint did not distinguish built-in and configured provenance: %q", a)
+	}
+}
+
+func TestSyncExcludeRuleUpgradeCompatibilityPreservesRenderedOrder(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".crabboxignore"), "coverage\n!coverage/keep.txt\n")
+	cfg := baseConfig()
+	cfg.Sync.Excludes = []string{"target", "!target/keep.txt"}
+
+	rules, err := syncExcludes(dir, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := appendOrderedStrings(defaultExcludes(), cfg.Sync.Excludes...)
+	want = appendOrderedStrings(want, "coverage", "!coverage/keep.txt")
+	want = appendOrderedStrings(want, protectedSyncExcludes()...)
+	if got := strings.Join(rules.patterns(), "\n"); got != strings.Join(want, "\n") {
+		t.Fatalf("rendered rule order changed across provenance upgrade:\n%s", got)
+	}
+	if !pathExcludedByRules("target/drop.txt", rules, true) || pathExcludedByRules("target/keep.txt", rules, true) {
+		t.Fatal("ordered configured target rules lost authority")
+	}
+	if !pathExcludedByRules("coverage/drop.txt", rules, true) || pathExcludedByRules("coverage/keep.txt", rules, true) {
+		t.Fatal("ordered .crabboxignore coverage rules lost authority")
 	}
 }
 
@@ -830,16 +1028,16 @@ func TestCrabboxIgnoreExtendsSyncExcludes(t *testing.T) {
 	}
 }
 
-func TestCrabboxIgnoreCanReincludeDefaultExcludedSourcePath(t *testing.T) {
+func TestCrabboxIgnoreCanReincludeDefaultExcludedUntrackedPath(t *testing.T) {
 	dir := t.TempDir()
 	runGit(t, dir, "init")
 	runGit(t, dir, "config", "user.email", "test@example.com")
 	runGit(t, dir, "config", "user.name", "Test")
 	writeFile(t, filepath.Join(dir, ".crabboxignore"), "!apps/backend/app/connectors/target\n")
+	runGit(t, dir, "add", ".crabboxignore")
+	runGit(t, dir, "commit", "-m", "init")
 	writeFile(t, filepath.Join(dir, "apps", "backend", "app", "connectors", "target", "schemas.py"), "class Schema: ...\n")
 	writeFile(t, filepath.Join(dir, "build", "target", "debug.o"), "cache")
-	runGit(t, dir, "add", ".")
-	runGit(t, dir, "commit", "-m", "init")
 
 	excludes, err := syncExcludes(dir, baseConfig())
 	if err != nil {
@@ -901,7 +1099,7 @@ func TestCrabboxRuntimeExcludesCannotBeReincluded(t *testing.T) {
 		if strings.Contains(got, notWant) {
 			t.Fatalf("manifest %q should not include protected runtime path %q", got, notWant)
 		}
-		if !pathExcluded(notWant, excludes) {
+		if !pathExcludedByRules(notWant, excludes, true) {
 			t.Fatalf("protected runtime path %q was re-included: %v", notWant, excludes)
 		}
 	}
@@ -912,7 +1110,7 @@ func TestCrabboxRuntimeExcludesCannotBeReincluded(t *testing.T) {
 		".crabbox/CAPTURES/failure.tgz",
 		".CRABBOX/RUNS/run_123/artifact.tgz",
 	} {
-		if !pathExcluded(alias, excludes) {
+		if !pathExcludedByRules(alias, excludes, true) {
 			t.Fatalf("case alias of protected runtime path %q was re-included: %v", alias, excludes)
 		}
 	}
@@ -948,10 +1146,10 @@ func TestSyncExcludesPreservesRepeatedRuleOrder(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if pathExcluded("apps/backend/target/schema.py", excludes) {
+	if pathExcludedByRules("apps/backend/target/schema.py", excludes, true) {
 		t.Fatal("final precise negation should reinclude source target path")
 	}
-	if !pathExcluded("build/target/debug.o", excludes) {
+	if !pathExcludedByRules("build/target/debug.o", excludes, false) {
 		t.Fatal("repeated target rule should re-exclude unrelated target path")
 	}
 }
@@ -1175,7 +1373,7 @@ func TestSyncGitCoherencePlanSelectsEligibleOriginBranch(t *testing.T) {
 		if !plan.seedEnabled() || plan.enabled() {
 			t.Fatalf("plan should seed without coherence: %#v", plan)
 		}
-		fingerprint, _ := syncFingerprintForManifest(Repo{}, baseConfig(), SyncManifest{}, nil, plan)
+		fingerprint, _ := syncFingerprintForManifest(Repo{}, baseConfig(), SyncManifest{}, SyncExcludeRules{}, plan)
 		if fingerprint != "" {
 			t.Fatalf("ineligible coherence published fingerprint %q", fingerprint)
 		}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1405,7 +1405,7 @@ retrySync:
 			return recordFailure(err)
 		}
 		stepStart = time.Now()
-		manifest, err := syncManifestFiltered(repo.Root, excludes, syncIncludes(cfg))
+		manifest, err := syncManifestFilteredRules(repo.Root, excludes, syncIncludes(cfg))
 		if err != nil {
 			return recordFailure(exit(6, "build sync file list: %v", err))
 		}
@@ -1527,7 +1527,7 @@ retrySync:
 			timings.syncSteps.prune = time.Since(stepStart)
 		}
 		stepStart = time.Now()
-		if err := rsync(ctx, target, repo.Root, workdir, excludes, a.Stdout, a.Stderr, rsyncOptions{Debug: *debugSync, Delete: cfg.Sync.Delete, Checksum: cfg.Sync.Checksum, UseFilesFrom: true, FilesFrom: manifestData, NoTimes: localContainerDockerSocketSync(cfg, server), Timeout: cfg.Sync.Timeout, HeartbeatInterval: 15 * time.Second}); err != nil {
+		if err := rsync(ctx, target, repo.Root, workdir, excludes.patterns(), a.Stdout, a.Stderr, rsyncOptions{Debug: *debugSync, Delete: cfg.Sync.Delete, Checksum: cfg.Sync.Checksum, UseFilesFrom: true, FilesFrom: manifestData, NoTimes: localContainerDockerSocketSync(cfg, server), Timeout: cfg.Sync.Timeout, HeartbeatInterval: 15 * time.Second}); err != nil {
 			return recordFailure(exit(6, "rsync failed: %v", err))
 		}
 		timings.syncSteps.rsync = time.Since(stepStart)

--- a/internal/cli/sync_plan.go
+++ b/internal/cli/sync_plan.go
@@ -19,9 +19,15 @@ type syncPlanJSONOutput struct {
 	Candidate           syncPlanJSONSize      `json:"candidate"`
 	DirtyDelta          syncPlanJSONSize      `json:"dirtyDelta"`
 	DeletedTrackedPaths int                   `json:"deletedTrackedPaths"`
+	ProtectedTracked    syncPlanJSONProtected `json:"protectedTrackedFiles"`
 	Guardrail           syncPlanJSONGuardrail `json:"guardrail"`
 	TopFiles            []syncPlanJSONRow     `json:"topFiles"`
 	TopDirs             []syncPlanJSONRow     `json:"topDirs"`
+}
+
+type syncPlanJSONProtected struct {
+	Count    int                           `json:"count"`
+	Examples []SyncProtectedTrackedExclude `json:"examples,omitempty"`
 }
 
 type syncPlanJSONSize struct {
@@ -84,7 +90,7 @@ func (a App) syncPlan(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	manifest, err := syncManifestFiltered(repo.Root, excludes, syncIncludes(cfg))
+	manifest, err := syncManifestFilteredRules(repo.Root, excludes, syncIncludes(cfg))
 	if err != nil {
 		return exit(6, "build sync file list: %v", err)
 	}
@@ -97,6 +103,7 @@ func (a App) syncPlan(ctx context.Context, args []string) error {
 		return nil
 	}
 	fmt.Fprintf(a.Stdout, "sync candidate: %d files, %s\n", len(manifest.Files), humanBytes(manifest.Bytes))
+	printProtectedTrackedExcludes(a.Stdout, manifest)
 	if len(manifest.Deleted) > 0 {
 		fmt.Fprintf(a.Stdout, "deleted tracked paths: %d\n", len(manifest.Deleted))
 	}
@@ -116,9 +123,23 @@ func syncPlanJSON(manifest SyncManifest, files, dirs []syncPlanRow, cfg Config) 
 		Candidate:           syncPlanJSONSizeFor(len(manifest.Files), manifest.Bytes),
 		DirtyDelta:          syncPlanJSONSizeFor(len(manifest.Changed), manifest.ChangedBytes),
 		DeletedTrackedPaths: len(manifest.Deleted),
+		ProtectedTracked:    syncPlanJSONProtectedFor(manifest),
 		Guardrail:           syncPlanJSONGuardrailFor(manifest, cfg),
 		TopFiles:            syncPlanJSONRows(files),
 		TopDirs:             syncPlanJSONRows(dirs),
+	}
+}
+
+const protectedTrackedExcludeExampleLimit = 5
+
+func syncPlanJSONProtectedFor(manifest SyncManifest) syncPlanJSONProtected {
+	examples := manifest.ProtectedTrackedExcludes
+	if len(examples) > protectedTrackedExcludeExampleLimit {
+		examples = examples[:protectedTrackedExcludeExampleLimit]
+	}
+	return syncPlanJSONProtected{
+		Count:    len(manifest.ProtectedTrackedExcludes),
+		Examples: append([]SyncProtectedTrackedExclude(nil), examples...),
 	}
 }
 

--- a/internal/cli/sync_plan_test.go
+++ b/internal/cli/sync_plan_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -96,6 +97,49 @@ func TestSyncPlanJSONOutput(t *testing.T) {
 	}
 	if len(got.TopDirs) != 1 || got.TopDirs[0].Path != "assets" || got.TopDirs[0].Bytes != 16 {
 		t.Fatalf("topDirs=%+v", got.TopDirs)
+	}
+}
+
+func TestSyncPlanAnnotatesProtectedTrackedFilesWithBoundedExamples(t *testing.T) {
+	clearConfigEnv(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("CRABBOX_PROVIDER", "")
+	t.Setenv("CRABBOX_DEFAULT_CLASS", "")
+
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.email", "test@example.com")
+	runGit(t, dir, "config", "user.name", "Test")
+	for i := 0; i < 7; i++ {
+		writeFile(t, filepath.Join(dir, "target", fmt.Sprintf("file-%d.txt", i)), "tracked\n")
+	}
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-m", "init")
+	t.Chdir(dir)
+
+	var stdout, stderr bytes.Buffer
+	app := App{Stdout: &stdout, Stderr: &stderr}
+	if err := app.Run(context.Background(), []string{"sync-plan"}); err != nil {
+		t.Fatalf("sync-plan: %v stderr=%q", err, stderr.String())
+	}
+	annotation := "warning: protected 7 tracked files from built-in artifact excludes:"
+	if !strings.Contains(stdout.String(), annotation) || !strings.Contains(stdout.String(), "target/file-0.txt (target)") || !strings.Contains(stdout.String(), "(+2 more)") {
+		t.Fatalf("sync-plan output missing bounded protection annotation:\n%s", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if err := app.Run(context.Background(), []string{"sync-plan", "--json"}); err != nil {
+		t.Fatalf("sync-plan --json: %v stderr=%q", err, stderr.String())
+	}
+	var got syncPlanJSONOutput
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("decode sync-plan JSON: %v\n%s", err, stdout.String())
+	}
+	if got.ProtectedTracked.Count != 7 || len(got.ProtectedTracked.Examples) != protectedTrackedExcludeExampleLimit {
+		t.Fatalf("protectedTrackedFiles=%+v", got.ProtectedTracked)
 	}
 }
 

--- a/internal/cli/watch.go
+++ b/internal/cli/watch.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -56,6 +55,8 @@ var watchFilterSourceFiles = map[string]bool{
 	"crabbox.yaml":   true,
 	".crabbox.yaml":  true,
 }
+
+const watchGitIndexBatchKey = "\x00git-index"
 
 type watchOptions struct {
 	LeaseID        string
@@ -237,18 +238,22 @@ func (a App) watchLoop(ctx context.Context, opts watchOptions, repo Repo, cfg Co
 }
 
 type watchSession struct {
-	root     string
-	leaseID  string
-	runArgs  []string
-	command  []string
-	debounce time.Duration
-	idleExit time.Duration
-	cfg      Config
-	execute  watchRunExecutor
-	stderr   io.Writer
-	excludes []string
-	watcher  *fsnotify.Watcher
-	paths    map[string]watchPathState
+	root           string
+	leaseID        string
+	runArgs        []string
+	command        []string
+	debounce       time.Duration
+	idleExit       time.Duration
+	cfg            Config
+	execute        watchRunExecutor
+	stderr         io.Writer
+	excludes       SyncExcludeRules
+	trackedRegular map[string]struct{}
+	indexRegular   map[string]struct{}
+	pathScope      watchPathScope
+	gitIndexPath   string
+	watcher        *fsnotify.Watcher
+	paths          map[string]watchPathState
 }
 
 type watchPathState struct {
@@ -269,7 +274,24 @@ func (s *watchSession) run(ctx context.Context) error {
 	}
 	defer watcher.Close()
 	s.watcher = watcher
-	files, err := addWatchTree(watcher, s.root, s.root, s.excludes)
+	s.gitIndexPath, err = watchGitIndexPath(s.root)
+	if err != nil {
+		return exit(1, "watch: resolve Git index: %v", err)
+	}
+	if err := watcher.Add(filepath.Dir(s.gitIndexPath)); err != nil {
+		return exit(1, "watch: watch Git index: %v", err)
+	}
+	tracked, err := loadGitTrackedPaths(s.root)
+	if err != nil {
+		return exit(1, "watch: list tracked paths: %v", err)
+	}
+	s.indexRegular = trackedRegularPathSet(tracked)
+	s.trackedRegular, err = trackedRegularPathSetWithCachedDeletions(s.root, tracked)
+	if err != nil {
+		return exit(1, "watch: classify tracked paths: %v", err)
+	}
+	s.pathScope = newWatchPathScope(s.excludes, s.trackedRegular)
+	files, err := addWatchTree(watcher, s.root, s.root, s.pathScope)
 	if err != nil {
 		return exit(1, "watch: watch %s: %v", s.root, err)
 	}
@@ -394,6 +416,10 @@ func (s *watchSession) run(ctx context.Context) error {
 }
 
 func (s *watchSession) observeEvent(watcher *fsnotify.Watcher, event fsnotify.Event, batch map[string]struct{}) bool {
+	if s.gitIndexPath != "" && (sameLocalPath(event.Name, s.gitIndexPath) || sameLocalPath(event.Name, s.gitIndexPath+".lock")) {
+		batch[watchGitIndexBatchKey] = struct{}{}
+		return true
+	}
 	rel, err := filepath.Rel(s.root, event.Name)
 	if err != nil {
 		return false
@@ -402,21 +428,12 @@ func (s *watchSession) observeEvent(watcher *fsnotify.Watcher, event fsnotify.Ev
 	if rel == "." || !safeRepoRel(rel) {
 		return false
 	}
-	excluded := pathExcluded(rel, s.excludes)
-	if excluded {
-		if !excludedDirMayContainReinclude(rel, s.excludes) {
+	if !s.pathScope.pathEligible(rel) {
+		if !s.pathScope.traverseExcludedDir(rel) {
 			return false
 		}
 		if event.Op&(fsnotify.Remove|fsnotify.Rename) != 0 {
-			changed := false
-			for path := range s.paths {
-				if strings.HasPrefix(path, rel+"/") && !pathExcluded(path, s.excludes) {
-					delete(s.paths, path)
-					batch[path] = struct{}{}
-					changed = true
-				}
-			}
-			return changed
+			return s.queueRemovedDescendants(rel, batch)
 		}
 		if event.Op&fsnotify.Create == 0 {
 			return false
@@ -425,7 +442,7 @@ func (s *watchSession) observeEvent(watcher *fsnotify.Watcher, event fsnotify.Ev
 		if err != nil || !info.IsDir() {
 			return false
 		}
-		files, err := addWatchTree(watcher, s.root, event.Name, s.excludes)
+		files, err := addWatchTree(watcher, s.root, event.Name, s.pathScope)
 		if err != nil {
 			return false
 		}
@@ -443,7 +460,7 @@ func (s *watchSession) observeEvent(watcher *fsnotify.Watcher, event fsnotify.Ev
 	}
 	if event.Op&fsnotify.Create != 0 {
 		if info, err := os.Lstat(event.Name); err == nil && info.IsDir() {
-			if files, err := addWatchTree(watcher, s.root, event.Name, s.excludes); err == nil {
+			if files, err := addWatchTree(watcher, s.root, event.Name, s.pathScope); err == nil {
 				for _, file := range files {
 					s.rememberPath(file, filepath.Join(s.root, filepath.FromSlash(file)))
 					batch[file] = struct{}{}
@@ -453,6 +470,18 @@ func (s *watchSession) observeEvent(watcher *fsnotify.Watcher, event fsnotify.Ev
 	}
 	batch[rel] = struct{}{}
 	return true
+}
+
+func (s *watchSession) queueRemovedDescendants(rel string, batch map[string]struct{}) bool {
+	changed := false
+	for path := range s.paths {
+		if strings.HasPrefix(path, rel+"/") && s.pathScope.pathEligible(path) {
+			delete(s.paths, path)
+			batch[path] = struct{}{}
+			changed = true
+		}
+	}
+	return changed
 }
 
 func (s *watchSession) rememberPath(rel, name string) bool {
@@ -489,10 +518,26 @@ func (s *watchSession) qualifyBatch(paths []string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	excludesChanged := !slices.Equal(excludes, s.excludes)
+	previousIndexRegular := s.indexRegular
+	tracked, err := loadGitTrackedPaths(s.root)
+	if err != nil {
+		return nil, exit(1, "watch: list tracked paths: %v", err)
+	}
+	trackedRegular, err := trackedRegularPathSetWithCachedDeletions(s.root, tracked)
+	if err != nil {
+		return nil, exit(1, "watch: classify tracked paths: %v", err)
+	}
+	excludesChanged := !syncExcludeRulesEqual(excludes, s.excludes)
+	indexRegular := trackedRegularPathSet(tracked)
 	s.excludes = excludes
+	s.indexRegular = indexRegular
+	s.trackedRegular = trackedRegular
+	s.pathScope = newWatchPathScope(excludes, trackedRegular)
+	includes := syncIncludes(s.cfg)
+	var indexQualified []string
+	paths, indexQualified = expandWatchGitIndexBatch(paths, previousIndexRegular, indexRegular, excludes, includes)
 	if excludesChanged && s.watcher != nil {
-		files, err := addWatchTree(s.watcher, s.root, s.root, s.excludes)
+		files, err := addWatchTree(s.watcher, s.root, s.root, s.pathScope)
 		if err != nil {
 			return nil, exit(1, "watch: rewatch %s after filter change: %v", s.root, err)
 		}
@@ -500,11 +545,10 @@ func (s *watchSession) qualifyBatch(paths []string) ([]string, error) {
 			s.rememberPath(file, filepath.Join(s.root, filepath.FromSlash(file)))
 		}
 	}
-	includes := syncIncludes(s.cfg)
 	existing := make([]string, 0, len(paths))
 	missing := make([]string, 0, len(paths))
 	for _, path := range paths {
-		if !safeRepoRel(path) || pathExcluded(path, s.excludes) {
+		if !safeRepoRel(path) || !s.pathScope.pathEligible(path) {
 			continue
 		}
 		if _, err := os.Lstat(filepath.Join(s.root, filepath.FromSlash(path))); err == nil {
@@ -513,14 +557,26 @@ func (s *watchSession) qualifyBatch(paths []string) ([]string, error) {
 			missing = append(missing, path)
 		}
 	}
-	qualified := map[string]struct{}{}
+	qualified := make(map[string]struct{}, len(indexQualified))
+	for _, rel := range indexQualified {
+		qualified[rel] = struct{}{}
+		_, trackedRegular := s.indexRegular[rel]
+		if trackedRegular && s.pathScope.pathEligible(rel) {
+			if err := addWatchParentChain(s.watcher, s.root, rel); err != nil {
+				return nil, exit(1, "watch: attach tracked path %s: %v", rel, err)
+			}
+			s.rememberPath(rel, filepath.Join(s.root, filepath.FromSlash(rel)))
+		} else {
+			delete(s.paths, rel)
+		}
+	}
 	if len(existing) > 0 {
 		universe, err := watchGitPaths(s.root, existing, "ls-files", "--cached", "--others", "--exclude-standard", "-z", "--")
 		if err != nil {
 			return nil, err
 		}
 		for _, rel := range universe {
-			if safeRepoRel(rel) && !pathExcluded(rel, s.excludes) && pathIncluded(rel, includes) {
+			if safeRepoRel(rel) && s.pathScope.pathEligible(rel) && pathIncluded(rel, includes) {
 				qualified[rel] = struct{}{}
 			}
 		}
@@ -561,6 +617,62 @@ func (s *watchSession) qualifyBatch(paths []string) ([]string, error) {
 	}
 	sort.Strings(result)
 	return result, nil
+}
+
+func watchGitIndexPath(root string) (string, error) {
+	cmd := exec.Command("git", "rev-parse", "--git-path", "index")
+	cmd.Dir = root
+	cmd.Env = repositoryGitEnvironment()
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	indexPath := strings.TrimSpace(string(out))
+	if indexPath == "" {
+		return "", fmt.Errorf("empty Git index path")
+	}
+	if !filepath.IsAbs(indexPath) {
+		indexPath = filepath.Join(root, indexPath)
+	}
+	return filepath.Clean(indexPath), nil
+}
+
+func sameLocalPath(a, b string) bool {
+	return filepath.Clean(a) == filepath.Clean(b)
+}
+
+func expandWatchGitIndexBatch(paths []string, before, after map[string]struct{}, rules SyncExcludeRules, includes []string) ([]string, []string) {
+	indexChanged := false
+	out := make([]string, 0, len(paths))
+	for _, path := range paths {
+		if path == watchGitIndexBatchKey {
+			indexChanged = true
+			continue
+		}
+		out = append(out, path)
+	}
+	if !indexChanged {
+		return out, nil
+	}
+	changed := map[string]struct{}{}
+	for path := range before {
+		if _, ok := after[path]; !ok && watchRulesProtectTrackedPath(path, rules) && pathIncluded(path, includes) {
+			changed[path] = struct{}{}
+		}
+	}
+	for path := range after {
+		if _, ok := before[path]; !ok && watchRulesProtectTrackedPath(path, rules) && pathIncluded(path, includes) {
+			changed[path] = struct{}{}
+		}
+	}
+	for path := range changed {
+		out = append(out, path)
+	}
+	qualified := make([]string, 0, len(changed))
+	for path := range changed {
+		qualified = append(qualified, path)
+	}
+	return out, qualified
 }
 
 func watchGitPaths(root string, paths []string, gitArgs ...string) ([]string, error) {
@@ -623,7 +735,7 @@ func isWatchIterationResult(err error) bool {
 	return strings.HasPrefix(exitErr.Message, "remote command exited") || strings.HasPrefix(exitErr.Message, "JUnit results contain")
 }
 
-func addWatchTree(watcher *fsnotify.Watcher, root, dir string, excludes []string) ([]string, error) {
+func addWatchTree(watcher *fsnotify.Watcher, root, dir string, scope watchPathScope) ([]string, error) {
 	var files []string
 	err := filepath.WalkDir(dir, func(path string, entry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
@@ -639,8 +751,7 @@ func addWatchTree(watcher *fsnotify.Watcher, root, dir string, excludes []string
 		rel = filepath.ToSlash(rel)
 		if entry.IsDir() {
 			if rel != "." &&
-				(!safeRepoRel(rel) ||
-					(pathExcluded(rel, excludes) && !excludedDirMayContainReinclude(rel, excludes))) {
+				(!safeRepoRel(rel) || !scope.traverseDir(rel)) {
 				return fs.SkipDir
 			}
 			if err := watcher.Add(path); err != nil {
@@ -654,13 +765,98 @@ func addWatchTree(watcher *fsnotify.Watcher, root, dir string, excludes []string
 		if entry.Type()&fs.ModeSymlink != 0 {
 			return nil
 		}
-		if !safeRepoRel(rel) || pathExcluded(rel, excludes) {
+		if !safeRepoRel(rel) || !scope.pathEligible(rel) {
 			return nil
 		}
 		files = append(files, rel)
 		return nil
 	})
 	return files, err
+}
+
+type watchPathScope struct {
+	rules                     SyncExcludeRules
+	trackedRegular            map[string]struct{}
+	protectedTrackedAncestors map[string]struct{}
+}
+
+func newWatchPathScope(rules SyncExcludeRules, trackedRegular map[string]struct{}) watchPathScope {
+	scope := watchPathScope{
+		rules:                     rules,
+		trackedRegular:            trackedRegular,
+		protectedTrackedAncestors: map[string]struct{}{},
+	}
+	for rel := range trackedRegular {
+		if !watchRulesProtectTrackedPath(rel, rules) {
+			continue
+		}
+		for parent := filepath.ToSlash(filepath.Dir(filepath.FromSlash(rel))); parent != "."; parent = filepath.ToSlash(filepath.Dir(filepath.FromSlash(parent))) {
+			scope.protectedTrackedAncestors[parent] = struct{}{}
+		}
+	}
+	return scope
+}
+
+func (s watchPathScope) pathEligible(rel string) bool {
+	_, trackedRegular := s.trackedRegular[rel]
+	return !pathExcludedByRules(rel, s.rules, trackedRegular)
+}
+
+func (s watchPathScope) traverseDir(rel string) bool {
+	if !pathExcludedByRules(rel, s.rules, false) {
+		return true
+	}
+	return s.traverseExcludedDir(rel)
+}
+
+func (s watchPathScope) traverseExcludedDir(rel string) bool {
+	if excludedDirMayContainReinclude(rel, s.rules.patterns()) {
+		return true
+	}
+	_, ok := s.protectedTrackedAncestors[rel]
+	return ok
+}
+
+func addWatchParentChain(watcher *fsnotify.Watcher, root, rel string) error {
+	if watcher == nil || !safeRepoRel(filepath.ToSlash(rel)) {
+		return nil
+	}
+	parts := strings.Split(filepath.ToSlash(rel), "/")
+	current := root
+	for _, part := range parts[:len(parts)-1] {
+		current = filepath.Join(current, filepath.FromSlash(part))
+		info, err := os.Lstat(current)
+		if os.IsNotExist(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("parent %s is not a directory", current)
+		}
+		if err := watcher.Add(current); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func syncExcludeRulesEqual(a, b SyncExcludeRules) bool {
+	if len(a.rules) != len(b.rules) {
+		return false
+	}
+	for i := range a.rules {
+		if a.rules[i] != b.rules[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func watchRulesProtectTrackedPath(rel string, rules SyncExcludeRules) bool {
+	excluded, protectedPattern := pathExcludeDecision(rel, rules, true)
+	return !excluded && protectedPattern != ""
 }
 
 func splitWatchArgs(args []string) ([]string, []string) {

--- a/internal/cli/watch_test.go
+++ b/internal/cli/watch_test.go
@@ -691,14 +691,19 @@ func TestWatchTraversesExcludedParentForReincludedDescendant(t *testing.T) {
 	root := newWatchGitRepo(t)
 	watchTestWrite(t, root, "target/keep.txt", "source")
 	watchTestWrite(t, root, "target/drop.bin", "generated")
-	excludes := appendOrderedStrings(defaultExcludes(), "!target/keep.txt")
+	excludes := newSyncExcludeRules(appendOrderedStrings(defaultExcludes(), "!target/keep.txt"), syncExcludeConfigured)
+	tracked, err := loadGitTrackedPaths(root)
+	if err != nil {
+		t.Fatal(err)
+	}
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer watcher.Close()
 
-	files, err := addWatchTree(watcher, root, root, excludes)
+	scope := newWatchPathScope(excludes, trackedRegularPathSet(tracked))
+	files, err := addWatchTree(watcher, root, root, scope)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -709,6 +714,102 @@ func TestWatchTraversesExcludedParentForReincludedDescendant(t *testing.T) {
 	if strings.Contains(got, "target/drop.bin") || strings.Contains(got, ".git/") {
 		t.Fatalf("watched files=%q should omit excluded paths", got)
 	}
+}
+
+func TestWatchSkipsAmbiguousBuiltInDirectoryWithoutTrackedDescendants(t *testing.T) {
+	root := newWatchGitRepo(t)
+	watchTestWrite(t, root, "target/generated.bin", "generated")
+	rules, err := syncExcludes(root, baseConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	tracked, err := loadGitTrackedPaths(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer watcher.Close()
+	scope := newWatchPathScope(rules, trackedRegularPathSet(tracked))
+	files, err := addWatchTree(watcher, root, root, scope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(strings.Join(files, ","), "target/generated.bin") {
+		t.Fatalf("untracked generated output entered watched file set: %v", files)
+	}
+	if watchListContains(watcher, filepath.Join(root, "target")) {
+		t.Fatalf("untracked artifact directory entered watch list: %v", watcher.WatchList())
+	}
+	session := &watchSession{
+		root:           root,
+		excludes:       rules,
+		trackedRegular: trackedRegularPathSet(tracked),
+		pathScope:      scope,
+		paths:          map[string]watchPathState{},
+	}
+	batch := map[string]struct{}{}
+	watchTestWrite(t, root, "target/generated.bin", "changed")
+	if session.observeEvent(nil, fsnotify.Event{Name: filepath.Join(root, "target", "generated.bin"), Op: fsnotify.Write}, batch) {
+		t.Fatalf("untracked artifact write entered debounce batch: %v", batch)
+	}
+	select {
+	case event := <-watcher.Events:
+		t.Fatalf("untracked artifact subtree produced event despite startup pruning: %+v", event)
+	case err := <-watcher.Errors:
+		t.Fatalf("watch error: %v", err)
+	case <-time.After(250 * time.Millisecond):
+	}
+}
+
+func TestWatchTraversesOnlyTrackedProtectedAncestorChain(t *testing.T) {
+	root := newWatchGitRepo(t)
+	watchTestWrite(t, root, "target/src/keep.go", "package src\n")
+	watchTestWrite(t, root, "target/generated/deep/output.bin", "generated")
+	watchTestGit(t, root, "add", "target/src/keep.go")
+	watchTestGit(t, root, "commit", "-q", "-m", "add tracked target source")
+	rules, err := syncExcludes(root, baseConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	tracked, err := loadGitTrackedPaths(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer watcher.Close()
+	scope := newWatchPathScope(rules, trackedRegularPathSet(tracked))
+	files, err := addWatchTree(watcher, root, root, scope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(files, ","); got != ".gitignore,main.go,target/src/keep.go" {
+		t.Fatalf("watched files=%q", got)
+	}
+	for _, want := range []string{root, filepath.Join(root, "target"), filepath.Join(root, "target", "src")} {
+		if !watchListContains(watcher, want) {
+			t.Errorf("watch list=%v missing ancestor %s", watcher.WatchList(), want)
+		}
+	}
+	for _, notWant := range []string{filepath.Join(root, "target", "generated"), filepath.Join(root, "target", "generated", "deep")} {
+		if watchListContains(watcher, notWant) {
+			t.Errorf("watch list=%v contains unrelated generated subtree %s", watcher.WatchList(), notWant)
+		}
+	}
+}
+
+func watchListContains(watcher *fsnotify.Watcher, want string) bool {
+	for _, watched := range watcher.WatchList() {
+		if sameLocalPath(watched, want) {
+			return true
+		}
+	}
+	return false
 }
 
 func TestWatchQueuesReincludedDescendantWhenExcludedParentIsRemoved(t *testing.T) {
@@ -726,16 +827,24 @@ func TestWatchQueuesReincludedDescendantWhenExcludedParentIsRemoved(t *testing.T
 		t.Fatal(err)
 	}
 	defer watcher.Close()
-	files, err := addWatchTree(watcher, root, root, excludes)
+	tracked, err := loadGitTrackedPaths(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	scope := newWatchPathScope(excludes, trackedRegularPathSet(tracked))
+	files, err := addWatchTree(watcher, root, root, scope)
 	if err != nil {
 		t.Fatal(err)
 	}
 	session := &watchSession{
-		root:     root,
-		cfg:      baseConfig(),
-		excludes: excludes,
-		paths:    map[string]watchPathState{},
-		watcher:  watcher,
+		root:           root,
+		cfg:            baseConfig(),
+		excludes:       excludes,
+		trackedRegular: trackedRegularPathSet(tracked),
+		indexRegular:   trackedRegularPathSet(tracked),
+		pathScope:      scope,
+		paths:          map[string]watchPathState{},
+		watcher:        watcher,
 	}
 	for _, file := range files {
 		session.rememberPath(file, filepath.Join(root, filepath.FromSlash(file)))
@@ -789,6 +898,215 @@ func TestWatchIncludeWhitelistFiltersReruns(t *testing.T) {
 	}
 	if executor.callCount() != 2 {
 		t.Fatalf("iterations=%d, want 2", executor.callCount())
+	}
+}
+
+func TestWatchQualifiesTrackedAmbiguousPathsButNotGeneratedOrConfiguredExcludes(t *testing.T) {
+	root := newWatchGitRepo(t)
+	watchTestWrite(t, root, "target/keep.txt", "tracked\n")
+	watchTestGit(t, root, "add", "target/keep.txt")
+	watchTestGit(t, root, "commit", "-q", "-m", "add tracked target source")
+	watchTestWrite(t, root, "target/keep.txt", "changed\n")
+	watchTestWrite(t, root, "target/generated.bin", "generated\n")
+
+	rules, err := syncExcludes(root, baseConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	tracked, err := loadGitTrackedPaths(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	session := &watchSession{
+		root:           root,
+		cfg:            baseConfig(),
+		excludes:       rules,
+		trackedRegular: trackedRegularPathSet(tracked),
+		indexRegular:   trackedRegularPathSet(tracked),
+		pathScope:      newWatchPathScope(rules, trackedRegularPathSet(tracked)),
+		paths:          map[string]watchPathState{},
+	}
+	batch := map[string]struct{}{}
+	if session.observeEvent(nil, fsnotify.Event{Name: filepath.Join(root, "target", "generated.bin"), Op: fsnotify.Write}, batch) {
+		t.Fatalf("untracked generated write entered debounce batch: %v", batch)
+	}
+
+	qualified, err := session.qualifyBatch([]string{"target/keep.txt", "target/generated.bin"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(qualified, ","); got != "target/keep.txt" {
+		t.Fatalf("qualified=%q, want tracked target path only", got)
+	}
+
+	session.cfg.Sync.Excludes = []string{"target"}
+	qualified, err = session.qualifyBatch([]string{"target/keep.txt"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(qualified) != 0 {
+		t.Fatalf("configured target exclude qualified tracked path: %v", qualified)
+	}
+	batch = map[string]struct{}{}
+	if session.observeEvent(nil, fsnotify.Event{Name: filepath.Join(root, "target", "keep.txt"), Op: fsnotify.Write}, batch) {
+		t.Fatalf("configured target exclude remained observable: %v", batch)
+	}
+
+	session.cfg.Sync.Excludes = nil
+	watchTestGit(t, root, "rm", "-q", "-f", "target/keep.txt")
+	qualified, err = session.qualifyBatch([]string{"target/keep.txt"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(qualified, ","); got != "target/keep.txt" {
+		t.Fatalf("qualified staged deletion=%q, want target/keep.txt", got)
+	}
+}
+
+func TestWatchDiscoversFileThatBecomesTrackedUnderAmbiguousBuiltInDirectory(t *testing.T) {
+	root := newWatchGitRepo(t)
+	watchTestWrite(t, root, "target/new.go", "package target\n")
+	rules, err := syncExcludes(root, baseConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	tracked, err := loadGitTrackedPaths(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer watcher.Close()
+	scope := newWatchPathScope(rules, trackedRegularPathSet(tracked))
+	files, err := addWatchTree(watcher, root, root, scope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if watchListContains(watcher, filepath.Join(root, "target")) {
+		t.Fatalf("untracked target directory was watched at startup: %v", watcher.WatchList())
+	}
+	session := &watchSession{
+		root:           root,
+		cfg:            baseConfig(),
+		excludes:       rules,
+		trackedRegular: trackedRegularPathSet(tracked),
+		indexRegular:   trackedRegularPathSet(tracked),
+		pathScope:      scope,
+		paths:          map[string]watchPathState{},
+		watcher:        watcher,
+	}
+	for _, file := range files {
+		session.rememberPath(file, filepath.Join(root, filepath.FromSlash(file)))
+	}
+	batch := map[string]struct{}{}
+	if session.observeEvent(nil, fsnotify.Event{Name: filepath.Join(root, "target", "new.go"), Op: fsnotify.Write}, batch) {
+		t.Fatalf("untracked ambiguous path entered batch before git add: %v", batch)
+	}
+	watchTestGit(t, root, "add", "target/new.go")
+	session.gitIndexPath, err = watchGitIndexPath(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	batch = map[string]struct{}{}
+	if !session.observeEvent(nil, fsnotify.Event{Name: session.gitIndexPath, Op: fsnotify.Write}, batch) {
+		t.Fatal("Git index event did not queue tracked-classification refresh")
+	}
+	qualified, err := session.qualifyBatch([]string{watchGitIndexBatchKey})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(qualified, ","); got != "target/new.go" {
+		t.Fatalf("index-only tracked transition qualified=%q, want target/new.go", got)
+	}
+	if _, ok := session.paths["target/new.go"]; !ok {
+		t.Fatal("index-only tracked transition was not remembered for parent removal")
+	}
+	if !watchListContains(watcher, filepath.Join(root, "target")) {
+		t.Fatalf("index transition did not attach target parent watcher: %v", watcher.WatchList())
+	}
+	watchTestWrite(t, root, "target/new.go", "package target\nvar changed = true\n")
+	batch = map[string]struct{}{}
+	if !session.observeEvent(watcher, fsnotify.Event{Name: filepath.Join(root, "target", "new.go"), Op: fsnotify.Write}, batch) {
+		t.Fatal("tracked protected write did not enter batch after index attachment")
+	}
+	qualified, err = session.qualifyBatch([]string{"target/new.go"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(qualified, ","); got != "target/new.go" {
+		t.Fatalf("tracked protected write qualified=%q, want target/new.go", got)
+	}
+	batch = map[string]struct{}{}
+	if !session.observeEvent(nil, fsnotify.Event{Name: filepath.Join(root, "target"), Op: fsnotify.Rename}, batch) {
+		t.Fatal("parent rename did not queue index-discovered tracked descendant")
+	}
+	if _, ok := batch["target/new.go"]; !ok {
+		t.Fatalf("parent rename batch=%v, want target/new.go", batch)
+	}
+	session.rememberPath("target/new.go", filepath.Join(root, "target", "new.go"))
+
+	watchTestGit(t, root, "rm", "--cached", "-q", "-f", "target/new.go")
+	qualified, err = session.qualifyBatch([]string{watchGitIndexBatchKey})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(qualified, ","); got != "target/new.go" {
+		t.Fatalf("index-only untracked transition qualified=%q, want target/new.go", got)
+	}
+	if _, ok := session.paths["target/new.go"]; ok {
+		t.Fatal("index-only untracked transition remained in remembered path set")
+	}
+
+	session.cfg.Sync.Includes = []string{"src"}
+	watchTestGit(t, root, "add", "target/new.go")
+	qualified, err = session.qualifyBatch([]string{watchGitIndexBatchKey})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(qualified) != 0 {
+		t.Fatalf("index transition outside include whitelist qualified: %v", qualified)
+	}
+}
+
+func TestWatchDiscoversCommittedFileRemovedFromIndexUnderAmbiguousDirectory(t *testing.T) {
+	root := newWatchGitRepo(t)
+	watchTestWrite(t, root, "target/committed.go", "package target\n")
+	watchTestGit(t, root, "add", "target/committed.go")
+	watchTestGit(t, root, "commit", "-q", "-m", "add tracked artifact source")
+	rules, err := syncExcludes(root, baseConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	tracked, err := loadGitTrackedPaths(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	indexRegular := trackedRegularPathSet(tracked)
+	session := &watchSession{
+		root:           root,
+		cfg:            baseConfig(),
+		excludes:       rules,
+		trackedRegular: indexRegular,
+		indexRegular:   indexRegular,
+		pathScope:      newWatchPathScope(rules, indexRegular),
+		paths:          map[string]watchPathState{},
+	}
+	watchTestGit(t, root, "rm", "--cached", "-q", "target/committed.go")
+	qualified, err := session.qualifyBatch([]string{watchGitIndexBatchKey})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(qualified, ","); got != "target/committed.go" {
+		t.Fatalf("committed index removal qualified=%q, want target/committed.go", got)
+	}
+	manifest, err := syncManifest(root, rules)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(manifest.Deleted, ","); got != "target/committed.go" {
+		t.Fatalf("committed index removal delete manifest=%q", got)
 	}
 }
 

--- a/internal/providers/agentsandbox/core.go
+++ b/internal/providers/agentsandbox/core.go
@@ -186,11 +186,11 @@ func shellQuote(s string) string {
 	return core.ShellQuote(s)
 }
 
-func syncExcludes(root string, cfg Config) ([]string, error) {
+func syncExcludes(root string, cfg Config) (core.SyncExcludeRules, error) {
 	return core.SyncExcludes(root, cfg)
 }
 
-func syncManifest(root string, excludes, includes []string) (core.SyncManifest, error) {
+func syncManifest(root string, excludes core.SyncExcludeRules, includes []string) (core.SyncManifest, error) {
 	return core.BuildSyncManifestFiltered(root, excludes, includes)
 }
 

--- a/internal/providers/azuredynamicsessions/core.go
+++ b/internal/providers/azuredynamicsessions/core.go
@@ -145,11 +145,11 @@ func leadingEnvAssignment(command []string) bool {
 	return core.LeadingEnvAssignment(command)
 }
 
-func syncExcludes(root string, cfg Config) ([]string, error) {
+func syncExcludes(root string, cfg Config) (core.SyncExcludeRules, error) {
 	return core.SyncExcludes(root, cfg)
 }
 
-func syncManifest(root string, excludes, includes []string) (SyncManifest, error) {
+func syncManifest(root string, excludes core.SyncExcludeRules, includes []string) (SyncManifest, error) {
 	return core.BuildSyncManifestFiltered(root, excludes, includes)
 }
 

--- a/internal/providers/blaxel/core.go
+++ b/internal/providers/blaxel/core.go
@@ -141,11 +141,11 @@ func shellQuote(s string) string {
 	return core.ShellQuote(s)
 }
 
-func syncExcludes(root string, cfg Config) ([]string, error) {
+func syncExcludes(root string, cfg Config) (core.SyncExcludeRules, error) {
 	return core.SyncExcludes(root, cfg)
 }
 
-func syncManifest(root string, excludes, includes []string) (SyncManifest, error) {
+func syncManifest(root string, excludes core.SyncExcludeRules, includes []string) (SyncManifest, error) {
 	return core.BuildSyncManifestFiltered(root, excludes, includes)
 }
 

--- a/internal/providers/cloudflare/core.go
+++ b/internal/providers/cloudflare/core.go
@@ -136,11 +136,11 @@ func leadingEnvAssignment(command []string) bool {
 	return core.LeadingEnvAssignment(command)
 }
 
-func syncExcludes(root string, cfg Config) ([]string, error) {
+func syncExcludes(root string, cfg Config) (core.SyncExcludeRules, error) {
 	return core.SyncExcludes(root, cfg)
 }
 
-func syncManifest(root string, excludes, includes []string) (SyncManifest, error) {
+func syncManifest(root string, excludes core.SyncExcludeRules, includes []string) (SyncManifest, error) {
 	return core.BuildSyncManifestFiltered(root, excludes, includes)
 }
 

--- a/internal/providers/crownest/core.go
+++ b/internal/providers/crownest/core.go
@@ -100,11 +100,11 @@ func leadingEnvAssignment(command []string) bool {
 	return core.LeadingEnvAssignment(command)
 }
 
-func syncExcludes(root string, cfg Config) ([]string, error) {
+func syncExcludes(root string, cfg Config) (core.SyncExcludeRules, error) {
 	return core.SyncExcludes(root, cfg)
 }
 
-func syncManifest(root string, excludes, includes []string) (SyncManifest, error) {
+func syncManifest(root string, excludes core.SyncExcludeRules, includes []string) (SyncManifest, error) {
 	return core.BuildSyncManifestFiltered(root, excludes, includes)
 }
 

--- a/internal/providers/daytona/core.go
+++ b/internal/providers/daytona/core.go
@@ -168,11 +168,11 @@ func remoteJoin(cfg Config, parts ...string) string {
 	return core.RemoteJoin(cfg, parts...)
 }
 
-func syncExcludes(root string, cfg Config) ([]string, error) {
+func syncExcludes(root string, cfg Config) (core.SyncExcludeRules, error) {
 	return core.SyncExcludes(root, cfg)
 }
 
-func syncManifest(root string, excludes, includes []string) (SyncManifest, error) {
+func syncManifest(root string, excludes core.SyncExcludeRules, includes []string) (SyncManifest, error) {
 	return core.BuildSyncManifestFiltered(root, excludes, includes)
 }
 

--- a/internal/providers/e2b/core.go
+++ b/internal/providers/e2b/core.go
@@ -140,11 +140,11 @@ func leadingEnvAssignment(command []string) bool {
 	return core.LeadingEnvAssignment(command)
 }
 
-func syncExcludes(root string, cfg Config) ([]string, error) {
+func syncExcludes(root string, cfg Config) (core.SyncExcludeRules, error) {
 	return core.SyncExcludes(root, cfg)
 }
 
-func syncManifest(root string, excludes, includes []string) (SyncManifest, error) {
+func syncManifest(root string, excludes core.SyncExcludeRules, includes []string) (SyncManifest, error) {
 	return core.BuildSyncManifestFiltered(root, excludes, includes)
 }
 

--- a/internal/providers/freestyle/core.go
+++ b/internal/providers/freestyle/core.go
@@ -76,11 +76,11 @@ func removeLeaseClaim(leaseID string) {
 	core.RemoveLeaseClaim(leaseID)
 }
 
-func syncExcludes(root string, cfg Config) ([]string, error) {
+func syncExcludes(root string, cfg Config) (core.SyncExcludeRules, error) {
 	return core.SyncExcludes(root, cfg)
 }
 
-func syncManifest(root string, excludes, includes []string) (core.SyncManifest, error) {
+func syncManifest(root string, excludes core.SyncExcludeRules, includes []string) (core.SyncManifest, error) {
 	return core.BuildSyncManifestFiltered(root, excludes, includes)
 }
 

--- a/internal/providers/islo/core.go
+++ b/internal/providers/islo/core.go
@@ -91,11 +91,11 @@ func clearLeaseClaimTailscale(leaseID string) error {
 	return core.ClearLeaseClaimTailscale(leaseID)
 }
 
-func syncExcludes(root string, cfg Config) ([]string, error) {
+func syncExcludes(root string, cfg Config) (core.SyncExcludeRules, error) {
 	return core.SyncExcludes(root, cfg)
 }
 
-func syncManifest(root string, excludes, includes []string) (core.SyncManifest, error) {
+func syncManifest(root string, excludes core.SyncExcludeRules, includes []string) (core.SyncManifest, error) {
 	return core.BuildSyncManifestFiltered(root, excludes, includes)
 }
 

--- a/internal/providers/modal/core.go
+++ b/internal/providers/modal/core.go
@@ -117,11 +117,11 @@ func leadingEnvAssignment(command []string) bool {
 	return core.LeadingEnvAssignment(command)
 }
 
-func syncExcludes(root string, cfg Config) ([]string, error) {
+func syncExcludes(root string, cfg Config) (core.SyncExcludeRules, error) {
 	return core.SyncExcludes(root, cfg)
 }
 
-func syncManifest(root string, excludes, includes []string) (SyncManifest, error) {
+func syncManifest(root string, excludes core.SyncExcludeRules, includes []string) (SyncManifest, error) {
 	return core.BuildSyncManifestFiltered(root, excludes, includes)
 }
 

--- a/internal/providers/smolvm/core.go
+++ b/internal/providers/smolvm/core.go
@@ -114,11 +114,11 @@ func leadingEnvAssignment(command []string) bool {
 	return core.LeadingEnvAssignment(command)
 }
 
-func syncExcludes(root string, cfg Config) ([]string, error) {
+func syncExcludes(root string, cfg Config) (core.SyncExcludeRules, error) {
 	return core.SyncExcludes(root, cfg)
 }
 
-func syncManifest(root string, excludes, includes []string) (SyncManifest, error) {
+func syncManifest(root string, excludes core.SyncExcludeRules, includes []string) (SyncManifest, error) {
 	return core.BuildSyncManifestFiltered(root, excludes, includes)
 }
 

--- a/internal/providers/tensorlake/core.go
+++ b/internal/providers/tensorlake/core.go
@@ -131,11 +131,11 @@ func tensorlakeCleanupCommand(leaseID string) string {
 	return "crabbox stop --provider " + providerName + " --id " + shellQuote(leaseID)
 }
 
-func syncExcludes(root string, cfg Config) ([]string, error) {
+func syncExcludes(root string, cfg Config) (core.SyncExcludeRules, error) {
 	return core.SyncExcludes(root, cfg)
 }
 
-func syncManifest(root string, excludes, includes []string) (core.SyncManifest, error) {
+func syncManifest(root string, excludes core.SyncExcludeRules, includes []string) (core.SyncManifest, error) {
 	return core.BuildSyncManifestFiltered(root, excludes, includes)
 }
 

--- a/internal/providers/upstashbox/core.go
+++ b/internal/providers/upstashbox/core.go
@@ -126,11 +126,11 @@ func leadingEnvAssignment(command []string) bool {
 	return core.LeadingEnvAssignment(command)
 }
 
-func syncExcludes(root string, cfg Config) ([]string, error) {
+func syncExcludes(root string, cfg Config) (core.SyncExcludeRules, error) {
 	return core.SyncExcludes(root, cfg)
 }
 
-func syncManifest(root string, excludes, includes []string) (SyncManifest, error) {
+func syncManifest(root string, excludes core.SyncExcludeRules, includes []string) (SyncManifest, error) {
 	return core.BuildSyncManifestFiltered(root, excludes, includes)
 }
 

--- a/internal/providers/windowssandbox/backend_test.go
+++ b/internal/providers/windowssandbox/backend_test.go
@@ -289,7 +289,7 @@ func TestSyncManifestHonorsIncludes(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	manifest, err := syncManifest(repo, nil, []string{"keep.txt", "nested/"})
+	manifest, err := syncManifest(repo, core.SyncExcludeRules{}, []string{"keep.txt", "nested/"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/providers/windowssandbox/core.go
+++ b/internal/providers/windowssandbox/core.go
@@ -59,11 +59,11 @@ func rejectDelegatedSyncOptionsForSpec(spec ProviderSpec, req RunRequest) error 
 	return core.RejectDelegatedSyncOptionsForSpec(spec, req)
 }
 
-func syncExcludes(root string, cfg Config) ([]string, error) {
+func syncExcludes(root string, cfg Config) (core.SyncExcludeRules, error) {
 	return core.SyncExcludes(root, cfg)
 }
 
-func syncManifest(root string, excludes, includes []string) (SyncManifest, error) {
+func syncManifest(root string, excludes core.SyncExcludeRules, includes []string) (SyncManifest, error) {
 	return core.BuildSyncManifestFiltered(root, excludes, includes)
 }
 


### PR DESCRIPTION
## Summary

- propagate exclude-rule provenance through sync manifests and provider adapters so ambiguous Crabbox built-ins preserve tracked regular files while `sync.exclude` and `.crabboxignore` remain authoritative
- keep deletion and fingerprint behavior consistent with effective ordered rules, and report protected paths with bounded sync-plan annotations
- make watch traversal prune untracked artifact trees while observing tracked-protected ancestor chains and Git index transitions

## Verification

- focused `go test -race ./internal/cli` regression set for manifest protection, rule provenance, sync-plan annotations, watch traversal/index transitions, and rsync file lists
- `go vet ./...`
- `scripts/check-docs.sh`
- `git diff origin/main...HEAD --check`
- fresh-repository black-box `sync-plan` proof covering tracked `target`/`dist`, untracked artifact output, tracked `node_modules`, annotations, and explicit `sync.exclude`

Fixes https://github.com/openclaw/crabbox/issues/1231
