### PR TITLE
feat(install): support versioned go install

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,7 @@
 /scripts/*publish* @openclaw/openclaw-secops
 /scripts/codesign-* @openclaw/openclaw-secops
 /scripts/render-homebrew-formula.mjs @openclaw/openclaw-secops
+/scripts/verify-go-install.sh @openclaw/openclaw-secops
 /scripts/verify-macos-* @openclaw/openclaw-secops
 
 # Every eventually executed Apple VM Mach-O shares this boundary.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,24 @@ jobs:
       - name: Build
         run: go build -trimpath -o /tmp/crabbox ./cmd/crabbox
 
+  go-install:
+    name: Direct Go install
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Verify versioned remote module installation
+        run: scripts/verify-go-install.sh v0.0.0 "$(git rev-parse HEAD)"
+
   windows-pond-mesh-cancellation:
     name: Windows Pond Mesh Cancellation
     runs-on: windows-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added credential-free `crabbox providers describe` discovery for canonical provider-scoped run flags and compiled defaults. Thanks @coygeek.
+- Added supported versioned `go install` as a CLI-only installation channel, with clean module dependency semantics, source-derived release and revision versions, and hermetic release verification. Thanks @coygeek.
 - Added an opt-in Linux/WSL2 `raw_socket` preflight probe that distinguishes direct, non-interactive-sudo, unavailable, and missing-interpreter states without sending packets or elevating workloads. Thanks @coygeek.
 - Added checkpoint last-use tracking and composable `checkpoint prune --unused-for` cleanup for inactive local records and provider artifacts.
 - Added provider-native create, verify, delete, and fork lifecycle for direct Hetzner project-snapshot checkpoints, including exact local-claim image deletion.

--- a/README.md
+++ b/README.md
@@ -137,20 +137,35 @@ doc-to-code map, see [Source Map](docs/source-map.md).
 
 ## Install
 
+Homebrew installs the complete release distribution:
+
 ```sh
 brew install openclaw/tap/crabbox
 crabbox --version
 ```
 
-No Homebrew? Grab a [GoReleaser archive](https://github.com/openclaw/crabbox/releases)
-for macOS, Linux, or Windows.
+The [release archives](https://github.com/openclaw/crabbox/releases) are the
+other complete distribution for macOS, Linux, and Windows. Go users can instead
+compile and install only the CLI from an explicit release version (supported
+starting with v0.44.0; do not use `@latest` while older releases remain visible):
+
+```sh
+go install github.com/openclaw/crabbox/cmd/crabbox@v0.44.0
+```
+
+The module requires Go 1.26 and declares go1.26.5 as its preferred toolchain;
+use Go 1.26.5 or newer, or leave Go's automatic toolchain selection enabled.
+`go install` builds the Go CLI locally. It does not install release companion
+executables or assets, especially `crabbox-apple-vm-helper`, and it is not the
+signed/notarized prebuilt distribution. Use Homebrew or a release archive for
+complete platform capabilities, notably the Apple VM provider on Apple Silicon.
 
 Supported WSL2 and x64 no-WSL Windows transfer selection requires a build from
 current `main` or Crabbox v0.42.1 and newer. Follow the
 [Windows installation guide](docs/windows-install.md) for the supported setup.
 
 The Apple Silicon Homebrew install uses the release archive that also contains
-the native `crabbox-apple-vm-helper` for the local Apple VZ provider.
+the native `crabbox-apple-vm-helper` for the local Apple VM provider.
 
 Laptop prerequisites: `git`, `ssh`, `ssh-keygen`, `rsync`, `curl`.
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -71,6 +71,12 @@ Production macOS packaging runs locally on a trusted Mac through the shared
 managed-keychain release wrapper. Signing keys and notary credentials remain in
 the local keychain/approved secret store and never enter GitHub Actions or Git.
 
+Before GoReleaser runs, the credential-free producer calls
+`scripts/verify-go-install.sh` with the actual release tag and peeled source
+commit. That gate constructs a complete read-only local module proxy from the
+exact commit and verifies a cold, version-suffixed `go install` outside the
+checkout. It must pass before candidate production begins.
+
 Run the credential-free producer first and capture its printed manifest digest:
 
 ```sh
@@ -343,6 +349,45 @@ gh run watch "$PUBLIC_VERIFIER_RUN_ID" \
   --repo openclaw/crabbox --exit-status
 ```
 
+Prove the newly public source-install channel from the public Go module proxy,
+not from a checkout, local proxy, or direct VCS fallback. Use fresh state and
+require the exact public tag, fork dependency, replacement-free build metadata,
+version, and help surfaces:
+
+```sh
+PUBLIC_GO_INSTALL=$(mktemp -d "${TMPDIR:-/tmp}/crabbox-public-go-install.XXXXXX")
+mkdir -m 700 \
+  "$PUBLIC_GO_INSTALL/home" "$PUBLIC_GO_INSTALL/gopath" \
+  "$PUBLIC_GO_INSTALL/gomodcache" "$PUBLIC_GO_INSTALL/gocache" \
+  "$PUBLIC_GO_INSTALL/bin" "$PUBLIC_GO_INSTALL/tmp" "$PUBLIC_GO_INSTALL/work"
+(
+  cd "$PUBLIC_GO_INSTALL/work"
+  env -i \
+    GOBIN="$PUBLIC_GO_INSTALL/bin" GOCACHE="$PUBLIC_GO_INSTALL/gocache" \
+    GOENV=off GOMODCACHE="$PUBLIC_GO_INSTALL/gomodcache" \
+    GOPATH="$PUBLIC_GO_INSTALL/gopath" GOPROXY=https://proxy.golang.org \
+    GOSUMDB=sum.golang.org GOTOOLCHAIN=local GOWORK=off \
+    HOME="$PUBLIC_GO_INSTALL/home" PATH="$PATH" TMPDIR="$PUBLIC_GO_INSTALL/tmp" \
+    go install "github.com/openclaw/crabbox/cmd/crabbox@$TAG"
+)
+go version -m -json "$PUBLIC_GO_INSTALL/bin/crabbox" >"$PUBLIC_GO_INSTALL/build.json"
+jq -e --arg version "$TAG" \
+  --arg forkVersion v6.0.3-0.20260817142523-966654abed4a '
+  .Path == "github.com/openclaw/crabbox/cmd/crabbox" and
+  .Main.Path == "github.com/openclaw/crabbox" and
+  .Main.Version == $version and .Main.Replace == null and
+  ([.Deps[] | select(
+    .Path == "github.com/steipete/jsonschema/v6" and
+    .Version == $forkVersion and .Replace == null
+  )] | length == 1) and
+  ([.Deps[] | select(.Replace != null)] | length == 0) and
+  ([.Deps[] | select(.Path == "github.com/santhosh-tekuri/jsonschema/v6")] | length == 0)
+' "$PUBLIC_GO_INSTALL/build.json"
+test "$(cd "$PUBLIC_GO_INSTALL/work" && "$PUBLIC_GO_INSTALL/bin/crabbox" --version)" = "${TAG#v}"
+(cd "$PUBLIC_GO_INSTALL/work" && "$PUBLIC_GO_INSTALL/bin/crabbox" --help >/dev/null 2>&1)
+(cd "$PUBLIC_GO_INSTALL/work" && "$PUBLIC_GO_INSTALL/bin/crabbox" run --help >/dev/null 2>&1)
+```
+
 Only after that public run and a separate tap-update authorization, update the
 formula with the four verified public archive hashes. Generate the only
 accepted Ruby program with protected tooling (the four digest arguments are
@@ -536,7 +581,16 @@ provenance, native architecture, signature, online notarization, and clean
 candidate-execution checks. The successful public verifier run must be newer
 than the publication and every release or asset update.
 
-### 5. Update and prove Homebrew
+### 5. Verify public Go installation
+
+Install `github.com/openclaw/crabbox/cmd/crabbox@$TAG` from the public Go module
+proxy with the fresh, proxy-only procedure above. This gate is distinct from
+the pre-release hermetic fixture: it proves that the actual published tag is
+remotely resolvable. Preserve its structured build metadata with the release
+proof. Do not substitute a checkout, `replace`, pseudo-version, local proxy, or
+`,direct` fallback.
+
+### 6. Update and prove Homebrew
 
 Homebrew mutation needs a final separate authorization and a successful public
 verifier proof. Re-download the frozen public assets immediately before the tap

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -36,6 +36,22 @@ configured; run `crabbox providers recommend` to compare options.
 If you do not use Homebrew, GitHub Releases ship signed archives for macOS,
 Linux, and Windows. Download the matching archive from
 <https://github.com/openclaw/crabbox/releases>.
+
+Go users can install only the CLI from an explicit release version. This
+channel is supported starting with v0.44.0; do not use `@latest` while older,
+incompatible releases remain visible:
+
+```sh
+go install github.com/openclaw/crabbox/cmd/crabbox@v0.44.0
+```
+
+The module requires Go 1.26 and declares go1.26.5 as its preferred toolchain;
+use Go 1.26.5 or newer, or leave automatic toolchain selection enabled. This
+command compiles the Go CLI locally. It does not install release companion
+executables or assets, especially `crabbox-apple-vm-helper`, and it is not the
+signed/notarized prebuilt distribution. Use Homebrew or a release archive for
+the complete platform distribution, notably Apple VM support on Apple Silicon.
+
 Supported WSL2 and x64 no-WSL Windows transfer selection requires a build from
 current `main` or Crabbox v0.42.1 and newer. See the
 [supported Windows installation](windows-install.md) for the complete setup.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -789,6 +789,7 @@ Before creating or reusing a signed release tag:
 - `go vet ./...`
 - `go test -race ./...`
 - `scripts/test-go-modules.sh`
+- `scripts/verify-go-install.sh v0.0.0 "$(git rev-parse HEAD)"`
 - `go build -trimpath -o bin/crabbox ./cmd/crabbox`
 - `scripts/check-go-coverage.sh 90.0`
 - Worker gate: `npm run format:check --prefix worker && npm run lint --prefix worker && npm run check --prefix worker && npm test --prefix worker && npm run build --prefix worker`
@@ -830,7 +831,14 @@ Then advance exactly one gate at a time:
    ID and repeat the exact metadata, checksum, signature, notarization, native
    execution, and notes proof. The proof must be newer than publication and
    every release or asset mutation.
-7. **Homebrew.** Only after published verification, grant a separate tap-update
+7. **Public Go installation.** From fresh `HOME`, `GOPATH`, module/build caches,
+   and `GOBIN`, install
+   `github.com/openclaw/crabbox/cmd/crabbox@vX.Y.Z` using only the public Go
+   module proxy. Require exact replacement-free build metadata, the immutable
+   JSON Schema fork version, exact `--version`, `--help`, and `run --help` as
+   documented in [Release engineering](RELEASING.md#operator-command-sequence).
+8. **Homebrew.** Only after published verification and the public Go-install
+   proof, grant a separate tap-update
    gate. Bind every formula URL and SHA-256 to the frozen release record, then
    run the documented downstream verifier on clean native Apple Silicon and
    Intel hosts. The verifier re-fetches the current public release and run,

--- a/docs/providers/apple-vm.md
+++ b/docs/providers/apple-vm.md
@@ -77,6 +77,11 @@ to `Virtualization.framework`. A managed daemon is refreshed only when its
 signed copy no longer matches the recorded SHA-256 digest, and older inactive
 copies are pruned as new versions are installed.
 
+Direct `go install github.com/openclaw/crabbox/cmd/crabbox@vX.Y.Z` installs
+only the CLI, not this helper or its embedded daemon. It therefore does not
+provide the complete Apple VM distribution; use Homebrew or the Apple Silicon
+release archive when this provider is required.
+
 For source development:
 
 ```sh

--- a/go.mod
+++ b/go.mod
@@ -48,11 +48,9 @@ require (
 	nhooyr.io/websocket v1.8.17
 )
 
-require github.com/santhosh-tekuri/jsonschema/v6 v6.0.3-0.20260218184449-befd2c18b2f0
+require github.com/steipete/jsonschema/v6 v6.0.3-0.20260817142523-966654abed4a
 
 require golang.org/x/sync v0.22.0 // indirect
-
-replace github.com/santhosh-tekuri/jsonschema/v6 => github.com/steipete/jsonschema/v6 v6.0.3-0.20260717053323-7235d3ee9642
 
 require (
 	cloud.google.com/go/auth v0.20.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -892,8 +892,8 @@ github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980/go.mod h1:AO3tvPzVZ/ayst6UlUKUv6rcPQInYe3IknH3jYhAKu8=
-github.com/steipete/jsonschema/v6 v6.0.3-0.20260717053323-7235d3ee9642 h1:HBzDWz/MdDSutJjGP0hCU4q5hVzFXyoAafLaTsWdPBY=
-github.com/steipete/jsonschema/v6 v6.0.3-0.20260717053323-7235d3ee9642/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
+github.com/steipete/jsonschema/v6 v6.0.3-0.20260817142523-966654abed4a h1:LNuURnj9QEg3Ngss4/f6KrWYKG9TDDRkpo6YLs5dips=
+github.com/steipete/jsonschema/v6 v6.0.3-0.20260817142523-966654abed4a/go.mod h1:UnJZm3hcrooNZOAJ5r0xcldGiPgnaxt0uxN6aJOup6c=
 github.com/stretchr/objx v0.0.0-20180129172003-8a3f7159479f/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/internal/cli/run_artifact_schema.go
+++ b/internal/cli/run_artifact_schema.go
@@ -21,7 +21,7 @@ import (
 	"unicode/utf8"
 
 	regexp2syntax "github.com/dlclark/regexp2/syntax"
-	jsonschema "github.com/santhosh-tekuri/jsonschema/v6"
+	jsonschema "github.com/steipete/jsonschema/v6"
 )
 
 const (

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -19,7 +19,7 @@ func resolveVersion(injected, buildInfoVersion string) string {
 	if normalized := normalizeBuildVersion(injected); normalized != "" && normalized != "dev" && !strings.HasSuffix(normalized, "-dev") {
 		return normalized
 	}
-	if normalized := normalizeTaggedBuildInfoVersion(buildInfoVersion); normalized != "" {
+	if normalized := normalizeModuleBuildInfoVersion(buildInfoVersion); normalized != "" {
 		return normalized
 	}
 	if normalized := normalizeBuildVersion(injected); normalized != "" {
@@ -36,34 +36,10 @@ func normalizeBuildVersion(value string) string {
 	return strings.TrimPrefix(value, "v")
 }
 
-func normalizeTaggedBuildInfoVersion(value string) string {
+func normalizeModuleBuildInfoVersion(value string) string {
 	value = strings.TrimSpace(value)
 	if value == "" || value == "(devel)" || !strings.HasPrefix(value, "v") || strings.Contains(value, "+") {
 		return ""
 	}
-	value = strings.TrimPrefix(value, "v")
-	if isPseudoVersion(value) {
-		return ""
-	}
-	return value
-}
-
-func isPseudoVersion(value string) bool {
-	parts := strings.Split(value, "-")
-	if len(parts) < 3 {
-		return false
-	}
-	candidate := parts[len(parts)-2]
-	if dot := strings.LastIndex(candidate, "."); dot >= 0 {
-		candidate = candidate[dot+1:]
-	}
-	if len(candidate) != 14 {
-		return false
-	}
-	for _, ch := range candidate {
-		if ch < '0' || ch > '9' {
-			return false
-		}
-	}
-	return true
+	return strings.TrimPrefix(value, "v")
 }

--- a/internal/cli/version_test.go
+++ b/internal/cli/version_test.go
@@ -18,10 +18,10 @@ func TestResolveVersionUsesTaggedBuildInfoForDevDefault(t *testing.T) {
 	}
 }
 
-func TestResolveVersionKeepsDevForPseudoBuildInfo(t *testing.T) {
+func TestResolveVersionUsesPseudoBuildInfoForRevisionInstall(t *testing.T) {
 	got := resolveVersion("dev", "v1.2.4-0.20260810123456-abcdef123456")
-	if got != "dev" {
-		t.Fatalf("version=%q want dev", got)
+	if got != "1.2.4-0.20260810123456-abcdef123456" {
+		t.Fatalf("version=%q want normalized pseudo-version", got)
 	}
 }
 
@@ -60,10 +60,10 @@ func TestResolveVersionIgnoresDevelBuildInfo(t *testing.T) {
 	}
 }
 
-func TestResolveVersionIgnoresPseudoBuildInfo(t *testing.T) {
+func TestResolveVersionUsesPseudoBuildInfoBeforeInjectedDevFallback(t *testing.T) {
 	got := resolveVersion("0.13.0-dev", "v0.13.1-0.20260514070813-eb9404600773")
-	if got != "0.13.0-dev" {
-		t.Fatalf("version=%q want 0.13.0-dev", got)
+	if got != "0.13.1-0.20260514070813-eb9404600773" {
+		t.Fatalf("version=%q want normalized pseudo-version", got)
 	}
 }
 

--- a/scripts/build-release-candidate.sh
+++ b/scripts/build-release-candidate.sh
@@ -100,6 +100,7 @@ if [[ -n "${DEVELOPER_DIR:-}" ]]; then
     exit 1
   }
 fi
+"$ROOT/scripts/verify-go-install.sh" "$TAG" "$TAG_COMMIT"
 git clone --quiet --no-local --no-checkout "$ROOT" "$SOURCE"
 git -C "$SOURCE" checkout --quiet --detach "$TAG_COMMIT"
 [[ "$(git -C "$SOURCE" rev-parse "refs/tags/$TAG")" == "$TAG_OBJECT" ]]

--- a/scripts/release-workflow.test.js
+++ b/scripts/release-workflow.test.js
@@ -413,6 +413,35 @@ test("GoReleaser is credential-free build-only with exact binary archives", () =
   assert.doesNotMatch(build, /gh release|HOMEBREW_TAP_GITHUB_TOKEN=.*\$\{/);
 });
 
+test("versioned Go installation is hermetic and precedes release builds", () => {
+  const gate = read("scripts/verify-go-install.sh");
+  assert.match(gate, /go install "\$MODULE\/cmd\/crabbox@\$VERSION"/);
+  assert.match(gate, /GOPROXY="file:\/\/\$PROXY" GOSUMDB=off GOTOOLCHAIN=local GOWORK=off/);
+  assert.match(gate, /GOPROXY=https:\/\/proxy\.golang\.org GOSUMDB=sum\.golang\.org/);
+  assert.doesNotMatch(gate, /proxy\.golang\.org,direct/);
+  assert.match(gate, /GOENV=off GOMODCACHE="\$INSTALL_MODCACHE" GOPATH="\$INSTALL_GOPATH"/);
+  assert.match(gate, /go version -m -json "\$BINARY"/);
+  assert.match(gate, /github\.com\/steipete\/jsonschema\/v6/);
+  assert.match(gate, /dependency\.Replace != nil/);
+  assert.match(gate, /"\$BINARY" --help/);
+  assert.match(gate, /"\$BINARY" run --help/);
+  assert.doesNotMatch(gate, /-mindepth|< <\(find|find "\$ZIP_SOURCE"/);
+  assert.match(gate, /func sanitizeNestedModules\(root string\)[\s\S]*filepath\.Walk\(root/);
+  assert.match(gate, /path != rootGoMod[\s\S]*os\.RemoveAll\(dir\)/);
+  assert.match(gate, /go run "\$VERIFY_GO" sanitize-zip "\$ZIP_SOURCE"/);
+
+  const ci = read(".github/workflows/ci.yml");
+  assert.match(ci, /scripts\/verify-go-install\.sh v0\.0\.0 "\$\(git rev-parse HEAD\)"/);
+
+  const producer = read("scripts/build-release-candidate.sh");
+  const gateIndex = producer.indexOf('verify-go-install.sh" "$TAG" "$TAG_COMMIT"');
+  const releaseIndex = producer.indexOf("goreleaser release --clean --skip=publish");
+  assert.ok(gateIndex >= 0 && gateIndex < releaseIndex);
+
+  const codeowners = read(".github/CODEOWNERS");
+  assert.match(codeowners, /^\/scripts\/verify-go-install\.sh @openclaw\/openclaw-secops$/m);
+});
+
 test("release config emits the exact immutable eight-asset inventory", () => {
   const config = path.join(repoRoot, "scripts", "release-config.sh");
   const output = execFileSync(config, ["assets", "v0.37.0"], { encoding: "utf8" })

--- a/scripts/verify-go-install.sh
+++ b/scripts/verify-go-install.sh
@@ -1,0 +1,349 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+MODULE=github.com/openclaw/crabbox
+FORK_VERSION=v6.0.3-0.20260817142523-966654abed4a
+VERSION=${1:-}
+SOURCE_REF=${2:-}
+
+fail() {
+  echo "go install verification failed: $*" >&2
+  exit 1
+}
+
+if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ || -z "$SOURCE_REF" ]]; then
+  echo "usage: $0 vX.Y.Z <exact-source-ref>" >&2
+  exit 2
+fi
+for tool in git go tar zip; do
+  command -v "$tool" >/dev/null || fail "missing required tool: $tool"
+done
+
+SOURCE_COMMIT=$(git -C "$ROOT" rev-parse --verify "${SOURCE_REF}^{commit}")
+[[ "$SOURCE_COMMIT" =~ ^[0-9a-f]{40}$ ]] || fail "source ref did not resolve to a commit"
+
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/crabbox-go-install.XXXXXX")
+cleanup() {
+  chmod -R u+w "$WORK" 2>/dev/null || true
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+SOURCE="$WORK/source"
+PROXY="$WORK/proxy"
+SEED_HOME="$WORK/seed-home"
+SEED_MODCACHE="$WORK/seed-modcache"
+SEED_GOCACHE="$WORK/seed-gocache"
+SEED_TMP="$WORK/seed-tmp"
+mkdir -m 700 "$SOURCE" "$PROXY" "$SEED_HOME" "$SEED_MODCACHE" "$SEED_GOCACHE" "$SEED_TMP"
+git -C "$ROOT" archive "$SOURCE_COMMIT" | tar -xf - -C "$SOURCE"
+
+VERIFY_GO="$WORK/verify.go"
+cat >"$VERIFY_GO" <<'EOF'
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const (
+	modulePath  = "github.com/openclaw/crabbox"
+	forkPath    = "github.com/steipete/jsonschema/v6"
+	upstreamPath = "github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+type module struct {
+	Path    string  `json:"Path"`
+	Version string  `json:"Version"`
+	Replace *module `json:"Replace"`
+}
+
+func fatalf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}
+
+func decode(path string, value any) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		fatalf("read %s: %v", path, err)
+	}
+	if err := json.Unmarshal(data, value); err != nil {
+		fatalf("decode %s: %v", path, err)
+	}
+}
+
+func verifySource(modJSON, sourceRoot, forkVersion string) {
+	var edit struct {
+		Module  module
+		Require []struct {
+			Path     string
+			Version  string
+			Indirect bool
+		}
+		Replace []json.RawMessage
+	}
+	decode(modJSON, &edit)
+	if edit.Module.Path != modulePath {
+		fatalf("module path=%q want %q", edit.Module.Path, modulePath)
+	}
+	if len(edit.Replace) != 0 {
+		fatalf("go.mod contains replacement directives")
+	}
+	forkRequires := 0
+	for _, requirement := range edit.Require {
+		switch requirement.Path {
+		case forkPath:
+			forkRequires++
+			if requirement.Version != forkVersion || requirement.Indirect {
+				fatalf("fork requirement=%s indirect=%t want %s direct", requirement.Version, requirement.Indirect, forkVersion)
+			}
+		case upstreamPath:
+			fatalf("go.mod still requires upstream JSON Schema module")
+		}
+	}
+	if forkRequires != 1 {
+		fatalf("direct fork requirement count=%d want 1", forkRequires)
+	}
+
+	forkImports := 0
+	err := filepath.Walk(sourceRoot, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			if info.Name() == "vendor" || info.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(info.Name(), ".go") {
+			return nil
+		}
+		file, err := parser.ParseFile(token.NewFileSet(), path, nil, parser.ImportsOnly)
+		if err != nil {
+			return err
+		}
+		for _, spec := range file.Imports {
+			value, err := strconv.Unquote(spec.Path.Value)
+			if err != nil {
+				return err
+			}
+			switch value {
+			case forkPath:
+				forkImports++
+			case upstreamPath:
+				fatalf("source still imports upstream JSON Schema module: %s", path)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		fatalf("inspect source imports: %v", err)
+	}
+	if forkImports == 0 {
+		fatalf("source does not directly import the JSON Schema fork")
+	}
+}
+
+func verifyBinary(metadataPath, version, forkVersion string) {
+	var info struct {
+		Path string
+		Main module
+		Deps []module
+	}
+	decode(metadataPath, &info)
+	if info.Path != modulePath+"/cmd/crabbox" {
+		fatalf("binary package=%q want %q", info.Path, modulePath+"/cmd/crabbox")
+	}
+	if info.Main.Path != modulePath || info.Main.Version != version || info.Main.Replace != nil {
+		fatalf("binary main=%s@%s replacement=%t want %s@%s without replacement", info.Main.Path, info.Main.Version, info.Main.Replace != nil, modulePath, version)
+	}
+	forkDeps := 0
+	for _, dependency := range info.Deps {
+		if dependency.Replace != nil {
+			fatalf("binary dependency %s contains a replacement record", dependency.Path)
+		}
+		switch dependency.Path {
+		case forkPath:
+			forkDeps++
+			if dependency.Version != forkVersion {
+				fatalf("binary fork dependency=%s want %s", dependency.Version, forkVersion)
+			}
+		case upstreamPath:
+			fatalf("binary contains upstream JSON Schema dependency")
+		}
+	}
+	if forkDeps != 1 {
+		fatalf("binary fork dependency count=%d want 1", forkDeps)
+	}
+}
+
+func sanitizeNestedModules(root string) {
+	root = filepath.Clean(root)
+	rootGoMod := filepath.Join(root, "go.mod")
+	var nested []string
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.Mode().IsRegular() && info.Name() == "go.mod" && path != rootGoMod {
+			nested = append(nested, filepath.Dir(path))
+		}
+		return nil
+	})
+	if err != nil {
+		fatalf("inspect nested modules: %v", err)
+	}
+	sort.Slice(nested, func(i, j int) bool {
+		return len(nested[i]) > len(nested[j])
+	})
+	for _, dir := range nested {
+		if err := os.RemoveAll(dir); err != nil {
+			fatalf("remove nested module %q: %v", dir, err)
+		}
+	}
+	err = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.Mode().IsRegular() && info.Name() == "go.mod" && path != rootGoMod {
+			return fmt.Errorf("nested module remains: %q", path)
+		}
+		return nil
+	})
+	if err != nil {
+		fatalf("verify nested module cleanup: %v", err)
+	}
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fatalf("missing verifier action")
+	}
+	switch os.Args[1] {
+	case "source":
+		if len(os.Args) != 5 {
+			fatalf("source verifier expects mod-json, source-root, and fork-version")
+		}
+		verifySource(os.Args[2], os.Args[3], os.Args[4])
+	case "binary":
+		if len(os.Args) != 5 {
+			fatalf("binary verifier expects metadata, version, and fork-version")
+		}
+		verifyBinary(os.Args[2], os.Args[3], os.Args[4])
+	case "sanitize-zip":
+		if len(os.Args) != 3 {
+			fatalf("zip sanitizer expects a module root")
+		}
+		sanitizeNestedModules(os.Args[2])
+	default:
+		fatalf("unknown verifier action %q", os.Args[1])
+	}
+}
+
+EOF
+
+MOD_JSON="$WORK/go-mod.json"
+(
+  cd "$SOURCE"
+  env -i \
+    GOENV=off GOTOOLCHAIN=local GOWORK=off \
+    HOME="$SEED_HOME" PATH="$PATH" TMPDIR="$SEED_TMP" \
+    go mod edit -json >"$MOD_JSON"
+)
+env -i \
+  GOCACHE="$SEED_GOCACHE" GOENV=off GOTOOLCHAIN=local GOWORK=off \
+  HOME="$SEED_HOME" PATH="$PATH" TMPDIR="$SEED_TMP" \
+  go run "$VERIFY_GO" source "$MOD_JSON" "$SOURCE" "$FORK_VERSION"
+
+# Download the complete selected dependency graph into an isolated cache, then
+# copy the proxy-form cache entries. Network access ends before the install.
+(
+  cd "$SOURCE"
+  env -i \
+    GOCACHE="$SEED_GOCACHE" GOMODCACHE="$SEED_MODCACHE" \
+    GOENV=off GOPROXY=https://proxy.golang.org GOSUMDB=sum.golang.org \
+    GOTOOLCHAIN=local GOWORK=off \
+    HOME="$SEED_HOME" PATH="$PATH" TMPDIR="$SEED_TMP" \
+    go mod download all
+)
+[[ -d "$SEED_MODCACHE/cache/download" ]] || fail "dependency download did not create proxy cache metadata"
+cp -R "$SEED_MODCACHE/cache/download/." "$PROXY/"
+
+MODULE_PROXY="$PROXY/github.com/openclaw/crabbox/@v"
+mkdir -p "$MODULE_PROXY"
+cp "$SOURCE/go.mod" "$MODULE_PROXY/$VERSION.mod"
+COMMIT_TIME=$(git -C "$ROOT" show -s --format=%cI "$SOURCE_COMMIT")
+printf '{"Version":"%s","Time":"%s"}\n' "$VERSION" "$COMMIT_TIME" >"$MODULE_PROXY/$VERSION.info"
+printf '%s\n' "$VERSION" >"$MODULE_PROXY/list"
+
+# A proxy module zip excludes nested modules. Stage the tracked source under
+# the required module@version prefix and remove each nested module subtree.
+ZIP_ROOT="$WORK/module-zip"
+ZIP_SOURCE="$ZIP_ROOT/$MODULE@$VERSION"
+mkdir -p "$(dirname "$ZIP_SOURCE")"
+cp -R "$SOURCE" "$ZIP_SOURCE"
+env -i \
+  GOCACHE="$SEED_GOCACHE" GOENV=off GOTOOLCHAIN=local GOWORK=off \
+  HOME="$SEED_HOME" PATH="$PATH" TMPDIR="$SEED_TMP" \
+  go run "$VERIFY_GO" sanitize-zip "$ZIP_SOURCE"
+(
+  cd "$ZIP_ROOT"
+  zip -q -X -r "$MODULE_PROXY/$VERSION.zip" "$MODULE@$VERSION"
+)
+chmod -R a-w "$PROXY"
+
+INSTALL_ROOT="$WORK/install"
+INSTALL_HOME="$INSTALL_ROOT/home"
+INSTALL_GOPATH="$INSTALL_ROOT/gopath"
+INSTALL_MODCACHE="$INSTALL_ROOT/gomodcache"
+INSTALL_GOCACHE="$INSTALL_ROOT/gocache"
+INSTALL_GOBIN="$INSTALL_ROOT/bin"
+INSTALL_TMP="$INSTALL_ROOT/tmp"
+INSTALL_CWD="$INSTALL_ROOT/work"
+mkdir -m 700 "$INSTALL_ROOT"
+mkdir -m 700 \
+  "$INSTALL_HOME" "$INSTALL_GOPATH" "$INSTALL_MODCACHE" "$INSTALL_GOCACHE" \
+  "$INSTALL_GOBIN" "$INSTALL_TMP" "$INSTALL_CWD"
+
+(
+  cd "$INSTALL_CWD"
+  env -i \
+    GOBIN="$INSTALL_GOBIN" GOCACHE="$INSTALL_GOCACHE" \
+    GOENV=off GOMODCACHE="$INSTALL_MODCACHE" GOPATH="$INSTALL_GOPATH" \
+    GOPROXY="file://$PROXY" GOSUMDB=off GOTOOLCHAIN=local GOWORK=off \
+    HOME="$INSTALL_HOME" PATH="$PATH" TMPDIR="$INSTALL_TMP" \
+    go install "$MODULE/cmd/crabbox@$VERSION"
+)
+
+BINARY="$INSTALL_GOBIN/crabbox"
+[[ -x "$BINARY" ]] || fail "go install did not produce an executable"
+METADATA="$WORK/build-metadata.json"
+env -i \
+  GOENV=off GOTOOLCHAIN=local HOME="$INSTALL_HOME" PATH="$PATH" TMPDIR="$INSTALL_TMP" \
+  go version -m -json "$BINARY" >"$METADATA"
+env -i \
+  GOCACHE="$SEED_GOCACHE" GOENV=off GOTOOLCHAIN=local GOWORK=off \
+  HOME="$SEED_HOME" PATH="$PATH" TMPDIR="$SEED_TMP" \
+  go run "$VERIFY_GO" binary "$METADATA" "$VERSION" "$FORK_VERSION"
+
+EXPECTED_VERSION=${VERSION#v}
+ACTUAL_VERSION=$(cd "$INSTALL_CWD" && env -i HOME="$INSTALL_HOME" PATH="$PATH" TMPDIR="$INSTALL_TMP" "$BINARY" --version)
+[[ "$ACTUAL_VERSION" == "$EXPECTED_VERSION" ]] || fail "crabbox --version=$ACTUAL_VERSION want $EXPECTED_VERSION"
+(
+  cd "$INSTALL_CWD"
+  env -i HOME="$INSTALL_HOME" PATH="$PATH" TMPDIR="$INSTALL_TMP" "$BINARY" --help >/dev/null 2>&1
+  env -i HOME="$INSTALL_HOME" PATH="$PATH" TMPDIR="$INSTALL_TMP" "$BINARY" run --help >/dev/null 2>&1
+)
+
+echo "Verified remote go install: $MODULE/cmd/crabbox@$VERSION source=$SOURCE_COMMIT"


### PR DESCRIPTION
## Summary

- make `go install github.com/openclaw/crabbox/cmd/crabbox@<released-version>` an official, replacement-free installation channel starting with v0.44.0
- migrate Crabbox to the importable `github.com/steipete/jsonschema/v6` module while retaining the required modern-draft `dependencies` fix
- derive meaningful tagged and revision-install versions from Go build information without changing GoReleaser/Homebrew linker injection
- add a clean-cache, source-blind module-proxy installation gate to CI and release-candidate production
- document that direct Go installation provides only the locally compiled CLI, not the signed/notarized distribution, `crabbox-apple-vm-helper`, or its embedded Apple VM daemon

Closes https://github.com/openclaw/crabbox/issues/1374

## Module and release contract

The previous remote `replace` caused the Go tool to reject version-suffixed installation before compilation. The JSON Schema fork now truthfully declares its own module path and was landed in https://github.com/steipete/jsonschema/pull/1. Crabbox directly requires immutable version `v6.0.3-0.20260817142523-966654abed4a`; the upstream-path requirement and `replace` are gone, while the existing draft 2019-09/2020-12 regression coverage remains intact.

`scripts/verify-go-install.sh` exports an exact source commit as a stable semantic module version, constructs a valid local GOPROXY fixture, seeds dependencies exclusively from the public Go proxy, makes the fixture read-only, and installs from outside the checkout with fresh HOME/GOPATH/module/build caches. It verifies exact replacement-free build metadata, the fork dependency/version, `--version`, `--help`, and `run --help`. CI uses synthetic `v0.0.0`; the credential-free release producer uses the actual release tag and source commit before GoReleaser. Release documentation also requires a fresh real public-proxy proof after publication.

## Distribution limitation

`go install` compiles and installs the Go CLI only. It does not install release companion executables/assets and is not the Foundation-signed/notarized prebuilt distribution. In particular, Apple Silicon users who need the Apple VM provider must install through Homebrew or the release archive to receive `crabbox-apple-vm-helper` and its embedded daemon.

## Verification

- `gofmt` and `git diff --check`
- stable `go mod tidy`; `go mod verify`
- `go vet ./...`
- focused version and JSON Schema race tests
- `GOCACHE=/tmp/crabbox-1374-gocache GOTMPDIR=/tmp/crabbox-1374-gotmp go test -race -p 4 -parallel 4 -timeout 20m ./...`
- `GOCACHE=/tmp/crabbox-1374-gocache GOTMPDIR=/tmp/crabbox-1374-gotmp scripts/test-go-modules.sh`
- `scripts/check-docs.sh`
- `node --test scripts/release-workflow.test.js` (28/28)
- `shellcheck scripts/verify-go-install.sh`
- `scripts/verify-go-install.sh v0.0.0 a03964da5c8701518ec956efd3a9b412fc3eaff2`
  - output: `Verified remote go install: github.com/openclaw/crabbox/cmd/crabbox@v0.0.0 source=a03964da5c8701518ec956efd3a9b412fc3eaff2`
- source-blind behavior validation passed the install, version/help, build-metadata, no-replacement, and companion-limit contract
- Codex-backed P1 autoreview: no actionable findings

The first full race attempt was invalidated by another process deleting shared Go build-cache entries while a test spawned `go build`; the exact failed test passed with an isolated cache, and the complete isolated race suite then passed.

Co-authored-by: Coy Geek <coygeek@users.noreply.github.com>
