### PR TITLE
fix(local-container): retain claim during readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Clarified that POSIX SSH `run --script` uploads a content-hashed standalone copy whose `$0` points under `.crabbox/scripts/`, and documented synced-path execution for scripts that need adjacent repository assets. Thanks @coygeek.
 - Classified per-run local-container cgroup OOM-kill increments as memory resource exhaustion, with bounded evidence collection and actionable memory/concurrency guidance while ignoring historical OOM counts on reused leases. Thanks @coygeek.
 - Made bare `crabbox doctor` report compiled-default provider provenance and skip that unchosen provider's credential readiness without weakening explicitly configured provider checks. Thanks @coygeek.
+- Retained keep-enabled local containers after SSH readiness failures behind durable exact-resource pending claims, with fenced recovery and cleanup commands, while preserving full rollback for one-shot leases. Thanks @coygeek.
 - Reconciled exact-owned Azure VM, NIC, public IP, and managed OS disk orphan sets with stable-identity quarantine and fail-closed durable deletion progress. Thanks @chsong1.
 - Invalidated adopted Actions workspace readiness markers before full resync and rehydrated the canonical workspace before running commands. Thanks @vincentkoc.
 - Stopped sparse-checkout and skip-worktree omissions from deleting in-scope remote files, and kept staged gitlink removals out of file-deletion manifests. Thanks @vincentkoc.

--- a/docs/commands/warmup.md
+++ b/docs/commands/warmup.md
@@ -45,6 +45,14 @@ stderr.
 Warmup records a local claim binding the lease to the current repo checkout. Use
 `--reclaim` to overwrite an existing claim for that lease.
 
+For `local-container`, the default `--keep=true` also covers SSH readiness
+failure: once Docker has returned an exact container identity, Crabbox persists
+a scoped `provisioning` claim before inspecting the container or waiting for
+SSH. Cancellation or timeout retains that pending lease and prints exact
+inspect, reclaim, and cleanup commands.
+`warmup --keep=false` rolls the container and all per-lease local state back
+instead.
+
 ## Lifetime: TTL and idle timeout
 
 - `--ttl <duration>` is the maximum wall-clock lifetime. Default `90m`.

--- a/docs/features/lifecycle-cleanup.md
+++ b/docs/features/lifecycle-cleanup.md
@@ -185,6 +185,15 @@ validate that the current repo matches the claim; deleting a lease removes its
 claim. Move a claim to a different repo deliberately with `--reclaim`. See
 [Identifiers](identifiers.md) for the claim file format and location.
 
+Providers may durably publish an exact-resource claim with the generic
+`state=provisioning` label before post-create readiness completes. Such a claim
+is recovery authority, not proof that the lease is ready: inventory and status
+must keep it non-ready until a fenced claim update records `state=ready`.
+Provider adapters own the immutable resource identity and routing scope needed
+to inspect or delete that pending resource. Cleanup must compare the unchanged
+claim under its lifecycle fence before mutation so an old readiness or cleanup
+attempt cannot overwrite or delete a newer claim.
+
 ## Related docs
 
 - [stop command](../commands/stop.md)

--- a/docs/providers/local-container.md
+++ b/docs/providers/local-container.md
@@ -198,16 +198,41 @@ metadata updates.
    required.
 5. With `--browser`, the container installs a real package-manager browser where
    the image provides one and writes `/var/lib/crabbox/browser.env`.
-6. Crabbox waits for SSH readiness, syncs tracked and non-ignored files into
+6. As soon as the runtime returns an exact container ID, before the first
+   inspect or readiness probe, Crabbox durably records a `state=provisioning`
+   claim bound to that ID, the runtime context/endpoint/daemon identity, SSH
+   key, bootstrap directory, and host-work-root ownership. Later inspect and
+   endpoint discoveries are compare-and-swap claim transitions. The claim
+   changes to `state=ready` only after the SSH readiness check succeeds.
+7. Crabbox syncs tracked and non-ignored files into
    `localContainer.workRoot`, then drives the command over the normal SSH
    executor.
-7. `status`, `list`, and `stop` inspect or remove labeled containers.
-8. `cleanup --provider docker` removes stopped containers and running
+8. `status`, `list`, and `stop` inspect or remove labeled containers.
+9. `cleanup --provider docker` removes stopped containers and running
    non-`keep` containers whose local claim or lease labels are stale past the
    idle timeout plus a safety grace period.
-9. If a local claim remains after its container was removed outside Crabbox,
+10. If a local claim remains after its container was removed outside Crabbox,
    `crabbox stop --provider docker <lease-or-slug>` removes the stale claim and
    stored SSH key.
+
+When `warmup` or `run --keep` creates the container but SSH readiness is
+canceled, fails, or times out, Crabbox keeps the exact pending claim, container,
+key, and bootstrap directory. The failed command prints copyable, runtime-scoped
+`inspect`, `run --reclaim --sync-only`, and `stop` commands. Pending claims stay
+visible in inventory as `provisioning` (or `missing` with a provisioning label
+if the container disappeared) and never report ready. `stop` accepts the exact
+pending claim without requiring a successful intervening run and fences the
+container deletion against concurrent claim changes. The provider cleanup sweep
+leaves a missing keep-enabled pending claim for explicit recovery or `stop`
+instead of discarding its ownership evidence; a missing non-keep pending claim
+is fenced and removed with its key and bootstrap state. Fresh one-shot runs and
+`warmup --keep=false` still remove the container, key, bootstrap directory, and
+claim when readiness does not complete.
+
+Named Docker contexts and Podman connections are included in those recovery
+commands. Custom runtime endpoints remain private in the local claim rather
+than being printed; exact-ID commands hydrate that route from the claim before
+their first runtime lookup and reject a changed endpoint or daemon identity.
 
 ## Limits and caveats
 

