### PR TITLE
feat(preflight): add Python runtime probes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,9 @@ jobs:
       - name: Test Windows transport detection
         run: go test ./internal/cli/ -run '^(TestWindowsWSLNativeToolProbeUsesDirectCommandOutput|TestWindowsWSLNativeToolPathsRejectsWindowsShims)$' -count=1 -v
 
+      - name: Test native Windows Python preflight probes
+        run: go test ./internal/cli/ -run '^(TestPythonPreflightToolValidationAndTargetFiltering|TestPythonPreflightWindowsProbeUsesLiteralExecutableAndMissingContract)$' -count=1 -v
+
       - name: Test Git workspace coherence
         run: go test ./internal/cli/ -run '^(TestWindowsGitRootIdentityAcceptsShortAliasAndRejectsDistinctRoot|TestWindowsGitCoherenceRollbackRestoresIndexAfterSymbolicHeadFailure|TestWindowsGitSeedReplacesUnusableExactRootsAfterVerifiedClone|TestWindowsGitCoherenceSupportsDetachedSparseSplitAndLinkedIndexes|TestWorkspaceOwnerWindowsProtocolBehavior)$' -count=1 -v
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.42.1 - Unreleased
 
+### Added
+
+- Added opt-in `python` and `python3` preflight probes that check the literal executable on POSIX, WSL2, and native Windows targets.
+
 ### Fixed
 
 - Selected native WSL rsync and OpenSSH correctly on Windows instead of falling back to incompatible Windows shims.

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -368,31 +368,35 @@ or the command/script you run.
 
 By default it probes common language and infrastructure tools plus OS-specific
 basics. Default generic probes are `git`, `tar`, `node`, `npm`, `corepack`,
-`pnpm`, `yarn`, `bun`, and `docker`; `uv` is available as an additional built-in.
-POSIX/Linux/WSL probes also include `sudo`, `apt`, and `bubblewrap`; native
-Windows probes include `powershell`, `execution_policy`, `longpaths`, `temp`,
-and `pwsh`.
+`pnpm`, `yarn`, `bun`, and `docker`; `uv`, `python`, and `python3` are available
+as additional opt-in built-ins. POSIX/Linux/WSL probes also include `sudo`,
+`apt`, and `bubblewrap`; native Windows probes include `powershell`,
+`execution_policy`, `longpaths`, `temp`, and `pwsh`.
 
 Use `--preflight-tools` to replace the default tool list for one run:
 
 ```sh
 crabbox run --preflight --preflight-tools node,bun,docker -- bun test
 crabbox run --preflight --preflight-tools default,uv -- node --test
+crabbox run --preflight --preflight-tools python,python3 -- python3 -m pytest
 crabbox run --preflight --preflight-tools none -- ./smoke.sh
 ```
 
-`default` expands to the built-ins; `none` keeps only the workspace summary.
-Unknown tool names fail before leasing so typos do not hide missing
+`default` expands to the default probe list; `none` keeps only the workspace
+summary. Unknown tool names fail before leasing so typos do not hide missing
 diagnostics. Unsupported OS-specific probes are skipped for the current target.
+The Python probes always invoke the literal requested command with `--version`,
+including `python` and `python3` on native Windows; Crabbox does not map either
+name to `py`. An unavailable literal command prints `<name>=missing` and the run
+continues.
 
 Configure the default per repo:
 
 ```yaml
 run:
   preflightTools:
-    - node
-    - bun
-    - docker
+    - python
+    - python3
 ```
 
 ## Profiles, presets, and proof

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -962,14 +962,14 @@ list, and explicit `--allow-env` flags append afterward. See
 ```yaml
 run:
   preflightTools:
-    - node
-    - bun
-    - docker
+    - python
+    - python3
 ```
 
 `run.preflightTools` configures which built-in probes `crabbox run --preflight`
 executes before the remote command. The CLI flag
-`--preflight-tools node,bun,docker` overrides this list for one run. Use
+`--preflight-tools python,python3` overrides this list for one run. Both names
+are opt-in and probe the corresponding literal command with `--version`. Use
 `default` to include Crabbox's default built-ins and `none` to print only the
 workspace summary. Preflight probes only report availability; they do not
 install toolchains or mutate the machine.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -298,12 +298,13 @@ a prebaked image, a devcontainer/Nix/mise/asdf setup, or the uploaded
 script/command itself.
 
 The built-in probes cover common toolchains — `git`, `tar`, `node`, `npm`,
-`corepack`, `pnpm`, `yarn`, `bun`, `docker`, `uv` — plus target-specific probes
-such as `sudo`, `apt`, `bubblewrap`, `powershell`, `execution_policy`,
-`longpaths`, `temp`, and `pwsh`. Override the probe list per run:
+`corepack`, `pnpm`, `yarn`, `bun`, `docker`, and opt-in `uv`, `python`, and
+`python3` — plus target-specific probes such as `sudo`, `apt`, `bubblewrap`,
+`powershell`, `execution_policy`, `longpaths`, `temp`, and `pwsh`. Override the
+probe list per run:
 
 ```sh
-crabbox run --preflight --preflight-tools node,bun,docker -- bun test
+crabbox run --preflight --preflight-tools python,python3 -- python3 -m pytest
 ```
 
 Or per repository:
