### PR TITLE
chore(release): authorize v0.41.6 source

### DIFF
--- a/release/records/v0.41.6.json
+++ b/release/records/v0.41.6.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "repository": "openclaw/crabbox",
+  "tag": "v0.41.6",
+  "tagObject": "d13c6879b47e1ed11517072a025a3588fe584ae3",
+  "sourceCommit": "7e9e7e37d90f5a9a6f865ea2ef3215283b2ccdf4",
+  "publicationStatus": "ready"
+}


### PR DESCRIPTION
## Summary

Authorize the immutable v0.41.6 release source:

- signed tag: `v0.41.6`
- tag object: `d13c6879b47e1ed11517072a025a3588fe584ae3`
- source commit: `7e9e7e37d90f5a9a6f865ea2ef3215283b2ccdf4`
- publication status: `ready`

The remote tag was fetched into a private verification ref, matched these exact identities, verified against `.github/release-allowed-signers`, and the source commit is contained by protected `main`.

This pull request authorizes candidate production only. It does not build assets, create or publish a GitHub Release, dispatch native release verification, or update Homebrew.

## Verification

- `scripts/verify-release-source.sh` with `REQUIRE_PUBLISHABLE=1`
- `node --test scripts/release-workflow.test.js` — 27 passed
- `git diff --check`
- structured P1 autoreview and secret scan: clean
