### PR TITLE
fix(claims): bound inventory file reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- Bounded `crabbox claims list` inventory reads to 1 MiB per local claim while preserving valid partial output for oversized files. Thanks @coygeek.
 - Made local-container heartbeat authorize recorded dynamic runtime scopes and durably compare-and-swap exact claim lifecycle state without recreating or overwriting changed claims. Thanks @coygeek.
 - Made AWS image deletion resume from owner-level durable snapshot claims after AMI deregistration or catalog cleanup failures, preventing stale ordinary and capability-variant records from remaining selectable.
 - Made static SSH heartbeats persist touched timestamps and explicit idle-timeout replacements across fresh CLI processes, while omitted overrides preserve the stored timeout. Thanks @coygeek.

--- a/docs/commands/claims.md
+++ b/docs/commands/claims.md
@@ -50,12 +50,17 @@ details, labels, login and registration URLs or IDs, credentials, cache
 metadata, revisions, and fixed-create internals are never included. Claims are
 sorted by lease ID, provider, and slug.
 
-Malformed files do not hide valid claims. Each problem has stable `file`, `code`,
-and `message` fields. Supported codes are `invalid_filename`, `invalid_json`,
-`empty_lease_id`, `lease_id_mismatch`, `read_error`, and `invalid_claim`. Unsafe
-or overlong filenames are represented by a short SHA-256 fingerprint instead of
-their contents. Non-regular claim paths use `non_regular_file`. At most 100
-problem entries are emitted; the final
+Malformed files do not hide valid claims. For this read-only inventory, each
+local claim file has an inclusive 1 MiB implementation limit. Files that exceed
+the limit while being read use `claim_too_large` and are never read into memory
+in full; other concurrent changes remain `read_error`. This inventory limit does
+not change the runtime claim loader. Each problem has stable `file`, `code`, and
+`message` fields. Supported codes are
+`invalid_filename`, `invalid_json`, `claim_too_large`, `empty_lease_id`,
+`lease_id_mismatch`, `read_error`, and `invalid_claim`. Unsafe or overlong
+filenames are represented by a short SHA-256 fingerprint instead of their
+contents. Non-regular claim paths use `non_regular_file`. At most 100 problem
+entries are emitted; the final
 `problems_truncated` entry reports when additional files were omitted. Problems
 are sorted by file reference and code.
 

