### PR TITLE
fix(local-container): bypass fresh one-shot ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Omitted coordinator-only history commands from failure digests when run history is unavailable, while preserving direct lease recovery guidance.
+- Bypassed reusable-workspace ownership for fresh non-retained local-container runs while preserving ownership for retained and reused leases.
 
 ## 0.43.0 - 2026-08-15
 

--- a/internal/cli/profiles_test.go
+++ b/internal/cli/profiles_test.go
@@ -1818,9 +1818,7 @@ esac
 printf 'Live harness ready: baseUrl=http://127.0.0.1:28008/\nscenario pass login-regression 33.8s\nsuite pass 4/4 total=81.2s\n'
 exit 0
 `
-	if err := os.WriteFile(sshPath, []byte(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	installWorkspaceOwnerAwareSSH(t, sshPath, script)
 	var stdout, stderr bytes.Buffer
 	err = (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
 		"--provider", "run-env-profile-test",

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1036,7 +1036,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 			return recordFailure(err)
 		}
 	}
-	if shouldAcquireWorkspaceOwner(acquired, sshBackend) {
+	if shouldAcquireWorkspaceOwner(acquired, acquiredRunMayRetainLease(*keep, *keepOnFailure, *stopAfter), sshBackend) {
 		target = bootstrapNetworkTarget(cfg, server, target)
 		if waitErr := waitForSSHReady(ctx, &target, a.Stderr, "workspace owner", 2*time.Minute); waitErr != nil {
 			return recordFailure(waitErr)

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -321,6 +321,49 @@ exit 0
 	return logPath
 }
 
+func installWorkspaceOwnerAwareSSH(t *testing.T, sshPath, commandScript string) {
+	t.Helper()
+	commandPath := filepath.Join(filepath.Dir(sshPath), "ssh-command")
+	if err := os.WriteFile(commandPath, []byte(commandScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	wrapper := `#!/bin/sh
+cmd=""
+for arg do cmd="$arg"; done
+current=$cmd
+decode_depth=0
+while [ "$decode_depth" -lt 8 ]; do
+  case "$current" in
+    *'payload_b64="'*'"; decoded=; if command -v base64'*)
+      payload_b64=${current#*'payload_b64="'}
+      payload_b64=${payload_b64%%'"; decoded=; if command -v base64'*}
+      current=$(printf %s "$payload_b64" | /usr/bin/base64 --decode 2>/dev/null) ||
+        current=$(printf %s "$payload_b64" | /usr/bin/base64 -d 2>/dev/null) ||
+        current=$(printf %s "$payload_b64" | /usr/bin/base64 -D 2>/dev/null) || break
+      decode_depth=$((decode_depth + 1))
+      ;;
+    *) break ;;
+  esac
+done
+case "$current" in
+  *"protocol_action='acquire'"*) printf ACQUIRED; exit 0 ;;
+  *"protocol_action='renew'"*) printf RENEWED; exit 0 ;;
+  *"protocol_action='inspect'"*)
+    if [ -e "$(dirname "$0")/owner-child" ]; then printf CHILD; else printf OWNED; fi
+    exit 0
+    ;;
+  *"protocol_action='release'"*) printf RELEASED; exit 0 ;;
+  *"rsync-stop."*"phase_live="*) : > "$(dirname "$0")/owner-child"; printf '123\n'; exit 0 ;;
+  *'touch "$HOME/.crabbox/workspace-owners/'*"rsync-stop."*) rm -f "$(dirname "$0")/owner-child"; exit 0 ;;
+  *"kill -0"*"exit=unknown"*) printf 'exit=unknown\nno marker written\n'; exit 0 ;;
+esac
+exec "$(dirname "$0")/ssh-command" "$current"
+`
+	if err := os.WriteFile(sshPath, []byte(wrapper), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func assertSSHLogContains(t *testing.T, logPath, want string) {
 	t.Helper()
 	data, err := os.ReadFile(logPath)
@@ -1958,9 +2001,7 @@ func TestRunCommandTimingJSONRemainsFinalLineWithCleanup(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(sshPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	installWorkspaceOwnerAwareSSH(t, sshPath, "#!/bin/sh\nexit 0\n")
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	t.Setenv("CRABBOX_FAKE_SSH_PORT", sshPort)
 	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, ".crabbox.yaml"))
@@ -2015,9 +2056,7 @@ func TestRunCommandTimingJSONSurfacesCleanupFailure(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(sshPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	installWorkspaceOwnerAwareSSH(t, sshPath, "#!/bin/sh\nexit 0\n")
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	t.Setenv("CRABBOX_FAKE_SSH_PORT", sshPort)
 	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, ".crabbox.yaml"))
@@ -2083,9 +2122,7 @@ case "$cmd" in
 esac
 exit 0
 `
