### PR TITLE
feat(providers): report machine class shapes in the provider matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added concrete primary machine types, vCPU counts, and RAM sizes to `crabbox providers` class reporting.
 - Added credential-free `crabbox providers describe` discovery for canonical provider-scoped run flags and compiled defaults. Thanks @coygeek.
 - Added supported versioned `go install` as a CLI-only installation channel, with clean module dependency semantics, source-derived release and revision versions, and hermetic release verification. Thanks @coygeek.
 - Added an opt-in Linux/WSL2 `raw_socket` preflight probe that distinguishes direct, non-interactive-sudo, unavailable, and missing-interpreter states without sending packets or elevating workloads. Thanks @coygeek.

--- a/docs/commands/providers.md
+++ b/docs/commands/providers.md
@@ -376,6 +376,10 @@ aws
   runtime: ssh-host,interactive
   reachability: ssh-tunnel
   coordinator: supported
+  class standard: c7a.8xlarge (32 vCPU, 64 GB RAM)
+  class fast: c7a.16xlarge (64 vCPU, 128 GB RAM)
+  class large: c7a.24xlarge (96 vCPU, 192 GB RAM)
+  class beast: c7a.48xlarge (192 vCPU, 384 GB RAM)
 
 parallels
   family: parallels
@@ -460,16 +464,22 @@ Direct self-hosted SSH-lease providers such as `firecracker`, `proxmox`, and
 ```json
 [
   {
-    "provider": "hostinger",
-    "family": "hostinger",
+    "provider": "aws",
+    "family": "aws",
     "kind": "ssh-lease",
-    "category": "direct-cloud",
-    "targets": ["linux"],
-    "features": ["ssh", "crabbox-sync", "cleanup"],
-    "runtime": ["ssh-host"],
+    "category": "brokerable-cloud",
+    "targets": ["linux", "windows/normal", "windows/wsl2", "macos"],
+    "features": ["ssh", "crabbox-sync", "cleanup", "desktop", "browser", "code"],
+    "runtime": ["ssh-host", "interactive"],
     "reachability": ["ssh-tunnel"],
-    "lifecycle": ["cleanup"],
-    "coordinator": "never"
+    "lifecycle": ["coordinator-governed", "cleanup"],
+    "coordinator": "supported",
+    "classes": [
+      {"class": "standard", "type": "c7a.8xlarge", "vcpu": 32, "memoryGb": 64},
+      {"class": "fast", "type": "c7a.16xlarge", "vcpu": 64, "memoryGb": 128},
+      {"class": "large", "type": "c7a.24xlarge", "vcpu": 96, "memoryGb": 192},
+      {"class": "beast", "type": "c7a.48xlarge", "vcpu": 192, "memoryGb": 384}
+    ]
   },
   {
     "provider": "blacksmith-testbox",
@@ -548,6 +558,12 @@ Direct self-hosted SSH-lease providers such as `firecracker`, `proxmox`, and
   - `supported`: the provider can be brokered through the coordinator when a
     broker URL is configured; otherwise it runs direct from the CLI.
   - `never`: the provider always runs direct from the CLI.
+- `classes`: the primary machine type selected for each provider-neutral class
+  on the provider's default Linux/amd64 target, with nominal `vcpu` and
+  `memoryGb` values when known. When present, the array contains `standard`,
+  `fast`, `large`, and `beast` in that order. Providers without a machine-sizing
+  implementation omit the field; unknown shape values are omitted rather than
+  reported as zero.
 
 Recommendation JSON returns ranked objects:
 

--- a/docs/features/providers.md
+++ b/docs/features/providers.md
@@ -69,20 +69,20 @@ checks whether the selected provider is usable from the current environment.
 `--class standard|fast|large|beast` (default `beast`) maps to an ordered list of
 provider machine types. Crabbox tries each in turn, falling back when capacity or
 quota rejects a request. The maps below come from `internal/cli/config.go` and
-`internal/cli/gcp.go`:
+the corresponding provider adapters:
 
 ```text
 Hetzner
-standard  ccx33, cpx62, cx53
-fast      ccx43, cpx62, cx53
-large     ccx53, ccx43, cpx62, cx53
-beast     ccx63, ccx53, ccx43, cpx62, cx53
+standard  ccx33 (8 vCPU, 32 GB RAM), cpx62, cx53
+fast      ccx43 (16 vCPU, 64 GB RAM), cpx62, cx53
+large     ccx53 (32 vCPU, 128 GB RAM), ccx43, cpx62, cx53
+beast     ccx63 (48 vCPU, 192 GB RAM), ccx53, ccx43, cpx62, cx53
 
 AWS (Linux)
