### PR TITLE
fix(worker): retry transient GitHub OAuth failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixed
 
+- Retried brief GitHub API failures during browser login and kept exhausted post-exchange attempts safely retryable instead of turning the next CLI poll into a terminal failure.
 - Bounded `crabbox claims list` inventory reads to 1 MiB per local claim while preserving valid partial output for oversized files. Thanks @coygeek.
 - Made local-container heartbeat authorize recorded dynamic runtime scopes and durably compare-and-swap exact claim lifecycle state without recreating or overwriting changed claims. Thanks @coygeek.
 - Made AWS image deletion resume from owner-level durable snapshot claims after AMI deregistration or catalog cleanup failures, preventing stale ordinary and capability-variant records from remaining selectable.

--- a/worker/src/auth.ts
+++ b/worker/src/auth.ts
@@ -325,6 +325,23 @@ export async function issuePortalToken(
   return issueSignedUserToken(env, input, "crabbox-portal", portalTokenPrefix);
 }
 
+export async function sealPendingGitHubCredential(
+  env: Pick<Env, "CRABBOX_SHARED_TOKEN" | "CRABBOX_SESSION_SECRET">,
+  accessToken: string,
+): Promise<string> {
+  if (!accessToken || accessToken.length > githubAccessTokenMaxChars) {
+    throw new Error("GitHub access token is invalid");
+  }
+  return sealGitHubCredential(accessToken, sessionSecret(env));
+}
+
+export async function openPendingGitHubCredential(
+  env: Pick<Env, "CRABBOX_SHARED_TOKEN" | "CRABBOX_SESSION_SECRET">,
+  credential: string,
+): Promise<string | undefined> {
+  return openGitHubCredential(credential, sessionSecret(env));
+}
+
 async function issueSignedUserToken(
   env: Pick<Env, "CRABBOX_SHARED_TOKEN" | "CRABBOX_SESSION_SECRET">,
   input: SignedUserTokenInput,

--- a/worker/src/github-membership.ts
+++ b/worker/src/github-membership.ts
@@ -366,10 +366,10 @@ function githubHeaders(accessToken: string): Record<string, string> {
   };
 }
 
