### PR TITLE
fix(checkpoints): preserve local container claim scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 
 - Bounded Lambda MicroVM runner response-header waits without limiting uploads or streamed executions, while preserving injected HTTP clients. Thanks @SebTardif.
+- Fixed native local-container checkpoint forks to complete their recorded Docker runtime scope before claim creation, allowing immediate commands and safe normal stop while preserving exact claim validation.
 - Rejected native Jujutsu and other unsupported local sync sources before delegated archive providers can provision or execute a remote sandbox.
 - Accepted explicit local-container architecture assertions only when the selected Docker or Podman daemon reports a matching native architecture, without enabling emulation. Thanks @coygeek.
 - Omitted coordinator-only history commands from failure digests when run history is unavailable, while preserving direct lease recovery guidance.

--- a/internal/providers/localcontainer/backend.go
+++ b/internal/providers/localcontainer/backend.go
@@ -88,7 +88,7 @@ func newBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.B
 		if isPodmanRuntime(cfg.LocalContainer.Runtime) {
 			return podmanScopeForConfig(ctx, cfg)
 		}
-		return checkpointScopeForServer(ctx, cfg, core.Server{})
+		return checkpointScopeForServer(ctx, cfg, core.Server{Labels: cfg.LocalContainer.CheckpointMetadata})
 	}
 	b.validateRuntimeScope = validateCheckpointScope
 	b.confirmContainerAbsent = b.exactContainerAbsent
@@ -183,16 +183,21 @@ func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.Le
 	if err := validateCheckpointFork(ctx, cfg); err != nil {
 		return core.LeaseTarget{}, err
 	}
