### PR TITLE
fix(release): resolve drafts by exact tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.44.1 - Unreleased
+
+### Fixed
+
+- Made private draft verification resolve the exact draft by tag and numeric release ID instead of relying on a release-list endpoint that can omit drafts.
+
 ## 0.44.0 - 2026-08-18
 
 ### Added

--- a/scripts/create-release-draft.sh
+++ b/scripts/create-release-draft.sh
@@ -89,13 +89,12 @@ env -i \
   "$ROOT/scripts/verify-release.sh" \
     "$TAG" "$ASSET_DIR" "$TAG_OBJECT" "$TAG_COMMIT" "$VERIFIER_COMMIT"
 
-releases="$verify_home/releases.json"
-gh api --paginate --slurp "repos/$CRABBOX_RELEASE_REPOSITORY/releases?per_page=100" >"$releases"
-matches=$(jq --arg tag "$TAG" '[.[][] | select(.tag_name == $tag)] | length' "$releases")
-[[ "$matches" == 0 ]] || {
+release_view="$verify_home/release-view.json"
+if gh release view "$TAG" --repo "$CRABBOX_RELEASE_REPOSITORY" \
+  --json databaseId >"$release_view" 2>/dev/null; then
   echo "release record already exists for $TAG; refusing to delete or replace it" >&2
   exit 1
-}
+fi
 
 notes="$verify_home/release-notes.md"
 tagged_changelog="$verify_home/tagged-changelog.md"
@@ -117,12 +116,9 @@ gh release create "$TAG" \
   --notes-file "$notes" \
   "${assets[@]}"
 
-gh api --paginate --slurp "repos/$CRABBOX_RELEASE_REPOSITORY/releases?per_page=100" >"$releases"
-jq --arg tag "$TAG" \
-  '[.[][] | select(.tag_name == $tag and .draft == true and .prerelease == false)]
-   | if length == 1 then .[0] else error("expected exactly one private draft") end' \
-  "$releases" >"$verify_home/release.json"
-release_id=$(jq -r '.id' "$verify_home/release.json")
+gh release view "$TAG" --repo "$CRABBOX_RELEASE_REPOSITORY" \
+  --json databaseId >"$release_view"
+release_id=$(jq -r '.databaseId' "$release_view")
 [[ "$release_id" =~ ^[1-9][0-9]*$ ]]
 gh api --method GET "repos/$CRABBOX_RELEASE_REPOSITORY/releases/$release_id" \
   >"$verify_home/release.json"

--- a/scripts/release-workflow.test.js
+++ b/scripts/release-workflow.test.js
@@ -1001,9 +1001,9 @@ test("credential-bearing packager is pipefail-safe and removes read-only Go tool
 test("draft creation performs static-only verification and never deletes or replaces partial records", () => {
   const script = read("scripts/create-release-draft.sh");
   const verifyIndex = script.indexOf('env -i');
-  const listIndex = script.indexOf('gh api --paginate');
+  const lookupIndex = script.indexOf('gh release view "$TAG"');
   const createIndex = script.indexOf('gh release create');
-  assert.ok(verifyIndex >= 0 && verifyIndex < listIndex && listIndex < createIndex);
+  assert.ok(verifyIndex >= 0 && verifyIndex < lookupIndex && lookupIndex < createIndex);
   assert.match(script, /CRABBOX_VERIFY_MODE=static/);
   assert.doesNotMatch(script, /CRABBOX_VERIFY_MODE=execute/);
   assert.match(script, /--draft/);
@@ -1011,6 +1011,9 @@ test("draft creation performs static-only verification and never deletes or repl
   assert.doesNotMatch(script, /--target/);
   assert.doesNotMatch(script, /target_commitish !== process\.env\.RELEASE_COMMIT/);
   assert.match(script, /--notes-file "\$notes"/);
+  assert.match(script, /--json databaseId/);
+  assert.match(script, /releases\/\$release_id/);
+  assert.doesNotMatch(script, /gh api --paginate/);
   assert.match(script, /refusing to delete or replace it/);
   assert.doesNotMatch(script, /--method (?:DELETE|PATCH|PUT)|gh release (?:delete|edit|upload)/);
 });


### PR DESCRIPTION
## Summary

- open v0.44.1 development after the verified v0.44.0 release
- detect existing releases through exact tag lookup, including private drafts
- resolve the newly created draft's numeric ID through `gh release view`, then fetch the canonical REST record for full validation and byte comparison

## Root cause

During v0.44.0, `gh release create --draft` successfully created release `372392709`, but the paginated release-list endpoint used by the post-upload gate omitted that private draft for the active CLI credential. Exact tag lookup and numeric lookup both returned it correctly. The script therefore stopped after upload even though the immutable draft was complete.

No release was deleted or recreated. The existing numeric draft was independently validated, published, and passed public/native/Homebrew verification.

## Verification

- ShellCheck passed with repository source path
- release workflow tests: 28/28 passed
- docs checks passed
- mandatory P1 autoreview found no actionable findings
- v0.44.0 public verification: https://github.com/openclaw/crabbox/actions/runs/32147337666
- v0.44.0 Homebrew verification: https://github.com/openclaw/crabbox/actions/runs/32148382946
