### PR TITLE
fix(heartbeat): persist dynamic local-container claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- Made local-container heartbeat authorize recorded dynamic runtime scopes and durably compare-and-swap exact claim lifecycle state without recreating or overwriting changed claims. Thanks @coygeek.
 - Made AWS image deletion resume from owner-level durable snapshot claims after AMI deregistration or catalog cleanup failures, preventing stale ordinary and capability-variant records from remaining selectable.
 - Made static SSH heartbeats persist touched timestamps and explicit idle-timeout replacements across fresh CLI processes, while omitted overrides preserve the stored timeout. Thanks @coygeek.
 - Bounded Lambda MicroVM runner response-header waits without limiting uploads or streamed executions, while preserving injected HTTP clients. Thanks @SebTardif.

--- a/docs/commands/heartbeat.md
+++ b/docs/commands/heartbeat.md
@@ -30,16 +30,23 @@ with the same idle timeout before reporting success.
 
 Without a coordinator, Crabbox resolves the direct SSH lease and calls the
 provider's existing `Touch` capability. This fallback requires an exact local
-claim that matches the provider scope and live resource identity, and it
-rejects terminal leases before touching them. Providers without lease-touch
-support fail with `provider=<name> does not support lease heartbeat`.
+claim for the canonical provider. Static scopes must match the configured
+provider scope and live resource identity exactly. Providers with a dynamic
+runtime scope may hydrate their recorded context, but must validate the live
+endpoint/daemon identity and exact resource before authorizing. The provider
+then compare-and-swaps the carried claim snapshot, so a disappeared or replaced
+claim is never recreated or overwritten. Terminal leases are rejected before
+touch. Providers without lease-touch support fail with
+`provider=<name> does not support lease heartbeat`.
 
 ## Idle timeout
 
 `--idle-timeout <duration>` optionally replaces the lease's idle window while
 refreshing it. The value must be positive. Omitting the flag preserves the
 current direct-provider timeout when it is available in lease metadata and
-omits the coordinator heartbeat override.
+omits the coordinator heartbeat override. Direct static and local-runtime
+providers persist the refreshed timestamps, expiry, and any explicit timeout
+replacement in the exact claim so a fresh CLI process observes the same state.
 
 ## Output
 

--- a/docs/features/provider-authoring.md
+++ b/docs/features/provider-authoring.md
@@ -338,6 +338,23 @@ claim under its claim lock after revalidating provider, scope, resource, and
 host identity. Updating only the returned in-memory `Server` makes heartbeat
 success disappear in a fresh process and is not sufficient.
 
+Providers whose exact ownership scope is captured from a runtime rather than
+derived statically from config may implement the narrow optional capability:
+
+```go
+type StatusTouchClaimAuthorizer interface {
+	AuthorizeStatusTouchClaim(context.Context, LeaseTarget, LeaseClaim) error
+}
+```
+
+Core first resolves an exact claim for the canonical provider, then delegates
+the complete status/heartbeat authorization decision to this method. The
+backend must fail closed unless the lease ID, provider, non-empty current
+scope, live resource, and every provider-owned runtime identity field match.
+If authorization requires hydrating a recorded context or endpoint, validate
+that captured route and its live immutable identity before returning `nil`.
+This hook must not adopt, rewrite, or otherwise repair a claim.
+
 `ReleaseLease` is called when a lease ends or expires. Make it idempotent; treat
 "not found" as success. Remove local claims and the per-lease key directory
 after the provider release succeeds.

--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -226,6 +226,24 @@ must never replace the command failure. A fresh collector is created for every
 command, including watch iterations and reused leases, so historical provider
 counters cannot be attributed to a later run.
 
+Exact status/heartbeat claim authorization is optional for providers with a
+runtime-derived ownership scope:
+
+```go
+type StatusTouchClaimAuthorizer interface {
+	AuthorizeStatusTouchClaim(context.Context, LeaseTarget, LeaseClaim) error
+}
+```
+
+Core requires an exact claim for the canonical provider before calling this
+hook. Implementations then own the full authorization decision; only `nil`
+permits a touch. They must validate the canonical lease and resource IDs, a
+non-empty current scope, and all provider-native context, endpoint, account,
+daemon, or immutable runtime identity recorded by the claim. Hydration may
+select the recorded runtime route, but it must not mutate or adopt ownership.
+Providers without this capability retain core's exact static provider-scope
+and resource comparison, plus any `StatusTouchClaimValidator` check.
+
 ## Package layout
 
 Built-in providers live under `internal/providers/<name>`. The registry is
@@ -621,11 +639,12 @@ rendering belongs to core.
 
 `Touch` should update provider labels/tags with idle and state metadata when the
 provider supports it. `TouchRequest.IdleTimeoutOverride` is non-nil only for an
