### PR TITLE
feat(run): add CMake preflight probe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,8 +108,8 @@ jobs:
       - name: Test Windows SSH and rsync transport selection
         run: go test ./internal/cli/ -run '^(TestWindowsWSLNativeToolProbeUsesDirectCommandOutput|TestWindowsWSLNativeToolPathsRejectsWindowsShims|TestDirectSSHExecutableSelection|TestSSHCommandContextUsesNativeWindowsOpenSSHEvenWhenPATHSelectsMSYS2|TestResolveWindowsNativeRsyncPairUsesExactSibling|TestResolveWindowsNativeRsyncPairFailsClosedWithoutSibling|TestBindWindowsNativeRsyncSSHPreservesOwnedArguments|TestWindowsNativeRsyncCommandUsesSiblingPairAndEnvironment|TestResolvedSSHCopyCommandUsesNativeWindowsSiblingPair|TestResolvedSSHCopyCommandFailsClosedWithoutNativeWindowsSibling)$' -count=1 -v
 
-      - name: Test native Windows Python preflight probes
-        run: go test ./internal/cli/ -run '^(TestPythonPreflightToolValidationAndTargetFiltering|TestPythonPreflightWindowsProbeUsesLiteralExecutableAndMissingContract)$' -count=1 -v
+      - name: Test native Windows Python and CMake preflight probes
+        run: go test ./internal/cli/ -run '^(TestPythonPreflightToolValidationAndTargetFiltering|TestPythonPreflightWindowsProbeUsesLiteralExecutableAndMissingContract|TestCMakePreflightNativeWindowsPresentAndMissing)$' -count=1 -v
 
       - name: Test Git workspace coherence
         run: go test ./internal/cli/ -run '^(TestWindowsGitRootIdentityAcceptsShortAliasAndRejectsDistinctRoot|TestWindowsGitCoherenceRollbackRestoresIndexAfterSymbolicHeadFailure|TestWindowsGitSeedReplacesUnusableExactRootsAfterVerifiedClone|TestWindowsGitCoherenceSupportsDetachedSparseSplitAndLinkedIndexes|TestWorkspaceOwnerWindowsProtocolBehavior)$' -count=1 -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.44.1 - Unreleased
 
+### Added
+
+- Added an opt-in `cmake --version` preflight probe for POSIX, WSL2, and native Windows targets. Thanks @coygeek.
+
 ### Fixed
 
 - Made private draft verification resolve the exact draft by tag and numeric release ID instead of relying on a release-list endpoint that can omit drafts.

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -400,10 +400,11 @@ or the command/script you run.
 
 By default it probes common language and infrastructure tools plus OS-specific
 basics. Default generic probes are `git`, `tar`, `node`, `npm`, `corepack`,
-`pnpm`, `yarn`, `bun`, and `docker`; `uv`, `python`, and `python3` are available
-as additional opt-in built-ins. Linux and WSL2 also support the opt-in
-`raw_socket` capability probe. POSIX/Linux/WSL probes include `sudo`, `apt`,
-and `bubblewrap`; native Windows probes include `powershell`,
+`pnpm`, `yarn`, `bun`, and `docker`. Additional opt-in built-ins are `go`,
+`cargo`, `cmake`, `uv`, `python`, and `python3` on POSIX, WSL2, and native
+Windows targets, plus `make` on POSIX and WSL2. Linux and WSL2 also support the
+opt-in `raw_socket` capability probe. POSIX/Linux/WSL probes include `sudo`,
+`apt`, and `bubblewrap`; native Windows probes include `powershell`,
 `execution_policy`, `longpaths`, `temp`, and `pwsh`.
 
 Use `--preflight-tools` to replace the default tool list for one run:
