### PR TITLE
fix(aws): stop the claim-lock deadlock guard from flaking under load

### DIFF
--- a/internal/providers/aws/backend_test.go
+++ b/internal/providers/aws/backend_test.go
@@ -859,9 +859,12 @@ func TestAWSFixedAcquireOnAcquiredCanReenterClaimLock(t *testing.T) {
 		result <- acquireResult{lease: lease, err: err}
 	}()
 
-	timeout := 2 * time.Second
+	// Acquire does real claim-lock and state-file work (~1.3s unloaded), so this budget
+	// only has to sit far enough above that to survive a loaded runner and the race
+	// detector's slowdown. A genuine deadlock still fails the test, just later.
+	timeout := 60 * time.Second
 	if testing.Short() {
-		timeout = time.Second
+		timeout = 10 * time.Second
 	}
 	select {
 	case got := <-result:
@@ -872,7 +875,7 @@ func TestAWSFixedAcquireOnAcquiredCanReenterClaimLock(t *testing.T) {
 			t.Fatalf("lease=%#v", got.lease)
 		}
 	case <-time.After(timeout):
-		t.Fatal("fixed OnAcquired callback deadlocked while re-entering the claim lock")
+		t.Fatalf("fixed OnAcquired did not return within %s; the callback is likely deadlocked re-entering the claim lock", timeout)
 	}
 	select {
 	case <-callbackCalled:


### PR DESCRIPTION
Closes #1306.

## Summary

`TestAWSFixedAcquireOnAcquiredCanReenterClaimLock` asserted deadlock-freedom with
a 2-second wall-clock budget against a test that takes 1.31s unloaded. The race
detector's slowdown alone exhausts that margin, so `go test -race ./...` — the
exact command the CI Go job runs — could fail on a healthy tree.

This raises the budget and makes the failure message describe what actually
happened.

## Motivation

There is no deadlock. The test runs out of budget:

```text
$ go test ./internal/providers/aws/ -run TestAWSFixed... -count=1
--- PASS (1.31s)

$ go test ./internal/providers/aws/ -run TestAWSFixed... -count=3
--- FAIL (2.01s)  x3

$ go test -race ./...
--- FAIL: TestAWSFixedAcquireOnAcquiredCanReenterClaimLock (2.01s)
```

The old message — `"fixed OnAcquired callback deadlocked while re-entering the
claim lock"` — asserts a deadlock, so anyone seeing this in CI starts
investigating claim-lock re-entrancy, which is a genuinely subtle area. The wrong
diagnosis costs more than the flake.

## What changed

| File | Change |
| --- | --- |
| `internal/providers/aws/backend_test.go` | Budget 2s → 60s (`-short`: 1s → 10s), with a comment recording the observed runtime the number is derived from. Failure message now names the budget and marks the deadlock as the likely cause rather than a stated fact. |

```
 internal/providers/aws/backend_test.go | 9 ++++++---
 1 file changed, 6 insertions(+), 3 deletions(-)
```

## Design decisions

- **Raise the budget rather than make it deterministic.** A deterministic signal
  would need production instrumentation to observe lock acquisition — new
  non-test surface area to fix a test-only problem. For a regression guard whose
  job is "this must not hang", a generous timeout is the standard shape: a real
  deadlock still fails, just later, and `go test`'s own 10-minute default remains
  the outer bound.
- **60s, not 10s.** The margin has to absorb the race detector (2–20x) on top of
  a contended runner. 10s would still be a 7.6x margin over 1.31s, which is the
  kind of number that quietly rots as the test grows.
- **`-short` keeps a tight-ish 10s.** `-short` runs are for fast feedback on an
  unloaded machine, where 10s is already ~7x headroom.
- **The comment records the derivation.** The next person to touch this should be
  able to see that 60s came from a measured 1.31s plus detector headroom, not
  from taste.

## Testing

The proof is the previously-failing invocations now passing, including the exact
race-detector case from CI:

```sh
go test ./internal/providers/aws/ -run TestAWSFixedAcquireOnAcquiredCanReenterClaimLock -count=5
# ok      github.com/openclaw/crabbox/internal/providers/aws      3.416s

go test -race ./internal/providers/aws/ -run TestAWSFixedAcquireOnAcquiredCanReenterClaimLock -count=3
# ok      github.com/openclaw/crabbox/internal/providers/aws      6.018s

gofmt -l $(git ls-files '*.go')     # clean
go vet ./internal/providers/aws/    # clean
```

`-count=3` and `-race` are the two invocations that failed 3/3 before this change.

`../verify-fixes.sh aws-test-timeout` re-runs both.

## Non-goals

- No production code changes. The re-entrancy behaviour under test is unchanged,
  and the guard still fails on a genuine deadlock.