-	if err := os.WriteFile(sshPath, []byte(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	installWorkspaceOwnerAwareSSH(t, sshPath, script)
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	t.Setenv("CRABBOX_FAKE_SSH_LOG", logPath)
 	t.Setenv("CRABBOX_FAKE_SSH_PORT", sshPort)
@@ -2374,9 +2411,7 @@ case "$cmd" in
 esac
 exit 0
 `
-	if err := os.WriteFile(sshPath, []byte(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	installWorkspaceOwnerAwareSSH(t, sshPath, script)
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	t.Setenv("CRABBOX_FAKE_SSH_LOG", logPath)
 	t.Setenv("CRABBOX_FAKE_SSH_PORT", "22")
@@ -2444,9 +2479,7 @@ case "$cmd" in
 esac
 exit 0
 `
-	if err := os.WriteFile(sshPath, []byte(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	installWorkspaceOwnerAwareSSH(t, sshPath, script)
 	if err := os.WriteFile(rsyncPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -3182,9 +3215,7 @@ case "$remote" in
 esac
 exit 0
 `
-			if err := os.WriteFile(sshPath, []byte(sshScript), 0o755); err != nil {
-				t.Fatal(err)
-			}
+			installWorkspaceOwnerAwareSSH(t, sshPath, sshScript)
 			t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 			t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, "missing.yaml"))
 			t.Setenv("CRABBOX_FAKE_SSH_PORT", "22")

--- a/internal/cli/workspace_owner.go
+++ b/internal/cli/workspace_owner.go
@@ -97,12 +97,24 @@ func workspaceOwnerKey(leaseID string) string {
 	return fmt.Sprintf("%x", sha256.Sum256([]byte("crabbox-workspace-owner-v1\x00"+leaseID)))
 }
 
-func shouldAcquireWorkspaceOwner(acquired bool, backend SSHLeaseBackend) bool {
-	if !acquired {
+func shouldAcquireWorkspaceOwner(acquired, mayRetain bool, backend SSHLeaseBackend) bool {
+	if !acquired || mayRetain {
 		return true
 	}
 	exclusive, ok := backend.(ExclusiveOneShotAcquireBackend)
 	return !ok || !exclusive.AcquireIsExclusiveOneShot()
+}
+
+func acquiredRunMayRetainLease(keep, keepOnFailure bool, stopAfter string) bool {
+	if keep || keepOnFailure {
+		return true
+	}
+	switch strings.ToLower(strings.TrimSpace(stopAfter)) {
+	case "", "always":
+		return false
+	default:
+		return true
+	}
 }
 
 func acquireWorkspaceOwner(ctx context.Context, target SSHTarget, leaseID string, stderr io.Writer) (*workspaceOwner, error) {

--- a/internal/cli/workspace_owner_test.go
+++ b/internal/cli/workspace_owner_test.go
@@ -290,15 +290,52 @@ func TestWorkspaceOwnerTokenAndTransportFailuresFailClosed(t *testing.T) {
 
 func TestWorkspaceOwnerAcquisitionBoundary(t *testing.T) {
 	nonExclusive := newWatchTestBackend()
-	if !shouldAcquireWorkspaceOwner(true, nonExclusive) {
+	if !shouldAcquireWorkspaceOwner(true, false, nonExclusive) {
 		t.Fatal("a successful non-exclusive acquisition must acquire the workspace owner")
 	}
 	exclusive := runEnvProfileTestBackend{}
-	if shouldAcquireWorkspaceOwner(true, exclusive) {
-		t.Fatal("newly acquired exclusive one-shot lease must bypass the workspace owner")
+	tests := []struct {
+		name      string
+		acquired  bool
+		mayRetain bool
+		wantOwner bool
+	}{
+		{name: "fresh one-shot cleanup", acquired: true, wantOwner: false},
+		{name: "fresh keep", acquired: true, mayRetain: true, wantOwner: true},
+		{name: "fresh keep-on-failure", acquired: true, mayRetain: true, wantOwner: true},
+		{name: "reused retained lease", acquired: false, wantOwner: true},
 	}
-	if !shouldAcquireWorkspaceOwner(false, exclusive) {
-		t.Fatal("existing, pooled, and watch-reused leases must acquire the reuse owner")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldAcquireWorkspaceOwner(tt.acquired, tt.mayRetain, exclusive); got != tt.wantOwner {
+				t.Fatalf("shouldAcquireWorkspaceOwner()=%t, want %t", got, tt.wantOwner)
+			}
+		})
+	}
+}
+
+func TestAcquiredRunMayRetainLease(t *testing.T) {
+	tests := []struct {
+		name          string
+		keep          bool
+		keepOnFailure bool
+		stopAfter     string
+		want          bool
+	}{
+		{name: "default cleanup"},
+		{name: "always cleanup", stopAfter: "always"},
+		{name: "keep", keep: true, want: true},
+		{name: "keep on failure", keepOnFailure: true, want: true},
+		{name: "success policy may retain failure", stopAfter: "success", want: true},
+		{name: "failure policy may retain success", stopAfter: "failure", want: true},
+		{name: "never cleanup", stopAfter: "never", want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := acquiredRunMayRetainLease(tt.keep, tt.keepOnFailure, tt.stopAfter); got != tt.want {
+				t.Fatalf("acquiredRunMayRetainLease()=%t, want %t", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -338,7 +375,7 @@ func TestWorkspaceOwnerLifecycleBoundaryMatrix(t *testing.T) {
 		"watch iteration",
 	} {
 		t.Run(lifecycle, func(t *testing.T) {
-			if !shouldAcquireWorkspaceOwner(false, nil) {
+			if !shouldAcquireWorkspaceOwner(false, false, nil) {
 				t.Fatalf("reused %s path bypassed workspace ownership", lifecycle)
 			}
 		})
@@ -346,7 +383,7 @@ func TestWorkspaceOwnerLifecycleBoundaryMatrix(t *testing.T) {
 }
 
 func TestWorkspaceOwnerSerializesStaticRunAndStandaloneActionsHydration(t *testing.T) {
-	if !shouldAcquireWorkspaceOwner(true, testStaticSSHBackend{}) {
+	if !shouldAcquireWorkspaceOwner(true, false, testStaticSSHBackend{}) {
 		t.Fatal("static SSH acquisition bypassed workspace ownership")
 	}
 	remote := newFakeWorkspaceOwnerRemote()

--- a/internal/providers/localcontainer/backend.go
+++ b/internal/providers/localcontainer/backend.go
@@ -50,6 +50,8 @@ type backend struct {
 	afterClaimCleanup      func(string)
 }
 
+var _ core.ExclusiveOneShotAcquireBackend = (*backend)(nil)
+
 type inspectContainer struct {
 	ID              string            `json:"Id"`
 	Name            string            `json:"Name"`
@@ -94,6 +96,8 @@ func newBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.B
 }
 
 func (b *backend) Spec() core.ProviderSpec { return b.spec }
+
+func (b *backend) AcquireIsExclusiveOneShot() bool { return true }
 
 func (b *backend) BeginRunFailureEvidence(ctx context.Context, req core.RunFailureEvidenceRequest) (core.RunFailureEvidenceCollector, error) {
 	containerID := strings.TrimSpace(req.Lease.Server.CloudID)

--- a/internal/providers/localcontainer/backend_test.go
+++ b/internal/providers/localcontainer/backend_test.go
@@ -93,6 +93,14 @@ func testBackend(runner *recordingRunner) *backend {
 	return b
 }
 
+func TestBackendAdvertisesExclusiveOneShotAcquireOnly(t *testing.T) {
+	b := testBackend(&recordingRunner{})
+	capability, ok := any(b).(core.ExclusiveOneShotAcquireBackend)
+	if !ok || !capability.AcquireIsExclusiveOneShot() {
+		t.Fatal("local-container must advertise exclusive fresh acquisitions")
+	}
+}
+
 func TestRunFailureEvidenceUsesPerRunOOMKillIncrement(t *testing.T) {
 	tests := []struct {
 		name              string


### PR DESCRIPTION
## Summary

- Advertise local-container's fresh acquisition as exclusive through the existing provider-neutral capability.
- Bypass reusable-workspace ownership only when a newly acquired run is guaranteed to clean up.
- Preserve workspace ownership for `--keep`, `--keep-on-failure`, conditional `--stop-after` policies, and all reused leases.

Closes https://github.com/openclaw/crabbox/issues/1353

## Root cause

The owner selector already knew how to skip fencing for an exclusive fresh acquisition, but local-container did not advertise that capability. The selection also needed to account for fresh runs that may retain their lease after the command; those must remain fenced because the workspace can become reusable.

## Verification

- Focused workspace-owner race tests
- Full `go test -race ./internal/cli`
- `go test -race ./internal/providers/localcontainer`
- `go vet ./...`
- `git diff --check`
- P1 autoreview: clean

## Inspectable local Docker proof

Exact head `e75bf792fec7e8b82deb025a489856a4632eaee8` produced:

```text
=== fresh one-shot ===
provisioning provider=local-container lease=cbx_6fd68bf18380 slug=fresh-owner-proof-21505 ... keep=false
provisioned lease=cbx_6fd68bf18380 ... state=ready
running on 127.0.0.1 true
command complete ...
lease cleanup stopped=true policy=always lease=cbx_6fd68bf18380 slug=fresh-owner-proof-21505

=== fresh retained ===
provisioning provider=local-container lease=cbx_76b5a1486ad9 slug=reuse-owner-proof-5190 ... keep=true
provisioned lease=cbx_76b5a1486ad9 ... state=ready
workspace owner acquired ... recovered=false
running on 127.0.0.1 true
command complete ...
workspace owner released

=== reused retained ===
workspace owner acquired ... recovered=false
running on 127.0.0.1 true
command complete ...
workspace owner released
```

The fresh one-shot transcript contains no owner acquire/release line and cleans itself automatically. The retained and reused controls both remain owner-fenced. The exact retained lease was then deleted and the proof-specific inventory was `[]`.
