### PR TITLE
fix(worker): bind the declared artifact sha256 into the signed upload grant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Made GitHub team authorization fail closed on malformed selectors, enforced same-org team scope, and invalidated membership and device proofs when the normalized policy changes. Thanks @dwin-gharibi.
 - Rejected invalid or overlong coordinator-requested lease slugs before provisioning while preserving exact fixed-ID replays created under the legacy length behavior. Thanks @dwin-gharibi.
+- Bound valid caller-declared artifact SHA-256 digests into signed broker upload grants, rejected malformed nonblank digests instead of silently disabling integrity checks, and made object storage reject mismatching payloads. Thanks @dwin-gharibi.
 
 ## 0.41.5 - 2026-08-12
 

--- a/docs/commands/artifacts.md
+++ b/docs/commands/artifacts.md
@@ -243,11 +243,16 @@ For brokered publishing, the CLI never receives object-store credentials. It
 sends artifact names, sizes, content types, and hashes to
 `POST /v1/artifacts/uploads`; the coordinator returns one short-lived upload URL
 per file plus the final URL to place in Markdown. Upload grants are signed with
-the declared `content-length`, so the object store rejects oversized PUTs during
-the grant window, and the broker caps each upload request at 5 GiB total before
-signing grants. When `--prefix` is omitted for hosted publishing, the CLI
-derives a unique prefix from the PR number, bundle directory, and current time
-so later QA comments do not overwrite earlier evidence.
+the declared `content-length` and, when supplied, the file's `sha256` as a
+base64 `x-amz-checksum-sha256`, so the object store rejects bodies whose size or
+contents do not match the grant. The `sha256` field may be omitted or blank; a
+nonblank value must be exactly 64 hexadecimal characters, with uppercase input
+normalized to lowercase. Malformed values receive the route's standard 400
+response instead of minting a grant without checksum enforcement. The broker
+caps each upload request at 5 GiB total before signing grants. When `--prefix`
+is omitted for hosted publishing, the CLI derives a unique prefix from the PR
+number, bundle directory, and current time so later QA comments do not overwrite
+earlier evidence.
 
 The coordinator scopes each new grant under versioned base64url encodings of
 the exact authenticated organization and owner. These values are reversible,

--- a/docs/features/artifacts.md
+++ b/docs/features/artifacts.md
@@ -236,7 +236,10 @@ by request metadata — the CLI verifies the file size still matches the grant
 before uploading. When the caller declares a `sha256` for a file, the grant also
 carries a signed `x-amz-checksum-sha256`, so the storage backend rejects a body
 whose contents do not match the declared digest — integrity is enforced by the
-store, not merely asserted in the request. The broker enforces a 1 GiB per-file cap and a 5 GiB
+store, not merely asserted in the request. Omitted or blank digests remain
+optional, while every nonblank digest must contain exactly 64 hexadecimal
+characters; malformed declarations are rejected rather than silently losing
+integrity enforcement. The broker enforces a 1 GiB per-file cap and a 5 GiB
 per-request aggregate cap before minting upload URLs. When you do not pass
 `--prefix`, hosted publishing adds a unique PR/bundle/timestamp prefix so later
 bundles cannot overwrite links from earlier QA comments.

--- a/docs/features/artifacts.md
+++ b/docs/features/artifacts.md
@@ -233,7 +233,10 @@ need normal Crabbox coordinator auth; the coordinator holds the storage keys and
 signs one upload request per artifact. Each upload grant carries a signed
 `content-length`, so the size cap is enforced by the storage backend, not just
 by request metadata — the CLI verifies the file size still matches the grant
-before uploading. The broker enforces a 1 GiB per-file cap and a 5 GiB
+before uploading. When the caller declares a `sha256` for a file, the grant also
+carries a signed `x-amz-checksum-sha256`, so the storage backend rejects a body
+whose contents do not match the declared digest — integrity is enforced by the
+store, not merely asserted in the request. The broker enforces a 1 GiB per-file cap and a 5 GiB
 per-request aggregate cap before minting upload URLs. When you do not pass
 `--prefix`, hosted publishing adds a unique PR/bundle/timestamp prefix so later
 bundles cannot overwrite links from earlier QA comments.

--- a/internal/cli/artifacts_test.go
+++ b/internal/cli/artifacts_test.go
@@ -1694,6 +1694,7 @@ func TestPublishArtifactFilesBrokerUploadsViaGrantedURL(t *testing.T) {
 	}
 	defer cleanup()
 	wantHash := fmt.Sprintf("%x", sha256.Sum256([]byte("png-data")))
