### PR TITLE
fix(windows): frame workspace owner transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Omitted coordinator-only history commands from failure digests when run history is unavailable, while preserving direct lease recovery guidance.
 - Bypassed reusable-workspace ownership for fresh non-retained local-container runs while preserving ownership for retained and reused leases.
+- Streamed workspace-owner scripts outside native Windows SSH command arguments so retained runs no longer exceed the `cmd.exe` command-line limit.
 
 ## 0.43.0 - 2026-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Omitted coordinator-only history commands from failure digests when run history is unavailable, while preserving direct lease recovery guidance.
 - Bypassed reusable-workspace ownership for fresh non-retained local-container runs while preserving ownership for retained and reused leases.
-- Streamed workspace-owner scripts outside native Windows SSH command arguments so retained runs no longer exceed the `cmd.exe` command-line limit.
+- Framed workspace-owner scripts outside native Windows SSH command arguments so retained runs avoid `cmd.exe` limits, preserve finite stdin and nonzero exits, and clean up promptly.
 
 ## 0.43.0 - 2026-08-15
 

--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -262,7 +262,7 @@ func (a App) hydrateActionsWithGitHubRunner(ctx context.Context, cfg Config, rep
 			return actionsHydrationState{}, exit(7, "prepare Actions hydration child witness on %s: %v", target.Host, err)
 		}
 		monitor := remoteActionsHydrationMonitorForTarget(target, leaseID, waitTimeout, owner)
