### PR TITLE
fix(checkpoint): fence provider-native identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Provider-native checkpoint identifiers no longer reroute through coincidentally matching Static or External lease identities.
 - Required explicit provider intent before lifecycle commands initialize a backend, while preserving claim and recorded-run routing and keeping bare doctor provider-neutral. Thanks @coygeek.
 - Prevented Azure orphan-sweep release failures from writing secret-bearing diagnostics to Worker console logs while retaining redacted details in sweep records.
 - Rejected native Jujutsu workspaces before Git-manifest sync can fall through to an outer checkout, while preserving colocated Git workspaces and `--no-sync`. Thanks @atimmer.

--- a/internal/cli/external_routing_test.go
+++ b/internal/cli/external_routing_test.go
@@ -891,3 +891,41 @@ func TestLeaseTargetConfigPreservesImplicitExternalClaimRouting(t *testing.T) {
 		t.Fatalf("provider source=%q want %q", cfg.providerSelectionSource, providerSelectionLeaseContext)
 	}
 }
+
+func TestLeaseTargetConfigProviderResourceIDSkipsExternalRouting(t *testing.T) {
+	setupClaimRoutingCommandTest(t, parallelsProvider)
+	root := setExternalRoutingTestHome(t)
+	const leaseID = "cbx_1293ee000002"
+	routing := ExternalConfig{Command: "claimed-provider", WorkRoot: "/claimed/work"}
+	if _, err := PersistExternalRouting(leaseID, routing); err != nil {
+		t.Fatal(err)
+	}
+	if err := claimLeaseForRepoProviderScope(leaseID, "native-vm-name", "external", "claimed-scope", root, time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+
+	defaults := defaultConfig()
+	if defaults.Provider != parallelsProvider || !providerSelectionIsActionable(defaults) {
+		t.Fatalf("configured provider=%q source=%q", defaults.Provider, defaults.providerSelectionSource)
+	}
+	fs := newFlagSet("checkpoint restore", os.Stderr)
+	provider := fs.String("provider", defaults.Provider, "")
+	targetFlags := registerTargetFlags(fs, defaults)
+	networkFlags := registerNetworkModeFlag(fs, defaults)
+	if err := parseFlags(fs, nil); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{
+		LeaseID:            "native-vm-name",
+		ProviderResourceID: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Provider != parallelsProvider || cfg.providerSelectionSource != defaults.providerSelectionSource {
+		t.Fatalf("provider=%q source=%q want %q/%q", cfg.Provider, cfg.providerSelectionSource, parallelsProvider, defaults.providerSelectionSource)
+	}
+	if cfg.External.RoutingFile != "" || cfg.External.Command != "" || cfg.External.routingLoaded || cfg.WorkRoot == routing.WorkRoot {
+		t.Fatalf("provider-native id loaded External routing: cfg=%#v external=%#v", cfg, cfg.External)
+	}
+}

--- a/internal/cli/lease_flags.go
+++ b/internal/cli/lease_flags.go
@@ -413,7 +413,8 @@ type leaseTargetConfigOptions struct {
 	LeaseID string
 	// ProviderResourceID marks LeaseID as a provider-native resource identifier,
 	// not a Crabbox lease identifier. Native snapshot operations use this to
-	// avoid routing an unrelated local claim whose slug happens to match.
+	// avoid routing unrelated claim, Static, or External lease identities that
+	// happen to match.
 	ProviderResourceID bool
 }
 
@@ -438,12 +439,12 @@ func loadLeaseTargetConfig(fs *flag.FlagSet, provider string, targetFlags target
 		if err := autoRouteClaimLeaseProvider(&cfg, fs, opts.LeaseID); err != nil {
 			return Config{}, err
 		}
-	}
-	if err := autoRouteStaticLease(&cfg, fs, opts.LeaseID); err != nil {
-		return Config{}, err
-	}
-	if err := autoRouteExternalLease(&cfg, fs, opts.LeaseID); err != nil {
-		return Config{}, err
+		if err := autoRouteStaticLease(&cfg, fs, opts.LeaseID); err != nil {
+			return Config{}, err
+		}
+		if err := autoRouteExternalLease(&cfg, fs, opts.LeaseID); err != nil {
+			return Config{}, err
+		}
 	}
 	if err := applyNetworkModeFlagOverride(&cfg, fs, networkFlags); err != nil {
 		return Config{}, err

--- a/internal/cli/static_route_test.go
+++ b/internal/cli/static_route_test.go
@@ -151,6 +151,44 @@ func TestLeaseTargetConfigPreservesImplicitStaticClaimRouting(t *testing.T) {
 	}
 }
 
+func TestLeaseTargetConfigProviderResourceIDSkipsStaticRouting(t *testing.T) {
+	setupClaimRoutingCommandTest(t, parallelsProvider)
+	claimed := baseConfig()
+	claimed.Provider = staticProvider
+	claimed.Static.Host = "builder.example.com"
+	claimed.Static.User = "builder"
+	claimed.Static.Port = "2202"
+	claimed.Static.WorkRoot = "/work/static-builder"
+	if err := claimLeaseForRepoConfig("static_builder", "builder", claimed, "/repo", time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+
+	defaults := defaultConfig()
+	if defaults.Provider != parallelsProvider || !providerSelectionIsActionable(defaults) {
+		t.Fatalf("configured provider=%q source=%q", defaults.Provider, defaults.providerSelectionSource)
+	}
+	fs := newFlagSet("checkpoint list", io.Discard)
+	provider := fs.String("provider", defaults.Provider, "")
+	targetFlags := registerTargetFlags(fs, defaults)
+	networkFlags := registerNetworkModeFlag(fs, defaults)
+	if err := parseFlags(fs, nil); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{
+		LeaseID:            "static_builder",
+		ProviderResourceID: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Provider != parallelsProvider || cfg.providerSelectionSource != defaults.providerSelectionSource {
+		t.Fatalf("provider=%q source=%q want %q/%q", cfg.Provider, cfg.providerSelectionSource, parallelsProvider, defaults.providerSelectionSource)
+	}
+	if cfg.Static.ID != "" || cfg.Static.Name != "" || cfg.Static.Host != "" || cfg.Static.User != "" || cfg.Static.Port != "" || cfg.Static.WorkRoot != "" {
+		t.Fatalf("provider-native id loaded Static config: %#v", cfg.Static)
+	}
+}
+
 func TestAutoRouteStaticLeaseDoesNotGuessHostWithoutClaim(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	defaults := baseConfig()


### PR DESCRIPTION
## Summary

- treat provider-native checkpoint IDs as provider-owned identifiers throughout shared lease-target config loading
- skip generic claim, Static, and External lease-identity routing when `ProviderResourceID` is set
- preserve existing implicit Static and External routing for ordinary Crabbox lease IDs
- add regressions for `static_` prefix and persisted External-claim collisions

This completes the provider-native identifier fence introduced in https://github.com/openclaw/crabbox/pull/1324.

## Verification

- focused provider-native Static and External routing regressions
- `go test ./internal/cli`
- `scripts/check-docs.sh`
- `git diff --check`
- structured P1 autoreview and secret scan: clean
