### PR TITLE
fix(e2b): stalled API host can hang sandbox create and inspect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Bounded Lambda MicroVM runner response-header waits without limiting uploads or streamed executions, while preserving injected HTTP clients. Thanks @SebTardif.
 - Fixed native local-container checkpoint forks to complete their recorded Docker runtime scope before claim creation, allowing immediate commands and safe normal stop while preserving exact claim validation.
+- Split fallback E2B HTTP ownership so finite lifecycle calls cannot hang indefinitely while uploads and process streams remain caller-controlled. Thanks @SebTardif.
 - Rejected native Jujutsu and other unsupported local sync sources before delegated archive providers can provision or execute a remote sandbox.
 - Accepted explicit local-container architecture assertions only when the selected Docker or Podman daemon reports a matching native architecture, without enabling emulation. Thanks @coygeek.
 - Omitted coordinator-only history commands from failure digests when run history is unavailable, while preserving direct lease recovery guidance.

--- a/internal/providers/e2b/backend_test.go
+++ b/internal/providers/e2b/backend_test.go
@@ -28,6 +28,58 @@ func (fn e2bRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) 
 	return fn(req)
 }
 
+type e2bRewriteTransport struct {
+	target *url.URL
+	base   http.RoundTripper
+}
+
+func (transport e2bRewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	clone := req.Clone(req.Context())
+	endpoint := *req.URL
+	endpoint.Scheme = transport.target.Scheme
+	endpoint.Host = transport.target.Host
+	clone.URL = &endpoint
+	clone.Host = transport.target.Host
+	return transport.base.RoundTrip(clone)
+}
+
+type e2bDelayedReader struct {
+	data    []byte
+	split   int
+	delay   time.Duration
+	offset  int
+	delayed bool
+}
+
+func (reader *e2bDelayedReader) Read(p []byte) (int, error) {
+	if reader.offset >= len(reader.data) {
+		return 0, io.EOF
+	}
+	if reader.offset >= reader.split && !reader.delayed {
+		time.Sleep(reader.delay)
+		reader.delayed = true
+	}
+	limit := len(reader.data)
+	if !reader.delayed && limit > reader.split {
+		limit = reader.split
+	}
+	n := copy(p, reader.data[reader.offset:limit])
+	reader.offset += n
+	return n, nil
+}
+
+func e2bLoopbackClient(t *testing.T, server *httptest.Server, timeout time.Duration) *http.Client {
+	t.Helper()
+	target, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &http.Client{
+		Transport: e2bRewriteTransport{target: target, base: server.Client().Transport},
+		Timeout:   timeout,
+	}
+}
+
 func TestE2BClientRedactsReflectedCredentials(t *testing.T) {
 	t.Run("API key", func(t *testing.T) {
 		const secret = "e2b-api-secret"
@@ -52,7 +104,7 @@ func TestE2BClientRedactsReflectedCredentials(t *testing.T) {
 				Request:    req,
 			}, nil
 		})}
-		client := &e2bClient{httpClient: httpClient}
+		client := &e2bClient{envdClient: httpClient}
 		_, err := client.StartProcess(context.Background(), e2bSession{SandboxID: "sbx_1", Domain: "example.test", EnvdAccessToken: secret}, e2bProcessRequest{Command: "true"})
 		assertE2BRedactedError(t, err, secret)
 	})
