### PR TITLE
fix(aws): resume partial image deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- Made AWS image deletion resume from owner-level durable snapshot claims after AMI deregistration or catalog cleanup failures, preventing stale ordinary and capability-variant records from remaining selectable.
 - Bounded Lambda MicroVM runner response-header waits without limiting uploads or streamed executions, while preserving injected HTTP clients. Thanks @SebTardif.
 - Rejected native Jujutsu and other unsupported local sync sources before delegated archive providers can provision or execute a remote sandbox.
 - Accepted explicit local-container architecture assertions only when the selected Docker or Podman daemon reports a matching native architecture, without enabling emulation. Thanks @coygeek.

--- a/worker/src/aws.ts
+++ b/worker/src/aws.ts
@@ -1412,19 +1412,22 @@ export class EC2SpotClient {
     };
   }
 
-  async deleteImage(imageID: string): Promise<void> {
+  async deleteImage(imageID: string, knownSnapshotIDs?: string[]): Promise<void> {
     if (imageID.startsWith("snap-")) {
       await this.deleteSnapshotWithRetry(imageID);
       return;
     }
-    const image = await this.getImage(imageID);
+    const snapshotIDs =
+      knownSnapshotIDs === undefined
+        ? ((await this.getImage(imageID)).snapshots ?? [])
+        : uniqueStrings(knownSnapshotIDs);
     await this.ec2("DeregisterImage", { ImageId: imageID }).catch((error: unknown) => {
       const message = error instanceof Error ? error.message : String(error);
       if (!message.includes("InvalidAMIID.NotFound")) {
         throw error;
       }
     });
-    for (const snapshotID of image.snapshots ?? []) {
+    for (const snapshotID of snapshotIDs) {
       // oxlint-disable-next-line eslint/no-await-in-loop -- EBS snapshot deletes are independent cleanup calls.
       await this.deleteSnapshotWithRetry(snapshotID);
     }

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -13822,7 +13822,7 @@ export class FleetCoordinator {
       if (deleteBlocked) {
         return json(deleteBlocked.body, { status: deleteBlocked.status });
       }
-      await providerForRegion.deleteImage(decodedImageID, kind);
+      await providerForRegion.deleteImage(decodedImageID, kind, metadata);
       return json({ imageID: decodedImageID, deleted: true });
     }
     if (method === "POST" && action === "promote") {
@@ -16905,6 +16905,73 @@ function runEventKey(runID: string, seq: number): string {
 
 function createdAWSImageKey(imageID: string): string {
   return `image:aws:created:${imageID}`;
+}
+
+const awsImageDeletionClaimVersion = 1;
+
+interface AWSImageDeletionClaim {
+  version: typeof awsImageDeletionClaimVersion;
+  imageID: string;
+  metadata: ProviderImage;
+  snapshotIDs: string[];
+  phase: "claimed" | "provider-deleted";
+  claimedAt: string;
+  providerDeletedAt?: string;
+}
+
+function awsImageDeletionClaimKey(imageID: string): string {
+  return `image:aws:deletion:${encodeURIComponent(imageID)}`;
+}
+
+function validAWSImageDeletionClaim(
+  value: unknown,
+  imageID: string,
+): value is AWSImageDeletionClaim {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const claim = value as Partial<AWSImageDeletionClaim>;
+  return (
+    claim.version === awsImageDeletionClaimVersion &&
+    claim.imageID === imageID &&
+    claim.metadata?.id === imageID &&
+    claim.metadata.provider === "aws" &&
+    Array.isArray(claim.snapshotIDs) &&
+    claim.snapshotIDs.every((snapshotID) => typeof snapshotID === "string" && snapshotID !== "") &&
+    (claim.phase === "claimed" || claim.phase === "provider-deleted") &&
+    typeof claim.claimedAt === "string"
+  );
+}
+
+function awsImageDeletionSnapshotIDs(image: ProviderImage): string[] {
+  return [
+    ...new Set((image.snapshots ?? []).map((snapshotID) => snapshotID.trim()).filter(Boolean)),
+  ];
+}
+
+function awsImageDeletionMetadata(
+  imageID: string,
+  described: ProviderImage,
+  stored?: Partial<ProviderImage>,
+): ProviderImage {
+  const merged = mergeAWSImageMetadata(described, stored);
+  const snapshots = awsImageDeletionSnapshotIDs(described);
+  const metadata: ProviderImage = {
+    id: imageID,
+    name: merged.name,
+    state: merged.state,
+    provider: "aws",
+    kind: merged.kind ?? (imageID.startsWith("snap-") ? "aws-ebs-snapshot" : "aws-ami"),
+    resourceID: imageID,
+    snapshots,
+  };
+  const region = sanitizeAWSRegion(merged.region ?? "");
+  if (region) metadata.region = region;
+  if (merged.target) metadata.target = merged.target;
+  if (merged.os) metadata.os = merged.os;
+  if (merged.windowsMode) metadata.windowsMode = merged.windowsMode;
+  if (merged.serverType) metadata.serverType = merged.serverType;
+  if (merged.architecture) metadata.architecture = merged.architecture;
+  if (merged.capabilities) metadata.capabilities = structuredClone(merged.capabilities);
+  return metadata;
 }
 
 function createdProviderImageKey(provider: Provider, imageID: string): string {
@@ -22260,7 +22327,7 @@ interface CloudProvider {
     strategy: "image" | "disk-snapshot",
   ): Promise<ProviderImage>;
   getImage(imageID: string, kind?: string): Promise<ProviderImage>;
-  deleteImage(imageID: string, kind?: string): Promise<void>;
+  deleteImage(imageID: string, kind?: string, metadata?: ProviderImage): Promise<void>;
   storedImageMetadata(imageID: string): Promise<ProviderImage | undefined>;
   decorateImage(image: ProviderImage, metadata?: Partial<ProviderImage>): ProviderImage;
   validateDeleteImage(
@@ -24071,21 +24138,41 @@ export class AWSProvider implements CloudProvider {
     return this.client.fastSnapshotRestoreStatus(snapshotIDs, availabilityZones);
   }
 
-  async deleteImage(imageID: string): Promise<void> {
-    await this.client.deleteImage(imageID);
-    const catalog = await this.storage.list<PromotedImageRecord>({ prefix: "image:aws:catalog:" });
-    await Promise.all(
-      [...catalog.entries()]
-        .filter(([, image]) => image.id === imageID)
-        .map(([key]) => this.storage.delete(key)),
-    );
+  async deleteImage(imageID: string, _kind?: string, metadata?: ProviderImage): Promise<void> {
+    let claim = await this.imageDeletionClaim(imageID);
+    if (!claim) {
+      const described = await this.client.getImage(imageID);
+      claim = {
+        version: awsImageDeletionClaimVersion,
+        imageID,
+        metadata: awsImageDeletionMetadata(imageID, described, metadata),
+        snapshotIDs: awsImageDeletionSnapshotIDs(described),
+        phase: "claimed",
+        claimedAt: new Date().toISOString(),
+      };
+      await this.storage.put(awsImageDeletionClaimKey(imageID), claim);
+    }
+    if (claim.phase !== "provider-deleted") {
+      await this.client.deleteImage(imageID, claim.snapshotIDs);
+      claim = {
+        ...claim,
+        phase: "provider-deleted",
+        providerDeletedAt: new Date().toISOString(),
+      };
+      await this.storage.put(awsImageDeletionClaimKey(imageID), claim);
+    }
+    await this.deleteMatchingImageRecords("image:aws:created:", imageID);
+    await this.deleteMatchingImageRecords(promotedAWSImagePrefix(), imageID);
+    await this.deleteMatchingImageRecords("image:aws:catalog:", imageID);
+    await this.storage.delete(awsImageDeletionClaimKey(imageID));
   }
 
   async storedImageMetadata(imageID: string): Promise<ProviderImage | undefined> {
     return (
       (await this.promotedImageByID(imageID)) ??
       (await this.storage.get<ProviderImage>(createdAWSImageKey(imageID))) ??
-      (await this.storage.get<ProviderImage>(createdProviderImageKey("aws", imageID)))
+      (await this.storage.get<ProviderImage>(createdProviderImageKey("aws", imageID))) ??
+      (await this.imageDeletionClaim(imageID))?.metadata
     );
   }
 
@@ -24097,6 +24184,9 @@ export class AWSProvider implements CloudProvider {
     imageID: string,
     metadata?: Partial<ProviderImage>,
   ): Promise<{ status: number; body: Record<string, unknown> } | undefined> {
+    if (await this.imageDeletionClaim(imageID)) {
+      return undefined;
+    }
     if (metadata?.id === imageID && "promotedAt" in metadata) {
       return {
         status: 409,
@@ -24107,6 +24197,20 @@ export class AWSProvider implements CloudProvider {
       };
     }
     return undefined;
+  }
+
+  private async imageDeletionClaim(imageID: string): Promise<AWSImageDeletionClaim | undefined> {
+    const claim = await this.storage.get<unknown>(awsImageDeletionClaimKey(imageID));
+    return validAWSImageDeletionClaim(claim, imageID) ? claim : undefined;
+  }
+
+  private async deleteMatchingImageRecords(prefix: string, imageID: string): Promise<void> {
+    const records = await this.storage.list<ProviderImage>({ prefix });
+    for (const [key, image] of records) {
+      if (image.id !== imageID && image.resourceID !== imageID) continue;
+      // oxlint-disable-next-line eslint/no-await-in-loop -- ordered deletes leave a retryable durable prefix boundary.
+      await this.storage.delete(key);
+    }
   }
 
   async fastSnapshotRestoreForImage(

--- a/worker/test/aws.test.ts
+++ b/worker/test/aws.test.ts
@@ -2930,6 +2930,51 @@ describe("aws provider", () => {
     ]);
   });
 
+  it("resumes image deletion from known snapshots after the AMI is missing", async () => {
+    const actions: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        const body = await request.clone().text();
+        const params = new URLSearchParams(body);
+        const action = params.get("Action") ?? "";
+        actions.push(action);
+        if (action === "DeregisterImage") {
+          return ec2XMLResponse(
+            "<Response><Errors><Error><Code>InvalidAMIID.NotFound</Code><Message>AMI is already gone</Message></Error></Errors></Response>",
+            400,
+          );
+        }
+        if (action === "DeleteSnapshot" && params.get("SnapshotId") === "snap-missing") {
+          return ec2XMLResponse(
+            "<Response><Errors><Error><Code>InvalidSnapshot.NotFound</Code><Message>snapshot is already gone</Message></Error></Errors></Response>",
+            400,
+          );
+        }
+        if (action === "DeleteSnapshot") {
+          return ec2XMLResponse("<DeleteSnapshotResponse />");
+        }
+        return ec2XMLResponse(
+          `<Response><Errors><Error><Code>Unexpected</Code><Message>${action}</Message></Error></Errors></Response>`,
+          500,
+        );
+      }),
+    );
+
+    const client = new EC2SpotClient(
+      { AWS_ACCESS_KEY_ID: "test", AWS_SECRET_ACCESS_KEY: "secret" } as never,
+      "eu-west-1",
+    );
+    await client.deleteImage("ami-000000000001", ["snap-present", "snap-missing"]);
+
+    expect(actions).toEqual(["DeregisterImage", "DeleteSnapshot", "DeleteSnapshot"]);
+
+    actions.length = 0;
+    await client.deleteImage("snap-direct", ["snap-ignored"]);
+    expect(actions).toEqual(["DeleteSnapshot"]);
+  });
+
   it("describes Fast Snapshot Restore status for selected snapshots and zones", async () => {
     const actions: string[] = [];
     const queries: URLSearchParams[] = [];

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -110,6 +110,7 @@ class MemoryStorage {
   beforeGet?: (key: string) => Promise<void>;
   afterGet?: (key: string, value: unknown) => Promise<void> | void;
   beforePut?: (key: string, value: unknown) => Promise<void>;
+  beforeDelete?: (key: string) => Promise<void>;
 
   async get<T>(key: string, _options?: { noCache?: boolean }): Promise<T | undefined> {
     await this.beforeGet?.(key);
@@ -124,6 +125,7 @@ class MemoryStorage {
   }
 
   async delete(key: string): Promise<void> {
+    await this.beforeDelete?.(key);
     this.values.delete(key);
   }
 
@@ -29228,6 +29230,274 @@ describe("fleet lease identity and idle", () => {
     );
     expect(allowed.status).toBe(200);
     expect(deleted).toBe("ami-000000000001");
+  });
+
+  it("does not claim AWS images that fail ownership or promotion validation", async () => {
+    const imageID = "ami-000000000000";
+    const claimKey = `image:aws:deletion:${imageID}`;
+    const storage = new MemoryStorage();
+    const provider = new AWSProvider({} as Env, "eu-west-1", storage);
+    const getImage = vi.fn<() => Promise<ProviderImage>>(async () => ({
+      id: imageID,
+      name: "unowned",
+      state: "available",
+      provider: "aws",
+      kind: "aws-ami",
+      region: "eu-west-1",
+      snapshots: ["snap-unowned"],
+    }));
+    const deleteImage = vi.fn<() => Promise<void>>(async () => undefined);
+    (
+      provider as unknown as {
+        clientValue: { getImage: typeof getImage; deleteImage: typeof deleteImage };
+      }
+    ).clientValue = { getImage, deleteImage };
+    const fleet = testFleet(storage, { aws: provider });
+    const deleteRequest = () =>
+      request("DELETE", `/v1/images/${imageID}`, {
+        headers: { "x-crabbox-admin": "true" },
+        body: {},
+      });
+
+    const unowned = await fleet.fetch(deleteRequest());
+    expect(unowned.status).toBe(409);
+    expect(storage.value(claimKey)).toBeUndefined();
+
+    storage.seed("image:aws:promoted:linux:x86_64:ubuntu26.04:eu-west-1", {
+      id: imageID,
+      name: "promoted",
+      state: "available",
+      provider: "aws",
+      kind: "aws-ami",
+      region: "eu-west-1",
+      promotedAt: "2026-08-01T00:00:00Z",
+    });
+    const promoted = await fleet.fetch(deleteRequest());
+    expect(promoted.status).toBe(409);
+    expect(storage.value(claimKey)).toBeUndefined();
+    expect(getImage).not.toHaveBeenCalled();
+    expect(deleteImage).not.toHaveBeenCalled();
+  });
+
+  it("claims AWS snapshot inputs before provider deletion and reuses them on retry", async () => {
+    const imageID = "ami-000000000001";
+    const claimKey = `image:aws:deletion:${imageID}`;
+    const storage = new MemoryStorage();
+    const image: ProviderImage = {
+      id: imageID,
+      name: "checkpoint",
+      state: "available",
+      provider: "aws",
+      kind: "aws-ami",
+      region: "eu-west-1",
+    };
+    storage.seed(`image:aws:created:${imageID}`, image);
+    const provider = new AWSProvider({} as Env, "eu-west-1", storage);
+    const getImage = vi.fn<() => Promise<ProviderImage>>(async () => ({
+      ...image,
+      snapshots: ["snap-root", "snap-data"],
+    }));
+    let providerAttempts = 0;
+    const deleteImage = vi.fn<(_imageID: string, snapshotIDs?: string[]) => Promise<void>>(
+      async (_imageID, snapshotIDs) => {
+        expect(storage.value(claimKey)).toMatchObject({
+          version: 1,
+          imageID,
+          snapshotIDs: ["snap-root", "snap-data"],
+          phase: "claimed",
+        });
+        expect(snapshotIDs).toEqual(["snap-root", "snap-data"]);
+        providerAttempts += 1;
+        if (providerAttempts === 1) {
+          throw new Error("injected AWS snapshot deletion failure");
+        }
+      },
+    );
+    (
+      provider as unknown as {
+        clientValue: { getImage: typeof getImage; deleteImage: typeof deleteImage };
+      }
+    ).clientValue = { getImage, deleteImage };
+    const fleet = testFleet(storage, { aws: provider });
+    const deleteRequest = () =>
+      request("DELETE", `/v1/images/${imageID}`, {
+        headers: { "x-crabbox-admin": "true" },
+        body: {},
+      });
+
+    const failed = await fleet.fetch(deleteRequest());
+    expect(failed.status).toBe(500);
+    expect(getImage).toHaveBeenCalledTimes(1);
+    expect(storage.value(claimKey)).toMatchObject({ phase: "claimed" });
+
+    const retried = await fleet.fetch(deleteRequest());
+    expect(retried.status).toBe(200);
+    expect(getImage).toHaveBeenCalledTimes(1);
+    expect(deleteImage).toHaveBeenCalledTimes(2);
+    expect(storage.value(`image:aws:created:${imageID}`)).toBeUndefined();
+    expect(storage.value(claimKey)).toBeUndefined();
+  });
+
+  it("retries AWS provider cleanup when persisting provider progress fails", async () => {
+    const imageID = "ami-000000000002";
+    const claimKey = `image:aws:deletion:${imageID}`;
+    const storage = new MemoryStorage();
+    const image: ProviderImage = {
+      id: imageID,
+      name: "checkpoint-progress",
+      state: "available",
+      provider: "aws",
+      kind: "aws-ami",
+      region: "eu-west-1",
+    };
+    storage.seed(`image:aws:created:${imageID}`, image);
+    let failProgressWrite = true;
+    storage.beforePut = async (key, value) => {
+      if (
+        failProgressWrite &&
+        key === claimKey &&
+        (value as { phase?: string }).phase === "provider-deleted"
+      ) {
+        failProgressWrite = false;
+        throw new Error("injected AWS deletion progress write failure");
+      }
+    };
+    const provider = new AWSProvider({} as Env, "eu-west-1", storage);
+    const getImage = vi.fn<() => Promise<ProviderImage>>(async () => ({
+      ...image,
+      snapshots: ["snap-progress"],
+    }));
+    const deleteImage = vi.fn<() => Promise<void>>(async () => undefined);
+    (
+      provider as unknown as {
+        clientValue: { getImage: typeof getImage; deleteImage: typeof deleteImage };
+      }
+    ).clientValue = { getImage, deleteImage };
+    const fleet = testFleet(storage, { aws: provider });
+    const deleteRequest = () =>
+      request("DELETE", `/v1/images/${imageID}`, {
+        headers: { "x-crabbox-admin": "true" },
+        body: {},
+      });
+
+    const failed = await fleet.fetch(deleteRequest());
+    expect(failed.status).toBe(500);
+    expect(storage.value(claimKey)).toMatchObject({
+      phase: "claimed",
+      snapshotIDs: ["snap-progress"],
+    });
+
+    storage.beforePut = undefined;
+    const retried = await fleet.fetch(deleteRequest());
+    expect(retried.status).toBe(200);
+    expect(getImage).toHaveBeenCalledTimes(1);
+    expect(deleteImage).toHaveBeenCalledTimes(2);
+    expect(storage.value(claimKey)).toBeUndefined();
+  });
+
+  it("retries partial AWS catalog deletion and removes only records for the claimed image", async () => {
+    const imageID = "ami-000000000003";
+    const otherImageID = "ami-000000000004";
+    const claimKey = `image:aws:deletion:${imageID}`;
+    const targetCreatedKey = `image:aws:created:${imageID}`;
+    const otherCreatedKey = `image:aws:created:${otherImageID}`;
+    const targetSelectorKey = "image:aws:promoted:linux:x86_64:ubuntu26.04:eu-west-1";
+    const targetLegacySelectorKey = "image:aws:promoted:linux:x86_64:ubuntu26.04";
+    const otherSelectorKey = "image:aws:promoted:linux:x86_64:ubuntu26.04:us-east-1";
+    const targetCatalogKeyA =
+      "image:aws:catalog:linux:x86_64:ubuntu26.04:eu-west-1:ami-000000000003";
+    const targetCatalogKeyB =
+      "image:aws:catalog:linux:x86_64:ubuntu26.04:eu-west-1:ami-000000000003-variant";
+    const otherCatalogKey = "image:aws:catalog:linux:x86_64:ubuntu26.04:eu-west-1:ami-000000000004";
+    const storage = new MemoryStorage();
+    const image: ProviderImage = {
+      id: imageID,
+      name: "checkpoint-catalog",
+      state: "available",
+      provider: "aws",
+      kind: "aws-ami",
+      region: "eu-west-1",
+    };
+    const otherImage: ProviderImage = { ...image, id: otherImageID, name: "unrelated" };
+    storage.seed(targetCreatedKey, image);
+    storage.seed(otherCreatedKey, otherImage);
+    storage.seed(targetCatalogKeyA, image);
+    storage.seed(targetCatalogKeyB, image);
+    storage.seed(otherCatalogKey, otherImage);
+    const provider = new AWSProvider({} as Env, "eu-west-1", storage);
+    const getImage = vi.fn<() => Promise<ProviderImage>>(async () => ({
+      ...image,
+      snapshots: ["snap-catalog"],
+    }));
+    const deleteImage = vi.fn<() => Promise<void>>(async () => {
+      storage.seed(targetSelectorKey, { ...image, promotedAt: "2026-08-01T00:00:00Z" });
+      storage.seed(targetLegacySelectorKey, {
+        ...image,
+        promotedAt: "2026-07-01T00:00:00Z",
+      });
+      storage.seed(otherSelectorKey, {
+        ...otherImage,
+        promotedAt: "2026-08-01T00:00:00Z",
+      });
+    });
+    (
+      provider as unknown as {
+        clientValue: { getImage: typeof getImage; deleteImage: typeof deleteImage };
+      }
+    ).clientValue = { getImage, deleteImage };
+    let failCatalogDelete = true;
+    let claimDeletedAfterCatalog = false;
+    let recordsPresentWhenClaimDeleted: Array<string | undefined> | undefined;
+    storage.beforeDelete = async (key) => {
+      if (failCatalogDelete && key === targetCatalogKeyB) {
+        failCatalogDelete = false;
+        throw new Error("injected AWS catalog delete failure");
+      }
+      if (key === claimKey) {
+        recordsPresentWhenClaimDeleted = [
+          storage.value(targetCreatedKey),
+          storage.value(targetSelectorKey),
+          storage.value(targetLegacySelectorKey),
+          storage.value(targetCatalogKeyA),
+          storage.value(targetCatalogKeyB),
+        ];
+        claimDeletedAfterCatalog = true;
+      }
+    };
+    const fleet = testFleet(storage, { aws: provider });
+    const deleteRequest = () =>
+      request("DELETE", `/v1/images/${imageID}`, {
+        headers: { "x-crabbox-admin": "true" },
+        body: {},
+      });
+
+    const failed = await fleet.fetch(deleteRequest());
+    expect(failed.status).toBe(500);
+    expect(storage.value(targetCreatedKey)).toBeUndefined();
+    expect(storage.value(targetCatalogKeyB)).toEqual(image);
+    expect(storage.value(claimKey)).toMatchObject({ phase: "provider-deleted" });
+
+    const retried = await fleet.fetch(deleteRequest());
+    expect(retried.status).toBe(200);
+    expect(getImage).toHaveBeenCalledTimes(1);
+    expect(deleteImage).toHaveBeenCalledTimes(1);
+    expect(storage.value(targetCreatedKey)).toBeUndefined();
+    expect(storage.value(targetSelectorKey)).toBeUndefined();
+    expect(storage.value(targetLegacySelectorKey)).toBeUndefined();
+    expect(storage.value(targetCatalogKeyA)).toBeUndefined();
+    expect(storage.value(targetCatalogKeyB)).toBeUndefined();
+    expect(storage.value(otherCreatedKey)).toEqual(otherImage);
+    expect(storage.value(otherSelectorKey)).toMatchObject({ id: otherImageID });
+    expect(storage.value(otherCatalogKey)).toEqual(otherImage);
+    expect(storage.value(claimKey)).toBeUndefined();
+    expect(claimDeletedAfterCatalog).toBe(true);
+    expect(recordsPresentWhenClaimDeleted).toEqual([
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    ]);
   });
 
   it("rejects deleting AWS images without Crabbox ownership metadata", async () => {


### PR DESCRIPTION
## Summary

- persist a versioned AWS image-deletion claim before AMI deregistration, including the snapshot IDs needed to resume
- retry provider cleanup from the durable claim when the AMI or snapshots are already missing
- remove matching created-image, promoted-selector, and capability-variant catalog records before deleting the claim
- preserve the existing ownership and currently-promoted-image deletion guards

## Root cause

AWS image deletion previously described the AMI, deregistered it, and then deleted its EBS snapshots. Fleet-owned catalog cleanup ran only after that provider operation completed. If snapshot deletion or later Durable Object storage cleanup failed, the next request attempted to describe an AMI that had already been deregistered and could not recover the snapshot inputs. Ordinary and capability-variant catalog records could therefore remain selectable indefinitely.

The Fleet durable object is the owner of both the provider adapter and its catalog storage, so the recovery state now lives in the AWS provider adapter rather than adding AWS-specific reconciliation to generic image routing.

## Verification

- `npm test --prefix worker -- aws.test.ts fleet.test.ts` — 648 passed
- `npm test --prefix worker` — 1,357 passed, 3 skipped
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `git diff --check`
- structured autoreview — clean, no actionable findings

Injected regression coverage proves provider failure, deletion-progress persistence failure, missing-AMI retry, missing-snapshot retry, partial catalog cleanup, unrelated-record preservation, and claim removal ordering.

A real AWS mutation run was attempted, but the available local test principal does not grant AMI registration or deregistration. Authorization preflight created no AWS resources, so the partial-failure proof remains the injected provider and durable-storage test suite above.

## Scope

This is independent of the catalog-variant feature repair in https://github.com/openclaw/crabbox/pull/1349. It does not change catalog selection or promotion semantics; it makes deletion of an already-authorized image durable and resumable.

## Configuration and secrets

No configuration changes, new dependencies, or secret-handling changes.