-explicit replacement; omission must preserve the persisted timeout. Static
-providers must atomically compare-and-swap lifecycle labels and an optional
-timeout into the exact canonical local claim, then reconstruct later `Resolve`
-results from that claim. An in-memory-only static touch is not durable enough
-for heartbeat.
+explicit replacement; omission must preserve the persisted timeout. Static and
+local-runtime providers must atomically compare-and-swap lifecycle labels and
+an optional timeout into the exact canonical local claim, then reconstruct
+later `Resolve` results from that claim. `Touch` must require the exact claim
+snapshot carried by `Resolve` and revalidate ownership before the CAS. An
+in-memory-only touch is not durable enough for heartbeat.
 
 `ReleaseLease` should be idempotent where practical. Remove local claims after the
 provider release succeeds or is known to be unnecessary.

--- a/docs/providers/local-container.md
+++ b/docs/providers/local-container.md
@@ -238,10 +238,15 @@ metadata updates.
    `localContainer.workRoot`, then drives the command over the normal SSH
    executor.
 9. `status`, `list`, and `stop` inspect or remove labeled containers.
-10. `cleanup --provider docker` removes stopped containers and running
+10. `heartbeat` and `status --wait` hydrate the exact claim's recorded runtime
+   route, verify its context, endpoint, daemon, and container ID, then
+   compare-and-swap touched timestamps, expiry, and any explicit idle-timeout
+   replacement into that same claim. Omitting `--idle-timeout` preserves the
+   stored timeout even when current config differs.
+11. `cleanup --provider docker` removes stopped containers and running
    non-`keep` containers whose local claim or lease labels are stale past the
    idle timeout plus a safety grace period.
-11. If a local claim remains after its container was removed outside Crabbox,
+12. If a local claim remains after its container was removed outside Crabbox,
    `crabbox stop --provider docker <lease-or-slug>` removes the stale claim and
    stored SSH key.
 
@@ -263,6 +268,9 @@ Named Docker contexts and Podman connections are included in those recovery
 commands. Custom runtime endpoints remain private in the local claim rather
 than being printed; exact-ID commands hydrate that route from the claim before
 their first runtime lookup and reject a changed endpoint or daemon identity.
+Heartbeat uses the same fail-closed ownership boundary. A missing claim, stale
+resolved snapshot, changed provider/runtime scope, replaced daemon, or different
+container ID leaves both the container and claim untouched.
 
 ## Limits and caveats
 

