### PR TITLE
feat(providers): add tiny and small machine classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added `tiny` and `small` machine classes for lower-cost smoke checks and small repositories.
 - Added an opt-in `cmake --version` preflight probe for POSIX, WSL2, and native Windows targets. Thanks @coygeek.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -411,53 +411,71 @@ The providers below fall back across ordered instance-type lists unless `--type`
 pins a specific provider-native size.
 
 ```text
-Hetzner    standard  ccx33, cpx62, cx53
+Hetzner    tiny      ccx13, cpx22, cx23
+           small     ccx23, cpx32, cx33
+           standard  ccx33, cpx62, cx53
            fast      ccx43, cpx62, cx53
            large     ccx53, ccx43, cpx62, cx53
            beast     ccx63, ccx53, ccx43, cpx62, cx53
 
-AWS Linux  standard  c7a/c7i/m7a/m7i.8xlarge family
+AWS Linux  tiny      m7a.large, m7i.large, c7a.xlarge, c7i.xlarge
+           small     c7a.2xlarge, c7i.2xlarge, m7a.xlarge, m7i.xlarge, c7a.xlarge
+           standard  c7a/c7i/m7a/m7i.8xlarge family
            fast      …16xlarge family
            large     …24xlarge family
            beast     …48xlarge family, falling back to 32x/24x/16x
            arm64     c7g/m7g/r7g families with --arch arm64
 
-AWS Win    standard  m7i.large, m7a.large, t3.large
+AWS Win    tiny      m7a.large, m7i.large, t3.large
+           small     c7a.2xlarge, c7i.2xlarge, m7a.xlarge, m7i.xlarge, t3.xlarge
+           standard  m7i.large, m7a.large, t3.large
            fast      m7i.xlarge, m7a.xlarge, t3.xlarge
            large     m7i.2xlarge, m7a.2xlarge, t3.2xlarge
            beast     m7i.4xlarge, m7a.4xlarge, m7i.2xlarge
 
-AWS WSL2   standard  m8i.large, m8i-flex.large, c8i.large, r8i.large
+AWS WSL2   tiny      m8i.large, m8i-flex.large, c8i.xlarge, r8i.large
+           small     c8i.2xlarge, m8i.xlarge, m8i-flex.xlarge, r8i.large, c8i.xlarge
+           standard  m8i.large, m8i-flex.large, c8i.large, r8i.large
            fast      m8i.xlarge, m8i-flex.xlarge, c8i.xlarge, r8i.xlarge
            large     m8i.2xlarge, m8i-flex.2xlarge, c8i.2xlarge, r8i.2xlarge
            beast     m8i.4xlarge, m8i-flex.4xlarge, c8i.4xlarge, r8i.4xlarge, m8i.2xlarge
 
 AWS macOS  all       mac2.metal, then mac1.metal unless --type is set
 
-Azure      standard  Standard_D32ads_v6, Standard_D32ds_v6, Standard_F32s_v2, then 16-vCPU fallbacks
+Azure      tiny      Standard_D2ads_v6, Standard_D2ds_v6, then v5/F2 fallbacks
+           small     Standard_D8ads_v6, Standard_D8ds_v6, then v5/F8/4-vCPU fallbacks
+           standard  Standard_D32ads_v6, Standard_D32ds_v6, Standard_F32s_v2, then 16-vCPU fallbacks
            fast      Standard_D64ads_v6, Standard_D64ds_v6, Standard_F64s_v2, then 48/32-vCPU fallbacks
            large     Standard_D96ads_v6, Standard_D96ds_v6, then 64/48-vCPU fallbacks
            beast     Standard_D192ds_v6, Standard_D128ds_v6, then 96/64-vCPU fallbacks
            arm64     Standard_D*ps_v6 / D*pds_v6 Cobalt families with --arch arm64
 
 Azure Win/
-WSL2       standard  Standard_D2ads_v6, Standard_D2ds_v6, Standard_D2ads_v5, Standard_D2ds_v5, Standard_D2as_v6
+WSL2       tiny      Standard_D2ads_v6, Standard_D2ds_v6, Standard_D2ads_v5, Standard_D2ds_v5, Standard_D2as_v6
+           small     Standard_D8ads_v6, Standard_D8ds_v6, Standard_D8ads_v5, Standard_D8ds_v5, Standard_D8as_v6
+           standard  Standard_D2ads_v6, Standard_D2ds_v6, Standard_D2ads_v5, Standard_D2ds_v5, Standard_D2as_v6
            fast      Standard_D4ads_v6, Standard_D4ds_v6, Standard_D4ads_v5, Standard_D4ds_v5, Standard_D4as_v6
            large     Standard_D8ads_v6, Standard_D8ds_v6, Standard_D8ads_v5, Standard_D8ds_v5, Standard_D8as_v6
            beast     Standard_D16ads_v6, Standard_D16ds_v6, Standard_D16ads_v5, Standard_D16ds_v5, Standard_D8ads_v6
 
-Namespace  standard  S
+Namespace  tiny      S
+           small     S
+           standard  S
            fast      M
            large     L
            beast     XL
 
 Namespace
-Compute    standard  4x8
+Compute    tiny      1x2
+           small     2x4
+           standard  4x8
            fast      8x16
            large     16x32
            beast     32x64
 
-Cloudflare standard  standard-4
+Cloudflare tiny      standard-4
+           small     standard-4
+           standard  standard-4
            fast      standard-4
            large     standard-4
            beast     standard-4

--- a/docs/features/capacity-fallback.md
+++ b/docs/features/capacity-fallback.md
@@ -26,13 +26,15 @@ resource.
 Class names are provider-neutral intent labels:
 
 ```text
+tiny      smoke checks and minimal repositories
+small     small repositories and light CI lanes
 standard  typical CI lane
 fast      more cores for parallel-friendly suites
 large     memory-heavy or many-process workloads
 beast     maximum capacity within the provider's family
 ```
 
-Each provider maps the four class names to an ordered list of concrete
+Each provider maps the six class names to an ordered list of concrete
 instance types. That list *is* the fallback chain: try the first; if it is
 rejected, try the next; and so on until one succeeds or the chain is exhausted.
 

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -104,7 +104,7 @@ windows:
   mode: normal           # normal | wsl2 when target=windows
 
 profile: project-check
-class: beast             # standard | fast | large | beast
+class: beast             # tiny | small | standard | fast | large | beast
 serverType: c7a.48xlarge # explicit provider type; overrides class fallback
 network: auto            # auto | tailscale | public
 hostId: h-0123456789abcdef0 # brokered use requires admin authentication
@@ -1122,6 +1122,8 @@ the list when the first candidate cannot be provisioned.
 
 | Class | Intent |
 |:------|:-------|
+| `tiny` | smoke checks and minimal repositories |
+| `small` | small repositories and light CI lanes |
 | `standard` | typical CI lane |
 | `fast` | ~2x more cores than standard for parallel-friendly suites |
 | `large` | memory-heavy or many-process workloads |

--- a/docs/features/providers.md
+++ b/docs/features/providers.md
@@ -66,31 +66,43 @@ checks whether the selected provider is usable from the current environment.
 
 ## Machine classes
 
-`--class standard|fast|large|beast` (default `beast`) maps to an ordered list of
+`--class tiny|small|standard|fast|large|beast` (default `beast`) maps to an ordered list of
 provider machine types. Crabbox tries each in turn, falling back when capacity or
 quota rejects a request. The maps below come from `internal/cli/config.go` and
 the corresponding provider adapters:
 
 ```text
 Hetzner
+tiny      ccx13 (2 vCPU, 8 GB RAM), cpx22, cx23
+small     ccx23 (4 vCPU, 16 GB RAM), cpx32, cx33
 standard  ccx33 (8 vCPU, 32 GB RAM), cpx62, cx53
 fast      ccx43 (16 vCPU, 64 GB RAM), cpx62, cx53
 large     ccx53 (32 vCPU, 128 GB RAM), ccx43, cpx62, cx53
 beast     ccx63 (48 vCPU, 192 GB RAM), ccx53, ccx43, cpx62, cx53
 
 AWS (Linux)
