### PR TITLE
feat(claims): add local claim inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added `crabbox heartbeat` so external SSH drivers can refresh owned lease idle deadlines and optionally update the idle timeout.
+- Added credential-free `crabbox claims list` output for deterministic, secret-safe inspection of unverified local lease claims across providers. Thanks @coygeek.
 
 ### Fixed
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -48,6 +48,7 @@ crabbox bench run --providers a,b -- <cmd>   run a workload and record benchmark
 crabbox status --id <id>                     show lease state (--wait to block)
 crabbox heartbeat --id <id>                  refresh the lease idle deadline
 crabbox inspect --id <id>                     print lease/provider details
+crabbox claims list [--json]                  list unverified local claims without provider access
 crabbox list                                  list machines (alias: crabbox pool list)
 crabbox share --id <id> [--user|--org]        grant access to a lease
 crabbox unshare --id <id> [--user|--org|--all]
@@ -61,7 +62,7 @@ crabbox pool ready [key]                      list hydrated broker ready-pool le
 See [warmup](commands/warmup.md), [prewarm](commands/prewarm.md),
 [run](commands/run.md), [watch](commands/watch.md),
 [status](commands/status.md), [heartbeat](commands/heartbeat.md), [inspect](commands/inspect.md),
-[list](commands/list.md), [share](commands/share.md),
+[claims](commands/claims.md), [list](commands/list.md), [share](commands/share.md),
 [unshare](commands/unshare.md), [stop](commands/stop.md),
 [pause](commands/pause.md), [resume](commands/resume.md),
 [cleanup](commands/cleanup.md), [pool](commands/pool.md).

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -34,6 +34,7 @@ same order as the CLI help.
 - [cache](cache.md)
 - [status](status.md)
 - [heartbeat](heartbeat.md)
+- [claims](claims.md)
 - [list](list.md)
 - [share](share.md)
 - [unshare](unshare.md)

--- a/docs/commands/claims.md
+++ b/docs/commands/claims.md
@@ -1,0 +1,74 @@
+# claims
+
+`crabbox claims list` prints the lease claims stored on the current machine. It
+is a read-only, credential-free inventory: it does not load provider
+configuration, initialize a provider backend, contact a provider, refresh a
+claim, or remove stale state.
+
+```sh
+crabbox claims list
+crabbox claims list --json
+```
+
+Human output is headed `unverified local state` because a structurally valid
+claim may be stale. Provider-scoped [`crabbox list`](list.md) remains the command
+for provider-backed machine inventory.
+
+## JSON
+
+`--json` emits this versioned envelope, including empty arrays when no claims or
+problems exist:
+
+```json
+{
+  "version": 1,
+  "source": "local-claims",
+  "claims": [],
+  "problems": []
+}
+```
+
+Each claim contains only these public fields:
+
+```json
+{
+  "leaseId": "cbx_abcdef123456",
+  "slug": "blue-lobster",
+  "provider": "aws",
+  "repoRoot": "/path/to/repo",
+  "pond": "",
+  "targetOS": "linux",
+  "windowsMode": "",
+  "claimedAt": "2026-08-16T10:00:00Z",
+  "lastUsedAt": "2026-08-16T10:05:00Z",
+  "idleTimeoutSeconds": 1800
+}
+```
+
+Cloud and resource identifiers, provider scope, hosts and endpoints, SSH
+details, labels, login and registration URLs or IDs, credentials, cache
+metadata, revisions, and fixed-create internals are never included. Claims are
+sorted by lease ID, provider, and slug.
+
+Malformed files do not hide valid claims. Each problem has stable `file`, `code`,
+and `message` fields. Supported codes are `invalid_filename`, `invalid_json`,
+`empty_lease_id`, `lease_id_mismatch`, `read_error`, and `invalid_claim`. Unsafe
+or overlong filenames are represented by a short SHA-256 fingerprint instead of
+their contents. Non-regular claim paths use `non_regular_file`. At most 100
+problem entries are emitted; the final
+`problems_truncated` entry reports when additional files were omitted. Problems
+are sorted by file reference and code.
+
+## Exit codes
+
+- `0`: the snapshot is missing, empty, or contains only valid claims.
+- `2`: one or more malformed claim records were found. Valid claims and bounded
+  problem entries are still written before exit.
+- Other nonzero codes: the local state directory itself could not be read or the
+  output could not be written.
+
+## Flags
+
+```text
+--json    print the stable JSON envelope
+```

--- a/docs/commands/list.md
+++ b/docs/commands/list.md
@@ -3,6 +3,11 @@
 `crabbox list` shows the current Crabbox machines (leases) for a provider. It is
 read-only and never provisions or releases anything.
 
