### PR TITLE
fix(lambda-microvm): bound runner response headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- Bounded Lambda MicroVM runner response-header waits without limiting uploads or streamed executions, while preserving injected HTTP clients. Thanks @SebTardif.
 - Rejected native Jujutsu and other unsupported local sync sources before delegated archive providers can provision or execute a remote sandbox.
 - Accepted explicit local-container architecture assertions only when the selected Docker or Podman daemon reports a matching native architecture, without enabling emulation. Thanks @coygeek.
 - Omitted coordinator-only history commands from failure digests when run history is unavailable, while preserving direct lease recovery guidance.

--- a/internal/providers/awslambdamicrovm/backend_test.go
+++ b/internal/providers/awslambdamicrovm/backend_test.go
@@ -3,16 +3,22 @@ package awslambdamicrovm
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"flag"
+	"fmt"
 	"io"
 	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -265,6 +271,283 @@ func TestRunnerClientExecPreservesBinaryOutput(t *testing.T) {
 	}
 	if gotExit != 0 || !bytes.Equal(stdout.Bytes(), want) {
 		t.Fatalf("exit=%d stdout=%x want=%x", gotExit, stdout.Bytes(), want)
+	}
+}
+
+func TestNewRunnerClientDefaultsResponseHeaderTimeout(t *testing.T) {
+	client := newRunnerClient(&fakeControlPlane{}, nil, "eu-west-1")
+	if client.http == nil {
+		t.Fatal("expected default HTTP client")
+	}
+	if client.http.Timeout != 0 {
+		t.Fatalf("client timeout=%s, want no whole-request timeout", client.http.Timeout)
+	}
+	transport, ok := client.http.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport=%T, want *http.Transport", client.http.Transport)
+	}
+	if transport == http.DefaultTransport {
+		t.Fatal("fallback client reused the shared default transport")
+	}
+	if transport.ResponseHeaderTimeout != runnerResponseHeaderTimeout {
+		t.Fatalf("response header timeout=%s want %s", transport.ResponseHeaderTimeout, runnerResponseHeaderTimeout)
+	}
+}
+
+func TestDefaultRunnerHTTPClientTimesOutBeforeResponseHeaders(t *testing.T) {
+	const bound = 40 * time.Millisecond
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		time.Sleep(5 * bound)
+	}))
+	defer server.Close()
+
+	started := time.Now()
+	_, err := defaultRunnerHTTPClient(bound).Get(server.URL)
+	elapsed := time.Since(started)
+	if err == nil {
+		t.Fatal("request with withheld response headers unexpectedly succeeded")
+	}
+	var timeoutError interface{ Timeout() bool }
+	if !errors.As(err, &timeoutError) || !timeoutError.Timeout() {
+		t.Fatalf("error=%v, want timeout", err)
+	}
+	if elapsed >= time.Second {
+		t.Fatalf("withheld response headers failed after %s, want near %s", elapsed, bound)
+	}
+	t.Logf("withheld response headers failed after %s (configured bound %s)", elapsed.Round(time.Millisecond), bound)
+}
+
+func TestDefaultRunnerHTTPClientStreamsPastResponseHeaderTimeout(t *testing.T) {
+	const bound = 30 * time.Millisecond
+	const streamDelay = 3 * bound
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		time.Sleep(streamDelay)
+		_, _ = io.WriteString(w, "stream-complete")
+	}))
+	defer server.Close()
+
+	started := time.Now()
+	resp, err := defaultRunnerHTTPClient(bound).Get(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	elapsed := time.Since(started)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != "stream-complete" {
+		t.Fatalf("body=%q want stream-complete", body)
+	}
+	if elapsed <= bound {
+		t.Fatalf("stream completed in %s, want it readable beyond %s", elapsed, bound)
+	}
+	t.Logf("response headers flushed promptly; body remained readable through %s, past the %s header bound", elapsed.Round(time.Millisecond), bound)
+}
+
+func TestDefaultRunnerHTTPClientUploadsPastResponseHeaderTimeout(t *testing.T) {
+	const bound = 30 * time.Millisecond
+	const uploadDelay = 3 * bound
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Errorf("read upload: %v", err)
+			return
+		}
+		if string(body) != "upload-complete" {
+			t.Errorf("upload body=%q want upload-complete", body)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	reader, writer := io.Pipe()
+	go func() {
+		_, _ = io.WriteString(writer, "upload-")
+		time.Sleep(uploadDelay)
+		_, _ = io.WriteString(writer, "complete")
+		_ = writer.Close()
+	}()
+	started := time.Now()
+	resp, err := defaultRunnerHTTPClient(bound).Post(server.URL, "application/gzip", reader)
+	elapsed := time.Since(started)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("status=%d want %d", resp.StatusCode, http.StatusNoContent)
+	}
+	if elapsed <= bound {
+		t.Fatalf("upload completed in %s, want it to outlive %s", elapsed, bound)
+	}
+	t.Logf("upload completed after %s, beyond the %s response-header bound", elapsed.Round(time.Millisecond), bound)
+}
+
+func TestNewRunnerClientPreservesInjectedHTTPSettingsOnClone(t *testing.T) {
+	proxyURL, err := url.Parse("http://proxy.example.test:8080")
+	if err != nil {
+		t.Fatal(err)
+	}
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
+	transport := &http.Transport{Proxy: http.ProxyURL(proxyURL), TLSClientConfig: tlsConfig}
+	injected := &http.Client{
+		Transport: transport,
+		Jar:       jar,
+		Timeout:   17 * time.Second,
+	}
+
+	client := newRunnerClient(&fakeControlPlane{}, injected, "eu-west-1")
+	if client.http == injected {
+		t.Fatal("runner reused the injected client instead of cloning it")
+	}
+	if client.http.Transport != transport || client.http.Jar != jar || client.http.Timeout != 17*time.Second {
+		t.Fatalf("cloned settings: transport=%p jar=%p timeout=%s", client.http.Transport, client.http.Jar, client.http.Timeout)
+	}
+	if transport.TLSClientConfig != tlsConfig || transport.Proxy == nil {
+		t.Fatal("injected proxy or TLS configuration was not preserved")
+	}
+	if injected.Transport != transport || injected.Jar != jar || injected.Timeout != 17*time.Second || injected.CheckRedirect != nil {
+		t.Fatal("newRunnerClient mutated the injected source client")
+	}
+}
+
+func TestNewRunnerClientPreservesStricterSameOriginRedirectPolicy(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		http.Redirect(w, req, "/redirected", http.StatusFound)
+	}))
+	defer server.Close()
+
+	callerErr := errors.New("injected redirect policy")
+	var callerChecks atomic.Int32
+	injected := server.Client()
+	injected.CheckRedirect = func(*http.Request, []*http.Request) error {
+		callerChecks.Add(1)
+		return callerErr
+	}
+	client := newRunnerClient(&fakeControlPlane{}, injected, "eu-west-1")
+
+	_, err := client.http.Get(server.URL)
+	if !errors.Is(err, callerErr) {
+		t.Fatalf("redirect error=%v want injected policy", err)
+	}
+	if callerChecks.Load() != 1 {
+		t.Fatalf("injected redirect checks=%d want 1", callerChecks.Load())
+	}
+	if injected.CheckRedirect == nil {
+		t.Fatal("newRunnerClient cleared the injected redirect policy")
+	}
+}
+
+func TestNewRunnerClientRejectsCrossOriginRedirectBeforeInjectedPolicy(t *testing.T) {
+	origin, err := url.Parse("https://mvm-test.lambda-microvm.eu-west-1.on.aws")
+	if err != nil {
+		t.Fatal(err)
+	}
+	target, err := url.Parse("http://127.0.0.1:8080/stolen")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name     string
+		callback bool
+	}{
+		{name: "nil callback"},
+		{name: "permissive callback", callback: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var callerChecks atomic.Int32
+			injected := &http.Client{}
+			if tc.callback {
+				injected.CheckRedirect = func(*http.Request, []*http.Request) error {
+					callerChecks.Add(1)
+					return nil
+				}
+			}
+			client := newRunnerClient(&fakeControlPlane{}, injected, "eu-west-1")
+			err := client.http.CheckRedirect(&http.Request{URL: target}, []*http.Request{{URL: origin}})
+			if err == nil || !strings.Contains(err.Error(), "refused cross-origin redirect") {
+				t.Fatalf("redirect error=%v want cross-origin refusal", err)
+			}
+			if callerChecks.Load() != 0 {
+				t.Fatalf("injected policy called %d times before cross-origin refusal", callerChecks.Load())
+			}
+		})
+	}
+}
+
+func TestNewRunnerClientRetainsDefaultSameOriginRedirectLimit(t *testing.T) {
+	origin, err := url.Parse("https://mvm-test.lambda-microvm.eu-west-1.on.aws")
+	if err != nil {
+		t.Fatal(err)
+	}
+	injected := &http.Client{}
+	client := newRunnerClient(&fakeControlPlane{}, injected, "eu-west-1")
+	request := &http.Request{URL: origin}
+	via := make([]*http.Request, 10)
+	for i := range via {
+		via[i] = &http.Request{URL: origin}
+	}
+	if err := client.http.CheckRedirect(request, via); err == nil || !strings.Contains(err.Error(), "stopped after 10 redirects") {
+		t.Fatalf("redirect error=%v want default redirect limit", err)
+	}
+	if injected.CheckRedirect != nil {
+		t.Fatal("newRunnerClient mutated the source redirect policy")
+	}
+}
+
+func TestRunnerClientCrossOriginRedirectNeverSendsProxyHeaders(t *testing.T) {
+	var targetRequests atomic.Int32
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		targetRequests.Add(1)
+		t.Errorf("cross-origin target received auth=%q port=%q", req.Header.Get("X-aws-proxy-auth"), req.Header.Get("X-aws-proxy-port"))
+		http.Error(w, "unexpected request", http.StatusInternalServerError)
+	}))
+	defer target.Close()
+	targetURL, err := url.Parse(target.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var injectedChecks atomic.Int32
+	injected := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.URL.Host == targetURL.Host {
+				return http.DefaultTransport.RoundTrip(req)
+			}
+			if req.Header.Get("X-aws-proxy-auth") != "token" || req.Header.Get("X-aws-proxy-port") != fmt.Sprint(runnerPort) {
+				t.Fatalf("runner request headers: auth=%q port=%q", req.Header.Get("X-aws-proxy-auth"), req.Header.Get("X-aws-proxy-port"))
+			}
+			return &http.Response{
+				StatusCode: http.StatusTemporaryRedirect,
+				Header:     http.Header{"Location": []string{target.URL + "/stolen"}},
+				Body:       io.NopCloser(strings.NewReader("")),
+				Request:    req,
+			}, nil
+		}),
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			injectedChecks.Add(1)
+			return nil
+		},
+	}
+	client := newRunnerClient(&fakeControlPlane{}, injected, "eu-west-1")
+	err = client.Health(context.Background(), microVM{ID: "mvm-test", Endpoint: "mvm-test.lambda-microvm.eu-west-1.on.aws"})
+	if err == nil || !strings.Contains(err.Error(), "refused cross-origin redirect") {
+		t.Fatalf("Health error=%v want cross-origin refusal", err)
+	}
+	if injectedChecks.Load() != 0 {
+		t.Fatalf("injected redirect checks=%d want 0", injectedChecks.Load())
+	}
+	if targetRequests.Load() != 0 {
+		t.Fatalf("cross-origin target requests=%d want 0", targetRequests.Load())
 	}
 }
 