+tiny      m7a.large (2 vCPU, 8 GB RAM), m7i.large, c7a.xlarge, c7i.xlarge
+small     c7a.2xlarge (8 vCPU, 16 GB RAM), c7i.2xlarge, m7a.xlarge, m7i.xlarge, c7a.xlarge
 standard  c7a.8xlarge (32 vCPU, 64 GB RAM), c7i.8xlarge, m7a.8xlarge, m7i.8xlarge, c7a.4xlarge
 fast      c7a.16xlarge (64 vCPU, 128 GB RAM), c7i.16xlarge, m7a.16xlarge, m7i.16xlarge, c7a.12xlarge, c7a.8xlarge
 large     c7a.24xlarge (96 vCPU, 192 GB RAM), c7i.24xlarge, m7a.24xlarge, m7i.24xlarge, r7a.24xlarge, c7a.16xlarge, c7a.12xlarge
 beast     c7a.48xlarge (192 vCPU, 384 GB RAM), c7i.48xlarge, m7a.48xlarge, m7i.48xlarge, r7a.48xlarge, c7a.32xlarge, c7i.32xlarge, m7a.32xlarge, c7a.24xlarge, c7a.16xlarge
 
+AWS (Linux ARM64)
+tiny      m7g.large, c7g.xlarge, r7g.large
+small     c7g.2xlarge, m7g.xlarge, r7g.large, c7g.xlarge
+
 AWS Windows (normal)
+tiny      m7a.large, m7i.large, t3.large
+small     c7a.2xlarge, c7i.2xlarge, m7a.xlarge, m7i.xlarge, t3.xlarge
 standard  m7i.large, m7a.large, t3.large
 fast      m7i.xlarge, m7a.xlarge, t3.xlarge
 large     m7i.2xlarge, m7a.2xlarge, t3.2xlarge
 beast     m7i.4xlarge, m7a.4xlarge, m7i.2xlarge
 
 AWS Windows WSL2
+tiny      m8i.large, m8i-flex.large, c8i.xlarge, r8i.large
+small     c8i.2xlarge, m8i.xlarge, m8i-flex.xlarge, r8i.large, c8i.xlarge
 standard  m8i.large, m8i-flex.large, c8i.large, r8i.large
 fast      m8i.xlarge, m8i-flex.xlarge, c8i.xlarge, r8i.xlarge
 large     m8i.2xlarge, m8i-flex.2xlarge, c8i.2xlarge, r8i.2xlarge
@@ -102,28 +114,56 @@ mac-m4max.metal, mac2-m1ultra.metal, mac-m3ultra.metal, then mac1.metal unless
 `--type` is set
 
 Google Cloud
+tiny      c4-standard-4 (4 vCPU, 15 GB RAM), c3-standard-4, n2-standard-4, n2d-standard-4
+small     c4-standard-8 (8 vCPU, 30 GB RAM), c3-standard-8, n2-standard-8, n2d-standard-8, c4-standard-4
 standard  c4-standard-32 (32 vCPU, 120 GB RAM), c3-standard-22, n2-standard-32, n2d-standard-32
 fast      c4-standard-64 (64 vCPU, 240 GB RAM), c3-standard-44, n2-standard-64, n2d-standard-64, c4-standard-32
 large     c4-standard-96 (96 vCPU, 360 GB RAM), c3-standard-88, n2-standard-80, n2d-standard-96, c4-standard-64
 beast     c4-standard-192 (192 vCPU, 720 GB RAM), c4-standard-96, c3-standard-176, c3-standard-88, n2d-standard-224, n2-standard-128
 
 Azure (Linux)
+tiny      Standard_D2ads_v6 (2 vCPU, 8 GB RAM), Standard_D2ds_v6, Standard_D2ads_v5, Standard_D2ds_v5, Standard_F2s_v2
+small     Standard_D8ads_v6 (8 vCPU, 32 GB RAM), Standard_D8ds_v6, Standard_F8s_v2, Standard_D8ads_v5, Standard_D8ds_v5, Standard_D4ads_v6, Standard_D4ds_v6, Standard_F4s_v2
 standard  Standard_D32ads_v6 (32 vCPU, 128 GB RAM), Standard_D32ds_v6, Standard_F32s_v2, Standard_D32ads_v5, Standard_D32ds_v5, Standard_D16ads_v6, Standard_D16ds_v6, Standard_F16s_v2
 fast      Standard_D64ads_v6 (64 vCPU, 256 GB RAM), Standard_D64ds_v6, Standard_F64s_v2, Standard_D64ads_v5, Standard_D64ds_v5, Standard_D48ads_v6, Standard_D48ds_v6, Standard_F48s_v2, Standard_D32ads_v6, Standard_D32ds_v6, Standard_F32s_v2
 large     Standard_D96ads_v6 (96 vCPU, 384 GB RAM), Standard_D96ds_v6, Standard_D96ads_v5, Standard_D96ds_v5, Standard_D64ads_v6, Standard_D64ds_v6, Standard_F64s_v2, Standard_D48ads_v6, Standard_D48ds_v6, Standard_F48s_v2
 beast     Standard_D192ds_v6 (192 vCPU, 768 GB RAM), Standard_D128ds_v6, Standard_D96ads_v6, Standard_D96ds_v6, Standard_D96ads_v5, Standard_D96ds_v5, Standard_D64ads_v6, Standard_D64ds_v6, Standard_F64s_v2
 
 Namespace Instance
+tiny      1x2 (1 vCPU, 2 GB RAM)
+small     2x4 (2 vCPU, 4 GB RAM)
 standard  4x8 (4 vCPU, 8 GB RAM)
 fast      8x16 (8 vCPU, 16 GB RAM)
 large     16x32 (16 vCPU, 32 GB RAM)
 beast     32x64 (32 vCPU, 64 GB RAM)
 
+Azure (Linux)
+tiny      Standard_D2ads_v6, Standard_D2ds_v6, Standard_D2ads_v5, Standard_D2ds_v5, Standard_F2s_v2
+small     Standard_D8ads_v6, Standard_D8ds_v6, Standard_F8s_v2, Standard_D8ads_v5, Standard_D8ds_v5, Standard_D4ads_v6, Standard_D4ds_v6, Standard_F4s_v2
+
+Azure (Linux/Windows ARM64)
+tiny      Standard_D2pds_v6, Standard_D2ps_v6
+small     Standard_D8pds_v6, Standard_D8ps_v6, Standard_D4pds_v6, Standard_D4ps_v6
+
+Azure Windows (normal/WSL2)
+tiny      Standard_D2ads_v6, Standard_D2ds_v6, Standard_D2ads_v5, Standard_D2ds_v5, Standard_D2as_v6
+small     Standard_D8ads_v6, Standard_D8ds_v6, Standard_D8ads_v5, Standard_D8ds_v5, Standard_D8as_v6
+
 Namespace Devbox
+tiny      S
+small     S
 standard  S
 fast      M
 large     L
 beast     XL
+
+Namespace Instance
+tiny      1x2
+small     2x4
+standard  4x8
+fast      8x16
+large     16x32
+beast     32x64
 
 Cloudflare Containers (any class -> standard-4)
 lite, basic, standard-1, standard-2, standard-3, standard-4

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -153,7 +153,7 @@ The generated `.crabbox.yaml` ships sensible defaults. Adjust the parts that
 matter for your repo:
 
 - `profile`: a name for this lane (the template uses `<repo>-check`);
