### PR TITLE
feat(images): add explicit catalog variant selectors

### DIFF
--- a/docs/commands/image.md
+++ b/docs/commands/image.md
@@ -118,9 +118,12 @@ Flags:
 --os-version <version>   numeric OS version present in the image
 --sdk <name=version>     SDK present in the image (repeatable)
 --runtime <name=version> runtime present in the image (repeatable)
+--variant-sdk <name=version>     SDK that explicitly activates a catalog-only image (repeatable)
+--variant-runtime <name=version> runtime that explicitly activates a catalog-only image (repeatable)
 --browser                image includes browser support
 --webview2               image includes Microsoft WebView2
 --desktop                image includes desktop support
+--catalog-only           publish an AWS capability variant without changing the default image
 --fast-snapshot-restore  enable AWS Fast Snapshot Restore for the backing snapshots
 --fsr-az <az>            availability zone for Fast Snapshot Restore (repeatable)
 --json                   print the promoted image record as JSON
@@ -143,6 +146,17 @@ Capability declarations make the AMI eligible for capability-aware selection.
 Versions use numeric dot notation, for example `--os-version 15.5`,
 `--sdk xcode=16.4`, or `--runtime node=24.2`. Omitted capabilities remain
 unknown and do not satisfy an explicit image requirement.
+
+AWS catalog-only images keep specialized variants out of the scoped default.
+Each promotion requires at least one `--variant-sdk` or `--variant-runtime`;
+the variant flag both declares the capability and records it as an activation
+selector. Ordinary `--sdk` and `--runtime` flags remain capability inventory
+only. For example, an image promoted with `--catalog-only --variant-sdk
+toolkit=2.0 --runtime node=24` is activated by an exactly matching `--image-sdk
+toolkit=2.0` request, not by a Node-only request. After activation, every
+requested capability must still match. Catalog-only promotion uses the
+dedicated `POST /v1/images/<id>/promote-catalog` route and fails closed against
+older coordinators.
 
 Add `--fast-snapshot-restore` plus one or more `--fsr-az` values when the
 promoted image backs hot lanes that need immediate EBS snapshot reads:

--- a/docs/commands/image.md
+++ b/docs/commands/image.md
@@ -14,6 +14,7 @@ crabbox image promote ami-1234567890abcdef0 --target macos --region us-east-1 --
 crabbox image promote snapshot-devtools --provider azure --target linux --region westeurope
 crabbox image fsr-status ami-1234567890abcdef0 --region us-west-2 --fsr-az us-west-2a
 crabbox image delete ami-1234567890abcdef0 --region eu-west-1
+crabbox image delete ami-external --catalog-only
 crabbox image delete my-managed-image --provider azure --region westeurope
 crabbox image delete my-machine-image --provider gcp --region europe-west1-b --project example-project
 crabbox image delete 123456789 --provider hetzner --region fsn1
@@ -241,6 +242,7 @@ Delete a Crabbox-created provider image.
 
 ```sh
 crabbox image delete ami-1234567890abcdef0 --region eu-west-1
+crabbox image delete ami-external --catalog-only
 crabbox image delete my-managed-image --provider azure --region westeurope
 crabbox image delete my-machine-image --provider gcp --region europe-west1-b --project example-project
 crabbox image delete 123456789 --provider hetzner --region fsn1
@@ -252,11 +254,30 @@ Flags:
 --provider <name>   image provider: aws, azure, gcp, or hetzner (default aws)
 --region <name>     region, location, or zone containing the image
 --project <name>    GCP project containing the image
+--catalog-only      unpublish every AWS catalog-only role without deleting the AMI
 ```
 
 AWS deletion deregisters the AMI and then deletes the EBS snapshots referenced by
 its block-device mappings. Azure deletion removes the managed image or disk
 snapshot. GCP deletion removes the machine image or disk snapshot.
