### PR TITLE
fix(proof): report explicit stream captures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Preserved pinned AWS SSH ingress and dynamic CIDRs from the other IP family when broker heartbeats refresh access, while replacing obsolete same-family dynamic sources. Thanks @jalehman.
 - Made `cache stats --json` emit an empty array for empty inventories while live smoke accepts legacy null and object reports but rejects other scalar shapes before workloads. Thanks @excelsier.
 - Derived implicit Static SSH macOS work roots from the resolved SSH user while preserving explicit roots and EC2 Mac defaults. Thanks @osouthgate.
+- Reported explicit stdout and stderr capture paths and byte counts in emitted run proofs without reading or embedding captured content. Thanks @coygeek.
 
 ## 0.41.5 - 2026-08-12
 

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -450,7 +450,10 @@ Use `--capture-stdout <path>` when stdout is binary or terminal-hostile. Crabbox
 writes the remote stdout bytes directly to the local file, leaves stderr on the
 terminal, and skips stdout run-log/event capture. `--capture-stderr <path>`
 works the same way for stderr. Both are SSH-run-only; delegated providers reject
-them.
+them. When `--emit-proof` is also set, the proof includes the safely escaped
+local capture path and final byte count for each redirected stream, but never
+reads or embeds the captured bytes. Any other live console output remains in
+the proof's redacted tail excerpt.
 
 When the remote command exits non-zero, Crabbox writes a local-only
 `.crabbox/captures/*.tar.gz` failure bundle by default. SSH-backed bundles

--- a/internal/cli/profiles_test.go
+++ b/internal/cli/profiles_test.go
@@ -515,6 +515,68 @@ func TestRenderRunProofUsesSafeMarkdownFence(t *testing.T) {
 	}
 }
 
