### PR TITLE
fix(coordinator): bind lease mutations to provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.42.1 - Unreleased
 
+### Fixed
+
+- Bound coordinator release, heartbeat, and Tailscale mutations to the CLI-selected provider, preventing cross-provider lease deletion or metadata changes.
+
 ## 0.42.0 - 2026-08-14
 
 ### Added

--- a/docs/features/coordinator.md
+++ b/docs/features/coordinator.md
@@ -27,6 +27,14 @@ selected by the CLI. Legacy responses may omit provider metadata and inherit
 that selection, but a response naming an unknown or different provider is
 rejected before the CLI converts or acts on the lease.
 
+Mutating CLI requests for release, heartbeat (including idle-timeout and
+telemetry updates), and Tailscale metadata carry the canonical selected
+provider as `expectedProvider`. The coordinator compares it with the stored
+record inside the same state transaction and returns a stable `409` identity
+error before any mutation when they differ. Omitting `expectedProvider` remains
+supported for older clients and provider-neutral portal flows; when supplied,
+it must be a nonempty normalized provider name.
+
 `broker.mode: registered` is provider-neutral. Provisioning, SSH, touch, and
 cleanup remain in the direct adapter, while the CLI idempotently registers an
 owner-scoped lease record with the coordinator. This enables portal inventory,