+To inspect unverified claim files across every locally recorded provider without
+loading a backend or requiring provider credentials, use
+[`crabbox claims list`](claims.md). The meanings of bare `list`, `--provider`,
+and `--all` remain provider-scoped.
+
 ```sh
 crabbox list
 crabbox list --provider aws

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -210,6 +210,7 @@ Commands:
   cache       Inspect, purge, warm, or list remote cache volumes
   status      Show lease state; add --wait to block until ready
   heartbeat   Refresh a lease idle deadline and print its state
+  claims      Inspect unverified local lease claims without loading providers
   list        List Crabbox machines
   share       Share a lease with users or the owning org
   unshare     Remove lease sharing
@@ -248,6 +249,7 @@ Common Flows:
   crabbox warmup
   crabbox status --id blue-lobster --wait
   crabbox heartbeat --id blue-lobster --idle-timeout 90m
+  crabbox claims list
   crabbox run --id blue-lobster --shell 'pnpm install --frozen-lockfile && pnpm test'
   crabbox run --timing-record=default -- pnpm test
   crabbox bench run --providers aws,hetzner --repeats 3 -- pnpm test

--- a/internal/cli/claim.go
+++ b/internal/cli/claim.go
@@ -115,7 +115,7 @@ func snapshotLeaseClaims() (leaseClaimsSnapshot, error) {
 			continue
 		}
 		leaseID := strings.TrimSuffix(entry.Name(), ".json")
-		if !validLeaseClaimID(leaseID) {
+		if !validLeaseClaimPathID(leaseID) {
 			snapshot.invalid[leaseID] = &leaseClaimFileError{
 				code: "invalid_filename",
 				err:  exit(2, "claim filename is not a valid lease id"),
@@ -167,7 +167,7 @@ func snapshotLeaseClaimsReadOnlyWithReader(read leaseClaimSnapshotReader) (lease
 			continue
 		}
 		leaseID := strings.TrimSuffix(entry.Name(), ".json")
-		if !validLeaseClaimID(leaseID) {
+		if !validLeaseClaimPathID(leaseID) {
 			snapshot.invalid[leaseID] = &leaseClaimFileError{
 				code: "invalid_filename",
 				err:  exit(2, "claim filename is not a valid lease id"),
@@ -2081,10 +2081,7 @@ func decodeLeaseClaim(path string, data []byte) (leaseClaim, error) {
 }
 
 func leaseClaimPath(leaseID string) (string, error) {
-	if leaseID != strings.TrimSpace(leaseID) {
-		return "", invalidLeaseClaimIDError{id: leaseID}
-	}
-	if !validLeaseClaimID(leaseID) {
+	if !validLeaseClaimPathID(leaseID) {
 		return "", invalidLeaseClaimIDError{id: leaseID}
 	}
 	dir, err := crabboxStateDir()
@@ -2092,6 +2089,10 @@ func leaseClaimPath(leaseID string) (string, error) {
 		return "", err
 	}
 	return filepath.Join(dir, "claims", leaseID+".json"), nil
+}
+
+func validLeaseClaimPathID(leaseID string) bool {
+	return leaseID == strings.TrimSpace(leaseID) && validLeaseClaimID(leaseID)
 }
 
 func validLeaseClaimID(leaseID string) bool {

--- a/internal/cli/claim.go
+++ b/internal/cli/claim.go
@@ -109,7 +109,11 @@ type leaseClaimSnapshotReader func(path, leaseID string, expected os.FileInfo) (
 // bypasses claim locks so scanning a readable store never creates lock state or
 // requires write access. Runtime paths continue to use snapshotLeaseClaims.
 func snapshotLeaseClaimsReadOnly() (leaseClaimsSnapshot, error) {
-	return snapshotLeaseClaimsWithReader(readLeaseClaimSnapshotWithPresence)
+	snapshot, err := snapshotLeaseClaimsWithReader(readLeaseClaimSnapshotWithPresence)
+	if err != nil {
+		return leaseClaimsSnapshot{}, exit(1, "%v", err)
+	}
+	return snapshot, nil
 }
 
 func snapshotLeaseClaimsReadOnlyWithReader(read leaseClaimSnapshotReader) (leaseClaimsSnapshot, error) {

--- a/internal/cli/claim.go
+++ b/internal/cli/claim.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/gofrs/flock"
 )
@@ -87,6 +88,14 @@ type leaseClaimsSnapshot struct {
 	invalid map[string]error
 }
 
+type leaseClaimFileError struct {
+	code string
+	err  error
+}
+
+func (e *leaseClaimFileError) Error() string { return e.err.Error() }
+func (e *leaseClaimFileError) Unwrap() error { return e.err }
+
 func snapshotLeaseClaims() (leaseClaimsSnapshot, error) {
 	dir, err := crabboxStateDir()
 	if err != nil {
@@ -101,13 +110,45 @@ func snapshotLeaseClaims() (leaseClaimsSnapshot, error) {
 	}
 	snapshot := leaseClaimsSnapshot{invalid: make(map[string]error)}
 	for _, entry := range entries {
-		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+		if filepath.Ext(entry.Name()) != ".json" {
 			continue
 		}
 		leaseID := strings.TrimSuffix(entry.Name(), ".json")
-		claim, err := readLeaseClaim(leaseID)
+		if !validLeaseClaimID(leaseID) {
+			snapshot.invalid[leaseID] = &leaseClaimFileError{
+				code: "invalid_filename",
+				err:  exit(2, "claim filename is not a valid lease id"),
+			}
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			snapshot.invalid[leaseID] = &leaseClaimFileError{
+				code: "read_error",
+				err:  exit(2, "inspect claim file %s: %v", leaseID, err),
+			}
+			continue
+		}
+		if !info.Mode().IsRegular() {
+			snapshot.invalid[leaseID] = &leaseClaimFileError{
+				code: "non_regular_file",
+				err:  exit(2, "claim file %s is not a regular file", leaseID),
+			}
+			continue
+		}
+		claim, exists, err := readLeaseClaimWithPresence(leaseID)
 		if err != nil {
 			snapshot.invalid[leaseID] = err
+			continue
+		}
+		if !exists {
+			continue
+		}
+		if claim.LeaseID == "" {
+			snapshot.invalid[leaseID] = &leaseClaimFileError{
+				code: "empty_lease_id",
+				err:  exit(2, "claim file %s has an empty lease id", leaseID),
+			}
 			continue
 		}
 		snapshot.claims = append(snapshot.claims, claim)
@@ -1830,7 +1871,10 @@ func readLeaseClaimWithPresence(leaseID string) (leaseClaim, bool, error) {
 
 func validateLeaseClaimFileIdentity(leaseID string, claim leaseClaim, exists bool) error {
 	if exists && claim.LeaseID != "" && claim.LeaseID != leaseID {
-		return exit(2, "claim file %s contains lease id %s; refusing misfiled claim", leaseID, claim.LeaseID)
+		return &leaseClaimFileError{
+			code: "lease_id_mismatch",
+			err:  exit(2, "claim file %s contains lease id %s; refusing misfiled claim", leaseID, claim.LeaseID),
+		}
 	}
 	return nil
 }
@@ -1858,11 +1902,23 @@ func readLeaseClaimPathWithPresence(path string) (leaseClaim, bool, error) {
 		return leaseClaim{}, false, nil
 	}
 	if err != nil {
-		return leaseClaim{}, true, exit(2, "read claim %s: %v", path, err)
+		return leaseClaim{}, true, &leaseClaimFileError{
+			code: "read_error",
+			err:  exit(2, "read claim %s: %v", path, err),
+		}
+	}
+	if !utf8.Valid(data) {
+		return leaseClaim{}, true, &leaseClaimFileError{
+			code: "invalid_json",
+			err:  exit(2, "parse claim %s: invalid UTF-8", path),
+		}
 	}
 	var claim leaseClaim
 	if err := json.Unmarshal(data, &claim); err != nil {
-		return leaseClaim{}, true, exit(2, "parse claim %s: %v", path, err)
+		return leaseClaim{}, true, &leaseClaimFileError{
+			code: "invalid_json",
+			err:  exit(2, "parse claim %s: %v", path, err),
+		}
 	}
 	return claim, true, nil
 }

--- a/internal/cli/claim.go
+++ b/internal/cli/claim.go
@@ -98,9 +98,40 @@ func (e *leaseClaimFileError) Error() string { return e.err.Error() }
 func (e *leaseClaimFileError) Unwrap() error { return e.err }
 
 func snapshotLeaseClaims() (leaseClaimsSnapshot, error) {
-	return snapshotLeaseClaimsWithReader(func(_ string, leaseID string, _ os.FileInfo) (leaseClaim, bool, error) {
-		return readLeaseClaimWithPresence(leaseID)
-	})
+	dir, err := crabboxStateDir()
+	if err != nil {
+		return leaseClaimsSnapshot{}, err
+	}
+	entries, err := os.ReadDir(filepath.Join(dir, "claims"))
+	if errors.Is(err, os.ErrNotExist) {
+		return leaseClaimsSnapshot{}, nil
+	}
+	if err != nil {
+		return leaseClaimsSnapshot{}, exit(2, "read claims directory: %v", err)
+	}
+	snapshot := leaseClaimsSnapshot{invalid: make(map[string]error)}
+	for _, entry := range entries {
+		if filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		leaseID := strings.TrimSuffix(entry.Name(), ".json")
+		if !validLeaseClaimID(leaseID) {
+			snapshot.invalid[leaseID] = &leaseClaimFileError{
+				code: "invalid_filename",
+				err:  exit(2, "claim filename is not a valid lease id"),
+			}
+			continue
+		}
+		claim, exists, err := readLeaseClaimSnapshotLockedWithPresence(leaseID)
+		if err != nil {
+			snapshot.invalid[leaseID] = err
+			continue
+		}
+		if exists {
+			snapshot.claims = append(snapshot.claims, claim)
+		}
+	}
+	return snapshot, nil
 }
 
 type leaseClaimSnapshotReader func(path, leaseID string, expected os.FileInfo) (leaseClaim, bool, error)
@@ -109,7 +140,7 @@ type leaseClaimSnapshotReader func(path, leaseID string, expected os.FileInfo) (
 // bypasses claim locks so scanning a readable store never creates lock state or
 // requires write access. Runtime paths continue to use snapshotLeaseClaims.
 func snapshotLeaseClaimsReadOnly() (leaseClaimsSnapshot, error) {
-	snapshot, err := snapshotLeaseClaimsWithReader(readLeaseClaimSnapshotWithPresence)
+	snapshot, err := snapshotLeaseClaimsReadOnlyWithReader(readLeaseClaimSnapshotWithPresence)
 	if err != nil {
 		return leaseClaimsSnapshot{}, exit(1, "%v", err)
 	}
@@ -117,10 +148,6 @@ func snapshotLeaseClaimsReadOnly() (leaseClaimsSnapshot, error) {
 }
 
 func snapshotLeaseClaimsReadOnlyWithReader(read leaseClaimSnapshotReader) (leaseClaimsSnapshot, error) {
-	return snapshotLeaseClaimsWithReader(read)
-}
-
-func snapshotLeaseClaimsWithReader(read leaseClaimSnapshotReader) (leaseClaimsSnapshot, error) {
 	dir, err := crabboxStateDir()
 	if err != nil {
 		return leaseClaimsSnapshot{}, err
@@ -1889,6 +1916,52 @@ func readLeaseClaimWithPresence(leaseID string) (leaseClaim, bool, error) {
 	}
 	if err := validateLeaseClaimFileIdentity(leaseID, claim, exists); err != nil {
 		return leaseClaim{}, exists, err
+	}
+	return claim, exists, nil
+}
+
+func readLeaseClaimSnapshotLockedWithPresence(leaseID string) (leaseClaim, bool, error) {
+	path, err := leaseClaimPath(leaseID)
+	if err != nil {
+		var invalid invalidLeaseClaimIDError
+		if errors.As(err, &invalid) {
+			return leaseClaim{}, false, nil
+		}
+		return leaseClaim{}, false, err
+	}
+	var claim leaseClaim
+	var exists bool
+	err = withLeaseClaimLock(path, func() error {
+		info, statErr := os.Lstat(path)
+		if errors.Is(statErr, os.ErrNotExist) {
+			return nil
+		}
+		if statErr != nil {
+			exists = true
+			return leaseClaimSnapshotReadError(leaseID, "inspect", statErr)
+		}
+		exists = true
+		if !info.Mode().IsRegular() {
+			return &leaseClaimFileError{
+				code: "non_regular_file",
+				err:  exit(2, "claim file %s is not a regular file", leaseID),
+			}
+		}
+		var readErr error
+		claim, exists, readErr = readLeaseClaimPathWithPresence(path)
+		return readErr
+	})
+	if err != nil {
+		return leaseClaim{}, exists, err
+	}
+	if err := validateLeaseClaimFileIdentity(leaseID, claim, exists); err != nil {
+		return leaseClaim{}, exists, err
+	}
+	if exists && claim.LeaseID == "" {
+		return leaseClaim{}, true, &leaseClaimFileError{
+			code: "empty_lease_id",
+			err:  exit(2, "claim file %s has an empty lease id", leaseID),
+		}
 	}
 	return claim, exists, nil
 }

--- a/internal/cli/claim.go
+++ b/internal/cli/claim.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"io"
 	"net"
 	"net/url"
 	"os"
@@ -97,17 +98,38 @@ func (e *leaseClaimFileError) Error() string { return e.err.Error() }
 func (e *leaseClaimFileError) Unwrap() error { return e.err }
 
 func snapshotLeaseClaims() (leaseClaimsSnapshot, error) {
+	return snapshotLeaseClaimsWithReader(func(_ string, leaseID string, _ os.FileInfo) (leaseClaim, bool, error) {
+		return readLeaseClaimWithPresence(leaseID)
+	})
+}
+
+type leaseClaimSnapshotReader func(path, leaseID string, expected os.FileInfo) (leaseClaim, bool, error)
+
+// snapshotLeaseClaimsReadOnly is the public inventory reader. It intentionally
+// bypasses claim locks so scanning a readable store never creates lock state or
+// requires write access. Runtime paths continue to use snapshotLeaseClaims.
+func snapshotLeaseClaimsReadOnly() (leaseClaimsSnapshot, error) {
+	return snapshotLeaseClaimsWithReader(readLeaseClaimSnapshotWithPresence)
+}
+
+func snapshotLeaseClaimsReadOnlyWithReader(read leaseClaimSnapshotReader) (leaseClaimsSnapshot, error) {
+	return snapshotLeaseClaimsWithReader(read)
+}
+
+func snapshotLeaseClaimsWithReader(read leaseClaimSnapshotReader) (leaseClaimsSnapshot, error) {
 	dir, err := crabboxStateDir()
 	if err != nil {
 		return leaseClaimsSnapshot{}, err
 	}
-	entries, err := os.ReadDir(filepath.Join(dir, "claims"))
+	claimsDir := filepath.Join(dir, "claims")
+	entries, err := os.ReadDir(claimsDir)
 	if errors.Is(err, os.ErrNotExist) {
 		return leaseClaimsSnapshot{}, nil
 	}
 	if err != nil {
 		return leaseClaimsSnapshot{}, exit(2, "read claims directory: %v", err)
 	}
+
 	snapshot := leaseClaimsSnapshot{invalid: make(map[string]error)}
 	for _, entry := range entries {
 		if filepath.Ext(entry.Name()) != ".json" {
@@ -123,10 +145,7 @@ func snapshotLeaseClaims() (leaseClaimsSnapshot, error) {
 		}
 		info, err := entry.Info()
 		if err != nil {
-			snapshot.invalid[leaseID] = &leaseClaimFileError{
-				code: "read_error",
-				err:  exit(2, "inspect claim file %s: %v", leaseID, err),
-			}
+			snapshot.invalid[leaseID] = leaseClaimSnapshotReadError(leaseID, "inspect", err)
 			continue
 		}
 		if !info.Mode().IsRegular() {
@@ -136,7 +155,8 @@ func snapshotLeaseClaims() (leaseClaimsSnapshot, error) {
 			}
 			continue
 		}
-		claim, exists, err := readLeaseClaimWithPresence(leaseID)
+
+		claim, exists, err := read(filepath.Join(claimsDir, entry.Name()), leaseID, info)
 		if err != nil {
 			snapshot.invalid[leaseID] = err
 			continue
@@ -1869,6 +1889,61 @@ func readLeaseClaimWithPresence(leaseID string) (leaseClaim, bool, error) {
 	return claim, exists, nil
 }
 
+func readLeaseClaimSnapshotWithPresence(path, leaseID string, expected os.FileInfo) (leaseClaim, bool, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return leaseClaim{}, true, leaseClaimSnapshotReadError(leaseID, "open", err)
+	}
+	defer file.Close()
+
+	opened, err := file.Stat()
+	if err != nil {
+		return leaseClaim{}, true, leaseClaimSnapshotReadError(leaseID, "inspect opened", err)
+	}
+	if !opened.Mode().IsRegular() {
+		return leaseClaim{}, true, leaseClaimSnapshotReadError(leaseID, "verify regular", errors.New("claim path changed during scan"))
+	}
+	if !sameLeaseClaimSnapshotFile(expected, opened) {
+		return leaseClaim{}, true, leaseClaimSnapshotReadError(leaseID, "verify opened", errors.New("claim file changed during scan"))
+	}
+
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return leaseClaim{}, true, leaseClaimSnapshotReadError(leaseID, "read", err)
+	}
+	afterRead, err := file.Stat()
+	if err != nil {
+		return leaseClaim{}, true, leaseClaimSnapshotReadError(leaseID, "inspect read", err)
+	}
+	current, err := os.Lstat(path)
+	if err != nil {
+		return leaseClaim{}, true, leaseClaimSnapshotReadError(leaseID, "verify current", err)
+	}
+	if !sameLeaseClaimSnapshotFile(opened, afterRead) || !sameLeaseClaimSnapshotFile(afterRead, current) {
+		return leaseClaim{}, true, leaseClaimSnapshotReadError(leaseID, "verify stable", errors.New("claim file changed during scan"))
+	}
+
+	claim, err := decodeLeaseClaim(path, data)
+	if err != nil {
+		return leaseClaim{}, true, err
+	}
+	if err := validateLeaseClaimFileIdentity(leaseID, claim, true); err != nil {
+		return leaseClaim{}, true, err
+	}
+	return claim, true, nil
+}
+
+func sameLeaseClaimSnapshotFile(a, b os.FileInfo) bool {
+	return a != nil && b != nil && os.SameFile(a, b) && a.Mode() == b.Mode() && a.Size() == b.Size() && a.ModTime().Equal(b.ModTime())
+}
+
+func leaseClaimSnapshotReadError(leaseID, action string, err error) error {
+	return &leaseClaimFileError{
+		code: "read_error",
+		err:  exit(2, "%s claim file %s: %v", action, leaseID, err),
+	}
+}
+
 func validateLeaseClaimFileIdentity(leaseID string, claim leaseClaim, exists bool) error {
 	if exists && claim.LeaseID != "" && claim.LeaseID != leaseID {
 		return &leaseClaimFileError{
@@ -1907,20 +1982,25 @@ func readLeaseClaimPathWithPresence(path string) (leaseClaim, bool, error) {
 			err:  exit(2, "read claim %s: %v", path, err),
 		}
 	}
+	claim, err := decodeLeaseClaim(path, data)
+	return claim, true, err
+}
+
+func decodeLeaseClaim(path string, data []byte) (leaseClaim, error) {
 	if !utf8.Valid(data) {
-		return leaseClaim{}, true, &leaseClaimFileError{
+		return leaseClaim{}, &leaseClaimFileError{
 			code: "invalid_json",
 			err:  exit(2, "parse claim %s: invalid UTF-8", path),
 		}
 	}
 	var claim leaseClaim
 	if err := json.Unmarshal(data, &claim); err != nil {
-		return leaseClaim{}, true, &leaseClaimFileError{
+		return leaseClaim{}, &leaseClaimFileError{
 			code: "invalid_json",
 			err:  exit(2, "parse claim %s: %v", path, err),
 		}
 	}
-	return claim, true, nil
+	return claim, nil
 }
 
 func leaseClaimPath(leaseID string) (string, error) {

--- a/internal/cli/claims.go
+++ b/internal/cli/claims.go
@@ -1,0 +1,197 @@
+package cli
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const (
+	localClaimsListVersion        = 1
+	localClaimsListSource         = "local-claims"
+	maxLocalClaimProblems         = 100
+	maxLocalClaimProblemFileBytes = 160
+)
+
+type localClaimsListOutput struct {
+	Version  int                 `json:"version"`
+	Source   string              `json:"source"`
+	Claims   []localClaimView    `json:"claims"`
+	Problems []localClaimProblem `json:"problems"`
+}
+
+type localClaimView struct {
+	LeaseID            string `json:"leaseId"`
+	Slug               string `json:"slug"`
+	Provider           string `json:"provider"`
+	RepoRoot           string `json:"repoRoot"`
+	Pond               string `json:"pond"`
+	TargetOS           string `json:"targetOS"`
+	WindowsMode        string `json:"windowsMode"`
+	ClaimedAt          string `json:"claimedAt"`
+	LastUsedAt         string `json:"lastUsedAt"`
+	IdleTimeoutSeconds int    `json:"idleTimeoutSeconds"`
+}
+
+type localClaimProblem struct {
+	File    string `json:"file"`
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+func (a App) claimsList(args []string) error {
+	fs := newFlagSet("claims list", a.Stderr)
+	jsonOut := fs.Bool("json", false, "print JSON")
+	if err := parseFlags(fs, args); err != nil {
+		return err
+	}
+	if fs.NArg() != 0 {
+		return exit(2, "claims list does not accept positional arguments")
+	}
+
+	snapshot, err := snapshotLeaseClaims()
+	if err != nil {
+		return err
+	}
+	output := projectLocalClaims(snapshot)
+	if *jsonOut {
+		if err := json.NewEncoder(a.Stdout).Encode(output); err != nil {
+			return err
+		}
+	} else {
+		if err := renderLocalClaims(a.Stdout, output); err != nil {
+			return err
+		}
+	}
+	if len(snapshot.invalid) > 0 {
+		return ExitError{Code: 2}
+	}
+	return nil
+}
+
+func projectLocalClaims(snapshot leaseClaimsSnapshot) localClaimsListOutput {
+	claims := make([]localClaimView, 0, len(snapshot.claims))
+	for _, claim := range snapshot.claims {
+		claims = append(claims, localClaimView{
+			LeaseID:            claim.LeaseID,
+			Slug:               claim.Slug,
+			Provider:           claim.Provider,
+			RepoRoot:           claim.RepoRoot,
+			Pond:               claim.Pond,
+			TargetOS:           claim.TargetOS,
+			WindowsMode:        claim.WindowsMode,
+			ClaimedAt:          claim.ClaimedAt,
+			LastUsedAt:         claim.LastUsedAt,
+			IdleTimeoutSeconds: claim.IdleTimeoutSeconds,
+		})
+	}
+	sort.Slice(claims, func(i, j int) bool {
+		if claims[i].LeaseID != claims[j].LeaseID {
+			return claims[i].LeaseID < claims[j].LeaseID
+		}
+		if claims[i].Provider != claims[j].Provider {
+			return claims[i].Provider < claims[j].Provider
+		}
+		return claims[i].Slug < claims[j].Slug
+	})
+
+	problems := make([]localClaimProblem, 0, len(snapshot.invalid))
+	for leaseID, err := range snapshot.invalid {
+		code := "invalid_claim"
+		var fileErr *leaseClaimFileError
+		if errors.As(err, &fileErr) {
+			code = fileErr.code
+		}
+		problems = append(problems, localClaimProblem{
+			File:    localClaimProblemFile(leaseID),
+			Code:    code,
+			Message: localClaimProblemMessage(code),
+		})
+	}
+	sort.Slice(problems, func(i, j int) bool {
+		if problems[i].File != problems[j].File {
+			return problems[i].File < problems[j].File
+		}
+		return problems[i].Code < problems[j].Code
+	})
+	if len(problems) > maxLocalClaimProblems {
+		omitted := len(problems) - (maxLocalClaimProblems - 1)
+		problems = append(problems[:maxLocalClaimProblems-1], localClaimProblem{
+			Code:    "problems_truncated",
+			Message: fmt.Sprintf("%d additional malformed claim files omitted", omitted),
+		})
+	}
+
+	return localClaimsListOutput{
+		Version:  localClaimsListVersion,
+		Source:   localClaimsListSource,
+		Claims:   claims,
+		Problems: problems,
+	}
+}
+
+func localClaimProblemFile(leaseID string) string {
+	name := leaseID + ".json"
+	if validLeaseClaimID(leaseID) && len(name) <= maxLocalClaimProblemFileBytes {
+		return RedactDiagnosticSecrets(name)
+	}
+	digest := sha256.Sum256([]byte(name))
+	return fmt.Sprintf("sha256:%x", digest[:8])
+}
+
+func localClaimProblemMessage(code string) string {
+	switch code {
+	case "invalid_filename":
+		return "claim filename is not a valid lease id; filename replaced by a fingerprint"
+	case "invalid_json":
+		return "claim file is not valid JSON"
+	case "empty_lease_id":
+		return "claim file has a missing or empty leaseId"
+	case "lease_id_mismatch":
+		return "claim filename and payload leaseId do not match"
+	case "read_error":
+		return "claim file could not be read"
+	case "non_regular_file":
+		return "claim path is not a regular file"
+	default:
+		return "claim file is invalid"
+	}
+}
+
+func renderLocalClaims(stdout io.Writer, output localClaimsListOutput) error {
+	var rendered strings.Builder
+	fmt.Fprintln(&rendered, "Local claims (unverified local state; provider backends were not queried)")
+	if len(output.Claims) == 0 {
+		fmt.Fprintln(&rendered, "No valid local claims found.")
+	} else {
+		for _, claim := range output.Claims {
+			fmt.Fprintf(&rendered, "- leaseId: %s\n", strconv.QuoteToGraphic(claim.LeaseID))
+			fmt.Fprintf(&rendered, "  slug: %s\n", strconv.QuoteToGraphic(claim.Slug))
+			fmt.Fprintf(&rendered, "  provider: %s\n", strconv.QuoteToGraphic(claim.Provider))
+			fmt.Fprintf(&rendered, "  repoRoot: %s\n", strconv.QuoteToGraphic(claim.RepoRoot))
+			fmt.Fprintf(&rendered, "  pond: %s\n", strconv.QuoteToGraphic(claim.Pond))
+			fmt.Fprintf(&rendered, "  targetOS: %s\n", strconv.QuoteToGraphic(claim.TargetOS))
+			fmt.Fprintf(&rendered, "  windowsMode: %s\n", strconv.QuoteToGraphic(claim.WindowsMode))
+			fmt.Fprintf(&rendered, "  claimedAt: %s\n", strconv.QuoteToGraphic(claim.ClaimedAt))
+			fmt.Fprintf(&rendered, "  lastUsedAt: %s\n", strconv.QuoteToGraphic(claim.LastUsedAt))
+			fmt.Fprintf(&rendered, "  idleTimeoutSeconds: %d\n", claim.IdleTimeoutSeconds)
+		}
+	}
+	if len(output.Problems) > 0 {
+		fmt.Fprintln(&rendered, "Problems:")
+		for _, problem := range output.Problems {
+			if problem.File == "" {
+				fmt.Fprintf(&rendered, "- %s (%s)\n", problem.Message, problem.Code)
+				continue
+			}
+			fmt.Fprintf(&rendered, "- %s: %s (%s)\n", strconv.QuoteToGraphic(problem.File), problem.Message, problem.Code)
+		}
+	}
+	_, err := io.WriteString(stdout, rendered.String())
+	return err
+}

--- a/internal/cli/claims.go
+++ b/internal/cli/claims.go
@@ -54,7 +54,7 @@ func (a App) claimsList(args []string) error {
 		return exit(2, "claims list does not accept positional arguments")
 	}
 
-	snapshot, err := snapshotLeaseClaims()
+	snapshot, err := snapshotLeaseClaimsReadOnly()
 	if err != nil {
 		return err
 	}

--- a/internal/cli/claims.go
+++ b/internal/cli/claims.go
@@ -137,7 +137,7 @@ func projectLocalClaims(snapshot leaseClaimsSnapshot) localClaimsListOutput {
 
 func localClaimProblemFile(leaseID string) string {
 	name := leaseID + ".json"
-	if validLeaseClaimID(leaseID) && len(name) <= maxLocalClaimProblemFileBytes {
+	if validLeaseClaimPathID(leaseID) && len(name) <= maxLocalClaimProblemFileBytes {
 		return RedactDiagnosticSecrets(name)
 	}
 	digest := sha256.Sum256([]byte(name))

--- a/internal/cli/claims_readonly_unix_test.go
+++ b/internal/cli/claims_readonly_unix_test.go
@@ -85,3 +85,42 @@ func TestClaimsListReadableNonWritableStore(t *testing.T) {
 		})
 	}
 }
+
+func TestRuntimeClaimsSnapshotChecksFileTypeInsideLock(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	stateDir, err := crabboxStateDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	claimsDir := filepath.Join(stateDir, "claims")
+	if err := os.MkdirAll(claimsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(stateDir, "outside-claim.json")
+	if err := os.WriteFile(target, []byte(`{"leaseID":"cbx_link"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(claimsDir, "cbx_link.json")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(claimsDir, "cbx_dir.json"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	snapshot, err := snapshotLeaseClaims()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snapshot.claims) != 0 {
+		t.Fatalf("claims=%#v", snapshot.claims)
+	}
+	for _, leaseID := range []string{"cbx_dir", "cbx_link"} {
+		var fileErr *leaseClaimFileError
+		if !errors.As(snapshot.invalid[leaseID], &fileErr) || fileErr.code != "non_regular_file" {
+			t.Fatalf("invalid[%s]=%v", leaseID, snapshot.invalid[leaseID])
+		}
+		if _, err := os.Stat(filepath.Join(stateDir, "claim-locks", leaseID+".json.lock")); err != nil {
+			t.Fatalf("runtime lock missing for %s: %v", leaseID, err)
+		}
+	}
+}

