### PR TITLE
chore(release): prepare v0.41.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,21 @@
 # Changelog
 
-## 0.41.6 - Unreleased
+## 0.41.6 - 2026-08-13
 
 ### Fixed
 
-- Kept the exact updated lease-claim snapshot through one-shot run registration and replacement retries so task-owned local containers can clean up without weakening concurrent replacement fences. Thanks @coygeek.
-- Made GitHub team authorization fail closed on malformed selectors, enforced same-org team scope, and invalidated membership and device proofs when the normalized policy changes. Thanks @dwin-gharibi.
+- Restricted sensitive generated local files, including managed attestation keys and signed-URL artifact outputs, to the current OS user on POSIX and Windows. Thanks @dwin-gharibi.
+- Made POSIX workspace ownership independent of the remote account's login shell by transporting owner scripts through a private `/bin/sh` launcher, fixing static macOS sync under zsh, Bash, and Fish. Thanks @osouthgate and @hosmelq.
+- Derived implicit Static SSH macOS work roots from the resolved SSH user while preserving explicit roots and EC2 Mac defaults. Thanks @osouthgate.
+- Routed implicit `status` and `inspect` lease identifiers through the provider recorded in local claims before initializing the configured provider, while preserving explicit-provider precedence and missing-claim fallback. Thanks @coygeek.
+- Reported explicit stdout and stderr capture paths and byte counts in emitted run proofs without reading or embedding captured content. Thanks @coygeek.
+- Kept repeated repository sync and finalization idempotent across shallow and complete Git workspaces while preserving command exits and clearing witnessed ownership state. Thanks @osouthgate and @hosmelq.
+- Made `cache stats --json` emit an empty array for empty inventories while live smoke accepts legacy null and object reports but rejects other scalar shapes before workloads. Thanks @excelsier.
 - Rejected invalid or overlong coordinator-requested lease slugs before provisioning while preserving exact fixed-ID replays created under the legacy length behavior. Thanks @dwin-gharibi.
 - Bound valid caller-declared artifact SHA-256 digests into signed broker upload grants, rejected malformed nonblank digests instead of silently disabling integrity checks, and made object storage reject mismatching payloads. Thanks @dwin-gharibi.
+- Made GitHub team authorization fail closed on malformed selectors, enforced same-org team scope, and invalidated membership and device proofs when the normalized policy changes. Thanks @dwin-gharibi.
 - Preserved pinned AWS SSH ingress and dynamic CIDRs from the other IP family when broker heartbeats refresh access, while replacing obsolete same-family dynamic sources. Thanks @jalehman.
-- Made `cache stats --json` emit an empty array for empty inventories while live smoke accepts legacy null and object reports but rejects other scalar shapes before workloads. Thanks @excelsier.
-- Derived implicit Static SSH macOS work roots from the resolved SSH user while preserving explicit roots and EC2 Mac defaults. Thanks @osouthgate.
-- Reported explicit stdout and stderr capture paths and byte counts in emitted run proofs without reading or embedding captured content. Thanks @coygeek.
-- Routed implicit `status` and `inspect` lease identifiers through the provider recorded in local claims before initializing the configured provider, while preserving explicit-provider precedence and missing-claim fallback. Thanks @coygeek.
-- Made POSIX workspace ownership independent of the remote account's login shell by transporting owner scripts through a private `/bin/sh` launcher, fixing static macOS sync under zsh, Bash, and Fish. Thanks @osouthgate and @hosmelq.
-- Restricted sensitive generated local files, including managed attestation keys and signed-URL artifact outputs, to the current OS user on POSIX and Windows. Thanks @dwin-gharibi.
-- Kept repeated repository sync and finalization idempotent across shallow and complete Git workspaces while preserving command exits and clearing witnessed ownership state. Thanks @osouthgate and @hosmelq.
+- Kept the exact updated lease-claim snapshot through one-shot run registration and replacement retries so task-owned local containers can clean up without weakening concurrent replacement fences. Thanks @coygeek.
 
 ## 0.41.5 - 2026-08-12
 

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/crabbox-worker",
-  "version": "0.41.5",
+  "version": "0.41.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/crabbox-worker",
-      "version": "0.41.5",
+      "version": "0.41.6",
       "dependencies": {
         "@aws-sdk/credential-providers": "^3.1095.0",
         "@cloudflare/containers": "^0.3.7",

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/crabbox-worker",
-  "version": "0.41.5",
+  "version": "0.41.6",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Prepare the protected source snapshot for v0.41.6:

- date and prioritize the v0.41.6 changelog section while preserving every release note and contributor credit
- bump `worker/package.json` to 0.41.6
- bump both root version entries in `worker/package-lock.json` to 0.41.6

This pull request does not create or move a tag, build release assets, publish a GitHub Release, or update Homebrew. Those remain separate serialized release gates.

## Verification

- `go vet ./...`
- all Go packages under the race detector; `internal/cli` ran separately in 584.6 seconds to stay below its package deadline, and every remaining package passed
- `scripts/test-go-modules.sh`
- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- `scripts/check-go-coverage.sh 90.0` — core coverage exactly 90.0%
- Worker formatting, lint, typecheck, 1,309 tests, and Wrangler dry-run build
- all 583 script tests with deterministic single-file concurrency, docs checks, generated docs checks, and `git diff --check`
- structured P1 autoreview and secret scan: clean

## Live proof

Coordinator-backed AWS release smoke:

- provider: `aws`
- lease: `cbx_65dd299d136c`
- run: `run_1bb4c030220f`
- portal: https://crabbox.openclaw.ai/portal/runs/run_1bb4c030220f
- command output: `release-v0416-live-ok`, `Linux`, and the synced remote workdir
- attach replay, JSON events, and JSON logs all returned the completed run
- cleanup succeeded and both `status` and `inspect` reported `state=released`
