### PR TITLE
feat(cp): add validated archive fallback for old rsync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.41.7 - Unreleased
 
+### Added
+
+- Added a checksummed, validated archive fallback for SSH-backed `cp` from POSIX operator hosts to native Linux or macOS leases (not WSL2) when local rsync is missing or older than 3.4.3, including stock macOS OpenRsync. Thanks @coygeek.
+
 ### Fixed
 
 - Rejected native Jujutsu workspaces before Git-manifest sync can fall through to an outer checkout, while preserving colocated Git workspaces and `--no-sync`. Thanks @atimmer.

--- a/docs/commands/cp.md
+++ b/docs/commands/cp.md
@@ -3,7 +3,7 @@
 `crabbox cp` copies files or directories between the host and a Crabbox-owned
 lease. It resolves the lease id or slug first. Providers with a native copy
 backend keep using that backend; SSH-backed leases otherwise transfer through
-the resolved SSH transport with rsync.
+the resolved SSH transport with rsync or a validated archive stream.
 
 ```sh
 crabbox cp --provider docker-sandbox --id blue-box ./coverage.xml SANDBOX:/tmp/coverage.xml
@@ -43,8 +43,11 @@ is a path on the resolved remote host.
 
 Provider-native copy remains the first choice when the backend implements it.
 Otherwise, Crabbox accepts any provider that resolves a managed SSH lease and
-uses rsync over the same `SSHTarget` used by `run`, sync, and interactive SSH.
-Delegated providers with neither transport fail clearly.
+uses the same `SSHTarget` used by `run`, sync, and interactive SSH. Crabbox
+prefers rsync 3.4.3 or newer. On a POSIX operator host, if the local client is missing or older, it uses a
+Go-owned tar+gzip archive stream over SSH instead; it never invokes the rejected
+rsync client, scp, or another copy command. Delegated providers with neither
+transport fail clearly.
 
 The resolved SSH user, key/certificate paths, host-key policy, and ProxyCommand
 are rendered into a mode-`0600` temporary OpenSSH config. The Crabbox-launched
@@ -56,17 +59,42 @@ not inherited. OpenSSH executes the provider-resolved ProxyCommand under that
 provider's existing transport contract. Crabbox keeps the private config for
 the full transfer and removes it after the child exits.
 
-SSH fallback requires rsync on both sides. The local client must be rsync 3.4.3
-or newer; Crabbox rejects older clients before connecting because known
-sender/receiver vulnerabilities cross the lease trust boundary.
+The rsync path requires rsync on both sides. The local client must be rsync
+3.4.3 or newer; Crabbox rejects older clients for data transfer because known
+sender/receiver vulnerabilities cross the lease trust boundary. The archive
+path instead requires standard POSIX tools including `bash`, `tar`, `gzip`,
+`find`, `mktemp`, `awk`, `ps`, `ln`, and `sync` on the native Linux or macOS POSIX
+lease. Local Go code creates uploads and validates downloads. Download entries must remain under one
+source root and may contain only regular files and directories; Crabbox rejects
+links (including hard links), special files, duplicate or escaping paths, archives over 1,000,000
+entries, individual files over 64 GiB, or streams over 256 GiB. Tar header
+checksums and the gzip stream checksum must validate before publication.
+
+Archive uploads reject host-side symlinks by default and follow them with `-L`,
+so no preserved link graph can escape the transferred tree.
+Uploads extract into a private remote staging directory. Downloads extract into
+a private directory beside the destination. Both replace the selected target
+only after the complete archive validates. An interruption before publication
+keeps the prior contents at the target or in its durable backup, which the next
+copy restores if publication did not finish. An interruption after publication
+keeps the new target and defers backup cleanup to the next copy. Replacement
+uses a private durable `<target>.crabbox-cp-transaction` lock record and
+`<target>.crabbox-cp-backup` sidecars; after a process or host crash, the next
+copy to that target automatically restores an interrupted backup or finishes
+cleanup of a published replacement. A backup without its marker is never
+deleted automatically and produces an actionable error. This differs
+from rsync's incremental merge: archive fallback replaces an existing selected
+file or directory subtree on success instead of retaining unrelated entries in
+that subtree.
+
 Downloads preserve regular files, directories, and timestamps, but do not
 materialize lease-provided symlinks or special files and do not apply remote
 ownership or group metadata to the host. New local files and directories use
 normalized non-executable modes (`0644` and `0755`, subject to the host umask)
 instead of lease-provided permission bits. Native Windows
-SSH targets use the archive sync path and currently require a provider-native
-copy backend; WSL2 targets use the SSH rsync fallback after Crabbox verifies
-that the remote rsync supports secluded arguments.
+SSH targets use the workspace archive sync path and currently require a
+provider-native copy backend; Windows operator hosts and WSL2 targets require
+safe rsync 3.4.3 or newer.
 
 On a Windows client, targets that depend on the native Windows OpenSSH config
 use native rsync rather than WSL rsync so the configured route remains intact.

--- a/docs/features/ssh-transport.md
+++ b/docs/features/ssh-transport.md
@@ -15,13 +15,29 @@ SSH rules.
 
 `crabbox cp` preserves provider-native copy when available. If the backend has
 no native copy capability but does expose a managed SSH lease, Crabbox maps the
-single `SANDBOX:PATH` operand to the remote side and runs rsync over the resolved
+single `SANDBOX:PATH` operand to the remote side and transfers over the resolved
 transport. Both upload and download preserve the existing cp syntax. `-L`
 follows host-side symlinks during upload.
 
-Transfers require local rsync 3.4.3 or newer. Crabbox rejects older clients
-before connecting because known sender and receiver vulnerabilities cross the
-lease trust boundary.
+Crabbox prefers local rsync 3.4.3 or newer and rejects older clients for data
+transfer because known sender and receiver vulnerabilities cross the lease
+trust boundary. From POSIX operator hosts to native Linux or macOS leases, when local
+rsync is missing or older—including stock macOS OpenRsync—Crabbox creates or validates a checksummed tar+gzip stream in Go and
+carries it over the same private SSH session. The remote uses standard POSIX
+archive and filesystem tools only as the archive endpoint; Crabbox does not
+fall back to rsync, scp, or another copy protocol.
+
+Archive entries are confined to one root with bounded entry and byte counts.
+Downloads reject links, special files, duplicate paths, and invalid checksums
+before replacing the destination. Archive uploads reject symlinks unless `-L`
+follows them. Archive transfers stage the complete
+operand and replace its selected destination only after validation. An
+interruption before publication keeps the prior contents at the target or in a
+durable backup that the next copy restores. After publication, the new target
+remains and the next copy finishes backup cleanup. Target-named sidecars recover either state
+after a process or host crash. Unlike rsync's incremental merge,
+a successful archive transfer replaces that selected subtree and does not
+preserve unrelated entries already inside it.
 
 Downloads accept regular files and directories, not lease-provided symlinks or
 special files. Ownership and group metadata are discarded, and newly created

--- a/internal/cli/cp.go
+++ b/internal/cli/cp.go
@@ -98,11 +98,22 @@ func copyOverResolvedSSH(ctx context.Context, target SSHTarget, src, dst string,
 		return ctxErr
 	}
 	if !capabilities.safeTransport {
-		version := capabilities.version
-		if version == "" {
-			version = "unknown"
+		if runtime.GOOS == "windows" {
+			return exit(2, "SSH cp archive fallback is unavailable on Windows operator hosts; install rsync 3.4.3 or newer")
 		}
-		return exit(2, "SSH cp requires rsync 3.4.3 or newer for secure transfers; found %s", version)
+		// The archive fallback is driven by native Go on the operator host, so it
+		// must use the native OpenSSH session even when Windows rsync probing chose
+		// a WSL session.
+		if wslExe != "" {
+			if closeErr := session.Close(); closeErr != nil {
+				return closeErr
+			}
+			session, err = newSSHTransportSession(ctx, target, false)
+			if err != nil {
+				return err
+			}
+		}
+		return copyOverResolvedSSHArchive(ctx, session, target, src, dst, followLink, stdout, stderr)
 	}
 	// Prefer secluded arguments whenever the remote rsync supports them: the
 	// paths then travel over the rsync protocol stream instead of the remote

--- a/internal/cli/cp.go
+++ b/internal/cli/cp.go
@@ -98,8 +98,8 @@ func copyOverResolvedSSH(ctx context.Context, target SSHTarget, src, dst string,
 		return ctxErr
 	}
 	if !capabilities.safeTransport {
-		if runtime.GOOS == "windows" {
-			return exit(2, "SSH cp archive fallback is unavailable on Windows operator hosts; install rsync 3.4.3 or newer")
+		if runtime.GOOS == "windows" || isWindowsWSL2Target(target) {
+			return exit(2, "SSH cp archive fallback requires a POSIX operator host and native Linux or macOS lease (not WSL2); install rsync 3.4.3 or newer")
 		}
 		// The archive fallback is driven by native Go on the operator host, so it
 		// must use the native OpenSSH session even when Windows rsync probing chose

--- a/internal/cli/cp_archive.go
+++ b/internal/cli/cp_archive.go
@@ -665,6 +665,13 @@ func extractValidatedCopyArchive(ctx context.Context, archive io.Reader, stage, 
 		if rel != "" {
 			destination = filepath.Join(destination, filepath.FromSlash(rel))
 		}
+		// Defense in depth: validatedCopyArchiveEntryPath already rejects
+		// traversal, but assert containment at the use site so the guarantee
+		// is local and provable independent of the sanitizer.
+		payloadRoot := filepath.Join(stage, copyArchivePayloadRoot)
+		if destination != payloadRoot && !strings.HasPrefix(destination, payloadRoot+string(os.PathSeparator)) {
+			return exit(2, "copy archive entry escapes the staging root: %q", header.Name)
+		}
 		switch header.Typeflag {
 		case tar.TypeDir:
 			if err := directories.ensure(stage, archiveRoot, rel); err != nil {

--- a/internal/cli/cp_archive.go
+++ b/internal/cli/cp_archive.go
@@ -657,6 +657,12 @@ func extractValidatedCopyArchive(ctx context.Context, archive io.Reader, stage, 
 		if err != nil {
 			return err
 		}
+		// validatedCopyArchiveEntryPath normalizes and containment-checks the
+		// entry; this explicit dot-dot rejection restates the guarantee in the
+		// form static dataflow analysis recognizes (go/zipslip sanitizer).
+		if strings.Contains(clean, "..") || strings.Contains(rel, "..") {
+			return exit(2, "copy archive contains unsafe path: %q", header.Name)
+		}
 		if seen[clean] {
 			return exit(2, "copy archive contains duplicate entry: %s", clean)
 		}

--- a/internal/cli/cp_archive.go
+++ b/internal/cli/cp_archive.go
@@ -1,0 +1,1091 @@
+package cli
+
+import (
+	"archive/tar"
+	"bufio"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gofrs/flock"
+)
+
+const copyArchivePayloadRoot = "payload"
+
+type copyArchiveLimits struct {
+	maxEntries         int
+	maxFileBytes       int64
+	maxTotalBytes      int64
+	maxCompressedBytes int64
+}
+
+var defaultCopyArchiveLimits = copyArchiveLimits{
+	maxEntries:         1_000_000,
+	maxFileBytes:       64 << 30,
+	maxTotalBytes:      256 << 30,
+	maxCompressedBytes: 256 << 30,
+}
+
+var copyArchiveTargetMutexes sync.Map
+
+type copyArchiveSource struct {
+	base         string
+	contentsOnly bool
+}
+
+func copyOverResolvedSSHArchive(ctx context.Context, session *sshTransportSession, target SSHTarget, src, dst string, followLink bool, stdout, stderr anyWriter) error {
+	srcRemote, srcPath := sandboxCopyPath(src)
+	_, dstPath := sandboxCopyPath(dst)
+	if strings.TrimSpace(srcPath) == "" || strings.TrimSpace(dstPath) == "" {
+		return exit(2, "copy source and destination paths must not be empty")
+	}
+	if srcRemote {
+		return downloadResolvedSSHArchive(ctx, session, target, srcPath, dstPath, stdout, stderr, defaultCopyArchiveLimits)
+	}
+	return uploadResolvedSSHArchive(ctx, session, target, srcPath, dstPath, followLink, stdout, stderr, defaultCopyArchiveLimits)
+}
+
+func uploadResolvedSSHArchive(ctx context.Context, session *sshTransportSession, target SSHTarget, localPath, remotePath string, followLink bool, stdout, stderr anyWriter, limits copyArchiveLimits) error {
+	source, archive, err := createCopyArchive(ctx, localPath, followLink, limits)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		name := archive.Name()
+		_ = archive.Close()
+		_ = os.Remove(name)
+	}()
+	remote, err := remoteCopyArchiveUploadCommand(remotePath, source.base, source.contentsOnly)
+	if err != nil {
+		return err
+	}
+	if err := runResolvedSSHArchiveCommand(ctx, session, target, remote, archive, stdout, stderr); err != nil {
+		return fmt.Errorf("copy archive over resolved SSH transport: %w", err)
+	}
+	return nil
+}
+
+func downloadResolvedSSHArchive(ctx context.Context, session *sshTransportSession, target SSHTarget, remotePath, localPath string, stdout, stderr anyWriter, limits copyArchiveLimits) error {
+	archiveRoot, contentsOnly, err := remoteCopyArchiveRoot(remotePath)
+	if err != nil {
+		return err
+	}
+	remote, err := remoteCopyArchiveDownloadCommand(remotePath)
+	if err != nil {
+		return err
+	}
+	archive, err := os.CreateTemp("", "crabbox-cp-download-*.tgz")
+	if err != nil {
+		return fmt.Errorf("create copy archive temp file: %w", err)
+	}
+	defer func() {
+		name := archive.Name()
+		_ = archive.Close()
+		_ = os.Remove(name)
+	}()
+	bounded := &copyArchiveBoundedWriter{writer: archive, remaining: limits.maxCompressedBytes, limit: limits.maxCompressedBytes}
+	if err := runResolvedSSHArchiveCommand(ctx, session, target, remote, nil, bounded, stderr); err != nil {
+		if bounded.limitErr != nil {
+			return bounded.limitErr
+		}
+		return fmt.Errorf("copy archive over resolved SSH transport: %w", err)
+	}
+	if _, err := archive.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("rewind copy archive: %w", err)
+	}
+	targetPath, err := localCopyArchiveTarget(localPath, archiveRoot, contentsOnly)
+	if err != nil {
+		return err
+	}
+	parent := filepath.Dir(targetPath)
+	if info, err := os.Stat(parent); err != nil {
+		return exit(2, "copy destination parent is unavailable: %v", err)
+	} else if !info.IsDir() {
+		return exit(2, "copy destination parent is not a directory: %s", parent)
+	}
+	stage, err := os.MkdirTemp(parent, ".crabbox-cp-*")
+	if err != nil {
+		return fmt.Errorf("create copy extraction directory: %w", err)
+	}
+	defer os.RemoveAll(stage)
+	if err := extractValidatedCopyArchive(ctx, archive, stage, archiveRoot, limits); err != nil {
+		return err
+	}
+	payload := filepath.Join(stage, copyArchivePayloadRoot)
+	if err := syncCopyArchiveTree(payload); err != nil {
+		return err
+	}
+	if err := publishCopyArchivePayload(payload, targetPath); err != nil {
+		return err
+	}
+	return nil
+}
+
+type copyArchiveBoundedWriter struct {
+	writer    io.Writer
+	remaining int64
+	limit     int64
+	limitErr  error
+}
+
+func (w *copyArchiveBoundedWriter) Write(data []byte) (int, error) {
+	if int64(len(data)) > w.remaining {
+		w.limitErr = exit(2, "copy archive exceeds compressed size limit (%d bytes)", w.limit)
+		return 0, w.limitErr
+	}
+	n, err := w.writer.Write(data)
+	w.remaining -= int64(n)
+	return n, err
+}
+
+func runResolvedSSHArchiveCommand(ctx context.Context, session *sshTransportSession, target SSHTarget, remote string, stdin io.Reader, stdout io.Writer, stderr anyWriter) error {
+	args := append(session.commandPrefix(), "-T", "--", session.host(), wrapRemoteForTarget(target, remote))
+	handle := pondMeshExecCommand(ctx, target.ChildEnvDenylist, "ssh", args...)
+	execHandle, ok := handle.(*pondMeshExecHandle)
+	if !ok {
+		return errors.New("resolved SSH archive transport does not expose process streams")
+	}
+	stderrTail := newSynchronizedTailBuffer(failureTailLines)
+	execHandle.cmd.Stdin = stdin
+	execHandle.cmd.Stdout = stdout
+	execHandle.cmd.Stderr = stderrTail
+	if err := handle.Start(); err != nil {
+		return fmt.Errorf("start archive copy over resolved SSH transport: %w", err)
+	}
+	waitErr := handle.Wait()
+	writeSSHTransportDiagnostic(stderr, target, stderrTail.String())
+	if waitErr != nil {
+		if cause := context.Cause(ctx); cause != nil && handle.WasTerminatedByOurCancel() {
+			return cause
+		}
+		return waitErr
+	}
+	return nil
+}
+
+func createCopyArchive(ctx context.Context, sourcePath string, followLink bool, limits copyArchiveLimits) (_ copyArchiveSource, _ *os.File, err error) {
+	trimmedSource := strings.TrimRight(sourcePath, "/")
+	if trimmedSource != "" {
+		lastComponent := trimmedSource
+		if index := strings.LastIndexByte(trimmedSource, '/'); index >= 0 {
+			lastComponent = trimmedSource[index+1:]
+		}
+		if lastComponent == "." || lastComponent == ".." {
+			return copyArchiveSource{}, nil, exit(2, "archive copy does not support local source paths ending in . or ..")
+		}
+	}
+	abs, err := filepath.Abs(sourcePath)
+	if err != nil {
+		return copyArchiveSource{}, nil, exit(2, "resolve copy source: %v", err)
+	}
+	info, err := os.Lstat(abs)
+	if err != nil {
+		return copyArchiveSource{}, nil, exit(2, "read copy source: %v", err)
+	}
+	semanticInfo := info
+	if followLink && info.Mode()&os.ModeSymlink != 0 {
+		semanticInfo, err = os.Stat(abs)
+		if err != nil {
+			return copyArchiveSource{}, nil, exit(2, "follow copy source: %v", err)
+		}
+	}
+	if hasTrailingPathSeparator(sourcePath) && !semanticInfo.IsDir() {
+		return copyArchiveSource{}, nil, exit(2, "archive copy source with trailing slash is not a directory")
+	}
+	contentsOnly := hasTrailingPathSeparator(sourcePath) && semanticInfo.IsDir()
+	source := copyArchiveSource{base: filepath.Base(abs), contentsOnly: contentsOnly}
+	archive, err := os.CreateTemp("", "crabbox-cp-upload-*.tgz")
+	if err != nil {
+		return copyArchiveSource{}, nil, fmt.Errorf("create copy archive temp file: %w", err)
+	}
+	keep := false
+	defer func() {
+		if !keep {
+			name := archive.Name()
+			_ = archive.Close()
+			_ = os.Remove(name)
+		}
+	}()
+	gz := gzip.NewWriter(archive)
+	tw := tar.NewWriter(gz)
+	rootPath := filepath.Dir(abs)
+	rootRelative := filepath.Base(abs)
+	if info.IsDir() {
+		rootPath = abs
+		rootRelative = "."
+	}
+	root, err := os.OpenRoot(rootPath)
+	if err != nil {
+		_ = tw.Close()
+		_ = gz.Close()
+		return copyArchiveSource{}, nil, exit(2, "open copy source root: %v", err)
+	}
+	anchoredInfo, err := root.Lstat(rootRelative)
+	if err != nil || !os.SameFile(info, anchoredInfo) {
+		_ = root.Close()
+		_ = tw.Close()
+		_ = gz.Close()
+		return copyArchiveSource{}, nil, exit(2, "copy source changed before it could be archived")
+	}
+	state := &copyArchiveCreateState{ctx: ctx, writer: tw, limits: limits, followLink: followLink}
+	appendErr := state.append(root, rootRelative, copyArchivePayloadRoot)
+	closeRootErr := root.Close()
+	if appendErr != nil {
+		_ = tw.Close()
+		_ = gz.Close()
+		return copyArchiveSource{}, nil, appendErr
+	}
+	if closeRootErr != nil {
+		_ = tw.Close()
+		_ = gz.Close()
+		return copyArchiveSource{}, nil, fmt.Errorf("close copy source root: %w", closeRootErr)
+	}
+	if err := tw.Close(); err != nil {
+		_ = gz.Close()
+		return copyArchiveSource{}, nil, fmt.Errorf("finish copy archive: %w", err)
+	}
+	if err := gz.Close(); err != nil {
+		return copyArchiveSource{}, nil, fmt.Errorf("finish checksummed copy archive: %w", err)
+	}
+	if info, err := archive.Stat(); err != nil {
+		return copyArchiveSource{}, nil, fmt.Errorf("stat copy archive: %w", err)
+	} else if info.Size() > limits.maxCompressedBytes {
+		return copyArchiveSource{}, nil, exit(2, "copy archive exceeds compressed size limit (%d bytes)", limits.maxCompressedBytes)
+	}
+	if _, err := archive.Seek(0, io.SeekStart); err != nil {
+		return copyArchiveSource{}, nil, fmt.Errorf("rewind copy archive: %w", err)
+	}
+	keep = true
+	return source, archive, nil
+}
+
+type copyArchiveCreateState struct {
+	ctx        context.Context
+	writer     *tar.Writer
+	limits     copyArchiveLimits
+	followLink bool
+	entries    int
+	totalBytes int64
+	activeDirs []os.FileInfo
+}
+
+func (s *copyArchiveCreateState) append(root *os.Root, name, archiveName string) error {
+	if err := s.ctx.Err(); err != nil {
+		return err
+	}
+	info, err := root.Lstat(name)
+	if err != nil {
+		return exit(2, "read copy source %s: %v", archiveName, err)
+	}
+	linkName := ""
+	if info.Mode()&os.ModeSymlink != 0 {
+		if s.followLink {
+			resolved, resolveErr := filepath.EvalSymlinks(filepath.Join(root.Name(), name))
+			if resolveErr != nil {
+				return exit(2, "follow copy source symlink %s: %v", archiveName, resolveErr)
+			}
+			resolvedRoot, openErr := os.OpenRoot(filepath.Dir(resolved))
+			if openErr != nil {
+				return exit(2, "open followed copy source symlink %s: %v", archiveName, openErr)
+			}
+			defer resolvedRoot.Close()
+			return s.append(resolvedRoot, filepath.Base(resolved), archiveName)
+		} else {
+			return exit(2, "archive copy source contains a symlink; use -L to follow it: %s", archiveName)
+		}
+	}
+	var opened *os.File
+	if info.Mode()&os.ModeSymlink == 0 {
+		opened, err = root.Open(name)
+		if err != nil {
+			return exit(2, "open copy source %s without following links: %v", archiveName, err)
+		}
+		openedInfo, statErr := opened.Stat()
+		if statErr != nil {
+			_ = opened.Close()
+			return exit(2, "verify opened copy source %s: %v", archiveName, statErr)
+		}
+		if !os.SameFile(info, openedInfo) || info.Mode().Type() != openedInfo.Mode().Type() {
+			_ = opened.Close()
+			return exit(2, "copy source changed while it was being archived: %s", archiveName)
+		}
+		info = openedInfo
+		defer opened.Close()
+	}
+	if !info.Mode().IsRegular() && !info.IsDir() && info.Mode()&os.ModeSymlink == 0 {
+		return exit(2, "copy archive source contains unsupported special file: %s", archiveName)
+	}
+	s.entries++
+	if s.entries > s.limits.maxEntries {
+		return exit(2, "copy archive exceeds entry limit (%d)", s.limits.maxEntries)
+	}
+	if info.Mode().IsRegular() {
+		if info.Size() > s.limits.maxFileBytes {
+			return exit(2, "copy archive file exceeds size limit (%d bytes): %s", s.limits.maxFileBytes, archiveName)
+		}
+		s.totalBytes += info.Size()
+		if s.totalBytes > s.limits.maxTotalBytes {
+			return exit(2, "copy archive exceeds total size limit (%d bytes)", s.limits.maxTotalBytes)
+		}
+	}
+	header, err := tar.FileInfoHeader(info, linkName)
+	if err != nil {
+		return exit(2, "create copy archive header %s: %v", archiveName, err)
+	}
+	header.Name = filepath.ToSlash(archiveName)
+	header.Format = tar.FormatPAX
+	if err := s.writer.WriteHeader(header); err != nil {
+		return fmt.Errorf("write copy archive header %s: %w", archiveName, err)
+	}
+	if info.Mode().IsRegular() {
+		copyErr := copySyncArchiveMember(s.ctx, s.writer, opened)
+		if copyErr != nil {
+			return fmt.Errorf("archive copy source %s: %w", archiveName, copyErr)
+		}
+	}
+	if !info.IsDir() {
+		return nil
+	}
+	for _, active := range s.activeDirs {
+		if os.SameFile(active, info) {
+			return exit(2, "copy source symlink cycle at %s", archiveName)
+		}
+	}
+	s.activeDirs = append(s.activeDirs, info)
+	defer func() { s.activeDirs = s.activeDirs[:len(s.activeDirs)-1] }()
+	children, err := opened.ReadDir(-1)
+	if err != nil {
+		return exit(2, "read copy source directory %s: %v", archiveName, err)
+	}
+	subroot, err := root.OpenRoot(name)
+	if err != nil {
+		return exit(2, "open copy source directory %s: %v", archiveName, err)
+	}
+	defer subroot.Close()
+	subrootInfo, err := subroot.Stat(".")
+	if err != nil || !os.SameFile(info, subrootInfo) {
+		return exit(2, "copy source changed while it was being archived: %s", archiveName)
+	}
+	for _, child := range children {
+		if err := s.append(subroot, child.Name(), path.Join(archiveName, filepath.ToSlash(child.Name()))); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func hasTrailingPathSeparator(value string) bool {
+	return strings.HasSuffix(value, "/")
+}
+
+func remoteCopyArchiveRoot(remotePath string) (string, bool, error) {
+	if err := validateRemoteCopyArchivePath(remotePath); err != nil {
+		return "", false, err
+	}
+	trimmed := strings.TrimRight(remotePath, "/")
+	if trimmed == "" || trimmed == "~" {
+		return "", false, exit(2, "archive copy of a remote filesystem root or bare home is unsupported; use a path below it")
+	}
+	root := path.Base(trimmed)
+	lastComponent := trimmed
+	if index := strings.LastIndexByte(trimmed, '/'); index >= 0 {
+		lastComponent = trimmed[index+1:]
+	}
+	if lastComponent == "." || lastComponent == ".." {
+		return "", false, exit(2, "archive copy does not support remote source paths ending in . or ..")
+	}
+	if root == "." || root == ".." || root == "/" {
+		return "", false, exit(2, "archive copy requires a named remote source path")
+	}
+	return root, strings.HasSuffix(remotePath, "/"), nil
+}
+
+func validateRemoteCopyArchivePath(remotePath string) error {
+	if strings.TrimSpace(remotePath) == "" {
+		return exit(2, "remote copy paths must not be empty")
+	}
+	if strings.ContainsAny(remotePath, "\x00\r\n") {
+		return exit(2, "remote copy paths must not contain control characters")
+	}
+	if strings.HasPrefix(remotePath, "~") && remotePath != "~" && !strings.HasPrefix(remotePath, "~/") {
+		return exit(2, "archive copy does not support named-user ~ paths; use an absolute path")
+	}
+	return nil
+}
+
+func remoteCopyArchivePathResolver() string {
+	return `resolve_path() {
+  case "$1" in
+    "~") printf '%s\n' "$HOME" ;;
+    "~/"*) printf '%s/%s\n' "$HOME" "${1#\~/}" ;;
+    /*) printf '%s\n' "$1" ;;
+    *) printf '%s/%s\n' "$PWD" "$1" ;;
+  esac
+}`
+}
+
+func remoteCopyArchiveUploadCommand(remotePath, sourceBase string, contentsOnly bool) (string, error) {
+	if err := validateRemoteCopyArchivePath(remotePath); err != nil {
+		return "", err
+	}
+	if sourceBase == "" || sourceBase == "." || strings.ContainsAny(sourceBase, "/\x00\r\n") {
+		return "", exit(2, "copy source has an unsupported base name")
+	}
+	var script strings.Builder
+	script.WriteString("set -euo pipefail\n")
+	script.WriteString("export COPYFILE_DISABLE=1\n")
+	script.WriteString(remoteCopyArchivePathResolver())
+	script.WriteByte('\n')
+	script.WriteString("for tool in tar gzip mktemp mkdir mv dirname basename find chmod ln awk ps sync; do command -v \"$tool\" >/dev/null || { echo \"archive copy requires remote $tool\" >&2; exit 127; }; done\n")
+	script.WriteString("dest=$(resolve_path ")
+	script.WriteString(shellQuote(remotePath))
+	script.WriteString(")\n")
+	script.WriteString("if [ -L \"$dest\" ]; then echo 'archive copy refuses a symlink destination' >&2; exit 2; fi\n")
+	if contentsOnly {
+		script.WriteString("target=$dest\nwhile [ \"$target\" != / ] && [ \"${target%/}\" != \"$target\" ]; do target=${target%/}; done\n")
+	} else {
+		if strings.HasSuffix(remotePath, "/") {
+			script.WriteString("while [ \"$dest\" != / ] && [ \"${dest%/}\" != \"$dest\" ]; do dest=${dest%/}; done\nif [ -L \"$dest\" ]; then echo 'archive copy refuses a symlink destination' >&2; exit 2; fi\nif [ -e \"$dest\" ] && [ ! -d \"$dest\" ]; then echo 'archive copy directory destination is not a directory' >&2; exit 2; fi\nif [ ! -e \"$dest\" ]; then mkdir \"$dest\"; sync; fi\n")
+		}
+		script.WriteString("if [ -d \"$dest\" ]; then target=$dest/")
+		script.WriteString(shellQuote(sourceBase))
+		script.WriteString("; else target=$dest; fi\n")
+	}
+	script.WriteString(`target_parent=$(dirname -- "$target")
+if [ ! -d "$target_parent" ]; then echo 'archive copy destination parent is unavailable' >&2; exit 2; fi
+if [ -L "$target" ]; then echo 'archive copy refuses a symlink target' >&2; exit 2; fi
+backup="${target}.crabbox-cp-backup"
+marker="${target}.crabbox-cp-transaction"
+process_identity() {
+  if [ -r "/proc/$1/stat" ]; then awk '{ print $22 }' "/proc/$1/stat"; else ps -o lstart= -p "$1" 2>/dev/null; fi
+}
+recover_transaction() {
+  current_owner=${1:-}
+  if [ -e "$marker" ] || [ -L "$marker" ]; then
+    if [ ! -f "$marker" ] || [ -L "$marker" ] || [ ! -O "$marker" ] || [ -n "$(find "$marker" -prune ! -perm 600 -print)" ]; then
+      echo 'archive copy found an unauthenticated transaction marker' >&2
+      return 2
+    fi
+    owner=""
+    owner_start=""
+    { IFS= read -r owner; IFS= read -r owner_start; } < "$marker"
+    case "$owner" in ''|*[!0-9]*) echo 'archive copy found an invalid transaction owner' >&2; return 2 ;; esac
+    if [ -z "$owner_start" ]; then echo 'archive copy found invalid transaction owner identity' >&2; return 2; fi
+    if [ "$owner" != "$current_owner" ] && kill -0 "$owner" 2>/dev/null; then
+      live_start=$(process_identity "$owner" || true)
+      if [ -z "$live_start" ] || [ "$live_start" = "$owner_start" ]; then
+        echo 'another archive copy is active for this target' >&2
+        return 2
+      fi
+    fi
+    if [ -e "$backup" ] || [ -L "$backup" ]; then
+      if [ -e "$target" ] || [ -L "$target" ]; then rm -rf -- "$backup"; else mv "$backup" "$target"; fi
+      sync
+    fi
+    rm -f -- "$marker"
+    sync
+  elif [ -e "$backup" ] || [ -L "$backup" ]; then
+    echo 'archive copy found a reserved backup without its transaction marker' >&2
+    return 2
+  fi
+}
+recover_transaction ""
+stage=$(mktemp -d "$target_parent/.crabbox-cp.XXXXXX")
+tar_errors=$(mktemp "${TMPDIR:-/tmp}/crabbox-cp-tar.XXXXXX")
+marker_tmp=$(mktemp "$target_parent/.crabbox-cp-owner.XXXXXX")
+cleanup() {
+  recover_transaction "$$" || true
+  rm -rf -- "$stage"
+  rm -f -- "$tar_errors" "$marker_tmp"
+}
+trap cleanup EXIT INT TERM
+set +e
+gzip -dc | tar -C "$stage" -xpf - 2>"$tar_errors"
+pipeline_status=$?
+set -e
+if [ "$pipeline_status" -ne 0 ] || [ -s "$tar_errors" ]; then
+  cat "$tar_errors" >&2
+  exit 2
+fi
+if ! { [ -e "$stage/payload" ] || [ -L "$stage/payload" ]; }; then echo 'archive copy payload is missing' >&2; exit 2; fi
+sync
+chmod 600 "$marker_tmp"
+owner_start=$(process_identity "$$")
+if [ -z "$owner_start" ]; then echo 'archive copy could not resolve its transaction owner identity' >&2; exit 2; fi
+printf '%s\n%s\n' "$$" "$owner_start" > "$marker_tmp"
+sync
+if ! ln "$marker_tmp" "$marker"; then echo 'another archive copy is active for this target' >&2; exit 2; fi
+sync
+if [ -e "$target" ] || [ -L "$target" ]; then
+  mv "$target" "$backup"
+  sync
+fi
+if ! mv "$stage/payload" "$target"; then
+  recover_transaction "$$" || true
+  exit 2
+fi
+sync
+if [ -e "$backup" ] || [ -L "$backup" ]; then
+  rm -rf -- "$backup"
+  sync
+fi
+rm -f -- "$marker"
+sync
+`)
+	return "bash --noprofile --norc -c " + shellQuote(script.String()), nil
+}
+
+func remoteCopyArchiveDownloadCommand(remotePath string) (string, error) {
+	_, directoryIntent, err := remoteCopyArchiveRoot(remotePath)
+	if err != nil {
+		return "", err
+	}
+	var script strings.Builder
+	script.WriteString("set -euo pipefail\n")
+	script.WriteString("export COPYFILE_DISABLE=1\n")
+	script.WriteString(remoteCopyArchivePathResolver())
+	script.WriteByte('\n')
+	script.WriteString("for tool in tar gzip dirname basename find mktemp; do command -v \"$tool\" >/dev/null || { echo \"archive copy requires remote $tool\" >&2; exit 127; }; done\n")
+	script.WriteString("src=$(resolve_path ")
+	script.WriteString(shellQuote(strings.TrimRight(remotePath, "/")))
+	script.WriteString(")\n")
+	script.WriteString(`if [ -L "$src" ]; then echo 'archive copy refuses a remote symlink source' >&2; exit 2; fi
+if [ ! -f "$src" ] && [ ! -d "$src" ]; then echo 'archive copy source must be a regular file or directory' >&2; exit 2; fi
+`)
+	if directoryIntent {
+		script.WriteString("if [ ! -d \"$src\" ]; then echo 'archive copy source with trailing slash is not a directory' >&2; exit 2; fi\n")
+	}
+	script.WriteString(`
+special=$(find "$src" \( -type l -o \( -type f -links +1 \) -o \( ! -type f ! -type d \) \) -print -quit)
+if [ -n "$special" ]; then echo 'archive copy source contains a link or special file' >&2; exit 2; fi
+parent=$(dirname -- "$src")
+leaf=$(basename -- "$src")
+tar_errors=$(mktemp "${TMPDIR:-/tmp}/crabbox-cp-tar.XXXXXX")
+cleanup() { rm -f -- "$tar_errors"; }
+trap cleanup EXIT INT TERM
+set +e
+tar -C "$parent" -cf - -- "$leaf" 2>"$tar_errors" | gzip -c
+pipeline_status=$?
+set -e
+if [ "$pipeline_status" -ne 0 ] || [ -s "$tar_errors" ]; then
+  cat "$tar_errors" >&2
+  exit 2
+fi
+`)
+	return "bash --noprofile --norc -c " + shellQuote(script.String()), nil
+}
+
+func localCopyArchiveTarget(localPath, sourceBase string, contentsOnly bool) (string, error) {
+	directoryIntent := hasTrailingPathSeparator(localPath)
+	abs, err := filepath.Abs(localPath)
+	if err != nil {
+		return "", exit(2, "resolve copy destination: %v", err)
+	}
+	info, statErr := os.Lstat(abs)
+	if statErr == nil && info.Mode()&os.ModeSymlink != 0 {
+		return "", exit(2, "archive copy refuses a symlink destination: %s", localPath)
+	}
+	if statErr != nil && !os.IsNotExist(statErr) {
+		return "", exit(2, "read copy destination: %v", statErr)
+	}
+	if directoryIntent && statErr == nil && !info.IsDir() {
+		return "", exit(2, "archive copy directory destination is not a directory: %s", localPath)
+	}
+	if contentsOnly {
+		return abs, nil
+	}
+	if directoryIntent && os.IsNotExist(statErr) {
+		if err := os.Mkdir(abs, 0o755); err != nil {
+			return "", exit(2, "create copy destination directory: %v", err)
+		}
+		if err := syncCopyArchiveDirectory(filepath.Dir(abs)); err != nil {
+			return "", err
+		}
+		return filepath.Join(abs, sourceBase), nil
+	}
+	if statErr == nil && info.IsDir() {
+		return filepath.Join(abs, sourceBase), nil
+	}
+	return abs, nil
+}
+
+func extractValidatedCopyArchive(ctx context.Context, archive io.Reader, stage, archiveRoot string, limits copyArchiveLimits) error {
+	buffered := bufio.NewReader(archive)
+	gz, err := gzip.NewReader(buffered)
+	if err != nil {
+		return exit(2, "read checksummed copy archive: %v", err)
+	}
+	gz.Multistream(false)
+	maxArchiveBytes := limits.maxTotalBytes + int64(limits.maxEntries)*4096 + 1<<20
+	if maxArchiveBytes < limits.maxTotalBytes {
+		return exit(2, "copy archive size limit overflow")
+	}
+	limitedArchive := &io.LimitedReader{R: gz, N: maxArchiveBytes + 1}
+	tr := tar.NewReader(limitedArchive)
+	seen := make(map[string]bool)
+	directories := copyArchiveDirectoryTracker{}
+	var directoryTimes []copyArchiveDirectoryTime
+	entries := 0
+	var totalBytes int64
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		header, nextErr := tr.Next()
+		if nextErr == io.EOF {
+			break
+		}
+		if nextErr != nil {
+			return exit(2, "read copy archive: %v", nextErr)
+		}
+		entries++
+		if entries > limits.maxEntries {
+			return exit(2, "copy archive exceeds entry limit (%d)", limits.maxEntries)
+		}
+		clean, rel, err := validatedCopyArchiveEntryPath(header.Name, archiveRoot)
+		if err != nil {
+			return err
+		}
+		if seen[clean] {
+			return exit(2, "copy archive contains duplicate entry: %s", clean)
+		}
+		seen[clean] = true
+		destination := filepath.Join(stage, copyArchivePayloadRoot)
+		if rel != "" {
+			destination = filepath.Join(destination, filepath.FromSlash(rel))
+		}
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := directories.ensure(stage, archiveRoot, rel); err != nil {
+				return err
+			}
+			directoryTimes = append(directoryTimes, copyArchiveDirectoryTime{path: destination, modTime: header.ModTime})
+		case tar.TypeReg, tar.TypeRegA:
+			if header.Size < 0 || header.Size > limits.maxFileBytes {
+				return exit(2, "copy archive file exceeds size limit (%d bytes): %s", limits.maxFileBytes, clean)
+			}
+			totalBytes += header.Size
+			if totalBytes > limits.maxTotalBytes {
+				return exit(2, "copy archive exceeds total size limit (%d bytes)", limits.maxTotalBytes)
+			}
+			if rel != "" {
+				parentRel := path.Dir(rel)
+				if parentRel == "." {
+					parentRel = ""
+				}
+				if err := directories.ensure(stage, archiveRoot, parentRel); err != nil {
+					return err
+				}
+			}
+			if existing, err := os.Lstat(destination); err == nil {
+				return exit(2, "copy archive entry conflicts with existing path: %s (%s)", clean, existing.Mode())
+			} else if !os.IsNotExist(err) {
+				return fmt.Errorf("inspect copy archive destination: %w", err)
+			}
+			file, err := os.OpenFile(destination, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+			if err != nil {
+				return fmt.Errorf("create copy archive file %s: %w", destination, err)
+			}
+			written, copyErr := io.CopyN(file, tr, header.Size)
+			syncErr := file.Sync()
+			closeErr := file.Close()
+			if copyErr != nil || written != header.Size {
+				return exit(2, "copy archive entry %s is truncated", clean)
+			}
+			if closeErr != nil {
+				return fmt.Errorf("close copy archive file %s: %w", destination, closeErr)
+			}
+			if syncErr != nil {
+				return fmt.Errorf("sync copy archive file %s: %w", destination, syncErr)
+			}
+			if err := applyCopyArchiveModTime(destination, header.ModTime); err != nil {
+				return err
+			}
+		default:
+			return exit(2, "copy archive contains unsupported link or special entry: %s", clean)
+		}
+	}
+	trailerBuffer := make([]byte, 128*1024)
+	for {
+		n, readErr := limitedArchive.Read(trailerBuffer)
+		for _, value := range trailerBuffer[:n] {
+			if value != 0 {
+				return exit(2, "copy archive contains data after its end marker")
+			}
+		}
+		if readErr == io.EOF {
+			break
+		}
+		if readErr != nil {
+			return exit(2, "verify copy archive checksum: %v", readErr)
+		}
+		if limitedArchive.N == 0 {
+			return exit(2, "copy archive exceeds uncompressed size limit (%d bytes)", maxArchiveBytes)
+		}
+	}
+	if limitedArchive.N == 0 {
+		return exit(2, "copy archive exceeds uncompressed size limit (%d bytes)", maxArchiveBytes)
+	}
+	if err := gz.Close(); err != nil {
+		return exit(2, "verify copy archive checksum: %v", err)
+	}
+	if _, err := buffered.Peek(1); err != io.EOF {
+		if err == nil {
+			return exit(2, "copy archive contains trailing compressed data")
+		}
+		return exit(2, "inspect copy archive trailer: %v", err)
+	}
+	payload := filepath.Join(stage, copyArchivePayloadRoot)
+	if _, err := os.Lstat(payload); err != nil {
+		return exit(2, "copy archive contained no payload")
+	}
+	for index := len(directoryTimes) - 1; index >= 0; index-- {
+		if err := applyCopyArchiveModTime(directoryTimes[index].path, directoryTimes[index].modTime); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type copyArchiveDirectoryTime struct {
+	path    string
+	modTime time.Time
+}
+
+type copyArchiveDirectoryTracker struct {
+	identities map[string]string
+}
+
+func (t *copyArchiveDirectoryTracker) ensure(stage, archiveRoot, rel string) error {
+	if t.identities == nil {
+		t.identities = make(map[string]string)
+	}
+	current := filepath.Join(stage, copyArchivePayloadRoot)
+	logical := archiveRoot
+	components := []string(nil)
+	if rel != "" {
+		components = strings.Split(rel, "/")
+	}
+	for index := -1; index < len(components); index++ {
+		if index >= 0 {
+			current = filepath.Join(current, filepath.FromSlash(components[index]))
+			logical = path.Join(logical, components[index])
+		}
+		if err := os.Mkdir(current, 0o755); err != nil && !os.IsExist(err) {
+			return fmt.Errorf("create copy archive directory %s: %w", current, err)
+		}
+		info, err := os.Stat(current)
+		if err != nil {
+			return fmt.Errorf("inspect copy archive directory %s: %w", current, err)
+		}
+		if !info.IsDir() {
+			return exit(2, "copy archive directory conflicts with existing path: %s", logical)
+		}
+		identity := copyArchiveDirectoryIdentity(current, info)
+		if existing, ok := t.identities[identity]; ok {
+			if existing != logical {
+				return exit(2, "copy archive contains duplicate filesystem path aliases: %s and %s", existing, logical)
+			}
+		} else {
+			t.identities[identity] = logical
+		}
+	}
+	return nil
+}
+
+func applyCopyArchiveModTime(name string, modTime time.Time) error {
+	if modTime.IsZero() {
+		return nil
+	}
+	if err := os.Chtimes(name, modTime, modTime); err != nil {
+		return fmt.Errorf("apply copy archive timestamp to %s: %w", name, err)
+	}
+	return nil
+}
+
+func validatedCopyArchiveEntryPath(name, archiveRoot string) (string, string, error) {
+	return validatedCopyArchiveEntryPathForGOOS(runtime.GOOS, name, archiveRoot)
+}
+
+func validatedCopyArchiveEntryPathForGOOS(goos, name, archiveRoot string) (string, string, error) {
+	if goos == "windows" && strings.Contains(name, `\`) {
+		return "", "", exit(2, "copy archive contains unsafe path: %q", name)
+	}
+	slashed := filepath.ToSlash(name)
+	if strings.ContainsRune(slashed, '\x00') || path.IsAbs(slashed) {
+		return "", "", exit(2, "copy archive contains unsafe path: %q", name)
+	}
+	clean := path.Clean(slashed)
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, "../") {
+		return "", "", exit(2, "copy archive contains unsafe path: %q", name)
+	}
+	if clean != archiveRoot && !strings.HasPrefix(clean, archiveRoot+"/") {
+		return "", "", exit(2, "copy archive entry escapes its source root: %q", name)
+	}
+	rel := strings.TrimPrefix(clean, archiveRoot)
+	rel = strings.TrimPrefix(rel, "/")
+	if goos == "windows" && !validWindowsCopyArchivePath(rel) {
+		return "", "", exit(2, "copy archive contains unsafe Windows path: %q", name)
+	}
+	return clean, rel, nil
+}
+
+func validWindowsCopyArchivePath(rel string) bool {
+	for _, component := range strings.Split(rel, "/") {
+		if component == "" {
+			continue
+		}
+		if strings.Contains(component, ":") || strings.HasSuffix(component, ".") || strings.HasSuffix(component, " ") {
+			return false
+		}
+		base := component
+		if index := strings.IndexByte(base, '.'); index >= 0 {
+			base = base[:index]
+		}
+		base = strings.ToUpper(base)
+		if base == "CON" || base == "PRN" || base == "AUX" || base == "NUL" ||
+			len(base) == 4 && (strings.HasPrefix(base, "COM") || strings.HasPrefix(base, "LPT")) && base[3] >= '1' && base[3] <= '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func publishCopyArchivePayload(payload, target string) error {
+	if _, err := os.Lstat(payload); err != nil {
+		return fmt.Errorf("read staged copy payload: %w", err)
+	}
+	releaseLock, err := acquireCopyArchiveTargetLock(target)
+	if err != nil {
+		return err
+	}
+	defer releaseLock()
+	backup := target + ".crabbox-cp-backup"
+	marker := target + ".crabbox-cp-transaction"
+	if err := recoverCopyArchiveTransaction(target, backup, marker, 0); err != nil {
+		return err
+	}
+	if err := writeCopyArchiveTransactionMarker(marker); err != nil {
+		return fmt.Errorf("write copy transaction marker: %w", err)
+	}
+	if _, err := os.Lstat(target); err == nil {
+		if err := os.Rename(target, backup); err != nil {
+			_ = os.Remove(marker)
+			return fmt.Errorf("stage existing copy destination: %w", err)
+		}
+		if err := syncCopyArchiveDirectory(filepath.Dir(target)); err != nil {
+			recoverErr := recoverCopyArchiveTransaction(target, backup, marker, os.Getpid())
+			return errors.Join(err, recoverErr)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("inspect copy destination: %w", err)
+	}
+	if err := os.Rename(payload, target); err != nil {
+		recoverErr := recoverCopyArchiveTransaction(target, backup, marker, os.Getpid())
+		return errors.Join(fmt.Errorf("publish copy archive: %w", err), recoverErr)
+	}
+	if err := syncCopyArchiveDirectory(filepath.Dir(target)); err != nil {
+		recoverErr := recoverCopyArchiveTransaction(target, backup, marker, os.Getpid())
+		return errors.Join(err, recoverErr)
+	}
+	if _, err := os.Lstat(backup); err == nil {
+		if err := os.RemoveAll(backup); err != nil {
+			return fmt.Errorf("remove replaced copy destination: %w", err)
+		}
+		if err := syncCopyArchiveDirectory(filepath.Dir(target)); err != nil {
+			return err
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("inspect replaced copy destination: %w", err)
+	}
+	if err := os.Remove(marker); err != nil {
+		return fmt.Errorf("remove copy transaction marker: %w", err)
+	}
+	if err := syncCopyArchiveDirectory(filepath.Dir(target)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func recoverCopyArchiveTransaction(target, backup, marker string, currentOwner int) error {
+	markerInfo, markerErr := os.Lstat(marker)
+	if markerErr != nil && !os.IsNotExist(markerErr) {
+		return fmt.Errorf("inspect copy transaction marker: %w", markerErr)
+	}
+	_, backupErr := os.Lstat(backup)
+	backupExists := backupErr == nil
+	if backupErr != nil && !os.IsNotExist(backupErr) {
+		return fmt.Errorf("inspect copy transaction backup: %w", backupErr)
+	}
+	if os.IsNotExist(markerErr) {
+		if backupExists {
+			return exit(2, "archive copy found reserved backup without transaction marker: %s", backup)
+		}
+		return nil
+	}
+	if !copyArchiveMarkerIsPrivate(markerInfo) {
+		return exit(2, "archive copy found an unauthenticated transaction marker: %s", marker)
+	}
+	state, err := os.ReadFile(marker)
+	if err != nil {
+		return fmt.Errorf("read copy transaction state: %w", err)
+	}
+	lines := strings.Split(strings.TrimSuffix(string(state), "\n"), "\n")
+	if len(lines) != 3 || lines[0] != "crabbox-cp-v1" || strings.TrimSpace(lines[2]) == "" {
+		return exit(2, "archive copy found invalid transaction state: %s", marker)
+	}
+	owner, err := strconv.Atoi(lines[1])
+	if err != nil || owner <= 0 {
+		return exit(2, "archive copy found invalid transaction state: %s", marker)
+	}
+	if owner != currentOwner && copyArchiveProcessIsAlive(owner) {
+		identity, ok := copyArchiveProcessIdentity(owner)
+		if !ok || identity == lines[2] {
+			return exit(2, "another archive copy is active for destination %s", target)
+		}
+	}
+	if backupExists {
+		if _, targetErr := os.Lstat(target); targetErr == nil {
+			if err := os.RemoveAll(backup); err != nil {
+				return fmt.Errorf("remove completed copy transaction backup: %w", err)
+			}
+		} else if os.IsNotExist(targetErr) {
+			if err := os.Rename(backup, target); err != nil {
+				return fmt.Errorf("restore interrupted copy transaction: %w", err)
+			}
+		} else {
+			return fmt.Errorf("inspect interrupted copy destination: %w", targetErr)
+		}
+		if err := syncCopyArchiveDirectory(filepath.Dir(target)); err != nil {
+			return err
+		}
+	}
+	if err := os.Remove(marker); err != nil {
+		return fmt.Errorf("remove recovered copy transaction marker: %w", err)
+	}
+	if err := syncCopyArchiveDirectory(filepath.Dir(target)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func acquireCopyArchiveTargetLock(target string) (func(), error) {
+	cache, err := os.UserCacheDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolve copy transaction lock directory: %w", err)
+	}
+	lockDir := filepath.Join(cache, "crabbox", "cp-locks")
+	if err := os.MkdirAll(lockDir, 0o700); err != nil {
+		return nil, fmt.Errorf("create copy transaction lock directory: %w", err)
+	}
+	if err := os.Chmod(lockDir, 0o700); err != nil {
+		return nil, fmt.Errorf("secure copy transaction lock directory: %w", err)
+	}
+	canonicalParent, err := filepath.EvalSymlinks(filepath.Dir(target))
+	if err != nil {
+		return nil, fmt.Errorf("canonicalize copy destination parent: %w", err)
+	}
+	canonicalTarget := filepath.Join(canonicalParent, filepath.Base(target))
+	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
+		canonicalTarget = strings.ToLower(canonicalTarget)
+	}
+	digest := sha256.Sum256([]byte(canonicalTarget))
+	lockPath := filepath.Join(lockDir, fmt.Sprintf("%x.lock", digest[:]))
+	value, _ := copyArchiveTargetMutexes.LoadOrStore(lockPath, &sync.Mutex{})
+	mutex := value.(*sync.Mutex)
+	mutex.Lock()
+	fileLock := flock.New(lockPath, flock.SetPermissions(0o600))
+	locked, err := fileLock.TryLock()
+	if err != nil || !locked {
+		mutex.Unlock()
+		if err != nil {
+			return nil, fmt.Errorf("lock copy destination: %w", err)
+		}
+		return nil, exit(2, "another archive copy is active for destination %s", target)
+	}
+	return func() {
+		_ = fileLock.Unlock()
+		mutex.Unlock()
+	}, nil
+}
+
+func writeCopyArchiveTransactionMarker(name string) error {
+	file, err := os.CreateTemp(filepath.Dir(name), ".crabbox-cp-marker-*")
+	if err != nil {
+		return err
+	}
+	temporary := file.Name()
+	defer os.Remove(temporary)
+	if err := file.Chmod(0o600); err != nil {
+		_ = file.Close()
+		return err
+	}
+	identity, ok := copyArchiveProcessIdentity(os.Getpid())
+	if !ok {
+		_ = file.Close()
+		return errors.New("resolve copy transaction owner identity")
+	}
+	if _, err := fmt.Fprintf(file, "crabbox-cp-v1\n%d\n%s\n", os.Getpid(), identity); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	if err := os.Link(temporary, name); err != nil {
+		return err
+	}
+	if err := syncCopyArchiveDirectory(filepath.Dir(name)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func syncCopyArchiveTree(root string) error {
+	return filepath.WalkDir(root, func(name string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return exit(2, "refusing to sync symlink in downloaded copy archive: %s", name)
+		}
+		file, err := os.Open(name)
+		if err != nil {
+			return fmt.Errorf("open staged copy archive path for sync: %w", err)
+		}
+		syncErr := file.Sync()
+		closeErr := file.Close()
+		if syncErr != nil && !(runtime.GOOS == "windows" && entry.IsDir()) {
+			return fmt.Errorf("sync staged copy archive path %s: %w", name, syncErr)
+		}
+		return closeErr
+	})
+}
+
+func syncCopyArchiveDirectory(name string) error {
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+	directory, err := os.Open(name)
+	if err != nil {
+		return fmt.Errorf("open copy transaction directory for sync: %w", err)
+	}
+	syncErr := directory.Sync()
+	closeErr := directory.Close()
+	return errors.Join(syncErr, closeErr)
+}

--- a/internal/cli/cp_archive_owner_unix.go
+++ b/internal/cli/cp_archive_owner_unix.go
@@ -1,0 +1,51 @@
+//go:build !windows
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+func copyArchiveDirectoryIdentity(name string, info os.FileInfo) string {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return name
+	}
+	return fmt.Sprintf("%d:%d", stat.Dev, stat.Ino)
+}
+
+func copyArchiveMarkerIsPrivate(info os.FileInfo) bool {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	return info.Mode().IsRegular() && info.Mode()&os.ModeSymlink == 0 && info.Mode().Perm()&0o077 == 0 && ok && int(stat.Uid) == os.Geteuid()
+}
+
+func copyArchiveProcessIsAlive(pid int) bool {
+	return syscall.Kill(pid, 0) == nil
+}
+
+func copyArchiveProcessIdentity(pid int) (string, bool) {
+	if runtime.GOOS == "linux" {
+		data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+		if err != nil {
+			return "", false
+		}
+		closing := strings.LastIndexByte(string(data), ')')
+		if closing < 0 {
+			return "", false
+		}
+		fields := strings.Fields(string(data)[closing+1:])
+		if len(fields) <= 19 {
+			return "", false
+		}
+		return fields[19], true
+	}
+	output, err := exec.Command("ps", "-o", "lstart=", "-p", strconv.Itoa(pid)).Output()
+	identity := strings.TrimSpace(string(output))
+	return identity, err == nil && identity != ""
+}

--- a/internal/cli/cp_archive_owner_windows.go
+++ b/internal/cli/cp_archive_owner_windows.go
@@ -1,0 +1,35 @@
+//go:build windows
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/windows"
+)
+
+func copyArchiveDirectoryIdentity(name string, _ os.FileInfo) string {
+	return strings.ToLower(filepath.Clean(name))
+}
+
+// Windows user profiles and the lock directory carry the current user's ACL.
+// Opening the private marker and its state successfully is the ownership proof.
+func copyArchiveMarkerIsPrivate(info os.FileInfo) bool {
+	return false
+}
+
+func copyArchiveProcessIsAlive(pid int) bool {
+	handle, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	defer windows.CloseHandle(handle)
+	var code uint32
+	return windows.GetExitCodeProcess(handle, &code) == nil && code == 259
+}
+
+func copyArchiveProcessIdentity(_ int) (string, bool) {
+	return "", false
+}

--- a/internal/cli/cp_archive_test.go
+++ b/internal/cli/cp_archive_test.go
@@ -1,0 +1,739 @@
+package cli
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCopyArchiveRoundTripNormalizesDownloads(t *testing.T) {
+	source := filepath.Join(t.TempDir(), "source")
+	if err := os.Mkdir(source, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	mtime := time.Unix(1_725_000_000, 0)
+	file := filepath.Join(source, "executable.sh")
+	if err := os.WriteFile(file, []byte("proof\n"), 0o751); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(file, mtime, mtime); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(source, mtime, mtime); err != nil {
+		t.Fatal(err)
+	}
+
+	_, archive, err := createCopyArchive(t.Context(), source, false, defaultCopyArchiveLimits)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		name := archive.Name()
+		_ = archive.Close()
+		_ = os.Remove(name)
+	})
+	stage := t.TempDir()
+	if err := extractValidatedCopyArchive(t.Context(), archive, stage, copyArchivePayloadRoot, defaultCopyArchiveLimits); err != nil {
+		t.Fatal(err)
+	}
+	extracted := filepath.Join(stage, copyArchivePayloadRoot, "executable.sh")
+	data, err := os.ReadFile(extracted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "proof\n" {
+		t.Fatalf("content=%q", data)
+	}
+	info, err := os.Stat(extracted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm()&0o111 != 0 {
+		t.Fatalf("download mode retained remote executable bits: %o", info.Mode().Perm())
+	}
+	if !info.ModTime().Equal(mtime) {
+		t.Fatalf("mtime=%s, want %s", info.ModTime(), mtime)
+	}
+}
+
+func TestCreateCopyArchiveSymlinkSafety(t *testing.T) {
+	if os.PathSeparator == '\\' {
+		t.Skip("archive fallback is unavailable on Windows operator hosts")
+	}
+	root := t.TempDir()
+	target := filepath.Join(root, "target.txt")
+	if err := os.WriteFile(target, []byte("target"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := createCopyArchive(t.Context(), link, false, defaultCopyArchiveLimits); err == nil || !strings.Contains(err.Error(), "use -L") {
+		t.Fatalf("unsafe symlink err=%v", err)
+	}
+	_, archive, err := createCopyArchive(t.Context(), link, true, defaultCopyArchiveLimits)
+	if err != nil {
+		t.Fatal(err)
+	}
+	name := archive.Name()
+	_ = archive.Close()
+	_ = os.Remove(name)
+	directory := filepath.Join(root, "directory")
+	if err := os.Mkdir(directory, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	directoryLink := filepath.Join(root, "directory-link")
+	if err := os.Symlink(directory, directoryLink); err != nil {
+		t.Fatal(err)
+	}
+	source, archive, err := createCopyArchive(t.Context(), directoryLink+string(os.PathSeparator), true, defaultCopyArchiveLimits)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !source.contentsOnly {
+		t.Fatal("followed directory symlink with trailing slash must copy contents")
+	}
+	name = archive.Name()
+	_ = archive.Close()
+	_ = os.Remove(name)
+}
+
+func TestCreateCopyArchiveSourcePathIntent(t *testing.T) {
+	if os.PathSeparator == '\\' {
+		t.Skip("archive fallback is unavailable on Windows operator hosts")
+	}
+	root := t.TempDir()
+	file := filepath.Join(root, "file")
+	if err := os.WriteFile(file, []byte("proof"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := createCopyArchive(t.Context(), file+"/", false, defaultCopyArchiveLimits); err == nil || !strings.Contains(err.Error(), "not a directory") {
+		t.Fatalf("file trailing slash err=%v", err)
+	}
+	for _, source := range []string{root + "/.", root + "/.."} {
+		if _, _, err := createCopyArchive(t.Context(), source, false, defaultCopyArchiveLimits); err == nil || !strings.Contains(err.Error(), "ending in . or ..") {
+			t.Fatalf("source=%q err=%v", source, err)
+		}
+	}
+}
+
+func TestExtractValidatedCopyArchiveRejectsUnsafeEntries(t *testing.T) {
+	tests := []struct {
+		name    string
+		header  tar.Header
+		body    string
+		limits  copyArchiveLimits
+		wantErr string
+	}{
+		{
+			name:    "path traversal",
+			header:  tar.Header{Name: "../escape", Mode: 0o644, Size: 1, Typeflag: tar.TypeReg},
+			body:    "x",
+			limits:  defaultCopyArchiveLimits,
+			wantErr: "unsafe path",
+		},
+		{
+			name:    "symlink",
+			header:  tar.Header{Name: "remote/link", Linkname: "/tmp/escape", Typeflag: tar.TypeSymlink},
+			limits:  defaultCopyArchiveLimits,
+			wantErr: "unsupported link or special entry",
+		},
+		{
+			name:    "file size",
+			header:  tar.Header{Name: "remote/file", Mode: 0o644, Size: 5, Typeflag: tar.TypeReg},
+			body:    "12345",
+			limits:  copyArchiveLimits{maxEntries: 10, maxFileBytes: 4, maxTotalBytes: 10, maxCompressedBytes: 1024},
+			wantErr: "file exceeds size limit",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			archive := testCopyArchive(t, test.header, test.body)
+			err := extractValidatedCopyArchive(t.Context(), bytes.NewReader(archive), t.TempDir(), "remote", test.limits)
+			if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("err=%v", err)
+			}
+		})
+	}
+}
+
+func TestExtractValidatedCopyArchiveVerifiesChecksum(t *testing.T) {
+	archive := testCopyArchive(t, tar.Header{Name: "remote", Mode: 0o644, Size: 5, Typeflag: tar.TypeReg}, "proof")
+	archive[len(archive)-5] ^= 0xff
+	err := extractValidatedCopyArchive(t.Context(), bytes.NewReader(archive), t.TempDir(), "remote", defaultCopyArchiveLimits)
+	if err == nil || !strings.Contains(err.Error(), "checksum") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestExtractValidatedCopyArchiveBoundsZeroTrailer(t *testing.T) {
+	var compressed bytes.Buffer
+	gz := gzip.NewWriter(&compressed)
+	tw := tar.NewWriter(gz)
+	if err := tw.WriteHeader(&tar.Header{Name: "remote", Mode: 0o644, Size: 1, Typeflag: tar.TypeReg}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.WriteString(tw, "x"); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.CopyN(gz, zeroReader{}, 2<<20); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	limits := copyArchiveLimits{maxEntries: 1, maxFileBytes: 10, maxTotalBytes: 10, maxCompressedBytes: 1 << 20}
+	err := extractValidatedCopyArchive(t.Context(), bytes.NewReader(compressed.Bytes()), t.TempDir(), "remote", limits)
+	if err == nil || !strings.Contains(err.Error(), "uncompressed size limit") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+type zeroReader struct{}
+
+func (zeroReader) Read(data []byte) (int, error) {
+	clear(data)
+	return len(data), nil
+}
+
+func TestValidatedCopyArchiveEntryPathRejectsWindowsSpecialPaths(t *testing.T) {
+	for _, name := range []string{
+		`remote\escape`,
+		"remote/C:/escape",
+		"remote/NUL",
+		"remote/COM1.txt",
+		"remote/trailing.",
+		"remote/trailing ",
+	} {
+		if _, _, err := validatedCopyArchiveEntryPathForGOOS("windows", name, "remote"); err == nil {
+			t.Errorf("Windows archive path %q was accepted", name)
+		}
+	}
+	if _, rel, err := validatedCopyArchiveEntryPathForGOOS("windows", "remote/results/proof.txt", "remote"); err != nil || rel != "results/proof.txt" {
+		t.Fatalf("safe Windows path rel=%q err=%v", rel, err)
+	}
+}
+
+func TestCopyOverResolvedSSHArchiveFallbackWithOldRsync(t *testing.T) {
+	if os.PathSeparator == '\\' {
+		t.Skip("POSIX fake SSH helper")
+	}
+	tools := t.TempDir()
+	sshArgs := filepath.Join(tools, "ssh-args")
+	rsyncTransfer := filepath.Join(tools, "rsync-transfer")
+	secret := "opaque-user-value"
+	writeExecutable(t, filepath.Join(tools, "rsync"), `#!/bin/sh
+set -eu
+if [ "${1:-}" = "--version" ]; then
+  printf 'openrsync: protocol version 29\nrsync version 2.6.9 compatible\n'
+  exit 0
+fi
+printf started > "$CRABBOX_TEST_RSYNC_TRANSFER"
+exit 91
+`)
+	writeExecutable(t, filepath.Join(tools, "ssh"), `#!/bin/sh
+set -eu
+printf '%s\n' "$@" >> "$CRABBOX_TEST_SSH_ARGS"
+printf '%s: transport diagnostic\n' "$CRABBOX_TEST_SECRET" >&2
+for last do :; done
+exec /bin/bash -c "$last"
+`)
+	t.Setenv("PATH", tools+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("CRABBOX_TEST_SSH_ARGS", sshArgs)
+	t.Setenv("CRABBOX_TEST_RSYNC_TRANSFER", rsyncTransfer)
+	t.Setenv("CRABBOX_TEST_SECRET", secret)
+
+	sourceParent := t.TempDir()
+	source := filepath.Join(sourceParent, "input")
+	if err := os.Mkdir(source, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	mtime := time.Unix(1_725_000_123, 0)
+	if err := os.WriteFile(filepath.Join(source, "proof.txt"), []byte("archive-proof"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(filepath.Join(source, "proof.txt"), mtime, mtime); err != nil {
+		t.Fatal(err)
+	}
+	remoteDestination := t.TempDir()
+	target := SSHTarget{User: secret, Host: "example.test", Port: "22", AuthSecret: true}
+	var stderr bytes.Buffer
+	if err := copyOverResolvedSSH(t.Context(), target, source, "SANDBOX:"+remoteDestination, false, io.Discard, &stderr); err != nil {
+		t.Fatal(err)
+	}
+	remoteFile := filepath.Join(remoteDestination, filepath.Base(source), "proof.txt")
+	data, err := os.ReadFile(remoteFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "archive-proof" {
+		t.Fatalf("remote content=%q", data)
+	}
+	remoteInfo, err := os.Stat(remoteFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if remoteInfo.Mode().Perm() != 0o640 || !remoteInfo.ModTime().Equal(mtime) {
+		t.Fatalf("remote metadata mode=%o mtime=%s", remoteInfo.Mode().Perm(), remoteInfo.ModTime())
+	}
+
+	downloadParent := t.TempDir()
+	if err := copyOverResolvedSSH(t.Context(), target, "SANDBOX:"+remoteFile, downloadParent, false, io.Discard, &stderr); err != nil {
+		t.Fatal(err)
+	}
+	downloaded := filepath.Join(downloadParent, "proof.txt")
+	data, err = os.ReadFile(downloaded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "archive-proof" {
+		t.Fatalf("downloaded content=%q", data)
+	}
+	downloadInfo, err := os.Stat(downloaded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if downloadInfo.Mode().Perm()&0o111 != 0 || !downloadInfo.ModTime().Equal(mtime) {
+		t.Fatalf("download metadata mode=%o mtime=%s", downloadInfo.Mode().Perm(), downloadInfo.ModTime())
+	}
+	if _, err := os.Stat(rsyncTransfer); !os.IsNotExist(err) {
+		t.Fatalf("rejected rsync started a transfer: %v", err)
+	}
+	args, err := os.ReadFile(sshArgs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(args), secret) {
+		t.Fatalf("SSH argv leaked resolved user: %q", args)
+	}
+	if strings.Contains(stderr.String(), secret) || !strings.Contains(stderr.String(), diagnosticRedaction) {
+		t.Fatalf("SSH diagnostics were not redacted: %q", stderr.String())
+	}
+}
+
+func TestRemoteCopyArchiveUploadCleansPartialTransfer(t *testing.T) {
+	if os.PathSeparator == '\\' {
+		t.Skip("POSIX archive endpoint")
+	}
+	parent := t.TempDir()
+	target := filepath.Join(parent, "target")
+	if err := os.WriteFile(target, []byte("original"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	remote, err := remoteCopyArchiveUploadCommand(target, "source", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("bash", "-c", remote)
+	cmd.Stdin = strings.NewReader("truncated archive")
+	if err := cmd.Run(); err == nil {
+		t.Fatal("truncated transfer unexpectedly succeeded")
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "original" {
+		t.Fatalf("partial transfer changed destination: %q", data)
+	}
+	matches, err := filepath.Glob(filepath.Join(parent, ".crabbox-cp*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("partial transfer left staging paths: %#v", matches)
+	}
+}
+
+func TestRemoteCopyArchiveUploadCreatesTrailingSlashDestination(t *testing.T) {
+	if os.PathSeparator == '\\' {
+		t.Skip("POSIX archive endpoint")
+	}
+	source := filepath.Join(t.TempDir(), "source")
+	if err := os.Mkdir(source, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(source, "proof.txt"), []byte("proof"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, archive, err := createCopyArchive(t.Context(), source+string(os.PathSeparator), false, defaultCopyArchiveLimits)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func(file *os.File) {
+		name := file.Name()
+		_ = file.Close()
+		_ = os.Remove(name)
+	}(archive)
+	target := filepath.Join(t.TempDir(), "new-destination") + string(os.PathSeparator)
+	remote, err := remoteCopyArchiveUploadCommand(target, "source", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("bash", "-c", remote)
+	cmd.Stdin = archive
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("upload: %v: %s", err, output)
+	}
+	data, err := os.ReadFile(filepath.Join(target, "proof.txt"))
+	if err != nil || string(data) != "proof" {
+		t.Fatalf("content=%q err=%v", data, err)
+	}
+	_, archive, err = createCopyArchive(t.Context(), source, false, defaultCopyArchiveLimits)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func(file *os.File) {
+		name := file.Name()
+		_ = file.Close()
+		_ = os.Remove(name)
+	}(archive)
+	target = filepath.Join(t.TempDir(), "new-parent") + string(os.PathSeparator)
+	remote, err = remoteCopyArchiveUploadCommand(target, "source", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd = exec.Command("bash", "-c", remote)
+	cmd.Stdin = archive
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("directory upload: %v: %s", err, output)
+	}
+	data, err = os.ReadFile(filepath.Join(target, "source", "proof.txt"))
+	if err != nil || string(data) != "proof" {
+		t.Fatalf("directory content=%q err=%v", data, err)
+	}
+	fileDestination := filepath.Join(t.TempDir(), "existing-file")
+	if err := os.WriteFile(fileDestination, []byte("original"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	remote, err = remoteCopyArchiveUploadCommand(fileDestination+string(os.PathSeparator), "source", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd = exec.Command("bash", "-c", remote)
+	cmd.Stdin = strings.NewReader("unused")
+	if output, err := cmd.CombinedOutput(); err == nil || !strings.Contains(string(output), "not a directory") {
+		t.Fatalf("existing file directory destination err=%v output=%s", err, output)
+	}
+	symlinkDestination := filepath.Join(t.TempDir(), "directory-link")
+	if err := os.Symlink(t.TempDir(), symlinkDestination); err != nil {
+		t.Fatal(err)
+	}
+	remote, err = remoteCopyArchiveUploadCommand(symlinkDestination+string(os.PathSeparator), "source", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd = exec.Command("bash", "-c", remote)
+	cmd.Stdin = strings.NewReader("unused")
+	if output, err := cmd.CombinedOutput(); err == nil || !strings.Contains(string(output), "symlink destination") {
+		t.Fatalf("symlink directory destination err=%v output=%s", err, output)
+	}
+}
+
+func TestLocalCopyArchiveTargetPreservesTrailingDirectoryIntent(t *testing.T) {
+	if os.PathSeparator == '\\' {
+		t.Skip("archive fallback is unavailable on Windows operator hosts")
+	}
+	parent := t.TempDir()
+	destination := filepath.Join(parent, "new-directory") + string(os.PathSeparator)
+	target, err := localCopyArchiveTarget(destination, "source", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := filepath.Join(parent, "new-directory", "source"); target != want {
+		t.Fatalf("target=%q want=%q", target, want)
+	}
+	if info, err := os.Stat(filepath.Join(parent, "new-directory")); err != nil || !info.IsDir() {
+		t.Fatalf("destination directory info=%v err=%v", info, err)
+	}
+	fileDestination := filepath.Join(parent, "existing-file")
+	if err := os.WriteFile(fileDestination, []byte("original"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := localCopyArchiveTarget(fileDestination+string(os.PathSeparator), "source", false); err == nil || !strings.Contains(err.Error(), "not a directory") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestRemoteCopyArchiveCommandsAvoidLoginShells(t *testing.T) {
+	upload, err := remoteCopyArchiveUploadCommand("/tmp/target", "source", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	download, err := remoteCopyArchiveDownloadCommand("/tmp/source")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, command := range []string{upload, download} {
+		if strings.Contains(command, "bash -l") || !strings.Contains(command, "bash --noprofile --norc -c") {
+			t.Fatalf("archive stream uses profile-loading shell: %s", command)
+		}
+	}
+}
+
+func TestRemoteCopyArchiveSourcePathIntent(t *testing.T) {
+	if os.PathSeparator == '\\' {
+		t.Skip("archive fallback is unavailable on Windows operator hosts")
+	}
+	for _, source := range []string{"/tmp/results/.", "/tmp/results/.."} {
+		if _, _, err := remoteCopyArchiveRoot(source); err == nil || !strings.Contains(err.Error(), "ending in . or ..") {
+			t.Fatalf("source=%q err=%v", source, err)
+		}
+	}
+	if hasTrailingPathSeparator(`build\`) {
+		t.Fatal("POSIX backslash filename was treated as directory intent")
+	}
+}
+
+func TestRemoteCopyArchiveDownloadRejectsFileWithTrailingSlash(t *testing.T) {
+	if os.PathSeparator == '\\' {
+		t.Skip("POSIX archive endpoint")
+	}
+	file := filepath.Join(t.TempDir(), "file")
+	if err := os.WriteFile(file, []byte("proof"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	remote, err := remoteCopyArchiveDownloadCommand(file + "/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("bash", "-c", remote)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err == nil {
+		t.Fatal("file source with trailing slash unexpectedly streamed")
+	}
+	if stdout.Len() != 0 || !strings.Contains(stderr.String(), "not a directory") {
+		t.Fatalf("stdout=%d stderr=%q", stdout.Len(), stderr.String())
+	}
+}
+
+func TestRemoteCopyArchiveDownloadRejectsSocketBeforeStreaming(t *testing.T) {
+	if os.PathSeparator == '\\' {
+		t.Skip("POSIX archive endpoint")
+	}
+	source, err := os.MkdirTemp("/tmp", "cbx-cp-socket-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(source) })
+	listener, err := net.Listen("unix", filepath.Join(source, "service.sock"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	remote, err := remoteCopyArchiveDownloadCommand(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("bash", "-c", remote)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err == nil {
+		t.Fatal("socket-containing source unexpectedly streamed")
+	}
+	if stdout.Len() != 0 || !strings.Contains(stderr.String(), "link or special file") {
+		t.Fatalf("stdout=%d stderr=%q", stdout.Len(), stderr.String())
+	}
+}
+
+func TestRemoteCopyArchiveDownloadRejectsHardLinksBeforeStreaming(t *testing.T) {
+	if os.PathSeparator == '\\' {
+		t.Skip("POSIX archive endpoint")
+	}
+	source := t.TempDir()
+	first := filepath.Join(source, "first")
+	if err := os.WriteFile(first, []byte("proof"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Link(first, filepath.Join(source, "second")); err != nil {
+		t.Fatal(err)
+	}
+	remote, err := remoteCopyArchiveDownloadCommand(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("bash", "-c", remote)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err == nil {
+		t.Fatal("hard-linked source unexpectedly streamed")
+	}
+	if stdout.Len() != 0 || !strings.Contains(stderr.String(), "link or special file") {
+		t.Fatalf("stdout=%d stderr=%q", stdout.Len(), stderr.String())
+	}
+	remote, err = remoteCopyArchiveDownloadCommand(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd = exec.Command("bash", "-c", remote)
+	stdout.Reset()
+	stderr.Reset()
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err == nil {
+		t.Fatal("top-level hard-linked file unexpectedly streamed")
+	}
+	if stdout.Len() != 0 || !strings.Contains(stderr.String(), "link or special file") {
+		t.Fatalf("top-level stdout=%d stderr=%q", stdout.Len(), stderr.String())
+	}
+}
+
+func TestRecoverCopyArchiveTransaction(t *testing.T) {
+	if os.PathSeparator == '\\' {
+		t.Skip("archive fallback is unavailable on Windows operator hosts")
+	}
+	t.Run("restore interrupted backup", func(t *testing.T) {
+		parent := t.TempDir()
+		target := filepath.Join(parent, "target")
+		backup := target + ".crabbox-cp-backup"
+		marker := target + ".crabbox-cp-transaction"
+		if err := os.WriteFile(backup, []byte("original"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(marker, []byte("crabbox-cp-v1\n2147483646\ndead-process\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := recoverCopyArchiveTransaction(target, backup, marker, 0); err != nil {
+			t.Fatal(err)
+		}
+		data, err := os.ReadFile(target)
+		if err != nil || string(data) != "original" {
+			t.Fatalf("content=%q err=%v", data, err)
+		}
+	})
+	t.Run("finish published transaction", func(t *testing.T) {
+		parent := t.TempDir()
+		target := filepath.Join(parent, "target")
+		backup := target + ".crabbox-cp-backup"
+		marker := target + ".crabbox-cp-transaction"
+		if err := os.WriteFile(target, []byte("new"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(backup, []byte("old"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(marker, []byte("crabbox-cp-v1\n2147483646\ndead-process\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := recoverCopyArchiveTransaction(target, backup, marker, 0); err != nil {
+			t.Fatal(err)
+		}
+		data, err := os.ReadFile(target)
+		if err != nil || string(data) != "new" {
+			t.Fatalf("content=%q err=%v", data, err)
+		}
+		for _, reserved := range []string{backup, marker} {
+			if _, err := os.Lstat(reserved); !os.IsNotExist(err) {
+				t.Fatalf("reserved path remains: %s err=%v", reserved, err)
+			}
+		}
+	})
+	t.Run("reject forged marker", func(t *testing.T) {
+		parent := t.TempDir()
+		target := filepath.Join(parent, "target")
+		backup := target + ".crabbox-cp-backup"
+		marker := target + ".crabbox-cp-transaction"
+		if err := os.WriteFile(target, []byte("current"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(backup, []byte("reserved"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(marker, []byte("crabbox-cp-v1\n2147483646\ndead-process\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := recoverCopyArchiveTransaction(target, backup, marker, 0); err == nil || !strings.Contains(err.Error(), "unauthenticated") {
+			t.Fatalf("err=%v", err)
+		}
+		data, err := os.ReadFile(backup)
+		if err != nil || string(data) != "reserved" {
+			t.Fatalf("backup=%q err=%v", data, err)
+		}
+	})
+	t.Run("refuse active owner", func(t *testing.T) {
+		parent := t.TempDir()
+		target := filepath.Join(parent, "target")
+		backup := target + ".crabbox-cp-backup"
+		marker := target + ".crabbox-cp-transaction"
+		identity, ok := copyArchiveProcessIdentity(os.Getpid())
+		if !ok {
+			t.Fatal("current process identity unavailable")
+		}
+		if err := os.WriteFile(marker, []byte(fmt.Sprintf("crabbox-cp-v1\n%d\n%s\n", os.Getpid(), identity)), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := recoverCopyArchiveTransaction(target, backup, marker, 0); err == nil || !strings.Contains(err.Error(), "another archive copy is active") {
+			t.Fatalf("err=%v", err)
+		}
+		if _, err := os.Lstat(marker); err != nil {
+			t.Fatalf("active marker was removed: %v", err)
+		}
+	})
+}
+
+func TestCopyArchiveDirectoryTrackerRejectsFilesystemAliases(t *testing.T) {
+	stage := t.TempDir()
+	tracker := copyArchiveDirectoryTracker{}
+	if err := tracker.ensure(stage, "remote", "A"); err != nil {
+		t.Fatal(err)
+	}
+	upper, err := os.Stat(filepath.Join(stage, copyArchivePayloadRoot, "A"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	lower, err := os.Stat(filepath.Join(stage, copyArchivePayloadRoot, "a"))
+	if err != nil || !os.SameFile(upper, lower) {
+		t.Skip("test volume is case-sensitive")
+	}
+	if err := tracker.ensure(stage, "remote", "a"); err == nil || !strings.Contains(err.Error(), "path aliases") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func testCopyArchive(t *testing.T, header tar.Header, body string) []byte {
+	t.Helper()
+	var compressed bytes.Buffer
+	gz := gzip.NewWriter(&compressed)
+	tw := tar.NewWriter(gz)
+	if err := tw.WriteHeader(&header); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.WriteString(tw, body); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return compressed.Bytes()
+}
+
+func writeExecutable(t *testing.T, name, contents string) {
+	t.Helper()
+	if err := os.WriteFile(name, []byte(contents), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/cli/cp_ssh_test.go
+++ b/internal/cli/cp_ssh_test.go
@@ -387,7 +387,7 @@ func TestCopyOverResolvedSSHRejectsNativeWindows(t *testing.T) {
 	}
 }
 
-func TestCopyOverResolvedSSHRejectsUnsafeRsyncBeforeTransfer(t *testing.T) {
+func TestCopyOverResolvedSSHFallsBackWithoutStartingUnsafeRsync(t *testing.T) {
 	if os.PathSeparator == '\\' {
 		t.Skip("POSIX fake rsync helper")
 	}
@@ -404,11 +404,16 @@ printf started > "$CRABBOX_TEST_RSYNC_TRANSFER_MARKER"
 	if err := os.WriteFile(rsyncPath, []byte(script), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	writeExecutable(t, filepath.Join(dir, "ssh"), "#!/bin/sh\nexit 86\n")
+	input := filepath.Join(dir, "input")
+	if err := os.WriteFile(input, []byte("archive fallback"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("CRABBOX_TEST_RSYNC_TRANSFER_MARKER", transferMarker)
-	err := copyOverResolvedSSH(t.Context(), SSHTarget{User: "alice", Host: "example.test", Port: "22"}, "./input", "SANDBOX:/tmp/input", false, &bytes.Buffer{}, &bytes.Buffer{})
-	if err == nil || !strings.Contains(err.Error(), "rsync 3.4.3 or newer") {
+	err := copyOverResolvedSSH(t.Context(), SSHTarget{User: "alice", Host: "example.test", Port: "22"}, input, "SANDBOX:/tmp/input", false, &bytes.Buffer{}, &bytes.Buffer{})
+	if err == nil || strings.Contains(err.Error(), "rsync 3.4.3 or newer") {
 		t.Fatalf("err=%v", err)
 	}
 	if _, err := os.Stat(transferMarker); !os.IsNotExist(err) {


### PR DESCRIPTION
## Summary

- prefer the existing secure rsync transport when local rsync is 3.4.3 or newer
- fall back on POSIX operator hosts to a Go-created/validated tar+gzip stream over the resolved private SSH session for native Linux and macOS leases
- bound compressed, expanded, per-file, and entry counts; reject traversal, duplicate filesystem aliases, links, hard links, and special files on download
- make publication durable and target-scoped with staged validation, authenticated transaction ownership, crash recovery, and fail-closed tar diagnostics
- preserve upload permissions/mtimes and normalize downloaded modes while preserving mtimes
- document platform scope, replacement semantics, and pre/post-publication recovery behavior

## Verification

- `go test ./...`
- `go test -race ./internal/cli -run 'Test(CopyArchive|CreateCopyArchive|ExtractValidatedCopyArchive|CopyOverResolvedSSH|RemoteCopyArchive|LocalCopyArchive|ValidatedCopyArchive|RecoverCopyArchive)' -count=1`
- `go vet ./...`
- `GOOS=windows GOARCH=amd64 go test -c -o /tmp/crabbox-cli-1280.test.exe ./internal/cli`
- `node scripts/build-docs-site.mjs`
- structured autoreview: clean, no accepted/actionable findings

## Live proof

Built the branch CLI on macOS with stock `/usr/bin/rsync` reporting OpenRsync 2.6.9, then used a task-owned local-container SSH lease to upload and download a regular file and a trailing-slash directory. The file SHA-256 matched across host, lease, and downloaded copy; file counts matched 4/4; mode was normalized to `0644`; mtime was preserved. The lease was deleted after proof.

No configuration or secret changes.

Closes https://github.com/openclaw/crabbox/issues/1280