--- a/internal/cli/claims_readonly_unix_test.go
+++ b/internal/cli/claims_readonly_unix_test.go
@@ -1,0 +1,87 @@
+//go:build !windows
+
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestClaimsListReadableNonWritableStore(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		malformed bool
+		wantCode  int
+	}{
+		{name: "valid", wantCode: 0},
+		{name: "malformed_partial", malformed: true, wantCode: 2},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			writeClaimsListFixture(t, "cbx_valid.json", leaseClaim{LeaseID: "cbx_valid", Provider: "local-container"})
+			if test.malformed {
+				writeClaimsListRawFixture(t, "cbx_broken.json", []byte("{"))
+			}
+
+			stateDir, err := crabboxStateDir()
+			if err != nil {
+				t.Fatal(err)
+			}
+			claimsDir := filepath.Join(stateDir, "claims")
+			entries, err := os.ReadDir(claimsDir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, entry := range entries {
+				if err := os.Chmod(filepath.Join(claimsDir, entry.Name()), 0o400); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := os.Chmod(claimsDir, 0o500); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Chmod(stateDir, 0o500); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() {
+				_ = os.Chmod(stateDir, 0o700)
+				_ = os.Chmod(claimsDir, 0o700)
+				for _, entry := range entries {
+					_ = os.Chmod(filepath.Join(claimsDir, entry.Name()), 0o600)
+				}
+			})
+
+			before := captureClaimsListState(t, stateDir)
+			stdout, stderr, runErr := runClaimsList(t, "--json")
+			assertClaimsExitCode(t, runErr, test.wantCode)
+			if stderr != "" {
+				t.Fatalf("stderr=%q", stderr)
+			}
+			var output localClaimsListOutput
+			if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+				t.Fatalf("decode output: %v\n%s", err, stdout)
+			}
+			if len(output.Claims) != 1 || output.Claims[0].LeaseID != "cbx_valid" {
+				t.Fatalf("partial claims=%#v", output.Claims)
+			}
+			wantProblems := 0
+			if test.malformed {
+				wantProblems = 1
+			}
+			if len(output.Problems) != wantProblems {
+				t.Fatalf("problems=%#v", output.Problems)
+			}
+			after := captureClaimsListState(t, stateDir)
+			if !reflect.DeepEqual(after, before) {
+				t.Fatalf("read-only scan mutated state\nbefore=%#v\nafter=%#v", before, after)
+			}
+			if _, err := os.Stat(filepath.Join(stateDir, "claim-locks")); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("claim-locks created or unreadable: %v", err)
+			}
+		})
+	}
+}