--- a/internal/cli/heartbeat.go
+++ b/internal/cli/heartbeat.go
@@ -90,7 +90,7 @@ func (a App) heartbeat(ctx context.Context, args []string) error {
 	if statusTerminalState(state) {
 		return exit(5, "lease %s is in terminal state %s", *id, state)
 	}
-	claimed, err := statusLeaseHasExactClaim(backend, lease, backend.Spec().Name, leaseOptionsFromConfig(cfg).ProviderScope)
+	claimed, err := statusLeaseHasExactClaim(ctx, backend, lease, backend.Spec().Name, leaseOptionsFromConfig(cfg).ProviderScope)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -170,6 +170,12 @@ type StatusTouchClaimValidator interface {
 	StatusTouchClaimMatches(LeaseTarget, LeaseClaim) bool
 }
 
+// StatusTouchClaimAuthorizer lets a provider fully authorize an exact claim
+// whose ownership scope must be hydrated or validated at runtime.
+type StatusTouchClaimAuthorizer interface {
+	AuthorizeStatusTouchClaim(context.Context, LeaseTarget, LeaseClaim) error
+}
+
 type ResolvedLeaseTargetRebinder interface {
 	RebindResolvedLeaseTarget(target *LeaseTarget, leaseID string) error
 }

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -68,7 +68,7 @@ func (a App) status(ctx context.Context, args []string) error {
 			if err == nil {
 				state, err = statusViewFromLeaseTarget(statusCtx, cfg, lease)
 				if err == nil && *wait {
-					claimed, claimErr := statusLeaseHasExactClaim(backend, lease, backend.Spec().Name, leaseOptionsFromConfig(cfg).ProviderScope)
+					claimed, claimErr := statusLeaseHasExactClaim(statusCtx, backend, lease, backend.Spec().Name, leaseOptionsFromConfig(cfg).ProviderScope)
 					if claimErr != nil {
 						fmt.Fprintf(a.Stderr, "warning: touch skipped for %s: %v\n", lease.LeaseID, claimErr)
 					} else if claimed {
@@ -136,7 +136,7 @@ func statusWaitDone(state statusView) bool {
 	return state.Ready || statusTerminalState(state.State)
 }
 
-func statusLeaseHasExactClaim(backend Backend, lease LeaseTarget, fallbackProvider, providerScope string) (bool, error) {
+func statusLeaseHasExactClaim(ctx context.Context, backend Backend, lease LeaseTarget, fallbackProvider, providerScope string) (bool, error) {
 	provider := canonicalClaimProvider(blank(lease.Server.Provider, fallbackProvider))
 	if lease.LeaseID == "" || provider == "" {
 		return false, nil
@@ -145,9 +145,17 @@ func statusLeaseHasExactClaim(backend Backend, lease LeaseTarget, fallbackProvid
 	if err != nil {
 		return false, fmt.Errorf("read exact %s lease claim: %w", provider, err)
 	}
+	if !claimed || !exact {
+		return false, nil
+	}
+	if authorizer, ok := backend.(StatusTouchClaimAuthorizer); ok {
+		if err := authorizer.AuthorizeStatusTouchClaim(ctx, lease, claim); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
 	resourceID := strings.TrimSpace(lease.Server.CloudID)
-	matched := claimed && exact &&
-		claim.ProviderScope == providerScope &&
+	matched := claim.ProviderScope == providerScope &&
 		resourceID != "" && claim.CloudID == resourceID
 	if !matched {
 		return false, nil

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -188,20 +188,20 @@ func TestStatusWaitRequestsReadyProbe(t *testing.T) {
 		t.Fatal(err)
 	}
 	providerScope := leaseOptionsFromConfig(cfg).ProviderScope
-	claimed, err := statusLeaseHasExactClaim(backend, LeaseTarget{LeaseID: "cbx_status", Server: claimServer}, "aws", providerScope)
+	claimed, err := statusLeaseHasExactClaim(context.Background(), backend, LeaseTarget{LeaseID: "cbx_status", Server: claimServer}, "aws", providerScope)
 	if err != nil || !claimed {
 		t.Fatalf("matching exact claim allowed=%t err=%v", claimed, err)
 	}
 	rejecting := &statusTouchClaimRejectingBackend{statusResolveRecordingBackend: backend}
-	if claimed, err := statusLeaseHasExactClaim(rejecting, LeaseTarget{LeaseID: "cbx_status", Server: claimServer}, "aws", providerScope); err != nil || claimed {
+	if claimed, err := statusLeaseHasExactClaim(context.Background(), rejecting, LeaseTarget{LeaseID: "cbx_status", Server: claimServer}, "aws", providerScope); err != nil || claimed {
 		t.Fatalf("provider identity-rejected claim allowed=%t err=%v", claimed, err)
 	}
-	if claimed, err := statusLeaseHasExactClaim(backend, LeaseTarget{LeaseID: "cbx_status", Server: claimServer}, "aws", providerScope+"-other"); err != nil || claimed {
+	if claimed, err := statusLeaseHasExactClaim(context.Background(), backend, LeaseTarget{LeaseID: "cbx_status", Server: claimServer}, "aws", providerScope+"-other"); err != nil || claimed {
 		t.Fatalf("scope-mismatched claim allowed=%t err=%v", claimed, err)
 	}
 	wrongResource := claimServer
 	wrongResource.CloudID = "i-other"
-	if claimed, err := statusLeaseHasExactClaim(backend, LeaseTarget{LeaseID: "cbx_status", Server: wrongResource}, "aws", providerScope); err != nil || claimed {
+	if claimed, err := statusLeaseHasExactClaim(context.Background(), backend, LeaseTarget{LeaseID: "cbx_status", Server: wrongResource}, "aws", providerScope); err != nil || claimed {
 		t.Fatalf("resource-mismatched claim allowed=%t err=%v", claimed, err)
 	}
 	err = app.status(context.Background(), []string{"--provider", "aws", "--id", "cbx_status", "--wait", "--wait-timeout", "1ns"})
@@ -210,6 +210,60 @@ func TestStatusWaitRequestsReadyProbe(t *testing.T) {
 	}
 	if len(backend.touches) != 1 {
 		t.Fatalf("claimed status --wait touch calls=%d want 1", len(backend.touches))
+	}
+}
+
+func TestStatusLeaseExactClaimAuthorizerOwnsDynamicScopeValidation(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	leaseID := "cbx_dynamic_status"
+	server := Server{Provider: "aws", CloudID: "dynamic-resource", Labels: map[string]string{
+		"lease": leaseID, "provider": "aws", "runtime_scope": "runtime:dynamic/context:owned",
+	}}
+	if err := claimLeaseForRepoProviderScopePondEndpoint(
+		leaseID,
+		"dynamic-status",
+		"aws",
+		"runtime:dynamic/context:owned",
+		"",
+		t.TempDir(),
+		time.Minute,
+		false,
+		server,
+		SSHTarget{},
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.WithValue(context.Background(), statusAuthorizerContextKey{}, "present")
+	backend := &statusTouchClaimAuthorizingBackend{}
+	claimed, err := statusLeaseHasExactClaim(ctx, backend, LeaseTarget{LeaseID: leaseID, Server: server}, "aws", "")
+	if err != nil || !claimed {
+		t.Fatalf("dynamic claim authorized=%t err=%v", claimed, err)
+	}
+	if backend.calls != 1 || backend.contextValue != "present" || backend.claim.ProviderScope != "runtime:dynamic/context:owned" {
+		t.Fatalf("authorizer calls=%d context=%q claim=%#v", backend.calls, backend.contextValue, backend.claim)
+	}
+
+	backend.err = errors.New("dynamic ownership mismatch")
+	claimed, err = statusLeaseHasExactClaim(ctx, backend, LeaseTarget{LeaseID: leaseID, Server: server}, "aws", "")
+	if claimed || err == nil || !strings.Contains(err.Error(), "dynamic ownership mismatch") {
+		t.Fatalf("rejected dynamic claim authorized=%t err=%v", claimed, err)
+	}
+
+	backend.calls = 0
+	wrongProvider := server
+	wrongProvider.Provider = "gcp"
+	if claimed, err := statusLeaseHasExactClaim(ctx, backend, LeaseTarget{LeaseID: leaseID, Server: wrongProvider}, "aws", ""); err != nil || claimed {
+		t.Fatalf("wrong-provider claim authorized=%t err=%v", claimed, err)
+	}
+	if backend.calls != 0 {
+		t.Fatalf("authorizer called before exact canonical-provider claim check: %d", backend.calls)
+	}
+	if claimed, err := statusLeaseHasExactClaim(ctx, backend, LeaseTarget{LeaseID: "cbx_missing_dynamic", Server: server}, "aws", ""); err != nil || claimed {
+		t.Fatalf("missing claim authorized=%t err=%v", claimed, err)
+	}
+	if backend.calls != 0 {
+		t.Fatalf("authorizer called for missing claim: %d", backend.calls)
 	}
 }
 
@@ -267,6 +321,23 @@ type statusTouchClaimRejectingBackend struct {
 
 func (*statusTouchClaimRejectingBackend) StatusTouchClaimMatches(LeaseTarget, LeaseClaim) bool {
 	return false
+}
+
+type statusAuthorizerContextKey struct{}
+
+type statusTouchClaimAuthorizingBackend struct {
+	testSSHBackend
+	calls        int
+	contextValue string
+	claim        LeaseClaim
+	err          error
+}
+
+func (b *statusTouchClaimAuthorizingBackend) AuthorizeStatusTouchClaim(ctx context.Context, _ LeaseTarget, claim LeaseClaim) error {
+	b.calls++
+	b.contextValue, _ = ctx.Value(statusAuthorizerContextKey{}).(string)
+	b.claim = claim
+	return b.err
 }
 
 func (b *statusResolveRecordingBackend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {

--- a/internal/providers/localcontainer/backend.go
+++ b/internal/providers/localcontainer/backend.go
@@ -51,6 +51,7 @@ type backend struct {
 }
 
 var _ core.ExclusiveOneShotAcquireBackend = (*backend)(nil)
+var _ core.StatusTouchClaimAuthorizer = (*backend)(nil)
 
 type inspectContainer struct {
 	ID              string            `json:"Id"`
@@ -927,6 +928,23 @@ func (b *backend) validateExactLocalContainerClaim(ctx context.Context, claim co
 	return nil
 }
 
+func (b *backend) AuthorizeStatusTouchClaim(ctx context.Context, lease core.LeaseTarget, claim core.LeaseClaim) error {
+	leaseID := strings.TrimSpace(lease.LeaseID)
+	containerID := strings.TrimSpace(lease.Server.CloudID)
+	if lease.Server.Provider != providerName || claim.LeaseID != leaseID || claim.Provider != providerName ||
+		claim.CloudID == "" || claim.CloudID != containerID {
+		return localContainerOwnershipError(lease.LeaseID, lease.Server.CloudID)
+	}
+	applied, err := b.applyCheckpointScopeLabels(ctx, claim.Labels)
+	if err != nil {
+		return err
+	}
+	if !applied {
+		return localContainerOwnershipError(lease.LeaseID, lease.Server.CloudID)
+	}
+	return b.validateExactLocalContainerClaim(ctx, claim, lease.LeaseID, lease.Server.CloudID)
+}
+
 func (b *backend) releaseMissingClaim(ctx context.Context, lease core.LeaseTarget) (bool, error) {
 	leaseID := strings.TrimSpace(firstNonBlank(lease.LeaseID, lease.Server.Labels["lease"]))
 	if leaseID == "" || strings.TrimSpace(lease.Server.CloudID) != "" {
@@ -1405,21 +1423,47 @@ func (b *backend) cleanupContainerSidecars(leaseID string, labels map[string]str
 	return nil
 }
 
-func (b *backend) Touch(_ context.Context, req core.TouchRequest) (core.Server, error) {
-	server := req.Lease.Server
-	if server.Labels == nil {
-		server.Labels = map[string]string{}
+func (b *backend) Touch(ctx context.Context, req core.TouchRequest) (core.Server, error) {
+	expected, exists, set := core.ServerLeaseClaimSnapshot(req.Lease.Server)
+	if !set || !exists {
+		return core.Server{}, core.Exit(4, "local-container lease %s has no exact claim snapshot; refusing touch", req.Lease.LeaseID)
 	}
-	original := server.Labels
-	server.Labels = core.TouchDirectLeaseLabels(original, b.configForRun(), req.State, time.Now().UTC())
-	preservedKeys := []string{"bootstrap_dir", "container_id", "docker_socket", "host_work_root", "image", "runtime", "runtime_context", "ssh_port", "ssh_user", "work_root"}
-	preservedKeys = append(preservedKeys, checkpointScopeMetadataKeys...)
-	for _, key := range preservedKeys {
-		if value := strings.TrimSpace(original[key]); value != "" {
-			server.Labels[key] = value
-		}
+	if err := b.AuthorizeStatusTouchClaim(ctx, req.Lease, expected); err != nil {
+		return core.Server{}, err
 	}
+	if req.IdleTimeoutOverride != nil && *req.IdleTimeoutOverride <= 0 {
+		return core.Server{}, core.Exit(2, "local-container lease %s idle timeout override must be positive", req.Lease.LeaseID)
+	}
+
+	now := time.Now().UTC()
+	if b.rt.Clock != nil {
+		now = b.rt.Clock.Now().UTC()
+	}
+	cfg := b.configForRun()
+	if expected.IdleTimeoutSeconds > 0 {
+		cfg.IdleTimeout = time.Duration(expected.IdleTimeoutSeconds) * time.Second
+	}
+	labels := localContainerTouchLabels(expected, cfg, req.State, now, req.IdleTimeoutOverride)
+	updated, err := core.UpdateLeaseClaimTouchIfUnchanged(req.Lease.LeaseID, expected, labels, now, req.IdleTimeoutOverride)
+	if err != nil {
+		return core.Server{}, err
+	}
+	server := mergeLocalContainerClaim(req.Lease.Server, updated)
+	core.SetServerLeaseClaimSnapshot(&server, updated, true)
 	return server, nil
+}
+
+func localContainerTouchLabels(claim core.LeaseClaim, cfg core.Config, state string, now time.Time, idleTimeoutOverride *time.Duration) map[string]string {
+	labels := cloneLabels(claim.Labels)
+	labels = core.TouchDirectLeaseLabelsWithIdleTimeoutOverride(labels, cfg, state, now, idleTimeoutOverride)
+	for key, value := range claim.Labels {
+		switch key {
+		case "state", "last_touched_at", "idle_timeout", "idle_timeout_secs", "expires_at":
+			continue
+		}
+		labels[key] = value
+	}
+	return labels
 }
 
 func (b *backend) ValidateCheckpointForkWorkdir(ctx context.Context, lease core.LeaseTarget, workdir string) error {

--- a/internal/providers/localcontainer/backend_test.go
+++ b/internal/providers/localcontainer/backend_test.go
@@ -30,6 +30,10 @@ type recordingRunner struct {
 	run       func(core.LocalCommandRequest) (core.LocalCommandResult, error)
 }
 
+type localContainerTestClock struct{ now time.Time }
+
+func (c localContainerTestClock) Now() time.Time { return c.now }
+
 func (r *recordingRunner) Run(_ context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 	r.calls = append(r.calls, req)
 	if r.run != nil {
@@ -3654,33 +3658,161 @@ func TestResolvePendingClaimDoesNotRequirePublishedSSHPort(t *testing.T) {
 	}
 }
 
-func TestTouchPreservesLocalContainerLabels(t *testing.T) {
-	b := testBackend(&recordingRunner{responses: map[string]core.LocalCommandResult{}})
-	bootstrapDir := filepath.Join(os.TempDir(), "crabbox-bootstrap-touchtest")
-	lease := core.LeaseTarget{
-		LeaseID: "cbx_touch",
-		Server: core.Server{
-			Labels: map[string]string{
-				"bootstrap_dir":  bootstrapDir,
-				"docker_socket":  "1",
-				"host_work_root": "/tmp/crabbox-local-container-work",
-				"work_root":      "/tmp/crabbox-local-container-work",
-				"ssh_user":       "runner",
-			},
-		},
+func TestAuthorizeStatusTouchClaimHydratesDynamicRuntimeScope(t *testing.T) {
+	leaseID, containerID, claim, runner := createLocalContainerTouchClaim(t, 37*time.Minute)
+	b := testBackend(runner)
+	if len(b.cfg.LocalContainer.CheckpointMetadata) != 0 {
+		t.Fatal("test backend unexpectedly started with hydrated runtime metadata")
 	}
-	server, err := b.Touch(context.Background(), core.TouchRequest{Lease: lease, State: "running"})
-	if err != nil {
+	lease := core.LeaseTarget{LeaseID: leaseID, Server: core.Server{Provider: providerName, CloudID: containerID}}
+	if err := b.AuthorizeStatusTouchClaim(context.Background(), lease, claim); err != nil {
 		t.Fatal(err)
 	}
-	if server.Labels["work_root"] != lease.Server.Labels["work_root"] || server.Labels["host_work_root"] != lease.Server.Labels["host_work_root"] || server.Labels["docker_socket"] != "1" || server.Labels["ssh_user"] != "runner" {
-		t.Fatalf("provider labels not preserved: %#v", server.Labels)
+	if got := b.claimScope(context.Background()); got != claim.ProviderScope {
+		t.Fatalf("hydrated scope=%q want=%q", got, claim.ProviderScope)
 	}
-	if server.Labels["bootstrap_dir"] != bootstrapDir {
-		t.Fatalf("bootstrap_dir not preserved through touch: got %q want %q", server.Labels["bootstrap_dir"], bootstrapDir)
+	if got := b.cfg.LocalContainer.CheckpointMetadata[checkpointMetadataEndpoint]; got != claim.Labels[checkpointMetadataEndpoint] {
+		t.Fatalf("hydrated endpoint=%q want=%q", got, claim.Labels[checkpointMetadataEndpoint])
 	}
-	if server.Labels["state"] != "running" {
-		t.Fatalf("state not touched: %#v", server.Labels)
+}
+
+func TestLocalContainerTouchPersistsExactClaimLifecycle(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		override    *time.Duration
+		wantTimeout time.Duration
+	}{
+		{name: "omitted override preserves stored timeout", wantTimeout: 37 * time.Minute},
+		{name: "explicit override persists", override: durationPointer(45 * time.Minute), wantTimeout: 45 * time.Minute},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			leaseID, _, initial, runner := createLocalContainerTouchClaim(t, 37*time.Minute)
+			touchedAt := time.Date(2026, time.August, 17, 20, 30, 0, 0, time.UTC)
+			b := testBackend(runner)
+			b.cfg.IdleTimeout = 5 * time.Minute
+			b.rt.Clock = localContainerTestClock{now: touchedAt}
+			resolved, err := b.Resolve(context.Background(), core.ResolveRequest{ID: leaseID, StatusOnly: true, NoLocalStateMutations: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			touched, err := b.Touch(context.Background(), core.TouchRequest{
+				Lease:               resolved,
+				State:               "busy",
+				IdleTimeout:         5 * time.Minute,
+				IdleTimeoutOverride: test.override,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			committed, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
+			if err != nil || !exists {
+				t.Fatalf("read committed claim exists=%t err=%v", exists, err)
+			}
+			if committed.IdleTimeoutSeconds != int(test.wantTimeout/time.Second) {
+				t.Fatalf("committed timeout=%d want=%d", committed.IdleTimeoutSeconds, int(test.wantTimeout/time.Second))
+			}
+			if committed.LastUsedAt != touchedAt.Format(time.RFC3339) || committed.Labels["last_touched_at"] != core.LeaseLabelTime(touchedAt) {
+				t.Fatalf("committed touch lastUsed=%q labels=%#v", committed.LastUsedAt, committed.Labels)
+			}
+			if committed.Labels["idle_timeout_secs"] != strconv.Itoa(int(test.wantTimeout/time.Second)) {
+				t.Fatalf("committed timeout label=%q", committed.Labels["idle_timeout_secs"])
+			}
+			if got := unixLocalContainerLabelTime(t, committed.Labels["expires_at"]); !got.Equal(touchedAt.Add(test.wantTimeout)) {
+				t.Fatalf("expires=%s want=%s", got, touchedAt.Add(test.wantTimeout))
+			}
+			for _, key := range []string{"bootstrap_dir", "host_work_root", "work_root", checkpointMetadataConfig, checkpointMetadataEndpoint, checkpointMetadataDaemonID} {
+				if committed.Labels[key] != initial.Labels[key] {
+					t.Fatalf("claim label %s=%q want exact %q", key, committed.Labels[key], initial.Labels[key])
+				}
+			}
+			if touched.Status != "busy" || touched.Labels["state"] != "busy" {
+				t.Fatalf("touch response status=%q labels=%#v", touched.Status, touched.Labels)
+			}
+			snapshot, snapshotExists, snapshotSet := core.ServerLeaseClaimSnapshot(touched)
+			if !snapshotSet || !snapshotExists || !reflect.DeepEqual(snapshot, committed) {
+				t.Fatalf("touch snapshot set=%t exists=%t snapshot=%#v committed=%#v", snapshotSet, snapshotExists, snapshot, committed)
+			}
+
+			freshRunner := localContainerTouchRunner(t, leaseID, committed.CloudID)
+			fresh := testBackend(freshRunner)
+			fresh.cfg.IdleTimeout = 3 * time.Minute
+			freshResolved, err := fresh.Resolve(context.Background(), core.ResolveRequest{ID: leaseID, StatusOnly: true, NoLocalStateMutations: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if freshResolved.Server.Labels["last_touched_at"] != committed.Labels["last_touched_at"] || freshResolved.Server.Labels["expires_at"] != committed.Labels["expires_at"] || freshResolved.Server.Labels["idle_timeout_secs"] != committed.Labels["idle_timeout_secs"] {
+				t.Fatalf("fresh resolve lost committed lifecycle: fresh=%#v committed=%#v", freshResolved.Server.Labels, committed.Labels)
+			}
+			freshSnapshot, freshExists, freshSet := core.ServerLeaseClaimSnapshot(freshResolved.Server)
+			if !freshSet || !freshExists || !reflect.DeepEqual(freshSnapshot, committed) {
+				t.Fatalf("fresh resolve snapshot set=%t exists=%t snapshot=%#v", freshSet, freshExists, freshSnapshot)
+			}
+		})
+	}
+}
+
+func TestLocalContainerTouchRejectsUnownedOrChangedClaimWithoutMutation(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(*testing.T, *backend, *core.LeaseTarget, core.LeaseClaim)
+	}{
+		{name: "missing carried snapshot", mutate: func(_ *testing.T, _ *backend, lease *core.LeaseTarget, _ core.LeaseClaim) {
+			lease.Server = core.Server{Provider: lease.Server.Provider, CloudID: lease.Server.CloudID, Labels: cloneLabels(lease.Server.Labels)}
+		}},
+		{name: "wrong provider", mutate: func(t *testing.T, _ *backend, lease *core.LeaseTarget, claim core.LeaseClaim) {
+			claim.Provider = "aws"
+			core.SetServerLeaseClaimSnapshot(&lease.Server, claim, true)
+		}},
+		{name: "wrong dynamic runtime scope", mutate: func(t *testing.T, _ *backend, lease *core.LeaseTarget, claim core.LeaseClaim) {
+			claim.ProviderScope = "runtime:docker/context:other"
+			core.SetServerLeaseClaimSnapshot(&lease.Server, claim, true)
+		}},
+		{name: "wrong container", mutate: func(_ *testing.T, _ *backend, lease *core.LeaseTarget, _ core.LeaseClaim) {
+			lease.Server.CloudID = strings.Repeat("b", 64)
+		}},
+		{name: "runtime metadata mismatch", mutate: func(t *testing.T, _ *backend, lease *core.LeaseTarget, claim core.LeaseClaim) {
+			claim.Labels = cloneLabels(claim.Labels)
+			claim.Labels[checkpointMetadataContext] = "other"
+			core.SetServerLeaseClaimSnapshot(&lease.Server, claim, true)
+		}},
+		{name: "stale carried snapshot after CAS replacement", mutate: func(t *testing.T, _ *backend, lease *core.LeaseTarget, claim core.LeaseClaim) {
+			labels := cloneLabels(claim.Labels)
+			labels["concurrent_replacement"] = "true"
+			if _, err := core.UpdateLeaseClaimLabelsIfUnchanged(lease.LeaseID, claim, labels); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{name: "raced-away claim", mutate: func(_ *testing.T, _ *backend, lease *core.LeaseTarget, _ core.LeaseClaim) {
+			core.RemoveLeaseClaim(lease.LeaseID)
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			leaseID, _, initial, runner := createLocalContainerTouchClaim(t, 37*time.Minute)
+			b := testBackend(runner)
+			resolved, err := b.Resolve(context.Background(), core.ResolveRequest{ID: leaseID, StatusOnly: true, NoLocalStateMutations: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			test.mutate(t, b, &resolved, initial)
+			before, beforeExists, err := core.ReadLeaseClaimWithPresence(leaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			callsBefore := len(runner.calls)
+			if _, err := b.Touch(context.Background(), core.TouchRequest{Lease: resolved, State: "busy"}); err == nil {
+				t.Fatal("touch unexpectedly succeeded")
+			}
+			after, afterExists, err := core.ReadLeaseClaimWithPresence(leaseID)
+			if err != nil || beforeExists != afterExists || !reflect.DeepEqual(before, after) {
+				t.Fatalf("rejected touch mutated claim: beforeExists=%t afterExists=%t err=%v before=%#v after=%#v", beforeExists, afterExists, err, before, after)
+			}
+			for _, call := range runner.calls[callsBefore:] {
+				if len(call.Args) > 0 && (call.Args[0] == "rm" || call.Args[0] == "run" || call.Args[0] == "stop") {
+					t.Fatalf("rejected touch reached container mutation: %#v", call.Args)
+				}
+			}
+		})
 	}
 }
 
@@ -5248,6 +5380,92 @@ func writeLocalContainerClaimAndKey(t *testing.T, leaseID, slug string, scopes .
 		scope = scopes[0]
 	}
 	return writeLocalContainerClaimAndKeyAt(t, leaseID, slug, scope, time.Now().UTC(), time.Minute)
+}
+
+func createLocalContainerTouchClaim(t *testing.T, idleTimeout time.Duration) (string, string, core.LeaseClaim, *recordingRunner) {
+	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	leaseID := "cbx_local_touch"
+	containerID := strings.Repeat("a", 64)
+	labels := testCapturedScopeLabels(map[string]string{
+		"bootstrap_dir":   filepath.Join(os.TempDir(), "crabbox-bootstrap-touch test"),
+		"container_id":    containerID[:12],
+		"crabbox":         "true",
+		"docker_socket":   "1",
+		"host_work_root":  filepath.Join(os.TempDir(), "crabbox local touch"),
+		"image":           "ubuntu:24.04",
+		"lease":           leaseID,
+		"provider":        providerName,
+		"runtime_context": "default",
+		"server_type":     "ubuntu:24.04",
+		"slug":            "local-touch",
+		"ssh_port":        "49153",
+		"ssh_user":        "runner",
+		"state":           "ready",
+		"created_at":      core.LeaseLabelTime(time.Date(2026, time.August, 17, 20, 0, 0, 0, time.UTC)),
+		"ttl_secs":        "86400",
+		"work_root":       "/workspace/crabbox touch",
+	})
+	labels[checkpointMetadataConfig] = filepath.Join(os.TempDir(), "docker config touch")
+	labels[checkpointMetadataEndpoint] = "unix:///tmp/docker touch.sock"
+	server := core.Server{Provider: providerName, CloudID: containerID, Status: "ready", Labels: labels}
+	server.PublicNet.IPv4.IP = "127.0.0.1"
+	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(
+		leaseID,
+		"local-touch",
+		providerName,
+		"runtime:docker/context:default",
+		"",
+		t.TempDir(),
+		idleTimeout,
+		false,
+		server,
+		core.SSHTarget{Host: "127.0.0.1", Port: "49153", User: "runner"},
+	); err != nil {
+		t.Fatal(err)
+	}
+	claim, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
+	if err != nil || !exists {
+		t.Fatalf("read touch claim exists=%t err=%v", exists, err)
+	}
+	return leaseID, containerID, claim, localContainerTouchRunner(t, leaseID, containerID)
+}
+
+func localContainerTouchRunner(t *testing.T, leaseID, containerID string) *recordingRunner {
+	t.Helper()
+	container := inspectContainer{
+		ID:   containerID,
+		Name: "/crabbox-local-touch",
+		Config: inspectConfig{Image: "ubuntu:24.04", Labels: map[string]string{
+			"crabbox": "true", "provider": providerName, "lease": leaseID, "slug": "local-touch",
+			"state": "ready", "server_type": "ubuntu:24.04", "ssh_user": "runner", "work_root": "/workspace/crabbox touch",
+		}},
+		State: inspectState{Status: "running", Running: true},
+		NetworkSettings: inspectNetworking{Ports: map[string][]inspectPort{
+			sshPort + "/tcp": {{HostIP: "127.0.0.1", HostPort: "49153"}},
+		}},
+	}
+	data, err := json.Marshal([]inspectContainer{container})
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+		commandKey([]string{"ps", "-a", "--filter", "label=crabbox=true", "--filter", "label=provider=local-container", "--format", "{{.ID}}"}): {Stdout: containerID + "\n"},
+		commandKey([]string{"inspect", containerID}): {Stdout: string(data)},
+	}}
+	addDefaultLocalContainerScopeResponses(runner)
+	return runner
+}
+
+func durationPointer(value time.Duration) *time.Duration { return &value }
+
+func unixLocalContainerLabelTime(t *testing.T, value string) time.Time {
+	t.Helper()
+	seconds, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		t.Fatalf("parse timestamp label %q: %v", value, err)
+	}
+	return time.Unix(seconds, 0).UTC()
 }
 
 func writeLocalContainerReleaseClaim(t *testing.T, leaseID, containerID string) {


### PR DESCRIPTION
## Summary

- add a provider-neutral optional exact-claim authorizer for runtime-derived ownership scopes while preserving core's generic static scope/resource validation
- make local-container rehydrate and validate the recorded runtime context, endpoint, daemon identity, and exact container before heartbeat mutation
- persist heartbeat timestamps, expiry, and explicit idle-timeout replacements through exact claim compare-and-swap; omitted timeouts preserve the stored value and fresh processes observe the committed state
- document the capability and local-container behavior, with focused fail-closed regression coverage

Thanks @coygeek for the precise report and Docker reproduction.

Fixes https://github.com/openclaw/crabbox/issues/1367

## Verification

- `gofmt` on changed Go files
- `git diff --check`
- `go test -race -count=1 -timeout=4m ./internal/cli -run 'Test(StatusWaitRequestsReadyProbe|StatusLeaseExactClaimAuthorizerOwnsDynamicScopeValidation|HeartbeatDirectProviderUsesTouchForExactClaim|HeartbeatDirectProviderOmitsIdleTimeoutOverrideIntent|HeartbeatDirectProviderRejectsClaimlessLease)$'`
- `go test -race -count=1 -timeout=5m ./internal/providers/localcontainer -run 'Test(AuthorizeStatusTouchClaimHydratesDynamicRuntimeScope|LocalContainerTouchPersistsExactClaimLifecycle|LocalContainerTouchRejectsUnownedOrChangedClaimWithoutMutation)$'`
- `go test -race -count=1 -p 1 -timeout=12m ./internal/providers/localcontainer`
- `go test -race -count=1 -p 1 -timeout=6m ./internal/cli -run '^(TestHeartbeat|TestStatus)'`
- `go vet -p 2 ./...`
- `scripts/check-docs.sh`
- P1 autoreview: clean, no accepted or actionable findings

A repository-wide macOS `internal/cli` race run was also attempted; unrelated browser-opener and listener-helper tests failed before the package later timed out. The complete heartbeat/status race slice and full local-container race suite above pass, and required CI will provide the isolated full-suite result.

## Live local-container proof

Provider: `local-container` on Docker-compatible OrbStack. Proof lease `cbx_96f08273aaba` was removed after verification.

- created a retained lease with a 5-minute idle timeout
- heartbeat succeeded with an explicit 11-minute replacement
- a separate CLI process inspected `lastTouchedAt=2026-08-17T08:59:32Z`, `idleTimeout=11m0s`, and `expiresAt=2026-08-17T09:10:32Z`
- a deliberately mismatched persisted runtime scope exited 4; the exact claim SHA-256 was identical before and after rejection, and heartbeat emitted no success output
- restored the valid proof claim solely for cleanup, then `stop` removed the exact container, claim, per-lease SSH key directory, and bootstrap directory
- final Docker lookup returned no proof-owned container and isolated `claims list --json` returned an empty claim set

## Configuration and secrets

No new configuration, dependency, credential, or secret handling is introduced.
