### PR TITLE
feat: Telegram Desktop catalog-only variant image

### DIFF
--- a/.github/workflows/devtools-image-publish.yml
+++ b/.github/workflows/devtools-image-publish.yml
@@ -22,6 +22,11 @@ on:
         required: true
         default: m7i.large
         type: string
+      telegram_desktop:
+        description: Bake the Linux Telegram Desktop variant and promote it catalog-only
+        required: true
+        default: false
+        type: boolean
       windows_type:
         description: Windows source instance type
         required: true
@@ -106,6 +111,7 @@ jobs:
       TARGET: ${{ inputs.target }}
       REGION: ${{ inputs.region }}
       LINUX_TYPE: ${{ inputs.linux_type }}
+      TELEGRAM_DESKTOP: ${{ inputs.telegram_desktop }}
       WINDOWS_TYPE: ${{ inputs.windows_type }}
       MACOS_TYPE: ${{ inputs.macos_type }}
       MACOS_HOST: ${{ inputs.macos_host }}
@@ -157,6 +163,9 @@ jobs:
                 --type "$LINUX_TYPE"
                 --run
               )
+              if [[ "$TELEGRAM_DESKTOP" == true ]]; then
+                command+=(--telegram-desktop)
+              fi
               ;;
             windows)
               command=(

--- a/docs/features/image-bake-runbook.md
+++ b/docs/features/image-bake-runbook.md
@@ -352,8 +352,10 @@ scripts/mint-aws-devtools-image.sh \
 
 - **Linux** (`scripts/install-linux-developer-tools.sh`): common CLI/build
   tooling, GitHub CLI, Node 24, corepack/pnpm, TruffleHog 3.95.9, Chrome or
-  Chromium for browser lanes, desktop/VNC helpers, Docker Engine, Compose,
-  buildx, and a small default Docker image set. TruffleHog archives are pinned
+  Chromium for browser lanes, desktop/VNC helpers, and checksum-pinned Telegram
+  Desktop 7.0.9 with QR/screen tools (amd64 only; other architectures skip it
+  and omit the version marker). It also installs Docker Engine,
+  Compose, buildx, and a small default Docker image set. TruffleHog archives are pinned
   to reviewed SHA-256 digests for amd64 and arm64. NodeSource, Docker, and
   Chrome APT repositories use scoped keyrings whose primary fingerprints are
   checked before installation; primary-key rotations require a reviewed code

--- a/docs/features/image-bake-runbook.md
+++ b/docs/features/image-bake-runbook.md
@@ -352,10 +352,12 @@ scripts/mint-aws-devtools-image.sh \
 
 - **Linux** (`scripts/install-linux-developer-tools.sh`): common CLI/build
   tooling, GitHub CLI, Node 24, corepack/pnpm, TruffleHog 3.95.9, Chrome or
-  Chromium for browser lanes, desktop/VNC helpers, and checksum-pinned Telegram
-  Desktop 7.0.9 with QR/screen tools (amd64 only; other architectures skip it
-  and omit the version marker). It also installs Docker Engine,
-  Compose, buildx, and a small default Docker image set. TruffleHog archives are pinned
+  Chromium for browser lanes, desktop/VNC helpers, Docker Engine, Compose,
+  buildx, and a small default Docker image set. With
+  `CRABBOX_LINUX_TELEGRAM_DESKTOP=1` it additionally bakes checksum-pinned
+  Telegram Desktop 7.0.9 plus QR/screen tools for a variant image (amd64 only;
+  other architectures skip it and omit `/var/lib/crabbox/telegram-desktop-version`);
+  the default bake never includes it. TruffleHog archives are pinned
   to reviewed SHA-256 digests for amd64 and arm64. NodeSource, Docker, and
   Chrome APT repositories use scoped keyrings whose primary fingerprints are
   checked before installation; primary-key rotations require a reviewed code

--- a/docs/features/image-bake-runbook.md
+++ b/docs/features/image-bake-runbook.md
@@ -329,6 +329,29 @@ scripts/mint-aws-devtools-image.sh \
   --run
 ```
 
+### Telegram Desktop variant
+
+Bake the Linux desktop variant with `--telegram-desktop`:
+
+```bash
+scripts/mint-aws-devtools-image.sh \
+  --target linux \
+  --region us-west-2 \
+  --type m7i.large \
+  --telegram-desktop \
+  --run
+```
+
+The smoke checks the Telegram binary, removed updater, pinned version marker,
+`zbarimg`, and `xdpyinfo`. Promotion uses `--catalog-only --desktop --variant-sdk
+telegram-desktop=<version>`, so it does not replace the generic Linux default
+and only an exactly matching request activates it. Consumers request the
+variant by capability:
+
+```bash
+crabbox warmup --desktop --image-sdk telegram-desktop=<version>
+```
+
 The wrapper captures its candidate through `crabbox checkpoint create`, so the
 same source/candidate proof works with direct AWS credentials and with an
 admin-authenticated broker. Promotion updates broker-managed image defaults;

--- a/docs/features/prebaked-images.md
+++ b/docs/features/prebaked-images.md
@@ -58,8 +58,11 @@ Bake stable machine capabilities:
 - current OS security updates and base packages;
 - core access tooling: SSH, Git, rsync, curl, jq, and the readiness helpers;
 - desktop and browser capabilities for `--desktop --browser` leases
-  (resize-capable TigerVNC, slim XFCE, Chrome or Chromium, checksum-pinned
-  Telegram Desktop on amd64, and QR/screen tools);
+  (resize-capable TigerVNC, slim XFCE, Chrome or Chromium);
+- application capabilities only some lanes need — for example checksum-pinned
+  Telegram Desktop (`CRABBOX_LINUX_TELEGRAM_DESKTOP=1`, amd64) — go into a
+  variant image promoted catalog-only with a declared `--sdk`, never into the
+  generic default;
 - capture tools such as `ffmpeg`, `ffprobe`, `scrot`, and `xdotool`;
 - language and build toolchains the image targets: Node 24 with corepack/pnpm,
   `build-essential`, Python, and common native-addon headers;

--- a/docs/features/prebaked-images.md
+++ b/docs/features/prebaked-images.md
@@ -61,8 +61,8 @@ Bake stable machine capabilities:
   (resize-capable TigerVNC, slim XFCE, Chrome or Chromium);
 - application capabilities only some lanes need — for example checksum-pinned
   Telegram Desktop (`CRABBOX_LINUX_TELEGRAM_DESKTOP=1`, amd64) — go into a
-  variant image promoted catalog-only with a declared `--sdk`, never into the
-  generic default;
+  variant image promoted catalog-only with a `--variant-sdk` selector, never
+  into the generic default;
 - capture tools such as `ffmpeg`, `ffprobe`, `scrot`, and `xdotool`;
 - language and build toolchains the image targets: Node 24 with corepack/pnpm,
   `build-essential`, Python, and common native-addon headers;

--- a/docs/features/prebaked-images.md
+++ b/docs/features/prebaked-images.md
@@ -58,7 +58,8 @@ Bake stable machine capabilities:
 - current OS security updates and base packages;
 - core access tooling: SSH, Git, rsync, curl, jq, and the readiness helpers;
 - desktop and browser capabilities for `--desktop --browser` leases
-  (resize-capable TigerVNC, slim XFCE, Chrome or Chromium);
+  (resize-capable TigerVNC, slim XFCE, Chrome or Chromium, checksum-pinned
+  Telegram Desktop on amd64, and QR/screen tools);
 - capture tools such as `ffmpeg`, `ffprobe`, `scrot`, and `xdotool`;
 - language and build toolchains the image targets: Node 24 with corepack/pnpm,
   `build-essential`, Python, and common native-addon headers;

--- a/scripts/devtools-image-workflow.test.js
+++ b/scripts/devtools-image-workflow.test.js
@@ -33,6 +33,19 @@ test("publication uses the existing source candidate promotion proof wrappers", 
   assert.match(workflow, /go build -trimpath -o bin\/crabbox \.\/cmd\/crabbox/);
 });
 
+test("publication can select the Linux Telegram Desktop catalog variant", () => {
+  assert.match(
+    workflow,
+    /telegram_desktop:\n\s+description: Bake the Linux Telegram Desktop variant and promote it catalog-only\n\s+required: true\n\s+default: false\n\s+type: boolean/,
+  );
+  assert.match(workflow, /TELEGRAM_DESKTOP: \$\{\{ inputs\.telegram_desktop \}\}/);
+  assert.match(
+    workflow,
+    /linux\)[\s\S]*if \[\[ "\$TELEGRAM_DESKTOP" == true \]\]; then\n\s+command\+=\(--telegram-desktop\)\n\s+fi\n\s+;;/,
+  );
+  assert.equal((workflow.match(/command\+=\(--telegram-desktop\)/g) ?? []).length, 1);
+});
+
 test("publication keeps credentials environment-scoped and retains proof", () => {
   assert.match(workflow, /CRABBOX_COORDINATOR: \$\{\{ vars\.CRABBOX_COORDINATOR \}\}/);
   assert.equal(

--- a/scripts/install-linux-developer-tools.sh
+++ b/scripts/install-linux-developer-tools.sh
@@ -8,6 +8,9 @@ telegram_desktop_version="7.0.9"
 telegram_desktop_sha256="d3c05df0259ab116d11d8c1cdc1403019d2a3be303ad3b46d16a84e19df6615f"
 docker_images="${CRABBOX_LINUX_DOCKER_IMAGES:-hello-world ubuntu:24.04 node:24-bookworm}"
 install_desktop="${CRABBOX_LINUX_DESKTOP_TOOLS:-1}"
+# Variant capability, off by default: the generic desktop image stays free of the
+# Telegram client; variant bakes opt in and promote catalog-only with --sdk telegram-desktop=<version>.
+install_telegram_desktop="${CRABBOX_LINUX_TELEGRAM_DESKTOP:-0}"
 install_browser="${CRABBOX_LINUX_BROWSER:-1}"
 apt_keyrings_dir="${CRABBOX_LINUX_APT_KEYRINGS_DIR:-/etc/apt/keyrings}"
 apt_sources_dir="${CRABBOX_LINUX_APT_SOURCES_DIR:-/etc/apt/sources.list.d}"
@@ -22,7 +25,7 @@ trufflehog_bin_dir="${CRABBOX_LINUX_TRUFFLEHOG_BIN_DIR:-/usr/local/bin}"
 telegram_install_dir="${CRABBOX_LINUX_TELEGRAM_INSTALL_DIR:-/opt/Telegram}"
 telegram_state_dir="${CRABBOX_LINUX_TELEGRAM_STATE_DIR:-/var/lib/crabbox}"
 telegram_version_file="$telegram_state_dir/telegram-desktop-version"
-sudo_preserve_env="CRABBOX_LINUX_PNPM_VERSION,CRABBOX_LINUX_NODE_MAJOR,CRABBOX_LINUX_DOCKER_IMAGES,CRABBOX_LINUX_DESKTOP_TOOLS,CRABBOX_LINUX_BROWSER,CRABBOX_LINUX_APT_KEYRINGS_DIR,CRABBOX_LINUX_APT_SOURCES_DIR,CRABBOX_LINUX_APT_CONF_DIR,CRABBOX_LINUX_OS_RELEASE_FILE,CRABBOX_LINUX_CHROME_POLICY_DIR,CRABBOX_LINUX_CHROMIUM_POLICY_DIR,CRABBOX_LINUX_BROWSER_BIN_DIR,CRABBOX_LINUX_BROWSER_STATE_DIR,CRABBOX_LINUX_CHROME_DEFAULTS_FILE,CRABBOX_LINUX_TRUFFLEHOG_BIN_DIR,CRABBOX_LINUX_TELEGRAM_INSTALL_DIR,CRABBOX_LINUX_TELEGRAM_STATE_DIR,HTTP_PROXY,HTTPS_PROXY,NO_PROXY,http_proxy,https_proxy,no_proxy,ALL_PROXY,all_proxy"
+sudo_preserve_env="CRABBOX_LINUX_PNPM_VERSION,CRABBOX_LINUX_NODE_MAJOR,CRABBOX_LINUX_DOCKER_IMAGES,CRABBOX_LINUX_DESKTOP_TOOLS,CRABBOX_LINUX_BROWSER,CRABBOX_LINUX_APT_KEYRINGS_DIR,CRABBOX_LINUX_APT_SOURCES_DIR,CRABBOX_LINUX_APT_CONF_DIR,CRABBOX_LINUX_OS_RELEASE_FILE,CRABBOX_LINUX_CHROME_POLICY_DIR,CRABBOX_LINUX_CHROMIUM_POLICY_DIR,CRABBOX_LINUX_BROWSER_BIN_DIR,CRABBOX_LINUX_BROWSER_STATE_DIR,CRABBOX_LINUX_CHROME_DEFAULTS_FILE,CRABBOX_LINUX_TRUFFLEHOG_BIN_DIR,CRABBOX_LINUX_TELEGRAM_DESKTOP,CRABBOX_LINUX_TELEGRAM_INSTALL_DIR,CRABBOX_LINUX_TELEGRAM_STATE_DIR,HTTP_PROXY,HTTPS_PROXY,NO_PROXY,http_proxy,https_proxy,no_proxy,ALL_PROXY,all_proxy"
 nodesource_signing_key_fingerprint="6F71F525282841EEDAF851B42F59B5F99B1BE0B4"
 docker_signing_key_fingerprint="9DC858229FC7DD38854AE2D88D81803C0EBFCD88"
 google_linux_signing_key_fingerprint="EB4C1BFD4F042F6DDDCCEC917721F63BD38B4796"
@@ -459,10 +462,11 @@ APT
   fi
 
   if [[ "$install_desktop" == "1" ]]; then
+    apt_install xvfb xfce4-session xfwm4 xfce4-panel xfdesktop4 xfce4-terminal xfconf xfce4-settings x11vnc xauth dbus-x11 x11-xserver-utils xterm scrot ffmpeg xdotool wmctrl xclip xsel fonts-dejavu-core fonts-liberation
+  fi
+  if [[ "$install_desktop" == "1" && "$install_telegram_desktop" == "1" ]]; then
     apt_install \
-      xvfb xfce4-session xfwm4 xfce4-panel xfdesktop4 xfce4-terminal xfconf xfce4-settings \
-      x11vnc xauth dbus-x11 x11-xserver-utils x11-utils xterm scrot ffmpeg xdotool wmctrl xclip xsel \
-      fonts-dejavu-core fonts-liberation zbar-tools \
+      x11-utils zbar-tools \
       libopengl0 libxcb-cursor0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 \
       libxcb-render-util0 libxcb-shape0 libxcb-xfixes0 libxcb-xinerama0 libxkbcommon-x11-0
     install_telegram_desktop

--- a/scripts/install-linux-developer-tools.sh
+++ b/scripts/install-linux-developer-tools.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 pnpm_version="${CRABBOX_LINUX_PNPM_VERSION:-11.1.0}"
 node_major="${CRABBOX_LINUX_NODE_MAJOR:-24}"
 trufflehog_version="3.95.9"
+telegram_desktop_version="7.0.9"
+telegram_desktop_sha256="d3c05df0259ab116d11d8c1cdc1403019d2a3be303ad3b46d16a84e19df6615f"
 docker_images="${CRABBOX_LINUX_DOCKER_IMAGES:-hello-world ubuntu:24.04 node:24-bookworm}"
 install_desktop="${CRABBOX_LINUX_DESKTOP_TOOLS:-1}"
 install_browser="${CRABBOX_LINUX_BROWSER:-1}"
@@ -17,7 +19,10 @@ browser_bin_dir="${CRABBOX_LINUX_BROWSER_BIN_DIR:-/usr/local/bin}"
 browser_state_dir="${CRABBOX_LINUX_BROWSER_STATE_DIR:-/var/lib/crabbox}"
 chrome_defaults_file="${CRABBOX_LINUX_CHROME_DEFAULTS_FILE:-/etc/default/google-chrome}"
 trufflehog_bin_dir="${CRABBOX_LINUX_TRUFFLEHOG_BIN_DIR:-/usr/local/bin}"
-sudo_preserve_env="CRABBOX_LINUX_PNPM_VERSION,CRABBOX_LINUX_NODE_MAJOR,CRABBOX_LINUX_DOCKER_IMAGES,CRABBOX_LINUX_DESKTOP_TOOLS,CRABBOX_LINUX_BROWSER,CRABBOX_LINUX_APT_KEYRINGS_DIR,CRABBOX_LINUX_APT_SOURCES_DIR,CRABBOX_LINUX_APT_CONF_DIR,CRABBOX_LINUX_OS_RELEASE_FILE,CRABBOX_LINUX_CHROME_POLICY_DIR,CRABBOX_LINUX_CHROMIUM_POLICY_DIR,CRABBOX_LINUX_BROWSER_BIN_DIR,CRABBOX_LINUX_BROWSER_STATE_DIR,CRABBOX_LINUX_CHROME_DEFAULTS_FILE,CRABBOX_LINUX_TRUFFLEHOG_BIN_DIR,HTTP_PROXY,HTTPS_PROXY,NO_PROXY,http_proxy,https_proxy,no_proxy,ALL_PROXY,all_proxy"
+telegram_install_dir="${CRABBOX_LINUX_TELEGRAM_INSTALL_DIR:-/opt/Telegram}"
+telegram_state_dir="${CRABBOX_LINUX_TELEGRAM_STATE_DIR:-/var/lib/crabbox}"
+telegram_version_file="$telegram_state_dir/telegram-desktop-version"
+sudo_preserve_env="CRABBOX_LINUX_PNPM_VERSION,CRABBOX_LINUX_NODE_MAJOR,CRABBOX_LINUX_DOCKER_IMAGES,CRABBOX_LINUX_DESKTOP_TOOLS,CRABBOX_LINUX_BROWSER,CRABBOX_LINUX_APT_KEYRINGS_DIR,CRABBOX_LINUX_APT_SOURCES_DIR,CRABBOX_LINUX_APT_CONF_DIR,CRABBOX_LINUX_OS_RELEASE_FILE,CRABBOX_LINUX_CHROME_POLICY_DIR,CRABBOX_LINUX_CHROMIUM_POLICY_DIR,CRABBOX_LINUX_BROWSER_BIN_DIR,CRABBOX_LINUX_BROWSER_STATE_DIR,CRABBOX_LINUX_CHROME_DEFAULTS_FILE,CRABBOX_LINUX_TRUFFLEHOG_BIN_DIR,CRABBOX_LINUX_TELEGRAM_INSTALL_DIR,CRABBOX_LINUX_TELEGRAM_STATE_DIR,HTTP_PROXY,HTTPS_PROXY,NO_PROXY,http_proxy,https_proxy,no_proxy,ALL_PROXY,all_proxy"
 nodesource_signing_key_fingerprint="6F71F525282841EEDAF851B42F59B5F99B1BE0B4"
 docker_signing_key_fingerprint="9DC858229FC7DD38854AE2D88D81803C0EBFCD88"
 google_linux_signing_key_fingerprint="EB4C1BFD4F042F6DDDCCEC917721F63BD38B4796"
@@ -307,6 +312,55 @@ install_trufflehog() {
   mv -f "$candidate" "$target"
 }
 
+telegram_desktop_ready() {
+  [[ -x "$telegram_install_dir/Telegram" ]] &&
+    [[ -f "$telegram_version_file" ]] &&
+    [[ "$(<"$telegram_version_file")" == "$telegram_desktop_version" ]]
+}
+
+install_telegram_desktop() {
+  local arch
+  local archive="tsetup.${telegram_desktop_version}.tar.xz"
+  local tmp_dir
+  local url="https://github.com/telegramdesktop/tdesktop/releases/download/v${telegram_desktop_version}/${archive}"
+  local version_tmp
+
+  arch="$(dpkg --print-architecture)"
+  # Upstream ships amd64 only. Non-amd64 desktop images stay valid without Telegram;
+  # consumers detect absence through the missing version marker.
+  if [[ "$arch" != "amd64" ]]; then
+    log "skipping Telegram Desktop: upstream tarball is amd64-only; found $arch"
+    return 0
+  fi
+
+  if telegram_desktop_ready; then
+    rm -f "$telegram_install_dir/Updater"
+    return 0
+  fi
+
+  tmp_dir="$(mktemp -d)"
+  if ! retry curl -fsSL --output "$tmp_dir/$archive" "$url" ||
+    ! (
+      cd "$tmp_dir"
+      printf '%s  %s\n' "$telegram_desktop_sha256" "$archive" | sha256sum -c -
+    ) ||
+    ! tar --no-same-owner -xJf "$tmp_dir/$archive" -C "$tmp_dir" Telegram; then
+    rm -rf "$tmp_dir"
+    return 1
+  fi
+
+  rm -f "$tmp_dir/Telegram/Updater"
+  chmod 0755 "$tmp_dir/Telegram" "$tmp_dir/Telegram/Telegram"
+  install -d -m 0755 "$(dirname "$telegram_install_dir")" "$telegram_state_dir"
+  rm -rf "$telegram_install_dir"
+  mv "$tmp_dir/Telegram" "$telegram_install_dir"
+  version_tmp="$(mktemp "$telegram_state_dir/.telegram-desktop-version.tmp.XXXXXX")"
+  printf '%s\n' "$telegram_desktop_version" >"$version_tmp"
+  chmod 0644 "$version_tmp"
+  mv -f "$version_tmp" "$telegram_version_file"
+  rm -rf "$tmp_dir"
+}
+
 install_docker() {
   apt_install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
   systemctl enable --now docker || service docker start
@@ -335,7 +389,7 @@ prepare_fast_boot() {
 }
 
 print_versions() {
-  # shellcheck disable=SC1091
+  # shellcheck disable=SC1090
   . "$os_release_file"
   printf 'os=%s %s\n' "${PRETTY_NAME:-unknown}" "$(uname -m)"
   git --version
@@ -351,6 +405,9 @@ print_versions() {
   "$trufflehog_bin_dir/trufflehog" --no-update --version
   docker --version
   docker compose version
+  if [[ -f "$telegram_version_file" ]]; then
+    printf 'telegram-desktop=%s\n' "$(<"$telegram_version_file")"
+  fi
 }
 
 main() {
@@ -402,7 +459,13 @@ APT
   fi
 
   if [[ "$install_desktop" == "1" ]]; then
-    apt_install xvfb xfce4-session xfwm4 xfce4-panel xfdesktop4 xfce4-terminal xfconf xfce4-settings x11vnc xauth dbus-x11 x11-xserver-utils xterm scrot ffmpeg xdotool wmctrl xclip xsel fonts-dejavu-core fonts-liberation
+    apt_install \
+      xvfb xfce4-session xfwm4 xfce4-panel xfdesktop4 xfce4-terminal xfconf xfce4-settings \
+      x11vnc xauth dbus-x11 x11-xserver-utils x11-utils xterm scrot ffmpeg xdotool wmctrl xclip xsel \
+      fonts-dejavu-core fonts-liberation zbar-tools \
+      libopengl0 libxcb-cursor0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 \
+      libxcb-render-util0 libxcb-shape0 libxcb-xfixes0 libxcb-xinerama0 libxkbcommon-x11-0
+    install_telegram_desktop
   fi
   if [[ "$install_browser" == "1" ]]; then
     install_chrome_or_chromium

--- a/scripts/install-linux-developer-tools.test.js
+++ b/scripts/install-linux-developer-tools.test.js
@@ -875,11 +875,18 @@ test("linux desktop image installs pinned Telegram Desktop once without its upda
 	assert.equal(fs.statSync(path.join(fixture.stateDir, "telegram-desktop-version")).mode & 0o777, 0o644);
 });
 
-test("linux desktop package block includes Telegram runtime and screen tools", () => {
+test("linux desktop package block keeps the generic image free of Telegram; the variant gate adds it", () => {
 	const script = fs.readFileSync(path.join(repoRoot, "scripts/install-linux-developer-tools.sh"), "utf8");
+	assert.match(script, /^install_telegram_desktop="\$\{CRABBOX_LINUX_TELEGRAM_DESKTOP:-0\}"$/m);
+	assert.match(script, /sudo_preserve_env=".*CRABBOX_LINUX_TELEGRAM_DESKTOP.*"/);
 	const main = script.slice(script.indexOf("main() {"));
 	const desktopBlock = main.match(/if \[\[ "\$install_desktop" == "1" \]\]; then([\s\S]*?)\n  fi/);
 	assert.ok(desktopBlock, "missing desktop package block");
+	assert.doesNotMatch(desktopBlock[1], /install_telegram_desktop|zbar-tools|libxcb-cursor0/);
+	const telegramBlock = main.match(
+		/if \[\[ "\$install_desktop" == "1" && "\$install_telegram_desktop" == "1" \]\]; then([\s\S]*?)\n  fi/,
+	);
+	assert.ok(telegramBlock, "missing Telegram variant block");
 	for (const packageName of [
 		"libopengl0",
 		"libxcb-cursor0",
@@ -895,9 +902,9 @@ test("linux desktop package block includes Telegram runtime and screen tools", (
 		"zbar-tools",
 		"x11-utils",
 	]) {
-		assert.match(desktopBlock[1], new RegExp(`\\b${packageName}\\b`));
+		assert.match(telegramBlock[1], new RegExp(`\\b${packageName}\\b`));
 	}
-	assert.match(desktopBlock[1], /install_telegram_desktop/);
+	assert.match(telegramBlock[1], /install_telegram_desktop/);
 });
 
 test("linux desktop image skips Telegram Desktop on non-amd64 without downloading", () => {

--- a/scripts/install-linux-developer-tools.test.js
+++ b/scripts/install-linux-developer-tools.test.js
@@ -9,6 +9,8 @@ const repoRoot = path.resolve(import.meta.dirname, "..");
 const nodesourceSigningKeyFingerprint = "6F71F525282841EEDAF851B42F59B5F99B1BE0B4";
 const dockerSigningKeyFingerprint = "9DC858229FC7DD38854AE2D88D81803C0EBFCD88";
 const googleLinuxSigningKeyFingerprint = "EB4C1BFD4F042F6DDDCCEC917721F63BD38B4796";
+const telegramDesktopVersion = "7.0.9";
+const telegramDesktopSha256 = "d3c05df0259ab116d11d8c1cdc1403019d2a3be303ad3b46d16a84e19df6615f";
 
 function writeExecutable(file, body) {
 	fs.writeFileSync(file, body, "utf8");
@@ -534,6 +536,12 @@ function installTruffleHogFixture(dir) {
 	const downloadLog = path.join(dir, "download.log");
 	const checksumLog = path.join(dir, "checksum.log");
 	fs.mkdirSync(bin);
+	writeExecutable(
+		path.join(bin, "dpkg"),
+		`#!/usr/bin/env bash
+[[ "$*" == "--print-architecture" ]] && printf 'amd64\n'
+`,
+	);
 	fs.mkdirSync(targetBin);
 	writeExecutable(
 		path.join(bin, "dpkg"),
@@ -717,7 +725,10 @@ test("linux developer image reports TruffleHog from the configured install direc
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-linux-trufflehog-version-"));
 	const fixture = installTruffleHogFixture(dir);
 	const osRelease = path.join(dir, "os-release");
+	const telegramState = path.join(dir, "state");
+	fs.mkdirSync(telegramState);
 	fs.writeFileSync(osRelease, "PRETTY_NAME='Test Linux'\n", "utf8");
+	fs.writeFileSync(path.join(telegramState, "telegram-desktop-version"), `${telegramDesktopVersion}\n`, "utf8");
 	writeExecutable(
 		path.join(fixture.targetBin, "trufflehog"),
 		"#!/usr/bin/env bash\nprintf 'trufflehog 3.95.9\\n'\n",
@@ -737,6 +748,7 @@ test("linux developer image reports TruffleHog from the configured install direc
 				...process.env,
 				PATH: `${fixture.bin}${path.delimiter}/usr/bin:/bin`,
 				CRABBOX_LINUX_OS_RELEASE_FILE: osRelease,
+				CRABBOX_LINUX_TELEGRAM_STATE_DIR: telegramState,
 				CRABBOX_LINUX_TRUFFLEHOG_BIN_DIR: fixture.targetBin,
 			},
 			encoding: "utf8",
@@ -745,10 +757,176 @@ test("linux developer image reports TruffleHog from the configured install direc
 
 	assert.equal(result.status, 0, result.stderr || result.stdout);
 	assert.match(result.stdout, /trufflehog 3\.95\.9/);
+	assert.match(result.stdout, /telegram-desktop=7\.0\.9/);
 });
 
 test("linux developer image keeps pinned TruffleHog probes update-free", () => {
 	const script = fs.readFileSync(path.join(repoRoot, "scripts/install-linux-developer-tools.sh"), "utf8");
 	assert.match(script, /"\$binary" --no-update --version/);
 	assert.match(script, /"\$trufflehog_bin_dir\/trufflehog" --no-update --version/);
+});
+
+function installTelegramDesktopFixture(dir) {
+	const bin = path.join(dir, "bin");
+	const installDir = path.join(dir, "opt", "Telegram");
+	const stateDir = path.join(dir, "state");
+	const downloadLog = path.join(dir, "download.log");
+	const checksumLog = path.join(dir, "checksum.log");
+	fs.mkdirSync(bin);
+	writeExecutable(
+		path.join(bin, "curl"),
+		`#!/usr/bin/env bash
+set -euo pipefail
+output=""
+printf '%s\n' "$*" >>"$CRABBOX_FAKE_DOWNLOAD_LOG"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    -o|--output)
+      output="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+printf 'fake Telegram archive\n' >"$output"
+`,
+	);
+	writeExecutable(
+		path.join(bin, "sha256sum"),
+		`#!/usr/bin/env bash
+set -euo pipefail
+cat >"$CRABBOX_FAKE_CHECKSUM_LOG"
+`,
+	);
+	writeExecutable(
+		path.join(bin, "tar"),
+		`#!/usr/bin/env bash
+set -euo pipefail
+output_dir=""
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    -C)
+      output_dir="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+mkdir -p "$output_dir/Telegram"
+cat >"$output_dir/Telegram/Telegram" <<'SCRIPT'
+#!/usr/bin/env bash
+exit 0
+SCRIPT
+chmod 0755 "$output_dir/Telegram/Telegram"
+printf 'updater\n' >"$output_dir/Telegram/Updater"
+`,
+	);
+	return { bin, installDir, stateDir, downloadLog, checksumLog };
+}
+
+test("linux desktop image installs pinned Telegram Desktop once without its updater", () => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-linux-telegram-"));
+	const fixture = installTelegramDesktopFixture(dir);
+	const result = spawnSync(
+		"bash",
+		[
+			"-c",
+			"set -euo pipefail\nsource scripts/install-linux-developer-tools.sh\ninstall_telegram_desktop\ninstall_telegram_desktop",
+		],
+		{
+			cwd: repoRoot,
+			env: {
+				...process.env,
+				PATH: `${fixture.bin}${path.delimiter}/usr/bin:/bin`,
+				CRABBOX_FAKE_CHECKSUM_LOG: fixture.checksumLog,
+				CRABBOX_FAKE_DOWNLOAD_LOG: fixture.downloadLog,
+				CRABBOX_LINUX_TELEGRAM_INSTALL_DIR: fixture.installDir,
+				CRABBOX_LINUX_TELEGRAM_STATE_DIR: fixture.stateDir,
+			},
+			encoding: "utf8",
+		},
+	);
+
+	assert.equal(result.status, 0, result.stderr || result.stdout);
+	const downloadLog = fs.readFileSync(fixture.downloadLog, "utf8");
+	assert.equal(downloadLog.trim().split("\n").length, 1, "matching marker and binary must skip the second download");
+	assert.match(
+		downloadLog,
+		new RegExp(
+			`telegramdesktop/tdesktop/releases/download/v${telegramDesktopVersion}/tsetup\\.${telegramDesktopVersion}\\.tar\\.xz`,
+		),
+	);
+	assert.equal(
+		fs.readFileSync(fixture.checksumLog, "utf8"),
+		`${telegramDesktopSha256}  tsetup.${telegramDesktopVersion}.tar.xz\n`,
+	);
+	assert.equal(fs.existsSync(path.join(fixture.installDir, "Telegram")), true);
+	assert.equal(fs.existsSync(path.join(fixture.installDir, "Updater")), false);
+	assert.equal(fs.statSync(fixture.installDir).mode & 0o777, 0o755);
+	assert.equal(fs.statSync(path.join(fixture.installDir, "Telegram")).mode & 0o777, 0o755);
+	assert.equal(
+		fs.readFileSync(path.join(fixture.stateDir, "telegram-desktop-version"), "utf8"),
+		`${telegramDesktopVersion}\n`,
+	);
+	assert.equal(fs.statSync(path.join(fixture.stateDir, "telegram-desktop-version")).mode & 0o777, 0o644);
+});
+
+test("linux desktop package block includes Telegram runtime and screen tools", () => {
+	const script = fs.readFileSync(path.join(repoRoot, "scripts/install-linux-developer-tools.sh"), "utf8");
+	const main = script.slice(script.indexOf("main() {"));
+	const desktopBlock = main.match(/if \[\[ "\$install_desktop" == "1" \]\]; then([\s\S]*?)\n  fi/);
+	assert.ok(desktopBlock, "missing desktop package block");
+	for (const packageName of [
+		"libopengl0",
+		"libxcb-cursor0",
+		"libxcb-icccm4",
+		"libxcb-image0",
+		"libxcb-keysyms1",
+		"libxcb-randr0",
+		"libxcb-render-util0",
+		"libxcb-shape0",
+		"libxcb-xfixes0",
+		"libxcb-xinerama0",
+		"libxkbcommon-x11-0",
+		"zbar-tools",
+		"x11-utils",
+	]) {
+		assert.match(desktopBlock[1], new RegExp(`\\b${packageName}\\b`));
+	}
+	assert.match(desktopBlock[1], /install_telegram_desktop/);
+});
+
+test("linux desktop image skips Telegram Desktop on non-amd64 without downloading", () => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-linux-telegram-arm64-"));
+	const fixture = installTelegramDesktopFixture(dir);
+	writeExecutable(
+		path.join(fixture.bin, "dpkg"),
+		`#!/usr/bin/env bash
+[[ "$*" == "--print-architecture" ]] && printf 'arm64\n'
+`,
+	);
+	const result = spawnSync(
+		"bash",
+		["-c", "set -euo pipefail\nsource scripts/install-linux-developer-tools.sh\ninstall_telegram_desktop"],
+		{
+			cwd: repoRoot,
+			env: {
+				...process.env,
+				PATH: `${fixture.bin}${path.delimiter}/usr/bin:/bin`,
+				CRABBOX_FAKE_CHECKSUM_LOG: fixture.checksumLog,
+				CRABBOX_FAKE_DOWNLOAD_LOG: fixture.downloadLog,
+				CRABBOX_LINUX_TELEGRAM_INSTALL_DIR: fixture.installDir,
+				CRABBOX_LINUX_TELEGRAM_STATE_DIR: fixture.stateDir,
+			},
+			encoding: "utf8",
+		},
+	);
+
+	assert.equal(result.status, 0, result.stderr);
+	assert.match(result.stderr, /skipping Telegram Desktop: upstream tarball is amd64-only/);
+	assert.equal(fs.existsSync(fixture.downloadLog), false);
 });

--- a/scripts/mint-aws-devtools-image.sh
+++ b/scripts/mint-aws-devtools-image.sh
@@ -25,6 +25,7 @@ promote="${CRABBOX_IMAGE_PROMOTE:-1}"
 keep_lease="${CRABBOX_IMAGE_KEEP_LEASE:-0}"
 desktop="${CRABBOX_IMAGE_DESKTOP:-auto}"
 browser="${CRABBOX_IMAGE_BROWSER:-auto}"
+telegram_desktop="${CRABBOX_IMAGE_TELEGRAM_DESKTOP:-0}"
 windows_mode="${CRABBOX_WINDOWS_MODE:-normal}"
 prep_script="${CRABBOX_IMAGE_PREP_SCRIPT:-}"
 windows_reboot_marker='C:\ProgramData\crabbox\image-prep-reboot-required'
@@ -52,6 +53,7 @@ Flags:
   --desktop             request desktop bootstrap
   --no-desktop          do not request desktop bootstrap
   --no-browser          do not request browser bootstrap on Linux
+  --telegram-desktop    bake the Linux Telegram Desktop variant
   --windows-mode MODE   normal or wsl2, default normal
   --prep-script PATH    override target prep script
   -h, --help            show this help
@@ -71,6 +73,7 @@ Useful env:
   CRABBOX_IMAGE_WINDOWS_WARMUP_SETTLE_SECONDS
   CRABBOX_IMAGE_FAST_SNAPSHOT_RESTORE
   CRABBOX_IMAGE_FAST_SNAPSHOT_RESTORE_AZS
+  CRABBOX_IMAGE_TELEGRAM_DESKTOP
 USAGE
 }
 
@@ -138,6 +141,10 @@ while [[ "$#" -gt 0 ]]; do
       browser=0
       shift
       ;;
+    --telegram-desktop)
+      telegram_desktop=1
+      shift
+      ;;
     --windows-mode)
       [[ "$#" -ge 2 ]] || { printf '%s requires a value\n' "$1" >&2; exit 2; }
       windows_mode="$2"
@@ -170,10 +177,6 @@ esac
 
 invocation_id="$(date -u +%Y%m%d-%H%M%S)-$$-${RANDOM}"
 log_id="$(printf '%s' "$invocation_id" | tr -c 'A-Za-z0-9_.-' '_')"
-if [[ -z "$image_name" ]]; then
-  image_name="crabbox-${target}-devtools-${log_id}"
-fi
-log_image_name="$(printf '%s' "$image_name" | tr -c 'A-Za-z0-9_.-' '_')"
 if [[ -z "$prep_script" ]]; then
   if [[ "$target" == "windows" ]]; then
     prep_script="$ROOT/scripts/install-windows-developer-tools.ps1"
@@ -196,6 +199,22 @@ if [[ "$desktop" == "auto" ]]; then
   fi
 fi
 
+if [[ "$telegram_desktop" == "1" && "$target" != "linux" ]]; then
+  printf '%s\n' '--telegram-desktop requires --target linux' >&2
+  exit 2
+fi
+if [[ "$telegram_desktop" == "1" && "$desktop" != "1" ]]; then
+  printf '%s\n' '--telegram-desktop requires desktop bootstrap; remove --no-desktop' >&2
+  exit 2
+fi
+
+image_variant=""
+[[ "$telegram_desktop" == "1" ]] && image_variant="-telegram"
+if [[ -z "$image_name" ]]; then
+  image_name="crabbox-${target}-devtools${image_variant}-${log_id}"
+fi
+log_image_name="$(printf '%s' "$image_name" | tr -c 'A-Za-z0-9_.-' '_')"
+
 if [[ ! -x "$CRABBOX_BIN" ]]; then
   printf 'CRABBOX_BIN is not executable: %s\n' "$CRABBOX_BIN" >&2
   exit 2
@@ -205,13 +224,25 @@ if [[ ! -f "$prep_script" ]]; then
   exit 2
 fi
 
+telegram_desktop_version=""
+if [[ "$telegram_desktop" == "1" ]]; then
+  telegram_desktop_version="$(sed -n 's/^telegram_desktop_version="\([^"]*\)"$/\1/p' "$prep_script")"
+  if [[ -z "$telegram_desktop_version" ]]; then
+    printf 'telegram_desktop_version pin not found in prep script: %s\n' "$prep_script" >&2
+    exit 2
+  fi
+fi
+
 source_lease=""
 candidate_lease=""
 promoted_lease=""
+default_unchanged_lease=""
+telegram_prep_script=""
 
 cleanup() {
+  [[ -z "$telegram_prep_script" ]] || rm -f "$telegram_prep_script"
   [[ "$keep_lease" == "1" ]] && return 0
-  for lease in "$promoted_lease" "$candidate_lease" "$source_lease"; do
+  for lease in "$default_unchanged_lease" "$promoted_lease" "$candidate_lease" "$source_lease"; do
     [[ -n "$lease" ]] || continue
     "$CRABBOX_BIN" stop --provider aws --target "$target" "$lease" || true
   done
@@ -382,11 +413,13 @@ wait_windows_prep_task() {
 }
 
 warmup_args() {
+  local label="$1"
   printf '%s\0' warmup --provider aws --target "$target" --class "$server_class" --market on-demand --ttl "$ttl" --idle-timeout "$idle_timeout" --timing-json
   [[ -n "$server_type" ]] && printf '%s\0' --type "$server_type"
   [[ "$desktop" == "1" ]] && printf '%s\0' --desktop
   [[ "$browser" == "1" ]] && printf '%s\0' --browser
   [[ "$target" == "windows" ]] && printf '%s\0' --windows-mode "$windows_mode"
+  [[ "$label" == "promoted" && "$telegram_desktop" == "1" ]] && printf '%s\0' --image-sdk "telegram-desktop=$telegram_desktop_version"
 }
 
 lease_from_log() {
@@ -406,16 +439,38 @@ process.exit(1);
 ' "$1"
 }
 
+image_selections() {
+  grep -F 'image selected id=' "$1"
+}
+
 assert_selected_image() {
   local log="$1"
   local image_id="$2"
   local source="$3"
-  if ! grep -Fq "image selected id=$image_id source=$source" "$log"; then
+  local selection
+  selection="$(image_selections "$log" || true)"
+  if [[ "$selection" != *"image selected id=$image_id source=$source"* ]]; then
     printf 'warmup did not prove image selection id=%s source=%s; log=%s\n' \
       "$image_id" "$source" "$log" >&2
     return 1
   fi
   printf '%s image selection proved: %s\n' "$source" "$image_id" >&2
+}
+
+assert_different_image() {
+  local log="$1"
+  local image_id="$2"
+  local selection
+  selection="$(image_selections "$log" || true)"
+  if [[ -z "$selection" ]]; then
+    printf 'warmup did not report image selection; log=%s\n' "$log" >&2
+    return 1
+  fi
+  if [[ "$selection" == *"image selected id=$image_id "* ]]; then
+    printf 'warmup unexpectedly selected image id=%s; log=%s\n' "$image_id" "$log" >&2
+    return 1
+  fi
+  printf 'default image remained unchanged from: %s\n' "$image_id" >&2
 }
 
 warmup() {
@@ -424,7 +479,7 @@ warmup() {
   mkdir -p "$log_dir"
   log="$(mktemp "$log_dir/image-mint-${log_image_name}-${label}-${log_id}.log.XXXXXX")"
   local -a args
-  while IFS= read -r -d '' arg; do args+=("$arg"); done < <(warmup_args)
+  while IFS= read -r -d '' arg; do args+=("$arg"); done < <(warmup_args "$label")
   local -a env_args=()
   [[ -n "$region" ]] && env_args+=(CRABBOX_AWS_REGION="$region" AWS_REGION="$region")
   [[ "$label" == "candidate" ]] && env_args+=(CRABBOX_AWS_AMI="$2")
@@ -447,14 +502,15 @@ warmup() {
     printf 'warmup did not return a lease id for %s\n' "$label" >&2
     return 1
   fi
-  if [[ "$label" == "candidate" ]]; then
-    if ! assert_selected_image "$log" "$2" explicit; then
-      return 1
-    fi
-  elif [[ "$label" == "promoted" ]]; then
-    if ! assert_selected_image "$log" "$ami_id" promoted; then
-      return 1
-    fi
+  local selection_status=0
+  case "$label" in
+    candidate) assert_selected_image "$log" "$2" explicit || selection_status=$? ;;
+    promoted) assert_selected_image "$log" "$ami_id" promoted || selection_status=$? ;;
+    default-unchanged) assert_different_image "$log" "$ami_id" || selection_status=$? ;;
+  esac
+  if [[ "$selection_status" -ne 0 ]]; then
+    [[ "$keep_lease" == "1" ]] || run_cmd "$CRABBOX_BIN" stop --provider aws --target "$target" "$lease" >&2 || true
+    return "$selection_status"
   fi
   if [[ "$target" == "windows" ]]; then
     sleep "$windows_warmup_settle_seconds"
@@ -539,6 +595,18 @@ fi
 test -d /var/cache/crabbox/pnpm
 test -f /var/lib/crabbox/image-ready
 SHELL
+    if [[ "$telegram_desktop" == "1" ]]; then
+      cat <<'SHELL'
+test -x /opt/Telegram/Telegram
+test ! -e /opt/Telegram/Updater
+SHELL
+      printf 'telegram_desktop_expected=%q\n' "$telegram_desktop_version"
+      cat <<'SHELL'
+test "$(</var/lib/crabbox/telegram-desktop-version)" = "$telegram_desktop_expected"
+command -v zbarimg
+command -v xdpyinfo
+SHELL
+    fi
   fi
 }
 
@@ -579,7 +647,18 @@ run_prep() {
     wait_windows_prep_task "$lease"
     return
   fi
-  run_cmd "$CRABBOX_BIN" run --provider aws --target "$target" --id "$lease" --no-sync --script "$prep_script"
+  local run_prep_script="$prep_script"
+  if [[ "$telegram_desktop" == "1" ]]; then
+    telegram_prep_script="$(mktemp "${TMPDIR:-/tmp}/crabbox-telegram-prep.XXXXXX.sh")"
+    {
+      printf '#!/usr/bin/env bash\n'
+      printf 'export CRABBOX_LINUX_TELEGRAM_DESKTOP=1\n'
+      cat "$prep_script"
+    } >"$telegram_prep_script"
+    chmod +x "$telegram_prep_script"
+    run_prep_script="$telegram_prep_script"
+  fi
+  run_cmd "$CRABBOX_BIN" run --provider aws --target "$target" --id "$lease" --no-sync --script "$run_prep_script"
 }
 
 mark_linux_image_ready() {
@@ -647,7 +726,7 @@ AWS devtools image mint
   class:  $server_class
   type:   ${server_type:-auto}
   prep:   $prep_script
-  proof:  desktop=$desktop browser=$browser promote=$promote
+  proof:  desktop=$desktop browser=$browser telegram_desktop=$telegram_desktop promote=$promote
   fsr:    enabled=$fast_snapshot_restore azs=${fast_snapshot_restore_azs:-auto}
   paid:   run=$run keep_lease=$keep_lease
 EOF
@@ -698,6 +777,9 @@ if [[ "$fast_snapshot_restore" == "1" ]]; then
     promote_args+=(--fsr-az "$fsr_az")
   done
 fi
+if [[ "$telegram_desktop" == "1" ]]; then
+  promote_args+=(--catalog-only --desktop --variant-sdk "telegram-desktop=$telegram_desktop_version")
+fi
 promote_args+=("$ami_id")
 run_cmd "$CRABBOX_BIN" "${promote_args[@]}"
 
@@ -709,4 +791,8 @@ fi
 promoted_lease="$(warmup promoted)"
 smoke "$promoted_lease"
 printf 'promoted image selection proved: %s\n' "$ami_id"
+if [[ "$telegram_desktop" == "1" ]]; then
+  default_unchanged_lease="$(warmup default-unchanged)"
+  printf 'default image unchanged proof passed: %s\n' "$ami_id"
+fi
 printf 'promoted %s developer image passed: %s\n' "$target" "$ami_id"

--- a/scripts/mint-aws-devtools-image.test.js
+++ b/scripts/mint-aws-devtools-image.test.js
@@ -16,7 +16,10 @@ async function setupFakeCrabbox() {
   const fake = path.join(dir, "crabbox");
   const linuxPrep = path.join(dir, "linux.sh");
   const windowsPrep = path.join(dir, "windows.ps1");
-  await writeFile(linuxPrep, "#!/usr/bin/env bash\nexit 0\n");
+  await writeFile(
+    linuxPrep,
+    '#!/usr/bin/env bash\ntelegram_desktop_version="7.0.9"\nexit 0\n',
+  );
   await chmod(linuxPrep, 0o755);
   await writeFile(windowsPrep, "exit 0\n");
   await writeFile(
@@ -37,9 +40,13 @@ case "$1" in
         printf 'image selected id=%s source=explicit kind=aws-ami region=%s promoted_at=-\\n' "\${CRABBOX_AWS_AMI:-}" "\${CRABBOX_AWS_REGION:-eu-west-1}"
         printf '{"leaseId":"cbx_candidate"}\\n'
         ;;
-      *)
+      3)
         printf 'image selected id=ami-devtools source=promoted kind=aws-ami region=%s promoted_at=2026-07-31T00:00:00Z\\n' "\${CRABBOX_AWS_REGION:-eu-west-1}"
         printf '{"leaseId":"cbx_promoted"}\\n'
+        ;;
+      *)
+        printf 'image selected id=ami-generic source=promoted kind=aws-ami region=%s promoted_at=2026-07-30T00:00:00Z\\n' "\${CRABBOX_AWS_REGION:-eu-west-1}"
+        printf '{"leaseId":"cbx_default"}\\n'
         ;;
     esac
     if [[ "\${CRABBOX_FAKE_WARMUP_FAIL_AFTER_LEASE:-0}" == "1" ]]; then
@@ -47,6 +54,9 @@ case "$1" in
     fi
     ;;
   run)
+    if [[ -n "\${CRABBOX_FAKE_CAPTURE_PREP_SCRIPT:-}" && "$*" == *"--script"* ]]; then
+      cp "\${@: -1}" "\${CRABBOX_FAKE_CAPTURE_PREP_SCRIPT}"
+    fi
     if [[ -n "\${CRABBOX_FAKE_CAPTURE_RUN_SCRIPT:-}" ]]; then
       last_arg="\${@: -1}"
       if [[ "$last_arg" == *"docker_probe="* ]]; then
@@ -137,6 +147,23 @@ test("AWS devtools mint wrapper defaults to dry plan", async () => {
   await assert.rejects(readFile(fake.log, "utf8"));
 });
 
+test("AWS devtools mint wrapper plans the Linux Telegram Desktop variant", async () => {
+  const fake = await setupFakeCrabbox();
+  const result = await runScript(
+    ["--telegram-desktop", "--prep-script", fake.linuxPrep],
+    {
+      CRABBOX_BIN: fake.fake,
+      CRABBOX_FAKE_LOG: fake.log,
+    },
+  );
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stderr, /image:  crabbox-linux-devtools-telegram-/);
+  assert.match(
+    result.stderr,
+    /proof:  desktop=1 browser=1 telegram_desktop=1 promote=1/,
+  );
+});
+
 test("AWS developer image smoke executes package managers and requires TruffleHog", async () => {
   const text = await readFile(script, "utf8");
   assert.match(text, /pnpm --version\ntrufflehog --no-update --version\ndocker --version/);
@@ -189,6 +216,98 @@ test("AWS devtools mint wrapper runs linux source candidate and promoted proof",
   assert.match(log, /env CRABBOX_AWS_REGION=us-west-2 AWS_REGION=us-west-2 CRABBOX_AWS_AMI= args checkpoint create --provider aws --target linux --id cbx_source --name crabbox-linux-devtools-/);
   assert.match(log, /--mode native --strategy image --no-reboot=false --wait --wait-timeout 60m/);
   assert.match(log, /image promote --target linux --json --region us-west-2 --fast-snapshot-restore --fsr-az us-west-2a ami-devtools/);
+});
+
+test("AWS devtools mint wrapper publishes a catalog-only Telegram variant", async () => {
+  const fake = await setupFakeCrabbox();
+  const prepCapture = path.join(fake.dir, "telegram-prep.sh");
+  const smokeCapture = path.join(fake.dir, "telegram-smoke.sh");
+  const result = await runScript(
+    [
+      "--target",
+      "linux",
+      "--region",
+      "us-west-2",
+      "--run",
+      "--telegram-desktop",
+      "--prep-script",
+      fake.linuxPrep,
+    ],
+    {
+      CRABBOX_BIN: fake.fake,
+      CRABBOX_FAKE_LOG: fake.log,
+      CRABBOX_FAKE_CAPTURE_PREP_SCRIPT: prepCapture,
+      CRABBOX_FAKE_CAPTURE_RUN_SCRIPT: smokeCapture,
+    },
+  );
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /default image unchanged proof passed: ami-devtools/);
+
+  const prep = await readFile(prepCapture, "utf8");
+  assert.match(prep, /^#!\/usr\/bin\/env bash\nexport CRABBOX_LINUX_TELEGRAM_DESKTOP=1\n/);
+  assert.match(prep, /telegram_desktop_version="7\.0\.9"/);
+
+  const smoke = await readFile(smokeCapture, "utf8");
+  assert.match(smoke, /test -x \/opt\/Telegram\/Telegram/);
+  assert.match(smoke, /test ! -e \/opt\/Telegram\/Updater/);
+  assert.match(smoke, /telegram_desktop_expected=7\.0\.9/);
+  assert.match(smoke, /telegram-desktop-version\)" = "\$telegram_desktop_expected"/);
+  assert.match(smoke, /command -v zbarimg/);
+  assert.match(smoke, /command -v xdpyinfo/);
+
+  const log = await readFile(fake.log, "utf8");
+  assert.match(log, /--name crabbox-linux-devtools-telegram-/);
+  assert.match(
+    log,
+    /image promote --target linux --json --region us-west-2 --catalog-only --desktop --variant-sdk telegram-desktop=7\.0\.9 ami-devtools/,
+  );
+  const warmups = log.split("\n").filter((line) => line.includes("args warmup "));
+  assert.equal(warmups.length, 4);
+  assert.match(warmups[2], /--image-sdk telegram-desktop=7\.0\.9/);
+  assert.doesNotMatch(warmups[3], /--image-sdk/);
+  assert.match(log, /stop --provider aws --target linux cbx_promoted/);
+  assert.match(log, /stop --provider aws --target linux cbx_default/);
+  const prepRun = log.match(/run --provider aws --target linux --id cbx_source --no-sync --script (\S+)/);
+  assert.ok(prepRun);
+  await assert.rejects(readFile(prepRun[1], "utf8"));
+});
+
+test("AWS devtools mint wrapper rejects invalid Telegram variant targets", async () => {
+  const fake = await setupFakeCrabbox();
+  const windows = await runScript(
+    [
+      "--target",
+      "windows",
+      "--telegram-desktop",
+      "--prep-script",
+      fake.windowsPrep,
+    ],
+    { CRABBOX_BIN: fake.fake, CRABBOX_FAKE_LOG: fake.log },
+  );
+  assert.equal(windows.code, 2);
+  assert.match(windows.stderr, /--telegram-desktop requires --target linux/);
+
+  const headless = await runScript(
+    [
+      "--target",
+      "linux",
+      "--telegram-desktop",
+      "--no-desktop",
+      "--prep-script",
+      fake.linuxPrep,
+    ],
+    { CRABBOX_BIN: fake.fake, CRABBOX_FAKE_LOG: fake.log },
+  );
+  assert.equal(headless.code, 2);
+  assert.match(headless.stderr, /--telegram-desktop requires desktop bootstrap/);
+
+  await writeFile(fake.linuxPrep, "#!/usr/bin/env bash\nexit 0\n");
+  const unpinned = await runScript(
+    ["--target", "linux", "--telegram-desktop", "--prep-script", fake.linuxPrep],
+    { CRABBOX_BIN: fake.fake, CRABBOX_FAKE_LOG: fake.log },
+  );
+  assert.equal(unpinned.code, 2);
+  assert.match(unpinned.stderr, /telegram_desktop_version pin not found/);
 });
 
 test("AWS devtools mint wrapper isolates warmup logs from explicit image names", async () => {


### PR DESCRIPTION
Follow-up to https://github.com/openclaw/crabbox/pull/1349 (catalog-only variant primitive): the first consumer.

## What Problem This Solves

Resolves a problem where OpenClaw's Telegram Desktop proof lanes had to install ~20 apt packages, download Telegram Desktop from telegram.org, and download TDLib on every fresh Linux desktop lease. That per-lease bootstrap added minutes and raced Ubuntu's `unattended-upgrades` (`Could not get lock /var/lib/dpkg/lock-frontend`) — the leading failure in the last runs of https://github.com/openclaw/openclaw/actions/workflows/mantis-telegram-desktop-proof.yml.

## Why This Change Was Made

Telegram Desktop is a stable machine capability that only some lanes need, so it ships as a **catalog-only variant image**, never in the generic desktop default:

- `scripts/install-linux-developer-tools.sh`: `CRABBOX_LINUX_TELEGRAM_DESKTOP=1` (default **0**; the generic bake is byte-identical to today) installs checksum-pinned Telegram Desktop 7.0.9 to `/opt/Telegram`, removes its `Updater`, writes `/var/lib/crabbox/telegram-desktop-version`, and adds `zbar-tools`/`x11-utils` plus the xcb/xkb runtime libs. amd64 only; other architectures skip and omit the marker.
- `scripts/mint-aws-devtools-image.sh --telegram-desktop` (Linux, desktop required): bakes `crabbox-linux-devtools-telegram-<id>`, smokes the Telegram contract, promotes `--catalog-only --desktop --variant-sdk telegram-desktop=7.0.9`, then proves both that a `--image-sdk telegram-desktop=7.0.9` lease selects the new AMI and that a plain lease still selects the previous default (`default-unchanged` proof lease).
- `devtools-image-publish` gains a `telegram_desktop` boolean input (default false); the generic path is unchanged when false.

Consumers opt in per lease with `crabbox warmup --desktop --image-sdk telegram-desktop=7.0.9`; Crabbox refuses the lease if no such image is promoted. No TDLib, no login state, no scenario data in the image.

## User Impact

Generic Crabbox desktop leases are unaffected. Lanes that ask for the Telegram capability boot with Telegram Desktop ready and skip per-lease apt/download work; OpenClaw's recorder preflights the contract and starts recording in seconds.

## Evidence

Real amd64 lease proof of the bake path (promoted `crabbox-devtools-v1` desktop image, `c7a.8xlarge`, lease `cbx_35253c1cee3e`, released):

- Baseline on the current promoted image: `telegram-absent`, `no-zbarimg`.
- Prep script with the gate on → exit 0 in 1m40s; `print_versions` ends with `telegram-desktop=7.0.9`.
- Recorder preflight on the same lease:
  ```
  binary: ok            (/opt/Telegram/Telegram executable)
  updater removed: ok
  marker: 7.0.9
  wmctrl/xdotool/scrot/ffmpeg/zbarimg/xdpyinfo: ok
  DISPLAY :99: ok
  ```
- Launch: `/opt/Telegram/Telegram -noupdate -workdir …` → `wmctrl -lx`: `Telegram.TelegramDesktop … Telegram`; screenshot (intro screen, no login QR/token in frame):

  ![baked Telegram Desktop launched under Xvfb on the Crabbox desktop lease](https://github.com/user-attachments/assets/3d9a580e-875a-4c12-ba3f-b2d212ee987e)

Local:

- `node --test scripts/install-linux-developer-tools.test.js scripts/mint-aws-devtools-image.test.js scripts/devtools-image-workflow.test.js` → 34 passed, 0 failed (gate default off + generic block free of Telegram; pinned install once without updater; non-amd64 skip; mint flag/plan/wrapper prep/name suffix/`--catalog-only --desktop --variant-sdk` promote args/`--image-sdk` proof/default-unchanged proof; workflow input wiring)
- `shellcheck` (koalaman/shellcheck:v0.10.0) on both scripts → clean; `node scripts/build-docs-site.mjs` → built
- Tarball digest re-verified: `sha256sum tsetup.7.0.9.tar.xz` = `d3c05df0259ab116d11d8c1cdc1403019d2a3be303ad3b46d16a84e19df6615f`; upstream latest tag `v7.0.9`

The variant bake/promotion itself runs after merge: dispatch `devtools-image-publish` with `target=linux`, `telegram_desktop=true`; that run's log (candidate smoke, catalog-only promote, `--image-sdk` selection, `default-unchanged`) will be attached here.
