### PR TITLE
fix(http): stalled control plane can hang remaining providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Bounded Lambda MicroVM runner response-header waits without limiting uploads or streamed executions, while preserving injected HTTP clients. Thanks @SebTardif.
 - Fixed native local-container checkpoint forks to complete their recorded Docker runtime scope before claim creation, allowing immediate commands and safe normal stop while preserving exact claim validation.
 - Split fallback E2B HTTP ownership so finite lifecycle calls cannot hang indefinitely while uploads and process streams remain caller-controlled. Thanks @SebTardif.
+- Split fallback HTTP ownership for Azure Dynamic Sessions, Blaxel, Cloudflare Sandbox, Freestyle, Orgo, and SmolVM so finite control calls cannot hang while data-plane lifetimes remain caller-controlled. Thanks @SebTardif.
 - Rejected native Jujutsu and other unsupported local sync sources before delegated archive providers can provision or execute a remote sandbox.
 - Accepted explicit local-container architecture assertions only when the selected Docker or Podman daemon reports a matching native architecture, without enabling emulation. Thanks @coygeek.
 - Omitted coordinator-only history commands from failure digests when run history is unavailable, while preserving direct lease recovery guidance.

--- a/internal/providers/azuredynamicsessions/client.go
+++ b/internal/providers/azuredynamicsessions/client.go
@@ -32,7 +32,10 @@ type azureDynamicSessionsClient struct {
 	managementAPIVersion string
 	token                string
 	httpClient           *http.Client
+	dataHTTPClient       *http.Client
 }