-standard  c7a.8xlarge, c7i.8xlarge, m7a.8xlarge, m7i.8xlarge, c7a.4xlarge
-fast      c7a.16xlarge, c7i.16xlarge, m7a.16xlarge, m7i.16xlarge, c7a.12xlarge, c7a.8xlarge
-large     c7a.24xlarge, c7i.24xlarge, m7a.24xlarge, m7i.24xlarge, r7a.24xlarge, c7a.16xlarge, c7a.12xlarge
-beast     c7a.48xlarge, c7i.48xlarge, m7a.48xlarge, m7i.48xlarge, r7a.48xlarge, c7a.32xlarge, c7i.32xlarge, m7a.32xlarge, c7a.24xlarge, c7a.16xlarge
+standard  c7a.8xlarge (32 vCPU, 64 GB RAM), c7i.8xlarge, m7a.8xlarge, m7i.8xlarge, c7a.4xlarge
+fast      c7a.16xlarge (64 vCPU, 128 GB RAM), c7i.16xlarge, m7a.16xlarge, m7i.16xlarge, c7a.12xlarge, c7a.8xlarge
+large     c7a.24xlarge (96 vCPU, 192 GB RAM), c7i.24xlarge, m7a.24xlarge, m7i.24xlarge, r7a.24xlarge, c7a.16xlarge, c7a.12xlarge
+beast     c7a.48xlarge (192 vCPU, 384 GB RAM), c7i.48xlarge, m7a.48xlarge, m7i.48xlarge, r7a.48xlarge, c7a.32xlarge, c7i.32xlarge, m7a.32xlarge, c7a.24xlarge, c7a.16xlarge
 
 AWS Windows (normal)
 standard  m7i.large, m7a.large, t3.large
@@ -102,10 +102,22 @@ mac-m4max.metal, mac2-m1ultra.metal, mac-m3ultra.metal, then mac1.metal unless
 `--type` is set
 
 Google Cloud
-standard  c4-standard-32, c3-standard-22, n2-standard-32, n2d-standard-32
-fast      c4-standard-64, c3-standard-44, n2-standard-64, n2d-standard-64, c4-standard-32
-large     c4-standard-96, c3-standard-88, n2-standard-80, n2d-standard-96, c4-standard-64
-beast     c4-standard-192, c4-standard-96, c3-standard-176, c3-standard-88, n2d-standard-224, n2-standard-128
+standard  c4-standard-32 (32 vCPU, 120 GB RAM), c3-standard-22, n2-standard-32, n2d-standard-32
+fast      c4-standard-64 (64 vCPU, 240 GB RAM), c3-standard-44, n2-standard-64, n2d-standard-64, c4-standard-32
+large     c4-standard-96 (96 vCPU, 360 GB RAM), c3-standard-88, n2-standard-80, n2d-standard-96, c4-standard-64
+beast     c4-standard-192 (192 vCPU, 720 GB RAM), c4-standard-96, c3-standard-176, c3-standard-88, n2d-standard-224, n2-standard-128
+
+Azure (Linux)
+standard  Standard_D32ads_v6 (32 vCPU, 128 GB RAM), Standard_D32ds_v6, Standard_F32s_v2, Standard_D32ads_v5, Standard_D32ds_v5, Standard_D16ads_v6, Standard_D16ds_v6, Standard_F16s_v2
+fast      Standard_D64ads_v6 (64 vCPU, 256 GB RAM), Standard_D64ds_v6, Standard_F64s_v2, Standard_D64ads_v5, Standard_D64ds_v5, Standard_D48ads_v6, Standard_D48ds_v6, Standard_F48s_v2, Standard_D32ads_v6, Standard_D32ds_v6, Standard_F32s_v2
+large     Standard_D96ads_v6 (96 vCPU, 384 GB RAM), Standard_D96ds_v6, Standard_D96ads_v5, Standard_D96ds_v5, Standard_D64ads_v6, Standard_D64ds_v6, Standard_F64s_v2, Standard_D48ads_v6, Standard_D48ds_v6, Standard_F48s_v2
+beast     Standard_D192ds_v6 (192 vCPU, 768 GB RAM), Standard_D128ds_v6, Standard_D96ads_v6, Standard_D96ds_v6, Standard_D96ads_v5, Standard_D96ds_v5, Standard_D64ads_v6, Standard_D64ds_v6, Standard_F64s_v2
+
+Namespace Instance
+standard  4x8 (4 vCPU, 8 GB RAM)
+fast      8x16 (8 vCPU, 16 GB RAM)
+large     16x32 (16 vCPU, 32 GB RAM)
+beast     32x64 (32 vCPU, 64 GB RAM)
 
 Namespace Devbox
 standard  S

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -100,6 +100,21 @@ type ProviderServerTypeProvider interface {
 	ServerTypeForClass(class string) string
 }
 
+// ClassSpec reports the concrete machine one class resolves to on this
+// provider's default target, with its nominal shape when known.
+type ClassSpec struct {
+	Class    string `json:"class"`
+	Type     string `json:"type"`
+	VCPUs    int    `json:"vcpu,omitempty"`
+	MemoryGB int    `json:"memoryGb,omitempty"`
+}
+
+// ProviderClassSpecProvider reports provider-owned machine class resolutions
+// for the provider matrix.
+type ProviderClassSpecProvider interface {
+	ClassSpecs() []ClassSpec
+}
+
 type Backend interface {
 	Spec() ProviderSpec
 }

--- a/internal/cli/provider_exports.go
+++ b/internal/cli/provider_exports.go
@@ -55,6 +55,10 @@ func AWSInstanceTypeCandidatesForClass(class string) []string {
 	return awsInstanceTypeCandidatesForClass(class)
 }
 
+func AWSInstanceTypeVCPUs(instanceType string) int {
+	return awsInstanceTypeVCPUs(instanceType)
+}
+
 func AzureVMSizeCandidatesForConfig(cfg Config) []string {
 	return azureVMSizeCandidatesForConfig(cfg)
 }
