### PR TITLE
fix(worker): validate and scope GitHub team authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.41.6 - Unreleased
 
+### Fixed
+
+- Made GitHub team authorization fail closed on malformed selectors, enforced same-org team scope, and invalidated membership and device proofs when the normalized policy changes. Thanks @dwin-gharibi.
+
 ## 0.41.5 - 2026-08-12
 
 ### Fixed

--- a/docs/features/broker-auth-routing.md
+++ b/docs/features/broker-auth-routing.md
@@ -178,6 +178,10 @@ Login is gated by GitHub org membership before a user token is minted:
 - If `CRABBOX_GITHUB_ALLOWED_TEAMS` (or `CRABBOX_GITHUB_ALLOWED_TEAM`) is set, the user must
   also belong to at least one listed team after org membership passes. Entries are team
   slugs: use `team-slug` for the resolved org, or `org/team-slug` to qualify the org.
+- The team check is **scoped to the org being authorized**: only entries that resolve to that
+  org can satisfy it, so a team in a different configured org never grants access. If teams are
+  configured but none resolve to the org being authorized, that org is **rejected** — list at
+  least one team per allowed org, or leave the setting unset to gate on org membership alone.
 
 ### Coordinator secrets for login
 

--- a/docs/features/broker-auth-routing.md
+++ b/docs/features/broker-auth-routing.md
@@ -182,6 +182,11 @@ Login is gated by GitHub org membership before a user token is minted:
   org can satisfy it, so a team in a different configured org never grants access. If teams are
   configured but none resolve to the org being authorized, that org is **rejected** — list at
   least one team per allowed org, or leave the setting unset to gate on org membership alone.
+- Every nonblank selector must be exactly `team-slug` or `org/team-slug`, using GitHub-style
+  letters, numbers, and hyphens. Missing components, extra slashes, invalid tokens, comma-only
+  values, and empty entries mixed into a list fail GitHub authorization closed. A nonblank
+  plural value takes precedence over the legacy singular alias; an unset, empty, or
+  whitespace-only plural value may fall back to the singular value.
 
 ### Coordinator secrets for login
 

--- a/docs/features/device-pairing.md
+++ b/docs/features/device-pairing.md
@@ -72,10 +72,12 @@ repository configuration.
 The coordinator stores the paired browser session's sealed GitHub authorization
 grant beside the token hash. Every device request reads the durable token
 verifier, checks the sealed grant's expiry and readability, and applies current
-local revoked-user and allowed-organization policy. Successful remote GitHub
+local revoked-user and allowed-organization/team policy. Successful remote GitHub
 account and organization/team membership checks are cached for 60 seconds per
-exact device token. The cache is bounded and never shared by devices, owners, or
-organizations.
+exact device token and normalized organization/team policy. The cache is bounded
+and never shared by devices, owners, organizations, or policy versions. A policy
+change is therefore enforced on the next request even while an older proof is warm;
+malformed team configuration fails closed before cache lookup.
 
 After a cache miss or expiry, GitHub errors, account mismatch, removed
 membership, revoked users, or a no-longer-allowed organization fail closed with
@@ -125,11 +127,12 @@ failures after that deadline deny access rather than extending the window.
 
 The window does not apply to the durable device-token verifier, device-token
 expiry, sealed-grant expiry or decryption, configured revoked-user policy,
-allowed-organization policy, or current lease visibility. Those checks run on
-every request. Individual or bulk device revocation deletes the verifier first
-and takes effect on the next request regardless of cache state. Cache entries
-are keyed by the exact device ID and token hash and are held only in bounded
-ephemeral Worker memory, preventing cross-token or cross-tenant reuse.
+allowed-organization/team policy, or current lease visibility. Those checks run
+on every request. Individual or bulk device revocation deletes the verifier first
+and takes effect on the next request regardless of cache state. Cache entries are
+keyed by the exact device ID, token hash, and normalized org/team policy and are
+held only in bounded ephemeral Worker memory, preventing cross-token,
+cross-tenant, or cross-policy reuse.
 
 ## Non-goals
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -99,7 +99,9 @@ by coordinator config:
 - `CRABBOX_GITHUB_ALLOWED_TEAMS` (or `CRABBOX_GITHUB_ALLOWED_TEAM`) further
   narrows access to selected team slugs after org membership passes. The check is
   scoped to the org being authorized, so a team in another configured org cannot