--- a/internal/providers/localcontainer/backend.go
+++ b/internal/providers/localcontainer/backend.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -20,12 +21,15 @@ import (
 )
 
 const (
-	providerName        = "local-container"
-	sshPort             = "2222"
-	workRootMarkerName  = ".crabbox-local-container-work-root"
-	dockerSocketInGuest = "/var/run/docker.sock"
-	rollbackTimeout     = 10 * time.Second
-	cgroupEvidenceLimit = 4 << 10
+	providerName          = "local-container"
+	sshPort               = "2222"
+	workRootMarkerName    = ".crabbox-local-container-work-root"
+	dockerSocketInGuest   = "/var/run/docker.sock"
+	rollbackTimeout       = 10 * time.Second
+	cgroupEvidenceLimit   = 4 << 10
+	pendingClaimState     = "provisioning"
+	pendingRecoveryKind   = "ssh-readiness-pending"
+	pendingRecoveryReason = "post-create failure; exact claim retained"
 )
 
 var cgroupOOMCounterPaths = []string{
@@ -34,9 +38,16 @@ var cgroupOOMCounterPaths = []string{
 }
 
 type backend struct {
-	spec core.ProviderSpec
-	cfg  core.Config
-	rt   core.Runtime
+	spec                   core.ProviderSpec
+	cfg                    core.Config
+	rt                     core.Runtime
+	waitForSSHReady        func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error
+	captureRuntimeScope    func(context.Context, core.Config) (checkpointScope, error)
+	validateRuntimeScope   func(context.Context, checkpointScope) error
+	confirmContainerAbsent func(context.Context, string) (bool, error)
+	removeAll              func(string) error
+	beforeCleanupMutation  func(string)
+	afterClaimCleanup      func(string)
 }
 
 type inspectContainer struct {
@@ -70,7 +81,16 @@ type inspectPort struct {
 
 func newBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	applyDefaults(&cfg)
-	return &backend{spec: spec, cfg: cfg, rt: rt}
+	b := &backend{spec: spec, cfg: cfg, rt: rt, waitForSSHReady: core.WaitForSSHReady, removeAll: os.RemoveAll}
+	b.captureRuntimeScope = func(ctx context.Context, cfg core.Config) (checkpointScope, error) {
+		if isPodmanRuntime(cfg.LocalContainer.Runtime) {
+			return podmanScopeForConfig(ctx, cfg)
+		}
+		return checkpointScopeForServer(ctx, cfg, core.Server{})
+	}
+	b.validateRuntimeScope = validateCheckpointScope
+	b.confirmContainerAbsent = b.exactContainerAbsent
+	return b
 }
 
 func (b *backend) Spec() core.ProviderSpec { return b.spec }
@@ -152,6 +172,17 @@ func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.Le
 	if err := validateCheckpointFork(ctx, cfg); err != nil {
 		return core.LeaseTarget{}, err
 	}
+	if len(cfg.LocalContainer.CheckpointMetadata) == 0 {
+		scope, err := b.captureRuntimeScope(ctx, cfg)
+		if err != nil {
+			return core.LeaseTarget{}, err
+		}
+		if strings.TrimSpace(scope.DaemonID) == "" {
+			return core.LeaseTarget{}, core.Exit(2, "local-container runtime identity is unavailable; refusing to create an unscoped lease")
+		}
+		cfg.LocalContainer.CheckpointMetadata = checkpointScopeMetadata(scope)
+		b.cfg.LocalContainer.CheckpointMetadata = checkpointScopeMetadata(scope)
+	}
 	leaseID := core.NewLeaseID()
 	containers, err := b.listContainers(ctx)
 	if err != nil {
@@ -164,6 +195,10 @@ func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.Le
 	slug, err := core.AllocateDirectLeaseSlug(leaseID, req.RequestedSlug, servers)
 	if err != nil {
 		return core.LeaseTarget{}, err
+	}
+	claimScope := b.claimScope(ctx)
+	if strings.TrimSpace(claimScope) == "" {
+		return core.LeaseTarget{}, core.Exit(2, "local-container runtime scope is unavailable; refusing to create an unscoped lease")
 	}
 	keyPath, publicKey, err := core.EnsureTestboxKeyForConfig(cfg, leaseID)
 	if err != nil {
@@ -178,48 +213,348 @@ func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.Le
 	cfg.SSHKey = keyPath
 	name := core.LeaseProviderName(leaseID, slug)
 	fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s runtime=%s image=%s keep=%v\n", providerName, leaseID, slug, cfg.LocalContainer.Runtime, cfg.LocalContainer.Image, req.Keep)
-	containerID, bootstrapDir, err := b.createContainer(ctx, cfg, name, leaseID, slug, publicKey, req.Keep)
+	containerID, bootstrapDir, createErr := b.createContainer(ctx, cfg, name, leaseID, slug, publicKey, req.Keep)
+	if containerID == "" {
+		return core.LeaseTarget{}, createErr
+	}
+	lease := createdPendingLease(cfg, containerID, leaseID, slug, bootstrapDir, req.Keep)
+	pendingClaim, err := b.publishCreatedPendingClaim(leaseID, slug, claimScope, req, cfg, lease)
 	if err != nil {
-		if req.Keep && containerID != "" {
-			cleanupKey = false
-		}
-		return core.LeaseTarget{}, err
-	}
-	if req.Keep {
 		cleanupKey = false
+		rollbackErr := b.rollbackUnclaimedContainer(containerID, leaseID, bootstrapDir, &lease.Server)
+		if rollbackErr != nil {
+			if retryClaim, retryErr := b.publishCreatedPendingClaim(leaseID, slug, claimScope, req, cfg, lease); retryErr == nil {
+				pendingClaim = retryClaim
+				b.printPendingRecovery(leaseID, slug, pendingClaim, errors.Join(err, rollbackErr))
+				return core.LeaseTarget{}, errors.Join(err, rollbackErr)
+			}
+		}
+		return core.LeaseTarget{}, errors.Join(err, rollbackErr)
 	}
-	cleanupContainer := func() {
+	cleanupKey = false
+	if createErr != nil {
 		if req.Keep {
-			return
+			b.printPendingRecovery(leaseID, slug, pendingClaim, createErr)
+			return core.LeaseTarget{}, createErr
 		}
-		if err := b.removeContainer(context.Background(), containerID); err != nil {
-			return
+		rollbackErr := b.rollbackPendingLease(pendingClaim, lease, bootstrapDir)
+		if rollbackErr != nil {
+			b.printPendingRecovery(leaseID, slug, pendingClaim, rollbackErr)
 		}
-		if bootstrapDir != "" && trustedBootstrapDir(bootstrapDir) {
-			_ = os.RemoveAll(bootstrapDir)
-		}
+		return core.LeaseTarget{}, errors.Join(createErr, rollbackErr)
 	}
 	container, err := b.inspectContainer(ctx, containerID)
 	if err != nil {
-		cleanupContainer()
-		return core.LeaseTarget{}, err
+		if req.Keep {
+			b.printPendingRecovery(leaseID, slug, pendingClaim, err)
+			return core.LeaseTarget{}, err
+		}
+		rollbackErr := b.rollbackPendingLease(pendingClaim, lease, bootstrapDir)
+		if rollbackErr != nil {
+			b.printPendingRecovery(leaseID, slug, pendingClaim, rollbackErr)
+		}
+		return core.LeaseTarget{}, errors.Join(err, rollbackErr)
 	}
-	lease, err := b.prepareLease(ctx, cfg, container, leaseID, slug, true)
+	lease = b.pendingLease(cfg, container, leaseID, slug)
+	markPendingLease(&lease.Server)
+	updatedPendingClaim, err := core.UpdateLeaseClaimEndpointIfUnchanged(leaseID, pendingClaim, lease.Server, lease.SSH)
 	if err != nil {
-		cleanupContainer()
-		return core.LeaseTarget{}, err
+		retained, reconcileErr := b.reconcileChangedClaim(lease, bootstrapDir)
+		if retained {
+			b.printPendingRecovery(leaseID, slug, pendingClaim, err)
+		}
+		return core.LeaseTarget{}, errors.Join(err, reconcileErr)
 	}
-	if err := core.ClaimLeaseForRepoProviderScopePondCacheVolumes(leaseID, slug, providerName, b.claimScope(ctx), cfg.Pond, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, core.CacheVolumeStickyDiskSpecs(cfg.Cache.Volumes)); err != nil {
-		cleanupContainer()
-		return core.LeaseTarget{}, err
+	pendingClaim = updatedPendingClaim
+	lease, err = b.waitForContainerEndpoint(ctx, cfg, containerID, leaseID, slug)
+	if err != nil {
+		retained, reconcileErr := b.reconcileReadinessFailure(req.Keep, pendingClaim, lease, bootstrapDir)
+		if retained {
+			b.printPendingRecovery(leaseID, slug, pendingClaim, err)
+		}
+		return core.LeaseTarget{}, errors.Join(err, reconcileErr)
 	}
-	if err := core.UpdateLeaseClaimEndpoint(leaseID, lease.Server, lease.SSH); err != nil {
-		cleanupContainer()
-		return core.LeaseTarget{}, err
+	markPendingLease(&lease.Server)
+	updatedPendingClaim, err = core.UpdateLeaseClaimEndpointIfUnchanged(leaseID, pendingClaim, lease.Server, lease.SSH)
+	if err != nil {
+		retained, reconcileErr := b.reconcileChangedClaim(lease, bootstrapDir)
+		if retained {
+			b.printPendingRecovery(leaseID, slug, pendingClaim, err)
+			return core.LeaseTarget{}, err
+		}
+		return core.LeaseTarget{}, errors.Join(err, reconcileErr)
 	}
-	cleanupKey = false
+	pendingClaim = updatedPendingClaim
+	if err := b.waitForSSHReady(ctx, &lease.SSH, b.rt.Stderr, "local container ssh", core.BootstrapWaitTimeout(cfg)); err != nil {
+		retained, reconcileErr := b.reconcileReadinessFailure(req.Keep, pendingClaim, lease, bootstrapDir)
+		if retained {
+			b.printPendingRecovery(leaseID, slug, pendingClaim, err)
+		}
+		return core.LeaseTarget{}, errors.Join(err, reconcileErr)
+	}
+	lease.Server.Status = "ready"
+	lease.Server.Labels = cloneLabels(lease.Server.Labels)
+	lease.Server.Labels["state"] = "ready"
+	delete(lease.Server.Labels, "recovery")
+	readyClaim, err := core.UpdateLeaseClaimEndpointIfUnchanged(leaseID, pendingClaim, lease.Server, lease.SSH)
+	if err != nil {
+		retained, reconcileErr := b.reconcileChangedClaim(lease, bootstrapDir)
+		if retained {
+			b.printPendingRecovery(leaseID, slug, pendingClaim, err)
+			return core.LeaseTarget{}, err
+		}
+		return core.LeaseTarget{}, errors.Join(err, reconcileErr)
+	}
+	core.SetServerLeaseClaimSnapshot(&lease.Server, readyClaim, true)
 	fmt.Fprintf(b.rt.Stderr, "provisioned lease=%s container=%s state=ready\n", leaseID, shortID(container.ID))
 	return lease, nil
+}
+
+func createdPendingLease(cfg core.Config, containerID, leaseID, slug, bootstrapDir string, keep bool) core.LeaseTarget {
+	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", keep, time.Now().UTC())
+	labels["state"] = pendingClaimState
+	labels["recovery"] = pendingRecoveryKind
+	labels["ssh_key_owned"] = "true"
+	labels["bootstrap_owned"] = "true"
+	labels["bootstrap_dir"] = bootstrapDir
+	labels["runtime"] = cfg.LocalContainer.Runtime
+	labels["image"] = localContainerDisplayImage(cfg)
+	labels["ssh_user"] = cfg.LocalContainer.User
+	labels["ssh_port"] = sshPort
+	labels["docker_socket"] = boolEnv(cfg.LocalContainer.DockerSocket)
+	containerWorkRoot := cfg.LocalContainer.WorkRoot
+	if cfg.LocalContainer.DockerSocket {
+		hostWorkRoot, resolvedWorkRoot := dockerSocketWorkRoots(cfg)
+		labels["host_work_root"] = hostWorkRoot
+		containerWorkRoot = resolvedWorkRoot
+	}
+	labels["work_root"] = containerWorkRoot
+	for _, key := range checkpointScopeMetadataKeys {
+		if value := strings.TrimSpace(cfg.LocalContainer.CheckpointMetadata[key]); value != "" {
+			labels[key] = value
+		}
+	}
+	if contextName := strings.TrimSpace(cfg.LocalContainer.CheckpointMetadata[checkpointMetadataContext]); contextName != "" {
+		labels["runtime_context"] = contextName
+	}
+	server := core.Server{
+		CloudID:  containerID,
+		Provider: providerName,
+		Name:     core.LeaseProviderName(leaseID, slug),
+		Status:   pendingClaimState,
+		Labels:   labels,
+	}
+	server.ServerType.Name = localContainerDisplayImage(cfg)
+	target := core.SSHTargetFromConfig(cfg, "")
+	target.Port = ""
+	target.ReadyCheck = localContainerReadyCheck(cfg)
+	return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}
+}
+
+func (b *backend) publishCreatedPendingClaim(leaseID, slug, claimScope string, req core.AcquireRequest, cfg core.Config, lease core.LeaseTarget) (core.LeaseClaim, error) {
+	claim, err := core.ClaimLeaseTargetForRepoConfigScopeIfUnchangedDurable(
+		leaseID,
+		slug,
+		cfg,
+		claimScope,
+		lease.Server,
+		lease.SSH,
+		req.Repo.Root,
+		cfg.IdleTimeout,
+		req.Reclaim,
+		core.LeaseClaim{},
+		false,
+	)
+	if err == nil && claim.LeaseID != leaseID {
+		err = core.Exit(2, "local-container pending claim was not persisted for lease=%s", leaseID)
+	}
+	return claim, err
+}
+
+func (b *backend) pendingLease(cfg core.Config, container inspectContainer, leaseID, slug string) core.LeaseTarget {
+	server := b.serverFromContainer(container, cfg)
+	if user := strings.TrimSpace(server.Labels["ssh_user"]); user != "" {
+		cfg.LocalContainer.User = user
+		cfg.SSHUser = user
+	}
+	if root := strings.TrimSpace(server.Labels["work_root"]); root != "" {
+		cfg.LocalContainer.WorkRoot = root
+		cfg.WorkRoot = root
+	}
+	host, port, _ := containerSSHHostPort(container)
+	if keyPath, err := core.TestboxKeyPath(leaseID); err == nil {
+		if _, statErr := os.Stat(keyPath); statErr == nil {
+			cfg.SSHKey = keyPath
+		}
+	}
+	target := core.SSHTargetFromConfig(cfg, host)
+	target.Port = port
+	target.ReadyCheck = localContainerReadyCheck(cfg)
+	return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}
+}
+
+func (b *backend) waitForContainerEndpoint(ctx context.Context, cfg core.Config, containerID, leaseID, slug string) (core.LeaseTarget, error) {
+	deadline := time.Now().Add(30 * time.Second)
+	var lastErr error
+	for {
+		if err := context.Cause(ctx); err != nil {
+			return core.LeaseTarget{LeaseID: leaseID, Server: core.Server{CloudID: containerID}}, err
+		}
+		container, err := b.inspectContainer(ctx, containerID)
+		if err == nil {
+			lease, prepareErr := b.prepareLease(ctx, cfg, container, leaseID, slug, false)
+			if prepareErr == nil {
+				return lease, nil
+			}
+			lastErr = prepareErr
+		} else {
+			lastErr = err
+		}
+		if time.Now().After(deadline) {
+			return core.LeaseTarget{LeaseID: leaseID, Server: core.Server{CloudID: containerID}}, core.Exit(5, "timed out waiting for SSH port on local-container %s: %v", shortID(containerID), lastErr)
+		}
+		timer := time.NewTimer(100 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return core.LeaseTarget{LeaseID: leaseID, Server: core.Server{CloudID: containerID}}, context.Cause(ctx)
+		case <-timer.C:
+		}
+	}
+}
+
+func markPendingLease(server *core.Server) {
+	if server.Labels == nil {
+		server.Labels = map[string]string{}
+	} else {
+		server.Labels = cloneLabels(server.Labels)
+	}
+	server.Status = pendingClaimState
+	server.Labels["state"] = pendingClaimState
+	server.Labels["recovery"] = pendingRecoveryKind
+	server.Labels["ssh_key_owned"] = "true"
+	server.Labels["bootstrap_owned"] = "true"
+}
+
+func (b *backend) rollbackUnclaimedContainer(containerID, leaseID, bootstrapDir string, server *core.Server) error {
+	lease := core.LeaseTarget{LeaseID: leaseID, Server: core.Server{CloudID: containerID}}
+	if server != nil {
+		lease.Server = *server
+		lease.Server.CloudID = containerID
+	}
+	retained, err := b.reconcileChangedClaim(lease, bootstrapDir)
+	if retained {
+		return errors.Join(err, core.Exit(2, "lease %s claim changed to own container %s; refusing stale rollback", leaseID, shortID(containerID)))
+	}
+	return err
+}
+
+func (b *backend) reconcileChangedClaim(lease core.LeaseTarget, bootstrapDir string) (bool, error) {
+	rollbackCtx, cancel := context.WithTimeout(context.Background(), rollbackTimeout)
+	defer cancel()
+	retained := false
+	err := core.WithDurableLeaseClaimLock(lease.LeaseID, func(claim *core.LeaseClaim, exists bool, _ func() error) error {
+		if exists && strings.TrimSpace(claim.CloudID) == strings.TrimSpace(lease.Server.CloudID) {
+			retained = true
+			return nil
+		}
+		if err := b.removeContainer(rollbackCtx, lease.Server.CloudID); err != nil {
+			return fmt.Errorf("rollback unclaimed local-container resource %s: %w", shortID(lease.Server.CloudID), err)
+		}
+		var cleanupErrs []error
+		if hostRoot := hostLeaseWorkRoot(lease); hostRoot != "" {
+			winningHostRoot := ""
+			if exists {
+				winningHostRoot = hostLeaseWorkRoot(core.LeaseTarget{LeaseID: claim.LeaseID, Server: core.Server{Labels: claim.Labels}})
+			}
+			if hostRoot != winningHostRoot {
+				if err := b.removeAll(hostRoot); err != nil {
+					cleanupErrs = append(cleanupErrs, fmt.Errorf("remove local-container host work root %s: %w", hostRoot, err))
+				}
+			}
+		}
+		if bootstrapDir != "" && trustedBootstrapDir(bootstrapDir) {
+			winningBootstrapDir := ""
+			if exists {
+				winningBootstrapDir = strings.TrimSpace(claim.Labels["bootstrap_dir"])
+			}
+			if bootstrapDir != winningBootstrapDir {
+				if err := b.removeAll(bootstrapDir); err != nil {
+					cleanupErrs = append(cleanupErrs, fmt.Errorf("remove local-container bootstrap directory %s: %w", bootstrapDir, err))
+				}
+			}
+		}
+		if !exists {
+			core.RemoveStoredTestboxKey(lease.LeaseID)
+		}
+		return errors.Join(cleanupErrs...)
+	})
+	return retained, err
+}
+
+func (b *backend) reconcileReadinessFailure(keep bool, expected core.LeaseClaim, lease core.LeaseTarget, bootstrapDir string) (bool, error) {
+	lease.Server = mergeLocalContainerClaim(lease.Server, expected)
+	if lease.Server.CloudID == "" {
+		lease.Server.CloudID = expected.CloudID
+	}
+	if !keep {
+		rollbackErr := b.rollbackPendingLease(expected, lease, bootstrapDir)
+		if rollbackErr == nil {
+			return false, nil
+		}
+		retained, reconcileErr := b.reconcileChangedClaim(lease, bootstrapDir)
+		return retained, errors.Join(rollbackErr, reconcileErr)
+	}
+	return b.reconcileChangedClaim(lease, bootstrapDir)
+}
+
+func (b *backend) rollbackPendingLease(expected core.LeaseClaim, lease core.LeaseTarget, bootstrapDir string) error {
+	lease.Server = mergeLocalContainerClaim(lease.Server, expected)
+	if lease.Server.CloudID == "" {
+		lease.Server.CloudID = expected.CloudID
+	}
+	rollbackCtx, cancel := context.WithTimeout(context.Background(), rollbackTimeout)
+	defer cancel()
+	err := core.RemoveLeaseClaimIfUnchangedAfter(lease.LeaseID, expected, func() error {
+		if err := b.removeContainer(rollbackCtx, lease.Server.CloudID); err != nil {
+			return err
+		}
+		var cleanupErrs []error
+		if hostRoot := hostLeaseWorkRoot(lease); hostRoot != "" {
+			if err := b.removeAll(hostRoot); err != nil {
+				cleanupErrs = append(cleanupErrs, fmt.Errorf("remove local-container host work root %s: %w", hostRoot, err))
+			}
+		}
+		if bootstrapDir != "" && trustedBootstrapDir(bootstrapDir) {
+			if err := b.removeAll(bootstrapDir); err != nil {
+				cleanupErrs = append(cleanupErrs, fmt.Errorf("remove local-container bootstrap directory %s: %w", bootstrapDir, err))
+			}
+		}
+		core.RemoveStoredTestboxKey(lease.LeaseID)
+		return errors.Join(cleanupErrs...)
+	})
+	if b.afterClaimCleanup != nil {
+		b.afterClaimCleanup(lease.LeaseID)
+	}
+	return err
+}
+
+func (b *backend) printPendingRecovery(leaseID, slug string, claim core.LeaseClaim, _ error) {
+	runtimeName := firstNonBlank(claim.Labels[checkpointMetadataRuntime], claim.Labels["runtime"], b.cfg.LocalContainer.Runtime, "docker")
+	envPrefix := []string{"CRABBOX_LOCAL_CONTAINER_RUNTIME=" + core.ShellQuote(runtimeName)}
+	scope := checkpointScopeFromMetadata(checkpointScopeMetadataFromLabels(claim.Labels), runtimeName)
+	if isDockerRuntime(runtimeName) && scope.Context != "" {
+		envPrefix = append(envPrefix, "DOCKER_CONTEXT="+core.ShellQuote(scope.Context))
+	}
+	if isPodmanRuntime(runtimeName) && scope.Context != "" && scope.Context != "default" && scope.Host == "" {
+		envPrefix = append(envPrefix, "CONTAINER_CONNECTION="+core.ShellQuote(scope.Context))
+	}
+	routeEnv := strings.Join(envPrefix, " ")
+	idArg := core.ShellQuote(leaseID)
+	fmt.Fprintf(b.rt.Stderr, "retained provider=%s lease=%s slug=%s state=%s reason=%q\n", providerName, leaseID, blank(slug, "-"), pendingClaimState, pendingRecoveryReason)
+	fmt.Fprintf(b.rt.Stderr, "inspect: %s crabbox inspect --provider %s --id %s --json\n", routeEnv, providerName, idArg)
+	fmt.Fprintf(b.rt.Stderr, "reclaim: %s crabbox run --provider %s --id %s --reclaim --keep --sync-only\n", routeEnv, providerName, idArg)
+	fmt.Fprintf(b.rt.Stderr, "cleanup: %s crabbox stop --provider %s --id %s\n", routeEnv, providerName, idArg)
 }
 
 func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.LeaseTarget, error) {
@@ -234,6 +569,15 @@ func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.Le
 		}
 		return core.LeaseTarget{}, err
 	}
+	if leaseID != "" {
+		if claim, ok, exact, claimErr := core.ResolveLeaseClaimForProviderWithExact(leaseID, providerName); claimErr != nil {
+			return core.LeaseTarget{}, claimErr
+		} else if ok && exact {
+			if _, scopeErr := b.applyCheckpointScopeLabels(ctx, claim.Labels); scopeErr != nil {
+				return core.LeaseTarget{}, scopeErr
+			}
+		}
+	}
 	cfg := b.configForRun()
 	readOnlyStatus := req.StatusOnly && !req.ReleaseOnly
 	if strings.TrimSpace(leaseID) == "" && (!readOnlyStatus || req.Reclaim) {
@@ -247,17 +591,119 @@ func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.Le
 		return core.LeaseTarget{}, localContainerOwnershipError(leaseID, container.ID)
 	}
 	if req.ReleaseOnly {
-		return core.LeaseTarget{Server: b.serverFromContainer(container, cfg), LeaseID: leaseID}, nil
+		claim, err := b.requireExactLocalContainerClaim(ctx, leaseID, container.ID)
+		if err != nil {
+			return core.LeaseTarget{}, err
+		}
+		server := mergeLocalContainerClaim(b.serverFromContainer(container, cfg), claim)
+		core.SetServerLeaseClaimSnapshot(&server, claim, true)
+		return core.LeaseTarget{Server: server, LeaseID: leaseID}, nil
 	}
-	lease, err := b.prepareLease(ctx, cfg, container, leaseID, slug, false)
-	if err != nil {
-		return core.LeaseTarget{}, err
+	var exactClaim core.LeaseClaim
+	if owned {
+		claim, ok, exact, claimErr := core.ResolveLeaseClaimForProviderWithExact(leaseID, providerName)
+		if claimErr != nil {
+			return core.LeaseTarget{}, claimErr
+		}
+		legacyReclaim := req.Reclaim && !hasCompleteCapturedRuntimeScope(claim.Labels) && strings.TrimSpace(claim.ProviderScope) == strings.TrimSpace(b.claimScope(ctx))
+		if !ok || !exact || claim.CloudID != container.ID || (!b.claimMatchesCurrentScope(ctx, claim) && !legacyReclaim) {
+			return core.LeaseTarget{}, localContainerOwnershipError(leaseID, container.ID)
+		}
+		exactClaim = claim
 	}
-	if req.Repo.Root != "" && (!readOnlyStatus || req.Reclaim) {
-		if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, slug, providerName, b.claimScope(ctx), cfg.Pond, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, lease.Server, lease.SSH); err != nil {
+	var lease core.LeaseTarget
+	if isPendingLocalContainerClaim(exactClaim) {
+		lease = b.pendingLease(cfg, container, leaseID, slug)
+		if req.Prepare {
+			keep := strings.EqualFold(exactClaim.Labels["keep"], "true")
+			bootstrapDir := strings.TrimSpace(exactClaim.Labels["bootstrap_dir"])
+			lease, err = b.waitForContainerEndpoint(ctx, cfg, container.ID, leaseID, slug)
+			if err != nil {
+				retained, reconcileErr := b.reconcileReadinessFailure(keep, exactClaim, lease, bootstrapDir)
+				if retained {
+					b.printPendingRecovery(leaseID, slug, exactClaim, err)
+				}
+				return core.LeaseTarget{}, errors.Join(err, reconcileErr)
+			}
+			markPendingLease(&lease.Server)
+			updatedClaim, updateErr := core.UpdateLeaseClaimEndpointIfUnchanged(leaseID, exactClaim, lease.Server, lease.SSH)
+			err = updateErr
+			if err != nil {
+				retained, reconcileErr := b.reconcileChangedClaim(lease, bootstrapDir)
+				if retained {
+					b.printPendingRecovery(leaseID, slug, exactClaim, err)
+				}
+				return core.LeaseTarget{}, errors.Join(err, reconcileErr)
+			}
+			exactClaim = updatedClaim
+			if err := b.waitForSSHReady(ctx, &lease.SSH, b.rt.Stderr, "local container ssh", core.BootstrapWaitTimeout(cfg)); err != nil {
+				retained, reconcileErr := b.reconcileReadinessFailure(keep, exactClaim, lease, bootstrapDir)
+				if retained {
+					b.printPendingRecovery(leaseID, slug, exactClaim, err)
+				}
+				return core.LeaseTarget{}, errors.Join(err, reconcileErr)
+			}
+			lease.Server.Status = "ready"
+			lease.Server.Labels = cloneLabels(lease.Server.Labels)
+			lease.Server.Labels["state"] = "ready"
+			delete(lease.Server.Labels, "recovery")
+			updatedClaim, updateErr = core.UpdateLeaseClaimEndpointIfUnchanged(leaseID, exactClaim, lease.Server, lease.SSH)
+			err = updateErr
+			if err != nil {
+				retained, reconcileErr := b.reconcileChangedClaim(lease, bootstrapDir)
+				if retained {
+					b.printPendingRecovery(leaseID, slug, exactClaim, err)
+				}
+				return core.LeaseTarget{}, errors.Join(err, reconcileErr)
+			}
+			exactClaim = updatedClaim
+		}
+	} else {
+		lease, err = b.prepareLease(ctx, cfg, container, leaseID, slug, false)
+		if err != nil {
 			return core.LeaseTarget{}, err
 		}
 	}
+	if owned {
+		lease.Server = mergeLocalContainerClaim(lease.Server, exactClaim)
+		core.SetServerLeaseClaimSnapshot(&lease.Server, exactClaim, true)
+	}
+	if req.Reclaim && (!owned || !hasCompleteCapturedRuntimeScope(exactClaim.Labels)) {
+		scope, scopeErr := b.captureRuntimeScope(ctx, cfg)
+		if scopeErr != nil {
+			return core.LeaseTarget{}, scopeErr
+		}
+		if strings.TrimSpace(scope.DaemonID) == "" {
+			return core.LeaseTarget{}, core.Exit(2, "local-container runtime identity is unavailable; refusing reclaim")
+		}
+		metadata := checkpointScopeMetadata(scope)
+		cfg.LocalContainer.CheckpointMetadata = metadata
+		b.cfg.LocalContainer.CheckpointMetadata = metadata
+		if lease.Server.Labels == nil {
+			lease.Server.Labels = map[string]string{}
+		}
+		for key, value := range metadata {
+			if strings.TrimSpace(value) != "" {
+				lease.Server.Labels[key] = value
+			}
+		}
+	}
+	if req.Repo.Root != "" && (!readOnlyStatus || req.Reclaim) {
+		var claimErr error
+		if expected, exists, set := core.ServerLeaseClaimSnapshot(lease.Server); set {
+			var updated core.LeaseClaim
+			updated, claimErr = core.ClaimLeaseTargetForRepoConfigScopeIfUnchanged(leaseID, slug, cfg, b.claimScope(ctx), lease.Server, lease.SSH, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, expected, exists)
+			if claimErr == nil {
+				core.SetServerLeaseClaimSnapshot(&lease.Server, updated, true)
+			}
+		} else {
+			claimErr = core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, slug, providerName, b.claimScope(ctx), cfg.Pond, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, lease.Server, lease.SSH)
+		}
+		if claimErr != nil {
+			return core.LeaseTarget{}, claimErr
+		}
+	}
+	lease.Server.Labels = publicLocalContainerClaimLabels(lease.Server.Labels)
 	return lease, nil
 }
 
@@ -267,9 +713,44 @@ func (b *backend) List(ctx context.Context, _ core.ListRequest) ([]core.LeaseVie
 	if err != nil {
 		return nil, err
 	}
-	servers := make([]core.LeaseView, 0, len(containers))
+	claims, err := core.ListLeaseClaims()
+	if err != nil {
+		return nil, err
+	}
+	claimScope := b.claimScope(ctx)
+	claimsByLease := make(map[string]core.LeaseClaim, len(claims))
+	for _, claim := range claims {
+		if claim.Provider == providerName && claim.ProviderScope == claimScope {
+			claimsByLease[claim.LeaseID] = claim
+		}
+	}
+	servers := make([]core.LeaseView, 0, len(containers)+len(claimsByLease))
+	seenClaims := make(map[string]struct{}, len(containers))
 	for _, container := range containers {
-		servers = append(servers, b.serverFromContainer(container, cfg))
+		server := b.serverFromContainer(container, cfg)
+		leaseID := strings.TrimSpace(server.Labels["lease"])
+		if claim, ok := claimsByLease[leaseID]; ok && claim.CloudID == container.ID {
+			server = mergeLocalContainerClaim(server, claim)
+			seenClaims[leaseID] = struct{}{}
+		}
+		servers = append(servers, server)
+	}
+	for leaseID, claim := range claimsByLease {
+		if _, ok := seenClaims[leaseID]; ok || !isPendingLocalContainerClaim(claim) {
+			continue
+		}
+		labels := publicLocalContainerClaimLabels(claim.Labels)
+		labels["missing_container"] = "1"
+		server := core.Server{
+			CloudID:  claim.CloudID,
+			Provider: providerName,
+			Name:     core.LeaseProviderName(claim.LeaseID, claim.Slug),
+			Status:   "missing",
+			Labels:   labels,
+		}
+		server.PublicNet.IPv4.IP = claim.SSHHost
+		server.ServerType.Name = labels["server_type"]
+		servers = append(servers, server)
 	}
 	return servers, nil
 }
@@ -291,7 +772,11 @@ func (b *backend) Doctor(ctx context.Context, req core.DoctorRequest) (core.Doct
 
 func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest) error {
 	lease := req.Lease
-	appliedScope, err := b.applyCheckpointScopeLabels(ctx, lease.Server.Labels)
+	scopeLabels := lease.Server.Labels
+	if snapshot, exists, set := core.ServerLeaseClaimSnapshot(lease.Server); set && exists {
+		scopeLabels = snapshot.Labels
+	}
+	appliedScope, err := b.applyCheckpointScopeLabels(ctx, scopeLabels)
 	if err != nil {
 		return err
 	}
@@ -307,8 +792,8 @@ func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest
 	}
 	id := strings.TrimSpace(req.Lease.Server.CloudID)
 	if id == "" {
-		if b.releaseMissingClaim(lease) {
-			return nil
+		if handled, err := b.releaseMissingClaim(ctx, lease); handled || err != nil {
+			return err
 		}
 		container, leaseID, _, err := b.resolveContainer(ctx, req.Lease.LeaseID)
 		if err != nil {
@@ -323,27 +808,46 @@ func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest
 	if id == "" {
 		return core.Exit(2, "provider=%s release requires a container id", providerName)
 	}
-	if err := b.requireExactLocalContainerClaim(ctx, lease.LeaseID, id); err != nil {
-		return err
-	}
-	hostLeaseRoot := hostLeaseWorkRoot(lease)
-	bootstrapDir := strings.TrimSpace(lease.Server.Labels["bootstrap_dir"])
-	if err := b.removeContainer(ctx, id); err != nil {
-		return err
-	}
-	var cleanupErr error
-	if hostLeaseRoot != "" {
-		cleanupErr = os.RemoveAll(hostLeaseRoot)
-	}
-	if bootstrapDir != "" && trustedBootstrapDir(bootstrapDir) {
-		if err := os.RemoveAll(bootstrapDir); err != nil && cleanupErr == nil {
-			cleanupErr = err
+	claim, claimExists, snapshotSet := core.ServerLeaseClaimSnapshot(lease.Server)
+	if snapshotSet {
+		if !claimExists {
+			return localContainerOwnershipError(lease.LeaseID, id)
+		}
+		if err := b.validateExactLocalContainerClaim(ctx, claim, lease.LeaseID, id); err != nil {
+			return err
+		}
+	} else {
+		claim, err = b.requireExactLocalContainerClaim(ctx, lease.LeaseID, id)
+		if err != nil {
+			return err
 		}
 	}
-	core.RemoveLeaseClaim(lease.LeaseID)
-	core.RemoveStoredTestboxKey(lease.LeaseID)
-	if cleanupErr != nil {
-		return core.Exit(2, "remove local-container host work root %s: %v", hostLeaseRoot, cleanupErr)
+	lease.Server = mergeLocalContainerClaim(lease.Server, claim)
+	hostLeaseRoot := hostLeaseWorkRoot(lease)
+	bootstrapDir := strings.TrimSpace(lease.Server.Labels["bootstrap_dir"])
+	err = core.RemoveLeaseClaimIfUnchangedAfter(lease.LeaseID, claim, func() error {
+		if err := b.removeContainer(ctx, id); err != nil {
+			return err
+		}
+		var cleanupErrs []error
+		if hostLeaseRoot != "" {
+			if err := b.removeAll(hostLeaseRoot); err != nil {
+				cleanupErrs = append(cleanupErrs, fmt.Errorf("remove local-container host work root %s: %w", hostLeaseRoot, err))
+			}
+		}
+		if bootstrapDir != "" && trustedBootstrapDir(bootstrapDir) {
+			if err := b.removeAll(bootstrapDir); err != nil {
+				cleanupErrs = append(cleanupErrs, fmt.Errorf("remove local-container bootstrap directory %s: %w", bootstrapDir, err))
+			}
+		}
+		core.RemoveStoredTestboxKey(lease.LeaseID)
+		return errors.Join(cleanupErrs...)
+	})
+	if b.afterClaimCleanup != nil {
+		b.afterClaimCleanup(lease.LeaseID)
+	}
+	if err != nil {
+		return err
 	}
 	return nil
 }
@@ -376,28 +880,75 @@ func localContainerOwnershipError(leaseID, containerID string) error {
 	return core.Exit(4, "local-container lease %q has no exact local claim bound to container %q in the current runtime scope; adopt it with an explicit --reclaim reuse before stop", strings.TrimSpace(leaseID), strings.TrimSpace(containerID))
 }
 
-func (b *backend) requireExactLocalContainerClaim(ctx context.Context, leaseID, containerID string) error {
-	owned, _, err := b.localContainerClaimStatus(ctx, leaseID, containerID)
+func (b *backend) requireExactLocalContainerClaim(ctx context.Context, leaseID, containerID string) (core.LeaseClaim, error) {
+	claim, ok, exact, err := core.ResolveLeaseClaimForProviderWithExact(leaseID, providerName)
 	if err != nil {
-		return err
+		return core.LeaseClaim{}, err
 	}
-	if !owned {
+	if !ok || !exact {
+		return core.LeaseClaim{}, localContainerOwnershipError(leaseID, containerID)
+	}
+	if err := b.validateExactLocalContainerClaim(ctx, claim, leaseID, containerID); err != nil {
+		return core.LeaseClaim{}, err
+	}
+	return claim, nil
+}
+
+func (b *backend) validateExactLocalContainerClaim(ctx context.Context, claim core.LeaseClaim, leaseID, containerID string) error {
+	claimScope := strings.TrimSpace(claim.ProviderScope)
+	currentScope := strings.TrimSpace(b.claimScope(ctx))
+	if claim.LeaseID != strings.TrimSpace(leaseID) || claim.Provider != providerName ||
+		claim.CloudID == "" || claim.CloudID != strings.TrimSpace(containerID) ||
+		claimScope == "" || currentScope == "" || claimScope != currentScope {
+		return localContainerOwnershipError(leaseID, containerID)
+	}
+	if err := b.validateClaimRuntimeScope(ctx, claim); err != nil {
 		return localContainerOwnershipError(leaseID, containerID)
 	}
 	return nil
 }
 
-func (b *backend) releaseMissingClaim(lease core.LeaseTarget) bool {
+func (b *backend) releaseMissingClaim(ctx context.Context, lease core.LeaseTarget) (bool, error) {
 	leaseID := strings.TrimSpace(firstNonBlank(lease.LeaseID, lease.Server.Labels["lease"]))
 	if leaseID == "" || strings.TrimSpace(lease.Server.CloudID) != "" {
-		return false
+		return false, nil
 	}
 	if lease.Server.Labels["missing_container"] != "1" {
-		return false
+		return false, nil
 	}
-	core.RemoveLeaseClaim(leaseID)
-	core.RemoveStoredTestboxKey(leaseID)
-	return true
+	claim, claimExists, snapshotSet := core.ServerLeaseClaimSnapshot(lease.Server)
+	if !snapshotSet || !claimExists || claim.LeaseID != leaseID || claim.Provider != providerName || !b.claimMatchesCurrentScope(ctx, claim) {
+		return true, localContainerOwnershipError(leaseID, claim.CloudID)
+	}
+	err := core.RemoveLeaseClaimIfUnchangedAfter(leaseID, claim, func() error {
+		absent, err := b.confirmContainerAbsent(ctx, claim.CloudID)
+		if err != nil {
+			return err
+		}
+		if !absent {
+			return core.Exit(4, "local-container %s still exists; refusing to remove its claim", shortID(claim.CloudID))
+		}
+		var cleanupErrs []error
+		if hostRoot := hostLeaseWorkRoot(core.LeaseTarget{LeaseID: leaseID, Server: core.Server{Labels: claim.Labels}}); hostRoot != "" {
+			if err := b.removeAll(hostRoot); err != nil {
+				cleanupErrs = append(cleanupErrs, fmt.Errorf("remove local-container host work root %s: %w", hostRoot, err))
+			}
+		}
+		if bootstrapDir := strings.TrimSpace(claim.Labels["bootstrap_dir"]); bootstrapDir != "" && trustedBootstrapDir(bootstrapDir) {
+			if err := b.removeAll(bootstrapDir); err != nil {
+				cleanupErrs = append(cleanupErrs, fmt.Errorf("remove local-container bootstrap directory %s: %w", bootstrapDir, err))
+			}
+		}
+		core.RemoveStoredTestboxKey(leaseID)
+		return errors.Join(cleanupErrs...)
+	})
+	if b.afterClaimCleanup != nil {
+		b.afterClaimCleanup(leaseID)
+	}
+	if err != nil {
+		return true, err
+	}
+	return true, nil
 }
 
 func (b *backend) resolveMissingClaimForRelease(ctx context.Context, identifier string) (core.LeaseTarget, bool, error) {
@@ -418,11 +969,11 @@ func (b *backend) resolveMissingClaimForRelease(ctx context.Context, identifier 
 		"missing_container": "1",
 	}
 	for key, value := range claim.Labels {
-		if strings.TrimSpace(value) != "" {
+		if strings.TrimSpace(value) != "" && !privateLocalContainerScopeLabel(key) {
 			labels[key] = value
 		}
 	}
-	return core.LeaseTarget{
+	lease := core.LeaseTarget{
 		LeaseID: claim.LeaseID,
 		Server: core.Server{
 			Provider: providerName,
@@ -430,7 +981,9 @@ func (b *backend) resolveMissingClaimForRelease(ctx context.Context, identifier 
 			Status:   "missing",
 			Labels:   labels,
 		},
-	}, true, nil
+	}
+	core.SetServerLeaseClaimSnapshot(&lease.Server, claim, true)
+	return lease, true, nil
 }
 
 func localContainerClaimByIDOrSlug(identifier string) (core.LeaseClaim, bool, error) {
@@ -473,12 +1026,57 @@ func (b *backend) claimMatchesCurrentScope(ctx context.Context, claim core.Lease
 	if claimScope == "" {
 		return true
 	}
-	return claimScope == strings.TrimSpace(b.claimScope(ctx))
+	if claimScope != strings.TrimSpace(b.claimScope(ctx)) {
+		return false
+	}
+	return b.validateClaimRuntimeScope(ctx, claim) == nil
+}
+
+func (b *backend) validateClaimRuntimeScope(ctx context.Context, claim core.LeaseClaim) error {
+	metadata := checkpointScopeMetadataFromLabels(claim.Labels)
+	if !hasCompleteCapturedRuntimeScope(claim.Labels) {
+		return core.Exit(4, "local-container claim lacks captured runtime identity")
+	}
+	expected := checkpointScopeFromMetadata(metadata, claim.Labels["runtime"])
+	currentMetadata := b.cfg.LocalContainer.CheckpointMetadata
+	if len(currentMetadata) == 0 {
+		return core.Exit(4, "local-container captured runtime scope is not hydrated")
+	}
+	current := checkpointScopeFromMetadata(currentMetadata, b.cfg.LocalContainer.Runtime)
+	if !sameCheckpointScope(expected, current) {
+		return core.Exit(4, "local-container captured runtime scope changed")
+	}
+	if err := b.validateRuntimeScope(ctx, expected); err != nil {
+		return core.Exit(4, "local-container captured runtime identity changed")
+	}
+	return nil
+}
+
+func hasCompleteCapturedRuntimeScope(labels map[string]string) bool {
+	metadata := checkpointScopeMetadataFromLabels(labels)
+	return strings.TrimSpace(metadata[checkpointMetadataRuntime]) != "" &&
+		strings.TrimSpace(metadata[checkpointMetadataEndpoint]) != "" &&
+		strings.TrimSpace(metadata[checkpointMetadataDaemonID]) != "" &&
+		(strings.TrimSpace(metadata[checkpointMetadataContext]) != "" || strings.TrimSpace(metadata[checkpointMetadataHost]) != "")
+}
+
+func sameCheckpointScope(a, b checkpointScope) bool {
+	return strings.TrimSpace(a.Runtime) == strings.TrimSpace(b.Runtime) &&
+		strings.TrimSpace(a.Host) == strings.TrimSpace(b.Host) &&
+		strings.TrimSpace(a.Context) == strings.TrimSpace(b.Context) &&
+		strings.TrimSpace(a.Config) == strings.TrimSpace(b.Config) &&
+		strings.TrimSpace(a.Endpoint) == strings.TrimSpace(b.Endpoint) &&
+		strings.TrimSpace(a.DaemonID) == strings.TrimSpace(b.DaemonID)
 }
 
 func isExitCode(err error, code int) bool {
 	var exit core.ExitError
 	return core.AsExitError(err, &exit) && exit.Code == code
+}
+
+type cleanupMutationOutcome struct {
+	changed          bool
+	scopeUnavailable bool
 }
 
 func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
@@ -520,33 +1118,46 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 			fmt.Fprintf(b.rt.Stderr, "skip container id=%s name=%s reason=%s\n", server.DisplayID(), server.Name, reason)
 			continue
 		}
-		if req.DryRun {
-			fmt.Fprintf(b.rt.Stdout, "would remove container id=%s name=%s lease=%s reason=%s\n", server.DisplayID(), server.Name, blank(leaseID, "-"), reason)
-			continue
+		if leaseID != "" && b.beforeCleanupMutation != nil {
+			b.beforeCleanupMutation(leaseID)
 		}
-		fmt.Fprintf(b.rt.Stdout, "remove container id=%s name=%s lease=%s reason=%s\n", server.DisplayID(), server.Name, blank(leaseID, "-"), reason)
-		if err := b.removeContainer(ctx, container.ID); err != nil {
-			return err
-		}
-		var cleanupErr error
-		hostLeaseRoot := hostLeaseWorkRootFromLabels(leaseID, server.Labels)
-		if hostLeaseRoot != "" {
-			cleanupErr = os.RemoveAll(hostLeaseRoot)
-		}
-		bootstrapDir := strings.TrimSpace(server.Labels["bootstrap_dir"])
-		if bootstrapDir != "" && trustedBootstrapDir(bootstrapDir) {
-			if err := os.RemoveAll(bootstrapDir); err != nil && cleanupErr == nil {
-				cleanupErr = err
+		if hasClaim {
+			outcome, cleanupErr := b.cleanupClaimedContainer(ctx, claim, container.ID, req.DryRun)
+			if outcome.changed {
+				fmt.Fprintf(b.rt.Stderr, "skip container id=%s name=%s reason=changed-during-cleanup err=%v\n", server.DisplayID(), server.Name, cleanupErr)
+				continue
+			}
+			if outcome.scopeUnavailable {
+				fmt.Fprintf(b.rt.Stderr, "skip container id=%s name=%s reason=captured-scope-unavailable err=%v\n", server.DisplayID(), server.Name, cleanupErr)
+				continue
+			}
+			if cleanupErr != nil {
+				return cleanupErr
+			}
+		} else if leaseID != "" {
+			claimAppeared, cleanupErr := b.cleanupClaimlessContainer(ctx, leaseID, container.ID, server.Labels, req.DryRun)
+			if claimAppeared {
+				fmt.Fprintf(b.rt.Stderr, "skip container id=%s name=%s reason=changed-during-cleanup\n", server.DisplayID(), server.Name)
+				continue
+			}
+			if cleanupErr != nil {
+				return cleanupErr
+			}
+		} else if !req.DryRun {
+			if err := b.removeContainer(ctx, container.ID); err != nil {
+				return err
+			}
+			if err := b.cleanupContainerSidecars("", server.Labels, false); err != nil {
+				return err
 			}
 		}
-		if leaseID != "" {
-			core.RemoveLeaseClaim(leaseID)
-			core.RemoveStoredTestboxKey(leaseID)
+		verb := "remove"
+		if req.DryRun {
+			verb = "would remove"
+		} else {
+			removed++
 		}
-		if cleanupErr != nil {
-			return core.Exit(2, "remove local-container host work root %s: %v", hostLeaseRoot, cleanupErr)
-		}
-		removed++
+		fmt.Fprintf(b.rt.Stdout, "%s container id=%s name=%s lease=%s reason=%s\n", verb, server.DisplayID(), server.Name, blank(leaseID, "-"), reason)
 	}
 	claimsRemoved := 0
 	for _, claim := range orphanCandidates {
@@ -559,7 +1170,41 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 		if !localContainerClaimMatchesScope(claim, claimScope, now) {
 			continue
 		}
+		if isPendingLocalContainerClaim(claim) && strings.EqualFold(claim.Labels["keep"], "true") {
+			fmt.Fprintf(b.rt.Stderr, "skip claim lease=%s slug=%s reason=pending-readiness-recovery\n", claim.LeaseID, blank(claim.Slug, "-"))
+			continue
+		}
+		missing, scopeErr := b.claimMissingInCapturedScope(ctx, claim)
+		if scopeErr != nil {
+			fmt.Fprintf(b.rt.Stderr, "skip claim lease=%s slug=%s reason=captured-scope-unavailable err=%v\n", claim.LeaseID, blank(claim.Slug, "-"), scopeErr)
+			continue
+		}
+		if !missing {
+			fmt.Fprintf(b.rt.Stderr, "skip claim lease=%s slug=%s reason=container-present-in-captured-scope\n", claim.LeaseID, blank(claim.Slug, "-"))
+			continue
+		}
 		reason := "missing container"
+		if isPendingLocalContainerClaim(claim) {
+			reason = "missing non-keep pending container"
+			if b.beforeCleanupMutation != nil {
+				b.beforeCleanupMutation(claim.LeaseID)
+			}
+			outcome, removeErr := b.cleanupMissingPendingClaim(ctx, claim, req.DryRun)
+			if outcome.changed {
+				fmt.Fprintf(b.rt.Stderr, "skip claim lease=%s slug=%s reason=changed-during-cleanup err=%v\n", claim.LeaseID, blank(claim.Slug, "-"), removeErr)
+				continue
+			}
+			if removeErr != nil {
+				return removeErr
+			}
+			if req.DryRun {
+				fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s slug=%s reason=%s\n", claim.LeaseID, blank(claim.Slug, "-"), reason)
+				continue
+			}
+			fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s slug=%s reason=%s\n", claim.LeaseID, blank(claim.Slug, "-"), reason)
+			claimsRemoved++
+			continue
+		}
 		if req.DryRun {
 			if err := core.VerifyLeaseClaimUnchanged(claim.LeaseID, claim); err != nil {
 				fmt.Fprintf(b.rt.Stderr, "skip claim lease=%s slug=%s reason=changed-during-cleanup err=%v\n", claim.LeaseID, blank(claim.Slug, "-"), err)
@@ -591,6 +1236,152 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 	}
 	if !req.DryRun {
 		fmt.Fprintf(b.rt.Stdout, "%s cleanup removed=%d claims_removed=%d checked=%d\n", providerName, removed, claimsRemoved, len(containers))
+	}
+	return nil
+}
+
+func (b *backend) claimMissingInCapturedScope(ctx context.Context, claim core.LeaseClaim) (bool, error) {
+	originalCfg := b.cfg
+	defer func() { b.cfg = originalCfg }()
+	if _, err := b.applyCheckpointScopeLabels(ctx, claim.Labels); err != nil {
+		return false, err
+	}
+	if err := b.validateClaimRuntimeScope(ctx, claim); err != nil {
+		return false, err
+	}
+	_, _, _, err := b.findContainerForClaim(ctx, claim)
+	if err == nil {
+		return false, nil
+	}
+	if isExitCode(err, 4) {
+		return true, nil
+	}
+	return false, err
+}
+
+func (b *backend) cleanupClaimedContainer(ctx context.Context, claim core.LeaseClaim, containerID string, dryRun bool) (cleanupMutationOutcome, error) {
+	originalCfg := b.cfg
+	defer func() { b.cfg = originalCfg }()
+	actionEntered := false
+	mutationEntered := false
+	action := func() error {
+		actionEntered = true
+		if err := b.validateCleanupClaim(ctx, claim, claim.LeaseID, containerID); err != nil {
+			return err
+		}
+		if dryRun {
+			return nil
+		}
+		mutationEntered = true
+		if err := b.removeContainer(ctx, containerID); err != nil {
+			return err
+		}
+		return b.cleanupContainerSidecars(claim.LeaseID, claim.Labels, true)
+	}
+	var err error
+	if dryRun {
+		err = core.WithLeaseClaimUnchanged(claim.LeaseID, claim, action)
+	} else {
+		err = core.RemoveLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, action)
+	}
+	if err == nil {
+		return cleanupMutationOutcome{}, nil
+	}
+	if !actionEntered {
+		return cleanupMutationOutcome{changed: true}, err
+	}
+	if !mutationEntered {
+		return cleanupMutationOutcome{scopeUnavailable: true}, err
+	}
+	return cleanupMutationOutcome{}, err
+}
+
+func (b *backend) cleanupClaimlessContainer(ctx context.Context, leaseID, containerID string, labels map[string]string, dryRun bool) (bool, error) {
+	claimAppeared := false
+	err := core.WithDurableLeaseClaimLock(leaseID, func(_ *core.LeaseClaim, exists bool, _ func() error) error {
+		if exists {
+			claimAppeared = true
+			return nil
+		}
+		if dryRun {
+			return nil
+		}
+		if err := b.removeContainer(ctx, containerID); err != nil {
+			return err
+		}
+		return b.cleanupContainerSidecars(leaseID, labels, true)
+	})
+	return claimAppeared, err
+}
+
+func (b *backend) cleanupMissingPendingClaim(ctx context.Context, claim core.LeaseClaim, dryRun bool) (cleanupMutationOutcome, error) {
+	originalCfg := b.cfg
+	defer func() { b.cfg = originalCfg }()
+	actionEntered := false
+	action := func() error {
+		actionEntered = true
+		checkCtx, cancel := context.WithTimeout(ctx, rollbackTimeout)
+		defer cancel()
+		if err := b.validateCleanupClaim(checkCtx, claim, claim.LeaseID, claim.CloudID); err != nil {
+			return err
+		}
+		absent, err := b.confirmContainerAbsent(checkCtx, claim.CloudID)
+		if err != nil {
+			return err
+		}
+		if !absent {
+			return core.Exit(4, "local-container %s reappeared; refusing to remove its pending claim", shortID(claim.CloudID))
+		}
+		if dryRun {
+			return nil
+		}
+		return b.cleanupContainerSidecars(claim.LeaseID, claim.Labels, true)
+	}
+	var err error
+	if dryRun {
+		err = core.WithLeaseClaimUnchanged(claim.LeaseID, claim, action)
+	} else {
+		err = core.RemoveLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, action)
+	}
+	if err != nil && !actionEntered {
+		return cleanupMutationOutcome{changed: true}, err
+	}
+	return cleanupMutationOutcome{}, err
+}
+
+func (b *backend) validateCleanupClaim(ctx context.Context, claim core.LeaseClaim, leaseID, containerID string) error {
+	if claim.LeaseID != strings.TrimSpace(leaseID) || claim.Provider != providerName ||
+		strings.TrimSpace(claim.CloudID) == "" || strings.TrimSpace(claim.CloudID) != strings.TrimSpace(containerID) ||
+		!hasCompleteCapturedRuntimeScope(claim.Labels) {
+		return localContainerOwnershipError(leaseID, containerID)
+	}
+	applied, err := b.applyCheckpointScopeLabels(ctx, claim.Labels)
+	if err != nil {
+		return err
+	}
+	if !applied {
+		return core.Exit(4, "local-container claim lacks captured runtime identity")
+	}
+	return b.validateExactLocalContainerClaim(ctx, claim, leaseID, containerID)
+}
+
+func (b *backend) cleanupContainerSidecars(leaseID string, labels map[string]string, removeKey bool) error {
+	var cleanupErrs []error
+	if hostRoot := hostLeaseWorkRootFromLabels(leaseID, labels); hostRoot != "" {
+		if err := b.removeAll(hostRoot); err != nil {
+			cleanupErrs = append(cleanupErrs, fmt.Errorf("remove local-container host work root %s: %w", hostRoot, err))
+		}
+	}
+	if bootstrapDir := strings.TrimSpace(labels["bootstrap_dir"]); bootstrapDir != "" && trustedBootstrapDir(bootstrapDir) {
+		if err := b.removeAll(bootstrapDir); err != nil {
+			cleanupErrs = append(cleanupErrs, fmt.Errorf("remove local-container bootstrap directory %s: %w", bootstrapDir, err))
+		}
+	}
+	if len(cleanupErrs) != 0 {
+		return errors.Join(cleanupErrs...)
+	}
+	if removeKey && leaseID != "" {
+		core.RemoveStoredTestboxKey(leaseID)
 	}
 	return nil
 }
@@ -719,9 +1510,13 @@ func localContainerDisplayImage(cfg core.Config) string {
 
 func (b *backend) createContainer(ctx context.Context, cfg core.Config, name, leaseID, slug, publicKey string, keep bool) (string, string, error) {
 	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", keep, time.Now().UTC())
+	labels["state"] = pendingClaimState
+	labels["recovery"] = pendingRecoveryKind
+	labels["ssh_key_owned"] = "true"
+	labels["bootstrap_owned"] = "true"
 	labels["runtime"] = cfg.LocalContainer.Runtime
 	labels["image"] = localContainerDisplayImage(cfg)
-	for _, key := range checkpointScopeMetadataKeys {
+	for _, key := range []string{checkpointMetadataRuntime, checkpointMetadataContext, checkpointMetadataDaemonID} {
 		if value := strings.TrimSpace(cfg.LocalContainer.CheckpointMetadata[key]); value != "" {
 			labels[key] = value
 		}
@@ -840,17 +1635,11 @@ func (b *backend) createContainer(ctx context.Context, cfg core.Config, name, le
 		cleanupCtx, cancel := context.WithTimeout(context.Background(), rollbackTimeout)
 		defer cancel()
 		containerID, owned, inspectErr := b.ownedContainerID(cleanupCtx, leaseID, bootstrapDir)
-		if owned && keep {
+		if owned {
 			cleanupHostLeaseWorkRoot = false
 			return containerID, bootstrapDir, commandError("container run", result, err)
 		}
-		if owned {
-			if removeErr := b.removeContainer(cleanupCtx, containerID); removeErr == nil {
-				os.RemoveAll(bootstrapDir)
-			} else {
-				cleanupHostLeaseWorkRoot = false
-			}
-		} else if inspectErr == nil {
+		if inspectErr == nil {
 			os.RemoveAll(bootstrapDir)
 		} else {
 			cleanupHostLeaseWorkRoot = false
@@ -1123,6 +1912,61 @@ func (b *backend) inspectContainer(ctx context.Context, id string) (inspectConta
 	return containers[0], nil
 }
 
+func (b *backend) exactContainerAbsent(ctx context.Context, id string) (bool, error) {
+	result, err := b.docker(ctx, []string{"inspect", "--type", "container", id}, nil, nil)
+	if err == nil {
+		return false, nil
+	}
+	detail := strings.ToLower(strings.TrimSpace(firstNonBlank(result.Stderr, result.Stdout)))
+	if localContainerRouteFailure(detail) {
+		return false, commandError("confirm local-container absence", result, err)
+	}
+	containerID := strings.ToLower(strings.TrimSpace(id))
+	for _, marker := range []string{
+		"no such object: " + containerID,
+		"no such container: " + containerID,
+		"container " + containerID + " not found",
+		"container " + containerID + " does not exist",
+		"no container with name or id \"" + containerID + "\" found",
+		"no container with id or name \"" + containerID + "\" found",
+		"no such object: '" + containerID + "'",
+		"no such container: '" + containerID + "'",
+	} {
+		if containerID != "" && strings.Contains(detail, marker) {
+			return true, nil
+		}
+	}
+	return false, commandError("confirm local-container absence", result, err)
+}
+
+func localContainerRouteFailure(detail string) bool {
+	for _, marker := range []string{
+		"cannot connect to the docker daemon",
+		"cannot connect to podman",
+		"connection refused",
+		"error during connect",
+		"failed to connect",
+		"daemon not found",
+		"daemon does not exist",
+		"daemon unavailable",
+	} {
+		if strings.Contains(detail, marker) {
+			return true
+		}
+	}
+	for _, route := range []string{"context", "connection", "endpoint", "socket", "transport"} {
+		if !strings.Contains(detail, route) {
+			continue
+		}
+		for _, failure := range []string{"not found", "does not exist", "unavailable", "cannot connect", "refused"} {
+			if strings.Contains(detail, failure) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func (b *backend) resolveContainer(ctx context.Context, identifier string) (inspectContainer, string, string, error) {
 	identifier = strings.TrimSpace(identifier)
 	if identifier == "" {
@@ -1191,12 +2035,15 @@ func (b *backend) resolveContainer(ctx context.Context, identifier string) (insp
 }
 
 func (b *backend) applyCheckpointScopeLabels(ctx context.Context, labels map[string]string) (bool, error) {
+	if !hasCompleteCapturedRuntimeScope(labels) {
+		return false, nil
+	}
 	metadata := checkpointScopeMetadataFromLabels(labels)
 	if len(metadata) == 0 {
 		return false, nil
 	}
 	scope := checkpointScopeFromMetadata(metadata, b.cfg.LocalContainer.Runtime)
-	if err := validateCheckpointScope(ctx, scope); err != nil {
+	if err := b.validateRuntimeScope(ctx, scope); err != nil {
 		return false, err
 	}
 	b.cfg.LocalContainer.CheckpointMetadata = metadata
@@ -1248,26 +2095,39 @@ func (b *backend) removeContainer(ctx context.Context, id string) error {
 }
 
 func (b *backend) ownedContainerID(ctx context.Context, leaseID, bootstrapDir string) (string, bool, error) {
-	result, err := b.docker(ctx, []string{"ps", "-aq", "--filter", "label=lease=" + leaseID}, nil, nil)
+	result, err := b.docker(ctx, []string{
+		"ps", "-aq", "--no-trunc",
+		"--filter", "label=provider=" + providerName,
+		"--filter", "label=lease=" + leaseID,
+		"--filter", "label=bootstrap_dir=" + bootstrapDir,
+	}, nil, nil)
 	if err != nil {
 		return "", false, err
 	}
-	for _, id := range strings.Fields(result.Stdout) {
-		container, err := b.inspectContainer(ctx, id)
-		if err != nil {
-			return "", false, err
-		}
-		labels := container.Config.Labels
-		if labels["lease"] != leaseID || labels["bootstrap_dir"] != bootstrapDir {
-			continue
-		}
-		containerID := strings.TrimSpace(container.ID)
-		if containerID == "" {
-			containerID = id
-		}
-		return containerID, true, nil
+	ids := strings.Fields(result.Stdout)
+	if len(ids) > 1 {
+		return "", false, core.Exit(2, "local-container lease %s matches multiple exact bootstrap identities", leaseID)
 	}
-	return "", false, nil
+	if len(ids) == 0 {
+		return "", false, nil
+	}
+	id := strings.TrimSpace(ids[0])
+	if !isFullContainerID(id) {
+		return "", false, core.Exit(2, "local-container runtime returned a truncated or invalid container id")
+	}
+	return id, true, nil
+}
+
+func isFullContainerID(id string) bool {
+	if len(id) != 64 {
+		return false
+	}
+	for _, r := range id {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') && (r < 'A' || r > 'F') {
+			return false
+		}
+	}
+	return true
 }
 
 func (b *backend) runtimeInfo(ctx context.Context) (string, string) {
@@ -1287,7 +2147,10 @@ func (b *backend) runtimeContext(ctx context.Context, runtimeName string) string
 	if err != nil {
 		return ""
 	}
-	return strings.TrimSpace(contextName.Stdout)
+	if name := strings.TrimSpace(contextName.Stdout); name != "" {
+		return name
+	}
+	return "default"
 }
 
 func (b *backend) claimScope(ctx context.Context) string {
@@ -1372,8 +2235,10 @@ func (b *backend) docker(ctx context.Context, args []string, stdout, stderr io.W
 	var env []string
 	if metadata := cfg.LocalContainer.CheckpointMetadata; len(metadata) != 0 {
 		scope := checkpointScopeFromMetadata(metadata, cfg.LocalContainer.Runtime)
-		if scope.Context != "" {
+		if isDockerRuntime(scope.Runtime) && scope.Context != "" && scope.Context != "default" {
 			args = append([]string{"--context", scope.Context}, args...)
+		} else if isPodmanRuntime(scope.Runtime) && scope.Context != "" && scope.Context != "default" && scope.Host == "" {
+			args = append([]string{"--connection", scope.Context}, args...)
 		}
 		env = checkpointEnvForScope(scope)
 	}
@@ -1389,7 +2254,7 @@ func (b *backend) docker(ctx context.Context, args []string, stdout, stderr io.W
 func (b *backend) serverFromContainer(container inspectContainer, cfg core.Config) core.Server {
 	labels := map[string]string{}
 	for key, value := range container.Config.Labels {
-		if strings.TrimSpace(value) == "" {
+		if strings.TrimSpace(value) == "" || privateLocalContainerScopeLabel(key) {
 			continue
 		}
 		labels[key] = value
@@ -1421,6 +2286,66 @@ func (b *backend) serverFromContainer(container inspectContainer, cfg core.Confi
 	server.PublicNet.IPv4.IP = host
 	server.ServerType.Name = firstNonBlank(labels["server_type"], cfg.LocalContainer.Image)
 	return server
+}
+
+func mergeLocalContainerClaim(server core.Server, claim core.LeaseClaim) core.Server {
+	labels := publicLocalContainerClaimLabels(server.Labels)
+	for key, value := range claim.Labels {
+		if strings.TrimSpace(value) != "" && !privateLocalContainerScopeLabel(key) {
+			labels[key] = value
+		}
+	}
+	if _, ok := claim.Labels["recovery"]; !ok {
+		delete(labels, "recovery")
+	}
+	server.Labels = labels
+	state := strings.TrimSpace(labels["state"])
+	observedRunning := strings.EqualFold(server.Status, "running") || strings.EqualFold(server.Status, "ready")
+	if state != "" && observedRunning {
+		server.Status = state
+	}
+	if server.CloudID == "" {
+		server.CloudID = claim.CloudID
+	}
+	if server.PublicNet.IPv4.IP == "" {
+		server.PublicNet.IPv4.IP = claim.SSHHost
+	}
+	return server
+}
+
+func publicLocalContainerClaimLabels(labels map[string]string) map[string]string {
+	out := cloneLabels(labels)
+	for key := range out {
+		if privateLocalContainerScopeLabel(key) {
+			delete(out, key)
+		}
+	}
+	return out
+}
+
+func privateLocalContainerScopeLabel(key string) bool {
+	switch key {
+	case checkpointMetadataHost, checkpointMetadataEndpoint, checkpointMetadataConfig:
+		return true
+	default:
+		return false
+	}
+}
+
+func isPendingLocalContainerClaim(claim core.LeaseClaim) bool {
+	return claim.Provider == providerName &&
+		strings.EqualFold(strings.TrimSpace(claim.Labels["state"]), pendingClaimState) &&
+		strings.TrimSpace(claim.Labels["recovery"]) == pendingRecoveryKind &&
+		strings.TrimSpace(claim.CloudID) != "" &&
+		strings.TrimSpace(claim.ProviderScope) != ""
+}
+
+func cloneLabels(labels map[string]string) map[string]string {
+	cloned := make(map[string]string, len(labels))
+	for key, value := range labels {
+		cloned[key] = value
+	}
+	return cloned
 }
 
 func containerSSHHostPort(container inspectContainer) (string, string, error) {

--- a/internal/providers/localcontainer/backend_test.go
+++ b/internal/providers/localcontainer/backend_test.go
@@ -21,6 +21,8 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
+const testRecoveredContainerID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
 type recordingRunner struct {
 	calls     []core.LocalCommandRequest
 	responses map[string]core.LocalCommandResult
@@ -82,7 +84,13 @@ func testBackend(runner *recordingRunner) *backend {
 		Memory:   "8g",
 		Network:  "bridge",
 	}
-	return newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}).(*backend)
+	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}).(*backend)
+	b.captureRuntimeScope = func(context.Context, core.Config) (checkpointScope, error) {
+		return checkpointScope{Runtime: "docker", Context: "default", Endpoint: "unix:///tmp/docker-test.sock", DaemonID: "daemon-test"}, nil
+	}
+	b.validateRuntimeScope = func(context.Context, checkpointScope) error { return nil }
+	b.confirmContainerAbsent = func(context.Context, string) (bool, error) { return true, nil }
+	return b
 }
 
 func TestRunFailureEvidenceUsesPerRunOOMKillIncrement(t *testing.T) {
@@ -441,6 +449,81 @@ func TestResolveContainerUsesCheckpointScopeFromClaim(t *testing.T) {
 	}
 }
 
+func TestResolveContainerHydratesCustomRuntimeRouteBeforeLookup(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		runtime       string
+		context       string
+		host          string
+		providerScope string
+	}{
+		{name: "docker host", runtime: "docker", host: "unix:///captured-docker.sock", providerScope: "runtime:docker/context:default/host:unix:///captured-docker.sock"},
+		{name: "podman connection", runtime: "podman", context: "captured-podman", providerScope: "runtime:podman/context:captured-podman"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			t.Setenv("DOCKER_HOST", "unix:///ambient.sock")
+			leaseID := "cbx_hydrated_route"
+			labels := checkpointScopeMetadata(checkpointScope{
+				Runtime: tc.runtime, Context: tc.context, Host: tc.host, Endpoint: firstNonBlank(tc.host, "connection://captured-podman"), DaemonID: "daemon-captured",
+			})
+			labels["provider"] = providerName
+			labels["lease"] = leaseID
+			labels["slug"] = "hydrated-route"
+			labels["state"] = pendingClaimState
+			if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(
+				leaseID, "hydrated-route", providerName, tc.providerScope, "", t.TempDir(), time.Minute, false,
+				core.Server{CloudID: "hydrated-container", Provider: providerName, Labels: labels}, core.SSHTarget{},
+			); err != nil {
+				t.Fatal(err)
+			}
+			inspectJSON := `[{"Id":"hydrated-container","Name":"/hydrated-container","Config":{"Image":"ubuntu:24.04","Labels":{"provider":"local-container","lease":"cbx_hydrated_route","slug":"hydrated-route","state":"provisioning"}},"State":{"Status":"running","Running":true}}]`
+			runner := &recordingRunner{run: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+				args := req.Args
+				if tc.runtime == "podman" {
+					if req.Name != "podman" || len(args) < 3 || args[0] != "--connection" || args[1] != tc.context {
+						t.Fatalf("Podman route not hydrated: name=%s args=%v", req.Name, args)
+					}
+					args = args[2:]
+				} else {
+					if req.Name != "docker" {
+						t.Fatalf("runtime=%s", req.Name)
+					}
+					foundHost := false
+					for _, value := range req.Env {
+						if value == "DOCKER_HOST="+tc.host {
+							foundHost = true
+						}
+						if value == "DOCKER_HOST=unix:///ambient.sock" {
+							t.Fatal("ambient Docker host reached lookup")
+						}
+					}
+					if !foundHost {
+						t.Fatalf("captured Docker host missing: %v", req.Env)
+					}
+				}
+				switch firstArg(args) {
+				case "ps":
+					return core.LocalCommandResult{Stdout: "hydrated-container\n"}, nil
+				case "inspect":
+					return core.LocalCommandResult{Stdout: inspectJSON}, nil
+				default:
+					return core.LocalCommandResult{}, nil
+				}
+			}}
+			b := testBackend(runner)
+			b.validateRuntimeScope = func(context.Context, checkpointScope) error { return nil }
+			container, gotLease, _, err := b.resolveContainer(context.Background(), leaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if container.ID != "hydrated-container" || gotLease != leaseID {
+				t.Fatalf("container=%q lease=%q", container.ID, gotLease)
+			}
+		})
+	}
+}
+
 func TestResolveContainerRejectsAmbiguousClaimSlug(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	for _, leaseID := range []string{"cbx_scope_a", "cbx_scope_b"} {
@@ -495,15 +578,49 @@ func TestServerFromContainerDropsEmptyInheritedLabels(t *testing.T) {
 		Config: inspectConfig{
 			Image: "checkpoint-image",
 			Labels: map[string]string{
-				"crabbox":             "true",
-				"provider":            providerName,
-				"lease":               "cbx_123",
-				"tailscale_exit_node": "",
+				"crabbox":                  "true",
+				"provider":                 providerName,
+				"lease":                    "cbx_123",
+				"tailscale_exit_node":      "",
+				checkpointMetadataHost:     "tcp://user:password@example.invalid",
+				checkpointMetadataEndpoint: "tcp://user:password@example.invalid",
+				checkpointMetadataConfig:   "/private/docker-config",
 			},
 		},
 	}, b.cfg)
 	if _, ok := server.Labels["tailscale_exit_node"]; ok {
 		t.Fatalf("empty inherited label survived: %#v", server.Labels)
+	}
+	for _, key := range []string{checkpointMetadataHost, checkpointMetadataEndpoint, checkpointMetadataConfig} {
+		if server.Labels[key] != "" {
+			t.Fatalf("private inherited label %s survived: %#v", key, server.Labels)
+		}
+	}
+}
+
+func TestMergeReadyClaimPreservesObservedExitedStatus(t *testing.T) {
+	server := core.Server{
+		CloudID: "stopped-container",
+		Status:  "exited",
+		Labels:  map[string]string{"state": "provisioning"},
+	}
+	claim := core.LeaseClaim{
+		CloudID: "stopped-container",
+		Labels: map[string]string{
+			"state": "ready", checkpointMetadataHost: "tcp://user:password@example.invalid", checkpointMetadataEndpoint: "tcp://user:password@example.invalid", checkpointMetadataConfig: "/private/docker-config",
+		},
+	}
+	merged := mergeLocalContainerClaim(server, claim)
+	if merged.Status != "exited" {
+		t.Fatalf("merged status=%q, want observed exited", merged.Status)
+	}
+	if merged.Labels["state"] != "ready" {
+		t.Fatalf("claim readiness label lost: %#v", merged.Labels)
+	}
+	for _, key := range []string{checkpointMetadataHost, checkpointMetadataEndpoint, checkpointMetadataConfig} {
+		if merged.Labels[key] != "" {
+			t.Fatalf("private claim label %s projected: %#v", key, merged.Labels)
+		}
 	}
 }
 
@@ -589,7 +706,39 @@ func TestCreateContainerUsesDockerCompatibleSSHLease(t *testing.T) {
 	}
 }
 
-func TestCreateContainerRemovesBootstrapDirOnRunFailure(t *testing.T) {
+func TestCreateContainerDoesNotLabelPrivateRuntimeScope(t *testing.T) {
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	runner.run = func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		if len(req.Args) >= 3 && req.Args[0] == "--context" && req.Args[1] == "named" && req.Args[2] == "run" {
+			return core.LocalCommandResult{Stdout: "private-scope-container\n"}, nil
+		}
+		return core.LocalCommandResult{}, nil
+	}
+	b := testBackend(runner)
+	cfg := b.configForRun()
+	cfg.LocalContainer.CheckpointMetadata = checkpointScopeMetadata(checkpointScope{
+		Runtime: "docker", Context: "named", Config: "/private/docker-config", Host: "tcp://user:password@example.invalid:2376", Endpoint: "tcp://user:password@example.invalid:2376", DaemonID: "daemon-private",
+	})
+	b.cfg.LocalContainer.CheckpointMetadata = cloneLabels(cfg.LocalContainer.CheckpointMetadata)
+	_, bootstrapDir, err := b.createContainer(context.Background(), cfg, "crabbox-private", "cbx_private", "private", "ssh-ed25519 AAAA test", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(bootstrapDir) })
+	args := strings.Join(runner.calls[len(runner.calls)-1].Args, "\n")
+	for _, forbidden := range []string{"password", "example.invalid", "docker_endpoint=", "docker_host=", "docker_config="} {
+		if strings.Contains(args, forbidden) {
+			t.Fatalf("container labels disclosed %q:\n%s", forbidden, args)
+		}
+	}
+	for _, want := range []string{"docker_context=named", "docker_daemon_id=daemon-private"} {
+		if !strings.Contains(args, want) {
+			t.Fatalf("safe scope label %q missing:\n%s", want, args)
+		}
+	}
+}
+
+func TestCreateContainerReturnsOwnedIDBeforeRollbackOnRunFailure(t *testing.T) {
 	var bootstrapDir string
 	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
 	runner.run = func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
@@ -598,13 +747,12 @@ func TestCreateContainerRemovesBootstrapDirOnRunFailure(t *testing.T) {
 			bootstrapDir = bootstrapDirFromRunArgs(t, []core.LocalCommandRequest{req})
 			return core.LocalCommandResult{Stderr: "run failed"}, errors.New("run failed")
 		case "ps":
-			return core.LocalCommandResult{Stdout: "created123\n"}, nil
+			return core.LocalCommandResult{Stdout: testRecoveredContainerID + "\n"}, nil
 		case "inspect":
-			return core.LocalCommandResult{Stdout: `[{"Id":"created123","Config":{"Labels":{"lease":"cbx_123","bootstrap_dir":` + strconv.Quote(bootstrapDir) + `}}}]`}, nil
+			t.Fatal("known ID was inspected before claim publication")
+			return core.LocalCommandResult{}, nil
 		case "rm":
-			if _, err := os.Stat(bootstrapDir); err != nil {
-				t.Fatalf("bootstrap directory removed before container rollback: %v", err)
-			}
+			t.Fatal("createContainer removed a known-ID resource before claim publication")
 			return core.LocalCommandResult{}, nil
 		default:
 			return core.LocalCommandResult{}, nil
@@ -612,14 +760,35 @@ func TestCreateContainerRemovesBootstrapDirOnRunFailure(t *testing.T) {
 	}
 	b := testBackend(runner)
 
-	if _, _, err := b.createContainer(context.Background(), b.configForRun(), "crabbox-blue", "cbx_123", "blue-lobster", "ssh-ed25519 AAAA test", false); err == nil {
+	containerID, _, err := b.createContainer(context.Background(), b.configForRun(), "crabbox-blue", "cbx_123", "blue-lobster", "ssh-ed25519 AAAA test", false)
+	if err == nil {
 		t.Fatal("createContainer succeeded")
 	}
-	if _, err := os.Stat(bootstrapDir); !os.IsNotExist(err) {
-		t.Fatalf("bootstrap directory still exists after run failure: %v", err)
+	if containerID != testRecoveredContainerID {
+		t.Fatalf("container id=%q, want exact owned id", containerID)
 	}
-	if args := recordedArgsForCommand(t, runner, "rm"); !strings.Contains(args, "created123") {
-		t.Fatalf("run failure rollback did not remove owned container:\n%s", args)
+	if _, err := os.Stat(bootstrapDir); err != nil {
+		t.Fatalf("bootstrap directory removed before claim publication: %v", err)
+	}
+	if args := recordedArgsForCommand(t, runner, "ps"); !strings.Contains(args, "--no-trunc") {
+		t.Fatalf("exact-ID discovery omitted --no-trunc:\n%s", args)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(bootstrapDir) })
+}
+
+func TestFullContainerIDValidation(t *testing.T) {
+	for _, tc := range []struct {
+		id   string
+		want bool
+	}{
+		{id: testRecoveredContainerID, want: true},
+		{id: strings.ToUpper(testRecoveredContainerID), want: true},
+		{id: "aaaaaaaaaaaa"},
+		{id: strings.Repeat("g", 64)},
+	} {
+		if got := isFullContainerID(tc.id); got != tc.want {
+			t.Fatalf("isFullContainerID(%q)=%v want=%v", tc.id, got, tc.want)
+		}
 	}
 }
 
@@ -632,9 +801,9 @@ func TestCreateContainerPreservesBootstrapDirWhenRollbackFails(t *testing.T) {
 			bootstrapDir = bootstrapDirFromRunArgs(t, []core.LocalCommandRequest{req})
 			return core.LocalCommandResult{Stderr: "run failed"}, errors.New("run failed")
 		case "ps":
-			return core.LocalCommandResult{Stdout: "created123\n"}, nil
+			return core.LocalCommandResult{Stdout: testRecoveredContainerID + "\n"}, nil
 		case "inspect":
-			return core.LocalCommandResult{Stdout: `[{"Id":"created123","Config":{"Labels":{"lease":"cbx_123","bootstrap_dir":` + strconv.Quote(bootstrapDir) + `}}}]`}, nil
+			return core.LocalCommandResult{Stdout: `[{"Id":` + strconv.Quote(testRecoveredContainerID) + `,"Config":{"Labels":{"lease":"cbx_123","bootstrap_dir":` + strconv.Quote(bootstrapDir) + `}}}]`}, nil
 		case "rm":
 			return core.LocalCommandResult{Stderr: "daemon unavailable"}, errors.New("remove failed")
 		default:
@@ -688,9 +857,9 @@ func TestCreateContainerRunFailureKeepsOwnedContainer(t *testing.T) {
 			bootstrapDir = bootstrapDirFromRunArgs(t, []core.LocalCommandRequest{req})
 			return core.LocalCommandResult{Stderr: "connection lost"}, errors.New("run failed")
 		case "ps":
-			return core.LocalCommandResult{Stdout: "created123\n"}, nil
+			return core.LocalCommandResult{Stdout: testRecoveredContainerID + "\n"}, nil
 		case "inspect":
-			return core.LocalCommandResult{Stdout: `[{"Id":"created123","Config":{"Labels":{"lease":"cbx_123","bootstrap_dir":` + strconv.Quote(bootstrapDir) + `}}}]`}, nil
+			return core.LocalCommandResult{Stdout: `[{"Id":` + strconv.Quote(testRecoveredContainerID) + `,"Config":{"Labels":{"lease":"cbx_123","bootstrap_dir":` + strconv.Quote(bootstrapDir) + `}}}]`}, nil
 		case "rm":
 			t.Fatal("removed kept container after run failure")
 			return core.LocalCommandResult{}, nil
@@ -704,8 +873,8 @@ func TestCreateContainerRunFailureKeepsOwnedContainer(t *testing.T) {
 	if err == nil {
 		t.Fatal("createContainer succeeded")
 	}
-	if containerID != "created123" {
-		t.Fatalf("kept container id = %q, want created123", containerID)
+	if containerID != testRecoveredContainerID {
+		t.Fatalf("kept container id = %q, want %s", containerID, testRecoveredContainerID)
 	}
 	if _, err := os.Stat(bootstrapDir); err != nil {
 		t.Fatalf("kept bootstrap directory missing after run failure: %v", err)
@@ -741,7 +910,7 @@ func TestCreateContainerRunFailureKeepsBootstrapDirWhenOwnershipUnknown(t *testi
 	t.Cleanup(func() { _ = os.RemoveAll(bootstrapDir) })
 }
 
-func TestAcquireRunFailureKeepsOwnedContainerKey(t *testing.T) {
+func TestAcquireRunFailureKeepsExactPendingClaim(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 
@@ -756,16 +925,18 @@ func TestAcquireRunFailureKeepsOwnedContainerKey(t *testing.T) {
 			return core.LocalCommandResult{Stderr: "connection lost"}, errors.New("run failed")
 		case "ps":
 			if strings.Contains(strings.Join(req.Args, "\n"), "label=lease=") {
-				return core.LocalCommandResult{Stdout: "created123\n"}, nil
+				return core.LocalCommandResult{Stdout: testRecoveredContainerID + "\n"}, nil
 			}
 			return core.LocalCommandResult{}, nil
 		case "inspect":
-			return core.LocalCommandResult{Stdout: `[{"Id":"created123","Config":{"Labels":{"lease":` + strconv.Quote(leaseID) + `,"bootstrap_dir":` + strconv.Quote(bootstrapDir) + `}}}]`}, nil
+			return core.LocalCommandResult{Stdout: `[{"Id":` + strconv.Quote(testRecoveredContainerID) + `,"Config":{"Labels":{"lease":` + strconv.Quote(leaseID) + `,"bootstrap_dir":` + strconv.Quote(bootstrapDir) + `}}}]`}, nil
 		default:
 			return core.LocalCommandResult{}, nil
 		}
 	}
+	var stderr strings.Builder
 	b := testBackend(runner)
+	b.rt.Stderr = &stderr
 
 	if _, err := b.Acquire(context.Background(), core.AcquireRequest{Keep: true, Repo: core.Repo{Root: t.TempDir()}}); err == nil {
 		t.Fatal("Acquire succeeded")
@@ -775,32 +946,45 @@ func TestAcquireRunFailureKeepsOwnedContainerKey(t *testing.T) {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(keyPath); err != nil {
-		t.Fatalf("kept container SSH key missing: %v", err)
+		t.Fatalf("retained container SSH key missing: %v", err)
 	}
-	t.Cleanup(func() {
-		core.RemoveStoredTestboxKey(leaseID)
-		_ = os.RemoveAll(bootstrapDir)
-	})
+	if _, err := os.Stat(bootstrapDir); err != nil {
+		t.Fatalf("retained container bootstrap directory missing: %v", err)
+	}
+	claim, err := core.ReadLeaseClaim(leaseID)
+	if err != nil || claim.CloudID != testRecoveredContainerID || claim.Labels["state"] != pendingClaimState {
+		t.Fatalf("pending claim=%#v err=%v", claim, err)
+	}
+	if !strings.Contains(stderr.String(), "cleanup:") {
+		t.Fatalf("recovery output missing: %s", stderr.String())
+	}
+	core.RemoveLeaseClaim(leaseID)
+	core.RemoveStoredTestboxKey(leaseID)
+	_ = os.RemoveAll(bootstrapDir)
 }
 
-func TestAcquirePostCreateFailureKeepsRetainedContainerKey(t *testing.T) {
+func TestAcquireInspectFailureKeepsExactPendingClaim(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 
 	var leaseID string
+	var bootstrapDir string
 	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
 	runner.run = func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		switch firstArg(req.Args) {
 		case "run":
 			leaseID = labelFromRunArgs(t, req.Args, "lease")
-			return core.LocalCommandResult{Stdout: "created123\n"}, nil
+			bootstrapDir = bootstrapDirFromRunArgs(t, []core.LocalCommandRequest{req})
+			return core.LocalCommandResult{Stdout: testRecoveredContainerID + "\n"}, nil
 		case "inspect":
 			return core.LocalCommandResult{Stderr: "inspect failed"}, errors.New("inspect failed")
 		default:
 			return core.LocalCommandResult{}, nil
 		}
 	}
+	var stderr strings.Builder
 	b := testBackend(runner)
+	b.rt.Stderr = &stderr
 
 	if _, err := b.Acquire(context.Background(), core.AcquireRequest{Keep: true, Repo: core.Repo{Root: t.TempDir()}}); err == nil {
 		t.Fatal("Acquire succeeded")
@@ -810,11 +994,128 @@ func TestAcquirePostCreateFailureKeepsRetainedContainerKey(t *testing.T) {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(keyPath); err != nil {
-		t.Fatalf("kept post-create container SSH key missing: %v", err)
+		t.Fatalf("retained post-create SSH key missing: %v", err)
 	}
-	t.Cleanup(func() {
-		core.RemoveStoredTestboxKey(leaseID)
-	})
+	claim, err := core.ReadLeaseClaim(leaseID)
+	if err != nil || claim.CloudID != testRecoveredContainerID || claim.Labels["bootstrap_dir"] != bootstrapDir {
+		t.Fatalf("pending claim=%#v err=%v", claim, err)
+	}
+	if !strings.Contains(stderr.String(), "inspect:") {
+		t.Fatalf("recovery output missing: %s", stderr.String())
+	}
+	core.RemoveLeaseClaim(leaseID)
+	core.RemoveStoredTestboxKey(leaseID)
+	_ = os.RemoveAll(bootstrapDir)
+}
+
+func TestPostIDRollbackFailureRetainsExactPendingClaim(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		createErr bool
+	}{
+		{name: "create error", createErr: true},
+		{name: "inspect error"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			var leaseID string
+			var bootstrapDir string
+			runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+			runner.run = func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+				switch firstArg(req.Args) {
+				case "run":
+					leaseID = labelFromRunArgs(t, req.Args, "lease")
+					bootstrapDir = bootstrapDirFromRunArgs(t, []core.LocalCommandRequest{req})
+					if tc.createErr {
+						return core.LocalCommandResult{Stderr: "connection lost"}, errors.New("run failed")
+					}
+					return core.LocalCommandResult{Stdout: testRecoveredContainerID + "\n"}, nil
+				case "ps":
+					if tc.createErr && strings.Contains(strings.Join(req.Args, "\n"), "label=lease=") {
+						return core.LocalCommandResult{Stdout: testRecoveredContainerID + "\n"}, nil
+					}
+					return core.LocalCommandResult{}, nil
+				case "inspect":
+					if tc.createErr {
+						return core.LocalCommandResult{Stdout: `[{"Id":` + strconv.Quote(testRecoveredContainerID) + `,"Config":{"Labels":{"lease":` + strconv.Quote(leaseID) + `,"bootstrap_dir":` + strconv.Quote(bootstrapDir) + `}}}]`}, nil
+					}
+					return core.LocalCommandResult{Stderr: "inspect failed", ExitCode: 1}, errors.New("inspect failed")
+				case "rm":
+					return core.LocalCommandResult{Stderr: "daemon unavailable", ExitCode: 1}, errors.New("remove failed")
+				default:
+					return core.LocalCommandResult{}, nil
+				}
+			}
+			var stderr strings.Builder
+			b := testBackend(runner)
+			b.rt.Stderr = &stderr
+			_, err := b.Acquire(context.Background(), core.AcquireRequest{Keep: false, Repo: core.Repo{Root: t.TempDir()}})
+			if err == nil || !strings.Contains(err.Error(), "remove failed") {
+				t.Fatalf("Acquire error=%v", err)
+			}
+			claim, err := core.ReadLeaseClaim(leaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if claim.CloudID != testRecoveredContainerID || claim.ProviderScope != "runtime:docker/context:default" || claim.Labels["bootstrap_dir"] != bootstrapDir {
+				t.Fatalf("retained claim=%#v", claim)
+			}
+			if !strings.Contains(stderr.String(), "cleanup:") {
+				t.Fatalf("recovery output missing: %s", stderr.String())
+			}
+			keyPath, err := core.TestboxKeyPath(leaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := os.Stat(keyPath); err != nil {
+				t.Fatalf("retained key missing: %v", err)
+			}
+			core.RemoveLeaseClaim(leaseID)
+			core.RemoveStoredTestboxKey(leaseID)
+			_ = os.RemoveAll(bootstrapDir)
+		})
+	}
+}
+
+func TestAcquireInspectFailureRemovesDockerSocketHostWorkRoot(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	socketPath := filepath.Join(t.TempDir(), "docker.sock")
+	listener := listenUnixSocketOrSkip(t, socketPath)
+	defer listener.Close()
+	t.Setenv("DOCKER_HOST", "unix://"+socketPath)
+	hostRoot := t.TempDir()
+	var leaseID string
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	runner.run = func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		switch firstArg(req.Args) {
+		case "ps":
+			return core.LocalCommandResult{}, nil
+		case "run":
+			leaseID = labelFromRunArgs(t, req.Args, "lease")
+			return core.LocalCommandResult{Stdout: "socket-inspect-failure\n"}, nil
+		case "inspect":
+			return core.LocalCommandResult{Stderr: "inspect failed", ExitCode: 1}, errors.New("inspect failed")
+		case "rm":
+			return core.LocalCommandResult{}, nil
+		default:
+			return core.LocalCommandResult{}, nil
+		}
+	}
+	b := testBackend(runner)
+	b.cfg.LocalContainer.DockerSocket = true
+	b.cfg.LocalContainer.WorkRoot = hostRoot
+	b.cfg.WorkRoot = hostRoot
+	if _, err := b.Acquire(context.Background(), core.AcquireRequest{Keep: false, Repo: core.Repo{Root: t.TempDir()}}); err == nil {
+		t.Fatal("Acquire succeeded")
+	}
+	if leaseID == "" {
+		t.Fatal("lease id was not captured")
+	}
+	if _, err := os.Stat(filepath.Join(hostRoot, leaseID)); !os.IsNotExist(err) {
+		t.Fatalf("host work root still exists after inspect rollback: %v", err)
+	}
 }
 
 func TestCreateContainerRecoversEmptyContainerID(t *testing.T) {
@@ -826,9 +1127,9 @@ func TestCreateContainerRecoversEmptyContainerID(t *testing.T) {
 			bootstrapDir = bootstrapDirFromRunArgs(t, []core.LocalCommandRequest{req})
 			return core.LocalCommandResult{}, nil
 		case "ps":
-			return core.LocalCommandResult{Stdout: "created123\n"}, nil
+			return core.LocalCommandResult{Stdout: testRecoveredContainerID + "\n"}, nil
 		case "inspect":
-			return core.LocalCommandResult{Stdout: `[{"Id":"created123","Config":{"Labels":{"lease":"cbx_123","bootstrap_dir":` + strconv.Quote(bootstrapDir) + `}}}]`}, nil
+			return core.LocalCommandResult{Stdout: `[{"Id":` + strconv.Quote(testRecoveredContainerID) + `,"Config":{"Labels":{"lease":"cbx_123","bootstrap_dir":` + strconv.Quote(bootstrapDir) + `}}}]`}, nil
 		default:
 			return core.LocalCommandResult{}, nil
 		}
@@ -839,8 +1140,8 @@ func TestCreateContainerRecoversEmptyContainerID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if containerID != "created123" {
-		t.Fatalf("container id = %q, want created123", containerID)
+	if containerID != testRecoveredContainerID {
+		t.Fatalf("container id = %q, want %s", containerID, testRecoveredContainerID)
 	}
 	if gotBootstrapDir != bootstrapDir {
 		t.Fatalf("bootstrap directory = %q, want %q", gotBootstrapDir, bootstrapDir)
@@ -906,6 +1207,765 @@ func TestAcquireRollbackRemovesContainerBeforeBootstrapDir(t *testing.T) {
 	}
 	if args := recordedArgsForCommand(t, runner, "rm"); !strings.Contains(args, "container123456") {
 		t.Fatalf("acquire rollback did not remove container:\n%s", args)
+	}
+}
+
+func TestAcquireSSHReadinessFailurePolicy(t *testing.T) {
+	tests := []struct {
+		name    string
+		keep    bool
+		waitErr error
+	}{
+		{name: "keep cancellation", keep: true, waitErr: context.Canceled},
+		{name: "keep timeout", keep: true, waitErr: core.Exit(5, "timed out waiting for SSH during local container ssh")},
+		{name: "rollback cancellation", keep: false, waitErr: context.Canceled},
+		{name: "rollback timeout", keep: false, waitErr: core.Exit(5, "timed out waiting for SSH during local container ssh")},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b, runner, stderr, leaseID, bootstrapDir, containerPresent := pendingAcquireBackend(t)
+			b.waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error {
+				return tc.waitErr
+			}
+			_, err := b.Acquire(context.Background(), core.AcquireRequest{
+				Keep: tc.keep,
+				Repo: core.Repo{Root: t.TempDir()},
+			})
+			if err == nil || !errors.Is(err, tc.waitErr) {
+				t.Fatalf("Acquire error=%v, want %v", err, tc.waitErr)
+			}
+			claim, claimErr := core.ReadLeaseClaim(*leaseID)
+			if claimErr != nil {
+				t.Fatal(claimErr)
+			}
+			keyPath, keyErr := core.TestboxKeyPath(*leaseID)
+			if keyErr != nil {
+				t.Fatal(keyErr)
+			}
+			if tc.keep {
+				if claim.LeaseID != *leaseID || claim.CloudID != "container-pending" || claim.ProviderScope != "runtime:docker/context:default" {
+					t.Fatalf("pending claim identity=%#v", claim)
+				}
+				if claim.Labels["state"] != pendingClaimState || claim.Labels["recovery"] != pendingRecoveryKind || claim.Labels["ssh_key_owned"] != "true" || claim.Labels["bootstrap_owned"] != "true" {
+					t.Fatalf("pending claim labels=%#v", claim.Labels)
+				}
+				if _, statErr := os.Stat(keyPath); statErr != nil {
+					t.Fatalf("pending key missing: %v", statErr)
+				}
+				if _, statErr := os.Stat(*bootstrapDir); statErr != nil {
+					t.Fatalf("pending bootstrap directory missing: %v", statErr)
+				}
+				if !*containerPresent {
+					t.Fatal("kept pending container was removed")
+				}
+				for _, want := range []string{
+					"inspect: CRABBOX_LOCAL_CONTAINER_RUNTIME='docker' DOCKER_CONTEXT='default' crabbox inspect --provider local-container --id '" + *leaseID + "' --json",
+					"reclaim: CRABBOX_LOCAL_CONTAINER_RUNTIME='docker' DOCKER_CONTEXT='default' crabbox run --provider local-container --id '" + *leaseID + "' --reclaim --keep --sync-only",
+					"cleanup: CRABBOX_LOCAL_CONTAINER_RUNTIME='docker' DOCKER_CONTEXT='default' crabbox stop --provider local-container --id '" + *leaseID + "'",
+				} {
+					if !strings.Contains(stderr.String(), want) {
+						t.Fatalf("recovery output missing %q:\n%s", want, stderr.String())
+					}
+				}
+				views, listErr := b.List(context.Background(), core.ListRequest{})
+				if listErr != nil {
+					t.Fatal(listErr)
+				}
+				if len(views) != 1 || views[0].Status == "ready" || views[0].Labels["state"] != pendingClaimState {
+					t.Fatalf("pending inventory=%#v", views)
+				}
+				*containerPresent = false
+				views, listErr = b.List(context.Background(), core.ListRequest{})
+				if listErr != nil {
+					t.Fatal(listErr)
+				}
+				if len(views) != 1 || views[0].Status != "missing" || views[0].Labels["state"] != pendingClaimState {
+					t.Fatalf("stale pending inventory=%#v", views)
+				}
+				if cleanupErr := b.Cleanup(context.Background(), core.CleanupRequest{}); cleanupErr != nil {
+					t.Fatal(cleanupErr)
+				}
+				if cleanupErr := b.Cleanup(context.Background(), core.CleanupRequest{}); cleanupErr != nil {
+					t.Fatalf("repeated pending cleanup: %v", cleanupErr)
+				}
+				if afterCleanup, readErr := core.ReadLeaseClaim(*leaseID); readErr != nil || afterCleanup.LeaseID != *leaseID {
+					t.Fatalf("cleanup removed pending recovery claim=%#v err=%v", afterCleanup, readErr)
+				}
+				lease, resolveErr := b.Resolve(context.Background(), core.ResolveRequest{ID: *leaseID, ReleaseOnly: true})
+				if resolveErr != nil {
+					t.Fatal(resolveErr)
+				}
+				if releaseErr := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); releaseErr != nil {
+					t.Fatal(releaseErr)
+				}
+			} else {
+				if claim.LeaseID != "" {
+					t.Fatalf("rollback retained claim=%#v", claim)
+				}
+				if *containerPresent {
+					t.Fatal("rollback retained container")
+				}
+				if _, statErr := os.Stat(keyPath); !os.IsNotExist(statErr) {
+					t.Fatalf("rollback retained key: %v", statErr)
+				}
+				if _, statErr := os.Stat(*bootstrapDir); !os.IsNotExist(statErr) {
+					t.Fatalf("rollback retained bootstrap directory: %v", statErr)
+				}
+				if args := recordedArgsForCommand(t, runner, "rm"); !strings.Contains(args, "container-pending") {
+					t.Fatalf("rollback did not remove exact container:\n%s", args)
+				}
+			}
+		})
+	}
+}
+
+func TestPendingRecoveryCommandsUseSafeExactRoute(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		runtime        string
+		context        string
+		host           string
+		forbidden      []string
+		wantAssignment string
+	}{
+		{name: "default docker", runtime: "docker", context: "default", wantAssignment: "DOCKER_CONTEXT='default'"},
+		{name: "named docker context quoting", runtime: "docker", context: "team's context", wantAssignment: "DOCKER_CONTEXT=" + core.ShellQuote("team's context")},
+		{name: "custom docker endpoint hidden", runtime: "docker", host: "tcp://user:password@example.invalid:2376", forbidden: []string{"password", "example.invalid", "DOCKER_HOST="}},
+		{name: "named podman connection", runtime: "podman", context: "remote podman", wantAssignment: "CONTAINER_CONNECTION='remote podman'"},
+		{name: "custom podman endpoint hidden", runtime: "podman", host: "ssh://user:secret@example.invalid/run/podman.sock", forbidden: []string{"secret", "example.invalid", "CONTAINER_HOST="}},
+		{name: "runtime path quoting", runtime: "/opt/My Runtime/docker", context: "default", wantAssignment: "CRABBOX_LOCAL_CONTAINER_RUNTIME='/opt/My Runtime/docker'"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			b := testBackend(&recordingRunner{})
+			var stderr strings.Builder
+			b.rt.Stderr = &stderr
+			labels := checkpointScopeMetadata(checkpointScope{
+				Runtime: tc.runtime, Context: tc.context, Host: tc.host, Endpoint: firstNonBlank(tc.host, "local"), DaemonID: "daemon-test",
+			})
+			labels["runtime"] = tc.runtime
+			claim := core.LeaseClaim{LeaseID: "cbx_recovery_route", Provider: providerName, CloudID: "container-route", Labels: labels}
+			b.printPendingRecovery(claim.LeaseID, "recovery-route", claim, errors.New("readiness failed via tcp://user:password@example.invalid and /private/docker/config"))
+			output := stderr.String()
+			if !strings.Contains(output, "CRABBOX_LOCAL_CONTAINER_RUNTIME="+core.ShellQuote(tc.runtime)) {
+				t.Fatalf("runtime assignment missing:\n%s", output)
+			}
+			if tc.wantAssignment != "" && !strings.Contains(output, tc.wantAssignment) {
+				t.Fatalf("route assignment %q missing:\n%s", tc.wantAssignment, output)
+			}
+			for _, forbidden := range append(tc.forbidden, "readiness failed", "password", "example.invalid", "/private/docker/config") {
+				if strings.Contains(output, forbidden) {
+					t.Fatalf("recovery output disclosed %q:\n%s", forbidden, output)
+				}
+			}
+			for _, command := range []string{"inspect:", "reclaim:", "cleanup:"} {
+				if !strings.Contains(output, command) {
+					t.Fatalf("%s command missing:\n%s", command, output)
+				}
+			}
+		})
+	}
+}
+
+func TestAcquireSSHReadinessSuccessFencesReadyClaim(t *testing.T) {
+	b, _, _, leaseID, _, containerPresent := pendingAcquireBackend(t)
+	b.waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error { return nil }
+	lease, err := b.Acquire(context.Background(), core.AcquireRequest{Keep: true, Repo: core.Repo{Root: t.TempDir()}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim, err := core.ReadLeaseClaim(*leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claim.Labels["state"] != "ready" || claim.Labels["recovery"] != "" {
+		t.Fatalf("ready claim labels=%#v", claim.Labels)
+	}
+	if expected, exists, set := core.ServerLeaseClaimSnapshot(lease.Server); !set || !exists || expected.Revision != claim.Revision {
+		t.Fatalf("ready snapshot set=%v exists=%v expected=%#v claim=%#v", set, exists, expected, claim)
+	}
+	views, err := b.List(context.Background(), core.ListRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(views) != 1 || views[0].Status != "ready" || views[0].Labels["state"] != "ready" || views[0].Labels["recovery"] != "" {
+		t.Fatalf("ready inventory=%#v", views)
+	}
+	if !*containerPresent {
+		t.Fatal("ready container missing")
+	}
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestResolvePrepareRecoversPendingClaimToReady(t *testing.T) {
+	b, _, _, leaseID, _, _ := pendingAcquireBackend(t)
+	b.waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error {
+		return core.Exit(5, "timed out waiting for SSH during local container ssh")
+	}
+	if _, err := b.Acquire(context.Background(), core.AcquireRequest{Keep: true, Repo: core.Repo{Root: t.TempDir()}}); err == nil {
+		t.Fatal("Acquire succeeded")
+	}
+	b.waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error { return nil }
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{
+		ID:      *leaseID,
+		Repo:    core.Repo{Root: t.TempDir()},
+		Reclaim: true,
+		Prepare: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim, err := core.ReadLeaseClaim(*leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.Server.Status != "ready" || claim.Labels["state"] != "ready" || claim.Labels["recovery"] != "" {
+		t.Fatalf("recovered lease=%#v claim=%#v", lease, claim)
+	}
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAcquireSSHReadinessSuccessCannotOverwriteNewerClaim(t *testing.T) {
+	b, runner, _, leaseID, bootstrapDir, _ := pendingAcquireBackend(t)
+	b.waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error {
+		claim, err := core.ReadLeaseClaim(*leaseID)
+		if err != nil {
+			return err
+		}
+		labels := cloneLabels(claim.Labels)
+		labels["state"] = "superseded"
+		_, err = core.UpdateLeaseClaimLabelsIfUnchanged(*leaseID, claim, labels)
+		return err
+	}
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{Keep: true, Repo: core.Repo{Root: t.TempDir()}})
+	if err == nil || !strings.Contains(err.Error(), "claim changed") {
+		t.Fatalf("Acquire error=%v, want fenced claim change", err)
+	}
+	claim, err := core.ReadLeaseClaim(*leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claim.Labels["state"] != "superseded" {
+		t.Fatalf("newer claim overwritten=%#v", claim)
+	}
+	for _, call := range runner.calls {
+		if firstArg(call.Args) == "rm" {
+			t.Fatalf("stale acquisition removed newer claim resource: %#v", call.Args)
+		}
+	}
+	lease := core.LeaseTarget{LeaseID: *leaseID, Server: core.Server{CloudID: claim.CloudID, Labels: claim.Labels}}
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+	_ = os.RemoveAll(*bootstrapDir)
+}
+
+func TestAcquireReadyCASRollsBackContainerClaimedByNewerIdentity(t *testing.T) {
+	b, runner, _, leaseID, bootstrapDir, containerPresent := pendingAcquireBackend(t)
+	b.waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error {
+		claim, err := core.ReadLeaseClaim(*leaseID)
+		if err != nil {
+			return err
+		}
+		labels := cloneLabels(claim.Labels)
+		labels["state"] = "ready"
+		replacement := claim
+		replacement.CloudID = "newer-container"
+		replacement.Labels = labels
+		return core.ReplaceLeaseClaimIfUnchanged(*leaseID, claim, replacement)
+	}
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{Keep: true, Repo: core.Repo{Root: t.TempDir()}})
+	if err == nil || !strings.Contains(err.Error(), "claim changed") {
+		t.Fatalf("Acquire error=%v, want fenced claim change", err)
+	}
+	claim, err := core.ReadLeaseClaim(*leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claim.CloudID != "newer-container" {
+		t.Fatalf("newer claim overwritten=%#v", claim)
+	}
+	if *containerPresent {
+		t.Fatal("CAS loser retained its unclaimed container")
+	}
+	if _, err := os.Stat(*bootstrapDir); err != nil {
+		t.Fatalf("CAS loser removed bootstrap directory still referenced by winner: %v", err)
+	}
+	if args := recordedArgsForCommand(t, runner, "rm"); !strings.Contains(args, "container-pending") {
+		t.Fatalf("CAS loser did not remove exact old container:\n%s", args)
+	}
+	core.RemoveLeaseClaim(*leaseID)
+	core.RemoveStoredTestboxKey(*leaseID)
+	_ = os.RemoveAll(*bootstrapDir)
+}
+
+func TestAcquireReadinessFailureReconcilesDifferentClaim(t *testing.T) {
+	b, runner, stderr, leaseID, bootstrapDir, containerPresent := pendingAcquireBackend(t)
+	b.waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error {
+		claim, err := core.ReadLeaseClaim(*leaseID)
+		if err != nil {
+			return err
+		}
+		labels := cloneLabels(claim.Labels)
+		replacement := claim
+		replacement.CloudID = "newer-container"
+		replacement.Labels = labels
+		if err := core.ReplaceLeaseClaimIfUnchanged(*leaseID, claim, replacement); err != nil {
+			return err
+		}
+		return context.Canceled
+	}
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{Keep: true, Repo: core.Repo{Root: t.TempDir()}})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Acquire error=%v", err)
+	}
+	claim, err := core.ReadLeaseClaim(*leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claim.CloudID != "newer-container" {
+		t.Fatalf("winning claim=%#v", claim)
+	}
+	if *containerPresent {
+		t.Fatal("readiness failure retained displaced container")
+	}
+	if strings.Contains(stderr.String(), "retained provider=local-container") {
+		t.Fatalf("reported displaced container as recoverable:\n%s", stderr.String())
+	}
+	if _, err := os.Stat(*bootstrapDir); err != nil {
+		t.Fatalf("removed bootstrap directory referenced by winning claim: %v", err)
+	}
+	if args := recordedArgsForCommand(t, runner, "rm"); !strings.Contains(args, "container-pending") {
+		t.Fatalf("readiness failure did not remove displaced container:\n%s", args)
+	}
+	core.RemoveLeaseClaim(*leaseID)
+	core.RemoveStoredTestboxKey(*leaseID)
+	_ = os.RemoveAll(*bootstrapDir)
+}
+
+func TestKeepFalseReadinessRollbackFailurePrintsRecovery(t *testing.T) {
+	b, _, stderr, leaseID, _, containerPresent := pendingAcquireBackend(t)
+	b.waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error {
+		claim, err := core.ReadLeaseClaim(*leaseID)
+		if err != nil {
+			return err
+		}
+		labels := cloneLabels(claim.Labels)
+		labels["concurrent_touch"] = "true"
+		if _, err := core.UpdateLeaseClaimLabelsIfUnchanged(*leaseID, claim, labels); err != nil {
+			return err
+		}
+		return context.Canceled
+	}
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{Keep: false, Repo: core.Repo{Root: t.TempDir()}})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Acquire error=%v", err)
+	}
+	if !*containerPresent {
+		t.Fatal("same-identity replacement claim did not retain container")
+	}
+	if !strings.Contains(stderr.String(), "cleanup:") {
+		t.Fatalf("keep=false retained failure omitted recovery commands:\n%s", stderr.String())
+	}
+	claim, err := core.ReadLeaseClaim(*leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claim.CloudID != "container-pending" || claim.Labels["concurrent_touch"] != "true" {
+		t.Fatalf("retained claim=%#v", claim)
+	}
+	lease := core.LeaseTarget{LeaseID: *leaseID, Server: core.Server{CloudID: claim.CloudID, Labels: claim.Labels}}
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAcquirePendingClaimCannotAuthorizeReplacementContainer(t *testing.T) {
+	b, runner, _, leaseID, bootstrapDir, containerPresent := pendingAcquireBackend(t)
+	originalRun := runner.run
+	injected := false
+	runner.run = func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		result, err := originalRun(req)
+		if err != nil || firstArg(req.Args) != "run" || injected {
+			return result, err
+		}
+		injected = true
+		server := core.Server{
+			CloudID:  "newer-container",
+			Provider: providerName,
+			Labels: map[string]string{
+				"provider": providerName,
+				"lease":    *leaseID,
+				"slug":     "newer-owner",
+				"state":    "ready",
+			},
+		}
+		claimErr := core.ClaimLeaseForRepoProviderScopePondEndpoint(
+			*leaseID,
+			"newer-owner",
+			providerName,
+			"runtime:docker/context:default",
+			"",
+			t.TempDir(),
+			time.Minute,
+			false,
+			server,
+			core.SSHTarget{Host: "127.0.0.1", Port: "49171"},
+		)
+		return result, claimErr
+	}
+	b.waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error {
+		t.Fatal("readiness wait started before exact pending claim publication")
+		return nil
+	}
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{Keep: true, Repo: core.Repo{Root: t.TempDir()}})
+	if err == nil || !strings.Contains(err.Error(), "claim changed") {
+		t.Fatalf("Acquire error=%v, want claim collision", err)
+	}
+	claim, err := core.ReadLeaseClaim(*leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claim.CloudID != "newer-container" || claim.Labels["state"] != "ready" {
+		t.Fatalf("newer claim was replaced=%#v", claim)
+	}
+	if *containerPresent {
+		t.Fatal("unclaimed replacement container survived")
+	}
+	if _, err := os.Stat(*bootstrapDir); !os.IsNotExist(err) {
+		t.Fatalf("replacement bootstrap directory survived: %v", err)
+	}
+	core.RemoveLeaseClaim(*leaseID)
+	core.RemoveStoredTestboxKey(*leaseID)
+}
+
+func pendingAcquireBackend(t *testing.T) (*backend, *recordingRunner, *strings.Builder, *string, *string, *bool) {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	var leaseID string
+	var bootstrapDir string
+	containerPresent := false
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	runner.run = func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		if result, ok := defaultLocalContainerScopeResponse(req); ok {
+			return result, nil
+		}
+		switch firstArg(req.Args) {
+		case "ps":
+			if containerPresent {
+				return core.LocalCommandResult{Stdout: "container-pending\n"}, nil
+			}
+			return core.LocalCommandResult{}, nil
+		case "run":
+			leaseID = labelFromRunArgs(t, req.Args, "lease")
+			bootstrapDir = bootstrapDirFromRunArgs(t, []core.LocalCommandRequest{req})
+			containerPresent = true
+			return core.LocalCommandResult{Stdout: "container-pending\n"}, nil
+		case "inspect":
+			if !containerPresent {
+				return core.LocalCommandResult{Stderr: "not found", ExitCode: 1}, errors.New("not found")
+			}
+			labels := map[string]string{
+				"crabbox": "true", "provider": providerName, "lease": leaseID, "slug": "pending-test",
+				"state": pendingClaimState, "recovery": pendingRecoveryKind, "runtime": "docker",
+				"server_type": "ubuntu:24.04", "ssh_user": "runner", "work_root": "/workspace/crabbox",
+				"bootstrap_dir": bootstrapDir, "ssh_key_owned": "true", "bootstrap_owned": "true", "keep": "true",
+			}
+			data, err := json.Marshal([]inspectContainer{{
+				ID: "container-pending", Name: "/crabbox-pending", Config: inspectConfig{Image: "ubuntu:24.04", Labels: labels},
+				State:           inspectState{Status: "running", Running: true},
+				NetworkSettings: inspectNetworking{Ports: map[string][]inspectPort{"2222/tcp": {{HostIP: "127.0.0.1", HostPort: "49170"}}}},
+			}})
+			return core.LocalCommandResult{Stdout: string(data)}, err
+		case "rm":
+			containerPresent = false
+			return core.LocalCommandResult{}, nil
+		default:
+			return core.LocalCommandResult{}, nil
+		}
+	}
+	stderr := &strings.Builder{}
+	b := testBackend(runner)
+	b.rt.Stderr = stderr
+	return b, runner, stderr, &leaseID, &bootstrapDir, &containerPresent
+}
+
+func TestAcquirePinsDockerLifecycleToCapturedContext(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	var leaseID string
+	var bootstrapDir string
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	runner.run = func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		if len(req.Args) < 3 || req.Args[0] != "--context" || req.Args[1] != "pinned-context" {
+			t.Fatalf("Docker lifecycle command was not pinned: %v", req.Args)
+		}
+		args := req.Args[2:]
+		switch firstArg(args) {
+		case "ps":
+			return core.LocalCommandResult{}, nil
+		case "run":
+			leaseID = labelFromRunArgs(t, args, "lease")
+			bootstrapDir = bootstrapDirFromRunArgs(t, []core.LocalCommandRequest{{Args: args}})
+			return core.LocalCommandResult{Stdout: "pinned-container\n"}, nil
+		case "inspect":
+			labels := map[string]string{
+				"crabbox": "true", "provider": providerName, "lease": leaseID, "slug": "pinned",
+				"state": pendingClaimState, "recovery": pendingRecoveryKind, "runtime": "docker",
+				"server_type": "ubuntu:24.04", "ssh_user": "runner", "work_root": "/workspace/crabbox",
+				"bootstrap_dir": bootstrapDir, checkpointMetadataContext: "pinned-context",
+				checkpointMetadataEndpoint: "unix:///pinned.sock", checkpointMetadataDaemonID: "daemon-pinned",
+			}
+			data, err := json.Marshal([]inspectContainer{{
+				ID: "pinned-container", Name: "/pinned", Config: inspectConfig{Image: "ubuntu:24.04", Labels: labels},
+				State:           inspectState{Status: "running", Running: true},
+				NetworkSettings: inspectNetworking{Ports: map[string][]inspectPort{"2222/tcp": {{HostIP: "127.0.0.1", HostPort: "49173"}}}},
+			}})
+			return core.LocalCommandResult{Stdout: string(data)}, err
+		case "rm":
+			return core.LocalCommandResult{}, nil
+		default:
+			return core.LocalCommandResult{}, nil
+		}
+	}
+	b := testBackend(runner)
+	b.captureRuntimeScope = func(context.Context, core.Config) (checkpointScope, error) {
+		return checkpointScope{Runtime: "docker", Context: "pinned-context", Endpoint: "unix:///pinned.sock", DaemonID: "daemon-pinned"}, nil
+	}
+	b.waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error {
+		return context.Canceled
+	}
+	if _, err := b.Acquire(context.Background(), core.AcquireRequest{Keep: true, Repo: core.Repo{Root: t.TempDir()}}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Acquire error=%v", err)
+	}
+	claim, err := core.ReadLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claim.ProviderScope != "runtime:docker/context:pinned-context" || claim.Labels[checkpointMetadataDaemonID] != "daemon-pinned" {
+		t.Fatalf("pinned claim=%#v", claim)
+	}
+	lease := core.LeaseTarget{LeaseID: leaseID, Server: core.Server{CloudID: claim.CloudID, Labels: claim.Labels}}
+	if err := b.rollbackPendingLease(claim, lease, bootstrapDir); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestUnclaimedRollbackContinuesSidecarCleanupAfterError(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	leaseID := "cbx_rollback_sidecars"
+	keyPath, err := core.TestboxKeyPath(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(keyPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyPath, []byte("private"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	hostRoot := t.TempDir()
+	markTestLocalContainerWorkRoot(t, hostRoot)
+	hostLeaseRoot := filepath.Join(hostRoot, leaseID)
+	if err := os.MkdirAll(hostLeaseRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	bootstrapDir, err := os.MkdirTemp("", "crabbox-bootstrap-sidecar-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(bootstrapDir) })
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+		commandKey([]string{"rm", "-f", "sidecar-container"}): {},
+	}}
+	b := testBackend(runner)
+	b.removeAll = func(path string) error {
+		if path == hostLeaseRoot {
+			return errors.New("host cleanup failed")
+		}
+		return os.RemoveAll(path)
+	}
+	lease := core.LeaseTarget{LeaseID: leaseID, Server: core.Server{CloudID: "sidecar-container", Labels: map[string]string{
+		"docker_socket": "1", "host_work_root": hostRoot, "work_root": "/work/crabbox",
+	}}}
+	retained, err := b.reconcileChangedClaim(lease, bootstrapDir)
+	if retained || err == nil || !strings.Contains(err.Error(), "host cleanup failed") {
+		t.Fatalf("retained=%v err=%v", retained, err)
+	}
+	if _, err := os.Stat(bootstrapDir); !os.IsNotExist(err) {
+		t.Fatalf("bootstrap cleanup did not continue: %v", err)
+	}
+	if _, err := os.Stat(keyPath); !os.IsNotExist(err) {
+		t.Fatalf("key cleanup did not continue: %v", err)
+	}
+}
+
+func TestPendingRollbackContinuesSidecarAndKeyCleanupAfterError(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	leaseID := "cbx_pending_sidecars"
+	keyPath, err := core.TestboxKeyPath(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(keyPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyPath, []byte("private"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	hostRoot := t.TempDir()
+	markTestLocalContainerWorkRoot(t, hostRoot)
+	hostLeaseRoot := filepath.Join(hostRoot, leaseID)
+	if err := os.MkdirAll(hostLeaseRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	bootstrapDir, err := os.MkdirTemp("", "crabbox-bootstrap-pending-sidecar-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(bootstrapDir) })
+	labels := map[string]string{
+		"provider": providerName, "lease": leaseID, "slug": "pending-sidecars",
+		"state": pendingClaimState, "recovery": pendingRecoveryKind, "keep": "false",
+		"docker_socket": "1", "host_work_root": hostRoot, "work_root": "/work/crabbox",
+		"bootstrap_dir": bootstrapDir,
+	}
+	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(
+		leaseID,
+		"pending-sidecars",
+		providerName,
+		"runtime:docker/context:default",
+		"",
+		t.TempDir(),
+		time.Minute,
+		false,
+		core.Server{CloudID: "pending-sidecar-container", Provider: providerName, Labels: labels},
+		core.SSHTarget{},
+	); err != nil {
+		t.Fatal(err)
+	}
+	claim, err := core.ReadLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+		commandKey([]string{"rm", "-f", "pending-sidecar-container"}): {},
+	}}
+	b := testBackend(runner)
+	b.removeAll = func(path string) error {
+		if path == hostLeaseRoot {
+			return errors.New("host cleanup failed")
+		}
+		return os.RemoveAll(path)
+	}
+	lease := core.LeaseTarget{LeaseID: leaseID, Server: core.Server{CloudID: claim.CloudID, Labels: claim.Labels}}
+	err = b.rollbackPendingLease(claim, lease, bootstrapDir)
+	if err == nil || !strings.Contains(err.Error(), "host cleanup failed") {
+		t.Fatalf("rollback error=%v", err)
+	}
+	if _, err := os.Stat(bootstrapDir); !os.IsNotExist(err) {
+		t.Fatalf("bootstrap cleanup did not continue: %v", err)
+	}
+	if _, err := os.Stat(keyPath); !os.IsNotExist(err) {
+		t.Fatalf("key cleanup did not continue: %v", err)
+	}
+	if current, err := core.ReadLeaseClaim(leaseID); err != nil || current.LeaseID != leaseID {
+		t.Fatalf("claim should remain for sidecar retry: %#v err=%v", current, err)
+	}
+	core.RemoveLeaseClaim(leaseID)
+}
+
+func TestClaimCleanupDoesNotDeleteReplacementKeyAfterFence(t *testing.T) {
+	for _, action := range []string{"rollback", "release", "missing-release"} {
+		t.Run(action, func(t *testing.T) {
+			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			leaseID := "cbx_key_fence_" + strings.ReplaceAll(action, "-", "_")
+			labels := map[string]string{"provider": providerName, "lease": leaseID, "slug": "key-fence", "state": pendingClaimState, "keep": "false"}
+			labels = testCapturedScopeLabels(labels)
+			cloudID := "old-container"
+			if action == "missing-release" {
+				cloudID = ""
+			}
+			if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(
+				leaseID, "key-fence", providerName, "runtime:docker/context:default", "", t.TempDir(), time.Minute, false,
+				core.Server{CloudID: cloudID, Provider: providerName, Labels: labels}, core.SSHTarget{},
+			); err != nil {
+				t.Fatal(err)
+			}
+			keyPath, err := core.TestboxKeyPath(leaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.MkdirAll(filepath.Dir(keyPath), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(keyPath, []byte("old"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+			if cloudID != "" {
+				runner.responses[commandKey([]string{"rm", "-f", cloudID})] = core.LocalCommandResult{}
+			}
+			addDefaultLocalContainerScopeResponses(runner)
+			b := testBackend(runner)
+			b.afterClaimCleanup = func(id string) {
+				replacementLabels := map[string]string{"provider": providerName, "lease": id, "slug": "replacement", "state": "ready"}
+				if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(
+					id, "replacement", providerName, "runtime:docker/context:default", "", t.TempDir(), time.Minute, false,
+					core.Server{CloudID: "replacement-container", Provider: providerName, Labels: replacementLabels}, core.SSHTarget{},
+				); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.MkdirAll(filepath.Dir(keyPath), 0o700); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(keyPath, []byte("replacement"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			claim, err := core.ReadLeaseClaim(leaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			switch action {
+			case "rollback":
+				lease := core.LeaseTarget{LeaseID: leaseID, Server: core.Server{CloudID: cloudID, Labels: claim.Labels}}
+				if err := b.rollbackPendingLease(claim, lease, ""); err != nil {
+					t.Fatal(err)
+				}
+			case "release":
+				server := core.Server{CloudID: cloudID, Labels: claim.Labels}
+				core.SetServerLeaseClaimSnapshot(&server, claim, true)
+				if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: server}}); err != nil {
+					t.Fatal(err)
+				}
+			case "missing-release":
+				lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: leaseID, ReleaseOnly: true})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
+					t.Fatal(err)
+				}
+			}
+			data, err := os.ReadFile(keyPath)
+			if err != nil || string(data) != "replacement" {
+				t.Fatalf("replacement key=%q err=%v", data, err)
+			}
+			replacement, err := core.ReadLeaseClaim(leaseID)
+			if err != nil || replacement.CloudID != "replacement-container" {
+				t.Fatalf("replacement claim=%#v err=%v", replacement, err)
+			}
+			core.RemoveLeaseClaim(leaseID)
+			core.RemoveStoredTestboxKey(leaseID)
+		})
 	}
 }
 
@@ -2042,6 +3102,9 @@ func TestListAndResolveContainers(t *testing.T) {
 	if views[0].Provider != providerName || views[0].CloudID != "abcdef1234567890" || views[0].Labels["ssh_port"] != "49153" {
 		t.Fatalf("unexpected view: %#v", views[0])
 	}
+	if owned, conflict, statusErr := b.localContainerClaimStatus(context.Background(), "cbx_123", "abcdef1234567890"); statusErr != nil || !owned || conflict {
+		t.Fatalf("claim status owned=%v conflict=%v err=%v", owned, conflict, statusErr)
+	}
 
 	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "blue-lobster"})
 	if err != nil {
@@ -2049,6 +3112,45 @@ func TestListAndResolveContainers(t *testing.T) {
 	}
 	if lease.LeaseID != "cbx_123" || lease.SSH.Host != "127.0.0.1" || lease.SSH.Port != "49153" || lease.SSH.User != "runner" || lease.SSH.TargetOS != core.TargetLinux || len(lease.SSH.FallbackPorts) != 0 || !strings.Contains(lease.SSH.ReadyCheck, "rsync --version") {
 		t.Fatalf("unexpected lease: %#v", lease)
+	}
+}
+
+func TestResolvePendingClaimDoesNotRequirePublishedSSHPort(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	leaseID := "cbx_pending_no_port"
+	labels := map[string]string{
+		"crabbox": "true", "provider": providerName, "lease": leaseID, "slug": "pending-no-port",
+		"state": pendingClaimState, "recovery": pendingRecoveryKind, "runtime": "docker",
+		"server_type": "ubuntu:24.04", "ssh_user": "runner", "work_root": "/workspace/crabbox",
+	}
+	labels = testCapturedScopeLabels(labels)
+	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(
+		leaseID,
+		"pending-no-port",
+		providerName,
+		"runtime:docker/context:default",
+		"",
+		t.TempDir(),
+		time.Minute,
+		false,
+		core.Server{CloudID: "pending-container", Provider: providerName, Labels: labels},
+		core.SSHTarget{},
+	); err != nil {
+		t.Fatal(err)
+	}
+	inspectJSON := `[{"Id":"pending-container","Name":"/pending-container","Config":{"Image":"ubuntu:24.04","Labels":{"crabbox":"true","provider":"local-container","lease":"cbx_pending_no_port","slug":"pending-no-port","state":"provisioning","recovery":"ssh-readiness-pending","ssh_user":"runner","work_root":"/workspace/crabbox"}},"State":{"Status":"running","Running":true},"NetworkSettings":{"Ports":{}}}]`
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+		commandKey([]string{"ps", "-a", "--filter", "label=crabbox=true", "--filter", "label=provider=local-container", "--format", "{{.ID}}"}): {Stdout: "pending-container\n"},
+		commandKey([]string{"inspect", "pending-container"}): {Stdout: inspectJSON},
+	}}
+	addDefaultLocalContainerScopeResponses(runner)
+	b := testBackend(runner)
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: leaseID, StatusOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.Server.Status != pendingClaimState || lease.Server.Labels["recovery"] != pendingRecoveryKind || lease.SSH.Host != "" || lease.SSH.Port != "" {
+		t.Fatalf("pending lease=%#v", lease)
 	}
 }
 
@@ -2166,6 +3268,79 @@ func TestReleaseLeaseRemovesStoredKey(t *testing.T) {
 	}
 }
 
+func TestReleaseLeaseContinuesSidecarAndKeyCleanupAfterError(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	leaseID := "cbx_release_sidecars"
+	keyPath, err := core.TestboxKeyPath(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(keyPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyPath, []byte("private"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	hostRoot := t.TempDir()
+	markTestLocalContainerWorkRoot(t, hostRoot)
+	hostLeaseRoot := filepath.Join(hostRoot, leaseID)
+	if err := os.MkdirAll(hostLeaseRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	bootstrapDir, err := os.MkdirTemp("", "crabbox-bootstrap-release-sidecar-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(bootstrapDir) })
+	labels := map[string]string{
+		"provider": providerName, "lease": leaseID, "slug": "release-sidecars", "state": "ready",
+		"docker_socket": "1", "host_work_root": hostRoot, "work_root": "/work/crabbox",
+		"bootstrap_dir": bootstrapDir,
+	}
+	labels = testCapturedScopeLabels(labels)
+	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(
+		leaseID,
+		"release-sidecars",
+		providerName,
+		"runtime:docker/context:default",
+		"",
+		t.TempDir(),
+		time.Minute,
+		false,
+		core.Server{CloudID: "release-sidecar-container", Provider: providerName, Labels: labels},
+		core.SSHTarget{},
+	); err != nil {
+		t.Fatal(err)
+	}
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+		commandKey([]string{"rm", "-f", "release-sidecar-container"}): {},
+	}}
+	addDefaultLocalContainerScopeResponses(runner)
+	b := testBackend(runner)
+	b.removeAll = func(path string) error {
+		if path == hostLeaseRoot {
+			return errors.New("host cleanup failed")
+		}
+		return os.RemoveAll(path)
+	}
+	lease := core.LeaseTarget{LeaseID: leaseID, Server: core.Server{CloudID: "release-sidecar-container", Labels: labels}}
+	err = b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease})
+	if err == nil || !strings.Contains(err.Error(), "host cleanup failed") {
+		t.Fatalf("release error=%v", err)
+	}
+	if _, err := os.Stat(bootstrapDir); !os.IsNotExist(err) {
+		t.Fatalf("bootstrap cleanup did not continue: %v", err)
+	}
+	if _, err := os.Stat(keyPath); !os.IsNotExist(err) {
+		t.Fatalf("key cleanup did not continue: %v", err)
+	}
+	if claim, err := core.ReadLeaseClaim(leaseID); err != nil || claim.LeaseID != leaseID {
+		t.Fatalf("claim should remain for sidecar retry: %#v err=%v", claim, err)
+	}
+	core.RemoveLeaseClaim(leaseID)
+}
+
 func TestReleaseLeaseRejectsUnclaimedContainer(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
@@ -2215,6 +3390,120 @@ func TestReleaseLeaseRejectsClaimBoundToDifferentContainerOrScope(t *testing.T) 
 			}
 		})
 	}
+}
+
+func TestExactClaimValidatesCapturedEndpointAndDaemon(t *testing.T) {
+	base := checkpointScope{
+		Runtime:  "docker",
+		Context:  "named-context",
+		Config:   "/tmp/docker-config",
+		Endpoint: "unix:///captured.sock",
+		DaemonID: "daemon-captured",
+	}
+	for _, tc := range []struct {
+		name          string
+		current       checkpointScope
+		validationErr error
+		wantErr       bool
+	}{
+		{name: "matching", current: base},
+		{name: "endpoint mismatch", current: func() checkpointScope { value := base; value.Endpoint = "unix:///other.sock"; return value }(), wantErr: true},
+		{name: "daemon metadata mismatch", current: func() checkpointScope { value := base; value.DaemonID = "daemon-other"; return value }(), wantErr: true},
+		{name: "live daemon mismatch", current: base, validationErr: errors.New("daemon changed"), wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			b := testBackend(&recordingRunner{})
+			b.cfg.LocalContainer.CheckpointMetadata = checkpointScopeMetadata(tc.current)
+			b.validateRuntimeScope = func(context.Context, checkpointScope) error { return tc.validationErr }
+			claim := core.LeaseClaim{
+				LeaseID:       "cbx_exact_scope",
+				Provider:      providerName,
+				CloudID:       "container-scope",
+				ProviderScope: "runtime:docker/context:named-context",
+				Labels:        checkpointScopeMetadata(base),
+			}
+			err := b.validateExactLocalContainerClaim(context.Background(), claim, claim.LeaseID, claim.CloudID)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("error=%v wantErr=%v", err, tc.wantErr)
+			}
+			if got := b.claimMatchesCurrentScope(context.Background(), claim); got == tc.wantErr {
+				t.Fatalf("claimMatchesCurrentScope=%v want=%v", got, !tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestReleaseRejectsCapturedDaemonMismatchBeforeRemove(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	leaseID := "cbx_daemon_mismatch"
+	scope := checkpointScope{Runtime: "docker", Context: "named", Config: "/tmp/docker-config", Endpoint: "unix:///captured.sock", DaemonID: "daemon-captured"}
+	labels := checkpointScopeMetadata(scope)
+	labels["provider"] = providerName
+	labels["lease"] = leaseID
+	labels["slug"] = "daemon-mismatch"
+	labels["state"] = "ready"
+	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(
+		leaseID, "daemon-mismatch", providerName, "runtime:docker/context:named", "", t.TempDir(), time.Minute, false,
+		core.Server{CloudID: "daemon-container", Provider: providerName, Labels: labels}, core.SSHTarget{},
+	); err != nil {
+		t.Fatal(err)
+	}
+	claim, err := core.ReadLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := core.Server{CloudID: claim.CloudID, Labels: claim.Labels}
+	core.SetServerLeaseClaimSnapshot(&server, claim, true)
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+		commandKey([]string{"rm", "-f", "daemon-container"}): {},
+	}}
+	b := testBackend(runner)
+	b.validateRuntimeScope = func(context.Context, checkpointScope) error { return errors.New("daemon changed") }
+	err = b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: server}})
+	if err == nil {
+		t.Fatal("release accepted changed daemon")
+	}
+	for _, call := range runner.calls {
+		if firstArg(call.Args) == "rm" {
+			t.Fatalf("daemon mismatch reached rm: %v", call.Args)
+		}
+	}
+	core.RemoveLeaseClaim(leaseID)
+}
+
+func TestReleaseLeaseRejectsClaimChangedAfterResolution(t *testing.T) {
+	leaseID := "cbx_release_snapshot"
+	writeLocalContainerReleaseClaim(t, leaseID, "snapshot-container")
+	claim, err := core.ReadLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := core.Server{CloudID: "snapshot-container", Labels: map[string]string{"lease": leaseID}}
+	core.SetServerLeaseClaimSnapshot(&server, claim, true)
+	labels := cloneLabels(claim.Labels)
+	labels["state"] = "newer"
+	if _, err := core.UpdateLeaseClaimLabelsIfUnchanged(leaseID, claim, labels); err != nil {
+		t.Fatal(err)
+	}
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+		commandKey([]string{"rm", "-f", "snapshot-container"}): {},
+	}}
+	addDefaultLocalContainerScopeResponses(runner)
+	b := testBackend(runner)
+	err = b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: server}})
+	if err == nil || !strings.Contains(err.Error(), "claim changed") {
+		t.Fatalf("release error=%v", err)
+	}
+	for _, call := range runner.calls {
+		if firstArg(call.Args) == "rm" {
+			t.Fatalf("stale release removed winning resource: %v", call.Args)
+		}
+	}
+	current, err := core.ReadLeaseClaim(leaseID)
+	if err != nil || current.Labels["state"] != "newer" {
+		t.Fatalf("winning claim=%#v err=%v", current, err)
+	}
+	core.RemoveLeaseClaim(leaseID)
 }
 
 func TestResolveRawContainerRequiresExplicitReclaimAndPersistsBinding(t *testing.T) {
@@ -2269,7 +3558,17 @@ func TestLegacyLocalContainerClaimRequiresReclaimBeforeStop(t *testing.T) {
 	if err := writeLocalContainerClaim(t, leaseID, "legacy-local", "runtime:docker/context:default", time.Now().UTC(), time.Minute); err != nil {
 		t.Fatal(err)
 	}
-	inspectJSON := `[{"Id":"legacy-container","Name":"/legacy-container","Config":{"Image":"ubuntu:24.04","Labels":{"crabbox":"true","provider":"local-container","lease":"cbx_legacy_local","slug":"legacy-local","state":"ready","ssh_user":"runner","work_root":"/workspace/crabbox"}},"State":{"Status":"running","Running":true},"NetworkSettings":{"Ports":{"2222/tcp":[{"HostIp":"127.0.0.1","HostPort":"49160"}]}}}]`
+	legacy, err := core.ReadLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacement := legacy
+	replacement.CloudID = "legacy-container"
+	replacement.Labels = nil
+	if err := core.ReplaceLeaseClaimIfUnchanged(leaseID, legacy, replacement); err != nil {
+		t.Fatal(err)
+	}
+	inspectJSON := `[{"Id":"legacy-container","Name":"/legacy-container","Config":{"Image":"ubuntu:24.04","Labels":{"crabbox":"true","provider":"local-container","lease":"cbx_legacy_local","slug":"legacy-local","state":"ready","ssh_user":"runner","work_root":"/workspace/crabbox","runtime":"docker","docker_context":"stale-context","docker_endpoint":"unix:///stale.sock","docker_daemon_id":"stale-daemon"}},"State":{"Status":"running","Running":true},"NetworkSettings":{"Ports":{"2222/tcp":[{"HostIp":"127.0.0.1","HostPort":"49160"}]}}}]`
 	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
 		commandKey([]string{"ps", "-a", "--filter", "label=crabbox=true", "--filter", "label=provider=local-container", "--format", "{{.ID}}"}): {Stdout: "legacy-container\n"},
 		commandKey([]string{"inspect", "legacy-container"}):  {Stdout: inspectJSON},
@@ -2288,8 +3587,11 @@ func TestLegacyLocalContainerClaimRequiresReclaimBeforeStop(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if claim.CloudID != "legacy-container" || claim.ProviderScope != "runtime:docker/context:default" {
+	if claim.CloudID != "legacy-container" || claim.ProviderScope != "runtime:docker/context:default" || !hasCompleteCapturedRuntimeScope(claim.Labels) {
 		t.Fatalf("legacy reclaim binding=%#v", claim)
+	}
+	if claim.Labels[checkpointMetadataEndpoint] != "unix:///tmp/docker-test.sock" || claim.Labels[checkpointMetadataDaemonID] != "daemon-test" {
+		t.Fatalf("legacy reclaim trusted stale container scope: %#v", claim.Labels)
 	}
 	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
 		t.Fatal(err)
@@ -2405,6 +3707,126 @@ func TestReleaseOnlyResolveMissingContainerClaim(t *testing.T) {
 	}
 	if _, err := os.Stat(keyPath); !os.IsNotExist(err) {
 		t.Fatalf("stored key still exists after release: %v", err)
+	}
+}
+
+func TestMissingReleaseRejectsClaimChangedAfterResolution(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	leaseID := "cbx_missing_snapshot"
+	keyPath := writeLocalContainerClaimAndKey(t, leaseID, "missing-snapshot", localContainerClaimScope("docker", "default"))
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+		commandKey([]string{"ps", "-a", "--filter", "label=crabbox=true", "--filter", "label=provider=local-container", "--format", "{{.ID}}"}): {},
+		commandKey([]string{"context", "show"}): {Stdout: "default\n"},
+	}}
+	b := testBackend(runner)
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: leaseID, ReleaseOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim, err := core.ReadLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	labels := cloneLabels(claim.Labels)
+	labels["state"] = "ready"
+	if _, err := core.UpdateLeaseClaimEndpointIfUnchanged(
+		leaseID,
+		claim,
+		core.Server{CloudID: "newer-live-container", Provider: providerName, Labels: labels},
+		core.SSHTarget{Host: "127.0.0.1", Port: "49175"},
+	); err != nil {
+		t.Fatal(err)
+	}
+	err = b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease})
+	if err == nil || !strings.Contains(err.Error(), "claim changed") {
+		t.Fatalf("missing release error=%v", err)
+	}
+	current, err := core.ReadLeaseClaim(leaseID)
+	if err != nil || current.CloudID != "newer-live-container" {
+		t.Fatalf("winning claim=%#v err=%v", current, err)
+	}
+	if _, err := os.Stat(keyPath); err != nil {
+		t.Fatalf("stale missing release removed winning key: %v", err)
+	}
+	core.RemoveLeaseClaim(leaseID)
+	core.RemoveStoredTestboxKey(leaseID)
+}
+
+func TestMissingReleaseReconfirmsExactAbsenceInsideFence(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	leaseID := "cbx_missing_reappeared"
+	labels := testCapturedScopeLabels(map[string]string{"provider": providerName, "lease": leaseID, "slug": "missing-reappeared", "state": pendingClaimState, "keep": "true"})
+	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(
+		leaseID, "missing-reappeared", providerName, "runtime:docker/context:default", "", t.TempDir(), time.Minute, false,
+		core.Server{CloudID: "reappeared-container", Provider: providerName, Labels: labels}, core.SSHTarget{},
+	); err != nil {
+		t.Fatal(err)
+	}
+	keyPath, err := core.TestboxKeyPath(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(keyPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyPath, []byte("private"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+		commandKey([]string{"ps", "-a", "--filter", "label=crabbox=true", "--filter", "label=provider=local-container", "--format", "{{.ID}}"}): {},
+	}}
+	addDefaultLocalContainerScopeResponses(runner)
+	b := testBackend(runner)
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: leaseID, ReleaseOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b.confirmContainerAbsent = func(context.Context, string) (bool, error) { return false, nil }
+	err = b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease})
+	if err == nil || !strings.Contains(err.Error(), "still exists") {
+		t.Fatalf("release error=%v", err)
+	}
+	claim, err := core.ReadLeaseClaim(leaseID)
+	if err != nil || claim.LeaseID != leaseID {
+		t.Fatalf("claim=%#v err=%v", claim, err)
+	}
+	if _, err := os.Stat(keyPath); err != nil {
+		t.Fatalf("key removed despite reappeared container: %v", err)
+	}
+	core.RemoveLeaseClaim(leaseID)
+	core.RemoveStoredTestboxKey(leaseID)
+}
+
+func TestExactContainerAbsenceRejectsRoutingNotFound(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		detail     string
+		wantAbsent bool
+		wantErr    bool
+	}{
+		{name: "missing object", detail: "Error: No such object: " + testRecoveredContainerID, wantAbsent: true},
+		{name: "missing container", detail: "container " + testRecoveredContainerID + " not found", wantAbsent: true},
+		{name: "missing podman container", detail: `Error: no container with name or ID "` + testRecoveredContainerID + `" found: no such container`, wantAbsent: true},
+		{name: "missing docker context", detail: `context "captured" not found`, wantErr: true},
+		{name: "missing podman connection", detail: `connection "captured" not found`, wantErr: true},
+		{name: "container runtime endpoint missing", detail: `container runtime endpoint not found while inspecting ` + testRecoveredContainerID, wantErr: true},
+		{name: "container connection missing", detail: `container connection "captured" does not exist for ` + testRecoveredContainerID, wantErr: true},
+		{name: "endpoint failure wrapping missing object", detail: `container runtime endpoint not found: no such container: ` + testRecoveredContainerID, wantErr: true},
+		{name: "connection failure wrapping missing container", detail: `container connection "captured" does not exist; container ` + testRecoveredContainerID + ` not found`, wantErr: true},
+		{name: "unrelated missing container", detail: "container bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb not found", wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := &recordingRunner{run: func(core.LocalCommandRequest) (core.LocalCommandResult, error) {
+				return core.LocalCommandResult{Stderr: tc.detail, ExitCode: 1}, errors.New("inspect failed")
+			}}
+			b := testBackend(runner)
+			absent, err := b.exactContainerAbsent(context.Background(), testRecoveredContainerID)
+			if absent != tc.wantAbsent || (err != nil) != tc.wantErr {
+				t.Fatalf("absent=%v err=%v", absent, err)
+			}
+		})
 	}
 }
 
@@ -2587,6 +4009,318 @@ func TestReleaseLeaseWithIDResolvesHostWorkRoot(t *testing.T) {
 	}
 }
 
+type cleanupClaimFixture struct {
+	b             *backend
+	runner        *recordingRunner
+	claim         core.LeaseClaim
+	leaseID       string
+	containerID   string
+	keyPath       string
+	bootstrapDir  string
+	hostLeaseRoot string
+	output        *strings.Builder
+}
+
+func newCleanupClaimFixture(t *testing.T, leaseID, containerID, status string, keep bool) *cleanupClaimFixture {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	hostRoot := t.TempDir()
+	markTestLocalContainerWorkRoot(t, hostRoot)
+	hostLeaseRoot := filepath.Join(hostRoot, leaseID)
+	if err := os.MkdirAll(filepath.Join(hostLeaseRoot, "repo"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	bootstrapDir, err := os.MkdirTemp("", "crabbox-bootstrap-cleanup-fence-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(bootstrapDir) })
+	labels := testCapturedScopeLabels(map[string]string{
+		"crabbox": "true", "provider": providerName, "lease": leaseID, "slug": "cleanup-fence",
+		"state": "ready", "keep": strconv.FormatBool(keep), "docker_socket": "1",
+		"host_work_root": hostRoot, "bootstrap_dir": bootstrapDir, "bootstrap_owned": "true", "ssh_key_owned": "true",
+	})
+	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(
+		leaseID, "cleanup-fence", providerName, "runtime:docker/context:default", "", t.TempDir(), time.Minute, false,
+		core.Server{CloudID: containerID, Provider: providerName, Labels: labels}, core.SSHTarget{},
+	); err != nil {
+		t.Fatal(err)
+	}
+	claim, err := core.ReadLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyPath, err := core.TestboxKeyPath(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(keyPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyPath, []byte("private"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		core.RemoveLeaseClaim(leaseID)
+		core.RemoveStoredTestboxKey(leaseID)
+	})
+	containerLabels := publicLocalContainerClaimLabels(labels)
+	running := status == "running"
+	inspectData, err := json.Marshal([]inspectContainer{{
+		ID: containerID, Name: "/cleanup-fence", Config: inspectConfig{Image: "ubuntu:24.04", Labels: containerLabels},
+		State: inspectState{Status: status, Running: running},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+		commandKey([]string{"ps", "-a", "--filter", "label=crabbox=true", "--filter", "label=provider=local-container", "--format", "{{.ID}}"}): {Stdout: containerID + "\n"},
+		commandKey([]string{"inspect", containerID}):  {Stdout: string(inspectData)},
+		commandKey([]string{"rm", "-f", containerID}): {},
+	}}
+	addDefaultLocalContainerScopeResponses(runner)
+	output := &strings.Builder{}
+	b := testBackend(runner)
+	b.rt.Stdout = output
+	b.rt.Stderr = output
+	return &cleanupClaimFixture{
+		b: b, runner: runner, claim: claim, leaseID: leaseID, containerID: containerID,
+		keyPath: keyPath, bootstrapDir: bootstrapDir, hostLeaseRoot: hostLeaseRoot, output: output,
+	}
+}
+
+func (f *cleanupClaimFixture) expire(t *testing.T) {
+	t.Helper()
+	updated, err := core.UpdateLeaseClaimLabelsAndLastUsedIfUnchanged(
+		f.leaseID, f.claim, f.claim.Labels, time.Now().Add(-48*time.Hour),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.claim = updated
+}
+
+func (f *cleanupClaimFixture) assertOwnershipPresent(t *testing.T) {
+	t.Helper()
+	if _, err := os.Stat(f.keyPath); err != nil {
+		t.Fatalf("key missing: %v", err)
+	}
+	if _, err := os.Stat(f.bootstrapDir); err != nil {
+		t.Fatalf("bootstrap directory missing: %v", err)
+	}
+	if _, err := os.Stat(f.hostLeaseRoot); err != nil {
+		t.Fatalf("host lease root missing: %v", err)
+	}
+}
+
+func recordedCommandCount(runner *recordingRunner, command string) int {
+	count := 0
+	for _, call := range runner.calls {
+		if len(call.Args) > 0 && call.Args[0] == command {
+			count++
+		}
+	}
+	return count
+}
+
+func TestCleanupLiveClaimChangeFencesMutation(t *testing.T) {
+	for _, dryRun := range []bool{false, true} {
+		t.Run(fmt.Sprintf("dry_run_%t", dryRun), func(t *testing.T) {
+			fixture := newCleanupClaimFixture(t, "cbx_cleanup_reclaimed", "cleanup-old-container", "exited", false)
+			replacement := fixture.claim
+			replacement.CloudID = "cleanup-replacement-container"
+			replacement.Labels = cloneLabels(replacement.Labels)
+			replaced := false
+			fixture.b.beforeCleanupMutation = func(leaseID string) {
+				if leaseID != fixture.leaseID || replaced {
+					return
+				}
+				replaced = true
+				if err := core.ReplaceLeaseClaimIfUnchanged(fixture.leaseID, fixture.claim, replacement); err != nil {
+					t.Fatalf("replace cleanup claim: %v", err)
+				}
+			}
+			if err := fixture.b.Cleanup(context.Background(), core.CleanupRequest{DryRun: dryRun}); err != nil {
+				t.Fatal(err)
+			}
+			if recordedCommandCount(fixture.runner, "rm") != 0 {
+				t.Fatalf("cleanup removed container after claim rewrite: %s", fixture.output.String())
+			}
+			got, err := core.ReadLeaseClaim(fixture.leaseID)
+			if err != nil || got.CloudID != replacement.CloudID {
+				t.Fatalf("replacement claim=%#v err=%v", got, err)
+			}
+			fixture.assertOwnershipPresent(t)
+			if !strings.Contains(fixture.output.String(), "reason=changed-during-cleanup") {
+				t.Fatalf("cleanup did not report changed claim: %s", fixture.output.String())
+			}
+			if strings.Contains(fixture.output.String(), "remove container") {
+				t.Fatalf("cleanup reported removal after claim rewrite: %s", fixture.output.String())
+			}
+		})
+	}
+}
+
+func TestCleanupLiveClaimScopeChangeFailsClosed(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{name: "daemon identity", err: errors.New("daemon identity changed")},
+		{name: "endpoint identity", err: errors.New("endpoint identity changed")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := newCleanupClaimFixture(t, "cbx_cleanup_scope_change", "cleanup-scope-container", "exited", false)
+			fixture.b.validateRuntimeScope = func(context.Context, checkpointScope) error { return tc.err }
+			if err := fixture.b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+				t.Fatal(err)
+			}
+			if recordedCommandCount(fixture.runner, "rm") != 0 {
+				t.Fatalf("cleanup removed container after scope mismatch: %s", fixture.output.String())
+			}
+			got, err := core.ReadLeaseClaim(fixture.leaseID)
+			if err != nil || got.CloudID != fixture.containerID {
+				t.Fatalf("claim=%#v err=%v", got, err)
+			}
+			fixture.assertOwnershipPresent(t)
+			if !strings.Contains(fixture.output.String(), "reason=captured-scope-unavailable") {
+				t.Fatalf("cleanup did not report scope failure: %s", fixture.output.String())
+			}
+		})
+	}
+}
+
+func TestCleanupClaimlessContainerSkipsClaimCreatedBeforeMutation(t *testing.T) {
+	fixture := newCleanupClaimFixture(t, "cbx_cleanup_claim_appears", "cleanup-claimless-container", "exited", false)
+	core.RemoveLeaseClaim(fixture.leaseID)
+	appeared := false
+	fixture.b.beforeCleanupMutation = func(leaseID string) {
+		if leaseID != fixture.leaseID || appeared {
+			return
+		}
+		appeared = true
+		labels := testCapturedScopeLabels(map[string]string{
+			"crabbox": "true", "provider": providerName, "lease": leaseID, "slug": "new-owner", "state": "ready",
+		})
+		if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(
+			leaseID, "new-owner", providerName, "runtime:docker/context:default", "", t.TempDir(), time.Minute, false,
+			core.Server{CloudID: "new-owner-container", Provider: providerName, Labels: labels}, core.SSHTarget{},
+		); err != nil {
+			t.Fatalf("create concurrent claim: %v", err)
+		}
+	}
+	if err := fixture.b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if recordedCommandCount(fixture.runner, "rm") != 0 {
+		t.Fatalf("cleanup removed claimless container after claim appeared: %s", fixture.output.String())
+	}
+	claim, err := core.ReadLeaseClaim(fixture.leaseID)
+	if err != nil || claim.CloudID != "new-owner-container" {
+		t.Fatalf("concurrent claim=%#v err=%v", claim, err)
+	}
+	fixture.assertOwnershipPresent(t)
+	if !strings.Contains(fixture.output.String(), "reason=changed-during-cleanup") {
+		t.Fatalf("cleanup did not report appearing claim: %s", fixture.output.String())
+	}
+}
+
+func TestCleanupExactExpiredClaimRemovesOwnershipOnce(t *testing.T) {
+	fixture := newCleanupClaimFixture(t, "cbx_cleanup_exact_expired", "cleanup-exact-container", "running", false)
+	fixture.expire(t)
+	if err := fixture.b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if got := recordedCommandCount(fixture.runner, "rm"); got != 1 {
+		t.Fatalf("container remove calls=%d, want 1", got)
+	}
+	if claim, err := core.ReadLeaseClaim(fixture.leaseID); err != nil || claim.LeaseID != "" {
+		t.Fatalf("claim=%#v err=%v", claim, err)
+	}
+	for name, path := range map[string]string{"key": fixture.keyPath, "bootstrap": fixture.bootstrapDir, "host root": fixture.hostLeaseRoot} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("%s remains after cleanup: %v", name, err)
+		}
+	}
+	if got := strings.Count(fixture.output.String(), "remove container id="); got != 1 {
+		t.Fatalf("remove output count=%d, want 1: %s", got, fixture.output.String())
+	}
+}
+
+func TestCleanupMissingPendingRechecksAbsenceInsideFence(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		absent   bool
+		checkErr error
+	}{
+		{name: "container reappears", absent: false},
+		{name: "captured route fails", checkErr: errors.New("captured route unavailable")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := newCleanupClaimFixture(t, "cbx_cleanup_missing_pending", "cleanup-missing-pending", "exited", false)
+			fixture.runner.responses[commandKey([]string{"ps", "-a", "--filter", "label=crabbox=true", "--filter", "label=provider=local-container", "--format", "{{.ID}}"})] = core.LocalCommandResult{}
+			labels := cloneLabels(fixture.claim.Labels)
+			labels["state"] = pendingClaimState
+			labels["recovery"] = pendingRecoveryKind
+			updated, err := core.UpdateLeaseClaimLabelsIfUnchanged(fixture.leaseID, fixture.claim, labels)
+			if err != nil {
+				t.Fatal(err)
+			}
+			fixture.claim = updated
+			checks := 0
+			fixture.b.confirmContainerAbsent = func(context.Context, string) (bool, error) {
+				checks++
+				return tc.absent, tc.checkErr
+			}
+			if err := fixture.b.Cleanup(context.Background(), core.CleanupRequest{}); err == nil {
+				t.Fatal("cleanup succeeded without an in-fence absence proof")
+			}
+			if checks != 1 {
+				t.Fatalf("in-fence absence checks=%d, want 1", checks)
+			}
+			claim, err := core.ReadLeaseClaim(fixture.leaseID)
+			if err != nil || claim.LeaseID != fixture.leaseID {
+				t.Fatalf("claim=%#v err=%v", claim, err)
+			}
+			fixture.assertOwnershipPresent(t)
+			if strings.Contains(fixture.output.String(), "remove claim") {
+				t.Fatalf("cleanup reported pending claim removal: %s", fixture.output.String())
+			}
+		})
+	}
+}
+
+func TestCleanupPreservesKeepAndActiveClaimedContainers(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status string
+		keep   bool
+		reason string
+	}{
+		{name: "keep", status: "exited", keep: true, reason: "keep=true"},
+		{name: "active claim", status: "running", reason: "claim active"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := newCleanupClaimFixture(t, "cbx_cleanup_preserve_"+strings.ReplaceAll(tc.name, " ", "_"), "cleanup-preserve-container", tc.status, tc.keep)
+			if err := fixture.b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+				t.Fatal(err)
+			}
+			if recordedCommandCount(fixture.runner, "rm") != 0 {
+				t.Fatalf("cleanup removed preserved container: %s", fixture.output.String())
+			}
+			claim, err := core.ReadLeaseClaim(fixture.leaseID)
+			if err != nil || claim.LeaseID != fixture.leaseID {
+				t.Fatalf("claim=%#v err=%v", claim, err)
+			}
+			fixture.assertOwnershipPresent(t)
+			if !strings.Contains(fixture.output.String(), "reason="+tc.reason) {
+				t.Fatalf("cleanup skip reason missing: %s", fixture.output.String())
+			}
+		})
+	}
+}
+
 func TestCleanupRemovesExpiredLocalContainers(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
@@ -2632,7 +4366,7 @@ func TestCleanupRemovesExpiredLocalContainers(t *testing.T) {
 	}
 }
 
-func TestCleanupRemovesClaimAfterHostWorkRootFailure(t *testing.T) {
+func TestCleanupSkipsIncompleteClaimBeforeHostWorkRootMutation(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	stateHome := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", stateHome)
@@ -2655,6 +4389,10 @@ func TestCleanupRemovesClaimAfterHostWorkRootFailure(t *testing.T) {
 	if err := os.WriteFile(keyPath, []byte("private"), 0o600); err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() {
+		core.RemoveLeaseClaim("cbx_cleanup")
+		core.RemoveStoredTestboxKey("cbx_cleanup")
+	})
 	hostRoot := t.TempDir()
 	markTestLocalContainerWorkRoot(t, hostRoot)
 	leaseRoot := filepath.Join(hostRoot, "cbx_cleanup")
@@ -2690,16 +4428,27 @@ func TestCleanupRemovesClaimAfterHostWorkRootFailure(t *testing.T) {
 		},
 	}
 	b := testBackend(runner)
-	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err == nil {
-		t.Fatal("cleanup succeeded despite host work root removal failure")
+	var stderr strings.Builder
+	b.rt.Stderr = &stderr
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+		t.Fatal(err)
 	}
 	if claim, err := core.ReadLeaseClaim("cbx_cleanup"); err != nil {
 		t.Fatal(err)
-	} else if claim.LeaseID != "" {
-		t.Fatalf("claim still exists after partial cleanup failure: %#v", claim)
+	} else if claim.LeaseID != "cbx_cleanup" {
+		t.Fatalf("incomplete claim was removed: %#v", claim)
 	}
-	if _, err := os.Stat(keyPath); !os.IsNotExist(err) {
-		t.Fatalf("stored key still exists after partial cleanup failure: %v", err)
+	if _, err := os.Stat(keyPath); err != nil {
+		t.Fatalf("stored key removed for incomplete claim: %v", err)
+	}
+	if _, err := os.Stat(leaseRoot); err != nil {
+		t.Fatalf("host lease root removed for incomplete claim: %v", err)
+	}
+	if got := recordedCommandCount(runner, "rm"); got != 0 {
+		t.Fatalf("container remove calls=%d, want 0", got)
+	}
+	if !strings.Contains(stderr.String(), "reason=captured-scope-unavailable") {
+		t.Fatalf("cleanup did not report incomplete captured scope: %s", stderr.String())
 	}
 }
 
@@ -2725,6 +4474,178 @@ func TestCleanupRemovesClaimWithoutContainer(t *testing.T) {
 	// would strand a live lease. See the retention note in (*backend).Cleanup.
 	if _, err := os.Stat(keyPath); err != nil {
 		t.Fatalf("stored key should be retained after orphan-claim cleanup, got: %v", err)
+	}
+}
+
+func TestCleanupRemovesMissingNonKeepPendingClaimAndSidecars(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	leaseID := "cbx_missing_nonkeep_pending"
+	bootstrapDir, err := os.MkdirTemp("", "crabbox-bootstrap-nonkeep-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(bootstrapDir) })
+	keyPath, err := core.TestboxKeyPath(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(keyPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyPath, []byte("private"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	labels := map[string]string{
+		"crabbox": "true", "provider": providerName, "lease": leaseID, "slug": "missing-nonkeep",
+		"state": pendingClaimState, "recovery": pendingRecoveryKind, "keep": "false",
+		"bootstrap_dir": bootstrapDir, "bootstrap_owned": "true", "ssh_key_owned": "true",
+	}
+	labels = testCapturedScopeLabels(labels)
+	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(
+		leaseID,
+		"missing-nonkeep",
+		providerName,
+		"runtime:docker/context:default",
+		"",
+		t.TempDir(),
+		time.Minute,
+		false,
+		core.Server{CloudID: "missing-container", Provider: providerName, Labels: labels},
+		core.SSHTarget{},
+	); err != nil {
+		t.Fatal(err)
+	}
+	var stdout strings.Builder
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+		commandKey([]string{"ps", "-a", "--filter", "label=crabbox=true", "--filter", "label=provider=local-container", "--format", "{{.ID}}"}): {},
+	}}
+	addDefaultLocalContainerScopeResponses(runner)
+	b := testBackend(runner)
+	b.rt.Stdout = &stdout
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if claim, err := core.ReadLeaseClaim(leaseID); err != nil || claim.LeaseID != "" {
+		t.Fatalf("claim=%#v err=%v", claim, err)
+	}
+	if _, err := os.Stat(keyPath); !os.IsNotExist(err) {
+		t.Fatalf("key still exists: %v", err)
+	}
+	if _, err := os.Stat(bootstrapDir); !os.IsNotExist(err) {
+		t.Fatalf("bootstrap directory still exists: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "reason=missing non-keep pending container") {
+		t.Fatalf("cleanup output=%q", stdout.String())
+	}
+}
+
+func TestCleanupRetainsMissingPendingClaimWhenCapturedDaemonChanges(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	leaseID := "cbx_missing_changed_daemon"
+	labels := testCapturedScopeLabels(map[string]string{
+		"crabbox": "true", "provider": providerName, "lease": leaseID, "slug": "changed-daemon",
+		"state": pendingClaimState, "recovery": pendingRecoveryKind, "keep": "false", "ssh_key_owned": "true",
+	})
+	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(
+		leaseID, "changed-daemon", providerName, "runtime:docker/context:default", "", t.TempDir(), time.Minute, false,
+		core.Server{CloudID: "container-on-old-daemon", Provider: providerName, Labels: labels}, core.SSHTarget{},
+	); err != nil {
+		t.Fatal(err)
+	}
+	keyPath, err := core.TestboxKeyPath(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(keyPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyPath, []byte("private"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stderr strings.Builder
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+		commandKey([]string{"ps", "-a", "--filter", "label=crabbox=true", "--filter", "label=provider=local-container", "--format", "{{.ID}}"}): {},
+	}}
+	addDefaultLocalContainerScopeResponses(runner)
+	b := testBackend(runner)
+	b.rt.Stderr = &stderr
+	b.validateRuntimeScope = func(context.Context, checkpointScope) error { return errors.New("daemon changed") }
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	claim, err := core.ReadLeaseClaim(leaseID)
+	if err != nil || claim.LeaseID != leaseID {
+		t.Fatalf("claim=%#v err=%v", claim, err)
+	}
+	if _, err := os.Stat(keyPath); err != nil {
+		t.Fatalf("key removed after daemon mismatch: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "captured-scope-unavailable") {
+		t.Fatalf("cleanup did not report scope mismatch: %s", stderr.String())
+	}
+	core.RemoveLeaseClaim(leaseID)
+	core.RemoveStoredTestboxKey(leaseID)
+}
+
+func TestCleanupRetainsReadyAndLegacyClaimsWithoutValidatedDaemon(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		fullScope bool
+		validator error
+	}{
+		{name: "ready daemon mismatch", fullScope: true, validator: errors.New("daemon changed")},
+		{name: "legacy missing identity"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			leaseID := "cbx_cleanup_scope_" + strings.ReplaceAll(tc.name, " ", "_")
+			labels := map[string]string{"provider": providerName, "lease": leaseID, "slug": "cleanup-scope", "state": "ready"}
+			if tc.fullScope {
+				labels = testCapturedScopeLabels(labels)
+			}
+			if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(
+				leaseID, "cleanup-scope", providerName, "runtime:docker/context:default", "", t.TempDir(), time.Minute, false,
+				core.Server{CloudID: "container-on-captured-daemon", Provider: providerName, Labels: labels}, core.SSHTarget{},
+			); err != nil {
+				t.Fatal(err)
+			}
+			keyPath, err := core.TestboxKeyPath(leaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.MkdirAll(filepath.Dir(keyPath), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(keyPath, []byte("private"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			var stderr strings.Builder
+			runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+				commandKey([]string{"ps", "-a", "--filter", "label=crabbox=true", "--filter", "label=provider=local-container", "--format", "{{.ID}}"}): {},
+			}}
+			addDefaultLocalContainerScopeResponses(runner)
+			b := testBackend(runner)
+			b.rt.Stderr = &stderr
+			b.validateRuntimeScope = func(context.Context, checkpointScope) error { return tc.validator }
+			if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+				t.Fatal(err)
+			}
+			claim, err := core.ReadLeaseClaim(leaseID)
+			if err != nil || claim.LeaseID != leaseID {
+				t.Fatalf("claim=%#v err=%v", claim, err)
+			}
+			if _, err := os.Stat(keyPath); err != nil {
+				t.Fatalf("key removed without validated daemon: %v", err)
+			}
+			if !strings.Contains(stderr.String(), "captured-scope-unavailable") {
+				t.Fatalf("cleanup did not retain evidence: %s", stderr.String())
+			}
+			core.RemoveLeaseClaim(leaseID)
+			core.RemoveStoredTestboxKey(leaseID)
+		})
 	}
 }
 
@@ -2842,7 +4763,7 @@ func writeLocalContainerReleaseClaimWithScope(t *testing.T, leaseID, containerID
 		t.Fatal(err)
 	}
 	now := time.Now().UTC().Format(time.RFC3339)
-	data := []byte(`{"leaseID":` + strconv.Quote(leaseID) + `,"slug":"release","provider":` + strconv.Quote(providerName) + `,"cloudID":` + strconv.Quote(containerID) + `,"providerScope":` + strconv.Quote(scope) + `,"repoRoot":` + strconv.Quote(t.TempDir()) + `,"claimedAt":` + strconv.Quote(now) + `,"lastUsedAt":` + strconv.Quote(now) + `,"idleTimeoutSeconds":60}`)
+	data := []byte(`{"leaseID":` + strconv.Quote(leaseID) + `,"slug":"release","provider":` + strconv.Quote(providerName) + `,"cloudID":` + strconv.Quote(containerID) + `,"providerScope":` + strconv.Quote(scope) + `,"repoRoot":` + strconv.Quote(t.TempDir()) + `,"claimedAt":` + strconv.Quote(now) + `,"lastUsedAt":` + strconv.Quote(now) + `,"idleTimeoutSeconds":60,"labels":{"runtime":"docker","docker_context":"default","docker_endpoint":"unix:///tmp/docker-test.sock","docker_daemon_id":"daemon-test"}}`)
 	if err := os.WriteFile(filepath.Join(claimDir, leaseID+".json"), data, 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -2870,6 +4791,18 @@ func addDefaultLocalContainerScopeResponses(runner *recordingRunner) {
 		result, _ := defaultLocalContainerScopeResponse(core.LocalCommandRequest{Args: args})
 		runner.responses[commandKey(args)] = result
 	}
+}
+
+func testCapturedScopeLabels(labels map[string]string) map[string]string {
+	out := cloneLabels(labels)
+	for key, value := range checkpointScopeMetadata(checkpointScope{
+		Runtime: "docker", Context: "default", Endpoint: "unix:///tmp/docker-test.sock", DaemonID: "daemon-test",
+	}) {
+		if value != "" {
+			out[key] = value
+		}
+	}
+	return out
 }
 
 func writeLocalContainerClaimAndKeyAt(t *testing.T, leaseID, slug, scope string, lastUsed time.Time, idle time.Duration) string {
@@ -2904,7 +4837,7 @@ func writeLocalContainerClaim(t *testing.T, leaseID, slug, scope string, lastUse
 	if scope != "" {
 		scopeField = `,"providerScope":` + strconv.Quote(scope)
 	}
-	data := []byte(`{"leaseID":` + strconv.Quote(leaseID) + `,"slug":` + strconv.Quote(slug) + `,"provider":` + strconv.Quote(providerName) + scopeField + `,"repoRoot":` + strconv.Quote(t.TempDir()) + `,"claimedAt":` + strconv.Quote(lastUsed.Format(time.RFC3339)) + `,"lastUsedAt":` + strconv.Quote(lastUsed.Format(time.RFC3339)) + `,"idleTimeoutSeconds":` + strconv.Itoa(int(idle.Seconds())) + `}`)
+	data := []byte(`{"leaseID":` + strconv.Quote(leaseID) + `,"slug":` + strconv.Quote(slug) + `,"provider":` + strconv.Quote(providerName) + scopeField + `,"repoRoot":` + strconv.Quote(t.TempDir()) + `,"claimedAt":` + strconv.Quote(lastUsed.Format(time.RFC3339)) + `,"lastUsedAt":` + strconv.Quote(lastUsed.Format(time.RFC3339)) + `,"idleTimeoutSeconds":` + strconv.Itoa(int(idle.Seconds())) + `,"labels":{"runtime":"docker","docker_context":"default","docker_endpoint":"unix:///tmp/docker-test.sock","docker_daemon_id":"daemon-test"}}`)
 	return os.WriteFile(filepath.Join(claimDir, leaseID+".json"), data, 0o600)
 }
 

--- a/internal/providers/localcontainer/checkpoint.go
+++ b/internal/providers/localcontainer/checkpoint.go
@@ -2,6 +2,7 @@ package localcontainer
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -269,6 +270,9 @@ func checkpointScopeForServer(ctx context.Context, cfg core.Config, server core.
 		return scope, nil
 	}
 	scope := checkpointScope{Runtime: runtimeName}
+	if isPodmanRuntime(runtimeName) {
+		return podmanScopeForConfig(ctx, cfg)
+	}
 	if !isDockerRuntime(runtimeName) {
 		return scope, nil
 	}
@@ -318,6 +322,63 @@ func checkpointScopeForServer(ctx context.Context, cfg core.Config, server core.
 	}
 	scope.DaemonID = daemonID
 	return scope, nil
+}
+
+type podmanConnection struct {
+	Name    string `json:"Name"`
+	URI     string `json:"URI"`
+	Default bool   `json:"Default"`
+}
+
+func podmanScopeForConfig(ctx context.Context, cfg core.Config) (checkpointScope, error) {
+	runtimeName := firstCheckpointValue(cfg.LocalContainer.Runtime, "podman")
+	scope := checkpointScope{Runtime: runtimeName}
+	if host := strings.TrimSpace(os.Getenv("CONTAINER_HOST")); host != "" {
+		scope.Host = host
+		scope.Endpoint = host
+	} else {
+		connectionName := strings.TrimSpace(os.Getenv("CONTAINER_CONNECTION"))
+		connections, err := listPodmanConnections(ctx, runtimeName)
+		if err != nil {
+			return checkpointScope{}, err
+		}
+		for _, connection := range connections {
+			if connection.Name == connectionName || (connectionName == "" && connection.Default) {
+				scope.Context = connection.Name
+				scope.Endpoint = connection.URI
+				break
+			}
+		}
+		if connectionName != "" && scope.Context == "" {
+			return checkpointScope{}, core.Exit(2, "Podman connection %s is unavailable", connectionName)
+		}
+		if scope.Context == "" {
+			scope.Context = "default"
+			scope.Endpoint = "local"
+		}
+	}
+	daemonID, err := checkpointDaemonID(ctx, scope)
+	if err != nil {
+		return checkpointScope{}, err
+	}
+	scope.DaemonID = daemonID
+	return scope, nil
+}
+
+func listPodmanConnections(ctx context.Context, runtimeName string) ([]podmanConnection, error) {
+	cmd := exec.CommandContext(ctx, runtimeName, "system", "connection", "list", "--format", "json")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, core.Exit(2, "list Podman connections: %v", err)
+	}
+	var connections []podmanConnection
+	if len(strings.TrimSpace(string(out))) == 0 {
+		return connections, nil
+	}
+	if err := json.Unmarshal(out, &connections); err != nil {
+		return nil, core.Exit(2, "parse Podman connections: %v", err)
+	}
+	return connections, nil
 }
 
 func checkpointScopeFromRequest(req core.NativeCheckpointResourceRequest) checkpointScope {
@@ -381,6 +442,35 @@ func checkpointScopeMetadataFromLabels(labels map[string]string) map[string]stri
 }
 
 func validateCheckpointScope(ctx context.Context, scope checkpointScope) error {
+	if isPodmanRuntime(scope.Runtime) {
+		if scope.Context != "" && scope.Context != "default" && scope.Endpoint != "" {
+			connections, err := listPodmanConnections(ctx, scope.Runtime)
+			if err != nil {
+				return err
+			}
+			matched := false
+			for _, connection := range connections {
+				if connection.Name == scope.Context && connection.URI == scope.Endpoint {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				return core.Exit(7, "Podman connection routing changed; refusing operation")
+			}
+		}
+		if scope.DaemonID == "" {
+			return core.Exit(7, "Podman runtime identity is missing; refusing operation")
+		}
+		currentDaemonID, err := checkpointDaemonID(ctx, scope)
+		if err != nil {
+			return err
+		}
+		if currentDaemonID != scope.DaemonID {
+			return core.Exit(7, "Podman runtime identity changed; refusing operation")
+		}
+		return nil
+	}
 	if scope.Context != "" && scope.Endpoint != "" {
 		current, err := checkpointContextEndpoint(ctx, scope)
 		if err != nil {
@@ -448,6 +538,21 @@ func checkpointContextEndpoint(ctx context.Context, scope checkpointScope) (stri
 }
 
 func checkpointDaemonID(ctx context.Context, scope checkpointScope) (string, error) {
+	if isPodmanRuntime(scope.Runtime) {
+		var stderr strings.Builder
+		cmd := checkpointCommand(ctx, scope, "info", "--format", `{{.Host.Hostname}}|{{.Store.GraphRoot}}|{{.Store.RunRoot}}|{{.Host.RemoteSocket.Path}}|{{.Host.Security.Rootless}}`)
+		cmd.Stderr = &stderr
+		out, err := cmd.Output()
+		if err != nil {
+			return "", core.Exit(7, "resolve Podman runtime identity: %v: %s", err, trimCheckpointFailure(stderr.String()))
+		}
+		identity := strings.TrimSpace(string(out))
+		if identity == "" {
+			return "", core.Exit(7, "resolve Podman runtime identity: command returned an empty identity")
+		}
+		sum := sha256.Sum256([]byte(identity))
+		return fmt.Sprintf("podman-%x", sum[:16]), nil
+	}
 	var stderr strings.Builder
 	cmd := checkpointCommand(ctx, scope, "info", "--format", "{{.ID}}")
 	cmd.Stderr = &stderr
@@ -487,8 +592,10 @@ func checkpointConfigPath() (string, error) {
 
 func checkpointCommand(ctx context.Context, scope checkpointScope, args ...string) *exec.Cmd {
 	full := args
-	if scope.Context != "" {
+	if isDockerRuntime(scope.Runtime) && scope.Context != "" && scope.Context != "default" {
 		full = append([]string{"--context", scope.Context}, args...)
+	} else if isPodmanRuntime(scope.Runtime) && scope.Context != "" && scope.Context != "default" && scope.Host == "" {
+		full = append([]string{"--connection", scope.Context}, args...)
 	}
 	cmd := exec.CommandContext(ctx, scope.Runtime, full...)
 	if env := checkpointEnvForScope(scope); env != nil {
@@ -503,9 +610,27 @@ func checkpointEnvForScope(scope checkpointScope) []string {
 	}
 	base := os.Environ()
 	out := make([]string, 0, len(base)+2)
+	if isPodmanRuntime(scope.Runtime) {
+		for _, value := range base {
+			if strings.HasPrefix(value, "CONTAINER_HOST=") || strings.HasPrefix(value, "CONTAINER_CONNECTION=") || strings.HasPrefix(value, "DOCKER_HOST=") {
+				continue
+			}
+			out = append(out, value)
+		}
+		if scope.Host != "" {
+			out = append(out, "CONTAINER_HOST="+scope.Host)
+		} else if scope.Context != "" && scope.Context != "default" {
+			out = append(out, "CONTAINER_CONNECTION="+scope.Context)
+		}
+		return out
+	}
+	effectiveHost := scope.Host
+	if isDockerRuntime(scope.Runtime) && scope.Context == "default" && effectiveHost == "" {
+		effectiveHost = scope.Endpoint
+	}
 	for _, value := range base {
 		if strings.HasPrefix(value, "DOCKER_CONTEXT=") ||
-			(scope.Host != "" || scope.Context != "") && strings.HasPrefix(value, "DOCKER_HOST=") ||
+			(effectiveHost != "" || scope.Context != "") && strings.HasPrefix(value, "DOCKER_HOST=") ||
 			scope.Config != "" && strings.HasPrefix(value, "DOCKER_CONFIG=") {
 			continue
 		}
@@ -514,8 +639,8 @@ func checkpointEnvForScope(scope checkpointScope) []string {
 	if scope.Config != "" {
 		out = append(out, "DOCKER_CONFIG="+scope.Config)
 	}
-	if scope.Host != "" {
-		out = append(out, "DOCKER_HOST="+scope.Host)
+	if effectiveHost != "" {
+		out = append(out, "DOCKER_HOST="+effectiveHost)
 	}
 	return out
 }

--- a/internal/providers/localcontainer/checkpoint_test.go
+++ b/internal/providers/localcontainer/checkpoint_test.go
@@ -24,6 +24,46 @@ func TestNativeCheckpointWorkdirUsesResolvedLeaseRoot(t *testing.T) {
 	}
 }
 
+func TestPodmanScopeCapturesConnectionAndRuntimeIdentity(t *testing.T) {
+	dir := t.TempDir()
+	runtimePath := filepath.Join(dir, "podman")
+	script := `#!/bin/sh
+case "$*" in
+  "system connection list --format json")
+    printf '[{"Name":"team","URI":"%s","Default":true}]\n' "${PODMAN_TEST_URI:-ssh://runner@example.invalid/run/podman.sock}"
+    ;;
+  "--connection team info --format "*)
+    printf '%s\n' 'host-a|/var/lib/containers|/run/containers|/run/podman.sock|true'
+    ;;
+  *)
+    printf 'unexpected args: %s\n' "$*" >&2
+    exit 2
+    ;;
+esac
+`
+	if err := os.WriteFile(runtimePath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CONTAINER_CONNECTION", "team")
+	t.Setenv("CONTAINER_HOST", "")
+	t.Setenv("DOCKER_HOST", "tcp://unrelated-docker.invalid:2376")
+	cfg := core.Config{LocalContainer: core.LocalContainerConfig{Runtime: runtimePath}}
+	scope, err := podmanScopeForConfig(context.Background(), cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if scope.Runtime != runtimePath || scope.Context != "team" || scope.Endpoint != "ssh://runner@example.invalid/run/podman.sock" || !strings.HasPrefix(scope.DaemonID, "podman-") {
+		t.Fatalf("scope=%#v", scope)
+	}
+	if err := validateCheckpointScope(context.Background(), scope); err != nil {
+		t.Fatalf("validate matching scope: %v", err)
+	}
+	t.Setenv("PODMAN_TEST_URI", "ssh://runner@other.invalid/run/podman.sock")
+	if err := validateCheckpointScope(context.Background(), scope); err == nil {
+		t.Fatal("repointed Podman connection validated")
+	}
+}
+
 func TestCheckpointImageNameNormalizesAndBoundsRepository(t *testing.T) {
 	got := checkpointImageName("___", "sha256:ABCDEF0123456789")
 	if got != "crabbox-checkpoint-checkpoint-abcdef012345" {

--- a/internal/providers/localcontainer/cleanup_toctou_test.go
+++ b/internal/providers/localcontainer/cleanup_toctou_test.go
@@ -58,6 +58,7 @@ func TestCleanupOrphanSweepDeletesConcurrentAcquireClaim(t *testing.T) {
 	}
 	runner := &recordingRunner{}
 	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: &out, Stderr: io.Discard, Exec: runner}).(*backend)
+	b.validateRuntimeScope = func(context.Context, checkpointScope) error { return nil }
 
 	var once sync.Once
 	runner.run = func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
@@ -84,6 +85,7 @@ func TestCleanupOrphanSweepDeletesConcurrentAcquireClaim(t *testing.T) {
 						"state":    "ready",
 					},
 				}
+				server.Labels = cleanupTOCTOUScopeLabels(server.Labels, "test-context")
 				if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(
 					newLease, "fresh-slug", providerName, scope, "", repoRoot,
 					30*time.Minute, false, server, core.SSHTarget{},
@@ -150,6 +152,7 @@ func TestCleanupOrphanSweepGuardDeclinesReclaimedCandidate(t *testing.T) {
 	}
 	runner := &recordingRunner{}
 	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: &out, Stderr: io.Discard, Exec: runner}).(*backend)
+	b.validateRuntimeScope = func(context.Context, checkpointScope) error { return nil }
 
 	var scope string
 	var once sync.Once
@@ -174,6 +177,7 @@ func TestCleanupOrphanSweepGuardDeclinesReclaimedCandidate(t *testing.T) {
 						"state":    "ready",
 					},
 				}
+				rebound.Labels = cleanupTOCTOUScopeLabels(rebound.Labels, "test-context")
 				if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(
 					orphanLease, "orphan-slug", providerName, scope, "", repoRoot,
 					30*time.Minute, false, rebound, core.SSHTarget{},
@@ -206,6 +210,7 @@ func TestCleanupOrphanSweepGuardDeclinesReclaimedCandidate(t *testing.T) {
 			"state":    "idle",
 		},
 	}
+	origServer.Labels = cleanupTOCTOUScopeLabels(origServer.Labels, "test-context")
 	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(
 		orphanLease, "orphan-slug", providerName, scope, "", repoRoot,
 		30*time.Minute, false, origServer, core.SSHTarget{},
@@ -248,6 +253,7 @@ func TestCleanupDryRunDoesNotPlanReclaimedCandidateRemoval(t *testing.T) {
 	}
 	runner := &recordingRunner{}
 	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: &out, Stderr: &out, Exec: runner}).(*backend)
+	b.validateRuntimeScope = func(context.Context, checkpointScope) error { return nil }
 
 	var scope string
 	var once sync.Once
@@ -261,6 +267,7 @@ func TestCleanupDryRunDoesNotPlanReclaimedCandidateRemoval(t *testing.T) {
 					CloudID: orphanContainer, Provider: providerName, Name: orphanContainer, Status: "ready",
 					Labels: map[string]string{"crabbox": "true", "provider": providerName, "lease": orphanLease, "slug": "dryrun-slug", "state": "ready"},
 				}
+				rebound.Labels = cleanupTOCTOUScopeLabels(rebound.Labels, "test-context")
 				if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(
 					orphanLease, "dryrun-slug", providerName, scope, "", repoRoot,
 					30*time.Minute, false, rebound, core.SSHTarget{},
@@ -281,6 +288,7 @@ func TestCleanupDryRunDoesNotPlanReclaimedCandidateRemoval(t *testing.T) {
 		CloudID: orphanContainer, Provider: providerName, Name: orphanContainer, Status: "idle",
 		Labels: map[string]string{"crabbox": "true", "provider": providerName, "lease": orphanLease, "slug": "dryrun-slug", "state": "idle"},
 	}
+	original.Labels = cleanupTOCTOUScopeLabels(original.Labels, "test-context")
 	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(
 		orphanLease, "dryrun-slug", providerName, scope, "", repoRoot,
 		30*time.Minute, false, original, core.SSHTarget{},
@@ -337,6 +345,7 @@ func TestCleanupRetainsKeyPreparedByConcurrentAcquire(t *testing.T) {
 	}
 	runner := &recordingRunner{}
 	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: &out, Stderr: io.Discard, Exec: runner}).(*backend)
+	b.validateRuntimeScope = func(context.Context, checkpointScope) error { return nil }
 
 	runner.run = func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		switch {
@@ -360,6 +369,7 @@ func TestCleanupRetainsKeyPreparedByConcurrentAcquire(t *testing.T) {
 		CloudID: orphanContainer, Provider: providerName, Name: orphanContainer, Status: "idle",
 		Labels: map[string]string{"crabbox": "true", "provider": providerName, "lease": lease, "slug": "keyretain-slug", "state": "idle"},
 	}
+	server.Labels = cleanupTOCTOUScopeLabels(server.Labels, "test-context")
 	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(
 		lease, "keyretain-slug", providerName, scope, "", repoRoot, 30*time.Minute, false, server, core.SSHTarget{},
 	); err != nil {
@@ -394,4 +404,16 @@ func TestCleanupRetainsKeyPreparedByConcurrentAcquire(t *testing.T) {
 	if _, err := os.Stat(keyPath); err != nil {
 		t.Fatalf("cleanup deleted a stored key prepared by a concurrent Acquire (availability regression): %v\ncleanup output:\n%s", err, out.String())
 	}
+}
+
+func cleanupTOCTOUScopeLabels(labels map[string]string, contextName string) map[string]string {
+	out := cloneLabels(labels)
+	for key, value := range checkpointScopeMetadata(checkpointScope{
+		Runtime: "docker", Context: contextName, Endpoint: "unix:///tmp/docker-test.sock", DaemonID: "daemon-test",
+	}) {
+		if value != "" {
+			out[key] = value
+		}
+	}
+	return out
 }

--- a/internal/providers/localcontainer/provider.go
+++ b/internal/providers/localcontainer/provider.go
@@ -43,6 +43,25 @@ func (Provider) CreationOnlyFlagNames() []string {
 	return []string{"local-container-volume"}
 }
 
+func (Provider) PrepareLeaseClaimEndpoint(existing core.LeaseClaim, provider, slug string, server core.Server, _ bool) (core.Server, error) {
+	if existing.CloudID != "" && server.CloudID != "" && existing.CloudID != server.CloudID {
+		return core.Server{}, core.Exit(2, "local-container lease %s is bound to container %s; refusing endpoint rewrite to %s", existing.LeaseID, shortID(existing.CloudID), shortID(server.CloudID))
+	}
+	labels := cloneLabels(server.Labels)
+	for _, key := range append([]string{
+		"bootstrap_dir", "bootstrap_owned", "docker_socket", "host_work_root", "keep", "runtime", "runtime_context", "ssh_key_owned", "ssh_user", "work_root",
+	}, checkpointScopeMetadataKeys...) {
+		if strings.TrimSpace(labels[key]) == "" && strings.TrimSpace(existing.Labels[key]) != "" {
+			labels[key] = existing.Labels[key]
+		}
+	}
+	if !strings.EqualFold(labels["state"], "ready") && strings.TrimSpace(labels["recovery"]) == "" {
+		labels["recovery"] = existing.Labels["recovery"]
+	}
+	server.Labels = labels
+	return server, nil
+}
+
 func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
 	if cfg.TargetOS != "" && cfg.TargetOS != core.TargetLinux {
 		return nil, core.Exit(2, "provider=%s supports target=linux only", providerName)


### PR DESCRIPTION
## Summary

- publish an exact `state=provisioning` local-container claim immediately after the runtime returns the container ID, before inspect or readiness probes
- transition provisioning to ready with compare-and-swap claim updates, while retaining the exact pending claim for keep-enabled failures and rolling back container, claim, key, and bootstrap state for `keep=false`
- bind claims to the complete Docker/Podman route and daemon identity, hydrate that route for exact-ID recovery, and keep private endpoint/config values out of recovery output
- fence release, rollback, missing-container handling, cleanup, and SSH-key ownership against concurrent claim replacement
- emit copyable inspect, reclaim, and stop recovery commands for retained pending claims

## Verification

- `go test -race ./internal/providers/localcontainer -count=1`
- `go test ./internal/cli -count=1`
- `go vet ./...`
- `git diff origin/main...HEAD --check`
- focused ownership/cleanup race tests for live-claim changes, fail-closed scope changes, claimless containers, exact expired claims, missing pending claims, fenced release/key cleanup, rollback retention, captured daemon validation, and safe recovery routes
- source-blind Docker proof with a copied fresh CLI and isolated home/config/state: interrupted keep-enabled provisioning retained a non-ready exact claim without private route leakage; fresh-process stop removed container, claim, key, and bootstrap state; `keep=false` rollback left no matching state; repeated cleanup and dry-run preserved unrelated labeled inventory; named-context route hydration worked from a fresh process; zero task-owned residue remained

Residual: deterministic recovery-to-ready is covered by tests; the live synthetic delayed-image run did not demonstrate the later ready transition.

Fixes https://github.com/openclaw/crabbox/issues/1245