@@ -411,6 +412,7 @@ Use `--preflight-tools` to replace the default tool list for one run:
 ```sh
 crabbox run --preflight --preflight-tools node,bun,docker -- bun test
 crabbox run --preflight --preflight-tools default,uv -- node --test
+crabbox run --preflight --preflight-tools default,cmake -- cmake --build build
 crabbox run --preflight --preflight-tools python,python3 -- python3 -m pytest
 crabbox run --preflight --preflight-tools raw_socket -- ./packet-tests
 crabbox run --preflight --preflight-tools none -- ./smoke.sh
@@ -419,9 +421,13 @@ crabbox run --preflight --preflight-tools none -- ./smoke.sh
 `default` expands to the default probe list; `none` keeps only the workspace
 summary. Unknown tool names fail before leasing so typos do not hide missing
 diagnostics. Unsupported OS-specific probes are skipped for the current target.
-The Python probes always invoke the literal requested command with `--version`,
-including `python` and `python3` on native Windows; Crabbox does not map either
-name to `py`. An unavailable literal command prints `<name>=missing` and the run
+The CMake probe invokes the literal `cmake --version` command on POSIX, WSL2,
+and native Windows targets. It prints only the first output line when CMake is
+present or `cmake=missing` when it is unavailable; either result is diagnostic
+only and does not block the workload. There is no `cmake3` alias. The Python
+probes likewise invoke the literal requested command with `--version`, including
+`python` and `python3` on native Windows; Crabbox does not map either name to
+`py`. An unavailable literal command prints `<name>=missing` and the run
 continues.
 
 `raw_socket` uses `python3`, then `python`, to open and immediately close

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -996,17 +996,20 @@ list, and explicit `--allow-env` flags append afterward. See
 ```yaml
 run:
   preflightTools:
-    - python
-    - python3
+    - default
+    - cmake
 ```
 
 `run.preflightTools` configures which built-in probes `crabbox run --preflight`
 executes before the remote command. The CLI flag
-`--preflight-tools python,python3` overrides this list for one run. Both names
-are opt-in and probe the corresponding literal command with `--version`. Use
-`default` to include Crabbox's default built-ins and `none` to print only the
-workspace summary. Preflight probes only report availability; they do not
-install toolchains or mutate the machine.
+`--preflight-tools default,cmake` overrides this list for one run. Opt-in probes
+include `go`, `cargo`, `cmake`, `uv`, `python`, and `python3` on POSIX, WSL2,
+and native Windows, plus `make` on POSIX and WSL2. The CMake probe invokes only
+the literal `cmake --version` command and reports its first output line or
+`cmake=missing`. Use `default` to include Crabbox's default built-ins and `none`
+to print only the workspace summary. Preflight probes are diagnostic only: a
+missing tool does not block the workload, and Crabbox does not install or
+upgrade toolchains.
 
 ### Actions
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -298,16 +298,23 @@ a prebaked image, a devcontainer/Nix/mise/asdf setup, or the uploaded
 script/command itself.
 
 The built-in probes cover common toolchains — `git`, `tar`, `node`, `npm`,
-`corepack`, `pnpm`, `yarn`, `bun`, `docker`, and opt-in `uv`, `python`, and
-`python3` — plus target-specific probes such as `sudo`, `apt`, `bubblewrap`,
-`powershell`, `execution_policy`, `longpaths`, `temp`, and `pwsh`. Linux and
-WSL2 also support an opt-in `raw_socket` capability probe. Override the probe
-list per run:
+`corepack`, `pnpm`, `yarn`, `bun`, and `docker`; opt-in `go`, `cargo`, `cmake`,
+`uv`, `python`, and `python3` on POSIX, WSL2, and native Windows; and opt-in
+`make` on POSIX and WSL2 — plus target-specific probes such as `sudo`, `apt`,
+`bubblewrap`, `powershell`, `execution_policy`, `longpaths`, `temp`, and `pwsh`.
+Linux and WSL2 also support an opt-in `raw_socket` capability probe. Override
+the probe list per run:
 
 ```sh
 crabbox run --preflight --preflight-tools python,python3 -- python3 -m pytest
