### PR TITLE
chore(release): open v0.42.1 development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 0.42.1 - Unreleased
+
 ## 0.42.0 - 2026-08-14
 
 ### Added


### PR DESCRIPTION
## Summary

Open the next patch development cycle after the verified `v0.42.0` release:

- add `0.42.1 - Unreleased` at the top of `CHANGELOG.md`
- leave the published `0.42.0` notes and version metadata unchanged

## Verified release

- GitHub Release: https://github.com/openclaw/crabbox/releases/tag/v0.42.0
- public verifier: https://github.com/openclaw/crabbox/actions/runs/31792431823
- Homebrew verifier: https://github.com/openclaw/crabbox/actions/runs/31796930923
- canonical tap commit: https://github.com/openclaw/homebrew-tap/commit/d30b58396fc25c2adccd4d83e5c69cda6c9b46ae

## Verification

- `scripts/check-docs.sh`
- `git diff --check`
- structured P1 autoreview and secret scan: clean