+
+For an externally sourced AWS variant, use `--catalog-only` to remove every
+catalog-only role for the AMI while leaving the provider-owned AMI untouched.
+The command uses the dedicated `DELETE /v1/images/<id>/promote-catalog` route,
+never falls back to provider deletion, and fails with an upgrade error when the
+coordinator does not support safe retirement.
+
+Because AWS AMI IDs are regional, `--catalog-only --region <region>` retires
+only variant roles in that Region. Omitting `--region` is the explicit
+convenience form that retires every regional variant role with the same AMI ID.
+Its text output is:
+
+```text
+retired catalog-only image=ami-external provider=aws variants=1
+```
+
+Without `--catalog-only`, `image delete` keeps the existing provider deletion
+and ownership checks.
 
 Hetzner deletion runs directly without coordinator admin auth. It rejects
 `--project`, requires any supplied `--region` to match the recorded source

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -286,6 +286,8 @@ type CoordinatorImage struct {
 	PromotedAt           string                           `json:"promotedAt,omitempty"`
 	FastSnapshotRestores []CoordinatorFastSnapshotRestore `json:"fastSnapshotRestores,omitempty"`
 	Capabilities         *imageCapabilities               `json:"capabilities,omitempty"`
+	CatalogOnly          bool                             `json:"catalogOnly,omitempty"`
+	VariantSelectors     *imageVariantSelectors           `json:"variantSelectors,omitempty"`
 }
 
 type CoordinatorFastSnapshotRestore struct {
@@ -357,6 +359,8 @@ type CoordinatorImageRef struct {
 	FastSnapshotRestore    bool
 	FastSnapshotRestoreAZs []string
 	Capabilities           imageCapabilities
+	CatalogOnly            bool
+	VariantSelectors       imageVariantSelectors
 }
 
 type CoordinatorGitHubLoginStart struct {
@@ -1822,8 +1826,30 @@ func (c *CoordinatorClient) PromoteImage(ctx context.Context, imageID string, re
 	var res struct {
 		Image CoordinatorImage `json:"image"`
 	}
-	err := c.do(ctx, http.MethodPost, imagePath(imageID, "promote", refs...), map[string]any{}, &res)
-	return res.Image, err
+	action := "promote"
+	if len(refs) > 0 && refs[0].CatalogOnly {
+		action = "promote-catalog"
+	}
+	req := map[string]any{}
+	if action == "promote-catalog" {
+		req["variantSelectors"] = refs[0].VariantSelectors
+	}
+	err := c.do(ctx, http.MethodPost, imagePath(imageID, action, refs...), req, &res)
+	if err != nil {
+		if action == "promote-catalog" && isCoordinatorNotFound(err) {
+			return CoordinatorImage{}, fmt.Errorf("coordinator does not support catalog-only image promotion; upgrade the coordinator before publishing variant images (%w)", err)
+		}
+		return CoordinatorImage{}, err
+	}
+	if action == "promote-catalog" {
+		if !res.Image.CatalogOnly {
+			return CoordinatorImage{}, fmt.Errorf("coordinator did not confirm catalog-only promotion for %s", imageID)
+		}
+		if res.Image.VariantSelectors == nil || !imageVariantSelectorsEqual(*res.Image.VariantSelectors, refs[0].VariantSelectors) {
+			return CoordinatorImage{}, fmt.Errorf("coordinator did not confirm variant selectors for %s", imageID)
+		}
+	}
+	return res.Image, nil
 }
 
 func (c *CoordinatorClient) FastSnapshotRestoreStatus(ctx context.Context, imageID string, refs ...CoordinatorImageRef) (CoordinatorImage, error) {

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -363,6 +363,11 @@ type CoordinatorImageRef struct {
 	VariantSelectors       imageVariantSelectors
 }
 
+type CoordinatorCatalogImageRetirement struct {
+	ImageID string `json:"imageID"`
+	Retired int    `json:"retired"`
+}
+
 type CoordinatorGitHubLoginStart struct {
 	LoginID   string `json:"loginID"`
 	URL       string `json:"url"`
@@ -1866,6 +1871,18 @@ func (c *CoordinatorClient) FastSnapshotRestoreStatus(ctx context.Context, image
 
 func (c *CoordinatorClient) DeleteImage(ctx context.Context, imageID string, refs ...CoordinatorImageRef) error {
 	return c.do(ctx, http.MethodDelete, imagePath(imageID, "", refs...), nil, nil)
+}
+
+func (c *CoordinatorClient) RetireCatalogImage(ctx context.Context, imageID string, refs ...CoordinatorImageRef) (CoordinatorCatalogImageRetirement, error) {
+	var res CoordinatorCatalogImageRetirement
+	err := c.do(ctx, http.MethodDelete, imagePath(imageID, "promote-catalog", refs...), nil, &res)
+	if err != nil {
+		if isCoordinatorNotFound(err) {
+			return CoordinatorCatalogImageRetirement{}, fmt.Errorf("coordinator does not support catalog-only image retirement; upgrade the coordinator before unpublishing variant images (%w)", err)
+		}
+		return CoordinatorCatalogImageRetirement{}, err
+	}
+	return res, nil
 }
 
 func imagePath(imageID, action string, refs ...CoordinatorImageRef) string {

--- a/internal/cli/coordinator_test.go
+++ b/internal/cli/coordinator_test.go
@@ -2137,6 +2137,198 @@ func TestImagePromoteSupportsAzureSnapshots(t *testing.T) {
 	}
 }
 
+func TestImagePromoteCatalogOnlyValidation(t *testing.T) {
+	clearConfigEnv(t)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "catalog only requires selector",
+			args: []string{"ami-variant", "--catalog-only", "--sdk", "toolkit=2.0"},
+			want: "--catalog-only requires at least one --variant-sdk or --variant-runtime",
+		},
+		{
+			name: "selector requires catalog only",
+			args: []string{"ami-variant", "--variant-sdk", "toolkit=2.0"},
+			want: "--variant-sdk and --variant-runtime require --catalog-only",
+		},
+		{
+			name: "azure rejects catalog only",
+			args: []string{"ami-variant", "--provider", "azure", "--catalog-only", "--variant-sdk", "toolkit=2.0"},
+			want: "--catalog-only is AWS-only",
+		},
+		{
+			name: "conflicting repeated selector",
+			args: []string{"ami-variant", "--catalog-only", "--variant-sdk", "toolkit=2.0", "--variant-sdk", "toolkit=3.0"},
+			want: "--variant-sdk declares conflicting versions for toolkit",
+		},
+		{
+			name: "conflicting inventory and selector",
+			args: []string{"ami-variant", "--catalog-only", "--sdk", "toolkit=1.0", "--variant-sdk", "toolkit=2.0"},
+			want: "--sdk and --variant-sdk declare conflicting versions for toolkit",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := (App{Stdout: io.Discard, Stderr: io.Discard}).imagePromote(context.Background(), test.args)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error=%v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestImagePromoteCatalogOnlyCoordinatorContract(t *testing.T) {
+	clearConfigEnv(t)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	t.Run("interspersed flags merge and coalesce capabilities", func(t *testing.T) {
+		var requests int
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requests++
+			if r.Method != http.MethodPost || r.URL.Path != "/v1/images/ami-variant/promote-catalog" {
+				t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+			}
+			if got := r.URL.Query()["sdk"]; !reflect.DeepEqual(got, []string{"toolkit=2.0"}) {
+				t.Fatalf("sdk=%#v", got)
+			}
+			if got := r.URL.Query()["runtime"]; !reflect.DeepEqual(got, []string{"node=24"}) {
+				t.Fatalf("runtime=%#v", got)
+			}
+			var body struct {
+				VariantSelectors imageVariantSelectors `json:"variantSelectors"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatal(err)
+			}
+			wantSelectors := imageVariantSelectors{
+				SDKs:     map[string]string{"toolkit": "2.0"},
+				Runtimes: map[string]string{"node": "24"},
+			}
+			if !imageVariantSelectorsEqual(body.VariantSelectors, wantSelectors) {
+				t.Fatalf("variantSelectors=%#v", body.VariantSelectors)
+			}
+			_, _ = w.Write([]byte(`{"image":{"id":"ami-variant","name":"variant","state":"available","region":"eu-west-1","catalogOnly":true,"variantSelectors":{"sdks":{"toolkit":"2.0"},"runtimes":{"node":"24"}}}}`))
+		}))
+		defer server.Close()
+		t.Setenv("CRABBOX_COORDINATOR", server.URL)
+		t.Setenv("CRABBOX_COORDINATOR_ADMIN_TOKEN", "admin-token")
+
+		var out bytes.Buffer
+		err := (App{Stdout: &out, Stderr: io.Discard}).imagePromote(context.Background(), []string{
+			"ami-variant",
+			"--catalog-only",
+			"--sdk", "toolkit=2.0",
+			"--variant-sdk", "toolkit=2.0",
+			"--variant-sdk", "toolkit=2.0",
+			"--variant-runtime", "node=24",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if requests != 1 {
+			t.Fatalf("requests=%d", requests)
+		}
+		if got, want := out.String(), "promoted image=ami-variant name=variant state=available region=eu-west-1 catalogOnly=true\n"; got != want {
+			t.Fatalf("output=%q, want %q", got, want)
+		}
+	})
+
+	tests := []struct {
+		name       string
+		status     int
+		response   string
+		want       string
+		forbidPath string
+	}{
+		{
+			name:       "old coordinator does not fall back",
+			status:     http.StatusNotFound,
+			response:   `{"error":"not_found"}`,
+			want:       "coordinator does not support catalog-only image promotion",
+			forbidPath: "/v1/images/ami-variant/promote",
+		},
+		{
+			name:     "response must confirm catalog only",
+			status:   http.StatusOK,
+			response: `{"image":{"id":"ami-variant","name":"variant","state":"available","variantSelectors":{"sdks":{"toolkit":"2.0"}}}}`,
+			want:     "coordinator did not confirm catalog-only promotion",
+		},
+		{
+			name:     "response must confirm selectors",
+			status:   http.StatusOK,
+			response: `{"image":{"id":"ami-variant","name":"variant","state":"available","catalogOnly":true,"variantSelectors":{"sdks":{"other":"2.0"}}}}`,
+			want:     "coordinator did not confirm variant selectors",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if test.forbidPath != "" && r.URL.Path == test.forbidPath {
+					t.Fatalf("catalog-only promotion fell back to %s", r.URL.Path)
+				}
+				w.WriteHeader(test.status)
+				_, _ = w.Write([]byte(test.response))
+			}))
+			defer server.Close()
+			t.Setenv("CRABBOX_COORDINATOR", server.URL)
+			t.Setenv("CRABBOX_COORDINATOR_ADMIN_TOKEN", "admin-token")
+
+			err := (App{Stdout: io.Discard, Stderr: io.Discard}).imagePromote(context.Background(), []string{
+				"--catalog-only", "--variant-sdk", "toolkit=2.0", "ami-variant",
+			})
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error=%v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestImagePromoteOrdinaryOutputCompatibility(t *testing.T) {
+	clearConfigEnv(t)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/images/ami-default/promote" {
+			t.Fatalf("path=%q", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"image":{"id":"ami-default","name":"default","state":"available","region":"eu-west-1"}}`))
+	}))
+	defer server.Close()
+	t.Setenv("CRABBOX_COORDINATOR", server.URL)
+	t.Setenv("CRABBOX_COORDINATOR_ADMIN_TOKEN", "admin-token")
+
+	var textOut bytes.Buffer
+	if err := (App{Stdout: &textOut, Stderr: io.Discard}).imagePromote(context.Background(), []string{"ami-default"}); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := textOut.String(), "promoted image=ami-default name=default state=available region=eu-west-1\n"; got != want {
+		t.Fatalf("text output=%q, want %q", got, want)
+	}
+
+	var jsonOut bytes.Buffer
+	if err := (App{Stdout: &jsonOut, Stderr: io.Discard}).imagePromote(context.Background(), []string{"ami-default", "--json"}); err != nil {
+		t.Fatal(err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(jsonOut.Bytes(), &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := decoded["catalogOnly"]; ok {
+		t.Fatalf("ordinary JSON gained catalogOnly: %s", jsonOut.String())
+	}
+	if _, ok := decoded["variantSelectors"]; ok {
+		t.Fatalf("ordinary JSON gained variantSelectors: %s", jsonOut.String())
+	}
+}
+
 func TestLeaseStatusRequiresSSHReadiness(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet || r.URL.Path != "/v1/leases/cbx_123" {

--- a/internal/cli/coordinator_test.go
+++ b/internal/cli/coordinator_test.go
@@ -2142,6 +2142,17 @@ func TestImagePromoteCatalogOnlyValidation(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 
+	sdkOverflow := []string{"ami-variant", "--catalog-only"}
+	for index := range 32 {
+		sdkOverflow = append(sdkOverflow, "--sdk", fmt.Sprintf("sdk%d=1", index))
+	}
+	sdkOverflow = append(sdkOverflow, "--variant-sdk", "extra=1")
+	runtimeOverflow := []string{"ami-variant", "--catalog-only"}
+	for index := range 32 {
+		runtimeOverflow = append(runtimeOverflow, "--runtime", fmt.Sprintf("runtime%d=1", index))
+	}
+	runtimeOverflow = append(runtimeOverflow, "--variant-runtime", "extra=1")
+
 	tests := []struct {
 		name string
 		args []string
@@ -2172,6 +2183,16 @@ func TestImagePromoteCatalogOnlyValidation(t *testing.T) {
 			args: []string{"ami-variant", "--catalog-only", "--sdk", "toolkit=1.0", "--variant-sdk", "toolkit=2.0"},
 			want: "--sdk and --variant-sdk declare conflicting versions for toolkit",
 		},
+		{
+			name: "combined SDK limit",
+			args: sdkOverflow,
+			want: "--sdk and --variant-sdk support at most 32 combined entries",
+		},
+		{
+			name: "combined runtime limit",
+			args: runtimeOverflow,
+			want: "--runtime and --variant-runtime support at most 32 combined entries",
+		},
 	}
 
 	for _, test := range tests {
@@ -2182,6 +2203,87 @@ func TestImagePromoteCatalogOnlyValidation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestImageDeleteCatalogOnlyCoordinatorContract(t *testing.T) {
+	clearConfigEnv(t)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CRABBOX_COORDINATOR_ADMIN_TOKEN", "admin-token")
+
+	t.Run("uses dedicated route and reports retired variants", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodDelete || r.URL.Path != "/v1/images/ami-external/promote-catalog" {
+				t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+			}
+			if got := r.URL.Query().Get("provider"); got != "aws" {
+				t.Fatalf("provider=%q", got)
+			}
+			if got := r.URL.Query().Get("region"); got != "us-east-1" {
+				t.Fatalf("region=%q", got)
+			}
+			_, _ = w.Write([]byte(`{"imageID":"ami-external","catalogOnly":true,"retired":2}`))
+		}))
+		defer server.Close()
+		t.Setenv("CRABBOX_COORDINATOR", server.URL)
+
+		var out bytes.Buffer
+		err := (App{Stdout: &out, Stderr: io.Discard}).imageDelete(context.Background(), []string{
+			"ami-external", "--catalog-only", "--region", "us-east-1",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := out.String(), "retired catalog-only image=ami-external provider=aws variants=2\n"; got != want {
+			t.Fatalf("output=%q, want %q", got, want)
+		}
+	})
+
+	t.Run("old coordinator fails closed", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodDelete || r.URL.Path != "/v1/images/ami-external/promote-catalog" {
+				t.Fatalf("catalog-only retirement fell back to %s %s", r.Method, r.URL.Path)
+			}
+			http.NotFound(w, r)
+		}))
+		defer server.Close()
+		t.Setenv("CRABBOX_COORDINATOR", server.URL)
+
+		err := (App{Stdout: io.Discard, Stderr: io.Discard}).imageDelete(context.Background(), []string{
+			"ami-external", "--catalog-only",
+		})
+		if err == nil || !strings.Contains(err.Error(), "coordinator does not support catalog-only image retirement") {
+			t.Fatalf("error=%v", err)
+		}
+	})
+
+	t.Run("Azure fails before coordinator access", func(t *testing.T) {
+		err := (App{Stdout: io.Discard, Stderr: io.Discard}).imageDelete(context.Background(), []string{
+			"snapshot-variant", "--provider", "azure", "--catalog-only",
+		})
+		if err == nil || !strings.Contains(err.Error(), "--catalog-only is AWS-only") {
+			t.Fatalf("error=%v", err)
+		}
+	})
+
+	t.Run("invalid Region is visible to the operator", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Query().Get("region") != "not-a-region" {
+				t.Fatalf("region=%q", r.URL.Query().Get("region"))
+			}
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"invalid_region","message":"region must be an AWS region name"}`))
+		}))
+		defer server.Close()
+		t.Setenv("CRABBOX_COORDINATOR", server.URL)
+
+		err := (App{Stdout: io.Discard, Stderr: io.Discard}).imageDelete(context.Background(), []string{
+			"ami-external", "--catalog-only", "--region", "not-a-region",
+		})
+		if err == nil || !strings.Contains(err.Error(), "region must be an AWS region name") {
+			t.Fatalf("error=%v", err)
+		}
+	})
 }
 
 func TestImagePromoteCatalogOnlyCoordinatorContract(t *testing.T) {

--- a/internal/cli/image.go
+++ b/internal/cli/image.go
@@ -225,15 +225,19 @@ func (a App) imageDelete(ctx context.Context, args []string) error {
 	provider := fs.String("provider", "aws", "image provider: aws, azure, gcp, or hetzner")
 	region := fs.String("region", "", "region, location, or zone containing the image")
 	project := fs.String("project", "", "GCP project containing the image")
+	catalogOnly := fs.Bool("catalog-only", false, "unpublish AWS catalog-only variants without deleting the AMI")
 	if err := parseInterspersedFlags(fs, args); err != nil {
 		return err
 	}
 	if fs.NArg() != 1 {
-		return exit(2, "usage: crabbox image delete <image-id> [--provider aws|azure|gcp|hetzner] [--region <region>] [--project <project>]")
+		return exit(2, "usage: crabbox image delete <image-id> [--provider aws|azure|gcp|hetzner] [--region <region>] [--project <project>] [--catalog-only]")
 	}
 	normalizedProvider := normalizeProviderName(*provider)
 	if normalizedProvider != "aws" && normalizedProvider != "azure" && normalizedProvider != "gcp" && normalizedProvider != "hetzner" {
 		return exit(2, "unsupported image provider %q; use aws, azure, gcp, or hetzner", *provider)
+	}
+	if *catalogOnly && normalizedProvider != "aws" {
+		return exit(2, "--catalog-only is AWS-only")
 	}
 	if normalizedProvider == "hetzner" {
 		if strings.TrimSpace(*project) != "" {
@@ -259,6 +263,14 @@ func (a App) imageDelete(ctx context.Context, args []string) error {
 		return err
 	}
 	ref := CoordinatorImageRef{Provider: normalizedProvider, Region: *region, Project: *project}
+	if *catalogOnly {
+		retired, err := coord.RetireCatalogImage(ctx, fs.Arg(0), ref)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(a.Stdout, "retired catalog-only image=%s provider=aws variants=%d\n", fs.Arg(0), retired.Retired)
+		return nil
+	}
 	if err := coord.DeleteImage(ctx, fs.Arg(0), ref); err != nil {
 		return err
 	}

--- a/internal/cli/image.go
+++ b/internal/cli/image.go
@@ -56,24 +56,32 @@ func (a App) imagePromote(ctx context.Context, args []string) error {
 	osVersion := fs.String("os-version", "", "OS version present in the image")
 	var sdkVersions stringListFlag
 	var runtimeVersions stringListFlag
+	var variantSDKVersions stringListFlag
+	var variantRuntimeVersions stringListFlag
 	fs.Var(&sdkVersions, "sdk", "SDK present in name=version form; repeatable")
 	fs.Var(&runtimeVersions, "runtime", "runtime present in name=version form; repeatable")
+	fs.Var(&variantSDKVersions, "variant-sdk", "SDK that explicitly activates a catalog-only image; repeatable")
+	fs.Var(&variantRuntimeVersions, "variant-runtime", "runtime that explicitly activates a catalog-only image; repeatable")
 	browser := fs.Bool("browser", false, "image includes a browser")
 	webView2 := fs.Bool("webview2", false, "image includes Microsoft WebView2")
 	desktop := fs.Bool("desktop", false, "image includes desktop support")
+	catalogOnly := fs.Bool("catalog-only", false, "publish an AWS capability variant without changing the default image")
 	fastSnapshotRestore := fs.Bool("fast-snapshot-restore", false, "enable AWS Fast Snapshot Restore for the promoted AMI snapshots")
 	var fastSnapshotRestoreAZs stringListFlag
 	fs.Var(&fastSnapshotRestoreAZs, "fsr-az", "availability zone for Fast Snapshot Restore; repeatable")
 	jsonOut := fs.Bool("json", false, "print JSON")
-	if err := parseFlags(fs, args); err != nil {
+	if err := parseInterspersedFlags(fs, args); err != nil {
 		return err
 	}
 	if fs.NArg() != 1 {
-		return exit(2, "usage: crabbox image promote <image-id> [--provider aws|azure] [--target linux|macos|windows] [--os ubuntu:26.04|ubuntu:24.04] [--region <region>] [--type <instance-type>] [--architecture <arch>] [--os-version <version>] [--sdk <name=version>] [--runtime <name=version>] [--browser] [--webview2] [--desktop] [--fast-snapshot-restore --fsr-az <az>]")
+		return exit(2, "usage: crabbox image promote <image-id> [--provider aws|azure] [--target linux|macos|windows] [--os ubuntu:26.04|ubuntu:24.04] [--region <region>] [--type <instance-type>] [--architecture <arch>] [--os-version <version>] [--sdk <name=version>] [--runtime <name=version>] [--variant-sdk <name=version>] [--variant-runtime <name=version>] [--browser] [--webview2] [--desktop] [--catalog-only] [--fast-snapshot-restore --fsr-az <az>]")
 	}
 	normalizedProvider := normalizeProviderName(*provider)
 	if normalizedProvider != "aws" && normalizedProvider != "azure" {
 		return exit(2, "unsupported image promotion provider %q; use aws or azure", *provider)
+	}
+	if normalizedProvider == "azure" && *catalogOnly {
+		return exit(2, "--catalog-only is AWS-only")
 	}
 	if normalizedProvider == "azure" && (*fastSnapshotRestore || len(fastSnapshotRestoreAZs) > 0) {
 		return exit(2, "Fast Snapshot Restore is AWS-only")
@@ -89,6 +97,29 @@ func (a App) imagePromote(ctx context.Context, args []string) error {
 		return err
 	}
 	runtimes, err := parseImageVersions(runtimeVersions, "runtime")
+	if err != nil {
+		return err
+	}
+	variantSDKs, err := parseImageVersions(variantSDKVersions, "variant-sdk")
+	if err != nil {
+		return err
+	}
+	variantRuntimes, err := parseImageVersions(variantRuntimeVersions, "variant-runtime")
+	if err != nil {
+		return err
+	}
+	variantSelectors := imageVariantSelectors{SDKs: variantSDKs, Runtimes: variantRuntimes}
+	if *catalogOnly && imageVariantSelectorsEmpty(variantSelectors) {
+		return exit(2, "--catalog-only requires at least one --variant-sdk or --variant-runtime declaration")
+	}
+	if !*catalogOnly && !imageVariantSelectorsEmpty(variantSelectors) {
+		return exit(2, "--variant-sdk and --variant-runtime require --catalog-only")
+	}
+	sdks, err = mergeImageVersions(sdks, variantSDKs, "sdk", "variant-sdk")
+	if err != nil {
+		return err
+	}
+	runtimes, err = mergeImageVersions(runtimes, variantRuntimes, "runtime", "variant-runtime")
 	if err != nil {
 		return err
 	}
@@ -119,6 +150,7 @@ func (a App) imagePromote(ctx context.Context, args []string) error {
 		OSImage:                *osImage,
 		ServerType:             *serverType,
 		Architecture:           *architecture,
+		CatalogOnly:            *catalogOnly,
 		FastSnapshotRestore:    *fastSnapshotRestore,
 		FastSnapshotRestoreAZs: fastSnapshotRestoreAZs,
 		Capabilities: imageCapabilities{
@@ -129,6 +161,7 @@ func (a App) imagePromote(ctx context.Context, args []string) error {
 			WebView2:  *webView2,
 			Desktop:   *desktop,
 		},
+		VariantSelectors: variantSelectors,
 	})
 	if err != nil {
 		return err
@@ -136,7 +169,11 @@ func (a App) imagePromote(ctx context.Context, args []string) error {
 	if *jsonOut {
 		return json.NewEncoder(a.Stdout).Encode(image)
 	}
-	fmt.Fprintf(a.Stdout, "promoted image=%s name=%s state=%s region=%s\n", image.ID, image.Name, image.State, blank(image.Region, "-"))
+	fmt.Fprintf(a.Stdout, "promoted image=%s name=%s state=%s region=%s", image.ID, image.Name, image.State, blank(image.Region, "-"))
+	if image.CatalogOnly {
+		fmt.Fprint(a.Stdout, " catalogOnly=true")
+	}
+	fmt.Fprintln(a.Stdout)
 	return nil
 }
 

--- a/internal/cli/image_capabilities.go
+++ b/internal/cli/image_capabilities.go
@@ -63,6 +63,9 @@ func mergeImageVersions(base, additions map[string]string, baseFlag, additionsFl
 		}
 		merged[name] = version
 	}
+	if len(merged) > 32 {
+		return nil, exit(2, "--%s and --%s support at most 32 combined entries", baseFlag, additionsFlag)
+	}
 	if len(merged) == 0 {
 		return nil, nil
 	}

--- a/internal/cli/image_capabilities.go
+++ b/internal/cli/image_capabilities.go
@@ -15,6 +15,11 @@ type imageCapabilities struct {
 	Desktop   bool              `json:"desktop,omitempty"`
 }
 
+type imageVariantSelectors struct {
+	SDKs     map[string]string `json:"sdks,omitempty"`
+	Runtimes map[string]string `json:"runtimes,omitempty"`
+}
+
 type imageRequirements struct {
 	MinOS    string            `json:"minOS,omitempty"`
 	SDKs     map[string]string `json:"sdks,omitempty"`
@@ -36,12 +41,53 @@ func parseImageVersions(values []string, flagName string) (map[string]string, er
 		if !ok || !validImageCapabilityName(name) || !validImageVersion(version) {
 			return nil, exit(2, "--%s must use name=dot.separated.numeric.version", flagName)
 		}
+		if existing, ok := parsed[name]; ok && existing != version {
+			return nil, exit(2, "--%s declares conflicting versions for %s", flagName, name)
+		}
 		parsed[name] = version
 	}
 	if len(parsed) == 0 {
 		return nil, nil
 	}
 	return parsed, nil
+}
+
+func mergeImageVersions(base, additions map[string]string, baseFlag, additionsFlag string) (map[string]string, error) {
+	merged := make(map[string]string, len(base)+len(additions))
+	for name, version := range base {
+		merged[name] = version
+	}
+	for name, version := range additions {
+		if existing, ok := merged[name]; ok && existing != version {
+			return nil, exit(2, "--%s and --%s declare conflicting versions for %s", baseFlag, additionsFlag, name)
+		}
+		merged[name] = version
+	}
+	if len(merged) == 0 {
+		return nil, nil
+	}
+	return merged, nil
+}
+
+func imageVariantSelectorsEmpty(value imageVariantSelectors) bool {
+	return len(value.SDKs) == 0 && len(value.Runtimes) == 0
+}
+
+func imageVariantSelectorsEqual(left, right imageVariantSelectors) bool {
+	if len(left.SDKs) != len(right.SDKs) || len(left.Runtimes) != len(right.Runtimes) {
+		return false
+	}
+	for name, version := range left.SDKs {
+		if right.SDKs[name] != version {
+			return false
+		}
+	}
+	for name, version := range left.Runtimes {
+		if right.Runtimes[name] != version {
+			return false
+		}
+	}
+	return true
 }
 
 func validImageCapabilityName(value string) bool {

--- a/worker/node/postgres-storage.ts
+++ b/worker/node/postgres-storage.ts
@@ -92,7 +92,11 @@ export class PostgresCoordinatorStorage implements CoordinatorStorage {
     startAfter?: string;
     noCache?: boolean;
   } = {}): Promise<Map<string, T>> {
-    return this.view.list<T>({ prefix, limit, startAfter });
+    return this.view.list<T>({
+      prefix,
+      ...(limit === undefined ? {} : { limit }),
+      ...(startAfter === undefined ? {} : { startAfter }),
+    });
   }
 
   async transaction<T>(callback: (transaction: CoordinatorStorageView) => Promise<T>): Promise<T> {

--- a/worker/node/postgres-storage.ts
+++ b/worker/node/postgres-storage.ts
@@ -1,12 +1,15 @@
-import { Pool } from "pg";
+import { Pool, type PoolClient, type QueryResult, type QueryResultRow } from "pg";
 
-import type { CoordinatorStorage } from "../src/coordinator-runtime";
+import type { CoordinatorStorage, CoordinatorStorageView } from "../src/coordinator-runtime";
 
 const schema = "crabbox";
 const table = `${schema}.coordinator_kv`;
+const transactionAttempts = 3;
+const retryableTransactionErrorCodes = new Set(["40001", "40P01"]);
 
 export class PostgresCoordinatorStorage implements CoordinatorStorage {
   readonly pool: Pool;
+  private readonly view: PostgresCoordinatorStorageView;
 
   constructor(connectionString: string, pool?: Pool) {
     this.pool =
@@ -20,6 +23,7 @@ export class PostgresCoordinatorStorage implements CoordinatorStorage {
           10_000,
         ),
       });
+    this.view = new PostgresCoordinatorStorageView(storageQuery(this.pool));
   }
 
   async initialize(): Promise<void> {
@@ -51,43 +55,15 @@ export class PostgresCoordinatorStorage implements CoordinatorStorage {
   }
 
   async get<T>(key: string, _options?: { noCache?: boolean }): Promise<T | undefined> {
-    const result = await this.pool.query<{ encoded_value: unknown }>(
-      `
-        select case
-          when value_text_updated_at = updated_at then value_text
-          else value::text
-        end as encoded_value
-        from ${table}
-        where key = $1
-      `,
-      [key],
-    );
-    const row = result.rows[0];
-    return row ? decodeStoredValue<T>(row.encoded_value) : undefined;
+    return this.view.get<T>(key);
   }
 
   async put<T>(key: string, value: T, _options?: { noCache?: boolean }): Promise<void> {
-    const encoded = JSON.stringify(value);
-    if (encoded === undefined) {
-      throw new TypeError("coordinator storage cannot persist undefined");
-    }
-    const jsonbEncoded = jsonbCompatibleEncoding(encoded);
-    await this.pool.query(
-      `
-        insert into ${table} (key, value, value_text, value_text_updated_at)
-        values ($1, $2::jsonb, $3, now())
-        on conflict (key) do update
-        set value = excluded.value,
-            value_text = excluded.value_text,
-            value_text_updated_at = now(),
-            updated_at = now()
-      `,
-      [key, jsonbEncoded, encoded],
-    );
+    await this.view.put(key, value);
   }
 
   async delete(key: string): Promise<void> {
-    await this.pool.query(`delete from ${table} where key = $1`, [key]);
+    await this.view.delete(key);
   }
 
   async take<T>(key: string): Promise<T | undefined> {
@@ -116,10 +92,132 @@ export class PostgresCoordinatorStorage implements CoordinatorStorage {
     startAfter?: string;
     noCache?: boolean;
   } = {}): Promise<Map<string, T>> {
+    return this.view.list<T>({ prefix, limit, startAfter });
+  }
+
+  async transaction<T>(callback: (transaction: CoordinatorStorageView) => Promise<T>): Promise<T> {
+    const attempt = async (remaining: number): Promise<T> => {
+      try {
+        return await this.transactionAttempt(callback);
+      } catch (error) {
+        if (remaining > 1 && retryablePostgresTransactionError(error)) {
+          return attempt(remaining - 1);
+        }
+        throw error;
+      }
+    };
+    return attempt(transactionAttempts);
+  }
+
+  private async transactionAttempt<T>(
+    callback: (transaction: CoordinatorStorageView) => Promise<T>,
+  ): Promise<T> {
+    const client = await this.pool.connect();
+    let releaseError: Error | undefined;
+    try {
+      await client.query("begin isolation level serializable");
+      const result = await callback(new PostgresCoordinatorStorageView(storageQuery(client)));
+      await client.query("commit");
+      return result;
+    } catch (error) {
+      try {
+        await client.query("rollback");
+      } catch (rollbackError) {
+        releaseError =
+          rollbackError instanceof Error
+            ? rollbackError
+            : new Error("PostgreSQL rollback failed", { cause: rollbackError });
+        const aggregate = new AggregateError(
+          [error, rollbackError],
+          "PostgreSQL transaction failed and rollback also failed",
+          { cause: error },
+        );
+        throw aggregate;
+      }
+      throw error;
+    } finally {
+      if (releaseError) {
+        client.release(releaseError);
+      } else {
+        client.release();
+      }
+    }
+  }
+}
+
+function retryablePostgresTransactionError(error: unknown): boolean {
+  if (error instanceof AggregateError || !error || typeof error !== "object") return false;
+  const code = "code" in error ? error.code : undefined;
+  return typeof code === "string" && retryableTransactionErrorCodes.has(code);
+}
+
+type StorageQuery = <T extends QueryResultRow>(
+  text: string,
+  values?: unknown[],
+) => Promise<QueryResult<T>>;
+
+function storageQuery(queryable: Pick<Pool | PoolClient, "query">): StorageQuery {
+  return async <T extends QueryResultRow>(text: string, values?: unknown[]) =>
+    await queryable.query<T>(text, values);
+}
+
+class PostgresCoordinatorStorageView implements CoordinatorStorageView {
+  constructor(private readonly query: StorageQuery) {}
+
+  async get<T>(key: string, _options?: { noCache?: boolean }): Promise<T | undefined> {
+    const result = await this.query<{ encoded_value: unknown }>(
+      `
+        select case
+          when value_text_updated_at = updated_at then value_text
+          else value::text
+        end as encoded_value
+        from ${table}
+        where key = $1
+      `,
+      [key],
+    );
+    const row = result.rows[0];
+    return row ? decodeStoredValue<T>(row.encoded_value) : undefined;
+  }
+
+  async put<T>(key: string, value: T, _options?: { noCache?: boolean }): Promise<void> {
+    const encoded = JSON.stringify(value);
+    if (encoded === undefined) {
+      throw new TypeError("coordinator storage cannot persist undefined");
+    }
+    const jsonbEncoded = jsonbCompatibleEncoding(encoded);
+    await this.query(
+      `
+        insert into ${table} (key, value, value_text, value_text_updated_at)
+        values ($1, $2::jsonb, $3, now())
+        on conflict (key) do update
+        set value = excluded.value,
+            value_text = excluded.value_text,
+            value_text_updated_at = now(),
+            updated_at = now()
+      `,
+      [key, jsonbEncoded, encoded],
+    );
+  }
+
+  async delete(key: string): Promise<void> {
+    await this.query(`delete from ${table} where key = $1`, [key]);
+  }
+
+  async list<T>({
+    prefix = "",
+    limit,
+    startAfter,
+  }: {
+    prefix?: string;
+    limit?: number;
+    startAfter?: string;
+    noCache?: boolean;
+  } = {}): Promise<Map<string, T>> {
     const values: unknown[] = [`${escapeLike(prefix)}%`];
     const afterClause = startAfter ? `and key > $${values.push(startAfter)}` : "";
     const limitClause = limit === undefined ? "" : `limit $${values.push(limit)}`;
-    const result = await this.pool.query<{ key: string; encoded_value: unknown }>(
+    const result = await this.query<{ key: string; encoded_value: unknown }>(
       `
         select key,
                case

--- a/worker/src/coordinator-runtime.ts
+++ b/worker/src/coordinator-runtime.ts
@@ -1,4 +1,4 @@
-export interface CoordinatorStorage {
+export interface CoordinatorStorageView {
   get<T>(key: string, options?: { noCache?: boolean }): Promise<T | undefined>;
   put<T>(key: string, value: T, options?: { noCache?: boolean }): Promise<void>;
   delete(key: string): Promise<unknown>;
@@ -8,6 +8,12 @@ export interface CoordinatorStorage {
     startAfter?: string;
     noCache?: boolean;
   }): Promise<Map<string, T>>;
+}
+
+export interface CoordinatorStorage extends CoordinatorStorageView {
+  // Implementations may retry callbacks after serialization conflicts; callbacks must contain
+  // only storage reads/writes and must not perform external or otherwise non-idempotent effects.
+  transaction<T>(callback: (transaction: CoordinatorStorageView) => Promise<T>): Promise<T>;
 }
 
 export type CoordinatorRequestQueue = "direct" | "lifecycle";
@@ -70,6 +76,20 @@ export function coordinatorRequestQueue(request: Request): CoordinatorRequestQue
   }
   if (path[0] === "v1" && path[1] === "ready-pools") {
     return "direct";
+  }
+  if (
+    path[0] === "v1" &&
+    path[1] === "images" &&
+    path[2] &&
+    ((method === "POST" &&
+      path.length === 4 &&
+      (path[3] === "promote" || path[3] === "promote-catalog")) ||
+      (method === "DELETE" &&
+        (path.length === 3 || (path.length === 4 && path[3] === "promote-catalog"))))
+  ) {
+    // Existing-image mutations intentionally hold the lifecycle queue across provider I/O:
+    // these rare admin calls must validate, re-read, clean up, and publish as one serialized commit.
+    return "lifecycle";
   }
   if (path[0] === "v1" && path[1] === "images") {
     return "direct";

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -68,6 +68,8 @@ import {
   controlMessageOwnsTransaction,
   coordinatorRequestQueue,
   type CoordinatorRuntime,
+  type CoordinatorStorage,
+  type CoordinatorStorageView,
 } from "./coordinator-runtime";
 import {
   DaytonaClient,
@@ -13813,20 +13815,46 @@ export class FleetCoordinator {
       return result instanceof Response ? result : json(result);
     }
     if (method === "DELETE" && action === undefined) {
+      const ownershipMetadata = providerForRegion.storedImageDeleteMetadata
+        ? await providerForRegion.storedImageDeleteMetadata(decodedImageID)
+        : metadata;
       const ownershipBlocked = validateProviderImageDeleteOwnership(
         provider,
         decodedImageID,
-        metadata,
+        ownershipMetadata,
       );
       if (ownershipBlocked) {
         return json(ownershipBlocked.body, { status: ownershipBlocked.status });
       }
-      const deleteBlocked = await providerForRegion.validateDeleteImage(decodedImageID, metadata);
+      const deleteBlocked = await providerForRegion.validateDeleteImage(
+        decodedImageID,
+        ownershipMetadata,
+      );
       if (deleteBlocked) {
         return json(deleteBlocked.body, { status: deleteBlocked.status });
       }
       await providerForRegion.deleteImage(decodedImageID, kind, metadata);
       return json({ imageID: decodedImageID, deleted: true });
+    }
+    if (method === "DELETE" && action === "promote-catalog") {
+      const retirementRegion = region === undefined ? undefined : sanitizeAWSRegion(region);
+      if (region !== undefined && !retirementRegion) {
+        return json(
+          { error: "invalid_region", message: "region must be an AWS region name" },
+          { status: 400 },
+        );
+      }
+      if (!providerForRegion.retireCatalogImage) {
+        return json(
+          {
+            error: "unsupported_provider",
+            message: "catalog-only image retirement is AWS-only",
+          },
+          { status: 400 },
+        );
+      }
+      const retired = await providerForRegion.retireCatalogImage(decodedImageID, retirementRegion);
+      return json({ imageID: decodedImageID, catalogOnly: true, retired });
     }
     if (method === "POST" && (action === "promote" || action === "promote-catalog")) {
       url.searchParams.set("catalogOnly", action === "promote-catalog" ? "true" : "false");
@@ -17061,6 +17089,19 @@ function promotedAWSImageCatalogKey(image: PromotedImageRecord): string {
   return `${promotedAWSImageCatalogPrefix(image)}${encodeURIComponent(image.id)}`;
 }
 
+function promotedAWSImageVariantPrefix(
+  image: Pick<ProviderImage, "target" | "architecture" | "region" | "serverType"> & {
+    os?: string;
+  },
+): string {
+  const scope = promotedAWSImageKey(image).slice(`${promotedAWSImagePrefix()}:`.length);
+  return `image:aws:variant:${scope}:`;
+}
+
+function promotedAWSImageVariantKey(image: PromotedImageRecord): string {
+  return `${promotedAWSImageVariantPrefix(image)}${encodeURIComponent(image.id)}`;
+}
+
 class ImageCapabilityMismatchError extends Error {
   constructor(message: string) {
     super(message);
@@ -17069,7 +17110,7 @@ class ImageCapabilityMismatchError extends Error {
 }
 
 function promotionVersionMap(values: string[], label: string): Record<string, string> | undefined {
-  const versions: Record<string, string> = {};
+  const versions = Object.create(null) as Record<string, string>;
   for (const value of values) {
     const separator = value.indexOf("=");
     const name = (separator > 0 ? value.slice(0, separator) : value).trim().toLowerCase();
@@ -22356,7 +22397,9 @@ interface CloudProvider {
   ): Promise<ProviderImage>;
   getImage(imageID: string, kind?: string): Promise<ProviderImage>;
   deleteImage(imageID: string, kind?: string, metadata?: ProviderImage): Promise<void>;
+  retireCatalogImage?(imageID: string, region?: string): Promise<number>;
   storedImageMetadata(imageID: string): Promise<ProviderImage | undefined>;
+  storedImageDeleteMetadata?(imageID: string): Promise<ProviderImage | undefined>;
   decorateImage(image: ProviderImage, metadata?: Partial<ProviderImage>): ProviderImage;
   validateDeleteImage(
     imageID: string,
@@ -22417,12 +22460,8 @@ interface ProviderWorkspaceCapability {
   log(event: ProviderWorkspaceLifecycleEvent, fields: Record<string, string | undefined>): void;
 }
 
-interface ProviderStateStorage {
-  get<T>(key: string): Promise<T | undefined>;
-  put<T>(key: string, value: T): Promise<void>;
-  list<T>(options?: { prefix?: string }): Promise<Map<string, T>>;
-  delete(key: string): Promise<unknown>;
-}
+type ProviderStateStorage = CoordinatorStorage;
+type ProviderStateStorageView = CoordinatorStorageView;
 
 interface ProviderAccessContext {
   requestSourceCIDRs: string[];
@@ -24201,19 +24240,58 @@ export class AWSProvider implements CloudProvider {
       };
       await this.storage.put(awsImageDeletionClaimKey(imageID), claim);
     }
-    await this.deleteMatchingImageRecords("image:aws:created:", imageID);
-    await this.deleteMatchingImageRecords(promotedAWSImagePrefix(), imageID);
-    await this.deleteMatchingImageRecords("image:aws:catalog:", imageID);
-    await this.storage.delete(awsImageDeletionClaimKey(imageID));
+    await this.deleteMatchingImageRecords("image:aws:created:", imageID, this.region);
+    await this.deleteMatchingImageRecords(promotedAWSImagePrefix(), imageID, this.region);
+    await imageCatalogTransaction(this.storage, async (transaction) => {
+      await deletePromotedAWSImageRecords(
+        transaction,
+        imageID,
+        ["image:aws:catalog:", "image:aws:variant:"],
+        { region: this.region },
+      );
+      await transaction.delete(awsImageDeletionClaimKey(imageID));
+    });
+  }
+
+  retireCatalogImage(imageID: string, region?: string): Promise<number> {
+    return imageCatalogTransaction(
+      this.storage,
+      async (transaction) =>
+        await deletePromotedAWSImageRecords(
+          transaction,
+          imageID,
+          ["image:aws:variant:"],
+          region ? { region } : {},
+        ),
+    );
   }
 
   async storedImageMetadata(imageID: string): Promise<ProviderImage | undefined> {
-    return (
-      (await this.promotedImageByID(imageID)) ??
+    const promoted = await this.promotedImagesByID(imageID);
+    const currentPromoted = promoted.find((image) => image.region === this.region);
+    if (currentPromoted) return currentPromoted;
+    const created =
       (await this.storage.get<ProviderImage>(createdAWSImageKey(imageID))) ??
       (await this.storage.get<ProviderImage>(createdProviderImageKey("aws", imageID))) ??
-      (await this.imageDeletionClaim(imageID))?.metadata
+      (await this.imageDeletionClaim(imageID))?.metadata;
+    if (created?.region === this.region) return created;
+    const variants = await this.variantImagesByID(imageID);
+    return (
+      variants.find((image) => image.region === this.region) ??
+      promoted[0] ??
+      created ??
+      variants[0]
     );
+  }
+
+  async storedImageDeleteMetadata(imageID: string): Promise<ProviderImage | undefined> {
+    const promoted = await this.promotedImageByID(imageID);
+    if (promoted) return promoted;
+    const created =
+      (await this.storage.get<ProviderImage>(createdAWSImageKey(imageID))) ??
+      (await this.storage.get<ProviderImage>(createdProviderImageKey("aws", imageID))) ??
+      (await this.imageDeletionClaim(imageID))?.metadata;
+    return created?.region === this.region ? created : undefined;
   }
 
   decorateImage(image: ProviderImage, metadata?: Partial<ProviderImage>): ProviderImage {
@@ -24244,10 +24322,15 @@ export class AWSProvider implements CloudProvider {
     return validAWSImageDeletionClaim(claim, imageID) ? claim : undefined;
   }
 
-  private async deleteMatchingImageRecords(prefix: string, imageID: string): Promise<void> {
+  private async deleteMatchingImageRecords(
+    prefix: string,
+    imageID: string,
+    region?: string,
+  ): Promise<void> {
     const records = await this.storage.list<ProviderImage>({ prefix });
     for (const [key, image] of records) {
       if (image.id !== imageID && image.resourceID !== imageID) continue;
+      if (region !== undefined && image.region !== region) continue;
       // oxlint-disable-next-line eslint/no-await-in-loop -- ordered deletes leave a retryable durable prefix boundary.
       await this.storage.delete(key);
     }
@@ -24324,15 +24407,20 @@ export class AWSProvider implements CloudProvider {
       fastSnapshotRestoreAvailabilityZones?: string[];
     }>(request).catch(() => ({}));
     const requestedRegion = input.region ?? url.searchParams.get("region") ?? "";
-    const cataloged = await this.promotedCatalogImageByID(imageID, requestedRegion);
-    const priorCapabilities = known?.capabilities ?? cataloged?.capabilities;
-    const prior =
-      known || cataloged
-        ? {
-            ...cataloged,
-            ...known,
-            ...(priorCapabilities ? { capabilities: priorCapabilities } : {}),
-          }
+    const requestedImageRegion = requestedRegion ? sanitizeAWSRegion(requestedRegion) : "";
+    if (requestedRegion && !requestedImageRegion) {
+      return json(
+        { error: "invalid_region", message: "region must be an AWS region name" },
+        { status: 400 },
+      );
+    }
+    const historyRegion =
+      requestedImageRegion || sanitizeAWSRegion(known?.region ?? "") || this.region;
+    const cataloged = await this.promotedImageMetadataByID(imageID, historyRegion, known);
+    const prior: (ProviderImage & Partial<PromotedImageRecord>) | undefined = cataloged
+      ? { ...(known?.region === historyRegion ? known : {}), ...cataloged }
+      : known?.region === historyRegion
+        ? known
         : undefined;
     const target = normalizeAWSImageTarget(
       input.target ?? url.searchParams.get("target") ?? prior?.target ?? "linux",
@@ -24356,14 +24444,8 @@ export class AWSProvider implements CloudProvider {
         );
       }
     }
-    const rawRegion = requestedRegion || prior?.region || "";
+    const rawRegion = requestedRegion || prior?.region || known?.region || "";
     const imageRegion = sanitizeAWSRegion(rawRegion);
-    if (rawRegion && !imageRegion) {
-      return json(
-        { error: "invalid_region", message: "region must be an AWS region name" },
-        { status: 400 },
-      );
-    }
     const {
       catalogOnly: _priorCatalogOnly,
       variantSelectors: _priorVariantSelectors,
@@ -24381,10 +24463,12 @@ export class AWSProvider implements CloudProvider {
     if (architecture) {
       metadata.architecture = architecture;
     }
-    let capabilities: ImageCapabilities | undefined;
+    let declaredCapabilities: ImageCapabilities | undefined;
+    let declaredSDKs: Record<string, string> | undefined;
+    let declaredRuntimes: Record<string, string> | undefined;
     let variantSelectors: ImageVariantSelectors | undefined;
     try {
-      const declaredCapabilities = normalizeImageCapabilities({
+      declaredCapabilities = normalizeImageCapabilities({
         ...input.capabilities,
         osVersion: input.capabilities?.osVersion ?? url.searchParams.get("osVersion") ?? undefined,
         sdks:
@@ -24412,38 +24496,41 @@ export class AWSProvider implements CloudProvider {
             : undefined),
       });
       variantSelectors = normalizeImageVariantSelectors(input.variantSelectors);
-      const declaredSDKs = mergePromotionVersions(
+      declaredSDKs = mergePromotionVersions(
         declaredCapabilities?.sdks,
         variantSelectors?.sdks,
         "sdk",
         "variantSelectors.sdks",
       );
-      const declaredRuntimes = mergePromotionVersions(
+      declaredRuntimes = mergePromotionVersions(
         declaredCapabilities?.runtimes,
         variantSelectors?.runtimes,
         "runtime",
         "variantSelectors.runtimes",
       );
-      capabilities = normalizeImageCapabilities({
-        ...prior?.capabilities,
-        ...declaredCapabilities,
-        osVersion: declaredCapabilities?.osVersion ?? prior?.capabilities?.osVersion,
-        sdks: declaredSDKs
-          ? { ...prior?.capabilities?.sdks, ...declaredSDKs }
-          : prior?.capabilities?.sdks,
-        runtimes: declaredRuntimes
-          ? { ...prior?.capabilities?.runtimes, ...declaredRuntimes }
-          : prior?.capabilities?.runtimes,
-        browser: declaredCapabilities?.browser ?? prior?.capabilities?.browser,
-        webview2: declaredCapabilities?.webview2 ?? prior?.capabilities?.webview2,
-        desktop: declaredCapabilities?.desktop ?? prior?.capabilities?.desktop,
-      });
     } catch (error) {
       return json(
         { error: "invalid_image_capabilities", message: coordinatorErrorMessage(this.env, error) },
         { status: 400 },
       );
     }
+    const accumulatedCapabilities = (
+      priorCapabilities: ImageCapabilities | undefined,
+    ): ImageCapabilities | undefined =>
+      normalizeImageCapabilities({
+        ...priorCapabilities,
+        ...declaredCapabilities,
+        osVersion: declaredCapabilities?.osVersion ?? priorCapabilities?.osVersion,
+        sdks: declaredSDKs
+          ? { ...priorCapabilities?.sdks, ...declaredSDKs }
+          : priorCapabilities?.sdks,
+        runtimes: declaredRuntimes
+          ? { ...priorCapabilities?.runtimes, ...declaredRuntimes }
+          : priorCapabilities?.runtimes,
+        browser: declaredCapabilities?.browser ?? priorCapabilities?.browser,
+        webview2: declaredCapabilities?.webview2 ?? priorCapabilities?.webview2,
+        desktop: declaredCapabilities?.desktop ?? priorCapabilities?.desktop,
+      });
     const catalogOnly = boolFromUnknown(url.searchParams.get("catalogOnly") ?? input.catalogOnly);
     if (catalogOnly && !variantSelectors) {
       return json(
@@ -24509,6 +24596,25 @@ export class AWSProvider implements CloudProvider {
         { status: 409 },
       );
     }
+    const effectiveRegion = sanitizeAWSRegion(image.region ?? imageRegion) || region;
+    const preflightCataloged = await this.promotedImageMetadataByID(
+      imageID,
+      effectiveRegion,
+      known,
+    );
+    const preflightPrior = preflightCataloged
+      ? { ...(known?.region === effectiveRegion ? known : {}), ...preflightCataloged }
+      : known?.region === effectiveRegion
+        ? known
+        : undefined;
+    try {
+      accumulatedCapabilities(preflightPrior?.capabilities);
+    } catch (error) {
+      return json(
+        { error: "invalid_image_capabilities", message: coordinatorErrorMessage(this.env, error) },
+        { status: 400 },
+      );
+    }
     const fastSnapshotRestores =
       fastSnapshotRestoreAvailabilityZones.length > 0
         ? await provider.enableFastSnapshotRestore(
@@ -24516,35 +24622,69 @@ export class AWSProvider implements CloudProvider {
             fastSnapshotRestoreAvailabilityZones,
           )
         : undefined;
-    const promoted: PromotedImageRecord = {
-      ...image,
-      ...(fastSnapshotRestores ? { fastSnapshotRestores } : {}),
-      target,
-      ...(imageOS ? { os: imageOS } : {}),
-      region: image.region ?? imageRegion,
-      architecture:
-        image.architecture ?? awsImageArchitectureForTarget(target, image.serverType ?? ""),
-      promotedAt: new Date().toISOString(),
-      ...(capabilities ? { capabilities } : {}),
-      ...(catalogOnly && variantSelectors ? { catalogOnly: true, variantSelectors } : {}),
-    };
-    if (catalogOnly) {
-      await this.storage.put(promotedAWSImageCatalogKey(promoted), promoted);
-    } else {
-      await this.storage.put(promotedAWSImageKey(promoted), promoted);
-      await this.storage.put(promotedAWSImageCatalogKey(promoted), promoted);
-      if (target === "linux" && promoted.os) {
-        await this.storage.put(promotedAWSLinuxOSImageKey(promoted), promoted);
+    const { capabilities: _providerCapabilities, ...validatedImage } = image;
+    void _providerCapabilities;
+    try {
+      const promoted = await imageCatalogTransaction(this.storage, async (transaction) => {
+        const currentCataloged = await this.promotedImageMetadataByID(
+          imageID,
+          effectiveRegion,
+          known,
+          transaction,
+        );
+        const currentPrior: (ProviderImage & Partial<PromotedImageRecord>) | undefined =
+          currentCataloged
+            ? { ...(known?.region === effectiveRegion ? known : {}), ...currentCataloged }
+            : known?.region === effectiveRegion
+              ? known
+              : undefined;
+        const capabilities = accumulatedCapabilities(currentPrior?.capabilities);
+        const next: PromotedImageRecord = {
+          ...validatedImage,
+          ...(fastSnapshotRestores ? { fastSnapshotRestores } : {}),
+          target,
+          ...(imageOS ? { os: imageOS } : {}),
+          region: effectiveRegion,
+          architecture:
+            image.architecture ?? awsImageArchitectureForTarget(target, image.serverType ?? ""),
+          promotedAt: new Date().toISOString(),
+          ...(capabilities ? { capabilities } : {}),
+          ...(catalogOnly && variantSelectors ? { catalogOnly: true, variantSelectors } : {}),
+        };
+        await deletePromotedAWSImageRecords(transaction, imageID, ["image:aws:variant:"], {
+          region: effectiveRegion,
+        });
+        if (catalogOnly) {
+          await transaction.put(promotedAWSImageVariantKey(next), next);
+          return next;
+        }
+        await transaction.put(promotedAWSImageCatalogKey(next), next);
+        if (target === "linux" && next.os) {
+          await transaction.put(promotedAWSLinuxOSImageKey(next), next);
+        }
+        if (
+          target === "linux" &&
+          (!next.os || next.os === "ubuntu:24.04") &&
+          legacyPromotedAWSImageCompatible(next)
+        ) {
+          await transaction.put(legacyPromotedAWSImageKey(), next);
+        }
+        await transaction.put(promotedAWSImageKey(next), next);
+        return next;
+      });
+      return { image: promoted };
+    } catch (error) {
+      if (error instanceof InvalidImageCapabilitiesError) {
+        return json(
+          {
+            error: "invalid_image_capabilities",
+            message: coordinatorErrorMessage(this.env, error),
+          },
+          { status: 400 },
+        );
       }
-      if (
-        target === "linux" &&
-        (!promoted.os || promoted.os === "ubuntu:24.04") &&
-        legacyPromotedAWSImageCompatible(promoted)
-      ) {
-        await this.storage.put(legacyPromotedAWSImageKey(), promoted);
-      }
+      throw error;
     }
-    return { image: promoted };
   }
 
   async deleteSSHKey(name: string, leaseID: string): Promise<void> {
@@ -24584,28 +24724,34 @@ export class AWSProvider implements CloudProvider {
         serverType: config.serverType,
         region: config.awsRegion,
       };
-      const [selected, catalog] = await Promise.all([
+      const [selected, catalog, variants] = await Promise.all([
         this.storage.get<PromotedImageRecord>(promotedAWSImageKey(imageScope)),
         this.storage.list<PromotedImageRecord>({
           prefix: promotedAWSImageCatalogPrefix(imageScope),
         }),
+        this.storage.list<PromotedImageRecord>({
+          prefix: promotedAWSImageVariantPrefix(imageScope),
+        }),
       ]);
-      const candidates = new Map(
-        [selected, ...catalog.values()]
+      const candidates = [
+        ...[selected, ...catalog.values()]
           .filter((image): image is PromotedImageRecord => Boolean(image))
-          .map((image) => [image.id, image]),
-      );
-      return [...candidates.values()]
-        .filter((image) => imageSatisfiesRequirements(image.capabilities, config.imageRequirements))
+          .map((image) => ({ image, variant: false })),
+        ...[...variants.values()].map((image) => ({ image, variant: true })),
+      ];
+      return candidates
+        .filter(({ image }) =>
+          imageSatisfiesRequirements(image.capabilities, config.imageRequirements),
+        )
         .filter(
-          (image) =>
-            !image.catalogOnly ||
-            catalogOnlyImageRequested(image.variantSelectors, config.imageRequirements),
+          ({ image, variant }) =>
+            !variant || catalogOnlyImageRequested(image.variantSelectors, config.imageRequirements),
         )
         .toSorted(
           (left, right) =>
-            right.promotedAt.localeCompare(left.promotedAt) || left.id.localeCompare(right.id),
-        )[0];
+            right.image.promotedAt.localeCompare(left.image.promotedAt) ||
+            left.image.id.localeCompare(right.image.id),
+        )[0]?.image;
     }
     const scoped = await this.storage.get<PromotedImageRecord>(
       promotedAWSImageKey({
@@ -24673,20 +24819,119 @@ export class AWSProvider implements CloudProvider {
   }
 
   private async promotedImageByID(imageID: string): Promise<PromotedImageRecord | undefined> {
+    const matches = await this.promotedImagesByID(imageID);
+    return matches.find((image) => image.region === this.region);
+  }
+
+  private async promotedImagesByID(imageID: string): Promise<PromotedImageRecord[]> {
     const promoted = await this.storage.list<PromotedImageRecord>({
       prefix: promotedAWSImagePrefix(),
     });
-    return [...promoted.values()].find((image) => image.id === imageID);
+    return [...promoted.values()].filter((image) => image.id === imageID);
   }
 
-  private async promotedCatalogImageByID(
-    imageID: string,
-    preferredRegion: string,
-  ): Promise<PromotedImageRecord | undefined> {
-    const catalog = await this.storage.list<PromotedImageRecord>({ prefix: "image:aws:catalog:" });
-    const matches = [...catalog.values()].filter((image) => image.id === imageID);
-    return matches.find((image) => image.region === preferredRegion) ?? matches[0];
+  private async variantImagesByID(imageID: string): Promise<PromotedImageRecord[]> {
+    const variants = await this.storage.list<PromotedImageRecord>({ prefix: "image:aws:variant:" });
+    return [...variants.values()].filter((image) => image.id === imageID);
   }
+
+  private async promotedImageMetadataByID(
+    imageID: string,
+    region: string,
+    known?: ProviderImage,
+    storage: ProviderStateStorageView = this.storage,
+  ): Promise<PromotedImageRecord | undefined> {
+    const [catalog, variants] = await Promise.all([
+      storage.list<PromotedImageRecord>({ prefix: "image:aws:catalog:" }),
+      storage.list<PromotedImageRecord>({ prefix: "image:aws:variant:" }),
+    ]);
+    const matches = [
+      ...[...catalog.values()]
+        .filter((image) => image.id === imageID && image.region === region)
+        .map((image) => ({ image, variant: false })),
+      ...[...variants.values()]
+        .filter((image) => image.id === imageID && image.region === region)
+        .map((image) => ({ image, variant: true })),
+    ];
+    if (known?.region === region && typeof (known as PromotedImageRecord).promotedAt === "string") {
+      const knownPromotion = known as PromotedImageRecord;
+      const alreadyCataloged = matches.some(
+        ({ image, variant }) =>
+          !variant &&
+          image.promotedAt === knownPromotion.promotedAt &&
+          image.target === knownPromotion.target &&
+          image.region === knownPromotion.region,
+      );
+      if (!alreadyCataloged) matches.push({ image: knownPromotion, variant: false });
+    }
+    return mergedPromotedAWSImageHistory(matches);
+  }
+}
+
+async function deletePromotedAWSImageRecords(
+  storage: ProviderStateStorageView,
+  imageID: string,
+  prefixes: string[],
+  options: { region?: string } = {},
+): Promise<number> {
+  const catalogs = await Promise.all(
+    prefixes.map(async (prefix) => await storage.list<PromotedImageRecord>({ prefix })),
+  );
+  const keys = catalogs.flatMap((catalog) =>
+    [...catalog.entries()]
+      .filter(
+        ([, image]) =>
+          image.id === imageID && (options.region === undefined || image.region === options.region),
+      )
+      .map(([key]) => key),
+  );
+  await Promise.all(keys.map(async (key) => await storage.delete(key)));
+  return keys.length;
+}
+
+async function imageCatalogTransaction<T>(
+  storage: ProviderStateStorage,
+  callback: (transaction: ProviderStateStorageView) => Promise<T>,
+): Promise<T> {
+  if (typeof storage.transaction !== "function") {
+    throw new Error("transactional image catalog storage is required");
+  }
+  return storage.transaction(callback);
+}
+
+function mergedPromotedAWSImageHistory(
+  records: Array<{ image: PromotedImageRecord; variant: boolean }>,
+): PromotedImageRecord | undefined {
+  const ordered = records.toSorted(
+    (left, right) =>
+      left.image.promotedAt.localeCompare(right.image.promotedAt) ||
+      Number(left.variant) - Number(right.variant) ||
+      left.image.id.localeCompare(right.image.id),
+  );
+  const latest = ordered.at(-1);
+  if (!latest) return undefined;
+  const capabilities = ordered.reduce<ImageCapabilities | undefined>(
+    (inventory, { image }) => mergeImageCapabilityInventory(inventory, image.capabilities),
+    undefined,
+  );
+  return { ...latest.image, ...(capabilities ? { capabilities } : {}) };
+}
+
+function mergeImageCapabilityInventory(
+  inventory: ImageCapabilities | undefined,
+  additions: ImageCapabilities | undefined,
+): ImageCapabilities | undefined {
+  if (!additions) return inventory;
+  return {
+    ...inventory,
+    ...additions,
+    ...(inventory?.sdks || additions.sdks
+      ? { sdks: { ...inventory?.sdks, ...additions.sdks } }
+      : {}),
+    ...(inventory?.runtimes || additions.runtimes
+      ? { runtimes: { ...inventory?.runtimes, ...additions.runtimes } }
+      : {}),
+  };
 }
 
 function isRetryableAWSRegionProvisioningError(message: string): boolean {

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -100,10 +100,12 @@ import {
   requestOwner,
 } from "./http";
 import {
+  catalogOnlyImageRequested,
   hasImageRequirements,
   imageSatisfiesRequirements,
   InvalidImageCapabilitiesError,
   normalizeImageCapabilities,
+  normalizeImageVariantSelectors,
 } from "./image-capabilities";
 import {
   MarketplaceInputError,
@@ -259,6 +261,7 @@ import type {
   LeaseShareRole,
   LeaseTelemetry,
   ImageCapabilities,
+  ImageVariantSelectors,
   Provider,
   ProviderFastSnapshotRestore,
   LeaseImageIdentity,
@@ -13825,7 +13828,8 @@ export class FleetCoordinator {
       await providerForRegion.deleteImage(decodedImageID, kind, metadata);
       return json({ imageID: decodedImageID, deleted: true });
     }
-    if (method === "POST" && action === "promote") {
+    if (method === "POST" && (action === "promote" || action === "promote-catalog")) {
+      url.searchParams.set("catalogOnly", action === "promote-catalog" ? "true" : "false");
       if (!providerForRegion.promoteImage) {
         return json(
           {
@@ -17064,12 +17068,36 @@ class ImageCapabilityMismatchError extends Error {
   }
 }
 
-function promotionVersionMap(values: string[]): Record<string, string> | undefined {
-  const entries = values.map((value) => {
+function promotionVersionMap(values: string[], label: string): Record<string, string> | undefined {
+  const versions: Record<string, string> = {};
+  for (const value of values) {
     const separator = value.indexOf("=");
-    return separator > 0 ? [value.slice(0, separator), value.slice(separator + 1)] : [value, ""];
-  });
-  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+    const name = (separator > 0 ? value.slice(0, separator) : value).trim().toLowerCase();
+    const version = (separator > 0 ? value.slice(separator + 1) : "").trim();
+    if (Object.hasOwn(versions, name) && versions[name] !== version) {
+      throw new InvalidImageCapabilitiesError(`${label} declares conflicting versions for ${name}`);
+    }
+    versions[name] = version;
+  }
+  return values.length > 0 ? versions : undefined;
+}
+
+function mergePromotionVersions(
+  inventory: Record<string, string> | undefined,
+  selectors: Record<string, string> | undefined,
+  inventoryLabel: string,
+  selectorLabel: string,
+): Record<string, string> | undefined {
+  for (const [name, version] of Object.entries(selectors ?? {})) {
+    const inventoryVersion = inventory?.[name];
+    if (inventoryVersion !== undefined && inventoryVersion !== version) {
+      throw new InvalidImageCapabilitiesError(
+        `${inventoryLabel} and ${selectorLabel} declare conflicting versions for ${name}`,
+      );
+    }
+  }
+  if (!inventory && !selectors) return undefined;
+  return { ...inventory, ...selectors };
 }
 
 function promotedAWSImageKey(
@@ -22877,13 +22905,25 @@ export class AzureProvider implements CloudProvider {
       region?: string;
       architecture?: string;
       serverType?: string;
+      catalogOnly?: unknown;
     } = await readJson<{
       target?: string;
       os?: string;
       region?: string;
       architecture?: string;
       serverType?: string;
+      catalogOnly?: unknown;
     }>(request).catch(() => ({}));
+    const catalogOnly = boolFromUnknown(url.searchParams.get("catalogOnly") ?? input.catalogOnly);
+    if (catalogOnly) {
+      return json(
+        {
+          error: "unsupported_provider",
+          message: "catalog-only image promotion is AWS-only",
+        },
+        { status: 400 },
+      );
+    }
     if (!known) {
       return json(
         {
@@ -24267,6 +24307,8 @@ export class AWSProvider implements CloudProvider {
       serverType?: string;
       architecture?: string;
       capabilities?: ImageCapabilities;
+      catalogOnly?: unknown;
+      variantSelectors?: ImageVariantSelectors;
       fastSnapshotRestore?: unknown;
       fastSnapshotRestoreAvailabilityZones?: string[];
     } = await readJson<{
@@ -24276,6 +24318,8 @@ export class AWSProvider implements CloudProvider {
       serverType?: string;
       architecture?: string;
       capabilities?: ImageCapabilities;
+      catalogOnly?: unknown;
+      variantSelectors?: ImageVariantSelectors;
       fastSnapshotRestore?: unknown;
       fastSnapshotRestoreAvailabilityZones?: string[];
     }>(request).catch(() => ({}));
@@ -24320,7 +24364,14 @@ export class AWSProvider implements CloudProvider {
         { status: 400 },
       );
     }
-    const metadata: Partial<ProviderImage> = { ...prior, target, region: imageRegion };
+    const {
+      catalogOnly: _priorCatalogOnly,
+      variantSelectors: _priorVariantSelectors,
+      ...priorMetadata
+    } = prior ?? {};
+    void _priorCatalogOnly;
+    void _priorVariantSelectors;
+    const metadata: Partial<ProviderImage> = { ...priorMetadata, target, region: imageRegion };
     const serverType = input.serverType ?? url.searchParams.get("serverType") ?? prior?.serverType;
     if (serverType) {
       metadata.serverType = serverType;
@@ -24331,44 +24382,84 @@ export class AWSProvider implements CloudProvider {
       metadata.architecture = architecture;
     }
     let capabilities: ImageCapabilities | undefined;
+    let variantSelectors: ImageVariantSelectors | undefined;
     try {
-      capabilities = normalizeImageCapabilities({
-        ...prior?.capabilities,
+      const declaredCapabilities = normalizeImageCapabilities({
         ...input.capabilities,
-        osVersion:
-          input.capabilities?.osVersion ??
-          url.searchParams.get("osVersion") ??
-          prior?.capabilities?.osVersion,
+        osVersion: input.capabilities?.osVersion ?? url.searchParams.get("osVersion") ?? undefined,
         sdks:
           input.capabilities?.sdks ??
-          promotionVersionMap(url.searchParams.getAll("sdk")) ??
-          prior?.capabilities?.sdks,
+          promotionVersionMap(url.searchParams.getAll("sdk"), "sdk") ??
+          undefined,
         runtimes:
           input.capabilities?.runtimes ??
-          promotionVersionMap(url.searchParams.getAll("runtime")) ??
-          prior?.capabilities?.runtimes,
+          promotionVersionMap(url.searchParams.getAll("runtime"), "runtime") ??
+          undefined,
         browser:
           input.capabilities?.browser ??
           (url.searchParams.has("browser")
             ? boolFromUnknown(url.searchParams.get("browser"))
-            : undefined) ??
-          prior?.capabilities?.browser,
+            : undefined),
         webview2:
           input.capabilities?.webview2 ??
           (url.searchParams.has("webview2")
             ? boolFromUnknown(url.searchParams.get("webview2"))
-            : undefined) ??
-          prior?.capabilities?.webview2,
+            : undefined),
         desktop:
           input.capabilities?.desktop ??
           (url.searchParams.has("desktop")
             ? boolFromUnknown(url.searchParams.get("desktop"))
-            : undefined) ??
-          prior?.capabilities?.desktop,
+            : undefined),
+      });
+      variantSelectors = normalizeImageVariantSelectors(input.variantSelectors);
+      const declaredSDKs = mergePromotionVersions(
+        declaredCapabilities?.sdks,
+        variantSelectors?.sdks,
+        "sdk",
+        "variantSelectors.sdks",
+      );
+      const declaredRuntimes = mergePromotionVersions(
+        declaredCapabilities?.runtimes,
+        variantSelectors?.runtimes,
+        "runtime",
+        "variantSelectors.runtimes",
+      );
+      capabilities = normalizeImageCapabilities({
+        ...prior?.capabilities,
+        ...declaredCapabilities,
+        osVersion: declaredCapabilities?.osVersion ?? prior?.capabilities?.osVersion,
+        sdks: declaredSDKs
+          ? { ...prior?.capabilities?.sdks, ...declaredSDKs }
+          : prior?.capabilities?.sdks,
+        runtimes: declaredRuntimes
+          ? { ...prior?.capabilities?.runtimes, ...declaredRuntimes }
+          : prior?.capabilities?.runtimes,
+        browser: declaredCapabilities?.browser ?? prior?.capabilities?.browser,
+        webview2: declaredCapabilities?.webview2 ?? prior?.capabilities?.webview2,
+        desktop: declaredCapabilities?.desktop ?? prior?.capabilities?.desktop,
       });
     } catch (error) {
       return json(
         { error: "invalid_image_capabilities", message: coordinatorErrorMessage(this.env, error) },
+        { status: 400 },
+      );
+    }
+    const catalogOnly = boolFromUnknown(url.searchParams.get("catalogOnly") ?? input.catalogOnly);
+    if (catalogOnly && !variantSelectors) {
+      return json(
+        {
+          error: "catalog_only_variant_selectors_required",
+          message: "catalog-only image promotion requires at least one variant selector",
+        },
+        { status: 400 },
+      );
+    }
+    if (!catalogOnly && variantSelectors) {
+      return json(
+        {
+          error: "variant_selectors_require_catalog_only",
+          message: "variant selectors require catalog-only image promotion",
+        },
         { status: 400 },
       );
     }
@@ -24435,18 +24526,23 @@ export class AWSProvider implements CloudProvider {
         image.architecture ?? awsImageArchitectureForTarget(target, image.serverType ?? ""),
       promotedAt: new Date().toISOString(),
       ...(capabilities ? { capabilities } : {}),
+      ...(catalogOnly && variantSelectors ? { catalogOnly: true, variantSelectors } : {}),
     };
-    await this.storage.put(promotedAWSImageKey(promoted), promoted);
-    await this.storage.put(promotedAWSImageCatalogKey(promoted), promoted);
-    if (target === "linux" && promoted.os) {
-      await this.storage.put(promotedAWSLinuxOSImageKey(promoted), promoted);
-    }
-    if (
-      target === "linux" &&
-      (!promoted.os || promoted.os === "ubuntu:24.04") &&
-      legacyPromotedAWSImageCompatible(promoted)
-    ) {
-      await this.storage.put(legacyPromotedAWSImageKey(), promoted);
+    if (catalogOnly) {
+      await this.storage.put(promotedAWSImageCatalogKey(promoted), promoted);
+    } else {
+      await this.storage.put(promotedAWSImageKey(promoted), promoted);
+      await this.storage.put(promotedAWSImageCatalogKey(promoted), promoted);
+      if (target === "linux" && promoted.os) {
+        await this.storage.put(promotedAWSLinuxOSImageKey(promoted), promoted);
+      }
+      if (
+        target === "linux" &&
+        (!promoted.os || promoted.os === "ubuntu:24.04") &&
+        legacyPromotedAWSImageCompatible(promoted)
+      ) {
+        await this.storage.put(legacyPromotedAWSImageKey(), promoted);
+      }
     }
     return { image: promoted };
   }
@@ -24501,6 +24597,11 @@ export class AWSProvider implements CloudProvider {
       );
       return [...candidates.values()]
         .filter((image) => imageSatisfiesRequirements(image.capabilities, config.imageRequirements))
+        .filter(
+          (image) =>
+            !image.catalogOnly ||
+            catalogOnlyImageRequested(image.variantSelectors, config.imageRequirements),
+        )
         .toSorted(
           (left, right) =>
             right.promotedAt.localeCompare(left.promotedAt) || left.id.localeCompare(right.id),

--- a/worker/src/image-capabilities.ts
+++ b/worker/src/image-capabilities.ts
@@ -1,4 +1,4 @@
-import type { ImageCapabilities, ImageRequirements } from "./types";
+import type { ImageCapabilities, ImageRequirements, ImageVariantSelectors } from "./types";
 
 const maxVersionEntries = 32;
 const maxVersionLength = 128;
@@ -87,6 +87,18 @@ export function normalizeImageCapabilities(value: unknown): ImageCapabilities | 
   return hasValues(normalized) ? normalized : undefined;
 }
 
+export function normalizeImageVariantSelectors(value: unknown): ImageVariantSelectors | undefined {
+  if (value === undefined || value === null) return undefined;
+  const input = imageCapabilityObject(value, "variantSelectors", ["sdks", "runtimes"]);
+  const sdks = normalizedVersions(input["sdks"], "variantSelectors.sdks");
+  const runtimes = normalizedVersions(input["runtimes"], "variantSelectors.runtimes");
+  if (!sdks && !runtimes) return undefined;
+  return {
+    ...(sdks ? { sdks } : {}),
+    ...(runtimes ? { runtimes } : {}),
+  };
+}
+
 export function normalizeImageRequirements(value: unknown): ImageRequirements {
   if (value === undefined || value === null) return {};
   const input = imageCapabilityObject(value, "imageRequirements", [
@@ -161,6 +173,22 @@ export function imageSatisfiesRequirements(
   requirements: ImageRequirements,
 ): boolean {
   return missingImageCapabilities(capabilities, requirements).length === 0;
+}
+
+export function catalogOnlyImageRequested(
+  selectors: ImageVariantSelectors | undefined,
+  requirements: ImageRequirements,
+): boolean {
+  return (
+    Object.entries(selectors?.sdks ?? {}).some(([name, version]) => {
+      const requested = requirements.sdks?.[name];
+      return requested !== undefined && version === requested;
+    }) ||
+    Object.entries(selectors?.runtimes ?? {}).some(([name, version]) => {
+      const requested = requirements.runtimes?.[name];
+      return requested !== undefined && version === requested;
+    })
+  );
 }
 
 function versionAtLeast(actual: string | undefined, required: string): boolean {

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -266,6 +266,11 @@ export interface ImageCapabilities {
   desktop?: boolean;
 }
 
+export interface ImageVariantSelectors {
+  sdks?: Record<string, string>;
+  runtimes?: Record<string, string>;
+}
+
 export interface ImageRequirements {
   minOS?: string;
   sdks?: Record<string, string>;
@@ -716,6 +721,8 @@ export interface ProviderFastSnapshotRestore {
 
 export interface PromotedImageRecord extends ProviderImage {
   promotedAt: string;
+  catalogOnly?: boolean;
+  variantSelectors?: ImageVariantSelectors;
 }
 
 export interface RunRecord {

--- a/worker/test/coordinator-runtime.test.ts
+++ b/worker/test/coordinator-runtime.test.ts
@@ -7,6 +7,7 @@ import {
   type CoordinatorRuntime,
   type CoordinatorSocketHandlers,
   type CoordinatorStorage,
+  type CoordinatorStorageView,
   type CoordinatorWebSocketUpgradeOptions,
 } from "../src/coordinator-runtime";
 import { FleetCoordinator } from "../src/fleet";
@@ -57,6 +58,10 @@ class MemoryStorage implements CoordinatorStorage {
         value as T,
       ]),
     );
+  }
+
+  transaction<T>(callback: (transaction: CoordinatorStorageView) => Promise<T>): Promise<T> {
+    return callback(this);
   }
 
   value<T>(key: string): T | undefined {
@@ -585,6 +590,28 @@ describe("coordinator runtimes", () => {
         }),
       ),
     ).toBe("lifecycle");
+  });
+
+  it("serializes existing-image mutations while keeping image reads and creation direct", () => {
+    for (const [method, path] of [
+      ["POST", "/v1/images/ami-1/promote"],
+      ["POST", "/v1/images/ami-1/promote-catalog"],
+      ["DELETE", "/v1/images/ami-1"],
+      ["DELETE", "/v1/images/ami-1/promote-catalog"],
+    ]) {
+      expect(
+        coordinatorRequestQueue(new Request(`https://coordinator.test${path}`, { method })),
+      ).toBe("lifecycle");
+    }
+    for (const [method, path] of [
+      ["POST", "/v1/images"],
+      ["GET", "/v1/images/ami-1"],
+      ["GET", "/v1/images/ami-1/fast-snapshot-restore"],
+    ]) {
+      expect(
+        coordinatorRequestQueue(new Request(`https://coordinator.test${path}`, { method })),
+      ).toBe("direct");
+    }
   });
 
   it("does not hold the lifecycle queue across GitHub OAuth requests", async () => {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -17,6 +17,8 @@ import {
   CloudflareCoordinatorRuntime,
   type CoordinatorRuntime,
   type CoordinatorSocketHandlers,
+  type CoordinatorStorage,
+  type CoordinatorStorageView,
   type CoordinatorWebSocketUpgradeOptions,
 } from "../src/coordinator-runtime";
 import {
@@ -105,12 +107,16 @@ function workspaceFixtureKey(
 }
 
 class MemoryStorage {
-  private readonly values = new Map<string, unknown>();
+  private values: Map<string, unknown>;
   private alarmTime: number | undefined;
   beforeGet?: (key: string) => Promise<void>;
   afterGet?: (key: string, value: unknown) => Promise<void> | void;
   beforePut?: (key: string, value: unknown) => Promise<void>;
   beforeDelete?: (key: string) => Promise<void>;
+
+  constructor(values = new Map<string, unknown>()) {
+    this.values = values;
+  }
 
   async get<T>(key: string, _options?: { noCache?: boolean }): Promise<T | undefined> {
     await this.beforeGet?.(key);
@@ -141,8 +147,15 @@ class MemoryStorage {
     this.alarmTime = time;
   }
 
-  async transaction<T>(callback: (transaction: MemoryStorage) => Promise<T>): Promise<T> {
-    return await callback(this);
+  async transaction<T>(callback: (transaction: CoordinatorStorageView) => Promise<T>): Promise<T> {
+    const transaction = new MemoryStorage(new Map(this.values));
+    transaction.beforeGet = this.beforeGet;
+    transaction.afterGet = this.afterGet;
+    transaction.beforePut = this.beforePut;
+    transaction.beforeDelete = this.beforeDelete;
+    const result = await callback(transaction);
+    this.values = new Map(transaction.values);
+    return result;
   }
 
   async list<T>({
@@ -28070,7 +28083,7 @@ describe("fleet lease identity and idle", () => {
     });
     expect(storage.value(defaultKey)).toEqual(expect.objectContaining({ id: "ami-default" }));
     expect(
-      storage.value("image:aws:catalog:linux:x86_64:ubuntu26.04:eu-west-1:ami-variant"),
+      storage.value("image:aws:variant:linux:x86_64:ubuntu26.04:eu-west-1:ami-variant"),
     ).toEqual(
       expect.objectContaining({
         id: "ami-variant",
@@ -28078,6 +28091,10 @@ describe("fleet lease identity and idle", () => {
         variantSelectors: { sdks: { toolkit: "2.0" } },
       }),
     );
+    expect(
+      storage.value("image:aws:catalog:linux:x86_64:ubuntu26.04:eu-west-1:ami-variant"),
+    ).toBeUndefined();
+    await expect(storage.list({ prefix: "image:aws:catalog:" })).resolves.toHaveLength(0);
   });
 
   it("serves catalog-only promotion on its dedicated coordinator route", async () => {
@@ -28124,6 +28141,61 @@ describe("fleet lease identity and idle", () => {
     });
   });
 
+  it("serializes image mutations across provider awaits", async () => {
+    const order: string[] = [];
+    let releaseFirst!: () => void;
+    let markFirstStarted!: () => void;
+    const firstBlocked = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const firstStarted = new Promise<void>((resolve) => {
+      markFirstStarted = resolve;
+    });
+    const aws = fakeProvider();
+    vi.spyOn(aws, "promoteImage").mockImplementation(async (imageID) => {
+      order.push(`${imageID}:start`);
+      if (imageID === "ami-first") {
+        markFirstStarted();
+        await firstBlocked;
+      }
+      order.push(`${imageID}:end`);
+      return {
+        image: {
+          id: imageID,
+          name: imageID,
+          state: "available",
+          provider: "aws",
+          region: "eu-west-1",
+        },
+      };
+    });
+    const fleet = testFleet(new MemoryStorage(), { aws });
+
+    const first = fleet.fetch(
+      request("POST", "/v1/images/ami-first/promote?provider=aws", {
+        headers: { "x-crabbox-admin": "true" },
+      }),
+    );
+    await firstStarted;
+    const second = fleet.fetch(
+      request("POST", "/v1/images/ami-second/promote?provider=aws", {
+        headers: { "x-crabbox-admin": "true" },
+      }),
+    );
+    await Promise.resolve();
+    expect(order).toEqual(["ami-first:start"]);
+
+    releaseFirst();
+    const responses = await Promise.all([first, second]);
+    expect(responses.map((response) => response.status)).toEqual([200, 200]);
+    expect(order).toEqual([
+      "ami-first:start",
+      "ami-first:end",
+      "ami-second:start",
+      "ami-second:end",
+    ]);
+  });
+
   it("rejects missing, detached, or conflicting catalog variant selectors", async () => {
     const provider = new AWSProvider({} as Env, "eu-west-1", new MemoryStorage());
     vi.spyOn(provider, "getImage").mockResolvedValue({
@@ -28165,6 +28237,35 @@ describe("fleet lease identity and idle", () => {
     await expect((conflicting as Response).json()).resolves.toMatchObject({
       error: "invalid_image_capabilities",
       message: expect.stringContaining("conflicting versions for toolkit"),
+    });
+  });
+
+  it("rejects prototype-shaped promotion capability names", async () => {
+    const provider = new AWSProvider({} as Env, "eu-west-1", new MemoryStorage());
+    vi.spyOn(provider, "getImage").mockResolvedValue({
+      id: "ami-invalid",
+      name: "invalid",
+      state: "available",
+      provider: "aws",
+      region: "eu-west-1",
+      architecture: "x86_64",
+    });
+    const url = new URL(
+      "https://crabbox.test/v1/images/ami-invalid/promote?target=linux&region=eu-west-1&sdk=__proto__%3D1",
+    );
+
+    const response = await provider.promoteImage(
+      "ami-invalid",
+      undefined,
+      new Request(url, { method: "POST", body: "{}" }),
+      url,
+    );
+
+    expect(response).toBeInstanceOf(Response);
+    expect((response as Response).status).toBe(400);
+    await expect((response as Response).json()).resolves.toMatchObject({
+      error: "invalid_image_capabilities",
+      message: expect.stringContaining('capabilities.sdks name "__proto__" is invalid'),
     });
   });
 
@@ -28210,7 +28311,7 @@ describe("fleet lease identity and idle", () => {
     };
     storage.seed("image:aws:promoted:linux:x86_64:ubuntu26.04:eu-west-1", defaultImage);
     storage.seed("image:aws:catalog:linux:x86_64:ubuntu26.04:eu-west-1:ami-default", defaultImage);
-    storage.seed("image:aws:catalog:linux:x86_64:ubuntu26.04:eu-west-1:ami-variant", variantImage);
+    storage.seed("image:aws:variant:linux:x86_64:ubuntu26.04:eu-west-1:ami-variant", variantImage);
     const provider = new AWSProvider({} as Env, "eu-west-1", storage);
     const selected = async (
       imageRequirements: ReturnType<typeof leaseConfig>["imageRequirements"],
@@ -28245,9 +28346,52 @@ describe("fleet lease identity and idle", () => {
     await expect(selected({ minOS: "26.04" })).resolves.toBe("ami-default");
   });
 
+  it("preserves ordinary and variant roles when they share an AMI ID", async () => {
+    const storage = new MemoryStorage();
+    const ordinary = {
+      id: "ami-shared",
+      name: "shared",
+      state: "available",
+      target: "linux" as const,
+      os: "ubuntu:26.04",
+      region: "eu-west-1",
+      architecture: "x86_64",
+      promotedAt: "2026-07-01T00:00:00Z",
+      capabilities: { runtimes: { node: "24" } },
+    };
+    const variant = {
+      ...ordinary,
+      promotedAt: "2026-07-02T00:00:00Z",
+      catalogOnly: true,
+      variantSelectors: { sdks: { toolkit: "2.0" } },
+      capabilities: { sdks: { toolkit: "2.0" }, runtimes: { node: "24" } },
+    };
+    storage.seed("image:aws:promoted:linux:x86_64:ubuntu26.04:eu-west-1", ordinary);
+    storage.seed("image:aws:catalog:linux:x86_64:ubuntu26.04:eu-west-1:ami-shared", ordinary);
+    storage.seed("image:aws:variant:linux:x86_64:ubuntu26.04:eu-west-1:ami-shared", variant);
+    const provider = new AWSProvider({} as Env, "eu-west-1", storage);
+    const selected = async (
+      imageRequirements: ReturnType<typeof leaseConfig>["imageRequirements"],
+    ) => {
+      const config = leaseConfig({
+        provider: "aws",
+        os: "ubuntu:26.04",
+        sshPublicKey: "ssh-ed25519 test",
+        imageRequirements,
+      });
+      const prepared = await provider.prepareLeaseConfig(config);
+      return prepared.awsPromotedAMIs[awsPromotedAMIConfigKey("eu-west-1", config.serverType)];
+    };
+
+    await expect(selected({ runtimes: { node: "24" } })).resolves.toBe("ami-shared");
+    await expect(selected({ sdks: { toolkit: "2.0" }, runtimes: { node: "24" } })).resolves.toBe(
+      "ami-shared",
+    );
+  });
+
   it("clears catalog-only selector metadata on ordinary re-promotion", async () => {
     const storage = new MemoryStorage();
-    const catalogKey = "image:aws:catalog:linux:x86_64:ubuntu26.04:eu-west-1:ami-variant";
+    const catalogKey = "image:aws:variant:linux:x86_64:ubuntu26.04:eu-west-1:ami-variant";
     storage.seed(catalogKey, {
       id: "ami-variant",
       name: "variant",
@@ -28290,8 +28434,398 @@ describe("fleet lease identity and idle", () => {
     );
     expect(scoped).not.toHaveProperty("catalogOnly");
     expect(scoped).not.toHaveProperty("variantSelectors");
-    expect(storage.value(catalogKey)).not.toHaveProperty("catalogOnly");
-    expect(storage.value(catalogKey)).not.toHaveProperty("variantSelectors");
+    expect(storage.value(catalogKey)).toBeUndefined();
+    expect(
+      storage.value("image:aws:catalog:linux:x86_64:ubuntu26.04:eu-west-1:ami-variant"),
+    ).toEqual(
+      expect.objectContaining({
+        capabilities: { sdks: { toolkit: "2.0" }, runtimes: { node: "24" } },
+      }),
+    );
+  });
+
+  it("moves a catalog-only AMI to one canonical variant scope", async () => {
+    const storage = new MemoryStorage();
+    const provider = new AWSProvider({} as Env, "eu-west-1", storage);
+    vi.spyOn(provider, "getImage").mockResolvedValue({
+      id: "ami-variant",
+      name: "variant",
+      state: "available",
+      provider: "aws",
+      region: "eu-west-1",
+      architecture: "x86_64",
+    });
+    const promote = async (target: "linux" | "windows") => {
+      const url = new URL(
+        `https://crabbox.test/v1/images/ami-variant/promote-catalog?target=${target}&region=eu-west-1&catalogOnly=true`,
+      );
+      return await provider.promoteImage(
+        "ami-variant",
+        undefined,
+        new Request(url, {
+          method: "POST",
+          body: JSON.stringify({ variantSelectors: { sdks: { toolkit: "2.0" } } }),
+        }),
+        url,
+      );
+    };
+
+    await promote("linux");
+    await promote("windows");
+
+    expect(
+      storage.value("image:aws:variant:linux:x86_64:ubuntu26.04:eu-west-1:ami-variant"),
+    ).toBeUndefined();
+    expect(storage.value("image:aws:variant:windows:x86_64:eu-west-1:ami-variant")).toEqual(
+      expect.objectContaining({ id: "ami-variant", target: "windows" }),
+    );
+    await expect(storage.list({ prefix: "image:aws:variant:" })).resolves.toHaveLength(1);
+  });
+
+  it("does not publish a new variant when stale-role cleanup fails", async () => {
+    const storage = new MemoryStorage();
+    const staleKey = "image:aws:variant:linux:x86_64:ubuntu26.04:eu-west-1:ami-variant";
+    storage.seed(staleKey, {
+      id: "ami-variant",
+      state: "available",
+      provider: "aws",
+      target: "linux",
+      os: "ubuntu:26.04",
+      region: "eu-west-1",
+      architecture: "x86_64",
+      promotedAt: "2026-07-01T00:00:00Z",
+      catalogOnly: true,
+      variantSelectors: { sdks: { toolkit: "1.0" } },
+    });
+    storage.beforeDelete = async () => {
+      throw new Error("variant cleanup failed");
+    };
+    const provider = new AWSProvider({} as Env, "eu-west-1", storage);
+    vi.spyOn(provider, "getImage").mockResolvedValue({
+      id: "ami-variant",
+      state: "available",
+      provider: "aws",
+      region: "eu-west-1",
+      architecture: "x86_64",
+    });
+    const url = new URL(
+      "https://crabbox.test/v1/images/ami-variant/promote-catalog?target=windows&region=eu-west-1&catalogOnly=true",
+    );
+
+    await expect(
+      provider.promoteImage(
+        "ami-variant",
+        undefined,
+        new Request(url, {
+          method: "POST",
+          body: JSON.stringify({ variantSelectors: { sdks: { toolkit: "2.0" } } }),
+        }),
+        url,
+      ),
+    ).rejects.toThrow("variant cleanup failed");
+    expect(storage.value(staleKey)).toBeDefined();
+    expect(storage.value("image:aws:variant:windows:x86_64:eu-west-1:ami-variant")).toBeUndefined();
+  });
+
+  it("rolls back catalog-only replacement when the final variant write fails", async () => {
+    const storage = new MemoryStorage();
+    const staleKey = "image:aws:variant:linux:x86_64:ubuntu26.04:eu-west-1:ami-variant";
+    const stale = {
+      id: "ami-variant",
+      state: "available",
+      provider: "aws",
+      target: "linux",
+      os: "ubuntu:26.04",
+      region: "eu-west-1",
+      architecture: "x86_64",
+      promotedAt: "2026-07-01T00:00:00Z",
+      catalogOnly: true,
+      variantSelectors: { sdks: { toolkit: "1.0" } },
+    };
+    storage.seed(staleKey, stale);
+    storage.beforePut = async (key) => {
+      if (key === "image:aws:variant:windows:x86_64:eu-west-1:ami-variant") {
+        throw new Error("variant publish failed");
+      }
+    };
+    const provider = new AWSProvider({} as Env, "eu-west-1", storage);
+    vi.spyOn(provider, "getImage").mockResolvedValue({
+      id: "ami-variant",
+      state: "available",
+      provider: "aws",
+      region: "eu-west-1",
+      architecture: "x86_64",
+    });
+    const url = new URL(
+      "https://crabbox.test/v1/images/ami-variant/promote-catalog?target=windows&region=eu-west-1&catalogOnly=true",
+    );
+
+    await expect(
+      provider.promoteImage(
+        "ami-variant",
+        undefined,
+        new Request(url, {
+          method: "POST",
+          body: JSON.stringify({ variantSelectors: { sdks: { toolkit: "2.0" } } }),
+        }),
+        url,
+      ),
+    ).rejects.toThrow("variant publish failed");
+    expect(storage.value(staleKey)).toEqual(stale);
+    await expect(storage.list({ prefix: "image:aws:variant:" })).resolves.toHaveLength(1);
+  });
+
+  it("keeps the previous ordinary default when variant cleanup fails", async () => {
+    const storage = new MemoryStorage();
+    const defaultKey = "image:aws:promoted:linux:x86_64:ubuntu26.04:eu-west-1";
+    storage.seed(defaultKey, {
+      id: "ami-default",
+      state: "available",
+      provider: "aws",
+      target: "linux",
+      os: "ubuntu:26.04",
+      region: "eu-west-1",
+      architecture: "x86_64",
+      promotedAt: "2026-07-01T00:00:00Z",
+    });
+    storage.seed("image:aws:variant:linux:x86_64:ubuntu26.04:eu-west-1:ami-next", {
+      id: "ami-next",
+      state: "available",
+      provider: "aws",
+      target: "linux",
+      os: "ubuntu:26.04",
+      region: "eu-west-1",
+      architecture: "x86_64",
+      promotedAt: "2026-07-02T00:00:00Z",
+      catalogOnly: true,
+      variantSelectors: { sdks: { toolkit: "2.0" } },
+    });
+    storage.beforeDelete = async () => {
+      throw new Error("variant cleanup failed");
+    };
+    const provider = new AWSProvider({} as Env, "eu-west-1", storage);
+    vi.spyOn(provider, "getImage").mockResolvedValue({
+      id: "ami-next",
+      state: "available",
+      provider: "aws",
+      region: "eu-west-1",
+      architecture: "x86_64",
+    });
+    const url = new URL(
+      "https://crabbox.test/v1/images/ami-next/promote?target=linux&region=eu-west-1",
+    );
+
+    await expect(
+      provider.promoteImage(
+        "ami-next",
+        undefined,
+        new Request(url, { method: "POST", body: "{}" }),
+        url,
+      ),
+    ).rejects.toThrow("variant cleanup failed");
+    expect(storage.value(defaultKey)).toEqual(expect.objectContaining({ id: "ami-default" }));
+    expect(
+      storage.value("image:aws:catalog:linux:x86_64:ubuntu26.04:eu-west-1:ami-next"),
+    ).toBeUndefined();
+  });
+
+  it("keeps the previous ordinary default when the new default write fails", async () => {
+    const storage = new MemoryStorage();
+    const defaultKey = "image:aws:promoted:windows:x86_64:eu-west-1";
+    storage.seed(defaultKey, {
+      id: "ami-default",
+      state: "available",
+      provider: "aws",
+      target: "windows",
+      region: "eu-west-1",
+      architecture: "x86_64",
+      promotedAt: "2026-07-01T00:00:00Z",
+    });
+    storage.beforePut = async (key) => {
+      if (key === defaultKey) throw new Error("default publish failed");
+    };
+    const provider = new AWSProvider({} as Env, "eu-west-1", storage);
+    vi.spyOn(provider, "getImage").mockResolvedValue({
+      id: "ami-next",
+      state: "available",
+      provider: "aws",
+      region: "eu-west-1",
+      architecture: "x86_64",
+    });
+    const url = new URL(
+      "https://crabbox.test/v1/images/ami-next/promote?target=windows&region=eu-west-1",
+    );
+
+    await expect(
+      provider.promoteImage(
+        "ami-next",
+        undefined,
+        new Request(url, { method: "POST", body: "{}" }),
+        url,
+      ),
+    ).rejects.toThrow("default publish failed");
+    expect(storage.value(defaultKey)).toEqual(expect.objectContaining({ id: "ami-default" }));
+    expect(storage.value("image:aws:catalog:windows:x86_64:eu-west-1:ami-next")).toBeUndefined();
+  });
+
+  it("re-reads regional capability history after provider validation", async () => {
+    const storage = new MemoryStorage();
+    const catalogKey = "image:aws:catalog:linux:x86_64:ubuntu26.04:eu-west-1:ami-shared";
+    storage.seed(catalogKey, {
+      id: "ami-shared",
+      state: "available",
+      provider: "aws",
+      target: "linux",
+      os: "ubuntu:26.04",
+      region: "eu-west-1",
+      architecture: "x86_64",
+      promotedAt: "2026-07-01T00:00:00Z",
+      capabilities: { runtimes: { node: "22" } },
+    });
+    const provider = new AWSProvider({} as Env, "eu-west-1", storage);
+    vi.spyOn(provider, "getImage").mockImplementation(async () => {
+      storage.seed("image:aws:variant:linux:x86_64:ubuntu26.04:eu-west-1:ami-shared", {
+        id: "ami-shared",
+        state: "available",
+        provider: "aws",
+        target: "linux",
+        os: "ubuntu:26.04",
+        region: "eu-west-1",
+        architecture: "x86_64",
+        promotedAt: "2026-07-02T00:00:00Z",
+        catalogOnly: true,
+        variantSelectors: { sdks: { toolkit: "2.0" } },
+        capabilities: {
+          sdks: { toolkit: "2.0" },
+          runtimes: { node: "24" },
+        },
+      });
+      return {
+        id: "ami-shared",
+        state: "available",
+        provider: "aws",
+        region: "eu-west-1",
+        architecture: "x86_64",
+      };
+    });
+    const url = new URL(
+      "https://crabbox.test/v1/images/ami-shared/promote?target=linux&region=eu-west-1",
+    );
+
+    await provider.promoteImage(
+      "ami-shared",
+      undefined,
+      new Request(url, { method: "POST", body: "{}" }),
+      url,
+    );
+
+    expect(storage.value(catalogKey)).toEqual(
+      expect.objectContaining({
+        capabilities: { sdks: { toolkit: "2.0" }, runtimes: { node: "24" } },
+      }),
+    );
+  });
+
+  it("keeps same-string AMI history and cleanup within the effective Region", async () => {
+    const storage = new MemoryStorage();
+    const euVariantKey = "image:aws:variant:linux:x86_64:ubuntu26.04:eu-west-1:ami-shared";
+    const usVariantKey = "image:aws:variant:linux:x86_64:ubuntu26.04:us-east-1:ami-shared";
+    storage.seed(euVariantKey, {
+      id: "ami-shared",
+      state: "available",
+      provider: "aws",
+      target: "linux",
+      os: "ubuntu:26.04",
+      region: "eu-west-1",
+      architecture: "x86_64",
+      promotedAt: "2026-07-03T00:00:00Z",
+      catalogOnly: true,
+      variantSelectors: { sdks: { toolkit: "2.0" } },
+      capabilities: { sdks: { toolkit: "2.0" } },
+    });
+    storage.seed(usVariantKey, {
+      id: "ami-shared",
+      state: "available",
+      provider: "aws",
+      target: "linux",
+      os: "ubuntu:26.04",
+      region: "us-east-1",
+      architecture: "x86_64",
+      promotedAt: "2026-07-02T00:00:00Z",
+      catalogOnly: true,
+      variantSelectors: { sdks: { go: "1.25" } },
+      capabilities: { sdks: { go: "1.25" } },
+    });
+    const provider = new AWSProvider({} as Env, "us-east-1", storage);
+    vi.spyOn(provider, "getImage").mockResolvedValue({
+      id: "ami-shared",
+      state: "available",
+      provider: "aws",
+      region: "us-east-1",
+      architecture: "x86_64",
+    });
+    const url = new URL(
+      "https://crabbox.test/v1/images/ami-shared/promote?target=linux&region=us-east-1&runtime=node%3D24",
+    );
+
+    await provider.promoteImage(
+      "ami-shared",
+      undefined,
+      new Request(url, { method: "POST", body: "{}" }),
+      url,
+    );
+
+    expect(storage.value(euVariantKey)).toBeDefined();
+    expect(storage.value(usVariantKey)).toBeUndefined();
+    const promoted = storage.value<{
+      capabilities?: { sdks?: Record<string, string>; runtimes?: Record<string, string> };
+    }>("image:aws:catalog:linux:x86_64:ubuntu26.04:us-east-1:ami-shared");
+    expect(promoted?.capabilities).toEqual({
+      sdks: { go: "1.25" },
+      runtimes: { node: "24" },
+    });
+    expect(promoted?.capabilities?.sdks).not.toHaveProperty("toolkit");
+  });
+
+  it("preserves capability inventory through ordinary to variant to ordinary routes", async () => {
+    const storage = new MemoryStorage();
+    const provider = new AWSProvider({} as Env, "eu-west-1", storage);
+    vi.spyOn(provider, "getImage").mockResolvedValue({
+      id: "ami-shared",
+      name: "shared",
+      state: "available",
+      provider: "aws",
+      region: "eu-west-1",
+      architecture: "x86_64",
+    });
+    const fleet = testFleet(storage, { aws: provider });
+    const promote = async (path: string, body: Record<string, unknown> = {}) => {
+      const response = await fleet.fetch(
+        request("POST", path, {
+          headers: { "x-crabbox-admin": "true" },
+          body,
+        }),
+      );
+      expect(response.status).toBe(200);
+    };
+
+    await promote(
+      "/v1/images/ami-shared/promote?provider=aws&target=linux&region=eu-west-1&runtime=node%3D22",
+    );
+    await promote(
+      "/v1/images/ami-shared/promote-catalog?provider=aws&target=linux&region=eu-west-1&runtime=node%3D24",
+      { variantSelectors: { sdks: { toolkit: "2.0" } } },
+    );
+    await promote("/v1/images/ami-shared/promote?provider=aws&target=linux&region=eu-west-1");
+
+    expect(
+      storage.value("image:aws:catalog:linux:x86_64:ubuntu26.04:eu-west-1:ami-shared"),
+    ).toEqual(
+      expect.objectContaining({
+        capabilities: { sdks: { toolkit: "2.0" }, runtimes: { node: "24" } },
+      }),
+    );
+    await expect(storage.list({ prefix: "image:aws:variant:" })).resolves.toHaveLength(0);
   });
 
   it("records the exact promoted AWS image selected for a lease", async () => {
@@ -29115,6 +29649,50 @@ describe("fleet lease identity and idle", () => {
     );
   });
 
+  it("validates accumulated capabilities before enabling Fast Snapshot Restore", async () => {
+    const storage = new MemoryStorage();
+    storage.seed("image:aws:catalog:windows:x86_64:eu-west-1:ami-tools", {
+      id: "ami-tools",
+      state: "available",
+      provider: "aws",
+      target: "windows",
+      region: "eu-west-1",
+      architecture: "x86_64",
+      promotedAt: "2026-08-01T00:00:00Z",
+      capabilities: {
+        sdks: Object.fromEntries(Array.from({ length: 32 }, (_, index) => [`sdk${index}`, "1"])),
+      },
+    });
+    const provider = new AWSProvider({} as Env, "eu-west-1", storage);
+    vi.spyOn(provider, "getImage").mockResolvedValue({
+      id: "ami-tools",
+      state: "available",
+      provider: "aws",
+      region: "eu-west-1",
+      architecture: "x86_64",
+      snapshots: ["snap-root"],
+    });
+    const enable = vi.spyOn(provider, "enableFastSnapshotRestore").mockResolvedValue([]);
+    const url = new URL(
+      "https://crabbox.test/v1/images/ami-tools/promote?target=windows&region=eu-west-1&sdk=extra%3D1&fastSnapshotRestore=true&fsrAz=eu-west-1a",
+    );
+
+    const response = await provider.promoteImage(
+      "ami-tools",
+      undefined,
+      new Request(url, { method: "POST", body: "{}" }),
+      url,
+    );
+
+    expect(response).toBeInstanceOf(Response);
+    expect((response as Response).status).toBe(400);
+    await expect((response as Response).json()).resolves.toMatchObject({
+      error: "invalid_image_capabilities",
+      message: expect.stringContaining("supports at most 32 entries"),
+    });
+    expect(enable).not.toHaveBeenCalled();
+  });
+
   it("returns current AWS Fast Snapshot Restore status for promoted images", async () => {
     const storage = new MemoryStorage();
     const statusCalls: Array<{ snapshots: string[]; zones: string[] | undefined }> = [];
@@ -29799,13 +30377,513 @@ describe("fleet lease identity and idle", () => {
     expect(storage.value(otherCatalogKey)).toEqual(otherImage);
     expect(storage.value(claimKey)).toBeUndefined();
     expect(claimDeletedAfterCatalog).toBe(true);
-    expect(recordsPresentWhenClaimDeleted).toEqual([
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
+    expect(recordsPresentWhenClaimDeleted).toEqual([undefined, undefined, undefined, image, image]);
+  });
+
+  it("reroutes implicit AWS image GET and deletion to stored Regions", async () => {
+    const storage = new MemoryStorage();
+    storage.seed("image:aws:promoted:linux:x86_64:ubuntu26.04:us-east-1", {
+      id: "ami-promoted",
+      name: "promoted",
+      state: "available",
+      provider: "aws",
+      target: "linux",
+      os: "ubuntu:26.04",
+      region: "us-east-1",
+      architecture: "x86_64",
+      promotedAt: "2026-08-01T00:00:00Z",
+    });
+    storage.seed("image:aws:created:ami-created", {
+      id: "ami-created",
+      name: "created",
+      state: "available",
+      provider: "aws",
+      region: "us-east-1",
+      architecture: "x86_64",
+    });
+    const calls: Array<{ action: string; host: string; imageID: string }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+        async (input, init) => {
+          const providerRequest = input instanceof Request ? input : new Request(input, init);
+          const params = new URLSearchParams(await providerRequest.clone().text());
+          const action = params.get("Action") ?? "";
+          const imageID = params.get("ImageId.1") ?? params.get("ImageId") ?? "";
+          calls.push({ action, host: new URL(providerRequest.url).host, imageID });
+          if (action === "DescribeImages") {
+            return ec2XMLResponse(`
+              <DescribeImagesResponse><imagesSet><item>
+                <imageId>${imageID}</imageId><name>${imageID}</name>
+                <imageState>available</imageState><architecture>x86_64</architecture>
+              </item></imagesSet></DescribeImagesResponse>
+            `);
+          }
+          if (action === "DeregisterImage") {
+            return ec2XMLResponse("<DeregisterImageResponse />");
+          }
+          return ec2XMLResponse("<ErrorResponse />", 500);
+        },
+      ),
+    );
+    const fleet = testFleet(
+      storage,
+      {},
+      {
+        AWS_ACCESS_KEY_ID: "test",
+        AWS_SECRET_ACCESS_KEY: "secret",
+        CRABBOX_AWS_REGION: "eu-west-1",
+      },
+    );
+
+    const get = await fleet.fetch(
+      request("GET", "/v1/images/ami-promoted?provider=aws", {
+        headers: { "x-crabbox-admin": "true" },
+      }),
+    );
+    const deleted = await fleet.fetch(
+      request("DELETE", "/v1/images/ami-created?provider=aws", {
+        headers: { "x-crabbox-admin": "true" },
+      }),
+    );
+
+    expect(get.status).toBe(200);
+    await expect(get.json()).resolves.toMatchObject({ image: { region: "us-east-1" } });
+    expect(deleted.status).toBe(200);
+    expect(calls).toEqual([
+      { action: "DescribeImages", host: "ec2.us-east-1.amazonaws.com", imageID: "ami-promoted" },
+      { action: "DescribeImages", host: "ec2.us-east-1.amazonaws.com", imageID: "ami-created" },
+      { action: "DeregisterImage", host: "ec2.us-east-1.amazonaws.com", imageID: "ami-created" },
     ]);
+  });
+
+  it("prefers current-Region ordinary metadata when an AMI ID exists in multiple Regions", async () => {
+    const storage = new MemoryStorage();
+    for (const region of ["eu-west-1", "us-east-1"]) {
+      storage.seed(`image:aws:promoted:windows:x86_64:${region}`, {
+        id: "ami-shared",
+        state: "available",
+        provider: "aws",
+        target: "windows",
+        region,
+        architecture: "x86_64",
+        promotedAt: "2026-08-01T00:00:00Z",
+      });
+    }
+
+    const metadata = await new AWSProvider({} as Env, "us-east-1", storage).storedImageMetadata(
+      "ami-shared",
+    );
+
+    expect(metadata?.region).toBe("us-east-1");
+  });
+
+  it("prefers a current-Region variant over an ordinary fallback from another Region", async () => {
+    const storage = new MemoryStorage();
+    storage.seed("image:aws:promoted:windows:x86_64:eu-west-1", {
+      id: "ami-shared",
+      state: "available",
+      provider: "aws",
+      target: "windows",
+      region: "eu-west-1",
+      architecture: "x86_64",
+      promotedAt: "2026-08-01T00:00:00Z",
+    });
+    storage.seed("image:aws:variant:windows:x86_64:us-east-1:ami-shared", {
+      id: "ami-shared",
+      state: "available",
+      provider: "aws",
+      target: "windows",
+      region: "us-east-1",
+      architecture: "x86_64",
+      promotedAt: "2026-08-02T00:00:00Z",
+      catalogOnly: true,
+      variantSelectors: { sdks: { toolkit: "2.0" } },
+    });
+    storage.seed("image:aws:created:ami-shared", {
+      id: "ami-shared",
+      state: "available",
+      provider: "aws",
+      region: "eu-west-1",
+      architecture: "x86_64",
+    });
+
+    const metadata = await new AWSProvider({} as Env, "us-east-1", storage).storedImageMetadata(
+      "ami-shared",
+    );
+
+    expect(metadata?.region).toBe("us-east-1");
+    expect(metadata).toHaveProperty("catalogOnly", true);
+  });
+
+  it("uses external variant metadata for implicit reads without granting delete ownership", async () => {
+    const storage = new MemoryStorage();
+    storage.seed("image:aws:promoted:linux:x86_64:ubuntu26.04:eu-west-1", {
+      id: "ami-external",
+      name: "remote-ordinary",
+      state: "available",
+      provider: "aws",
+      target: "linux",
+      os: "ubuntu:26.04",
+      region: "eu-west-1",
+      architecture: "x86_64",
+      promotedAt: "2026-07-01T00:00:00Z",
+    });
+    storage.seed("image:aws:created:ami-external", {
+      id: "ami-external",
+      name: "remote-created",
+      state: "available",
+      provider: "aws",
+      region: "eu-west-1",
+      architecture: "x86_64",
+    });
+    const variantKey = "image:aws:variant:linux:x86_64:ubuntu26.04:us-east-1:ami-external";
+    storage.seed(variantKey, {
+      id: "ami-external",
+      name: "external",
+      state: "available",
+      provider: "aws",
+      target: "linux",
+      os: "ubuntu:26.04",
+      region: "us-east-1",
+      architecture: "x86_64",
+      promotedAt: "2026-08-01T00:00:00Z",
+      catalogOnly: true,
+      variantSelectors: { sdks: { toolkit: "2.0" } },
+    });
+    const calls: Array<{ action: string; host: string }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+        async (input, init) => {
+          const providerRequest = input instanceof Request ? input : new Request(input, init);
+          const action =
+            new URLSearchParams(await providerRequest.clone().text()).get("Action") ?? "";
+          calls.push({ action, host: new URL(providerRequest.url).host });
+          if (action === "DescribeImages") {
+            return ec2XMLResponse(`
+              <DescribeImagesResponse><imagesSet><item>
+                <imageId>ami-external</imageId><name>external</name>
+                <imageState>available</imageState><architecture>x86_64</architecture>
+                <blockDeviceMapping><item><ebs><snapshotId>snap-root</snapshotId></ebs></item></blockDeviceMapping>
+              </item></imagesSet></DescribeImagesResponse>
+            `);
+          }
+          if (action === "DescribeFastSnapshotRestores") {
+            return ec2XMLResponse(`
+              <DescribeFastSnapshotRestoresResponse><fastSnapshotRestoreSet><item>
+                <snapshotId>snap-root</snapshotId><availabilityZone>us-east-1a</availabilityZone>
+                <state>enabled</state>
+              </item></fastSnapshotRestoreSet></DescribeFastSnapshotRestoresResponse>
+            `);
+          }
+          return ec2XMLResponse("<ErrorResponse />", 500);
+        },
+      ),
+    );
+    const fleet = testFleet(
+      storage,
+      {},
+      {
+        AWS_ACCESS_KEY_ID: "test",
+        AWS_SECRET_ACCESS_KEY: "secret",
+        CRABBOX_AWS_REGION: "us-east-1",
+      },
+    );
+
+    const get = await fleet.fetch(
+      request("GET", "/v1/images/ami-external?provider=aws", {
+        headers: { "x-crabbox-admin": "true" },
+      }),
+    );
+    const fsr = await fleet.fetch(
+      request("GET", "/v1/images/ami-external/fast-snapshot-restore?provider=aws", {
+        headers: { "x-crabbox-admin": "true" },
+      }),
+    );
+    const providerDelete = await fleet.fetch(
+      request("DELETE", "/v1/images/ami-external?provider=aws", {
+        headers: { "x-crabbox-admin": "true" },
+      }),
+    );
+    const retirement = await fleet.fetch(
+      request("DELETE", "/v1/images/ami-external/promote-catalog?provider=aws", {
+        headers: { "x-crabbox-admin": "true" },
+      }),
+    );
+
+    expect(get.status).toBe(200);
+    await expect(get.json()).resolves.toMatchObject({ image: { region: "us-east-1" } });
+    expect(fsr.status).toBe(200);
+    await expect(fsr.json()).resolves.toMatchObject({
+      fastSnapshotRestores: [
+        { snapshotID: "snap-root", availabilityZone: "us-east-1a", state: "enabled" },
+      ],
+    });
+    expect(providerDelete.status).toBe(409);
+    await expect(providerDelete.json()).resolves.toMatchObject({ error: "image_not_owned" });
+    expect(retirement.status).toBe(200);
+    await expect(retirement.json()).resolves.toMatchObject({ retired: 1 });
+    expect(storage.value(variantKey)).toBeUndefined();
+    expect(calls).toEqual([
+      { action: "DescribeImages", host: "ec2.us-east-1.amazonaws.com" },
+      { action: "DescribeImages", host: "ec2.us-east-1.amazonaws.com" },
+      { action: "DescribeFastSnapshotRestores", host: "ec2.us-east-1.amazonaws.com" },
+    ]);
+  });
+
+  it("retires external AWS variants without deleting the provider image", async () => {
+    const storage = new MemoryStorage();
+    const euKey = "image:aws:variant:linux:x86_64:ubuntu26.04:eu-west-1:ami-external";
+    const usKey = "image:aws:variant:linux:x86_64:ubuntu26.04:us-east-1:ami-external";
+    for (const [key, region] of [
+      [euKey, "eu-west-1"],
+      [usKey, "us-east-1"],
+    ]) {
+      storage.seed(key, {
+        id: "ami-external",
+        name: "external",
+        state: "available",
+        provider: "aws",
+        target: "linux",
+        os: "ubuntu:26.04",
+        region,
+        architecture: "x86_64",
+        promotedAt: "2026-08-01T00:00:00Z",
+        catalogOnly: true,
+        variantSelectors: { sdks: { toolkit: "2.0" } },
+      });
+    }
+    const provider = new AWSProvider({} as Env, "eu-west-1", storage);
+    const deleteImage = vi.fn<(imageID: string) => Promise<void>>(async () => {});
+    (
+      provider as unknown as {
+        clientValue: { deleteImage: typeof deleteImage };
+      }
+    ).clientValue = { deleteImage };
+    const fleet = testFleet(storage, { aws: provider });
+
+    const regional = await fleet.fetch(
+      request("DELETE", "/v1/images/ami-external/promote-catalog?provider=aws&region=us-east-1", {
+        headers: { "x-crabbox-admin": "true" },
+      }),
+    );
+
+    expect(regional.status).toBe(200);
+    expect(deleteImage).not.toHaveBeenCalled();
+    expect(storage.value(usKey)).toBeUndefined();
+    expect(storage.value(euKey)).toBeDefined();
+    await expect(regional.json()).resolves.toEqual({
+      imageID: "ami-external",
+      catalogOnly: true,
+      retired: 1,
+    });
+
+    const allRegions = await fleet.fetch(
+      request("DELETE", "/v1/images/ami-external/promote-catalog?provider=aws", {
+        headers: { "x-crabbox-admin": "true" },
+      }),
+    );
+
+    expect(allRegions.status).toBe(200);
+    expect(deleteImage).not.toHaveBeenCalled();
+    expect(storage.value(euKey)).toBeUndefined();
+    await expect(allRegions.json()).resolves.toEqual({
+      imageID: "ami-external",
+      catalogOnly: true,
+      retired: 1,
+    });
+  });
+
+  it("rolls back catalog-only retirement when any metadata delete fails", async () => {
+    const storage = new MemoryStorage();
+    const keys = [
+      "image:aws:variant:linux:x86_64:ubuntu26.04:eu-west-1:ami-external",
+      "image:aws:variant:windows:x86_64:eu-west-1:ami-external",
+    ];
+    for (const key of keys) {
+      storage.seed(key, {
+        id: "ami-external",
+        state: "available",
+        provider: "aws",
+        region: "eu-west-1",
+        promotedAt: "2026-08-01T00:00:00Z",
+        catalogOnly: true,
+        variantSelectors: { sdks: { toolkit: "2.0" } },
+      });
+    }
+    storage.beforeDelete = async (key) => {
+      if (key === keys[1]) throw new Error("retirement delete failed");
+    };
+    const provider = new AWSProvider({} as Env, "eu-west-1", storage);
+
+    await expect(provider.retireCatalogImage("ami-external", "eu-west-1")).rejects.toThrow(
+      "retirement delete failed",
+    );
+    for (const key of keys) expect(storage.value(key)).toBeDefined();
+  });
+
+  it("fails closed when image catalog storage is not transactional", async () => {
+    const storage = {
+      get: async () => undefined,
+      put: async () => {},
+      delete: async () => {},
+      list: async () => new Map(),
+    } as unknown as CoordinatorStorage;
+    const provider = new AWSProvider({} as Env, "eu-west-1", storage);
+
+    await expect(provider.retireCatalogImage("ami-external")).rejects.toThrow(
+      "transactional image catalog storage is required",
+    );
+  });
+
+  it("rejects catalog-only retirement for non-AWS providers", async () => {
+    const fleet = testFleet(new MemoryStorage(), {
+      azure: fakeProvider(undefined, { provider: "azure" }),
+    });
+
+    const response = await fleet.fetch(
+      request("DELETE", "/v1/images/snapshot-variant/promote-catalog?provider=azure", {
+        headers: { "x-crabbox-admin": "true" },
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "unsupported_provider",
+      message: "catalog-only image retirement is AWS-only",
+    });
+  });
+
+  it("rejects an invalid explicit catalog-only retirement Region", async () => {
+    const storage = new MemoryStorage();
+    const provider = new AWSProvider({} as Env, "eu-west-1", storage);
+    const retire = vi.spyOn(provider, "retireCatalogImage");
+    const fleet = testFleet(storage, { aws: provider });
+
+    const response = await fleet.fetch(
+      request(
+        "DELETE",
+        "/v1/images/ami-external/promote-catalog?provider=aws&region=not-a-region",
+        { headers: { "x-crabbox-admin": "true" } },
+      ),
+    );
+
+    expect(response.status).toBe(400);
+    expect(retire).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toEqual({
+      error: "invalid_region",
+      message: "region must be an AWS region name",
+    });
+  });
+
+  it("removes ordinary and variant catalog metadata after provider image deletion", async () => {
+    const storage = new MemoryStorage();
+    const image = {
+      id: "ami-stale",
+      name: "stale",
+      state: "available",
+      provider: "aws" as const,
+      region: "eu-west-1",
+      architecture: "x86_64",
+    };
+    const catalogKey = "image:aws:catalog:linux:x86_64:ubuntu26.04:eu-west-1:ami-stale";
+    const variantKey = "image:aws:variant:windows:x86_64:eu-west-1:ami-stale";
+    const remoteCatalogKey = "image:aws:catalog:linux:x86_64:ubuntu26.04:us-east-1:ami-stale";
+    const remoteVariantKey = "image:aws:variant:windows:x86_64:us-east-1:ami-stale";
+    const remotePromotedKey = "image:aws:promoted:linux:x86_64:ubuntu26.04:us-east-1";
+    storage.seed("image:aws:created:ami-stale", image);
+    storage.seed(catalogKey, { ...image, promotedAt: "2026-07-01T00:00:00Z" });
+    storage.seed(variantKey, {
+      ...image,
+      promotedAt: "2026-07-02T00:00:00Z",
+      catalogOnly: true,
+      variantSelectors: { sdks: { toolkit: "2.0" } },
+    });
+    storage.seed(remoteCatalogKey, {
+      ...image,
+      region: "us-east-1",
+      promotedAt: "2026-07-01T00:00:00Z",
+    });
+    storage.seed(remoteVariantKey, {
+      ...image,
+      region: "us-east-1",
+      promotedAt: "2026-07-02T00:00:00Z",
+      catalogOnly: true,
+      variantSelectors: { sdks: { toolkit: "2.0" } },
+    });
+    storage.seed(remotePromotedKey, {
+      ...image,
+      region: "us-east-1",
+      promotedAt: "2026-07-02T00:00:00Z",
+    });
+    const provider = new AWSProvider({} as Env, "eu-west-1", storage);
+    const getImage = vi.fn<(imageID: string) => Promise<ProviderImage>>(async () => ({
+      ...image,
+      snapshots: [],
+    }));
+    const deleteImage = vi.fn<(imageID: string, snapshotIDs?: string[]) => Promise<void>>(
+      async () => {},
+    );
+    (
+      provider as unknown as {
+        clientValue: { getImage: typeof getImage; deleteImage: typeof deleteImage };
+      }
+    ).clientValue = { getImage, deleteImage };
+    const fleet = testFleet(storage, { aws: provider });
+
+    const response = await fleet.fetch(
+      request("DELETE", "/v1/images/ami-stale?provider=aws&region=eu-west-1", {
+        headers: { "x-crabbox-admin": "true" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(deleteImage).toHaveBeenCalledWith("ami-stale", []);
+    expect(storage.value(catalogKey)).toBeUndefined();
+    expect(storage.value(variantKey)).toBeUndefined();
+    expect(storage.value(remoteCatalogKey)).toBeDefined();
+    expect(storage.value(remoteVariantKey)).toBeDefined();
+    expect(storage.value(remotePromotedKey)).toBeDefined();
+  });
+
+  it("rolls back post-provider-delete catalog cleanup on metadata failure", async () => {
+    const storage = new MemoryStorage();
+    const catalogKey = "image:aws:catalog:linux:x86_64:ubuntu26.04:eu-west-1:ami-stale";
+    const variantKey = "image:aws:variant:windows:x86_64:eu-west-1:ami-stale";
+    for (const key of [catalogKey, variantKey]) {
+      storage.seed(key, {
+        id: "ami-stale",
+        state: "available",
+        provider: "aws",
+        region: "eu-west-1",
+        promotedAt: "2026-07-01T00:00:00Z",
+      });
+    }
+    storage.beforeDelete = async (key) => {
+      if (key === variantKey) throw new Error("catalog cleanup failed");
+    };
+    const provider = new AWSProvider({} as Env, "eu-west-1", storage);
+    const getImage = vi.fn<(imageID: string) => Promise<ProviderImage>>(async () => ({
+      id: "ami-stale",
+      state: "available",
+      provider: "aws",
+      region: "eu-west-1",
+      snapshots: [],
+    }));
+    const deleteImage = vi.fn<(imageID: string, snapshotIDs?: string[]) => Promise<void>>(
+      async () => {},
+    );
+    (
+      provider as unknown as {
+        clientValue: { getImage: typeof getImage; deleteImage: typeof deleteImage };
+      }
+    ).clientValue = { getImage, deleteImage };
+
+    await expect(provider.deleteImage("ami-stale")).rejects.toThrow("catalog cleanup failed");
+    expect(deleteImage).toHaveBeenCalledWith("ami-stale", []);
+    expect(storage.value(catalogKey)).toBeDefined();
+    expect(storage.value(variantKey)).toBeDefined();
   });
 
   it("rejects deleting AWS images without Crabbox ownership metadata", async () => {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -28016,6 +28016,284 @@ describe("fleet lease identity and idle", () => {
     );
   });
 
+  it("stores catalog-only variants with explicit selectors without replacing the default", async () => {
+    const storage = new MemoryStorage();
+    const defaultKey = "image:aws:promoted:linux:x86_64:ubuntu26.04:eu-west-1";
+    storage.seed(defaultKey, {
+      id: "ami-default",
+      name: "default",
+      state: "available",
+      target: "linux",
+      os: "ubuntu:26.04",
+      region: "eu-west-1",
+      architecture: "x86_64",
+      promotedAt: "2026-07-01T00:00:00Z",
+      capabilities: { runtimes: { node: "24" } },
+    });
+    const provider = new AWSProvider({} as Env, "eu-west-1", storage);
+    vi.spyOn(provider, "getImage").mockResolvedValue({
+      id: "ami-variant",
+      name: "variant",
+      state: "available",
+      provider: "aws",
+      region: "eu-west-1",
+      architecture: "x86_64",
+    });
+    const url = new URL(
+      "https://crabbox.test/v1/images/ami-variant/promote-catalog?target=linux&region=eu-west-1&catalogOnly=true&runtime=node%3D24&desktop=true",
+    );
+
+    await expect(
+      provider.promoteImage(
+        "ami-variant",
+        undefined,
+        new Request(url, {
+          method: "POST",
+          body: JSON.stringify({
+            catalogOnly: false,
+            variantSelectors: { sdks: { toolkit: "2.0" } },
+          }),
+        }),
+        url,
+      ),
+    ).resolves.toMatchObject({
+      image: {
+        id: "ami-variant",
+        catalogOnly: true,
+        variantSelectors: { sdks: { toolkit: "2.0" } },
+        capabilities: {
+          sdks: { toolkit: "2.0" },
+          runtimes: { node: "24" },
+          desktop: true,
+        },
+      },
+    });
+    expect(storage.value(defaultKey)).toEqual(expect.objectContaining({ id: "ami-default" }));
+    expect(
+      storage.value("image:aws:catalog:linux:x86_64:ubuntu26.04:eu-west-1:ami-variant"),
+    ).toEqual(
+      expect.objectContaining({
+        id: "ami-variant",
+        catalogOnly: true,
+        variantSelectors: { sdks: { toolkit: "2.0" } },
+      }),
+    );
+  });
+
+  it("serves catalog-only promotion on its dedicated coordinator route", async () => {
+    const aws = fakeProvider();
+    const promote = vi
+      .spyOn(aws, "promoteImage")
+      .mockImplementation(async (_id, _known, _request, url) => {
+        expect(url.searchParams.get("catalogOnly")).toBe("true");
+        const body = (await _request.clone().json()) as { variantSelectors?: unknown };
+        expect(body.variantSelectors).toEqual({ sdks: { toolkit: "2.0" } });
+        const image: ProviderImage & {
+          catalogOnly: true;
+          variantSelectors: { sdks: { toolkit: string } };
+        } = {
+          id: "ami-variant",
+          name: "variant",
+          state: "available",
+          provider: "aws",
+          catalogOnly: true,
+          variantSelectors: { sdks: { toolkit: "2.0" } },
+        };
+        return { image };
+      });
+    const fleet = testFleet(new MemoryStorage(), { aws });
+
+    const response = await fleet.fetch(
+      request("POST", "/v1/images/ami-variant/promote-catalog?provider=aws", {
+        headers: { "x-crabbox-admin": "true" },
+        body: {
+          catalogOnly: false,
+          variantSelectors: { sdks: { toolkit: "2.0" } },
+        },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(promote).toHaveBeenCalledOnce();
+    await expect(response.json()).resolves.toMatchObject({
+      image: {
+        id: "ami-variant",
+        catalogOnly: true,
+        variantSelectors: { sdks: { toolkit: "2.0" } },
+      },
+    });
+  });
+
+  it("rejects missing, detached, or conflicting catalog variant selectors", async () => {
+    const provider = new AWSProvider({} as Env, "eu-west-1", new MemoryStorage());
+    vi.spyOn(provider, "getImage").mockResolvedValue({
+      id: "ami-variant",
+      name: "variant",
+      state: "available",
+      provider: "aws",
+      region: "eu-west-1",
+      architecture: "x86_64",
+    });
+    const promote = async (query: string, body: Record<string, unknown> = {}) => {
+      const url = new URL(
+        `https://crabbox.test/v1/images/ami-variant/promote?target=linux&region=eu-west-1&${query}`,
+      );
+      return provider.promoteImage(
+        "ami-variant",
+        undefined,
+        new Request(url, { method: "POST", body: JSON.stringify(body) }),
+        url,
+      );
+    };
+
+    const missing = await promote("catalogOnly=true&sdk=toolkit%3D2.0");
+    expect(missing).toBeInstanceOf(Response);
+    await expect((missing as Response).json()).resolves.toMatchObject({
+      error: "catalog_only_variant_selectors_required",
+    });
+
+    const detached = await promote("", { variantSelectors: { sdks: { toolkit: "2.0" } } });
+    expect(detached).toBeInstanceOf(Response);
+    await expect((detached as Response).json()).resolves.toMatchObject({
+      error: "variant_selectors_require_catalog_only",
+    });
+
+    const conflicting = await promote("catalogOnly=true&sdk=toolkit%3D1.0", {
+      variantSelectors: { sdks: { toolkit: "2.0" } },
+    });
+    expect(conflicting).toBeInstanceOf(Response);
+    await expect((conflicting as Response).json()).resolves.toMatchObject({
+      error: "invalid_image_capabilities",
+      message: expect.stringContaining("conflicting versions for toolkit"),
+    });
+  });
+
+  it("activates catalog-only images only through explicit variant selectors", async () => {
+    const storage = new MemoryStorage();
+    const defaultImage = {
+      id: "ami-default",
+      name: "default",
+      state: "available",
+      target: "linux" as const,
+      os: "ubuntu:26.04",
+      region: "eu-west-1",
+      architecture: "x86_64",
+      promotedAt: "2026-07-01T00:00:00Z",
+      capabilities: {
+        osVersion: "26.04",
+        runtimes: { node: "24" },
+        browser: true,
+        desktop: true,
+      },
+    };
+    const variantImage = {
+      id: "ami-variant",
+      name: "variant",
+      state: "available",
+      target: "linux" as const,
+      os: "ubuntu:26.04",
+      region: "eu-west-1",
+      architecture: "x86_64",
+      promotedAt: "2026-07-02T00:00:00Z",
+      catalogOnly: true,
+      variantSelectors: {
+        sdks: { toolkit: "2.0" },
+        runtimes: { special: "3.0" },
+      },
+      capabilities: {
+        osVersion: "26.04",
+        sdks: { toolkit: "2.0" },
+        runtimes: { node: "24", special: "3.0" },
+        browser: true,
+        desktop: true,
+      },
+    };
+    storage.seed("image:aws:promoted:linux:x86_64:ubuntu26.04:eu-west-1", defaultImage);
+    storage.seed("image:aws:catalog:linux:x86_64:ubuntu26.04:eu-west-1:ami-default", defaultImage);
+    storage.seed("image:aws:catalog:linux:x86_64:ubuntu26.04:eu-west-1:ami-variant", variantImage);
+    const provider = new AWSProvider({} as Env, "eu-west-1", storage);
+    const selected = async (
+      imageRequirements: ReturnType<typeof leaseConfig>["imageRequirements"],
+    ) => {
+      const config = leaseConfig({
+        provider: "aws",
+        os: "ubuntu:26.04",
+        sshPublicKey: "ssh-ed25519 test",
+        imageRequirements,
+      });
+      const prepared = await provider.prepareLeaseConfig(config);
+      return prepared.awsPromotedAMIs[awsPromotedAMIConfigKey("eu-west-1", config.serverType)];
+    };
+
+    await expect(selected({ runtimes: { node: "24" } })).resolves.toBe("ami-default");
+    await expect(selected({ sdks: { toolkit: "2.0" } })).resolves.toBe("ami-variant");
+    await expect(selected({ runtimes: { special: "3.0" } })).resolves.toBe("ami-variant");
+    await expect(selected({ sdks: { toolkit: "2.0" }, runtimes: { node: "25" } })).rejects.toThrow(
+      "no promoted AWS linux image satisfies",
+    );
+    await expect(selected({ sdks: { other: "1.0" } })).rejects.toThrow(
+      "no promoted AWS linux image satisfies",
+    );
+    await expect(selected({ sdks: { toolkit: "2.1" } })).rejects.toThrow(
+      "no promoted AWS linux image satisfies",
+    );
+    await expect(selected({ sdks: { toolkit: "1.0" } })).rejects.toThrow(
+      "no promoted AWS linux image satisfies",
+    );
+    await expect(selected({ desktop: true })).resolves.toBe("ami-default");
+    await expect(selected({ browser: true })).resolves.toBe("ami-default");
+    await expect(selected({ minOS: "26.04" })).resolves.toBe("ami-default");
+  });
+
+  it("clears catalog-only selector metadata on ordinary re-promotion", async () => {
+    const storage = new MemoryStorage();
+    const catalogKey = "image:aws:catalog:linux:x86_64:ubuntu26.04:eu-west-1:ami-variant";
+    storage.seed(catalogKey, {
+      id: "ami-variant",
+      name: "variant",
+      state: "available",
+      target: "linux",
+      os: "ubuntu:26.04",
+      region: "eu-west-1",
+      architecture: "x86_64",
+      promotedAt: "2026-07-01T00:00:00Z",
+      catalogOnly: true,
+      variantSelectors: { sdks: { toolkit: "2.0" } },
+      capabilities: { sdks: { toolkit: "2.0" }, runtimes: { node: "24" } },
+    });
+    const provider = new AWSProvider({} as Env, "eu-west-1", storage);
+    vi.spyOn(provider, "getImage").mockResolvedValue({
+      id: "ami-variant",
+      name: "variant",
+      state: "available",
+      provider: "aws",
+      region: "eu-west-1",
+      architecture: "x86_64",
+    });
+    const url = new URL(
+      "https://crabbox.test/v1/images/ami-variant/promote?target=linux&region=eu-west-1&catalogOnly=false",
+    );
+
+    await provider.promoteImage(
+      "ami-variant",
+      undefined,
+      new Request(url, { method: "POST", body: JSON.stringify({ catalogOnly: true }) }),
+      url,
+    );
+
+    const scoped = storage.value("image:aws:promoted:linux:x86_64:ubuntu26.04:eu-west-1");
+    expect(scoped).toEqual(
+      expect.objectContaining({
+        id: "ami-variant",
+        capabilities: { sdks: { toolkit: "2.0" }, runtimes: { node: "24" } },
+      }),
+    );
+    expect(scoped).not.toHaveProperty("catalogOnly");
+    expect(scoped).not.toHaveProperty("variantSelectors");
+    expect(storage.value(catalogKey)).not.toHaveProperty("catalogOnly");
+    expect(storage.value(catalogKey)).not.toHaveProperty("variantSelectors");
+  });
+
   it("records the exact promoted AWS image selected for a lease", async () => {
     const storage = new MemoryStorage();
     storage.seed("image:aws:promoted:linux:x86_64:ubuntu26.04:eu-west-1", {
@@ -28277,6 +28555,36 @@ describe("fleet lease identity and idle", () => {
       ),
     ).resolves.toMatchObject({
       image: { id: "snapshot-devtools", serverType: "Standard_D192ds_v6" },
+    });
+  });
+
+  it("rejects catalog-only Azure image promotion", async () => {
+    const provider = new AzureProvider({} as Env, undefined, new MemoryStorage(), "westeurope");
+    const snapshot: ProviderImage = {
+      id: "snapshot-variant",
+      name: "snapshot-variant",
+      state: "succeeded",
+      provider: "azure",
+      kind: "azure-os-disk-snapshot",
+      target: "linux",
+      region: "westeurope",
+      architecture: "amd64",
+    };
+    const url = new URL(
+      "https://crabbox.test/v1/images/snapshot-variant/promote-catalog?provider=azure&catalogOnly=true",
+    );
+
+    const response = await provider.promoteImage(
+      snapshot.id,
+      snapshot,
+      new Request(url, { method: "POST", body: JSON.stringify({ catalogOnly: false }) }),
+      url,
+    );
+    expect(response).toBeInstanceOf(Response);
+    expect((response as Response).status).toBe(400);
+    await expect((response as Response).json()).resolves.toMatchObject({
+      error: "unsupported_provider",
+      message: "catalog-only image promotion is AWS-only",
     });
   });
 

--- a/worker/test/oauth-browser-binding.test.ts
+++ b/worker/test/oauth-browser-binding.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import type { CoordinatorStorage } from "../src/coordinator-runtime";
+import type { CoordinatorStorage, CoordinatorStorageView } from "../src/coordinator-runtime";
 import { githubAuthRoute, githubPortalLogin } from "../src/oauth";
 import type { Env } from "../src/types";
 
@@ -38,6 +38,10 @@ class MemoryStorage implements CoordinatorStorage {
         value as T,
       ]),
     );
+  }
+
+  transaction<T>(callback: (transaction: CoordinatorStorageView) => Promise<T>): Promise<T> {
+    return callback(this);
   }
 }
 

--- a/worker/test/pairing.test.ts
+++ b/worker/test/pairing.test.ts
@@ -6,6 +6,7 @@ import {
   type CoordinatorRuntime,
   type CoordinatorSocketHandlers,
   type CoordinatorStorage,
+  type CoordinatorStorageView,
   type CoordinatorWebSocketUpgradeOptions,
 } from "../src/coordinator-runtime";
 import { deviceMembershipCacheTTLMS, FleetCoordinator } from "../src/fleet";
@@ -79,6 +80,10 @@ class MemoryStorage implements CoordinatorStorage {
     const value = this.values.get(key) as T | undefined;
     this.values.delete(key);
     return Promise.resolve(value);
+  }
+
+  transaction<T>(callback: (transaction: CoordinatorStorageView) => Promise<T>): Promise<T> {
+    return callback(this);
   }
 
   resetObservations(): void {

--- a/worker/test/postgres-storage.test.ts
+++ b/worker/test/postgres-storage.test.ts
@@ -1,4 +1,4 @@
-import type { Pool, QueryResult, QueryResultRow } from "pg";
+import type { Pool, PoolClient, QueryResult, QueryResultRow } from "pg";
 import { describe, expect, it, vi } from "vitest";
 
 import { PostgresCoordinatorStorage } from "../node/postgres-storage";
@@ -104,6 +104,133 @@ describe("PostgresCoordinatorStorage", () => {
     expect(String(pool.query.mock.calls[0]?.[0])).toContain("returning case");
     expect(value).toEqual({ ticket: "one-time" });
   });
+
+  it("commits transaction-scoped storage work on one checked-out client", async () => {
+    const { pool, clientQuery, connect, release } = fakeTransactionalPool();
+    const storage = new PostgresCoordinatorStorage("postgres://unused", pool);
+
+    await storage.transaction(async (transaction) => {
+      await transaction.put("image:one", { id: "one" });
+      await transaction.delete("image:stale");
+    });
+
+    expect(connect).toHaveBeenCalledOnce();
+    expect(pool.query).not.toHaveBeenCalled();
+    expect(clientQuery.mock.calls.map(([sql]) => String(sql).trim().split(/\s+/, 1)[0])).toEqual([
+      "begin",
+      "insert",
+      "delete",
+      "commit",
+    ]);
+    expect(String(clientQuery.mock.calls[0]?.[0]).trim()).toBe(
+      "begin isolation level serializable",
+    );
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it("rolls back transaction-scoped storage work when the callback fails", async () => {
+    const { pool, clientQuery, release } = fakeTransactionalPool();
+    const storage = new PostgresCoordinatorStorage("postgres://unused", pool);
+
+    await expect(
+      storage.transaction(async (transaction) => {
+        await transaction.put("image:one", { id: "one" });
+        throw new Error("publish failed");
+      }),
+    ).rejects.toThrow("publish failed");
+
+    expect(clientQuery.mock.calls.map(([sql]) => String(sql).trim().split(/\s+/, 1)[0])).toEqual([
+      "begin",
+      "insert",
+      "rollback",
+    ]);
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    { code: "40001", label: "serialization failure" },
+    { code: "40P01", label: "deadlock" },
+  ])("retries one $label on a fresh client", async ({ code }) => {
+    const { pool, clients, connect } = fakeRetryTransactionalPool();
+    const storage = new PostgresCoordinatorStorage("postgres://unused", pool);
+    const retryableError = postgresError(code, "retry transaction");
+    let callbackInvocations = 0;
+
+    const result = await storage.transaction(async () => {
+      callbackInvocations++;
+      if (callbackInvocations === 1) throw retryableError;
+      return "committed";
+    });
+
+    expect(result).toBe("committed");
+    expect(callbackInvocations).toBe(2);
+    expect(connect).toHaveBeenCalledTimes(2);
+    expect(clients).toHaveLength(2);
+    expect(clients[0]?.query.mock.calls.map(([sql]) => String(sql).trim())).toEqual([
+      "begin isolation level serializable",
+      "rollback",
+    ]);
+    expect(clients[1]?.query.mock.calls.map(([sql]) => String(sql).trim())).toEqual([
+      "begin isolation level serializable",
+      "commit",
+    ]);
+    expect(clients[0]?.release).toHaveBeenCalledWith();
+    expect(clients[1]?.release).toHaveBeenCalledWith();
+  });
+
+  it("stops after three serialization failures and rethrows the database error", async () => {
+    const { pool, clients, connect } = fakeRetryTransactionalPool();
+    const storage = new PostgresCoordinatorStorage("postgres://unused", pool);
+    const serializationError = postgresError("40001", "serialization failed");
+    let callbackInvocations = 0;
+
+    await expect(
+      storage.transaction(async () => {
+        callbackInvocations++;
+        throw serializationError;
+      }),
+    ).rejects.toBe(serializationError);
+
+    expect(callbackInvocations).toBe(3);
+    expect(connect).toHaveBeenCalledTimes(3);
+    expect(clients).toHaveLength(3);
+    for (const client of clients) {
+      expect(client.query.mock.calls.map(([sql]) => String(sql).trim())).toEqual([
+        "begin isolation level serializable",
+        "rollback",
+      ]);
+      expect(client.release).toHaveBeenCalledWith();
+    }
+  });
+
+  it("preserves transaction and rollback failures and evicts the uncertain client", async () => {
+    const rollbackError = new Error("rollback failed");
+    const originalError = postgresError("40001", "publish failed");
+    const { pool, clientQuery, connect, release } = fakeTransactionalPool(rollbackError);
+    const storage = new PostgresCoordinatorStorage("postgres://unused", pool);
+    let callbackInvocations = 0;
+
+    let observed: unknown;
+    try {
+      await storage.transaction(async () => {
+        callbackInvocations++;
+        throw originalError;
+      });
+    } catch (error) {
+      observed = error;
+    }
+
+    expect(observed).toBeInstanceOf(AggregateError);
+    expect((observed as AggregateError).errors).toEqual([originalError, rollbackError]);
+    expect((observed as AggregateError).cause).toBe(originalError);
+    expect(clientQuery.mock.calls.map(([sql]) => String(sql).trim())).toEqual([
+      "begin isolation level serializable",
+      "rollback",
+    ]);
+    expect(callbackInvocations).toBe(1);
+    expect(connect).toHaveBeenCalledOnce();
+    expect(release).toHaveBeenCalledWith(rollbackError);
+  });
 });
 
 function fakePool(rows: QueryResultRow[] = []) {
@@ -112,6 +239,57 @@ function fakePool(rows: QueryResultRow[] = []) {
   );
   const end = vi.fn<() => Promise<void>>(async () => undefined);
   return { query, end } as unknown as Pool & { query: typeof query };
+}
+
+function fakeTransactionalPool(rollbackError?: Error) {
+  const clientQuery = vi.fn<
+    (text: string, values?: unknown[]) => Promise<QueryResult<QueryResultRow>>
+  >(async (text) => {
+    if (text.trim() === "rollback" && rollbackError) throw rollbackError;
+    return queryResult([]);
+  });
+  const release = vi.fn<(error?: Error | boolean) => void>();
+  const client = { query: clientQuery, release } as unknown as PoolClient;
+  const connect = vi.fn<() => Promise<PoolClient>>(async () => client);
+  const query = vi.fn<(text: string, values?: unknown[]) => Promise<QueryResult<QueryResultRow>>>(
+    async () => queryResult([]),
+  );
+  const end = vi.fn<() => Promise<void>>(async () => undefined);
+  const pool = { query, connect, end } as unknown as Pool & { query: typeof query };
+  return { pool, clientQuery, connect, release };
+}
+
+function fakeRetryTransactionalPool() {
+  const clients: Array<{
+    query: ReturnType<typeof transactionClientQuery>;
+    release: ReturnType<typeof transactionClientRelease>;
+  }> = [];
+  const connect = vi.fn<() => Promise<PoolClient>>(async () => {
+    const query = transactionClientQuery();
+    const release = transactionClientRelease();
+    clients.push({ query, release });
+    return { query, release } as unknown as PoolClient;
+  });
+  const query = vi.fn<(text: string, values?: unknown[]) => Promise<QueryResult<QueryResultRow>>>(
+    async () => queryResult([]),
+  );
+  const end = vi.fn<() => Promise<void>>(async () => undefined);
+  const pool = { query, connect, end } as unknown as Pool & { query: typeof query };
+  return { pool, clients, connect };
+}
+
+function transactionClientQuery() {
+  return vi.fn<(text: string, values?: unknown[]) => Promise<QueryResult<QueryResultRow>>>(
+    async () => queryResult([]),
+  );
+}
+
+function transactionClientRelease() {
+  return vi.fn<(error?: Error | boolean) => void>();
+}
+
+function postgresError(code: string, message: string): Error & { code: string } {
+  return Object.assign(new Error(message), { code });
 }
 
 function queryResult<T extends QueryResultRow>(rows: T[]): QueryResult<T> {

--- a/worker/test/private-aws-workspace.test.ts
+++ b/worker/test/private-aws-workspace.test.ts
@@ -6,6 +6,7 @@ import type {
   CoordinatorRuntime,
   CoordinatorSocketHandlers,
   CoordinatorStorage,
+  CoordinatorStorageView,
   CoordinatorWebSocketUpgradeOptions,
 } from "../src/coordinator-runtime";
 import { AWSProvider, FleetCoordinator } from "../src/fleet";
@@ -38,6 +39,10 @@ class MemoryStorage implements CoordinatorStorage {
         .filter(([key]) => key.startsWith(prefix))
         .map(([key, value]) => [key, value as T]),
     );
+  }
+
+  transaction<T>(callback: (transaction: CoordinatorStorageView) => Promise<T>): Promise<T> {
+    return callback(this);
   }
 }
 

--- a/worker/test/server-support.test.ts
+++ b/worker/test/server-support.test.ts
@@ -105,6 +105,19 @@ describe("Node server support", () => {
     ).toBe("direct");
   });
 
+  it("routes Node existing-image mutations through the lifecycle queue", () => {
+    for (const [method, path] of [
+      ["POST", "/v1/images/ami-1/promote"],
+      ["POST", "/v1/images/ami-1/promote-catalog"],
+      ["DELETE", "/v1/images/ami-1"],
+      ["DELETE", "/v1/images/ami-1/promote-catalog"],
+    ]) {
+      expect(fleetRequestQueue(new Request(`https://coordinator.test${path}`, { method }))).toBe(
+        "lifecycle",
+      );
+    }
+  });
+
   it("waits for queued and active work to drain", async () => {
     const mutex = new AsyncMutex();
     const tracker = new AsyncOperationTracker();


### PR DESCRIPTION
## Summary

- Add generic AWS catalog-only image variants without replacing the scoped default image.
- Separate an image's full SDK/runtime capability inventory from the small set of explicit selectors allowed to activate a specialized variant.
- Keep catalog-only promotion fail-closed through a dedicated coordinator route and a rollback-safe variant namespace that older coordinators never enumerate.
- Make promotion, retirement, and cleanup atomic across Cloudflare Durable Object and Node/PostgreSQL coordinators, with serializable retries for shared PostgreSQL state.
- Add safe external-variant retirement through `image delete --catalog-only`, preserve ordinary promotion/delete behavior, and clear variant metadata when an image is promoted normally.
- Remove the Telegram Desktop installer, workflow, bake mode, and consumer-specific documentation from Crabbox; those assets belong in the downstream consumer repository.

## Root cause and design

The original proposal treated every declared SDK/runtime capability as an activation key. A specialized image that contained both its distinguishing toolkit and a common runtime such as Node could therefore be selected by a Node-only request.

Catalog-only promotion now requires at least one explicit `--variant-sdk` or `--variant-runtime`. These flags also declare the capability, but ordinary `--sdk` and `--runtime` entries remain inventory only. The coordinator persists `variantSelectors` separately from `capabilities`, and a catalog-only image is eligible only when the lease names one matching selector. Once activated, it must still satisfy every requested capability.

The dedicated `POST /v1/images/<id>/promote-catalog` route remains authoritative: older coordinators return 404 and the CLI never falls back to ordinary promotion. AWS stores variants in a dedicated namespace, so rolling coordinator code back cannot make common inventory activate a specialized image. Ordinary and variant roles remain distinct even when they share an AMI ID.

Existing-image mutations are serialized around provider validation, then committed atomically in coordinator storage. Cloudflare uses its native Durable Object transaction. Node/PostgreSQL uses `SERIALIZABLE` transactions with bounded retries on serialization failures and deadlocks. Ordinary re-promotion preserves capability inventory and removes the variant role atomically; `image delete --catalog-only` retires external variants without deleting provider-owned AMIs. Azure rejects catalog-only publication and retirement.

## Verification

- `go test -race ./internal/cli -run '^TestImage(Promote|Delete)' -count=1`
- `npm test --prefix worker -- test/fleet.test.ts test/coordinator-runtime.test.ts test/server-support.test.ts test/postgres-storage.test.ts test/oauth-browser-binding.test.ts test/pairing.test.ts test/private-aws-workspace.test.ts` — 697 passing
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm run check:node --prefix worker`
- `git diff --check`
- Source-blind CLI retirement contract: 5/5 passing
- Codex autoreview plus independent storage/lifecycle review: clean
- Exact-head CI: https://github.com/openclaw/crabbox/actions/runs/32002935281 (rebased head `06e60308`; the prior run exposed the Node-only typecheck gap fixed in the stack)

Focused regressions cover namespace isolation from old readers, explicit activation and incidental-capability non-activation, same-AMI ordinary/variant roles, atomic ordinary/variant transitions, scope and Region isolation, external-variant retirement, invalid inputs, concurrent mutation ordering, Cloudflare transaction rollback, PostgreSQL serializable retries/rollback failure, old-coordinator failure, Azure rejection, response/output compatibility, and implicit Region routing without widening provider-delete ownership.

## Live proof boundary

An isolated changed-path Cloudflare-plus-AWS run was attempted on August 17, 2026. The repository has no staging coordinator or PR-head deployment workflow: its deploy workflow targets the fixed production Worker, while a separate preview Worker does not inherit the production AWS secrets. A short-lived brokered AWS control lease successfully selected the current promoted AMI and reached SSH readiness, but—correctly for the security boundary—exposed no instance role that could authorize an isolated coordinator. Using a production version preview would share production Durable Object state, so it was rejected as non-isolated.

The changed path is therefore proven by real Cloudflare/PostgreSQL transaction implementations, source-blind CLI HTTP behavior, injected persistence/restart/rollback/interleaving regressions, exact-head CI, and a separate real-AWS baseline—but not by a combined isolated coordinator+AMI run. This is the concrete infrastructure gap; no production coordinator or durable state was mutated.