+
+const azureDynamicSessionsControlTimeout = 60 * time.Second
 
 type azureDynamicSessionsExecRequest struct {
 	Command   string            `json:"command"`
@@ -103,16 +106,21 @@ var newAzureDynamicSessionsClient = func(ctx context.Context, cfg Config, rt Run
 	if err != nil {
 		return nil, err
 	}
-	httpClient := rt.HTTP
-	if httpClient == nil {
-		httpClient = http.DefaultClient
-	}
+	httpClient, dataHTTPClient := azureDynamicSessionsHTTPClients(rt.HTTP, azureDynamicSessionsControlTimeout)
 	return &azureDynamicSessionsClient{
 		endpoint:             endpoint,
 		managementAPIVersion: blank(strings.TrimSpace(cfg.AzureDynamicSessions.APIVersion), "2025-02-02-preview"),
 		token:                token,
 		httpClient:           httpClient,
+		dataHTTPClient:       dataHTTPClient,
 	}, nil
+}
+
+func azureDynamicSessionsHTTPClients(injected *http.Client, controlTimeout time.Duration) (*http.Client, *http.Client) {
+	if injected != nil {
+		return injected, injected
+	}
+	return &http.Client{Timeout: controlTimeout}, &http.Client{}
 }
 
 func azureDynamicSessionsEndpoint(cfg Config) (string, error) {
@@ -237,7 +245,7 @@ func (c *azureDynamicSessionsClient) UploadFile(ctx context.Context, identifier,
 	c.setHeaders(req)
 	req.ContentLength = info.Size()
 	req.Header.Set("Content-Type", "application/octet-stream")
-	resp, err := c.secureHTTPClient().Do(req)
+	resp, err := c.secureHTTPClient(c.dataPlaneHTTPClient()).Do(req)
 	if err != nil {
 		return err
 	}
@@ -260,7 +268,7 @@ func (c *azureDynamicSessionsClient) ExecStream(ctx context.Context, identifier 
 	}
 	c.setHeaders(req)
 	req.Header.Set("Content-Type", "application/json")
-	resp, err := c.secureHTTPClient().Do(req)
+	resp, err := c.secureHTTPClient(c.dataPlaneHTTPClient()).Do(req)
 	if err != nil {
 		return 0, err
 	}
@@ -403,7 +411,7 @@ func (c *azureDynamicSessionsClient) doJSONURL(ctx context.Context, method, endp
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	resp, err := c.secureHTTPClient().Do(req)
+	resp, err := c.secureHTTPClient(c.controlPlaneHTTPClient()).Do(req)
 	if err != nil {
 		return err
 	}
@@ -428,8 +436,24 @@ func (c *azureDynamicSessionsClient) responseError(resp *http.Response) error {
 	return &azureDynamicSessionsAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: shared.RedactErrorSecrets(summarizeJSON(data), c.token)}
 }
 
-func (c *azureDynamicSessionsClient) secureHTTPClient() *http.Client {
-	source := c.httpClient
+func (c *azureDynamicSessionsClient) controlPlaneHTTPClient() *http.Client {
+	if c.httpClient != nil {
+		return c.httpClient
+	}
+	return &http.Client{Timeout: azureDynamicSessionsControlTimeout}
+}
+
+func (c *azureDynamicSessionsClient) dataPlaneHTTPClient() *http.Client {
+	if c.dataHTTPClient != nil {
+		return c.dataHTTPClient
+	}
+	if c.httpClient != nil {
+		return c.httpClient
+	}
+	return &http.Client{}
+}
+
+func (c *azureDynamicSessionsClient) secureHTTPClient(source *http.Client) *http.Client {
 	if source == nil {
 		source = http.DefaultClient
 	}

--- a/internal/providers/azuredynamicsessions/client_test.go
+++ b/internal/providers/azuredynamicsessions/client_test.go
@@ -15,7 +15,76 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 )
+
+func TestAzureDynamicSessionsFallbackBoundsControlAndPreservesExecStream(t *testing.T) {
+	const controlTimeout = 30 * time.Millisecond
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.management/getSession":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{"identifier":`)
+			w.(http.Flusher).Flush()
+			<-r.Context().Done()
+		case "/v1/exec":
+			w.Header().Set("Content-Type", "application/x-ndjson")
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{"type":"heartbeat"}`+"\n")
+			w.(http.Flusher).Flush()
+			time.Sleep(3 * controlTimeout)
+			_, _ = io.WriteString(w, `{"type":"complete","exitCode":0}`+"\n")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	control, data := azureDynamicSessionsHTTPClients(nil, controlTimeout)
+	client := &azureDynamicSessionsClient{
+		endpoint:             server.URL,
+		managementAPIVersion: "2025-02-02-preview",
+		token:                "test-token",
+		httpClient:           control,
+		dataHTTPClient:       data,
+	}
+	started := time.Now()
+	_, err := client.GetSession(context.Background(), "azds-test")
+	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("GetSession error=%v, want whole-request deadline", err)
+	}
+	controlElapsed := time.Since(started)
+	if controlElapsed >= time.Second {
+		t.Fatalf("stalled control response bounded after %s, want under 1s", controlElapsed)
+	}
+
+	started = time.Now()
+	code, err := client.ExecStream(context.Background(), "azds-test", azureDynamicSessionsExecRequest{Command: "true"}, io.Discard, io.Discard)
+	if err != nil || code != 0 {
+		t.Fatalf("ExecStream code=%d err=%v", code, err)
+	}
+	dataElapsed := time.Since(started)
+	if dataElapsed <= controlTimeout {
+		t.Fatalf("exec stream completed in %s, want beyond %s", dataElapsed, controlTimeout)
+	}
+	t.Logf("Azure Dynamic Sessions control body bounded in %s; exec stream completed in %s beyond %s control deadline", controlElapsed.Round(time.Millisecond), dataElapsed.Round(time.Millisecond), controlTimeout)
+}
+
+func TestAzureDynamicSessionsInjectedHTTPClientIsPreservedForBothPlanes(t *testing.T) {
+	t.Setenv(tokenEnvName, "test-token")
+	injected := &http.Client{Timeout: 17 * time.Second}
+	api, err := newAzureDynamicSessionsClient(context.Background(), Config{AzureDynamicSessions: AzureDynamicSessionsConfig{
+		Endpoint: "http://127.0.0.1:8787",
+	}}, Runtime{HTTP: injected})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := api.(*azureDynamicSessionsClient)
+	if client.httpClient != injected || client.dataHTTPClient != injected {
+		t.Fatalf("clients=control:%p data:%p, want injected %p", client.httpClient, client.dataHTTPClient, injected)
+	}
+}
 
 func TestAzureDynamicSessionsEndpointRequiresPoolManagementEndpoint(t *testing.T) {
 	cfg := Config{}

--- a/internal/providers/blaxel/client.go
+++ b/internal/providers/blaxel/client.go
@@ -114,7 +114,10 @@ type restClient struct {
 	workspace string
 	version   string
 	http      *http.Client
+	dataHTTP  *http.Client
 }
+
+const blaxelControlTimeout = 60 * time.Second
 
 func newBlaxelClient(cfg Config, rt Runtime) (Client, error) {
 	baseURL := strings.TrimSpace(cfg.Blaxel.APIURL)
@@ -130,17 +133,22 @@ func newBlaxelClient(cfg Config, rt Runtime) (Client, error) {
 		return nil, exit(2, "provider=blaxel needs an API key; load CRABBOX_BLAXEL_API_KEY or BL_API_KEY from a secret manager")
 	}
 	workspace := strings.TrimSpace(cfg.Blaxel.Workspace)
-	httpClient := rt.HTTP
-	if httpClient == nil {
-		httpClient = http.DefaultClient
-	}
+	httpClient, dataHTTPClient := blaxelHTTPClients(rt.HTTP, blaxelControlTimeout)
 	return &restClient{
 		base:      baseURL,
 		apiKey:    apiKey,
 		workspace: workspace,
 		version:   defaultAPIVersion,
 		http:      secureHTTPClient(httpClient),
+		dataHTTP:  secureHTTPClient(dataHTTPClient),
 	}, nil
+}
+
+func blaxelHTTPClients(injected *http.Client, controlTimeout time.Duration) (*http.Client, *http.Client) {
+	if injected != nil {
+		return injected, injected
+	}
+	return &http.Client{Timeout: controlTimeout}, &http.Client{}
 }
 
 func BlaxelAPIKey(cfg Config) string {
@@ -485,11 +493,18 @@ func (c *restClient) doSandbox(ctx context.Context, sandbox, method, endpoint st
 	if err != nil {
 		return nil, err
 	}
-	return c.doAt(ctx, base, method, endpoint, values, request, response)
+	return c.doAt(ctx, c.dataPlaneHTTPClient(), base, method, endpoint, values, request, response)
 }
 
 func (c *restClient) do(ctx context.Context, method, endpoint string, values url.Values, request any, response any) ([]byte, error) {
-	return c.doAt(ctx, c.base, method, endpoint, values, request, response)
+	return c.doAt(ctx, c.http, c.base, method, endpoint, values, request, response)
+}
+
+func (c *restClient) dataPlaneHTTPClient() *http.Client {
+	if c.dataHTTP != nil {
+		return c.dataHTTP
+	}
+	return c.http
 }
 
 // blaxelWorkloadRetryDelays follows Blaxel's own WORKLOAD_UNAVAILABLE guidance:
@@ -535,7 +550,7 @@ func (c *restClient) doSandboxRetry(ctx context.Context, sandbox, method, endpoi
 	return body, err
 }
 
-func (c *restClient) doAt(ctx context.Context, baseURL, method, endpoint string, values url.Values, request any, response any) ([]byte, error) {
+func (c *restClient) doAt(ctx context.Context, httpClient *http.Client, baseURL, method, endpoint string, values url.Values, request any, response any) ([]byte, error) {
 	var body io.Reader
 	if request != nil {
 		data, err := json.Marshal(request)
@@ -565,7 +580,7 @@ func (c *restClient) doAt(ctx context.Context, baseURL, method, endpoint string,
 	if request != nil {
 		httpReq.Header.Set("Content-Type", "application/json")
 	}
-	resp, err := c.http.Do(httpReq)
+	resp, err := httpClient.Do(httpReq)
 	if err != nil {
 		return nil, redactError(err)
 	}
@@ -651,7 +666,7 @@ func (c *restClient) doMultipartAt(ctx context.Context, baseURL, method, endpoin
 		httpReq.Header.Set("X-Blaxel-Workspace", c.workspace)
 	}
 	httpReq.Header.Set("Content-Type", contentType)
-	resp, err := c.http.Do(httpReq)
+	resp, err := c.dataPlaneHTTPClient().Do(httpReq)
 	if err != nil {
 		return nil, redactError(err)
 	}

--- a/internal/providers/blaxel/client_test.go
+++ b/internal/providers/blaxel/client_test.go
@@ -9,11 +9,112 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
+
+func TestBlaxelFallbackBoundsControlAndPreservesUpload(t *testing.T) {
+	const controlTimeout = 30 * time.Millisecond
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v0/sandboxes":
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `[{"metadata":`)
+			w.(http.Flusher).Flush()
+			<-r.Context().Done()
+		case r.Method == http.MethodGet && r.URL.Path == "/v0/sandboxes/sbx-1":
+			_ = json.NewEncoder(w).Encode(map[string]any{"metadata": map[string]any{
+				"name": "sbx-1",
+				"url":  serverURL(r) + "/sandbox/sbx-1",
+			}})
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/filesystem-multipart/initiate/"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"uploadId": "upload-1"})
+		case r.Method == http.MethodPut && strings.HasSuffix(r.URL.Path, "/filesystem-multipart/upload-1/part"):
+			if err := r.ParseMultipartForm(1024); err != nil {
+				t.Error(err)
+			}
+			time.Sleep(3 * controlTimeout)
+			_ = json.NewEncoder(w).Encode(map[string]any{"etag": "etag-1", "partNumber": 1})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/filesystem-multipart/upload-1/complete"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	control, data := blaxelHTTPClients(nil, controlTimeout)
+	client := &restClient{
+		base:     server.URL,
+		apiKey:   "test-key",
+		version:  defaultAPIVersion,
+		http:     secureHTTPClient(control),
+		dataHTTP: secureHTTPClient(data),
+	}
+	started := time.Now()
+	err := client.Probe(context.Background())
+	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Probe error=%v, want whole-request deadline", err)
+	}
+	controlElapsed := time.Since(started)
+	if controlElapsed >= time.Second {
+		t.Fatalf("stalled control response bounded after %s, want under 1s", controlElapsed)
+	}
+
+	started = time.Now()
+	if err := client.UploadFile(context.Background(), "sbx-1", "/tmp/archive.tgz", strings.NewReader("archive")); err != nil {
+		t.Fatal(err)
+	}
+	dataElapsed := time.Since(started)
+	if dataElapsed <= controlTimeout {
+		t.Fatalf("upload completed in %s, want beyond %s", dataElapsed, controlTimeout)
+	}
+	t.Logf("Blaxel control body bounded in %s; multipart upload completed in %s beyond %s control deadline", controlElapsed.Round(time.Millisecond), dataElapsed.Round(time.Millisecond), controlTimeout)
+}
+
+func TestBlaxelInjectedHTTPSettingsArePreservedForBothPlanes(t *testing.T) {
+	transport := &http.Transport{DisableKeepAlives: true}
+	injected := &http.Client{Transport: transport, Timeout: 17 * time.Second}
+	api, err := newBlaxelClient(core.Config{Blaxel: core.BlaxelConfig{APIKey: "test-key"}}, core.Runtime{HTTP: injected})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := api.(*restClient)
+	if client.http.Transport != transport || client.dataHTTP.Transport != transport || client.http.Timeout != injected.Timeout || client.dataHTTP.Timeout != injected.Timeout {
+		t.Fatalf("settings=control:(%T,%s) data:(%T,%s)", client.http.Transport, client.http.Timeout, client.dataHTTP.Transport, client.dataHTTP.Timeout)
+	}
+	if injected.CheckRedirect != nil {
+		t.Fatal("constructor mutated injected redirect policy")
+	}
+}
+
+func TestBlaxelControlRedirectDoesNotLeakCredentials(t *testing.T) {
+	var targetRequests atomic.Int32
+	target := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		targetRequests.Add(1)
+	}))
+	defer target.Close()
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("Authorization=%q", got)
+		}
+		http.Redirect(w, r, target.URL+"/capture", http.StatusTemporaryRedirect)
+	}))
+	defer origin.Close()
+	api, err := newBlaxelClient(core.Config{Blaxel: core.BlaxelConfig{APIURL: origin.URL, APIKey: "test-key"}}, core.Runtime{HTTP: origin.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := api.Probe(context.Background()); err == nil || !strings.Contains(err.Error(), "refused cross-origin redirect") {
+		t.Fatalf("Probe error=%v, want redirect rejection", err)
+	}
+	if targetRequests.Load() != 0 {
+		t.Fatalf("redirect target requests=%d, want 0", targetRequests.Load())
+	}
+}
 
 func TestValidateAPIURLCanonicalizesAndRejectsUnsafe(t *testing.T) {
 	got, err := ValidateAPIURL("https://API.BLAXEL.AI:443/v1/")

--- a/internal/providers/cloudflaresandbox/client.go
+++ b/internal/providers/cloudflaresandbox/client.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"path"
 	"strings"
+	"time"
 )
 
 type bridgeClient interface {
@@ -31,10 +32,13 @@ type bridgeClient interface {
 }
 
 type client struct {
-	baseURL string
-	token   string
-	http    *http.Client
+	baseURL  string
+	token    string
+	http     *http.Client
+	dataHTTP *http.Client
 }
+
+const cloudflareSandboxControlTimeout = 60 * time.Second
 
 type healthResponse struct {
 	OK      bool   `json:"ok"`
@@ -104,15 +108,20 @@ func newBridgeClient(cfg Config, rt Runtime) (bridgeClient, error) {
 	if err != nil {
 		return nil, err
 	}
-	httpClient := rt.HTTP
-	if httpClient == nil {
-		httpClient = http.DefaultClient
-	}
+	httpClient, dataHTTPClient := cloudflareSandboxHTTPClients(rt.HTTP, cloudflareSandboxControlTimeout)
 	return &client{
-		baseURL: baseURL,
-		token:   strings.TrimSpace(cfg.CloudflareSandbox.Token),
-		http:    secureCloudflareSandboxHTTPClient(httpClient, baseURL),
+		baseURL:  baseURL,
+		token:    strings.TrimSpace(cfg.CloudflareSandbox.Token),
+		http:     secureCloudflareSandboxHTTPClient(httpClient, baseURL),
+		dataHTTP: secureCloudflareSandboxHTTPClient(dataHTTPClient, baseURL),
 	}, nil
+}
+
+func cloudflareSandboxHTTPClients(injected *http.Client, controlTimeout time.Duration) (*http.Client, *http.Client) {
+	if injected != nil {
+		return injected, injected
+	}
+	return &http.Client{Timeout: controlTimeout}, &http.Client{}
 }
 
 func secureCloudflareSandboxHTTPClient(source *http.Client, baseURL string) *http.Client {
@@ -218,7 +227,7 @@ func (c *client) DeleteSandbox(ctx context.Context, id string) error {
 }
 
 func (c *client) Exec(ctx context.Context, id string, req execRequest, stdout, stderr io.Writer) (execResult, error) {
-	resp, err := c.doRequest(ctx, http.MethodPost, "/v1/sandbox/"+url.PathEscape(id)+"/exec", true, req, "application/json")
+	resp, err := c.doRequest(ctx, c.dataHTTP, http.MethodPost, "/v1/sandbox/"+url.PathEscape(id)+"/exec", true, req, "application/json")
 	if err != nil {
 		return execResult{}, err
 	}
@@ -387,7 +396,7 @@ func firstNonEmpty(values ...string) string {
 
 func (c *client) UploadFile(ctx context.Context, id, remotePath string, content io.Reader) error {
 	route := "/v1/sandbox/" + url.PathEscape(id) + "/files/write?path=" + url.QueryEscape(remotePath) + "&encoding=raw"
-	resp, err := c.doRequest(ctx, http.MethodPost, route, true, content, "application/octet-stream")
+	resp, err := c.doRequest(ctx, c.dataHTTP, http.MethodPost, route, true, content, "application/octet-stream")
 	if err != nil {
 		return err
 	}
@@ -404,14 +413,14 @@ func (c *client) UploadFile(ctx context.Context, id, remotePath string, content 
 
 func (c *client) Persist(ctx context.Context, id string, req persistRequest) (persistResponse, error) {
 	var out persistResponse
-	if err := c.do(ctx, http.MethodPost, "/v1/sandbox/"+url.PathEscape(id)+"/persist", true, req, &out); err != nil {
+	if err := c.doData(ctx, http.MethodPost, "/v1/sandbox/"+url.PathEscape(id)+"/persist", true, req, &out); err != nil {
 		return persistResponse{}, err
 	}
 	return out, nil
 }
 
 func (c *client) Hydrate(ctx context.Context, id string, req hydrateRequest) error {
-	return c.do(ctx, http.MethodPost, "/v1/sandbox/"+url.PathEscape(id)+"/hydrate", true, req, nil)
+	return c.doData(ctx, http.MethodPost, "/v1/sandbox/"+url.PathEscape(id)+"/hydrate", true, req, nil)
 }
 
 func (c *client) WarmPool(ctx context.Context) (warmPoolResponse, error) {
@@ -423,7 +432,15 @@ func (c *client) WarmPool(ctx context.Context) (warmPoolResponse, error) {
 }
 
 func (c *client) do(ctx context.Context, method, route string, authenticated bool, body any, out any) error {
-	resp, err := c.doRequest(ctx, method, route, authenticated, body, "application/json")
+	return c.doWithClient(ctx, c.http, method, route, authenticated, body, out)
+}
+
+func (c *client) doData(ctx context.Context, method, route string, authenticated bool, body any, out any) error {
+	return c.doWithClient(ctx, c.dataHTTP, method, route, authenticated, body, out)
+}
+
+func (c *client) doWithClient(ctx context.Context, httpClient *http.Client, method, route string, authenticated bool, body any, out any) error {
+	resp, err := c.doRequest(ctx, httpClient, method, route, authenticated, body, "application/json")
 	if err != nil {
 		return err
 	}
@@ -452,7 +469,7 @@ func (c *client) responseError(method, route string, resp *http.Response, data [
 	return err
 }
 
-func (c *client) doRequest(ctx context.Context, method, route string, authenticated bool, body any, contentType string) (*http.Response, error) {
+func (c *client) doRequest(ctx context.Context, httpClient *http.Client, method, route string, authenticated bool, body any, contentType string) (*http.Response, error) {
 	var reader io.Reader
 	if body != nil {
 		if existing, ok := body.(io.Reader); ok {
@@ -476,7 +493,7 @@ func (c *client) doRequest(ctx context.Context, method, route string, authentica
 	if authenticated && c.token != "" {
 		req.Header.Set("Authorization", "Bearer "+c.token)
 	}
-	resp, err := c.http.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		requestErr := err
 		var urlErr *url.Error

--- a/internal/providers/cloudflaresandbox/client_test.go
+++ b/internal/providers/cloudflaresandbox/client_test.go
@@ -10,7 +10,78 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
+
+func TestBridgeFallbackBoundsControlAndPreservesExecStream(t *testing.T) {
+	const controlTimeout = 30 * time.Millisecond
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/sandbox/sb_123":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{"id":`)
+			w.(http.Flusher).Flush()
+			<-r.Context().Done()
+		case "/v1/sandbox/sb_123/exec":
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, "event: stdout\n"+`data: {"chunk":"started"}`+"\n\n")
+			w.(http.Flusher).Flush()
+			time.Sleep(3 * controlTimeout)
+			_, _ = io.WriteString(w, "event: exit\n"+`data: {"exitCode":0}`+"\n\n")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	control, data := cloudflareSandboxHTTPClients(nil, controlTimeout)
+	client := &client{
+		baseURL:  server.URL,
+		token:    "test-token",
+		http:     secureCloudflareSandboxHTTPClient(control, server.URL),
+		dataHTTP: secureCloudflareSandboxHTTPClient(data, server.URL),
+	}
+	started := time.Now()
+	_, err := client.GetSandbox(context.Background(), "sb_123")
+	if err == nil || !strings.Contains(err.Error(), context.DeadlineExceeded.Error()) {
+		t.Fatalf("GetSandbox error=%v, want whole-request deadline", err)
+	}
+	controlElapsed := time.Since(started)
+	if controlElapsed >= time.Second {
+		t.Fatalf("stalled control response bounded after %s, want under 1s", controlElapsed)
+	}
+
+	started = time.Now()
+	result, err := client.Exec(context.Background(), "sb_123", execRequest{Command: "true"}, io.Discard, io.Discard)
+	if err != nil || result.ExitCode != 0 {
+		t.Fatalf("Exec result=%#v err=%v", result, err)
+	}
+	dataElapsed := time.Since(started)
+	if dataElapsed <= controlTimeout {
+		t.Fatalf("exec stream completed in %s, want beyond %s", dataElapsed, controlTimeout)
+	}
+	t.Logf("Cloudflare Sandbox control body bounded in %s; SSE exec completed in %s beyond %s control deadline", controlElapsed.Round(time.Millisecond), dataElapsed.Round(time.Millisecond), controlTimeout)
+}
+
+func TestBridgeInjectedHTTPSettingsArePreservedForBothPlanes(t *testing.T) {
+	transport := &http.Transport{DisableKeepAlives: true}
+	injected := &http.Client{Transport: transport, Timeout: 17 * time.Second}
+	cfg := testConfig()
+	cfg.CloudflareSandbox.BridgeURL = "http://127.0.0.1:8787"
+	api, err := newBridgeClient(cfg, Runtime{HTTP: injected})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := api.(*client)
+	if client.http.Transport != transport || client.dataHTTP.Transport != transport || client.http.Timeout != injected.Timeout || client.dataHTTP.Timeout != injected.Timeout {
+		t.Fatalf("settings=control:(%T,%s) data:(%T,%s)", client.http.Transport, client.http.Timeout, client.dataHTTP.Transport, client.dataHTTP.Timeout)
+	}
+	if injected.CheckRedirect != nil {
+		t.Fatal("constructor mutated injected redirect policy")
+	}
+}
 
 func TestBridgeClientHealthOpenAPIAuthAndNonMutatingDoctorRoutes(t *testing.T) {
 	var requests []struct {

--- a/internal/providers/freestyle/client.go
+++ b/internal/providers/freestyle/client.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 )
 
 type freestyleAPI interface {
@@ -76,12 +77,14 @@ type freestyleReadFileResponse struct {
 }
 
 type freestyleHTTPClient struct {
-	apiKey     string
-	apiURL     string
-	httpClient *http.Client
+	apiKey         string
+	apiURL         string
+	httpClient     *http.Client
+	dataHTTPClient *http.Client
 }
 
 const freestyleListPageSize = 100
+const freestyleControlTimeout = 60 * time.Second
 
 var newFreestyleClient = func(cfg Config, rt Runtime) (freestyleAPI, error) {
 	apiKey := strings.TrimSpace(cfg.Freestyle.APIKey)
@@ -92,15 +95,20 @@ var newFreestyleClient = func(cfg Config, rt Runtime) (freestyleAPI, error) {
 	if err != nil {
 		return nil, err
 	}
-	httpClient := rt.HTTP
-	if httpClient == nil {
-		httpClient = http.DefaultClient
-	}
+	httpClient, dataHTTPClient := freestyleHTTPClients(rt.HTTP, freestyleControlTimeout)
 	return &freestyleHTTPClient{
-		apiKey:     apiKey,
-		apiURL:     apiURL,
-		httpClient: secureFreestyleHTTPClient(httpClient, apiURL),
+		apiKey:         apiKey,
+		apiURL:         apiURL,
+		httpClient:     secureFreestyleHTTPClient(httpClient, apiURL),
+		dataHTTPClient: secureFreestyleHTTPClient(dataHTTPClient, apiURL),
 	}, nil
+}
+
+func freestyleHTTPClients(injected *http.Client, controlTimeout time.Duration) (*http.Client, *http.Client) {
+	if injected != nil {
+		return injected, injected
+	}
+	return &http.Client{Timeout: controlTimeout}, &http.Client{}
 }
 
 func validateFreestyleAPIURL(raw string) (string, error) {
@@ -181,6 +189,18 @@ func effectiveFreestylePort(value *url.URL) string {
 }
 
 func (c *freestyleHTTPClient) do(ctx context.Context, method, urlPath string, body io.Reader) (*http.Response, error) {
+	return c.doWithClient(ctx, c.httpClient, method, urlPath, body)
+}
+
+func (c *freestyleHTTPClient) doData(ctx context.Context, method, urlPath string, body io.Reader) (*http.Response, error) {
+	httpClient := c.dataHTTPClient
+	if httpClient == nil {
+		httpClient = c.httpClient
+	}
+	return c.doWithClient(ctx, httpClient, method, urlPath, body)
+}
+
+func (c *freestyleHTTPClient) doWithClient(ctx context.Context, httpClient *http.Client, method, urlPath string, body io.Reader) (*http.Response, error) {
 	u, err := url.Parse(c.apiURL + urlPath)
 	if err != nil {
 		return nil, err
@@ -194,7 +214,7 @@ func (c *freestyleHTTPClient) do(ctx context.Context, method, urlPath string, bo
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	return c.httpClient.Do(req)
+	return httpClient.Do(req)
 }
 
 func (c *freestyleHTTPClient) CreateVM(ctx context.Context, req freestyleCreateVMRequest) (freestyleVM, error) {
@@ -285,7 +305,7 @@ func (c *freestyleHTTPClient) Exec(ctx context.Context, id string, command strin
 	if err != nil {
 		return 1, err
 	}
-	resp, err := c.do(ctx, http.MethodPost, "/v1/vms/"+url.PathEscape(id)+"/exec-await", bytes.NewReader(payload))
+	resp, err := c.doData(ctx, http.MethodPost, "/v1/vms/"+url.PathEscape(id)+"/exec-await", bytes.NewReader(payload))
 	if err != nil {
 		return 1, freestyleError("exec", err)
 	}
@@ -314,7 +334,7 @@ func (c *freestyleHTTPClient) WriteFile(ctx context.Context, id, path string, co
 	if err != nil {
 		return err
 	}
-	resp, err := c.do(ctx, http.MethodPut, freestyleFileURLPath(id, path), bytes.NewReader(payload))
+	resp, err := c.doData(ctx, http.MethodPut, freestyleFileURLPath(id, path), bytes.NewReader(payload))
 	if err != nil {
 		return freestyleError("write file", err)
 	}
@@ -329,7 +349,7 @@ func (c *freestyleHTTPClient) ReadFile(ctx context.Context, id, path string) (st
 	if !strings.HasPrefix(path, "/") {
 		path = "/" + path
 	}
-	resp, err := c.do(ctx, http.MethodGet, freestyleFileURLPath(id, path), nil)
+	resp, err := c.doData(ctx, http.MethodGet, freestyleFileURLPath(id, path), nil)
 	if err != nil {
 		return "", freestyleError("read file", err)
 	}

--- a/internal/providers/freestyle/client_test.go
+++ b/internal/providers/freestyle/client_test.go
@@ -3,12 +3,80 @@ package freestyle
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
+
+func TestFreestyleFallbackBoundsControlAndPreservesCommand(t *testing.T) {
+	const controlTimeout = 30 * time.Millisecond
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/vms/vm123":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{"id":`)
+			w.(http.Flusher).Flush()
+			<-r.Context().Done()
+		case "/v1/vms/vm123/exec-await":
+			time.Sleep(3 * controlTimeout)
+			_ = json.NewEncoder(w).Encode(map[string]any{"stdout": "ok", "statusCode": 0})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	control, data := freestyleHTTPClients(nil, controlTimeout)
+	client := &freestyleHTTPClient{
+		apiKey:         "test-key",
+		apiURL:         server.URL,
+		httpClient:     secureFreestyleHTTPClient(control, server.URL),
+		dataHTTPClient: secureFreestyleHTTPClient(data, server.URL),
+	}
+	started := time.Now()
+	_, err := client.GetVM(context.Background(), "vm123")
+	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("GetVM error=%v, want whole-request deadline", err)
+	}
+	controlElapsed := time.Since(started)
+	if controlElapsed >= time.Second {
+		t.Fatalf("stalled control response bounded after %s, want under 1s", controlElapsed)
+	}
+
+	started = time.Now()
+	code, err := client.Exec(context.Background(), "vm123", "true", io.Discard, io.Discard)
+	if err != nil || code != 0 {
+		t.Fatalf("Exec code=%d err=%v", code, err)
+	}
+	dataElapsed := time.Since(started)
+	if dataElapsed <= controlTimeout {
+		t.Fatalf("command completed in %s, want beyond %s", dataElapsed, controlTimeout)
+	}
+	t.Logf("Freestyle control body bounded in %s; synchronous command completed in %s beyond %s control deadline", controlElapsed.Round(time.Millisecond), dataElapsed.Round(time.Millisecond), controlTimeout)
+}
+
+func TestFreestyleInjectedHTTPSettingsArePreservedForBothPlanes(t *testing.T) {
+	transport := &http.Transport{DisableKeepAlives: true}
+	injected := &http.Client{Transport: transport, Timeout: 17 * time.Second}
+	api, err := newFreestyleClient(Config{Freestyle: FreestyleConfig{
+		APIKey: "test-key",
+		APIURL: "http://127.0.0.1:8787",
+	}}, Runtime{HTTP: injected})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := api.(*freestyleHTTPClient)
+	if client.httpClient.Transport != transport || client.dataHTTPClient.Transport != transport || client.httpClient.Timeout != injected.Timeout || client.dataHTTPClient.Timeout != injected.Timeout {
+		t.Fatalf("settings=control:(%T,%s) data:(%T,%s)", client.httpClient.Transport, client.httpClient.Timeout, client.dataHTTPClient.Transport, client.dataHTTPClient.Timeout)
+	}
+	if injected.CheckRedirect != nil {
+		t.Fatal("constructor mutated injected redirect policy")
+	}
+}
 
 func TestFreestyleClientRedactsAPIKeyFromAllResponseErrors(t *testing.T) {
 	const apiKey = "fs_test_response_secret"

--- a/internal/providers/orgo/client.go
+++ b/internal/providers/orgo/client.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
@@ -83,10 +84,13 @@ type orgoActionResponse struct {
 }
 
 type orgoHTTPClient struct {
-	baseURL string
-	apiKey  string
-	http    *http.Client
+	baseURL  string
+	apiKey   string
+	http     *http.Client
+	dataHTTP *http.Client
 }
+
+const orgoControlTimeout = 60 * time.Second
 
 type orgoHTTPError struct {
 	StatusCode int
@@ -150,15 +154,20 @@ func newOrgoClient(cfg Config, rt Runtime) (orgoAPI, error) {
 	if parsed.Scheme != "https" && !isOrgoLoopbackHTTP(parsed) {
 		return nil, exit(2, "provider=%s API base URL %q must use https unless it targets localhost", providerName, baseURL)
 	}
-	client := rt.HTTP
-	if client == nil {
-		client = http.DefaultClient
-	}
+	client, dataClient := orgoHTTPClients(rt.HTTP, orgoControlTimeout)
 	return &orgoHTTPClient{
-		baseURL: strings.TrimRight(baseURL, "/"),
-		apiKey:  apiKey,
-		http:    client,
+		baseURL:  strings.TrimRight(baseURL, "/"),
+		apiKey:   apiKey,
+		http:     client,
+		dataHTTP: dataClient,
 	}, nil
+}
+
+func orgoHTTPClients(injected *http.Client, controlTimeout time.Duration) (*http.Client, *http.Client) {
+	if injected != nil {
+		return injected, injected
+	}
+	return &http.Client{Timeout: controlTimeout}, &http.Client{}
 }
 
 func isOrgoLoopbackHTTP(parsed *url.URL) bool {
@@ -261,7 +270,7 @@ func (c *orgoHTTPClient) deleteResource(ctx context.Context, path, kind, id stri
 
 func (c *orgoHTTPClient) RunBash(ctx context.Context, id, command string, stdout, stderr io.Writer) (int, error) {
 	var res orgoBashResponse
-	if err := c.doJSON(ctx, http.MethodPost, "/computers/"+url.PathEscape(id)+"/bash", map[string]string{"command": command}, &res); err != nil {
+	if err := c.doDataJSON(ctx, http.MethodPost, "/computers/"+url.PathEscape(id)+"/bash", map[string]string{"command": command}, &res); err != nil {
 		return 1, err
 	}
 	if res.Stdout != "" {
@@ -291,6 +300,18 @@ func (c *orgoHTTPClient) RunBash(ctx context.Context, id, command string, stdout
 }
 
 func (c *orgoHTTPClient) doJSON(ctx context.Context, method, path string, body any, out any) error {
+	return c.doJSONWithClient(ctx, c.http, method, path, body, out)
+}
+
+func (c *orgoHTTPClient) doDataJSON(ctx context.Context, method, path string, body any, out any) error {
+	httpClient := c.dataHTTP
+	if httpClient == nil {
+		httpClient = c.http
+	}
+	return c.doJSONWithClient(ctx, httpClient, method, path, body, out)
+}
+
+func (c *orgoHTTPClient) doJSONWithClient(ctx context.Context, httpClient *http.Client, method, path string, body any, out any) error {
 	var reader io.Reader
 	if body != nil {
 		var buf bytes.Buffer
@@ -309,7 +330,7 @@ func (c *orgoHTTPClient) doJSON(ctx context.Context, method, path string, body a
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	res, err := c.http.Do(req)
+	res, err := httpClient.Do(req)
 	if err != nil {
 		return err
 	}

--- a/internal/providers/orgo/client_test.go
+++ b/internal/providers/orgo/client_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestRunBashExitCodeFieldPresence(t *testing.T) {
@@ -414,7 +415,90 @@ func TestNewOrgoClientUsesResolvedConfigBeforeAmbientAPIBase(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := client.(*orgoHTTPClient).baseURL; got != "https://flag-selected.example.test" {
-		t.Fatalf("base URL=%q", got)
+	got := client.(*orgoHTTPClient)
+	if got.baseURL != "https://flag-selected.example.test" {
+		t.Fatalf("base URL=%q", got.baseURL)
+	}
+	if got.http == nil || got.dataHTTP == nil || got.http == got.dataHTTP {
+		t.Fatalf("fallback clients=control:%p data:%p, want separate clients", got.http, got.dataHTTP)
+	}
+	if got.http.Timeout != orgoControlTimeout || got.dataHTTP.Timeout != 0 {
+		t.Fatalf("timeouts=control:%s data:%s", got.http.Timeout, got.dataHTTP.Timeout)
+	}
+}
+
+func TestOrgoFallbackBoundsControlAndPreservesCommand(t *testing.T) {
+	const controlTimeout = 30 * time.Millisecond
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/computers/computer-1":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{"id":`)
+			w.(http.Flusher).Flush()
+			<-r.Context().Done()
+		case "/computers/computer-1/bash":
+			time.Sleep(3 * controlTimeout)
+			_ = json.NewEncoder(w).Encode(map[string]any{"stdout": "ok", "exit_code": 0})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	control, data := orgoHTTPClients(nil, controlTimeout)
+	client := &orgoHTTPClient{baseURL: server.URL, apiKey: "test-key", http: control, dataHTTP: data}
+	started := time.Now()
+	_, err := client.GetComputer(context.Background(), "computer-1")
+	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("GetComputer error=%v, want whole-request deadline", err)
+	}
+	controlElapsed := time.Since(started)
+	if controlElapsed >= time.Second {
+		t.Fatalf("stalled control response bounded after %s, want under 1s", controlElapsed)
+	}
+
+	started = time.Now()
+	code, err := client.RunBash(context.Background(), "computer-1", "true", io.Discard, io.Discard)
+	if err != nil || code != 0 {
+		t.Fatalf("RunBash code=%d err=%v", code, err)
+	}
+	dataElapsed := time.Since(started)
+	if dataElapsed <= controlTimeout {
+		t.Fatalf("command completed in %s, want beyond %s", dataElapsed, controlTimeout)
+	}
+	t.Logf("Orgo control body bounded in %s; synchronous command completed in %s beyond %s control deadline", controlElapsed.Round(time.Millisecond), dataElapsed.Round(time.Millisecond), controlTimeout)
+}
+
+func TestOrgoInjectedHTTPClientIsPreservedForBothPlanes(t *testing.T) {
+	t.Setenv("CRABBOX_ORGO_API_KEY", "test-key")
+	injected := &http.Client{Timeout: 17 * time.Second}
+	api, err := newOrgoClient(Config{Orgo: OrgoConfig{APIBase: "http://127.0.0.1:8787"}}, Runtime{HTTP: injected})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := api.(*orgoHTTPClient)
+	if client.http != injected || client.dataHTTP != injected {
+		t.Fatalf("clients=control:%p data:%p, want injected %p", client.http, client.dataHTTP, injected)
+	}
+}
+
+func TestOrgoCrossHostRedirectDoesNotForwardAuthorization(t *testing.T) {
+	var targetAuthorization string
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		targetAuthorization = r.Header.Get("Authorization")
+		_, _ = io.WriteString(w, `[]`)
+	}))
+	defer target.Close()
+	targetURL := strings.Replace(target.URL, "127.0.0.1", "localhost", 1)
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, targetURL+r.URL.Path, http.StatusTemporaryRedirect)
+	}))
+	defer origin.Close()
+	client := &orgoHTTPClient{baseURL: origin.URL, apiKey: "test-key", http: &http.Client{}}
+	if _, err := client.ListWorkspaces(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if targetAuthorization != "" {
+		t.Fatalf("redirect target Authorization=%q, want empty", targetAuthorization)
 	}
 }

--- a/internal/providers/smolvm/backend_test.go
+++ b/internal/providers/smolvm/backend_test.go
@@ -228,8 +228,80 @@ func TestNewAPINormalizesBaseURL(t *testing.T) {
 	if !ok {
 		t.Fatalf("api client=%T, want *client", apiClient)
 	}
+	if c.http == nil || c.dataHTTP == nil || c.http == c.dataHTTP {
+		t.Fatalf("fallback clients=control:%p data:%p, want separate clients", c.http, c.dataHTTP)
+	}
+	if c.http.Timeout != smolvmControlTimeout || c.dataHTTP.Timeout != 0 {
+		t.Fatalf("timeouts=control:%s data:%s", c.http.Timeout, c.dataHTTP.Timeout)
+	}
 	if c.base != "https://eu.smolmachines.com/base" {
 		t.Fatalf("base = %q, want normalized base URL", c.base)
+	}
+}
+
+func TestSmolVMFallbackBoundsControlAndPreservesCommand(t *testing.T) {
+	const controlTimeout = 30 * time.Millisecond
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/machines/mach_1":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{"id":`)
+			w.(http.Flusher).Flush()
+			<-r.Context().Done()
+		case "/v1/machines/mach_1/exec":
+			time.Sleep(3 * controlTimeout)
+			_ = json.NewEncoder(w).Encode(map[string]any{"stdout": "ok", "exitCode": 0})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	control, data := smolvmHTTPClients(nil, controlTimeout)
+	client := &client{
+		apiKey:   "smk_key",
+		base:     server.URL,
+		http:     secureSmolvmHTTPClient(control, server.URL),
+		dataHTTP: secureSmolvmHTTPClient(data, server.URL),
+	}
+	started := time.Now()
+	_, err := client.GetMachine(context.Background(), "mach_1")
+	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("GetMachine error=%v, want whole-request deadline", err)
+	}
+	controlElapsed := time.Since(started)
+	if controlElapsed >= time.Second {
+		t.Fatalf("stalled control response bounded after %s, want under 1s", controlElapsed)
+	}
+
+	started = time.Now()
+	result, err := client.Exec(context.Background(), "mach_1", "true", "/workspace")
+	if err != nil || result.ExitCode != 0 {
+		t.Fatalf("Exec result=%#v err=%v", result, err)
+	}
+	dataElapsed := time.Since(started)
+	if dataElapsed <= controlTimeout {
+		t.Fatalf("command completed in %s, want beyond %s", dataElapsed, controlTimeout)
+	}
+	t.Logf("SmolVM control body bounded in %s; synchronous command completed in %s beyond %s control deadline", controlElapsed.Round(time.Millisecond), dataElapsed.Round(time.Millisecond), controlTimeout)
+}
+
+func TestSmolVMInjectedHTTPSettingsArePreservedForBothPlanes(t *testing.T) {
+	transport := &http.Transport{DisableKeepAlives: true}
+	injected := &http.Client{Transport: transport, Timeout: 17 * time.Second}
+	cfg := Config{}
+	cfg.Smolvm.APIKey = "smk_key"
+	cfg.Smolvm.BaseURL = "http://127.0.0.1:8787"
+	api, err := newAPI(cfg, Runtime{HTTP: injected})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := api.(*client)
+	if client.http.Transport != transport || client.dataHTTP.Transport != transport || client.http.Timeout != injected.Timeout || client.dataHTTP.Timeout != injected.Timeout {
+		t.Fatalf("settings=control:(%T,%s) data:(%T,%s)", client.http.Transport, client.http.Timeout, client.dataHTTP.Transport, client.dataHTTP.Timeout)
+	}
+	if injected.CheckRedirect != nil {
+		t.Fatal("constructor mutated injected redirect policy")
 	}
 }
 

--- a/internal/providers/smolvm/client.go
+++ b/internal/providers/smolvm/client.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
@@ -32,10 +33,13 @@ type api interface {
 }
 
 type client struct {
-	apiKey string
-	base   string
-	http   *http.Client
+	apiKey   string
+	base     string
+	http     *http.Client
+	dataHTTP *http.Client
 }
+
+const smolvmControlTimeout = 60 * time.Second
 
 type createRequest struct {
 	Name       string                 `json:"name,omitempty"`
@@ -141,10 +145,7 @@ var newAPI = func(cfg Config, rt Runtime) (api, error) {
 	// server), so this client talks net/http directly to the documented
 	// OpenAPI, like other direct-API providers. If an official Go client
 	// appears, the transport can be swapped behind the api interface.
-	httpClient := rt.HTTP
-	if httpClient == nil {
-		httpClient = http.DefaultClient
-	}
+	httpClient, dataHTTPClient := smolvmHTTPClients(rt.HTTP, smolvmControlTimeout)
 	base := blank(strings.TrimSpace(cfg.Smolvm.BaseURL), "https://api.smolmachines.com")
 	parsed, err := url.Parse(base)
 	if err != nil {
@@ -166,7 +167,19 @@ var newAPI = func(cfg Config, rt Runtime) (api, error) {
 		return nil, exit(2, "%s url host %q is not an official Smol Machines endpoint; set CRABBOX_SMOLVM_ALLOW_CUSTOM_BASE_URL=1 to send credentials to a custom control plane", providerName, parsed.Hostname())
 	}
 	base = strings.TrimRight(parsed.String(), "/")
-	return &client{apiKey: apiKey, base: base, http: secureSmolvmHTTPClient(httpClient, base)}, nil
+	return &client{
+		apiKey:   apiKey,
+		base:     base,
+		http:     secureSmolvmHTTPClient(httpClient, base),
+		dataHTTP: secureSmolvmHTTPClient(dataHTTPClient, base),
+	}, nil
+}
+
+func smolvmHTTPClients(injected *http.Client, controlTimeout time.Duration) (*http.Client, *http.Client) {
+	if injected != nil {
+		return injected, injected
+	}
+	return &http.Client{Timeout: controlTimeout}, &http.Client{}
 }
 
 func secureSmolvmHTTPClient(source *http.Client, apiURL string) *http.Client {
@@ -303,7 +316,7 @@ func (c *client) Exec(ctx context.Context, machineID, command, folder string) (e
 		}
 		execReq.CWD = f
 	}
-	if err := c.doJSON(ctx, http.MethodPost, "/v1/machines/"+url.PathEscape(machineID)+"/exec", nil, execReq, &result); err != nil {
+	if err := c.doDataJSON(ctx, http.MethodPost, "/v1/machines/"+url.PathEscape(machineID)+"/exec", nil, execReq, &result); err != nil {
 		return execResult{}, err
 	}
 	// Hosted API uses exitCode; the local smolvm serve variant uses exit_code.
@@ -410,6 +423,18 @@ echo "smolvm-direct-write: ok"
 }
 
 func (c *client) doJSON(ctx context.Context, method, path string, query url.Values, body any, out any) error {
+	return c.doJSONWithClient(ctx, c.http, method, path, query, body, out)
+}
+
+func (c *client) doDataJSON(ctx context.Context, method, path string, query url.Values, body any, out any) error {
+	httpClient := c.dataHTTP
+	if httpClient == nil {
+		httpClient = c.http
+	}
+	return c.doJSONWithClient(ctx, httpClient, method, path, query, body, out)
+}
+
+func (c *client) doJSONWithClient(ctx context.Context, httpClient *http.Client, method, path string, query url.Values, body any, out any) error {
 	var input io.Reader
 	if body != nil {
 		data, err := json.Marshal(body)
@@ -430,7 +455,7 @@ func (c *client) doJSON(ctx context.Context, method, path string, query url.Valu
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	resp, err := c.http.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## What Problem This Solves

When `Runtime.HTTP` is unset, six mixed-use provider adapters still shared one unbounded fallback HTTP client between finite lifecycle calls and potentially long uploads, commands, or response streams. A stalled lifecycle endpoint could therefore hang forever, while the original blanket `http.Client.Timeout = 60s` proposal would also terminate valid data-plane work after 60 seconds.

This rewrite follows the ownership split established by https://github.com/openclaw/crabbox/pull/1371 after the response-header-only mixed-client pattern in https://github.com/openclaw/crabbox/pull/1370.

## What Changed

Each retained adapter now uses a 60-second whole-request fallback client for finite control JSON, including complete response bodies, and a caller-owned fallback client for data-plane work:

- Azure Dynamic Sessions: runner/session lifecycle is bounded; archive upload and NDJSON exec remain caller-owned.
- Blaxel: management-plane sandbox lifecycle is bounded; workload process, filesystem, and multipart operations remain caller-owned.
- Cloudflare Sandbox: bridge health, lifecycle, inventory, and warm-pool calls are bounded; upload, persist/hydrate, and SSE exec remain caller-owned.
- Freestyle: VM lifecycle is bounded; synchronous exec and file reads/writes remain caller-owned.
- Orgo: workspace/computer lifecycle is bounded; synchronous bash execution remains caller-owned.
- SmolVM: machine lifecycle is bounded; synchronous exec, including archive/file injection through exec, remains caller-owned.

Injected `Runtime.HTTP` clients keep each adapter's existing contract: exact identity where the adapter already used it directly, or redirect-guarded shallow clones preserving transport, proxy/TLS, jar, timeout, and caller redirect policy. Cross-origin credential protections remain covered by real redirect tests.

The rewrite deliberately drops the original changes for Cloud Run Sandbox, OpenComputer, OpenSandbox, SuperServe, Unikraft Cloud, and Islo. Current `main` already bounds their relevant calls or keeps lifetime at the correct caller-owned boundary: Cloud Run uses 5-minute request contexts; OpenComputer uses 2-minute control and command-specific contexts; OpenSandbox applies the SDK lifecycle timeout separately from uploads/SSE; SuperServe uses 2-minute control and command-specific contexts; Unikraft Cloud uses a 2-minute whole-request JSON context; and Islo already uses a 30-second response-header-bound fallback without capping streams. The original Islo hunk changed a nil helper branch that its constructor does not reach.

No ambiguous provider mutation is described as safely cancelled. The timeout only establishes the client-side finite control boundary; provider-specific reconciliation remains authoritative where required.

## Source-Blind Loopback Proof

Six race-instrumented provider test binaries were compiled and then executed from an isolated directory containing only the binaries and a behavior contract, with no source checkout. Each test used a 30 ms fixture control deadline, sent response headers plus a partial finite body before stalling, and exercised a representative data operation beyond that deadline.

```console
Azure Dynamic Sessions control body bounded in 32ms; exec stream completed in 93ms beyond 30ms control deadline
Blaxel control body bounded in 34ms; multipart upload completed in 95ms beyond 30ms control deadline
Cloudflare Sandbox control body bounded in 31ms; SSE exec completed in 92ms beyond 30ms control deadline
Freestyle control body bounded in 32ms; synchronous command completed in 94ms beyond 30ms control deadline
Orgo control body bounded in 31ms; synchronous command completed in 92ms beyond 30ms control deadline
SmolVM control body bounded in 31ms; synchronous command completed in 92ms beyond 30ms control deadline
PASS
```

The same isolated run passed injected-client and cross-origin redirect credential probes for all six adapters.

## Verification

- `go test -race ./internal/providers/azuredynamicsessions ./internal/providers/blaxel ./internal/providers/cloudflaresandbox ./internal/providers/freestyle ./internal/providers/orgo ./internal/providers/smolvm ./internal/providers/shared -count=1` — passed.
- `go vet ./...` — passed.
- `scripts/check-docs.sh` — passed: command docs, 79-provider matrix, 240 Markdown link checks, docs build, and 14 site tests.
- `gofmt` and `git diff --check` — clean.
- P1-focused autoreview of the exact frozen bundle — clean, no accepted/actionable findings.
- `go test -race ./... -count=1 -timeout=20m` — every provider package and `shared` passed. The unrelated `internal/cli` package failed three macOS loopback/controller tests and then timed out in `TestLocalWebVNCListenerIdentityPinsCurrentProcess`; one controller test passed alone, while the three listener-owner tests remained blocked by the local macOS listener-inspection subprocess. This PR does not touch `internal/cli`.

## Credit

The six provider commits preserve Sebastien Tardif as author with Peter Steinberger as committer. The consolidated Unreleased changelog entry is maintainer-owned and thanks @SebTardif.

Base: `d977ebbae3235b5e6df522828cd19b19199cc7f4`  
Head: `6d4eb392dee539f3b806532470f7195f70d43703`