@@ -311,9 +312,8 @@ Or per repository:
 ```yaml
 run:
   preflightTools:
-    - node
-    - bun
-    - docker
+    - python
+    - python3
 ```
 
 ## Actions hydration

--- a/internal/cli/run_observability.go
+++ b/internal/cli/run_observability.go
@@ -513,6 +513,8 @@ var preflightToolRegistry = map[string]preflightToolSpec{
 	"npm":              {Posix: []string{"npm", "--version"}, Windows: []string{"npm", "--version"}},
 	"pnpm":             {Posix: []string{"pnpm", "--version"}, Windows: []string{"pnpm", "--version"}},
 	"powershell":       {Windows: []string{"$PSVersionTable.PSVersion.ToString()"}, OS: map[string]bool{"windows": true}},
+	"python":           {Posix: []string{"python", "--version"}, Windows: []string{"python", "--version"}},
+	"python3":          {Posix: []string{"python3", "--version"}, Windows: []string{"python3", "--version"}},
 	"pwsh":             {Windows: []string{"pwsh", "--version"}, OS: map[string]bool{"windows": true}},
 	"sudo":             {OS: map[string]bool{"linux": true, "macos": true}},
 	"tar":              {Posix: []string{"tar", "--version"}, Windows: []string{"tar", "--version"}},

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -3589,6 +3589,67 @@ func TestValidatePreflightToolsRejectsUnknown(t *testing.T) {
 	}
 }
 
+func TestPythonPreflightToolValidationAndTargetFiltering(t *testing.T) {
+	if err := validatePreflightTools([]string{"python", "python3"}); err != nil {
+		t.Fatalf("python tools should validate: %v", err)
+	}
+	err := validatePreflightTools([]string{"python", "bogus", "python3"})
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 2 || !strings.Contains(exitErr.Message, `unknown preflight tool "bogus"`) {
+		t.Fatalf("error=%v, want exit 2 for bogus tool", err)
+	}
+
+	targets := []struct {
+		name   string
+		target SSHTarget
+	}{
+		{name: "linux", target: SSHTarget{TargetOS: targetLinux}},
+		{name: "macos", target: SSHTarget{TargetOS: targetMacOS}},
+		{name: "wsl2", target: SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeWSL2}},
+		{name: "windows", target: SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeNormal}},
+	}
+	for _, tt := range targets {
+		t.Run(tt.name, func(t *testing.T) {
+			got := preflightToolsForTarget(tt.target, []string{"python", "python3"})
+			if strings.Join(got, ",") != "python,python3" {
+				t.Fatalf("tools=%v", got)
+			}
+		})
+	}
+
+	for _, tool := range preflightToolsForTarget(SSHTarget{TargetOS: targetLinux}, nil) {
+		if tool == "python" || tool == "python3" {
+			t.Fatalf("%s must remain opt-in, default tools=%v", tool, defaultPreflightToolNames)
+		}
+	}
+}
+
+func TestPythonPreflightPOSIXProbeUsesLiteralExecutableAndMissingContract(t *testing.T) {
+	script := remoteCapabilityPreflightCommand("/work/repo", nil, nil, []string{"python", "python3"})
+	for _, want := range []string{
+		`preflight_cmd '\''python'\'' '\''python'\'' python --version`,
+		`preflight_cmd '\''python3'\'' '\''python3'\'' python3 --version`,
+		`printf '\''%s=missing\n'\'' "$label"`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("POSIX preflight script missing %q in %q", want, script)
+		}
+	}
+}
+
+func TestPythonPreflightWindowsProbeUsesLiteralExecutableAndMissingContract(t *testing.T) {
+	script := windowsRemoteCapabilityPreflightScript(`C:\crabbox\repo`, nil, nil, []string{"python", "python3"})
+	for _, want := range []string{
+		`Test-Tool 'python' 'python' @('--version')`,
+		`Test-Tool 'python3' 'python3' @('--version')`,
+		`Write-Output ($Label + "=missing")`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("Windows preflight script missing %q in %q", want, script)
+		}
+	}
+}
+
 func TestDelegatedPreflightPrintsUnsupportedMessage(t *testing.T) {
 	var stderr bytes.Buffer
 	printDelegatedPreflightUnsupported(&stderr, "e2b")


### PR DESCRIPTION
## Summary

- Add opt-in literal `python` and `python3` registry probes on POSIX, WSL2, and native Windows.
- Keep the default probe list unchanged, preserve missing-tool diagnostics while allowing the run to continue, and preserve unknown-name failure before leasing.
- Document the accepted names and behavior, update the changelog, and add dedicated native Windows CI coverage.

## Verification

- Focused Python preflight tests passed (10 tests), all preflight tests passed, and `go test ./internal/cli` passed.
- Windows amd64 cross-compilation, action pin/validation, and the full documentation checks passed.
- A live `local-container` run passed with lease `cbx_c9aa0f71816f` and run `run_5b9480c9808c`; output included `python=missing`, `python3=Python 3.14.4`, and the workload marker, followed by successful cleanup.
- A unique invalid preflight tool exited 2 before creating any lease, run, or container.

## Config/secrets

This adds accepted `run.preflightTools` names only. No secrets are added or required.

Fixes https://github.com/openclaw/crabbox/issues/1243