--- a/internal/cli/claim.go
+++ b/internal/cli/claim.go
@@ -76,6 +76,8 @@ type FixedCreateIntent struct {
 
 const FixedAWSClaimProvider = "aws-fixed-v1"
 
+const maxLocalClaimInventoryFileBytes int64 = 1 * 1024 * 1024
+
 var claimMutationMutexes sync.Map
 
 type invalidLeaseClaimIDError struct{ id string }
@@ -2009,10 +2011,16 @@ func readLeaseClaimSnapshotWithPresence(path, leaseID string, expected os.FileIn
 	if !sameLeaseClaimSnapshotFile(expected, opened) {
 		return leaseClaim{}, true, leaseClaimSnapshotReadError(leaseID, "verify opened", errors.New("claim file changed during scan"))
 	}
+	if opened.Size() > maxLocalClaimInventoryFileBytes {
+		return leaseClaim{}, true, leaseClaimSnapshotTooLargeError(leaseID)
+	}
 
-	data, err := io.ReadAll(file)
+	data, tooLarge, err := readLocalClaimInventoryData(file)
 	if err != nil {
 		return leaseClaim{}, true, leaseClaimSnapshotReadError(leaseID, "read", err)
+	}
+	if tooLarge {
+		return leaseClaim{}, true, leaseClaimSnapshotTooLargeError(leaseID)
 	}
 	afterRead, err := file.Stat()
 	if err != nil {
@@ -2036,6 +2044,11 @@ func readLeaseClaimSnapshotWithPresence(path, leaseID string, expected os.FileIn
 	return claim, true, nil
 }
 
+func readLocalClaimInventoryData(r io.Reader) ([]byte, bool, error) {
+	data, err := io.ReadAll(io.LimitReader(r, maxLocalClaimInventoryFileBytes+1))
+	return data, int64(len(data)) > maxLocalClaimInventoryFileBytes, err
+}
+
 func sameLeaseClaimSnapshotFile(a, b os.FileInfo) bool {
 	return a != nil && b != nil && os.SameFile(a, b) && a.Mode() == b.Mode() && a.Size() == b.Size() && a.ModTime().Equal(b.ModTime())
 }
@@ -2044,6 +2057,13 @@ func leaseClaimSnapshotReadError(leaseID, action string, err error) error {
 	return &leaseClaimFileError{
 		code: "read_error",
 		err:  exit(2, "%s claim file %s: %v", action, leaseID, err),
+	}
+}
+
+func leaseClaimSnapshotTooLargeError(leaseID string) error {
+	return &leaseClaimFileError{
+		code: "claim_too_large",
+		err:  exit(2, "claim file %s exceeds the 1 MiB inventory limit", leaseID),
 	}
 }
 

--- a/internal/cli/claims.go
+++ b/internal/cli/claims.go
@@ -150,6 +150,8 @@ func localClaimProblemMessage(code string) string {
 		return "claim filename is not a valid lease id; filename replaced by a fingerprint"
 	case "invalid_json":
 		return "claim file is not valid JSON"
+	case "claim_too_large":
+		return "claim file exceeds the 1 MiB inventory limit"
 	case "empty_lease_id":
 		return "claim file has a missing or empty leaseId"
 	case "lease_id_mismatch":

--- a/internal/cli/claims_readonly_unix_test.go
+++ b/internal/cli/claims_readonly_unix_test.go
@@ -86,6 +86,61 @@ func TestClaimsListReadableNonWritableStore(t *testing.T) {
 	}
 }
 
+func TestClaimsListRejectsLargeSparseFilesWithoutCreatingState(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	writeClaimsListFixture(t, "cbx_valid.json", leaseClaim{LeaseID: "cbx_valid", Provider: "local-container"})
+	stateDir, err := crabboxStateDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	claimsDir := filepath.Join(stateDir, "claims")
+	wantSizes := map[string]int64{
+		"cbx_sparse_128m.json": 128 * 1024 * 1024,
+		"cbx_sparse_1g.json":   1 * 1024 * 1024 * 1024,
+	}
+	for name, size := range wantSizes {
+		path := filepath.Join(claimsDir, name)
+		if err := os.WriteFile(path, nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Truncate(path, size); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	stdout, stderr, runErr := runClaimsList(t, "--json")
+	assertClaimsExitCode(t, runErr, 2)
+	if stderr != "" {
+		t.Fatalf("stderr=%q", stderr)
+	}
+	var output localClaimsListOutput
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatalf("decode output: %v\n%s", err, stdout)
+	}
+	if len(output.Claims) != 1 || output.Claims[0].LeaseID != "cbx_valid" {
+		t.Fatalf("partial claims=%#v", output.Claims)
+	}
+	wantProblems := []localClaimProblem{
+		{File: "cbx_sparse_128m.json", Code: "claim_too_large", Message: "claim file exceeds the 1 MiB inventory limit"},
+		{File: "cbx_sparse_1g.json", Code: "claim_too_large", Message: "claim file exceeds the 1 MiB inventory limit"},
+	}
+	if !reflect.DeepEqual(output.Problems, wantProblems) {
+		t.Fatalf("problems=%#v want=%#v", output.Problems, wantProblems)
+	}
+	for name, wantSize := range wantSizes {
+		info, err := os.Stat(filepath.Join(claimsDir, name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Size() != wantSize {
+			t.Fatalf("%s size=%d want=%d", name, info.Size(), wantSize)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(stateDir, "claim-locks")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("claim-locks created or unreadable: %v", err)
+	}
+}
+
 func TestRuntimeClaimsSnapshotChecksFileTypeInsideLock(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	stateDir, err := crabboxStateDir()

--- a/internal/cli/claims_test.go
+++ b/internal/cli/claims_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -136,6 +137,100 @@ func TestClaimsListScansDoNotCreateLocksOrMutateState(t *testing.T) {
 				t.Fatalf("claim-locks created or unreadable: %v", err)
 			}
 		})
+	}
+}
+
+func TestClaimsListEnforcesInclusiveClaimFileSizeLimit(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	writeClaimsListFixture(t, "cbx_partial.json", leaseClaim{LeaseID: "cbx_partial", Provider: "local-container"})
+	writeClaimsListRawFixture(t, "cbx_exact.json", sizedClaimsListJSON(t, "cbx_exact", int(maxLocalClaimInventoryFileBytes)))
+	writeClaimsListRawFixture(t, "cbx_large_valid.json", sizedClaimsListJSON(t, "cbx_large_valid", int(maxLocalClaimInventoryFileBytes+1)))
+	writeClaimsListRawFixture(t, "cbx_large_malformed.json", bytes.Repeat([]byte("{"), int(maxLocalClaimInventoryFileBytes+1)))
+
+	stdout, stderr, err := runClaimsList(t, "--json")
+	assertClaimsExitCode(t, err, 2)
+	if stderr != "" {
+		t.Fatalf("stderr=%q", stderr)
+	}
+	var output localClaimsListOutput
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatalf("decode output: %v\n%s", err, stdout)
+	}
+	if len(output.Claims) != 2 || output.Claims[0].LeaseID != "cbx_exact" || output.Claims[1].LeaseID != "cbx_partial" {
+		t.Fatalf("partial claims=%#v", output.Claims)
+	}
+	wantProblems := []localClaimProblem{
+		{File: "cbx_large_malformed.json", Code: "claim_too_large", Message: "claim file exceeds the 1 MiB inventory limit"},
+		{File: "cbx_large_valid.json", Code: "claim_too_large", Message: "claim file exceeds the 1 MiB inventory limit"},
+	}
+	if !reflect.DeepEqual(output.Problems, wantProblems) {
+		t.Fatalf("problems=%#v want=%#v", output.Problems, wantProblems)
+	}
+
+	human, humanStderr, humanErr := runClaimsList(t)
+	assertClaimsExitCode(t, humanErr, 2)
+	if humanStderr != "" {
+		t.Fatalf("human stderr=%q", humanStderr)
+	}
+	for _, want := range []string{
+		`leaseId: "cbx_exact"`,
+		`leaseId: "cbx_partial"`,
+		`"cbx_large_malformed.json": claim file exceeds the 1 MiB inventory limit (claim_too_large)`,
+		`"cbx_large_valid.json": claim file exceeds the 1 MiB inventory limit (claim_too_large)`,
+	} {
+		if !strings.Contains(human, want) {
+			t.Fatalf("human output missing %q:\n%s", want, human)
+		}
+	}
+	stateDir, err := crabboxStateDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(stateDir, "claim-locks")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("claim-locks created or unreadable: %v", err)
+	}
+}
+
+func TestClaimsListSizeLimitDoesNotChangeRuntimeClaimReader(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	const leaseID = "cbx_runtime_large"
+	writeClaimsListRawFixture(t, leaseID+".json", sizedClaimsListJSON(t, leaseID, int(maxLocalClaimInventoryFileBytes+1)))
+
+	stdout, _, inventoryErr := runClaimsList(t, "--json")
+	assertClaimsExitCode(t, inventoryErr, 2)
+	var output localClaimsListOutput
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatal(err)
+	}
+	if len(output.Claims) != 0 || len(output.Problems) != 1 || output.Problems[0].Code != "claim_too_large" {
+		t.Fatalf("inventory output=%#v", output)
+	}
+	stateDir, err := crabboxStateDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(stateDir, "claim-locks")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("inventory created claim locks: %v", err)
+	}
+
+	claim, err := readLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatalf("runtime reader rejected compatible large claim: %v", err)
+	}
+	if claim.LeaseID != leaseID {
+		t.Fatalf("runtime claim=%#v", claim)
+	}
+}
+
+func TestLocalClaimInventoryBoundsUnknownOrGrowingRead(t *testing.T) {
+	reader := &claimsListRepeatingReader{remaining: 1 * 1024 * 1024 * 1024}
+	data, tooLarge, err := readLocalClaimInventoryData(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantRead := maxLocalClaimInventoryFileBytes + 1
+	if !tooLarge || int64(len(data)) != wantRead || reader.read != wantRead {
+		t.Fatalf("tooLarge=%t bytes=%d sourceRead=%d want=%d", tooLarge, len(data), reader.read, wantRead)
 	}
 }
 
@@ -280,6 +375,7 @@ func TestClaimsListConcurrentDeleteAndChangeProduceDeterministicProblems(t *test
 		t.Setenv("XDG_STATE_HOME", t.TempDir())
 		writeClaimsListFixture(t, "cbx_change.json", leaseClaim{LeaseID: "cbx_change", Slug: "before"})
 		writeClaimsListFixture(t, "cbx_delete.json", leaseClaim{LeaseID: "cbx_delete"})
+		writeClaimsListFixture(t, "cbx_grow.json", leaseClaim{LeaseID: "cbx_grow"})
 		writeClaimsListFixture(t, "cbx_valid.json", leaseClaim{LeaseID: "cbx_valid", Provider: "local-container"})
 
 		reader := func(path, leaseID string, expected os.FileInfo) (leaseClaim, bool, error) {
@@ -291,6 +387,8 @@ func TestClaimsListConcurrentDeleteAndChangeProduceDeterministicProblems(t *test
 				}
 			case "cbx_delete":
 				mutate = func() error { return os.Remove(path) }
+			case "cbx_grow":
+				mutate = func() error { return os.Truncate(path, maxLocalClaimInventoryFileBytes+1) }
 			}
 			if mutate != nil {
 				result := make(chan error, 1)
@@ -310,7 +408,7 @@ func TestClaimsListConcurrentDeleteAndChangeProduceDeterministicProblems(t *test
 		if len(output.Claims) != 1 || output.Claims[0].LeaseID != "cbx_valid" {
 			t.Fatalf("partial claims=%#v", output.Claims)
 		}
-		if len(output.Problems) != 2 || len(output.Problems) > maxLocalClaimProblems {
+		if len(output.Problems) != 3 || len(output.Problems) > maxLocalClaimProblems {
 			t.Fatalf("problems=%#v", output.Problems)
 		}
 		for i, problem := range output.Problems {
@@ -568,6 +666,41 @@ func writeClaimsListRawFixture(t *testing.T, name string, data []byte) {
 	if err := os.WriteFile(filepath.Join(claimsDir, name), data, 0o600); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func sizedClaimsListJSON(t *testing.T, leaseID string, size int) []byte {
+	t.Helper()
+	prefix := []byte(fmt.Sprintf(`{"leaseID":%q,"padding":"`, leaseID))
+	suffix := []byte(`"}`)
+	if size < len(prefix)+len(suffix) {
+		t.Fatalf("claim fixture size %d is too small", size)
+	}
+	data := make([]byte, 0, size)
+	data = append(data, prefix...)
+	data = append(data, bytes.Repeat([]byte("x"), size-len(prefix)-len(suffix))...)
+	data = append(data, suffix...)
+	return data
+}
+
+type claimsListRepeatingReader struct {
+	remaining int64
+	read      int64
+}
+
+func (r *claimsListRepeatingReader) Read(p []byte) (int, error) {
+	if r.remaining == 0 {
+		return 0, io.EOF
+	}
+	n := int64(len(p))
+	if n > r.remaining {
+		n = r.remaining
+	}
+	for i := range p[:n] {
+		p[i] = 'x'
+	}
+	r.remaining -= n
+	r.read += n
+	return int(n), nil
 }
 
 func makeClaimsListDirectoryFixture(t *testing.T, name string) {


### PR DESCRIPTION
## Summary

- cap `crabbox claims list` at an inclusive 1 MiB per claim file
- reject known oversized files before allocation and bound concurrent growth with a limit-plus-one reader
- emit a stable `claim_too_large` problem while preserving valid partial output and exit code 2
- leave runtime and mutating claim readers unchanged

Closes https://github.com/openclaw/crabbox/issues/1373

## Verification

- exact 1 MiB acceptance and 1 MiB + 1 rejection tests
- malformed, valid, concurrent-growth, deterministic-output, and lock-free inventory race tests
- source-blind RSS proof: empty 49,381,376 B; 128 MiB sparse file 49,397,760 B; 1 GiB sparse file 49,414,144 B
- `go vet ./...`, docs validation, `gofmt`, and `git diff --check`
- P1 autoreview clean
