### PR TITLE
fix(proof): use neutral wording for ordinary run evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Made default `run --emit-proof` headings context-neutral instead of claiming every run occurred after a patch or fix.
 - Preserved authoritative recorded-run and lease-claim provider routes while keeping unselected inspection and archive dry-run output provider-neutral.
 - Bound coordinator release, heartbeat, and Tailscale mutations to the CLI-selected provider, preventing cross-provider lease deletion or metadata changes.
 

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -409,7 +409,9 @@ Use `--emit-proof <path>` to render a Markdown `## Real behavior proof` block
 after a successful run, derived from run metadata, the expanded command,
 selected live console output, collected artifact paths, and the
 `--proof-template` or preset template. Keep proof templates in repo config so
-parser-sensitive PR wording stays project-owned.
+parser-sensitive PR wording stays project-owned. Default headings are
+context-neutral; put patch- or fix-specific claims in repository-owned template
+fields only when the run actually proves them.
 
 Use `--attest <path>` to write a signed run receipt after a successful run: a
 flat JSON record of the provider, lease, command, exit code, timing, and the

--- a/internal/cli/profiles_test.go
+++ b/internal/cli/profiles_test.go
@@ -470,12 +470,35 @@ func TestRenderRunProofUsesTemplateAndLiveOutput(t *testing.T) {
 	for _, want := range []string{
 		"## Real behavior proof",
 		"Behavior addressed: Live QA login-regression",
-		"Evidence after fix: Copied live console output from Crabbox `run_123`",
+		"Exact steps or command run:",
+		"Evidence: Copied live console output from Crabbox `run_123`",
+		"Observed result: The scenario passed.",
 		"scenario pass login-regression 33.8s",
 		"What was not tested: No public service.",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("proof missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestRenderRunProofUsesContextNeutralDefaultLabels(t *testing.T) {
+	got, err := renderRunProof(proofRenderInput{Command: "make test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"Exact steps or command run:",
+		"Evidence: Copied live console output from Crabbox",
+		"Observed result: The command completed successfully on the remote environment.",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("proof missing %q:\n%s", want, got)
+		}
+	}
+	for _, forbidden := range []string{"after this patch", "after fix"} {
+		if strings.Contains(got, forbidden) {
+			t.Fatalf("proof contains patch-specific claim %q:\n%s", forbidden, got)
 		}
 	}
 }

--- a/internal/cli/run_artifacts.go
+++ b/internal/cli/run_artifacts.go
@@ -368,10 +368,10 @@ func renderRunProof(input proofRenderInput) (string, error) {
 	b.WriteString("Behavior addressed: " + behavior + "\n\n")
 	b.WriteString("Real environment tested: " + environment + "\n\n")
 	stepsOpenFence, stepsCloseFence := markdownFence("sh", steps)
-	b.WriteString("Exact steps or command run after this patch:\n\n" + stepsOpenFence + "\n")
+	b.WriteString("Exact steps or command run:\n\n" + stepsOpenFence + "\n")
 	b.WriteString(steps)
 	b.WriteString("\n" + stepsCloseFence + "\n\n")
-	b.WriteString("Evidence after fix: Copied live console output from Crabbox")
+	b.WriteString("Evidence: Copied live console output from Crabbox")
 	if input.RunID != "" {
 		b.WriteString(" `" + input.RunID + "`")
 	}
@@ -380,7 +380,7 @@ func renderRunProof(input proofRenderInput) (string, error) {
 	b.WriteString(":\n\n" + openFence + "\n")
 	b.WriteString(logExcerpt)
 	b.WriteString("\n" + closeFence + "\n\n")
-	b.WriteString("Observed result after fix: " + observed + "\n\n")
+	b.WriteString("Observed result: " + observed + "\n\n")
 	if len(input.Artifacts) > 0 || input.ActionsURL != "" {
 		b.WriteString("Additional evidence: ")
 		parts := make([]string, 0, len(input.Artifacts)+1)


### PR DESCRIPTION
## Summary

- Generic proof headings no longer claim every run followed a patch or fix.
- Custom templates and Markdown structure remain unchanged.
- Documentation, changelog, and regression coverage are updated.

## Verification

- Focused Go proof tests passed with `-count=3`.
- `node scripts/build-docs-site.mjs`
- Live `local-container` run using Docker 29.4.0: lease `cbx_76011c9b6998`, run `run_09492c6c429c`; ordinary command output remained in the proof, all neutral labels were present, neither `after this patch` nor `after fix` was present, and lease/container cleanup was verified.

## Config/secrets

None.

Fixes https://github.com/openclaw/crabbox/issues/1342
