### PR TITLE
feat: add lease heartbeat command

### DIFF
--- a/.agents/skills/crabbox/SKILL.md
+++ b/.agents/skills/crabbox/SKILL.md
@@ -425,6 +425,7 @@ crabbox sync-plan
 crabbox warmup --class beast
 crabbox prewarm
 crabbox status --id <lease> --wait
+crabbox heartbeat --id <lease> --idle-timeout 90m
 crabbox inspect --id <lease> --json
 crabbox run --id <lease> --preflight --timing-json -- pnpm test
 crabbox job list

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Added `crabbox heartbeat` so external SSH drivers can refresh owned lease idle deadlines and optionally update the idle timeout.
+
 ## 0.43.0 - 2026-08-15
 
 ### Added

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -46,6 +46,7 @@ crabbox run --timing-record=default -- <cmd> append timing to the local benchmar
 crabbox watch -- <command...>                re-run on a warm lease when local files change
 crabbox bench run --providers a,b -- <cmd>   run a workload and record benchmark timings
 crabbox status --id <id>                     show lease state (--wait to block)
+crabbox heartbeat --id <id>                  refresh the lease idle deadline
 crabbox inspect --id <id>                     print lease/provider details
 crabbox list                                  list machines (alias: crabbox pool list)
 crabbox share --id <id> [--user|--org]        grant access to a lease
@@ -59,7 +60,7 @@ crabbox pool ready [key]                      list hydrated broker ready-pool le
 
 See [warmup](commands/warmup.md), [prewarm](commands/prewarm.md),
 [run](commands/run.md), [watch](commands/watch.md),
-[status](commands/status.md), [inspect](commands/inspect.md),
+[status](commands/status.md), [heartbeat](commands/heartbeat.md), [inspect](commands/inspect.md),
 [list](commands/list.md), [share](commands/share.md),
 [unshare](commands/unshare.md), [stop](commands/stop.md),
 [pause](commands/pause.md), [resume](commands/resume.md),

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -33,6 +33,7 @@ same order as the CLI help.
 - [verify](verify.md)
 - [cache](cache.md)
 - [status](status.md)
+- [heartbeat](heartbeat.md)
 - [list](list.md)
 - [share](share.md)
 - [unshare](unshare.md)

--- a/docs/commands/heartbeat.md
+++ b/docs/commands/heartbeat.md
@@ -1,0 +1,63 @@
+# heartbeat
+
+`crabbox heartbeat` refreshes the idle deadline for one owned lease and prints
+the resulting lease state. It is intended for external drivers that keep a
+lease busy over SSH without running commands through `crabbox run`.
+
+```sh
+crabbox heartbeat --id swift-crab
+crabbox heartbeat --id swift-crab --idle-timeout 90m
+crabbox heartbeat --id cbx_abcdef123456 --provider aws --json
+```
+
+## Identifying the lease
+
+`--id` accepts a canonical `cbx_...` lease ID or an active slug. When
+`--provider` is omitted, Crabbox uses the same local-claim routing as `status`
+and `inspect`; an explicit provider still wins.
+
+## Coordinator and direct-provider behavior
+
+For managed coordinator leases, the command sends exactly one request through
+the existing lease heartbeat endpoint. The configured owner credentials and
+provider binding are unchanged, so unknown, unowned, expired, released, or
+otherwise terminal leases retain the coordinator's normal failure response.
+
+`broker.mode: registered` has both coordinator and direct-provider expiry
+state. The command therefore requires the exact direct claim, sends one
+coordinator heartbeat, and calls the provider's existing `Touch` capability
+with the same idle timeout before reporting success.
+
+Without a coordinator, Crabbox resolves the direct SSH lease and calls the
+provider's existing `Touch` capability. This fallback requires an exact local
+claim that matches the provider scope and live resource identity, and it
+rejects terminal leases before touching them. Providers without lease-touch
+support fail with `provider=<name> does not support lease heartbeat`.
+
+## Idle timeout
+
+`--idle-timeout <duration>` optionally replaces the lease's idle window while
+refreshing it. The value must be positive. Omitting the flag preserves the
+current direct-provider timeout when it is available in lease metadata and
+omits the coordinator heartbeat override.
+
+## Output
+
+Human output is one line with the lease ID, slug, provider, state, idle timeout,
+last-touch timestamp, and expiry. `--json` emits the same fields as a JSON
+object.
+
+## Flags
+
+```text
+--id <lease-id-or-slug>
+--provider <provider>
+--idle-timeout <duration>
+--json
+```
+
+## See also
+
+- [`status`](status.md) — read the current lease state without touching it.
+- [`inspect`](inspect.md) — inspect full lease and provider details.
+- [`run`](run.md) — run a command with automatic background heartbeats.

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -107,6 +107,8 @@ func (a App) directCommandHelp(ctx context.Context, args []string) (error, bool)
 		return a.verify(ctx, helpArgs), true
 	case "status":
 		return a.status(ctx, helpArgs), true
