### PR TITLE
fix(cli): require explicit provider intent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Required explicit provider intent before lifecycle commands initialize a backend, while preserving claim and recorded-run routing and keeping bare doctor provider-neutral. Thanks @coygeek.
 - Prevented Azure orphan-sweep release failures from writing secret-bearing diagnostics to Worker console logs while retaining redacted details in sweep records.
 - Rejected native Jujutsu workspaces before Git-manifest sync can fall through to an outer checkout, while preserving colocated Git workspaces and `--no-sync`. Thanks @atimmer.
 - Redacted compound environment assignments, cookie and security-token headers, and camel-case API-token fields from client-visible coordinator diagnostics while preserving surrounding operational context. Thanks @dwin-gharibi.

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -40,9 +40,15 @@ skipped). This changes selection only: an explicit path inside the active
 repository, or a symlink that resolves into it, still has repository trust.
 `config show` reflects the resulting effective values, including
 provider defaults applied at load time; per-command flags are not part of what
-it reports. The provider line also includes `provider_source` (and JSON includes
-`providerSource`) so diagnostics distinguish a `compiled_default` from a
-selection in `user_config`, `repo_config`, or the `environment`. Passing
+it reports. The provider line includes `provider_selected` and `provider_source`
+(JSON: `providerSelected` and `providerSource`). With only compatibility
+metadata, the public `provider` value is the empty string and the state is
+`provider_selected=false provider_source=compiled_default`; it is not an
+actionable provider selection. The public top-level `serverType` / text `type`
+is also empty in that state so provider-specific compatibility defaults are not
+presented as effective; provider-specific configuration sections remain visible.
+Selections in `user_config`, `repo_config`, or
+the `environment` retain the canonical provider name and report selected=true. Passing
 `config show --provider <name>` reports `flag` because that command-scoped
 override wins the merge.
 

--- a/docs/commands/doctor.md
+++ b/docs/commands/doctor.md
@@ -3,9 +3,10 @@
 `crabbox doctor` runs a preflight before you commit to a long workflow. It is
 fast on a healthy machine, non-destructive, and never creates, mutates, or
 deletes provider resources. Bare `crabbox doctor` is also the pre-configuration
-local-readiness check: when the provider comes only from Crabbox's compiled
-default, doctor reports that provenance and skips provider credential readiness
-with a warning. Run it before your first `crabbox run`, after rotating tokens or
+local-readiness check: with no selected provider, doctor reports
+`source=compiled_default selected=false`, leaves the top-level JSON provider
+empty, and skips provider credential readiness with a warning. Run it before
+your first `crabbox run`, after rotating tokens or
 editing config, and as a sanity check in agent boot sequences or CI smoke jobs.
 
 ```sh
@@ -53,11 +54,11 @@ A missing tool prints `missing` and fails the run.
 
 Provider readiness validates the selected provider without creating a lease.
 
-Doctor first prints `provider-selection` with the resolved provider and source:
+Doctor first prints `provider-selection` with the selected state and source:
 `compiled_default`, `user_config`, `repo_config`, `environment`, `flag`,
-`recorded_run`, or `lease_context`. If the only source is `compiled_default`, doctor prints
-`warning provider ... readiness=skipped` and does not run either direct or
-coordinator provider credential readiness. This warning does not hide other
+`recorded_run`, or `lease_context`. If the only source is `compiled_default`,
+doctor explicitly says `no provider selected`, reports `selected=false`, and
+does not run provider-specific tool or credential readiness. This warning does not hide other
 failures: missing local tools, invalid coordinator authentication, unsafe config
 permissions, and other applicable checks still determine the exit status.
 Selecting the same provider explicitly is strict; for example,
@@ -223,7 +224,7 @@ Exit codes:
 ## Flags
 
 ```text
---provider <name>             provider to validate strictly (defaults to resolved provider)
+--provider <name>             provider to validate strictly (defaults to configured selection)
 --profile <name>              configured profile for remote prerequisite checks
 --id <lease-id-or-slug>       resolve a lease and run a remote SSH/tool probe
 --from-run <run-id>           load provider/target/lease/phase context from a recorded run

--- a/docs/commands/warmup.md
+++ b/docs/commands/warmup.md
@@ -45,6 +45,11 @@ stderr.
 Warmup records a local claim binding the lease to the current repo checkout. Use
 `--reclaim` to overwrite an existing claim for that lease.
 
+Warmup requires an explicit provider selection from `--provider`,
+`CRABBOX_PROVIDER`, user or repository config, broker config, or an applicable
+recorded lease route. With no selection it exits before provider initialization
+and points to `crabbox providers recommend`.
+
 For `local-container`, the default `--keep=true` also covers SSH readiness
 failure: once Docker has returned an exact container identity, Crabbox persists
 a scoped `provisioning` claim before inspecting the container or waiting for
@@ -284,7 +289,7 @@ warmup, because it also dispatches the workflow and waits for the ready marker.
 ## Flags
 
 ```text
---provider <name>                  provider (see crabbox providers); default hetzner
+--provider <name>                  provider (see crabbox providers); defaults to configured selection
 --profile <name>                   configuration profile
 --class <name>                     machine class; default beast
 --arch amd64|arm64                 CPU architecture; arm64 supports Linux on AWS/Azure/Apple Container and native Windows on Azure

--- a/docs/features/doctor.md
+++ b/docs/features/doctor.md
@@ -16,8 +16,10 @@ The command is fast (under a second on a healthy machine), non-destructive, and
 never calls billable provider create APIs. When a coordinator is configured it
 performs cheap broker checks such as health, identity, and provider secret
 readiness. The provider readiness probe is bounded to a 10s timeout. Bare doctor
-skips that probe when the resolved provider is only the compiled default; all
-explicit or configured provider selections remain strict.
+is provider-neutral: it reports no selected provider, preserves
+`source=compiled_default selected=false` as compatibility metadata, and skips
+provider-specific tool and credential probes. All explicit or configured
+provider selections remain strict.
 
 ## Output Model
 
@@ -101,15 +103,16 @@ coordinator, doctor falls through to the direct provider check below.
 
 Provider readiness validates the selected provider without creating a lease.
 
-Before local tool checks, `provider-selection` reports the canonical provider
-and the winning source: `compiled_default`, `user_config`, `repo_config`,
+Before local tool checks, `provider-selection` reports whether a provider is
+selected and the winning source: `compiled_default`, `user_config`, `repo_config`,
 `environment`, `flag`, `recorded_run`, or `lease_context`. This provenance is
 resolved while configuration and command context are applied; doctor does not
 infer it from the provider name.
 
-When the source is `compiled_default`, doctor skips both brokered and direct
-provider credential readiness and emits an advisory provider warning with
-`readiness=skipped`. Other checks still run and can fail the command. A provider
+When the source is `compiled_default`, doctor reports `no provider selected`,
+sets selected=false, and skips provider-specific tools plus brokered and direct
+provider credential readiness. JSON keeps its top-level provider empty. Other
+provider-neutral checks still run and can fail the command. A provider
 selected from any higher-precedence source remains strict, including an
 explicit flag that happens to select the same provider as the compiled default.
 

--- a/docs/features/provider-selection.md
+++ b/docs/features/provider-selection.md
@@ -48,6 +48,15 @@ crabbox doctor --provider <name>
 before spending real capacity. For the live proof expected from provider PRs,
 see [Provider live smoke](provider-live-smoke.md).
 
+Lifecycle commands require actionable provider intent: pass `--provider
+<name>`, set `CRABBOX_PROVIDER`, or configure a provider in user, repository,
+or broker config. The compiled provider value is retained only for compatible
+default derivation and is never enough to initialize a backend. Existing lease
+commands may instead route from an exact local claim, an unambiguous claimed
+slug, or recorded run context. With no actionable selection, commands stop with
+shared guidance before provider credential validation. Run `crabbox providers
+recommend` when choosing a provider.
+
 ## Selection rules
 
 Use these rules before adding a new adapter:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,12 +24,14 @@ crabbox --version
 crabbox doctor
 ```
 
-`crabbox doctor` prints one line per check. Local tool checks (`git`, `ssh`,
-`ssh-keygen`, `rsync`) should report `ok`. On a fresh install, doctor reports the
-compiled provider default as `source=compiled_default` and warns that provider
-credential readiness was skipped; the warning does not fail the command. Once
-you select a provider through config, `CRABBOX_PROVIDER`, or `--provider`, its
-broker or direct credential check is strict and can fail until you configure it.
+`crabbox doctor` prints one line per check. On a fresh install, its
+provider-neutral `git` check should report `ok`; provider-specific tool checks
+begin after you select a provider. Doctor reports `no provider selected`, keeps
+the compatibility metadata as `source=compiled_default selected=false`, and
+skips provider credential readiness without failing the command. Select a
+provider through config, `CRABBOX_PROVIDER`, or `--provider` before a lifecycle
+command. That selection is strict and can fail until its credentials are
+configured; run `crabbox providers recommend` to compare options.
 
 If you do not use Homebrew, GitHub Releases ship signed archives for macOS,
 Linux, and Windows. Download the matching archive from

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -366,6 +366,9 @@ func newFlagSet(name string, stderr io.Writer) *flag.FlagSet {
 }
 
 func parseFlags(fs *flag.FlagSet, args []string) error {
+	if provider := fs.Lookup("provider"); provider != nil {
+		provider.DefValue = ""
+	}
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return ExitError{Code: 0}

--- a/internal/cli/app_help_test.go
+++ b/internal/cli/app_help_test.go
@@ -41,6 +41,26 @@ func TestCleanupHelpListsRegisteredXCPNgProvider(t *testing.T) {
 	}
 }
 
