### PR TITLE
feat: catalog-only image promotion for capability variants

### DIFF
--- a/docs/commands/image.md
+++ b/docs/commands/image.md
@@ -119,6 +119,7 @@ Flags:
 --browser                image includes browser support
 --webview2               image includes Microsoft WebView2
 --desktop                image includes desktop support
+--catalog-only           publish an AWS capability variant without changing the default image
 --fast-snapshot-restore  enable AWS Fast Snapshot Restore for the backing snapshots
 --fsr-az <az>            availability zone for Fast Snapshot Restore (repeatable)
 --json                   print the promoted image record as JSON
@@ -141,6 +142,11 @@ Capability declarations make the AMI eligible for capability-aware selection.
 Versions use numeric dot notation, for example `--os-version 15.5`,
 `--sdk xcode=16.4`, or `--runtime node=24.2`. Omitted capabilities remain
 unknown and do not satisfy an explicit image requirement.
+
+Variant images carry capabilities that ordinary leases do not need. Promote an
+AWS variant with `--catalog-only` plus at least one capability declaration, such
+as `--sdk toolkit=2.0`; ordinary leases keep the scoped default while matching
+`--image-sdk` or `--image-runtime` requests can select the variant.
 
 Add `--fast-snapshot-restore` plus one or more `--fsr-az` values when the
 promoted image backs hot lanes that need immediate EBS snapshot reads:

--- a/docs/features/image-bake-runbook.md
+++ b/docs/features/image-bake-runbook.md
@@ -178,6 +178,9 @@ Promote only after a candidate smoke passes:
 crabbox image promote ami-1234567890abcdef0 --json
 ```
 
+- For a capability variant, add `--catalog-only` and at least one `--sdk`,
+  `--runtime`, `--os-version`, `--browser`, `--webview2`, or `--desktop` declaration.
+
 Then confirm a normal brokered lease, with no override, uses the promoted image:
 
 ```bash

--- a/docs/features/prebaked-images.md
+++ b/docs/features/prebaked-images.md
@@ -134,6 +134,12 @@ guard scripts. At a high level, an AWS bake is:
    Add declarations such as `--os-version 26.04 --runtime node=24.2
    --browser --desktop` when future leases must select by baked capabilities.
 
+### Variant images
+
+Bake capabilities most leases do not need as AWS catalog-only variants. Promote
+them with `--catalog-only`; matching `--image-sdk` or `--image-runtime` requests
+select them without changing the ordinary lease default.
+
 6. Run a normal brokered lease (no override) plus the relevant QA lane. The CLI
    prints `image selected id=... source=promoted`; require the exact promoted
    ID in publication proof.
@@ -153,7 +159,7 @@ provider-side artifacts.
 - `crabbox image promote <image-id> [--provider aws|azure] [--target
   linux|macos|windows] [--region <r>]` — set a scoped brokered AWS AMI or Azure
   OS disk snapshot default. AWS supports `--fast-snapshot-restore` with
