### PR TITLE
fix(live-smoke): accept empty cache reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Rejected invalid or overlong coordinator-requested lease slugs before provisioning while preserving exact fixed-ID replays created under the legacy length behavior. Thanks @dwin-gharibi.
 - Bound valid caller-declared artifact SHA-256 digests into signed broker upload grants, rejected malformed nonblank digests instead of silently disabling integrity checks, and made object storage reject mismatching payloads. Thanks @dwin-gharibi.
 - Preserved pinned AWS SSH ingress and dynamic CIDRs from the other IP family when broker heartbeats refresh access, while replacing obsolete same-family dynamic sources. Thanks @jalehman.
+- Made `cache stats --json` emit an empty array for empty inventories while live smoke accepts legacy null and object reports but rejects other scalar shapes before workloads. Thanks @excelsier.
 
 ## 0.41.5 - 2026-08-12
 

--- a/internal/cli/cache.go
+++ b/internal/cli/cache.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"strings"
 )
 
@@ -66,7 +67,7 @@ func (a App) cacheStats(ctx context.Context, args []string) error {
 	}
 	entries := parseCacheStats(out)
 	if *jsonOut {
-		return json.NewEncoder(a.Stdout).Encode(entries)
+		return writeCacheStatsJSON(a.Stdout, entries)
 	}
 	for _, entry := range entries {
 		if entry.Note != "" {
@@ -76,6 +77,15 @@ func (a App) cacheStats(ctx context.Context, args []string) error {
 		fmt.Fprintf(a.Stdout, "%-8s %-32s %s\n", entry.Kind, formatBytes(entry.Bytes), entry.Path)
 	}
 	return nil
+}
+
+// writeCacheStatsJSON preserves the public CLI contract that an empty cache
+// inventory is a JSON array, never null.
+func writeCacheStatsJSON(out io.Writer, entries []cacheEntry) error {
+	if entries == nil {
+		entries = []cacheEntry{}
+	}
+	return json.NewEncoder(out).Encode(entries)
 }
 
 func (a App) cachePurge(ctx context.Context, args []string) error {

--- a/internal/cli/cache_test.go
+++ b/internal/cli/cache_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 )
@@ -15,6 +16,16 @@ func TestParseCacheStats(t *testing.T) {
 	}
 	if entries[1].Kind != "docker" || entries[1].Note == "" {
 		t.Fatalf("docker entry=%#v", entries[1])
+	}
+}
+
+func TestCacheStatsJSONEmptyResultIsArray(t *testing.T) {
+	var stdout bytes.Buffer
+	if err := writeCacheStatsJSON(&stdout, parseCacheStats("")); err != nil {
+		t.Fatal(err)
+	}
+	if got := stdout.String(); got != "[]\n" {
+		t.Fatalf("cache stats JSON=%q, want empty array", got)
 	}
 }
 

--- a/scripts/live-smoke.sh
+++ b/scripts/live-smoke.sh
@@ -270,7 +270,19 @@ provider_smoke() (
   run_in_repo "$cb" status --provider "$provider" --id "$slug" --wait --wait-timeout 90s
   run_in_repo "$cb" inspect --provider "$provider" --id "$slug" --json | jq '{id,slug,provider,state,serverType,host,ready,lastTouchedAt,expiresAt}'
   run_in_repo "$cb" ssh --provider "$provider" --id "$slug"
-  run_in_repo "$cb" cache stats --id "$slug" --json | jq 'if type=="array" then {items:length,kinds:[.[].kind]} else {keys:keys} end'
+  # Older or external Crabbox binaries may still encode an empty cache list as
+  # JSON null. Accept that compatible shape while rejecting any other scalar.
+  run_in_repo "$cb" cache stats --id "$slug" --json | jq '
+    if type == "null" then
+      {items: 0, kinds: []}
+    elif type == "array" then
+      {items: length, kinds: [.[].kind]}
+    elif type == "object" then
+      {keys: keys}
+    else
+      error("cache stats must be null, an array, or an object")
+    end
+  '
 
   local runout
   # shellcheck disable=SC2016 # expanded by the remote shell.

--- a/scripts/live-smoke.test.js
+++ b/scripts/live-smoke.test.js
@@ -1962,7 +1962,7 @@ case "$1" in
     exit 0
     ;;
   cache)
-    printf '[]\\n'
+    printf '%s\\n' "\${CRABBOX_FAKE_CACHE_STATS:-[]}"
     ;;
   run)
     printf 'crabbox-live-ok\\n'