-  satisfy it; an org with teams configured but none of its own is rejected.
+  satisfy it; an org with teams configured but none of its own is rejected. Every
+  nonblank selector must be `team-slug` or `org/team-slug`; malformed paths, invalid
+  tokens, comma-only values, and mixed empty entries fail authorization closed.
 - `CRABBOX_GITHUB_MEMBERSHIP_CACHE_SECONDS` controls successful request-time
   membership caching (default 300, maximum 3600; set 0 to check every request).
 - `CRABBOX_GITHUB_REVOKED_USERS` immediately rejects comma-separated immutable

--- a/docs/security.md
+++ b/docs/security.md
@@ -97,7 +97,9 @@ by coordinator config:
 - `CRABBOX_GITHUB_ALLOWED_ORG` / `CRABBOX_GITHUB_ALLOWED_ORGS` restrict login to
   members of the listed GitHub org(s).
 - `CRABBOX_GITHUB_ALLOWED_TEAMS` (or `CRABBOX_GITHUB_ALLOWED_TEAM`) further
-  narrows access to selected team slugs after org membership passes.
+  narrows access to selected team slugs after org membership passes. The check is
+  scoped to the org being authorized, so a team in another configured org cannot
+  satisfy it; an org with teams configured but none of its own is rejected.
 - `CRABBOX_GITHUB_MEMBERSHIP_CACHE_SECONDS` controls successful request-time
   membership caching (default 300, maximum 3600; set 0 to check every request).
 - `CRABBOX_GITHUB_REVOKED_USERS` immediately rejects comma-separated immutable

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -76,8 +76,8 @@ import {
 } from "./daytona";
 import { GCPClient, gcpProviderLabelValue } from "./gcp";
 import {
+  githubMembershipPolicy,
   requireFreshGitHubMembership,
-  requireGitHubMembershipPolicy,
   type GitHubMembershipEnv,
   type GitHubMembershipIdentity,
 } from "./github-membership";
