### PR TITLE
chore(release): open v0.41.7 development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 0.41.7 - Unreleased
+
 ## 0.41.6 - 2026-08-13
 
 ### Fixed


### PR DESCRIPTION
## Summary

Open v0.41.7 development after the verified v0.41.6 release.

v0.41.6 is public and immutable at https://github.com/openclaw/crabbox/releases/tag/v0.41.6. Its separate public native verifier passed at https://github.com/openclaw/crabbox/actions/runs/31701323354, and the protected Apple Silicon/Intel Homebrew proof passed at https://github.com/openclaw/crabbox/actions/runs/31701726604.

## Verification

- `scripts/check-docs.sh`
- `git diff --check`
- structured P1 autoreview and secret scan: clean
