### PR TITLE
fix(release): derive Homebrew version from URL

### DIFF
--- a/scripts/homebrew-release.test.js
+++ b/scripts/homebrew-release.test.js
@@ -77,7 +77,6 @@ function formula(overrides = {}, { literalUrls = true } = {}) {
 class Crabbox < Formula
   desc "Remote software testing and execution"
   homepage "https://github.com/openclaw/crabbox"
-  version "1.2.3"
   license "MIT"
 
   on_macos do
@@ -796,6 +795,12 @@ test("mocked Homebrew phase rejects the installed CLI version last", () => {
 test("formula verifier accepts only the exact four frozen archive mappings", () => {
   const exactCanonical = verifyFormula(formula());
   assert.equal(exactCanonical.status, 0, exactCanonical.stderr);
+
+  const explicitVersion = verifyFormula(
+    formula().replace('  license "MIT"', '  version "1.2.3"\n  license "MIT"'),
+  );
+  assert.notEqual(explicitVersion.status, 0);
+  assert.match(explicitVersion.stderr, /exact protected canonical program/);
 
   const interpolationTemplate = verifyFormula(formula({}, { literalUrls: false }));
   assert.notEqual(interpolationTemplate.status, 0);

--- a/scripts/render-homebrew-formula.mjs
+++ b/scripts/render-homebrew-formula.mjs
@@ -18,7 +18,6 @@ process.stdout.write(`# typed: false
 class Crabbox < Formula
   desc "Remote software testing and execution"
   homepage "https://github.com/openclaw/crabbox"
-  version "${version}"
   license "MIT"
 
   on_macos do

--- a/scripts/verify-homebrew-release.sh
+++ b/scripts/verify-homebrew-release.sh
@@ -355,11 +355,9 @@ const expected = new Map([
 ]);
 
 const lines = fs.readFileSync(formulaFile, "utf8").split(/\r?\n/);
-const versions = lines
-  .map((line) => /^\s*version "([^"]+)"\s*$/.exec(line)?.[1])
-  .filter(Boolean);
-if (versions.length !== 1 || versions[0] !== version) {
-  throw new Error("Homebrew formula version does not match the exact release");
+const versions = lines.filter((line) => /^\s*version\b/.test(line));
+if (versions.length !== 0) {
+  throw new Error("Homebrew formula version must be derived from the exact release URL");
 }
 if (lines.filter((line) => line.trim() === "class Crabbox < Formula").length !== 1) {
   throw new Error("Homebrew formula class is not exactly Crabbox");


### PR DESCRIPTION
## Summary

- Remove the redundant explicit `version` directive from protected generated Homebrew formulas.
- Require formula versions to be derived from the already-frozen release URLs.
- Keep exact canonical-program, URL, architecture, and digest verification unchanged.

## Root cause

Homebrew now reports an explicit formula version as redundant when the version is unambiguously scanned from each release URL. The protected generator still emitted that directive, so the published v0.43.0 formula passed native installation verification but failed `brew audit --strict`.

## Verification

- `node --test scripts/homebrew-release.test.js` — 15 passing
- Generated v0.43.0 formula contains no `version` directive
- Published formula URLs and four SHA-256 mappings remain unchanged
- `git diff --check`
- P1 autoreview: clean

## Inspectable Homebrew proof

The versionless canonical v0.43.0 formula was published to `openclaw/tap` with the same frozen URLs and digests. A real Apple Silicon Homebrew installation then returned exit `0` from:

```text
brew audit --formula --strict openclaw/tap/crabbox
```

(The command printed only unrelated deprecation warnings from `cirruslabs/homebrew-cli`; it reported no Crabbox audit problem.) Homebrew independently derived the expected version from the release URL:

```json
{
  "name": "crabbox",
  "full_name": "openclaw/tap/crabbox",
  "versions": { "stable": "0.43.0", "head": null, "bottle": false },
  "urls": [
    "https://github.com/openclaw/crabbox/releases/download/v0.43.0/crabbox_0.43.0_darwin_arm64.tar.gz"
  ]
}
```

The public v0.43.0 release also passed the protected native Homebrew workflow on arm64 and x86_64 before this audit cleanup; this change affects future canonical generation and strict auditability, not release hashes.
