### PR TITLE
fix(static): derive macOS work root from SSH user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Bound valid caller-declared artifact SHA-256 digests into signed broker upload grants, rejected malformed nonblank digests instead of silently disabling integrity checks, and made object storage reject mismatching payloads. Thanks @dwin-gharibi.
 - Preserved pinned AWS SSH ingress and dynamic CIDRs from the other IP family when broker heartbeats refresh access, while replacing obsolete same-family dynamic sources. Thanks @jalehman.
 - Made `cache stats --json` emit an empty array for empty inventories while live smoke accepts legacy null and object reports but rejects other scalar shapes before workloads. Thanks @excelsier.
+- Derived implicit Static SSH macOS work roots from the resolved SSH user while preserving explicit roots and EC2 Mac defaults. Thanks @osouthgate.
 
 ## 0.41.5 - 2026-08-12
 

--- a/docs/providers/ssh.md
+++ b/docs/providers/ssh.md
@@ -83,6 +83,10 @@ static:
   workRoot: /Users/alice/crabbox
 ```
 
+When no generic or `static.workRoot` override is configured, a macOS target
+uses `/Users/<resolved-user>/crabbox`, where `<resolved-user>` is the final SSH
+user after applying `ssh.user` and `static.user` precedence.
+
 ### Windows (native)
 
 ```yaml

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -51,7 +51,11 @@ func normalizeTargetConfig(cfg *Config) {
 		}
 	}
 	if shouldDeriveTargetWorkRoot(cfg) {
-		cfg.WorkRoot = defaultWorkRootForTarget(cfg.TargetOS, cfg.WindowsMode)
+		if isStaticProvider(cfg.Provider) && cfg.TargetOS == targetMacOS {
+			cfg.WorkRoot = path.Join("/Users", cfg.SSHUser, "crabbox")
+		} else {
+			cfg.WorkRoot = defaultWorkRootForTarget(cfg.TargetOS, cfg.WindowsMode)
+		}
 	}
 	if isStaticProvider(cfg.Provider) {
 		if cfg.Static.Port != "" && cfg.SSHPort == baseConfig().SSHPort {

--- a/internal/cli/target_test.go
+++ b/internal/cli/target_test.go
@@ -467,6 +467,118 @@ func TestNormalizeTargetConfigForcesAWSMacOSLaunchdSSHPort(t *testing.T) {
 	}
 }
 
+func TestNormalizeTargetConfigWorkRoots(t *testing.T) {
+	tests := []struct {
+		name      string
+		configure func(*Config)
+		wantUser  string
+		wantRoot  string
+	}{
+		{
+			name: "static macOS uses static user",
+			configure: func(cfg *Config) {
+				cfg.Provider = staticProvider
+				cfg.TargetOS = targetMacOS
+				cfg.Static.User = "alice"
+			},
+			wantUser: "alice",
+			wantRoot: "/Users/alice/crabbox",
+		},
+		{
+			name: "static macOS uses explicit SSH user",
+			configure: func(cfg *Config) {
+				cfg.Provider = staticProvider
+				cfg.TargetOS = targetMacOS
+				cfg.Static.User = "alice"
+				cfg.SSHUser = "builder"
+				MarkSSHUserExplicit(cfg)
+			},
+			wantUser: "builder",
+			wantRoot: "/Users/builder/crabbox",
+		},
+		{
+			name: "static macOS preserves static work root",
+			configure: func(cfg *Config) {
+				cfg.Provider = staticProvider
+				cfg.TargetOS = targetMacOS
+				cfg.Static.User = "alice"
+				cfg.Static.WorkRoot = "/Volumes/build/crabbox"
+			},
+			wantUser: "alice",
+			wantRoot: "/Volumes/build/crabbox",
+		},
+		{
+			name: "static macOS preserves generic work root",
+			configure: func(cfg *Config) {
+				cfg.Provider = staticProvider
+				cfg.TargetOS = targetMacOS
+				cfg.Static.User = "alice"
+				cfg.WorkRoot = "/srv/crabbox"
+				MarkWorkRootExplicit(cfg)
+			},
+			wantUser: "alice",
+			wantRoot: "/srv/crabbox",
+		},
+		{
+			name: "AWS macOS keeps EC2 Mac default",
+			configure: func(cfg *Config) {
+				cfg.Provider = "aws"
+				cfg.TargetOS = targetMacOS
+			},
+			wantUser: "ec2-user",
+			wantRoot: defaultMacOSWorkRoot,
+		},
+		{
+			name: "static Linux keeps POSIX default",
+			configure: func(cfg *Config) {
+				cfg.Provider = staticProvider
+				cfg.TargetOS = targetLinux
+				cfg.Static.User = "alice"
+			},
+			wantUser: "alice",
+			wantRoot: defaultPOSIXWorkRoot,
+		},
+		{
+			name: "static native Windows keeps Windows default",
+			configure: func(cfg *Config) {
+				cfg.Provider = staticProvider
+				cfg.TargetOS = targetWindows
+				cfg.WindowsMode = windowsModeNormal
+				cfg.Static.User = "alice"
+			},
+			wantUser: "alice",
+			wantRoot: defaultWindowsWorkRoot,
+		},
+		{
+			name: "static WSL2 keeps POSIX default",
+			configure: func(cfg *Config) {
+				cfg.Provider = staticProvider
+				cfg.TargetOS = targetWindows
+				cfg.WindowsMode = windowsModeWSL2
+				cfg.Static.User = "alice"
+			},
+			wantUser: "alice",
+			wantRoot: defaultPOSIXWorkRoot,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := baseConfig()
+			tt.configure(&cfg)
+
+			normalizeTargetConfig(&cfg)
+
+			if cfg.SSHUser != tt.wantUser {
+				t.Fatalf("SSHUser=%q want %q", cfg.SSHUser, tt.wantUser)
+			}
+			if cfg.WorkRoot != tt.wantRoot {
+				t.Fatalf("WorkRoot=%q want %q", cfg.WorkRoot, tt.wantRoot)
+			}
+		})
+	}
+}
+
 func TestNormalizeTargetConfigUsesSealosWorkRoot(t *testing.T) {
 	cfg := baseConfig()
 	cfg.Provider = "sealos-devbox"


### PR DESCRIPTION
Closes https://github.com/openclaw/crabbox/issues/1302.

## Summary

Static SSH normalization applied `static.user` to the SSH connection, but an implicit macOS work root still used the AWS EC2-Mac default `/Users/ec2-user/crabbox`. A static target configured with another user could therefore sync into the wrong or unwritable home directory.

This change derives only an implicit Static SSH macOS root from the final resolved SSH user: `/Users/<user>/crabbox`. Explicit generic and `static.workRoot` values retain their existing precedence. AWS macOS continues using the EC2-Mac user/root and port-22 behavior; Linux, native Windows, and WSL2 defaults are unchanged.

## Verification

- table-driven target normalization regressions
- full `internal/cli` package before final rebase
- `go vet ./...`
- structured P1 branch autoreview: clean
