### PR TITLE
fix(windows): detect native WSL transfer tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,9 @@ jobs:
       - name: Test pond mesh cancellation
         run: go test ./internal/cli/ -run PondMeshCancel -count=1 -v
 
+      - name: Test Windows transport detection
+        run: go test ./internal/cli/ -run '^(TestWindowsWSLNativeToolProbeUsesDirectCommandOutput|TestWindowsWSLNativeToolPathsRejectsWindowsShims)$' -count=1 -v
+
       - name: Test Git workspace coherence
         run: go test ./internal/cli/ -run '^(TestWindowsGitRootIdentityAcceptsShortAliasAndRejectsDistinctRoot|TestWindowsGitCoherenceRollbackRestoresIndexAfterSymbolicHeadFailure|TestWindowsGitSeedReplacesUnusableExactRootsAfterVerifiedClone|TestWindowsGitCoherenceSupportsDetachedSparseSplitAndLinkedIndexes|TestWorkspaceOwnerWindowsProtocolBehavior)$' -count=1 -v
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Selected native WSL rsync and OpenSSH correctly on Windows instead of falling back to incompatible Windows shims.
 - Made default `run --emit-proof` headings context-neutral instead of claiming every run occurred after a patch or fix.
 - Preserved authoritative recorded-run and lease-claim provider routes while keeping unselected inspection and archive dry-run output provider-neutral.
 - Bound coordinator release, heartbeat, and Tailscale mutations to the CLI-selected provider, preventing cross-provider lease deletion or metadata changes.

