### PR TITLE
fix(local-container): retain updated release claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Kept the exact updated lease-claim snapshot through one-shot run registration and replacement retries so task-owned local containers can clean up without weakening concurrent replacement fences. Thanks @coygeek.
 - Made GitHub team authorization fail closed on malformed selectors, enforced same-org team scope, and invalidated membership and device proofs when the normalized policy changes. Thanks @dwin-gharibi.
 - Rejected invalid or overlong coordinator-requested lease slugs before provisioning while preserving exact fixed-ID replays created under the legacy length behavior. Thanks @dwin-gharibi.
 - Bound valid caller-declared artifact SHA-256 digests into signed broker upload grants, rejected malformed nonblank digests instead of silently disabling integrity checks, and made object storage reject mismatching payloads. Thanks @dwin-gharibi.

--- a/internal/cli/coordinator_registration.go
+++ b/internal/cli/coordinator_registration.go
@@ -38,6 +38,40 @@ func (a App) claimResolvedLeaseTargetForRepoAndRegister(
 	return err
 }
 
+func (a App) claimRunLeaseTargetForRepoAndRegister(
+	ctx context.Context,
+	leaseID, slug string,
+	cfg Config,
+	server *Server,
+	target SSHTarget,
+	repoRoot string,
+	reclaim, resolved bool,
+) error {
+	claimed, err := a.claimLeaseTargetForRepoAndRegisterMode(ctx, leaseID, slug, cfg, *server, target, repoRoot, reclaim, resolved)
+	if claimed.LeaseID != "" {
+		SetServerLeaseClaimSnapshot(server, claimed, true)
+	}
+	return err
+}
+
+func refreshRunLeaseClaimEndpoint(leaseID string, server *Server, target SSHTarget) {
+	if server == nil {
+		return
+	}
+	expected, exists, set := ServerLeaseClaimSnapshot(*server)
+	if !set {
+		_ = updateLeaseClaimEndpoint(leaseID, *server, target)
+		return
+	}
+	if !exists {
+		return
+	}
+	updated, err := updateLeaseClaimEndpointIfUnchanged(leaseID, expected, *server, target)
+	if err == nil {
+		SetServerLeaseClaimSnapshot(server, updated, true)
+	}
+}
+
 func (a App) claimLeaseTargetForRepoAndRegisterMode(
 	ctx context.Context,
 	leaseID, slug string,

--- a/internal/cli/coordinator_registration_test.go
+++ b/internal/cli/coordinator_registration_test.go
@@ -809,6 +809,104 @@ func TestResolvedLeaseClaimAllowsUnclaimedResourceAdoption(t *testing.T) {
 	}
 }
 
