### PR TITLE
feat(cli): add provider-scoped flag discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added credential-free `crabbox providers describe` discovery for canonical provider-scoped run flags and compiled defaults. Thanks @coygeek.
 - Added an opt-in Linux/WSL2 `raw_socket` preflight probe that distinguishes direct, non-interactive-sudo, unavailable, and missing-interpreter states without sending packets or elevating workloads. Thanks @coygeek.
 - Added checkpoint last-use tracking and composable `checkpoint prune --unused-for` cleanup for inactive local records and provider artifacts.
 - Added provider-native create, verify, delete, and fork lifecycle for direct Hetzner project-snapshot checkpoints, including exact local-claim image deletion.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -164,6 +164,7 @@ See [pond](commands/pond.md) and the [pond feature](features/pond.md).
 
 ```text
 crabbox providers                             show provider capabilities
+crabbox providers describe <provider>         show compiled run flags for one runnable provider
 crabbox usage [--scope user|org|all]          cost and usage estimates
 crabbox marketplace status|quote              preview the credits gateway and smart-routing quotes
 crabbox admin leases|lease-audit|providers|hosts|release|delete

--- a/docs/commands/providers.md
+++ b/docs/commands/providers.md
@@ -10,6 +10,8 @@ crabbox providers
 crabbox providers --json
 crabbox providers filters
 crabbox providers filters --json
+crabbox providers describe local-container
+crabbox providers describe docker --json
 crabbox providers --reachability provider-url --evidence preview-url
 crabbox providers --lifecycle cleanup --lifecycle workspace-state
 crabbox providers --target linux --workspace checkpoint --workspace fork --json
@@ -63,6 +65,128 @@ the current binary.
 
 The matrix form takes no positional arguments. Use `providers recommend` for
 workflow-oriented ranked selection guidance.
+
+## `providers describe`
+
+`crabbox providers describe <provider>` reports the selected runnable
+provider's canonical identity, normalized capabilities, and the exact flags
+registered by `crabbox run`. An alias is accepted before or after `--json`:
+
+```sh
+crabbox providers describe local-container
+crabbox providers describe docker --json
+crabbox providers describe --json docker
+```
+
+Alias input is visible in both formats. Human output starts with the
+canonicalization and keeps command-level and provider-owned flags separate:
+
+```text
+docker -> local-container
+  kind: ssh-lease
+  runnable: true
+  family: container
+  aliases: container,docker,local-docker
+  deprecated: false
+  replacement: -
+  targets: linux
+  features: browser,cache-volume,cleanup,crabbox-sync,desktop,run-session,ssh,workspace-checkpoint,workspace-fork
+  runtime: interactive,local-runtime,ssh-host
+  reachability: ssh-tunnel
+  workspace: checkpoint,fork
+  evidence: session
+  lifecycle: cleanup,run-session,workspace-state
+  coordinator: never
+
+Shared run flags:
+  --arch
+    type: string; value shape: scalar; default: "amd64"; repeatable: false
+    deprecated: false; replacement: -; routing: false; creation-only: false
+    CPU architecture: amd64 or arm64
+  ...
+
+local-container flags:
+  --local-container-volume
+    type: string; value shape: string-list; default: []; repeatable: true
+    deprecated: false; replacement: -; routing: false; creation-only: true
+    bind-mount a host path into the container; host:container[:ro]; repeatable
+```
+
+Providers with no provider-owned flags still print `Shared run flags` and an
+explicit `(none)` in their provider section. Shared flags are command-level
+`run` workflow flags; their presence does not bypass ordinary capability,
+target, provider-kind, or option-combination validation.
+
+### JSON schema v1
+
+`--json` emits one object. Every array is present, including empty arrays, and
+identity aliases, targets, capability arrays, and flag records are sorted for
+deterministic output:
+
+```json
+{
+  "schemaVersion": 1,
+  "provider": {
+    "requested": "docker",
+    "canonical": "local-container",
+    "inputAlias": "docker",
+    "aliases": ["container", "docker", "local-docker"],
+    "deprecated": false,
+    "replacement": ""
+  },
+  "runnable": true,
+  "kind": "ssh-lease",
+  "family": "container",
+  "targets": ["linux"],
+  "capabilities": {
+    "features": ["browser", "cache-volume", "cleanup", "crabbox-sync", "desktop", "run-session", "ssh", "workspace-checkpoint", "workspace-fork"],
+    "runtime": ["interactive", "local-runtime", "ssh-host"],
+    "reachability": ["ssh-tunnel"],
+    "workspace": ["checkpoint", "fork"],
+    "evidence": ["session"],
+    "lifecycle": ["cleanup", "run-session", "workspace-state"],
+    "coordinator": "never"
+  },
+  "sharedFlags": [],
+  "providerFlags": []
+}
+```
+
+The abbreviated empty flag arrays above have this stable record shape when
+populated:
+
+```json
+{
+  "name": "local-container-volume",
+  "type": "string",
+  "valueShape": "string-list",
+  "default": [],
+  "repeatable": true,
+  "usage": "bind-mount a host path into the container; host:container[:ro]; repeatable",
+  "deprecated": false,
+  "replacement": "",
+  "routing": false,
+  "creationOnly": true
+}
+```
+
+Scalar `type` values are `string`, `bool`, `int`, `int64`, `float64`, or
+`duration`; durations use canonical Go duration strings. A repeatable string
+list has `type: "string"`, `valueShape: "string-list"`, a JSON string-array
+default, and `repeatable: true`.
+
+Defaults come from the compiled `baseConfig()` passed through the real `run`
+flag registration. The command does not load config files or environment
+overrides, inspect credentials, configure or apply a provider, create clients,
+contact a network, read claims/state/locks, or write files. Consequently it
+never serializes live config, credential, or environment values. Provider-level
+deprecation is currently always `false` with an empty replacement because the
+registry has equivalent aliases but no deprecated-provider contract. Flag
+deprecations are explicit per flag and point to their canonical replacement.
+
+Only `ssh-lease` and `delegated-run` providers are runnable. Unknown providers,
+`service-control` providers, future unsupported provider kinds, missing names,
+and extra names fail with exit 2 and produce no partial JSON.
 
 ## `providers filters`
 

--- a/docs/features/provider-authoring.md
+++ b/docs/features/provider-authoring.md
@@ -281,6 +281,43 @@ Conventions:
   (`RouteConfig`) and `ProviderRoutingFlagProvider` (`RoutingFlagNames`) so a
   family-shared flag selects the right sibling. Most new providers do not need
   this.
+- Providers with flags valid only while creating a lease should implement
+  `ProviderCreationOnlyFlagProvider` (`CreationOnlyFlagNames`). Both routing and
+  creation-only names must refer to flags registered by that provider;
+  `providers describe` fails closed if the contracts drift.
+
+`crabbox providers describe` observes each real `RegisterFlags` call while
+registering the complete `run` flag set against `baseConfig()`. Do not maintain
+a second flag inventory. Standard string, bool, int, int64, float64, and
+`time.Duration` values are discoverable automatically. A custom repeatable
+string value must implement `flag.Getter` and return a defensive `[]string`
+copy:
+
+```go
+type stringListFlag []string
+
+func (f *stringListFlag) String() string { return strings.Join(*f, ",") }
+func (f *stringListFlag) Set(value string) error {
+	*f = append(*f, value)
+	return nil
+}
+func (f *stringListFlag) Get() any {
+	return append([]string{}, (*f)...)
+}
+```
+
+Unsupported custom values make discovery fail rather than guessing a type or
+serializing `String()` output. Keep `RegisterFlags` side-effect free: discovery
+calls it for every provider, but never calls `ApplyFlags`, `Configure`, config
+loading, clients, credentials, or provider state.
+
+When renaming a flag, register the compatibility spelling beside the canonical
+flag and call `core.MarkFlagDeprecated(fs, "old-name", "new-name")` immediately
+in the same registration function. The annotation validates that both real
+flags exist, preserves normal help and parsing behavior, and supplies
+deprecation/replacement metadata without a detached provider-name or flag
+table. Keep precedence in `ApplyFlags`; canonical-wins behavior is an execution
+contract, not metadata inference.
 
 Never accept secrets as flag arguments. Pull them from environment variables,
 SDK config, the broker, or the operator's credential store. Flags are visible in

--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -538,6 +538,12 @@ unknown flags. `RegisterFlags` must be cheap and side-effect free. It returns an
 opaque values struct passed back into `ApplyFlags` only after config and common
 flags select the provider.
 
+The same real registration is the source for `crabbox providers describe`.
+Discovery passes `baseConfig()` compiled defaults, attributes flags added by
+each `Provider.RegisterFlags` invocation, and treats everything else registered
+by `run` as a shared command flag. It never calls `ApplyFlags` or `Configure`.
+Do not add a parallel flag inventory.
+
 Pattern for a provider with typed config fields:
 
 ```go