+crabbox run --preflight --preflight-tools default,cmake -- cmake --build build
 crabbox run --preflight --preflight-tools raw_socket -- ./packet-tests
 ```
+
+The opt-in CMake probe invokes the literal `cmake --version` command on POSIX,
+WSL2, and native Windows targets. It reports only the first output line or
+`cmake=missing`; the result is diagnostic only, so missing CMake does not block
+the workload or trigger installation or upgrades.
 
 `raw_socket` reports `direct` when the execution user can open and immediately
 close `socket(AF_INET, SOCK_RAW, IPPROTO_RAW)`, `sudo` when only the same
@@ -322,7 +329,8 @@ Or per repository:
 ```yaml
 run:
   preflightTools:
-    - raw_socket
+    - default
+    - cmake
 ```
 
 ## Actions hydration

--- a/internal/cli/run_observability.go
+++ b/internal/cli/run_observability.go
@@ -546,6 +546,7 @@ var preflightToolRegistry = map[string]preflightToolSpec{
 	"bun":                  {Posix: []string{"bun", "--version"}, Windows: []string{"bun", "--version"}},
 	"bwrap":                {Posix: []string{"bwrap", "--version"}, OS: map[string]bool{"linux": true}},
 	"cargo":                {Posix: []string{"cargo", "--version"}, Windows: []string{"cargo", "--version"}},
+	"cmake":                {Posix: []string{"cmake", "--version"}, Windows: []string{"cmake", "--version"}},
 	"corepack":             {Posix: []string{"corepack", "--version"}, Windows: []string{"corepack", "--version"}},
 	"docker":               {Posix: []string{"docker", "--version"}, Windows: []string{"docker", "--version"}},
 	"execution_policy":     {Windows: []string{"Get-ExecutionPolicy -Scope Process"}, OS: map[string]bool{"windows": true}},

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -4512,6 +4512,204 @@ func TestPythonPreflightWindowsProbeUsesLiteralExecutableAndMissingContract(t *t
 	}
 }
 
+func TestCMakePreflightToolValidationAndTargetFiltering(t *testing.T) {
+	if err := validatePreflightTools([]string{"cmake"}); err != nil {
+		t.Fatalf("cmake should validate: %v", err)
+	}
+
+	targets := []struct {
+		name   string
+		target SSHTarget
+	}{
+		{name: "linux", target: SSHTarget{TargetOS: targetLinux}},
+		{name: "macos", target: SSHTarget{TargetOS: targetMacOS}},
+		{name: "wsl2", target: SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeWSL2}},
+		{name: "native_windows", target: SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeNormal}},
+	}
+	for _, tt := range targets {
+		t.Run(tt.name, func(t *testing.T) {
+			got := preflightToolsForTarget(tt.target, []string{"cmake"})
+			if strings.Join(got, ",") != "cmake" {
+				t.Fatalf("tools=%v", got)
+			}
+		})
+	}
+
+	for _, tool := range preflightToolsForTarget(SSHTarget{TargetOS: targetLinux}, nil) {
+		if tool == "cmake" {
+			t.Fatalf("cmake must remain opt-in, default tools=%v", defaultPreflightToolNames)
+		}
+	}
+	tools := normalizePreflightToolNames([]string{"default,cmake,cmake"})
+	if count := strings.Count(","+strings.Join(tools, ",")+",", ",cmake,"); count != 1 {
+		t.Fatalf("default plus duplicate cmake tools=%v, cmake count=%d", tools, count)
+	}
+	if len(tools) != len(defaultPreflightToolNames)+1 {
+		t.Fatalf("default plus cmake tools=%v, want %d entries", tools, len(defaultPreflightToolNames)+1)
+	}
+}
+
+func TestCMakePreflightLiteralCommandGeneration(t *testing.T) {
+	const posixProbe = `preflight_cmd '\''cmake'\'' '\''cmake'\'' cmake --version`
+	posix := remoteCapabilityPreflightCommand("/work/repo", nil, nil, []string{"cmake"})
+	if !strings.Contains(posix, posixProbe) {
+		t.Fatalf("POSIX preflight script missing %q in %q", posixProbe, posix)
+	}
+	wsl2Tools := preflightToolsForTarget(SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeWSL2}, []string{"cmake"})
+	wsl2 := remoteCapabilityPreflightCommand("/work/repo", nil, nil, wsl2Tools)
+	if !strings.Contains(wsl2, posixProbe) {
+		t.Fatalf("WSL2 preflight script missing %q in %q", posixProbe, wsl2)
+	}
+	windows := windowsRemoteCapabilityPreflightScript(`C:\crabbox\repo`, nil, nil, []string{"cmake"})
+	if !strings.Contains(windows, `Test-Tool 'cmake' 'cmake' @('--version')`) {
+		t.Fatalf("native Windows preflight script does not use literal cmake command: %q", windows)
+	}
+	for name, script := range map[string]string{"posix": posix, "wsl2": wsl2, "windows": windows} {
+		if strings.Contains(script, "cmake3") {
+			t.Fatalf("%s preflight script contains unsupported alias: %q", name, script)
+		}
+	}
+}
+
+func TestCMakePreflightPOSIXPresentFirstLineAndMissing(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shell behavior is covered on non-Windows CI")
+	}
+
+	run := func(t *testing.T, installCMake bool) string {
+		t.Helper()
+		binDir := t.TempDir()
+		bash := "#!/bin/sh\nif [ \"$1\" = \"-lc\" ]; then exec /bin/bash --noprofile --norc -c \"$2\"; fi\nexec /bin/bash \"$@\"\n"
+		if err := os.WriteFile(filepath.Join(binDir, "bash"), []byte(bash), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		for name, path := range map[string]string{"id": "/usr/bin/id", "sed": "/usr/bin/sed", "whoami": "/usr/bin/whoami"} {
+			if err := os.Symlink(path, filepath.Join(binDir, name)); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if installCMake {
+			cmake := "#!/bin/sh\nprintf 'cmake version 9.8.7\\nignored second line\\n'\n"
+			if err := os.WriteFile(filepath.Join(binDir, "cmake"), []byte(cmake), 0o700); err != nil {
+				t.Fatal(err)
+			}
+		}
+		command := remoteCapabilityPreflightCommand(t.TempDir(), map[string]string{"PATH": binDir}, nil, []string{"cmake"})
+		cmd := exec.Command("/bin/sh", "-c", command)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("run POSIX preflight: %v\n%s", err, out)
+		}
+		return string(out)
+	}
+
+	present := run(t, true)
+	if !strings.Contains(present, "cmake=cmake version 9.8.7\n") || strings.Contains(present, "ignored second line") {
+		t.Fatalf("present output did not preserve first-line contract: %q", present)
+	}
+	missing := run(t, false)
+	if !strings.Contains(missing, "cmake=missing\n") {
+		t.Fatalf("missing output did not preserve diagnostic-only contract: %q", missing)
+	}
+}
+
+func TestCMakePreflightNativeWindowsPresentAndMissing(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("native Windows PowerShell behavior requires windows-latest")
+	}
+
+	run := func(t *testing.T, installCMake bool) string {
+		t.Helper()
+		binDir := t.TempDir()
+		if installCMake {
+			cmake := "@echo off\r\necho cmake version 9.8.7\r\necho ignored second line\r\n"
+			if err := os.WriteFile(filepath.Join(binDir, "cmake.cmd"), []byte(cmake), 0o700); err != nil {
+				t.Fatal(err)
+			}
+		}
+		script := windowsRemoteCapabilityPreflightScript(t.TempDir(), map[string]string{"Path": binDir}, nil, []string{"cmake"})
+		out, err := runWindowsPowerShellScript(t, script)
+		if err != nil {
+			t.Fatalf("run native Windows preflight: %v\n%s", err, out)
+		}
+		return strings.ReplaceAll(string(out), "\r\n", "\n")
+	}
+
+	present := run(t, true)
+	if !strings.Contains(present, "cmake=cmake version 9.8.7\n") || strings.Contains(present, "ignored second line") {
+		t.Fatalf("present output did not preserve first-line contract: %q", present)
+	}
+	missing := run(t, false)
+	if !strings.Contains(missing, "cmake=missing\n") {
+		t.Fatalf("missing output did not preserve diagnostic-only contract: %q", missing)
+	}
+}
+
+func TestCMakePreflightUserAndRepositoryConfig(t *testing.T) {
+	for _, source := range []string{"user", "repository"} {
+		t.Run(source, func(t *testing.T) {
+			clearConfigEnv(t)
+			root := t.TempDir()
+			home := filepath.Join(root, "home")
+			repo := filepath.Join(root, "repo")
+			if err := os.MkdirAll(repo, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("HOME", home)
+			t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+			t.Setenv("CRABBOX_CONFIG", "")
+			t.Chdir(repo)
+
+			path := filepath.Join(repo, ".crabbox.yaml")
+			if source == "user" {
+				path = userConfigPath()
+				if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := os.WriteFile(path, []byte("run:\n  preflightTools: [cmake]\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := loadConfig()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := strings.Join(cfg.Run.PreflightTools, ","); got != "cmake" {
+				t.Fatalf("%s run.preflightTools=%q", source, got)
+			}
+			if err := validatePreflightTools(cfg.Run.PreflightTools); err != nil {
+				t.Fatalf("%s cmake config should validate: %v", source, err)
+			}
+		})
+	}
+}
+
+func TestCMakeUnknownPreflightToolFailsBeforeAcquire(t *testing.T) {
+	clearConfigEnv(t)
+	dir := t.TempDir()
+	isolateRunTestUserDirs(t, dir)
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, "missing.yaml"))
+	acquireCalls := 0
+	runEnvProfileTestAcquireHook = func(AcquireRequest) { acquireCalls++ }
+	t.Cleanup(func() { runEnvProfileTestAcquireHook = nil })
+
+	err := (App{Stdout: io.Discard, Stderr: io.Discard}).runCommand(t.Context(), []string{
+		"--provider", runEnvProfileTestProvider{}.Name(),
+		"--preflight",
+		"--preflight-tools", "cmake,cmake3",
+		"--no-sync",
+		"--no-hydrate",
+		"--", "true",
+	})
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 2 || !strings.Contains(exitErr.Message, `unknown preflight tool "cmake3"`) {
+		t.Fatalf("error=%v, want exit 2 for unknown cmake alias", err)
+	}
+	if acquireCalls != 0 {
+		t.Fatalf("Acquire called %d time(s) before unknown preflight tool rejection", acquireCalls)
+	}
+}
+
 func TestRawSocketPreflightToolValidationAndTargetFiltering(t *testing.T) {
 	if err := validatePreflightTools([]string{rawSocketPreflightTool}); err != nil {
 		t.Fatalf("raw_socket should validate: %v", err)


### PR DESCRIPTION
## Summary

- add `cmake` as an opt-in built-in preflight probe using literal `cmake --version`
- preserve the existing first-line-or-`missing` diagnostic contract across POSIX, WSL2, and native Windows
- keep CMake out of the default probe set and reject unsupported aliases before lease acquisition
- document the expanded opt-in build-tool surface and run native Windows behavior coverage in CI

Closes https://github.com/openclaw/crabbox/issues/1394

## Behavior proof

Prepared Linux local-container targets exercised the exact built CLI:

- CMake present: lease `cbx_e54fa5453091`, run `run_30c221ceff1b`, output `remote preflight cmake=cmake version 4.2.3`, workload marker present, exit 0, lease stopped automatically
- CMake absent: lease `cbx_9a4405520e97`, run `run_2fcd70f684fb`, output `remote preflight cmake=missing`, workload marker present, exit 0, lease stopped automatically
- default probes emitted no CMake result
- `default,cmake,cmake` emitted exactly one CMake result
- `cmake3` returned exit 2 and Docker container inventory stayed unchanged

Provider: `local-container`; run URL: none for local provider runs.

## Verification

- focused CMake/Python preflight tests passed
- focused CMake tests passed under the race detector
- `go test ./internal/cli -timeout 30m -count=1` passed in 599s
- `go vet ./internal/cli` passed
- `bash scripts/check-docs.sh` passed
- `git diff --check` passed
- mandatory P1 autoreview found no actionable findings

The native Windows present/missing behavior test is explicitly selected by the `windows-latest` CI job; WSL2 and command-generation coverage remain in the shared CLI tests.
