### PR TITLE
chore(release): open v0.41.6 development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 0.41.6 - Unreleased
+
 ## 0.41.5 - 2026-08-12
 
 ### Fixed


### PR DESCRIPTION
## Summary

- open the next patch changelog section as `0.41.6 - Unreleased`
- preserve the shipped v0.41.5 release notes unchanged

## Release proof

- immutable release: https://github.com/openclaw/crabbox/releases/tag/v0.41.5
- public asset verifier: https://github.com/openclaw/crabbox/actions/runs/31583149331
- organization tap reconcile: https://github.com/openclaw/homebrew-tap/actions/runs/31584211121
- native Homebrew verification and anonymous postflight: https://github.com/openclaw/crabbox/actions/runs/31584407026

## Verification

- `git diff --check`
- `scripts/extract-release-notes.sh v0.41.5 < CHANGELOG.md`
- strict pre-commit review: clean
