### PR TITLE
chore(release): authorize v0.41.4 source

### DIFF
--- a/release/records/v0.41.4.json
+++ b/release/records/v0.41.4.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "repository": "openclaw/crabbox",
+  "tag": "v0.41.4",
+  "tagObject": "fcfd27062df39f3d4b6689dd786ba2dc96f310cb",
+  "sourceCommit": "5390447e3b02f43ba6bfd174ca6d809286c9d65d",
+  "publicationStatus": "ready"
+}


### PR DESCRIPTION
## Summary

Adds the immutable release authorization record binding `v0.41.4` to:

- tag object `fcfd27062df39f3d4b6689dd786ba2dc96f310cb`
- source commit `5390447e3b02f43ba6bfd174ca6d809286c9d65d`

This authorization does not create, build, draft, or publish release assets.

## Verification

- Remote tag object: `fcfd27062df39f3d4b6689dd786ba2dc96f310cb`
- Remote peeled commit: `5390447e3b02f43ba6bfd174ca6d809286c9d65d`
- Focused release tests: passed
- P1 autoreview: clean; no accepted or actionable findings
