### PR TITLE
chore(release): prepare v0.44.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.44.0 - 2026-08-18
 
 ### Added
 

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/crabbox-worker",
-  "version": "0.43.0",
+  "version": "0.44.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/crabbox-worker",
-      "version": "0.43.0",
+      "version": "0.44.0",
       "dependencies": {
         "@aws-sdk/credential-providers": "^3.1095.0",
         "@cloudflare/containers": "^0.3.7",

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/crabbox-worker",
-  "version": "0.43.0",
+  "version": "0.44.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Prepare Crabbox v0.44.0 from the fully tested current `main`:

- freeze the Unreleased changelog as `0.44.0 - 2026-08-18`
- bump the Worker package and both lockfile root versions to `0.44.0`

## Pre-release proof

- exact merged-main CI for the final version fix is green, including Direct Go install, Go, Worker, Docs, Scripts, Windows, Apple VM, connector smokes, Release Check, and CodeQL
- clean-cache direct Go installation passed at merged source `e0e2cdded9e085aed5652f822ed127f63022fe8b`
- local source/worktree build reports `dev`
- Worker format and type checks passed
- release workflow tests: 28/28 passed
- docs checks: 240 Markdown files and 14 generated-site tests passed
- live AWS run https://crabbox.openclaw.ai/portal/runs/run_9a7275098d34 succeeded with `raw_socket=sudo`, workload exit 0, and confirmed lease cleanup
- mandatory P1 autoreview found no actionable findings

This PR contains only the three version-carrying release-preparation files.
