### PR TITLE
fix(worker): reject malformed allowed-team entries instead of widening them

### DIFF
--- a/docs/features/broker-auth-routing.md
+++ b/docs/features/broker-auth-routing.md
@@ -177,7 +177,9 @@ Login is gated by GitHub org membership before a user token is minted:
 - The user must be an **active** member of an allowed org.
 - If `CRABBOX_GITHUB_ALLOWED_TEAMS` (or `CRABBOX_GITHUB_ALLOWED_TEAM`) is set, the user must
   also belong to at least one listed team after org membership passes. Entries are team
-  slugs: use `team-slug` for the resolved org, or `org/team-slug` to qualify the org.
+  slugs: use `team-slug` for the resolved org, or `org/team-slug` to qualify the org. Any other
+  shape (a nested `org/team/extra` path, or a missing org or slug) is rejected and fails all
+  GitHub auth closed until corrected, so a typo cannot silently widen or disable the team gate.
 
 ### Coordinator secrets for login
 

--- a/worker/src/github-membership.ts
+++ b/worker/src/github-membership.ts
@@ -238,14 +238,22 @@ function allowedGitHubOrgs(env: GitHubMembershipEnv): string[] {
 
 function allowedGitHubTeams(env: GitHubMembershipEnv, defaultOrg: string): AllowedGitHubTeam[] {
   const raw = env.CRABBOX_GITHUB_ALLOWED_TEAMS || env.CRABBOX_GITHUB_ALLOWED_TEAM;
-  return envList(raw)
-    .map((value) => parseAllowedGitHubTeam(value, defaultOrg))
-    .filter((team): team is AllowedGitHubTeam => team !== undefined);
+  return envList(raw).map((value) => parseAllowedGitHubTeam(value, defaultOrg));
 }
 
-function parseAllowedGitHubTeam(value: string, defaultOrg: string): AllowedGitHubTeam | undefined {
-  const [org, slug] = value.includes("/") ? value.split("/", 2) : [defaultOrg, value];
-  if (!org || !slug) return undefined;
+/**
+ * Accepts only `team-slug` or `org/team-slug`. A malformed entry throws rather than
+ * being dropped: silently skipping it would either widen the entry to a different team
+ * or, if every entry is malformed, disable the team gate entirely.
+ */
+function parseAllowedGitHubTeam(value: string, defaultOrg: string): AllowedGitHubTeam {
+  const segments = value.includes("/") ? value.split("/") : [defaultOrg, value];
+  const [org, slug] = segments;
+  if (segments.length !== 2 || !org || !slug) {
+    throw new GitHubAuthorizationError(
+      "CRABBOX_GITHUB_ALLOWED_TEAMS contains an invalid entry. Use team-slug or org/team-slug.",
+    );
+  }
   return { org, slug };
 }
 

--- a/worker/test/github-membership.test.ts
+++ b/worker/test/github-membership.test.ts
@@ -197,6 +197,38 @@ describe("GitHub user-token membership", () => {
     await expect(authenticateRequest(tokenRequest(token), env)).resolves.toBeUndefined();
   });
 
+  it.each([
+    ["a nested path", "example-org/operators/leads"],
+    ["a missing org", "/operators"],
+    ["a missing slug", "example-org/"],
+  ])("fails closed on an allowed-team entry with %s", async (_label, teams) => {
+    const env = testEnv({ CRABBOX_GITHUB_ALLOWED_TEAMS: teams });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<(input: RequestInfo | URL) => Promise<Response>>(async (input) => {
+        const url = String(input);
+        if (url === "https://api.github.com/user") return userResponse();
+        if (url.includes("/user/teams")) {
+          return Response.json([{ slug: "operators", organization: { login: "example-org" } }]);
+        }
+        return membershipResponse();
+      }),
+    );
+
+    await expect(
+      requireFreshGitHubMembership(
+        {
+          accessToken,
+          tokenID: "team-entry",
+          owner: `github:${accountID}`,
+          org: "example-org",
+          login: "alice",
+        },
+        env,
+      ),
+    ).rejects.toThrow(/CRABBOX_GITHUB_ALLOWED_TEAMS/);
+  });
+
   it.each([`github:${accountID}`, `owner:github:${accountID}`])(
     "applies narrow revocation %s before the GitHub cache",
     async (revoked) => {


### PR DESCRIPTION
Closes #1308.

## Summary

`parseAllowedGitHubTeam` used `value.split("/", 2)`. JavaScript's `split` limit
**truncates** rather than keeping the remainder, so `acme/engineers/leads` was
silently reinterpreted as the parent team `acme/engineers`. Entries with an empty
segment were dropped, and if every entry was malformed the team gate switched off
altogether.

Malformed entries now throw, so a bad allowlist fails closed instead of granting
more than it says.

## Motivation

Both failure modes open access **wider** than the configuration reads, and both
are silent — no log line, no startup error. The worst case is not the widening
but the disappearance: a config of only `"/operators"` left
`allowedGitHubTeams` empty, and `requireAllowedTeamMembership`'s
`if (allowed.length === 0) return` early-out then skipped the team check for
every caller, quietly degrading to "org membership is enough".

`worker/src/github-membership.ts` already takes the fail-closed posture for
`CRABBOX_GITHUB_REVOKED_USERS`, where `docs/security.md` states that invalid
selectors "fail all GitHub auth closed until replaced". This applies the same
rule to team entries.

## What changed

| File | Change |
| --- | --- |
| `worker/src/github-membership.ts` | `parseAllowedGitHubTeam` returns `AllowedGitHubTeam` (no longer optional) and throws `GitHubAuthorizationError` on any entry that is not exactly `team-slug` or `org/team-slug`. `allowedGitHubTeams` drops its now-unreachable `.filter()`. |
| `worker/test/github-membership.test.ts` | Three malformed shapes — nested path, missing org, missing slug. |
| `docs/features/broker-auth-routing.md` | Documents that any other shape is rejected and fails auth closed. |

```
 docs/features/broker-auth-routing.md  |  4 +++-
 worker/src/github-membership.ts       | 20 ++++++++++++++------
 worker/test/github-membership.test.ts | 32 ++++++++++++++++++++++++++++++++
 3 files changed, 49 insertions(+), 7 deletions(-)
```

## Design decisions

- **Throw rather than drop.** Returning `undefined` was the root of the second
  failure mode: a dropped entry can silently empty the allowlist and disable the
  gate. Throwing makes a malformed allowlist impossible to ignore, and reuses
  `GitHubAuthorizationError` so it lands on the existing deny path rather than
  surfacing as a 500.
- **Explicit segment count.** The check is `segments.length !== 2 || !org || !slug`,
  which covers the nested path, both empty-segment shapes, and (via the
  `defaultOrg` branch) an empty resolved org — one rule instead of three.
- **Error text names the variable, not the value.** The message is
  `"CRABBOX_GITHUB_ALLOWED_TEAMS contains an invalid entry. Use team-slug or
  org/team-slug."` — enough for an operator to find and fix it, without echoing
  configuration back into an auth error response.

## Testing

New cases in `worker/test/github-membership.test.ts`, driving
`requireFreshGitHubMembership` against a stubbed GitHub API, with the caller
deliberately a member of `example-org/operators` so a widened match would
otherwise succeed:

- nested path `example-org/operators/leads`
- missing org `/operators`
- missing slug `example-org/`

Each must reject with a message naming `CRABBOX_GITHUB_ALLOWED_TEAMS`.

**Proof that the tests observe the defect.** Reverting *only*
`worker/src/github-membership.ts` (keeping the new tests):

```text
FAIL  ... fails closed on an allowed-team entry with a nested path
FAIL  ... fails closed on an allowed-team entry with a missing org
FAIL  ... fails closed on an allowed-team entry with a missing slug
      Tests  3 failed | 17 passed | 1 skipped (21)
```

With the fix restored: `20 passed | 1 skipped (21)`.

**Verified locally** (Node 24 toolchain, worker CI gate in order):

```sh
npm ci --prefix worker
npm run format:check --prefix worker
npm run lint --prefix worker
npm run check --prefix worker
npm run check:node --prefix worker
npm test --prefix worker          # 1258 passed | 3 skipped (1261)
scripts/check-docs.sh
```

All green. `../verify-fixes.sh gh-team-entry-parse` re-runs the red/green proof
and the full gate.

## Non-goals

- Does not validate that a team actually exists on GitHub; that stays a runtime
  membership question.
- Does not change how a well-formed unqualified `team-slug` resolves.
