### PR TITLE
feat(checkpoints): expire unused checkpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added checkpoint last-use tracking and composable `checkpoint prune --unused-for` cleanup for inactive local records and provider artifacts.
 - Added `crabbox heartbeat` so external SSH drivers can refresh owned lease idle deadlines and optionally update the idle timeout.
 - Added credential-free `crabbox claims list` output for deterministic, secret-safe inspection of unverified local lease claims across providers. Thanks @coygeek.
 

--- a/docs/commands/checkpoint.md
+++ b/docs/commands/checkpoint.md
@@ -145,8 +145,8 @@ crabbox checkpoint inspect chk_abc123 --verify
 
 `list` and `inspect` read the local checkpoint records. Each record holds the
 checkpoint id/name/kind, source lease/provider/region, repo name and git head,
-workdir, creation time, and — for native checkpoints — the provider resource id;
-for archives, the tarball path and size.
+workdir, creation and last-use times, and — for native checkpoints — the
+provider resource id; for archives, the tarball path and size.
 
 > A native checkpoint needs **both** halves to fork: the local metadata and the
 > provider resource. An archive checkpoint needs the local metadata and the
@@ -317,27 +317,37 @@ Crabbox (manual cleanup, account migration, and so on).
 
 ## prune
 
-Delete checkpoints older than a cutoff, optionally restricted to one kind.
+Delete checkpoints selected by creation age, time since last use, or both,
+optionally restricted to one kind.
 
 ```sh
 crabbox checkpoint prune --older-than 30d --dry-run
-crabbox checkpoint prune --older-than 30d --kind archive
-crabbox checkpoint prune --older-than 30d --kind native
+crabbox checkpoint prune --unused-for 14d --dry-run
+crabbox checkpoint prune --older-than 30d --unused-for 14d --kind native
 ```
 
 **Flags**
 
 ```
---older-than <duration> Required. Delete checkpoints older than this. Accepts a
-                        Go duration (e.g. 720h) or a whole number of days (30d).
+--older-than <duration> Select checkpoints created before this age.
+--unused-for <duration> Select checkpoints whose last successful fork or
+                        restore was before this age.
 --kind native|archive   Restrict to one kind.
---dry-run               Print matches without deleting.
+--dry-run               Print matches, including creation and last-use times,
+                        without deleting.
 --local-only            Skip provider deletion for native checkpoints.
 ```
 
-Native checkpoints prune through the same provider-deletion path as
-`checkpoint delete`. Keep `--dry-run` in operator automation until the match set
-looks right.
+At least one of `--older-than` or `--unused-for` is required; when both are
+present, a checkpoint must satisfy both. Durations accept Go syntax such as
+`720h` or a whole number of days such as `30d`. Native checkpoints prune through
+the same provider-first deletion path as `checkpoint delete`, so a provider
+failure keeps the local record. Preview the exact match set with `--dry-run`.
+
+Crabbox does not run an automatic checkpoint reaper. Any scheduler must invoke
+this CLI as the user and in the environment that owns the local checkpoint
+records. See [Checkpoints](../features/checkpoints.md#lifecycle-and-expiry) for
+the detailed lifecycle behavior and scheduled-job recipe.
 
 > Provider snapshots and images keep accruing storage cost while they exist.
 > Prune stale checkpoints periodically, and name checkpoints after the scenario

--- a/docs/features/checkpoints.md
+++ b/docs/features/checkpoints.md
@@ -153,6 +153,23 @@ macOS). Each entry holds a `checkpoint.json` record plus, for archives, a
 delete by checkpoint ID; deleting the provider resource leaves the local record
 unable to fork.
 
+## Lifecycle and expiry
+
+Checkpoint records store both `createdAt` and `lastUsedAt`. A new checkpoint
+initializes `lastUsedAt` to exactly `createdAt`; each successful recorded
+`checkpoint fork` or `checkpoint restore` updates it. Dry runs and failed
+consumption attempts do not count as use. For records written by older Crabbox
+versions without `lastUsedAt`, reads treat `createdAt` as the last-use time.
+This fallback does not eagerly rewrite or migrate the record.
+
+Crabbox does not run an automatic checkpoint reaper yet. Use `checkpoint prune`
+manually or schedule it in the environment that owns the local checkpoint
+records. Native provider snapshots and images can keep incurring provider
+storage charges even when no lease uses them, while archive checkpoints consume
+disk in the local state directory. Choose an unused interval that reflects the
+cost of rebuilding the checkpoint and preview it with `--dry-run` before making
+the scheduled job destructive.
+
 ## Commands
 
 ```
@@ -162,7 +179,7 @@ crabbox checkpoint inspect <checkpoint-id> [--json] [--verify]
 crabbox checkpoint restore <checkpoint-id> --id <lease> [--clear=false]
 crabbox checkpoint fork    <checkpoint-id> [--class <class>] [--keep] [--count <n>]
 crabbox checkpoint delete  <checkpoint-id> [--local-only]
-crabbox checkpoint prune   --older-than <duration> [--kind native|archive] [--dry-run]
+crabbox checkpoint prune   [--older-than <duration>] [--unused-for <duration>] [--kind native|archive] [--dry-run]
 ```
 
 Checkpoint IDs look like `chk_<hex>` (see [identifiers](identifiers.md)).