@@ -1984,29 +1984,47 @@ esac
 `,
   );
 
-  const result = spawnSync("bash", ["scripts/live-smoke.sh"], {
-    cwd: repoRoot,
-    env: {
-      ...process.env,
-      PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}`,
-      CRABBOX_BIN: fakeCrabbox,
-      CRABBOX_CONFIG: path.join(dir, "missing-crabbox.yaml"),
-      CRABBOX_FAKE_LOG: crabboxLog,
-      CRABBOX_LIVE: "1",
-      CRABBOX_LIVE_COORDINATOR: "0",
-      CRABBOX_LIVE_PROVIDERS: "apple-container",
-      CRABBOX_LIVE_REPO: repoRoot,
-    },
-    encoding: "utf8",
-  });
+  const smoke = (cacheStats) => {
+    fs.writeFileSync(crabboxLog, "", "utf8");
+    const result = spawnSync("bash", ["scripts/live-smoke.sh"], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}`,
+        CRABBOX_BIN: fakeCrabbox,
+        CRABBOX_CONFIG: path.join(dir, "missing-crabbox.yaml"),
+        CRABBOX_FAKE_CACHE_STATS: cacheStats,
+        CRABBOX_FAKE_LOG: crabboxLog,
+        CRABBOX_LIVE: "1",
+        CRABBOX_LIVE_COORDINATOR: "0",
+        CRABBOX_LIVE_PROVIDERS: "apple-container",
+        CRABBOX_LIVE_REPO: repoRoot,
+      },
+      encoding: "utf8",
+    });
+    return { result, calls: fs.readFileSync(crabboxLog, "utf8") };
+  };
 
-  assert.equal(result.status, 0, result.stdout + result.stderr);
-  assert.match(result.stdout, /crabbox-live-ok/);
-  const calls = fs.readFileSync(crabboxLog, "utf8");
-  assert.match(calls, /^warmup --provider apple-container --ttl 15m --idle-timeout 5m$/m);
-  for (const command of ["status", "inspect", "ssh", "cache", "run", "stop"]) {
-    assert.match(calls, new RegExp(`^${command}(?: |$)`, "m"));
+  for (const [cacheStats, expected] of [
+    ["null", /"items": 0,[\s\S]*"kinds": \[\]/],
+    [JSON.stringify([{ kind: "bun" }]), /"items": 1,[\s\S]*"kinds": \[\s*"bun"\s*\]/],
+    [JSON.stringify({ entries: 0 }), /"keys": \[\s*"entries"\s*\]/],
+  ]) {
+    const { result, calls } = smoke(cacheStats);
+    assert.equal(result.status, 0, result.stdout + result.stderr);
+    assert.match(result.stdout, expected);
+    assert.match(result.stdout, /crabbox-live-ok/);
+    assert.match(calls, /^run --provider apple-container --id apple-container-smoke-test /m);
+    assert.equal((calls.match(/^stop --provider apple-container apple-container-smoke-test$/gm) ?? []).length, 1);
   }
+
+  const { result: malformed, calls } = smoke(JSON.stringify("not-a-cache-report"));
+  assert.notEqual(malformed.status, 0, malformed.stdout + malformed.stderr);
+  assert.match(malformed.stderr, /cache stats must be null, an array, or an object/);
+  assert.match(calls, /^warmup --provider apple-container --ttl 15m --idle-timeout 5m$/m);
+  assert.match(calls, /^cache stats --id apple-container-smoke-test --json$/m);
+  assert.doesNotMatch(calls, /^run --provider apple-container /m);
+  assert.equal((calls.match(/^stop --provider apple-container apple-container-smoke-test$/gm) ?? []).length, 1);
   assert.doesNotMatch(calls, /^history(?: |$)/m);
 });
 

--- a/scripts/live-smoke.test.js
+++ b/scripts/live-smoke.test.js
@@ -2016,16 +2016,19 @@ esac
     assert.match(result.stdout, /crabbox-live-ok/);
     assert.match(calls, /^run --provider apple-container --id apple-container-smoke-test /m);
     assert.equal((calls.match(/^stop --provider apple-container apple-container-smoke-test$/gm) ?? []).length, 1);
+    assert.doesNotMatch(calls, /^history(?: |$)/m);
   }
 
-  const { result: malformed, calls } = smoke(JSON.stringify("not-a-cache-report"));
-  assert.notEqual(malformed.status, 0, malformed.stdout + malformed.stderr);
-  assert.match(malformed.stderr, /cache stats must be null, an array, or an object/);
-  assert.match(calls, /^warmup --provider apple-container --ttl 15m --idle-timeout 5m$/m);
-  assert.match(calls, /^cache stats --id apple-container-smoke-test --json$/m);
-  assert.doesNotMatch(calls, /^run --provider apple-container /m);
-  assert.equal((calls.match(/^stop --provider apple-container apple-container-smoke-test$/gm) ?? []).length, 1);
-  assert.doesNotMatch(calls, /^history(?: |$)/m);
+  for (const cacheStats of [JSON.stringify("not-a-cache-report"), JSON.stringify(42), JSON.stringify(true)]) {
+    const { result: malformed, calls } = smoke(cacheStats);
+    assert.notEqual(malformed.status, 0, malformed.stdout + malformed.stderr);
+    assert.match(malformed.stderr, /cache stats must be null, an array, or an object/);
+    assert.match(calls, /^warmup --provider apple-container --ttl 15m --idle-timeout 5m$/m);
+    assert.match(calls, /^cache stats --id apple-container-smoke-test --json$/m);
+    assert.doesNotMatch(calls, /^run --provider apple-container /m);
+    assert.equal((calls.match(/^stop --provider apple-container apple-container-smoke-test$/gm) ?? []).length, 1);
+    assert.doesNotMatch(calls, /^history(?: |$)/m);
+  }
 });
 
 test("local-container live smoke uses the generic SSH lease lifecycle", () => {


### PR DESCRIPTION
## Summary

`cache stats --json` encoded an empty inventory as JSON `null`, while the live-smoke parser expected an array or object and attempted `keys` on the scalar. This PR makes the CLI's public JSON shape stable by emitting `[]` for an empty inventory.

The live smoke remains compatible with older or external Crabbox binaries: it accepts legacy `null`, arrays, and object-shaped compatibility reports, but rejects strings, numbers, booleans, and other scalar shapes before running the workload. Cleanup still runs on that early failure path.

## Verification

- focused `CacheStats` Go tests
- complete `scripts/live-smoke.test.js` suite
- shell syntax validation
- full `internal/cli` package before final rebase
- structured P1 full-branch autoreview: clean
