### PR TITLE
chore(release): authorize v0.43.0 source

### DIFF
--- a/.github/release-allowed-signers
+++ b/.github/release-allowed-signers
@@ -1,2 +1,3 @@
 steipete@gmail.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAII9XsaCcr8TInPnHcuTVfvXXcsoUFrOE7menfbEIHFW9 steipete@gmail.com
+steipete@gmail.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINJpNX7Qza7z78FxujtboBJZC73Co1cgWJ5xrFXaek+W mac-studio-sf2 automation
 vincentkoc@ieee.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMYJHwFnesHbwtPLErQBRMffbET0Wrbzh+PjkndZRNyy vincentkoc@ieee.org git signing

--- a/release/records/v0.43.0.json
+++ b/release/records/v0.43.0.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "repository": "openclaw/crabbox",
+  "tag": "v0.43.0",
+  "tagObject": "76d199b15d8440c601e4aefda65bfde961558097",
+  "sourceCommit": "7e03cb13a9ff89c894d2960e2c2c6024f2fa7b48",
+  "publicationStatus": "ready"
+}


### PR DESCRIPTION
## Summary

- Add the Mac Studio automation SSH signing key to the repository-pinned release signer policy, as explicitly authorized by the release owner after the immutable tag was created.
- Bind the signed `v0.43.0` tag object `76d199b15d8440c601e4aefda65bfde961558097` to source commit `7e03cb13a9ff89c894d2960e2c2c6024f2fa7b48` in the protected release record.
- Keep the existing immutable tag unchanged.

## Trust boundary and owner decision

The release owner explicitly selected **Authorize automation key** for this recovery. The added public key has fingerprint `SHA256:0R9sOfREAbuojItYW9O6fvh2RHbgqVJyvk8FBS/35dk` and is the key that signed the already-pushed annotated tag. This PR changes the repository allowlist explicitly rather than moving the protected tag or weakening signature verification. It does not register the key on any GitHub account.

## Captured exact-head verification

Tag verification against this PR's signer policy:

```text
Good "git" signature for steipete@gmail.com with ED25519 key SHA256:0R9sOfREAbuojItYW9O6fvh2RHbgqVJyvk8FBS/35dk
object 7e03cb13a9ff89c894d2960e2c2c6024f2fa7b48
type commit
tag v0.43.0
tagger Peter Steinberger <steipete@gmail.com>

v0.43.0
```

Protected source verification from exact PR head `bc027c415da320794156a29976943b46fc473bac`:

```text
76d199b15d8440c601e4aefda65bfde961558097 7e03cb13a9ff89c894d2960e2c2c6024f2fa7b48
```

The first value is the immutable annotated tag object; the second is its peeled source commit, which is ancestor-reachable from protected `main`.

## Verification commands

- `DEFAULT_BRANCH=main RELEASE_TAG=v0.43.0 EXPECTED_TAG_OBJECT=76d199b15d8440c601e4aefda65bfde961558097 EXPECTED_TAG_COMMIT=7e03cb13a9ff89c894d2960e2c2c6024f2fa7b48 TRUSTED_HEAD=HEAD REQUIRE_PUBLISHABLE=1 scripts/verify-release-source.sh`
- `git -c gpg.format=ssh -c gpg.ssh.allowedSignersFile=.github/release-allowed-signers tag -v v0.43.0`
- `node --test scripts/release-workflow.test.js scripts/release-verifier-isolation.test.js scripts/publish-release.test.js` — 75 passing
- `go test ./internal/cli -run 'Release|Tag|Signer' -count=1`
- P1 autoreview: clean
