### PR TITLE
fix(local-container): honor native architecture assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Rejected native Jujutsu and other unsupported local sync sources before delegated archive providers can provision or execute a remote sandbox.
+- Accepted explicit local-container architecture assertions only when the selected Docker or Podman daemon reports a matching native architecture, without enabling emulation. Thanks @coygeek.
 - Omitted coordinator-only history commands from failure digests when run history is unavailable, while preserving direct lease recovery guidance.
 - Bypassed reusable-workspace ownership for fresh non-retained local-container runs while preserving ownership for retained and reused leases.
 - Framed workspace-owner scripts outside native Windows SSH command arguments so retained runs avoid `cmd.exe` limits, preserve finite stdin and nonzero exits, and clean up promptly.

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -611,7 +611,7 @@ lease-acting commands):
 --provider <name>            See `crabbox providers` for the full list.
 --profile <name>
 --class <name>
---arch amd64|arm64           CPU architecture; arm64 supports Linux on AWS/Azure/Apple Container and native Windows on Azure.
+--arch amd64|arm64           CPU architecture; cloud/Apple select capacity, while local-container asserts selected-daemon native architecture.
 --os <selector>              Portable Linux OS image, e.g. ubuntu:26.04
 --type <provider-type>
 --market spot|on-demand

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -1131,8 +1131,11 @@ they fail loud if the provider rejects the type.
 
 Set `architecture: arm64` (or `--arch arm64`) for Linux ARM capacity on AWS or
 Azure. Apple Container defaults to native ARM64 and also accepts explicit ARM64
-or AMD64 guest selection. Explicit ARM cloud provider types select matching ARM
-Linux images when no provider-specific image override is set.
+or AMD64 guest selection. Local Container treats explicit `amd64` or `arm64` as
+an assertion about the selected Docker/Podman daemon's native architecture,
+including remote contexts; it does not add `--platform` or enable emulation.
+Explicit ARM cloud provider types select matching ARM Linux images when no
+provider-specific image override is set.
 
 ## Environment variables
 

--- a/docs/providers/local-container.md
+++ b/docs/providers/local-container.md
@@ -87,6 +87,15 @@ When `runtime` is unset or left at `docker`, Crabbox detects an installed
 container CLI. If both `docker` and `podman` are available, `docker` is selected
 unless `runtime` is set explicitly.
 
+An explicit `--arch amd64|arm64` is a native-architecture assertion against the
+selected Docker daemon or Podman service, including a named remote context or
+connection. Crabbox normalizes `x86_64` to `amd64` and `aarch64` to `arm64`,
+continues only when the daemon matches, and reports the normalized architecture
+in `--preflight` output. A mismatch or unrecognized daemon response fails before
+container creation. Crabbox never adds `--platform` or opts into emulation for
+this assertion. When `--arch` is omitted, the runtime keeps its existing native
+behavior without an added architecture guarantee or probe.
+
 ### Memory-failure evidence
 
 For every user command, Local Container reads the container cgroup OOM-kill
@@ -154,7 +163,9 @@ host paths are machine-specific and benefit from invocation-time review.
 For runtimes that use Docker contexts or Docker-compatible API sockets, the
 active socket is selected from `DOCKER_HOST` or the Docker context when socket
 pass-through is enabled. Remote TCP contexts are not the intended path because
-Crabbox connects to the published SSH port from the local machine.
+Crabbox connects to the published SSH port from the local machine. Architecture
+assertions still describe the selected daemon, not the machine running the
+Crabbox CLI.
 
 ### Socket pass-through
 

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -38,6 +38,12 @@ type ProviderConfigDefaulter interface {
 	ApplyConfigDefaults(cfg *Config) error
 }
 
