### PR TITLE
fix(version): ignore local VCS pseudo-versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixed
 
+- Kept local source and worktree builds on the `dev` identity instead of trusting Go 1.26 pseudo-versions synthesized from VCS metadata in another checkout.
 - Prevented confirmed `run --stop-after always` teardown from racing workspace-owner renewal and replacing successful, evidence-backed runs with exit 7. Thanks @coygeek.
 - Retried brief GitHub API failures during browser login and kept exhausted post-exchange attempts safely retryable instead of turning the next CLI poll into a terminal failure.
 - Bounded `crabbox claims list` inventory reads to 1 MiB per local claim while preserving valid partial output for oversized files. Thanks @coygeek.

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -9,18 +9,31 @@ var version = "dev"
 
 func currentVersion() string {
 	buildInfoVersion := ""
+	localVCSBuild := false
 	if info, ok := debug.ReadBuildInfo(); ok {
 		buildInfoVersion = info.Main.Version
+		for _, setting := range info.Settings {
+			if setting.Key == "vcs.revision" {
+				localVCSBuild = true
+				break
+			}
+		}
 	}
-	return resolveVersion(version, buildInfoVersion)
+	return resolveVersionForBuild(version, buildInfoVersion, localVCSBuild)
 }
 
 func resolveVersion(injected, buildInfoVersion string) string {
+	return resolveVersionForBuild(injected, buildInfoVersion, false)
+}
+
+func resolveVersionForBuild(injected, buildInfoVersion string, localVCSBuild bool) string {
 	if normalized := normalizeBuildVersion(injected); normalized != "" && normalized != "dev" && !strings.HasSuffix(normalized, "-dev") {
 		return normalized
 	}
-	if normalized := normalizeModuleBuildInfoVersion(buildInfoVersion); normalized != "" {
-		return normalized
+	if !localVCSBuild {
+		if normalized := normalizeModuleBuildInfoVersion(buildInfoVersion); normalized != "" {
+			return normalized
+		}
 	}
 	if normalized := normalizeBuildVersion(injected); normalized != "" {
 		return normalized

--- a/internal/cli/version_test.go
+++ b/internal/cli/version_test.go
@@ -25,6 +25,20 @@ func TestResolveVersionUsesPseudoBuildInfoForRevisionInstall(t *testing.T) {
 	}
 }
 
+func TestResolveVersionIgnoresPseudoVersionForLocalVCSBuild(t *testing.T) {
+	got := resolveVersionForBuild("dev", "v1.2.4-0.20260810123456-abcdef123456", true)
+	if got != "dev" {
+		t.Fatalf("version=%q want dev", got)
+	}
+}
+
+func TestResolveVersionKeepsInjectedReleaseForLocalVCSBuild(t *testing.T) {
+	got := resolveVersionForBuild("v1.2.3", "v1.2.4-0.20260810123456-abcdef123456", true)
+	if got != "1.2.3" {
+		t.Fatalf("version=%q want injected release", got)
+	}
+}
+
 func TestResolveVersionKeepsDevForDirtyBuildInfo(t *testing.T) {
 	got := resolveVersion("dev", "v1.2.4-0.20260810123456-abcdef123456+dirty")
 	if got != "dev" {


### PR DESCRIPTION
## Summary

- ignore synthesized main-module pseudo-versions when a build carries local VCS metadata
- preserve tagged and revision-based `go install` version reporting
- keep linker-injected release versions authoritative

## Root cause

Go 1.26 can stamp a linked worktree build with `vcs.revision` from the shared repository while also synthesizing `debug.BuildInfo.Main.Version` from another checkout. The new Go-install version fallback trusted that pseudo-version, so a local source build could report a stale released revision instead of `dev`.

## Verification

- focused version tests passed
- locally built CLI reports `dev`
- clean-cache remote Go installation still reports its synthetic module version and exact source
- `go vet ./...`, docs checks, and release workflow tests passed
- mandatory P1 autoreview found no actionable findings
- bounded full race run encountered one unrelated controller timing flake; the exact failing test passed independently under race
- live AWS smoke succeeded with `raw_socket=sudo`, workload exit 0, and confirmed lease cleanup
