### PR TITLE
fix(run): omit unavailable history commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added `crabbox heartbeat` so external SSH drivers can refresh owned lease idle deadlines and optionally update the idle timeout.
 
+### Fixed
+
+- Omitted coordinator-only history commands from failure digests when run history is unavailable, while preserving direct lease recovery guidance.
+
 ## 0.43.0 - 2026-08-15
 
 ### Added

--- a/internal/cli/run_failure.go
+++ b/internal/cli/run_failure.go
@@ -340,7 +340,7 @@ func failureDigestArea(classification FailureClassification, phase string) strin
 
 func failureDigestNextCommands(input runFailureDigestInput, retry string) []string {
 	var commands []string
-	if input.RunID != "" {
+	if input.RunID != "" && !input.RunHistoryUnavailable {
 		commands = append(commands,
 			"crabbox logs "+input.RunID+" --tail 80",
 			"crabbox events "+input.RunID+" --type stderr",

--- a/internal/cli/run_failure_test.go
+++ b/internal/cli/run_failure_test.go
@@ -311,6 +311,7 @@ func TestPrintRunFailureDigestExplainsUnavailableRunHistory(t *testing.T) {
 	printRunFailureDigest(&buf, runFailureDigestInput{
 		LeaseID:               "cbx_123",
 		Slug:                  "blue-lobster",
+		RunID:                 "run_local123",
 		RunHistoryUnavailable: true,
 		CommandDisplay:        "go test ./...",
 		Classification:        FailureClassification{BlockedStage: "unknown", RetryLikely: "unknown"},
@@ -327,11 +328,59 @@ func TestPrintRunFailureDigestExplainsUnavailableRunHistory(t *testing.T) {
 	}
 	for _, unexpected := range []string{
 		"crabbox logs run_",
+		"crabbox events run_",
 		"crabbox doctor --from-run run_",
 	} {
 		if strings.Contains(out, unexpected) {
 			t.Fatalf("digest should not include run-based command %q:\n%s", unexpected, out)
 		}
+	}
+}
+
+func TestFailureDigestNextCommandsRespectRunHistoryAvailability(t *testing.T) {
+	historyCommands := []string{
+		"crabbox logs run_123 --tail 80",
+		"crabbox events run_123 --type stderr",
+		"crabbox doctor --from-run run_123",
+	}
+	leaseCommands := []string{
+		"crabbox ssh --provider local-container --id retained-direct",
+		"crabbox run --provider local-container --id retained-direct --fresh-sync -- go test ./...",
+		"crabbox stop --provider local-container retained-direct",
+	}
+	tests := []struct {
+		name               string
+		runID              string
+		historyUnavailable bool
+		wantHistory        bool
+	}{
+		{name: "run ID with unavailable history", runID: "run_123", historyUnavailable: true},
+		{name: "run ID with available history", runID: "run_123", wantHistory: true},
+		{name: "no run ID", historyUnavailable: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			commands := failureDigestNextCommands(runFailureDigestInput{
+				Provider:              "local-container",
+				LeaseID:               "cbx_123",
+				Slug:                  "retained-direct",
+				RunID:                 tt.runID,
+				RunHistoryUnavailable: tt.historyUnavailable,
+				CommandDisplay:        "go test ./...",
+				Classification:        FailureClassification{RetryLikely: "unknown"},
+			}, "unknown")
+			joined := strings.Join(commands, "\n")
+			for _, command := range historyCommands {
+				if got := strings.Contains(joined, command); got != tt.wantHistory {
+					t.Fatalf("history command presence=%v, want %v for %q:\n%s", got, tt.wantHistory, command, joined)
+				}
+			}
+			for _, command := range leaseCommands {
+				if !strings.Contains(joined, command) {
+					t.Fatalf("lease recovery command missing %q:\n%s", command, joined)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Stop treating a coordinatorless local execution ID as a coordinator run-history handle.
- Omit `logs`, `events`, and `doctor --from-run` suggestions when run history is unavailable.
- Preserve local execution IDs and direct lease SSH/retry/stop recovery commands.

Closes https://github.com/openclaw/crabbox/issues/1354

## Root cause

Direct-provider failures pass a useful local execution ID into the digest while independently marking coordinator history unavailable. Command selection previously checked only whether `RunID` was non-empty, so it recommended three commands that necessarily require a coordinator.

## Verification

- `go test -race ./internal/cli -run 'Test(PrintRunFailureDigest|FailureDigest|RunFailure)' -count=1`
- `go test ./internal/cli -count=1`
- `go vet ./...`
- `git diff --check`
- P1 autoreview: clean

## Inspectable after-fix behavior proof

A clean coordinatorless local-container run from exact head `681d6c5f0a0fcf0eaa87eb95009b52585a77e1ad` intentionally failed its user command with `--keep-on-failure`. Redacted terminal excerpt:

```text
run=run_0cbc789de40c portal=- logs=-
lease=cbx_7689e167eaed slug=direct-history-proof-26609 provider=local-container
...
failure digest
  phase: user-command
  area: user_command
  retryable: unknown
  run_history: unavailable; use lease-based recovery commands below
  next: crabbox ssh --provider local-container --target linux --id direct-history-proof-26609
  next: crabbox run --provider local-container --target linux --id direct-history-proof-26609 --fresh-sync -- false
  next: crabbox stop --provider local-container --target linux --id direct-history-proof-26609
```

The transcript contains no `next: crabbox logs`, `next: crabbox events`, or `next: crabbox doctor --from-run` line. The retained lease then remained directly inspectable:

```text
{"id":"cbx_7689e167eaed","slug":"direct-history-proof-26609","state":"ready","provider":"local-container"}
```

The exact lease was stopped successfully and its container was deleted. A separate pre-existing stopped container was intentionally left untouched; the proof lease and claim had no residue.