+func TestRenderRunProofIncludesCaptureMetadataWithoutCapturedContent(t *testing.T) {
+	unsafePath := "captures/stdout`\n# forged heading\x1b.md"
+	got, err := renderRunProof(proofRenderInput{
+		Provider:   "aws",
+		LeaseID:    "cbx_123",
+		Command:    "make test",
+		LogExcerpt: "live stderr remains",
+		Captures: []streamCaptureMetadata{
+			{Label: "stdout", Path: unsafePath, Bytes: 19},
+			{Label: "stderr", Path: "captures/stderr.bin", Bytes: 7},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"live stderr remains",
+		`captured stream=stdout path="captures/stdout\x60\x0a\x23 forged heading\x1b.md" bytes=19`,
+		`captured stream=stderr path="captures/stderr.bin" bytes=7`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("proof missing %q:\n%s", want, got)
+		}
+	}
+	for _, forbidden := range []string{"stdout`", "\n# forged heading", "\x1b"} {
+		if strings.Contains(got, forbidden) {
+			t.Fatalf("proof contains unsafe capture path fragment %q:\n%s", forbidden, got)
+		}
+	}
+}
+
+func TestRenderRunProofUsesCaptureMetadataInsteadOfNoOutputSentinel(t *testing.T) {
+	got, err := renderRunProof(proofRenderInput{
+		LogExcerpt: "(no console output captured)",
+		Captures: []streamCaptureMetadata{
+			{Label: "stdout", Path: "/tmp/stdout.bin", Bytes: 0},
+			{Label: "stderr", Path: "/tmp/stderr.bin", Bytes: 12},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	stdout := `captured stream=stdout path="/tmp/stdout.bin" bytes=0`
+	stderr := `captured stream=stderr path="/tmp/stderr.bin" bytes=12`
+	if !strings.Contains(got, stdout+"\n"+stderr) {
+		t.Fatalf("capture metadata order is not deterministic:\n%s", got)
+	}
+	if strings.Contains(got, "(no console output captured)") {
+		t.Fatalf("proof kept no-output sentinel with explicit captures:\n%s", got)
+	}
+}
+
+func TestRenderRunProofKeepsNoOutputSentinelWithoutCaptures(t *testing.T) {
+	got, err := renderRunProof(proofRenderInput{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "(no console output captured)") {
+		t.Fatalf("proof lost no-output sentinel:\n%s", got)
+	}
+}
+
 func TestSelectProofLogExcerptStripsTerminalControl(t *testing.T) {
 	got := selectProofLogExcerpt("\x1b[2KWaiting for testbox... queued\r\x1b[2KTestbox ready!\nblacksmith-proof-live-ok\n")
 	for _, want := range []string{"Waiting for testbox... queued", "Testbox ready!", "blacksmith-proof-live-ok"} {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1908,6 +1908,7 @@ afterSync:
 			RunID:       executionRunID,
 			Command:     commandDisplay,
 			LogExcerpt:  selectProofLogExcerpt(logBuffer.String()),
+			Captures:    streamCaptures.metadata(),
 			ActionsURL:  actionsURL,
 			Artifacts:   runArtifacts,
 			Variables:   expansion.Variables,

--- a/internal/cli/run_artifacts.go
+++ b/internal/cli/run_artifacts.go
@@ -314,6 +314,7 @@ type proofRenderInput struct {
 	RunID       string
 	Command     string
 	LogExcerpt  string
+	Captures    []streamCaptureMetadata
 	ActionsURL  string
 	Artifacts   []runArtifact
 	Variables   map[string]string
@@ -339,6 +340,7 @@ func writeRunProof(path, templateName string, input proofRenderInput) (runArtifa
 }
 
 func renderRunProof(input proofRenderInput) (string, error) {
+	input.LogExcerpt = proofConsoleEvidence(input.LogExcerpt, input.Captures)
 	values := proofTemplateValues(input)
 	tmpl := input.Template
 	behavior, err := renderProofTemplateField("behaviorAddressed", tmpl.BehaviorAddressed, "Remote behavior exercised by the Crabbox command.", values)
@@ -392,6 +394,43 @@ func renderRunProof(input proofRenderInput) (string, error) {
 	}
 	b.WriteString("What was not tested: " + notTested + "\n")
 	return b.String(), nil
+}
+
+func proofConsoleEvidence(logExcerpt string, captures []streamCaptureMetadata) string {
+	logExcerpt = strings.TrimSpace(logExcerpt)
+	if len(captures) == 0 {
+		if logExcerpt == "" {
+			return "(no console output captured)"
+		}
+		return logExcerpt
+	}
+	if logExcerpt == "(no console output captured)" {
+		logExcerpt = ""
+	}
+	lines := make([]string, 0, len(captures)+1)
+	if logExcerpt != "" {
+		lines = append(lines, logExcerpt)
+	}
+	for _, capture := range captures {
+		lines = append(lines, fmt.Sprintf("captured stream=%s path=%s bytes=%d", capture.Label, quoteProofCapturePath(capture.Path), capture.Bytes))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func quoteProofCapturePath(path string) string {
+	const safe = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789/.- "
+	var b strings.Builder
+	b.Grow(len(path) + 2)
+	b.WriteByte('"')
+	for _, value := range []byte(path) {
+		if strings.IndexByte(safe, value) >= 0 {
+			b.WriteByte(value)
+			continue
+		}
+		fmt.Fprintf(&b, "\\x%02x", value)
+	}
+	b.WriteByte('"')
+	return b.String()
 }
 
 func proofTemplateValues(input proofRenderInput) map[string]string {

--- a/internal/cli/run_capture.go
+++ b/internal/cli/run_capture.go
@@ -20,6 +20,14 @@ type failureStreamCapture struct {
 	bundlePath    string
 	bundleCleanup func()
 	capture       *countingWriteCloser
+	captureBytes  int64
+	captureClosed bool
+}
+
+type streamCaptureMetadata struct {
+	Label string
+	Path  string
+	Bytes int64
 }
 
 func openFailureStreamCaptures(stdoutPath, stderrPath string) (*failureStreamCaptures, error) {
@@ -98,6 +106,27 @@ func (c *failureStreamCaptures) closeAfterStream(streamErr error, code int, stat
 	return c.stderr.closeAfterStream(streamErr, code, status)
 }
 
+func (c *failureStreamCaptures) metadata() []streamCaptureMetadata {
+	if c == nil {
+		return nil
+	}
+	metadata := make([]streamCaptureMetadata, 0, 2)
+	if stdout, ok := c.stdout.metadata(); ok {
+		metadata = append(metadata, stdout)
+	}
+	if stderr, ok := c.stderr.metadata(); ok {
+		metadata = append(metadata, stderr)
+	}
+	return metadata
+}
+
+func (c *failureStreamCapture) metadata() (streamCaptureMetadata, bool) {
+	if c == nil || c.explicitPath == "" || !c.captureClosed {
+		return streamCaptureMetadata{}, false
+	}
+	return streamCaptureMetadata{Label: c.label, Path: c.explicitPath, Bytes: c.captureBytes}, true
+}
+
 func (c *failureStreamCapture) closeAfterStream(streamErr error, code int, status io.Writer) error {
 	if c == nil {
 		return nil
@@ -105,12 +134,17 @@ func (c *failureStreamCapture) closeAfterStream(streamErr error, code int, statu
 	if c.capture != nil {
 		if streamErr != nil && !isSSHCommandExitError(streamErr) {
 			_ = c.capture.Close()
+			c.captureBytes = c.capture.N
+			c.captureClosed = true
 			return exit(2, "capture %s: %v", c.label, streamErr)
 		}
-		if err := c.capture.Close(); err != nil && code == 0 {
-			return exit(2, "capture %s close: %v", c.label, err)
+		closeErr := c.capture.Close()
+		c.captureBytes = c.capture.N
+		c.captureClosed = true
+		if closeErr != nil && code == 0 {
+			return exit(2, "capture %s close: %v", c.label, closeErr)
 		}
-		fmt.Fprintf(status, "captured %s=%s bytes=%d\n", c.label, c.explicitPath, c.capture.N)
+		fmt.Fprintf(status, "captured %s=%s bytes=%d\n", c.label, c.explicitPath, c.captureBytes)
 		c.capture = nil
 		return nil
 	}
@@ -129,6 +163,8 @@ func (c *failureStreamCapture) closeQuiet() error {
 	}
 	if c.capture != nil {
 		err := c.capture.Close()
+		c.captureBytes = c.capture.N
+		c.captureClosed = true
 		c.capture = nil
 		return err
 	}

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -2821,6 +2821,189 @@ func TestRunCommandPreflightsLocalOutputOptions(t *testing.T) {
 	}
 }
 
+func TestFailureStreamCaptureRetainsMetadataAfterClose(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "stdout.bin")
+	capture := &failureStreamCapture{label: "stdout", explicitPath: path}
+	writer, explicit, err := capture.writer(io.Discard, &phaseMarkerWriter{}, io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !explicit {
+		t.Fatal("explicit capture was not selected")
+	}
+	if _, ok := capture.metadata(); ok {
+		t.Fatal("capture metadata became available before close")
+	}
+	payload := []byte{0, 1, 2, 3, 4}
+	if _, err := writer.Write(payload); err != nil {
+		t.Fatal(err)
+	}
+	if err := capture.closeAfterStream(nil, 0, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	metadata, ok := capture.metadata()
+	if !ok {
+		t.Fatal("capture metadata missing after close")
+	}
+	if metadata.Label != "stdout" || metadata.Path != path || metadata.Bytes != int64(len(payload)) {
+		t.Fatalf("metadata=%+v", metadata)
+	}
+}
+
+func TestRunCommandProofReportsExplicitStreamCaptures(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX fake ssh fixture")
+	}
+	tests := []struct {
+		name          string
+		mode          string
+		captureStdout bool
+		captureStderr bool
+		stdoutData    []byte
+		stderrData    []byte
+		proofContains []string
+		proofExcludes []string
+	}{
+		{
+			name:          "text stdout capture",
+			mode:          "text-stdout",
+			captureStdout: true,
+			stdoutData:    []byte("captured text stdout\n"),
+			proofExcludes: []string{"captured text stdout", "(no console output captured)"},
+		},
+		{
+			name:          "binary control stdout capture",
+			mode:          "binary-stdout",
+			captureStdout: true,
+			stdoutData:    []byte{0, 1, 0x1b, '[', '3', '1', 'm', 'S', 'E', 'C', 'R', 'E', 'T', 0xff},
+			proofExcludes: []string{"SECRET", "\x00", "\x01", "\x1b", "(no console output captured)"},
+		},
+		{
+			name:          "both streams captured",
+			mode:          "both",
+			captureStdout: true,
+			captureStderr: true,
+			stdoutData:    []byte("stdout-only\n"),
+			stderrData:    []byte("stderr-only\n"),
+			proofExcludes: []string{"stdout-only", "stderr-only", "(no console output captured)"},
+		},
+		{
+			name:          "live stderr and captured stdout",
+			mode:          "live-stderr",
+			captureStdout: true,
+			stdoutData:    []byte("hidden stdout\n"),
+			stderrData:    []byte("visible live stderr\n"),
+			proofContains: []string{"visible live stderr"},
+			proofExcludes: []string{"hidden stdout", "(no console output captured)"},
+		},
+		{
+			name:          "no output and no captures",
+			mode:          "none",
+			proofContains: []string{"(no console output captured)"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearConfigEnv(t)
+			dir := t.TempDir()
+			isolateRunTestUserDirs(t, dir)
+			sshPath := filepath.Join(dir, "ssh")
+			sshScript := `#!/bin/sh
+remote=""
+for arg do remote="$arg"; done
+case "$remote" in
+  *"proof-capture-fixture"*)
+    case "$CRABBOX_TEST_CAPTURE_MODE" in
+      text-stdout) printf 'captured text stdout\n' ;;
+      binary-stdout) printf '\000\001\033[31mSECRET\377' ;;
+      both) printf 'stdout-only\n'; printf 'stderr-only\n' >&2 ;;
+      live-stderr) printf 'hidden stdout\n'; printf 'visible live stderr\n' >&2 ;;
+    esac
+    ;;
+esac
+exit 0
+`
+			if err := os.WriteFile(sshPath, []byte(sshScript), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+			t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, "missing.yaml"))
+			t.Setenv("CRABBOX_FAKE_SSH_PORT", "22")
+			t.Setenv("CRABBOX_FAKE_SSH_PROXY", "1")
+			t.Setenv("CRABBOX_TEST_CAPTURE_MODE", tt.mode)
+
+			proofPath := filepath.Join(dir, "proof.md")
+			args := []string{
+				"--provider", "run-env-profile-test",
+				"--no-sync",
+				"--no-hydrate",
+				"--keep",
+				"--emit-proof", proofPath,
+			}
+			var stdoutPath, stderrPath string
+			if tt.captureStdout {
+				stdoutPath = filepath.Join(dir, "stdout`\n# proof-injection.bin")
+				args = append(args, "--capture-stdout", stdoutPath)
+			}
+			if tt.captureStderr {
+				stderrPath = filepath.Join(dir, "stderr.bin")
+				args = append(args, "--capture-stderr", stderrPath)
+			}
+			args = append(args, "--", "proof-capture-fixture")
+			var stdout, stderr bytes.Buffer
+			if err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), args); err != nil {
+				t.Fatalf("run error=%v\nstdout=%q\nstderr=%s", err, stdout.Bytes(), stderr.String())
+			}
+			proofData, err := os.ReadFile(proofPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			proof := string(proofData)
+			if tt.captureStdout {
+				got, err := os.ReadFile(stdoutPath)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !bytes.Equal(got, tt.stdoutData) {
+					t.Fatalf("stdout capture=%q want=%q", got, tt.stdoutData)
+				}
+				metadata := fmt.Sprintf("captured stream=stdout path=%s bytes=%d", quoteProofCapturePath(stdoutPath), len(tt.stdoutData))
+				if !strings.Contains(proof, metadata) {
+					t.Fatalf("proof missing stdout metadata %q:\n%s", metadata, proof)
+				}
+			}
+			if tt.captureStderr {
+				got, err := os.ReadFile(stderrPath)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !bytes.Equal(got, tt.stderrData) {
+					t.Fatalf("stderr capture=%q want=%q", got, tt.stderrData)
+				}
+				metadata := fmt.Sprintf("captured stream=stderr path=%s bytes=%d", quoteProofCapturePath(stderrPath), len(tt.stderrData))
+				if !strings.Contains(proof, metadata) {
+					t.Fatalf("proof missing stderr metadata %q:\n%s", metadata, proof)
+				}
+			}
+			if tt.captureStdout && tt.captureStderr {
+				if strings.Index(proof, "captured stream=stdout") > strings.Index(proof, "captured stream=stderr") {
+					t.Fatalf("capture metadata order is not stdout then stderr:\n%s", proof)
+				}
+			}
+			for _, want := range tt.proofContains {
+				if !strings.Contains(proof, want) {
+					t.Fatalf("proof missing %q:\n%s", want, proof)
+				}
+			}
+			for _, forbidden := range tt.proofExcludes {
+				if strings.Contains(proof, forbidden) {
+					t.Fatalf("proof contains forbidden %q:\n%s", forbidden, proof)
+				}
+			}
+		})
+	}
+}
+
 func TestWriteRunLeaseOutput(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "session.json")
 	session := &RunSessionHandle{


### PR DESCRIPTION
Closes https://github.com/openclaw/crabbox/issues/1297.

## Summary

Explicit `--capture-stdout` and `--capture-stderr` intentionally remove those bytes from the live log/event fan-out. `--emit-proof` previously read only that live buffer, so a successful run could claim no console output was captured even though bytes were safely redirected to disk.

The stream-capture owner now retains only post-close metadata: stream label, local path, and final byte count. Proof rendering includes that metadata alongside any remaining live excerpt, safely escapes every nontrivial path byte, and never reopens or embeds captured text, binary, ANSI, terminal-hostile, or secret content. Runs without explicit captures keep the existing no-output sentinel.

## Verification

- text, binary/control-byte, dual-stream, live-stderr, empty-output, and path-injection regressions
- full `internal/cli` package before final rebase
- `go vet ./...`
- structured P1 branch autoreview: clean