+	wantChecksumHeader := "cGluLWRhdGEtY2hlY2tzdW0="
 	var uploaded string
 	var server *httptest.Server
 	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1715,10 +1716,10 @@ func TestPublishArtifactFilesBrokerUploadsViaGrantedURL(t *testing.T) {
 				"files":[{
 					"name":"screenshot.png",
 					"key":"runs/abc/screenshot.png",
-					"upload":{"method":"PUT","url":%q,"headers":{"content-type":"image/png","content-length":"8"},"expiresAt":"2026-05-08T00:00:00Z"},
+					"upload":{"method":"PUT","url":%q,"headers":{"content-type":"image/png","content-length":"8","x-amz-checksum-sha256":%q},"expiresAt":"2026-05-08T00:00:00Z"},
 					"url":"https://artifacts.example.com/runs/abc/screenshot.png"
 				}]
-			}`, server.URL+"/upload/screenshot.png")
+			}`, server.URL+"/upload/screenshot.png", wantChecksumHeader)
 		case "/upload/screenshot.png":
 			if r.Method != http.MethodPut {
 				t.Fatalf("method=%s", r.Method)
@@ -1728,6 +1729,9 @@ func TestPublishArtifactFilesBrokerUploadsViaGrantedURL(t *testing.T) {
 			}
 			if len(r.TransferEncoding) > 0 {
 				t.Fatalf("transfer encoding=%v", r.TransferEncoding)
+			}
+			if got := r.Header.Get("x-amz-checksum-sha256"); got != wantChecksumHeader {
+				t.Fatalf("checksum header=%q, want %q", got, wantChecksumHeader)
 			}
 			data, _ := io.ReadAll(r.Body)
 			uploaded = string(data)

--- a/worker/src/artifacts.ts
+++ b/worker/src/artifacts.ts
@@ -263,8 +263,20 @@ function artifactObjectKey(prefix: string, name: string): string {
 function artifactUploadHeaders(file: Required<ArtifactUploadFile>): Record<string, string> {
   return {
     ...(file.contentType ? { "content-type": file.contentType } : {}),
+    // Signed alongside content-length so the store rejects a body that does not match the
+    // declared digest. Without this the caller-supplied sha256 would assure nothing.
+    ...(file.sha256 ? { "x-amz-checksum-sha256": base64FromHex(file.sha256) } : {}),
     "content-length": String(file.size),
   };
+}
+
+/** normalizeHash guarantees 64 lowercase hex characters, so this always yields 32 bytes. */
+function base64FromHex(value: string): string {
+  let binary = "";
+  for (let index = 0; index < value.length; index += 2) {
+    binary += String.fromCharCode(Number.parseInt(value.slice(index, index + 2), 16));
+  }
+  return btoa(binary);
 }
 
 async function artifactReadURL(config: ArtifactConfig, key: string): Promise<string> {

--- a/worker/src/artifacts.ts
+++ b/worker/src/artifacts.ts
@@ -186,7 +186,7 @@ function normalizeArtifactFiles(files: ArtifactUploadFile[]): Required<ArtifactU
       name,
       size,
       contentType: normalizeContentType(file.contentType),
-      sha256: normalizeHash(file.sha256),
+      sha256: normalizeHash(file.sha256, name),
     };
   });
   if (totalSize > maxArtifactBatchBytes) {
@@ -208,9 +208,14 @@ function normalizeContentType(value: string | undefined): string {
   return trimmed(value).slice(0, 200);
 }
 
-function normalizeHash(value: string | undefined): string {
-  const hash = trimmed(value).toLowerCase();
-  return /^[a-f0-9]{64}$/.test(hash) ? hash : "";
+function normalizeHash(value: string | undefined, name: string): string {
+  if (value === undefined || (typeof value === "string" && !value.trim())) {
+    return "";
+  }
+  if (typeof value !== "string" || !/^[a-fA-F0-9]{64}$/.test(value)) {
+    throw new Error(`invalid artifact sha256 for ${name}`);
+  }
+  return value.toLowerCase();
 }
 
 function artifactPrefix(

--- a/worker/test/artifacts.live.test.ts
+++ b/worker/test/artifacts.live.test.ts
@@ -2,6 +2,7 @@ import { AwsClient } from "aws4fetch";
 import { describe, expect, it } from "vitest";
 
 import { artifactUploadResponse } from "../src/artifacts";
+import { sha256Hex } from "../src/auth";
 import type { Env } from "../src/types";
 
 const liveAccessKeyID = process.env.CRABBOX_ARTIFACTS_ACCESS_KEY_ID;
@@ -15,9 +16,15 @@ const liveConfigured =
 
 describe("artifact broker live", () => {
   it.skipIf(!liveConfigured)(
-    "live: signs private R2 reads and leaves no object residue",
+    "live: R2 enforces signed checksums and leaves no rejected object residue",
     async () => {
-      const body = new TextEncoder().encode(`crabbox-artifact-live-${crypto.randomUUID()}\n`);
+      const nonce = crypto.randomUUID();
+      const matchingText = `crabbox-artifact-live-${nonce}-match\n`;
+      const mismatchingText = `crabbox-artifact-live-${nonce}-wrong\n`;
+      const matchingBody = new TextEncoder().encode(matchingText);
+      const mismatchingBody = new TextEncoder().encode(mismatchingText);
+      expect(mismatchingBody.byteLength).toBe(matchingBody.byteLength);
+      const declaredSHA256 = await sha256Hex(matchingText);
       const env = {
         CRABBOX_ARTIFACTS_BACKEND: "r2",
         CRABBOX_ARTIFACTS_BUCKET: liveBucket,
@@ -29,18 +36,24 @@ describe("artifact broker live", () => {
         CRABBOX_ARTIFACTS_SECRET_ACCESS_KEY: liveSecretAccessKey,
         CRABBOX_ARTIFACTS_SESSION_TOKEN: liveSessionToken,
       } as Env;
+      const prefix = crypto.randomUUID();
       const response = await artifactUploadResponse(
         env,
         {
-          prefix: crypto.randomUUID(),
-          files: [{ name: "proof.txt", size: body.byteLength, contentType: "text/plain" }],
+          prefix: `${prefix}/matching`,
+          files: [
+            {
+              name: "proof.txt",
+              size: matchingBody.byteLength,
+              contentType: "text/plain",
+              sha256: declaredSHA256,
+            },
+          ],
         },
         { org: "example-org", owner: "alice@example.com" },
       );
       const grant = response.files[0]!;
       const readURL = new URL(grant.url);
-      const objectURL = new URL(readURL);
-      objectURL.search = "";
 
       expect(response.accessPolicy).toBe("signed-url");
       expect(grant.accessPolicy).toBe("signed-url");
@@ -55,20 +68,58 @@ describe("artifact broker live", () => {
         region: "auto",
         retries: 0,
       });
+      const cleanupURLs: URL[] = [];
+      const matchingObjectURL = new URL(readURL);
+      matchingObjectURL.search = "";
+      cleanupURLs.push(matchingObjectURL);
       try {
         const upload = await fetch(grant.upload.url, {
           method: grant.upload.method,
           headers: grant.upload.headers,
-          body,
+          body: matchingBody,
         });
         expect(upload.ok).toBe(true);
 
         const download = await fetch(grant.url);
         expect(download.ok).toBe(true);
-        expect(new Uint8Array(await download.arrayBuffer())).toEqual(body);
+        expect(new Uint8Array(await download.arrayBuffer())).toEqual(matchingBody);
+
+        const mismatchResponse = await artifactUploadResponse(
+          env,
+          {
+            prefix: `${prefix}/mismatch`,
+            files: [
+              {
+                name: "proof.txt",
+                size: mismatchingBody.byteLength,
+                contentType: "text/plain",
+                sha256: declaredSHA256,
+              },
+            ],
+          },
+          { org: "example-org", owner: "alice@example.com" },
+        );
+        const mismatchGrant = mismatchResponse.files[0]!;
+        const mismatchObjectURL = new URL(mismatchGrant.url);
+        mismatchObjectURL.search = "";
+        cleanupURLs.push(mismatchObjectURL);
+
+        const mismatchUpload = await fetch(mismatchGrant.upload.url, {
+          method: mismatchGrant.upload.method,
+          headers: mismatchGrant.upload.headers,
+          body: mismatchingBody,
+        });
+        expect(mismatchUpload.status).toBe(400);
+
+        const rejectedObject = await fetch(mismatchGrant.url);
+        expect(rejectedObject.status).toBe(404);
       } finally {
-        const cleanup = await client.fetch(objectURL, { method: "DELETE" });
-        expect(cleanup.ok).toBe(true);
+        const cleanups = await Promise.all(
+          cleanupURLs.map((objectURL) => client.fetch(objectURL, { method: "DELETE" })),
+        );
+        for (const cleanup of cleanups) {
+          expect(cleanup.ok).toBe(true);
+        }
       }
 
       const missing = await fetch(grant.url);

--- a/worker/test/artifacts.test.ts
+++ b/worker/test/artifacts.test.ts
@@ -126,13 +126,13 @@ describe("artifact broker namespaces", () => {
     expect(grant.upload.url.toLowerCase()).toContain("x-amz-checksum-sha256");
   });
 
-  it("omits the checksum header when no usable digest is declared", async () => {
+  it("omits the checksum header when the digest is omitted or blank", async () => {
     const response = await artifactUploadResponse(
       artifactEnv(),
       {
         files: [
           { name: "result.txt", size: 1 },
-          { name: "other.txt", size: 1, sha256: "not-a-digest" },
+          { name: "other.txt", size: 1, sha256: " \t " },
         ],
       },
       { org: "example-org", owner: "alice" },
@@ -141,6 +141,16 @@ describe("artifact broker namespaces", () => {
     for (const grant of response.files) {
       expect(grant.upload.headers).not.toHaveProperty("x-amz-checksum-sha256");
     }
+  });
+
+  it("rejects a malformed nonblank digest", async () => {
+    await expect(
+      artifactUploadResponse(
+        artifactEnv(),
+        { files: [{ name: "result.txt", size: 1, sha256: "not-a-digest" }] },
+        { org: "example-org", owner: "alice" },
+      ),
+    ).rejects.toThrow("invalid artifact sha256 for result.txt");
   });
 });
 

--- a/worker/test/artifacts.test.ts
+++ b/worker/test/artifacts.test.ts
@@ -109,6 +109,39 @@ describe("artifact broker namespaces", () => {
       ),
     ).rejects.toThrow(`artifact upload ${label} identity is required`);
   });
+
+  it("binds a declared sha256 into the signed upload grant", async () => {
+    // sha256 of the empty string, so the expected base64 digest is verifiable by hand.
+    const sha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+    const response = await artifactUploadResponse(
+      artifactEnv(),
+      { files: [{ name: "result.txt", size: 0, sha256 }] },
+      { org: "example-org", owner: "alice" },
+    );
+
+    const grant = response.files[0]!;
+    expect(grant.upload.headers["x-amz-checksum-sha256"]).toBe(
+      "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",
+    );
+    expect(grant.upload.url.toLowerCase()).toContain("x-amz-checksum-sha256");
+  });
+
+  it("omits the checksum header when no usable digest is declared", async () => {
+    const response = await artifactUploadResponse(
+      artifactEnv(),
+      {
+        files: [
+          { name: "result.txt", size: 1 },
+          { name: "other.txt", size: 1, sha256: "not-a-digest" },
+        ],
+      },
+      { org: "example-org", owner: "alice" },
+    );
+
+    for (const grant of response.files) {
+      expect(grant.upload.headers).not.toHaveProperty("x-amz-checksum-sha256");
+    }
+  });
 });
 
 function artifactEnv(overrides: Partial<Env> = {}): Env {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -29254,11 +29254,112 @@ describe("fleet lease identity and idle", () => {
     expect(body.files[0].accessPolicy).toBe("public");
     expect(body.files[0].upload.headers["content-length"]).toBe("123");
     expect(body.files[0].upload.headers["content-type"]).toBe("image/png");
+    expect(body.files[0].upload.headers["x-amz-checksum-sha256"]).toBe(
+      "85WSOT7whZyxlqUmk9LOoA+y33hLPASuVKp8rbjlYvg=",
+    );
     expect(body.files[0].upload.url).toContain("X-Amz-Signature=");
     expect(new URL(body.files[0].upload.url).searchParams.get("X-Amz-SignedHeaders")).toContain(
       "content-length",
     );
+    expect(new URL(body.files[0].upload.url).searchParams.get("X-Amz-SignedHeaders")).toContain(
+      "x-amz-checksum-sha256",
+    );
     expect(JSON.stringify(body)).not.toContain("super-secret");
+  });
+
+  it.each([
+    { label: "an omitted digest", sha256: undefined },
+    { label: "a blank digest", sha256: " \t " },
+  ])("keeps artifact sha256 optional for $label", async ({ sha256 }) => {
+    const fleet = testFleet(
+      new MemoryStorage(),
+      {},
+      {
+        CRABBOX_ARTIFACTS_BACKEND: "r2",
+        CRABBOX_ARTIFACTS_BUCKET: "qa-artifacts",
+        CRABBOX_ARTIFACTS_ENDPOINT_URL: "https://account.r2.cloudflarestorage.com",
+        CRABBOX_ARTIFACTS_ACCESS_KEY_ID: "access-key",
+        CRABBOX_ARTIFACTS_SECRET_ACCESS_KEY: "super-secret",
+      },
+    );
+
+    const response = await fleet.fetch(
+      request("POST", "/v1/artifacts/uploads", {
+        headers: { "x-crabbox-owner": "alice@example.com" },
+        body: { files: [{ name: "result.txt", size: 0, sha256 }] },
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    const body = (await response.json()) as {
+      files: Array<{ upload: { headers: Record<string, string> } }>;
+    };
+    expect(body.files[0].upload.headers).not.toHaveProperty("x-amz-checksum-sha256");
+  });
+
+  it("normalizes an uppercase artifact sha256 before binding it to the upload grant", async () => {
+    const fleet = testFleet(
+      new MemoryStorage(),
+      {},
+      {
+        CRABBOX_ARTIFACTS_BACKEND: "r2",
+        CRABBOX_ARTIFACTS_BUCKET: "qa-artifacts",
+        CRABBOX_ARTIFACTS_ENDPOINT_URL: "https://account.r2.cloudflarestorage.com",
+        CRABBOX_ARTIFACTS_ACCESS_KEY_ID: "access-key",
+        CRABBOX_ARTIFACTS_SECRET_ACCESS_KEY: "super-secret",
+      },
+    );
+    const sha256 = "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855";
+
+    const response = await fleet.fetch(
+      request("POST", "/v1/artifacts/uploads", {
+        headers: { "x-crabbox-owner": "alice@example.com" },
+        body: { files: [{ name: "result.txt", size: 0, sha256 }] },
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    const body = (await response.json()) as {
+      files: Array<{ upload: { headers: Record<string, string>; url: string } }>;
+    };
+    expect(body.files[0].upload.headers["x-amz-checksum-sha256"]).toBe(
+      "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",
+    );
+    expect(new URL(body.files[0].upload.url).searchParams.get("X-Amz-SignedHeaders")).toContain(
+      "x-amz-checksum-sha256",
+    );
+  });
+
+  it.each([
+    { label: "too short", sha256: "a".repeat(63) },
+    { label: "too long", sha256: "a".repeat(65) },
+    { label: "non-hex", sha256: `${"a".repeat(63)}g` },
+    { label: "whitespace-padded", sha256: ` ${"a".repeat(64)} ` },
+  ])("returns the artifact route's normal 400 error for a $label sha256", async ({ sha256 }) => {
+    const fleet = testFleet(
+      new MemoryStorage(),
+      {},
+      {
+        CRABBOX_ARTIFACTS_BACKEND: "r2",
+        CRABBOX_ARTIFACTS_BUCKET: "qa-artifacts",
+        CRABBOX_ARTIFACTS_ENDPOINT_URL: "https://account.r2.cloudflarestorage.com",
+        CRABBOX_ARTIFACTS_ACCESS_KEY_ID: "access-key",
+        CRABBOX_ARTIFACTS_SECRET_ACCESS_KEY: "super-secret",
+      },
+    );
+
+    const response = await fleet.fetch(
+      request("POST", "/v1/artifacts/uploads", {
+        headers: { "x-crabbox-owner": "alice@example.com" },
+        body: { files: [{ name: "result.txt", size: 1, sha256 }] },
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "artifact_upload_unavailable",
+      message: "invalid artifact sha256 for result.txt",
+    });
   });
 
   it("isolates artifact grants by opaque organization and owner identities", async () => {


### PR DESCRIPTION
Closes https://github.com/openclaw/crabbox/issues/1305.

## Summary

Artifact upload requests already carried an optional `sha256`, but the broker did not bind it into the presigned object-store request. This PR converts valid 64-hex digests to the base64 `x-amz-checksum-sha256` value required by R2/S3, includes that header in the signed upload grant, and preserves it through the CLI uploader.

Omitted or blank digests remain optional. Any nonblank malformed digest now receives the route's normal 400 response rather than silently disabling integrity enforcement; uppercase hex is normalized.

## Verification

- focused Worker artifact/route tests: passed
- Worker format, lint, and TypeScript checks
- focused Go uploader tests: passed
- full Worker and Go suites before final rebase: passed
- structured P1 full-branch autoreview: clean
- an opt-in R2 live regression now proves matching upload success, same-size mismatching upload rejection, and no residual rejected object; it was not run locally because live R2 credentials are not configured