@@ -63,8 +67,16 @@ func AzureVMSizeCandidatesForClass(class string) []string {
 	return azureVMSizeCandidatesForClass(class)
 }
 
+func AzureVMSizeVCPUCount(vmSize string) (int, bool) {
+	return azureVMSizeVCPUCount(vmSize)
+}
+
 func GCPMachineTypeCandidatesForClass(class string) []string {
 	return gcpMachineTypeCandidatesForClass(class)
+}
+
+func HetznerServerTypeCandidatesForClass(class string) []string {
+	return serverTypeCandidatesForClass(class)
 }
 
 func ProxmoxServerTypeForConfig(cfg Config) string {

--- a/internal/cli/providers.go
+++ b/internal/cli/providers.go
@@ -24,6 +24,7 @@ type providerMatrixEntry struct {
 	Evidence     []string     `json:"evidence,omitempty"`
 	Lifecycle    []string     `json:"lifecycle,omitempty"`
 	Coordinator  string       `json:"coordinator"`
+	Classes      []ClassSpec  `json:"classes,omitempty"`
 }
 
 type providerRecommendationEntry struct {
@@ -208,7 +209,7 @@ func providerMatrixEntryFor(provider Provider) providerMatrixEntry {
 	name := firstNonBlank(spec.Name, provider.Name())
 	category := benchmarkProviderCategories[name]
 	targets := formatProviderTargets(spec.Targets)
-	return providerMatrixEntry{
+	entry := providerMatrixEntry{
 		Provider:     name,
 		Family:       firstNonBlank(spec.Family, provider.Name()),
 		Aliases:      append([]string(nil), provider.Aliases()...),
@@ -223,6 +224,10 @@ func providerMatrixEntryFor(provider Provider) providerMatrixEntry {
 		Lifecycle:    lifecycleCapabilitiesForProvider(spec.Coordinator, spec.Features),
 		Coordinator:  string(spec.Coordinator),
 	}
+	if classProvider, ok := provider.(ProviderClassSpecProvider); ok {
+		entry.Classes = append([]ClassSpec(nil), classProvider.ClassSpecs()...)
+	}
+	return entry
 }
 
 func registerProviderMatrixFilterFlags(fs *flag.FlagSet) *providerMatrixFilterFlagValues {
@@ -1673,6 +1678,18 @@ func printProviderMatrix(out io.Writer, entries []providerMatrixEntry) {
 		fmt.Fprintf(out, "  coordinator: %s\n", blank(entry.Coordinator, "never"))
 		if len(entry.Aliases) > 0 {
 			fmt.Fprintf(out, "  aliases: %s\n", strings.Join(entry.Aliases, ","))
+		}
+		for _, class := range entry.Classes {
+			shape := ""
+			switch {
+			case class.VCPUs > 0 && class.MemoryGB > 0:
+				shape = fmt.Sprintf(" (%d vCPU, %d GB RAM)", class.VCPUs, class.MemoryGB)
+			case class.VCPUs > 0:
+				shape = fmt.Sprintf(" (%d vCPU)", class.VCPUs)
+			case class.MemoryGB > 0:
+				shape = fmt.Sprintf(" (%d GB RAM)", class.MemoryGB)
+			}
+			fmt.Fprintf(out, "  class %s: %s%s\n", class.Class, class.Type, shape)
 		}
 	}
 }

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -93,6 +93,16 @@ func TestProviderMatrixIncludesCapabilities(t *testing.T) {
 	if firecracker == nil {
 		t.Fatal("firecracker provider not found")
 	}
+	if len(firecracker.Classes) != 0 {
+		t.Fatalf("firecracker classes=%#v want omitted", firecracker.Classes)
+	}
+	encodedFirecracker, err := json.Marshal(firecracker)
+	if err != nil {
+		t.Fatalf("marshal firecracker matrix entry: %v", err)
+	}
+	if bytes.Contains(encodedFirecracker, []byte(`"classes"`)) {
+		t.Fatalf("firecracker JSON unexpectedly contains classes: %s", encodedFirecracker)
+	}
 	if vast == nil {
 		t.Fatal("vast provider not found")
 	}
@@ -399,6 +409,64 @@ func TestProvidersCommandHumanOutput(t *testing.T) {
 	}
 	if !strings.Contains(text, "blacksmith-testbox\n") || !strings.Contains(text, "  lifecycle: run-session\n") {
 		t.Fatalf("providers output missing run-session lifecycle:\n%s", text)
+	}
+}
+
+func TestPrintProviderMatrixClasses(t *testing.T) {
+	var output bytes.Buffer
+	printProviderMatrix(&output, []providerMatrixEntry{{
+		Provider:    "example",
+		Family:      "example",
+		Kind:        ProviderKindSSHLease,
+		Targets:     []string{targetLinux},
+		Features:    FeatureSet{},
+		Coordinator: string(CoordinatorNever),
+		Classes: []ClassSpec{
+			{Class: "standard", Type: "shape-1", VCPUs: 4, MemoryGB: 8},
+			{Class: "fast", Type: "shape-2", VCPUs: 8},
+			{Class: "large", Type: "shape-3", MemoryGB: 32},
+			{Class: "beast", Type: "shape-4"},
+		},
+	}})
+	for _, want := range []string{
+		"  class standard: shape-1 (4 vCPU, 8 GB RAM)\n",
+		"  class fast: shape-2 (8 vCPU)\n",
+		"  class large: shape-3 (32 GB RAM)\n",
+		"  class beast: shape-4\n",
+	} {
+		if !strings.Contains(output.String(), want) {
+			t.Fatalf("provider matrix output missing %q:\n%s", want, output.String())
+		}
+	}
+}
+
+func TestClassSpecJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		spec ClassSpec
+		want string
+	}{
+		{
+			name: "known shape",
+			spec: ClassSpec{Class: "standard", Type: "shape-1", VCPUs: 4, MemoryGB: 8},
+			want: `{"class":"standard","type":"shape-1","vcpu":4,"memoryGb":8}`,
+		},
+		{
+			name: "unknown shape",
+			spec: ClassSpec{Class: "standard", Type: "shape-1"},
+			want: `{"class":"standard","type":"shape-1"}`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			encoded, err := json.Marshal(test.spec)
+			if err != nil {
+				t.Fatalf("marshal ClassSpec: %v", err)
+			}
+			if string(encoded) != test.want {
+				t.Fatalf("ClassSpec JSON=%s want %s", encoded, test.want)
+			}
+		})
 	}
 }
 
@@ -1866,17 +1934,29 @@ func TestProvidersJSONIncludesBuiltIns(t *testing.T) {
 	}
 
 	var firecracker *providerMatrixEntry
-	var aws *providerMatrixEntry
+	classProviders := map[string]*providerMatrixEntry{}
 	for i := range entries {
 		switch entries[i].Provider {
-		case "aws":
-			aws = &entries[i]
 		case "firecracker":
 			firecracker = &entries[i]
+		case "aws", "azure", "gcp", "hetzner", "namespace-instance":
+			classProviders[entries[i].Provider] = &entries[i]
 		}
 	}
-	if aws == nil {
-		t.Fatal("built binary providers json missing aws")
+	for _, provider := range []string{"aws", "azure", "gcp", "hetzner", "namespace-instance"} {
+		entry := classProviders[provider]
+		if entry == nil {
+			t.Fatalf("built binary providers json missing %s", provider)
+		}
+		if len(entry.Classes) != 4 {
+			t.Fatalf("%s classes=%#v want four entries", provider, entry.Classes)
+		}
+		for classIndex, className := range []string{"standard", "fast", "large", "beast"} {
+			classSpec := entry.Classes[classIndex]
+			if classSpec.Class != className || classSpec.Type == "" || classSpec.VCPUs <= 0 || classSpec.MemoryGB <= 0 {
+				t.Fatalf("%s class[%d]=%#v", provider, classIndex, classSpec)
+			}
+		}
 	}
 	if firecracker == nil {
 		t.Fatal("built binary providers json missing firecracker")

--- a/internal/providers/aws/class_specs_test.go
+++ b/internal/providers/aws/class_specs_test.go
@@ -1,0 +1,44 @@
+package aws
+
+import (
+	"reflect"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestClassSpecs(t *testing.T) {
+	want := []core.ClassSpec{
+		{Class: "standard", Type: "c7a.8xlarge", VCPUs: 32, MemoryGB: 64},
+		{Class: "fast", Type: "c7a.16xlarge", VCPUs: 64, MemoryGB: 128},
+		{Class: "large", Type: "c7a.24xlarge", VCPUs: 96, MemoryGB: 192},
+		{Class: "beast", Type: "c7a.48xlarge", VCPUs: 192, MemoryGB: 384},
+	}
+	if got := (Provider{}).ClassSpecs(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("ClassSpecs()=%#v want %#v", got, want)
+	}
+}
+
+func TestInstanceShape(t *testing.T) {
+	tests := []struct {
+		name       string
+		instance   string
+		wantVCPUs  int
+		wantMemory int
+	}{
+		{name: "bare xlarge", instance: "m7i.xlarge", wantVCPUs: 4, wantMemory: 16},
+		{name: "numbered xlarge", instance: "r8i.2xlarge", wantVCPUs: 8, wantMemory: 64},
+		{name: "small size", instance: "c7a.large", wantVCPUs: 2, wantMemory: 4},
+		{name: "unknown family", instance: "z9.2xlarge", wantVCPUs: 8},
+		{name: "unparseable size", instance: "c7a.enormous"},
+		{name: "missing separator", instance: "c7a"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			gotVCPUs, gotMemory := instanceShape(test.instance)
+			if gotVCPUs != test.wantVCPUs || gotMemory != test.wantMemory {
+				t.Fatalf("instanceShape(%q)=(%d,%d) want (%d,%d)", test.instance, gotVCPUs, gotMemory, test.wantVCPUs, test.wantMemory)
+			}
+		})
+	}
+}

--- a/internal/providers/aws/provider.go
+++ b/internal/providers/aws/provider.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"flag"
+	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
@@ -11,6 +12,27 @@ func init() {
 }
 
 type Provider struct{}
+
+var _ core.ProviderClassSpecProvider = Provider{}
+
+// AWS publishes C7 compute-optimized instances at 2 GiB/vCPU, M7/M8
+// general-purpose instances at 4 GiB/vCPU, and R7/R8 memory-optimized instances
+// in its EC2 instance-family tables:
+// https://docs.aws.amazon.com/ec2/latest/instancetypes/co.html
+// https://docs.aws.amazon.com/ec2/latest/instancetypes/gp.html
+// https://docs.aws.amazon.com/ec2/latest/instancetypes/mo.html
+var memoryGiBPerVCPU = map[string]int{
+	"c7a": 2,
+	"c7g": 2,
+	"c7i": 2,
+	"m7a": 4,
+	"m7g": 4,
+	"m7i": 4,
+	"m8i": 4,
+	"r7a": 8,
+	"r7g": 8,
+	"r8i": 8,
+}
 
 func (Provider) Name() string      { return "aws" }
 func (Provider) Aliases() []string { return nil }
@@ -70,6 +92,29 @@ func (Provider) ServerTypeForConfig(cfg core.Config) string {
 
 func (Provider) ServerTypeForClass(class string) string {
 	return core.AWSInstanceTypeCandidatesForClass(class)[0]
+}
+
+func (Provider) ClassSpecs() []core.ClassSpec {
+	classes := []string{"standard", "fast", "large", "beast"}
+	specs := make([]core.ClassSpec, 0, len(classes))
+	for _, class := range classes {
+		instanceType := core.AWSInstanceTypeCandidatesForClass(class)[0]
+		vcpus, memoryGB := instanceShape(instanceType)
+		specs = append(specs, core.ClassSpec{Class: class, Type: instanceType, VCPUs: vcpus, MemoryGB: memoryGB})
+	}
+	return specs
+}
+
+func instanceShape(instanceType string) (int, int) {
+	vcpus := core.AWSInstanceTypeVCPUs(instanceType)
+	if vcpus == 0 {
+		return 0, 0
+	}
+	family, _, ok := strings.Cut(strings.ToLower(strings.TrimSpace(instanceType)), ".")
+	if !ok {
+		return vcpus, 0
+	}
+	return vcpus, vcpus * memoryGiBPerVCPU[family]
 }
 
 func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {

--- a/internal/providers/azure/class_specs_test.go
+++ b/internal/providers/azure/class_specs_test.go
@@ -1,0 +1,42 @@
+package azure
+
+import (
+	"reflect"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestClassSpecs(t *testing.T) {
+	want := []core.ClassSpec{
+		{Class: "standard", Type: "Standard_D32ads_v6", VCPUs: 32, MemoryGB: 128},
+		{Class: "fast", Type: "Standard_D64ads_v6", VCPUs: 64, MemoryGB: 256},
+		{Class: "large", Type: "Standard_D96ads_v6", VCPUs: 96, MemoryGB: 384},
+		{Class: "beast", Type: "Standard_D192ds_v6", VCPUs: 192, MemoryGB: 768},
+	}
+	if got := (Provider{}).ClassSpecs(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("ClassSpecs()=%#v want %#v", got, want)
+	}
+}
+
+func TestVMShape(t *testing.T) {
+	tests := []struct {
+		name       string
+		vmSize     string
+		wantVCPUs  int
+		wantMemory int
+	}{
+		{name: "Dv6", vmSize: "Standard_D32ads_v6", wantVCPUs: 32, wantMemory: 128},
+		{name: "not Dv6", vmSize: "Standard_D32ads_v5"},
+		{name: "non-numeric D family", vmSize: "Standard_DC32ads_v6"},
+		{name: "unparseable", vmSize: "not-a-vm-size"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			gotVCPUs, gotMemory := vmShape(test.vmSize)
+			if gotVCPUs != test.wantVCPUs || gotMemory != test.wantMemory {
+				t.Fatalf("vmShape(%q)=(%d,%d) want (%d,%d)", test.vmSize, gotVCPUs, gotMemory, test.wantVCPUs, test.wantMemory)
+			}
+		})
+	}
+}

--- a/internal/providers/azure/provider.go
+++ b/internal/providers/azure/provider.go
@@ -12,6 +12,9 @@ func init() {
 }
 
 type Provider struct{}
+
+var _ core.ProviderClassSpecProvider = Provider{}
+
 type flagValues struct {
 	Backend     *string
 	OSDisk      *string
@@ -156,6 +159,33 @@ func (Provider) ServerTypeForConfig(cfg core.Config) string {
 
 func (Provider) ServerTypeForClass(class string) string {
 	return core.AzureVMSizeCandidatesForClass(class)[0]
+}
+
+func (Provider) ClassSpecs() []core.ClassSpec {
+	classes := []string{"standard", "fast", "large", "beast"}
+	specs := make([]core.ClassSpec, 0, len(classes))
+	for _, class := range classes {
+		vmSize := core.AzureVMSizeCandidatesForClass(class)[0]
+		vcpus, memoryGB := vmShape(vmSize)
+		specs = append(specs, core.ClassSpec{Class: class, Type: vmSize, VCPUs: vcpus, MemoryGB: memoryGB})
+	}
+	return specs
+}
+
+func vmShape(vmSize string) (int, int) {
+	normalized := strings.ToLower(strings.TrimSpace(vmSize))
+	const prefix = "standard_d"
+	if !strings.HasPrefix(normalized, prefix) || len(normalized) == len(prefix) || normalized[len(prefix)] < '0' || normalized[len(prefix)] > '9' || !strings.HasSuffix(normalized, "_v6") {
+		return 0, 0
+	}
+	vcpus, ok := core.AzureVMSizeVCPUCount(vmSize)
+	if !ok || vcpus <= 0 {
+		return 0, 0
+	}
+	// Azure publishes both Dadsv6 and Ddsv6 at 4 GiB per vCPU:
+	// https://learn.microsoft.com/azure/virtual-machines/sizes/general-purpose/dadsv6-series
+	// https://learn.microsoft.com/azure/virtual-machines/sizes/general-purpose/ddsv6-series
+	return vcpus, vcpus * 4
 }
 
 func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {

--- a/internal/providers/gcp/class_specs_test.go
+++ b/internal/providers/gcp/class_specs_test.go
@@ -1,0 +1,47 @@
+package gcp
+
+import (
+	"reflect"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestClassSpecs(t *testing.T) {
+	want := []core.ClassSpec{
+		{Class: "standard", Type: "c4-standard-32", VCPUs: 32, MemoryGB: 120},
+		{Class: "fast", Type: "c4-standard-64", VCPUs: 64, MemoryGB: 240},
+		{Class: "large", Type: "c4-standard-96", VCPUs: 96, MemoryGB: 360},
+		{Class: "beast", Type: "c4-standard-192", VCPUs: 192, MemoryGB: 720},
+	}
+	if got := (Provider{}).ClassSpecs(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("ClassSpecs()=%#v want %#v", got, want)
+	}
+}
+
+func TestMachineShape(t *testing.T) {
+	tests := []struct {
+		name       string
+		machine    string
+		wantVCPUs  int
+		wantMemory int
+	}{
+		{name: "C4 standard", machine: "c4-standard-32", wantVCPUs: 32, wantMemory: 120},
+		{name: "C3 standard", machine: "c3-standard-22", wantVCPUs: 22, wantMemory: 88},
+		{name: "N2 standard", machine: "n2-standard-32", wantVCPUs: 32, wantMemory: 128},
+		{name: "N2D standard", machine: "n2d-standard-32", wantVCPUs: 32, wantMemory: 128},
+		{name: "known vCPU only", machine: "c4-highcpu-32", wantVCPUs: 32},
+		{name: "unknown standard family", machine: "future-standard-32", wantVCPUs: 32},
+		{name: "fractional whole GB", machine: "c4-standard-1", wantVCPUs: 1},
+		{name: "unparseable vCPU", machine: "c4-standard-many"},
+		{name: "missing suffix", machine: "c4-standard"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			gotVCPUs, gotMemory := machineShape(test.machine)
+			if gotVCPUs != test.wantVCPUs || gotMemory != test.wantMemory {
+				t.Fatalf("machineShape(%q)=(%d,%d) want (%d,%d)", test.machine, gotVCPUs, gotMemory, test.wantVCPUs, test.wantMemory)
+			}
+		})
+	}
+}

--- a/internal/providers/gcp/provider.go
+++ b/internal/providers/gcp/provider.go
@@ -2,6 +2,8 @@ package gcp
 
 import (
 	"flag"
+	"strconv"
+	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
@@ -11,6 +13,17 @@ func init() {
 }
 
 type Provider struct{}
+
+var _ core.ProviderClassSpecProvider = Provider{}
+
+// Google publishes these standard machine-family ratios in the Compute Engine
+// machine-family tables: https://cloud.google.com/compute/docs/general-purpose-machines
+var memoryQuarterGBPerVCPU = map[string]int{
+	"c4-standard":  15,
+	"c3-standard":  16,
+	"n2-standard":  16,
+	"n2d-standard": 16,
+}
 
 func (Provider) Name() string { return "gcp" }
 func (Provider) Aliases() []string {
@@ -75,6 +88,38 @@ func (Provider) ServerTypeForConfig(cfg core.Config) string {
 
 func (Provider) ServerTypeForClass(class string) string {
 	return core.GCPMachineTypeCandidatesForClass(class)[0]
+}
+
+func (Provider) ClassSpecs() []core.ClassSpec {
+	classes := []string{"standard", "fast", "large", "beast"}
+	specs := make([]core.ClassSpec, 0, len(classes))
+	for _, class := range classes {
+		machineType := core.GCPMachineTypeCandidatesForClass(class)[0]
+		vcpus, memoryGB := machineShape(machineType)
+		specs = append(specs, core.ClassSpec{Class: class, Type: machineType, VCPUs: vcpus, MemoryGB: memoryGB})
+	}
+	return specs
+}
+
+func machineShape(machineType string) (int, int) {
+	normalized := strings.ToLower(strings.TrimSpace(machineType))
+	separator := strings.LastIndexByte(normalized, '-')
+	if separator < 0 || separator == len(normalized)-1 {
+		return 0, 0
+	}
+	vcpus, err := strconv.Atoi(normalized[separator+1:])
+	if err != nil || vcpus <= 0 {
+		return 0, 0
+	}
+	memoryQuartersPerVCPU, ok := memoryQuarterGBPerVCPU[normalized[:separator]]
+	if !ok {
+		return vcpus, 0
+	}
+	memoryQuarters := vcpus * memoryQuartersPerVCPU
+	if memoryQuarters%4 != 0 {
+		return vcpus, 0
+	}
+	return vcpus, memoryQuarters / 4
 }
 
 func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {

--- a/internal/providers/hetzner/class_specs_test.go
+++ b/internal/providers/hetzner/class_specs_test.go
@@ -1,0 +1,41 @@
+package hetzner
+
+import (
+	"reflect"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestClassSpecs(t *testing.T) {
+	want := []core.ClassSpec{
+		{Class: "standard", Type: "ccx33", VCPUs: 8, MemoryGB: 32},
+		{Class: "fast", Type: "ccx43", VCPUs: 16, MemoryGB: 64},
+		{Class: "large", Type: "ccx53", VCPUs: 32, MemoryGB: 128},
+		{Class: "beast", Type: "ccx63", VCPUs: 48, MemoryGB: 192},
+	}
+	if got := (Provider{}).ClassSpecs(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("ClassSpecs()=%#v want %#v", got, want)
+	}
+}
+
+func TestServerShape(t *testing.T) {
+	tests := []struct {
+		name       string
+		serverType string
+		wantVCPUs  int
+		wantMemory int
+	}{
+		{name: "known", serverType: "CCX43", wantVCPUs: 16, wantMemory: 64},
+		{name: "unknown", serverType: "ccx99"},
+		{name: "empty"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			gotVCPUs, gotMemory := serverShape(test.serverType)
+			if gotVCPUs != test.wantVCPUs || gotMemory != test.wantMemory {
+				t.Fatalf("serverShape(%q)=(%d,%d) want (%d,%d)", test.serverType, gotVCPUs, gotMemory, test.wantVCPUs, test.wantMemory)
+			}
+		})
+	}
+}

--- a/internal/providers/hetzner/provider.go
+++ b/internal/providers/hetzner/provider.go
@@ -14,6 +14,20 @@ func init() {
 
 type Provider struct{}
 
+var _ core.ProviderClassSpecProvider = Provider{}
+
+// Hetzner publishes these dedicated-vCPU shapes in its General Purpose plan:
+// https://www.hetzner.com/cloud/general-purpose/
+var serverShapes = map[string]struct {
+	vcpus    int
+	memoryGB int
+}{
+	"ccx33": {vcpus: 8, memoryGB: 32},
+	"ccx43": {vcpus: 16, memoryGB: 64},
+	"ccx53": {vcpus: 32, memoryGB: 128},
+	"ccx63": {vcpus: 48, memoryGB: 192},
+}
+
 func (Provider) Name() string      { return "hetzner" }
 func (Provider) Aliases() []string { return nil }
 func (Provider) Spec() core.ProviderSpec {
@@ -83,6 +97,26 @@ func (Provider) RegisterFlags(*flag.FlagSet, core.Config) any { return core.NoPr
 func (Provider) ApplyFlags(*core.Config, *flag.FlagSet, any) error {
 	return nil
 }
+
+func (Provider) ClassSpecs() []core.ClassSpec {
+	classes := []string{"standard", "fast", "large", "beast"}
+	specs := make([]core.ClassSpec, 0, len(classes))
+	for _, class := range classes {
+		serverType := core.HetznerServerTypeCandidatesForClass(class)[0]
+		vcpus, memoryGB := serverShape(serverType)
+		specs = append(specs, core.ClassSpec{Class: class, Type: serverType, VCPUs: vcpus, MemoryGB: memoryGB})
+	}
+	return specs
+}
+
+func serverShape(serverType string) (int, int) {
+	shape, ok := serverShapes[strings.ToLower(strings.TrimSpace(serverType))]
+	if !ok {
+		return 0, 0
+	}
+	return shape.vcpus, shape.memoryGB
+}
+
 func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
 	return NewHetznerLeaseBackend(p.Spec(), cfg, rt), nil
 }

--- a/internal/providers/namespaceinstance/class_specs_test.go
+++ b/internal/providers/namespaceinstance/class_specs_test.go
@@ -1,0 +1,44 @@
+package namespaceinstance
+
+import (
+	"reflect"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestClassSpecs(t *testing.T) {
+	want := []core.ClassSpec{
+		{Class: "standard", Type: "4x8", VCPUs: 4, MemoryGB: 8},
+		{Class: "fast", Type: "8x16", VCPUs: 8, MemoryGB: 16},
+		{Class: "large", Type: "16x32", VCPUs: 16, MemoryGB: 32},
+		{Class: "beast", Type: "32x64", VCPUs: 32, MemoryGB: 64},
+	}
+	if got := (Provider{}).ClassSpecs(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("ClassSpecs()=%#v want %#v", got, want)
+	}
+}
+
+func TestMachineShape(t *testing.T) {
+	tests := []struct {
+		name       string
+		machine    string
+		wantVCPUs  int
+		wantMemory int
+	}{
+		{name: "known", machine: "8x16", wantVCPUs: 8, wantMemory: 16},
+		{name: "unparseable CPU", machine: "manyx16"},
+		{name: "unparseable memory", machine: "8xmany"},
+		{name: "extra separator", machine: "8x16x32"},
+		{name: "zero", machine: "0x16"},
+		{name: "missing separator", machine: "8"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			gotVCPUs, gotMemory := machineShape(test.machine)
+			if gotVCPUs != test.wantVCPUs || gotMemory != test.wantMemory {
+				t.Fatalf("machineShape(%q)=(%d,%d) want (%d,%d)", test.machine, gotVCPUs, gotMemory, test.wantVCPUs, test.wantMemory)
+			}
+		})
+	}
+}

--- a/internal/providers/namespaceinstance/provider.go
+++ b/internal/providers/namespaceinstance/provider.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"net/url"
 	"path"
+	"strconv"
 	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
@@ -14,6 +15,8 @@ func init() {
 }
 
 type Provider struct{}
+
+var _ core.ProviderClassSpecProvider = Provider{}
 
 func (Provider) Name() string      { return providerName }
 func (Provider) Aliases() []string { return []string{"namespace-compute"} }
@@ -133,4 +136,28 @@ func (Provider) ServerTypeForConfig(cfg core.Config) string {
 
 func (Provider) ServerTypeForClass(class string) string {
 	return machineTypeForClass(class)
+}
+
+func (Provider) ClassSpecs() []core.ClassSpec {
+	classes := []string{"standard", "fast", "large", "beast"}
+	specs := make([]core.ClassSpec, 0, len(classes))
+	for _, class := range classes {
+		machineType := machineTypeForClass(class)
+		vcpus, memoryGB := machineShape(machineType)
+		specs = append(specs, core.ClassSpec{Class: class, Type: machineType, VCPUs: vcpus, MemoryGB: memoryGB})
+	}
+	return specs
+}
+
+func machineShape(machineType string) (int, int) {
+	cpuValue, memoryValue, ok := strings.Cut(strings.ToLower(strings.TrimSpace(machineType)), "x")
+	if !ok || cpuValue == "" || memoryValue == "" || strings.Contains(memoryValue, "x") {
+		return 0, 0
+	}
+	vcpus, cpuErr := strconv.Atoi(cpuValue)
+	memoryGB, memoryErr := strconv.Atoi(memoryValue)
+	if cpuErr != nil || memoryErr != nil || vcpus <= 0 || memoryGB <= 0 {
+		return 0, 0
+	}
+	return vcpus, memoryGB
 }


### PR DESCRIPTION
## Summary

`--class standard|fast|large|beast` are provider-neutral intent labels, so the only way to learn
what a class actually gets you was to read `docs/features/providers.md`. This teaches the CLI to
report it: `crabbox providers --json` now emits, per provider, the concrete primary instance type
each class resolves to plus its nominal vCPU count and RAM.

```
$ crabbox providers --json | jq -c '.[] | select(.classes) | {provider, classes}'
{"provider":"aws","classes":[{"class":"standard","type":"c7a.8xlarge","vcpu":32,"memoryGb":64}, ...]}
```

Useful for capacity planning, quota math, scripting a size choice, and anything that wants to show
a machine size without hardcoding a per-provider table.

## Design

A new optional `ProviderClassSpecProvider` hook sits beside the existing `ProviderServerTypeProvider`
in `internal/cli/provider_backend.go`. `providerMatrix()` type-asserts it and fills a new
`classes` field; providers that do not implement it emit no `classes` key at all.

Per-provider shape knowledge lives in each provider's own package rather than in core, so the
`serverTypeForProviderClass` if-chain is not extended. Types come from the existing class tables —
no mapping, ordering, or fallback behaviour changed.

Implemented for the five providers whose classes vary by size and whose shapes are derivable:
aws, azure, gcp, hetzner, namespace-instance. Everything else is unchanged.

Shapes are derived, not hardcoded per class:
- AWS reuses the existing `awsInstanceTypeVCPUs` size parser, plus a family GiB-per-vCPU table
  (c7* = 2, m7*/m8* = 4, r7*/r8* = 8).
- Azure reuses the existing `azureVMSizeVCPUCount` parser; Dv6 is 4 GiB/vCPU.
- GCP parses the trailing vCPU count and applies a family ratio in **quarter-GB units**, because
  `c4-standard` is 3.75 GB/vCPU, not 4. A non-divisible result omits memory rather than rounding.
- Hetzner uses a small CCX table.
- namespace-instance parses its self-describing `CPUxMemoryGB` type strings.

Unknown families return the vCPU count with memory omitted. Nothing guesses; `vcpu`/`memoryGb` are
`omitempty` and never emitted as 0.

## Verification

```
gofmt -l $(git ls-files '*.go')          # clean
go build -trimpath -o bin/crabbox ./cmd/crabbox
go vet ./...                              # clean
go test -race ./internal/...              # all 85 packages pass
bash scripts/check-docs.sh                # 14/14, no generated drift
bash scripts/check-go-coverage.sh
```

Note for anyone reproducing locally: `internal/cli` needs ~20 minutes under `-race` on an Apple
Silicon laptop, so `go test -race ./internal/...` can exceed the 10-minute default timeout on a
loaded machine. Pass `-timeout 30m` or test the package on its own.

Vendor sources for every ratio used:
- AWS instance types: https://aws.amazon.com/ec2/instance-types/
- Azure Ddsv6: https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/general-purpose/ddsv6-series
- GCP machine families: https://docs.cloud.google.com/compute/docs/machine-resource
- Hetzner dedicated vCPU: https://www.hetzner.com/cloud/dedicated-vcpu/

## Config / secret implications

None. `providers --json` remains a static compiled report: no network, no credentials, no provider
API calls. The new field is additive and optional; existing fields and their ordering are unchanged.
