### PR TITLE
fix(worker): harden diagnostic credential redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.41.7 - Unreleased
 
+### Fixed
+
+- Redacted compound environment assignments, cookie and security-token headers, and camel-case API-token fields from client-visible coordinator diagnostics while preserving surrounding operational context. Thanks @dwin-gharibi.
+
 ## 0.41.6 - 2026-08-13
 
 ### Fixed

--- a/worker/src/http.ts
+++ b/worker/src/http.ts
@@ -67,6 +67,154 @@ export function redactDiagnosticSecrets(
   return "[redacted]";
 }
 
+function diagnosticQuotedSegmentCloses(
+  value: string,
+  start: number,
+  quote: string,
+  allowNewlines = false,
+): boolean {
+  for (let index = start; index < value.length; index++) {
+    const char = value[index]!;
+    if (char === "\r" || char === "\n") {
+      if (!allowNewlines) return false;
+      continue;
+    }
+    if (char === "\\" && index + 1 < value.length) {
+      if (!allowNewlines && (value[index + 1] === "\r" || value[index + 1] === "\n")) {
+        return false;
+      }
+      index++;
+      continue;
+    }
+    if (char === quote) return true;
+  }
+  return false;
+}
+
+function diagnosticEnvironmentNameIsSensitive(name: string): boolean {
+  return (
+    /(?:^|[-_]+)(?:tokens?|secrets?|keys?|password|passwd|credentials?|authkey|apikey)$/i.test(
+      name,
+    ) ||
+    /(?:^|[-_]+)(?:secrets?|password|passwd|credentials?|authkey|apikey)(?:$|[-_]+)/i.test(name)
+  );
+}
+
+function diagnosticEnclosingQuote(value: string, index: number): string {
+  if (value[index - 1] === "'") return "'";
+  let quote = "";
+  for (let offset = 0; offset < index; offset++) {
+    const char = value[offset]!;
+    if (char === "\\" && offset + 1 < index) {
+      offset++;
+      continue;
+    }
+    if (char === '"') quote = quote ? "" : char;
+  }
+  return quote;
+}
+
+function diagnosticCredentialValueRange(
+  value: string,
+  start: number,
+  conservativeUnterminatedQuotes: boolean,
+  enclosingQuote = "",
+  continueAfterSemicolon = false,
+): { end: number; preservedEnclosingQuote?: number } {
+  let quote = enclosingQuote;
+  let quoteClosesAcrossLines = enclosingQuote
+    ? diagnosticQuotedSegmentCloses(value, start, enclosingQuote, true)
+    : false;
+  let preservedEnclosingQuote: number | undefined;
+  const structuredClosers: string[] = [];
+  let index = start;
+  while (index < value.length) {
+    const char = value[index]!;
+    if (char === "\r" || char === "\n") {
+      if ((!quote || !quoteClosesAcrossLines) && structuredClosers.length === 0) break;
+      index++;
+      continue;
+    }
+    if (char === "\\" && index + 1 < value.length) {
+      if (value[index + 1] === "\r" || value[index + 1] === "\n") {
+        // A shell continuation keeps an unquoted word (or a known-closing quote) together.
+        if (!quote || quoteClosesAcrossLines || structuredClosers.length > 0) {
+          index += value[index + 1] === "\r" && value[index + 2] === "\n" ? 3 : 2;
+          continue;
+        }
+        index++;
+        break;
+      }
+      index += 2;
+      continue;
+    }
+    if (quote) {
+      if (char === quote) {
+        if (quote === enclosingQuote && preservedEnclosingQuote === undefined) {
+          preservedEnclosingQuote = index;
+        }
+        quote = "";
+        quoteClosesAcrossLines = false;
+      }
+      index++;
+      continue;
+    }
+    if (
+      preservedEnclosingQuote !== undefined &&
+      index === preservedEnclosingQuote + 1 &&
+      (char === "," || char === "}" || char === "]")
+    ) {
+      break;
+    }
+    if (char === "{" || char === "[") {
+      structuredClosers.push(char === "{" ? "}" : "]");
+      index++;
+      continue;
+    }
+    if (char === structuredClosers.at(-1)) {
+      structuredClosers.pop();
+      index++;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      if (
+        index === start ||
+        conservativeUnterminatedQuotes ||
+        diagnosticQuotedSegmentCloses(value, index + 1, char)
+      ) {
+        quote = char;
+        quoteClosesAcrossLines = diagnosticQuotedSegmentCloses(value, index + 1, char, true);
+      }
+      index++;
+      continue;
+    }
+    if (/\s/.test(char)) {
+      if (structuredClosers.length > 0) {
+        index++;
+        continue;
+      }
+      if (continueAfterSemicolon) {
+        let next = index;
+        while (value[next] === " " || value[next] === "\t") next++;
+        if (value[index - 1] === ";") {
+          index = next;
+          continue;
+        }
+        if (value[next] === ";") {
+          index = next + 1;
+          while (value[index] === " " || value[index] === "\t") index++;
+          continue;
+        }
+      }
+      break;
+    }
+    index++;
+  }
+  return preservedEnclosingQuote === undefined
+    ? { end: index }
+    : { end: index, preservedEnclosingQuote };
+}
+
 function redactDiagnosticPass(value: string, secrets: readonly string[]): string {
   // Collect structural and exact spans from the same source text so one
   // rewrite cannot hide a still-unredacted part of another credential.
@@ -77,6 +225,17 @@ function redactDiagnosticPass(value: string, secrets: readonly string[]): string
     if (start >= end || diagnosticRangeInsideMarker(start, end, markerRanges)) return;
     ranges.push({ start, end, preserve: false });
     added = true;
+  };
+  const addCredentialValueRedaction = (
+    start: number,
+    scanned: { end: number; preservedEnclosingQuote?: number },
+  ) => {
+    if (scanned.preservedEnclosingQuote === undefined) {
+      addRedaction(start, scanned.end);
+      return;
+    }
+    addRedaction(start, scanned.preservedEnclosingQuote);
+    addRedaction(scanned.preservedEnclosingQuote + 1, scanned.end);
   };
 
   for (const match of value.matchAll(
@@ -99,21 +258,72 @@ function redactDiagnosticPass(value: string, secrets: readonly string[]): string
       fullStart + full.length,
     );
   }