@@ -562,6 +568,19 @@ func (Provider) ApplyFlags(cfg *cli.Config, fs *flag.FlagSet, values any) error 
 	return nil
 }
 ```
+
+Custom repeatable string-list values must also implement `flag.Getter` and
+return a defensive `[]string` copy. Discovery supports standard string, bool,
+int, int64, float64, and duration values and fails closed on any other custom
+getter type. Routing names from `ProviderRoutingFlagProvider` and create-only
+names from `ProviderCreationOnlyFlagProvider` must resolve to flags registered
+by that provider.
+
+Register renamed compatibility flags with their canonical spelling and annotate
+them in place with `cli.MarkFlagDeprecated(fs, "old-name", "new-name")`. The
+annotation checks that both registered flags exist, feeds discovery metadata,
+and leaves help, parsing, and provider-owned canonical-wins application logic
+unchanged.
 
 `Config` does not have a generic provider config bag. New provider packages
 should either add typed config fields and use `cli.FlagWasSet` from the provider

--- a/docs/source-map.md
+++ b/docs/source-map.md
@@ -39,7 +39,9 @@ Crabbox has three implementation surfaces:
 - `login`/`logout`/`whoami` and `config path|show|set-broker`: `internal/cli/auth.go`, `internal/cli/config_cmd.go`
 - `azure login` (subscription detection via `az` CLI): `internal/cli/azure_login.go`, `internal/cli/azure_cli.go`
 - Doctor checks, broker/provider readiness output, and pond doctor: `internal/cli/doctor.go`, `internal/cli/doctor_pond.go`
-- `providers`, `usage`, and admin commands: `internal/cli/providers.go`, `internal/cli/usage.go`, `internal/cli/admin.go`
+- Provider matrix/filter/recommend output: `internal/cli/providers.go`
+- Provider-scoped `run` flag discovery and JSON schema v1: `internal/cli/providers_describe.go`, with the real reusable registration owner in `internal/cli/run.go` and coupled flag annotations in `internal/cli/flag_metadata.go`
+- `usage` and admin commands: `internal/cli/usage.go`, `internal/cli/admin.go`
 - Provider image bake/promote/fsr-status/delete: `internal/cli/image.go`, `internal/cli/os_image.go`, `internal/cli/coordinator.go`
 - Deterministic perf evidence is contract-only for now:
   `docs/features/deterministic-perf-evidence.md`; no `--perf-budget`,

--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -3205,3 +3205,7 @@ func (f *stringListFlag) Set(value string) error {
 	*f = append(*f, value)
 	return nil
 }
+
+func (f *stringListFlag) Get() any {
+	return append([]string{}, (*f)...)
+}

--- a/internal/cli/flag_metadata.go
+++ b/internal/cli/flag_metadata.go
@@ -1,0 +1,44 @@
+package cli
+
+import (
+	"flag"
+	"sync"
+)
+
+type registeredFlagAnnotation struct {
+	Deprecated  bool
+	Replacement string
+}
+
+var registeredFlagAnnotations sync.Map
+
+// MarkFlagDeprecated attaches deprecation metadata to a flag's real registered
+// value. Missing flags or replacements panic during registration so provider
+// authoring drift cannot silently reach discovery output.
+func MarkFlagDeprecated(fs *flag.FlagSet, name, replacement string) {
+	item := fs.Lookup(name)
+	if item == nil {
+		panic("cannot deprecate unregistered flag --" + name)
+	}
+	if replacement == "" || replacement == name || fs.Lookup(replacement) == nil {
+		panic("deprecated flag --" + name + " has invalid replacement --" + replacement)
+	}
+	if _, ok := registeredFlagAnnotations.Load(item); ok {
+		panic("flag --" + name + " already has metadata")
+	}
+	registeredFlagAnnotations.Store(item, registeredFlagAnnotation{
+		Deprecated:  true,
+		Replacement: replacement,
+	})
+}
+
+func annotationForFlag(item *flag.Flag) registeredFlagAnnotation {
+	if annotation, ok := registeredFlagAnnotations.Load(item); ok {
+		return annotation.(registeredFlagAnnotation)
+	}
+	return registeredFlagAnnotation{}
+}
+
+func clearFlagAnnotations(fs *flag.FlagSet) {
+	fs.VisitAll(func(item *flag.Flag) { registeredFlagAnnotations.Delete(item) })
+}

--- a/internal/cli/lease_flags.go
+++ b/internal/cli/lease_flags.go
@@ -41,6 +41,10 @@ type leaseCreateFlagValues struct {
 }
 
 func registerLeaseCreateFlags(fs *flag.FlagSet, defaults Config) leaseCreateFlagValues {
+	return registerLeaseCreateFlagsObserved(fs, defaults, nil)
+}
+
+func registerLeaseCreateFlagsObserved(fs *flag.FlagSet, defaults Config, observe providerFlagRegistrationObserver) leaseCreateFlagValues {
 	expose := stringListFlag{}
 	cacheVolumes := stringListFlag{}
 	imageSDK := stringListFlag{}
@@ -74,7 +78,7 @@ func registerLeaseCreateFlags(fs *flag.FlagSet, defaults Config) leaseCreateFlag
 		ImageWebView2: fs.Bool("image-require-webview2", false, "require WebView2 support in the promoted image"),
 		ImageDesktop:  fs.Bool("image-require-desktop", false, "require desktop support in the promoted image"),
 		Code:          fs.Bool("code", defaults.Code, "provision or require web code-server capability"),
-		ProviderFlags: registerProviderFlags(fs, defaults),
+		ProviderFlags: registerProviderFlagsObserved(fs, defaults, observe),
 		Target:        registerTargetFlags(fs, defaults),
 		Network:       registerNetworkFlags(fs, defaults),
 	}

--- a/internal/cli/lease_flags.go
+++ b/internal/cli/lease_flags.go
@@ -40,11 +40,22 @@ type leaseCreateFlagValues struct {
 	Network       networkFlagValues
 }
 
-func registerLeaseCreateFlags(fs *flag.FlagSet, defaults Config) leaseCreateFlagValues {
-	return registerLeaseCreateFlagsObserved(fs, defaults, nil)
+type leaseCreateFlagRegistrationOptions struct {
+	serverTypeDefault string
+	observe           providerFlagRegistrationObserver
 }
 
-func registerLeaseCreateFlagsObserved(fs *flag.FlagSet, defaults Config, observe providerFlagRegistrationObserver) leaseCreateFlagValues {
+func ordinaryLeaseCreateFlagRegistrationOptions() leaseCreateFlagRegistrationOptions {
+	return leaseCreateFlagRegistrationOptions{
+		serverTypeDefault: getenv("CRABBOX_SERVER_TYPE", ""),
+	}
+}
+
+func registerLeaseCreateFlags(fs *flag.FlagSet, defaults Config) leaseCreateFlagValues {
+	return registerLeaseCreateFlagsWithOptions(fs, defaults, ordinaryLeaseCreateFlagRegistrationOptions())
+}
+
+func registerLeaseCreateFlagsWithOptions(fs *flag.FlagSet, defaults Config, options leaseCreateFlagRegistrationOptions) leaseCreateFlagValues {
 	expose := stringListFlag{}
 	cacheVolumes := stringListFlag{}
 	imageSDK := stringListFlag{}
@@ -59,7 +70,7 @@ func registerLeaseCreateFlagsObserved(fs *flag.FlagSet, defaults Config, observe
 		Class:         fs.String("class", defaults.Class, "machine class"),
 		Architecture:  fs.String("arch", defaults.Architecture, "CPU architecture: amd64 or arm64"),
 		OSImage:       fs.String("os", defaults.OSImage, "portable Linux OS image selector, for example ubuntu:26.04"),
-		ServerType:    fs.String("type", getenv("CRABBOX_SERVER_TYPE", ""), "provider server/instance type"),
+		ServerType:    fs.String("type", options.serverTypeDefault, "provider server/instance type"),
 		SSHPort:       fs.String("ssh-port", defaults.SSHPort, "SSH port for the leased target"),
 		Market:        fs.String("market", defaults.Capacity.Market, "capacity market: spot or on-demand"),
 		Slug:          fs.String("slug", "", "request a friendly slug for a new lease"),
@@ -78,7 +89,7 @@ func registerLeaseCreateFlagsObserved(fs *flag.FlagSet, defaults Config, observe
 		ImageWebView2: fs.Bool("image-require-webview2", false, "require WebView2 support in the promoted image"),
 		ImageDesktop:  fs.Bool("image-require-desktop", false, "require desktop support in the promoted image"),
 		Code:          fs.Bool("code", defaults.Code, "provision or require web code-server capability"),
-		ProviderFlags: registerProviderFlagsObserved(fs, defaults, observe),
+		ProviderFlags: registerProviderFlagsObserved(fs, defaults, options.observe),
 		Target:        registerTargetFlags(fs, defaults),
 		Network:       registerNetworkFlags(fs, defaults),
 	}

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -1182,10 +1182,33 @@ func isBlacksmithProvider(provider string) bool {
 
 type providerFlagValues map[string]any
 
+type providerFlagRegistrationObserver func(provider Provider, flags []*flag.Flag)
+
 func registerProviderFlags(fs *flag.FlagSet, defaults Config) providerFlagValues {
+	return registerProviderFlagsObserved(fs, defaults, nil)
+}
+
+func registerProviderFlagsObserved(fs *flag.FlagSet, defaults Config, observe providerFlagRegistrationObserver) providerFlagValues {
 	values := providerFlagValues{}
 	for _, provider := range registeredProviders() {
+		var before map[string]bool
+		if observe != nil {
+			before = map[string]bool{}
+			fs.VisitAll(func(item *flag.Flag) { before[item.Name] = true })
+		}
 		values[provider.Name()] = provider.RegisterFlags(fs, defaults)
+		if observe != nil {
+			var added []*flag.Flag
+			fs.VisitAll(func(item *flag.Flag) {
+				if !before[item.Name] {
+					added = append(added, item)
+				}
+			})
+			observe(provider, added)
+		}
+	}
+	if observe == nil {
+		clearFlagAnnotations(fs)
 	}
 	return values
 }

--- a/internal/cli/providers.go
+++ b/internal/cli/providers.go
@@ -78,6 +78,9 @@ type providerMatrixFilterFlagValues struct {
 }
 
 func (a App) providers(_ context.Context, args []string) error {
+	if len(args) > 0 && args[0] == "describe" {
+		return a.providerDescribe(args[1:])
+	}
 	if len(args) > 0 && args[0] == "filters" {
 		return a.providerFilters(args[1:])
 	}
@@ -195,26 +198,31 @@ func providerMatrix() []providerMatrixEntry {
 	providers := registeredProviders()
 	entries := make([]providerMatrixEntry, 0, len(providers))
 	for _, provider := range providers {
-		spec := provider.Spec()
-		category := benchmarkProviderCategories[firstNonBlank(spec.Name, provider.Name())]
-		targets := formatProviderTargets(spec.Targets)
-		entries = append(entries, providerMatrixEntry{
-			Provider:     firstNonBlank(spec.Name, provider.Name()),
-			Family:       firstNonBlank(spec.Family, provider.Name()),
-			Aliases:      append([]string(nil), provider.Aliases()...),
-			Kind:         spec.Kind,
-			Category:     category,
-			Targets:      targets,
-			Features:     append(FeatureSet{}, spec.Features...),
-			Runtime:      runtimeCapabilitiesForProvider(firstNonBlank(spec.Name, provider.Name()), spec.Kind, category, targets, spec.Features),
-			Reachability: reachabilityCapabilitiesForProvider(firstNonBlank(spec.Name, provider.Name())),
-			Workspace:    workspaceCapabilitiesForFeatures(spec.Features),
-			Evidence:     evidenceCapabilitiesForFeatures(spec.Features),
-			Lifecycle:    lifecycleCapabilitiesForProvider(spec.Coordinator, spec.Features),
-			Coordinator:  string(spec.Coordinator),
-		})
+		entries = append(entries, providerMatrixEntryFor(provider))
 	}
 	return entries
+}
+
+func providerMatrixEntryFor(provider Provider) providerMatrixEntry {
+	spec := provider.Spec()
+	name := firstNonBlank(spec.Name, provider.Name())
+	category := benchmarkProviderCategories[name]
+	targets := formatProviderTargets(spec.Targets)
+	return providerMatrixEntry{
+		Provider:     name,
+		Family:       firstNonBlank(spec.Family, provider.Name()),
+		Aliases:      append([]string(nil), provider.Aliases()...),
+		Kind:         spec.Kind,
+		Category:     category,
+		Targets:      targets,
+		Features:     append(FeatureSet{}, spec.Features...),
+		Runtime:      runtimeCapabilitiesForProvider(name, spec.Kind, category, targets, spec.Features),
+		Reachability: reachabilityCapabilitiesForProvider(name),
+		Workspace:    workspaceCapabilitiesForFeatures(spec.Features),
+		Evidence:     evidenceCapabilitiesForFeatures(spec.Features),
+		Lifecycle:    lifecycleCapabilitiesForProvider(spec.Coordinator, spec.Features),
+		Coordinator:  string(spec.Coordinator),
+	}
 }
 
 func registerProviderMatrixFilterFlags(fs *flag.FlagSet) *providerMatrixFilterFlagValues {

--- a/internal/cli/providers_builtin_test.go
+++ b/internal/cli/providers_builtin_test.go
@@ -1919,15 +1919,12 @@ type testLocalContainerFlagValues struct {
 	Memory       *string
 	Network      *string
 	DockerSocket *bool
-	Volumes      *[]string
+	Volumes      *stringListFlag
 }
 
 func (testLocalContainerProvider) RegisterFlags(fs *flag.FlagSet, defaults Config) any {
-	volumes := append([]string(nil), defaults.LocalContainer.Volumes...)
-	fs.Func("local-container-volume", "container volume", func(value string) error {
-		volumes = append(volumes, value)
-		return nil
-	})
+	volumes := stringListFlag(append([]string{}, defaults.LocalContainer.Volumes...))
+	fs.Var(&volumes, "local-container-volume", "container volume")
 	return testLocalContainerFlagValues{
 		Runtime:      fs.String("local-container-runtime", defaults.LocalContainer.Runtime, "Docker-compatible CLI"),
 		Image:        fs.String("local-container-image", defaults.LocalContainer.Image, "container image"),
@@ -2038,7 +2035,7 @@ type testAppleVMFlagValues struct {
 }
 
 func (testAppleVMProvider) RegisterFlags(fs *flag.FlagSet, defaults Config) any {
-	return testAppleVMFlagValues{
+	values := testAppleVMFlagValues{
 		HelperPath:  fs.String("apple-vm-helper", defaults.AppleVM.HelperPath, "apple-vm helper"),
 		Image:       fs.String("apple-vm-image", defaults.AppleVM.Image, "apple-vm image"),
 		ImageSHA256: fs.String("apple-vm-image-sha256", defaults.AppleVM.ImageSHA256, "apple-vm image sha256"),
@@ -2048,6 +2045,23 @@ func (testAppleVMProvider) RegisterFlags(fs *flag.FlagSet, defaults Config) any 
 		MemoryMiB:   fs.Int("apple-vm-memory", defaults.AppleVM.MemoryMiB, "apple-vm memory MiB"),
 		DiskGiB:     fs.Int("apple-vm-disk", defaults.AppleVM.DiskGiB, "apple-vm disk GiB"),
 	}
+	fs.String("apple-vz-helper", defaults.AppleVM.HelperPath, "deprecated alias for --apple-vm-helper")
+	fs.String("apple-vz-image", defaults.AppleVM.Image, "deprecated alias for --apple-vm-image")
+	fs.String("apple-vz-image-sha256", defaults.AppleVM.ImageSHA256, "deprecated alias for --apple-vm-image-sha256")
+	fs.String("apple-vz-user", defaults.AppleVM.User, "deprecated alias for --apple-vm-user")
+	fs.String("apple-vz-work-root", defaults.AppleVM.WorkRoot, "deprecated alias for --apple-vm-work-root")
+	fs.Int("apple-vz-cpus", defaults.AppleVM.CPUs, "deprecated alias for --apple-vm-cpus")
+	fs.Int("apple-vz-memory", defaults.AppleVM.MemoryMiB, "deprecated alias for --apple-vm-memory")
+	fs.Int("apple-vz-disk", defaults.AppleVM.DiskGiB, "deprecated alias for --apple-vm-disk")
+	MarkFlagDeprecated(fs, "apple-vz-helper", "apple-vm-helper")
+	MarkFlagDeprecated(fs, "apple-vz-image", "apple-vm-image")
+	MarkFlagDeprecated(fs, "apple-vz-image-sha256", "apple-vm-image-sha256")
+	MarkFlagDeprecated(fs, "apple-vz-user", "apple-vm-user")
+	MarkFlagDeprecated(fs, "apple-vz-work-root", "apple-vm-work-root")
+	MarkFlagDeprecated(fs, "apple-vz-cpus", "apple-vm-cpus")
+	MarkFlagDeprecated(fs, "apple-vz-memory", "apple-vm-memory")
+	MarkFlagDeprecated(fs, "apple-vz-disk", "apple-vm-disk")
+	return values
 }
 func (testAppleVMProvider) ApplyFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 	v, ok := values.(testAppleVMFlagValues)

--- a/internal/cli/providers_describe.go
+++ b/internal/cli/providers_describe.go
@@ -1,0 +1,328 @@
+package cli
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"time"
+)
+
+const providerDescriptionSchemaVersion = 1
+
+type providerDescription struct {
+	SchemaVersion int                         `json:"schemaVersion"`
+	Provider      providerDescriptionIdentity `json:"provider"`
+	Runnable      bool                        `json:"runnable"`
+	Kind          ProviderKind                `json:"kind"`
+	Family        string                      `json:"family"`
+	Targets       []string                    `json:"targets"`
+	Capabilities  providerDescriptionCaps     `json:"capabilities"`
+	SharedFlags   []providerDescriptionFlag   `json:"sharedFlags"`
+	ProviderFlags []providerDescriptionFlag   `json:"providerFlags"`
+}
+
+type providerDescriptionIdentity struct {
+	Requested   string   `json:"requested"`
+	Canonical   string   `json:"canonical"`
+	InputAlias  string   `json:"inputAlias"`
+	Aliases     []string `json:"aliases"`
+	Deprecated  bool     `json:"deprecated"`
+	Replacement string   `json:"replacement"`
+}
+
+type providerDescriptionCaps struct {
+	Features     []string `json:"features"`
+	Runtime      []string `json:"runtime"`
+	Reachability []string `json:"reachability"`
+	Workspace    []string `json:"workspace"`
+	Evidence     []string `json:"evidence"`
+	Lifecycle    []string `json:"lifecycle"`
+	Coordinator  string   `json:"coordinator"`
+}
+
+type providerDescriptionFlag struct {
+	Name         string `json:"name"`
+	Type         string `json:"type"`
+	ValueShape   string `json:"valueShape"`
+	Default      any    `json:"default"`
+	Repeatable   bool   `json:"repeatable"`
+	Usage        string `json:"usage"`
+	Deprecated   bool   `json:"deprecated"`
+	Replacement  string `json:"replacement"`
+	Routing      bool   `json:"routing"`
+	CreationOnly bool   `json:"creationOnly"`
+}
+
+func (a App) providerDescribe(args []string) error {
+	fs := newFlagSet("providers describe", a.Stderr)
+	jsonOut := fs.Bool("json", false, "print JSON")
+	flagArgs, positional := splitProviderDescribeArgs(args)
+	if err := parseFlags(fs, append(flagArgs, positional...)); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return exit(2, "usage: crabbox providers describe <provider> [--json]")
+	}
+	description, err := describeProvider(fs.Arg(0))
+	if err != nil {
+		return err
+	}
+	if *jsonOut {
+		return json.NewEncoder(a.Stdout).Encode(description)
+	}
+	printProviderDescription(a.Stdout, description)
+	return nil
+}
+
+func splitProviderDescribeArgs(args []string) (flagArgs, positional []string) {
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "-") {
+			flagArgs = append(flagArgs, arg)
+		} else {
+			positional = append(positional, arg)
+		}
+	}
+	return flagArgs, positional
+}
+
+func describeProvider(requestedName string) (providerDescription, error) {
+	requested := normalizeProviderName(requestedName)
+	if requested == "" {
+		return providerDescription{}, exit(2, "provider name must not be empty")
+	}
+	provider, err := ProviderFor(requested)
+	if err != nil {
+		return providerDescription{}, err
+	}
+	canonical := normalizeProviderName(provider.Name())
+	spec := provider.Spec()
+	switch spec.Kind {
+	case ProviderKindSSHLease, ProviderKindDelegatedRun:
+	case ProviderKindServiceControl:
+		return providerDescription{}, exit(2, "provider %q is not runnable (kind %s); providers describe supports ssh-lease and delegated-run providers", canonical, spec.Kind)
+	default:
+		return providerDescription{}, exit(2, "provider %q has unsupported kind %q; providers describe supports ssh-lease and delegated-run providers", canonical, spec.Kind)
+	}
+
+	providerOwned := map[string]map[string]bool{}
+	runFlags := newFlagSet("run", io.Discard)
+	defer clearFlagAnnotations(runFlags)
+	registerRunFlags(runFlags, baseConfig(), func(owner Provider, added []*flag.Flag) {
+		owned := map[string]bool{}
+		for _, item := range added {
+			owned[item.Name] = true
+		}
+		providerOwned[normalizeProviderName(owner.Name())] = owned
+	})
+
+	routing, err := providerFlagContractNames(provider, providerOwned[canonical], "routing")
+	if err != nil {
+		return providerDescription{}, err
+	}
+	creationOnly, err := providerFlagContractNames(provider, providerOwned[canonical], "creation-only")
+	if err != nil {
+		return providerDescription{}, err
+	}
+
+	allProviderFlags := map[string]bool{}
+	for _, owned := range providerOwned {
+		for name := range owned {
+			allProviderFlags[name] = true
+		}
+	}
+	shared := make([]providerDescriptionFlag, 0)
+	selected := make([]providerDescriptionFlag, 0)
+	var metadataErr error
+	runFlags.VisitAll(func(item *flag.Flag) {
+		if metadataErr != nil {
+			return
+		}
+		if allProviderFlags[item.Name] && !providerOwned[canonical][item.Name] {
+			return
+		}
+		record, recordErr := describeRegisteredFlag(item)
+		if recordErr != nil {
+			metadataErr = recordErr
+			return
+		}
+		record.Routing = routing[item.Name]
+		record.CreationOnly = creationOnly[item.Name]
+		if providerOwned[canonical][item.Name] {
+			selected = append(selected, record)
+		} else {
+			shared = append(shared, record)
+		}
+	})
+	if metadataErr != nil {
+		return providerDescription{}, metadataErr
+	}
+	sort.Slice(shared, func(i, j int) bool { return shared[i].Name < shared[j].Name })
+	sort.Slice(selected, func(i, j int) bool { return selected[i].Name < selected[j].Name })
+	if shared == nil {
+		shared = []providerDescriptionFlag{}
+	}
+	if selected == nil {
+		selected = []providerDescriptionFlag{}
+	}
+
+	entry := providerMatrixEntryFor(provider)
+	aliases := normalizedSortedStrings(provider.Aliases())
+	inputAlias := ""
+	if requested != canonical {
+		inputAlias = requested
+	}
+	return providerDescription{
+		SchemaVersion: providerDescriptionSchemaVersion,
+		Provider: providerDescriptionIdentity{
+			Requested:   requested,
+			Canonical:   canonical,
+			InputAlias:  inputAlias,
+			Aliases:     aliases,
+			Deprecated:  false,
+			Replacement: "",
+		},
+		Runnable: true,
+		Kind:     spec.Kind,
+		Family:   normalizeProviderName(firstNonBlank(spec.Family, canonical)),
+		Targets:  normalizedSortedStrings(entry.Targets),
+		Capabilities: providerDescriptionCaps{
+			Features:     normalizedSortedStrings(featuresToStrings(entry.Features)),
+			Runtime:      normalizedSortedStrings(entry.Runtime),
+			Reachability: normalizedSortedStrings(entry.Reachability),
+			Workspace:    normalizedSortedStrings(entry.Workspace),
+			Evidence:     normalizedSortedStrings(entry.Evidence),
+			Lifecycle:    normalizedSortedStrings(entry.Lifecycle),
+			Coordinator:  firstNonBlank(entry.Coordinator, string(CoordinatorNever)),
+		},
+		SharedFlags:   shared,
+		ProviderFlags: selected,
+	}, nil
+}
+
+func providerFlagContractNames(provider Provider, owned map[string]bool, contract string) (map[string]bool, error) {
+	result := map[string]bool{}
+	var names []string
+	switch contract {
+	case "routing":
+		if source, ok := provider.(ProviderRoutingFlagProvider); ok {
+			names = source.RoutingFlagNames()
+		}
+	case "creation-only":
+		if source, ok := provider.(ProviderCreationOnlyFlagProvider); ok {
+			names = source.CreationOnlyFlagNames()
+		}
+	}
+	for _, raw := range names {
+		name := strings.TrimLeft(strings.TrimSpace(raw), "-")
+		if name == "" || !owned[name] {
+			return nil, exit(2, "provider %q %s flag annotation references unregistered provider flag --%s", provider.Name(), contract, name)
+		}
+		result[name] = true
+	}
+	return result, nil
+}
+
+func describeRegisteredFlag(item *flag.Flag) (providerDescriptionFlag, error) {
+	getter, ok := item.Value.(flag.Getter)
+	if !ok {
+		return providerDescriptionFlag{}, exit(2, "run flag --%s uses unsupported value type %T; implement flag.Getter with a supported typed value", item.Name, item.Value)
+	}
+	value := getter.Get()
+	record := providerDescriptionFlag{
+		Name:        item.Name,
+		ValueShape:  "scalar",
+		Usage:       item.Usage,
+		Replacement: "",
+	}
+	switch typed := value.(type) {
+	case string:
+		record.Type = "string"
+		record.Default = typed
+	case bool:
+		record.Type = "bool"
+		record.Default = typed
+	case int:
+		record.Type = "int"
+		record.Default = typed
+	case int64:
+		record.Type = "int64"
+		record.Default = typed
+	case float64:
+		record.Type = "float64"
+		record.Default = typed
+	case time.Duration:
+		record.Type = "duration"
+		record.Default = typed.String()
+	case []string:
+		record.Type = "string"
+		record.ValueShape = "string-list"
+		record.Default = append([]string{}, typed...)
+		record.Repeatable = true
+	default:
+		return providerDescriptionFlag{}, exit(2, "run flag --%s uses unsupported getter value type %T", item.Name, value)
+	}
+	annotation := annotationForFlag(item)
+	if annotation.Deprecated {
+		if item.Name == annotation.Replacement || item.Value == nil {
+			return providerDescriptionFlag{}, exit(2, "run flag --%s has invalid deprecation metadata", item.Name)
+		}
+		record.Deprecated = true
+		record.Replacement = annotation.Replacement
+	}
+	return record, nil
+}
+
+func normalizedSortedStrings(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.ToLower(strings.TrimSpace(value))
+		if value != "" {
+			out = append(out, value)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func printProviderDescription(out io.Writer, description providerDescription) {
+	identity := description.Provider
+	if identity.InputAlias != "" {
+		fmt.Fprintf(out, "%s -> %s\n", identity.Requested, identity.Canonical)
+	} else {
+		fmt.Fprintln(out, identity.Canonical)
+	}
+	fmt.Fprintf(out, "  kind: %s\n", description.Kind)
+	fmt.Fprintf(out, "  runnable: %t\n", description.Runnable)
+	fmt.Fprintf(out, "  family: %s\n", description.Family)
+	fmt.Fprintf(out, "  aliases: %s\n", commaOrDash(identity.Aliases))
+	fmt.Fprintf(out, "  deprecated: %t\n", identity.Deprecated)
+	fmt.Fprintf(out, "  replacement: %s\n", blank(identity.Replacement, "-"))
+	fmt.Fprintf(out, "  targets: %s\n", commaOrDash(description.Targets))
+	fmt.Fprintf(out, "  features: %s\n", commaOrDash(description.Capabilities.Features))
+	fmt.Fprintf(out, "  runtime: %s\n", commaOrDash(description.Capabilities.Runtime))
+	fmt.Fprintf(out, "  reachability: %s\n", commaOrDash(description.Capabilities.Reachability))
+	fmt.Fprintf(out, "  workspace: %s\n", commaOrDash(description.Capabilities.Workspace))
+	fmt.Fprintf(out, "  evidence: %s\n", commaOrDash(description.Capabilities.Evidence))
+	fmt.Fprintf(out, "  lifecycle: %s\n", commaOrDash(description.Capabilities.Lifecycle))
+	fmt.Fprintf(out, "  coordinator: %s\n", description.Capabilities.Coordinator)
+	printProviderDescriptionFlags(out, "Shared run flags", description.SharedFlags)
+	printProviderDescriptionFlags(out, description.Provider.Canonical+" flags", description.ProviderFlags)
+}
+
+func printProviderDescriptionFlags(out io.Writer, title string, flags []providerDescriptionFlag) {
+	fmt.Fprintf(out, "\n%s:\n", title)
+	if len(flags) == 0 {
+		fmt.Fprintln(out, "  (none)")
+		return
+	}
+	for _, item := range flags {
+		encodedDefault, _ := json.Marshal(item.Default)
+		fmt.Fprintf(out, "  --%s\n", item.Name)
+		fmt.Fprintf(out, "    type: %s; value shape: %s; default: %s; repeatable: %t\n", item.Type, item.ValueShape, encodedDefault, item.Repeatable)
+		fmt.Fprintf(out, "    deprecated: %t; replacement: %s; routing: %t; creation-only: %t\n", item.Deprecated, blank(item.Replacement, "-"), item.Routing, item.CreationOnly)
+		fmt.Fprintf(out, "    %s\n", item.Usage)
+	}
+}

--- a/internal/cli/providers_describe.go
+++ b/internal/cli/providers_describe.go
@@ -108,14 +108,18 @@ func describeProvider(requestedName string) (providerDescription, error) {
 	}
 
 	providerOwned := map[string]map[string]bool{}
+	defaults := baseConfig()
 	runFlags := newFlagSet("run", io.Discard)
 	defer clearFlagAnnotations(runFlags)
-	registerRunFlags(runFlags, baseConfig(), func(owner Provider, added []*flag.Flag) {
-		owned := map[string]bool{}
-		for _, item := range added {
-			owned[item.Name] = true
-		}
-		providerOwned[normalizeProviderName(owner.Name())] = owned
+	registerRunFlags(runFlags, defaults, leaseCreateFlagRegistrationOptions{
+		serverTypeDefault: defaults.ServerType,
+		observe: func(owner Provider, added []*flag.Flag) {
+			owned := map[string]bool{}
+			for _, item := range added {
+				owned[item.Name] = true
+			}
+			providerOwned[normalizeProviderName(owner.Name())] = owned
+		},
 	})
 
 	routing, err := providerFlagContractNames(provider, providerOwned[canonical], "routing")

--- a/internal/cli/providers_describe_binary_test.go
+++ b/internal/cli/providers_describe_binary_test.go
@@ -48,6 +48,7 @@ func TestProvidersDescribeBuiltBinaryContract(t *testing.T) {
 		"TMPDIR=" + tmp,
 		"CRABBOX_CONFIG=" + invalidConfig,
 		"CRABBOX_LOCAL_CONTAINER_IMAGE=ENV_SECRET_MARKER",
+		"CRABBOX_SERVER_TYPE=SERVER_TYPE_SECRET_MARKER",
 		"CRABBOX_COORDINATOR_TOKEN=TOKEN_SECRET_MARKER",
 		"HTTPS_PROXY=http://127.0.0.1:1",
 		"HTTP_PROXY=http://127.0.0.1:1",
@@ -122,6 +123,10 @@ func TestProvidersDescribeBuiltBinaryContract(t *testing.T) {
 	}
 	if defaults, ok := localFlags["local-container-volume"].Default.([]any); !ok || defaults == nil || len(defaults) != 0 {
 		t.Fatalf("local-container volume default=%#v", localFlags["local-container-volume"].Default)
+	}
+	sharedFlags := descriptionFlagMap(local.SharedFlags)
+	if sharedFlags["type"].Default != baseConfig().ServerType {
+		t.Fatalf("type default=%#v, want compiled base default %#v", sharedFlags["type"].Default, baseConfig().ServerType)
 	}
 	for _, excluded := range []string{"aws-lambda-microvm-image", "azure-backend", "daytona-api-url", "tart-image"} {
 		if _, ok := localFlags[excluded]; ok {

--- a/internal/cli/providers_describe_binary_test.go
+++ b/internal/cli/providers_describe_binary_test.go
@@ -1,0 +1,222 @@
+package cli
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestProvidersDescribeBuiltBinaryContract(t *testing.T) {
+	root := filepath.Clean(filepath.Join("..", ".."))
+	binary := filepath.Join(t.TempDir(), "crabbox")
+	build := exec.Command("go", "build", "-trimpath", "-o", binary, "./cmd/crabbox")
+	build.Dir = root
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("go build ./cmd/crabbox: %v\n%s", err, output)
+	}
+
+	isolation := t.TempDir()
+	home := filepath.Join(isolation, "home")
+	configHome := filepath.Join(isolation, "config")
+	stateHome := filepath.Join(isolation, "state")
+	cacheHome := filepath.Join(isolation, "cache")
+	tmp := filepath.Join(isolation, "tmp")
+	for _, dir := range []string{home, configHome, stateHome, cacheHome, tmp} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	invalidConfig := filepath.Join(isolation, "invalid-config.yaml")
+	if err := os.WriteFile(invalidConfig, []byte("[CONFIG_FILE_SECRET_MARKER\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	env := []string{
+		"HOME=" + home,
+		"XDG_CONFIG_HOME=" + configHome,
+		"XDG_STATE_HOME=" + stateHome,
+		"XDG_CACHE_HOME=" + cacheHome,
+		"TMPDIR=" + tmp,
+		"CRABBOX_CONFIG=" + invalidConfig,
+		"CRABBOX_LOCAL_CONTAINER_IMAGE=ENV_SECRET_MARKER",
+		"CRABBOX_COORDINATOR_TOKEN=TOKEN_SECRET_MARKER",
+		"HTTPS_PROXY=http://127.0.0.1:1",
+		"HTTP_PROXY=http://127.0.0.1:1",
+	}
+	before, err := snapshotTestTree(isolation)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	matrixOut, matrixErr, code := runDescribeTestBinary(binary, root, env, "providers", "--json")
+	if code != 0 {
+		t.Fatalf("providers --json exit=%d stderr=%s", code, matrixErr)
+	}
+	var entries []providerMatrixEntry
+	if err := json.Unmarshal(matrixOut, &entries); err != nil {
+		t.Fatalf("providers --json: %v\n%s", err, matrixOut)
+	}
+	for _, entry := range entries {
+		stdout, stderr, exitCode := runDescribeTestBinary(binary, root, env, "providers", "describe", entry.Provider, "--json")
+		switch entry.Kind {
+		case ProviderKindSSHLease, ProviderKindDelegatedRun:
+			if exitCode != 0 {
+				t.Errorf("describe %s exit=%d stderr=%s", entry.Provider, exitCode, stderr)
+				continue
+			}
+			var description providerDescription
+			if err := json.Unmarshal(stdout, &description); err != nil {
+				t.Errorf("describe %s JSON: %v\n%s", entry.Provider, err, stdout)
+				continue
+			}
+			if !description.Runnable || description.Provider.Canonical != entry.Provider {
+				t.Errorf("describe %s identity=%#v runnable=%t", entry.Provider, description.Provider, description.Runnable)
+			}
+		case ProviderKindServiceControl:
+			if exitCode != 2 || len(stdout) != 0 || !strings.Contains(string(stderr), "not runnable") {
+				t.Errorf("service-control describe %s exit=%d stdout=%q stderr=%q", entry.Provider, exitCode, stdout, stderr)
+			}
+		default:
+			if exitCode != 2 || len(stdout) != 0 || !strings.Contains(string(stderr), "unsupported kind") {
+				t.Errorf("unknown-kind describe %s exit=%d stdout=%q stderr=%q", entry.Provider, exitCode, stdout, stderr)
+			}
+		}
+	}
+
+	stdout, stderr, exitCode := runDescribeTestBinary(binary, root, env, "providers", "describe", "missing-provider", "--json")
+	if exitCode != 2 || len(stdout) != 0 || !strings.Contains(string(stderr), "unknown provider") {
+		t.Fatalf("unknown describe exit=%d stdout=%q stderr=%q", exitCode, stdout, stderr)
+	}
+
+	aliasOut, aliasErr, aliasCode := runDescribeTestBinary(binary, root, env, "providers", "describe", "--json", "docker")
+	if aliasCode != 0 {
+		t.Fatalf("describe docker exit=%d stderr=%s", aliasCode, aliasErr)
+	}
+	if bytes.Contains(aliasOut, []byte("SECRET_MARKER")) {
+		t.Fatalf("describe output leaked config/env marker: %s", aliasOut)
+	}
+	var local providerDescription
+	if err := json.Unmarshal(aliasOut, &local); err != nil {
+		t.Fatal(err)
+	}
+	if local.Provider.Requested != "docker" || local.Provider.Canonical != "local-container" || local.Provider.InputAlias != "docker" || local.Family != "container" {
+		t.Fatalf("local-container identity=%#v family=%q", local.Provider, local.Family)
+	}
+	localFlags := descriptionFlagMap(local.ProviderFlags)
+	wantLocal := []string{
+		"local-container-cpus", "local-container-docker-socket", "local-container-image",
+		"local-container-memory", "local-container-network", "local-container-runtime",
+		"local-container-user", "local-container-volume", "local-container-work-root",
+	}
+	if got := sortedDescriptionFlagNames(local.ProviderFlags); !reflect.DeepEqual(got, wantLocal) {
+		t.Fatalf("local-container flags=%v want %v", got, wantLocal)
+	}
+	if defaults, ok := localFlags["local-container-volume"].Default.([]any); !ok || defaults == nil || len(defaults) != 0 {
+		t.Fatalf("local-container volume default=%#v", localFlags["local-container-volume"].Default)
+	}
+	for _, excluded := range []string{"aws-lambda-microvm-image", "azure-backend", "daytona-api-url", "tart-image"} {
+		if _, ok := localFlags[excluded]; ok {
+			t.Errorf("local-container output included --%s", excluded)
+		}
+	}
+
+	appleOut, appleErr, appleCode := runDescribeTestBinary(binary, root, env, "providers", "describe", "apple-vm", "--json")
+	if appleCode != 0 {
+		t.Fatalf("describe apple-vm exit=%d stderr=%s", appleCode, appleErr)
+	}
+	var apple providerDescription
+	if err := json.Unmarshal(appleOut, &apple); err != nil {
+		t.Fatal(err)
+	}
+	for _, item := range apple.ProviderFlags {
+		if strings.HasPrefix(item.Name, "apple-vz-") && (!item.Deprecated || !strings.HasPrefix(item.Replacement, "apple-vm-")) {
+			t.Errorf("Apple VM deprecated metadata=%#v", item)
+		}
+	}
+
+	after, err := snapshotTestTree(isolation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(before, after) {
+		t.Fatalf("providers describe mutated isolated filesystem\nbefore=%v\nafter=%v", before, after)
+	}
+
+	helpEnv := []string{
+		"HOME=" + home, "XDG_CONFIG_HOME=" + configHome, "XDG_STATE_HOME=" + stateHome,
+		"XDG_CACHE_HOME=" + cacheHome, "TMPDIR=" + tmp,
+	}
+	helpStdout, helpStderr, helpCode := runDescribeTestBinary(binary, root, helpEnv, "run", "--help")
+	if helpCode != 0 || len(helpStdout) != 0 {
+		t.Fatalf("run --help exit=%d stdout=%q stderr=%q", helpCode, helpStdout, helpStderr)
+	}
+	digest := sha256.Sum256(helpStderr)
+	const baselineSHA256 = "d8702c9a6133c7e96fe8cbbf89470a49921b664c268fa91a23b1c8bc319a0f0b"
+	if got := hex.EncodeToString(digest[:]); got != baselineSHA256 || len(helpStderr) != 59796 {
+		t.Fatalf("run --help changed: sha256=%s bytes=%d, want sha256=%s bytes=59796", got, len(helpStderr), baselineSHA256)
+	}
+}
+
+func runDescribeTestBinary(binary, dir string, env []string, args ...string) (stdout, stderr []byte, exitCode int) {
+	cmd := exec.Command(binary, args...)
+	cmd.Dir = dir
+	cmd.Env = env
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err == nil {
+		return outBuf.Bytes(), errBuf.Bytes(), 0
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return outBuf.Bytes(), errBuf.Bytes(), exitErr.ExitCode()
+	}
+	return outBuf.Bytes(), append(errBuf.Bytes(), []byte(fmt.Sprintf("%v", err))...), -1
+}
+
+func snapshotTestTree(root string) (map[string]string, error) {
+	out := map[string]string{}
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		relative, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		value := fmt.Sprintf("%s:%d", info.Mode(), info.Size())
+		if !entry.IsDir() {
+			contents, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			digest := sha256.Sum256(contents)
+			value += ":" + hex.EncodeToString(digest[:])
+		}
+		out[relative] = value
+		return nil
+	})
+	return out, err
+}
+
+func sortedDescriptionFlagNames(flags []providerDescriptionFlag) []string {
+	names := make([]string, 0, len(flags))
+	for _, item := range flags {
+		names = append(names, item.Name)
+	}
+	return names
+}

--- a/internal/cli/providers_describe_test.go
+++ b/internal/cli/providers_describe_test.go
@@ -150,6 +150,7 @@ func TestDescribeProviderRegistersOnlyAndUsesBaseDefaults(t *testing.T) {
 	providerRegistry[provider.Name()] = provider
 	t.Cleanup(func() { delete(providerRegistry, provider.Name()) })
 	t.Setenv("CRABBOX_PROVIDER", "ENV_SECRET_MARKER")
+	t.Setenv("CRABBOX_SERVER_TYPE", "SERVER_TYPE_SECRET_MARKER")
 	t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
 
 	description, err := describeProvider(provider.Name())
@@ -162,6 +163,10 @@ func TestDescribeProviderRegistersOnlyAndUsesBaseDefaults(t *testing.T) {
 	flag := descriptionFlagMap(description.ProviderFlags)["counting-describe-default"]
 	if flag.Default != "default" {
 		t.Fatalf("flag default=%#v, want compiled base default", flag.Default)
+	}
+	typeFlag := descriptionFlagMap(description.SharedFlags)["type"]
+	if typeFlag.Default != baseConfig().ServerType {
+		t.Fatalf("type default=%#v, want compiled base default %#v", typeFlag.Default, baseConfig().ServerType)
 	}
 	encoded, err := json.Marshal(description)
 	if err != nil {

--- a/internal/cli/providers_describe_test.go
+++ b/internal/cli/providers_describe_test.go
@@ -1,0 +1,330 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"flag"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDescribeProviderCoversRegisteredRunnableKinds(t *testing.T) {
+	for _, provider := range registeredProviders() {
+		provider := provider
+		t.Run(provider.Name(), func(t *testing.T) {
+			description, err := describeProvider(provider.Name())
+			switch provider.Spec().Kind {
+			case ProviderKindSSHLease, ProviderKindDelegatedRun:
+				if err != nil {
+					t.Fatalf("describeProvider(%q): %v", provider.Name(), err)
+				}
+				if !description.Runnable || description.Provider.Canonical != normalizeProviderName(provider.Name()) {
+					t.Fatalf("description=%#v", description)
+				}
+			case ProviderKindServiceControl:
+				assertDescribeExitCode(t, err, 2)
+				if !strings.Contains(err.Error(), "not runnable") {
+					t.Fatalf("service-control error=%v", err)
+				}
+			default:
+				assertDescribeExitCode(t, err, 2)
+			}
+		})
+	}
+
+	_, err := describeProvider("does-not-exist")
+	assertDescribeExitCode(t, err, 2)
+}
+
+func TestDescribeProviderAliasSchemaCapabilitiesAndFlags(t *testing.T) {
+	description, err := describeProvider(" Docker ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if description.SchemaVersion != 1 || description.Provider.Requested != "docker" || description.Provider.Canonical != "local-container" || description.Provider.InputAlias != "docker" {
+		t.Fatalf("identity=%#v schema=%d", description.Provider, description.SchemaVersion)
+	}
+	if description.Provider.Deprecated || description.Provider.Replacement != "" {
+		t.Fatalf("provider deprecation=%#v", description.Provider)
+	}
+	if !description.Runnable || description.Kind != ProviderKindSSHLease || description.Family != "local-container" {
+		t.Fatalf("runnable metadata=%#v", description)
+	}
+	assertSortedStrings(t, "aliases", description.Provider.Aliases)
+	assertSortedStrings(t, "targets", description.Targets)
+	for name, values := range map[string][]string{
+		"features": description.Capabilities.Features, "runtime": description.Capabilities.Runtime,
+		"reachability": description.Capabilities.Reachability, "workspace": description.Capabilities.Workspace,
+		"evidence": description.Capabilities.Evidence, "lifecycle": description.Capabilities.Lifecycle,
+	} {
+		if values == nil {
+			t.Fatalf("%s is nil", name)
+		}
+		assertSortedStrings(t, name, values)
+	}
+	if description.SharedFlags == nil || description.ProviderFlags == nil {
+		t.Fatalf("flag arrays must be present: shared=%v provider=%v", description.SharedFlags, description.ProviderFlags)
+	}
+	assertSortedFlags(t, "shared", description.SharedFlags)
+	assertSortedFlags(t, "provider", description.ProviderFlags)
+
+	providerFlags := descriptionFlagMap(description.ProviderFlags)
+	for _, name := range []string{
+		"local-container-image", "local-container-cpus", "local-container-memory", "local-container-network",
+		"local-container-runtime", "local-container-user", "local-container-volume", "local-container-work-root",
+		"local-container-docker-socket",
+	} {
+		if _, ok := providerFlags[name]; !ok {
+			t.Errorf("missing provider flag --%s", name)
+		}
+	}
+	for _, unrelated := range []string{"aws-lambda-microvm-image", "azure-backend", "daytona-api-url", "tart-image"} {
+		if _, ok := providerFlags[unrelated]; ok {
+			t.Errorf("included unrelated provider flag --%s", unrelated)
+		}
+	}
+	volume := providerFlags["local-container-volume"]
+	if volume.Type != "string" || volume.ValueShape != "string-list" || !volume.Repeatable || !volume.CreationOnly {
+		t.Fatalf("volume metadata=%#v", volume)
+	}
+	if defaults, ok := volume.Default.([]string); !ok || defaults == nil || len(defaults) != 0 {
+		t.Fatalf("volume default=%#v", volume.Default)
+	}
+	shared := descriptionFlagMap(description.SharedFlags)
+	if shared["download"].ValueShape != "string-list" || !shared["download"].Repeatable {
+		t.Fatalf("download metadata=%#v", shared["download"])
+	}
+	if shared["ttl"].Type != "duration" || shared["ttl"].Default != (90*time.Minute).String() {
+		t.Fatalf("ttl metadata=%#v", shared["ttl"])
+	}
+	if _, ok := shared["provider"]; !ok {
+		t.Fatal("shared flags omitted --provider")
+	}
+}
+
+func TestDescribeProviderCanonicalIdentityAndAppleDeprecations(t *testing.T) {
+	canonical, err := describeProvider("local-container")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if canonical.Provider.InputAlias != "" || canonical.Provider.Requested != "local-container" {
+		t.Fatalf("canonical identity=%#v", canonical.Provider)
+	}
+	empty, err := describeProvider("aws-lambda-microvm")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if empty.ProviderFlags == nil || len(empty.ProviderFlags) != 0 {
+		t.Fatalf("empty provider flags=%#v", empty.ProviderFlags)
+	}
+
+	apple, err := describeProvider("apple-vm")
+	if err != nil {
+		t.Fatal(err)
+	}
+	flags := descriptionFlagMap(apple.ProviderFlags)
+	for legacy, replacement := range map[string]string{
+		"apple-vz-helper": "apple-vm-helper", "apple-vz-image": "apple-vm-image",
+		"apple-vz-image-sha256": "apple-vm-image-sha256", "apple-vz-user": "apple-vm-user",
+		"apple-vz-work-root": "apple-vm-work-root", "apple-vz-cpus": "apple-vm-cpus",
+		"apple-vz-memory": "apple-vm-memory", "apple-vz-disk": "apple-vm-disk",
+	} {
+		item, ok := flags[legacy]
+		if !ok || !item.Deprecated || item.Replacement != replacement {
+			t.Errorf("deprecated flag --%s=%#v", legacy, item)
+		}
+		if _, ok := flags[replacement]; !ok {
+			t.Errorf("replacement --%s missing", replacement)
+		}
+	}
+}
+
+func TestDescribeProviderRegistersOnlyAndUsesBaseDefaults(t *testing.T) {
+	counters := &describeProviderCounters{}
+	provider := countingDescribeProvider{counters: counters}
+	providerRegistry[provider.Name()] = provider
+	t.Cleanup(func() { delete(providerRegistry, provider.Name()) })
+	t.Setenv("CRABBOX_PROVIDER", "ENV_SECRET_MARKER")
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+
+	description, err := describeProvider(provider.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if counters.register != 1 || counters.apply != 0 || counters.configure != 0 {
+		t.Fatalf("provider calls=%#v", counters)
+	}
+	flag := descriptionFlagMap(description.ProviderFlags)["counting-describe-default"]
+	if flag.Default != "default" {
+		t.Fatalf("flag default=%#v, want compiled base default", flag.Default)
+	}
+	encoded, err := json.Marshal(description)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(encoded, []byte("SECRET_MARKER")) {
+		t.Fatalf("description leaked environment/config marker: %s", encoded)
+	}
+}
+
+func TestProvidersDescribeHumanAndJSONArgumentOrder(t *testing.T) {
+	for _, args := range [][]string{{"describe", "docker", "--json"}, {"describe", "--json", "docker"}} {
+		var stdout, stderr bytes.Buffer
+		err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), args)
+		if err != nil {
+			t.Fatalf("providers %v: %v stderr=%q", args, err, stderr.String())
+		}
+		var description providerDescription
+		if err := json.Unmarshal(stdout.Bytes(), &description); err != nil {
+			t.Fatalf("providers %v JSON: %v\n%s", args, err, stdout.String())
+		}
+		if description.Provider.Canonical != "local-container" {
+			t.Fatalf("providers %v identity=%#v", args, description.Provider)
+		}
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{"describe", "docker"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	human := stdout.String()
+	for _, want := range []string{"docker -> local-container", "kind: ssh-lease", "runnable: true", "Shared run flags:", "local-container flags:", "--local-container-volume", "creation-only: true"} {
+		if !strings.Contains(human, want) {
+			t.Errorf("human output missing %q\n%s", want, human)
+		}
+	}
+}
+
+func TestDescribeRegisteredFlagSupportedTypesAndFailClosed(t *testing.T) {
+	fs := flag.NewFlagSet("metadata", flag.ContinueOnError)
+	fs.String("string", "value", "string usage")
+	fs.Bool("bool", true, "bool usage")
+	fs.Int("int", 3, "int usage")
+	fs.Int64("int64", 4, "int64 usage")
+	fs.Float64("float64", 1.5, "float usage")
+	fs.Duration("duration", 2*time.Minute, "duration usage")
+	list := stringListFlag{"one"}
+	fs.Var(&list, "list", "list usage")
+	wants := map[string]string{"string": "string", "bool": "bool", "int": "int", "int64": "int64", "float64": "float64", "duration": "duration", "list": "string"}
+	for name, wantType := range wants {
+		record, err := describeRegisteredFlag(fs.Lookup(name))
+		if err != nil {
+			t.Fatalf("--%s: %v", name, err)
+		}
+		if record.Type != wantType {
+			t.Errorf("--%s type=%q want %q", name, record.Type, wantType)
+		}
+	}
+	got := fs.Lookup("list").Value.(flag.Getter).Get().([]string)
+	got[0] = "changed"
+	if list[0] != "one" {
+		t.Fatal("repeatable getter did not return a defensive copy")
+	}
+
+	unsupported := flag.NewFlagSet("unsupported", flag.ContinueOnError)
+	unsupported.Func("future", "future usage", func(string) error { return nil })
+	if _, err := describeRegisteredFlag(unsupported.Lookup("future")); err == nil || !strings.Contains(err.Error(), "unsupported value type") {
+		t.Fatalf("unsupported flag error=%v", err)
+	}
+}
+
+func TestProviderFlagAnnotationsFailOnDrift(t *testing.T) {
+	fs := flag.NewFlagSet("annotations", flag.ContinueOnError)
+	fs.String("legacy", "", "legacy")
+	assertPanicsContaining(t, "invalid replacement", func() { MarkFlagDeprecated(fs, "legacy", "missing") })
+	assertPanicsContaining(t, "unregistered flag", func() { MarkFlagDeprecated(fs, "missing", "legacy") })
+
+	provider := driftContractProvider{}
+	if _, err := providerFlagContractNames(provider, map[string]bool{"actual": true}, "routing"); err == nil || !strings.Contains(err.Error(), "unregistered provider flag") {
+		t.Fatalf("routing drift error=%v", err)
+	}
+}
+
+type driftContractProvider struct{}
+
+func (driftContractProvider) Name() string                                 { return "drift" }
+func (driftContractProvider) Aliases() []string                            { return nil }
+func (driftContractProvider) Spec() ProviderSpec                           { return ProviderSpec{} }
+func (driftContractProvider) RegisterFlags(*flag.FlagSet, Config) any      { return NoProviderFlags() }
+func (driftContractProvider) ApplyFlags(*Config, *flag.FlagSet, any) error { return nil }
+func (driftContractProvider) Configure(Config, Runtime) (Backend, error)   { return nil, nil }
+func (driftContractProvider) RoutingFlagNames() []string                   { return []string{"missing"} }
+
+type describeProviderCounters struct {
+	register  int
+	apply     int
+	configure int
+}
+
+type countingDescribeProvider struct {
+	counters *describeProviderCounters
+}
+
+func (p countingDescribeProvider) Name() string      { return "counting-describe" }
+func (p countingDescribeProvider) Aliases() []string { return nil }
+func (p countingDescribeProvider) Spec() ProviderSpec {
+	return ProviderSpec{Name: p.Name(), Kind: ProviderKindSSHLease, Targets: []TargetSpec{{OS: targetLinux}}}
+}
+func (p countingDescribeProvider) RegisterFlags(fs *flag.FlagSet, defaults Config) any {
+	p.counters.register++
+	return fs.String("counting-describe-default", defaults.Profile, "compiled default probe")
+}
+func (p countingDescribeProvider) ApplyFlags(*Config, *flag.FlagSet, any) error {
+	p.counters.apply++
+	return nil
+}
+func (p countingDescribeProvider) Configure(Config, Runtime) (Backend, error) {
+	p.counters.configure++
+	return nil, nil
+}
+
+func descriptionFlagMap(values []providerDescriptionFlag) map[string]providerDescriptionFlag {
+	out := make(map[string]providerDescriptionFlag, len(values))
+	for _, value := range values {
+		out[value.Name] = value
+	}
+	return out
+}
+
+func assertSortedStrings(t *testing.T, name string, values []string) {
+	t.Helper()
+	want := append([]string(nil), values...)
+	sort.Strings(want)
+	if !reflect.DeepEqual(values, want) {
+		t.Fatalf("%s not sorted: %v", name, values)
+	}
+}
+
+func assertSortedFlags(t *testing.T, name string, values []providerDescriptionFlag) {
+	t.Helper()
+	for i := 1; i < len(values); i++ {
+		if values[i-1].Name >= values[i].Name {
+			t.Fatalf("%s flags not sorted at %q, %q", name, values[i-1].Name, values[i].Name)
+		}
+	}
+}
+
+func assertDescribeExitCode(t *testing.T, err error, code int) {
+	t.Helper()
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != code {
+		t.Fatalf("error=%v, want exit %d", err, code)
+	}
+}
+
+func assertPanicsContaining(t *testing.T, want string, fn func()) {
+	t.Helper()
+	defer func() {
+		got := recover()
+		if got == nil || !strings.Contains(got.(string), want) {
+			t.Fatalf("panic=%v, want substring %q", got, want)
+		}
+	}()
+	fn()
+}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -245,8 +245,8 @@ type runFlagValues struct {
 	TimingRecord           *string
 }
 
-func registerRunFlags(fs *flag.FlagSet, defaults Config, observe providerFlagRegistrationObserver) runFlagValues {
-	leaseFlags := registerLeaseCreateFlagsObserved(fs, defaults, observe)
+func registerRunFlags(fs *flag.FlagSet, defaults Config, options leaseCreateFlagRegistrationOptions) runFlagValues {
+	leaseFlags := registerLeaseCreateFlagsWithOptions(fs, defaults, options)
 	values := runFlagValues{
 		Lease:                  leaseFlags,
 		LeaseID:                fs.String("id", "", "existing lease or server id"),
@@ -314,7 +314,7 @@ func (a App) runCommand(ctx context.Context, args []string) error {
 func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, benchmarkCtx benchmarkRecordContext) (err error) {
 	defaults := defaultConfig()
 	fs := newFlagSet("run", a.Stderr)
-	runFlags := registerRunFlags(fs, defaults, nil)
+	runFlags := registerRunFlags(fs, defaults, ordinaryLeaseCreateFlagRegistrationOptions())
 	if err := parseFlags(fs, args); err != nil {
 		return err
 	}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -194,6 +194,119 @@ type benchmarkRecordContext struct {
 	OnRecord    func()
 }
 
+type runFlagValues struct {
+	Lease                  leaseCreateFlagValues
+	LeaseID                *string
+	Keep                   *bool
+	KeepOnFailure          *bool
+	NoSync                 *bool
+	SyncOnly               *bool
+	NoHydrate              *bool
+	DebugSync              *bool
+	ShellMode              *bool
+	ChecksumSync           *bool
+	ForceSyncLarge         *bool
+	FullResync             *bool
+	FreshSync              *bool
+	JUnitResults           *string
+	ResultsAuto            *bool
+	FailOnTestFailures     *bool
+	CaptureStdout          *string
+	CaptureStderr          *string
+	CaptureOnFail          *bool
+	Preflight              *bool
+	PreflightTools         *string
+	ScriptPath             *string
+	ScriptStdin            *bool
+	FreshPR                *string
+	ApplyLocalPatch        *bool
+	EnvHelper              *string
+	RunLabel               *string
+	PresetName             *string
+	Scenario               *string
+	EmitProof              *string
+	ProofTemplate          *string
+	AttestOut              *string
+	AttestKeyOverride      *string
+	StopAfter              *string
+	LeaseOutput            *string
+	ReadyPool              *string
+	ReadyPoolCompatibility *string
+	ReadyPoolReturn        *string
+	Downloads              *stringListFlag
+	AllowEnv               *stringListFlag
+	EnvProfiles            *stringListFlag
+	PresetVars             *stringListFlag
+	ArtifactGlobs          *stringListFlag
+	RequiredArtifacts      *stringListFlag
+	RequiredSchemas        *stringListFlag
+	Reclaim                *bool
+	TimingJSON             *bool
+	TimingRecord           *string
+}
+
+func registerRunFlags(fs *flag.FlagSet, defaults Config, observe providerFlagRegistrationObserver) runFlagValues {
+	leaseFlags := registerLeaseCreateFlagsObserved(fs, defaults, observe)
+	values := runFlagValues{
+		Lease:                  leaseFlags,
+		LeaseID:                fs.String("id", "", "existing lease or server id"),
+		Keep:                   fs.Bool("keep", false, "keep server after command"),
+		KeepOnFailure:          fs.Bool("keep-on-failure", false, "keep a newly acquired lease when the remote command exits non-zero"),
+		NoSync:                 fs.Bool("no-sync", false, "skip rsync"),
+		SyncOnly:               fs.Bool("sync-only", false, "sync and exit"),
+		NoHydrate:              fs.Bool("no-hydrate", false, "skip configured Actions hydration"),
+		DebugSync:              fs.Bool("debug", false, "print detailed sync timing"),
+		ShellMode:              fs.Bool("shell", false, "run command through the remote shell"),
+		ChecksumSync:           fs.Bool("checksum", false, "use checksum rsync instead of size/time"),
+		ForceSyncLarge:         fs.Bool("force-sync-large", false, "allow unusually large sync candidates"),
+		FullResync:             fs.Bool("full-resync", false, "reset the remote workdir and force a complete sync"),
+		FreshSync:              fs.Bool("fresh-sync", false, "alias for --full-resync"),
+		JUnitResults:           fs.String("junit", "", "comma-separated remote JUnit XML paths to record"),
+		ResultsAuto:            fs.Bool("results-auto", false, "scan common remote JUnit XML paths after the command"),
+		FailOnTestFailures:     fs.Bool("fail-on-test-failures", false, "exit non-zero when collected JUnit reports contain failures or errors"),
+		CaptureStdout:          fs.String("capture-stdout", "", "write remote stdout to a local file instead of the terminal"),
+		CaptureStderr:          fs.String("capture-stderr", "", "write remote stderr to a local file instead of the terminal"),
+		CaptureOnFail:          fs.Bool("capture-on-fail", false, "compatibility alias; failure bundles are saved by default on non-zero exit"),
+		Preflight:              fs.Bool("preflight", false, "print remote capability preflight before running the command"),
+		PreflightTools:         fs.String("preflight-tools", "", "comma-separated preflight tools to probe; overrides run.preflightTools"),
+		ScriptPath:             fs.String("script", "", "on POSIX SSH leases, upload and run a standalone content-hashed copy under .crabbox/scripts/; delegated module runtimes use source input"),
+		ScriptStdin:            fs.Bool("script-stdin", false, "read a script from stdin, upload it, and run it"),
+		FreshPR:                fs.String("fresh-pr", "", "run from a fresh remote checkout of a GitHub PR: owner/repo#123, URL, or number"),
+		ApplyLocalPatch:        fs.Bool("apply-local-patch", false, "apply the local git diff on top of --fresh-pr checkout"),
+		EnvHelper:              fs.String("env-helper", "", "persist profile env as a reusable remote helper name under .crabbox/env/"),
+		RunLabel:               fs.String("label", "", "human-readable label for this run"),
+		PresetName:             fs.String("preset", "", "configured profile preset to expand into a command"),
+		Scenario:               fs.String("scenario", "", "preset variable shorthand for --preset-var scenario=<value>"),
+		EmitProof:              fs.String("emit-proof", "", "write a generated proof block after a successful run"),
+		ProofTemplate:          fs.String("proof-template", "", "proof template name from the selected profile"),
+		AttestOut:              fs.String("attest", "", "write a signed run receipt after a successful run"),
+		AttestKeyOverride:      fs.String("attest-key", "", "path to an existing PKCS8 PEM ed25519 private key for --attest"),
+		StopAfter:              fs.String("stop-after", "", "stop policy for the lease: success, always, failure, or never"),
+		LeaseOutput:            fs.String("lease-output", "", "write a retained JSON lease handle for orchestrators on supported providers"),
+		ReadyPool:              fs.String("pool", "", "borrow a broker ready-pool lease"),
+		ReadyPoolCompatibility: fs.String("pool-compatibility-key", "", "provider-neutral ready-pool capability and size key"),
+		ReadyPoolReturn:        fs.String("pool-return", "auto", "ready-pool return policy: auto, ready, drain, release"),
+		Downloads:              &stringListFlag{},
+		AllowEnv:               &stringListFlag{},
+		EnvProfiles:            &stringListFlag{},
+		PresetVars:             &stringListFlag{},
+		ArtifactGlobs:          &stringListFlag{},
+		RequiredArtifacts:      &stringListFlag{},
+		RequiredSchemas:        &stringListFlag{},
+	}
+	fs.Var(values.Downloads, "download", "download a remote file after command success: remote=local; repeatable")
+	fs.Var(values.AllowEnv, "allow-env", "allow an environment variable for this run; repeatable or comma-separated")
+	fs.Var(values.EnvProfiles, "env-from-profile", "load allowed environment values from a local profile file; repeatable")
+	fs.Var(values.PresetVars, "preset-var", "preset template variable name=value; repeatable or comma-separated")
+	fs.Var(values.ArtifactGlobs, "artifact-glob", "collect remote files matching a safe glob into a local run artifact tarball; repeatable")
+	fs.Var(values.RequiredArtifacts, "require-artifact", "require a remote file matching a safe glob after command success; repeatable")
+	fs.Var(values.RequiredSchemas, "require-artifact-schema", "validate a required artifact's JSON content against a schema file after command success: remote=schema.json; repeatable")
+	values.Reclaim = fs.Bool("reclaim", false, "claim this lease for the current repo")
+	values.TimingJSON = fs.Bool("timing-json", false, "print final timing as JSON")
+	values.TimingRecord = fs.String("timing-record", "", "append final timing to benchmark JSONL store: default, off, or path")
+	return values
+}
+
 func (a App) runCommand(ctx context.Context, args []string) error {
 	return a.runCommandWithBenchmarkRecord(ctx, args, benchmarkRecordContext{})
 }
@@ -201,64 +314,58 @@ func (a App) runCommand(ctx context.Context, args []string) error {
 func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, benchmarkCtx benchmarkRecordContext) (err error) {
 	defaults := defaultConfig()
 	fs := newFlagSet("run", a.Stderr)
-	leaseFlags := registerLeaseCreateFlags(fs, defaults)
-	leaseIDFlag := fs.String("id", "", "existing lease or server id")
-	keep := fs.Bool("keep", false, "keep server after command")
-	keepOnFailure := fs.Bool("keep-on-failure", false, "keep a newly acquired lease when the remote command exits non-zero")
-	noSync := fs.Bool("no-sync", false, "skip rsync")
-	syncOnly := fs.Bool("sync-only", false, "sync and exit")
-	noHydrate := fs.Bool("no-hydrate", false, "skip configured Actions hydration")
-	debugSync := fs.Bool("debug", false, "print detailed sync timing")
-	shellMode := fs.Bool("shell", false, "run command through the remote shell")
-	checksumSync := fs.Bool("checksum", false, "use checksum rsync instead of size/time")
-	forceSyncLarge := fs.Bool("force-sync-large", false, "allow unusually large sync candidates")
-	fullResync := fs.Bool("full-resync", false, "reset the remote workdir and force a complete sync")
-	freshSync := fs.Bool("fresh-sync", false, "alias for --full-resync")
-	junitResults := fs.String("junit", "", "comma-separated remote JUnit XML paths to record")
-	resultsAuto := fs.Bool("results-auto", false, "scan common remote JUnit XML paths after the command")
-	failOnTestFailures := fs.Bool("fail-on-test-failures", false, "exit non-zero when collected JUnit reports contain failures or errors")
-	captureStdout := fs.String("capture-stdout", "", "write remote stdout to a local file instead of the terminal")
-	captureStderr := fs.String("capture-stderr", "", "write remote stderr to a local file instead of the terminal")
-	captureOnFail := fs.Bool("capture-on-fail", false, "compatibility alias; failure bundles are saved by default on non-zero exit")
-	preflight := fs.Bool("preflight", false, "print remote capability preflight before running the command")
-	preflightTools := fs.String("preflight-tools", "", "comma-separated preflight tools to probe; overrides run.preflightTools")
-	scriptPath := fs.String("script", "", "on POSIX SSH leases, upload and run a standalone content-hashed copy under .crabbox/scripts/; delegated module runtimes use source input")
-	scriptStdin := fs.Bool("script-stdin", false, "read a script from stdin, upload it, and run it")
-	freshPRValue := fs.String("fresh-pr", "", "run from a fresh remote checkout of a GitHub PR: owner/repo#123, URL, or number")
-	applyLocalPatch := fs.Bool("apply-local-patch", false, "apply the local git diff on top of --fresh-pr checkout")
-	envHelper := fs.String("env-helper", "", "persist profile env as a reusable remote helper name under .crabbox/env/")
-	runLabel := fs.String("label", "", "human-readable label for this run")
-	presetName := fs.String("preset", "", "configured profile preset to expand into a command")
-	scenario := fs.String("scenario", "", "preset variable shorthand for --preset-var scenario=<value>")
-	emitProof := fs.String("emit-proof", "", "write a generated proof block after a successful run")
-	proofTemplate := fs.String("proof-template", "", "proof template name from the selected profile")
-	attestOut := fs.String("attest", "", "write a signed run receipt after a successful run")
-	attestKeyOverride := fs.String("attest-key", "", "path to an existing PKCS8 PEM ed25519 private key for --attest")
-	stopAfter := fs.String("stop-after", "", "stop policy for the lease: success, always, failure, or never")
-	leaseOutput := fs.String("lease-output", "", "write a retained JSON lease handle for orchestrators on supported providers")
-	readyPool := fs.String("pool", "", "borrow a broker ready-pool lease")
-	readyPoolCompatibilityKey := fs.String("pool-compatibility-key", "", "provider-neutral ready-pool capability and size key")
-	readyPoolReturn := fs.String("pool-return", "auto", "ready-pool return policy: auto, ready, drain, release")
-	var downloads stringListFlag
-	var allowEnvFlags stringListFlag
-	var envProfileFlags stringListFlag
-	var presetVars stringListFlag
-	var artifactGlobs stringListFlag
-	var requiredArtifactGlobs stringListFlag
-	var requiredArtifactSchemas stringListFlag
-	fs.Var(&downloads, "download", "download a remote file after command success: remote=local; repeatable")
-	fs.Var(&allowEnvFlags, "allow-env", "allow an environment variable for this run; repeatable or comma-separated")
-	fs.Var(&envProfileFlags, "env-from-profile", "load allowed environment values from a local profile file; repeatable")
-	fs.Var(&presetVars, "preset-var", "preset template variable name=value; repeatable or comma-separated")
-	fs.Var(&artifactGlobs, "artifact-glob", "collect remote files matching a safe glob into a local run artifact tarball; repeatable")
-	fs.Var(&requiredArtifactGlobs, "require-artifact", "require a remote file matching a safe glob after command success; repeatable")
-	fs.Var(&requiredArtifactSchemas, "require-artifact-schema", "validate a required artifact's JSON content against a schema file after command success: remote=schema.json; repeatable")
-	reclaim := fs.Bool("reclaim", false, "claim this lease for the current repo")
-	timingJSON := fs.Bool("timing-json", false, "print final timing as JSON")
-	timingRecord := fs.String("timing-record", "", "append final timing to benchmark JSONL store: default, off, or path")
+	runFlags := registerRunFlags(fs, defaults, nil)
 	if err := parseFlags(fs, args); err != nil {
 		return err
 	}
+	leaseFlags := runFlags.Lease
+	leaseIDFlag := runFlags.LeaseID
+	keep := runFlags.Keep
+	keepOnFailure := runFlags.KeepOnFailure
+	noSync := runFlags.NoSync
+	syncOnly := runFlags.SyncOnly
+	noHydrate := runFlags.NoHydrate
+	debugSync := runFlags.DebugSync
+	shellMode := runFlags.ShellMode
+	checksumSync := runFlags.ChecksumSync
+	forceSyncLarge := runFlags.ForceSyncLarge
+	fullResync := runFlags.FullResync
+	freshSync := runFlags.FreshSync
+	junitResults := runFlags.JUnitResults
+	resultsAuto := runFlags.ResultsAuto
+	failOnTestFailures := runFlags.FailOnTestFailures
+	captureStdout := runFlags.CaptureStdout
+	captureStderr := runFlags.CaptureStderr
+	captureOnFail := runFlags.CaptureOnFail
+	preflight := runFlags.Preflight
+	preflightTools := runFlags.PreflightTools
+	scriptPath := runFlags.ScriptPath
+	scriptStdin := runFlags.ScriptStdin
+	freshPRValue := runFlags.FreshPR
+	applyLocalPatch := runFlags.ApplyLocalPatch
+	envHelper := runFlags.EnvHelper
+	runLabel := runFlags.RunLabel
+	presetName := runFlags.PresetName
+	scenario := runFlags.Scenario
+	emitProof := runFlags.EmitProof
+	proofTemplate := runFlags.ProofTemplate
+	attestOut := runFlags.AttestOut
+	attestKeyOverride := runFlags.AttestKeyOverride
+	stopAfter := runFlags.StopAfter
+	leaseOutput := runFlags.LeaseOutput
+	readyPool := runFlags.ReadyPool
+	readyPoolCompatibilityKey := runFlags.ReadyPoolCompatibility
+	readyPoolReturn := runFlags.ReadyPoolReturn
+	downloads := append(stringListFlag(nil), (*runFlags.Downloads)...)
+	allowEnvFlags := append(stringListFlag(nil), (*runFlags.AllowEnv)...)
+	envProfileFlags := append(stringListFlag(nil), (*runFlags.EnvProfiles)...)
+	presetVars := append(stringListFlag(nil), (*runFlags.PresetVars)...)
+	artifactGlobs := append(stringListFlag(nil), (*runFlags.ArtifactGlobs)...)
+	requiredArtifactGlobs := append(stringListFlag(nil), (*runFlags.RequiredArtifacts)...)
+	requiredArtifactSchemas := append(stringListFlag(nil), (*runFlags.RequiredSchemas)...)
+	reclaim := runFlags.Reclaim
+	timingJSON := runFlags.TimingJSON
+	timingRecord := runFlags.TimingRecord
 	timingRecordPath, timingRecordEnabled, err := resolveBenchmarkTimingStore(*timingRecord)
 	if err != nil {
 		return err

--- a/internal/providers/applevm/flags.go
+++ b/internal/providers/applevm/flags.go
@@ -30,7 +30,7 @@ type flagValues struct {
 }
 
 func registerFlags(fs *flag.FlagSet, defaults core.Config) any {
-	return flagValues{
+	values := flagValues{
 		HelperPath:  fs.String("apple-vm-helper", defaults.AppleVM.HelperPath, "apple-vm helper binary path"),
 		Image:       fs.String("apple-vm-image", applevmhelper.ImageIdentity(defaults.AppleVM.Image, defaults.AppleVM.ImageSHA256), "apple-vm local source image path"),
 		ImageSHA256: fs.String("apple-vm-image-sha256", defaults.AppleVM.ImageSHA256, "expected SHA-256 for apple-vm source image downloads"),
@@ -49,6 +49,15 @@ func registerFlags(fs *flag.FlagSet, defaults core.Config) any {
 		LegacyMemoryMiB:   fs.Int("apple-vz-memory", defaults.AppleVM.MemoryMiB, "deprecated alias for --apple-vm-memory"),
 		LegacyDiskGiB:     fs.Int("apple-vz-disk", defaults.AppleVM.DiskGiB, "deprecated alias for --apple-vm-disk"),
 	}
+	core.MarkFlagDeprecated(fs, "apple-vz-helper", "apple-vm-helper")
+	core.MarkFlagDeprecated(fs, "apple-vz-image", "apple-vm-image")
+	core.MarkFlagDeprecated(fs, "apple-vz-image-sha256", "apple-vm-image-sha256")
+	core.MarkFlagDeprecated(fs, "apple-vz-user", "apple-vm-user")
+	core.MarkFlagDeprecated(fs, "apple-vz-work-root", "apple-vm-work-root")
+	core.MarkFlagDeprecated(fs, "apple-vz-cpus", "apple-vm-cpus")
+	core.MarkFlagDeprecated(fs, "apple-vz-memory", "apple-vm-memory")
+	core.MarkFlagDeprecated(fs, "apple-vz-disk", "apple-vm-disk")
+	return values
 }
 
 // stringFlag returns the effective value of a renamed flag: the current name

--- a/internal/providers/dockersandbox/flags.go
+++ b/internal/providers/dockersandbox/flags.go
@@ -23,6 +23,10 @@ func (f *stringListFlag) Set(value string) error {
 	return nil
 }
 
+func (f *stringListFlag) Get() any {
+	return append([]string{}, (*f)...)
+}
+
 type flagValues struct {
 	CLIPath         *string
 	Agent           *string

--- a/internal/providers/external/flags.go
+++ b/internal/providers/external/flags.go
@@ -143,6 +143,10 @@ func (f *stringListFlag) Set(value string) error {
 	return nil
 }
 
+func (f *stringListFlag) Get() any {
+	return append([]string{}, f.values...)
+}
+
 func validateConfig(cfg core.Config) error {
 	hasCommand := strings.TrimSpace(cfg.External.Command) != ""
 	hasLifecycle := lifecycleConfigured(cfg.External)

--- a/internal/providers/localcontainer/flags.go
+++ b/internal/providers/localcontainer/flags.go
@@ -14,6 +14,7 @@ func (f *volumeListFlag) Set(value string) error {
 	*f = append(*f, value)
 	return nil
 }
+func (f *volumeListFlag) Get() any { return append([]string{}, (*f)...) }
 
 type flagValues struct {
 	Runtime      *string

--- a/internal/providers/modal/flags.go
+++ b/internal/providers/modal/flags.go
@@ -35,6 +35,10 @@ func (s *modalSecretList) Set(value string) error {
 	return nil
 }
 
+func (s *modalSecretList) Get() any {
+	return append([]string{}, s.values...)
+}
+
 func RegisterModalProviderFlags(fs *flag.FlagSet, defaults Config) any {
 	secrets := modalSecretList{values: append([]string(nil), defaults.Modal.Secrets...)}
 	fs.Var(&secrets, "modal-secret", "named Modal Secret to inject into the sandbox; repeatable or comma-separated")

--- a/internal/providers/namespaceinstance/flags.go
+++ b/internal/providers/namespaceinstance/flags.go
@@ -14,6 +14,7 @@ func (f *stringListFlag) Set(value string) error {
 	*f = append(*f, strings.TrimSpace(value))
 	return nil
 }
+func (f *stringListFlag) Get() any { return append([]string{}, (*f)...) }
 
 type flagValues struct {
 	CLIPath     *string


### PR DESCRIPTION
## Summary

- add `crabbox providers describe <provider>` as the credential-free provider-scoped run flag discovery surface
- derive shared and provider-owned flag metadata from the real `run` and provider registrations instead of a parallel flag inventory
- expose deterministic human output and a stable JSON schema v1 with canonical identity, alias input, provider kind/capabilities, typed compiled defaults, repeatability, and deprecation metadata
- preserve the comprehensive existing `crabbox run --help` byte-for-byte

Closes https://github.com/openclaw/crabbox/issues/1375

## Architecture

The command resolves providers through the existing registry and defines runnability from the existing provider kind contract (`ssh-lease` and `delegated-run`). It registers the real run flag set against compiled `baseConfig()` defaults, observes each adapter's actual `RegisterFlags` call to assign ownership, and treats the remaining run flags as shared command-level flags.

The describe path never loads configuration, applies provider flags, constructs a backend or client, reads credentials/state/locks, contacts a network, or writes files. Repeatable custom flag values implement typed `flag.Getter` metadata, and renamed Apple VM flags use registration-coupled deprecation annotations so drift fails closed.

JSON schema v1 contains:

- canonical and requested provider identity, input alias, aliases, and provider deprecation status
- runnable status, provider kind/family, targets, and normalized capability arrays
- separate `sharedFlags` and `providerFlags` arrays
- typed defaults, value shape, repeatability, usage, deprecation/replacement, routing, and creation-only metadata per flag

## Proof

- `gofmt` and `git diff --check`
- `go vet ./...`
- `go test -race -count=1 -timeout=10m ./internal/cli`
- `go test -count=1 -timeout=10m ./internal/providers/...`
- `go test -timeout=15m ./...`
- `go test -race -timeout=20m ./...`
- `scripts/test-go-modules.sh`
- `scripts/check-docs.sh`
- `go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...`
- Codex-backed P1 autoreview: no accepted/actionable findings

A source-blind built-binary pass in a fresh HOME/XDG sandbox proved:

- `docker` canonicalizes to `local-container`
- 84 shared run flags and exactly the nine expected local-container flags
- AWS Lambda MicroVM, Azure, Daytona, Tart, and other provider-owned flags are excluded
- unknown and service-control providers exit 2 without partial JSON
- config/credential marker values are absent
- no files are created or changed in the isolated HOME/XDG roots
- `crabbox run --help` remains exactly 59,796 bytes with SHA-256 `d8702c9a6133c7e96fe8cbbf89470a49921b664c268fa91a23b1c8bc319a0f0b`

## Config and secrets

No new configuration or credentials are introduced. The command intentionally ignores live config and environment overrides and serializes only compiled, non-secret defaults.