@@ -100,6 +152,181 @@ func TestParseE2BProcessStream(t *testing.T) {
 	if code != 7 || stdout.String() != "hello" || stderr.String() != "warn" {
 		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
 	}
+}
+
+func TestE2BDefaultHTTPClientsSeparateControlAndDataPlanes(t *testing.T) {
+	api, err := newE2BClient(Config{E2B: E2BConfig{APIKey: "e2b_test"}}, Runtime{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, ok := api.(*e2bClient)
+	if !ok {
+		t.Fatalf("api=%T, want *e2bClient", api)
+	}
+	if client.httpClient.Timeout != e2bControlTimeout {
+		t.Fatalf("control Timeout=%s, want %s", client.httpClient.Timeout, e2bControlTimeout)
+	}
+	if client.envdClient.Timeout != 0 {
+		t.Fatalf("envd Timeout=%s, want caller-owned lifetime", client.envdClient.Timeout)
+	}
+	if client.httpClient == client.envdClient {
+		t.Fatal("control and envd fallbacks share one client")
+	}
+	if client.httpClient.Transport != nil || client.envdClient.Transport != nil {
+		t.Fatalf("fallback transports=control:%T envd:%T, want process default transport", client.httpClient.Transport, client.envdClient.Transport)
+	}
+}
+
+func TestE2BInjectedHTTPClientIsPreservedForBothPlanes(t *testing.T) {
+	injected := &http.Client{
+		Transport: e2bRoundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, errors.New("test transport")
+		}),
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+		Timeout:       17 * time.Second,
+	}
+	api, err := newE2BClient(Config{E2B: E2BConfig{APIKey: "e2b_test"}}, Runtime{HTTP: injected})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := api.(*e2bClient)
+	if client.httpClient != injected || client.envdClient != injected {
+		t.Fatalf("clients=control:%p envd:%p, want injected %p", client.httpClient, client.envdClient, injected)
+	}
+}
+
+func TestE2BControlClientBoundsStalledResponseBody(t *testing.T) {
+	const controlTimeout = 40 * time.Millisecond
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"sandboxID":`)
+		w.(http.Flusher).Flush()
+		<-req.Context().Done()
+	}))
+	defer server.Close()
+
+	controlClient, _ := e2bHTTPClients(nil, controlTimeout)
+	client := &e2bClient{apiKey: "e2b_test", apiURL: server.URL, httpClient: controlClient}
+	started := time.Now()
+	_, err := client.GetSandbox(context.Background(), "sbx_1")
+	elapsed := time.Since(started)
+	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("GetSandbox error=%v, want whole-request deadline", err)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("stalled response body bounded after %s, want under 1s", elapsed)
+	}
+	t.Logf("control response-body stall bounded: elapsed=%s timeout=%s", elapsed.Round(time.Millisecond), controlTimeout)
+}
+
+func TestE2BControlClientBoundsWithheldHeaders(t *testing.T) {
+	const controlTimeout = 40 * time.Millisecond
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
+		<-req.Context().Done()
+	}))
+	defer server.Close()
+
+	controlClient, _ := e2bHTTPClients(nil, controlTimeout)
+	client := &e2bClient{apiKey: "e2b_test", apiURL: server.URL, httpClient: controlClient}
+	started := time.Now()
+	_, err := client.GetSandbox(context.Background(), "sbx_1")
+	elapsed := time.Since(started)
+	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("GetSandbox error=%v, want whole-request deadline", err)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("withheld headers bounded after %s, want under 1s", elapsed)
+	}
+	t.Logf("control withheld headers bounded: elapsed=%s timeout=%s", elapsed.Round(time.Millisecond), controlTimeout)
+}
+
+func TestE2BDataPlaneStreamOutlivesControlTimeout(t *testing.T) {
+	const controlTimeout = 30 * time.Millisecond
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		_, _ = io.Copy(io.Discard, req.Body)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(e2bTestEnvelope(0, map[string]any{"event": map[string]any{"start": map[string]any{"pid": 42}}}))
+		w.(http.Flusher).Flush()
+		time.Sleep(3 * controlTimeout)
+		_, _ = w.Write(e2bTestEnvelope(0, map[string]any{"event": map[string]any{"end": map[string]any{"exitCode": 0, "exited": true}}}))
+		_, _ = w.Write(e2bTestEnvelope(2, map[string]any{}))
+	}))
+	defer server.Close()
+
+	controlClient, _ := e2bHTTPClients(nil, controlTimeout)
+	client := &e2bClient{
+		domain:     "e2b.test",
+		httpClient: controlClient,
+		envdClient: e2bLoopbackClient(t, server, 0),
+	}
+	started := time.Now()
+	code, err := client.StartProcess(context.Background(), e2bSession{SandboxID: "sbx_1", Domain: "e2b.test"}, e2bProcessRequest{Command: "true"})
+	elapsed := time.Since(started)
+	if err != nil || code != 0 {
+		t.Fatalf("StartProcess code=%d err=%v", code, err)
+	}
+	if elapsed <= controlTimeout {
+		t.Fatalf("stream completed in %s, want it active beyond %s", elapsed, controlTimeout)
+	}
+	t.Logf("envd stream survived control deadline: elapsed=%s control_timeout=%s", elapsed.Round(time.Millisecond), controlTimeout)
+}
+
+func TestE2BDataPlaneUploadOutlivesControlTimeout(t *testing.T) {
+	const controlTimeout = 30 * time.Millisecond
+	type uploadResult struct {
+		data []byte
+		err  error
+	}
+	uploaded := make(chan uploadResult, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		reader, err := req.MultipartReader()
+		if err != nil {
+			uploaded <- uploadResult{err: err}
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		part, err := reader.NextPart()
+		if err != nil {
+			uploaded <- uploadResult{err: err}
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		data, err := io.ReadAll(part)
+		uploaded <- uploadResult{data: data, err: err}
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	payload := []byte("before-after")
+	controlClient, _ := e2bHTTPClients(nil, controlTimeout)
+	client := &e2bClient{
+		domain:     "e2b.test",
+		httpClient: controlClient,
+		envdClient: e2bLoopbackClient(t, server, 0),
+	}
+	reader := &e2bDelayedReader{data: payload, split: len("before-"), delay: 3 * controlTimeout}
+	started := time.Now()
+	err := client.UploadFile(context.Background(), e2bSession{SandboxID: "sbx_1", Domain: "e2b.test"}, "/tmp/archive.tgz", reader)
+	elapsed := time.Since(started)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := <-uploaded
+	if result.err != nil {
+		t.Fatal(result.err)
+	}
+	if !bytes.Equal(result.data, payload) {
+		t.Fatalf("uploaded=%q, want %q", result.data, payload)
+	}
+	if elapsed <= controlTimeout {
+		t.Fatalf("upload completed in %s, want it active beyond %s", elapsed, controlTimeout)
+	}
+	t.Logf("envd upload completed without truncation: bytes=%d elapsed=%s control_timeout=%s", len(result.data), elapsed.Round(time.Millisecond), controlTimeout)
 }
 
 func TestValidateE2BAPIURL(t *testing.T) {

--- a/internal/providers/e2b/client.go
+++ b/internal/providers/e2b/client.go
@@ -35,7 +35,10 @@ type e2bClient struct {
 	domain     string
 	user       string
 	httpClient *http.Client
+	envdClient *http.Client
 }
+
+const e2bControlTimeout = 60 * time.Second
 
 type e2bCreateSandboxRequest struct {
 	TemplateID          string
@@ -97,16 +100,20 @@ var newE2BClient = func(cfg Config, rt Runtime) (e2bAPI, error) {
 	if apiKey == "" {
 		return nil, exit(2, "provider=e2b requires E2B_API_KEY")
 	}
-	httpClient := rt.HTTP
-	if httpClient == nil {
-		httpClient = http.DefaultClient
-	}
+	httpClient, envdClient := e2bHTTPClients(rt.HTTP, e2bControlTimeout)
 	apiURL, err := validateE2BAPIURL(blank(cfg.E2B.APIURL, "https://api.e2b.app"))
 	if err != nil {
 		return nil, err
 	}
 	domain := strings.TrimSpace(blank(cfg.E2B.Domain, "e2b.app"))
-	return &e2bClient{apiKey: apiKey, apiURL: apiURL, domain: domain, user: cfg.E2B.User, httpClient: httpClient}, nil
+	return &e2bClient{
+		apiKey:     apiKey,
+		apiURL:     apiURL,
+		domain:     domain,
+		user:       cfg.E2B.User,
+		httpClient: httpClient,
+		envdClient: envdClient,
+	}, nil
 }
 
 func validateE2BAPIURL(raw string) (string, error) {
@@ -144,6 +151,13 @@ func isE2BLoopbackHost(host string) bool {
 	}
 	ip := net.ParseIP(host)
 	return ip != nil && ip.IsLoopback()
+}
+
+func e2bHTTPClients(injected *http.Client, controlTimeout time.Duration) (*http.Client, *http.Client) {
+	if injected != nil {
+		return injected, injected
+	}
+	return &http.Client{Timeout: controlTimeout}, &http.Client{Timeout: 0}
 }
 
 func secureE2BHTTPClient(source *http.Client, trusted *url.URL) *http.Client {
@@ -305,7 +319,7 @@ func (c *e2bClient) UploadFile(ctx context.Context, session e2bSession, targetPa
 		}
 		_ = pw.Close()
 	}()
-	resp, err := secureE2BHTTPClient(c.httpClient, req.URL).Do(req)
+	resp, err := secureE2BHTTPClient(c.dataPlaneHTTPClient(), req.URL).Do(req)
 	if err != nil {
 		_ = pr.CloseWithError(err)
 		_ = pw.CloseWithError(err)
@@ -359,7 +373,7 @@ func (c *e2bClient) StartProcess(ctx context.Context, session e2bSession, req e2
 	if timeoutMs := durationMillisCeil(req.Timeout); timeoutMs > 0 {
 		httpReq.Header.Set("Connect-Timeout-Ms", fmt.Sprint(timeoutMs))
 	}
-	resp, err := secureE2BHTTPClient(c.httpClient, httpReq.URL).Do(httpReq)
+	resp, err := secureE2BHTTPClient(c.dataPlaneHTTPClient(), httpReq.URL).Do(httpReq)
 	if err != nil {
 		return 1, err
 	}
@@ -443,6 +457,13 @@ func (c *e2bClient) setEnvdHeaders(req *http.Request, session e2bSession) {
 	req.Header.Set("X-Access-Token", session.EnvdAccessToken)
 	req.Header.Set("E2b-Sandbox-Id", session.SandboxID)
 	req.Header.Set("E2b-Sandbox-Port", "49983")
+}
+
+func (c *e2bClient) dataPlaneHTTPClient() *http.Client {
+	if c.envdClient != nil {
+		return c.envdClient
+	}
+	return &http.Client{Timeout: 0}
 }
 
 type e2bStartResponse struct {


### PR DESCRIPTION
## What problem this solves

When `Runtime.HTTP` is unset, E2B used one fallback HTTP client for two different ownership domains:

- finite lifecycle JSON (`create`, `connect`, `get`, `list`, and `delete`); and
- envd uploads and process response streams.

An unbounded fallback can hang a lifecycle call forever. The original `ResponseHeaderTimeout` proposal only bounded the wait for headers: it did not stop a lifecycle response that sent headers and then stalled its JSON body, and it imposed the provider's deadline on envd data-plane handshakes.

This is the same control/data ownership split established for CubeSandbox in https://github.com/openclaw/crabbox/pull/1229.

## What changed

- The fallback control client now has a 60-second whole-request timeout, covering connection setup, response headers, and complete finite JSON bodies.
- The fallback envd client has no whole-request timeout; upload and process-stream lifetime remains owned by the caller context.
- `doJSON` and every lifecycle method use the control client.
- `UploadFile` and `StartProcess` use the envd client.
- An injected `Runtime.HTTP` remains the exact same client object for both paths, preserving its transport, proxy, TLS, redirect, jar, and timeout behavior.
- Both private fallbacks leave `Transport` nil so Go continues to use the process-level default transport.

Thanks @SebTardif for identifying the hang and contributing the original patch.

## Source-blind loopback behavior proof

The E2B test artifact was compiled, then executed from an isolated directory containing only the binary and behavior contract—no source checkout. Short injected fixture deadlines avoid real-minute tests.

```console
=== RUN   TestE2BControlClientBoundsStalledResponseBody
    control response-body stall bounded: elapsed=41ms timeout=40ms
--- PASS: TestE2BControlClientBoundsStalledResponseBody (0.04s)
=== RUN   TestE2BControlClientBoundsWithheldHeaders
    control withheld headers bounded: elapsed=41ms timeout=40ms
--- PASS: TestE2BControlClientBoundsWithheldHeaders (0.04s)
=== RUN   TestE2BDataPlaneStreamOutlivesControlTimeout
    envd stream survived control deadline: elapsed=92ms control_timeout=30ms
--- PASS: TestE2BDataPlaneStreamOutlivesControlTimeout (0.09s)
=== RUN   TestE2BDataPlaneUploadOutlivesControlTimeout
    envd upload completed without truncation: bytes=12 elapsed=92ms control_timeout=30ms
--- PASS: TestE2BDataPlaneUploadOutlivesControlTimeout (0.09s)
PASS
```

## Verification

- `go test -race ./internal/providers/e2b -count=1` — passed.
- Focused ownership/timeout behavior tests with `-race -count=5` — passed.
- `go test -race ./internal/providers/shared -count=1` — passed.
- Final isolated `go test -race ./internal/providers/e2b ./internal/providers/shared -count=1` — passed.
- `go vet ./...` — passed.
- P1 autoreview of the final branch diff — clean, no actionable findings.

The exact broad command `go test -race ./... -count=1 -timeout=20m` was run. Every provider package, including E2B and shared, passed, but the unrelated `internal/cli` package hit its 20-minute timeout in `TestSyncGitCoherencePlanSelectsEligibleOriginBranch`. That test then passed 10/10 in isolation. A second all-package run with package concurrency capped at four again passed every provider package but exposed different unrelated `internal/cli` flakes (`TestOpenLocalURLScrubsExternalDesktopPassword` and `TestWatchChangeDuringRunQueuesExactlyOnePendingRerun`); both passed together in isolation under race.

## Live-provider proof still open

No E2B credential was used for this rewrite. A live `warmup` → `status` → no-sync `run` → `list` → `stop` smoke remains useful provider integration proof, but the timeout and stream-ownership behavior itself is covered by the source-blind loopback transcript above.