-async function githubResponseError(
-  response: Response,
-  message: string,
-): Promise<GitHubAuthorizationError> {
+async function githubResponseError(response: Response, message: string): Promise<Error> {
+  if (response.status === 429 || response.status >= 500) {
+    return new GitHubTransientError(message);
+  }
   if (response.status === 401) return new GitHubCredentialError(message);
   if (response.status !== 403) return new GitHubAuthorizationError(message);
 
@@ -424,3 +424,5 @@ function github403RequiresReauthentication(details: {
 export class GitHubAuthorizationError extends Error {}
 
 export class GitHubCredentialError extends GitHubAuthorizationError {}
+
+export class GitHubTransientError extends Error {}

--- a/worker/src/oauth.ts
+++ b/worker/src/oauth.ts
@@ -1,14 +1,20 @@
 import {
   issuePortalToken,
   issueUserToken,
+  openPendingGitHubCredential,
   portalTokenExpiresAt,
+  sealPendingGitHubCredential,
   sha256Hex,
   userTokenExpiresAt,
   userTokenSigningConfigurationError,
 } from "./auth";
 import { legacyPortalSessionCookieName, portalSessionCookieName } from "./cookies";
 import type { CoordinatorRuntime, CoordinatorStorage } from "./coordinator-runtime";
-import { GitHubAuthorizationError, requireGitHubLoginMembership } from "./github-membership";
+import {
+  GitHubAuthorizationError,
+  GitHubTransientError,
+  requireGitHubLoginMembership,
+} from "./github-membership";
 import { errorMessage, json, readJson } from "./http";
 import { requestOrgLabel } from "./org-identity";
 import { timingSafeEqual } from "./timing-safe";
@@ -21,6 +27,7 @@ const portalOAuthCookiePrefix = "__Host-crabbox_oauth_";
 const pendingOAuthTTLSeconds = 10 * 60;
 const maxPendingOAuthLogins = 100;
 const maxPendingOAuthLoginsPerSource = 10;
+const githubPostExchangeRetryDelayMS = 200;
 const defaultUserTokenTTLSeconds = 180 * 24 * 60 * 60;
 const minUserTokenTTLSeconds = 60 * 60;
 const maxUserTokenTTLSeconds = 365 * 24 * 60 * 60;
@@ -45,6 +52,7 @@ interface OAuthPending {
   login?: string;
   error?: string;
   callbackClaim?: string;
+  githubCredential?: string;
   sourceHash?: string;
 }
 
@@ -327,10 +335,36 @@ async function githubAuthCallback(
     );
   }
   try {
-    const accessToken = await exchangeGitHubCode(code, pending.redirectURI, env);
-    const identity = await githubIdentity(accessToken);
+    let accessToken: string;
+    if (pending.githubCredential) {
+      const opened = await openPendingGitHubCredential(env, pending.githubCredential);
+      if (!opened) throw new Error("Stored GitHub credential is invalid");
+      accessToken = opened;
+    } else {
+      accessToken = await exchangeGitHubCode(code, pending.redirectURI, env);
+      // The OAuth code is one-use, so retain the credential securely for callback retries.
+      const githubCredential = await sealPendingGitHubCredential(env, accessToken);
+      const stored = await storeClaimedGitHubCredential(
+        runtime,
+        pending.id,
+        claim,
+        githubCredential,
+      );
+      if (!stored) {
+        return expiredOAuthResponse(pending);
+      }
+    }
     const requestedOrg = requestOrgLabel(new Request(request.url), env);
-    const org = await requireGitHubLoginMembership(accessToken, identity, requestedOrg, env);
+    const { identity, org } = await retryGitHubPostExchange(async () => {
+      const resolvedIdentity = await githubIdentity(accessToken);
+      const resolvedOrg = await requireGitHubLoginMembership(
+        accessToken,
+        resolvedIdentity,
+        requestedOrg,
+        env,
+      );
+      return { identity: resolvedIdentity, org: resolvedOrg };
+    });
     const ttlSeconds = userTokenTTLSeconds(env);
     const tokenInput = {
       owner: identity.owner,
@@ -397,6 +431,12 @@ async function githubAuthCallback(
       "referrer-policy": "no-referrer",
     });
   } catch (err) {
+    if (err instanceof GitHubTransientError) {
+      const released = await releasePendingOAuthClaim(runtime, pending.id, claim);
+      return released
+        ? retryableOAuthResponse(request.url, pending.mode)
+        : expiredOAuthResponse(pending);
+    }
     await finishPendingOAuth(runtime, pending.id, claim, { error: errorMessage(err) });
     if (err instanceof GitHubAuthorizationError) {
       return html("Crabbox login denied", err.message, 403, terminalPortalOAuthHeaders(pending));
@@ -408,6 +448,47 @@ async function githubAuthCallback(
       terminalPortalOAuthHeaders(pending),
     );
   }
+}
+
+async function storeClaimedGitHubCredential(
+  runtime: Pick<CoordinatorRuntime, "storage" | "runExclusive">,
+  id: string,
+  claim: string,
+  githubCredential: string,
+): Promise<boolean> {
+  return runtime.runExclusive(async () => {
+    const pending = await runtime.storage.get<OAuthPending>(oauthKey(id));
+    if (
+      !pending ||
+      pending.callbackClaim !== claim ||
+      Date.parse(pending.expiresAt) <= Date.now()
+    ) {
+      return false;
+    }
+    pending.githubCredential = githubCredential;
+    await runtime.storage.put(oauthKey(pending.id), pending);
+    return true;
+  });
+}
+
+async function releasePendingOAuthClaim(
+  runtime: Pick<CoordinatorRuntime, "storage" | "runExclusive">,
+  id: string,
+  claim: string,
+): Promise<boolean> {
+  return runtime.runExclusive(async () => {
+    const pending = await runtime.storage.get<OAuthPending>(oauthKey(id));
+    if (
+      !pending ||
+      pending.callbackClaim !== claim ||
+      Date.parse(pending.expiresAt) <= Date.now()
+    ) {
+      return false;
+    }
+    delete pending.callbackClaim;
+    await runtime.storage.put(oauthKey(pending.id), pending);
+    return true;
+  });
 }
 
 async function claimPendingOAuth(
@@ -464,6 +545,7 @@ async function finishPendingOAuth(
     }
     Object.assign(pending, result);
     delete pending.callbackClaim;
+    delete pending.githubCredential;
     await runtime.storage.put(oauthKey(pending.id), pending);
     return structuredClone(pending);
   });
@@ -475,6 +557,24 @@ function expiredOAuthResponse(pending?: OAuthPending): Response {
     "The login request expired. Run crabbox login --url <broker-url> again.",
     400,
     pending ? terminalPortalOAuthHeaders(pending) : undefined,
+  );
+}
+
+function retryableOAuthResponse(callbackURL: string, mode: OAuthPending["mode"]): Response {
+  const message =
+    mode === "portal"
+      ? "Your Crabbox portal login is still waiting. Click the link below to retry."
+      : "The Crabbox CLI is still waiting for this login. Click the link below to retry.";
+  return html(
+    "Crabbox login delayed",
+    `GitHub is temporarily unavailable. ${message}`,
+    503,
+    {
+      "cache-control": "no-store",
+      "referrer-policy": "no-referrer",
+      "retry-after": "2",
+    },
+    `<p><a href="${escapeHTML(callbackURL)}">Retry GitHub login</a></p>`,
   );
 }
 
@@ -630,9 +730,20 @@ async function exchangeGitHubCode(code: string, redirectURI: string, env: Env): 
     },
     body,
   });
