### PR TITLE
fix(sync): validate Jujutsu before delegated provisioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Rejected native Jujutsu and other unsupported local sync sources before delegated archive providers can provision or execute a remote sandbox.
 - Omitted coordinator-only history commands from failure digests when run history is unavailable, while preserving direct lease recovery guidance.
 - Bypassed reusable-workspace ownership for fresh non-retained local-container runs while preserving ownership for retained and reused leases.
 - Framed workspace-owner scripts outside native Windows SSH command arguments so retained runs avoid `cmd.exe` limits, preserve finite stdin and nonzero exits, and clean up promptly.

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -936,6 +936,13 @@ func gitSyncFileList(root string) ([]byte, error) {
 	return out, nil
 }
 
+func validateLocalWorkspaceSyncSource(repo Repo) error {
+	if _, err := gitSyncFileList(repo.Root); err != nil {
+		return exit(6, "build sync file list: %v", err)
+	}
+	return nil
+}
+
 func syncManifest(root string, excludes SyncExcludeRules) (SyncManifest, error) {
 	return syncManifestFilteredRules(root, excludes, nil)
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -548,6 +548,65 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 			return exit(2, "profile doctor is not supported for native Windows targets")
 		}
 	}
+	options := leaseOptionsFromConfig(cfg)
+	scriptRequested := *scriptPath != "" || *scriptStdin
+	var script *RunScriptSpec
+	runReq := RunRequest{
+		Repo:                  repo,
+		ID:                    *leaseIDFlag,
+		RunID:                 executionRunID,
+		Options:               options,
+		Keep:                  *keep,
+		KeepOnFailure:         *keepOnFailure,
+		Reclaim:               *reclaim,
+		NoSync:                *noSync,
+		SyncOnly:              *syncOnly,
+		DebugSync:             *debugSync,
+		ShellMode:             *shellMode,
+		ChecksumSync:          *checksumSync,
+		ForceSyncLarge:        *forceSyncLarge,
+		FullResync:            fullResyncRequested,
+		EnvHelper:             envHelperName,
+		CaptureStdout:         *captureStdout,
+		CaptureStderr:         *captureStderr,
+		CaptureOnFail:         *captureOnFail,
+		Preflight:             *preflight,
+		Downloads:             downloads,
+		Env:                   envSelection.Effective,
+		EnvSummary:            envSelection.SummaryRequested,
+		ScriptRequested:       scriptRequested,
+		FreshPR:               freshPR,
+		ApplyLocalPatch:       *applyLocalPatch,
+		Command:               command,
+		Label:                 runLabelValue,
+		RequestedSlug:         requestedSlug,
+		TimingJSON:            *timingJSON || timingRecordEnabled,
+		ArtifactGlobs:         expansion.ArtifactGlobs,
+		RequiredArtifactGlobs: requiredArtifactGlobs,
+		EmitProof:             strings.TrimSpace(*emitProof),
+		ProofTemplate:         strings.TrimSpace(*proofTemplate),
+		ProfileVariables:      expansion.Variables,
+		StopAfter:             strings.TrimSpace(*stopAfter),
+	}
+	delegatedRoutePreflighted := false
+	if providerSelectionIsActionable(cfg) {
+		provider, err := ProviderFor(cfg.Provider)
+		if err != nil {
+			return err
+		}
+		providerSpec := provider.Spec()
+		if providerSpec.Kind == ProviderKindDelegatedRun {
+			if err := validateDelegatedRunRouting(providerSpec, runReq, *readyPool, len(requiredArtifactSchemas) > 0, expansion.Profile.Doctor.Enabled); err != nil {
+				return err
+			}
+			if delegatedRunNeedsLocalWorkspaceSync(providerSpec, runReq) {
+				if err := validateLocalWorkspaceSyncSource(repo); err != nil {
+					return err
+				}
+			}
+			delegatedRoutePreflighted = true
+		}
+	}
 	backendRuntime := runtimeForApp(a)
 	if timingRecordEnabled {
 		delegatedTimingCapture = &capturedTimingReportWriter{writer: a.Stderr}
@@ -677,58 +736,14 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		// and advertise FeatureRunSession once their lifecycle contract is covered.
 		return exit(2, "--lease-output is not supported for provider=%s yet", backend.Spec().Name)
 	}
