### PR TITLE
fix(http): do not panic if DefaultTransport is replaced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- Rejected nil or unsupported process-wide HTTP transports with a clear setup error instead of panicking or bypassing host network policy, while preserving explicitly injected clients. Thanks @SebTardif.
 - Kept explicit Hetzner server-type requests exact instead of continuing through class fallback candidates after capacity errors.
 - Made private draft verification resolve the exact draft by tag and numeric release ID instead of relying on a release-list endpoint that can omit drafts.
 

--- a/internal/cli/http_redirect.go
+++ b/internal/cli/http_redirect.go
@@ -7,6 +7,15 @@ import (
 	"strings"
 )
 
+// CloneDefaultTransport copies http.DefaultTransport when it is a *http.Transport.
+// A replaced non-transport RoundTripper falls back to a new Transport.
+func CloneDefaultTransport() *http.Transport {
+	if transport, ok := http.DefaultTransport.(*http.Transport); ok {
+		return transport.Clone()
+	}
+	return &http.Transport{}
+}
+
 // redirectCheckedHTTPClient clones source so callers can constrain redirects
 // without mutating a shared client or discarding its transport and timeouts.
 func redirectCheckedHTTPClient(source *http.Client, check func(*http.Request) error) *http.Client {

--- a/internal/cli/http_redirect.go
+++ b/internal/cli/http_redirect.go
@@ -2,18 +2,36 @@ package cli
 
 import (
 	"errors"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 )
 
 // CloneDefaultTransport copies http.DefaultTransport when it is a *http.Transport.
-// A replaced non-transport RoundTripper falls back to a new Transport.
+// A replaced non-transport RoundTripper falls back to standard Transport defaults,
+// including environment proxy lookup.
 func CloneDefaultTransport() *http.Transport {
 	if transport, ok := http.DefaultTransport.(*http.Transport); ok {
 		return transport.Clone()
 	}
-	return &http.Transport{}
+	return newStandardHTTPTransport()
+}
+
+func newStandardHTTPTransport() *http.Transport {
+	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
 }
 
 // redirectCheckedHTTPClient clones source so callers can constrain redirects

--- a/internal/cli/http_redirect.go
+++ b/internal/cli/http_redirect.go
@@ -2,36 +2,22 @@ package cli
 
 import (
 	"errors"
-	"net"
 	"net/http"
 	"net/url"
 	"strings"
-	"time"
 )
 
-// CloneDefaultTransport copies http.DefaultTransport when it is a *http.Transport.
-// A replaced non-transport RoundTripper falls back to standard Transport defaults,
-// including environment proxy lookup.
-func CloneDefaultTransport() *http.Transport {
-	if transport, ok := http.DefaultTransport.(*http.Transport); ok {
-		return transport.Clone()
-	}
-	return newStandardHTTPTransport()
-}
+const cloneDefaultTransportError = "http.DefaultTransport must be a non-nil *http.Transport; inject an explicit HTTP client where supported"
 
-func newStandardHTTPTransport() *http.Transport {
-	return &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		DialContext: (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-		}).DialContext,
-		ForceAttemptHTTP2:     true,
-		MaxIdleConns:          100,
-		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
+// CloneDefaultTransport copies http.DefaultTransport when it is a non-nil
+// *http.Transport. Callers that need to mutate transport settings must not
+// bypass a process-wide custom RoundTripper.
+func CloneDefaultTransport() (*http.Transport, error) {
+	transport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok || transport == nil {
+		return nil, errors.New(cloneDefaultTransportError)
 	}
+	return transport.Clone(), nil
 }
 
 // redirectCheckedHTTPClient clones source so callers can constrain redirects

--- a/internal/cli/http_redirect_test.go
+++ b/internal/cli/http_redirect_test.go
@@ -2,7 +2,9 @@ package cli
 
 import (
 	"fmt"
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
@@ -37,5 +39,38 @@ func TestCloneDefaultTransportCopiesRealDefaultTransport(t *testing.T) {
 	}
 	if cloned == original {
 		t.Fatal("clone reused http.DefaultTransport")
+	}
+}
+
+func TestCloneDefaultTransportFallbackRoutesThroughProxy(t *testing.T) {
+	proxied := 0
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		proxied++
+		if r.Method != http.MethodGet || r.URL.Host == "" {
+			t.Errorf("proxy request method=%s host=%q", r.Method, r.URL.Host)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "proxied")
+	}))
+	t.Cleanup(proxy.Close)
+
+	original := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = original
+	})
+	http.DefaultTransport = unusedDefaultRoundTripper{}
+	t.Setenv("HTTP_PROXY", proxy.URL)
+	t.Setenv("HTTPS_PROXY", proxy.URL)
+	t.Setenv("NO_PROXY", "")
+	t.Setenv("ALL_PROXY", "")
+
+	client := &http.Client{Transport: CloneDefaultTransport()}
+	resp, err := client.Get("http://example.invalid/fallback")
+	if err != nil {
+		t.Fatalf("fallback request: %v", err)
+	}
+	defer resp.Body.Close()
+	if proxied == 0 {
+		t.Fatal("fallback transport did not send the request through HTTP_PROXY")
 	}
 }

--- a/internal/cli/http_redirect_test.go
+++ b/internal/cli/http_redirect_test.go
@@ -1,0 +1,41 @@
+package cli
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+type unusedDefaultRoundTripper struct{}
+
+func (unusedDefaultRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, fmt.Errorf("unused default transport")
+}
+
+func TestCloneDefaultTransportAcceptsNonTransportDefault(t *testing.T) {
+	original := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = original
+	})
+	http.DefaultTransport = unusedDefaultRoundTripper{}
+
+	transport := CloneDefaultTransport()
+	if transport == nil {
+		t.Fatal("cloned transport is nil")
+	}
+}
+
+func TestCloneDefaultTransportCopiesRealDefaultTransport(t *testing.T) {
+	original, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		t.Skip("http.DefaultTransport is not *http.Transport")
+	}
+
+	cloned := CloneDefaultTransport()
+	if cloned == nil {
+		t.Fatal("cloned transport is nil")
+	}
+	if cloned == original {
+		t.Fatal("clone reused http.DefaultTransport")
+	}
+}

--- a/internal/cli/http_redirect_test.go
+++ b/internal/cli/http_redirect_test.go
@@ -1,120 +1,101 @@
 package cli
 
 import (
-	"fmt"
-	"io"
+	"crypto/tls"
+	"errors"
 	"net/http"
-	"net/http/httptest"
-	"os"
-	"os/exec"
-	"strings"
 	"testing"
+	"time"
 )
 
