### PR TITLE
fix(ssh): persist static heartbeat lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 
 - Made AWS image deletion resume from owner-level durable snapshot claims after AMI deregistration or catalog cleanup failures, preventing stale ordinary and capability-variant records from remaining selectable.
+- Made static SSH heartbeats persist touched timestamps and explicit idle-timeout replacements across fresh CLI processes, while omitted overrides preserve the stored timeout. Thanks @coygeek.
 - Bounded Lambda MicroVM runner response-header waits without limiting uploads or streamed executions, while preserving injected HTTP clients. Thanks @SebTardif.
 - Fixed native local-container checkpoint forks to complete their recorded Docker runtime scope before claim creation, allowing immediate commands and safe normal stop while preserving exact claim validation.
 - Split fallback E2B HTTP ownership so finite lifecycle calls cannot hang indefinitely while uploads and process streams remain caller-controlled. Thanks @SebTardif.

--- a/docs/features/provider-authoring.md
+++ b/docs/features/provider-authoring.md
@@ -326,8 +326,17 @@ fresh key.
 `List` — core renders the table.
 
 `Touch` updates idle/state metadata on the provider when possible. Use the
-`internal/cli/provider_labels.go` helpers for safe label encoding. For static
-providers, an in-memory update is enough.
+`internal/cli/provider_labels.go` helpers for safe label encoding. The optional
+`TouchRequest.IdleTimeoutOverride` carries replacement intent: `nil` preserves
+the current lease timeout, while a non-nil value replaces it. Do not infer
+replacement intent from the effective `IdleTimeout` fallback.
+
+Static providers must commit touched lifecycle labels and any explicit timeout
+replacement to their durable local claim. `Resolve` must reconstruct lifecycle
+state from that claim, and `Touch` must compare-and-swap the exact canonical
+claim under its claim lock after revalidating provider, scope, resource, and
+host identity. Updating only the returned in-memory `Server` makes heartbeat
+success disappear in a fresh process and is not sufficient.
 
 `ReleaseLease` is called when a lease ends or expires. Make it idempotent; treat
 "not found" as success. Remove local claims and the per-lease key directory

--- a/docs/features/provider-live-smoke.md
+++ b/docs/features/provider-live-smoke.md
@@ -155,7 +155,7 @@ hermetic lifecycle tests, `scripts/live-smoke.sh`, dedicated live runners, and
 `//go:build smoke` tests. Regenerate it with
 `node scripts/generate-provider-matrix.mjs`; docs CI rejects drift.
 
-Current coverage: 79 providers; 4 with convention-named hermetic lifecycle tests, 59 with a live runner, 8 with tagged Go smoke tests, and 19 with none of those lifecycle surfaces.
+Current coverage: 79 providers; 5 with convention-named hermetic lifecycle tests, 59 with a live runner, 8 with tagged Go smoke tests, and 18 with none of those lifecycle surfaces.
 
 | Provider | Hermetic lifecycle | Live runner | Tagged Go smoke |
 | --- | --- | --- | --- |
@@ -224,7 +224,7 @@ Current coverage: 79 providers; 4 with convention-named hermetic lifecycle tests
 | [semaphore](../providers/semaphore.md) | — | matrix | — |
 | [smolvm](../providers/smolvm.md) | — | dedicated + matrix | — |
 | [sprites](../providers/sprites.md) | — | matrix | — |
-| [ssh](../providers/ssh.md) | — | — | — |
+| [ssh](../providers/ssh.md) | yes (`ssh`) | — | — |
 | [superserve](../providers/superserve.md) | — | dedicated + matrix | — |
 | [tart](../providers/tart.md) | — | matrix | — |
 | [tencentcloud](../providers/tencentcloud.md) | — | dedicated + matrix | — |

--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -620,7 +620,12 @@ available.
 rendering belongs to core.
 
 `Touch` should update provider labels/tags with idle and state metadata when the
-provider supports it. Static providers can update only the in-memory view.
+provider supports it. `TouchRequest.IdleTimeoutOverride` is non-nil only for an
+explicit replacement; omission must preserve the persisted timeout. Static
+providers must atomically compare-and-swap lifecycle labels and an optional
+timeout into the exact canonical local claim, then reconstruct later `Resolve`
+results from that claim. An in-memory-only static touch is not durable enough
+for heartbeat.
 
 `ReleaseLease` should be idempotent where practical. Remove local claims after the
 provider release succeeds or is known to be unnecessary.

