### PR TITLE
fix(worker): bound requested lease slugs to the provider name limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Made GitHub team authorization fail closed on malformed selectors, enforced same-org team scope, and invalidated membership and device proofs when the normalized policy changes. Thanks @dwin-gharibi.
+- Rejected invalid or overlong coordinator-requested lease slugs before provisioning while preserving exact fixed-ID replays created under the legacy length behavior. Thanks @dwin-gharibi.
 
 ## 0.41.5 - 2026-08-12
 

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -3352,6 +3352,18 @@ export class FleetCoordinator {
         return replay;
       }
     }
+    const requestedSlugInput = input.slug ?? input.requestedSlug;
+    let requestedSlug = normalizeLeaseSlug(requestedSlugInput);
+    let deferredSlugError: InvalidLeaseSlugError | undefined;
+    try {
+      requestedSlug = requestedLeaseSlug(requestedSlugInput);
+    } catch (error) {
+      if (!(error instanceof InvalidLeaseSlugError)) throw error;
+      if (error.reason === "empty" || !fixedLeaseID) {
+        return json({ error: "invalid_slug", message: error.message }, { status: 400 });
+      }
+      deferredSlugError = error;
+    }
     const defaults: LeaseConfigDefaults = { allowAzurePromotedImage: true };
     const azureImage = this.env.CRABBOX_AZURE_IMAGE?.trim();
     if (azureImage) defaults.azureImage = azureImage;