-type unusedDefaultRoundTripper struct{}
-
-func (unusedDefaultRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
-	return nil, fmt.Errorf("unused default transport")
+type recordingDefaultRoundTripper struct {
+	calls int
 }
 
-func TestCloneDefaultTransportAcceptsNonTransportDefault(t *testing.T) {
-	original := http.DefaultTransport
-	t.Cleanup(func() {
-		http.DefaultTransport = original
-	})
-	http.DefaultTransport = unusedDefaultRoundTripper{}
+func (r *recordingDefaultRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	r.calls++
+	return nil, errors.New("deny all")
+}
 
-	transport := CloneDefaultTransport()
-	if transport == nil {
-		t.Fatal("cloned transport is nil")
+func TestCloneDefaultTransportRejectsUnsupportedDefaults(t *testing.T) {
+	recorder := &recordingDefaultRoundTripper{}
+	var typedNil *http.Transport
+	tests := []struct {
+		name      string
+		transport http.RoundTripper
+	}{
+		{name: "recording wrapper", transport: recorder},
+		{name: "nil", transport: nil},
+		{name: "typed nil transport", transport: typedNil},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			original := http.DefaultTransport
+			t.Cleanup(func() { http.DefaultTransport = original })
+			http.DefaultTransport = tc.transport
+
+			transport, err := CloneDefaultTransport()
+			if transport != nil {
+				t.Fatalf("transport=%#v, want nil", transport)
+			}
+			if err == nil || err.Error() != cloneDefaultTransportError {
+				t.Fatalf("error=%v, want %q", err, cloneDefaultTransportError)
+			}
+		})
+	}
+	if recorder.calls != 0 {
+		t.Fatalf("recording default invoked %d times, want 0", recorder.calls)
 	}
 }
 
-func TestCloneDefaultTransportCopiesRealDefaultTransport(t *testing.T) {
-	original, ok := http.DefaultTransport.(*http.Transport)
-	if !ok {
-		t.Skip("http.DefaultTransport is not *http.Transport")
-	}
+func TestCloneDefaultTransportPreservesSettingsAndIsolatesMutableState(t *testing.T) {
+	originalDefault := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalDefault })
 
-	cloned := CloneDefaultTransport()
-	if cloned == nil {
-		t.Fatal("cloned transport is nil")
+	original := &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          37,
+		ResponseHeaderTimeout: 19 * time.Second,
+		TLSClientConfig:       &tls.Config{MinVersion: tls.VersionTLS12},
+		ProxyConnectHeader:    http.Header{"X-Trace": {"preserved"}},
+		TLSNextProto: map[string]func(string, *tls.Conn) http.RoundTripper{
+			"custom": nil,
+		},
+	}
+	http.DefaultTransport = original
+
+	cloned, err := CloneDefaultTransport()
+	if err != nil {
+		t.Fatal(err)
 	}
 	if cloned == original {
 		t.Fatal("clone reused http.DefaultTransport")
 	}
-}
-
-func TestCloneDefaultTransportFallbackRoutesThroughProxy(t *testing.T) {
-	if os.Getenv("CRABBOX_CLONE_TRANSPORT_PROXY_CHILD") == "1" {
-		runCloneDefaultTransportProxyChild(t)
-		return
+	if cloned.Proxy == nil || !cloned.ForceAttemptHTTP2 || cloned.MaxIdleConns != 37 || cloned.ResponseHeaderTimeout != 19*time.Second {
+		t.Fatalf("clone lost transport settings: %#v", cloned)
+	}
+	if cloned.TLSClientConfig == nil || cloned.TLSClientConfig.MinVersion != tls.VersionTLS12 {
+		t.Fatalf("clone lost TLS settings: %#v", cloned.TLSClientConfig)
+	}
+	if cloned.ProxyConnectHeader.Get("X-Trace") != "preserved" {
+		t.Fatalf("clone lost proxy headers: %#v", cloned.ProxyConnectHeader)
+	}
+	if _, ok := cloned.TLSNextProto["custom"]; !ok {
+		t.Fatalf("clone lost TLSNextProto: %#v", cloned.TLSNextProto)
 	}
 
-	proxied := 0
-	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		proxied++
-		if r.Method != http.MethodGet || r.URL.Host == "" {
-			t.Errorf("proxy request method=%s host=%q", r.Method, r.URL.Host)
-		}
-		w.WriteHeader(http.StatusOK)
-		_, _ = io.WriteString(w, "proxied")
-	}))
-	t.Cleanup(proxy.Close)
-
-	cmd := exec.Command(os.Args[0], "-test.run=^TestCloneDefaultTransportFallbackRoutesThroughProxy$", "-test.count=1")
-	cmd.Env = cloneTransportProxyChildEnv(proxy.URL)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("child process: %v\n%s", err, out)
+	cloned.TLSClientConfig.MinVersion = tls.VersionTLS13
+	cloned.ProxyConnectHeader.Set("X-Trace", "changed")
+	delete(cloned.TLSNextProto, "custom")
+	if original.TLSClientConfig.MinVersion != tls.VersionTLS12 {
+		t.Fatal("clone shared TLSClientConfig with default transport")
 	}
-	if proxied == 0 {
-		t.Fatalf("parent proxy received no request\n%s", out)
+	if original.ProxyConnectHeader.Get("X-Trace") != "preserved" {
+		t.Fatal("clone shared ProxyConnectHeader with default transport")
 	}
-}
-
-func runCloneDefaultTransportProxyChild(t *testing.T) {
-	http.DefaultTransport = unusedDefaultRoundTripper{}
-	transport := CloneDefaultTransport()
-	if transport.Proxy == nil {
-		t.Fatal("fallback Proxy is nil, want ProxyFromEnvironment")
+	if _, ok := original.TLSNextProto["custom"]; !ok {
+		t.Fatal("clone shared TLSNextProto with default transport")
 	}
-	client := &http.Client{Transport: transport}
-	resp, err := client.Get("http://example.invalid/fallback")
-	if err != nil {
-		t.Fatalf("fallback request: %v", err)
-	}
-	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(body) != "proxied" {
-		t.Fatalf("body=%q, want proxied", body)
-	}
-}
-
-func cloneTransportProxyChildEnv(proxyURL string) []string {
-	skip := map[string]bool{
-		"HTTP_PROXY": true, "HTTPS_PROXY": true, "NO_PROXY": true, "ALL_PROXY": true,
-		"http_proxy": true, "https_proxy": true, "no_proxy": true, "all_proxy": true,
-	}
-	env := make([]string, 0, 16)
-	for _, item := range os.Environ() {
-		key, _, _ := strings.Cut(item, "=")
-		if skip[key] {
-			continue
-		}
-		env = append(env, item)
-	}
-	return append(env,
-		"CRABBOX_CLONE_TRANSPORT_PROXY_CHILD=1",
-		"HTTP_PROXY="+proxyURL,
-		"HTTPS_PROXY="+proxyURL,
-		"NO_PROXY=",
-		"ALL_PROXY=",
-		"http_proxy="+proxyURL,
-		"https_proxy="+proxyURL,
-		"no_proxy=",
-	)
 }

--- a/internal/cli/http_redirect_test.go
+++ b/internal/cli/http_redirect_test.go
@@ -5,7 +5,9 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
+	"os"
+	"os/exec"
+	"strings"
 	"testing"
 )
 
@@ -44,6 +46,11 @@ func TestCloneDefaultTransportCopiesRealDefaultTransport(t *testing.T) {
 }
 
 func TestCloneDefaultTransportFallbackRoutesThroughProxy(t *testing.T) {
+	if os.Getenv("CRABBOX_CLONE_TRANSPORT_PROXY_CHILD") == "1" {
+		runCloneDefaultTransportProxyChild(t)
+		return
+	}
+
 	proxied := 0
 	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		proxied++
@@ -55,32 +62,59 @@ func TestCloneDefaultTransportFallbackRoutesThroughProxy(t *testing.T) {
 	}))
 	t.Cleanup(proxy.Close)
 
-	original := http.DefaultTransport
-	t.Cleanup(func() {
-		http.DefaultTransport = original
-	})
-	http.DefaultTransport = unusedDefaultRoundTripper{}
+	cmd := exec.Command(os.Args[0], "-test.run=^TestCloneDefaultTransportFallbackRoutesThroughProxy$", "-test.count=1")
+	cmd.Env = cloneTransportProxyChildEnv(proxy.URL)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("child process: %v\n%s", err, out)
+	}
+	if proxied == 0 {
+		t.Fatalf("parent proxy received no request\n%s", out)
+	}
+}
 