-- `class`: `standard`, `fast`, `large`, or `beast` (the template uses `beast`);
+- `class`: `tiny`, `small`, `standard`, `fast`, `large`, or `beast` (the template uses `beast`);
 - `sync.exclude`: directories that should never be sent to the runner;
 - `sync.include`: an optional root-relative whitelist — when set, **only** these
   paths are synced (after excludes), so you can ship a few paths out of a large

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -504,6 +504,8 @@ command can override with `--class`. The default class is `beast`.
 Hetzner server types per class:
 
 ```text
+tiny      ccx13, cpx22, cx23
+small     ccx23, cpx32, cx33
 standard  ccx33, cpx62, cx53
 fast      ccx43, cpx62, cx53
 large     ccx53, ccx43, cpx62, cx53
@@ -514,18 +516,24 @@ AWS instance types per class:
 
 ```text
 Linux
+tiny      m7a.large, m7i.large, c7a.xlarge, c7i.xlarge
+small     c7a.2xlarge, c7i.2xlarge, m7a.xlarge, m7i.xlarge, c7a.xlarge
 standard  c7a.8xlarge, c7i.8xlarge, m7a.8xlarge, m7i.8xlarge, c7a.4xlarge
 fast      c7a.16xlarge, c7i.16xlarge, m7a.16xlarge, m7i.16xlarge, c7a.12xlarge, c7a.8xlarge
 large     c7a.24xlarge, c7i.24xlarge, m7a.24xlarge, m7i.24xlarge, r7a.24xlarge, c7a.16xlarge, c7a.12xlarge
 beast     c7a.48xlarge, c7i.48xlarge, m7a.48xlarge, m7i.48xlarge, r7a.48xlarge, c7a.32xlarge, ...
 
 Windows
+tiny      m7a.large, m7i.large, t3.large
+small     c7a.2xlarge, c7i.2xlarge, m7a.xlarge, m7i.xlarge, t3.xlarge
 standard  m7i.large, m7a.large, t3.large
 fast      m7i.xlarge, m7a.xlarge, t3.xlarge
 large     m7i.2xlarge, m7a.2xlarge, t3.2xlarge
 beast     m7i.4xlarge, m7a.4xlarge, m7i.2xlarge
 
 Windows WSL2
+tiny      m8i.large, m8i-flex.large, c8i.xlarge, r8i.large
+small     c8i.2xlarge, m8i.xlarge, m8i-flex.xlarge, r8i.large, c8i.xlarge
 standard  m8i.large, m8i-flex.large, c8i.large, r8i.large
 fast      m8i.xlarge, m8i-flex.xlarge, c8i.xlarge, r8i.xlarge
 large     m8i.2xlarge, m8i-flex.2xlarge, c8i.2xlarge, r8i.2xlarge

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -177,7 +177,9 @@ package-backed lane for release confidence.
 Pick the smallest class that keeps the target command CPU-bound without hitting
 queue or quota failures. Typical choices:
 
-- `standard` — cheap smoke checks and small repos.
+- `tiny` — minimal smoke checks.
+- `small` — small repositories and light CI lanes.
+- `standard` — typical CI lanes.
 - `fast` — general maintainer testing.
 - `large` — broad test shards or heavy builds.
 - `beast` — high-core changed-test runs.

--- a/docs/providers/aws.md
+++ b/docs/providers/aws.md
@@ -94,6 +94,8 @@ Linux the classes resolve to (first candidate shown):
 
 | Class | First candidate | vCPUs |
 | --- | --- | --- |
+| `tiny` | `m7a.large` | 2 |
+| `small` | `c7a.2xlarge` | 8 |
 | `standard` | `c7a.8xlarge` | 32 |
 | `fast` | `c7a.16xlarge` | 64 |
 | `large` | `c7a.24xlarge` | 96 |

--- a/docs/providers/azure.md
+++ b/docs/providers/azure.md
@@ -240,6 +240,8 @@ until the required service-principal secrets are present.
 Default Linux SKU candidates (first that provisions wins):
 
 ```text
+tiny      Standard_D2ads_v6, Standard_D2ds_v6, Standard_D2ads_v5, Standard_D2ds_v5, Standard_F2s_v2
+small     Standard_D8ads_v6, Standard_D8ds_v6, Standard_F8s_v2, Standard_D8ads_v5, Standard_D8ds_v5, then D/F 4-vCPU fallbacks
 standard  Standard_D32ads_v6, Standard_D32ds_v6, Standard_F32s_v2, Standard_D32ads_v5, Standard_D32ds_v5, then D/F 16-vCPU fallbacks
 fast      Standard_D64ads_v6, Standard_D64ds_v6, Standard_F64s_v2, Standard_D64ads_v5, Standard_D64ds_v5, then D/F 48-vCPU and 32-vCPU fallbacks
 large     Standard_D96ads_v6, Standard_D96ds_v6, Standard_D96ads_v5, Standard_D96ds_v5, then D/F 64-vCPU and 48-vCPU fallbacks
@@ -249,6 +251,8 @@ beast     Standard_D192ds_v6, Standard_D128ds_v6, then D/F 96-vCPU and 64-vCPU f
 Default native Windows and WSL2 SKU candidates:
 
 ```text
+tiny      Standard_D2ads_v6, Standard_D2ds_v6, Standard_D2ads_v5, Standard_D2ds_v5, then Standard_D2as_v6
+small     Standard_D8ads_v6, Standard_D8ds_v6, Standard_D8ads_v5, Standard_D8ds_v5, then Standard_D8as_v6
 standard  Standard_D2ads_v6, Standard_D2ds_v6, Standard_D2ads_v5, Standard_D2ds_v5, then Standard_D2as_v6
 fast      Standard_D4ads_v6, Standard_D4ds_v6, Standard_D4ads_v5, Standard_D4ds_v5, then Standard_D4as_v6
 large     Standard_D8ads_v6, Standard_D8ds_v6, Standard_D8ads_v5, Standard_D8ds_v5, then Standard_D8as_v6

--- a/docs/providers/cloudflare.md
+++ b/docs/providers/cloudflare.md
@@ -155,6 +155,8 @@ predefined Cloudflare instance type. Crabbox maps every generic class to
 default Linux classes on other providers.
 
 ```text
+--class tiny      standard-4
+--class small     standard-4
 --class standard  standard-4
 --class fast      standard-4
 --class large     standard-4

--- a/docs/providers/gcp.md
+++ b/docs/providers/gcp.md
@@ -266,6 +266,8 @@ project plus either a complete service-account key pair or
 ## Machine classes
 
 ```text
+tiny      c4-standard-4, c3-standard-4, n2-standard-4, n2d-standard-4
+small     c4-standard-8, c3-standard-8, n2-standard-8, n2d-standard-8, c4-standard-4
 standard  c4-standard-32, c3-standard-22, n2-standard-32, n2d-standard-32
 fast      c4-standard-64, c3-standard-44, n2-standard-64, n2d-standard-64, c4-standard-32
 large     c4-standard-96, c3-standard-88, n2-standard-80, n2d-standard-96, c4-standard-64

--- a/docs/providers/hetzner.md
+++ b/docs/providers/hetzner.md
@@ -135,6 +135,8 @@ Classes expand to an ordered list of Hetzner server types; provisioning tries
 each in turn until one has capacity:
 
 ```text
+tiny      ccx13, cpx22, cx23
+small     ccx23, cpx32, cx33
 standard  ccx33, cpx62, cx53
 fast      ccx43, cpx62, cx53
 large     ccx53, ccx43, cpx62, cx53

--- a/docs/providers/namespace-devbox.md
+++ b/docs/providers/namespace-devbox.md
@@ -139,6 +139,8 @@ derives it from `--class`:
 
 | Class      | Size |
 | ---------- | ---- |
+| `tiny`     | `S`  |
+| `small`    | `S`  |
 | `standard` | `S`  |
 | `fast`     | `M`  |
 | `large`    | `L`  |

--- a/docs/providers/namespace-instance.md
+++ b/docs/providers/namespace-instance.md
@@ -48,8 +48,9 @@ namespaceInstance:
   bare: true
 ```
 
