### PR TITLE
feat(preflight): add raw-socket capability probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added an opt-in Linux/WSL2 `raw_socket` preflight probe that distinguishes direct, non-interactive-sudo, unavailable, and missing-interpreter states without sending packets or elevating workloads. Thanks @coygeek.
 - Added checkpoint last-use tracking and composable `checkpoint prune --unused-for` cleanup for inactive local records and provider artifacts.
 - Added provider-native create, verify, delete, and fork lifecycle for direct Hetzner project-snapshot checkpoints, including exact local-claim image deletion.
 - Added `crabbox heartbeat` so external SSH drivers can refresh owned lease idle deadlines and optionally update the idle timeout.

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -401,8 +401,9 @@ or the command/script you run.
 By default it probes common language and infrastructure tools plus OS-specific
 basics. Default generic probes are `git`, `tar`, `node`, `npm`, `corepack`,
 `pnpm`, `yarn`, `bun`, and `docker`; `uv`, `python`, and `python3` are available
-as additional opt-in built-ins. POSIX/Linux/WSL probes also include `sudo`,
-`apt`, and `bubblewrap`; native Windows probes include `powershell`,
+as additional opt-in built-ins. Linux and WSL2 also support the opt-in
+`raw_socket` capability probe. POSIX/Linux/WSL probes include `sudo`, `apt`,
+and `bubblewrap`; native Windows probes include `powershell`,
 `execution_policy`, `longpaths`, `temp`, and `pwsh`.
 
 Use `--preflight-tools` to replace the default tool list for one run:
@@ -411,6 +412,7 @@ Use `--preflight-tools` to replace the default tool list for one run:
 crabbox run --preflight --preflight-tools node,bun,docker -- bun test
 crabbox run --preflight --preflight-tools default,uv -- node --test
 crabbox run --preflight --preflight-tools python,python3 -- python3 -m pytest
+crabbox run --preflight --preflight-tools raw_socket -- ./packet-tests
 crabbox run --preflight --preflight-tools none -- ./smoke.sh
 ```
 
@@ -422,13 +424,21 @@ including `python` and `python3` on native Windows; Crabbox does not map either
 name to `py`. An unavailable literal command prints `<name>=missing` and the run
 continues.
 
+`raw_socket` uses `python3`, then `python`, to open and immediately close
+`socket(AF_INET, SOCK_RAW, IPPROTO_RAW)` without binding, connecting, sending,
+or receiving. Its stable result is `direct`, `sudo`, `unavailable`, or
+`probe_missing`. `sudo` means only that the same bounded probe succeeded through
+non-interactive `sudo -n`; Crabbox never elevates the workload, grants
+capabilities, installs software, or changes an image or container. The probe is
+separate from Python, Scapy, tcpdump, libpcap, and packet-capture availability.
+Unsupported targets skip it through normal preflight target filtering.
+
 Configure the default per repo:
 
 ```yaml
 run:
   preflightTools:
-    - python
-    - python3
+    - raw_socket
 ```
 
 ## Profiles, presets, and proof

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -300,20 +300,29 @@ script/command itself.
 The built-in probes cover common toolchains — `git`, `tar`, `node`, `npm`,
 `corepack`, `pnpm`, `yarn`, `bun`, `docker`, and opt-in `uv`, `python`, and
 `python3` — plus target-specific probes such as `sudo`, `apt`, `bubblewrap`,
-`powershell`, `execution_policy`, `longpaths`, `temp`, and `pwsh`. Override the
-probe list per run:
+`powershell`, `execution_policy`, `longpaths`, `temp`, and `pwsh`. Linux and
+WSL2 also support an opt-in `raw_socket` capability probe. Override the probe
+list per run:
 
 ```sh
 crabbox run --preflight --preflight-tools python,python3 -- python3 -m pytest
+crabbox run --preflight --preflight-tools raw_socket -- ./packet-tests
 ```
+
+`raw_socket` reports `direct` when the execution user can open and immediately
+close `socket(AF_INET, SOCK_RAW, IPPROTO_RAW)`, `sudo` when only the same
+bounded probe succeeds through `sudo -n`, `unavailable` otherwise, and
+`probe_missing` when neither `python3` nor `python` exists. It never sends a
+packet or elevates the workload. This kernel capability is distinct from
+Python, Scapy, tcpdump, libpcap, or packet-capture-tool availability, and
+unsupported targets skip the probe.
 
 Or per repository:
 
 ```yaml
 run:
   preflightTools:
-    - python
-    - python3
+    - raw_socket
 ```
 
 ## Actions hydration

--- a/internal/cli/run_observability.go
+++ b/internal/cli/run_observability.go
@@ -165,26 +165,41 @@ func printRemoteCapabilityPreflight(ctx context.Context, w io.Writer, cfg Config
 	if len(tools) == 0 {
 		return
 	}
-	var out string
-	var err error
-	if isWindowsNativeTarget(target) {
-		out, err = runWindowsRemoteCapabilityPreflight(ctx, target, workdir, env, envFiles, tools)
-	} else if isWindowsWSL2Target(target) {
-		out, err = runWSL2RemoteCapabilityPreflight(ctx, target, workdir, env, envFiles, tools)
-	} else {
-		out, err = runSSHCombinedOutput(ctx, target, remoteCapabilityPreflightCommand(workdir, env, envFiles, tools))
-	}
-	if err != nil {
-		fmt.Fprintf(w, "remote preflight failed: %v\n", err)
-		if strings.TrimSpace(out) != "" {
-			fmt.Fprintf(w, "remote preflight output: %s\n", strings.TrimSpace(out))
+	baseTools := make([]string, 0, len(tools))
+	rawSocketRequested := false
+	for _, tool := range tools {
+		if tool == rawSocketPreflightTool {
+			rawSocketRequested = true
+			continue
 		}
-		return
+		baseTools = append(baseTools, tool)
 	}
-	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
-		if strings.TrimSpace(line) != "" {
-			fmt.Fprintf(w, "remote preflight %s\n", strings.TrimSpace(line))
+	if len(baseTools) > 0 {
+		var out string
+		var err error
+		if isWindowsNativeTarget(target) {
+			out, err = runWindowsRemoteCapabilityPreflight(ctx, target, workdir, env, envFiles, baseTools)
+		} else if isWindowsWSL2Target(target) {
+			out, err = runWSL2RemoteCapabilityPreflight(ctx, target, workdir, env, envFiles, baseTools)
+		} else {
+			out, err = runSSHCombinedOutput(ctx, target, remoteCapabilityPreflightCommand(workdir, env, envFiles, baseTools))
 		}
+		if err != nil {
+			fmt.Fprintf(w, "remote preflight failed: %v\n", err)
+			if strings.TrimSpace(out) != "" {
+				fmt.Fprintf(w, "remote preflight output: %s\n", strings.TrimSpace(out))
+			}
+		} else {
+			for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+				if strings.TrimSpace(line) != "" {
+					fmt.Fprintf(w, "remote preflight %s\n", strings.TrimSpace(line))
+				}
+			}
+		}
+	}
+	if rawSocketRequested {
+		state := runRawSocketCapabilityPreflight(ctx, target, workdir, env, envFiles)
+		fmt.Fprintf(w, "remote preflight %s=%s\n", rawSocketPreflightTool, state)
 	}
 }
 
@@ -501,31 +516,175 @@ type preflightToolSpec struct {
 	OS      map[string]bool
 }
 
+const (
+	rawSocketPreflightTool    = "raw_socket"
+	rawSocketPreflightTimeout = 30 * time.Second
+	rawSocketProbePrefix      = "__crabbox_raw_socket_v1__:"
+	rawSocketProbeDirect      = rawSocketProbePrefix + "direct"
+	rawSocketProbeSudo        = rawSocketProbePrefix + "sudo"
+	rawSocketProbeUnavailable = rawSocketProbePrefix + "unavailable"
+	rawSocketProbeMissing     = rawSocketProbePrefix + "probe_missing"
+)
+
+const rawSocketPythonProbe = `import sys
+sys.path = [entry for entry in sys.path if entry not in ("", ".")]
+import errno
+import socket
+try:
+    probe = socket.socket(socket.AF_INET, socket.SOCK_RAW, socket.IPPROTO_RAW)
+    probe.close()
+except socket.error as exc:
+    if getattr(exc, "errno", None) in (errno.EPERM, errno.EACCES):
+        sys.exit(77)
+    sys.exit(78)
+except BaseException:
+    sys.exit(78)`
+
 var preflightToolRegistry = map[string]preflightToolSpec{
-	"apt":              {Posix: []string{"apt-get", "--version"}, OS: map[string]bool{"linux": true}},
-	"bubblewrap":       {Posix: []string{"bwrap", "--version"}, OS: map[string]bool{"linux": true}},
-	"bun":              {Posix: []string{"bun", "--version"}, Windows: []string{"bun", "--version"}},
-	"bwrap":            {Posix: []string{"bwrap", "--version"}, OS: map[string]bool{"linux": true}},
-	"cargo":            {Posix: []string{"cargo", "--version"}, Windows: []string{"cargo", "--version"}},
-	"corepack":         {Posix: []string{"corepack", "--version"}, Windows: []string{"corepack", "--version"}},
-	"docker":           {Posix: []string{"docker", "--version"}, Windows: []string{"docker", "--version"}},
-	"execution_policy": {Windows: []string{"Get-ExecutionPolicy -Scope Process"}, OS: map[string]bool{"windows": true}},
-	"git":              {Posix: []string{"git", "--version"}, Windows: []string{"git", "--version"}},
-	"go":               {Posix: []string{"go", "version"}, Windows: []string{"go", "version"}},
-	"longpaths":        {Windows: []string{"git config --global --get core.longpaths"}, OS: map[string]bool{"windows": true}},
-	"make":             {Posix: []string{"make", "--version"}},
-	"node":             {Posix: []string{"node", "--version"}, Windows: []string{"node", "--version"}},
-	"npm":              {Posix: []string{"npm", "--version"}, Windows: []string{"npm", "--version"}},
-	"pnpm":             {Posix: []string{"pnpm", "--version"}, Windows: []string{"pnpm", "--version"}},
-	"powershell":       {Windows: []string{"$PSVersionTable.PSVersion.ToString()"}, OS: map[string]bool{"windows": true}},
-	"python":           {Posix: []string{"python", "--version"}, Windows: []string{"python", "--version"}},
-	"python3":          {Posix: []string{"python3", "--version"}, Windows: []string{"python3", "--version"}},
-	"pwsh":             {Windows: []string{"pwsh", "--version"}, OS: map[string]bool{"windows": true}},
-	"sudo":             {OS: map[string]bool{"linux": true, "macos": true}},
-	"tar":              {Posix: []string{"tar", "--version"}, Windows: []string{"tar", "--version"}},
-	"temp":             {Windows: []string{"$env:TEMP"}, OS: map[string]bool{"windows": true}},
-	"uv":               {Posix: []string{"uv", "--version"}, Windows: []string{"uv", "--version"}},
-	"yarn":             {Posix: []string{"yarn", "--version"}, Windows: []string{"yarn", "--version"}},
+	"apt":                  {Posix: []string{"apt-get", "--version"}, OS: map[string]bool{"linux": true}},
+	"bubblewrap":           {Posix: []string{"bwrap", "--version"}, OS: map[string]bool{"linux": true}},
+	"bun":                  {Posix: []string{"bun", "--version"}, Windows: []string{"bun", "--version"}},
+	"bwrap":                {Posix: []string{"bwrap", "--version"}, OS: map[string]bool{"linux": true}},
+	"cargo":                {Posix: []string{"cargo", "--version"}, Windows: []string{"cargo", "--version"}},
+	"corepack":             {Posix: []string{"corepack", "--version"}, Windows: []string{"corepack", "--version"}},
+	"docker":               {Posix: []string{"docker", "--version"}, Windows: []string{"docker", "--version"}},
+	"execution_policy":     {Windows: []string{"Get-ExecutionPolicy -Scope Process"}, OS: map[string]bool{"windows": true}},
+	"git":                  {Posix: []string{"git", "--version"}, Windows: []string{"git", "--version"}},
+	"go":                   {Posix: []string{"go", "version"}, Windows: []string{"go", "version"}},
+	"longpaths":            {Windows: []string{"git config --global --get core.longpaths"}, OS: map[string]bool{"windows": true}},
+	"make":                 {Posix: []string{"make", "--version"}},
+	"node":                 {Posix: []string{"node", "--version"}, Windows: []string{"node", "--version"}},
+	"npm":                  {Posix: []string{"npm", "--version"}, Windows: []string{"npm", "--version"}},
+	"pnpm":                 {Posix: []string{"pnpm", "--version"}, Windows: []string{"pnpm", "--version"}},
+	"powershell":           {Windows: []string{"$PSVersionTable.PSVersion.ToString()"}, OS: map[string]bool{"windows": true}},
+	"python":               {Posix: []string{"python", "--version"}, Windows: []string{"python", "--version"}},
+	"python3":              {Posix: []string{"python3", "--version"}, Windows: []string{"python3", "--version"}},
+	"pwsh":                 {Windows: []string{"pwsh", "--version"}, OS: map[string]bool{"windows": true}},
+	rawSocketPreflightTool: {OS: map[string]bool{"linux": true}},
+	"sudo":                 {OS: map[string]bool{"linux": true, "macos": true}},
+	"tar":                  {Posix: []string{"tar", "--version"}, Windows: []string{"tar", "--version"}},
+	"temp":                 {Windows: []string{"$env:TEMP"}, OS: map[string]bool{"windows": true}},
+	"uv":                   {Posix: []string{"uv", "--version"}, Windows: []string{"uv", "--version"}},
+	"yarn":                 {Posix: []string{"yarn", "--version"}, Windows: []string{"yarn", "--version"}},
+}
+
+const rawSocketSudoPATH = "/usr/local/bin:/usr/bin:/bin:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/run/current-system/profile/bin"
+
+func rawSocketPreflightScript() string {
+	return rawSocketPreflightScriptWithSudoEnvironment([]string{
+		"/usr/bin/sudo",
+		"/bin/sudo",
+		"/usr/local/bin/sudo",
+		"/run/wrappers/bin/sudo",
+		"/run/setuid-programs/sudo",
+	}, rawSocketSudoPATH)
+}
+
+func rawSocketPreflightScriptWithSudoEnvironment(sudoExecutables []string, sudoPath string) string {
+	probe := shellQuote(rawSocketPythonProbe)
+	sudoCandidates := make([]string, 0, len(sudoExecutables))
+	for _, sudo := range sudoExecutables {
+		sudoCandidates = append(sudoCandidates, shellQuote(sudo))
+	}
+	if len(sudoCandidates) == 0 {
+		sudoCandidates = append(sudoCandidates, "__crabbox_no_trusted_sudo__")
+	}
+	sudoProbe := shellQuote(`PATH=` + shellQuote(sudoPath) + `
+export PATH
+case "$1" in
+  python3|python) ;;
+  *) exit 79 ;;
+esac
+command -v "$1" >/dev/null 2>&1 || exit 79
+exec "$1" -B -E -S -c "$2"`)
+	return `found_interpreter=0
+for interpreter_name in python3 python; do
+  interpreter="$(command -v "$interpreter_name" 2>/dev/null || true)"
+  if [ -z "$interpreter" ] || [ ! -x "$interpreter" ]; then
+    continue
+  fi
+  found_interpreter=1
+  direct_status=0
+  "$interpreter" -B -E -S -c ` + probe + ` >/dev/null 2>&1 || direct_status=$?
+  if [ "$direct_status" -eq 0 ]; then
+    printf '` + rawSocketProbeDirect + `\n'
+    exit 0
+  fi
+  if [ "$direct_status" -ne 77 ]; then
+    continue
+  fi
+  # Resolve the same interpreter name only inside a fixed root-side PATH, never the workload PATH.
+  for sudo_executable in ` + strings.Join(sudoCandidates, " ") + `; do
+    if [ ! -x "$sudo_executable" ]; then
+      continue
+    fi
+    if "$sudo_executable" -n -- /bin/sh -c ` + sudoProbe + ` crabbox-raw-socket "$interpreter_name" ` + probe + ` >/dev/null 2>&1; then
+      printf '` + rawSocketProbeSudo + `\n'
+      exit 0
+    fi
+  done
+done
+if [ "$found_interpreter" -eq 0 ]; then
+  printf '` + rawSocketProbeMissing + `\n'
+else
+  printf '` + rawSocketProbeUnavailable + `\n'
+fi
+`
+}
+
+func runRawSocketCapabilityPreflight(ctx context.Context, target SSHTarget, workdir string, env map[string]string, envFiles []string) string {
+	command := rawSocketCapabilityPreflightCommand(workdir, env, envFiles)
+	return runRawSocketCapabilityPreflightWithRunner(ctx, rawSocketPreflightTimeout, func(probeCtx context.Context) (string, error) {
+		if isWindowsWSL2Target(target) {
+			return runWSL2ControlCombinedOutput(probeCtx, target, command)
+		}
+		return runSSHCombinedOutput(probeCtx, target, command)
+	})
+}
+
+func rawSocketCapabilityPreflightCommand(workdir string, env map[string]string, envFiles []string) string {
+	return remoteShellCommandWithEnvFiles(workdir, env, envFiles, rawSocketPreflightScript())
+}
+
+func runRawSocketCapabilityPreflightWithRunner(ctx context.Context, timeout time.Duration, runner func(context.Context) (string, error)) string {
+	probeCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	out, err := runner(probeCtx)
+	if err != nil || probeCtx.Err() != nil {
+		return "unavailable"
+	}
+	return parseRawSocketProbeOutput(out)
+}
+
+func parseRawSocketProbeOutput(out string) string {
+	state := ""
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, rawSocketProbePrefix) {
+			continue
+		}
+		var next string
+		switch line {
+		case rawSocketProbeDirect:
+			next = "direct"
+		case rawSocketProbeSudo:
+			next = "sudo"
+		case rawSocketProbeMissing:
+			next = "probe_missing"
+		case rawSocketProbeUnavailable:
+			next = "unavailable"
+		default:
+			return "unavailable"
+		}
+		if state != "" {
+			return "unavailable"
+		}
+		state = next
+	}
+	if state == "" {
+		return "unavailable"
+	}
+	return state
 }
 
 var defaultPreflightToolNames = []string{"git", "tar", "node", "npm", "corepack", "pnpm", "yarn", "bun", "docker", "sudo", "apt", "bubblewrap", "powershell", "execution_policy", "longpaths", "temp", "pwsh"}

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -4512,6 +4512,400 @@ func TestPythonPreflightWindowsProbeUsesLiteralExecutableAndMissingContract(t *t
 	}
 }
 
+func TestRawSocketPreflightToolValidationAndTargetFiltering(t *testing.T) {
+	if err := validatePreflightTools([]string{rawSocketPreflightTool}); err != nil {
+		t.Fatalf("raw_socket should validate: %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		target SSHTarget
+		want   string
+	}{
+		{name: "linux", target: SSHTarget{TargetOS: targetLinux}, want: rawSocketPreflightTool},
+		{name: "wsl2", target: SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeWSL2}, want: rawSocketPreflightTool},
+		{name: "macos", target: SSHTarget{TargetOS: targetMacOS}},
+		{name: "native_windows", target: SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeNormal}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := strings.Join(preflightToolsForTarget(tt.target, []string{rawSocketPreflightTool}), ",")
+			if got != tt.want {
+				t.Fatalf("tools=%q want %q", got, tt.want)
+			}
+		})
+	}
+
+	for _, tool := range preflightToolsForTarget(SSHTarget{TargetOS: targetLinux}, nil) {
+		if tool == rawSocketPreflightTool {
+			t.Fatalf("raw_socket must remain opt-in, default tools=%v", defaultPreflightToolNames)
+		}
+	}
+}
+
+func TestRawSocketPreflightConfigRoundTripAndValidation(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "crabbox.yaml")
+	if err := os.WriteFile(path, []byte("run:\n  preflightTools: [raw_socket]\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := defaultConfig()
+	if err := applyConfigFile(&cfg, path, configPathTrust{trusted: true}); err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(cfg.Run.PreflightTools, ","); got != rawSocketPreflightTool {
+		t.Fatalf("run.preflightTools=%q", got)
+	}
+	if err := validatePreflightTools(cfg.Run.PreflightTools); err != nil {
+		t.Fatalf("configured raw_socket should validate: %v", err)
+	}
+}
+
+func TestRawSocketOnlyPreflightUsesOneBoundedRemoteCommand(t *testing.T) {
+	dir := t.TempDir()
+	logPath := installRecordingSSH(t, dir)
+	cfg := defaultConfig()
+	cfg.Run.PreflightTools = []string{rawSocketPreflightTool}
+	target := SSHTarget{
+		User:     "crabbox",
+		Host:     "127.0.0.1",
+		Port:     "22",
+		TargetOS: targetLinux,
+	}
+
+	var out bytes.Buffer
+	printRemoteCapabilityPreflight(context.Background(), &out, cfg, Server{}, target, "cbx_123", "/work/repo", nil, false, "", true, nil)
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	commands := recordedSSHCommands(string(data))
+	if len(commands) != 1 {
+		t.Fatalf("raw_socket-only SSH commands=%d want 1:\n%s", len(commands), data)
+	}
+	if !strings.Contains(commands[0], rawSocketProbePrefix) {
+		t.Fatalf("raw_socket command missing protocol: %q", commands[0])
+	}
+	if !strings.Contains(out.String(), "remote preflight raw_socket=unavailable\n") {
+		t.Fatalf("unexpected preflight output: %q", out.String())
+	}
+}
+
+func TestRawSocketPreflightScriptIsMinimalAndProtocolBound(t *testing.T) {
+	script := rawSocketPreflightScript()
+	for _, want := range []string{
+		"for interpreter_name in python3 python",
+		`"$interpreter" -B -E -S -c ` + shellQuote(rawSocketPythonProbe) + ` >/dev/null 2>&1`,
+		`for sudo_executable in '/usr/bin/sudo' '/bin/sudo' '/usr/local/bin/sudo' '/run/wrappers/bin/sudo' '/run/setuid-programs/sudo'`,
+		`"$sudo_executable" -n -- /bin/sh -c `,
+		`case "$1" in`,
+		`python3|python) ;;`,
+		rawSocketSudoPATH,
+		rawSocketProbeDirect,
+		rawSocketProbeSudo,
+		rawSocketProbeUnavailable,
+		rawSocketProbeMissing,
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("raw socket script missing %q in %q", want, script)
+		}
+	}
+	if strings.Count(script, rawSocketPythonProbe) != 2 {
+		t.Fatalf("direct and sudo attempts must use identical code: %q", script)
+	}
+	if strings.Contains(script, "command -v sudo") || strings.Contains(script, " sudo -n") {
+		t.Fatalf("sudo must not resolve through workload PATH: %q", script)
+	}
+	if strings.Count(rawSocketPythonProbe, "socket.socket(socket.AF_INET, socket.SOCK_RAW, socket.IPPROTO_RAW)") != 1 || strings.Count(rawSocketPythonProbe, "probe.close()") != 1 {
+		t.Fatalf("unexpected Python probe: %q", rawSocketPythonProbe)
+	}
+	if strings.Contains(rawSocketPythonProbe, "PermissionError") || strings.Contains(script, " -I ") || !strings.Contains(script, " -B -E -S -c ") {
+		t.Fatalf("probe must remain bytecode-free and compatible with the literal python fallback: %q", script)
+	}
+	for _, forbidden := range []string{".bind(", ".connect(", ".send(", ".sendto(", ".recv(", "scapy", "tcpdump", "setcap", "cap_net_raw", "apt ", "install "} {
+		if strings.Contains(strings.ToLower(rawSocketPythonProbe), forbidden) {
+			t.Fatalf("Python probe contains forbidden operation %q: %q", forbidden, rawSocketPythonProbe)
+		}
+	}
+	ordinary := remoteCapabilityPreflightCommand("/work/repo", nil, nil, []string{"node"})
+	if strings.Contains(ordinary, rawSocketProbePrefix) || strings.Contains(ordinary, "sudo -n --") {
+		t.Fatalf("ordinary preflight gained raw-socket elevation: %q", ordinary)
+	}
+
+	workdir := "/work/runner's repo"
+	envFile := "/work/env file's/run.env"
+	command := rawSocketCapabilityPreflightCommand(workdir, map[string]string{"CI": "value with ' quote"}, []string{envFile})
+	for _, want := range []string{
+		"cd " + shellQuote(workdir),
+		". " + shellQuote(envFile),
+		"CI=" + shellQuote("value with ' quote"),
+		shellQuote(rawSocketPythonProbe),
+	} {
+		if !strings.Contains(command, want) {
+			t.Fatalf("quoted raw socket command missing %q in %q", want, command)
+		}
+	}
+}
+
+func TestRawSocketPreflightStatesAndPermissionFallback(t *testing.T) {
+	tests := []struct {
+		name          string
+		pythonName    string
+		directExit    int
+		sudoExit      int
+		installPython bool
+		installSudo   bool
+		want          string
+		wantSudo      bool
+		errexit       bool
+	}{
+		{name: "direct", pythonName: "python3", directExit: 0, sudoExit: 0, installPython: true, installSudo: true, want: "direct"},
+		{name: "sudo", pythonName: "python3", directExit: 77, sudoExit: 0, installPython: true, installSudo: true, want: "sudo", wantSudo: true},
+		{name: "sudo_with_errexit", pythonName: "python3", directExit: 77, sudoExit: 0, installPython: true, installSudo: true, want: "sudo", wantSudo: true, errexit: true},
+		{name: "permission_denied_without_sudo", pythonName: "python3", directExit: 77, sudoExit: 0, installPython: true, want: "unavailable"},
+		{name: "permission_denied_sudo_fails", pythonName: "python3", directExit: 77, sudoExit: 78, installPython: true, installSudo: true, want: "unavailable", wantSudo: true},
+		{name: "other_error_does_not_elevate", pythonName: "python3", directExit: 78, sudoExit: 0, installPython: true, installSudo: true, want: "unavailable"},
+		{name: "python_fallback", pythonName: "python", directExit: 0, installPython: true, want: "direct"},
+		{name: "probe_missing", want: "probe_missing"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			sudoLog := filepath.Join(dir, "sudo.log")
+			if tt.installPython {
+				python := fmt.Sprintf(`#!/bin/sh
+printf '%%s\n' '%s'
+if [ "${CRABBOX_TEST_RAW_SOCKET_SUDO:-}" = 1 ]; then exit %d; fi
+exit %d
+`, rawSocketProbeDirect, tt.sudoExit, tt.directExit)
+				if err := os.WriteFile(filepath.Join(dir, tt.pythonName), []byte(python), 0o700); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if tt.installSudo {
+				sudo := `#!/bin/sh
+printf 'called\n' >> ` + shellQuote(sudoLog) + `
+if [ "$1" = -n ]; then shift; fi
+if [ "$1" = -- ]; then shift; fi
+CRABBOX_TEST_RAW_SOCKET_SUDO=1
+export CRABBOX_TEST_RAW_SOCKET_SUDO
+exec "$@"
+`
+				if err := os.WriteFile(filepath.Join(dir, "sudo"), []byte(sudo), 0o700); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			script := rawSocketPreflightScriptWithSudoEnvironment([]string{filepath.Join(dir, "sudo")}, dir)
+			if tt.errexit {
+				script = "set -e\n" + script
+			}
+			cmd := exec.Command("/bin/bash", "-c", script)
+			cmd.Env = []string{"PATH=" + dir}
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("probe script: %v: %s", err, out)
+			}
+			if got := parseRawSocketProbeOutput(string(out)); got != tt.want {
+				t.Fatalf("state=%q want %q, output=%q", got, tt.want, out)
+			}
+			_, statErr := os.Stat(sudoLog)
+			if gotSudo := statErr == nil; gotSudo != tt.wantSudo {
+				t.Fatalf("sudo called=%t want %t", gotSudo, tt.wantSudo)
+			}
+		})
+	}
+}
+
+func TestRawSocketPreflightTriesEachTrustedSudoCandidate(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "sudo.log")
+	python := `#!/bin/sh
+if [ "${CRABBOX_TEST_RAW_SOCKET_SUDO:-}" = 1 ]; then exit 0; fi
+exit 77
+`
+	if err := os.WriteFile(filepath.Join(dir, "python3"), []byte(python), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	firstSudo := filepath.Join(dir, "sudo-first")
+	if err := os.WriteFile(firstSudo, []byte("#!/bin/sh\nprintf 'first\\n' >> "+shellQuote(logPath)+"\nexit 1\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	secondSudo := filepath.Join(dir, "sudo-second")
+	sudo := `#!/bin/sh
+printf 'second\n' >> ` + shellQuote(logPath) + `
+if [ "$1" = -n ]; then shift; fi
+if [ "$1" = -- ]; then shift; fi
+CRABBOX_TEST_RAW_SOCKET_SUDO=1
+export CRABBOX_TEST_RAW_SOCKET_SUDO
+exec "$@"
+`
+	if err := os.WriteFile(secondSudo, []byte(sudo), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	script := rawSocketPreflightScriptWithSudoEnvironment([]string{firstSudo, secondSudo}, dir)
+	cmd := exec.Command("/bin/bash", "-c", script)
+	cmd.Env = []string{"PATH=" + dir}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("probe script: %v: %s", err, out)
+	}
+	if got := parseRawSocketProbeOutput(string(out)); got != "sudo" {
+		t.Fatalf("state=%q want sudo, output=%q", got, out)
+	}
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(data); got != "first\nsecond\n" {
+		t.Fatalf("sudo attempts=%q", got)
+	}
+}
+
+func TestRawSocketPreflightFallsBackAfterBrokenPython3(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "interpreters.log")
+	python3 := "#!/bin/sh\nprintf 'python3\\n' >> " + shellQuote(logPath) + "\nexit 78\n"
+	if err := os.WriteFile(filepath.Join(dir, "python3"), []byte(python3), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	python := "#!/bin/sh\nprintf 'python\\n' >> " + shellQuote(logPath) + "\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(dir, "python"), []byte(python), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command("/bin/bash", "-c", rawSocketPreflightScriptWithSudoEnvironment(nil, dir))
+	cmd.Env = []string{"PATH=" + dir}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("probe script: %v: %s", err, out)
+	}
+	if got := parseRawSocketProbeOutput(string(out)); got != "direct" {
+		t.Fatalf("state=%q want direct, output=%q", got, out)
+	}
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(data); got != "python3\npython\n" {
+		t.Fatalf("interpreter order=%q", got)
+	}
+}
+
+func TestRawSocketPreflightDoesNotResolveSudoInterpreterFromWorkloadPATH(t *testing.T) {
+	dir := t.TempDir()
+	sudoPath := t.TempDir()
+	privilegedMarker := filepath.Join(dir, "privileged")
+	python := `#!/bin/sh
+if [ "${CRABBOX_TEST_RAW_SOCKET_SUDO:-}" = 1 ]; then
+  printf 'ran\n' > ` + shellQuote(privilegedMarker) + `
+  exit 0
+fi
+exit 77
+`
+	if err := os.WriteFile(filepath.Join(dir, "python3"), []byte(python), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	sudoLog := filepath.Join(dir, "sudo.log")
+	sudo := `#!/bin/sh
+printf 'called\n' >> ` + shellQuote(sudoLog) + `
+if [ "$1" = -n ]; then shift; fi
+if [ "$1" = -- ]; then shift; fi
+CRABBOX_TEST_RAW_SOCKET_SUDO=1
+export CRABBOX_TEST_RAW_SOCKET_SUDO
+exec "$@"
+`
+	sudoExecutable := filepath.Join(dir, "sudo")
+	if err := os.WriteFile(sudoExecutable, []byte(sudo), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	script := rawSocketPreflightScriptWithSudoEnvironment([]string{sudoExecutable}, sudoPath)
+	cmd := exec.Command("/bin/bash", "-c", script)
+	cmd.Env = []string{"PATH=" + dir}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("probe script: %v: %s", err, out)
+	}
+	if got := parseRawSocketProbeOutput(string(out)); got != "unavailable" {
+		t.Fatalf("state=%q want unavailable, output=%q", got, out)
+	}
+	if _, err := os.Stat(sudoLog); err != nil {
+		t.Fatalf("sudo fallback not attempted: %v", err)
+	}
+	if _, err := os.Stat(privilegedMarker); !os.IsNotExist(err) {
+		t.Fatalf("workload PATH interpreter ran through sudo: %v", err)
+	}
+}
+
+func TestRawSocketPythonProbeIgnoresWorkdirModuleShadow(t *testing.T) {
+	python, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skip("python3 unavailable")
+	}
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "shadow-imported")
+	shadow := "from pathlib import Path\nPath(" + fmt.Sprintf("%q", marker) + ").write_text('imported')\n"
+	if err := os.WriteFile(filepath.Join(dir, "socket.py"), []byte(shadow), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(python, "-B", "-E", "-S", "-c", rawSocketPythonProbe)
+	cmd.Dir = dir
+	_ = cmd.Run()
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("workdir socket.py was imported: %v", err)
+	}
+	cmd = exec.Command(python, "-B", "-E", "-S", "-c", `import sys; print("site" in sys.modules, sys.dont_write_bytecode)`)
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("check isolated Python startup: %v", err)
+	}
+	if got := strings.TrimSpace(string(out)); got != "False True" {
+		t.Fatalf("isolated bytecode-free Python startup not active: %q", got)
+	}
+}
+
+func TestRawSocketPreflightProtocolRejectsAmbiguousMarkersAndToleratesNoise(t *testing.T) {
+	valid := map[string]string{
+		rawSocketProbeDirect:                       "direct",
+		rawSocketProbeSudo:                         "sudo",
+		rawSocketProbeUnavailable:                  "unavailable",
+		rawSocketProbeMissing:                      "probe_missing",
+		"login banner\n" + rawSocketProbeDirect:    "direct",
+		rawSocketProbeSudo + "\nlogout diagnostic": "sudo",
+	}
+	for output, want := range valid {
+		if got := parseRawSocketProbeOutput(output); got != want {
+			t.Fatalf("output %q produced %q want %q", output, got, want)
+		}
+	}
+	for _, out := range []string{
+		rawSocketProbeDirect + "\n" + rawSocketProbeUnavailable,
+		rawSocketProbePrefix + "unknown",
+		"raw_socket=direct",
+		"direct",
+		"",
+	} {
+		if got := parseRawSocketProbeOutput(out); got != "unavailable" {
+			t.Fatalf("ambiguous output %q produced %q", out, got)
+		}
+	}
+}
+
+func TestRawSocketPreflightAttemptIsBounded(t *testing.T) {
+	started := time.Now()
+	state := runRawSocketCapabilityPreflightWithRunner(context.Background(), 20*time.Millisecond, func(ctx context.Context) (string, error) {
+		<-ctx.Done()
+		return rawSocketProbeDirect, ctx.Err()
+	})
+	if state != "unavailable" {
+		t.Fatalf("state=%q want unavailable", state)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("probe timeout took %s", elapsed)
+	}
+}
+
 func TestDelegatedPreflightPrintsUnsupportedMessage(t *testing.T) {
 	var stderr bytes.Buffer
 	printDelegatedPreflightUnsupported(&stderr, "e2b")


### PR DESCRIPTION
## Summary

- add the opt-in `raw_socket` preflight capability for Linux and WSL2
- report stable `direct`, `sudo`, `unavailable`, or `probe_missing` states using `python3` then `python`
- keep the probe diagnostic-only: it opens and immediately closes one raw socket, never binds, connects, sends, receives, installs software, grants capabilities, or elevates the workload
- isolate interpreter imports, suppress bytecode writes, reject ambiguous protocol output, and run sudo fallback only through trusted executable locations with a fixed root-side interpreter path

## Verification

- `go test -race ./internal/cli -run 'TestRawSocket|TestPreflight|TestPythonPreflight|TestRemoteCapabilityPreflight' -count=1 -timeout=10m`
- `go vet ./internal/cli`
- `git diff --check origin/main...HEAD`
- `node scripts/build-docs-site.mjs`
- clean P1 maintainer autoreview after addressing portability, protocol-noise, bytecode, and multi-sudo-candidate findings

A broad local CLI race run encountered unrelated host-sensitive controller/listener timing failures and timed out under concurrent test load; every reported failing test passed when rerun independently. Exact-head CI is the authoritative broad gate.

## Exact-head live proof

Built from exact head `3d44f9c95428b16ab377c6ca92a2a771609d3d9b`:

```text
binary_sha256=72874b482cfc66399109ae5668b38cf56f90c5d845aa84eb620a615437f635df
provider=local-container runtime=docker server=29.4.0 image=python:3.13-slim

