### PR TITLE
chore(release): authorize v0.44.0 source

### DIFF
--- a/release/records/v0.44.0.json
+++ b/release/records/v0.44.0.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "repository": "openclaw/crabbox",
+  "tag": "v0.44.0",
+  "tagObject": "7c04944f02fedb882434b8eea739c05398f56019",
+  "sourceCommit": "a12e4cf60ecb98be55ffa8e46bf3bcd96b782704",
+  "publicationStatus": "ready"
+}


### PR DESCRIPTION
## Summary

Authorize the immutable v0.44.0 release source:

- signed tag object: `7c04944f02fedb882434b8eea739c05398f56019`
- peeled source commit: `a12e4cf60ecb98be55ffa8e46bf3bcd96b782704`
- publication status: `ready`

The signed tag annotation is exactly `v0.44.0`, the signature verifies against the repository signer policy, and the source commit is the merged release-preparation commit on protected `main`.

## Verification

- `scripts/verify-release-source.sh` passed with `REQUIRE_PUBLISHABLE=1`
- mandatory P1 autoreview found no actionable findings
- this PR adds only `release/records/v0.44.0.json`
