### PR TITLE
fix(cli): honor context cancel during remaining poll sleeps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Made default `run --emit-proof` headings context-neutral instead of claiming every run occurred after a patch or fix.
 - Preserved authoritative recorded-run and lease-claim provider routes while keeping unselected inspection and archive dry-run output provider-neutral.
 - Bound coordinator release, heartbeat, and Tailscale mutations to the CLI-selected provider, preventing cross-provider lease deletion or metadata changes.
+- Made Actions hydration waits, coordinator lease-release retries, and managed Windows VNC waits return promptly when cancelled during backoff. Thanks @SebTardif.
 
 ## 0.42.0 - 2026-08-14
 

--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -2322,7 +2322,9 @@ func waitForActionsHydration(ctx context.Context, target SSHTarget, leaseID, exp
 			return actionsHydrationState{}, exit(5, "timed out waiting for GitHub Actions hydration marker for %s", leaseID)
 		}
 		fmt.Fprintf(stderr, "waiting for GitHub Actions hydration marker id=%s...\n", leaseID)
-		time.Sleep(10 * time.Second)
+		if err := sleepContext(ctx, 10*time.Second); err != nil {
+			return actionsHydrationState{}, err
+		}
 	}
 }
 
@@ -2370,7 +2372,9 @@ func waitForLocalActionsHydration(ctx context.Context, target SSHTarget, leaseID
 			return actionsHydrationState{}, exit(5, "timed out waiting for local Actions hydration marker for %s", leaseID)
 		}
 		fmt.Fprintf(stderr, "waiting for local Actions hydration marker id=%s...\n", leaseID)
-		time.Sleep(5 * time.Second)
+		if err := sleepContext(ctx, 5*time.Second); err != nil {
+			return actionsHydrationState{}, err
+		}
 	}
 }
 

--- a/internal/cli/actions_test.go
+++ b/internal/cli/actions_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"errors"
 	"io"
 	"os"
 	"os/exec"
