### PR TITLE
fix(cli): derive macOS work root from effective SSH user

### DIFF
--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -51,7 +51,10 @@ func normalizeTargetConfig(cfg *Config) {
 		}
 	}
 	if shouldDeriveTargetWorkRoot(cfg) {
-		cfg.WorkRoot = defaultWorkRootForTarget(cfg.TargetOS, cfg.WindowsMode)
+		// Derive after static/aws user defaults so macOS work roots follow
+		// the effective SSH user (e.g. -static-user), not a hardcoded
+		// ec2-user path that may not exist on the host.
+		cfg.WorkRoot = defaultWorkRootForTarget(cfg.TargetOS, cfg.WindowsMode, cfg.SSHUser)
 	}
 	if isStaticProvider(cfg.Provider) {
 		if cfg.Static.Port != "" && cfg.SSHPort == baseConfig().SSHPort {
@@ -85,11 +88,13 @@ func shouldDeriveTargetWorkRoot(cfg *Config) bool {
 }
 
 func isDefaultWorkRoot(value string) bool {
+	value = strings.TrimSpace(value)
 	switch value {
-	case "", defaultPOSIXWorkRoot, defaultMacOSWorkRoot, defaultWindowsWorkRoot:
+	case "", defaultPOSIXWorkRoot, defaultWindowsWorkRoot:
 		return true
 	default:
-		return false
+		// macOS defaults are user-specific (/Users/<user>/crabbox).
+		return isDefaultMacOSWorkRoot(value)
 	}
 }
 
@@ -97,9 +102,34 @@ func IsDefaultWorkRoot(value string) bool {
 	return isDefaultWorkRoot(value)
 }
 
-func defaultWorkRootForTarget(targetOS, windowsMode string) string {
+// isDefaultMacOSWorkRoot reports whether value is a platform-default macOS
+// work root of the form /Users/<single-segment-user>/crabbox.
+func isDefaultMacOSWorkRoot(value string) bool {
+	const prefix = "/Users/"
+	const suffix = "/crabbox"
+	if !strings.HasPrefix(value, prefix) || !strings.HasSuffix(value, suffix) {
+		return false
+	}
+	user := strings.TrimSuffix(strings.TrimPrefix(value, prefix), suffix)
+	return user != "" && user != "." && user != ".." && !strings.Contains(user, "/")
+}
+
+func defaultMacOSWorkRootForUser(sshUser string) string {
+	user := strings.TrimSpace(sshUser)
+	if user == "" {
+		user = "ec2-user"
+	}
+	// path.Base collapses odd input (slashes, trailing segments) to one name.
+	user = path.Base(user)
+	if user == "." || user == ".." || user == string(os.PathSeparator) {
+		user = "ec2-user"
+	}
+	return "/Users/" + user + "/crabbox"
+}
+
+func defaultWorkRootForTarget(targetOS, windowsMode, sshUser string) string {
 	if targetOS == targetMacOS {
-		return defaultMacOSWorkRoot
+		return defaultMacOSWorkRootForUser(sshUser)
 	}
 	if targetOS == targetWindows && windowsMode == windowsModeNormal {
 		return defaultWindowsWorkRoot

--- a/internal/cli/target_test.go
+++ b/internal/cli/target_test.go
@@ -467,6 +467,73 @@ func TestNormalizeTargetConfigForcesAWSMacOSLaunchdSSHPort(t *testing.T) {
 	}
 }
 
+func TestNormalizeTargetConfigStaticMacOSWorkRootFollowsStaticUser(t *testing.T) {
+	// Regression for openclaw/crabbox#1302: ssh/static macOS defaults used a
+	// hardcoded /Users/ec2-user/crabbox work root even when -static-user set a
+	// different account, so sync mkdir failed on real hosts.
+	cfg := baseConfig()
+	cfg.Provider = staticProvider
+	cfg.TargetOS = targetMacOS
+	cfg.Static.User = "alice"
+	cfg.WorkRoot = ""
+
+	normalizeTargetConfig(&cfg)
+
+	wantRoot := "/Users/alice/crabbox"
+	if cfg.SSHUser != "alice" {
+		t.Fatalf("SSHUser=%q want alice", cfg.SSHUser)
+	}
+	if cfg.WorkRoot != wantRoot {
+		t.Fatalf("WorkRoot=%q want %q", cfg.WorkRoot, wantRoot)
+	}
+}
+
+func TestNormalizeTargetConfigStaticMacOSWorkRootKeepsExplicitStaticWorkRoot(t *testing.T) {
+	cfg := baseConfig()
+	cfg.Provider = staticProvider
+	cfg.TargetOS = targetMacOS
+	cfg.Static.User = "alice"
+	cfg.Static.WorkRoot = "/Users/alice/custom-runs"
+	cfg.WorkRoot = ""
+
+	normalizeTargetConfig(&cfg)
+
+	if cfg.WorkRoot != "/Users/alice/custom-runs" {
+		t.Fatalf("WorkRoot=%q want explicit static work root", cfg.WorkRoot)
+	}
+}
+
+func TestNormalizeTargetConfigAWSMacOSWorkRootStaysEc2UserDefault(t *testing.T) {
+	cfg := baseConfig()
+	cfg.Provider = "aws"
+	cfg.TargetOS = targetMacOS
+	cfg.WorkRoot = ""
+
+	normalizeTargetConfig(&cfg)
+
+	if cfg.SSHUser != "ec2-user" {
+		t.Fatalf("SSHUser=%q want ec2-user", cfg.SSHUser)
+	}
+	if cfg.WorkRoot != defaultMacOSWorkRoot {
+		t.Fatalf("WorkRoot=%q want %q", cfg.WorkRoot, defaultMacOSWorkRoot)
+	}
+}
+
+func TestIsDefaultWorkRootRecognizesUserSpecificMacOSDefaults(t *testing.T) {
+	if !isDefaultWorkRoot("/Users/builder/crabbox") {
+		t.Fatal("expected /Users/builder/crabbox to count as a default macOS work root")
+	}
+	if !isDefaultWorkRoot(defaultMacOSWorkRoot) {
+		t.Fatal("expected legacy ec2-user default to remain a default work root")
+	}
+	if isDefaultWorkRoot("/Users/builder/custom") {
+		t.Fatal("non-crabbox user path must not count as a default")
+	}
+	if isDefaultWorkRoot("/Users/alice/nested/crabbox") {
+		t.Fatal("multi-segment user path must not count as a default")
+	}
+}
+
 func TestNormalizeTargetConfigUsesSealosWorkRoot(t *testing.T) {
 	cfg := baseConfig()
 	cfg.Provider = "sealos-devbox"


### PR DESCRIPTION
## What problem this solves

For `provider=ssh` / static macOS targets, `-static-user` correctly became the SSH login, but the default work root stayed hardcoded as `/Users/ec2-user/crabbox`. On non-EC2 hosts that path often does not exist or is not writable, so sync fails immediately with `mkdir: /Users/ec2-user: Permission denied` (exit 7).

Closes #1302

## Change

- Derive the macOS default work root as `/Users/<effective-ssh-user>/crabbox` (same shape as the worker default).
- Apply derivation after static/AWS user defaults so `-static-user` is visible.
- Treat any `/Users/<user>/crabbox` path as a platform default so re-derivation stays correct when the user changes.
- Keep AWS EC2 Mac default as `ec2-user` → `/Users/ec2-user/crabbox`.

## Evidence

### Red (main tree + new regression test)

```text
--- FAIL: TestNormalizeTargetConfigStaticMacOSWorkRootFollowsStaticUser (0.00s)
    target_test.go:487: WorkRoot="/Users/ec2-user/crabbox" want "/Users/alice/crabbox"
FAIL
```

### Green (this branch)

```text
=== RUN   TestNormalizeTargetConfigStaticMacOSWorkRootFollowsStaticUser
--- PASS: TestNormalizeTargetConfigStaticMacOSWorkRootFollowsStaticUser (0.00s)
PASS
ok  github.com/openclaw/crabbox/internal/cli
```

### Real behavior proof

**Environment:** local Go test on macOS arm64, package `github.com/openclaw/crabbox/internal/cli`, head of this branch vs `upstream/main` for the product file.

**Command / scenario:**

```bash
# Config shape from the issue: static ssh + macos + -static-user alice, no -static-work-root
cfg.Provider = "ssh"           # static provider
cfg.TargetOS = "macos"
cfg.Static.User = "alice"
cfg.WorkRoot = ""
normalizeTargetConfig(&cfg)
```

**Before (main `defaultWorkRootForTarget` ignores SSH user):**

```text
SSHUser=alice
WorkRoot=/Users/ec2-user/crabbox   # wrong: would mkdir under missing/unwritable home
```

**After (this PR):**

```text
SSHUser=alice
WorkRoot=/Users/alice/crabbox      # matches -static-user; sync can mkdir under the real home
```

AWS macOS managed path still defaults to `ec2-user` + `/Users/ec2-user/crabbox`. Explicit `-static-work-root` still wins.

## Tests

```bash
go test ./internal/cli/ -count=1 -run 'TestNormalizeTargetConfigStaticMacOS|TestNormalizeTargetConfigAWSMacOS|TestIsDefaultWorkRoot|TestNormalizeTargetConfig'
```