-Class defaults are `standard=4x8`, `fast=8x16`, `large=16x32`, and
-`beast=32x64`. Use `--type` or `--namespace-instance-machine-type` for an exact
+Class defaults are `tiny=1x2`, `small=2x4`, `standard=4x8`, `fast=8x16`,
+`large=16x32`, and `beast=32x64`. Use `--type` or
+`--namespace-instance-machine-type` for an exact
 Namespace `CPUxMemoryGB` shape.
 
 Provider flags:

--- a/docs/providers/phala.md
+++ b/docs/providers/phala.md
@@ -73,8 +73,9 @@ phala:
   attest: true   # verify Intel TDX attestation before trusting the CVM (default)
 ```
 
-Class defaults are `standard=tdx.small`, `fast=tdx.medium`, `large=tdx.large`,
-and `beast=tdx.xlarge`. Use `--type` or `--phala-instance-type` for an exact
+Class defaults are `tiny=tdx.small`, `small=tdx.small`, `standard=tdx.small`,
+`fast=tdx.medium`, `large=tdx.large`, and `beast=tdx.xlarge`. Use `--type` or
+`--phala-instance-type` for an exact
 Phala instance shape.
 
 Provider flags:

--- a/internal/cli/aws.go
+++ b/internal/cli/aws.go
@@ -1641,7 +1641,7 @@ func awsRecommendedClassForQuota(cfg Config, limitVCPUs int) (string, string) {
 		return "", ""
 	}
 	architecture := effectiveArchitectureForConfig(cfg)
-	classes := []string{"beast", "large", "fast", "standard"}
+	classes := []string{"beast", "large", "fast", "standard", "small", "tiny"}
 	for _, class := range classes {
 		candidates := awsInstanceTypeCandidatesForTargetModeArchitectureClass(cfg.TargetOS, cfg.WindowsMode, architecture, class)
 		if len(candidates) == 0 {

--- a/internal/cli/aws_test.go
+++ b/internal/cli/aws_test.go
@@ -716,6 +716,27 @@ func TestAWSCapacityDoctorCheckWarnsWhenQuotaBelowDefaultClass(t *testing.T) {
 	}
 }
 
+func TestAWSRecommendedClassForQuotaIncludesSmallClasses(t *testing.T) {
+	t.Parallel()
+	cfg := defaultConfig()
+	cfg.Provider = "aws"
+	cfg.TargetOS = targetLinux
+
+	for _, tt := range []struct {
+		limitVCPUs int
+		wantClass  string
+		wantType   string
+	}{
+		{limitVCPUs: 2, wantClass: "tiny", wantType: "m7a.large"},
+		{limitVCPUs: 8, wantClass: "small", wantType: "c7a.2xlarge"},
+	} {
+		gotClass, gotType := awsRecommendedClassForQuota(cfg, tt.limitVCPUs)
+		if gotClass != tt.wantClass || gotType != tt.wantType {
+			t.Fatalf("limit=%d got=(%q,%q) want=(%q,%q)", tt.limitVCPUs, gotClass, gotType, tt.wantClass, tt.wantType)
+		}
+	}
+}
+
 func TestAWSCapacityDoctorCheckRecommendsARM64Types(t *testing.T) {
 	cfg := defaultConfig()
 	cfg.Provider = "aws"

--- a/internal/cli/azure.go
+++ b/internal/cli/azure.go
@@ -302,6 +302,10 @@ func azureVMSizeCandidatesForArchitectureClass(architecture, class string) []str
 		return azureARM64VMSizeCandidatesForClass(class)
 	}
 	switch class {
+	case "tiny":
+		return []string{"Standard_D2ads_v6", "Standard_D2ds_v6", "Standard_D2ads_v5", "Standard_D2ds_v5", "Standard_F2s_v2"}
+	case "small":
+		return []string{"Standard_D8ads_v6", "Standard_D8ds_v6", "Standard_F8s_v2", "Standard_D8ads_v5", "Standard_D8ds_v5", "Standard_D4ads_v6", "Standard_D4ds_v6", "Standard_F4s_v2"}
 	case "standard":
 		return []string{"Standard_D32ads_v6", "Standard_D32ds_v6", "Standard_F32s_v2", "Standard_D32ads_v5", "Standard_D32ds_v5", "Standard_D16ads_v6", "Standard_D16ds_v6", "Standard_F16s_v2"}
 	case "fast":
@@ -317,6 +321,10 @@ func azureVMSizeCandidatesForArchitectureClass(architecture, class string) []str
 
 func azureARM64VMSizeCandidatesForClass(class string) []string {
 	switch class {
+	case "tiny":
+		return []string{"Standard_D2pds_v6", "Standard_D2ps_v6"}
+	case "small":
+		return []string{"Standard_D8pds_v6", "Standard_D8ps_v6", "Standard_D4pds_v6", "Standard_D4ps_v6"}
 	case "standard":
 		return []string{"Standard_D32pds_v6", "Standard_D32ps_v6", "Standard_D16pds_v6", "Standard_D16ps_v6"}
 	case "fast":
@@ -337,6 +345,10 @@ func azureVMSizeIsARM64(vmSize string) bool {
 
 func azureWindowsVMSizeCandidatesForClass(class string) []string {
 	switch class {
+	case "tiny":
+		return []string{"Standard_D2ads_v6", "Standard_D2ds_v6", "Standard_D2ads_v5", "Standard_D2ds_v5", "Standard_D2as_v6"}
+	case "small":
+		return []string{"Standard_D8ads_v6", "Standard_D8ds_v6", "Standard_D8ads_v5", "Standard_D8ds_v5", "Standard_D8as_v6"}
 	case "standard":
 		return []string{"Standard_D2ads_v6", "Standard_D2ds_v6", "Standard_D2ads_v5", "Standard_D2ds_v5", "Standard_D2as_v6"}
 	case "fast":

--- a/internal/cli/azure_test.go
+++ b/internal/cli/azure_test.go
@@ -297,6 +297,8 @@ func TestAzureVMSizeCandidatesForClass(t *testing.T) {
 		class string
 		want  []string
 	}{
+		{class: "tiny", want: []string{"Standard_D2ads_v6", "Standard_D2ds_v6", "Standard_D2ads_v5", "Standard_D2ds_v5", "Standard_F2s_v2"}},
+		{class: "small", want: []string{"Standard_D8ads_v6", "Standard_D8ds_v6", "Standard_F8s_v2", "Standard_D8ads_v5", "Standard_D8ds_v5", "Standard_D4ads_v6", "Standard_D4ds_v6", "Standard_F4s_v2"}},
 		{class: "standard", want: []string{"Standard_D32ads_v6", "Standard_D32ds_v6", "Standard_F32s_v2", "Standard_D32ads_v5", "Standard_D32ds_v5", "Standard_D16ads_v6", "Standard_D16ds_v6", "Standard_F16s_v2"}},
 		{class: "fast", want: []string{"Standard_D64ads_v6", "Standard_D64ds_v6", "Standard_F64s_v2", "Standard_D64ads_v5", "Standard_D64ds_v5", "Standard_D48ads_v6", "Standard_D48ds_v6", "Standard_F48s_v2", "Standard_D32ads_v6", "Standard_D32ds_v6", "Standard_F32s_v2"}},
 		{class: "large", want: []string{"Standard_D96ads_v6", "Standard_D96ds_v6", "Standard_D96ads_v5", "Standard_D96ds_v5", "Standard_D64ads_v6", "Standard_D64ds_v6", "Standard_F64s_v2", "Standard_D48ads_v6", "Standard_D48ds_v6", "Standard_F48s_v2"}},
@@ -313,10 +315,17 @@ func TestAzureVMSizeCandidatesForClass(t *testing.T) {
 
 func TestAzureARM64VMSizeCandidatesForClass(t *testing.T) {
 	t.Parallel()
-	got := azureARM64VMSizeCandidatesForClass("beast")
-	want := []string{"Standard_D96pds_v6", "Standard_D96ps_v6", "Standard_D64pds_v6", "Standard_D64ps_v6"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("got %v, want %v", got, want)
+	for _, tt := range []struct {
+		class string
+		want  []string
+	}{
+		{class: "tiny", want: []string{"Standard_D2pds_v6", "Standard_D2ps_v6"}},
+		{class: "small", want: []string{"Standard_D8pds_v6", "Standard_D8ps_v6", "Standard_D4pds_v6", "Standard_D4ps_v6"}},
+		{class: "beast", want: []string{"Standard_D96pds_v6", "Standard_D96ps_v6", "Standard_D64pds_v6", "Standard_D64ps_v6"}},
+	} {
+		if got := azureARM64VMSizeCandidatesForClass(tt.class); !reflect.DeepEqual(got, tt.want) {
+			t.Fatalf("class=%q got %v, want %v", tt.class, got, tt.want)
+		}
 	}
 }
 
@@ -696,10 +705,17 @@ func TestAzureWindowsSnapshotRehydrateDefinesVNCPathWithoutDesktop(t *testing.T)
 
 func TestAzureWindowsVMSizeCandidatesForClass(t *testing.T) {
 	t.Parallel()
-	got := azureWindowsVMSizeCandidatesForClass("beast")
-	want := []string{"Standard_D16ads_v6", "Standard_D16ds_v6", "Standard_D16ads_v5", "Standard_D16ds_v5", "Standard_D8ads_v6"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("got %v, want %v", got, want)
+	for _, tt := range []struct {
+		class string
+		want  []string
+	}{
+		{class: "tiny", want: []string{"Standard_D2ads_v6", "Standard_D2ds_v6", "Standard_D2ads_v5", "Standard_D2ds_v5", "Standard_D2as_v6"}},
+		{class: "small", want: []string{"Standard_D8ads_v6", "Standard_D8ds_v6", "Standard_D8ads_v5", "Standard_D8ds_v5", "Standard_D8as_v6"}},
+		{class: "beast", want: []string{"Standard_D16ads_v6", "Standard_D16ds_v6", "Standard_D16ads_v5", "Standard_D16ds_v5", "Standard_D8ads_v6"}},
+	} {
+		if got := azureWindowsVMSizeCandidatesForClass(tt.class); !reflect.DeepEqual(got, tt.want) {
+			t.Fatalf("class=%q got %v, want %v", tt.class, got, tt.want)
+		}
 	}
 }
 

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -10133,6 +10133,8 @@ func namespaceDevboxSizeForConfig(cfg Config) string {
 
 func namespaceDevboxSizeForClass(class string) string {
 	switch strings.ToLower(strings.TrimSpace(class)) {
+	case "tiny", "small":
+		return "S"
 	case "standard":
 		return "S"
 	case "fast":
@@ -10173,7 +10175,7 @@ func NormalizeCloudflareContainerInstanceType(value string) (string, bool) {
 
 func cloudflareContainerInstanceTypeForClass(class string) string {
 	switch strings.ToLower(strings.TrimSpace(class)) {
-	case "", "standard", "fast", "large", "beast":
+	case "", "tiny", "small", "standard", "fast", "large", "beast":
 		return "standard-4"
 	default:
 		if instanceType, ok := normalizeCloudflareContainerInstanceType(class); ok {
@@ -10189,6 +10191,10 @@ func CloudflareContainerInstanceTypeForClass(class string) string {
 
 func serverTypeCandidatesForClass(class string) []string {
 	switch class {
+	case "tiny":
+		return []string{"ccx13", "cpx22", "cx23"}
+	case "small":
+		return []string{"ccx23", "cpx32", "cx33"}
 	case "standard":
 		return []string{"ccx33", "cpx62", "cx53"}
 	case "fast":
@@ -10221,6 +10227,10 @@ func awsInstanceTypeCandidatesForTargetModeArchitectureClass(target, windowsMode
 	case targetWindows:
 		if windowsMode == windowsModeWSL2 {
 			switch class {
+			case "tiny":
+				return []string{"m8i.large", "m8i-flex.large", "c8i.xlarge", "r8i.large"}
+			case "small":
+				return []string{"c8i.2xlarge", "m8i.xlarge", "m8i-flex.xlarge", "r8i.large", "c8i.xlarge"}
 			case "standard":
 				return []string{"m8i.large", "m8i-flex.large", "c8i.large", "r8i.large"}
 			case "fast":
@@ -10234,6 +10244,10 @@ func awsInstanceTypeCandidatesForTargetModeArchitectureClass(target, windowsMode
 			}
 		}
 		switch class {
+		case "tiny":
+			return []string{"m7a.large", "m7i.large", "t3.large"}
+		case "small":
+			return []string{"c7a.2xlarge", "c7i.2xlarge", "m7a.xlarge", "m7i.xlarge", "t3.xlarge"}
 		case "standard":
 			return []string{"m7i.large", "m7a.large", "t3.large"}
 		case "fast":
@@ -10273,6 +10287,10 @@ func awsInstanceTypeCandidatesForArchitectureClass(architecture, class string) [
 		return awsARM64InstanceTypeCandidatesForClass(class)
 	}
 	switch class {
+	case "tiny":
+		return []string{"m7a.large", "m7i.large", "c7a.xlarge", "c7i.xlarge"}
+	case "small":
+		return []string{"c7a.2xlarge", "c7i.2xlarge", "m7a.xlarge", "m7i.xlarge", "c7a.xlarge"}
 	case "standard":
 		return []string{"c7a.8xlarge", "c7i.8xlarge", "m7a.8xlarge", "m7i.8xlarge", "c7a.4xlarge"}
 	case "fast":
@@ -10288,6 +10306,10 @@ func awsInstanceTypeCandidatesForArchitectureClass(architecture, class string) [
 
 func awsARM64InstanceTypeCandidatesForClass(class string) []string {
 	switch class {
+	case "tiny":
+		return []string{"m7g.large", "c7g.xlarge", "r7g.large"}
+	case "small":
+		return []string{"c7g.2xlarge", "m7g.xlarge", "r7g.large", "c7g.xlarge"}
 	case "standard":
 		return []string{"c7g.8xlarge", "m7g.8xlarge", "r7g.8xlarge", "c7g.4xlarge"}
 	case "fast":

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -7712,6 +7712,8 @@ func TestConfigServerTypeHelperBranches(t *testing.T) {
 		class string
 		want  string
 	}{
+		{class: "tiny", want: "S"},
+		{class: "small", want: "S"},
 		{class: "standard", want: "S"},
 		{class: "fast", want: "M"},
 		{class: "beast", want: "XL"},

--- a/internal/cli/gcp.go
+++ b/internal/cli/gcp.go
@@ -90,6 +90,10 @@ func newGCPClientWithOptions(ctx context.Context, cfg Config, opts ...option.Cli
 
 func gcpMachineTypeCandidatesForClass(class string) []string {
 	switch class {
+	case "tiny":
+		return []string{"c4-standard-4", "c3-standard-4", "n2-standard-4", "n2d-standard-4"}
+	case "small":
+		return []string{"c4-standard-8", "c3-standard-8", "n2-standard-8", "n2d-standard-8", "c4-standard-4"}
 	case "standard":
 		return []string{"c4-standard-32", "c3-standard-22", "n2-standard-32", "n2d-standard-32"}
 	case "fast":

--- a/internal/cli/gcp_test.go
+++ b/internal/cli/gcp_test.go
@@ -20,10 +20,17 @@ import (
 )
 
 func TestGCPMachineTypeCandidatesForClass(t *testing.T) {
-	got := gcpMachineTypeCandidatesForClass("standard")
-	want := []string{"c4-standard-32", "c3-standard-22", "n2-standard-32", "n2d-standard-32"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("standard=%v want %v", got, want)
+	for _, tt := range []struct {
+		class string
+		want  []string
+	}{
+		{class: "tiny", want: []string{"c4-standard-4", "c3-standard-4", "n2-standard-4", "n2d-standard-4"}},
+		{class: "small", want: []string{"c4-standard-8", "c3-standard-8", "n2-standard-8", "n2d-standard-8", "c4-standard-4"}},
+		{class: "standard", want: []string{"c4-standard-32", "c3-standard-22", "n2-standard-32", "n2d-standard-32"}},
+	} {
+		if got := gcpMachineTypeCandidatesForClass(tt.class); !reflect.DeepEqual(got, tt.want) {
+			t.Fatalf("class=%q got %v want %v", tt.class, got, tt.want)
+		}
 	}
 	if got := serverTypeForProviderClass("gcp", "beast"); got != "c4-standard-192" {
 		t.Fatalf("gcp beast=%q", got)

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -111,6 +111,11 @@ type ClassSpec struct {
 
 // ProviderClassSpecProvider reports provider-owned machine class resolutions
 // for the provider matrix.
+// MachineClassOrder lists every portable machine class from smallest to
+// largest. Providers iterate it so a new class reaches every ClassSpecs()
+// implementation at once instead of drifting per provider.
+var MachineClassOrder = []string{"tiny", "small", "standard", "fast", "large", "beast"}
+
 type ProviderClassSpecProvider interface {
 	ClassSpecs() []ClassSpec
 }

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -1948,10 +1948,10 @@ func TestProvidersJSONIncludesBuiltIns(t *testing.T) {
 		if entry == nil {
 			t.Fatalf("built binary providers json missing %s", provider)
 		}
-		if len(entry.Classes) != 4 {
-			t.Fatalf("%s classes=%#v want four entries", provider, entry.Classes)
+		if len(entry.Classes) != len(MachineClassOrder) {
+			t.Fatalf("%s classes=%#v want %d entries", provider, entry.Classes, len(MachineClassOrder))
 		}
-		for classIndex, className := range []string{"standard", "fast", "large", "beast"} {
+		for classIndex, className := range MachineClassOrder {
 			classSpec := entry.Classes[classIndex]
 			if classSpec.Class != className || classSpec.Type == "" || classSpec.VCPUs <= 0 || classSpec.MemoryGB <= 0 {
 				t.Fatalf("%s class[%d]=%#v", provider, classIndex, classSpec)

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -4381,6 +4381,8 @@ func TestCloudflareContainerInstanceTypeMapping(t *testing.T) {
 		want  string
 	}{
 		{class: "", want: "standard-4"},
+		{class: "tiny", want: "standard-4"},
+		{class: "small", want: "standard-4"},
 		{class: "standard", want: "standard-4"},
 		{class: "fast", want: "standard-4"},
 		{class: "large", want: "standard-4"},
@@ -4465,13 +4467,19 @@ func TestAWSInstanceTypeCandidatesForTargetsAndModes(t *testing.T) {
 		want        []string
 	}{
 		{name: "macos", target: targetMacOS, class: "beast", want: awsMacOSInstanceTypeCandidates()},
+		{name: "windows normal tiny", target: targetWindows, class: "tiny", want: []string{"m7a.large", "m7i.large", "t3.large"}},
+		{name: "windows normal small", target: targetWindows, class: "small", want: []string{"c7a.2xlarge", "c7i.2xlarge", "m7a.xlarge", "m7i.xlarge", "t3.xlarge"}},
 		{name: "windows normal standard", target: targetWindows, class: "standard", want: []string{"m7i.large", "m7a.large", "t3.large"}},
 		{name: "windows normal custom", target: targetWindows, class: "m7i.8xlarge", want: []string{"m7i.8xlarge"}},
+		{name: "windows wsl2 tiny", target: targetWindows, windowsMode: windowsModeWSL2, class: "tiny", want: []string{"m8i.large", "m8i-flex.large", "c8i.xlarge", "r8i.large"}},
+		{name: "windows wsl2 small", target: targetWindows, windowsMode: windowsModeWSL2, class: "small", want: []string{"c8i.2xlarge", "m8i.xlarge", "m8i-flex.xlarge", "r8i.large", "c8i.xlarge"}},
 		{name: "windows wsl2 standard", target: targetWindows, windowsMode: windowsModeWSL2, class: "standard", want: []string{"m8i.large", "m8i-flex.large", "c8i.large", "r8i.large"}},
 		{name: "windows wsl2 fast", target: targetWindows, windowsMode: windowsModeWSL2, class: "fast", want: []string{"m8i.xlarge", "m8i-flex.xlarge", "c8i.xlarge", "r8i.xlarge"}},
 		{name: "windows wsl2 large", target: targetWindows, windowsMode: windowsModeWSL2, class: "large", want: []string{"m8i.2xlarge", "m8i-flex.2xlarge", "c8i.2xlarge", "r8i.2xlarge"}},
 		{name: "windows wsl2 beast", target: targetWindows, windowsMode: windowsModeWSL2, class: "beast", want: []string{"m8i.4xlarge", "m8i-flex.4xlarge", "c8i.4xlarge", "r8i.4xlarge", "m8i.2xlarge"}},
 		{name: "windows wsl2 custom", target: targetWindows, windowsMode: windowsModeWSL2, class: "m8i.8xlarge", want: []string{"m8i.8xlarge"}},
+		{name: "linux tiny", target: targetLinux, class: "tiny", want: []string{"m7a.large", "m7i.large", "c7a.xlarge", "c7i.xlarge"}},
+		{name: "linux small", target: targetLinux, class: "small", want: []string{"c7a.2xlarge", "c7i.2xlarge", "m7a.xlarge", "m7i.xlarge", "c7a.xlarge"}},
 		{name: "linux large", target: targetLinux, class: "large", want: []string{"c7a.24xlarge", "c7i.24xlarge", "m7a.24xlarge", "m7i.24xlarge", "r7a.24xlarge", "c7a.16xlarge", "c7a.12xlarge"}},
 	}
 	for _, tt := range tests {
@@ -4488,10 +4496,32 @@ func TestAWSInstanceTypeCandidatesForTargetsAndModes(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("target class candidates=%v want %v", got, want)
 	}
-	got = awsInstanceTypeCandidatesForTargetModeArchitectureClass(targetLinux, windowsModeNormal, ArchitectureARM64, "fast")
-	want = []string{"c7g.16xlarge", "m7g.16xlarge", "r7g.16xlarge", "c7g.12xlarge", "c7g.8xlarge"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("arm target class candidates=%v want %v", got, want)
+	for _, tt := range []struct {
+		class string
+		want  []string
+	}{
+		{class: "tiny", want: []string{"m7g.large", "c7g.xlarge", "r7g.large"}},
+		{class: "small", want: []string{"c7g.2xlarge", "m7g.xlarge", "r7g.large", "c7g.xlarge"}},
+		{class: "fast", want: []string{"c7g.16xlarge", "m7g.16xlarge", "r7g.16xlarge", "c7g.12xlarge", "c7g.8xlarge"}},
+	} {
+		got = awsInstanceTypeCandidatesForTargetModeArchitectureClass(targetLinux, windowsModeNormal, ArchitectureARM64, tt.class)
+		if !reflect.DeepEqual(got, tt.want) {
+			t.Fatalf("arm target class=%q candidates=%v want %v", tt.class, got, tt.want)
+		}
+	}
+}
+
+func TestHetznerServerTypeCandidatesForSmallClasses(t *testing.T) {
+	for _, tt := range []struct {
+		class string
+		want  []string
+	}{
+		{class: "tiny", want: []string{"ccx13", "cpx22", "cx23"}},
+		{class: "small", want: []string{"ccx23", "cpx32", "cx33"}},
+	} {
+		if got := serverTypeCandidatesForClass(tt.class); !reflect.DeepEqual(got, tt.want) {
+			t.Fatalf("class=%q candidates=%v want %v", tt.class, got, tt.want)
+		}
 	}
 }
 

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -201,7 +201,7 @@ func validateProviderTarget(cfg Config) error {
 		cfg.WindowsMode == windowsModeWSL2 &&
 		cfg.ServerTypeExplicit &&
 		!awsInstanceTypeSupportsNestedVirtualization(cfg.ServerType) {
-		return exit(2, "provider=aws target=windows windows.mode=wsl2 requires an instance type with AWS nested virtualization; %s is not supported. Use --type m8i.4xlarge or omit --type and choose class=standard|fast|large|beast", cfg.ServerType)
+		return exit(2, "provider=aws target=windows windows.mode=wsl2 requires an instance type with AWS nested virtualization; %s is not supported. Use --type m8i.4xlarge or omit --type and choose class=tiny|small|standard|fast|large|beast", cfg.ServerType)
 	}
 	if cfg.Provider == "aws" && cfg.TargetOS == targetMacOS {
 		if cfg.HostID == "" && cfg.AWSMacHostID == "" && cfg.Coordinator == "" {

--- a/internal/cli/target_test.go
+++ b/internal/cli/target_test.go
@@ -116,7 +116,10 @@ func TestValidateProviderTargetRejectsAWSWSL2ExactTypeWithoutNestedVirtualizatio
 	cfg.ServerTypeExplicit = true
 
 	err := validateProviderTarget(cfg)
-	if err == nil || !strings.Contains(err.Error(), "nested virtualization") || !strings.Contains(err.Error(), "m8i.4xlarge") {
+	if err == nil ||
+		!strings.Contains(err.Error(), "nested virtualization") ||
+		!strings.Contains(err.Error(), "m8i.4xlarge") ||
+		!strings.Contains(err.Error(), "class=tiny|small|standard|fast|large|beast") {
 		t.Fatalf("err=%v", err)
 	}
 }

--- a/internal/providers/all/all_test.go
+++ b/internal/providers/all/all_test.go
@@ -1431,3 +1431,40 @@ func mustProvider(t *testing.T, name string) core.Provider {
 	}
 	return provider
 }
+
+func TestClassSpecsReportCompleteShapesForEveryClass(t *testing.T) {
+	seen := 0
+	for _, providerName := range core.RegisteredProviderNames() {
+		provider, err := core.ProviderFor(providerName)
+		if err != nil {
+			t.Fatalf("ProviderFor(%q): %v", providerName, err)
+		}
+		specs, ok := provider.(core.ProviderClassSpecProvider)
+		if !ok {
+			continue
+		}
+		seen++
+		classes := specs.ClassSpecs()
+		if got, want := len(classes), len(core.MachineClassOrder); got != want {
+			t.Errorf("%s reports %d classes, want %d", providerName, got, want)
+			continue
+		}
+		for i, class := range classes {
+			if class.Class != core.MachineClassOrder[i] {
+				t.Errorf("%s class %d = %q, want %q", providerName, i, class.Class, core.MachineClassOrder[i])
+			}
+			if class.Type == "" {
+				t.Errorf("%s/%s has no type", providerName, class.Class)
+			}
+			// A class present in the type tables but absent from the provider's
+			// shape data would otherwise render with no CPU/RAM at all.
+			if class.VCPUs <= 0 || class.MemoryGB <= 0 {
+				t.Errorf("%s/%s (%s) reports incomplete shape vcpu=%d memoryGb=%d",
+					providerName, class.Class, class.Type, class.VCPUs, class.MemoryGB)
+			}
+		}
+	}
+	if seen == 0 {
+		t.Fatal("no providers implement ClassSpecs; test would be vacuous")
+	}
+}

--- a/internal/providers/aws/class_specs_test.go
+++ b/internal/providers/aws/class_specs_test.go
@@ -9,6 +9,8 @@ import (
 
 func TestClassSpecs(t *testing.T) {
 	want := []core.ClassSpec{
+		{Class: "tiny", Type: "m7a.large", VCPUs: 2, MemoryGB: 8},
+		{Class: "small", Type: "c7a.2xlarge", VCPUs: 8, MemoryGB: 16},
 		{Class: "standard", Type: "c7a.8xlarge", VCPUs: 32, MemoryGB: 64},
 		{Class: "fast", Type: "c7a.16xlarge", VCPUs: 64, MemoryGB: 128},
 		{Class: "large", Type: "c7a.24xlarge", VCPUs: 96, MemoryGB: 192},

--- a/internal/providers/aws/provider.go
+++ b/internal/providers/aws/provider.go
@@ -95,7 +95,7 @@ func (Provider) ServerTypeForClass(class string) string {
 }
 
 func (Provider) ClassSpecs() []core.ClassSpec {
-	classes := []string{"standard", "fast", "large", "beast"}
+	classes := core.MachineClassOrder
 	specs := make([]core.ClassSpec, 0, len(classes))
 	for _, class := range classes {
 		instanceType := core.AWSInstanceTypeCandidatesForClass(class)[0]

--- a/internal/providers/azure/class_specs_test.go
+++ b/internal/providers/azure/class_specs_test.go
@@ -9,6 +9,8 @@ import (
 
 func TestClassSpecs(t *testing.T) {
 	want := []core.ClassSpec{
+		{Class: "tiny", Type: "Standard_D2ads_v6", VCPUs: 2, MemoryGB: 8},
+		{Class: "small", Type: "Standard_D8ads_v6", VCPUs: 8, MemoryGB: 32},
 		{Class: "standard", Type: "Standard_D32ads_v6", VCPUs: 32, MemoryGB: 128},
 		{Class: "fast", Type: "Standard_D64ads_v6", VCPUs: 64, MemoryGB: 256},
 		{Class: "large", Type: "Standard_D96ads_v6", VCPUs: 96, MemoryGB: 384},

--- a/internal/providers/azure/provider.go
+++ b/internal/providers/azure/provider.go
@@ -162,7 +162,7 @@ func (Provider) ServerTypeForClass(class string) string {
 }
 
 func (Provider) ClassSpecs() []core.ClassSpec {
-	classes := []string{"standard", "fast", "large", "beast"}
+	classes := core.MachineClassOrder
 	specs := make([]core.ClassSpec, 0, len(classes))
 	for _, class := range classes {
 		vmSize := core.AzureVMSizeCandidatesForClass(class)[0]

--- a/internal/providers/gcp/class_specs_test.go
+++ b/internal/providers/gcp/class_specs_test.go
@@ -9,6 +9,8 @@ import (
 
 func TestClassSpecs(t *testing.T) {
 	want := []core.ClassSpec{
+		{Class: "tiny", Type: "c4-standard-4", VCPUs: 4, MemoryGB: 15},
+		{Class: "small", Type: "c4-standard-8", VCPUs: 8, MemoryGB: 30},
 		{Class: "standard", Type: "c4-standard-32", VCPUs: 32, MemoryGB: 120},
 		{Class: "fast", Type: "c4-standard-64", VCPUs: 64, MemoryGB: 240},
 		{Class: "large", Type: "c4-standard-96", VCPUs: 96, MemoryGB: 360},

--- a/internal/providers/gcp/provider.go
+++ b/internal/providers/gcp/provider.go
@@ -91,7 +91,7 @@ func (Provider) ServerTypeForClass(class string) string {
 }
 
 func (Provider) ClassSpecs() []core.ClassSpec {
-	classes := []string{"standard", "fast", "large", "beast"}
+	classes := core.MachineClassOrder
 	specs := make([]core.ClassSpec, 0, len(classes))
 	for _, class := range classes {
 		machineType := core.GCPMachineTypeCandidatesForClass(class)[0]

--- a/internal/providers/hetzner/class_specs_test.go
+++ b/internal/providers/hetzner/class_specs_test.go
@@ -9,6 +9,8 @@ import (
 
 func TestClassSpecs(t *testing.T) {
 	want := []core.ClassSpec{
+		{Class: "tiny", Type: "ccx13", VCPUs: 2, MemoryGB: 8},
+		{Class: "small", Type: "ccx23", VCPUs: 4, MemoryGB: 16},
 		{Class: "standard", Type: "ccx33", VCPUs: 8, MemoryGB: 32},
 		{Class: "fast", Type: "ccx43", VCPUs: 16, MemoryGB: 64},
 		{Class: "large", Type: "ccx53", VCPUs: 32, MemoryGB: 128},

--- a/internal/providers/hetzner/provider.go
+++ b/internal/providers/hetzner/provider.go
@@ -22,6 +22,8 @@ var serverShapes = map[string]struct {
 	vcpus    int
 	memoryGB int
 }{
+	"ccx13": {vcpus: 2, memoryGB: 8},
+	"ccx23": {vcpus: 4, memoryGB: 16},
 	"ccx33": {vcpus: 8, memoryGB: 32},
 	"ccx43": {vcpus: 16, memoryGB: 64},
 	"ccx53": {vcpus: 32, memoryGB: 128},
@@ -99,7 +101,7 @@ func (Provider) ApplyFlags(*core.Config, *flag.FlagSet, any) error {
 }
 
 func (Provider) ClassSpecs() []core.ClassSpec {
-	classes := []string{"standard", "fast", "large", "beast"}
+	classes := core.MachineClassOrder
 	specs := make([]core.ClassSpec, 0, len(classes))
 	for _, class := range classes {
 		serverType := core.HetznerServerTypeCandidatesForClass(class)[0]

--- a/internal/providers/namespaceinstance/backend.go
+++ b/internal/providers/namespaceinstance/backend.go
@@ -78,6 +78,10 @@ func applyDefaults(cfg *core.Config) {
 
 func machineTypeForClass(class string) string {
 	switch strings.ToLower(strings.TrimSpace(class)) {
+	case "tiny":
+		return "1x2"
+	case "small":
+		return "2x4"
 	case "", "standard":
 		return "4x8"
 	case "fast":

--- a/internal/providers/namespaceinstance/backend_test.go
+++ b/internal/providers/namespaceinstance/backend_test.go
@@ -175,6 +175,8 @@ func TestMachineTypeForClass(t *testing.T) {
 		class string
 		want  string
 	}{
+		{"tiny", "1x2"},
+		{"small", "2x4"},
 		{"standard", "4x8"},
 		{"fast", "8x16"},
 		{"large", "16x32"},

--- a/internal/providers/namespaceinstance/class_specs_test.go
+++ b/internal/providers/namespaceinstance/class_specs_test.go
@@ -9,6 +9,8 @@ import (
 
 func TestClassSpecs(t *testing.T) {
 	want := []core.ClassSpec{
+		{Class: "tiny", Type: "1x2", VCPUs: 1, MemoryGB: 2},
+		{Class: "small", Type: "2x4", VCPUs: 2, MemoryGB: 4},
 		{Class: "standard", Type: "4x8", VCPUs: 4, MemoryGB: 8},
 		{Class: "fast", Type: "8x16", VCPUs: 8, MemoryGB: 16},
 		{Class: "large", Type: "16x32", VCPUs: 16, MemoryGB: 32},

--- a/internal/providers/namespaceinstance/provider.go
+++ b/internal/providers/namespaceinstance/provider.go
@@ -139,7 +139,7 @@ func (Provider) ServerTypeForClass(class string) string {
 }
 
 func (Provider) ClassSpecs() []core.ClassSpec {
-	classes := []string{"standard", "fast", "large", "beast"}
+	classes := core.MachineClassOrder
 	specs := make([]core.ClassSpec, 0, len(classes))
 	for _, class := range classes {
 		machineType := machineTypeForClass(class)

--- a/internal/providers/phala/backend.go
+++ b/internal/providers/phala/backend.go
@@ -227,6 +227,8 @@ func applyDefaults(cfg *core.Config) {
 
 func instanceTypeForClass(class string) string {
 	switch strings.ToLower(strings.TrimSpace(class)) {
+	case "tiny", "small":
+		return "tdx.small"
 	case "", "standard":
 		return "tdx.small"
 	case "fast":

--- a/internal/providers/phala/backend_test.go
+++ b/internal/providers/phala/backend_test.go
@@ -136,6 +136,8 @@ func TestInstanceTypeForClass(t *testing.T) {
 		class string
 		want  string
 	}{
+		{"tiny", "tdx.small"},
+		{"small", "tdx.small"},
 		{"standard", "tdx.small"},
 		{"fast", "tdx.medium"},
 		{"large", "tdx.large"},


### PR DESCRIPTION
## Summary

The class ladder started at `standard`, which is a 32-vCPU machine on AWS, Azure and GCP — heavy
and expensive for smoke checks or small repos. This adds two classes below it.

| class | aws | azure | gcp | hetzner | namespace-instance |
|---|---|---|---|---|---|
| **tiny** | `m7a.large` 2/8 | `Standard_D2ads_v6` 2/8 | `c4-standard-4` 4/15 | `ccx13` 2/8 | `1x2` |
| **small** | `c7a.2xlarge` 8/16 | `Standard_D8ads_v6` 8/32 | `c4-standard-8` 8/30 | `ccx23` 4/16 | `2x4` |
| standard *(unchanged)* | `c7a.8xlarge` 32/64 | `Standard_D32ads_v6` 32/128 | `c4-standard-32` 32/120 | `ccx33` 8/32 | `4x8` |

`standard`, `fast`, `large` and `beast` keep their exact mappings and fallback ordering. The
default class stays `beast`.

## Notes on the sizing

- **GCP stays at 4 vCPU minimum.** `c4-standard-2` is 7.5 GB, and C4 standard is 3.75 GB/vCPU, so
  smaller sizes carry fractional GB. Sizes are chosen so memory lands on whole gigabytes.
- **Providers without a distinct smaller shape reuse their existing smallest type** rather than
  naming one that does not exist: Phala maps `tiny`/`small` to `tdx.small`, Namespace Devbox to
  `S`, and Cloudflare Containers keeps its single `standard-4`.
- **Every class switch was updated, not just the primary one.** Each switch ends in a `default:`
  that returns the class string as a literal provider type, so a partially-covered class would try
  to launch an instance type named "tiny" and fail at the provider. Coverage includes AWS
  amd64/ARM64/Windows/WSL2, Azure amd64/ARM64/Windows, GCP, Hetzner, both Namespace variants,
  Cloudflare, Phala, and the AWS quota recommendation path.

Vendor sources for the ten new sizes:
- AWS [M7a](https://aws.amazon.com/ec2/instance-types/m7a/) (4 GiB/vCPU) and
  [C7a](https://aws.amazon.com/ec2/instance-types/c7a/) (2 GiB/vCPU)
- Azure [Dadsv6](https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/general-purpose/dadsv6-series) (4 GiB/vCPU)
- GCP [C4 machine types](https://docs.cloud.google.com/compute/docs/machine-resource) (c4-standard = 3.75 GB/vCPU)
- Hetzner [dedicated vCPU](https://www.hetzner.com/cloud/dedicated-vcpu/) CCX line (4 GB/vCPU)

## Verification

```
gofmt -l $(git ls-files '*.go')          # clean
go build -trimpath -o bin/crabbox ./cmd/crabbox
go vet ./...                              # clean
go test ./internal/cli/... ./internal/providers/{aws,azure,gcp,hetzner,namespaceinstance,phala}
                                          # all ok (internal/cli 711s)
bash scripts/check-docs.sh                # passed, no generated drift
```

`internal/providers/freestyle` has a timing-bound test that can fail on a loaded machine
(`TestFreestyleSyncHonorsConfiguredTimeout`). It passes on clean `main` in under a second and this
branch touches no files in that package.

Note `internal/cli` needs ~12 minutes here, so a full `go test ./...` can exceed Go's 10-minute
default; pass `-timeout 40m` when running the whole suite locally.

## Config / secret implications

None. Class names are additive; no existing mapping, default, or fallback order changes. Nothing
contacts a provider API at report time.