-		if _, err := runSSHOutput(contextWithoutWorkspaceOwner(ctx), target, owner.WrapBackgroundCommand(monitor)); err != nil {
+		if _, err := runWorkspaceOwnerBackgroundOutput(ctx, target, owner, monitor); err != nil {
 			return actionsHydrationState{}, exit(7, "start Actions hydration child witness on %s: %v", target.Host, err)
 		}
 		monitorStarted = true
@@ -620,14 +620,17 @@ func (a App) executeLocalActionsHydration(ctx context.Context, cfg Config, repo 
 		return state, nil
 	}
 	startRemote := remoteStartLocalActionsHydrateScript(plan.leaseID)
-	if owner != nil {
-		startRemote = owner.WrapBackgroundCommand(remoteLocalActionsHydrateBackgroundPayload(plan.leaseID))
-	}
 	startCtx := ctx
 	if owner != nil {
 		startCtx = contextWithoutWorkspaceOwner(ctx)
 	}
-	pid, err := runSSHOutput(startCtx, target, startRemote)
+	var pid string
+	var err error
+	if owner != nil {
+		pid, err = runWorkspaceOwnerBackgroundOutput(startCtx, target, owner, remoteLocalActionsHydrateBackgroundPayload(plan.leaseID))
+	} else {
+		pid, err = runSSHOutput(startCtx, target, startRemote)
+	}
 	if err != nil {
 		return actionsHydrationState{}, exit(7, "start local Actions hydration on %s: %v", target.Host, err)
 	}

--- a/internal/cli/desktop.go
+++ b/internal/cli/desktop.go
@@ -1075,7 +1075,7 @@ func runDesktopLaunchRemoteCombinedOutput(ctx context.Context, target SSHTarget,
 	err := runSSHInput(
 		ctx,
 		target,
-		windowsPowerShellStdinScriptCommand(),
+		windowsPowerShellStdinScriptCommand(len([]byte(remote))),
 		strings.NewReader(remote),
 		&output,
 		&output,

--- a/internal/cli/desktop.go
+++ b/internal/cli/desktop.go
@@ -1072,11 +1072,10 @@ func runDesktopLaunchRemoteCombinedOutput(ctx context.Context, target SSHTarget,
 		return runSSHCombinedOutput(ctx, target, remote)
 	}
 	var output bytes.Buffer
-	command := `powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "$path=Join-Path $env:TEMP ('crabbox-desktop-launch-command-'+[Guid]::NewGuid().ToString('N')+'.ps1');$source=[Console]::In.ReadToEnd();[IO.File]::WriteAllText($path,$source,(New-Object Text.UTF8Encoding($false)));try{& powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File $path;$code=$LASTEXITCODE}finally{Remove-Item -Force -LiteralPath $path -ErrorAction SilentlyContinue};if($null -eq $code){$code=0};exit $code"`
 	err := runSSHInput(
 		ctx,
 		target,
-		command,
+		windowsPowerShellStdinScriptCommand(),
 		strings.NewReader(remote),
 		&output,
 		&output,

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -222,8 +222,14 @@ func directSSHExecutableForGOOS(goos string, getenv func(string) string, stat fu
 	return "ssh"
 }
 
+const sshCommandWaitDelay = 5 * time.Second
+
 func sshCommandContext(ctx context.Context, target SSHTarget, args ...string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, directSSHExecutable(), args...)
+	// A cancelled multiplexed SSH session can leave its ControlPersist master
+	// holding inherited pipes after the session process exits. Bound Go's pipe
+	// drain so cancellation cannot strand the caller in Cmd.Wait.
+	cmd.WaitDelay = sshCommandWaitDelay
 	applyTargetChildEnvironment(cmd, target)
 	return cmd
 }
@@ -461,7 +467,7 @@ func runSSHQuietWithOptions(ctx context.Context, target SSHTarget, remote, conne
 }
 
 func runSSHQuietWithOptionsResolvePort(ctx context.Context, target *SSHTarget, remote, connectTimeout, connectionAttempts string) (err error) {
-	prepared, err := prepareWorkspaceOwnerRemote(ctx, *target, remote, false)
+	prepared, err := prepareWorkspaceOwnerRemote(ctx, *target, remote, nil)
 	if err != nil {
 		return err
 	}
@@ -492,7 +498,7 @@ func runSSHQuietWithOptionsResolvePort(ctx context.Context, target *SSHTarget, r
 }
 
 func runSSHQuietWithRemoteWaitTimeout(ctx context.Context, target SSHTarget, remote string, waitTimeout time.Duration, connectTimeout, connectionAttempts string) (err error) {
-	prepared, err := prepareWorkspaceOwnerRemote(ctx, target, remote, false)
+	prepared, err := prepareWorkspaceOwnerRemote(ctx, target, remote, nil)
 	if err != nil {
 		return err
 	}
@@ -522,7 +528,7 @@ func runSSHQuietWithRemoteWaitTimeout(ctx context.Context, target SSHTarget, rem
 }
 
 func runSSHOutput(ctx context.Context, target SSHTarget, remote string) (output string, err error) {
-	prepared, err := prepareWorkspaceOwnerRemote(ctx, target, remote, false)
+	prepared, err := prepareWorkspaceOwnerRemote(ctx, target, remote, nil)
 	if err != nil {
 		return "", err
 	}
@@ -554,7 +560,7 @@ func runSSHOutput(ctx context.Context, target SSHTarget, remote string) (output 
 }
 
 func runSSHOutputWithRemoteWaitTimeout(ctx context.Context, target SSHTarget, remote string, waitTimeout time.Duration, connectTimeout, connectionAttempts string) (output string, err error) {
-	prepared, err := prepareWorkspaceOwnerRemote(ctx, target, remote, false)
+	prepared, err := prepareWorkspaceOwnerRemote(ctx, target, remote, nil)
 	if err != nil {
 		return "", err
 	}
@@ -587,7 +593,7 @@ func runSSHOutputWithRemoteWaitTimeout(ctx context.Context, target SSHTarget, re
 }
 
 func runSSHCombinedOutput(ctx context.Context, target SSHTarget, remote string) (output string, err error) {
-	prepared, err := prepareWorkspaceOwnerRemote(ctx, target, remote, false)
+	prepared, err := prepareWorkspaceOwnerRemote(ctx, target, remote, nil)
 	if err != nil {
 		return "", err
 	}
@@ -641,7 +647,7 @@ func runIdempotentSSHCombinedOutput(ctx context.Context, target SSHTarget, remot
 }
 
 func runWSL2ControlScriptCombinedOutput(ctx context.Context, target SSHTarget, remote string, waitTimeout time.Duration, connectTimeout, connectionAttempts string) (output string, err error) {
-	prepared, err := prepareWorkspaceOwnerRemote(ctx, target, remote, false)
+	prepared, err := prepareWorkspaceOwnerRemote(ctx, target, remote, nil)
 	if err != nil {
 		return "", err
 	}
@@ -689,7 +695,15 @@ func runSSHInputQuiet(ctx context.Context, target SSHTarget, remote, input strin
 }
 
 func runSSHInputCombinedOutput(ctx context.Context, target SSHTarget, remote string, input io.Reader) (output string, err error) {
-	prepared, err := prepareWorkspaceOwnerRemote(ctx, target, remote, true)
+	if input == nil {
+		input = strings.NewReader("")
+	}
+	data, err := io.ReadAll(input)
+	if err != nil {
+		return "", err
+	}
+	inputSize := int64(len(data))
+	prepared, err := prepareWorkspaceOwnerRemote(ctx, target, remote, &inputSize)
 	if err != nil {
 		return "", err
 	}
@@ -699,13 +713,6 @@ func runSSHInputCombinedOutput(ctx context.Context, target SSHTarget, remote str
 		}
 	}()
 	remote = wrapRemoteForTarget(target, prepared.command)
-	if input == nil {
-		input = strings.NewReader("")
-	}
-	data, err := io.ReadAll(input)
-	if err != nil {
-		return "", err
-	}
 	replayableInput, err := newReplayableSSHInput(data)
 	if err != nil {
 		return "", err
@@ -736,7 +743,15 @@ func runSSHInputCombinedOutput(ctx context.Context, target SSHTarget, remote str
 }
 
 func runSSHInput(ctx context.Context, target SSHTarget, remote string, input io.Reader, stdout, stderr io.Writer) (err error) {
-	prepared, err := prepareWorkspaceOwnerRemote(ctx, target, remote, true)
+	if input == nil {
+		input = strings.NewReader("")
+	}
+	data, err := io.ReadAll(input)
+	if err != nil {
+		return err
+	}
+	inputSize := int64(len(data))
+	prepared, err := prepareWorkspaceOwnerRemote(ctx, target, remote, &inputSize)
 	if err != nil {
 		return err
 	}
@@ -745,15 +760,7 @@ func runSSHInput(ctx context.Context, target SSHTarget, remote string, input io.
 			err = errors.Join(err, prepared.close(ctx, target))
 		}
 	}()
-	remote = prepared.command
-	remote = wrapRemoteForTarget(target, remote)
-	if input == nil {
-		input = strings.NewReader("")
-	}
-	data, err := io.ReadAll(input)
-	if err != nil {
-		return err
-	}
+	remote = wrapRemoteForTarget(target, prepared.command)
 	replayableInput, err := newReplayableSSHInput(data)
 	if err != nil {
 		return err
@@ -783,7 +790,17 @@ func runSSHInput(ctx context.Context, target SSHTarget, remote string, input io.
 }
 
 func runSSHInputStream(ctx context.Context, target SSHTarget, remote string, input io.ReadSeeker, stdout, stderr io.Writer) (err error) {
-	prepared, err := prepareWorkspaceOwnerRemote(ctx, target, remote, true)
+	if input == nil {
+		input = strings.NewReader("")
+	}
+	inputSize, err := input.Seek(0, io.SeekEnd)
+	if err != nil {
+		return err
+	}
+	if _, err := input.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+	prepared, err := prepareWorkspaceOwnerRemote(ctx, target, remote, &inputSize)
 	if err != nil {
 		return err
 	}
@@ -792,11 +809,7 @@ func runSSHInputStream(ctx context.Context, target SSHTarget, remote string, inp
 			err = errors.Join(err, prepared.close(ctx, target))
 		}
 	}()
-	remote = prepared.command
-	remote = wrapRemoteForTarget(target, remote)
-	if input == nil {
-		input = strings.NewReader("")
-	}
+	remote = wrapRemoteForTarget(target, prepared.command)
 	var lastErr error
 	for _, port := range sshPortCandidates(target.Port, target.FallbackPorts) {
 		if _, err := input.Seek(0, io.SeekStart); err != nil {
@@ -824,7 +837,7 @@ func runSSHStream(ctx context.Context, target SSHTarget, remote string, stdout, 
 }
 
 func runSSHStreamResult(ctx context.Context, target SSHTarget, remote string, stdout, stderr io.Writer) (int, error) {
-	prepared, err := prepareWorkspaceOwnerRemote(ctx, target, remote, false)
+	prepared, err := prepareWorkspaceOwnerRemote(ctx, target, remote, nil)
 	if err != nil {
 		return 7, err
 	}
@@ -1571,8 +1584,40 @@ func powershellCommand(script string) string {
 	return "powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand " + encoded
 }
 
-func windowsPowerShellStdinScriptCommand() string {
-	return `powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "$path=Join-Path $env:TEMP ('crabbox-stdin-command-'+[Guid]::NewGuid().ToString('N')+'.ps1');$source=[Console]::In.ReadToEnd();[IO.File]::WriteAllText($path,$source,(New-Object Text.UTF8Encoding($false)));try{& powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File $path;$code=$LASTEXITCODE}finally{Remove-Item -Force -LiteralPath $path -ErrorAction SilentlyContinue};if($null -eq $code){$code=0};exit $code"`
+func windowsPowerShellCopyExactInput(destination string, inputSize int64) string {
+	return `$stdin = [Console]::OpenStandardInput()
+$remaining = [Int64]` + strconv.FormatInt(inputSize, 10) + `
+$buffer = New-Object byte[] 65536
+while ($remaining -gt 0) {
+	$readSize = [int][Math]::Min([Int64]$buffer.Length, $remaining)
+	$read = $stdin.Read($buffer, 0, $readSize)
+	if ($read -le 0) { throw "SSH stdin ended before the framed payload" }
+	` + destination + `.Write($buffer, 0, $read)
+	$remaining -= $read
+}
+`
+}
+
+func windowsPowerShellStdinScriptCommand(inputSize int) string {
+	return powershellCommand(`$ErrorActionPreference = "Stop"
+$path = Join-Path $env:TEMP ("crabbox-stdin-command-" + [Guid]::NewGuid().ToString("N") + ".ps1")
+try {
+	$scriptFile = [IO.File]::Open($path, [IO.FileMode]::CreateNew, [IO.FileAccess]::Write, [IO.FileShare]::None)
+	try {
+		$bom = [byte[]](0xEF, 0xBB, 0xBF)
+		$scriptFile.Write($bom, 0, $bom.Length)
+` + windowsPowerShellCopyExactInput("$scriptFile", int64(inputSize)) + `		$scriptFile.Flush($true)
+	} finally {
+		$scriptFile.Dispose()
+	}
+	& powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File $path
+	$code = $LASTEXITCODE
+} finally {
+	Remove-Item -Force -LiteralPath $path -ErrorAction SilentlyContinue
+}
+if ($null -eq $code) { $code = 0 }
+exit $code
+`)
 }
 
 func utf16LE(input []byte) []byte {

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -460,8 +460,17 @@ func runSSHQuietWithOptions(ctx context.Context, target SSHTarget, remote, conne
 	return runSSHQuietWithOptionsResolvePort(ctx, &target, remote, connectTimeout, connectionAttempts)
 }
 
-func runSSHQuietWithOptionsResolvePort(ctx context.Context, target *SSHTarget, remote, connectTimeout, connectionAttempts string) error {
-	remote = wrapWorkspaceOwnerRemote(ctx, remote, false)
+func runSSHQuietWithOptionsResolvePort(ctx context.Context, target *SSHTarget, remote, connectTimeout, connectionAttempts string) (err error) {
+	prepared, err := prepareWorkspaceOwnerRemote(ctx, *target, remote, false)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			err = errors.Join(err, prepared.close(ctx, *target))
+		}
+	}()
+	remote = prepared.command
 	remote = wrapRemoteForTarget(*target, remote)
 	var lastErr error
 	for _, port := range sshPortCandidates(target.Port, target.FallbackPorts) {
@@ -482,8 +491,17 @@ func runSSHQuietWithOptionsResolvePort(ctx context.Context, target *SSHTarget, r
 	return lastErr
 }
 
-func runSSHQuietWithRemoteWaitTimeout(ctx context.Context, target SSHTarget, remote string, waitTimeout time.Duration, connectTimeout, connectionAttempts string) error {
-	remote = wrapWorkspaceOwnerRemote(ctx, remote, false)
+func runSSHQuietWithRemoteWaitTimeout(ctx context.Context, target SSHTarget, remote string, waitTimeout time.Duration, connectTimeout, connectionAttempts string) (err error) {
+	prepared, err := prepareWorkspaceOwnerRemote(ctx, target, remote, false)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			err = errors.Join(err, prepared.close(ctx, target))
+		}
+	}()
+	remote = prepared.command
 	remote = wrapRemoteForTargetWithWaitTimeout(target, remote, waitTimeout)
 	var lastErr error
 	for _, port := range sshPortCandidates(target.Port, target.FallbackPorts) {
@@ -503,8 +521,17 @@ func runSSHQuietWithRemoteWaitTimeout(ctx context.Context, target SSHTarget, rem
 	return lastErr
 }
 
-func runSSHOutput(ctx context.Context, target SSHTarget, remote string) (string, error) {
-	remote = wrapWorkspaceOwnerRemote(ctx, remote, false)
+func runSSHOutput(ctx context.Context, target SSHTarget, remote string) (output string, err error) {
+	prepared, err := prepareWorkspaceOwnerRemote(ctx, target, remote, false)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		if err != nil {
+			err = errors.Join(err, prepared.close(ctx, target))
+		}
+	}()
+	remote = prepared.command
 	remote = wrapRemoteForTarget(target, remote)
 	var lastOut []byte
 	var lastErr error
@@ -526,8 +553,17 @@ func runSSHOutput(ctx context.Context, target SSHTarget, remote string) (string,
 	return strings.TrimSpace(string(lastOut)), lastErr
 }
 
-func runSSHOutputWithRemoteWaitTimeout(ctx context.Context, target SSHTarget, remote string, waitTimeout time.Duration, connectTimeout, connectionAttempts string) (string, error) {
-	remote = wrapWorkspaceOwnerRemote(ctx, remote, false)
+func runSSHOutputWithRemoteWaitTimeout(ctx context.Context, target SSHTarget, remote string, waitTimeout time.Duration, connectTimeout, connectionAttempts string) (output string, err error) {
+	prepared, err := prepareWorkspaceOwnerRemote(ctx, target, remote, false)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		if err != nil {
+			err = errors.Join(err, prepared.close(ctx, target))
+		}
+	}()
+	remote = prepared.command
 	remote = wrapRemoteForTargetWithWaitTimeout(target, remote, waitTimeout)
 	var lastOut []byte
 	var lastErr error
@@ -550,8 +586,17 @@ func runSSHOutputWithRemoteWaitTimeout(ctx context.Context, target SSHTarget, re
 	return strings.TrimSpace(string(lastOut)), lastErr
 }
 
-func runSSHCombinedOutput(ctx context.Context, target SSHTarget, remote string) (string, error) {
-	remote = wrapWorkspaceOwnerRemote(ctx, remote, false)
+func runSSHCombinedOutput(ctx context.Context, target SSHTarget, remote string) (output string, err error) {
+	prepared, err := prepareWorkspaceOwnerRemote(ctx, target, remote, false)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		if err != nil {
+			err = errors.Join(err, prepared.close(ctx, target))
+		}
+	}()
+	remote = prepared.command
 	remote = wrapRemoteForTarget(target, remote)
 	var lastOut []byte
 	var lastErr error
@@ -596,7 +641,16 @@ func runIdempotentSSHCombinedOutput(ctx context.Context, target SSHTarget, remot
 }
 
 func runWSL2ControlScriptCombinedOutput(ctx context.Context, target SSHTarget, remote string, waitTimeout time.Duration, connectTimeout, connectionAttempts string) (output string, err error) {
-	remote = wrapWorkspaceOwnerRemote(ctx, remote, false)
+	prepared, err := prepareWorkspaceOwnerRemote(ctx, target, remote, false)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		if err != nil {
+			err = errors.Join(err, prepared.close(ctx, target))
+		}
+	}()
+	remote = prepared.command
 	command := wsl2StdinScriptCommandWithWaitTimeout(waitTimeout)
 	input, err := newReplayableSSHInput([]byte(remote))
 	if err != nil {
@@ -634,8 +688,64 @@ func runSSHInputQuiet(ctx context.Context, target SSHTarget, remote, input strin
 	return runSSHInput(ctx, target, remote, strings.NewReader(input), io.Discard, io.Discard)
 }
 
+func runSSHInputCombinedOutput(ctx context.Context, target SSHTarget, remote string, input io.Reader) (output string, err error) {
+	prepared, err := prepareWorkspaceOwnerRemote(ctx, target, remote, true)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		if err != nil {
+			err = errors.Join(err, prepared.close(ctx, target))
+		}
+	}()
+	remote = wrapRemoteForTarget(target, prepared.command)
+	if input == nil {
+		input = strings.NewReader("")
+	}
+	data, err := io.ReadAll(input)
+	if err != nil {
+		return "", err
+	}
+	replayableInput, err := newReplayableSSHInput(data)
+	if err != nil {
+		return "", err
+	}
+	defer func() { err = errors.Join(err, replayableInput.close()) }()
+	var lastOutput string
+	var lastErr error
+	for _, port := range sshPortCandidates(target.Port, target.FallbackPorts) {
+		probe := target
+		probe.Port = port
+		cmd := sshCommandContext(ctx, probe, sshArgs(probe, remote)...)
+		cmd.Stdin, err = replayableInput.reset()
+		if err != nil {
+			return "", err
+		}
+		var attempt synchronizedBuffer
+		err = runSSHCommand(cmd, &attempt, &attempt)
+		lastOutput = strings.TrimSpace(attempt.String())
+		if err == nil {
+			return lastOutput, nil
+		}
+		lastErr = err
+		if !shouldRetrySSHPort(err) {
+			return lastOutput, err
+		}
+	}
+	return lastOutput, lastErr
+}
+
 func runSSHInput(ctx context.Context, target SSHTarget, remote string, input io.Reader, stdout, stderr io.Writer) (err error) {
-	remote = wrapWorkspaceOwnerRemote(ctx, remote, true)
+	prepared, err := prepareWorkspaceOwnerRemote(ctx, target, remote, true)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			err = errors.Join(err, prepared.close(ctx, target))
+		}
+	}()
+	remote = prepared.command
 	remote = wrapRemoteForTarget(target, remote)
 	if input == nil {
 		input = strings.NewReader("")
@@ -672,8 +782,17 @@ func runSSHInput(ctx context.Context, target SSHTarget, remote string, input io.
 	return lastErr
 }
 
-func runSSHInputStream(ctx context.Context, target SSHTarget, remote string, input io.ReadSeeker, stdout, stderr io.Writer) error {
-	remote = wrapWorkspaceOwnerRemote(ctx, remote, true)
+func runSSHInputStream(ctx context.Context, target SSHTarget, remote string, input io.ReadSeeker, stdout, stderr io.Writer) (err error) {
+	prepared, err := prepareWorkspaceOwnerRemote(ctx, target, remote, true)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			err = errors.Join(err, prepared.close(ctx, target))
+		}
+	}()
+	remote = prepared.command
 	remote = wrapRemoteForTarget(target, remote)
 	if input == nil {
 		input = strings.NewReader("")
@@ -705,7 +824,11 @@ func runSSHStream(ctx context.Context, target SSHTarget, remote string, stdout, 
 }
 
 func runSSHStreamResult(ctx context.Context, target SSHTarget, remote string, stdout, stderr io.Writer) (int, error) {
-	remote = wrapWorkspaceOwnerRemote(ctx, remote, false)
+	prepared, err := prepareWorkspaceOwnerRemote(ctx, target, remote, false)
+	if err != nil {
+		return 7, err
+	}
+	remote = prepared.command
 	remote = wrapRemoteForTarget(target, remote)
 	lastCode := 7
 	var lastErr error
@@ -720,10 +843,10 @@ func runSSHStreamResult(ctx context.Context, target SSHTarget, remote string, st
 		lastErr = err
 		lastCode = exitCode(err)
 		if !shouldRetrySSHPort(err) {
-			return lastCode, err
+			return lastCode, errors.Join(err, prepared.close(ctx, target))
 		}
 	}
-	return lastCode, lastErr
+	return lastCode, errors.Join(lastErr, prepared.close(ctx, target))
 }
 
 func runSSHCommand(cmd *exec.Cmd, stdout, stderr io.Writer) error {
@@ -963,7 +1086,7 @@ func rsync(ctx context.Context, target SSHTarget, src, dst string, excludes []st
 		if err := runSSHQuiet(rawCtx, target, owner.rsyncPrepareCommand()); err != nil {
 			return exit(7, "prepare rsync workspace witness: %v", err)
 		}
-		if _, err := runSSHOutput(rawCtx, target, owner.WrapBackgroundCommand(owner.rsyncGuardPayload(dst))); err != nil {
+		if _, err := runSSHOutput(rawCtx, target, owner.wrapPOSIXBackgroundCommand(owner.rsyncGuardPayload(dst))); err != nil {
 			return exit(7, "start rsync workspace witness: %v", err)
 		}
 		if err := owner.WaitForChild(rawCtx, 10*time.Second); err != nil {
@@ -1446,6 +1569,10 @@ func powershellCommand(script string) string {
 	script = `$ProgressPreference = "SilentlyContinue"` + "\n" + script
 	encoded := base64.StdEncoding.EncodeToString(utf16LE([]byte(script)))
 	return "powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand " + encoded
+}
+
+func windowsPowerShellStdinScriptCommand() string {
+	return `powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "$path=Join-Path $env:TEMP ('crabbox-stdin-command-'+[Guid]::NewGuid().ToString('N')+'.ps1');$source=[Console]::In.ReadToEnd();[IO.File]::WriteAllText($path,$source,(New-Object Text.UTF8Encoding($false)));try{& powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File $path;$code=$LASTEXITCODE}finally{Remove-Item -Force -LiteralPath $path -ErrorAction SilentlyContinue};if($null -eq $code){$code=0};exit $code"`
 }
 
 func utf16LE(input []byte) []byte {

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -22,6 +22,35 @@ import (
 
 const powerShellEncodedCommandPrefix = "powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand "
 
+func TestSSHCommandContextBoundsPipeDrainAfterCancellation(t *testing.T) {
+	cmd := sshCommandContext(context.Background(), SSHTarget{}, "-V")
+	if cmd.WaitDelay != sshCommandWaitDelay {
+		t.Fatalf("SSH command WaitDelay=%s want %s", cmd.WaitDelay, sshCommandWaitDelay)
+	}
+}
+
+func TestWindowsPowerShellStdinScriptCommandUsesExactLengthFrame(t *testing.T) {
+	command := windowsPowerShellStdinScriptCommand(12_345)
+	if len(command) >= 8191 {
+		t.Fatalf("stdin script command length=%d exceeds cmd.exe limit", len(command))
+	}
+	decoded := decodePowerShellCommand(t, command)
+	for _, want := range []string{
+		"$remaining = [Int64]12345",
+		"$stdin.Read($buffer, 0, $readSize)",
+		"SSH stdin ended before the framed payload",
+		"$scriptFile.Flush($true)",
+		"-File $path",
+	} {
+		if !strings.Contains(decoded, want) {
+			t.Fatalf("stdin script command missing %q:\n%s", want, decoded)
+		}
+	}
+	if strings.Contains(decoded, "ReadToEnd") || strings.Contains(decoded, "CopyTo") {
+		t.Fatalf("stdin script command still depends on EOF:\n%s", decoded)
+	}
+}
+
 func TestDirectSSHExecutableSelection(t *testing.T) {
 	windowsDir := t.TempDir()
 	nativeSSH := filepath.Join(windowsDir, "System32", "OpenSSH", "ssh.exe")

--- a/internal/cli/workspace_owner.go
+++ b/internal/cli/workspace_owner.go
@@ -46,9 +46,12 @@ type sshWorkspaceOwnerTransport struct {
 }
 
 func (t sshWorkspaceOwnerTransport) Do(ctx context.Context, req workspaceOwnerRemoteRequest) (string, error) {
-	remote := remoteWorkspaceOwnerCommand(t.target, req)
-	out, err := runSSHCombinedOutput(contextWithoutWorkspaceOwner(ctx), t.target, remote)
-	return strings.TrimSpace(out), err
+	ctx = contextWithoutWorkspaceOwner(ctx)
+	if !isWindowsNativeTarget(t.target) {
+		out, err := runSSHCombinedOutput(ctx, t.target, remoteWorkspaceOwnerCommand(t.target, req))
+		return strings.TrimSpace(out), err
+	}
+	return runSSHInputCombinedOutput(ctx, t.target, windowsPowerShellStdinScriptCommand(), strings.NewReader(remoteWorkspaceOwnerWindows(req)))
 }
 
 type workspaceOwner struct {
@@ -82,15 +85,74 @@ func workspaceOwnerFromContext(ctx context.Context) *workspaceOwner {
 	return owner
 }
 
-func wrapWorkspaceOwnerRemote(ctx context.Context, remote string, preserveInput bool) string {
+type workspaceOwnerRemotePreparation struct {
+	command string
+	cleanup string
+	name    string
+}
+
+func prepareWorkspaceOwnerRemote(ctx context.Context, target SSHTarget, remote string, preserveInput bool) (workspaceOwnerRemotePreparation, error) {
 	owner := workspaceOwnerFromContext(ctx)
 	if owner == nil {
-		return remote
+		return workspaceOwnerRemotePreparation{command: remote}, nil
 	}
-	if preserveInput {
-		return owner.WrapInputCommand(remote)
+	if !isWindowsNativeTarget(target) {
+		return workspaceOwnerRemotePreparation{command: owner.wrapPOSIXCommand(remote, preserveInput)}, nil
 	}
-	return owner.WrapCommand(remote)
+	return stageWorkspaceOwnerWindowsWitness(contextWithoutWorkspaceOwner(ctx), target, owner, remote, preserveInput, false)
+}
+
+func (p workspaceOwnerRemotePreparation) close(ctx context.Context, target SSHTarget) error {
+	if p.cleanup == "" {
+		return nil
+	}
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer cancel()
+	return runSSHQuiet(contextWithoutWorkspaceOwner(cleanupCtx), target, p.cleanup)
+}
+
+func stageWorkspaceOwnerWindowsWitness(ctx context.Context, target SSHTarget, owner *workspaceOwner, remote string, preserveInput, selfCleaning bool) (workspaceOwnerRemotePreparation, error) {
+	nonce, err := randomHex(16)
+	if err != nil {
+		return workspaceOwnerRemotePreparation{}, fmt.Errorf("create native Windows workspace witness name: %w", err)
+	}
+	name := owner.key + ".witness." + owner.token + "." + nonce + ".ps1"
+	script := remoteWorkspaceOwnerWindowsWitness(owner.key, owner.token, remote, preserveInput)
+	if selfCleaning {
+		script = remoteWorkspaceOwnerWindowsSelfCleaningWitness(name, script)
+	}
+	var output synchronizedBuffer
+	if err := runSSHInput(ctx, target, remoteWorkspaceOwnerWindowsStageWitnessCommand(owner.key, owner.token, name), strings.NewReader(script), &output, &output); err != nil {
+		detail := trimFailureDetail(strings.TrimSpace(output.String()))
+		if detail != "" {
+			return workspaceOwnerRemotePreparation{}, fmt.Errorf("stage native Windows workspace witness: %w: %s", err, detail)
+		}
+		return workspaceOwnerRemotePreparation{}, fmt.Errorf("stage native Windows workspace witness: %w", err)
+	}
+	return workspaceOwnerRemotePreparation{
+		command: remoteWorkspaceOwnerWindowsRunWitnessCommand(name),
+		cleanup: remoteWorkspaceOwnerWindowsCleanupWitnessCommand(name),
+		name:    name,
+	}, nil
+}
+
+func runWorkspaceOwnerBackgroundOutput(ctx context.Context, target SSHTarget, owner *workspaceOwner, remote string) (string, error) {
+	ctx = contextWithoutWorkspaceOwner(ctx)
+	if owner == nil {
+		return runSSHOutput(ctx, target, remote)
+	}
+	if !isWindowsNativeTarget(target) {
+		return runSSHOutput(ctx, target, owner.wrapPOSIXBackgroundCommand(remote))
+	}
+	prepared, err := stageWorkspaceOwnerWindowsWitness(ctx, target, owner, remote, false, true)
+	if err != nil {
+		return "", err
+	}
+	out, runErr := runSSHOutput(ctx, target, remoteWorkspaceOwnerWindowsStartBackgroundWitnessCommand(prepared.name))
+	if runErr != nil {
+		runErr = errors.Join(runErr, prepared.close(ctx, target))
+	}
+	return out, runErr
 }
 
 func workspaceOwnerKey(leaseID string) string {
@@ -338,43 +400,25 @@ func (o *workspaceOwner) CloseAfterLeaseRelease() error {
 	return o.Err()
 }
 
-func (o *workspaceOwner) WrapCommand(remote string) string {
-	return o.wrapCommand(remote, false)
-}
-
-func (o *workspaceOwner) WrapInputCommand(remote string) string {
-	return o.wrapCommand(remote, true)
-}
-
-func (o *workspaceOwner) wrapCommand(remote string, preserveInput bool) string {
+func (o *workspaceOwner) wrapPOSIXCommand(remote string, preserveInput bool) string {
 	if o == nil {
 		return remote
-	}
-	if isWindowsNativeTarget(o.target) {
-		return remoteWorkspaceOwnerWindowsWitness(o.key, o.token, remote, preserveInput)
 	}
 	return remoteWorkspaceOwnerPOSIXWitness(o.key, o.token, remote, preserveInput)
 }
 
-func (o *workspaceOwner) WrapBackgroundCommand(remote string) string {
+func (o *workspaceOwner) wrapPOSIXBackgroundCommand(remote string) string {
 	if o == nil {
 		return remote
 	}
-	wrapped := o.WrapCommand(remote)
-	if isWindowsNativeTarget(o.target) {
-		encoded := base64.StdEncoding.EncodeToString(utf16LE([]byte(wrapped)))
-		return powershellCommand(`$p = Start-Process -FilePath "powershell.exe" -ArgumentList @("-NoLogo", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-EncodedCommand", ` + psQuote(encoded) + `) -WindowStyle Hidden -PassThru
-Write-Output $p.Id
-exit 0
-`)
-	}
+	wrapped := o.wrapPOSIXCommand(remote, false)
 	background := "nohup /bin/sh -c " + shellQuote(wrapped) + " >/dev/null 2>&1 < /dev/null & printf '%s\\n' \"$!\""
 	return remoteWorkspaceOwnerPOSIXLauncher(o.key, o.token, background)
 }
 
 func remoteWorkspaceOwnerCommand(target SSHTarget, req workspaceOwnerRemoteRequest) string {
 	if isWindowsNativeTarget(target) {
-		return remoteWorkspaceOwnerWindows(req)
+		return windowsPowerShellStdinScriptCommand()
 	}
 	return remoteWorkspaceOwnerPOSIXLauncher(req.Key, req.Token, remoteWorkspaceOwnerPOSIX(req))
 }
@@ -507,7 +551,7 @@ exit "$lock_status"
 }
 
 func remoteWorkspaceOwnerWindows(req workspaceOwnerRemoteRequest) string {
-	return powershellCommand(`$ErrorActionPreference = "Stop"
+	return `$ErrorActionPreference = "Stop"
 $root = Join-Path $HOME ".crabbox\workspace-owners"
 $key = ` + psQuote(req.Key) + `
 $token = ` + psQuote(req.Token) + `
@@ -624,7 +668,7 @@ try {
 	$gateStream.Dispose()
 	Remove-Item -LiteralPath $gate -Force -ErrorAction SilentlyContinue
 }
-`)
+`
 }
 
 func remoteWorkspaceOwnerPOSIXLauncher(key, token, script string) string {
@@ -720,6 +764,81 @@ exit "$code"
 `
 }
 
+func remoteWorkspaceOwnerWindowsStageWitnessCommand(key, token, name string) string {
+	return powershellCommand(`$ErrorActionPreference = "Stop"
+$root = Join-Path $HOME ".crabbox\workspace-owners"
+$state = Join-Path $root (` + psQuote(key) + ` + ".owner")
+$path = Join-Path $root ` + psQuote(name) + `
+$stream = $null
+$created = $false
+try {
+	$rootItem = Get-Item -LiteralPath $root -ErrorAction Stop
+	if (-not $rootItem.PSIsContainer -or ($rootItem.Attributes -band [IO.FileAttributes]::ReparsePoint)) { throw "ambiguous workspace owner root" }
+	$lines = @(Get-Content -LiteralPath $state -ErrorAction Stop)
+	if ($lines.Count -ne 3 -or $lines[0] -ne "v1" -or $lines[1] -ne ` + psQuote(token) + ` -or $lines[2] -notmatch "^[0-9]+$") { throw "workspace owner state changed before witness staging" }
+	if ([Int64]$lines[2] -le [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()) { throw "workspace owner expired before witness staging" }
+	$stream = [IO.File]::Open($path, [IO.FileMode]::CreateNew, [IO.FileAccess]::Write, [IO.FileShare]::None)
+	$created = $true
+	$bom = [byte[]](0xEF, 0xBB, 0xBF)
+	$stream.Write($bom, 0, $bom.Length)
+	[Console]::OpenStandardInput().CopyTo($stream)
+	$stream.Flush($true)
+} catch {
+	if ($null -ne $stream) { $stream.Dispose(); $stream = $null }
+	if ($created) { Remove-Item -LiteralPath $path -Force -ErrorAction SilentlyContinue }
+	throw
+} finally {
+	if ($null -ne $stream) { $stream.Dispose() }
+}
+`)
+}
+
+func remoteWorkspaceOwnerWindowsRunWitnessCommand(name string) string {
+	return powershellCommand(`$ErrorActionPreference = "Stop"
+$path = Join-Path (Join-Path $HOME ".crabbox\workspace-owners") ` + psQuote(name) + `
+try {
+	if (-not (Test-Path -LiteralPath $path -PathType Leaf)) { throw "staged workspace witness is missing" }
+	& powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File $path
+	$code = $LASTEXITCODE
+} finally {
+	Remove-Item -LiteralPath $path -Force -ErrorAction SilentlyContinue
+}
+exit $code
+`)
+}
+
+func remoteWorkspaceOwnerWindowsCleanupWitnessCommand(name string) string {
+	return powershellCommand(`$ErrorActionPreference = "Stop"
+$path = Join-Path (Join-Path $HOME ".crabbox\workspace-owners") ` + psQuote(name) + `
+Remove-Item -LiteralPath $path -Force -ErrorAction SilentlyContinue
+`)
+}
+
+func remoteWorkspaceOwnerWindowsSelfCleaningWitness(name, script string) string {
+	return `$selfPath = Join-Path (Join-Path $HOME ".crabbox\workspace-owners") ` + psQuote(name) + `
+try {
+` + script + `
+} finally {
+	Remove-Item -LiteralPath $selfPath -Force -ErrorAction SilentlyContinue
+}
+`
+}
+
+func remoteWorkspaceOwnerWindowsStartBackgroundWitnessCommand(name string) string {
+	return powershellCommand(`$ErrorActionPreference = "Stop"
+$path = Join-Path (Join-Path $HOME ".crabbox\workspace-owners") ` + psQuote(name) + `
+try {
+	if (-not (Test-Path -LiteralPath $path -PathType Leaf)) { throw "staged workspace witness is missing" }
+	$fileArg = '"' + $path + '"'
+	$process = Start-Process -FilePath "powershell.exe" -ArgumentList @("-NoLogo", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", $fileArg) -WindowStyle Hidden -PassThru
+	Write-Output $process.Id
+} catch {
+	Remove-Item -LiteralPath $path -Force -ErrorAction SilentlyContinue
+	throw
+}
+`)
+}
+
 func remoteWorkspaceOwnerWindowsWitness(key, token, remote string, preserveInput ...bool) string {
 	payload := base64.StdEncoding.EncodeToString([]byte(remote))
 	inputSetup := ""
@@ -731,7 +850,7 @@ try { [Console]::OpenStandardInput().CopyTo($inputFile); $inputFile.Flush() } fi
 `
 		inputArgument = ` -RedirectStandardInput $inputPath`
 	}
-	return powershellCommand(`$ErrorActionPreference = "Stop"
+	return `$ErrorActionPreference = "Stop"
 $root = Join-Path $HOME ".crabbox\workspace-owners"
 $key = ` + psQuote(key) + `
 $token = ` + psQuote(token) + `
@@ -796,8 +915,10 @@ $payload = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('__PAYLOA
 exit $LASTEXITCODE
 '@
 $childSource = $childSource.Replace('__START__', $start.Replace("'", "''")).Replace('__PAYLOAD__', ` + psQuote(payload) + `)
-$childEncoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($childSource))
-$process = Start-Process -FilePath "powershell.exe" -ArgumentList @("-NoLogo", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-EncodedCommand", $childEncoded) -NoNewWindow -PassThru` + inputArgument + `
+$childScript = Join-Path $runDir "child.ps1"
+[IO.File]::WriteAllText($childScript, $childSource, [Text.UTF8Encoding]::new($true))
+$childFileArg = '"' + $childScript + '"'
+$process = Start-Process -FilePath "powershell.exe" -ArgumentList @("-NoLogo", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", $childFileArg) -NoNewWindow -PassThru` + inputArgument + `
 $identity = [string]$process.StartTime.ToUniversalTime().Ticks
 $gateStream = Enter-Gate
 if ($null -eq $gateStream) { Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue; throw "ambiguous owner gate" }
@@ -829,5 +950,5 @@ if ($null -ne $gateStream) {
 Remove-Item -LiteralPath $runDir -Recurse -Force -ErrorAction SilentlyContinue
 if (-not $clear) { exit 74 }
 exit $code
-`)
+`
 }

--- a/internal/cli/workspace_owner.go
+++ b/internal/cli/workspace_owner.go
@@ -51,7 +51,8 @@ func (t sshWorkspaceOwnerTransport) Do(ctx context.Context, req workspaceOwnerRe
 		out, err := runSSHCombinedOutput(ctx, t.target, remoteWorkspaceOwnerCommand(t.target, req))
 		return strings.TrimSpace(out), err
 	}
-	return runSSHInputCombinedOutput(ctx, t.target, windowsPowerShellStdinScriptCommand(), strings.NewReader(remoteWorkspaceOwnerWindows(req)))
+	script := remoteWorkspaceOwnerWindows(req)
+	return runSSHInputCombinedOutput(ctx, t.target, windowsPowerShellStdinScriptCommand(len([]byte(script))), strings.NewReader(script))
 }
 
 type workspaceOwner struct {
@@ -91,15 +92,15 @@ type workspaceOwnerRemotePreparation struct {
 	name    string
 }
 
-func prepareWorkspaceOwnerRemote(ctx context.Context, target SSHTarget, remote string, preserveInput bool) (workspaceOwnerRemotePreparation, error) {
+func prepareWorkspaceOwnerRemote(ctx context.Context, target SSHTarget, remote string, inputSize *int64) (workspaceOwnerRemotePreparation, error) {
 	owner := workspaceOwnerFromContext(ctx)
 	if owner == nil {
 		return workspaceOwnerRemotePreparation{command: remote}, nil
 	}
 	if !isWindowsNativeTarget(target) {
-		return workspaceOwnerRemotePreparation{command: owner.wrapPOSIXCommand(remote, preserveInput)}, nil
+		return workspaceOwnerRemotePreparation{command: owner.wrapPOSIXCommand(remote, inputSize != nil)}, nil
 	}
-	return stageWorkspaceOwnerWindowsWitness(contextWithoutWorkspaceOwner(ctx), target, owner, remote, preserveInput, false)
+	return stageWorkspaceOwnerWindowsWitness(contextWithoutWorkspaceOwner(ctx), target, owner, remote, inputSize, false)
 }
 
 func (p workspaceOwnerRemotePreparation) close(ctx context.Context, target SSHTarget) error {
@@ -111,18 +112,18 @@ func (p workspaceOwnerRemotePreparation) close(ctx context.Context, target SSHTa
 	return runSSHQuiet(contextWithoutWorkspaceOwner(cleanupCtx), target, p.cleanup)
 }
 
-func stageWorkspaceOwnerWindowsWitness(ctx context.Context, target SSHTarget, owner *workspaceOwner, remote string, preserveInput, selfCleaning bool) (workspaceOwnerRemotePreparation, error) {
+func stageWorkspaceOwnerWindowsWitness(ctx context.Context, target SSHTarget, owner *workspaceOwner, remote string, inputSize *int64, selfCleaning bool) (workspaceOwnerRemotePreparation, error) {
 	nonce, err := randomHex(16)
 	if err != nil {
 		return workspaceOwnerRemotePreparation{}, fmt.Errorf("create native Windows workspace witness name: %w", err)
 	}
 	name := owner.key + ".witness." + owner.token + "." + nonce + ".ps1"
-	script := remoteWorkspaceOwnerWindowsWitness(owner.key, owner.token, remote, preserveInput)
+	script := remoteWorkspaceOwnerWindowsWitness(owner.key, owner.token, remote, inputSize)
 	if selfCleaning {
 		script = remoteWorkspaceOwnerWindowsSelfCleaningWitness(name, script)
 	}
 	var output synchronizedBuffer
-	if err := runSSHInput(ctx, target, remoteWorkspaceOwnerWindowsStageWitnessCommand(owner.key, owner.token, name), strings.NewReader(script), &output, &output); err != nil {
+	if err := runSSHInput(ctx, target, remoteWorkspaceOwnerWindowsStageWitnessCommand(owner.key, owner.token, name, int64(len([]byte(script)))), strings.NewReader(script), &output, &output); err != nil {
 		detail := trimFailureDetail(strings.TrimSpace(output.String()))
 		if detail != "" {
 			return workspaceOwnerRemotePreparation{}, fmt.Errorf("stage native Windows workspace witness: %w: %s", err, detail)
@@ -144,7 +145,7 @@ func runWorkspaceOwnerBackgroundOutput(ctx context.Context, target SSHTarget, ow
 	if !isWindowsNativeTarget(target) {
 		return runSSHOutput(ctx, target, owner.wrapPOSIXBackgroundCommand(remote))
 	}
-	prepared, err := stageWorkspaceOwnerWindowsWitness(ctx, target, owner, remote, false, true)
+	prepared, err := stageWorkspaceOwnerWindowsWitness(ctx, target, owner, remote, nil, true)
 	if err != nil {
 		return "", err
 	}
@@ -418,7 +419,7 @@ func (o *workspaceOwner) wrapPOSIXBackgroundCommand(remote string) string {
 
 func remoteWorkspaceOwnerCommand(target SSHTarget, req workspaceOwnerRemoteRequest) string {
 	if isWindowsNativeTarget(target) {
-		return windowsPowerShellStdinScriptCommand()
+		return windowsPowerShellStdinScriptCommand(len([]byte(remoteWorkspaceOwnerWindows(req))))
 	}
 	return remoteWorkspaceOwnerPOSIXLauncher(req.Key, req.Token, remoteWorkspaceOwnerPOSIX(req))
 }
@@ -764,7 +765,7 @@ exit "$code"
 `
 }
 
-func remoteWorkspaceOwnerWindowsStageWitnessCommand(key, token, name string) string {
+func remoteWorkspaceOwnerWindowsStageWitnessCommand(key, token, name string, scriptSize int64) string {
 	return powershellCommand(`$ErrorActionPreference = "Stop"
 $root = Join-Path $HOME ".crabbox\workspace-owners"
 $state = Join-Path $root (` + psQuote(key) + ` + ".owner")
@@ -781,7 +782,7 @@ try {
 	$created = $true
 	$bom = [byte[]](0xEF, 0xBB, 0xBF)
 	$stream.Write($bom, 0, $bom.Length)
-	[Console]::OpenStandardInput().CopyTo($stream)
+` + windowsPowerShellCopyExactInput("$stream", scriptSize) + `	if ($stream.Length -ne ` + strconv.FormatInt(scriptSize+3, 10) + `) { throw "staged workspace witness length is ambiguous" }
 	$stream.Flush($true)
 } catch {
 	if ($null -ne $stream) { $stream.Dispose(); $stream = $null }
@@ -839,14 +840,16 @@ try {
 `)
 }
 
-func remoteWorkspaceOwnerWindowsWitness(key, token, remote string, preserveInput ...bool) string {
+func remoteWorkspaceOwnerWindowsWitness(key, token, remote string, inputSize *int64) string {
 	payload := base64.StdEncoding.EncodeToString([]byte(remote))
 	inputSetup := ""
 	inputArgument := ""
-	if len(preserveInput) > 0 && preserveInput[0] {
+	if inputSize != nil {
 		inputSetup = `$inputPath = Join-Path $runDir "input"
 $inputFile = [IO.File]::Open($inputPath, [IO.FileMode]::CreateNew, [IO.FileAccess]::Write, [IO.FileShare]::None)
-try { [Console]::OpenStandardInput().CopyTo($inputFile); $inputFile.Flush() } finally { $inputFile.Dispose() }
+try {
+` + windowsPowerShellCopyExactInput("$inputFile", *inputSize) + `	$inputFile.Flush($true)
+} finally { $inputFile.Dispose() }
 `
 		inputArgument = ` -RedirectStandardInput $inputPath`
 	}
@@ -911,14 +914,20 @@ $childSource = @'
 $ErrorActionPreference = "Stop"
 while (-not (Test-Path -LiteralPath '__START__')) { Start-Sleep -Milliseconds 50 }
 $payload = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('__PAYLOAD__'))
+$global:LASTEXITCODE = $null
 & ([ScriptBlock]::Create($payload))
-exit $LASTEXITCODE
+$payloadSucceeded = $?
+$payloadExitCode = $global:LASTEXITCODE
+if ($null -ne $payloadExitCode) { exit [int]$payloadExitCode }
+if (-not $payloadSucceeded) { exit 1 }
+exit 0
 '@
 $childSource = $childSource.Replace('__START__', $start.Replace("'", "''")).Replace('__PAYLOAD__', ` + psQuote(payload) + `)
 $childScript = Join-Path $runDir "child.ps1"
 [IO.File]::WriteAllText($childScript, $childSource, [Text.UTF8Encoding]::new($true))
 $childFileArg = '"' + $childScript + '"'
 $process = Start-Process -FilePath "powershell.exe" -ArgumentList @("-NoLogo", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", $childFileArg) -NoNewWindow -PassThru` + inputArgument + `
+$null = $process.Handle
 $identity = [string]$process.StartTime.ToUniversalTime().Ticks
 $gateStream = Enter-Gate
 if ($null -eq $gateStream) { Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue; throw "ambiguous owner gate" }

--- a/internal/cli/workspace_owner.go
+++ b/internal/cli/workspace_owner.go
@@ -92,6 +92,13 @@ type workspaceOwnerRemotePreparation struct {
 	name    string
 }
 
+const (
+	workspaceOwnerCleanupTimeout         = 30 * time.Second
+	workspaceOwnerCanceledCleanupTimeout = 5 * time.Second
+)
+
+type workspaceOwnerCleanupRunner func(context.Context, SSHTarget, string) error
+
 func prepareWorkspaceOwnerRemote(ctx context.Context, target SSHTarget, remote string, inputSize *int64) (workspaceOwnerRemotePreparation, error) {
 	owner := workspaceOwnerFromContext(ctx)
 	if owner == nil {
@@ -104,12 +111,24 @@ func prepareWorkspaceOwnerRemote(ctx context.Context, target SSHTarget, remote s
 }
 
 func (p workspaceOwnerRemotePreparation) close(ctx context.Context, target SSHTarget) error {
+	return p.closeWithRunner(ctx, target, runSSHQuiet)
+}
+
+func (p workspaceOwnerRemotePreparation) closeWithRunner(ctx context.Context, target SSHTarget, run workspaceOwnerCleanupRunner) error {
+	timeout := workspaceOwnerCleanupTimeout
+	if ctx.Err() != nil {
+		timeout = workspaceOwnerCanceledCleanupTimeout
+	}
+	return p.closeWithin(ctx, target, timeout, run)
+}
+
+func (p workspaceOwnerRemotePreparation) closeWithin(ctx context.Context, target SSHTarget, timeout time.Duration, run workspaceOwnerCleanupRunner) error {
 	if p.cleanup == "" {
 		return nil
 	}
-	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), timeout)
 	defer cancel()
-	return runSSHQuiet(contextWithoutWorkspaceOwner(cleanupCtx), target, p.cleanup)
+	return run(contextWithoutWorkspaceOwner(cleanupCtx), target, p.cleanup)
 }
 
 func stageWorkspaceOwnerWindowsWitness(ctx context.Context, target SSHTarget, owner *workspaceOwner, remote string, inputSize *int64, selfCleaning bool) (workspaceOwnerRemotePreparation, error) {
@@ -122,19 +141,22 @@ func stageWorkspaceOwnerWindowsWitness(ctx context.Context, target SSHTarget, ow
 	if selfCleaning {
 		script = remoteWorkspaceOwnerWindowsSelfCleaningWitness(name, script)
 	}
+	prepared := workspaceOwnerRemotePreparation{
+		command: remoteWorkspaceOwnerWindowsRunWitnessCommand(name),
+		cleanup: remoteWorkspaceOwnerWindowsCleanupWitnessCommand(name),
+		name:    name,
+	}
 	var output synchronizedBuffer
 	if err := runSSHInput(ctx, target, remoteWorkspaceOwnerWindowsStageWitnessCommand(owner.key, owner.token, name, int64(len([]byte(script)))), strings.NewReader(script), &output, &output); err != nil {
 		detail := trimFailureDetail(strings.TrimSpace(output.String()))
+		// The remote write may have succeeded even when its SSH result was lost.
+		_ = prepared.closeWithin(ctx, target, workspaceOwnerCanceledCleanupTimeout, runSSHQuiet)
 		if detail != "" {
 			return workspaceOwnerRemotePreparation{}, fmt.Errorf("stage native Windows workspace witness: %w: %s", err, detail)
 		}
 		return workspaceOwnerRemotePreparation{}, fmt.Errorf("stage native Windows workspace witness: %w", err)
 	}
-	return workspaceOwnerRemotePreparation{
-		command: remoteWorkspaceOwnerWindowsRunWitnessCommand(name),
-		cleanup: remoteWorkspaceOwnerWindowsCleanupWitnessCommand(name),
-		name:    name,
-	}, nil
+	return prepared, nil
 }
 
 func runWorkspaceOwnerBackgroundOutput(ctx context.Context, target SSHTarget, owner *workspaceOwner, remote string) (string, error) {

--- a/internal/cli/workspace_owner_test.go
+++ b/internal/cli/workspace_owner_test.go
@@ -617,6 +617,78 @@ func TestWorkspaceOwnerNativeWindowsProtocolKeepsOnlySuccessfulFallbackOutput(t 
 	}
 }
 
+func TestWorkspaceOwnerNativeWindowsAmbiguousStageCleansExactWitness(t *testing.T) {
+	dir := installWorkspaceOwnerRecordingSSH(t)
+	t.Setenv("CRABBOX_OWNER_SSH_FAIL_CALL", "1")
+	target := SSHTarget{User: "crabbox", Host: "127.0.0.1", Port: "22", FallbackPorts: []string{"2222"}, TargetOS: targetWindows, WindowsMode: windowsModeNormal}
+	owner := &workspaceOwner{target: target, key: workspaceOwnerKey("cbx_windows_ambiguous_stage"), token: strings.Repeat("8", 64)}
+	ctx := contextWithWorkspaceOwner(context.Background(), owner)
+	_, err := prepareWorkspaceOwnerRemote(ctx, target, "Write-Output ambiguous-stage", nil)
+	if err == nil || exitCode(err) != 7 || !strings.Contains(err.Error(), "stage native Windows workspace witness") {
+		t.Fatalf("ambiguous stage err=%v", err)
+	}
+
+	stageCommand, stagedScript := readWorkspaceOwnerSSHCall(t, dir, 1)
+	if !strings.Contains(stagedScript, base64.StdEncoding.EncodeToString([]byte("Write-Output ambiguous-stage"))) {
+		t.Fatal("staging failure did not follow a complete remote witness write")
+	}
+	stage := decodePowerShellCommand(t, stageCommand)
+	prefix := owner.key + ".witness." + owner.token + "."
+	start := strings.Index(stage, prefix)
+	if start < 0 {
+		t.Fatalf("stage command missing witness prefix %q", prefix)
+	}
+	end := strings.Index(stage[start:], ".ps1")
+	if end < 0 {
+		t.Fatalf("stage command missing witness suffix: %s", stage)
+	}
+	name := stage[start : start+end+len(".ps1")]
+	cleanupCommand, cleanupInput := readWorkspaceOwnerSSHCall(t, dir, 2)
+	if cleanupCommand != remoteWorkspaceOwnerWindowsCleanupWitnessCommand(name) || cleanupInput != "" {
+		t.Fatalf("cleanup command=%q stdin=%q want exact witness=%q", cleanupCommand, cleanupInput, name)
+	}
+	count, readErr := os.ReadFile(filepath.Join(dir, "count"))
+	if readErr != nil || string(count) != "2" {
+		t.Fatalf("SSH call count=%q err=%v; want one failed stage and one cleanup without fallback", count, readErr)
+	}
+}
+
+func TestWorkspaceOwnerCanceledCleanupUsesShortDetachedBudget(t *testing.T) {
+	parent, cancel := context.WithCancel(context.Background())
+	cancel()
+	prepared := workspaceOwnerRemotePreparation{cleanup: "cleanup", name: "witness.ps1"}
+	started := time.Now()
+	var observedBudget time.Duration
+	err := prepared.closeWithRunner(parent, SSHTarget{}, func(ctx context.Context, _ SSHTarget, command string) error {
+		if command != prepared.cleanup {
+			t.Fatalf("cleanup command=%q want %q", command, prepared.cleanup)
+		}
+		if ctx.Err() != nil {
+			t.Fatalf("cleanup inherited caller cancellation: %v", ctx.Err())
+		}
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			t.Fatal("cleanup context has no deadline")
+		}
+		observedBudget = time.Until(deadline)
+		<-ctx.Done()
+		return ctx.Err()
+	})
+	elapsed := time.Since(started)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("cleanup err=%v want deadline exceeded", err)
+	}
+	if observedBudget <= 0 || observedBudget > workspaceOwnerCanceledCleanupTimeout+250*time.Millisecond {
+		t.Fatalf("cleanup budget=%s want at most %s", observedBudget, workspaceOwnerCanceledCleanupTimeout)
+	}
+	if elapsed > workspaceOwnerCanceledCleanupTimeout+2*time.Second {
+		t.Fatalf("cancelled cleanup elapsed=%s exceeded short budget %s", elapsed, workspaceOwnerCanceledCleanupTimeout)
+	}
+	if observedBudget >= workspaceOwnerCleanupTimeout {
+		t.Fatalf("cancelled cleanup inherited normal timeout %s", workspaceOwnerCleanupTimeout)
+	}
+}
+
 func TestWorkspaceOwnerNativeWindowsWitnessStagesRawScriptAndPreservesInput(t *testing.T) {
 	dir := installWorkspaceOwnerRecordingSSH(t)
 	target := SSHTarget{User: "crabbox", Host: "127.0.0.1", Port: "22", TargetOS: targetWindows, WindowsMode: windowsModeNormal}

--- a/internal/cli/workspace_owner_test.go
+++ b/internal/cli/workspace_owner_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -342,19 +343,31 @@ func TestAcquiredRunMayRetainLease(t *testing.T) {
 func TestWorkspaceOwnerContextWrapsEverySSHChild(t *testing.T) {
 	owner := &workspaceOwner{target: SSHTarget{TargetOS: targetLinux}, key: strings.Repeat("a", 64), token: strings.Repeat("b", 64)}
 	ctx := contextWithWorkspaceOwner(context.Background(), owner)
-	if got, want := wrapWorkspaceOwnerRemote(ctx, "printf ok", false), remoteWorkspaceOwnerPOSIXWitness(owner.key, owner.token, "printf ok"); got != want {
+	prepared, err := prepareWorkspaceOwnerRemote(ctx, owner.target, "printf ok", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := prepared.command, remoteWorkspaceOwnerPOSIXWitness(owner.key, owner.token, "printf ok"); got != want {
 		t.Fatalf("ordinary SSH child was not witnessed:\n%s", got)
 	}
 	if script := remoteWorkspaceOwnerPOSIXWitnessScript(owner.key, owner.token, "printf ok"); !strings.Contains(script, "child_identity=$(ps -o lstart=") {
 		t.Fatalf("ordinary SSH child witness lost identity fencing:\n%s", script)
 	}
-	if got, want := wrapWorkspaceOwnerRemote(ctx, "cat", true), remoteWorkspaceOwnerPOSIXWitness(owner.key, owner.token, "cat", true); got != want {
+	prepared, err = prepareWorkspaceOwnerRemote(ctx, owner.target, "cat", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := prepared.command, remoteWorkspaceOwnerPOSIXWitness(owner.key, owner.token, "cat", true); got != want {
 		t.Fatalf("input SSH child did not preserve stdin:\n%s", got)
 	}
 	if script := remoteWorkspaceOwnerPOSIXWitnessScript(owner.key, owner.token, "cat", true); !strings.Contains(script, `cat >"$run_dir/input"`) || !strings.Contains(script, `<"$run_dir/input"`) {
 		t.Fatalf("input SSH child witness lost stdin preservation:\n%s", script)
 	}
-	if got := wrapWorkspaceOwnerRemote(contextWithoutWorkspaceOwner(ctx), "printf raw", false); got != "printf raw" {
+	prepared, err = prepareWorkspaceOwnerRemote(contextWithoutWorkspaceOwner(ctx), owner.target, "printf raw", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := prepared.command; got != "printf raw" {
 		t.Fatalf("owner bypass wrapped protocol-internal command: %q", got)
 	}
 }
@@ -446,7 +459,7 @@ func TestWorkspaceOwnerProtocolGeneration(t *testing.T) {
 		t.Fatalf("POSIX protocol exposed raw lease ID: %s", posix)
 	}
 
-	windows := decodePowerShellCommand(t, remoteWorkspaceOwnerCommand(SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeNormal}, req))
+	windows := remoteWorkspaceOwnerWindows(req)
 	for _, want := range []string{".crabbox\\workspace-owners", "$key = '" + key + "'", "$key + \".owner\"", "$key + \".child\"", "[Diagnostics.Process]::GetProcessById", "return \"ambiguous\"", "StartTime.ToUniversalTime().Ticks", "RECOVERED", "MISMATCH", "EXPIRED", "AMBIGUOUS", "$current.Expiry -le [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()"} {
 		if !strings.Contains(windows, want) {
 			t.Fatalf("Windows protocol missing %q:\n%s", want, windows)
@@ -465,17 +478,266 @@ func TestWorkspaceOwnerProtocolGeneration(t *testing.T) {
 			t.Fatalf("POSIX child witness missing %q:\n%s", want, posixWitness)
 		}
 	}
-	windowsWitness := decodePowerShellCommand(t, remoteWorkspaceOwnerWindowsWitness(key, token, "Write-Output ok"))
+	windowsWitness := remoteWorkspaceOwnerWindowsWitness(key, token, "Write-Output ok")
 	for _, want := range []string{"Start-Process", "StartTime.ToUniversalTime().Ticks", "Read-Expiry", "(Read-Expiry) -le [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()", "Move-Item -LiteralPath $tmp -Destination $child", "$process.WaitForExit()", "Remove-Item -LiteralPath $child"} {
 		if !strings.Contains(windowsWitness, want) {
 			t.Fatalf("Windows child witness missing %q:\n%s", want, windowsWitness)
 		}
 	}
-	windowsInputWitness := decodePowerShellCommand(t, remoteWorkspaceOwnerWindowsWitness(key, token, "Write-Output ok", true))
+	windowsInputWitness := remoteWorkspaceOwnerWindowsWitness(key, token, "Write-Output ok", true)
 	for _, want := range []string{"[Console]::OpenStandardInput().CopyTo($inputFile)", "-RedirectStandardInput $inputPath", "[IO.FileShare]::None"} {
 		if !strings.Contains(windowsInputWitness, want) {
 			t.Fatalf("Windows input witness missing %q:\n%s", want, windowsInputWitness)
 		}
+	}
+}
+
+func TestWorkspaceOwnerNativeWindowsCommandLengthBaseline(t *testing.T) {
+	key := workspaceOwnerKey("cbx_windows_command_length")
+	token := strings.Repeat("a", 64)
+	req := workspaceOwnerRemoteRequest{Action: workspaceOwnerAcquire, Key: key, Token: token, TTL: time.Minute}
+	acquire := remoteWorkspaceOwnerCommand(SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeNormal}, req)
+	name := key + ".witness." + token + "." + strings.Repeat("b", 32) + ".ps1"
+	commands := map[string]string{
+		"owner acquire":       acquire,
+		"large witness stage": remoteWorkspaceOwnerWindowsStageWitnessCommand(key, token, name),
+		"large witness run":   remoteWorkspaceOwnerWindowsRunWitnessCommand(name),
+		"witness cleanup":     remoteWorkspaceOwnerWindowsCleanupWitnessCommand(name),
+		"background witness":  remoteWorkspaceOwnerWindowsStartBackgroundWitnessCommand(name),
+	}
+	for label, command := range commands {
+		t.Logf("%s command length=%d", label, len(command))
+		if len(command) >= 8191 {
+			t.Fatalf("%s command length=%d exceeds cmd.exe limit", label, len(command))
+		}
+		if strings.Contains(command, strings.Repeat("Write-Output 'large witness'\n", 512)) {
+			t.Fatalf("%s embeds the large witness payload", label)
+		}
+	}
+}
+
+func installWorkspaceOwnerRecordingSSH(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	sshPath := filepath.Join(dir, "ssh")
+	script := `#!/bin/sh
+log_dir=$CRABBOX_OWNER_SSH_LOG_DIR
+count=0
+if [ -f "$log_dir/count" ]; then read count < "$log_dir/count"; fi
+count=$((count + 1))
+printf '%s' "$count" > "$log_dir/count"
+command=
+for arg do command=$arg; done
+printf '%s' "$command" > "$log_dir/$count.command"
+/bin/cat > "$log_dir/$count.stdin"
+if [ "${CRABBOX_OWNER_SSH_RETRY_CALL:-}" = "$count" ]; then printf 'failed port diagnostic\n' >&2; exit 255; fi
+if [ "${CRABBOX_OWNER_SSH_FAIL_CALL:-}" = "$count" ]; then exit 7; fi
+if /usr/bin/grep -Fq "\$action = 'acquire'" "$log_dir/$count.stdin"; then printf ACQUIRED; fi
+if /usr/bin/grep -Fq "\$action = 'renew'" "$log_dir/$count.stdin"; then printf RENEWED; fi
+if /usr/bin/grep -Fq "\$action = 'inspect'" "$log_dir/$count.stdin"; then printf OWNED; fi
+if /usr/bin/grep -Fq "\$action = 'release'" "$log_dir/$count.stdin"; then printf RELEASED; fi
+`
+	if err := os.WriteFile(sshPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CRABBOX_OWNER_SSH_LOG_DIR", dir)
+	return dir
+}
+
+func readWorkspaceOwnerSSHCall(t *testing.T, dir string, index int) (string, string) {
+	t.Helper()
+	command, err := os.ReadFile(filepath.Join(dir, strconv.Itoa(index)+".command"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	input, err := os.ReadFile(filepath.Join(dir, strconv.Itoa(index)+".stdin"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(command), string(input)
+}
+
+func TestWorkspaceOwnerNativeWindowsProtocolStreamsScriptsOverStdin(t *testing.T) {
+	dir := installWorkspaceOwnerRecordingSSH(t)
+	target := SSHTarget{User: "crabbox", Host: "127.0.0.1", Port: "22", TargetOS: targetWindows, WindowsMode: windowsModeNormal}
+	transport := sshWorkspaceOwnerTransport{target: target}
+	key := workspaceOwnerKey("cbx_windows_protocol_transport")
+	token := strings.Repeat("c", 64)
+	actions := []struct {
+		action workspaceOwnerAction
+		want   string
+	}{
+		{workspaceOwnerAcquire, "ACQUIRED"},
+		{workspaceOwnerRenew, "RENEWED"},
+		{workspaceOwnerInspect, "OWNED"},
+		{workspaceOwnerRelease, "RELEASED"},
+	}
+	for i, test := range actions {
+		got, err := transport.Do(context.Background(), workspaceOwnerRemoteRequest{Action: test.action, Key: key, Token: token, TTL: time.Minute})
+		if err != nil || got != test.want {
+			t.Fatalf("%s response=%q err=%v", test.action, got, err)
+		}
+		command, input := readWorkspaceOwnerSSHCall(t, dir, i+1)
+		if command != windowsPowerShellStdinScriptCommand() {
+			t.Fatalf("%s command=%q", test.action, command)
+		}
+		if len(command) >= 8191 {
+			t.Fatalf("%s command length=%d exceeds cmd.exe limit", test.action, len(command))
+		}
+		for _, want := range []string{"$action = " + psQuote(string(test.action)), "$key = " + psQuote(key), "$token = " + psQuote(token)} {
+			if !strings.Contains(input, want) {
+				t.Fatalf("%s stdin script missing %q", test.action, want)
+			}
+		}
+		if strings.Contains(command, "$action") || strings.Contains(command, key) || strings.Contains(command, token) {
+			t.Fatalf("%s script leaked into SSH command argv", test.action)
+		}
+	}
+}
+
+func TestWorkspaceOwnerNativeWindowsProtocolKeepsOnlySuccessfulFallbackOutput(t *testing.T) {
+	dir := installWorkspaceOwnerRecordingSSH(t)
+	t.Setenv("CRABBOX_OWNER_SSH_RETRY_CALL", "1")
+	target := SSHTarget{User: "crabbox", Host: "127.0.0.1", Port: "2222", FallbackPorts: []string{"22"}, TargetOS: targetWindows, WindowsMode: windowsModeNormal}
+	transport := sshWorkspaceOwnerTransport{target: target}
+	key := workspaceOwnerKey("cbx_windows_protocol_fallback")
+	token := strings.Repeat("7", 64)
+	got, err := transport.Do(context.Background(), workspaceOwnerRemoteRequest{Action: workspaceOwnerAcquire, Key: key, Token: token, TTL: time.Minute})
+	if err != nil || got != "ACQUIRED" {
+		t.Fatalf("fallback response=%q err=%v", got, err)
+	}
+	for _, index := range []int{1, 2} {
+		command, input := readWorkspaceOwnerSSHCall(t, dir, index)
+		if command != windowsPowerShellStdinScriptCommand() || !strings.Contains(input, "$action = 'acquire'") {
+			t.Fatalf("fallback attempt %d command=%q", index, command)
+		}
+	}
+}
+
+func TestWorkspaceOwnerNativeWindowsWitnessStagesRawScriptAndPreservesInput(t *testing.T) {
+	dir := installWorkspaceOwnerRecordingSSH(t)
+	target := SSHTarget{User: "crabbox", Host: "127.0.0.1", Port: "22", TargetOS: targetWindows, WindowsMode: windowsModeNormal}
+	owner := &workspaceOwner{target: target, key: workspaceOwnerKey("cbx_windows_witness_transport"), token: strings.Repeat("d", 64)}
+	ctx := contextWithWorkspaceOwner(context.Background(), owner)
+	payload := strings.Repeat("Write-Output 'large witness'\n", 512)
+	userInput := "preserved user stdin\n"
+	if err := runSSHInput(ctx, target, payload, strings.NewReader(userInput), io.Discard, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+
+	stageCommand, stagedScript := readWorkspaceOwnerSSHCall(t, dir, 1)
+	stage := decodePowerShellCommand(t, stageCommand)
+	for _, want := range []string{"[IO.FileMode]::CreateNew", "[IO.FileShare]::None", "OpenStandardInput().CopyTo($stream)", owner.key, owner.token} {
+		if !strings.Contains(stage, want) {
+			t.Fatalf("stage command missing %q", want)
+		}
+	}
+	encodedPayload := base64.StdEncoding.EncodeToString([]byte(payload))
+	if !strings.Contains(stagedScript, encodedPayload) {
+		t.Fatal("raw staged witness omitted the large remote payload")
+	}
+	for _, want := range []string{"$childScript = Join-Path $runDir \"child.ps1\"", "-File", "Remove-Item -LiteralPath $runDir"} {
+		if !strings.Contains(stagedScript, want) {
+			t.Fatalf("staged witness missing %q", want)
+		}
+	}
+	if strings.Contains(stagedScript, "-EncodedCommand") {
+		t.Fatal("staged witness still launches its child through EncodedCommand")
+	}
+
+	runCommand, runInput := readWorkspaceOwnerSSHCall(t, dir, 2)
+	run := decodePowerShellCommand(t, runCommand)
+	for _, want := range []string{"& powershell.exe", "-File $path", "finally", "Remove-Item -LiteralPath $path"} {
+		if !strings.Contains(run, want) {
+			t.Fatalf("run command missing %q", want)
+		}
+	}
+	if runInput != userInput {
+		t.Fatalf("witnessed command stdin=%q want=%q", runInput, userInput)
+	}
+
+	count, err := os.ReadFile(filepath.Join(dir, "count"))
+	if err != nil || string(count) != "2" {
+		t.Fatalf("SSH call count=%q err=%v; successful self-cleaning run must not open a cleanup connection", count, err)
+	}
+	for label, command := range map[string]string{"stage": stageCommand, "run": runCommand} {
+		if len(command) >= 8191 {
+			t.Fatalf("%s command length=%d exceeds cmd.exe limit", label, len(command))
+		}
+		if strings.Contains(command, payload) {
+			t.Fatalf("%s command embeds the large witness payload", label)
+		}
+	}
+}
+
+func TestWorkspaceOwnerNativeWindowsWitnessFallsBackToCleanupAfterFailure(t *testing.T) {
+	dir := installWorkspaceOwnerRecordingSSH(t)
+	t.Setenv("CRABBOX_OWNER_SSH_FAIL_CALL", "2")
+	target := SSHTarget{User: "crabbox", Host: "127.0.0.1", Port: "22", TargetOS: targetWindows, WindowsMode: windowsModeNormal}
+	owner := &workspaceOwner{target: target, key: workspaceOwnerKey("cbx_windows_witness_cleanup"), token: strings.Repeat("9", 64)}
+	ctx := contextWithWorkspaceOwner(context.Background(), owner)
+	if err := runSSHInput(ctx, target, "Write-Output fail", strings.NewReader("input"), io.Discard, io.Discard); err == nil {
+		t.Fatal("failed witnessed command returned success")
+	}
+	cleanupCommand, cleanupInput := readWorkspaceOwnerSSHCall(t, dir, 3)
+	cleanup := decodePowerShellCommand(t, cleanupCommand)
+	if !strings.Contains(cleanup, "Remove-Item -LiteralPath $path") || cleanupInput != "" {
+		t.Fatalf("fallback cleanup command=%q stdin=%q", cleanup, cleanupInput)
+	}
+}
+
+func TestWorkspaceOwnerNativeWindowsBackgroundWitnessStagesSelfCleaningScript(t *testing.T) {
+	dir := installWorkspaceOwnerRecordingSSH(t)
+	target := SSHTarget{User: "crabbox", Host: "127.0.0.1", Port: "22", TargetOS: targetWindows, WindowsMode: windowsModeNormal}
+	owner := &workspaceOwner{target: target, key: workspaceOwnerKey("cbx_windows_background_transport"), token: strings.Repeat("e", 64)}
+	payload := strings.Repeat("Write-Output background\n", 512)
+	if _, err := runWorkspaceOwnerBackgroundOutput(context.Background(), target, owner, payload); err != nil {
+		t.Fatal(err)
+	}
+	_, stagedScript := readWorkspaceOwnerSSHCall(t, dir, 1)
+	if !strings.Contains(stagedScript, base64.StdEncoding.EncodeToString([]byte(payload))) || !strings.Contains(stagedScript, "$selfPath") || !strings.Contains(stagedScript, "finally") {
+		t.Fatal("background witness was not staged with self-cleanup")
+	}
+	backgroundCommand, backgroundInput := readWorkspaceOwnerSSHCall(t, dir, 2)
+	background := decodePowerShellCommand(t, backgroundCommand)
+	for _, want := range []string{"Start-Process", "-File", "-WindowStyle Hidden", "Write-Output $process.Id"} {
+		if !strings.Contains(background, want) {
+			t.Fatalf("background command missing %q", want)
+		}
+	}
+	if backgroundInput != "" || len(backgroundCommand) >= 8191 || strings.Contains(backgroundCommand, payload) {
+		t.Fatalf("background command length=%d stdin=%q", len(backgroundCommand), backgroundInput)
+	}
+}
+
+func TestWorkspaceOwnerNativeWindowsStreamPathsUseStagedWitnesses(t *testing.T) {
+	dir := installWorkspaceOwnerRecordingSSH(t)
+	target := SSHTarget{User: "crabbox", Host: "127.0.0.1", Port: "22", TargetOS: targetWindows, WindowsMode: windowsModeNormal}
+	owner := &workspaceOwner{target: target, key: workspaceOwnerKey("cbx_windows_stream_transport"), token: strings.Repeat("f", 64)}
+	ctx := contextWithWorkspaceOwner(context.Background(), owner)
+	payload := strings.Repeat("Write-Output stream\n", 512)
+	if code, err := runSSHStreamResult(ctx, target, payload, io.Discard, io.Discard); err != nil || code != 0 {
+		t.Fatalf("output stream code=%d err=%v", code, err)
+	}
+	streamInput := "streamed user input\n"
+	if err := runSSHInputStream(ctx, target, payload, strings.NewReader(streamInput), io.Discard, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	for _, index := range []int{1, 3} {
+		stageCommand, stagedScript := readWorkspaceOwnerSSHCall(t, dir, index)
+		if len(stageCommand) >= 8191 || !strings.Contains(stagedScript, base64.StdEncoding.EncodeToString([]byte(payload))) {
+			t.Fatalf("stream stage %d command length=%d", index, len(stageCommand))
+		}
+	}
+	_, noInput := readWorkspaceOwnerSSHCall(t, dir, 2)
+	_, preservedInput := readWorkspaceOwnerSSHCall(t, dir, 4)
+	if noInput != "" || preservedInput != streamInput {
+		t.Fatalf("stream inputs output=%q input=%q", noInput, preservedInput)
+	}
+	count, err := os.ReadFile(filepath.Join(dir, "count"))
+	if err != nil || string(count) != "4" {
+		t.Fatalf("SSH call count=%q err=%v; staging must bypass owner recursion", count, err)
 	}
 }
 
@@ -808,7 +1070,7 @@ func TestWorkspaceOwnerPOSIXProtocolBehavior(t *testing.T) {
 		t.Fatal(err)
 	}
 	guardOwner := &workspaceOwner{target: SSHTarget{TargetOS: targetLinux}, key: key, token: tokenA}
-	if out, err := runPOSIXWorkspaceOwnerScript(t, home, guardOwner.WrapBackgroundCommand(guardOwner.rsyncGuardPayload(filepath.Join(home, "guard-destination")))); err != nil || strings.TrimSpace(out) == "" {
+	if out, err := runPOSIXWorkspaceOwnerScript(t, home, guardOwner.wrapPOSIXBackgroundCommand(guardOwner.rsyncGuardPayload(filepath.Join(home, "guard-destination")))); err != nil || strings.TrimSpace(out) == "" {
 		t.Fatalf("start rsync guard out=%q err=%v", out, err)
 	}
 	deadline := time.Now().Add(3 * time.Second)
@@ -896,7 +1158,7 @@ Set-Content -LiteralPath (Join-Path $root (` + psQuote(key) + ` + ".gate")) -Val
 		t.Fatalf("prepare abandoned Windows gate out=%q err=%v", out, err)
 	}
 	req := workspaceOwnerRemoteRequest{Action: workspaceOwnerAcquire, Key: key, Token: token, TTL: 30 * time.Second}
-	if out, err := runWindowsPowerShellScript(t, decodePowerShellCommand(t, remoteWorkspaceOwnerWindows(req))); err != nil || !strings.Contains(string(out), "ACQUIRED") {
+	if out, err := runWindowsPowerShellScript(t, remoteWorkspaceOwnerWindows(req)); err != nil || !strings.Contains(string(out), "ACQUIRED") {
 		t.Fatalf("Windows acquire out=%q err=%v", out, err)
 	}
 	expire := `$root = Join-Path $HOME ".crabbox\workspace-owners"
@@ -907,14 +1169,14 @@ Set-Content -LiteralPath $state -Value @("v1", ` + psQuote(token) + `, "1") -Enc
 		t.Fatalf("expire Windows owner state out=%q err=%v", out, err)
 	}
 	req.Action = workspaceOwnerRenew
-	if out, err := runWindowsPowerShellScript(t, decodePowerShellCommand(t, remoteWorkspaceOwnerWindows(req))); err == nil || !strings.Contains(string(out), "EXPIRED") {
+	if out, err := runWindowsPowerShellScript(t, remoteWorkspaceOwnerWindows(req)); err == nil || !strings.Contains(string(out), "EXPIRED") {
 		t.Fatalf("late Windows renew out=%q err=%v", out, err)
 	}
 	req.Action = workspaceOwnerInspect
-	if out, err := runWindowsPowerShellScript(t, decodePowerShellCommand(t, remoteWorkspaceOwnerWindows(req))); err == nil || !strings.Contains(string(out), "EXPIRED") {
+	if out, err := runWindowsPowerShellScript(t, remoteWorkspaceOwnerWindows(req)); err == nil || !strings.Contains(string(out), "EXPIRED") {
 		t.Fatalf("late Windows inspect out=%q err=%v", out, err)
 	}
-	if out, err := runWindowsPowerShellScript(t, decodePowerShellCommand(t, remoteWorkspaceOwnerWindowsWitness(key, token, "Write-Output late-child"))); err == nil || strings.Contains(string(out), "late-child") {
+	if out, err := runWindowsPowerShellScript(t, remoteWorkspaceOwnerWindowsWitness(key, token, "Write-Output late-child")); err == nil || strings.Contains(string(out), "late-child") {
 		t.Fatalf("late Windows witness executed: out=%q err=%v", out, err)
 	}
 	verifyExpired := `$root = Join-Path $HOME ".crabbox\workspace-owners"
@@ -928,14 +1190,14 @@ if (Test-Path -LiteralPath $child) { throw "late witness published child" }
 		t.Fatalf("verify expired Windows generation out=%q err=%v", out, err)
 	}
 	req.Action = workspaceOwnerAcquire
-	if out, err := runWindowsPowerShellScript(t, decodePowerShellCommand(t, remoteWorkspaceOwnerWindows(req))); err != nil || !strings.Contains(string(out), "RECOVERED") {
+	if out, err := runWindowsPowerShellScript(t, remoteWorkspaceOwnerWindows(req)); err != nil || !strings.Contains(string(out), "RECOVERED") {
 		t.Fatalf("recover expired Windows generation out=%q err=%v", out, err)
 	}
-	if out, err := runWindowsPowerShellScript(t, decodePowerShellCommand(t, remoteWorkspaceOwnerWindowsWitness(key, token, "Write-Output child-ok"))); err != nil || !strings.Contains(string(out), "child-ok") {
+	if out, err := runWindowsPowerShellScript(t, remoteWorkspaceOwnerWindowsWitness(key, token, "Write-Output child-ok")); err != nil || !strings.Contains(string(out), "child-ok") {
 		t.Fatalf("Windows witnessed child out=%q err=%v", out, err)
 	}
 	req.Action = workspaceOwnerRelease
-	if out, err := runWindowsPowerShellScript(t, decodePowerShellCommand(t, remoteWorkspaceOwnerWindows(req))); err != nil || !strings.Contains(string(out), "RELEASED") {
+	if out, err := runWindowsPowerShellScript(t, remoteWorkspaceOwnerWindows(req)); err != nil || !strings.Contains(string(out), "RELEASED") {
 		t.Fatalf("Windows release out=%q err=%v", out, err)
 	}
 }

--- a/internal/cli/workspace_owner_test.go
+++ b/internal/cli/workspace_owner_test.go
@@ -343,7 +343,7 @@ func TestAcquiredRunMayRetainLease(t *testing.T) {
 func TestWorkspaceOwnerContextWrapsEverySSHChild(t *testing.T) {
 	owner := &workspaceOwner{target: SSHTarget{TargetOS: targetLinux}, key: strings.Repeat("a", 64), token: strings.Repeat("b", 64)}
 	ctx := contextWithWorkspaceOwner(context.Background(), owner)
-	prepared, err := prepareWorkspaceOwnerRemote(ctx, owner.target, "printf ok", false)
+	prepared, err := prepareWorkspaceOwnerRemote(ctx, owner.target, "printf ok", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -353,7 +353,8 @@ func TestWorkspaceOwnerContextWrapsEverySSHChild(t *testing.T) {
 	if script := remoteWorkspaceOwnerPOSIXWitnessScript(owner.key, owner.token, "printf ok"); !strings.Contains(script, "child_identity=$(ps -o lstart=") {
 		t.Fatalf("ordinary SSH child witness lost identity fencing:\n%s", script)
 	}
-	prepared, err = prepareWorkspaceOwnerRemote(ctx, owner.target, "cat", true)
+	inputSize := int64(0)
+	prepared, err = prepareWorkspaceOwnerRemote(ctx, owner.target, "cat", &inputSize)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -363,7 +364,7 @@ func TestWorkspaceOwnerContextWrapsEverySSHChild(t *testing.T) {
 	if script := remoteWorkspaceOwnerPOSIXWitnessScript(owner.key, owner.token, "cat", true); !strings.Contains(script, `cat >"$run_dir/input"`) || !strings.Contains(script, `<"$run_dir/input"`) {
 		t.Fatalf("input SSH child witness lost stdin preservation:\n%s", script)
 	}
-	prepared, err = prepareWorkspaceOwnerRemote(contextWithoutWorkspaceOwner(ctx), owner.target, "printf raw", false)
+	prepared, err = prepareWorkspaceOwnerRemote(contextWithoutWorkspaceOwner(ctx), owner.target, "printf raw", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -478,14 +479,15 @@ func TestWorkspaceOwnerProtocolGeneration(t *testing.T) {
 			t.Fatalf("POSIX child witness missing %q:\n%s", want, posixWitness)
 		}
 	}
-	windowsWitness := remoteWorkspaceOwnerWindowsWitness(key, token, "Write-Output ok")
-	for _, want := range []string{"Start-Process", "StartTime.ToUniversalTime().Ticks", "Read-Expiry", "(Read-Expiry) -le [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()", "Move-Item -LiteralPath $tmp -Destination $child", "$process.WaitForExit()", "Remove-Item -LiteralPath $child"} {
+	windowsWitness := remoteWorkspaceOwnerWindowsWitness(key, token, "Write-Output ok", nil)
+	for _, want := range []string{"Start-Process", "$null = $process.Handle", "StartTime.ToUniversalTime().Ticks", "Read-Expiry", "(Read-Expiry) -le [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()", "Move-Item -LiteralPath $tmp -Destination $child", "$payloadExitCode = $global:LASTEXITCODE", "if (-not $payloadSucceeded) { exit 1 }", "$process.WaitForExit()", "Remove-Item -LiteralPath $child"} {
 		if !strings.Contains(windowsWitness, want) {
 			t.Fatalf("Windows child witness missing %q:\n%s", want, windowsWitness)
 		}
 	}
-	windowsInputWitness := remoteWorkspaceOwnerWindowsWitness(key, token, "Write-Output ok", true)
-	for _, want := range []string{"[Console]::OpenStandardInput().CopyTo($inputFile)", "-RedirectStandardInput $inputPath", "[IO.FileShare]::None"} {
+	windowsInputSize := int64(len("input"))
+	windowsInputWitness := remoteWorkspaceOwnerWindowsWitness(key, token, "Write-Output ok", &windowsInputSize)
+	for _, want := range []string{"$remaining = [Int64]5", "$stdin.Read($buffer, 0, $readSize)", "-RedirectStandardInput $inputPath", "[IO.FileShare]::None"} {
 		if !strings.Contains(windowsInputWitness, want) {
 			t.Fatalf("Windows input witness missing %q:\n%s", want, windowsInputWitness)
 		}
@@ -500,7 +502,7 @@ func TestWorkspaceOwnerNativeWindowsCommandLengthBaseline(t *testing.T) {
 	name := key + ".witness." + token + "." + strings.Repeat("b", 32) + ".ps1"
 	commands := map[string]string{
 		"owner acquire":       acquire,
-		"large witness stage": remoteWorkspaceOwnerWindowsStageWitnessCommand(key, token, name),
+		"large witness stage": remoteWorkspaceOwnerWindowsStageWitnessCommand(key, token, name, 20_000),
 		"large witness run":   remoteWorkspaceOwnerWindowsRunWitnessCommand(name),
 		"witness cleanup":     remoteWorkspaceOwnerWindowsCleanupWitnessCommand(name),
 		"background witness":  remoteWorkspaceOwnerWindowsStartBackgroundWitnessCommand(name),
@@ -579,7 +581,7 @@ func TestWorkspaceOwnerNativeWindowsProtocolStreamsScriptsOverStdin(t *testing.T
 			t.Fatalf("%s response=%q err=%v", test.action, got, err)
 		}
 		command, input := readWorkspaceOwnerSSHCall(t, dir, i+1)
-		if command != windowsPowerShellStdinScriptCommand() {
+		if command != windowsPowerShellStdinScriptCommand(len([]byte(input))) {
 			t.Fatalf("%s command=%q", test.action, command)
 		}
 		if len(command) >= 8191 {
@@ -609,7 +611,7 @@ func TestWorkspaceOwnerNativeWindowsProtocolKeepsOnlySuccessfulFallbackOutput(t 
 	}
 	for _, index := range []int{1, 2} {
 		command, input := readWorkspaceOwnerSSHCall(t, dir, index)
-		if command != windowsPowerShellStdinScriptCommand() || !strings.Contains(input, "$action = 'acquire'") {
+		if command != windowsPowerShellStdinScriptCommand(len([]byte(input))) || !strings.Contains(input, "$action = 'acquire'") {
 			t.Fatalf("fallback attempt %d command=%q", index, command)
 		}
 	}
@@ -628,7 +630,7 @@ func TestWorkspaceOwnerNativeWindowsWitnessStagesRawScriptAndPreservesInput(t *t
 
 	stageCommand, stagedScript := readWorkspaceOwnerSSHCall(t, dir, 1)
 	stage := decodePowerShellCommand(t, stageCommand)
-	for _, want := range []string{"[IO.FileMode]::CreateNew", "[IO.FileShare]::None", "OpenStandardInput().CopyTo($stream)", owner.key, owner.token} {
+	for _, want := range []string{"[IO.FileMode]::CreateNew", "[IO.FileShare]::None", "$stdin.Read($buffer, 0, $readSize)", "staged workspace witness length is ambiguous", owner.key, owner.token} {
 		if !strings.Contains(stage, want) {
 			t.Fatalf("stage command missing %q", want)
 		}
@@ -1176,7 +1178,7 @@ Set-Content -LiteralPath $state -Value @("v1", ` + psQuote(token) + `, "1") -Enc
 	if out, err := runWindowsPowerShellScript(t, remoteWorkspaceOwnerWindows(req)); err == nil || !strings.Contains(string(out), "EXPIRED") {
 		t.Fatalf("late Windows inspect out=%q err=%v", out, err)
 	}
-	if out, err := runWindowsPowerShellScript(t, remoteWorkspaceOwnerWindowsWitness(key, token, "Write-Output late-child")); err == nil || strings.Contains(string(out), "late-child") {
+	if out, err := runWindowsPowerShellScript(t, remoteWorkspaceOwnerWindowsWitness(key, token, "Write-Output late-child", nil)); err == nil || strings.Contains(string(out), "late-child") {
 		t.Fatalf("late Windows witness executed: out=%q err=%v", out, err)
 	}
 	verifyExpired := `$root = Join-Path $HOME ".crabbox\workspace-owners"
@@ -1193,8 +1195,11 @@ if (Test-Path -LiteralPath $child) { throw "late witness published child" }
 	if out, err := runWindowsPowerShellScript(t, remoteWorkspaceOwnerWindows(req)); err != nil || !strings.Contains(string(out), "RECOVERED") {
 		t.Fatalf("recover expired Windows generation out=%q err=%v", out, err)
 	}
-	if out, err := runWindowsPowerShellScript(t, remoteWorkspaceOwnerWindowsWitness(key, token, "Write-Output child-ok")); err != nil || !strings.Contains(string(out), "child-ok") {
+	if out, err := runWindowsPowerShellScript(t, remoteWorkspaceOwnerWindowsWitness(key, token, "Write-Output child-ok", nil)); err != nil || !strings.Contains(string(out), "child-ok") {
 		t.Fatalf("Windows witnessed child out=%q err=%v", out, err)
+	}
+	if out, err := runWindowsPowerShellScript(t, remoteWorkspaceOwnerWindowsWitness(key, token, "exit 23", nil)); err == nil || exitCode(err) != 23 {
+		t.Fatalf("Windows nonzero witnessed child out=%q err=%v", out, err)
 	}
 	req.Action = workspaceOwnerRelease
 	if out, err := runWindowsPowerShellScript(t, remoteWorkspaceOwnerWindows(req)); err != nil || !strings.Contains(string(out), "RELEASED") {


### PR DESCRIPTION
## Summary

- replace oversized native-Windows workspace-owner command lines with a short PowerShell launcher and exact length-framed stdin
- stage owner-witnessed scripts without relying on OpenSSH stdin EOF, preserve workload stdin and native exit status, and clean temporary process/gate files
- clean the exact witness after ambiguous staging outcomes and use a short detached cleanup budget when the caller is already cancelled
- bound cancelled SSH pipe draining so failed Windows commands return instead of hanging in local process cleanup

Closes https://github.com/openclaw/crabbox/issues/1360

## Root cause

Native Windows OpenSSH enters through a `cmd.exe` hop, so the generated encoded workspace-owner command exceeded the practical command-line limit. Streaming the same script with EOF-dependent PowerShell reads was also unsafe on this boundary: EOF was not reliably delivered, which left zero or partial staging files and could keep the local process waiting on inherited SSH pipes. The witnessed child additionally needed its process handle opened before execution so PowerShell retained the real exit code.

The transport now frames each script and preserved-input segment with its exact byte length. Windows PowerShell reads those bounded segments directly, while Linux and WSL retain their existing command paths. Ambiguous staging failures perform best-effort cleanup of the exact generated witness without replacing the original error, and cancellation uses a five-second detached cleanup budget rather than the ordinary thirty-second budget.

## Verification

- `go test -race ./... -count=1`
- focused native-Windows owner, SSH framing, stdin, failure-cleanup, cancellation, desktop, and Actions tests
- `go vet ./...`
- Windows amd64 test-binary cross-compile
- `gofmt` and `git diff --check`
- P1 autoreview clean against current `main`
- independent follow-up review clean after both cleanup findings were corrected
- real retained brokered AWS native-Windows behavior proof

Live native-Windows behavior on disposable lease `cbx_a4a414a4f68a`:

1. `run_1784207c688f` acquired ownership, printed `CRABBOX_OWNER_TRANSPORT_OK`, released ownership, and exited 0.
2. `run_9d8fee584cec` preserved a 512-line `--script-stdin` payload, printed `CRABBOX_OWNER_STDIN_OK`, released ownership, and exited 0.
3. `run_aeda63209abd` printed `CRABBOX_OWNER_EXPECTED_FAILURE`, completed the owner-wrapped command in 9.497 seconds, returned exit 23, and released ownership. The longer outer CLI wall time contained recorded coordinator event-write timeouts rather than workspace-owner cleanup.
4. `run_e62e8cfb6c01` found zero stale owner/staging/child/gate artifacts or processes after failure.
5. `run_55b7cc3de151` subsequently reacquired ownership, printed `CRABBOX_OWNER_RECOVERY_OK`, released ownership, and exited 0.
6. `run_7126778d5383` found zero final residue.

The proof lease was released afterward and provider inventory returned no matching resources.