--- a/docs/refactor/provider.md
+++ b/docs/refactor/provider.md
@@ -606,9 +606,10 @@ type ReleaseLeaseRequest struct {
 }
 
 type TouchRequest struct {
-	Lease       LeaseTarget
-	State       string
-	IdleTimeout time.Duration
+	Lease               LeaseTarget
+	State               string
+	IdleTimeout         time.Duration
+	IdleTimeoutOverride *time.Duration
 }
 ```
 

--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -156,9 +156,11 @@ func (a App) actionsHydrate(ctx context.Context, args []string) (err error) {
 		fmt.Fprintln(a.Stderr, "workspace owner released")
 	}()
 	ctx = contextWithWorkspaceOwner(owner.Context(), owner)
-	if _, err := updateLeaseClaimEndpointIfUnchanged(leaseID, ownedClaim, server, target); err != nil {
+	updatedClaim, err := updateLeaseClaimEndpointIfUnchanged(leaseID, ownedClaim, server, target)
+	if err != nil {
 		return err
 	}
+	SetServerLeaseClaimSnapshot(&server, updatedClaim, true)
 	a.registerCoordinatorLeaseBestEffort(ctx, cfg, LeaseTarget{Server: server, SSH: target, LeaseID: leaseID})
 	backend, err := loadBackend(cfg, runtimeForApp(a))
 	if err != nil {

--- a/internal/cli/claim.go
+++ b/internal/cli/claim.go
@@ -745,6 +745,32 @@ func updateLeaseClaimLabelsAndLastUsedIfUnchanged(leaseID string, expected lease
 	return updated, err
 }
 
+func updateLeaseClaimTouchIfUnchanged(leaseID string, expected leaseClaim, labels map[string]string, lastUsed time.Time, idleTimeoutOverride *time.Duration) (leaseClaim, error) {
+	if leaseID == "" {
+		return leaseClaim{}, nil
+	}
+	if idleTimeoutOverride != nil && *idleTimeoutOverride <= 0 {
+		return leaseClaim{}, exit(2, "lease %s idle timeout override must be positive", leaseID)
+	}
+	var updated leaseClaim
+	err := mutateLeaseClaimGuarded(leaseID, unchangedLeaseClaimGuard(leaseID, expected, true), func(claim *leaseClaim) error {
+		if claim.LeaseID == "" {
+			return nil
+		}
+		claim.Labels = cloneStringMap(labels)
+		claim.LastUsedAt = lastUsed.UTC().Format(time.RFC3339)
+		if idleTimeoutOverride != nil {
+			claim.IdleTimeoutSeconds = int(idleTimeoutOverride.Round(time.Second) / time.Second)
+			if claim.IdleTimeoutSeconds <= 0 {
+				return exit(2, "lease %s idle timeout override must be at least one second", leaseID)
+			}
+		}
+		updated = cloneLeaseClaim(*claim)
+		return nil
+	})
+	return updated, err
+}
+
 func updateLeaseClaimLabelsIfUnchangedAfter(leaseID string, expected leaseClaim, labels map[string]string, action func() error) (leaseClaim, error) {
 	if leaseID == "" {
 		return leaseClaim{}, nil

--- a/internal/cli/claim_test.go
+++ b/internal/cli/claim_test.go
@@ -1256,6 +1256,52 @@ func TestUpdateLeaseClaimLabelsAndLastUsedIfUnchanged(t *testing.T) {
 	}
 }
 
+func TestUpdateLeaseClaimTouchIfUnchangedCommitsOptionalTimeoutAtomically(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	const leaseID = "static_touch_claim"
+	expected, err := claimLeaseForRepoProviderScopePondWithLabels(
+		leaseID, "static-touch", "ssh", "", "", "/repo", 30*time.Minute,
+		map[string]string{"state": "ready", "idle_timeout_secs": "1800"},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	firstTouch := time.Date(2026, time.August, 16, 20, 0, 0, 0, time.UTC)
+	preserved, err := updateLeaseClaimTouchIfUnchanged(leaseID, expected, map[string]string{
+		"state": "ready", "idle_timeout_secs": "1800", "last_touched_at": leaseLabelTime(firstTouch),
+	}, firstTouch, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if preserved.IdleTimeoutSeconds != 1800 || preserved.LastUsedAt != firstTouch.Format(time.RFC3339) {
+		t.Fatalf("preserved claim=%#v", preserved)
+	}
+
+	secondTouch := firstTouch.Add(time.Minute)
+	override := 45 * time.Minute
+	replaced, err := updateLeaseClaimTouchIfUnchanged(leaseID, preserved, map[string]string{
+		"state": "ready", "idle_timeout_secs": "2700", "last_touched_at": leaseLabelTime(secondTouch),
+	}, secondTouch, &override)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if replaced.IdleTimeoutSeconds != 2700 || replaced.LastUsedAt != secondTouch.Format(time.RFC3339) || replaced.Labels["idle_timeout_secs"] != "2700" {
+		t.Fatalf("replaced claim=%#v", replaced)
+	}
+
+	if _, err := updateLeaseClaimTouchIfUnchanged(leaseID, preserved, nil, time.Now(), nil); err == nil || !strings.Contains(err.Error(), "claim changed") {
+		t.Fatalf("stale touch err=%v", err)
+	}
+	removeLeaseClaim(leaseID)
+	if _, err := updateLeaseClaimTouchIfUnchanged(leaseID, replaced, nil, time.Now(), nil); err == nil || !strings.Contains(err.Error(), "claim changed") {
+		t.Fatalf("raced-away touch err=%v", err)
+	}
+	if _, exists, err := readLeaseClaimWithPresence(leaseID); err != nil || exists {
+		t.Fatalf("raced-away touch recreated claim: exists=%t err=%v", exists, err)
+	}
+}
+
 func TestConditionalClaimEndpointActionUpdatesAtomically(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	leaseID := "cbx_conditionalendpoint123"

--- a/internal/cli/heartbeat.go
+++ b/internal/cli/heartbeat.go
@@ -44,8 +44,10 @@ func (a App) heartbeat(ctx context.Context, args []string) error {
 	if err := requireLeaseID(*id, "crabbox heartbeat --id <lease-id-or-slug>", cfg); err != nil {
 		return err
 	}
+	var idleTimeoutOverride *time.Duration
 	if idleTimeoutSet {
 		cfg.IdleTimeout = *idleTimeout
+		idleTimeoutOverride = idleTimeout
 	}
 
 	backend, err := loadBackend(cfg, runtimeForApp(a))
@@ -53,11 +55,7 @@ func (a App) heartbeat(ctx context.Context, args []string) error {
 		return err
 	}
 	if coordinator, ok := backend.(*coordinatorLeaseBackend); ok {
-		var override *time.Duration
-		if idleTimeoutSet {
-			override = idleTimeout
-		}
-		lease, err := coordinator.HeartbeatLease(ctx, *id, override)
+		lease, err := coordinator.HeartbeatLease(ctx, *id, idleTimeoutOverride)
 		if err != nil {
 			return err
 		}
@@ -116,12 +114,8 @@ func (a App) heartbeat(ctx context.Context, args []string) error {
 	}
 	var registeredLease *CoordinatorLease
 	if registeredCoord != nil {
-		var override *time.Duration
-		if idleTimeoutSet {
-			override = idleTimeout
-		}
 		canonicalLeaseID := lease.LeaseID
-		coordinatorLease, err := heartbeatCoordinatorLease(ctx, registeredCoord, canonicalLeaseID, cfg.Provider, override)
+		coordinatorLease, err := heartbeatCoordinatorLease(ctx, registeredCoord, canonicalLeaseID, cfg.Provider, idleTimeoutOverride)
 		if err != nil {
 			return err
 		}
@@ -134,9 +128,10 @@ func (a App) heartbeat(ctx context.Context, args []string) error {
 		registeredLease = &coordinatorLease
 	}
 	touched, err := sshBackend.Touch(ctx, TouchRequest{
-		Lease:       lease,
-		State:       state,
-		IdleTimeout: cfg.IdleTimeout,
+		Lease:               lease,
+		State:               state,
+		IdleTimeout:         cfg.IdleTimeout,
+		IdleTimeoutOverride: idleTimeoutOverride,
 	})
 	if err != nil {
 		return err

--- a/internal/cli/heartbeat_test.go
+++ b/internal/cli/heartbeat_test.go
@@ -169,7 +169,7 @@ func TestHeartbeatRegisteredModeUsesCoordinator(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if len(backend.touches) != 1 || backend.touches[0].IdleTimeout != time.Hour {
+	if len(backend.touches) != 1 || backend.touches[0].IdleTimeout != time.Hour || backend.touches[0].IdleTimeoutOverride == nil || *backend.touches[0].IdleTimeoutOverride != time.Hour {
 		t.Fatalf("registered heartbeat direct touches=%#v", backend.touches)
 	}
 }
@@ -264,7 +264,7 @@ func TestHeartbeatDirectProviderUsesTouchForExactClaim(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if len(backend.touches) != 1 || backend.touches[0].IdleTimeout != 45*time.Minute {
+	if len(backend.touches) != 1 || backend.touches[0].IdleTimeout != 45*time.Minute || backend.touches[0].IdleTimeoutOverride == nil || *backend.touches[0].IdleTimeoutOverride != 45*time.Minute {
 		t.Fatalf("touches=%#v", backend.touches)
 	}
 	var got leaseHeartbeatView
@@ -273,6 +273,18 @@ func TestHeartbeatDirectProviderUsesTouchForExactClaim(t *testing.T) {
 	}
 	if got.ID != backend.lease.LeaseID || got.IdleTimeout != "45m0s" || got.LastTouchedAt != "2026-08-16T20:00:00Z" {
 		t.Fatalf("heartbeat output=%#v", got)
+	}
+}
+
+func TestHeartbeatDirectProviderOmitsIdleTimeoutOverrideIntent(t *testing.T) {
+	backend := configureHeartbeatDirectTest(t, true)
+	if err := (App{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}).heartbeat(context.Background(), []string{
+		"--provider", heartbeatDirectProviderName, "--id", "direct-heartbeat",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(backend.touches) != 1 || backend.touches[0].IdleTimeoutOverride != nil {
+		t.Fatalf("omitted timeout carried replacement intent: %#v", backend.touches)
 	}
 }
 

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -843,9 +843,10 @@ func ValidateLeaseTargetProviderIdentity(lease LeaseTarget, expected ProviderIde
 }
 
 type TouchRequest struct {
-	Lease       LeaseTarget
-	State       string
-	IdleTimeout time.Duration
+	Lease               LeaseTarget
+	State               string
+	IdleTimeout         time.Duration
+	IdleTimeoutOverride *time.Duration
 }
 
 type ListRequest struct {

--- a/internal/cli/provider_exports.go
+++ b/internal/cli/provider_exports.go
@@ -326,6 +326,12 @@ func UpdateLeaseClaimLabelsAndLastUsedIfUnchanged(leaseID string, expected Lease
 	return updateLeaseClaimLabelsAndLastUsedIfUnchanged(leaseID, expected, labels, lastUsed)
 }
 
+// UpdateLeaseClaimTouchIfUnchanged atomically commits touched lifecycle labels,
+// last-use time, and an explicitly requested idle-timeout replacement.
+func UpdateLeaseClaimTouchIfUnchanged(leaseID string, expected LeaseClaim, labels map[string]string, lastUsed time.Time, idleTimeoutOverride *time.Duration) (LeaseClaim, error) {
+	return updateLeaseClaimTouchIfUnchanged(leaseID, expected, labels, lastUsed, idleTimeoutOverride)
+}
+
 func UpdateLeaseClaimLabelsIfUnchangedAfter(leaseID string, expected LeaseClaim, labels map[string]string, action func() error) (LeaseClaim, error) {
 	return updateLeaseClaimLabelsIfUnchangedAfter(leaseID, expected, labels, action)
 }
@@ -508,6 +514,10 @@ func DirectLeaseLabels(cfg Config, leaseID, slug, provider, market string, keep 
 
 func TouchDirectLeaseLabels(labels map[string]string, cfg Config, state string, now time.Time) map[string]string {
 	return touchDirectLeaseLabels(labels, cfg, state, now)
+}
+
+func TouchDirectLeaseLabelsWithIdleTimeoutOverride(labels map[string]string, cfg Config, state string, now time.Time, idleTimeoutOverride *time.Duration) map[string]string {
+	return touchDirectLeaseLabelsWithIdleTimeoutOverride(labels, cfg, state, now, idleTimeoutOverride)
 }
 
 func LeaseLabelTime(t time.Time) string {

--- a/internal/cli/provider_labels.go
+++ b/internal/cli/provider_labels.go
@@ -65,6 +65,10 @@ func directLeaseLabels(cfg Config, leaseID, slug, provider, market string, keep 
 }
 
 func touchDirectLeaseLabels(labels map[string]string, cfg Config, state string, now time.Time) map[string]string {
+	return touchDirectLeaseLabelsWithIdleTimeoutOverride(labels, cfg, state, now, nil)
+}
+
+func touchDirectLeaseLabelsWithIdleTimeoutOverride(labels map[string]string, cfg Config, state string, now time.Time, idleTimeoutOverride *time.Duration) map[string]string {
 	next := make(map[string]string, len(labels)+4)
 	for key, value := range labels {
 		next[key] = value
@@ -78,10 +82,14 @@ func touchDirectLeaseLabels(labels map[string]string, cfg Config, state string, 
 		next["created_at"] = leaseLabelTime(createdAt)
 	}
 	idleTimeout := cfg.IdleTimeout
-	if stored, ok := parseDurationSecondsLabel(next["idle_timeout_secs"]); ok {
-		idleTimeout = stored
-	} else if stored, ok := parseDurationSecondsLabel(next["idle_timeout"]); ok {
-		idleTimeout = stored
+	if idleTimeoutOverride != nil {
+		idleTimeout = *idleTimeoutOverride
+	} else {
+		if stored, ok := parseDurationSecondsLabel(next["idle_timeout_secs"]); ok {
+			idleTimeout = stored
+		} else if stored, ok := parseDurationSecondsLabel(next["idle_timeout"]); ok {
+			idleTimeout = stored
+		}
 	}
 	if idleTimeout <= 0 {
 		idleTimeout = defaultConfig().IdleTimeout

--- a/internal/cli/provider_labels_test.go
+++ b/internal/cli/provider_labels_test.go
@@ -102,6 +102,27 @@ func TestTouchDirectLeaseLabelsMovesExpiryForwardToTTLCap(t *testing.T) {
 	}
 }
 
+func TestTouchDirectLeaseLabelsExplicitIdleTimeoutOverridesStoredValue(t *testing.T) {
+	created := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	touched := created.Add(time.Minute)
+	labels := directLeaseLabels(Config{
+		TTL:         2 * time.Hour,
+		IdleTimeout: 30 * time.Minute,
+	}, "cbx_abcdef123456", "blue-lobster", "ssh", "", true, created)
+	override := 45 * time.Minute
+
+	got := touchDirectLeaseLabelsWithIdleTimeoutOverride(labels, Config{
+		TTL:         2 * time.Hour,
+		IdleTimeout: 5 * time.Minute,
+	}, "ready", touched, &override)
+	if got["idle_timeout"] != "2700" || got["idle_timeout_secs"] != "2700" {
+		t.Fatalf("idle timeout labels=%#v want explicit 2700", got)
+	}
+	if got["expires_at"] != leaseLabelTime(touched.Add(override)) {
+		t.Fatalf("expires_at=%q want=%q", got["expires_at"], leaseLabelTime(touched.Add(override)))
+	}
+}
+
 func TestParseLeaseLabelTimeAcceptsLegacyRFC3339(t *testing.T) {
 	legacy := "2026-05-01T12:00:00Z"
 	got, ok := parseLeaseLabelTime(legacy)

--- a/internal/providers/ssh/backend.go
+++ b/internal/providers/ssh/backend.go
@@ -392,6 +392,3 @@ func claimLeaseTargetForRepoConfig(leaseID, slug string, cfg Config, server Serv
 func resolveLeaseClaimForProvider(id, provider string) (core.LeaseClaim, bool, error) {
 	return core.ResolveLeaseClaimForProvider(id, provider)
 }
-func touchDirectLeaseLabels(labels map[string]string, cfg Config, state string, now time.Time) map[string]string {
-	return core.TouchDirectLeaseLabels(labels, cfg, state, now)
-}

--- a/internal/providers/ssh/backend.go
+++ b/internal/providers/ssh/backend.go
@@ -199,6 +199,7 @@ func (b *staticLeaseBackend) Touch(_ context.Context, req TouchRequest) (Server,
 		server.Status = state
 	}
 	core.SetServerLeaseClaimSnapshot(&server, updated, true)
+	b.refreshAcquiredLeaseServer(req.Lease.LeaseID, server)
 	return server, nil
 }
 
@@ -216,6 +217,14 @@ func (b *staticLeaseBackend) rememberAcquiredLease(lease LeaseTarget) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.acquired = lease
+}
+
+func (b *staticLeaseBackend) refreshAcquiredLeaseServer(leaseID string, server Server) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.acquired.LeaseID == leaseID {
+		b.acquired.Server = server
+	}
 }
 
 func (b *staticLeaseBackend) acquiredLeaseForID(id string) (LeaseTarget, bool) {

--- a/internal/providers/ssh/backend.go
+++ b/internal/providers/ssh/backend.go
@@ -3,6 +3,8 @@ package ssh
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -63,6 +65,15 @@ func (b *staticLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (L
 	lease := LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}
 	if err := claimLeaseTargetForRepoConfig(leaseID, serverSlug(server), cfg, server, target, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
 		return LeaseTarget{}, err
+	}
+	claim, claimed, exact, err := core.ResolveLeaseClaimForProviderWithExact(leaseID, staticProvider)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	if claimed && exact && staticLeaseClaimMatchesConfig(cfg, claim) {
+		core.SetServerLeaseClaimSnapshot(&lease.Server, claim, true)
+	} else if req.Repo.Root != "" {
+		return LeaseTarget{}, exit(4, "static lease %s claim changed after acquisition", leaseID)
 	}
 	b.rememberAcquiredLease(lease)
 	return lease, nil
@@ -157,11 +168,37 @@ func (b *staticLeaseBackend) ReleaseLeaseMessage(lease LeaseTarget) string {
 }
 
 func (b *staticLeaseBackend) Touch(_ context.Context, req TouchRequest) (Server, error) {
-	server := req.Lease.Server
-	if server.Labels == nil {
-		server.Labels = map[string]string{}
+	expected, exists, set := core.ServerLeaseClaimSnapshot(req.Lease.Server)
+	if !set || !exists {
+		return Server{}, exit(4, "static lease %s has no exact claim snapshot; refusing touch", req.Lease.LeaseID)
 	}
-	server.Labels = touchDirectLeaseLabels(server.Labels, b.Cfg, req.State, time.Now().UTC())
+	if err := validateStaticTouchIdentity(b.Cfg, req.Lease, expected); err != nil {
+		return Server{}, err
+	}
+	if req.IdleTimeoutOverride != nil && *req.IdleTimeoutOverride <= 0 {
+		return Server{}, exit(2, "static lease %s idle timeout override must be positive", req.Lease.LeaseID)
+	}
+
+	now := time.Now().UTC()
+	if b.RT.Clock != nil {
+		now = b.RT.Clock.Now().UTC()
+	}
+	cfg := b.Cfg
+	if expected.IdleTimeoutSeconds > 0 {
+		cfg.IdleTimeout = time.Duration(expected.IdleTimeoutSeconds) * time.Second
+	}
+	labels := staticLeaseLabelsFromClaim(expected)
+	labels = core.TouchDirectLeaseLabelsWithIdleTimeoutOverride(labels, cfg, req.State, now, req.IdleTimeoutOverride)
+	updated, err := core.UpdateLeaseClaimTouchIfUnchanged(req.Lease.LeaseID, expected, labels, now, req.IdleTimeoutOverride)
+	if err != nil {
+		return Server{}, err
+	}
+	server := req.Lease.Server
+	server.Labels = labels
+	if state := strings.TrimSpace(labels["state"]); state != "" {
+		server.Status = state
+	}
+	core.SetServerLeaseClaimSnapshot(&server, updated, true)
 	return server, nil
 }
 
@@ -259,7 +296,77 @@ func staticLeaseFromClaim(cfg Config, claim core.LeaseClaim) (Server, SSHTarget,
 			cfg.WindowsMode = claim.WindowsMode
 		}
 	}
-	return staticLease(cfg)
+	if claim.IdleTimeoutSeconds > 0 {
+		cfg.IdleTimeout = time.Duration(claim.IdleTimeoutSeconds) * time.Second
+	}
+	server, target, leaseID, err := staticLease(cfg)
+	if err != nil {
+		return Server{}, SSHTarget{}, "", err
+	}
+	server.Labels = staticLeaseLabelsFromClaim(claim)
+	if state := strings.TrimSpace(server.Labels["state"]); state != "" {
+		server.Status = state
+	}
+	core.SetServerLeaseClaimSnapshot(&server, claim, true)
+	return server, target, leaseID, nil
+}
+
+func staticLeaseLabelsFromClaim(claim core.LeaseClaim) map[string]string {
+	labels := make(map[string]string, len(claim.Labels)+6)
+	for key, value := range claim.Labels {
+		labels[key] = value
+	}
+	labels["lease"] = claim.LeaseID
+	labels["slug"] = claim.Slug
+	labels["provider"] = staticProvider
+	if claim.TargetOS != "" {
+		labels["target"] = claim.TargetOS
+	}
+	if claim.WindowsMode != "" {
+		labels["windows_mode"] = claim.WindowsMode
+	}
+	if claim.IdleTimeoutSeconds > 0 {
+		seconds := strconv.Itoa(claim.IdleTimeoutSeconds)
+		labels["idle_timeout"] = seconds
+		labels["idle_timeout_secs"] = seconds
+	}
+	if labels["created_at"] == "" {
+		labels["created_at"] = persistedClaimTimeLabel(claim.ClaimedAt)
+	}
+	if labels["last_touched_at"] == "" {
+		labels["last_touched_at"] = persistedClaimTimeLabel(claim.LastUsedAt)
+	}
+	return labels
+}
+
+func persistedClaimTimeLabel(value string) string {
+	for _, layout := range []string{time.RFC3339, time.RFC3339Nano} {
+		if parsed, err := time.Parse(layout, strings.TrimSpace(value)); err == nil {
+			return core.LeaseLabelTime(parsed)
+		}
+	}
+	return ""
+}
+
+func validateStaticTouchIdentity(cfg Config, lease LeaseTarget, claim core.LeaseClaim) error {
+	leaseID := strings.TrimSpace(lease.LeaseID)
+	if leaseID == "" || claim.LeaseID != leaseID {
+		return exit(4, "static lease claim ID mismatch: expected %s, found %s", leaseID, claim.LeaseID)
+	}
+	if claim.Provider != staticProvider || lease.Server.Provider != staticProvider || claim.Labels["provider"] != staticProvider {
+		return exit(4, "static lease %s provider identity mismatch", leaseID)
+	}
+	if claim.ProviderScope != core.ProviderClaimScope(staticProvider, cfg) {
+		return exit(4, "static lease %s provider scope mismatch", leaseID)
+	}
+	if claim.CloudID == "" || claim.CloudID != leaseID || lease.Server.CloudID != claim.CloudID || claim.Labels["lease"] != leaseID {
+		return exit(4, "static lease %s resource identity mismatch", leaseID)
+	}
+	host := strings.TrimSpace(claim.StaticHost)
+	if host == "" || strings.TrimSpace(cfg.Static.Host) != host || strings.TrimSpace(lease.SSH.Host) != host || strings.TrimSpace(lease.Server.PublicNet.IPv4.IP) != host {
+		return exit(4, "static lease %s host identity mismatch", leaseID)
+	}
+	return nil
 }
 
 func staticLeaseClaimMatchesConfig(cfg Config, claim core.LeaseClaim) bool {

--- a/internal/providers/ssh/backend_lifecycle_test.go
+++ b/internal/providers/ssh/backend_lifecycle_test.go
@@ -86,6 +86,43 @@ func TestStaticSSHTouchPersistsExplicitIdleTimeoutForFreshResolve(t *testing.T) 
 	}
 }
 
+func TestStaticSSHTouchRefreshesAcquiredLeaseCache(t *testing.T) {
+	cfg, lease, initial := acquireStaticLifecycleLease(t, 30*time.Minute)
+	touchedAt := unixLabelTime(t, initial.Labels["last_touched_at"]).Add(time.Minute)
+	backend := newStaticLifecycleBackend(cfg, touchedAt)
+	backend.rememberAcquiredLease(lease)
+
+	override := 45 * time.Minute
+	touched, err := backend.Touch(context.Background(), TouchRequest{
+		Lease:               lease,
+		State:               "busy",
+		IdleTimeoutOverride: &override,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resolved, err := backend.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved.Server.Labels["idle_timeout_secs"] != "2700" || !reflect.DeepEqual(resolved.Server.Labels, touched.Labels) {
+		t.Fatalf("cached resolve did not observe touch: resolved=%#v touched=%#v", resolved.Server.Labels, touched.Labels)
+	}
+	listed, err := backend.List(context.Background(), ListRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(listed) != 1 || !reflect.DeepEqual(listed[0].Labels, touched.Labels) {
+		t.Fatalf("cached list did not observe touch: listed=%#v touched=%#v", listed, touched.Labels)
+	}
+
+	backend.RT.Clock = staticLifecycleClock{now: touchedAt.Add(time.Minute)}
+	if _, err := backend.Touch(context.Background(), TouchRequest{Lease: resolved, State: "ready"}); err != nil {
+		t.Fatalf("touch using cached refreshed snapshot: %v", err)
+	}
+}
+
 func TestStaticSSHTouchWithoutOverridePreservesPersistedIdleTimeout(t *testing.T) {
 	cfg, lease, initial := acquireStaticLifecycleLease(t, 37*time.Minute)
 	touchedAt := unixLabelTime(t, initial.Labels["last_touched_at"]).Add(time.Minute)

--- a/internal/providers/ssh/backend_lifecycle_test.go
+++ b/internal/providers/ssh/backend_lifecycle_test.go
@@ -1,0 +1,284 @@
+package ssh
+
+import (
+	"context"
+	"errors"
+	"io"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type staticLifecycleClock struct{ now time.Time }
+
+func (c staticLifecycleClock) Now() time.Time { return c.now }
+
+func TestStaticSSHTouchPersistsExplicitIdleTimeoutForFreshResolve(t *testing.T) {
+	cfg, lease, initial := acquireStaticLifecycleLease(t, 30*time.Minute)
+	createdAt := initial.Labels["created_at"]
+	initialTouchedAt := initial.Labels["last_touched_at"]
+	touchedAt := unixLabelTime(t, initialTouchedAt).Add(2 * time.Minute)
+
+	backend := newStaticLifecycleBackend(cfg, touchedAt)
+	resolved, err := backend.Resolve(context.Background(), ResolveRequest{ID: initial.Slug})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved.LeaseID != lease.LeaseID {
+		t.Fatalf("resolved lease=%q want canonical %q", resolved.LeaseID, lease.LeaseID)
+	}
+	if resolved.Server.Labels["created_at"] != createdAt || resolved.Server.Labels["last_touched_at"] != initialTouchedAt {
+		t.Fatalf("resolve fabricated timestamps: labels=%#v claim=%#v", resolved.Server.Labels, initial.Labels)
+	}
+	if resolved.Server.Labels["idle_timeout_secs"] != "1800" {
+		t.Fatalf("resolved idle timeout=%q want persisted 1800", resolved.Server.Labels["idle_timeout_secs"])
+	}
+
+	override := 45 * time.Minute
+	touched, err := backend.Touch(context.Background(), TouchRequest{
+		Lease:               resolved,
+		State:               "busy",
+		IdleTimeout:         override,
+		IdleTimeoutOverride: &override,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if touched.ServerType.Name != resolved.Server.ServerType.Name {
+		t.Fatalf("touch changed server identity: touched=%#v resolved=%#v", touched, resolved.Server)
+	}
+	if touched.Status != "busy" || touched.Labels["state"] != "busy" {
+		t.Fatalf("touch response state=%q labels=%#v want busy", touched.Status, touched.Labels)
+	}
+
+	committed, exists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+	if err != nil || !exists {
+		t.Fatalf("read committed claim exists=%t err=%v", exists, err)
+	}
+	if committed.IdleTimeoutSeconds != 2700 || touched.Labels["idle_timeout_secs"] != "2700" {
+		t.Fatalf("timeout mismatch touched=%q claim=%d", touched.Labels["idle_timeout_secs"], committed.IdleTimeoutSeconds)
+	}
+	if committed.LastUsedAt != touchedAt.Format(time.RFC3339) || touched.Labels["last_touched_at"] != core.LeaseLabelTime(touchedAt) {
+		t.Fatalf("last touch mismatch touched=%q claim=%q want=%s", touched.Labels["last_touched_at"], committed.LastUsedAt, touchedAt.Format(time.RFC3339))
+	}
+	if touched.Labels["created_at"] != createdAt || !reflect.DeepEqual(touched.Labels, committed.Labels) {
+		t.Fatalf("touch response and committed labels differ: response=%#v claim=%#v", touched.Labels, committed.Labels)
+	}
+	if got := unixLabelTime(t, touched.Labels["expires_at"]); !got.Equal(touchedAt.Add(override)) {
+		t.Fatalf("expires=%s want=%s", got, touchedAt.Add(override))
+	}
+
+	freshCfg := cfg
+	freshCfg.IdleTimeout = 7 * time.Minute
+	fresh, err := newStaticLifecycleBackend(freshCfg, touchedAt.Add(time.Minute)).Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fresh.Server.Labels["idle_timeout_secs"] != "2700" || fresh.Server.Labels["last_touched_at"] != touched.Labels["last_touched_at"] || fresh.Server.Labels["created_at"] != createdAt {
+		t.Fatalf("fresh resolve disagrees with committed touch: fresh=%#v touched=%#v", fresh.Server.Labels, touched.Labels)
+	}
+	if fresh.Server.Status != "busy" || fresh.Server.Labels["state"] != "busy" {
+		t.Fatalf("fresh resolve state=%q labels=%#v want busy", fresh.Server.Status, fresh.Server.Labels)
+	}
+}
+
+func TestStaticSSHTouchWithoutOverridePreservesPersistedIdleTimeout(t *testing.T) {
+	cfg, lease, initial := acquireStaticLifecycleLease(t, 37*time.Minute)
+	touchedAt := unixLabelTime(t, initial.Labels["last_touched_at"]).Add(time.Minute)
+	backendCfg := cfg
+	backendCfg.IdleTimeout = 5 * time.Minute
+	backend := newStaticLifecycleBackend(backendCfg, touchedAt)
+	resolved, err := backend.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	touched, err := backend.Touch(context.Background(), TouchRequest{
+		Lease:       resolved,
+		State:       "ready",
+		IdleTimeout: 5 * time.Minute,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	committed, exists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+	if err != nil || !exists {
+		t.Fatalf("read committed claim exists=%t err=%v", exists, err)
+	}
+	if committed.IdleTimeoutSeconds != 2220 || touched.Labels["idle_timeout_secs"] != "2220" {
+		t.Fatalf("omitted override replaced timeout: response=%q claim=%d", touched.Labels["idle_timeout_secs"], committed.IdleTimeoutSeconds)
+	}
+	fresh, err := newStaticLifecycleBackend(backendCfg, touchedAt.Add(time.Minute)).Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fresh.Server.Labels["idle_timeout_secs"] != "2220" || fresh.Server.Labels["last_touched_at"] != core.LeaseLabelTime(touchedAt) {
+		t.Fatalf("fresh resolve lost preserved lifecycle: %#v", fresh.Server.Labels)
+	}
+}
+
+func TestStaticSSHTouchRejectsMismatchedIdentity(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(*testing.T, *LeaseTarget)
+	}{
+		{name: "canonical lease ID", mutate: func(_ *testing.T, lease *LeaseTarget) { lease.LeaseID = lease.Server.Labels["slug"] }},
+		{name: "provider", mutate: func(_ *testing.T, lease *LeaseTarget) { lease.Server.Provider = "aws" }},
+		{name: "scope", mutate: func(t *testing.T, lease *LeaseTarget) {
+			claim, exists, set := core.ServerLeaseClaimSnapshot(lease.Server)
+			if !exists || !set {
+				t.Fatal("resolved lease has no claim snapshot")
+			}
+			claim.ProviderScope = "other-scope"
+			core.SetServerLeaseClaimSnapshot(&lease.Server, claim, true)
+		}},
+		{name: "resource", mutate: func(_ *testing.T, lease *LeaseTarget) { lease.Server.CloudID = "static_replacement" }},
+		{name: "host", mutate: func(_ *testing.T, lease *LeaseTarget) { lease.SSH.Host = "replacement.example.test" }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cfg, lease, initial := acquireStaticLifecycleLease(t, 30*time.Minute)
+			backend := newStaticLifecycleBackend(cfg, unixLabelTime(t, initial.Labels["last_touched_at"]).Add(time.Minute))
+			resolved, err := backend.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID})
+			if err != nil {
+				t.Fatal(err)
+			}
+			test.mutate(t, &resolved)
+			if _, err := backend.Touch(context.Background(), TouchRequest{Lease: resolved, State: "ready"}); err == nil || !strings.Contains(err.Error(), "mismatch") {
+				t.Fatalf("touch error=%v want identity mismatch", err)
+			}
+			after, exists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+			if err != nil || !exists || !reflect.DeepEqual(after, initial) {
+				t.Fatalf("rejected touch changed claim: exists=%t err=%v before=%#v after=%#v", exists, err, initial, after)
+			}
+		})
+	}
+}
+
+func TestStaticSSHTouchRejectsConcurrentClaimReplacement(t *testing.T) {
+	cfg, lease, initial := acquireStaticLifecycleLease(t, 30*time.Minute)
+	backend := newStaticLifecycleBackend(cfg, unixLabelTime(t, initial.Labels["last_touched_at"]).Add(time.Minute))
+	resolved, err := backend.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacementLabels := make(map[string]string, len(initial.Labels)+1)
+	for key, value := range initial.Labels {
+		replacementLabels[key] = value
+	}
+	replacementLabels["replacement"] = "true"
+	replacement, err := core.UpdateLeaseClaimLabelsIfUnchanged(lease.LeaseID, initial, replacementLabels)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := backend.Touch(context.Background(), TouchRequest{Lease: resolved, State: "ready"}); err == nil || !strings.Contains(err.Error(), "claim changed") {
+		t.Fatalf("touch error=%v want claim changed", err)
+	}
+	after, exists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+	if err != nil || !exists || !reflect.DeepEqual(after, replacement) {
+		t.Fatalf("touch overwrote replacement: exists=%t err=%v replacement=%#v after=%#v", exists, err, replacement, after)
+	}
+}
+
+func TestStaticSSHProviderReplacementFailsClosed(t *testing.T) {
+	cfg, lease, initial := acquireStaticLifecycleLease(t, 30*time.Minute)
+	backend := newStaticLifecycleBackend(cfg, unixLabelTime(t, initial.Labels["last_touched_at"]).Add(time.Minute))
+	resolved, err := backend.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var replacement core.LeaseClaim
+	if err := core.WithDurableLeaseClaimLock(lease.LeaseID, func(claim *core.LeaseClaim, exists bool, persist func() error) error {
+		if !exists {
+			return errors.New("claim disappeared before replacement")
+		}
+		claim.Provider = "aws"
+		claim.ProviderScope = "region:replacement"
+		claim.CloudID = "i-replacement"
+		claim.StaticHost = "replacement.example.test"
+		if err := persist(); err != nil {
+			return err
+		}
+		replacement = *claim
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := backend.Touch(context.Background(), TouchRequest{Lease: resolved, State: "ready"}); err == nil || !strings.Contains(err.Error(), "claim changed") {
+		t.Fatalf("touch error=%v want claim changed", err)
+	}
+	after, exists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+	if err != nil || !exists || !reflect.DeepEqual(after, replacement) {
+		t.Fatalf("provider replacement was not preserved: exists=%t err=%v replacement=%#v after=%#v", exists, err, replacement, after)
+	}
+
+	fresh := newStaticLifecycleBackend(cfg, time.Now().UTC())
+	unclaimed, err := fresh.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, exists, set := core.ServerLeaseClaimSnapshot(unclaimed.Server); exists || set {
+		t.Fatalf("provider-mismatched exact claim authorized static resolve: %#v", unclaimed.Server)
+	}
+}
+
+func TestStaticSSHTouchDoesNotRecreateRacedAwayClaim(t *testing.T) {
+	cfg, lease, initial := acquireStaticLifecycleLease(t, 30*time.Minute)
+	backend := newStaticLifecycleBackend(cfg, unixLabelTime(t, initial.Labels["last_touched_at"]).Add(time.Minute))
+	resolved, err := backend.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	core.RemoveLeaseClaim(lease.LeaseID)
+
+	if _, err := backend.Touch(context.Background(), TouchRequest{Lease: resolved, State: "ready"}); err == nil || !strings.Contains(err.Error(), "claim changed") {
+		t.Fatalf("touch error=%v want claim changed", err)
+	}
+	if claim, exists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID); err != nil || exists {
+		t.Fatalf("raced-away claim was recreated: exists=%t err=%v claim=%#v", exists, err, claim)
+	}
+}
+
+func acquireStaticLifecycleLease(t *testing.T, idleTimeout time.Duration) (Config, LeaseTarget, core.LeaseClaim) {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	oldWait := waitForSSH
+	waitForSSH = func(context.Context, *SSHTarget, io.Writer) error { return nil }
+	t.Cleanup(func() { waitForSSH = oldWait })
+
+	cfg := core.BaseConfig()
+	cfg.Provider = staticProvider
+	cfg.TargetOS = core.TargetLinux
+	cfg.Static.Host = "static.example.test"
+	cfg.Static.ID = "static_heartbeat"
+	cfg.Static.Name = "heartbeat-static"
+	cfg.IdleTimeout = idleTimeout
+	backend := NewStaticSSHLeaseBackend(Provider{}.Spec(), cfg, Runtime{Stderr: io.Discard}).(*staticLeaseBackend)
+	lease, err := backend.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim, exists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+	if err != nil || !exists {
+		t.Fatalf("read acquired claim exists=%t err=%v", exists, err)
+	}
+	return cfg, lease, claim
+}
+
+func newStaticLifecycleBackend(cfg Config, now time.Time) *staticLeaseBackend {
+	return NewStaticSSHLeaseBackend(Provider{}.Spec(), cfg, Runtime{Stderr: io.Discard, Clock: staticLifecycleClock{now: now}}).(*staticLeaseBackend)
+}
+
+func unixLabelTime(t *testing.T, value string) time.Time {
+	t.Helper()
+	seconds, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		t.Fatalf("parse timestamp label %q: %v", value, err)
+	}
+	return time.Unix(seconds, 0).UTC()
+}


### PR DESCRIPTION
## Summary

- distinguish omitted heartbeat timeouts from explicit replacements in the provider touch contract
- restore persisted static-SSH lifecycle state instead of synthesizing fresh defaults and timestamps
- atomically compare-and-swap the exact static lease claim on heartbeat, rejecting provider/scope/resource/host mismatches and replacement races
- preserve non-default timeouts when the override is omitted
- refresh an already-acquired matching static lease cache only after the durable claim update succeeds
- remove the obsolete SSH-package touch-label forwarding helper reported by Deadcode

Closes https://github.com/openclaw/crabbox/issues/1369

## Rebase

- rebased onto `25df71fe515167c0ea55b9eb1a48d681bcdd747c`, a direct descendant of required base `e648395ace0d8418194576fed6b950755935acf8`
- heartbeat commit: `cbcab9a769ead485b6eb1d2114025c9633b887e0` → `32abd8478bcfe85507f16df2ca1b0c13846cb55a`
- CI cleanup: `b700bc40` → `954db0bb8c6f46fd435f86e3bf452d7552b4b68c`
- acquired-cache follow-up: `40e712e17b1b06f6976ea777a5ee5d86b361b5d5`
- the Coy Geek co-author trailer is preserved; base overlaps were additive changelog entries only

## Verification

- Deadcode: `go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...` produced no output locally and in the clean final-head remote proof
- focused race suite: heartbeat, Static SSH lifecycle, acquired-cache refresh, direct-label overrides, atomic claim touch, and concurrent claim mutation tests
- fresh-process proof: `TestStaticSSHTouchPersistsExplicitIdleTimeoutForFreshResolve`
- same-process proof: `TestStaticSSHTouchRefreshesAcquiredLeaseCache` covers Resolve, List, and a second Touch
- `go vet ./...`
- `scripts/check-docs.sh`
- `gofmt`, `git diff --check`, clean worktree
- final P1 Codex autoreview clean: no accepted/actionable findings
- clean final-head Blacksmith proof: https://github.com/openclaw/crabbox/actions/runs/31999694233 (`tbx_01m074pb85z7ek6jzd4gfvdr9m`, Go 1.26.5)

## Source-blind localhost proof

Built the rebased CLI, used isolated claim/config directories, and exercised a real retained Static SSH lease against localhost. Each command below was a separate process; identity and key-path fields are omitted from the copied output.

```text
initial run: lease=static_localhost provider=ssh idle_timeout=30m0s exit=0

heartbeat --idle-timeout 45m:
{"id":"static_localhost","provider":"ssh","state":"ready","idleTimeout":"45m0s","expiresAt":"2026-08-17T06:38:03Z"}

fresh inspect:
{"id":"static_localhost","provider":"ssh","target":"macos","state":"ready","idleTimeout":"45m0s","labels":{"idle_timeout":"2700","idle_timeout_secs":"2700"}}

heartbeat with --idle-timeout omitted:
{"id":"static_localhost","provider":"ssh","state":"ready","idleTimeout":"45m0s","expiresAt":"2026-08-17T06:38:13Z"}

second fresh inspect:
{"id":"static_localhost","provider":"ssh","target":"macos","state":"ready","idleTimeout":"45m0s","labels":{"idle_timeout":"2700","idle_timeout_secs":"2700"}}

heartbeat --idle-timeout 0s:
idle timeout must be positive
exit=2

fresh inspect after rejected input:
{"id":"static_localhost","provider":"ssh","target":"macos","state":"ready","idleTimeout":"45m0s","labels":{"idle_timeout":"2700","idle_timeout_secs":"2700"}}

cleanup: released static lease=static_localhost host=localhost
```
