### PR TITLE
fix(run): quiesce renewal before lease teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixed
 
+- Prevented confirmed `run --stop-after always` teardown from racing workspace-owner renewal and replacing successful, evidence-backed runs with exit 7. Thanks @coygeek.
 - Retried brief GitHub API failures during browser login and kept exhausted post-exchange attempts safely retryable instead of turning the next CLI poll into a terminal failure.
 - Bounded `crabbox claims list` inventory reads to 1 MiB per local claim while preserving valid partial output for oversized files. Thanks @coygeek.
 - Made local-container heartbeat authorize recorded dynamic runtime scopes and durably compare-and-swap exact claim lifecycle state without recreating or overwriting changed claims. Thanks @coygeek.

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -14,7 +14,8 @@ type App struct {
 	Stderr io.Writer
 	Stdin  io.Reader
 
-	runOutcome *shardRunOutcome
+	runOutcome             *shardRunOutcome
+	workspaceOwnerAcquirer func(context.Context, SSHTarget, string, io.Writer) (*workspaceOwner, error)
 }
 
 func Run(ctx context.Context, args []string) error {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -737,14 +737,6 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		if lifecycleOwner == nil {
 			return
 		}
-		if cleanup.Stopped {
-			if closeErr := lifecycleOwner.CloseAfterLeaseRelease(); closeErr != nil {
-				runFailure = recordRunFailure(&runFailure, closeErr)
-				err = errors.Join(err, closeErr)
-				fmt.Fprintf(a.Stderr, "warning: workspace owner stopped with released lease after renewal failure: %v\n", closeErr)
-			}
-			return
-		}
 		releaseCtx, cancel := context.WithTimeout(context.WithoutCancel(ownerParentCtx), 30*time.Second)
 		closeErr := lifecycleOwner.Close(releaseCtx)
 		cancel()
@@ -1045,13 +1037,13 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		}
 		if lifecycleOwner != nil {
 			inspectCtx, cancel := context.WithTimeout(context.WithoutCancel(ownerParentCtx), 15*time.Second)
-			ownerErr := lifecycleOwner.ConfirmNoChild(inspectCtx)
+			ownerErr := lifecycleOwner.QuiesceForLeaseRelease(inspectCtx)
 			cancel()
 			if ownerErr != nil {
 				cleanup.Err = ownerErr
 				runFailure = recordRunFailure(&runFailure, ownerErr)
 				err = errors.Join(err, ownerErr)
-				fmt.Fprintf(a.Stderr, "lease cleanup skipped while workspace child remains possible: %v\n", ownerErr)
+				fmt.Fprintf(a.Stderr, "lease cleanup skipped while workspace owner remains ambiguous: %v\n", ownerErr)
 				return
 			}
 		}
@@ -1063,6 +1055,8 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		cleanup.Err = releaseApp.releaseBackendLeaseBestEffort(context.Background(), sshBackend, cfg, LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: coord})
 		cleanup.Stopped = cleanup.Err == nil
 		if cleanup.Err == nil {
+			// Destructive cleanup owns the quiesced owner once the lease is gone.
+			lifecycleOwner = nil
 			recorder.Event("lease.released", "released", "")
 		}
 		if !*timingJSON {
@@ -1202,7 +1196,11 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 				fmt.Fprintf(a.Stderr, "network fallback %s\n", resolved.FallbackReason)
 			}
 		}
-		lifecycleOwner, err = acquireWorkspaceOwner(ctx, target, leaseID, a.Stderr)
+		if a.workspaceOwnerAcquirer != nil {
+			lifecycleOwner, err = a.workspaceOwnerAcquirer(ctx, target, leaseID, a.Stderr)
+		} else {
+			lifecycleOwner, err = acquireWorkspaceOwner(ctx, target, leaseID, a.Stderr)
+		}
 		if err != nil {
 			return recordFailure(err)
 		}

