### PR TITLE
fix(worker): redact env-assignment, cookie, and header credential forms

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -374,9 +374,10 @@ Configured provider credentials are redacted from documented HTTP or streamed
 error diagnostics, including Azure Dynamic Sessions, Cloudflare runner, Daytona,
 DigitalOcean, E2B, FastAPI Cloud, Freestyle, Islo, Morph, OpenComputer, Orgo,
 Railway, RunPod, Semaphore, SmolVM, Sprites, and Upstash Box. The same final redaction covers `doctor` text and JSON
-messages/details. It removes exact configured secrets, authorization and API-key
-headers, credential-bearing URL query/userinfo components, common secret JSON
-fields, bearer values, and PEM private keys while retaining non-secret routing
+messages/details. It removes exact configured secrets, authorization, API-key and
+cookie headers, credential-bearing URL query/userinfo components, common secret
+JSON fields, bearer values, environment-style `NAME_TOKEN=` / `NAME_SECRET=` /
+`NAME_KEY=` assignments, and PEM private keys while retaining non-secret routing
 context. Providers contribute runtime-only environment and local CLI-store
 credentials to that exact-value pass, keeping credential discovery beside the
 provider that owns it. Header and bearer fallbacks treat whitespace or an

--- a/worker/src/http.ts
+++ b/worker/src/http.ts
@@ -100,7 +100,24 @@ function redactDiagnosticPass(value: string, secrets: readonly string[]): string
     );
   }
   for (const match of value.matchAll(
-    /(^|[^?&A-Za-z0-9_-])(authorization|proxy-authorization|x-api-key|api[-_]?key|access[-_]?token|refresh[-_]?token|id[-_]?token|client[-_]?secret|secret[-_]?access[-_]?key|api[-_]?secret|session[-_]?token|token|password)[ \t]*[:=][ \t]*(?:(?:bearer|basic)(?:[ \t]*:[ \t]*\r?\n[ \t]+|[ \t]*:[ \t]*|[ \t]*\r?\n[ \t]+|[ \t]+))?(?:\\.|[^\s"])+/gi,
+    /(^|[^?&A-Za-z0-9_-])(authorization|proxy-authorization|x-amz-security-token|x-goog-security-token|x-api-key|api[-_]?key|api[-_]?token|auth[-_]?key|access[-_]?token|refresh[-_]?token|id[-_]?token|client[-_]?secret|secret[-_]?access[-_]?key|api[-_]?secret|session[-_]?token|set-cookie|cookie|token|password)[ \t]*[:=][ \t]*(?:(?:bearer|basic)(?:[ \t]*:[ \t]*\r?\n[ \t]+|[ \t]*:[ \t]*|[ \t]*\r?\n[ \t]+|[ \t]+))?(?:\\.|[^\s"])+/gi,
+  )) {
+    const full = match[0];
+    const keyEnd = (match[1]?.length ?? 0) + (match[2]?.length ?? 0);
+    const separator = diagnosticSeparator(full, keyEnd);
+    if (separator < 0) continue;
+    const fullStart = match.index;
+    addRedaction(
+      fullStart + diagnosticSkipHorizontalSpace(full, separator + 1, full.length),
+      fullStart + full.length,
+    );
+  }
+  // Environment-style assignments (AWS_SECRET_ACCESS_KEY=..., GITHUB_TOKEN=...). The rules
+  // above deliberately refuse a keyword preceded by "_" or "-" so a query parameter cannot
+  // over-match past its "&" separator, which leaves the whole NAME_SUFFIX= shape uncovered.
+  // Anchoring on whitespace keeps that separation: a URL never has whitespace before a param.
+  for (const match of value.matchAll(
+    /(^|[\s;,(){}[\]'"`])([A-Za-z][A-Za-z0-9]*(?:[-_][A-Za-z0-9]+)*[-_](?:tokens?|secrets?|keys?|password|passwd|credentials?|authkey|apikey))[ \t]*=[ \t]*(?:\\.|[^\s"])+/gi,
   )) {
     const full = match[0];
     const keyEnd = (match[1]?.length ?? 0) + (match[2]?.length ?? 0);
@@ -113,7 +130,7 @@ function redactDiagnosticPass(value: string, secrets: readonly string[]): string
     );
   }
   for (const match of value.matchAll(
-    /"(authorization|proxy-authorization|x-api-key|apiKey|api-key|api_key|accessToken|access-token|access_token|refreshToken|refresh-token|refresh_token|idToken|id-token|id_token|clientSecret|client-secret|client_secret|secretAccessKey|secret-access-key|secret_access_key|apiSecret|api-secret|api_secret|credential|credentials|privateKey|private-key|private_key|secret|sessionToken|session-token|session_token|token|password)"\s*:\s*"(?:\\(?:[\s\S]|$)|[^"\\])*(?:"|$)/gi,
+    /"(authorization|proxy-authorization|x-api-key|apiKey|api-key|api_key|apiToken|api-token|api_token|authKey|auth-key|auth_key|setCookie|set-cookie|cookie|accessToken|access-token|access_token|refreshToken|refresh-token|refresh_token|idToken|id-token|id_token|clientSecret|client-secret|client_secret|secretAccessKey|secret-access-key|secret_access_key|apiSecret|api-secret|api_secret|credential|credentials|privateKey|private-key|private_key|secret|sessionToken|session-token|session_token|token|password)"\s*:\s*"(?:\\(?:[\s\S]|$)|[^"\\])*(?:"|$)/gi,
   )) {
     const full = match[0];
     const separator = full.indexOf(":");
@@ -124,7 +141,7 @@ function redactDiagnosticPass(value: string, secrets: readonly string[]): string
     addRedaction(fullStart + quote + 1, fullStart + secretEnd);
   }
   for (const match of value.matchAll(
-    /([?&](?:authorization|proxy-authorization|x-api-key|api[_-]?key|access[_-]?token|refresh[_-]?token|id[_-]?token|client[_-]?secret|secret[_-]?access[_-]?key|api[_-]?secret|session[_-]?token|password|token|signature|sig|x-amz-credential|x-amz-signature|x-amz-security-token|x-goog-credential|x-goog-signature|x-goog-security-token)=)[^&#\s]+/gi,
+    /([?&](?:authorization|proxy-authorization|x-api-key|api[_-]?key|api[_-]?token|auth[_-]?key|cookie|access[_-]?token|refresh[_-]?token|id[_-]?token|client[_-]?secret|secret[_-]?access[_-]?key|api[_-]?secret|session[_-]?token|password|token|signature|sig|x-amz-credential|x-amz-signature|x-amz-security-token|x-goog-credential|x-goog-signature|x-goog-security-token)=)[^&#\s]+/gi,
   )) {
     addRedaction(match.index + match[1]!.length, match.index + match[0].length);
   }

--- a/worker/test/http.test.ts
+++ b/worker/test/http.test.ts
@@ -1642,6 +1642,50 @@ describe("http responses", () => {
     expect(redactDiagnosticSecrets(redacted, secrets)).toBe(redacted);
   });
 
+  it.each([
+    [
+      "AWS env assignment",
+      "bootstrap failed: AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI",
+      "wJalrXUtnFEMI",
+    ],
+    [
+      "GitHub env assignment",
+      "sh: GITHUB_TOKEN=ghp_16C7e42F292c6912: not found",
+      "ghp_16C7e42F292c6912",
+    ],
+    ["shell export", "export TAILSCALE_AUTHKEY=tskey-auth-k7Yh2", "tskey-auth-k7Yh2"],
+    ["quoted env assignment", `run "CI_API_KEY=abcdef123456"`, "abcdef123456"],
+    ["set-cookie header", "upstream: Set-Cookie: sid=s%3AabcdefQRST", "s%3AabcdefQRST"],
+    ["cookie header", "Cookie: session=abcdefghij1234567890", "abcdefghij1234567890"],
+    ["amz security token header", "x-amz-security-token: FwoGZXIvYXdzEBYa", "FwoGZXIvYXdzEBYa"],
+    ["camelCase api token", "stringData:\n  apiToken: sk-live-9f8e7d6c", "sk-live-9f8e7d6c"],
+  ])("redacts a credential carried by %s", (_label, diagnostic, secret) => {
+    const redacted = redactDiagnosticSecrets(diagnostic);
+    expect(redacted).not.toContain(secret);
+    expect(redacted).toContain("[redacted]");
+    expect(redactDiagnosticSecrets(redacted)).toBe(redacted);
+  });
+
+  it("keeps redacting query parameters at their own separator", () => {
+    const redacted = redactDiagnosticSecrets(
+      "https://host.example.test/p?id_token=query-id-token&X-Amz-Security-Token=amz-token&region=eu",
+    );
+    expect(redacted).not.toContain("query-id-token");
+    expect(redacted).not.toContain("amz-token");
+    expect(redacted).toContain("region=eu");
+  });
+
+  it("leaves non-credential assignments and identifiers intact", () => {
+    for (const value of [
+      "region=eu-central-1",
+      "token_type=Bearer_placeholder",
+      "retry_count=3",
+      "instance-type=c7a.4xlarge",
+    ]) {
+      expect(redactDiagnosticSecrets(value)).toBe(value);
+    }
+  });
+
   it("preserves already-redacted and non-userinfo URL at-signs", () => {
     const value =
       "http://<redacted>@broker.example.test https://[redacted]@api.example.test https://host.example.test?email=alice@example.test https://host.example.test#realm@tenant";


### PR DESCRIPTION
Closes #1307.

## Summary

`redactDiagnosticSecrets` left the most common real-world credential shapes
intact: `AWS_SECRET_ACCESS_KEY=…`, `GITHUB_TOKEN=…`, `TAILSCALE_AUTHKEY=…`,
`Cookie:` / `Set-Cookie:`, the `x-amz-security-token:` header form, and camelCase
`apiToken:`.

This adds a dedicated rule for environment-style assignments plus the missing
keywords, while leaving query-string handling exactly as it was.

## Motivation

Every structural rule is anchored with `(^|[^?&A-Za-z0-9_-])`. That class
excludes `_` and `-`, so a keyword that appears as the suffix of a longer
identifier — which is how credentials are actually named — can never match.

The exclusion is load-bearing, not an oversight: it stops a rule from matching
mid-identifier inside a query string, where the value pattern
`(?:\\.|[^\s"])+` would run past the `&` separator and swallow the rest of the
URL. Relaxing it is what a first attempt at this fix does, and it immediately
breaks `region=eu` at the tail of a signed URL.

This matters because `coordinatorDiagnosticText` applies the redactor to
`cleanupError` and `failureError` before returning them to clients, and
`errorMessage()` is called without a secrets list at 18 of 19 call sites in
`worker/src` — so the stored text is unredacted and this pass is what stands
between a bootstrap failure that echoed its environment and whoever can read the
lease.

## What changed

| File | Change |
| --- | --- |
| `worker/src/http.ts` | New rule for `NAME_TOKEN=` / `NAME_SECRET=` / `NAME_KEY=`-style assignments, anchored on whitespace. Adds `x-amz-security-token`, `x-goog-security-token`, `api[-_]?token`, `auth[-_]?key`, `set-cookie`, `cookie` to the unquoted rule; the camelCase/kebab/snake variants plus `cookie` to the JSON rule; `api[_-]?token`, `auth[_-]?key`, `cookie` to the query rule. |
| `worker/test/http.test.ts` | Eight credential-carrying diagnostics, a query-string non-regression case, and a set of non-credential strings that must stay untouched. |
| `docs/security.md` | Names cookie headers and env-style assignments in the redaction description. |

```
 docs/security.md         |  7 ++++---
 worker/src/http.ts       | 23 ++++++++++++++++++++---
 worker/test/http.test.ts | 44 ++++++++++++++++++++++++++++++++++++++++++++
 3 files changed, 68 insertions(+), 6 deletions(-)
```

## Design decisions

- **Additive, not a relaxed boundary.** Loosening `[^?&A-Za-z0-9_-]` to allow
  `_`/`-` is the obvious fix and it is wrong. With `-` allowed, `token` matches
  inside `&X-Goog-Security-Token=…` and the unquoted rule's value pattern
  consumes `gcp-token&region=eu` to end-of-token; the existing suite catches this
  as `expected … to contain 'region=eu'`. With `_` allowed, `&id_token=…` breaks
  the same way. The boundary is left exactly as it was.
- **The env rule is anchored on whitespace.** `(^|[\s;,(){}[\]'"`])` — a URL
  never has whitespace before a parameter name, so this rule structurally cannot
  fire inside a query string, no matter how greedy its value pattern is. That is
  what makes it safe where a boundary relaxation is not.
- **The name shape is required, not just the suffix.** The rule matches
  `[A-Za-z][A-Za-z0-9]*(?:[-_][A-Za-z0-9]+)*[-_](?:tokens?|secrets?|keys?|password|passwd|credentials?|authkey|apikey)`,
  so `MY_API_TOKEN=` matches while `token_type=`, `retry_count=`, and
  `region=eu-central-1` do not.
- **Hyphenated header names are added as whole keywords.** `x-amz-security-token`
  and `set-cookie` are listed explicitly rather than reached by relaxing the
  boundary. In a URL they are preceded by `?`/`&`, which the boundary still
  excludes, so the query rule keeps handling them at its own `&` stop.
- **Command-line `--api-key=secret` stays uncovered.** Its preceding `-` is
  excluded by both the existing boundary and the new rule's anchor. Covering it
  needs its own rule; that is unchanged behaviour, not a regression, and is left
  as a follow-up.

## Testing

New cases in `worker/test/http.test.ts`:

- **eight credential-carrying diagnostics** — AWS env assignment, GitHub env
  assignment, shell `export`, quoted assignment, `Set-Cookie`, `Cookie`,
  `x-amz-security-token`, camelCase `apiToken`. Each asserts the secret is gone,
  a marker is present, and the result is **idempotent** under a second pass;
- **query-string non-regression** — `?id_token=…&X-Amz-Security-Token=…&region=eu`
  redacts both credentials and keeps `region=eu`;
- **non-credential strings unchanged** — `region=eu-central-1`,
  `token_type=Bearer_placeholder`, `retry_count=3`, `instance-type=c7a.4xlarge`
  must come back byte-identical, pinning against over-redaction.

**Proof that the tests observe the defect.** Reverting *only*
`worker/src/http.ts` (keeping the new tests) fails 8 of them; with the fix,
`67 passed (67)` — including all 57 pre-existing cases, which is the real
guarantee that the boundary semantics were not disturbed.

**Verified locally** (Node 24 toolchain, worker CI gate in order):

```sh
npm ci --prefix worker
npm run format:check --prefix worker
npm run lint --prefix worker
npm run check --prefix worker
npm run check:node --prefix worker
npm test --prefix worker          # 1265 passed | 3 skipped (1268)
scripts/check-docs.sh
```

All green. `../verify-fixes.sh diag-redaction` re-runs the red/green proof and
the full gate.

## Non-goals / follow-ups

- Not a general secrets scanner; this stays a pattern-based safety net behind the
  exact-value pass.
- Command-line flag credentials (`--api-key=…`, `-p secret`) remain uncovered.
- Passing a secrets list to the remaining `errorMessage()` call sites would
  reduce reliance on structural matching, and is worth doing separately.
