### PR TITLE
fix(heartbeat): keep retained local containers alive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- Made local-container heartbeats validate exact dynamic runtime claims and durably persist touches and timeout replacements without weakening claim ownership fences. Thanks @coygeek. https://github.com/openclaw/crabbox/issues/1367
 - Made AWS image deletion resume from owner-level durable snapshot claims after AMI deregistration or catalog cleanup failures, preventing stale ordinary and capability-variant records from remaining selectable.
 - Made static SSH heartbeats persist touched timestamps and explicit idle-timeout replacements across fresh CLI processes, while omitted overrides preserve the stored timeout. Thanks @coygeek.
 - Bounded Lambda MicroVM runner response-header waits without limiting uploads or streamed executions, while preserving injected HTTP clients. Thanks @SebTardif.

--- a/docs/commands/heartbeat.md
+++ b/docs/commands/heartbeat.md
@@ -34,12 +34,20 @@ claim that matches the provider scope and live resource identity, and it
 rejects terminal leases before touching them. Providers without lease-touch
 support fail with `provider=<name> does not support lease heartbeat`.
 
+For providers such as `local-container`, whose scope includes a dynamically
+resolved runtime and context, the exact persisted claim supplies that scope.
+Crabbox validates the live runtime, context, and resource against the resolved
+claim before committing the touch; a missing, stale, replaced, or mismatched
+claim is rejected without recreating or changing it.
+
 ## Idle timeout
 
 `--idle-timeout <duration>` optionally replaces the lease's idle window while
 refreshing it. The value must be positive. Omitting the flag preserves the
 current direct-provider timeout when it is available in lease metadata and
-omits the coordinator heartbeat override.
+omits the coordinator heartbeat override. Exact local-container claims store
+both explicit replacements and touched timestamps durably, so a later CLI
+process observes the same timeout and refreshed expiry.
 
 ## Output
 

--- a/docs/features/provider-authoring.md
+++ b/docs/features/provider-authoring.md
@@ -338,6 +338,18 @@ claim under its claim lock after revalidating provider, scope, resource, and
 host identity. Updating only the returned in-memory `Server` makes heartbeat
 success disappear in a fresh process and is not sufficient.
 
+Providers whose exact claim scope is derived from live runtime state rather
+than static config may additionally implement
+`StatusTouchClaimAuthorizer`. After core resolves the exact canonical provider
+claim and matches its non-empty resource identity, this hook fully owns claim
+authorization on every call, even when the persisted scope happens to equal
+the config-derived scope. The hook must validate the resolved claim snapshot
+and live provider scope without mutating durable claim state or provider
+resources. `Touch` must still compare-and-swap that snapshot so a missing or
+replaced claim cannot be recreated or overwritten. Providers without this
+capability retain the static config-scope check followed by the additive
+`StatusTouchClaimValidator` check.
+
 `ReleaseLease` is called when a lease ends or expires. Make it idempotent; treat
 "not found" as success. Remove local claims and the per-lease key directory
 after the provider release succeeds.

--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -148,6 +148,28 @@ type CleanupBackend interface {
 }
 ```
 
+Exact heartbeat claim authorization may be provider-owned when claim scope or
+identity comes from live provider state:
+
+```go
+type StatusTouchClaimAuthorizer interface {
+	AuthorizeStatusTouchClaim(ctx context.Context, lease LeaseTarget, claim LeaseClaim) error
+}
+```
+
+Core first requires the exact canonical provider claim and an exact, non-empty
+live resource ID match. If the backend implements this interface, core then
+delegates the complete remaining authorization decision to it on every call;
+only a nil error authorizes the touch. An equal-looking config-derived scope
+does not bypass the hook. The authorizer may hydrate in-memory provider context
+from the exact claim, but it must not mutate durable claim state or provider
+resources. The subsequent `Touch` must revalidate ownership and durably
+compare-and-swap the resolved claim snapshot so a disappeared or replaced claim
+cannot be recreated or overwritten.
+
+Backends without this interface use the generic exact config-scope comparison,
+followed by the additive `StatusTouchClaimValidator` check when implemented.
+
 Pause and resume are optional:
 
 ```go

--- a/docs/providers/local-container.md
+++ b/docs/providers/local-container.md
@@ -245,6 +245,14 @@ metadata updates.
    `crabbox stop --provider docker <lease-or-slug>` removes the stale claim and
    stored SSH key.
 
+`crabbox heartbeat` durably advances the exact claim's last-touch and expiry
+timestamps. An explicit `--idle-timeout` replacement is stored in that claim;
+omitting the flag preserves the stored timeout across later CLI processes.
+Heartbeat authorization is fenced to the Resolve-carried exact claim, captured
+runtime/context identity, and exact container ID. Missing, stale, replaced, or
+scope-mismatched claims are rejected before durable mutation and are never
+recreated by a touch.
+
 When `warmup` or `run --keep` creates the container but SSH readiness is
 canceled, fails, or times out, Crabbox keeps the exact pending claim, container,
 key, and bootstrap directory. The failed command prints copyable, runtime-scoped

--- a/internal/cli/heartbeat.go
+++ b/internal/cli/heartbeat.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 )
 