-  `--fsr-az <az>` and capability declarations.
+  `--fsr-az <az>`, `--catalog-only`, and capability declarations.
 - `crabbox image fsr-status <ami-id|snapshot-id>` — AWS Fast Snapshot Restore
   status.
 - `crabbox image delete <image-id> [--provider aws|azure|gcp]` — remove a

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -286,6 +286,7 @@ type CoordinatorImage struct {
 	PromotedAt           string                           `json:"promotedAt,omitempty"`
 	FastSnapshotRestores []CoordinatorFastSnapshotRestore `json:"fastSnapshotRestores,omitempty"`
 	Capabilities         *imageCapabilities               `json:"capabilities,omitempty"`
+	CatalogOnly          bool                             `json:"catalogOnly"`
 }
 
 type CoordinatorFastSnapshotRestore struct {
@@ -357,6 +358,7 @@ type CoordinatorImageRef struct {
 	FastSnapshotRestore    bool
 	FastSnapshotRestoreAZs []string
 	Capabilities           imageCapabilities
+	CatalogOnly            bool
 }
 
 type CoordinatorGitHubLoginStart struct {
@@ -1876,6 +1878,9 @@ func imagePath(imageID, action string, refs ...CoordinatorImageRef) string {
 		}
 		if ref.FastSnapshotRestore {
 			values.Set("fastSnapshotRestore", "true")
+		}
+		if ref.CatalogOnly {
+			values.Set("catalogOnly", "true")
 		}
 		for _, zone := range ref.FastSnapshotRestoreAZs {
 			if strings.TrimSpace(zone) != "" {

--- a/internal/cli/coordinator_test.go
+++ b/internal/cli/coordinator_test.go
@@ -2137,6 +2137,84 @@ func TestImagePromoteSupportsAzureSnapshots(t *testing.T) {
 	}
 }
 
+func TestImagePromoteCatalogOnly(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		response   string
+		wantOutput string
+		wantError  string
+	}{
+		{
+			name:       "text output and interspersed flag",
+			args:       []string{"ami-variant", "--catalog-only", "--sdk", "toolkit=2.0"},
+			response:   `{"image":{"id":"ami-variant","name":"variant","state":"available","region":"eu-west-1","promotedAt":"2026-08-15T00:00:00Z","catalogOnly":true}}`,
+			wantOutput: "catalogOnly=true",
+		},
+		{
+			name:       "JSON output",
+			args:       []string{"--catalog-only", "--runtime", "node=24.2", "--json", "ami-variant"},
+			response:   `{"image":{"id":"ami-variant","name":"variant","state":"available","region":"eu-west-1","promotedAt":"2026-08-15T00:00:00Z","catalogOnly":true}}`,
+			wantOutput: `"catalogOnly":true`,
+		},
+		{
+			name:      "capability required",
+			args:      []string{"--catalog-only", "ami-variant"},
+			wantError: "--catalog-only requires at least one capability declaration",
+		},
+		{
+			name:      "Azure rejected",
+			args:      []string{"--provider", "azure", "--catalog-only", "--sdk", "toolkit=2.0", "snapshot-variant"},
+			wantError: "--catalog-only is AWS-only",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clearConfigEnv(t)
+			t.Setenv("HOME", t.TempDir())
+			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+			requests := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests++
+				if r.Method != http.MethodPost || r.URL.Path != "/v1/images/ami-variant/promote" {
+					t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+				}
+				if r.URL.Query().Get("catalogOnly") != "true" {
+					t.Fatalf("catalogOnly query=%q", r.URL.Query().Get("catalogOnly"))
+				}
+				_, _ = w.Write([]byte(test.response))
+			}))
+			defer server.Close()
+
+			t.Setenv("CRABBOX_COORDINATOR", server.URL)
+			t.Setenv("CRABBOX_COORDINATOR_ADMIN_TOKEN", "admin-token")
+			var out bytes.Buffer
+			app := App{Stdout: &out, Stderr: io.Discard}
+			err := app.imagePromote(context.Background(), test.args)
+			if test.wantError != "" {
+				if err == nil || !strings.Contains(err.Error(), test.wantError) {
+					t.Fatalf("error=%v", err)
+				}
+				if requests != 0 {
+					t.Fatalf("requests=%d", requests)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if requests != 1 {
+				t.Fatalf("requests=%d", requests)
+			}
+			if !strings.Contains(out.String(), test.wantOutput) {
+				t.Fatalf("output=%q", out.String())
+			}
+		})
+	}
+}
+
 func TestLeaseStatusRequiresSSHReadiness(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet || r.URL.Path != "/v1/leases/cbx_123" {

--- a/internal/cli/image.go
+++ b/internal/cli/image.go
@@ -61,19 +61,23 @@ func (a App) imagePromote(ctx context.Context, args []string) error {
 	browser := fs.Bool("browser", false, "image includes a browser")
 	webView2 := fs.Bool("webview2", false, "image includes Microsoft WebView2")
 	desktop := fs.Bool("desktop", false, "image includes desktop support")
+	catalogOnly := fs.Bool("catalog-only", false, "publish an AWS capability variant without changing the default image")
 	fastSnapshotRestore := fs.Bool("fast-snapshot-restore", false, "enable AWS Fast Snapshot Restore for the promoted AMI snapshots")
 	var fastSnapshotRestoreAZs stringListFlag
 	fs.Var(&fastSnapshotRestoreAZs, "fsr-az", "availability zone for Fast Snapshot Restore; repeatable")
 	jsonOut := fs.Bool("json", false, "print JSON")
-	if err := parseFlags(fs, args); err != nil {
+	if err := parseInterspersedFlags(fs, args); err != nil {
 		return err
 	}
 	if fs.NArg() != 1 {
-		return exit(2, "usage: crabbox image promote <image-id> [--provider aws|azure] [--target linux|macos|windows] [--os ubuntu:26.04|ubuntu:24.04] [--region <region>] [--type <instance-type>] [--architecture <arch>] [--os-version <version>] [--sdk <name=version>] [--runtime <name=version>] [--browser] [--webview2] [--desktop] [--fast-snapshot-restore --fsr-az <az>]")
+		return exit(2, "usage: crabbox image promote <image-id> [--provider aws|azure] [--target linux|macos|windows] [--os ubuntu:26.04|ubuntu:24.04] [--region <region>] [--type <instance-type>] [--architecture <arch>] [--os-version <version>] [--sdk <name=version>] [--runtime <name=version>] [--browser] [--webview2] [--desktop] [--catalog-only] [--fast-snapshot-restore --fsr-az <az>]")
 	}
 	normalizedProvider := normalizeProviderName(*provider)
 	if normalizedProvider != "aws" && normalizedProvider != "azure" {
 		return exit(2, "unsupported image promotion provider %q; use aws or azure", *provider)
+	}
+	if normalizedProvider == "azure" && *catalogOnly {
+		return exit(2, "--catalog-only is AWS-only")
 	}
 	if normalizedProvider == "azure" && (*fastSnapshotRestore || len(fastSnapshotRestoreAZs) > 0) {
 		return exit(2, "Fast Snapshot Restore is AWS-only")
@@ -91,6 +95,17 @@ func (a App) imagePromote(ctx context.Context, args []string) error {
 	runtimes, err := parseImageVersions(runtimeVersions, "runtime")
 	if err != nil {
 		return err
+	}
+	capabilities := imageCapabilities{
+		OSVersion: strings.TrimSpace(*osVersion),
+		SDKs:      sdks,
+		Runtimes:  runtimes,
+		Browser:   *browser,
+		WebView2:  *webView2,
+		Desktop:   *desktop,
+	}
+	if *catalogOnly && imageCapabilitiesEmpty(capabilities) {
+		return exit(2, "--catalog-only requires at least one capability declaration")
 	}
 	if normalizedProvider == "azure" &&
 		(strings.TrimSpace(*osVersion) != "" ||
@@ -119,16 +134,10 @@ func (a App) imagePromote(ctx context.Context, args []string) error {
 		OSImage:                *osImage,
 		ServerType:             *serverType,
 		Architecture:           *architecture,
+		CatalogOnly:            *catalogOnly,
 		FastSnapshotRestore:    *fastSnapshotRestore,
 		FastSnapshotRestoreAZs: fastSnapshotRestoreAZs,
-		Capabilities: imageCapabilities{
-			OSVersion: strings.TrimSpace(*osVersion),
-			SDKs:      sdks,
-			Runtimes:  runtimes,
-			Browser:   *browser,
-			WebView2:  *webView2,
-			Desktop:   *desktop,
-		},
+		Capabilities:           capabilities,
 	})
 	if err != nil {
 		return err
@@ -136,7 +145,7 @@ func (a App) imagePromote(ctx context.Context, args []string) error {
 	if *jsonOut {
 		return json.NewEncoder(a.Stdout).Encode(image)
 	}
-	fmt.Fprintf(a.Stdout, "promoted image=%s name=%s state=%s region=%s\n", image.ID, image.Name, image.State, blank(image.Region, "-"))
+	fmt.Fprintf(a.Stdout, "promoted image=%s name=%s state=%s region=%s catalogOnly=%t\n", image.ID, image.Name, image.State, blank(image.Region, "-"), image.CatalogOnly)
 	return nil
 }
 

--- a/internal/cli/image_capabilities.go
+++ b/internal/cli/image_capabilities.go
@@ -84,6 +84,11 @@ func imageRequirementsEmpty(value imageRequirements) bool {
 		!value.Browser && !value.WebView2 && !value.Desktop
 }
 
+func imageCapabilitiesEmpty(value imageCapabilities) bool {
+	return value.OSVersion == "" && len(value.SDKs) == 0 && len(value.Runtimes) == 0 &&
+		!value.Browser && !value.WebView2 && !value.Desktop
+}
+
 func validateReadyPoolImageRequirements(value imageRequirements, pool string) error {
 	if strings.TrimSpace(pool) != "" && !imageRequirementsEmpty(value) {
 		return exit(2, "--pool cannot verify image capability requirements; omit --pool or the --image-* flags")

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -22810,13 +22810,25 @@ export class AzureProvider implements CloudProvider {
       region?: string;
       architecture?: string;
       serverType?: string;
+      catalogOnly?: unknown;
     } = await readJson<{
       target?: string;
       os?: string;
       region?: string;
       architecture?: string;
       serverType?: string;
+      catalogOnly?: unknown;
     }>(request).catch(() => ({}));
+    const catalogOnly = boolFromUnknown(input.catalogOnly ?? url.searchParams.get("catalogOnly"));
+    if (catalogOnly) {
+      return json(
+        {
+          error: "unsupported_provider",
+          message: "catalog-only image promotion is AWS-only",
+        },
+        { status: 400 },
+      );
+    }
     if (!known) {
       return json(
         {
@@ -24163,6 +24175,7 @@ export class AWSProvider implements CloudProvider {
       serverType?: string;
       architecture?: string;
       capabilities?: ImageCapabilities;
+      catalogOnly?: unknown;
       fastSnapshotRestore?: unknown;
       fastSnapshotRestoreAvailabilityZones?: string[];
     } = await readJson<{
@@ -24172,6 +24185,7 @@ export class AWSProvider implements CloudProvider {
       serverType?: string;
       architecture?: string;
       capabilities?: ImageCapabilities;
+      catalogOnly?: unknown;
       fastSnapshotRestore?: unknown;
       fastSnapshotRestoreAvailabilityZones?: string[];
     }>(request).catch(() => ({}));
@@ -24226,8 +24240,36 @@ export class AWSProvider implements CloudProvider {
     if (architecture) {
       metadata.architecture = architecture;
     }
+    let declaredCapabilities: ImageCapabilities | undefined;
     let capabilities: ImageCapabilities | undefined;
     try {
+      declaredCapabilities = normalizeImageCapabilities({
+        ...input.capabilities,
+        osVersion: input.capabilities?.osVersion ?? url.searchParams.get("osVersion") ?? undefined,
+        sdks:
+          input.capabilities?.sdks ??
+          promotionVersionMap(url.searchParams.getAll("sdk")) ??
+          undefined,
+        runtimes:
+          input.capabilities?.runtimes ??
+          promotionVersionMap(url.searchParams.getAll("runtime")) ??
+          undefined,
+        browser:
+          input.capabilities?.browser ??
+          (url.searchParams.has("browser")
+            ? boolFromUnknown(url.searchParams.get("browser"))
+            : undefined),
+        webview2:
+          input.capabilities?.webview2 ??
+          (url.searchParams.has("webview2")
+            ? boolFromUnknown(url.searchParams.get("webview2"))
+            : undefined),
+        desktop:
+          input.capabilities?.desktop ??
+          (url.searchParams.has("desktop")
+            ? boolFromUnknown(url.searchParams.get("desktop"))
+            : undefined),
+      });
       capabilities = normalizeImageCapabilities({
         ...prior?.capabilities,
         ...input.capabilities,
@@ -24265,6 +24307,16 @@ export class AWSProvider implements CloudProvider {
     } catch (error) {
       return json(
         { error: "invalid_image_capabilities", message: coordinatorErrorMessage(this.env, error) },
+        { status: 400 },
+      );
+    }
+    const catalogOnly = boolFromUnknown(input.catalogOnly ?? url.searchParams.get("catalogOnly"));
+    if (catalogOnly && !declaredCapabilities) {
+      return json(
+        {
+          error: "catalog_only_capabilities_required",
+          message: "catalog-only image promotion requires at least one capability declaration",
+        },
         { status: 400 },
       );
     }
@@ -24331,18 +24383,23 @@ export class AWSProvider implements CloudProvider {
         image.architecture ?? awsImageArchitectureForTarget(target, image.serverType ?? ""),
       promotedAt: new Date().toISOString(),
       ...(capabilities ? { capabilities } : {}),
+      ...(catalogOnly ? { catalogOnly: true } : {}),
     };
-    await this.storage.put(promotedAWSImageKey(promoted), promoted);
-    await this.storage.put(promotedAWSImageCatalogKey(promoted), promoted);
-    if (target === "linux" && promoted.os) {
-      await this.storage.put(promotedAWSLinuxOSImageKey(promoted), promoted);
-    }
-    if (
-      target === "linux" &&
-      (!promoted.os || promoted.os === "ubuntu:24.04") &&
-      legacyPromotedAWSImageCompatible(promoted)
-    ) {
-      await this.storage.put(legacyPromotedAWSImageKey(), promoted);
+    if (catalogOnly) {
+      await this.storage.put(promotedAWSImageCatalogKey(promoted), promoted);
+    } else {
+      await this.storage.put(promotedAWSImageKey(promoted), promoted);
+      await this.storage.put(promotedAWSImageCatalogKey(promoted), promoted);
+      if (target === "linux" && promoted.os) {
+        await this.storage.put(promotedAWSLinuxOSImageKey(promoted), promoted);
+      }
+      if (
+        target === "linux" &&
+        (!promoted.os || promoted.os === "ubuntu:24.04") &&
+        legacyPromotedAWSImageCompatible(promoted)
+      ) {
+        await this.storage.put(legacyPromotedAWSImageKey(), promoted);
+      }
     }
     return { image: promoted };
   }

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -716,6 +716,7 @@ export interface ProviderFastSnapshotRestore {
 
 export interface PromotedImageRecord extends ProviderImage {
   promotedAt: string;
+  catalogOnly?: boolean;
 }
 
 export interface RunRecord {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -28014,6 +28014,166 @@ describe("fleet lease identity and idle", () => {
     );
   });
 
+  it("stores catalog-only AWS promotions without changing default keys", async () => {
+    const storage = new MemoryStorage();
+    const provider = new AWSProvider({} as Env, "eu-west-1", storage);
+    vi.spyOn(provider, "getImage").mockResolvedValue({
+      id: "ami-desktop",
+      name: "linux-desktop",
+      state: "available",
+      provider: "aws",
+      region: "eu-west-1",
+      architecture: "x86_64",
+      snapshots: ["snap-root"],
+    });
+    const enableFastSnapshotRestore = vi
+      .spyOn(provider, "enableFastSnapshotRestore")
+      .mockResolvedValue([
+        { snapshotID: "snap-root", availabilityZone: "eu-west-1a", state: "enabling" },
+      ]);
+    const url = new URL(
+      "https://crabbox.test/v1/images/ami-desktop/promote?target=linux&os=ubuntu%3A24.04&region=eu-west-1&sdk=toolkit%3D1.2&catalogOnly=true&fastSnapshotRestore=true&fsrAz=eu-west-1a",
+    );
+
+    const response = await provider.promoteImage(
+      "ami-desktop",
+      undefined,
+      new Request(url, { method: "POST", body: "{}" }),
+      url,
+    );
+
+    expect(response).toMatchObject({
+      image: {
+        id: "ami-desktop",
+        catalogOnly: true,
+        capabilities: { sdks: { toolkit: "1.2" } },
+      },
+    });
+    expect(enableFastSnapshotRestore).toHaveBeenCalledWith(["snap-root"], ["eu-west-1a"]);
+    expect(
+      storage.value("image:aws:catalog:linux:x86_64:ubuntu24.04:eu-west-1:ami-desktop"),
+    ).toEqual(expect.objectContaining({ id: "ami-desktop", catalogOnly: true }));
+    expect(storage.value("image:aws:promoted:linux:x86_64:ubuntu24.04:eu-west-1")).toBeUndefined();
+    expect(storage.value("image:aws:promoted:linux:x86_64:ubuntu24.04")).toBeUndefined();
+    expect(storage.value("image:aws:promoted")).toBeUndefined();
+  });
+
+  it("keeps default selection unchanged after a catalog-only promotion", async () => {
+    const storage = new MemoryStorage();
+    storage.seed("image:aws:promoted:linux:x86_64:ubuntu26.04:eu-west-1", {
+      id: "ami-default",
+      name: "default",
+      state: "available",
+      target: "linux",
+      os: "ubuntu:26.04",
+      region: "eu-west-1",
+      architecture: "x86_64",
+      promotedAt: "2026-07-01T00:00:00Z",
+    });
+    const provider = new AWSProvider({} as Env, "eu-west-1", storage);
+    vi.spyOn(provider, "getImage").mockResolvedValue({
+      id: "ami-variant",
+      name: "variant",
+      state: "available",
+      provider: "aws",
+      region: "eu-west-1",
+      architecture: "x86_64",
+    });
+    const url = new URL(
+      "https://crabbox.test/v1/images/ami-variant/promote?target=linux&region=eu-west-1&sdk=toolkit%3D2.0&catalogOnly=true",
+    );
+    await provider.promoteImage(
+      "ami-variant",
+      undefined,
+      new Request(url, { method: "POST", body: "{}" }),
+      url,
+    );
+
+    const config = leaseConfig({
+      provider: "aws",
+      os: "ubuntu:26.04",
+      sshPublicKey: "ssh-ed25519 test",
+    });
+
+    await expect(provider.prepareLeaseConfig(config)).resolves.toMatchObject({
+      awsAMI: "ami-default",
+      selectedImage: { id: "ami-default" },
+    });
+  });
+
+  it("selects a matching catalog-only AWS image for capability-aware leases", async () => {
+    const storage = new MemoryStorage();
+    storage.seed("image:aws:promoted:linux:x86_64:ubuntu26.04:eu-west-1", {
+      id: "ami-default",
+      name: "default",
+      state: "available",
+      target: "linux",
+      os: "ubuntu:26.04",
+      region: "eu-west-1",
+      architecture: "x86_64",
+      promotedAt: "2026-07-01T00:00:00Z",
+    });
+    const provider = new AWSProvider({} as Env, "eu-west-1", storage);
+    vi.spyOn(provider, "getImage").mockResolvedValue({
+      id: "ami-variant",
+      name: "variant",
+      state: "available",
+      provider: "aws",
+      region: "eu-west-1",
+      architecture: "x86_64",
+    });
+    const url = new URL(
+      "https://crabbox.test/v1/images/ami-variant/promote?target=linux&region=eu-west-1&sdk=toolkit%3D2.0&catalogOnly=true",
+    );
+    await provider.promoteImage(
+      "ami-variant",
+      undefined,
+      new Request(url, { method: "POST", body: "{}" }),
+      url,
+    );
+
+    const config = leaseConfig({
+      provider: "aws",
+      os: "ubuntu:26.04",
+      sshPublicKey: "ssh-ed25519 test",
+      imageRequirements: { sdks: { toolkit: "2" } },
+    });
+
+    await expect(provider.prepareLeaseConfig(config)).resolves.toMatchObject({
+      awsAMI: "",
+      awsPromotedAMIs: expect.objectContaining({
+        [awsPromotedAMIConfigKey("eu-west-1", config.serverType)]: "ami-variant",
+      }),
+    });
+  });
+
+  it("rejects catalog-only AWS promotions without capabilities", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(
+      storage,
+      {},
+      {
+        AWS_ACCESS_KEY_ID: "test",
+        AWS_SECRET_ACCESS_KEY: "test",
+        CRABBOX_AWS_REGION: "eu-west-1",
+      },
+    );
+
+    const response = await fleet.fetch(
+      request("POST", "/v1/images/ami-variant/promote?catalogOnly=true", {
+        headers: { "x-crabbox-admin": "true" },
+        body: {},
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "catalog_only_capabilities_required",
+      message: "catalog-only image promotion requires at least one capability declaration",
+    });
+    expect(await storage.list({ prefix: "image:aws:" })).toHaveLength(0);
+  });
+
   it("records the exact promoted AWS image selected for a lease", async () => {
     const storage = new MemoryStorage();
     storage.seed("image:aws:promoted:linux:x86_64:ubuntu26.04:eu-west-1", {
@@ -28320,6 +28480,42 @@ describe("fleet lease identity and idle", () => {
     });
   });
 
+  it("rejects catalog-only Azure image promotion", async () => {
+    const storage = new MemoryStorage();
+    const provider = new AzureProvider({} as Env, undefined, storage, "westeurope");
+    const snapshot: ProviderImage = {
+      id: "snapshot-variant",
+      name: "snapshot-variant",
+      state: "succeeded",
+      provider: "azure",
+      kind: "azure-os-disk-snapshot",
+      target: "linux",
+      os: "ubuntu:26.04",
+      region: "westeurope",
+      architecture: "amd64",
+      serverType: "Standard_D192ds_v6",
+    };
+    const url = new URL(
+      "https://crabbox.test/v1/images/snapshot-variant/promote?provider=azure&catalogOnly=true",
+    );
+
+    const response = await provider.promoteImage(
+      snapshot.id,
+      snapshot,
+      new Request(url, { method: "POST", body: "{}" }),
+      url,
+    );
+
+    expect(response).toBeInstanceOf(Response);
+    if (!(response instanceof Response)) throw new Error("expected error response");
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "unsupported_provider",
+      message: "catalog-only image promotion is AWS-only",
+    });
+    expect(await storage.list({ prefix: "image:azure:promoted:" })).toHaveLength(0);
+  });
+
   it("rejects brokered Azure ARM64 leases when neither a promoted snapshot nor image exists", async () => {
     const provider = new AzureProvider({} as Env, undefined, new MemoryStorage(), "westeurope");
     const config = leaseConfig(
@@ -28463,9 +28659,9 @@ describe("fleet lease identity and idle", () => {
       region: "eu-west-1",
       architecture: "x86_64",
     }));
-    const promote = async (imageID: string, runtime?: string) => {
+    const promote = async (imageID: string, runtime?: string, browser?: boolean) => {
       const url = new URL(
-        `https://crabbox.test/v1/images/${imageID}/promote?target=linux&region=eu-west-1${runtime ? `&runtime=node%3D${runtime}` : ""}`,
+        `https://crabbox.test/v1/images/${imageID}/promote?target=linux&region=eu-west-1${runtime ? `&runtime=node%3D${runtime}` : ""}${browser === undefined ? "" : `&browser=${browser}`}`,
       );
       return provider.promoteImage(
         imageID,
@@ -28475,7 +28671,7 @@ describe("fleet lease identity and idle", () => {
       );
     };
 
-    await promote("ami-a", "24.2");
+    await promote("ami-a", "24.2", true);
     await promote("ami-b", "22.17");
     const rollback = await promote("ami-a");
 
@@ -28483,8 +28679,16 @@ describe("fleet lease identity and idle", () => {
       image: { id: "ami-a", capabilities: { runtimes: { node: "24.2" } } },
     });
     expect(storage.value("image:aws:catalog:linux:x86_64:ubuntu26.04:eu-west-1:ami-a")).toEqual(
-      expect.objectContaining({ capabilities: { runtimes: { node: "24.2" } } }),
+      expect.objectContaining({
+        capabilities: { runtimes: { node: "24.2" }, browser: true },
+      }),
     );
+
+    const cleared = await promote("ami-a", undefined, false);
+    expect(cleared).toMatchObject({
+      image: { id: "ami-a", capabilities: { runtimes: { node: "24.2" } } },
+    });
+    expect(cleared).not.toMatchObject({ image: { capabilities: { browser: true } } });
   });
 
   it("selects the newest promoted AWS image satisfying every requirement", async () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where operators who bake a capability *variant* image (a desktop image with an extra application only some lanes need) had no safe way to publish it: `crabbox image promote` always rewrote the scoped default alongside the capability catalog, so a variant silently became every matching lease's image, and the only workaround was to re-promote the generic image afterwards.

## Why This Change Was Made

`crabbox image promote --catalog-only` (AWS) writes only the capability-catalog record. Ordinary leases keep the existing scoped default; leases that request the capability (`warmup --image-sdk name=version`, `--image-runtime`, `--image-require-desktop`, …) select the newest catalog image satisfying every requirement, which already covers catalog-only entries. A catalog-only promotion without any capability declaration is rejected (CLI and Worker) because nothing could ever select it. Azure rejects the flag. Existing `image promote` calls are unchanged.

## User Impact

Operators can publish variant images (`--desktop --sdk <app>=<version> --catalog-only`) without touching the generic default; consumers opt in per lease with `--image-sdk <app>=<version>` and Crabbox fails before leasing when no matching image exists. Follow-up: https://github.com/openclaw/crabbox/pull/1349 uses this to ship a Telegram Desktop variant while keeping the generic desktop image unchanged.

## Evidence

- `npm test --prefix worker` → 37 files passed, 2 skipped; 1357 tests passed, 3 skipped — new cases: catalog-only writes the catalog key only; default selection unchanged after a catalog-only promotion; requirement-based selection returns the catalog-only image; catalog-only without capabilities → 400 `catalog_only_capabilities_required`.
- `npm run format:check`, `npm run lint`, `npm run check` (worker) → clean.
- `go test ./internal/cli/...` → ok (flag parsing/serialization `catalogOnly=true`, `--catalog-only` without capabilities exits 2, Azure rejects).
- `go build ./cmd/crabbox` → built; `crabbox image promote --help` shows `--catalog-only`.
- `node scripts/build-docs-site.mjs` → built.