+func runCloneDefaultTransportProxyChild(t *testing.T) {
+	http.DefaultTransport = unusedDefaultRoundTripper{}
 	transport := CloneDefaultTransport()
 	if transport.Proxy == nil {
-		t.Fatal("fallback Proxy is nil, want environment proxy lookup")
+		t.Fatal("fallback Proxy is nil, want ProxyFromEnvironment")
 	}
-	// ProxyFromEnvironment caches process env on first use, so a later
-	// t.Setenv(HTTP_PROXY) is ignored in the full package suite. Prove the
-	// returned transport can still send through a local proxy.
-	proxyURL, err := url.Parse(proxy.URL)
-	if err != nil {
-		t.Fatal(err)
-	}
-	transport.Proxy = http.ProxyURL(proxyURL)
-
 	client := &http.Client{Transport: transport}
 	resp, err := client.Get("http://example.invalid/fallback")
 	if err != nil {
 		t.Fatalf("fallback request: %v", err)
 	}
 	defer resp.Body.Close()
-	if proxied == 0 {
-		t.Fatal("fallback transport did not send the request through the local proxy")
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
 	}
+	if string(body) != "proxied" {
+		t.Fatalf("body=%q, want proxied", body)
+	}
+}
+
+func cloneTransportProxyChildEnv(proxyURL string) []string {
+	skip := map[string]bool{
+		"HTTP_PROXY": true, "HTTPS_PROXY": true, "NO_PROXY": true, "ALL_PROXY": true,
+		"http_proxy": true, "https_proxy": true, "no_proxy": true, "all_proxy": true,
+	}
+	env := make([]string, 0, 16)
+	for _, item := range os.Environ() {
+		key, _, _ := strings.Cut(item, "=")
+		if skip[key] {
+			continue
+		}
+		env = append(env, item)
+	}
+	return append(env,
+		"CRABBOX_CLONE_TRANSPORT_PROXY_CHILD=1",
+		"HTTP_PROXY="+proxyURL,
+		"HTTPS_PROXY="+proxyURL,
+		"NO_PROXY=",
+		"ALL_PROXY=",
+		"http_proxy="+proxyURL,
+		"https_proxy="+proxyURL,
+		"no_proxy=",
+	)
 }

--- a/internal/cli/http_redirect_test.go
+++ b/internal/cli/http_redirect_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 )
 
@@ -59,18 +60,27 @@ func TestCloneDefaultTransportFallbackRoutesThroughProxy(t *testing.T) {
 		http.DefaultTransport = original
 	})
 	http.DefaultTransport = unusedDefaultRoundTripper{}
-	t.Setenv("HTTP_PROXY", proxy.URL)
-	t.Setenv("HTTPS_PROXY", proxy.URL)
-	t.Setenv("NO_PROXY", "")
-	t.Setenv("ALL_PROXY", "")
 
-	client := &http.Client{Transport: CloneDefaultTransport()}
+	transport := CloneDefaultTransport()
+	if transport.Proxy == nil {
+		t.Fatal("fallback Proxy is nil, want environment proxy lookup")
+	}
+	// ProxyFromEnvironment caches process env on first use, so a later
+	// t.Setenv(HTTP_PROXY) is ignored in the full package suite. Prove the
+	// returned transport can still send through a local proxy.
+	proxyURL, err := url.Parse(proxy.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	transport.Proxy = http.ProxyURL(proxyURL)
+
+	client := &http.Client{Transport: transport}
 	resp, err := client.Get("http://example.invalid/fallback")
 	if err != nil {
 		t.Fatalf("fallback request: %v", err)
 	}
 	defer resp.Body.Close()
 	if proxied == 0 {
-		t.Fatal("fallback transport did not send the request through HTTP_PROXY")
+		t.Fatal("fallback transport did not send the request through the local proxy")
 	}
 }

--- a/internal/cli/proxmox.go
+++ b/internal/cli/proxmox.go
@@ -86,7 +86,10 @@ func NewProxmoxClient(cfg Config) (*ProxmoxClient, error) {
 	}
 	client := &http.Client{Timeout: 60 * time.Second}
 	if cfg.Proxmox.InsecureTLS {
-		transport := CloneDefaultTransport()
+		transport, err := CloneDefaultTransport()
+		if err != nil {
+			return nil, fmt.Errorf("proxmox HTTP client setup: %w", err)
+		}
 		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // User opt-in for self-signed private Proxmox clusters.
 		client.Transport = transport
 	}

--- a/internal/cli/proxmox.go
+++ b/internal/cli/proxmox.go
@@ -86,7 +86,7 @@ func NewProxmoxClient(cfg Config) (*ProxmoxClient, error) {
 	}
 	client := &http.Client{Timeout: 60 * time.Second}
 	if cfg.Proxmox.InsecureTLS {
-		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport := CloneDefaultTransport()
 		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // User opt-in for self-signed private Proxmox clusters.
 		client.Transport = transport
 	}

--- a/internal/cli/proxmox_test.go
+++ b/internal/cli/proxmox_test.go
@@ -58,6 +58,46 @@ func TestNewProxmoxClientStripsAPIPathAndUsesTokenAuth(t *testing.T) {
 	}
 }
 
+func TestNewProxmoxClientRejectsUnsupportedDefaultTransportForInsecureTLS(t *testing.T) {
+	original := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = original })
+	recorder := &recordingDefaultRoundTripper{}
+	http.DefaultTransport = recorder
+	cfg := baseConfig()
+	cfg.Proxmox.APIURL = "https://proxmox.example.test"
+	cfg.Proxmox.TokenID = "runner@pve!crabbox"
+	cfg.Proxmox.TokenSecret = "secret"
+	cfg.Proxmox.Node = "pve1"
+	cfg.Proxmox.InsecureTLS = true
+
+	client, err := NewProxmoxClient(cfg)
+	if client != nil || err == nil || !strings.Contains(err.Error(), "non-nil *http.Transport") {
+		t.Fatalf("client=%#v err=%v, want transport setup error", client, err)
+	}
+	if recorder.calls != 0 {
+		t.Fatalf("custom default invoked %d times, want 0", recorder.calls)
+	}
+}
+
+func TestNewProxmoxClientAllowsUnsupportedDefaultTransportWithoutTLSMutation(t *testing.T) {
+	original := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = original })
+	http.DefaultTransport = &recordingDefaultRoundTripper{}
+	cfg := baseConfig()
+	cfg.Proxmox.APIURL = "https://proxmox.example.test"
+	cfg.Proxmox.TokenID = "runner@pve!crabbox"
+	cfg.Proxmox.TokenSecret = "secret"
+	cfg.Proxmox.Node = "pve1"
+
+	client, err := NewProxmoxClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.Client.Transport != nil {
+		t.Fatalf("transport=%T, want nil client transport", client.Client.Transport)
+	}
+}
+
 func TestProxmoxClientRedactsCredentialsFromHTTPErrorBody(t *testing.T) {
 	const (
 		tokenID     = "runner@pve!crabbox"

--- a/internal/providers/awslambdamicrovm/backend.go
+++ b/internal/providers/awslambdamicrovm/backend.go
@@ -25,7 +25,7 @@ type backend struct {
 	cfg        Config
 	rt         Runtime
 	newControl func(context.Context, Config) (controlPlane, error)
-	newRunner  func(controlPlane, Config, Runtime) runnerAPI
+	newRunner  func(controlPlane, Config, Runtime) (runnerAPI, error)
 }
 
 func newBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
@@ -34,7 +34,7 @@ func newBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
 		cfg:        cfg,
 		rt:         rt,
 		newControl: newControlPlane,
-		newRunner: func(control controlPlane, cfg Config, rt Runtime) runnerAPI {
+		newRunner: func(control controlPlane, cfg Config, rt Runtime) (runnerAPI, error) {
 			return newRunnerClient(control, rt.HTTP, cfg.AWSRegion)
 		},
 	}
@@ -367,7 +367,11 @@ func (b *backend) clients(ctx context.Context) (controlPlane, runnerAPI, error) 
 	if err != nil {
 		return nil, nil, err
 	}
-	return control, b.newRunner(control, b.cfg, b.rt), nil
+	runner, err := b.newRunner(control, b.cfg, b.rt)
+	if err != nil {
+		return nil, nil, err
+	}
+	return control, runner, nil
 }
 
 func (b *backend) create(ctx context.Context, control controlPlane, runner runnerAPI, repo Repo, requestedSlug string, keep, reclaim bool) (string, string, microVM, error) {

--- a/internal/providers/awslambdamicrovm/backend_test.go
+++ b/internal/providers/awslambdamicrovm/backend_test.go
@@ -263,7 +263,7 @@ func TestRunnerClientExecPreservesBinaryOutput(t *testing.T) {
 			Request:    req,
 		}, nil
 	})}