+func TestWarmupHelpDescribesConfiguredProviderWithoutCompiledDefault(t *testing.T) {
+	isolateDoctorProviderSelectionTest(t)
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).warmup(context.Background(), []string{"--help"})
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 0 {
+		t.Fatalf("crabbox warmup --help error=%v stderr=%q", err, stderr.String())
+	}
+	help := stderr.String()
+	if strings.Contains(help, `default "hetzner"`) {
+		t.Fatalf("warmup help exposed compiled provider default:\n%s", help)
+	}
+	if !strings.Contains(help, "defaults to configured selection") {
+		t.Fatalf("warmup help omitted configured-selection guidance:\n%s", help)
+	}
+	if !strings.Contains(help, `default "default"`) {
+		t.Fatalf("warmup help suppressed unrelated defaults:\n%s", help)
+	}
+}
+
 func TestRunHelpDescribesStandaloneScriptUpload(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	err := (App{Stdout: &stdout, Stderr: &stderr}).Run(context.Background(), []string{"run", "--help"})

--- a/internal/cli/cache.go
+++ b/internal/cli/cache.go
@@ -173,6 +173,9 @@ func (a App) cacheTarget(ctx context.Context, id string, reclaim bool) (SSHTarge
 	if err != nil {
 		return SSHTarget{}, Config{}, "", err
 	}
+	if err := autoRouteClaimLeaseProviderForIdentifier(&cfg, id); err != nil {
+		return SSHTarget{}, Config{}, "", err
+	}
 	repo, err := findRepo()
 	if err != nil {
 		return SSHTarget{}, Config{}, "", err

--- a/internal/cli/cache_test.go
+++ b/internal/cli/cache_test.go
@@ -2,8 +2,11 @@ package cli
 
 import (
 	"bytes"
+	"context"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestParseCacheStats(t *testing.T) {
@@ -16,6 +19,30 @@ func TestParseCacheStats(t *testing.T) {
 	}
 	if entries[1].Kind != "docker" || entries[1].Note == "" {
 		t.Fatalf("docker entry=%#v", entries[1])
+	}
+}
+
+func TestCacheTargetRoutesOrdinaryLeaseClaim(t *testing.T) {
+	clearConfigEnv(t)
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+	repo, err := findRepo()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := claimLeaseForRepoProvider("cbx_1335_cache01", "Cache Claimed", "run-prepare-test", repo.Root, time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	runPrepareTestResolveRequests = nil
+	_, cfg, _, err := (App{}).cacheTarget(context.Background(), "cache-claimed", false)
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 9 || !strings.Contains(exitErr.Message, "resolve captured") {
+		t.Fatalf("cacheTarget error=%v", err)
+	}
+	if cfg.Provider != "run-prepare-test" || cfg.providerSelectionSource != providerSelectionLeaseContext || !providerSelectionIsActionable(cfg) {
+		t.Fatalf("provider=%q source=%q", cfg.Provider, cfg.providerSelectionSource)
+	}
+	if len(runPrepareTestResolveRequests) != 1 || runPrepareTestResolveRequests[0].ID != "cache-claimed" {
+		t.Fatalf("resolve requests=%#v", runPrepareTestResolveRequests)
 	}
 }
 

--- a/internal/cli/checkpoint.go
+++ b/internal/cli/checkpoint.go
@@ -433,7 +433,7 @@ func parallelsSnapshotCheckpointView(source string, snapshot ParallelsSnapshot) 
 }
 
 func applyParallelsCheckpointHostConfig(cfg *Config, record checkpointRecord) {
-	cfg.Provider = "parallels"
+	setProviderSelection(cfg, "parallels", providerSelectionRecordedRun)
 	applyParallelsHostRefConfig(cfg, record.Native.Region)
 }
 
@@ -937,11 +937,8 @@ func validateCheckpointForkWorkdirs(ctx context.Context, backend Backend, lease 
 }
 
 func (a App) checkpointForkParallelsSnapshot(ctx context.Context, fs *flag.FlagSet, leaseFlags leaseCreateFlagValues, source, snapshot string, keep, reclaim bool, requestedSlug string, count int, dryRun bool, runArgs []string) (err error) {
-	cfg, err := loadConfig()
+	cfg, err := loadCheckpointForkParallelsConfig(fs, leaseFlags)
 	if err != nil {
-		return err
-	}
-	if err := applyLeaseCreateFlags(&cfg, fs, leaseFlags); err != nil {
 		return err
 	}
 	if cfg.Provider != "parallels" {
@@ -1010,6 +1007,18 @@ func (a App) checkpointForkParallelsSnapshot(ctx context.Context, fs *flag.FlagS
 		}
 	}
 	return nil
+}
+
+func loadCheckpointForkParallelsConfig(fs *flag.FlagSet, leaseFlags leaseCreateFlagValues) (Config, error) {
+	cfg, err := loadConfig()
+	if err != nil {
+		return Config{}, err
+	}
+	setProviderSelection(&cfg, "parallels", providerSelectionFlag)
+	if err := applyLeaseCreateFlags(&cfg, fs, leaseFlags); err != nil {
+		return Config{}, err
+	}
+	return cfg, nil
 }
 
 func (a App) checkpointForkParallelsSnapshotOnce(ctx context.Context, cfg Config, sshBackend SSHLeaseBackend, repo Repo, source, snapshot string, keep, reclaim bool, requestedSlug string, runOpts checkpointForkRunOptions) (err error) {

--- a/internal/cli/checkpoint_native.go
+++ b/internal/cli/checkpoint_native.go
@@ -552,7 +552,7 @@ func directAWSCheckpointConfig(record checkpointRecord) (Config, bool) {
 	if err != nil {
 		return Config{}, false
 	}
-	cfg.Provider = "aws"
+	setProviderSelection(&cfg, "aws", providerSelectionRecordedRun)
 	if record.Native.Region != "" {
 		cfg.AWSRegion = record.Native.Region
 	}
@@ -567,7 +567,7 @@ func directAzureCheckpointConfig(record checkpointRecord) (Config, bool) {
 	if err != nil {
 		return Config{}, false
 	}
-	cfg.Provider = "azure"
+	setProviderSelection(&cfg, "azure", providerSelectionRecordedRun)
 	if record.Native.Region != "" {
 		cfg.AzureLocation = record.Native.Region
 	}
@@ -689,7 +689,11 @@ func coordinatorStatusCode(err error) int {
 }
 
 func applyNativeCheckpointForkConfig(cfg *Config, fs *flag.FlagSet, record checkpointRecord) error {
-	cfg.Provider = record.nativeProvider()
+	providerSource := providerSelectionRecordedRun
+	if flagWasSet(fs, "provider") {
+		providerSource = providerSelectionFlag
+	}
+	setProviderSelection(cfg, record.nativeProvider(), providerSource)
 	if record.Native.Direct {
 		cfg.Coordinator = ""
 		cfg.CoordToken = ""

--- a/internal/cli/checkpoint_test.go
+++ b/internal/cli/checkpoint_test.go
@@ -310,6 +310,26 @@ func TestCheckpointForkDryRunDoesNotAcquireLease(t *testing.T) {
 	}
 }
 
+func TestCheckpointForkParallelsTemplateDryRunConfigMarksProviderIntent(t *testing.T) {
+	clearConfigEnv(t)
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+	defaults := defaultConfig()
+	fs := newFlagSet("checkpoint fork parallels dry run", io.Discard)
+	leaseFlags := registerLeaseCreateFlags(fs, defaults)
+	_ = fs.String("parallels-template", "", "")
+	if err := parseFlags(fs, []string{"--parallels-template", "win"}); err != nil {
+		t.Fatal(err)
+	}
+	*leaseFlags.Provider = "parallels"
+	cfg, err := loadCheckpointForkParallelsConfig(fs, leaseFlags)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Provider != "parallels" || cfg.providerSelectionSource != providerSelectionFlag || !providerSelectionIsActionable(cfg) {
+		t.Fatalf("provider=%q source=%q", cfg.Provider, cfg.providerSelectionSource)
+	}
+}
+
 func TestCheckpointForkDryRunFansOutRequestedSlug(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
@@ -968,6 +988,9 @@ func TestDirectAWSCheckpointConfigUsesDirectMarker(t *testing.T) {
 	}
 	if cfg.AWSRegion != "eu-west-1" {
 		t.Fatalf("AWSRegion=%q, want record region", cfg.AWSRegion)
+	}
+	if cfg.providerSelectionSource != providerSelectionRecordedRun {
+		t.Fatalf("provider source=%q want %q", cfg.providerSelectionSource, providerSelectionRecordedRun)
 	}
 
 	if err := os.WriteFile(cfgPath, []byte("provider: aws\ncoordinator: https://coordinator.example\naws:\n  region: us-east-1\n"), 0o600); err != nil {
@@ -1714,6 +1737,9 @@ func TestApplyAWSMacOSCheckpointForkConfigPreservesTypeWithoutHostPin(t *testing
 
 	if cfg.Provider != "aws" || cfg.TargetOS != targetMacOS || cfg.AWSSnapshot != "snap-000000000001" {
 		t.Fatalf("aws macOS snapshot config not applied: %#v", cfg)
+	}
+	if cfg.providerSelectionSource != providerSelectionRecordedRun {
+		t.Fatalf("provider source=%q want %q", cfg.providerSelectionSource, providerSelectionRecordedRun)
 	}
 	if cfg.HostID != "" || cfg.AWSMacHostID != "" {
 		t.Fatalf("host pin carried into fork: hostID=%q awsMacHostID=%q", cfg.HostID, cfg.AWSMacHostID)

--- a/internal/cli/claim_routing_commands_test.go
+++ b/internal/cli/claim_routing_commands_test.go
@@ -61,6 +61,15 @@ type claimRoutingStatusBackend struct {
 }
 
 func (b claimRoutingStatusBackend) Spec() ProviderSpec { return b.spec }
+func (b claimRoutingStatusBackend) Warmup(context.Context, WarmupRequest) error {
+	return nil
+}
+func (b claimRoutingStatusBackend) Run(context.Context, RunRequest) (RunResult, error) {
+	return RunResult{}, nil
+}
+func (b claimRoutingStatusBackend) List(context.Context, ListRequest) ([]LeaseView, error) {
+	return nil, nil
+}
 func (b claimRoutingStatusBackend) Status(_ context.Context, req StatusRequest) (StatusView, error) {
 	return StatusView{
 		ID:       req.ID,
@@ -69,6 +78,9 @@ func (b claimRoutingStatusBackend) Status(_ context.Context, req StatusRequest) 
 		State:    "ready",
 		Ready:    true,
 	}, nil
+}
+func (b claimRoutingStatusBackend) Stop(context.Context, StopRequest) error {
+	return errors.New("stop provider=" + b.spec.Name)
 }
 
 func TestStatusAndInspectRouteImplicitIdentifiersThroughLocalClaims(t *testing.T) {
@@ -157,6 +169,30 @@ func TestStatusAndInspectRouteImplicitIdentifiersThroughLocalClaims(t *testing.T
 	}
 }
 
+func TestStopRoutesImplicitIdentifiersThroughLocalClaims(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		leaseID    string
+		slug       string
+		identifier string
+	}{
+		{name: "exact lease id", leaseID: "cbx_1293aa000011", slug: "stop-exact", identifier: "cbx_1293aa000011"},
+		{name: "unambiguous slug", leaseID: "cbx_1293aa000012", slug: "Stop Slug", identifier: "stop-slug"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			setupClaimRoutingCommandTest(t, claimRoutingUnusableProvider)
+			mustWriteClaimRoutingTestClaim(t, tt.leaseID, tt.slug, claimRoutingUsableProvider)
+
+			_, err := runClaimRoutingCommand(func(app App, ctx context.Context, args []string) error {
+				return app.stop(ctx, args)
+			}, []string{"--id", tt.identifier})
+			if err == nil || !strings.Contains(err.Error(), "stop provider="+claimRoutingUsableProvider) {
+				t.Fatalf("stop error=%v, want claim-routed provider", err)
+			}
+		})
+	}
+}
+
 func TestLoadLeaseTargetConfigKeepsProviderResourceIdentifiersOnConfiguredProvider(t *testing.T) {
 	setupClaimRoutingCommandTest(t, claimRoutingConfiguredProvider)
 	mustWriteClaimRoutingTestClaim(t, "cbx_1293aa000009", "native-vm-name", claimRoutingUsableProvider)
@@ -182,7 +218,7 @@ func TestLoadLeaseTargetConfigKeepsProviderResourceIdentifiersOnConfiguredProvid
 	}
 }
 
-func TestLoadLeaseTargetConfigClaimRoutingPreservesProviderProvenance(t *testing.T) {
+func TestLoadLeaseTargetConfigClaimRoutingSetsLeaseContextProvenance(t *testing.T) {
 	setupClaimRoutingCommandTest(t, claimRoutingConfiguredProvider)
 	mustWriteClaimRoutingTestClaim(t, "cbx_1293aa000010", "provenance-claim", claimRoutingUsableProvider)
 	defaults := defaultConfig()
@@ -199,8 +235,8 @@ func TestLoadLeaseTargetConfigClaimRoutingPreservesProviderProvenance(t *testing
 	if cfg.Provider != claimRoutingUsableProvider {
 		t.Fatalf("provider=%q want claim provider %q", cfg.Provider, claimRoutingUsableProvider)
 	}
-	if cfg.providerSelectionSource != defaults.providerSelectionSource {
-		t.Fatalf("provider source=%q want unchanged provenance %q", cfg.providerSelectionSource, defaults.providerSelectionSource)
+	if cfg.providerSelectionSource != providerSelectionLeaseContext {
+		t.Fatalf("provider source=%q want %q", cfg.providerSelectionSource, providerSelectionLeaseContext)
 	}
 }
 

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -259,6 +259,8 @@ type Config struct {
 
 type providerSelectionSource string
 
+const providerSelectionRequiredDiagnostic = "no provider selected; use --provider <name>, set CRABBOX_PROVIDER, or configure a provider; run 'crabbox providers recommend' to compare options"
+
 const (
 	providerSelectionCompiledDefault providerSelectionSource = "compiled_default"
 	providerSelectionUserConfig      providerSelectionSource = "user_config"
@@ -272,6 +274,32 @@ const (
 func setProviderSelection(cfg *Config, provider string, source providerSelectionSource) {
 	cfg.Provider = provider
 	cfg.providerSelectionSource = source
+}
+
+func providerSelectionIsActionable(cfg Config) bool {
+	if strings.TrimSpace(cfg.Provider) == "" {
+		return false
+	}
+	switch cfg.providerSelectionSource {
+	case providerSelectionUserConfig,
+		providerSelectionRepoConfig,
+		providerSelectionEnvironment,
+		providerSelectionFlag,
+		providerSelectionRecordedRun,
+		providerSelectionLeaseContext:
+		return true
+	default:
+		return false
+	}
+}
+
+func providerSelectionIsAuthoritativeRoute(cfg Config) bool {
+	switch cfg.providerSelectionSource {
+	case providerSelectionRecordedRun, providerSelectionLeaseContext:
+		return true
+	default:
+		return false
+	}
 }
 
 func providerSelectionSourceForConfigPath(trust configPathTrust) providerSelectionSource {

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -56,7 +56,11 @@ func (a App) configShow(args []string) error {
 			return err
 		}
 		view := configShowView(cfg)
-		view["provider"] = provider
+		if providerSelectionIsActionable(cfg) {
+			view["provider"] = provider
+		} else {
+			view["provider"] = ""
+		}
 		view["providerScope"] = providerScope
 		view["idempotentLeaseId"] = fixedLeaseID
 		view["coordinatorRegistrationUrl"] = redactedConfigURL(coordinatorRegistrationURL)
@@ -142,16 +146,24 @@ func effectiveConfigForShow(cfg Config) Config {
 }
 
 func configShowView(cfg Config) map[string]any {
+	provider := cfg.Provider
+	serverType := cfg.ServerType
+	providerSelected := providerSelectionIsActionable(cfg)
+	if !providerSelected {
+		provider = ""
+		serverType = ""
+	}
 	return map[string]any{
 		"profile":                    cfg.Profile,
-		"provider":                   cfg.Provider,
+		"provider":                   provider,
+		"providerSelected":           providerSelected,
 		"providerSource":             cfg.providerSelectionSource,
 		"target":                     cfg.TargetOS,
 		"architecture":               effectiveArchitectureForConfig(cfg),
 		"os":                         cfg.OSImage,
 		"windowsMode":                cfg.WindowsMode,
 		"class":                      cfg.Class,
-		"serverType":                 cfg.ServerType,
+		"serverType":                 serverType,
 		"serverTypeExplicit":         cfg.ServerTypeExplicit,
 		"coordinator":                redactedConfigURL(cfg.Coordinator),
 		"brokerMode":                 cfg.BrokerMode,
@@ -754,7 +766,14 @@ func redactedParallelsHostConfigs(hosts []ParallelsHostConfig) []ParallelsHostCo
 
 func writeConfigShowText(w io.Writer, cfg Config) {
 	fmt.Fprintf(w, "config=%s\n", userConfigPath())
-	fmt.Fprintf(w, "provider=%s provider_source=%s target=%s arch=%s os=%s windows_mode=%s class=%s type=%s profile=%s\n", cfg.Provider, cfg.providerSelectionSource, cfg.TargetOS, effectiveArchitectureForConfig(cfg), cfg.OSImage, cfg.WindowsMode, cfg.Class, cfg.ServerType, cfg.Profile)
+	provider := cfg.Provider
+	serverType := cfg.ServerType
+	providerSelected := providerSelectionIsActionable(cfg)
+	if !providerSelected {
+		provider = ""
+		serverType = ""
+	}
+	fmt.Fprintf(w, "provider=%s provider_selected=%t provider_source=%s target=%s arch=%s os=%s windows_mode=%s class=%s type=%s profile=%s\n", provider, providerSelected, cfg.providerSelectionSource, cfg.TargetOS, effectiveArchitectureForConfig(cfg), cfg.OSImage, cfg.WindowsMode, cfg.Class, serverType, cfg.Profile)
 	fmt.Fprintf(w, "broker=%s mode=%s auto_webvnc=%t login_redirect_origins=%s auth=%s admin_auth=%s\n", blank(redactedConfigURL(cfg.Coordinator), "-"), cfg.BrokerMode, cfg.BrokerAutoWebVNC, blank(strings.Join(cfg.BrokerLoginRedirectOrigins, ","), "-"), coordinatorTokenState(cfg), tokenState(cfg.CoordAdminToken))
 	fmt.Fprintf(w, "access_auth=%s\n", accessAuthState(cfg.Access))
 	fmt.Fprintf(w, "ssh=%s@<host>:%s fallback_ports=%s key=%s\n", cfg.SSHUser, cfg.SSHPort, blank(strings.Join(cfg.SSHFallbackPorts, ","), "-"), cfg.SSHKey)

--- a/internal/cli/config_cmd_test.go
+++ b/internal/cli/config_cmd_test.go
@@ -18,8 +18,29 @@ func TestConfigShowReportsProviderSelectionSource(t *testing.T) {
 		if err := (App{Stdout: &stdout, Stderr: &stderr}).configShow(nil); err != nil {
 			t.Fatalf("config show error=%v stderr=%q", err, stderr.String())
 		}
-		if !strings.Contains(stdout.String(), "provider=hetzner provider_source=compiled_default") {
+		if !strings.Contains(stdout.String(), "provider= provider_selected=false provider_source=compiled_default") {
 			t.Fatalf("config show missing compiled-default provenance:\n%s", stdout.String())
+		}
+		if !strings.Contains(stdout.String(), " class=beast type= profile=default") {
+			t.Fatalf("config show exposed a provider-specific effective machine type:\n%s", stdout.String())
+		}
+		if strings.Contains(stdout.String(), "provider=hetzner") {
+			t.Fatalf("config show presented compiled metadata as selected:\n%s", stdout.String())
+		}
+	})
+
+	t.Run("compiled default json", func(t *testing.T) {
+		isolateDoctorProviderSelectionTest(t)
+		var stdout, stderr bytes.Buffer
+		if err := (App{Stdout: &stdout, Stderr: &stderr}).configShow([]string{"--json"}); err != nil {
+			t.Fatalf("config show error=%v stderr=%q", err, stderr.String())
+		}
+		var view map[string]any
+		if err := json.Unmarshal(stdout.Bytes(), &view); err != nil {
+			t.Fatalf("config show JSON invalid: %v\n%s", err, stdout.String())
+		}
+		if view["provider"] != "" || view["providerSource"] != "compiled_default" || view["providerSelected"] != false || view["serverType"] != "" {
+			t.Fatalf("config show provider selection=%#v", view)
 		}
 	})
 
@@ -33,7 +54,7 @@ func TestConfigShowReportsProviderSelectionSource(t *testing.T) {
 		if err := json.Unmarshal(stdout.Bytes(), &view); err != nil {
 			t.Fatalf("config show JSON invalid: %v\n%s", err, stdout.String())
 		}
-		if view["provider"] != "hetzner" || view["providerSource"] != "flag" {
+		if view["provider"] != "hetzner" || view["providerSource"] != "flag" || view["providerSelected"] != true || view["serverType"] == "" {
 			t.Fatalf("config show provider provenance=%#v", view)
 		}
 	})

--- a/internal/cli/controller_subprocess.go
+++ b/internal/cli/controller_subprocess.go
@@ -107,7 +107,7 @@ func loadControllerRunnerConfigState(configPath, provider, workDir string) (Conf
 	}
 	applyCloudflareDynamicWorkersRepositoryCaps(&cfg)
 	if provider = strings.TrimSpace(provider); provider != "" {
-		cfg.Provider = provider
+		setProviderSelection(&cfg, provider, providerSelectionFlag)
 		cfg.brokerProvider = ""
 	}
 	if err := normalizeBrokerConfig(&cfg); err != nil {

--- a/internal/cli/coordinator_test.go
+++ b/internal/cli/coordinator_test.go
@@ -2009,11 +2009,13 @@ func TestLeaseStatusRequiresSSHReadiness(t *testing.T) {
 	}))
 	defer server.Close()
 
-	state, err := (App{}).leaseStatus(context.Background(), Config{
+	cfg := Config{
 		Coordinator: server.URL,
 		Provider:    "aws",
 		SSHKey:      filepath.Join(t.TempDir(), "missing-key"),
-	}, "cbx_123")
+	}
+	setProviderSelection(&cfg, "aws", providerSelectionFlag)
+	state, err := (App{}).leaseStatus(context.Background(), cfg, "cbx_123")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/credential_provenance_test.go
+++ b/internal/cli/credential_provenance_test.go
@@ -622,6 +622,7 @@ func TestLoadBackendRejectsRepositoryCredentialDestination(t *testing.T) {
 			e2bAPIKey: credentialSourceEnvironment,
 		},
 	}
+	setProviderSelection(&cfg, "e2b", providerSelectionFlag)
 	if _, err := loadBackend(cfg, Runtime{}); err == nil || !strings.Contains(err.Error(), "e2b.apiUrl") {
 		t.Fatalf("loadBackend error=%v", err)
 	}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -127,7 +127,11 @@ func (a App) doctor(ctx context.Context, args []string) error {
 			record(status, "pond", message, details)
 		}
 		if *jsonOut {
-			if err := json.NewEncoder(a.Stdout).Encode(doctorJSONOutput{OK: ok, Provider: cfg.Provider, Checks: checks}); err != nil {
+			provider := cfg.Provider
+			if !providerSelectionIsActionable(cfg) {
+				provider = ""
+			}
+			if err := json.NewEncoder(a.Stdout).Encode(doctorJSONOutput{OK: ok, Provider: provider, Checks: checks}); err != nil {
 				return err
 			}
 		}
@@ -177,7 +181,7 @@ func (a App) doctor(ctx context.Context, args []string) error {
 	if err := prepareProviderSelection(&cfg, *provider); err != nil {
 		return err
 	}
-	if flagWasSet(fs, "provider") && cfg.providerSelectionSource != providerSelectionRecordedRun {
+	if flagWasSet(fs, "provider") {
 		cfg.providerSelectionSource = providerSelectionFlag
 	}
 	if err := applyTargetFlagOverrides(&cfg, fs, targetFlags); err != nil {
@@ -192,23 +196,37 @@ func (a App) doctor(ctx context.Context, args []string) error {
 	if err := finalizeProviderSelection(&cfg); err != nil {
 		return err
 	}
+	providerSelected := providerSelectionIsActionable(cfg)
 	var providerDef Provider
-	if resolvedDoctorID == "" {
-		providerDef, err = validateProviderTargetSupport(cfg)
-		if err != nil {
-			return err
-		}
-	} else {
-		providerDef, err = ProviderFor(cfg.Provider)
-		if err != nil {
-			return err
+	if providerSelected {
+		if resolvedDoctorID == "" {
+			providerDef, err = validateProviderTargetSupport(cfg)
+			if err != nil {
+				return err
+			}
+		} else {
+			providerDef, err = ProviderFor(cfg.Provider)
+			if err != nil {
+				return err
+			}
 		}
 	}
-	record("ok", "provider-selection", fmt.Sprintf("provider=%s source=%s", cfg.Provider, cfg.providerSelectionSource), map[string]string{
-		"provider": cfg.Provider,
-		"source":   string(cfg.providerSelectionSource),
-	})
-	for _, tool := range doctorLocalTools(providerDef.Spec()) {
+	providerSpec := ProviderSpec{}
+	if providerSelected {
+		providerSpec = providerDef.Spec()
+		record("ok", "provider-selection", fmt.Sprintf("provider=%s source=%s selected=true", cfg.Provider, cfg.providerSelectionSource), map[string]string{
+			"provider": cfg.Provider,
+			"source":   string(cfg.providerSelectionSource),
+			"selected": "true",
+		})
+	} else {
+		record("ok", "provider-selection", fmt.Sprintf("no provider selected source=%s selected=false", cfg.providerSelectionSource), map[string]string{
+			"provider": "",
+			"source":   string(cfg.providerSelectionSource),
+			"selected": "false",
+		})
+	}
+	for _, tool := range doctorLocalTools(providerSpec) {
 		path, err := exec.LookPath(tool)
 		if err != nil {
 			record("missing", tool, "", map[string]string{"tool": tool})
@@ -244,7 +262,11 @@ func (a App) doctor(ctx context.Context, args []string) error {
 					record("failed", "remote", fmt.Sprintf("%s\n%s", resolvedDoctorID, strings.TrimSpace(out)), map[string]string{"id": resolvedDoctorID})
 				}
 				if *jsonOut {
-					_ = json.NewEncoder(a.Stdout).Encode(doctorJSONOutput{OK: false, Provider: cfg.Provider, Checks: checks})
+					provider := cfg.Provider
+					if !providerSelected {
+						provider = ""
+					}
+					_ = json.NewEncoder(a.Stdout).Encode(doctorJSONOutput{OK: false, Provider: provider, Checks: checks})
 				}
 				return exit(7, "remote doctor failed for %s: %v", resolvedDoctorID, err)
 			}
@@ -254,11 +276,15 @@ func (a App) doctor(ctx context.Context, args []string) error {
 	if os.Getenv("CRABBOX_SERVER_TYPE") == "" {
 		applyServerTypeFlagOverrides(&cfg, fs, "")
 	}
-	if largeDefaultServerType(cfg) {
+	if providerSelected && largeDefaultServerType(cfg) {
 		record("warning", "capacity", fmt.Sprintf("provider=%s class=%s type=%s large_default=true hint=set class/type in .crabbox.yaml for routine tests", cfg.Provider, cfg.Class, cfg.ServerType), map[string]string{"provider": cfg.Provider, "class": cfg.Class, "type": cfg.ServerType, "large_default": "true"})
 	}
 	useCoordinator := false
-	if shouldUseCoordinator(cfg, providerDef.Spec()) {
+	useCoordinatorForDoctor := cfg.BrokerMode != BrokerModeRegistered && strings.TrimSpace(cfg.Coordinator) != ""
+	if providerSelected {
+		useCoordinatorForDoctor = shouldUseCoordinator(cfg, providerDef.Spec())
+	}
+	if useCoordinatorForDoctor {
 		if coord, coordinatorConfigured, err := newTargetCoordinatorClient(cfg); err != nil {
 			record("failed", "coord", err.Error(), nil)
 			ok = false
@@ -298,7 +324,7 @@ func (a App) doctor(ctx context.Context, args []string) error {
 					}
 					record("ok", "broker", doctorBrokerOKMessage(whoami, cfg.ServerType), details)
 				}
-				if brokerOK && cfg.providerSelectionSource != providerSelectionCompiledDefault && coordinatorProviderReadinessSupported(cfg.Provider) {
+				if brokerOK && providerSelected && coordinatorProviderReadinessSupported(cfg.Provider) {
 					readiness, err := coord.ProviderReadiness(ctx, cfg)
 					if err == nil {
 						if readiness.Configured {
@@ -321,7 +347,7 @@ func (a App) doctor(ctx context.Context, args []string) error {
 						ok = false
 					}
 				}
-				if cfg.CoordAdminToken != "" {
+				if providerSelected && cfg.CoordAdminToken != "" {
 					adminCfg := cfg
 					adminCfg.CoordToken = cfg.CoordAdminToken
 					adminCfg.CoordTokenCommand = nil
@@ -357,10 +383,11 @@ func (a App) doctor(ctx context.Context, args []string) error {
 	} else {
 		record("ok", "ssh-key", "per-lease", map[string]string{"mode": "per-lease"})
 	}
-	if cfg.providerSelectionSource == providerSelectionCompiledDefault {
-		record("warning", "provider", fmt.Sprintf("provider=%s source=%s readiness=skipped hint=select_provider_with_flag_env_or_config", cfg.Provider, cfg.providerSelectionSource), map[string]string{
-			"provider":  cfg.Provider,
+	if !providerSelected {
+		record("warning", "provider", fmt.Sprintf("no provider selected source=%s selected=false readiness=skipped hint=select_provider_with_flag_env_or_config", cfg.providerSelectionSource), map[string]string{
+			"provider":  "",
 			"source":    string(cfg.providerSelectionSource),
+			"selected":  "false",
 			"readiness": "skipped",
 			"hint":      "select_provider_with_flag_env_or_config",
 		})

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -145,7 +145,8 @@ func TestDoctorProviderSelectionProvenanceAndStrictness(t *testing.T) {
 				if err != nil {
 					t.Fatalf("doctor error=%v stdout=%q stderr=%q", err, stdout.String(), stderr.String())
 				}
-				if !strings.Contains(stdout.String(), "warning provider provider=hetzner source=compiled_default readiness=skipped") {
+				if !strings.Contains(stdout.String(), "provider-selection no provider selected source=compiled_default selected=false") ||
+					!strings.Contains(stdout.String(), "warning provider no provider selected source=compiled_default selected=false readiness=skipped") {
 					t.Fatalf("doctor did not skip compiled-default readiness:\n%s", stdout.String())
 				}
 			} else {
@@ -157,7 +158,10 @@ func TestDoctorProviderSelectionProvenanceAndStrictness(t *testing.T) {
 					t.Fatalf("doctor did not preserve strict provider readiness:\n%s", stdout.String())
 				}
 			}
-			wantSelection := "provider-selection provider=hetzner source=" + string(tt.wantSource)
+			wantSelection := "provider-selection provider=hetzner source=" + string(tt.wantSource) + " selected=true"
+			if tt.wantSource == providerSelectionCompiledDefault {
+				wantSelection = "provider-selection no provider selected source=compiled_default selected=false"
+			}
 			if !strings.Contains(stdout.String(), wantSelection) {
 				t.Fatalf("doctor selection provenance missing %q:\n%s", wantSelection, stdout.String())
 			}
@@ -192,7 +196,7 @@ func TestDoctorCompiledDefaultSkipsCoordinatorProviderReadiness(t *testing.T) {
 	if readinessCalled {
 		t.Fatal("doctor called coordinator readiness for the compiled default")
 	}
-	for _, want := range []string{"ok      coord", "ok      broker", "warning provider provider=hetzner source=compiled_default readiness=skipped"} {
+	for _, want := range []string{"ok      coord", "ok      broker", "warning provider no provider selected source=compiled_default selected=false readiness=skipped"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("doctor output missing %q:\n%s", want, stdout.String())
 		}
@@ -209,17 +213,38 @@ func TestDoctorCompiledDefaultJSONReportsSkippedReadiness(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &view); err != nil {
 		t.Fatalf("doctor JSON invalid: %v\n%s", err, stdout.String())
 	}
-	if !view.OK || view.Provider != "hetzner" {
+	if !view.OK || view.Provider != "" {
 		t.Fatalf("doctor view=%#v", view)
 	}
 	var selection, readiness bool
 	for _, check := range view.Checks {
-		selection = selection || (check.Check == "provider-selection" && check.Details["source"] == "compiled_default")
-		readiness = readiness || (check.Check == "provider" && check.Status == "warning" && check.Details["readiness"] == "skipped")
+		selection = selection || (check.Check == "provider-selection" && check.Details["provider"] == "" && check.Details["source"] == "compiled_default" && check.Details["selected"] == "false")
+		readiness = readiness || (check.Check == "provider" && check.Status == "warning" && check.Details["provider"] == "" && check.Details["selected"] == "false" && check.Details["readiness"] == "skipped")
 	}
 	if !selection || !readiness {
 		t.Fatalf("doctor JSON missing provenance or skip: %#v", view.Checks)
 	}
+}
+
+func TestDoctorExplicitProviderJSONReportsSelected(t *testing.T) {
+	isolateDoctorProviderSelectionTest(t)
+	var stdout, stderr bytes.Buffer
+	if err := (App{Stdout: &stdout, Stderr: &stderr}).doctor(context.Background(), []string{"--provider", "ssh", "--json"}); err != nil {
+		t.Fatalf("doctor error=%v stdout=%q stderr=%q", err, stdout.String(), stderr.String())
+	}
+	var view doctorJSONOutput
+	if err := json.Unmarshal(stdout.Bytes(), &view); err != nil {
+		t.Fatalf("doctor JSON invalid: %v\n%s", err, stdout.String())
+	}
+	if !view.OK || view.Provider != "ssh" {
+		t.Fatalf("doctor view=%#v", view)
+	}
+	for _, check := range view.Checks {
+		if check.Check == "provider-selection" && check.Details["provider"] == "ssh" && check.Details["source"] == "flag" && check.Details["selected"] == "true" {
+			return
+		}
+	}
+	t.Fatalf("doctor JSON missing selected provider provenance: %#v", view.Checks)
 }
 
 func TestDoctorConfiguredProviderKeepsCoordinatorReadinessStrict(t *testing.T) {
@@ -259,9 +284,9 @@ func TestDoctorConfiguredProviderKeepsCoordinatorReadinessStrict(t *testing.T) {
 	}
 }
 
-func TestDoctorCompiledDefaultStillFailsOtherReadinessChecks(t *testing.T) {
+func TestDoctorCompiledDefaultStillFailsProviderNeutralReadinessChecks(t *testing.T) {
 	isolateDoctorProviderSelectionTest(t)
-	t.Setenv("PATH", doctorTestToolPath(t, []string{"git"}))
+	t.Setenv("PATH", doctorTestToolPath(t, nil))
 
 	var stdout, stderr bytes.Buffer
 	err := (App{Stdout: &stdout, Stderr: &stderr}).doctor(context.Background(), nil)
@@ -269,7 +294,7 @@ func TestDoctorCompiledDefaultStillFailsOtherReadinessChecks(t *testing.T) {
 	if !AsExitError(err, &exitErr) || exitErr.Code != 1 {
 		t.Fatalf("doctor error=%v, want exit 1; stdout=%q stderr=%q", err, stdout.String(), stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "missing ssh") || !strings.Contains(stdout.String(), "readiness=skipped") {
+	if !strings.Contains(stdout.String(), "missing git") || !strings.Contains(stdout.String(), "readiness=skipped") || strings.Contains(stdout.String(), "missing ssh") {
 		t.Fatalf("doctor did not preserve non-provider failures:\n%s", stdout.String())
 	}
 }

--- a/internal/cli/lease_flags.go
+++ b/internal/cli/lease_flags.go
@@ -92,12 +92,16 @@ func autoRouteClaimLeaseProvider(cfg *Config, fs *flag.FlagSet, identifier strin
 	if flagWasSet(fs, "provider") {
 		return nil
 	}
+	return autoRouteClaimLeaseProviderForIdentifier(cfg, identifier)
+}
+
+func autoRouteClaimLeaseProviderForIdentifier(cfg *Config, identifier string) error {
 	provider, ok, err := claimProviderForIdentifier(identifier)
 	if err != nil {
 		return err
 	}
 	if ok {
-		cfg.Provider = provider
+		setProviderSelection(cfg, provider, providerSelectionLeaseContext)
 	}
 	return nil
 }
@@ -418,7 +422,11 @@ func loadLeaseTargetConfig(fs *flag.FlagSet, provider string, targetFlags target
 	if err != nil {
 		return Config{}, err
 	}
-	cfg.Provider = provider
+	if flagWasSet(fs, "provider") {
+		setProviderSelection(&cfg, provider, providerSelectionFlag)
+	} else {
+		cfg.Provider = provider
+	}
 	prepareProviderDefaults(&cfg)
 	if opts.Desktop {
 		cfg.Desktop = true

--- a/internal/cli/pause.go
+++ b/internal/cli/pause.go
@@ -35,6 +35,12 @@ func (a App) pauseResume(ctx context.Context, args []string, action string) erro
 	if err := prepareProviderSelection(&cfg, *provider); err != nil {
 		return err
 	}
+	if err := autoRouteClaimLeaseProvider(&cfg, fs, *id); err != nil {
+		return err
+	}
+	if err := autoRouteStaticLease(&cfg, fs, *id); err != nil {
+		return err
+	}
 	if err := autoRouteExternalLease(&cfg, fs, *id); err != nil {
 		return err
 	}

--- a/internal/cli/pause_test.go
+++ b/internal/cli/pause_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestPauseResumeCommandsDispatchToPausableBackend(t *testing.T) {
@@ -28,6 +30,38 @@ func TestPauseResumeCommandsDispatchToPausableBackend(t *testing.T) {
 	if got := stderr.String(); !strings.Contains(got, "resumed id=isb_crabbox-repo-abcdef") {
 		t.Fatalf("resume stderr=%q", got)
 	}
+}
+
+func TestPauseResumeCommandsRouteOrdinaryClaims(t *testing.T) {
+	t.Run("claim provider without ambient config", func(t *testing.T) {
+		clearConfigEnv(t)
+		t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+		if err := claimLeaseForRepoProvider("isb_1335_pause", "Pause Claimed", "islo", "/repo", time.Minute, false); err != nil {
+			t.Fatal(err)
+		}
+		var stderr bytes.Buffer
+		if err := (App{Stdout: io.Discard, Stderr: &stderr}).pause(context.Background(), []string{"pause-claimed"}); err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(stderr.String(), "paused id=pause-claimed") {
+			t.Fatalf("stderr=%q", stderr.String())
+		}
+	})
+
+	t.Run("explicit provider wins", func(t *testing.T) {
+		clearConfigEnv(t)
+		t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+		if err := claimLeaseForRepoProvider("isb_1335_resume", "Resume Claimed", "e2b", "/repo", time.Minute, false); err != nil {
+			t.Fatal(err)
+		}
+		var stderr bytes.Buffer
+		if err := (App{Stdout: io.Discard, Stderr: &stderr}).resume(context.Background(), []string{"--provider", "islo", "resume-claimed"}); err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(stderr.String(), "resumed id=resume-claimed") {
+			t.Fatalf("stderr=%q", stderr.String())
+		}
+	})
 }
 
 func TestPauseResumeCommandsRejectAmbiguousIdentifiers(t *testing.T) {

--- a/internal/cli/pond_bridge.go
+++ b/internal/cli/pond_bridge.go
@@ -191,7 +191,7 @@ func (a App) pondRelease(ctx context.Context, args []string) error {
 			fmt.Fprintf(a.Stderr, "warning: skip %s/%s: load config: %v\n", claim.Provider, claim.LeaseID, cerr)
 			continue
 		}
-		cfg.Provider = canonicalClaimProvider(claim.Provider)
+		setProviderSelection(&cfg, canonicalClaimProvider(claim.Provider), providerSelectionLeaseContext)
 		var routeErr error
 		if canonicalClaimProvider(claim.Provider) == "external" {
 			routeErr = routeExternalLeaseClaim(&cfg, claim.LeaseID)

--- a/internal/cli/pond_mesh.go
+++ b/internal/cli/pond_mesh.go
@@ -588,7 +588,7 @@ func collectPondMembersAcrossProviders(ctx context.Context, rt Runtime, cfg Conf
 			continue
 		}
 		providerCfg := cfg
-		providerCfg.Provider = p
+		setProviderSelection(&providerCfg, p, providerSelectionLeaseContext)
 		backend, berr := loadBackend(providerCfg, rt)
 		if berr != nil {
 			return nil, nil, fmt.Errorf("load backend for provider %s: %w", p, berr)

--- a/internal/cli/ports.go
+++ b/internal/cli/ports.go
@@ -85,6 +85,9 @@ func loadPortsConfig(fs *flag.FlagSet, provider string, providerFlags providerFl
 	if err := applyTargetFlagOverrides(&cfg, fs, targetFlags); err != nil {
 		return Config{}, err
 	}
+	if err := autoRouteClaimLeaseProvider(&cfg, fs, id); err != nil {
+		return Config{}, err
+	}
 	if err := autoRouteStaticLease(&cfg, fs, id); err != nil {
 		return Config{}, err
 	}

--- a/internal/cli/ports_cp_test.go
+++ b/internal/cli/ports_cp_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"io"
 	"strings"
 	"testing"
 )
@@ -44,6 +45,53 @@ func TestPortsCommand(t *testing.T) {
 	if !strings.Contains(stderr.String(), "Usage") {
 		t.Fatalf("ports help=%q", stderr.String())
 	}
+}
+
+func TestLoadPortsConfigRoutesOrdinaryClaims(t *testing.T) {
+	load := func(t *testing.T, identifier string, args ...string) Config {
+		t.Helper()
+		defaults := defaultConfig()
+		fs := newFlagSet("ports claim routing", io.Discard)
+		provider := fs.String("provider", defaults.Provider, "")
+		providerFlags := registerProviderFlags(fs, defaults)
+		targetFlags := registerTargetFlags(fs, defaults)
+		if err := parseFlags(fs, args); err != nil {
+			t.Fatal(err)
+		}
+		cfg, err := loadPortsConfig(fs, *provider, providerFlags, targetFlags, identifier)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return cfg
+	}
+
+	for _, tt := range []struct {
+		name       string
+		leaseID    string
+		slug       string
+		identifier string
+	}{
+		{name: "exact id", leaseID: "cbx_1335aa000001", slug: "ports-exact", identifier: "cbx_1335aa000001"},
+		{name: "unambiguous slug", leaseID: "cbx_1335aa000002", slug: "Ports Slug", identifier: "ports-slug"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			setupClaimRoutingCommandTest(t, claimRoutingConfiguredProvider)
+			mustWriteClaimRoutingTestClaim(t, tt.leaseID, tt.slug, claimRoutingUsableProvider)
+			cfg := load(t, tt.identifier)
+			if cfg.Provider != claimRoutingUsableProvider || cfg.providerSelectionSource != providerSelectionLeaseContext {
+				t.Fatalf("provider=%q source=%q", cfg.Provider, cfg.providerSelectionSource)
+			}
+		})
+	}
+
+	t.Run("explicit provider wins", func(t *testing.T) {
+		setupClaimRoutingCommandTest(t, claimRoutingConfiguredProvider)
+		mustWriteClaimRoutingTestClaim(t, "cbx_1335aa000003", "ports-explicit", claimRoutingUsableProvider)
+		cfg := load(t, "ports-explicit", "--provider", claimRoutingExplicitProvider)
+		if cfg.Provider != claimRoutingExplicitProvider || cfg.providerSelectionSource != providerSelectionFlag {
+			t.Fatalf("provider=%q source=%q", cfg.Provider, cfg.providerSelectionSource)
+		}
+	})
 }
 
 func TestCopyCommand(t *testing.T) {

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -1106,7 +1106,7 @@ func normalizeProviderName(name string) string {
 }
 
 func providerHelpAll() string {
-	return "provider: " + strings.Join(providerNamesForHelp(nil), ", ")
+	return "provider: " + strings.Join(providerNamesForHelp(nil), ", ") + " (defaults to configured selection)"
 }
 
 func providerHelpEnvValues() string {
@@ -1127,13 +1127,13 @@ func joinProviderNames(names []string) string {
 func providerHelpSSH() string {
 	return "provider: " + strings.Join(providerNamesForHelp(func(spec ProviderSpec) bool {
 		return spec.Features.Has(FeatureSSH)
-	}), ", ")
+	}), ", ") + " (defaults to configured selection)"
 }
 
 func providerHelpCleanup() string {
 	return "provider: " + joinProviderNames(providerNamesForHelp(func(spec ProviderSpec) bool {
 		return spec.Features.Has(FeatureCleanup)
-	}))
+	})) + " (defaults to configured selection)"
 }
 
 func isBlacksmithProvider(provider string) bool {
@@ -1292,6 +1292,9 @@ func routeConfiguredProvider(cfg *Config) error {
 		return err
 	}
 	cfg.Provider = provider.Name()
+	if providerSelectionIsAuthoritativeRoute(*cfg) {
+		return nil
+	}
 	if router, ok := provider.(ProviderRouter); ok {
 		if err := router.RouteConfig(cfg, nil, nil); err != nil {
 			return err
@@ -1369,6 +1372,9 @@ func validateControllerCoordinatorRegistrationBinding(cfg Config) error {
 }
 
 func loadBackend(cfg Config, rt Runtime) (Backend, error) {
+	if !providerSelectionIsActionable(cfg) {
+		return nil, exit(2, "%s", providerSelectionRequiredDiagnostic)
+	}
 	if rt.Stdout == nil {
 		rt.Stdout = io.Discard
 	}

--- a/internal/cli/provider_backend_test.go
+++ b/internal/cli/provider_backend_test.go
@@ -26,12 +26,38 @@ func testRuntimeWithRunner(r CommandRunner) Runtime {
 	return Runtime{Stdout: io.Discard, Stderr: io.Discard, Clock: realClock{}, Exec: r}
 }
 
+func TestLoadBackendRequiresActionableProviderSelection(t *testing.T) {
+	t.Setenv(controllerProviderScopeEnv, "")
+	t.Setenv("HCLOUD_TOKEN", "")
+	t.Setenv("HETZNER_TOKEN", "")
+	cfg := baseConfig()
+
+	_, err := loadBackend(cfg, testRuntimeWithRunner(&recordingCommandRunner{}))
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 2 || exitErr.Message != providerSelectionRequiredDiagnostic {
+		t.Fatalf("compiled-default error=%v, want exit 2 %q", err, providerSelectionRequiredDiagnostic)
+	}
+	if strings.Contains(err.Error(), "HCLOUD_TOKEN") || strings.Contains(err.Error(), "HETZNER_TOKEN") {
+		t.Fatalf("compiled default reached provider credential validation: %v", err)
+	}
+
+	setProviderSelection(&cfg, claimRoutingUnusableProvider, providerSelectionFlag)
+	if _, err := loadBackend(cfg, testRuntimeWithRunner(&recordingCommandRunner{})); err == nil || !strings.Contains(err.Error(), "configured provider credentials are unavailable") {
+		t.Fatalf("actionable selection did not reach provider configuration: %v", err)
+	}
+
+	setProviderSelection(&cfg, "ssh", providerSelectionEnvironment)
+	if _, err := loadBackend(cfg, testRuntimeWithRunner(&recordingCommandRunner{})); err != nil {
+		t.Fatalf("actionable non-Hetzner selection rejected: %v", err)
+	}
+}
+
 func TestLoadBackendScrubsTrustedExternalDesktopPasswordFromNonExternalCommands(t *testing.T) {
 	t.Setenv(controllerProviderScopeEnv, "")
 	t.Setenv("TRUSTED_DESKTOP_PASSWORD", "ambient-secret")
 	t.Setenv("CRABBOX_TEST_CHILD_KEEP", "ambient-value")
 	cfg := baseConfig()
-	cfg.Provider = "aws"
+	setProviderSelection(&cfg, "aws", providerSelectionFlag)
 	cfg.Coordinator = "https://coordinator.example"
 	cfg.External.Connection.Desktop.PasswordEnv = "TRUSTED_DESKTOP_PASSWORD"
 	MarkExternalDesktopPasswordEnvExplicit(&cfg)
@@ -310,10 +336,74 @@ func TestProviderFlagsOverrideDynamicSessionsConfigWithoutLeaseCreate(t *testing
 	}
 }
 
+func TestRouteConfiguredProviderPreservesAuthoritativeProviderFamilyRoute(t *testing.T) {
+	for _, source := range []providerSelectionSource{providerSelectionLeaseContext, providerSelectionRecordedRun} {
+		t.Run(string(source), func(t *testing.T) {
+			defaults := baseConfig()
+			defaults.Provider = "azure"
+			defaults.AzureBackend = AzureBackendDynamicSessions
+			fs := newFlagSet("authoritative Azure flags", io.Discard)
+			values := registerProviderFlags(fs, defaults)
+			if err := parseFlags(fs, []string{"--azure-snapshot-sku", "premium_lrs"}); err != nil {
+				t.Fatal(err)
+			}
+			cfg := defaults
+			setProviderSelection(&cfg, "azure", source)
+			if !ProviderSelectionIsAuthoritativeRoute(cfg) {
+				t.Fatalf("source=%q not exposed as authoritative", source)
+			}
+			if err := routeConfiguredProvider(&cfg); err != nil {
+				t.Fatal(err)
+			}
+			if err := applyProviderFlags(&cfg, fs, values); err != nil {
+				t.Fatal(err)
+			}
+			if cfg.Provider != "azure" || cfg.providerSelectionSource != source {
+				t.Fatalf("provider=%q source=%q, want authoritative azure/%s", cfg.Provider, cfg.providerSelectionSource, source)
+			}
+			if cfg.AzureSnapshotSKU != "Premium_LRS" {
+				t.Fatalf("snapshot SKU=%q, want non-routing flag applied", cfg.AzureSnapshotSKU)
+			}
+		})
+	}
+
+	for _, source := range []providerSelectionSource{providerSelectionUserConfig, providerSelectionFlag} {
+		t.Run("routed_"+string(source), func(t *testing.T) {
+			cfg := baseConfig()
+			setProviderSelection(&cfg, "azure", source)
+			cfg.AzureBackend = AzureBackendDynamicSessions
+			if err := routeConfiguredProvider(&cfg); err != nil {
+				t.Fatal(err)
+			}
+			if cfg.Provider != "azure-dynamic-sessions" || cfg.providerSelectionSource != source {
+				t.Fatalf("provider=%q source=%q, want routed azure-dynamic-sessions/%s", cfg.Provider, cfg.providerSelectionSource, source)
+			}
+		})
+	}
+
+	t.Run("routing flag overrides authoritative route", func(t *testing.T) {
+		defaults := baseConfig()
+		defaults.Provider = "azure"
+		fs := newFlagSet("authoritative route override", io.Discard)
+		values := registerProviderFlags(fs, defaults)
+		if err := parseFlags(fs, []string{"--azure-backend", "dynamic-sessions"}); err != nil {
+			t.Fatal(err)
+		}
+		cfg := defaults
+		setProviderSelection(&cfg, "azure", providerSelectionLeaseContext)
+		if err := applyProviderFlags(&cfg, fs, values); err != nil {
+			t.Fatal(err)
+		}
+		if cfg.Provider != "azure-dynamic-sessions" || cfg.providerSelectionSource != providerSelectionFlag {
+			t.Fatalf("provider=%q source=%q", cfg.Provider, cfg.providerSelectionSource)
+		}
+	})
+}
+
 func TestLoadBackendWrapsCoordinatorOnlyForSupportedSSHProviders(t *testing.T) {
 	t.Setenv(controllerProviderScopeEnv, "")
 	cfg := baseConfig()
-	cfg.Provider = "aws"
+	setProviderSelection(&cfg, "aws", providerSelectionFlag)
 	cfg.Coordinator = "https://coordinator.example"
 	backend, err := loadBackend(cfg, testRuntimeWithRunner(&recordingCommandRunner{}))
 	if err != nil {
@@ -431,7 +521,7 @@ func TestLoadBackendWrapsCoordinatorOnlyForSupportedSSHProviders(t *testing.T) {
 
 func TestLoadBackendRejectsChangedControllerProviderScope(t *testing.T) {
 	cfg := baseConfig()
-	cfg.Provider = "external"
+	setProviderSelection(&cfg, "external", providerSelectionFlag)
 	cfg.External.Command = "provider-a"
 	_, scope, _, err := controllerProviderIdentityForConfig(cfg)
 	if err != nil {
@@ -449,7 +539,7 @@ func TestLoadBackendRejectsChangedControllerProviderScope(t *testing.T) {
 
 func TestLoadBackendResetsInferredTargetAfterProviderSwitch(t *testing.T) {
 	cfg := baseConfig()
-	cfg.Provider = "cloudflare-dynamic-workers"
+	setProviderSelection(&cfg, "cloudflare-dynamic-workers", providerSelectionFlag)
 	applySingleProviderTargetDefault(&cfg)
 	if cfg.TargetOS != "worker-runtime" {
 		t.Fatalf("initial target=%q, want worker-runtime", cfg.TargetOS)
@@ -473,7 +563,7 @@ func TestLoadBackendResetsInferredTargetAfterProviderSwitch(t *testing.T) {
 func TestRegisteredBrokerKeepsProviderLifecycleDirect(t *testing.T) {
 	t.Setenv(controllerProviderScopeEnv, "")
 	cfg := baseConfig()
-	cfg.Provider = "aws"
+	setProviderSelection(&cfg, "aws", providerSelectionFlag)
 	cfg.Coordinator = "https://coordinator.example"
 	cfg.BrokerMode = BrokerModeRegistered
 	backend, err := loadBackend(cfg, testRuntimeWithRunner(&recordingCommandRunner{}))

--- a/internal/cli/provider_exports.go
+++ b/internal/cli/provider_exports.go
@@ -17,6 +17,12 @@ func LoadConfig() (Config, error) {
 	return loadConfig()
 }
 
+// ProviderSelectionIsAuthoritativeRoute reports whether cfg names an exact
+// provider restored from lease or recorded-run context.
+func ProviderSelectionIsAuthoritativeRoute(cfg Config) bool {
+	return providerSelectionIsAuthoritativeRoute(cfg)
+}
+
 func NormalizeTargetConfig(cfg *Config) {
 	normalizeTargetConfig(cfg)
 }

--- a/internal/cli/provider_selection_intent_test.go
+++ b/internal/cli/provider_selection_intent_test.go
@@ -1,0 +1,116 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestProviderSelectionIsActionable(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		source providerSelectionSource
+		want   bool
+	}{
+		{name: "empty source", source: providerSelectionSource("")},
+		{name: "unknown source", source: providerSelectionSource("future_source")},
+		{name: "compiled default", source: providerSelectionCompiledDefault},
+		{name: "user config", source: providerSelectionUserConfig, want: true},
+		{name: "repo config", source: providerSelectionRepoConfig, want: true},
+		{name: "environment", source: providerSelectionEnvironment, want: true},
+		{name: "flag", source: providerSelectionFlag, want: true},
+		{name: "recorded run", source: providerSelectionRecordedRun, want: true},
+		{name: "lease context", source: providerSelectionLeaseContext, want: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Config{Provider: "ssh", providerSelectionSource: tt.source}
+			if got := providerSelectionIsActionable(cfg); got != tt.want {
+				t.Fatalf("providerSelectionIsActionable()=%t want %t", got, tt.want)
+			}
+		})
+	}
+	if providerSelectionIsActionable(Config{providerSelectionSource: providerSelectionFlag}) {
+		t.Fatal("empty provider must not be actionable")
+	}
+}
+
+func TestExplicitHetznerWarmupReachesCredentialValidation(t *testing.T) {
+	clearConfigEnv(t)
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+	t.Setenv("CRABBOX_PROVIDER", "")
+	t.Setenv("HCLOUD_TOKEN", "")
+	t.Setenv("HETZNER_TOKEN", "")
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).warmup(context.Background(), []string{"--provider", "hetzner"})
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 3 || !strings.Contains(exitErr.Message, "HCLOUD_TOKEN or HETZNER_TOKEN is required") {
+		t.Fatalf("explicit Hetzner error=%v, want credential exit 3; stdout=%q stderr=%q", err, stdout.String(), stderr.String())
+	}
+	if strings.Contains(err.Error(), providerSelectionRequiredDiagnostic) {
+		t.Fatalf("explicit Hetzner selection hit no-provider guard: %v", err)
+	}
+}
+
+func TestBrokerProviderIsActionableUserSelection(t *testing.T) {
+	clearConfigEnv(t)
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte("broker:\n  provider: aws\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CRABBOX_CONFIG", path)
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Provider != "aws" || cfg.brokerProvider != "aws" || cfg.providerSelectionSource != providerSelectionUserConfig || !providerSelectionIsActionable(cfg) {
+		t.Fatalf("broker provider selection=%#v source=%q", cfg.brokerProvider, cfg.providerSelectionSource)
+	}
+}
+
+func TestUnconfiguredProviderCommandsUseSharedSelectionDiagnostic(t *testing.T) {
+	commands := []struct {
+		name string
+		run  func(App) error
+	}{
+		{name: "warmup", run: func(app App) error { return app.warmup(context.Background(), nil) }},
+		{name: "new run", run: func(app App) error {
+			return app.runCommand(context.Background(), []string{"--no-sync", "--", "true"})
+		}},
+		{name: "list", run: func(app App) error { return app.list(context.Background(), nil) }},
+		{name: "cleanup dry run", run: func(app App) error {
+			return app.cleanup(context.Background(), []string{"--dry-run"})
+		}},
+		{name: "unknown status", run: func(app App) error {
+			return app.status(context.Background(), []string{"--id", "unknown-provider-selection"})
+		}},
+		{name: "unknown inspect", run: func(app App) error {
+			return app.inspect(context.Background(), []string{"--id", "unknown-provider-selection"})
+		}},
+		{name: "unknown stop", run: func(app App) error {
+			return app.stop(context.Background(), []string{"--id", "unknown-provider-selection"})
+		}},
+	}
+
+	for _, command := range commands {
+		t.Run(command.name, func(t *testing.T) {
+			clearConfigEnv(t)
+			t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+			t.Setenv("CRABBOX_PROVIDER", "")
+			t.Setenv("HCLOUD_TOKEN", "")
+			t.Setenv("HETZNER_TOKEN", "")
+			var stdout, stderr bytes.Buffer
+			err := command.run(App{Stdout: &stdout, Stderr: &stderr})
+			var exitErr ExitError
+			if !AsExitError(err, &exitErr) || exitErr.Code != 2 || !strings.Contains(err.Error(), providerSelectionRequiredDiagnostic) {
+				t.Fatalf("error=%v, want shared exit 2 diagnostic; stdout=%q stderr=%q", err, stdout.String(), stderr.String())
+			}
+			output := err.Error() + stdout.String() + stderr.String()
+			if strings.Contains(output, "HCLOUD_TOKEN") || strings.Contains(output, "HETZNER_TOKEN") {
+				t.Fatalf("command emitted Hetzner credential guidance: %s", output)
+			}
+		})
+	}
+}

--- a/internal/cli/providers_builtin_test.go
+++ b/internal/cli/providers_builtin_test.go
@@ -202,8 +202,14 @@ func (testAzureProvider) RouteConfig(cfg *Config, fs *flag.FlagSet, values any) 
 	return nil
 }
 func (p testAzureProvider) ApplyFlags(cfg *Config, fs *flag.FlagSet, values any) error {
-	if err := p.RouteConfig(cfg, fs, values); err != nil {
-		return err
+	backendExplicit := fs != nil && flagWasSet(fs, "azure-backend")
+	if !providerSelectionIsAuthoritativeRoute(*cfg) || backendExplicit {
+		if err := p.RouteConfig(cfg, fs, values); err != nil {
+			return err
+		}
+	}
+	if cfg.Provider != p.Name() {
+		return nil
 	}
 	flags, _ := values.(testAzureFlagValues)
 	if fs != nil && flagWasSet(fs, "azure-snapshot-sku") && flags.SnapshotSKU != nil {
@@ -398,13 +404,24 @@ func (testHetznerProvider) ApplyFlags(*Config, *flag.FlagSet, any) error {
 	return nil
 }
 func (p testHetznerProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
-	return testSSHBackend{spec: p.Spec()}, nil
+	return testHetznerBackend{testSSHBackend{spec: p.Spec()}}, nil
 }
 func (p testHetznerProvider) ConfigureDoctor(Config, Runtime) (DoctorBackend, error) {
 	if _, err := newHetznerClient(); err != nil {
 		return nil, err
 	}
 	return testDoctorDelegatedBackend{testDelegatedBackend{spec: p.Spec()}}, nil
+}
+
+type testHetznerBackend struct {
+	testSSHBackend
+}
+
+func (b testHetznerBackend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
+	if _, err := newHetznerClient(); err != nil {
+		return LeaseTarget{}, err
+	}
+	return b.testSSHBackend.Acquire(ctx, req)
 }
 
 type testDigitalOceanProvider struct{}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -3561,6 +3561,9 @@ func (a App) stop(ctx context.Context, args []string) error {
 			}
 		}
 	}
+	if err := autoRouteClaimLeaseProvider(&cfg, fs, *id); err != nil {
+		return err
+	}
 	if err := autoRouteStaticLease(&cfg, fs, *id); err != nil {
 		return err
 	}

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -4153,6 +4153,9 @@ func TestAutoRouteClaimLeaseProvider(t *testing.T) {
 		if cfg.Provider != "aws" {
 			t.Fatalf("provider=%q want aws", cfg.Provider)
 		}
+		if cfg.providerSelectionSource != providerSelectionLeaseContext {
+			t.Fatalf("provider source=%q want %q", cfg.providerSelectionSource, providerSelectionLeaseContext)
+		}
 	})
 
 	t.Run("exact id wins over slug collision", func(t *testing.T) {
@@ -4186,6 +4189,9 @@ func TestAutoRouteClaimLeaseProvider(t *testing.T) {
 		}
 		if cfg.Provider != "local-container" {
 			t.Fatalf("provider=%q want local-container", cfg.Provider)
+		}
+		if cfg.providerSelectionSource != providerSelectionLeaseContext {
+			t.Fatalf("provider source=%q want %q", cfg.providerSelectionSource, providerSelectionLeaseContext)
 		}
 	})
 

--- a/internal/cli/webvnc_test.go
+++ b/internal/cli/webvnc_test.go
@@ -2860,7 +2860,7 @@ func TestControllerWebVNCResolveIsIdentityBoundAndReadOnly(t *testing.T) {
 	t.Cleanup(func() { testExternalResolveHook = nil })
 
 	cfg := BaseConfig()
-	cfg.Provider = "external"
+	setProviderSelection(&cfg, "external", providerSelectionFlag)
 	cfg.External.Command = "provider-command"
 	cfg.External.Capabilities.IdempotentLeaseID = true
 	app := App{Stdout: io.Discard, Stderr: io.Discard}

--- a/internal/providers/azure/provider.go
+++ b/internal/providers/azure/provider.go
@@ -69,8 +69,11 @@ func (Provider) RouteConfig(cfg *core.Config, fs *flag.FlagSet, values any) erro
 }
 
 func (p Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
-	if err := p.RouteConfig(cfg, fs, values); err != nil {
-		return err
+	backendExplicit := fs != nil && core.FlagWasSet(fs, "azure-backend")
+	if !core.ProviderSelectionIsAuthoritativeRoute(*cfg) || backendExplicit {
+		if err := p.RouteConfig(cfg, fs, values); err != nil {
+			return err
+		}
 	}
 	if cfg.Provider != p.Name() {
 		return nil

--- a/internal/providers/azure/provider_test.go
+++ b/internal/providers/azure/provider_test.go
@@ -173,6 +173,23 @@ func TestProviderAppliesAzureSnapshotStorageFlags(t *testing.T) {
 	}
 }
 
+func TestProviderExplicitBackendRoutesToDynamicSessions(t *testing.T) {
+	t.Parallel()
+	provider := Provider{}
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	values := provider.RegisterFlags(fs, core.Config{AzureBackend: core.AzureBackendVM})
+	if err := fs.Parse([]string{"--azure-backend", "dynamic-sessions"}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := core.Config{Provider: "azure", AzureBackend: core.AzureBackendVM}
+	if err := provider.ApplyFlags(&cfg, fs, values); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Provider != "azure-dynamic-sessions" || cfg.AzureBackend != core.AzureBackendDynamicSessions {
+		t.Fatalf("provider=%q backend=%q", cfg.Provider, cfg.AzureBackend)
+	}
+}
+
 func TestProviderValidatesConfiguredAzureOSDisk(t *testing.T) {
 	t.Parallel()
 	provider := Provider{}


### PR DESCRIPTION
## Summary

- treat the compiled Hetzner compatibility fallback as non-actionable provider metadata
- require explicit, configured, recorded-run, or lease-claim provider intent before backend initialization
- keep bare `doctor` provider-neutral and make `config show` report an empty effective provider/type when none is selected
- preserve exact claim and recorded-run routing, including Azure VM routes when stale family config points at Dynamic Sessions
- route claim-oriented lifecycle helpers consistently and remove the implicit Hetzner default from generated help

Closes https://github.com/openclaw/crabbox/issues/1335

## Verification

- `go test ./internal/cli`
- `go test ./internal/providers/azure -count=1`
- focused provider-selection, claim-routing, and Azure routing tests
- `scripts/check-docs.sh`
- `git diff --check`
- built the CLI and source-blindly verified:
  - clean `config show --json` reports `provider=""`, `providerSelected=false`, `providerSource=compiled_default`, and an empty top-level `serverType`
  - bare `doctor --json` remains successful and provider-neutral
  - unconfigured warmup, run, list, cleanup, status, inspect, and stop fail before backend initialization with shared provider-selection guidance
  - explicit Hetzner still reaches its existing credential requirement
  - generated warmup help no longer advertises Hetzner as the default
- structured P1 autoreview and secret scan: clean
