### PR TITLE
fix: keep remote sync finalization idempotent

### DIFF
--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -1945,7 +1945,11 @@ fi
 	if opts.HydrateGit && opts.BaseRef != "" {
 		refspec := "+refs/heads/" + opts.BaseRef + ":refs/remotes/origin/" + opts.BaseRef
 		script += `if exact_git_root && git remote get-url origin >/dev/null 2>&1; then
-  git fetch --quiet --unshallow origin ` + shellQuote(refspec) + ` || git fetch --quiet --depth=1000 origin ` + shellQuote(refspec) + ` || git fetch --quiet origin ` + shellQuote(refspec) + ` || git fetch --quiet origin ` + shellQuote(opts.BaseRef) + ` || true
+  if [ "$(git rev-parse --is-shallow-repository 2>/dev/null)" = true ]; then
+    git fetch --quiet --unshallow origin ` + shellQuote(refspec) + ` || git fetch --quiet --depth=1000 origin ` + shellQuote(refspec) + ` || git fetch --quiet origin ` + shellQuote(refspec) + ` || git fetch --quiet origin ` + shellQuote(opts.BaseRef) + ` || true
+  else
+    git fetch --quiet origin ` + shellQuote(refspec) + ` || git fetch --quiet origin ` + shellQuote(opts.BaseRef) + ` || true
+  fi
 fi
 `
 	}
@@ -2001,7 +2005,8 @@ else
     fi
     git update-ref -d "$tmp_ref" "$fetched_head" >/dev/null 2>&1 || true; rm -f "${index_backup:-}" "${index_candidate:-}" "${index_verify:-}" "${index_restore:-}"
     if [ -n "${index_lock:-}" ] && [ "$(cat "$index_lock" 2>/dev/null || true)" = "${index_marker:-}" ]; then rm -f "$index_lock"; fi
-    cleanup_finalize_lock; exit "$status"
+    # Bash 5.2 can corrupt function context when a successful EXIT handler re-exits.
+    cleanup_finalize_lock; trap - EXIT; if [ "$status" -ne 0 ]; then exit "$status"; fi
   }
   trap coherence_cleanup EXIT
   fetched_head="$(git rev-parse --verify "$tmp_ref^{commit}")"; old_head="$(git rev-parse --verify HEAD^{commit})"

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -1795,6 +1795,82 @@ func TestRemoteFinalizeSyncCommitsMetadataInOneCommand(t *testing.T) {
 	}
 }
 
+func TestRemoteFinalizeSyncHydratesForRepositoryDepth(t *testing.T) {
+	const finalizeToken = "0123456789abcdef0123456789abcdef"
+	fixture := newGitCoherenceFixture(t)
+	realGit := filepath.Join(gitOutput("", "--exec-path"), "git")
+	refspec := "+refs/heads/main:refs/remotes/origin/main"
+
+	tests := []struct {
+		name          string
+		shallow       bool
+		wantUnshallow bool
+	}{
+		{name: "complete", shallow: false, wantUnshallow: false},
+		{name: "shallow", shallow: true, wantUnshallow: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			workdir := filepath.Join(t.TempDir(), "work")
+			cloneArgs := []string{"clone", "--quiet"}
+			origin := fixture.origin
+			if tt.shallow {
+				cloneArgs = append(cloneArgs, "--depth=1")
+				origin = "file://" + filepath.ToSlash(origin)
+			}
+			cloneArgs = append(cloneArgs, origin, workdir)
+			if out, err := exec.Command("git", cloneArgs...).CombinedOutput(); err != nil {
+				t.Fatalf("clone workspace: %v\n%s", err, out)
+			}
+			if got := gitOutput(workdir, "rev-parse", "--is-shallow-repository"); got != strconv.FormatBool(tt.shallow) {
+				t.Fatalf("is-shallow-repository=%q, want %t", got, tt.shallow)
+			}
+			stageCoherenceFinalize(t, workdir, finalizeToken)
+
+			tools := t.TempDir()
+			fetchLog := filepath.Join(tools, "fetch.log")
+			gitScript := `#!/bin/sh
+if [ "$1" = fetch ]; then
+  printf '%s\n' "$*" >> "$CRABBOX_GIT_FETCH_LOG"
+fi
+exec ` + shellQuote(realGit) + ` "$@"
+`
+			if err := os.WriteFile(filepath.Join(tools, "git"), []byte(gitScript), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			envFile := filepath.Join(tools, "env")
+			if err := os.WriteFile(envFile, []byte("export PATH="+shellQuote(tools)+":\"$PATH\"\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			cmd := exec.Command("bash", "-lc", remoteFinalizeSync(workdir, remoteSyncFinalizeOptions{
+				HydrateGit: true,
+				BaseRef:    "main",
+				Token:      finalizeToken,
+			}))
+			cmd.Env = append(os.Environ(), "BASH_ENV="+envFile, "CRABBOX_GIT_FETCH_LOG="+fetchLog)
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("remote finalize: %v\n%s", err, out)
+			}
+			fetches, err := os.ReadFile(fetchLog)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := string(fetches)
+			if strings.Contains(got, "--unshallow") != tt.wantUnshallow {
+				t.Fatalf("fetch log unshallow=%t, want %t: %q", strings.Contains(got, "--unshallow"), tt.wantUnshallow, got)
+			}
+			wantFetch := "fetch --quiet origin " + refspec
+			if tt.shallow {
+				wantFetch = "fetch --quiet --unshallow origin " + refspec
+			}
+			if !strings.Contains(got, wantFetch) {
+				t.Fatalf("fetch log missing requested refspec: %q", got)
+			}
+		})
+	}
+}
+
 func TestRemoteFinalizeSyncRetriesAfterAmbiguousTransportFailure(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell ssh fixture")
@@ -2405,6 +2481,15 @@ func requireGitOutput(t *testing.T, workdir, want string, args ...string) {
 		t.Fatalf("git %v=%q want %q", args, got, want)
 	}
 }