$ crabbox run --provider local-container --local-container-runtime docker \
    --local-container-image python:3.13-slim --no-sync \
    --preflight --preflight-tools raw_socket -- true
provisioning provider=local-container lease=<redacted> keep=false
provisioned lease=<redacted> container=<redacted> state=ready
remote preflight workspace=raw hydrate_supported=true
remote preflight raw_socket=sudo
running on 127.0.0.1 true
command complete exit=0
releasing <redacted>
lease cleanup stopped=true policy=auto lease=<redacted>

$ docker ps -a --filter label=com.crabbox.lease=<redacted>
<no output>
$ crabbox claims list --json | jq '[.claims[] | select(.leaseId == "<redacted>")] | length'
0
```

The execution user could not open the raw socket directly; the identical bounded probe succeeded through non-interactive sudo. The ordinary workload remained unprivileged, the user command completed normally, and cleanup left no proof-owned container or claim. Separate Docker controls observed permission denial without `NET_RAW`, direct success with `NET_RAW`, and sudo-assisted success from an unprivileged user.

Maintainer decision: retain the Unreleased changelog entry. Repository policy requires changelog coverage for user-visible features; release preparation consumes that maintained section rather than replacing normal feature entries.

Closes https://github.com/openclaw/crabbox/issues/1258