+// ProviderArchitectureCapability lets a provider admit architecture requests
+// whose runtime feasibility is validated inside the provider adapter.
+type ProviderArchitectureCapability interface {
+	SupportsArchitecture(cfg Config, architecture string) bool
+}
+
 // ProviderClaimScoper contributes opaque routing identity to local claims.
 // Core persists and compares the value without interpreting provider fields.
 type ProviderClaimScoper interface {

--- a/internal/cli/provider_exports.go
+++ b/internal/cli/provider_exports.go
@@ -209,6 +209,10 @@ func IsArchitectureExplicit(cfg Config) bool {
 	return cfg.architectureExplicit
 }
 
+func MarkArchitectureExplicit(cfg *Config) {
+	cfg.architectureExplicit = true
+}
+
 func NormalizeArchitecture(value string) (string, error) {
 	return normalizeArchitecture(value)
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1132,7 +1132,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 			hydrateTarget.WindowsMode = cfg.WindowsMode
 		}
 		hydrateSupported := supportsLocalActionsHydrateTarget(hydrateTarget) || supportsGitHubActionsRunnerTarget(hydrateTarget)
-		printRemoteCapabilityPreflight(ctx, a.Stderr, cfg, currentTarget, leaseID, workdir, remoteRunEnvFiles(actionsEnvFile, profileEnvFile), hydratedByActions, actionsURL, hydrateSupported, envSelection.Inline)
+		printRemoteCapabilityPreflight(ctx, a.Stderr, cfg, server, currentTarget, leaseID, workdir, remoteRunEnvFiles(actionsEnvFile, profileEnvFile), hydratedByActions, actionsURL, hydrateSupported, envSelection.Inline)
 		preflightPrinted = true
 	}
 	preflightRawJSRuntime := func(currentTarget SSHTarget) error {

--- a/internal/cli/run_observability.go
+++ b/internal/cli/run_observability.go
@@ -156,8 +156,10 @@ func printRemoteCapabilityPreflight(ctx context.Context, w io.Writer, cfg Config
 	for _, line := range remotePreflightWorkspaceLines(cfg, target, leaseID, workdir, hydrated, actionsURL, hydrateSupported) {
 		fmt.Fprintln(w, line)
 	}
-	if architecture := strings.TrimSpace(server.Labels["architecture"]); architecture != "" {
-		fmt.Fprintf(w, "remote preflight architecture=%s\n", architecture)
+	if cfg.architectureExplicit {
+		if architecture := strings.TrimSpace(server.Labels["architecture"]); architecture != "" {
+			fmt.Fprintf(w, "remote preflight architecture=%s\n", architecture)
+		}
 	}
 	tools := preflightToolsForTarget(target, cfg.Run.PreflightTools)
 	if len(tools) == 0 {

--- a/internal/cli/run_observability.go
+++ b/internal/cli/run_observability.go
@@ -149,12 +149,15 @@ func runLogsURL(coord *CoordinatorClient, runID string) string {
 	return strings.TrimRight(coord.BaseURL, "/") + "/v1/runs/" + url.PathEscape(runID) + "/logs"
 }
 
-func printRemoteCapabilityPreflight(ctx context.Context, w io.Writer, cfg Config, target SSHTarget, leaseID, workdir string, envFiles []string, hydrated bool, actionsURL string, hydrateSupported bool, env map[string]string) {
+func printRemoteCapabilityPreflight(ctx context.Context, w io.Writer, cfg Config, server Server, target SSHTarget, leaseID, workdir string, envFiles []string, hydrated bool, actionsURL string, hydrateSupported bool, env map[string]string) {
 	if w == nil {
 		return
 	}
 	for _, line := range remotePreflightWorkspaceLines(cfg, target, leaseID, workdir, hydrated, actionsURL, hydrateSupported) {
 		fmt.Fprintln(w, line)
+	}
+	if architecture := strings.TrimSpace(server.Labels["architecture"]); architecture != "" {
+		fmt.Fprintf(w, "remote preflight architecture=%s\n", architecture)
 	}
 	tools := preflightToolsForTarget(target, cfg.Run.PreflightTools)
 	if len(tools) == 0 {

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -3852,11 +3852,23 @@ func TestRemotePreflightNonePrintsWorkspaceOnly(t *testing.T) {
 func TestRemotePreflightPrintsEffectiveArchitectureEvidence(t *testing.T) {
 	cfg := defaultConfig()
 	cfg.Run.PreflightTools = []string{"none"}
+	cfg.architectureExplicit = true
 	server := Server{Labels: map[string]string{"architecture": ArchitectureARM64}}
 	var out bytes.Buffer
 	printRemoteCapabilityPreflight(context.Background(), &out, cfg, server, SSHTarget{TargetOS: targetLinux}, "cbx_123", "/work/repo", nil, false, "", false, nil)
 	if !strings.Contains(out.String(), "remote preflight architecture=arm64\n") {
 		t.Fatalf("missing architecture evidence: %q", out.String())
+	}
+}
+
+func TestRemotePreflightOmitsUnassertedArchitectureLabel(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.Run.PreflightTools = []string{"none"}
+	server := Server{Labels: map[string]string{"architecture": ArchitectureARM64}}
+	var out bytes.Buffer
+	printRemoteCapabilityPreflight(context.Background(), &out, cfg, server, SSHTarget{TargetOS: targetLinux}, "cbx_123", "/work/repo", nil, false, "", false, nil)
+	if strings.Contains(out.String(), "remote preflight architecture=") {
+		t.Fatalf("omitted architecture printed stale evidence: %q", out.String())
 	}
 }
 

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -3705,7 +3705,7 @@ func TestWindowsRemoteCapabilityPreflightUploadsScriptBeforeRunning(t *testing.T
 	env := map[string]string{"CRABBOX_LONG_ENV": strings.Repeat("x", 40000)}
 
 	var out bytes.Buffer
-	printRemoteCapabilityPreflight(context.Background(), &out, cfg, target, "cbx_123", `C:\crabbox\repo`, []string{`.crabbox\env\run.env`}, true, "", true, env)
+	printRemoteCapabilityPreflight(context.Background(), &out, cfg, Server{}, target, "cbx_123", `C:\crabbox\repo`, []string{`.crabbox\env\run.env`}, true, "", true, env)
 
 	data, err := os.ReadFile(logPath)
 	if err != nil {
@@ -3802,7 +3802,7 @@ func TestWindowsWSL2RemoteCapabilityPreflightUsesBoundedWrapper(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	printRemoteCapabilityPreflight(context.Background(), &out, cfg, target, "cbx_123", `/work/repo`, nil, false, "", true, nil)
+	printRemoteCapabilityPreflight(context.Background(), &out, cfg, Server{}, target, "cbx_123", `/work/repo`, nil, false, "", true, nil)
 
 	data, err := os.ReadFile(logPath)
 	if err != nil {
@@ -3839,13 +3839,24 @@ func TestRemotePreflightNonePrintsWorkspaceOnly(t *testing.T) {
 	cfg := defaultConfig()
 	cfg.Run.PreflightTools = []string{"none"}
 	var out bytes.Buffer
-	printRemoteCapabilityPreflight(context.Background(), &out, cfg, SSHTarget{TargetOS: targetLinux}, "cbx_123", "/work/repo", nil, false, "", false, nil)
+	printRemoteCapabilityPreflight(context.Background(), &out, cfg, Server{}, SSHTarget{TargetOS: targetLinux}, "cbx_123", "/work/repo", nil, false, "", false, nil)
 	got := out.String()
 	if !strings.Contains(got, "remote preflight workspace=raw workdir=/work/repo hydrate_supported=false") {
 		t.Fatalf("missing workspace summary: %q", got)
 	}
 	if strings.Contains(got, "remote preflight failed") || strings.Contains(got, "remote preflight user=") || strings.Contains(got, "remote preflight cwd=") {
 		t.Fatalf("none should skip remote probes, got %q", got)
+	}
+}
+
+func TestRemotePreflightPrintsEffectiveArchitectureEvidence(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.Run.PreflightTools = []string{"none"}
+	server := Server{Labels: map[string]string{"architecture": ArchitectureARM64}}
+	var out bytes.Buffer
+	printRemoteCapabilityPreflight(context.Background(), &out, cfg, server, SSHTarget{TargetOS: targetLinux}, "cbx_123", "/work/repo", nil, false, "", false, nil)
+	if !strings.Contains(out.String(), "remote preflight architecture=arm64\n") {
+		t.Fatalf("missing architecture evidence: %q", out.String())
 	}
 }
 

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -166,9 +166,10 @@ func validateProviderTarget(cfg Config) error {
 	if machineTarget && (provider.Name() == "tart" || provider.Name() == "apple-vm" || provider.Name() == "lume" || provider.Name() == "aws-lambda-microvm") && cfg.architectureExplicit && effectiveArchitectureForConfig(cfg) != ArchitectureARM64 {
 		return exit(2, "provider=%s supports architecture=arm64 only", provider.Name())
 	}
-	if machineTarget && effectiveArchitectureForConfig(cfg) == ArchitectureARM64 {
-		if !providerSupportsARM64(provider.Name()) {
-			return exit(2, "architecture=arm64 currently supports provider=azure, provider=aws, provider=tart, provider=apple-container, provider=apple-vm, provider=lume, provider=aws-lambda-microvm, or provider=external")
+	architecture := effectiveArchitectureForConfig(cfg)
+	if machineTarget && architecture == ArchitectureARM64 {
+		if !providerSupportsArchitecture(provider, cfg, architecture) {
+			return exit(2, "architecture=arm64 currently supports provider=azure, provider=aws, provider=tart, provider=apple-container, provider=apple-vm, provider=lume, provider=aws-lambda-microvm, provider=external, or a provider with runtime-native architecture support such as provider=local-container")
 		}
 		if cfg.TargetOS != targetLinux &&
 			!(provider.Name() == "azure" && cfg.TargetOS == targetWindows) &&
@@ -212,6 +213,16 @@ func validateProviderTarget(cfg Config) error {
 		return nil
 	}
 	return nil
+}
+
+func providerSupportsArchitecture(provider Provider, cfg Config, architecture string) bool {
+	if capability, ok := provider.(ProviderArchitectureCapability); ok {
+		return capability.SupportsArchitecture(cfg, architecture)
+	}
+	if architecture == ArchitectureARM64 {
+		return providerSupportsARM64(provider.Name())
+	}
+	return true
 }
 
 func providerSupportsARM64(name string) bool {

--- a/internal/cli/target_test.go
+++ b/internal/cli/target_test.go
@@ -1,12 +1,54 @@
 package cli
 
 import (
+	"flag"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+type architectureCapabilityTestProvider struct{}
+
+func (architectureCapabilityTestProvider) Name() string {
+	return "architecture-capability-test"
+}
+func (architectureCapabilityTestProvider) Aliases() []string { return nil }
+func (architectureCapabilityTestProvider) Spec() ProviderSpec {
+	return ProviderSpec{
+		Name:        "architecture-capability-test",
+		Family:      "architecture-capability-test",
+		Kind:        ProviderKindSSHLease,
+		Targets:     []TargetSpec{{OS: targetLinux}},
+		Coordinator: CoordinatorNever,
+	}
+}
+func (architectureCapabilityTestProvider) RegisterFlags(*flag.FlagSet, Config) any {
+	return noProviderFlags{}
+}
+func (architectureCapabilityTestProvider) ApplyFlags(*Config, *flag.FlagSet, any) error {
+	return nil
+}
+func (architectureCapabilityTestProvider) Configure(Config, Runtime) (Backend, error) {
+	return nil, nil
+}
+func (architectureCapabilityTestProvider) SupportsArchitecture(_ Config, architecture string) bool {
+	return architecture == ArchitectureAMD64 || architecture == ArchitectureARM64
+}
+
+func TestProviderArchitectureCapabilityAdmitsStaticArchitecture(t *testing.T) {
+	provider := architectureCapabilityTestProvider{}
+	for _, architecture := range []string{ArchitectureAMD64, ArchitectureARM64} {
+		t.Run(architecture, func(t *testing.T) {
+			cfg := baseConfig()
+			cfg.TargetOS = targetLinux
+			if !providerSupportsArchitecture(provider, cfg, architecture) {
+				t.Fatalf("architecture capability rejected %s", architecture)
+			}
+		})
+	}
+}
 
 func TestValidateProviderTargetRejectsUnsupportedAWSTargets(t *testing.T) {
 	t.Run("macOS needs dedicated host", func(t *testing.T) {

--- a/internal/providers/localcontainer/backend.go
+++ b/internal/providers/localcontainer/backend.go
@@ -173,6 +173,13 @@ func (b *backend) RebindResolvedLeaseTarget(target *core.LeaseTarget, leaseID st
 
 func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.LeaseTarget, error) {
 	cfg := b.configForRun()
+	architecture, err := b.assertRequestedArchitecture(ctx, cfg)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	if architecture != "" {
+		cfg.Architecture = architecture
+	}
 	if err := validateCheckpointFork(ctx, cfg); err != nil {
 		return core.LeaseTarget{}, err
 	}
@@ -316,6 +323,9 @@ func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.Le
 
 func createdPendingLease(cfg core.Config, containerID, leaseID, slug, bootstrapDir string, keep bool) core.LeaseTarget {
 	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", keep, time.Now().UTC())
+	if core.IsArchitectureExplicit(cfg) {
+		labels["architecture"] = cfg.Architecture
+	}
 	labels["state"] = pendingClaimState
 	labels["recovery"] = pendingRecoveryKind
 	labels["ssh_key_owned"] = "true"
@@ -1514,6 +1524,9 @@ func localContainerDisplayImage(cfg core.Config) string {
 
 func (b *backend) createContainer(ctx context.Context, cfg core.Config, name, leaseID, slug, publicKey string, keep bool) (string, string, error) {
 	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", keep, time.Now().UTC())
+	if core.IsArchitectureExplicit(cfg) {
+		labels["architecture"] = cfg.Architecture
+	}
 	labels["state"] = pendingClaimState
 	labels["recovery"] = pendingRecoveryKind
 	labels["ssh_key_owned"] = "true"
@@ -2235,7 +2248,10 @@ func localContainerClaimExpired(claim core.LeaseClaim, now time.Time) bool {
 }
 
 func (b *backend) docker(ctx context.Context, args []string, stdout, stderr io.Writer) (core.LocalCommandResult, error) {
-	cfg := b.configForRun()
+	return b.containerRuntime(ctx, b.configForRun(), args, stdout, stderr)
+}
+
+func (b *backend) containerRuntime(ctx context.Context, cfg core.Config, args []string, stdout, stderr io.Writer) (core.LocalCommandResult, error) {
 	var env []string
 	if metadata := cfg.LocalContainer.CheckpointMetadata; len(metadata) != 0 {
 		scope := checkpointScopeFromMetadata(metadata, cfg.LocalContainer.Runtime)
@@ -2253,6 +2269,35 @@ func (b *backend) docker(ctx context.Context, args []string, stdout, stderr io.W
 		Stdout: stdout,
 		Stderr: stderr,
 	})
+}
+
+func (b *backend) assertRequestedArchitecture(ctx context.Context, cfg core.Config) (string, error) {
+	if !core.IsArchitectureExplicit(cfg) {
+		return "", nil
+	}
+	requested, err := core.NormalizeArchitecture(cfg.Architecture)
+	if err != nil {
+		return "", err
+	}
+	format := "{{.Architecture}}"
+	runtimeLabel := "Docker"
+	if isPodmanRuntime(cfg.LocalContainer.Runtime) {
+		format = "{{.Host.Arch}}"
+		runtimeLabel = "Podman"
+	}
+	result, runErr := b.containerRuntime(ctx, cfg, []string{"info", "--format", format}, nil, nil)
+	if runErr != nil {
+		return "", core.Exit(2, "local-container architecture assertion failed: requested=%s available=unknown: query %s daemon architecture: %v", requested, runtimeLabel, commandError("container runtime info", result, runErr))
+	}
+	raw := strings.TrimSpace(result.Stdout)
+	available, normalizeErr := core.NormalizeArchitecture(raw)
+	if raw == "" || normalizeErr != nil {
+		return "", core.Exit(2, "local-container architecture assertion failed: requested=%s available=%q: %s daemon returned an unrecognized architecture", requested, raw, runtimeLabel)
+	}
+	if requested != available {
+		return "", core.Exit(2, "local-container architecture mismatch: requested=%s available=%s", requested, available)
+	}
+	return available, nil
 }
 
 func (b *backend) serverFromContainer(container inspectContainer, cfg core.Config) core.Server {

--- a/internal/providers/localcontainer/backend.go
+++ b/internal/providers/localcontainer/backend.go
@@ -1997,6 +1997,9 @@ func (b *backend) resolveContainer(ctx context.Context, identifier string) (insp
 		if _, err := b.applyCheckpointScopeLabels(ctx, exactClaim.Labels); err != nil {
 			return inspectContainer{}, "", "", err
 		}
+		if err := b.assertResolveRequestedArchitecture(ctx); err != nil {
+			return inspectContainer{}, "", "", err
+		}
 		return b.findContainerForClaim(ctx, exactClaim)
 	}
 	claims, err := core.ListLeaseClaims()
@@ -2016,6 +2019,14 @@ func (b *backend) resolveContainer(ctx context.Context, identifier string) (insp
 	}
 	if len(slugClaims) > 1 {
 		return inspectContainer{}, "", "", core.Exit(2, "local-container slug %s is ambiguous across %d lease claims; use a lease id", identifier, len(slugClaims))
+	}
+	if len(slugClaims) == 1 && core.IsArchitectureExplicit(b.cfg) {
+		if _, err := b.applyCheckpointScopeLabels(ctx, slugClaims[0].Labels); err != nil {
+			return inspectContainer{}, "", "", err
+		}
+	}
+	if err := b.assertResolveRequestedArchitecture(ctx); err != nil {
+		return inspectContainer{}, "", "", err
 	}
 	containers, listErr := b.listContainers(ctx)
 	for _, container := range containers {
@@ -2049,6 +2060,18 @@ func (b *backend) resolveContainer(ctx context.Context, identifier string) (insp
 		return inspectContainer{}, "", "", listErr
 	}
 	return inspectContainer{}, "", "", core.Exit(4, "local-container lease not found: %s", identifier)
+}
+
+func (b *backend) assertResolveRequestedArchitecture(ctx context.Context) error {
+	cfg := b.configForRun()
+	architecture, err := b.assertRequestedArchitecture(ctx, cfg)
+	if err != nil {
+		return err
+	}
+	if architecture != "" {
+		b.cfg.Architecture = architecture
+	}
+	return nil
 }
 
 func (b *backend) applyCheckpointScopeLabels(ctx context.Context, labels map[string]string) (bool, error) {
@@ -2307,6 +2330,9 @@ func (b *backend) serverFromContainer(container inspectContainer, cfg core.Confi
 			continue
 		}
 		labels[key] = value
+	}
+	if core.IsArchitectureExplicit(cfg) {
+		labels["architecture"] = cfg.Architecture
 	}
 	labels["container_id"] = shortID(container.ID)
 	if labels["provider"] == "" {

--- a/internal/providers/localcontainer/backend_test.go
+++ b/internal/providers/localcontainer/backend_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"slices"
 	"strconv"
@@ -812,6 +813,199 @@ func TestAcquireArchitectureMismatchFailsBeforeContainerCreation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestResolveArchitectureAssertionMatchesAndNormalizesAliases(t *testing.T) {
+	tests := []struct {
+		name      string
+		runtime   string
+		requested string
+		available string
+		want      string
+		context   string
+	}{
+		{name: "docker canonical", runtime: "docker", requested: core.ArchitectureAMD64, available: "amd64", want: core.ArchitectureAMD64, context: "default"},
+		{name: "docker daemon alias", runtime: "docker", requested: core.ArchitectureAMD64, available: "x86_64", want: core.ArchitectureAMD64, context: "default"},
+		{name: "docker request alias", runtime: "docker", requested: "aarch64", available: "arm64", want: core.ArchitectureARM64, context: "default"},
+		{name: "podman aliases", runtime: "podman", requested: "x86_64", available: "amd64", want: core.ArchitectureAMD64, context: "default"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b, runner, leaseID, _ := resolveArchitectureFixture(t, tc.runtime, tc.context, tc.requested, tc.available)
+			lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: leaseID})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := lease.Server.Labels["architecture"]; got != tc.want {
+				t.Fatalf("resolved architecture=%q, want %q", got, tc.want)
+			}
+			if len(runner.calls) != 3 {
+				t.Fatalf("runtime calls=%d, want info/list/inspect: %#v", len(runner.calls), runner.calls)
+			}
+			for _, call := range runner.calls {
+				if slices.Contains(call.Args, "--platform") {
+					t.Fatalf("reuse architecture assertion requested emulation: %#v", call.Args)
+				}
+			}
+		})
+	}
+}
+
+func TestResolveArchitectureAssertionUsesCapturedRemoteRuntimeRoute(t *testing.T) {
+	tests := []struct {
+		name      string
+		runtime   string
+		context   string
+		requested string
+		available string
+	}{
+		{name: "docker context", runtime: "docker", context: "remote-docker", requested: core.ArchitectureAMD64, available: "x86_64"},
+		{name: "podman connection", runtime: "podman", context: "remote-podman", requested: core.ArchitectureARM64, available: "aarch64"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b, runner, leaseID, _ := resolveArchitectureFixture(t, tc.runtime, tc.context, tc.requested, tc.available)
+			lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: leaseID})
+			if err != nil {
+				t.Fatal(err)
+			}
+			want, err := core.NormalizeArchitecture(tc.requested)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := lease.Server.Labels["architecture"]; got != want {
+				t.Fatalf("resolved architecture=%q, want %q", got, want)
+			}
+			if len(runner.calls) != 3 {
+				t.Fatalf("runtime calls=%d, want info/list/inspect: %#v", len(runner.calls), runner.calls)
+			}
+		})
+	}
+}
+
+func TestResolveArchitectureAssertionFailurePrecedesContainerUseAndClaimMutation(t *testing.T) {
+	tests := []struct {
+		name      string
+		runtime   string
+		context   string
+		requested string
+		available string
+		wantError string
+	}{
+		{name: "docker mismatch", runtime: "docker", context: "default", requested: core.ArchitectureARM64, available: "x86_64", wantError: "requested=arm64 available=amd64"},
+		{name: "malformed remote docker response", runtime: "docker", context: "remote-docker", requested: core.ArchitectureAMD64, available: "amd64\narm64", wantError: `available="amd64\narm64"`},
+		{name: "remote podman mismatch", runtime: "podman", context: "remote-podman", requested: core.ArchitectureAMD64, available: "aarch64", wantError: "requested=amd64 available=arm64"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b, runner, leaseID, before := resolveArchitectureFixture(t, tc.runtime, tc.context, tc.requested, tc.available)
+			_, err := b.Resolve(context.Background(), core.ResolveRequest{ID: leaseID, Repo: core.Repo{Root: t.TempDir()}})
+			if err == nil || !strings.Contains(err.Error(), tc.wantError) {
+				t.Fatalf("Resolve error=%v, want %q", err, tc.wantError)
+			}
+			if len(runner.calls) != 1 {
+				t.Fatalf("runtime calls=%d, want architecture probe only: %#v", len(runner.calls), runner.calls)
+			}
+			for _, forbidden := range []string{"ps", "inspect", "exec", "run", "rm"} {
+				if slices.Contains(runner.calls[0].Args, forbidden) {
+					t.Fatalf("architecture failure reached container %s: %#v", forbidden, runner.calls[0].Args)
+				}
+			}
+			after, readErr := core.ReadLeaseClaim(leaseID)
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			if !reflect.DeepEqual(after, before) {
+				t.Fatalf("architecture failure mutated claim:\nbefore=%#v\nafter=%#v", before, after)
+			}
+		})
+	}
+}
+
+func resolveArchitectureFixture(t *testing.T, runtimeName, contextName, requested, available string) (*backend, *recordingRunner, string, core.LeaseClaim) {
+	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	leaseID := "cbx_resolve_arch"
+	slug := "resolve-arch"
+	containerID := "resolve-arch-container"
+	scope := checkpointScope{
+		Runtime:  runtimeName,
+		Context:  contextName,
+		Endpoint: "unix:///tmp/resolve-arch.sock",
+		DaemonID: "resolve-arch-daemon",
+	}
+	labels := map[string]string{
+		"crabbox": "true", "provider": providerName, "lease": leaseID, "slug": slug,
+		"state": "ready", "runtime": runtimeName, "ssh_user": "runner", "work_root": "/workspace/crabbox",
+	}
+	for key, value := range checkpointScopeMetadata(scope) {
+		if value != "" {
+			labels[key] = value
+		}
+	}
+	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(
+		leaseID,
+		slug,
+		providerName,
+		localContainerClaimScope(runtimeName, contextName),
+		"",
+		t.TempDir(),
+		time.Minute,
+		false,
+		core.Server{CloudID: containerID, Provider: providerName, Labels: labels},
+		core.SSHTarget{Host: "127.0.0.1", Port: "49153"},
+	); err != nil {
+		t.Fatal(err)
+	}
+	before, err := core.ReadLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	inspectJSON := fmt.Sprintf(`[{"Id":%q,"Name":"/crabbox-resolve-arch","Config":{"Image":"ubuntu:24.04","Labels":{"crabbox":"true","provider":"local-container","lease":%q,"slug":%q,"state":"ready","runtime":%q,"ssh_user":"runner","work_root":"/workspace/crabbox"}},"State":{"Status":"running","Running":true},"NetworkSettings":{"Ports":{"2222/tcp":[{"HostIp":"127.0.0.1","HostPort":"49153"}]}}}]`, containerID, leaseID, slug, runtimeName)
+	prefix := []string{}
+	if contextName != "" && contextName != "default" {
+		if runtimeName == "podman" {
+			prefix = []string{"--connection", contextName}
+		} else {
+			prefix = []string{"--context", contextName}
+		}
+	}
+	runner := &recordingRunner{run: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		if req.Name != runtimeName || len(req.Args) < len(prefix)+1 || !slices.Equal(req.Args[:len(prefix)], prefix) {
+			t.Fatalf("runtime request name=%q args=%v, want %s prefix=%v", req.Name, req.Args, runtimeName, prefix)
+		}
+		args := req.Args[len(prefix):]
+		switch args[0] {
+		case "info":
+			wantFormat := "{{.Architecture}}"
+			if runtimeName == "podman" {
+				wantFormat = "{{.Host.Arch}}"
+			}
+			if !slices.Equal(args, []string{"info", "--format", wantFormat}) {
+				t.Fatalf("architecture probe args=%v", req.Args)
+			}
+			return core.LocalCommandResult{Stdout: available + "\n"}, nil
+		case "ps":
+			return core.LocalCommandResult{Stdout: containerID + "\n"}, nil
+		case "inspect":
+			return core.LocalCommandResult{Stdout: inspectJSON}, nil
+		default:
+			t.Fatalf("unexpected runtime request: %#v", req.Args)
+			return core.LocalCommandResult{}, nil
+		}
+	}}
+	b := testBackend(runner)
+	b.cfg.LocalContainer.Runtime = runtimeName
+	core.MarkLocalContainerRuntimeExplicit(&b.cfg)
+	b.cfg.Architecture = requested
+	core.MarkArchitectureExplicit(&b.cfg)
+	b.validateRuntimeScope = func(_ context.Context, got checkpointScope) error {
+		if !sameCheckpointScope(got, scope) {
+			t.Fatalf("validated scope=%#v, want %#v", got, scope)
+		}
+		return nil
+	}
+	return b, runner, leaseID, before
 }
 
 func TestCreateContainerNeverRequestsEmulationPlatform(t *testing.T) {

--- a/internal/providers/localcontainer/backend_test.go
+++ b/internal/providers/localcontainer/backend_test.go
@@ -655,6 +655,198 @@ func TestProviderAliases(t *testing.T) {
 	if _, ok := newBackend(spec, core.BaseConfig(), core.Runtime{Exec: &recordingRunner{}}).(core.SSHRunFailureEvidenceBackend); !ok {
 		t.Fatal("local-container backend does not expose failed-run evidence capability")
 	}
+	capability, ok := any(Provider{}).(core.ProviderArchitectureCapability)
+	if !ok {
+		t.Fatal("local-container provider does not expose architecture capability")
+	}
+	for _, architecture := range []string{core.ArchitectureAMD64, core.ArchitectureARM64} {
+		cfg := core.BaseConfig()
+		cfg.TargetOS = core.TargetLinux
+		if !capability.SupportsArchitecture(cfg, architecture) {
+			t.Fatalf("architecture capability rejected %s", architecture)
+		}
+	}
+}
+
+func TestAssertRequestedArchitectureNormalizesDockerAndPodman(t *testing.T) {
+	tests := []struct {
+		runtime   string
+		requested string
+		available string
+		want      string
+	}{
+		{runtime: "docker", requested: core.ArchitectureAMD64, available: "amd64", want: core.ArchitectureAMD64},
+		{runtime: "docker", requested: core.ArchitectureAMD64, available: "x86_64", want: core.ArchitectureAMD64},
+		{runtime: "docker", requested: core.ArchitectureARM64, available: "arm64", want: core.ArchitectureARM64},
+		{runtime: "docker", requested: core.ArchitectureARM64, available: "aarch64", want: core.ArchitectureARM64},
+		{runtime: "podman", requested: core.ArchitectureAMD64, available: "amd64", want: core.ArchitectureAMD64},
+		{runtime: "podman", requested: core.ArchitectureAMD64, available: "x86_64", want: core.ArchitectureAMD64},
+		{runtime: "podman", requested: core.ArchitectureARM64, available: "arm64", want: core.ArchitectureARM64},
+		{runtime: "podman", requested: core.ArchitectureARM64, available: "aarch64", want: core.ArchitectureARM64},
+	}
+	for _, tc := range tests {
+		t.Run(tc.runtime+"_"+tc.available, func(t *testing.T) {
+			runner := &recordingRunner{run: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+				wantFormat := "{{.Architecture}}"
+				if tc.runtime == "podman" {
+					wantFormat = "{{.Host.Arch}}"
+				}
+				if req.Name != tc.runtime || !slices.Equal(req.Args, []string{"info", "--format", wantFormat}) {
+					t.Fatalf("runtime request name=%q args=%v", req.Name, req.Args)
+				}
+				return core.LocalCommandResult{Stdout: tc.available + "\n"}, nil
+			}}
+			b := testBackend(runner)
+			cfg := b.cfg
+			cfg.LocalContainer.Runtime = tc.runtime
+			cfg.Architecture = tc.requested
+			core.MarkArchitectureExplicit(&cfg)
+			got, err := b.assertRequestedArchitecture(context.Background(), cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.want {
+				t.Fatalf("architecture=%q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAssertRequestedArchitectureRejectsMismatchAndUnrecognizedOutput(t *testing.T) {
+	tests := []struct {
+		name          string
+		runtime       string
+		requested     string
+		available     string
+		wantAvailable string
+	}{
+		{name: "docker mismatch", runtime: "docker", requested: core.ArchitectureARM64, available: "x86_64", wantAvailable: "available=amd64"},
+		{name: "podman mismatch", runtime: "podman", requested: core.ArchitectureAMD64, available: "aarch64", wantAvailable: "available=arm64"},
+		{name: "docker unrecognized", runtime: "docker", requested: core.ArchitectureAMD64, available: "ppc64le", wantAvailable: `available="ppc64le"`},
+		{name: "podman malformed", runtime: "podman", requested: core.ArchitectureARM64, available: "amd64\narm64", wantAvailable: `available="amd64\narm64"`},
+		{name: "docker empty", runtime: "docker", requested: core.ArchitectureAMD64, available: "", wantAvailable: `available=""`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := &recordingRunner{run: func(core.LocalCommandRequest) (core.LocalCommandResult, error) {
+				return core.LocalCommandResult{Stdout: tc.available}, nil
+			}}
+			b := testBackend(runner)
+			cfg := b.cfg
+			cfg.LocalContainer.Runtime = tc.runtime
+			cfg.Architecture = tc.requested
+			core.MarkArchitectureExplicit(&cfg)
+			_, err := b.assertRequestedArchitecture(context.Background(), cfg)
+			if err == nil || !strings.Contains(err.Error(), "requested="+tc.requested) || !strings.Contains(err.Error(), tc.wantAvailable) {
+				t.Fatalf("err=%v, want requested and available architecture", err)
+			}
+		})
+	}
+}
+
+func TestAssertRequestedArchitectureUsesCapturedRemoteRuntimeRoute(t *testing.T) {
+	tests := []struct {
+		name       string
+		runtime    string
+		context    string
+		wantPrefix []string
+		wantFormat string
+	}{
+		{name: "docker context", runtime: "docker", context: "remote-docker", wantPrefix: []string{"--context", "remote-docker"}, wantFormat: "{{.Architecture}}"},
+		{name: "podman connection", runtime: "podman", context: "remote-podman", wantPrefix: []string{"--connection", "remote-podman"}, wantFormat: "{{.Host.Arch}}"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := &recordingRunner{run: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+				want := append(append([]string{}, tc.wantPrefix...), "info", "--format", tc.wantFormat)
+				if req.Name != tc.runtime || !slices.Equal(req.Args, want) {
+					t.Fatalf("runtime request name=%q args=%v want=%v", req.Name, req.Args, want)
+				}
+				return core.LocalCommandResult{Stdout: "arm64\n"}, nil
+			}}
+			b := testBackend(runner)
+			cfg := b.cfg
+			cfg.LocalContainer.Runtime = tc.runtime
+			cfg.LocalContainer.CheckpointMetadata = checkpointScopeMetadata(checkpointScope{
+				Runtime: tc.runtime, Context: tc.context, Endpoint: "remote", DaemonID: "daemon-remote",
+			})
+			cfg.Architecture = core.ArchitectureARM64
+			core.MarkArchitectureExplicit(&cfg)
+			if _, err := b.assertRequestedArchitecture(context.Background(), cfg); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestAssertRequestedArchitectureOmittedDoesNotProbe(t *testing.T) {
+	runner := &recordingRunner{}
+	b := testBackend(runner)
+	if got, err := b.assertRequestedArchitecture(context.Background(), b.cfg); err != nil || got != "" {
+		t.Fatalf("architecture=%q err=%v", got, err)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("omitted architecture probed runtime: %#v", runner.calls)
+	}
+}
+
+func TestAcquireArchitectureMismatchFailsBeforeContainerCreation(t *testing.T) {
+	for _, runtimeName := range []string{"docker", "podman"} {
+		t.Run(runtimeName, func(t *testing.T) {
+			runner := &recordingRunner{run: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+				if slices.Contains(req.Args, "run") {
+					t.Fatalf("container creation attempted after architecture mismatch: %v", req.Args)
+				}
+				return core.LocalCommandResult{Stdout: "amd64\n"}, nil
+			}}
+			b := testBackend(runner)
+			b.cfg.LocalContainer.Runtime = runtimeName
+			b.cfg.Architecture = core.ArchitectureARM64
+			core.MarkArchitectureExplicit(&b.cfg)
+			_, err := b.Acquire(context.Background(), core.AcquireRequest{})
+			if err == nil || !strings.Contains(err.Error(), "requested=arm64 available=amd64") {
+				t.Fatalf("err=%v", err)
+			}
+			if len(runner.calls) != 1 {
+				t.Fatalf("runtime calls=%d, want architecture probe only: %#v", len(runner.calls), runner.calls)
+			}
+		})
+	}
+}
+
+func TestCreateContainerNeverRequestsEmulationPlatform(t *testing.T) {
+	tests := []struct {
+		runtime      string
+		architecture string
+	}{
+		{runtime: "docker", architecture: core.ArchitectureAMD64},
+		{runtime: "docker", architecture: core.ArchitectureARM64},
+		{runtime: "podman", architecture: core.ArchitectureAMD64},
+		{runtime: "podman", architecture: core.ArchitectureARM64},
+	}
+	for _, tc := range tests {
+		t.Run(tc.runtime+"_"+tc.architecture, func(t *testing.T) {
+			runner := &recordingRunner{responses: map[string]core.LocalCommandResult{"run": {Stdout: "container123456\n"}}}
+			b := testBackend(runner)
+			b.cfg.LocalContainer.Runtime = tc.runtime
+			core.MarkLocalContainerRuntimeExplicit(&b.cfg)
+			cfg := b.configForRun()
+			cfg.Architecture = tc.architecture
+			core.MarkArchitectureExplicit(&cfg)
+			_, bootstrapDir, err := b.createContainer(context.Background(), cfg, "crabbox-arch", "cbx_arch", "arch-test", "ssh-ed25519 AAAA test", true)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = os.RemoveAll(bootstrapDir) })
+			args := recordedArgsForCommand(t, runner, "run")
+			if strings.Contains(args, "--platform") {
+				t.Fatalf("native architecture assertion emitted platform selection:\n%s", args)
+			}
+			if !strings.Contains(args, "--label\narchitecture="+tc.architecture) {
+				t.Fatalf("normalized architecture label missing:\n%s", args)
+			}
+		})
+	}
 }
 
 func TestCreateContainerUsesDockerCompatibleSSHLease(t *testing.T) {

--- a/internal/providers/localcontainer/provider.go
+++ b/internal/providers/localcontainer/provider.go
@@ -39,6 +39,10 @@ func (Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error
 	return applyFlags(cfg, fs, values)
 }
 
+func (Provider) SupportsArchitecture(cfg core.Config, architecture string) bool {
+	return cfg.TargetOS == core.TargetLinux && (architecture == core.ArchitectureAMD64 || architecture == core.ArchitectureARM64)
+}
+
 func (Provider) CreationOnlyFlagNames() []string {
 	return []string{"local-container-volume"}
 }


### PR DESCRIPTION
## Summary

- let providers advertise explicit architecture support instead of rejecting local-container through a core allowlist
- define local-container `--arch` as a strict native assertion against the selected Docker or Podman daemon, with no emulation fallback
- apply the same normalized assertion to fresh acquisition and retained-lease resolution, after captured remote-context routing but before container creation, list, inspect, exec, or lease mutation
- normalize `x86_64`/`aarch64` aliases, preserve the no-`--platform` invariant, and expose normalized preflight evidence only when the current invocation explicitly asserted architecture

Omitting `--arch` preserves the existing runtime-native behavior without an architecture probe or preflight claim.

Closes https://github.com/openclaw/crabbox/issues/1242

## Verification

- focused local-container Resolve/acquisition and provider-conformance race tests, including retained match/mismatch, aliases, malformed daemon output, Docker contexts, Podman connections, unchanged claims, and no container use after mismatch
- `go test -race ./internal/providers/... -count=1`
- `go test -race ./... -count=1 -timeout=20m`
- `go vet ./...`
- `scripts/check-docs.sh`, repository-wide `gofmt`, and `git diff --check`
- source-blind CLI behavior contract passed against real Docker
- final P1-focused Codex autoreview clean against current `origin/main` with no accepted/actionable findings

One concurrent full-suite run tripped the existing Freestyle timeout wall-clock bound while Docker proof and review were also running. The implicated test then passed 10/10 independently, and two fresh exact full race runs passed; the final run was on the fixed committed head.

## Real Docker transcript

Exact head: `e0f27d428a28d9ec9caceff5e1d68f9bcb3800a7`  
Docker 29.4.0, ARM64 daemon (`aarch64` normalized to `arm64`). Generated IDs and isolated paths are redacted.

```text
$ crabbox run --provider local-container --arch arm64 --slug proof-fresh-match --preflight --shell 'uname -m'
remote preflight architecture=arm64
aarch64
fresh_match_exit=0

$ before=$(proof-container-count); crabbox run --provider local-container --arch amd64 --slug proof-fresh-mismatch --shell 'uname -m'; after=$(proof-container-count)
local-container architecture mismatch: requested=amd64 available=arm64
fresh_mismatch_exit=2 containers_before=0 containers_after=0

$ crabbox warmup --provider local-container --arch arm64 --slug proof-reuse
provisioned lease=[proof lease] container=[proof container] state=ready
$ crabbox run --provider local-container --id proof-reuse --arch arm64 --preflight --shell 'uname -m'
remote preflight architecture=arm64
aarch64
reuse_match_exit=0

$ crabbox run --provider local-container --id proof-reuse --arch amd64 --shell 'uname -m'
local-container architecture mismatch: requested=amd64 available=arm64
reuse_mismatch_exit=2 claim_unchanged=yes container_unchanged=yes
docker_trace: --context orbstack context inspect orbstack --format {{(index .Endpoints "docker").Host}}
docker_trace: --context orbstack info --format {{.ID}}
docker_trace: --context orbstack info --format {{.Architecture}}
container_inspect_exec_mutation_or_platform_calls=0

$ crabbox run --provider local-container --id proof-reuse --preflight --shell 'uname -m'
aarch64
omitted_exit=0 architecture_lines=0 architecture_probes=0 platform_args=0

$ crabbox stop --provider local-container proof-reuse
cleanup_exit=0 proof_containers=0 local_claims=0 all_platform_args=0
```

The `context inspect` trace validates captured Docker-context metadata; it is not a container inspect. The forwarding wrapper recorded every Crabbox runtime call and forwarded it to the real daemon.