--- a/internal/cli/run_workspace_owner_cleanup_test.go
+++ b/internal/cli/run_workspace_owner_cleanup_test.go
@@ -1,0 +1,387 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type runCleanupWorkspaceOwnerTransport struct {
+	mu sync.Mutex
+
+	blockInspectAt int
+	inspectCount   int
+	renewErr       error
+	destroyed      atomic.Bool
+
+	renewStarted   chan struct{}
+	allowRenew     chan struct{}
+	renewFinished  chan struct{}
+	inspectStarted chan struct{}
+	allowInspect   chan struct{}
+	ownerReleased  chan struct{}
+
+	renewStartOnce   sync.Once
+	allowRenewOnce   sync.Once
+	renewFinishOnce  sync.Once
+	inspectOnce      sync.Once
+	allowInspectOnce sync.Once
+	ownerReleaseOnce sync.Once
+}
+
+func newRunCleanupWorkspaceOwnerTransport(blockInspectAt int, renewErr error) *runCleanupWorkspaceOwnerTransport {
+	return &runCleanupWorkspaceOwnerTransport{
+		blockInspectAt: blockInspectAt,
+		renewErr:       renewErr,
+		renewStarted:   make(chan struct{}),
+		allowRenew:     make(chan struct{}),
+		renewFinished:  make(chan struct{}),
+		inspectStarted: make(chan struct{}),
+		allowInspect:   make(chan struct{}),
+		ownerReleased:  make(chan struct{}),
+	}
+}
+
+func (r *runCleanupWorkspaceOwnerTransport) Do(ctx context.Context, req workspaceOwnerRemoteRequest) (string, error) {
+	switch req.Action {
+	case workspaceOwnerRenew:
+		r.renewStartOnce.Do(func() { close(r.renewStarted) })
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-r.allowRenew:
+		}
+		r.renewFinishOnce.Do(func() { close(r.renewFinished) })
+		if r.destroyed.Load() {
+			return "", errors.New("renew transport destroyed with lease")
+		}
+		if r.renewErr != nil {
+			return "", r.renewErr
+		}
+		return "RENEWED", nil
+	case workspaceOwnerInspect:
+		r.mu.Lock()
+		r.inspectCount++
+		blocked := r.inspectCount == r.blockInspectAt
+		r.mu.Unlock()
+		if blocked {
+			r.inspectOnce.Do(func() { close(r.inspectStarted) })
+			select {
+			case <-ctx.Done():
+				return "", ctx.Err()
+			case <-r.allowInspect:
+			}
+		}
+		return "OWNED", nil
+	case workspaceOwnerRelease:
+		r.ownerReleaseOnce.Do(func() { close(r.ownerReleased) })
+		return "RELEASED", nil
+	default:
+		return "", errors.New("unexpected workspace-owner action")
+	}
+}
+
+func (r *runCleanupWorkspaceOwnerTransport) unblockRenewal() {
+	r.allowRenewOnce.Do(func() { close(r.allowRenew) })
+}
+
+func (r *runCleanupWorkspaceOwnerTransport) unblockInspect() {
+	r.allowInspectOnce.Do(func() { close(r.allowInspect) })
+}
+
+func (r *runCleanupWorkspaceOwnerTransport) acquire(ctx context.Context, target SSHTarget, leaseID string, _ io.Writer) (*workspaceOwner, error) {
+	ownerCtx, cancel := context.WithCancel(ctx)
+	owner := &workspaceOwner{
+		target:    target,
+		transport: r,
+		key:       workspaceOwnerKey(leaseID),
+		token:     strings.Repeat("a", 64),
+		ttl:       time.Minute,
+		ctx:       ownerCtx,
+		cancel:    cancel,
+		stop:      make(chan struct{}),
+		done:      make(chan struct{}),
+	}
+	ticks := make(chan time.Time, 1)
+	go owner.renewLoopWithTicks(ticks, time.Minute)
+	ticks <- time.Now()
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-r.renewStarted:
+		return owner, nil
+	}
+}
+
+func waitRunCleanupSignal(t *testing.T, signal <-chan struct{}, label string) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for %s", label)
+	}
+}
+
+type runCleanupAsyncResult struct {
+	done chan struct{}
+	err  error
+}
+
+func startRunCleanupAsync(t *testing.T, remote *runCleanupWorkspaceOwnerTransport, run func(context.Context) error) *runCleanupAsyncResult {
+	t.Helper()
+	ctx, cancel := context.WithCancel(t.Context())
+	result := &runCleanupAsyncResult{done: make(chan struct{})}
+	go func() {
+		result.err = run(ctx)
+		close(result.done)
+	}()
+	t.Cleanup(func() {
+		remote.unblockInspect()
+		remote.unblockRenewal()
+		cancel()
+		select {
+		case <-result.done:
+		case <-time.After(5 * time.Second):
+			t.Errorf("run goroutine did not stop during cleanup")
+		}
+	})
+	return result
+}
+
+func (r *runCleanupAsyncResult) wait(t *testing.T) error {
+	t.Helper()
+	select {
+	case <-r.done:
+		return r.err
+	case <-time.After(5 * time.Second):
+		t.Fatal("run did not finish")
+		return nil
+	}
+}
+
+func assertRunCleanupExitCode(t *testing.T, err error, want int, stdout, stderr string) {
+	t.Helper()
+	if want == 0 {
+		if err != nil {
+			t.Fatalf("error=%v, want success\nstdout=%s\nstderr=%s", err, stdout, stderr)
+		}
+		return
+	}
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != want {
+		t.Fatalf("error=%v exit=%d, want %d\nstdout=%s\nstderr=%s", err, exitErr.Code, want, stdout, stderr)
+	}
+}
+
+func setupRunCleanupWorkspaceOwnerTest(t *testing.T) string {
+	t.Helper()
+	clearConfigEnv(t)
+	dir := t.TempDir()
+	isolateRunTestUserDirs(t, dir)
+	t.Chdir(dir)
+	sshPath := filepath.Join(dir, "ssh")
+	commandScript := `#!/bin/sh
+case "$1" in
+  *"base64 <"*) printf 'cHJvb2YtZG93bmxvYWRlZAo='; exit 0 ;;
+  *"renewal-cleanup-exit-23"*) exit 23 ;;
+esac
+exit 0
+`
+	installWorkspaceOwnerAwareSSH(t, sshPath, commandScript)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, "missing.yaml"))
+	t.Setenv("CRABBOX_FAKE_SSH_PORT", "22")
+	t.Setenv("CRABBOX_FAKE_SSH_PROXY", "1")
+	runEnvProfileTestAcquireLease = nil
+	runEnvProfileTestAcquireHook = nil
+	runEnvProfileTestReleaseHook = nil
+	runEnvProfileTestReleaseRequestHook = nil
+	runEnvProfileTestTouchHook = nil
+	runEnvProfileTestReleaseErr = nil
+	runEnvProfileTestConnectionCleanupSafe = true
+	t.Cleanup(func() {
+		runEnvProfileTestAcquireLease = nil
+		runEnvProfileTestAcquireHook = nil
+		runEnvProfileTestReleaseHook = nil
+		runEnvProfileTestReleaseRequestHook = nil
+		runEnvProfileTestTouchHook = nil
+		runEnvProfileTestReleaseErr = nil
+		runEnvProfileTestConnectionCleanupSafe = true
+		removeLeaseClaim("cbx_env_profile_test")
+	})
+	return dir
+}
+
+func TestRunCommandDestructiveCleanupQuiescesWorkspaceOwner(t *testing.T) {
+	tests := []struct {
+		name             string
+		command          string
+		renewErr         error
+		stopErr          error
+		download         bool
+		wantExit         int
+		wantStop         bool
+		wantOwnerRelease bool
+	}{
+		{name: "successful evidence-backed run", command: "renewal-cleanup-success", download: true, wantStop: true},
+		{name: "renewal fails before stop", command: "renewal-cleanup-success", renewErr: errors.New("renew response lost"), wantExit: 7, wantOwnerRelease: true},
+		{name: "stop is not confirmed", command: "renewal-cleanup-success", stopErr: errors.New("stop not confirmed"), wantExit: 7, wantStop: true, wantOwnerRelease: true},
+		{name: "remote command remains nonzero", command: "renewal-cleanup-exit-23", wantExit: 23, wantStop: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dir := setupRunCleanupWorkspaceOwnerTest(t)
+			remote := newRunCleanupWorkspaceOwnerTransport(2, test.renewErr)
+			releaseStarted := make(chan struct{})
+			var releaseOnce sync.Once
+			var releaseOvertookRenewal atomic.Bool
+			runEnvProfileTestReleaseHook = func() error {
+				remote.destroyed.Store(true)
+				releaseOnce.Do(func() { close(releaseStarted) })
+				select {
+				case <-remote.renewFinished:
+				default:
+					releaseOvertookRenewal.Store(true)
+					remote.unblockRenewal()
+				}
+				return test.stopErr
+			}
+
+			downloadPath := filepath.Join(dir, "proof.txt")
+			args := []string{
+				"--provider", runEnvProfileTestProvider{}.Name(),
+				"--id", "cbx_env_profile_test",
+				"--no-sync",
+				"--no-hydrate",
+				"--stop-after", "always",
+			}
+			if test.download {
+				args = append(args, "--download", "proof.txt="+downloadPath)
+			}
+			args = append(args, "--", test.command)
+			var stdout, stderr bytes.Buffer
+			ownerReady := make(chan *workspaceOwner, 1)
+			app := App{
+				Stdout: &stdout,
+				Stderr: &stderr,
+				workspaceOwnerAcquirer: func(ctx context.Context, target SSHTarget, leaseID string, stderr io.Writer) (*workspaceOwner, error) {
+					owner, err := remote.acquire(ctx, target, leaseID, stderr)
+					if err == nil {
+						ownerReady <- owner
+					}
+					return owner, err
+				},
+			}
+			result := startRunCleanupAsync(t, remote, func(ctx context.Context) error {
+				return app.runCommand(ctx, args)
+			})
+			var owner *workspaceOwner
+			select {
+			case owner = <-ownerReady:
+			case <-time.After(5 * time.Second):
+				t.Fatal("run did not acquire workspace owner")
+			}
+
+			waitRunCleanupSignal(t, remote.inspectStarted, "destructive-cleanup owner inspection")
+			if test.download {
+				data, err := os.ReadFile(downloadPath)
+				if err != nil || string(data) != "proof-downloaded\n" {
+					t.Fatalf("download before cleanup=%q err=%v", data, err)
+				}
+			}
+			remote.unblockInspect()
+			select {
+			case <-releaseStarted:
+				t.Fatal("destructive stop overtook workspace-owner renewal quiescence")
+			case <-time.After(5 * time.Second):
+				t.Fatal("workspace-owner renewal was not asked to quiesce")
+			case <-owner.stop:
+			}
+			select {
+			case <-releaseStarted:
+				t.Fatal("destructive stop began while renewal transport was still in flight")
+			default:
+			}
+			remote.unblockRenewal()
+
+			runErr := result.wait(t)
+			if releaseOvertookRenewal.Load() {
+				t.Fatal("backend release observed renewal still in flight")
+			}
+			assertRunCleanupExitCode(t, runErr, test.wantExit, stdout.String(), stderr.String())
+			select {
+			case <-releaseStarted:
+				if !test.wantStop {
+					t.Fatal("destructive stop ran after pre-stop renewal failure")
+				}
+			default:
+				if test.wantStop {
+					t.Fatal("destructive stop did not run")
+				}
+			}
+			select {
+			case <-remote.ownerReleased:
+				if !test.wantOwnerRelease {
+					t.Fatal("confirmed stop attempted a remote owner release")
+				}
+			default:
+				if test.wantOwnerRelease {
+					t.Fatal("failed or skipped stop did not release the remote owner")
+				}
+			}
+		})
+	}
+}
+
+func TestRunCommandRetainedLeaseRetainsFailClosedRenewal(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "new lease explicitly kept", args: []string{"--keep"}},
+		{name: "reused lease normal lifecycle", args: []string{"--id", "cbx_env_profile_test"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			setupRunCleanupWorkspaceOwnerTest(t)
+			remote := newRunCleanupWorkspaceOwnerTransport(1, errors.New("renew response lost"))
+			releaseStarted := make(chan struct{})
+			var releaseOnce sync.Once
+			runEnvProfileTestReleaseHook = func() error {
+				releaseOnce.Do(func() { close(releaseStarted) })
+				return nil
+			}
+			var stdout, stderr bytes.Buffer
+			app := App{Stdout: &stdout, Stderr: &stderr, workspaceOwnerAcquirer: remote.acquire}
+			args := []string{
+				"--provider", runEnvProfileTestProvider{}.Name(),
+				"--no-sync",
+				"--no-hydrate",
+			}
+			args = append(args, test.args...)
+			args = append(args, "--", "renewal-cleanup-success")
+			result := startRunCleanupAsync(t, remote, func(ctx context.Context) error {
+				return app.runCommand(ctx, args)
+			})
+			waitRunCleanupSignal(t, remote.inspectStarted, "post-command owner inspection")
+			remote.unblockInspect()
+			remote.unblockRenewal()
+			runErr := result.wait(t)
+			assertRunCleanupExitCode(t, runErr, 7, stdout.String(), stderr.String())
+			select {
+			case <-releaseStarted:
+				t.Fatal("retained lease was destructively stopped")
+			default:
+			}
+			waitRunCleanupSignal(t, remote.ownerReleased, "retained owner release")
+		})
+	}
+}