@@ -3359,10 +3371,8 @@ export class FleetCoordinator {
     if (azureWindowsARM64Image) defaults.azureWindowsARM64Image = azureWindowsARM64Image;
     if (this.env.CRABBOX_AZURE_OS_DISK) defaults.azureOSDisk = this.env.CRABBOX_AZURE_OS_DISK;
     let config: LeaseConfig;
-    let requestedSlug: string;
     try {
       config = leaseConfig(input, defaults);
-      requestedSlug = requestedLeaseSlug(input.slug ?? input.requestedSlug);
     } catch (error) {
       if (error instanceof InvalidAWSRegionError) {
         return json({ error: "invalid_region", message: error.message }, { status: 400 });
@@ -3372,9 +3382,6 @@ export class FleetCoordinator {
           { error: "invalid_image_requirements", message: error.message },
           { status: 400 },
         );
-      }
-      if (error instanceof InvalidLeaseSlugError) {
-        return json({ error: "invalid_slug", message: error.message }, { status: 400 });
       }
       throw error;
     }
@@ -3436,6 +3443,9 @@ export class FleetCoordinator {
       if (replay) {
         return replay;
       }
+    }
+    if (deferredSlugError) {
+      return json({ error: "invalid_slug", message: deferredSlugError.message }, { status: 400 });
     }
     const configProvider = this.provider(
       config.provider,
@@ -20969,7 +20979,7 @@ function boundedTelemetrySamples(samples: LeaseTelemetry[], max: number): LeaseT
 
 const fixedLeaseCreateIntentVersion = 2;
 
-async function fixedLeaseCreateIntentHash(
+export async function fixedLeaseCreateIntentHash(
   config: LeaseConfig,
   requestedSlug: string,
 ): Promise<string> {

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -226,7 +226,14 @@ import {
   type RuntimeAdapterRelayRequest,
   type RuntimeAdapterRelayResponse,
 } from "./runtime-adapter-relay";
-import { leaseSlugFromID, normalizeLeaseSlug, slugWithCollisionSuffix } from "./slug";
+import {
+  InvalidLeaseSlugError,
+  leaseSlugFromID,
+  maxRequestedLeaseSlugLength,
+  normalizeLeaseSlug,
+  requestedLeaseSlug,
+  slugWithCollisionSuffix,
+} from "./slug";
 import {
   createTailscaleAuthKey,
   renderTailscaleHostname,
@@ -3353,8 +3360,10 @@ export class FleetCoordinator {
     if (azureWindowsARM64Image) defaults.azureWindowsARM64Image = azureWindowsARM64Image;
     if (this.env.CRABBOX_AZURE_OS_DISK) defaults.azureOSDisk = this.env.CRABBOX_AZURE_OS_DISK;
     let config: LeaseConfig;
+    let requestedSlug: string;
     try {
       config = leaseConfig(input, defaults);
+      requestedSlug = requestedLeaseSlug(input.slug ?? input.requestedSlug);
     } catch (error) {
       if (error instanceof InvalidAWSRegionError) {
         return json({ error: "invalid_region", message: error.message }, { status: 400 });
@@ -3364,6 +3373,9 @@ export class FleetCoordinator {
           { error: "invalid_image_requirements", message: error.message },
           { status: 400 },
         );
+      }
+      if (error instanceof InvalidLeaseSlugError) {
+        return json({ error: "invalid_slug", message: error.message }, { status: 400 });
       }
       throw error;
     }
@@ -3410,10 +3422,7 @@ export class FleetCoordinator {
       if (!config.providerKey) {
         config = { ...config, providerKey: providerKeyForLease(fixedLeaseID) };
       }
-      fixedCreateIntentHash = await fixedLeaseCreateIntentHash(
-        config,
-        normalizeLeaseSlug(input.slug ?? input.requestedSlug),
-      );
+      fixedCreateIntentHash = await fixedLeaseCreateIntentHash(config, requestedSlug);
       const replay = await this.state.runExclusive(async () => {
         if (createAttemptBlocksLeaseID(await this.getCreateAttempt(fixedLeaseID))) {
           return createAttemptIDConflictResponse();
@@ -3872,7 +3881,7 @@ export class FleetCoordinator {
       const createAttemptGeneration = currentAttempt ? newCreateAttemptGeneration() : undefined;
       const admission = await this.leaseAdmissionState({ owner, org }, now);
       const slug = allocateLeaseSlug(
-        normalizeLeaseSlug(input.slug ?? input.requestedSlug) || leaseSlugFromID(leaseID),
+        requestedSlug || leaseSlugFromID(leaseID),
         leaseID,
         owner,
         org,
@@ -6540,6 +6549,12 @@ export class FleetCoordinator {
     }
     if (!host) {
       return json({ error: "host_required" }, { status: 400 });
+    }
+    if (normalizeLeaseSlug(input.slug).length > maxRequestedLeaseSlugLength) {
+      return json(
+        { error: "invalid_slug", message: new InvalidLeaseSlugError().message },
+        { status: 400 },
+      );
     }
     const runtimeAdapterID = input.runtimeAdapterID;
     const runtimeAdapterWorkspaceID = input.runtimeAdapterWorkspaceID;

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -229,7 +229,6 @@ import {
 import {
   InvalidLeaseSlugError,
   leaseSlugFromID,
-  maxRequestedLeaseSlugLength,
   normalizeLeaseSlug,
   requestedLeaseSlug,
   slugWithCollisionSuffix,
@@ -6550,12 +6549,10 @@ export class FleetCoordinator {
     if (!host) {
       return json({ error: "host_required" }, { status: 400 });
     }
-    if (normalizeLeaseSlug(input.slug).length > maxRequestedLeaseSlugLength) {
-      return json(
-        { error: "invalid_slug", message: new InvalidLeaseSlugError().message },
-        { status: 400 },
-      );
-    }
+    // No slug bound here on purpose. A registered lease records an already-provisioned
+    // external machine and never derives a provider resource name from the slug — the CLI
+    // sends the machine's existing `slug` label back (serverSlug in coordinator_registration.go).
+    // Rejecting a long one would break re-registering a machine that already exists.
     const runtimeAdapterID = input.runtimeAdapterID;
     const runtimeAdapterWorkspaceID = input.runtimeAdapterWorkspaceID;
     const runtimeAdapterRegistrationID = input.runtimeAdapterRegistrationID;

--- a/worker/src/slug.ts
+++ b/worker/src/slug.ts
@@ -24,6 +24,29 @@ export function leaseSlugFromID(leaseID: string): string {
   return `${adjective}-${noun}`;
 }
 
+/**
+ * Bounds a requested slug so `leaseProviderName` always fits a 63-character provider
+ * resource name: 41 + 5 (collision suffix) + 17 ("crabbox-", the separator, and the
+ * 8-hex lease hash) = 63. Mirrors maxRequestedLeaseSlugLength in internal/cli/slug.go.
+ */
+export const maxRequestedLeaseSlugLength = 41;
+
+export class InvalidLeaseSlugError extends Error {
+  constructor() {
+    super(`slug must be ${maxRequestedLeaseSlugLength} characters or fewer after normalization`);
+    this.name = "InvalidLeaseSlugError";
+  }
+}
+
+/** Validates a client-requested slug; normalization alone cannot bound length. */
+export function requestedLeaseSlug(value: string | undefined): string {
+  const slug = normalizeLeaseSlug(value);
+  if (slug.length > maxRequestedLeaseSlugLength) {
+    throw new InvalidLeaseSlugError();
+  }
+  return slug;
+}
+
 export function normalizeLeaseSlug(value: string | undefined): string {
   let out = "";
   let lastDash = false;
@@ -45,7 +68,11 @@ export function normalizeLeaseSlug(value: string | undefined): string {
 
 export function slugWithCollisionSuffix(base: string, seed: string): string {
   const normalized = normalizeLeaseSlug(base) || leaseSlugFromID(seed);
-  return `${normalized}-${(slugHash(seed) & 0xffff).toString(16).padStart(4, "0")}`;
+  const bounded =
+    normalized.length > maxRequestedLeaseSlugLength
+      ? trimDashes(normalized.slice(0, maxRequestedLeaseSlugLength))
+      : normalized;
+  return `${bounded}-${(slugHash(seed) & 0xffff).toString(16).padStart(4, "0")}`;
 }
 
 export function leaseProviderName(leaseID: string, slug: string | undefined): string {

--- a/worker/src/slug.ts
+++ b/worker/src/slug.ts
@@ -32,17 +32,28 @@ export function leaseSlugFromID(leaseID: string): string {
 export const maxRequestedLeaseSlugLength = 41;
 
 export class InvalidLeaseSlugError extends Error {
-  constructor() {
-    super(`slug must be ${maxRequestedLeaseSlugLength} characters or fewer after normalization`);
+  readonly reason: "empty" | "too_long";
+
+  constructor(reason: "empty" | "too_long") {
+    super(
+      reason === "empty"
+        ? "slug must contain at least one letter or digit"
+        : `slug must be ${maxRequestedLeaseSlugLength} characters or fewer after normalization`,
+    );
     this.name = "InvalidLeaseSlugError";
+    this.reason = reason;
   }
 }
 
 /** Validates a client-requested slug; normalization alone cannot bound length. */
 export function requestedLeaseSlug(value: string | undefined): string {
+  if (!value?.trim()) return "";
   const slug = normalizeLeaseSlug(value);
+  if (!slug) {
+    throw new InvalidLeaseSlugError("empty");
+  }
   if (slug.length > maxRequestedLeaseSlugLength) {
-    throw new InvalidLeaseSlugError();
+    throw new InvalidLeaseSlugError("too_long");
   }
   return slug;
 }

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -32083,6 +32083,28 @@ describe("fleet identity", () => {
     await expect(response.json()).resolves.toMatchObject({ error: "invalid_slug" });
   });
 
+  // A registered lease records an already-provisioned external machine and never derives a
+  // provider resource name, so the create-path bound must not reject its existing slug label.
+  it("registers an external lease whose existing slug exceeds the create bound", async () => {
+    const fleet = testFleet();
+    const longSlug = "a".repeat(64);
+    const response = await fleet.fetch(
+      request("PUT", "/v1/leases/cbx_0000000slug/registration", {
+        body: {
+          provider: "external",
+          target: "linux",
+          host: "203.0.113.10",
+          slug: longSlug,
+        },
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toMatchObject({
+      lease: { lifecycle: "registered", slug: longSlug },
+    });
+  });
+
   it("fails brokered Azure leases with provider_not_configured before constructing Azure", async () => {
     const fleet = testFleet();
     const response = await fleet.fetch(

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -32,6 +32,7 @@ import {
   codeForwardHeaders,
   codeResponseCookiePath,
   codeResponseHeaders,
+  fixedLeaseCreateIntentHash,
   flushPendingWebVNC,
   forwardOrBufferWebVNC,
   resetWebVNCBridge,
@@ -15564,6 +15565,60 @@ describe("fleet lease identity and idle", () => {
     expect(terminalReplay.status).toBe(409);
     await expect(terminalReplay.json()).resolves.toMatchObject({ error: "lease_id_conflict" });
     expect(creates).toBe(1);
+  });
+
+  it("replays only the identical legacy fixed intent with an overlong requested slug", async () => {
+    const storage = new MemoryStorage();
+    const create = vi.fn<(config: LeaseConfig) => void>();
+    const leaseID = "cbx_abcdef123472";
+    const longSlug = "legacy-" + "a".repeat(41);
+    const providerKey = "crabbox-cbx-abcdef123472";
+    const body = {
+      leaseID,
+      slug: longSlug,
+      provider: "azure" as const,
+      providerKey,
+      azureLocation: "eastus",
+      sshPublicKey: "ssh-ed25519 legacy-fixed-replay",
+    };
+    const config = leaseConfig(body, { allowAzurePromotedImage: true });
+    const intentHash = await fixedLeaseCreateIntentHash(config, longSlug);
+    storage.seed(
+      `lease:${leaseID}`,
+      testLease({
+        id: leaseID,
+        slug: longSlug,
+        provider: "azure",
+        providerKey,
+        cloudID: "vm-legacy-fixed-replay",
+        owner: "alice@example.com",
+        org: "example-org",
+        fixedCreateIntentVersion: 2,
+        fixedCreateIntentHash: intentHash,
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      }),
+    );
+    const fleet = testFleet(storage, { azure: fakeProvider(create, { provider: "azure" }) });
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+
+    const replay = await fleet.fetch(request("PUT", `/v1/leases/${leaseID}`, { headers, body }));
+    expect(replay.status).toBe(200);
+    await expect(replay.json()).resolves.toMatchObject({
+      lease: { id: leaseID, slug: longSlug, cloudID: "vm-legacy-fixed-replay" },
+    });
+
+    const drift = await fleet.fetch(
+      request("PUT", `/v1/leases/${leaseID}`, {
+        headers,
+        body: { ...body, class: "standard" },
+      }),
+    );
+    expect(drift.status).toBe(409);
+    await expect(drift.json()).resolves.toMatchObject({ error: "lease_id_conflict" });
+    expect(create).not.toHaveBeenCalled();
   });
 
   it("rejects fixed lease keep drift without another provider create", async () => {
@@ -32067,20 +32122,31 @@ describe("fleet identity", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("rejects a requested slug that would overflow the provider resource name", async () => {
-    const fleet = testFleet();
+  it.each([
+    { field: "slug", label: "slug", value: "a".repeat(42) },
+    { field: "requestedSlug", label: "requestedSlug alias", value: "a".repeat(42) },
+    { field: "slug", label: "punctuation-only slug", value: " !@#$%^&*() " },
+    {
+      field: "requestedSlug",
+      label: "punctuation-only requestedSlug alias",
+      value: " !@#$%^&*() ",
+    },
+  ] as const)("rejects a new $label before calling the provider", async ({ field, value }) => {
+    const create = vi.fn<(config: LeaseConfig) => void>();
+    const fleet = testFleet(undefined, { hetzner: fakeProvider(create) });
     const response = await fleet.fetch(
       request("POST", "/v1/leases", {
         body: {
           provider: "hetzner",
           sshPublicKey: "ssh-ed25519 test",
-          slug: "a".repeat(42),
+          [field]: value,
         },
       }),
     );
 
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toMatchObject({ error: "invalid_slug" });
+    expect(create).not.toHaveBeenCalled();
   });
 
   // A registered lease records an already-provisioned external machine and never derives a

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -32067,6 +32067,22 @@ describe("fleet identity", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("rejects a requested slug that would overflow the provider resource name", async () => {
+    const fleet = testFleet();
+    const response = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        body: {
+          provider: "hetzner",
+          sshPublicKey: "ssh-ed25519 test",
+          slug: "a".repeat(42),
+        },
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ error: "invalid_slug" });
+  });
+
   it("fails brokered Azure leases with provider_not_configured before constructing Azure", async () => {
     const fleet = testFleet();
     const response = await fleet.fetch(

--- a/worker/test/slug.test.ts
+++ b/worker/test/slug.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  InvalidLeaseSlugError,
   leaseProviderName,
   leaseSlugFromID,
+  maxRequestedLeaseSlugLength,
   normalizeLeaseSlug,
+  requestedLeaseSlug,
   slugWithCollisionSuffix,
 } from "../src/slug";
 
@@ -34,5 +37,33 @@ describe("lease slugs", () => {
       "crabbox-blue-lobster-c80c2195",
     );
     expect(leaseProviderName("cbx_abcdef123456", "")).toBe("crabbox-cbx-abcdef123456");
+  });
+
+  it("accepts a requested slug up to the provider-name bound", () => {
+    const longest = "a".repeat(maxRequestedLeaseSlugLength);
+    expect(requestedLeaseSlug(longest)).toBe(longest);
+    expect(requestedLeaseSlug(undefined)).toBe("");
+    // 8 ("crabbox-") + 41 + 1 + 8 (lease hash); the 5-char collision suffix fills it to 63.
+    expect(leaseProviderName("cbx_abcdef123456", longest).length).toBe(58);
+    expect(
+      leaseProviderName("cbx_abcdef123456", slugWithCollisionSuffix(longest, "cbx_abcdef123456"))
+        .length,
+    ).toBe(63);
+  });
+
+  it("rejects a requested slug longer than the provider-name bound", () => {
+    expect(() => requestedLeaseSlug("a".repeat(maxRequestedLeaseSlugLength + 1))).toThrow(
+      InvalidLeaseSlugError,
+    );
+    // Normalization collapses separators, so length is measured after normalizing.
+    expect(() => requestedLeaseSlug("A! ".repeat(maxRequestedLeaseSlugLength))).toThrow(
+      InvalidLeaseSlugError,
+    );
+  });
+
+  it("keeps collision suffixes inside the provider-name bound", () => {
+    const suffixed = slugWithCollisionSuffix("b".repeat(80), "cbx_abcdef123456");
+    expect(suffixed).toMatch(/^b{41}-[a-f0-9]{4}$/);
+    expect(leaseProviderName("cbx_abcdef123456", suffixed).length).toBeLessThanOrEqual(63);
   });
 });

--- a/worker/test/slug.test.ts
+++ b/worker/test/slug.test.ts
@@ -43,6 +43,7 @@ describe("lease slugs", () => {
     const longest = "a".repeat(maxRequestedLeaseSlugLength);
     expect(requestedLeaseSlug(longest)).toBe(longest);
     expect(requestedLeaseSlug(undefined)).toBe("");
+    expect(requestedLeaseSlug("   ")).toBe("");
     // 8 ("crabbox-") + 41 + 1 + 8 (lease hash); the 5-char collision suffix fills it to 63.
     expect(leaseProviderName("cbx_abcdef123456", longest).length).toBe(58);
     expect(
@@ -58,6 +59,12 @@ describe("lease slugs", () => {
     // Normalization collapses separators, so length is measured after normalizing.
     expect(() => requestedLeaseSlug("A! ".repeat(maxRequestedLeaseSlugLength))).toThrow(
       InvalidLeaseSlugError,
+    );
+  });
+
+  it("rejects a nonblank requested slug that normalizes to empty", () => {
+    expect(() => requestedLeaseSlug(" !@#$%^&*() ")).toThrow(
+      "slug must contain at least one letter or digit",
     );
   });
 


### PR DESCRIPTION
Closes https://github.com/openclaw/crabbox/issues/1310.

## Summary

The coordinator accepted unbounded caller-requested slugs and later embedded them in provider resource names. This PR mirrors the CLI's normalized 41-character budget at the Worker request boundary, keeps collision suffixes inside the 63-character provider-name limit, and rejects nonblank inputs that normalize to an empty slug.

The validation is deliberately compatibility-aware: a new overlong request is rejected before provider construction, but an exact fixed-ID replay of a lease created under the legacy behavior still returns the existing lease. Intent drift remains a conflict. Registered external machines keep their existing labels because registration does not derive a provider resource name from the slug.

## Verification

- focused slug/fleet regressions: 7 passed
- complete slug/fleet files before final rebase: 565 passed
- full Worker suite before final rebase: 1,265 passed, 3 skipped
- Worker formatting, lint, and TypeScript checks
- structured P1 full-branch autoreview: clean