+
+func TestRemoteGitCoherenceCleanupAvoidsSuccessfulReexit(t *testing.T) {
+	script := remoteGitCoherenceFinalizeScript(gitCoherencePlan{}, "")
+	want := `cleanup_finalize_lock; trap - EXIT; if [ "$status" -ne 0 ]; then exit "$status"; fi`
+	if !strings.Contains(script, want) {
+		t.Fatalf("coherence cleanup does not avoid re-exiting after successful teardown:\n%s", script)
+	}
+}
+
 func TestRemoteGitCoherenceRepairsReuseBeforeFingerprintSkip(t *testing.T) {
 	f := newGitCoherenceFixture(t)
 	workdir := f.workspace(t, f.a, true)

--- a/internal/cli/workspace_owner.go
+++ b/internal/cli/workspace_owner.go
@@ -680,8 +680,10 @@ gate_status=$?
 set -e
 if [ "$gate_status" -ne 0 ]; then kill "$child_pid" 2>/dev/null || true; rm -rf "$run_dir"; exit "$gate_status"; fi
 touch "$start"
+set +e
 wait "$child_pid"
 code=$?
+set -e
 set +e
 run_owner_gate ` + shellQuote(clearBody) + `
 clear_status=$?

--- a/internal/cli/workspace_owner_test.go
+++ b/internal/cli/workspace_owner_test.go
@@ -500,6 +500,24 @@ func TestWorkspaceOwnerPOSIXProtocolBehavior(t *testing.T) {
 	if data, err := os.ReadFile(inputPath); err != nil || string(data) != "registration-input" {
 		t.Fatalf("witnessed input=%q err=%v", data, err)
 	}
+	const childExitCode = 42
+	if out, err := runPOSIXWorkspaceOwnerScript(t, home, remoteWorkspaceOwnerPOSIXWitness(key, tokenA, "exit "+strconv.Itoa(childExitCode))); err == nil {
+		t.Fatalf("nonzero witnessed command succeeded: out=%q", out)
+	} else if exitErr, ok := err.(*exec.ExitError); !ok || exitErr.ExitCode() != childExitCode {
+		t.Fatalf("nonzero witnessed command out=%q err=%v, want exit code %d", out, err, childExitCode)
+	}
+	for _, path := range []string{childPath, filepath.Join(home, ".crabbox", "workspace-owners", key+".run."+tokenA)} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("nonzero witnessed command left run state %q: %v", path, err)
+		}
+	}
+	laterResultPath := filepath.Join(home, "after-nonzero.txt")
+	if out, err := runPOSIXWorkspaceOwnerScript(t, home, remoteWorkspaceOwnerPOSIXWitness(key, tokenA, "touch "+shellQuote(laterResultPath))); err != nil {
+		t.Fatalf("witness after nonzero child out=%q err=%v", out, err)
+	}
+	if _, err := os.Stat(laterResultPath); err != nil {
+		t.Fatalf("command after nonzero child did not proceed: %v", err)
+	}
 	identityOut, err := exec.Command("ps", "-o", "lstart=", "-p", strconv.Itoa(os.Getpid())).Output()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where remote sync from a complete checkout could fail before command execution because finalization always requested `--unshallow`. Bash 5.2 cleanup paths could also mask the real command outcome.

## Why This Change Was Made

Branch fetch behavior on Git's authoritative shallow-repository state, preserve nonzero child status through workspace-owner cleanup, and avoid an explicit successful re-exit from coherence EXIT cleanup.

## User Impact

Sparse and full checkout sync is repeatable, failed commands retain their exact status, and complete repositories reach remote command execution.

## Evidence

- `go test ./internal/cli -run '^(TestRemoteFinalizeSync|TestRemoteGitCoherence|TestWorkspaceOwnerPOSIXProtocolBehavior)' -count=1`
- Before the fix, the complete-repository regression failed because the fetch log contained `--unshallow` and the `--depth=1000` fallback.
- Daytona changed-gate remote proof passed: provider `daytona`, run [`run_d3bcef781c3c`](https://crabbox.openclaw.ai/portal/runs/run_d3bcef781c3c), released lease `cbx_3198facdad67`. Sync finalized, the remote changed-gate command executed, and the tooling lane exited 0.
- Codex autoreview completed cleanly with no actionable findings.