@@ -1891,5 +1892,73 @@ exit 255
 	}
 	if got := strings.Count(string(calls), "call\n"); got != 2 {
 		t.Fatalf("ssh calls=%d want 2", got)
+	}
+}
+
+func TestActionsHydrationWaitsHonorCancellationDuringBackoff(t *testing.T) {
+	// Prove cancel is observed during the inter-attempt backoff, not only at
+	// the top of the loop. Fake ssh always fails so wait enters the sleep.
+	if runtime.GOOS == "windows" {
+		t.Skip("shell ssh fixture")
+	}
+	dir := t.TempDir()
+	sshPath := filepath.Join(dir, "ssh")
+	script := `#!/bin/sh
+exit 255
+`
+	if err := os.WriteFile(sshPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	target := SSHTarget{User: "crabbox", Host: "private.example", Port: "22"}
+
+	tests := []struct {
+		name string
+		wait func(context.Context, io.Writer) error
+	}{
+		{
+			name: "remote",
+			wait: func(ctx context.Context, stderr io.Writer) error {
+				_, err := waitForActionsHydration(ctx, target, "cbx_123", "", time.Minute, stderr)
+				return err
+			},
+		},
+		{
+			name: "local",
+			wait: func(ctx context.Context, stderr io.Writer) error {
+				_, err := waitForLocalActionsHydration(ctx, target, "cbx_123", "", "1", time.Minute, stderr)
+				return err
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			progress := &sshWaitProgressSignal{ready: make(chan struct{})}
+			errCh := make(chan error, 1)
+			go func() {
+				errCh <- test.wait(ctx, progress)
+			}()
+
+			select {
+			case <-progress.ready:
+				// Progress is written after the failed probe and immediately before backoff.
+			case err := <-errCh:
+				t.Fatalf("hydration wait returned before backoff: %v", err)
+			case <-time.After(3 * time.Second):
+				t.Fatal("hydration wait did not reach the backoff")
+			}
+			cancel()
+
+			select {
+			case err := <-errCh:
+				if !errors.Is(err, context.Canceled) {
+					t.Fatalf("hydration wait returned %v, want context.Canceled", err)
+				}
+			case <-time.After(3 * time.Second):
+				t.Fatal("hydration wait did not return within 3s after cancel; still blocked on bare sleep")
+			}
+		})
 	}
 }

--- a/internal/cli/aws_windows_bootstrap.go
+++ b/internal/cli/aws_windows_bootstrap.go
@@ -136,7 +136,9 @@ func waitForManagedWindowsLoopbackVNC(ctx context.Context, target *SSHTarget, st
 		if time.Now().After(deadline) {
 			return exit(5, "managed Windows desktop did not expose VNC on 127.0.0.1:5900")
 		}
-		time.Sleep(5 * time.Second)
+		if err := sleepContext(ctx, 5*time.Second); err != nil {
+			return context.Cause(ctx)
+		}
 	}
 }
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -3158,7 +3158,9 @@ func releaseCoordinatorLease(ctx context.Context, coord *CoordinatorClient, leas
 		if attempt == 5 {
 			break
 		}
-		time.Sleep(time.Duration(attempt*2) * time.Second)
+		if err := sleepContext(ctx, time.Duration(attempt*2)*time.Second); err != nil {
+			return err
+		}
 	}
 	return lastErr
 }

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -19,6 +19,7 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -122,6 +123,65 @@ func TestReleaseBackendLeaseBestEffortCleansMediatedEgressBeforeRelease(t *testi
 		t.Fatalf("releaseBackendLeaseBestEffort error=%v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
 	}
 	assertSSHLogContains(t, logPath, remoteStopEgressClientCommand())
+}
+
+func TestReleaseCoordinatorLeaseHonorsCancellationDuringBackoff(t *testing.T) {
+	// Prove cancel is observed during the inter-attempt backoff, not only at
+	// the next release attempt. The coordinator always fails so release enters the sleep.
+	var (
+		mu    sync.Mutex
+		calls int
+		first = make(chan struct{})
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || !strings.HasSuffix(r.URL.Path, "/release") {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			http.Error(w, "bad", http.StatusNotFound)
+			return
+		}
+		mu.Lock()
+		calls++
+		n := calls
+		mu.Unlock()
+		if n == 1 {
+			close(first)
+		}
+		http.Error(w, "busy", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(server.Close)
+	client := &CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- releaseCoordinatorLease(ctx, client, "cbx_123", "aws")
+	}()
+
+	select {
+	case <-first:
+		// First failed release completed and the retry sleep is next.
+	case err := <-errCh:
+		t.Fatalf("releaseCoordinatorLease returned before backoff: %v", err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("releaseCoordinatorLease did not reach the backoff")
+	}
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("releaseCoordinatorLease returned %v, want context.Canceled", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("releaseCoordinatorLease did not return within 3s after cancel; still blocked on bare sleep")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if calls != 1 {
+		t.Fatalf("release attempts=%d, want 1 (no retries after cancel)", calls)
+	}
 }
 
 func TestStopCleansMediatedEgressBeforeRelease(t *testing.T) {

--- a/internal/cli/sleep_context_test.go
+++ b/internal/cli/sleep_context_test.go
@@ -3,6 +3,10 @@ package cli
 import (
 	"context"
 	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 )
@@ -58,5 +62,61 @@ func TestResolveVNCEndpointStaticHonorsCancellation(t *testing.T) {
 	}
 	if time.Since(start) > time.Second {
 		t.Fatalf("resolveVNCEndpoint took %v; expected immediate return on cancel", time.Since(start))
+	}
+}
+
+func TestWaitForManagedWindowsLoopbackVNCHonorsCancellationDuringBackoff(t *testing.T) {
+	// Prove cancel is observed during the inter-attempt backoff, not only at
+	// the top of the loop. Fake ssh always fails so wait enters the sleep.
+	if runtime.GOOS == "windows" {
+		t.Skip("shell ssh fixture")
+	}
+	dir := t.TempDir()
+	sshPath := filepath.Join(dir, "ssh")
+	probesPath := filepath.Join(dir, "probes")
+	script := `#!/bin/sh
+printf 'probe\n' >> "$CRABBOX_FAKE_SSH_PROBES"
+exit 255
+`
+	if err := os.WriteFile(sshPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CRABBOX_FAKE_SSH_PROBES", probesPath)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- waitForManagedWindowsLoopbackVNC(ctx, &SSHTarget{
+			User: "crabbox",
+			Host: "203.0.113.10",
+			Port: "22",
+		}, io.Discard, time.Minute)
+	}()
+
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		if _, err := os.Stat(probesPath); err == nil {
+			break
+		}
+		select {
+		case err := <-errCh:
+			t.Fatalf("waitForManagedWindowsLoopbackVNC returned before backoff: %v", err)
+		case <-time.After(10 * time.Millisecond):
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("waitForManagedWindowsLoopbackVNC did not probe before backoff")
+		}
+	}
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("waitForManagedWindowsLoopbackVNC returned %v, want context.Canceled", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("waitForManagedWindowsLoopbackVNC did not return within 3s after cancel; still blocked on bare sleep")
 	}
 }


### PR DESCRIPTION
## What Problem This Solves

Actions hydration (`crabbox actions` wait for a GitHub/local marker) and coordinator lease-release backoff still used bare `time.Sleep`. Cancel (Ctrl+C or a cancelled parent context) waited until the sleep finished (up to 10s / 8s). IP and SSH wait loops already use `sleepContext`.

## Evidence

```console
$ go test ./internal/cli -count=1 -timeout 60s -run 'SleepContext|Hydration|ReleaseCoordinator|sleepContext'
ok  	github.com/openclaw/crabbox/internal/cli	2.040s
```

Red: new tests that cancel during the sleep failed while `time.Sleep` was still in place. Green after `sleepContext`.

## Real behavior proof
Behavior addressed: Remaining CLI poll sleeps return as soon as the context is cancelled instead of finishing the delay.
Real environment tested: macOS, Go from the worktree, crabbox `/tmp/oc-impl-crabbox-sleep` head `da20696f`.
Exact steps or command run after this patch: `go test ./internal/cli -count=1 -timeout 60s -run 'SleepContext|Hydration|ReleaseCoordinator|sleepContext'`
Evidence after fix: terminal output copied above.
Observed result after fix: package tests pass in about 2s; cancel during hydration and lease-release sleeps returns `context.Canceled`.
What was not tested: A live `crabbox actions` hydrate against GitHub with a cancelled lease.