+	case "heartbeat":
+		return a.heartbeat(ctx, helpArgs), true
 	case "list":
 		return a.list(ctx, helpArgs), true
 	case "usage":
@@ -207,6 +209,7 @@ Commands:
   verify      Verify a signed run receipt
   cache       Inspect, purge, warm, or list remote cache volumes
   status      Show lease state; add --wait to block until ready
+  heartbeat   Refresh a lease idle deadline and print its state
   list        List Crabbox machines
   share       Share a lease with users or the owning org
   unshare     Remove lease sharing
@@ -244,6 +247,7 @@ Common Flows:
   crabbox job run openclaw-wsl2
   crabbox warmup
   crabbox status --id blue-lobster --wait
+  crabbox heartbeat --id blue-lobster --idle-timeout 90m
   crabbox run --id blue-lobster --shell 'pnpm install --frozen-lockfile && pnpm test'
   crabbox run --timing-record=default -- pnpm test
   crabbox bench run --providers aws,hetzner --repeats 3 -- pnpm test

--- a/internal/cli/cli_kong.go
+++ b/internal/cli/cli_kong.go
@@ -37,6 +37,7 @@ type crabboxKongCLI struct {
 	Verify      verifyKongCmd      `cmd:"" passthrough:"" help:"Verify a signed run receipt."`
 	Cache       cacheKongCmd       `cmd:"" help:"Inspect, purge, or warm remote caches."`
 	Status      statusKongCmd      `cmd:"" passthrough:"" help:"Show lease state; add --wait to block until ready."`
+	Heartbeat   heartbeatKongCmd   `cmd:"" passthrough:"" help:"Refresh a lease idle deadline and print its state."`
 	List        listKongCmd        `cmd:"" passthrough:"" help:"List Crabbox machines."`
 	Ports       portsKongCmd       `cmd:"" passthrough:"" help:"Publish, list, or unpublish provider-native ports."`
 	Cp          cpKongCmd          `cmd:"" name:"cp" passthrough:"" help:"Copy files between the host and a lease."`
@@ -227,6 +228,9 @@ type tunnelKongCmd struct {
 	Args []string `arg:"" optional:""`
 }
 type statusKongCmd struct {
+	Args []string `arg:"" optional:""`
+}
+type heartbeatKongCmd struct {
 	Args []string `arg:"" optional:""`
 }
 type listKongCmd struct {
@@ -651,6 +655,7 @@ func (c *portsKongCmd) Run(ctx context.Context, app App) error     { return app.
 func (c *cpKongCmd) Run(ctx context.Context, app App) error        { return app.copyCommand(ctx, c.Args) }
 func (c *tunnelKongCmd) Run(ctx context.Context, app App) error    { return app.tunnel(ctx, c.Args) }
 func (c *statusKongCmd) Run(ctx context.Context, app App) error    { return app.status(ctx, c.Args) }
+func (c *heartbeatKongCmd) Run(ctx context.Context, app App) error { return app.heartbeat(ctx, c.Args) }
 func (c *listKongCmd) Run(ctx context.Context, app App) error      { return app.list(ctx, c.Args) }
 func (c *shareKongCmd) Run(ctx context.Context, app App) error     { return app.share(ctx, c.Args) }
 func (c *unshareKongCmd) Run(ctx context.Context, app App) error   { return app.unshare(ctx, c.Args) }

--- a/internal/cli/heartbeat.go
+++ b/internal/cli/heartbeat.go
@@ -1,0 +1,195 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+)
+
+type leaseHeartbeatView struct {
+	ID            string `json:"id"`
+	Slug          string `json:"slug,omitempty"`
+	Provider      string `json:"provider"`
+	State         string `json:"state"`
+	LastTouchedAt string `json:"lastTouchedAt,omitempty"`
+	IdleTimeout   string `json:"idleTimeout,omitempty"`
+	ExpiresAt     string `json:"expiresAt,omitempty"`
+}
+
+func (a App) heartbeat(ctx context.Context, args []string) error {
+	defaults := defaultConfig()
+	fs := newFlagSet("heartbeat", a.Stderr)
+	provider := registerProviderSelectionFlag(fs, defaults, providerHelpSSH())
+	id := fs.String("id", "", "lease id or slug")
+	idleTimeout := fs.Duration("idle-timeout", 0, "replace the lease idle timeout while heartbeating")
+	jsonOut := fs.Bool("json", false, "print JSON")
+	if err := parseFlags(fs, args); err != nil {
+		return err
+	}
+	setIDFromFirstArg(fs, id)
+	if fs.NArg() > 1 {
+		return exit(2, "usage: crabbox heartbeat --id <lease-id-or-slug> [--provider <provider>] [--idle-timeout <duration>] [--json]")
+	}
+	idleTimeoutSet := flagWasSet(fs, "idle-timeout")
+	if idleTimeoutSet && *idleTimeout <= 0 {
+		return exit(2, "idle timeout must be positive")
+	}
+
+	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlagValues{}, networkModeFlagValues{}, leaseTargetConfigOptions{LeaseID: *id})
+	if err != nil {
+		return err
+	}
+	if err := requireLeaseID(*id, "crabbox heartbeat --id <lease-id-or-slug>", cfg); err != nil {
+		return err
+	}
+	if idleTimeoutSet {
+		cfg.IdleTimeout = *idleTimeout
+	}
+
+	backend, err := loadBackend(cfg, runtimeForApp(a))
+	if err != nil {
+		return err
+	}
+	if coordinator, ok := backend.(*coordinatorLeaseBackend); ok {
+		var override *time.Duration
+		if idleTimeoutSet {
+			override = idleTimeout
+		}
+		lease, err := coordinator.HeartbeatLease(ctx, *id, override)
+		if err != nil {
+			return err
+		}
+		return writeLeaseHeartbeatView(a.Stdout, heartbeatViewFromCoordinatorLease(lease), *jsonOut)
+	}
+	var registeredCoord *CoordinatorClient
+	if shouldRegisterCoordinatorLease(cfg) {
+		coord, configured, err := newCoordinatorClient(cfg)
+		if err != nil {
+			return err
+		}
+		if !configured {
+			return exit(2, "provider=%s does not support lease heartbeat", backend.Spec().Name)
+		}
+		registeredCoord = coord
+	}
+
+	sshBackend, ok := backend.(SSHLeaseBackend)
+	if !ok {
+		return exit(2, "provider=%s does not support lease heartbeat", backend.Spec().Name)
+	}
+	lease, err := sshBackend.Resolve(ctx, ResolveRequest{
+		Options:               leaseOptionsFromConfig(cfg),
+		ID:                    *id,
+		StatusOnly:            true,
+		NoLocalStateMutations: true,
+	})
+	if err != nil {
+		return err
+	}
+	state := blank(lease.Server.Labels["state"], lease.Server.Status)
+	if statusTerminalState(state) {
+		return exit(5, "lease %s is in terminal state %s", *id, state)
+	}
+	claimed, err := statusLeaseHasExactClaim(backend, lease, backend.Spec().Name, leaseOptionsFromConfig(cfg).ProviderScope)
+	if err != nil {
+		return err
+	}
+	if !claimed {
+		return exit(4, "lease %s is not claimed for provider=%s; refusing heartbeat", *id, backend.Spec().Name)
+	}
+
+	if !idleTimeoutSet {
+		if current, ok := directLeaseIdleTimeout(lease.Server.Labels); ok {
+			cfg.IdleTimeout = current
+			backend, err = loadBackend(cfg, runtimeForApp(a))
+			if err != nil {
+				return err
+			}
+			var supportsTouch bool
+			sshBackend, supportsTouch = backend.(SSHLeaseBackend)
+			if !supportsTouch {
+				return exit(2, "provider=%s does not support lease heartbeat", backend.Spec().Name)
+			}
+		}
+	}
+	var registeredLease *CoordinatorLease
+	if registeredCoord != nil {
+		var override *time.Duration
+		if idleTimeoutSet {
+			override = idleTimeout
+		}
+		canonicalLeaseID := lease.LeaseID
+		coordinatorLease, err := heartbeatCoordinatorLease(ctx, registeredCoord, canonicalLeaseID, cfg.Provider, override)
+		if err != nil {
+			return err
+		}
+		if err := validateCoordinatorProviderIdentity(cfg.Provider, coordinatorLease.ID, coordinatorLease.Provider, true); err != nil {
+			return err
+		}
+		if coordinatorLease.ID != canonicalLeaseID {
+			return exit(4, "coordinator returned mismatched lease id: expected %s, found %s", canonicalLeaseID, blank(coordinatorLease.ID, "<empty>"))
+		}
+		registeredLease = &coordinatorLease
+	}
+	touched, err := sshBackend.Touch(ctx, TouchRequest{
+		Lease:       lease,
+		State:       state,
+		IdleTimeout: cfg.IdleTimeout,
+	})
+	if err != nil {
+		return err
+	}
+	if registeredLease != nil {
+		return writeLeaseHeartbeatView(a.Stdout, heartbeatViewFromCoordinatorLease(*registeredLease), *jsonOut)
+	}
+	return writeLeaseHeartbeatView(a.Stdout, heartbeatViewFromServer(lease.LeaseID, touched), *jsonOut)
+}
+
+func directLeaseIdleTimeout(labels map[string]string) (time.Duration, bool) {
+	if duration, ok := parseDurationSecondsLabel(labels["idle_timeout_secs"]); ok {
+		return duration, true
+	}
+	return parseDurationSecondsLabel(labels["idle_timeout"])
+}
+
+func heartbeatViewFromCoordinatorLease(lease CoordinatorLease) leaseHeartbeatView {
+	return leaseHeartbeatView{
+		ID:            lease.ID,
+		Slug:          lease.Slug,
+		Provider:      lease.Provider,
+		State:         lease.State,
+		LastTouchedAt: lease.LastTouchedAt,
+		IdleTimeout:   formatSecondsDuration(lease.IdleTimeoutSeconds),
+		ExpiresAt:     lease.ExpiresAt,
+	}
+}
+
+func heartbeatViewFromServer(leaseID string, server Server) leaseHeartbeatView {
+	return leaseHeartbeatView{
+		ID:            leaseID,
+		Slug:          serverSlug(server),
+		Provider:      server.Provider,
+		State:         blank(server.Labels["state"], server.Status),
+		LastTouchedAt: blank(leaseLabelTimeDisplay(server.Labels["last_touched_at"]), server.Labels["last_touched_at"]),
+		IdleTimeout:   leaseLabelDurationDisplay(server.Labels["idle_timeout_secs"], server.Labels["idle_timeout"]),
+		ExpiresAt:     blank(leaseLabelTimeDisplay(server.Labels["expires_at"]), server.Labels["expires_at"]),
+	}
+}
+
+func writeLeaseHeartbeatView(stdout io.Writer, view leaseHeartbeatView, jsonOut bool) error {
+	if jsonOut {
+		return json.NewEncoder(stdout).Encode(view)
+	}
+	_, err := fmt.Fprintf(stdout, "heartbeat lease=%s slug=%s provider=%s state=%s idle_timeout=%s last_touched=%s expires=%s\n",
+		view.ID,
+		blank(view.Slug, "-"),
+		view.Provider,
+		view.State,
+		blank(view.IdleTimeout, "-"),
+		blank(view.LastTouchedAt, "-"),
+		blank(view.ExpiresAt, "-"),
+	)
+	return err
+}

--- a/internal/cli/heartbeat_test.go
+++ b/internal/cli/heartbeat_test.go
@@ -1,0 +1,329 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHeartbeatCoordinatorPassesIdleTimeoutAndPrintsLeaseState(t *testing.T) {
+	var requestBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/leases/blue-lobster/heartbeat" {
+			t.Fatalf("request=%s %s, want heartbeat POST", r.Method, r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer user-token" {
+			t.Fatalf("authorization=%q", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&requestBody); err != nil {
+			t.Fatal(err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
+			ID:                 "cbx_heartbeat",
+			Slug:               "blue-lobster",
+			Provider:           "aws",
+			State:              "active",
+			LastTouchedAt:      "2026-08-16T20:00:00Z",
+			IdleTimeoutSeconds: 5400,
+			ExpiresAt:          "2026-08-16T21:30:00Z",
+		}})
+	}))
+	defer server.Close()
+
+	configureHeartbeatCoordinatorTest(t, server.URL)
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).Run(context.Background(), []string{
+		"heartbeat", "--provider", "aws", "--id", "blue-lobster", "--idle-timeout", "90m", "--json",
+	})
+	if err != nil {
+		t.Fatalf("heartbeat error=%v stderr=%s", err, stderr.String())
+	}
+	if requestBody["expectedProvider"] != "aws" || requestBody["idleTimeoutSeconds"] != float64(5400) {
+		t.Fatalf("heartbeat body=%v", requestBody)
+	}
+	var got leaseHeartbeatView
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != "cbx_heartbeat" || got.Slug != "blue-lobster" || got.Provider != "aws" || got.State != "active" || got.IdleTimeout != "1h30m0s" {
+		t.Fatalf("heartbeat output=%#v", got)
+	}
+}
+
+func TestHeartbeatCoordinatorOmitsIdleTimeoutWithoutOverride(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := body["idleTimeoutSeconds"]; ok {
+			t.Fatalf("heartbeat body unexpectedly included idle timeout: %v", body)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
+			ID: "cbx_heartbeat", Slug: "blue-lobster", Provider: "aws", State: "active",
+		}})
+	}))
+	defer server.Close()
+
+	configureHeartbeatCoordinatorTest(t, server.URL)
+	var stdout bytes.Buffer
+	if err := (App{Stdout: &stdout, Stderr: &bytes.Buffer{}}).heartbeat(context.Background(), []string{"--provider", "aws", "--id", "blue-lobster"}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout.String(), "heartbeat lease=cbx_heartbeat slug=blue-lobster provider=aws state=active") {
+		t.Fatalf("heartbeat output=%q", stdout.String())
+	}
+}
+
+func TestHeartbeatCoordinatorFailsClosed(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		statusCode int
+		errorCode  string
+		message    string
+	}{
+		{name: "not owner", statusCode: http.StatusForbidden, errorCode: "forbidden", message: "lease manage access required"},
+		{name: "unknown lease", statusCode: http.StatusNotFound, errorCode: "not_found", message: "not found"},
+		{name: "terminal lease", statusCode: http.StatusConflict, errorCode: "lease_ended", message: "lease has already ended"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(test.statusCode)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": test.errorCode, "message": test.message})
+			}))
+			defer server.Close()
+
+			configureHeartbeatCoordinatorTest(t, server.URL)
+			var stdout bytes.Buffer
+			err := (App{Stdout: &stdout, Stderr: &bytes.Buffer{}}).heartbeat(context.Background(), []string{"--provider", "aws", "--id", "missing-or-foreign"})
+			if err == nil {
+				t.Fatal("heartbeat unexpectedly succeeded")
+			}
+			for _, want := range []string{
+				"coordinator POST /v1/leases/missing-or-foreign/heartbeat",
+				"http " + strconv.Itoa(test.statusCode),
+				test.message,
+			} {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("error=%q, want %q", err, want)
+				}
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("failed heartbeat output=%q", stdout.String())
+			}
+		})
+	}
+}
+
+func TestHeartbeatRegisteredModeUsesCoordinator(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/leases/cbx_registered/heartbeat" {
+			t.Fatalf("registered heartbeat path=%q", r.URL.Path)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		if body["expectedProvider"] != heartbeatDirectProviderName || body["idleTimeoutSeconds"] != float64(3600) {
+			t.Fatalf("registered heartbeat body=%v", body)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
+			ID: "cbx_registered", Slug: "registered-heartbeat", Provider: heartbeatDirectProviderName, State: "active", IdleTimeoutSeconds: 3600,
+		}})
+	}))
+	defer server.Close()
+
+	clearConfigEnv(t)
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	config := fmt.Sprintf("provider: %s\nbroker:\n  url: %s\n  mode: registered\n", heartbeatDirectProviderName, server.URL)
+	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CRABBOX_CONFIG", configPath)
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "user-token")
+	backend := &heartbeatDirectBackend{}
+	backend.lease = heartbeatDirectTestLease("cbx_registered", "registered-heartbeat")
+	heartbeatDirectBackendForTest = backend
+	t.Cleanup(func() { heartbeatDirectBackendForTest = nil })
+	cfg := defaultConfig()
+	cfg.Provider = heartbeatDirectProviderName
+	if err := claimLeaseTargetForRepoConfig(backend.lease.LeaseID, serverSlug(backend.lease.Server), cfg, backend.lease.Server, SSHTarget{}, "/repo", 30*time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	if err := (App{Stdout: &stdout, Stderr: &bytes.Buffer{}}).heartbeat(context.Background(), []string{
+		"--id", "registered-heartbeat", "--idle-timeout", "1h", "--json",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(backend.touches) != 1 || backend.touches[0].IdleTimeout != time.Hour {
+		t.Fatalf("registered heartbeat direct touches=%#v", backend.touches)
+	}
+}
+
+func TestHeartbeatRejectsProviderWithoutLeaseTouch(t *testing.T) {
+	clearConfigEnv(t)
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+	err := (App{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}).heartbeat(context.Background(), []string{
+		"--provider", "service-control-test", "--id", "configured-app",
+	})
+	if err == nil || !strings.Contains(err.Error(), "provider=service-control-test does not support lease heartbeat") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func configureHeartbeatCoordinatorTest(t *testing.T, serverURL string) {
+	t.Helper()
+	clearConfigEnv(t)
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+	t.Setenv("CRABBOX_COORDINATOR", serverURL)
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "user-token")
+}
+
+const heartbeatDirectProviderName = "heartbeat-direct-test"
+
+var heartbeatDirectBackendForTest *heartbeatDirectBackend
+
+func init() {
+	RegisterProvider(heartbeatDirectProvider{})
+}
+
+type heartbeatDirectProvider struct{}
+
+func (heartbeatDirectProvider) Name() string      { return heartbeatDirectProviderName }
+func (heartbeatDirectProvider) Aliases() []string { return nil }
+func (heartbeatDirectProvider) Spec() ProviderSpec {
+	return ProviderSpec{
+		Name:        heartbeatDirectProviderName,
+		Family:      "heartbeat-test",
+		Kind:        ProviderKindSSHLease,
+		Targets:     []TargetSpec{{OS: targetLinux}},
+		Coordinator: CoordinatorNever,
+	}
+}
+func (heartbeatDirectProvider) RegisterFlags(*flag.FlagSet, Config) any { return noProviderFlags{} }
+func (heartbeatDirectProvider) ApplyFlags(*Config, *flag.FlagSet, any) error {
+	return nil
+}
+func (heartbeatDirectProvider) Configure(Config, Runtime) (Backend, error) {
+	if heartbeatDirectBackendForTest == nil {
+		return nil, errors.New("heartbeat direct test backend is not configured")
+	}
+	return heartbeatDirectBackendForTest, nil
+}
+
+type heartbeatDirectBackend struct {
+	lease   LeaseTarget
+	touches []TouchRequest
+}
+
+func (*heartbeatDirectBackend) Spec() ProviderSpec { return heartbeatDirectProvider{}.Spec() }
+func (b *heartbeatDirectBackend) Acquire(context.Context, AcquireRequest) (LeaseTarget, error) {
+	return b.lease, nil
+}
+func (b *heartbeatDirectBackend) Resolve(_ context.Context, req ResolveRequest) (LeaseTarget, error) {
+	if req.ID != b.lease.LeaseID && req.ID != serverSlug(b.lease.Server) {
+		return LeaseTarget{}, fmt.Errorf("lease %s not found", req.ID)
+	}
+	return b.lease, nil
+}
+func (*heartbeatDirectBackend) List(context.Context, ListRequest) ([]LeaseView, error) {
+	return nil, nil
+}
+func (b *heartbeatDirectBackend) Touch(_ context.Context, req TouchRequest) (Server, error) {
+	b.touches = append(b.touches, req)
+	server := req.Lease.Server
+	server.Labels = cloneStringMap(server.Labels)
+	server.Labels["last_touched_at"] = "2026-08-16T20:00:00Z"
+	server.Labels["idle_timeout_secs"] = durationSecondsLabel(req.IdleTimeout)
+	server.Labels["expires_at"] = "2026-08-16T21:30:00Z"
+	return server, nil
+}
+func (*heartbeatDirectBackend) ReleaseLease(context.Context, ReleaseLeaseRequest) error {
+	return nil
+}
+
+func TestHeartbeatDirectProviderUsesTouchForExactClaim(t *testing.T) {
+	backend := configureHeartbeatDirectTest(t, true)
+	var stdout bytes.Buffer
+	if err := (App{Stdout: &stdout, Stderr: &bytes.Buffer{}}).heartbeat(context.Background(), []string{
+		"--provider", heartbeatDirectProviderName, "--id", "direct-heartbeat", "--idle-timeout", "45m", "--json",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(backend.touches) != 1 || backend.touches[0].IdleTimeout != 45*time.Minute {
+		t.Fatalf("touches=%#v", backend.touches)
+	}
+	var got leaseHeartbeatView
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != backend.lease.LeaseID || got.IdleTimeout != "45m0s" || got.LastTouchedAt != "2026-08-16T20:00:00Z" {
+		t.Fatalf("heartbeat output=%#v", got)
+	}
+}
+
+func TestHeartbeatDirectProviderRejectsClaimlessLease(t *testing.T) {
+	backend := configureHeartbeatDirectTest(t, false)
+	err := (App{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}).heartbeat(context.Background(), []string{
+		"--provider", heartbeatDirectProviderName, "--id", "direct-heartbeat",
+	})
+	if err == nil || !strings.Contains(err.Error(), "is not claimed for provider="+heartbeatDirectProviderName) {
+		t.Fatalf("error=%v", err)
+	}
+	if len(backend.touches) != 0 {
+		t.Fatalf("claimless heartbeat touched lease: %#v", backend.touches)
+	}
+}
+
+func configureHeartbeatDirectTest(t *testing.T, claim bool) *heartbeatDirectBackend {
+	t.Helper()
+	clearConfigEnv(t)
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	t.Setenv("CRABBOX_CONFIG", configPath)
+	if err := os.WriteFile(configPath, []byte("provider: "+heartbeatDirectProviderName+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	lease := heartbeatDirectTestLease("cbx_direct_heartbeat", "direct-heartbeat")
+	server := lease.Server
+	backend := &heartbeatDirectBackend{lease: lease}
+	heartbeatDirectBackendForTest = backend
+	t.Cleanup(func() { heartbeatDirectBackendForTest = nil })
+	if claim {
+		cfg := defaultConfig()
+		cfg.Provider = heartbeatDirectProviderName
+		if err := claimLeaseTargetForRepoConfig(backend.lease.LeaseID, serverSlug(server), cfg, server, SSHTarget{}, "/repo", 30*time.Minute, false); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return backend
+}
+
+func heartbeatDirectTestLease(leaseID, slug string) LeaseTarget {
+	return LeaseTarget{LeaseID: leaseID, Server: Server{
+		Provider: heartbeatDirectProviderName,
+		CloudID:  "direct-resource",
+		Status:   "ready",
+		Labels: map[string]string{
+			"lease":             leaseID,
+			"slug":              slug,
+			"provider":          heartbeatDirectProviderName,
+			"state":             "ready",
+			"idle_timeout_secs": "1800",
+		},
+	}}
+}

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -501,7 +501,7 @@ func TestSubcommandHelpExitsZero(t *testing.T) {
 }
 
 func TestPassthroughCommandHelpExitsBeforeExecution(t *testing.T) {
-	for _, command := range []string{"warmup", "run", "status", "ssh", "ports", "cp", "vnc", "webvnc", "screenshot", "inspect", "stop"} {
+	for _, command := range []string{"warmup", "run", "status", "heartbeat", "ssh", "ports", "cp", "vnc", "webvnc", "screenshot", "inspect", "stop"} {
 		t.Run(command, func(t *testing.T) {
 			var stderr bytes.Buffer
 			app := App{Stdout: &bytes.Buffer{}, Stderr: &stderr}

--- a/internal/cli/provider_coordinator.go
+++ b/internal/cli/provider_coordinator.go
@@ -930,6 +930,31 @@ func (b *coordinatorLeaseBackend) Touch(ctx context.Context, req TouchRequest) (
 	return server, nil
 }
 
+// HeartbeatLease sends one owner-scoped coordinator heartbeat and returns the
+// committed lease state. A non-nil idle timeout uses the existing heartbeat
+// override field; ordinary touches intentionally leave that field unset.
+func (b *coordinatorLeaseBackend) HeartbeatLease(ctx context.Context, leaseID string, idleTimeout *time.Duration) (CoordinatorLease, error) {
+	expectedProvider, err := b.expectedProvider()
+	if err != nil {
+		return CoordinatorLease{}, err
+	}
+	lease, err := heartbeatCoordinatorLease(ctx, b.coord, leaseID, expectedProvider, idleTimeout)
+	if err != nil {
+		return CoordinatorLease{}, err
+	}
+	if err := b.validateCoordinatorLeaseProviderIdentity(lease); err != nil {
+		return CoordinatorLease{}, err
+	}
+	return lease, nil
+}
+
+func heartbeatCoordinatorLease(ctx context.Context, coord *CoordinatorClient, leaseID, expectedProvider string, idleTimeout *time.Duration) (CoordinatorLease, error) {
+	if idleTimeout != nil {
+		return coord.UpdateLeaseIdleTimeoutForProvider(ctx, leaseID, expectedProvider, *idleTimeout)
+	}
+	return coord.TouchLeaseForProvider(ctx, leaseID, expectedProvider)
+}
+
 func coordinatorMachinesToServers(machines []CoordinatorMachine, activeLeaseIDs map[string]struct{}) []Server {
 	servers := make([]Server, 0, len(machines))
 	for _, machine := range machines {

--- a/skills/crabbox/SKILL.md
+++ b/skills/crabbox/SKILL.md
@@ -425,6 +425,7 @@ crabbox sync-plan
 crabbox warmup --class beast
 crabbox prewarm
 crabbox status --id <lease> --wait
+crabbox heartbeat --id <lease> --idle-timeout 90m
 crabbox inspect --id <lease> --json
 crabbox run --id <lease> --preflight --timing-json -- pnpm test
 crabbox job list


### PR DESCRIPTION
## Summary

- add `crabbox heartbeat --id <lease-or-slug> [--provider <p>] [--idle-timeout <duration>] [--json]`
- send one owner-scoped heartbeat through the existing coordinator endpoint and print the committed lease state
- use the established direct-provider `Touch` fallback only after exact local-claim and terminal-state checks
- update CLI help, command docs, the shipped Crabbox skill, and the changelog

## Why

External drivers can keep a warm Crabbox lease busy entirely over SSH without invoking `crabbox run`. In that workflow, ordinary SSH activity and read-only `inspect` / `status` calls do not advance the coordinator's `lastTouchedAt`, so an actively used machine can cross its idle deadline and be reaped.

This provides the missing explicit keepalive surface for https://github.com/openclaw/openclaw/issues/124546 without adding a second endpoint or changing the coordinator protocol.

## Backend behavior

Managed coordinator leases use the same provider-bound heartbeat client methods as the existing background heartbeat loop. Registered mode updates both the canonical coordinator lease and the exact claimed direct-provider resource because both own expiry state. Coordinator-free SSH providers use their existing `Touch` capability. Unsupported providers fail with a clear lease-heartbeat diagnostic.

Unknown, unowned, expired, released, or otherwise terminal coordinator leases retain the coordinator's existing error shape. Direct-provider mutation requires an exact matching local claim and rejects terminal state before touching the resource.

## Verification

- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- `go vet ./...`
- `go test -race ./...`
- `node scripts/check-command-docs.mjs`
- `node scripts/build-docs-site.mjs`
- source-blind CLI contract against a loopback coordinator fixture: help flags, one 90-minute heartbeat payload, JSON state output, missing-ID failure, and non-positive-timeout failure
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output`

No new configuration keys, credentials, secrets, Worker source changes, or coordinator protocol changes are required.