-  const data = (await response.json()) as { access_token?: string; error?: string };
-  if (!response.ok || !data.access_token) {
-    throw new Error(data.error || `github token exchange failed: ${response.status}`);
+  if (!response.ok) {
+    let error = "";
+    try {
+      const data = (await response.json()) as { error?: string };
+      error = data.error ?? "";
+    } catch {
+      // GitHub may return an HTML or empty body during an upstream outage.
+    }
+    const message = error || `github token exchange failed: ${response.status}`;
+    throw githubLookupError(message, response.status);
+  }
+  const data = (await response.json()) as { access_token?: string };
+  if (!data.access_token) {
+    throw new Error("github token exchange failed: missing access token");
   }
   return data.access_token;
 }
@@ -651,7 +762,10 @@ async function githubIdentity(accessToken: string): Promise<{
   };
   const userResponse = await fetch(`${githubAPIURL}/user`, { headers });
   if (!userResponse.ok) {
-    throw new Error(`github user lookup failed: ${userResponse.status}`);
+    throw githubLookupError(
+      `github user lookup failed: ${userResponse.status}`,
+      userResponse.status,
+    );
   }
   const user = (await userResponse.json()) as GitHubUser;
   if (typeof user.id !== "number" || !Number.isSafeInteger(user.id) || user.id <= 0) {
@@ -660,7 +774,10 @@ async function githubIdentity(accessToken: string): Promise<{
   const login = user.login || "unknown";
   const emailResponse = await fetch(`${githubAPIURL}/user/emails`, { headers });
   if (!emailResponse.ok) {
-    throw new Error(`github email lookup failed: ${emailResponse.status}`);
+    throw githubLookupError(
+      `github email lookup failed: ${emailResponse.status}`,
+      emailResponse.status,
+    );
   }
   const emails = (await emailResponse.json()) as GitHubEmail[];
   const verifiedEmails = emails.filter(
@@ -683,6 +800,20 @@ async function githubIdentity(accessToken: string): Promise<{
     identity.name = user.name;
   }
   return identity;
+}
+
+async function retryGitHubPostExchange<T>(operation: () => Promise<T>): Promise<T> {
+  try {
+    return await operation();
+  } catch (err) {
+    if (!(err instanceof GitHubTransientError)) throw err;
+    await new Promise<void>((resolve) => setTimeout(resolve, githubPostExchangeRetryDelayMS));
+    return operation();
+  }
+}
+
+function githubLookupError(message: string, status: number): Error {
+  return status === 429 || status >= 500 ? new GitHubTransientError(message) : new Error(message);
 }
 
 async function deletePendingOAuth(

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -34096,7 +34096,7 @@ describe("fleet identity", () => {
       githubFetchMock({
         member: true,
         profileEmail: "victim@example.com",
-        emailStatus: 500,
+        emailStatus: 401,
       }),
     );
 
@@ -34113,7 +34113,7 @@ describe("fleet identity", () => {
     expect(poll.status).toBe(400);
     await expect(poll.json()).resolves.toMatchObject({
       status: "failed",
-      error: "github email lookup failed: 500",
+      error: "github email lookup failed: 401",
     });
   });
 

--- a/worker/test/oauth-browser-binding.test.ts
+++ b/worker/test/oauth-browser-binding.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { sha256Hex } from "../src/auth";
 import type { CoordinatorStorage, CoordinatorStorageView } from "../src/coordinator-runtime";
 import { githubAuthRoute, githubPortalLogin } from "../src/oauth";
 import type { Env } from "../src/types";
@@ -114,7 +115,74 @@ function stubSuccessfulGitHubOAuth(): ReturnType<typeof vi.fn> {
   return mock;
 }
 
+const cliPollSecret = "local-poll-secret";
+const cliLoopbackRedirectURI = `http://127.0.0.1:54321/crabbox/oauth/${"a".repeat(64)}`;
+
+async function startCLILogin(storage: MemoryStorage): Promise<{
+  callbackURL: string;
+  loginID: string;
+}> {
+  const start = await githubAuthRoute(
+    new Request("https://broker.test/v1/auth/github/start", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        pollSecretHash: await sha256Hex(cliPollSecret),
+        loopbackRedirectURI: cliLoopbackRedirectURI,
+      }),
+    }),
+    "start",
+    testRuntime(storage),
+    env,
+  );
+  expect(start.status).toBe(200);
+  const started = (await start.json()) as { loginID: string; url: string };
+  const state = new URL(started.url).searchParams.get("state");
+  expect(state).toBeTruthy();
+  return {
+    callbackURL: `https://broker.test/v1/auth/github/callback?code=code&state=${encodeURIComponent(state ?? "")}`,
+    loginID: started.loginID,
+  };
+}
+
+async function pollCLILogin(
+  storage: MemoryStorage,
+  loginID: string,
+  browserConfirmation?: string | null,
+): Promise<Response> {
+  return githubAuthRoute(
+    new Request("https://broker.test/v1/auth/github/poll", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        loginID,
+        pollSecret: cliPollSecret,
+        browserConfirmation,
+      }),
+    }),
+    "poll",
+    testRuntime(storage),
+    env,
+  );
+}
+
+function fetchCallCount(fetchMock: ReturnType<typeof vi.fn>, expectedURL: string): number {
+  return fetchMock.mock.calls.filter(([input]) => {
+    const url = input instanceof Request ? input.url : String(input);
+    return url === expectedURL;
+  }).length;
+}
+
+function runRetryDelayImmediately(): ReturnType<typeof vi.spyOn> {
+  return vi.spyOn(globalThis, "setTimeout").mockImplementation(((callback: () => void) => {
+    callback();
+    return 0;
+  }) as typeof setTimeout);
+}
+
 afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
 
