### PR TITLE
fix(sync): reject native Jujutsu workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Rejected native Jujutsu workspaces before Git-manifest sync can fall through to an outer checkout, while preserving colocated Git workspaces and `--no-sync`. Thanks @atimmer.
 - Redacted compound environment assignments, cookie and security-token headers, and camel-case API-token fields from client-visible coordinator diagnostics while preserving surrounding operational context. Thanks @dwin-gharibi.
 
 ## 0.41.6 - 2026-08-13

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -164,6 +164,13 @@ common caches stay out. Default excludes also cover common generated churn such
 as `.ignored`, `.vite`, `playwright-report`, `test-results`, and local
 `.crabbox` log/capture directories.
 
+Jujutsu workspaces are supported for sync only when `.jj` is colocated with
+same-root `.git` metadata. Native Jujutsu revision mapping is not supported yet;
+`run` fails before lease acquisition or ready-pool borrowing instead of risking
+sync of an outer Git checkout's revision. Use a colocated Git workspace or pass
+`--no-sync` to run without transferring local files. See
+[sync](../features/sync.md#jujutsu-workspaces) for safe initialization guidance.
+
 Before the first rsync into a Git checkout, Crabbox seeds the remote worktree
 from your `origin` remote so the first sync is a dirty-tree overlay instead of a
 full source upload. Crabbox also records a local/remote sync fingerprint and

--- a/docs/features/sync.md
+++ b/docs/features/sync.md
@@ -42,6 +42,21 @@ Git-ignored output, dependency folders, `.git`, and common local caches stay out
 of the transfer. This keeps a first sync close to what CI would see while still
 letting you test uncommitted local edits.
 
+### Jujutsu workspaces
+
+Crabbox currently supports Jujutsu workspaces only when they are colocated with
+Git metadata: the workspace root must contain both `.jj` and `.git`. Native
+Jujutsu revision mapping is not supported yet. Because the sync manifest is
+Git-owned, Crabbox rejects a native `.jj` workspace before leasing or borrowing
+a runner rather than letting Git discover an outer checkout and sync the wrong
+revision. This also applies when the native workspace is nested inside an outer
+Git repository.
+
+If you are starting from an existing Git checkout and want a colocated Jujutsu
+workspace, `jj git init --git-repo=.` is one initialization example. It does not
+convert an existing native Jujutsu repository in place. Use `--no-sync` when you
+intentionally want to run without transferring local files.
+
 The built-in excludes are intentionally conservative. They cover common churn
 such as `node_modules`, `.git`, `dist`, `coverage`, `playwright-report`,
 `test-results`, `.next`, `.vite`, `.turbo`, `target`, `.venv`, `__pycache__`,

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -61,6 +61,9 @@ func nearestRepositoryBoundary(start string) (repositoryBoundary, bool, error) {
 			return repositoryBoundary{}, false, err
 		}
 		if hasGit {
+			if hasJujutsu && !gitBoundaryIsValid(current) {
+				return repositoryBoundary{root: current, kind: repositoryBoundaryNativeJujutsu}, true, nil
+			}
 			return repositoryBoundary{root: current, kind: repositoryBoundaryGit}, true, nil
 		}
 		if hasJujutsu {
@@ -72,6 +75,27 @@ func nearestRepositoryBoundary(start string) (repositoryBoundary, bool, error) {
 		}
 		current = parent
 	}
+}
+
+func gitBoundaryIsValid(root string) bool {
+	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	cmd.Dir = root
+	cmd.Env = repositoryGitEnvironmentWithCeiling(filepath.Dir(root))
+	out, err := cmd.Output()
+	return err == nil && sameRepositoryPath(strings.TrimSpace(string(out)), root)
+}
+
+func repositoryGitEnvironmentWithCeiling(ceiling string) []string {
+	env := repositoryGitEnvironment()
+	result := make([]string, 0, len(env)+1)
+	for _, entry := range env {
+		name, _, _ := strings.Cut(entry, "=")
+		if strings.EqualFold(name, "GIT_CEILING_DIRECTORIES") {
+			continue
+		}
+		result = append(result, entry)
+	}
+	return append(result, "GIT_CEILING_DIRECTORIES="+ceiling)
 }
 
 func explicitGitRepositoryRouting() bool {

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -25,6 +25,60 @@ type Repo struct {
 	BaseRef   string
 }
 
+type repositoryBoundaryKind uint8
+
+const (
+	repositoryBoundaryGit repositoryBoundaryKind = iota + 1
+	repositoryBoundaryNativeJujutsu
+)
+
+type repositoryBoundary struct {
+	root string
+	kind repositoryBoundaryKind
+}
+
+// nearestRepositoryBoundary keeps repository ownership tied to the closest
+// workspace marker. In particular, Git must not discover an outer checkout
+// through a native Jujutsu workspace nested inside it.
+func nearestRepositoryBoundary(start string) (repositoryBoundary, bool, error) {
+	current, err := filepath.Abs(start)
+	if err != nil {
+		return repositoryBoundary{}, false, err
+	}
+	for {
+		hasGit, err := repositoryMarkerExists(filepath.Join(current, ".git"))
+		if err != nil {
+			return repositoryBoundary{}, false, err
+		}
+		hasJujutsu, err := repositoryMarkerExists(filepath.Join(current, ".jj"))
+		if err != nil {
+			return repositoryBoundary{}, false, err
+		}
+		if hasGit {
+			return repositoryBoundary{root: current, kind: repositoryBoundaryGit}, true, nil
+		}
+		if hasJujutsu {
+			return repositoryBoundary{root: current, kind: repositoryBoundaryNativeJujutsu}, true, nil
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return repositoryBoundary{}, false, nil
+		}
+		current = parent
+	}
+}
+
+func repositoryMarkerExists(marker string) (bool, error) {
+	_, err := os.Lstat(marker)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, fmt.Errorf("inspect repository marker %s: %w", marker, err)
+}
+
 // Repository inspection never needs provider or desktop credentials. Keep its
 // environment intentionally small because discovery runs before the complete
 // project configuration (and therefore its secret denylist) is known.
@@ -241,14 +295,21 @@ func nulPathSet(out []byte) map[string]struct{} {
 }
 
 func findRepo() (Repo, error) {
-	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
-	cmd.Env = repositoryGitEnvironment()
-	out, err := cmd.Output()
+	wd, err := os.Getwd()
 	if err != nil {
-		wd, _ := os.Getwd()
+		return Repo{}, err
+	}
+	boundary, found, err := nearestRepositoryBoundary(wd)
+	if err != nil {
+		return Repo{}, err
+	}
+	if !found {
 		return Repo{Root: wd, Name: filepath.Base(wd)}, nil
 	}
-	root := strings.TrimSpace(string(out))
+	if boundary.kind == repositoryBoundaryNativeJujutsu {
+		return Repo{Root: boundary.root, Name: filepath.Base(boundary.root)}, nil
+	}
+	root := boundary.root
 	remoteURL := gitOutput(root, "remote", "get-url", "origin")
 	return Repo{
 		Root:      root,
@@ -763,6 +824,13 @@ func isNotAGitRepoError(stderr string) bool {
 }
 
 func gitSyncFileList(root string) ([]byte, error) {
+	boundary, found, err := nearestRepositoryBoundary(root)
+	if err != nil {
+		return nil, err
+	}
+	if found && boundary.kind == repositoryBoundaryNativeJujutsu {
+		return nil, fmt.Errorf("%s is a native Jujutsu workspace without colocated Git metadata: Crabbox sync is Git-manifest-based, and native Jujutsu sync is not supported yet because it risks syncing the wrong revision; use a colocated Git workspace instead (for example, from an existing Git checkout, initialize Jujutsu with `jj git init --git-repo=.`; this does not convert the current native workspace in place), or pass --no-sync to run without syncing local files", boundary.root)
+	}
 	cmd := exec.Command("git", "ls-files", "--cached", "--others", "--exclude-standard", "-z")
 	cmd.Dir = root
 	cmd.Env = repositoryGitEnvironment()

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -39,39 +39,46 @@ type repositoryBoundary struct {
 }
 
 // nearestRepositoryBoundary keeps repository ownership tied to the closest
-// workspace marker. In particular, Git must not discover an outer checkout
-// through a native Jujutsu workspace nested inside it.
-func nearestRepositoryBoundary(start string) (repositoryBoundary, bool, error) {
+// workspace marker before stop. In particular, Git must not discover an outer
+// checkout through a native Jujutsu workspace nested inside it.
+func nearestRepositoryBoundary(start, stop string) (repositoryBoundary, error) {
 	current, err := filepath.Abs(start)
 	if err != nil {
-		return repositoryBoundary{}, false, err
+		return repositoryBoundary{}, err
 	}
+	current = canonicalRepositoryPath(current)
 	start = current
+	if stop != "" {
+		stop = canonicalRepositoryPath(stop)
+	}
 	ceilings := gitDiscoveryCeilings()
 	for {
-		if current != start && repositoryPathSetContains(ceilings, current) {
-			return repositoryBoundary{}, false, nil
+		if stop != "" && sameCanonicalRepositoryPath(current, stop) {
+			return repositoryBoundary{}, nil
+		}
+		if len(ceilings) > 0 && !sameCanonicalRepositoryPath(current, start) && canonicalRepositoryPathSetContains(ceilings, current) {
+			return repositoryBoundary{}, nil
 		}
 		hasGit, err := repositoryMarkerExists(filepath.Join(current, ".git"))
 		if err != nil {
-			return repositoryBoundary{}, false, err
+			return repositoryBoundary{}, err
 		}
 		hasJujutsu, err := repositoryMarkerExists(filepath.Join(current, ".jj"))
 		if err != nil {
-			return repositoryBoundary{}, false, err
+			return repositoryBoundary{}, err
 		}
 		if hasGit {
 			if hasJujutsu && !gitBoundaryIsValid(current) {
-				return repositoryBoundary{root: current, kind: repositoryBoundaryNativeJujutsu}, true, nil
+				return repositoryBoundary{root: current, kind: repositoryBoundaryNativeJujutsu}, nil
 			}
-			return repositoryBoundary{root: current, kind: repositoryBoundaryGit}, true, nil
+			return repositoryBoundary{root: current, kind: repositoryBoundaryGit}, nil
 		}
 		if hasJujutsu {
-			return repositoryBoundary{root: current, kind: repositoryBoundaryNativeJujutsu}, true, nil
+			return repositoryBoundary{root: current, kind: repositoryBoundaryNativeJujutsu}, nil
 		}
 		parent := filepath.Dir(current)
 		if parent == current {
-			return repositoryBoundary{}, false, nil
+			return repositoryBoundary{}, nil
 		}
 		current = parent
 	}
@@ -86,16 +93,8 @@ func gitBoundaryIsValid(root string) bool {
 }
 
 func repositoryGitEnvironmentWithCeiling(ceiling string) []string {
-	env := repositoryGitEnvironment()
-	result := make([]string, 0, len(env)+1)
-	for _, entry := range env {
-		name, _, _ := strings.Cut(entry, "=")
-		if strings.EqualFold(name, "GIT_CEILING_DIRECTORIES") {
-			continue
-		}
-		result = append(result, entry)
-	}
-	return append(result, "GIT_CEILING_DIRECTORIES="+ceiling)
+	env := childEnvironmentWithout(repositoryGitEnvironment(), "GIT_CEILING_DIRECTORIES")
+	return append(env, "GIT_CEILING_DIRECTORIES="+ceiling)
 }
 
 func explicitGitRepositoryRouting() bool {
@@ -114,10 +113,9 @@ func gitDiscoveryCeilings() []string {
 	return ceilings
 }
 
-func repositoryPathSetContains(paths []string, candidate string) bool {
-	candidate = canonicalRepositoryPath(candidate)
+func canonicalRepositoryPathSetContains(paths []string, candidate string) bool {
 	for _, path := range paths {
-		if sameRepositoryPath(path, candidate) {
+		if sameCanonicalRepositoryPath(path, candidate) {
 			return true
 		}
 	}
@@ -127,6 +125,10 @@ func repositoryPathSetContains(paths []string, candidate string) bool {
 func sameRepositoryPath(left, right string) bool {
 	left = canonicalRepositoryPath(left)
 	right = canonicalRepositoryPath(right)
+	return sameCanonicalRepositoryPath(left, right)
+}
+
+func sameCanonicalRepositoryPath(left, right string) bool {
 	if runtime.GOOS == "windows" {
 		return strings.EqualFold(left, right)
 	}
@@ -139,33 +141,6 @@ func canonicalRepositoryPath(value string) string {
 		return filepath.Clean(resolved)
 	}
 	return value
-}
-
-// closerNativeJujutsuRoot returns a native Jujutsu marker encountered before
-// Git's own discovered root. The Git root itself remains authoritative, which
-// preserves colocated Git/Jujutsu and linked-worktree behavior.
-func closerNativeJujutsuRoot(start, gitRoot string) (string, bool, error) {
-	current, err := filepath.Abs(start)
-	if err != nil {
-		return "", false, err
-	}
-	current = canonicalRepositoryPath(current)
-	gitRoot = canonicalRepositoryPath(gitRoot)
-	for !sameRepositoryPath(current, gitRoot) {
-		hasJujutsu, err := repositoryMarkerExists(filepath.Join(current, ".jj"))
-		if err != nil {
-			return "", false, err
-		}
-		if hasJujutsu {
-			return current, true, nil
-		}
-		parent := filepath.Dir(current)
-		if parent == current {
-			return "", false, nil
-		}
-		current = parent
-	}
-	return "", false, nil
 }
 
 func repositoryMarkerExists(marker string) (bool, error) {
@@ -406,11 +381,11 @@ func findRepo() (Repo, error) {
 	if err != nil {
 		wd, _ := os.Getwd()
 		if !explicitGitRepositoryRouting() {
-			boundary, found, boundaryErr := nearestRepositoryBoundary(wd)
+			boundary, boundaryErr := nearestRepositoryBoundary(wd, "")
 			if boundaryErr != nil {
 				return Repo{}, boundaryErr
 			}
-			if found && boundary.kind == repositoryBoundaryNativeJujutsu {
+			if boundary.kind == repositoryBoundaryNativeJujutsu {
 				return Repo{Root: boundary.root, Name: filepath.Base(boundary.root)}, nil
 			}
 		}
@@ -422,10 +397,10 @@ func findRepo() (Repo, error) {
 		if getwdErr != nil {
 			return Repo{}, getwdErr
 		}
-		if nativeRoot, found, boundaryErr := closerNativeJujutsuRoot(wd, root); boundaryErr != nil {
+		if boundary, boundaryErr := nearestRepositoryBoundary(wd, root); boundaryErr != nil {
 			return Repo{}, boundaryErr
-		} else if found {
-			return Repo{Root: nativeRoot, Name: filepath.Base(nativeRoot)}, nil
+		} else if boundary.kind == repositoryBoundaryNativeJujutsu {
+			return Repo{Root: boundary.root, Name: filepath.Base(boundary.root)}, nil
 		}
 	}
 	remoteURL := gitOutput(root, "remote", "get-url", "origin")
@@ -943,11 +918,11 @@ func isNotAGitRepoError(stderr string) bool {
 
 func gitSyncFileList(root string) ([]byte, error) {
 	if !explicitGitRepositoryRouting() {
-		boundary, found, err := nearestRepositoryBoundary(root)
+		boundary, err := nearestRepositoryBoundary(root, "")
 		if err != nil {
 			return nil, err
 		}
-		if found && boundary.kind == repositoryBoundaryNativeJujutsu {
+		if boundary.kind == repositoryBoundaryNativeJujutsu {
 			return nil, fmt.Errorf("%s is a native Jujutsu workspace without colocated Git metadata: Crabbox sync is Git-manifest-based, and native Jujutsu sync is not supported yet because it risks syncing the wrong revision; use a colocated Git workspace instead (for example, from an existing Git checkout, initialize Jujutsu with `jj git init --git-repo=.`; this does not convert the current native workspace in place), or pass --no-sync to run without syncing local files", boundary.root)
 		}
 	}

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -45,7 +46,12 @@ func nearestRepositoryBoundary(start string) (repositoryBoundary, bool, error) {
 	if err != nil {
 		return repositoryBoundary{}, false, err
 	}
+	start = current
+	ceilings := gitDiscoveryCeilings()
 	for {
+		if current != start && repositoryPathSetContains(ceilings, current) {
+			return repositoryBoundary{}, false, nil
+		}
 		hasGit, err := repositoryMarkerExists(filepath.Join(current, ".git"))
 		if err != nil {
 			return repositoryBoundary{}, false, err
@@ -66,6 +72,76 @@ func nearestRepositoryBoundary(start string) (repositoryBoundary, bool, error) {
 		}
 		current = parent
 	}
+}
+
+func explicitGitRepositoryRouting() bool {
+	return strings.TrimSpace(os.Getenv("GIT_DIR")) != "" || strings.TrimSpace(os.Getenv("GIT_WORK_TREE")) != ""
+}
+
+func gitDiscoveryCeilings() []string {
+	entries := filepath.SplitList(os.Getenv("GIT_CEILING_DIRECTORIES"))
+	ceilings := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry == "" || !filepath.IsAbs(entry) {
+			continue
+		}
+		ceilings = append(ceilings, canonicalRepositoryPath(entry))
+	}
+	return ceilings
+}
+
+func repositoryPathSetContains(paths []string, candidate string) bool {
+	candidate = canonicalRepositoryPath(candidate)
+	for _, path := range paths {
+		if sameRepositoryPath(path, candidate) {
+			return true
+		}
+	}
+	return false
+}
+
+func sameRepositoryPath(left, right string) bool {
+	left = canonicalRepositoryPath(left)
+	right = canonicalRepositoryPath(right)
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(left, right)
+	}
+	return left == right
+}
+
+func canonicalRepositoryPath(value string) string {
+	value = filepath.Clean(value)
+	if resolved, err := filepath.EvalSymlinks(value); err == nil {
+		return filepath.Clean(resolved)
+	}
+	return value
+}
+
+// closerNativeJujutsuRoot returns a native Jujutsu marker encountered before
+// Git's own discovered root. The Git root itself remains authoritative, which
+// preserves colocated Git/Jujutsu and linked-worktree behavior.
+func closerNativeJujutsuRoot(start, gitRoot string) (string, bool, error) {
+	current, err := filepath.Abs(start)
+	if err != nil {
+		return "", false, err
+	}
+	current = canonicalRepositoryPath(current)
+	gitRoot = canonicalRepositoryPath(gitRoot)
+	for !sameRepositoryPath(current, gitRoot) {
+		hasJujutsu, err := repositoryMarkerExists(filepath.Join(current, ".jj"))
+		if err != nil {
+			return "", false, err
+		}
+		if hasJujutsu {
+			return current, true, nil
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return "", false, nil
+		}
+		current = parent
+	}
+	return "", false, nil
 }
 
 func repositoryMarkerExists(marker string) (bool, error) {
@@ -94,9 +170,14 @@ func repositoryGitEnvironment() []string {
 	}
 	result := make([]string, 0, len(allowed)+4)
 	for _, entry := range os.Environ() {
-		name, _, _ := strings.Cut(entry, "=")
+		name, value, _ := strings.Cut(entry, "=")
 		upper := strings.ToUpper(name)
 		if _, ok := allowed[upper]; ok || strings.HasPrefix(upper, "LC_") {
+			if (upper == "GIT_DIR" || upper == "GIT_WORK_TREE") && value != "" && !filepath.IsAbs(value) {
+				if absolute, err := filepath.Abs(value); err == nil {
+					entry = name + "=" + absolute
+				}
+			}
 			result = append(result, entry)
 		}
 	}
@@ -295,21 +376,34 @@ func nulPathSet(out []byte) map[string]struct{} {
 }
 
 func findRepo() (Repo, error) {
-	wd, err := os.Getwd()
+	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	cmd.Env = repositoryGitEnvironment()
+	out, err := cmd.Output()
 	if err != nil {
-		return Repo{}, err
-	}
-	boundary, found, err := nearestRepositoryBoundary(wd)
-	if err != nil {
-		return Repo{}, err
-	}
-	if !found {
+		wd, _ := os.Getwd()
+		if !explicitGitRepositoryRouting() {
+			boundary, found, boundaryErr := nearestRepositoryBoundary(wd)
+			if boundaryErr != nil {
+				return Repo{}, boundaryErr
+			}
+			if found && boundary.kind == repositoryBoundaryNativeJujutsu {
+				return Repo{Root: boundary.root, Name: filepath.Base(boundary.root)}, nil
+			}
+		}
 		return Repo{Root: wd, Name: filepath.Base(wd)}, nil
 	}
-	if boundary.kind == repositoryBoundaryNativeJujutsu {
-		return Repo{Root: boundary.root, Name: filepath.Base(boundary.root)}, nil
+	root := strings.TrimSpace(string(out))
+	if !explicitGitRepositoryRouting() {
+		wd, getwdErr := os.Getwd()
+		if getwdErr != nil {
+			return Repo{}, getwdErr
+		}
+		if nativeRoot, found, boundaryErr := closerNativeJujutsuRoot(wd, root); boundaryErr != nil {
+			return Repo{}, boundaryErr
+		} else if found {
+			return Repo{Root: nativeRoot, Name: filepath.Base(nativeRoot)}, nil
+		}
 	}
-	root := boundary.root
 	remoteURL := gitOutput(root, "remote", "get-url", "origin")
 	return Repo{
 		Root:      root,
@@ -824,12 +918,14 @@ func isNotAGitRepoError(stderr string) bool {
 }
 
 func gitSyncFileList(root string) ([]byte, error) {
-	boundary, found, err := nearestRepositoryBoundary(root)
-	if err != nil {
-		return nil, err
-	}
-	if found && boundary.kind == repositoryBoundaryNativeJujutsu {
-		return nil, fmt.Errorf("%s is a native Jujutsu workspace without colocated Git metadata: Crabbox sync is Git-manifest-based, and native Jujutsu sync is not supported yet because it risks syncing the wrong revision; use a colocated Git workspace instead (for example, from an existing Git checkout, initialize Jujutsu with `jj git init --git-repo=.`; this does not convert the current native workspace in place), or pass --no-sync to run without syncing local files", boundary.root)
+	if !explicitGitRepositoryRouting() {
+		boundary, found, err := nearestRepositoryBoundary(root)
+		if err != nil {
+			return nil, err
+		}
+		if found && boundary.kind == repositoryBoundaryNativeJujutsu {
+			return nil, fmt.Errorf("%s is a native Jujutsu workspace without colocated Git metadata: Crabbox sync is Git-manifest-based, and native Jujutsu sync is not supported yet because it risks syncing the wrong revision; use a colocated Git workspace instead (for example, from an existing Git checkout, initialize Jujutsu with `jj git init --git-repo=.`; this does not convert the current native workspace in place), or pass --no-sync to run without syncing local files", boundary.root)
+		}
 	}
 	cmd := exec.Command("git", "ls-files", "--cached", "--others", "--exclude-standard", "-z")
 	cmd.Dir = root

--- a/internal/cli/repo_test.go
+++ b/internal/cli/repo_test.go
@@ -132,19 +132,55 @@ func TestFindRepoNearestRepositoryMarkerWins(t *testing.T) {
 }
 
 func TestNearestRepositoryBoundaryAcceptsGitFileMarker(t *testing.T) {
-	root := t.TempDir()
-	if err := os.WriteFile(filepath.Join(root, ".git"), []byte("gitdir: /tmp/example\n"), 0o644); err != nil {
+	parent := t.TempDir()
+	source := filepath.Join(parent, "source")
+	if err := os.Mkdir(source, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Mkdir(filepath.Join(root, ".jj"), 0o755); err != nil {
+	runGit(t, source, "init")
+	runGit(t, source, "config", "user.email", "test@example.com")
+	runGit(t, source, "config", "user.name", "Test")
+	writeFile(t, filepath.Join(source, "tracked.txt"), "tracked\n")
+	runGit(t, source, "add", "tracked.txt")
+	runGit(t, source, "commit", "-m", "init")
+	worktree := filepath.Join(parent, "worktree")
+	runGit(t, source, "worktree", "add", "--detach", worktree)
+	if err := os.Mkdir(filepath.Join(worktree, ".jj"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	boundary, found, err := nearestRepositoryBoundary(root)
+	boundary, found, err := nearestRepositoryBoundary(worktree)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !found || boundary.kind != repositoryBoundaryGit || boundary.root != root {
+	if !found || boundary.kind != repositoryBoundaryGit || !sameRepositoryPath(boundary.root, worktree) {
 		t.Fatalf("boundary=%#v found=%v, want colocated Git root", boundary, found)
+	}
+}
+
+func TestSyncManifestRejectsInvalidColocatedGitMarkerInsideOuterGit(t *testing.T) {
+	outer := t.TempDir()
+	runGit(t, outer, "init")
+	nativeRoot := filepath.Join(outer, "native-workspace")
+	makeNativeJujutsuWorkspace(t, nativeRoot)
+	if err := os.Mkdir(filepath.Join(nativeRoot, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	workingDir := filepath.Join(nativeRoot, "src")
+	if err := os.Mkdir(workingDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(workingDir)
+
+	repo, err := findRepo()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sameRepositoryPath(repo.Root, nativeRoot) {
+		t.Fatalf("repo root=%q want native Jujutsu root %q", repo.Root, nativeRoot)
+	}
+	_, err = syncManifest(repo.Root, configuredExcludes(baseConfig()))
+	if err == nil || !strings.Contains(err.Error(), "native Jujutsu workspace") {
+		t.Fatalf("manifest error=%v, want native Jujutsu rejection", err)
 	}
 }
 

--- a/internal/cli/repo_test.go
+++ b/internal/cli/repo_test.go
@@ -34,11 +34,7 @@ func TestFindRepoUsesOriginNameInsideLinkedWorktree(t *testing.T) {
 		t.Fatal(err)
 	}
 	runGit(t, root, "init")
-	runGit(t, root, "config", "user.email", "test@example.com")
-	runGit(t, root, "config", "user.name", "Test")
-	writeFile(t, filepath.Join(root, "README.md"), "crabbox\n")
-	runGit(t, root, "add", "README.md")
-	runGit(t, root, "commit", "-m", "init")
+	runGit(t, root, "-c", "user.email=test@example.com", "-c", "user.name=Test", "commit", "--allow-empty", "-m", "init")
 	runGit(t, root, "remote", "add", "origin", "https://github.com/openclaw/crabbox.git")
 
 	worktree := filepath.Join(parent, "fix-blacksmith-success-workflow-state")
@@ -89,9 +85,7 @@ func TestFindRepoNearestRepositoryMarkerWins(t *testing.T) {
 	t.Run("colocated Jujutsu and Git", func(t *testing.T) {
 		root := t.TempDir()
 		runGit(t, root, "init")
-		if err := os.Mkdir(filepath.Join(root, ".jj"), 0o755); err != nil {
-			t.Fatal(err)
-		}
+		makeNativeJujutsuWorkspace(t, root)
 		workingDir := filepath.Join(root, "src")
 		if err := os.Mkdir(workingDir, 0o755); err != nil {
 			t.Fatal(err)
@@ -138,22 +132,16 @@ func TestNearestRepositoryBoundaryAcceptsGitFileMarker(t *testing.T) {
 		t.Fatal(err)
 	}
 	runGit(t, source, "init")
-	runGit(t, source, "config", "user.email", "test@example.com")
-	runGit(t, source, "config", "user.name", "Test")
-	writeFile(t, filepath.Join(source, "tracked.txt"), "tracked\n")
-	runGit(t, source, "add", "tracked.txt")
-	runGit(t, source, "commit", "-m", "init")
+	runGit(t, source, "-c", "user.email=test@example.com", "-c", "user.name=Test", "commit", "--allow-empty", "-m", "init")
 	worktree := filepath.Join(parent, "worktree")
 	runGit(t, source, "worktree", "add", "--detach", worktree)
-	if err := os.Mkdir(filepath.Join(worktree, ".jj"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	boundary, found, err := nearestRepositoryBoundary(worktree)
+	makeNativeJujutsuWorkspace(t, worktree)
+	boundary, err := nearestRepositoryBoundary(worktree, "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !found || boundary.kind != repositoryBoundaryGit || !sameRepositoryPath(boundary.root, worktree) {
-		t.Fatalf("boundary=%#v found=%v, want colocated Git root", boundary, found)
+	if boundary.kind != repositoryBoundaryGit || !sameRepositoryPath(boundary.root, worktree) {
+		t.Fatalf("boundary=%#v, want colocated Git root", boundary)
 	}
 }
 
@@ -827,9 +815,7 @@ func TestSyncManifestNativeJujutsuReturnsActionableError(t *testing.T) {
 func TestSyncManifestColocatedJujutsuUsesGitManifest(t *testing.T) {
 	root := t.TempDir()
 	runGit(t, root, "init")
-	if err := os.Mkdir(filepath.Join(root, ".jj"), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	makeNativeJujutsuWorkspace(t, root)
 	writeFile(t, filepath.Join(root, "tracked.txt"), "tracked\n")
 	runGit(t, root, "add", "tracked.txt")
 

--- a/internal/cli/repo_test.go
+++ b/internal/cli/repo_test.go
@@ -65,6 +65,96 @@ func TestFindRepoUsesOriginNameInsideLinkedWorktree(t *testing.T) {
 	}
 }
 
+func TestFindRepoNearestRepositoryMarkerWins(t *testing.T) {
+	t.Run("native Jujutsu nested in outer Git", func(t *testing.T) {
+		outer := t.TempDir()
+		runGit(t, outer, "init")
+		nativeRoot := filepath.Join(outer, "native")
+		makeNativeJujutsuWorkspace(t, nativeRoot)
+		workingDir := filepath.Join(nativeRoot, "src")
+		if err := os.MkdirAll(workingDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		t.Chdir(workingDir)
+
+		repo, err := findRepo()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if repo.Root != nativeRoot {
+			t.Fatalf("repo root=%q want native Jujutsu root %q", repo.Root, nativeRoot)
+		}
+	})
+
+	t.Run("colocated Jujutsu and Git", func(t *testing.T) {
+		root := t.TempDir()
+		runGit(t, root, "init")
+		if err := os.Mkdir(filepath.Join(root, ".jj"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		workingDir := filepath.Join(root, "src")
+		if err := os.Mkdir(workingDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		t.Chdir(workingDir)
+
+		repo, err := findRepo()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if repo.Root != root {
+			t.Fatalf("repo root=%q want colocated Git root %q", repo.Root, root)
+		}
+	})
+
+	t.Run("closer Git nested in outer Jujutsu", func(t *testing.T) {
+		outer := t.TempDir()
+		makeNativeJujutsuWorkspace(t, outer)
+		gitRoot := filepath.Join(outer, "git-workspace")
+		if err := os.Mkdir(gitRoot, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		runGit(t, gitRoot, "init")
+		workingDir := filepath.Join(gitRoot, "src")
+		if err := os.Mkdir(workingDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		t.Chdir(workingDir)
+
+		repo, err := findRepo()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if repo.Root != gitRoot {
+			t.Fatalf("repo root=%q want closer Git root %q", repo.Root, gitRoot)
+		}
+	})
+}
+
+func TestNearestRepositoryBoundaryAcceptsGitFileMarker(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".git"), []byte("gitdir: /tmp/example\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(root, ".jj"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	boundary, found, err := nearestRepositoryBoundary(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found || boundary.kind != repositoryBoundaryGit || boundary.root != root {
+		t.Fatalf("boundary=%#v found=%v, want colocated Git root", boundary, found)
+	}
+}
+
+func makeNativeJujutsuWorkspace(t *testing.T, root string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(root, ".jj"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestRepoNameFromRootAndRemoteFallsBackToRemoteBasename(t *testing.T) {
 	if got := repoNameFromRootAndRemote("/tmp/worktrees/feature", "git@gitlab.example.com:team/project.git"); got != "project" {
 		t.Fatalf("repo name=%q want project", got)
@@ -586,6 +676,54 @@ func TestSyncManifestNonGitWorkdirReturnsActionableError(t *testing.T) {
 		if !strings.Contains(msg, want) {
 			t.Fatalf("error should suggest %q: %q", want, msg)
 		}
+	}
+}
+
+func TestSyncManifestNativeJujutsuReturnsActionableError(t *testing.T) {
+	outer := t.TempDir()
+	runGit(t, outer, "init")
+	root := filepath.Join(outer, "native-workspace")
+	makeNativeJujutsuWorkspace(t, root)
+	writeFile(t, filepath.Join(root, "main.txt"), "hello\n")
+
+	_, err := syncManifest(root, configuredExcludes(baseConfig()))
+	if err == nil {
+		t.Fatal("expected error for native Jujutsu workspace, got nil")
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		root,
+		"native Jujutsu workspace",
+		"Git-manifest-based",
+		"native Jujutsu sync is not supported yet",
+		"wrong revision",
+		"colocated Git workspace",
+		"from an existing Git checkout",
+		"jj git init --git-repo=.",
+		"does not convert the current native workspace in place",
+		"--no-sync",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("error should include %q: %q", want, msg)
+		}
+	}
+}
+
+func TestSyncManifestColocatedJujutsuUsesGitManifest(t *testing.T) {
+	root := t.TempDir()
+	runGit(t, root, "init")
+	if err := os.Mkdir(filepath.Join(root, ".jj"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(root, "tracked.txt"), "tracked\n")
+	runGit(t, root, "add", "tracked.txt")
+
+	manifest, err := syncManifest(root, configuredExcludes(baseConfig()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Join(manifest.Files, ",") != "tracked.txt" {
+		t.Fatalf("manifest files=%v, want ordinary Git manifest", manifest.Files)
 	}
 }
 

--- a/internal/cli/repo_test.go
+++ b/internal/cli/repo_test.go
@@ -81,7 +81,7 @@ func TestFindRepoNearestRepositoryMarkerWins(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if repo.Root != nativeRoot {
+		if !sameRepositoryPath(repo.Root, nativeRoot) {
 			t.Fatalf("repo root=%q want native Jujutsu root %q", repo.Root, nativeRoot)
 		}
 	})
@@ -102,7 +102,7 @@ func TestFindRepoNearestRepositoryMarkerWins(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if repo.Root != root {
+		if !sameRepositoryPath(repo.Root, root) {
 			t.Fatalf("repo root=%q want colocated Git root %q", repo.Root, root)
 		}
 	})
@@ -125,7 +125,7 @@ func TestFindRepoNearestRepositoryMarkerWins(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if repo.Root != gitRoot {
+		if !sameRepositoryPath(repo.Root, gitRoot) {
 			t.Fatalf("repo root=%q want closer Git root %q", repo.Root, gitRoot)
 		}
 	})
@@ -145,6 +145,85 @@ func TestNearestRepositoryBoundaryAcceptsGitFileMarker(t *testing.T) {
 	}
 	if !found || boundary.kind != repositoryBoundaryGit || boundary.root != root {
 		t.Fatalf("boundary=%#v found=%v, want colocated Git root", boundary, found)
+	}
+}
+
+func TestFindRepoPreservesExplicitGitRoutingInsideNativeJujutsu(t *testing.T) {
+	parent := t.TempDir()
+	explicitWorktree := filepath.Join(parent, "explicit-worktree")
+	if err := os.Mkdir(explicitWorktree, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, explicitWorktree, "init")
+	writeFile(t, filepath.Join(explicitWorktree, "tracked.txt"), "tracked\n")
+	runGit(t, explicitWorktree, "add", "tracked.txt")
+
+	nativeRoot := filepath.Join(parent, "native-workspace")
+	makeNativeJujutsuWorkspace(t, nativeRoot)
+	workingDir := filepath.Join(nativeRoot, "src")
+	if err := os.Mkdir(workingDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(workingDir)
+	relativeGitDir, err := filepath.Rel(workingDir, filepath.Join(explicitWorktree, ".git"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	relativeWorktree, err := filepath.Rel(workingDir, explicitWorktree)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GIT_DIR", relativeGitDir)
+	t.Setenv("GIT_WORK_TREE", relativeWorktree)
+
+	repo, err := findRepo()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sameRepositoryPath(repo.Root, explicitWorktree) {
+		t.Fatalf("repo root=%q want explicit Git worktree %q", repo.Root, explicitWorktree)
+	}
+	manifest, err := syncManifest(repo.Root, configuredExcludes(baseConfig()))
+	if err != nil {
+		t.Fatalf("explicit Git manifest failed: %v", err)
+	}
+	if strings.Join(manifest.Files, ",") != "tracked.txt" {
+		t.Fatalf("manifest files=%v, want explicitly routed Git manifest", manifest.Files)
+	}
+}
+
+func TestFindRepoHonorsGitDiscoveryCeilingForJujutsuFallback(t *testing.T) {
+	outerGit := t.TempDir()
+	runGit(t, outerGit, "init")
+	nativeRoot := filepath.Join(outerGit, "native-workspace")
+	makeNativeJujutsuWorkspace(t, nativeRoot)
+	workingDir := filepath.Join(nativeRoot, "work")
+	if err := os.Mkdir(workingDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(workingDir)
+	t.Setenv("GIT_DIR", "")
+	t.Setenv("GIT_WORK_TREE", "")
+	t.Setenv("GIT_CEILING_DIRECTORIES", nativeRoot)
+
+	repo, err := findRepo()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sameRepositoryPath(repo.Root, workingDir) {
+		t.Fatalf("repo root=%q want non-repository fallback %q", repo.Root, workingDir)
+	}
+	_, err = syncManifest(repo.Root, configuredExcludes(baseConfig()))
+	if err == nil {
+		t.Fatal("expected ordinary non-Git manifest error below discovery ceiling")
+	}
+	if strings.Contains(err.Error(), "native Jujutsu workspace") {
+		t.Fatalf("manifest crossed Git discovery ceiling: %v", err)
+	}
+	for _, want := range []string{"not a Git repository", "git init", "--no-sync"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("ordinary non-Git error missing %q: %v", want, err)
+		}
 	}
 }
 

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -732,6 +732,36 @@ func TestRunNonGitWorkdirFailsBeforeAcquire(t *testing.T) {
 	}
 }
 
+func TestRunNativeJujutsuFailsBeforeAcquire(t *testing.T) {
+	clearConfigEnv(t)
+	dir := t.TempDir()
+	isolateRunTestUserDirs(t, dir)
+	makeNativeJujutsuWorkspace(t, dir)
+	t.Chdir(dir)
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, "missing.yaml"))
+	acquireCalls := 0
+	runEnvProfileTestAcquireHook = func(AcquireRequest) { acquireCalls++ }
+	t.Cleanup(func() { runEnvProfileTestAcquireHook = nil })
+
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
+		"--provider", "run-env-profile-test",
+		"--", "true",
+	})
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 6 {
+		t.Fatalf("error=%v, want exit 6\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	if acquireCalls != 0 {
+		t.Fatalf("Acquire called %d time(s) before native Jujutsu failure", acquireCalls)
+	}
+	for _, want := range []string{dir, "native Jujutsu workspace", "Git-manifest-based", "wrong revision", "colocated Git workspace", "jj git init --git-repo=.", "--no-sync"} {
+		if !strings.Contains(exitErr.Message, want) {
+			t.Fatalf("message missing %q: %q", want, exitErr.Message)
+		}
+	}
+}
+
 func TestRunNonGitWorkdirFailsBeforeReadyPoolBorrow(t *testing.T) {
 	clearConfigEnv(t)
 	dir := t.TempDir()
@@ -761,6 +791,40 @@ func TestRunNonGitWorkdirFailsBeforeReadyPoolBorrow(t *testing.T) {
 	select {
 	case request := <-requests:
 		t.Fatalf("ready-pool request occurred before local manifest failure: %s", request)
+	default:
+	}
+}
+
+func TestRunNativeJujutsuFailsBeforeReadyPoolBorrow(t *testing.T) {
+	clearConfigEnv(t)
+	dir := t.TempDir()
+	isolateRunTestUserDirs(t, dir)
+	makeNativeJujutsuWorkspace(t, dir)
+	t.Chdir(dir)
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, "missing.yaml"))
+	requests := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests <- r.Method + " " + r.URL.Path
+		http.Error(w, "unexpected request", http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+	t.Setenv("CRABBOX_COORDINATOR", server.URL)
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "test-token")
+
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
+		"--provider", "run-ready-pool-preflight-test",
+		"--pool", "shared-linux",
+		"--pool-return", "drain",
+		"--", "true",
+	})
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 6 || !strings.Contains(exitErr.Message, "native Jujutsu workspace") {
+		t.Fatalf("error=%v, want native Jujutsu exit 6\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	select {
+	case request := <-requests:
+		t.Fatalf("ready-pool request occurred before native Jujutsu failure: %s", request)
 	default:
 	}
 }
@@ -985,6 +1049,58 @@ func TestRunNonGitWorkdirFailsBeforeExistingLeaseResolveAndPrepare(t *testing.T)
 	}
 	if len(runPrepareTestResolveRequests) != 0 {
 		t.Fatalf("Resolve/Prepare called before local manifest failure: %#v", runPrepareTestResolveRequests)
+	}
+}
+
+func TestRunNativeJujutsuFailsBeforeExistingLeaseResolveAndPrepare(t *testing.T) {
+	clearConfigEnv(t)
+	dir := t.TempDir()
+	isolateRunTestUserDirs(t, dir)
+	makeNativeJujutsuWorkspace(t, dir)
+	t.Chdir(dir)
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, "missing.yaml"))
+	runPrepareTestResolveRequests = nil
+
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
+		"--provider", "run-prepare-test",
+		"--id", "cbx_existing",
+		"--", "true",
+	})
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 6 || !strings.Contains(exitErr.Message, "native Jujutsu workspace") {
+		t.Fatalf("error=%v, want native Jujutsu exit 6\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	if len(runPrepareTestResolveRequests) != 0 {
+		t.Fatalf("Resolve/Prepare called before native Jujutsu failure: %#v", runPrepareTestResolveRequests)
+	}
+}
+
+func TestRunNativeJujutsuNoSyncReachesBackend(t *testing.T) {
+	clearConfigEnv(t)
+	dir := t.TempDir()
+	isolateRunTestUserDirs(t, dir)
+	makeNativeJujutsuWorkspace(t, dir)
+	t.Chdir(dir)
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, "missing.yaml"))
+	runPrepareTestResolveRequests = nil
+
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
+		"--provider", "run-prepare-test",
+		"--id", "cbx_existing",
+		"--no-sync",
+		"--", "true",
+	})
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 9 || !strings.Contains(exitErr.Message, "resolve captured") {
+		t.Fatalf("run error=%v, want backend resolve proof\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	if strings.Contains(exitErr.Message, "native Jujutsu workspace") {
+		t.Fatalf("--no-sync triggered native Jujutsu guard: %q", exitErr.Message)
+	}
+	if len(runPrepareTestResolveRequests) != 1 || !runPrepareTestResolveRequests[0].Prepare {
+		t.Fatalf("--no-sync did not reach backend Resolve/Prepare: %#v", runPrepareTestResolveRequests)
 	}
 }
 

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -703,129 +703,92 @@ func (b runEnvProfileTestBackend) ReleaseLeaseConnectionCleanupSafe() bool {
 	return runEnvProfileTestConnectionCleanupSafe
 }
 
-func TestRunNonGitWorkdirFailsBeforeAcquire(t *testing.T) {
-	clearConfigEnv(t)
-	dir := t.TempDir()
-	isolateRunTestUserDirs(t, dir)
-	t.Chdir(dir)
-	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, "missing.yaml"))
-	acquireCalls := 0
-	runEnvProfileTestAcquireHook = func(AcquireRequest) { acquireCalls++ }
-	t.Cleanup(func() { runEnvProfileTestAcquireHook = nil })
+type runWorkdirCase struct {
+	name       string
+	native     bool
+	diagnostic string
+	guidance   []string
+}
 
-	var stdout, stderr bytes.Buffer
-	err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
-		"--provider", "run-env-profile-test",
-		"--", "true",
-	})
-	var exitErr ExitError
-	if !AsExitError(err, &exitErr) || exitErr.Code != 6 {
-		t.Fatalf("error=%v, want exit 6\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
-	}
-	if acquireCalls != 0 {
-		t.Fatalf("Acquire called %d time(s) before local manifest failure", acquireCalls)
-	}
-	for _, want := range []string{dir, "not a Git repository", "git init", "--no-sync"} {
-		if !strings.Contains(exitErr.Message, want) {
-			t.Fatalf("message missing %q: %q", want, exitErr.Message)
-		}
+func runWorkdirCases() []runWorkdirCase {
+	return []runWorkdirCase{
+		{name: "ordinary non-Git", diagnostic: "not a Git repository", guidance: []string{"git init", "--no-sync"}},
+		{name: "native Jujutsu", native: true, diagnostic: "native Jujutsu workspace", guidance: []string{"Git-manifest-based", "wrong revision", "colocated Git workspace", "jj git init --git-repo=.", "--no-sync"}},
 	}
 }
 
-func TestRunNativeJujutsuFailsBeforeAcquire(t *testing.T) {
+func setupRunWorkdirCase(t *testing.T, tc runWorkdirCase) string {
+	t.Helper()
 	clearConfigEnv(t)
 	dir := t.TempDir()
 	isolateRunTestUserDirs(t, dir)
-	makeNativeJujutsuWorkspace(t, dir)
+	if tc.native {
+		makeNativeJujutsuWorkspace(t, dir)
+	}
 	t.Chdir(dir)
 	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, "missing.yaml"))
-	acquireCalls := 0
-	runEnvProfileTestAcquireHook = func(AcquireRequest) { acquireCalls++ }
-	t.Cleanup(func() { runEnvProfileTestAcquireHook = nil })
+	return dir
+}
 
-	var stdout, stderr bytes.Buffer
-	err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
-		"--provider", "run-env-profile-test",
-		"--", "true",
-	})
-	var exitErr ExitError
-	if !AsExitError(err, &exitErr) || exitErr.Code != 6 {
-		t.Fatalf("error=%v, want exit 6\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
-	}
-	if acquireCalls != 0 {
-		t.Fatalf("Acquire called %d time(s) before native Jujutsu failure", acquireCalls)
-	}
-	for _, want := range []string{dir, "native Jujutsu workspace", "Git-manifest-based", "wrong revision", "colocated Git workspace", "jj git init --git-repo=.", "--no-sync"} {
-		if !strings.Contains(exitErr.Message, want) {
-			t.Fatalf("message missing %q: %q", want, exitErr.Message)
-		}
+func TestRunWorkdirFailsBeforeAcquire(t *testing.T) {
+	for _, tc := range runWorkdirCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := setupRunWorkdirCase(t, tc)
+			acquireCalls := 0
+			runEnvProfileTestAcquireHook = func(AcquireRequest) { acquireCalls++ }
+			t.Cleanup(func() { runEnvProfileTestAcquireHook = nil })
+
+			var stdout, stderr bytes.Buffer
+			err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
+				"--provider", "run-env-profile-test",
+				"--", "true",
+			})
+			var exitErr ExitError
+			if !AsExitError(err, &exitErr) || exitErr.Code != 6 {
+				t.Fatalf("error=%v, want exit 6\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+			}
+			if acquireCalls != 0 {
+				t.Fatalf("Acquire called %d time(s) before local manifest failure", acquireCalls)
+			}
+			for _, want := range append([]string{dir, tc.diagnostic}, tc.guidance...) {
+				if !strings.Contains(exitErr.Message, want) {
+					t.Fatalf("message missing %q: %q", want, exitErr.Message)
+				}
+			}
+		})
 	}
 }
 
-func TestRunNonGitWorkdirFailsBeforeReadyPoolBorrow(t *testing.T) {
-	clearConfigEnv(t)
-	dir := t.TempDir()
-	isolateRunTestUserDirs(t, dir)
-	t.Chdir(dir)
-	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, "missing.yaml"))
-	requests := make(chan string, 1)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requests <- r.Method + " " + r.URL.Path
-		http.Error(w, "unexpected request", http.StatusInternalServerError)
-	}))
-	t.Cleanup(server.Close)
-	t.Setenv("CRABBOX_COORDINATOR", server.URL)
-	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "test-token")
+func TestRunWorkdirFailsBeforeReadyPoolBorrow(t *testing.T) {
+	for _, tc := range runWorkdirCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			setupRunWorkdirCase(t, tc)
+			requests := make(chan string, 1)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests <- r.Method + " " + r.URL.Path
+				http.Error(w, "unexpected request", http.StatusInternalServerError)
+			}))
+			t.Cleanup(server.Close)
+			t.Setenv("CRABBOX_COORDINATOR", server.URL)
+			t.Setenv("CRABBOX_COORDINATOR_TOKEN", "test-token")
 
-	var stdout, stderr bytes.Buffer
-	err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
-		"--provider", "run-ready-pool-preflight-test",
-		"--pool", "shared-linux",
-		"--pool-return", "drain",
-		"--", "true",
-	})
-	var exitErr ExitError
-	if !AsExitError(err, &exitErr) || exitErr.Code != 6 || !strings.Contains(exitErr.Message, "not a Git repository") {
-		t.Fatalf("error=%v, want non-Git exit 6\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
-	}
-	select {
-	case request := <-requests:
-		t.Fatalf("ready-pool request occurred before local manifest failure: %s", request)
-	default:
-	}
-}
-
-func TestRunNativeJujutsuFailsBeforeReadyPoolBorrow(t *testing.T) {
-	clearConfigEnv(t)
-	dir := t.TempDir()
-	isolateRunTestUserDirs(t, dir)
-	makeNativeJujutsuWorkspace(t, dir)
-	t.Chdir(dir)
-	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, "missing.yaml"))
-	requests := make(chan string, 1)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requests <- r.Method + " " + r.URL.Path
-		http.Error(w, "unexpected request", http.StatusInternalServerError)
-	}))
-	t.Cleanup(server.Close)
-	t.Setenv("CRABBOX_COORDINATOR", server.URL)
-	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "test-token")
-
-	var stdout, stderr bytes.Buffer
-	err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
-		"--provider", "run-ready-pool-preflight-test",
-		"--pool", "shared-linux",
-		"--pool-return", "drain",
-		"--", "true",
-	})
-	var exitErr ExitError
-	if !AsExitError(err, &exitErr) || exitErr.Code != 6 || !strings.Contains(exitErr.Message, "native Jujutsu workspace") {
-		t.Fatalf("error=%v, want native Jujutsu exit 6\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
-	}
-	select {
-	case request := <-requests:
-		t.Fatalf("ready-pool request occurred before native Jujutsu failure: %s", request)
-	default:
+			var stdout, stderr bytes.Buffer
+			err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
+				"--provider", "run-ready-pool-preflight-test",
+				"--pool", "shared-linux",
+				"--pool-return", "drain",
+				"--", "true",
+			})
+			var exitErr ExitError
+			if !AsExitError(err, &exitErr) || exitErr.Code != 6 || !strings.Contains(exitErr.Message, tc.diagnostic) {
+				t.Fatalf("error=%v, want %s exit 6\nstdout=%s\nstderr=%s", err, tc.name, stdout.String(), stderr.String())
+			}
+			select {
+			case request := <-requests:
+				t.Fatalf("ready-pool request occurred before local manifest failure: %s", request)
+			default:
+			}
+		})
 	}
 }
 
@@ -1002,105 +965,56 @@ func (b runModuleRuntimeTestBackend) Stop(context.Context, StopRequest) error {
 	return nil
 }
 
-func TestRunWithExistingLeaseRequestsProviderPreparation(t *testing.T) {
-	clearConfigEnv(t)
-	dir := t.TempDir()
-	isolateRunTestUserDirs(t, dir)
-	t.Chdir(dir)
-	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, "missing.yaml"))
-	runPrepareTestResolveRequests = nil
-	var stdout, stderr bytes.Buffer
-	err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
-		"--provider", "run-prepare-test",
-		"--id", "cbx_existing",
-		"--no-sync",
-		"--",
-		"true",
-	})
-	var exitErr ExitError
-	if !AsExitError(err, &exitErr) || exitErr.Code != 9 || !strings.Contains(exitErr.Message, "resolve captured") {
-		t.Fatalf("run error=%v, want resolve-captured exit", err)
-	}
-	if len(runPrepareTestResolveRequests) != 1 {
-		t.Fatalf("resolve requests=%#v, want one", runPrepareTestResolveRequests)
-	}
-	if got := runPrepareTestResolveRequests[0]; got.ID != "cbx_existing" || !got.Prepare {
-		t.Fatalf("resolve request=%#v, want existing id with Prepare", got)
+func TestRunNoSyncRequestsExistingLeasePreparation(t *testing.T) {
+	for _, tc := range runWorkdirCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			setupRunWorkdirCase(t, tc)
+			runPrepareTestResolveRequests = nil
+
+			var stdout, stderr bytes.Buffer
+			err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
+				"--provider", "run-prepare-test",
+				"--id", "cbx_existing",
+				"--no-sync",
+				"--", "true",
+			})
+			var exitErr ExitError
+			if !AsExitError(err, &exitErr) || exitErr.Code != 9 || !strings.Contains(exitErr.Message, "resolve captured") {
+				t.Fatalf("run error=%v, want backend resolve proof\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+			}
+			if strings.Contains(exitErr.Message, "native Jujutsu workspace") {
+				t.Fatalf("--no-sync triggered native Jujutsu guard: %q", exitErr.Message)
+			}
+			if len(runPrepareTestResolveRequests) != 1 {
+				t.Fatalf("resolve requests=%#v, want one", runPrepareTestResolveRequests)
+			}
+			if got := runPrepareTestResolveRequests[0]; got.ID != "cbx_existing" || !got.Prepare {
+				t.Fatalf("resolve request=%#v, want existing id with Prepare", got)
+			}
+		})
 	}
 }
 
-func TestRunNonGitWorkdirFailsBeforeExistingLeaseResolveAndPrepare(t *testing.T) {
-	clearConfigEnv(t)
-	dir := t.TempDir()
-	isolateRunTestUserDirs(t, dir)
-	t.Chdir(dir)
-	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, "missing.yaml"))
-	runPrepareTestResolveRequests = nil
+func TestRunWorkdirFailsBeforeExistingLeaseResolveAndPrepare(t *testing.T) {
+	for _, tc := range runWorkdirCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			setupRunWorkdirCase(t, tc)
+			runPrepareTestResolveRequests = nil
 
-	var stdout, stderr bytes.Buffer
-	err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
-		"--provider", "run-prepare-test",
-		"--id", "cbx_existing",
-		"--", "true",
-	})
-	var exitErr ExitError
-	if !AsExitError(err, &exitErr) || exitErr.Code != 6 || !strings.Contains(exitErr.Message, "not a Git repository") {
-		t.Fatalf("error=%v, want non-Git exit 6\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
-	}
-	if len(runPrepareTestResolveRequests) != 0 {
-		t.Fatalf("Resolve/Prepare called before local manifest failure: %#v", runPrepareTestResolveRequests)
-	}
-}
-
-func TestRunNativeJujutsuFailsBeforeExistingLeaseResolveAndPrepare(t *testing.T) {
-	clearConfigEnv(t)
-	dir := t.TempDir()
-	isolateRunTestUserDirs(t, dir)
-	makeNativeJujutsuWorkspace(t, dir)
-	t.Chdir(dir)
-	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, "missing.yaml"))
-	runPrepareTestResolveRequests = nil
-
-	var stdout, stderr bytes.Buffer
-	err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
-		"--provider", "run-prepare-test",
-		"--id", "cbx_existing",
-		"--", "true",
-	})
-	var exitErr ExitError
-	if !AsExitError(err, &exitErr) || exitErr.Code != 6 || !strings.Contains(exitErr.Message, "native Jujutsu workspace") {
-		t.Fatalf("error=%v, want native Jujutsu exit 6\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
-	}
-	if len(runPrepareTestResolveRequests) != 0 {
-		t.Fatalf("Resolve/Prepare called before native Jujutsu failure: %#v", runPrepareTestResolveRequests)
-	}
-}
-
-func TestRunNativeJujutsuNoSyncReachesBackend(t *testing.T) {
-	clearConfigEnv(t)
-	dir := t.TempDir()
-	isolateRunTestUserDirs(t, dir)
-	makeNativeJujutsuWorkspace(t, dir)
-	t.Chdir(dir)
-	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, "missing.yaml"))
-	runPrepareTestResolveRequests = nil
-
-	var stdout, stderr bytes.Buffer
-	err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
-		"--provider", "run-prepare-test",
-		"--id", "cbx_existing",
-		"--no-sync",
-		"--", "true",
-	})
-	var exitErr ExitError
-	if !AsExitError(err, &exitErr) || exitErr.Code != 9 || !strings.Contains(exitErr.Message, "resolve captured") {
-		t.Fatalf("run error=%v, want backend resolve proof\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
-	}
-	if strings.Contains(exitErr.Message, "native Jujutsu workspace") {
-		t.Fatalf("--no-sync triggered native Jujutsu guard: %q", exitErr.Message)
-	}
-	if len(runPrepareTestResolveRequests) != 1 || !runPrepareTestResolveRequests[0].Prepare {
-		t.Fatalf("--no-sync did not reach backend Resolve/Prepare: %#v", runPrepareTestResolveRequests)
+			var stdout, stderr bytes.Buffer
+			err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
+				"--provider", "run-prepare-test",
+				"--id", "cbx_existing",
+				"--", "true",
+			})
+			var exitErr ExitError
+			if !AsExitError(err, &exitErr) || exitErr.Code != 6 || !strings.Contains(exitErr.Message, tc.diagnostic) {
+				t.Fatalf("error=%v, want %s exit 6\nstdout=%s\nstderr=%s", err, tc.name, stdout.String(), stderr.String())
+			}
+			if len(runPrepareTestResolveRequests) != 0 {
+				t.Fatalf("Resolve/Prepare called before local manifest failure: %#v", runPrepareTestResolveRequests)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Addresses the safe first slice of https://github.com/openclaw/crabbox/issues/1081. The issue remains open for fixture-backed native Jujutsu revision support.

## Summary

Crabbox sync manifests are Git-owned. In a native Jujutsu workspace nested beneath an outer Git checkout, ordinary Git discovery could previously escape the `.jj` workspace, select the outer repository, and sync the wrong revision.

This change makes repository ownership explicit before manifest generation:

- the nearest native `.jj` workspace stops Git-manifest sync before lease acquisition, existing-lease preparation, or ready-pool borrowing
- same-root valid `.jj` + `.git` metadata remains supported as a colocated Git workspace
- malformed same-root `.git` metadata fails closed rather than being treated as colocated
- a closer nested Git repository still wins over an outer Jujutsu workspace
- explicit `GIT_DIR` / `GIT_WORK_TREE` routing remains authoritative
- `GIT_CEILING_DIRECTORIES`, linked-worktree `.git` files, and ordinary non-Git diagnostics retain their existing behavior
- `--no-sync` remains the explicit way to run without transferring local files

The diagnostic explains that native Jujutsu revision mapping is not supported yet and points users starting from an existing Git checkout at the documented colocated workflow. This does not invoke `jj`, convert repositories, or attempt native revision mapping.

## Verification

- focused repository and run preflight tests
- focused race-detector suite
- `go vet ./...`
- `scripts/check-docs.sh`
- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- `git diff --check`
- source-blind synthetic CLI contract: 22/22 probes passed, covering nested native Jujutsu, valid and malformed colocated metadata, nested Git, explicit Git routing, discovery ceilings, and `--no-sync`
- structured P1 full-branch autoreview and secret scan: clean
- four-angle simplification review; applied shared-helper/path-walk/test deduplication and reduced the branch by 125 lines without changing behavior

No configuration, credential, provider, or migration changes are required.