--- a/internal/cli/claims_test.go
+++ b/internal/cli/claims_test.go
@@ -157,6 +157,78 @@ func TestRuntimeClaimsSnapshotRetainsLockedReader(t *testing.T) {
 	}
 }
 
+func TestLeaseClaimsSnapshotBoundaryHandling(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	writeClaimsListRawFixture(t, ".json", []byte(`{"leaseID":"ignored"}`))
+	writeClaimsListRawFixture(t, "ignored.txt", []byte("not a claim"))
+	writeClaimsListFixture(t, "cbx_empty.json", leaseClaim{})
+	writeClaimsListFixture(t, "cbx_mismatch.json", leaseClaim{LeaseID: "cbx_other"})
+	writeClaimsListFixture(t, "cbx_skip.json", leaseClaim{LeaseID: "cbx_skip"})
+
+	snapshot, err := snapshotLeaseClaims()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snapshot.claims) != 1 || snapshot.claims[0].LeaseID != "cbx_skip" {
+		t.Fatalf("claims=%#v", snapshot.claims)
+	}
+	for leaseID, wantCode := range map[string]string{
+		"":             "invalid_filename",
+		"cbx_empty":    "empty_lease_id",
+		"cbx_mismatch": "lease_id_mismatch",
+	} {
+		var fileErr *leaseClaimFileError
+		if !errors.As(snapshot.invalid[leaseID], &fileErr) || fileErr.code != wantCode {
+			t.Fatalf("invalid[%q]=%v want code=%s", leaseID, snapshot.invalid[leaseID], wantCode)
+		}
+	}
+
+	if claim, exists, err := readLeaseClaimSnapshotLockedWithPresence("bad/name"); err != nil || exists || claim.LeaseID != "" {
+		t.Fatalf("invalid ID read=(%#v, %t, %v)", claim, exists, err)
+	}
+	if claim, exists, err := readLeaseClaimSnapshotLockedWithPresence("cbx_missing"); err != nil || exists || claim.LeaseID != "" {
+		t.Fatalf("missing read=(%#v, %t, %v)", claim, exists, err)
+	}
+
+	readCalls := 0
+	readOnly, err := snapshotLeaseClaimsReadOnlyWithReader(func(_ string, _ string, _ os.FileInfo) (leaseClaim, bool, error) {
+		readCalls++
+		return leaseClaim{}, false, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if readCalls != 3 || len(readOnly.claims) != 0 {
+		t.Fatalf("read calls=%d snapshot=%#v", readCalls, readOnly)
+	}
+	stateDir, err := crabboxStateDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	claimsDir := filepath.Join(stateDir, "claims")
+	dirInfo, err := os.Stat(claimsDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, exists, err := readLeaseClaimSnapshotWithPresence(claimsDir, "cbx_directory", dirInfo); err == nil || !exists {
+		t.Fatalf("directory snapshot read=(exists=%t, err=%v)", exists, err)
+	}
+
+	sentinel := errors.New("sentinel")
+	if !errors.Is(&leaseClaimFileError{code: "test", err: sentinel}, sentinel) {
+		t.Fatal("lease claim file error did not unwrap")
+	}
+
+	brokenStateRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(brokenStateRoot, "crabbox"), []byte("not a directory"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("XDG_STATE_HOME", brokenStateRoot)
+	if _, err := snapshotLeaseClaims(); err == nil {
+		t.Fatal("runtime snapshot accepted an unreadable claims directory")
+	}
+}
+
 func TestClaimsListConcurrentDeleteAndChangeProduceDeterministicProblems(t *testing.T) {
 	var want localClaimsListOutput
 	for iteration := 0; iteration < 2; iteration++ {

--- a/internal/cli/claims_test.go
+++ b/internal/cli/claims_test.go
@@ -1,0 +1,350 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestClaimsListReadsTwoProvidersWithoutBackendOrCredentials(t *testing.T) {
+	clearConfigEnv(t)
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(configPath, []byte("provider: hetzner\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CRABBOX_CONFIG", configPath)
+	t.Setenv("HCLOUD_TOKEN", "")
+	t.Setenv("HETZNER_TOKEN", "")
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+
+	writeClaimsListFixture(t, "cbx_zulu.json", leaseClaim{
+		LeaseID: "cbx_zulu", Provider: "aws", RepoRoot: "/repo/zulu", LastUsedAt: "2026-08-01T00:00:00Z",
+	})
+	writeClaimsListFixture(t, "cbx_alpha.json", leaseClaim{
+		LeaseID: "cbx_alpha", Provider: "hetzner", RepoRoot: "/repo/alpha", LastUsedAt: "2026-08-02T00:00:00Z",
+	})
+
+	stdout, stderr, err := runClaimsList(t, "--json")
+	if err != nil {
+		t.Fatalf("claims list error=%v stderr=%q", err, stderr)
+	}
+	var output localClaimsListOutput
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatalf("decode output: %v\n%s", err, stdout)
+	}
+	if output.Version != 1 || output.Source != "local-claims" {
+		t.Fatalf("metadata=%#v", output)
+	}
+	if len(output.Claims) != 2 || output.Claims[0].LeaseID != "cbx_alpha" || output.Claims[1].LeaseID != "cbx_zulu" {
+		t.Fatalf("claims=%#v", output.Claims)
+	}
+	if len(output.Problems) != 0 {
+		t.Fatalf("problems=%#v", output.Problems)
+	}
+}
+
+func TestClaimsListKeepsStaleValidClaimAndLabelsHumanOutputUnverified(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	writeClaimsListFixture(t, "cbx_stale.json", leaseClaim{
+		LeaseID:    "cbx_stale",
+		Slug:       "old-lobster",
+		Provider:   "local-container",
+		RepoRoot:   "/repo/stale",
+		ClaimedAt:  "2000-01-01T00:00:00Z",
+		LastUsedAt: "2000-01-02T00:00:00Z",
+	})
+
+	stdout, stderr, err := runClaimsList(t)
+	if err != nil {
+		t.Fatalf("claims list error=%v stderr=%q", err, stderr)
+	}
+	for _, want := range []string{
+		"unverified local state",
+		"provider backends were not queried",
+		`leaseId: "cbx_stale"`,
+		`provider: "local-container"`,
+		`repoRoot: "/repo/stale"`,
+		`lastUsedAt: "2000-01-02T00:00:00Z"`,
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("human output missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestClaimsListReportsMalformedRecordsWithStablePartialOutput(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	writeClaimsListFixture(t, "cbx_zulu.json", leaseClaim{LeaseID: "cbx_zulu", Provider: "aws"})
+	writeClaimsListFixture(t, "cbx_alpha.json", leaseClaim{LeaseID: "cbx_alpha", Provider: "hetzner"})
+	writeClaimsListRawFixture(t, ".json", []byte(`{"leaseID":"ignored"}`))
+	writeClaimsListRawFixture(t, "z-invalid.json", []byte(`{"token":"invalid-json-secret"`))
+	writeClaimsListRawFixture(t, "y-invalid-utf8.json", append([]byte(`{"leaseID":"y-invalid-utf8","slug":"`), 0xff, '"', '}'))
+	writeClaimsListRawFixture(t, "m-empty.json", []byte(`{"leaseID":""}`))
+	writeClaimsListRawFixture(t, "a-mismatch.json", []byte(`{"leaseID":"token=payload-secret"}`))
+	makeClaimsListDirectoryFixture(t, "n-non-regular.json")
+
+	stdout, stderr, err := runClaimsList(t, "--json")
+	assertClaimsExitCode(t, err, 2)
+	if stderr != "" {
+		t.Fatalf("stderr=%q", stderr)
+	}
+	if strings.Contains(stdout, "invalid-json-secret") || strings.Contains(stdout, "payload-secret") {
+		t.Fatalf("malformed-record output leaked fixture content: %s", stdout)
+	}
+	var output localClaimsListOutput
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatalf("decode output: %v\n%s", err, stdout)
+	}
+	if got := []string{output.Claims[0].LeaseID, output.Claims[1].LeaseID}; !reflect.DeepEqual(got, []string{"cbx_alpha", "cbx_zulu"}) {
+		t.Fatalf("claim order=%q", got)
+	}
+	wantCodes := map[string]bool{
+		"invalid_filename":  false,
+		"empty_lease_id":    false,
+		"lease_id_mismatch": false,
+		"non_regular_file":  false,
+	}
+	if len(output.Problems) != len(wantCodes)+2 {
+		t.Fatalf("problems=%#v", output.Problems)
+	}
+	invalidJSONProblems := 0
+	for i, problem := range output.Problems {
+		if i > 0 && localClaimProblemLess(problem, output.Problems[i-1]) {
+			t.Fatalf("problems not sorted: %#v", output.Problems)
+		}
+		if problem.Code == "invalid_json" {
+			invalidJSONProblems++
+		} else if _, ok := wantCodes[problem.Code]; !ok {
+			t.Fatalf("unexpected problem=%#v", problem)
+		} else {
+			wantCodes[problem.Code] = true
+		}
+		if problem.Message == "" || len(problem.File) > maxLocalClaimProblemFileBytes {
+			t.Fatalf("unbounded or empty problem=%#v", problem)
+		}
+	}
+	for code, seen := range wantCodes {
+		if !seen {
+			t.Fatalf("missing problem code %s: %#v", code, output.Problems)
+		}
+	}
+	if invalidJSONProblems != 2 {
+		t.Fatalf("invalid JSON problems=%d want=2: %#v", invalidJSONProblems, output.Problems)
+	}
+}
+
+func TestClaimsListJSONProjectionExcludesEveryPrivateSensitiveField(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	claim := leaseClaim{
+		LeaseID:                             "cbx_sensitive",
+		Revision:                            "sensitive-revision",
+		Slug:                                "safe-slug",
+		Provider:                            "external",
+		CloudID:                             "sensitive-cloud-id",
+		CloudNumericID:                      424242,
+		CloudImmutableID:                    "sensitive-immutable-id",
+		ProviderScope:                       "sensitive-provider-scope",
+		StaticHost:                          "sensitive-static-host",
+		StaticUser:                          "sensitive-static-user",
+		StaticPort:                          "2244",
+		StaticWorkRoot:                      "/sensitive/static/root",
+		TargetOS:                            "windows",
+		WindowsMode:                         "wsl2",
+		Pond:                                "safe-pond",
+		RepoRoot:                            "/safe/repo",
+		ClaimedAt:                           "2026-08-01T00:00:00Z",
+		LastUsedAt:                          "2026-08-02T00:00:00Z",
+		IdleTimeoutSeconds:                  1800,
+		TailscaleIPv4:                       "100.64.0.1",
+		TailscaleFQDN:                       "sensitive.ts.net",
+		TailscaleHostname:                   "sensitive-hostname",
+		TailscaleTags:                       []string{"tag:sensitive"},
+		TailscaleLoginURL:                   "https://login.example.test/?token=sensitive-login-token",
+		TailscaleExitNode:                   "sensitive-exit-node",
+		TailscaleExitLAN:                    true,
+		SSHHost:                             "sensitive-ssh-host",
+		SSHPort:                             2222,
+		BridgeURL:                           "https://bridge.example.test/sensitive",
+		CoordinatorRegistrationURL:          "https://coordinator.example.test/register/sensitive",
+		RuntimeAdapterRegistrationID:        "sensitive-registration-id",
+		RuntimeAdapterPendingRegistrationID: "sensitive-pending-registration-id",
+		CacheVolumes:                        []string{"sensitive-cache-volume"},
+		Labels:                              map[string]string{"secret": "sensitive-label"},
+		FixedCreateIntent: &FixedCreateIntent{
+			Version: 1, Fingerprint: "sensitive-fingerprint", ProviderScope: "sensitive-fixed-scope",
+			Slug: "sensitive-fixed-slug", CreatedAt: "2026-08-03T00:00:00Z", State: "pending",
+			Attempt: map[string]string{"credential": "sensitive-attempt"}, FailedAttempts: []string{"sensitive-failure"},
+		},
+	}
+	writeClaimsListFixture(t, "cbx_sensitive.json", claim)
+
+	stdout, stderr, err := runClaimsList(t, "--json")
+	if err != nil {
+		t.Fatalf("claims list error=%v stderr=%q", err, stderr)
+	}
+	for _, secret := range []string{
+		"sensitive-revision", "sensitive-cloud-id", "sensitive-provider-scope", "sensitive-static-host",
+		"sensitive-login-token", "sensitive-ssh-host", "sensitive-registration-id", "sensitive-label",
+		"sensitive-fingerprint", "sensitive-attempt", "sensitive-failure",
+	} {
+		if strings.Contains(stdout, secret) {
+			t.Fatalf("JSON leaked %q: %s", secret, stdout)
+		}
+	}
+
+	var document map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(stdout), &document); err != nil {
+		t.Fatal(err)
+	}
+	if got := sortedMapKeys(document); !reflect.DeepEqual(got, []string{"claims", "problems", "source", "version"}) {
+		t.Fatalf("root keys=%q", got)
+	}
+	var claims []map[string]json.RawMessage
+	if err := json.Unmarshal(document["claims"], &claims); err != nil {
+		t.Fatal(err)
+	}
+	wantKeys := []string{
+		"claimedAt", "idleTimeoutSeconds", "lastUsedAt", "leaseId", "pond", "provider", "repoRoot", "slug", "targetOS", "windowsMode",
+	}
+	if len(claims) != 1 || !reflect.DeepEqual(sortedMapKeys(claims[0]), wantKeys) {
+		t.Fatalf("public claim keys=%q", sortedMapKeys(claims[0]))
+	}
+	allowlistedPrivateTags := map[string]bool{
+		"leaseID": true, "slug": true, "provider": true, "repoRoot": true, "pond": true,
+		"targetOS": true, "windowsMode": true, "claimedAt": true, "lastUsedAt": true, "idleTimeoutSeconds": true,
+	}
+	claimType := reflect.TypeOf(leaseClaim{})
+	for i := 0; i < claimType.NumField(); i++ {
+		name := strings.Split(claimType.Field(i).Tag.Get("json"), ",")[0]
+		if name != "" && !allowlistedPrivateTags[name] && strings.Contains(stdout, `"`+name+`"`) {
+			t.Fatalf("JSON serialized sensitive private field %q: %s", name, stdout)
+		}
+	}
+}
+
+func TestClaimsListEmptyJSONHasStableArrays(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	stdout, stderr, err := runClaimsList(t, "--json")
+	if err != nil {
+		t.Fatalf("claims list error=%v stderr=%q", err, stderr)
+	}
+	want := `{"version":1,"source":"local-claims","claims":[],"problems":[]}` + "\n"
+	if stdout != want {
+		t.Fatalf("output=%q want=%q", stdout, want)
+	}
+}
+
+func TestClaimsListBoundsProblemEntries(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	for i := 0; i < maxLocalClaimProblems+7; i++ {
+		writeClaimsListRawFixture(t, fmt.Sprintf("cbx_broken_%03d.json", i), []byte("{"))
+	}
+
+	stdout, _, err := runClaimsList(t, "--json")
+	assertClaimsExitCode(t, err, 2)
+	var output localClaimsListOutput
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatal(err)
+	}
+	if len(output.Problems) != maxLocalClaimProblems {
+		t.Fatalf("problems=%d want=%d", len(output.Problems), maxLocalClaimProblems)
+	}
+	last := output.Problems[len(output.Problems)-1]
+	if last.Code != "problems_truncated" || last.File != "" || !strings.Contains(last.Message, "additional malformed claim files omitted") {
+		t.Fatalf("truncation problem=%#v", last)
+	}
+}
+
+func TestClaimsListHelpAndTopLevelHelpExposeLocalOnlyCommand(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	app := App{Stdout: &stdout, Stderr: &stderr}
+	if err := app.Run(context.Background(), []string{"--help"}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout.String(), "claims      Inspect unverified local lease claims without loading providers") {
+		t.Fatalf("top-level help omitted claims command:\n%s", stdout.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	err := app.Run(context.Background(), []string{"claims", "list", "--help"})
+	assertClaimsExitCode(t, err, 0)
+	if !strings.Contains(stderr.String(), "Usage of claims list:") || !strings.Contains(stderr.String(), "-json") {
+		t.Fatalf("claims list help=%q", stderr.String())
+	}
+}
+
+func runClaimsList(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	command := append([]string{"claims", "list"}, args...)
+	err := (App{Stdout: &stdout, Stderr: &stderr}).Run(context.Background(), command)
+	return stdout.String(), stderr.String(), err
+}
+
+func writeClaimsListFixture(t *testing.T, name string, value any) {
+	t.Helper()
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeClaimsListRawFixture(t, name, data)
+}
+
+func writeClaimsListRawFixture(t *testing.T, name string, data []byte) {
+	t.Helper()
+	dir, err := crabboxStateDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	claimsDir := filepath.Join(dir, "claims")
+	if err := os.MkdirAll(claimsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(claimsDir, name), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func makeClaimsListDirectoryFixture(t *testing.T, name string) {
+	t.Helper()
+	dir, err := crabboxStateDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "claims", name), 0o700); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertClaimsExitCode(t *testing.T, err error, want int) {
+	t.Helper()
+	if want == 0 && err == nil {
+		return
+	}
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != want {
+		t.Fatalf("exit error=%v want code=%d", err, want)
+	}
+}
+
+func localClaimProblemLess(a, b localClaimProblem) bool {
+	return a.File < b.File || (a.File == b.File && a.Code < b.Code)
+}
+
+func sortedMapKeys[V any](values map[string]V) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/cli/claims_test.go
+++ b/internal/cli/claims_test.go
@@ -84,18 +84,24 @@ func TestClaimsListKeepsStaleValidClaimAndLabelsHumanOutputUnverified(t *testing
 
 func TestClaimsListScansDoNotCreateLocksOrMutateState(t *testing.T) {
 	for _, test := range []struct {
-		name      string
-		malformed bool
-		wantCode  int
+		name               string
+		malformedJSON      bool
+		whitespaceFilename bool
+		wantCode           int
+		wantProblemCode    string
 	}{
 		{name: "clean", wantCode: 0},
-		{name: "malformed", malformed: true, wantCode: 2},
+		{name: "malformed", malformedJSON: true, wantCode: 2, wantProblemCode: "invalid_json"},
+		{name: "whitespace_filename", whitespaceFilename: true, wantCode: 2, wantProblemCode: "invalid_filename"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Setenv("XDG_STATE_HOME", t.TempDir())
 			writeClaimsListFixture(t, "cbx_valid.json", leaseClaim{LeaseID: "cbx_valid", Provider: "local-container"})
-			if test.malformed {
+			if test.malformedJSON {
 				writeClaimsListRawFixture(t, "cbx_broken.json", []byte("{"))
+			}
+			if test.whitespaceFilename {
+				writeClaimsListFixture(t, " cbx_padded.json", leaseClaim{LeaseID: " cbx_padded"})
 			}
 
 			stateDir, err := crabboxStateDir()
@@ -107,6 +113,20 @@ func TestClaimsListScansDoNotCreateLocksOrMutateState(t *testing.T) {
 			assertClaimsExitCode(t, runErr, test.wantCode)
 			if stderr != "" || !strings.Contains(stdout, `"leaseId":"cbx_valid"`) {
 				t.Fatalf("stdout=%q stderr=%q", stdout, stderr)
+			}
+			var output localClaimsListOutput
+			if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+				t.Fatalf("decode output: %v\n%s", err, stdout)
+			}
+			if len(output.Claims) != 1 || output.Claims[0].LeaseID != "cbx_valid" {
+				t.Fatalf("claims=%#v", output.Claims)
+			}
+			if test.wantProblemCode == "" {
+				if len(output.Problems) != 0 {
+					t.Fatalf("problems=%#v", output.Problems)
+				}
+			} else if len(output.Problems) != 1 || output.Problems[0].Code != test.wantProblemCode {
+				t.Fatalf("problems=%#v want code=%s", output.Problems, test.wantProblemCode)
 			}
 			after := captureClaimsListState(t, stateDir)
 			if !reflect.DeepEqual(after, before) {
@@ -160,6 +180,9 @@ func TestRuntimeClaimsSnapshotRetainsLockedReader(t *testing.T) {
 func TestLeaseClaimsSnapshotBoundaryHandling(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	writeClaimsListRawFixture(t, ".json", []byte(`{"leaseID":"ignored"}`))
+	writeClaimsListFixture(t, " cbx_leading.json", leaseClaim{LeaseID: " cbx_leading"})
+	writeClaimsListFixture(t, "cbx_trailing .json", leaseClaim{LeaseID: "cbx_trailing "})
+	writeClaimsListFixture(t, "   .json", leaseClaim{LeaseID: "   "})
 	writeClaimsListRawFixture(t, "ignored.txt", []byte("not a claim"))
 	writeClaimsListFixture(t, "cbx_empty.json", leaseClaim{})
 	writeClaimsListFixture(t, "cbx_mismatch.json", leaseClaim{LeaseID: "cbx_other"})
@@ -172,15 +195,35 @@ func TestLeaseClaimsSnapshotBoundaryHandling(t *testing.T) {
 	if len(snapshot.claims) != 1 || snapshot.claims[0].LeaseID != "cbx_skip" {
 		t.Fatalf("claims=%#v", snapshot.claims)
 	}
-	for leaseID, wantCode := range map[string]string{
-		"":             "invalid_filename",
-		"cbx_empty":    "empty_lease_id",
-		"cbx_mismatch": "lease_id_mismatch",
-	} {
+	wantInvalidCodes := map[string]string{
+		"":              "invalid_filename",
+		" cbx_leading":  "invalid_filename",
+		"cbx_trailing ": "invalid_filename",
+		"   ":           "invalid_filename",
+		"cbx_empty":     "empty_lease_id",
+		"cbx_mismatch":  "lease_id_mismatch",
+	}
+	for leaseID, wantCode := range wantInvalidCodes {
 		var fileErr *leaseClaimFileError
 		if !errors.As(snapshot.invalid[leaseID], &fileErr) || fileErr.code != wantCode {
 			t.Fatalf("invalid[%q]=%v want code=%s", leaseID, snapshot.invalid[leaseID], wantCode)
 		}
+	}
+	stateDir, err := crabboxStateDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	lockEntries, err := os.ReadDir(filepath.Join(stateDir, "claim-locks"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotLocks := make([]string, 0, len(lockEntries))
+	for _, entry := range lockEntries {
+		gotLocks = append(gotLocks, entry.Name())
+	}
+	wantLocks := []string{"cbx_empty.json.lock", "cbx_mismatch.json.lock", "cbx_skip.json.lock"}
+	if !reflect.DeepEqual(gotLocks, wantLocks) {
+		t.Fatalf("runtime locks=%q want=%q", gotLocks, wantLocks)
 	}
 
 	if claim, exists, err := readLeaseClaimSnapshotLockedWithPresence("bad/name"); err != nil || exists || claim.LeaseID != "" {
@@ -201,9 +244,11 @@ func TestLeaseClaimsSnapshotBoundaryHandling(t *testing.T) {
 	if readCalls != 3 || len(readOnly.claims) != 0 {
 		t.Fatalf("read calls=%d snapshot=%#v", readCalls, readOnly)
 	}
-	stateDir, err := crabboxStateDir()
-	if err != nil {
-		t.Fatal(err)
+	for _, leaseID := range []string{"", " cbx_leading", "cbx_trailing ", "   "} {
+		var fileErr *leaseClaimFileError
+		if !errors.As(readOnly.invalid[leaseID], &fileErr) || fileErr.code != "invalid_filename" {
+			t.Fatalf("read-only invalid[%q]=%v want code=invalid_filename", leaseID, readOnly.invalid[leaseID])
+		}
 	}
 	claimsDir := filepath.Join(stateDir, "claims")
 	dirInfo, err := os.Stat(claimsDir)
@@ -293,6 +338,9 @@ func TestClaimsListReportsMalformedRecordsWithStablePartialOutput(t *testing.T) 
 	writeClaimsListFixture(t, "cbx_zulu.json", leaseClaim{LeaseID: "cbx_zulu", Provider: "aws"})
 	writeClaimsListFixture(t, "cbx_alpha.json", leaseClaim{LeaseID: "cbx_alpha", Provider: "hetzner"})
 	writeClaimsListRawFixture(t, ".json", []byte(`{"leaseID":"ignored"}`))
+	writeClaimsListFixture(t, " cbx_leading.json", leaseClaim{LeaseID: " cbx_leading"})
+	writeClaimsListFixture(t, "cbx_trailing .json", leaseClaim{LeaseID: "cbx_trailing "})
+	writeClaimsListFixture(t, "   .json", leaseClaim{LeaseID: "   "})
 	writeClaimsListRawFixture(t, "z-invalid.json", []byte(`{"token":"invalid-json-secret"`))
 	writeClaimsListRawFixture(t, "y-invalid-utf8.json", append([]byte(`{"leaseID":"y-invalid-utf8","slug":"`), 0xff, '"', '}'))
 	writeClaimsListRawFixture(t, "m-empty.json", []byte(`{"leaseID":""}`))
@@ -314,38 +362,39 @@ func TestClaimsListReportsMalformedRecordsWithStablePartialOutput(t *testing.T) 
 	if got := []string{output.Claims[0].LeaseID, output.Claims[1].LeaseID}; !reflect.DeepEqual(got, []string{"cbx_alpha", "cbx_zulu"}) {
 		t.Fatalf("claim order=%q", got)
 	}
-	wantCodes := map[string]bool{
-		"invalid_filename":  false,
-		"empty_lease_id":    false,
-		"lease_id_mismatch": false,
-		"non_regular_file":  false,
+	wantCodeCounts := map[string]int{
+		"invalid_filename":  4,
+		"invalid_json":      2,
+		"empty_lease_id":    1,
+		"lease_id_mismatch": 1,
+		"non_regular_file":  1,
 	}
-	if len(output.Problems) != len(wantCodes)+2 {
+	if len(output.Problems) != 9 {
 		t.Fatalf("problems=%#v", output.Problems)
 	}
-	invalidJSONProblems := 0
+	gotCodeCounts := make(map[string]int)
 	for i, problem := range output.Problems {
 		if i > 0 && localClaimProblemLess(problem, output.Problems[i-1]) {
 			t.Fatalf("problems not sorted: %#v", output.Problems)
 		}
-		if problem.Code == "invalid_json" {
-			invalidJSONProblems++
-		} else if _, ok := wantCodes[problem.Code]; !ok {
+		if _, ok := wantCodeCounts[problem.Code]; !ok {
 			t.Fatalf("unexpected problem=%#v", problem)
-		} else {
-			wantCodes[problem.Code] = true
+		}
+		gotCodeCounts[problem.Code]++
+		if problem.Code == "invalid_filename" && !strings.HasPrefix(problem.File, "sha256:") {
+			t.Fatalf("invalid filename was not fingerprinted: %#v", problem)
 		}
 		if problem.Message == "" || len(problem.File) > maxLocalClaimProblemFileBytes {
 			t.Fatalf("unbounded or empty problem=%#v", problem)
 		}
 	}
-	for code, seen := range wantCodes {
-		if !seen {
-			t.Fatalf("missing problem code %s: %#v", code, output.Problems)
-		}
+	if !reflect.DeepEqual(gotCodeCounts, wantCodeCounts) {
+		t.Fatalf("problem counts=%v want=%v: %#v", gotCodeCounts, wantCodeCounts, output.Problems)
 	}
-	if invalidJSONProblems != 2 {
-		t.Fatalf("invalid JSON problems=%d want=2: %#v", invalidJSONProblems, output.Problems)
+	secondStdout, secondStderr, secondErr := runClaimsList(t, "--json")
+	assertClaimsExitCode(t, secondErr, 2)
+	if secondStderr != "" || secondStdout != stdout {
+		t.Fatalf("nondeterministic output\nfirst stdout=%q\nsecond stdout=%q\nsecond stderr=%q", stdout, secondStdout, secondStderr)
 	}
 }
 

--- a/internal/cli/claims_test.go
+++ b/internal/cli/claims_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -17,7 +18,7 @@ func TestClaimsListReadsTwoProvidersWithoutBackendOrCredentials(t *testing.T) {
 	clearConfigEnv(t)
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	configPath := filepath.Join(t.TempDir(), "config.yaml")
-	if err := os.WriteFile(configPath, []byte("provider: hetzner\n"), 0o600); err != nil {
+	if err := os.WriteFile(configPath, []byte("provider: backend-that-must-not-load\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("CRABBOX_CONFIG", configPath)
@@ -77,6 +78,123 @@ func TestClaimsListKeepsStaleValidClaimAndLabelsHumanOutputUnverified(t *testing
 	} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("human output missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestClaimsListScansDoNotCreateLocksOrMutateState(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		malformed bool
+		wantCode  int
+	}{
+		{name: "clean", wantCode: 0},
+		{name: "malformed", malformed: true, wantCode: 2},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			writeClaimsListFixture(t, "cbx_valid.json", leaseClaim{LeaseID: "cbx_valid", Provider: "local-container"})
+			if test.malformed {
+				writeClaimsListRawFixture(t, "cbx_broken.json", []byte("{"))
+			}
+
+			stateDir, err := crabboxStateDir()
+			if err != nil {
+				t.Fatal(err)
+			}
+			before := captureClaimsListState(t, stateDir)
+			stdout, stderr, runErr := runClaimsList(t, "--json")
+			assertClaimsExitCode(t, runErr, test.wantCode)
+			if stderr != "" || !strings.Contains(stdout, `"leaseId":"cbx_valid"`) {
+				t.Fatalf("stdout=%q stderr=%q", stdout, stderr)
+			}
+			after := captureClaimsListState(t, stateDir)
+			if !reflect.DeepEqual(after, before) {
+				t.Fatalf("claims scan mutated state\nbefore=%#v\nafter=%#v", before, after)
+			}
+			if _, err := os.Stat(filepath.Join(stateDir, "claim-locks")); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("claim-locks created or unreadable: %v", err)
+			}
+		})
+	}
+}
+
+func TestRuntimeClaimsSnapshotRetainsLockedReader(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	writeClaimsListFixture(t, "cbx_runtime.json", leaseClaim{LeaseID: "cbx_runtime", Provider: "local-container"})
+
+	snapshot, err := snapshotLeaseClaims()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snapshot.claims) != 1 || snapshot.claims[0].LeaseID != "cbx_runtime" {
+		t.Fatalf("claims=%#v", snapshot.claims)
+	}
+	stateDir, err := crabboxStateDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	lockPath := filepath.Join(stateDir, "claim-locks", "cbx_runtime.json.lock")
+	if info, err := os.Stat(lockPath); err != nil || !info.Mode().IsRegular() {
+		t.Fatalf("runtime claim lock missing or invalid: info=%v err=%v", info, err)
+	}
+}
+
+func TestClaimsListConcurrentDeleteAndChangeProduceDeterministicProblems(t *testing.T) {
+	var want localClaimsListOutput
+	for iteration := 0; iteration < 2; iteration++ {
+		t.Setenv("XDG_STATE_HOME", t.TempDir())
+		writeClaimsListFixture(t, "cbx_change.json", leaseClaim{LeaseID: "cbx_change", Slug: "before"})
+		writeClaimsListFixture(t, "cbx_delete.json", leaseClaim{LeaseID: "cbx_delete"})
+		writeClaimsListFixture(t, "cbx_valid.json", leaseClaim{LeaseID: "cbx_valid", Provider: "local-container"})
+
+		reader := func(path, leaseID string, expected os.FileInfo) (leaseClaim, bool, error) {
+			var mutate func() error
+			switch leaseID {
+			case "cbx_change":
+				mutate = func() error {
+					return os.WriteFile(path, []byte(`{"leaseID":"cbx_change","slug":"changed-during-scan"}`), 0o600)
+				}
+			case "cbx_delete":
+				mutate = func() error { return os.Remove(path) }
+			}
+			if mutate != nil {
+				result := make(chan error, 1)
+				go func() { result <- mutate() }()
+				if err := <-result; err != nil {
+					t.Fatalf("concurrent mutation: %v", err)
+				}
+			}
+			return readLeaseClaimSnapshotWithPresence(path, leaseID, expected)
+		}
+
+		snapshot, err := snapshotLeaseClaimsReadOnlyWithReader(reader)
+		if err != nil {
+			t.Fatal(err)
+		}
+		output := projectLocalClaims(snapshot)
+		if len(output.Claims) != 1 || output.Claims[0].LeaseID != "cbx_valid" {
+			t.Fatalf("partial claims=%#v", output.Claims)
+		}
+		if len(output.Problems) != 2 || len(output.Problems) > maxLocalClaimProblems {
+			t.Fatalf("problems=%#v", output.Problems)
+		}
+		for i, problem := range output.Problems {
+			if problem.Code != "read_error" || problem.Message != "claim file could not be read" {
+				t.Fatalf("problem[%d]=%#v", i, problem)
+			}
+		}
+		if iteration == 0 {
+			want = output
+		} else if !reflect.DeepEqual(output, want) {
+			t.Fatalf("nondeterministic output\nfirst=%#v\nsecond=%#v", want, output)
+		}
+		stateDir, err := crabboxStateDir()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := os.Stat(filepath.Join(stateDir, "claim-locks")); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("claim-locks created or unreadable: %v", err)
 		}
 	}
 }
@@ -323,6 +441,38 @@ func makeClaimsListDirectoryFixture(t *testing.T, name string) {
 	if err := os.MkdirAll(filepath.Join(dir, "claims", name), 0o700); err != nil {
 		t.Fatal(err)
 	}
+}
+
+type claimsListStateEntry struct {
+	Mode os.FileMode
+	Data string
+}
+
+func captureClaimsListState(t *testing.T, root string) map[string]claimsListStateEntry {
+	t.Helper()
+	state := make(map[string]claimsListStateEntry)
+	if err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		entry := claimsListStateEntry{Mode: info.Mode()}
+		if info.Mode().IsRegular() {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			entry.Data = string(data)
+		}
+		state[rel] = entry
+		return nil
+	}); err != nil {
+		t.Fatalf("capture state: %v", err)
+	}
+	return state
 }
 
 func assertClaimsExitCode(t *testing.T, err error, want int) {

--- a/internal/cli/claims_test.go
+++ b/internal/cli/claims_test.go
@@ -119,6 +119,23 @@ func TestClaimsListScansDoNotCreateLocksOrMutateState(t *testing.T) {
 	}
 }
 
+func TestClaimsListClaimStoreFailureIsNotMalformedPartialOutput(t *testing.T) {
+	stateRoot := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateRoot)
+	if err := os.WriteFile(filepath.Join(stateRoot, "crabbox"), []byte("not a directory"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, err := runClaimsList(t, "--json")
+	assertClaimsExitCode(t, err, 1)
+	if stdout != "" {
+		t.Fatalf("fatal store error wrote partial output: %q", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr=%q", stderr)
+	}
+}
+
 func TestRuntimeClaimsSnapshotRetainsLockedReader(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	writeClaimsListFixture(t, "cbx_runtime.json", leaseClaim{LeaseID: "cbx_runtime", Provider: "local-container"})

--- a/internal/cli/cli_kong.go
+++ b/internal/cli/cli_kong.go
@@ -38,6 +38,7 @@ type crabboxKongCLI struct {
 	Cache       cacheKongCmd       `cmd:"" help:"Inspect, purge, or warm remote caches."`
 	Status      statusKongCmd      `cmd:"" passthrough:"" help:"Show lease state; add --wait to block until ready."`
 	Heartbeat   heartbeatKongCmd   `cmd:"" passthrough:"" help:"Refresh a lease idle deadline and print its state."`
+	Claims      claimsKongCmd      `cmd:"" help:"Inspect unverified local lease claims without loading providers."`
 	List        listKongCmd        `cmd:"" passthrough:"" help:"List Crabbox machines."`
 	Ports       portsKongCmd       `cmd:"" passthrough:"" help:"Publish, list, or unpublish provider-native ports."`
 	Cp          cpKongCmd          `cmd:"" name:"cp" passthrough:"" help:"Copy files between the host and a lease."`
@@ -133,7 +134,7 @@ func normalizeKongHelpArgs(args []string) []string {
 
 func isKongCommandGroup(command string) bool {
 	switch command {
-	case "actions", "adapter", "admin", "artifacts", "azure", "bench", "cache", "capsule", "checkpoint", "config", "pond", "desktop", "image", "job", "machine", "marketplace", "media", "pool":
+	case "actions", "adapter", "admin", "artifacts", "azure", "bench", "cache", "capsule", "checkpoint", "claims", "config", "pond", "desktop", "image", "job", "machine", "marketplace", "media", "pool":
 		return true
 	default:
 		return false
@@ -231,6 +232,12 @@ type statusKongCmd struct {
 	Args []string `arg:"" optional:""`
 }
 type heartbeatKongCmd struct {
+	Args []string `arg:"" optional:""`
+}
+type claimsKongCmd struct {
+	List claimsListKongCmd `cmd:"" passthrough:"" help:"List unverified local lease claims without loading providers."`
+}
+type claimsListKongCmd struct {
 	Args []string `arg:"" optional:""`
 }
 type listKongCmd struct {
@@ -656,10 +663,13 @@ func (c *cpKongCmd) Run(ctx context.Context, app App) error        { return app.
 func (c *tunnelKongCmd) Run(ctx context.Context, app App) error    { return app.tunnel(ctx, c.Args) }
 func (c *statusKongCmd) Run(ctx context.Context, app App) error    { return app.status(ctx, c.Args) }
 func (c *heartbeatKongCmd) Run(ctx context.Context, app App) error { return app.heartbeat(ctx, c.Args) }
-func (c *listKongCmd) Run(ctx context.Context, app App) error      { return app.list(ctx, c.Args) }
-func (c *shareKongCmd) Run(ctx context.Context, app App) error     { return app.share(ctx, c.Args) }
-func (c *unshareKongCmd) Run(ctx context.Context, app App) error   { return app.unshare(ctx, c.Args) }
-func (c *usageKongCmd) Run(ctx context.Context, app App) error     { return app.usage(ctx, c.Args) }
+func (c *claimsListKongCmd) Run(_ context.Context, app App) error {
+	return app.claimsList(stripKongCommandPath(c.Args, "claims", "list"))
+}
+func (c *listKongCmd) Run(ctx context.Context, app App) error    { return app.list(ctx, c.Args) }
+func (c *shareKongCmd) Run(ctx context.Context, app App) error   { return app.share(ctx, c.Args) }
+func (c *unshareKongCmd) Run(ctx context.Context, app App) error { return app.unshare(ctx, c.Args) }
+func (c *usageKongCmd) Run(ctx context.Context, app App) error   { return app.usage(ctx, c.Args) }
 func (c *marketplaceStatusKongCmd) Run(ctx context.Context, app App) error {
 	return app.marketplaceStatus(ctx, c.Args)
 }


### PR DESCRIPTION
## Summary

- add `crabbox claims list` as the supported credential-free, local-only inventory command
- expose a versioned `local-claims` JSON envelope with an explicit secret-safe field allowlist
- preserve valid claims while reporting malformed local records as bounded deterministic problems with exit code 2
- keep provider-scoped `crabbox list` behavior unchanged and never load provider credentials or backends
- scan local inventory without acquiring claim locks, creating state, refreshing records, or requiring write permission

Human output labels the inventory as unverified local state. Runtime and mutating claim readers remain lock-first.

Maintainer decisions: approve the public `crabbox claims list` and versioned `local-claims` contract; retain the Unreleased changelog entry under repository policy for user-visible features.

Closes https://github.com/openclaw/crabbox/issues/1250

## Verification

- focused claim-inventory race tests, including leading/trailing/all-whitespace filenames at both public and runtime snapshot boundaries, deterministic partial output, read-only storage, concurrent deletion/change, no state mutation, and retained runtime locking
- `go test -race ./internal/cli -run 'Test(LeaseClaimsSnapshotBoundaryHandling|ClaimsListReportsMalformedRecordsWithStablePartialOutput|RuntimeClaimsSnapshotRetainsLockedReader)$' -count=1`
- `GOMAXPROCS=8 go test -race ./internal/cli -count=1 -parallel=8 -timeout=30m`
- `go vet ./...`
- `scripts/check-docs.sh`
- source-blind CLI validation: 2/2 contract clauses and 4/4 anti-cheat probes passed, 0 failed/blocked
- `gofmt` and `git diff --check`
- final P1 autoreview clean against current `origin/main`

The default-timeout full-package race attempt reached an unrelated Git-coherence test at the 10-minute package limit. An extended unbounded-parallel retry then hit two unrelated load-sensitive timing assertions; both passed 10/10 in focused race reruns, and the bounded-parallel full package passed in 889.619s.

### Redacted local CLI proof

Synthetic claims and redacted paths only; provider credentials were intentionally absent.

```text
$ provider config and credential precondition
provider: backend-that-must-not-load
AWS_ACCESS_KEY_ID=absent AWS_SECRET_ACCESS_KEY=absent AWS_SESSION_TOKEN=absent
HCLOUD_TOKEN=absent HETZNER_TOKEN=absent CRABBOX_COORDINATOR_TOKEN=absent

$ CRABBOX_CONFIG=$CONFIG XDG_STATE_HOME=$STATE $CRABBOX claims list --json
{"version":1,"source":"local-claims","claims":[{"leaseId":"cbx_demo_local_001","slug":"demo-box","provider":"local-container","repoRoot":"/demo/worktree","pond":"","targetOS":"","windowsMode":"","claimedAt":"2026-08-16T10:00:00Z","lastUsedAt":"2026-08-16T10:05:00Z","idleTimeoutSeconds":1800}],"problems":[]}
exit=0

$ CRABBOX_CONFIG=$CONFIG XDG_STATE_HOME=$STATE $CRABBOX claims list
Local claims (unverified local state; provider backends were not queried)
- leaseId: "cbx_demo_local_001"
  slug: "demo-box"
  provider: "local-container"
  repoRoot: "/demo/worktree"
  claimedAt: "2026-08-16T10:00:00Z"
  lastUsedAt: "2026-08-16T10:05:00Z"
  idleTimeoutSeconds: 1800
exit=0

$ sensitive fixture marker in JSON and human output
absent

$ clean scan state manifest SHA-256 (before / after)
before=1eceb4d162f08bb9b19032f49be9611827b31e78da30e1f9c5f17c0cf4021d58
after=1eceb4d162f08bb9b19032f49be9611827b31e78da30e1f9c5f17c0cf4021d58
unchanged=yes
claim-locks=absent

$ add malformed cbx_broken.json; CRABBOX_CONFIG=$CONFIG XDG_STATE_HOME=$STATE $CRABBOX claims list --json
{"version":1,"source":"local-claims","claims":[{"leaseId":"cbx_demo_local_001","slug":"demo-box","provider":"local-container","repoRoot":"/demo/worktree","pond":"","targetOS":"","windowsMode":"","claimedAt":"2026-08-16T10:00:00Z","lastUsedAt":"2026-08-16T10:05:00Z","idleTimeoutSeconds":1800}],"problems":[{"file":"cbx_broken.json","code":"invalid_json","message":"claim file is not valid JSON"}]}
exit=2

$ malformed scan state manifest SHA-256 (before / after)
before=be71f6a80e9a743b79e449b7e1a2e92aa00d60ca34367292ad98da4e244546e1
after=be71f6a80e9a743b79e449b7e1a2e92aa00d60ca34367292ad98da4e244546e1
unchanged=yes
claim-locks=absent

$ add leading-, trailing-, and all-whitespace filename variants; redacted jq summary of claims list --json
{"version":1,"source":"local-claims","claim_ids":["cbx_valid"],"problems":[{"file":"sha256:2152efdec404a9ce","code":"invalid_filename","message":"claim filename is not a valid lease id; filename replaced by a fingerprint"},{"file":"sha256:35819ac9ffd6a600","code":"invalid_filename","message":"claim filename is not a valid lease id; filename replaced by a fingerprint"},{"file":"sha256:3b7206e6e597b73b","code":"invalid_filename","message":"claim filename is not a valid lease id; filename replaced by a fingerprint"}]}
exit=2
deterministic=yes
state-unchanged=yes
claim-locks=absent
```

The complete local proof transcript is mode `0600` and was regenerated from head `d611e6811a05e87a3cc7387cd02f8a5a820cddfe`.