@@ -269,14 +286,37 @@ crabbox checkpoint fork --provider parallels --id <vm> --snapshot <name-or-id> [
 crabbox checkpoint delete chk_abc123          # remove provider resource + local record
 crabbox checkpoint delete chk_abc123 --local-only   # keep provider resource
 crabbox checkpoint prune --older-than 7d --kind native --dry-run
+crabbox checkpoint prune --unused-for 30d --kind native --dry-run
 ```
 
 `delete` removes the provider snapshot/image (AWS AMI + backing snapshots, Azure
 or GCP image, Parallels snapshot) and then the local record. `--local-only`
-deletes the record only. `prune` deletes records older than `--older-than`
-(`30m`, `12h`, `7d`, …), optionally filtered by `--kind native|archive`; pair it
-with `--dry-run` first. Deleting a non-Crabbox Parallels snapshot requires
-`--yes`.
+deletes the record only. Provider deletion remains first: if it fails, Crabbox
+keeps the local record. `prune` requires at least one age filter. `--older-than`
+selects by creation time and `--unused-for` selects by last-use time (`30m`,
+`12h`, `7d`, …). When both are supplied, a checkpoint must satisfy both; the
+optional `--kind native|archive` filter is also composed with them. Pair the
+final filter set with `--dry-run` first. Deleting a non-Crabbox Parallels
+snapshot requires `--yes`.
+
+For example, this user crontab previews the policy interactively first, then
+removes native checkpoints that have not been forked or restored for 30 days:
+
+```sh
+crabbox checkpoint prune --unused-for 30d --kind native --dry-run
+
+# crontab -e (run as the same user that created the checkpoint records)
+SHELL=/bin/sh
+PATH=/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin
+XDG_STATE_HOME=/home/alice/.local/state
+CRABBOX_CONFIG=/home/alice/.config/crabbox/config.yaml
+15 3 * * * crabbox checkpoint prune --unused-for 30d --kind native >> /home/alice/.local/state/crabbox/checkpoint-prune.log 2>&1
+```
+
+The scheduler invokes the CLI; Crabbox itself does not run an automatic
+checkpoint reaper yet. The scheduled environment must point at the same state
+directory and config as the checkpoint owner and provide whatever provider
+credentials or local runtime access deletion requires.
 
 ## When to use which
 

--- a/internal/cli/checkpoint.go
+++ b/internal/cli/checkpoint.go
@@ -42,6 +42,7 @@ type checkpointRecord struct {
 	Name           string `json:"name,omitempty"`
 	Kind           string `json:"kind"`
 	CreatedAt      string `json:"createdAt"`
+	LastUsedAt     string `json:"lastUsedAt"`
 	CrabboxVersion string `json:"crabboxVersion"`
 	Provider       string `json:"provider,omitempty"`
 	LeaseID        string `json:"leaseId,omitempty"`
@@ -298,7 +299,7 @@ func (a App) checkpointList(ctx context.Context, args []string) error {
 			if audit.Error != "" {
 				extra += fmt.Sprintf(" error=%q", audit.Error)
 			}
-			fmt.Fprintf(a.Stdout, "%s kind=%s name=%q repo=%s lease=%s %s next=%s created=%s\n", record.ID, record.Kind, record.Name, record.Repo.Name, blank(record.LeaseID, "-"), extra, audit.NextAction, record.CreatedAt)
+			fmt.Fprintf(a.Stdout, "%s kind=%s name=%q repo=%s lease=%s %s next=%s created=%s last_used=%s\n", record.ID, record.Kind, record.Name, record.Repo.Name, blank(record.LeaseID, "-"), extra, audit.NextAction, record.CreatedAt, record.LastUsedAt)
 		}
 		return nil
 	}
@@ -314,7 +315,7 @@ func (a App) checkpointList(ctx context.Context, args []string) error {
 		if isNativeCheckpointKind(record.Kind) {
 			extra = fmt.Sprintf("resource=%s state=%s region=%s", blank(record.Native.ImageID, "-"), blank(record.Native.State, "-"), blank(record.Native.Region, "-"))
 		}
-		fmt.Fprintf(a.Stdout, "%s kind=%s name=%q repo=%s lease=%s %s created=%s\n", record.ID, record.Kind, record.Name, record.Repo.Name, blank(record.LeaseID, "-"), extra, record.CreatedAt)
+		fmt.Fprintf(a.Stdout, "%s kind=%s name=%q repo=%s lease=%s %s created=%s last_used=%s\n", record.ID, record.Kind, record.Name, record.Repo.Name, blank(record.LeaseID, "-"), extra, record.CreatedAt, record.LastUsedAt)
 	}
 	return nil
 }
@@ -505,8 +506,8 @@ func (a App) checkpointInspect(ctx context.Context, args []string) error {
 }
 
 func printCheckpointInspect(stdout io.Writer, record checkpointRecord) {
-	fmt.Fprintf(stdout, "id=%s\nkind=%s\nname=%s\ncreated=%s\nprovider=%s\nlease=%s\nrepo=%s\nhead=%s\nserver_type=%s\nworkdir=%s\narchive=%s\nbytes=%s\n",
-		record.ID, record.Kind, blank(record.Name, "-"), record.CreatedAt, blank(record.Provider, "-"), blank(record.LeaseID, "-"), blank(record.Repo.Name, "-"), blank(record.Repo.Head, "-"), blank(record.ServerType, "-"), blank(record.Workdir, "-"), blank(record.ArchivePath, "-"), humanBytes(record.ArchiveBytes))
+	fmt.Fprintf(stdout, "id=%s\nkind=%s\nname=%s\ncreated=%s\nlast_used=%s\nprovider=%s\nlease=%s\nrepo=%s\nhead=%s\nserver_type=%s\nworkdir=%s\narchive=%s\nbytes=%s\n",
+		record.ID, record.Kind, blank(record.Name, "-"), record.CreatedAt, record.LastUsedAt, blank(record.Provider, "-"), blank(record.LeaseID, "-"), blank(record.Repo.Name, "-"), blank(record.Repo.Head, "-"), blank(record.ServerType, "-"), blank(record.Workdir, "-"), blank(record.ArchivePath, "-"), humanBytes(record.ArchiveBytes))
 	if isNativeCheckpointKind(record.Kind) {
 		fmt.Fprintf(stdout, "resource=%s\nresource_name=%s\nresource_state=%s\nresource_region=%s\nstrategy=%s\nno_reboot=%t\n",
 			blank(record.Native.ImageID, "-"), blank(record.Native.Name, "-"), blank(record.Native.State, "-"), blank(record.Native.Region, "-"), blank(record.Native.Strategy, checkpointStrategyImage), record.Native.NoReboot)
@@ -611,6 +612,9 @@ func (a App) checkpointRestore(ctx context.Context, args []string) error {
 				if err := NewParallelsClient(restoreCfg, nil).SwitchSnapshot(ctx, server.CloudID, record.Native.ImageID, true); err != nil {
 					return err
 				}
+				if err := recordCheckpointUse(store, &record); err != nil {
+					return err
+				}
 				fmt.Fprintf(a.Stdout, "checkpoint restored id=%s lease=%s snapshot=%s\n", record.ID, blank(server.Labels["lease"], server.CloudID), record.Native.ImageID)
 				return nil
 			}
@@ -656,6 +660,9 @@ func (a App) checkpointRestore(ctx context.Context, args []string) error {
 		return err
 	}
 	if err := restoreCheckpointArchive(ctx, target, checkpointArchivePath(paths, record), record.ID, workdir, *clear); err != nil {
+		return err
+	}
+	if err := recordCheckpointUse(store, &record); err != nil {
 		return err
 	}
 	fmt.Fprintf(a.Stdout, "checkpoint restored id=%s lease=%s workdir=%s\n", record.ID, leaseID, workdir)
@@ -761,7 +768,7 @@ func (a App) checkpointFork(ctx context.Context, args []string) (err error) {
 	for i := 1; i <= *count; i++ {
 		slug := checkpointForkFanoutSlug(requestedSlug, i, *count)
 		runOpts := checkpointForkRunOptions{Command: runArgs, Index: i, Total: *count}
-		if err := a.checkpointForkRecordOnce(ctx, cfg, backend, sshBackend, repo, record, paths, *keep, *reclaim, slug, strings.TrimSpace(*workdirOverride), *clear, runOpts); err != nil {
+		if err := a.checkpointForkRecordOnce(ctx, cfg, backend, sshBackend, repo, store, &record, paths, *keep, *reclaim, slug, strings.TrimSpace(*workdirOverride), *clear, runOpts); err != nil {
 			return err
 		}
 	}
@@ -891,8 +898,8 @@ func (a App) provisionCheckpointFork(ctx context.Context, cfg Config, backend Ba
 	return checkpointForkProvision{Lease: forkLease, Workdir: workdir, Release: release}, nil
 }
 
-func (a App) checkpointForkRecordOnce(ctx context.Context, cfg Config, backend Backend, sshBackend SSHLeaseBackend, repo Repo, record checkpointRecord, paths checkpointPaths, keep, reclaim bool, requestedSlug, workdirOverride string, clear bool, runOpts checkpointForkRunOptions) error {
-	provision, err := a.provisionCheckpointFork(ctx, cfg, backend, sshBackend, repo, record, paths, keep, reclaim, requestedSlug, workdirOverride, clear)
+func (a App) checkpointForkRecordOnce(ctx context.Context, cfg Config, backend Backend, sshBackend SSHLeaseBackend, repo Repo, store checkpointStore, record *checkpointRecord, paths checkpointPaths, keep, reclaim bool, requestedSlug, workdirOverride string, clear bool, runOpts checkpointForkRunOptions) error {
+	provision, err := a.provisionCheckpointFork(ctx, cfg, backend, sshBackend, repo, *record, paths, keep, reclaim, requestedSlug, workdirOverride, clear)
 	if err != nil {
 		return err
 	}
@@ -901,10 +908,14 @@ func (a App) checkpointForkRecordOnce(ctx context.Context, cfg Config, backend B
 			provision.Release(context.Background())
 		}
 	}()
+	if err := recordCheckpointUse(store, record); err != nil {
+		provision.Release(context.Background())
+		return err
+	}
 	leaseID := provision.Lease.LeaseID
 	slug := serverSlug(provision.Lease.Server)
 	if isNativeCheckpointKind(record.Kind) {
-		fmt.Fprintf(a.Stdout, "checkpoint forked id=%s lease=%s slug=%s image=%s workdir=%s\n", record.ID, leaseID, blank(slug, "-"), nativeCheckpointResourceID(record), blank(provision.Workdir, "-"))
+		fmt.Fprintf(a.Stdout, "checkpoint forked id=%s lease=%s slug=%s image=%s workdir=%s\n", record.ID, leaseID, blank(slug, "-"), nativeCheckpointResourceID(*record), blank(provision.Workdir, "-"))
 	} else {
 		fmt.Fprintf(a.Stdout, "checkpoint forked id=%s lease=%s slug=%s workdir=%s\n", record.ID, leaseID, blank(slug, "-"), provision.Workdir)
 	}
@@ -1210,21 +1221,29 @@ func deleteCheckpoint(ctx context.Context, store checkpointStore, id string, loc
 func (a App) checkpointPrune(ctx context.Context, args []string) error {
 	fs := newFlagSet("checkpoint prune", a.Stderr)
 	olderThan := fs.String("older-than", "", "delete checkpoints older than this duration")
+	unusedFor := fs.String("unused-for", "", "delete checkpoints unused for this duration")
 	kind := fs.String("kind", "", "checkpoint kind filter: native or archive")
 	dryRun := fs.Bool("dry-run", false, "print checkpoints that would be deleted")
 	localOnly := fs.Bool("local-only", false, "delete local checkpoint records without deleting provider resources")
 	if err := parseInterspersedFlags(fs, args); err != nil {
 		return err
 	}
+	usage := "usage: crabbox checkpoint prune [--older-than <duration>] [--unused-for <duration>] [--kind native|archive] [--dry-run]"
 	if fs.NArg() != 0 {
-		return exit(2, "usage: crabbox checkpoint prune --older-than <duration> [--kind native|archive] [--dry-run]")
+		return exit(2, "%s", usage)
 	}
-	pruneAge, err := parseCheckpointPruneDuration(*olderThan)
+	createdAge, err := parseCheckpointPruneDuration(*olderThan)
 	if err != nil {
 		return err
 	}
-	if pruneAge <= 0 {
-		return exit(2, "usage: crabbox checkpoint prune --older-than <duration> [--kind native|archive] [--dry-run]")
+	unusedAge, err := parseCheckpointPruneDurationFlag("--unused-for", *unusedFor)
+	if err != nil {
+		return err
+	}
+	invalidCreatedAge := strings.TrimSpace(*olderThan) != "" && createdAge <= 0
+	invalidUnusedAge := strings.TrimSpace(*unusedFor) != "" && unusedAge <= 0
+	if invalidCreatedAge || invalidUnusedAge || createdAge == 0 && unusedAge == 0 {
+		return exit(2, "%s", usage)
 	}
 	kindFilter := strings.TrimSpace(*kind)
 	if kindFilter != "" && kindFilter != "native" && kindFilter != "archive" {
@@ -1238,25 +1257,33 @@ func (a App) checkpointPrune(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	cutoff := time.Now().Add(-pruneAge)
+	now := time.Now()
+	createdCutoff := now.Add(-createdAge)
+	unusedCutoff := now.Add(-unusedAge)
 	matched := 0
 	for _, record := range records {
 		created, err := time.Parse(time.RFC3339, record.CreatedAt)
 		if err != nil {
 			return exit(2, "checkpoint %s has invalid createdAt: %v", record.ID, err)
 		}
-		if !created.Before(cutoff) || !checkpointMatchesPruneKind(record, kindFilter) {
+		lastUsed, err := time.Parse(time.RFC3339, record.LastUsedAt)
+		if err != nil {
+			return exit(2, "checkpoint %s has invalid lastUsedAt: %v", record.ID, err)
+		}
+		matchesCreatedAge := createdAge == 0 || created.Before(createdCutoff)
+		matchesUnusedAge := unusedAge == 0 || lastUsed.Before(unusedCutoff)
+		if !matchesCreatedAge || !matchesUnusedAge || !checkpointMatchesPruneKind(record, kindFilter) {
 			continue
 		}
 		matched++
 		if *dryRun {
-			fmt.Fprintf(a.Stdout, "would delete id=%s kind=%s created=%s\n", record.ID, record.Kind, record.CreatedAt)
+			fmt.Fprintf(a.Stdout, "would delete id=%s kind=%s created=%s last_used=%s\n", record.ID, record.Kind, record.CreatedAt, record.LastUsedAt)
 			continue
 		}
 		if err := deleteCheckpoint(ctx, store, record.ID, *localOnly); err != nil {
 			return err
 		}
-		fmt.Fprintf(a.Stdout, "checkpoint pruned id=%s kind=%s created=%s\n", record.ID, record.Kind, record.CreatedAt)
+		fmt.Fprintf(a.Stdout, "checkpoint pruned id=%s kind=%s created=%s last_used=%s\n", record.ID, record.Kind, record.CreatedAt, record.LastUsedAt)
 	}
 	if matched == 0 {
 		fmt.Fprintln(a.Stdout, "no checkpoints matched prune criteria")
@@ -1265,6 +1292,10 @@ func (a App) checkpointPrune(ctx context.Context, args []string) error {
 }
 
 func parseCheckpointPruneDuration(value string) (time.Duration, error) {
+	return parseCheckpointPruneDurationFlag("--older-than", value)
+}
+
+func parseCheckpointPruneDurationFlag(flagName, value string) (time.Duration, error) {
 	trimmed := strings.TrimSpace(value)
 	if trimmed == "" {
 		return 0, nil
@@ -1272,13 +1303,13 @@ func parseCheckpointPruneDuration(value string) (time.Duration, error) {
 	if strings.HasSuffix(trimmed, "d") {
 		days, err := strconv.Atoi(strings.TrimSuffix(trimmed, "d"))
 		if err != nil || days <= 0 {
-			return 0, exit(2, "--older-than day duration must be a positive integer")
+			return 0, exit(2, "%s day duration must be a positive integer", flagName)
 		}
 		return time.Duration(days) * 24 * time.Hour, nil
 	}
 	duration, err := time.ParseDuration(trimmed)
 	if err != nil {
-		return 0, exit(2, "parse --older-than: %v", err)
+		return 0, exit(2, "parse %s: %v", flagName, err)
 	}
 	return duration, nil
 }
@@ -1447,11 +1478,13 @@ func newCheckpointRecord(repo Repo, cfg Config, server Server, target SSHTarget,
 	if err != nil {
 		return checkpointRecord{}, "", err
 	}
+	createdAt := time.Now().UTC().Format(time.RFC3339)
 	record := checkpointRecord{
 		ID:             id,
 		Name:           strings.TrimSpace(name),
 		Kind:           checkpointKindArchive,
-		CreatedAt:      time.Now().UTC().Format(time.RFC3339),
+		CreatedAt:      createdAt,
+		LastUsedAt:     createdAt,
 		CrabboxVersion: currentVersion(),
 		Provider:       firstNonBlank(server.Provider, cfg.Provider),
 		LeaseID:        leaseID,

--- a/internal/cli/checkpoint_store.go
+++ b/internal/cli/checkpoint_store.go
@@ -68,8 +68,11 @@ func (s checkpointStore) Reserve(record checkpointRecord) (checkpointRecord, che
 	if record.CreatedAt == "" {
 		record.CreatedAt = time.Now().UTC().Format(time.RFC3339)
 	}
-	if _, err := time.Parse(time.RFC3339, record.CreatedAt); err != nil {
-		return checkpointRecord{}, checkpointPaths{}, exit(2, "checkpoint createdAt must be RFC3339: %v", err)
+	if record.LastUsedAt == "" {
+		record.LastUsedAt = record.CreatedAt
+	}
+	if err := validateCheckpointRecordTimes(record); err != nil {
+		return checkpointRecord{}, checkpointPaths{}, err
 	}
 	paths, err := s.Paths(record.ID)
 	if err != nil {
@@ -110,6 +113,9 @@ func (s checkpointStore) Create(record checkpointRecord) (checkpointRecord, erro
 }
 
 func (s checkpointStore) Write(record checkpointRecord) error {
+	if err := validateCheckpointRecordTimes(record); err != nil {
+		return err
+	}
 	paths, err := s.Paths(record.ID)
 	if err != nil {
 		return err
@@ -154,7 +160,25 @@ func (s checkpointStore) Read(id string) (checkpointRecord, checkpointPaths, err
 	} else if record.ID != dirID {
 		return checkpointRecord{}, checkpointPaths{}, exit(2, "checkpoint %s metadata id mismatch: %s", dirID, record.ID)
 	}
+	if record.LastUsedAt == "" {
+		record.LastUsedAt = record.CreatedAt
+	}
 	return record, paths, nil
+}
+
+func validateCheckpointRecordTimes(record checkpointRecord) error {
+	if _, err := time.Parse(time.RFC3339, record.CreatedAt); err != nil {
+		return exit(2, "checkpoint createdAt must be RFC3339: %v", err)
+	}
+	if _, err := time.Parse(time.RFC3339, record.LastUsedAt); err != nil {
+		return exit(2, "checkpoint lastUsedAt must be RFC3339: %v", err)
+	}
+	return nil
+}
+
+func recordCheckpointUse(store checkpointStore, record *checkpointRecord) error {
+	record.LastUsedAt = time.Now().UTC().Format(time.RFC3339)
+	return store.Write(*record)
 }
 
 func (s checkpointStore) List() ([]checkpointRecord, error) {

--- a/internal/cli/checkpoint_store_test.go
+++ b/internal/cli/checkpoint_store_test.go
@@ -24,6 +24,9 @@ func TestCheckpointStoreCreateReadList(t *testing.T) {
 	if first.ID != "chk_first" {
 		t.Fatalf("id=%q", first.ID)
 	}
+	if first.LastUsedAt != first.CreatedAt {
+		t.Fatalf("lastUsedAt=%q, want createdAt=%q", first.LastUsedAt, first.CreatedAt)
+	}
 	second, err := store.Create(checkpointRecord{
 		ID:        "chk_second",
 		Name:      "second",
@@ -202,5 +205,38 @@ func TestCheckpointStoreFillsIDAndCreatedAt(t *testing.T) {
 	}
 	if record.CreatedAt == "" {
 		t.Fatal("createdAt not filled")
+	}
+	if record.LastUsedAt != record.CreatedAt {
+		t.Fatalf("lastUsedAt=%q, want createdAt=%q", record.LastUsedAt, record.CreatedAt)
+	}
+}
+
+func TestCheckpointStoreDefaultsMissingLastUsedAtOnReadWithoutMigration(t *testing.T) {
+	store := checkpointStore{root: t.TempDir()}
+	paths, err := store.Paths("chk_legacy")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(paths.Dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	legacy := []byte(`{"id":"chk_legacy","kind":"workspace-archive","createdAt":"2026-05-09T10:00:00Z","crabboxVersion":"0.42.0","repo":{}}` + "\n")
+	if err := os.WriteFile(paths.Meta, legacy, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	record, _, err := store.Read("chk_legacy")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.LastUsedAt != record.CreatedAt {
+		t.Fatalf("lastUsedAt=%q, want createdAt=%q", record.LastUsedAt, record.CreatedAt)
+	}
+	data, err := os.ReadFile(paths.Meta)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "lastUsedAt") {
+		t.Fatalf("read eagerly migrated legacy metadata: %s", data)
 	}
 }

--- a/internal/cli/checkpoint_test.go
+++ b/internal/cli/checkpoint_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -206,7 +208,8 @@ func TestCheckpointRestoreDryRunDoesNotResolveLease(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	record, err := store.Create(checkpointRecord{ID: "chk_restore_dryrun", Kind: checkpointKindArchive, CreatedAt: time.Now().UTC().Format(time.RFC3339), Workdir: "/work/cbx_old/my-app"})
+	const lastUsedAt = "2026-05-14T10:00:00Z"
+	record, err := store.Create(checkpointRecord{ID: "chk_restore_dryrun", Kind: checkpointKindArchive, CreatedAt: "2026-05-13T10:00:00Z", LastUsedAt: lastUsedAt, Workdir: "/work/cbx_old/my-app"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -218,6 +221,7 @@ func TestCheckpointRestoreDryRunDoesNotResolveLease(t *testing.T) {
 	if !strings.Contains(stdout.String(), "would restore checkpoint") || !strings.Contains(stdout.String(), "cbx_missing") {
 		t.Fatalf("stdout=%q", stdout.String())
 	}
+	assertCheckpointLastUsedAt(t, store, record.ID, lastUsedAt)
 }
 
 func TestCheckpointRestoreDryRunUsesStoredLeaseTarget(t *testing.T) {
@@ -227,7 +231,8 @@ func TestCheckpointRestoreDryRunUsesStoredLeaseTarget(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	record, err := store.Create(checkpointRecord{ID: "chk_restore_windows_dryrun", Kind: checkpointKindArchive, CreatedAt: time.Now().UTC().Format(time.RFC3339), Workdir: "/work/cbx_old/my-app"})
+	const lastUsedAt = "2026-05-14T11:00:00Z"
+	record, err := store.Create(checkpointRecord{ID: "chk_restore_windows_dryrun", Kind: checkpointKindArchive, CreatedAt: "2026-05-13T11:00:00Z", LastUsedAt: lastUsedAt, Workdir: "/work/cbx_old/my-app"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -251,6 +256,59 @@ func TestCheckpointRestoreDryRunUsesStoredLeaseTarget(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), `workdir=C:\crabbox\`+leaseID+`\crabbox`) {
 		t.Fatalf("stdout=%q", stdout.String())
+	}
+	assertCheckpointLastUsedAt(t, store, record.ID, lastUsedAt)
+}
+
+func TestCheckpointRestoreUpdatesLastUsedAtOnSuccess(t *testing.T) {
+	if os.PathSeparator == '\\' {
+		t.Skip("POSIX fake SSH helper")
+	}
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+	t.Setenv("CRABBOX_COORDINATOR", "")
+	tools := t.TempDir()
+	writeExecutable(t, filepath.Join(tools, "ssh"), "#!/bin/sh\ncat >/dev/null\n")
+	t.Setenv("PATH", tools+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	backend := &checkpointForkReleaseBackend{leaseID: "cbx_restore_success"}
+	testAWSBackendOverride = backend
+	t.Cleanup(func() { testAWSBackendOverride = nil })
+
+	store, err := defaultCheckpointStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	const lastUsedAt = "2026-05-14T11:30:00Z"
+	record, err := store.Create(checkpointRecord{
+		ID:          "chk_restore_success",
+		Kind:        checkpointKindArchive,
+		CreatedAt:   "2026-05-13T11:30:00Z",
+		LastUsedAt:  lastUsedAt,
+		ArchivePath: checkpointArchive,
+		Workdir:     "/work/cbx_source/my-app",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	paths, err := store.Paths(record.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths.Archive, []byte("archive"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	app := App{Stdout: io.Discard, Stderr: io.Discard}
+	if err := app.checkpointRestore(context.Background(), []string{record.ID, "--id", backend.leaseID, "--provider", "aws"}); err != nil {
+		t.Fatal(err)
+	}
+	stored, _, err := store.Read(record.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.LastUsedAt == lastUsedAt {
+		t.Fatal("successful restore did not update lastUsedAt")
 	}
 }
 
@@ -296,7 +354,8 @@ func TestCheckpointForkDryRunDoesNotAcquireLease(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	record, err := store.Create(checkpointRecord{ID: "chk_fork_dryrun", Kind: checkpointKindArchive, CreatedAt: time.Now().UTC().Format(time.RFC3339)})
+	const lastUsedAt = "2026-05-14T12:00:00Z"
+	record, err := store.Create(checkpointRecord{ID: "chk_fork_dryrun", Kind: checkpointKindArchive, CreatedAt: "2026-05-13T12:00:00Z", LastUsedAt: lastUsedAt})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -308,6 +367,7 @@ func TestCheckpointForkDryRunDoesNotAcquireLease(t *testing.T) {
 	if !strings.Contains(stdout.String(), "would fork checkpoint") || !strings.Contains(stdout.String(), "fork-dryrun") {
 		t.Fatalf("stdout=%q", stdout.String())
 	}
+	assertCheckpointLastUsedAt(t, store, record.ID, lastUsedAt)
 }
 
 func TestCheckpointForkArchiveDryRunRequiresProviderIntent(t *testing.T) {
@@ -335,7 +395,8 @@ func TestCheckpointForkNativeDryRunUsesRecordedProvider(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	record := checkpointRecord{ID: "chk_native_recorded_provider", Kind: checkpointKindDockerCommit, CreatedAt: time.Now().UTC().Format(time.RFC3339), TargetOS: targetLinux}
+	const lastUsedAt = "2026-05-14T13:00:00Z"
+	record := checkpointRecord{ID: "chk_native_recorded_provider", Kind: checkpointKindDockerCommit, CreatedAt: "2026-05-13T13:00:00Z", LastUsedAt: lastUsedAt, TargetOS: targetLinux}
 	record.Native.ImageID = "sha256:checkpoint"
 	record.Native.Direct = true
 	if _, err := store.Create(record); err != nil {
@@ -349,6 +410,7 @@ func TestCheckpointForkNativeDryRunUsesRecordedProvider(t *testing.T) {
 	if !strings.Contains(stdout.String(), "provider=local-container") {
 		t.Fatalf("stdout=%q", stdout.String())
 	}
+	assertCheckpointLastUsedAt(t, store, record.ID, lastUsedAt)
 }
 
 func TestCheckpointForkParallelsTemplateDryRunConfigMarksProviderIntent(t *testing.T) {
@@ -378,7 +440,8 @@ func TestCheckpointForkDryRunFansOutRequestedSlug(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	record, err := store.Create(checkpointRecord{ID: "chk_fork_fanout", Kind: checkpointKindArchive, CreatedAt: time.Now().UTC().Format(time.RFC3339)})
+	const lastUsedAt = "2026-05-14T14:00:00Z"
+	record, err := store.Create(checkpointRecord{ID: "chk_fork_fanout", Kind: checkpointKindArchive, CreatedAt: "2026-05-13T14:00:00Z", LastUsedAt: lastUsedAt})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -401,6 +464,7 @@ func TestCheckpointForkDryRunFansOutRequestedSlug(t *testing.T) {
 	if got := strings.Count(out, "would fork checkpoint"); got != 3 {
 		t.Fatalf("dry-run fork lines=%d, want 3:\n%s", got, out)
 	}
+	assertCheckpointLastUsedAt(t, store, record.ID, lastUsedAt)
 }
 
 func TestCheckpointForkDryRunFansOutCommand(t *testing.T) {
@@ -410,7 +474,8 @@ func TestCheckpointForkDryRunFansOutCommand(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	record, err := store.Create(checkpointRecord{ID: "chk_fork_run_fanout", Kind: checkpointKindArchive, CreatedAt: time.Now().UTC().Format(time.RFC3339)})
+	const lastUsedAt = "2026-05-14T15:00:00Z"
+	record, err := store.Create(checkpointRecord{ID: "chk_fork_run_fanout", Kind: checkpointKindArchive, CreatedAt: "2026-05-13T15:00:00Z", LastUsedAt: lastUsedAt})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -433,6 +498,7 @@ func TestCheckpointForkDryRunFansOutCommand(t *testing.T) {
 			t.Fatalf("stdout missing %q:\n%s", want, out)
 		}
 	}
+	assertCheckpointLastUsedAt(t, store, record.ID, lastUsedAt)
 }
 
 func TestCheckpointForkRejectsInvalidCount(t *testing.T) {
@@ -712,6 +778,229 @@ func TestCheckpointPruneDryRunAndDelete(t *testing.T) {
 	}
 }
 
+func TestCheckpointPruneUnusedForComposesWithAgeAndKind(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	store, err := defaultCheckpointStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	records := []checkpointRecord{
+		{ID: "chk_old_unused_archive", Kind: checkpointKindArchive, CreatedAt: now.Add(-96 * time.Hour).Format(time.RFC3339), LastUsedAt: now.Add(-72 * time.Hour).Format(time.RFC3339)},
+		{ID: "chk_old_used_archive", Kind: checkpointKindArchive, CreatedAt: now.Add(-96 * time.Hour).Format(time.RFC3339), LastUsedAt: now.Add(-2 * time.Hour).Format(time.RFC3339)},
+		{ID: "chk_new_archive", Kind: checkpointKindArchive, CreatedAt: now.Add(-12 * time.Hour).Format(time.RFC3339), LastUsedAt: now.Add(-12 * time.Hour).Format(time.RFC3339)},
+		{ID: "chk_old_unused_native", Kind: checkpointKindAzureOS, CreatedAt: now.Add(-96 * time.Hour).Format(time.RFC3339), LastUsedAt: now.Add(-72 * time.Hour).Format(time.RFC3339)},
+	}
+	for _, record := range records {
+		if _, err := store.Create(record); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var stdout bytes.Buffer
+	app := App{Stdout: &stdout, Stderr: io.Discard}
+	if err := app.checkpointPrune(context.Background(), []string{
+		"--older-than", "48h",
+		"--unused-for", "24h",
+		"--kind", "archive",
+		"--dry-run",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "would delete id=chk_old_unused_archive") || !strings.Contains(out, "last_used=") {
+		t.Fatalf("dry-run stdout=%q", out)
+	}
+	for _, excluded := range []string{"chk_old_used_archive", "chk_new_archive", "chk_old_unused_native"} {
+		if strings.Contains(out, excluded) {
+			t.Fatalf("dry-run unexpectedly selected %s: %q", excluded, out)
+		}
+	}
+	for _, record := range records {
+		if _, _, err := store.Read(record.ID); err != nil {
+			t.Fatalf("dry-run removed %s: %v", record.ID, err)
+		}
+	}
+}
+
+func TestCheckpointPruneUnusedForUsesCreatedAtFallback(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	store, err := defaultCheckpointStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	paths, err := store.Paths("chk_legacy_unused")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(paths.Dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	createdAt := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+	legacy := fmt.Sprintf(`{"id":"chk_legacy_unused","kind":"workspace-archive","createdAt":%q,"repo":{}}`+"\n", createdAt)
+	if err := os.WriteFile(paths.Meta, []byte(legacy), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := App{Stdout: &stdout, Stderr: io.Discard}
+	if err := app.checkpointPrune(context.Background(), []string{"--unused-for", "24h", "--dry-run"}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout.String(), "would delete id=chk_legacy_unused") || !strings.Contains(stdout.String(), "last_used="+createdAt) {
+		t.Fatalf("stdout=%q", stdout.String())
+	}
+	data, err := os.ReadFile(paths.Meta)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "lastUsedAt") {
+		t.Fatalf("dry-run migrated legacy metadata: %s", data)
+	}
+}
+
+func TestCheckpointPruneProviderDeleteFailureRetainsRecord(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "provider delete failed", http.StatusBadGateway)
+	}))
+	defer server.Close()
+	t.Setenv("CRABBOX_COORDINATOR", server.URL)
+	t.Setenv("CRABBOX_COORDINATOR_ADMIN_TOKEN", "admin")
+
+	store, err := defaultCheckpointStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	record := checkpointRecord{
+		ID:         "chk_provider_delete_failure",
+		Kind:       checkpointKindAzureOS,
+		CreatedAt:  time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339),
+		LastUsedAt: time.Now().Add(-48 * time.Hour).UTC().Format(time.RFC3339),
+	}
+	record.Native.Provider = "azure"
+	record.Native.Resource = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/snapshots/checkpoint"
+	if _, err := store.Create(record); err != nil {
+		t.Fatal(err)
+	}
+
+	app := App{Stdout: io.Discard, Stderr: io.Discard}
+	if err := app.checkpointPrune(context.Background(), []string{"--unused-for", "24h"}); err == nil {
+		t.Fatal("prune succeeded despite provider deletion failure")
+	}
+	if _, _, err := store.Read(record.ID); err != nil {
+		t.Fatalf("provider deletion failure removed local record: %v", err)
+	}
+}
+
+func TestCheckpointForkUseTimestampChangesOnlyAfterConsumption(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+	t.Setenv("CRABBOX_COORDINATOR", "")
+	store, err := defaultCheckpointStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := store.Create(checkpointRecord{
+		ID:         "chk_fork_use",
+		Kind:       checkpointKindAWSEBS,
+		CreatedAt:  "2026-05-01T10:00:00Z",
+		LastUsedAt: "2026-05-01T10:00:00Z",
+		TargetOS:   targetWindows,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	paths, err := store.Paths(record.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend := newWatchTestBackend()
+	backend.acquireErr = errors.New("acquire failed")
+	app := App{Stdout: io.Discard, Stderr: io.Discard}
+	cfg := Config{Provider: "watch-test"}
+	repo := Repo{Root: t.TempDir(), Name: "my-app"}
+	if err := app.checkpointForkRecordOnce(context.Background(), cfg, backend, backend, repo, store, &record, paths, true, false, "", "", true, checkpointForkRunOptions{}); err == nil {
+		t.Fatal("failed checkpoint consumption succeeded")
+	}
+	stored, _, err := store.Read(record.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.LastUsedAt != "2026-05-01T10:00:00Z" {
+		t.Fatalf("failed consumption updated lastUsedAt=%q", stored.LastUsedAt)
+	}
+
+	backend.acquireErr = nil
+	if err := app.checkpointForkRecordOnce(context.Background(), cfg, backend, backend, repo, store, &record, paths, true, false, "", "", true, checkpointForkRunOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	stored, _, err = store.Read(record.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.LastUsedAt == "2026-05-01T10:00:00Z" {
+		t.Fatal("successful consumption did not update lastUsedAt")
+	}
+}
+
+func TestCheckpointForkMetadataWriteFailureReleasesProvisionedLease(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+	t.Setenv("CRABBOX_COORDINATOR", "")
+	store, err := defaultCheckpointStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := store.Create(checkpointRecord{
+		ID:         "chk_fork_write_failure",
+		Kind:       checkpointKindAWSEBS,
+		CreatedAt:  "2026-05-01T11:00:00Z",
+		LastUsedAt: "2026-05-01T11:00:00Z",
+		TargetOS:   targetWindows,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	paths, err := store.Paths(record.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend := newWatchTestBackend()
+	var stdout bytes.Buffer
+	app := App{Stdout: &stdout, Stderr: io.Discard}
+	cfg := Config{Provider: "watch-test"}
+	repo := Repo{Root: t.TempDir(), Name: "my-app"}
+	failingRoot := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(failingRoot, []byte("block checkpoint metadata writes"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	failingStore := checkpointStore{root: failingRoot}
+	if err := app.checkpointForkRecordOnce(context.Background(), cfg, backend, backend, repo, failingStore, &record, paths, true, false, "", "", true, checkpointForkRunOptions{}); err == nil {
+		t.Fatal("checkpoint fork succeeded despite metadata write failure")
+	}
+	_, _, releases := backend.counts()
+	if releases != 1 {
+		t.Fatalf("metadata write failure releases=%d, want 1", releases)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("metadata write failure printed an untracked fork: %q", stdout.String())
+	}
+	assertCheckpointLastUsedAt(t, store, record.ID, "2026-05-01T11:00:00Z")
+}
+
+func assertCheckpointLastUsedAt(t *testing.T, store checkpointStore, id, want string) {
+	t.Helper()
+	record, _, err := store.Read(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.LastUsedAt != want {
+		t.Fatalf("checkpoint %s lastUsedAt=%q, want %q", id, record.LastUsedAt, want)
+	}
+}
+
 func TestCheckpointPruneRejectsOperands(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	store, err := defaultCheckpointStore()
@@ -732,6 +1021,9 @@ func TestCheckpointPruneRejectsOperands(t *testing.T) {
 	}
 	if _, _, err := store.Read("chk_old"); err != nil {
 		t.Fatalf("checkpoint removed after invalid prune command: %v", err)
+	}
+	if err := app.checkpointPrune(context.Background(), nil); err == nil {
+		t.Fatal("expected prune without an age filter to fail")
 	}
 }
 
@@ -1585,7 +1877,7 @@ func (b *checkpointForkReleaseBackend) Acquire(_ context.Context, req AcquireReq
 	b.acquireSlug = req.RequestedSlug
 	return LeaseTarget{
 		Server:  Server{Provider: "aws", CloudID: "i-123", Labels: map[string]string{}},
-		SSH:     SSHTarget{User: "crabbox", Port: "22", TargetOS: targetLinux},
+		SSH:     SSHTarget{User: "crabbox", Host: "checkpoint.example.test", Port: "22", TargetOS: targetLinux},
 		LeaseID: b.leaseID,
 	}, nil
 }


### PR DESCRIPTION
## Summary

- Persist `lastUsedAt`, initialized from `createdAt`, and update it after successful checkpoint fork and restore operations.
- Preserve legacy checkpoint reads with a fallback for records that predate `lastUsedAt`.
- Add composable `checkpoint prune --unused-for` filtering while retaining provider-first deletion semantics.
- Document operator scheduling for expiry pruning because Crabbox does not yet have an automatic checkpoint reaper.

## Tests / proof

- Focused checkpoint tests passed.
- Checkpoint tests passed with `-race`.
- `go build -trimpath -o bin/crabbox ./cmd/crabbox` passed.
- Source-blind isolated-state CLI validation passed all 7 clauses with no provider calls.
- `go test -count=1 -timeout 20m ./internal/cli` completed after approximately 18 minutes. It was red only in these reproducible, unrelated macOS tunnel/WebVNC tests: `TestSSHLocalForwardWaitsForAcceptingListenerAndReapsProcessGroup`, `TestStartVNCTunnelVerifiesOwnedLoopbackListener`, `TestLocalWebVNCListenerIdentityPinsCurrentProcess`, `TestWebVNCLocalRunsWithPasswordOnlyOnStdin`, `TestWebVNCLocalStopsWhenSourceListenerDisappears`, and `TestVNCForegroundTunnelReportsSSHExit`. The checkpoint tests passed.

## Config / secrets

No new secrets. Scheduled pruning must run as the checkpoint owner with the same state/config and provider deletion access.

## Follow-up

- https://github.com/openclaw/crabbox/issues/1377 tracks coordinator-managed checkpoint expiry sweeps.
