### PR TITLE
fix(heartbeat): reject ambiguous identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fixed native local-container checkpoint forks to complete their recorded Docker runtime scope before claim creation, allowing immediate commands and safe normal stop while preserving exact claim validation.
 - Split fallback E2B HTTP ownership so finite lifecycle calls cannot hang indefinitely while uploads and process streams remain caller-controlled. Thanks @SebTardif.
 - Split fallback HTTP ownership for Azure Dynamic Sessions, Blaxel, Cloudflare Sandbox, Freestyle, Orgo, and SmolVM so finite control calls cannot hang while data-plane lifetimes remain caller-controlled. Thanks @SebTardif.
+- Rejected ambiguous or extra `crabbox heartbeat` identifiers before configuration or provider resolution, preventing malformed commands from reaching lease mutation. Thanks @coygeek.
 - Rejected native Jujutsu and other unsupported local sync sources before delegated archive providers can provision or execute a remote sandbox.
 - Accepted explicit local-container architecture assertions only when the selected Docker or Podman daemon reports a matching native architecture, without enabling emulation. Thanks @coygeek.
 - Omitted coordinator-only history commands from failure digests when run history is unavailable, while preserving direct lease recovery guidance.

--- a/docs/commands/heartbeat.md
+++ b/docs/commands/heartbeat.md
@@ -5,6 +5,7 @@ the resulting lease state. It is intended for external drivers that keep a
 lease busy over SSH without running commands through `crabbox run`.
 
 ```sh
+crabbox heartbeat swift-crab
 crabbox heartbeat --id swift-crab
 crabbox heartbeat --id swift-crab --idle-timeout 90m
 crabbox heartbeat --id cbx_abcdef123456 --provider aws --json
@@ -12,7 +13,9 @@ crabbox heartbeat --id cbx_abcdef123456 --provider aws --json
 
 ## Identifying the lease
 
-`--id` accepts a canonical `cbx_...` lease ID or an active slug. When
+Supply exactly one identifier, either as the positional argument or with
+`--id`; combining the two is a usage error. The identifier accepts a canonical
+`cbx_...` lease ID or an active slug. When
 `--provider` is omitted, Crabbox uses the same local-claim routing as `status`
 and `inspect`; an explicit provider still wins.
 

--- a/internal/cli/heartbeat.go
+++ b/internal/cli/heartbeat.go
@@ -23,15 +23,20 @@ func (a App) heartbeat(ctx context.Context, args []string) error {
 	defaults := defaultConfig()
 	fs := newFlagSet("heartbeat", a.Stderr)
 	provider := registerProviderSelectionFlag(fs, defaults, providerHelpSSH())
-	id := fs.String("id", "", "lease id or slug")
+	id := new(string)
+	idOccurrences := 0
+	fs.Func("id", "lease id or slug", func(value string) error {
+		*id = value
+		idOccurrences++
+		return nil
+	})
 	idleTimeout := fs.Duration("idle-timeout", 0, "replace the lease idle timeout while heartbeating")
 	jsonOut := fs.Bool("json", false, "print JSON")
 	if err := parseFlags(fs, args); err != nil {
 		return err
 	}
-	idFlagSet := flagWasSet(fs, "id")
 	setIDFromFirstArg(fs, id)
-	if strings.TrimSpace(*id) == "" || fs.NArg() > 1 || (idFlagSet && fs.NArg() > 0) {
+	if strings.TrimSpace(*id) == "" || idOccurrences > 1 || fs.NArg() > 1 || (idOccurrences == 1 && fs.NArg() > 0) {
 		return exit(2, "usage: crabbox heartbeat --id <lease-id-or-slug> [--provider <provider>] [--idle-timeout <duration>] [--json]")
 	}
 	idleTimeoutSet := flagWasSet(fs, "idle-timeout")

--- a/internal/cli/heartbeat.go
+++ b/internal/cli/heartbeat.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 )
 
@@ -28,8 +29,9 @@ func (a App) heartbeat(ctx context.Context, args []string) error {
 	if err := parseFlags(fs, args); err != nil {
 		return err
 	}
+	idFlagSet := flagWasSet(fs, "id")
 	setIDFromFirstArg(fs, id)
-	if fs.NArg() > 1 {
+	if strings.TrimSpace(*id) == "" || fs.NArg() > 1 || (idFlagSet && fs.NArg() > 0) {
 		return exit(2, "usage: crabbox heartbeat --id <lease-id-or-slug> [--provider <provider>] [--idle-timeout <duration>] [--json]")
 	}
 	idleTimeoutSet := flagWasSet(fs, "idle-timeout")

--- a/internal/cli/heartbeat_test.go
+++ b/internal/cli/heartbeat_test.go
@@ -11,11 +11,102 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
+
+func TestHeartbeatIdentifierSyntax(t *testing.T) {
+	tests := []struct {
+		name   string
+		args   []string
+		valid  bool
+		wantID string
+	}{
+		{name: "positional", args: []string{"--provider", heartbeatDirectProviderName, "direct-heartbeat"}, valid: true, wantID: "cbx_direct_heartbeat"},
+		{name: "id flag", args: []string{"--provider", heartbeatDirectProviderName, "--id", "direct-heartbeat"}, valid: true, wantID: "cbx_direct_heartbeat"},
+		{name: "id flag and one positional", args: []string{"--provider", heartbeatDirectProviderName, "--id", "direct-heartbeat", "extra"}},
+		{name: "id flag and two positionals", args: []string{"--provider", heartbeatDirectProviderName, "--id", "direct-heartbeat", "extra", "second"}},
+		{name: "two positionals", args: []string{"--provider", heartbeatDirectProviderName, "direct-heartbeat", "extra"}},
+		{name: "missing identifier", args: []string{"--provider", heartbeatDirectProviderName}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clearConfigEnv(t)
+			stateRoot := t.TempDir()
+			t.Setenv("XDG_STATE_HOME", stateRoot)
+
+			backend := &heartbeatDirectBackend{lease: heartbeatDirectTestLease("cbx_direct_heartbeat", "direct-heartbeat")}
+			heartbeatDirectBackendForTest = backend
+			t.Cleanup(func() { heartbeatDirectBackendForTest = nil })
+
+			var coordinatorRequests atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				coordinatorRequests.Add(1)
+				if r.Method != http.MethodPost || r.URL.Path != "/v1/leases/cbx_direct_heartbeat/heartbeat" {
+					t.Errorf("request=%s %s, want registered heartbeat POST", r.Method, r.URL.Path)
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
+					ID: "cbx_direct_heartbeat", Slug: "direct-heartbeat", Provider: heartbeatDirectProviderName, State: "active",
+				}})
+			}))
+			defer server.Close()
+
+			configPath := filepath.Join(t.TempDir(), "config.yaml")
+			if test.valid {
+				config := fmt.Sprintf("provider: %s\nbroker:\n  url: %s\n  mode: registered\n", heartbeatDirectProviderName, server.URL)
+				if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				cfg := defaultConfig()
+				cfg.Provider = heartbeatDirectProviderName
+				if err := claimLeaseTargetForRepoConfig(backend.lease.LeaseID, serverSlug(backend.lease.Server), cfg, backend.lease.Server, SSHTarget{}, "/repo", 30*time.Minute, false); err != nil {
+					t.Fatal(err)
+				}
+			} else if err := os.Mkdir(configPath, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("CRABBOX_CONFIG", configPath)
+			t.Setenv("CRABBOX_COORDINATOR", server.URL)
+			t.Setenv("CRABBOX_COORDINATOR_TOKEN", "user-token")
+
+			before := captureClaimsListState(t, stateRoot)
+			var stdout, stderr bytes.Buffer
+			err := (App{Stdout: &stdout, Stderr: &stderr}).Run(context.Background(), append([]string{"heartbeat"}, test.args...))
+			if test.valid {
+				if err != nil {
+					t.Fatalf("heartbeat error=%v stderr=%q", err, stderr.String())
+				}
+				if coordinatorRequests.Load() != 1 || backend.resolves != 1 || len(backend.touches) != 1 {
+					t.Fatalf("side effects: requests=%d configures=%d resolves=%d touches=%d", coordinatorRequests.Load(), backend.configures, backend.resolves, len(backend.touches))
+				}
+				if !strings.Contains(stdout.String(), "heartbeat lease="+test.wantID) {
+					t.Fatalf("heartbeat output=%q", stdout.String())
+				}
+				return
+			}
+
+			var exitErr ExitError
+			if !AsExitError(err, &exitErr) || exitErr.Code != 2 || !strings.HasPrefix(exitErr.Message, "usage: crabbox heartbeat") {
+				t.Fatalf("error=%v, want heartbeat usage with exit 2", err)
+			}
+			if stdout.Len() != 0 || stderr.Len() != 0 {
+				t.Fatalf("invalid syntax wrote stdout=%q stderr=%q", stdout.String(), stderr.String())
+			}
+			if backend.configures != 0 || backend.resolves != 0 || len(backend.touches) != 0 || coordinatorRequests.Load() != 0 {
+				t.Fatalf("invalid syntax crossed side-effect boundary: requests=%d configures=%d resolves=%d touches=%d", coordinatorRequests.Load(), backend.configures, backend.resolves, len(backend.touches))
+			}
+			after := captureClaimsListState(t, stateRoot)
+			if !reflect.DeepEqual(after, before) {
+				t.Fatalf("invalid syntax mutated claim state\nbefore=%#v\nafter=%#v", before, after)
+			}
+		})
+	}
+}
 
 func TestHeartbeatCoordinatorPassesIdleTimeoutAndPrintsLeaseState(t *testing.T) {
 	var requestBody map[string]any
@@ -222,12 +313,15 @@ func (heartbeatDirectProvider) Configure(Config, Runtime) (Backend, error) {
 	if heartbeatDirectBackendForTest == nil {
 		return nil, errors.New("heartbeat direct test backend is not configured")
 	}
+	heartbeatDirectBackendForTest.configures++
 	return heartbeatDirectBackendForTest, nil
 }
 
 type heartbeatDirectBackend struct {
-	lease   LeaseTarget
-	touches []TouchRequest
+	lease      LeaseTarget
+	configures int
+	resolves   int
+	touches    []TouchRequest
 }
 
 func (*heartbeatDirectBackend) Spec() ProviderSpec { return heartbeatDirectProvider{}.Spec() }
@@ -235,6 +329,7 @@ func (b *heartbeatDirectBackend) Acquire(context.Context, AcquireRequest) (Lease
 	return b.lease, nil
 }
 func (b *heartbeatDirectBackend) Resolve(_ context.Context, req ResolveRequest) (LeaseTarget, error) {
+	b.resolves++
 	if req.ID != b.lease.LeaseID && req.ID != serverSlug(b.lease.Server) {
 		return LeaseTarget{}, fmt.Errorf("lease %s not found", req.ID)
 	}

--- a/internal/cli/heartbeat_test.go
+++ b/internal/cli/heartbeat_test.go
@@ -28,6 +28,8 @@ func TestHeartbeatIdentifierSyntax(t *testing.T) {
 	}{
 		{name: "positional", args: []string{"--provider", heartbeatDirectProviderName, "direct-heartbeat"}, valid: true, wantID: "cbx_direct_heartbeat"},
 		{name: "id flag", args: []string{"--provider", heartbeatDirectProviderName, "--id", "direct-heartbeat"}, valid: true, wantID: "cbx_direct_heartbeat"},
+		{name: "repeated id flags", args: []string{"--provider", heartbeatDirectProviderName, "--id", "first", "--id", "second"}},
+		{name: "repeated id equals flags", args: []string{"--provider", heartbeatDirectProviderName, "--id=first", "--id=second"}},
 		{name: "id flag and one positional", args: []string{"--provider", heartbeatDirectProviderName, "--id", "direct-heartbeat", "extra"}},
 		{name: "id flag and two positionals", args: []string{"--provider", heartbeatDirectProviderName, "--id", "direct-heartbeat", "extra", "second"}},
 		{name: "two positionals", args: []string{"--provider", heartbeatDirectProviderName, "direct-heartbeat", "extra"}},


### PR DESCRIPTION
## Summary

- reject `heartbeat --id <lease> <extra>` and other ambiguous identifier forms before loading configuration or resolving a provider
- preserve the supported single positional-ID and `--id`-only forms
- prove invalid syntax causes zero coordinator, backend, resolve, touch, or claim mutations

Closes https://github.com/openclaw/crabbox/issues/1368

## Verification

- focused heartbeat/status/claim race tests
- loopback coordinator and fake backend zero-side-effect regression matrix
- built-CLI source-blind argument proof
- `go vet ./...`, docs validation, `gofmt`, and `git diff --check`
- P1 autoreview clean

## Built-CLI behavior proof

Source-blind proof was run from exact head `0c5efc2123221729fbf403ad3023a3f99b4e3f4e`. The temporary binary was built with `go build -trimpath -o "$PROOF_DIR/crabbox" ./cmd/crabbox` and had SHA-256 `509b3d096a0da3072d2dd5062ea79aa51b4a537afcb7ce6f2ce991419490d22f`.

Each invocation used a new private temporary HOME/XDG tree plus deliberately invalid YAML, with the inherited environment removed:

```sh
printf '%s\n' 'provider: [' > "$PROOF_DIR/invalid.yaml"
env -i \
  PATH="/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin" \
  HOME="$PROOF_DIR/home" \
  XDG_CONFIG_HOME="$PROOF_DIR/home/config" \
  XDG_STATE_HOME="$PROOF_DIR/home/state" \
  XDG_CACHE_HOME="$PROOF_DIR/home/cache" \
  CRABBOX_CONFIG="$PROOF_DIR/invalid.yaml" \
  CRABBOX_COORDINATOR="http://127.0.0.1:1" \
  LC_ALL=C \
  "$PROOF_DIR/crabbox" heartbeat <case arguments>
