### PR TITLE
fix(cli): keep sensitive generated output private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Reported explicit stdout and stderr capture paths and byte counts in emitted run proofs without reading or embedding captured content. Thanks @coygeek.
 - Routed implicit `status` and `inspect` lease identifiers through the provider recorded in local claims before initializing the configured provider, while preserving explicit-provider precedence and missing-claim fallback. Thanks @coygeek.
 - Made POSIX workspace ownership independent of the remote account's login shell by transporting owner scripts through a private `/bin/sh` launcher, fixing static macOS sync under zsh, Bash, and Fish. Thanks @osouthgate and @hosmelq.
+- Restricted sensitive generated local files, including managed attestation keys and signed-URL artifact outputs, to the current OS user on POSIX and Windows. Thanks @dwin-gharibi.
 
 ## 0.41.5 - 2026-08-12
 

--- a/docs/commands/artifacts.md
+++ b/docs/commands/artifacts.md
@@ -289,6 +289,15 @@ published file:
 }
 ```
 
+When a generated manifest contains a signed or presigned bearer URL, Crabbox
+keeps the local manifest owner-only: mode `0600` on POSIX, with inherited
+extended ACLs removed on macOS, and a protected DACL owned by and limited to
+the current user on Windows. The generated
+`published-artifacts.md` summary uses the same protection only when it embeds a
+signed URL. Republishing tightens an older broad file instead of preserving its
+permissions. Manifests and summaries containing only local paths or public URLs
+keep their existing shared-output `0644` and mode-preservation behavior.
+
 Inspect or fetch that manifest later:
 
 ```sh

--- a/docs/security.md
+++ b/docs/security.md
@@ -429,7 +429,16 @@ S3, R2, or Cloudflare uploads, so later bundle path replacement cannot change
 uploaded bytes. Local and dry-run manifests hash through rooted validated file
 handles without duplicating the bundle. Generated manifest and Markdown files
 replace reserved outputs through root-confined temporary files without
-following symlinks. Required artifact paths must resolve to regular files.
+following symlinks. Manifests and summaries that contain signed bearer URLs are
+restricted to the current OS user before their sensitive bytes are written and
+are verified before publication: mode `0600` on POSIX, with inherited macOS
+ACLs removed, and a protected, current-user-owned DACL with no unrelated grants
+on Windows. Public-URL and local-path artifact outputs retain their shareable
+permissions. The same local
+private-file boundary protects Crabbox-generated run outputs and the managed
+attestation signing key; replacement or reuse tightens an older broad mode or
+DACL instead of preserving it. Required artifact paths must resolve to regular
+files.
 Automatic remote failure bundles confine member names and link targets to their
 generated subtree and omit
 escaping, rooted, empty, or special-file entries. These filesystem checks do

--- a/internal/cli/artifacts.go
+++ b/internal/cli/artifacts.go
@@ -682,9 +682,14 @@ func (a App) publishArtifactDirectory(ctx context.Context, opts artifactPublishO
 	}
 	body := artifactTemplateMarkdown(opts.Template, summary, "", "", published)
 	bodyPath := filepath.Join(opts.Directory, "published-artifacts.md")