--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -165,7 +165,10 @@ func (a App) actionsHydrate(ctx context.Context, args []string) (err error) {
 		return err
 	}
 	if coord := backendCoordinator(backend); coord != nil {
-		stopHeartbeat := startCoordinatorHeartbeat(ctx, coord, leaseID, cfg.IdleTimeout, nil, leaseTelemetryCollectorForTarget(target), a.Stderr)
+		stopHeartbeat, err := startCoordinatorHeartbeat(ctx, coord, leaseID, cfg.Provider, cfg.IdleTimeout, nil, leaseTelemetryCollectorForTarget(target), a.Stderr)
+		if err != nil {
+			return err
+		}
 		defer stopHeartbeat()
 	} else if sshBackend, ok := backend.(SSHLeaseBackend); ok {
 		_, err := sshBackend.Touch(ctx, TouchRequest{Lease: LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, State: blank(server.Labels["state"], "ready"), IdleTimeout: cfg.IdleTimeout})

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -642,8 +642,19 @@ func (a App) adminRelease(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	lease, err := coord.AdminReleaseLease(ctx, *id, *deleteServer)
+	current, err := coord.GetLease(ctx, *id)
 	if err != nil {
+		return err
+	}
+	expectedProvider, err := canonicalProviderName(current.Provider)
+	if err != nil {
+		return err
+	}
+	lease, err := coord.AdminReleaseLeaseForProvider(ctx, *id, *deleteServer, expectedProvider)
+	if err != nil {
+		return err
+	}
+	if err := validateCoordinatorProviderIdentity(expectedProvider, lease.ID, lease.Provider, true); err != nil {
 		return err
 	}
 	if *jsonOut {

--- a/internal/cli/connect.go
+++ b/internal/cli/connect.go
@@ -41,7 +41,11 @@ func (a App) startInteractiveSSHLeaseActivity(ctx context.Context, cfg Config, l
 		if resolved, ok := parseDurationSecondsLabel(lease.Server.Labels["idle_timeout_secs"]); ok {
 			heartbeatIdleTimeout = resolved
 		}
-		stopHeartbeat = startCoordinatorHeartbeat(ctx, coord, lease.LeaseID, heartbeatIdleTimeout, nil, telemetry, a.Stderr)
+		var heartbeatErr error
+		stopHeartbeat, heartbeatErr = startCoordinatorHeartbeat(ctx, coord, lease.LeaseID, cfg.Provider, heartbeatIdleTimeout, nil, telemetry, a.Stderr)
+		if heartbeatErr != nil {
+			fmt.Fprintf(a.Stderr, "warning: coordinator heartbeat disabled for %s: %v\n", lease.LeaseID, heartbeatErr)
+		}
 	}
 	backend, err := loadBackend(cfg, runtimeForApp(a))
 	if err != nil {

--- a/internal/cli/control_ws.go
+++ b/internal/cli/control_ws.go
@@ -29,6 +29,7 @@ type coordinatorControlMessage struct {
 	Events             []CoordinatorRunEvent `json:"events,omitempty"`
 	NextSeq            int                   `json:"nextSeq,omitempty"`
 	LeaseID            string                `json:"leaseID,omitempty"`
+	ExpectedProvider   string                `json:"expectedProvider,omitempty"`
 	OK                 bool                  `json:"ok,omitempty"`
 	ExpiresAt          string                `json:"expiresAt,omitempty"`
 	Code               string                `json:"code,omitempty"`
@@ -204,11 +205,12 @@ func coordinatorRunDone(ctx context.Context, coord *CoordinatorClient, runID str
 	return run.State != "running", nil
 }
 
-func (c *coordinatorControlConn) heartbeat(ctx context.Context, leaseID string, idleTimeout *time.Duration, telemetry *LeaseTelemetry) error {
+func (c *coordinatorControlConn) heartbeat(ctx context.Context, leaseID, expectedProvider string, idleTimeout *time.Duration, telemetry *LeaseTelemetry) error {
 	payload := coordinatorControlMessage{
-		Type:      "heartbeat",
-		LeaseID:   leaseID,
-		Telemetry: telemetry,
+		Type:             "heartbeat",
+		LeaseID:          leaseID,
+		ExpectedProvider: expectedProvider,
+		Telemetry:        telemetry,
 	}
 	if idleTimeout != nil && *idleTimeout > 0 {
 		payload.IdleTimeoutSeconds = int(idleTimeout.Seconds())

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -1057,10 +1057,22 @@ func stringSlicesEqual(a, b []string) bool {
 }
 
 func (c *CoordinatorClient) UpdateLeaseTailscale(ctx context.Context, id string, meta TailscaleMetadata) (CoordinatorLease, error) {
+	return c.UpdateLeaseTailscaleForProvider(ctx, id, "", meta)
+}
+
+func (c *CoordinatorClient) UpdateLeaseTailscaleForProvider(ctx context.Context, id, expectedProvider string, meta TailscaleMetadata) (CoordinatorLease, error) {
 	var res struct {
 		Lease CoordinatorLease `json:"lease"`
 	}
-	err := c.do(ctx, http.MethodPost, "/v1/leases/"+url.PathEscape(id)+"/tailscale", meta, &res)
+	expectedProvider, err := canonicalCoordinatorMutationProvider(expectedProvider)
+	if err != nil {
+		return res.Lease, err
+	}
+	body := struct {
+		TailscaleMetadata
+		ExpectedProvider string `json:"expectedProvider,omitempty"`
+	}{TailscaleMetadata: meta, ExpectedProvider: expectedProvider}
+	err = c.do(ctx, http.MethodPost, "/v1/leases/"+url.PathEscape(id)+"/tailscale", body, &res)
 	return res.Lease, err
 }
 
@@ -1116,10 +1128,22 @@ func (c *CoordinatorClient) DeleteLeaseShare(ctx context.Context, id, user strin
 }
 
 func (c *CoordinatorClient) ReleaseLease(ctx context.Context, id string, deleteServer bool) (CoordinatorLease, error) {
+	return c.ReleaseLeaseForProvider(ctx, id, deleteServer, "")
+}
+
+func (c *CoordinatorClient) ReleaseLeaseForProvider(ctx context.Context, id string, deleteServer bool, expectedProvider string) (CoordinatorLease, error) {
 	var res struct {
 		Lease CoordinatorLease `json:"lease"`
 	}
-	err := c.do(ctx, http.MethodPost, "/v1/leases/"+url.PathEscape(id)+"/release", map[string]any{"delete": deleteServer}, &res)
+	expectedProvider, err := canonicalCoordinatorMutationProvider(expectedProvider)
+	if err != nil {
+		return res.Lease, err
+	}
+	body := map[string]any{"delete": deleteServer}
+	if expectedProvider != "" {
+		body["expectedProvider"] = expectedProvider
+	}
+	err = c.do(ctx, http.MethodPost, "/v1/leases/"+url.PathEscape(id)+"/release", body, &res)
 	return res.Lease, err
 }
 
@@ -1130,60 +1154,107 @@ func (c *CoordinatorClient) CancelLeaseCreate(ctx context.Context, id, createAtt
 }
 
 func (c *CoordinatorClient) CompleteRuntimeAdapterDelete(ctx context.Context, id, adapterID, workspaceID, registrationID string) (CoordinatorLease, error) {
+	return c.CompleteRuntimeAdapterDeleteForProvider(ctx, id, "", adapterID, workspaceID, registrationID)
+}
+
+func (c *CoordinatorClient) CompleteRuntimeAdapterDeleteForProvider(ctx context.Context, id, expectedProvider, adapterID, workspaceID, registrationID string) (CoordinatorLease, error) {
 	var res struct {
 		Lease CoordinatorLease `json:"lease"`
 	}
-	err := c.do(ctx, http.MethodPost, "/v1/leases/"+url.PathEscape(id)+"/release", map[string]any{
+	expectedProvider, err := canonicalCoordinatorMutationProvider(expectedProvider)
+	if err != nil {
+		return res.Lease, err
+	}
+	body := map[string]any{
 		"runtimeAdapterDeleteCompletion": map[string]string{
 			"adapterID":      adapterID,
 			"workspaceID":    workspaceID,
 			"registrationID": registrationID,
 			"status":         "absent",
 		},
-	}, &res)
+	}
+	if expectedProvider != "" {
+		body["expectedProvider"] = expectedProvider
+	}
+	err = c.do(ctx, http.MethodPost, "/v1/leases/"+url.PathEscape(id)+"/release", body, &res)
 	return res.Lease, err
 }
 
 func (c *CoordinatorClient) CompleteLegacyRuntimeAdapterDelete(ctx context.Context, id, adapterID, workspaceID string) (CoordinatorLease, error) {
+	return c.CompleteLegacyRuntimeAdapterDeleteForProvider(ctx, id, "", adapterID, workspaceID)
+}
+
+func (c *CoordinatorClient) CompleteLegacyRuntimeAdapterDeleteForProvider(ctx context.Context, id, expectedProvider, adapterID, workspaceID string) (CoordinatorLease, error) {
 	var res struct {
 		Lease CoordinatorLease `json:"lease"`
 	}
-	err := c.do(ctx, http.MethodPost, "/v1/leases/"+url.PathEscape(id)+"/release", map[string]any{
+	expectedProvider, err := canonicalCoordinatorMutationProvider(expectedProvider)
+	if err != nil {
+		return res.Lease, err
+	}
+	body := map[string]any{
 		"runtimeAdapterLegacyDeleteCompletion": map[string]string{
 			"adapterID":   adapterID,
 			"workspaceID": workspaceID,
 			"status":      "absent",
 		},
-	}, &res)
+	}
+	if expectedProvider != "" {
+		body["expectedProvider"] = expectedProvider
+	}
+	err = c.do(ctx, http.MethodPost, "/v1/leases/"+url.PathEscape(id)+"/release", body, &res)
 	return res.Lease, err
 }
 
 func (c *CoordinatorClient) TouchLease(ctx context.Context, id string) (CoordinatorLease, error) {
-	return c.heartbeatLease(ctx, id, nil, nil)
+	return c.heartbeatLease(ctx, id, "", nil, nil)
+}
+
+func (c *CoordinatorClient) TouchLeaseForProvider(ctx context.Context, id, expectedProvider string) (CoordinatorLease, error) {
+	return c.heartbeatLease(ctx, id, expectedProvider, nil, nil)
 }
 
 func (c *CoordinatorClient) TouchLeaseWithTelemetry(ctx context.Context, id string, telemetry *LeaseTelemetry) (CoordinatorLease, error) {
-	return c.heartbeatLease(ctx, id, nil, telemetry)
+	return c.heartbeatLease(ctx, id, "", nil, telemetry)
+}
+
+func (c *CoordinatorClient) TouchLeaseWithTelemetryForProvider(ctx context.Context, id, expectedProvider string, telemetry *LeaseTelemetry) (CoordinatorLease, error) {
+	return c.heartbeatLease(ctx, id, expectedProvider, nil, telemetry)
 }
 
 func (c *CoordinatorClient) UpdateLeaseIdleTimeout(ctx context.Context, id string, idleTimeout time.Duration) (CoordinatorLease, error) {
-	return c.heartbeatLease(ctx, id, &idleTimeout, nil)
+	return c.heartbeatLease(ctx, id, "", &idleTimeout, nil)
+}
+
+func (c *CoordinatorClient) UpdateLeaseIdleTimeoutForProvider(ctx context.Context, id, expectedProvider string, idleTimeout time.Duration) (CoordinatorLease, error) {
+	return c.heartbeatLease(ctx, id, expectedProvider, &idleTimeout, nil)
 }
 
 func (c *CoordinatorClient) UpdateLeaseIdleTimeoutWithTelemetry(ctx context.Context, id string, idleTimeout time.Duration, telemetry *LeaseTelemetry) (CoordinatorLease, error) {
-	return c.heartbeatLease(ctx, id, &idleTimeout, telemetry)
+	return c.heartbeatLease(ctx, id, "", &idleTimeout, telemetry)
 }
 
-func (c *CoordinatorClient) heartbeatLease(ctx context.Context, id string, idleTimeout *time.Duration, telemetry *LeaseTelemetry) (CoordinatorLease, error) {
+func (c *CoordinatorClient) UpdateLeaseIdleTimeoutWithTelemetryForProvider(ctx context.Context, id, expectedProvider string, idleTimeout time.Duration, telemetry *LeaseTelemetry) (CoordinatorLease, error) {
+	return c.heartbeatLease(ctx, id, expectedProvider, &idleTimeout, telemetry)
+}
+
+func (c *CoordinatorClient) heartbeatLease(ctx context.Context, id, expectedProvider string, idleTimeout *time.Duration, telemetry *LeaseTelemetry) (CoordinatorLease, error) {
 	var res struct {
 		Lease CoordinatorLease `json:"lease"`
 	}
-	err := c.do(ctx, http.MethodPost, "/v1/leases/"+url.PathEscape(id)+"/heartbeat", heartbeatRequestBody(idleTimeout, telemetry), &res)
+	expectedProvider, err := canonicalCoordinatorMutationProvider(expectedProvider)
+	if err != nil {
+		return res.Lease, err
+	}
+	err = c.do(ctx, http.MethodPost, "/v1/leases/"+url.PathEscape(id)+"/heartbeat", heartbeatRequestBody(expectedProvider, idleTimeout, telemetry), &res)
 	return res.Lease, err
 }
 
-func heartbeatRequestBody(idleTimeout *time.Duration, telemetry *LeaseTelemetry) map[string]any {
+func heartbeatRequestBody(expectedProvider string, idleTimeout *time.Duration, telemetry *LeaseTelemetry) map[string]any {
 	body := map[string]any{}
+	if expectedProvider != "" {
+		body["expectedProvider"] = expectedProvider
+	}
 	if idleTimeout != nil && *idleTimeout > 0 {
 		body["idleTimeoutSeconds"] = int(idleTimeout.Seconds())
 	}
@@ -1191,6 +1262,13 @@ func heartbeatRequestBody(idleTimeout *time.Duration, telemetry *LeaseTelemetry)
 		body["telemetry"] = telemetry
 	}
 	return body
+}
+
+func canonicalCoordinatorMutationProvider(expectedProvider string) (string, error) {
+	if expectedProvider == "" {
+		return "", nil
+	}
+	return canonicalProviderName(expectedProvider)
 }
 
 func (c *CoordinatorClient) Pool(ctx context.Context, cfg Config) ([]CoordinatorMachine, error) {
@@ -1500,10 +1578,22 @@ func (c *CoordinatorClient) AdminLeaseAudit(ctx context.Context, state, provider
 }
 
 func (c *CoordinatorClient) AdminReleaseLease(ctx context.Context, id string, deleteServer bool) (CoordinatorLease, error) {
+	return c.AdminReleaseLeaseForProvider(ctx, id, deleteServer, "")
+}
+
+func (c *CoordinatorClient) AdminReleaseLeaseForProvider(ctx context.Context, id string, deleteServer bool, expectedProvider string) (CoordinatorLease, error) {
 	var res struct {
 		Lease CoordinatorLease `json:"lease"`
 	}
-	err := c.do(ctx, http.MethodPost, "/v1/admin/leases/"+url.PathEscape(id)+"/release", map[string]any{"delete": deleteServer}, &res)
+	expectedProvider, err := canonicalCoordinatorMutationProvider(expectedProvider)
+	if err != nil {
+		return res.Lease, err
+	}
+	body := map[string]any{"delete": deleteServer}
+	if expectedProvider != "" {
+		body["expectedProvider"] = expectedProvider
+	}
+	err = c.do(ctx, http.MethodPost, "/v1/admin/leases/"+url.PathEscape(id)+"/release", body, &res)
 	return res.Lease, err
 }
 

--- a/internal/cli/coordinator_registration.go
+++ b/internal/cli/coordinator_registration.go
@@ -238,7 +238,7 @@ func (a App) registerCoordinatorLeaseBestEffort(ctx context.Context, cfg Config,
 	if cfg.macOSPortalAuto {
 		if err := persistAutomaticCoordinatorRegistrationBinding(lease.LeaseID, cfg, coord.BaseURL); err != nil {
 			callCtx, cancel := context.WithTimeout(context.Background(), coordinatorRegistrationTimeout)
-			_, releaseErr := coord.ReleaseLease(callCtx, lease.LeaseID, false)
+			_, releaseErr := coord.ReleaseLeaseForProvider(callCtx, lease.LeaseID, false, cfg.Provider)
 			cancel()
 			a.coordinatorRegistrationWarning(lease.LeaseID, errors.Join(err, releaseErr))
 			return err
@@ -559,6 +559,7 @@ func (a App) completeRuntimeAdapterDeleteAfterConfirmedAbsence(ctx context.Conte
 			ctx,
 			coord,
 			leaseID,
+			cfg.Provider,
 			adapterID,
 			workspaceID,
 		)
@@ -568,7 +569,7 @@ func (a App) completeRuntimeAdapterDeleteAfterConfirmedAbsence(ctx context.Conte
 			return fmt.Errorf("runtime adapter delete completion has an invalid persisted registration id")
 		}
 		callCtx, cancel := context.WithTimeout(ctx, coordinatorRegistrationTimeout)
-		_, err := coord.CompleteRuntimeAdapterDelete(callCtx, leaseID, adapterID, workspaceID, registrationID)
+		_, err := coord.CompleteRuntimeAdapterDeleteForProvider(callCtx, leaseID, cfg.Provider, adapterID, workspaceID, registrationID)
 		cancel()
 		if err == nil || isCoordinatorNotFound(err) {
 			return nil
@@ -582,6 +583,7 @@ func (a App) completeRuntimeAdapterDeleteAfterConfirmedAbsence(ctx context.Conte
 		ctx,
 		coord,
 		leaseID,
+		cfg.Provider,
 		adapterID,
 		workspaceID,
 	)
@@ -590,11 +592,11 @@ func (a App) completeRuntimeAdapterDeleteAfterConfirmedAbsence(ctx context.Conte
 func completeLegacyRuntimeAdapterDeleteAfterConfirmedAbsence(
 	ctx context.Context,
 	coord *CoordinatorClient,
-	leaseID, adapterID, workspaceID string,
+	leaseID, expectedProvider, adapterID, workspaceID string,
 ) error {
 	callCtx, cancel := context.WithTimeout(ctx, coordinatorRegistrationTimeout)
 	defer cancel()
-	_, err := coord.CompleteLegacyRuntimeAdapterDelete(callCtx, leaseID, adapterID, workspaceID)
+	_, err := coord.CompleteLegacyRuntimeAdapterDeleteForProvider(callCtx, leaseID, expectedProvider, adapterID, workspaceID)
 	if isCoordinatorNotFound(err) {
 		return nil
 	}
@@ -625,7 +627,7 @@ func (a App) releaseRegisteredCoordinatorLease(ctx context.Context, cfg Config, 
 	}
 	callCtx, cancel := context.WithTimeout(ctx, coordinatorRegistrationTimeout)
 	defer cancel()
-	if _, err := coord.ReleaseLease(callCtx, leaseID, false); err != nil {
+	if _, err := coord.ReleaseLeaseForProvider(callCtx, leaseID, false, cfg.Provider); err != nil {
 		return err
 	}
 	return nil

--- a/internal/cli/coordinator_test.go
+++ b/internal/cli/coordinator_test.go
@@ -798,16 +798,19 @@ func mapStringString(input map[string]any) map[string]string {
 }
 
 func TestHeartbeatRequestBodyOmitsIdleTimeoutForTouch(t *testing.T) {
-	if body := heartbeatRequestBody(nil, nil); len(body) != 0 {
+	if body := heartbeatRequestBody("", nil, nil); len(body) != 0 {
 		t.Fatalf("touch heartbeat body=%v, want empty", body)
 	}
 	idleTimeout := 45 * time.Minute
-	body := heartbeatRequestBody(&idleTimeout, nil)
+	body := heartbeatRequestBody("aws", &idleTimeout, nil)
 	if body["idleTimeoutSeconds"] != 2700 {
 		t.Fatalf("heartbeat body=%v, want idle timeout seconds", body)
 	}
 	load := 0.42
-	body = heartbeatRequestBody(nil, &LeaseTelemetry{Load1: &load})
+	if body["expectedProvider"] != "aws" {
+		t.Fatalf("heartbeat body=%v, want expected provider", body)
+	}
+	body = heartbeatRequestBody("aws", nil, &LeaseTelemetry{Load1: &load})
 	if body["telemetry"] == nil {
 		t.Fatalf("heartbeat body=%v, want telemetry", body)
 	}
@@ -826,18 +829,141 @@ func TestCoordinatorTouchAndUpdateHeartbeatBodies(t *testing.T) {
 	}))
 	defer server.Close()
 	client := CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
-	if _, err := client.TouchLease(context.Background(), "cbx_123"); err != nil {
+	if _, err := client.TouchLeaseForProvider(context.Background(), "cbx_123", "google-cloud"); err != nil {
 		t.Fatal(err)
 	}
 	load := 0.42
-	if _, err := client.TouchLeaseWithTelemetry(context.Background(), "cbx_123", &LeaseTelemetry{Load1: &load}); err != nil {
+	if _, err := client.TouchLeaseWithTelemetryForProvider(context.Background(), "cbx_123", "google", &LeaseTelemetry{Load1: &load}); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := client.UpdateLeaseIdleTimeout(context.Background(), "cbx_123", 45*time.Minute); err != nil {
+	if _, err := client.UpdateLeaseIdleTimeoutForProvider(context.Background(), "cbx_123", "google-cloud", 45*time.Minute); err != nil {
 		t.Fatal(err)
 	}
-	if len(bodies) != 3 || bodies[0] != "{}" || !strings.Contains(bodies[1], `"load1":0.42`) || !strings.Contains(bodies[2], `"idleTimeoutSeconds":2700`) {
+	if len(bodies) != 3 || !strings.Contains(bodies[0], `"expectedProvider":"gcp"`) || !strings.Contains(bodies[1], `"expectedProvider":"gcp"`) || !strings.Contains(bodies[1], `"load1":0.42`) || !strings.Contains(bodies[2], `"expectedProvider":"gcp"`) || !strings.Contains(bodies[2], `"idleTimeoutSeconds":2700`) {
 		t.Fatalf("heartbeat bodies=%q", bodies)
+	}
+}
+
+func TestCoordinatorTailscaleUpdateIncludesExpectedProvider(t *testing.T) {
+	var body map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/leases/cbx_123/tailscale" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
+			ID: "cbx_123", Provider: "aws", State: "active",
+		}})
+	}))
+	defer server.Close()
+	client := CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
+	if _, err := client.UpdateLeaseTailscaleForProvider(context.Background(), "cbx_123", "google-cloud", TailscaleMetadata{
+		Enabled: true, IPv4: "100.64.0.10",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if body["expectedProvider"] != "gcp" || body["ipv4"] != "100.64.0.10" {
+		t.Fatalf("tailscale body=%#v", body)
+	}
+}
+
+func TestCoordinatorMutationTransportsCanonicalizeProviderAliasesAndRejectInvalid(t *testing.T) {
+	tests := []struct {
+		name   string
+		path   string
+		invoke func(context.Context, *CoordinatorClient, string) error
+	}{
+		{
+			name: "release", path: "/v1/leases/cbx_123/release",
+			invoke: func(ctx context.Context, client *CoordinatorClient, provider string) error {
+				_, err := client.ReleaseLeaseForProvider(ctx, "cbx_123", true, provider)
+				return err
+			},
+		},
+		{
+			name: "admin release", path: "/v1/admin/leases/cbx_123/release",
+			invoke: func(ctx context.Context, client *CoordinatorClient, provider string) error {
+				_, err := client.AdminReleaseLeaseForProvider(ctx, "cbx_123", true, provider)
+				return err
+			},
+		},
+		{
+			name: "runtime adapter completion", path: "/v1/leases/cbx_123/release",
+			invoke: func(ctx context.Context, client *CoordinatorClient, provider string) error {
+				_, err := client.CompleteRuntimeAdapterDeleteForProvider(ctx, "cbx_123", provider, "adapter", "workspace", "registration")
+				return err
+			},
+		},
+		{
+			name: "legacy runtime adapter completion", path: "/v1/leases/cbx_123/release",
+			invoke: func(ctx context.Context, client *CoordinatorClient, provider string) error {
+				_, err := client.CompleteLegacyRuntimeAdapterDeleteForProvider(ctx, "cbx_123", provider, "adapter", "workspace")
+				return err
+			},
+		},
+		{
+			name: "heartbeat", path: "/v1/leases/cbx_123/heartbeat",
+			invoke: func(ctx context.Context, client *CoordinatorClient, provider string) error {
+				_, err := client.TouchLeaseForProvider(ctx, "cbx_123", provider)
+				return err
+			},
+		},
+		{
+			name: "tailscale", path: "/v1/leases/cbx_123/tailscale",
+			invoke: func(ctx context.Context, client *CoordinatorClient, provider string) error {
+				_, err := client.UpdateLeaseTailscaleForProvider(ctx, "cbx_123", provider, TailscaleMetadata{Enabled: true})
+				return err
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			requests := 0
+			var body map[string]any
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests++
+				if r.Method != http.MethodPost || r.URL.Path != test.path {
+					t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+				}
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Fatal(err)
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{ID: "cbx_123", Provider: "gcp"}})
+			}))
+			defer server.Close()
+			client := &CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
+
+			if err := test.invoke(context.Background(), client, "google-cloud"); err != nil {
+				t.Fatal(err)
+			}
+			if requests != 1 || body["expectedProvider"] != "gcp" {
+				t.Fatalf("requests=%d body=%#v", requests, body)
+			}
+			if err := test.invoke(context.Background(), client, "future-cloud"); err == nil {
+				t.Fatal("invalid provider was accepted")
+			}
+			if requests != 1 {
+				t.Fatalf("invalid provider sent request; requests=%d", requests)
+			}
+		})
+	}
+}
+
+func TestCoordinatorHeartbeatRejectsInvalidProviderBeforeStarting(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requests++
+	}))
+	defer server.Close()
+	client := &CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
+	stop, err := startCoordinatorHeartbeat(context.Background(), client, "cbx_123", "future-cloud", 30*time.Minute, nil, nil, io.Discard)
+	if err == nil || stop != nil {
+		t.Fatalf("stop_present=%t error=%v, want invalid provider rejection", stop != nil, err)
+	}
+	if requests != 0 {
+		t.Fatalf("invalid provider sent %d request(s)", requests)
 	}
 }
 
@@ -880,7 +1006,10 @@ func TestCoordinatorHeartbeatTouchesImmediately(t *testing.T) {
 	defer server.Close()
 
 	client := CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
-	stop := startCoordinatorHeartbeat(context.Background(), &client, "cbx_123", 30*time.Minute, nil, nil, io.Discard)
+	stop, err := startCoordinatorHeartbeat(context.Background(), &client, "cbx_123", "aws", 30*time.Minute, nil, nil, io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer stop()
 
 	select {
@@ -1016,12 +1145,15 @@ func TestCoordinatorHeartbeatIncludesTelemetry(t *testing.T) {
 		return &LeaseTelemetry{Load1: &load}, nil
 	}
 	client := CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
-	stop := startCoordinatorHeartbeat(context.Background(), &client, "cbx_123", 30*time.Minute, nil, collector, io.Discard)
+	stop, err := startCoordinatorHeartbeat(context.Background(), &client, "cbx_123", "aws", 30*time.Minute, nil, collector, io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer stop()
 
 	select {
 	case body := <-bodies:
-		if !strings.Contains(body, `"load1":0.77`) {
+		if !strings.Contains(body, `"expectedProvider":"aws"`) || !strings.Contains(body, `"load1":0.77`) {
 			t.Fatalf("heartbeat body=%s, want telemetry", body)
 		}
 	case <-time.After(2 * time.Second):
@@ -1064,12 +1196,15 @@ func TestCoordinatorHeartbeatUsesControlWebSocket(t *testing.T) {
 		return &LeaseTelemetry{Load1: &load}, nil
 	}
 	client := CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
-	stop := startCoordinatorHeartbeat(context.Background(), &client, "cbx_123", 30*time.Minute, nil, collector, io.Discard)
+	stop, err := startCoordinatorHeartbeat(context.Background(), &client, "cbx_123", "google-cloud", 30*time.Minute, nil, collector, io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer stop()
 
 	select {
 	case body := <-bodies:
-		if !strings.Contains(body, `"type":"heartbeat"`) || !strings.Contains(body, `"load1":0.77`) {
+		if !strings.Contains(body, `"type":"heartbeat"`) || !strings.Contains(body, `"expectedProvider":"gcp"`) || !strings.Contains(body, `"load1":0.77`) {
 			t.Fatalf("control heartbeat body=%s", body)
 		}
 	case <-time.After(2 * time.Second):
@@ -1126,7 +1261,10 @@ func TestCoordinatorHeartbeatMintsTokenBeforeControlDialTimeout(t *testing.T) {
 		},
 		Client: server.Client(),
 	}
-	stop := startCoordinatorHeartbeat(context.Background(), &client, "cbx_123", 30*time.Minute, nil, nil, io.Discard)
+	stop, err := startCoordinatorHeartbeat(context.Background(), &client, "cbx_123", "aws", 30*time.Minute, nil, nil, io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer stop()
 
 	select {

--- a/internal/cli/cp_ssh_unix_test.go
+++ b/internal/cli/cp_ssh_unix_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -158,24 +157,7 @@ wait "$child"
 	go func() {
 		done <- copyOverResolvedSSH(ctx, SSHTarget{User: "alice", Host: "example.test", Port: "22"}, "./input", "SANDBOX:/tmp/input", false, &bytes.Buffer{}, &bytes.Buffer{})
 	}()
-	deadline := time.Now().Add(5 * time.Second)
-	var childPID int
-	for time.Now().Before(deadline) {
-		data, err := os.ReadFile(pidPath)
-		if err == nil {
-			value := strings.TrimSpace(string(data))
-			if value != "" {
-				if parsed, parseErr := strconv.Atoi(value); parseErr == nil && parsed > 0 {
-					childPID = parsed
-					break
-				}
-			}
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	if childPID == 0 {
-		t.Fatal("rsync descendant did not start")
-	}
+	childPID := waitForPIDFile(t, pidPath)
 	cancel()
 	select {
 	case err := <-done:

--- a/internal/cli/daemon_unix_test.go
+++ b/internal/cli/daemon_unix_test.go
@@ -44,9 +44,9 @@ func TestStopDaemonProcessKillsProcessGroup(t *testing.T) {
 
 func waitForPIDFile(t *testing.T, path string) int {
 	t.Helper()
-	// The child fork/exec that writes this file can be slow under CI load, so
-	// allow generous slack before declaring the descendant never started.
-	deadline := time.Now().Add(5 * time.Second)
+	// The child fork/exec that writes this file can be slow when the full package
+	// runs in parallel under CI load, so allow generous startup slack.
+	deadline := time.Now().Add(30 * time.Second)
 	var lastErr error
 	for {
 		data, err := os.ReadFile(path)

--- a/internal/cli/network.go
+++ b/internal/cli/network.go
@@ -363,10 +363,16 @@ func (a App) refreshTailscaleMetadata(ctx context.Context, cfg Config, backend B
 	}
 	applyTailscaleMetadataToServer(server, meta)
 	if useCoordinator && coord != nil && leaseID != "" {
-		if lease, err := coord.UpdateLeaseTailscale(ctx, leaseID, meta); err == nil {
-			updated, _, _ := leaseToServerTarget(lease, cfg)
+		if lease, err := coord.UpdateLeaseTailscaleForProvider(ctx, leaseID, cfg.Provider, meta); err == nil {
+			updated, identityErr := coordinatorTailscaleResponseServer(cfg, original, lease)
+			if identityErr != nil {
+				*server = original
+				fmt.Fprintf(a.Stderr, "warning: tailscale metadata update returned mismatched provider for %s: %v\n", leaseID, identityErr)
+				return
+			}
 			*server = updated
 		} else {
+			*server = original
 			fmt.Fprintf(a.Stderr, "warning: tailscale metadata update failed for %s: %v\n", leaseID, err)
 		}
 	} else if direct, ok := backend.(TailscaleMetadataBackend); ok && leaseID != "" {
@@ -378,6 +384,14 @@ func (a App) refreshTailscaleMetadata(ctx context.Context, cfg Config, backend B
 			fmt.Fprintf(a.Stderr, "warning: tailscale metadata update failed for %s: %v\n", leaseID, err)
 		}
 	}
+}
+
+func coordinatorTailscaleResponseServer(cfg Config, previous Server, lease CoordinatorLease) (Server, error) {
+	if err := validateCoordinatorProviderIdentity(cfg.Provider, lease.ID, lease.Provider, true); err != nil {
+		return previous, err
+	}
+	updated, _, _ := leaseToServerTarget(lease, cfg)
+	return updated, nil
 }
 
 func readRemoteTailscaleMetadata(ctx context.Context, target SSHTarget) (TailscaleMetadata, error) {

--- a/internal/cli/network_test.go
+++ b/internal/cli/network_test.go
@@ -120,6 +120,19 @@ func TestRenderTailscaleHostname(t *testing.T) {
 	}
 }
 
+func TestCoordinatorTailscaleProviderMismatchRetainsPreviousServer(t *testing.T) {
+	previous := Server{CloudID: "i-original", Provider: "aws", Name: "original"}
+	updated, err := coordinatorTailscaleResponseServer(Config{Provider: "aws"}, previous, CoordinatorLease{
+		ID: "cbx_tailscale_identity", Provider: "external", CloudID: "external-workspace", ServerName: "replacement",
+	})
+	if !isCoordinatorProviderIdentityError(err) {
+		t.Fatalf("error=%v, want typed provider identity mismatch", err)
+	}
+	if updated.CloudID != previous.CloudID || updated.Provider != previous.Provider || updated.Name != previous.Name {
+		t.Fatalf("updated server=%#v, want previous=%#v", updated, previous)
+	}
+}
+
 func TestValidateNetworkConfigRejectsStaticProvisioning(t *testing.T) {
 	cfg := baseConfig()
 	cfg.Provider = "ssh"

--- a/internal/cli/pond_bridge.go
+++ b/internal/cli/pond_bridge.go
@@ -234,7 +234,7 @@ func (a App) pondRelease(ctx context.Context, args []string) error {
 		if rerr != nil {
 			if backendCoordinator(backend) != nil {
 				fmt.Fprintf(a.Stderr, "warning: could not inspect %s/%s before release: %v\n", claim.Provider, claim.LeaseID, rerr)
-				lease = LeaseTarget{LeaseID: claim.LeaseID}
+				lease = LeaseTarget{LeaseID: claim.LeaseID, Server: Server{Provider: sshBackend.Spec().Name}}
 			} else {
 				if firstErr == nil {
 					firstErr = rerr

--- a/internal/cli/prewarm.go
+++ b/internal/cli/prewarm.go
@@ -298,8 +298,12 @@ func (a App) releasePrewarmLeaseAfterFailure(ctx context.Context, backend Backen
 			fmt.Fprintf(a.Stderr, "warning: prewarm %s failed; automatic release of %s skipped: %v; next: crabbox stop --provider %s --id %s\n", stage, leaseID, err, cfg.Provider, leaseID)
 			return
 		}
+		if isCoordinatorProviderIdentityError(err) {
+			fmt.Fprintf(a.Stderr, "warning: prewarm %s failed; automatic release of %s blocked: %v\n", stage, leaseID, err)
+			return
+		}
 		fmt.Fprintf(a.Stderr, "warning: could not inspect lease %s before prewarm cleanup: %v; releasing by lease ID\n", leaseID, err)
-		lease = LeaseTarget{LeaseID: leaseID}
+		lease = LeaseTarget{LeaseID: leaseID, Server: Server{Provider: sshBackend.Spec().Name}}
 	}
 	fmt.Fprintf(a.Stderr, "prewarm cleanup: releasing id=%s after %s failure\n", leaseID, stage)
 	a.cleanupBackendLeaseConnectionsBestEffort(cleanupCtx, lease)

--- a/internal/cli/provider_coordinator.go
+++ b/internal/cli/provider_coordinator.go
@@ -28,6 +28,47 @@ type coordinatorLeaseBackend struct {
 	rt     Runtime
 }
 
+type coordinatorProviderIdentityError struct {
+	selectedProvider string
+	returnedProvider string
+	leaseID          string
+}
+
+func (e coordinatorProviderIdentityError) Error() string {
+	return fmt.Sprintf(
+		"coordinator lease provider identity mismatch: selected_provider=%s returned_provider=%s lease_id=%s",
+		blank(e.selectedProvider, "<empty>"),
+		blank(e.returnedProvider, "<empty>"),
+		blank(e.leaseID, "<empty>"),
+	)
+}
+
+func (e coordinatorProviderIdentityError) Unwrap() error {
+	return exit(4, "%s", e.Error())
+}
+
+func isCoordinatorProviderIdentityError(err error) bool {
+	var identityErr coordinatorProviderIdentityError
+	return errors.As(err, &identityErr)
+}
+
+func canonicalProviderName(name string) (string, error) {
+	provider, err := ProviderFor(strings.TrimSpace(name))
+	if err != nil {
+		return "", err
+	}
+	return provider.Name(), nil
+}
+
+func canonicalProvidersMatch(expected, actual string) bool {
+	expected, err := canonicalProviderName(expected)
+	if err != nil {
+		return false
+	}
+	actual, err = canonicalProviderName(actual)
+	return err == nil && actual == expected
+}
+
 func (b *coordinatorLeaseBackend) BeginRunFailureEvidence(ctx context.Context, req RunFailureEvidenceRequest) (RunFailureEvidenceCollector, error) {
 	capability, ok := b.direct.(SSHRunFailureEvidenceBackend)
 	if !ok {
@@ -55,29 +96,38 @@ func (b *coordinatorLeaseBackend) validateCoordinatorProviderIdentity(leaseID, r
 	if selectedProvider == "" {
 		selectedProvider = strings.TrimSpace(b.cfg.Provider)
 	}
+	return validateCoordinatorProviderIdentity(selectedProvider, leaseID, returnedProvider, true)
+}
+
+func validateCoordinatorProviderIdentity(selectedProvider, leaseID, returnedProvider string, allowEmptyReturned bool) error {
+	selectedProvider = strings.TrimSpace(selectedProvider)
 	returnedProvider = strings.TrimSpace(returnedProvider)
 	identityError := func() error {
-		return exit(
-			4,
-			"coordinator lease provider identity mismatch: selected_provider=%s returned_provider=%s lease_id=%s",
-			blank(selectedProvider, "<empty>"),
-			blank(returnedProvider, "<empty>"),
-			blank(strings.TrimSpace(leaseID), "<empty>"),
-		)
+		return coordinatorProviderIdentityError{
+			selectedProvider: selectedProvider,
+			returnedProvider: returnedProvider,
+			leaseID:          strings.TrimSpace(leaseID),
+		}
 	}
-	selected, err := ProviderFor(selectedProvider)
+	selectedProvider, err := canonicalProviderName(selectedProvider)
 	if err != nil {
 		return identityError()
 	}
-	selectedProvider = selected.Name()
-	if returnedProvider == "" {
+	if returnedProvider == "" && allowEmptyReturned {
 		return nil
 	}
-	provider, err := ProviderFor(returnedProvider)
-	if err == nil && provider.Name() == selectedProvider {
+	if canonicalProvidersMatch(selectedProvider, returnedProvider) {
 		return nil
 	}
 	return identityError()
+}
+
+func (b *coordinatorLeaseBackend) expectedProvider() (string, error) {
+	selectedProvider := strings.TrimSpace(b.spec.Name)
+	if selectedProvider == "" {
+		selectedProvider = strings.TrimSpace(b.cfg.Provider)
+	}
+	return canonicalProviderName(selectedProvider)
 }
 
 func (b *coordinatorLeaseBackend) coordinatorLeaseTarget(lease CoordinatorLease, coord *CoordinatorClient) (LeaseTarget, error) {
@@ -170,17 +220,6 @@ func (b *coordinatorLeaseBackend) acquireOnceWithLeaseID(ctx context.Context, ke
 		}
 		return LeaseTarget{}, err
 	}
-	if requestedLeaseID != "" && lease.ID != leaseID {
-		return LeaseTarget{}, exit(4, "lease_id_conflict: coordinator fixed create returned lease %s for operation %s", blank(lease.ID, "<empty>"), leaseID)
-	}
-	if err := b.validateCoordinatorLeaseProviderIdentity(lease); err != nil {
-		if requestedLeaseID == "" {
-			if releaseErr := releaseCoordinatorLease(context.Background(), b.coord, blank(lease.ID, leaseID)); releaseErr != nil {
-				fmt.Fprintf(b.rt.Stderr, "warning: release failed after provider identity mismatch for %s: %v\n", blank(lease.ID, leaseID), releaseErr)
-			}
-		}
-		return LeaseTarget{}, err
-	}
 	if lease.ID != "" && lease.ID != leaseID {
 		if err := moveStoredTestboxKey(leaseID, lease.ID); err != nil {
 			fmt.Fprintf(b.rt.Stderr, "warning: could not move local key from %s to %s: %v\n", leaseID, lease.ID, err)
@@ -188,7 +227,7 @@ func (b *coordinatorLeaseBackend) acquireOnceWithLeaseID(ctx context.Context, ke
 	}
 	if err := validateCoordinatorLeaseCapabilities(cfg, lease); err != nil {
 		if requestedLeaseID == "" {
-			if releaseErr := releaseCoordinatorLease(context.Background(), b.coord, blank(lease.ID, leaseID)); releaseErr != nil {
+			if releaseErr := releaseCoordinatorLease(context.Background(), b.coord, blank(lease.ID, leaseID), cfg.Provider); releaseErr != nil {
 				fmt.Fprintf(b.rt.Stderr, "warning: release failed after capability mismatch for %s: %v\n", blank(lease.ID, leaseID), releaseErr)
 			}
 		}
@@ -205,14 +244,17 @@ func (b *coordinatorLeaseBackend) acquireOnceWithLeaseID(ctx context.Context, ke
 	}
 	waitCtx, cancelWait := context.WithCancelCause(ctx)
 	defer cancelWait(nil)
-	stopHeartbeat := startCoordinatorHeartbeat(waitCtx, b.coord, leaseID, cfg.IdleTimeout, nil, leaseTelemetryCollectorForTarget(target), b.rt.Stderr)
+	stopHeartbeat, err := startCoordinatorHeartbeat(waitCtx, b.coord, leaseID, cfg.Provider, cfg.IdleTimeout, nil, leaseTelemetryCollectorForTarget(target), b.rt.Stderr)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
 	defer stopHeartbeat()
 	stopLeaseWatch := startCoordinatorLeaseWatch(waitCtx, b.coord, leaseID, cancelWait, b.rt.Stderr)
 	defer stopLeaseWatch()
 	bootstrapTarget := bootstrapNetworkTarget(cfg, server, target)
 	if err := bootstrapManagedWindowsDesktop(waitCtx, cfg, &bootstrapTarget, publicKey, b.rt.Stderr); err != nil {
 		if requestedLeaseID == "" {
-			if releaseErr := releaseCoordinatorLease(context.Background(), b.coord, leaseID); releaseErr != nil {
+			if releaseErr := releaseCoordinatorLease(context.Background(), b.coord, leaseID, cfg.Provider); releaseErr != nil {
 				fmt.Fprintf(b.rt.Stderr, "warning: release failed after bootstrap error for %s: %v\n", leaseID, releaseErr)
 			}
 		}
@@ -262,11 +304,16 @@ func (b *coordinatorLeaseBackend) createCoordinatorLeaseWithProgress(ctx context
 	return b.createCoordinatorLeaseWithProgressMode(ctx, cfg, publicKey, keep, leaseID, slug, false)
 }
 
-func (b *coordinatorLeaseBackend) createCoordinatorLeaseWithProgressMode(ctx context.Context, cfg Config, publicKey string, keep bool, leaseID, slug string, fixed bool) (CoordinatorLease, error) {
+func (b *coordinatorLeaseBackend) createCoordinatorLeaseWithProgressMode(ctx context.Context, cfg Config, publicKey string, keep bool, leaseID, slug string, fixed bool) (lease CoordinatorLease, err error) {
 	createAttemptID := ""
 	if !fixed {
 		createAttemptID = coordinatorCreateAttemptID()
 	}
+	defer func() {
+		if err == nil {
+			lease, err = b.validateCoordinatorLeaseCreateResult(ctx, lease, leaseID, slug, createAttemptID, fixed)
+		}
+	}()
 	timeout := coordinatorCreateLeaseTimeoutForConfig(cfg)
 	createCtx, cancelCreate := context.WithTimeout(ctx, timeout)
 	defer cancelCreate()
@@ -299,8 +346,8 @@ func (b *coordinatorLeaseBackend) createCoordinatorLeaseWithProgressMode(ctx con
 			}
 			if result.err != nil && errors.Is(result.err, context.DeadlineExceeded) && ctx.Err() == nil {
 				err := coordinatorCreateLeaseTimeoutError(cfg, leaseID, slug, timeout)
-				if lease, ok := b.recoverCoordinatorLeaseAfterCreateError(ctx, cfg, publicKey, keep, leaseID, slug, createAttemptID, err); ok {
-					return lease, nil
+				if lease, recoverErr, handled := b.recoverCoordinatorLeaseAfterCreateError(ctx, cfg, publicKey, keep, leaseID, slug, createAttemptID, err); handled {
+					return lease, recoverErr
 				}
 				if ctx.Err() != nil {
 					return CoordinatorLease{}, b.canceledCoordinatorLeaseCreateError(ctx, leaseID, slug, createAttemptID, false, result.err)
@@ -308,8 +355,8 @@ func (b *coordinatorLeaseBackend) createCoordinatorLeaseWithProgressMode(ctx con
 				return CoordinatorLease{}, b.abandonUnrecoveredCoordinatorLeaseCreate(ctx, leaseID, slug, createAttemptID, err)
 			}
 			if result.err != nil {
-				if lease, ok := b.recoverCoordinatorLeaseAfterCreateError(ctx, cfg, publicKey, keep, leaseID, slug, createAttemptID, result.err); ok {
-					return lease, nil
+				if lease, recoverErr, handled := b.recoverCoordinatorLeaseAfterCreateError(ctx, cfg, publicKey, keep, leaseID, slug, createAttemptID, result.err); handled {
+					return lease, recoverErr
 				}
 				if ctx.Err() != nil {
 					return CoordinatorLease{}, b.canceledCoordinatorLeaseCreateError(ctx, leaseID, slug, createAttemptID, false, result.err)
@@ -349,8 +396,8 @@ func (b *coordinatorLeaseBackend) createCoordinatorLeaseWithProgressMode(ctx con
 				}
 				return CoordinatorLease{}, err
 			}
-			if lease, ok := b.recoverCoordinatorLeaseAfterCreateError(ctx, cfg, publicKey, keep, leaseID, slug, createAttemptID, err); ok {
-				return lease, nil
+			if lease, recoverErr, handled := b.recoverCoordinatorLeaseAfterCreateError(ctx, cfg, publicKey, keep, leaseID, slug, createAttemptID, err); handled {
+				return lease, recoverErr
 			}
 			if ctx.Err() != nil {
 				return CoordinatorLease{}, b.canceledCoordinatorLeaseCreateError(ctx, leaseID, slug, createAttemptID, false, nil)
@@ -366,6 +413,30 @@ func (b *coordinatorLeaseBackend) createCoordinatorLeaseWithProgressMode(ctx con
 			return CoordinatorLease{}, b.canceledCoordinatorLeaseCreateError(ctx, leaseID, slug, createAttemptID, fixed, createErr)
 		}
 	}
+}
+
+func (b *coordinatorLeaseBackend) validateCoordinatorLeaseCreateResult(
+	ctx context.Context,
+	lease CoordinatorLease,
+	requestedLeaseID, slug, createAttemptID string,
+	fixed bool,
+) (CoordinatorLease, error) {
+	if fixed && lease.ID != requestedLeaseID {
+		return CoordinatorLease{}, exit(4, "lease_id_conflict: coordinator fixed create returned lease %s for operation %s", blank(lease.ID, "<empty>"), requestedLeaseID)
+	}
+	if err := b.validateCoordinatorLeaseProviderIdentity(lease); err != nil {
+		if fixed {
+			return CoordinatorLease{}, err
+		}
+		cancelCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), coordinatorCanceledCreateRecoveryTimeout)
+		defer cancel()
+		fmt.Fprintf(b.rt.Stderr, "warning: coordinator create returned mismatched provider for %s; recording durable cancellation\n", requestedLeaseID)
+		if cancelErr := b.cancelCoordinatorLeaseCreate(cancelCtx, requestedLeaseID, slug, createAttemptID); cancelErr != nil {
+			return CoordinatorLease{}, errors.Join(err, fmt.Errorf("cancel mismatched coordinator lease create %s: %w", requestedLeaseID, cancelErr))
+		}
+		return CoordinatorLease{}, err
+	}
+	return lease, nil
 }
 
 func (b *coordinatorLeaseBackend) canceledCoordinatorLeaseCreateError(ctx context.Context, leaseID, slug, createAttemptID string, fixed bool, createErr error) error {
@@ -508,9 +579,9 @@ func (b *coordinatorLeaseBackend) waitForCoordinatorLeaseActivation(ctx context.
 	}
 }
 
-func (b *coordinatorLeaseBackend) recoverCoordinatorLeaseAfterCreateError(ctx context.Context, cfg Config, publicKey string, keep bool, leaseID, slug, createAttemptID string, createErr error) (CoordinatorLease, bool) {
+func (b *coordinatorLeaseBackend) recoverCoordinatorLeaseAfterCreateError(ctx context.Context, cfg Config, publicKey string, keep bool, leaseID, slug, createAttemptID string, createErr error) (CoordinatorLease, error, bool) {
 	if !coordinatorCreateLeaseErrorMayHaveCommitted(createErr) {
-		return CoordinatorLease{}, false
+		return CoordinatorLease{}, nil, false
 	}
 	recoverCtx, cancel := context.WithTimeout(ctx, coordinatorCreateLeaseRecoveryTimeout)
 	defer cancel()
@@ -520,28 +591,36 @@ func (b *coordinatorLeaseBackend) recoverCoordinatorLeaseAfterCreateError(ctx co
 	for {
 		lease, err := b.coord.CreateLeaseWithAttempt(recoverCtx, cfg, publicKey, keep, leaseID, slug, createAttemptID)
 		if err == nil {
+			lease, identityErr := b.validateCoordinatorLeaseCreateResult(recoverCtx, lease, leaseID, slug, createAttemptID, false)
+			if identityErr != nil {
+				return CoordinatorLease{}, identityErr, true
+			}
 			if coordinatorLeaseRecoveredFromCreateError(cfg, lease) {
 				fmt.Fprintf(b.rt.Stderr, "recovered coordinator lease %s slug=%s with token-bound POST after uncertain response\n", lease.ID, blank(lease.Slug, slug))
-				return lease, true
+				return lease, nil, true
 			}
 			if lease.State == "provisioning" {
 				active, waitErr := b.waitForCoordinatorLeaseActivation(recoverCtx, blank(lease.ID, leaseID), lease)
 				if waitErr == nil {
+					active, identityErr = b.validateCoordinatorLeaseCreateResult(recoverCtx, active, leaseID, slug, createAttemptID, false)
+					if identityErr != nil {
+						return CoordinatorLease{}, identityErr, true
+					}
 					fmt.Fprintf(b.rt.Stderr, "recovered coordinator lease %s slug=%s with token-bound POST after uncertain response\n", active.ID, blank(active.Slug, slug))
-					return active, true
+					return active, nil, true
 				}
-				return CoordinatorLease{}, false
+				return CoordinatorLease{}, nil, false
 			}
 			if lease.State == "failed" || lease.State == "released" || lease.State == "expired" {
-				return CoordinatorLease{}, false
+				return CoordinatorLease{}, nil, false
 			}
 		} else if !coordinatorCreateLeaseErrorMayHaveCommitted(err) {
-			return CoordinatorLease{}, false
+			return CoordinatorLease{}, nil, false
 		}
 		select {
 		case <-ticker.C:
 		case <-recoverCtx.Done():
-			return CoordinatorLease{}, false
+			return CoordinatorLease{}, nil, false
 		}
 	}
 }
@@ -564,7 +643,7 @@ func coordinatorLeaseRecoveredFromCreateError(cfg Config, lease CoordinatorLease
 	if lease.ID == "" || lease.State != "active" || lease.Host == "" {
 		return false
 	}
-	if lease.Provider != "" && !strings.EqualFold(lease.Provider, cfg.Provider) {
+	if lease.Provider != "" && !canonicalProvidersMatch(cfg.Provider, lease.Provider) {
 		return false
 	}
 	if lease.TargetOS != "" && cfg.TargetOS != "" && !strings.EqualFold(lease.TargetOS, cfg.TargetOS) {
@@ -779,7 +858,7 @@ func filterCoordinatorLeasesForProvider(leases []CoordinatorLease, provider stri
 	}
 	out := make([]CoordinatorLease, 0, len(leases))
 	for _, lease := range leases {
-		if strings.EqualFold(strings.TrimSpace(lease.Provider), provider) {
+		if canonicalProvidersMatch(provider, lease.Provider) {
 			out = append(out, lease)
 		}
 	}
@@ -804,16 +883,20 @@ func (b *coordinatorLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseL
 	if req.Lease.LeaseID == "" {
 		return exit(2, "missing coordinator lease id")
 	}
-	if err := b.validateCoordinatorLeaseTargetProviderIdentity(req.Lease); err != nil {
+	expectedProvider, err := b.expectedProvider()
+	if err != nil {
 		return err
 	}
-	if err := releaseCoordinatorLease(ctx, b.coord, req.Lease.LeaseID); err != nil {
+	if err := validateCoordinatorProviderIdentity(expectedProvider, req.Lease.LeaseID, req.Lease.Server.Provider, false); err != nil {
+		return err
+	}
+	if err := releaseCoordinatorLease(ctx, b.coord, req.Lease.LeaseID, expectedProvider); err != nil {
 		if b.cfg.CoordAdminToken != "" && (isCoordinatorNotFoundError(err) || isCoordinatorUnauthorized(err)) {
 			adminCoord, adminErr := b.adminCoordinatorClient()
 			if adminErr != nil {
 				return err
 			}
-			if _, adminErr = adminCoord.AdminReleaseLease(ctx, req.Lease.LeaseID, true); adminErr == nil {
+			if _, adminErr = adminCoord.AdminReleaseLeaseForProvider(ctx, req.Lease.LeaseID, true, expectedProvider); adminErr == nil {
 				removeLeaseClaim(req.Lease.LeaseID)
 				return nil
 			}
@@ -833,10 +916,14 @@ func (b *coordinatorLeaseBackend) adminCoordinatorClient() (*CoordinatorClient, 
 }
 
 func (b *coordinatorLeaseBackend) Touch(ctx context.Context, req TouchRequest) (Server, error) {
-	if err := b.validateCoordinatorLeaseTargetProviderIdentity(req.Lease); err != nil {
+	expectedProvider, err := b.expectedProvider()
+	if err != nil {
 		return req.Lease.Server, err
 	}
-	lease, err := b.coord.TouchLease(ctx, req.Lease.LeaseID)
+	if err := validateCoordinatorProviderIdentity(expectedProvider, req.Lease.LeaseID, req.Lease.Server.Provider, false); err != nil {
+		return req.Lease.Server, err
+	}
+	lease, err := b.coord.TouchLeaseForProvider(ctx, req.Lease.LeaseID, expectedProvider)
 	if err != nil {
 		return req.Lease.Server, err
 	}

--- a/internal/cli/provider_coordinator.go
+++ b/internal/cli/provider_coordinator.go
@@ -87,10 +87,6 @@ func (b *coordinatorLeaseBackend) validateCoordinatorLeaseProviderIdentity(lease
 	return b.validateCoordinatorProviderIdentity(lease.ID, lease.Provider)
 }
 
-func (b *coordinatorLeaseBackend) validateCoordinatorLeaseTargetProviderIdentity(lease LeaseTarget) error {
-	return b.validateCoordinatorProviderIdentity(lease.LeaseID, lease.Server.Provider)
-}
-
 func (b *coordinatorLeaseBackend) validateCoordinatorProviderIdentity(leaseID, returnedProvider string) error {
 	selectedProvider := strings.TrimSpace(b.spec.Name)
 	if selectedProvider == "" {

--- a/internal/cli/provider_coordinator_test.go
+++ b/internal/cli/provider_coordinator_test.go
@@ -1627,6 +1627,45 @@ func TestCoordinatorProviderIdentityValidationCanonicalizesAliases(t *testing.T)
 	}
 }
 
+func TestCoordinatorCreateRecoveryCanonicalProviderMatching(t *testing.T) {
+	cfg := Config{Provider: "gcp", TargetOS: targetLinux}
+	base := CoordinatorLease{ID: "cbx_recovered", State: "active", Host: "203.0.113.10", TargetOS: targetLinux}
+	for _, test := range []struct {
+		name     string
+		provider string
+		want     bool
+	}{
+		{name: "canonical", provider: "gcp", want: true},
+		{name: "alias", provider: "google-cloud", want: true},
+		{name: "legacy empty", provider: "", want: true},
+		{name: "cross provider", provider: "aws"},
+		{name: "distinct azure route", provider: "azure-dynamic-sessions"},
+		{name: "unknown", provider: "future-cloud"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			lease := base
+			lease.Provider = test.provider
+			if got := coordinatorLeaseRecoveredFromCreateError(cfg, lease); got != test.want {
+				t.Fatalf("recovered=%t want %t for provider=%q", got, test.want, test.provider)
+			}
+		})
+	}
+}
+
+func TestCoordinatorListCanonicalProviderMatching(t *testing.T) {
+	leases := []CoordinatorLease{
+		{ID: "canonical", Provider: "gcp"},
+		{ID: "alias", Provider: "google-cloud"},
+		{ID: "cross", Provider: "aws"},
+		{ID: "empty"},
+		{ID: "unknown", Provider: "future-cloud"},
+	}
+	filtered := filterCoordinatorLeasesForProvider(leases, "gcp")
+	if len(filtered) != 2 || filtered[0].ID != "canonical" || filtered[1].ID != "alias" {
+		t.Fatalf("filtered leases=%#v", filtered)
+	}
+}
+
 func TestCoordinatorResolveEnforcesSelectedProviderIdentity(t *testing.T) {
 	for _, test := range []struct {
 		name             string
@@ -1757,36 +1796,114 @@ func TestCoordinatorReleaseRejectsInputProviderMismatchBeforeRequest(t *testing.
 	defer server.Close()
 
 	backend := newCoordinatorIdentityTestBackend(t, server.URL, "admin-token")
-	err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{
-		LeaseID: "cbx_release_identity",
-		Server:  Server{Provider: "external"},
-	}})
-	assertCoordinatorProviderIdentityError(t, err, "external", "cbx_release_identity")
+	for _, provider := range []string{"", "external"} {
+		err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{
+			LeaseID: "cbx_release_identity",
+			Server:  Server{Provider: provider},
+		}})
+		assertCoordinatorProviderIdentityError(t, err, provider, "cbx_release_identity")
+	}
 	if requests != 0 {
 		t.Fatalf("release mismatch sent %d coordinator request(s), want zero", requests)
 	}
 }
 
+func TestStopCoordinatorProviderMismatchDoesNotRelease(t *testing.T) {
+	clearConfigEnv(t)
+	isolateTestUserDirs(t)
+	releases := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/leases/cbx_stop_identity":
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
+				ID: "cbx_stop_identity", Provider: "external", State: "active",
+			}})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/leases/cbx_stop_identity/release":
+			releases++
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{ID: "cbx_stop_identity", State: "released"}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	t.Setenv("CRABBOX_COORDINATOR", server.URL)
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "user-token")
+
+	err := (App{Stdout: io.Discard, Stderr: io.Discard}).stop(context.Background(), []string{
+		"--provider", "aws", "--id", "cbx_stop_identity",
+	})
+	assertCoordinatorProviderIdentityError(t, err, "external", "cbx_stop_identity")
+	if releases != 0 {
+		t.Fatalf("release requests=%d want zero", releases)
+	}
+}
+
+func TestStopCoordinatorInspectFailureKeepsProviderBinding(t *testing.T) {
+	clearConfigEnv(t)
+	isolateTestUserDirs(t)
+	var releaseBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/leases/cbx_stop_fallback":
+			http.Error(w, `{"error":"inspect_failed"}`, http.StatusInternalServerError)
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/leases/cbx_stop_fallback/release":
+			if err := json.NewDecoder(r.Body).Decode(&releaseBody); err != nil {
+				t.Fatal(err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
+				ID: "cbx_stop_fallback", Provider: "aws", State: "released",
+			}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	t.Setenv("CRABBOX_COORDINATOR", server.URL)
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "user-token")
+
+	if err := (App{Stdout: io.Discard, Stderr: io.Discard}).stop(context.Background(), []string{
+		"--provider", "aws", "--id", "cbx_stop_fallback",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if releaseBody["expectedProvider"] != "aws" {
+		t.Fatalf("release body=%#v, want expectedProvider=aws", releaseBody)
+	}
+}
+
 func TestCoordinatorAcquireProviderMismatchCleanupPolicy(t *testing.T) {
 	for _, test := range []struct {
-		name      string
-		fixed     bool
-		wantLease string
-		wantPath  string
-		wantPut   bool
-		wantDrops int
+		name        string
+		fixed       bool
+		wantLease   string
+		wantPath    string
+		wantPut     bool
+		wantCancels int
 	}{
-		{name: "new non-fixed lease rolls back", wantLease: "cbx_created_identity", wantPath: "/v1/leases", wantDrops: 1},
+		{name: "new non-fixed lease cancels requested create", wantLease: "cbx_created_identity", wantPath: "/v1/leases", wantCancels: 1},
 		{name: "fixed lease is retained", fixed: true, wantLease: "cbx_fixed_identity", wantPath: "/v1/leases/cbx_fixed_identity", wantPut: true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			isolateTestUserDirs(t)
 			releases := 0
+			cancellations := 0
+			var capturedRequestedID, createAttemptID string
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				switch {
 				case r.URL.Path == test.wantPath && ((!test.wantPut && r.Method == http.MethodPost) || (test.wantPut && r.Method == http.MethodPut)):
+					var body map[string]any
+					if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+						t.Fatal(err)
+					}
+					capturedRequestedID, _ = body["leaseID"].(string)
+					createAttemptID, _ = body["createAttemptID"].(string)
 					_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
 						ID: test.wantLease, Provider: "external", TargetOS: targetLinux, State: "active",
+					}})
+				case r.Method == http.MethodPost && r.URL.Path == "/v1/leases/"+capturedRequestedID+"/cancel-create":
+					cancellations++
+					_ = json.NewEncoder(w).Encode(map[string]any{"canceledCreate": CoordinatorCanceledCreateAttestation{
+						Version: 1, RequestedLeaseID: capturedRequestedID, CreateAttemptID: createAttemptID, State: "canceled",
 					}})
 				case r.Method == http.MethodPost && r.URL.Path == "/v1/leases/"+test.wantLease+"/release":
 					releases++
@@ -1799,14 +1916,17 @@ func TestCoordinatorAcquireProviderMismatchCleanupPolicy(t *testing.T) {
 
 			backend := newCoordinatorIdentityTestBackend(t, server.URL, "")
 			backend.cfg.AWSSSHCIDRs = []string{"0.0.0.0/0"}
-			requestedID := ""
+			operationID := ""
 			if test.fixed {
-				requestedID = test.wantLease
+				operationID = test.wantLease
 			}
-			_, err := backend.acquireOnceWithLeaseID(context.Background(), false, requestedID, "identity-fence")
+			_, err := backend.acquireOnceWithLeaseID(context.Background(), false, operationID, "identity-fence")
 			assertCoordinatorProviderIdentityError(t, err, "external", test.wantLease)
-			if releases != test.wantDrops {
-				t.Fatalf("release requests=%d want %d", releases, test.wantDrops)
+			if cancellations != test.wantCancels {
+				t.Fatalf("cancel-create requests=%d want %d", cancellations, test.wantCancels)
+			}
+			if releases != 0 {
+				t.Fatalf("release requests=%d want zero", releases)
 			}
 		})
 	}
@@ -1892,6 +2012,9 @@ func newCoordinatorIdentityTestBackend(t *testing.T, serverURL, adminToken strin
 
 func assertCoordinatorProviderIdentityError(t *testing.T, err error, returnedProvider, leaseID string) {
 	t.Helper()
+	if !isCoordinatorProviderIdentityError(err) {
+		t.Fatalf("error=%v, want typed coordinator provider identity error", err)
+	}
 	var exitErr ExitError
 	if !AsExitError(err, &exitErr) || exitErr.Code != 4 {
 		t.Fatalf("error=%v, want exit 4 provider identity mismatch", err)
@@ -1910,11 +2033,19 @@ func assertCoordinatorProviderIdentityError(t *testing.T, err error, returnedPro
 func TestCoordinatorReleaseFallsBackToAdminToken(t *testing.T) {
 	isolateTestUserDirs(t)
 	adminReleased := false
+	var payloads []map[string]any
+	var paths []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost || r.URL.Path != "/v1/admin/leases/cbx_admin/release" && r.URL.Path != "/v1/leases/cbx_admin/release" {
 			http.NotFound(w, r)
 			return
 		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		payloads = append(payloads, body)
+		paths = append(paths, r.URL.Path)
 		switch r.Header.Get("Authorization") {
 		case "Bearer user-token":
 			http.Error(w, `{"error":"not_found"}`, http.StatusNotFound)
@@ -1943,12 +2074,22 @@ func TestCoordinatorReleaseFallsBackToAdminToken(t *testing.T) {
 	}
 	backend := &coordinatorLeaseBackend{cfg: cfg, coord: coord, rt: Runtime{Stderr: &bytes.Buffer{}}}
 
-	err = backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: "cbx_admin"}})
+	err = backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{
+		LeaseID: "cbx_admin", Server: Server{Provider: "aws"},
+	}})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !adminReleased {
 		t.Fatal("admin release was not called")
+	}
+	if len(payloads) != 6 || paths[len(paths)-1] != "/v1/admin/leases/cbx_admin/release" {
+		t.Fatalf("release paths=%#v payloads=%#v", paths, payloads)
+	}
+	for i, payload := range payloads {
+		if payload["expectedProvider"] != "aws" {
+			t.Fatalf("release payload %d=%#v, want expectedProvider=aws", i, payload)
+		}
 	}
 }
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1002,29 +1002,39 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		stopHeartbeat = nil
 	}
 	defer stopRunHeartbeat()
-	startRunHeartbeat := func(updateIdleTimeout *time.Duration) {
+	startRunHeartbeat := func(updateIdleTimeout *time.Duration) error {
 		stopRunHeartbeat()
 		heartbeatCoord := coord
 		if heartbeatCoord == nil {
 			heartbeatCoord = registrationCoord
 		}
 		if heartbeatCoord != nil {
-			stopHeartbeat = startCoordinatorHeartbeat(ctx, heartbeatCoord, leaseID, cfg.IdleTimeout, updateIdleTimeout, leaseTelemetryCollectorForTarget(target), a.Stderr)
+			var err error
+			stopHeartbeat, err = startCoordinatorHeartbeat(ctx, heartbeatCoord, leaseID, cfg.Provider, cfg.IdleTimeout, updateIdleTimeout, leaseTelemetryCollectorForTarget(target), a.Stderr)
+			return err
 		}
+		return nil
 	}
 	if useCoordinator && leaseID != "" {
 		var heartbeatIdleTimeout *time.Duration
 		if *leaseIDFlag != "" && flagWasSet(fs, "idle-timeout") {
 			heartbeatIdleTimeout = &cfg.IdleTimeout
-			if lease, err := coord.UpdateLeaseIdleTimeout(ctx, leaseID, *heartbeatIdleTimeout); err == nil {
+			if lease, err := coord.UpdateLeaseIdleTimeoutForProvider(ctx, leaseID, cfg.Provider, *heartbeatIdleTimeout); err == nil {
+				if identityErr := validateCoordinatorProviderIdentity(cfg.Provider, lease.ID, lease.Provider, true); identityErr != nil {
+					return recordFailure(identityErr)
+				}
 				fmt.Fprintf(a.Stderr, "updated idle_timeout=%s expires=%s\n", cfg.IdleTimeout, blank(lease.ExpiresAt, "-"))
 			} else {
 				return recordFailure(err)
 			}
 		}
-		startRunHeartbeat(heartbeatIdleTimeout)
+		if err := startRunHeartbeat(heartbeatIdleTimeout); err != nil {
+			return recordFailure(err)
+		}
 	} else if registrationCoord != nil && leaseID != "" {
-		startRunHeartbeat(nil)
+		if err := startRunHeartbeat(nil); err != nil {
+			return recordFailure(err)
+		}
 	}
 	if shouldAcquireWorkspaceOwner(acquired, sshBackend) {
 		target = bootstrapNetworkTarget(cfg, server, target)
@@ -3135,11 +3145,11 @@ func shouldReplaceLeaseAfterBeforeCommandSSHFailure(err error, acquired, useCoor
 	return shouldReleaseRunLease(acquired, keep, keepOnFailure, stopAfter, err)
 }
 
-func releaseCoordinatorLease(ctx context.Context, coord *CoordinatorClient, leaseID string) error {
+func releaseCoordinatorLease(ctx context.Context, coord *CoordinatorClient, leaseID, expectedProvider string) error {
 	var lastErr error
 	for attempt := 1; attempt <= 5; attempt++ {
 		releaseCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
-		_, err := coord.ReleaseLease(releaseCtx, leaseID, true)
+		_, err := coord.ReleaseLeaseForProvider(releaseCtx, leaseID, true, expectedProvider)
 		cancel()
 		if err == nil {
 			return nil
@@ -3245,7 +3255,11 @@ func (a App) releaseBackendLease(ctx context.Context, backend SSHLeaseBackend, c
 	return nil
 }
 
-func startCoordinatorHeartbeat(ctx context.Context, coord *CoordinatorClient, leaseID string, idleTimeout time.Duration, updateIdleTimeout *time.Duration, telemetryCollector leaseTelemetryCollector, stderr io.Writer) func() {
+func startCoordinatorHeartbeat(ctx context.Context, coord *CoordinatorClient, leaseID, expectedProvider string, idleTimeout time.Duration, updateIdleTimeout *time.Duration, telemetryCollector leaseTelemetryCollector, stderr io.Writer) (func(), error) {
+	expectedProvider, err := canonicalProviderName(expectedProvider)
+	if err != nil {
+		return nil, err
+	}
 	rootCtx, cancel := context.WithCancel(ctx)
 	interval := heartbeatInterval(idleTimeout)
 	done := make(chan struct{})
@@ -3271,7 +3285,7 @@ func startCoordinatorHeartbeat(ctx context.Context, coord *CoordinatorClient, le
 				control, _ = dialCoordinatorControl(callCtx, coord)
 			}
 			if control != nil {
-				err = control.heartbeat(callCtx, leaseID, idleTimeoutOverride, telemetry)
+				err = control.heartbeat(callCtx, leaseID, expectedProvider, idleTimeoutOverride, telemetry)
 				if err != nil {
 					control.close()
 					control = nil
@@ -3279,9 +3293,9 @@ func startCoordinatorHeartbeat(ctx context.Context, coord *CoordinatorClient, le
 			}
 			if control == nil {
 				if updateIdleTimeout != nil {
-					_, err = coord.UpdateLeaseIdleTimeoutWithTelemetry(callCtx, leaseID, *updateIdleTimeout, telemetry)
+					_, err = coord.UpdateLeaseIdleTimeoutWithTelemetryForProvider(callCtx, leaseID, expectedProvider, *updateIdleTimeout, telemetry)
 				} else {
-					_, err = coord.TouchLeaseWithTelemetry(callCtx, leaseID, telemetry)
+					_, err = coord.TouchLeaseWithTelemetryForProvider(callCtx, leaseID, expectedProvider, telemetry)
 				}
 			} else {
 				err = nil
@@ -3300,7 +3314,7 @@ func startCoordinatorHeartbeat(ctx context.Context, coord *CoordinatorClient, le
 	return func() {
 		cancel()
 		<-done
-	}
+	}, nil
 }
 
 var readyPoolBorrowHeartbeatInterval = 30 * time.Second
@@ -3644,8 +3658,11 @@ func (a App) stop(ctx context.Context, args []string) error {
 	})
 	if err != nil {
 		if backendCoordinator(backend) != nil {
+			if isCoordinatorProviderIdentityError(err) {
+				return err
+			}
 			fmt.Fprintf(a.Stderr, "warning: could not inspect lease before release: %v\n", err)
-			lease = LeaseTarget{LeaseID: *id}
+			lease = LeaseTarget{LeaseID: *id, Server: Server{Provider: backend.Spec().Name}}
 		} else {
 			return err
 		}

--- a/internal/cli/webvnc.go
+++ b/internal/cli/webvnc.go
@@ -389,6 +389,7 @@ func (a App) webvnc(ctx context.Context, args []string) error {
 	return serveWebVNCBridgePool(bridgeCtx, webVNCBridgePoolConfig{
 		Coord:              coord,
 		LeaseID:            leaseID,
+		ExpectedProvider:   cfg.Provider,
 		Host:               connHost,
 		Port:               connPort,
 		Credentials:        credentials,
@@ -493,6 +494,7 @@ func requireMacOSScreenSharingCredentials(credentials rfbCredentials) error {
 type webVNCBridgePoolConfig struct {
 	Coord              *CoordinatorClient
 	LeaseID            string
+	ExpectedProvider   string
 	Host               string
 	Port               string
 	Credentials        rfbCredentials
@@ -522,7 +524,10 @@ func serveWebVNCBridgePool(ctx context.Context, cfg webVNCBridgePoolConfig) erro
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	if !cfg.DisableHeartbeat && cfg.Coord != nil && strings.TrimSpace(cfg.LeaseID) != "" {
-		stopHeartbeat := startCoordinatorHeartbeat(ctx, cfg.Coord, cfg.LeaseID, cfg.IdleTimeout, nil, cfg.Telemetry, cfg.Log)
+		stopHeartbeat, err := startCoordinatorHeartbeat(ctx, cfg.Coord, cfg.LeaseID, cfg.ExpectedProvider, cfg.IdleTimeout, nil, cfg.Telemetry, cfg.Log)
+		if err != nil {
+			return err
+		}
 		defer stopHeartbeat()
 	}
 	events := make(chan webVNCBridgePoolEvent, cfg.PoolSize)

--- a/worker/src/coordinator-runtime.ts
+++ b/worker/src/coordinator-runtime.ts
@@ -12,6 +12,18 @@ export interface CoordinatorStorage {
 
 export type CoordinatorRequestQueue = "direct" | "lifecycle";
 
+export function controlMessageOwnsTransaction(message: unknown): boolean {
+  if (typeof message !== "string") {
+    return false;
+  }
+  try {
+    const input = JSON.parse(message) as { type?: unknown };
+    return input.type === "heartbeat";
+  } catch {
+    return false;
+  }
+}
+
 export function coordinatorRequestQueue(request: Request): CoordinatorRequestQueue {
   const url = new URL(request.url);
   const path = url.pathname.split("/").filter(Boolean);
@@ -89,7 +101,10 @@ export function coordinatorRequestQueue(request: Request): CoordinatorRequestQue
     path[1] === "leases" &&
     path[2] &&
     method === "POST" &&
-    (path[3] === "heartbeat" || path[3] === "release" || path[3] === "cancel-create")
+    (path[3] === "heartbeat" ||
+      path[3] === "tailscale" ||
+      path[3] === "release" ||
+      path[3] === "cancel-create")
   ) {
     return "direct";
   }
@@ -234,7 +249,7 @@ export class CloudflareCoordinatorRuntime implements CoordinatorRuntime {
     }
     socket.accept();
     socket.addEventListener("message", (event) => {
-      void this.runSocketOperation(attachment, () => handlers.message(event.data));
+      void this.runSocketOperation(attachment, event.data, () => handlers.message(event.data));
     });
     socket.addEventListener("close", (event) => {
       handlers.close(event.code, event.reason);
@@ -279,9 +294,13 @@ export class CloudflareCoordinatorRuntime implements CoordinatorRuntime {
     return this.state.storage.deleteAlarm();
   }
 
-  private runSocketOperation<T>(attachment: unknown, callback: () => Promise<T> | T): Promise<T> {
+  private runSocketOperation<T>(
+    attachment: unknown,
+    message: unknown,
+    callback: () => Promise<T> | T,
+  ): Promise<T> {
     const operation = async () => callback();
-    if (socketAttachmentKind(attachment) === "control") {
+    if (socketAttachmentKind(attachment) === "control" && !controlMessageOwnsTransaction(message)) {
       return this.runExclusive(operation);
     }
     return operation();

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -65,6 +65,7 @@ import {
 import {
   CloudflareCoordinatorRuntime,
   bufferCoordinatorRequestBody,
+  controlMessageOwnsTransaction,
   coordinatorRequestQueue,
   type CoordinatorRuntime,
 } from "./coordinator-runtime";
@@ -587,6 +588,7 @@ interface RuntimeAdapterDeleteDispatch {
 type RuntimeAdapterDeleteFinalization =
   | { status: "completed"; lease: LeaseRecord }
   | { status: "in-flight"; retryAt: string }
+  | { status: "provider-mismatch" }
   | { status: "mismatch" };
 
 interface RuntimeAdapterDeleteCompletion {
@@ -983,10 +985,15 @@ type ControlMessage =
   | {
       type: "heartbeat";
       leaseID?: string;
+      expectedProvider?: unknown;
       idleTimeoutSeconds?: number;
       telemetry?: Partial<LeaseTelemetry>;
     }
   | { type: "ping" };
+
+type ControlHeartbeatResult =
+  | { leaseID: string; ok: true; expiresAt: string }
+  | { leaseID: string; ok: false; error: string };
 
 interface WebVNCEvent {
   at: string;
@@ -2603,39 +2610,6 @@ export class FleetCoordinator {
     input: Extract<ControlMessage, { type: "heartbeat" }>,
   ): Promise<void> {
     const leaseID = typeof input.leaseID === "string" ? input.leaseID : "";
-    const lease = leaseID ? await this.resolveLeaseForControl(leaseID, attachment) : undefined;
-    if (!lease) {
-      sendControl(socket, { type: "heartbeat", leaseID, ok: false, error: "not_found" });
-      return;
-    }
-    if (lease.workspaceID) {
-      sendControl(socket, {
-        type: "heartbeat",
-        leaseID: lease.id,
-        ok: false,
-        error: "workspace_managed_lease",
-      });
-      return;
-    }
-    if (lease.cleanupStartedAt) {
-      sendControl(socket, {
-        type: "heartbeat",
-        leaseID: lease.id,
-        ok: false,
-        error: "cleanup_in_progress",
-      });
-      return;
-    }
-    const heartbeatError = leaseHeartbeatStateError(lease);
-    if (heartbeatError) {
-      sendControl(socket, {
-        type: "heartbeat",
-        leaseID: lease.id,
-        ok: false,
-        error: heartbeatError,
-      });
-      return;
-    }
     const heartbeat: { idleTimeoutSeconds?: number; telemetry?: Partial<LeaseTelemetry> } = {};
     if (input.idleTimeoutSeconds !== undefined) {
       heartbeat.idleTimeoutSeconds = input.idleTimeoutSeconds;
@@ -2643,13 +2617,29 @@ export class FleetCoordinator {
     if (input.telemetry !== undefined) {
       heartbeat.telemetry = input.telemetry;
     }
-    const updated = await this.applyLeaseHeartbeatState(lease, heartbeat);
-    sendControl(socket, {
-      type: "heartbeat",
-      leaseID: lease.id,
-      ok: true,
-      expiresAt: updated.expiresAt,
+    const result = await this.state.runExclusive<ControlHeartbeatResult>(async () => {
+      const lease = leaseID ? await this.resolveLeaseForControl(leaseID, attachment) : undefined;
+      if (!lease) {
+        return { leaseID, ok: false, error: "not_found" };
+      }
+      const providerError = mutationExpectedProviderErrorCode(input.expectedProvider, lease);
+      if (providerError) {
+        return { leaseID: lease.id, ok: false, error: providerError };
+      }
+      if (lease.workspaceID) {
+        return { leaseID: lease.id, ok: false, error: "workspace_managed_lease" };
+      }
+      if (lease.cleanupStartedAt) {
+        return { leaseID: lease.id, ok: false, error: "cleanup_in_progress" };
+      }
+      const heartbeatError = leaseHeartbeatStateError(lease);
+      if (heartbeatError) {
+        return { leaseID: lease.id, ok: false, error: heartbeatError };
+      }
+      const updated = await this.applyLeaseHeartbeatState(lease, heartbeat);
+      return { leaseID: lease.id, ok: true, expiresAt: updated.expiresAt };
     });
+    sendControl(socket, { type: "heartbeat", ...result });
   }
 
   private serializeBridgeAttachment(socket: WebSocket, attachment: BridgeAttachment): void {
@@ -6514,22 +6504,30 @@ export class FleetCoordinator {
       return this.heartbeatLease(request, leaseID);
     }
     if (method === "POST" && action === "tailscale") {
-      const admin = isAdminRequest(request);
-      const lease = await this.resolveLease(leaseID, request, admin);
-      if (!lease) {
-        return notFound();
-      }
-      if (!this.leaseManageableByRequest(lease, request, admin)) {
-        return json(
-          { error: "forbidden", message: "lease manage access required" },
-          { status: 403 },
-        );
-      }
-      const input = await readJson<Partial<TailscaleMetadata>>(request);
-      lease.tailscale = mergeTailscaleMetadata(lease.tailscale, input);
-      lease.updatedAt = new Date().toISOString();
-      await this.putLease(lease);
-      return json({ lease: this.leaseForRequest(lease, request, admin) });
+      const input = await readJson<Partial<TailscaleMetadata> & { expectedProvider?: unknown }>(
+        request,
+      );
+      return await this.state.runExclusive(async () => {
+        const admin = isAdminRequest(request);
+        const lease = await this.resolveLease(leaseID, request, admin);
+        if (!lease) {
+          return notFound();
+        }
+        if (!this.leaseManageableByRequest(lease, request, admin)) {
+          return json(
+            { error: "forbidden", message: "lease manage access required" },
+            { status: 403 },
+          );
+        }
+        const providerError = mutationExpectedProviderError(input.expectedProvider, lease);
+        if (providerError) {
+          return providerError;
+        }
+        lease.tailscale = mergeTailscaleMetadata(lease.tailscale, input);
+        lease.updatedAt = new Date().toISOString();
+        await this.putLease(lease);
+        return json({ lease: this.leaseForRequest(lease, request, admin) });
+      });
     }
     if (method === "POST" && action === "release") {
       return this.releaseLease(request, leaseID, false);
@@ -6823,6 +6821,7 @@ export class FleetCoordinator {
 
   private async heartbeatLease(request: Request, leaseID: string): Promise<Response> {
     const input = await optionalJson<{
+      expectedProvider?: unknown;
       idleTimeoutSeconds?: number;
       telemetry?: Partial<LeaseTelemetry>;
     }>(request);
@@ -6838,6 +6837,10 @@ export class FleetCoordinator {
           { error: "forbidden", message: "lease manage access required" },
           { status: 403 },
         );
+      }
+      const providerError = mutationExpectedProviderError(input.expectedProvider, lease);
+      if (providerError) {
+        return providerError;
       }
       if (lease.workspaceID) {
         return workspaceManagedLeaseResponse();
@@ -7052,6 +7055,12 @@ export class FleetCoordinator {
   }
 
   private async releaseLease(request: Request, leaseID: string, admin: boolean): Promise<Response> {
+    const body = await optionalJson<{
+      expectedProvider?: unknown;
+      delete?: boolean;
+      runtimeAdapterDeleteCompletion?: unknown;
+      runtimeAdapterLegacyDeleteCompletion?: unknown;
+    }>(request);
     const lease = await this.resolveLease(leaseID, request, admin);
     if (!lease) {
       return notFound();
@@ -7059,14 +7068,15 @@ export class FleetCoordinator {
     if (!this.leaseManageableByRequest(lease, request, admin)) {
       return json({ error: "forbidden", message: "lease manage access required" }, { status: 403 });
     }
+    const providerError = mutationExpectedProviderError(body.expectedProvider, lease);
+    if (providerError) {
+      return providerError;
+    }
+    const expectedProvider =
+      typeof body.expectedProvider === "string" ? body.expectedProvider : undefined;
     if (lease.workspaceID) {
       return workspaceManagedLeaseResponse();
     }
-    const body = await optionalJson<{
-      delete?: boolean;
-      runtimeAdapterDeleteCompletion?: unknown;
-      runtimeAdapterLegacyDeleteCompletion?: unknown;
-    }>(request);
     const runtimeAdapterCompletion = runtimeAdapterDeleteCompletion(
       body.runtimeAdapterDeleteCompletion,
     );
@@ -7114,6 +7124,7 @@ export class FleetCoordinator {
         lease,
         runtimeAdapterCompletion,
         admin,
+        expectedProvider,
       );
     }
     if (runtimeAdapterLegacyCompletion) {
@@ -7122,6 +7133,7 @@ export class FleetCoordinator {
         lease,
         runtimeAdapterLegacyCompletion,
         admin,
+        expectedProvider,
       );
     }
     if (
@@ -7140,7 +7152,7 @@ export class FleetCoordinator {
           { status: 409 },
         );
       }
-      return await this.deleteRegisteredRuntimeAdapterWorkspace(request, lease);
+      return await this.deleteRegisteredRuntimeAdapterWorkspace(request, lease, expectedProvider);
     }
     if (lease.runtimeAdapterDeleteRequestedAt) {
       return this.runtimeAdapterDeletePendingResponse(lease, request, admin);
@@ -7165,6 +7177,7 @@ export class FleetCoordinator {
       released = await this.releaseResolvedLease(lease, {
         deleteServer: shouldDelete,
         expectedLease: lease,
+        ...(expectedProvider ? { expectedProvider } : {}),
       });
     } catch (error) {
       if (error instanceof LeaseReleaseResolutionConflictError) {
@@ -7175,6 +7188,9 @@ export class FleetCoordinator {
           },
           { status: 409 },
         );
+      }
+      if (error instanceof LeaseProviderIdentityMismatchError) {
+        return providerIdentityMismatchResponse();
       }
       throw error;
     }
@@ -7199,6 +7215,7 @@ export class FleetCoordinator {
     lease: LeaseRecord,
     completion: RuntimeAdapterDeleteCompletion,
     admin: boolean,
+    expectedProvider?: string,
   ): Promise<Response> {
     if (
       !isRegisteredLease(lease) ||
@@ -7228,7 +7245,11 @@ export class FleetCoordinator {
       );
     }
     return await this.serializeRuntimeAdapterDelete(lease.id, async () => {
-      const result = await this.finalizeRuntimeAdapterDeleteCompletion(lease, completion);
+      const result = await this.finalizeRuntimeAdapterDeleteCompletion(
+        lease,
+        completion,
+        expectedProvider,
+      );
       if (result.status === "in-flight") {
         return runtimeAdapterDeleteInFlightResponse(result.retryAt);
       }
@@ -7243,6 +7264,9 @@ export class FleetCoordinator {
           { status: 409 },
         );
       }
+      if (result.status === "provider-mismatch") {
+        return providerIdentityMismatchResponse();
+      }
       return json({ lease: publicLeaseRecord(result.lease) });
     });
   }
@@ -7252,6 +7276,7 @@ export class FleetCoordinator {
     lease: LeaseRecord,
     completion: RuntimeAdapterLegacyDeleteCompletion,
     admin: boolean,
+    expectedProvider?: string,
   ): Promise<Response> {
     if (
       !isRegisteredLease(lease) ||
@@ -7281,7 +7306,11 @@ export class FleetCoordinator {
       );
     }
     return await this.serializeRuntimeAdapterDelete(lease.id, async () => {
-      const result = await this.finalizeLegacyRuntimeAdapterDelete(lease, completion);
+      const result = await this.finalizeLegacyRuntimeAdapterDelete(
+        lease,
+        completion,
+        expectedProvider,
+      );
       if (result.status === "in-flight") {
         return runtimeAdapterDeleteInFlightResponse(result.retryAt);
       }
@@ -7295,6 +7324,9 @@ export class FleetCoordinator {
           },
           { status: 409 },
         );
+      }
+      if (result.status === "provider-mismatch") {
+        return providerIdentityMismatchResponse();
       }
       return json({ lease: publicLeaseRecord(result.lease) });
     });
@@ -8242,6 +8274,7 @@ export class FleetCoordinator {
   private async deleteRegisteredRuntimeAdapterWorkspace(
     request: Request,
     lease: LeaseRecord,
+    expectedProvider?: string,
   ): Promise<Response> {
     const adapterID = lease.runtimeAdapterID;
     const workspaceID = lease.runtimeAdapterWorkspaceID;
@@ -8271,6 +8304,9 @@ export class FleetCoordinator {
           403,
         );
       }
+      if (expectedProvider && !mutationProvidersMatch(current.provider, expectedProvider)) {
+        return providerIdentityMismatchResponse();
+      }
       if (
         current.runtimeAdapterID !== adapterID ||
         current.runtimeAdapterWorkspaceID !== workspaceID ||
@@ -8283,10 +8319,19 @@ export class FleetCoordinator {
           409,
         );
       }
-      const deleteClaim = await this.markRuntimeAdapterDeletePending(
-        current,
-        runtimeAdapterDeleteInitialRetryMs,
-      );
+      let deleteClaim: RuntimeAdapterDeleteClaim | undefined;
+      try {
+        deleteClaim = await this.markRuntimeAdapterDeletePending(
+          current,
+          runtimeAdapterDeleteInitialRetryMs,
+          expectedProvider,
+        );
+      } catch (error) {
+        if (error instanceof LeaseProviderIdentityMismatchError) {
+          return providerIdentityMismatchResponse();
+        }
+        throw error;
+      }
       if (!deleteClaim) {
         return runtimeAdapterWorkspaceDeleteError(
           "runtime_adapter_lease_inactive",
@@ -8431,9 +8476,17 @@ export class FleetCoordinator {
   private async markRuntimeAdapterDeletePending(
     lease: LeaseRecord,
     retryDelay: number,
+    expectedProvider?: string,
   ): Promise<RuntimeAdapterDeleteClaim | undefined> {
     return await this.state.runExclusive(async () => {
       const current = await this.getLease(lease.id);
+      if (
+        current &&
+        expectedProvider &&
+        !mutationProvidersMatch(current.provider, expectedProvider)
+      ) {
+        throw new LeaseProviderIdentityMismatchError();
+      }
       if (
         !current ||
         !leaseIsLive(current) ||
@@ -8536,10 +8589,18 @@ export class FleetCoordinator {
   private async finalizeRuntimeAdapterDeleteCompletion(
     lease: LeaseRecord,
     completion: RuntimeAdapterDeleteCompletion,
+    expectedProvider?: string,
   ): Promise<RuntimeAdapterDeleteFinalization> {
     const result = await this.state.runExclusive(
       async (): Promise<RuntimeAdapterDeleteFinalization> => {
         const current = await this.getLease(lease.id);
+        if (
+          current &&
+          expectedProvider &&
+          !mutationProvidersMatch(current.provider, expectedProvider)
+        ) {
+          return { status: "provider-mismatch" };
+        }
         if (
           !current ||
           !isRegisteredLease(current) ||
@@ -8580,10 +8641,18 @@ export class FleetCoordinator {
   private async finalizeLegacyRuntimeAdapterDelete(
     lease: LeaseRecord,
     completion: RuntimeAdapterLegacyDeleteCompletion,
+    expectedProvider?: string,
   ): Promise<RuntimeAdapterDeleteFinalization> {
     const result = await this.state.runExclusive(
       async (): Promise<RuntimeAdapterDeleteFinalization> => {
         const current = await this.getLease(lease.id);
+        if (
+          current &&
+          expectedProvider &&
+          !mutationProvidersMatch(current.provider, expectedProvider)
+        ) {
+          return { status: "provider-mismatch" };
+        }
         if (
           !current ||
           !isRegisteredLease(current) ||
@@ -16165,6 +16234,7 @@ export class FleetCoordinator {
       awaitProviderCleanup?: boolean;
       expectedCreateAttempt?: CreateAttemptRecord;
       expectedLease?: LeaseRecord;
+      expectedProvider?: string;
     },
   ): Promise<LeaseRecord> {
     const current = (await this.getLease(lease.id)) ?? lease;
@@ -16236,10 +16306,18 @@ export class FleetCoordinator {
       awaitProviderCleanup?: boolean;
       expectedCreateAttempt?: CreateAttemptRecord;
       expectedLease?: LeaseRecord;
+      expectedProvider?: string;
     },
   ): Promise<LeaseRecord> {
     const preparation = await this.state.runExclusive(async () => {
       const stored = await this.getLease(lease.id);
+      if (
+        stored &&
+        options.expectedProvider &&
+        !mutationProvidersMatch(stored.provider, options.expectedProvider)
+      ) {
+        throw new LeaseProviderIdentityMismatchError();
+      }
       if (options.expectedCreateAttempt) {
         const currentAttempt = await this.getCreateAttempt(
           options.expectedCreateAttempt.requestedLeaseID,
@@ -16419,7 +16497,7 @@ export class FleetDurableObject extends FleetCoordinator implements DurableObjec
 
   override webSocketMessage(socket: WebSocket, message: string | ArrayBuffer): Promise<void> {
     const attachment = this.runtime.socketAttachment<{ kind?: string }>(socket);
-    if (attachment?.kind !== "control") {
+    if (attachment?.kind !== "control" || controlMessageOwnsTransaction(message)) {
       return super.webSocketMessage(socket, message);
     }
     return this.runtime.runExclusive(() => super.webSocketMessage(socket, message));
@@ -16443,6 +16521,8 @@ interface CreateAttemptRecord {
 class CreateAttemptConflictError extends Error {}
 
 class LeaseReleaseResolutionConflictError extends Error {}
+
+class LeaseProviderIdentityMismatchError extends Error {}
 
 class LeaseCleanupInProgressError extends Error {}
 
@@ -19785,6 +19865,63 @@ function sanitizeRegisteredPorts(value: unknown): string[] | undefined {
 function sanitizeRunnerProvider(value: unknown): string {
   const provider = nonSecretString(value).toLowerCase();
   return /^[a-z0-9][a-z0-9-]{1,63}$/.test(provider) ? provider : "";
+}
+
+function mutationExpectedProviderError(value: unknown, lease: LeaseRecord): Response | undefined {
+  const code = mutationExpectedProviderErrorCode(value, lease);
+  if (code === "invalid_expected_provider") {
+    return json(
+      {
+        error: code,
+        message: "expectedProvider must be a nonempty normalized provider",
+      },
+      { status: 400 },
+    );
+  }
+  if (code === "provider_identity_mismatch") {
+    return providerIdentityMismatchResponse();
+  }
+  return undefined;
+}
+
+function mutationExpectedProviderErrorCode(
+  value: unknown,
+  lease: LeaseRecord,
+): "invalid_expected_provider" | "provider_identity_mismatch" | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const expectedProvider = sanitizeRunnerProvider(value);
+  if (typeof value !== "string" || !expectedProvider || expectedProvider !== value) {
+    return "invalid_expected_provider";
+  }
+  return mutationProvidersMatch(lease.provider, expectedProvider)
+    ? undefined
+    : "provider_identity_mismatch";
+}
+
+function canonicalMutationProvider(value: unknown): string {
+  const provider = sanitizeRunnerProvider(value);
+  if (provider === "google" || provider === "google-cloud") {
+    return "gcp";
+  }
+  return provider;
+}
+
+function mutationProvidersMatch(stored: unknown, expected: unknown): boolean {
+  const storedProvider = canonicalMutationProvider(stored);
+  const expectedProvider = canonicalMutationProvider(expected);
+  return Boolean(storedProvider && expectedProvider && storedProvider === expectedProvider);
+}
+
+function providerIdentityMismatchResponse(): Response {
+  return json(
+    {
+      error: "provider_identity_mismatch",
+      message: "expectedProvider does not match the lease provider",
+    },
+    { status: 409 },
+  );
 }
 
 function sanitizeExternalRunner(

--- a/worker/test/coordinator-runtime.test.ts
+++ b/worker/test/coordinator-runtime.test.ts
@@ -557,6 +557,7 @@ describe("coordinator runtimes", () => {
       ["GET", "/v1/native-vnc/handoff"],
       ["GET", "/v1/leases/cbx_abcdef123456"],
       ["PUT", "/v1/leases/cbx_abcdef123456"],
+      ["POST", "/v1/leases/cbx_abcdef123456/tailscale"],
       ["GET", "/v1/adapters/applied-alice"],
       ["POST", "/v1/adapters/applied-alice/proxy/v1/workspaces"],
     ]) {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -108,11 +108,14 @@ class MemoryStorage {
   private readonly values = new Map<string, unknown>();
   private alarmTime: number | undefined;
   beforeGet?: (key: string) => Promise<void>;
+  afterGet?: (key: string, value: unknown) => Promise<void> | void;
   beforePut?: (key: string, value: unknown) => Promise<void>;
 
   async get<T>(key: string, _options?: { noCache?: boolean }): Promise<T | undefined> {
     await this.beforeGet?.(key);
-    return this.values.get(key) as T | undefined;
+    const value = this.values.get(key) as T | undefined;
+    await this.afterGet?.(key, value);
+    return value;
   }
 
   async put<T>(key: string, value: T, _options?: { noCache?: boolean }): Promise<void> {
@@ -14638,6 +14641,297 @@ describe("fleet lease identity and idle", () => {
     const tailscaleBody = (await manageTailscale.json()) as { lease: LeaseRecord };
     expect(tailscaleBody.lease.tailscale?.ipv4).toBe("100.64.0.10");
     expect(tailscaleBody.lease.tailscale?.state).toBe("ready");
+  });
+
+  it("atomically binds release mutations to an optional expected provider", async () => {
+    const storage = new MemoryStorage();
+    const deleted: string[] = [];
+    const fleet = testFleet(storage, {
+      aws: fakeProvider(undefined, { provider: "aws" }, async (id) => deleted.push(id)),
+    });
+    const headers = {
+      "x-crabbox-owner": "peter@example.com",
+      "x-crabbox-org": "openclaw",
+    };
+    const expiresAt = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    const managed = testLease({
+      id: "cbx_provider_bound_release",
+      provider: "aws",
+      cloudID: "i-provider-bound",
+      expiresAt,
+    });
+    storage.seed(`lease:${managed.id}`, managed);
+
+    const mismatched = await fleet.fetch(
+      request("POST", `/v1/leases/${managed.id}/release`, {
+        headers,
+        body: { delete: true, expectedProvider: "external" },
+      }),
+    );
+    expect(mismatched.status).toBe(409);
+    await expect(mismatched.json()).resolves.toMatchObject({
+      error: "provider_identity_mismatch",
+    });
+    expect(storage.value<LeaseRecord>(`lease:${managed.id}`)).toEqual(managed);
+    expect(deleted).toEqual([]);
+
+    const invalid = await fleet.fetch(
+      request("POST", `/v1/leases/${managed.id}/release`, {
+        headers,
+        body: { delete: true, expectedProvider: " AWS " },
+      }),
+    );
+    expect(invalid.status).toBe(400);
+    expect(storage.value<LeaseRecord>(`lease:${managed.id}`)).toEqual(managed);
+
+    const matching = await fleet.fetch(
+      request("POST", `/v1/leases/${managed.id}/release`, {
+        headers,
+        body: { delete: false, expectedProvider: "aws" },
+      }),
+    );
+    expect(matching.status).toBe(200);
+    expect(storage.value<LeaseRecord>(`lease:${managed.id}`)?.state).toBe("released");
+
+    const legacy = testLease({
+      id: "cbx_provider_bound_release_legacy",
+      provider: "aws",
+      cloudID: "i-provider-bound-legacy",
+      expiresAt,
+    });
+    storage.seed(`lease:${legacy.id}`, legacy);
+    const omitted = await fleet.fetch(
+      request("POST", `/v1/leases/${legacy.id}/release`, {
+        headers,
+        body: { delete: false },
+      }),
+    );
+    expect(omitted.status).toBe(200);
+
+    const registered = testLease({
+      id: "cbx_provider_bound_registered",
+      provider: "external",
+      lifecycle: "registered",
+      runtimeAdapterID: "adapter_provider_bound",
+      runtimeAdapterWorkspaceID: "workspace_provider_bound",
+      runtimeAdapterRegistrationID: "registration_provider_bound",
+      expiresAt,
+    });
+    storage.seed(`lease:${registered.id}`, registered);
+    const registeredMismatch = await fleet.fetch(
+      request("POST", `/v1/leases/${registered.id}/release`, {
+        headers,
+        body: {
+          expectedProvider: "aws",
+          runtimeAdapterDeleteCompletion: {
+            adapterID: registered.runtimeAdapterID,
+            workspaceID: registered.runtimeAdapterWorkspaceID,
+            registrationID: registered.runtimeAdapterRegistrationID,
+            status: "absent",
+          },
+        },
+      }),
+    );
+    expect(registeredMismatch.status).toBe(409);
+    expect(storage.value<LeaseRecord>(`lease:${registered.id}`)).toEqual(registered);
+
+    const releaseAlias = async (provider: string): Promise<void> => {
+      const aliasLease = testLease({
+        id: `cbx_provider_bound_release_${provider}`,
+        provider,
+        expiresAt,
+      });
+      storage.seed(`lease:${aliasLease.id}`, aliasLease);
+      const aliasResponse = await fleet.fetch(
+        request("POST", `/v1/leases/${aliasLease.id}/release`, {
+          headers,
+          body: { delete: false, expectedProvider: "gcp" },
+        }),
+      );
+      expect(aliasResponse.status).toBe(200);
+    };
+    await releaseAlias("google-cloud");
+    await releaseAlias("google");
+
+    const azureLease = testLease({
+      id: "cbx_provider_bound_release_azure",
+      provider: "azure",
+      expiresAt,
+    });
+    storage.seed(`lease:${azureLease.id}`, azureLease);
+    const distinctRoute = await fleet.fetch(
+      request("POST", `/v1/leases/${azureLease.id}/release`, {
+        headers,
+        body: { delete: false, expectedProvider: "azure-dynamic-sessions" },
+      }),
+    );
+    expect(distinctRoute.status).toBe(409);
+
+    const nonNormalizedLease = testLease({
+      id: "cbx_provider_bound_release_non_normalized",
+      provider: "google-cloud",
+      expiresAt,
+    });
+    storage.seed(`lease:${nonNormalizedLease.id}`, nonNormalizedLease);
+    const nonNormalized = await fleet.fetch(
+      request("POST", `/v1/leases/${nonNormalizedLease.id}/release`, {
+        headers,
+        body: { delete: false, expectedProvider: " Google-Cloud " },
+      }),
+    );
+    expect(nonNormalized.status).toBe(400);
+    expect(storage.value<LeaseRecord>(`lease:${nonNormalizedLease.id}`)).toEqual(
+      nonNormalizedLease,
+    );
+  });
+
+  it("atomically binds heartbeat mutations to an optional expected provider", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const lease = testLease({
+      id: "cbx_provider_bound_heartbeat",
+      provider: "aws",
+      idleTimeoutSeconds: 1800,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      lastTouchedAt: new Date().toISOString(),
+      telemetry: { capturedAt: "2026-05-01T00:00:00.000Z", load1: 0.1 },
+      providerAccessExpiresAt: "2026-05-01T00:30:00.000Z",
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+    });
+    storage.seed(`lease:${lease.id}`, lease);
+    const headers = {
+      "x-crabbox-owner": lease.owner,
+      "x-crabbox-org": "openclaw",
+    };
+
+    const mismatched = await fleet.fetch(
+      request("POST", `/v1/leases/${lease.id}/heartbeat`, {
+        headers,
+        body: {
+          expectedProvider: "external",
+          idleTimeoutSeconds: 3600,
+          telemetry: { capturedAt: new Date().toISOString(), load1: 0.9 },
+        },
+      }),
+    );
+    expect(mismatched.status).toBe(409);
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)).toEqual(lease);
+
+    const invalid = await fleet.fetch(
+      request("POST", `/v1/leases/${lease.id}/heartbeat`, {
+        headers,
+        body: { expectedProvider: "AWS", idleTimeoutSeconds: 3600 },
+      }),
+    );
+    expect(invalid.status).toBe(400);
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)).toEqual(lease);
+
+    const matching = await fleet.fetch(
+      request("POST", `/v1/leases/${lease.id}/heartbeat`, {
+        headers,
+        body: { expectedProvider: "aws", idleTimeoutSeconds: 2400 },
+      }),
+    );
+    expect(matching.status).toBe(200);
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)?.idleTimeoutSeconds).toBe(2400);
+
+    const omitted = await fleet.fetch(
+      request("POST", `/v1/leases/${lease.id}/heartbeat`, {
+        headers,
+        body: { idleTimeoutSeconds: 3000 },
+      }),
+    );
+    expect(omitted.status).toBe(200);
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)?.idleTimeoutSeconds).toBe(3000);
+
+    const aliasLease = testLease({
+      id: "cbx_provider_bound_heartbeat_google_cloud",
+      provider: "google-cloud",
+      createdAt: new Date().toISOString(),
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+    });
+    storage.seed(`lease:${aliasLease.id}`, aliasLease);
+    const aliasResponse = await fleet.fetch(
+      request("POST", `/v1/leases/${aliasLease.id}/heartbeat`, {
+        headers,
+        body: { expectedProvider: "gcp", idleTimeoutSeconds: 2400 },
+      }),
+    );
+    expect(aliasResponse.status).toBe(200);
+    expect(storage.value<LeaseRecord>(`lease:${aliasLease.id}`)?.idleTimeoutSeconds).toBe(2400);
+  });
+
+  it("atomically binds Tailscale mutations to an optional expected provider", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const lease = testLease({
+      id: "cbx_provider_bound_tailscale",
+      provider: "aws",
+      tailscale: { enabled: true, state: "requested", hostname: "provider-bound" },
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+    });
+    storage.seed(`lease:${lease.id}`, lease);
+    const headers = {
+      "x-crabbox-owner": lease.owner,
+      "x-crabbox-org": "openclaw",
+    };
+
+    const mismatched = await fleet.fetch(
+      request("POST", `/v1/leases/${lease.id}/tailscale`, {
+        headers,
+        body: { expectedProvider: "external", ipv4: "100.64.0.10", state: "ready" },
+      }),
+    );
+    expect(mismatched.status).toBe(409);
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)).toEqual(lease);
+
+    const invalid = await fleet.fetch(
+      request("POST", `/v1/leases/${lease.id}/tailscale`, {
+        headers,
+        body: { expectedProvider: " aws", ipv4: "100.64.0.10", state: "ready" },
+      }),
+    );
+    expect(invalid.status).toBe(400);
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)).toEqual(lease);
+
+    const matching = await fleet.fetch(
+      request("POST", `/v1/leases/${lease.id}/tailscale`, {
+        headers,
+        body: { expectedProvider: "aws", ipv4: "100.64.0.10", state: "ready" },
+      }),
+    );
+    expect(matching.status).toBe(200);
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)?.tailscale?.ipv4).toBe("100.64.0.10");
+
+    const omitted = await fleet.fetch(
+      request("POST", `/v1/leases/${lease.id}/tailscale`, {
+        headers,
+        body: { fqdn: "provider-bound.example.ts.net" },
+      }),
+    );
+    expect(omitted.status).toBe(200);
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)?.tailscale?.fqdn).toBe(
+      "provider-bound.example.ts.net",
+    );
+
+    const aliasLease = testLease({
+      id: "cbx_provider_bound_tailscale_google_cloud",
+      provider: "google-cloud",
+      tailscale: { enabled: true, state: "requested", hostname: "provider-bound-alias" },
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+    });
+    storage.seed(`lease:${aliasLease.id}`, aliasLease);
+    const aliasResponse = await fleet.fetch(
+      request("POST", `/v1/leases/${aliasLease.id}/tailscale`, {
+        headers,
+        body: { expectedProvider: "gcp", ipv4: "100.64.0.11", state: "ready" },
+      }),
+    );
+    expect(aliasResponse.status).toBe(200);
+    expect(storage.value<LeaseRecord>(`lease:${aliasLease.id}`)?.tailscale?.ipv4).toBe(
+      "100.64.0.11",
+    );
   });
 
   it("requires manage access for lease metadata writes", async () => {
@@ -30586,6 +30880,186 @@ describe("fleet run history", () => {
       cleanupAttempts: 1,
       cleanupRetryAt: expiredRetryAt,
     });
+  });
+
+  it("serializes control heartbeat provider validation with its mutation", async () => {
+    const storage = new MemoryStorage();
+    const runtime = new CloudflareCoordinatorRuntime({ storage } as unknown as DurableObjectState);
+    const fleet = new FleetCoordinator(runtime, {
+      CRABBOX_DEFAULT_ORG: "openclaw",
+    } as Env);
+    const leaseID = "cbx_control_provider_fence";
+    const now = new Date();
+    const original = testLease({
+      id: leaseID,
+      provider: "aws",
+      owner: "peter@example.com",
+      org: "openclaw",
+      createdAt: now.toISOString(),
+      updatedAt: now.toISOString(),
+      lastTouchedAt: now.toISOString(),
+      expiresAt: new Date(now.getTime() + 60 * 60 * 1000).toISOString(),
+    });
+    const replacementTouchedAt = new Date(now.getTime() - 30_000).toISOString();
+    const replacement = testLease({
+      id: leaseID,
+      provider: "external",
+      lifecycle: "registered",
+      owner: "peter@example.com",
+      org: "openclaw",
+      idleTimeoutSeconds: 777,
+      updatedAt: replacementTouchedAt,
+      lastTouchedAt: replacementTouchedAt,
+      telemetry: { capturedAt: replacementTouchedAt, load1: 0.2 },
+      expiresAt: new Date(now.getTime() + 60 * 60 * 1000).toISOString(),
+    });
+    storage.seed(`lease:${leaseID}`, original);
+
+    const replacementDone = deferred<void>();
+    let replacementScheduled = false;
+    storage.afterGet = (key) => {
+      if (key !== `lease:${leaseID}` || replacementScheduled) {
+        return;
+      }
+      replacementScheduled = true;
+      void runtime.runExclusive(async () => {
+        storage.seed(`lease:${leaseID}`, replacement);
+        replacementDone.resolve();
+      });
+    };
+
+    const attachment = {
+      kind: "control" as const,
+      clientID: "ctrl_provider_fence",
+      owner: "peter@example.com",
+      org: "openclaw",
+      subscriptions: {},
+    };
+    const socket = new FakeWebSocket(attachment);
+    (
+      fleet as unknown as {
+        controlSockets: Map<string, WebSocket>;
+      }
+    ).controlSockets.set(attachment.clientID, socket as unknown as WebSocket);
+
+    await fleet.webSocketMessage(
+      socket as unknown as WebSocket,
+      JSON.stringify({
+        type: "heartbeat",
+        leaseID,
+        expectedProvider: "aws",
+        idleTimeoutSeconds: 3600,
+        telemetry: { capturedAt: new Date().toISOString(), load1: 0.9 },
+      }),
+    );
+    await replacementDone.promise;
+
+    await fleet.webSocketMessage(
+      socket as unknown as WebSocket,
+      JSON.stringify({
+        type: "heartbeat",
+        leaseID,
+        expectedProvider: "aws",
+        idleTimeoutSeconds: 4000,
+      }),
+    );
+
+    expect(socket.sentJSON()).toEqual([
+      expect.objectContaining({ type: "heartbeat", leaseID, ok: true }),
+      {
+        type: "heartbeat",
+        leaseID,
+        ok: false,
+        error: "provider_identity_mismatch",
+      },
+    ]);
+    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)).toMatchObject({
+      provider: "external",
+      lifecycle: "registered",
+      idleTimeoutSeconds: 777,
+      updatedAt: replacementTouchedAt,
+      lastTouchedAt: replacementTouchedAt,
+      telemetry: { capturedAt: replacementTouchedAt, load1: 0.2 },
+    });
+  });
+
+  it("canonicalizes exact provider aliases for control heartbeats", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const attachment = {
+      kind: "control" as const,
+      clientID: "ctrl_provider_alias",
+      owner: "peter@example.com",
+      org: "openclaw",
+      subscriptions: {},
+    };
+    const socket = new FakeWebSocket(attachment);
+    (
+      fleet as unknown as {
+        controlSockets: Map<string, WebSocket>;
+      }
+    ).controlSockets.set(attachment.clientID, socket as unknown as WebSocket);
+
+    const heartbeatAlias = async (provider: string): Promise<void> => {
+      const lease = testLease({
+        id: `cbx_control_provider_${provider}`,
+        provider,
+        owner: "peter@example.com",
+        org: "openclaw",
+        createdAt: new Date().toISOString(),
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      });
+      storage.seed(`lease:${lease.id}`, lease);
+      await fleet.webSocketMessage(
+        socket as unknown as WebSocket,
+        JSON.stringify({
+          type: "heartbeat",
+          leaseID: lease.id,
+          expectedProvider: "gcp",
+          idleTimeoutSeconds: 2400,
+        }),
+      );
+    };
+    await heartbeatAlias("google-cloud");
+    await heartbeatAlias("google");
+
+    const azure = testLease({
+      id: "cbx_control_provider_azure",
+      provider: "azure",
+      owner: "peter@example.com",
+      org: "openclaw",
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+    });
+    storage.seed(`lease:${azure.id}`, azure);
+    await fleet.webSocketMessage(
+      socket as unknown as WebSocket,
+      JSON.stringify({
+        type: "heartbeat",
+        leaseID: azure.id,
+        expectedProvider: "azure-dynamic-sessions",
+        idleTimeoutSeconds: 2400,
+      }),
+    );
+
+    expect(socket.sentJSON()).toEqual([
+      expect.objectContaining({
+        type: "heartbeat",
+        leaseID: "cbx_control_provider_google-cloud",
+        ok: true,
+      }),
+      expect.objectContaining({
+        type: "heartbeat",
+        leaseID: "cbx_control_provider_google",
+        ok: true,
+      }),
+      {
+        type: "heartbeat",
+        leaseID: azure.id,
+        ok: false,
+        error: "provider_identity_mismatch",
+      },
+    ]);
+    expect(storage.value<LeaseRecord>(`lease:${azure.id}`)?.idleTimeoutSeconds).not.toBe(2400);
   });
 
   it("records finished runs and serves logs", async () => {


### PR DESCRIPTION
## Summary

- bind coordinator release, heartbeat/idle/telemetry, Tailscale, and runtime-adapter mutations to the CLI-selected provider
- enforce `expectedProvider` atomically inside Worker state transactions while preserving omitted legacy requests
- prevent identity mismatches from falling through to blind stop/release paths
- cancel mismatching ordinary creates through the token-bound requested lease/create-attempt contract instead of releasing an untrusted returned ID
- canonicalize `gcp`, `google`, and `google-cloud` without conflating distinct routes such as Azure VM and Dynamic Sessions

## Verification

- full `go test ./internal/cli`
- Worker format, lint, typecheck, 1,355 tests, and dry-run build
- `scripts/check-docs.sh`
- `git diff --check`
- source-blind behavior contract covering release, HTTP/WebSocket heartbeat, Tailscale, stop fallback, create cancellation, aliases, and distinct-route rejection
- focused security review: no high- or medium-confidence vulnerabilities
- structured P1 autoreview and secret scan: clean