```

Inspected, path-redacted transcript:

```text
--id lease-a extra                 exit=2  usage: crabbox heartbeat --id <lease-id-or-slug> [--provider <provider>] [--idle-timeout <duration>] [--json]
--id lease-a --id lease-b          exit=2  usage: crabbox heartbeat --id <lease-id-or-slug> [--provider <provider>] [--idle-timeout <duration>] [--json]
--id=lease-a --id=lease-b          exit=2  usage: crabbox heartbeat --id <lease-id-or-slug> [--provider <provider>] [--idle-timeout <duration>] [--json]
lease-a lease-b                     exit=2  usage: crabbox heartbeat --id <lease-id-or-slug> [--provider <provider>] [--idle-timeout <duration>] [--json]
<no identifier>                    exit=2  usage: crabbox heartbeat --id <lease-id-or-slug> [--provider <provider>] [--idle-timeout <duration>] [--json]
--id ''                             exit=2  usage: crabbox heartbeat --id <lease-id-or-slug> [--provider <provider>] [--idle-timeout <duration>] [--json]
--id lease-a                        exit=2  parse config $PROOF_DIR/invalid.yaml: yaml: line 1: did not find expected node content
```

All six malformed identifier forms returned the same usage error without exposing the invalid-config diagnostic. The valid single-ID control crossed the syntax boundary and failed on that deliberately invalid configuration, proving malformed input is rejected first.

### Maintainer disposition

The P3 suggestion to remove the Unreleased changelog entry is intentionally rejected. Repository standing policy requires changelog coverage for user-visible fixes, so the existing credited entry remains.