-	// Same reason as the manifest: artifactTemplateMarkdown embeds each file's URL, which
-	// under the signed-url access policy is a presigned bearer capability.
-	if err := writeArtifactBundleFile(bundleRoot, "published-artifacts.md", []byte(body), privateRunOutputFileMode); err != nil {
+	// artifactTemplateMarkdown embeds each file's URL. Restrict the summary only when one of
+	// those URLs is a presigned bearer capability; a public or local summary is meant to be
+	// shared, so it keeps the readable mode it has always had.
+	bodyMode := os.FileMode(0o644)
+	if artifactFilesContainSignedURL(published) {
+		bodyMode = privateRunOutputFileMode
+	}
+	if err := writeArtifactBundleFile(bundleRoot, "published-artifacts.md", []byte(body), bodyMode); err != nil {
 		return nil, "", "", err
 	}
 	if opts.PR > 0 && !opts.NoComment {

--- a/internal/cli/artifacts.go
+++ b/internal/cli/artifacts.go
@@ -682,7 +682,9 @@ func (a App) publishArtifactDirectory(ctx context.Context, opts artifactPublishO
 	}
 	body := artifactTemplateMarkdown(opts.Template, summary, "", "", published)
 	bodyPath := filepath.Join(opts.Directory, "published-artifacts.md")
-	if err := writeArtifactBundleFile(bundleRoot, "published-artifacts.md", []byte(body), 0o644); err != nil {
+	// Same reason as the manifest: artifactTemplateMarkdown embeds each file's URL, which
+	// under the signed-url access policy is a presigned bearer capability.
+	if err := writeArtifactBundleFile(bundleRoot, "published-artifacts.md", []byte(body), privateRunOutputFileMode); err != nil {
 		return nil, "", "", err
 	}
 	if opts.PR > 0 && !opts.NoComment {

--- a/internal/cli/artifacts.go
+++ b/internal/cli/artifacts.go
@@ -685,11 +685,12 @@ func (a App) publishArtifactDirectory(ctx context.Context, opts artifactPublishO
 	// artifactTemplateMarkdown embeds each file's URL. Restrict the summary only when one of
 	// those URLs is a presigned bearer capability; a public or local summary is meant to be
 	// shared, so it keeps the readable mode it has always had.
-	bodyMode := os.FileMode(0o644)
 	if artifactFilesContainSignedURL(published) {
-		bodyMode = privateRunOutputFileMode
+		err = writePrivateArtifactBundleFile(bundleRoot, "published-artifacts.md", []byte(body))
+	} else {
+		err = writeArtifactBundleFile(bundleRoot, "published-artifacts.md", []byte(body), 0o644)
 	}
-	if err := writeArtifactBundleFile(bundleRoot, "published-artifacts.md", []byte(body), bodyMode); err != nil {
+	if err != nil {
 		return nil, "", "", err
 	}
 	if opts.PR > 0 && !opts.NoComment {

--- a/internal/cli/artifacts_manifest.go
+++ b/internal/cli/artifacts_manifest.go
@@ -137,11 +137,21 @@ func writeArtifactManifest(root *os.Root, opts artifactPublishOptions, files []a
 		return "", nil, exit(2, "encode artifact manifest: %v", err)
 	}
 	data = append(data, '\n')
-	// The manifest embeds each file's URL, which for the signed-url access policy is a
-	// presigned bearer capability. Keep it owner-only even when --output selects a
-	// directory that is not itself private.
-	if err := writeArtifactBundleFile(root, artifactManifestFilename, data, privateRunOutputFileMode); err != nil {
-		return "", nil, err
+	private := false
+	for _, file := range manifest.Files {
+		if file.AccessPolicy == "signed-url" {
+			private = true
+			break
+		}
+	}
+	var writeErr error
+	if private {
+		writeErr = writePrivateArtifactBundleFile(root, artifactManifestFilename, data)
+	} else {
+		writeErr = writeArtifactBundleFile(root, artifactManifestFilename, data, 0o644)
+	}
+	if writeErr != nil {
+		return "", nil, writeErr
 	}
 	return path, data, nil
 }

--- a/internal/cli/artifacts_manifest.go
+++ b/internal/cli/artifacts_manifest.go
@@ -137,7 +137,10 @@ func writeArtifactManifest(root *os.Root, opts artifactPublishOptions, files []a
 		return "", nil, exit(2, "encode artifact manifest: %v", err)
 	}
 	data = append(data, '\n')
-	if err := writeArtifactBundleFile(root, artifactManifestFilename, data, 0o644); err != nil {
+	// The manifest embeds each file's URL, which for the signed-url access policy is a
+	// presigned bearer capability. Keep it owner-only even when --output selects a
+	// directory that is not itself private.
+	if err := writeArtifactBundleFile(root, artifactManifestFilename, data, privateRunOutputFileMode); err != nil {
 		return "", nil, err
 	}
 	return path, data, nil

--- a/internal/cli/artifacts_manifest.go
+++ b/internal/cli/artifacts_manifest.go
@@ -491,16 +491,37 @@ func rejectSymlinkedArtifactOutputParents(root, name string) error {
 	return nil
 }
 
+// artifactURLIsSigned reports whether a URL carries a presigned bearer capability. It is the
+// single definition of that boundary, shared by the access policy and by output file modes.
+func artifactURLIsSigned(rawURL string) bool {
+	if strings.TrimSpace(rawURL) == "" {
+		return false
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	query := parsed.Query()
+	return query.Get("X-Amz-Signature") != "" || query.Get("X-Amz-Credential") != ""
+}
+
+// artifactFilesContainSignedURL reports whether any published file exposes a presigned URL,
+// so generated output that embeds those URLs can be written owner-only.
+func artifactFilesContainSignedURL(files []artifactFile) bool {
+	for _, file := range files {
+		if artifactURLIsSigned(file.URL) {
+			return true
+		}
+	}
+	return false
+}
+
 func artifactAccessPolicy(rawURL, storage string) string {
 	if strings.TrimSpace(rawURL) == "" {
 		return "local"
 	}
-	parsed, err := url.Parse(rawURL)
-	if err == nil {
-		query := parsed.Query()
-		if query.Get("X-Amz-Signature") != "" || query.Get("X-Amz-Credential") != "" {
-			return "signed-url"
-		}
+	if artifactURLIsSigned(rawURL) {
+		return "signed-url"
 	}
 	if strings.HasPrefix(strings.ToLower(strings.TrimSpace(rawURL)), "http://") || strings.HasPrefix(strings.ToLower(strings.TrimSpace(rawURL)), "https://") {
 		return "public"

--- a/internal/cli/artifacts_private_other.go
+++ b/internal/cli/artifacts_private_other.go
@@ -1,0 +1,21 @@
+//go:build !windows
+
+package cli
+
+import (
+	"os"
+)
+
+func openArtifactBundleTemp(root *os.Root, name string, perm os.FileMode, private bool) (*os.File, error) {
+	file, err := root.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_EXCL, perm)
+	if err != nil {
+		return nil, err
+	}
+	if private {
+		if err := securePrivateFile(file); err != nil {
+			_ = file.Close()
+			return nil, err
+		}
+	}
+	return file, nil
+}

--- a/internal/cli/artifacts_private_windows.go
+++ b/internal/cli/artifacts_private_windows.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package cli
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func openArtifactBundleTemp(root *os.Root, name string, perm os.FileMode, private bool) (*os.File, error) {
+	if !private {
+		return root.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_EXCL, perm)
+	}
+	directory, err := root.Open(".")
+	if err != nil {
+		return nil, err
+	}
+	defer directory.Close()
+	return createPrivateWindowsFileAt(windows.Handle(directory.Fd()), name)
+}

--- a/internal/cli/artifacts_publish.go
+++ b/internal/cli/artifacts_publish.go
@@ -437,7 +437,10 @@ func writeArtifactBundleFile(root *os.Root, name string, data []byte, perm os.Fi
 	if info, statErr := root.Lstat(name); statErr == nil {
 		if info.Mode().IsRegular() {
 			createPerm = 0o600
-			existingMode = info.Mode().Perm()
+			// Respect a mode the user already narrowed, but never widen past what the
+			// caller asked for: a republished manifest must not inherit a world-readable
+			// mode from an earlier bundle.
+			existingMode = info.Mode().Perm() & perm
 			preserveExistingMode = true
 		}
 	} else if !os.IsNotExist(statErr) {

--- a/internal/cli/artifacts_publish.go
+++ b/internal/cli/artifacts_publish.go
@@ -426,6 +426,14 @@ func requireArtifactValidation(file artifactFile) error {
 }
 
 func writeArtifactBundleFile(root *os.Root, name string, data []byte, perm os.FileMode) error {
+	return writeArtifactBundleFileWithPrivacy(root, name, data, perm, false)
+}
+
+func writePrivateArtifactBundleFile(root *os.Root, name string, data []byte) error {
+	return writeArtifactBundleFileWithPrivacy(root, name, data, privateRunOutputFileMode, true)
+}
+
+func writeArtifactBundleFileWithPrivacy(root *os.Root, name string, data []byte, perm os.FileMode, private bool) error {
 	token, err := randomHex(12)
 	if err != nil {
 		return exit(2, "create private temporary name for %s: %v", name, err)
@@ -437,16 +445,17 @@ func writeArtifactBundleFile(root *os.Root, name string, data []byte, perm os.Fi
 	if info, statErr := root.Lstat(name); statErr == nil {
 		if info.Mode().IsRegular() {
 			createPerm = 0o600
-			// Respect a mode the user already narrowed, but never widen past what the
-			// caller asked for: a republished manifest must not inherit a world-readable
-			// mode from an earlier bundle.
-			existingMode = info.Mode().Perm() & perm
-			preserveExistingMode = true
+			if !private {
+				// Preserve modes the user narrowed, but do not retain permissions
+				// broader than this shared output requests.
+				existingMode = info.Mode().Perm() & perm
+				preserveExistingMode = true
+			}
 		}
 	} else if !os.IsNotExist(statErr) {
 		return exit(2, "inspect existing artifact output %s: %v", name, statErr)
 	}
-	file, err := root.OpenFile(tempName, os.O_WRONLY|os.O_CREATE|os.O_EXCL, createPerm)
+	file, err := openArtifactBundleTemp(root, tempName, createPerm, private)
 	if err != nil {
 		return exit(2, "create private temporary artifact output for %s: %v", name, err)
 	}

--- a/internal/cli/artifacts_test.go
+++ b/internal/cli/artifacts_test.go
@@ -1522,6 +1522,92 @@ func TestWriteArtifactBundleFilePreservesExistingMode(t *testing.T) {
 	}
 }
 
+// The manifest carries presigned upload/read URLs, which are bearer capabilities, so it
+// must stay owner-only even when --output selects a non-private directory and even when
+// an earlier bundle left a world-readable manifest in place.
+//
+// published-artifacts.md is the sibling instance: artifactTemplateMarkdown embeds the same
+// URLs, so both bundle files that can carry a presigned URL are covered here.
+func TestWriteArtifactBundleCredentialFilesKeepOwnerOnlyMode(t *testing.T) {
+	for _, name := range []string{artifactManifestFilename, "published-artifacts.md"} {
+		for _, existing := range []os.FileMode{0, 0o644, 0o600} {
+			t.Run(fmt.Sprintf("%s/%#o", name, existing), func(t *testing.T) {
+				dir := t.TempDir()
+				path := filepath.Join(dir, name)
+				if existing != 0 {
+					if err := os.WriteFile(path, []byte("old"), existing); err != nil {
+						t.Fatal(err)
+					}
+					if err := os.Chmod(path, existing); err != nil {
+						t.Fatal(err)
+					}
+				}
+				root, err := os.OpenRoot(dir)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer root.Close()
+
+				if err := writeArtifactBundleFile(root, name, []byte("body"), privateRunOutputFileMode); err != nil {
+					t.Fatal(err)
+				}
+
+				info, err := os.Stat(path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if got := info.Mode().Perm(); got&0o077 != 0 {
+					t.Fatalf("%s mode=%#o, want no group or other access", name, got)
+				}
+			})
+		}
+	}
+}
+
+func TestWriteArtifactManifestKeepsOwnerOnlyMode(t *testing.T) {
+	for _, existing := range []struct {
+		name string
+		mode os.FileMode
+	}{
+		{name: "fresh", mode: 0},
+		{name: "world-readable", mode: 0o644},
+		{name: "already-private", mode: 0o600},
+	} {
+		t.Run(existing.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, artifactManifestFilename)
+			if existing.mode != 0 {
+				if err := os.WriteFile(path, []byte("old"), existing.mode); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Chmod(path, existing.mode); err != nil {
+					t.Fatal(err)
+				}
+			}
+			root, err := os.OpenRoot(dir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer root.Close()
+
+			if _, _, err := writeArtifactManifest(root, artifactPublishOptions{
+				Directory: dir,
+				Storage:   "broker",
+			}, nil); err != nil {
+				t.Fatal(err)
+			}
+
+			info, err := os.Stat(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := info.Mode().Perm(); got&0o077 != 0 {
+				t.Fatalf("manifest mode=%#o, want no group or other access", got)
+			}
+		})
+	}
+}
+
 func TestArtifactsPublishRejectsReservedOutputDirectoriesBeforeSideEffects(t *testing.T) {
 	for _, reservedName := range []string{
 		artifactManifestFilename,

--- a/internal/cli/artifacts_test.go
+++ b/internal/cli/artifacts_test.go
@@ -1528,6 +1528,8 @@ func TestWriteArtifactBundleFilePreservesExistingMode(t *testing.T) {
 //
 // published-artifacts.md is the sibling instance: artifactTemplateMarkdown embeds the same
 // URLs, so both bundle files that can carry a presigned URL are covered here.
+//
+// The summary's mode is conditional — see TestPublishedArtifactsSummaryModeFollowsURLKind.
 func TestWriteArtifactBundleCredentialFilesKeepOwnerOnlyMode(t *testing.T) {
 	for _, name := range []string{artifactManifestFilename, "published-artifacts.md"} {
 		for _, existing := range []os.FileMode{0, 0o644, 0o600} {
@@ -1561,6 +1563,50 @@ func TestWriteArtifactBundleCredentialFilesKeepOwnerOnlyMode(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+// The summary is meant to be shared (it is the PR comment body), so it may only be
+// restricted when it actually embeds a presigned URL. A public or local bundle keeps the
+// readable mode it has always had.
+func TestPublishedArtifactsSummaryModeFollowsURLKind(t *testing.T) {
+	signed := "https://bucket.s3.amazonaws.com/proof.txt?X-Amz-Signature=deadbeef&X-Amz-Expires=900"
+	for _, item := range []struct {
+		name    string
+		files   []artifactFile
+		private bool
+	}{
+		{name: "signed", files: []artifactFile{{Kind: "proof", Name: "proof.txt", URL: signed}}, private: true},
+		{name: "public", files: []artifactFile{{Kind: "proof", Name: "proof.txt", URL: "https://artifacts.example.com/proof.txt"}}, private: false},
+		{name: "local", files: []artifactFile{{Kind: "proof", Name: "proof.txt", Path: "proof.txt"}}, private: false},
+		{name: "mixed", files: []artifactFile{{Kind: "a", Name: "a.txt", URL: "https://artifacts.example.com/a.txt"}, {Kind: "b", Name: "b.txt", URL: signed}}, private: true},
+	} {
+		t.Run(item.name, func(t *testing.T) {
+			if got := artifactFilesContainSignedURL(item.files); got != item.private {
+				t.Fatalf("artifactFilesContainSignedURL=%t, want %t", got, item.private)
+			}
+			mode := os.FileMode(0o644)
+			if item.private {
+				mode = privateRunOutputFileMode
+			}
+			dir := t.TempDir()
+			root, err := os.OpenRoot(dir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer root.Close()
+			if err := writeArtifactBundleFile(root, "published-artifacts.md", []byte("body"), mode); err != nil {
+				t.Fatal(err)
+			}
+			info, err := os.Stat(filepath.Join(dir, "published-artifacts.md"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			restricted := info.Mode().Perm()&0o077 == 0
+			if restricted != item.private {
+				t.Fatalf("summary mode=%#o restricted=%t, want restricted=%t", info.Mode().Perm(), restricted, item.private)
+			}
+		})
 	}
 }
 

--- a/internal/cli/artifacts_test.go
+++ b/internal/cli/artifacts_test.go
@@ -1550,10 +1550,13 @@ func TestWriteArtifactBundleCredentialFilesKeepOwnerOnlyMode(t *testing.T) {
 				}
 				defer root.Close()
 
-				if err := writeArtifactBundleFile(root, name, []byte("body"), privateRunOutputFileMode); err != nil {
+				if err := writePrivateArtifactBundleFile(root, name, []byte("body")); err != nil {
 					t.Fatal(err)
 				}
 
+				if runtime.GOOS == "windows" {
+					return
+				}
 				info, err := os.Stat(path)
 				if err != nil {
 					t.Fatal(err)
@@ -1585,18 +1588,22 @@ func TestPublishedArtifactsSummaryModeFollowsURLKind(t *testing.T) {
 			if got := artifactFilesContainSignedURL(item.files); got != item.private {
 				t.Fatalf("artifactFilesContainSignedURL=%t, want %t", got, item.private)
 			}
-			mode := os.FileMode(0o644)
-			if item.private {
-				mode = privateRunOutputFileMode
-			}
 			dir := t.TempDir()
 			root, err := os.OpenRoot(dir)
 			if err != nil {
 				t.Fatal(err)
 			}
 			defer root.Close()
-			if err := writeArtifactBundleFile(root, "published-artifacts.md", []byte("body"), mode); err != nil {
+			if item.private {
+				err = writePrivateArtifactBundleFile(root, "published-artifacts.md", []byte("body"))
+			} else {
+				err = writeArtifactBundleFile(root, "published-artifacts.md", []byte("body"), 0o644)
+			}
+			if err != nil {
 				t.Fatal(err)
+			}
+			if runtime.GOOS == "windows" {
+				return
 			}
 			info, err := os.Stat(filepath.Join(dir, "published-artifacts.md"))
 			if err != nil {
@@ -1610,7 +1617,15 @@ func TestPublishedArtifactsSummaryModeFollowsURLKind(t *testing.T) {
 	}
 }
 
-func TestWriteArtifactManifestKeepsOwnerOnlyMode(t *testing.T) {
+func TestWriteSensitiveArtifactManifestKeepsOwnerOnlyMode(t *testing.T) {
+	signedFile := artifactFile{
+		Kind:          "proof",
+		Name:          "proof.txt",
+		URL:           "https://bucket.s3.amazonaws.com/proof.txt?X-Amz-Signature=deadbeef&X-Amz-Expires=900",
+		snapshotValid: true,
+		snapshotHash:  strings.Repeat("a", 64),
+		snapshotSize:  1,
+	}
 	for _, existing := range []struct {
 		name string
 		mode os.FileMode
@@ -1639,16 +1654,77 @@ func TestWriteArtifactManifestKeepsOwnerOnlyMode(t *testing.T) {
 			if _, _, err := writeArtifactManifest(root, artifactPublishOptions{
 				Directory: dir,
 				Storage:   "broker",
-			}, nil); err != nil {
+			}, []artifactFile{signedFile}); err != nil {
 				t.Fatal(err)
 			}
 
+			if runtime.GOOS == "windows" {
+				return
+			}
 			info, err := os.Stat(path)
 			if err != nil {
 				t.Fatal(err)
 			}
 			if got := info.Mode().Perm(); got&0o077 != 0 {
 				t.Fatalf("manifest mode=%#o, want no group or other access", got)
+			}
+		})
+	}
+}
+
+func TestPublicAndLocalArtifactManifestPreserveSharedModes(t *testing.T) {
+	for _, item := range []struct {
+		name     string
+		url      string
+		existing os.FileMode
+		want     os.FileMode
+	}{
+		{name: "public fresh", url: "https://artifacts.example.com/proof.txt", want: 0o644},
+		{name: "local fresh", want: 0o644},
+		{name: "public narrowed", url: "https://artifacts.example.com/proof.txt", existing: 0o640, want: 0o640},
+		{name: "public writable capped", url: "https://artifacts.example.com/proof.txt", existing: 0o666, want: 0o644},
+		{name: "local private", existing: 0o600, want: 0o600},
+	} {
+		t.Run(item.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, artifactManifestFilename)
+			if item.existing != 0 {
+				if err := os.WriteFile(path, []byte("old"), item.existing); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Chmod(path, item.existing); err != nil {
+					t.Fatal(err)
+				}
+			}
+			root, err := os.OpenRoot(dir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer root.Close()
+			file := artifactFile{
+				Kind:          "proof",
+				Name:          "proof.txt",
+				Path:          "proof.txt",
+				URL:           item.url,
+				snapshotValid: true,
+				snapshotHash:  strings.Repeat("b", 64),
+				snapshotSize:  1,
+			}
+			if _, _, err := writeArtifactManifest(root, artifactPublishOptions{
+				Directory: dir,
+				Storage:   "local",
+			}, []artifactFile{file}); err != nil {
+				t.Fatal(err)
+			}
+			if runtime.GOOS == "windows" {
+				return
+			}
+			info, err := os.Stat(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := info.Mode().Perm(); got != item.want {
+				t.Fatalf("manifest mode=%#o, want %#o", got, item.want)
 			}
 		})
 	}

--- a/internal/cli/attest.go
+++ b/internal/cli/attest.go
@@ -52,12 +52,12 @@ func ensureAttestKey() (ed25519.PrivateKey, error) {
 	if err != nil {
 		return nil, err
 	}
-	if _, err := os.Stat(path); err == nil {
-		return loadAttestKey(path)
-	} else if !errors.Is(err, os.ErrNotExist) {
+	if err := ensurePrivateRunOutputDir(filepath.Dir(path)); err != nil {
 		return nil, err
 	}
-	if err := ensurePrivateRunOutputDir(filepath.Dir(path)); err != nil {
+	if _, err := os.Stat(path); err == nil {
+		return loadManagedAttestKey(path)
+	} else if !errors.Is(err, os.ErrNotExist) {
 		return nil, err
 	}
 	_, key, err := ed25519.GenerateKey(rand.Reader)
@@ -74,7 +74,7 @@ func ensureAttestKey() (ed25519.PrivateKey, error) {
 		return nil, err
 	}
 	if !created {
-		return loadAttestKey(path)
+		return loadManagedAttestKey(path)
 	}
 	return key, nil
 }
@@ -161,11 +161,28 @@ func preflightAttestPaths(opts attestPathPreflight) error {
 	return nil
 }
 
+func loadManagedAttestKey(path string) (ed25519.PrivateKey, error) {
+	file, err := openExistingPrivateRunOutputFile(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return nil, err
+	}
+	return parseAttestKey(path, data)
+}
+
 func loadAttestKey(path string) (ed25519.PrivateKey, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
+	return parseAttestKey(path, data)
+}
+
+func parseAttestKey(path string, data []byte) (ed25519.PrivateKey, error) {
 	block, rest := pem.Decode(data)
 	if block == nil {
 		return nil, fmt.Errorf("attest key %s is not PEM encoded", path)

--- a/internal/cli/attest_test.go
+++ b/internal/cli/attest_test.go
@@ -28,6 +28,7 @@ func setAttestTestHome(t *testing.T) string {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("APPDATA", filepath.Join(home, "AppData", "Roaming"))
 	return home
 }
 

--- a/internal/cli/run_local_output.go
+++ b/internal/cli/run_local_output.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"io"
 	"os"
-	"path/filepath"
 )
 
 const (
@@ -13,24 +12,14 @@ const (
 	privateRunOutputFileMode = 0o600
 )
 
-func createPrivateRunOutputDir(path string) error {
-	return os.MkdirAll(path, privateRunOutputDirMode)
-}
-
 func writePrivateRunOutputFileIfAbsent(path string, data []byte) (bool, error) {
-	dir := filepath.Dir(path)
-	file, err := os.CreateTemp(dir, "."+filepath.Base(path)+".crabbox-*")
+	file, tempPath, err := createPrivateRunOutputTemp(path)
 	if err != nil {
 		return false, err
 	}
-	tempPath := file.Name()
 	cleanup := func() {
 		_ = file.Close()
 		_ = os.Remove(tempPath)
-	}
-	if err := file.Chmod(privateRunOutputFileMode); err != nil {
-		cleanup()
-		return false, err
 	}
 	if _, err := io.Copy(file, bytes.NewReader(data)); err != nil {
 		cleanup()

--- a/internal/cli/run_local_output_darwin_test.go
+++ b/internal/cli/run_local_output_darwin_test.go
@@ -1,0 +1,40 @@
+//go:build darwin
+
+package cli
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPrivateRunOutputRemovesInheritedDarwinACL(t *testing.T) {
+	parent := t.TempDir()
+	if output, err := exec.Command("chmod", "+a", "everyone allow read,file_inherit", parent).CombinedOutput(); err != nil {
+		t.Fatalf("add inherited ACL: %v\n%s", err, output)
+	}
+	path := filepath.Join(parent, "private.txt")
+	if err := os.WriteFile(path, []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	assertDarwinPathHasInheritedACL(t, path, true)
+	if err := writePrivateRunOutputFile(path, []byte("private")); err != nil {
+		t.Fatal(err)
+	}
+	assertRunOutputMode(t, path, privateRunOutputFileMode)
+	assertDarwinPathHasInheritedACL(t, path, false)
+}
+
+func assertDarwinPathHasInheritedACL(t *testing.T, path string, want bool) {
+	t.Helper()
+	output, err := exec.Command("ls", "-le", path).CombinedOutput()
+	if err != nil {
+		t.Fatalf("inspect ACL: %v\n%s", err, output)
+	}
+	hasInherited := strings.Contains(string(output), " inherited ")
+	if hasInherited != want {
+		t.Fatalf("%s inherited ACL=%t, want %t\n%s", path, hasInherited, want, output)
+	}
+}

--- a/internal/cli/run_local_output_permissions_darwin.go
+++ b/internal/cli/run_local_output_permissions_darwin.go
@@ -1,0 +1,32 @@
+//go:build darwin
+
+package cli
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+const darwinFchmodExtended = 283
+
+func setPrivateFDPermissions(fd uintptr, mode os.FileMode) error {
+	const (
+		kauthUIDNone  = ^uint32(0) - 100
+		kauthGIDNone  = ^uint32(0) - 100
+		removeFileACL = uintptr(1)
+	)
+	_, _, err := unix.Syscall6(
+		darwinFchmodExtended,
+		fd,
+		uintptr(kauthUIDNone),
+		uintptr(kauthGIDNone),
+		uintptr(mode.Perm()),
+		removeFileACL,
+		0,
+	)
+	if err != 0 {
+		return err
+	}
+	return nil
+}

--- a/internal/cli/run_local_output_permissions_unix.go
+++ b/internal/cli/run_local_output_permissions_unix.go
@@ -1,0 +1,13 @@
+//go:build !windows && !darwin
+
+package cli
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func setPrivateFDPermissions(fd uintptr, mode os.FileMode) error {
+	return unix.Fchmod(int(fd), uint32(mode.Perm()))
+}

--- a/internal/cli/run_local_output_unix.go
+++ b/internal/cli/run_local_output_unix.go
@@ -4,6 +4,7 @@ package cli
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -21,7 +22,21 @@ func ensurePrivateRunOutputDir(path string) error {
 		return err
 	}
 	defer unix.Close(fd)
-	return unix.Fchmod(fd, privateRunOutputDirMode)
+	if err := setPrivateFDPermissions(uintptr(fd), privateRunOutputDirMode); err != nil {
+		return err
+	}
+	var stat unix.Stat_t
+	if err := unix.Fstat(fd, &stat); err != nil {
+		return err
+	}
+	if os.FileMode(stat.Mode).Perm() != privateRunOutputDirMode {
+		return fmt.Errorf("private output directory mode is %#o, want %#o", os.FileMode(stat.Mode).Perm(), privateRunOutputDirMode)
+	}
+	return nil
+}
+
+func createPrivateRunOutputDir(path string) error {
+	return os.MkdirAll(path, privateRunOutputDirMode)
 }
 
 func openPrivateRunOutputFile(path string) (*os.File, error) {
@@ -68,12 +83,53 @@ func createPrivateRunOutputTemp(path string) (*os.File, string, error) {
 		return nil, "", err
 	}
 	tempPath := file.Name()
-	if err := file.Chmod(privateRunOutputFileMode); err != nil {
+	if err := securePrivateFile(file); err != nil {
 		_ = file.Close()
 		_ = os.Remove(tempPath)
 		return nil, "", err
 	}
 	return file, tempPath, nil
+}
+
+func securePrivateFile(file *os.File) error {
+	if file == nil {
+		return fmt.Errorf("private output file handle is unavailable")
+	}
+	info, err := file.Stat()
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("private output must be a regular file")
+	}
+	if err := setPrivateFDPermissions(file.Fd(), privateRunOutputFileMode); err != nil {
+		return err
+	}
+	info, err = file.Stat()
+	if err != nil {
+		return err
+	}
+	if got := info.Mode().Perm(); got != privateRunOutputFileMode {
+		return fmt.Errorf("private output mode is %#o, want %#o", got, privateRunOutputFileMode)
+	}
+	return nil
+}
+
+func openExistingPrivateRunOutputFile(path string) (*os.File, error) {
+	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_NOFOLLOW|unix.O_CLOEXEC|unix.O_NONBLOCK, 0)
+	if err != nil {
+		return nil, err
+	}
+	file := os.NewFile(uintptr(fd), path)
+	if file == nil {
+		_ = unix.Close(fd)
+		return nil, fmt.Errorf("open private output file handle")
+	}
+	if err := securePrivateFile(file); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	return file, nil
 }
 
 func checkPrivateRunOutputReplaceable(label, path string) error {

--- a/internal/cli/run_local_output_unix_test.go
+++ b/internal/cli/run_local_output_unix_test.go
@@ -218,6 +218,22 @@ func TestStickyRunOutputReplaceAllowed(t *testing.T) {
 	}
 }
 
+func TestSecurePrivateFileRejectsDirectoryWithoutChangingMode(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	file, err := os.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	if err := securePrivateFile(file); err == nil {
+		t.Fatal("expected directory to be rejected")
+	}
+	assertRunOutputMode(t, dir, 0o700)
+}
+
 func assertRunOutputMode(t *testing.T, path string, want os.FileMode) {
 	t.Helper()
 	info, err := os.Stat(path)

--- a/internal/cli/run_local_output_windows.go
+++ b/internal/cli/run_local_output_windows.go
@@ -4,43 +4,581 @@ package cli
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
-func ensurePrivateRunOutputDir(path string) error {
-	if err := createPrivateRunOutputDir(path); err != nil {
+const privateRunOutputTempAttempts = 32
+
+var (
+	movePrivateRunOutputFileExW = windows.NewLazySystemDLL("kernel32.dll").NewProc("MoveFileExW")
+	reopenPrivateRunOutputFile  = windows.NewLazySystemDLL("kernel32.dll").NewProc("ReOpenFile")
+)
+
+func createPrivateRunOutputDir(path string) error {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
 		return err
 	}
-	return os.Chmod(path, privateRunOutputDirMode)
+	absPath = filepath.Clean(absPath)
+	volume := filepath.VolumeName(absPath)
+	components := strings.FieldsFunc(strings.TrimPrefix(absPath, volume), func(r rune) bool {
+		return r == '\\' || r == '/'
+	})
+	if volume == "" || len(components) == 0 {
+		return fmt.Errorf("private output directory must be below a Windows volume root")
+	}
+	rootPath := volume + string(os.PathSeparator)
+	rootPathPtr, err := windows.UTF16PtrFromString(rootPath)
+	if err != nil {
+		return err
+	}
+	rootHandle, err := windows.CreateFile(
+		rootPathPtr,
+		windows.FILE_TRAVERSE|windows.FILE_READ_ATTRIBUTES|windows.READ_CONTROL|windows.SYNCHRONIZE,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_FLAG_OPEN_REPARSE_POINT|windows.FILE_FLAG_BACKUP_SEMANTICS,
+		0,
+	)
+	if err != nil {
+		return err
+	}
+	handles := []windows.Handle{rootHandle}
+	defer func() {
+		for index := len(handles) - 1; index >= 0; index-- {
+			_ = windows.CloseHandle(handles[index])
+		}
+	}()
+	descriptor, user, err := privateWindowsSecurityDescriptor(true)
+	if err != nil {
+		return err
+	}
+	parent := rootHandle
+	for index, component := range components {
+		final := index == len(components)-1
+		handle, created, err := openOrCreatePrivateWindowsDirectoryAt(parent, component, descriptor, final)
+		if err != nil {
+			return fmt.Errorf("open private output directory component %q: %w", component, err)
+		}
+		handles = append(handles, handle)
+		if err := validatePrivateWindowsFileType(handle, true); err != nil {
+			return err
+		}
+		if created {
+			if err := verifyPrivateWindowsHandle(handle, true, user); err != nil {
+				return err
+			}
+		} else if final {
+			if err := securePrivateWindowsHandle(handle, true); err != nil {
+				return err
+			}
+		}
+		parent = handle
+	}
+	return nil
+}
+
+func ensurePrivateRunOutputDir(path string) error {
+	return createPrivateRunOutputDir(path)
+}
+
+func openOrCreatePrivateWindowsDirectoryAt(parent windows.Handle, name string, descriptor *windows.SECURITY_DESCRIPTOR, secureExisting bool) (windows.Handle, bool, error) {
+	objectName, err := windows.NewNTUnicodeString(name)
+	if err != nil {
+		return windows.InvalidHandle, false, err
+	}
+	objectAttributes := &windows.OBJECT_ATTRIBUTES{
+		Length:             uint32(unsafe.Sizeof(windows.OBJECT_ATTRIBUTES{})),
+		RootDirectory:      parent,
+		ObjectName:         objectName,
+		Attributes:         windows.OBJ_CASE_INSENSITIVE | windows.OBJ_DONT_REPARSE,
+		SecurityDescriptor: descriptor,
+	}
+	status := &windows.IO_STATUS_BLOCK{}
+	var handle windows.Handle
+	access := uint32(windows.FILE_TRAVERSE | windows.FILE_READ_ATTRIBUTES | windows.READ_CONTROL | windows.SYNCHRONIZE)
+	if secureExisting {
+		access |= windows.WRITE_DAC
+	}
+	err = windows.NtCreateFile(
+		&handle,
+		access,
+		objectAttributes,
+		status,
+		nil,
+		windows.FILE_ATTRIBUTE_NORMAL,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE,
+		windows.FILE_OPEN_IF,
+		windows.FILE_DIRECTORY_FILE|windows.FILE_OPEN_REPARSE_POINT|windows.FILE_OPEN_FOR_BACKUP_INTENT|windows.FILE_SYNCHRONOUS_IO_NONALERT,
+		0,
+		0,
+	)
+	if err != nil {
+		return windows.InvalidHandle, false, err
+	}
+	const fileCreated = 2
+	return handle, status.Information == fileCreated, nil
 }
 
 func openPrivateRunOutputFile(path string) (*os.File, error) {
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, privateRunOutputFileMode)
+	file, tempPath, err := createPrivateRunOutputTemp(path)
 	if err != nil {
 		return nil, err
 	}
-	if err := file.Chmod(privateRunOutputFileMode); err != nil {
+	if err := replacePrivateRunOutputTemp(tempPath, path); err != nil {
 		_ = file.Close()
-		return nil, err
-	}
-	if err := file.Truncate(0); err != nil {
-		_ = file.Close()
+		_ = os.Remove(tempPath)
 		return nil, err
 	}
 	return file, nil
 }
 
 func writePrivateRunOutputFile(path string, data []byte) error {
-	file, err := openPrivateRunOutputFile(path)
+	file, tempPath, err := createPrivateRunOutputTemp(path)
 	if err != nil {
 		return err
 	}
-	if _, err := io.Copy(file, bytes.NewReader(data)); err != nil {
+	cleanup := func() {
 		_ = file.Close()
+		_ = os.Remove(tempPath)
+	}
+	if _, err := io.Copy(file, bytes.NewReader(data)); err != nil {
+		cleanup()
 		return err
 	}
-	return file.Close()
+	if err := file.Close(); err != nil {
+		_ = os.Remove(tempPath)
+		return err
+	}
+	if err := replacePrivateRunOutputTemp(tempPath, path); err != nil {
+		_ = os.Remove(tempPath)
+		return err
+	}
+	return nil
+}
+
+func createPrivateRunOutputTemp(path string) (*os.File, string, error) {
+	security, user, err := privateWindowsSecurityAttributes(false)
+	if err != nil {
+		return nil, "", err
+	}
+	dir := filepath.Dir(path)
+	base := filepath.Base(path)
+	for attempt := 0; attempt < privateRunOutputTempAttempts; attempt++ {
+		token, err := randomHex(12)
+		if err != nil {
+			return nil, "", err
+		}
+		tempPath := filepath.Join(dir, "."+base+".crabbox-"+token)
+		tempPathPtr, err := windows.UTF16PtrFromString(tempPath)
+		if err != nil {
+			return nil, "", err
+		}
+		handle, err := windows.CreateFile(
+			tempPathPtr,
+			windows.GENERIC_WRITE|windows.FILE_READ_ATTRIBUTES|windows.READ_CONTROL,
+			windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+			security,
+			windows.CREATE_NEW,
+			windows.FILE_ATTRIBUTE_NORMAL,
+			0,
+		)
+		if err != nil {
+			if err == windows.ERROR_FILE_EXISTS || err == windows.ERROR_ALREADY_EXISTS {
+				continue
+			}
+			return nil, "", err
+		}
+		if err := verifyPrivateWindowsHandle(handle, false, user); err != nil {
+			_ = windows.CloseHandle(handle)
+			_ = os.Remove(tempPath)
+			return nil, "", err
+		}
+		file := os.NewFile(uintptr(handle), tempPath)
+		if file == nil {
+			_ = windows.CloseHandle(handle)
+			_ = os.Remove(tempPath)
+			return nil, "", fmt.Errorf("create private output file handle")
+		}
+		return file, tempPath, nil
+	}
+	return nil, "", fmt.Errorf("allocate private output temporary file")
+}
+
+func securePrivateFile(file *os.File) error {
+	if file == nil {
+		return fmt.Errorf("private output file handle is unavailable")
+	}
+	handle, err := reOpenPrivateWindowsHandle(windows.Handle(file.Fd()), windows.FILE_READ_ATTRIBUTES|windows.READ_CONTROL|windows.WRITE_DAC, false)
+	if err != nil {
+		return err
+	}
+	defer windows.CloseHandle(handle)
+	return securePrivateWindowsHandle(handle, false)
+}
+
+func openExistingPrivateRunOutputFile(path string) (*os.File, error) {
+	pathPtr, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return nil, err
+	}
+	handle, err := windows.CreateFile(
+		pathPtr,
+		windows.GENERIC_READ|windows.READ_CONTROL|windows.WRITE_DAC,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_FLAG_OPEN_REPARSE_POINT,
+		0,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := securePrivateWindowsHandle(handle, false); err != nil {
+		_ = windows.CloseHandle(handle)
+		return nil, err
+	}
+	file := os.NewFile(uintptr(handle), path)
+	if file == nil {
+		_ = windows.CloseHandle(handle)
+		return nil, fmt.Errorf("open private output file handle")
+	}
+	return file, nil
+}
+
+func securePrivateWindowsPath(path string, directory bool) error {
+	handle, err := openPrivateWindowsSecurityHandle(path, directory, windows.READ_CONTROL|windows.WRITE_DAC)
+	if err != nil {
+		return err
+	}
+	defer windows.CloseHandle(handle)
+	return securePrivateWindowsHandle(handle, directory)
+}
+
+func verifyPrivateWindowsPath(path string, directory bool) error {
+	handle, err := openPrivateWindowsSecurityHandle(path, directory, windows.READ_CONTROL)
+	if err != nil {
+		return err
+	}
+	defer windows.CloseHandle(handle)
+	user, err := currentWindowsUserSID()
+	if err != nil {
+		return err
+	}
+	return verifyPrivateWindowsHandle(handle, directory, user)
+}
+
+func openPrivateWindowsSecurityHandle(path string, directory bool, access uint32) (windows.Handle, error) {
+	pathPtr, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return windows.InvalidHandle, err
+	}
+	flags := uint32(windows.FILE_FLAG_OPEN_REPARSE_POINT)
+	if directory {
+		flags |= windows.FILE_FLAG_BACKUP_SEMANTICS
+	}
+	handle, err := windows.CreateFile(
+		pathPtr,
+		access|windows.FILE_READ_ATTRIBUTES,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		nil,
+		windows.OPEN_EXISTING,
+		flags,
+		0,
+	)
+	if err != nil {
+		return windows.InvalidHandle, err
+	}
+	return handle, nil
+}
+
+func securePrivateWindowsHandle(handle windows.Handle, directory bool) error {
+	if err := validatePrivateWindowsFileType(handle, directory); err != nil {
+		return err
+	}
+	user, err := currentWindowsUserSID()
+	if err != nil {
+		return err
+	}
+	acl, err := privateWindowsACL(user, directory)
+	if err != nil {
+		return fmt.Errorf("build private Windows access-control list: %w", err)
+	}
+	descriptor, err := windows.GetSecurityInfo(handle, windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION)
+	if err != nil {
+		return fmt.Errorf("inspect private Windows output owner: %w", err)
+	}
+	owner, _, err := descriptor.Owner()
+	if err != nil {
+		return fmt.Errorf("read private Windows output owner: %w", err)
+	}
+	securityInformation := windows.SECURITY_INFORMATION(windows.DACL_SECURITY_INFORMATION | windows.PROTECTED_DACL_SECURITY_INFORMATION)
+	var newOwner *windows.SID
+	securityHandle := handle
+	closeSecurityHandle := false
+	if owner == nil || !owner.Equals(user) {
+		securityInformation |= windows.OWNER_SECURITY_INFORMATION
+		newOwner = user
+		securityHandle, err = reOpenPrivateWindowsHandle(handle, windows.FILE_READ_ATTRIBUTES|windows.READ_CONTROL|windows.WRITE_DAC|windows.WRITE_OWNER, directory)
+		if err != nil {
+			return err
+		}
+		closeSecurityHandle = true
+	}
+	if closeSecurityHandle {
+		defer windows.CloseHandle(securityHandle)
+	}
+	if err := windows.SetSecurityInfo(
+		securityHandle,
+		windows.SE_FILE_OBJECT,
+		securityInformation,
+		newOwner,
+		nil,
+		acl,
+		nil,
+	); err != nil {
+		return fmt.Errorf("apply private Windows access-control list: %w", err)
+	}
+	return verifyPrivateWindowsHandle(securityHandle, directory, user)
+}
+
+func verifyPrivateWindowsHandle(handle windows.Handle, directory bool, currentUser *windows.SID) error {
+	if err := validatePrivateWindowsFileType(handle, directory); err != nil {
+		return err
+	}
+	descriptor, err := windows.GetSecurityInfo(
+		handle,
+		windows.SE_FILE_OBJECT,
+		windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION,
+	)
+	if err != nil {
+		return fmt.Errorf("inspect private Windows access-control list: %w", err)
+	}
+	return validateCurrentUserPrivateWindowsDescriptor(descriptor, currentUser)
+}
+
+func validatePrivateWindowsFileType(handle windows.Handle, directory bool) error {
+	var info windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(handle, &info); err != nil {
+		return fmt.Errorf("inspect private Windows output: %w", err)
+	}
+	if info.FileAttributes&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+		return fmt.Errorf("private Windows output must not be a reparse point")
+	}
+	isDirectory := info.FileAttributes&windows.FILE_ATTRIBUTE_DIRECTORY != 0
+	if isDirectory != directory {
+		if directory {
+			return fmt.Errorf("private Windows output must be a directory")
+		}
+		return fmt.Errorf("private Windows output must be a regular file")
+	}
+	return nil
+}
+
+func currentWindowsUserSID() (*windows.SID, error) {
+	user, err := windows.GetCurrentProcessToken().GetTokenUser()
+	if err != nil {
+		return nil, fmt.Errorf("read current Windows user: %w", err)
+	}
+	if user == nil || user.User.Sid == nil {
+		return nil, fmt.Errorf("read current Windows user: missing SID")
+	}
+	return user.User.Sid, nil
+}
+
+func privateWindowsACL(user *windows.SID, directory bool) (*windows.ACL, error) {
+	var pinner runtime.Pinner
+	pinner.Pin(user)
+	defer pinner.Unpin()
+	inheritance := uint32(0)
+	if directory {
+		inheritance = windows.OBJECT_INHERIT_ACE | windows.CONTAINER_INHERIT_ACE
+	}
+	return windows.ACLFromEntries([]windows.EXPLICIT_ACCESS{{
+		AccessPermissions: windows.GENERIC_ALL,
+		AccessMode:        windows.GRANT_ACCESS,
+		Inheritance:       inheritance,
+		Trustee: windows.TRUSTEE{
+			TrusteeForm:  windows.TRUSTEE_IS_SID,
+			TrusteeType:  windows.TRUSTEE_IS_USER,
+			TrusteeValue: windows.TrusteeValueFromSID(user),
+		},
+	}}, nil)
+}
+
+func privateWindowsSecurityDescriptor(directory bool) (*windows.SECURITY_DESCRIPTOR, *windows.SID, error) {
+	user, err := currentWindowsUserSID()
+	if err != nil {
+		return nil, nil, err
+	}
+	inheritance := ""
+	if directory {
+		inheritance = "OICI"
+	}
+	descriptor, err := windows.SecurityDescriptorFromString("O:" + user.String() + "D:P(A;" + inheritance + ";GA;;;" + user.String() + ")")
+	if err != nil {
+		return nil, nil, fmt.Errorf("build private Windows security descriptor: %w", err)
+	}
+	return descriptor, user, nil
+}
+
+func privateWindowsSecurityAttributes(directory bool) (*windows.SecurityAttributes, *windows.SID, error) {
+	descriptor, user, err := privateWindowsSecurityDescriptor(directory)
+	if err != nil {
+		return nil, nil, err
+	}
+	attributes := &windows.SecurityAttributes{SecurityDescriptor: descriptor}
+	attributes.Length = uint32(unsafe.Sizeof(*attributes))
+	return attributes, user, nil
+}
+
+func createPrivateWindowsFileAt(parent windows.Handle, name string) (*os.File, error) {
+	descriptor, user, err := privateWindowsSecurityDescriptor(false)
+	if err != nil {
+		return nil, err
+	}
+	objectName, err := windows.NewNTUnicodeString(name)
+	if err != nil {
+		return nil, err
+	}
+	objectAttributes := &windows.OBJECT_ATTRIBUTES{
+		Length:             uint32(unsafe.Sizeof(windows.OBJECT_ATTRIBUTES{})),
+		RootDirectory:      parent,
+		ObjectName:         objectName,
+		Attributes:         windows.OBJ_CASE_INSENSITIVE | windows.OBJ_DONT_REPARSE,
+		SecurityDescriptor: descriptor,
+	}
+	var handle windows.Handle
+	err = windows.NtCreateFile(
+		&handle,
+		windows.GENERIC_WRITE|windows.FILE_READ_ATTRIBUTES|windows.READ_CONTROL|windows.SYNCHRONIZE,
+		objectAttributes,
+		&windows.IO_STATUS_BLOCK{},
+		nil,
+		windows.FILE_ATTRIBUTE_NORMAL,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		windows.FILE_CREATE,
+		windows.FILE_NON_DIRECTORY_FILE|windows.FILE_OPEN_REPARSE_POINT|windows.FILE_OPEN_FOR_BACKUP_INTENT|windows.FILE_SYNCHRONOUS_IO_NONALERT,
+		0,
+		0,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := verifyPrivateWindowsHandle(handle, false, user); err != nil {
+		_ = windows.CloseHandle(handle)
+		return nil, err
+	}
+	file := os.NewFile(uintptr(handle), name)
+	if file == nil {
+		_ = windows.CloseHandle(handle)
+		return nil, fmt.Errorf("create private Windows file handle")
+	}
+	return file, nil
+}
+
+func validateCurrentUserPrivateWindowsDescriptor(descriptor *windows.SECURITY_DESCRIPTOR, currentUser *windows.SID) error {
+	if descriptor == nil || currentUser == nil {
+		return fmt.Errorf("private Windows output must have a current-user security descriptor")
+	}
+	owner, _, err := descriptor.Owner()
+	if err != nil {
+		return fmt.Errorf("read private Windows output owner: %w", err)
+	}
+	if owner == nil || !owner.Equals(currentUser) {
+		return fmt.Errorf("private Windows output must be owned by the current user")
+	}
+	control, _, err := descriptor.Control()
+	if err != nil {
+		return fmt.Errorf("read private Windows output control flags: %w", err)
+	}
+	if control&windows.SE_DACL_PROTECTED == 0 {
+		return fmt.Errorf("private Windows output must have a protected access-control list")
+	}
+	dacl, _, err := descriptor.DACL()
+	if err != nil || dacl == nil || dacl.AceCount == 0 {
+		return fmt.Errorf("private Windows output must grant access only to the current user")
+	}
+	foundCurrentUserGrant := false
+	for index := uint16(0); index < dacl.AceCount; index++ {
+		var ace *windows.ACCESS_ALLOWED_ACE
+		if err := windows.GetAce(dacl, uint32(index), &ace); err != nil {
+			return fmt.Errorf("inspect private Windows access-control entry: %w", err)
+		}
+		if ace == nil || ace.Header.AceType != windows.ACCESS_ALLOWED_ACE_TYPE {
+			return fmt.Errorf("private Windows output contains an unsupported access-control entry")
+		}
+		if ace.Mask == 0 {
+			continue
+		}
+		sid := (*windows.SID)(unsafe.Pointer(&ace.SidStart))
+		if !sid.Equals(currentUser) {
+			return fmt.Errorf("private Windows output grants access to an unrelated principal")
+		}
+		foundCurrentUserGrant = true
+	}
+	if !foundCurrentUserGrant {
+		return fmt.Errorf("private Windows output must grant access to the current user")
+	}
+	return nil
+}
+
+func reOpenPrivateWindowsHandle(handle windows.Handle, access uint32, directory bool) (windows.Handle, error) {
+	flags := uint32(windows.FILE_FLAG_OPEN_REPARSE_POINT)
+	if directory {
+		flags |= windows.FILE_FLAG_BACKUP_SEMANTICS
+	}
+	result, _, callErr := reopenPrivateRunOutputFile.Call(
+		uintptr(handle),
+		uintptr(access),
+		uintptr(windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE),
+		uintptr(flags),
+	)
+	reopened := windows.Handle(result)
+	if reopened != windows.InvalidHandle {
+		return reopened, nil
+	}
+	if callErr != nil && callErr != syscall.Errno(0) {
+		return windows.InvalidHandle, fmt.Errorf("reopen private Windows output handle: %w", callErr)
+	}
+	return windows.InvalidHandle, fmt.Errorf("reopen private Windows output handle")
+}
+
+func replacePrivateRunOutputTemp(tempPath, path string) error {
+	tempPathPtr, err := windows.UTF16PtrFromString(tempPath)
+	if err != nil {
+		return err
+	}
+	pathPtr, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return err
+	}
+	const (
+		moveFileReplaceExisting = 0x1
+		moveFileWriteThrough    = 0x8
+	)
+	result, _, callErr := movePrivateRunOutputFileExW.Call(
+		uintptr(unsafe.Pointer(tempPathPtr)),
+		uintptr(unsafe.Pointer(pathPtr)),
+		uintptr(moveFileReplaceExisting|moveFileWriteThrough),
+	)
+	if result != 0 {
+		return nil
+	}
+	if callErr != nil && callErr != syscall.Errno(0) {
+		return callErr
+	}
+	return fmt.Errorf("replace private Windows output")
 }
 
 func checkPrivateRunOutputReplaceable(_, _ string) error {

--- a/internal/cli/run_local_output_windows_test.go
+++ b/internal/cli/run_local_output_windows_test.go
@@ -1,0 +1,266 @@
+//go:build windows
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestPrivateRunOutputWindowsDoesNotInheritPermissiveDACL(t *testing.T) {
+	parent := t.TempDir()
+	testSID := makeWindowsTestParentPermissive(t, parent)
+
+	path := filepath.Join(parent, "downloads", "proof.txt")
+	if err := writeRunDownloadFile(path, []byte("private proof")); err != nil {
+		t.Fatal(err)
+	}
+	assertWindowsPathPrivateFromSID(t, filepath.Dir(path), true, testSID)
+	assertWindowsPathPrivateFromSID(t, path, false, testSID)
+
+	if err := setWindowsPathPermissive(t, path, false, testSID); err != nil {
+		t.Fatal(err)
+	}
+	assertWindowsPathGrantsSID(t, path, testSID)
+	if err := writeRunDownloadFile(path, []byte("replacement proof")); err != nil {
+		t.Fatal(err)
+	}
+	assertWindowsPathPrivateFromSID(t, path, false, testSID)
+}
+
+func TestManagedAttestKeyWindowsRepairsPermissiveDACL(t *testing.T) {
+	setAttestTestHome(t)
+	path, err := attestKeyPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	configRoot := filepath.Dir(filepath.Dir(filepath.Dir(path)))
+	if err := os.MkdirAll(configRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	testSID := makeWindowsTestParentPermissive(t, configRoot)
+
+	first, err := ensureAttestKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertWindowsPathPrivateFromSID(t, filepath.Dir(filepath.Dir(path)), true, testSID)
+	assertWindowsPathPrivateFromSID(t, filepath.Dir(path), true, testSID)
+	assertWindowsPathPrivateFromSID(t, path, false, testSID)
+
+	if err := setWindowsPathPermissive(t, path, false, testSID); err != nil {
+		t.Fatal(err)
+	}
+	assertWindowsPathGrantsSID(t, path, testSID)
+	second, err := ensureAttestKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !first.Equal(second) {
+		t.Fatal("repair changed the managed attestation key")
+	}
+	assertWindowsPathPrivateFromSID(t, path, false, testSID)
+}
+
+func TestArtifactOutputWindowsPrivacyFollowsSignedURLs(t *testing.T) {
+	signedFile := artifactFile{
+		Kind:          "proof",
+		Name:          "proof.txt",
+		URL:           "https://bucket.s3.amazonaws.com/proof.txt?X-Amz-Signature=deadbeef&X-Amz-Expires=900",
+		snapshotValid: true,
+		snapshotHash:  strings.Repeat("a", 64),
+		snapshotSize:  1,
+	}
+	publicFile := artifactFile{
+		Kind:          "proof",
+		Name:          "proof.txt",
+		URL:           "https://artifacts.example.com/proof.txt",
+		snapshotValid: true,
+		snapshotHash:  strings.Repeat("b", 64),
+		snapshotSize:  1,
+	}
+
+	t.Run("private temporary is restricted at creation", func(t *testing.T) {
+		dir := t.TempDir()
+		testSID := makeWindowsTestParentPermissive(t, dir)
+		root, err := os.OpenRoot(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer root.Close()
+		file, err := openArtifactBundleTemp(root, ".private.crabbox-test", privateRunOutputFileMode, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer file.Close()
+		assertWindowsPathPrivateFromSID(t, filepath.Join(dir, ".private.crabbox-test"), false, testSID)
+	})
+
+	t.Run("signed manifest and summary", func(t *testing.T) {
+		dir := t.TempDir()
+		testSID := makeWindowsTestParentPermissive(t, dir)
+		root, err := os.OpenRoot(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer root.Close()
+
+		manifestPath := filepath.Join(dir, artifactManifestFilename)
+		if err := os.WriteFile(manifestPath, []byte("old"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := setWindowsPathPermissive(t, manifestPath, false, testSID); err != nil {
+			t.Fatal(err)
+		}
+		if _, _, err := writeArtifactManifest(root, artifactPublishOptions{
+			Directory: dir,
+			Storage:   "broker",
+		}, []artifactFile{signedFile}); err != nil {
+			t.Fatal(err)
+		}
+		assertWindowsPathPrivateFromSID(t, manifestPath, false, testSID)
+
+		summaryPath := filepath.Join(dir, "published-artifacts.md")
+		if err := writePrivateArtifactBundleFile(root, "published-artifacts.md", []byte("signed summary")); err != nil {
+			t.Fatal(err)
+		}
+		assertWindowsPathPrivateFromSID(t, summaryPath, false, testSID)
+
+		if err := setWindowsPathPermissive(t, summaryPath, false, testSID); err != nil {
+			t.Fatal(err)
+		}
+		if err := writePrivateArtifactBundleFile(root, "published-artifacts.md", []byte("republished signed summary")); err != nil {
+			t.Fatal(err)
+		}
+		assertWindowsPathPrivateFromSID(t, summaryPath, false, testSID)
+	})
+
+	t.Run("public manifest and summary stay shareable", func(t *testing.T) {
+		dir := t.TempDir()
+		testSID := makeWindowsTestParentPermissive(t, dir)
+		root, err := os.OpenRoot(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer root.Close()
+
+		if _, _, err := writeArtifactManifest(root, artifactPublishOptions{
+			Directory: dir,
+			Storage:   "local",
+		}, []artifactFile{publicFile}); err != nil {
+			t.Fatal(err)
+		}
+		assertWindowsPathGrantsSID(t, filepath.Join(dir, artifactManifestFilename), testSID)
+
+		if err := writeArtifactBundleFile(root, "published-artifacts.md", []byte("public summary"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		assertWindowsPathGrantsSID(t, filepath.Join(dir, "published-artifacts.md"), testSID)
+	})
+}
+
+func makeWindowsTestParentPermissive(t *testing.T, path string) *windows.SID {
+	t.Helper()
+	testSID, err := windows.CreateWellKnownSid(windows.WinWorldSid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := setWindowsPathPermissive(t, path, true, testSID); err != nil {
+		t.Fatal(err)
+	}
+	return testSID
+}
+
+func setWindowsPathPermissive(t *testing.T, path string, directory bool, testSID *windows.SID) error {
+	t.Helper()
+	user, err := currentWindowsUserSID()
+	if err != nil {
+		return err
+	}
+	var pinner runtime.Pinner
+	pinner.Pin(user)
+	pinner.Pin(testSID)
+	defer pinner.Unpin()
+	inheritance := uint32(0)
+	if directory {
+		inheritance = windows.OBJECT_INHERIT_ACE | windows.CONTAINER_INHERIT_ACE
+	}
+	entries := []windows.EXPLICIT_ACCESS{
+		windowsTestAccessEntry(user, inheritance),
+		windowsTestAccessEntry(testSID, inheritance),
+	}
+	acl, err := windows.ACLFromEntries(entries, nil)
+	if err != nil {
+		return err
+	}
+	return windows.SetNamedSecurityInfo(
+		path,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION,
+		nil,
+		nil,
+		acl,
+		nil,
+	)
+}
+
+func windowsTestAccessEntry(sid *windows.SID, inheritance uint32) windows.EXPLICIT_ACCESS {
+	return windows.EXPLICIT_ACCESS{
+		AccessPermissions: windows.GENERIC_ALL,
+		AccessMode:        windows.GRANT_ACCESS,
+		Inheritance:       inheritance,
+		Trustee: windows.TRUSTEE{
+			TrusteeForm:  windows.TRUSTEE_IS_SID,
+			TrusteeValue: windows.TrusteeValueFromSID(sid),
+		},
+	}
+}
+
+func assertWindowsPathPrivateFromSID(t *testing.T, path string, directory bool, testSID *windows.SID) {
+	t.Helper()
+	if err := verifyPrivateWindowsPath(path, directory); err != nil {
+		t.Fatalf("%s is not current-user private: %v", path, err)
+	}
+	if windowsPathGrantsSID(t, path, testSID) {
+		t.Fatalf("%s grants access to test principal %s", path, testSID.String())
+	}
+}
+
+func assertWindowsPathGrantsSID(t *testing.T, path string, sid *windows.SID) {
+	t.Helper()
+	if !windowsPathGrantsSID(t, path, sid) {
+		t.Fatalf("%s does not retain the shareable grant for test principal %s", path, sid.String())
+	}
+}
+
+func windowsPathGrantsSID(t *testing.T, path string, want *windows.SID) bool {
+	t.Helper()
+	descriptor, err := windows.GetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dacl, _, err := descriptor.DACL()
+	if err != nil || dacl == nil {
+		t.Fatalf("read DACL for %s: %v", path, err)
+	}
+	for index := uint16(0); index < dacl.AceCount; index++ {
+		var ace *windows.ACCESS_ALLOWED_ACE
+		if err := windows.GetAce(dacl, uint32(index), &ace); err != nil {
+			t.Fatal(err)
+		}
+		if ace == nil || ace.Header.AceType != windows.ACCESS_ALLOWED_ACE_TYPE || ace.Mask == 0 {
+			continue
+		}
+		sid := (*windows.SID)(unsafe.Pointer(&ace.SidStart))
+		if sid.Equals(want) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/ssh_transport_permissions_windows.go
+++ b/internal/cli/ssh_transport_permissions_windows.go
@@ -2,72 +2,10 @@
 
 package cli
 
-import (
-	"fmt"
-
-	"golang.org/x/sys/windows"
-)
-
 func secureSSHTransportPath(path string, directory bool) error {
-	user, err := windows.GetCurrentProcessToken().GetTokenUser()
-	if err != nil {
-		return fmt.Errorf("read current Windows user: %w", err)
-	}
-	if user == nil || user.User.Sid == nil {
-		return fmt.Errorf("read current Windows user: missing SID")
-	}
-	inheritance := uint32(0)
-	if directory {
-		inheritance = windows.OBJECT_INHERIT_ACE | windows.CONTAINER_INHERIT_ACE
-	}
-	acl, err := windows.ACLFromEntries([]windows.EXPLICIT_ACCESS{{
-		AccessPermissions: windows.GENERIC_ALL,
-		AccessMode:        windows.GRANT_ACCESS,
-		Inheritance:       inheritance,
-		Trustee: windows.TRUSTEE{
-			TrusteeForm:  windows.TRUSTEE_IS_SID,
-			TrusteeValue: windows.TrusteeValueFromSID(user.User.Sid),
-		},
-	}}, nil)
-	if err != nil {
-		return fmt.Errorf("build private Windows access-control list: %w", err)
-	}
-	if err := windows.SetNamedSecurityInfo(
-		path,
-		windows.SE_FILE_OBJECT,
-		windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION,
-		user.User.Sid,
-		nil,
-		acl,
-		nil,
-	); err != nil {
-		return fmt.Errorf("apply private Windows access-control list: %w", err)
-	}
-	return verifySSHTransportPathPrivate(path, directory)
+	return securePrivateWindowsPath(path, directory)
 }
 
-func verifySSHTransportPathPrivate(path string, _ bool) error {
-	descriptor, err := windows.GetNamedSecurityInfo(
-		path,
-		windows.SE_FILE_OBJECT,
-		windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION,
-	)
-	if err != nil {
-		return fmt.Errorf("inspect private Windows access-control list: %w", err)
-	}
-	user, err := windows.GetCurrentProcessToken().GetTokenUser()
-	if err != nil {
-		return fmt.Errorf("read current Windows user: %w", err)
-	}
-	if user == nil || user.User.Sid == nil {
-		return fmt.Errorf("read current Windows user: missing SID")
-	}
-	owner, _, err := descriptor.Owner()
-	if err != nil || owner == nil || !owner.Equals(user.User.Sid) {
-		return fmt.Errorf("private Windows path must be owned by the current user")
-	}
-	if err := validateExternalRoutingWindowsPrivateDACL(descriptor, user.User.Sid); err != nil {
-		return fmt.Errorf("private Windows path: %w", err)
-	}
-	return nil
+func verifySSHTransportPathPrivate(path string, directory bool) error {
+	return verifyPrivateWindowsPath(path, directory)
 }

--- a/internal/cli/webvnc_bootstrap_file_windows.go
+++ b/internal/cli/webvnc_bootstrap_file_windows.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"unsafe"
 
 	"golang.org/x/sys/windows"
 )
@@ -15,7 +14,11 @@ import (
 const webVNCPortalBootstrapTempAttempts = 32
 
 func createWebVNCPortalBootstrapFile() (string, string, *os.File, error) {
-	security, userSID, err := webVNCPortalBootstrapSecurity()
+	directorySecurity, userSID, err := privateWindowsSecurityAttributes(true)
+	if err != nil {
+		return "", "", nil, err
+	}
+	fileSecurity, _, err := privateWindowsSecurityAttributes(false)
 	if err != nil {
 		return "", "", nil, err
 	}
@@ -29,7 +32,7 @@ func createWebVNCPortalBootstrapFile() (string, string, *os.File, error) {
 		if err != nil {
 			return "", "", nil, err
 		}
-		if err := windows.CreateDirectory(dirUTF16, security); err != nil {
+		if err := windows.CreateDirectory(dirUTF16, directorySecurity); err != nil {
 			if errors.Is(err, windows.ERROR_ALREADY_EXISTS) || errors.Is(err, windows.ERROR_FILE_EXISTS) {
 				continue
 			}
@@ -53,7 +56,7 @@ func createWebVNCPortalBootstrapFile() (string, string, *os.File, error) {
 			pathUTF16,
 			windows.GENERIC_WRITE|windows.READ_CONTROL,
 			windows.FILE_SHARE_READ,
-			security,
+			fileSecurity,
 			windows.CREATE_NEW,
 			windows.FILE_ATTRIBUTE_TEMPORARY,
 			0,
@@ -78,24 +81,6 @@ func createWebVNCPortalBootstrapFile() (string, string, *os.File, error) {
 	return "", "", nil, fmt.Errorf("allocate private WebVNC bootstrap directory")
 }
 
-func webVNCPortalBootstrapSecurity() (*windows.SecurityAttributes, *windows.SID, error) {
-	user, err := windows.GetCurrentProcessToken().GetTokenUser()
-	if err != nil {
-		return nil, nil, err
-	}
-	if user == nil || user.User.Sid == nil {
-		return nil, nil, fmt.Errorf("current Windows user SID is unavailable")
-	}
-	sid := user.User.Sid.String()
-	sd, err := windows.SecurityDescriptorFromString("O:" + sid + "D:P(A;;GA;;;" + sid + ")")
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := &windows.SecurityAttributes{SecurityDescriptor: sd}
-	attributes.Length = uint32(unsafe.Sizeof(*attributes))
-	return attributes, user.User.Sid, nil
-}
-
 func validateWebVNCPortalBootstrapWindowsPath(path string, currentUser *windows.SID) error {
 	descriptor, err := windows.GetNamedSecurityInfo(
 		path,
@@ -105,19 +90,5 @@ func validateWebVNCPortalBootstrapWindowsPath(path string, currentUser *windows.
 	if err != nil {
 		return err
 	}
-	owner, _, err := descriptor.Owner()
-	if err != nil {
-		return err
-	}
-	if owner == nil || currentUser == nil || !owner.Equals(currentUser) {
-		return fmt.Errorf("must be owned by the current user")
-	}
-	control, _, err := descriptor.Control()
-	if err != nil {
-		return err
-	}
-	if control&windows.SE_DACL_PROTECTED == 0 {
-		return fmt.Errorf("must have a protected access-control list")
-	}
-	return validateExternalRoutingWindowsPrivateDACL(descriptor, currentUser)
+	return validateCurrentUserPrivateWindowsDescriptor(descriptor, currentUser)
 }


### PR DESCRIPTION
Closes https://github.com/openclaw/crabbox/issues/1304.
Closes https://github.com/openclaw/crabbox/issues/1240.

## Summary

Sensitive generated files were not governed by one cross-platform privacy boundary. Artifact manifests and publication summaries could contain signed URLs, run captures could contain command output, and managed attestation keys are credentials, but individual writers relied on POSIX mode literals or inherited filesystem behavior. That left wider existing modes intact, did not remove inherited macOS ACLs, and did not provide an equivalent protected-DACL contract on Windows.

This change introduces one shared private-output path for those generated files:

- POSIX files are created or replaced as `0600` and verified after writing.
- macOS additionally removes inherited extended ACLs before accepting the file as private.
- Windows creates files with a protected, current-user-owned DACL, validates owner and access entries through the file handle, rejects reparse points, and uses handle-relative creation beneath `os.Root` where required.
- Existing Crabbox-managed attestation keys are tightened before use. User-supplied `--attest-key` files are never modified.
- Artifact manifests and Markdown summaries use the private writer only when they contain signed-URL bearer capabilities. Public/local artifact output retains its intended shareability.
- Republishing sensitive output cannot restore a broad POSIX mode or Windows DACL.

The shared primitive also replaces duplicated per-feature permission logic, so future sensitive generated output has one ownership boundary rather than another platform-specific mode check.

## Verification

Local and cross-platform proof:

- focused `internal/cli` regression tests passed
- `go vet ./...` passed
- Windows and Linux test cross-builds passed
- focused affected race suites passed before the final rebase
- structured branch security review passed with no actionable findings after explicitly adding `FILE_READ_ATTRIBUTES` to handles that are subsequently validated

Native Windows proof ran these exact tests successfully:

- `TestPrivateRunOutputWindowsDoesNotInheritPermissiveDACL`
- `TestManagedAttestKeyWindowsRepairsPermissiveDACL`
- `TestArtifactOutputWindowsPrivacyFollowsSignedURLs`

The native proof confirmed private temporary creation, repair of permissive managed-key DACLs, private signed-URL manifests/summaries, and shareable public manifests/summaries. Crabbox workspace-owner acquisition on the clean Windows lease twice stopped earlier with `ambiguous remote state`; to isolate that unrelated wrapper state, the already cross-built focused test executable was uploaded and executed through the owned direct SSH transport. It passed, the executable was removed, and the lease was released.

## Compatibility

Public artifact bundles remain public. The privacy change is conditional on sensitive content or an explicitly private output surface, and existing user-supplied attestation-key permissions remain under user control.