-	client := newRunnerClient(&fakeControlPlane{}, httpClient, "eu-west-1")
+	client := mustNewRunnerClient(t, &fakeControlPlane{}, httpClient, "eu-west-1")
 	var stdout bytes.Buffer
 	gotExit, err := client.Exec(context.Background(), microVM{ID: "mvm-test", Endpoint: "mvm-test.lambda-microvm.eu-west-1.on.aws"}, "true", "/workspace/crabbox", nil, &stdout, io.Discard)
 	if err != nil {
@@ -275,7 +275,7 @@ func TestRunnerClientExecPreservesBinaryOutput(t *testing.T) {
 }
 
 func TestNewRunnerClientDefaultsResponseHeaderTimeout(t *testing.T) {
-	client := newRunnerClient(&fakeControlPlane{}, nil, "eu-west-1")
+	client := mustNewRunnerClient(t, &fakeControlPlane{}, nil, "eu-west-1")
 	if client.http == nil {
 		t.Fatal("expected default HTTP client")
 	}
@@ -294,6 +294,43 @@ func TestNewRunnerClientDefaultsResponseHeaderTimeout(t *testing.T) {
 	}
 }
 
+func TestNewRunnerClientRejectsUnsupportedDefaultTransport(t *testing.T) {
+	original := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = original })
+	var calls atomic.Int32
+	http.DefaultTransport = roundTripFunc(func(*http.Request) (*http.Response, error) {
+		calls.Add(1)
+		return nil, errors.New("deny all")
+	})
+
+	client, err := newRunnerClient(&fakeControlPlane{}, nil, "eu-west-1")
+	if client != nil || err == nil || !strings.Contains(err.Error(), "non-nil *http.Transport") {
+		t.Fatalf("client=%#v err=%v, want transport setup error", client, err)
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("custom default invoked %d times, want 0", calls.Load())
+	}
+}
+
+func TestNewRunnerClientAcceptsExplicitClientWithUnsupportedDefault(t *testing.T) {
+	original := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = original })
+	http.DefaultTransport = roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("deny all")
+	})
+	injected := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("injected")
+	})}
+
+	client, err := newRunnerClient(&fakeControlPlane{}, injected, "eu-west-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := client.http.Transport.(roundTripFunc); !ok {
+		t.Fatalf("transport=%T, want explicit roundTripFunc", client.http.Transport)
+	}
+}
+
 func TestDefaultRunnerHTTPClientTimesOutBeforeResponseHeaders(t *testing.T) {
 	const bound = 40 * time.Millisecond
 	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
@@ -302,7 +339,8 @@ func TestDefaultRunnerHTTPClientTimesOutBeforeResponseHeaders(t *testing.T) {
 	defer server.Close()
 
 	started := time.Now()
-	_, err := defaultRunnerHTTPClient(bound).Get(server.URL)
+	client := mustDefaultRunnerHTTPClient(t, bound)
+	_, err := client.Get(server.URL)
 	elapsed := time.Since(started)
 	if err == nil {
 		t.Fatal("request with withheld response headers unexpectedly succeeded")
@@ -329,7 +367,8 @@ func TestDefaultRunnerHTTPClientStreamsPastResponseHeaderTimeout(t *testing.T) {
 	defer server.Close()
 
 	started := time.Now()
-	resp, err := defaultRunnerHTTPClient(bound).Get(server.URL)
+	client := mustDefaultRunnerHTTPClient(t, bound)
+	resp, err := client.Get(server.URL)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -373,7 +412,8 @@ func TestDefaultRunnerHTTPClientUploadsPastResponseHeaderTimeout(t *testing.T) {
 		_ = writer.Close()
 	}()
 	started := time.Now()
-	resp, err := defaultRunnerHTTPClient(bound).Post(server.URL, "application/gzip", reader)
+	client := mustDefaultRunnerHTTPClient(t, bound)
+	resp, err := client.Post(server.URL, "application/gzip", reader)
 	elapsed := time.Since(started)
 	if err != nil {
 		t.Fatal(err)
@@ -405,7 +445,7 @@ func TestNewRunnerClientPreservesInjectedHTTPSettingsOnClone(t *testing.T) {
 		Timeout:   17 * time.Second,
 	}
 
-	client := newRunnerClient(&fakeControlPlane{}, injected, "eu-west-1")
+	client := mustNewRunnerClient(t, &fakeControlPlane{}, injected, "eu-west-1")
 	if client.http == injected {
 		t.Fatal("runner reused the injected client instead of cloning it")
 	}
@@ -433,7 +473,7 @@ func TestNewRunnerClientPreservesStricterSameOriginRedirectPolicy(t *testing.T) 
 		callerChecks.Add(1)
 		return callerErr
 	}
-	client := newRunnerClient(&fakeControlPlane{}, injected, "eu-west-1")
+	client := mustNewRunnerClient(t, &fakeControlPlane{}, injected, "eu-west-1")
 
 	_, err := client.http.Get(server.URL)
 	if !errors.Is(err, callerErr) {
@@ -472,7 +512,7 @@ func TestNewRunnerClientRejectsCrossOriginRedirectBeforeInjectedPolicy(t *testin
 					return nil
 				}
 			}
-			client := newRunnerClient(&fakeControlPlane{}, injected, "eu-west-1")
+			client := mustNewRunnerClient(t, &fakeControlPlane{}, injected, "eu-west-1")
 			err := client.http.CheckRedirect(&http.Request{URL: target}, []*http.Request{{URL: origin}})
 			if err == nil || !strings.Contains(err.Error(), "refused cross-origin redirect") {
 				t.Fatalf("redirect error=%v want cross-origin refusal", err)
@@ -490,7 +530,7 @@ func TestNewRunnerClientRetainsDefaultSameOriginRedirectLimit(t *testing.T) {
 		t.Fatal(err)
 	}
 	injected := &http.Client{}
-	client := newRunnerClient(&fakeControlPlane{}, injected, "eu-west-1")
+	client := mustNewRunnerClient(t, &fakeControlPlane{}, injected, "eu-west-1")
 	request := &http.Request{URL: origin}
 	via := make([]*http.Request, 10)
 	for i := range via {
@@ -538,7 +578,7 @@ func TestRunnerClientCrossOriginRedirectNeverSendsProxyHeaders(t *testing.T) {
 			return nil
 		},
 	}
-	client := newRunnerClient(&fakeControlPlane{}, injected, "eu-west-1")
+	client := mustNewRunnerClient(t, &fakeControlPlane{}, injected, "eu-west-1")
 	err = client.Health(context.Background(), microVM{ID: "mvm-test", Endpoint: "mvm-test.lambda-microvm.eu-west-1.on.aws"})
 	if err == nil || !strings.Contains(err.Error(), "refused cross-origin redirect") {
 		t.Fatalf("Health error=%v want cross-origin refusal", err)
@@ -684,8 +724,26 @@ func testBackend(control *fakeControlPlane, runner *fakeRunner, stdout io.Writer
 		newControl: func(context.Context, Config) (controlPlane, error) {
 			return control, nil
 		},
-		newRunner: func(controlPlane, Config, Runtime) runnerAPI { return runner },
+		newRunner: func(controlPlane, Config, Runtime) (runnerAPI, error) { return runner, nil },
 	}
+}
+
+func mustNewRunnerClient(t *testing.T, control controlPlane, source *http.Client, region string) *runnerClient {
+	t.Helper()
+	client, err := newRunnerClient(control, source, region)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}
+
+func mustDefaultRunnerHTTPClient(t *testing.T, timeout time.Duration) *http.Client {
+	t.Helper()
+	client, err := defaultRunnerHTTPClient(timeout)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
 }
 
 func testRepo(t *testing.T) string {

--- a/internal/providers/awslambdamicrovm/client.go
+++ b/internal/providers/awslambdamicrovm/client.go
@@ -18,6 +18,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/lambdamicrovms"
 	lambdatypes "github.com/aws/aws-sdk-go-v2/service/lambdamicrovms/types"
 	"github.com/aws/smithy-go"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 type microVM struct {
@@ -211,7 +213,7 @@ func newRunnerClient(control controlPlane, source *http.Client, region string) *
 }
 
 func defaultRunnerHTTPClient(responseHeaderTimeout time.Duration) *http.Client {
-	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport := core.CloneDefaultTransport()
 	transport.ResponseHeaderTimeout = responseHeaderTimeout
 	return &http.Client{Transport: transport}
 }

--- a/internal/providers/awslambdamicrovm/client.go
+++ b/internal/providers/awslambdamicrovm/client.go
@@ -191,9 +191,13 @@ type runnerEvent struct {
 	Error    string `json:"error,omitempty"`
 }
 
-func newRunnerClient(control controlPlane, source *http.Client, region string) *runnerClient {
+func newRunnerClient(control controlPlane, source *http.Client, region string) (*runnerClient, error) {
 	if source == nil {
-		source = defaultRunnerHTTPClient(runnerResponseHeaderTimeout)
+		var err error
+		source, err = defaultRunnerHTTPClient(runnerResponseHeaderTimeout)
+		if err != nil {
+			return nil, fmt.Errorf("%s HTTP client setup: %w", providerName, err)
+		}
 	}
 	cloned := *source
 	originalRedirect := source.CheckRedirect
@@ -209,13 +213,16 @@ func newRunnerClient(control controlPlane, source *http.Client, region string) *
 		}
 		return nil
 	}
-	return &runnerClient{control: control, http: &cloned, region: region}
+	return &runnerClient{control: control, http: &cloned, region: region}, nil
 }
 
-func defaultRunnerHTTPClient(responseHeaderTimeout time.Duration) *http.Client {
-	transport := core.CloneDefaultTransport()
+func defaultRunnerHTTPClient(responseHeaderTimeout time.Duration) (*http.Client, error) {
+	transport, err := core.CloneDefaultTransport()
+	if err != nil {
+		return nil, err
+	}
 	transport.ResponseHeaderTimeout = responseHeaderTimeout
-	return &http.Client{Transport: transport}
+	return &http.Client{Transport: transport}, nil
 }
 
 func (c *runnerClient) Health(ctx context.Context, vm microVM) error {

--- a/internal/providers/cloudflare/backend_test.go
+++ b/internal/providers/cloudflare/backend_test.go
@@ -158,6 +158,32 @@ func TestCloudflareClientUsesBoundedDefaultTransport(t *testing.T) {
 	}
 }
 
+type unusedDefaultRoundTripper struct{}
+
+func (unusedDefaultRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, fmt.Errorf("unused default transport")
+}
+
+func TestDefaultCloudflareHTTPClientAcceptsNonTransportDefault(t *testing.T) {
+	original := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = original
+	})
+	http.DefaultTransport = unusedDefaultRoundTripper{}
+
+	client := defaultCloudflareHTTPClient()
+	if client == nil {
+		t.Fatal("default client is nil")
+	}
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok || transport == nil {
+		t.Fatalf("transport=%T, want non-nil *http.Transport", client.Transport)
+	}
+	if transport.ResponseHeaderTimeout != cloudflareDefaultResponseHeaderTimeout {
+		t.Fatalf("response header timeout=%s, want %s", transport.ResponseHeaderTimeout, cloudflareDefaultResponseHeaderTimeout)
+	}
+}
+
 func TestCloudflareClientRejectsCrossOriginExecRedirectBeforeReplay(t *testing.T) {
 	for _, status := range []int{http.StatusTemporaryRedirect, http.StatusPermanentRedirect} {
 		t.Run(http.StatusText(status), func(t *testing.T) {

--- a/internal/providers/cloudflare/backend_test.go
+++ b/internal/providers/cloudflare/backend_test.go
@@ -158,29 +158,48 @@ func TestCloudflareClientUsesBoundedDefaultTransport(t *testing.T) {
 	}
 }
 
-type unusedDefaultRoundTripper struct{}
+type unusedDefaultRoundTripper struct {
+	calls int
+}
 
-func (unusedDefaultRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+func (r *unusedDefaultRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	r.calls++
 	return nil, fmt.Errorf("unused default transport")
 }
 
-func TestDefaultCloudflareHTTPClientAcceptsNonTransportDefault(t *testing.T) {
+func TestNewCloudflareClientRejectsUnsupportedDefaultTransport(t *testing.T) {
 	original := http.DefaultTransport
-	t.Cleanup(func() {
-		http.DefaultTransport = original
-	})
-	http.DefaultTransport = unusedDefaultRoundTripper{}
+	t.Cleanup(func() { http.DefaultTransport = original })
+	recorder := &unusedDefaultRoundTripper{}
+	http.DefaultTransport = recorder
 
-	client := defaultCloudflareHTTPClient()
-	if client == nil {
-		t.Fatal("default client is nil")
+	cfg := Config{}
+	cfg.Cloudflare.APIURL = "http://127.0.0.1:8787"
+	cfg.Cloudflare.Token = "token"
+	client, err := newCloudflareClient(cfg, Runtime{})
+	if client != nil || err == nil || !strings.Contains(err.Error(), "non-nil *http.Transport") {
+		t.Fatalf("client=%#v err=%v, want transport setup error", client, err)
 	}
-	transport, ok := client.Transport.(*http.Transport)
-	if !ok || transport == nil {
-		t.Fatalf("transport=%T, want non-nil *http.Transport", client.Transport)
+	if recorder.calls != 0 {
+		t.Fatalf("custom default invoked %d times, want 0", recorder.calls)
 	}
-	if transport.ResponseHeaderTimeout != cloudflareDefaultResponseHeaderTimeout {
-		t.Fatalf("response header timeout=%s, want %s", transport.ResponseHeaderTimeout, cloudflareDefaultResponseHeaderTimeout)
+}
+
+func TestNewCloudflareClientAcceptsExplicitClientWithUnsupportedDefault(t *testing.T) {
+	original := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = original })
+	http.DefaultTransport = &unusedDefaultRoundTripper{}
+	injected := &http.Client{Transport: &unusedDefaultRoundTripper{}}
+	cfg := Config{}
+	cfg.Cloudflare.APIURL = "http://127.0.0.1:8787"
+	cfg.Cloudflare.Token = "token"
+
+	client, err := newCloudflareClient(cfg, Runtime{HTTP: injected})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.http.Transport != injected.Transport {
+		t.Fatal("newCloudflareClient did not preserve the explicit transport")
 	}
 }
 

--- a/internal/providers/cloudflare/client.go
+++ b/internal/providers/cloudflare/client.go
@@ -103,7 +103,10 @@ func newCloudflareClient(cfg Config, rt Runtime) (*cloudflareClient, error) {
 	baseURL := strings.TrimRight(parsed.String(), "/")
 	httpClient := rt.HTTP
 	if httpClient == nil {
-		httpClient = defaultCloudflareHTTPClient()
+		httpClient, err = defaultCloudflareHTTPClient()
+		if err != nil {
+			return nil, fmt.Errorf("%s HTTP client setup: %w", providerName, err)
+		}
 	}
 	return &cloudflareClient{
 		baseURL:      baseURL,
@@ -123,10 +126,13 @@ func cloudflareCleanupContext() (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.Background(), cloudflareCleanupTimeout)
 }
 
-func defaultCloudflareHTTPClient() *http.Client {
-	transport := core.CloneDefaultTransport()
+func defaultCloudflareHTTPClient() (*http.Client, error) {
+	transport, err := core.CloneDefaultTransport()
+	if err != nil {
+		return nil, err
+	}
 	transport.ResponseHeaderTimeout = cloudflareDefaultResponseHeaderTimeout
-	return &http.Client{Transport: transport}
+	return &http.Client{Transport: transport}, nil
 }
 
 func secureCloudflareHTTPClient(source *http.Client, baseURL string) *http.Client {

--- a/internal/providers/cloudflare/client.go
+++ b/internal/providers/cloudflare/client.go
@@ -16,6 +16,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 type cloudflareClient struct {
@@ -122,7 +124,7 @@ func cloudflareCleanupContext() (context.Context, context.CancelFunc) {
 }
 
 func defaultCloudflareHTTPClient() *http.Client {
-	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport := core.CloneDefaultTransport()
 	transport.ResponseHeaderTimeout = cloudflareDefaultResponseHeaderTimeout
 	return &http.Client{Transport: transport}
 }

--- a/internal/providers/cloudflaredynamicworkers/backend_test.go
+++ b/internal/providers/cloudflaredynamicworkers/backend_test.go
@@ -183,7 +183,10 @@ func TestLoaderURLRedactsOpaqueUserinfo(t *testing.T) {
 func TestDefaultHTTPClientHonorsConfiguredRunTimeout(t *testing.T) {
 	cfg := testConfig("http://127.0.0.1:1")
 	cfg.CloudflareDynamicWorkers.TimeoutSecs = 60
-	client := defaultHTTPClient(cfg)
+	client, err := defaultHTTPClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 	transport, ok := client.Transport.(*http.Transport)
 	if !ok {
 		t.Fatalf("transport=%T", client.Transport)
@@ -196,13 +199,60 @@ func TestDefaultHTTPClientHonorsConfiguredRunTimeout(t *testing.T) {
 func TestDefaultHTTPClientDisablesTimeoutWhenRunTimeoutIsDisabled(t *testing.T) {
 	cfg := testConfig("http://127.0.0.1:1")
 	cfg.CloudflareDynamicWorkers.TimeoutSecs = 0
-	client := defaultHTTPClient(cfg)
+	client, err := defaultHTTPClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 	transport, ok := client.Transport.(*http.Transport)
 	if !ok {
 		t.Fatalf("transport=%T", client.Transport)
 	}
 	if transport.ResponseHeaderTimeout != 0 {
 		t.Fatalf("response header timeout=%s, want disabled", transport.ResponseHeaderTimeout)
+	}
+}
+
+type recordingDefaultRoundTripper struct {
+	calls int
+}
+
+func (r *recordingDefaultRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	r.calls++
+	return nil, errors.New("deny all")
+}
+
+func TestNewLoaderAPIRejectsUnsupportedDefaultTransport(t *testing.T) {
+	original := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = original })
+	recorder := &recordingDefaultRoundTripper{}
+	http.DefaultTransport = recorder
+
+	client, err := newLoaderAPI(testConfig("http://127.0.0.1:8787"), Runtime{})
+	if client != nil || err == nil || !strings.Contains(err.Error(), "non-nil *http.Transport") {
+		t.Fatalf("client=%#v err=%v, want transport setup error", client, err)
+	}
+	if recorder.calls != 0 {
+		t.Fatalf("custom default invoked %d times, want 0", recorder.calls)
+	}
+}
+
+func TestNewLoaderAPIAcceptsExplicitClientWithUnsupportedDefault(t *testing.T) {
+	original := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = original })
+	http.DefaultTransport = &recordingDefaultRoundTripper{}
+	injectedTransport := &recordingDefaultRoundTripper{}
+	injected := &http.Client{Transport: injectedTransport}
+
+	api, err := newLoaderAPI(testConfig("http://127.0.0.1:8787"), Runtime{HTTP: injected})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, ok := api.(*client)
+	if !ok {
+		t.Fatalf("api=%T, want *client", api)
+	}
+	if client.http.Transport != injectedTransport {
+		t.Fatalf("transport=%T, want explicit transport", client.http.Transport)
 	}
 }
 

--- a/internal/providers/cloudflaredynamicworkers/client.go
+++ b/internal/providers/cloudflaredynamicworkers/client.go
@@ -11,6 +11,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 type loaderAPI interface {
@@ -291,7 +293,7 @@ func isLoopbackHTTPURL(parsed *url.URL) bool {
 }
 
 func defaultHTTPClient(cfg Config) *http.Client {
-	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport := core.CloneDefaultTransport()
 	transport.ResponseHeaderTimeout = responseHeaderTimeout(cfg)
 	return &http.Client{Transport: transport}
 }

--- a/internal/providers/cloudflaredynamicworkers/client.go
+++ b/internal/providers/cloudflaredynamicworkers/client.go
@@ -142,7 +142,10 @@ var newLoaderAPI = func(cfg Config, rt Runtime) (loaderAPI, error) {
 	}
 	httpClient := rt.HTTP
 	if httpClient == nil {
-		httpClient = defaultHTTPClient(cfg)
+		httpClient, err = defaultHTTPClient(cfg)
+		if err != nil {
+			return nil, fmt.Errorf("%s HTTP client setup: %w", providerName, err)
+		}
 	}
 	httpClient = noRedirectHTTPClient(httpClient)
 	return &client{
@@ -292,10 +295,13 @@ func isLoopbackHTTPURL(parsed *url.URL) bool {
 	return host == "localhost" || host == "127.0.0.1" || host == "::1"
 }
 
-func defaultHTTPClient(cfg Config) *http.Client {
-	transport := core.CloneDefaultTransport()
+func defaultHTTPClient(cfg Config) (*http.Client, error) {
+	transport, err := core.CloneDefaultTransport()
+	if err != nil {
+		return nil, err
+	}
 	transport.ResponseHeaderTimeout = responseHeaderTimeout(cfg)
-	return &http.Client{Transport: transport}
+	return &http.Client{Transport: transport}, nil
 }
 
 func noRedirectHTTPClient(httpClient *http.Client) *http.Client {

--- a/internal/providers/islo/backend_test.go
+++ b/internal/providers/islo/backend_test.go
@@ -696,6 +696,50 @@ func TestIsloClientUsesBoundedDefaultTransport(t *testing.T) {
 	}
 }
 
+type recordingDefaultRoundTripper struct {
+	calls int
+}
+
+func (r *recordingDefaultRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	r.calls++
+	return nil, errors.New("deny all")
+}
+
+func TestNewIsloClientRejectsUnsupportedDefaultTransport(t *testing.T) {
+	original := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = original })
+	recorder := &recordingDefaultRoundTripper{}
+	http.DefaultTransport = recorder
+
+	api, err := newIsloClient(Config{Islo: IsloConfig{APIKey: "test", BaseURL: "http://127.0.0.1:8787"}}, Runtime{})
+	if api != nil || err == nil || !strings.Contains(err.Error(), "non-nil *http.Transport") {
+		t.Fatalf("api=%#v err=%v, want transport setup error", api, err)
+	}
+	if recorder.calls != 0 {
+		t.Fatalf("custom default invoked %d times, want 0", recorder.calls)
+	}
+}
+
+func TestNewIsloClientAcceptsExplicitClientWithUnsupportedDefault(t *testing.T) {
+	original := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = original })
+	http.DefaultTransport = &recordingDefaultRoundTripper{}
+	injectedTransport := &recordingDefaultRoundTripper{}
+	injected := &http.Client{Transport: injectedTransport}
+
+	api, err := newIsloClient(Config{Islo: IsloConfig{APIKey: "test", BaseURL: "http://127.0.0.1:8787"}}, Runtime{HTTP: injected})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, ok := api.(*isloSDKClient)
+	if !ok {
+		t.Fatalf("api=%T, want *isloSDKClient", api)
+	}
+	if client.httpClient.Transport != injectedTransport {
+		t.Fatal("newIsloClient did not preserve the explicit transport")
+	}
+}
+
 func TestIsloRunReturnsSessionHandleForKeptSandbox(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	client := &fakeIsloSyncClient{createName: "crabbox-repo-abcdef"}

--- a/internal/providers/islo/client.go
+++ b/internal/providers/islo/client.go
@@ -19,6 +19,8 @@ import (
 	"github.com/islo-labs/go-sdk/client"
 	"github.com/islo-labs/go-sdk/customauth"
 	"github.com/islo-labs/go-sdk/option"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -93,7 +95,7 @@ func isloCleanupContext() (context.Context, context.CancelFunc) {
 }
 
 func defaultIsloHTTPClient() *http.Client {
-	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport := core.CloneDefaultTransport()
 	transport.ResponseHeaderTimeout = isloDefaultResponseHeaderTimeout
 	return &http.Client{Transport: transport}
 }

--- a/internal/providers/islo/client.go
+++ b/internal/providers/islo/client.go
@@ -68,7 +68,11 @@ var newIsloClient = func(cfg Config, rt Runtime) (isloAPI, error) {
 	baseURL := strings.TrimRight(blank(cfg.Islo.BaseURL, "https://api.islo.dev"), "/")
 	httpClient := rt.HTTP
 	if httpClient == nil {
-		httpClient = defaultIsloHTTPClient()
+		var err error
+		httpClient, err = defaultIsloHTTPClient()
+		if err != nil {
+			return nil, fmt.Errorf("%s HTTP client setup: %w", isloProvider, err)
+		}
 	}
 	httpClient, err := isloHTTPClientWithRedirectGuard(baseURL, httpClient)
 	if err != nil {
@@ -94,10 +98,13 @@ func isloCleanupContext() (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.Background(), isloCleanupTimeout)
 }
 
-func defaultIsloHTTPClient() *http.Client {
-	transport := core.CloneDefaultTransport()
+func defaultIsloHTTPClient() (*http.Client, error) {
+	transport, err := core.CloneDefaultTransport()
+	if err != nil {
+		return nil, err
+	}
 	transport.ResponseHeaderTimeout = isloDefaultResponseHeaderTimeout
-	return &http.Client{Transport: transport}
+	return &http.Client{Transport: transport}, nil
 }
 
 func isloHTTPClientWithRedirectGuard(baseURL string, source *http.Client) (*http.Client, error) {

--- a/internal/providers/scaleway/client.go
+++ b/internal/providers/scaleway/client.go
@@ -110,7 +110,10 @@ func newClient(cfg core.Config, rt core.Runtime) (Client, error) {
 
 	httpClient := rt.HTTP
 	if httpClient == nil {
-		httpClient = defaultScalewayHTTPClient()
+		httpClient, err = defaultScalewayHTTPClient()
+		if err != nil {
+			return nil, fmt.Errorf("%s HTTP client setup: %w", providerName, err)
+		}
 	}
 	trustedAPI, _ := url.Parse(scalewayAPIURL(profile))
 	opts := []scw.ClientOption{
@@ -144,11 +147,15 @@ func scalewayAPIURL(profile *scw.Profile) string {
 	return defaultScalewayAPIURL
 }
 
-func defaultScalewayHTTPClient() *http.Client {
+func defaultScalewayHTTPClient() (*http.Client, error) {
+	transport, err := core.CloneDefaultTransport()
+	if err != nil {
+		return nil, err
+	}
 	return &http.Client{
 		Timeout:   30 * time.Second,
-		Transport: core.CloneDefaultTransport(),
-	}
+		Transport: transport,
+	}, nil
 }
 
 type scalewayRedirectHopKey struct{}

--- a/internal/providers/scaleway/client.go
+++ b/internal/providers/scaleway/client.go
@@ -147,7 +147,7 @@ func scalewayAPIURL(profile *scw.Profile) string {
 func defaultScalewayHTTPClient() *http.Client {
 	return &http.Client{
 		Timeout:   30 * time.Second,
-		Transport: http.DefaultTransport.(*http.Transport).Clone(),
+		Transport: core.CloneDefaultTransport(),
 	}
 }
 

--- a/internal/providers/scaleway/client_test.go
+++ b/internal/providers/scaleway/client_test.go
@@ -318,6 +318,53 @@ func TestNewClientSanitizesSDKValidationError(t *testing.T) {
 	}
 }
 
+func TestNewClientRejectsUnsupportedDefaultTransport(t *testing.T) {
+	clearScalewayEnv(t)
+	t.Setenv("SCW_ACCESS_KEY", testScalewayAccessKey)
+	t.Setenv("SCW_SECRET_KEY", testScalewaySecretKey)
+	t.Setenv("SCW_DEFAULT_PROJECT_ID", testScalewayProjectID)
+	t.Setenv("SCW_DEFAULT_ORGANIZATION_ID", testScalewayOrganizationID)
+	original := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = original })
+	calls := 0
+	http.DefaultTransport = scalewayRoundTripFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		return nil, errors.New("deny all")
+	})
+
+	client, err := newClient(core.Config{}, core.Runtime{})
+	if client != nil || err == nil || !strings.Contains(err.Error(), "non-nil *http.Transport") {
+		t.Fatalf("client=%#v err=%v, want transport setup error", client, err)
+	}
+	if calls != 0 {
+		t.Fatalf("custom default invoked %d times, want 0", calls)
+	}
+}
+
+func TestNewClientAcceptsExplicitHTTPClientWithUnsupportedDefault(t *testing.T) {
+	clearScalewayEnv(t)
+	t.Setenv("SCW_ACCESS_KEY", testScalewayAccessKey)
+	t.Setenv("SCW_SECRET_KEY", testScalewaySecretKey)
+	t.Setenv("SCW_DEFAULT_PROJECT_ID", testScalewayProjectID)
+	t.Setenv("SCW_DEFAULT_ORGANIZATION_ID", testScalewayOrganizationID)
+	original := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = original })
+	http.DefaultTransport = scalewayRoundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("deny all")
+	})
+	injected := &http.Client{Transport: scalewayRoundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("injected")
+	})}
+
+	client, err := newClient(core.Config{}, core.Runtime{HTTP: injected})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client == nil {
+		t.Fatal("newClient returned nil client")
+	}
+}
+
 func TestSanitizeSDKErrorRedactsProfileValues(t *testing.T) {
 	const accessKey = "invalid-profile-access"
 	const secretKey = "invalid-profile-secret"

--- a/internal/providers/upstashbox/backend_test.go
+++ b/internal/providers/upstashbox/backend_test.go
@@ -338,6 +338,48 @@ func TestNewAPIUsesBoundedDefaultHTTPClient(t *testing.T) {
 	}
 }
 
+func TestNewAPIRejectsUnsupportedDefaultTransport(t *testing.T) {
+	original := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = original })
+	calls := 0
+	http.DefaultTransport = roundTripFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		return nil, errors.New("deny all")
+	})
+
+	api, err := newAPI(testConfig(), Runtime{})
+	if api != nil || err == nil || !strings.Contains(err.Error(), "non-nil *http.Transport") {
+		t.Fatalf("api=%#v err=%v, want transport setup error", api, err)
+	}
+	if calls != 0 {
+		t.Fatalf("custom default invoked %d times, want 0", calls)
+	}
+}
+
+func TestNewAPIAcceptsExplicitClientWithUnsupportedDefault(t *testing.T) {
+	original := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = original })
+	http.DefaultTransport = roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("deny all")
+	})
+	injectedTransport := roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("injected")
+	})
+	injected := &http.Client{Transport: injectedTransport}
+
+	api, err := newAPI(testConfig(), Runtime{HTTP: injected})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, ok := api.(*client)
+	if !ok {
+		t.Fatalf("api=%T, want *client", api)
+	}
+	if _, ok := client.http.Transport.(roundTripFunc); !ok {
+		t.Fatalf("transport=%T, want explicit roundTripFunc", client.http.Transport)
+	}
+}
+
 type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {

--- a/internal/providers/upstashbox/client.go
+++ b/internal/providers/upstashbox/client.go
@@ -16,6 +16,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 type api interface {
@@ -122,7 +124,7 @@ func upstashBoxCleanupContext() (context.Context, context.CancelFunc) {
 }
 
 func defaultUpstashBoxHTTPClient() *http.Client {
-	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport := core.CloneDefaultTransport()
 	transport.ResponseHeaderTimeout = upstashBoxDefaultResponseHeaderTimeout
 	return &http.Client{Transport: transport}
 }

--- a/internal/providers/upstashbox/client.go
+++ b/internal/providers/upstashbox/client.go
@@ -73,7 +73,11 @@ var newAPI = func(cfg Config, rt Runtime) (api, error) {
 	}
 	httpClient := rt.HTTP
 	if httpClient == nil {
-		httpClient = defaultUpstashBoxHTTPClient()
+		var err error
+		httpClient, err = defaultUpstashBoxHTTPClient()
+		if err != nil {
+			return nil, fmt.Errorf("%s HTTP client setup: %w", providerName, err)
+		}
 	}
 	base := strings.TrimRight(blank(strings.TrimSpace(cfg.UpstashBox.BaseURL), "https://us-east-1.box.upstash.com"), "/")
 	return &client{apiKey: apiKey, base: base, http: secureUpstashBoxHTTPClient(httpClient, base)}, nil
@@ -123,10 +127,13 @@ func upstashBoxCleanupContext() (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.Background(), upstashBoxCleanupTimeout)
 }
 
-func defaultUpstashBoxHTTPClient() *http.Client {
-	transport := core.CloneDefaultTransport()
+func defaultUpstashBoxHTTPClient() (*http.Client, error) {
+	transport, err := core.CloneDefaultTransport()
+	if err != nil {
+		return nil, err
+	}
 	transport.ResponseHeaderTimeout = upstashBoxDefaultResponseHeaderTimeout
-	return &http.Client{Transport: transport}
+	return &http.Client{Transport: transport}, nil
 }
 
 func (c *client) CreateBox(ctx context.Context, req createRequest) (boxData, error) {


### PR DESCRIPTION
## What problem this solves

Seven Crabbox-owned provider HTTP constructors assumed that `http.DefaultTransport` was a non-nil `*http.Transport`. An embedding process can validly replace that interface with a tracing, recording, authenticated, mTLS, deny-all, or other custom `RoundTripper`; the old force assertion then panicked during provider setup.

## Maintainer transport contract

This PR now applies one fail-closed rule wherever Crabbox must mutate transport TLS or timeout settings:

- A non-nil concrete `*http.Transport` is cloned with `Clone()`, preserving customized proxy, dial, TLS, and protocol settings while isolating mutable state.
- A nil, typed-nil, or non-`*http.Transport` process default returns a clear setup error. Crabbox does not silently create an unrelated network-capable transport that could bypass host egress, authentication, TLS, tracing, or recording policy.
- Explicitly injected HTTP clients remain supported and do not depend on the process-global default.

The error is propagated through Proxmox, AWS Lambda MicroVM, Cloudflare, Cloudflare Dynamic Workers, Islo, Scaleway, and Upstash Box client construction. Normal standalone CLI behavior is unchanged because Go's standard default is a non-nil `*http.Transport`.

## Exact-head behavior proof

Exact head: `0cd9a1252b6907326415fa05e171e7a3fa6eb5ca`

A temporary operator harness replaced the process default with a deny-all policy transport, guarded both calls with `recover`, and invoked the shared helper plus the exported Proxmox insecure-TLS constructor:

```console
helper transport_nil=true panic=<nil> error="http.DefaultTransport must be a non-nil *http.Transport; inject an explicit HTTP client where supported" policy_calls=0
proxmox client_nil=true panic=<nil> error="proxmox HTTP client setup: http.DefaultTransport must be a non-nil *http.Transport; inject an explicit HTTP client where supported" policy_calls=0
```

This proves the final contract returns an operator-readable error, does not panic, does not invoke the host policy transport, and does not bypass it with a provider request.

Explicit-client paths were then exercised under the same unsupported process default:

```console
$ go test -race ./internal/providers/awslambdamicrovm ./internal/providers/cloudflare ./internal/providers/cloudflaredynamicworkers ./internal/providers/islo ./internal/providers/scaleway ./internal/providers/upstashbox -count=1 -run 'AcceptsExplicit.*UnsupportedDefault' -v
--- PASS: TestNewRunnerClientAcceptsExplicitClientWithUnsupportedDefault
--- PASS: TestNewCloudflareClientAcceptsExplicitClientWithUnsupportedDefault
--- PASS: TestNewLoaderAPIAcceptsExplicitClientWithUnsupportedDefault
--- PASS: TestNewIsloClientAcceptsExplicitClientWithUnsupportedDefault
--- PASS: TestNewClientAcceptsExplicitHTTPClientWithUnsupportedDefault
--- PASS: TestNewAPIAcceptsExplicitClientWithUnsupportedDefault
```

Focused fail-closed race tests also passed for the helper, Proxmox, and all six provider packages. They cover non-standard wrappers, nil interface defaults, typed-nil transports, deep clone isolation, provider error propagation, and explicit client preservation.

## Verification

- `go test -race ./...` passed in 567.18s.
- `go vet ./...` passed.
- `go build -trimpath -o /tmp/crabbox-pr1401-bin ./cmd/crabbox` passed.
- Exact-head structured P1 autoreview reported no accepted or actionable findings.
- Exact-head CI passed: https://github.com/openclaw/crabbox/actions/runs/32243866815
- Exact-head connector E2E smokes passed: https://github.com/openclaw/crabbox/actions/runs/32243866832
- Exact-head release check passed: https://github.com/openclaw/crabbox/actions/runs/32243866865

No provider credentials or live provider API calls were needed: the failure happens during deterministic local client construction, before network I/O. The claim is intentionally scoped to the seven Crabbox-owned constructors; dependency-internal transport assertions are outside this PR.

The maintainer-owned changelog entry thanks @SebTardif, and contributor authorship is preserved in the repair commits.