@@ -1615,8 +1615,8 @@ export class FleetCoordinator {
     identity: GitHubMembershipIdentity,
     env: GitHubMembershipEnv,
   ): Promise<void> {
-    requireGitHubMembershipPolicy(identity, env);
-    const key = deviceMembershipCacheKey(record);
+    const policy = githubMembershipPolicy(identity, env);
+    const key = deviceMembershipCacheKey(record, policy.cacheKey);
     const now = Date.now();
     const cached = this.deviceMembershipCache.get(key);
     if (cached?.expiresAt && cached.expiresAt > now) {
@@ -1628,8 +1628,10 @@ export class FleetCoordinator {
     this.deviceMembershipCache.delete(key);
 
     const entry: DeviceMembershipCacheEntry = { expiresAt: 0 };
-    const membership = this.authContext.githubMembership ?? requireFreshGitHubMembership;
-    entry.load = membership(identity, env).then(
+    const membership = this.authContext.githubMembership;
+    entry.load = (
+      membership ? membership(identity, env) : requireFreshGitHubMembership(identity, env, policy)
+    ).then(
       () => {
         if (this.deviceMembershipCache.get(key) === entry) {
           entry.expiresAt = Date.now() + deviceMembershipCacheTTLMS;
@@ -1686,7 +1688,7 @@ export class FleetCoordinator {
 
   private async revokeDeviceRecord(record: DeviceTokenRecord): Promise<void> {
     await this.state.storage.delete(deviceTokenKey(record.id));
-    this.deviceMembershipCache.delete(deviceMembershipCacheKey(record));
+    deleteDeviceMembershipCacheEntries(this.deviceMembershipCache, record);
     await this.state.storage.delete(deviceOwnerIndexKey(record.owner, record.org, record.id));
   }
 
@@ -18906,8 +18908,27 @@ function pairingBrowserSession(
   return { login, grant: { tokenID, sealedCredential, expiresAt } };
 }
 
-function deviceMembershipCacheKey(record: Pick<DeviceTokenRecord, "id" | "tokenHash">): string {
-  return `${record.id}:${record.tokenHash}`;
+function deviceMembershipCacheKey(
+  record: Pick<DeviceTokenRecord, "id" | "tokenHash">,
+  policyKey: string,
+): string {
+  return `${deviceMembershipCacheKeyPrefix(record)}${policyKey}`;
+}
+
+function deviceMembershipCacheKeyPrefix(
+  record: Pick<DeviceTokenRecord, "id" | "tokenHash">,
+): string {
+  return `${record.id}:${record.tokenHash}\0`;
+}
+
+function deleteDeviceMembershipCacheEntries(
+  cache: Map<string, DeviceMembershipCacheEntry>,
+  record: Pick<DeviceTokenRecord, "id" | "tokenHash">,
+): void {
+  const prefix = deviceMembershipCacheKeyPrefix(record);
+  for (const key of cache.keys()) {
+    if (key.startsWith(prefix)) cache.delete(key);
+  }
 }
 
 function trimDeviceMembershipCache(cache: Map<string, DeviceMembershipCacheEntry>): void {

--- a/worker/src/github-membership.ts
+++ b/worker/src/github-membership.ts
@@ -23,6 +23,12 @@ interface AllowedGitHubTeam {
   slug: string;
 }
 
+export interface GitHubMembershipPolicy {
+  org: string;
+  allowedTeams: readonly string[];
+  cacheKey: string;
+}
+
 export interface GitHubMembershipIdentity {
   accessToken: string;
   tokenID: string;
@@ -61,15 +67,16 @@ export async function requireGitHubLoginMembership(
   if (!org) {
     throw new GitHubAuthorizationError("GitHub login is not configured with an allowed org.");
   }
-  return requireExactGitHubMembership(accessToken, identity.login, org, env);
+  const policy = githubMembershipPolicy({ ...identity, org }, env);
+  return requireExactGitHubMembership(accessToken, identity.login, policy);
 }
 
 export async function requireCurrentGitHubMembership(
   identity: GitHubMembershipIdentity,
   env: GitHubMembershipEnv,
 ): Promise<void> {
-  requireGitHubMembershipPolicy(identity, env);
-  const key = membershipCacheKey(identity, env);
+  const policy = githubMembershipPolicy(identity, env);
+  const key = membershipCacheKey(identity, policy);
   const now = Date.now();
   const cachedUntil = membershipCache.get(key) ?? 0;
   if (cachedUntil > now) {
@@ -81,9 +88,7 @@ export async function requireCurrentGitHubMembership(
     return loading;
   }
   const load = requireExactGitHubAccount(identity.accessToken, identity.owner, identity.login)
-    .then(() =>
-      requireExactGitHubMembership(identity.accessToken, identity.login, identity.org, env),
-    )
+    .then(() => requireExactGitHubMembership(identity.accessToken, identity.login, policy))
     .then(() => {
       const ttlSeconds = membershipCacheSeconds(env);
       if (ttlSeconds > 0) {
@@ -100,23 +105,41 @@ export async function requireCurrentGitHubMembership(
 export async function requireFreshGitHubMembership(
   identity: GitHubMembershipIdentity,
   env: GitHubMembershipEnv,
+  normalizedPolicy?: GitHubMembershipPolicy,
 ): Promise<void> {
-  requireGitHubMembershipPolicy(identity, env);
+  const policy = normalizedPolicy ?? githubMembershipPolicy(identity, env);
   await requireExactGitHubAccount(identity.accessToken, identity.owner, identity.login);
-  await requireExactGitHubMembership(identity.accessToken, identity.login, identity.org, env);
+  await requireExactGitHubMembership(identity.accessToken, identity.login, policy);
 }
 
-export function requireGitHubMembershipPolicy(
+export function githubMembershipPolicy(
   identity: Pick<GitHubMembershipIdentity, "owner" | "org" | "login">,
   env: GitHubMembershipEnv,
-): void {
+): GitHubMembershipPolicy {
   requireSafeGitHubRevocationConfig(env);
   if (githubUserIsRevoked(identity, env)) {
     throw new GitHubAuthorizationError(`GitHub user ${identity.login} has been revoked.`);
   }
-  if (!allowedGitHubOrgs(env).includes(identity.org.trim().toLowerCase())) {
+  const org = identity.org.trim().toLowerCase();
+  const allowedOrgs = allowedGitHubOrgs(env);
+  if (!allowedOrgs.includes(org)) {
     throw new GitHubAuthorizationError(`GitHub organization ${identity.org} is no longer allowed.`);
   }
+  const configuredTeams = allowedGitHubTeams(env, org)
+    .map((team) => teamKey(team.org, team.slug))
+    .toSorted();
+  const normalizedTeams = [...new Set(configuredTeams)];
+  const allowedTeams = normalizedTeams.filter((team) => team.startsWith(`${org}/`));
+  if (normalizedTeams.length > 0 && allowedTeams.length === 0) {
+    throw new GitHubAuthorizationError(
+      `GitHub organization ${org} has no allowed team configured.`,
+    );
+  }
+  return {
+    org,
+    allowedTeams,
+    cacheKey: JSON.stringify([[...new Set(allowedOrgs)].toSorted(), normalizedTeams]),
+  };
 }
 
 function githubUserIsRevoked(
@@ -180,13 +203,9 @@ export function githubAccountID(owner: string): number | undefined {
 async function requireExactGitHubMembership(
   accessToken: string,
   login: string,
-  org: string,
-  env: GitHubMembershipEnv,
+  policy: GitHubMembershipPolicy,
 ): Promise<string> {
-  const exactOrg = org.trim().toLowerCase();
-  if (!allowedGitHubOrgs(env).includes(exactOrg)) {
-    throw new GitHubAuthorizationError(`GitHub organization ${org} is no longer allowed.`);
-  }
+  const exactOrg = policy.org;
   const response = await fetch(
     `${githubAPIURL}/user/memberships/orgs/${encodeURIComponent(exactOrg)}`,
     { headers: githubHeaders(accessToken) },
@@ -206,38 +225,24 @@ async function requireExactGitHubMembership(
       `GitHub user ${login} is not an active member of ${exactOrg}.`,
     );
   }
-  await requireAllowedTeamMembership(accessToken, login, exactOrg, env);
+  await requireAllowedTeamMembership(accessToken, login, policy);
   return membership.organization.login || exactOrg;
 }
 
 async function requireAllowedTeamMembership(
   accessToken: string,
   login: string,
-  org: string,
-  env: GitHubMembershipEnv,
+  policy: GitHubMembershipPolicy,
 ): Promise<void> {
-  const allowed = allowedGitHubTeams(env, org);
-  if (allowed.length === 0) return;
-  // /user/teams spans every org the caller belongs to, so the allowlist must be
-  // narrowed to the org being authorized. Without this, a team in another
-  // configured org would satisfy this org's gate.
-  const allowedKeys = new Set(
-    allowed
-      .filter((team) => team.org.toLowerCase() === org)
-      .map((team) => teamKey(team.org, team.slug)),
-  );
-  if (allowedKeys.size === 0) {
-    throw new GitHubAuthorizationError(
-      `GitHub organization ${org} has no allowed team configured.`,
-    );
-  }
+  if (policy.allowedTeams.length === 0) return;
+  const allowedKeys = new Set(policy.allowedTeams);
   for (const team of await userGitHubTeams(accessToken)) {
     const teamOrg = team.organization?.login?.toLowerCase() ?? "";
     const teamSlug = team.slug?.toLowerCase() ?? "";
     if (teamOrg && teamSlug && allowedKeys.has(teamKey(teamOrg, teamSlug))) return;
   }
   throw new GitHubAuthorizationError(
-    `GitHub user ${login} is not a member of an allowed team in ${org}.`,
+    `GitHub user ${login} is not a member of an allowed team in ${policy.org}.`,
   );
 }
 
@@ -249,16 +254,42 @@ function allowedGitHubOrgs(env: GitHubMembershipEnv): string[] {
 }
 
 function allowedGitHubTeams(env: GitHubMembershipEnv, defaultOrg: string): AllowedGitHubTeam[] {
-  const raw = env.CRABBOX_GITHUB_ALLOWED_TEAMS || env.CRABBOX_GITHUB_ALLOWED_TEAM;
-  return envList(raw)
-    .map((value) => parseAllowedGitHubTeam(value, defaultOrg))
-    .filter((team): team is AllowedGitHubTeam => team !== undefined);
+  const plural = env.CRABBOX_GITHUB_ALLOWED_TEAMS;
+  const raw =
+    plural === undefined || plural.trim() === "" ? env.CRABBOX_GITHUB_ALLOWED_TEAM : plural;
+  if (raw === undefined || raw.trim() === "") return [];
+  const values = raw.split(",").map((value) => value.trim().toLowerCase());
+  if (values.some((value) => value === "")) throw invalidAllowedTeamConfig();
+  return values.map((value) => parseAllowedGitHubTeam(value, defaultOrg));
 }
 
-function parseAllowedGitHubTeam(value: string, defaultOrg: string): AllowedGitHubTeam | undefined {
-  const [org, slug] = value.includes("/") ? value.split("/", 2) : [defaultOrg, value];
-  if (!org || !slug) return undefined;
+function parseAllowedGitHubTeam(value: string, defaultOrg: string): AllowedGitHubTeam {
+  const segments = value.split("/");
+  if (segments.length > 2) throw invalidAllowedTeamConfig();
+  const [org, slug] = segments.length === 2 ? segments : [defaultOrg, segments[0]];
+  if (!validGitHubOrgSelector(org) || !validGitHubTeamSlug(slug)) {
+    throw invalidAllowedTeamConfig();
+  }
   return { org, slug };
+}
+
+function validGitHubOrgSelector(value: string | undefined): value is string {
+  return Boolean(
+    value &&
+    value.length <= 39 &&
+    /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(value) &&
+    !value.includes("--"),
+  );
+}
+
+function validGitHubTeamSlug(value: string | undefined): value is string {
+  return Boolean(value && value.length <= 100 && /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(value));
+}
+
+function invalidAllowedTeamConfig(): GitHubAuthorizationError {
+  return new GitHubAuthorizationError(
+    "CRABBOX_GITHUB_ALLOWED_TEAMS contains an invalid entry. Use team-slug or org/team-slug without empty entries.",
+  );
 }
 
 async function userGitHubTeams(accessToken: string): Promise<GitHubTeam[]> {
@@ -285,15 +316,13 @@ async function userGitHubTeams(accessToken: string): Promise<GitHubTeam[]> {
 
 function membershipCacheKey(
   identity: Pick<GitHubMembershipIdentity, "tokenID" | "owner" | "org">,
-  env: GitHubMembershipEnv,
+  policy: GitHubMembershipPolicy,
 ): string {
   return JSON.stringify([
     identity.tokenID,
     identity.owner.toLowerCase(),
     identity.org.toLowerCase(),
-    envList(env.CRABBOX_GITHUB_ALLOWED_ORGS || env.CRABBOX_GITHUB_ALLOWED_ORG),
-    envList(env.CRABBOX_GITHUB_ALLOWED_TEAMS || env.CRABBOX_GITHUB_ALLOWED_TEAM),
-    envList(env.CRABBOX_DEFAULT_ORG),
+    policy.cacheKey,
   ]);
 }
 

--- a/worker/src/github-membership.ts
+++ b/worker/src/github-membership.ts
@@ -218,7 +218,19 @@ async function requireAllowedTeamMembership(
 ): Promise<void> {
   const allowed = allowedGitHubTeams(env, org);
   if (allowed.length === 0) return;
-  const allowedKeys = new Set(allowed.map((team) => teamKey(team.org, team.slug)));
+  // /user/teams spans every org the caller belongs to, so the allowlist must be
+  // narrowed to the org being authorized. Without this, a team in another
+  // configured org would satisfy this org's gate.
+  const allowedKeys = new Set(
+    allowed
+      .filter((team) => team.org.toLowerCase() === org)
+      .map((team) => teamKey(team.org, team.slug)),
+  );
+  if (allowedKeys.size === 0) {
+    throw new GitHubAuthorizationError(
+      `GitHub organization ${org} has no allowed team configured.`,
+    );
+  }
   for (const team of await userGitHubTeams(accessToken)) {
     const teamOrg = team.organization?.login?.toLowerCase() ?? "";
     const teamSlug = team.slug?.toLowerCase() ?? "";

--- a/worker/test/github-membership.test.ts
+++ b/worker/test/github-membership.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { authenticateRequest, issueUserToken } from "../src/auth";
 import { prepareCoordinatorRequest } from "../src/coordinator-entry";
-import { requireFreshGitHubMembership } from "../src/github-membership";
+import { githubMembershipPolicy, requireFreshGitHubMembership } from "../src/github-membership";
 import type { Env } from "../src/types";
 
 const accessToken = "github-access-token-for-tests";
@@ -54,7 +54,7 @@ function membershipResponse(state = "active", org = "example-org"): Response {
   return Response.json({ state, organization: { login: org } });
 }
 
-function teamIdentity(): {
+function teamIdentity(org = "example-org"): {
   accessToken: string;
   tokenID: string;
   owner: string;
@@ -63,9 +63,9 @@ function teamIdentity(): {
 } {
   return {
     accessToken,
-    tokenID: "team-scope-token",
+    tokenID: `team-scope-token-${org}`,
     owner: `github:${accountID}`,
-    org: "example-org",
+    org,
     login: "alice",
   };
 }
@@ -214,6 +214,59 @@ describe("GitHub user-token membership", () => {
   });
 
   it.each([
+    ["a missing org", "/operators"],
+    ["a missing slug", "example-org/"],
+    ["an extra path component", "example-org/operators/extra"],
+    ["only commas", ", ,"],
+    ["a valid selector mixed with an empty entry", "operators,"],
+    ["an invalid org token", "example_org/operators"],
+    ["an invalid team token", "example-org/operator!"],
+  ])("fails closed on allowed-team configuration with %s", async (_label, teams) => {
+    const env = testEnv({
+      CRABBOX_GITHUB_ALLOWED_TEAMS: teams,
+      CRABBOX_GITHUB_ALLOWED_TEAM: "fallback-team",
+    });
+    const token = await testToken(env);
+    const fetchMock = vi.fn<() => void>();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(authenticateRequest(tokenRequest(token), env)).resolves.toBeUndefined();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["an unset team policy", {}, []],
+    ["an empty plural policy", { CRABBOX_GITHUB_ALLOWED_TEAMS: "" }, []],
+    [
+      "an empty plural policy with singular fallback",
+      { CRABBOX_GITHUB_ALLOWED_TEAMS: "", CRABBOX_GITHUB_ALLOWED_TEAM: "operators" },
+      ["example-org/operators"],
+    ],
+    [
+      "a whitespace-only plural policy with singular fallback",
+      { CRABBOX_GITHUB_ALLOWED_TEAMS: " \t ", CRABBOX_GITHUB_ALLOWED_TEAM: "operators" },
+      ["example-org/operators"],
+    ],
+    [
+      "a singular-only policy",
+      { CRABBOX_GITHUB_ALLOWED_TEAM: "example-org/operators" },
+      ["example-org/operators"],
+    ],
+    [
+      "a configured plural policy taking precedence over singular",
+      {
+        CRABBOX_GITHUB_ALLOWED_TEAMS: "release-captains",
+        CRABBOX_GITHUB_ALLOWED_TEAM: "operators",
+      },
+      ["example-org/release-captains"],
+    ],
+  ])("normalizes %s", (_label, overrides, expectedTeams) => {
+    const policy = githubMembershipPolicy(teamIdentity(), testEnv(overrides));
+
+    expect(policy.allowedTeams).toEqual(expectedTeams);
+  });
+
+  it.each([
     [
       "a team qualified for another configured org",
       "example-org/operators,partner-org/contractors",
@@ -254,6 +307,113 @@ describe("GitHub user-token membership", () => {
     );
 
     await expect(requireFreshGitHubMembership(teamIdentity(), env)).resolves.toBeUndefined();
+  });
+
+  it.each(["example-org", "partner-org"])(
+    "binds a bare team slug to the selected organization %s",
+    (org) => {
+      const env = testEnv({
+        CRABBOX_GITHUB_ALLOWED_ORG: undefined,
+        CRABBOX_GITHUB_ALLOWED_ORGS: "example-org,partner-org",
+        CRABBOX_GITHUB_ALLOWED_TEAMS: "operators",
+      });
+
+      expect(githubMembershipPolicy(teamIdentity(org), env).allowedTeams).toEqual([
+        `${org}/operators`,
+      ]);
+    },
+  );
+
+  it("allows an org-qualified team only for that exact selected organization", async () => {
+    const env = testEnv({
+      CRABBOX_GITHUB_ALLOWED_ORG: undefined,
+      CRABBOX_GITHUB_ALLOWED_ORGS: "example-org,partner-org",
+      CRABBOX_GITHUB_ALLOWED_TEAMS: "partner-org/contractors",
+    });
+    const fetchMock = vi.fn<(input: RequestInfo | URL) => Promise<Response>>(async (input) => {
+      const url = String(input);
+      if (url === "https://api.github.com/user") return userResponse();
+      if (url === "https://api.github.com/user/memberships/orgs/partner-org") {
+        return membershipResponse("active", "partner-org");
+      }
+      if (url.includes("/user/teams")) {
+        return Response.json([{ slug: "contractors", organization: { login: "partner-org" } }]);
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(requireFreshGitHubMembership(teamIdentity("example-org"), env)).rejects.toThrow(
+      /no allowed team configured/,
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+    await expect(
+      requireFreshGitHubMembership(teamIdentity("partner-org"), env),
+    ).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not migrate a session to another allowed organization", async () => {
+    const env = testEnv({
+      CRABBOX_DEFAULT_ORG: "partner-org",
+      CRABBOX_GITHUB_ALLOWED_ORG: "partner-org",
+      CRABBOX_GITHUB_ALLOWED_TEAMS: "partner-org/contractors",
+    });
+    const fetchMock = vi.fn<() => void>();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(requireFreshGitHubMembership(teamIdentity("example-org"), env)).rejects.toThrow(
+      /no longer allowed/,
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("invalidates the ordinary membership cache when a valid team policy changes", async () => {
+    const env = testEnv({
+      CRABBOX_GITHUB_ALLOWED_TEAMS: "example-org/operators",
+      CRABBOX_GITHUB_MEMBERSHIP_CACHE_SECONDS: "300",
+    });
+    const token = await testToken(env);
+    const fetchMock = vi.fn<(input: RequestInfo | URL) => Promise<Response>>(async (input) => {
+      const url = String(input);
+      if (url === "https://api.github.com/user") return userResponse();
+      if (url.includes("/user/teams")) {
+        return Response.json([{ slug: "operators", organization: { login: "example-org" } }]);
+      }
+      return membershipResponse();
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(authenticateRequest(tokenRequest(token), env)).resolves.toMatchObject({
+      authorized: true,
+    });
+    env.CRABBOX_GITHUB_ALLOWED_TEAMS = "example-org/release-captains";
+    await expect(authenticateRequest(tokenRequest(token), env)).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(6);
+  });
+
+  it("rejects malformed team policy before consulting a warm ordinary cache", async () => {
+    const env = testEnv({
+      CRABBOX_GITHUB_ALLOWED_TEAMS: "example-org/operators",
+      CRABBOX_GITHUB_MEMBERSHIP_CACHE_SECONDS: "300",
+    });
+    const token = await testToken(env);
+    const fetchMock = vi.fn<(input: RequestInfo | URL) => Promise<Response>>(async (input) => {
+      const url = String(input);
+      if (url === "https://api.github.com/user") return userResponse();
+      if (url.includes("/user/teams")) {
+        return Response.json([{ slug: "operators", organization: { login: "example-org" } }]);
+      }
+      return membershipResponse();
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(authenticateRequest(tokenRequest(token), env)).resolves.toMatchObject({
+      authorized: true,
+    });
+    env.CRABBOX_GITHUB_ALLOWED_TEAMS = "operators,";
+    await expect(authenticateRequest(tokenRequest(token), env)).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 
   it.each([`github:${accountID}`, `owner:github:${accountID}`])(

--- a/worker/test/github-membership.test.ts
+++ b/worker/test/github-membership.test.ts
@@ -54,6 +54,22 @@ function membershipResponse(state = "active", org = "example-org"): Response {
   return Response.json({ state, organization: { login: org } });
 }
 
+function teamIdentity(): {
+  accessToken: string;
+  tokenID: string;
+  owner: string;
+  org: string;
+  login: string;
+} {
+  return {
+    accessToken,
+    tokenID: "team-scope-token",
+    owner: `github:${accountID}`,
+    org: "example-org",
+    login: "alice",
+  };
+}
+
 function membershipFetch(): ReturnType<typeof vi.fn> {
   return vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
     async (input, init) => {
@@ -195,6 +211,49 @@ describe("GitHub user-token membership", () => {
     );
 
     await expect(authenticateRequest(tokenRequest(token), env)).resolves.toBeUndefined();
+  });
+
+  it.each([
+    [
+      "a team qualified for another configured org",
+      "example-org/operators,partner-org/contractors",
+    ],
+    ["no team configured for the org being authorized", "partner-org/contractors"],
+  ])("fails closed on %s", async (_label, teams) => {
+    const env = testEnv({ CRABBOX_GITHUB_ALLOWED_TEAMS: teams });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<(input: RequestInfo | URL) => Promise<Response>>(async (input) => {
+        const url = String(input);
+        if (url === "https://api.github.com/user") return userResponse();
+        if (url.includes("/user/teams")) {
+          return Response.json([{ slug: "contractors", organization: { login: "partner-org" } }]);
+        }
+        return membershipResponse();
+      }),
+    );
+
+    await expect(requireFreshGitHubMembership(teamIdentity(), env)).rejects.toThrow(/example-org/);
+  });
+
+  it.each([
+    ["an org-qualified entry", "example-org/operators,partner-org/contractors"],
+    ["an unqualified entry resolved against the authorized org", "operators"],
+  ])("accepts a team membership matched by %s", async (_label, teams) => {
+    const env = testEnv({ CRABBOX_GITHUB_ALLOWED_TEAMS: teams });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<(input: RequestInfo | URL) => Promise<Response>>(async (input) => {
+        const url = String(input);
+        if (url === "https://api.github.com/user") return userResponse();
+        if (url.includes("/user/teams")) {
+          return Response.json([{ slug: "operators", organization: { login: "example-org" } }]);
+        }
+        return membershipResponse();
+      }),
+    );
+
+    await expect(requireFreshGitHubMembership(teamIdentity(), env)).resolves.toBeUndefined();
   });
 
   it.each([`github:${accountID}`, `owner:github:${accountID}`])(

--- a/worker/test/pairing.test.ts
+++ b/worker/test/pairing.test.ts
@@ -472,6 +472,44 @@ describe("coordinator device pairing", () => {
     expect(fixture.membershipChecks).toHaveBeenCalledTimes(2);
   });
 
+  it.each([
+    ["malformed", "operators,"],
+    ["qualified for another organization", "partner-org/contractors"],
+  ])("invalidates a warm device membership when policy becomes %s", async (_label, teams) => {
+    const fixture = await pairingFixture();
+    fixture.env.CRABBOX_GITHUB_ALLOWED_TEAMS = "example-org/operators";
+    const { token } = await fixture.pair();
+    fixture.membershipChecks.mockClear();
+
+    expect((await fixture.request("/v1/leases", deviceRequest(token))).status).toBe(200);
+    expect(fixture.membershipChecks).toHaveBeenCalledTimes(1);
+
+    fixture.env.CRABBOX_GITHUB_ALLOWED_TEAMS = teams;
+    const denied = await fixture.request("/v1/leases", deviceRequest(token));
+
+    expect(denied.status).toBe(401);
+    await expect(denied.json()).resolves.toEqual({ error: "device_owner_unauthorized" });
+    expect(fixture.membershipChecks).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reuse a warm device proof after changing valid team A to team B", async () => {
+    const fixture = await pairingFixture();
+    fixture.env.CRABBOX_GITHUB_ALLOWED_TEAMS = "example-org/operators";
+    const { token } = await fixture.pair();
+    fixture.membershipChecks.mockClear();
+
+    expect((await fixture.request("/v1/leases", deviceRequest(token))).status).toBe(200);
+    expect(fixture.membershipChecks).toHaveBeenCalledTimes(1);
+
+    fixture.env.CRABBOX_GITHUB_ALLOWED_TEAMS = "example-org/release-captains";
+    fixture.membershipAllowed.value = false;
+    const denied = await fixture.request("/v1/leases", deviceRequest(token));
+
+    expect(denied.status).toBe(401);
+    await expect(denied.json()).resolves.toEqual({ error: "device_owner_unauthorized" });
+    expect(fixture.membershipChecks).toHaveBeenCalledTimes(2);
+  });
+
   it("fails closed on a lookup error after a warm membership entry expires", async () => {
     vi.useFakeTimers({ now: new Date("2026-07-27T12:00:00Z") });
     const fixture = await pairingFixture();


### PR DESCRIPTION
Closes https://github.com/openclaw/crabbox/issues/1308.
Closes https://github.com/openclaw/crabbox/issues/1309.

## Summary

GitHub team admission had two related fail-open paths:

- malformed configured selectors were filtered away, so an all-invalid list disabled team enforcement;
- `/user/teams` spans every organization, so membership in a team from one organization could satisfy another organization's admission gate.

This PR now parses one normalized team policy before any cache lookup, rejects malformed nonblank selectors, scopes bare and qualified teams to the organization being authorized, and includes the normalized org/team policy in both ordinary membership and device authorization cache keys. A policy change therefore takes effect on the next request instead of reusing a warm proof.

## Compatibility

- Unset team configuration remains organization-only admission.
- Empty or whitespace-only plural configuration may fall back to the legacy singular variable.
- Valid bare team slugs continue to resolve against the selected organization.
- Multi-organization deployments must list at least one applicable team for each admitted organization when team restrictions are enabled.
- Revocation, account-ID binding, GitHub pagination, membership TTLs, and allowed-organization fallback behavior are unchanged.

## Verification

- focused GitHub membership and device-pairing suite: 72 passed, 1 skipped
- Worker formatting, lint, and TypeScript checks
- full Worker suite before rebase: 1,281 passed, 3 skipped
- Worker dry-run build
- documentation gate
- structured P1 autoreview: clean