@@ -284,5 +352,225 @@ describe("portal OAuth browser binding", () => {
     expect(await response.text()).toContain(
       "Replace email or login selectors with github:&lt;numeric-id&gt;",
     );
+  });
+});
+
+describe("GitHub OAuth transient failures", () => {
+  it("does not automatically retry a transient OAuth code exchange", async () => {
+    const storage = new MemoryStorage();
+    const { callbackURL, loginID } = await startCLILogin(storage);
+    const fetchMock = vi.fn<() => Promise<Response>>(async () =>
+      Response.json({ message: "Service Unavailable" }, { status: 503 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const unavailable = await githubAuthRoute(
+      new Request(callbackURL),
+      "callback",
+      testRuntime(storage),
+      env,
+    );
+    expect(unavailable.status).toBe(503);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const pending = [
+      ...(
+        await storage.list<{ githubCredential?: string }>({
+          prefix: "oauth:",
+        })
+      ).values(),
+    ][0];
+    expect(pending?.githubCredential).toBeUndefined();
+
+    const waiting = await pollCLILogin(storage, loginID);
+    expect(waiting.status).toBe(200);
+    await expect(waiting.json()).resolves.toMatchObject({ status: "pending" });
+  });
+
+  it("retries a one-time user lookup 503 inside the original callback", async () => {
+    const retryDelay = runRetryDelayImmediately();
+    const storage = new MemoryStorage();
+    const { callbackURL, loginID } = await startCLILogin(storage);
+
+    let userLookups = 0;
+    const fetchMock = vi.fn<(input: string | URL | Request) => Promise<Response>>(async (input) => {
+      const url = input instanceof Request ? input.url : input.toString();
+      if (url === "https://github.com/login/oauth/access_token") {
+        return Response.json({ access_token: "github-access-token" });
+      }
+      if (url === "https://api.github.com/user") {
+        userLookups += 1;
+        return userLookups === 1
+          ? Response.json({ message: "Service Unavailable" }, { status: 503 })
+          : Response.json({ id: 12345, login: "alice", name: "Alice" });
+      }
+      if (url === "https://api.github.com/user/emails") {
+        return Response.json([{ email: "alice@example.com", primary: true, verified: true }]);
+      }
+      if (url === "https://api.github.com/user/memberships/orgs/openclaw") {
+        return Response.json({ state: "active", organization: { login: "openclaw" } });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const callback = await githubAuthRoute(
+      new Request(callbackURL),
+      "callback",
+      testRuntime(storage),
+      env,
+    );
+    expect(callback.status).toBe(303);
+    const confirmation = new URL(callback.headers.get("location") ?? "").searchParams.get(
+      "confirmation",
+    );
+    expect(confirmation).toMatch(/^confirm_[a-f0-9]{32}$/);
+    expect(userLookups).toBe(2);
+    expect(retryDelay).toHaveBeenCalledOnce();
+    expect(retryDelay.mock.calls[0]?.[1]).toBe(200);
+    expect(fetchCallCount(fetchMock, "https://github.com/login/oauth/access_token")).toBe(1);
+
+    const complete = await pollCLILogin(storage, loginID, confirmation);
+    expect(complete.status).toBe(200);
+    await expect(complete.json()).resolves.toMatchObject({
+      status: "complete",
+      owner: "github:12345",
+      org: "openclaw",
+      login: "alice",
+    });
+  });
+
+  it("keeps a persistent outage retryable with only the sealed exchanged credential", async () => {
+    const retryDelay = runRetryDelayImmediately();
+    const storage = new MemoryStorage();
+    const { callbackURL, loginID } = await startCLILogin(storage);
+    let recovered = false;
+    let membershipLookups = 0;
+    const fetchMock = vi.fn<(input: string | URL | Request) => Promise<Response>>(async (input) => {
+      const url = input instanceof Request ? input.url : input.toString();
+      if (url === "https://github.com/login/oauth/access_token") {
+        return Response.json({ access_token: "github-access-token" });
+      }
+      if (url === "https://api.github.com/user") {
+        return Response.json({ id: 12345, login: "alice", name: "Alice" });
+      }
+      if (url === "https://api.github.com/user/emails") {
+        return Response.json([{ email: "alice@example.com", primary: true, verified: true }]);
+      }
+      if (url === "https://api.github.com/user/memberships/orgs/openclaw") {
+        membershipLookups += 1;
+        return recovered
+          ? Response.json({ state: "active", organization: { login: "openclaw" } })
+          : Response.json({ message: "Service Unavailable" }, { status: 503 });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const unavailable = await githubAuthRoute(
+      new Request(callbackURL),
+      "callback",
+      testRuntime(storage),
+      env,
+    );
+    expect(unavailable.status).toBe(503);
+    expect(unavailable.headers.get("cache-control")).toBe("no-store");
+    expect(unavailable.headers.get("referrer-policy")).toBe("no-referrer");
+    expect(unavailable.headers.get("retry-after")).toBe("2");
+    const retryPage = await unavailable.text();
+    expect(retryPage).toContain("The Crabbox CLI is still waiting");
+    expect(retryPage).toContain("Retry GitHub login");
+    expect(membershipLookups).toBe(2);
+    expect(retryDelay).toHaveBeenCalledOnce();
+    expect(retryDelay.mock.calls[0]?.[1]).toBe(200);
+
+    const pending = [
+      ...(
+        await storage.list<{ callbackClaim?: string; githubCredential?: string }>({
+          prefix: "oauth:",
+        })
+      ).values(),
+    ][0];
+    expect(pending?.callbackClaim).toBeUndefined();
+    expect(pending?.githubCredential).toBeTruthy();
+    expect(JSON.stringify(pending)).not.toContain("github-access-token");
+
+    const waiting = await pollCLILogin(storage, loginID);
+    expect(waiting.status).toBe(200);
+    await expect(waiting.json()).resolves.toMatchObject({ status: "pending" });
+
+    recovered = true;
+    const retry = await githubAuthRoute(
+      new Request(callbackURL),
+      "callback",
+      testRuntime(storage),
+      env,
+    );
+    expect(retry.status).toBe(303);
+    const confirmation = new URL(retry.headers.get("location") ?? "").searchParams.get(
+      "confirmation",
+    );
+    expect(confirmation).toMatch(/^confirm_[a-f0-9]{32}$/);
+
+    const complete = await pollCLILogin(storage, loginID, confirmation);
+    expect(complete.status).toBe(200);
+    await expect(complete.json()).resolves.toMatchObject({
+      status: "complete",
+      owner: "github:12345",
+      org: "openclaw",
+      login: "alice",
+    });
+    expect(membershipLookups).toBe(3);
+    expect(fetchCallCount(fetchMock, "https://github.com/login/oauth/access_token")).toBe(1);
+  });
+
+  it("preserves portal browser binding across the retry page", async () => {
+    const retryDelay = runRetryDelayImmediately();
+    const storage = new MemoryStorage();
+    const login = await startPortalLogin(storage);
+    const portalCookie = portalBindingCookie(login);
+    const callbackURL = `https://broker.test/v1/auth/github/callback?code=code&state=${encodeURIComponent(oauthState(login))}`;
+    let recovered = false;
+    const fetchMock = vi.fn<(input: string | URL | Request) => Promise<Response>>(async (input) => {
+      const url = input instanceof Request ? input.url : input.toString();
+      if (url === "https://github.com/login/oauth/access_token") {
+        return Response.json({ access_token: "github-access-token" });
+      }
+      if (url === "https://api.github.com/user") {
+        return recovered
+          ? Response.json({ id: 12345, login: "alice", name: "Alice" })
+          : Response.json({ message: "Service Unavailable" }, { status: 503 });
+      }
+      if (url === "https://api.github.com/user/emails") {
+        return Response.json([{ email: "alice@example.com", primary: true, verified: true }]);
+      }
+      if (url === "https://api.github.com/user/memberships/orgs/openclaw") {
+        return Response.json({ state: "active", organization: { login: "openclaw" } });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const unavailable = await githubAuthRoute(
+      new Request(callbackURL, { headers: { cookie: portalCookie.pair } }),
+      "callback",
+      testRuntime(storage),
+      env,
+    );
+    expect(unavailable.status).toBe(503);
+    expect(await unavailable.text()).toContain("Your Crabbox portal login is still waiting");
+    expect(setCookies(unavailable).join("\n")).not.toContain(`${portalCookie.name}=;`);
+    expect(retryDelay).toHaveBeenCalledOnce();
+
+    recovered = true;
+    const complete = await githubAuthRoute(
+      new Request(callbackURL, { headers: { cookie: portalCookie.pair } }),
+      "callback",
+      testRuntime(storage),
+      env,
+    );
+    expect(complete.status).toBe(302);
+    expect(complete.headers.get("location")).toBe("/portal");
+    expect(setCookies(complete).join("\n")).toContain("__Host-crabbox_session=");
+    expect(fetchCallCount(fetchMock, "https://github.com/login/oauth/access_token")).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

Transient GitHub 429/5xx responses during OAuth post-exchange work were stored as terminal failures. The CLI poll then returned 400 and consumed the login, even though retrying the upstream GitHub API work could recover.

This change adds one bounded 200 ms retry for post-exchange GitHub API work. If GitHub is still unavailable, the coordinator retains only a sealed credential, releases the callback claim for a manual callback retry, and keeps CLI polling pending. Terminal authorization, credential, and policy failures remain terminal.

## Verification

- `npm test --prefix worker -- oauth-browser-binding.test.ts` — 11 passed
- `npm test --prefix worker` — 1,398 passed, 3 skipped
- `npm run format:check --prefix worker` — passed
- `npm run lint --prefix worker` — passed
- `npm run check --prefix worker` — passed
- `npm run build --prefix worker` — Wrangler dry-run passed
- `git diff --check origin/main...HEAD` — passed

No new secrets, configuration, or migrations are required. Merging changes under `worker/**` automatically triggers Deploy Coordinator.

## Isolated behavior proof

A source-blind contract was exercised against an isolated local Wrangler/workerd coordinator with SQLite-backed Durable Object state and a controlled mock GitHub upstream. No production traffic or real GitHub credentials were used.

- One-time user lookup sequence `503, 200`: the original callback completed with HTTP 303 and the OAuth token exchange count remained one.
- Persistent membership sequence `503, 503`: the callback returned HTTP 503 while authenticated polling remained HTTP 200 with `status: pending`.
- Pending storage contained no callback claim and retained only a sealed credential; the controlled plaintext credential was absent.
- After upstream recovery, callback retry completed with HTTP 303, polling returned `complete`, and the token exchange count was still one.
- The sealed pending credential was removed on callback completion, and the pending record was consumed after successful polling.
- A controlled terminal membership 401 remained terminal: callback HTTP 403, poll HTTP 400 `failed`, with credential cleanup.

Captured evidence omitted callback state, OAuth code, poll secret, browser confirmation, access token, cookies, sealed credential value, and target endpoints.