--- a/internal/providers/awslambdamicrovm/client.go
+++ b/internal/providers/awslambdamicrovm/client.go
@@ -174,6 +174,8 @@ type runnerClient struct {
 	region  string
 }
 
+const runnerResponseHeaderTimeout = 60 * time.Second
+
 type runnerExecRequest struct {
 	Command string            `json:"command"`
 	Workdir string            `json:"workdir,omitempty"`
@@ -189,7 +191,7 @@ type runnerEvent struct {
 
 func newRunnerClient(control controlPlane, source *http.Client, region string) *runnerClient {
 	if source == nil {
-		source = &http.Client{}
+		source = defaultRunnerHTTPClient(runnerResponseHeaderTimeout)
 	}
 	cloned := *source
 	originalRedirect := source.CheckRedirect
@@ -200,9 +202,18 @@ func newRunnerClient(control controlPlane, source *http.Client, region string) *
 		if originalRedirect != nil {
 			return originalRedirect(req, via)
 		}
+		if len(via) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
 		return nil
 	}
 	return &runnerClient{control: control, http: &cloned, region: region}
+}
+
+func defaultRunnerHTTPClient(responseHeaderTimeout time.Duration) *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.ResponseHeaderTimeout = responseHeaderTimeout
+	return &http.Client{Transport: transport}
 }
 
 func (c *runnerClient) Health(ctx context.Context, vm microVM) error {
@@ -315,7 +326,7 @@ func endpointURL(endpoint, region string) (*url.URL, error) {
 }
 
 func sameOrigin(left, right *url.URL) bool {
-	return strings.EqualFold(left.Scheme, right.Scheme) && strings.EqualFold(left.Host, right.Host)
+	return left != nil && right != nil && strings.EqualFold(left.Scheme, right.Scheme) && strings.EqualFold(left.Host, right.Host)
 }
 
 func responseError(action string, resp *http.Response) error {


### PR DESCRIPTION
## What Problem This Solves

The Lambda MicroVM runner fallback previously had no response-header deadline. A stalled runner endpoint could therefore wait forever. The original 60-second `http.Client.Timeout` proposal bounded that wait, but it also bounded uploads and streamed command bodies, breaking valid long-running work.

This rewrite scopes the 60-second bound to response headers only.

## Correctness and Security Boundary

- A nil source uses a clone of the default transport with `ResponseHeaderTimeout` set to 60 seconds and `http.Client.Timeout` left at zero.
- Uploads and response streams remain bounded by the caller context after headers arrive.
- An injected `http.Client` is shallow-cloned rather than mutated. Its transport, proxy/TLS settings, cookie jar, timeout, and other fields remain intact.
- The clone wraps the injected redirect callback. Cross-origin scheme or host changes are rejected before caller policy; same-origin redirects delegate to a stricter caller callback unchanged.
- A nil injected redirect callback retains Go's normal ten-redirect limit for same-origin redirects.
- `X-aws-proxy-auth` and `X-aws-proxy-port` never reach a cross-origin redirect target. Go does not classify these custom headers as sensitive, so the runner client must enforce this boundary itself.

## Evidence

Focused security, timeout, upload, and stream coverage under the race detector:

```console
$ go test -race ./internal/providers/awslambdamicrovm -count=1 -run 'Test(NewRunnerClient|DefaultRunnerHTTPClient|RunnerClientCrossOriginRedirect)' -v
PASS
ok  github.com/openclaw/crabbox/internal/providers/awslambdamicrovm  2.175s
```

Full provider package under the race detector:

```console
$ go test -race ./internal/providers/awslambdamicrovm -count=1
ok  github.com/openclaw/crabbox/internal/providers/awslambdamicrovm  8.592s
```

Static analysis:

```console
$ go vet ./internal/providers/awslambdamicrovm
```

The same package race suite passed on a clean hydrated Blacksmith Testbox:

```console
$ go test -race ./internal/providers/awslambdamicrovm -count=1
ok  github.com/openclaw/crabbox/internal/providers/awslambdamicrovm  1.493s
```

Run: https://github.com/openclaw/crabbox/actions/runs/31994992845

The loopback redirect regression test exercises Go's real redirect machinery: a simulated runner response points at a second HTTP server, the permissive injected callback is not called, and the target observes zero requests.

## Review

A P1-focused structured autoreview of the exact branch diff found no P1 security or correctness issue. It raised one P2 concern about replacing Go's process-global `http.DefaultTransport` with a non-`*http.Transport` implementation. That was reviewed and not accepted: the requested fallback contract explicitly clones the standard default transport, and Crabbox uses the same typed-clone convention across its provider clients. Supporting arbitrary replacement round-trippers while timing only response headers would require a separate adapter and is outside this fix.

## Not Tested

No live AWS Lambda MicroVM control-plane or runner endpoint was available in this checkout. The network behavior is covered with loopback HTTP servers locally and on the clean Testbox.

## Credit

The rewritten commit preserves Sebastien Tardif's contribution with a `Co-authored-by` trailer, and the changelog thanks `@SebTardif`.
