### PR TITLE
chore(release): prepare v0.42.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.41.7 - Unreleased
+## 0.42.0 - 2026-08-14
 
 ### Added
 

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/crabbox-worker",
-  "version": "0.41.6",
+  "version": "0.42.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/crabbox-worker",
-      "version": "0.41.6",
+      "version": "0.42.0",
       "dependencies": {
         "@aws-sdk/credential-providers": "^3.1095.0",
         "@cloudflare/containers": "^0.3.7",

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/crabbox-worker",
-  "version": "0.41.6",
+  "version": "0.42.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- finalize the accumulated unreleased changelog as `0.42.0` dated 2026-08-14
- bump the Worker package and both root lockfile version fields to `0.42.0`
- prepare the exact source commit for the signed release tag and authorization record

This PR does not create a tag, release, draft, artifact, or Homebrew update.

## Verification

- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- `go vet ./...`
- `go test -race ./internal/cli`
- race tests for all remaining Go packages
- Worker format, lint, typecheck, 1,309 tests, and dry-run build
- 583 serialized script tests
- `scripts/check-docs.sh`
- `scripts/extract-release-notes.sh v0.42.0 CHANGELOG.md`
- `scripts/release-config.sh assets v0.42.0`
- `git diff --check`
- structured P1 autoreview and secret scan: clean
