### PR TITLE
docs: clarify portable work root

### DIFF
--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -33,6 +33,29 @@ The trailing command after `--` is sent to the box verbatim as argv. Use
 `--shell` to run it through the remote shell instead, for multi-statement
 snippets, pipes, or shell expansion.
 
+## Remote workspace root
+
+Use `CRABBOX_WORK_ROOT` to change the portable base root for one run without
+selecting a provider-specific flag:
+
+```sh
+CRABBOX_WORK_ROOT=/srv/crabbox \
+  crabbox run --provider "$PROVIDER" -- pnpm test
+```
+
+This changes the base root, not the command's exact working directory. A normal
+SSH-backed run derives `<root>/<lease>/<repository>`, syncs the checkout there,
+and uses that derived repository workspace as the command PWD. There is no
+provider-neutral exact-chdir flag; provider adapters and hydration own their
+workspace semantics.
+
+An explicitly configured provider-specific work root or workdir takes
+precedence over the generic root. If the lease has a valid GitHub Actions
+hydration marker, its canonical `WORKSPACE` takes precedence over both roots
+for sync and command execution. See [Configuration](../features/configuration.md#work-roots)
+for configuration precedence and [Sync](../features/sync.md#remote-workspace-path)
+for path resolution.
+
 ## Leasing model
 
 If `--id` is omitted, Crabbox creates a fresh, non-kept lease and releases it

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -108,6 +108,7 @@ class: beast             # standard | fast | large | beast
 serverType: c7a.48xlarge # explicit provider type; overrides class fallback
 network: auto            # auto | tailscale | public
 hostId: h-0123456789abcdef0 # brokered use requires admin authentication
+workRoot: /srv/crabbox   # portable base root; not an exact command PWD
 
 lease:
   idleTimeout: 30m
@@ -126,6 +127,39 @@ invokes provider deletion. `CRABBOX_COORDINATOR_MODE` and
 default class is `beast`, the default TTL is `90m`, and the default idle
 timeout is `30m`. Setting `serverType` (or `--type` on the command line) pins
 that exact provider type and disables class fallback.
+
+### Work roots
+
+Top-level `workRoot` is the provider-neutral base for remote workspaces.
+`CRABBOX_WORK_ROOT` overrides that generic value for the current process, so a
+portable one-run override is:
+
+```sh
+CRABBOX_WORK_ROOT=/srv/crabbox \
+  crabbox run --provider "$PROVIDER" -- pnpm test
+```
+
+For a normal SSH-backed run, Crabbox appends the lease and repository names and
+uses `<root>/<lease>/<repository>` for sync and command execution. The generic
+value therefore does not request an exact remote `chdir`. Delegated adapters
+may own an exact workdir instead, and a valid Actions hydration marker owns the
+canonical workspace used by subsequent syncs and commands.
+
+Root selection has two levels of precedence:
+
+1. For one setting, the normal source order remains flags, environment,
+   repo-local config, user config, then defaults.
+2. After provider routing, an explicitly configured provider-specific work-root
+   or workdir setting is more specific than top-level `workRoot` or
+   `CRABBOX_WORK_ROOT`. If no provider-specific value is explicit, providers
+   that support the generic root inherit it. Provider validation and path
+   translation still apply.
+
+For example, `localContainer.workRoot`,
+`CRABBOX_LOCAL_CONTAINER_WORK_ROOT`, or `--local-container-work-root` wins over
+the generic root. Within that provider-specific setting, the normal source
+order above decides the value. Use `crabbox config show` to inspect the resolved
+root before starting a lease.
 
 ### Profiles and presets
 

--- a/docs/features/sync.md
+++ b/docs/features/sync.md
@@ -12,6 +12,24 @@ own their own file transfer and reject the local sync options. Native Windows
 targets use the same file list but ship it as a tar archive over OpenSSH instead
 of rsync.
 
+## Remote workspace path
+
+For normal SSH-backed runs, sync starts from the effective work root and derives
+the repository workspace as `<root>/<lease>/<repository>`. Top-level
+`workRoot` and `CRABBOX_WORK_ROOT` change only `<root>`; they do not name the
+exact sync target or command working directory. An explicitly configured
+provider-specific work root or workdir takes precedence over the generic root
+and remains subject to that adapter's validation and path translation.
+
+Actions hydration has final authority over the exact workspace. When a lease
+has a valid hydration marker, Crabbox uses the marker's canonical `WORKSPACE`
+for both sync and command execution instead of the base-derived candidate.
+Changing `CRABBOX_WORK_ROOT` does not relocate an already adopted Actions
+workspace. Local automatic hydration uses the canonical lease workspace it
+derived before writing the marker; `--full-resync` refuses a noncanonical
+adopted workspace when it cannot safely rebuild that path. See
+[Actions hydration](actions-hydration.md) for the marker lifecycle.
+
 ## What gets synced
 
 Sync transfers the Git-managed working set, not the whole directory tree. The


### PR DESCRIPTION
## Summary

- document `CRABBOX_WORK_ROOT` as the provider-neutral one-run base-root override
- clarify that ordinary SSH-backed runs derive `<root>/<lease>/<repository>` rather than treating the value as an exact command directory
- document provider-specific root precedence and Actions hydration's canonical workspace precedence

Crabbox intentionally does not add a unified `--workdir` alias: that name would imply an exact remote `chdir` while workspace placement remains owned by provider adapters and hydration.

Closes https://github.com/openclaw/crabbox/issues/1269

## Verification

- `scripts/check-docs.sh`
- focused work-root, provider-precedence, and Actions-hydration Go tests
- Go formatting check
- `git diff --check`
- P1 autoreview clean
