### PR TITLE
fix(lease-routing): route status and inspect by claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Made `cache stats --json` emit an empty array for empty inventories while live smoke accepts legacy null and object reports but rejects other scalar shapes before workloads. Thanks @excelsier.
 - Derived implicit Static SSH macOS work roots from the resolved SSH user while preserving explicit roots and EC2 Mac defaults. Thanks @osouthgate.
 - Reported explicit stdout and stderr capture paths and byte counts in emitted run proofs without reading or embedding captured content. Thanks @coygeek.
+- Routed implicit `status` and `inspect` lease identifiers through the provider recorded in local claims before initializing the configured provider, while preserving explicit-provider precedence and missing-claim fallback. Thanks @coygeek.
 
 ## 0.41.5 - 2026-08-12
 

--- a/docs/commands/inspect.md
+++ b/docs/commands/inspect.md
@@ -20,6 +20,12 @@ You can also pass the lease id or slug as a positional argument instead of
 crabbox inspect blue-lobster
 ```
 
+When `--provider` is omitted, an exact local claim or an unambiguous claimed
+slug selects its recorded provider before provider initialization. An explicit
+`--provider` remains authoritative; ambiguous claimed slugs require a canonical
+lease ID or `--provider`, while missing claims keep the configured-provider
+fallback.
+
 ## Output
 
 Human output prints one `key=value` line per field, followed by any Tailscale

--- a/docs/commands/status.md
+++ b/docs/commands/status.md
@@ -20,6 +20,12 @@ crabbox status --provider ssh --target macos --static-host mac-studio.local
 `--id` is optional: status resolves the configured static target or the local
 claim for the current repo.
 
+When `--provider` is omitted, an exact local claim or an unambiguous claimed
+slug selects its recorded provider before that provider is initialized. An
+explicit `--provider` still wins; a slug claimed by multiple providers asks
+you to pass a canonical lease ID or `--provider`, and an identifier without a
+local claim keeps the configured-provider fallback.
+
 Several delegated and direct providers resolve their own native identifiers in
 addition to the Crabbox lease ID and local slug:
 

--- a/internal/cli/checkpoint.go
+++ b/internal/cli/checkpoint.go
@@ -252,7 +252,7 @@ func (a App) checkpointList(ctx context.Context, args []string) error {
 	}
 	setIDFromFirstArg(fs, id)
 	if strings.TrimSpace(*id) != "" || flagWasSet(fs, "provider") || flagWasSet(fs, "parallels-template") {
-		cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{LeaseID: *id})
+		cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{LeaseID: *id, ProviderResourceID: true})
 		if err != nil {
 			return err
 		}
@@ -542,7 +542,7 @@ func (a App) checkpointRestore(ctx context.Context, args []string) error {
 		if fs.NArg() != 0 {
 			return exit(2, "usage: crabbox checkpoint restore --provider parallels --id <vm-or-lease> --snapshot <name-or-id>")
 		}
-		cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{LeaseID: *id})
+		cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{LeaseID: *id, ProviderResourceID: true})
 		if err != nil {
 			return err
 		}
@@ -1065,7 +1065,7 @@ func (a App) checkpointDelete(ctx context.Context, args []string) error {
 		if *localOnly {
 			return exit(2, "--local-only applies only to recorded checkpoints")
 		}
-		cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{LeaseID: *sourceID})
+		cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{LeaseID: *sourceID, ProviderResourceID: true})
 		if err != nil {
 			return err
 		}

--- a/internal/cli/claim_routing_commands_test.go
+++ b/internal/cli/claim_routing_commands_test.go
@@ -1,0 +1,237 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"flag"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	claimRoutingUsableProvider     = "claim-routing-usable-test"
+	claimRoutingConfiguredProvider = "claim-routing-configured-test"
+	claimRoutingExplicitProvider   = "claim-routing-explicit-test"
+	claimRoutingUnusableProvider   = "claim-routing-unusable-test"
+)
+
+func init() {
+	RegisterProvider(claimRoutingCommandProvider{name: claimRoutingUsableProvider})
+	RegisterProvider(claimRoutingCommandProvider{name: claimRoutingConfiguredProvider})
+	RegisterProvider(claimRoutingCommandProvider{name: claimRoutingExplicitProvider})
+	RegisterProvider(claimRoutingCommandProvider{name: claimRoutingUnusableProvider, configureErr: errors.New("configured provider credentials are unavailable")})
+}
+
+type claimRoutingCommandProvider struct {
+	name         string
+	configureErr error
+}
+
+func (p claimRoutingCommandProvider) Name() string      { return p.name }
+func (p claimRoutingCommandProvider) Aliases() []string { return nil }
+func (p claimRoutingCommandProvider) Spec() ProviderSpec {
+	return ProviderSpec{
+		Name:        p.name,
+		Family:      "claim-routing-test",
+		Kind:        ProviderKindSSHLease,
+		Targets:     []TargetSpec{{OS: targetLinux}},
+		Coordinator: CoordinatorNever,
+	}
+}
+func (claimRoutingCommandProvider) RegisterFlags(*flag.FlagSet, Config) any {
+	return noProviderFlags{}
+}
+func (claimRoutingCommandProvider) ApplyFlags(*Config, *flag.FlagSet, any) error {
+	return nil
+}
+func (p claimRoutingCommandProvider) Configure(Config, Runtime) (Backend, error) {
+	if p.configureErr != nil {
+		return nil, p.configureErr
+	}
+	return claimRoutingStatusBackend{spec: p.Spec()}, nil
+}
+
+type claimRoutingStatusBackend struct {
+	spec ProviderSpec
+}
+
+func (b claimRoutingStatusBackend) Spec() ProviderSpec { return b.spec }
+func (b claimRoutingStatusBackend) Status(_ context.Context, req StatusRequest) (StatusView, error) {
+	return StatusView{
+		ID:       req.ID,
+		Provider: b.spec.Name,
+		TargetOS: targetLinux,
+		State:    "ready",
+		Ready:    true,
+	}, nil
+}
+
+func TestStatusAndInspectRouteImplicitIdentifiersThroughLocalClaims(t *testing.T) {
+	commands := []struct {
+		name string
+		run  func(App, context.Context, []string) error
+	}{
+		{name: "status", run: func(app App, ctx context.Context, args []string) error { return app.status(ctx, args) }},
+		{name: "inspect", run: func(app App, ctx context.Context, args []string) error { return app.inspect(ctx, args) }},
+	}
+	for _, command := range commands {
+		t.Run(command.name, func(t *testing.T) {
+			t.Run("implicit exact lease id", func(t *testing.T) {
+				setupClaimRoutingCommandTest(t, claimRoutingConfiguredProvider)
+				const leaseID = "cbx_1293aa000001"
+				mustWriteClaimRoutingTestClaim(t, leaseID, "exact-lease", claimRoutingUsableProvider)
+				mustWriteClaimRoutingTestClaim(t, "cbx_1293aa000002", leaseID, claimRoutingExplicitProvider)
+
+				output, err := runClaimRoutingCommand(command.run, []string{"--id", leaseID})
+				if err != nil {
+					t.Fatalf("%s exact id: %v", command.name, err)
+				}
+				assertClaimRoutingProvider(t, output, claimRoutingUsableProvider)
+			})
+
+			t.Run("implicit unambiguous slug", func(t *testing.T) {
+				setupClaimRoutingCommandTest(t, claimRoutingConfiguredProvider)
+				mustWriteClaimRoutingTestClaim(t, "cbx_1293aa000003", "Claimed Slug", claimRoutingUsableProvider)
+
+				output, err := runClaimRoutingCommand(command.run, []string{"--id", "claimed-slug"})
+				if err != nil {
+					t.Fatalf("%s slug: %v", command.name, err)
+				}
+				assertClaimRoutingProvider(t, output, claimRoutingUsableProvider)
+			})
+
+			t.Run("explicit provider precedence", func(t *testing.T) {
+				setupClaimRoutingCommandTest(t, claimRoutingConfiguredProvider)
+				mustWriteClaimRoutingTestClaim(t, "cbx_1293aa000004", "shared-slug", claimRoutingUsableProvider)
+				mustWriteClaimRoutingTestClaim(t, "cbx_1293aa000005", "shared-slug", claimRoutingConfiguredProvider)
+
+				output, err := runClaimRoutingCommand(command.run, []string{"--provider", claimRoutingExplicitProvider, "--id", "shared-slug"})
+				if err != nil {
+					t.Fatalf("%s explicit provider: %v", command.name, err)
+				}
+				assertClaimRoutingProvider(t, output, claimRoutingExplicitProvider)
+			})
+
+			t.Run("ambiguous slug", func(t *testing.T) {
+				setupClaimRoutingCommandTest(t, claimRoutingConfiguredProvider)
+				mustWriteClaimRoutingTestClaim(t, "cbx_1293aa000006", "ambiguous-slug", claimRoutingUsableProvider)
+				mustWriteClaimRoutingTestClaim(t, "cbx_1293aa000007", "ambiguous-slug", claimRoutingExplicitProvider)
+
+				_, err := runClaimRoutingCommand(command.run, []string{"--id", "ambiguous-slug"})
+				if err == nil || !strings.Contains(err.Error(), "lease identifier ambiguous-slug matches local claims from multiple providers; use a canonical lease id or pass --provider") {
+					t.Fatalf("%s ambiguous slug error=%v", command.name, err)
+				}
+			})
+
+			t.Run("missing claim configured fallback", func(t *testing.T) {
+				setupClaimRoutingCommandTest(t, claimRoutingConfiguredProvider)
+
+				output, err := runClaimRoutingCommand(command.run, []string{"--id", "missing-claim"})
+				if err != nil {
+					t.Fatalf("%s missing claim: %v", command.name, err)
+				}
+				assertClaimRoutingProvider(t, output, claimRoutingConfiguredProvider)
+			})
+
+			t.Run("claim bypasses unusable configured provider", func(t *testing.T) {
+				setupClaimRoutingCommandTest(t, claimRoutingUnusableProvider)
+				const leaseID = "cbx_1293aa000008"
+				mustWriteClaimRoutingTestClaim(t, leaseID, "usable-claim", claimRoutingUsableProvider)
+
+				output, err := runClaimRoutingCommand(command.run, []string{"--id", leaseID})
+				if err != nil {
+					t.Fatalf("%s claim-routed usable provider: %v", command.name, err)
+				}
+				assertClaimRoutingProvider(t, output, claimRoutingUsableProvider)
+
+				if _, err := runClaimRoutingCommand(command.run, []string{"--provider", claimRoutingUnusableProvider, "--id", leaseID}); err == nil || !strings.Contains(err.Error(), "configured provider credentials are unavailable") {
+					t.Fatalf("%s explicit unusable provider error=%v", command.name, err)
+				}
+			})
+		})
+	}
+}
+
+func TestLoadLeaseTargetConfigKeepsProviderResourceIdentifiersOnConfiguredProvider(t *testing.T) {
+	setupClaimRoutingCommandTest(t, claimRoutingConfiguredProvider)
+	mustWriteClaimRoutingTestClaim(t, "cbx_1293aa000009", "native-vm-name", claimRoutingUsableProvider)
+	defaults := defaultConfig()
+	fs := newFlagSet("provider resource", io.Discard)
+	targetFlags := registerTargetFlags(fs, defaults)
+	networkFlags := registerNetworkModeFlag(fs, defaults)
+	if err := parseFlags(fs, nil); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := loadLeaseTargetConfig(fs, defaults.Provider, targetFlags, networkFlags, leaseTargetConfigOptions{
+		LeaseID:            "native-vm-name",
+		ProviderResourceID: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Provider != claimRoutingConfiguredProvider {
+		t.Fatalf("provider=%q want configured provider %q", cfg.Provider, claimRoutingConfiguredProvider)
+	}
+	if cfg.providerSelectionSource != defaults.providerSelectionSource {
+		t.Fatalf("provider source=%q want %q", cfg.providerSelectionSource, defaults.providerSelectionSource)
+	}
+}
+
+func TestLoadLeaseTargetConfigClaimRoutingPreservesProviderProvenance(t *testing.T) {
+	setupClaimRoutingCommandTest(t, claimRoutingConfiguredProvider)
+	mustWriteClaimRoutingTestClaim(t, "cbx_1293aa000010", "provenance-claim", claimRoutingUsableProvider)
+	defaults := defaultConfig()
+	fs := newFlagSet("claim provenance", io.Discard)
+	targetFlags := registerTargetFlags(fs, defaults)
+	networkFlags := registerNetworkModeFlag(fs, defaults)
+	if err := parseFlags(fs, nil); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := loadLeaseTargetConfig(fs, defaults.Provider, targetFlags, networkFlags, leaseTargetConfigOptions{LeaseID: "provenance-claim"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Provider != claimRoutingUsableProvider {
+		t.Fatalf("provider=%q want claim provider %q", cfg.Provider, claimRoutingUsableProvider)
+	}
+	if cfg.providerSelectionSource != defaults.providerSelectionSource {
+		t.Fatalf("provider source=%q want unchanged provenance %q", cfg.providerSelectionSource, defaults.providerSelectionSource)
+	}
+}
+
+func setupClaimRoutingCommandTest(t *testing.T, configuredProvider string) {
+	t.Helper()
+	clearConfigEnv(t)
+	t.Setenv("CRABBOX_PROVIDER", "")
+	configPath := filepath.Join(t.TempDir(), "crabbox.yaml")
+	if err := os.WriteFile(configPath, []byte("provider: "+configuredProvider+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CRABBOX_CONFIG", configPath)
+}
+
+func mustWriteClaimRoutingTestClaim(t *testing.T, leaseID, slug, provider string) {
+	t.Helper()
+	if err := claimLeaseForRepoProvider(leaseID, slug, provider, "/repo", time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func runClaimRoutingCommand(run func(App, context.Context, []string) error, args []string) (string, error) {
+	var stdout bytes.Buffer
+	app := App{Stdout: &stdout, Stderr: io.Discard}
+	err := run(app, context.Background(), args)
+	return stdout.String(), err
+}
+
+func assertClaimRoutingProvider(t *testing.T, output, provider string) {
+	t.Helper()
+	if !strings.Contains(output, "provider="+provider) {
+		t.Fatalf("output=%q, want provider=%s", output, provider)
+	}
+}

--- a/internal/cli/external_routing_test.go
+++ b/internal/cli/external_routing_test.go
@@ -855,3 +855,39 @@ func TestLeaseTargetConfigPreservesExplicitNonExternalProvider(t *testing.T) {
 		t.Fatalf("config=%#v", cfg)
 	}
 }
+
+func TestLeaseTargetConfigPreservesImplicitExternalClaimRouting(t *testing.T) {
+	root := setExternalRoutingTestHome(t)
+	leaseID := "cbx_1293ee000001"
+	routing := ExternalConfig{Command: "claimed-provider", WorkRoot: "/claimed/work"}
+	wantPath, err := PersistExternalRouting(leaseID, routing)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := claimLeaseForRepoProviderScope(leaseID, "claimed-external", "external", "claimed-scope", root, time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	configPath := filepath.Join(t.TempDir(), "crabbox.yaml")
+	if err := os.WriteFile(configPath, []byte("provider: aws\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CRABBOX_CONFIG", configPath)
+	defaults := defaultConfig()
+	fs := newFlagSet("status", os.Stderr)
+	provider := fs.String("provider", defaults.Provider, "")
+	targetFlags := registerTargetFlags(fs, defaults)
+	networkFlags := registerNetworkModeFlag(fs, defaults)
+	if err := parseFlags(fs, nil); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{LeaseID: "claimed-external"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Provider != "external" || cfg.External.RoutingFile != wantPath || cfg.External.Command != routing.Command || cfg.WorkRoot != routing.WorkRoot {
+		t.Fatalf("config=%#v", cfg)
+	}
+	if cfg.providerSelectionSource != providerSelectionLeaseContext {
+		t.Fatalf("provider source=%q want %q", cfg.providerSelectionSource, providerSelectionLeaseContext)
+	}
+}

--- a/internal/cli/lease_flags.go
+++ b/internal/cli/lease_flags.go
@@ -407,6 +407,10 @@ type leaseTargetConfigOptions struct {
 	// ssh provider so callers don't have to re-pass --provider / --static-host
 	// that warmup already implied.
 	LeaseID string
+	// ProviderResourceID marks LeaseID as a provider-native resource identifier,
+	// not a Crabbox lease identifier. Native snapshot operations use this to
+	// avoid routing an unrelated local claim whose slug happens to match.
+	ProviderResourceID bool
 }
 
 func loadLeaseTargetConfig(fs *flag.FlagSet, provider string, targetFlags targetFlagValues, networkFlags networkModeFlagValues, opts leaseTargetConfigOptions) (Config, error) {
@@ -421,6 +425,11 @@ func loadLeaseTargetConfig(fs *flag.FlagSet, provider string, targetFlags target
 	}
 	if err := applyTargetFlagOverrides(&cfg, fs, targetFlags); err != nil {
 		return Config{}, err
+	}
+	if !opts.ProviderResourceID {
+		if err := autoRouteClaimLeaseProvider(&cfg, fs, opts.LeaseID); err != nil {
+			return Config{}, err
+		}
 	}
 	if err := autoRouteStaticLease(&cfg, fs, opts.LeaseID); err != nil {
 		return Config{}, err

--- a/internal/cli/static_route_test.go
+++ b/internal/cli/static_route_test.go
@@ -114,6 +114,43 @@ func TestAutoRouteStaticLeaseRestoresFriendlySlugClaim(t *testing.T) {
 	}
 }
 
+func TestLeaseTargetConfigPreservesImplicitStaticClaimRouting(t *testing.T) {
+	isolateTestUserDirs(t)
+	claimed := baseConfig()
+	claimed.Provider = staticProvider
+	claimed.Static.Host = "claimed-static.example.com"
+	claimed.Static.User = "builder"
+	claimed.Static.Port = "2202"
+	claimed.Static.WorkRoot = "/work/claimed-static"
+	claimed.TargetOS = targetMacOS
+	if err := claimLeaseForRepoConfig("static_claimed-static", "claimed-static", claimed, "/repo", time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	configPath := filepath.Join(t.TempDir(), "crabbox.yaml")
+	if err := os.WriteFile(configPath, []byte("provider: aws\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CRABBOX_CONFIG", configPath)
+	defaults := defaultConfig()
+	fs := newFlagSet("status", io.Discard)
+	provider := fs.String("provider", defaults.Provider, "")
+	targetFlags := registerTargetFlags(fs, defaults)
+	networkFlags := registerNetworkModeFlag(fs, defaults)
+	if err := parseFlags(fs, nil); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{LeaseID: "claimed-static"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Provider != staticProvider || cfg.Static.Host != claimed.Static.Host || cfg.Static.User != claimed.Static.User || cfg.Static.Port != claimed.Static.Port || cfg.WorkRoot != claimed.Static.WorkRoot || cfg.TargetOS != targetMacOS {
+		t.Fatalf("config=%#v static=%#v", cfg, cfg.Static)
+	}
+	if cfg.providerSelectionSource != providerSelectionLeaseContext {
+		t.Fatalf("provider source=%q want %q", cfg.providerSelectionSource, providerSelectionLeaseContext)
+	}
+}
+
 func TestAutoRouteStaticLeaseDoesNotGuessHostWithoutClaim(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	defaults := baseConfig()


### PR DESCRIPTION
Closes https://github.com/openclaw/crabbox/issues/1293.

## Summary

`status` and `inspect` accepted provider-less lease IDs and slugs, but their shared target loader initialized the ambient configured provider before consulting ordinary local claims. A valid reusable lease could therefore fail on unrelated credentials for the configured provider.

This change reuses the established claim-provider router before backend initialization. Exact IDs and unambiguous claimed slugs select their recorded provider; explicit `--provider` remains authoritative; ambiguous cross-provider slugs fail with canonical-ID guidance; identifiers without claims retain the configured-provider fallback. Static and external claim restoration remains intact.

Provider-native checkpoint identifiers are explicitly marked so a coincidentally matching local claim cannot reroute snapshot operations.

## Verification

- status/inspect exact ID, slug, explicit-provider, ambiguity, missing-claim, and unusable-configured-provider regressions
- static/external routing compatibility and provider-native checkpoint fence
- `go test -race ./internal/cli`
- `go vet ./...`
- structured P1 branch autoreview: clean
