### PR TITLE
fix(windows): support matched native SSH transport

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,8 +87,8 @@ jobs:
       - name: Test pond mesh cancellation
         run: go test ./internal/cli/ -run PondMeshCancel -count=1 -v
 
-      - name: Test Windows transport detection
-        run: go test ./internal/cli/ -run '^(TestWindowsWSLNativeToolProbeUsesDirectCommandOutput|TestWindowsWSLNativeToolPathsRejectsWindowsShims)$' -count=1 -v
+      - name: Test Windows SSH and rsync transport selection
+        run: go test ./internal/cli/ -run '^(TestWindowsWSLNativeToolProbeUsesDirectCommandOutput|TestWindowsWSLNativeToolPathsRejectsWindowsShims|TestDirectSSHExecutableSelection|TestSSHCommandContextUsesNativeWindowsOpenSSHEvenWhenPATHSelectsMSYS2|TestResolveWindowsNativeRsyncPairUsesExactSibling|TestResolveWindowsNativeRsyncPairFailsClosedWithoutSibling|TestBindWindowsNativeRsyncSSHPreservesOwnedArguments|TestWindowsNativeRsyncCommandUsesSiblingPairAndEnvironment|TestResolvedSSHCopyCommandUsesNativeWindowsSiblingPair|TestResolvedSSHCopyCommandFailsClosedWithoutNativeWindowsSibling)$' -count=1 -v
 
       - name: Test native Windows Python preflight probes
         run: go test ./internal/cli/ -run '^(TestPythonPreflightToolValidationAndTargetFiltering|TestPythonPreflightWindowsProbeUsesLiteralExecutableAndMissingContract)$' -count=1 -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Fixed
 
 - Bounded fallback HTTP clients for finite provider control calls without truncating uploads, downloads, or streaming executions. Thanks @SebTardif.
-- Selected native WSL rsync and OpenSSH correctly on Windows instead of falling back to incompatible Windows shims.
+- Selected native WSL rsync and OpenSSH correctly on Windows, while x64 no-WSL transfers now keep direct control on System32 OpenSSH and bind native rsync to its sibling OpenSSH.
 - Made default `run --emit-proof` headings context-neutral instead of claiming every run occurred after a patch or fix.
 - Preserved authoritative recorded-run and lease-claim provider routes while keeping unselected inspection and archive dry-run output provider-neutral.
 - Bound coordinator release, heartbeat, and Tailscale mutations to the CLI-selected provider, preventing cross-provider lease deletion or metadata changes.