+func TestClaimRunLeaseTargetForRepoAndRegisterRetainsReplacementSnapshot(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	cfg := baseConfig()
+	cfg.Provider = "local-container"
+	cfg.IdleTimeout = time.Hour
+	leaseID := "cbx_replacement_snapshot"
+	server := Server{
+		CloudID:  "replacement-container",
+		Provider: cfg.Provider,
+		Labels: map[string]string{
+			"lease":    leaseID,
+			"provider": cfg.Provider,
+			"slug":     "replacement",
+			"state":    "ready",
+		},
+	}
+	target := SSHTarget{Host: "127.0.0.1", Port: "49152"}
+	if err := claimLeaseTargetForRepoConfig(leaseID, "replacement", cfg, server, target, "/repo", cfg.IdleTimeout, false); err != nil {
+		t.Fatal(err)
+	}
+	acquired, err := readLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	SetServerLeaseClaimSnapshot(&server, acquired, true)
+
+	if err := (App{}).claimRunLeaseTargetForRepoAndRegister(
+		context.Background(), leaseID, "replacement", cfg, &server, target, "/repo", false, false,
+	); err != nil {
+		t.Fatal(err)
+	}
+	registered, exists, set := ServerLeaseClaimSnapshot(server)
+	if !set || !exists {
+		t.Fatal("replacement server did not retain its registered claim snapshot")
+	}
+	current, err := readLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if registered.Revision == acquired.Revision || registered.Revision != current.Revision {
+		t.Fatalf("acquired=%q registered=%q current=%q", acquired.Revision, registered.Revision, current.Revision)
+	}
+}
+
+func TestClaimRunLeaseTargetForRepoAndRegisterRetainsSnapshotOnRegistrationError(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CRABBOX_ADAPTER_ID", "")
+	t.Setenv(controllerWorkspaceIDEnv, "")
+	coordinator := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"error":"registration unavailable"}`, http.StatusServiceUnavailable)
+	}))
+	defer coordinator.Close()
+
+	cfg := baseConfig()
+	cfg.Provider = "local-container"
+	cfg.Coordinator = coordinator.URL
+	cfg.CoordToken = "test-token"
+	cfg.BrokerMode = BrokerModeRegistered
+	cfg.macOSPortalAuto = true
+	cfg.IdleTimeout = time.Hour
+	leaseID := "cbx_registration_error"
+	server := Server{
+		CloudID:  "registration-error-container",
+		Provider: cfg.Provider,
+		Labels: map[string]string{
+			"lease":    leaseID,
+			"provider": cfg.Provider,
+			"slug":     "registration-error",
+			"state":    "ready",
+		},
+	}
+	target := SSHTarget{Host: "127.0.0.1", Port: "49153"}
+	err := (App{Stderr: &bytes.Buffer{}}).claimRunLeaseTargetForRepoAndRegister(
+		context.Background(), leaseID, "registration-error", cfg, &server, target, "/repo", false, false,
+	)
+	if err == nil || !strings.Contains(err.Error(), "register macOS portal lease") {
+		t.Fatalf("registration error=%v", err)
+	}
+	registered, exists, set := ServerLeaseClaimSnapshot(server)
+	if !set || !exists {
+		t.Fatal("registration error discarded the updated claim snapshot")
+	}
+	current, readErr := readLeaseClaim(leaseID)
+	if readErr != nil || registered.Revision != current.Revision {
+		t.Fatalf("registered=%#v current=%#v err=%v", registered, current, readErr)
+	}
+	resourceDeleted := false
+	if err := removeLeaseClaimIfUnchangedAfter(leaseID, registered, func() error {
+		resourceDeleted = true
+		return nil
+	}); err != nil {
+		t.Fatalf("failure cleanup: %v", err)
+	}
+	if !resourceDeleted {
+		t.Fatal("failure cleanup did not delete the task-owned resource")
+	}
+}
+
 func TestResolvedLeaseClaimUpdatesRejectActiveStateChange(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	cfg := baseConfig()

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -976,11 +976,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 			fmt.Fprintf(a.Stderr, "lease cleanup stopped=true policy=%s lease=%s slug=%s\n", blank(*stopAfter, "auto"), leaseID, blank(serverSlug(server), "-"))
 		}
 	}()
-	claimLease := a.claimLeaseTargetForRepoAndRegister
-	if *leaseIDFlag != "" {
-		claimLease = a.claimResolvedLeaseTargetForRepoAndRegister
-	}
-	if err := claimLease(ctx, leaseID, serverSlug(server), cfg, server, target, repo.Root, *reclaim || borrowedPool != nil); err != nil {
+	if err := a.claimRunLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, &server, target, repo.Root, *reclaim || borrowedPool != nil, *leaseIDFlag != ""); err != nil {
 		return recordFailure(err)
 	}
 	a.startRegisteredWebVNCDaemonBestEffort(cfg, target, leaseID, acquired && *keep)
@@ -1036,12 +1032,12 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 			return recordFailure(waitErr)
 		}
 		a.refreshTailscaleMetadata(ctx, cfg, sshBackend, coord, useCoordinator, &server, target, leaseID)
-		_ = updateLeaseClaimEndpoint(leaseID, server, target)
+		refreshRunLeaseClaimEndpoint(leaseID, &server, target)
 		if resolved, resolveErr := resolveNetworkTarget(ctx, cfg, server, target); resolveErr != nil {
 			return recordFailure(resolveErr)
 		} else {
 			target = resolved.Target
-			_ = updateLeaseClaimEndpoint(leaseID, server, target)
+			refreshRunLeaseClaimEndpoint(leaseID, &server, target)
 			if resolved.FallbackReason != "" {
 				fmt.Fprintf(a.Stderr, "network fallback %s\n", resolved.FallbackReason)
 			}
@@ -1276,7 +1272,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		applyRunExecutionMetadata(&envSelection, leaseID, executionRunID, serverSlug(server))
 		runReq.RunID = executionRunID
 		runReq.Env = envSelection.Effective
-		if err := a.claimLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, server, target, repo.Root, *reclaim); err != nil {
+		if err := a.claimRunLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, &server, target, repo.Root, *reclaim, false); err != nil {
 			return true, err
 		}
 		workdir = remoteJoin(cfg, leaseID, repo.Name)
@@ -1331,12 +1327,12 @@ retrySync:
 			return recordFailure(bootstrapErr)
 		}
 		a.refreshTailscaleMetadata(ctx, cfg, sshBackend, coord, useCoordinator, &server, target, leaseID)
-		_ = updateLeaseClaimEndpoint(leaseID, server, target)
+		refreshRunLeaseClaimEndpoint(leaseID, &server, target)
 		if resolved, err := resolveNetworkTarget(ctx, cfg, server, target); err != nil {
 			return recordFailure(err)
 		} else {
 			target = resolved.Target
-			_ = updateLeaseClaimEndpoint(leaseID, server, target)
+			refreshRunLeaseClaimEndpoint(leaseID, &server, target)
 			if resolved.FallbackReason != "" {
 				fmt.Fprintf(a.Stderr, "network fallback %s\n", resolved.FallbackReason)
 			}
@@ -1609,12 +1605,12 @@ afterSync:
 	}
 	commandStart := time.Now()
 	a.refreshTailscaleMetadata(ctx, cfg, sshBackend, coord, useCoordinator, &server, target, leaseID)
-	_ = updateLeaseClaimEndpoint(leaseID, server, target)
+	refreshRunLeaseClaimEndpoint(leaseID, &server, target)
 	if resolved, err := resolveNetworkTarget(ctx, cfg, server, target); err != nil {
 		return recordFailure(err)
 	} else {
 		target = resolved.Target
-		_ = updateLeaseClaimEndpoint(leaseID, server, target)
+		refreshRunLeaseClaimEndpoint(leaseID, &server, target)
 		if resolved.FallbackReason != "" {
 			fmt.Fprintf(a.Stderr, "network fallback %s\n", resolved.FallbackReason)
 		}

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -509,13 +509,18 @@ func (b runEnvProfileTestBackend) AcquireIsExclusiveOneShot() bool { return true
 
 var runEnvProfileTestReleaseErr error
 var runEnvProfileTestReleaseHook func() error
+var runEnvProfileTestReleaseRequestHook func(ReleaseLeaseRequest) error
 var runEnvProfileTestConnectionCleanupSafe = true
 var runEnvProfileTestAcquireHook func(AcquireRequest)
+var runEnvProfileTestAcquireLease func(AcquireRequest) (LeaseTarget, error)
 
 func (b runEnvProfileTestBackend) Spec() ProviderSpec { return b.spec }
 func (b runEnvProfileTestBackend) Acquire(_ context.Context, req AcquireRequest) (LeaseTarget, error) {
 	if runEnvProfileTestAcquireHook != nil {
 		runEnvProfileTestAcquireHook(req)
+	}
+	if runEnvProfileTestAcquireLease != nil {
+		return runEnvProfileTestAcquireLease(req)
 	}
 	return LeaseTarget{
 		Server: Server{Provider: b.spec.Name},
@@ -544,10 +549,143 @@ func (b runEnvProfileTestBackend) ReleaseLease(ctx context.Context, req ReleaseL
 			return err
 		}
 	}
+	if runEnvProfileTestReleaseRequestHook != nil {
+		if err := runEnvProfileTestReleaseRequestHook(req); err != nil {
+			return err
+		}
+	}
 	return runEnvProfileTestReleaseErr
 }
-func (b runEnvProfileTestBackend) Touch(context.Context, TouchRequest) (Server, error) {
-	return Server{Provider: b.spec.Name}, nil
+func (b runEnvProfileTestBackend) Touch(_ context.Context, req TouchRequest) (Server, error) {
+	server := req.Lease.Server
+	server.Provider = b.spec.Name
+	return server, nil
+}
+
+func setupRunClaimSnapshotTest(t *testing.T) (LeaseTarget, leaseClaim) {
+	t.Helper()
+	clearConfigEnv(t)
+	dir := t.TempDir()
+	isolateRunTestUserDirs(t, dir)
+	installRecordingSSH(t, dir)
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, "missing.yaml"))
+	t.Setenv("CRABBOX_FAKE_SSH_PORT", "22")
+	t.Setenv("CRABBOX_FAKE_SSH_PROXY", "1")
+
+	repo, err := findRepo()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := baseConfig()
+	cfg.Provider = runEnvProfileTestProvider{}.Name()
+	lease := LeaseTarget{
+		LeaseID: "cbx_env_profile_test",
+		Server: Server{
+			CloudID:  "task-owned-container",
+			Provider: cfg.Provider,
+			Labels: map[string]string{
+				"lease":    "cbx_env_profile_test",
+				"provider": cfg.Provider,
+				"slug":     "claim-snapshot",
+				"state":    "ready",
+			},
+		},
+		SSH: SSHTarget{
+			User:           "crabbox",
+			Host:           "127.0.0.1",
+			Port:           "22",
+			TargetOS:       targetLinux,
+			SSHConfigProxy: true,
+		},
+	}
+	if err := claimLeaseTargetForRepoConfig(lease.LeaseID, "claim-snapshot", cfg, lease.Server, lease.SSH, repo.Root, cfg.IdleTimeout, false); err != nil {
+		t.Fatal(err)
+	}
+	initial, err := readLeaseClaim(lease.LeaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	SetServerLeaseClaimSnapshot(&lease.Server, initial, true)
+	runEnvProfileTestAcquireLease = func(AcquireRequest) (LeaseTarget, error) { return lease, nil }
+	t.Cleanup(func() {
+		runEnvProfileTestAcquireLease = nil
+		runEnvProfileTestReleaseRequestHook = nil
+		removeLeaseClaim(lease.LeaseID)
+	})
+	return lease, initial
+}
+
+func TestRunCommandOneShotCleanupUsesUpdatedClaimSnapshot(t *testing.T) {
+	lease, initial := setupRunClaimSnapshotTest(t)
+	resourceDeleted := false
+	runEnvProfileTestReleaseRequestHook = func(req ReleaseLeaseRequest) error {
+		claim, exists, set := ServerLeaseClaimSnapshot(req.Lease.Server)
+		if !set || !exists {
+			return errors.New("release did not receive a claim snapshot")
+		}
+		if claim.Revision == initial.Revision {
+			return errors.New("release received the pre-registration claim snapshot")
+		}
+		return removeLeaseClaimIfUnchangedAfter(req.Lease.LeaseID, claim, func() error {
+			resourceDeleted = true
+			return nil
+		})
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
+		"--provider", runEnvProfileTestProvider{}.Name(),
+		"--no-sync",
+		"--",
+		"true",
+	})
+	if err != nil {
+		t.Fatalf("run error=%v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	if !resourceDeleted {
+		t.Fatal("task-owned resource was not deleted")
+	}
+	if _, exists, err := readLeaseClaimWithPresence(lease.LeaseID); err != nil || exists {
+		t.Fatalf("claim exists=%v err=%v after successful cleanup", exists, err)
+	}
+}
+
+func TestRunCommandCleanupRejectsClaimReplacedAfterRegistration(t *testing.T) {
+	lease, _ := setupRunClaimSnapshotTest(t)
+	resourceDeleted := false
+	runEnvProfileTestReleaseRequestHook = func(req ReleaseLeaseRequest) error {
+		claim, exists, set := ServerLeaseClaimSnapshot(req.Lease.Server)
+		if !set || !exists {
+			return errors.New("release did not receive a claim snapshot")
+		}
+		labels := cloneStringMap(claim.Labels)
+		labels["owner"] = "replacement-process"
+		if _, err := updateLeaseClaimLabelsIfUnchanged(req.Lease.LeaseID, claim, labels); err != nil {
+			return err
+		}
+		return removeLeaseClaimIfUnchangedAfter(req.Lease.LeaseID, claim, func() error {
+			resourceDeleted = true
+			return nil
+		})
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
+		"--provider", runEnvProfileTestProvider{}.Name(),
+		"--no-sync",
+		"--",
+		"true",
+	})
+	if err == nil || !strings.Contains(err.Error(), "claim changed") {
+		t.Fatalf("run error=%v, want ownership-change cleanup failure\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	if resourceDeleted {
+		t.Fatal("replacement-owned resource was deleted")
+	}
+	replacement, readErr := readLeaseClaim(lease.LeaseID)
+	if readErr != nil || replacement.Labels["owner"] != "replacement-process" {
+		t.Fatalf("replacement claim=%#v err=%v", replacement, readErr)
+	}
 }
 func (b runEnvProfileTestBackend) ReleaseLeaseConnectionCleanupSafe() bool {
 	return runEnvProfileTestConnectionCleanupSafe


### PR DESCRIPTION
Closes https://github.com/openclaw/crabbox/issues/1296.

## Summary

A local-container acquisition returned a ready claim snapshot, then repo registration advanced that claim. The run path discarded the updated snapshot, so one-shot deferred cleanup later presented the stale acquired revision and correctly failed the exact-claim ownership fence.

This change threads the exact updated claim returned by the same process into the mutable run server used for deferred cleanup. It also advances the snapshot only after successful compare-and-swap endpoint updates, covers replacement-lease retries, and preserves the updated snapshot even when coordinator registration subsequently fails. A genuinely concurrent replacement still blocks cleanup and remains untouched.

## Verification

- focused successful-cleanup, registration-error, replacement-retry, and concurrent-replacement regressions
- `go test -race ./internal/cli ./internal/providers/localcontainer`
- Docker live proof: successful command, cleanup succeeded, claim absent, container absent
- `go vet ./...`
- structured P1 branch autoreview: clean