--- a/internal/cli/workspace_owner.go
+++ b/internal/cli/workspace_owner.go
@@ -279,17 +279,21 @@ func (o *workspaceOwner) Context() context.Context {
 }
 
 func (o *workspaceOwner) renewLoop(interval time.Duration) {
-	defer close(o.done)
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
+	o.renewLoopWithTicks(ticker.C, interval)
+}
+
+func (o *workspaceOwner) renewLoopWithTicks(ticks <-chan time.Time, callTimeout time.Duration) {
+	defer close(o.done)
 	for {
 		select {
 		case <-o.stop:
 			return
 		case <-o.ctx.Done():
 			return
-		case <-ticker.C:
-			callCtx, cancel := context.WithTimeout(context.WithoutCancel(o.ctx), interval)
+		case <-ticks:
+			callCtx, cancel := context.WithTimeout(context.WithoutCancel(o.ctx), callTimeout)
 			response, err := o.transport.Do(callCtx, workspaceOwnerRemoteRequest{Action: workspaceOwnerRenew, Key: o.key, Token: o.token, TTL: o.ttl})
 			cancel()
 			if err == nil && response == "RENEWED" {
@@ -398,10 +402,7 @@ func (o *workspaceOwner) Close(ctx context.Context) error {
 	if o == nil {
 		return nil
 	}
-	o.closeOnce.Do(func() {
-		close(o.stop)
-		<-o.done
-	})
+	o.stopRenewal()
 	renewErr := o.Err()
 	response, releaseErr := o.transport.Do(ctx, workspaceOwnerRemoteRequest{Action: workspaceOwnerRelease, Key: o.key, Token: o.token, TTL: o.ttl})
 	if releaseErr != nil {
@@ -412,15 +413,25 @@ func (o *workspaceOwner) Close(ctx context.Context) error {
 	return errors.Join(renewErr, releaseErr)
 }
 
-func (o *workspaceOwner) CloseAfterLeaseRelease() error {
+func (o *workspaceOwner) QuiesceForLeaseRelease(ctx context.Context) error {
 	if o == nil {
 		return nil
+	}
+	if err := o.ConfirmNoChild(ctx); err != nil {
+		return err
+	}
+	o.stopRenewal()
+	return o.Err()
+}
+
+func (o *workspaceOwner) stopRenewal() {
+	if o == nil {
+		return
 	}
 	o.closeOnce.Do(func() {
 		close(o.stop)
 		<-o.done
 	})
-	return o.Err()
 }
 
 func (o *workspaceOwner) wrapPOSIXCommand(remote string, preserveInput bool) string {


### PR DESCRIPTION
## Summary

Fix the stopped-lease renewal race reported in https://github.com/openclaw/crabbox/issues/1390 without weakening workspace-owner fail-closed behavior.

An SSH-backed run registered the workspace-owner close defer before the later lease-cleanup defer. Because defers execute in reverse order, `--stop-after always` could destroy the lease while a renewal transport was still in flight. The later owner close then joined the teardown-caused renewal error into an otherwise successful run after the command, requested evidence retrieval, and confirmed stop had all succeeded.

## Lifecycle design

Destructive lease cleanup now explicitly owns workspace-owner sequencing:

1. Confirm that no protected child remains.
2. Quiesce and join the renewal loop before destructive stop.
3. Preserve any genuine renewal ambiguity as exit 7 and skip destructive cleanup.
4. After confirmed stop, retire the quiesced owner without attempting a remote release against a destroyed lease.
5. If stop is not confirmed, leave the owner for the existing normal fail-closed release path.

This removes the obsolete post-release `CloseAfterLeaseRelease` error-joining path. Kept leases, normally reused leases, ready-pool handling, workspace fencing, child-liveness checks, renewal cancellation, command/proof/download failures, and POSIX/Windows transport behavior remain unchanged.

## Deterministic proof

The new run-level regression harness uses explicit channels and a fake SSH owner transport; it does not rely on timing sleeps. It holds renewal in flight, models lease destruction making that transport fail if cleanup overtakes it, and proves:

- successful command + downloaded evidence + confirmed stop returns 0;
- destructive stop cannot overtake renewal quiescence;
- renewal failure before stop remains exit 7 and skips destructive stop;
- unconfirmed stop remains exit 7 and uses normal owner release;
- remote command exit 23 remains 23;
- newly kept and normally reused leases remain non-destructive and fail closed with exit 7.

An independent source-blind rerun exercised the exact rebased binary (`4e6c6eb63d3bbda376741fa878936a6a5d85435d6b09aed0c9dae0d4acb5b762`) through public Tart/SSH/SCP surfaces with FIFO-controlled phases. Its exit matrix was `0 / 7 / 7 / 23 / 7 / 7` for successful held renewal, pre-stop ambiguity, unconfirmed stop, command failure, kept lease ambiguity, and reused lease ambiguity. The success ordering was renewal enter → command completion → evidence download → renewal completion → owner inspection → Tart stop → Tart delete, with no active lease, claim, key, or owner residue.

## Live proof

A real disposable AWS SSH-backed lease crossed the owner-renewal interval using the built CLI:

- provider: `aws`
- lease: `cbx_936922740495`
- run: https://crabbox.openclaw.ai/portal/runs/run_37a382afa393
- workload: write `proof-1390.txt`, wait 15 seconds, print success
- observed: command exit 0, 19-byte evidence downloaded with expected contents, timing JSON reported `runStatus: "succeeded"` and `leaseStopped: true`
- cleanup: subsequent AWS list returned no leases; the lease had no local claim, key, or owner record

A second real AWS run on `cbx_8c3257f30144` also returned 0 with downloaded evidence and confirmed stop. Real Tart proof was not safe on this host: `tart list` was empty and only 17 GiB was free, so pulling the configured macOS image would have risked exhausting disk. The deterministic source-blind Tart path therefore supplies the forced in-flight and pre-stop ambiguity proof; the real AWS run supplies live provider behavior.

## Verification

- `gofmt` / `git diff --check`
- `go vet ./...`
- focused cleanup/renewal race tests, including 20 repeated deterministic runs
- broader workspace-owner/run-cleanup race subset
- `go test -race ./internal/providers/ssh ./internal/providers/tart -count=1 -timeout=5m`
- provider sweep; two unrelated contention-sensitive timeout tests failed in the concurrent sweep, then each passed 10 isolated reruns
- CI dead-code gate
- `scripts/check-docs.sh`
- independent P1 autoreview: no accepted/actionable findings

Two bounded attempts at the monolithic `internal/cli` suite hit unrelated existing hangs/timeouts in ready-pool/watch/VNC/run-script tests; the changed lifecycle tests and adjacent suites remained green. Fresh exact-head CI is required before this PR is considered ready.

## Credit

Thanks @coygeek for the report, root-cause analysis, and deterministic closure criteria.

Closes https://github.com/openclaw/crabbox/issues/1390