--- a/README.md
+++ b/README.md
@@ -145,8 +145,8 @@ crabbox --version
 No Homebrew? Grab a [GoReleaser archive](https://github.com/openclaw/crabbox/releases)
 for macOS, Linux, or Windows.
 
-Automatic WSL transport selection on Windows requires a build from current
-`main` or Crabbox v0.42.1 and newer. Follow the
+Supported WSL2 and x64 no-WSL Windows transfer selection requires a build from
+current `main` or Crabbox v0.42.1 and newer. Follow the
 [Windows installation guide](docs/windows-install.md) for the supported setup.
 
 The Apple Silicon Homebrew install uses the release archive that also contains

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -36,8 +36,8 @@ configured; run `crabbox providers recommend` to compare options.
 If you do not use Homebrew, GitHub Releases ship signed archives for macOS,
 Linux, and Windows. Download the matching archive from
 <https://github.com/openclaw/crabbox/releases>.
-Automatic WSL transport selection on Windows requires a build from current
-`main` or Crabbox v0.42.1 and newer. See the
+Supported WSL2 and x64 no-WSL Windows transfer selection requires a build from
+current `main` or Crabbox v0.42.1 and newer. See the
 [supported Windows installation](windows-install.md) for the complete setup.
 
 ## Step 2. Log In

--- a/docs/windows-install.md
+++ b/docs/windows-install.md
@@ -1,25 +1,37 @@
 # Install Crabbox on Windows
 
-The currently supported Windows client setup uses the native `crabbox.exe`
-from the latest GitHub Release and WSL2 Ubuntu's native Linux `rsync` and
-OpenSSH client for repository transfer. Native Windows Git, OpenSSH
-(`ssh.exe` and `ssh-keygen.exe`), and `curl.exe` must also be on `PATH`.
+The supported Windows client setup uses the native `crabbox.exe` from the
+latest GitHub Release, native Windows OpenSSH for Crabbox control commands,
+and one of two matched transfer toolchains:
+
+1. A default WSL2 distribution with native Linux `rsync` and OpenSSH. This is
+   the preferred path.
+2. On x64 only, no WSL: MSYS2 `rsync.exe` and the sibling MSYS2 `ssh.exe`
+   from the exact same directory.
+
+Native Windows Git, the Windows OpenSSH Client capability (`ssh.exe` and
+`ssh-keygen.exe`), and `curl.exe` are required for both paths.
+
+The native Crabbox release installer below supports both amd64 and arm64
+archives. The no-WSL MSYS2 transport has been live-proven and is supported on
+x64 Windows only; use the preferred WSL2 path on Windows ARM64.
 
 Crabbox invokes `wsl.exe` without naming a distribution, so it probes the
 default WSL distribution. This guide configures Ubuntu as that default, but
 Ubuntu is not a code requirement: another distribution works when it is the
 default and provides native Linux `rsync` and `ssh` commands.
 
-The automatic WSL transport selection documented here requires a build that
-contains the direct-output detection fix: current `main` or Crabbox v0.42.1
-and newer. Crabbox v0.42.0 and older can silently fall back to an incompatible
-Windows shim even when the native WSL tools are installed.
+The transport selection documented here requires current `main` or Crabbox
+v0.42.1 and newer. Crabbox v0.42.0 and older can silently select an
+incompatible Windows SSH pairing.
 
-A native no-WSL rsync/OpenSSH transport tuple is not yet supported. In
-particular, do not pair MSYS2 or Cygwin rsync with native Windows OpenSSH:
-rsync can exit while its SSH child remains connected. Crabbox therefore
-prefers native WSL tools and rejects `.exe` files and tools resolved through
-mounted Windows paths when probing WSL.
+Crabbox never pairs MSYS2 or Cygwin rsync with the native System32 OpenSSH
+client. That combination is unsupported: rsync can exit while its SSH child
+remains connected. Crabbox prefers native WSL tools when both are available;
+without WSL, it resolves `rsync.exe` from `PATH` and fails closed unless a
+regular `ssh.exe` exists beside it. Direct control commands separately use
+`%WINDIR%\System32\OpenSSH\ssh.exe` when present, ignoring an MSYS2 SSH that
+appears earlier on `PATH`.
 
 ## Install the native Crabbox executable
 
@@ -152,19 +164,128 @@ wsl.exe --distribution Ubuntu -- bash -lc 'sudo apt-get update && sudo apt-get i
 If you prefer another WSL distribution, set that distribution as the default
 instead and install its native `rsync` and OpenSSH client packages there.
 
-## Verify the installation
+## Install no-WSL transfer tools with MSYS2
 
-Open a fresh, ordinary PowerShell session. The first command checks the native
-Windows tools. The second exactly matches Crabbox's unqualified
-default-distribution probe and deliberately uses direct `command -v` output:
-both paths must be Linux paths such as `/usr/bin/rsync` and `/usr/bin/ssh`,
-never `.exe` files or paths below `/mnt/<drive>` or `/mnt/host/<drive>`.
+Skip this section when using the WSL2 path above. In an **elevated PowerShell**
+session on x64 Windows, download the official maintained MSYS2 self-extracting
+base archive, verify the exact digest exercised by the live proof, extract it
+to `C:\msys64`, and install both transfer packages. This path intentionally
+does not depend on Winget, which was unavailable on the clean AWS Windows image
+used for the live proof.
 
 ```powershell
-Get-Command crabbox.exe, git.exe, ssh.exe, ssh-keygen.exe, curl.exe
-wsl.exe sh -c 'command -v rsync || exit 1; command -v ssh || exit 1'
+$ErrorActionPreference = "Stop"
+$msysRoot = "C:\msys64"
+$msysBin = Join-Path $msysRoot "usr\bin"
+$msysBash = Join-Path $msysBin "bash.exe"
+$msysURL = "https://github.com/msys2/msys2-installer/releases/download/2026-06-11/msys2-base-x86_64-20260611.sfx.exe"
+$expectedMSYSHash = "c105946e64e08f099ac0e4647461ce762b95333ad211777666476a9a41451d65"
+$downloadDir = Join-Path ([IO.Path]::GetTempPath()) ("crabbox-msys2-" + [guid]::NewGuid())
+$msysSFX = Join-Path $downloadDir "msys2-base-x86_64-20260611.sfx.exe"
+
+New-Item -ItemType Directory -Path $downloadDir -Force | Out-Null
+try {
+    Invoke-WebRequest -Uri $msysURL -OutFile $msysSFX
+    $actualMSYSHash = (Get-FileHash -Algorithm SHA256 -Path $msysSFX).Hash
+    if ($actualMSYSHash -ine $expectedMSYSHash) {
+        throw "MSYS2 SHA-256 mismatch; do not bypass checksum verification."
+    }
+
+    $extract = Start-Process -FilePath $msysSFX `
+        -ArgumentList "-y", "-oC:\" `
+        -Wait -PassThru -NoNewWindow
+    if ($extract.ExitCode -ne 0) { throw "MSYS2 extraction failed." }
+} finally {
+    Remove-Item -LiteralPath $downloadDir -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+if (-not (Test-Path -LiteralPath $msysBash -PathType Leaf)) {
+    throw "MSYS2 bash was not installed at $msysBash."
+}
+
+& $msysBash -lc 'pacman -Sy --needed --noconfirm rsync openssh'
+if ($LASTEXITCODE -ne 0) { throw "MSYS2 rsync/OpenSSH installation failed." }
+
+$requiredTransferTools = @(
+    (Join-Path $msysBin "rsync.exe")
+    (Join-Path $msysBin "ssh.exe")
+)
+foreach ($tool in $requiredTransferTools) {
+    if (-not (Test-Path -LiteralPath $tool -PathType Leaf)) {
+        throw "Required no-WSL transfer tool is missing: $tool"
+    }
+}
+
+$userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+$userPathParts = @($userPath -split ';' | Where-Object { $_ })
+if ($userPathParts -notcontains $msysBin) {
+    [Environment]::SetEnvironmentVariable(
+        "Path",
+        (@($msysBin) + $userPathParts) -join ';',
+        "User"
+    )
+}
+if (($env:Path -split ';') -notcontains $msysBin) {
+    $env:Path = "$msysBin;$env:Path"
+}
+```
+
+The URL and digest above pin the immutable MSYS2 2026-06-11 base archive.
+The digest verifies that archive, while `pacman` installs the current package
+versions rather than pinning them.
+
+This deliberately places `C:\msys64\usr\bin\rsync.exe` and its sibling
+`ssh.exe` together on `PATH`. Crabbox binds native rsync's `-e` remote shell to
+that exact sibling executable, including when the directory contains spaces.
+It still uses System32 OpenSSH for direct control, probes, connect, and tunnel
+commands. Do not remove the sibling MSYS2 `ssh.exe` or substitute System32
+OpenSSH in rsync configuration.
+
+The x64 live proof installed MSYS2 rsync 3.5.0 and OpenSSH 10.5p1, and that
+tuple completed a real 64 MiB Windows-to-Linux sync. Those package versions
+describe the proven run; the `pacman` command above does not pin future installs
+to identical versions. The no-WSL tuple has not been live-proven on Windows
+ARM64, so use WSL2 there.
+
+## Verify the installation
+
+Open a fresh, ordinary PowerShell session and verify the shared native tools:
+
+```powershell
+Get-Command crabbox.exe, git.exe, ssh-keygen.exe, curl.exe
+Test-Path -LiteralPath "$env:WINDIR\System32\OpenSSH\ssh.exe" -PathType Leaf
 crabbox --version
 crabbox doctor
+```
+
+For WSL2, run Crabbox's unqualified default-distribution probe. Both results
+must be Linux paths such as `/usr/bin/rsync` and `/usr/bin/ssh`, never `.exe`
+files or paths below `/mnt/<drive>` or `/mnt/host/<drive>`:
+
+```powershell
+wsl.exe sh -c 'command -v rsync || exit 1; command -v ssh || exit 1'
+```
+
+For no-WSL MSYS2 on x64, verify that PATH-selected rsync and its required
+sibling are the exact two files installed together. `Get-Command ssh.exe` may
+report the MSYS2 binary; Crabbox still selects System32 OpenSSH for direct
+control.
+
+```powershell
+$expectedRsync = "C:\msys64\usr\bin\rsync.exe"
+$expectedSiblingSSH = "C:\msys64\usr\bin\ssh.exe"
+$rsync = (Get-Command rsync.exe -CommandType Application).Source
+$siblingSSH = Join-Path (Split-Path -Parent $rsync) "ssh.exe"
+$rsync
+$siblingSSH
+if ($rsync -ine $expectedRsync -or $siblingSSH -ine $expectedSiblingSSH) {
+    throw "PATH-selected rsync.exe and its sibling ssh.exe are not the verified C:\msys64\usr\bin pair."
+}
+foreach ($tool in @($expectedRsync, $expectedSiblingSSH)) {
+    if (-not (Test-Path -LiteralPath $tool -PathType Leaf)) {
+        throw "Required no-WSL transfer tool is missing: $tool"
+    }
+}
 ```
 
 A provider-neutral `crabbox doctor` can report `no provider selected`. That is
@@ -176,7 +297,7 @@ remote lifecycle command.
 
 If Docker Desktop is already installed and running, this secretless local
 container smoke creates and commits a fixture in a temporary repository, syncs
-that repository through the configured default WSL transport, verifies the
+that repository through the selected Windows transfer transport, verifies the
 fixture in the container, and removes both the container and local repository:
 
 ```powershell
@@ -189,7 +310,7 @@ $smokeRepo = Join-Path ([IO.Path]::GetTempPath()) ("crabbox-windows-sync-" + [gu
 New-Item -ItemType Directory -Path $smokeRepo | Out-Null
 
 try {
-    Set-Content -LiteralPath (Join-Path $smokeRepo "fixture.txt") -Value "crabbox-wsl-sync-ok" -NoNewline
+    Set-Content -LiteralPath (Join-Path $smokeRepo "fixture.txt") -Value "crabbox-windows-sync-ok" -NoNewline
     Push-Location $smokeRepo
     try {
         git init
@@ -201,7 +322,7 @@ try {
         git -c 'user.name=Crabbox Sync Test' -c 'user.email=crabbox-sync-test@example.invalid' commit -m 'test: add sync fixture'
         if ($LASTEXITCODE -ne 0) { throw "git commit failed." }
 
-        crabbox run --provider local-container --local-container-runtime docker --stop-after always -- sh -lc 'test "$(cat fixture.txt)" = "crabbox-wsl-sync-ok"'
+        crabbox run --provider local-container --local-container-runtime docker --stop-after always -- sh -lc 'test "$(cat fixture.txt)" = "crabbox-windows-sync-ok"'
         if ($LASTEXITCODE -ne 0) { throw "Crabbox repository sync smoke failed." }
     } finally {
         Pop-Location

--- a/internal/cli/cp.go
+++ b/internal/cli/cp.go
@@ -141,25 +141,14 @@ func copyOverResolvedSSH(ctx context.Context, target SSHTarget, src, dst string,
 	if err != nil {
 		return err
 	}
-	name := "rsync"
-	commandArgs := args
-	if runtime.GOOS == "windows" {
-		if wslExe != "" {
-			name = wslExe
-			commandArgs = append([]string{"rsync"}, resolvedSSHCopyWSLArgs(args, mountRoot)...)
-		}
+	handle, err := resolvedSSHCopyCommand(ctx, target, args, wslExe, mountRoot)
+	if err != nil {
+		return err
 	}
-	handle := pondMeshExecCommand(ctx, target.ChildEnvDenylist, name, commandArgs...)
 	stderrTail := newSynchronizedTailBuffer(failureTailLines)
 	if execHandle, ok := handle.(*pondMeshExecHandle); ok {
 		execHandle.cmd.Stdout = stdout
 		execHandle.cmd.Stderr = stderrTail
-		if runtime.GOOS == "windows" && wslExe == "" {
-			if execHandle.cmd.Env == nil {
-				execHandle.cmd.Env = os.Environ()
-			}
-			execHandle.cmd.Env = append(execHandle.cmd.Env, "MSYS2_ARG_CONV_EXCL=*", "MSYS_NO_PATHCONV=1", "CYGWIN=nodosfilewarning")
-		}
 	}
 	if err := handle.Start(); err != nil {
 		return fmt.Errorf("start copy over resolved SSH transport: %w", err)
@@ -175,6 +164,35 @@ func copyOverResolvedSSH(ctx context.Context, target SSHTarget, src, dst string,
 		return fmt.Errorf("copy over resolved SSH transport: %w", waitErr)
 	}
 	return nil
+}
+
+func resolvedSSHCopyCommand(ctx context.Context, target SSHTarget, args []string, wslExe, mountRoot string) (pondMeshHandle, error) {
+	return resolvedSSHCopyCommandForGOOS(ctx, runtime.GOOS, target, args, wslExe, mountRoot)
+}
+
+func resolvedSSHCopyCommandForGOOS(ctx context.Context, goos string, target SSHTarget, args []string, wslExe, mountRoot string) (pondMeshHandle, error) {
+	name := "rsync"
+	commandArgs := args
+	nativeWindows := goos == "windows" && wslExe == ""
+	if goos == "windows" {
+		if wslExe != "" {
+			name = wslExe
+			commandArgs = append([]string{"rsync"}, resolvedSSHCopyWSLArgs(args, mountRoot)...)
+		} else {
+			var err error
+			name, commandArgs, err = windowsNativeRsyncCommandSpec(args)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	handle := pondMeshExecCommand(ctx, target.ChildEnvDenylist, name, commandArgs...)
+	if nativeWindows {
+		if execHandle, ok := handle.(*pondMeshExecHandle); ok {
+			applyWindowsNativeRsyncEnvironment(execHandle.cmd)
+		}
+	}
+	return handle, nil
 }
 
 func resolvedSSHCopyWSLArgs(args []string, mountRoot string) []string {
@@ -200,7 +218,7 @@ func probeResolvedSSHRemoteSecludedArgs(ctx context.Context, session *sshTranspo
 		remoteProbe = "wsl.exe " + remoteProbe
 	}
 	args := append(session.commandPrefix(), "-n", session.host(), remoteProbe)
-	name := "ssh"
+	name := directSSHExecutable()
 	if wslExe != "" {
 		name = wslExe
 		args = append([]string{"ssh"}, args...)
@@ -227,12 +245,18 @@ type resolvedRsyncCapabilities struct {
 	safeTransport bool
 }
 
-func resolvedSSHCopyRsyncCapabilities(ctx context.Context, target SSHTarget, wslExe string) resolvedRsyncCapabilities {
+func resolvedSSHCopyRsyncCapabilities(ctx context.Context, target SSHTarget, wslExe string) (resolvedRsyncCapabilities, error) {
 	name := "rsync"
 	prefix := []string(nil)
 	if runtime.GOOS == "windows" && wslExe != "" {
 		name = wslExe
 		prefix = []string{"rsync"}
+	} else if runtime.GOOS == "windows" {
+		var err error
+		name, _, err = resolveWindowsNativeRsyncPair(exec.LookPath, os.Stat)
+		if err != nil {
+			return resolvedRsyncCapabilities{}, err
+		}
 	}
 	capabilities := resolvedRsyncCapabilities{}
 	versionArgs := append(append([]string{}, prefix...), "--version")
@@ -245,7 +269,7 @@ func resolvedSSHCopyRsyncCapabilities(ctx context.Context, target SSHTarget, wsl
 			capabilities.safeTransport = rsyncVersionAtLeast(major, minor, patch, 3, 4, 3)
 		}
 	}
-	return capabilities
+	return capabilities, nil
 }
 
 func parseRsyncVersion(output string) (int, int, int, string, bool) {
@@ -301,18 +325,29 @@ func redactSSHTransportDiagnostic(target SSHTarget, value string) string {
 
 func newResolvedSSHCopySession(ctx context.Context, target SSHTarget) (*sshTransportSession, string, string, resolvedRsyncCapabilities, error) {
 	if !sshCopyUsesWSL(runtime.GOOS, target) {
+		capabilities, err := resolvedSSHCopyRsyncCapabilities(ctx, target, "")
+		if err != nil {
+			return nil, "", "", resolvedRsyncCapabilities{}, err
+		}
 		session, err := newSSHTransportSession(ctx, target, false)
-		return session, "", "", resolvedSSHCopyRsyncCapabilities(ctx, target, ""), err
+		return session, "", "", capabilities, err
 	}
 	wslExe, ok := windowsRsyncWSLExecutable(ctx, target)
 	if !ok {
+		capabilities, err := resolvedSSHCopyRsyncCapabilities(ctx, target, "")
+		if err != nil {
+			return nil, "", "", resolvedRsyncCapabilities{}, err
+		}
 		session, err := newSSHTransportSession(ctx, target, false)
-		return session, "", "", resolvedSSHCopyRsyncCapabilities(ctx, target, ""), err
+		return session, "", "", capabilities, err
 	}
-	wslCapabilities := resolvedSSHCopyRsyncCapabilities(ctx, target, wslExe)
+	wslCapabilities, err := resolvedSSHCopyRsyncCapabilities(ctx, target, wslExe)
+	if err != nil {
+		return nil, "", "", resolvedRsyncCapabilities{}, err
+	}
 	if !wslCapabilities.safeTransport {
-		nativeCapabilities := resolvedSSHCopyRsyncCapabilities(ctx, target, "")
-		if preferNativeResolvedRsync(wslCapabilities, nativeCapabilities) {
+		nativeCapabilities, nativeErr := resolvedSSHCopyRsyncCapabilities(ctx, target, "")
+		if nativeErr == nil && preferNativeResolvedRsync(wslCapabilities, nativeCapabilities) {
 			session, err := newSSHTransportSession(ctx, target, false)
 			return session, "", "", nativeCapabilities, err
 		}

--- a/internal/cli/cp_archive.go
+++ b/internal/cli/cp_archive.go
@@ -151,7 +151,7 @@ func (w *copyArchiveBoundedWriter) Write(data []byte) (int, error) {
 
 func runResolvedSSHArchiveCommand(ctx context.Context, session *sshTransportSession, target SSHTarget, remote string, stdin io.Reader, stdout io.Writer, stderr anyWriter) error {
 	args := append(session.commandPrefix(), "-T", "--", session.host(), wrapRemoteForTarget(target, remote))
-	handle := pondMeshExecCommand(ctx, target.ChildEnvDenylist, "ssh", args...)
+	handle := pondMeshExecCommand(ctx, target.ChildEnvDenylist, directSSHExecutable(), args...)
 	execHandle, ok := handle.(*pondMeshExecHandle)
 	if !ok {
 		return errors.New("resolved SSH archive transport does not expose process streams")

--- a/internal/cli/cp_ssh_test.go
+++ b/internal/cli/cp_ssh_test.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -10,6 +12,58 @@ import (
 	"strings"
 	"testing"
 )
+
+func TestResolvedSSHCopyCommandUsesNativeWindowsSiblingPair(t *testing.T) {
+	toolDir := filepath.Join(t.TempDir(), "MSYS2 tools")
+	if err := os.MkdirAll(toolDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"rsync.exe", "ssh.exe"} {
+		if err := os.WriteFile(filepath.Join(toolDir, name), []byte("fixture"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("PATH", toolDir)
+	handle, err := resolvedSSHCopyCommandForGOOS(context.Background(), "windows", SSHTarget{}, []string{
+		"-az", "-e", "'ssh' '-F' 'private config'", "--", "source", "target:dest",
+	}, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	execHandle, ok := handle.(*pondMeshExecHandle)
+	if !ok {
+		t.Fatalf("handle=%T", handle)
+	}
+	if execHandle.cmd.Path != filepath.Join(toolDir, "rsync.exe") {
+		t.Fatalf("rsync path=%q", execHandle.cmd.Path)
+	}
+	wantSSH := rsyncShellWords([]string{filepath.Join(toolDir, "ssh.exe")})[0]
+	if got := execHandle.cmd.Args[3]; !strings.HasPrefix(got, wantSSH+" ") || !strings.Contains(got, "'private config'") {
+		t.Fatalf("paired remote shell=%q", got)
+	}
+	joinedEnv := strings.Join(execHandle.cmd.Env, "\n")
+	if !strings.Contains(joinedEnv, "MSYS2_ARG_CONV_EXCL=*") || !strings.Contains(joinedEnv, "MSYS_NO_PATHCONV=1") || !strings.Contains(joinedEnv, "CYGWIN=nodosfilewarning") {
+		t.Fatalf("native rsync environment=%q", execHandle.cmd.Env)
+	}
+}
+
+func TestResolvedSSHCopyCommandFailsClosedWithoutNativeWindowsSibling(t *testing.T) {
+	toolDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(toolDir, "rsync.exe"), []byte("fixture"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", toolDir)
+	_, err := resolvedSSHCopyCommandForGOOS(context.Background(), "windows", SSHTarget{}, []string{
+		"-az", "-e", "'ssh' '-F' 'private config'", "--", "source", "target:dest",
+	}, "", "")
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("error=%v, want exit 2", err)
+	}
+	if !strings.Contains(err.Error(), "sibling OpenSSH") || !strings.Contains(err.Error(), "WSL2") {
+		t.Fatalf("diagnostic=%q", err)
+	}
+}
 
 func TestResolvedSSHCopyArgs(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())

--- a/internal/cli/parallels.go
+++ b/internal/cli/parallels.go
@@ -720,7 +720,7 @@ func (c *ParallelsClient) prlctl(ctx context.Context, extraEnv []string, args ..
 			host = c.Cfg.Parallels.HostUser + "@" + host
 		}
 		sshArgs = append(sshArgs, host, remote)
-		return c.Runner.Run(ctx, LocalCommandRequest{Name: "ssh", Args: sshArgs, Env: extraEnv})
+		return c.Runner.Run(ctx, LocalCommandRequest{Name: directSSHExecutable(), Args: sshArgs, Env: extraEnv})
 	}
 	return c.Runner.Run(ctx, LocalCommandRequest{Name: "prlctl", Args: args, Env: extraEnv})
 }

--- a/internal/cli/pond_mesh.go
+++ b/internal/cli/pond_mesh.go
@@ -476,7 +476,7 @@ func (a App) pondConnect(ctx context.Context, args []string) error {
 		var startedGroups []pondMeshForwardGroup
 		for _, group := range groups {
 			args := pondMeshSSHArgsForForwards(group.Target, group.Forwards)
-			handle := pondMeshRunnerCommand(context.Background(), daemonRunner, group.Target, "ssh", args...)
+			handle := pondMeshRunnerCommand(context.Background(), daemonRunner, group.Target, directSSHExecutable(), args...)
 			if err := handle.Start(); err != nil {
 				stopDaemonHandles(started)
 				return fmt.Errorf("start ssh forwards for %s: %w", pondMeshForwardGroupLabel(group.Forwards), err)
@@ -1171,7 +1171,7 @@ func runPondMeshForwards(ctx context.Context, opts pondConnectOptions, members [
 	}
 	for _, group := range groups {
 		args := pondMeshSSHArgsForForwards(group.Target, group.Forwards)
-		handle := pondMeshRunnerCommand(ctx, runner, group.Target, "ssh", args...)
+		handle := pondMeshRunnerCommand(ctx, runner, group.Target, directSSHExecutable(), args...)
 		if err := handle.Start(); err != nil {
 			parentErr := terminationCtx.Err()
 			cancel()

--- a/internal/cli/pond_mesh_cancel_windows_test.go
+++ b/internal/cli/pond_mesh_cancel_windows_test.go
@@ -47,6 +47,7 @@ func TestPondMeshCancelRunForwardsReturnsNoErrorOnWindows(t *testing.T) {
 		t.Fatal(err)
 	}
 	ready := filepath.Join(t.TempDir(), "ready")
+	t.Setenv("WINDIR", t.TempDir())
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	t.Setenv(pondMeshWindowsCancelHelperEnv, "1")
 	t.Setenv("CRABBOX_POND_MESH_WINDOWS_CANCEL_READY", ready)

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha1"
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -202,8 +203,27 @@ func applyTargetChildEnvironment(cmd *exec.Cmd, target SSHTarget) {
 	cmd.Env = env
 }
 
+func directSSHExecutable() string {
+	return directSSHExecutableForGOOS(runtime.GOOS, os.Getenv, os.Stat)
+}
+
+func directSSHExecutableForGOOS(goos string, getenv func(string) string, stat func(string) (os.FileInfo, error)) string {
+	if goos != "windows" {
+		return "ssh"
+	}
+	windowsDir := strings.TrimSpace(getenv("WINDIR"))
+	if windowsDir == "" {
+		return "ssh"
+	}
+	candidate := filepath.Join(windowsDir, "System32", "OpenSSH", "ssh.exe")
+	if info, err := stat(candidate); err == nil && info.Mode().IsRegular() {
+		return candidate
+	}
+	return "ssh"
+}
+
 func sshCommandContext(ctx context.Context, target SSHTarget, args ...string) *exec.Cmd {
-	cmd := exec.CommandContext(ctx, "ssh", args...)
+	cmd := exec.CommandContext(ctx, directSSHExecutable(), args...)
 	applyTargetChildEnvironment(cmd, target)
 	return cmd
 }
@@ -575,9 +595,16 @@ func runIdempotentSSHCombinedOutput(ctx context.Context, target SSHTarget, remot
 	return lastOut, lastErr
 }
 
-func runWSL2ControlScriptCombinedOutput(ctx context.Context, target SSHTarget, remote string, waitTimeout time.Duration, connectTimeout, connectionAttempts string) (string, error) {
+func runWSL2ControlScriptCombinedOutput(ctx context.Context, target SSHTarget, remote string, waitTimeout time.Duration, connectTimeout, connectionAttempts string) (output string, err error) {
 	remote = wrapWorkspaceOwnerRemote(ctx, remote, false)
 	command := wsl2StdinScriptCommandWithWaitTimeout(waitTimeout)
+	input, err := newReplayableSSHInput([]byte(remote))
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		err = errors.Join(err, input.close())
+	}()
 	var lastOut []byte
 	var lastErr error
 	for _, port := range sshPortCandidates(target.Port, target.FallbackPorts) {
@@ -585,9 +612,12 @@ func runWSL2ControlScriptCombinedOutput(ctx context.Context, target SSHTarget, r
 		probe.Port = port
 		probe.FallbackPorts = []string{}
 		cmd := sshCommandContext(ctx, probe, sshArgsWithOptions(probe, command, connectTimeout, connectionAttempts)...)
-		cmd.Stdin = strings.NewReader(remote)
+		cmd.Stdin, err = input.reset()
+		if err != nil {
+			return "", err
+		}
 		var out synchronizedBuffer
-		err := runSSHCommand(cmd, &out, &out)
+		err = runSSHCommand(cmd, &out, &out)
 		if err == nil {
 			return strings.TrimSpace(out.String()), nil
 		}
@@ -604,7 +634,7 @@ func runSSHInputQuiet(ctx context.Context, target SSHTarget, remote, input strin
 	return runSSHInput(ctx, target, remote, strings.NewReader(input), io.Discard, io.Discard)
 }
 
-func runSSHInput(ctx context.Context, target SSHTarget, remote string, input io.Reader, stdout, stderr io.Writer) error {
+func runSSHInput(ctx context.Context, target SSHTarget, remote string, input io.Reader, stdout, stderr io.Writer) (err error) {
 	remote = wrapWorkspaceOwnerRemote(ctx, remote, true)
 	remote = wrapRemoteForTarget(target, remote)
 	if input == nil {
@@ -614,13 +644,23 @@ func runSSHInput(ctx context.Context, target SSHTarget, remote string, input io.
 	if err != nil {
 		return err
 	}
+	replayableInput, err := newReplayableSSHInput(data)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err = errors.Join(err, replayableInput.close())
+	}()
 	var lastErr error
 	for _, port := range sshPortCandidates(target.Port, target.FallbackPorts) {
 		probe := target
 		probe.Port = port
 		cmd := sshCommandContext(ctx, probe, sshArgs(probe, remote)...)
-		cmd.Stdin = bytes.NewReader(data)
-		err := runSSHCommand(cmd, stdout, stderr)
+		cmd.Stdin, err = replayableInput.reset()
+		if err != nil {
+			return err
+		}
+		err = runSSHCommand(cmd, stdout, stderr)
 		if err == nil {
 			return nil
 		}
@@ -877,21 +917,6 @@ func rsync(ctx context.Context, target SSHTarget, src, dst string, excludes []st
 		ctx, cancel = context.WithTimeout(ctx, opts.Timeout)
 		defer cancel()
 	}
-	owner := workspaceOwnerFromContext(ctx)
-	guardStarted := false
-	if owner != nil && !isWindowsNativeTarget(target) {
-		rawCtx := contextWithoutWorkspaceOwner(ctx)
-		if err := runSSHQuiet(rawCtx, target, owner.rsyncPrepareCommand()); err != nil {
-			return exit(7, "prepare rsync workspace witness: %v", err)
-		}
-		if _, err := runSSHOutput(rawCtx, target, owner.WrapBackgroundCommand(owner.rsyncGuardPayload(dst))); err != nil {
-			return exit(7, "start rsync workspace witness: %v", err)
-		}
-		if err := owner.WaitForChild(rawCtx, 10*time.Second); err != nil {
-			return err
-		}
-		guardStarted = true
-	}
 	args := []string{
 		"-az",
 		"-e", strings.Join(shellWords(append([]string{"ssh"}, sshBaseArgs(target)...)), " "),
@@ -920,21 +945,40 @@ func rsync(ctx context.Context, target SSHTarget, src, dst string, excludes []st
 		args = append(args, "--stats", "--itemize-changes", "--progress")
 	}
 	args = append(args, ensureTrailingSlash(rsyncLocalPath(src)), target.User+"@"+target.Host+":"+dst+"/")
-	start := time.Now()
 	var cmd *exec.Cmd
+	var err error
 	if runtime.GOOS == "windows" {
-		cmd = windowsRsyncCommand(ctx, target, args)
+		cmd, err = windowsRsyncCommand(ctx, target, args)
+		if err != nil {
+			return err
+		}
 	} else {
 		cmd = exec.CommandContext(ctx, "rsync", args...)
 	}
 	applyTargetChildEnvironment(cmd, target)
+	owner := workspaceOwnerFromContext(ctx)
+	guardStarted := false
+	if owner != nil && !isWindowsNativeTarget(target) {
+		rawCtx := contextWithoutWorkspaceOwner(ctx)
+		if err := runSSHQuiet(rawCtx, target, owner.rsyncPrepareCommand()); err != nil {
+			return exit(7, "prepare rsync workspace witness: %v", err)
+		}
+		if _, err := runSSHOutput(rawCtx, target, owner.WrapBackgroundCommand(owner.rsyncGuardPayload(dst))); err != nil {
+			return exit(7, "start rsync workspace witness: %v", err)
+		}
+		if err := owner.WaitForChild(rawCtx, 10*time.Second); err != nil {
+			return err
+		}
+		guardStarted = true
+	}
+	start := time.Now()
 	if opts.UseFilesFrom {
 		cmd.Stdin = bytes.NewReader(opts.FilesFrom)
 	}
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 	stopHeartbeat := startSyncHeartbeat(stderr, start, opts.HeartbeatInterval)
-	err := cmd.Run()
+	err = cmd.Run()
 	stopHeartbeat()
 	if guardStarted {
 		guardCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 20*time.Second)
@@ -1115,7 +1159,7 @@ func rsyncLocalPathForGOOS(goos, path string) string {
 // processes, so we prefer WSL rsync when available. The SSH key is copied
 // into WSL /tmp with correct permissions, and paths within args are
 // converted to WSL mount paths.
-func windowsRsyncCommand(ctx context.Context, target SSHTarget, args []string) *exec.Cmd {
+func windowsRsyncCommand(ctx context.Context, target SSHTarget, args []string) (*exec.Cmd, error) {
 	wslExe, ok := windowsRsyncWSLExecutable(ctx, target)
 	if !ok {
 		return windowsNativeRsyncCommand(ctx, args)
@@ -1134,7 +1178,7 @@ func windowsRsyncWSLExecutable(ctx context.Context, target SSHTarget) (string, b
 	return wslExe, true
 }
 
-func windowsWSLRsyncCommand(ctx context.Context, target SSHTarget, args []string, wslExe string) *exec.Cmd {
+func windowsWSLRsyncCommand(ctx context.Context, target SSHTarget, args []string, wslExe string) (*exec.Cmd, error) {
 	mountRoot := windowsWSLMountRoot(ctx, target, wslExe)
 
 	// Prepare WSL key: copy with correct permissions.
@@ -1191,13 +1235,72 @@ func windowsWSLRsyncCommand(ctx context.Context, target SSHTarget, args []string
 		}
 		wslArgs[i] = converted
 	}
-	return exec.CommandContext(ctx, wslExe, append([]string{"rsync"}, wslArgs...)...)
+	return exec.CommandContext(ctx, wslExe, append([]string{"rsync"}, wslArgs...)...), nil
 }
 
-func windowsNativeRsyncCommand(ctx context.Context, args []string) *exec.Cmd {
-	cmd := exec.CommandContext(ctx, "rsync", args...)
-	cmd.Env = append(os.Environ(), "MSYS2_ARG_CONV_EXCL=*", "MSYS_NO_PATHCONV=1", "CYGWIN=nodosfilewarning")
-	return cmd
+func windowsNativeRsyncCommand(ctx context.Context, args []string) (*exec.Cmd, error) {
+	name, pairedArgs, err := windowsNativeRsyncCommandSpec(args)
+	if err != nil {
+		return nil, err
+	}
+	cmd := exec.CommandContext(ctx, name, pairedArgs...)
+	applyWindowsNativeRsyncEnvironment(cmd)
+	return cmd, nil
+}
+
+func windowsNativeRsyncCommandSpec(args []string) (string, []string, error) {
+	rsyncPath, sshPath, err := resolveWindowsNativeRsyncPair(exec.LookPath, os.Stat)
+	if err != nil {
+		return "", nil, err
+	}
+	pairedArgs, err := bindWindowsNativeRsyncSSH(args, sshPath)
+	if err != nil {
+		return "", nil, err
+	}
+	return rsyncPath, pairedArgs, nil
+}
+
+func resolveWindowsNativeRsyncPair(lookPath func(string) (string, error), stat func(string) (os.FileInfo, error)) (string, string, error) {
+	rsyncPath, err := lookPath("rsync.exe")
+	if err != nil {
+		return "", "", exit(2, "native Windows transfers require rsync.exe on PATH with a sibling ssh.exe in the same directory; install MSYS2 rsync and OpenSSH together, or use the supported WSL2 transport")
+	}
+	if absolute, absoluteErr := filepath.Abs(rsyncPath); absoluteErr == nil {
+		rsyncPath = absolute
+	}
+	sshPath := filepath.Join(filepath.Dir(rsyncPath), "ssh.exe")
+	info, err := stat(sshPath)
+	if err != nil || !info.Mode().IsRegular() {
+		return "", "", exit(2, "native Windows rsync requires its matching sibling OpenSSH at %s next to %s; install MSYS2 rsync and OpenSSH together, or use the supported WSL2 transport", sshPath, rsyncPath)
+	}
+	return rsyncPath, sshPath, nil
+}
+
+func bindWindowsNativeRsyncSSH(args []string, sshPath string) ([]string, error) {
+	paired := append([]string(nil), args...)
+	for index := 0; index < len(paired); index++ {
+		if paired[index] != "-e" {
+			continue
+		}
+		if index+1 >= len(paired) {
+			return nil, exit(2, "native Windows rsync command is missing its owned -e remote shell value")
+		}
+		const ownedSSH = "'ssh'"
+		remoteShell := paired[index+1]
+		if !strings.HasPrefix(remoteShell, ownedSSH) || len(remoteShell) > len(ownedSSH) && remoteShell[len(ownedSSH)] != ' ' {
+			return nil, exit(2, "native Windows rsync command has an unsupported -e remote shell; Crabbox must own the OpenSSH pairing")
+		}
+		paired[index+1] = rsyncShellWords([]string{sshPath})[0] + remoteShell[len(ownedSSH):]
+		return paired, nil
+	}
+	return nil, exit(2, "native Windows rsync command is missing its owned -e remote shell")
+}
+
+func applyWindowsNativeRsyncEnvironment(cmd *exec.Cmd) {
+	if cmd.Env == nil {
+		cmd.Env = os.Environ()
+	}
+	cmd.Env = append(cmd.Env, "MSYS2_ARG_CONV_EXCL=*", "MSYS_NO_PATHCONV=1", "CYGWIN=nodosfilewarning")
 }
 
 func windowsHostPath(path string) string {
@@ -1702,15 +1805,35 @@ func remoteWriteSyncManifestsNew(workdir, finalizeToken string) string {
 	deletedName := remoteSyncPendingDeletedName(finalizeToken)
 	script := "set -e\nmkdir -p " + shellQuote(workdir) + "\ncd " + shellQuote(workdir) + "\n" + remoteSyncMetaDirScript() + `mkdir -p "$meta_dir"
 ` + remoteSyncAbandonedMetadataCleanup() + `
-IFS= read -r manifest_len
+if ! IFS= read -r manifest_len; then
+  echo "invalid sync manifest length" >&2
+  exit 1
+fi
 case "$manifest_len" in
-  ''|*[!0-9]*) echo "invalid sync manifest length" >&2; exit 1 ;;
+  ''|*[!0-9]*|0[0-9]*) echo "invalid sync manifest length" >&2; exit 1 ;;
+esac
+if ! IFS= read -r deleted_len; then
+  echo "invalid sync deleted length" >&2
+  exit 1
+fi
+case "$deleted_len" in
+  ''|*[!0-9]*|0[0-9]*) echo "invalid sync deleted length" >&2; exit 1 ;;
 esac
 # Keep this to POSIX dd operands: minimal guests commonly provide BusyBox dd,
-# which rejects GNU's progress-suppression extension. Suppress only the summary;
-# dd's exit status still makes the fail-closed script abort on a short write.
+# which rejects GNU's progress-suppression extension. Check the output size too:
+# portable dd can exit successfully after reading fewer records than requested.
 dd bs=1 count="$manifest_len" of="$meta_dir/` + manifestName + `" 2>/dev/null
-cat > "$meta_dir/` + deletedName + `"
+manifest_size=$(wc -c < "$meta_dir/` + manifestName + `" | tr -d '[:space:]')
+if [ "$manifest_size" != "$manifest_len" ]; then
+  echo "short sync manifest: got $manifest_size want $manifest_len" >&2
+  exit 1
+fi
+dd bs=1 count="$deleted_len" of="$meta_dir/` + deletedName + `" 2>/dev/null
+deleted_size=$(wc -c < "$meta_dir/` + deletedName + `" | tr -d '[:space:]')
+if [ "$deleted_size" != "$deleted_len" ]; then
+  echo "short sync deleted manifest: got $deleted_size want $deleted_len" >&2
+  exit 1
+fi
 `
 	return "bash -lc " + shellQuote(script)
 }
@@ -1721,7 +1844,7 @@ func syncManifestInputForTarget(target SSHTarget, manifestData, deletedData []by
 		deletedEncoded := base64.StdEncoding.EncodeToString(deletedData)
 		return fmt.Sprintf("%d\n%d\n", len(manifestEncoded), len(deletedEncoded)) + manifestEncoded + deletedEncoded
 	}
-	return fmt.Sprintf("%d\n", len(manifestData)) + string(manifestData) + string(deletedData)
+	return fmt.Sprintf("%d\n%d\n", len(manifestData), len(deletedData)) + string(manifestData) + string(deletedData)
 }
 
 func remoteWriteSyncManifestsNewForTarget(target SSHTarget, workdir, finalizeToken string) string {

--- a/internal/cli/ssh_input_other.go
+++ b/internal/cli/ssh_input_other.go
@@ -1,0 +1,27 @@
+//go:build !windows
+
+package cli
+
+import (
+	"bytes"
+	"io"
+)
+
+type replayableSSHInput struct {
+	reader *bytes.Reader
+}
+
+func newReplayableSSHInput(data []byte) (*replayableSSHInput, error) {
+	return &replayableSSHInput{reader: bytes.NewReader(data)}, nil
+}
+
+func (input *replayableSSHInput) reset() (io.Reader, error) {
+	if _, err := input.reader.Seek(0, io.SeekStart); err != nil {
+		return nil, err
+	}
+	return input.reader, nil
+}
+
+func (*replayableSSHInput) close() error {
+	return nil
+}

--- a/internal/cli/ssh_input_other_test.go
+++ b/internal/cli/ssh_input_other_test.go
@@ -1,0 +1,42 @@
+//go:build !windows
+
+package cli
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+func TestReplayableSSHInputRemainsInMemoryAndResets(t *testing.T) {
+	want := []byte{'a', 0, 'b', '\n'}
+	input, err := newReplayableSSHInput(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer input.close()
+
+	first, err := input.reset()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := first.(*bytes.Reader); !ok {
+		t.Fatalf("reader=%T, want *bytes.Reader", first)
+	}
+	prefix := make([]byte, 2)
+	if _, err := io.ReadFull(first, prefix); err != nil {
+		t.Fatal(err)
+	}
+
+	second, err := input.reset()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := io.ReadAll(second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("replayed input=%v, want %v", got, want)
+	}
+}

--- a/internal/cli/ssh_input_windows.go
+++ b/internal/cli/ssh_input_windows.go
@@ -1,0 +1,124 @@
+//go:build windows
+
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/windows"
+)
+
+type replayableSSHInput struct {
+	reader *os.File
+	path   string
+}
+
+// Windows inbox OpenSSH can stall waiting for EOF from Go's anonymous stdin
+// pipe. Finite SSH payloads use a private regular file so EOF is file-backed.
+func newReplayableSSHInput(data []byte) (*replayableSSHInput, error) {
+	security, err := commandStreamFileSecurity()
+	if err != nil {
+		return nil, err
+	}
+	path := filepath.Join(os.TempDir(), "crabbox-ssh-"+strings.TrimPrefix(newLeaseID(), "cbx_")+".tmp")
+	pathUTF16, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return nil, err
+	}
+	const fileFlags = windows.FILE_ATTRIBUTE_NORMAL | windows.FILE_FLAG_SEQUENTIAL_SCAN
+	handle, err := windows.CreateFile(
+		pathUTF16,
+		windows.GENERIC_WRITE,
+		0,
+		security,
+		windows.CREATE_NEW,
+		fileFlags,
+		0,
+	)
+	if err != nil {
+		return nil, err
+	}
+	writer := os.NewFile(uintptr(handle), path)
+	if writer == nil {
+		return nil, errors.Join(
+			errors.New("create SSH input spool file"),
+			windows.CloseHandle(handle),
+			removeReplayableSSHInputPath(path),
+		)
+	}
+	cleanupWriter := func(cause error) (*replayableSSHInput, error) {
+		return nil, errors.Join(cause, writer.Close(), removeReplayableSSHInputPath(path))
+	}
+	if n, err := writer.Write(data); err != nil {
+		return cleanupWriter(fmt.Errorf("write SSH input spool: %w", err))
+	} else if n != len(data) {
+		return cleanupWriter(fmt.Errorf("write SSH input spool: %w", io.ErrShortWrite))
+	}
+	if err := writer.Sync(); err != nil {
+		return cleanupWriter(fmt.Errorf("flush SSH input spool: %w", err))
+	}
+	if err := writer.Close(); err != nil {
+		return nil, errors.Join(
+			fmt.Errorf("close SSH input spool writer: %w", err),
+			removeReplayableSSHInputPath(path),
+		)
+	}
+
+	reader, err := os.Open(path)
+	if err != nil {
+		return nil, errors.Join(
+			fmt.Errorf("reopen SSH input spool read-only: %w", err),
+			removeReplayableSSHInputPath(path),
+		)
+	}
+	input := &replayableSSHInput{reader: reader, path: path}
+	user, err := currentWindowsUserSID()
+	if err != nil {
+		return nil, errors.Join(err, input.close())
+	}
+	if err := verifyPrivateWindowsHandle(windows.Handle(reader.Fd()), false, user); err != nil {
+		return nil, errors.Join(fmt.Errorf("verify SSH input spool privacy: %w", err), input.close())
+	}
+	return input, nil
+}
+
+func (input *replayableSSHInput) reset() (io.Reader, error) {
+	if input.reader == nil {
+		return nil, errors.New("SSH input spool is closed")
+	}
+	if _, err := input.reader.Seek(0, io.SeekStart); err != nil {
+		return nil, err
+	}
+	return input.reader, nil
+}
+
+func (input *replayableSSHInput) close() error {
+	var errs []error
+	if input.reader != nil {
+		errs = append(errs, input.reader.Close())
+		input.reader = nil
+	}
+	if input.path != "" {
+		if err := removeReplayableSSHInputPath(input.path); err != nil {
+			errs = append(errs, err)
+		} else {
+			input.path = ""
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func removeReplayableSSHInputPath(path string) error {
+	if path == "" {
+		return nil
+	}
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove SSH input spool: %w", err)
+	}
+	return nil
+}

--- a/internal/cli/ssh_input_windows_test.go
+++ b/internal/cli/ssh_input_windows_test.go
@@ -1,0 +1,79 @@
+//go:build windows
+
+package cli
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestReplayableSSHInputUsesPrivatePathBackedRegularFileAndResets(t *testing.T) {
+	want := []byte{'a', 0, 'b', '\n'}
+	input, err := newReplayableSSHInput(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := input.path
+	t.Cleanup(func() {
+		if err := input.close(); err != nil {
+			t.Errorf("close input: %v", err)
+		}
+	})
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("private input spool is not path-backed at %s: %v", path, err)
+	}
+	if !info.Mode().IsRegular() {
+		t.Fatalf("input mode=%v, want regular file", info.Mode())
+	}
+	user, err := currentWindowsUserSID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := verifyPrivateWindowsHandle(windows.Handle(input.reader.Fd()), false, user); err != nil {
+		t.Fatalf("input spool is not current-user private: %v", err)
+	}
+	if _, err := input.reader.Write([]byte("x")); err == nil {
+		t.Fatal("input spool reader is writable, want read-only handle")
+	}
+
+	first, err := input.reset()
+	if err != nil {
+		t.Fatal(err)
+	}
+	file, ok := first.(*os.File)
+	if !ok {
+		t.Fatalf("reader=%T, want *os.File", first)
+	}
+	prefix := make([]byte, 2)
+	if _, err := io.ReadFull(file, prefix); err != nil {
+		t.Fatal(err)
+	}
+
+	second, err := input.reset()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := io.ReadAll(second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("replayed input=%v, want %v", got, want)
+	}
+
+	if err := input.close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := input.close(); err != nil {
+		t.Fatalf("second close: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("input spool remains after close at %s: %v", path, err)
+	}
+}

--- a/internal/cli/ssh_stream_windows.go
+++ b/internal/cli/ssh_stream_windows.go
@@ -385,17 +385,8 @@ func closeCommandThreadHandles(handles []windows.Handle) {
 }
 
 func commandStreamFileSecurity() (*windows.SecurityAttributes, error) {
-	user, err := windows.GetCurrentProcessToken().GetTokenUser()
-	if err != nil {
-		return nil, err
-	}
-	sd, err := windows.SecurityDescriptorFromString("D:P(A;;GA;;;" + user.User.Sid.String() + ")")
-	if err != nil {
-		return nil, err
-	}
-	attributes := &windows.SecurityAttributes{SecurityDescriptor: sd}
-	attributes.Length = uint32(unsafe.Sizeof(*attributes))
-	return attributes, nil
+	attributes, _, err := privateWindowsSecurityAttributes(false)
+	return attributes, err
 }
 
 func markCommandStreamDeletePending(handle windows.Handle, path *uint16) error {

--- a/internal/cli/ssh_stream_windows_test.go
+++ b/internal/cli/ssh_stream_windows_test.go
@@ -93,6 +93,20 @@ func TestRunCommandWithPlatformStreamsAllowsNilWriters(t *testing.T) {
 	}
 }
 
+func TestCommandStreamFileSecurityIsCurrentUserPrivate(t *testing.T) {
+	attributes, err := commandStreamFileSecurity()
+	if err != nil {
+		t.Fatal(err)
+	}
+	user, err := currentWindowsUserSID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validateCurrentUserPrivateWindowsDescriptor(attributes.SecurityDescriptor, user); err != nil {
+		t.Fatalf("command stream security is not current-user private: %v", err)
+	}
+}
+
 func TestCommandStreamRotationNeededBoundsSpool(t *testing.T) {
 	spool, err := newCommandStreamSpool()
 	if err != nil {

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -22,6 +22,149 @@ import (
 
 const powerShellEncodedCommandPrefix = "powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand "
 
+func TestDirectSSHExecutableSelection(t *testing.T) {
+	windowsDir := t.TempDir()
+	nativeSSH := filepath.Join(windowsDir, "System32", "OpenSSH", "ssh.exe")
+	if err := os.MkdirAll(filepath.Dir(nativeSSH), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(nativeSSH, []byte("fixture"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name       string
+		goos       string
+		windowsDir string
+		want       string
+	}{
+		{name: "Windows native path exists", goos: "windows", windowsDir: windowsDir, want: nativeSSH},
+		{name: "Windows native path missing", goos: "windows", windowsDir: filepath.Join(t.TempDir(), "missing"), want: "ssh"},
+		{name: "non-Windows", goos: "linux", windowsDir: windowsDir, want: "ssh"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := directSSHExecutableForGOOS(test.goos, func(name string) string {
+				if name != "WINDIR" {
+					t.Fatalf("environment lookup=%q", name)
+				}
+				return test.windowsDir
+			}, os.Stat)
+			if got != test.want {
+				t.Fatalf("executable=%q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestResolveWindowsNativeRsyncPairUsesExactSibling(t *testing.T) {
+	toolDir := filepath.Join(t.TempDir(), "MSYS2 tools with spaces")
+	if err := os.MkdirAll(toolDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rsyncPath := filepath.Join(toolDir, "rsync.exe")
+	sshPath := filepath.Join(toolDir, "ssh.exe")
+	for _, path := range []string{rsyncPath, sshPath} {
+		if err := os.WriteFile(path, []byte("fixture"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	gotRsync, gotSSH, err := resolveWindowsNativeRsyncPair(func(name string) (string, error) {
+		if name != "rsync.exe" {
+			t.Fatalf("lookup=%q", name)
+		}
+		return rsyncPath, nil
+	}, os.Stat)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotRsync != rsyncPath || gotSSH != sshPath {
+		t.Fatalf("pair=(%q, %q), want (%q, %q)", gotRsync, gotSSH, rsyncPath, sshPath)
+	}
+}
+
+func TestResolveWindowsNativeRsyncPairFailsClosedWithoutSibling(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		directory bool
+	}{
+		{name: "missing"},
+		{name: "not a regular file", directory: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			toolDir := t.TempDir()
+			rsyncPath := filepath.Join(toolDir, "rsync.exe")
+			if err := os.WriteFile(rsyncPath, []byte("fixture"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if test.directory {
+				if err := os.Mkdir(filepath.Join(toolDir, "ssh.exe"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			}
+			_, _, err := resolveWindowsNativeRsyncPair(func(string) (string, error) { return rsyncPath, nil }, os.Stat)
+			var exitErr ExitError
+			if !errors.As(err, &exitErr) || exitErr.Code != 2 {
+				t.Fatalf("error=%v, want exit 2", err)
+			}
+			for _, want := range []string{"sibling OpenSSH", "ssh.exe", "WSL2"} {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("diagnostic=%q missing %q", err, want)
+				}
+			}
+		})
+	}
+}
+
+func TestBindWindowsNativeRsyncSSHPreservesOwnedArguments(t *testing.T) {
+	sshPath := `C:\Program Files\MSYS2\usr\bin\ssh.exe`
+	remoteShell := `'ssh' '-F' 'C:\Users\alice\private ssh_config' '-o' 'ProxyCommand=provider-helper token'`
+	args := []string{"-az", "-e", remoteShell, "--", "source", "target:/work/repo"}
+	got, err := bindWindowsNativeRsyncSSH(args, sshPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantShell := rsyncShellWords([]string{sshPath})[0] + remoteShell[len("'ssh'"):]
+	if got[2] != wantShell {
+		t.Fatalf("remote shell=%q, want %q", got[2], wantShell)
+	}
+	if !reflect.DeepEqual(got[:2], args[:2]) || !reflect.DeepEqual(got[3:], args[3:]) {
+		t.Fatalf("paired args changed unrelated values: got=%#v want=%#v", got, args)
+	}
+	if args[2] != remoteShell {
+		t.Fatalf("input args mutated: %#v", args)
+	}
+}
+
+func TestWindowsNativeRsyncCommandUsesSiblingPairAndEnvironment(t *testing.T) {
+	toolDir := filepath.Join(t.TempDir(), "native tools")
+	if err := os.MkdirAll(toolDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"rsync.exe", "ssh.exe"} {
+		if err := os.WriteFile(filepath.Join(toolDir, name), []byte("fixture"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("PATH", toolDir)
+	cmd, err := windowsNativeRsyncCommand(t.Context(), []string{"-e", "'ssh' '-i' 'injected key'", "source", "host:dest"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cmd.Path != filepath.Join(toolDir, "rsync.exe") {
+		t.Fatalf("rsync path=%q", cmd.Path)
+	}
+	if got := cmd.Args[2]; !strings.HasPrefix(got, rsyncShellWords([]string{filepath.Join(toolDir, "ssh.exe")})[0]+" ") || !strings.Contains(got, "'injected key'") {
+		t.Fatalf("paired remote shell=%q", got)
+	}
+	joinedEnv := strings.Join(cmd.Env, "\n")
+	for _, want := range []string{"MSYS2_ARG_CONV_EXCL=*", "MSYS_NO_PATHCONV=1", "CYGWIN=nodosfilewarning"} {
+		if !strings.Contains(joinedEnv, want) {
+			t.Fatalf("environment missing %q: %q", want, cmd.Env)
+		}
+	}
+}
+
 func TestApplyTargetChildEnvironmentAddsOverridesAndRemovesAmbientValue(t *testing.T) {
 	cmd := &exec.Cmd{Env: []string{"PATH=/bin", "GH_HOST=ambient.example"}}
 	applyTargetChildEnvironment(cmd, SSHTarget{
@@ -3615,9 +3758,9 @@ func TestRemoteWriteSyncDeletedNew(t *testing.T) {
 func TestRemoteWriteSyncManifestsNew(t *testing.T) {
 	const finalizeToken = "0123456789abcdef0123456789abcdef"
 	workdir := t.TempDir()
-	manifest := "keep.txt\x00"
-	deleted := "old.txt\x00"
-	input := fmt.Sprintf("%d\n", len(manifest)) + manifest + deleted
+	manifest := "keep.txt\x00binary\xff\x00"
+	deleted := "old.txt\x00gone\xfe\x00"
+	input := syncManifestInputForTarget(SSHTarget{TargetOS: targetLinux}, []byte(manifest), []byte(deleted))
 	cmd := exec.Command("bash", "-lc", remoteWriteSyncManifestsNew(workdir, finalizeToken))
 	cmd.Stdin = strings.NewReader(input)
 	if out, err := cmd.CombinedOutput(); err != nil {
@@ -3668,9 +3811,20 @@ func TestRemoteWriteSyncManifestsNewForTargetUsesInterpretedWriterForWSL2(t *tes
 	if strings.Contains(plain, "status=none") {
 		t.Fatalf("non-WSL2 manifest writer should not require GNU dd extensions: %q", plain)
 	}
+	if strings.Count(plain, "dd bs=1 count=\"") != 2 {
+		t.Fatalf("non-WSL2 manifest writer should exact-read both blobs: %q", plain)
+	}
+	if strings.Contains(plain, "cat >") {
+		t.Fatalf("non-WSL2 manifest writer should not read either blob through EOF: %q", plain)
+	}
+	for _, want := range []string{"IFS= read -r manifest_len", "IFS= read -r deleted_len", "wc -c", "short sync manifest", "short sync deleted manifest"} {
+		if !strings.Contains(plain, want) {
+			t.Fatalf("non-WSL2 manifest writer missing %q: %q", want, plain)
+		}
+	}
 }
 
-func TestSyncManifestInputForTargetFramesDeletedLengthForWSL2(t *testing.T) {
+func TestSyncManifestInputForTargetFramesBothLengths(t *testing.T) {
 	manifest := []byte("keep.txt\x00")
 	deleted := []byte("old.txt\x00")
 	got := syncManifestInputForTarget(SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeWSL2}, manifest, deleted)
@@ -3682,9 +3836,126 @@ func TestSyncManifestInputForTargetFramesDeletedLengthForWSL2(t *testing.T) {
 	}
 
 	plain := syncManifestInputForTarget(SSHTarget{TargetOS: targetLinux}, manifest, deleted)
-	plainWant := fmt.Sprintf("%d\n", len(manifest)) + string(manifest) + string(deleted)
+	plainWant := fmt.Sprintf("%d\n%d\n", len(manifest), len(deleted)) + string(manifest) + string(deleted)
 	if plain != plainWant {
 		t.Fatalf("plain manifest input = %q, want %q", plain, plainWant)
+	}
+}
+
+func TestSyncManifestInputForTargetFramesEmptyDeletedData(t *testing.T) {
+	manifest := []byte("keep.txt\x00")
+	got := syncManifestInputForTarget(SSHTarget{TargetOS: targetLinux}, manifest, nil)
+	want := fmt.Sprintf("%d\n0\n", len(manifest)) + string(manifest)
+	if got != want {
+		t.Fatalf("plain manifest input = %q, want %q", got, want)
+	}
+}
+
+func TestRemoteWriteSyncManifestsNewRejectsMalformedLengths(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "missing manifest length", input: "", want: "invalid sync manifest length"},
+		{name: "non-decimal manifest length", input: "x\n0\n", want: "invalid sync manifest length"},
+		{name: "non-canonical manifest length", input: "01\n0\n", want: "invalid sync manifest length"},
+		{name: "missing deleted length", input: "0\n", want: "invalid sync deleted length"},
+		{name: "non-decimal deleted length", input: "0\nx\n", want: "invalid sync deleted length"},
+		{name: "non-canonical deleted length", input: "0\n01\n", want: "invalid sync deleted length"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cmd := exec.Command("bash", "-lc", remoteWriteSyncManifestsNew(t.TempDir(), "0123456789abcdef0123456789abcdef"))
+			cmd.Stdin = strings.NewReader(test.input)
+			out, err := cmd.CombinedOutput()
+			if err == nil {
+				t.Fatalf("malformed frame unexpectedly succeeded: %q", out)
+			}
+			if !strings.Contains(string(out), test.want) {
+				t.Fatalf("output=%q, want %q", out, test.want)
+			}
+		})
+	}
+}
+
+func TestRemoteWriteSyncManifestsNewRejectsShortInput(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "manifest", input: "2\n0\na", want: "short sync manifest: got 1 want 2"},
+		{name: "deleted", input: "1\n2\nab", want: "short sync deleted manifest: got 1 want 2"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cmd := exec.Command("bash", "-lc", remoteWriteSyncManifestsNew(t.TempDir(), "0123456789abcdef0123456789abcdef"))
+			cmd.Stdin = strings.NewReader(test.input)
+			out, err := cmd.CombinedOutput()
+			if err == nil {
+				t.Fatalf("short frame unexpectedly succeeded: %q", out)
+			}
+			if !strings.Contains(string(out), test.want) {
+				t.Fatalf("output=%q, want %q", out, test.want)
+			}
+		})
+	}
+}
+
+func TestRemoteWriteSyncManifestsNewDoesNotWaitForEOF(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		deleted []byte
+	}{
+		{name: "empty deleted data"},
+		{name: "non-empty deleted data", deleted: []byte("old.txt\x00")},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			const finalizeToken = "0123456789abcdef0123456789abcdef"
+			workdir := t.TempDir()
+			manifest := []byte("keep.txt\x00")
+			cmd := exec.Command("bash", "-lc", remoteWriteSyncManifestsNew(workdir, finalizeToken))
+			stdin, err := cmd.StdinPipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := cmd.Start(); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := io.WriteString(stdin, syncManifestInputForTarget(SSHTarget{TargetOS: targetLinux}, manifest, test.deleted)); err != nil {
+				t.Fatal(err)
+			}
+
+			done := make(chan error, 1)
+			go func() { done <- cmd.Wait() }()
+			select {
+			case err := <-done:
+				if err != nil {
+					t.Fatalf("write manifests before EOF failed: %v", err)
+				}
+			case <-time.After(2 * time.Second):
+				_ = stdin.Close()
+				_ = cmd.Process.Kill()
+				<-done
+				t.Fatal("manifest writer waited for transport EOF after a complete deleted frame")
+			}
+			_ = stdin.Close()
+
+			metaDir := filepath.Join(workdir, ".crabbox")
+			gotManifest, err := os.ReadFile(filepath.Join(metaDir, remoteSyncPendingManifestName(finalizeToken)))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(gotManifest, manifest) {
+				t.Fatalf("manifest=%q, want %q", gotManifest, manifest)
+			}
+			gotDeleted, err := os.ReadFile(filepath.Join(metaDir, remoteSyncPendingDeletedName(finalizeToken)))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(gotDeleted, test.deleted) {
+				t.Fatalf("deleted manifest=%q, want %q", gotDeleted, test.deleted)
+			}
+		})
 	}
 }
 
@@ -3737,11 +4008,14 @@ func TestRemoteWriteSyncManifestsNewReadsChunkedInput(t *testing.T) {
 	if err := cmd.Start(); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := io.WriteString(stdin, fmt.Sprintf("%d\n", len(manifest))+manifest[:1]); err != nil {
+	frame := syncManifestInputForTarget(SSHTarget{TargetOS: targetLinux}, []byte(manifest), []byte(deleted))
+	headerLen := strings.Index(frame, "\n") + 1
+	headerLen += strings.Index(frame[headerLen:], "\n") + 1
+	if _, err := io.WriteString(stdin, frame[:headerLen+1]); err != nil {
 		t.Fatal(err)
 	}
 	time.Sleep(100 * time.Millisecond)
-	if _, err := io.WriteString(stdin, manifest[1:]+deleted); err != nil {
+	if _, err := io.WriteString(stdin, frame[headerLen+1:]); err != nil {
 		t.Fatal(err)
 	}
 	if err := stdin.Close(); err != nil {

--- a/internal/cli/ssh_transport_command_windows_test.go
+++ b/internal/cli/ssh_transport_command_windows_test.go
@@ -2,7 +2,53 @@
 
 package cli
 
-import "testing"
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSSHCommandContextUsesNativeWindowsOpenSSHEvenWhenPATHSelectsMSYS2(t *testing.T) {
+	windowsDir := t.TempDir()
+	nativeSSH := filepath.Join(windowsDir, "System32", "OpenSSH", "ssh.exe")
+	if err := os.MkdirAll(filepath.Dir(nativeSSH), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(nativeSSH, []byte("native fixture"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	msysDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(msysDir, "ssh.exe"), []byte("MSYS2 fixture"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("WINDIR", windowsDir)
+	t.Setenv("PATH", msysDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	cmd := sshCommandContext(context.Background(), SSHTarget{}, "-V")
+	if cmd.Path != nativeSSH {
+		t.Fatalf("direct SSH executable=%q, want %q", cmd.Path, nativeSSH)
+	}
+}
+
+func TestProxyJumpDirectCommandUsesNativeWindowsOpenSSH(t *testing.T) {
+	windowsDir := t.TempDir()
+	nativeSSH := filepath.Join(windowsDir, "System32", "OpenSSH", "ssh.exe")
+	if err := os.MkdirAll(filepath.Dir(nativeSSH), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(nativeSSH, []byte("native fixture"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("WINDIR", windowsDir)
+
+	command := proxyJumpDirectCommand(directSSHExecutable(), `C:\private\jump config`, "jump.example.test")
+	wantPrefix := sshProxyCommandWords([]string{nativeSSH})[0] + " "
+	if !strings.HasPrefix(command, wantPrefix) {
+		t.Fatalf("command=%q, want native prefix %q", command, wantPrefix)
+	}
+}
 
 func TestSSHProxyCommandWordsUseWindowsQuoting(t *testing.T) {
 	got := sshProxyCommandWords([]string{"ssh", "-F", `C:\Users\O'Brien\ssh config`})

--- a/internal/cli/ssh_transport_session.go
+++ b/internal/cli/ssh_transport_session.go
@@ -589,7 +589,7 @@ func probeSSHTransportRouteCapabilities(ctx context.Context, target SSHTarget, c
 }
 
 func runOwnedSSHTransportCommand(ctx context.Context, target SSHTarget, args []string, stdout, stderr io.Writer) error {
-	handle := pondMeshExecCommand(ctx, target.ChildEnvDenylist, "ssh", args...)
+	handle := pondMeshExecCommand(ctx, target.ChildEnvDenylist, directSSHExecutable(), args...)
 	if execHandle, ok := handle.(*pondMeshExecHandle); ok {
 		execHandle.cmd.Stdout = stdout
 		execHandle.cmd.Stderr = stderr
@@ -640,7 +640,7 @@ func writeSSHTransportJumpConfig(dir, userConfigPath, proxyJump string, remoteCo
 		path := filepath.Join(dir, name)
 		proxyCommand := ""
 		if previousPath != "" {
-			proxyCommand = proxyJumpDirectCommand(previousPath, hops[index-1])
+			proxyCommand = proxyJumpDirectCommand(directSSHExecutable(), previousPath, hops[index-1])
 		}
 		config := renderSSHTransportJumpConfig(userConfigPath, proxyCommand, remoteCommandSupported)
 		if err := os.WriteFile(path, []byte(config), 0o600); err != nil {
@@ -731,11 +731,11 @@ func expandSSHProxyJumpTokens(command, originalHost, host, user, port string) st
 
 func proxyJumpCommand(route sshTransportConfigRoute) string {
 	hops := strings.Split(route.proxyJump, ",")
-	return proxyJumpDirectCommand(route.jumpConfigPath, hops[len(hops)-1])
+	return proxyJumpDirectCommand(directSSHExecutable(), route.jumpConfigPath, hops[len(hops)-1])
 }
 
-func proxyJumpDirectCommand(configPath, hop string) string {
-	args := []string{"ssh"}
+func proxyJumpDirectCommand(sshExecutable, configPath, hop string) string {
+	args := []string{sshExecutable}
 	if configPath != "" {
 		// This command is embedded in ProxyCommand. Protect path percent signs
 		// from the outer OpenSSH client's token expansion.

--- a/internal/cli/ssh_transport_session_test.go
+++ b/internal/cli/ssh_transport_session_test.go
@@ -508,6 +508,14 @@ func TestProxyJumpCommandPreservesMultiHopChainAndOwnership(t *testing.T) {
 	}
 }
 
+func TestProxyJumpDirectCommandUsesProvidedExecutable(t *testing.T) {
+	command := proxyJumpDirectCommand("ssh", "/tmp/jump-config", "jump.example.test")
+	wantPrefix := sshProxyCommandWords([]string{"ssh"})[0] + " "
+	if !strings.HasPrefix(command, wantPrefix) {
+		t.Fatalf("command=%q, want prefix %q", command, wantPrefix)
+	}
+}
+
 func TestSSHTransportConfigsHonorRemoteCommandCapability(t *testing.T) {
 	legacyJump := renderSSHTransportJumpConfig("/tmp/user-config", "", false)
 	if strings.Contains(legacyJump, "RemoteCommand") {

--- a/internal/cli/tunnel.go
+++ b/internal/cli/tunnel.go
@@ -96,7 +96,7 @@ func runSSHLocalForward(ctx context.Context, target SSHTarget, requestedLocalPor
 	forwardCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	args := resolvedSSHTunnelArgs(session, reservation.port, remotePort)
-	handle := pondMeshExecCommand(forwardCtx, target.ChildEnvDenylist, "ssh", args...)
+	handle := pondMeshExecCommand(forwardCtx, target.ChildEnvDenylist, directSSHExecutable(), args...)
 	output := newSynchronizedTailBuffer(failureTailLines)
 	if execHandle, ok := handle.(*pondMeshExecHandle); ok {
 		execHandle.cmd.Stdout = output

--- a/internal/cli/vnc.go
+++ b/internal/cli/vnc.go
@@ -441,7 +441,7 @@ func vncTunnelCommand(target SSHTarget, localPort string) string {
 }
 
 func startVNCTunnel(ctx context.Context, target SSHTarget, localPort, remoteHost, remotePort string) (int, error) {
-	cmd := exec.Command("ssh", vncTunnelArgs(target, localPort, remoteHost, remotePort)...)
+	cmd := exec.Command(directSSHExecutable(), vncTunnelArgs(target, localPort, remoteHost, remotePort)...)
 	applyTargetChildEnvironment(cmd, target)
 	configureDaemonCommand(cmd)
 	var output bytes.Buffer


### PR DESCRIPTION
## Summary

- Keep native Windows control commands on System32 OpenSSH while binding no-WSL rsync transfers to the exact sibling MSYS2 OpenSSH executable.
- Make finite Windows SSH input path-backed, current-user private, replayable across port fallback, and independent of inbox OpenSSH pipe EOF behavior.
- Frame both remote sync metadata blobs with explicit lengths so the POSIX writer never waits for transport EOF.
- Document the preferred WSL2 path plus the live-proven x64 no-WSL setup using the immutable MSYS2 2026-06-11 installer.

## Root cause

Crabbox previously let PATH choose the same SSH client for unrelated execution environments. On no-WSL Windows this made generated control commands run through MSYS2 SSH, while pairing MSYS2 rsync with System32 OpenSSH left incompatible child-process behavior. System32 OpenSSH also did not reliably deliver Go pipe EOF or data from delete-pending input handles, and the POSIX manifest writer used EOF to delimit its second blob.

The fix assigns ownership explicitly: host-native control uses System32 OpenSSH; WSL keeps Linux `ssh`; native rsync resolves `rsync.exe`, requires a sibling `ssh.exe`, and binds that exact executable into `-e`. Finite control input uses a current-user-owned read-only file, and sync metadata uses exact two-length framing.

## Verification

- `go test ./internal/cli -count=1`
- `go vet ./...`
- `go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...`
- Windows amd64 CLI test cross-compile
- Focused native Windows input, stream, direct-SSH, rsync-pairing, and ProxyJump tests executed on a real Windows host
- `scripts/check-docs.sh`
- PowerShell AST parsing for all 11 Windows guide blocks
- Final P1 autoreview: clean
- Source-blind behavior validation: 6 pass, 0 fail, 0 blocked

Live no-WSL proof:

- Operator: AWS Windows lease `cbx_44ccb7a12634`, no WSL distribution
- Target/run: AWS Linux lease `cbx_69c9cfa8f069`, run `run_c30db55bc696`
- Windows tools: MSYS2 rsync 3.5.0 and sibling OpenSSH 10.5p1; System32 OpenSSH for direct control
- Transfer: 67,108,864-byte incompressible payload plus fixture, exact SHA-256 verification, remote command reached
- Process evidence: MSYS2 `ssh.exe <- rsync.exe <- rsync.exe`, sibling binding present, zero native OpenSSH descendants under rsync
- Cleanup: target and operator released and absent from active inventory; staged broker config, lease keys, binaries, scripts, and proof directories removed
- Immutable installer proof: MSYS2 2026-06-11 SFX digest verified and reproduced rsync 3.5.0/OpenSSH 10.5p1

No public config or secret format changes.

Fixes https://github.com/openclaw/crabbox/issues/1319