-	options := leaseOptionsFromConfig(cfg)
-	scriptRequested := *scriptPath != "" || *scriptStdin
-	var script *RunScriptSpec
-	runReq := RunRequest{
-		Repo:                  repo,
-		ID:                    *leaseIDFlag,
-		RunID:                 executionRunID,
-		Options:               options,
-		Keep:                  *keep,
-		KeepOnFailure:         *keepOnFailure,
-		Reclaim:               *reclaim,
-		NoSync:                *noSync,
-		SyncOnly:              *syncOnly,
-		DebugSync:             *debugSync,
-		ShellMode:             *shellMode,
-		ChecksumSync:          *checksumSync,
-		ForceSyncLarge:        *forceSyncLarge,
-		FullResync:            fullResyncRequested,
-		EnvHelper:             envHelperName,
-		CaptureStdout:         *captureStdout,
-		CaptureStderr:         *captureStderr,
-		CaptureOnFail:         *captureOnFail,
-		Preflight:             *preflight,
-		Downloads:             downloads,
-		Env:                   envSelection.Effective,
-		EnvSummary:            envSelection.SummaryRequested,
-		ScriptRequested:       scriptRequested,
-		FreshPR:               freshPR,
-		ApplyLocalPatch:       *applyLocalPatch,
-		Command:               command,
-		Label:                 runLabelValue,
-		RequestedSlug:         requestedSlug,
-		TimingJSON:            *timingJSON || timingRecordEnabled,
-		ArtifactGlobs:         expansion.ArtifactGlobs,
-		RequiredArtifactGlobs: requiredArtifactGlobs,
-		EmitProof:             strings.TrimSpace(*emitProof),
-		ProofTemplate:         strings.TrimSpace(*proofTemplate),
-		ProfileVariables:      expansion.Variables,
-		StopAfter:             strings.TrimSpace(*stopAfter),
-	}
 	if delegated, ok := backend.(DelegatedRunBackend); ok {
-		if strings.TrimSpace(*readyPool) != "" {
-			return exit(2, "--pool requires a brokered SSH lease provider")
-		}
-		if len(requiredArtifactSchemas) > 0 {
-			return exit(2, "--require-artifact-schema is not supported for provider=%s yet; use an SSH-backed provider", backend.Spec().Name)
-		}
-		if expansion.Profile.Doctor.Enabled {
-			return exit(2, "%s delegates run execution; profile doctor is not supported", backend.Spec().Name)
-		}
-		if err := RejectDelegatedSyncOptionsForSpec(backend.Spec(), runReq); err != nil {
+		if err := validateDelegatedRunRouting(backend.Spec(), runReq, *readyPool, len(requiredArtifactSchemas) > 0, expansion.Profile.Doctor.Enabled); err != nil {
 			return err
+		}
+		if !delegatedRoutePreflighted && delegatedRunNeedsLocalWorkspaceSync(backend.Spec(), runReq) {
+			if err := validateLocalWorkspaceSyncSource(repo); err != nil {
+				return err
+			}
 		}
 		if scriptRequested && backend.Spec().Features.Has(FeatureModuleRun) {
 			script, err = loadRunScript(*scriptPath, *scriptStdin, a.Stdin)
@@ -793,9 +808,8 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		return exit(2, "provider=%s does not support run", backend.Spec().Name)
 	}
 	if !*noSync && freshPR.Empty() {
-		_, err = gitSyncFileList(repo.Root)
-		if err != nil {
-			return exit(6, "build sync file list: %v", err)
+		if err := validateLocalWorkspaceSyncSource(repo); err != nil {
+			return err
 		}
 	}
 	coord := backendCoordinator(backend)
@@ -2585,6 +2599,23 @@ func commandNeedsHydrationHint(command []string, shellMode bool) bool {
 
 func shouldAutoHydrateActions(cfg Config, noHydrate, noSync bool, freshPR FreshPRSpec, syncOnly bool) bool {
 	return strings.TrimSpace(cfg.Actions.Workflow) != "" && !noHydrate && !noSync && freshPR.Empty() && !syncOnly
+}
+
+func delegatedRunNeedsLocalWorkspaceSync(spec ProviderSpec, req RunRequest) bool {
+	return spec.Features.Has(FeatureArchiveSync) && !req.NoSync && req.FreshPR.Empty()
+}
+
+func validateDelegatedRunRouting(spec ProviderSpec, req RunRequest, readyPool string, hasArtifactSchemas, profileDoctor bool) error {
+	if strings.TrimSpace(readyPool) != "" {
+		return exit(2, "--pool requires a brokered SSH lease provider")
+	}
+	if hasArtifactSchemas {
+		return exit(2, "--require-artifact-schema is not supported for provider=%s yet; use an SSH-backed provider", spec.Name)
+	}
+	if profileDoctor {
+		return exit(2, "%s delegates run execution; profile doctor is not supported", spec.Name)
+	}
+	return RejectDelegatedSyncOptionsForSpec(spec, req)
 }
 
 func rawJSRuntimeHydrateSuggestion(cfg Config, target SSHTarget, leaseID string, acquired, keep, keepOnFailure bool) string {

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -20,6 +20,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -30,6 +31,7 @@ func init() {
 	RegisterProvider(runReadyPoolPreflightTestProvider{})
 	RegisterProvider(runPrepareTestProvider{})
 	RegisterProvider(runModuleRuntimeTestProvider{})
+	RegisterProvider(runArchiveSyncPreflightTestProvider{})
 }
 
 type warmupFailureReleaseBackend struct {
@@ -811,6 +813,182 @@ type runWorkdirCase struct {
 	native     bool
 	diagnostic string
 	guidance   []string
+}
+
+type runArchiveSyncPreflightTestProvider struct{}
+
+func (runArchiveSyncPreflightTestProvider) Name() string { return "run-archive-sync-preflight-test" }
+func (runArchiveSyncPreflightTestProvider) Aliases() []string {
+	return nil
+}
+func (runArchiveSyncPreflightTestProvider) Spec() ProviderSpec {
+	return ProviderSpec{
+		Name:        "run-archive-sync-preflight-test",
+		Kind:        ProviderKindDelegatedRun,
+		Targets:     []TargetSpec{{OS: targetLinux}},
+		Features:    FeatureSet{FeatureArchiveSync},
+		Coordinator: CoordinatorNever,
+	}
+}
+func (runArchiveSyncPreflightTestProvider) RegisterFlags(*flag.FlagSet, Config) any {
+	return noProviderFlags{}
+}
+func (runArchiveSyncPreflightTestProvider) ApplyFlags(*Config, *flag.FlagSet, any) error {
+	return nil
+}
+func (p runArchiveSyncPreflightTestProvider) Configure(Config, Runtime) (Backend, error) {
+	runArchiveSyncPreflightProviderCalls.Add(1)
+	return runArchiveSyncPreflightTestBackend{spec: p.Spec()}, nil
+}
+
+type runArchiveSyncPreflightTestBackend struct {
+	spec ProviderSpec
+}
+
+var runArchiveSyncPreflightProviderCalls atomic.Int64
+
+func (b runArchiveSyncPreflightTestBackend) Spec() ProviderSpec { return b.spec }
+func (runArchiveSyncPreflightTestBackend) Warmup(context.Context, WarmupRequest) error {
+	runArchiveSyncPreflightProviderCalls.Add(1)
+	return nil
+}
+func (b runArchiveSyncPreflightTestBackend) Run(context.Context, RunRequest) (RunResult, error) {
+	runArchiveSyncPreflightProviderCalls.Add(1)
+	return RunResult{Provider: b.spec.Name}, nil
+}
+func (runArchiveSyncPreflightTestBackend) List(context.Context, ListRequest) ([]LeaseView, error) {
+	runArchiveSyncPreflightProviderCalls.Add(1)
+	return nil, nil
+}
+func (runArchiveSyncPreflightTestBackend) Status(context.Context, StatusRequest) (StatusView, error) {
+	runArchiveSyncPreflightProviderCalls.Add(1)
+	return StatusView{}, nil
+}
+func (runArchiveSyncPreflightTestBackend) Stop(context.Context, StopRequest) error {
+	runArchiveSyncPreflightProviderCalls.Add(1)
+	return nil
+}
+
+func setupDelegatedArchiveSyncPreflightWorkspace(t *testing.T, colocatedGit, invalidGitMarker bool) string {
+	t.Helper()
+	clearConfigEnv(t)
+	outer := t.TempDir()
+	runGit(t, outer, "init")
+	root := filepath.Join(outer, "native-workspace")
+	makeNativeJujutsuWorkspace(t, root)
+	if colocatedGit {
+		runGit(t, root, "init")
+	} else if invalidGitMarker {
+		if err := os.Mkdir(filepath.Join(root, ".git"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeFile(t, filepath.Join(root, "tracked.txt"), "tracked\n")
+	if colocatedGit {
+		runGit(t, root, "add", "tracked.txt")
+	}
+	isolateRunTestUserDirs(t, root)
+	t.Chdir(root)
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(root, "missing.yaml"))
+	return root
+}
+
+func TestRunDelegatedArchiveSyncValidatesSourceBeforeProviderCall(t *testing.T) {
+	provider := runArchiveSyncPreflightTestProvider{}.Name()
+
+	t.Run("native Jujutsu", func(t *testing.T) {
+		root := setupDelegatedArchiveSyncPreflightWorkspace(t, false, false)
+		runArchiveSyncPreflightProviderCalls.Store(0)
+
+		var stdout, stderr bytes.Buffer
+		err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
+			"--provider", provider,
+			"--", "true",
+		})
+		var exitErr ExitError
+		if !AsExitError(err, &exitErr) || exitErr.Code != 6 {
+			t.Fatalf("error=%v, want exit 6\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+		}
+		for _, want := range []string{root, "native Jujutsu workspace", "Git-manifest-based", "wrong revision", "colocated Git workspace", "jj git init --git-repo=.", "--no-sync"} {
+			if !strings.Contains(exitErr.Message, want) {
+				t.Fatalf("message missing %q: %q", want, exitErr.Message)
+			}
+		}
+		if calls := runArchiveSyncPreflightProviderCalls.Load(); calls != 0 {
+			t.Fatalf("delegated provider calls=%d, want zero before source validation", calls)
+		}
+	})
+
+	t.Run("invalid colocated Git marker", func(t *testing.T) {
+		setupDelegatedArchiveSyncPreflightWorkspace(t, false, true)
+		runArchiveSyncPreflightProviderCalls.Store(0)
+
+		err := (App{Stdout: io.Discard, Stderr: io.Discard}).runCommand(context.Background(), []string{
+			"--provider", provider,
+			"--", "true",
+		})
+		var exitErr ExitError
+		if !AsExitError(err, &exitErr) || exitErr.Code != 6 || !strings.Contains(exitErr.Message, "native Jujutsu workspace") {
+			t.Fatalf("error=%v, want native Jujutsu exit 6", err)
+		}
+		if calls := runArchiveSyncPreflightProviderCalls.Load(); calls != 0 {
+			t.Fatalf("delegated provider calls=%d, want zero for invalid Git metadata", calls)
+		}
+	})
+
+	t.Run("no sync", func(t *testing.T) {
+		setupDelegatedArchiveSyncPreflightWorkspace(t, false, false)
+		runArchiveSyncPreflightProviderCalls.Store(0)
+
+		err := (App{Stdout: io.Discard, Stderr: io.Discard}).runCommand(context.Background(), []string{
+			"--provider", provider,
+			"--no-sync",
+			"--", "true",
+		})
+		if err != nil {
+			t.Fatalf("run error=%v", err)
+		}
+		if calls := runArchiveSyncPreflightProviderCalls.Load(); calls != 2 {
+			t.Fatalf("delegated provider calls=%d, want configure and --no-sync run", calls)
+		}
+	})
+
+	t.Run("colocated Git", func(t *testing.T) {
+		setupDelegatedArchiveSyncPreflightWorkspace(t, true, false)
+		runArchiveSyncPreflightProviderCalls.Store(0)
+
+		err := (App{Stdout: io.Discard, Stderr: io.Discard}).runCommand(context.Background(), []string{
+			"--provider", provider,
+			"--", "true",
+		})
+		if err != nil {
+			t.Fatalf("run error=%v", err)
+		}
+		if calls := runArchiveSyncPreflightProviderCalls.Load(); calls != 2 {
+			t.Fatalf("delegated provider calls=%d, want configure and colocated Git run", calls)
+		}
+	})
+
+	t.Run("fresh PR remains provider option validation", func(t *testing.T) {
+		setupDelegatedArchiveSyncPreflightWorkspace(t, false, false)
+		runArchiveSyncPreflightProviderCalls.Store(0)
+
+		err := (App{Stdout: io.Discard, Stderr: io.Discard}).runCommand(context.Background(), []string{
+			"--provider", provider,
+			"--fresh-pr", "example-org/my-app#1",
+			"--", "true",
+		})
+		var exitErr ExitError
+		if !AsExitError(err, &exitErr) || exitErr.Code != 2 || !strings.Contains(exitErr.Message, "--fresh-pr is not supported") {
+			t.Fatalf("error=%v, want delegated fresh-PR rejection", err)
+		}
+		if strings.Contains(exitErr.Message, "native Jujutsu workspace") {
+			t.Fatalf("fresh-PR option rejection triggered local source validation: %q", exitErr.Message)
+		}
+		if calls := runArchiveSyncPreflightProviderCalls.Load(); calls != 0 {
+			t.Fatalf("delegated provider calls=%d, want zero for rejected fresh PR", calls)
+		}
+	})
 }
 
 func runWorkdirCases() []runWorkdirCase {


### PR DESCRIPTION
## Summary

- validate local sync sources before configuring or invoking delegated archive-sync providers
- reject native non-colocated Jujutsu with the existing actionable diagnostic before any sandbox provisioning or API call
- preserve `--no-sync`, fresh-PR routing, colocated Git/Jujutsu, non-archive delegated providers, and SSH-provider ownership paths

This closes the remaining paid-resource side effect in the fail-closed Jujutsu guard. Native Jujutsu revision mapping remains intentionally unresolved in https://github.com/openclaw/crabbox/issues/1081.

## Verification

- focused repo-discovery, delegated archive-sync, and run-routing race tests
- fake delegated backend proves zero configure/run/provider calls for rejected native Jujutsu
- colocated, `--no-sync`, fresh-PR, and non-archive controls
- `go test -race -p=4 ./... -count=1 -timeout=20m`
- `go vet ./...`
- provider conformance, `gofmt`, and `git diff --check`
- P1 autoreview clean after correcting validation/configuration ordering

## Real delegated-provider proof

Redacted proof from exact head `49b76ee6a8e11f007b54b4790df53759fefc5063`:

```text
jj_source=official jj-vcs/jj GitHub release
jj_version=0.44.0-af45d57de7163cc5f17f3df178a31577e4951ea3
jj_sha256=22b92ed109378a9638f0ae55ca7a7bdc9ef26aa60124215a1f04f6808623ba94
jj_sha256_verified_against_official_release_asset=true
system_install=false
git_control_sha=49b76ee6a8e11f007b54b4790df53759fefc5063
git_control_dot_git=true
jj_external_git_store_bare=true
jj_external_git_store_head=49b76ee6a8e11f007b54b4790df53759fefc5063
jj_workspace_dot_jj=true
jj_workspace_dot_git=false
jj_workspace_parent=49b76ee6a8e11f007b54b4790df53759fefc5063
sdk_cache_package=@codesandbox/sdk@2.4.2
sdk_cache_prepared_before_credential=true
credential_source_redaction=true
provider_readable=true
sandbox_count_unchanged=true
git_control_command=(cd <temp>/git-control && <temp>/crabbox run --provider codesandbox --no-sync --codesandbox-bridge-command <temp>/tripwire.sh -- true)
git_control_tripwire=true
git_control_exit=1
jj_command=(cd <temp>/jj-native && <temp>/crabbox run --provider codesandbox --codesandbox-bridge-command <temp>/tripwire.sh -- true)
jj_diagnostic=build sync file list: <temp>/jj-native is a native Jujutsu workspace without colocated Git metadata: Crabbox sync is Git-manifest-based, and native Jujutsu sync is not supported yet because it risks syncing the wrong revision; use a colocated Git workspace instead (for example, from an existing Git checkout, initialize Jujutsu with `jj git init --git-repo=.`; this does not convert the current native workspace in place), or pass --no-sync to run without syncing local files
jj_exit=6
jj_tripwire_invoked=false
lease_or_run_url_printed=false
local_claims=0
focused_test=go test -race ./internal/cli -run '^TestRunDelegatedArchiveSyncValidatesSourceBeforeProviderCall$' -count=1
focused_test_result=PASS
cleanup=true
```
