### PR TITLE
chore(release): authorize v0.42.0 source

### DIFF
--- a/release/records/v0.42.0.json
+++ b/release/records/v0.42.0.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "repository": "openclaw/crabbox",
+  "tag": "v0.42.0",
+  "tagObject": "7432d12d93af16e6073ade7ffb3ab32dd55b2651",
+  "sourceCommit": "13f20f81edd76dd51f4b4351450a70755331816c",
+  "publicationStatus": "ready"
+}


### PR DESCRIPTION
## Summary

Authorize the immutable `v0.42.0` release source by binding:

- signed tag object: `7432d12d93af16e6073ade7ffb3ab32dd55b2651`
- peeled source commit: `13f20f81edd76dd51f4b4351450a70755331816c`
- publication status: `ready`

The tag annotation is exactly `v0.42.0` and verifies against the repository-pinned Foundation signer allowlist.

This PR does not build artifacts, create a release draft, publish a release, or update Homebrew.

## Verification

- `verify-release-source.sh` with `REQUIRE_PUBLISHABLE=1`
- remote tag object and peeled commit match the record
- tag signature matches the pinned release signer fingerprint
- JSON schema/identity assertions
- `git diff --check`
- structured P1 autoreview and secret scan: clean