+  // A quoted JSON key cannot match this header rule because its closing quote precedes the colon;
+  // structured cookie fields are bounded by the JSON scalar and array rules below.
   for (const match of value.matchAll(
-    /(^|[^?&A-Za-z0-9_-])(authorization|proxy-authorization|x-api-key|api[-_]?key|access[-_]?token|refresh[-_]?token|id[-_]?token|client[-_]?secret|secret[-_]?access[-_]?key|api[-_]?secret|session[-_]?token|token|password)[ \t]*[:=][ \t]*(?:(?:bearer|basic)(?:[ \t]*:[ \t]*\r?\n[ \t]+|[ \t]*:[ \t]*|[ \t]*\r?\n[ \t]+|[ \t]+))?(?:\\.|[^\s"])+/gi,
+    /(^|[^?&A-Za-z0-9_-])(set-cookie|cookie|x-amz-security-token|x-goog-security-token)[ \t]*:[ \t]*(?:\r?\n[ \t]+|[^\r\n])*/gi,
   )) {
     const full = match[0];
     const keyEnd = (match[1]?.length ?? 0) + (match[2]?.length ?? 0);
     const separator = diagnosticSeparator(full, keyEnd);
     if (separator < 0) continue;
     const fullStart = match.index;
-    addRedaction(
-      fullStart + diagnosticSkipHorizontalSpace(full, separator + 1, full.length),
-      fullStart + full.length,
+    const valueStart = fullStart + diagnosticSkipHorizontalSpace(full, separator + 1, full.length);
+    const keyStart = fullStart + (match[1]?.length ?? 0);
+    const enclosingQuote = diagnosticEnclosingQuote(value, keyStart);
+    if (enclosingQuote) {
+      addCredentialValueRedaction(
+        valueStart,
+        diagnosticCredentialValueRange(value, valueStart, true, enclosingQuote),
+      );
+    } else {
+      addRedaction(valueStart, fullStart + full.length);
+    }
+  }
+  for (const match of value.matchAll(
+    /(^|[^?&A-Za-z0-9_-])(authorization|proxy-authorization|x-amz-security-token|x-goog-security-token|x-api-key|api[-_]?key|api[-_]?token|auth[-_]?key|access[-_]?token|refresh[-_]?token|id[-_]?token|client[-_]?secret|secret[-_]?access[-_]?key|api[-_]?secret|session[-_]?token|set-cookie|cookie|token|password)[ \t]*[:=][ \t]*(?:(?:bearer|basic)(?:[ \t]*:[ \t]*\r?\n[ \t]+|[ \t]*:[ \t]*|[ \t]*\r?\n[ \t]+|[ \t]+))?/gi,
+  )) {
+    const full = match[0];
+    const keyEnd = (match[1]?.length ?? 0) + (match[2]?.length ?? 0);
+    const separator = diagnosticSeparator(full, keyEnd);
+    if (separator < 0) continue;
+    const fullStart = match.index;
+    const valueStart = fullStart + full.length;
+    const redactionStart =
+      fullStart + diagnosticSkipHorizontalSpace(full, separator + 1, full.length);
+    const key = match[2]!.toLowerCase();
+    const keyStart = fullStart + (match[1]?.length ?? 0);
+    const enclosingQuote = diagnosticEnclosingQuote(value, keyStart);
+    addCredentialValueRedaction(
+      redactionStart,
+      diagnosticCredentialValueRange(
+        value,
+        valueStart,
+        key !== "authorization" && key !== "proxy-authorization",
+        enclosingQuote,
+        (key === "cookie" || key === "set-cookie") && full[separator] === "=",
+      ),
+    );
+  }
+  // A separate assignment rule recognizes the complete environment name without relaxing the
+  // delimiter-sensitive field rule above, which would otherwise consume later URL parameters.
+  for (const match of value.matchAll(
+    /(?:^|(?<=[\s.:;=,(){}[\]'"`]))([A-Za-z_][A-Za-z0-9_-]*)[ \t]*=[ \t]*/g,
+  )) {
+    if (!diagnosticEnvironmentNameIsSensitive(match[1]!)) continue;
+    const full = match[0];
+    const keyEnd = match[1]!.length;
+    const separator = diagnosticSeparator(full, keyEnd);
+    if (separator < 0) continue;
+    const valueStart = match.index + full.length;
+    const enclosingQuote = diagnosticEnclosingQuote(value, match.index);
+    addCredentialValueRedaction(
+      valueStart,
+      diagnosticCredentialValueRange(value, valueStart, true, enclosingQuote),
     );
   }
   for (const match of value.matchAll(
-    /"(authorization|proxy-authorization|x-api-key|apiKey|api-key|api_key|accessToken|access-token|access_token|refreshToken|refresh-token|refresh_token|idToken|id-token|id_token|clientSecret|client-secret|client_secret|secretAccessKey|secret-access-key|secret_access_key|apiSecret|api-secret|api_secret|credential|credentials|privateKey|private-key|private_key|secret|sessionToken|session-token|session_token|token|password)"\s*:\s*"(?:\\(?:[\s\S]|$)|[^"\\])*(?:"|$)/gi,
+    /"(authorization|proxy-authorization|x-amz-security-token|x-goog-security-token|x-api-key|apiKey|api-key|api_key|apiToken|api-token|api_token|authKey|auth-key|auth_key|setCookie|set-cookie|cookie|accessToken|access-token|access_token|refreshToken|refresh-token|refresh_token|idToken|id-token|id_token|clientSecret|client-secret|client_secret|secretAccessKey|secret-access-key|secret_access_key|apiSecret|api-secret|api_secret|credential|credentials|privateKey|private-key|private_key|secret|sessionToken|session-token|session_token|token|password)"\s*:\s*"(?:\\(?:[\s\S]|$)|[^"\\])*(?:"|$)/gi,
   )) {
     const full = match[0];
     const separator = full.indexOf(":");
@@ -123,8 +333,32 @@ function redactDiagnosticPass(value: string, secrets: readonly string[]): string
     const secretEnd = full.endsWith('"') ? full.length - 1 : full.length;
     addRedaction(fullStart + quote + 1, fullStart + secretEnd);
   }
+  for (const match of value.matchAll(/"(?:setCookie|set-cookie|cookie)"\s*:\s*\[/gi)) {
+    let index = match.index + match[0].length;
+    while (index < value.length) {
+      while (/\s/.test(value[index] ?? "")) index++;
+      if (value[index] === "]") break;
+      if (value[index] !== '"') break;
+      const itemStart = ++index;
+      while (index < value.length && value[index] !== '"') {
+        if (value[index] === "\\" && index + 1 < value.length) index++;
+        index++;
+      }
+      addRedaction(itemStart, index);
+      if (value[index] !== '"') break;
+      index++;
+      while (/\s/.test(value[index] ?? "")) index++;
+      if (value[index] !== ",") break;
+      index++;
+    }
+  }
+  for (const match of value.matchAll(/([?&])([A-Za-z_][A-Za-z0-9_-]*)=([^&#\s]*)/g)) {
+    if (!diagnosticEnvironmentNameIsSensitive(match[2]!)) continue;
+    const valueStart = match.index + match[1]!.length + match[2]!.length + 1;
+    addRedaction(valueStart, valueStart + match[3]!.length);
+  }
   for (const match of value.matchAll(
-    /([?&](?:authorization|proxy-authorization|x-api-key|api[_-]?key|access[_-]?token|refresh[_-]?token|id[_-]?token|client[_-]?secret|secret[_-]?access[_-]?key|api[_-]?secret|session[_-]?token|password|token|signature|sig|x-amz-credential|x-amz-signature|x-amz-security-token|x-goog-credential|x-goog-signature|x-goog-security-token)=)[^&#\s]+/gi,
+    /([?&](?:authorization|proxy-authorization|x-api-key|api[_-]?key|api[_-]?token|auth[_-]?key|cookie|access[_-]?token|refresh[_-]?token|id[_-]?token|client[_-]?secret|secret[_-]?access[_-]?key|api[_-]?secret|session[_-]?token|password|token|signature|sig|x-amz-credential|x-amz-signature|x-amz-security-token|x-goog-credential|x-goog-signature|x-goog-security-token)=)[^&#\s]+/gi,
   )) {
     addRedaction(match.index + match[1]!.length, match.index + match[0].length);
   }

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -15864,15 +15864,16 @@ describe("fleet lease identity and idle", () => {
   it("redacts legacy stored diagnostics from lease get and list responses", async () => {
     const storage = new MemoryStorage();
     const configuredSecret = "configured-aws-secret";
-    const reflectedSecret = "legacy-reflected-secret";
+    const environmentSecret = "legacy-environment-secret";
+    const cookieSecret = "legacy-cookie-secret";
     storage.seed(
       "lease:cbx_abcdef123456",
       testLease({
         id: "cbx_abcdef123456",
         owner: "alice@example.com",
         org: "example-org",
-        cleanupError: `cleanup failed ${configuredSecret}`,
-        failureError: `X-API-Key: ${reflectedSecret}`,
+        cleanupError: `cleanup failed ${configuredSecret} AWS_SECRET_ACCESS_KEY=${environmentSecret} region=eu`,
+        failureError: `Cookie: session=${cookieSecret}`,
       }),
     );
     const fleet = testFleet(storage, {}, { AWS_SECRET_ACCESS_KEY: configuredSecret });
@@ -15894,11 +15895,16 @@ describe("fleet lease identity and idle", () => {
     );
     for (const body of bodies) {
       expect(body).toContain("[redacted]");
+      expect(body).toContain("region=eu");
       expect(body).not.toContain(configuredSecret);
-      expect(body).not.toContain(reflectedSecret);
+      expect(body).not.toContain(environmentSecret);
+      expect(body).not.toContain(cookieSecret);
     }
     expect(storage.value<LeaseRecord>("lease:cbx_abcdef123456")?.cleanupError).toContain(
       configuredSecret,
+    );
+    expect(storage.value<LeaseRecord>("lease:cbx_abcdef123456")?.cleanupError).toContain(
+      environmentSecret,
     );
   });
 

--- a/worker/test/http.test.ts
+++ b/worker/test/http.test.ts
@@ -1642,6 +1642,270 @@ describe("http responses", () => {
     expect(redactDiagnosticSecrets(redacted, secrets)).toBe(redacted);
   });
 
+  it.each([
+    [
+      "compound AWS environment name",
+      "bootstrap failed: AWS_SECRET_ACCESS_KEY=aws-secret-value",
+      "aws-secret-value",
+    ],
+    [
+      "compound GitHub environment name",
+      "sh: GITHUB_TOKEN=github-secret-value: not found",
+      "github-secret-value",
+    ],
+    [
+      "auth-key environment name",
+      "export TAILSCALE_AUTHKEY=auth-secret-value",
+      "auth-secret-value",
+    ],
+    ["cookie assignment", 'COOKIE="cookie secret value"', "cookie secret value"],
+    [
+      "Set-Cookie header",
+      'Set-Cookie: sid="quoted-cookie-secret"; HttpOnly',
+      "quoted-cookie-secret",
+    ],
+    [
+      "multi-pair Cookie header",
+      "Cookie: theme=light; sid=later-cookie-secret",
+      "later-cookie-secret",
+    ],
+    [
+      "AWS security-token header",
+      "x-amz-security-token: security-token-secret",
+      "security-token-secret",
+    ],
+    ["camel-case API token", "apiToken: api-token-secret", "api-token-secret"],
+    ["double-quoted assignment", 'GITHUB_TOKEN="github quoted secret"', "github quoted secret"],
+    ["single-quoted assignment", "DB_PASSWORD='database quoted secret'", "database quoted secret"],
+    ["mixed shell assignment", "DB_PASSWORD=prefix'secret middle'suffix", "secret middle"],
+    ["adjacent shell segments", "TOKEN=''actual-secret", "actual-secret"],
+  ])("redacts %s", (_label, diagnostic, secret) => {
+    const redacted = redactDiagnosticSecrets(diagnostic);
+    expect(redacted).not.toContain(secret);
+    expect(redacted).toContain("[redacted]");
+    expect(redactDiagnosticSecrets(redacted)).toBe(redacted);
+  });
+
+  it("bounds structured credentials without hiding diagnostic context", () => {
+    expect(redactDiagnosticSecrets('env "DB_PASSWORD=correct horse" command')).toBe(
+      'env "DB_PASSWORD=[redacted]" command',
+    );
+    expect(redactDiagnosticSecrets("env 'GITHUB_TOKEN='ghp_secret command")).toBe(
+      "env 'GITHUB_TOKEN='[redacted] command",
+    );
+    expect(redactDiagnosticSecrets('GITHUB_TOKEN="line-secret\nnext diagnostic remains')).toBe(
+      "GITHUB_TOKEN=[redacted]\nnext diagnostic remains",
+    );
+    expect(
+      redactDiagnosticSecrets("DB_PASSWORD=prefix'correct horse\nnext diagnostic remains"),
+    ).toBe("DB_PASSWORD=[redacted]\nnext diagnostic remains");
+    expect(redactDiagnosticSecrets("DB_PASSWORD=line-secret\\\ncontinued-secret remains")).toBe(
+      "DB_PASSWORD=[redacted] remains",
+    );
+  });
+
+  it("redacts an unquoted shell continuation as one assignment value", () => {
+    expect(redactDiagnosticSecrets("GITHUB_TOKEN=\\\nghp_actual_secret requestId=useful")).toBe(
+      "GITHUB_TOKEN=[redacted] requestId=useful",
+    );
+  });
+
+  it("redacts quoted assignments that close across diagnostic lines", () => {
+    expect(
+      redactDiagnosticSecrets("DB_PASSWORD='first-secret\nsecond-secret'\nnext diagnostic remains"),
+    ).toBe("DB_PASSWORD=[redacted]\nnext diagnostic remains");
+    expect(redactDiagnosticSecrets('env "DB_PASSWORD=first-secret\nsecond-secret" command')).toBe(
+      'env "DB_PASSWORD=[redacted]" command',
+    );
+    expect(redactDiagnosticSecrets('env "prefix\nDB_PASSWORD=correct horse" command')).toBe(
+      'env "prefix\nDB_PASSWORD=[redacted]" command',
+    );
+  });
+
+  it("redacts balanced structured environment values through internal whitespace", () => {
+    expect(
+      redactDiagnosticSecrets(
+        'GOOGLE_CREDENTIALS={"type":"service_account", "private_key":"structured-secret"} requestId=useful',
+      ),
+    ).toBe("GOOGLE_CREDENTIALS=[redacted] requestId=useful");
+  });
+
+  it("recognizes strong credential components before an environment-name suffix", () => {
+    expect(redactDiagnosticSecrets("SECRET_KEY_BASE=rails-secret requestId=useful")).toBe(
+      "SECRET_KEY_BASE=[redacted] requestId=useful",
+    );
+  });
+
+  it.each([
+    ["Cookie", "Cookie: sid=first-cookie;\r\n private=second-cookie"],
+    ["AWS security token", "x-amz-security-token: first-token\n second-token"],
+  ])("redacts folded %s headers without consuming the next diagnostic", (_label, header) => {
+    const redacted = redactDiagnosticSecrets(`${header}\nnext diagnostic remains`);
+    expect(redacted).toBe(
+      `${header.slice(0, header.indexOf(":"))}: [redacted]\nnext diagnostic remains`,
+    );
+  });
+
+  it("redacts every equals-form cookie pair without hiding later context", () => {
+    expect(redactDiagnosticSecrets("Cookie=theme=light; sid=session-secret requestId=useful")).toBe(
+      "Cookie=[redacted] requestId=useful",
+    );
+    expect(
+      redactDiagnosticSecrets("Cookie=theme=light ; sid=spaced-session-secret requestId=useful"),
+    ).toBe("Cookie=[redacted] requestId=useful");
+    expect(redactDiagnosticSecrets("worker's Cookie: marker=abc'; session=apostrophe-secret")).toBe(
+      "worker's Cookie: [redacted]",
+    );
+    expect(
+      redactDiagnosticSecrets("Set-Cookie=safe=1; session=set-cookie-secret requestId=useful"),
+    ).toBe("Set-Cookie=[redacted] requestId=useful");
+  });
+
+  it.each([
+    [
+      "flag assignment",
+      "docker --env=AWS_SECRET_ACCESS_KEY=flag-secret requestId=useful",
+      "docker --env=AWS_SECRET_ACCESS_KEY=[redacted] requestId=useful",
+    ],
+    [
+      "colon prefix",
+      "env:AWS_SECRET_ACCESS_KEY=colon-secret requestId=useful",
+      "env:AWS_SECRET_ACCESS_KEY=[redacted] requestId=useful",
+    ],
+    [
+      "ambiguous comma value",
+      "AWS_SECRET_ACCESS_KEY=comma-secret,region=eu",
+      "AWS_SECRET_ACCESS_KEY=[redacted]",
+    ],
+    [
+      "semicolon context",
+      "AWS_SECRET_ACCESS_KEY=semicolon-secret;requestId=useful",
+      "AWS_SECRET_ACCESS_KEY=[redacted]",
+    ],
+    [
+      "query assignment",
+      "https://example.test/p?AWS_SECRET_ACCESS_KEY=query-secret&region=eu",
+      "https://example.test/p?AWS_SECRET_ACCESS_KEY=[redacted]&region=eu",
+    ],
+    [
+      "leading underscore name",
+      "_SERVICE_TOKEN=leading-secret requestId=useful",
+      "_SERVICE_TOKEN=[redacted] requestId=useful",
+    ],
+    [
+      "repeated underscore name",
+      "DATABASE__PASSWORD=nested-secret requestId=useful",
+      "DATABASE__PASSWORD=[redacted] requestId=useful",
+    ],
+    [
+      "process.env qualifier",
+      "process.env.AWS_SECRET_ACCESS_KEY=qualified-secret requestId=useful",
+      "process.env.AWS_SECRET_ACCESS_KEY=[redacted] requestId=useful",
+    ],
+    [
+      "env qualifier",
+      "env.GITHUB_TOKEN=qualified-token requestId=useful",
+      "env.GITHUB_TOKEN=[redacted] requestId=useful",
+    ],
+  ])("bounds a compound environment %s", (_label, diagnostic, expected) => {
+    expect(redactDiagnosticSecrets(diagnostic)).toBe(expected);
+  });
+
+  it("fails closed on assignment-like text inside a comma-bearing credential", () => {
+    expect(redactDiagnosticSecrets("AWS_SECRET_ACCESS_KEY=,region=eu")).toBe(
+      "AWS_SECRET_ACCESS_KEY=[redacted]",
+    );
+    expect(redactDiagnosticSecrets("DB_PASSWORD=prefix,part=secret")).toBe(
+      "DB_PASSWORD=[redacted]",
+    );
+  });
+
+  it("fails closed on punctuation-bearing environment values", () => {
+    expect(redactDiagnosticSecrets("DB_PASSWORD=abc;def requestId=useful")).toBe(
+      "DB_PASSWORD=[redacted] requestId=useful",
+    );
+    expect(redactDiagnosticSecrets("DB_PASSWORD=abc&def requestId=useful")).toBe(
+      "DB_PASSWORD=[redacted] requestId=useful",
+    );
+  });
+
+  it("fails closed on ambiguous spaced equals-form assignments", () => {
+    expect(redactDiagnosticSecrets("TOKEN= requestId=useful")).toBe("TOKEN= [redacted]");
+    expect(redactDiagnosticSecrets("TOKEN= top-secret requestId=useful")).toBe(
+      "TOKEN= [redacted] requestId=useful",
+    );
+    expect(redactDiagnosticSecrets("AWS_SECRET_ACCESS_KEY = aws-secret requestId=useful")).toBe(
+      "AWS_SECRET_ACCESS_KEY = [redacted] requestId=useful",
+    );
+  });
+
+  it("stops a whole quoted assignment at compact structured punctuation", () => {
+    expect(redactDiagnosticSecrets('{"message":"DB_PASSWORD=secret","requestId":"useful"}')).toBe(
+      '{"message":"DB_PASSWORD=[redacted]","requestId":"useful"}',
+    );
+  });
+
+  it("rescans a shared separator for nested environment assignments", () => {
+    expect(
+      redactDiagnosticSecrets("env=AWS_SECRET_ACCESS_KEY=nested-secret requestId=useful"),
+    ).toBe("env=AWS_SECRET_ACCESS_KEY=[redacted] requestId=useful");
+  });
+
+  it("bounds header and colon-form fields embedded in structured strings", () => {
+    expect(
+      redactDiagnosticSecrets('{"message":"Cookie: sid=cookie-secret","requestId":"useful"}'),
+    ).toBe('{"message":"Cookie: [redacted]","requestId":"useful"}');
+    expect(redactDiagnosticSecrets('{"message":"apiToken: api-secret","requestId":"useful"}')).toBe(
+      '{"message":"apiToken: [redacted]","requestId":"useful"}',
+    );
+    expect(
+      redactDiagnosticSecrets(
+        '{"message":"upstream Cookie: sid=prefixed-cookie-secret","requestId":"useful"}',
+      ),
+    ).toBe('{"message":"upstream Cookie: [redacted]","requestId":"useful"}');
+    expect(
+      redactDiagnosticSecrets(
+        '{"message":"upstream x-api-key: prefixed-api-secret","requestId":"useful"}',
+      ),
+    ).toBe('{"message":"upstream x-api-key: [redacted]","requestId":"useful"}');
+  });
+
+  it("uses JSON and query bounds for newly recognized credential fields", () => {
+    expect(
+      redactDiagnosticSecrets(
+        '{"set-cookie":["sid=array-secret; HttpOnly","csrf=second-secret"],"requestId":"useful"}',
+      ),
+    ).toBe('{"set-cookie":["[redacted]","[redacted]"],"requestId":"useful"}');
+    expect(redactDiagnosticSecrets('{"set-cookie":["unterminated-array-secret"')).toBe(
+      '{"set-cookie":["[redacted]"',
+    );
+    expect(
+      redactDiagnosticSecrets('{"Set-Cookie":["sid=capitalized-array-secret"],"region":"eu"}'),
+    ).toBe('{"Set-Cookie":["[redacted]"],"region":"eu"}');
+    expect(
+      redactDiagnosticSecrets(
+        '{"cookie":"json-cookie-secret","apiToken":"json-api-secret","requestId":"useful"}',
+      ),
+    ).toBe('{"cookie":"[redacted]","apiToken":"[redacted]","requestId":"useful"}');
+    expect(
+      redactDiagnosticSecrets(
+        "https://host.example.test/p?api_token=query-api-secret&cookie=query-cookie-secret&region=eu",
+      ),
+    ).toBe("https://host.example.test/p?api_token=[redacted]&cookie=[redacted]&region=eu");
+  });
+
+  it("leaves operational assignment context readable", () => {
+    for (const diagnostic of [
+      "region=eu-central-1",
+      "requestId=req-123",
+      "retry_count=3",
+      "instance-type=c7a.4xlarge",
+      "token_type=Bearer_placeholder",
+    ]) {
+      expect(redactDiagnosticSecrets(diagnostic)).toBe(diagnostic);
+    }
+  });
+
   it("preserves already-redacted and non-userinfo URL at-signs", () => {
     const value =
       "http://<redacted>@broker.example.test https://[redacted]@api.example.test https://host.example.test?email=alice@example.test https://host.example.test#realm@tenant";


### PR DESCRIPTION
## Summary

- replace the delimiter-sensitive credential fallback with context-owned bounds for environment/shell assignments, Cookie and security-token headers, structured JSON values and arrays, and query parameters
- preserve quoted shell syntax, later diagnostic lines, JSON siblings, and routing/request context while failing closed on ambiguous credential bytes
- sanitize legacy stored failure and cleanup diagnostics at the lease GET/list boundary without rewriting stored records

This credits @dwin-gharibi for the original diagnosis and reproduction matrix.

## Verification

- `npm test --prefix worker` — 37 files passed, 2 skipped; 1,346 tests passed, 3 skipped
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm run format:check --prefix worker`
- `npm run build --prefix worker` — Wrangler dry-run build succeeded
- source-blind bundled-artifact contract — 3 clauses, 6 carrier cases, 38 boundary probes, and 4 negative probes passed
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` — clean, no accepted/actionable findings

No configuration or secret changes are required.

Closes https://github.com/openclaw/crabbox/issues/1307
