### PR TITLE
chore(release): authorize v0.41.5 source

### DIFF
--- a/release/records/v0.41.5.json
+++ b/release/records/v0.41.5.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "repository": "openclaw/crabbox",
+  "tag": "v0.41.5",
+  "tagObject": "9811a613cb3c01168841eb993c5fe0ddd72e5e0a",
+  "sourceCommit": "1611d9dfc3d913d9c48a8c592a809c95eec90499",
+  "publicationStatus": "ready"
+}


### PR DESCRIPTION
This pull request adds only the immutable source binding for v0.41.5. It does not build or publish assets and does not authorize any asset build or publication.