-	if len(cfg.LocalContainer.CheckpointMetadata) == 0 {
+	if !hasCompleteCapturedRuntimeScope(cfg.LocalContainer.CheckpointMetadata) {
 		scope, err := b.captureRuntimeScope(ctx, cfg)
 		if err != nil {
 			return core.LeaseTarget{}, err
 		}
-		if strings.TrimSpace(scope.DaemonID) == "" {
-			return core.LeaseTarget{}, core.Exit(2, "local-container runtime identity is unavailable; refusing to create an unscoped lease")
+		completedScope := checkpointScopeMetadata(scope)
+		if !hasCompleteCapturedRuntimeScope(completedScope) {
+			return core.LeaseTarget{}, core.Exit(2, "local-container runtime identity is incomplete; refusing to create an unscoped lease")
 		}
-		cfg.LocalContainer.CheckpointMetadata = checkpointScopeMetadata(scope)
-		b.cfg.LocalContainer.CheckpointMetadata = checkpointScopeMetadata(scope)
+		metadata := cloneLabels(cfg.LocalContainer.CheckpointMetadata)
+		for _, key := range checkpointScopeMetadataKeys {
+			metadata[key] = completedScope[key]
+		}
+		cfg.LocalContainer.CheckpointMetadata = cloneLabels(metadata)
+		b.cfg.LocalContainer.CheckpointMetadata = cloneLabels(metadata)
 	}
 	leaseID := core.NewLeaseID()
 	containers, err := b.listContainers(ctx)

--- a/internal/providers/localcontainer/backend_test.go
+++ b/internal/providers/localcontainer/backend_test.go
@@ -2149,6 +2149,112 @@ func TestAcquirePinsDockerLifecycleToCapturedContext(t *testing.T) {
 	}
 }
 
+func TestAcquireCheckpointForkCompletesClaimRuntimeScope(t *testing.T) {
+	const (
+		checkpointImageID  = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+		checkpointImage    = "crabbox-checkpoint-pinned"
+		checkpointUser     = "checkpoint-user"
+		checkpointWorkRoot = "/checkpoint/work"
+	)
+	binDir := t.TempDir()
+	dockerScript := `#!/bin/sh
+if [ "$1" = "--context" ]; then
+  shift 2
+fi
+case "$1" in
+  info) printf '%s\n' 'daemon-pinned' ;;
+  image) printf '%s\n' 'sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef' ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(binDir, "docker"), []byte(dockerScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	b, runner, _, leaseID, _, _ := pendingAcquireBackend(t)
+	originalRun := runner.run
+	var dockerRunArgs []string
+	runner.run = func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		if len(req.Args) < 3 || req.Args[0] != "--context" || req.Args[1] != "pinned-context" {
+			t.Fatalf("Docker lifecycle command was not pinned: %v", req.Args)
+		}
+		req.Args = req.Args[2:]
+		if firstArg(req.Args) == "run" {
+			dockerRunArgs = append([]string(nil), req.Args...)
+		}
+		return originalRun(req)
+	}
+	checkpointMetadata := map[string]string{
+		checkpointMetadataRuntime:  "docker",
+		checkpointMetadataContext:  "pinned-context",
+		checkpointMetadataDaemonID: "daemon-pinned",
+		checkpointMetadataUser:     checkpointUser,
+		checkpointMetadataWorkRoot: checkpointWorkRoot,
+	}
+	if err := (Provider{}).ApplyNativeCheckpointForkConfig(core.NativeCheckpointForkRequest{
+		Config: &b.cfg,
+		Record: core.NativeCheckpointForkRecord{
+			Kind:     core.CheckpointKindDockerCommit,
+			ImageID:  checkpointImageID,
+			Name:     checkpointImage,
+			Metadata: checkpointMetadata,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	applyDefaults(&b.cfg)
+	captures := 0
+	b.captureRuntimeScope = func(context.Context, core.Config) (checkpointScope, error) {
+		captures++
+		return checkpointScope{
+			Runtime:  "docker",
+			Context:  "pinned-context",
+			Config:   "/tmp/docker-config",
+			Endpoint: "unix:///pinned.sock",
+			DaemonID: "daemon-pinned",
+		}, nil
+	}
+	b.waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error { return nil }
+	lease, err := b.Acquire(context.Background(), core.AcquireRequest{Keep: true, Repo: core.Repo{Root: t.TempDir()}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if captures != 1 {
+		t.Fatalf("runtime scope captures=%d, want 1", captures)
+	}
+	for key, want := range map[string]string{
+		checkpointMetadataForkID:   checkpointImageID,
+		checkpointMetadataForkName: checkpointImage,
+		checkpointMetadataUser:     checkpointUser,
+		checkpointMetadataWorkRoot: checkpointWorkRoot,
+	} {
+		if got := b.cfg.LocalContainer.CheckpointMetadata[key]; got != want {
+			t.Fatalf("checkpoint metadata %s=%q, want %q", key, got, want)
+		}
+	}
+	if !slices.Contains(dockerRunArgs, checkpointImageID) {
+		t.Fatalf("Docker run did not use checkpoint image id: %v", dockerRunArgs)
+	}
+	for key, want := range map[string]string{
+		"image":     checkpointImage,
+		"ssh_user":  checkpointUser,
+		"work_root": checkpointWorkRoot,
+	} {
+		if got := labelFromRunArgs(t, dockerRunArgs, key); got != want {
+			t.Fatalf("Docker run label %s=%q, want %q", key, got, want)
+		}
+	}
+	claim, err := core.ReadLeaseClaim(*leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasCompleteCapturedRuntimeScope(claim.Labels) || claim.Labels[checkpointMetadataConfig] != "/tmp/docker-config" || claim.Labels[checkpointMetadataEndpoint] != "unix:///pinned.sock" {
+		t.Fatalf("checkpoint fork claim scope=%#v", claim.Labels)
+	}
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatalf("release checkpoint fork: %v", err)
+	}
+}
+
 func TestUnclaimedRollbackContinuesSidecarCleanupAfterError(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("XDG_STATE_HOME", t.TempDir())

--- a/internal/providers/localcontainer/checkpoint.go
+++ b/internal/providers/localcontainer/checkpoint.go
@@ -262,10 +262,32 @@ func inspectCheckpointTag(ctx context.Context, scope checkpointScope, image core
 
 func checkpointScopeForServer(ctx context.Context, cfg core.Config, server core.Server) (checkpointScope, error) {
 	runtimeName := leaseRuntime(server, cfg.LocalContainer.Runtime)
-	if metadata := checkpointScopeMetadataFromLabels(server.Labels); len(metadata) != 0 {
+	scopeLabels := server.Labels
+	if claim, exists, set := core.ServerLeaseClaimSnapshot(server); set && exists {
+		scopeLabels = claim.Labels
+	}
+	if metadata := checkpointScopeMetadataFromLabels(scopeLabels); len(metadata) != 0 {
 		scope := checkpointScopeFromMetadata(metadata, runtimeName)
 		if err := validateCheckpointScope(ctx, scope); err != nil {
 			return checkpointScope{}, err
+		}
+		if scope.Config == "" && scope.Host == "" {
+			configPath, err := checkpointConfigPath()
+			if err != nil {
+				return checkpointScope{}, err
+			}
+			scope.Config = configPath
+		}
+		if scope.Endpoint == "" {
+			if scope.Host != "" {
+				scope.Endpoint = scope.Host
+			} else if scope.Context != "" {
+				endpoint, err := checkpointContextEndpoint(ctx, scope)
+				if err != nil {
+					return checkpointScope{}, err
+				}
+				scope.Endpoint = endpoint
+			}
 		}
 		return scope, nil
 	}

--- a/internal/providers/localcontainer/checkpoint_test.go
+++ b/internal/providers/localcontainer/checkpoint_test.go
@@ -284,6 +284,48 @@ func TestCheckpointScopeForServerUsesPersistedLabels(t *testing.T) {
 	}
 }
 
+func TestCheckpointScopeForServerUsesExactClaimSnapshot(t *testing.T) {
+	binDir := writeCheckpointScopeDocker(t, "unix:///claim/docker.sock", "daemon-123")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("DOCKER_CONTEXT", "ambient-invalid")
+	t.Setenv("DOCKER_HOST", "tcp://ambient.invalid:2376")
+	server := core.Server{Labels: map[string]string{
+		checkpointMetadataRuntime:  "docker",
+		checkpointMetadataContext:  "remote-context",
+		checkpointMetadataDaemonID: "daemon-123",
+	}}
+	claimLabels := cloneLabels(server.Labels)
+	claimLabels[checkpointMetadataConfig] = "/claim/docker-config"
+	claimLabels[checkpointMetadataEndpoint] = "unix:///claim/docker.sock"
+	core.SetServerLeaseClaimSnapshot(&server, core.LeaseClaim{Labels: claimLabels}, true)
+	scope, err := checkpointScopeForServer(context.Background(), core.Config{}, server)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if scope.Context != "remote-context" || scope.Config != "/claim/docker-config" || scope.Endpoint != "unix:///claim/docker.sock" || scope.DaemonID != "daemon-123" {
+		t.Fatalf("claim scope=%#v", scope)
+	}
+}
+
+func TestCheckpointScopeForServerCompletesPrivateRoutingOmittedFromLabels(t *testing.T) {
+	binDir := writeCheckpointScopeDocker(t, "unix:///tmp/docker.sock", "daemon-123")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("DOCKER_CONTEXT", "ambient-invalid")
+	t.Setenv("DOCKER_HOST", "tcp://ambient.invalid:2376")
+	labels := map[string]string{
+		checkpointMetadataRuntime:  "docker",
+		checkpointMetadataContext:  "remote-context",
+		checkpointMetadataDaemonID: "daemon-123",
+	}
+	scope, err := checkpointScopeForServer(context.Background(), core.Config{}, core.Server{Labels: labels})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if scope.Context != "remote-context" || scope.Endpoint != "unix:///tmp/docker.sock" || scope.Config == "" || scope.DaemonID != "daemon-123" {
+		t.Fatalf("completed scope=%#v", scope)
+	}
+}
+
 func TestCheckpointMetadataForServerPreservesUserAndWorkRoot(t *testing.T) {
 	metadata := checkpointMetadataForServer(
 		checkpointScope{Runtime: "docker", DaemonID: "daemon-123"},


### PR DESCRIPTION
## Summary

- Real Docker live testing of https://github.com/openclaw/crabbox/pull/1376 exposed native local-container docker-commit forks provisioning a container, then failing exact-claim validation before command/normal stop.
- Root cause: public container metadata intentionally omitted private Docker config/endpoint routing fields; checkpoint creation did not preferentially use the carried exact claim snapshot, and fork acquisition treated partial checkpoint scope as complete.
- Fix: persist exact claim scope into new checkpoints, reconstruct and validate partial legacy scope before claim creation, and keep exact container/runtime/daemon validation unchanged.
- No new configuration or secrets. The previously landed checkpoint lifecycle docs remain current; this follow-up adds its user-visible fix to the changelog.

## Proof

- gofmt and git diff --check clean.
- `go test -race -count=1 ./internal/providers/localcontainer` passed.
- `go test -count=1 ./internal/cli -run '^Test.*Checkpoint.*$'` passed.
- Focused local-container lease-output/claim tests and the full provider package passed.
- CLI build passed.
- Codex autoreview clean with no accepted/actionable findings.
- Four real isolated-state Docker lifecycle passes succeeded after the fix. The final source-blind pass used retained session handle source lease `cbx_7bfd1ce725b3`, archive checkpoint `chk_bb5b7419b4ac4784`, native checkpoint `chk_7adb6e36fafb672d`, archive fork `cbx_05b57fd4b440`, and native fork `cbx_bd8e0d6a1e8d`. It proved archive create/restore/fork, native create/verify/fork, successful marker commands, lastUsedAt advancement only after successful use, dry-run safety, AND/kind prune filters, legacy missing-lastUsedAt fallback without eager rewrite, provider-first Docker image deletion, normal stop, and exact cleanup. All resources are gone.
- Documentation site build passed and rendered `--unused-for`; the lifecycle/cron docs are already on main via https://github.com/openclaw/crabbox/pull/1376.