@@ -90,7 +91,7 @@ func (a App) heartbeat(ctx context.Context, args []string) error {
 	if statusTerminalState(state) {
 		return exit(5, "lease %s is in terminal state %s", *id, state)
 	}
-	claimed, err := statusLeaseHasExactClaim(backend, lease, backend.Spec().Name, leaseOptionsFromConfig(cfg).ProviderScope)
+	claimed, err := heartbeatLeaseHasExactClaim(ctx, backend, lease, backend.Spec().Name, leaseOptionsFromConfig(cfg).ProviderScope)
 	if err != nil {
 		return err
 	}
@@ -101,14 +102,16 @@ func (a App) heartbeat(ctx context.Context, args []string) error {
 	if !idleTimeoutSet {
 		if current, ok := directLeaseIdleTimeout(lease.Server.Labels); ok {
 			cfg.IdleTimeout = current
-			backend, err = loadBackend(cfg, runtimeForApp(a))
-			if err != nil {
-				return err
-			}
-			var supportsTouch bool
-			sshBackend, supportsTouch = backend.(SSHLeaseBackend)
-			if !supportsTouch {
-				return exit(2, "provider=%s does not support lease heartbeat", backend.Spec().Name)
+			if _, authorizes := backend.(StatusTouchClaimAuthorizer); !authorizes {
+				backend, err = loadBackend(cfg, runtimeForApp(a))
+				if err != nil {
+					return err
+				}
+				var supportsTouch bool
+				sshBackend, supportsTouch = backend.(SSHLeaseBackend)
+				if !supportsTouch {
+					return exit(2, "provider=%s does not support lease heartbeat", backend.Spec().Name)
+				}
 			}
 		}
 	}
@@ -140,6 +143,34 @@ func (a App) heartbeat(ctx context.Context, args []string) error {
 		return writeLeaseHeartbeatView(a.Stdout, heartbeatViewFromCoordinatorLease(*registeredLease), *jsonOut)
 	}
 	return writeLeaseHeartbeatView(a.Stdout, heartbeatViewFromServer(lease.LeaseID, touched), *jsonOut)
+}
+
+func heartbeatLeaseHasExactClaim(ctx context.Context, backend Backend, lease LeaseTarget, fallbackProvider, providerScope string) (bool, error) {
+	provider := canonicalClaimProvider(blank(lease.Server.Provider, fallbackProvider))
+	if lease.LeaseID == "" || provider == "" {
+		return false, nil
+	}
+	claim, claimed, exact, err := resolveLeaseClaimForProviderWithExact(lease.LeaseID, provider)
+	if err != nil {
+		return false, fmt.Errorf("read exact %s lease claim: %w", provider, err)
+	}
+	resourceID := strings.TrimSpace(lease.Server.CloudID)
+	if !claimed || !exact || resourceID == "" || claim.CloudID != resourceID {
+		return false, nil
+	}
+	if authorizer, ok := backend.(StatusTouchClaimAuthorizer); ok {
+		if err := authorizer.AuthorizeStatusTouchClaim(ctx, lease, claim); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+	if claim.ProviderScope != providerScope {
+		return false, nil
+	}
+	if validator, ok := backend.(StatusTouchClaimValidator); ok && !validator.StatusTouchClaimMatches(lease, claim) {
+		return false, nil
+	}
+	return true, nil
 }
 
 func directLeaseIdleTimeout(labels map[string]string) (time.Duration, bool) {

--- a/internal/cli/heartbeat_test.go
+++ b/internal/cli/heartbeat_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -195,7 +196,7 @@ func configureHeartbeatCoordinatorTest(t *testing.T, serverURL string) {
 
 const heartbeatDirectProviderName = "heartbeat-direct-test"
 
-var heartbeatDirectBackendForTest *heartbeatDirectBackend
+var heartbeatDirectBackendForTest Backend
 
 func init() {
 	RegisterProvider(heartbeatDirectProvider{})
@@ -256,6 +257,20 @@ func (*heartbeatDirectBackend) ReleaseLease(context.Context, ReleaseLeaseRequest
 	return nil
 }
 
+type heartbeatAuthorizingBackend struct {
+	*heartbeatDirectBackend
+	authorize func(context.Context, LeaseTarget, LeaseClaim) error
+	calls     int
+}
+
+func (b *heartbeatAuthorizingBackend) AuthorizeStatusTouchClaim(ctx context.Context, lease LeaseTarget, claim LeaseClaim) error {
+	b.calls++
+	if b.authorize == nil {
+		return errors.New("status touch claim is not authorized")
+	}
+	return b.authorize(ctx, lease, claim)
+}
+
 func TestHeartbeatDirectProviderUsesTouchForExactClaim(t *testing.T) {
 	backend := configureHeartbeatDirectTest(t, true)
 	var stdout bytes.Buffer
@@ -298,6 +313,163 @@ func TestHeartbeatDirectProviderRejectsClaimlessLease(t *testing.T) {
 	}
 	if len(backend.touches) != 0 {
 		t.Fatalf("claimless heartbeat touched lease: %#v", backend.touches)
+	}
+}
+
+func TestHeartbeatStatusTouchClaimAuthorization(t *testing.T) {
+	for _, test := range []struct {
+		name             string
+		claim            bool
+		claimProvider    string
+		claimScope       string
+		claimResource    string
+		resolvedResource string
+		authorize        func(context.Context, LeaseTarget, LeaseClaim) error
+		wantSuccess      bool
+		wantAuthCalls    int
+	}{
+		{
+			name: "matching non-empty dynamic scope", claim: true,
+			claimProvider: heartbeatDirectProviderName, claimScope: "runtime:docker/context:desktop-linux",
+			claimResource: "direct-resource", resolvedResource: "direct-resource",
+			authorize:   func(context.Context, LeaseTarget, LeaseClaim) error { return nil },
+			wantSuccess: true, wantAuthCalls: 1,
+		},
+		{
+			name: "equal static scope still delegates and rejects", claim: true,
+			claimProvider: heartbeatDirectProviderName, claimScope: "",
+			claimResource: "direct-resource", resolvedResource: "direct-resource",
+			authorize:     func(context.Context, LeaseTarget, LeaseClaim) error { return errors.New("equal scope rejected") },
+			wantAuthCalls: 1,
+		},
+		{
+			name: "missing claim", resolvedResource: "direct-resource",
+		},
+		{
+			name: "wrong provider", claim: true,
+			claimProvider: "aws", claimScope: "runtime:docker/context:desktop-linux",
+			claimResource: "direct-resource", resolvedResource: "direct-resource",
+		},
+		{
+			name: "wrong resource", claim: true,
+			claimProvider: heartbeatDirectProviderName, claimScope: "runtime:docker/context:desktop-linux",
+			claimResource: "replacement-resource", resolvedResource: "direct-resource",
+		},
+		{
+			name: "provider rejects dynamic scope", claim: true,
+			claimProvider: heartbeatDirectProviderName, claimScope: "runtime:docker/context:other",
+			claimResource: "direct-resource", resolvedResource: "direct-resource",
+			authorize:     func(context.Context, LeaseTarget, LeaseClaim) error { return errors.New("dynamic scope mismatch") },
+			wantAuthCalls: 1,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			base := configureHeartbeatDirectTest(t, false)
+			base.lease.Server.CloudID = test.resolvedResource
+			backend := &heartbeatAuthorizingBackend{heartbeatDirectBackend: base, authorize: test.authorize}
+			heartbeatDirectBackendForTest = backend
+			if test.claim {
+				if err := claimLeaseForRepoProviderScopePondEndpoint(
+					base.lease.LeaseID,
+					serverSlug(base.lease.Server),
+					test.claimProvider,
+					test.claimScope,
+					"",
+					"/repo",
+					30*time.Minute,
+					false,
+					Server{Provider: test.claimProvider, CloudID: test.claimResource},
+					SSHTarget{},
+				); err != nil {
+					t.Fatal(err)
+				}
+			}
+			before, beforeExists, err := readLeaseClaimWithPresence(base.lease.LeaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = (App{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}).heartbeat(context.Background(), []string{
+				"--provider", heartbeatDirectProviderName, "--id", base.lease.LeaseID,
+			})
+			if test.wantSuccess && err != nil {
+				t.Fatalf("heartbeat error=%v", err)
+			}
+			if !test.wantSuccess && err == nil {
+				t.Fatal("heartbeat unexpectedly succeeded")
+			}
+			if backend.calls != test.wantAuthCalls {
+				t.Fatalf("authorization calls=%d want=%d", backend.calls, test.wantAuthCalls)
+			}
+			wantTouches := 0
+			if test.wantSuccess {
+				wantTouches = 1
+			}
+			if len(base.touches) != wantTouches {
+				t.Fatalf("touch calls=%d want=%d", len(base.touches), wantTouches)
+			}
+			after, afterExists, readErr := readLeaseClaimWithPresence(base.lease.LeaseID)
+			if readErr != nil || beforeExists != afterExists || !reflect.DeepEqual(before, after) {
+				t.Fatalf("heartbeat gate mutated claim: before=%#v exists=%t after=%#v exists=%t err=%v", before, beforeExists, after, afterExists, readErr)
+			}
+		})
+	}
+}
+
+func TestHeartbeatGenericStaticClaimValidation(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		claimScope  string
+		wantSuccess bool
+	}{
+		{name: "matching static scope", claimScope: "", wantSuccess: true},
+		{name: "mismatched static scope", claimScope: "region:other"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			backend := configureHeartbeatDirectTest(t, false)
+			if _, ok := any(backend).(StatusTouchClaimAuthorizer); ok {
+				t.Fatal("generic static backend unexpectedly implements StatusTouchClaimAuthorizer")
+			}
+			if err := claimLeaseForRepoProviderScopePondEndpoint(
+				backend.lease.LeaseID,
+				serverSlug(backend.lease.Server),
+				heartbeatDirectProviderName,
+				test.claimScope,
+				"",
+				"/repo",
+				30*time.Minute,
+				false,
+				backend.lease.Server,
+				SSHTarget{},
+			); err != nil {
+				t.Fatal(err)
+			}
+			before, exists, err := readLeaseClaimWithPresence(backend.lease.LeaseID)
+			if err != nil || !exists {
+				t.Fatalf("read claim exists=%t err=%v", exists, err)
+			}
+
+			err = (App{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}).heartbeat(context.Background(), []string{
+				"--provider", heartbeatDirectProviderName, "--id", backend.lease.LeaseID,
+			})
+			if test.wantSuccess && err != nil {
+				t.Fatalf("heartbeat error=%v", err)
+			}
+			if !test.wantSuccess && err == nil {
+				t.Fatal("heartbeat unexpectedly succeeded")
+			}
+			wantTouches := 0
+			if test.wantSuccess {
+				wantTouches = 1
+			}
+			if len(backend.touches) != wantTouches {
+				t.Fatalf("touch calls=%d want=%d", len(backend.touches), wantTouches)
+			}
+			after, afterExists, readErr := readLeaseClaimWithPresence(backend.lease.LeaseID)
+			if readErr != nil || !afterExists || !reflect.DeepEqual(after, before) {
+				t.Fatalf("static authorization mutated claim: before=%#v after=%#v exists=%t err=%v", before, after, afterExists, readErr)
+			}
+		})
 	}
 }
 

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -170,6 +170,12 @@ type StatusTouchClaimValidator interface {
 	StatusTouchClaimMatches(LeaseTarget, LeaseClaim) bool
 }
 
+// StatusTouchClaimAuthorizer lets a provider fully authorize an exact claim
+// whose scope or identity must be resolved from provider-owned state.
+type StatusTouchClaimAuthorizer interface {
+	AuthorizeStatusTouchClaim(context.Context, LeaseTarget, LeaseClaim) error
+}
+
 type ResolvedLeaseTargetRebinder interface {
 	RebindResolvedLeaseTarget(target *LeaseTarget, leaseID string) error
 }

--- a/internal/providers/localcontainer/backend.go
+++ b/internal/providers/localcontainer/backend.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strconv"
 	"strings"
@@ -51,6 +52,7 @@ type backend struct {
 }
 
 var _ core.ExclusiveOneShotAcquireBackend = (*backend)(nil)
+var _ core.StatusTouchClaimAuthorizer = (*backend)(nil)
 
 type inspectContainer struct {
 	ID              string            `json:"Id"`
@@ -1405,20 +1407,56 @@ func (b *backend) cleanupContainerSidecars(leaseID string, labels map[string]str
 	return nil
 }
 
-func (b *backend) Touch(_ context.Context, req core.TouchRequest) (core.Server, error) {
-	server := req.Lease.Server
-	if server.Labels == nil {
-		server.Labels = map[string]string{}
+func (b *backend) AuthorizeStatusTouchClaim(ctx context.Context, lease core.LeaseTarget, claim core.LeaseClaim) error {
+	expected, exists, set := core.ServerLeaseClaimSnapshot(lease.Server)
+	if !set || !exists {
+		return localContainerOwnershipError(lease.LeaseID, lease.Server.CloudID)
 	}
-	original := server.Labels
-	server.Labels = core.TouchDirectLeaseLabels(original, b.configForRun(), req.State, time.Now().UTC())
+	if !reflect.DeepEqual(expected, claim) {
+		return core.Exit(2, "lease %s claim changed; retry", lease.LeaseID)
+	}
+	applied, err := b.applyCheckpointScopeLabels(ctx, claim.Labels)
+	if err != nil || !applied {
+		return localContainerOwnershipError(lease.LeaseID, lease.Server.CloudID)
+	}
+	return b.validateExactLocalContainerClaim(ctx, claim, lease.LeaseID, lease.Server.CloudID)
+}
+
+func (b *backend) Touch(ctx context.Context, req core.TouchRequest) (core.Server, error) {
+	expected, exists, set := core.ServerLeaseClaimSnapshot(req.Lease.Server)
+	if !set || !exists {
+		return core.Server{}, localContainerOwnershipError(req.Lease.LeaseID, req.Lease.Server.CloudID)
+	}
+	if err := b.validateExactLocalContainerClaim(ctx, expected, req.Lease.LeaseID, req.Lease.Server.CloudID); err != nil {
+		return core.Server{}, err
+	}
+	if req.IdleTimeoutOverride != nil && *req.IdleTimeoutOverride <= 0 {
+		return core.Server{}, core.Exit(2, "local-container lease %s idle timeout override must be positive", req.Lease.LeaseID)
+	}
+
+	now := time.Now().UTC()
+	if b.rt.Clock != nil {
+		now = b.rt.Clock.Now().UTC()
+	}
+	cfg := b.configForRun()
+	if expected.IdleTimeoutSeconds > 0 {
+		cfg.IdleTimeout = time.Duration(expected.IdleTimeoutSeconds) * time.Second
+	}
+	labels := core.TouchDirectLeaseLabelsWithIdleTimeoutOverride(expected.Labels, cfg, req.State, now, req.IdleTimeoutOverride)
 	preservedKeys := []string{"bootstrap_dir", "container_id", "docker_socket", "host_work_root", "image", "runtime", "runtime_context", "ssh_port", "ssh_user", "work_root"}
 	preservedKeys = append(preservedKeys, checkpointScopeMetadataKeys...)
 	for _, key := range preservedKeys {
-		if value := strings.TrimSpace(original[key]); value != "" {
-			server.Labels[key] = value
+		if value := strings.TrimSpace(expected.Labels[key]); value != "" {
+			labels[key] = value
 		}
 	}
+	updated, err := core.UpdateLeaseClaimTouchIfUnchanged(req.Lease.LeaseID, expected, labels, now, req.IdleTimeoutOverride)
+	if err != nil {
+		return core.Server{}, err
+	}
+	server := mergeLocalContainerClaim(req.Lease.Server, updated)
+	server.Labels = publicLocalContainerClaimLabels(server.Labels)
+	core.SetServerLeaseClaimSnapshot(&server, updated, true)
 	return server, nil
 }
 

--- a/internal/providers/localcontainer/backend_test.go
+++ b/internal/providers/localcontainer/backend_test.go
@@ -3654,34 +3654,290 @@ func TestResolvePendingClaimDoesNotRequirePublishedSSHPort(t *testing.T) {
 	}
 }
 
-func TestTouchPreservesLocalContainerLabels(t *testing.T) {
-	b := testBackend(&recordingRunner{responses: map[string]core.LocalCommandResult{}})
-	bootstrapDir := filepath.Join(os.TempDir(), "crabbox-bootstrap-touchtest")
-	lease := core.LeaseTarget{
-		LeaseID: "cbx_touch",
-		Server: core.Server{
-			Labels: map[string]string{
-				"bootstrap_dir":  bootstrapDir,
-				"docker_socket":  "1",
-				"host_work_root": "/tmp/crabbox-local-container-work",
-				"work_root":      "/tmp/crabbox-local-container-work",
-				"ssh_user":       "runner",
-			},
-		},
-	}
-	server, err := b.Touch(context.Background(), core.TouchRequest{Lease: lease, State: "running"})
+type localContainerTouchClock struct{ now time.Time }
+
+func (c localContainerTouchClock) Now() time.Time { return c.now }
+
+func TestTouchPersistsLocalContainerLifecycleForFreshResolve(t *testing.T) {
+	b, lease, initial, touchedAt := newLocalContainerTouchFixture(t, 30*time.Minute)
+	override := 45 * time.Minute
+	server, err := b.Touch(context.Background(), core.TouchRequest{
+		Lease:               lease,
+		State:               "running",
+		IdleTimeout:         override,
+		IdleTimeoutOverride: &override,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if server.Labels["work_root"] != lease.Server.Labels["work_root"] || server.Labels["host_work_root"] != lease.Server.Labels["host_work_root"] || server.Labels["docker_socket"] != "1" || server.Labels["ssh_user"] != "runner" {
-		t.Fatalf("provider labels not preserved: %#v", server.Labels)
+	committed, exists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+	if err != nil || !exists {
+		t.Fatalf("read committed touch exists=%t err=%v", exists, err)
 	}
-	if server.Labels["bootstrap_dir"] != bootstrapDir {
-		t.Fatalf("bootstrap_dir not preserved through touch: got %q want %q", server.Labels["bootstrap_dir"], bootstrapDir)
+	if committed.Revision == initial.Revision || committed.LastUsedAt != touchedAt.Format(time.RFC3339) || committed.IdleTimeoutSeconds != 2700 {
+		t.Fatalf("committed touch=%#v initial=%#v", committed, initial)
 	}
-	if server.Labels["state"] != "running" {
-		t.Fatalf("state not touched: %#v", server.Labels)
+	for _, key := range []string{"bootstrap_dir", "docker_socket", "host_work_root", "work_root", "ssh_user"} {
+		if server.Labels[key] != initial.Labels[key] || committed.Labels[key] != initial.Labels[key] {
+			t.Fatalf("provider label %s was not preserved: response=%q claim=%q want=%q", key, server.Labels[key], committed.Labels[key], initial.Labels[key])
+		}
 	}
+	if server.Labels["state"] != "running" || server.Labels["idle_timeout_secs"] != "2700" || server.Labels["last_touched_at"] != core.LeaseLabelTime(touchedAt) {
+		t.Fatalf("touch response labels=%#v", server.Labels)
+	}
+	if got := unixTouchLabelTime(t, committed.Labels["expires_at"]); !got.Equal(touchedAt.Add(override)) {
+		t.Fatalf("expires=%s want=%s", got, touchedAt.Add(override))
+	}
+
+	fresh := freshResolveLocalContainerTouchClaim(t, committed)
+	if fresh.Server.Labels["last_touched_at"] != server.Labels["last_touched_at"] || fresh.Server.Labels["expires_at"] != server.Labels["expires_at"] || fresh.Server.Labels["idle_timeout_secs"] != "2700" {
+		t.Fatalf("fresh resolve=%#v touched=%#v", fresh.Server.Labels, server.Labels)
+	}
+}
+
+func TestTouchWithoutOverridePreservesLocalContainerTimeout(t *testing.T) {
+	b, lease, _, touchedAt := newLocalContainerTouchFixture(t, 37*time.Minute)
+	server, err := b.Touch(context.Background(), core.TouchRequest{
+		Lease: lease, State: "ready", IdleTimeout: 5 * time.Minute,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	committed, exists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+	if err != nil || !exists {
+		t.Fatalf("read committed touch exists=%t err=%v", exists, err)
+	}
+	if committed.IdleTimeoutSeconds != 2220 || server.Labels["idle_timeout_secs"] != "2220" {
+		t.Fatalf("omitted override replaced timeout: response=%q claim=%d", server.Labels["idle_timeout_secs"], committed.IdleTimeoutSeconds)
+	}
+	if got := unixTouchLabelTime(t, committed.Labels["expires_at"]); !got.Equal(touchedAt.Add(37 * time.Minute)) {
+		t.Fatalf("expires=%s want=%s", got, touchedAt.Add(37*time.Minute))
+	}
+}
+
+func TestAuthorizeStatusTouchClaimHydratesCapturedRuntimeScope(t *testing.T) {
+	b, lease, initial, _ := newLocalContainerTouchFixture(t, 30*time.Minute)
+	b.cfg.LocalContainer.CheckpointMetadata = nil
+	if err := b.AuthorizeStatusTouchClaim(context.Background(), lease, initial); err != nil {
+		t.Fatalf("authorization error=%v", err)
+	}
+	if !hasCompleteCapturedRuntimeScope(b.cfg.LocalContainer.CheckpointMetadata) {
+		t.Fatalf("authorizer did not hydrate captured runtime scope: %#v", b.cfg.LocalContainer.CheckpointMetadata)
+	}
+	after, exists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+	if err != nil || !exists || !reflect.DeepEqual(after, initial) {
+		t.Fatalf("authorization mutated claim: initial=%#v after=%#v exists=%t err=%v", initial, after, exists, err)
+	}
+}
+
+func TestAuthorizeStatusTouchClaimFailsClosed(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(*backend, *core.LeaseTarget, *core.LeaseClaim)
+	}{
+		{name: "missing resolved snapshot", mutate: func(_ *backend, lease *core.LeaseTarget, _ *core.LeaseClaim) {
+			lease.Server = core.Server{Provider: providerName, CloudID: "touch-container"}
+		}},
+		{name: "wrong provider", mutate: func(_ *backend, lease *core.LeaseTarget, claim *core.LeaseClaim) {
+			claim.Provider = "aws"
+			core.SetServerLeaseClaimSnapshot(&lease.Server, *claim, true)
+		}},
+		{name: "wrong resource", mutate: func(_ *backend, lease *core.LeaseTarget, _ *core.LeaseClaim) {
+			lease.Server.CloudID = "replacement-container"
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			b, lease, initial, _ := newLocalContainerTouchFixture(t, 30*time.Minute)
+			candidate := initial
+			test.mutate(b, &lease, &candidate)
+			if err := b.AuthorizeStatusTouchClaim(context.Background(), lease, candidate); err == nil {
+				t.Fatal("authorization unexpectedly succeeded")
+			}
+			after, exists, readErr := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+			if readErr != nil || !exists || !reflect.DeepEqual(after, initial) {
+				t.Fatalf("authorization mutated claim: initial=%#v after=%#v exists=%t err=%v", initial, after, exists, readErr)
+			}
+		})
+	}
+}
+
+func TestAuthorizeStatusTouchClaimRejectsPersistedScopeMetadataMismatch(t *testing.T) {
+	b, lease, initial, _ := newLocalContainerTouchFixture(t, 30*time.Minute)
+	labels := cloneLabels(initial.Labels)
+	for key, value := range checkpointScopeMetadata(checkpointScope{
+		Runtime: "docker", Context: "other", Endpoint: "unix:///other.sock", DaemonID: "daemon-other",
+	}) {
+		labels[key] = value
+	}
+	mismatched, err := core.UpdateLeaseClaimLabelsIfUnchanged(lease.LeaseID, initial, labels)
+	if err != nil {
+		t.Fatal(err)
+	}
+	core.SetServerLeaseClaimSnapshot(&lease.Server, mismatched, true)
+	b.cfg.LocalContainer.CheckpointMetadata = nil
+
+	if err := b.AuthorizeStatusTouchClaim(context.Background(), lease, mismatched); err == nil {
+		t.Fatal("persisted scope/metadata mismatch unexpectedly authorized")
+	}
+	after, exists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+	if err != nil || !exists || !reflect.DeepEqual(after, mismatched) {
+		t.Fatalf("rejected authorization mutated claim: mismatched=%#v after=%#v exists=%t err=%v", mismatched, after, exists, err)
+	}
+}
+
+func TestTouchRejectsInvalidLocalContainerOwnershipWithoutMutation(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(*backend, *core.LeaseTarget, *core.LeaseClaim)
+	}{
+		{name: "missing snapshot", mutate: func(_ *backend, lease *core.LeaseTarget, _ *core.LeaseClaim) {
+			lease.Server = core.Server{Provider: providerName, CloudID: "touch-container"}
+		}},
+		{name: "wrong provider", mutate: func(_ *backend, lease *core.LeaseTarget, claim *core.LeaseClaim) {
+			claim.Provider = "aws"
+			core.SetServerLeaseClaimSnapshot(&lease.Server, *claim, true)
+		}},
+		{name: "wrong runtime context", mutate: func(b *backend, _ *core.LeaseTarget, _ *core.LeaseClaim) {
+			scope := checkpointScope{Runtime: "docker", Context: "other", Endpoint: "unix:///other.sock", DaemonID: "daemon-other"}
+			b.cfg.LocalContainer.CheckpointMetadata = checkpointScopeMetadata(scope)
+		}},
+		{name: "wrong container", mutate: func(_ *backend, lease *core.LeaseTarget, _ *core.LeaseClaim) {
+			lease.Server.CloudID = "replacement-container"
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			b, lease, initial, _ := newLocalContainerTouchFixture(t, 30*time.Minute)
+			candidate := initial
+			test.mutate(b, &lease, &candidate)
+			if _, err := b.Touch(context.Background(), core.TouchRequest{Lease: lease, State: "ready"}); err == nil {
+				t.Fatal("touch unexpectedly succeeded")
+			}
+			after, exists, readErr := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+			if readErr != nil || !exists || !reflect.DeepEqual(after, initial) {
+				t.Fatalf("rejected touch mutated claim: initial=%#v after=%#v exists=%t err=%v", initial, after, exists, readErr)
+			}
+		})
+	}
+}
+
+func TestTouchDoesNotRecreateMissingLocalContainerClaim(t *testing.T) {
+	b, lease, _, _ := newLocalContainerTouchFixture(t, 30*time.Minute)
+	core.RemoveLeaseClaim(lease.LeaseID)
+	if _, err := b.Touch(context.Background(), core.TouchRequest{Lease: lease, State: "ready"}); err == nil || !strings.Contains(err.Error(), "claim changed") {
+		t.Fatalf("touch error=%v want claim changed", err)
+	}
+	if claim, exists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID); err != nil || exists {
+		t.Fatalf("missing claim was recreated: claim=%#v exists=%t err=%v", claim, exists, err)
+	}
+}
+
+func TestTouchRejectsLocalContainerClaimReplacement(t *testing.T) {
+	b, lease, initial, _ := newLocalContainerTouchFixture(t, 30*time.Minute)
+	labels := cloneLabels(initial.Labels)
+	labels["replacement"] = "true"
+	replacement, err := core.UpdateLeaseClaimLabelsIfUnchanged(lease.LeaseID, initial, labels)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.Touch(context.Background(), core.TouchRequest{Lease: lease, State: "ready"}); err == nil || !strings.Contains(err.Error(), "claim changed") {
+		t.Fatalf("touch error=%v want claim changed", err)
+	}
+	after, exists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+	if err != nil || !exists || !reflect.DeepEqual(after, replacement) {
+		t.Fatalf("replacement was overwritten: replacement=%#v after=%#v exists=%t err=%v", replacement, after, exists, err)
+	}
+}
+
+func TestTouchRejectsStaleResolvedLocalContainerSnapshot(t *testing.T) {
+	b, lease, _, _ := newLocalContainerTouchFixture(t, 30*time.Minute)
+	if _, err := b.Touch(context.Background(), core.TouchRequest{Lease: lease, State: "ready"}); err != nil {
+		t.Fatal(err)
+	}
+	committed, exists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+	if err != nil || !exists {
+		t.Fatalf("read first touch exists=%t err=%v", exists, err)
+	}
+	if _, err := b.Touch(context.Background(), core.TouchRequest{Lease: lease, State: "ready"}); err == nil || !strings.Contains(err.Error(), "claim changed") {
+		t.Fatalf("stale touch error=%v want claim changed", err)
+	}
+	after, exists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+	if err != nil || !exists || !reflect.DeepEqual(after, committed) {
+		t.Fatalf("stale snapshot changed claim: committed=%#v after=%#v exists=%t err=%v", committed, after, exists, err)
+	}
+}
+
+func newLocalContainerTouchFixture(t *testing.T, idleTimeout time.Duration) (*backend, core.LeaseTarget, core.LeaseClaim, time.Time) {
+	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	leaseID := "cbx_touch"
+	containerID := "touch-container"
+	createdAt := time.Date(2026, 8, 17, 8, 0, 0, 0, time.UTC)
+	touchedAt := createdAt.Add(2 * time.Minute)
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.IdleTimeout = idleTimeout
+	labels := core.DirectLeaseLabels(cfg, leaseID, "touch", providerName, "", true, createdAt)
+	labels["bootstrap_dir"] = filepath.Join(os.TempDir(), "crabbox-bootstrap-touchtest")
+	labels["docker_socket"] = "1"
+	labels["host_work_root"] = "/tmp/crabbox-local-container-work"
+	labels["work_root"] = "/tmp/crabbox-local-container-work"
+	labels["ssh_user"] = "runner"
+	labels = testCapturedScopeLabels(labels)
+	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(
+		leaseID, "touch", providerName, "runtime:docker/context:default", "", t.TempDir(), idleTimeout, false,
+		core.Server{Provider: providerName, CloudID: containerID, Status: "ready", Labels: labels}, core.SSHTarget{},
+	); err != nil {
+		t.Fatal(err)
+	}
+	claim, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
+	if err != nil || !exists {
+		t.Fatalf("read touch fixture claim exists=%t err=%v", exists, err)
+	}
+	server := core.Server{Provider: providerName, CloudID: containerID, Status: "ready", Labels: publicLocalContainerClaimLabels(claim.Labels)}
+	core.SetServerLeaseClaimSnapshot(&server, claim, true)
+	lease := core.LeaseTarget{LeaseID: leaseID, Server: server}
+	b := testBackend(&recordingRunner{})
+	b.cfg.LocalContainer.CheckpointMetadata = checkpointScopeMetadata(checkpointScope{
+		Runtime: "docker", Context: "default", Endpoint: "unix:///tmp/docker-test.sock", DaemonID: "daemon-test",
+	})
+	b.rt.Clock = localContainerTouchClock{now: touchedAt}
+	return b, lease, claim, touchedAt
+}
+
+func freshResolveLocalContainerTouchClaim(t *testing.T, claim core.LeaseClaim) core.LeaseTarget {
+	t.Helper()
+	container := inspectContainer{
+		ID: claim.CloudID, Name: "/crabbox-touch",
+		Config: inspectConfig{Image: "ubuntu:24.04", Labels: cloneLabels(claim.Labels)},
+		State:  inspectState{Status: "running", Running: true},
+		NetworkSettings: inspectNetworking{Ports: map[string][]inspectPort{
+			sshPort + "/tcp": {{HostIP: "127.0.0.1", HostPort: "49153"}},
+		}},
+	}
+	inspectJSON, err := json.Marshal([]inspectContainer{container})
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+		commandKey([]string{"ps", "-a", "--filter", "label=crabbox=true", "--filter", "label=provider=local-container", "--format", "{{.ID}}"}): {Stdout: claim.CloudID + "\n"},
+		commandKey([]string{"inspect", claim.CloudID}): {Stdout: string(inspectJSON)},
+	}}
+	addDefaultLocalContainerScopeResponses(runner)
+	fresh := testBackend(runner)
+	lease, err := fresh.Resolve(context.Background(), core.ResolveRequest{ID: claim.LeaseID, StatusOnly: true, NoLocalStateMutations: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return lease
+}
+
+func unixTouchLabelTime(t *testing.T, value string) time.Time {
+	t.Helper()
+	seconds, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		t.Fatalf("parse timestamp label %q: %v", value, err)
+	}
+	return time.Unix(seconds, 0).UTC()
 }
 
 func TestHostLeaseWorkRootRequiresTrustedLabels(t *testing.T) {


### PR DESCRIPTION
Closes https://github.com/openclaw/crabbox/issues/1367

## What Problem This Solves

Fixes an issue where users heartbeating a retained local-container lease would receive a false ownership rejection when the claim included the dynamically resolved Docker or Podman runtime context. The lease could therefore expire even though the same checkout could still inspect and stop it.

## Why This Change Was Made

Heartbeat now supports a narrow provider-neutral claim-authorizer capability for backends whose exact ownership scope comes from live runtime state. Local-container validates the exact resolved claim, runtime context, daemon identity, and container before its touch operation durably compare-and-swaps lifecycle state. Providers without this capability keep the existing exact static-scope validation.

## User Impact

Owned retained local-container leases can now be kept alive with `crabbox heartbeat`. Explicit idle-timeout replacements and refreshed timestamps persist across fresh CLI processes, while missing, stale, replaced, wrong-scope, or wrong-resource claims continue to fail closed without mutation.

## Evidence

- P1 maintainer autoreview: clean, with no accepted or actionable findings.
- `go test -race -p 2 -timeout 10m -count=1 -run 'TestHeartbeat|TestAuthorizeStatusTouchClaim|TestTouch' ./internal/cli ./internal/providers/localcontainer`
- `go test -p 2 -timeout 10m -count=1 ./internal/providers/localcontainer ./internal/providers/ssh`
- `go vet -p 2 ./...`
- `scripts/check-docs.sh`
- `git diff --check`

A retained Docker lease was exercised end to end. Heartbeat advanced the persisted touch and expiry timestamps, an explicit timeout changed from 20 minutes to 45 minutes, an omitted timeout preserved 45 minutes, and fresh-process inspect calls observed each committed update. A mismatched-scope control exited 4 with an unchanged claim digest. Cleanup left zero proof-owned containers, claims, copied claims, or per-lease key residue.

### Redacted live Docker transcript

```text
docker client=29.4.0 server=29.4.0

fresh-process inspect before heartbeat
lastTouchedAt=2026-08-17T08:50:12Z idleTimeout=20m0s expiresAt=2026-08-17T09:10:12Z

heartbeat --idle-timeout 45m
lastTouchedAt=2026-08-17T08:50:15Z idleTimeout=45m0s expiresAt=2026-08-17T09:35:15Z

fresh-process inspect after explicit heartbeat
lastTouchedAt=2026-08-17T08:50:15Z idleTimeout=45m0s expiresAt=2026-08-17T09:35:15Z

heartbeat with omitted timeout
lastTouchedAt=2026-08-17T08:50:19Z idleTimeout=45m0s expiresAt=2026-08-17T09:35:19Z

fresh-process inspect after omitted-timeout heartbeat
lastTouchedAt=2026-08-17T08:50:19Z idleTimeout=45m0s expiresAt=2026-08-17T09:35:19Z

mismatched persisted runtime-scope control
exit=4
claim_sha_before=ad3b880b6448e86ff8be2a278ef5f993e5bac69c730a53af8b5629502df481ff
claim_sha_after=ad3b880b6448e86ff8be2a278ef5f993e5bac69c730a53af8b5629502df481ff

proof-owned cleanup
containers=0 claims=0 copied_claims=0 per_lease_key_residue=0
```

An additional bounded full `go test ./...` attempt completed 90 non-CLI packages but timed out in unrelated host-sensitive CLI subprocess, browser-opener, and port-forward tests while concurrent full CLI test runs were active. The affected race tests and complete local-container and static-SSH suites pass.

## Configuration and secrets

No new configuration, dependency, credential, or secret handling is introduced.