--- a/README.md
+++ b/README.md
@@ -145,6 +145,10 @@ crabbox --version
 No Homebrew? Grab a [GoReleaser archive](https://github.com/openclaw/crabbox/releases)
 for macOS, Linux, or Windows.
 
+Automatic WSL transport selection on Windows requires a build from current
+`main` or Crabbox v0.42.1 and newer. Follow the
+[Windows installation guide](docs/windows-install.md) for the supported setup.
+
 The Apple Silicon Homebrew install uses the release archive that also contains
 the native `crabbox-apple-vm-helper` for the local Apple VZ provider.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -36,6 +36,9 @@ configured; run `crabbox providers recommend` to compare options.
 If you do not use Homebrew, GitHub Releases ship signed archives for macOS,
 Linux, and Windows. Download the matching archive from
 <https://github.com/openclaw/crabbox/releases>.
+Automatic WSL transport selection on Windows requires a build from current
+`main` or Crabbox v0.42.1 and newer. See the
+[supported Windows installation](windows-install.md) for the complete setup.
 
 ## Step 2. Log In
 

--- a/docs/windows-install.md
+++ b/docs/windows-install.md
@@ -1,0 +1,215 @@
+# Install Crabbox on Windows
+
+The currently supported Windows client setup uses the native `crabbox.exe`
+from the latest GitHub Release and WSL2 Ubuntu's native Linux `rsync` and
+OpenSSH client for repository transfer. Native Windows Git, OpenSSH
+(`ssh.exe` and `ssh-keygen.exe`), and `curl.exe` must also be on `PATH`.
+
+Crabbox invokes `wsl.exe` without naming a distribution, so it probes the
+default WSL distribution. This guide configures Ubuntu as that default, but
+Ubuntu is not a code requirement: another distribution works when it is the
+default and provides native Linux `rsync` and `ssh` commands.
+
+The automatic WSL transport selection documented here requires a build that
+contains the direct-output detection fix: current `main` or Crabbox v0.42.1
+and newer. Crabbox v0.42.0 and older can silently fall back to an incompatible
+Windows shim even when the native WSL tools are installed.
+
+A native no-WSL rsync/OpenSSH transport tuple is not yet supported. In
+particular, do not pair MSYS2 or Cygwin rsync with native Windows OpenSSH:
+rsync can exit while its SSH child remains connected. Crabbox therefore
+prefers native WSL tools and rejects `.exe` files and tools resolved through
+mounted Windows paths when probing WSL.
+
+## Install the native Crabbox executable
+
+Run this block in ordinary, non-elevated PowerShell. It detects amd64 versus
+arm64, queries the latest stable
+[Crabbox GitHub Release](https://github.com/openclaw/crabbox/releases),
+downloads the matching archive and `checksums.txt`, verifies SHA-256 before
+extraction, and adds the install directory to your user `PATH`.
+
+```powershell
+$ErrorActionPreference = "Stop"
+$minimumVersion = [version]"0.42.1"
+
+$osArchitecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant()
+$architecture = switch ($osArchitecture) {
+    "x64"   { "amd64" }
+    "arm64" { "arm64" }
+    default { throw "Unsupported Windows architecture: $osArchitecture" }
+}
+
+$headers = @{
+    Accept = "application/vnd.github+json"
+    "User-Agent" = "Crabbox-Windows-Installer"
+}
+$release = Invoke-RestMethod `
+    -Uri "https://api.github.com/repos/openclaw/crabbox/releases/latest" `
+    -Headers $headers
+if ($release.draft -or $release.prerelease) {
+    throw "The GitHub latest-release endpoint returned a non-stable release."
+}
+
+$version = $release.tag_name -replace '^v', ''
+$stableVersion = [version]$version
+if ($stableVersion -lt $minimumVersion) {
+    throw "Latest stable Crabbox release v$version is older than required v$minimumVersion. Use a build from current main or wait for Crabbox v$minimumVersion or newer."
+}
+
+$archiveName = "crabbox_${version}_windows_${architecture}.zip"
+$archiveAsset = $release.assets | Where-Object { $_.name -eq $archiveName } | Select-Object -First 1
+$checksumsAsset = $release.assets | Where-Object { $_.name -eq "checksums.txt" } | Select-Object -First 1
+if ($null -eq $archiveAsset -or $null -eq $checksumsAsset) {
+    throw "Release assets are missing $archiveName or checksums.txt."
+}
+
+$downloadDir = Join-Path ([IO.Path]::GetTempPath()) ("crabbox-install-" + [guid]::NewGuid())
+$archivePath = Join-Path $downloadDir $archiveName
+$checksumsPath = Join-Path $downloadDir "checksums.txt"
+$installDir = Join-Path $env:LOCALAPPDATA "Programs\Crabbox"
+New-Item -ItemType Directory -Path $downloadDir -Force | Out-Null
+
+try {
+    Invoke-WebRequest -Uri $archiveAsset.browser_download_url -OutFile $archivePath
+    Invoke-WebRequest -Uri $checksumsAsset.browser_download_url -OutFile $checksumsPath
+
+    $checksumPattern = '\s+\*?' + [regex]::Escape($archiveName) + '$'
+    $checksumLine = Get-Content $checksumsPath |
+        Where-Object { $_ -match $checksumPattern } |
+        Select-Object -First 1
+    if (-not $checksumLine) {
+        throw "No checksum found for $archiveName."
+    }
+    $expectedHash = ($checksumLine.Trim() -split '\s+')[0]
+    $actualHash = (Get-FileHash -Algorithm SHA256 -Path $archivePath).Hash
+    if ($actualHash -ine $expectedHash) {
+        throw "SHA-256 mismatch for $archiveName."
+    }
+
+    New-Item -ItemType Directory -Path $installDir -Force | Out-Null
+    Expand-Archive -Path $archivePath -DestinationPath $installDir -Force
+} finally {
+    Remove-Item -LiteralPath $downloadDir -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+$userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+$userPathParts = @($userPath -split ';' | Where-Object { $_ })
+if ($userPathParts -notcontains $installDir) {
+    $updatedUserPath = (@($userPathParts) + $installDir) -join ';'
+    [Environment]::SetEnvironmentVariable("Path", $updatedUserPath, "User")
+}
+if (($env:Path -split ';') -notcontains $installDir) {
+    $env:Path = "$installDir;$env:Path"
+}
+```
+
+## Install Windows prerequisites
+
+Git for Windows can be installed from an ordinary PowerShell session:
+
+```powershell
+winget install --id Git.Git --exact --source winget
+```
+
+Windows 11 includes `curl.exe`. Install the Windows OpenSSH Client capability
+from an **elevated PowerShell** session; this also supplies `ssh-keygen.exe`:
+
+```powershell
+$openSSH = Get-WindowsCapability -Online -Name "OpenSSH.Client*"
+if ($openSSH.State -ne "Installed") {
+    Add-WindowsCapability -Online -Name "OpenSSH.Client~~~~0.0.1.0"
+}
+```
+
+Close and reopen PowerShell after installation so the updated application and
+user paths are visible.
+
+## Install WSL2 transport tools
+
+Install WSL2 with Ubuntu from an **elevated PowerShell** session. Windows may
+require a restart before Ubuntu completes its first-launch setup.
+
+```powershell
+wsl.exe --install --distribution Ubuntu
+```
+
+After Ubuntu has initialized, make it the default distribution from an
+ordinary, non-elevated PowerShell session. This must match Crabbox's
+unqualified `wsl.exe` probe.
+
+```powershell
+wsl.exe --set-default Ubuntu
+```
+
+Then install Ubuntu's native Linux transfer tools from PowerShell. Ubuntu may
+prompt for the Linux user's password for `sudo`.
+
+```powershell
+wsl.exe --distribution Ubuntu -- bash -lc 'sudo apt-get update && sudo apt-get install -y rsync openssh-client'
+```
+
+If you prefer another WSL distribution, set that distribution as the default
+instead and install its native `rsync` and OpenSSH client packages there.
+
+## Verify the installation
+
+Open a fresh, ordinary PowerShell session. The first command checks the native
+Windows tools. The second exactly matches Crabbox's unqualified
+default-distribution probe and deliberately uses direct `command -v` output:
+both paths must be Linux paths such as `/usr/bin/rsync` and `/usr/bin/ssh`,
+never `.exe` files or paths below `/mnt/<drive>` or `/mnt/host/<drive>`.
+
+```powershell
+Get-Command crabbox.exe, git.exe, ssh.exe, ssh-keygen.exe, curl.exe
+wsl.exe sh -c 'command -v rsync || exit 1; command -v ssh || exit 1'
+crabbox --version
+crabbox doctor
+```
+
+A provider-neutral `crabbox doctor` can report `no provider selected`. That is
+expected until provider or broker configuration is added and is separate from
+local installation readiness. Select and configure a provider before running a
+remote lifecycle command.
+
+## Optional Docker Desktop smoke
+
+If Docker Desktop is already installed and running, this secretless local
+container smoke creates and commits a fixture in a temporary repository, syncs
+that repository through the configured default WSL transport, verifies the
+fixture in the container, and removes both the container and local repository:
+
+```powershell
+docker info
+if ($LASTEXITCODE -ne 0) {
+    throw "Docker Desktop is not ready."
+}
+
+$smokeRepo = Join-Path ([IO.Path]::GetTempPath()) ("crabbox-windows-sync-" + [guid]::NewGuid())
+New-Item -ItemType Directory -Path $smokeRepo | Out-Null
+
+try {
+    Set-Content -LiteralPath (Join-Path $smokeRepo "fixture.txt") -Value "crabbox-wsl-sync-ok" -NoNewline
+    Push-Location $smokeRepo
+    try {
+        git init
+        if ($LASTEXITCODE -ne 0) { throw "git init failed." }
+
+        git add fixture.txt
+        if ($LASTEXITCODE -ne 0) { throw "git add failed." }
+
+        git -c 'user.name=Crabbox Sync Test' -c 'user.email=crabbox-sync-test@example.invalid' commit -m 'test: add sync fixture'
+        if ($LASTEXITCODE -ne 0) { throw "git commit failed." }
+
+        crabbox run --provider local-container --local-container-runtime docker --stop-after always -- sh -lc 'test "$(cat fixture.txt)" = "crabbox-wsl-sync-ok"'
+        if ($LASTEXITCODE -ne 0) { throw "Crabbox repository sync smoke failed." }
+    } finally {
+        Pop-Location
+    }
+} finally {
+    Remove-Item -LiteralPath $smokeRepo -Recurse -Force -ErrorAction SilentlyContinue
+}
+```
+
+See [Getting Started](getting-started.md) when you are ready to configure a
+provider or broker and run a project workload.

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -1213,10 +1213,15 @@ func windowsWSLHasNativeRsyncSSH(ctx context.Context, target SSHTarget, wslExe s
 	if strings.TrimSpace(wslExe) == "" {
 		return false
 	}
-	cmd := exec.CommandContext(ctx, wslExe, "sh", "-c", "rsync_path=$(command -v rsync) || exit 1; ssh_path=$(command -v ssh) || exit 1; printf '%s\\n%s\\n' \"$rsync_path\" \"$ssh_path\"")
+	cmd := windowsWSLNativeToolProbeCommand(ctx, wslExe)
 	applyTargetChildEnvironment(cmd, target)
 	out, err := cmd.Output()
 	return err == nil && windowsWSLNativeToolPaths(string(out))
+}
+
+func windowsWSLNativeToolProbeCommand(ctx context.Context, wslExe string) *exec.Cmd {
+	// Direct command output is intentional: assignment plus printf produced blank lines on real Windows/WSL systems.
+	return exec.CommandContext(ctx, wslExe, "sh", "-c", "command -v rsync || exit 1; command -v ssh || exit 1")
 }
 
 func windowsWSLNativeToolPaths(output string) bool {

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -1383,6 +1383,20 @@ func TestWindowsHostPathConvertsMSYSDrivePath(t *testing.T) {
 	}
 }
 
+func TestWindowsWSLNativeToolProbeUsesDirectCommandOutput(t *testing.T) {
+	t.Parallel()
+	cmd := windowsWSLNativeToolProbeCommand(context.Background(), "wsl.exe")
+	want := []string{
+		"wsl.exe",
+		"sh",
+		"-c",
+		"command -v rsync || exit 1; command -v ssh || exit 1",
+	}
+	if !reflect.DeepEqual(cmd.Args, want) {
+		t.Fatalf("WSL native-tool probe args = %q, want %q", cmd.Args, want)
+	}
+}
+
 func TestWindowsWSLNativeToolPathsRejectsWindowsShims(t *testing.T) {
 	t.Parallel()
 	tests := []struct {


### PR DESCRIPTION
## Summary

- Detect native `rsync` and `ssh` in the default WSL distribution from direct `command -v` output.
- Preserve rejection of Windows and mounted-path shims.
- Add focused Windows CI coverage for transport detection.
- Document the supported WSL-first installation for current `main` and v0.42.1+, including a minimum-version guard.

## Verification

- Focused WSL transport tests passed (10 tests), followed by the focused post-review tests (3 tests).
- `go test ./internal/cli` passed.
- `GOOS=windows GOARCH=amd64` CLI test compilation passed.
- `node scripts/build-docs-site.mjs` and `scripts/check-docs.sh` passed.
- Source-blind PowerShell validation confirmed that the installer fails closed before downloads or installation when the latest stable release is below v0.42.1.

## Live evidence

No fresh authorized Windows runtime was available for this change, so this PR does not claim a new live Windows run. Existing public Windows evidence for the direct-output diagnostic fix is recorded in https://github.com/openclaw/crabbox/issues/1319; that prior evidence completed sync, remote command execution, fixture verification, artifact download, and cleanup.

## Support boundary

The native no-WSL transport tuple remains unsupported, and https://github.com/openclaw/crabbox/issues/1319 remains open for that requirement. MSYS2 or Cygwin `rsync` paired with native Windows OpenSSH is unsupported.

## Config and secrets

None.

## Related

https://github.com/openclaw/crabbox/issues/1319
